### PR TITLE
docs(astro): epic #2151 추가 옵션 — output.exports / sourcemapMode / inline-dynamic / lifecycle / loader override

### DIFF
--- a/documents/src/content/docs/en/guides/plugins.md
+++ b/documents/src/content/docs/en/guides/plugins.md
@@ -65,6 +65,46 @@ Custom module content loading (first-match).
 }
 ```
 
+#### `loader` option — asset loader override (#2157)
+
+When the object returned from `load` includes `loader`, the graph overrides the module loader to that value (skipping extension inference). Same semantics as esbuild's `onLoad` callback `loader: 'text' | 'binary' | ...`.
+
+```typescript
+{
+  name: 'md-as-text',
+  load(id) {
+    if (id.endsWith('.md')) {
+      return {
+        contents: readFileSync(id, 'utf-8'),
+        loader: 'text',     // emit file contents as a string default export
+      };
+    }
+    return null;
+  }
+}
+```
+
+Supported loaders: `text` / `dataurl` / `base64` / `binary` / `empty` / `javascript` / `json` / `css`.
+
+#### `contents` binary support (#2157 follow-up)
+
+`contents` accepts `string` or `Uint8Array` / Node.js `Buffer` — PNG/JPG and other utf-8-invalid byte sequences are forwarded losslessly.
+
+```typescript
+{
+  name: 'png-as-dataurl',
+  load(id) {
+    if (id.endsWith('.png')) {
+      return {
+        contents: readFileSync(id),  // Buffer / Uint8Array — binary safe
+        loader: 'dataurl',
+      };
+    }
+    return null;
+  }
+}
+```
+
 ### transform
 
 Transform module code (chaining -- all plugins applied in order).
@@ -106,6 +146,30 @@ Called after bundle generation is complete.
   }
 }
 ```
+
+### buildStart / buildEnd / closeBundle (#2156)
+
+Bundle lifecycle hooks. Compatible with esbuild's `onStart` / `onEnd` / `onDispose` and Rollup/Vite/rolldown's `buildStart` / `buildEnd` / `closeBundle`.
+
+| Hook | When | Argument |
+|---|---|---|
+| `buildStart` | Once at bundle start (every rebuild in watch mode) | none |
+| `buildEnd` | Right after output contents are determined | `error?: Error` (message of the first fatal diagnostic on failure) |
+| `closeBundle` | After output files are written | none |
+
+```typescript
+{
+  name: 'lifecycle',
+  buildStart() { console.log('build started'); },
+  buildEnd(err) {
+    if (err) console.error('build failed:', err.message);
+    else console.log('output ready');
+  },
+  closeBundle() { console.log('write done'); },
+}
+```
+
+Call order: `buildStart → onLoad / onTransform → buildEnd → closeBundle`. With multiple plugins each hook fires in sequence. Errors thrown from `buildEnd` / `closeBundle` are swallowed so they don't mask the actual build result.
 
 ## Build API
 

--- a/documents/src/content/docs/en/reference/cli.md
+++ b/documents/src/content/docs/en/reference/cli.md
@@ -62,7 +62,8 @@ zts --bundle <entry.ts> --plugin zts.config.js        # JS plugin
 
 | Option | Description |
 |--------|-------------|
-| `--sourcemap` | External `.js.map` |
+| `--sourcemap` | External `.js.map` with `sourceMappingURL` comment (linked, default) |
+| `--sourcemap=linked` | Explicit linked mode (#2152) — same as above |
 | `--sourcemap=inline` | Inline data URL |
 | `--sourcemap=external` | External file, no comment |
 | `--sourcemap=hidden` | External only (omit comment) |
@@ -118,10 +119,12 @@ zts --bundle <entry.ts> --plugin zts.config.js        # JS plugin
 | `--splitting` | Code splitting (requires `--outdir`) |
 | `--preserve-modules` | Per-module output (library build) |
 | `--preserve-modules-root=<dir>` | Root for output structure |
+| `--inline-dynamic-imports` | Absorb dynamic-import targets into the entry chunk (Rollup `inlineDynamicImports`, #2185) |
+| `--output-exports=<mode>` | CJS/UMD entry export shape — `auto\|named\|default\|none` (Rollup `output.exports`, #2159) |
 | `--entry-names=<pattern>` | Entry name pattern (`[name]`, `[hash]`) |
 | `--chunk-names=<pattern>` | Chunk name pattern |
 | `--asset-names=<pattern>` | Asset name pattern |
-| `--loader:.ext=type` | Loader by extension (`file\|dataurl\|text\|binary\|copy\|json\|css\|js\|ts\|jsx\|tsx`) |
+| `--loader:.ext=type` | Loader by extension (`file\|dataurl\|base64\|text\|binary\|copy\|empty\|json\|css\|js\|ts\|jsx\|tsx`) |
 | `--metafile` / `--metafile=<path>` | Build meta JSON (stdout or file) |
 | `--analyze` | Bundle analysis report |
 | `--legal-comments=<mode>` | License comments: `none\|inline\|eof\|linked\|external` |

--- a/documents/src/content/docs/en/reference/options.md
+++ b/documents/src/content/docs/en/reference/options.md
@@ -57,6 +57,17 @@ Use `$schema` to get autocomplete in VSCode / IntelliJ / any JSON-schema-aware e
 | `asciiOnly` | `boolean` | `false` | Escape non-ASCII as hex escape sequences |
 | `charsetUtf8` | `boolean` | `false` | Preserve non-ASCII verbatim |
 
+### Code Splitting / Chunks
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `splitting` | `boolean` | `false` | Split chunks at dynamic-import boundaries and extract shared modules |
+| `manualChunks` | `(id, meta) => string \| null` or `[{name, patterns}]` | — | Rollup-compatible custom chunking. Function form via JS API; record form via `zts.config.json` (#2186). [See guide](/zts/guides/manual-chunks/) |
+| `inlineDynamicImports` | `boolean` | `false` | Absorb dynamic-import targets into the importer chunk + `__esm` wrapping (single-file output). CLI: `--inline-dynamic-imports` (#2185) |
+| `external` | `string[]` | `[]` | Specifiers to exclude from the bundle. Registered as phantom modules in the graph |
+| `preserveModules` | `boolean` | `false` | Preserve original directory structure instead of bundling (Rollup compatible) |
+| `outputExports` | `auto`, `named`, `default`, `none` | `auto` | CJS/UMD entry export shape (Rollup `output.exports` compatible, #2159). `default` mode + named exports → build error |
+
 ### Minify
 
 | Option | Type | Default | Description |
@@ -77,6 +88,7 @@ Use `$schema` to get autocomplete in VSCode / IntelliJ / any JSON-schema-aware e
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `sourcemap` | `boolean` | `false` | Emit sourcemap JSON |
+| `sourcemapMode` | `linked`, `inline`, `external`, `hidden` | `linked` | Sourcemap output style (#2152). `linked` = external `.js.map` + `sourceMappingURL` comment (esbuild/rolldown default) |
 | `sourcemapDebugIds` | `boolean` | `false` | Sentry-compatible Debug ID |
 | `sourcesContent` | `boolean` | `true` | Include original source in sourcemap |
 | `sourceRoot` | `string` | `""` | Sourcemap `sourceRoot` field |

--- a/documents/src/content/docs/guides/plugins.md
+++ b/documents/src/content/docs/guides/plugins.md
@@ -103,6 +103,46 @@ export default defineConfig({
 }
 ```
 
+#### `loader` 옵션 — asset 로더 override (#2157)
+
+`load` 가 반환하는 객체에 `loader` 를 명시하면 graph 가 그 값으로 module loader 를 override 합니다 (확장자 추론 무시). esbuild `onLoad` callback 의 `loader: 'text' | 'binary' | ...` 와 동일.
+
+```typescript
+{
+  name: 'md-as-text',
+  load(id) {
+    if (id.endsWith('.md')) {
+      return {
+        contents: readFileSync(id, 'utf-8'),
+        loader: 'text',     // 파일 내용을 string default export 로 처리
+      };
+    }
+    return null;
+  }
+}
+```
+
+지원 loader: `text` / `dataurl` / `base64` / `binary` / `empty` / `javascript` / `json` / `css`.
+
+#### `contents` binary 지원 (#2157 follow-up)
+
+`contents` 는 `string` 또는 `Uint8Array` / Node.js `Buffer` 모두 받습니다 — PNG/JPG 등 utf-8 invalid bytes 도 손실 없이 forward.
+
+```typescript
+{
+  name: 'png-as-dataurl',
+  load(id) {
+    if (id.endsWith('.png')) {
+      return {
+        contents: readFileSync(id),  // Buffer / Uint8Array — binary safe
+        loader: 'dataurl',
+      };
+    }
+    return null;
+  }
+}
+```
+
 ### transform
 
 모듈 코드를 변환합니다 (chaining — 모든 플러그인 순서대로 적용).
@@ -144,6 +184,30 @@ export default defineConfig({
   }
 }
 ```
+
+### buildStart / buildEnd / closeBundle (#2156)
+
+Bundle lifecycle hook. esbuild `onStart` / `onEnd` / `onDispose`, Rollup/Vite/rolldown `buildStart` / `buildEnd` / `closeBundle` 호환.
+
+| Hook | 호출 시점 | 인자 |
+|---|---|---|
+| `buildStart` | bundle 시작 직후 1회 (watch 모드는 매 rebuild) | 없음 |
+| `buildEnd` | output contents 결정 직후 | `error?: Error` (build 실패 시 fatal diagnostic 의 message) |
+| `closeBundle` | output 파일 write 완료 후 | 없음 |
+
+```typescript
+{
+  name: 'lifecycle',
+  buildStart() { console.log('build started'); },
+  buildEnd(err) {
+    if (err) console.error('build failed:', err.message);
+    else console.log('output ready');
+  },
+  closeBundle() { console.log('write done'); },
+}
+```
+
+호출 순서: `buildStart → onLoad / onTransform → buildEnd → closeBundle`. 다중 plugin 시 모두 순차 실행. `buildEnd` / `closeBundle` 의 plugin 에러는 swallow — 본 build 결과를 가리지 않음.
 
 ## Build API
 

--- a/documents/src/content/docs/reference/cli.md
+++ b/documents/src/content/docs/reference/cli.md
@@ -62,7 +62,8 @@ zts --bundle <entry.ts> --plugin zts.config.js        # JS 플러그인
 
 | 옵션 | 설명 |
 |------|------|
-| `--sourcemap` | `.js.map` 외부 파일 |
+| `--sourcemap` | `.js.map` 외부 파일 + `sourceMappingURL` 주석 (linked, 기본) |
+| `--sourcemap=linked` | linked 명시 (#2152) — 동일 |
 | `--sourcemap=inline` | data URL 인라인 |
 | `--sourcemap=external` | sourceMappingURL 주석 없이 외부만 |
 | `--sourcemap=hidden` | 외부 파일 생성만 (주석 생략) |
@@ -118,10 +119,12 @@ zts --bundle <entry.ts> --plugin zts.config.js        # JS 플러그인
 | `--splitting` | 코드 스플리팅 (`--outdir` 필요) |
 | `--preserve-modules` | 모듈별 출력 (라이브러리 빌드) |
 | `--preserve-modules-root=<dir>` | 출력 구조 기준 디렉토리 |
+| `--inline-dynamic-imports` | dynamic import target 을 entry chunk 에 흡수 (Rollup `inlineDynamicImports`, #2185) |
+| `--output-exports=<mode>` | CJS/UMD entry export 형식 — `auto\|named\|default\|none` (Rollup `output.exports`, #2159) |
 | `--entry-names=<pattern>` | 엔트리 파일명 패턴 (`[name]`, `[hash]`) |
 | `--chunk-names=<pattern>` | 청크 파일명 패턴 |
 | `--asset-names=<pattern>` | 에셋 파일명 패턴 |
-| `--loader:.ext=type` | 확장자별 로더 (`file\|dataurl\|text\|binary\|copy\|json\|css\|js\|ts\|jsx\|tsx`) |
+| `--loader:.ext=type` | 확장자별 로더 (`file\|dataurl\|base64\|text\|binary\|copy\|empty\|json\|css\|js\|ts\|jsx\|tsx`) |
 | `--metafile` / `--metafile=<path>` | 빌드 메타 JSON (stdout 또는 파일) |
 | `--analyze` | 번들 분석 리포트 |
 | `--legal-comments=<mode>` | 라이선스 주석: `none\|inline\|eof\|linked\|external` |

--- a/documents/src/content/docs/reference/options.md
+++ b/documents/src/content/docs/reference/options.md
@@ -62,10 +62,11 @@ ZTS의 트랜스파일 옵션은 **Zig `TranspileOptionsDto` struct에서 compti
 | 옵션 | 타입 | 기본값 | 설명 |
 |---|---|---|---|
 | `splitting` | `boolean` | `false` | dynamic import 경계에서 청크 분리 + 공유 모듈 추출 |
-| `manualChunks` | `(id, meta) => string \| null` | — | Rollup 호환 사용자 정의 분할. [상세 가이드](/zts/guides/manual-chunks/) |
-| `inlineDynamicImports` | `boolean` | `false` | dynamic import target 을 importer chunk 로 흡수 + `__esm` 래핑 (단일 파일 출력) |
+| `manualChunks` | `(id, meta) => string \| null` 또는 `[{name, patterns}]` | — | Rollup 호환 사용자 정의 분할. JS API 는 함수형, `zts.config.json` 은 record form (#2186). [상세 가이드](/zts/guides/manual-chunks/) |
+| `inlineDynamicImports` | `boolean` | `false` | dynamic import target 을 importer chunk 로 흡수 + `__esm` 래핑 (단일 파일 출력). CLI: `--inline-dynamic-imports` (#2185) |
 | `external` | `string[]` | `[]` | 번들에서 제외할 specifier 목록. graph 에는 phantom Module 로 등록 |
 | `preserveModules` | `boolean` | `false` | 번들 대신 원본 디렉토리 구조 유지 (Rollup 호환) |
+| `outputExports` | `auto`, `named`, `default`, `none` | `auto` | CJS/UMD entry export 형식 (Rollup `output.exports` 호환, #2159). `default` 모드 + named export 섞이면 빌드 실패 |
 
 ### Minify
 
@@ -87,6 +88,7 @@ ZTS의 트랜스파일 옵션은 **Zig `TranspileOptionsDto` struct에서 compti
 | 옵션 | 타입 | 기본값 | 설명 |
 |---|---|---|---|
 | `sourcemap` | `boolean` | `false` | 소스맵 JSON 생성 |
+| `sourcemapMode` | `linked`, `inline`, `external`, `hidden` | `linked` | 소스맵 출력 형식 (#2152). `linked` = 외부 파일 + `sourceMappingURL` 주석 (esbuild/rolldown 기본값) |
 | `sourcemapDebugIds` | `boolean` | `false` | Sentry 호환 Debug ID 삽입 |
 | `sourcesContent` | `boolean` | `true` | 소스맵에 원본 소스 포함 |
 | `sourceRoot` | `string` | `""` | 소스맵의 `sourceRoot` 필드 |


### PR DESCRIPTION
## Summary

ZTS Astro 문서 사이트 (`documents/` — GitHub Pages) 에 epic #2151 1.0 bundler option parity 에서 추가된 옵션들 정리. 한국어 + 영어 모두 갱신.

## 변경 파일 (6 files)

### `reference/cli.md` (한/영)
- `--output-exports=<mode>` (Rollup `output.exports`, #2159) — 번들 전용 표 추가
- `--inline-dynamic-imports` (Rollup `inlineDynamicImports`, #2185) — 번들 전용 표 추가
- `--sourcemap=linked` (#2152) — 소스맵 표 추가
- loader 목록에 `base64` / `empty` 명시 (#2157)

### `reference/options.md` (한/영)
- `outputExports` (`auto/named/default/none`) — Code Splitting 섹션
- `sourcemapMode` (`linked/inline/external/hidden`) — Sourcemap 섹션
- `manualChunks` 의 record form 변형 명시 (#2186) — JS API 함수형 / `zts.config.json` record form
- 영어 `options.md` 의 누락된 **Code Splitting 섹션 자체 추가** (한국어와 sync)

### `guides/plugins.md` (한/영)
- **`load` 의 `loader` override 옵션** (#2157) — `text` / `dataurl` / `binary` / `empty` 등으로 모듈 로더 강제. esbuild `onLoad` callback 의 `loader` 와 동일.
- **`contents` 의 binary 지원** (#2181) — `string` / `Uint8Array` / Node.js `Buffer` 모두 forward. PNG/JPG 등 utf-8 invalid bytes 손실 없음.
- **`buildStart` / `buildEnd` / `closeBundle` lifecycle hook 신규 섹션** (#2156) — esbuild `onStart`/`onEnd`/`onDispose` 호환. 호출 순서 + watch 모드 동작 + plugin 에러 swallow 정책 명시.

## 검증

- [x] `bun run build` (Astro) — 419 pages built, all internal links valid
- [x] 한/영 양쪽 모두 갱신

🤖 Generated with [Claude Code](https://claude.com/claude-code)