### PR TITLE
fix(codegen): string enum 멤버 reverse mapping 제거 (#2192)

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -3510,9 +3510,18 @@ pub const Codegen = struct {
             // 문자열 리터럴 키의 따옴표 제거: 'a' → a, "a b" → a b
             const member_text = Ast.stripStringQuotes(raw_text);
 
-            // Color[Color["Red"] = 0] = "Red";
-            try self.write(param_name);
-            try self.writeByte('[');
+            // String enum 멤버는 reverse mapping 을 만들지 않음 (TS spec).
+            const is_string_member = if (member_values.get(member_text)) |resolved|
+                resolved == .str
+            else
+                false;
+
+            // numeric: Color[Color["Red"]=0]="Red"  → outer wrap 추가
+            // string : Color["X"]="x"               → wrap 없음
+            if (!is_string_member) {
+                try self.write(param_name);
+                try self.writeByte('[');
+            }
             try self.write(param_name);
             try self.write("[\"");
             try self.write(member_text);
@@ -3555,9 +3564,13 @@ pub const Codegen = struct {
                 auto_value += 1;
             }
 
-            try self.write("]=\"");
-            try self.write(member_text);
-            try self.write("\";");
+            if (is_string_member) {
+                try self.writeByte(';');
+            } else {
+                try self.write("]=\"");
+                try self.write(member_text);
+                try self.write("\";");
+            }
         }
 
         // return Color;})(Color || {});

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -2492,6 +2492,38 @@ describe("ES 다운레벨링 엣지케이스 (복합 조합)", () => {
       expect(result.runOutput).toBe("ab");
     });
 
+    test("string enum: no reverse mapping (TS spec)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            enum S { X = 'x', Y = 'y' }
+            console.log((S as any)['x'], (S as any)['y'], Object.keys(S).length);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("undefined undefined 2");
+    });
+
+    test("mixed enum: numeric reverse, string forward-only", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            enum E { A = 1, B = 'b' }
+            console.log(JSON.stringify(E));
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe('{"1":"A","A":1,"B":"b"}');
+    });
+
     test("namespace + enum 조합", async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
## Summary
TypeScript spec 상 string enum 은 reverse mapping 이 없어야 합니다 (numeric enum 한정). ZTS 가 numeric/string 구분 없이 reverse mapping 을 emit 하던 동작을 멤버별로 분기하도록 수정했습니다.

## Before / After
**Before**
```js
var E = ((E) => {E[E["X"]="x"]="X"; E[E["Y"]="y"]="Y"; return E;})(E || {});
console.log(E["x"]); // → "X" (잘못됨)
```

**After**
```js
var E = ((E) => {E["X"]="x"; E["Y"]="y"; return E;})(E || {});
console.log(E["x"]); // → undefined (spec 부합)
```

Mixed enum (numeric + string) 도 멤버별로 분기:
```js
// enum E { A = 1, B = "b" }
var E = ((E) => {E[E["A"]=1]="A"; E["B"]="b"; return E;})(E || {});
```

## 변경 내용
- `src/codegen/codegen.zig::emitEnumIIFE` 의 2차 패스에서 1차 패스에 수집된 `EnumMemberValue.str` 케이스를 기준으로 outer wrap (`E[ ... ]="name"`) 여부 분기
- 멤버 이니셜라이저의 평가 결과가 `.str` 인 경우만 forward-only emit
- auto-increment / numeric / 기타 케이스는 기존 동작 유지

## 테스트
`tests/integration/tests/downlevel-edge.test.ts` 에 회귀 테스트 2개 추가:
- `string enum: no reverse mapping (TS spec)` — `(E as any)["x"]` 가 `undefined` 이고 `Object.keys(E).length === 2`
- `mixed enum: numeric reverse, string forward-only` — `JSON.stringify(E)` 결과 검증

## Test plan
- [x] `zig build` Debug + ReleaseFast 빌드 통과
- [x] `zig build test` 유닛 테스트 통과
- [x] `tests/integration/tests/downlevel-edge.test.ts` 154 + 추가 2개 = 156 pass
- [x] `tests/integration/tests/esm-enum-hoisting.test.ts` 5 pass
- [x] minimal repro (`enum E { X = "x", Y = "y" }`) → `undefined undefined 2` 출력 확인

## Notes
Zig 초보자용 설명: 1차 패스(`member_values` 구성)에서 이미 numeric/string 분류해두고 있었기 때문에, 2차 패스에서 그 결과를 재사용해 분기만 추가하는 최소 변경입니다. HashMap lookup 한 번 추가되지만 enum 멤버 수가 일반적으로 적어 핫패스 영향 미미.

Closes #2192

🤖 Generated with [Claude Code](https://claude.com/claude-code)