### PR TITLE
fix(mangler): named class expression inner name 보존 (#2197)

### DIFF
--- a/src/codegen/mangler.zig
+++ b/src/codegen/mangler.zig
@@ -519,6 +519,9 @@ const SlotSortEntry = struct {
 fn shouldSkip(sym: Symbol, name: []const u8) bool {
     if (sym.decl_flags.is_exported or sym.decl_flags.is_default_export) return true;
     if (sym.decl_flags.is_import) return true;
+    // `const Foo = class Bar {}` 의 inner `Bar` (#2197). mangle 시 `.name` 프로퍼티도
+    // 함께 바뀌므로 spec 준수를 위해 원본 이름 보존.
+    if (sym.decl_flags.is_class_expr_name) return true;
     if (std.mem.eql(u8, name, "arguments")) return true;
     if (name.len <= 1) return true;
     return false;

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -626,6 +626,19 @@ pub const SemanticAnalyzer = struct {
         self.recordDeclareRef(@intCast(sym_index), target_scope);
     }
 
+    /// `const Foo = class Bar {}` 의 inner `Bar` 같은 named class expression 의
+    /// inner name 을 등록하면서 `is_class_expr_name` 표식을 부여한다 (#2197).
+    /// mangler 가 이 비트를 보면 mangle 대상에서 제외하여 `.name` 프로퍼티가 보존된다.
+    /// `declareSymbolWithNode` 가 redeclaration 충돌 시 push 를 건너뛰는 케이스를
+    /// 방어하기 위해 호출 전후 길이 비교로 실제 push 여부를 검증한다.
+    fn declareClassExprInnerName(self: *SemanticAnalyzer, name_span: Span, node_idx: u32) AllocError!void {
+        const before_len = self.symbols.items.len;
+        try self.declareSymbolWithNode(name_span, .class_decl, name_span, node_idx);
+        if (self.symbols.items.len > before_len) {
+            self.symbols.items[before_len].decl_flags.is_class_expr_name = true;
+        }
+    }
+
     /// 선언을 `references` 배열에 `flags.declare` 로 기록. #1669.
     /// 현재 `enable_stmt_info` + 유효 stmt_idx 가 있을 때만 기록.
     /// `scope_id` 는 선언 대상 scope — top-level 판별은 buildFromSemantic 에서 수행.
@@ -2499,7 +2512,7 @@ pub const SemanticAnalyzer = struct {
         // 이 심볼로 resolve되고, body scope 종료 후 외부 참조는 다른 심볼(또는 unresolved).
         if (!class_expr_name_idx.isNone()) {
             const name_node = self.ast.getNode(class_expr_name_idx);
-            try self.declareSymbolWithNode(name_node.span, .class_decl, name_node.span, @intFromEnum(class_expr_name_idx));
+            try self.declareClassExprInnerName(name_node.span, @intFromEnum(class_expr_name_idx));
         }
 
         if (!body_idx.isNone() and @intFromEnum(body_idx) < self.ast.nodes.items.len) {

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -130,8 +130,12 @@ pub const DeclFlags = packed struct(u16) {
     /// Annex B: if/else body의 function declaration (sloppy mode).
     /// catch body에서 catch parameter와의 충돌 검사를 건너뛰기 위해 필요.
     is_annex_b_function: bool = false,
+    /// `const Foo = class Bar {}` 의 inner `Bar` 같은 named class expression 의
+    /// inner name binding. ECMA spec: 외부 scope 에서 안 보이고 `.name` 프로퍼티로만
+    /// 관찰됨. mangler 가 이 이름을 mangle 하면 `.name` 도 변하므로 (#2197) skip.
+    is_class_expr_name: bool = false,
     /// 나머지 패딩
-    _padding: u2 = 0,
+    _padding: u1 = 0,
 
     /// 모든 "값(value)" 비트. 재선언 체크에 사용할 전체 마스크.
     pub const all_values: DeclFlags = .{

--- a/tests/integration/tests/mangler-minify.test.ts
+++ b/tests/integration/tests/mangler-minify.test.ts
@@ -1,5 +1,28 @@
 import { describe, test, expect, afterEach } from "bun:test";
-import { bundleAndRun } from "./helpers";
+import { spawnSync } from "node:child_process";
+import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { bundleAndRun, runZts } from "./helpers";
+
+/// Transpile-only (no --bundle) helper. mangler 의 *transpile* path 동작을 격리
+/// 검증할 때 사용. bundleAndRun 은 --bundle 을 강제하므로 inner-name elision 같은
+/// 별도 pass 와 섞여 mangler 단독 동작을 잡아내기 어렵다 (#2197).
+async function transpileAndRun(source: string, extraArgs: string[] = []) {
+  const dir = mkdtempSync(join(tmpdir(), "zts-mangler-"));
+  const inFile = join(dir, "in.ts");
+  const outFile = join(dir, "out.js");
+  writeFileSync(inFile, source);
+  const r = await runZts([inFile, "-o", outFile, ...extraArgs]);
+  const exec = spawnSync("bun", ["run", outFile], { encoding: "utf-8", timeout: 10000 });
+  return {
+    transpileExitCode: r.exitCode,
+    transpileStderr: r.stderr,
+    runOutput: (exec.stdout || "").trimEnd(),
+    runStderr: (exec.stderr || "").trimEnd(),
+    cleanup: async () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
 
 describe("mangler --minify 회귀", () => {
   let cleanup: (() => Promise<void>) | undefined;
@@ -219,5 +242,41 @@ describe("mangler --minify 회귀", () => {
 
     expect(result.exitCode).toBe(0);
     expect(result.runOutput).toBe("LR");
+  });
+
+  // #2197: named class expression 의 inner name 은 mangle 대상에서 제외해야 함.
+  // 외부 var 와 inner class name 이 같은 slot 으로 합쳐지면 `.name` 프로퍼티가 mangled
+  // 식별자로 바뀌어 spec 위반 (ECMA: class expression inner name binding 은 외부 scope 에
+  // 안 보이지만 .name 으로 관찰 가능).
+  //
+  // 격리: transpile-only path. --bundle 모드에는 inner-name elision pass 가 별도로
+  // 동작 (esbuild 와 동일한 minifier convention) 하므로 그 path 와 섞이지 않게 분리.
+  test("named class expression 의 .name 이 mangle 후에도 보존된다 (#2197)", async () => {
+    const result = await transpileAndRun("const Foo = class Bar {};\nconsole.log(Foo.name);\n", [
+      "--minify",
+    ]);
+    cleanup = result.cleanup;
+
+    expect(result.transpileExitCode).toBe(0);
+    expect(result.runOutput).toBe("Bar");
+  });
+
+  // class body 안에서 inner name 으로 self-reference 하는 경우에도 동일하게 보존되어야
+  // 함 (Bar 가 mangle 되면 self-ref 와 .name 둘 다 깨짐).
+  test("class expression body 의 self-reference 와 .name 이 모두 보존된다 (#2197)", async () => {
+    const result = await transpileAndRun(
+      [
+        "const Foo = class Bar {",
+        "  static n = 0;",
+        "  static count() { return ++Bar.n; }",
+        "};",
+        "console.log(Foo.count(), Foo.count(), Foo.name);",
+      ].join("\n"),
+      ["--minify"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.transpileExitCode).toBe(0);
+    expect(result.runOutput).toBe("1 2 Bar");
   });
 });


### PR DESCRIPTION
## Summary
`const Foo = class Bar {}` 형태에서 `--minify` 시 outer var 와 inner class name binding 이 같은 mangle slot 으로 합쳐져 `Foo.name` 프로퍼티가 mangled 식별자 (`"e"`) 로 변질되던 버그 수정. ECMA spec: class expression 의 inner name 은 외부 scope 에 노출되지 않지만 `.name` 으로 관찰 가능하므로 spec 위반.

## Before / After
**Before**
```bash
$ zts repro.ts --minify
const e=class e{};console.log(e.name);
$ bun run out.js
e        # ← spec 위반: "Bar" 여야 함
```

**After**
```bash
$ zts repro.ts --minify
const e=class Bar{};console.log(e.name);
$ bun run out.js
Bar      # ✓ spec 부합
```

## 변경 내용
1. **`src/semantic/symbol.zig`** — `DeclFlags` packed struct(u16) 에 `is_class_expr_name` 비트 추가 (`_padding: u2` → `u1`). 사이즈 변동 없음.
2. **`src/semantic/analyzer.zig`** — `declareClassExprInnerName` helper 추가. `visitClassWithHeritage` 에서 inner name 등록 시 helper 통해 비트 set. `declareSymbolWithNode` 가 redeclaration 충돌로 push 를 건너뛸 수 있는 케이스를 length 비교로 방어 (helper 안에 캡슐화).
3. **`src/codegen/mangler.zig`** — `shouldSkip` 에 비트 체크 추가. 해당 심볼은 mangle 대상에서 제외되어 원본 이름이 출력에 보존됨. `reserveNameFor` 가 자동으로 reserved 처리.

## Scope
이번 fix 는 **transpile-only path** 에 한정 (이슈 본문의 minimal repro 가 transpile 모드).

`--bundle` 모드에는 별도 inner-name elision pass (`shouldDropClassExprName`) 가 동작하여 `class Bar {}` 를 anonymous class 로 변환합니다. 이건 esbuild 와 동일한 minifier convention 이라 별도 사안 — 동작 비교:

| 모드 | ZTS | esbuild |
|------|-----|---------|
| transpile + minify | (수정 후) `class Bar` 보존, `.name === "Bar"` | `class` (anonymous), `.name === "Foo"` |
| bundle + minify | `class` (anonymous), `.name === "<mangled>"` | `class` (anonymous), `.name === "<mangled>"` |

bundle path 에서 spec preserving `.name` 을 원하면 별도 옵션 (`--keep-names` 류) 추가 가능 — follow-up 으로 분리.

## 테스트
`tests/integration/tests/mangler-minify.test.ts` 에 transpile-only 격리 헬퍼 `transpileAndRun` + 회귀 테스트 2개 추가:
- `Foo.name === "Bar"` 보존
- class body 안 self-reference (`Bar.n`) + `.name` 동시 보존

## Test plan
- [x] `zig build` Debug + ReleaseFast 빌드 통과
- [x] `zig build test` 유닛 테스트 통과
- [x] `mangler-minify.test.ts` 8 + 2 = 10 pass
- [x] 인접 minify 테스트 회귀 0: `export-preserve-minify.test.ts`, `minify-orphan-dead-store.test.ts`, `downlevel-edge.test.ts`, `esm-enum-hoisting.test.ts` 178 pass
- [x] minimal repro (`const Foo = class Bar {}`) → `.name === "Bar"` 확인

## Notes
Zig 초보자용 설명: ZTS 의 mangler 는 *liveness-based slot reuse* 를 합니다 — 두 심볼의 lifetime 이 겹치지 않으면 같은 짧은 이름을 재사용해 사이즈를 줄이는 방식. 그런데 named class expression 의 inner name 은 *외부에서 안 보이지만* `.name` 프로퍼티로 관찰 가능하므로 외부 변수와 같은 slot 에 합쳐지면 spec 위반. `is_class_expr_name` 비트가 mangler 에게 "이 심볼은 mangle 하지 마라" 신호 역할.

Closes #2197

🤖 Generated with [Claude Code](https://claude.com/claude-code)