### PR TITLE
fix(transformer): legacy decorator helper transpile-only emit (#2194)

### DIFF
--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -1252,6 +1252,9 @@ pub fn appendRuntimeHelpers(buf: *std.ArrayList(u8), allocator: std.mem.Allocato
     if (helpers.es_decorator) {
         try buf.appendSlice(allocator, if (minify) ES_DECORATOR_RUNTIME_MIN else ES_DECORATOR_RUNTIME);
     }
+    if (helpers.legacy_decorator) {
+        try buf.appendSlice(allocator, if (minify) DECORATOR_RUNTIME_MIN else DECORATOR_RUNTIME);
+    }
     if (helpers.spread_array) {
         try buf.appendSlice(allocator, if (minify) SPREAD_ARRAY_RUNTIME_MIN else SPREAD_ARRAY_RUNTIME);
     }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -239,7 +239,11 @@ pub const RuntimeHelpers = packed struct(u32) {
     tdz: bool = false,
     /// __read: array destructuring iterable protocol read
     read: bool = false,
-    _padding: u7 = 0,
+    /// __decorateClass: TS legacy `experimentalDecorators` 변환 (#2194).
+    /// transpile-only 모드에서도 헬퍼 정의가 출력에 inline 되도록 transformer 가
+    /// 호출 emit 시 함께 set 한다.
+    legacy_decorator: bool = false,
+    _padding: u6 = 0,
 };
 
 /// 단일 AST append-only 변환기.

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -1251,6 +1251,8 @@ pub fn transformExperimentalDecorators(
     // #1621: minify 시 $dC 축약.
     const decorate_name = rt.helperName("__decorateClass", self.options.minify_whitespace);
     const decorate_span = try self.ast.addString(decorate_name);
+    // 헬퍼 정의가 transpile-only 모드에서도 inline 되도록 표식 (#2194).
+    self.runtime_helpers.legacy_decorator = true;
 
     // class 이름 텍스트를 가져옴 (let Foo = class Foo {} 에 필요)
     const class_name_text = if (!new_name.isNone()) blk: {

--- a/tests/integration/tests/downlevel.test.ts
+++ b/tests/integration/tests/downlevel.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, afterEach } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { bundleAndRun, createFixture, runZts } from "./helpers";
+import { bundleAndRun, createFixture, runZts, transpileAndRun } from "./helpers";
 
 // 런타임 헬퍼는 번들러가 자동 주입 (emitter.zig의 appendRuntimeHelpers)
 
@@ -4862,6 +4862,33 @@ describe("ES 다운레벨링 런타임 테스트", () => {
       cleanup = result.cleanup;
       expect(result.exitCode).toBe(0);
       expect(result.runOutput).toBe("Alice true col:id,col:name,meth:greet");
+    });
+
+    // #2194: transpile-only 모드에서도 `__decorateClass` 헬퍼 정의가 emit 되어야 함.
+    // 기존 테스트들은 모두 bundle 모드(`bundleAndRun`)였고 번들 runtime preamble 이
+    // 헬퍼를 주입해 가려져 있었음. transpile-only 격리 시 ReferenceError 가 났던 회귀.
+    test("transpile-only 에서 __decorateClass 헬퍼가 inline emit 된다 (#2194)", async () => {
+      const result = await transpileAndRun(
+        [
+          "function tag(label: string) {",
+          "  return function (target: any, key?: string) {",
+          "    target.__tags = target.__tags || [];",
+          "    target.__tags.push(label + ':' + (key || 'class'));",
+          "  };",
+          "}",
+          "@tag('cls')",
+          "class D {",
+          "  @tag('m') hi() { return 'hi'; }",
+          "}",
+          "console.log((D.prototype as any).__tags?.join('|'), new D().hi());",
+        ].join("\n"),
+        ["--experimental-decorators"],
+      );
+      cleanup = result.cleanup;
+
+      expect(result.transpileExitCode).toBe(0);
+      expect(result.runStderr).not.toContain("ReferenceError");
+      expect(result.runOutput).toBe("m:hi hi");
     });
   });
 

--- a/tests/integration/tests/helpers.ts
+++ b/tests/integration/tests/helpers.ts
@@ -128,6 +128,36 @@ export async function runZts(
   return runCmd([ZTS_BIN, ...args], options);
 }
 
+/// Transpile-only (no `--bundle`) helper. ZTS 의 *transpile* path 단독 동작을
+/// 격리 검증할 때 사용. `bundleAndRun` 은 `--bundle` 을 강제하므로 inner-name
+/// elision 같은 별도 pass 와 섞여 transpile 단독 동작을 잡아내기 어렵다 (#2194,
+/// #2197). source 를 임시 파일에 쓰고 ZTS 로 트랜스파일 → bun 으로 실행 → stdout/stderr
+/// 비교를 한 번에.
+export async function transpileAndRun(
+  source: string,
+  extraArgs: string[] = [],
+): Promise<{
+  transpileExitCode: number;
+  transpileStderr: string;
+  runOutput: string;
+  runStderr: string;
+  cleanup: () => Promise<void>;
+}> {
+  const dir = await mkdtemp(join(tmpdir(), "zts-transpile-"));
+  const inFile = join(dir, "in.ts");
+  const outFile = join(dir, "out.js");
+  await writeFile(inFile, source);
+  const r = await runZts([inFile, "-o", outFile, ...extraArgs]);
+  const exec = await runCmd(["bun", "run", outFile]);
+  return {
+    transpileExitCode: r.exitCode,
+    transpileStderr: r.stderr,
+    runOutput: exec.stdout.trimEnd(),
+    runStderr: exec.stderr.trimEnd(),
+    cleanup: async () => rm(dir, { recursive: true, force: true }),
+  };
+}
+
 /// Node로 JS 파일을 실행. exit != 0 시 stdout/stderr를 포함한 에러 throw (디버깅 편의).
 export async function runNode(file: string): Promise<{ stdout: string; stderr: string }> {
   const { stdout, stderr, exitCode } = await runCmd(["node", file]);

--- a/tests/integration/tests/mangler-minify.test.ts
+++ b/tests/integration/tests/mangler-minify.test.ts
@@ -1,28 +1,5 @@
 import { describe, test, expect, afterEach } from "bun:test";
-import { spawnSync } from "node:child_process";
-import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { bundleAndRun, runZts } from "./helpers";
-
-/// Transpile-only (no --bundle) helper. mangler 의 *transpile* path 동작을 격리
-/// 검증할 때 사용. bundleAndRun 은 --bundle 을 강제하므로 inner-name elision 같은
-/// 별도 pass 와 섞여 mangler 단독 동작을 잡아내기 어렵다 (#2197).
-async function transpileAndRun(source: string, extraArgs: string[] = []) {
-  const dir = mkdtempSync(join(tmpdir(), "zts-mangler-"));
-  const inFile = join(dir, "in.ts");
-  const outFile = join(dir, "out.js");
-  writeFileSync(inFile, source);
-  const r = await runZts([inFile, "-o", outFile, ...extraArgs]);
-  const exec = spawnSync("bun", ["run", outFile], { encoding: "utf-8", timeout: 10000 });
-  return {
-    transpileExitCode: r.exitCode,
-    transpileStderr: r.stderr,
-    runOutput: (exec.stdout || "").trimEnd(),
-    runStderr: (exec.stderr || "").trimEnd(),
-    cleanup: async () => rmSync(dir, { recursive: true, force: true }),
-  };
-}
+import { bundleAndRun, transpileAndRun } from "./helpers";
 
 describe("mangler --minify 회귀", () => {
   let cleanup: (() => Promise<void>) | undefined;


### PR DESCRIPTION
## Summary
`--experimental-decorators` 로 트랜스파일 시 `__decorateClass(...)` 호출 코드는 emit 되지만 헬퍼 정의가 출력에 누락되어 실행 시 `ReferenceError: __decorateClass is not defined`. 번들 모드에서는 runtime preamble 이 헬퍼를 주입해 가려져 있던 회귀.

## Before / After
**Before**
```bash
$ zts file.ts --experimental-decorators
let D = class D { hi() { return "hi"; } };
__decorateClass([tag("m")], D.prototype, "hi", 1);  // ← 헬퍼 정의 없음
$ bun run out.js
ReferenceError: __decorateClass is not defined
```

**After**
```bash
$ zts file.ts --experimental-decorators
var __defProp2 = Object.defineProperty;
var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
var __decorateClass = (decorators, target, key, kind) => { ... };
var __decorateParam = (index, decorator) => ...;
let D = class D { hi() { return "hi"; } };
__decorateClass([tag("m")], D.prototype, "hi", 1);
$ bun run out.js
m:hi hi
```

## 원인
`RuntimeHelpers` 비트맵에 legacy decorator 비트가 부재. `appendRuntimeHelpers` 가 transpile 끝에 emit 분기를 타지 못함. Stage 3 `__esDecorate` 는 `es_decorator` 비트가 이미 존재 — *대칭 파괴*.

## 수정
1. `src/transformer/transformer.zig` — `RuntimeHelpers` 에 `legacy_decorator: bool` 비트 추가 (`_padding: u7` → `u6`). u32 사이즈 변동 없음.
2. `src/transformer/transformer/class_decorator.zig` — `transformExperimentalDecorators` 진입에서 비트 set. 호출 emit 과 헬퍼 emit 이 같은 변환 path 에서 결정.
3. `src/bundler/runtime_helpers.zig::appendRuntimeHelpers` — `if (helpers.legacy_decorator)` 분기 추가. 기존 `appendDecoratorRuntime` 의 `DECORATOR_RUNTIME(_MIN)` 상수 재사용.

## Cleanup (관련 패턴 통합)
이전 PR #2197 에서 `mangler-minify.test.ts` 에 로컬로 둔 `transpileAndRun` 헬퍼를 `helpers.ts` 로 통합. 이번 PR 의 회귀 테스트도 같은 헬퍼 사용 → 두 곳 이상에서 쓰일 때 자연스러운 통합 시점.

## 테스트
`tests/integration/tests/downlevel.test.ts::experimentalDecorators` 에 transpile-only 격리 회귀 테스트 추가:
- class + method decorator 조합 (이슈 본문 repro)
- `runStderr` 에 `ReferenceError` 없음
- `runOutput === "m:hi hi"`

기존 11개 decorator 테스트 + 신규 1개 = 12 pass. 인접 영역 (downlevel-edge, mangler-minify) 회귀 0 (전체 414 pass).

## Test plan
- [x] `zig build` Debug + ReleaseFast 통과
- [x] `zig build test` 유닛 테스트 통과
- [x] `downlevel.test.ts` decorator 12 pass (신규 포함)
- [x] `mangler-minify.test.ts` 10 pass (helpers 이전 후)
- [x] minimal repro (`@tag class D { @tag hi() {} }`) 단독 실행 → `m:hi hi`

## Notes
Zig 초보자용 설명: ZTS 의 `RuntimeHelpers` 는 packed bitmap (32비트) — 각 비트가 "이 변환을 했으니 헬퍼 정의도 함께 emit 해야 함" 신호. transformer 의 각 변환 path 에서 비트 set, 끝에서 `appendRuntimeHelpers` 가 비트를 보고 필요한 헬퍼만 inline. 이번 fix 는 단순히 *legacy decorator* 라는 빠진 비트 하나 추가 + 두 위치 (set / consume) 연결.

Closes #2194

🤖 Generated with [Claude Code](https://claude.com/claude-code)