### PR TITLE
test(tsc): string enum reverse mapping 제거 후 snapshot 갱신 (#2192 follow-up)

### DIFF
--- a/tests/integration/tests/tsc/__snapshots__/classes.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/classes.test.ts.snap
@@ -7028,13 +7028,6 @@ exports[`TSC: classes privateNameInLhsReceiverExpression 1`] = `
 "
 `;
 
-exports[`TSC: classes privateNameInObjectLiteral-3 1`] = `
-"const obj = { get #foo() {
-	return "";
-} };
-"
-`;
-
 exports[`TSC: classes privateNameJsBadAssignment 1`] = `
 "exports.#nope = 1;
 // Error (outside class body)
@@ -10953,7 +10946,7 @@ class C12 {
 		this["c"] = 1;
 	}
 }
-var E = /* @__PURE__ */ ((E) => {E[E["A"]="A"]="A";E[E["B"]="B"]="B";return E;})(E || {});
+var E = /* @__PURE__ */ ((E) => {E["A"]="A";E["B"]="B";return E;})(E || {});
 class C13 {
 	[E.A];
 	constructor() {

--- a/tests/integration/tests/tsc/__snapshots__/enums.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/enums.test.ts.snap
@@ -45,12 +45,12 @@ exports[`TSC: enums enumClassification 1`] = `
 // Examples of literal enum types
 var E01 = /* @__PURE__ */ ((E01) => {E01[E01["A"]=0]="A";return E01;})(E01 || {});
 var E02 = /* @__PURE__ */ ((E02) => {E02[E02["A"]=123]="A";return E02;})(E02 || {});
-var E03 = /* @__PURE__ */ ((E03) => {E03[E03["A"]="hello"]="A";return E03;})(E03 || {});
+var E03 = /* @__PURE__ */ ((E03) => {E03["A"]="hello";return E03;})(E03 || {});
 var E04 = /* @__PURE__ */ ((E04) => {E04[E04["A"]=0]="A";E04[E04["B"]=1]="B";E04[E04["C"]=2]="C";return E04;})(E04 || {});
 var E05 = /* @__PURE__ */ ((E05) => {E05[E05["A"]=0]="A";E05[E05["B"]=10]="B";E05[E05["C"]=11]="C";return E05;})(E05 || {});
-var E06 = /* @__PURE__ */ ((E06) => {E06[E06["A"]="one"]="A";E06[E06["B"]="two"]="B";E06[E06["C"]="three"]="C";return E06;})(E06 || {});
-var E07 = /* @__PURE__ */ ((E07) => {E07[E07["A"]=0]="A";E07[E07["B"]=1]="B";E07[E07["C"]="hi"]="C";E07[E07["D"]=10]="D";E07[E07["E"]=11]="E";E07[E07["F"]="bye"]="F";return E07;})(E07 || {});
-var E08 = /* @__PURE__ */ ((E08) => {E08[E08["A"]=10]="A";E08[E08["B"]="hello"]="B";E08[E08["C"]=10 /* A */]="C";E08[E08["D"]="hello" /* B */]="D";E08[E08["E"]=10 /* C */]="E";return E08;})(E08 || {});
+var E06 = /* @__PURE__ */ ((E06) => {E06["A"]="one";E06["B"]="two";E06["C"]="three";return E06;})(E06 || {});
+var E07 = /* @__PURE__ */ ((E07) => {E07[E07["A"]=0]="A";E07[E07["B"]=1]="B";E07["C"]="hi";E07[E07["D"]=10]="D";E07[E07["E"]=11]="E";E07["F"]="bye";return E07;})(E07 || {});
+var E08 = /* @__PURE__ */ ((E08) => {E08[E08["A"]=10]="A";E08["B"]="hello";E08[E08["C"]=10 /* A */]="C";E08["D"]="hello" /* B */;E08[E08["E"]=10 /* C */]="E";return E08;})(E08 || {});
 // Examples of numeric enum types with only constant members
 var E10 = /* @__PURE__ */ ((E10) => {return E10;})(E10 || {});
 var E11 = /* @__PURE__ */ ((E11) => {E11[E11["A"]=+0]="A";E11[E11["B"]=0]="B";E11[E11["C"]=1]="C";return E11;})(E11 || {});
@@ -79,26 +79,26 @@ var E5 = /* @__PURE__ */ ((E5) => {E5[E5["a"]=1 / 0]="a";E5[E5["b"]=2 / 0.0]="b"
 `;
 
 exports[`TSC: enums enumConstantMemberWithString 1`] = `
-"var T1 = /* @__PURE__ */ ((T1) => {T1[T1["a"]="1"]="a";T1[T1["b"]="1" + "2"]="b";T1[T1["c"]="1" + "2" + "3"]="c";T1[T1["d"]="a" - "a"]="d";T1[T1["e"]="a" + 1]="e";return T1;})(T1 || {});
-var T2 = /* @__PURE__ */ ((T2) => {T2[T2["a"]="1"]="a";T2[T2["b"]="1" + "2"]="b";return T2;})(T2 || {});
-var T3 = /* @__PURE__ */ ((T3) => {T3[T3["a"]="1"]="a";T3[T3["b"]="1" + "2"]="b";T3[T3["c"]=1]="c";T3[T3["d"]=1 + 2]="d";return T3;})(T3 || {});
-var T4 = /* @__PURE__ */ ((T4) => {T4[T4["a"]="1"]="a";return T4;})(T4 || {});
+"var T1 = /* @__PURE__ */ ((T1) => {T1["a"]="1";T1[T1["b"]="1" + "2"]="b";T1[T1["c"]="1" + "2" + "3"]="c";T1[T1["d"]="a" - "a"]="d";T1[T1["e"]="a" + 1]="e";return T1;})(T1 || {});
+var T2 = /* @__PURE__ */ ((T2) => {T2["a"]="1";T2[T2["b"]="1" + "2"]="b";return T2;})(T2 || {});
+var T3 = /* @__PURE__ */ ((T3) => {T3["a"]="1";T3[T3["b"]="1" + "2"]="b";T3[T3["c"]=1]="c";T3[T3["d"]=1 + 2]="d";return T3;})(T3 || {});
+var T4 = /* @__PURE__ */ ((T4) => {T4["a"]="1";return T4;})(T4 || {});
 var T5 = /* @__PURE__ */ ((T5) => {T5[T5["a"]="1" + "2"]="a";return T5;})(T5 || {});
 "
 `;
 
 exports[`TSC: enums enumConstantMemberWithStringEmitDeclaration 1`] = `
-"var T1 = /* @__PURE__ */ ((T1) => {T1[T1["a"]="1"]="a";T1[T1["b"]="1" + "2"]="b";T1[T1["c"]="1" + "2" + "3"]="c";return T1;})(T1 || {});
-var T2 = /* @__PURE__ */ ((T2) => {T2[T2["a"]="1"]="a";T2[T2["b"]="1" + "2"]="b";return T2;})(T2 || {});
-var T3 = /* @__PURE__ */ ((T3) => {T3[T3["a"]="1"]="a";T3[T3["b"]="1" + "2"]="b";return T3;})(T3 || {});
-var T4 = /* @__PURE__ */ ((T4) => {T4[T4["a"]="1"]="a";return T4;})(T4 || {});
+"var T1 = /* @__PURE__ */ ((T1) => {T1["a"]="1";T1[T1["b"]="1" + "2"]="b";T1[T1["c"]="1" + "2" + "3"]="c";return T1;})(T1 || {});
+var T2 = /* @__PURE__ */ ((T2) => {T2["a"]="1";T2[T2["b"]="1" + "2"]="b";return T2;})(T2 || {});
+var T3 = /* @__PURE__ */ ((T3) => {T3["a"]="1";T3[T3["b"]="1" + "2"]="b";return T3;})(T3 || {});
+var T4 = /* @__PURE__ */ ((T4) => {T4["a"]="1";return T4;})(T4 || {});
 var T5 = /* @__PURE__ */ ((T5) => {T5[T5["a"]="1" + "2"]="a";return T5;})(T5 || {});
 "
 `;
 
 exports[`TSC: enums enumConstantMemberWithTemplateLiterals 1`] = `
 "var T1 = /* @__PURE__ */ ((T1) => {T1[T1["a"]=\`1\`]="a";return T1;})(T1 || {});
-var T2 = /* @__PURE__ */ ((T2) => {T2[T2["a"]=\`1\`]="a";T2[T2["b"]="2"]="b";T2[T2["c"]=3]="c";return T2;})(T2 || {});
+var T2 = /* @__PURE__ */ ((T2) => {T2[T2["a"]=\`1\`]="a";T2["b"]="2";T2[T2["c"]=3]="c";return T2;})(T2 || {});
 var T3 = /* @__PURE__ */ ((T3) => {T3[T3["a"]=\`1\` + \`1\`]="a";return T3;})(T3 || {});
 var T4 = /* @__PURE__ */ ((T4) => {T4[T4["a"]=\`1\`]="a";T4[T4["b"]=\`1\` + \`1\`]="b";T4[T4["c"]=\`1\` + "2"]="c";T4[T4["d"]="2" + \`1\`]="d";T4[T4["e"]="2" + \`1\` + \`1\`]="e";return T4;})(T4 || {});
 var T5 = /* @__PURE__ */ ((T5) => {T5[T5["a"]=\`1\`]="a";T5[T5["b"]=\`1\` + \`2\`]="b";T5[T5["c"]=\`1\` + \`2\` + \`3\`]="c";T5[T5["d"]=1]="d";T5[T5["e"]=\`1\` - \`1\`]="e";T5[T5["f"]=\`1\` + 1]="f";T5[T5["g"]=\`1\${"2"}3\`]="g";T5[T5["h"]=\`1\`.length]="h";return T5;})(T5 || {});
@@ -108,7 +108,7 @@ var T6 = /* @__PURE__ */ ((T6) => {T6[T6["a"]=1]="a";T6[T6["b"]=\`12\`.length]="
 
 exports[`TSC: enums enumConstantMemberWithTemplateLiteralsEmitDeclaration 1`] = `
 "var T1 = /* @__PURE__ */ ((T1) => {T1[T1["a"]=\`1\`]="a";return T1;})(T1 || {});
-var T2 = /* @__PURE__ */ ((T2) => {T2[T2["a"]=\`1\`]="a";T2[T2["b"]="2"]="b";T2[T2["c"]=3]="c";return T2;})(T2 || {});
+var T2 = /* @__PURE__ */ ((T2) => {T2[T2["a"]=\`1\`]="a";T2["b"]="2";T2[T2["c"]=3]="c";return T2;})(T2 || {});
 var T3 = /* @__PURE__ */ ((T3) => {T3[T3["a"]=\`1\` + \`1\`]="a";return T3;})(T3 || {});
 var T4 = /* @__PURE__ */ ((T4) => {T4[T4["a"]=\`1\`]="a";T4[T4["b"]=\`1\` + \`1\`]="b";T4[T4["c"]=\`1\` + "2"]="c";T4[T4["d"]="2" + \`1\`]="d";T4[T4["e"]="2" + \`1\` + \`1\`]="e";return T4;})(T4 || {});
 var T5 = /* @__PURE__ */ ((T5) => {T5[T5["a"]=\`1\`]="a";T5[T5["b"]=\`1\` + \`2\`]="b";T5[T5["c"]=\`1\` + \`2\` + \`3\`]="c";T5[T5["d"]=1]="d";return T5;})(T5 || {});

--- a/tests/integration/tests/tsc/__snapshots__/es6-destructuring.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-destructuring.test.ts.snap
@@ -662,7 +662,7 @@ console.log(aVal, bVal);
 `;
 
 exports[`TSC: es6/destructuring destructuringObjectBindingPatternAndAssignment7 1`] = `
-"var K = /* @__PURE__ */ ((K) => {K[K["a"]="a"]="a";K[K["b"]="b"]="b";return K;})(K || {});
+"var K = /* @__PURE__ */ ((K) => {K["a"]="a";K["b"]="b";return K;})(K || {});
 const { [K.a]:aVal, [K.b]:bVal } = (() => {
 	return { [K.a]: 1, [K.b]: 1 };
 })();

--- a/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`TSC: expressions arrayLiteralInference 1`] = `
 "// Repro from #31204
-export var AppType = /* @__PURE__ */ ((AppType) => {AppType[AppType["HeaderDetail"]="HeaderDetail"]="HeaderDetail";AppType[AppType["HeaderMultiDetail"]="HeaderMultiDetail"]="HeaderMultiDetail";AppType[AppType["AdvancedList"]="AdvancedList"]="AdvancedList";AppType[AppType["Standard"]="Standard"]="Standard";AppType[AppType["Relationship"]="Relationship"]="Relationship";AppType[AppType["Report"]="Report"]="Report";AppType[AppType["Composite"]="Composite"]="Composite";AppType[AppType["ListOnly"]="ListOnly"]="ListOnly";AppType[AppType["ModuleSettings"]="ModuleSettings"]="ModuleSettings";return AppType;})(AppType || {});
+export var AppType = /* @__PURE__ */ ((AppType) => {AppType["HeaderDetail"]="HeaderDetail";AppType["HeaderMultiDetail"]="HeaderMultiDetail";AppType["AdvancedList"]="AdvancedList";AppType["Standard"]="Standard";AppType["Relationship"]="Relationship";AppType["Report"]="Report";AppType["Composite"]="Composite";AppType["ListOnly"]="ListOnly";AppType["ModuleSettings"]="ModuleSettings";return AppType;})(AppType || {});
 export var AppStyle = /* @__PURE__ */ ((AppStyle) => {AppStyle[AppStyle["Tree"]=0]="Tree";AppStyle[AppStyle["TreeEntity"]=1]="TreeEntity";AppStyle[AppStyle["Standard"]=2]="Standard";AppStyle[AppStyle["MiniApp"]=3]="MiniApp";AppStyle[AppStyle["PivotTable"]=4]="PivotTable";return AppStyle;})(AppStyle || {});
 const appTypeStylesWithError = new Map([[AppType.Standard, [AppStyle.Standard, AppStyle.MiniApp]], [AppType.Relationship, [AppStyle.Standard, AppStyle.Tree, AppStyle.TreeEntity]], [AppType.AdvancedList, [AppStyle.Standard, AppStyle.MiniApp]]]);
 // Repro from #31204
@@ -6949,7 +6949,7 @@ var let = {};
 `;
 
 exports[`TSC: expressions stringEnumInElementAccess01 1`] = `
-"var E = /* @__PURE__ */ ((E) => {E[E["A"]="a"]="A";E[E["B"]="b"]="B";E[E["C"]="c"]="C";return E;})(E || {});
+"var E = /* @__PURE__ */ ((E) => {E["A"]="a";E["B"]="b";E["C"]="c";return E;})(E || {});
 const snb = item[e];
 "
 `;


### PR DESCRIPTION
## Summary
PR #2192 (string enum reverse mapping 제거) 머지 후 TSC conformance 스냅샷 8개가 stale 상태였습니다. 모두 #2192 의 의도된 동작 변경 결과 — TypeScript spec 부합 (`E["X"]="x"`, no reverse mapping). 사용자 보고된 9개 실패 모두 해결.

## 변경된 snapshot 패턴
모두 동일:
```diff
- E[E["X"]="x"]="X"   ← 잘못된 reverse mapping
+ E["X"]="x"          ← spec 부합, forward only
```

## 영향 받은 테스트 (8개 — #2192 직접 결과)
| 파일 | 테스트 |
|------|--------|
| `enums.test.ts` | `enumClassification` |
| `enums.test.ts` | `enumConstantMemberWithString` |
| `enums.test.ts` | `enumConstantMemberWithStringEmitDeclaration` |
| `enums.test.ts` | `enumConstantMemberWithTemplateLiterals` |
| `enums.test.ts` | `enumConstantMemberWithTemplateLiteralsEmitDeclaration` |
| `expressions.test.ts` | `arrayLiteralInference` |
| `expressions.test.ts` | `stringEnumInElementAccess01` |
| `es6-destructuring.test.ts` | `destructuringObjectBindingPatternAndAssignment7` |
| `classes.test.ts` | `strictPropertyInitialization` |

## 부수 cleanup (1개)
`classes.privateNameInObjectLiteral-3` 의 obsolete 스냅샷이 함께 제거됐습니다. 해당 입력:
```ts
const obj = { get #foo() { return ""; } };
```
이건 spec 상 syntax error 이고 ZTS 가 정확히 거부 (`ZTS0615 Private identifier is not allowed as object property key`). 결과 빈 출력 + non-zero exit → `expectPass` 헬퍼가 snapshot 기록을 건너뛰는 상태. 출력이 있던 시절의 잔존 항목이라 자동 청소된 것 — 이번 PR 의 부수 효과지만 별개 동작 변화는 없음.

## Test plan
- [x] `bun test tests/tsc/{enums,expressions,es6-destructuring,classes}.test.ts` → 992 pass / 0 fail
- [x] minimal repro 단순 테스트 (`enum E { X = "x" }`) 모두 spec 부합 동작 확인
- [x] 다른 영역 회귀 0

## Notes
PR #2192 자체는 root cause fix 였고 (codegen 분기 추가), 이 PR 은 그 fix 가 영향을 준 기존 conformance snapshot 의 *예상된* 갱신만 반영합니다. 기능 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)