### PR TITLE
fix(jsx,mangler): JSX factory head identifier 의 symbol_id 전파 (#2196)

### DIFF
--- a/src/transformer/jsx_lowering.zig
+++ b/src/transformer/jsx_lowering.zig
@@ -1194,11 +1194,19 @@ pub fn JsxLowering(comptime Transformer: type) type {
 
         /// "A.B.C" 형태의 factory 문자열을 static_member_expression 체인으로 변환.
         /// "React.createElement" → static_member(React, createElement)
+        ///
+        /// 첫 식별자 (head — `React`/`jsx`/`h`) 는 외부 binding 을 가리키므로 root scope
+        /// 에서 symbol_id lookup → attach 한다 (#2196). 이렇게 안 하면 mangler 가
+        /// 원본 binding 만 rename 하고 여기서 만든 새 노드는 mangle 대상에서 누락 →
+        /// `const n=...; React.createElement(...)` 같은 ReferenceError. 멤버 (`createElement`,
+        /// `Fragment`) 는 property access 라 lookup 불필요.
         fn makeFactoryCallee(self: *Transformer, factory: []const u8) Transformer.Error!NodeIndex {
             // dot이 없으면 단순 identifier
             const dot_pos = std.mem.indexOf(u8, factory, ".");
             if (dot_pos == null) {
-                return helpers.makeIdentifierRef(self, factory);
+                const node = try helpers.makeIdentifierRef(self, factory);
+                self.attachRootScopeSymbolByName(node, factory);
+                return node;
             }
 
             // dot 기반 분할: "A.B.C" → ["A", "B", "C"]
@@ -1210,6 +1218,7 @@ pub fn JsxLowering(comptime Transformer: type) type {
                 const part_node = try helpers.makeIdentifierRef(self, part);
 
                 if (current.isNone()) {
+                    self.attachRootScopeSymbolByName(part_node, part);
                     current = part_node;
                 } else {
                     const span_val = try self.ast.addString(factory);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1585,6 +1585,43 @@ pub const Transformer = struct {
         return ref;
     }
 
+    /// JSX → `React.createElement` 변환처럼 transformer 가 *원본 AST 에 없는*
+    /// 식별자 노드를 만들 때, 그 이름으로 root scope (module/global) 의 binding
+    /// 을 lookup 하여 symbol_id 를 attach 한다 (#2196).
+    ///
+    /// 이렇게 해야 mangler/linker 가 원본 binding 의 rename 결과를 새 노드에도
+    /// 그대로 반영. lookup 실패 시 (해당 이름의 root binding 없음) 그냥 패스 —
+    /// 원본 그대로 emit 됨.
+    ///
+    /// **Limitation**: root scope (scope_id=0) 만 검색. 함수 안에서 declare 한
+    /// `function f() { const React = ...; return <div/>; }` 같은 shadowed binding
+    /// 은 미지원 — JSX runtime 식별자가 함수 스코프에 있으면 lookup 실패 후
+    /// silent fallback 으로 원본 이름 그대로 emit. 외부에 동일 이름 root binding
+    /// 이 있으면 mangle 불일치 발생 가능. 실세계 React 코드 패턴이 거의 항상
+    /// module/global level 이라 의도된 trade-off.
+    ///
+    /// linear scan 이지만 호출 빈도 (factory head 식별자만) 가 낮아 비용 무시할
+    /// 수준. 측정 후 필요하면 root scope sym map caching 으로 follow-up.
+    pub fn attachRootScopeSymbolByName(self: *Transformer, node_idx: NodeIndex, name: []const u8) void {
+        if (self.symbols.len == 0) return;
+        if (self.symbol_ids.items.len == 0) return;
+        if (node_idx.isNone()) return;
+
+        for (self.symbols, 0..) |sym, i| {
+            if (sym.scope_id.isNone()) continue;
+            if (sym.scope_id.toIndex() != 0) continue;
+            const sym_name = sym.nameText(self.ast.source);
+            if (std.mem.eql(u8, sym_name, name)) {
+                const ni = @intFromEnum(node_idx);
+                self.ensureSymbolIds(ni);
+                if (ni < self.symbol_ids.items.len) {
+                    self.symbol_ids.items[ni] = @intCast(i);
+                }
+                return;
+            }
+        }
+    }
+
     /// export default class/function → ES5 lowering 시 operand가 .none이 되는 케이스 처리.
     /// lowerClassDeclaration이 pending_nodes에 function 등을 넣고 .none을 반환하므로,
     /// 클래스/함수 이름(또는 익명의 합성 이름 _Class)의 identifier reference를 operand로 사용.

--- a/tests/integration/tests/helpers.ts
+++ b/tests/integration/tests/helpers.ts
@@ -136,6 +136,7 @@ export async function runZts(
 export async function transpileAndRun(
   source: string,
   extraArgs: string[] = [],
+  opts: { ext?: "ts" | "tsx" | "js" | "jsx" } = {},
 ): Promise<{
   transpileExitCode: number;
   transpileStderr: string;
@@ -144,7 +145,7 @@ export async function transpileAndRun(
   cleanup: () => Promise<void>;
 }> {
   const dir = await mkdtemp(join(tmpdir(), "zts-transpile-"));
-  const inFile = join(dir, "in.ts");
+  const inFile = join(dir, `in.${opts.ext ?? "ts"}`);
   const outFile = join(dir, "out.js");
   await writeFile(inFile, source);
   const r = await runZts([inFile, "-o", outFile, ...extraArgs]);

--- a/tests/integration/tests/mangler-minify.test.ts
+++ b/tests/integration/tests/mangler-minify.test.ts
@@ -256,4 +256,46 @@ describe("mangler --minify 회귀", () => {
     expect(result.transpileExitCode).toBe(0);
     expect(result.runOutput).toBe("1 2 Bar");
   });
+
+  // #2196: JSX 가 만든 `React.createElement(...)` 호출의 head 식별자 (`React`)
+  // 가 mangle 결과로 attach 되도록. 이전엔 transformer 가 만든 새 노드에 symbol_id
+  // 가 없어 mangler 가 무시 → outer var 만 mangle, JSX 호출은 원본 `React` 그대로
+  // → `ReferenceError: React is not defined`.
+  test("JSX factory head identifier 가 mangle 결과로 따라간다 (#2196)", async () => {
+    const result = await transpileAndRun(
+      [
+        "const React = { createElement: (t: any, p: any, ...c: any[]) => ({ t, p, c }), Fragment: 'F' };",
+        "const el = <div>hi</div>;",
+        "console.log(JSON.stringify(el));",
+      ].join("\n"),
+      ["--minify"],
+      { ext: "tsx" },
+    );
+    cleanup = result.cleanup;
+
+    expect(result.transpileExitCode).toBe(0);
+    expect(result.runStderr).not.toContain("ReferenceError");
+    expect(result.runOutput).toBe('{"t":"div","p":null,"c":["hi"]}');
+  });
+
+  // Fragment + 중첩 element + spread props 까지 같은 mangle path 통과 검증.
+  test("JSX Fragment + 중첩 element + spread props 도 mangle 후 정상 (#2196)", async () => {
+    const result = await transpileAndRun(
+      [
+        "const React = {",
+        "  createElement(t: any, p: any, ...c: any[]) { return { type: t, props: p || {}, children: c }; },",
+        "  Fragment: 'Fragment',",
+        "};",
+        "const el = (<><div className='a' {...{ id: 'x' }}>hi {1+2}</div><span /></>);",
+        "console.log(el.type, (el as any).children[0].props.id);",
+      ].join("\n"),
+      ["--minify"],
+      { ext: "tsx" },
+    );
+    cleanup = result.cleanup;
+
+    expect(result.transpileExitCode).toBe(0);
+    expect(result.runStderr).not.toContain("ReferenceError");
+    expect(result.runOutput).toBe("Fragment x");
+  });
 });


### PR DESCRIPTION
## Summary
JSX → `React.createElement` 변환에서 transformer 가 만든 새 `React` 식별자에 symbol_id 가 부여되지 않아, mangler 가 원본 `const React` 만 mangle (`n` 으로) 하고 JSX 호출은 원본 `React` 그대로 emit → 실행 시 `ReferenceError: React is not defined`.

## Before / After
**Before**
```bash
$ zts r.tsx --minify
const n={createElement:(t,p,...c)=>({t,p,c}),Fragment:"F"},e=React.createElement("div",null,"hi");
$ bun run out.js
ReferenceError: React is not defined
```

**After**
```bash
$ zts r.tsx --minify
const n={createElement:(t,p,...c)=>({t,p,c}),Fragment:"F"},e=n.createElement("div",null,"hi");
$ bun run out.js
{ t: "div", p: null, c: [ "hi" ] }
```

## Root cause
`makeIdentifierRef` 가 raw string 만 가진 새 노드를 생성하고 symbol_id 연결을 하지 않음. 파이프라인 순서:
1. **Semantic** (reference 수집): `{"React": symbol_id=123}`
2. **Transformer** (JSX lowering): 새 `React` 노드 생성 — `propagateSymbolId` 가 *원본 노드* 의 symbol_id 를 복사하는데 새 노드는 원본이 없어 미부여
3. **Mangler**: 원본 `const React` 의 sym=123 만 mangle, 새 노드는 sym 없어 무시

## 변경 내용
1. **`src/transformer/transformer.zig`** — `attachRootScopeSymbolByName(node_idx, name)` helper 추가. root scope (scope_id=0) 의 동일 이름 symbol 을 linear scan 후 symbol_id attach. mangler 의 표준 path 가 새 노드도 인식.
2. **`src/transformer/jsx_lowering.zig::makeFactoryCallee`** — head 식별자 (`React`/`jsx`/`h`) 에만 lookup 적용. 멤버 (`createElement`, `Fragment`) 는 property access 라 lookup 불필요.
3. **`tests/integration/tests/helpers.ts::transpileAndRun`** — `opts.ext?: 'ts' | 'tsx' | 'js' | 'jsx'` 추가 (JSX 테스트용).

## Limitation
**root scope 만 검색.** `function f() { const React = ...; <div/> }` 같은 함수 스코프 shadowed binding 은 미지원 — silent fallback (원본 이름 그대로 emit). 실세계 React 패턴이 거의 module/global level 이라 의도된 trade-off. measure 후 root scope sym map caching 으로 follow-up 가능.

**Automatic runtime 영향 없음**: `_jsx`/`_jsxs` 는 사용자 source 에 binding 이 없고 transformer 가 import 를 자동 prepend 하므로 mangler 가 건드릴 root binding 자체 부재.

## 테스트
`mangler-minify.test.ts` 에 transpile-only 격리 회귀 테스트 2개 추가:
- `Foo.name === "Bar"` 같은 mangle 결과 일관성 (ReferenceError 부재 + 출력 매치)
- Fragment + 중첩 element + spread props 조합

## Test plan
- [x] `zig build` Debug + ReleaseFast 통과
- [x] `zig build test` 유닛 테스트 통과
- [x] `mangler-minify.test.ts` 12 pass (신규 2개 포함)
- [x] 광범위 회귀 0: `downlevel`, `downlevel-edge`, `tsc/{enums,expressions,classes,es6-classDeclaration}`, `esm-enum-hoisting` 합쳐 1293 pass
- [x] minimal repro (`<div>hi</div>`) 단독 minify → `n.createElement(...)` mangle 정확

## Notes
Zig 초보자용 설명: 트랜스파일러는 *세 단계 파이프라인* (semantic → transformer → mangler) 으로 동작. semantic 이 식별자 → `symbol_id` 매핑을 만들고, transformer 가 코드 변환하면서 새 노드를 추가, mangler 가 symbol_id 기반으로 rename. transformer 가 만든 새 노드가 *원본 binding 의 symbol_id* 를 가져와야 mangler 가 같은 rename 결과를 적용. 이번 fix 가 이 누락된 연결을 메움.

Closes #2196

🤖 Generated with [Claude Code](https://claude.com/claude-code)