### PR TITLE
fix(transformer): const enum + type wrapper cast 인라인 (#2193)

### DIFF
--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2491,6 +2491,22 @@ pub const Transformer = struct {
                 if (inner.isNone()) return null;
                 return self.evalConstEnumExpr(inner, ctx);
             },
+            // TS / Flow 타입 wrapper — 값에는 영향 없으니 inner 만 평가 (#2193).
+            // 누락 시 `Blue = "B" as any` 같은 cast 가 들어간 멤버 한 개 때문에
+            // collectConstEnum 의 `orelse return` 으로 enum 전체 등록이 실패하고,
+            // declaration 은 transformer 가 drop 한 상태로 참조만 남아 ReferenceError.
+            .ts_as_expression,
+            .ts_satisfies_expression,
+            .ts_non_null_expression,
+            .ts_type_assertion,
+            .ts_instantiation_expression,
+            .flow_as_expression,
+            .flow_type_cast_expression,
+            => {
+                const inner = node.data.unary.operand;
+                if (inner.isNone()) return null;
+                return self.evalConstEnumExpr(inner, ctx);
+            },
             .unary_expression => {
                 const ue = node.data.extra;
                 if (ue + 1 >= self.ast.extra_data.items.len) return null;

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -2460,6 +2460,40 @@ describe("ES 다운레벨링 엣지케이스 (복합 조합)", () => {
       expect(result.runOutput).toBe("Red 2");
     });
 
+    test("const enum + as any cast: 값 인라인 + declaration drop (#2193)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const enum Color { Red = 1, Green, Blue = "B" as any }
+            console.log(Color.Red, Color.Green, Color.Blue);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("1 2 B");
+    });
+
+    test("const enum + satisfies / non-null / type-assertion cast (#2193)", async () => {
+      const result = await bundleAndRun(
+        {
+          "index.ts": `
+            const enum E1 { A = 1 satisfies number, B = "x" satisfies string }
+            const enum E2 { A = 5! }
+            const enum E3 { A = <number>10 }
+            console.log(E1.A, E1.B, E2.A, E3.A);
+          `,
+        },
+        "index.ts",
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.exitCode).toBe(0);
+      expect(result.runOutput).toBe("1 x 5 10");
+    });
+
     test("const enum inline", async () => {
       const result = await bundleAndRun(
         {


### PR DESCRIPTION
## Summary
`const enum Color { Blue = "B" as any }` 처럼 type wrapper cast 가 들어간 멤버 한 개 때문에 `evalConstEnumExpr` 가 null → `collectConstEnum` 의 `orelse return` 에서 **전체 enum 등록 실패** → declaration drop + 참조 잔존 → `ReferenceError`.

## Before / After
**Before**
```bash
$ zts repro.ts
console.log(Color.Red, Color.Green, Color.Blue);   # ← Color 자체 없음
$ bun run out.js
ReferenceError: Color is not defined
```

**After**
```bash
$ zts repro.ts
console.log(1, 2, "B");
```

## Root cause
`evalConstEnumExpr` 의 switch 에 type wrapper 노드 케이스 누락. `parenthesized_expression` 같은 *값 보존 wrapper* 는 처리하면서 TS/Flow 의 동등 wrapper 들 (ts_as / satisfies / non_null / type_assertion / instantiation, flow_as / type_cast) 은 빠져있어 *값에 영향 없는 cast* 가 들어가도 평가 실패.

## 수정
기존 `parenthesized_expression` 패턴과 동일하게 wrapper 의 `node.data.unary.operand` 만 재귀 평가:
```zig
.ts_as_expression,
.ts_satisfies_expression,
.ts_non_null_expression,
.ts_type_assertion,
.ts_instantiation_expression,
.flow_as_expression,
.flow_type_cast_expression,
=> {
    const inner = node.data.unary.operand;
    if (inner.isNone()) return null;
    return self.evalConstEnumExpr(inner, ctx);
},
```

이 7개 wrapper 모두 ast.zig:520-533 에서 unary layout 보장 + codegen.zig:1025-1032 의 동일 그룹화와 일치.

## 테스트
`tests/integration/tests/downlevel-edge.test.ts` 회귀 가드 2개:
- `as any` cast 가 든 mixed numeric/string const enum
- `satisfies` / non-null `!` / angle-bracket `<T>` cast 동시 검증

## Test plan
- [x] `zig build` Debug + ReleaseFast 통과
- [x] `zig build test` 유닛 테스트 통과
- [x] `downlevel-edge.test.ts` 회귀 0 (158 pass)
- [x] 전체 통합 3462 pass / 0 fail
- [x] minimal repro 4종 모두 esbuild 와 동일 출력

## Notes
이번 fix 가 ZTS 헌팅 epic (#2192~#2198) 의 **마지막 fix**. 7개 issue 모두 root cause level 로 처리.

Zig 초보자용 설명: const enum 은 *값을 미리 평가해서 사용처에 박는* 최적화. 평가 함수 (`evalConstEnumExpr`) 가 노드 종류별로 분기하는데 *type cast wrapper* (값에 영향 없는 TS/Flow 문법 sugar) 들이 처리 안 돼 fallthrough → null 반환. 한 멤버 평가 실패가 전체 enum drop 으로 이어져 silent runtime fail. fix 는 wrapper 들을 *parenthesized expression 처럼 inner 만 평가* 하도록 추가.

Closes #2193

🤖 Generated with [Claude Code](https://claude.com/claude-code)