### PR TITLE
feat(app): enable dev PostCSS CSS HMR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules/
 
 # Playwright
 test-results/
+tests/e2e/test-results/
 
 # compat-table report (CI에서 생성)
 tests/integration/compat-table-report.json

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -49,7 +49,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { resolve, dirname, basename, extname, join, sep } from "node:path";
+import { resolve, relative, dirname, basename, extname, join, sep } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "node:http";
 import { createServer as createHttpsServer } from "node:https";
@@ -425,6 +425,16 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
   }
 }
 
+const APP_DEV_HMR_CLIENT_PATH = "/__zts_app_dev_hmr__";
+const APP_DEV_HMR_WS_PATH = "/__hmr";
+const HMR_MSG = Object.freeze({
+  Connected: "connected",
+  CssUpdate: "css-update",
+  FullReload: "full-reload",
+});
+// RFC 6455 fixed handshake GUID — 변경 불가.
+const HMR_WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
 async function runAppDev(opts, config, configEnv, _dotenvVars) {
   const root = resolve(opts.appRoot ?? ".");
   opts.outdir = opts.outdir || join(root, ".zts-dev");
@@ -433,25 +443,21 @@ async function runAppDev(opts, config, configEnv, _dotenvVars) {
 
   opts.entryPoints = [prepared.entryPath];
   opts.serveDir = opts.outdir;
-  opts.appDev = appDev;
 
-  return runServe(opts, config);
+  return runServe(opts, config, { appDev });
 }
 
 function createAppDevController(opts, root, configEnv) {
   const outdir = resolve(opts.outdir || join(root, ".zts-dev"));
   const base = normalizeBase(opts.base ?? opts.publicPath ?? "/");
-  const state = {
-    cssDeps: new Set(),
-    cssDirDeps: new Set(),
-    cssHrefs: new Set(),
-  };
+  let cssDeps = new Set();
+  let cssDirDeps = new Set();
+  let primaryHref = null;
 
   return {
     root,
     outdir,
     base,
-    state,
     async prepare() {
       const prepared = prepareAppDevSync({
         root,
@@ -466,12 +472,18 @@ function createAppDevController(opts, root, configEnv) {
       injectAppDevHmrClient(outdir);
       return prepared;
     },
-    async afterBundle() {
-      const result = await runPostcssForAppDev(root, outdir, configEnv, opts.logLevel, base);
-      state.cssDeps = result.deps;
-      state.cssDirDeps = result.dirDeps;
-      state.cssHrefs = result.hrefs;
-      injectAppDevHmrClient(outdir);
+    async afterBundle({ changedPath = null } = {}) {
+      const result = await runPostcssForAppDev({
+        root,
+        outdir,
+        configEnv,
+        logLevel: opts.logLevel,
+        base,
+        changedPath,
+      });
+      cssDeps = result.deps;
+      cssDirDeps = result.dirDeps;
+      primaryHref = result.primaryHref;
       return result;
     },
     isPostcssConfig(absPath) {
@@ -479,15 +491,15 @@ function createAppDevController(opts, root, configEnv) {
     },
     isCssOnlyChange(absPath) {
       if (absPath.endsWith(".css")) return true;
-      if (state.cssDeps.has(absPath)) return true;
-      for (const dir of state.cssDirDeps) {
+      if (cssDeps.has(absPath)) return true;
+      for (const dir of cssDirDeps) {
         if (absPath === dir || absPath.startsWith(`${dir}${sep}`)) return true;
       }
       return false;
     },
     hrefFor(absPath) {
-      if (absPath.endsWith(".css")) return joinUrl(base, basename(absPath));
-      return state.cssHrefs.values().next().value ?? joinUrl(base, "style.css");
+      if (absPath.endsWith(".css")) return joinUrl(base, relative(root, absPath));
+      return primaryHref ?? joinUrl(base, "style.css");
     },
   };
 }
@@ -499,10 +511,15 @@ function joinUrl(base, rel) {
 
 function injectAppDevHmrClient(outdir) {
   const htmlPath = join(outdir, "index.html");
-  if (!existsSync(htmlPath)) return;
-  const html = readFileSync(htmlPath, "utf8");
-  if (html.includes("/__zts_app_dev_hmr__")) return;
-  const tag = `<script type="module" src="/__zts_app_dev_hmr__"></script>`;
+  let html;
+  try {
+    html = readFileSync(htmlPath, "utf8");
+  } catch (err) {
+    if (err?.code === "ENOENT") return;
+    throw err;
+  }
+  if (html.includes(APP_DEV_HMR_CLIENT_PATH)) return;
+  const tag = `<script type="module" src="${APP_DEV_HMR_CLIENT_PATH}"></script>`;
   const next = html.includes("</head>")
     ? html.replace("</head>", `${tag}\n</head>`)
     : html.replace("<script", `${tag}\n<script`);
@@ -511,14 +528,14 @@ function injectAppDevHmrClient(outdir) {
 
 const APP_DEV_HMR_CLIENT = `
 const socketProtocol = location.protocol === "https:" ? "wss:" : "ws:";
-const socket = new WebSocket(socketProtocol + "//" + location.host + "/__hmr");
+const socket = new WebSocket(socketProtocol + "//" + location.host + "${APP_DEV_HMR_WS_PATH}");
 socket.addEventListener("message", (event) => {
   const msg = JSON.parse(event.data);
-  if (msg.type === "full-reload") {
+  if (msg.type === "${HMR_MSG.FullReload}") {
     location.reload();
     return;
   }
-  if (msg.type !== "css-update") return;
+  if (msg.type !== "${HMR_MSG.CssUpdate}") return;
   const stamp = msg.timestamp || Date.now();
   const links = Array.from(document.querySelectorAll('link[rel="stylesheet"]'));
   let updated = false;
@@ -542,7 +559,10 @@ socket.addEventListener("message", (event) => {
 `;
 
 function createAppDevHmrChannel() {
-  const clients = new Set();
+  // Node 와 Bun runtime 의 WebSocket 표현이 다르므로 두 클라이언트 종류를 구분.
+  const nodeSockets = new Set();
+  const bunClients = new Set();
+  const connected = JSON.stringify({ type: HMR_MSG.Connected });
   return {
     accept(req, socket) {
       const key = req.headers["sec-websocket-key"];
@@ -550,9 +570,7 @@ function createAppDevHmrChannel() {
         socket.destroy();
         return;
       }
-      const accept = createHash("sha1")
-        .update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
-        .digest("base64");
+      const accept = createHash("sha1").update(`${key}${HMR_WS_GUID}`).digest("base64");
       socket.write(
         [
           "HTTP/1.1 101 Switching Protocols",
@@ -563,14 +581,22 @@ function createAppDevHmrChannel() {
           "",
         ].join("\r\n"),
       );
-      clients.add(socket);
-      socket.on("close", () => clients.delete(socket));
-      socket.on("error", () => clients.delete(socket));
-      writeWsText(socket, JSON.stringify({ type: "connected" }));
+      nodeSockets.add(socket);
+      socket.on("close", () => nodeSockets.delete(socket));
+      socket.on("error", () => nodeSockets.delete(socket));
+      writeWsText(socket, connected);
+    },
+    addBunClient(ws) {
+      bunClients.add(ws);
+      ws.send(connected);
+    },
+    removeBunClient(ws) {
+      bunClients.delete(ws);
     },
     broadcast(message) {
       const text = JSON.stringify(message);
-      for (const socket of clients) writeWsText(socket, text);
+      for (const socket of nodeSockets) writeWsText(socket, text);
+      for (const ws of bunClients) ws.send(text);
     },
   };
 }
@@ -684,10 +710,10 @@ function collectCssFiles(dir, skipDir = null) {
   if (!existsSync(dir)) return [];
   const files = [];
   for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === ".git") continue;
     const path = join(dir, entry);
     const stat = statSync(path);
     if (skipDir && stat.isDirectory() && resolve(path) === resolve(skipDir)) continue;
-    if (path.includes(`${sep}node_modules${sep}`)) continue;
     if (stat.isDirectory()) {
       files.push(...collectCssFiles(path, skipDir));
     } else if (stat.isFile() && path.endsWith(".css")) {
@@ -697,7 +723,7 @@ function collectCssFiles(dir, skipDir = null) {
   return files;
 }
 
-async function runPostcssIfConfigured(root, cssDir, skipDir, configEnv, logLevel) {
+async function loadPostcssConfig(root, configEnv) {
   const requireFromRoot = createRequire(join(root, "package.json"));
   const postcssrc = requireFromAppOrCli(requireFromRoot, "postcss-load-config");
   const postcssModule = requireFromAppOrCli(requireFromRoot, "postcss");
@@ -706,74 +732,90 @@ async function runPostcssIfConfigured(root, cssDir, skipDir, configEnv, logLevel
     if (err?.message?.includes("No PostCSS Config found")) return null;
     throw err;
   });
-  if (!config) return;
+  if (!config) return null;
   const plugins = config.plugins ?? [];
-  if (plugins.length === 0) return;
-  const cssFiles = collectCssFiles(cssDir, skipDir);
-  for (const file of cssFiles) {
-    const input = readFileSync(file, "utf8");
-    const result = await postcss(plugins).process(input, {
-      ...config.options,
-      from: file,
-      to: file,
-    });
-    writeFileSync(file, result.css);
-    if (result.map) writeFileSync(`${file}.map`, result.map.toString());
-  }
-  if (logLevel !== "silent") {
-    console.error(
-      `[postcss] processed ${cssFiles.length} CSS file(s) using ${basename(config.file ?? "postcss config")}`,
-    );
-  }
+  if (plugins.length === 0) return null;
+  return { postcss, plugins, options: config.options ?? {}, configFile: config.file ?? null };
 }
 
-async function runPostcssForAppDev(root, outdir, configEnv, logLevel, base) {
+function logPostcssProcessed(logLevel, count, configFile) {
+  if (logLevel === "silent") return;
+  console.error(
+    `[postcss] processed ${count} CSS file(s) using ${basename(configFile ?? "postcss config")}`,
+  );
+}
+
+async function runPostcssIfConfigured(root, cssDir, skipDir, configEnv, logLevel) {
+  const loaded = await loadPostcssConfig(root, configEnv);
+  if (!loaded) return;
+  const cssFiles = collectCssFiles(cssDir, skipDir);
+  await Promise.all(
+    cssFiles.map(async (file) => {
+      const input = readFileSync(file, "utf8");
+      const result = await loaded.postcss(loaded.plugins).process(input, {
+        ...loaded.options,
+        from: file,
+        to: file,
+      });
+      writeFileSync(file, result.css);
+      if (result.map) writeFileSync(`${file}.map`, result.map.toString());
+    }),
+  );
+  logPostcssProcessed(logLevel, cssFiles.length, loaded.configFile);
+}
+
+async function runPostcssForAppDev({
+  root,
+  outdir,
+  configEnv,
+  logLevel,
+  base,
+  changedPath = null,
+}) {
   const deps = new Set();
   const dirDeps = new Set();
-  const hrefs = new Set();
+  let primaryHref = null;
   const configPath = findPostcssConfig(root);
   if (!configPath) {
-    for (const file of collectCssFiles(root, outdir)) hrefs.add(joinUrl(base, basename(file)));
-    return { deps, dirDeps, hrefs, processed: 0 };
+    const first = collectCssFiles(root, outdir)[0];
+    if (first) primaryHref = joinUrl(base, relative(root, first));
+    return { deps, dirDeps, primaryHref, processed: 0 };
   }
 
-  const requireFromRoot = createRequire(join(root, "package.json"));
-  const postcssrc = requireFromAppOrCli(requireFromRoot, "postcss-load-config");
-  const postcssModule = requireFromAppOrCli(requireFromRoot, "postcss");
-  const postcss = postcssModule.default ?? postcssModule;
-  const config = await postcssrc({ cwd: root, env: configEnv.mode }, root).catch((err) => {
-    if (err?.message?.includes("No PostCSS Config found")) return null;
-    throw err;
-  });
-  if (!config || (config.plugins ?? []).length === 0) {
-    return { deps, dirDeps, hrefs, processed: 0 };
-  }
+  const loaded = await loadPostcssConfig(root, configEnv);
+  if (!loaded) return { deps, dirDeps, primaryHref, processed: 0 };
+  deps.add(resolve(loaded.configFile ?? configPath));
 
   mkdirSync(outdir, { recursive: true });
-  const cssFiles = collectCssFiles(root, outdir);
-  deps.add(resolve(config.file ?? configPath));
-  for (const file of cssFiles) {
-    const outputName = basename(file);
-    const outputPath = join(outdir, outputName);
-    const input = readFileSync(file, "utf8");
-    const result = await postcss(config.plugins).process(input, {
-      ...config.options,
-      from: file,
-      to: outputPath,
-    });
-    writeFileSync(outputPath, result.css);
-    if (result.map) writeFileSync(`${outputPath}.map`, result.map.toString());
-    deps.add(resolve(file));
-    hrefs.add(joinUrl(base, outputName));
-    collectPostcssMessages(result.messages, deps, dirDeps);
-  }
+  const allCssFiles = collectCssFiles(root, outdir);
+  // 단일 CSS 파일 변경이면 그 파일만 reprocess. 그 외(첫 빌드, postcss config 변경 등)는 전체.
+  const targets =
+    changedPath && changedPath.endsWith(".css") && allCssFiles.includes(changedPath)
+      ? [changedPath]
+      : allCssFiles;
 
-  if (logLevel !== "silent") {
-    console.error(
-      `[postcss] processed ${cssFiles.length} CSS file(s) using ${basename(config.file ?? "postcss config")}`,
-    );
-  }
-  return { deps, dirDeps, hrefs, processed: cssFiles.length };
+  await Promise.all(
+    targets.map(async (file) => {
+      const outputRel = relative(root, file);
+      const outputPath = join(outdir, outputRel);
+      mkdirSync(dirname(outputPath), { recursive: true });
+      const input = readFileSync(file, "utf8");
+      const result = await loaded.postcss(loaded.plugins).process(input, {
+        ...loaded.options,
+        from: file,
+        to: outputPath,
+      });
+      writeFileSync(outputPath, result.css);
+      if (result.map) writeFileSync(`${outputPath}.map`, result.map.toString());
+      deps.add(resolve(file));
+      collectPostcssMessages(result.messages, deps, dirDeps);
+    }),
+  );
+  // primaryHref 는 "임의의 첫 stylesheet" 기준 — non-CSS 변경 시 fallback 으로 사용.
+  if (allCssFiles.length > 0) primaryHref = joinUrl(base, relative(root, allCssFiles[0]));
+
+  logPostcssProcessed(logLevel, targets.length, loaded.configFile);
+  return { deps, dirDeps, primaryHref, processed: targets.length };
 }
 
 function collectPostcssMessages(messages, deps, dirDeps) {
@@ -1294,9 +1336,9 @@ function emitRestart(opts, reason) {
 
 // ─── Serve 모드 ───
 
-async function runServe(opts, config) {
+async function runServe(opts, config, { appDev = null } = {}) {
   const isBun = typeof globalThis.Bun !== "undefined";
-  const hmr = opts.appDev ? createAppDevHmrChannel() : null;
+  const hmr = appDev ? createAppDevHmrChannel() : null;
   const mimeTypes = {
     ".html": "text/html",
     ".js": "application/javascript",
@@ -1317,7 +1359,7 @@ async function runServe(opts, config) {
   if (opts.bundle && opts.entryPoints.length > 0) {
     opts.outdir = opts.outdir || join(opts.serveDir, ".zts-serve");
     await runBundle(opts, config);
-    if (opts.appDev) await opts.appDev.afterBundle();
+    if (appDev) await appDev.afterBundle();
 
     // watch도 같이
     if (!opts.watch) {
@@ -1330,7 +1372,7 @@ async function runServe(opts, config) {
 
   function handleRequest(reqUrl) {
     let pathname = new URL(reqUrl, "http://localhost").pathname;
-    if (opts.appDev && pathname === "/__zts_app_dev_hmr__") {
+    if (appDev && pathname === APP_DEV_HMR_CLIENT_PATH) {
       return {
         status: 200,
         body: APP_DEV_HMR_CLIENT,
@@ -1360,9 +1402,14 @@ async function runServe(opts, config) {
     const serveOpts = {
       port: opts.port,
       hostname: opts.host,
-      fetch(req) {
-        // 프록시 처리
+      fetch(req, server) {
         const url = new URL(req.url);
+        // /__hmr WebSocket upgrade — Bun-native API 사용 (Node 분기는 server.on('upgrade')).
+        if (hmr && url.pathname === APP_DEV_HMR_WS_PATH) {
+          if (server.upgrade(req)) return undefined;
+          return new Response("Upgrade required", { status: 426 });
+        }
+        // 프록시 처리
         for (const [prefix, target] of Object.entries(opts.proxy)) {
           if (url.pathname.startsWith(prefix)) {
             return fetch(target + url.pathname.slice(prefix.length) + url.search);
@@ -1379,6 +1426,17 @@ async function runServe(opts, config) {
         });
       },
     };
+    if (hmr) {
+      serveOpts.websocket = {
+        open(ws) {
+          hmr.addBunClient(ws);
+        },
+        close(ws) {
+          hmr.removeBunClient(ws);
+        },
+        message() {},
+      };
+    }
     if (useTls) {
       serveOpts.tls = {
         cert: globalThis.Bun.file(opts.certfile),
@@ -1426,7 +1484,7 @@ async function runServe(opts, config) {
       server.on("upgrade", (req, socket) => {
         const pathname = new URL(req.url, `${useTls ? "https" : "http"}://${req.headers.host}`)
           .pathname;
-        if (pathname !== "/__hmr") {
+        if (pathname !== APP_DEV_HMR_WS_PATH) {
           socket.destroy();
           return;
         }
@@ -1444,55 +1502,75 @@ async function runServe(opts, config) {
   // watch 시작 (번들 모드일 때)
   if (opts.watch && opts.bundle) {
     const { watch: fsWatch } = await import("node:fs");
+    const outdirAbs = opts.outdir ? resolve(opts.outdir) : null;
+    const outdirPrefix = outdirAbs ? `${outdirAbs}${sep}` : null;
     let debounceTimer = null;
     let rebuilding = false;
-    let pending = false;
+    const dirty = new Set();
 
-    async function rebuildForChange(absPath) {
-      if (rebuilding) {
-        pending = true;
-        return;
-      }
+    async function rebuildAppDevCss(changedPath) {
+      await appDev.afterBundle({ changedPath });
+      hmr?.broadcast({
+        type: HMR_MSG.CssUpdate,
+        href: appDev.hrefFor(changedPath),
+        timestamp: Date.now(),
+      });
+      if (opts.logLevel !== "silent") console.error("[serve] css updated");
+    }
+
+    async function rebuildAppDevFull() {
+      const prepared = await appDev.prepare();
+      opts.entryPoints = [prepared.entryPath];
+      await runBundle(opts, config);
+      await appDev.afterBundle();
+      hmr?.broadcast({ type: HMR_MSG.FullReload, timestamp: Date.now() });
+      if (opts.logLevel !== "silent") console.error("[serve] rebuilt");
+    }
+
+    async function drain() {
+      if (rebuilding) return;
       rebuilding = true;
       try {
-        if (opts.appDev) {
-          if (opts.appDev.isCssOnlyChange(absPath) || opts.appDev.isPostcssConfig(absPath)) {
-            await opts.appDev.afterBundle();
-            hmr?.broadcast({
-              type: "css-update",
-              href: opts.appDev.hrefFor(absPath),
-              timestamp: Date.now(),
-            });
-            if (opts.logLevel !== "silent") console.error("[serve] css updated");
-            return;
+        while (dirty.size > 0) {
+          const paths = Array.from(dirty);
+          dirty.clear();
+          if (!appDev) {
+            await runBundle(opts, config);
+            if (opts.logLevel !== "silent") console.error("[serve] rebuilt");
+            continue;
           }
-
-          const prepared = await opts.appDev.prepare();
-          opts.entryPoints = [prepared.entryPath];
-          await runBundle(opts, config);
-          await opts.appDev.afterBundle();
-          hmr?.broadcast({ type: "full-reload", timestamp: Date.now() });
-          if (opts.logLevel !== "silent") console.error("[serve] rebuilt");
-          return;
+          // 변경된 path 들이 모두 CSS-only 면 incremental 처리, 그 외엔 full reload.
+          const allCssOnly = paths.every(
+            (p) => appDev.isCssOnlyChange(p) || appDev.isPostcssConfig(p),
+          );
+          if (allCssOnly) {
+            // postcss config 변경이 섞이면 changedPath 미지정 → 전체 재처리.
+            const cssChanges = paths.filter(
+              (p) => p.endsWith(".css") && !appDev.isPostcssConfig(p),
+            );
+            if (cssChanges.length === 1 && paths.length === 1) {
+              await rebuildAppDevCss(cssChanges[0]);
+            } else {
+              await appDev.afterBundle();
+              hmr?.broadcast({ type: HMR_MSG.CssUpdate, timestamp: Date.now() });
+              if (opts.logLevel !== "silent") console.error("[serve] css updated");
+            }
+          } else {
+            await rebuildAppDevFull();
+          }
         }
-
-        await runBundle(opts, config);
-        if (opts.logLevel !== "silent") console.error("[serve] rebuilt");
       } catch (err) {
         console.error("[serve] rebuild error:", err);
-        hmr?.broadcast({ type: "full-reload", timestamp: Date.now() });
+        hmr?.broadcast({ type: HMR_MSG.FullReload, timestamp: Date.now() });
       } finally {
         rebuilding = false;
-        if (pending) {
-          pending = false;
-          rebuildForChange(absPath);
-        }
+        if (dirty.size > 0) drain();
       }
     }
 
     const watchDirs = new Set();
-    if (opts.appDev) {
-      watchDirs.add(opts.appDev.root);
+    if (appDev) {
+      watchDirs.add(appDev.root);
     } else {
       for (const entry of opts.entryPoints) {
         watchDirs.add(dirname(resolve(entry)));
@@ -1505,18 +1583,14 @@ async function runServe(opts, config) {
       fsWatch(dir, { recursive: true }, (_event, filename) => {
         if (!filename || filename.includes("node_modules") || filename.includes(".git")) return;
         const absPath = resolve(dir, filename);
-        if (
-          opts.outdir &&
-          (absPath === resolve(opts.outdir) || absPath.startsWith(`${resolve(opts.outdir)}${sep}`))
-        ) {
-          return;
-        }
-        if (!opts.appDev && restartTriggers.matches(filename)) {
+        if (outdirAbs && (absPath === outdirAbs || absPath.startsWith(outdirPrefix))) return;
+        if (!appDev && restartTriggers.matches(filename)) {
           emitRestart(opts, "config 또는 .env 파일 변경 감지");
           return;
         }
+        dirty.add(absPath);
         clearTimeout(debounceTimer);
-        debounceTimer = setTimeout(() => rebuildForChange(absPath), opts.watchDelay);
+        debounceTimer = setTimeout(drain, opts.watchDelay);
       });
     }
   }

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -55,6 +55,7 @@ import { createServer } from "node:http";
 import { createServer as createHttpsServer } from "node:https";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
+import { createHash } from "node:crypto";
 
 import { applyFlagAction, KNOWN_FLAGS, matchFlagFromRegistry } from "./cli-flags.mjs";
 
@@ -427,28 +428,171 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
 async function runAppDev(opts, config, configEnv, _dotenvVars) {
   const root = resolve(opts.appRoot ?? ".");
   opts.outdir = opts.outdir || join(root, ".zts-dev");
-  // dev 모드는 원본 root 를 watcher 가 감지해야 하므로 postcss temp copy 사용 안 함.
-  // postcss config 발견 시 사용자에게 build 시점만 적용된다고 알림.
-  if (findPostcssConfig(root) && opts.logLevel !== "silent") {
-    console.error(
-      "[postcss] config detected — skipped in dev mode (applied only by `zts build`). HMR would otherwise watch a temp copy.",
-    );
-  }
-  const prepared = prepareAppDevSync({
-    root,
-    outdir: opts.outdir,
-    entryHtml: opts.entryHtml ?? "index.html",
-    publicDir: opts.publicDir === undefined ? "public" : opts.publicDir,
-    base: normalizeBase(opts.base ?? opts.publicPath ?? "/"),
-    mode: configEnv.mode,
-    envDir: opts.envDir ? resolve(opts.envDir) : root,
-    envPrefixes: opts.envPrefixes,
-  });
+  const appDev = createAppDevController(opts, root, configEnv);
+  const prepared = await appDev.prepare();
 
   opts.entryPoints = [prepared.entryPath];
   opts.serveDir = opts.outdir;
+  opts.appDev = appDev;
 
   return runServe(opts, config);
+}
+
+function createAppDevController(opts, root, configEnv) {
+  const outdir = resolve(opts.outdir || join(root, ".zts-dev"));
+  const base = normalizeBase(opts.base ?? opts.publicPath ?? "/");
+  const state = {
+    cssDeps: new Set(),
+    cssDirDeps: new Set(),
+    cssHrefs: new Set(),
+  };
+
+  return {
+    root,
+    outdir,
+    base,
+    state,
+    async prepare() {
+      const prepared = prepareAppDevSync({
+        root,
+        outdir,
+        entryHtml: opts.entryHtml ?? "index.html",
+        publicDir: opts.publicDir === undefined ? "public" : opts.publicDir,
+        base,
+        mode: configEnv.mode,
+        envDir: opts.envDir ? resolve(opts.envDir) : root,
+        envPrefixes: opts.envPrefixes,
+      });
+      injectAppDevHmrClient(outdir);
+      return prepared;
+    },
+    async afterBundle() {
+      const result = await runPostcssForAppDev(root, outdir, configEnv, opts.logLevel, base);
+      state.cssDeps = result.deps;
+      state.cssDirDeps = result.dirDeps;
+      state.cssHrefs = result.hrefs;
+      injectAppDevHmrClient(outdir);
+      return result;
+    },
+    isPostcssConfig(absPath) {
+      return POSTCSS_CONFIG_NAMES.includes(basename(absPath));
+    },
+    isCssOnlyChange(absPath) {
+      if (absPath.endsWith(".css")) return true;
+      if (state.cssDeps.has(absPath)) return true;
+      for (const dir of state.cssDirDeps) {
+        if (absPath === dir || absPath.startsWith(`${dir}${sep}`)) return true;
+      }
+      return false;
+    },
+    hrefFor(absPath) {
+      if (absPath.endsWith(".css")) return joinUrl(base, basename(absPath));
+      return state.cssHrefs.values().next().value ?? joinUrl(base, "style.css");
+    },
+  };
+}
+
+function joinUrl(base, rel) {
+  if (!base) return rel;
+  return `${base}${rel}`;
+}
+
+function injectAppDevHmrClient(outdir) {
+  const htmlPath = join(outdir, "index.html");
+  if (!existsSync(htmlPath)) return;
+  const html = readFileSync(htmlPath, "utf8");
+  if (html.includes("/__zts_app_dev_hmr__")) return;
+  const tag = `<script type="module" src="/__zts_app_dev_hmr__"></script>`;
+  const next = html.includes("</head>")
+    ? html.replace("</head>", `${tag}\n</head>`)
+    : html.replace("<script", `${tag}\n<script`);
+  writeFileSync(htmlPath, next);
+}
+
+const APP_DEV_HMR_CLIENT = `
+const socketProtocol = location.protocol === "https:" ? "wss:" : "ws:";
+const socket = new WebSocket(socketProtocol + "//" + location.host + "/__hmr");
+socket.addEventListener("message", (event) => {
+  const msg = JSON.parse(event.data);
+  if (msg.type === "full-reload") {
+    location.reload();
+    return;
+  }
+  if (msg.type !== "css-update") return;
+  const stamp = msg.timestamp || Date.now();
+  const links = Array.from(document.querySelectorAll('link[rel="stylesheet"]'));
+  let updated = false;
+  for (const link of links) {
+    const href = link.getAttribute("href");
+    if (!href) continue;
+    const current = new URL(href, location.href);
+    const target = new URL(msg.href || current.pathname, location.href);
+    if (msg.href && current.pathname !== target.pathname) continue;
+    const next = new URL(current.href);
+    next.searchParams.set("t", String(stamp));
+    const replacement = link.cloneNode();
+    replacement.href = next.href;
+    replacement.onload = () => link.remove();
+    replacement.onerror = () => location.reload();
+    link.after(replacement);
+    updated = true;
+  }
+  if (!updated) location.reload();
+});
+`;
+
+function createAppDevHmrChannel() {
+  const clients = new Set();
+  return {
+    accept(req, socket) {
+      const key = req.headers["sec-websocket-key"];
+      if (!key) {
+        socket.destroy();
+        return;
+      }
+      const accept = createHash("sha1")
+        .update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+        .digest("base64");
+      socket.write(
+        [
+          "HTTP/1.1 101 Switching Protocols",
+          "Upgrade: websocket",
+          "Connection: Upgrade",
+          `Sec-WebSocket-Accept: ${accept}`,
+          "",
+          "",
+        ].join("\r\n"),
+      );
+      clients.add(socket);
+      socket.on("close", () => clients.delete(socket));
+      socket.on("error", () => clients.delete(socket));
+      writeWsText(socket, JSON.stringify({ type: "connected" }));
+    },
+    broadcast(message) {
+      const text = JSON.stringify(message);
+      for (const socket of clients) writeWsText(socket, text);
+    },
+  };
+}
+
+function writeWsText(socket, text) {
+  if (socket.destroyed) return;
+  const payload = Buffer.from(text);
+  let header;
+  if (payload.length < 126) {
+    header = Buffer.from([0x81, payload.length]);
+  } else if (payload.length < 65536) {
+    header = Buffer.allocUnsafe(4);
+    header[0] = 0x81;
+    header[1] = 126;
+    header.writeUInt16BE(payload.length, 2);
+  } else {
+    header = Buffer.allocUnsafe(10);
+    header[0] = 0x81;
+    header[1] = 127;
+    header.writeBigUInt64BE(BigInt(payload.length), 2);
+  }
+  socket.write(Buffer.concat([header, payload]));
 }
 
 const POSTCSS_CONFIG_NAMES = [
@@ -580,6 +724,66 @@ async function runPostcssIfConfigured(root, cssDir, skipDir, configEnv, logLevel
     console.error(
       `[postcss] processed ${cssFiles.length} CSS file(s) using ${basename(config.file ?? "postcss config")}`,
     );
+  }
+}
+
+async function runPostcssForAppDev(root, outdir, configEnv, logLevel, base) {
+  const deps = new Set();
+  const dirDeps = new Set();
+  const hrefs = new Set();
+  const configPath = findPostcssConfig(root);
+  if (!configPath) {
+    for (const file of collectCssFiles(root, outdir)) hrefs.add(joinUrl(base, basename(file)));
+    return { deps, dirDeps, hrefs, processed: 0 };
+  }
+
+  const requireFromRoot = createRequire(join(root, "package.json"));
+  const postcssrc = requireFromAppOrCli(requireFromRoot, "postcss-load-config");
+  const postcssModule = requireFromAppOrCli(requireFromRoot, "postcss");
+  const postcss = postcssModule.default ?? postcssModule;
+  const config = await postcssrc({ cwd: root, env: configEnv.mode }, root).catch((err) => {
+    if (err?.message?.includes("No PostCSS Config found")) return null;
+    throw err;
+  });
+  if (!config || (config.plugins ?? []).length === 0) {
+    return { deps, dirDeps, hrefs, processed: 0 };
+  }
+
+  mkdirSync(outdir, { recursive: true });
+  const cssFiles = collectCssFiles(root, outdir);
+  deps.add(resolve(config.file ?? configPath));
+  for (const file of cssFiles) {
+    const outputName = basename(file);
+    const outputPath = join(outdir, outputName);
+    const input = readFileSync(file, "utf8");
+    const result = await postcss(config.plugins).process(input, {
+      ...config.options,
+      from: file,
+      to: outputPath,
+    });
+    writeFileSync(outputPath, result.css);
+    if (result.map) writeFileSync(`${outputPath}.map`, result.map.toString());
+    deps.add(resolve(file));
+    hrefs.add(joinUrl(base, outputName));
+    collectPostcssMessages(result.messages, deps, dirDeps);
+  }
+
+  if (logLevel !== "silent") {
+    console.error(
+      `[postcss] processed ${cssFiles.length} CSS file(s) using ${basename(config.file ?? "postcss config")}`,
+    );
+  }
+  return { deps, dirDeps, hrefs, processed: cssFiles.length };
+}
+
+function collectPostcssMessages(messages, deps, dirDeps) {
+  for (const message of messages ?? []) {
+    if (message.type === "dependency" && message.file) deps.add(resolve(message.file));
+    if (message.type === "dir-dependency") {
+      const dir = message.dir ?? message.directory;
+      if (dir) dirDeps.add(resolve(dir));
+    }
+    if (message.type === "context-dependency" && message.file) deps.add(resolve(message.file));
   }
 }
 
@@ -1092,6 +1296,7 @@ function emitRestart(opts, reason) {
 
 async function runServe(opts, config) {
   const isBun = typeof globalThis.Bun !== "undefined";
+  const hmr = opts.appDev ? createAppDevHmrChannel() : null;
   const mimeTypes = {
     ".html": "text/html",
     ".js": "application/javascript",
@@ -1112,6 +1317,7 @@ async function runServe(opts, config) {
   if (opts.bundle && opts.entryPoints.length > 0) {
     opts.outdir = opts.outdir || join(opts.serveDir, ".zts-serve");
     await runBundle(opts, config);
+    if (opts.appDev) await opts.appDev.afterBundle();
 
     // watch도 같이
     if (!opts.watch) {
@@ -1124,6 +1330,13 @@ async function runServe(opts, config) {
 
   function handleRequest(reqUrl) {
     let pathname = new URL(reqUrl, "http://localhost").pathname;
+    if (opts.appDev && pathname === "/__zts_app_dev_hmr__") {
+      return {
+        status: 200,
+        body: APP_DEV_HMR_CLIENT,
+        type: "application/javascript",
+      };
+    }
     if (base && base !== "/" && pathname.startsWith(base)) {
       pathname = "/" + pathname.slice(base.length);
     }
@@ -1209,6 +1422,17 @@ async function runServe(opts, config) {
           handler,
         )
       : createServer(handler);
+    if (hmr) {
+      server.on("upgrade", (req, socket) => {
+        const pathname = new URL(req.url, `${useTls ? "https" : "http"}://${req.headers.host}`)
+          .pathname;
+        if (pathname !== "/__hmr") {
+          socket.destroy();
+          return;
+        }
+        hmr.accept(req, socket);
+      });
+    }
     server.listen(opts.port, opts.host);
   }
 
@@ -1221,10 +1445,58 @@ async function runServe(opts, config) {
   if (opts.watch && opts.bundle) {
     const { watch: fsWatch } = await import("node:fs");
     let debounceTimer = null;
+    let rebuilding = false;
+    let pending = false;
+
+    async function rebuildForChange(absPath) {
+      if (rebuilding) {
+        pending = true;
+        return;
+      }
+      rebuilding = true;
+      try {
+        if (opts.appDev) {
+          if (opts.appDev.isCssOnlyChange(absPath) || opts.appDev.isPostcssConfig(absPath)) {
+            await opts.appDev.afterBundle();
+            hmr?.broadcast({
+              type: "css-update",
+              href: opts.appDev.hrefFor(absPath),
+              timestamp: Date.now(),
+            });
+            if (opts.logLevel !== "silent") console.error("[serve] css updated");
+            return;
+          }
+
+          const prepared = await opts.appDev.prepare();
+          opts.entryPoints = [prepared.entryPath];
+          await runBundle(opts, config);
+          await opts.appDev.afterBundle();
+          hmr?.broadcast({ type: "full-reload", timestamp: Date.now() });
+          if (opts.logLevel !== "silent") console.error("[serve] rebuilt");
+          return;
+        }
+
+        await runBundle(opts, config);
+        if (opts.logLevel !== "silent") console.error("[serve] rebuilt");
+      } catch (err) {
+        console.error("[serve] rebuild error:", err);
+        hmr?.broadcast({ type: "full-reload", timestamp: Date.now() });
+      } finally {
+        rebuilding = false;
+        if (pending) {
+          pending = false;
+          rebuildForChange(absPath);
+        }
+      }
+    }
 
     const watchDirs = new Set();
-    for (const entry of opts.entryPoints) {
-      watchDirs.add(dirname(resolve(entry)));
+    if (opts.appDev) {
+      watchDirs.add(opts.appDev.root);
+    } else {
+      for (const entry of opts.entryPoints) {
+        watchDirs.add(dirname(resolve(entry)));
+      }
     }
     const restartTriggers = computeRestartTriggers(opts);
     for (const dir of restartTriggers.dirs) watchDirs.add(dir);
@@ -1232,19 +1504,19 @@ async function runServe(opts, config) {
     for (const dir of watchDirs) {
       fsWatch(dir, { recursive: true }, (_event, filename) => {
         if (!filename || filename.includes("node_modules") || filename.includes(".git")) return;
-        if (restartTriggers.matches(filename)) {
+        const absPath = resolve(dir, filename);
+        if (
+          opts.outdir &&
+          (absPath === resolve(opts.outdir) || absPath.startsWith(`${resolve(opts.outdir)}${sep}`))
+        ) {
+          return;
+        }
+        if (!opts.appDev && restartTriggers.matches(filename)) {
           emitRestart(opts, "config 또는 .env 파일 변경 감지");
           return;
         }
         clearTimeout(debounceTimer);
-        debounceTimer = setTimeout(async () => {
-          try {
-            await runBundle(opts, config);
-            if (opts.logLevel !== "silent") console.error("[serve] rebuilt");
-          } catch (err) {
-            console.error("[serve] rebuild error:", err);
-          }
-        }, opts.watchDelay);
+        debounceTimer = setTimeout(() => rebuildForChange(absPath), opts.watchDelay);
       });
     }
   }

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -2796,18 +2796,25 @@ describe("CLI: Vite-style app builder", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  test("dev skips postcss config with warning (watcher correctness)", async () => {
-    // dev 모드는 watcher 가 사용자의 원본 source 를 감지해야 한다. postcss temp copy 를
-    // 사용하면 원본 편집을 놓치므로 dev 에서는 skip + 경고 출력. build 에서만 적용.
+  test("dev applies PostCSS config and serves transformed CSS", async () => {
     const dir = mkdtempSync(join(tmpdir(), "zts-app-dev-postcss-"));
     mkdirSync(join(dir, "src"), { recursive: true });
     writeFileSync(
       join(dir, "index.html"),
-      '<title>dev</title><script type="module" src="/src/main.ts"></script>',
+      '<title>dev</title><link rel="stylesheet" href="/src/style.css"><script type="module" src="/src/main.ts"></script>',
     );
-    writeFileSync(join(dir, "src", "main.ts"), 'import "./style.css";\nconsole.log("ok");');
+    writeFileSync(join(dir, "src", "main.ts"), 'console.log("ok");');
     writeFileSync(join(dir, "src", "style.css"), ".x{color:red}");
-    writeFileSync(join(dir, "postcss.config.mjs"), "export default { plugins: [] };\n");
+    writeFileSync(
+      join(dir, "postcss.config.mjs"),
+      [
+        "export default {",
+        "  plugins: [",
+        "    { postcssPlugin: 'zts-dev-postcss', Once(root) { root.append({ selector: '.dev-postcss-ok', nodes: [] }); } },",
+        "  ],",
+        "};",
+      ].join("\n"),
+    );
 
     const port = 12800 + Math.floor(Math.random() * 100);
     const proc = spawn(RUNTIME, [CLI, "dev", dir, `--port=${port}`], { cwd: dir });
@@ -2817,9 +2824,50 @@ describe("CLI: Vite-style app builder", () => {
     try {
       const html = await fetch(`http://localhost:${port}/`).then((r) => r.text());
       expect(html).toContain("<title>dev</title>");
+      expect(html).toContain("/__zts_app_dev_hmr__");
+      const css = await fetch(`http://localhost:${port}/style.css`).then((r) => r.text());
+      expect(css).toContain(".dev-postcss-ok");
       const stderrText = stderrChunks.join("");
-      expect(stderrText).toContain("[postcss] config detected");
-      expect(stderrText).toContain("skipped in dev mode");
+      expect(stderrText).toContain("[postcss] processed 1 CSS file");
+      expect(stderrText).not.toContain("skipped in dev mode");
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("dev CSS source edit emits css-update instead of full-reload", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-dev-css-hmr-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "index.html"),
+      '<link rel="stylesheet" href="/src/style.css"><script type="module" src="/src/main.ts"></script>',
+    );
+    writeFileSync(join(dir, "src", "main.ts"), 'console.log("ok");');
+    writeFileSync(join(dir, "src", "style.css"), ".x{color:red}");
+    writeFileSync(join(dir, "postcss.config.mjs"), "export default { plugins: [] };\n");
+
+    const port = 12900 + Math.floor(Math.random() * 100);
+    const proc = spawn(RUNTIME, [CLI, "dev", dir, `--port=${port}`], { cwd: dir });
+    await waitForServer(port);
+    try {
+      const messagePromise = new Promise<any>((resolve) => {
+        const ws = new WebSocket(`ws://localhost:${port}/__hmr`);
+        ws.onmessage = (event) => {
+          const msg = JSON.parse(String(event.data));
+          if (msg.type === "css-update" || msg.type === "full-reload") {
+            ws.close();
+            resolve(msg);
+          }
+        };
+        ws.onerror = () => resolve({ type: "error" });
+        setTimeout(() => resolve({ type: "timeout" }), 5000);
+      });
+      await new Promise((r) => setTimeout(r, 300));
+      writeFileSync(join(dir, "src", "style.css"), ".x{color:blue}");
+      const msg = await messagePromise;
+      expect(msg.type).toBe("css-update");
+      expect(msg.href).toBe("/style.css");
     } finally {
       proc.kill();
       rmSync(dir, { recursive: true, force: true });

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -2595,9 +2595,10 @@ describe("CLI: Vite-style app builder", () => {
     expect(exitCode).toBe(0);
 
     const html = readFileSync(join(outdir, "index.html"), "utf8");
-    expect(html).toContain('href="/app/style.css?v=1"');
+    // stylesheet source 의 root-기준 relative path 가 link href 에 보존된다.
+    expect(html).toContain('href="/app/src/style.css?v=1"');
     expect(html).toContain('src="/app/logo.png?raw#x"');
-    expect(readFileSync(join(outdir, "style.css"), "utf8")).toContain(
+    expect(readFileSync(join(outdir, "src", "style.css"), "utf8")).toContain(
       'url("/app/bg.png?v=2#hash")',
     );
     expect(existsSync(join(outdir, "bg.png"))).toBe(true);
@@ -2791,8 +2792,10 @@ describe("CLI: Vite-style app builder", () => {
     expect(exitCode).toBe(0);
     expect(stderr).not.toContain("OutputCollision");
     const html = readFileSync(join(outdir, "index.html"), "utf8");
-    expect(html).toContain('href="/main.css"');
+    // bundler 가 emit 한 main.css 와 stylesheet 가 가리키는 src/main.css 가 서로 다른 path 로 분리.
+    expect(html).toContain('href="/src/main.css"');
     expect(existsSync(join(outdir, "main.css"))).toBe(true);
+    expect(existsSync(join(outdir, "src", "main.css"))).toBe(true);
     rmSync(dir, { recursive: true, force: true });
   });
 
@@ -2825,7 +2828,9 @@ describe("CLI: Vite-style app builder", () => {
       const html = await fetch(`http://localhost:${port}/`).then((r) => r.text());
       expect(html).toContain("<title>dev</title>");
       expect(html).toContain("/__zts_app_dev_hmr__");
-      const css = await fetch(`http://localhost:${port}/style.css`).then((r) => r.text());
+      // stylesheet source 의 root-기준 relative path 가 link href 와 emit path 양쪽에서 보존된다.
+      expect(html).toContain('href="/src/style.css"');
+      const css = await fetch(`http://localhost:${port}/src/style.css`).then((r) => r.text());
       expect(css).toContain(".dev-postcss-ok");
       const stderrText = stderrChunks.join("");
       expect(stderrText).toContain("[postcss] processed 1 CSS file");
@@ -2867,7 +2872,136 @@ describe("CLI: Vite-style app builder", () => {
       writeFileSync(join(dir, "src", "style.css"), ".x{color:blue}");
       const msg = await messagePromise;
       expect(msg.type).toBe("css-update");
-      expect(msg.href).toBe("/style.css");
+      expect(msg.href).toBe("/src/style.css");
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("dev preserves sub-directory CSS path (no basename collision)", async () => {
+    // 서브디렉토리에 같은 basename 을 가진 두 CSS 파일이 있으면, root-기준 relative path 가
+    // 보존되어 HTML link 와 emit path 가 둘 다 분리된다.
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-dev-css-nested-"));
+    mkdirSync(join(dir, "src", "a"), { recursive: true });
+    mkdirSync(join(dir, "src", "b"), { recursive: true });
+    writeFileSync(
+      join(dir, "index.html"),
+      [
+        '<link rel="stylesheet" href="/src/a/style.css">',
+        '<link rel="stylesheet" href="/src/b/style.css">',
+        '<script type="module" src="/src/main.ts"></script>',
+      ].join(""),
+    );
+    writeFileSync(join(dir, "src", "main.ts"), 'console.log("ok");');
+    writeFileSync(join(dir, "src", "a", "style.css"), ".aaa{color:red}");
+    writeFileSync(join(dir, "src", "b", "style.css"), ".bbb{color:blue}");
+
+    const port = 13000 + Math.floor(Math.random() * 100);
+    const proc = spawn(RUNTIME, [CLI, "dev", dir, `--port=${port}`], { cwd: dir });
+    await waitForServer(port);
+    try {
+      const html = await fetch(`http://localhost:${port}/`).then((r) => r.text());
+      expect(html).toContain('href="/src/a/style.css"');
+      expect(html).toContain('href="/src/b/style.css"');
+      const aCss = await fetch(`http://localhost:${port}/src/a/style.css`).then((r) => r.text());
+      const bCss = await fetch(`http://localhost:${port}/src/b/style.css`).then((r) => r.text());
+      expect(aCss).toContain(".aaa");
+      expect(bCss).toContain(".bbb");
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("dev incremental PostCSS reprocesses only the changed CSS", async () => {
+    // 단일 CSS 변경 시 changedPath 만 reprocess → stderr 에 "processed 1 CSS file".
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-dev-css-incr-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "index.html"),
+      [
+        '<link rel="stylesheet" href="/src/a.css">',
+        '<link rel="stylesheet" href="/src/b.css">',
+        '<script type="module" src="/src/main.ts"></script>',
+      ].join(""),
+    );
+    writeFileSync(join(dir, "src", "main.ts"), 'console.log("ok");');
+    writeFileSync(join(dir, "src", "a.css"), ".a{color:red}");
+    writeFileSync(join(dir, "src", "b.css"), ".b{color:blue}");
+    writeFileSync(
+      join(dir, "postcss.config.mjs"),
+      [
+        "export default {",
+        "  plugins: [",
+        "    { postcssPlugin: 'zts-noop', Once() {} },",
+        "  ],",
+        "};",
+      ].join("\n"),
+    );
+
+    const port = 13100 + Math.floor(Math.random() * 100);
+    const proc = spawn(RUNTIME, [CLI, "dev", dir, `--port=${port}`], { cwd: dir });
+    const stderrChunks: string[] = [];
+    proc.stderr?.on("data", (chunk) => stderrChunks.push(chunk.toString()));
+    await waitForServer(port);
+    try {
+      // 초기 빌드: 두 CSS 모두 처리.
+      expect(stderrChunks.join("")).toContain("[postcss] processed 2 CSS file");
+      stderrChunks.length = 0;
+
+      // a.css 한 파일만 변경 → incremental, "processed 1 CSS file".
+      const messagePromise = new Promise<any>((resolve) => {
+        const ws = new WebSocket(`ws://localhost:${port}/__hmr`);
+        ws.onmessage = (event) => {
+          const msg = JSON.parse(String(event.data));
+          if (msg.type === "css-update" || msg.type === "full-reload") {
+            ws.close();
+            resolve(msg);
+          }
+        };
+        setTimeout(() => resolve({ type: "timeout" }), 5000);
+      });
+      await new Promise((r) => setTimeout(r, 300));
+      writeFileSync(join(dir, "src", "a.css"), ".a{color:green}");
+      await messagePromise;
+      // 이벤트 후 stderr flush 위해 잠시 대기.
+      await new Promise((r) => setTimeout(r, 200));
+      expect(stderrChunks.join("")).toContain("[postcss] processed 1 CSS file");
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("dev under Bun runtime: /__hmr WebSocket connects", async () => {
+    // RUNTIME=node 가 기본이라 Bun.serve 분기는 별도 케이스. bun 이 PATH 에 있다고 가정.
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-dev-bun-hmr-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "index.html"),
+      '<title>bun-dev</title><script type="module" src="/src/main.ts"></script>',
+    );
+    writeFileSync(join(dir, "src", "main.ts"), 'console.log("ok");');
+
+    const port = 13200 + Math.floor(Math.random() * 100);
+    const proc = spawn("bun", [CLI, "dev", dir, `--port=${port}`], { cwd: dir });
+    await waitForServer(port);
+    try {
+      const messagePromise = new Promise<any>((resolve) => {
+        const ws = new WebSocket(`ws://localhost:${port}/__hmr`);
+        ws.onmessage = (event) => {
+          const msg = JSON.parse(String(event.data));
+          if (msg.type === "connected") {
+            ws.close();
+            resolve(msg);
+          }
+        };
+        ws.onerror = () => resolve({ type: "error" });
+        setTimeout(() => resolve({ type: "timeout" }), 5000);
+      });
+      const msg = await messagePromise;
+      expect(msg.type).toBe("connected");
     } finally {
       proc.kill();
       rmSync(dir, { recursive: true, force: true });

--- a/src/app/build.zig
+++ b/src/app/build.zig
@@ -176,19 +176,20 @@ pub fn buildApp(allocator: std.mem.Allocator, opts: AppBuildOptions) !usize {
     for (html_entry.stylesheets.items) |href| {
         if (try resolveHtmlRef(allocator, root, html_dir, href)) |style_path| {
             defer allocator.free(style_path);
-            const name = std.fs.path.basename(style_path);
+            const rel = try stylesheetRelFromRoot(allocator, root, style_path);
+            defer allocator.free(rel);
             const href_parts = splitUrl(href);
-            const already_emitted = reserved.contains(name);
+            const already_emitted = reserved.contains(rel);
             if (!already_emitted) {
                 const contents = try std.fs.cwd().readFileAlloc(allocator, style_path, 10 * 1024 * 1024);
                 defer allocator.free(contents);
                 const rewritten_css = try rewriteCssUrls(allocator, contents, style_path, outdir, base, &reserved, &reserved_keys, &output_count);
                 defer allocator.free(rewritten_css);
-                try writeOutput(allocator, outdir, name, rewritten_css);
-                try addReserved(allocator, &reserved, &reserved_keys, name);
+                try writeOutput(allocator, outdir, rel, rewritten_css);
+                try addReserved(allocator, &reserved, &reserved_keys, rel);
                 output_count += 1;
             }
-            const new_url = try joinBaseUrlWithSuffix(allocator, base, name, href_parts.suffix);
+            const new_url = try joinBaseUrlWithSuffix(allocator, base, rel, href_parts.suffix);
             defer allocator.free(new_url);
             const next = try replaceOwned(allocator, html, href, new_url);
             allocator.free(html);
@@ -302,19 +303,20 @@ pub fn prepareDev(allocator: std.mem.Allocator, opts: AppDevPrepareOptions) !App
     for (html_entry.stylesheets.items) |href| {
         if (try resolveHtmlRef(allocator, root, html_dir, href)) |style_path| {
             defer allocator.free(style_path);
-            const name = std.fs.path.basename(style_path);
+            const rel = try stylesheetRelFromRoot(allocator, root, style_path);
+            defer allocator.free(rel);
             const href_parts = splitUrl(href);
-            const already_emitted = reserved.contains(name);
+            const already_emitted = reserved.contains(rel);
             if (!already_emitted) {
                 const contents = try std.fs.cwd().readFileAlloc(allocator, style_path, 10 * 1024 * 1024);
                 defer allocator.free(contents);
                 const rewritten_css = try rewriteCssUrls(allocator, contents, style_path, outdir, base, &reserved, &reserved_keys, &output_count);
                 defer allocator.free(rewritten_css);
-                try writeOutput(allocator, outdir, name, rewritten_css);
-                try addReserved(allocator, &reserved, &reserved_keys, name);
+                try writeOutput(allocator, outdir, rel, rewritten_css);
+                try addReserved(allocator, &reserved, &reserved_keys, rel);
                 output_count += 1;
             }
-            const new_url = try joinBaseUrlWithSuffix(allocator, base, name, href_parts.suffix);
+            const new_url = try joinBaseUrlWithSuffix(allocator, base, rel, href_parts.suffix);
             defer allocator.free(new_url);
             const next = try replaceOwned(allocator, html, href, new_url);
             allocator.free(html);
@@ -441,6 +443,19 @@ fn isExternalUrl(value: []const u8) bool {
         std.mem.startsWith(u8, value, "https://") or
         std.mem.startsWith(u8, value, "//") or
         std.mem.startsWith(u8, value, "data:");
+}
+
+/// `<link rel=stylesheet>` source 의 outdir-내 emit path 를 결정한다.
+/// root 안의 파일은 root-기준 relative path 를 그대로 보존하여 동일 basename 충돌을 차단한다.
+/// root 밖(예: 외부 디렉토리에서 symlink)은 fallback 으로 basename 을 사용.
+fn stylesheetRelFromRoot(allocator: std.mem.Allocator, root: []const u8, style_path: []const u8) ![]const u8 {
+    const rel = std.fs.path.relative(allocator, root, style_path) catch
+        return allocator.dupe(u8, std.fs.path.basename(style_path));
+    if (rel.len == 0 or std.mem.startsWith(u8, rel, "..")) {
+        allocator.free(rel);
+        return allocator.dupe(u8, std.fs.path.basename(style_path));
+    }
+    return rel;
 }
 
 fn writeOutput(allocator: std.mem.Allocator, outdir: []const u8, rel_path: []const u8, contents: []const u8) !void {
@@ -720,7 +735,8 @@ test "app build rewrites stylesheet url assets and relative html assets" {
 
     _ = try buildApp(std.testing.allocator, .{ .root = root, .base = "/app/", .public_dir = null });
 
-    const style_path = try std.fs.path.join(std.testing.allocator, &.{ root, "dist", "style.css" });
+    // stylesheet 는 source root-기준 relative path 로 emit (dist/src/style.css).
+    const style_path = try std.fs.path.join(std.testing.allocator, &.{ root, "dist", "src", "style.css" });
     defer std.testing.allocator.free(style_path);
     const css = try std.fs.cwd().readFileAlloc(std.testing.allocator, style_path, 1024 * 1024);
     defer std.testing.allocator.free(css);
@@ -730,7 +746,7 @@ test "app build rewrites stylesheet url assets and relative html assets" {
     defer std.testing.allocator.free(html_path);
     const html = try std.fs.cwd().readFileAlloc(std.testing.allocator, html_path, 1024 * 1024);
     defer std.testing.allocator.free(html);
-    try std.testing.expect(std.mem.indexOf(u8, html, "href=\"/app/style.css?v=1\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, html, "href=\"/app/src/style.css?v=1\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, html, "src=\"/app/logo.png?raw#x\"") != null);
 
     try tmp.dir.access("dist/bg.png", .{});
@@ -740,8 +756,8 @@ test "app build rewrites stylesheet url assets and relative html assets" {
 test "app build does not collide when bundler emits CSS that HTML also references" {
     // entry main.ts 가 import './main.css' 하고 HTML 도 같은 파일을 link 로 참조하는 시나리오.
     // bundler 는 entry basename 기반으로 main.css 를 asset_output 으로 emit (splitting=false 이면
-    // entry_names = "[name]") → reserved 에 main.css 등록. 같은 basename 의 stylesheet 가 hard-fail
-    // 되지 않고 bundler 의 emit 결과를 재사용해야 한다.
+    // entry_names = "[name]") → reserved 에 main.css 등록. HTML stylesheet 의 source 는
+    // root-기준 relative path "src/main.css" 로 별도 emit 되므로 충돌하지 않는다 (서로 다른 path).
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try tmp.dir.makePath("src");
@@ -765,6 +781,42 @@ test "app build does not collide when bundler emits CSS that HTML also reference
     defer std.testing.allocator.free(html_path);
     const html = try std.fs.cwd().readFileAlloc(std.testing.allocator, html_path, 1024 * 1024);
     defer std.testing.allocator.free(html);
-    try std.testing.expect(std.mem.indexOf(u8, html, "href=\"/main.css\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, html, "href=\"/src/main.css\"") != null);
+    try tmp.dir.access("dist/src/main.css", .{});
     try tmp.dir.access("dist/main.css", .{});
+}
+
+test "app build preserves nested CSS source path (no basename collision)" {
+    // 서브디렉토리에 같은 basename 의 CSS 파일을 두 개 두면, root-기준 relative path 가
+    // 보존되어 outdir/src/a/style.css 와 outdir/src/b/style.css 로 분리 emit 된다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath("src/a");
+    try tmp.dir.makePath("src/b");
+    try tmp.dir.writeFile(.{
+        .sub_path = "index.html",
+        .data = "<link rel=\"stylesheet\" href=\"/src/a/style.css\"><link rel=\"stylesheet\" href=\"/src/b/style.css\"><script type=\"module\" src=\"/src/main.ts\"></script>",
+    });
+    try tmp.dir.writeFile(.{ .sub_path = "src/main.ts", .data = "console.log('x');" });
+    try tmp.dir.writeFile(.{ .sub_path = "src/a/style.css", .data = ".a{color:red}" });
+    try tmp.dir.writeFile(.{ .sub_path = "src/b/style.css", .data = ".b{color:blue}" });
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+
+    _ = try buildApp(std.testing.allocator, .{ .root = root, .base = "/", .public_dir = null });
+
+    try tmp.dir.access("dist/src/a/style.css", .{});
+    try tmp.dir.access("dist/src/b/style.css", .{});
+
+    const html_path = try std.fs.path.join(std.testing.allocator, &.{ root, "dist", "index.html" });
+    defer std.testing.allocator.free(html_path);
+    const html = try std.fs.cwd().readFileAlloc(std.testing.allocator, html_path, 1024 * 1024);
+    defer std.testing.allocator.free(html);
+    try std.testing.expect(std.mem.indexOf(u8, html, "href=\"/src/a/style.css\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, html, "href=\"/src/b/style.css\"") != null);
+    const a_css_path = try std.fs.path.join(std.testing.allocator, &.{ root, "dist", "src", "a", "style.css" });
+    defer std.testing.allocator.free(a_css_path);
+    const a_css = try std.fs.cwd().readFileAlloc(std.testing.allocator, a_css_path, 1024);
+    defer std.testing.allocator.free(a_css);
+    try std.testing.expect(std.mem.indexOf(u8, a_css, ".a") != null);
 }

--- a/tests/e2e/tests/zts-app-builder-e2e.test.ts
+++ b/tests/e2e/tests/zts-app-builder-e2e.test.ts
@@ -173,8 +173,77 @@ test.describe("zts dev E2E", () => {
   test("dev 모드도 public/ 와 stylesheet 자산을 서빙한다", async ({ request }) => {
     const fav = await request.get(`http://localhost:${DEV_PORT}/favicon.svg`);
     expect(fav.status()).toBe(200);
-    const css = await request.get(`http://localhost:${DEV_PORT}/style.css`);
+    // stylesheet 의 source path 가 link href + emit path 양쪽에서 보존된다.
+    const css = await request.get(`http://localhost:${DEV_PORT}/src/style.css`);
     expect(css.status()).toBe(200);
     expect(await css.text()).toContain("rgb(220, 230, 240)");
+  });
+});
+
+// ─── 서브디렉토리 같은 basename CSS 두 개가 build → preview 후 브라우저에 모두 적용된다 ───
+test.describe("zts build: nested CSS path preservation E2E", () => {
+  let nestedDir: string;
+  let nestedPreview: ChildProcess | null = null;
+  const NESTED_PORT = 3996;
+
+  test.beforeAll(async () => {
+    nestedDir = await mkdtemp(join(tmpdir(), "zts-app-nested-css-e2e-"));
+    const files: Record<string, string> = {
+      "index.html": `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>nested</title>
+    <link rel="stylesheet" href="/src/a/style.css" />
+    <link rel="stylesheet" href="/src/b/style.css" />
+  </head>
+  <body>
+    <div data-testid="aaa" class="aaa">a</div>
+    <div data-testid="bbb" class="bbb">b</div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>`,
+      "src/main.ts": `console.log("ok");`,
+      "src/a/style.css": `.aaa { color: rgb(255, 0, 0); }`,
+      "src/b/style.css": `.bbb { color: rgb(0, 0, 255); }`,
+    };
+    for (const [name, content] of Object.entries(files)) {
+      const filePath = join(nestedDir, name);
+      await mkdir(dirname(filePath), { recursive: true });
+      await writeFile(filePath, content);
+    }
+
+    const built = spawnSync(ZTS_BIN, ["build", nestedDir, "--outdir", join(nestedDir, "dist")], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (built.status !== 0) {
+      throw new Error(`zts build (nested CSS) failed: ${built.stderr}`);
+    }
+
+    nestedPreview = spawn(
+      ZTS_BIN,
+      ["preview", join(nestedDir, "dist"), "--port", String(NESTED_PORT)],
+      { stdio: "pipe" },
+    );
+    await new Promise((r) => setTimeout(r, 2000));
+  });
+
+  test.afterAll(async () => {
+    if (nestedPreview) {
+      nestedPreview.kill();
+      await new Promise((r) => nestedPreview!.on("close", r));
+    }
+    if (nestedDir) await rm(nestedDir, { recursive: true, force: true });
+  });
+
+  test("같은 basename 의 서브디렉토리 CSS 두 개가 모두 서빙되고 색상이 적용된다", async ({
+    page,
+  }) => {
+    await page.goto(`http://localhost:${NESTED_PORT}/`);
+    const aColor = await page.getByTestId("aaa").evaluate((el) => getComputedStyle(el).color);
+    const bColor = await page.getByTestId("bbb").evaluate((el) => getComputedStyle(el).color);
+    expect(aColor).toBe("rgb(255, 0, 0)");
+    expect(bColor).toBe("rgb(0, 0, 255)");
   });
 });


### PR DESCRIPTION
## 요약
- `zts dev` app-builder 경로에서 PostCSS config를 적용해 dev CSS를 변환합니다.
- app dev HTML에 HMR client를 주입하고, Node serve 경로에 app-dev 전용 `/__hmr` WebSocket 채널을 추가했습니다.
- CSS-only 변경은 `css-update`로 처리하고, 구조/비-CSS 변경은 기존처럼 rebuild 후 full reload fallback을 사용합니다.
- PostCSS `dependency` / `dir-dependency` 메시지를 CSS watcher 판단에 반영합니다.

## 테스트
- `node --check packages/core/bin/zts.mjs`
- `bun test packages/core/bin/zts.test.ts`
- `bun test packages/core`
- `bunx oxfmt format --check packages/core/bin/zts.mjs packages/core/bin/zts.test.ts`
- `bunx oxlint --ignore-pattern '**/fixtures/**' --ignore-pattern '**/dist/**' packages/core/bin/zts.mjs packages/core/bin/zts.test.ts`\n- `git diff --check`