### PR TITLE
fix(parser): yield-outside-generator 명확한 진단 (#2210)

### DIFF
--- a/src/error_codes.zig
+++ b/src/error_codes.zig
@@ -184,6 +184,7 @@ pub const Code = enum(u16) {
     flow_opaque_type = 914,
     ts_index_sig_modifier = 915,
     ts_index_sig_optional = 916,
+    yield_outside_generator = 917,
 
     // ═══════════════════════════════════════════════════════
     // 1000-1099: 시맨틱 — 재선언/스코프
@@ -391,6 +392,7 @@ pub const Code = enum(u16) {
             .await_in_async_arrow_params => "'await' is not allowed in async arrow function parameters",
             .yield_in_parameters => "'yield' expression is not allowed in formal parameters",
             .yield_in_arrow_params => "'yield' is not allowed in arrow function parameters",
+            .yield_outside_generator => "'yield' is not allowed outside generator function",
             .template_invalid_escape => "Invalid escape sequence in template literal",
             .template_continuation_expected => "Expected template continuation",
             .jsx_tag_expected => "JSX tag name expected",

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -775,7 +775,16 @@ fn parseUnaryExpression(self: *Parser) ParseError2!NodeIndex {
         },
         // yield expression은 parseAssignmentExpression에서 처리됨 (ECMAScript 14.4)
         // generator 안에서 여기에 도달하면 identifier reference로 해석 → 에러
-        .kw_yield => return parsePostfixExpression(self),
+        .kw_yield => {
+            // generator 가 아닌 함수 본문에서 yield 사용 → 명확한 진단 (#2210).
+            // await 패턴 (in_async / in_module 비교) 과 동일하게 in_generator
+            // 검사 후 fail 하면 yield 키워드 위치에 진단 emit. fallthrough 로
+            // identifier 처리는 유지해 후속 토큰에 cascade 에러가 나지 않도록.
+            if (self.is_module and !self.in_namespace and self.ctx.in_function and !self.ctx.in_generator) {
+                try self.addErrorCode(self.currentSpan(), "'yield' is not allowed outside generator function", .yield_outside_generator);
+            }
+            return parsePostfixExpression(self);
+        },
         else => return parsePostfixExpression(self),
     }
 }

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -1718,6 +1718,28 @@ test "Parser: yield is identifier outside generator" {
     try std.testing.expect(parser.errors.items.len == 0);
 }
 
+test "Parser: yield in non-generator function (module) emits clear diagnostic (#2210)" {
+    var scanner = try Scanner.init(std.testing.allocator, "function notGen() { yield 1; }");
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    parser.is_module = true;
+    defer parser.deinit();
+
+    _ = try parser.parse();
+    // 명확한 진단 emit + yield 키워드 위치 정확.
+    try std.testing.expect(parser.errors.items.len > 0);
+    var found = false;
+    for (parser.errors.items) |err| {
+        if (err.code) |c| if (c == .yield_outside_generator) {
+            found = true;
+            // yield 키워드 위치는 'function notGen() { ' 다음 = offset 20
+            try std.testing.expectEqual(@as(u32, 20), err.span.start);
+            break;
+        };
+    }
+    try std.testing.expect(found);
+}
+
 test "Parser: await is identifier in script mode" {
     var scanner = try Scanner.init(std.testing.allocator, "var await = 1;");
     defer scanner.deinit();


### PR DESCRIPTION
## Summary
generator 가 아닌 함수 본문에서 `yield` 사용 시 ZTS 가 의미 없는 `× ;` 메시지 + 잘못된 위치 (yield 다음 토큰) 를 출력해 사용자가 원인 파악 어려웠음.

## Before / After
**Before**
```
  × ;
  ╭─[notGen.ts:1:27]
1 │ function notGen() { yield 1; }
  ·                           ^      ← '1' 다음 (잘못된 위치)
  ╰────
```

**After**
```
  × 'yield' is not allowed outside generator function [ZTS0917]
  ╭─[notGen.ts:1:21]
1 │ function notGen() { yield 1; }
  ·                     ^^^^^      ← yield 키워드 정확히
  ╰────
```

## Root cause
parser 의 UnaryExpression 진입점 (`expression.zig::parseUnary`) 의 `kw_yield` arm 이 `parsePostfixExpression` 으로 *fallthrough 만* 하고 generator context 검사 + 진단 emit 이 없었음. 같은 위치의 `kw_await` arm 은 이미 `'await' is not allowed in non-async function in module code [ZTS0903]` 같은 명확한 진단 패턴을 가지고 있어 그대로 yield 에 적용.

## 변경
1. `error_codes.zig`: `yield_outside_generator = 917` + 메시지 정의.
2. `expression.zig::parseUnary` 의 `kw_yield` arm 에 await 동일 패턴 추가:
   ```zig
   if (self.is_module and !self.in_namespace and self.ctx.in_function and !self.ctx.in_generator) {
       try self.addErrorCode(self.currentSpan(), "...", .yield_outside_generator);
   }
   return parsePostfixExpression(self);
   ```
3. `parser_test.zig`: 회귀 가드 — 진단 emit + 위치 검증.

## swc 비교
swc 도 명확한 진단 (`Expression expected` + yield 정확히 가리킴). ZTS 도 같은 UX.

## Test plan
- [x] `zig build` 통과
- [x] `zig build test` 유닛 테스트 통과
- [x] 신규 yield 진단 테스트 pass
- [x] 기존 generator 정상 동작 유지 (`function* gen() { yield 1; yield 2; }` → `1 2`)
- [x] 전체 통합 테스트 회귀 0 (3466 pass)
- [x] minimal repro: 명확한 메시지 + yield 키워드 위치

## Notes
fallthrough 후 cascade `× ;` 진단은 여전히 emit 됨 (parser 가 yield 를 식별자로 처리하면서 후속 expression slot 에서 fail). 그러나 *주 진단* 이 정확하므로 사용자 입장에선 원인 파악 가능. cascade 제거는 별도 follow-up 가능.

Closes #2210

🤖 Generated with [Claude Code](https://claude.com/claude-code)