### PR TITLE
docs(app): dev CSS HMR 문서 갱신

### DIFF
--- a/documents/src/components/diagrams.ts
+++ b/documents/src/components/diagrams.ts
@@ -4,22 +4,22 @@
  */
 
 export const NAPI_ARCHITECTURE_CHART = `flowchart TD
-    UC[User Code<br/>Node / Bun / Vite]
-    JS[<b>@zts/core JS layer</b><br/>transpile · build · watch<br/>defineConfig · vitePlugin]
-    PD[Plugin Dispatcher<br/>onResolve · onLoad<br/>onTransform · lifecycle]
-    NAPI[zts.node<br/>NAPI v8 addon]
+    UC["User Code<br/>Node / Bun / Vite"]
+    JS["<b>@zts/core JS layer</b><br/>transpile · build · watch<br/>defineConfig · vitePlugin"]
+    PD["Plugin Dispatcher<br/>onResolve · onLoad<br/>onTransform · lifecycle"]
+    NAPI["zts.node<br/>NAPI v8 addon"]
 
     subgraph Native["Zig Native Engine"]
         direction TB
-        Lex[Lexer / Scanner]
-        Parse[Parser<br/>TS · JSX · Flow · Decorators]
-        Sem[Semantic Analyzer<br/>scope · symbol · references]
-        Trans[Transformer<br/>type strip · JSX · downlevel]
-        CG[Codegen]
-        Bundle[Bundler<br/>resolver · graph]
-        Link[Linker<br/>scope hoisting · imports]
-        Shake[Tree Shaker<br/>statement · symbol · purity]
-        Emit[Emitter<br/>chunk · sourcemap · assets]
+        Lex["Lexer / Scanner"]
+        Parse["Parser<br/>TS · JSX · Flow · Decorators"]
+        Sem["Semantic Analyzer<br/>scope · symbol · references"]
+        Trans["Transformer<br/>type strip · JSX · downlevel"]
+        CG["Codegen"]
+        Bundle["Bundler<br/>resolver · graph"]
+        Link["Linker<br/>scope hoisting · imports"]
+        Shake["Tree Shaker<br/>statement · symbol · purity"]
+        Emit["Emitter<br/>chunk · sourcemap · assets"]
 
         Lex --> Parse --> Sem --> Trans --> CG
         Parse -.-> Bundle
@@ -30,5 +30,5 @@ export const NAPI_ARCHITECTURE_CHART = `flowchart TD
     JS <--> PD
     JS --> NAPI
     NAPI <--> Native
-    PD <-.threadsafe callback.-> NAPI
+    PD -. "threadsafe callback" .-> NAPI
 `;

--- a/documents/src/content/docs/en/guides/migration.md
+++ b/documents/src/content/docs/en/guides/migration.md
@@ -231,12 +231,12 @@ To write native-style plugins, use `setup(build) { build.onLoad(...) }`.
 
 | Vite feature | ZTS equivalent |
 |----------|---------|
-| `vite` (dev server) | `zts --serve --bundle <entry>` (HMR supported) |
-| `vite build` | `zts --bundle <entry> --outdir dist --splitting --minify --sourcemap` |
-| `vite preview` | Not supported. Use `zts --serve dist` for static serving |
-| `import.meta.env.MODE` | `--define:import.meta.env.MODE=\"production\"` |
-| `import.meta.env.DEV` | `--define:import.meta.env.DEV=true` (manual) |
-| `.env` / `.env.production` auto-load | Not supported. Use `dotenv` + `--define` to inject manually |
+| `vite` (dev server) | `zts dev` (HTML/env/public prepare + CSS-only HMR) |
+| `vite build` | `zts build`, or `zts --bundle <entry> --outdir dist --splitting --minify --sourcemap` for library builds |
+| `vite preview` | `zts preview dist` |
+| `import.meta.env.MODE` | App mode auto-loads `.env*`; CLI bundles can use `--define:import.meta.env.MODE=\"production\"` |
+| `import.meta.env.DEV` | App mode injects dev/build mode automatically; CLI bundles can use `--define:import.meta.env.DEV=true` |
+| `.env` / `.env.production` auto-load | Supported in app mode (`--env-dir`, `--env-prefix`) |
 | `import.meta.glob` | Not supported (planned) |
 | `import.meta.hot` | Supported (`--serve --bundle`) |
 | `import.meta.url` | Supported (ESM standard) |
@@ -246,10 +246,10 @@ To write native-style plugins, use `setup(build) { build.onLoad(...) }`.
 | `@vitejs/plugin-legacy` | Partial via `--target=es5` etc. |
 | CSS Modules (`.module.css`) | Built-in Lightning CSS post-processing (auto-detected) |
 | CSS `@import` | Built-in Lightning CSS or `--loader:.css=text` |
-| PostCSS (`postcss.config.js`) | Not supported. Replaced by Lightning CSS post-processing |
+| PostCSS (`postcss.config.js`) | Supported in app mode. `zts dev` watches PostCSS dependencies and sends CSS-only HMR |
 | Sass/Less/Stylus | Not supported. Pre-compile before build |
-| `public/` static directory | Not supported. Copy manually or use `--loader:.svg=file` |
-| HTML entry (`index.html`) | Not supported. Only JS/TS entries |
+| `public/` static directory | Supported in app mode (`--public-dir`) |
+| HTML entry (`index.html`) | Supported in app mode (`--entry-html`) |
 | `resolve.alias` | `--alias:name=target` |
 | `resolve.conditions` | `--conditions=...` |
 | `optimizeDeps` (pre-bundling) | Not needed (handled during bundling) |

--- a/documents/src/content/docs/en/guides/plugin-recipes.md
+++ b/documents/src/content/docs/en/guides/plugin-recipes.md
@@ -104,11 +104,41 @@ el.className = styles.container; // → hashed class name
 
 ## PostCSS + Tailwind CSS
 
-Process Tailwind CSS via PostCSS.
+The `zts dev` / `zts build` app mode reads `postcss.config.*` automatically and
+handles CSS-only HMR in the dev server. Tailwind v4 uses the
+`@tailwindcss/postcss` plugin.
 
 ```bash
 npm install postcss tailwindcss @tailwindcss/postcss
 ```
+
+```typescript
+// postcss.config.mjs
+export default {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+```
+
+```css
+/* src/style.css */
+@import "tailwindcss";
+```
+
+```html
+<!-- index.html -->
+<link rel="stylesheet" href="/src/style.css" />
+<script type="module" src="/src/main.ts"></script>
+```
+
+```bash
+zts dev
+zts build
+```
+
+For library builds that need to inject CSS from a JS plugin, run PostCSS from a
+`load` hook:
 
 ```typescript
 // zts.config.ts

--- a/documents/src/content/docs/en/guides/quick-start.md
+++ b/documents/src/content/docs/en/guides/quick-start.md
@@ -59,3 +59,24 @@ zts --serve
 # Bundle + HMR
 zts --serve --bundle src/index.ts
 ```
+
+## App Builder
+
+For Vite-style `index.html` apps, use `zts dev` / `zts build`.
+
+```html
+<!-- index.html -->
+<link rel="stylesheet" href="/src/style.css" />
+<script type="module" src="/src/main.ts"></script>
+```
+
+```bash
+# HTML/env/public prepare + bundle + CSS HMR
+zts dev
+
+# write dist/
+zts build
+```
+
+If the app root contains `postcss.config.*`, ZTS applies it to CSS in both dev
+and build. Tailwind v4 uses `@tailwindcss/postcss`.

--- a/documents/src/content/docs/en/reference/cli.md
+++ b/documents/src/content/docs/en/reference/cli.md
@@ -32,7 +32,8 @@ zts preview [outdir]       # serve built files only
 
 The default app layout is `index.html`, `public/`, `src/main.ts(x)`, and `.env*`.
 `zts build` uses `<script type="module" src>` as bundle entries and rewrites CSS
-`url()`, HTML asset URLs, and `%ENV%` tokens.
+`url()`, HTML asset URLs, and `%ENV%` tokens. `zts dev` uses the same HTML/env/public
+prepare step and updates stylesheets for CSS edits without a full page reload.
 
 | Option | Description |
 |--------|-------------|
@@ -44,8 +45,9 @@ The default app layout is `index.html`, `public/`, `src/main.ts(x)`, and `.env*`
 | `--env-dir <dir>` | directory for `.env*` files |
 
 If the app root contains `postcss.config.{js,mjs,cjs,json}` or `.postcssrc*`,
-ZTS automatically applies it to imported CSS. Tailwind v4 works via
-`@tailwindcss/postcss`.
+ZTS automatically applies it to CSS. In `zts dev`, original CSS files and PostCSS
+`dependency` / `dir-dependency` messages are watched and CSS-only edits are sent
+as stylesheet HMR updates. Tailwind v4 works via `@tailwindcss/postcss`.
 
 ## I/O
 

--- a/documents/src/content/docs/guides/migration.md
+++ b/documents/src/content/docs/guides/migration.md
@@ -231,12 +231,12 @@ export default defineConfig({
 
 | Vite 기능 | ZTS 대응 |
 |----------|---------|
-| `vite` (dev server) | `zts --serve --bundle <entry>` (HMR 지원) |
-| `vite build` | `zts --bundle <entry> --outdir dist --splitting --minify --sourcemap` |
-| `vite preview` | 미지원. `zts --serve dist` 로 정적 서빙 |
-| `import.meta.env.MODE` | `--define:import.meta.env.MODE=\"production\"` |
-| `import.meta.env.DEV` | `--define:import.meta.env.DEV=true` (수동) |
-| `.env` / `.env.production` 자동 로드 | 미지원. `dotenv` + `--define`으로 수동 주입 |
+| `vite` (dev server) | `zts dev` (HTML/env/public prepare + CSS-only HMR) |
+| `vite build` | `zts build` 또는 library build는 `zts --bundle <entry> --outdir dist --splitting --minify --sourcemap` |
+| `vite preview` | `zts preview dist` |
+| `import.meta.env.MODE` | 앱 모드는 `.env*` 자동 로드, CLI 번들은 `--define:import.meta.env.MODE=\"production\"` |
+| `import.meta.env.DEV` | 앱 모드는 dev/build mode로 자동 주입, CLI 번들은 `--define:import.meta.env.DEV=true` |
+| `.env` / `.env.production` 자동 로드 | 앱 모드에서 지원 (`--env-dir`, `--env-prefix`) |
 | `import.meta.glob` | 미지원 (구현 예정) |
 | `import.meta.hot` | 지원 (`--serve --bundle`) |
 | `import.meta.url` | 지원 (ESM 표준) |
@@ -246,10 +246,10 @@ export default defineConfig({
 | `@vitejs/plugin-legacy` | `--target=es5` 등으로 일부 대응 |
 | CSS Modules (`.module.css`) | Lightning CSS 내장 후처리 (자동 감지) |
 | CSS `@import` | Lightning CSS 내장 후처리 또는 `--loader:.css=text` |
-| PostCSS (`postcss.config.js`) | 미지원. Lightning CSS 후처리로 대체 |
+| PostCSS (`postcss.config.js`) | 앱 모드에서 지원. `zts dev`는 PostCSS dependency watch와 CSS-only HMR 지원 |
 | Sass/Less/Stylus | 미지원. 빌드 전 사전 컴파일 필요 |
-| `public/` 정적 디렉토리 | 미지원. 직접 복사 또는 `--loader:.svg=file` 등 |
-| HTML 엔트리 (`index.html`) | 미지원. JS/TS 엔트리만 |
+| `public/` 정적 디렉토리 | 앱 모드에서 지원 (`--public-dir`) |
+| HTML 엔트리 (`index.html`) | 앱 모드에서 지원 (`--entry-html`) |
 | `resolve.alias` | `--alias:name=target` |
 | `resolve.conditions` | `--conditions=...` |
 | `optimizeDeps` (pre-bundling) | 불필요 (번들 시 직접 처리) |

--- a/documents/src/content/docs/guides/plugin-recipes.md
+++ b/documents/src/content/docs/guides/plugin-recipes.md
@@ -104,11 +104,41 @@ el.className = styles.container; // → 해싱된 클래스명
 
 ## PostCSS + Tailwind CSS
 
-PostCSS로 Tailwind CSS를 처리합니다.
+`zts dev` / `zts build` 앱 모드는 `postcss.config.*`를 자동으로 읽고 dev 서버에서
+CSS-only HMR까지 처리합니다. Tailwind v4는 `@tailwindcss/postcss` 플러그인을
+사용합니다.
 
 ```bash
 npm install postcss tailwindcss @tailwindcss/postcss
 ```
+
+```typescript
+// postcss.config.mjs
+export default {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+```
+
+```css
+/* src/style.css */
+@import "tailwindcss";
+```
+
+```html
+<!-- index.html -->
+<link rel="stylesheet" href="/src/style.css" />
+<script type="module" src="/src/main.ts"></script>
+```
+
+```bash
+zts dev
+zts build
+```
+
+CSS를 JS 플러그인에서 직접 주입해야 하는 라이브러리 빌드는 다음처럼 `load` 훅에서
+PostCSS를 실행할 수 있습니다.
 
 ```typescript
 // zts.config.ts

--- a/documents/src/content/docs/guides/quick-start.md
+++ b/documents/src/content/docs/guides/quick-start.md
@@ -59,3 +59,24 @@ zts --serve
 # 번들 + HMR
 zts --serve --bundle src/index.ts
 ```
+
+## 앱 빌더
+
+Vite 스타일의 `index.html` 앱은 `zts dev` / `zts build`를 사용합니다.
+
+```html
+<!-- index.html -->
+<link rel="stylesheet" href="/src/style.css" />
+<script type="module" src="/src/main.ts"></script>
+```
+
+```bash
+# HTML/env/public prepare + bundle + CSS HMR
+zts dev
+
+# dist/에 빌드 산출물 쓰기
+zts build
+```
+
+앱 root에 `postcss.config.*`가 있으면 dev와 build 모두 CSS에 적용됩니다.
+Tailwind v4는 `@tailwindcss/postcss`로 설정합니다.

--- a/documents/src/content/docs/reference/cli.md
+++ b/documents/src/content/docs/reference/cli.md
@@ -32,7 +32,8 @@ zts preview [outdir]       # 빌드 산출물 정적 서빙
 
 기본 구조는 `index.html`, `public/`, `src/main.ts(x)`, `.env*`입니다.
 `zts build`는 `<script type="module" src>`를 번들 엔트리로 사용하고, CSS `url()`,
-HTML asset URL, `%ENV%` 토큰을 rewrite합니다.
+HTML asset URL, `%ENV%` 토큰을 rewrite합니다. `zts dev`는 같은 HTML/env/public
+prepare 단계를 사용하고 CSS 변경은 페이지 전체 reload 없이 stylesheet만 갱신합니다.
 
 | 옵션 | 설명 |
 |------|------|
@@ -43,8 +44,10 @@ HTML asset URL, `%ENV%` 토큰을 rewrite합니다.
 | `--env-prefix <list>` | 노출할 env prefix CSV (기본: `VITE_,ZTS_`) |
 | `--env-dir <dir>` | `.env*` 파일 탐색 디렉토리 |
 
-앱 root에 `postcss.config.{js,mjs,cjs,json}` 또는 `.postcssrc*`가 있으면 imported CSS에
-자동 적용됩니다. Tailwind v4는 `@tailwindcss/postcss` 설정을 지원합니다.
+앱 root에 `postcss.config.{js,mjs,cjs,json}` 또는 `.postcssrc*`가 있으면 CSS에 자동
+적용됩니다. `zts dev`는 원본 CSS와 PostCSS `dependency` / `dir-dependency` 메시지를
+watch하고 CSS-only 변경은 stylesheet HMR로 보냅니다. Tailwind v4는
+`@tailwindcss/postcss` 설정을 지원합니다.
 
 ## 입출력
 


### PR DESCRIPTION
## 요약
- App Builder 문서에 `zts dev`의 PostCSS/Tailwind dev transform, dependency watch, CSS-only HMR 동작을 반영했습니다.
- Vite migration 표와 quick start, plugin recipe의 app-mode PostCSS/Tailwind 안내를 갱신했습니다.
- Mermaid v11에서 NAPI 다이어그램이 parse error를 내지 않도록 노드 라벨과 edge label 문법을 고쳤습니다.

## 검증
- `git diff --check`
- `cd documents && bun run build`
- Playwright로 `/zts/reference/napi/` 접속 후 `.mermaid-diagram svg` 렌더 확인
- push 전 hook: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check` 통과

## 참고
- `oxlint`는 기존 unused import 경고 4개를 출력했지만 에러는 없었습니다.