### PR TITLE
fix(bundler): dynamic target 의 외부 sibling fallback 잔여 케이스 제거 (#2211 follow-up)

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -2438,12 +2438,19 @@ pub const ModuleGraph = struct {
         // Pass 4: inlineDynamicImports — dynamic-import target 만 __esm 래핑.
         // 일반 모듈은 scope-hoisting 그대로, dynamic target 만 lazy factory 로
         // 묶어서 emitter 가 `import("./x")` 호출을 init/exports 호출로 재작성.
+        //
+        // exports_kind 검사: `.commonjs` 는 Pass 1 의 require 처리에서 이미 wrap_kind
+        // =.cjs 로 set 됐어야 (require 안 받은 CJS 도 exports_kind 만 있고 .none 인
+        // wrap_kind 면 여기서 wrap 안전). `.none` (script / side-effect only) 도
+        // ESM lazy wrap 으로 승격해야 호출이 init() 으로 재작성됨 — 그렇지 않으면
+        // codegen 의 `.none` arm fallback 으로 외부 sibling 파일 의존 (#2211 후속).
         if (self.inline_dynamic_imports) {
             var it = self.modules.iterator(0);
             while (it.next()) |m| {
                 if (m.dynamic_importers.items.len == 0) continue;
                 if (m.wrap_kind != .none) continue;
-                if (!m.exports_kind.isEsm()) continue;
+                if (m.exports_kind == .commonjs) continue; // Pass 1 책임
+                if (m.exports_kind == .none) m.exports_kind = .esm;
                 m.wrap_kind = .esm;
             }
         }

--- a/tests/integration/tests/bundle-dynamic-import.test.ts
+++ b/tests/integration/tests/bundle-dynamic-import.test.ts
@@ -167,6 +167,74 @@ describe("#2209: dynamic import default lazy-wrap", () => {
     expect(result.runOutput).toBe(["helper evaluated", "a evaluated", "entry: A:H-VAL"].join("\n"));
   });
 
+  // side-effect-only dynamic target. exports 없는 모듈은 exports_kind=.none 이라
+  // Pass 4 의 `isEsm()` 체크에 걸려 wrap_kind 가 promote 안 됐었음 → rewriter 의
+  // `.none` arm fallback → 외부 sibling 파일 의존. fix: `.commonjs` 만 skip 하고
+  // `.none` 도 ESM 으로 승격.
+  test("side-effect-only dynamic target 도 lazy wrap (외부 sibling fallback 제거)", async () => {
+    const result = await bundleAndRun(
+      {
+        "sfx.ts": `
+          console.log("side-effect");
+          (globalThis as any).SFX_LOADED = true;
+        `,
+        "index.ts": `
+          async function run() { await import("./sfx.ts"); return (globalThis as any).SFX_LOADED; }
+          run().then(v => console.log("entry:", v));
+        `,
+      },
+      "index.ts",
+      ["--platform=node"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    // side-effect 가 *한 번만* 출력 — 이전엔 두 번 (eager + sibling fallback).
+    expect(result.runOutput).toBe(["side-effect", "entry: true"].join("\n"));
+  });
+
+  // CJS dynamic target — Pass 1 의 require 처리에서 wrap_kind=.cjs 로 set 되고
+  // rewriter 의 `.cjs` arm 이 `Promise.resolve().then(()=>require_x())` 변환.
+  test("CJS dynamic target: require_X() 호출로 변환", async () => {
+    const result = await bundleAndRun(
+      {
+        "dep.cjs": `
+          module.exports = { value: "from-cjs" };
+          console.log("cjs evaluated");
+        `,
+        "index.ts": `
+          async function run() { return (await import("./dep.cjs")).value; }
+          run().then(v => console.log("entry:", v));
+        `,
+      },
+      "index.ts",
+      ["--platform=node"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe(["cjs evaluated", "entry: from-cjs"].join("\n"));
+  });
+
+  // JSON dynamic target — module_type=.json 도 정상 lazy wrap (default export 로 접근).
+  test("JSON dynamic target: default export 접근", async () => {
+    const result = await bundleAndRun(
+      {
+        "data.json": `{ "value": "json-loaded" }`,
+        "index.ts": `
+          async function run() { return (await import("./data.json")).default.value; }
+          run().then(v => console.log("entry:", v));
+        `,
+      },
+      "index.ts",
+      ["--platform=node"],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe("entry: json-loaded");
+  });
+
   // 3-way static cycle 이 dynamic target 안에서 형성된 케이스. dfs 가 dependencies +
   // dynamic_imports 둘 다 따라가야 cycle 의 모든 멤버 (a, b, c) 에 marking + var 강등.
   test("3-way static cycle + dynamic importer (#2211 확장)", async () => {


### PR DESCRIPTION
## Summary
PR #2215 (`#2211` fix) 가 *대부분* dynamic import 케이스를 self-contained 로 처리했지만, **side-effect-only 모듈** (`exports` 없는 script 모듈) 이 dynamic target 일 때 잔여 fallback 케이스 발견. 이번 PR 로 *잔여 fallback 모두 제거*.

## Before / After
**Before** — `await import("./sfx.ts")` (exports 없는 모듈):
```
side-effect      ← bundle 안 region eager evaluation
side-effect      ← 외부 sibling 파일 다시 로딩 (rewriter 의 `.none` fallback)
entry: true
```

**After**:
```
side-effect      ← lazy factory 안에서 1회만
entry: true
```

## Root cause
`graph.zig::promoteExportsKinds` Pass 4 가 `!exports_kind.isEsm()` 으로 ESM 만 promote → side-effect 모듈 (exports_kind=.none) skip → wrap_kind=.none → `chunks.zig::rewriteDynamicImportsSingleFile` 의 `.none` arm 으로 빠짐 → 호출 변환 안 됨.

## 수정
Pass 4 의 분기 명확화:
```zig
// Before
if (!m.exports_kind.isEsm()) continue;

// After
if (m.exports_kind == .commonjs) continue;       // Pass 1 책임
if (m.exports_kind == .none) m.exports_kind = .esm;  // .none 도 .esm 으로 승격
m.wrap_kind = .esm;
```

side-effect 모듈도 `__esm` lazy factory 안에서 *호출 시점에 1회 평가*. 의미 보존 (eager 평가가 lazy 평가로 변환).

## Fallback 잔여 분석
이번 fix 후 `.none` arm 도달 케이스:
- `rec.resolved == .none` (external 모듈, 예: `await import("npm-pkg")`) → **정당한 path** (외부 resolver 가 처리)
- `target.wrap_kind == .none` after Pass 4 → OOM / semantic 실패 같은 비정상 경로 → silent fallback 안전

즉 *의도적인* fallback 만 남음.

## 테스트
3개 회귀 가드 추가 (총 10개):
- side-effect-only dynamic target (`console.log` 한 번만)
- CJS dynamic target (`require_X()` 변환)
- JSON dynamic target (default export)

## Test plan
- [x] `zig build` Debug + ReleaseFast 통과
- [x] `zig build test` 유닛 테스트 통과
- [x] `bundle-dynamic-import.test.ts` 10 pass
- [x] 전체 통합 테스트 3472 pass / 0 fail
- [x] minimal repro (side-effect dynamic) → bundle self-contained

Closes #2211

🤖 Generated with [Claude Code](https://claude.com/claude-code)