### PR TITLE
fix(sourcemap): footer 부착 + map.file 필드 spec 부합 (#2217)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@emotion/css": "^11.13.5",
         "@emotion/react": "^11.14.0",
         "@tailwindcss/postcss": "^4.2.2",
+        "hermes-engine-cli": "^0.12.0",
         "lodash-es": "^4.17.21",
         "mobx": "^6.13.0",
         "oxfmt": "^0.41.0",
@@ -2001,6 +2002,8 @@
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
     "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
+
+    "hermes-engine-cli": ["hermes-engine-cli@0.12.0", "", {}, "sha512-72a5yvwSC2qWtxJ80nlcoCCfNTkpYI8VVAfOro4FL9O105NM8Vpigz/A5Nq1rECKdP7M1N81HHiYL6jU5N1gYw=="],
 
     "hoist-non-react-statics": ["hoist-non-react-statics@3.3.2", "", { "dependencies": { "react-is": "^16.7.0" } }, "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw=="],
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@emotion/css": "^11.13.5",
     "@emotion/react": "^11.14.0",
     "@tailwindcss/postcss": "^4.2.2",
+    "hermes-engine-cli": "^0.12.0",
     "lodash-es": "^4.17.21",
     "mobx": "^6.13.0",
     "oxfmt": "^0.41.0",

--- a/src/main.zig
+++ b/src/main.zig
@@ -1334,7 +1334,15 @@ fn transpileFile(
     // 핵심 트랜스파일 — transpile.zig에 위임 (에러 시 코드 프레임 출력 콜백).
     // 파이프라인 단계별 타이밍은 `--profile` 플래그가 활성화됐을 때 `profile` 모듈이
     // hot-path timer 로 수집한다 (PR 3 이후 hot-path 에 삽입).
-    var result = transpile_mod.transpileWithCallback(allocator, source, file_path, options.core, &printErrors) catch |err| {
+    //
+    // sourcemap output filename: `--sourcemap` + `-o out.js` 인 single-file CLI 에서
+    // map.file 필드 + sourceMappingURL footer 가 정확한 output 파일명을 가리키도록
+    // basename 만 전달 (#2217). stdout 출력 모드는 빈 문자열 → footer 안 부착.
+    var core_opts = options.core;
+    if (core_opts.sourcemap and output_path != null) {
+        core_opts.sourcemap_output_filename = std.fs.path.basename(output_path.?);
+    }
+    var result = transpile_mod.transpileWithCallback(allocator, source, file_path, core_opts, &printErrors) catch |err| {
         // 콜백에서 이미 상세 에러를 출력했으므로, 파싱/시맨틱 에러는 추가 메시지 불필요
         switch (err) {
             error.ParseError, error.SemanticError => {},

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -80,6 +80,11 @@ pub const TranspileOptions = struct {
     sourcemap: bool = false,
     /// Sentry Debug ID (--sourcemap-debug-ids). 소스맵 + JS에 동일 UUID를 삽입.
     sourcemap_debug_ids: bool = false,
+    /// `--sourcemap` 시 sourceMappingURL footer + map.file 필드에 사용할 출력 파일명
+    /// (basename only, 확장자 포함 e.g. "out.js"). null/empty 면 footer 안 부착하고
+    /// map.file 은 source path 로 fallback (NAPI/library mode 처럼 *어디로 쓰일지
+    /// 모르는* 케이스 — 호출자가 후처리). #2217.
+    sourcemap_output_filename: []const u8 = "",
     source_root: []const u8 = "",
     sources_content: bool = true,
     platform: @import("codegen/codegen.zig").Platform = .browser,
@@ -558,24 +563,44 @@ pub fn transpileWithCallback(
         break :blk &debug_id_buf;
     } else null;
 
-    // 9. 소스맵 생성
+    // 9. 소스맵 생성. map.file 필드는 출력 파일명을 가리켜야 함 (Source Map Rev3
+    // spec — source path 가 아닌 *생성된* 파일). caller 가 sourcemap_output_filename
+    // 을 알려주면 그 값을, 아니면 빈 문자열 (spec 상 optional 필드 — invalid 한
+    // source path 보다 안전. CLI 는 main.zig 에서 자동 set, library/NAPI 호출자는
+    // 직접 전달 권장). #2217.
+    const map_file_name: []const u8 = options.sourcemap_output_filename;
     var sourcemap_json: ?[]const u8 = null;
     if (options.sourcemap) {
         if (cg.sm_builder) |*sm| {
             sm.debug_id = debug_id;
-            if (sm.generateJSON(file_path) catch null) |sm_json| {
+            if (sm.generateJSON(map_file_name) catch null) |sm_json| {
                 sourcemap_json = allocator.dupe(u8, sm_json) catch null;
             }
         }
     }
 
-    // 10. debugId 주석을 출력 코드 끝에 추가
-    const final_output = if (debug_id) |did| blk: {
+    // 10. footer 부착: sourceMappingURL (#2217) + debugId.
+    // sourcemap_output_filename 이 있으면 `//# sourceMappingURL=<file>.map` 도 emit.
+    // debugId 와 함께 부착하면 Sentry/DevTools 가 둘 다 인식.
+    const need_sm_footer = options.sourcemap and
+        sourcemap_json != null and
+        options.sourcemap_output_filename.len > 0;
+    const final_output = if (debug_id != null or need_sm_footer) blk: {
         var buf: std.ArrayList(u8) = .empty;
         buf.appendSlice(arena_alloc, output) catch break :blk output;
-        buf.appendSlice(arena_alloc, "//# debugId=") catch break :blk output;
-        buf.appendSlice(arena_alloc, did) catch break :blk output;
-        buf.append(arena_alloc, '\n') catch break :blk output;
+        if (output.len > 0 and output[output.len - 1] != '\n') {
+            buf.append(arena_alloc, '\n') catch break :blk output;
+        }
+        if (need_sm_footer) {
+            buf.appendSlice(arena_alloc, "//# sourceMappingURL=") catch break :blk output;
+            buf.appendSlice(arena_alloc, options.sourcemap_output_filename) catch break :blk output;
+            buf.appendSlice(arena_alloc, ".map\n") catch break :blk output;
+        }
+        if (debug_id) |did| {
+            buf.appendSlice(arena_alloc, "//# debugId=") catch break :blk output;
+            buf.appendSlice(arena_alloc, did) catch break :blk output;
+            buf.append(arena_alloc, '\n') catch break :blk output;
+        }
         break :blk buf.items;
     } else output;
 

--- a/tests/integration/tests/hermes-runtime.test.ts
+++ b/tests/integration/tests/hermes-runtime.test.ts
@@ -17,15 +17,21 @@ const EXAMPLE_APP = resolve(import.meta.dir, "fixtures/rn-example-app");
 
 // Hermes 런타임 바이너리 경로 탐색
 function findHermes(): string | null {
-  // 1. hermes-engine-cli (npm global)
+  const hermesDir = process.platform === "linux" ? "linux64-bin" : "osx-bin";
+  // 1. workspace node_modules (devDependencies 로 추가됨 — `bun install` 만으로
+  //    로컬 검증 가능). #2218 fix: 이전엔 npm global 만 봐서 `npm install -g`
+  //    안 한 로컬 환경에선 silent skip.
+  const wsRoot = resolve(import.meta.dir, "../../..");
+  const local = resolve(wsRoot, "node_modules/hermes-engine-cli", hermesDir, "hermes");
+  if (existsSync(local)) return local;
+  // 2. npm global (CI 의 `npm install -g hermes-engine-cli` path)
   const globalNpm = Bun.spawnSync(["npm", "root", "-g"]);
   if (globalNpm.exitCode === 0) {
     const dir = globalNpm.stdout.toString().trim();
-    const hermesDir = process.platform === "linux" ? "linux64-bin" : "osx-bin";
     const p = resolve(dir, `hermes-engine-cli/${hermesDir}/hermes`);
     if (existsSync(p)) return p;
   }
-  // 2. PATH
+  // 3. PATH
   const which = Bun.spawnSync(["which", "hermes"]);
   if (which.exitCode === 0) return which.stdout.toString().trim();
   return null;

--- a/tests/integration/tests/sourcemap-footer.test.ts
+++ b/tests/integration/tests/sourcemap-footer.test.ts
@@ -1,0 +1,89 @@
+/// #2217 회귀 가드:
+/// `zts file.ts -o out.js --sourcemap` 시 출력 파일에 `//# sourceMappingURL=` footer
+/// 부착 + map.file 필드가 *생성된 파일* (not 원본) 가리킴.
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { writeFileSync, readFileSync, mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runZts } from "./helpers";
+
+describe("#2217: sourcemap footer + map.file 필드", () => {
+  let cleanup: (() => void) | undefined;
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
+  function setupFixture(source: string, ext: "ts" | "tsx" = "ts") {
+    const dir = mkdtempSync(join(tmpdir(), "zts-sm-footer-"));
+    const inFile = join(dir, `input.${ext}`);
+    const outFile = join(dir, "out.js");
+    writeFileSync(inFile, source);
+    cleanup = () => rmSync(dir, { recursive: true, force: true });
+    return { dir, inFile, outFile };
+  }
+
+  test("footer 부착: //# sourceMappingURL=<basename>.map", async () => {
+    const { inFile, outFile } = setupFixture("export const x = 1;\n");
+    const r = await runZts([inFile, "-o", outFile, "--sourcemap"]);
+    expect(r.exitCode).toBe(0);
+
+    const code = readFileSync(outFile, "utf-8");
+    expect(code).toContain("//# sourceMappingURL=out.js.map");
+    expect(existsSync(outFile + ".map")).toBe(true);
+  });
+
+  test("map.file 필드는 출력 파일 basename (원본 아님)", async () => {
+    const { inFile, outFile } = setupFixture("export const x = 1;\n");
+    const r = await runZts([inFile, "-o", outFile, "--sourcemap"]);
+    expect(r.exitCode).toBe(0);
+
+    const map = JSON.parse(readFileSync(outFile + ".map", "utf-8"));
+    expect(map.file).toBe("out.js");
+    // sources 는 input 파일을 가리킴
+    expect(map.sources?.[0]).toMatch(/input\.ts$/);
+  });
+
+  test("Node --enable-source-maps 가 stack trace 를 원본 .ts 위치로 매핑", async () => {
+    const { inFile, outFile } = setupFixture(
+      [
+        "function level3() { throw new Error('boom'); }",
+        "function level2() { level3(); }",
+        "function level1() { level2(); }",
+        "try { level1(); } catch (e) { console.log(e.stack); }",
+      ].join("\n"),
+    );
+    const r = await runZts([inFile, "-o", outFile, "--sourcemap"]);
+    expect(r.exitCode).toBe(0);
+
+    const node = spawnSync("node", ["--enable-source-maps", outFile], {
+      encoding: "utf-8",
+      timeout: 10000,
+    });
+    expect(node.status).toBe(0);
+    // stack trace 의 첫 라인이 *원본 input.ts* 를 가리켜야 (out.js 가 아님).
+    expect(node.stdout).toContain("input.ts");
+    expect(node.stdout).not.toMatch(/at level3 .*out\.js/);
+  });
+
+  test("--sourcemap 없으면 footer 안 부착", async () => {
+    const { inFile, outFile } = setupFixture("export const x = 1;\n");
+    const r = await runZts([inFile, "-o", outFile]);
+    expect(r.exitCode).toBe(0);
+
+    const code = readFileSync(outFile, "utf-8");
+    expect(code).not.toContain("sourceMappingURL");
+    expect(existsSync(outFile + ".map")).toBe(false);
+  });
+
+  test("stdout 출력 모드는 footer 안 부착 (output filename 모름)", async () => {
+    const { inFile } = setupFixture("export const x = 1;\n");
+    const r = await runZts([inFile, "--sourcemap"]);
+    expect(r.exitCode).toBe(0);
+    // stdout 으로 코드만 출력. footer 안 부착 (어디로 쓰일지 모름).
+    expect(r.stdout).not.toContain("sourceMappingURL");
+  });
+});


### PR DESCRIPTION
## Summary
`zts file.ts -o out.js --sourcemap` 의 두 가지 정확성 문제 + 환경 일관성:

1. **footer 미부착** — 출력 파일 끝에 `//# sourceMappingURL=out.js.map` 주석 없음 → Node `--enable-source-maps`, DevTools, Sentry 모두 .map 못 찾아 stack trace 가 *생성된 .js* 표시.
2. **`map.file` 가 원본 .ts 가리킴** — Source Map Rev3 spec 위반 (생성 파일이어야).
3. **로컬 환경 의존성 누락** — `hermes-engine-cli` 가 `npm install -g` 로만 안내되어 `bun install` 만 한 로컬 환경에서 hermes 테스트 silent skip.

## Before / After
**Before**
```bash
$ zts input.ts -o out.js --sourcemap
$ tail -1 out.js
}                               # ← footer 없음

$ node --enable-source-maps out.js
Error: boom
    at level3 (out.js:2:8)      # ← 생성된 .js 위치
```

**After**
```bash
$ zts input.ts -o out.js --sourcemap
$ tail -1 out.js
//# sourceMappingURL=out.js.map # ← footer ✓

$ node --enable-source-maps out.js
Error: boom
    at level3 (input.ts:1:27)   # ← 원본 .ts 위치 ✓
```

## 변경
1. **`TranspileOptions.sourcemap_output_filename`** (`[]const u8 = ""`) 신규.
   - 빈 문자열 default — stdout 출력 / NAPI library 모드 (어디로 쓰일지 모름)
   - non-empty — `map.file` 에 사용 + footer 부착
2. **`transpile.zig`** 의 final_output 합성 단계에 footer 부착 분기 추가 (debugId 와 함께 부착 가능).
3. **`main.zig::transpileFile`** 가 `output_path` basename 을 자동으로 set — CLI 사용자는 추가 옵션 없이 `--sourcemap` 만으로 정상 동작.
4. **`map.file` fallback 변경**: 이전엔 source path 로 fallback (spec 위반) → 이제 빈 문자열 (spec optional 필드).
5. **`package.json`** 에 `hermes-engine-cli@^0.12.0` devDependency 추가 + `findHermes()` 가 workspace node_modules 도 검색.

## 비교 (esbuild)
- esbuild `--sourcemap`: footer 자동 부착 ✓
- ZTS (이전): footer 미부착 ❌
- ZTS (이번 fix): esbuild 와 동일하게 footer 부착 ✓

## 테스트
신규 5 케이스 (`sourcemap-footer.test.ts`):
- footer 부착 검증
- `map.file` 이 출력 basename
- node `--enable-source-maps` 의 stack trace 가 원본 .ts 위치로 매핑
- `--sourcemap` 없을 때 footer 미부착 (회귀 가드)
- stdout 모드 footer 미부착 (라이브러리 안전)

## Test plan
- [x] `zig build` Debug + ReleaseFast 통과
- [x] `zig build test` 유닛 테스트 통과
- [x] 신규 5 sourcemap-footer 테스트 pass
- [x] 전체 통합 3477 pass / 0 fail
- [x] minimal repro: stack trace 가 원본 .ts 위치로 매핑

## Notes (memory: feedback_napi_cache_trap)
NAPI / library caller 는 호출 시 `sourcemap_output_filename` 을 직접 전달 권장 — caller 만 *어디로 쓸지* 알기 때문. 빈 문자열로 두면 spec-valid 한 incomplete map 출력.

Closes #2217

🤖 Generated with [Claude Code](https://claude.com/claude-code)