### PR TITLE
fix(sourcemap): import/export specifier identifier 매핑 누락

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -2876,12 +2876,14 @@ pub const Codegen = struct {
             switch (spec_node.tag) {
                 .import_default_specifier => {
                     if (!first) try self.write(",");
+                    try self.addSourceMapping(spec_node.span);
                     try self.writeNodeSpan(spec_node);
                     first = false;
                 },
                 .import_namespace_specifier => {
                     if (!first) try self.write(",");
                     try self.write("* as ");
+                    try self.addSourceMapping(spec_node.span);
                     try self.writeNodeSpan(spec_node);
                     first = false;
                 },
@@ -3053,6 +3055,7 @@ pub const Codegen = struct {
     /// import_default_specifier / import_namespace_specifier의 이름을 renames 적용하여 출력.
     /// 이 노드들은 identifier_reference가 아니라 별도 태그이므로 emitNode에서 renames를 거치지 않음.
     fn emitSpecifierWithRename(self: *Codegen, idx: NodeIndex, spec: Node) !void {
+        try self.addSourceMapping(spec.span);
         if (self.options.linking_metadata) |meta| {
             const ni = @intFromEnum(idx);
             if (ni < meta.symbol_ids.len) {
@@ -3075,7 +3078,9 @@ pub const Codegen = struct {
         const imported = spec_node.data.binary.left;
         const local = spec_node.data.binary.right;
         // imported: 항상 원본 이름 (exports 객체 키 = rename 전 이름)
-        try self.writeSpan(self.ast.getNode(imported).span);
+        const imported_node = self.ast.getNode(imported);
+        try self.addSourceMapping(imported_node.span);
+        try self.writeSpan(imported_node.span);
         // local이 rename 되었거나 원본 imported와 다른 경우 → separator + local 출력
         const needs_rename = blk: {
             if (local.isNone() or @intFromEnum(local) == @intFromEnum(imported)) break :blk false;
@@ -3148,9 +3153,11 @@ pub const Codegen = struct {
         const exported_node = self.ast.getNode(exported_idx);
         const local_text = self.ast.getText(local_node.span);
         const exported_text = self.ast.getText(exported_node.span);
+        try self.addSourceMapping(local_node.span);
         try self.write(local_text);
         if (!std.mem.eql(u8, local_text, exported_text)) {
             try self.write(" as ");
+            try self.addSourceMapping(exported_node.span);
             try self.write(exported_text);
         }
     }

--- a/src/codegen/codegen_test/minify_sourcemap.zig
+++ b/src/codegen/codegen_test/minify_sourcemap.zig
@@ -234,4 +234,25 @@ test "SourceMap: export all as namespace has mapping" {
     try r.expectMappingAt("export", 0, 0);
 }
 
+test "SourceMap: import default specifier identifier mapping" {
+    var r = try e2eSourceMap(std.testing.allocator, "import foo from \"./mod\";");
+    defer r.deinit();
+    // foo 식별자가 col 7 에서 시작하므로 원본 col 7 에 매핑되어야 한다.
+    try r.expectMappingAt("foo", 0, 7);
+}
+
+test "SourceMap: import namespace specifier identifier mapping" {
+    var r = try e2eSourceMap(std.testing.allocator, "import * as ns from \"./mod\";");
+    defer r.deinit();
+    // ns 식별자는 col 12 에서 시작.
+    try r.expectMappingAt("ns", 0, 12);
+}
+
+test "SourceMap: export specifier rename target identifier mapping" {
+    var r = try e2eSourceMap(std.testing.allocator, "const a = 1;\nexport { a as b };");
+    defer r.deinit();
+    // export { a as b } — `b` 는 line 1, col 14 에서 시작.
+    try r.expectMappingAt("b }", 1, 14);
+}
+
 // ================================================================


### PR DESCRIPTION
## Summary
- `import_default_specifier`, `import_namespace_specifier`, `export { x as y }`, named import 등에서 식별자 위치에 sourcemap segment 가 emit 되지 않아 debugger 가 잘못된 위치를 가리키는 문제 수정
- 이 사이트들은 `emitNode` 를 우회하여 inline `writeSpan`/`writeNodeSpan` 호출 → emitNode 의 자동 mapping (line 810) 이 적용 안 됨

## 검출 경위
Round 5 bug-hunting harness (`/tmp/zts-bounty5/`) 의 fixture 10/13/14/17 에서 발견:
- `import * as ns from \"x\"` 의 `ns` (gen col 12) → mapped(0,0) (line 시작으로 fallback)
- `import foo from \"x\"` 의 `foo` (gen col 7) → mapped(0,0) 동일
- `export { a as b }` 의 `b` → a 의 segment 로 fallback (col 12 차이)

## 변경
- ESM `import_default_specifier` / `import_namespace_specifier` 분기에 `addSourceMapping(spec_node.span)` 추가
- `emitExportSpecifier`: local + exported (rename 시) 양쪽 식별자에 추가
- `emitImportSpecifierRename`: imported part 에 추가 (local 은 emitNode 경로라 이미 처리됨)
- `emitSpecifierWithRename` (CJS 경로): 진입 시 추가

## Test plan
- [x] `zig build test` (3477 pass / 0 fail) — 기존 테스트 회귀 없음
- [x] 회귀 테스트 3개 추가 — `import default`, `import namespace`, `export { a as b }` 식별자 매핑 검증
- [x] Round 5 harness 17 fixture 모두 통과 (10/13/14/17 wrong-line 0)