### PR TITLE
fix(sourcemap): enum 멤버 + IIFE trailing 매핑 누락

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -3556,6 +3556,10 @@ pub const Codegen = struct {
             else
                 false;
 
+            // single-line IIFE: 멤버별 anchor 가 없으면 직전 segment 로 fallback 되어
+            // debugger 가 잘못된 line 을 표시.
+            try self.addSourceMapping(member_name.span);
+
             // numeric: Color[Color["Red"]=0]="Red"  → outer wrap 추가
             // string : Color["X"]="x"               → wrap 없음
             if (!is_string_member) {
@@ -3614,6 +3618,8 @@ pub const Codegen = struct {
         }
 
         // return Color;})(Color || {});
+        // IIFE trailing 도 enum 이름 위치로 anchor — 마지막 멤버 segment 로의 fallback 방지.
+        try self.addSourceMapping(name_node.span);
         try self.write("return ");
         try self.write(param_name);
         try self.write(";})(");

--- a/src/codegen/codegen_test/minify_sourcemap.zig
+++ b/src/codegen/codegen_test/minify_sourcemap.zig
@@ -255,4 +255,22 @@ test "SourceMap: export specifier rename target identifier mapping" {
     try r.expectMappingAt("b }", 1, 14);
 }
 
+test "SourceMap: enum members map to their source line" {
+    // multi-line enum 이 single-line IIFE 로 emit 되어도 각 멤버가 자기 source line 으로 매핑되어야 함.
+    const src =
+        \\enum Color {
+        \\  Red = "r",
+        \\  Green = "g",
+        \\}
+    ;
+    var r = try e2eSourceMap(std.testing.allocator, src);
+    defer r.deinit();
+    // 멤버 시작 emit 이 source line 으로 anchor.
+    try r.expectMappingAt("Color[\"Red\"]", 1, 2);
+    try r.expectMappingAt("Color[\"Green\"]", 2, 2);
+    // IIFE trailing (`return X;})...`) 은 enum 이름 위치 (line 0, col 5) 로 anchor —
+    // 마지막 멤버 segment 로의 fallback 방지.
+    try r.expectMappingAt("return Color", 0, 5);
+}
+
 // ================================================================


### PR DESCRIPTION
## Summary
- `emitEnumIIFE` 가 multi-line enum 을 single-line IIFE 로 emit 하면서 각 멤버 식별자에 sourcemap segment 가 emit 되지 않음
- 결과적으로 모든 멤버가 enum 선언 시작 line 으로 매핑되어 debugger 가 잘못된 line 표시
- IIFE trailing `return X;})(X || {});` 영역도 마지막 멤버 segment 로 fallback 되어 의미 없는 위치 표시

## 검출 경위
Round 5 sourcemap mapping harness (`/tmp/zts-bounty5/12-enum.ts`):
- 입력: 4-line enum (`Red`/`Green`/`Blue` 멤버)
- ZTS 출력: 1-line IIFE (`var X = ((X)=>{X[\"Red\"]=...;X[\"Green\"]=...;...})(X||{});`)
- 매핑: 모든 멤버 식별자가 src line 0 (enum 선언) 으로 fallback → `MARKER_RED` (src line 1) 가 line 0 로 표시

esbuild 는 멤버를 별도 line 으로 emit 하여 line-level 매핑이 자연스럽게 정확. ZTS 는 single-line emit 을 유지하되 명시적 segment 를 추가하여 해결.

## 변경
1. 각 멤버 emit 직전 `addSourceMapping(member_name.span)` 추가
   - `X[\"Red\"]=...` 가 Red 정의 line 으로 anchor
2. 멤버 emit 종료 후 (`return X;` 직전) `addSourceMapping(name_node.span)` 추가
   - trailing IIFE 가 enum 이름 위치로 anchor — 마지막 멤버 line 으로의 fallback 제거

## Test plan
- [x] `zig build test` (3477 pass / 0 fail) — 기존 테스트 회귀 없음
- [x] 회귀 테스트 1개 추가 — 멤버 + trailing 모두 source line 검증
- [x] Round 5 harness — `12-enum.ts` 의 멤버 wrong-line 7건 모두 해소