### PR TITLE
test(regression): 라운드 1/2/4 광역 회귀 테스트 영구 보존

### DIFF
--- a/tests/integration/tests/__snapshots__/round1-fuzz.test.ts.snap
+++ b/tests/integration/tests/__snapshots__/round1-fuzz.test.ts.snap
@@ -1,0 +1,112 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`Round 1 fuzz 01-const-enum.ts 1`] = `"1 2 B"`;
+
+exports[`Round 1 fuzz 02-enum-reverse.ts 1`] = `"0 5 6 A B C"`;
+
+exports[`Round 1 fuzz 03-enum-str.ts 1`] = `"x y undefined undefined"`;
+
+exports[`Round 1 fuzz 04-namespace-merge.ts 1`] = `"1 2"`;
+
+exports[`Round 1 fuzz 05-param-props.ts 1`] = `"1/a/true"`;
+
+exports[`Round 1 fuzz 06-private-fields.ts 1`] = `"3 2"`;
+
+exports[`Round 1 fuzz 07-static-block.ts 1`] = `"1 11"`;
+
+exports[`Round 1 fuzz 08-getter-setter.ts 1`] = `"7 set:5,get,set:7,get"`;
+
+exports[`Round 1 fuzz 09-super-arrow.ts 1`] = `"A/B"`;
+
+exports[`Round 1 fuzz 10-logical-assign.ts 1`] = `
+"1 2 undefined
+10"
+`;
+
+exports[`Round 1 fuzz 11-optional-chain.ts 1`] = `
+"42
+undefined
+42
+undefined"
+`;
+
+exports[`Round 1 fuzz 12-tagged-template.ts 1`] = `
+"a
+b|c	d|e##a\\nb|c\\td|e##1,2"
+`;
+
+exports[`Round 1 fuzz 13-regex-named.ts 1`] = `"2026 04 0"`;
+
+exports[`Round 1 fuzz 14-bigint.ts 1`] = `"9007199254740994n 18446744073709551616n 340282366920938463463374607431768211456n bigint"`;
+
+exports[`Round 1 fuzz 15-spread-order.ts 1`] = `
+"{"a":99,"b":2,"c":3} b,a
+1,2,3,4,5"
+`;
+
+exports[`Round 1 fuzz 16-destructure.ts 1`] = `
+"10 5
+99
+{"a":1,"b":2}"
+`;
+
+exports[`Round 1 fuzz 17-for-of-let.ts 1`] = `
+"0,1,2
+a,b,c"
+`;
+
+exports[`Round 1 fuzz 18-generator.ts 1`] = `"1,2,3,4,"`;
+
+exports[`Round 1 fuzz 19-async-iter.ts 1`] = `"6"`;
+
+exports[`Round 1 fuzz 20-precedence.ts 1`] = `
+"512
+-8
+5 5
+stringy
+a12 3a"
+`;
+
+exports[`Round 1 fuzz 21-tdz.ts 1`] = `
+"TDZ: ReferenceError
+1 2 3"
+`;
+
+exports[`Round 1 fuzz 22-class-expr.ts 1`] = `"Bar-static Bar"`;
+
+exports[`Round 1 fuzz 23-computed-key.ts 1`] = `"1 2 0,1,2"`;
+
+exports[`Round 1 fuzz 24-jsx.tsx 1`] = `"{"type":"Fragment","props":{},"children":[{"type":"div","props":{"className":"a","id":"x"},"children":["hello ",3]},{"type":"span","props":{},"children":[]}]}"`;
+
+exports[`Round 1 fuzz 25-string-escape.ts 1`] = `"14 14 "a\\tb\\nc\\\\d\\"eéf😀g" "tpl x \\\\y \\r raw""`;
+
+exports[`Round 1 fuzz 26-numeric.ts 1`] = `
+"0.30000000000000004 1e+21 255 15 5 1000000 0.5 5 150
+9007199254740991 5e-324"
+`;
+
+exports[`Round 1 fuzz 27-asi.ts 1`] = `
+"undefined
+1
+2
+12"
+`;
+
+exports[`Round 1 fuzz 28-try-catch.ts 1`] = `
+"caught-no-binding
+string raw"
+`;
+
+exports[`Round 1 fuzz 29-default-export-fn.ts 1`] = `""`;
+
+exports[`Round 1 fuzz 30-import-meta.ts 1`] = `"object url-string"`;
+
+exports[`Round 1 fuzz 31-labeled.ts 1`] = `"0,1,2,10,20,21"`;
+
+exports[`Round 1 fuzz 32-satisfies.ts 1`] = `"2 TWO"`;
+
+exports[`Round 1 fuzz 33-as-const.ts 1`] = `"1,2,3 x 5"`;
+
+exports[`Round 1 fuzz 34-decorator-legacy.ts 1`] = `"undefined hi"`;
+
+exports[`Round 1 fuzz 35-arrow-vs-paren.ts 1`] = `"6 3 6 z"`;

--- a/tests/integration/tests/__snapshots__/round2-fuzz.test.ts.snap
+++ b/tests/integration/tests/__snapshots__/round2-fuzz.test.ts.snap
@@ -1,0 +1,102 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`Round 2 fuzz 01-namespace-merge.ts 1`] = `"1 2 11 8"`;
+
+exports[`Round 2 fuzz 02-namespace-nested.ts 1`] = `"5 10 105"`;
+
+exports[`Round 2 fuzz 03-abstract-override.ts 1`] = `"common:impl"`;
+
+exports[`Round 2 fuzz 04-using.ts 1`] = `"inside,disposed"`;
+
+exports[`Round 2 fuzz 05-await-using.ts 1`] = `"inside,async-disposed"`;
+
+exports[`Round 2 fuzz 06-iterator-helpers.ts 1`] = `"[ 10, 30, 50 ]"`;
+
+exports[`Round 2 fuzz 07-set-methods.ts 1`] = `
+"3,4
+1,2,3,4,5,6
+1,2"
+`;
+
+exports[`Round 2 fuzz 08-regex-v.ts 1`] = `"true false true"`;
+
+exports[`Round 2 fuzz 09-import-meta-url.ts 1`] = `"string true"`;
+
+exports[`Round 2 fuzz 10-pure-annotation.ts 1`] = `
+"called
+done"
+`;
+
+exports[`Round 2 fuzz 11-precedence-edge.ts 1`] = `
+"0
+512
+-8
+string
+true false
+7 9"
+`;
+
+exports[`Round 2 fuzz 12-assignment-target.ts 1`] = `"2,1,3 {"a":1,"b":10,"d":99}"`;
+
+exports[`Round 2 fuzz 13-private-brand.ts 1`] = `"true false false"`;
+
+exports[`Round 2 fuzz 14-static-block-order.ts 1`] = `"A1,Ax,A2 1"`;
+
+exports[`Round 2 fuzz 15-async-finally.ts 1`] = `"1 2"`;
+
+exports[`Round 2 fuzz 16-gen-return-finally.ts 1`] = `
+"cleanup
+1 99 true"
+`;
+
+exports[`Round 2 fuzz 17-string-codepoint.ts 1`] = `"7 5 1f600"`;
+
+exports[`Round 2 fuzz 18-template-nested.ts 1`] = `"123 a|b|c##1,2"`;
+
+exports[`Round 2 fuzz 19-numeric-edge.ts 1`] = `
+"1e+21 1e-7 0.30000000000000004 5e-324 9007199254740992 4294967295
+15 10 1000000 1.5e-10"
+`;
+
+exports[`Round 2 fuzz 20-sequence-comma.ts 1`] = `"3 [ 5, 7 ] 12"`;
+
+exports[`Round 2 fuzz 21-throw-finally.ts 1`] = `"b"`;
+
+exports[`Round 2 fuzz 22-optional-chain-call.ts 1`] = `
+"42
+undefined
+undefined
+42.00"
+`;
+
+exports[`Round 2 fuzz 23-class-fields-init-order.ts 1`] = `"1 2 101"`;
+
+exports[`Round 2 fuzz 24-arguments-arrow.ts 1`] = `"[ 3, 2 ]"`;
+
+exports[`Round 2 fuzz 25-tagged-raw.ts 1`] = `
+"a
+béc	d##a\\nb\\u00E9c\\td"
+`;
+
+exports[`Round 2 fuzz 26-symbol-iter.ts 1`] = `"1,2,3,4,5"`;
+
+exports[`Round 2 fuzz 27-symbol-asynciter.ts 1`] = `"6"`;
+
+exports[`Round 2 fuzz 28-getter-setter-symbol.ts 1`] = `"8 s:5,g,s:8,g"`;
+
+exports[`Round 2 fuzz 29-export-equals.ts 1`] = `""`;
+
+exports[`Round 2 fuzz 30-import-equals.ts 1`] = `"function"`;
+
+exports[`Round 2 fuzz 31-decorator-stage3.ts 1`] = `"[greet]hi x"`;
+
+exports[`Round 2 fuzz 32-decorator-accessor.ts 1`] = `"0 1 2"`;
+
+exports[`Round 2 fuzz 33-nested-destruct.ts 1`] = `"1 99"`;
+
+exports[`Round 2 fuzz 34-spread-call-rest.ts 1`] = `
+"21
+10 30,40,50"
+`;
+
+exports[`Round 2 fuzz 35-strict-mode.ts 1`] = `"TypeError"`;

--- a/tests/integration/tests/fixtures/round1/01-const-enum.ts
+++ b/tests/integration/tests/fixtures/round1/01-const-enum.ts
@@ -1,0 +1,2 @@
+const enum Color { Red = 1, Green, Blue = "B" as any }
+console.log(Color.Red, Color.Green, Color.Blue);

--- a/tests/integration/tests/fixtures/round1/02-enum-reverse.ts
+++ b/tests/integration/tests/fixtures/round1/02-enum-reverse.ts
@@ -1,0 +1,2 @@
+enum E { A, B = 5, C }
+console.log(E.A, E.B, E.C, E[0], E[5], E[6]);

--- a/tests/integration/tests/fixtures/round1/03-enum-str.ts
+++ b/tests/integration/tests/fixtures/round1/03-enum-str.ts
@@ -1,0 +1,2 @@
+enum S { X = "x", Y = "y" }
+console.log(S.X, S.Y, S["x"], (S as any)["x"]);

--- a/tests/integration/tests/fixtures/round1/04-namespace-merge.ts
+++ b/tests/integration/tests/fixtures/round1/04-namespace-merge.ts
@@ -1,0 +1,3 @@
+namespace N { export const a = 1; }
+namespace N { export const b = 2; }
+console.log(N.a, N.b);

--- a/tests/integration/tests/fixtures/round1/05-param-props.ts
+++ b/tests/integration/tests/fixtures/round1/05-param-props.ts
@@ -1,0 +1,5 @@
+class P {
+  constructor(public x: number, private y: string, readonly z: boolean) {}
+  show() { return `${this.x}/${this.y}/${this.z}`; }
+}
+console.log(new P(1, "a", true).show());

--- a/tests/integration/tests/fixtures/round1/06-private-fields.ts
+++ b/tests/integration/tests/fixtures/round1/06-private-fields.ts
@@ -1,0 +1,8 @@
+class C {
+  #x = 1;
+  static #y = 2;
+  get(){ return C.#y + this.#x; }
+  static stat(){ return C.#y; }
+}
+const c = new C();
+console.log(c.get(), C.stat());

--- a/tests/integration/tests/fixtures/round1/07-static-block.ts
+++ b/tests/integration/tests/fixtures/round1/07-static-block.ts
@@ -1,0 +1,6 @@
+class S {
+  static a = 1;
+  static b: number;
+  static { this.b = this.a + 10; }
+}
+console.log(S.a, S.b);

--- a/tests/integration/tests/fixtures/round1/08-getter-setter.ts
+++ b/tests/integration/tests/fixtures/round1/08-getter-setter.ts
@@ -1,0 +1,9 @@
+let log: string[] = [];
+class G {
+  _x = 0;
+  get x(){ log.push("get"); return this._x; }
+  set x(v: number){ log.push("set:" + v); this._x = v; }
+}
+const g = new G();
+g.x = 5; g.x += 2;
+console.log(g.x, log.join(","));

--- a/tests/integration/tests/fixtures/round1/09-super-arrow.ts
+++ b/tests/integration/tests/fixtures/round1/09-super-arrow.ts
@@ -1,0 +1,8 @@
+class A { greet(){ return "A"; } }
+class B extends A {
+  greet(){
+    const f = () => super.greet() + "/B";
+    return f();
+  }
+}
+console.log(new B().greet());

--- a/tests/integration/tests/fixtures/round1/10-logical-assign.ts
+++ b/tests/integration/tests/fixtures/round1/10-logical-assign.ts
@@ -1,0 +1,9 @@
+let a: any = null;
+let b: any = 0;
+let c: any = undefined;
+a ??= 1; b ||= 2; c &&= 3;
+console.log(a, b, c);
+let o: any = {};
+o.x ??= 10;
+o.x ??= 99;
+console.log(o.x);

--- a/tests/integration/tests/fixtures/round1/11-optional-chain.ts
+++ b/tests/integration/tests/fixtures/round1/11-optional-chain.ts
@@ -1,0 +1,6 @@
+const o: any = { a: { b: { c: () => 42 } } };
+console.log(o?.a?.b?.c?.());
+console.log(o?.x?.y?.z);
+console.log(o?.a?.["b"]?.c?.());
+const fn: any = null;
+console.log(fn?.(1, 2));

--- a/tests/integration/tests/fixtures/round1/12-tagged-template.ts
+++ b/tests/integration/tests/fixtures/round1/12-tagged-template.ts
@@ -1,0 +1,4 @@
+function tag(s: TemplateStringsArray, ...v: any[]) {
+  return [s.join("|"), s.raw.join("|"), v.join(",")].join("##");
+}
+console.log(tag`a\nb${1}c\td${2}e`);

--- a/tests/integration/tests/fixtures/round1/13-regex-named.ts
+++ b/tests/integration/tests/fixtures/round1/13-regex-named.ts
@@ -1,0 +1,3 @@
+const r = /(?<year>\d{4})-(?<month>\d{2})/d;
+const m = "2026-04".match(r);
+console.log(m?.groups?.year, m?.groups?.month, (m as any)?.indices?.groups?.year?.[0]);

--- a/tests/integration/tests/fixtures/round1/14-bigint.ts
+++ b/tests/integration/tests/fixtures/round1/14-bigint.ts
@@ -1,0 +1,3 @@
+const a = 9007199254740993n;
+const b = 2n ** 64n;
+console.log(a + 1n, b, b * b, typeof a);

--- a/tests/integration/tests/fixtures/round1/15-spread-order.ts
+++ b/tests/integration/tests/fixtures/round1/15-spread-order.ts
@@ -1,0 +1,6 @@
+const log: string[] = [];
+const get = (k: string, v: any) => { log.push(k); return { [k]: v }; };
+const o = { a: 1, ...get("b", 2), c: 3, ...get("a", 99) };
+console.log(JSON.stringify(o), log.join(","));
+const arr = [...[1,2], 3, ...[4,5]];
+console.log(arr.join(","));

--- a/tests/integration/tests/fixtures/round1/16-destructure.ts
+++ b/tests/integration/tests/fixtures/round1/16-destructure.ts
@@ -1,0 +1,6 @@
+const { a: x = 10, b: { c: y = 20 } = {} } = { a: undefined, b: { c: 5 } } as any;
+console.log(x, y);
+const [, , z = 99] = [1, 2];
+console.log(z);
+const { ...rest } = { a: 1, b: 2 };
+console.log(JSON.stringify(rest));

--- a/tests/integration/tests/fixtures/round1/17-for-of-let.ts
+++ b/tests/integration/tests/fixtures/round1/17-for-of-let.ts
@@ -1,0 +1,6 @@
+const fns: (() => number)[] = [];
+for (let i = 0; i < 3; i++) fns.push(() => i);
+console.log(fns.map(f => f()).join(","));
+const arr: (() => string)[] = [];
+for (const k of ["a","b","c"]) arr.push(() => k);
+console.log(arr.map(f => f()).join(","));

--- a/tests/integration/tests/fixtures/round1/18-generator.ts
+++ b/tests/integration/tests/fixtures/round1/18-generator.ts
@@ -1,0 +1,6 @@
+function* gen() { yield 1; yield 2; yield* [3, 4]; return 99; }
+const out: any[] = [];
+const g = gen();
+for (let v = g.next(); !v.done; v = g.next()) out.push(v.value);
+out.push(g.next().value);
+console.log(out.join(","));

--- a/tests/integration/tests/fixtures/round1/19-async-iter.ts
+++ b/tests/integration/tests/fixtures/round1/19-async-iter.ts
@@ -1,0 +1,7 @@
+async function run() {
+  async function* gen() { yield 1; yield 2; yield 3; }
+  let sum = 0;
+  for await (const v of gen()) sum += v;
+  return sum;
+}
+run().then(s => console.log(s));

--- a/tests/integration/tests/fixtures/round1/20-precedence.ts
+++ b/tests/integration/tests/fixtures/round1/20-precedence.ts
@@ -1,0 +1,6 @@
+console.log(2 ** 3 ** 2);
+console.log(-(2 ** 3));
+const a: any = null, b: any = 0, c = 5;
+console.log((a ?? b) || c, a ?? (b || c));
+console.log(typeof "x" + "y");
+console.log("a" + 1 + 2, 1 + 2 + "a");

--- a/tests/integration/tests/fixtures/round1/21-tdz.ts
+++ b/tests/integration/tests/fixtures/round1/21-tdz.ts
@@ -1,0 +1,13 @@
+try {
+  // @ts-ignore
+  console.log(x);
+  let x = 1;
+} catch (e: any) {
+  console.log("TDZ:", e.constructor.name);
+}
+const make = () => {
+  let count = 0;
+  return () => ++count;
+};
+const c = make();
+console.log(c(), c(), c());

--- a/tests/integration/tests/fixtures/round1/22-class-expr.ts
+++ b/tests/integration/tests/fixtures/round1/22-class-expr.ts
@@ -1,0 +1,6 @@
+const Foo = class Bar {
+  static name2 = "Bar-static";
+  who() { return Bar.name2; }
+};
+const f = new Foo();
+console.log(f.who(), Foo.name);

--- a/tests/integration/tests/fixtures/round1/23-computed-key.ts
+++ b/tests/integration/tests/fixtures/round1/23-computed-key.ts
@@ -1,0 +1,7 @@
+const sym = Symbol("k");
+const o = {
+  [sym]: 1,
+  ["a" + "b"]: 2,
+  [Symbol.iterator]() { let i = 0; return { next: () => ({ value: i++, done: i > 3 }) }; }
+};
+console.log((o as any)[sym], (o as any).ab, [...(o as any)].join(","));

--- a/tests/integration/tests/fixtures/round1/24-jsx.tsx
+++ b/tests/integration/tests/fixtures/round1/24-jsx.tsx
@@ -1,0 +1,13 @@
+const React = {
+  createElement(type: any, props: any, ...children: any[]) {
+    return { type, props: props || {}, children };
+  },
+  Fragment: "Fragment"
+};
+const el = (
+  <>
+    <div className="a" {...{ id: "x" }}>hello {1 + 2}</div>
+    <span />
+  </>
+);
+console.log(JSON.stringify(el));

--- a/tests/integration/tests/fixtures/round1/25-string-escape.ts
+++ b/tests/integration/tests/fixtures/round1/25-string-escape.ts
@@ -1,0 +1,3 @@
+const s1 = "a\tb\nc\\d\"eéf\u{1f600}g";
+const s2 = `tpl ${"x"} \\${"y"} \r raw`;
+console.log(s1.length, s2.length, JSON.stringify(s1), JSON.stringify(s2));

--- a/tests/integration/tests/fixtures/round1/26-numeric.ts
+++ b/tests/integration/tests/fixtures/round1/26-numeric.ts
@@ -1,0 +1,2 @@
+console.log(0.1 + 0.2, 1e21, 0xff, 0o17, 0b101, 1_000_000, .5, 5., 1.5e2);
+console.log(Number.MAX_SAFE_INTEGER, Number.MIN_VALUE);

--- a/tests/integration/tests/fixtures/round1/27-asi.ts
+++ b/tests/integration/tests/fixtures/round1/27-asi.ts
@@ -1,0 +1,15 @@
+function f() {
+  return
+    1
+}
+console.log(f());
+
+const a = 1
+const b = 2
+;[a, b].forEach(x => console.log(x))
+
+const c = [1,2,3]
+const d = c
+  .map(x => x * 2)
+  .reduce((s, x) => s + x, 0)
+console.log(d);

--- a/tests/integration/tests/fixtures/round1/28-try-catch.ts
+++ b/tests/integration/tests/fixtures/round1/28-try-catch.ts
@@ -1,0 +1,7 @@
+function attempt(): string {
+  try { throw new Error("boom"); }
+  catch { return "caught-no-binding"; }
+  finally { /* nothing */ }
+}
+console.log(attempt());
+try { throw "raw"; } catch (e: any) { console.log(typeof e, e); }

--- a/tests/integration/tests/fixtures/round1/29-default-export-fn.ts
+++ b/tests/integration/tests/fixtures/round1/29-default-export-fn.ts
@@ -1,0 +1,1 @@
+export default function () { return 42; }

--- a/tests/integration/tests/fixtures/round1/30-import-meta.ts
+++ b/tests/integration/tests/fixtures/round1/30-import-meta.ts
@@ -1,0 +1,1 @@
+console.log(typeof import.meta, typeof import.meta.url === "string" ? "url-string" : "no-url");

--- a/tests/integration/tests/fixtures/round1/31-labeled.ts
+++ b/tests/integration/tests/fixtures/round1/31-labeled.ts
@@ -1,0 +1,9 @@
+const out: number[] = [];
+outer: for (let i = 0; i < 3; i++) {
+  for (let j = 0; j < 3; j++) {
+    if (i === 1 && j === 1) continue outer;
+    if (i === 2 && j === 2) break outer;
+    out.push(i * 10 + j);
+  }
+}
+console.log(out.join(","));

--- a/tests/integration/tests/fixtures/round1/32-satisfies.ts
+++ b/tests/integration/tests/fixtures/round1/32-satisfies.ts
@@ -1,0 +1,3 @@
+type C = Record<string, number | string>;
+const data = { a: 1, b: "two", c: 3 } satisfies C;
+console.log(data.a + 1, data.b.toUpperCase());

--- a/tests/integration/tests/fixtures/round1/33-as-const.ts
+++ b/tests/integration/tests/fixtures/round1/33-as-const.ts
@@ -1,0 +1,3 @@
+const xs = [1, 2, 3] as const;
+const t = { name: "x", value: 5 } as const;
+console.log(xs.join(","), t.name, t.value);

--- a/tests/integration/tests/fixtures/round1/34-decorator-legacy.ts
+++ b/tests/integration/tests/fixtures/round1/34-decorator-legacy.ts
@@ -1,0 +1,12 @@
+function tag(label: string) {
+  return function (target: any, key?: string) {
+    target.__tags = target.__tags || [];
+    target.__tags.push(label + ":" + (key || "class"));
+  };
+}
+@tag("cls")
+class D {
+  @tag("m")
+  hi() { return "hi"; }
+}
+console.log((D.prototype as any).__tags?.join("|"), new D().hi());

--- a/tests/integration/tests/fixtures/round1/35-arrow-vs-paren.ts
+++ b/tests/integration/tests/fixtures/round1/35-arrow-vs-paren.ts
@@ -1,0 +1,4 @@
+const f = (x: number, y: number = 5) => x + y;
+const g: (n: number) => number = (n) => n * 2;
+const h = <T,>(x: T): T => x;
+console.log(f(1), f(1, 2), g(3), h("z"));

--- a/tests/integration/tests/fixtures/round2/01-namespace-merge.ts
+++ b/tests/integration/tests/fixtures/round2/01-namespace-merge.ts
@@ -1,0 +1,4 @@
+// TS namespace merging — same name can merge values across declarations
+namespace M { export const x = 1; export function inc(n: number) { return n + x; } }
+namespace M { export const y = 2; export function dec(n: number) { return n - y; } }
+console.log(M.x, M.y, M.inc(10), M.dec(10));

--- a/tests/integration/tests/fixtures/round2/02-namespace-nested.ts
+++ b/tests/integration/tests/fixtures/round2/02-namespace-nested.ts
@@ -1,0 +1,2 @@
+namespace A { export namespace B { export const v = 5; export function nest() { return v * 2; } } export const top = B.v + 100; }
+console.log(A.B.v, A.B.nest(), A.top);

--- a/tests/integration/tests/fixtures/round2/03-abstract-override.ts
+++ b/tests/integration/tests/fixtures/round2/03-abstract-override.ts
@@ -1,0 +1,3 @@
+abstract class Base { abstract greet(): string; common() { return "common:" + this.greet(); } }
+class Impl extends Base { override greet() { return "impl"; } }
+console.log(new Impl().common());

--- a/tests/integration/tests/fixtures/round2/04-using.ts
+++ b/tests/integration/tests/fixtures/round2/04-using.ts
@@ -1,0 +1,5 @@
+// ES2026 explicit resource management
+const log: string[] = [];
+class R { [Symbol.dispose]() { log.push("disposed"); } }
+{ using r = new R(); log.push("inside"); }
+console.log(log.join(","));

--- a/tests/integration/tests/fixtures/round2/05-await-using.ts
+++ b/tests/integration/tests/fixtures/round2/05-await-using.ts
@@ -1,0 +1,7 @@
+async function run() {
+  const log: string[] = [];
+  class R { async [Symbol.asyncDispose]() { log.push("async-disposed"); } }
+  { await using r = new R(); log.push("inside"); }
+  return log.join(",");
+}
+run().then(s => console.log(s));

--- a/tests/integration/tests/fixtures/round2/06-iterator-helpers.ts
+++ b/tests/integration/tests/fixtures/round2/06-iterator-helpers.ts
@@ -1,0 +1,4 @@
+// ES2025 Iterator helpers
+function* gen() { yield 1; yield 2; yield 3; yield 4; yield 5; }
+const r = (gen() as any).filter((x: number) => x % 2).map((x: number) => x * 10).toArray();
+console.log(r);

--- a/tests/integration/tests/fixtures/round2/07-set-methods.ts
+++ b/tests/integration/tests/fixtures/round2/07-set-methods.ts
@@ -1,0 +1,6 @@
+// ES2025 Set methods
+const a = new Set([1, 2, 3, 4]);
+const b = new Set([3, 4, 5, 6]);
+console.log([...(a as any).intersection(b)].sort().join(","));
+console.log([...(a as any).union(b)].sort((x: any, y: any) => x - y).join(","));
+console.log([...(a as any).difference(b)].sort().join(","));

--- a/tests/integration/tests/fixtures/round2/08-regex-v.ts
+++ b/tests/integration/tests/fixtures/round2/08-regex-v.ts
@@ -1,0 +1,3 @@
+// ES2024 /v flag — set notation
+const re = /[\p{L}--[a-z]]/v;
+console.log(re.test("A"), re.test("a"), re.test("Δ"));

--- a/tests/integration/tests/fixtures/round2/09-import-meta-url.ts
+++ b/tests/integration/tests/fixtures/round2/09-import-meta-url.ts
@@ -1,0 +1,1 @@
+console.log(typeof import.meta.url, import.meta.url.length > 0);

--- a/tests/integration/tests/fixtures/round2/10-pure-annotation.ts
+++ b/tests/integration/tests/fixtures/round2/10-pure-annotation.ts
@@ -1,0 +1,3 @@
+function effect() { console.log("called"); return 1; }
+const dead = /* @__PURE__ */ effect();
+console.log("done");

--- a/tests/integration/tests/fixtures/round2/11-precedence-edge.ts
+++ b/tests/integration/tests/fixtures/round2/11-precedence-edge.ts
@@ -1,0 +1,7 @@
+const a = 0, b = null, c = 5;
+console.log(a ?? b ?? c);
+console.log(2 ** 3 ** 2);
+console.log(-(2 ** 3));
+console.log(typeof typeof "x");
+console.log("y" in { y: 1 }, !"y" in { y: 1 });
+console.log(1 + 2 * 3, (1 + 2) * 3);

--- a/tests/integration/tests/fixtures/round2/12-assignment-target.ts
+++ b/tests/integration/tests/fixtures/round2/12-assignment-target.ts
@@ -1,0 +1,4 @@
+let arr = [1, 2, 3]; let obj: any = { a: 1 };
+[arr[0], arr[1]] = [arr[1], arr[0]];
+({ a: obj.b, c: obj.d = 99 } = { a: 10, c: undefined });
+console.log(arr.join(","), JSON.stringify(obj));

--- a/tests/integration/tests/fixtures/round2/13-private-brand.ts
+++ b/tests/integration/tests/fixtures/round2/13-private-brand.ts
@@ -1,0 +1,3 @@
+class C { #x = 1; static has(o: any) { return #x in o; } }
+const c1 = new C(); const c2: any = {};
+console.log(C.has(c1), C.has(c2), C.has({ x: 1 }));

--- a/tests/integration/tests/fixtures/round2/14-static-block-order.ts
+++ b/tests/integration/tests/fixtures/round2/14-static-block-order.ts
@@ -1,0 +1,3 @@
+const log: string[] = [];
+class A { static { log.push("A1"); } static x = (log.push("Ax"), 1); static { log.push("A2"); } }
+console.log(log.join(","), A.x);

--- a/tests/integration/tests/fixtures/round2/15-async-finally.ts
+++ b/tests/integration/tests/fixtures/round2/15-async-finally.ts
@@ -1,0 +1,7 @@
+async function f() {
+  try { return 1; } finally { /* return 2 in finally would override */ }
+}
+async function g() {
+  try { return 1; } finally { return 2; }
+}
+Promise.all([f(), g()]).then(([a, b]) => console.log(a, b));

--- a/tests/integration/tests/fixtures/round2/16-gen-return-finally.ts
+++ b/tests/integration/tests/fixtures/round2/16-gen-return-finally.ts
@@ -1,0 +1,6 @@
+function* g() {
+  try { yield 1; yield 2; yield 3; }
+  finally { /* @ts-ignore */ console.log("cleanup"); }
+}
+const it = g();
+console.log(it.next().value, it.return(99).value, it.next().done);

--- a/tests/integration/tests/fixtures/round2/17-string-codepoint.ts
+++ b/tests/integration/tests/fixtures/round2/17-string-codepoint.ts
@@ -1,0 +1,2 @@
+const s = "a\u{1F600}b\u{D83D}\u{DE00}c";
+console.log(s.length, [...s].length, s.codePointAt(1)?.toString(16));

--- a/tests/integration/tests/fixtures/round2/18-template-nested.ts
+++ b/tests/integration/tests/fixtures/round2/18-template-nested.ts
@@ -1,0 +1,4 @@
+const x = `${`${`${1}`}${2}`}${3}`;
+const tag = (s: TemplateStringsArray, ...v: any[]) => s.raw.join("|") + "##" + v.join(",");
+const y = tag`a${1}b${`${2}`}c`;
+console.log(x, y);

--- a/tests/integration/tests/fixtures/round2/19-numeric-edge.ts
+++ b/tests/integration/tests/fixtures/round2/19-numeric-edge.ts
@@ -1,0 +1,2 @@
+console.log(1e21, 1e-7, 0.1 + 0.2, Number.MIN_VALUE, 9007199254740993, 0xffffffff);
+console.log(0o17, 0b1010, 1_000_000, 1.5e-10);

--- a/tests/integration/tests/fixtures/round2/20-sequence-comma.ts
+++ b/tests/integration/tests/fixtures/round2/20-sequence-comma.ts
@@ -1,0 +1,4 @@
+const x = (1, 2, 3);
+const arr = [(4, 5), (6, 7)];
+const fn = (a: number) => (a + 1, a + 2);
+console.log(x, arr, fn(10));

--- a/tests/integration/tests/fixtures/round2/21-throw-finally.ts
+++ b/tests/integration/tests/fixtures/round2/21-throw-finally.ts
@@ -1,0 +1,6 @@
+function attempt() {
+  try { throw new Error("a"); }
+  catch { throw new Error("b"); }
+  finally { /* swallow? no, throws are independent */ }
+}
+try { attempt(); } catch (e: any) { console.log(e.message); }

--- a/tests/integration/tests/fixtures/round2/22-optional-chain-call.ts
+++ b/tests/integration/tests/fixtures/round2/22-optional-chain-call.ts
@@ -1,0 +1,5 @@
+const o: any = { f: () => 42, g: null };
+console.log(o?.f?.());
+console.log(o?.g?.());
+console.log((o?.h as any)?.());
+console.log(o?.f?.()?.toFixed?.(2));

--- a/tests/integration/tests/fixtures/round2/23-class-fields-init-order.ts
+++ b/tests/integration/tests/fixtures/round2/23-class-fields-init-order.ts
@@ -1,0 +1,5 @@
+// ECMAScript: instance field init in source order, after super()
+class P { x = 1; y = this.x + 1; constructor() { /* fields run before this */ } }
+class C extends P { z = (this.x || 0) + 100; }
+const c = new C();
+console.log(c.x, (c as any).y, (c as any).z);

--- a/tests/integration/tests/fixtures/round2/24-arguments-arrow.ts
+++ b/tests/integration/tests/fixtures/round2/24-arguments-arrow.ts
@@ -1,0 +1,6 @@
+function outer() {
+  const arrow = () => arguments.length;
+  function inner() { return arguments.length; }
+  return [arrow(), inner(99, 100)];
+}
+console.log((outer as any)(1, 2, 3));

--- a/tests/integration/tests/fixtures/round2/25-tagged-raw.ts
+++ b/tests/integration/tests/fixtures/round2/25-tagged-raw.ts
@@ -1,0 +1,2 @@
+const tag = (s: TemplateStringsArray, ..._v: any[]) => [s.join("|"), s.raw.join("|")].join("##");
+console.log(tag`a\nbéc\td`);

--- a/tests/integration/tests/fixtures/round2/26-symbol-iter.ts
+++ b/tests/integration/tests/fixtures/round2/26-symbol-iter.ts
@@ -1,0 +1,2 @@
+class Range { constructor(public lo: number, public hi: number) {} *[Symbol.iterator]() { for (let i = this.lo; i <= this.hi; i++) yield i; } }
+console.log([...new Range(1, 5)].join(","));

--- a/tests/integration/tests/fixtures/round2/27-symbol-asynciter.ts
+++ b/tests/integration/tests/fixtures/round2/27-symbol-asynciter.ts
@@ -1,0 +1,7 @@
+async function run() {
+  const obj = { async *[Symbol.asyncIterator]() { yield 1; yield 2; yield 3; } };
+  let sum = 0;
+  for await (const v of obj) sum += v;
+  return sum;
+}
+run().then(n => console.log(n));

--- a/tests/integration/tests/fixtures/round2/28-getter-setter-symbol.ts
+++ b/tests/integration/tests/fixtures/round2/28-getter-setter-symbol.ts
@@ -1,0 +1,5 @@
+const log: string[] = [];
+const sym = Symbol("k");
+const o: any = { _x: 0, get [sym]() { log.push("g"); return this._x; }, set [sym](v: number) { log.push("s:" + v); this._x = v; } };
+o[sym] = 5; o[sym] += 3;
+console.log(o[sym], log.join(","));

--- a/tests/integration/tests/fixtures/round2/29-export-equals.ts
+++ b/tests/integration/tests/fixtures/round2/29-export-equals.ts
@@ -1,0 +1,3 @@
+// TS-only: export = ... (CJS interop)
+const value = { name: "exp-eq", n: 42 };
+export = value;

--- a/tests/integration/tests/fixtures/round2/30-import-equals.ts
+++ b/tests/integration/tests/fixtures/round2/30-import-equals.ts
@@ -1,0 +1,3 @@
+// TS-only: import x = require("...")
+import path = require("path");
+console.log(typeof path.join);

--- a/tests/integration/tests/fixtures/round2/31-decorator-stage3.ts
+++ b/tests/integration/tests/fixtures/round2/31-decorator-stage3.ts
@@ -1,0 +1,5 @@
+function trace<T extends (...args: any[]) => any>(target: T, ctx: ClassMethodDecoratorContext): T {
+  return function (this: any, ...args: any[]) { return "[" + String(ctx.name) + "]" + target.apply(this, args); } as T;
+}
+class C { @trace greet(n: string) { return "hi " + n; } }
+console.log(new C().greet("x"));

--- a/tests/integration/tests/fixtures/round2/32-decorator-accessor.ts
+++ b/tests/integration/tests/fixtures/round2/32-decorator-accessor.ts
@@ -1,0 +1,5 @@
+function autoinc(_t: ClassAccessorDecoratorTarget<any, any>, _c: ClassAccessorDecoratorContext): ClassAccessorDecoratorResult<any, any> {
+  return { get() { return (this as any).__c++; }, init(_v: any) { (this as any).__c = 0; return _v; } };
+}
+class C { @autoinc accessor v = 100; }
+const c = new C(); console.log(c.v, c.v, c.v);

--- a/tests/integration/tests/fixtures/round2/33-nested-destruct.ts
+++ b/tests/integration/tests/fixtures/round2/33-nested-destruct.ts
@@ -1,0 +1,2 @@
+const { a: { b: [c, , { d = 99 } = {} as any] } } = { a: { b: [1, 2, { d: undefined }] } } as any;
+console.log(c, d);

--- a/tests/integration/tests/fixtures/round2/34-spread-call-rest.ts
+++ b/tests/integration/tests/fixtures/round2/34-spread-call-rest.ts
@@ -1,0 +1,5 @@
+function f(...args: number[]) { return args.reduce((a, b) => a + b, 0); }
+const arr = [1, 2, 3];
+console.log(f(...arr, 4, 5, ...[6]));
+const [a, , ...rest] = [10, 20, 30, 40, 50];
+console.log(a, rest.join(","));

--- a/tests/integration/tests/fixtures/round2/35-strict-mode.ts
+++ b/tests/integration/tests/fixtures/round2/35-strict-mode.ts
@@ -1,0 +1,3 @@
+"use strict";
+function f() { try { (this as any).x = 1; return "no-throw"; } catch (e: any) { return e.constructor.name; } }
+console.log(f.call(null));

--- a/tests/integration/tests/fixtures/round4-sourcemap/01-simple.ts
+++ b/tests/integration/tests/fixtures/round4-sourcemap/01-simple.ts
@@ -1,0 +1,2 @@
+const greet = (name: string): string => "Hello, " + name;
+console.log(greet("world"));

--- a/tests/integration/tests/fixtures/round4-sourcemap/02-multiline.ts
+++ b/tests/integration/tests/fixtures/round4-sourcemap/02-multiline.ts
@@ -1,0 +1,10 @@
+function compute(
+  x: number,
+  y: number,
+  z: number,
+): number {
+  const sum = x + y + z;
+  const product = x * y * z;
+  return sum + product;
+}
+console.log(compute(1, 2, 3));

--- a/tests/integration/tests/fixtures/round4-sourcemap/03-class-method.ts
+++ b/tests/integration/tests/fixtures/round4-sourcemap/03-class-method.ts
@@ -1,0 +1,14 @@
+class Calculator {
+  result: number = 0;
+  add(n: number): this {
+    this.result += n;
+    return this;
+  }
+  multiply(n: number): this {
+    this.result *= n;
+    return this;
+  }
+}
+const calc = new Calculator();
+calc.add(5).multiply(3);
+console.log(calc.result);

--- a/tests/integration/tests/fixtures/round4-sourcemap/04-throw-error.ts
+++ b/tests/integration/tests/fixtures/round4-sourcemap/04-throw-error.ts
@@ -1,0 +1,14 @@
+function level3() {
+  throw new Error("boom");
+}
+function level2() {
+  level3();
+}
+function level1() {
+  level2();
+}
+try {
+  level1();
+} catch (e: any) {
+  console.log(e.stack?.split("\n").slice(0, 5).join("\n"));
+}

--- a/tests/integration/tests/fixtures/round4-sourcemap/05-jsx.tsx
+++ b/tests/integration/tests/fixtures/round4-sourcemap/05-jsx.tsx
@@ -1,0 +1,10 @@
+const React = { createElement: (t: any, p: any, ...c: any[]) => ({ t, p, c }), Fragment: "F" };
+function App() {
+  return (
+    <div>
+      <h1>Hello</h1>
+      <p>World</p>
+    </div>
+  );
+}
+console.log(JSON.stringify(App()));

--- a/tests/integration/tests/fixtures/round4-sourcemap/06-async.ts
+++ b/tests/integration/tests/fixtures/round4-sourcemap/06-async.ts
@@ -1,0 +1,12 @@
+async function fetchData(): Promise<string> {
+  await Promise.resolve();
+  throw new Error("async-fail");
+}
+async function main() {
+  try {
+    await fetchData();
+  } catch (e: any) {
+    console.log(e.message, e.stack?.split("\n")[1]?.trim());
+  }
+}
+main();

--- a/tests/integration/tests/fixtures/round4-sourcemap/07-decorator.ts
+++ b/tests/integration/tests/fixtures/round4-sourcemap/07-decorator.ts
@@ -1,0 +1,7 @@
+function tag(target: any, key?: string) {
+  target.__tagged = true;
+}
+class Foo {
+  @tag bar() { return 1; }
+}
+console.log((Foo.prototype as any).__tagged, new Foo().bar());

--- a/tests/integration/tests/fixtures/round4-sourcemap/08-template-literal.ts
+++ b/tests/integration/tests/fixtures/round4-sourcemap/08-template-literal.ts
@@ -1,0 +1,5 @@
+const name = "world";
+const greeting = `Hello,
+${name}!
+Multiline string`;
+console.log(greeting.length, greeting.split("\n").length);

--- a/tests/integration/tests/round1-fuzz.test.ts
+++ b/tests/integration/tests/round1-fuzz.test.ts
@@ -1,0 +1,31 @@
+/// Round 1 fuzz 회귀 테스트 — 35 fixture (전 세션에서 7 critical PR 도출).
+///
+/// fixture 카테고리: TS enum / namespace / parameter property / private fields /
+/// static block / getter-setter / super arrow / logical assign / decorator / JSX 등.
+/// 각 fixture 는 transpile → bun 실행 → stdout snapshot 으로 회귀 감지.
+import { describe, test, expect } from "bun:test";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { transpileAndRun } from "./helpers";
+
+const FIXTURES_DIR = join(import.meta.dir, "fixtures/round1");
+const fixtures = readdirSync(FIXTURES_DIR)
+  .filter((f) => /\.(ts|tsx)$/.test(f))
+  .sort();
+
+describe("Round 1 fuzz", () => {
+  for (const fix of fixtures) {
+    test(fix, async () => {
+      const source = readFileSync(join(FIXTURES_DIR, fix), "utf-8");
+      const ext = fix.endsWith(".tsx") ? "tsx" : "ts";
+      const r = await transpileAndRun(source, [], { ext });
+      try {
+        expect(r.transpileExitCode).toBe(0);
+        expect(r.runStderr).toBe("");
+        expect(r.runOutput).toMatchSnapshot();
+      } finally {
+        await r.cleanup();
+      }
+    });
+  }
+});

--- a/tests/integration/tests/round2-fuzz.test.ts
+++ b/tests/integration/tests/round2-fuzz.test.ts
@@ -1,0 +1,31 @@
+/// Round 2 fuzz 회귀 테스트 — 35 fixture (전 세션 검증 결과 0 ZTS-DIFF, clean).
+///
+/// fixture 카테고리: namespace 병합/중첩, abstract override, using/await using, iterator
+/// helpers, set methods, regex /v, import.meta.url, /* @__PURE__ */ annotation 등 ES2024+.
+/// clean baseline 을 회귀로 보호.
+import { describe, test, expect } from "bun:test";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { transpileAndRun } from "./helpers";
+
+const FIXTURES_DIR = join(import.meta.dir, "fixtures/round2");
+const fixtures = readdirSync(FIXTURES_DIR)
+  .filter((f) => /\.(ts|tsx)$/.test(f))
+  .sort();
+
+describe("Round 2 fuzz", () => {
+  for (const fix of fixtures) {
+    test(fix, async () => {
+      const source = readFileSync(join(FIXTURES_DIR, fix), "utf-8");
+      const ext = fix.endsWith(".tsx") ? "tsx" : "ts";
+      const r = await transpileAndRun(source, [], { ext });
+      try {
+        expect(r.transpileExitCode).toBe(0);
+        expect(r.runStderr).toBe("");
+        expect(r.runOutput).toMatchSnapshot();
+      } finally {
+        await r.cleanup();
+      }
+    });
+  }
+});

--- a/tests/integration/tests/round4-sourcemap.test.ts
+++ b/tests/integration/tests/round4-sourcemap.test.ts
@@ -1,0 +1,46 @@
+/// Round 4 sourcemap footer/file 회귀 테스트 — 8 fixture (PR #2217 영역).
+///
+/// 각 fixture 에 대해 `--sourcemap` 트랜스파일 후 검증:
+///   1. 출력 코드 끝에 `//# sourceMappingURL=...` footer 존재
+///   2. `.map` 파일이 spec 부합 (version=3, sources/sourcesContent 비어있지 않음, mappings 비어있지 않음)
+///   3. `map.file` 필드가 출력 파일 basename 과 일치
+import { describe, test, expect } from "bun:test";
+import { readFileSync, readdirSync } from "node:fs";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { runZts } from "./helpers";
+
+const FIXTURES_DIR = join(import.meta.dir, "fixtures/round4-sourcemap");
+const fixtures = readdirSync(FIXTURES_DIR)
+  .filter((f) => /\.(ts|tsx)$/.test(f))
+  .sort();
+
+describe("Round 4 sourcemap footer/file", () => {
+  for (const fix of fixtures) {
+    test(fix, async () => {
+      const sourceText = readFileSync(join(FIXTURES_DIR, fix), "utf-8");
+      const dir = await mkdtemp(join(tmpdir(), "zts-round4-"));
+      try {
+        const inFile = join(dir, fix);
+        await writeFile(inFile, sourceText);
+        const outFile = join(dir, fix.replace(/\.(ts|tsx)$/, ".js"));
+        const r = await runZts([inFile, "-o", outFile, "--sourcemap"]);
+        expect(r.exitCode).toBe(0);
+
+        const outText = readFileSync(outFile, "utf-8");
+        // footer
+        expect(outText).toMatch(/\/\/#\s*sourceMappingURL=.+\.map\s*$/);
+
+        const mapJson = JSON.parse(readFileSync(outFile + ".map", "utf-8"));
+        expect(mapJson.version).toBe(3);
+        expect(Array.isArray(mapJson.sources) && mapJson.sources.length > 0).toBe(true);
+        expect(typeof mapJson.mappings === "string" && mapJson.mappings.length > 0).toBe(true);
+        // map.file 은 출력 파일 basename 과 일치 (spec 권장)
+        expect(mapJson.file).toBe(basename(outFile));
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
이전 세션에서 진행된 ZTS bug-bounty 라운드 1, 2, 4 의 fixture (총 78개) 를 통합 테스트로 영구 등록하여 회귀를 자동 감지.

이전 머지 PR (#2192~#2198, #2203, #2217) 에서 fix 된 영역들이 미래에 깨지면 즉시 잡힌다.

## 추가 카테고리
- **라운드 1** (35 fixture): TS enum / namespace / parameter property / private fields / static block / getter-setter / decorator / JSX / precedence / template / generator — 7 critical PR 도출 영역
- **라운드 2** (35 fixture): namespace 병합/중첩 / abstract override / using / iterator helpers / set methods / regex /v / import.meta.url / @__PURE__ — ES2024+ clean baseline
- **라운드 4** (8 fixture): sourcemap footer + map.file 검증 (#2217)

## 검증 방식
- **라운드 1, 2**: \`transpileAndRun\` → exitCode 0 + runStderr 빈 문자열 + runOutput snapshot
- **라운드 4**: \`--sourcemap\` 트랜스파일 후 footer 정규식 + .map JSON spec 부합 + \`map.file === basename(outFile)\`

## 부수 변경
- \`round1/20-precedence.ts\` 의 \`a ?? b || c\` (괄호 없음) 표현식 제거 — ECMAScript 12.16.3 SyntaxError. ZTS 가 정확히 거부하므로 fixture 가 통과 못함. 괄호 명시 버전 (\`(a ?? b) || c, a ?? (b || c)\`) 만 유지.

## Test plan
- [x] \`bun test round1-fuzz.test.ts round2-fuzz.test.ts round4-sourcemap.test.ts\` — 78/78 pass
- [x] \`bun test\` (전체) — 3555 pass / 0 fail (회귀 0)

## Context
**누적 회귀 테스트**: 145건 (라운드 5/11 67건 — #2222 + 라운드 1/2/4 78건 — 본 PR)