### PR TITLE
docs: README / STRUCTURE / TESTING 현재 구현 상태 동기화

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,43 @@
 # zts
 
-Zig로 작성한 고성능 JavaScript/TypeScript/Flow 트랜스파일러 + 번들러.
+Zig 로 작성한 고성능 JavaScript / TypeScript / Flow 트랜스파일러 + 번들러.
 
-> **Status**: Phase 1–6 전반 완료 (렉서/파서/트랜스포머/코드젠/번들러/Dev 서버/HMR).
-> Test262 50,504건 100% 통과. 131개 npm 패키지 스모크 테스트 통과. 상세: [docs/ROADMAP.md](./docs/ROADMAP.md).
+> **Status**: Phase 1–6 전반 완료 (렉서/파서/세만틱/트랜스포머/코드젠/번들러/Dev 서버/HMR).
+> Test262 50,504건 / 50,504 통과 (100%, 0 fail). 144 npm 패키지 스모크 테스트 통과 (esbuild 대비 평균 0.82x 사이즈, 합성 벤치 7ms vs Bun 10ms / esbuild 13ms / rolldown 62ms).
+> 상세: [docs/ROADMAP.md](./docs/ROADMAP.md)
 
 ## Goals
 
-- **Fast**: SIMD(@Vector) 렉서, 파일당 Arena + mimalloc, 인덱스 기반 AST, 멀티스레드 parse/resolve/emit
-- **Correct**: Test262 100% 통과, 스모크 테스트 + kangax compat-table + SWC 비교 CI 검증
-- **Compatible**: TS/TSX/JSX/Flow 전부, 엔진 타겟(es5~esnext, chrome/safari/node 등), Rollup/Vite 플러그인 호환
-- **Small**: WASM 빌드 지원, 외부 C/C++ 의존성 최소화
+- **Fast**: SIMD(@Vector) 렉서, 파일당 Arena + mimalloc, 인덱스 기반 24B 고정 AST, parse / resolve / emit 멀티스레드 + Producer-Consumer 파이프라인
+- **Correct**: Test262 100% 통과, 스모크 + kangax compat-table + SWC 비교 + Hermes 런타임 / Metro Flow 정합성 CI
+- **Compatible**: TS / TSX / JSX / Flow 전부, 엔진 타겟 (es5~esnext, chrome / safari / node / hermes), Vite / Rollup / esbuild / Metro 호환 플러그인
+- **Small**: WASM 빌드 (transpile-only + bundler 포함), 외부 C/C++ 의존성은 mimalloc 만
 
 ## Build
 
 ```bash
-# Prerequisites: Zig 0.15.2 (use mise for version management)
+# Prerequisites: Zig 0.15.2 (mise 권장)
 mise install
 
-# Build & run
-zig build
-zig build run -- src/index.ts
+# 빌드
+zig build                       # zts CLI + lib (Debug)
+zig build -Doptimize=ReleaseFast  # 성능 측정용
+zig build run -- src/index.ts   # CLI 직접 실행
 
-# Test
-zig build test            # 유닛 테스트
-zig build test262         # Test262 (50,504건)
-zig build napi            # NAPI .node 애드온
-zig build wasm            # WASM 타겟
+# 테스트
+zig build test                  # Zig 유닛 / 통합 테스트
+zig build test262-run           # Test262 50,504건 실행
+zig build napi                  # @zts/core 용 NAPI .node
+zig build wasm                  # transpile-only WASM
+zig build wasm-bundler          # bundler 포함 WASM (wasm32-wasi + threads)
+zig build schema                # BuildOptions JSON 스키마 자동 생성
 ```
 
-통합 테스트 / 스모크 테스트:
+JS 사이드 테스트:
 ```bash
-cd tests/integration && bun test
-cd tests/benchmark && bun run smoke.ts
+cd tests/integration && bun test         # CLI / NAPI 통합 테스트
+cd tests/e2e && bun test                 # Playwright E2E
+cd tests/benchmark && bun run smoke.ts   # 144 패키지 빌드+실행 vs esbuild/rolldown/rspack
 ```
 
 ## Usage (JS / NAPI)
@@ -42,44 +47,78 @@ import { init, transpile, build } from "@zts/core";
 init();
 
 // 단일 파일 트랜스파일
-const { code } = transpile(source, { jsx: "automatic", target: "es2022" });
+const { code, map } = transpile(source, {
+  jsx: "automatic",
+  target: "es2022",
+  sourcemap: true,
+});
 
-// 번들링 (플러그인 지원)
+// 번들링 (esbuild / Vite / Rollup 호환 플러그인 훅)
 const result = await build({
   entryPoints: ["src/index.ts"],
   bundle: true,
   format: "esm",
   platform: "browser",
-  plugins: [/* esbuild/Vite/Rollup 스타일 훅 */],
+  target: ["chrome100", "safari16"],
+  define: { "process.env.NODE_ENV": '"production"' },
+  plugins: [
+    {
+      name: "my-plugin",
+      setup(build) {
+        build.onResolve({ filter: /^virtual:/ }, (args) => ({ path: args.path, namespace: "virtual" }));
+        build.onLoad({ filter: /.*/, namespace: "virtual" }, () => ({ contents: "export const x = 1" }));
+      },
+    },
+  ],
 });
 ```
 
-Vite 어댑터: `vite-plugin-zts` — Vite의 esbuild transform을 ZTS로 교체.
+CLI:
+```bash
+zts src/index.ts --bundle --outdir dist --format=esm --target=es2022
+zts --watch src/index.ts                           # NDJSON 이벤트 (--watch-json)
+zts serve src/main.tsx --port 5173                 # Dev 서버 + HMR + Fast Refresh
+```
+
+Vite 어댑터 — `vite-plugin-zts` 가 Vite 의 esbuild transform 을 ZTS 로 교체합니다.
 
 ## Documentation
 
 - [CLAUDE.md](./CLAUDE.md) — 프로젝트 요약 + Dev workflow
+- [docs/USAGE.md](./docs/USAGE.md) — CLI / `@zts/core` JS API / 플랫폼 / watch / ES 타겟 / CSS
+- [docs/CONFIG.md](./docs/CONFIG.md) — `zts.config.{ts,js,json}` / tsconfig / .env / CLI flag 우선순위
 - [docs/STRUCTURE.md](./docs/STRUCTURE.md) — 디렉토리 구조
-- [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) — 파이프라인 / 메모리 / 설계 결정 요약
-- [docs/ROADMAP.md](./docs/ROADMAP.md) — Phase 현황, 성능, 미지원 기능
-- [docs/TESTING.md](./docs/TESTING.md) — Test262, 유닛/통합/스모크 테스트
+- [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) — 파이프라인 / 메모리 / 설계 결정
+- [docs/ROADMAP.md](./docs/ROADMAP.md) — Phase 현황, 성능, 미지원
+- [docs/TESTING.md](./docs/TESTING.md) — Test262 / 유닛 / 통합 / 스모크 / perf 가드
 - [docs/BUNDLER.md](./docs/BUNDLER.md) — 번들러 상세 설계
-- [docs/PLUGINS.md](./docs/PLUGINS.md) — 플러그인 시스템 + 로더
+- [docs/PLUGINS.md](./docs/PLUGINS.md) / [docs/AST_PLUGINS.md](./docs/AST_PLUGINS.md) — 플러그인 시스템
 - [docs/HMR.md](./docs/HMR.md) — Dev 서버 + HMR
 - [docs/FLOW.md](./docs/FLOW.md) — Flow 지원 전략
-- [docs/DECISIONS.md](./docs/DECISIONS.md) — 설계 결정 로그
+- [docs/DECISIONS.md](./docs/DECISIONS.md) / [docs/INVARIANTS.md](./docs/INVARIANTS.md) — 설계 결정 / 불변
+- [docs/DEBUG.md](./docs/DEBUG.md) — 디버그 / 진단
 - [docs/BACKLOG.md](./docs/BACKLOG.md) — 백로그 (미해결 버그는 [GitHub Issues](https://github.com/ohah/zts/issues))
+
+## Packages
+
+| 패키지 | 역할 |
+|--------|------|
+| `@zts/core` | NAPI .node 바인딩 + Node.js / Bun CLI (`zts` 커맨드) |
+| `@zts/wasm` | WASM 빌드 (브라우저 playground / Deno / Workers) |
+| `@zts/shared` | core / wasm 공유 타입 (TranspileOptions, Target, compat-engines) |
+| `vite-plugin-zts` | Vite 의 esbuild transform 을 ZTS 로 교체 |
 
 ## References
 
-- [Bun JS Parser](https://github.com/oven-sh/bun) (Zig, MIT)
-- [oxc](https://github.com/oxc-project/oxc) (Rust, MIT)
-- [SWC](https://github.com/swc-project/swc) (Rust, Apache-2.0)
-- [esbuild](https://github.com/evanw/esbuild) (Go, MIT)
-- [Rolldown](https://github.com/rolldown/rolldown) (Rust, MIT)
-- [Hermes](https://github.com/facebook/hermes) (C++, MIT) — Flow 파서
-- [Metro](https://github.com/facebook/metro) (JS, MIT) — React Native 번들러 참고
-- [Test262](https://github.com/tc39/test262)
+- [Bun JS Parser](https://github.com/oven-sh/bun) (Zig, MIT) — 파서 / 렉서 / SIMD
+- [oxc](https://github.com/oxc-project/oxc) (Rust, MIT) — 트랜스포머 / Reference flags
+- [SWC](https://github.com/swc-project/swc) (Rust, Apache-2.0) — 다운레벨 비교
+- [esbuild](https://github.com/evanw/esbuild) (Go, MIT) — 번들러 아키텍처 / 호환
+- [Rolldown](https://github.com/rolldown/rolldown) (Rust, MIT) — Rollup 호환 / Vite 통합
+- [Hermes](https://github.com/facebook/hermes) (C++, MIT) — Flow 파서 임베딩 + RN 런타임
+- [Metro](https://github.com/facebook/metro) (JS, MIT) — React Native 번들러 호환
+- [TypeScript](https://github.com/microsoft/TypeScript) (TS, Apache-2.0) — 다운레벨 / decorator 케이스
+- [Test262](https://github.com/tc39/test262) — TC39 정합성 50,504건
 
 ## License
 

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -5,7 +5,6 @@ src/
   main.zig                  # CLI 엔트리포인트 (zts 커맨드, zts.config.json 자동 로드)
   root.zig                  # 라이브러리 엔트리포인트 (모든 모듈 re-export)
   transpile.zig             # 트랜스파일 파이프라인 통합 (파일/stdin → JS 출력)
-  transpile_options_dto_test.zig  # Zig DTO ↔ TS TranspileOptions 필드 sync 검증
   diagnostic.zig            # 진단 (ParseError, SemanticError 통합, multi-span label)
   diagnostic_renderer.zig   # rich diagnostic 렌더러 (코드 프레임, ANSI, multi-span)
   rich_diagnostic.zig       # 렌더링 기반 구조 (SourceInfo, RenderOptions)
@@ -14,18 +13,34 @@ src/
   levenshtein.zig           # "did you mean?" 제안
   string_escape.zig         # 공용 문자열 escape 유틸
   crash_handler.zig         # panic handler (Bun 스타일 crash report)
+  debug_log.zig             # 디버그 로깅 유틸
   config.zig                # 설정 구조 (CompilerOptions, ResolverOptions, BundlerOptions)
   config_test.zig           # 설정 로딩 테스트
+  config_options_dto_test.zig  # Zig DTO ↔ TS BuildOptions 필드 sync 검증
+  tsconfig_merge.zig        # tsconfig.json extends/머지 로직
+  profile.zig               # --profile / phaseDurations 측정 (cold/HMR 진단)
+  bench.zig                 # 내부 마이크로벤치 진입점
   mimalloc.zig              # mimalloc 바인딩 (릴리즈 빌드 backing allocator)
+  runtime_helper_modules.zig  # __esm/__commonJS/__export 등 헬퍼 가상 모듈 정의
+  runtime_helper_names.zig    # 헬퍼 식별자 매핑
+  test_arena.zig            # 테스트 Arena 헬퍼
+  test_fixtures.zig         # 통합 테스트용 fixture 로더
+  test_regression.zig       # round1/2/4 회귀 fuzz 테스트 진입점
+  fixtures/                 # Zig 단위 테스트 입력 자료 (transform 등)
+  app/                      # zts.app builder (Vite 대체 진입 — entry HTML/CSS/asset)
+    mod.zig                 #   builder 엔트리
+    build.zig               #   HTML 진입 그래프 + asset emit
+    env.zig                 #   .env 처리, define 주입
   lexer/                    # Phase 1: 렉서 ✅
     mod.zig                 #   렉서 엔트리 + re-export
     token.zig               #   토큰 종류(Kind ~208개), Span, Token, 키워드 맵
-    scanner.zig             #   스캔 로직 (~2400줄, 모든 토큰 타입 처리)
+    scanner.zig             #   스캔 로직 (모든 토큰 타입 처리)
     unicode.zig             #   유니코드 식별자 (UTF-8 디코딩, ID_Start/ID_Continue)
   parser/                   # Phase 2: 파서 ✅
     mod.zig                 #   파서 엔트리 + re-export
-    parser.zig              #   파서 메인 로직 (~4000줄)
+    parser.zig              #   파서 메인 로직
     ast.zig                 #   AST 노드 정의 (~200개 Tag, 24B 고정)
+    ast_walk.zig            #   variant-typed AST walker (Reference flags, identity)
     expression.zig          #   표현식 파싱 (precedence climbing, cover grammar)
     statement.zig           #   문 파싱 (if/for/while/switch 등)
     declaration.zig         #   선언 파싱 (function/class/const 등)
@@ -35,10 +50,11 @@ src/
     module.zig              #   import/export 파싱
     ts.zig                  #   TypeScript 타입 어노테이션 파싱
     flow.zig                #   Flow 타입 어노테이션 파싱 (TIER 1+2+3, Metro 검증)
+    scan_results.zig        #   파싱 부산물 (binding/import scan 결과 캐시)
   semantic/                 # 의미 분석 ✅
     mod.zig                 #   의미 분석 엔트리 + re-export
-    analyzer.zig            #   의미 분석기 (~3000줄, 스코프/심볼 추적)
-    checker.zig             #   검증 (~700줄, 엄격 모드, 예약어, 중복)
+    analyzer.zig            #   의미 분석기 (스코프/심볼/Reference flags)
+    checker.zig             #   검증 (엄격 모드, 예약어, 중복 선언)
     scope.zig               #   스코프 체인 (플랫 배열 + 부모 인덱스)
     symbol.zig              #   심볼 테이블 (이름, 종류, 플래그, 참조 수)
   transformer/              # Phase 3: 트랜스포머 ✅ + ES 다운레벨링 ✅
@@ -47,15 +63,26 @@ src/
     transformer/            #   transformer 서브 모듈 (delegation 패턴)
       refresh.zig           #     React Fast Refresh ($RefreshReg$/$RefreshSig$)
       class_decorator.zig   #     class 변환 + experimental decorators
-    compat.zig              #   엔진 타겟 호환성 매핑 (chrome/safari/node 등 feature-level)
+      worklet.zig           #     react-native-reanimated worklet 추출
+    plugins/                #   trampoline AST 플러그인 (Zig builtin)
+      builtin.zig           #     기본 셋업
+      worklet.zig           #     worklet plugin entry
+    ast_plugin.zig          #   AST 플러그인 트램폴린 디스패처
+    plugin_state.zig        #   플러그인 공유 상태/심볼 매니저
+    runtime_helper_imports.zig  # 헬퍼 import 자동 주입
+    compat.zig              #   엔진 타겟 호환성 매핑 (chrome/safari/node feature-level)
     jsx_lowering.zig        #   JSX lowering (classic/automatic/automatic-dev)
+    regex_lower.zig         #   RegExp 다운레벨링 (named groups, dotAll, sticky 등)
+    unicode_escape_lower.zig  # 식별자/문자열 \u{...} 다운레벨
     es2025_using.zig        #   ES2025 다운레벨링 (using/await using)
-    es2024.zig              #   ES2024 다운레벨링 (using/await using)
+    es2024.zig              #   ES2024 다운레벨링
     es2022.zig              #   ES2022 다운레벨링 (class static block, this 치환)
+    es2022_tla.zig          #   Top-level await 다운레벨
     es2021.zig              #   ES2021 다운레벨링 (??=, ||=, &&=)
     es2020.zig              #   ES2020 다운레벨링 (??, ?.)
     es2019.zig              #   ES2019 다운레벨링 (optional catch binding)
     es2018.zig              #   ES2018 다운레벨링 (object spread)
+    es2018_for_await.zig    #   for-await-of → 상태 머신
     es2017.zig              #   ES2017 다운레벨링 (async/await → generator)
     es2016.zig              #   ES2016 다운레벨링 (**)
     es2015.zig              #   ES2015 엔트리 (기능별 모듈 re-export)
@@ -70,14 +97,18 @@ src/
     es2015_block_scoping.zig #  let/const → var
     es2015_class.zig        #   class → function + prototype
     es2015_generator.zig    #   generator → 상태 머신 (__generator)
+    es2015_object_methods.zig  # 메서드 단축 → function expression
     es_helpers.zig          #   다운레벨링 헬퍼 유틸
     minify.zig              #   AST 미니파이어 (별도 패스, new_ast in-place 수정)
   codegen/                  # Phase 4: 코드 생성 ✅
     mod.zig                 #   코드젠 엔트리 + re-export
     codegen.zig             #   코드 생성 (formatting, minify, indentation)
-    sourcemap.zig           #   V3 소스맵 생성 (VLQ 인코딩)
+    sourcemap.zig           #   V3 소스맵 생성 (VLQ 인코딩, lazy build)
     mangler.zig             #   식별자 축약 (번들러 심볼 데이터 활용)
-    codegen_test/           #   코드젠 테스트 (9개 파일로 분리)
+    private_mangler.zig     #   private field/method 축약
+    unified_mangler.zig     #   통합 mangler 엔트리
+    function_map.zig        #   sourcemap names + function range 매핑
+    codegen_test/           #   코드젠 테스트 (분리 모음)
       helpers.zig           #     공용 헬퍼 (TestResult, e2e*, SourceMapTestResult)
       basic.zig             #     기본 codegen 출력
       features.zig          #     E2E 기능 (class, arrow, async, destructuring 등)
@@ -87,39 +118,56 @@ src/
       flow.zig              #     Flow 타입 스트리핑
       engine_jsx.zig        #     엔진 타겟 + JSX 런타임
       private_jsx_advanced.zig #  private method, JSX auto, ES2025
+      class_expr_anonymize.zig # 미참조 class expression 익명화
+      decorator.zig         #     Stage 3 decorator
+      function_map.zig      #     sourcemap names 보존
+      import_attributes.zig #     ES2024 with {...}
+      skip_nodes_blank.zig  #     skip-node 빈 블록 처리
   bundler/                  # Phase 6a: 번들러 ✅
     mod.zig                 #   번들러 엔트리 + 오케스트레이션
     bundler.zig             #   번들러 메인 로직
     resolver.zig            #   모듈 경로 해석 (node_modules, package.json, tsconfig)
     graph.zig               #   모듈 그래프 (DFS, exec_index, 순환 감지)
     module.zig              #   모듈 데이터 (AST, import/export, 심볼, def_format, interop)
-    linker.zig              #   스코프 호이스팅 + 이름 충돌 해결 + CJS→ESM Interop
+    module_list.zig         #   증분 빌드 안전한 안정 인덱스 모듈 컨테이너
+    module_store.zig        #   PersistentModuleStore (증분 빌드 파싱 캐시)
+    linker.zig              #   스코프 호이스팅 + 이름 충돌 해결 + CJS↔ESM Interop
     linker/                 #   linker 서브 모듈
       metadata.zig          #     per-module LinkingMetadata 빌드
     tree_shaker.zig         #   Tree-shaking (export 추적, @__PURE__, sideEffects, 도달성)
-    stmt_info.zig           #   StmtInfo (rolldown 방식 심볼 기반 statement 도달성 분석)
     statement_shaker.zig    #   Statement-level DCE (span 기반 폴백)
+    stmt_info.zig           #   StmtInfo (rolldown 방식 심볼 기반 statement 도달성 분석)
     purity.zig              #   순수성 분석 (expression/statement/varDecl/class 공유)
+    constant_facts.zig      #   상수 사실 추적 (inline 가능 여부)
     chunk.zig               #   Code splitting (BitSet, 공통 청크, cross-chunk)
     emitter.zig             #   출력 생성 (exec_index 순서, ESM/CJS/IIFE)
-    css_scanner.zig         #   CSS @import 추출기 (경량 상태 머신)
-    css_emitter.zig         #   CSS 번들 생성 (@import strip + 연결 + 파일명 패턴)
     emitter/                #   emitter 서브 모듈
       dev.zig               #     dev mode 번들링 (HMR, __zts_register)
       chunks.zig            #     code splitting + hash/naming
       esm_wrap.zig          #     __esm 래퍼 + export getter
+      cjs_wrap.zig          #     __commonJS 래퍼
+      external_imports.zig  #     external 의존성 import 헤더
+    css_scanner.zig         #   CSS @import 추출기 (경량 상태 머신)
+    css_emitter.zig         #   CSS 번들 생성 (@import strip + 연결 + 파일명 패턴)
     types.zig               #   번들러 자료 구조 (Interop, ModuleDefFormat, ExportsKind 등)
+    symbol.zig              #   번들러 전용 심볼 테이블 (cross-module rename)
     package_json.zig        #   package.json 읽기 (exports, browser, sideEffects)
     resolve_cache.zig       #   해석 결과 캐싱 (import kind별)
     import_scanner.zig      #   import/export 문 추출
     binding_scanner.zig     #   심볼 바인딩 추적
     plugin.zig              #   Zig builtin 플러그인 (함수 포인터 기반, 내부 전용)
     json_to_esm.zig         #   JSON → ESM AST 변환 (export default <value>)
+    asset_meta.zig          #   asset 로더 메타 (file/dataurl/text/binary/copy)
+    block_list.zig          #   noExternal/exclude 패턴 매칭
+    fs.zig                  #   번들러 fs 추상화 (in-mem fixture 지원)
+    phase.zig               #   파이프라인 phase 정의 (scan/resolve/link/emit)
     mpsc_channel.zig        #   MPSC 채널 (Producer-Consumer 파이프라인)
-    module_store.zig        #   PersistentModuleStore (증분 빌드 파싱 캐시)
     incremental.zig         #   증분 빌드 로직 (watch/serve 리빌드)
+    compiled_module.zig     #   transform/codegen 결과 캐시 단위
+    compiled_cache.zig      #   compiled module 캐시 매핑
     runtime_helpers.zig     #   런타임 헬퍼 (__esm, __commonJS, __export 등)
-    bundler_test/           #   번들러 통합 테스트 (13개 파일로 분리)
+    test_helpers.zig        #   번들러 통합 테스트 헬퍼
+    bundler_test/           #   번들러 통합 테스트 (분리 모음)
       basic.zig             #     기본 번들링, 링커, re-export, scope hoist
       typescript_format.zig #     TypeScript, format, edge, complex
       compat.zig            #     Rollup/esbuild/Bun/Rolldown/Webpack 호환
@@ -133,16 +181,22 @@ src/
       splitting_dev.zig     #     code splitting, dev mode
       minify_loader.zig     #     minify, asset loader
       plugin_misc.zig       #     plugin, worker, JSX auto, RN
+      manual_chunks.zig     #     Rollup manualChunks 호환
+      function_map.zig      #     sourcemap function 매핑
+      exports_name_dedup.zig #    export 이름 중복 제거
+      lowering_rename_leak.zig # 다운레벨/rename 누수 가드
+      ns_member_shadow.zig  #     namespace member shadowing
+      virtual_ns_treeshake.zig # virtual namespace tree-shake
   server/                   # Phase 6b: 개발 서버 + HMR ✅
     mod.zig                 #   서버 엔트리 + re-export
     dev_server.zig          #   HTTP + WebSocket 서버 (HMR, Fast Refresh, SSE, MCP, Control API)
     file_watcher.zig        #   파일 변경 감지 (watch/serve, watchFolders 지원)
     watch_scan.zig          #   공통 디렉토리 walker (TOCTOU-free, glob filter)
-    tracked_file_set.zig    #   감시 대상 파일 추적
+    tracked_file_set.zig    #   감시 대상 파일 추적 (StableSegmentedList 기반)
     mime.zig                #   MIME 타입 매핑
   regexp/                   # RegExp 검증 ✅
     mod.zig                 #   RegExp 엔트리 + re-export
-    parser.zig              #   RegExp 패턴 파서 (~2000줄, comptime 모드 분리)
+    parser.zig              #   RegExp 패턴 파서 (comptime 모드 분리)
     ast.zig                 #   RegExp AST
     flags.zig               #   플래그 처리 (g, i, m, u, v, d, s)
     unicode_property.zig    #   유니코드 프로퍼티 (\p{Letter} 등)
@@ -150,16 +204,44 @@ src/
   test262/                  # Test262 러너
     mod.zig                 #   Test262 엔트리
     runner.zig              #   메타데이터 파서 + 테스트 실행기
+    main.zig                #   `zig build test262-run` 진입점
+  util/                     # 공용 유틸
+    mod.zig                 #   엔트리
+    wyhash.zig              #   wyhash 해시 (콘텐츠 해시 / mangler)
+
 packages/
   core/                     # @zts/core — C NAPI .node addon + Node CLI (기본 경로)
+    bin/                    #   `zts` CLI 엔트리 (zts.mjs)
+    src/                    #   napi_entry.zig + JS 사이드 (config-loader/load-env/workspace 등)
+    index.ts                #   JS API (init/transpile/build) — NAPI .node 로드 + 옵션 검증
+    dist/                   #   bun build 산출물 (배포용)
   wasm/                     # @zts/wasm — WASM 빌드 (브라우저 playground, Deno/Workers)
-  shared/                   # core/wasm 공유 타입 (TranspileOptions, Target, compat engines)
+    src/wasm_entry.zig      #   transpile only WASM 진입
+    src/wasm_bundler_entry.zig  # 번들러 포함 WASM 진입 (wasm32-wasi + threads)
+  shared/                   # core/wasm 공유 타입 (TranspileOptions, Target, compat-engines)
   vite-plugin-zts/          # Vite 플러그인 (esbuild transform → ZTS 교체, @zts/core 기반)
+  plugin/                   # 사용자 플러그인 워크스페이스 (workspace 의존성용)
+
 tests/
-  test262/                  # TC39 공식 Test262 (서브모듈)
-  integration/              # Bun 기반 CLI 통합 테스트
-  e2e/                      # Playwright E2E 테스트 (dev server)
-  benchmark/                # 스모크 테스트 + 벤치마크 (smoke.ts)
+  test262/                  # TC39 공식 Test262 (서브모듈, 50,504건)
+  integration/              # Bun 기반 CLI/NAPI 통합 테스트 (60+ 스위트)
+    tests/
+      tsc/                  #   TypeScript 컴파일러 테스트케이스 포팅 (36개, ES 다운레벨/decorator/enum 등)
+      fixtures/             #   round1/2/4 회귀, RN, RSC, AST 보존 등 fixture
+      __snapshots__/        #   bun snapshot
+  e2e/                      # Playwright E2E 테스트 (dev server, browser, sourcemap, vite/zts builder)
+  benchmark/                # 스모크 테스트 + 벤치마크
+    smoke.ts                #   144 케이스 패키지 빌드+실행 검증 (vs esbuild/rolldown/rspack)
+    bundle-perf.ts          #   번들 perf 회귀 가드 (small/medium/large × median 비교)
+    bench.ts / pipeline.ts  #   합성 벤치 (200 모듈, 단계별 시간)
+    napi-bench.ts           #   NAPI 콜백 hot-path 벤치 (#1891)
+    minify-bench.ts / size-gap.ts / tree-shake-size.ts  # 사이즈/미니파이 비교
+    mangler-property.ts     #   property mangler 안정성 fuzz
+    transpile-conformance.ts #  TS strip + 다운레벨 정합성
+    extract-esbuild-tests.ts #  esbuild 회귀 케이스 임포트
+    smoke-diagnostics.test.ts # 스모크 결과 회귀 어서션
+    baselines/              #   bundle-perf baseline JSON
+
 references/                 # 레퍼런스 프로젝트 (.gitignore, 로컬만)
   bun/                      #   Zig — 파서/렉서/SIMD 참고
   esbuild/                  #   Go — 번들러 아키텍처/모듈 해석/설정 참고
@@ -171,4 +253,27 @@ references/                 # 레퍼런스 프로젝트 (.gitignore, 로컬만)
   vite/                     #   JS — 개발 서버/HMR/플러그인 API 참고
   babel/                    #   JS — 플러그인 시스템/스펙 추종 참고
   typescript/               #   TS — 공식 컴파일러, 다운레벨링/decorator 테스트케이스 참고
+
+vendor/
+  mimalloc/                 # mimalloc backing allocator (release 빌드)
+  node-api-headers/         # NAPI v8 헤더
+
+scripts/                    # 보조 스크립트 (release/audit/sync 등)
+documents/                  # Vite/Tailwind 데모 (Vite 7 pin)
+tools/                      # 개발 도구
 ```
+
+## Build Steps (build.zig)
+
+| Step | 설명 |
+|------|------|
+| `zig build` | `zts` CLI + 정적 라이브러리 빌드 |
+| `zig build run -- <args>` | CLI 직접 실행 |
+| `zig build test` | 모든 모듈 유닛 테스트 |
+| `zig build test262` | Test262 러너 자체 테스트 |
+| `zig build test262-run` | Test262 50,504건 실행 (pass-rate 측정) |
+| `zig build napi` | `@zts/core` 용 NAPI .node 빌드 (`zig-out/lib/zts.node`) |
+| `zig build wasm` | `@zts/wasm` transpile-only WASM |
+| `zig build wasm-bundler` | bundler 포함 WASM (wasm32-wasi + threads) |
+| `zig build schema` | `BuildOptions` JSON 스키마 자동 생성 |
+| `zig build bench-callback` | NAPI 콜백 hot-path 마이크로벤치 (#1891) |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -2,50 +2,107 @@
 
 ## Test262 (TC39 정합성)
 ```bash
-zig build test262                       # 전체 실행 (50,504건)
-zig build test262 -- --filter=language  # 언어 기능만
-zig build test262 -- --verbose          # 상세 출력
+zig build test262                        # 러너 자체 유닛 테스트
+zig build test262-run                    # 전체 실행 (50,504건, pass-rate 측정)
+zig build test262-run -- --filter=language  # 언어 기능만
+zig build test262-run -- --verbose       # 상세 출력
 ```
+- 결과 (2026-04-29 기준): **50,504 / 50,504 통과 (0 fail, 100%)**
+- 러너 위치: `src/test262/`, 입력 서브모듈: `tests/test262/`
+- excludelist: 엔진 의존 / 스펙 외 항목만 (현재 0건)
 
-## 유닛 테스트
+## 유닛 테스트 (Zig)
 ```bash
-zig build test                          # 모든 모듈 테스트
+zig build test                           # 모든 모듈 유닛 + 통합 Zig 테스트
 ```
-테스트 위치: 각 모듈 파일 하단 (`test "..." { ... }` 블록)
-- `src/lexer/scanner.zig` — 렉서 유닛 테스트
-- `src/parser/parser.zig` — 파서 유닛 테스트
-- `src/transformer/transformer.zig` — 변환기 유닛 테스트
-- `src/codegen/codegen.zig` — 코드젠 형식 테스트
-- `src/bundler/bundler.zig` — 번들러 통합 테스트
-- `src/semantic/analyzer.zig` — 의미 분석 테스트
+주요 테스트 파일은 `*_test.zig` 로 분리되어 모듈별 디렉토리에 함께 위치.
+
+| 영역 | 위치 | 비고 |
+|------|------|------|
+| 렉서 | `src/lexer/{scanner,token,unicode}_test.zig` | 토큰/유니코드 ID/JSX |
+| 파서 | `src/parser/{parser,ast,ast_walk}_test.zig` | AST 24B layout, walker identity |
+| 의미 분석 | `src/semantic/{analyzer,checker,scope,symbol}_test.zig` | Reference flags, hoisting |
+| 트랜스포머 | `src/transformer/{transformer,minify,worklet*}_test.zig` | 다운레벨/미니파이 |
+| 코드젠 | `src/codegen/codegen_test/*.zig` + `mangler_test.zig`, `sourcemap_test.zig` | E2E 출력 어서션 |
+| 번들러 | `src/bundler/bundler_test/*.zig` + 모듈별 `*_test.zig` | 통합 + unit |
+| 정규식 | `src/regexp/{parser,ast,flags,unicode_property}_test.zig` | regex AST/플래그 |
+| 서버 | `src/server/{dev_server,file_watcher,mime}_test.zig` | HTTP/HMR/MIME |
+| 회귀 | `src/test_regression.zig` | 라운드 1/2/4 광역 fuzz 영구 보존 |
+| DTO sync | `src/config_options_dto_test.zig` | Zig DTO ↔ TS BuildOptions 필드 검증 |
 
 ## 통합 테스트 (Bun)
 ```bash
-cd tests/integration && bun test     # CLI 통합 테스트
-cd tests/e2e && bun test             # Playwright E2E (dev server)
+cd tests/integration && bun test         # CLI/NAPI 통합 테스트
+cd tests/e2e && bun test                 # Playwright E2E (dev server, 브라우저)
 ```
-테스트 파일:
-- `tests/integration/tests/bundle-smoke.test.ts` — 번들 스모크 (99개 케이스)
-- `tests/integration/tests/devserver.test.ts` — 개발 서버
-- `tests/integration/tests/downlevel.test.ts` — ES 다운레벨링
-- `tests/integration/tests/es5-rn.test.ts` — RN ES5 + Hermes
-- `tests/integration/tests/flow-rn.test.ts` — Flow + React Native
-- `tests/integration/tests/hermes-runtime.test.ts` — Hermes 런타임
-- `tests/integration/tests/plugin.test.ts` — JS 플러그인
-- `tests/integration/tests/polyfill-rbm.test.ts` — 폴리필 + run-before-main
-- `tests/integration/tests/watch-json.test.ts` — watch-json NDJSON 이벤트
-- `tests/integration/tests/compat-table.test.ts` — kangax compat-table ES5~ES2022 (237 subtests)
-- `tests/integration/tests/swc-compare.test.ts` — ZTS vs SWC 다운레벨링 비교 (29 cases × 9 targets)
-- `tests/integration/tests/css-bundle.test.ts` — CSS 번들링 (26개: @import 체인, 순환, 중복 제거, BOM, 대용량 등)
-- `tests/integration/tests/css-library-smoke.test.ts` — CSS 라이브러리 스모크 (Emotion, Styled-Components, 네이티브 CSS)
-- `tests/integration/tests/stage3-decorator-smoke.test.ts` — MobX 6 Stage 3 decorator 스모크
-- `tests/e2e/tests/smoke.test.ts` — E2E 스모크 (브라우저 실행)
-- `tests/e2e/tests/browser-smoke.test.ts` — 브라우저 번들 E2E
+
+`tests/integration/tests/` 주요 스위트 (총 60+):
+
+**번들러 / 코드젠**
+- `bundle-smoke.test.ts` — 번들 스모크 (다중 케이스)
+- `bundle-circular-cycle.test.ts` / `bundle-dynamic-import.test.ts` — 순환 / dynamic import
+- `tree-shake-precision.test.ts` / `const-value-inline.test.ts` / `export-preserve-minify.test.ts`
+- `inline-dynamic-imports{,-smoke}.test.ts` / `manual-chunks{,-smoke}.test.ts` / `preserve-modules.test.ts`
+- `runtime-helpers.test.ts` / `runtime-helper-virtual-module.test.ts`
+- `mangler-minify.test.ts` / `minify-orphan-dead-store.test.ts`
+
+**소스맵**
+- `sourcemap.test.ts` / `sourcemap-footer.test.ts` / `round4-sourcemap.test.ts`
+
+**ES 타겟 / Hermes / RN**
+- `downlevel.test.ts` / `downlevel-edge.test.ts`
+- `compat-table.test.ts` (kangax ES5~ES2022, 237 subtests) + `compat-table-extract.cjs`
+- `swc-compare.test.ts` (29 cases × 9 targets)
+- `es5-rn.test.ts` / `es5-call-super.test.ts` / `es5-class-super-shared-node.test.ts` / `es5-stage3-decorator.test.ts`
+- `hermes-runtime.test.ts` / `polyfill-rbm.test.ts` / `rn-refresh-prelude.test.ts` / `node-compat.test.ts`
+
+**Flow / RSC / 데코레이터**
+- `flow-rn.test.ts` / `flow-component-react-ref.test.ts`
+- `rsc-directives.test.ts`
+- `stage3-decorator{,-smoke}.test.ts`
+
+**dev 서버 / HMR / watch**
+- `devserver.test.ts` / `devserver-sse-mcp.test.ts` / `hmr.test.ts`
+- `watch-json.test.ts` / `watch-stress.test.ts`
+
+**Resolve / 외부 호환**
+- `resolve-fallback.test.ts` / `browser-field.test.ts` / `block-list.test.ts`
+- `vite-plugin-zts.test.ts` / `zts-config-bundler.test.ts`
+
+**ESM / namespace / semantic 회귀**
+- `esm-enum-hoisting.test.ts` / `esm-function-hoist.test.ts`
+- `ns-shadow-runtime.test.ts` / `ns-var-collision.test.ts`
+- `semantic-{arrow-var-hoist,block-function-hoist,lexical-hoist}.test.ts`
+
+**Profile / 진단 / asset**
+- `profile-flags.test.ts` / `profile-parity.test.ts` / `bench.test.ts`
+- `ast-info-preservation.test.ts` / `asset-registry.test.ts`
+- `strict-execution-order.test.ts` / `stop-after.test.ts` / `batch-e-cli.test.ts`
+
+**광역 fuzz 회귀** (Zig 유닛에 영구 보존)
+- `round1-fuzz.test.ts` / `round2-fuzz.test.ts` — 라운드 1/2 회귀
+
+**TypeScript 컴파일러 케이스 (36개)**
+- `tests/integration/tests/tsc/` — `classes`, `enums`, `decorator`, `es2021`~`es2025`, `es6-*`, `generators`, `expressions`, `ts-import-equals`, `ast-layout-snapshots` 등
+
+**CSS**
+- `css-bundle.test.ts` (@import 체인, 순환, 중복 제거, BOM, 대용량)
+- `css-library-smoke.test.ts` (Emotion, Styled-Components, 네이티브 CSS)
+
+`tests/e2e/tests/` (Playwright):
+- `smoke.test.ts` / `browser-smoke.test.ts` — 브라우저 번들 실행
+- `sourcemap-e2e.test.ts` — 브라우저 stack trace 매핑
+- `vite-app-e2e.test.ts` / `zts-app-builder-e2e.test.ts` — Vite/zts.app 빌더
 
 ## 스모크 테스트 (실제 패키지 빌드)
 ```bash
-cd tests/benchmark && bun run smoke.ts  # 143개 패키지 빌드+실행 검증
+cd tests/benchmark && bun run smoke.ts          # 144 케이스 빌드+실행 검증 (vs esbuild/rolldown/rspack)
+bun run smoke.ts -- --filter=react              # 특정 패키지만
+bun run smoke.ts -- --keep-output               # 산출물 보존 (디버깅)
 ```
+- esbuild 출력을 baseline 으로 ZTS / rolldown / rspack 출력 일치 검증
+- 빌드 성공 + 실행 성공 + 출력 일치 3단 어서션
+- `smoke-diagnostics.test.ts` — 결과를 통합 테스트에서 다시 회귀 어서션
 
 ## 번들 perf 회귀 가드
 ```bash
@@ -57,6 +114,21 @@ bun run tests/benchmark/bundle-perf.ts --write
 ```
 - fixture 3종 (small 10 / medium 100 / large 200 모듈, externals 포함)
 - 워밍업 5회 + 측정 20회 → median 비교
-- baseline 은 `tests/benchmark/baselines/bundle-perf.json` 에 commit
-- 머신 의존 — 절대값은 머신마다 다름. dev 머신 비교는 의미 있고, CI 절대값은 다름
-- CI: `benchmark.yml` 가 PR 마다 `--no-fail --output` 로 실행 → JSON artifact 업로드 (트렌드 추적용, 회귀 fail 안 함)
+- baseline: `tests/benchmark/baselines/bundle-perf.json` (commit 됨)
+- 머신 의존 — 절대값은 머신마다 다름. dev 머신 비교는 의미 있음, CI 절대값은 다름
+- CI: `benchmark.yml` 가 PR 마다 `--no-fail --output` 으로 실행 → JSON artifact 업로드 (트렌드 추적, 회귀 fail 안 함)
+
+## 기타 벤치 / 분석
+- `bench.ts` / `pipeline.ts` — 합성 벤치 (200 모듈, 단계별 시간)
+- `napi-bench.ts` — NAPI 콜백 hot-path (`zig build bench-callback` 와 한 쌍)
+- `minify-bench.ts` / `size-gap.ts` / `tree-shake-size.ts` — 사이즈/미니파이 vs esbuild/rolldown
+- `mangler-property.ts` — property mangler 안정성 fuzz
+- `transpile-conformance.ts` — TS strip + 다운레벨 정합성
+
+## 통합 테스트 실행 위치
+- 통합 테스트는 항상 `tests/integration/` cwd 에서 실행. 루트에서 `bun test` 하면 fixture 경로가 어긋나서 깨짐.
+- e2e 도 `tests/e2e/` cwd 에서. Playwright 가 자체 server fixture 를 띄움.
+
+## CI
+- `.github/workflows/` — `ci.yml` (zig + integration), `benchmark.yml` (perf 트렌드)
+- ReleaseFast 빌드에서만 깨지는 회귀가 존재 → debug 통과해도 CI 실패 시 `-Doptimize=ReleaseFast` 로 로컬 재현 필수

--- a/tests/integration/tests/__snapshots__/round1-fuzz.test.ts.snap
+++ b/tests/integration/tests/__snapshots__/round1-fuzz.test.ts.snap
@@ -1,0 +1,112 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`Round 1 fuzz 01-const-enum.ts 1`] = `"1 2 B"`;
+
+exports[`Round 1 fuzz 02-enum-reverse.ts 1`] = `"0 5 6 A B C"`;
+
+exports[`Round 1 fuzz 03-enum-str.ts 1`] = `"x y undefined undefined"`;
+
+exports[`Round 1 fuzz 04-namespace-merge.ts 1`] = `"1 2"`;
+
+exports[`Round 1 fuzz 05-param-props.ts 1`] = `"1/a/true"`;
+
+exports[`Round 1 fuzz 06-private-fields.ts 1`] = `"3 2"`;
+
+exports[`Round 1 fuzz 07-static-block.ts 1`] = `"1 11"`;
+
+exports[`Round 1 fuzz 08-getter-setter.ts 1`] = `"7 set:5,get,set:7,get"`;
+
+exports[`Round 1 fuzz 09-super-arrow.ts 1`] = `"A/B"`;
+
+exports[`Round 1 fuzz 10-logical-assign.ts 1`] = `
+"1 2 undefined
+10"
+`;
+
+exports[`Round 1 fuzz 11-optional-chain.ts 1`] = `
+"42
+undefined
+42
+undefined"
+`;
+
+exports[`Round 1 fuzz 12-tagged-template.ts 1`] = `
+"a
+b|c	d|e##a\\nb|c\\td|e##1,2"
+`;
+
+exports[`Round 1 fuzz 13-regex-named.ts 1`] = `"2026 04 0"`;
+
+exports[`Round 1 fuzz 14-bigint.ts 1`] = `"9007199254740994n 18446744073709551616n 340282366920938463463374607431768211456n bigint"`;
+
+exports[`Round 1 fuzz 15-spread-order.ts 1`] = `
+"{"a":99,"b":2,"c":3} b,a
+1,2,3,4,5"
+`;
+
+exports[`Round 1 fuzz 16-destructure.ts 1`] = `
+"10 5
+99
+{"a":1,"b":2}"
+`;
+
+exports[`Round 1 fuzz 17-for-of-let.ts 1`] = `
+"0,1,2
+a,b,c"
+`;
+
+exports[`Round 1 fuzz 18-generator.ts 1`] = `"1,2,3,4,"`;
+
+exports[`Round 1 fuzz 19-async-iter.ts 1`] = `"6"`;
+
+exports[`Round 1 fuzz 20-precedence.ts 1`] = `
+"512
+-8
+5 5
+stringy
+a12 3a"
+`;
+
+exports[`Round 1 fuzz 21-tdz.ts 1`] = `
+"TDZ: ReferenceError
+1 2 3"
+`;
+
+exports[`Round 1 fuzz 22-class-expr.ts 1`] = `"Bar-static Bar"`;
+
+exports[`Round 1 fuzz 23-computed-key.ts 1`] = `"1 2 0,1,2"`;
+
+exports[`Round 1 fuzz 24-jsx.tsx 1`] = `"{"type":"Fragment","props":{},"children":[{"type":"div","props":{"className":"a","id":"x"},"children":["hello ",3]},{"type":"span","props":{},"children":[]}]}"`;
+
+exports[`Round 1 fuzz 25-string-escape.ts 1`] = `"14 14 "a\\tb\\nc\\\\d\\"eéf😀g" "tpl x \\\\y \\r raw""`;
+
+exports[`Round 1 fuzz 26-numeric.ts 1`] = `
+"0.30000000000000004 1e+21 255 15 5 1000000 0.5 5 150
+9007199254740991 5e-324"
+`;
+
+exports[`Round 1 fuzz 27-asi.ts 1`] = `
+"undefined
+1
+2
+12"
+`;
+
+exports[`Round 1 fuzz 28-try-catch.ts 1`] = `
+"caught-no-binding
+string raw"
+`;
+
+exports[`Round 1 fuzz 29-default-export-fn.ts 1`] = `""`;
+
+exports[`Round 1 fuzz 30-import-meta.ts 1`] = `"object url-string"`;
+
+exports[`Round 1 fuzz 31-labeled.ts 1`] = `"0,1,2,10,20,21"`;
+
+exports[`Round 1 fuzz 32-satisfies.ts 1`] = `"2 TWO"`;
+
+exports[`Round 1 fuzz 33-as-const.ts 1`] = `"1,2,3 x 5"`;
+
+exports[`Round 1 fuzz 34-decorator-legacy.ts 1`] = `"undefined hi"`;
+
+exports[`Round 1 fuzz 35-arrow-vs-paren.ts 1`] = `"6 3 6 z"`;

--- a/tests/integration/tests/__snapshots__/round2-fuzz.test.ts.snap
+++ b/tests/integration/tests/__snapshots__/round2-fuzz.test.ts.snap
@@ -1,0 +1,102 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`Round 2 fuzz 01-namespace-merge.ts 1`] = `"1 2 11 8"`;
+
+exports[`Round 2 fuzz 02-namespace-nested.ts 1`] = `"5 10 105"`;
+
+exports[`Round 2 fuzz 03-abstract-override.ts 1`] = `"common:impl"`;
+
+exports[`Round 2 fuzz 04-using.ts 1`] = `"inside,disposed"`;
+
+exports[`Round 2 fuzz 05-await-using.ts 1`] = `"inside,async-disposed"`;
+
+exports[`Round 2 fuzz 06-iterator-helpers.ts 1`] = `"[ 10, 30, 50 ]"`;
+
+exports[`Round 2 fuzz 07-set-methods.ts 1`] = `
+"3,4
+1,2,3,4,5,6
+1,2"
+`;
+
+exports[`Round 2 fuzz 08-regex-v.ts 1`] = `"true false true"`;
+
+exports[`Round 2 fuzz 09-import-meta-url.ts 1`] = `"string true"`;
+
+exports[`Round 2 fuzz 10-pure-annotation.ts 1`] = `
+"called
+done"
+`;
+
+exports[`Round 2 fuzz 11-precedence-edge.ts 1`] = `
+"0
+512
+-8
+string
+true false
+7 9"
+`;
+
+exports[`Round 2 fuzz 12-assignment-target.ts 1`] = `"2,1,3 {"a":1,"b":10,"d":99}"`;
+
+exports[`Round 2 fuzz 13-private-brand.ts 1`] = `"true false false"`;
+
+exports[`Round 2 fuzz 14-static-block-order.ts 1`] = `"A1,Ax,A2 1"`;
+
+exports[`Round 2 fuzz 15-async-finally.ts 1`] = `"1 2"`;
+
+exports[`Round 2 fuzz 16-gen-return-finally.ts 1`] = `
+"cleanup
+1 99 true"
+`;
+
+exports[`Round 2 fuzz 17-string-codepoint.ts 1`] = `"7 5 1f600"`;
+
+exports[`Round 2 fuzz 18-template-nested.ts 1`] = `"123 a|b|c##1,2"`;
+
+exports[`Round 2 fuzz 19-numeric-edge.ts 1`] = `
+"1e+21 1e-7 0.30000000000000004 5e-324 9007199254740992 4294967295
+15 10 1000000 1.5e-10"
+`;
+
+exports[`Round 2 fuzz 20-sequence-comma.ts 1`] = `"3 [ 5, 7 ] 12"`;
+
+exports[`Round 2 fuzz 21-throw-finally.ts 1`] = `"b"`;
+
+exports[`Round 2 fuzz 22-optional-chain-call.ts 1`] = `
+"42
+undefined
+undefined
+42.00"
+`;
+
+exports[`Round 2 fuzz 23-class-fields-init-order.ts 1`] = `"1 2 101"`;
+
+exports[`Round 2 fuzz 24-arguments-arrow.ts 1`] = `"[ 3, 2 ]"`;
+
+exports[`Round 2 fuzz 25-tagged-raw.ts 1`] = `
+"a
+béc	d##a\\nb\\u00E9c\\td"
+`;
+
+exports[`Round 2 fuzz 26-symbol-iter.ts 1`] = `"1,2,3,4,5"`;
+
+exports[`Round 2 fuzz 27-symbol-asynciter.ts 1`] = `"6"`;
+
+exports[`Round 2 fuzz 28-getter-setter-symbol.ts 1`] = `"8 s:5,g,s:8,g"`;
+
+exports[`Round 2 fuzz 29-export-equals.ts 1`] = `""`;
+
+exports[`Round 2 fuzz 30-import-equals.ts 1`] = `"function"`;
+
+exports[`Round 2 fuzz 31-decorator-stage3.ts 1`] = `"[greet]hi x"`;
+
+exports[`Round 2 fuzz 32-decorator-accessor.ts 1`] = `"0 1 2"`;
+
+exports[`Round 2 fuzz 33-nested-destruct.ts 1`] = `"1 99"`;
+
+exports[`Round 2 fuzz 34-spread-call-rest.ts 1`] = `
+"21
+10 30,40,50"
+`;
+
+exports[`Round 2 fuzz 35-strict-mode.ts 1`] = `"TypeError"`;

--- a/tests/integration/tests/fixtures/round1/01-const-enum.ts
+++ b/tests/integration/tests/fixtures/round1/01-const-enum.ts
@@ -1,0 +1,2 @@
+const enum Color { Red = 1, Green, Blue = "B" as any }
+console.log(Color.Red, Color.Green, Color.Blue);

--- a/tests/integration/tests/fixtures/round1/02-enum-reverse.ts
+++ b/tests/integration/tests/fixtures/round1/02-enum-reverse.ts
@@ -1,0 +1,2 @@
+enum E { A, B = 5, C }
+console.log(E.A, E.B, E.C, E[0], E[5], E[6]);

--- a/tests/integration/tests/fixtures/round1/03-enum-str.ts
+++ b/tests/integration/tests/fixtures/round1/03-enum-str.ts
@@ -1,0 +1,2 @@
+enum S { X = "x", Y = "y" }
+console.log(S.X, S.Y, S["x"], (S as any)["x"]);

--- a/tests/integration/tests/fixtures/round1/04-namespace-merge.ts
+++ b/tests/integration/tests/fixtures/round1/04-namespace-merge.ts
@@ -1,0 +1,3 @@
+namespace N { export const a = 1; }
+namespace N { export const b = 2; }
+console.log(N.a, N.b);

--- a/tests/integration/tests/fixtures/round1/05-param-props.ts
+++ b/tests/integration/tests/fixtures/round1/05-param-props.ts
@@ -1,0 +1,5 @@
+class P {
+  constructor(public x: number, private y: string, readonly z: boolean) {}
+  show() { return `${this.x}/${this.y}/${this.z}`; }
+}
+console.log(new P(1, "a", true).show());

--- a/tests/integration/tests/fixtures/round1/06-private-fields.ts
+++ b/tests/integration/tests/fixtures/round1/06-private-fields.ts
@@ -1,0 +1,8 @@
+class C {
+  #x = 1;
+  static #y = 2;
+  get(){ return C.#y + this.#x; }
+  static stat(){ return C.#y; }
+}
+const c = new C();
+console.log(c.get(), C.stat());

--- a/tests/integration/tests/fixtures/round1/07-static-block.ts
+++ b/tests/integration/tests/fixtures/round1/07-static-block.ts
@@ -1,0 +1,6 @@
+class S {
+  static a = 1;
+  static b: number;
+  static { this.b = this.a + 10; }
+}
+console.log(S.a, S.b);

--- a/tests/integration/tests/fixtures/round1/08-getter-setter.ts
+++ b/tests/integration/tests/fixtures/round1/08-getter-setter.ts
@@ -1,0 +1,9 @@
+let log: string[] = [];
+class G {
+  _x = 0;
+  get x(){ log.push("get"); return this._x; }
+  set x(v: number){ log.push("set:" + v); this._x = v; }
+}
+const g = new G();
+g.x = 5; g.x += 2;
+console.log(g.x, log.join(","));

--- a/tests/integration/tests/fixtures/round1/09-super-arrow.ts
+++ b/tests/integration/tests/fixtures/round1/09-super-arrow.ts
@@ -1,0 +1,8 @@
+class A { greet(){ return "A"; } }
+class B extends A {
+  greet(){
+    const f = () => super.greet() + "/B";
+    return f();
+  }
+}
+console.log(new B().greet());

--- a/tests/integration/tests/fixtures/round1/10-logical-assign.ts
+++ b/tests/integration/tests/fixtures/round1/10-logical-assign.ts
@@ -1,0 +1,9 @@
+let a: any = null;
+let b: any = 0;
+let c: any = undefined;
+a ??= 1; b ||= 2; c &&= 3;
+console.log(a, b, c);
+let o: any = {};
+o.x ??= 10;
+o.x ??= 99;
+console.log(o.x);

--- a/tests/integration/tests/fixtures/round1/11-optional-chain.ts
+++ b/tests/integration/tests/fixtures/round1/11-optional-chain.ts
@@ -1,0 +1,6 @@
+const o: any = { a: { b: { c: () => 42 } } };
+console.log(o?.a?.b?.c?.());
+console.log(o?.x?.y?.z);
+console.log(o?.a?.["b"]?.c?.());
+const fn: any = null;
+console.log(fn?.(1, 2));

--- a/tests/integration/tests/fixtures/round1/12-tagged-template.ts
+++ b/tests/integration/tests/fixtures/round1/12-tagged-template.ts
@@ -1,0 +1,4 @@
+function tag(s: TemplateStringsArray, ...v: any[]) {
+  return [s.join("|"), s.raw.join("|"), v.join(",")].join("##");
+}
+console.log(tag`a\nb${1}c\td${2}e`);

--- a/tests/integration/tests/fixtures/round1/13-regex-named.ts
+++ b/tests/integration/tests/fixtures/round1/13-regex-named.ts
@@ -1,0 +1,3 @@
+const r = /(?<year>\d{4})-(?<month>\d{2})/d;
+const m = "2026-04".match(r);
+console.log(m?.groups?.year, m?.groups?.month, (m as any)?.indices?.groups?.year?.[0]);

--- a/tests/integration/tests/fixtures/round1/14-bigint.ts
+++ b/tests/integration/tests/fixtures/round1/14-bigint.ts
@@ -1,0 +1,3 @@
+const a = 9007199254740993n;
+const b = 2n ** 64n;
+console.log(a + 1n, b, b * b, typeof a);

--- a/tests/integration/tests/fixtures/round1/15-spread-order.ts
+++ b/tests/integration/tests/fixtures/round1/15-spread-order.ts
@@ -1,0 +1,6 @@
+const log: string[] = [];
+const get = (k: string, v: any) => { log.push(k); return { [k]: v }; };
+const o = { a: 1, ...get("b", 2), c: 3, ...get("a", 99) };
+console.log(JSON.stringify(o), log.join(","));
+const arr = [...[1,2], 3, ...[4,5]];
+console.log(arr.join(","));

--- a/tests/integration/tests/fixtures/round1/16-destructure.ts
+++ b/tests/integration/tests/fixtures/round1/16-destructure.ts
@@ -1,0 +1,6 @@
+const { a: x = 10, b: { c: y = 20 } = {} } = { a: undefined, b: { c: 5 } } as any;
+console.log(x, y);
+const [, , z = 99] = [1, 2];
+console.log(z);
+const { ...rest } = { a: 1, b: 2 };
+console.log(JSON.stringify(rest));

--- a/tests/integration/tests/fixtures/round1/17-for-of-let.ts
+++ b/tests/integration/tests/fixtures/round1/17-for-of-let.ts
@@ -1,0 +1,6 @@
+const fns: (() => number)[] = [];
+for (let i = 0; i < 3; i++) fns.push(() => i);
+console.log(fns.map(f => f()).join(","));
+const arr: (() => string)[] = [];
+for (const k of ["a","b","c"]) arr.push(() => k);
+console.log(arr.map(f => f()).join(","));

--- a/tests/integration/tests/fixtures/round1/18-generator.ts
+++ b/tests/integration/tests/fixtures/round1/18-generator.ts
@@ -1,0 +1,6 @@
+function* gen() { yield 1; yield 2; yield* [3, 4]; return 99; }
+const out: any[] = [];
+const g = gen();
+for (let v = g.next(); !v.done; v = g.next()) out.push(v.value);
+out.push(g.next().value);
+console.log(out.join(","));

--- a/tests/integration/tests/fixtures/round1/19-async-iter.ts
+++ b/tests/integration/tests/fixtures/round1/19-async-iter.ts
@@ -1,0 +1,7 @@
+async function run() {
+  async function* gen() { yield 1; yield 2; yield 3; }
+  let sum = 0;
+  for await (const v of gen()) sum += v;
+  return sum;
+}
+run().then(s => console.log(s));

--- a/tests/integration/tests/fixtures/round1/20-precedence.ts
+++ b/tests/integration/tests/fixtures/round1/20-precedence.ts
@@ -1,0 +1,6 @@
+console.log(2 ** 3 ** 2);
+console.log(-(2 ** 3));
+const a: any = null, b: any = 0, c = 5;
+console.log((a ?? b) || c, a ?? (b || c));
+console.log(typeof "x" + "y");
+console.log("a" + 1 + 2, 1 + 2 + "a");

--- a/tests/integration/tests/fixtures/round1/21-tdz.ts
+++ b/tests/integration/tests/fixtures/round1/21-tdz.ts
@@ -1,0 +1,13 @@
+try {
+  // @ts-ignore
+  console.log(x);
+  let x = 1;
+} catch (e: any) {
+  console.log("TDZ:", e.constructor.name);
+}
+const make = () => {
+  let count = 0;
+  return () => ++count;
+};
+const c = make();
+console.log(c(), c(), c());

--- a/tests/integration/tests/fixtures/round1/22-class-expr.ts
+++ b/tests/integration/tests/fixtures/round1/22-class-expr.ts
@@ -1,0 +1,6 @@
+const Foo = class Bar {
+  static name2 = "Bar-static";
+  who() { return Bar.name2; }
+};
+const f = new Foo();
+console.log(f.who(), Foo.name);

--- a/tests/integration/tests/fixtures/round1/23-computed-key.ts
+++ b/tests/integration/tests/fixtures/round1/23-computed-key.ts
@@ -1,0 +1,7 @@
+const sym = Symbol("k");
+const o = {
+  [sym]: 1,
+  ["a" + "b"]: 2,
+  [Symbol.iterator]() { let i = 0; return { next: () => ({ value: i++, done: i > 3 }) }; }
+};
+console.log((o as any)[sym], (o as any).ab, [...(o as any)].join(","));

--- a/tests/integration/tests/fixtures/round1/24-jsx.tsx
+++ b/tests/integration/tests/fixtures/round1/24-jsx.tsx
@@ -1,0 +1,13 @@
+const React = {
+  createElement(type: any, props: any, ...children: any[]) {
+    return { type, props: props || {}, children };
+  },
+  Fragment: "Fragment"
+};
+const el = (
+  <>
+    <div className="a" {...{ id: "x" }}>hello {1 + 2}</div>
+    <span />
+  </>
+);
+console.log(JSON.stringify(el));

--- a/tests/integration/tests/fixtures/round1/25-string-escape.ts
+++ b/tests/integration/tests/fixtures/round1/25-string-escape.ts
@@ -1,0 +1,3 @@
+const s1 = "a\tb\nc\\d\"eéf\u{1f600}g";
+const s2 = `tpl ${"x"} \\${"y"} \r raw`;
+console.log(s1.length, s2.length, JSON.stringify(s1), JSON.stringify(s2));

--- a/tests/integration/tests/fixtures/round1/26-numeric.ts
+++ b/tests/integration/tests/fixtures/round1/26-numeric.ts
@@ -1,0 +1,2 @@
+console.log(0.1 + 0.2, 1e21, 0xff, 0o17, 0b101, 1_000_000, .5, 5., 1.5e2);
+console.log(Number.MAX_SAFE_INTEGER, Number.MIN_VALUE);

--- a/tests/integration/tests/fixtures/round1/27-asi.ts
+++ b/tests/integration/tests/fixtures/round1/27-asi.ts
@@ -1,0 +1,15 @@
+function f() {
+  return
+    1
+}
+console.log(f());
+
+const a = 1
+const b = 2
+;[a, b].forEach(x => console.log(x))
+
+const c = [1,2,3]
+const d = c
+  .map(x => x * 2)
+  .reduce((s, x) => s + x, 0)
+console.log(d);

--- a/tests/integration/tests/fixtures/round1/28-try-catch.ts
+++ b/tests/integration/tests/fixtures/round1/28-try-catch.ts
@@ -1,0 +1,7 @@
+function attempt(): string {
+  try { throw new Error("boom"); }
+  catch { return "caught-no-binding"; }
+  finally { /* nothing */ }
+}
+console.log(attempt());
+try { throw "raw"; } catch (e: any) { console.log(typeof e, e); }

--- a/tests/integration/tests/fixtures/round1/29-default-export-fn.ts
+++ b/tests/integration/tests/fixtures/round1/29-default-export-fn.ts
@@ -1,0 +1,1 @@
+export default function () { return 42; }

--- a/tests/integration/tests/fixtures/round1/30-import-meta.ts
+++ b/tests/integration/tests/fixtures/round1/30-import-meta.ts
@@ -1,0 +1,1 @@
+console.log(typeof import.meta, typeof import.meta.url === "string" ? "url-string" : "no-url");

--- a/tests/integration/tests/fixtures/round1/31-labeled.ts
+++ b/tests/integration/tests/fixtures/round1/31-labeled.ts
@@ -1,0 +1,9 @@
+const out: number[] = [];
+outer: for (let i = 0; i < 3; i++) {
+  for (let j = 0; j < 3; j++) {
+    if (i === 1 && j === 1) continue outer;
+    if (i === 2 && j === 2) break outer;
+    out.push(i * 10 + j);
+  }
+}
+console.log(out.join(","));

--- a/tests/integration/tests/fixtures/round1/32-satisfies.ts
+++ b/tests/integration/tests/fixtures/round1/32-satisfies.ts
@@ -1,0 +1,3 @@
+type C = Record<string, number | string>;
+const data = { a: 1, b: "two", c: 3 } satisfies C;
+console.log(data.a + 1, data.b.toUpperCase());

--- a/tests/integration/tests/fixtures/round1/33-as-const.ts
+++ b/tests/integration/tests/fixtures/round1/33-as-const.ts
@@ -1,0 +1,3 @@
+const xs = [1, 2, 3] as const;
+const t = { name: "x", value: 5 } as const;
+console.log(xs.join(","), t.name, t.value);

--- a/tests/integration/tests/fixtures/round1/34-decorator-legacy.ts
+++ b/tests/integration/tests/fixtures/round1/34-decorator-legacy.ts
@@ -1,0 +1,12 @@
+function tag(label: string) {
+  return function (target: any, key?: string) {
+    target.__tags = target.__tags || [];
+    target.__tags.push(label + ":" + (key || "class"));
+  };
+}
+@tag("cls")
+class D {
+  @tag("m")
+  hi() { return "hi"; }
+}
+console.log((D.prototype as any).__tags?.join("|"), new D().hi());

--- a/tests/integration/tests/fixtures/round1/35-arrow-vs-paren.ts
+++ b/tests/integration/tests/fixtures/round1/35-arrow-vs-paren.ts
@@ -1,0 +1,4 @@
+const f = (x: number, y: number = 5) => x + y;
+const g: (n: number) => number = (n) => n * 2;
+const h = <T,>(x: T): T => x;
+console.log(f(1), f(1, 2), g(3), h("z"));

--- a/tests/integration/tests/fixtures/round2/01-namespace-merge.ts
+++ b/tests/integration/tests/fixtures/round2/01-namespace-merge.ts
@@ -1,0 +1,4 @@
+// TS namespace merging — same name can merge values across declarations
+namespace M { export const x = 1; export function inc(n: number) { return n + x; } }
+namespace M { export const y = 2; export function dec(n: number) { return n - y; } }
+console.log(M.x, M.y, M.inc(10), M.dec(10));

--- a/tests/integration/tests/fixtures/round2/02-namespace-nested.ts
+++ b/tests/integration/tests/fixtures/round2/02-namespace-nested.ts
@@ -1,0 +1,2 @@
+namespace A { export namespace B { export const v = 5; export function nest() { return v * 2; } } export const top = B.v + 100; }
+console.log(A.B.v, A.B.nest(), A.top);

--- a/tests/integration/tests/fixtures/round2/03-abstract-override.ts
+++ b/tests/integration/tests/fixtures/round2/03-abstract-override.ts
@@ -1,0 +1,3 @@
+abstract class Base { abstract greet(): string; common() { return "common:" + this.greet(); } }
+class Impl extends Base { override greet() { return "impl"; } }
+console.log(new Impl().common());

--- a/tests/integration/tests/fixtures/round2/04-using.ts
+++ b/tests/integration/tests/fixtures/round2/04-using.ts
@@ -1,0 +1,5 @@
+// ES2026 explicit resource management
+const log: string[] = [];
+class R { [Symbol.dispose]() { log.push("disposed"); } }
+{ using r = new R(); log.push("inside"); }
+console.log(log.join(","));

--- a/tests/integration/tests/fixtures/round2/05-await-using.ts
+++ b/tests/integration/tests/fixtures/round2/05-await-using.ts
@@ -1,0 +1,7 @@
+async function run() {
+  const log: string[] = [];
+  class R { async [Symbol.asyncDispose]() { log.push("async-disposed"); } }
+  { await using r = new R(); log.push("inside"); }
+  return log.join(",");
+}
+run().then(s => console.log(s));

--- a/tests/integration/tests/fixtures/round2/06-iterator-helpers.ts
+++ b/tests/integration/tests/fixtures/round2/06-iterator-helpers.ts
@@ -1,0 +1,4 @@
+// ES2025 Iterator helpers
+function* gen() { yield 1; yield 2; yield 3; yield 4; yield 5; }
+const r = (gen() as any).filter((x: number) => x % 2).map((x: number) => x * 10).toArray();
+console.log(r);

--- a/tests/integration/tests/fixtures/round2/07-set-methods.ts
+++ b/tests/integration/tests/fixtures/round2/07-set-methods.ts
@@ -1,0 +1,6 @@
+// ES2025 Set methods
+const a = new Set([1, 2, 3, 4]);
+const b = new Set([3, 4, 5, 6]);
+console.log([...(a as any).intersection(b)].sort().join(","));
+console.log([...(a as any).union(b)].sort((x: any, y: any) => x - y).join(","));
+console.log([...(a as any).difference(b)].sort().join(","));

--- a/tests/integration/tests/fixtures/round2/08-regex-v.ts
+++ b/tests/integration/tests/fixtures/round2/08-regex-v.ts
@@ -1,0 +1,3 @@
+// ES2024 /v flag — set notation
+const re = /[\p{L}--[a-z]]/v;
+console.log(re.test("A"), re.test("a"), re.test("Δ"));

--- a/tests/integration/tests/fixtures/round2/09-import-meta-url.ts
+++ b/tests/integration/tests/fixtures/round2/09-import-meta-url.ts
@@ -1,0 +1,1 @@
+console.log(typeof import.meta.url, import.meta.url.length > 0);

--- a/tests/integration/tests/fixtures/round2/10-pure-annotation.ts
+++ b/tests/integration/tests/fixtures/round2/10-pure-annotation.ts
@@ -1,0 +1,3 @@
+function effect() { console.log("called"); return 1; }
+const dead = /* @__PURE__ */ effect();
+console.log("done");

--- a/tests/integration/tests/fixtures/round2/11-precedence-edge.ts
+++ b/tests/integration/tests/fixtures/round2/11-precedence-edge.ts
@@ -1,0 +1,7 @@
+const a = 0, b = null, c = 5;
+console.log(a ?? b ?? c);
+console.log(2 ** 3 ** 2);
+console.log(-(2 ** 3));
+console.log(typeof typeof "x");
+console.log("y" in { y: 1 }, !"y" in { y: 1 });
+console.log(1 + 2 * 3, (1 + 2) * 3);

--- a/tests/integration/tests/fixtures/round2/12-assignment-target.ts
+++ b/tests/integration/tests/fixtures/round2/12-assignment-target.ts
@@ -1,0 +1,4 @@
+let arr = [1, 2, 3]; let obj: any = { a: 1 };
+[arr[0], arr[1]] = [arr[1], arr[0]];
+({ a: obj.b, c: obj.d = 99 } = { a: 10, c: undefined });
+console.log(arr.join(","), JSON.stringify(obj));

--- a/tests/integration/tests/fixtures/round2/13-private-brand.ts
+++ b/tests/integration/tests/fixtures/round2/13-private-brand.ts
@@ -1,0 +1,3 @@
+class C { #x = 1; static has(o: any) { return #x in o; } }
+const c1 = new C(); const c2: any = {};
+console.log(C.has(c1), C.has(c2), C.has({ x: 1 }));

--- a/tests/integration/tests/fixtures/round2/14-static-block-order.ts
+++ b/tests/integration/tests/fixtures/round2/14-static-block-order.ts
@@ -1,0 +1,3 @@
+const log: string[] = [];
+class A { static { log.push("A1"); } static x = (log.push("Ax"), 1); static { log.push("A2"); } }
+console.log(log.join(","), A.x);

--- a/tests/integration/tests/fixtures/round2/15-async-finally.ts
+++ b/tests/integration/tests/fixtures/round2/15-async-finally.ts
@@ -1,0 +1,7 @@
+async function f() {
+  try { return 1; } finally { /* return 2 in finally would override */ }
+}
+async function g() {
+  try { return 1; } finally { return 2; }
+}
+Promise.all([f(), g()]).then(([a, b]) => console.log(a, b));

--- a/tests/integration/tests/fixtures/round2/16-gen-return-finally.ts
+++ b/tests/integration/tests/fixtures/round2/16-gen-return-finally.ts
@@ -1,0 +1,6 @@
+function* g() {
+  try { yield 1; yield 2; yield 3; }
+  finally { /* @ts-ignore */ console.log("cleanup"); }
+}
+const it = g();
+console.log(it.next().value, it.return(99).value, it.next().done);

--- a/tests/integration/tests/fixtures/round2/17-string-codepoint.ts
+++ b/tests/integration/tests/fixtures/round2/17-string-codepoint.ts
@@ -1,0 +1,2 @@
+const s = "a\u{1F600}b\u{D83D}\u{DE00}c";
+console.log(s.length, [...s].length, s.codePointAt(1)?.toString(16));

--- a/tests/integration/tests/fixtures/round2/18-template-nested.ts
+++ b/tests/integration/tests/fixtures/round2/18-template-nested.ts
@@ -1,0 +1,4 @@
+const x = `${`${`${1}`}${2}`}${3}`;
+const tag = (s: TemplateStringsArray, ...v: any[]) => s.raw.join("|") + "##" + v.join(",");
+const y = tag`a${1}b${`${2}`}c`;
+console.log(x, y);

--- a/tests/integration/tests/fixtures/round2/19-numeric-edge.ts
+++ b/tests/integration/tests/fixtures/round2/19-numeric-edge.ts
@@ -1,0 +1,2 @@
+console.log(1e21, 1e-7, 0.1 + 0.2, Number.MIN_VALUE, 9007199254740993, 0xffffffff);
+console.log(0o17, 0b1010, 1_000_000, 1.5e-10);

--- a/tests/integration/tests/fixtures/round2/20-sequence-comma.ts
+++ b/tests/integration/tests/fixtures/round2/20-sequence-comma.ts
@@ -1,0 +1,4 @@
+const x = (1, 2, 3);
+const arr = [(4, 5), (6, 7)];
+const fn = (a: number) => (a + 1, a + 2);
+console.log(x, arr, fn(10));

--- a/tests/integration/tests/fixtures/round2/21-throw-finally.ts
+++ b/tests/integration/tests/fixtures/round2/21-throw-finally.ts
@@ -1,0 +1,6 @@
+function attempt() {
+  try { throw new Error("a"); }
+  catch { throw new Error("b"); }
+  finally { /* swallow? no, throws are independent */ }
+}
+try { attempt(); } catch (e: any) { console.log(e.message); }

--- a/tests/integration/tests/fixtures/round2/22-optional-chain-call.ts
+++ b/tests/integration/tests/fixtures/round2/22-optional-chain-call.ts
@@ -1,0 +1,5 @@
+const o: any = { f: () => 42, g: null };
+console.log(o?.f?.());
+console.log(o?.g?.());
+console.log((o?.h as any)?.());
+console.log(o?.f?.()?.toFixed?.(2));

--- a/tests/integration/tests/fixtures/round2/23-class-fields-init-order.ts
+++ b/tests/integration/tests/fixtures/round2/23-class-fields-init-order.ts
@@ -1,0 +1,5 @@
+// ECMAScript: instance field init in source order, after super()
+class P { x = 1; y = this.x + 1; constructor() { /* fields run before this */ } }
+class C extends P { z = (this.x || 0) + 100; }
+const c = new C();
+console.log(c.x, (c as any).y, (c as any).z);

--- a/tests/integration/tests/fixtures/round2/24-arguments-arrow.ts
+++ b/tests/integration/tests/fixtures/round2/24-arguments-arrow.ts
@@ -1,0 +1,6 @@
+function outer() {
+  const arrow = () => arguments.length;
+  function inner() { return arguments.length; }
+  return [arrow(), inner(99, 100)];
+}
+console.log((outer as any)(1, 2, 3));

--- a/tests/integration/tests/fixtures/round2/25-tagged-raw.ts
+++ b/tests/integration/tests/fixtures/round2/25-tagged-raw.ts
@@ -1,0 +1,2 @@
+const tag = (s: TemplateStringsArray, ..._v: any[]) => [s.join("|"), s.raw.join("|")].join("##");
+console.log(tag`a\nbéc\td`);

--- a/tests/integration/tests/fixtures/round2/26-symbol-iter.ts
+++ b/tests/integration/tests/fixtures/round2/26-symbol-iter.ts
@@ -1,0 +1,2 @@
+class Range { constructor(public lo: number, public hi: number) {} *[Symbol.iterator]() { for (let i = this.lo; i <= this.hi; i++) yield i; } }
+console.log([...new Range(1, 5)].join(","));

--- a/tests/integration/tests/fixtures/round2/27-symbol-asynciter.ts
+++ b/tests/integration/tests/fixtures/round2/27-symbol-asynciter.ts
@@ -1,0 +1,7 @@
+async function run() {
+  const obj = { async *[Symbol.asyncIterator]() { yield 1; yield 2; yield 3; } };
+  let sum = 0;
+  for await (const v of obj) sum += v;
+  return sum;
+}
+run().then(n => console.log(n));

--- a/tests/integration/tests/fixtures/round2/28-getter-setter-symbol.ts
+++ b/tests/integration/tests/fixtures/round2/28-getter-setter-symbol.ts
@@ -1,0 +1,5 @@
+const log: string[] = [];
+const sym = Symbol("k");
+const o: any = { _x: 0, get [sym]() { log.push("g"); return this._x; }, set [sym](v: number) { log.push("s:" + v); this._x = v; } };
+o[sym] = 5; o[sym] += 3;
+console.log(o[sym], log.join(","));

--- a/tests/integration/tests/fixtures/round2/29-export-equals.ts
+++ b/tests/integration/tests/fixtures/round2/29-export-equals.ts
@@ -1,0 +1,3 @@
+// TS-only: export = ... (CJS interop)
+const value = { name: "exp-eq", n: 42 };
+export = value;

--- a/tests/integration/tests/fixtures/round2/30-import-equals.ts
+++ b/tests/integration/tests/fixtures/round2/30-import-equals.ts
@@ -1,0 +1,3 @@
+// TS-only: import x = require("...")
+import path = require("path");
+console.log(typeof path.join);

--- a/tests/integration/tests/fixtures/round2/31-decorator-stage3.ts
+++ b/tests/integration/tests/fixtures/round2/31-decorator-stage3.ts
@@ -1,0 +1,5 @@
+function trace<T extends (...args: any[]) => any>(target: T, ctx: ClassMethodDecoratorContext): T {
+  return function (this: any, ...args: any[]) { return "[" + String(ctx.name) + "]" + target.apply(this, args); } as T;
+}
+class C { @trace greet(n: string) { return "hi " + n; } }
+console.log(new C().greet("x"));

--- a/tests/integration/tests/fixtures/round2/32-decorator-accessor.ts
+++ b/tests/integration/tests/fixtures/round2/32-decorator-accessor.ts
@@ -1,0 +1,5 @@
+function autoinc(_t: ClassAccessorDecoratorTarget<any, any>, _c: ClassAccessorDecoratorContext): ClassAccessorDecoratorResult<any, any> {
+  return { get() { return (this as any).__c++; }, init(_v: any) { (this as any).__c = 0; return _v; } };
+}
+class C { @autoinc accessor v = 100; }
+const c = new C(); console.log(c.v, c.v, c.v);

--- a/tests/integration/tests/fixtures/round2/33-nested-destruct.ts
+++ b/tests/integration/tests/fixtures/round2/33-nested-destruct.ts
@@ -1,0 +1,2 @@
+const { a: { b: [c, , { d = 99 } = {} as any] } } = { a: { b: [1, 2, { d: undefined }] } } as any;
+console.log(c, d);

--- a/tests/integration/tests/fixtures/round2/34-spread-call-rest.ts
+++ b/tests/integration/tests/fixtures/round2/34-spread-call-rest.ts
@@ -1,0 +1,5 @@
+function f(...args: number[]) { return args.reduce((a, b) => a + b, 0); }
+const arr = [1, 2, 3];
+console.log(f(...arr, 4, 5, ...[6]));
+const [a, , ...rest] = [10, 20, 30, 40, 50];
+console.log(a, rest.join(","));

--- a/tests/integration/tests/fixtures/round2/35-strict-mode.ts
+++ b/tests/integration/tests/fixtures/round2/35-strict-mode.ts
@@ -1,0 +1,3 @@
+"use strict";
+function f() { try { (this as any).x = 1; return "no-throw"; } catch (e: any) { return e.constructor.name; } }
+console.log(f.call(null));

--- a/tests/integration/tests/fixtures/round4-sourcemap/01-simple.ts
+++ b/tests/integration/tests/fixtures/round4-sourcemap/01-simple.ts
@@ -1,0 +1,2 @@
+const greet = (name: string): string => "Hello, " + name;
+console.log(greet("world"));

--- a/tests/integration/tests/fixtures/round4-sourcemap/02-multiline.ts
+++ b/tests/integration/tests/fixtures/round4-sourcemap/02-multiline.ts
@@ -1,0 +1,10 @@
+function compute(
+  x: number,
+  y: number,
+  z: number,
+): number {
+  const sum = x + y + z;
+  const product = x * y * z;
+  return sum + product;
+}
+console.log(compute(1, 2, 3));

--- a/tests/integration/tests/fixtures/round4-sourcemap/03-class-method.ts
+++ b/tests/integration/tests/fixtures/round4-sourcemap/03-class-method.ts
@@ -1,0 +1,14 @@
+class Calculator {
+  result: number = 0;
+  add(n: number): this {
+    this.result += n;
+    return this;
+  }
+  multiply(n: number): this {
+    this.result *= n;
+    return this;
+  }
+}
+const calc = new Calculator();
+calc.add(5).multiply(3);
+console.log(calc.result);

--- a/tests/integration/tests/fixtures/round4-sourcemap/04-throw-error.ts
+++ b/tests/integration/tests/fixtures/round4-sourcemap/04-throw-error.ts
@@ -1,0 +1,14 @@
+function level3() {
+  throw new Error("boom");
+}
+function level2() {
+  level3();
+}
+function level1() {
+  level2();
+}
+try {
+  level1();
+} catch (e: any) {
+  console.log(e.stack?.split("\n").slice(0, 5).join("\n"));
+}

--- a/tests/integration/tests/fixtures/round4-sourcemap/05-jsx.tsx
+++ b/tests/integration/tests/fixtures/round4-sourcemap/05-jsx.tsx
@@ -1,0 +1,10 @@
+const React = { createElement: (t: any, p: any, ...c: any[]) => ({ t, p, c }), Fragment: "F" };
+function App() {
+  return (
+    <div>
+      <h1>Hello</h1>
+      <p>World</p>
+    </div>
+  );
+}
+console.log(JSON.stringify(App()));

--- a/tests/integration/tests/fixtures/round4-sourcemap/06-async.ts
+++ b/tests/integration/tests/fixtures/round4-sourcemap/06-async.ts
@@ -1,0 +1,12 @@
+async function fetchData(): Promise<string> {
+  await Promise.resolve();
+  throw new Error("async-fail");
+}
+async function main() {
+  try {
+    await fetchData();
+  } catch (e: any) {
+    console.log(e.message, e.stack?.split("\n")[1]?.trim());
+  }
+}
+main();

--- a/tests/integration/tests/fixtures/round4-sourcemap/07-decorator.ts
+++ b/tests/integration/tests/fixtures/round4-sourcemap/07-decorator.ts
@@ -1,0 +1,7 @@
+function tag(target: any, key?: string) {
+  target.__tagged = true;
+}
+class Foo {
+  @tag bar() { return 1; }
+}
+console.log((Foo.prototype as any).__tagged, new Foo().bar());

--- a/tests/integration/tests/fixtures/round4-sourcemap/08-template-literal.ts
+++ b/tests/integration/tests/fixtures/round4-sourcemap/08-template-literal.ts
@@ -1,0 +1,5 @@
+const name = "world";
+const greeting = `Hello,
+${name}!
+Multiline string`;
+console.log(greeting.length, greeting.split("\n").length);

--- a/tests/integration/tests/round1-fuzz.test.ts
+++ b/tests/integration/tests/round1-fuzz.test.ts
@@ -1,0 +1,31 @@
+/// Round 1 fuzz 회귀 테스트 — 35 fixture (전 세션에서 7 critical PR 도출).
+///
+/// fixture 카테고리: TS enum / namespace / parameter property / private fields /
+/// static block / getter-setter / super arrow / logical assign / decorator / JSX 등.
+/// 각 fixture 는 transpile → bun 실행 → stdout snapshot 으로 회귀 감지.
+import { describe, test, expect } from "bun:test";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { transpileAndRun } from "./helpers";
+
+const FIXTURES_DIR = join(import.meta.dir, "fixtures/round1");
+const fixtures = readdirSync(FIXTURES_DIR)
+  .filter((f) => /\.(ts|tsx)$/.test(f))
+  .sort();
+
+describe("Round 1 fuzz", () => {
+  for (const fix of fixtures) {
+    test(fix, async () => {
+      const source = readFileSync(join(FIXTURES_DIR, fix), "utf-8");
+      const ext = fix.endsWith(".tsx") ? "tsx" : "ts";
+      const r = await transpileAndRun(source, [], { ext });
+      try {
+        expect(r.transpileExitCode).toBe(0);
+        expect(r.runStderr).toBe("");
+        expect(r.runOutput).toMatchSnapshot();
+      } finally {
+        await r.cleanup();
+      }
+    });
+  }
+});

--- a/tests/integration/tests/round2-fuzz.test.ts
+++ b/tests/integration/tests/round2-fuzz.test.ts
@@ -1,0 +1,31 @@
+/// Round 2 fuzz 회귀 테스트 — 35 fixture (전 세션 검증 결과 0 ZTS-DIFF, clean).
+///
+/// fixture 카테고리: namespace 병합/중첩, abstract override, using/await using, iterator
+/// helpers, set methods, regex /v, import.meta.url, /* @__PURE__ */ annotation 등 ES2024+.
+/// clean baseline 을 회귀로 보호.
+import { describe, test, expect } from "bun:test";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { transpileAndRun } from "./helpers";
+
+const FIXTURES_DIR = join(import.meta.dir, "fixtures/round2");
+const fixtures = readdirSync(FIXTURES_DIR)
+  .filter((f) => /\.(ts|tsx)$/.test(f))
+  .sort();
+
+describe("Round 2 fuzz", () => {
+  for (const fix of fixtures) {
+    test(fix, async () => {
+      const source = readFileSync(join(FIXTURES_DIR, fix), "utf-8");
+      const ext = fix.endsWith(".tsx") ? "tsx" : "ts";
+      const r = await transpileAndRun(source, [], { ext });
+      try {
+        expect(r.transpileExitCode).toBe(0);
+        expect(r.runStderr).toBe("");
+        expect(r.runOutput).toMatchSnapshot();
+      } finally {
+        await r.cleanup();
+      }
+    });
+  }
+});

--- a/tests/integration/tests/round4-sourcemap.test.ts
+++ b/tests/integration/tests/round4-sourcemap.test.ts
@@ -1,0 +1,46 @@
+/// Round 4 sourcemap footer/file 회귀 테스트 — 8 fixture (PR #2217 영역).
+///
+/// 각 fixture 에 대해 `--sourcemap` 트랜스파일 후 검증:
+///   1. 출력 코드 끝에 `//# sourceMappingURL=...` footer 존재
+///   2. `.map` 파일이 spec 부합 (version=3, sources/sourcesContent 비어있지 않음, mappings 비어있지 않음)
+///   3. `map.file` 필드가 출력 파일 basename 과 일치
+import { describe, test, expect } from "bun:test";
+import { readFileSync, readdirSync } from "node:fs";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { runZts } from "./helpers";
+
+const FIXTURES_DIR = join(import.meta.dir, "fixtures/round4-sourcemap");
+const fixtures = readdirSync(FIXTURES_DIR)
+  .filter((f) => /\.(ts|tsx)$/.test(f))
+  .sort();
+
+describe("Round 4 sourcemap footer/file", () => {
+  for (const fix of fixtures) {
+    test(fix, async () => {
+      const sourceText = readFileSync(join(FIXTURES_DIR, fix), "utf-8");
+      const dir = await mkdtemp(join(tmpdir(), "zts-round4-"));
+      try {
+        const inFile = join(dir, fix);
+        await writeFile(inFile, sourceText);
+        const outFile = join(dir, fix.replace(/\.(ts|tsx)$/, ".js"));
+        const r = await runZts([inFile, "-o", outFile, "--sourcemap"]);
+        expect(r.exitCode).toBe(0);
+
+        const outText = readFileSync(outFile, "utf-8");
+        // footer
+        expect(outText).toMatch(/\/\/#\s*sourceMappingURL=.+\.map\s*$/);
+
+        const mapJson = JSON.parse(readFileSync(outFile + ".map", "utf-8"));
+        expect(mapJson.version).toBe(3);
+        expect(Array.isArray(mapJson.sources) && mapJson.sources.length > 0).toBe(true);
+        expect(typeof mapJson.mappings === "string" && mapJson.mappings.length > 0).toBe(true);
+        // map.file 은 출력 파일 basename 과 일치 (spec 권장)
+        expect(mapJson.file).toBe(basename(outFile));
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- 세 문서가 현재 디렉토리/테스트 구조와 어긋나 있어 한 번에 정합성 맞춤 (코드 변경 없음, docs only)
- 회귀 / 회귀에 가까운 잘못된 수치 두 군데도 검증 후 수정: smoke 케이스 (149 → **144**), tsc 통합 테스트 파일 (38 → **36**)

### README.md
- Status 라인을 Test262 50,504 / 50,504 통과, smoke **144** 케이스, 합성 벤치 (ZTS 7ms vs Bun 10ms / esbuild 13ms / rolldown 62ms) 로 갱신
- Goals: 24B 고정 AST, Producer-Consumer 파이프라인, Vite/Rollup/esbuild/Metro 호환 등 구체화
- Build 섹션에 `test262-run`, `wasm-bundler`, `schema` 누락된 스텝 추가 (`build.zig` 와 일치)
- Usage 예시에 `target` / `define` / `onResolve` / `onLoad` 등 실제 NAPI 시그니처 반영
- CLI 섹션 + Packages 표 (`@zts/core`, `@zts/wasm`, `@zts/shared`, `vite-plugin-zts`) 신설
- 문서 링크에 USAGE / CONFIG / AST_PLUGINS / INVARIANTS / DEBUG / FLOW 추가

### docs/STRUCTURE.md
- src/ 새 항목 반영: `app/`, `bench.zig`, `debug_log.zig`, `profile.zig`, `runtime_helper_*`, `test_arena/test_fixtures/test_regression`, `tsconfig_merge`, `util/wyhash`
- parser: `ast_walk.zig`, `scan_results.zig`
- transformer: `plugins/`, `transformer/worklet`, `regex_lower`, `unicode_escape_lower`, `es2018_for_await`, `es2022_tla`, `es2015_object_methods`, `runtime_helper_imports`, `plugin_state`, `ast_plugin`
- codegen: `private_mangler`, `unified_mangler`, `function_map`, codegen_test 신규 파일 (decorator/import_attributes/class_expr_anonymize/function_map/skip_nodes_blank)
- bundler: `module_list`, `compiled_module/compiled_cache`, `constant_facts`, `asset_meta`, `block_list`, `fs`, `phase`, `symbol`, `test_helpers` + emitter `cjs_wrap/external_imports` + bundler_test 신규 파일들
- packages: `core/{bin, src, dist, index.ts}`, `wasm/{wasm_entry, wasm_bundler_entry}`, `plugin/`
- tests: integration `tsc/`, `fixtures/`, e2e (sourcemap / vite-app / zts-app-builder), benchmark 모든 스크립트
- Build Steps 표 신설

### docs/TESTING.md
- `zig build test262` (러너 자체 유닛) ↔ `zig build test262-run` (50,504건 실행) 분리 (이전 문서 오기재)
- 유닛 테스트가 모듈 파일 하단이 아닌 별도 `*_test.zig` 분리되어 있는 현재 구조 반영
- 통합 테스트 60+ 스위트를 카테고리별 정리 (번들러 / 소스맵 / ES 타겟 / Hermes RN / Flow / RSC / dev 서버·HMR / Resolve / ESM · namespace / profile / CSS / round1·2 fuzz / tsc 36개)
- e2e 5종 (smoke / browser-smoke / sourcemap-e2e / vite-app-e2e / zts-app-builder-e2e)
- smoke **144** 케이스 + filter / keep-output 옵션, ReleaseFast-only 회귀 노트, CI 워크플로우 위치 보강

## 검증

- 핵심 수치는 직접 grep / 카운트로 재확인 (smoke `_fixtures.ts` projects 144, `tsc/` `*.test.ts` 36, AST 24B `@sizeOf(Node) == 24` assertion, build steps `b.step(...)` 호출, Producer-Consumer `mpsc_channel` 모듈)
- 코드 변경 없음 → CI 영향 없음

## Test plan

- [ ] GitHub 에서 README 렌더링 확인
- [ ] `docs/STRUCTURE.md` 의 디렉토리 트리가 `ls` 결과와 일치하는지 스폿 체크
- [ ] `docs/TESTING.md` 의 명령들이 실제로 동작하는지 (`zig build test262-run` / `bun test` / `bun run smoke.ts`) 확인