### PR TITLE
feat(app): support CSS Modules and Sass pipeline

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "postcss": "^8.5.8",
         "postcss-load-config": "^6.0.1",
         "react": "^19.0.0",
+        "sass": "^1.99.0",
         "styled-components": "^6.4.0",
         "tailwindcss": "^4.2.2",
         "typescript": "^6.0.3",
@@ -67,6 +68,7 @@
         "lightningcss": "^1.28.0",
         "postcss": "^8.5.8",
         "postcss-load-config": "^6.0.1",
+        "sass": "^1.99.0",
       },
     },
     "packages/wasm": {
@@ -714,6 +716,34 @@
     "@pagefind/windows-arm64": ["@pagefind/windows-arm64@1.5.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-kg+szZwffZdyWn6SL6RHjAYjhSvJ2bT4qkv3KepGsbmD9fuSHUSC+2kydDneDVUA9qEDRf9uSFoEAsXsp1/JKA=="],
 
     "@pagefind/windows-x64": ["@pagefind/windows-x64@1.5.0", "", { "os": "win32", "cpu": "x64" }, "sha512-8eOCmB8lnpyvwz+HrcTXLuBxhj7UseAFh6KGEXRe8UCcAfVQih+qPy/4akJRezViI+ONijz9oi7HpMkw9rdtBg=="],
+
+    "@parcel/watcher": ["@parcel/watcher@2.5.6", "", { "dependencies": { "detect-libc": "^2.0.3", "is-glob": "^4.0.3", "node-addon-api": "^7.0.0", "picomatch": "^4.0.3" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.6", "@parcel/watcher-darwin-arm64": "2.5.6", "@parcel/watcher-darwin-x64": "2.5.6", "@parcel/watcher-freebsd-x64": "2.5.6", "@parcel/watcher-linux-arm-glibc": "2.5.6", "@parcel/watcher-linux-arm-musl": "2.5.6", "@parcel/watcher-linux-arm64-glibc": "2.5.6", "@parcel/watcher-linux-arm64-musl": "2.5.6", "@parcel/watcher-linux-x64-glibc": "2.5.6", "@parcel/watcher-linux-x64-musl": "2.5.6", "@parcel/watcher-win32-arm64": "2.5.6", "@parcel/watcher-win32-ia32": "2.5.6", "@parcel/watcher-win32-x64": "2.5.6" } }, "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ=="],
+
+    "@parcel/watcher-android-arm64": ["@parcel/watcher-android-arm64@2.5.6", "", { "os": "android", "cpu": "arm64" }, "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A=="],
+
+    "@parcel/watcher-darwin-arm64": ["@parcel/watcher-darwin-arm64@2.5.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA=="],
+
+    "@parcel/watcher-darwin-x64": ["@parcel/watcher-darwin-x64@2.5.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg=="],
+
+    "@parcel/watcher-freebsd-x64": ["@parcel/watcher-freebsd-x64@2.5.6", "", { "os": "freebsd", "cpu": "x64" }, "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng=="],
+
+    "@parcel/watcher-linux-arm-glibc": ["@parcel/watcher-linux-arm-glibc@2.5.6", "", { "os": "linux", "cpu": "arm" }, "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ=="],
+
+    "@parcel/watcher-linux-arm-musl": ["@parcel/watcher-linux-arm-musl@2.5.6", "", { "os": "linux", "cpu": "arm" }, "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg=="],
+
+    "@parcel/watcher-linux-arm64-glibc": ["@parcel/watcher-linux-arm64-glibc@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA=="],
+
+    "@parcel/watcher-linux-arm64-musl": ["@parcel/watcher-linux-arm64-musl@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA=="],
+
+    "@parcel/watcher-linux-x64-glibc": ["@parcel/watcher-linux-x64-glibc@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ=="],
+
+    "@parcel/watcher-linux-x64-musl": ["@parcel/watcher-linux-x64-musl@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg=="],
+
+    "@parcel/watcher-win32-arm64": ["@parcel/watcher-win32-arm64@2.5.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q=="],
+
+    "@parcel/watcher-win32-ia32": ["@parcel/watcher-win32-ia32@2.5.6", "", { "os": "win32", "cpu": "ia32" }, "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g=="],
+
+    "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw=="],
 
     "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 
@@ -1405,7 +1435,7 @@
 
     "chevrotain-allstar": ["chevrotain-allstar@0.4.1", "", { "dependencies": { "lodash-es": "^4.17.21" }, "peerDependencies": { "chevrotain": "^12.0.0" } }, "sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA=="],
 
-    "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "chrome-trace-event": ["chrome-trace-event@1.0.4", "", {}, "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ=="],
 
@@ -2051,6 +2081,8 @@
 
     "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
 
+    "immutable": ["immutable@5.1.5", "", {}, "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A=="],
+
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "import-local": ["import-local@3.2.0", "", { "dependencies": { "pkg-dir": "^4.2.0", "resolve-cwd": "^3.0.0" }, "bin": { "import-local-fixture": "fixtures/cli.js" } }, "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA=="],
@@ -2491,6 +2523,8 @@
 
     "nlcst-to-string": ["nlcst-to-string@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0" } }, "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA=="],
 
+    "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
 
     "node-forge": ["node-forge@1.4.0", "", {}, "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ=="],
@@ -2703,7 +2737,7 @@
 
     "readable-stream": ["readable-stream@1.1.14", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.1", "isarray": "0.0.1", "string_decoder": "~0.10.x" } }, "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ=="],
 
-    "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
     "recast": ["recast@0.11.23", "", { "dependencies": { "ast-types": "0.9.6", "esprima": "~3.1.0", "private": "~0.1.5", "source-map": "~0.5.0" } }, "sha512-+nixG+3NugceyR8O1bLU45qs84JgI3+8EauyRZafLgC9XbdAOIVgwV1Pe2da0YzGo62KzWoZwUpVEQf6qNAXWA=="],
 
@@ -2830,6 +2864,8 @@
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "sass": ["sass@1.99.0", "", { "dependencies": { "chokidar": "^4.0.0", "immutable": "^5.1.5", "source-map-js": ">=0.6.2 <2.0.0" }, "optionalDependencies": { "@parcel/watcher": "^2.4.1" }, "bin": { "sass": "sass.js" } }, "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q=="],
 
     "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
 
@@ -3337,6 +3373,8 @@
 
     "@rspack/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.0.7", "", { "dependencies": { "@emnapi/core": "^1.5.0", "@emnapi/runtime": "^1.5.0", "@tybys/wasm-util": "^0.10.1" } }, "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw=="],
 
+    "@rspack/dev-server/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
     "@swc/cli/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "@swc/cli/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
@@ -3434,10 +3472,6 @@
     "bun-types/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "cacheable-request/keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
-
-    "chokidar/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
-
-    "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "cli/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
@@ -3577,8 +3611,6 @@
 
     "raw-body/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
-    "readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
-
     "recast/esprima": ["esprima@3.1.3", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-AWwVMNxwhN8+NIPQzAQZCm7RkLC4RbM3B1OobMuyp3i+w73X57KCKaVIxaRZb+DYCojq7rspo+fmuQfAboyhFg=="],
 
     "recast/source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
@@ -3649,6 +3681,8 @@
 
     "webpack-core/source-map": ["source-map@0.4.4", "", { "dependencies": { "amdefine": ">=0.0.4" } }, "sha512-Y8nIfcb1s/7DcobUz1yOO1GSp7gyL+D9zLHDehT7iRESqGSxjJ448Sg7rvfgsRJCnKLdSl11uGf0s9X80cH0/A=="],
 
+    "webpack-dev-server/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
     "webpack-dev-server/ipaddr.js": ["ipaddr.js@2.3.0", "", {}, "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg=="],
 
     "webpack-merge/flat": ["flat@5.0.2", "", { "bin": { "flat": "cli.js" } }, "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="],
@@ -3686,6 +3720,12 @@
     "@rspack/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 
     "@rspack/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
+
+    "@rspack/dev-server/chokidar/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "@rspack/dev-server/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "@rspack/dev-server/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "@swc/cli/minimatch/brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
 
@@ -3738,6 +3778,8 @@
     "@types/ws/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@zts/integration/@swc/cli/@xhmikosr/bin-wrapper": ["@xhmikosr/bin-wrapper@14.2.2", "", { "dependencies": { "@xhmikosr/bin-check": "^8.2.1", "@xhmikosr/downloader": "^16.1.1", "@xhmikosr/os-filter-obj": "^4.0.0", "binary-version-check": "^6.1.0" } }, "sha512-4me/0Tw0ORrrRLliLc1w6K0unrnclVaFAp69z8fNu1rcYtD/pKtI1lZWvZ8htiRQtqhoqxBiQ2qfkZBN8q2KAw=="],
+
+    "@zts/integration/@swc/cli/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
     "@zts/integration/@swc/cli/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
@@ -3925,6 +3967,12 @@
 
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
+    "webpack-dev-server/chokidar/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "webpack-dev-server/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "webpack-dev-server/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
     "webpack/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -3985,6 +4033,8 @@
 
     "@rspack/binding-wasm32-wasi/@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
 
+    "@rspack/dev-server/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
     "@swc/cli/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "@tailwindcss/vite/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA=="],
@@ -4004,6 +4054,12 @@
     "@zts/integration/@swc/cli/@xhmikosr/bin-wrapper/@xhmikosr/downloader": ["@xhmikosr/downloader@16.1.1", "", { "dependencies": { "@xhmikosr/archive-type": "^8.0.1", "@xhmikosr/decompress": "^11.1.1", "content-disposition": "^1.0.1", "defaults": "^2.0.2", "ext-name": "^5.0.0", "file-type": "^21.3.0", "filenamify": "^7.0.1", "get-stream": "^9.0.1", "got": "^14.6.6" } }, "sha512-1B2ZqYDpIHn9bjah48rEo33GbmoV8hufXap/3KHStgIM9R9/QDm1pajqDwEgqDORMl2eZ7Dpbz71Xi854y3m3Q=="],
 
     "@zts/integration/@swc/cli/@xhmikosr/bin-wrapper/@xhmikosr/os-filter-obj": ["@xhmikosr/os-filter-obj@4.0.0", "", { "dependencies": { "arch": "^3.0.0" } }, "sha512-CBJYipR5lrtQQZl9ylarWyh1qhcs/tMy9ydSHte/Hefn3ev8NMvS3ss+eqiXEoBr2wBVgKj2qjcViXO9P/8K4A=="],
+
+    "@zts/integration/@swc/cli/chokidar/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "@zts/integration/@swc/cli/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "@zts/integration/@swc/cli/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "@zts/integration/@swc/cli/minimatch/brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
 
@@ -4103,6 +4159,8 @@
 
     "ts-loader/chalk/supports-color/has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
+    "webpack-dev-server/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
     "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "@zts/integration/@swc/cli/@xhmikosr/bin-wrapper/@xhmikosr/bin-check/execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
@@ -4122,6 +4180,8 @@
     "@zts/integration/@swc/cli/@xhmikosr/bin-wrapper/@xhmikosr/downloader/get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
     "@zts/integration/@swc/cli/@xhmikosr/bin-wrapper/@xhmikosr/downloader/got": ["got@14.6.6", "", { "dependencies": { "@sindresorhus/is": "^7.0.1", "byte-counter": "^0.1.0", "cacheable-lookup": "^7.0.0", "cacheable-request": "^13.0.12", "decompress-response": "^10.0.0", "form-data-encoder": "^4.0.2", "http2-wrapper": "^2.2.1", "keyv": "^5.5.3", "lowercase-keys": "^3.0.0", "p-cancelable": "^4.0.1", "responselike": "^4.0.2", "type-fest": "^4.26.1" } }, "sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg=="],
+
+    "@zts/integration/@swc/cli/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "@zts/integration/@swc/cli/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/documents/src/content/docs/en/guides/migration.md
+++ b/documents/src/content/docs/en/guides/migration.md
@@ -247,7 +247,7 @@ To write native-style plugins, use `setup(build) { build.onLoad(...) }`.
 | CSS Modules (`.module.css`) | Supported in app mode. Provides default exports and valid named exports |
 | CSS `@import` | Built-in Lightning CSS or `--loader:.css=text` |
 | PostCSS (`postcss.config.js`) | Supported in app mode. `zts dev` watches PostCSS dependencies and sends CSS-only HMR |
-| Sass/Less/Stylus | Not supported. Pre-compile before build |
+| Sass/Less/Stylus | Sass/SCSS is supported in app mode. Less/Stylus are not supported |
 | `public/` static directory | Supported in app mode (`--public-dir`) |
 | HTML entry (`index.html`) | Supported in app mode (`--entry-html`) |
 | SPA fallback | `zts preview --spa-fallback` |
@@ -296,7 +296,7 @@ module.exports = {
 | `raw-loader` / `asset/source` | `--loader:.txt=text` |
 | `svg-loader` / `@svgr/webpack` | `--loader:.svg=text`/`file`/`dataurl` or plugin |
 | `json-loader` | `--loader:.json=json` (built-in default) |
-| `sass-loader` / `less-loader` / `stylus-loader` | Not supported. Pre-compile needed |
+| `sass-loader` / `less-loader` / `stylus-loader` | Sass/SCSS is supported in app mode. Pre-compile Less/Stylus |
 | `postcss-loader` | Not supported. Replaced by Lightning CSS post-processing |
 | `html-loader` | Not supported. `--loader:.html=text` for string conversion |
 | `worker-loader` | Not supported (general Worker bundle support separate) |

--- a/documents/src/content/docs/en/guides/migration.md
+++ b/documents/src/content/docs/en/guides/migration.md
@@ -244,7 +244,7 @@ To write native-style plugins, use `setup(build) { build.onLoad(...) }`.
 | `@vitejs/plugin-react` Fast Refresh | Built-in HMR (React Refresh) |
 | `@vitejs/plugin-vue` | Not supported |
 | `@vitejs/plugin-legacy` | Partial via `--target=es5` etc. |
-| CSS Modules (`.module.css`) | Not supported. `.module.css` fails explicitly |
+| CSS Modules (`.module.css`) | Supported in app mode. Provides default exports and valid named exports |
 | CSS `@import` | Built-in Lightning CSS or `--loader:.css=text` |
 | PostCSS (`postcss.config.js`) | Supported in app mode. `zts dev` watches PostCSS dependencies and sends CSS-only HMR |
 | Sass/Less/Stylus | Not supported. Pre-compile before build |

--- a/documents/src/content/docs/en/guides/plugin-recipes.md
+++ b/documents/src/content/docs/en/guides/plugin-recipes.md
@@ -137,9 +137,9 @@ zts dev
 zts build
 ```
 
-CSS Modules (`.module.css`) are still outside the app CSS pipeline scope. They
-fail explicitly instead of emitting incorrect JS; use plain CSS or transform them
-through a JS plugin.
+App-mode CSS Modules (`.module.css`) are transformed into scoped class maps
+without a separate plugin. You can use the default export and valid named
+exports.
 
 For library builds that need to inject CSS from a JS plugin, run PostCSS from a
 `load` hook:

--- a/documents/src/content/docs/en/reference/cli.md
+++ b/documents/src/content/docs/en/reference/cli.md
@@ -50,8 +50,8 @@ If the app root contains `postcss.config.{js,mjs,cjs,json}` or `.postcssrc*`,
 ZTS automatically applies it to CSS. In `zts dev`, original CSS files and PostCSS
 `dependency` / `dir-dependency` messages are watched and CSS-only edits are sent
 as stylesheet HMR updates. Tailwind v4 works via `@tailwindcss/postcss`. CSS
-Modules (`.module.css`) are still outside the app CSS pipeline scope and fail
-explicitly.
+Modules (`.module.css`) in app mode are transformed into scoped class maps with
+default exports and valid named exports.
 
 ## I/O
 

--- a/documents/src/content/docs/en/reference/cli.md
+++ b/documents/src/content/docs/en/reference/cli.md
@@ -51,7 +51,8 @@ ZTS automatically applies it to CSS. In `zts dev`, original CSS files and PostCS
 `dependency` / `dir-dependency` messages are watched and CSS-only edits are sent
 as stylesheet HMR updates. Tailwind v4 works via `@tailwindcss/postcss`. CSS
 Modules (`.module.css`) in app mode are transformed into scoped class maps with
-default exports and valid named exports.
+default exports and valid named exports. `.scss` / `.sass` files are compiled to
+CSS before PostCSS when the optional `sass` dependency is installed.
 
 ## I/O
 

--- a/documents/src/content/docs/guides/migration.md
+++ b/documents/src/content/docs/guides/migration.md
@@ -244,7 +244,7 @@ export default defineConfig({
 | `@vitejs/plugin-react` Fast Refresh | HMR 내장 (React Refresh) |
 | `@vitejs/plugin-vue` | 미지원 |
 | `@vitejs/plugin-legacy` | `--target=es5` 등으로 일부 대응 |
-| CSS Modules (`.module.css`) | 미지원. `.module.css`는 명시적으로 에러 처리 |
+| CSS Modules (`.module.css`) | 앱 모드에서 지원. default export와 가능한 named export 제공 |
 | CSS `@import` | Lightning CSS 내장 후처리 또는 `--loader:.css=text` |
 | PostCSS (`postcss.config.js`) | 앱 모드에서 지원. `zts dev`는 PostCSS dependency watch와 CSS-only HMR 지원 |
 | Sass/Less/Stylus | 미지원. 빌드 전 사전 컴파일 필요 |

--- a/documents/src/content/docs/guides/migration.md
+++ b/documents/src/content/docs/guides/migration.md
@@ -247,7 +247,7 @@ export default defineConfig({
 | CSS Modules (`.module.css`) | 앱 모드에서 지원. default export와 가능한 named export 제공 |
 | CSS `@import` | Lightning CSS 내장 후처리 또는 `--loader:.css=text` |
 | PostCSS (`postcss.config.js`) | 앱 모드에서 지원. `zts dev`는 PostCSS dependency watch와 CSS-only HMR 지원 |
-| Sass/Less/Stylus | 미지원. 빌드 전 사전 컴파일 필요 |
+| Sass/Less/Stylus | Sass/SCSS는 앱 모드에서 지원. Less/Stylus는 미지원 |
 | `public/` 정적 디렉토리 | 앱 모드에서 지원 (`--public-dir`) |
 | HTML 엔트리 (`index.html`) | 앱 모드에서 지원 (`--entry-html`) |
 | SPA fallback | `zts preview --spa-fallback` |
@@ -296,7 +296,7 @@ module.exports = {
 | `raw-loader` / `asset/source` | `--loader:.txt=text` |
 | `svg-loader` / `@svgr/webpack` | `--loader:.svg=text`/`file`/`dataurl` 또는 플러그인 |
 | `json-loader` | `--loader:.json=json` (기본 내장) |
-| `sass-loader` / `less-loader` / `stylus-loader` | 미지원. 사전 컴파일 필요 |
+| `sass-loader` / `less-loader` / `stylus-loader` | Sass/SCSS는 앱 모드에서 지원. Less/Stylus는 사전 컴파일 필요 |
 | `postcss-loader` | 미지원. Lightning CSS 플러그인으로 대체 |
 | `html-loader` | 미지원. `--loader:.html=text` 로 문자열화는 가능 |
 | `worker-loader` | 미지원 (Bundle 내 Worker 일반 지원은 별도) |

--- a/documents/src/content/docs/guides/plugin-recipes.md
+++ b/documents/src/content/docs/guides/plugin-recipes.md
@@ -137,8 +137,8 @@ zts dev
 zts build
 ```
 
-CSS Modules(`.module.css`)는 아직 app CSS pipeline 범위 밖입니다. 현재는 조용히 잘못된
-JS를 내보내지 않도록 명시적으로 실패하며, plain CSS 또는 JS 플러그인 변환을 사용하세요.
+앱 모드의 CSS Modules(`.module.css`)는 별도 플러그인 없이 scoped class map으로
+변환됩니다. default export와 유효한 식별자 형태의 named export를 사용할 수 있습니다.
 
 CSS를 JS 플러그인에서 직접 주입해야 하는 라이브러리 빌드는 다음처럼 `load` 훅에서
 PostCSS를 실행할 수 있습니다.

--- a/documents/src/content/docs/reference/cli.md
+++ b/documents/src/content/docs/reference/cli.md
@@ -51,6 +51,7 @@ HTML asset URL, `%ENV%` 토큰을 rewrite하며 static split chunk는 `modulepre
 watch하고 CSS-only 변경은 stylesheet HMR로 보냅니다. Tailwind v4는
 `@tailwindcss/postcss` 설정을 지원합니다. 앱 모드는 CSS Modules(`.module.css`)를
 scoped class map으로 변환하며 default export와 가능한 named export를 제공합니다.
+`.scss` / `.sass`는 선택 의존성 `sass`가 설치되어 있으면 PostCSS 전에 CSS로 컴파일됩니다.
 
 ## 입출력
 

--- a/documents/src/content/docs/reference/cli.md
+++ b/documents/src/content/docs/reference/cli.md
@@ -49,8 +49,8 @@ HTML asset URL, `%ENV%` 토큰을 rewrite하며 static split chunk는 `modulepre
 앱 root에 `postcss.config.{js,mjs,cjs,json}` 또는 `.postcssrc*`가 있으면 CSS에 자동
 적용됩니다. `zts dev`는 원본 CSS와 PostCSS `dependency` / `dir-dependency` 메시지를
 watch하고 CSS-only 변경은 stylesheet HMR로 보냅니다. Tailwind v4는
-`@tailwindcss/postcss` 설정을 지원합니다. CSS Modules(`.module.css`)는 아직 app CSS
-pipeline 범위 밖이며 명시적으로 에러 처리됩니다.
+`@tailwindcss/postcss` 설정을 지원합니다. 앱 모드는 CSS Modules(`.module.css`)를
+scoped class map으로 변환하며 default export와 가능한 named export를 제공합니다.
 
 ## 입출력
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "postcss": "^8.5.8",
     "postcss-load-config": "^6.0.1",
     "react": "^19.0.0",
+    "sass": "^1.99.0",
     "styled-components": "^6.4.0",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.3",

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -494,10 +494,15 @@ function createAppDevController(opts, root, configEnv) {
       primaryHref = result.primaryHref;
       return result;
     },
+    injectBundleCssLinks(bundleResult) {
+      injectAppDevBundleCssLinks(outdir, base, bundleResult);
+    },
     isPostcssConfig(absPath) {
       return POSTCSS_CONFIG_NAMES.includes(basename(absPath));
     },
     isCssOnlyChange(absPath) {
+      // CSS Modules 는 class 이름 매핑이 변할 수 있어 JS proxy 도 같이 재생성 필요 →
+      // CSS-only HMR 로 갈음할 수 없고 full reload 가 안전한 기본값.
       if (isCssModuleFile(absPath)) return false;
       if (absPath.endsWith(".css")) return true;
       if (cssDeps.has(absPath)) return true;
@@ -518,7 +523,7 @@ function joinUrl(base, rel) {
   return `${base}${rel}`;
 }
 
-function injectAppDevHmrClient(outdir) {
+function injectIntoDevHtml(outdir, build) {
   const htmlPath = join(outdir, "index.html");
   let html;
   try {
@@ -527,12 +532,32 @@ function injectAppDevHmrClient(outdir) {
     if (err?.code === "ENOENT") return;
     throw err;
   }
-  if (html.includes(APP_DEV_HMR_CLIENT_PATH)) return;
-  const tag = `<script type="module" src="${APP_DEV_HMR_CLIENT_PATH}"></script>`;
+  const tag = build(html);
+  if (!tag) return;
   const next = html.includes("</head>")
     ? html.replace("</head>", `${tag}\n</head>`)
     : html.replace("<script", `${tag}\n<script`);
   writeFileSync(htmlPath, next);
+}
+
+function injectAppDevHmrClient(outdir) {
+  injectIntoDevHtml(outdir, (html) => {
+    if (html.includes(APP_DEV_HMR_CLIENT_PATH)) return null;
+    return `<script type="module" src="${APP_DEV_HMR_CLIENT_PATH}"></script>`;
+  });
+}
+
+function injectAppDevBundleCssLinks(outdir, base, bundleResult) {
+  injectIntoDevHtml(outdir, (html) => {
+    const cssHrefs = [];
+    for (const file of bundleResult?.outputFiles ?? []) {
+      if (!file?.path || !isCssFile(file.path)) continue;
+      const href = joinUrl(base, basename(file.path));
+      if (!html.includes(`href="${href}"`) && !html.includes(`href='${href}'`)) cssHrefs.push(href);
+    }
+    if (cssHrefs.length === 0) return null;
+    return cssHrefs.map((href) => `<link rel="stylesheet" href="${href}">`).join("\n");
+  });
 }
 
 const APP_DEV_HMR_CLIENT = `
@@ -715,59 +740,138 @@ function requireFromAppOrCli(requireFromRoot, specifier) {
   }
 }
 
-function collectCssFiles(dir, skipDir = null) {
+function collectAppFiles(dir, { skipDir = null, predicate = () => true } = {}) {
   if (!existsSync(dir)) return [];
+  const skipResolved = skipDir ? resolve(skipDir) : null;
   const files = [];
-  for (const entry of readdirSync(dir)) {
-    if (entry === "node_modules" || entry === ".git") continue;
-    const path = join(dir, entry);
-    const stat = statSync(path);
-    if (skipDir && stat.isDirectory() && resolve(path) === resolve(skipDir)) continue;
-    if (stat.isDirectory()) {
-      files.push(...collectCssFiles(path, skipDir));
-    } else if (stat.isFile() && path.endsWith(".css")) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === ".git") continue;
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (skipResolved && resolve(path) === skipResolved) continue;
+      files.push(...collectAppFiles(path, { skipDir, predicate }));
+    } else if (entry.isFile() && predicate(path)) {
       files.push(path);
     }
   }
   return files;
 }
 
-function collectAppFiles(dir, { skipDir = null, predicate = () => true } = {}) {
-  if (!existsSync(dir)) return [];
-  const files = [];
-  for (const entry of readdirSync(dir)) {
-    if (entry === "node_modules" || entry === ".git") continue;
-    const path = join(dir, entry);
-    const stat = statSync(path);
-    if (skipDir && stat.isDirectory() && resolve(path) === resolve(skipDir)) continue;
-    if (stat.isDirectory()) {
-      files.push(...collectAppFiles(path, { skipDir, predicate }));
-    } else if (stat.isFile() && predicate(path)) {
-      files.push(path);
-    }
+const isCssFile = (path) => path.endsWith(".css");
+
+const CSS_PREPROCESSOR_EXTENSIONS = new Set([".scss", ".sass"]);
+
+function isCssPreprocessorFile(path) {
+  return CSS_PREPROCESSOR_EXTENSIONS.has(extname(path));
+}
+
+function cssPreprocessorOutputPath(file) {
+  return file.replace(/\.(?:scss|sass)$/i, ".css");
+}
+
+function cssPreprocessorProxyPath(file) {
+  return `${cssPreprocessorOutputPath(file)}.js`;
+}
+
+function loadSassCompiler(root) {
+  const requireFromRoot = createRequire(join(root, "package.json"));
+  return requireFromAppOrCli(requireFromRoot, "sass");
+}
+
+// HTML 은 `<link href="x.scss">` 를 그대로 컴파일된 CSS 로, JS/TS 는 dev `<style>` injection
+// 가 들어간 `.css.js` proxy 로 다른 확장자로 rewrite. CSS Modules 는 HTML 미지원이라
+// 같은 헬퍼를 쓰지 않는다 — 아래 transformCssModules 의 인라인 regex 참고.
+function rewriteSassReferences(sourceFiles) {
+  const pattern = /(["'])([^"']+\.(?:scss|sass))([?#][^"']*)?\1/g;
+  for (const source of sourceFiles) {
+    const input = readFileSync(source, "utf8");
+    const toExt = source.endsWith(".html") ? ".css" : ".css.js";
+    const output = input.replace(
+      pattern,
+      (_match, quote, spec, suffix = "") =>
+        `${quote}${spec.replace(/\.(?:scss|sass)$/i, toExt)}${suffix}${quote}`,
+    );
+    if (output !== input) writeFileSync(source, output);
   }
-  return files;
+}
+
+function isStyleReferenceSource(path) {
+  return /\.(?:html|mjs|cjs|js|jsx|ts|tsx)$/.test(path);
+}
+
+// Dev mode 에서 `<style data-zts-${kind}>` 태그를 head 에 (재)삽입하는 inline 스니펫.
+// `import "./generated.css"` 가 bundler 의 CSS 출력으로 흘러간 뒤 첫 paint 까지의 race
+// 를 줄이고 HMR 시 동일 id 의 tag.textContent 만 swap 하면 끝나도록 하기 위함.
+// `import.meta.env.DEV` 는 production define 으로 false 치환 → 분기 통째 tree-shake.
+function buildDevStyleInjector(kind, file, root, css) {
+  const attr = `data-zts-${kind}`;
+  const cssText = JSON.stringify(css);
+  const idText = JSON.stringify(`zts-${kind}:${relative(root, file)}`);
+  return [
+    'if (import.meta.env.DEV && typeof document !== "undefined") {',
+    `  const css = ${cssText};`,
+    `  const id = ${idText};`,
+    `  let tag = document.querySelector(\`style[${attr}="\${id}"]\`);`,
+    "  if (!tag) {",
+    '    tag = document.createElement("style");',
+    `    tag.setAttribute(${JSON.stringify(attr)}, id);`,
+    "    document.head.appendChild(tag);",
+    "  }",
+    "  tag.textContent = css;",
+    "}",
+  ].join("\n");
+}
+
+function buildCssPreprocessorProxy(root, file, cssPath, css) {
+  const cssImport = `./${basename(cssPath)}`;
+  return [
+    `import ${JSON.stringify(cssImport)};`,
+    buildDevStyleInjector("css-preprocessor", file, root, css),
+    "",
+  ].join("\n");
+}
+
+function transformCssPreprocessors(root, files, sourceFiles, logLevel) {
+  if (files.length === 0) return 0;
+
+  let sass;
+  try {
+    sass = loadSassCompiler(root);
+  } catch (err) {
+    const message =
+      err?.code === "MODULE_NOT_FOUND" || err?.code === "ERR_MODULE_NOT_FOUND"
+        ? "Sass/SCSS support requires the optional `sass` package. Install it with `bun add -d sass` or `npm install -D sass`."
+        : `Failed to load sass: ${err?.message ?? err}`;
+    throw new Error(message);
+  }
+
+  for (const file of files) {
+    const result = sass.compile(file, {
+      style: "expanded",
+      loadPaths: [dirname(file), root],
+      sourceMap: false,
+    });
+    const cssPath = cssPreprocessorOutputPath(file);
+    writeFileSync(cssPath, result.css);
+    writeFileSync(
+      cssPreprocessorProxyPath(file),
+      buildCssPreprocessorProxy(root, file, cssPath, result.css),
+    );
+  }
+
+  rewriteSassReferences(sourceFiles);
+  if (logLevel !== "silent") {
+    console.error(`[sass] processed ${files.length} Sass/SCSS file(s)`);
+  }
+  return files.length;
 }
 
 function isCssModuleFile(path) {
   return basename(path).endsWith(".module.css");
 }
 
-function isAppSourceForCssModuleScan(path) {
-  return /\.(?:mjs|cjs|js|jsx|ts|tsx)$/.test(path);
-}
-
-function hasCssModules(root, outdir) {
-  return (
-    collectAppFiles(root, {
-      skipDir: outdir,
-      predicate: (path) => isCssModuleFile(path),
-    }).length > 0
-  );
-}
-
 function cssModuleGeneratedCssPath(file) {
-  return file.replace(/\.module\.css$/i, ".module.zts.css");
+  return file.replace(/\.module\.css$/, ".module.zts.css");
 }
 
 function cssModuleProxyPath(file) {
@@ -782,6 +886,8 @@ function cssModuleLocalName(root, file, local) {
   return `${fileName}_${safeLocal}__${hash}`;
 }
 
+// 지원 범위: 일반 `.class-name` 토큰의 위치 추출. `:global`/`:local` 슈도, `composes:`
+// 룰, `@keyframes` 이름 scoping 등 고급 CSS Modules 스펙은 미지원.
 function scanCssModuleClassTokens(css) {
   const tokens = [];
   let i = 0;
@@ -926,7 +1032,6 @@ const CSS_MODULE_RESERVED_EXPORTS = new Set([
 
 function buildCssModuleProxy(root, file, generatedCssPath, css, mapping) {
   const cssImport = `./${basename(generatedCssPath)}`;
-  const cssText = JSON.stringify(css);
   const stylesJson = JSON.stringify(mapping);
   const named = Object.keys(mapping)
     .filter(isValidExportName)
@@ -937,25 +1042,17 @@ function buildCssModuleProxy(root, file, generatedCssPath, css, mapping) {
     `const styles = ${stylesJson};`,
     "export default styles;",
     named,
-    'if (import.meta.env.DEV && typeof document !== "undefined") {',
-    `  const css = ${cssText};`,
-    `  const id = ${JSON.stringify(`zts-css-module:${relative(root, file)}`)};`,
-    '  let tag = document.querySelector(`style[data-zts-css-module="${id}"]`);',
-    "  if (!tag) {",
-    '    tag = document.createElement("style");',
-    '    tag.setAttribute("data-zts-css-module", id);',
-    "    document.head.appendChild(tag);",
-    "  }",
-    "  tag.textContent = css;",
-    "}",
+    buildDevStyleInjector("css-module", file, root, css),
     "",
   ]
     .filter(Boolean)
     .join("\n");
 }
 
-function transformCssModules(root, logLevel) {
-  const moduleFiles = collectAppFiles(root, { predicate: (path) => isCssModuleFile(path) });
+// CSS Modules 의 source rewrite 는 HTML 미지원 — `<link href="x.module.css">` 같은 직접
+// 참조는 일반 CSS 로 취급되므로 `.js` 로 rewrite 하면 안 됨. styleSources 에서 .html
+// 만 제외해서 사용한다.
+function transformCssModules(root, moduleFiles, styleSources, logLevel) {
   if (moduleFiles.length === 0) return 0;
 
   for (const file of moduleFiles) {
@@ -973,10 +1070,13 @@ function transformCssModules(root, logLevel) {
     );
   }
 
-  for (const source of collectAppFiles(root, { predicate: isAppSourceForCssModuleScan })) {
+  const pattern = /(["'])([^"']+\.module\.css)([?#][^"']*)?\1/g;
+  for (const source of styleSources) {
+    if (/\.html?$/i.test(source)) continue;
     const input = readFileSync(source, "utf8");
+    if (!input.includes(".module.css")) continue;
     const output = input.replace(
-      /(["'])([^"']+\.module\.css)([?#][^"']*)?\1/g,
+      pattern,
       (_match, quote, spec, suffix = "") => `${quote}${spec}.js${suffix}${quote}`,
     );
     if (output !== input) writeFileSync(source, output);
@@ -1013,7 +1113,7 @@ function logPostcssProcessed(logLevel, count, configFile) {
 async function runPostcssIfConfigured(root, cssDir, skipDir, configEnv, logLevel) {
   const loaded = await loadPostcssConfig(root, configEnv);
   if (!loaded) return;
-  const cssFiles = collectCssFiles(cssDir, skipDir);
+  const cssFiles = collectAppFiles(cssDir, { skipDir, predicate: isCssFile });
   await Promise.all(
     cssFiles.map(async (file) => {
       const input = readFileSync(file, "utf8");
@@ -1042,7 +1142,7 @@ async function runPostcssForAppDev({
   let primaryHref = null;
   const configPath = findPostcssConfig(root);
   if (!configPath) {
-    const first = collectCssFiles(root, outdir)[0];
+    const first = collectAppFiles(root, { skipDir: outdir, predicate: isCssFile })[0];
     if (first) primaryHref = joinUrl(base, relative(root, first));
     return { deps, dirDeps, primaryHref, processed: 0 };
   }
@@ -1052,7 +1152,7 @@ async function runPostcssForAppDev({
   deps.add(resolve(loaded.configFile ?? configPath));
 
   mkdirSync(outdir, { recursive: true });
-  const allCssFiles = collectCssFiles(root, outdir);
+  const allCssFiles = collectAppFiles(root, { skipDir: outdir, predicate: isCssFile });
   // 단일 CSS 파일 변경이면 그 파일만 reprocess. 그 외(첫 빌드, postcss config 변경 등)는 전체.
   const targets =
     changedPath && changedPath.endsWith(".css") && allCssFiles.includes(changedPath)
@@ -1096,11 +1196,39 @@ function collectPostcssMessages(messages, deps, dirDeps) {
 
 async function prepareAppCssPipelineRoot(root, outdir, configEnv, logLevel, phase) {
   const configPath = findPostcssConfig(root);
-  const needsCssModules = hasCssModules(root, outdir);
-  if (!configPath && !needsCssModules) return null;
+  // 한 번의 walk 로 모든 transform 의 입력 파일을 수집. 이전엔 hasCssPreprocessors /
+  // hasCssModules / 각 transform 안의 walk + source-rewriter 의 walk 까지 합쳐 5–6번
+  // 트리 traversal 을 수행했음.
+  const sourceFiles = collectAppFiles(root, {
+    skipDir: outdir,
+    predicate: (path) =>
+      isCssPreprocessorFile(path) || isCssModuleFile(path) || isStyleReferenceSource(path),
+  });
+  const preprocessorFiles = sourceFiles.filter(isCssPreprocessorFile);
+  const moduleFiles = sourceFiles.filter(isCssModuleFile);
+  const styleSourceFiles = sourceFiles.filter(isStyleReferenceSource);
+
+  if (!configPath && preprocessorFiles.length === 0 && moduleFiles.length === 0) return null;
   const tempRoot = copyAppRootForPostcss(root, outdir, phase);
+
+  // tempRoot 로 path 변환 — 위 walk 결과는 root 기준이므로 prefix 만 갈아끼우면 충분.
+  const toTemp = (path) => join(tempRoot, relative(root, path));
+  transformCssPreprocessors(
+    tempRoot,
+    preprocessorFiles.map(toTemp),
+    styleSourceFiles.map(toTemp),
+    logLevel,
+  );
   await runPostcssIfConfigured(tempRoot, tempRoot, null, configEnv, logLevel);
-  transformCssModules(tempRoot, logLevel);
+  const generatedModuleFiles = preprocessorFiles
+    .map(cssPreprocessorOutputPath)
+    .filter(isCssModuleFile);
+  transformCssModules(
+    tempRoot,
+    [...moduleFiles, ...generatedModuleFiles].map(toTemp),
+    styleSourceFiles.map(toTemp),
+    logLevel,
+  );
   return tempRoot;
 }
 
@@ -1641,8 +1769,11 @@ async function runServe(opts, config, { appDev = null } = {}) {
   // 번들 모드면 먼저 빌드
   if (opts.bundle && opts.entryPoints.length > 0) {
     opts.outdir = opts.outdir || join(opts.serveDir, ".zts-serve");
-    await runBundle(opts, config);
-    if (appDev) await appDev.afterBundle();
+    const bundleResult = await runBundle(opts, config);
+    if (appDev) {
+      appDev.injectBundleCssLinks(bundleResult);
+      await appDev.afterBundle();
+    }
 
     // watch도 같이
     if (!opts.watch) {
@@ -1814,7 +1945,8 @@ async function runServe(opts, config, { appDev = null } = {}) {
     async function rebuildAppDevFull() {
       const prepared = await appDev.prepare();
       opts.entryPoints = [prepared.entryPath];
-      await runBundle(opts, config);
+      const bundleResult = await runBundle(opts, config);
+      appDev.injectBundleCssLinks(bundleResult);
       await appDev.afterBundle();
       hmr?.broadcast({ type: HMR_MSG.FullReload, timestamp: Date.now() });
       if (opts.logLevel !== "silent") console.error("[serve] rebuilt");

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -400,18 +400,17 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
   const root = resolve(opts.appRoot ?? ".");
   const outdir = resolve(opts.outdir ?? join(root, "dist"));
   if (opts.clean) rmSync(outdir, { recursive: true, force: true });
-  assertNoAppCssModules(root, outdir);
-  let postcssRoot = null;
+  let pipelineRoot = null;
   try {
-    postcssRoot = await preparePostcssAppRoot(root, outdir, configEnv, opts.logLevel, "build");
+    pipelineRoot = await prepareAppCssPipelineRoot(root, outdir, configEnv, opts.logLevel, "build");
     const result = buildAppSync({
-      root: postcssRoot ?? root,
+      root: pipelineRoot ?? root,
       outdir,
       entryHtml: opts.entryHtml ?? "index.html",
       publicDir: opts.publicDir === undefined ? "public" : opts.publicDir,
       base: normalizeBase(opts.base ?? opts.publicPath ?? "/"),
       mode: configEnv.mode,
-      envDir: opts.envDir ? resolve(opts.envDir) : (postcssRoot ?? root),
+      envDir: opts.envDir ? resolve(opts.envDir) : (pipelineRoot ?? root),
       envPrefixes: opts.envPrefixes,
       define: Object.keys(opts.define).length > 0 ? opts.define : undefined,
       minify: opts.minify || opts.minifyWhitespace || opts.minifyIdentifiers || opts.minifySyntax,
@@ -423,7 +422,7 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
     }
     return result;
   } finally {
-    if (postcssRoot) cleanupPostcssTempRoot(postcssRoot);
+    if (pipelineRoot) cleanupPostcssTempRoot(pipelineRoot);
   }
 }
 
@@ -455,21 +454,27 @@ function createAppDevController(opts, root, configEnv) {
   let cssDeps = new Set();
   let cssDirDeps = new Set();
   let primaryHref = null;
+  let pipelineRoot = null;
 
   return {
     root,
     outdir,
     base,
     async prepare() {
-      assertNoAppCssModules(root, outdir);
+      if (pipelineRoot) {
+        cleanupPostcssTempRoot(pipelineRoot);
+        pipelineRoot = null;
+      }
+      pipelineRoot = await prepareAppCssPipelineRoot(root, outdir, configEnv, opts.logLevel, "dev");
+      const prepareRoot = pipelineRoot ?? root;
       const prepared = prepareAppDevSync({
-        root,
+        root: prepareRoot,
         outdir,
         entryHtml: opts.entryHtml ?? "index.html",
         publicDir: opts.publicDir === undefined ? "public" : opts.publicDir,
         base,
         mode: configEnv.mode,
-        envDir: opts.envDir ? resolve(opts.envDir) : root,
+        envDir: opts.envDir ? resolve(opts.envDir) : prepareRoot,
         envPrefixes: opts.envPrefixes,
       });
       injectAppDevHmrClient(outdir);
@@ -493,6 +498,7 @@ function createAppDevController(opts, root, configEnv) {
       return POSTCSS_CONFIG_NAMES.includes(basename(absPath));
     },
     isCssOnlyChange(absPath) {
+      if (isCssModuleFile(absPath)) return false;
       if (absPath.endsWith(".css")) return true;
       if (cssDeps.has(absPath)) return true;
       for (const dir of cssDirDeps) {
@@ -726,50 +732,260 @@ function collectCssFiles(dir, skipDir = null) {
   return files;
 }
 
-function assertNoAppCssModules(root, outdir) {
-  const hit = findAppCssModuleReference(root, new Set([resolve(outdir)]));
-  if (!hit) return;
-  throw new Error(
-    `CSS Modules (.module.css) are not supported by zts app CSS pipeline yet: ${relative(root, hit)}`,
-  );
-}
-
-function findAppCssModuleReference(dir, skip) {
-  if (!existsSync(dir)) return null;
-  const absDir = resolve(dir);
-  for (const ignored of skip) {
-    if (absDir === ignored || absDir.startsWith(`${ignored}${sep}`)) return null;
-  }
+function collectAppFiles(dir, { skipDir = null, predicate = () => true } = {}) {
+  if (!existsSync(dir)) return [];
+  const files = [];
   for (const entry of readdirSync(dir)) {
-    if (entry === "node_modules" || entry === ".git" || entry === "dist" || entry === ".zts-dev") {
-      continue;
-    }
+    if (entry === "node_modules" || entry === ".git") continue;
     const path = join(dir, entry);
     const stat = statSync(path);
+    if (skipDir && stat.isDirectory() && resolve(path) === resolve(skipDir)) continue;
     if (stat.isDirectory()) {
-      const found = findAppCssModuleReference(path, skip);
-      if (found) return found;
-      continue;
+      files.push(...collectAppFiles(path, { skipDir, predicate }));
+    } else if (stat.isFile() && predicate(path)) {
+      files.push(path);
     }
-    if (!stat.isFile() || !isAppSourceForCssModuleScan(path)) continue;
-    const text = readFileSync(path, "utf8");
-    if (referencesCssModulePath(path, text)) return path;
   }
-  return null;
+  return files;
+}
+
+function isCssModuleFile(path) {
+  return basename(path).endsWith(".module.css");
 }
 
 function isAppSourceForCssModuleScan(path) {
-  return /\.(?:html|mjs|cjs|js|jsx|ts|tsx)$/.test(path);
+  return /\.(?:mjs|cjs|js|jsx|ts|tsx)$/.test(path);
 }
 
-function referencesCssModulePath(path, text) {
-  if (!text.includes(".module.css")) return false;
-  if (/\.html?$/i.test(path)) {
-    return /\b(?:href|src)\s*=\s*["'][^"']*\.module\.css(?:[?#][^"']*)?["']/i.test(text);
-  }
-  return /(?:\bimport\s+(?:[^"'()]+\s+from\s*)?|\bimport\s*\(|\brequire\s*\()\s*["'][^"']*\.module\.css(?:[?#][^"']*)?["']/i.test(
-    text,
+function hasCssModules(root, outdir) {
+  return (
+    collectAppFiles(root, {
+      skipDir: outdir,
+      predicate: (path) => isCssModuleFile(path),
+    }).length > 0
   );
+}
+
+function cssModuleGeneratedCssPath(file) {
+  return file.replace(/\.module\.css$/i, ".module.zts.css");
+}
+
+function cssModuleProxyPath(file) {
+  return `${file}.js`;
+}
+
+function cssModuleLocalName(root, file, local) {
+  const rel = relative(root, file).replaceAll(sep, "/");
+  const fileName = basename(file, ".module.css").replace(/[^a-zA-Z0-9_]/g, "_");
+  const safeLocal = local.replace(/[^a-zA-Z0-9_]/g, "_");
+  const hash = createHash("sha1").update(`${rel}:${local}`).digest("base64url").slice(0, 5);
+  return `${fileName}_${safeLocal}__${hash}`;
+}
+
+function scanCssModuleClassTokens(css) {
+  const tokens = [];
+  let i = 0;
+  while (i < css.length) {
+    const ch = css[i];
+    const next = css[i + 1];
+    if ((ch === '"' || ch === "'") && css[i - 1] !== "\\") {
+      i = skipCssString(css, i, ch);
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      const end = css.indexOf("*/", i + 2);
+      i = end === -1 ? css.length : end + 2;
+      continue;
+    }
+    if (startsWithCssIdent(css, i, "url(")) {
+      i = skipCssUrl(css, i + 4);
+      continue;
+    }
+    if (ch === "." && isCssIdentStart(next)) {
+      let end = i + 2;
+      while (end < css.length && isCssIdent(css[end])) end += 1;
+      tokens.push({ start: i, end, local: css.slice(i + 1, end) });
+      i = end;
+      continue;
+    }
+    i += 1;
+  }
+  return tokens;
+}
+
+function skipCssString(css, start, quote) {
+  let i = start + 1;
+  while (i < css.length) {
+    if (css[i] === "\\" && i + 1 < css.length) {
+      i += 2;
+      continue;
+    }
+    if (css[i] === quote) return i + 1;
+    i += 1;
+  }
+  return css.length;
+}
+
+function skipCssUrl(css, start) {
+  let i = start;
+  while (i < css.length) {
+    if ((css[i] === '"' || css[i] === "'") && css[i - 1] !== "\\") {
+      i = skipCssString(css, i, css[i]);
+      continue;
+    }
+    if (css[i] === ")") return i + 1;
+    i += 1;
+  }
+  return css.length;
+}
+
+function startsWithCssIdent(css, offset, value) {
+  return css.slice(offset, offset + value.length).toLowerCase() === value;
+}
+
+function isCssIdentStart(ch) {
+  return ch === "_" || (ch >= "A" && ch <= "Z") || (ch >= "a" && ch <= "z");
+}
+
+function isCssIdent(ch) {
+  return isCssIdentStart(ch) || ch === "-" || (ch >= "0" && ch <= "9");
+}
+
+function collectCssModuleClasses(css) {
+  return [...new Set(scanCssModuleClassTokens(css).map((token) => token.local))];
+}
+
+function rewriteCssModuleClasses(css, mapping) {
+  const tokens = scanCssModuleClassTokens(css);
+  let out = "";
+  let offset = 0;
+  for (const token of tokens) {
+    const scoped = mapping[token.local];
+    if (!scoped) continue;
+    out += css.slice(offset, token.start);
+    out += `.${scoped}`;
+    offset = token.end;
+  }
+  out += css.slice(offset);
+  return out;
+}
+
+function isValidExportName(name) {
+  return /^[$A-Z_a-z][$\w]*$/.test(name) && !CSS_MODULE_RESERVED_EXPORTS.has(name);
+}
+
+const CSS_MODULE_RESERVED_EXPORTS = new Set([
+  "arguments",
+  "await",
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "default",
+  "delete",
+  "do",
+  "else",
+  "enum",
+  "export",
+  "extends",
+  "false",
+  "finally",
+  "for",
+  "function",
+  "if",
+  "implements",
+  "import",
+  "in",
+  "instanceof",
+  "interface",
+  "let",
+  "new",
+  "null",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "return",
+  "static",
+  "super",
+  "switch",
+  "this",
+  "throw",
+  "true",
+  "try",
+  "typeof",
+  "var",
+  "void",
+  "while",
+  "with",
+  "yield",
+]);
+
+function buildCssModuleProxy(root, file, generatedCssPath, css, mapping) {
+  const cssImport = `./${basename(generatedCssPath)}`;
+  const cssText = JSON.stringify(css);
+  const stylesJson = JSON.stringify(mapping);
+  const named = Object.keys(mapping)
+    .filter(isValidExportName)
+    .map((name) => `export const ${name} = ${JSON.stringify(mapping[name])};`)
+    .join("\n");
+  return [
+    `import ${JSON.stringify(cssImport)};`,
+    `const styles = ${stylesJson};`,
+    "export default styles;",
+    named,
+    'if (import.meta.env.DEV && typeof document !== "undefined") {',
+    `  const css = ${cssText};`,
+    `  const id = ${JSON.stringify(`zts-css-module:${relative(root, file)}`)};`,
+    '  let tag = document.querySelector(`style[data-zts-css-module="${id}"]`);',
+    "  if (!tag) {",
+    '    tag = document.createElement("style");',
+    '    tag.setAttribute("data-zts-css-module", id);',
+    "    document.head.appendChild(tag);",
+    "  }",
+    "  tag.textContent = css;",
+    "}",
+    "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function transformCssModules(root, logLevel) {
+  const moduleFiles = collectAppFiles(root, { predicate: (path) => isCssModuleFile(path) });
+  if (moduleFiles.length === 0) return 0;
+
+  for (const file of moduleFiles) {
+    const css = readFileSync(file, "utf8");
+    const mapping = {};
+    for (const local of collectCssModuleClasses(css)) {
+      mapping[local] = cssModuleLocalName(root, file, local);
+    }
+    const rewrittenCss = rewriteCssModuleClasses(css, mapping);
+    const generatedCssPath = cssModuleGeneratedCssPath(file);
+    writeFileSync(generatedCssPath, rewrittenCss);
+    writeFileSync(
+      cssModuleProxyPath(file),
+      buildCssModuleProxy(root, file, generatedCssPath, rewrittenCss, mapping),
+    );
+  }
+
+  for (const source of collectAppFiles(root, { predicate: isAppSourceForCssModuleScan })) {
+    const input = readFileSync(source, "utf8");
+    const output = input.replace(
+      /(["'])([^"']+\.module\.css)([?#][^"']*)?\1/g,
+      (_match, quote, spec, suffix = "") => `${quote}${spec}.js${suffix}${quote}`,
+    );
+    if (output !== input) writeFileSync(source, output);
+  }
+
+  if (logLevel !== "silent") {
+    console.error(`[css-modules] processed ${moduleFiles.length} CSS module file(s)`);
+  }
+  return moduleFiles.length;
 }
 
 async function loadPostcssConfig(root, configEnv) {
@@ -878,11 +1094,13 @@ function collectPostcssMessages(messages, deps, dirDeps) {
   }
 }
 
-async function preparePostcssAppRoot(root, outdir, configEnv, logLevel, phase) {
+async function prepareAppCssPipelineRoot(root, outdir, configEnv, logLevel, phase) {
   const configPath = findPostcssConfig(root);
-  if (!configPath) return null;
+  const needsCssModules = hasCssModules(root, outdir);
+  if (!configPath && !needsCssModules) return null;
   const tempRoot = copyAppRootForPostcss(root, outdir, phase);
   await runPostcssIfConfigured(tempRoot, tempRoot, null, configEnv, logLevel);
+  transformCssModules(tempRoot, logLevel);
   return tempRoot;
 }
 
@@ -906,8 +1124,7 @@ function requestAcceptsHtml(accept) {
 }
 
 function looksLikeAssetPath(pathname) {
-  const last = pathname.slice(pathname.lastIndexOf("/") + 1);
-  return last.includes(".");
+  return extname(pathname) !== "";
 }
 
 // ─── Transpile 모드 ───
@@ -1453,24 +1670,16 @@ async function runServe(opts, config, { appDev = null } = {}) {
     let filePath = join(serveDir, pathname);
     if (!existsSync(filePath)) {
       const fallback = normalizeSpaFallback(opts.spaFallback);
-      const acceptsHtml = requestAcceptsHtml(accept);
-      if (fallback && acceptsHtml && !looksLikeAssetPath(pathname)) {
-        const fallbackPath = resolve(serveDir, fallback);
-        if (fallbackPath !== serveDir && !fallbackPath.startsWith(`${serveDir}${sep}`)) {
-          return { status: 404, body: "Not Found", type: "text/plain" };
-        }
-        if (existsSync(fallbackPath)) {
-          filePath = fallbackPath;
-        } else {
-          return { status: 404, body: "Not Found", type: "text/plain" };
-        }
-      } else {
+      if (!fallback || !requestAcceptsHtml(accept) || looksLikeAssetPath(pathname)) {
         return { status: 404, body: "Not Found", type: "text/plain" };
       }
-    }
-
-    if (!existsSync(filePath)) {
-      return { status: 404, body: "Not Found", type: "text/plain" };
+      const fallbackPath = resolve(serveDir, fallback);
+      const insideServeDir =
+        fallbackPath === serveDir || fallbackPath.startsWith(`${serveDir}${sep}`);
+      if (!insideServeDir || !existsSync(fallbackPath)) {
+        return { status: 404, body: "Not Found", type: "text/plain" };
+      }
+      filePath = fallbackPath;
     }
 
     const ext = extname(filePath);

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -2989,6 +2989,120 @@ describe("CLI: Vite-style app builder", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  test("Sass/SCSS app styles are compiled before app build", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-scss-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "index.html"),
+      '<section class="panel"><script type="module" src="/src/main.ts"></script></section>',
+    );
+    writeFileSync(join(dir, "src", "main.ts"), 'import "./style.scss"; console.log("scss");');
+    writeFileSync(join(dir, "src", "_vars.scss"), "$panel-color: rgb(12, 34, 56);");
+    writeFileSync(
+      join(dir, "src", "style.scss"),
+      '@use "./vars" as *; .panel { color: $panel-color; .inner { padding: 4px; } }',
+    );
+
+    const outdir = join(dir, "dist");
+    const { exitCode, stderr } = runCli(["build", dir, "--outdir", outdir], { cwd: dir });
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain("[sass] processed 2 Sass/SCSS file");
+    const html = readFileSync(join(outdir, "index.html"), "utf8");
+    expect(html).toContain('href="/main.css"');
+    const css = readFileSync(join(outdir, "main.css"), "utf8");
+    expect(css).toContain("rgb(12, 34, 56)");
+    expect(css).toContain(".panel .inner");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("HTML-linked .sass styles are compiled and base-prefixed", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-sass-html-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "index.html"),
+      [
+        '<link rel="stylesheet" href="/src/page.sass">',
+        '<main class="page"><script type="module" src="/src/main.ts"></script></main>',
+      ].join(""),
+    );
+    writeFileSync(join(dir, "src", "main.ts"), 'console.log("sass html");');
+    writeFileSync(
+      join(dir, "src", "page.sass"),
+      "$page-color: rgb(31, 41, 59)\n.page\n  color: $page-color\n  .title\n    margin: 2px\n",
+    );
+
+    const outdir = join(dir, "dist");
+    const { exitCode, stderr } = runCli(["build", dir, "--outdir", outdir, "--base", "/app/"], {
+      cwd: dir,
+    });
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain("[sass] processed 1 Sass/SCSS file");
+    const html = readFileSync(join(outdir, "index.html"), "utf8");
+    expect(html).toContain('href="/app/src/page.css"');
+    const css = readFileSync(join(outdir, "src", "page.css"), "utf8");
+    expect(css).toContain("rgb(31, 41, 59)");
+    expect(css).toContain(".page .title");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("Sass output flows through PostCSS before CSS Modules scoping", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-scss-module-postcss-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "index.html"), '<script type="module" src="/src/main.ts"></script>');
+    writeFileSync(
+      join(dir, "src", "main.ts"),
+      'import styles from "./card.module.scss"; console.log(styles.card, styles.postcssAdded);',
+    );
+    writeFileSync(
+      join(dir, "src", "card.module.scss"),
+      "$fg: rgb(9, 8, 7); .card { color: $fg; .child { padding: 3px; } }",
+    );
+    writeFileSync(
+      join(dir, "postcss.config.mjs"),
+      [
+        "export default {",
+        "  plugins: [",
+        "    { postcssPlugin: 'zts-scss-postcss', Once(root) { root.append({ selector: '.postcss-added', nodes: [] }); } },",
+        "  ],",
+        "};",
+      ].join("\n"),
+    );
+
+    const outdir = join(dir, "dist");
+    const { exitCode, stderr } = runCli(["build", dir, "--outdir", outdir], { cwd: dir });
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain("[sass] processed 1 Sass/SCSS file");
+    expect(stderr).toContain("[postcss] processed 1 CSS file");
+    expect(stderr).toContain("[css-modules] processed 1 CSS module file");
+    const html = readFileSync(join(outdir, "index.html"), "utf8");
+    const scriptPath = scriptPathFromHtml(html);
+    const js = readFileSync(join(outdir, scriptPath.slice(1)), "utf8");
+    expect(js).toMatch(/card_card__[A-Za-z0-9_-]{5}/);
+    expect(js).toMatch(/card_postcss_added__[A-Za-z0-9_-]{5}/);
+    const cssPath = (html.match(/href="([^"]+\.css)"/) ?? [])[1];
+    expect(cssPath).toBeTruthy();
+    const css = readFileSync(join(outdir, cssPath.slice(1)), "utf8");
+    expect(css).toContain("rgb(9, 8, 7)");
+    expect(css).toMatch(/\.card_card__[A-Za-z0-9_-]{5} \.card_child__/);
+    expect(css).toMatch(/\.card_postcss_added__[A-Za-z0-9_-]{5}/);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("Sass syntax errors fail build without emitting partial app output", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-scss-error-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "index.html"), '<script type="module" src="/src/main.ts"></script>');
+    writeFileSync(join(dir, "src", "main.ts"), 'import "./broken.scss";');
+    writeFileSync(join(dir, "src", "broken.scss"), ".broken { color: $missing");
+
+    const outdir = join(dir, "dist");
+    const { exitCode, stderr } = runCli(["build", dir, "--outdir", outdir], { cwd: dir });
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("broken.scss");
+    expect(existsSync(join(outdir, "index.html"))).toBe(false);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   test("CSS Modules default and named exports map to scoped CSS in app build", () => {
     const dir = mkdtempSync(join(tmpdir(), "zts-app-css-module-"));
     mkdirSync(join(dir, "src"), { recursive: true });
@@ -3033,6 +3147,76 @@ describe("CLI: Vite-style app builder", () => {
     expect(css).toMatch(/\.card_active__[A-Za-z0-9_-]{5}/);
     expect(css).toMatch(/\.card_title_text__[A-Za-z0-9_-]{5}/);
     expect(css).toContain('url("./icon.png")');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("CSS Modules omit named exports for invalid JS identifiers", () => {
+    // 키워드 (`default`/`class`), 숫자 시작, 비-식별자 문자 등은 named export 로 못 만든다.
+    // proxy 가 이를 무시하고 default styles 객체에는 그대로 보존되는지 확인.
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-css-module-invalid-export-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "index.html"), '<script type="module" src="/src/main.ts"></script>');
+    writeFileSync(
+      join(dir, "src", "main.ts"),
+      [
+        'import styles, { ok } from "./names.module.css";',
+        'console.log(styles.default, styles.class, styles["1abc"], styles.ok, ok);',
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(dir, "src", "names.module.css"),
+      [".default { color: red; }", ".class { color: green; }", ".ok { color: blue; }"].join("\n"),
+    );
+    // .1abc 는 valid CSS class 가 아니므로 .module.css 에 직접 못 쓴다 — JS access 만 검증.
+
+    const outdir = join(dir, "dist");
+    const { exitCode } = runCli(["build", dir, "--outdir", outdir], { cwd: dir });
+    expect(exitCode).toBe(0);
+    const html = readFileSync(join(outdir, "index.html"), "utf8");
+    const scriptPath = scriptPathFromHtml(html);
+    const js = readFileSync(join(outdir, scriptPath.slice(1)), "utf8");
+    // 예약어/숫자-시작은 named export 미생성 — proxy 에 emit 됐다면 `const default`/`class`
+    // 같은 invalid binding 이라 bundler 가 parse-fail 했을 것 (exitCode 0 자체가 그 증거).
+    // valid 식별자 `ok` 는 export 됐어야 하고 (bundler 가 unused export 의 `export` 키워드는
+    // 떼더라도 binding 자체는 남는다).
+    expect(js).not.toMatch(/\bconst\s+default\s*=/);
+    expect(js).not.toMatch(/\bconst\s+class\s*=/);
+    expect(js).toMatch(/\bconst\s+ok\s*=/);
+    // 그러나 default styles 객체에는 모든 키가 보존되어야 함.
+    expect(js).toContain('"default":');
+    expect(js).toContain('"class":');
+    expect(js).toContain('"ok":');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("Sass CSS Modules compile to scoped class maps", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-scss-module-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "index.html"), '<script type="module" src="/src/main.ts"></script>');
+    writeFileSync(
+      join(dir, "src", "main.ts"),
+      'import styles from "./button.module.scss"; console.log(styles.button, styles.child);',
+    );
+    writeFileSync(
+      join(dir, "src", "button.module.scss"),
+      "$fg: rgb(1, 2, 3); .button { color: $fg; .child { margin: 1px; } }",
+    );
+
+    const outdir = join(dir, "dist");
+    const { exitCode, stderr } = runCli(["build", dir, "--outdir", outdir], { cwd: dir });
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain("[sass] processed 1 Sass/SCSS file");
+    expect(stderr).toContain("[css-modules] processed 1 CSS module file");
+    const html = readFileSync(join(outdir, "index.html"), "utf8");
+    const scriptPath = scriptPathFromHtml(html);
+    const js = readFileSync(join(outdir, scriptPath.slice(1)), "utf8");
+    expect(js).toMatch(/button_button__[A-Za-z0-9_-]{5}/);
+    expect(js).toMatch(/button_child__[A-Za-z0-9_-]{5}/);
+    const cssPath = (html.match(/href="([^"]+\.css)"/) ?? [])[1];
+    expect(cssPath).toBeTruthy();
+    const css = readFileSync(join(outdir, cssPath.slice(1)), "utf8");
+    expect(css).toContain("rgb(1, 2, 3)");
+    expect(css).toMatch(/\.button_button__[A-Za-z0-9_-]{5} \.button_child__/);
     rmSync(dir, { recursive: true, force: true });
   });
 
@@ -3171,6 +3355,48 @@ describe("CLI: Vite-style app builder", () => {
       const msg = await messagePromise;
       expect(msg.type).toBe("css-update");
       expect(msg.href).toBe("/src/style.css");
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("dev SCSS source edit falls back to full-reload and updates emitted CSS", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-dev-scss-reload-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "index.html"),
+      '<div class="box"></div><script type="module" src="/src/main.ts"></script>',
+    );
+    writeFileSync(join(dir, "src", "main.ts"), 'import "./style.scss";');
+    writeFileSync(join(dir, "src", "style.scss"), ".box { color: rgb(1, 2, 3); }");
+
+    const port = 12980 + Math.floor(Math.random() * 100);
+    const proc = spawn(RUNTIME, [CLI, "dev", dir, `--port=${port}`], { cwd: dir });
+    await waitForServer(port);
+    try {
+      const initialBundle = await fetch(`http://localhost:${port}/bundle.js`).then((r) => r.text());
+      expect(initialBundle).toContain("rgb(1, 2, 3)");
+
+      const messagePromise = new Promise<any>((resolve) => {
+        const ws = new WebSocket(`ws://localhost:${port}/__hmr`);
+        ws.onmessage = (event) => {
+          const msg = JSON.parse(String(event.data));
+          if (msg.type === "css-update" || msg.type === "full-reload") {
+            ws.close();
+            resolve(msg);
+          }
+        };
+        ws.onerror = () => resolve({ type: "error" });
+        setTimeout(() => resolve({ type: "timeout" }), 5000);
+      });
+      await new Promise((r) => setTimeout(r, 300));
+      writeFileSync(join(dir, "src", "style.scss"), ".box { color: rgb(4, 5, 6); }");
+      const msg = await messagePromise;
+      expect(msg.type).toBe("full-reload");
+      await new Promise((r) => setTimeout(r, 300));
+      const updatedBundle = await fetch(`http://localhost:${port}/bundle.js`).then((r) => r.text());
+      expect(updatedBundle).toContain("rgb(4, 5, 6)");
     } finally {
       proc.kill();
       rmSync(dir, { recursive: true, force: true });

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -2643,6 +2643,152 @@ describe("CLI: Vite-style app builder", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  test("modulepreload deduplicates shared chunk across multiple entries", () => {
+    // 여러 entry 가 같은 shared chunk 를 import 하면 modulepreload 는 entry 마다 중복
+    // 추가하지 말고 단 1회만 주입되어야 한다 (`appendModulePreloadImports` 의 seen set
+    // 동작 검증). ZTS 코드 분할은 동일 reachability mask 모듈을 한 chunk 로 머지하므로
+    // 이 setup 에서는 1개의 shared chunk 만 생긴다.
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-modulepreload-dedup-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "index.html"),
+      [
+        '<script type="module" src="/src/page-a.ts"></script>',
+        '<script type="module" src="/src/page-b.ts"></script>',
+      ].join(""),
+    );
+    writeFileSync(join(dir, "src", "shared.ts"), 'export const s = "shared";');
+    writeFileSync(
+      join(dir, "src", "page-a.ts"),
+      'import { s } from "./shared"; console.log("a", s);',
+    );
+    writeFileSync(
+      join(dir, "src", "page-b.ts"),
+      'import { s } from "./shared"; console.log("b", s);',
+    );
+
+    const outdir = join(dir, "dist");
+    const { exitCode } = runCli(["build", dir, "--outdir", outdir], { cwd: dir });
+    expect(exitCode).toBe(0);
+    const html = readFileSync(join(outdir, "index.html"), "utf8");
+    const preloadHrefs = [...html.matchAll(/<link rel="modulepreload" href="([^"]+)">/g)].map(
+      (m) => m[1],
+    );
+    expect(preloadHrefs.length).toBeGreaterThanOrEqual(1);
+    expect(new Set(preloadHrefs).size).toBe(preloadHrefs.length);
+    // shared chunk 만 modulepreload 대상이고 entry chunk 자신은 포함되지 않아야 한다.
+    const scripts = [...html.matchAll(/<script[^>]+src="([^"]+)"/g)].map((m) => m[1]);
+    for (const href of preloadHrefs) {
+      expect(scripts).not.toContain(href);
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("multiple module scripts each map to their own entry output", () => {
+    // Entry chunk 들은 emitter 내부에서 exec_order(=DFS post-order) 로 정렬되어
+    // 출력되므로, html 의 <script> 순서와 outputs 순서가 항상 일치한다고 가정하면
+    // 깨질 수 있다. build.zig 는 entry path → output 을 module_ids 로 매칭하므로
+    // 여기서는 alphabetical 역순/공유 의존성 등으로 자연스럽게 정렬을 흔들면서도
+    // 각 <script> 가 자기 entry 의 hashed output 으로 정확히 rewrite 되는지 확인한다.
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-entry-mapping-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "index.html"),
+      [
+        // 알파벳 역순 (zeta, alpha) — DFS exec_index 와 무관하게 src 가 자기 chunk 로 매핑되어야 함.
+        '<script type="module" src="/src/zeta.ts"></script>',
+        '<script type="module" src="/src/alpha.ts"></script>',
+      ].join(""),
+    );
+    writeFileSync(join(dir, "src", "shared.ts"), 'export const s = "s";');
+    writeFileSync(
+      join(dir, "src", "alpha.ts"),
+      'import { s } from "./shared"; console.log("ALPHA", s);',
+    );
+    writeFileSync(
+      join(dir, "src", "zeta.ts"),
+      'import { s } from "./shared"; console.log("ZETA", s);',
+    );
+
+    const outdir = join(dir, "dist");
+    const { exitCode } = runCli(["build", dir, "--outdir", outdir], { cwd: dir });
+    expect(exitCode).toBe(0);
+    const html = readFileSync(join(outdir, "index.html"), "utf8");
+    const scripts = [...html.matchAll(/<script[^>]+src="([^"]+)"/g)].map((m) => m[1]);
+    expect(scripts.length).toBe(2);
+    expect(scripts[0]).toMatch(/\/zeta-[a-f0-9]+\.js$/);
+    expect(scripts[1]).toMatch(/\/alpha-[a-f0-9]+\.js$/);
+    // 각 hashed output 의 실제 내용도 자기 entry 의 console.log 를 포함해야 함.
+    const zetaPath = join(outdir, scripts[0].replace(/^\//, ""));
+    const alphaPath = join(outdir, scripts[1].replace(/^\//, ""));
+    expect(readFileSync(zetaPath, "utf8")).toContain("ZETA");
+    expect(readFileSync(alphaPath, "utf8")).toContain("ALPHA");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("preview without --spa-fallback returns 404 for route-like misses", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-preview-no-spa-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "index.html"),
+      '<div id="app">noop</div><script type="module" src="/src/main.ts"></script>',
+    );
+    writeFileSync(join(dir, "src", "main.ts"), "console.log('noop');");
+
+    const outdir = join(dir, "dist");
+    const buildResult = runCli(["build", dir, "--outdir", outdir], { cwd: dir });
+    expect(buildResult.exitCode).toBe(0);
+
+    const port = 12860 + Math.floor(Math.random() * 100);
+    // --spa-fallback 미지정 — route-like 요청도 그대로 404 여야 한다.
+    const proc = spawn(RUNTIME, [CLI, "preview", outdir, `--port=${port}`], { cwd: dir });
+    await waitForServer(port);
+
+    try {
+      const res = await fetch(`http://localhost:${port}/dashboard/settings`, {
+        headers: { accept: "text/html" },
+      });
+      expect(res.status).toBe(404);
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("preview --spa-fallback=custom.html honors a custom fallback file", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-preview-spa-custom-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "index.html"),
+      '<div id="app">root</div><script type="module" src="/src/main.ts"></script>',
+    );
+    writeFileSync(join(dir, "src", "main.ts"), "console.log('root');");
+
+    const outdir = join(dir, "dist");
+    const buildResult = runCli(["build", dir, "--outdir", outdir], { cwd: dir });
+    expect(buildResult.exitCode).toBe(0);
+    // 별도 custom fallback 파일을 outdir 에 직접 추가 — preview 만 검증하면 충분.
+    writeFileSync(join(outdir, "custom.html"), "<title>CUSTOM_FALLBACK</title>");
+
+    const port = 12970 + Math.floor(Math.random() * 100);
+    const proc = spawn(
+      RUNTIME,
+      [CLI, "preview", outdir, `--port=${port}`, "--spa-fallback=custom.html"],
+      { cwd: dir },
+    );
+    await waitForServer(port);
+
+    try {
+      const html = await fetch(`http://localhost:${port}/some/route`, {
+        headers: { accept: "text/html" },
+      }).then((r) => r.text());
+      expect(html).toContain("CUSTOM_FALLBACK");
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("build rewrites stylesheet url assets and HTML assets with query/hash", () => {
     const dir = mkdtempSync(join(tmpdir(), "zts-app-assets-"));
     mkdirSync(join(dir, "src"), { recursive: true });
@@ -2843,20 +2989,84 @@ describe("CLI: Vite-style app builder", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  test("CSS Modules are rejected explicitly in app CSS pipeline", () => {
+  test("CSS Modules default and named exports map to scoped CSS in app build", () => {
     const dir = mkdtempSync(join(tmpdir(), "zts-app-css-module-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "index.html"),
+      '<div id="app"></div><script type="module" src="/src/main.ts"></script>',
+    );
+    writeFileSync(
+      join(dir, "src", "main.ts"),
+      [
+        'import styles, { card } from "./card.module.css";',
+        'document.getElementById("app").className = `${styles.card} ${styles["title-text"]} ${card}`;',
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(dir, "src", "card.module.css"),
+      [
+        '.card { color: rgb(255, 0, 0); background-image: url("./icon.png"); }',
+        ".card.active { outline-color: rgb(0, 0, 0); }",
+        ".title-text { background: white; }",
+      ].join("\n"),
+    );
+    writeFileSync(join(dir, "src", "icon.png"), "icon");
+
+    const outdir = join(dir, "dist");
+    const { exitCode, stderr } = runCli(["build", dir, "--outdir", outdir], { cwd: dir });
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain("[css-modules] processed 1 CSS module file");
+
+    const html = readFileSync(join(outdir, "index.html"), "utf8");
+    expect(html).toContain('rel="stylesheet"');
+    const scriptPath = scriptPathFromHtml(html);
+    const js = readFileSync(join(outdir, scriptPath.slice(1)), "utf8");
+    expect(js).toContain('"card"');
+    expect(js).toMatch(/card_card__[A-Za-z0-9_-]{5}/);
+    expect(js).not.toContain('import "./card.module.css"');
+
+    const cssPath = (html.match(/href="([^"]+\.css)"/) ?? [])[1];
+    expect(cssPath).toBeTruthy();
+    const css = readFileSync(join(outdir, cssPath.slice(1)), "utf8");
+    expect(css).toMatch(/\.card_card__[A-Za-z0-9_-]{5}/);
+    expect(css).toMatch(/\.card_active__[A-Za-z0-9_-]{5}/);
+    expect(css).toMatch(/\.card_title_text__[A-Za-z0-9_-]{5}/);
+    expect(css).toContain('url("./icon.png")');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("CSS Modules are transformed after PostCSS in app build", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-css-module-postcss-"));
     mkdirSync(join(dir, "src"), { recursive: true });
     writeFileSync(join(dir, "index.html"), '<script type="module" src="/src/main.ts"></script>');
     writeFileSync(
       join(dir, "src", "main.ts"),
-      'import styles from "./card.module.css"; console.log(styles.card);',
+      'import styles from "./card.module.css"; console.log(styles.card, styles.injected);',
     );
     writeFileSync(join(dir, "src", "card.module.css"), ".card { color: red; }");
+    writeFileSync(
+      join(dir, "postcss.config.mjs"),
+      [
+        "export default {",
+        "  plugins: [",
+        "    { postcssPlugin: 'zts-css-mod-postcss', Once(root) { root.append({ selector: '.injected', nodes: [] }); } },",
+        "  ],",
+        "};",
+      ].join("\n"),
+    );
 
     const outdir = join(dir, "dist");
     const { exitCode, stderr } = runCli(["build", dir, "--outdir", outdir], { cwd: dir });
-    expect(exitCode).toBe(1);
-    expect(stderr).toContain("CSS Modules (.module.css) are not supported");
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain("[postcss] processed 1 CSS file");
+    expect(stderr).toContain("[css-modules] processed 1 CSS module file");
+    const html = readFileSync(join(outdir, "index.html"), "utf8");
+    const cssPath = (html.match(/href="([^"]+\.css)"/) ?? [])[1];
+    expect(cssPath).toBeTruthy();
+    const css = readFileSync(join(outdir, cssPath.slice(1)), "utf8");
+    expect(css).toMatch(/\.card_card__[A-Za-z0-9_-]{5}/);
+    expect(css).toMatch(/\.card_injected__[A-Za-z0-9_-]{5}/);
     rmSync(dir, { recursive: true, force: true });
   });
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,7 @@
     "browserslist": "^4.24.0",
     "lightningcss": "^1.28.0",
     "postcss": "^8.5.8",
-    "postcss-load-config": "^6.0.1"
+    "postcss-load-config": "^6.0.1",
+    "sass": "^1.99.0"
   }
 }

--- a/src/app/build.zig
+++ b/src/app/build.zig
@@ -116,7 +116,10 @@ pub fn buildApp(allocator: std.mem.Allocator, opts: AppBuildOptions) !usize {
 
     var result = try bundler.bundle();
     defer result.deinit(allocator);
-    if (result.hasErrors()) return error.BundleFailed;
+    if (result.hasErrors()) {
+        printAppBundleDiagnostics(result.getDiagnostics());
+        return error.BundleFailed;
+    }
 
     var reserved = std.StringHashMap(void).init(allocator);
     defer reserved.deinit();
@@ -163,12 +166,16 @@ pub fn buildApp(allocator: std.mem.Allocator, opts: AppBuildOptions) !usize {
         html = next;
     }
 
-    const first_script_output = if (result.outputs) |outs| outs[0].path else "bundle.js";
+    // Entry chunks are emitted sorted by `exec_order` (post-order DFS index),
+    // not by `entry_points` array order. Match each `<script type="module">` to
+    // its chunk via `module_ids` (chunk → entry path) so the script `src` is
+    // rewritten to the correct hashed output even when one entry imports another.
+    const default_script_output = if (result.outputs) |outs| outs[0].path else "bundle.js";
     for (html_entry.module_scripts.items, 0..) |src, i| {
         const script_output = if (result.outputs) |outs|
-            if (i < outs.len) outs[i].path else first_script_output
+            findEntryOutputPath(outs, entry_points[i]) orelse default_script_output
         else
-            first_script_output;
+            default_script_output;
         const parts = splitUrl(src);
         const new_url = try joinBaseUrlWithSuffix(allocator, base, script_output, parts.suffix);
         defer allocator.free(new_url);
@@ -554,6 +561,14 @@ fn injectModulePreloads(
     base: []const u8,
 ) ![]const u8 {
     if (outputs.len == 0 or entry_count == 0) return allocator.dupe(u8, html);
+
+    // path → outputs index 를 한 번만 빌드. 이전엔 recursive walker 가 매 import 마다
+    // outputs 를 선형 스캔 (O(N²)) 했음. outputs 자체에 대한 alias 라 owned key 불필요.
+    var by_path = std.StringHashMap(usize).init(allocator);
+    defer by_path.deinit();
+    try by_path.ensureTotalCapacity(@intCast(outputs.len));
+    for (outputs, 0..) |out, i| by_path.putAssumeCapacity(out.path, i);
+
     var seen = std.StringHashMap(void).init(allocator);
     defer seen.deinit();
     var seen_keys: std.ArrayList([]const u8) = .empty;
@@ -566,7 +581,7 @@ fn injectModulePreloads(
 
     const limit = @min(entry_count, outputs.len);
     for (outputs[0..limit]) |out| {
-        try appendModulePreloadImports(allocator, outputs, out.imports, base, &seen, &seen_keys, &tags);
+        try appendModulePreloadImports(allocator, outputs, &by_path, out.imports, base, &seen, &seen_keys, &tags);
     }
     if (tags.items.len == 0) return allocator.dupe(u8, html);
     return injectIntoHtml(allocator, html, tags.items);
@@ -575,6 +590,7 @@ fn injectModulePreloads(
 fn appendModulePreloadImports(
     allocator: std.mem.Allocator,
     outputs: []const bundler_mod.emitter.OutputFile,
+    by_path: *const std.StringHashMap(usize),
     imports: []const []const u8,
     base: []const u8,
     seen: *std.StringHashMap(void),
@@ -583,10 +599,7 @@ fn appendModulePreloadImports(
 ) !void {
     for (imports) |path| {
         if (!isJavaScriptOutput(path) or seen.contains(path)) continue;
-        const owned = try allocator.dupe(u8, path);
-        errdefer allocator.free(owned);
-        try seen.put(owned, {});
-        try seen_keys.append(allocator, owned);
+        try addReserved(allocator, seen, seen_keys, path);
 
         const url = try joinBaseUrl(allocator, base, path);
         defer allocator.free(url);
@@ -595,21 +608,34 @@ fn appendModulePreloadImports(
         if (tags.items.len > 0) try tags.append(allocator, '\n');
         try tags.appendSlice(allocator, tag);
 
-        if (findOutputByPath(outputs, path)) |dep| {
-            try appendModulePreloadImports(allocator, outputs, dep.imports, base, seen, seen_keys, tags);
+        if (by_path.get(path)) |idx| {
+            try appendModulePreloadImports(allocator, outputs, by_path, outputs[idx].imports, base, seen, seen_keys, tags);
         }
     }
 }
 
-fn findOutputByPath(outputs: []const bundler_mod.emitter.OutputFile, path: []const u8) ?bundler_mod.emitter.OutputFile {
+fn findEntryOutputPath(outputs: []const bundler_mod.emitter.OutputFile, entry_path: []const u8) ?[]const u8 {
     for (outputs) |out| {
-        if (std.mem.eql(u8, out.path, path)) return out;
+        if (out.kind != .chunk) continue;
+        for (out.module_ids) |mid| {
+            if (std.mem.eql(u8, mid, entry_path)) return out.path;
+        }
     }
     return null;
 }
 
 fn isJavaScriptOutput(path: []const u8) bool {
     return std.mem.endsWith(u8, path, ".js") or std.mem.endsWith(u8, path, ".mjs");
+}
+
+fn printAppBundleDiagnostics(diags: []const bundler_mod.BundleResult.OwnedDiagnostic) void {
+    const stderr = std.fs.File.stderr().deprecatedWriter();
+    for (diags) |d| {
+        if (d.severity != .@"error") continue;
+        const where = if (d.file_path.len > 0) d.file_path else "<input>";
+        stderr.print("error[{s}]: {s}\n  at {s}\n", .{ @tagName(d.code), d.message, where }) catch {};
+        if (d.suggestion) |s| stderr.print("  hint: {s}\n", .{s}) catch {};
+    }
 }
 
 fn joinBaseUrl(allocator: std.mem.Allocator, base: []const u8, rel: []const u8) ![]const u8 {

--- a/tests/e2e/tests/zts-app-builder-e2e.test.ts
+++ b/tests/e2e/tests/zts-app-builder-e2e.test.ts
@@ -15,6 +15,7 @@ import { dirname, join, resolve } from "node:path";
 
 const ZTS_BIN = resolve(__dirname, "../../../zig-out/bin/zts");
 const ZTS_JS_CLI = resolve(__dirname, "../../../packages/core/bin/zts.mjs");
+const ZTS_JS_RUNTIME = "bun";
 const BUILD_PREVIEW_PORT = 3997;
 const DEV_PORT = 3998;
 const CSS_MODULE_PREVIEW_PORT = 3995;
@@ -297,7 +298,7 @@ el.textContent = styles.button.includes("button_button__") ? "scoped" : "raw";
     await writeCssModuleFixture(dir);
 
     const built = spawnSync(
-      process.execPath,
+      ZTS_JS_RUNTIME,
       [ZTS_JS_CLI, "build", dir, "--outdir", join(dir, "dist")],
       {
         encoding: "utf8",
@@ -309,7 +310,7 @@ el.textContent = styles.button.includes("button_button__") ? "scoped" : "raw";
     }
 
     const preview = spawn(
-      process.execPath,
+      ZTS_JS_RUNTIME,
       [ZTS_JS_CLI, "preview", join(dir, "dist"), "--port", String(CSS_MODULE_PREVIEW_PORT)],
       { stdio: "pipe" },
     );
@@ -337,7 +338,7 @@ el.textContent = styles.button.includes("button_button__") ? "scoped" : "raw";
     const dir = await mkdtemp(join(tmpdir(), "zts-app-css-mod-dev-e2e-"));
     await writeCssModuleFixture(dir);
     const server = spawn(
-      process.execPath,
+      ZTS_JS_RUNTIME,
       [ZTS_JS_CLI, "dev", dir, "--port", String(CSS_MODULE_DEV_PORT)],
       {
         stdio: "pipe",
@@ -416,7 +417,7 @@ $label-color: rgb(140, 30, 20);
     await writeScssFixture(dir);
 
     const built = spawnSync(
-      process.execPath,
+      ZTS_JS_RUNTIME,
       [ZTS_JS_CLI, "build", dir, "--outdir", join(dir, "dist")],
       {
         encoding: "utf8",
@@ -428,7 +429,7 @@ $label-color: rgb(140, 30, 20);
     }
 
     const preview = spawn(
-      process.execPath,
+      ZTS_JS_RUNTIME,
       [ZTS_JS_CLI, "preview", join(dir, "dist"), "--port", String(SCSS_PREVIEW_PORT)],
       { stdio: "pipe" },
     );
@@ -480,7 +481,7 @@ $label-color: rgb(170, 20, 60)
     }
 
     const built = spawnSync(
-      process.execPath,
+      ZTS_JS_RUNTIME,
       [ZTS_JS_CLI, "build", dir, "--outdir", join(dir, "dist")],
       {
         encoding: "utf8",
@@ -492,7 +493,7 @@ $label-color: rgb(170, 20, 60)
     }
 
     const preview = spawn(
-      process.execPath,
+      ZTS_JS_RUNTIME,
       [ZTS_JS_CLI, "preview", join(dir, "dist"), "--port", String(SASS_HTML_PREVIEW_PORT)],
       { stdio: "pipe" },
     );
@@ -516,7 +517,7 @@ $label-color: rgb(170, 20, 60)
     const dir = await mkdtemp(join(tmpdir(), "zts-app-scss-dev-e2e-"));
     await writeScssFixture(dir);
     const server = spawn(
-      process.execPath,
+      ZTS_JS_RUNTIME,
       [ZTS_JS_CLI, "dev", dir, "--port", String(SCSS_DEV_PORT)],
       {
         stdio: "pipe",
@@ -554,7 +555,7 @@ $label-color: rgb(170, 20, 60)
     const dir = await mkdtemp(join(tmpdir(), "zts-app-scss-recovery-e2e-"));
     await writeScssFixture(dir);
     const server = spawn(
-      process.execPath,
+      ZTS_JS_RUNTIME,
       [ZTS_JS_CLI, "dev", dir, "--port", String(SCSS_RECOVERY_DEV_PORT)],
       {
         stdio: "pipe",

--- a/tests/e2e/tests/zts-app-builder-e2e.test.ts
+++ b/tests/e2e/tests/zts-app-builder-e2e.test.ts
@@ -19,6 +19,10 @@ const BUILD_PREVIEW_PORT = 3997;
 const DEV_PORT = 3998;
 const CSS_MODULE_PREVIEW_PORT = 3995;
 const CSS_MODULE_DEV_PORT = 3994;
+const SCSS_PREVIEW_PORT = 3993;
+const SCSS_DEV_PORT = 3992;
+const SASS_HTML_PREVIEW_PORT = 3991;
+const SCSS_RECOVERY_DEV_PORT = 3990;
 
 const FIXTURE: Record<string, string> = {
   "index.html": `<!doctype html>
@@ -365,6 +369,220 @@ el.textContent = styles.button.includes("button_button__") ? "scoped" : "raw";
       await expect
         .poll(() => button.evaluate((el) => getComputedStyle(el).color), { timeout: 6000 })
         .toBe("rgb(120, 10, 10)");
+    } finally {
+      server.kill();
+      await new Promise((r) => server.on("close", r));
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─── Sass/SCSS: optional Sass compiler 경로를 실제 브라우저에서 검증 ───
+test.describe("zts app Sass/SCSS E2E", () => {
+  async function writeScssFixture(dir: string): Promise<void> {
+    const files: Record<string, string> = {
+      "index.html": `<!doctype html>
+<html>
+  <head><meta charset="utf-8" /><title>scss</title></head>
+  <body>
+    <section data-testid="panel" class="panel"><span class="label">SCSS</span></section>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>`,
+      "src/main.ts": `import "./style.scss";
+document.querySelector("[data-testid=panel]")!.setAttribute("data-ready", "yes");
+`,
+      "src/_tokens.scss": `$panel-color: rgb(10, 70, 120);
+$label-color: rgb(140, 30, 20);
+`,
+      "src/style.scss": `@use "./tokens" as *;
+.panel {
+  color: $panel-color;
+  .label {
+    color: $label-color;
+  }
+}
+`,
+    };
+    for (const [name, content] of Object.entries(files)) {
+      const filePath = join(dir, name);
+      await mkdir(dirname(filePath), { recursive: true });
+      await writeFile(filePath, content);
+    }
+  }
+
+  test("build + preview compiles SCSS imports and nesting", async ({ page }) => {
+    const dir = await mkdtemp(join(tmpdir(), "zts-app-scss-build-e2e-"));
+    await writeScssFixture(dir);
+
+    const built = spawnSync(
+      process.execPath,
+      [ZTS_JS_CLI, "build", dir, "--outdir", join(dir, "dist")],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    if (built.status !== 0) {
+      throw new Error(`zts build scss failed: ${built.stderr}`);
+    }
+
+    const preview = spawn(
+      process.execPath,
+      [ZTS_JS_CLI, "preview", join(dir, "dist"), "--port", String(SCSS_PREVIEW_PORT)],
+      { stdio: "pipe" },
+    );
+    await new Promise((r) => setTimeout(r, 2000));
+    try {
+      await page.goto(`http://localhost:${SCSS_PREVIEW_PORT}/`);
+      await expect(page.getByTestId("panel")).toHaveAttribute("data-ready", "yes");
+      expect(await page.getByTestId("panel").evaluate((el) => getComputedStyle(el).color)).toBe(
+        "rgb(10, 70, 120)",
+      );
+      expect(await page.locator(".label").evaluate((el) => getComputedStyle(el).color)).toBe(
+        "rgb(140, 30, 20)",
+      );
+    } finally {
+      preview.kill();
+      await new Promise((r) => preview.on("close", r));
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("build + preview compiles HTML-linked indented .sass", async ({ page }) => {
+    const dir = await mkdtemp(join(tmpdir(), "zts-app-sass-html-e2e-"));
+    const files: Record<string, string> = {
+      "index.html": `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>sass-html</title>
+    <link rel="stylesheet" href="/src/direct.sass" />
+  </head>
+  <body>
+    <article data-testid="direct" class="direct"><span class="direct-label">SASS</span></article>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>`,
+      "src/main.ts": `document.querySelector("[data-testid=direct]")!.setAttribute("data-ready", "yes");`,
+      "src/direct.sass": `$direct-color: rgb(42, 80, 110)
+$label-color: rgb(170, 20, 60)
+.direct
+  color: $direct-color
+  .direct-label
+    color: $label-color
+`,
+    };
+    for (const [name, content] of Object.entries(files)) {
+      const filePath = join(dir, name);
+      await mkdir(dirname(filePath), { recursive: true });
+      await writeFile(filePath, content);
+    }
+
+    const built = spawnSync(
+      process.execPath,
+      [ZTS_JS_CLI, "build", dir, "--outdir", join(dir, "dist")],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    if (built.status !== 0) {
+      throw new Error(`zts build .sass failed: ${built.stderr}`);
+    }
+
+    const preview = spawn(
+      process.execPath,
+      [ZTS_JS_CLI, "preview", join(dir, "dist"), "--port", String(SASS_HTML_PREVIEW_PORT)],
+      { stdio: "pipe" },
+    );
+    await new Promise((r) => setTimeout(r, 2000));
+    try {
+      await page.goto(`http://localhost:${SASS_HTML_PREVIEW_PORT}/`);
+      const direct = page.getByTestId("direct");
+      await expect(direct).toHaveAttribute("data-ready", "yes");
+      expect(await direct.evaluate((el) => getComputedStyle(el).color)).toBe("rgb(42, 80, 110)");
+      expect(await page.locator(".direct-label").evaluate((el) => getComputedStyle(el).color)).toBe(
+        "rgb(170, 20, 60)",
+      );
+    } finally {
+      preview.kill();
+      await new Promise((r) => preview.on("close", r));
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("dev recompiles SCSS through full reload fallback", async ({ page }) => {
+    const dir = await mkdtemp(join(tmpdir(), "zts-app-scss-dev-e2e-"));
+    await writeScssFixture(dir);
+    const server = spawn(
+      process.execPath,
+      [ZTS_JS_CLI, "dev", dir, "--port", String(SCSS_DEV_PORT)],
+      {
+        stdio: "pipe",
+      },
+    );
+    await new Promise((r) => setTimeout(r, 2500));
+
+    try {
+      await page.goto(`http://localhost:${SCSS_DEV_PORT}/`);
+      const panel = page.getByTestId("panel");
+      expect(await panel.evaluate((el) => getComputedStyle(el).color)).toBe("rgb(10, 70, 120)");
+
+      await writeFile(
+        join(dir, "src/style.scss"),
+        `@use "./tokens" as *;
+.panel {
+  color: rgb(20, 100, 40);
+  .label {
+    color: $label-color;
+  }
+}
+`,
+      );
+      await expect
+        .poll(() => panel.evaluate((el) => getComputedStyle(el).color), { timeout: 7000 })
+        .toBe("rgb(20, 100, 40)");
+    } finally {
+      server.kill();
+      await new Promise((r) => server.on("close", r));
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("dev recovers after an SCSS syntax error is fixed", async ({ page }) => {
+    const dir = await mkdtemp(join(tmpdir(), "zts-app-scss-recovery-e2e-"));
+    await writeScssFixture(dir);
+    const server = spawn(
+      process.execPath,
+      [ZTS_JS_CLI, "dev", dir, "--port", String(SCSS_RECOVERY_DEV_PORT)],
+      {
+        stdio: "pipe",
+      },
+    );
+    await new Promise((r) => setTimeout(r, 2500));
+
+    try {
+      await page.goto(`http://localhost:${SCSS_RECOVERY_DEV_PORT}/`);
+      const panel = page.getByTestId("panel");
+      expect(await panel.evaluate((el) => getComputedStyle(el).color)).toBe("rgb(10, 70, 120)");
+
+      await writeFile(join(dir, "src/style.scss"), ".panel { color: rgb(1, 1, ");
+      await new Promise((r) => setTimeout(r, 800));
+      await writeFile(
+        join(dir, "src/style.scss"),
+        `@use "./tokens" as *;
+.panel {
+  color: rgb(90, 45, 135);
+  .label {
+    color: $label-color;
+  }
+}
+`,
+      );
+      await expect
+        .poll(() => panel.evaluate((el) => getComputedStyle(el).color), { timeout: 9000 })
+        .toBe("rgb(90, 45, 135)");
     } finally {
       server.kill();
       await new Promise((r) => server.on("close", r));

--- a/tests/e2e/tests/zts-app-builder-e2e.test.ts
+++ b/tests/e2e/tests/zts-app-builder-e2e.test.ts
@@ -14,8 +14,11 @@ import { dirname, join, resolve } from "node:path";
  */
 
 const ZTS_BIN = resolve(__dirname, "../../../zig-out/bin/zts");
+const ZTS_JS_CLI = resolve(__dirname, "../../../packages/core/bin/zts.mjs");
 const BUILD_PREVIEW_PORT = 3997;
 const DEV_PORT = 3998;
+const CSS_MODULE_PREVIEW_PORT = 3995;
+const CSS_MODULE_DEV_PORT = 3994;
 
 const FIXTURE: Record<string, string> = {
   "index.html": `<!doctype html>
@@ -245,5 +248,127 @@ test.describe("zts build: nested CSS path preservation E2E", () => {
     const bColor = await page.getByTestId("bbb").evaluate((el) => getComputedStyle(el).color);
     expect(aColor).toBe("rgb(255, 0, 0)");
     expect(bColor).toBe("rgb(0, 0, 255)");
+  });
+});
+
+// ─── CSS Modules: JS class map + 실제 브라우저 스타일 적용까지 검증 ───
+test.describe("zts app CSS Modules E2E", () => {
+  async function writeCssModuleFixture(dir: string): Promise<void> {
+    const files: Record<string, string> = {
+      "index.html": `<!doctype html>
+<html>
+  <head><meta charset="utf-8" /><title>css-modules</title></head>
+  <body>
+    <button data-testid="button"></button>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>`,
+      "src/main.ts": `import styles, { button } from "./button.module.css";
+const el = document.querySelector("[data-testid=button]")!;
+el.className = \`\${styles.button} \${styles["label-text"]} \${button}\`;
+el.textContent = styles.button.includes("button_button__") ? "scoped" : "raw";
+`,
+      "src/button.module.css": `.button {
+  color: rgb(7, 92, 34);
+  background: rgb(241, 244, 248);
+}
+.label-text {
+  border-top-color: rgb(80, 90, 100);
+  border-top-style: solid;
+  border-top-width: 3px;
+}
+`,
+    };
+    for (const [name, content] of Object.entries(files)) {
+      const filePath = join(dir, name);
+      await mkdir(dirname(filePath), { recursive: true });
+      await writeFile(filePath, content);
+    }
+  }
+
+  test("build + preview applies scoped class names without a page-side workaround", async ({
+    page,
+  }) => {
+    const dir = await mkdtemp(join(tmpdir(), "zts-app-css-mod-build-e2e-"));
+    await writeCssModuleFixture(dir);
+
+    const built = spawnSync(
+      process.execPath,
+      [ZTS_JS_CLI, "build", dir, "--outdir", join(dir, "dist")],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    if (built.status !== 0) {
+      throw new Error(`zts build css modules failed: ${built.stderr}`);
+    }
+
+    const preview = spawn(
+      process.execPath,
+      [ZTS_JS_CLI, "preview", join(dir, "dist"), "--port", String(CSS_MODULE_PREVIEW_PORT)],
+      { stdio: "pipe" },
+    );
+    await new Promise((r) => setTimeout(r, 2000));
+    try {
+      await page.goto(`http://localhost:${CSS_MODULE_PREVIEW_PORT}/`);
+      const button = page.getByTestId("button");
+      await expect(button).toHaveText("scoped");
+      const className = await button.evaluate((el) => el.className);
+      expect(className).toContain("button_button__");
+      expect(className).toContain("button_label_text__");
+      expect(className).not.toContain(" label-text ");
+      expect(await button.evaluate((el) => getComputedStyle(el).color)).toBe("rgb(7, 92, 34)");
+      expect(await button.evaluate((el) => getComputedStyle(el).borderTopColor)).toBe(
+        "rgb(80, 90, 100)",
+      );
+    } finally {
+      preview.kill();
+      await new Promise((r) => preview.on("close", r));
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("dev applies CSS Modules through the app pipeline", async ({ page }) => {
+    const dir = await mkdtemp(join(tmpdir(), "zts-app-css-mod-dev-e2e-"));
+    await writeCssModuleFixture(dir);
+    const server = spawn(
+      process.execPath,
+      [ZTS_JS_CLI, "dev", dir, "--port", String(CSS_MODULE_DEV_PORT)],
+      {
+        stdio: "pipe",
+      },
+    );
+    await new Promise((r) => setTimeout(r, 2500));
+
+    try {
+      await page.goto(`http://localhost:${CSS_MODULE_DEV_PORT}/`);
+      const button = page.getByTestId("button");
+      await expect(button).toHaveText("scoped");
+      const className = await button.evaluate((el) => el.className);
+      expect(className).toContain("button_button__");
+      expect(await button.evaluate((el) => getComputedStyle(el).color)).toBe("rgb(7, 92, 34)");
+
+      await writeFile(
+        join(dir, "src/button.module.css"),
+        `.button {
+  color: rgb(120, 10, 10);
+  background: rgb(241, 244, 248);
+}
+.label-text {
+  border-top-color: rgb(80, 90, 100);
+  border-top-style: solid;
+  border-top-width: 3px;
+}
+`,
+      );
+      await expect
+        .poll(() => button.evaluate((el) => getComputedStyle(el).color), { timeout: 6000 })
+        .toBe("rgb(120, 10, 10)");
+    } finally {
+      server.kill();
+      await new Promise((r) => server.on("close", r));
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## 요약

- app builder JS CLI pipeline에 CSS Modules(`.module.css`) 지원을 추가했습니다.
- Sass/SCSS(`.scss`, `.sass`)를 app pipeline에서 지원합니다. Sass는 PostCSS 전에 컴파일되고, `.module.scss`는 Sass → PostCSS → CSS Modules 순서로 처리됩니다.
- CSS Modules import는 scoped class map JS proxy로 변환하며 default export와 유효한 named export를 제공합니다.
- dev 경로에서 CSS Modules와 Sass/SCSS 변경은 full rebuild/reload fallback으로 반영합니다. 일반 CSS/PostCSS 변경은 CSS-only HMR 경로를 유지합니다.
- CLI/migration 문서를 현재 지원 범위에 맞춰 업데이트했습니다.

## Vite reference

- `references/vite/packages/vite/src/node/plugins/css.ts`: PostCSS, CSS Modules, preprocessor 처리 흐름과 dev/build 분리 참고

Refs #2189

## 테스트

- `bun test packages/core/bin/zts.test.ts --test-name-pattern "Vite-style app builder"`
- `bun test packages/core/bin/zts.test.ts --test-name-pattern "Sass|SCSS"`
- `bun test packages/core/bin/zts.test.ts --test-name-pattern "CSS Modules"`
- `bun run --cwd tests/e2e test tests/zts-app-builder-e2e.test.ts --grep "Sass|SCSS|sass"`
- `bun run --cwd tests/e2e test tests/zts-app-builder-e2e.test.ts`
- `cd documents && bun run build`
- pre-push hook: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check` 통과

참고: `bun test packages/core` 전체 실행은 watch-json restart 타이밍 테스트가 간헐 timeout을 냈고, 실패 항목은 단독 재실행에서 통과했습니다. 이번 변경과 맞닿은 app-builder/CSS/Sass/CSS Modules/E2E 범위는 위 명령으로 통과 확인했습니다.