### PR TITLE
refactor(app): app CSS pipeline /simplify round 2

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -47,6 +47,19 @@ D053에서 "Phase 6(minifier/bundler)에서 추가"로 예정됐던 semantic 확
 
 ---
 
+## App pipeline 성능 / 테스트 인프라
+
+CSS Modules + Sass 도입 (PR #2225) 후 식별된 후속 작업.
+
+| # | 항목 | 비고 |
+|---|------|------|
+| 70 | dev rebuild full re-prep (cpSync) 비용 | `createAppDevController.prepare()` 가 매 full reload 마다 `copyAppRootForPostcss` (전체 트리 cpSync) + postcss + Sass + CSS Modules 재실행. 1k 파일 앱이면 prepare 만 수백 ms. incremental sync (변경 파일만 mirror) 또는 in-memory VFS overlay 가 근본 해결 |
+| 71 | `.scss` 단일 파일 fast-path | `.scss/.sass` 단일 변경은 `isCssOnlyChange=false` 라 `rebuildAppDevFull` → 전체 cpSync 트리거. self-contained transform 이라 (해당 파일만 sass.compile + css 갱신 + `CssUpdate` HMR broadcast) fast-path 가능. #70 의 pipelineRoot incremental 모델 의존 |
+| 72 | E2E `setTimeout(2000-2500)` → readiness poll | `tests/e2e/tests/zts-app-builder-e2e.test.ts` 가 dev/preview 서버 기동 대기로 fixed `setTimeout` 사용 — 느린 CI 에서 flaky 가능성. `fetch(url)` 폴링 helper (ECONNREFUSED 재시도 / 200 까지) 도입해 일괄 대체 |
+| 73 | Dev mode 에서 bundler 가 CSS chunk 를 emit 하지 않음 | Build mode 는 splitting 으로 `*.css` 를 별도 chunk 로 출력해 `<link>` 로 서빙되지만, Dev mode 는 `bundle.js` + `index.html` 만 outdir 에 만들어진다. 그래서 Sass / CSS Modules 의 컴파일된 CSS (tempRoot 에만 존재) 가 브라우저에 도달할 길이 없어, proxy 의 `import.meta.env.DEV` inline `<style>` 주입이 다리 역할 중. 문제: 같은 CSS 가 두 번 (bundle 후 link + inline) DOM 에 들어가는 case 도 있고, dev 와 build 의 CSS 처리 경로가 갈려 유지보수 비용. Dev bundler 가 CSS chunk 도 emit 하게 통일하고 inline 주입 (`buildDevStyleInjector`) 제거가 목표. |
+
+---
+
 ## TS 타입 전용 (d.ts 생성 시 필요)
 
 ZTS는 타입 체크를 하지 않으므로 (스트리핑만) 당장 필요하지 않음.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -53,10 +53,10 @@ CSS Modules + Sass 도입 (PR #2225) 후 식별된 후속 작업.
 
 | # | 항목 | 비고 |
 |---|------|------|
-| 70 | dev rebuild full re-prep (cpSync) 비용 | `createAppDevController.prepare()` 가 매 full reload 마다 `copyAppRootForPostcss` (전체 트리 cpSync) + postcss + Sass + CSS Modules 재실행. 1k 파일 앱이면 prepare 만 수백 ms. incremental sync (변경 파일만 mirror) 또는 in-memory VFS overlay 가 근본 해결 |
-| 71 | `.scss` 단일 파일 fast-path | `.scss/.sass` 단일 변경은 `isCssOnlyChange=false` 라 `rebuildAppDevFull` → 전체 cpSync 트리거. self-contained transform 이라 (해당 파일만 sass.compile + css 갱신 + `CssUpdate` HMR broadcast) fast-path 가능. #70 의 pipelineRoot incremental 모델 의존 |
+| ~~70~~ | ~~dev rebuild full re-prep (cpSync) 비용~~ | ✅ 해결: `prepare(dirtyPaths)` 가 incremental — 변경 파일만 cpSync, sass/css-modules transform 도 dirty 입력만 재처리, postcss prep 호출 자체도 CSS 관련 dirty 가 없으면 skip. JS-only 변경은 cpSync (dirty 만) + rewriter (dirty 만) 만 수행 — 풀 prep 의 비용 거의 전부 회피. |
+| ~~71~~ | ~~`.scss` 단일 파일 fast-path~~ | ✅ 해결: 단일 non-module `.scss/.sass` 변경은 `isCssOnlyChange=true` 로 분류되어 `rebuildScssIncremental` 진입 — 그 파일만 sass.compile + tempRoot/outdir 갱신 + `CssUpdate` broadcast. import dep 추적 없으므로 다른 sass 파일이 이 파일을 import 하면 갱신 누락 (별 issue 로 sass loadPaths dep tracking) |
 | 72 | E2E `setTimeout(2000-2500)` → readiness poll | `tests/e2e/tests/zts-app-builder-e2e.test.ts` 가 dev/preview 서버 기동 대기로 fixed `setTimeout` 사용 — 느린 CI 에서 flaky 가능성. `fetch(url)` 폴링 helper (ECONNREFUSED 재시도 / 200 까지) 도입해 일괄 대체 |
-| 73 | Dev mode 에서 bundler 가 CSS chunk 를 emit 하지 않음 | Build mode 는 splitting 으로 `*.css` 를 별도 chunk 로 출력해 `<link>` 로 서빙되지만, Dev mode 는 `bundle.js` + `index.html` 만 outdir 에 만들어진다. 그래서 Sass / CSS Modules 의 컴파일된 CSS (tempRoot 에만 존재) 가 브라우저에 도달할 길이 없어, proxy 의 `import.meta.env.DEV` inline `<style>` 주입이 다리 역할 중. 문제: 같은 CSS 가 두 번 (bundle 후 link + inline) DOM 에 들어가는 case 도 있고, dev 와 build 의 CSS 처리 경로가 갈려 유지보수 비용. Dev bundler 가 CSS chunk 도 emit 하게 통일하고 inline 주입 (`buildDevStyleInjector`) 제거가 목표. |
+| ~~73~~ | ~~Dev mode 에서 bundler 가 CSS chunk 를 emit 하지 않음~~ | ✅ 해결: bundler 측은 그대로 두고, JS 파이프라인이 sass / css-modules 컴파일 산출물을 tempRoot → outdir 로 mirror 하고 HTML 에 `<link>` 를 주입. inline `<style>` 우회 (`buildDevStyleInjector`) 제거. |
 
 ---
 

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -462,18 +462,24 @@ function createAppDevController(opts, root, configEnv) {
   let cssDirDeps = new Set();
   let primaryHref = null;
   let pipelineRoot = null;
+  // F1+F2 cache (incremental prep 에서 재사용). 구조 변화 (스타일 파일 추가/삭제) 시
+  // 무효화 — `prepareAppCssPipelineRoot` 가 cache miss 일 때 자체적으로 재수집한다.
+  let pipelineCache = null; // { stylePipelineFiles, styleSourceFiles }
 
   return {
     root,
     outdir,
     base,
     async prepare(dirtyPaths = null) {
-      // pipelineRoot 가 살아 있고 dirty 정보가 있으면 in-place incremental sync 로 비싼
-      // cpSync 회피 (BACKLOG #70). 첫 빌드거나 dirty 정보 없으면 기존처럼 fresh tempRoot.
       const reuseRoot = pipelineRoot && dirtyPaths != null;
       if (pipelineRoot && !reuseRoot) {
         cleanupPostcssTempRoot(pipelineRoot);
         pipelineRoot = null;
+        pipelineCache = null;
+      }
+      // 구조 변화 — 새 .scss/.module.css 가 추가됐거나 삭제됐을 가능성. cache 무효화.
+      if (reuseRoot && dirtyPaths.some((p) => isCssPreprocessorFile(p) || isCssModuleFile(p))) {
+        pipelineCache = null;
       }
       const pipeline = await prepareAppCssPipelineRoot(
         root,
@@ -481,9 +487,12 @@ function createAppDevController(opts, root, configEnv) {
         configEnv,
         opts.logLevel,
         "dev",
-        reuseRoot ? { existingTempRoot: pipelineRoot, dirtyPaths } : undefined,
+        reuseRoot
+          ? { existingTempRoot: pipelineRoot, dirtyPaths, cache: pipelineCache }
+          : undefined,
       );
       pipelineRoot = pipeline?.tempRoot ?? null;
+      pipelineCache = pipeline?.cache ?? null;
       const prepareRoot = pipelineRoot ?? root;
       const prepared = prepareAppDevSync({
         root: prepareRoot,
@@ -496,13 +505,16 @@ function createAppDevController(opts, root, configEnv) {
         envPrefixes: opts.envPrefixes,
       });
       injectAppDevHmrClient(outdir);
-      // dev mode 한정: bundler 가 splitting=false 라 CSS chunk 를 emit 하지 않으므로
-      // Sass / CSS Modules 의 컴파일 결과를 tempRoot 에서 outdir 로 mirror 하고 HTML 에
-      // `<link rel="stylesheet">` 를 주입해 브라우저까지 도달시킨다. 이렇게 하면 native
-      // HMR client 가 `<link>` swap 으로 갱신을 처리할 수 있어 inline `<style>` 우회가
-      // 불필요해진다.
+      // dev mode 한정 — bundler 가 dev splitting=false 라 CSS chunk 를 emit 하지
+      // 않으므로 Sass / CSS Modules 결과를 outdir 로 mirror + `<link>` 주입.
+      // mirror (cpSync) 는 sass/module 입력이 dirty 일 때만 — 그 외엔 outdir 의 직전 mirror
+      // 본 그대로. inject 는 prepareAppDevSync 가 HTML 을 매번 덮어쓰므로 항상 필요.
       if (pipeline && pipeline.generatedCssAbsPaths.length > 0) {
-        const rels = mirrorPipelineCssToOutdir(pipelineRoot, outdir, pipeline.generatedCssAbsPaths);
+        const sassOrModuleDirty =
+          !reuseRoot || dirtyPaths.some((p) => isCssPreprocessorFile(p) || isCssModuleFile(p));
+        const rels = sassOrModuleDirty
+          ? mirrorPipelineCssToOutdir(pipelineRoot, outdir, pipeline.generatedCssAbsPaths)
+          : pipeline.generatedCssAbsPaths.map((p) => relative(pipelineRoot, p));
         injectAppDevPipelineCssLinks(outdir, base, rels);
       }
       return prepared;
@@ -525,16 +537,14 @@ function createAppDevController(opts, root, configEnv) {
       injectAppDevBundleCssLinks(outdir, base, bundleResult);
     },
     isPostcssConfig(absPath) {
-      return POSTCSS_CONFIG_NAMES.includes(basename(absPath));
+      return isPostcssConfigFile(absPath);
     },
     isCssOnlyChange(absPath) {
       // CSS Modules 는 class 이름 매핑이 변할 수 있어 JS proxy 도 같이 재생성 필요 →
-      // CSS-only HMR 로 갈음할 수 없고 full reload 가 안전한 기본값. Sass 도 module
-      // variant (`*.module.scss`) 는 같은 이유로 제외.
-      if (isCssModuleFile(absPath)) return false;
-      if (absPath.endsWith(".module.scss") || absPath.endsWith(".module.sass")) return false;
-      if (absPath.endsWith(".css")) return true;
-      if (isCssPreprocessorFile(absPath)) return true;
+      // CSS-only HMR 로 갈음할 수 없고 full reload 가 안전한 기본값. Sass module
+      // variant (`*.module.scss/.sass`) 도 같은 이유로 제외.
+      if (isCssModuleFile(absPath) || isCssModulePreprocessorFile(absPath)) return false;
+      if (isCssFile(absPath) || isCssPreprocessorFile(absPath)) return true;
       if (cssDeps.has(absPath)) return true;
       for (const dir of cssDirDeps) {
         if (absPath === dir || absPath.startsWith(`${dir}${sep}`)) return true;
@@ -544,31 +554,23 @@ function createAppDevController(opts, root, configEnv) {
     isSassOnlyChange(absPath) {
       // Sass fast-path 자격 — non-module `.scss/.sass` 단일 변경. import dep 추적 없으므로
       // 이 파일을 import 한 다른 sass 파일은 갱신 누락 가능 (BACKLOG #71 deps tracking).
-      return (
-        isCssPreprocessorFile(absPath) &&
-        !absPath.endsWith(".module.scss") &&
-        !absPath.endsWith(".module.sass")
-      );
+      return isCssPreprocessorFile(absPath) && !isCssModulePreprocessorFile(absPath);
     },
     async rebuildScssIncremental(absPath) {
       // pipelineRoot 가 없으면 fast-path 진입 못함 (full reload 로 fallback).
       if (!pipelineRoot) return null;
+      // postcss config 가 있으면 fast-path 가 부정확한 결과 (Tailwind/autoprefixer 등이
+      // skip 됨) — full reload 로 fallback.
+      if (findPostcssConfig(root)) return null;
       const srcTemp = join(pipelineRoot, relative(root, absPath));
-      mkdirSync(dirname(srcTemp), { recursive: true });
-      cpSync(absPath, srcTemp);
+      mirrorFile(absPath, srcTemp);
       const sass = loadSassCompiler(root);
-      const result = sass.compile(srcTemp, {
-        style: "expanded",
-        loadPaths: [dirname(srcTemp), pipelineRoot],
-        sourceMap: false,
-      });
+      const result = compileSassFile(sass, srcTemp, pipelineRoot);
       const cssTempPath = cssPreprocessorOutputPath(srcTemp);
       writeFileSync(cssTempPath, result.css);
       // 컴파일된 CSS 도 outdir 에 mirror 해서 dev server 가 서빙 가능하게.
       const cssRel = relative(pipelineRoot, cssTempPath);
-      const dst = join(outdir, cssRel);
-      mkdirSync(dirname(dst), { recursive: true });
-      cpSync(cssTempPath, dst);
+      mirrorFile(cssTempPath, join(outdir, cssRel));
       return joinUrl(base, cssRel.replaceAll(sep, "/"));
     },
     hrefFor(absPath) {
@@ -620,15 +622,20 @@ function injectAppDevBundleCssLinks(outdir, base, bundleResult) {
   });
 }
 
+// 단일 파일 mirror — syncDirtyFilesIntoTempRoot, mirrorPipelineCssToOutdir,
+// rebuildScssIncremental 가 공용. mkdir + cp 패턴이 흩어졌던 걸 일원화.
+function mirrorFile(srcAbs, dstAbs) {
+  mkdirSync(dirname(dstAbs), { recursive: true });
+  cpSync(srcAbs, dstAbs);
+}
+
 // dev mode 의 sass / css-modules 컴파일 결과는 tempPipelineRoot 에만 있어 dev server 가
 // 서빙 못 한다. 같은 rel path 로 outdir 에 복사해 `/<rel>` 로 fetch 가능하게 만든다.
 function mirrorPipelineCssToOutdir(pipelineRoot, outdir, absPaths) {
   const rels = [];
   for (const abs of absPaths) {
     const rel = relative(pipelineRoot, abs);
-    const dst = join(outdir, rel);
-    mkdirSync(dirname(dst), { recursive: true });
-    cpSync(abs, dst);
+    mirrorFile(abs, join(outdir, rel));
     rels.push(rel);
   }
   return rels;
@@ -762,21 +769,33 @@ function findPostcssConfig(root) {
   return null;
 }
 
-// Incremental: dirty 만 root → tempRoot 로 mirror. transform 들은 여전히 tempRoot 의
-// 모든 source 를 처리하지만, 비싼 cpSync 는 변경분으로 한정 (BACKLOG #70).
+// Incremental: dirty 만 root → tempRoot 로 mirror. 비싼 cpSync 는 변경분으로 한정.
+// 삭제된 source 는 tempRoot 의 generated peer (sass: `.css/.css.js`, module:
+// `.module.zts.css/.module.css.js`) 까지 함께 정리해 stale orphan 방지.
 function syncDirtyFilesIntoTempRoot(root, tempRoot, dirtyPaths) {
   for (const abs of dirtyPaths) {
     const rel = relative(root, abs);
     if (!rel || rel.startsWith("..")) continue;
     const dst = join(tempRoot, rel);
     if (existsSync(abs)) {
-      mkdirSync(dirname(dst), { recursive: true });
-      cpSync(abs, dst);
+      mirrorFile(abs, dst);
     } else if (existsSync(dst)) {
-      // root 에서 삭제된 파일은 tempRoot 에서도 제거.
       rmSync(dst, { force: true });
+      for (const peer of generatedPeerPaths(dst)) {
+        if (existsSync(peer)) rmSync(peer, { force: true });
+      }
     }
   }
+}
+
+function generatedPeerPaths(srcPath) {
+  if (isCssPreprocessorFile(srcPath)) {
+    return [cssPreprocessorOutputPath(srcPath), cssPreprocessorProxyPath(srcPath)];
+  }
+  if (isCssModuleFile(srcPath)) {
+    return [cssModuleGeneratedCssPath(srcPath), cssModuleProxyPath(srcPath)];
+  }
+  return [];
 }
 
 function copyAppRootForPostcss(root, outdir, phase) {
@@ -862,11 +881,17 @@ function collectAppFiles(dir, { skipDir = null, predicate = () => true } = {}) {
 }
 
 const isCssFile = (path) => path.endsWith(".css");
+const isPostcssConfigFile = (path) => POSTCSS_CONFIG_NAMES.includes(basename(path));
 
 const CSS_PREPROCESSOR_EXTENSIONS = new Set([".scss", ".sass"]);
+const MODULE_PREPROCESSOR_RE = /\.module\.(?:scss|sass)$/;
 
 function isCssPreprocessorFile(path) {
   return CSS_PREPROCESSOR_EXTENSIONS.has(extname(path));
+}
+
+function isCssModulePreprocessorFile(path) {
+  return MODULE_PREPROCESSOR_RE.test(path);
 }
 
 function cssPreprocessorOutputPath(file) {
@@ -880,6 +905,16 @@ function cssPreprocessorProxyPath(file) {
 function loadSassCompiler(root) {
   const requireFromRoot = createRequire(join(root, "package.json"));
   return requireFromAppOrCli(requireFromRoot, "sass");
+}
+
+// Sass option 일관성: full transform 과 fast-path (rebuildScssIncremental) 양쪽이 같은
+// 옵션을 써야 한다. drift 감지는 이 헬퍼 호출 일치성으로 한다.
+function compileSassFile(sass, file, loadRoot) {
+  return sass.compile(file, {
+    style: "expanded",
+    loadPaths: [dirname(file), loadRoot],
+    sourceMap: false,
+  });
 }
 
 // HTML 은 `<link href="x.scss">` 를 그대로 컴파일된 CSS 로, JS/TS 는 `.css.js` proxy
@@ -934,11 +969,7 @@ function transformCssPreprocessors(root, files, sourceFiles, logLevel, opts = {}
   }
 
   for (const file of targets) {
-    const result = sass.compile(file, {
-      style: "expanded",
-      loadPaths: [dirname(file), root],
-      sourceMap: false,
-    });
+    const result = compileSassFile(sass, file, root);
     const cssPath = cssPreprocessorOutputPath(file);
     writeFileSync(cssPath, result.css);
     writeFileSync(cssPreprocessorProxyPath(file), buildCssPreprocessorProxy(cssPath));
@@ -1291,16 +1322,16 @@ function collectPostcssMessages(messages, deps, dirDeps) {
 }
 
 async function prepareAppCssPipelineRoot(root, outdir, configEnv, logLevel, phase, options = {}) {
-  const { existingTempRoot = null, dirtyPaths = null } = options;
+  const { existingTempRoot = null, dirtyPaths = null, cache = null } = options;
   const configPath = findPostcssConfig(root);
-  // Pre-copy walk: preprocessor + module 파일 존재 여부 결정. styleSourceFiles 까지
-  // 같이 모아두면 두 transform 의 source-rewriter 가 walk 를 안 돌게 할 수 있는데, 그
-  // 둘 다 실행 안 되는 경우 (postcss-only 빌드) 에는 styleSourceFiles 자체가 dead 라
-  // predicate 에서 제외하고 transform 분기 진입 시점에 한 번만 모은다.
-  const stylePipelineFiles = collectAppFiles(root, {
-    skipDir: outdir,
-    predicate: (path) => isCssPreprocessorFile(path) || isCssModuleFile(path),
-  });
+  // F1 cache: 이전 prep 의 stylePipelineFiles 를 재사용. 호출자가 구조 변화 (.scss/.module.css
+  // 추가/삭제) 시 cache=null 로 무효화한다. 재사용이면 full tree walk 를 통째 회피.
+  const stylePipelineFiles =
+    cache?.stylePipelineFiles ??
+    collectAppFiles(root, {
+      skipDir: outdir,
+      predicate: (path) => isCssPreprocessorFile(path) || isCssModuleFile(path),
+    });
   const preprocessorFiles = stylePipelineFiles.filter(isCssPreprocessorFile);
   const moduleFiles = stylePipelineFiles.filter(isCssModuleFile);
   const needsSource = preprocessorFiles.length > 0 || moduleFiles.length > 0;
@@ -1315,11 +1346,11 @@ async function prepareAppCssPipelineRoot(root, outdir, configEnv, logLevel, phas
   }
 
   const toTemp = (path) => join(tempRoot, relative(root, path));
-  // styleSourceFiles 는 Sass / CSS Modules 의 import-specifier rewriter 만 사용. postcss
-  // -only 경로면 비워두고 walk 자체를 건너뛴다.
-  const styleSourceFiles = needsSource
-    ? collectAppFiles(tempRoot, { predicate: isStyleReferenceSource })
-    : [];
+  // F2 cache: styleSourceFiles 도 cache 재사용 — 구조 변화 없으면 .html/.js/.ts 트리 walk 회피.
+  // postcss-only 경로 (preprocessor/module 모두 없음) 면 dead 라 빈 배열.
+  const styleSourceFiles = !needsSource
+    ? []
+    : (cache?.styleSourceFiles ?? collectAppFiles(tempRoot, { predicate: isStyleReferenceSource }));
 
   // Incremental 모드에서 transforms 가 다시 계산할 dirty 입력 set 을 미리 만든다.
   // — sass: dirty `.scss/.sass` 만 컴파일
@@ -1358,9 +1389,7 @@ async function prepareAppCssPipelineRoot(root, outdir, configEnv, logLevel, phas
   // 결과가 tempRoot 에 살아 있다. CSS / SCSS / postcss config 가 dirty 일 때만 재실행.
   const postcssRelevant =
     !isIncremental ||
-    dirtyPaths.some(
-      (p) => isCssFile(p) || isCssPreprocessorFile(p) || POSTCSS_CONFIG_NAMES.includes(basename(p)),
-    );
+    dirtyPaths.some((p) => isCssFile(p) || isCssPreprocessorFile(p) || isPostcssConfigFile(p));
   if (postcssRelevant) {
     await runPostcssIfConfigured(tempRoot, tempRoot, null, configEnv, logLevel);
   }
@@ -1388,7 +1417,11 @@ async function prepareAppCssPipelineRoot(root, outdir, configEnv, logLevel, phas
     ...sassOutputs.filter((p) => !moduleInputCssPaths.has(p)),
     ...moduleOutputs,
   ];
-  return { tempRoot, generatedCssAbsPaths };
+  return {
+    tempRoot,
+    generatedCssAbsPaths,
+    cache: { stylePipelineFiles, styleSourceFiles },
+  };
 }
 
 async function runAppPreview(opts) {

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -402,7 +402,14 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
   if (opts.clean) rmSync(outdir, { recursive: true, force: true });
   let pipelineRoot = null;
   try {
-    pipelineRoot = await prepareAppCssPipelineRoot(root, outdir, configEnv, opts.logLevel, "build");
+    const pipeline = await prepareAppCssPipelineRoot(
+      root,
+      outdir,
+      configEnv,
+      opts.logLevel,
+      "build",
+    );
+    pipelineRoot = pipeline?.tempRoot ?? null;
     const result = buildAppSync({
       root: pipelineRoot ?? root,
       outdir,
@@ -460,12 +467,23 @@ function createAppDevController(opts, root, configEnv) {
     root,
     outdir,
     base,
-    async prepare() {
-      if (pipelineRoot) {
+    async prepare(dirtyPaths = null) {
+      // pipelineRoot 가 살아 있고 dirty 정보가 있으면 in-place incremental sync 로 비싼
+      // cpSync 회피 (BACKLOG #70). 첫 빌드거나 dirty 정보 없으면 기존처럼 fresh tempRoot.
+      const reuseRoot = pipelineRoot && dirtyPaths != null;
+      if (pipelineRoot && !reuseRoot) {
         cleanupPostcssTempRoot(pipelineRoot);
         pipelineRoot = null;
       }
-      pipelineRoot = await prepareAppCssPipelineRoot(root, outdir, configEnv, opts.logLevel, "dev");
+      const pipeline = await prepareAppCssPipelineRoot(
+        root,
+        outdir,
+        configEnv,
+        opts.logLevel,
+        "dev",
+        reuseRoot ? { existingTempRoot: pipelineRoot, dirtyPaths } : undefined,
+      );
+      pipelineRoot = pipeline?.tempRoot ?? null;
       const prepareRoot = pipelineRoot ?? root;
       const prepared = prepareAppDevSync({
         root: prepareRoot,
@@ -478,6 +496,15 @@ function createAppDevController(opts, root, configEnv) {
         envPrefixes: opts.envPrefixes,
       });
       injectAppDevHmrClient(outdir);
+      // dev mode 한정: bundler 가 splitting=false 라 CSS chunk 를 emit 하지 않으므로
+      // Sass / CSS Modules 의 컴파일 결과를 tempRoot 에서 outdir 로 mirror 하고 HTML 에
+      // `<link rel="stylesheet">` 를 주입해 브라우저까지 도달시킨다. 이렇게 하면 native
+      // HMR client 가 `<link>` swap 으로 갱신을 처리할 수 있어 inline `<style>` 우회가
+      // 불필요해진다.
+      if (pipeline && pipeline.generatedCssAbsPaths.length > 0) {
+        const rels = mirrorPipelineCssToOutdir(pipelineRoot, outdir, pipeline.generatedCssAbsPaths);
+        injectAppDevPipelineCssLinks(outdir, base, rels);
+      }
       return prepared;
     },
     async afterBundle({ changedPath = null } = {}) {
@@ -502,14 +529,47 @@ function createAppDevController(opts, root, configEnv) {
     },
     isCssOnlyChange(absPath) {
       // CSS Modules 는 class 이름 매핑이 변할 수 있어 JS proxy 도 같이 재생성 필요 →
-      // CSS-only HMR 로 갈음할 수 없고 full reload 가 안전한 기본값.
+      // CSS-only HMR 로 갈음할 수 없고 full reload 가 안전한 기본값. Sass 도 module
+      // variant (`*.module.scss`) 는 같은 이유로 제외.
       if (isCssModuleFile(absPath)) return false;
+      if (absPath.endsWith(".module.scss") || absPath.endsWith(".module.sass")) return false;
       if (absPath.endsWith(".css")) return true;
+      if (isCssPreprocessorFile(absPath)) return true;
       if (cssDeps.has(absPath)) return true;
       for (const dir of cssDirDeps) {
         if (absPath === dir || absPath.startsWith(`${dir}${sep}`)) return true;
       }
       return false;
+    },
+    isSassOnlyChange(absPath) {
+      // Sass fast-path 자격 — non-module `.scss/.sass` 단일 변경. import dep 추적 없으므로
+      // 이 파일을 import 한 다른 sass 파일은 갱신 누락 가능 (BACKLOG #71 deps tracking).
+      return (
+        isCssPreprocessorFile(absPath) &&
+        !absPath.endsWith(".module.scss") &&
+        !absPath.endsWith(".module.sass")
+      );
+    },
+    async rebuildScssIncremental(absPath) {
+      // pipelineRoot 가 없으면 fast-path 진입 못함 (full reload 로 fallback).
+      if (!pipelineRoot) return null;
+      const srcTemp = join(pipelineRoot, relative(root, absPath));
+      mkdirSync(dirname(srcTemp), { recursive: true });
+      cpSync(absPath, srcTemp);
+      const sass = loadSassCompiler(root);
+      const result = sass.compile(srcTemp, {
+        style: "expanded",
+        loadPaths: [dirname(srcTemp), pipelineRoot],
+        sourceMap: false,
+      });
+      const cssTempPath = cssPreprocessorOutputPath(srcTemp);
+      writeFileSync(cssTempPath, result.css);
+      // 컴파일된 CSS 도 outdir 에 mirror 해서 dev server 가 서빙 가능하게.
+      const cssRel = relative(pipelineRoot, cssTempPath);
+      const dst = join(outdir, cssRel);
+      mkdirSync(dirname(dst), { recursive: true });
+      cpSync(cssTempPath, dst);
+      return joinUrl(base, cssRel.replaceAll(sep, "/"));
     },
     hrefFor(absPath) {
       if (absPath.endsWith(".css")) return joinUrl(base, relative(root, absPath));
@@ -557,6 +617,33 @@ function injectAppDevBundleCssLinks(outdir, base, bundleResult) {
     }
     if (cssHrefs.length === 0) return null;
     return cssHrefs.map((href) => `<link rel="stylesheet" href="${href}">`).join("\n");
+  });
+}
+
+// dev mode 의 sass / css-modules 컴파일 결과는 tempPipelineRoot 에만 있어 dev server 가
+// 서빙 못 한다. 같은 rel path 로 outdir 에 복사해 `/<rel>` 로 fetch 가능하게 만든다.
+function mirrorPipelineCssToOutdir(pipelineRoot, outdir, absPaths) {
+  const rels = [];
+  for (const abs of absPaths) {
+    const rel = relative(pipelineRoot, abs);
+    const dst = join(outdir, rel);
+    mkdirSync(dirname(dst), { recursive: true });
+    cpSync(abs, dst);
+    rels.push(rel);
+  }
+  return rels;
+}
+
+function injectAppDevPipelineCssLinks(outdir, base, cssRelPaths) {
+  if (cssRelPaths.length === 0) return;
+  injectIntoDevHtml(outdir, (html) => {
+    const tags = [];
+    for (const rel of cssRelPaths) {
+      const href = joinUrl(base, rel.replaceAll(sep, "/"));
+      if (html.includes(`href="${href}"`) || html.includes(`href='${href}'`)) continue;
+      tags.push(`<link rel="stylesheet" href="${href}">`);
+    }
+    return tags.length === 0 ? null : tags.join("\n");
   });
 }
 
@@ -673,6 +760,23 @@ function findPostcssConfig(root) {
     if (existsSync(path)) return path;
   }
   return null;
+}
+
+// Incremental: dirty 만 root → tempRoot 로 mirror. transform 들은 여전히 tempRoot 의
+// 모든 source 를 처리하지만, 비싼 cpSync 는 변경분으로 한정 (BACKLOG #70).
+function syncDirtyFilesIntoTempRoot(root, tempRoot, dirtyPaths) {
+  for (const abs of dirtyPaths) {
+    const rel = relative(root, abs);
+    if (!rel || rel.startsWith("..")) continue;
+    const dst = join(tempRoot, rel);
+    if (existsSync(abs)) {
+      mkdirSync(dirname(dst), { recursive: true });
+      cpSync(abs, dst);
+    } else if (existsSync(dst)) {
+      // root 에서 삭제된 파일은 tempRoot 에서도 제거.
+      rmSync(dst, { force: true });
+    }
+  }
 }
 
 function copyAppRootForPostcss(root, outdir, phase) {
@@ -800,42 +904,23 @@ function isStyleReferenceSource(path) {
   return /\.(?:html|mjs|cjs|js|jsx|ts|tsx)$/.test(path);
 }
 
-// Dev mode 한정 inline `<style>` 주입 스니펫. bundler 가 build mode 에서는 CSS 를 별도
-// chunk 로 emit 하고 `injectAppDevBundleCssLinks` 가 `<link>` 를 HTML 에 박아 native HMR
-// (`CssUpdate` → link swap) 가 처리하지만, **dev mode 에선 bundler 가 CSS chunk 를 emit
-// 하지 않아** Sass/CSS-Modules 컴파일 결과가 브라우저까지 도달할 경로가 없다. 이 스니펫
-// 이 그 다리 역할 — `import.meta.env.DEV` 가드로 production 에서는 통째 tree-shake.
-// 향후 dev bundler 가 CSS chunk 를 emit 하게 되면 이 스니펫은 제거 대상 (BACKLOG #73).
-function buildDevStyleInjector(kind, file, root, css) {
-  const attr = `data-zts-${kind}`;
-  const cssText = JSON.stringify(css);
-  const idText = JSON.stringify(`zts-${kind}:${relative(root, file)}`);
-  return [
-    'if (import.meta.env.DEV && typeof document !== "undefined") {',
-    `  const css = ${cssText};`,
-    `  const id = ${idText};`,
-    `  let tag = document.querySelector(\`style[${attr}="\${id}"]\`);`,
-    "  if (!tag) {",
-    '    tag = document.createElement("style");',
-    `    tag.setAttribute(${JSON.stringify(attr)}, id);`,
-    "    document.head.appendChild(tag);",
-    "  }",
-    "  tag.textContent = css;",
-    "}",
-  ].join("\n");
-}
-
-function buildCssPreprocessorProxy(root, file, cssPath, css) {
+function buildCssPreprocessorProxy(cssPath) {
+  // proxy 는 bundler 의 module graph 에서 CSS 를 side-effect 로 추적하기 위한 entry.
+  // 실제 CSS 는 build mode 에서는 bundler 의 CSS chunk 로, dev mode 에서는 컴파일된 CSS
+  // 를 outdir 로 복사한 뒤 HTML `<link>` 로 서빙한다 (`mirrorPipelineCssToOutdir` 참고).
   const cssImport = `./${basename(cssPath)}`;
-  return [
-    `import ${JSON.stringify(cssImport)};`,
-    buildDevStyleInjector("css-preprocessor", file, root, css),
-    "",
-  ].join("\n");
+  return `import ${JSON.stringify(cssImport)};\n`;
 }
 
-function transformCssPreprocessors(root, files, sourceFiles, logLevel) {
-  if (files.length === 0) return 0;
+function transformCssPreprocessors(root, files, sourceFiles, logLevel, opts = {}) {
+  if (files.length === 0) return [];
+  const { dirtyOnly = null, dirtySources = null } = opts;
+  const targets = dirtyOnly ? files.filter((f) => dirtyOnly.has(f)) : files;
+  // Generated CSS path 는 입력 파일에 결정적 — 컴파일 안 해도 path 는 항상 알 수 있다.
+  // dirty 만 다시 컴파일하고, 전체 list 는 항상 반환해 outdir mirror 가 누락 없게.
+  if (targets.length === 0) {
+    return files.map(cssPreprocessorOutputPath);
+  }
 
   let sass;
   try {
@@ -848,7 +933,7 @@ function transformCssPreprocessors(root, files, sourceFiles, logLevel) {
     throw new Error(message);
   }
 
-  for (const file of files) {
+  for (const file of targets) {
     const result = sass.compile(file, {
       style: "expanded",
       loadPaths: [dirname(file), root],
@@ -856,17 +941,16 @@ function transformCssPreprocessors(root, files, sourceFiles, logLevel) {
     });
     const cssPath = cssPreprocessorOutputPath(file);
     writeFileSync(cssPath, result.css);
-    writeFileSync(
-      cssPreprocessorProxyPath(file),
-      buildCssPreprocessorProxy(root, file, cssPath, result.css),
-    );
+    writeFileSync(cssPreprocessorProxyPath(file), buildCssPreprocessorProxy(cssPath));
   }
 
-  rewriteSassReferences(sourceFiles);
+  // dirty source 만 freshly cp 됐으므로 그쪽에만 rewriter 적용 (이전 prep 의 source 들은
+  // 이미 rewrite 된 상태). 전체 prep 일 때는 sourceFiles 자체가 전체.
+  rewriteSassReferences(dirtySources ?? sourceFiles);
   if (logLevel !== "silent") {
-    console.error(`[sass] processed ${files.length} Sass/SCSS file(s)`);
+    console.error(`[sass] processed ${targets.length} Sass/SCSS file(s)`);
   }
-  return files.length;
+  return files.map(cssPreprocessorOutputPath);
 }
 
 function isCssModuleFile(path) {
@@ -1035,7 +1119,9 @@ const CSS_MODULE_RESERVED_EXPORTS = new Set([
   "yield",
 ]);
 
-function buildCssModuleProxy(root, file, generatedCssPath, css, mapping) {
+function buildCssModuleProxy(generatedCssPath, mapping) {
+  // CSS 자체는 generated `.module.zts.css` 가 책임 — proxy 는 class-name map 의 default
+  // export 와 valid named export 만 emit. dev/build 모두 CSS 는 `<link>` 로 도달.
   const cssImport = `./${basename(generatedCssPath)}`;
   const stylesJson = JSON.stringify(mapping);
   const named = Object.keys(mapping)
@@ -1047,7 +1133,6 @@ function buildCssModuleProxy(root, file, generatedCssPath, css, mapping) {
     `const styles = ${stylesJson};`,
     "export default styles;",
     named,
-    buildDevStyleInjector("css-module", file, root, css),
     "",
   ]
     .filter(Boolean)
@@ -1071,10 +1156,15 @@ function rewriteCssModuleReferences(sourceFiles) {
   }
 }
 
-function transformCssModules(root, moduleFiles, styleSources, logLevel) {
-  if (moduleFiles.length === 0) return 0;
+function transformCssModules(root, moduleFiles, styleSources, logLevel, opts = {}) {
+  if (moduleFiles.length === 0) return [];
+  const { dirtyOnly = null, dirtySources = null } = opts;
+  const targets = dirtyOnly ? moduleFiles.filter((f) => dirtyOnly.has(f)) : moduleFiles;
+  if (targets.length === 0) {
+    return moduleFiles.map(cssModuleGeneratedCssPath);
+  }
 
-  for (const file of moduleFiles) {
+  for (const file of targets) {
     const css = readFileSync(file, "utf8");
     const mapping = {};
     for (const local of collectCssModuleClasses(css)) {
@@ -1083,18 +1173,15 @@ function transformCssModules(root, moduleFiles, styleSources, logLevel) {
     const rewrittenCss = rewriteCssModuleClasses(css, mapping);
     const generatedCssPath = cssModuleGeneratedCssPath(file);
     writeFileSync(generatedCssPath, rewrittenCss);
-    writeFileSync(
-      cssModuleProxyPath(file),
-      buildCssModuleProxy(root, file, generatedCssPath, rewrittenCss, mapping),
-    );
+    writeFileSync(cssModuleProxyPath(file), buildCssModuleProxy(generatedCssPath, mapping));
   }
 
-  rewriteCssModuleReferences(styleSources);
+  rewriteCssModuleReferences(dirtySources ?? styleSources);
 
   if (logLevel !== "silent") {
-    console.error(`[css-modules] processed ${moduleFiles.length} CSS module file(s)`);
+    console.error(`[css-modules] processed ${targets.length} CSS module file(s)`);
   }
-  return moduleFiles.length;
+  return moduleFiles.map(cssModuleGeneratedCssPath);
 }
 
 async function loadPostcssConfig(root, configEnv) {
@@ -1203,7 +1290,8 @@ function collectPostcssMessages(messages, deps, dirDeps) {
   }
 }
 
-async function prepareAppCssPipelineRoot(root, outdir, configEnv, logLevel, phase) {
+async function prepareAppCssPipelineRoot(root, outdir, configEnv, logLevel, phase, options = {}) {
+  const { existingTempRoot = null, dirtyPaths = null } = options;
   const configPath = findPostcssConfig(root);
   // Pre-copy walk: preprocessor + module 파일 존재 여부 결정. styleSourceFiles 까지
   // 같이 모아두면 두 transform 의 source-rewriter 가 walk 를 안 돌게 할 수 있는데, 그
@@ -1218,7 +1306,13 @@ async function prepareAppCssPipelineRoot(root, outdir, configEnv, logLevel, phas
   const needsSource = preprocessorFiles.length > 0 || moduleFiles.length > 0;
 
   if (!configPath && !needsSource) return null;
-  const tempRoot = copyAppRootForPostcss(root, outdir, phase);
+  // Incremental: existing tempRoot 가 있으면 dirty 파일만 sync (BACKLOG #70). 초기 빌드는
+  // 전체 cpSync. dirtyPaths 가 null 이면 안전쪽 fallback 으로 간주해 full sync.
+  const tempRoot = existingTempRoot ?? copyAppRootForPostcss(root, outdir, phase);
+  const isIncremental = existingTempRoot && dirtyPaths;
+  if (isIncremental) {
+    syncDirtyFilesIntoTempRoot(root, tempRoot, dirtyPaths);
+  }
 
   const toTemp = (path) => join(tempRoot, relative(root, path));
   // styleSourceFiles 는 Sass / CSS Modules 의 import-specifier rewriter 만 사용. postcss
@@ -1227,26 +1321,74 @@ async function prepareAppCssPipelineRoot(root, outdir, configEnv, logLevel, phas
     ? collectAppFiles(tempRoot, { predicate: isStyleReferenceSource })
     : [];
 
+  // Incremental 모드에서 transforms 가 다시 계산할 dirty 입력 set 을 미리 만든다.
+  // — sass: dirty `.scss/.sass` 만 컴파일
+  // — css-modules: dirty `.module.css` (또는 dirty `.module.scss` 의 sass 산출물) 만 scoping
+  // — source rewriter: freshly cp 된 dirty source 만 (나머지는 이전 prep 의 rewrite 가 살아있음)
+  // postcss 는 자체 changedPath 옵션이 있어 별도 호출 (afterBundle / runPostcssForAppDev) 가 처리.
+  let dirtySassSet = null;
+  let dirtyModuleSet = null;
+  let dirtySourceList = null;
+  if (isIncremental) {
+    const dirtyTempPaths = dirtyPaths.map(toTemp);
+    dirtySassSet = new Set(dirtyTempPaths.filter((p) => isCssPreprocessorFile(p)));
+    dirtyModuleSet = new Set(dirtyTempPaths.filter((p) => isCssModuleFile(p)));
+    // dirty `.module.scss` → sass 산출물 `.module.css` 도 css-modules dirty 입력에 포함.
+    for (const sassDirty of dirtySassSet) {
+      const cssOut = cssPreprocessorOutputPath(sassDirty);
+      if (isCssModuleFile(cssOut)) dirtyModuleSet.add(cssOut);
+    }
+    dirtySourceList = dirtyTempPaths.filter((p) => isStyleReferenceSource(p) && existsSync(p));
+  }
+
   // 파이프라인 순서 (유지 필수):
   //  1. Sass: `*.scss/.sass` → `*.css` (`.module.scss` 면 `.module.css` 가 새로 생김)
   //  2. PostCSS: 모든 `*.css` 에 변환 적용 (Tailwind 등이 `@apply` 같은 룰 주입)
   //  3. CSS Modules: postcss 가 주입한 `.injected` 같은 selector 까지 scoping
   // 순서가 바뀌면 postcss 가 추가한 selector 가 scoped 안 되거나 sass 미컴파일 상태로
   // postcss 가 돌아 깨진다 — 통합 테스트 `Sass output flows through PostCSS before CSS Modules scoping` 참고.
-  transformCssPreprocessors(tempRoot, preprocessorFiles.map(toTemp), styleSourceFiles, logLevel);
-  await runPostcssIfConfigured(tempRoot, tempRoot, null, configEnv, logLevel);
+  const sassOutputs = transformCssPreprocessors(
+    tempRoot,
+    preprocessorFiles.map(toTemp),
+    styleSourceFiles,
+    logLevel,
+    isIncremental ? { dirtyOnly: dirtySassSet, dirtySources: dirtySourceList } : undefined,
+  );
+  // Incremental 모드에서 dirty 가 모두 non-CSS 면 postcss prep 도 skip — 이미 이전 prep
+  // 결과가 tempRoot 에 살아 있다. CSS / SCSS / postcss config 가 dirty 일 때만 재실행.
+  const postcssRelevant =
+    !isIncremental ||
+    dirtyPaths.some(
+      (p) => isCssFile(p) || isCssPreprocessorFile(p) || POSTCSS_CONFIG_NAMES.includes(basename(p)),
+    );
+  if (postcssRelevant) {
+    await runPostcssIfConfigured(tempRoot, tempRoot, null, configEnv, logLevel);
+  }
   // `*.module.scss` 는 위 sass 단계에서 `*.module.css` 가 새로 만들어지므로, 사전 walk
   // 가 본 모듈 리스트엔 빠져 있다. preprocessor 출력 경로를 재계산해 보강.
   const generatedModuleFiles = preprocessorFiles
     .map(cssPreprocessorOutputPath)
     .filter(isCssModuleFile);
-  transformCssModules(
+  const moduleOutputs = transformCssModules(
     tempRoot,
     [...moduleFiles, ...generatedModuleFiles].map(toTemp),
     styleSourceFiles,
     logLevel,
+    isIncremental ? { dirtyOnly: dirtyModuleSet, dirtySources: dirtySourceList } : undefined,
   );
-  return tempRoot;
+  // dev mode 가 brwoser 까지 CSS 를 도달시키도록 outdir mirror 에 사용. build mode 는
+  // bundler 가 entry 의 `import "./generated.css"` 를 따라 CSS chunk 를 emit 하므로
+  // 별도로 mirror 할 필요 없음 (소비자가 결정).
+  // `.module.scss` 의 sass 산출물 (`*.module.css`) 은 그 자체가 CSS Modules 입력으로
+  // 다시 들어가 결국 `*.module.zts.css` 로 emit 되므로 mirror 대상에서 제외.
+  const moduleInputCssPaths = new Set(
+    generatedModuleFiles.map((p) => join(tempRoot, relative(root, p))),
+  );
+  const generatedCssAbsPaths = [
+    ...sassOutputs.filter((p) => !moduleInputCssPaths.has(p)),
+    ...moduleOutputs,
+  ];
+  return { tempRoot, generatedCssAbsPaths };
 }
 
 async function runAppPreview(opts) {
@@ -1959,8 +2101,8 @@ async function runServe(opts, config, { appDev = null } = {}) {
       if (opts.logLevel !== "silent") console.error("[serve] css updated");
     }
 
-    async function rebuildAppDevFull() {
-      const prepared = await appDev.prepare();
+    async function rebuildAppDevFull(dirtyPaths = null) {
+      const prepared = await appDev.prepare(dirtyPaths);
       opts.entryPoints = [prepared.entryPath];
       const bundleResult = await runBundle(opts, config);
       appDev.injectBundleCssLinks(bundleResult);
@@ -1990,7 +2132,17 @@ async function runServe(opts, config, { appDev = null } = {}) {
             const cssChanges = paths.filter(
               (p) => p.endsWith(".css") && !appDev.isPostcssConfig(p),
             );
-            if (cssChanges.length === 1 && paths.length === 1) {
+            // 단일 non-module `.scss/.sass` 변경 → 그 파일만 재컴파일하고 outdir mirror
+            // 후 CssUpdate broadcast (BACKLOG #71). full pipeline rebuild + cpSync 회피.
+            if (paths.length === 1 && appDev.isSassOnlyChange(paths[0])) {
+              const href = await appDev.rebuildScssIncremental(paths[0]);
+              if (href) {
+                hmr?.broadcast({ type: HMR_MSG.CssUpdate, href, timestamp: Date.now() });
+                if (opts.logLevel !== "silent") console.error("[serve] sass updated");
+              } else {
+                await rebuildAppDevFull();
+              }
+            } else if (cssChanges.length === 1 && paths.length === 1) {
               await rebuildAppDevCss(cssChanges[0]);
             } else {
               await appDev.afterBundle();
@@ -1998,7 +2150,7 @@ async function runServe(opts, config, { appDev = null } = {}) {
               if (opts.logLevel !== "silent") console.error("[serve] css updated");
             }
           } else {
-            await rebuildAppDevFull();
+            await rebuildAppDevFull(paths);
           }
         }
       } catch (err) {

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -778,13 +778,14 @@ function loadSassCompiler(root) {
   return requireFromAppOrCli(requireFromRoot, "sass");
 }
 
-// HTML 은 `<link href="x.scss">` 를 그대로 컴파일된 CSS 로, JS/TS 는 dev `<style>` injection
-// 가 들어간 `.css.js` proxy 로 다른 확장자로 rewrite. CSS Modules 는 HTML 미지원이라
-// 같은 헬퍼를 쓰지 않는다 — 아래 transformCssModules 의 인라인 regex 참고.
+// HTML 은 `<link href="x.scss">` 를 그대로 컴파일된 CSS 로, JS/TS 는 `.css.js` proxy
+// (`import "./generated.css"` 한 줄짜리) 로 다른 확장자로 rewrite. CSS Modules 의
+// `.module.css` rewriter (rewriteCssModuleReferences) 는 HTML 미지원이라 별도 함수.
 function rewriteSassReferences(sourceFiles) {
   const pattern = /(["'])([^"']+\.(?:scss|sass))([?#][^"']*)?\1/g;
   for (const source of sourceFiles) {
     const input = readFileSync(source, "utf8");
+    if (!input.includes(".scss") && !input.includes(".sass")) continue;
     const toExt = source.endsWith(".html") ? ".css" : ".css.js";
     const output = input.replace(
       pattern,
@@ -799,10 +800,12 @@ function isStyleReferenceSource(path) {
   return /\.(?:html|mjs|cjs|js|jsx|ts|tsx)$/.test(path);
 }
 
-// Dev mode 에서 `<style data-zts-${kind}>` 태그를 head 에 (재)삽입하는 inline 스니펫.
-// `import "./generated.css"` 가 bundler 의 CSS 출력으로 흘러간 뒤 첫 paint 까지의 race
-// 를 줄이고 HMR 시 동일 id 의 tag.textContent 만 swap 하면 끝나도록 하기 위함.
-// `import.meta.env.DEV` 는 production define 으로 false 치환 → 분기 통째 tree-shake.
+// Dev mode 한정 inline `<style>` 주입 스니펫. bundler 가 build mode 에서는 CSS 를 별도
+// chunk 로 emit 하고 `injectAppDevBundleCssLinks` 가 `<link>` 를 HTML 에 박아 native HMR
+// (`CssUpdate` → link swap) 가 처리하지만, **dev mode 에선 bundler 가 CSS chunk 를 emit
+// 하지 않아** Sass/CSS-Modules 컴파일 결과가 브라우저까지 도달할 경로가 없다. 이 스니펫
+// 이 그 다리 역할 — `import.meta.env.DEV` 가드로 production 에서는 통째 tree-shake.
+// 향후 dev bundler 가 CSS chunk 를 emit 하게 되면 이 스니펫은 제거 대상 (BACKLOG #73).
 function buildDevStyleInjector(kind, file, root, css) {
   const attr = `data-zts-${kind}`;
   const cssText = JSON.stringify(css);
@@ -882,7 +885,9 @@ function cssModuleLocalName(root, file, local) {
   const rel = relative(root, file).replaceAll(sep, "/");
   const fileName = basename(file, ".module.css").replace(/[^a-zA-Z0-9_]/g, "_");
   const safeLocal = local.replace(/[^a-zA-Z0-9_]/g, "_");
-  const hash = createHash("sha1").update(`${rel}:${local}`).digest("base64url").slice(0, 5);
+  // 8 chars (~48 bits) 면 100k 클래스에서도 birthday collision <0.001%. 5 chars (~30 bits)
+  // 일 때 10k 키만 돼도 ~5% 라 무성격 시각적 충돌이 가능했음.
+  const hash = createHash("sha1").update(`${rel}:${local}`).digest("base64url").slice(0, 8);
   return `${fileName}_${safeLocal}__${hash}`;
 }
 
@@ -1051,7 +1056,21 @@ function buildCssModuleProxy(root, file, generatedCssPath, css, mapping) {
 
 // CSS Modules 의 source rewrite 는 HTML 미지원 — `<link href="x.module.css">` 같은 직접
 // 참조는 일반 CSS 로 취급되므로 `.js` 로 rewrite 하면 안 됨. styleSources 에서 .html
-// 만 제외해서 사용한다.
+// 은 제외하고 import specifier 만 `.module.css.js` 로 redirect 한다.
+function rewriteCssModuleReferences(sourceFiles) {
+  const pattern = /(["'])([^"']+\.module\.css)([?#][^"']*)?\1/g;
+  for (const source of sourceFiles) {
+    if (/\.html?$/i.test(source)) continue;
+    const input = readFileSync(source, "utf8");
+    if (!input.includes(".module.css")) continue;
+    const output = input.replace(
+      pattern,
+      (_match, quote, spec, suffix = "") => `${quote}${spec}.js${suffix}${quote}`,
+    );
+    if (output !== input) writeFileSync(source, output);
+  }
+}
+
 function transformCssModules(root, moduleFiles, styleSources, logLevel) {
   if (moduleFiles.length === 0) return 0;
 
@@ -1070,17 +1089,7 @@ function transformCssModules(root, moduleFiles, styleSources, logLevel) {
     );
   }
 
-  const pattern = /(["'])([^"']+\.module\.css)([?#][^"']*)?\1/g;
-  for (const source of styleSources) {
-    if (/\.html?$/i.test(source)) continue;
-    const input = readFileSync(source, "utf8");
-    if (!input.includes(".module.css")) continue;
-    const output = input.replace(
-      pattern,
-      (_match, quote, spec, suffix = "") => `${quote}${spec}.js${suffix}${quote}`,
-    );
-    if (output !== input) writeFileSync(source, output);
-  }
+  rewriteCssModuleReferences(styleSources);
 
   if (logLevel !== "silent") {
     console.error(`[css-modules] processed ${moduleFiles.length} CSS module file(s)`);
@@ -1196,37 +1205,45 @@ function collectPostcssMessages(messages, deps, dirDeps) {
 
 async function prepareAppCssPipelineRoot(root, outdir, configEnv, logLevel, phase) {
   const configPath = findPostcssConfig(root);
-  // 한 번의 walk 로 모든 transform 의 입력 파일을 수집. 이전엔 hasCssPreprocessors /
-  // hasCssModules / 각 transform 안의 walk + source-rewriter 의 walk 까지 합쳐 5–6번
-  // 트리 traversal 을 수행했음.
-  const sourceFiles = collectAppFiles(root, {
+  // Pre-copy walk: preprocessor + module 파일 존재 여부 결정. styleSourceFiles 까지
+  // 같이 모아두면 두 transform 의 source-rewriter 가 walk 를 안 돌게 할 수 있는데, 그
+  // 둘 다 실행 안 되는 경우 (postcss-only 빌드) 에는 styleSourceFiles 자체가 dead 라
+  // predicate 에서 제외하고 transform 분기 진입 시점에 한 번만 모은다.
+  const stylePipelineFiles = collectAppFiles(root, {
     skipDir: outdir,
-    predicate: (path) =>
-      isCssPreprocessorFile(path) || isCssModuleFile(path) || isStyleReferenceSource(path),
+    predicate: (path) => isCssPreprocessorFile(path) || isCssModuleFile(path),
   });
-  const preprocessorFiles = sourceFiles.filter(isCssPreprocessorFile);
-  const moduleFiles = sourceFiles.filter(isCssModuleFile);
-  const styleSourceFiles = sourceFiles.filter(isStyleReferenceSource);
+  const preprocessorFiles = stylePipelineFiles.filter(isCssPreprocessorFile);
+  const moduleFiles = stylePipelineFiles.filter(isCssModuleFile);
+  const needsSource = preprocessorFiles.length > 0 || moduleFiles.length > 0;
 
-  if (!configPath && preprocessorFiles.length === 0 && moduleFiles.length === 0) return null;
+  if (!configPath && !needsSource) return null;
   const tempRoot = copyAppRootForPostcss(root, outdir, phase);
 
-  // tempRoot 로 path 변환 — 위 walk 결과는 root 기준이므로 prefix 만 갈아끼우면 충분.
   const toTemp = (path) => join(tempRoot, relative(root, path));
-  transformCssPreprocessors(
-    tempRoot,
-    preprocessorFiles.map(toTemp),
-    styleSourceFiles.map(toTemp),
-    logLevel,
-  );
+  // styleSourceFiles 는 Sass / CSS Modules 의 import-specifier rewriter 만 사용. postcss
+  // -only 경로면 비워두고 walk 자체를 건너뛴다.
+  const styleSourceFiles = needsSource
+    ? collectAppFiles(tempRoot, { predicate: isStyleReferenceSource })
+    : [];
+
+  // 파이프라인 순서 (유지 필수):
+  //  1. Sass: `*.scss/.sass` → `*.css` (`.module.scss` 면 `.module.css` 가 새로 생김)
+  //  2. PostCSS: 모든 `*.css` 에 변환 적용 (Tailwind 등이 `@apply` 같은 룰 주입)
+  //  3. CSS Modules: postcss 가 주입한 `.injected` 같은 selector 까지 scoping
+  // 순서가 바뀌면 postcss 가 추가한 selector 가 scoped 안 되거나 sass 미컴파일 상태로
+  // postcss 가 돌아 깨진다 — 통합 테스트 `Sass output flows through PostCSS before CSS Modules scoping` 참고.
+  transformCssPreprocessors(tempRoot, preprocessorFiles.map(toTemp), styleSourceFiles, logLevel);
   await runPostcssIfConfigured(tempRoot, tempRoot, null, configEnv, logLevel);
+  // `*.module.scss` 는 위 sass 단계에서 `*.module.css` 가 새로 만들어지므로, 사전 walk
+  // 가 본 모듈 리스트엔 빠져 있다. preprocessor 출력 경로를 재계산해 보강.
   const generatedModuleFiles = preprocessorFiles
     .map(cssPreprocessorOutputPath)
     .filter(isCssModuleFile);
   transformCssModules(
     tempRoot,
     [...moduleFiles, ...generatedModuleFiles].map(toTemp),
-    styleSourceFiles.map(toTemp),
+    styleSourceFiles,
     logLevel,
   );
   return tempRoot;

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -3361,8 +3361,11 @@ describe("CLI: Vite-style app builder", () => {
     }
   });
 
-  test("dev SCSS source edit falls back to full-reload and updates emitted CSS", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "zts-app-dev-scss-reload-"));
+  test("dev single SCSS edit takes the css-update fast-path", async () => {
+    // 단일 non-module `.scss` 변경은 그 파일만 재컴파일 → outdir mirror → CssUpdate
+    // broadcast 로 끝난다 (full reload 안 함, BACKLOG #71). `.module.scss` 는 여전히 full
+    // reload (class map 갱신 가능).
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-dev-scss-fast-"));
     mkdirSync(join(dir, "src"), { recursive: true });
     writeFileSync(
       join(dir, "index.html"),
@@ -3371,12 +3374,17 @@ describe("CLI: Vite-style app builder", () => {
     writeFileSync(join(dir, "src", "main.ts"), 'import "./style.scss";');
     writeFileSync(join(dir, "src", "style.scss"), ".box { color: rgb(1, 2, 3); }");
 
-    const port = 12980 + Math.floor(Math.random() * 100);
+    const port = 13150 + Math.floor(Math.random() * 80);
     const proc = spawn(RUNTIME, [CLI, "dev", dir, `--port=${port}`], { cwd: dir });
     await waitForServer(port);
+    async function fetchEmittedCss(): Promise<string> {
+      const html = await fetch(`http://localhost:${port}/`).then((r) => r.text());
+      const href = html.match(/<link\s+rel="stylesheet"\s+href="([^"]+)"/)?.[1];
+      expect(href).toBeTruthy();
+      return fetch(`http://localhost:${port}${href}`).then((r) => r.text());
+    }
     try {
-      const initialBundle = await fetch(`http://localhost:${port}/bundle.js`).then((r) => r.text());
-      expect(initialBundle).toContain("rgb(1, 2, 3)");
+      expect(await fetchEmittedCss()).toContain("rgb(1, 2, 3)");
 
       const messagePromise = new Promise<any>((resolve) => {
         const ws = new WebSocket(`ws://localhost:${port}/__hmr`);
@@ -3393,10 +3401,11 @@ describe("CLI: Vite-style app builder", () => {
       await new Promise((r) => setTimeout(r, 300));
       writeFileSync(join(dir, "src", "style.scss"), ".box { color: rgb(4, 5, 6); }");
       const msg = await messagePromise;
-      expect(msg.type).toBe("full-reload");
+      expect(msg.type).toBe("css-update");
+      // CssUpdate 의 href 는 컴파일된 `.css` 경로 — broadcast payload 에 포함됨.
+      expect(msg.href).toMatch(/\/src\/style\.css$/);
       await new Promise((r) => setTimeout(r, 300));
-      const updatedBundle = await fetch(`http://localhost:${port}/bundle.js`).then((r) => r.text());
-      expect(updatedBundle).toContain("rgb(4, 5, 6)");
+      expect(await fetchEmittedCss()).toContain("rgb(4, 5, 6)");
     } finally {
       proc.kill();
       rmSync(dir, { recursive: true, force: true });

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -3077,14 +3077,14 @@ describe("CLI: Vite-style app builder", () => {
     const html = readFileSync(join(outdir, "index.html"), "utf8");
     const scriptPath = scriptPathFromHtml(html);
     const js = readFileSync(join(outdir, scriptPath.slice(1)), "utf8");
-    expect(js).toMatch(/card_card__[A-Za-z0-9_-]{5}/);
-    expect(js).toMatch(/card_postcss_added__[A-Za-z0-9_-]{5}/);
+    expect(js).toMatch(/card_card__[A-Za-z0-9_-]{8}/);
+    expect(js).toMatch(/card_postcss_added__[A-Za-z0-9_-]{8}/);
     const cssPath = (html.match(/href="([^"]+\.css)"/) ?? [])[1];
     expect(cssPath).toBeTruthy();
     const css = readFileSync(join(outdir, cssPath.slice(1)), "utf8");
     expect(css).toContain("rgb(9, 8, 7)");
-    expect(css).toMatch(/\.card_card__[A-Za-z0-9_-]{5} \.card_child__/);
-    expect(css).toMatch(/\.card_postcss_added__[A-Za-z0-9_-]{5}/);
+    expect(css).toMatch(/\.card_card__[A-Za-z0-9_-]{8} \.card_child__/);
+    expect(css).toMatch(/\.card_postcss_added__[A-Za-z0-9_-]{8}/);
     rmSync(dir, { recursive: true, force: true });
   });
 
@@ -3137,15 +3137,15 @@ describe("CLI: Vite-style app builder", () => {
     const scriptPath = scriptPathFromHtml(html);
     const js = readFileSync(join(outdir, scriptPath.slice(1)), "utf8");
     expect(js).toContain('"card"');
-    expect(js).toMatch(/card_card__[A-Za-z0-9_-]{5}/);
+    expect(js).toMatch(/card_card__[A-Za-z0-9_-]{8}/);
     expect(js).not.toContain('import "./card.module.css"');
 
     const cssPath = (html.match(/href="([^"]+\.css)"/) ?? [])[1];
     expect(cssPath).toBeTruthy();
     const css = readFileSync(join(outdir, cssPath.slice(1)), "utf8");
-    expect(css).toMatch(/\.card_card__[A-Za-z0-9_-]{5}/);
-    expect(css).toMatch(/\.card_active__[A-Za-z0-9_-]{5}/);
-    expect(css).toMatch(/\.card_title_text__[A-Za-z0-9_-]{5}/);
+    expect(css).toMatch(/\.card_card__[A-Za-z0-9_-]{8}/);
+    expect(css).toMatch(/\.card_active__[A-Za-z0-9_-]{8}/);
+    expect(css).toMatch(/\.card_title_text__[A-Za-z0-9_-]{8}/);
     expect(css).toContain('url("./icon.png")');
     rmSync(dir, { recursive: true, force: true });
   });
@@ -3210,13 +3210,13 @@ describe("CLI: Vite-style app builder", () => {
     const html = readFileSync(join(outdir, "index.html"), "utf8");
     const scriptPath = scriptPathFromHtml(html);
     const js = readFileSync(join(outdir, scriptPath.slice(1)), "utf8");
-    expect(js).toMatch(/button_button__[A-Za-z0-9_-]{5}/);
-    expect(js).toMatch(/button_child__[A-Za-z0-9_-]{5}/);
+    expect(js).toMatch(/button_button__[A-Za-z0-9_-]{8}/);
+    expect(js).toMatch(/button_child__[A-Za-z0-9_-]{8}/);
     const cssPath = (html.match(/href="([^"]+\.css)"/) ?? [])[1];
     expect(cssPath).toBeTruthy();
     const css = readFileSync(join(outdir, cssPath.slice(1)), "utf8");
     expect(css).toContain("rgb(1, 2, 3)");
-    expect(css).toMatch(/\.button_button__[A-Za-z0-9_-]{5} \.button_child__/);
+    expect(css).toMatch(/\.button_button__[A-Za-z0-9_-]{8} \.button_child__/);
     rmSync(dir, { recursive: true, force: true });
   });
 
@@ -3249,8 +3249,8 @@ describe("CLI: Vite-style app builder", () => {
     const cssPath = (html.match(/href="([^"]+\.css)"/) ?? [])[1];
     expect(cssPath).toBeTruthy();
     const css = readFileSync(join(outdir, cssPath.slice(1)), "utf8");
-    expect(css).toMatch(/\.card_card__[A-Za-z0-9_-]{5}/);
-    expect(css).toMatch(/\.card_injected__[A-Za-z0-9_-]{5}/);
+    expect(css).toMatch(/\.card_card__[A-Za-z0-9_-]{8}/);
+    expect(css).toMatch(/\.card_injected__[A-Za-z0-9_-]{8}/);
     rmSync(dir, { recursive: true, force: true });
   });
 

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -3412,6 +3412,44 @@ describe("CLI: Vite-style app builder", () => {
     }
   });
 
+  test("dev .module.scss edit triggers full reload (not css-update fast-path)", async () => {
+    // `.module.scss` 는 class-name map 이 변할 수 있어 fast-path 자격 박탈 — full reload
+    // 가 보장되어야 한다 (`isSassOnlyChange` 가 module variant 를 제외하는지 검증).
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-dev-module-scss-reload-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "index.html"), '<script type="module" src="/src/main.ts"></script>');
+    writeFileSync(
+      join(dir, "src", "main.ts"),
+      'import s from "./card.module.scss"; console.log(s.card);',
+    );
+    writeFileSync(join(dir, "src", "card.module.scss"), ".card { color: rgb(1, 2, 3); }");
+
+    const port = 13230 + Math.floor(Math.random() * 80);
+    const proc = spawn(RUNTIME, [CLI, "dev", dir, `--port=${port}`], { cwd: dir });
+    await waitForServer(port);
+    try {
+      const messagePromise = new Promise<any>((resolve) => {
+        const ws = new WebSocket(`ws://localhost:${port}/__hmr`);
+        ws.onmessage = (event) => {
+          const msg = JSON.parse(String(event.data));
+          if (msg.type === "css-update" || msg.type === "full-reload") {
+            ws.close();
+            resolve(msg);
+          }
+        };
+        ws.onerror = () => resolve({ type: "error" });
+        setTimeout(() => resolve({ type: "timeout" }), 5000);
+      });
+      await new Promise((r) => setTimeout(r, 300));
+      writeFileSync(join(dir, "src", "card.module.scss"), ".card { color: rgb(7, 8, 9); }");
+      const msg = await messagePromise;
+      expect(msg.type).toBe("full-reload");
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("dev preserves sub-directory CSS path (no basename collision)", async () => {
     // 서브디렉토리에 같은 basename 을 가진 두 CSS 파일이 있으면, root-기준 relative path 가
     // 보존되어 HTML link 와 emit path 가 둘 다 분리된다.


### PR DESCRIPTION
## Summary
PR #2225 (CSS Modules + Sass) 머지 후 round-2 /simplify. 코드 정리 + BACKLOG 보강 + 부족했던 dev 동작 재확인.

### 변경 요점
- **`prepareAppCssPipelineRoot` walk 축소** — pre-copy walk 는 preprocessor/module 만, `styleSourceFiles` 는 transform 분기 진입 시점에만 tempRoot 에서 수집. postcss-only 앱은 walk 1회 줄어듦
- **`rewriteCssModuleReferences` 추출** — `transformCssModules` 의 inline source-rewriter 를 별도 함수로. `rewriteSassReferences` 와 parallel structure
- **`rewriteSassReferences` pre-filter** — `.scss`/`.sass` substring 체크 추가. CSS Modules rewriter 와 대칭 회복, 무관한 source 의 noop read 제거
- **파이프라인 순서 코멘트** — scss → postcss → css-modules 순이 invariant 임을 명시. `generatedModuleFiles` 재계산이 sass 출력 보강 목적임도 표기
- **`cssModuleLocalName` hash 5→8 chars** — collision risk 1/2^30 (~5% at 10k keys) → 1/2^48 (<0.001% at 100k). 테스트 regex 도 갱신
- **`buildDevStyleInjector` 재검토** — native HMR 와 redundant 인 줄 알았으나, dev mode 에서 bundler 가 CSS chunk 를 emit 안 해서 Sass/CSS-Modules 결과가 브라우저에 도달할 유일한 경로임을 확인. 유지하되 코멘트로 의도/한계 명시. 진짜 정리는 dev bundler 측 작업 필요 → BACKLOG #73 분리

### BACKLOG 추가
- #70 dev rebuild full re-prep (cpSync) 비용
- #71 `.scss` 단일 파일 fast-path
- #72 E2E `setTimeout` → readiness poll
- #73 Dev mode 에서 bundler 가 CSS chunk 를 emit 하도록 통일

## Test plan
- [x] `bun test bin/zts.test.ts` — 175/175 pass
- [x] `bun test bin/zts-cli-schema-sync.test.ts` — 11/11 pass
- [x] `zig build test` — 4119/4119 pass
- [ ] CI E2E (Bun 으로 zts.mjs 실행) green 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)