### PR TITLE
feat(examples): add web example app + compiler config namespace stub

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,23 @@
         "vite": "^7",
       },
     },
+    "examples/web": {
+      "name": "@zts/example-web",
+      "version": "0.0.0",
+      "dependencies": {
+        "@emotion/react": "^11.14.0",
+        "@emotion/styled": "^11.14.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "styled-components": "^6.4.0",
+      },
+      "devDependencies": {
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@zts/core": "workspace:*",
+        "typescript": "^6.0.3",
+      },
+    },
     "packages/core": {
       "name": "@zts/core",
       "version": "0.1.0",
@@ -1226,6 +1243,8 @@
     "@zts/core": ["@zts/core@workspace:packages/core"],
 
     "@zts/e2e": ["@zts/e2e@workspace:tests/e2e"],
+
+    "@zts/example-web": ["@zts/example-web@workspace:examples/web"],
 
     "@zts/integration": ["@zts/integration@workspace:tests/integration"],
 
@@ -3432,6 +3451,8 @@
     "@xhmikosr/bin-check/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "@zts/benchmark/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
+
+    "@zts/example-web/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
     "@zts/integration/@swc/cli": ["@swc/cli@0.8.1", "", { "dependencies": { "@swc/counter": "^0.1.3", "@xhmikosr/bin-wrapper": "^14.0.0", "commander": "^8.3.0", "minimatch": "^9.0.3", "piscina": "^4.3.1", "semver": "^7.3.8", "slash": "3.0.0", "source-map": "^0.7.3", "tinyglobby": "^0.2.13" }, "peerDependencies": { "@swc/core": "^1.2.66", "chokidar": "^5.0.0" }, "optionalPeers": ["chokidar"], "bin": { "swc": "bin/swc.js", "swcx": "bin/swcx.js", "spack": "bin/spack.js" } }, "sha512-L+ACCGHCiS0VqHVep/INLVnvRvJ2XooQFLZq4L8snhxw1jsqz+XRcY313UsyPVturPPE1shW3jic7rt3qEQTSQ=="],
 

--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -1,0 +1,90 @@
+# @zts/example-web
+
+ZTS 의 웹 빌드 / dev server 검증용 예제 앱. styled-components 와 emotion 의 주요 패턴을 모아 향후 1st-party transform 의 회귀 테스트 베이스로 사용.
+
+## 실행
+
+```bash
+# 루트에서
+bun install
+
+# dev (HMR)
+cd examples/web && bun run dev
+
+# 프로덕션 빌드
+cd examples/web && bun run build
+
+# 빌드 결과 미리보기
+cd examples/web && bun run preview
+```
+
+`zts.config.ts` 에 이미 `compiler.styledComponents: true` / `compiler.emotion: true` 가 선언돼 있지만, **현재는 타입 stub 단계라 런타임 효과는 없습니다**. 두 라이브러리 자체의 런타임으로 모든 기능이 동작.
+
+## 데모 케이스
+
+### styled-components (`src/styled-cases.tsx`)
+1. 기본 `styled.div\`...\``
+2. Props interpolation (`${({$primary}) => ...}`)
+3. `styled(Component)` 확장
+4. `.attrs()` default props
+5. `keyframes` 애니메이션
+6. `css\`...\`` helper 재사용
+7. `createGlobalStyle`
+
+### emotion (`src/emotion-cases.tsx`)
+1. `css={...}` prop
+2. `@emotion/styled`
+3. 동적 css 함수 (autoLabel 검증)
+4. `<Global styles={...} />`
+
+## 향후 1st-party transform 이 추가할 변환
+
+### styled-components
+- **displayName** — devtools 에 컴포넌트 이름 표시 (`Card`, `Button`, ...)
+- **componentId** — 결정론적 hash 로 SSR hydration mismatch 방지
+- **정적 CSS hoist** — 매 렌더 재할당 방지
+- **CSS minify** — 화이트스페이스 제거
+
+레퍼런스: `references/styled-components-babel/`, `references/swc-plugins/packages/styled-components/`
+
+### emotion
+- **autoLabel** — 변수명을 CSS class label 로 자동 부여
+- **sourceMap** — CSS 위치 → 원본 .tsx 역추적
+- **cssPropOptimization** — `css={...}` 정적 hoist
+- **hash 안정화** — SSR hydration
+
+레퍼런스: `references/emotion/packages/babel-plugin/`, `references/swc-plugins/packages/emotion/`
+
+## 옵션 surface (next.config.js 호환)
+
+```ts
+defineConfig({
+  compiler: {
+    styledComponents: true,
+    // 또는 세밀하게:
+    // styledComponents: {
+    //   displayName: true,
+    //   ssr: true,
+    //   fileName: true,
+    //   minify: true,
+    //   transpileTemplateLiterals: true,
+    // },
+    emotion: true,
+    // 또는:
+    // emotion: {
+    //   sourceMap: true,
+    //   autoLabel: "dev-only",  // "always" | "dev-only" | "never"
+    //   labelFormat: "[local]",
+    // },
+  },
+});
+```
+
+`@next/swc` 의 `compiler.styledComponents` / `compiler.emotion` 와 동일한 surface 를 의도. Next.js 사용자가 mental model 그대로 이전 가능.
+
+## 회귀 검증 메모
+
+- **HMR**: styled / css 인터폴레이션 변경 시 모듈만 교체되는지 (전체 새로고침 아님) 확인
+- **sourcemap**: `.tsx` 라인이 devtools 에서 매핑되는지
+- **production minify**: 클래스명/CSS 가 축약되는지
+- **번들 크기**: tree-shake 후 emotion / styled-components 의 dead path 제거 여부

--- a/examples/web/index.html
+++ b/examples/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ZTS Web Example — styled-components & emotion</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@zts/example-web",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "zts dev",
+    "build": "zts build",
+    "preview": "zts preview"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "styled-components": "^6.4.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@zts/core": "workspace:*",
+    "typescript": "^6.0.3"
+  }
+}

--- a/examples/web/src/App.tsx
+++ b/examples/web/src/App.tsx
@@ -1,0 +1,26 @@
+import { StyledShowcase } from "./styled-cases";
+import { EmotionShowcase } from "./emotion-cases";
+
+export function App() {
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", padding: 24, maxWidth: 960, margin: "0 auto" }}>
+      <header style={{ marginBottom: 32 }}>
+        <h1>ZTS Web Example</h1>
+        <p>
+          styled-components / emotion 패턴을 모은 데모. 향후 <code>compiler.styledComponents</code>{" "}
+          / <code>compiler.emotion</code> 1st-party transform 의 회귀 검증 대상.
+        </p>
+      </header>
+
+      <section>
+        <h2>styled-components</h2>
+        <StyledShowcase />
+      </section>
+
+      <section style={{ marginTop: 48 }}>
+        <h2>emotion</h2>
+        <EmotionShowcase />
+      </section>
+    </div>
+  );
+}

--- a/examples/web/src/emotion-cases.tsx
+++ b/examples/web/src/emotion-cases.tsx
@@ -1,0 +1,89 @@
+/**
+ * emotion 패턴 모음.
+ *
+ * 향후 1st-party transform 이 처리해야 하는 케이스:
+ * - autoLabel — 변수명 → CSS class label 자동 부여 (devtools 가독성)
+ * - sourceMap — CSS-in-JS 위치를 원본 .tsx 로 역추적
+ * - cssPropOptimization — `css={...}` prop 정적 hoist
+ * - hash 안정화 — SSR hydration mismatch 방지
+ *
+ * 현재는 transform 없이 emotion 런타임만으로 동작.
+ */
+
+/** @jsxImportSource @emotion/react */
+
+import { useState } from "react";
+import { css, Global } from "@emotion/react";
+import styled from "@emotion/styled";
+
+// 1. css prop — emotion 의 시그니처 패턴. transform 으로 hoist 대상.
+const cardCss = css`
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 16px;
+  margin: 8px 0;
+  background: #fafafa;
+`;
+
+// 2. styled (emotion 도 동일 API)
+const Pill = styled.span<{ tone: "info" | "warn" | "danger" }>`
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+  background: ${({ tone }) =>
+    tone === "info" ? "#dbeafe" : tone === "warn" ? "#fef3c7" : "#fee2e2"};
+  color: ${({ tone }) => (tone === "info" ? "#1e40af" : tone === "warn" ? "#92400e" : "#991b1b")};
+`;
+
+// 3. dynamic css 함수 — autoLabel 의 검증 대상 (변수명 = label)
+const focusableInput = (active: boolean) => css`
+  border: 2px solid ${active ? "#3b82f6" : "#cbd5e1"};
+  border-radius: 4px;
+  padding: 6px 10px;
+  outline: none;
+  transition: border-color 0.15s;
+`;
+
+// 4. Global styles
+const globalStyles = css`
+  body {
+    margin: 0;
+    background: #ffffff;
+    color: #111;
+  }
+`;
+
+export function EmotionShowcase() {
+  const [active, setActive] = useState(false);
+  const [text, setText] = useState("");
+
+  return (
+    <>
+      <Global styles={globalStyles} />
+
+      <div css={cardCss}>
+        <h3>1. css prop</h3>
+        <p>이 카드 div 가 css={`{cardCss}`} 로 스타일됨. transform 이 들어가면 정적 hoist 대상.</p>
+      </div>
+
+      <div css={cardCss}>
+        <h3>2. styled (emotion)</h3>
+        <Pill tone="info">info</Pill> <Pill tone="warn">warn</Pill>{" "}
+        <Pill tone="danger">danger</Pill>
+      </div>
+
+      <div css={cardCss}>
+        <h3>3. 동적 css 함수 (autoLabel 검증)</h3>
+        <input
+          css={focusableInput(active)}
+          placeholder="focus 해보세요"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onFocus={() => setActive(true)}
+          onBlur={() => setActive(false)}
+        />
+      </div>
+    </>
+  );
+}

--- a/examples/web/src/emotion-cases.tsx
+++ b/examples/web/src/emotion-cases.tsx
@@ -17,6 +17,7 @@ import { css, Global } from "@emotion/react";
 import styled from "@emotion/styled";
 
 // 1. css prop — emotion 의 시그니처 패턴. transform 으로 hoist 대상.
+// styled-cases.tsx 의 Card 와 시각적으로 일치하게 유지 (두 라이브러리 authoring 비교가 목적).
 const cardCss = css`
   border: 1px solid #ddd;
   border-radius: 8px;
@@ -26,14 +27,17 @@ const cardCss = css`
 `;
 
 // 2. styled (emotion 도 동일 API)
-const Pill = styled.span<{ tone: "info" | "warn" | "danger" }>`
+type Tone = "info" | "warn" | "danger";
+const TONE_BG: Record<Tone, string> = { info: "#dbeafe", warn: "#fef3c7", danger: "#fee2e2" };
+const TONE_FG: Record<Tone, string> = { info: "#1e40af", warn: "#92400e", danger: "#991b1b" };
+
+const Pill = styled.span<{ tone: Tone }>`
   display: inline-block;
   padding: 2px 8px;
   border-radius: 999px;
   font-size: 12px;
-  background: ${({ tone }) =>
-    tone === "info" ? "#dbeafe" : tone === "warn" ? "#fef3c7" : "#fee2e2"};
-  color: ${({ tone }) => (tone === "info" ? "#1e40af" : tone === "warn" ? "#92400e" : "#991b1b")};
+  background: ${({ tone }) => TONE_BG[tone]};
+  color: ${({ tone }) => TONE_FG[tone]};
 `;
 
 // 3. dynamic css 함수 — autoLabel 의 검증 대상 (변수명 = label)

--- a/examples/web/src/main.tsx
+++ b/examples/web/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("#root not found");
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/web/src/styled-cases.tsx
+++ b/examples/web/src/styled-cases.tsx
@@ -1,0 +1,126 @@
+/**
+ * styled-components 패턴 모음.
+ *
+ * 향후 1st-party transform 이 처리해야 하는 케이스:
+ * - displayName 자동 부여 (devtools)
+ * - componentId 결정론적 hash (SSR hydration)
+ * - 정적 CSS 템플릿 hoist
+ * - css minify / transpile
+ *
+ * 현재는 transform 없이 styled-components 런타임만으로 동작.
+ */
+
+import { useState } from "react";
+import styled, { css, keyframes, createGlobalStyle } from "styled-components";
+
+// 1. 기본 styled tag
+const Card = styled.div`
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 16px;
+  margin: 8px 0;
+  background: #fafafa;
+`;
+
+// 2. Props interpolation (조건부 스타일)
+const Button = styled.button<{ $primary?: boolean }>`
+  background: ${({ $primary }) => ($primary ? "#3b82f6" : "#e5e7eb")};
+  color: ${({ $primary }) => ($primary ? "white" : "#111")};
+  border: none;
+  border-radius: 6px;
+  padding: 8px 16px;
+  cursor: pointer;
+  font-weight: 500;
+
+  &:hover {
+    opacity: 0.85;
+  }
+`;
+
+// 3. styled(Component) — 다른 컴포넌트 확장
+const DangerButton = styled(Button)`
+  background: #ef4444;
+  color: white;
+`;
+
+// 4. .attrs() — default props 주입
+const Input = styled.input.attrs({ type: "text" })`
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 6px 10px;
+  font-size: 14px;
+`;
+
+// 5. keyframes
+const spin = keyframes`
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+`;
+
+const Spinner = styled.div`
+  width: 24px;
+  height: 24px;
+  border: 3px solid #e5e7eb;
+  border-top-color: #3b82f6;
+  border-radius: 50%;
+  animation: ${spin} 0.8s linear infinite;
+`;
+
+// 6. css helper — 재사용 가능한 부분 스타일
+const elevated = css`
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  transform: translateY(-1px);
+`;
+
+const FancyCard = styled(Card)`
+  ${elevated};
+  background: white;
+`;
+
+// 7. createGlobalStyle (트랜스폼 영향 받는 또다른 헬퍼)
+const GlobalReset = createGlobalStyle`
+  *, *::before, *::after { box-sizing: border-box; }
+`;
+
+export function StyledShowcase() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <>
+      <GlobalReset />
+
+      <Card>
+        <h3>1. 기본 styled tag</h3>
+        <p>이 카드 자체가 styled.div 입니다.</p>
+      </Card>
+
+      <Card>
+        <h3>2. Props interpolation</h3>
+        <Button onClick={() => setCount(count + 1)}>일반 ({count})</Button>{" "}
+        <Button $primary onClick={() => setCount(count + 1)}>
+          Primary ({count})
+        </Button>
+      </Card>
+
+      <Card>
+        <h3>3. styled(Component) 확장</h3>
+        <DangerButton onClick={() => setCount(0)}>Reset</DangerButton>
+      </Card>
+
+      <Card>
+        <h3>4. .attrs() default props</h3>
+        <Input placeholder="type: text 자동 부여됨" />
+      </Card>
+
+      <Card>
+        <h3>5. keyframes 애니메이션</h3>
+        <Spinner />
+      </Card>
+
+      <FancyCard>
+        <h3>6. css helper + 7. createGlobalStyle</h3>
+        <p>elevated css 가 재사용되어 그림자 + 살짝 들림. GlobalReset 도 같이 적용.</p>
+      </FancyCard>
+    </>
+  );
+}

--- a/examples/web/tsconfig.json
+++ b/examples/web/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src/**/*", "zts.config.ts"]
+}

--- a/examples/web/zts.config.ts
+++ b/examples/web/zts.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "@zts/core";
+
+export default defineConfig({
+  entryPoints: ["src/main.tsx"],
+  outdir: "dist",
+  format: "esm",
+  platform: "browser",
+  target: "es2022",
+  jsx: "automatic",
+  sourcemap: true,
+  // compiler 네임스페이스 — @next/swc 와 동일한 surface 를 따름.
+  // 현재는 타입 stub 단계: Zig transformer 가 아직 인식하지 않으므로 런타임 효과 없음.
+  // 후속 PR (#TBD) 에서 styled-components / emotion 1st-party transform 도입 시 활성화.
+  compiler: {
+    styledComponents: true,
+    emotion: true,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "./packages/core",
     "./packages/wasm",
     "./documents",
+    "./examples/web",
     "./tests/integration",
     "./tests/e2e",
     "./tests/benchmark"

--- a/packages/core/bin/zts-cli-schema-sync.test.ts
+++ b/packages/core/bin/zts-cli-schema-sync.test.ts
@@ -334,7 +334,8 @@ describe("CLI flag ↔ BuildOptions / TranspileOptions schema sync", () => {
   // 키 추가 시 그곳 1곳에만 등록하면 typo-suggest 와 cli-schema-sync 모두 자동 통과.
   const buildOptionsOnlyKeys: ReadonlySet<string> = new Set([
     ...NAPI_INTERNAL_ONLY_KEYS,
-    // 함수형 (CLI 표현 불가)
+    // 함수형 / 중첩 객체 (CLI 표현 불가)
+    "compiler", // compiler.styledComponents / compiler.emotion — 중첩 객체, CLI 미노출
     "manualChunks",
     "plugins",
     // entry — positional argument (flag 아님)

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -296,6 +296,57 @@ export interface ManualChunksMeta {
 }
 
 /**
+ * `compiler` 네임스페이스 — 라이브러리별 1st-party transform 설정 (`@next/swc` 호환 surface).
+ *
+ * 현재는 타입 stub. Zig transformer 가 아직 인식하지 않아 런타임 효과 없음.
+ * 후속 epic 에서 styled-components / emotion 1st-party transform 도입 시 활성화.
+ */
+export interface CompilerOptions {
+  /**
+   * styled-components 1st-party transform.
+   * `babel-plugin-styled-components` / `@swc/plugin-styled-components` 와 동일한 변환 의도.
+   */
+  styledComponents?: boolean | StyledComponentsOptions;
+  /**
+   * emotion 1st-party transform.
+   * `@emotion/babel-plugin` / `@swc/plugin-emotion` 와 동일한 변환 의도.
+   */
+  emotion?: boolean | EmotionOptions;
+}
+
+/** styled-components transform 옵션 (`babel-plugin-styled-components` 호환). */
+export interface StyledComponentsOptions {
+  /** devtools 표시용 displayName 자동 부여 (default: NODE_ENV !== "production") */
+  displayName?: boolean;
+  /** SSR hydration 안정화용 결정론적 componentId hash (default: true) */
+  ssr?: boolean;
+  /** componentId 에 파일명 포함 (default: true) */
+  fileName?: boolean;
+  /** CSS 화이트스페이스 minify (default: true) */
+  minify?: boolean;
+  /** 모던 JS 로 다운레벨된 템플릿 리터럴 인식 (default: true) */
+  transpileTemplateLiterals?: boolean;
+  /** styled.X 가 부수효과 없음을 minifier 에 알림 (default: false) */
+  pure?: boolean;
+  /** displayName / componentId 의 namespace prefix — 다중 styled 인스턴스 격리 */
+  namespace?: string;
+  /** [meta] 표시 (default: false) */
+  meta?: boolean;
+}
+
+/** emotion transform 옵션 (`@emotion/babel-plugin` 호환). */
+export interface EmotionOptions {
+  /** sourceMap 생성 (default: true) */
+  sourceMap?: boolean;
+  /** 변수명을 CSS class label 로 자동 부여 (default: "dev-only") */
+  autoLabel?: "always" | "dev-only" | "never";
+  /** label format string. tokens: `[local]`, `[filename]`, `[dirname]` (default: "[local]") */
+  labelFormat?: string;
+  /** import 경로 alias — fork 또는 vendored emotion 사용 시 */
+  importMap?: Record<string, Record<string, { canonicalImport: [string, string] }>>;
+}
+
+/**
  * Common build options shared by all platforms.
  * `platform` + `target` 조합은 `BuildOptions` 에서 discriminated union으로 제한됨.
  */
@@ -579,6 +630,23 @@ interface BuildOptionsCommon {
    *   을 호출해 lazy 엔드포인트로 serve 하는 경우 권장.
    */
   emitDiskSourcemap?: boolean;
+  /**
+   * 라이브러리별 1st-party transform 설정 (`@next/swc` 의 `compiler` 와 호환 surface).
+   *
+   * 현재는 타입 stub — Zig transformer 가 아직 인식하지 않아 런타임 효과 없음.
+   * 후속 epic 에서 styled-components / emotion 1st-party transform 도입 시 활성화.
+   *
+   * @example
+   * ```ts
+   * defineConfig({
+   *   compiler: {
+   *     styledComponents: true,
+   *     emotion: { autoLabel: "dev-only" },
+   *   },
+   * });
+   * ```
+   */
+  compiler?: CompilerOptions;
 }
 
 /**

--- a/packages/core/src/typo-suggest.ts
+++ b/packages/core/src/typo-suggest.ts
@@ -181,6 +181,8 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   "charsetUtf8",
   "asciiOnly",
   "quotes",
+  // ─── 1st-party transform 네임스페이스 (compiler.styledComponents/emotion 등) ───
+  "compiler",
   // ─── 기타 ───
   "flow",
   "plugins",

--- a/src/config_options_dto_test.zig
+++ b/src/config_options_dto_test.zig
@@ -215,6 +215,9 @@ const ts_buildoptions_only_allowlist = [_][]const u8{
     "target",
     "browserslist",
     "plugins",
+    "compiler", // 1st-party transform 네임스페이스 (compiler.styledComponents/emotion).
+    // 현재 stub — Zig transformer 가 아직 인식하지 않음. 후속 PR 에서 styled-components /
+    // emotion transform 도입 시 Zig DTO 로 옮김.
     "jsxSideEffects",
     "assetRegistry", // RN asset_registry 모듈 처리
     "scopeHoist", // bundler 옵션 (#1389)


### PR DESCRIPTION
## Summary

styled-components / emotion 1st-party transform 도입을 위한 **foundation PR**. 실제 Zig transformer 작업은 후속 PR 로 분리.

- **`examples/web/`** 신규 — React 19 + styled-components 6 + @emotion/react 11 데모. 향후 transform 의 회귀 검증 베이스.
- **`@zts/core` 공개 타입에 `CompilerOptions` / `StyledComponentsOptions` / `EmotionOptions` 추가**. surface 는 [`@next/swc` 의 `compiler.*`](https://nextjs.org/docs/app/api-reference/config/next-config-js/compiler) 와 호환.
- **typo-suggest / cli-schema-sync / Zig DTO allowlist 동기화** — 새 `compiler` 키가 unknown 경고 안 나오게 등록 (3개 단일 source 한 번씩).

## 변경 파일

### examples/web/ (신규)
| 파일 | 설명 |
|---|---|
| `src/styled-cases.tsx` | styled-components 7가지 패턴 (basic / props interp / styled() / .attrs() / keyframes / css helper / createGlobalStyle) |
| `src/emotion-cases.tsx` | emotion 4가지 패턴 (css prop / emotion styled / dynamic / Global) |
| `src/App.tsx`, `src/main.tsx` | React 19 entry + 카드 레이아웃 |
| `zts.config.ts` | `compiler.styledComponents/emotion: true` (현재 stub) |
| `package.json`, `tsconfig.json`, `index.html`, `README.md` | 표준 셋업 |

### @zts/core
- `index.ts` — 신규 `CompilerOptions` / `StyledComponentsOptions` / `EmotionOptions` interface, `BuildOptionsCommon.compiler?: CompilerOptions` 추가
- `src/typo-suggest.ts` — `KNOWN_CONFIG_KEYS` 에 `\"compiler\"` 등록
- `bin/zts-cli-schema-sync.test.ts` — `buildOptionsOnlyKeys` 에 `\"compiler\"` (CLI 미노출, 중첩 객체)

### Zig
- `src/config_options_dto_test.zig` — `ts_buildoptions_only_allowlist` 에 `\"compiler\"` 등록 (Zig DTO 미노출, 의도된 stub)

### root
- `package.json` workspaces 에 `./examples/web` 추가

## 옵션 surface (next.config.js 호환)

\`\`\`ts
defineConfig({
  compiler: {
    styledComponents: true,
    // 또는 세밀하게:
    // styledComponents: {
    //   displayName: true,
    //   ssr: true,
    //   fileName: true,
    //   minify: true,
    //   transpileTemplateLiterals: true,
    //   pure: false,
    // },
    emotion: true,
    // 또는:
    // emotion: {
    //   sourceMap: true,
    //   autoLabel: \"dev-only\",  // \"always\" | \"dev-only\" | \"never\"
    //   labelFormat: \"[local]\",
    // },
  },
});
\`\`\`

## 검증

- ✅ `bun test` (packages/core): 678/679 pass — 1 failure 는 `.env watch` flaky 타이밍 테스트로 본 PR 변경과 무관
- ✅ `zig build test`: 4118/4118 pass (DTO sync 통과)
- ✅ `examples/web/$ bun run build`: 정상 (1.45MB unminified, hashed asset path 정상)
- ⏸️ `examples/web/$ bun run dev`: HMR 본격 회귀 검증은 transform 도입 후 별도 PR 에서

## 후속 PR

별도 브랜치/PR 로 분리 — Zig transformer 신규 visitor 작성 + componentId hash + displayName injection + import source 감지 + NAPI threading 등 multi-day epic.

- [ ] styled-components 1st-party transform (Zig)
- [ ] emotion 1st-party transform (Zig)

## 레퍼런스 (gitignored, `references/` 아래 clone)

| 위치 | 라이선스 | 용도 |
|---|---|---|
| `references/styled-components-babel/` | MIT | babel-plugin-styled-components 원본 spec |
| `references/swc-plugins/packages/styled-components/` | Apache 2.0 | Rust 구현 참고 |
| `references/emotion/packages/babel-plugin/` | MIT | @emotion/babel-plugin 원본 spec |
| `references/swc-plugins/packages/emotion/` | Apache 2.0 | Rust 구현 참고 |

후속 transform PR 에서 fixtures 통째로 회귀 테스트로 가져올 예정.

## Test plan

- [ ] reviewer 가 `bun install` → `cd examples/web && bun run build` 로 build 동작 확인
- [ ] `bun run dev` 으로 React HMR 정상인지 확인 (transform 없는 baseline)
- [ ] `compiler.styledComponents` 자동완성이 IDE 에서 노출되는지 (TS 타입 인식)
- [ ] `bun run test` (packages/core) 회귀 없음
- [ ] `zig build test` DTO sync 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)