### PR TITLE
feat(transformer): styled-components withConfig({displayName}) 표준 출력

### DIFF
--- a/src/transformer/plugin_state.zig
+++ b/src/transformer/plugin_state.zig
@@ -64,22 +64,11 @@ pub const RefreshState = struct {
     suppress_registration: bool = false,
 };
 
-/// styled-components 1st-party transform 의 감지 결과.
-/// 변환 완료 후 프로그램 끝에 `<Var>.displayName = "<Var>";` 주입에 사용.
-pub const StyledComponentRegistration = struct {
-    /// 컴포넌트 변수 이름 (= displayName 값)
-    name: []const u8,
-};
-
 pub const StyledComponentsState = struct {
     /// `import styled from "styled-components"` 의 default binding 로컬 이름.
     /// alias 가 있으면 그 이름 (예: `import s from "styled-components"` → "s").
-    /// import 가 없으면 null — 이후 모든 detection 이 no-op.
+    /// import 가 없으면 null — 이후 모든 wrap 이 no-op.
     default_binding: ?[]const u8 = null,
-
-    /// 감지된 styled 컴포넌트 목록.
-    /// 변환 완료 후 프로그램 끝에서 일괄 주입.
-    registrations: std.ArrayList(StyledComponentRegistration) = .empty,
 };
 
 pub const PluginState = struct {

--- a/src/transformer/plugin_state.zig
+++ b/src/transformer/plugin_state.zig
@@ -69,6 +69,11 @@ pub const StyledComponentsState = struct {
     /// alias 가 있으면 그 이름 (예: `import s from "styled-components"` → "s").
     /// import 가 없으면 null — 이후 모든 wrap 이 no-op.
     default_binding: ?[]const u8 = null,
+
+    /// `.withConfig({...})` 래핑 시 매 컴포넌트마다 동일 문자열을 string_table 에 추가하는
+    /// 비용을 피하기 위한 lazy 캐시. 첫 wrap 시점에 채워짐.
+    with_config_span: ?Span = null,
+    display_name_span: ?Span = null,
 };
 
 pub const PluginState = struct {

--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -8,7 +8,15 @@ const CodegenOptions = helpers.CodegenOptions;
 
 const default_cg: CodegenOptions = .{ .minify_whitespace = false };
 
-test "styled-components: styled.X 선언에 displayName 주입" {
+/// 출력에 `withConfig({ displayName: "<expected>" })` 가 나타나는지 검증 (whitespace tolerant).
+fn expectDisplayName(output: []const u8, expected: []const u8) !void {
+    var quoted_buf: [256]u8 = undefined;
+    const needle = std.fmt.bufPrint(&quoted_buf, "displayName: \"{s}\"", .{expected}) catch return error.OutOfMemory;
+    try std.testing.expect(std.mem.indexOf(u8, output, needle) != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "withConfig") != null);
+}
+
+test "styled-components: styled.X 선언 → withConfig({displayName}) 래핑" {
     var r = try e2eFull(
         std.testing.allocator,
         \\import styled from "styled-components";
@@ -19,12 +27,10 @@ test "styled-components: styled.X 선언에 displayName 주입" {
         ".tsx",
     );
     defer r.deinit();
-
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "Button.displayName=\"Button\"") != null or
-        std.mem.indexOf(u8, r.output, "Button.displayName = \"Button\"") != null);
+    try expectDisplayName(r.output, "Button");
 }
 
-test "styled-components: styled(Component) 선언에 displayName 주입" {
+test "styled-components: styled(Component) 선언 → withConfig({displayName})" {
     var r = try e2eFull(
         std.testing.allocator,
         \\import styled from "styled-components";
@@ -36,12 +42,10 @@ test "styled-components: styled(Component) 선언에 displayName 주입" {
         ".tsx",
     );
     defer r.deinit();
-
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "Wrapped.displayName=\"Wrapped\"") != null or
-        std.mem.indexOf(u8, r.output, "Wrapped.displayName = \"Wrapped\"") != null);
+    try expectDisplayName(r.output, "Wrapped");
 }
 
-test "styled-components: 옵션 비활성 시 주입 없음" {
+test "styled-components: 옵션 비활성 시 변환 없음" {
     var r = try e2eFull(
         std.testing.allocator,
         \\import styled from "styled-components";
@@ -52,11 +56,11 @@ test "styled-components: 옵션 비활성 시 주입 없음" {
         ".tsx",
     );
     defer r.deinit();
-
-    try std.testing.expect(std.mem.indexOf(u8, r.output, ".displayName") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "displayName") == null);
 }
 
-test "styled-components: import 없으면 주입 없음" {
+test "styled-components: import 없으면 변환 없음" {
     // styled binding 이 없으므로 detection no-op. 옵션 활성이어도 변환 안 일어남.
     var r = try e2eFull(
         std.testing.allocator,
@@ -68,8 +72,7 @@ test "styled-components: import 없으면 주입 없음" {
         ".tsx",
     );
     defer r.deinit();
-
-    try std.testing.expect(std.mem.indexOf(u8, r.output, ".displayName") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") == null);
 }
 
 test "styled-components: @emotion/styled source 는 미감지" {
@@ -83,8 +86,7 @@ test "styled-components: @emotion/styled source 는 미감지" {
         ".tsx",
     );
     defer r.deinit();
-
-    try std.testing.expect(std.mem.indexOf(u8, r.output, ".displayName") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") == null);
 }
 
 test "styled-components: .attrs(...) chain 은 skip (이번 PR 스코프 외)" {
@@ -98,8 +100,10 @@ test "styled-components: .attrs(...) chain 은 skip (이번 PR 스코프 외)" {
         ".tsx",
     );
     defer r.deinit();
-
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "Input.displayName") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Input") != null);
+    // chain 안에 .withConfig 이 끼워져선 안 됨 (root tag detection 만 인식).
+    // attrs 의 type:"text" object 에 displayName 이 들어가면 안 됨 — withConfig 자체가 없어야 함.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") == null);
 }
 
 test "styled-components: styled-components/native source 도 인식" {
@@ -113,9 +117,7 @@ test "styled-components: styled-components/native source 도 인식" {
         ".tsx",
     );
     defer r.deinit();
-
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "Box.displayName=\"Box\"") != null or
-        std.mem.indexOf(u8, r.output, "Box.displayName = \"Box\"") != null);
+    try expectDisplayName(r.output, "Box");
 }
 
 test "styled-components: import alias 도 추적" {
@@ -130,7 +132,21 @@ test "styled-components: import alias 도 추적" {
         ".tsx",
     );
     defer r.deinit();
+    try expectDisplayName(r.output, "Btn");
+}
 
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "Btn.displayName=\"Btn\"") != null or
-        std.mem.indexOf(u8, r.output, "Btn.displayName = \"Btn\"") != null);
+test "styled-components: template literal 내용은 그대로 보존" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const C = styled.div`width: 100%; color: ${'red'};`;
+    ,
+        .{ .styled_components = true },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "C");
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "width: 100%") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "color:") != null);
 }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -675,7 +675,6 @@ pub const Transformer = struct {
             root = try self.appendRefreshRegistrations(root);
         }
 
-
         self.ast.transformed_root = root;
         self.ast.assertInvariants();
         return root;

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2917,16 +2917,20 @@ pub const Transformer = struct {
     /// variable_declarator: extra_data = [name, type_ann, init]
     fn visitVariableDeclarator(self: *Transformer, node: Node) Error!NodeIndex {
         const e = node.data.extra;
-        const name_idx = self.readNodeIdx(e, 0);
-        const new_name = try self.visitNode(name_idx);
+        const new_name = try self.visitNode(self.readNodeIdx(e, 0));
         var new_init = try self.visitNode(self.readNodeIdx(e, 2));
-        // styled-components: post-visit 로 init 이 styled tagged template 이면 tag 를
-        // `.withConfig({displayName})` 로 wrap. binding name 은 변환 후에도 변동 없음.
-        if (!new_init.isNone() and !name_idx.isNone() and self.options.styled_components) {
-            const name_node = self.ast.getNode(name_idx);
-            if (name_node.tag == .binding_identifier or name_node.tag == .identifier_reference) {
-                const var_name = self.ast.getText(name_node.data.string_ref);
-                new_init = try styled_components_mod.maybeWrapStyledTag(self, new_init, var_name);
+        // styled-components: tag 를 `.withConfig({displayName})` 로 wrap. fast-path 로 1) 옵션,
+        // 2) binding 감지, 3) init.tag == tagged_template_expression 을 사전 거른 뒤에만
+        // 본 helper 호출. var_name 은 block-scoping rename 후 안전하도록 new_name 에서 읽음.
+        if (self.options.styled_components and
+            self.plugins.styled_components.default_binding != null and
+            !new_init.isNone() and !new_name.isNone() and
+            self.ast.getNode(new_init).tag == .tagged_template_expression)
+        {
+            const new_name_node = self.ast.getNode(new_name);
+            if (new_name_node.tag == .binding_identifier or new_name_node.tag == .identifier_reference) {
+                const var_name = self.ast.getText(new_name_node.data.string_ref);
+                new_init = try styled_components_mod.wrapStyledTag(self, new_init, var_name);
             }
         }
         const none = @intFromEnum(NodeIndex.none);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -569,7 +569,6 @@ pub const Transformer = struct {
         self.plugins.refresh.registrations.deinit(self.allocator);
         for (self.plugins.refresh.signatures.items) |s| self.allocator.free(s.signature);
         self.plugins.refresh.signatures.deinit(self.allocator);
-        self.plugins.styled_components.registrations.deinit(self.allocator);
         self.trailing_nodes.deinit(self.allocator);
         self.generator_label_stack.deinit(self.allocator);
         self.generator_temp_var_spans.deinit(self.allocator);
@@ -676,10 +675,6 @@ pub const Transformer = struct {
             root = try self.appendRefreshRegistrations(root);
         }
 
-        // styled-components: PR 1 은 displayName 만, withConfig / componentId 는 후속.
-        if (self.options.styled_components and self.plugins.styled_components.registrations.items.len > 0) {
-            root = try styled_components_mod.appendDisplayNameAssignments(self, root);
-        }
 
         self.ast.transformed_root = root;
         self.ast.assertInvariants();
@@ -2921,11 +2916,19 @@ pub const Transformer = struct {
 
     /// variable_declarator: extra_data = [name, type_ann, init]
     fn visitVariableDeclarator(self: *Transformer, node: Node) Error!NodeIndex {
-        try styled_components_mod.detectStyledDeclaration(self, node);
-
         const e = node.data.extra;
-        const new_name = try self.visitNode(self.readNodeIdx(e, 0));
-        const new_init = try self.visitNode(self.readNodeIdx(e, 2));
+        const name_idx = self.readNodeIdx(e, 0);
+        const new_name = try self.visitNode(name_idx);
+        var new_init = try self.visitNode(self.readNodeIdx(e, 2));
+        // styled-components: post-visit 로 init 이 styled tagged template 이면 tag 를
+        // `.withConfig({displayName})` 로 wrap. binding name 은 변환 후에도 변동 없음.
+        if (!new_init.isNone() and !name_idx.isNone() and self.options.styled_components) {
+            const name_node = self.ast.getNode(name_idx);
+            if (name_node.tag == .binding_identifier or name_node.tag == .identifier_reference) {
+                const var_name = self.ast.getText(name_node.data.string_ref);
+                new_init = try styled_components_mod.maybeWrapStyledTag(self, new_init, var_name);
+            }
+        }
         const none = @intFromEnum(NodeIndex.none);
         return self.addExtraNode(.variable_declarator, node.span, &.{ @intFromEnum(new_name), none, @intFromEnum(new_init) });
     }

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -11,22 +11,23 @@
 //! import styled from "styled-components";
 //! const Button = styled.div`color: red;`;
 //!
-//! // 출력 (babel-plugin-styled-components 의 표준 형태)
+//! // 출력 (이번 PR — babel/swc 표준 형태)
 //! import styled from "styled-components";
 //! const Button = styled.div.withConfig({ displayName: "Button" })`color: red;`;
 //! ```
 //!
-//! 본 ZTS 구현은 **iterative**:
-//! - **현재 (이번 PR)**: post-declaration `Button.displayName = "Button";` — DevTools 표시 충족
-//! - **후속 PR**: `.withConfig(...)` 래핑 + componentId hash + SSR 안정화
+//! ## 진화
+//!
+//! - PR 2228 (이전): post-decl `Button.displayName = "Button";` — DevTools 만 충족
+//! - **본 PR**: in-place `.withConfig({ displayName })` 래핑 — babel/swc 호환 출력
+//! - 후속 PR: componentId hash + SSR 안정화 + chained `.attrs(...)` / `.withConfig(...)`
 //!
 //! ## hook point
 //!
-//! - `visitImportDeclaration`: source 가 "styled-components" / "styled-components/native" 면
-//!   default specifier 의 로컬 이름을 `state.default_binding` 에 저장.
-//! - `visitVariableDeclarator`: init 이 `<binding>.X\`...\`` / `<binding>(X)\`...\`` 형태이면
-//!   `state.registrations` 에 변수 이름 추가.
-//! - 프로그램 끝 (`run`): registrations 마다 `<name>.displayName = "<name>";` 주입.
+//! - `visitImportDeclaration`: source 가 styled-components 면 default specifier 의 로컬
+//!   이름을 `state.default_binding` 에 저장.
+//! - `visitVariableDeclarator`: init 변환 후 결과가 `<binding>.X\`...\`` /
+//!   `<binding>(arg)\`...\`` 이면 tag 를 `.withConfig({...})` 로 wrap 한 새 노드로 교체.
 //!
 //! ## 미지원 케이스 (후속 PR)
 //!
@@ -47,7 +48,6 @@ const import_scanner = @import("../../bundler/import_scanner.zig");
 const transformer_mod = @import("../transformer.zig");
 const Transformer = transformer_mod.Transformer;
 const Error = Transformer.Error;
-const StyledComponentRegistration = @import("../plugin_state.zig").StyledComponentRegistration;
 
 /// v6+ 는 "/native" subpath 도 인정. 추가될 가능성 있음 (vendored fork 등).
 pub const STYLED_SOURCES: []const []const u8 = &.{
@@ -117,119 +117,102 @@ fn tagUsesBinding(self: *Transformer, tag_idx: NodeIndex) bool {
     return std.mem.eql(u8, self.ast.getText(root_node.data.string_ref), binding);
 }
 
-/// `visitVariableDeclarator` hook — init 이 styled tagged template 이면 변수 이름을 등록.
-pub fn detectStyledDeclaration(self: *Transformer, node: Node) Error!void {
-    if (!self.options.styled_components) return;
-    if (self.plugins.styled_components.default_binding == null) return;
-
-    // variable_declarator extra = [name, type_annotation, init]
-    const e = node.data.extra;
-    if (!self.ast.hasExtra(e, 2)) return;
-    const name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
-    const init_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 2]);
-    if (init_idx.isNone()) return;
+/// `visitVariableDeclarator` 의 post-visit hook. visit 후 init 이 styled tagged template
+/// 이면 tag 를 `.withConfig({displayName})` 로 wrap 한 새 tagged_template 으로 교체.
+///
+/// 옵션 비활성 / binding 미감지 / pattern 불일치 시 init_idx 그대로 반환.
+pub fn maybeWrapStyledTag(self: *Transformer, init_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
+    if (!self.options.styled_components) return init_idx;
+    if (self.plugins.styled_components.default_binding == null) return init_idx;
+    if (var_name.len == 0) return init_idx;
+    if (init_idx.isNone()) return init_idx;
 
     const init_node = self.ast.getNode(init_idx);
-    if (init_node.tag != .tagged_template_expression) return;
+    if (init_node.tag != .tagged_template_expression) return init_idx;
 
-    // tagged_template_expression extra = [tag, template, flags]
-    const te = init_node.data.extra;
-    if (!self.ast.hasExtra(te, 1)) return;
-    const tag_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[te]);
-    if (!tagUsesBinding(self, tag_idx)) return;
+    // tagged_template extra = [tag, template, flags]
+    const e = init_node.data.extra;
+    if (!self.ast.hasExtra(e, 2)) return init_idx;
+    const tag_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+    const template_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 1]);
+    const flags = self.ast.extra_data.items[e + 2];
 
-    if (name_idx.isNone()) return;
-    const name_node = self.ast.getNode(name_idx);
-    if (name_node.tag != .binding_identifier and name_node.tag != .identifier_reference) return;
-    const var_name = self.ast.getText(name_node.data.string_ref);
-    if (var_name.len == 0) return;
+    if (!tagUsesBinding(self, tag_idx)) return init_idx;
 
-    try self.plugins.styled_components.registrations.append(self.allocator, .{ .name = var_name });
+    // 새 tag = <orig_tag>.withConfig({ displayName: "<var_name>" })
+    const new_tag = try buildWithConfigCall(self, tag_idx, var_name);
+
+    // 새 tagged_template — 같은 template + flags, 새 tag.
+    const new_extra = try self.ast.addExtras(&.{
+        @intFromEnum(new_tag),
+        @intFromEnum(template_idx),
+        flags,
+    });
+    return self.ast.addNode(.{
+        .tag = .tagged_template_expression,
+        .span = init_node.span,
+        .data = .{ .extra = new_extra },
+    });
 }
 
-// ================================================================
-// AST 변환 — 프로그램 끝에 displayName 할당문 주입
-// ================================================================
-
-/// `<Var>.displayName = "<Var>";` 단일 expression_statement 빌드.
-/// `display_name_span` 은 caller 에서 한 번만 만들어 재사용 (per-registration addString 회피).
-fn buildDisplayNameAssignment(
-    self: *Transformer,
-    reg: StyledComponentRegistration,
-    display_name_span: Span,
-) Error!NodeIndex {
+/// `<tag>.withConfig({ displayName: "<var_name>" })` call_expression 빌드.
+fn buildWithConfigCall(self: *Transformer, tag_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
     const zero = Span{ .start = 0, .end = 0 };
-    const name_span = try self.ast.addString(reg.name);
+    const with_config_span = try self.ast.addString("withConfig");
+    const display_name_key_span = try self.ast.addString("displayName");
     var quoted_buf: [256]u8 = undefined;
-    const quoted = std.fmt.bufPrint(&quoted_buf, "\"{s}\"", .{reg.name}) catch return error.OutOfMemory;
+    const quoted = std.fmt.bufPrint(&quoted_buf, "\"{s}\"", .{var_name}) catch return error.OutOfMemory;
     const quoted_span = try self.ast.addString(quoted);
 
-    const obj_ref = try self.ast.addNode(.{
+    // <tag>.withConfig — static_member_expression
+    const with_config_ref = try self.ast.addNode(.{
         .tag = .identifier_reference,
-        .span = name_span,
-        .data = .{ .string_ref = name_span },
+        .span = with_config_span,
+        .data = .{ .string_ref = with_config_span },
     });
-    const prop_ref = try self.ast.addNode(.{
-        .tag = .identifier_reference,
-        .span = display_name_span,
-        .data = .{ .string_ref = display_name_span },
-    });
-    const member = try self.addExtraNode(.static_member_expression, zero, &.{
-        @intFromEnum(obj_ref),
-        @intFromEnum(prop_ref),
+    const member = try addExtraNode(self, .static_member_expression, zero, &.{
+        @intFromEnum(tag_idx),
+        @intFromEnum(with_config_ref),
         0,
+    });
+
+    // displayName: "<var_name>" — object_property (binary = { left=key, right=value, flags=0 })
+    const key = try self.ast.addNode(.{
+        .tag = .identifier_reference,
+        .span = display_name_key_span,
+        .data = .{ .string_ref = display_name_key_span },
     });
     const value = try self.ast.addNode(.{
         .tag = .string_literal,
         .span = quoted_span,
         .data = .{ .string_ref = quoted_span },
     });
-    const assign = try self.ast.addNode(.{
-        .tag = .assignment_expression,
+    const property = try self.ast.addNode(.{
+        .tag = .object_property,
         .span = zero,
-        .data = .{ .binary = .{ .left = member, .right = value, .flags = 0 } },
+        .data = .{ .binary = .{ .left = key, .right = value, .flags = 0 } },
     });
-    return self.ast.addNode(.{
-        .tag = .expression_statement,
+
+    // { displayName: "..." } — object_expression (list of properties)
+    const obj_list = try self.ast.addNodeList(&.{property});
+    const obj = try self.ast.addNode(.{
+        .tag = .object_expression,
         .span = zero,
-        .data = .{ .unary = .{ .operand = assign, .flags = 0 } },
+        .data = .{ .list = obj_list },
+    });
+
+    // <tag>.withConfig({...}) — call_expression (extra = [callee, args_start, args_len, flags])
+    const args = try self.ast.addNodeList(&.{obj});
+    return addExtraNode(self, .call_expression, zero, &.{
+        @intFromEnum(member),
+        args.start,
+        args.len,
+        0,
     });
 }
 
-/// `addExtraNode` thin wrapper — `Transformer.addExtraNode` (transformer.zig:2772) 와 동일,
-/// 모듈 외부에서도 호출 가능하도록 노출.
+/// `Transformer.addExtraNode` 와 동일 — 모듈 외부에서도 호출 가능하도록 wrapper.
 fn addExtraNode(self: *Transformer, tag: Node.Tag, span: Span, extras: []const u32) Error!NodeIndex {
     const e = try self.ast.addExtras(extras);
     return self.ast.addNode(.{ .tag = tag, .span = span, .data = .{ .extra = e } });
-}
-
-/// 프로그램 body 끝에 등록된 styled 컴포넌트마다 `<Var>.displayName = "<Var>";` 추가.
-pub fn appendDisplayNameAssignments(self: *Transformer, root: NodeIndex) Error!NodeIndex {
-    const prog = self.ast.getNode(root);
-    if (prog.tag != .program) return root;
-    if (self.plugins.styled_components.registrations.items.len == 0) return root;
-
-    // "displayName" 은 모든 할당이 공유하므로 단일 span 으로 캐싱 (refresh.zig:105 의 $RefreshReg$ 패턴).
-    const display_name_span = try self.ast.addString("displayName");
-
-    const old_list = prog.data.list;
-    const old_stmts = self.ast.extra_data.items[old_list.start .. old_list.start + old_list.len];
-
-    const scratch_top = self.scratch.items.len;
-    defer self.scratch.shrinkRetainingCapacity(scratch_top);
-
-    for (old_stmts) |raw_idx| {
-        try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
-    }
-    for (self.plugins.styled_components.registrations.items) |reg| {
-        const stmt = try buildDisplayNameAssignment(self, reg, display_name_span);
-        try self.scratch.append(self.allocator, stmt);
-    }
-
-    const new_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
-    return self.ast.addNode(.{
-        .tag = .program,
-        .span = prog.span,
-        .data = .{ .list = new_list },
-    });
 }

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -117,18 +117,12 @@ fn tagUsesBinding(self: *Transformer, tag_idx: NodeIndex) bool {
     return std.mem.eql(u8, self.ast.getText(root_node.data.string_ref), binding);
 }
 
-/// `visitVariableDeclarator` 의 post-visit hook. visit 후 init 이 styled tagged template
-/// 이면 tag 를 `.withConfig({displayName})` 로 wrap 한 새 tagged_template 으로 교체.
-///
-/// 옵션 비활성 / binding 미감지 / pattern 불일치 시 init_idx 그대로 반환.
-pub fn maybeWrapStyledTag(self: *Transformer, init_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
-    if (!self.options.styled_components) return init_idx;
-    if (self.plugins.styled_components.default_binding == null) return init_idx;
+/// `visitVariableDeclarator` 의 post-visit hook. caller 가 init.tag 를 사전 검사한 뒤
+/// tagged_template_expression 일 때만 호출 — 옵션 비활성 / binding 미감지 / 다른 tag 면
+/// caller 가 미리 거른다.
+pub fn wrapStyledTag(self: *Transformer, init_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
     if (var_name.len == 0) return init_idx;
-    if (init_idx.isNone()) return init_idx;
-
     const init_node = self.ast.getNode(init_idx);
-    if (init_node.tag != .tagged_template_expression) return init_idx;
 
     // tagged_template extra = [tag, template, flags]
     const e = init_node.data.extra;
@@ -139,10 +133,7 @@ pub fn maybeWrapStyledTag(self: *Transformer, init_idx: NodeIndex, var_name: []c
 
     if (!tagUsesBinding(self, tag_idx)) return init_idx;
 
-    // 새 tag = <orig_tag>.withConfig({ displayName: "<var_name>" })
     const new_tag = try buildWithConfigCall(self, tag_idx, var_name);
-
-    // 새 tagged_template — 같은 template + flags, 새 tag.
     const new_extra = try self.ast.addExtras(&.{
         @intFromEnum(new_tag),
         @intFromEnum(template_idx),
@@ -156,27 +147,32 @@ pub fn maybeWrapStyledTag(self: *Transformer, init_idx: NodeIndex, var_name: []c
 }
 
 /// `<tag>.withConfig({ displayName: "<var_name>" })` call_expression 빌드.
+/// "withConfig" / "displayName" span 은 PluginState 에 lazy 캐싱 — 매 호출마다 string_table
+/// 에 같은 문자열이 append 되는 것을 피한다 (refresh.zig 의 $RefreshReg$ span 패턴과 동일).
 fn buildWithConfigCall(self: *Transformer, tag_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
     const zero = Span{ .start = 0, .end = 0 };
-    const with_config_span = try self.ast.addString("withConfig");
-    const display_name_key_span = try self.ast.addString("displayName");
+    const state = &self.plugins.styled_components;
+    if (state.with_config_span == null) state.with_config_span = try self.ast.addString("withConfig");
+    if (state.display_name_span == null) state.display_name_span = try self.ast.addString("displayName");
+    const with_config_span = state.with_config_span.?;
+    const display_name_key_span = state.display_name_span.?;
+
     var quoted_buf: [256]u8 = undefined;
     const quoted = std.fmt.bufPrint(&quoted_buf, "\"{s}\"", .{var_name}) catch return error.OutOfMemory;
     const quoted_span = try self.ast.addString(quoted);
 
-    // <tag>.withConfig — static_member_expression
     const with_config_ref = try self.ast.addNode(.{
         .tag = .identifier_reference,
         .span = with_config_span,
         .data = .{ .string_ref = with_config_span },
     });
-    const member = try addExtraNode(self, .static_member_expression, zero, &.{
+    // extra = [object, property, flags]
+    const member = try self.addExtraNode(.static_member_expression, zero, &.{
         @intFromEnum(tag_idx),
         @intFromEnum(with_config_ref),
         0,
     });
 
-    // displayName: "<var_name>" — object_property (binary = { left=key, right=value, flags=0 })
     const key = try self.ast.addNode(.{
         .tag = .identifier_reference,
         .span = display_name_key_span,
@@ -187,13 +183,13 @@ fn buildWithConfigCall(self: *Transformer, tag_idx: NodeIndex, var_name: []const
         .span = quoted_span,
         .data = .{ .string_ref = quoted_span },
     });
+    // object_property: binary = { left=key, right=value, flags }
     const property = try self.ast.addNode(.{
         .tag = .object_property,
         .span = zero,
         .data = .{ .binary = .{ .left = key, .right = value, .flags = 0 } },
     });
 
-    // { displayName: "..." } — object_expression (list of properties)
     const obj_list = try self.ast.addNodeList(&.{property});
     const obj = try self.ast.addNode(.{
         .tag = .object_expression,
@@ -201,18 +197,12 @@ fn buildWithConfigCall(self: *Transformer, tag_idx: NodeIndex, var_name: []const
         .data = .{ .list = obj_list },
     });
 
-    // <tag>.withConfig({...}) — call_expression (extra = [callee, args_start, args_len, flags])
+    // call_expression: extra = [callee, args_start, args_len, flags]
     const args = try self.ast.addNodeList(&.{obj});
-    return addExtraNode(self, .call_expression, zero, &.{
+    return self.addExtraNode(.call_expression, zero, &.{
         @intFromEnum(member),
         args.start,
         args.len,
         0,
     });
-}
-
-/// `Transformer.addExtraNode` 와 동일 — 모듈 외부에서도 호출 가능하도록 wrapper.
-fn addExtraNode(self: *Transformer, tag: Node.Tag, span: Span, extras: []const u32) Error!NodeIndex {
-    const e = try self.ast.addExtras(extras);
-    return self.ast.addNode(.{ .tag = tag, .span = span, .data = .{ .extra = e } });
 }


### PR DESCRIPTION
## Summary

styled-components transform 의 출력 형태를 babel-plugin-styled-components / @swc/plugin-styled-components 와 동일한 표준 형태로 전환.

- **이전 (PR #2228)**: post-decl `<X>.displayName = "<X>";` 주입 — DevTools 만 충족
- **본 PR**: in-place `<tag>.withConfig({ displayName: "<X>" })` 래핑 — babel/swc 호환

\`\`\`tsx
// 입력
import styled from \"styled-components\";
const Card = styled.div\`color: red;\`;

// 이전 PR #2228 (post-decl)
import styled from \"styled-components\";
const Card = styled.div\`color: red;\`;
Card.displayName = \"Card\";

// 본 PR (in-place withConfig — babel/swc 표준)
import styled from \"styled-components\";
const Card = styled.div.withConfig({ displayName: \"Card\" })\`color: red;\`;
\`\`\`

## 변경 내용

### 변환 로직 (`src/transformer/transformer/styled_components.zig`)
- `appendDisplayNameAssignments` / `buildDisplayNameAssignment` 제거 — program-end 주입 더 이상 불필요
- `wrapStyledTag` (post-visit hook) 추가 — visit 후 init 이 styled tagged template 이면 새 tag 로 교체
- `buildWithConfigCall` — `<tag>.withConfig({displayName: \"...\"})` call_expression 빌드 (member + object_expression + call)

### PluginState 정리 (`src/transformer/plugin_state.zig`)
- `StyledComponentRegistration` / `registrations: ArrayList` 제거. in-place 변환이라 collected list 불필요
- `with_config_span` / `display_name_span` lazy 캐시 필드 추가 (각 styled 컴포넌트마다 동일 문자열 string_table append 회피)

### Visitor wiring (`src/transformer/transformer.zig`)
- `visitVariableDeclarator` 가 visit 후 `wrapStyledTag` 호출. 사전 fast-path 체크:
  옵션 ON + binding 감지 + init.tag == tagged_template_expression 만 진입
- `var_name` 은 **post-visit `new_name` 에서** 읽음 — block scoping rename 안전성 (예: ES5 target 의 `Btn` → `Btn\$1` 시 displayName 도 일치)
- 프로그램 끝 styled_components 주입 블록 제거
- deinit 의 registrations 정리 라인 제거

### 회귀 테스트 (`src/transformer/styled_components_test.zig`)
- 9개 (8개 갱신 + 1개 신규)
- `expectDisplayName` helper — `displayName: \"X\"` + `withConfig` 동시 검증
- chain 케이스에서 `withConfig` 가 안 나오는지 검증 강화
- 템플릿 literal 본문 보존 새 테스트 추가

## /simplify 결과 반영

3 agent 리뷰에서 적용한 fix:

- 모듈 내 `addExtraNode` wrapper 제거 — `Transformer.addExtraNode` 가 이미 pub
- `var_name` 을 `name_node` (pre-visit) 가 아닌 `new_name` (post-visit) 에서 읽음 — block scoping rename 안전성
- `withConfig` / `displayName` string_table span 을 `PluginState` 에 lazy 캐싱 — `refresh.zig:105` 의 `\$RefreshReg\$` 패턴과 동일
- `visitVariableDeclarator` 에서 `init.tag == tagged_template_expression` 사전 체크 — hot path 단축
- 자명한 WHAT 주석 4개 정리 (extra layout 코멘트는 load-bearing 유지)

defer 항목 (별도 PR):
- `buildIdentRef` / `buildQuotedStringLiteral` 공통 헬퍼 (refresh 와 부분 중복)
- `quoted_buf [256]u8` ceiling — 253-char 식별자 overflow 시 OOM 오해
- `expectDisplayName` 테스트 helper 의 분리 검증 → 단일 needle 강화

## 검증

- ✅ `zig build test`: 4127/4127 pass (1개 신규 테스트 추가)
- ✅ `examples/web` 빌드 — 5개 styled 컴포넌트 모두 새 format 으로 출력:
  \`\`\`
  Card = styled.div.withConfig({ displayName: \"Card\" })\`...\`
  Button = styled.button.withConfig({ displayName: \"Button\" })\`...\`
  DangerButton = styled(Button).withConfig({ displayName: \"DangerButton\" })\`...\`
  Spinner = styled.div.withConfig({ displayName: \"Spinner\" })\`...\`
  FancyCard = styled(Card).withConfig({ displayName: \"FancyCard\" })\`...\`
  \`\`\`
- ✅ 이전 post-decl 패턴은 출력에서 사라짐 (`<Component>.displayName = \"...\"` 0건)

## 후속 PR (별도 발행)

- [ ] `componentId` hash + `.withConfig` 안에 displayName 옆에 추가 (SSR 안정화)
- [ ] chained `.attrs(...)` / `.withConfig(...)` 케이스 인식
- [ ] 조건부 / 클래스 정적 필드 / 객체 프로퍼티
- [ ] `transpileTemplateLiterals` / CSS minify
- [ ] options 객체 form throughpass

## Test plan

- [ ] `cd examples/web && bun run build` — 결과 bundle 에 `withConfig({ displayName: \"X\" })` 5개
- [ ] `bun run dev` 으로 React DevTools 에서 컴포넌트 이름이 정상 표시 (이전 PR 과 동일)
- [ ] `compiler.styledComponents: false` → 변환 없음
- [ ] `@emotion/styled` / 비-styled-components import → 변환 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)