### PR TITLE
test(app): cover HTTPS SPA fallback preview

### DIFF
--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -2609,6 +2609,65 @@ describe("CLI: Vite-style app builder", () => {
     }
   });
 
+  test("preview --spa-fallback works over HTTPS", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-preview-spa-https-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(
+      join(dir, "index.html"),
+      '<main id="app">secure spa</main><script type="module" src="/src/main.ts"></script>',
+    );
+    writeFileSync(join(dir, "src", "main.ts"), "console.log('secure spa');");
+
+    const outdir = join(dir, "dist");
+    const buildResult = runCli(["build", dir, "--outdir", outdir, "--base", "/secure/"], {
+      cwd: dir,
+    });
+    expect(buildResult.exitCode).toBe(0);
+
+    const certFile = join(dir, "cert.pem");
+    const keyFile = join(dir, "key.pem");
+    execSync(
+      `openssl req -x509 -newkey rsa:2048 -keyout ${keyFile} -out ${certFile} -days 1 -nodes -subj "/CN=localhost" 2>/dev/null`,
+    );
+
+    const port = 12780 + Math.floor(Math.random() * 100);
+    const proc = spawn(
+      RUNTIME,
+      [
+        CLI,
+        "preview",
+        outdir,
+        `--port=${port}`,
+        "--base",
+        "/secure/",
+        "--spa-fallback",
+        "--certfile",
+        certFile,
+        "--keyfile",
+        keyFile,
+      ],
+      { cwd: dir },
+    );
+    await waitForServer(port, 20, 100, "https");
+
+    try {
+      const route = await fetch(`https://localhost:${port}/secure/dashboard/settings`, {
+        headers: { accept: "text/html" },
+        tls: { rejectUnauthorized: false },
+      } as any);
+      expect(route.status).toBe(200);
+      expect(await route.text()).toContain('<main id="app">secure spa</main>');
+
+      const missingAsset = await fetch(`https://localhost:${port}/secure/missing.png`, {
+        tls: { rejectUnauthorized: false },
+      } as any);
+      expect(missingAsset.status).toBe(404);
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("build injects modulepreload links for static split chunks", () => {
     const dir = mkdtempSync(join(tmpdir(), "zts-app-modulepreload-"));
     mkdirSync(join(dir, "src"), { recursive: true });


### PR DESCRIPTION
## 요약

- `zts preview --spa-fallback`이 HTTPS 서버에서도 route-like 요청을 fallback하는지 검증하는 회귀 테스트를 추가했습니다.
- 같은 테스트에서 asset-like missing path는 HTTPS에서도 fallback하지 않고 404를 유지하는지 확인합니다.

## 변경 사항

- `packages/core/bin/zts.test.ts`에 `preview --spa-fallback works over HTTPS` 테스트 추가
- 자체 서명 인증서를 생성해 `--certfile` / `--keyfile` 조합으로 preview 서버 실행
- `--base /secure/`와 함께 HTTPS route fallback 및 missing asset 404 검증

## 테스트

- `bun test packages/core/bin/zts.test.ts --test-name-pattern "preview --spa-fallback works over HTTPS|preview --spa-fallback serves index.html"`
- `bun test packages/core/bin/zts.test.ts --test-name-pattern "Vite-style app builder"`
- pre-push hook: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check` 통과

참고: pre-push의 `oxlint`는 기존 미사용 import warning 5개를 출력했지만 error 없이 통과했습니다.