### PR TITLE
feat(transformer): styled-components componentId hash + counter (SSR ready)

### DIFF
--- a/src/transformer/plugin_state.zig
+++ b/src/transformer/plugin_state.zig
@@ -74,6 +74,15 @@ pub const StyledComponentsState = struct {
     /// 비용을 피하기 위한 lazy 캐시. 첫 wrap 시점에 채워짐.
     with_config_span: ?Span = null,
     display_name_span: ?Span = null,
+    component_id_span: ?Span = null,
+
+    /// componentId hash 의 file 부분 — `options.jsx_filename` 의 wyhash 8-hex.
+    /// SSR hydration 안정화: 같은 파일에서 같은 hash 보장 (counter 와 결합).
+    file_hash_hex: ?[8]u8 = null,
+
+    /// componentId 의 0-based counter — 같은 파일 내 styled 컴포넌트 등장 순서.
+    /// SWC 의 next_id 와 동일 (sc-<file_hash>-<counter>).
+    component_counter: u32 = 0,
 };
 
 pub const PluginState = struct {

--- a/src/transformer/plugin_state.zig
+++ b/src/transformer/plugin_state.zig
@@ -76,12 +76,16 @@ pub const StyledComponentsState = struct {
     display_name_span: ?Span = null,
     component_id_span: ?Span = null,
 
-    /// componentId hash 의 file 부분 — `options.jsx_filename` 의 wyhash 8-hex.
+    /// componentId hash 의 file 부분 — `options.jsx_filename` 의 wyhash 32-bit truncated 8-hex.
     /// SSR hydration 안정화: 같은 파일에서 같은 hash 보장 (counter 와 결합).
+    /// 32-bit truncation 은 일반 monorepo (수만 파일) 에서도 collision 무시 가능.
     file_hash_hex: ?[8]u8 = null,
 
     /// componentId 의 0-based counter — 같은 파일 내 styled 컴포넌트 등장 순서.
     /// SWC 의 next_id 와 동일 (sc-<file_hash>-<counter>).
+    /// **Invariant**: Transformer 가 파일당 새로 생성된다는 가정에 의존 — 재사용 금지.
+    /// 주의: 컴포넌트 추가/순서 변경 시 이후 ID 가 모두 shift → partial-deploy SSR
+    /// mismatch 가능. Babel 의 name-based hash 와 trade-off (SWC fixture 호환 우선).
     component_counter: u32 = 0,
 };
 

--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -24,7 +24,7 @@ test "styled-components: styled.X 선언 → withConfig({displayName}) 래핑" {
         \\import styled from "styled-components";
         \\const Button = styled.div`color: red;`;
     ,
-        .{ .styled_components = true },
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
         default_cg,
         ".tsx",
     );
@@ -39,7 +39,7 @@ test "styled-components: styled(Component) 선언 → withConfig({displayName})"
         \\import Inner from "./inner";
         \\const Wrapped = styled(Inner)`color: blue;`;
     ,
-        .{ .styled_components = true },
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
         default_cg,
         ".tsx",
     );
@@ -69,7 +69,7 @@ test "styled-components: import 없으면 변환 없음" {
         \\const styled = { div: () => null };
         \\const Button = styled.div`color: red;`;
     ,
-        .{ .styled_components = true },
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
         default_cg,
         ".tsx",
     );
@@ -83,7 +83,7 @@ test "styled-components: @emotion/styled source 는 미감지" {
         \\import styled from "@emotion/styled";
         \\const Button = styled.div`color: red;`;
     ,
-        .{ .styled_components = true },
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
         default_cg,
         ".tsx",
     );
@@ -97,7 +97,7 @@ test "styled-components: .attrs(...) chain 은 skip (이번 PR 스코프 외)" {
         \\import styled from "styled-components";
         \\const Input = styled.input.attrs({ type: "text" })`padding: 4px;`;
     ,
-        .{ .styled_components = true },
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
         default_cg,
         ".tsx",
     );
@@ -114,7 +114,7 @@ test "styled-components: styled-components/native source 도 인식" {
         \\import styled from "styled-components/native";
         \\const Box = styled.View`padding: 16px;`;
     ,
-        .{ .styled_components = true },
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
         default_cg,
         ".tsx",
     );
@@ -129,7 +129,7 @@ test "styled-components: import alias 도 추적" {
         \\import s from "styled-components";
         \\const Btn = s.div`color: red;`;
     ,
-        .{ .styled_components = true },
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
         default_cg,
         ".tsx",
     );
@@ -143,7 +143,7 @@ test "styled-components: template literal 내용은 그대로 보존" {
         \\import styled from "styled-components";
         \\const C = styled.div`width: 100%; color: ${'red'};`;
     ,
-        .{ .styled_components = true },
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
         default_cg,
         ".tsx",
     );
@@ -151,6 +151,22 @@ test "styled-components: template literal 내용은 그대로 보존" {
     try expectDisplayName(r.output, "C");
     try std.testing.expect(std.mem.indexOf(u8, r.output, "width: 100%") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "color:") != null);
+}
+
+test "styled-components: jsx_filename 빈 문자열 시 componentId 생략 (displayName 만)" {
+    // SSR 안전성: filename 없으면 cross-file ID 충돌 위험 → componentId 생략 (graceful degradation).
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const X = styled.div`color: red;`;
+    ,
+        .{ .styled_components = true }, // jsx_filename 미지정 (default "")
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "displayName: \"X\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "componentId") == null);
 }
 
 test "styled-components: componentId counter 가 같은 파일 내 0,1,2 로 증가" {
@@ -161,7 +177,7 @@ test "styled-components: componentId counter 가 같은 파일 내 0,1,2 로 증
         \\const B = styled.div`color: blue;`;
         \\const C = styled.div`color: green;`;
     ,
-        .{ .styled_components = true },
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
         default_cg,
         ".tsx",
     );

--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -8,12 +8,14 @@ const CodegenOptions = helpers.CodegenOptions;
 
 const default_cg: CodegenOptions = .{ .minify_whitespace = false };
 
-/// 출력에 `withConfig({ displayName: "<expected>" })` 가 나타나는지 검증 (whitespace tolerant).
+/// 출력에 `withConfig({ displayName: "<expected>" })` + componentId 패턴이 나타나는지 검증.
+/// componentId 는 `sc-<8hex>-<digit>` 형태만 확인 (정확 hash 는 file path 의존이라 변동 가능).
 fn expectDisplayName(output: []const u8, expected: []const u8) !void {
     var quoted_buf: [256]u8 = undefined;
     const needle = std.fmt.bufPrint(&quoted_buf, "displayName: \"{s}\"", .{expected}) catch return error.OutOfMemory;
     try std.testing.expect(std.mem.indexOf(u8, output, needle) != null);
     try std.testing.expect(std.mem.indexOf(u8, output, "withConfig") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output, "componentId: \"sc-") != null);
 }
 
 test "styled-components: styled.X 선언 → withConfig({displayName}) 래핑" {
@@ -149,4 +151,23 @@ test "styled-components: template literal 내용은 그대로 보존" {
     try expectDisplayName(r.output, "C");
     try std.testing.expect(std.mem.indexOf(u8, r.output, "width: 100%") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "color:") != null);
+}
+
+test "styled-components: componentId counter 가 같은 파일 내 0,1,2 로 증가" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const A = styled.div`color: red;`;
+        \\const B = styled.div`color: blue;`;
+        \\const C = styled.div`color: green;`;
+    ,
+        .{ .styled_components = true },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // 같은 파일 내 file_hash 는 동일, counter 만 0/1/2 로 증가.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "-0\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "-1\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "-2\"") != null);
 }

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -45,6 +45,7 @@ const token_mod = @import("../../lexer/token.zig");
 const Span = token_mod.Span;
 const module_parser = @import("../../parser/module.zig");
 const import_scanner = @import("../../bundler/import_scanner.zig");
+const wyhash = @import("../../util/wyhash.zig");
 const transformer_mod = @import("../transformer.zig");
 const Transformer = transformer_mod.Transformer;
 const Error = Transformer.Error;
@@ -146,20 +147,33 @@ pub fn wrapStyledTag(self: *Transformer, init_idx: NodeIndex, var_name: []const 
     });
 }
 
-/// `<tag>.withConfig({ displayName: "<var_name>" })` call_expression 빌드.
-/// "withConfig" / "displayName" span 은 PluginState 에 lazy 캐싱 — 매 호출마다 string_table
-/// 에 같은 문자열이 append 되는 것을 피한다 (refresh.zig 의 $RefreshReg$ span 패턴과 동일).
+/// `<tag>.withConfig({ displayName: "<var_name>", componentId: "sc-<hash>-<n>" })` 빌드.
+///
+/// componentId 는 SSR hydration 을 위한 결정론적 식별자. file path 기반 wyhash 8-hex +
+/// 파일 내 등장 순서 counter — SWC 의 sc-<hash>-<n> 형식과 동일. 같은 파일을 다시 빌드해도
+/// 같은 ID, 다른 파일은 (충돌 매우 희박) 다른 ID.
 fn buildWithConfigCall(self: *Transformer, tag_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
     const zero = Span{ .start = 0, .end = 0 };
     const state = &self.plugins.styled_components;
     if (state.with_config_span == null) state.with_config_span = try self.ast.addString("withConfig");
     if (state.display_name_span == null) state.display_name_span = try self.ast.addString("displayName");
+    if (state.component_id_span == null) state.component_id_span = try self.ast.addString("componentId");
+    if (state.file_hash_hex == null) state.file_hash_hex = wyhash.hashHex8(self.options.jsx_filename);
+
     const with_config_span = state.with_config_span.?;
     const display_name_key_span = state.display_name_span.?;
+    const component_id_key_span = state.component_id_span.?;
+    const file_hash = state.file_hash_hex.?;
+    const component_index = state.component_counter;
+    state.component_counter += 1;
 
-    var quoted_buf: [256]u8 = undefined;
-    const quoted = std.fmt.bufPrint(&quoted_buf, "\"{s}\"", .{var_name}) catch return error.OutOfMemory;
-    const quoted_span = try self.ast.addString(quoted);
+    var display_buf: [256]u8 = undefined;
+    const display_quoted = std.fmt.bufPrint(&display_buf, "\"{s}\"", .{var_name}) catch return error.OutOfMemory;
+    const display_value_span = try self.ast.addString(display_quoted);
+
+    var component_id_buf: [64]u8 = undefined;
+    const component_id_quoted = std.fmt.bufPrint(&component_id_buf, "\"sc-{s}-{d}\"", .{ file_hash, component_index }) catch return error.OutOfMemory;
+    const component_id_value_span = try self.ast.addString(component_id_quoted);
 
     const with_config_ref = try self.ast.addNode(.{
         .tag = .identifier_reference,
@@ -173,24 +187,10 @@ fn buildWithConfigCall(self: *Transformer, tag_idx: NodeIndex, var_name: []const
         0,
     });
 
-    const key = try self.ast.addNode(.{
-        .tag = .identifier_reference,
-        .span = display_name_key_span,
-        .data = .{ .string_ref = display_name_key_span },
-    });
-    const value = try self.ast.addNode(.{
-        .tag = .string_literal,
-        .span = quoted_span,
-        .data = .{ .string_ref = quoted_span },
-    });
-    // object_property: binary = { left=key, right=value, flags }
-    const property = try self.ast.addNode(.{
-        .tag = .object_property,
-        .span = zero,
-        .data = .{ .binary = .{ .left = key, .right = value, .flags = 0 } },
-    });
+    const display_property = try buildKeyStringProperty(self, display_name_key_span, display_value_span);
+    const component_id_property = try buildKeyStringProperty(self, component_id_key_span, component_id_value_span);
 
-    const obj_list = try self.ast.addNodeList(&.{property});
+    const obj_list = try self.ast.addNodeList(&.{ display_property, component_id_property });
     const obj = try self.ast.addNode(.{
         .tag = .object_expression,
         .span = zero,
@@ -204,5 +204,27 @@ fn buildWithConfigCall(self: *Transformer, tag_idx: NodeIndex, var_name: []const
         args.start,
         args.len,
         0,
+    });
+}
+
+/// `key: "value"` object_property 노드 빌드. key 는 identifier_reference, value 는
+/// 따옴표 포함 문자열 리터럴 span 으로 미리 준비되어 있어야 함.
+fn buildKeyStringProperty(self: *Transformer, key_span: Span, quoted_value_span: Span) Error!NodeIndex {
+    const zero = Span{ .start = 0, .end = 0 };
+    const key = try self.ast.addNode(.{
+        .tag = .identifier_reference,
+        .span = key_span,
+        .data = .{ .string_ref = key_span },
+    });
+    const value = try self.ast.addNode(.{
+        .tag = .string_literal,
+        .span = quoted_value_span,
+        .data = .{ .string_ref = quoted_value_span },
+    });
+    // object_property: binary = { left=key, right=value, flags }
+    return self.ast.addNode(.{
+        .tag = .object_property,
+        .span = zero,
+        .data = .{ .binary = .{ .left = key, .right = value, .flags = 0 } },
     });
 }

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -147,33 +147,30 @@ pub fn wrapStyledTag(self: *Transformer, init_idx: NodeIndex, var_name: []const 
     });
 }
 
-/// `<tag>.withConfig({ displayName: "<var_name>", componentId: "sc-<hash>-<n>" })` 빌드.
+/// `<tag>.withConfig({ displayName: "<var_name>"[, componentId: "sc-<hash>-<n>"] })` 빌드.
 ///
-/// componentId 는 SSR hydration 을 위한 결정론적 식별자. file path 기반 wyhash 8-hex +
-/// 파일 내 등장 순서 counter — SWC 의 sc-<hash>-<n> 형식과 동일. 같은 파일을 다시 빌드해도
-/// 같은 ID, 다른 파일은 (충돌 매우 희박) 다른 ID.
+/// componentId 는 SSR hydration 결정론적 식별자 — file path 기반 wyhash 8-hex + 파일 내
+/// 등장 순서 counter (SWC `sc-<hash>-<n>` 형식과 동일). `options.jsx_filename` 이 비어있는
+/// transpile 경로에선 cross-file ID 충돌 위험이 있어 componentId 자체를 생략 (graceful
+/// degradation — displayName 만으로 DevTools 표시는 유지). bundle / app 경로는 항상 filename
+/// 이 있으므로 정상 emit.
 fn buildWithConfigCall(self: *Transformer, tag_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
     const zero = Span{ .start = 0, .end = 0 };
     const state = &self.plugins.styled_components;
     if (state.with_config_span == null) state.with_config_span = try self.ast.addString("withConfig");
     if (state.display_name_span == null) state.display_name_span = try self.ast.addString("displayName");
-    if (state.component_id_span == null) state.component_id_span = try self.ast.addString("componentId");
-    if (state.file_hash_hex == null) state.file_hash_hex = wyhash.hashHex8(self.options.jsx_filename);
 
     const with_config_span = state.with_config_span.?;
     const display_name_key_span = state.display_name_span.?;
-    const component_id_key_span = state.component_id_span.?;
-    const file_hash = state.file_hash_hex.?;
-    const component_index = state.component_counter;
-    state.component_counter += 1;
+    const has_filename = self.options.jsx_filename.len > 0;
+    if (has_filename) {
+        if (state.component_id_span == null) state.component_id_span = try self.ast.addString("componentId");
+        if (state.file_hash_hex == null) state.file_hash_hex = wyhash.hashHex8(self.options.jsx_filename);
+    }
 
     var display_buf: [256]u8 = undefined;
     const display_quoted = std.fmt.bufPrint(&display_buf, "\"{s}\"", .{var_name}) catch return error.OutOfMemory;
     const display_value_span = try self.ast.addString(display_quoted);
-
-    var component_id_buf: [64]u8 = undefined;
-    const component_id_quoted = std.fmt.bufPrint(&component_id_buf, "\"sc-{s}-{d}\"", .{ file_hash, component_index }) catch return error.OutOfMemory;
-    const component_id_value_span = try self.ast.addString(component_id_quoted);
 
     const with_config_ref = try self.ast.addNode(.{
         .tag = .identifier_reference,
@@ -188,9 +185,21 @@ fn buildWithConfigCall(self: *Transformer, tag_idx: NodeIndex, var_name: []const
     });
 
     const display_property = try buildKeyStringProperty(self, display_name_key_span, display_value_span);
-    const component_id_property = try buildKeyStringProperty(self, component_id_key_span, component_id_value_span);
 
-    const obj_list = try self.ast.addNodeList(&.{ display_property, component_id_property });
+    const obj_list = if (has_filename) blk: {
+        var component_id_buf: [64]u8 = undefined;
+        const component_index = state.component_counter;
+        state.component_counter += 1;
+        const component_id_quoted = std.fmt.bufPrint(
+            &component_id_buf,
+            "\"sc-{s}-{d}\"",
+            .{ state.file_hash_hex.?, component_index },
+        ) catch return error.OutOfMemory;
+        const component_id_value_span = try self.ast.addString(component_id_quoted);
+        const component_id_property = try buildKeyStringProperty(self, state.component_id_span.?, component_id_value_span);
+        break :blk try self.ast.addNodeList(&.{ display_property, component_id_property });
+    } else try self.ast.addNodeList(&.{display_property});
+
     const obj = try self.ast.addNode(.{
         .tag = .object_expression,
         .span = zero,


### PR DESCRIPTION
## Summary

styled-components transform 의 `.withConfig({...})` 안에 `componentId: \"sc-<8hex>-<n>\"` 추가. SSR hydration 안정화 — server / client 가 같은 ID 생성. babel/swc 의 표준 형식과 일치 (fixture 호환).

\`\`\`tsx
// 입력
import styled from \"styled-components\";
const Card = styled.div\`color: red;\`;
const Button = styled.div\`color: blue;\`;

// 출력 (이번 PR — 첫 번째 styled-components/native build 포함 5개 컴포넌트가 같은 file hash + counter 0,1,2,3,4)
const Card = styled.div.withConfig({
  displayName: \"Card\",
  componentId: \"sc-c51dbed2-0\",
})\`color: red;\`;
const Button = styled.div.withConfig({
  displayName: \"Button\",
  componentId: \"sc-c51dbed2-1\",
})\`color: blue;\`;
\`\`\`

## componentId 구성

| 부분 | 산출 방식 |
|---|---|
| `sc-` | 고정 prefix (CSS class 가 숫자로 시작 못 하는 제약 회피 + babel/swc 컨벤션) |
| 8 hex | `wyhash.hashHex8(options.jsx_filename)` — `util/wyhash.zig` 의 placeholder hash 재사용 (entry/chunk hash 와 동일 알고리즘) |
| `-<n>` | 0-based counter (같은 파일 내 styled 컴포넌트 등장 순서) |

**Trade-off** (PR 본문 + 코드 주석에 명시):
- ✅ SWC fixture 호환 — 동일 형식
- ⚠️ 컴포넌트 추가/순서 변경 시 이후 ID 모두 shift → partial-deploy SSR mismatch 가능
- 대안: Babel 의 name-based hash (`<filename>__<componentName>`) 는 reorder 안정. 후속 옵션 검토.

## Graceful degradation

`options.jsx_filename` 이 빈 문자열인 경우 (transpile 직접 호출 / stdin 모드) cross-file ID 충돌 위험 → **componentId 자체를 생략**. displayName 만 emit 하므로 DevTools 표시는 유지.

bundle / app 빌드 경로는 항상 filename 이 설정되므로 정상 emit.

## 변경 내용

### `src/transformer/plugin_state.zig`
- `StyledComponentsState` 에 lazy 필드 추가:
  - `component_id_span: ?Span` — \"componentId\" 문자열 string_table 캐시
  - `file_hash_hex: ?[8]u8` — 파일 hash 캐시 (한 번만 계산)
  - `component_counter: u32 = 0` — 0-based counter

### `src/transformer/transformer/styled_components.zig`
- `buildWithConfigCall` 갱신:
  - 처음에 `\"withConfig\"` / `\"displayName\"` span 캐싱 (PR #2229 이미 도입)
  - filename 있을 때만 `\"componentId\"` span + `file_hash_hex` 추가 캐싱
  - `bufPrint(\"sc-{s}-{d}\")` 로 ID 생성, counter 증가
  - displayName + (옵셔널) componentId 두 property 를 object_expression 에 추가
- `buildKeyStringProperty` 헬퍼 추출 — displayName 과 componentId 가 같은 shape (key=identifier, value=quoted string)

### `src/transformer/styled_components_test.zig`
- `expectDisplayName` helper 가 componentId 도 동시 검증
- 모든 테스트에 `jsx_filename = \"test.tsx\"` 설정 (graceful degradation 도입 후 명시 필요)
- 신규 테스트:
  - 같은 파일 내 counter 0/1/2 증가 검증
  - filename 빈 문자열 시 componentId 생략 + displayName 유지

## /simplify 결과 반영

3 agent 리뷰에서 적용한 fix:

- `jsx_filename` 빈 문자열 graceful degradation (SSR 안전)
- `component_counter` 의 \"Transformer per-file\" invariant 주석 명시
- 32-bit truncation + reorder 불안정성 trade-off 주석

defer 항목 (별도 PR — cross-cutting):
- `es_helpers.makeIdentifierRefFromSpan` 재사용 (8+ 호출 사이트)
- `es_helpers.addQuotedString` 추출 (`bufPrint(\"\\\"{s}\\\"\")` 패턴 통합)

## 검증

- ✅ `zig build test`: 4129/4129 pass (2개 신규 테스트)
- ✅ `examples/web` 빌드 결과:
  \`\`\`
  Card           componentId: \"sc-c51dbed2-0\"
  Button         componentId: \"sc-c51dbed2-1\"
  DangerButton   componentId: \"sc-c51dbed2-2\"
  Spinner        componentId: \"sc-c51dbed2-3\"
  FancyCard      componentId: \"sc-c51dbed2-4\"
  \`\`\`
  → 같은 파일 hash + counter 0..4. SSR 재현성 확보.

## 후속 PR

- [ ] chained `.attrs(...)` / `.withConfig(...)` 인식 (Input 케이스 — 현재 skip)
- [ ] 조건부 / 클래스 정적 필드 / 객체 프로퍼티
- [ ] `transpileTemplateLiterals` / CSS minify
- [ ] options 객체 form throughpass (`compiler.styledComponents: { ssr: false }` 등)
- [ ] Babel-style name-based hash 옵션 (reorder 안정성 우선 시)

## Test plan

- [ ] `cd examples/web && bun run build` — `componentId: \"sc-...\"` 5개
- [ ] React DevTools 에서 컴포넌트 이름 표시 (PR #2228/2229 와 동일)
- [ ] `compiler.styledComponents: false` → 변환 없음
- [ ] `bun run dev` HMR 회귀 없는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)