### PR TITLE
feat(transformer): styled-components chain detection (.attrs / withConfig 체인)

### DIFF
--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -91,7 +91,7 @@ test "styled-components: @emotion/styled source 는 미감지" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") == null);
 }
 
-test "styled-components: .attrs(...) chain 은 skip (이번 PR 스코프 외)" {
+test "styled-components: .attrs(...) chain — 체인 끝에 withConfig 추가" {
     var r = try e2eFull(
         std.testing.allocator,
         \\import styled from "styled-components";
@@ -102,9 +102,39 @@ test "styled-components: .attrs(...) chain 은 skip (이번 PR 스코프 외)" {
         ".tsx",
     );
     defer r.deinit();
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "Input") != null);
-    // chain 안에 .withConfig 이 끼워져선 안 됨 (root tag detection 만 인식).
-    // attrs 의 type:"text" object 에 displayName 이 들어가면 안 됨 — withConfig 자체가 없어야 함.
+    try expectDisplayName(r.output, "Input");
+    // attrs 자체는 보존되어야 함 — chain 가 망가지면 안 됨.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, ".attrs(") != null);
+}
+
+test "styled-components: 다중 체인 styled(X).attrs() 도 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\import Inner from "./inner";
+        \\const Wrapped = styled(Inner).attrs(props => ({ id: props.id }))`color: blue;`;
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "Wrapped");
+    try std.testing.expect(std.mem.indexOf(u8, r.output, ".attrs(") != null);
+}
+
+test "styled-components: 다른 라이브러리의 비슷한 체인은 미인식" {
+    // emotion 의 styled (다른 binding) 은 chain 이어도 우리 transform 영향 받지 않음.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import emotionStyled from "@emotion/styled";
+        \\const X = emotionStyled.div.attrs({})`color: red;`;
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
     try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") == null);
 }
 

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -93,29 +93,38 @@ pub fn detectStyledImport(self: *Transformer, node: Node) Error!void {
     // 이 PR 은 default binding 만 처리. named (`{ styled }`) 는 후속.
 }
 
-/// tag 표현식이 styled binding 을 사용하는지 확인 (root identifier 만 비교).
-/// 인식: `<binding>.X` / `<binding>(arg)`. 미인식 (후속 PR): chain `.attrs(...)` / `.withConfig(...)`.
+/// tag 표현식의 chain root 가 styled binding 인지 확인.
+/// 인식 (모두):
+///   - `<binding>.X` (static_member)
+///   - `<binding>(arg)` (call)
+///   - `<binding>.X.attrs({...})` / `<binding>(X).attrs({...})` (chain: call→member→identifier)
+///   - `<binding>.X.attrs({...}).attrs({...})` (다중 체인)
+///   - `<binding>.X.withConfig({...})` (사용자 명시 withConfig — 본 PR 은 추가 .withConfig
+///     를 한 번 더 append 하므로 styled-components 의 later-wins 시맨틱에 의존; 후속 PR 에서
+///     기존 withConfig 인식 시 merge / skip 분기)
 fn tagUsesBinding(self: *Transformer, tag_idx: NodeIndex) bool {
-    if (tag_idx.isNone()) return false;
     const binding = self.plugins.styled_components.default_binding orelse return false;
-    const tag_node = self.ast.getNode(tag_idx);
-    const root_idx: NodeIndex = switch (tag_node.tag) {
-        .static_member_expression => blk: {
-            // extra = [object, property, flags]
-            if (!self.ast.hasExtra(tag_node.data.extra, 1)) return false;
-            break :blk @enumFromInt(self.ast.extra_data.items[tag_node.data.extra]);
-        },
-        .call_expression => blk: {
-            // extra = [callee, args_start, args_len, flags]
-            if (!self.ast.hasExtra(tag_node.data.extra, 0)) return false;
-            break :blk @enumFromInt(self.ast.extra_data.items[tag_node.data.extra]);
-        },
-        else => return false,
-    };
-    if (root_idx.isNone()) return false;
-    const root_node = self.ast.getNode(root_idx);
-    if (root_node.tag != .identifier_reference) return false;
-    return std.mem.eql(u8, self.ast.getText(root_node.data.string_ref), binding);
+    var current = tag_idx;
+    while (true) {
+        if (current.isNone()) return false;
+        const node = self.ast.getNode(current);
+        switch (node.tag) {
+            .identifier_reference => {
+                return std.mem.eql(u8, self.ast.getText(node.data.string_ref), binding);
+            },
+            .static_member_expression => {
+                // extra = [object, property, flags] — root 방향으로 object 만 따라감.
+                if (!self.ast.hasExtra(node.data.extra, 1)) return false;
+                current = @enumFromInt(self.ast.extra_data.items[node.data.extra]);
+            },
+            .call_expression => {
+                // extra = [callee, args_start, args_len, flags] — root 방향으로 callee 만 따라감.
+                if (!self.ast.hasExtra(node.data.extra, 0)) return false;
+                current = @enumFromInt(self.ast.extra_data.items[node.data.extra]);
+            },
+            else => return false,
+        }
+    }
 }
 
 /// `visitVariableDeclarator` 의 post-visit hook. caller 가 init.tag 를 사전 검사한 뒤


### PR DESCRIPTION
## Summary

styled-components transform 의 `tagUsesBinding` 이 1-level switch → while-loop chain walker 로 확장.
이제 `styled.div.attrs({...})` / 다중 체인 / `.withConfig` 체인 모두 root 까지 walk down 하여 binding 매칭.

\`\`\`tsx
// 이전 (PR #2231 까지): 직접 styled.X / styled(X) 만 인식
const Input = styled.input.attrs({ type: \"text\" })\`...\`;  // skip

// 본 PR: chain 끝에 withConfig append
const Input = styled.input
  .attrs({ type: \"text\" })
  .withConfig({ displayName: \"Input\", componentId: \"sc-...\" })\`...\`;
\`\`\`

## Walker 알고리즘

\`\`\`
loop:
  current.tag == identifier_reference   → binding 일치 시 true, 아니면 false
  current.tag == static_member_expression → current = object (extra[0])
  current.tag == call_expression          → current = callee (extra[0])
  else                                   → false
\`\`\`

- AST 가 acyclic (parser invariant) — 무한 loop 불가
- 실측 chain depth 1-3 (hot-path 영향 무시 가능)
- `visitVariableDeclarator` 의 fast-path 사전 필터로 옵션 OFF / non-tagged-template 은 walker 진입조차 안 함

## 인식 매트릭스 (이번 PR 후)

| 케이스 | 이전 | 현재 |
|---|---|---|
| `styled.div\`\`` | ✅ | ✅ |
| `styled(X)\`\`` | ✅ | ✅ |
| `styled.div.attrs({})\`\`` | ❌ skip | ✅ |
| `styled(X).attrs(props => ...)\`\`` | ❌ skip | ✅ |
| `styled.div.attrs({}).attrs({})\`\`` (다중 체인) | ❌ skip | ✅ |
| `styled.div.withConfig({})\`\`` | ❌ skip | ✅ (chain 끝에 추가 withConfig append) |
| `cond ? styled.div\`\` : styled.div\`\`` | ❌ | ❌ (후속 PR) |
| `class { static Child = styled.div\`\` }` | ❌ | ❌ (후속 PR) |
| `\`@emotion/styled\`` | ❌ (의도) | ❌ (의도) |

## 사용자 명시 .withConfig 처리

본 PR 은 chain 끝에 자동 .withConfig append. styled-components runtime 의 later-wins 시맨틱에 의존:
- 사용자가 `styled.div.withConfig({componentId: \"my-id\"})` 작성한 경우, 우리가 그 뒤에 `.withConfig({displayName, componentId: \"sc-...\"})` 를 또 append → 사용자 ID 가 override 됨

후속 PR 에서 기존 withConfig 인식 시 merge / skip 분기 도입 예정.

## 변경 내용

- `src/transformer/transformer/styled_components.zig:tagUsesBinding`
  switch (1-level) → while loop (chain walker)
- `src/transformer/styled_components_test.zig`
  - `.attrs(...) chain` 케이스: skip 검증 → include 검증 (assertion 반전)
  - 신규: `다중 체인 styled(X).attrs() 도 인식`
  - 신규: `다른 라이브러리의 비슷한 체인은 미인식` (`@emotion/styled`)

## 검증

- ✅ `zig build test`: 4131/4131 pass (2 신규)
- ✅ `examples/web` — 6개 styled 컴포넌트 모두 인식 (Input 신규):
  \`\`\`
  Card           sc-c51dbed2-0
  Button         sc-c51dbed2-1
  DangerButton   sc-c51dbed2-2
  Input          sc-c51dbed2-3   ← chain detection 으로 신규 인식
  Spinner        sc-c51dbed2-4
  FancyCard      sc-c51dbed2-5
  \`\`\`
  (다른 컴포넌트들의 counter 가 1씩 shift — chain detection 도입 일회성 전환)

## 후속 PR

- [ ] 사용자 명시 `.withConfig({...})` 인식 시 merge / skip 분기
- [ ] 조건부 / 클래스 정적 필드 / 객체 프로퍼티
- [ ] `transpileTemplateLiterals` / CSS minify
- [ ] options 객체 form throughpass

🤖 Generated with [Claude Code](https://claude.com/claude-code)