### PR TITLE
feat(transformer): styled-components object property 패턴 인식

### DIFF
--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -324,7 +324,7 @@ fn isCjsExportObjectExpr(ast: *const Ast, idx: NodeIndex) bool {
 
 /// string_literal 의 escape 가 풀린 형태로 비교 안 하므로 raw 와 source-after-decode
 /// 가 다른 경우는 reject — 잘못된 export 매칭을 막는 보수적 가드.
-fn plainStringLiteralValue(ast: *const Ast, idx: NodeIndex) ?[]const u8 {
+pub fn plainStringLiteralValue(ast: *const Ast, idx: NodeIndex) ?[]const u8 {
     if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return null;
     const n = ast.nodes.items[@intFromEnum(idx)];
     if (n.tag != .string_literal) return null;
@@ -333,7 +333,10 @@ fn plainStringLiteralValue(ast: *const Ast, idx: NodeIndex) ?[]const u8 {
     return Ast.stripStringQuotes(raw);
 }
 
-fn plainObjectKeyName(ast: *const Ast, key_idx: NodeIndex) ?[]const u8 {
+/// object_property 의 key 노드에서 정적 이름을 추출 (escape-bearing string 은 reject).
+/// 인식: `identifier_reference` (`{ x: ... }`), `string_literal` (`{ "x": ... }`).
+/// 미인식: `computed_property_key`, `numeric_literal`, escape 포함 문자열.
+pub fn plainObjectKeyName(ast: *const Ast, key_idx: NodeIndex) ?[]const u8 {
     if (key_idx.isNone() or @intFromEnum(key_idx) >= ast.nodes.items.len) return null;
     const key = ast.nodes.items[@intFromEnum(key_idx)];
     return switch (key.tag) {

--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -183,6 +183,67 @@ test "styled-components: template literal 내용은 그대로 보존" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "color:") != null);
 }
 
+test "styled-components: object property { One: styled.div`` } 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const styles = { One: styled.div`color: red;`, Two: styled.span`color: blue;` };
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "One");
+    try expectDisplayName(r.output, "Two");
+}
+
+test "styled-components: object property string-key { \"My Comp\": ... } 도 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const styles = { "MyComp": styled.div`color: red;` };
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "MyComp");
+}
+
+test "styled-components: object property string-key 의 escape 는 보수적으로 reject" {
+    // plainStringLiteralValue 는 raw vs decoded 시맨틱 차이를 피하려고 backslash 포함 문자열을
+    // 거절. 후속 PR 에서 decode 후 매칭 도입 시 이 케이스를 변환하도록 변경 가능.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const styles = { "A\"B": styled.div`color: red;` };
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") == null);
+}
+
+test "styled-components: computed property key 는 미인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const key = "X";
+        \\const styles = { [key]: styled.div`color: red;` };
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // computed key 는 displayName 추출 불가 — 변환 안 일어남.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") == null);
+}
+
 test "styled-components: jsx_filename 빈 문자열 시 componentId 생략 (displayName 만)" {
     // SSR 안전성: filename 없으면 cross-file ID 충돌 위험 → componentId 생략 (graceful degradation).
     var r = try e2eFull(

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -4373,7 +4373,18 @@ pub const Transformer = struct {
         else
             try self.visitNode(key_idx);
         self.propagateSymbolId(key_idx, new_key);
-        const new_value = try self.visitNode(node.data.binary.right);
+        var new_value = try self.visitNode(node.data.binary.right);
+        // styled-components: { One: styled.div`...` } 의 value 가 styled tagged template 이면
+        // property key 이름을 displayName 으로 사용해 wrap. variable_declarator 와 동일 패턴.
+        if (self.options.styled_components and
+            self.plugins.styled_components.default_binding != null and
+            !new_value.isNone() and !new_key.isNone() and
+            self.ast.getNode(new_value).tag == .tagged_template_expression)
+        {
+            if (styled_components_mod.objectPropertyKeyName(self, new_key)) |prop_name| {
+                new_value = try styled_components_mod.wrapStyledTag(self, new_value, prop_name);
+            }
+        }
         return self.ast.addNode(.{
             .tag = .object_property,
             .span = node.span,

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -45,6 +45,7 @@ const token_mod = @import("../../lexer/token.zig");
 const Span = token_mod.Span;
 const module_parser = @import("../../parser/module.zig");
 const import_scanner = @import("../../bundler/import_scanner.zig");
+const stmt_info = @import("../../bundler/stmt_info.zig");
 const wyhash = @import("../../util/wyhash.zig");
 const transformer_mod = @import("../transformer.zig");
 const Transformer = transformer_mod.Transformer;
@@ -125,6 +126,15 @@ fn tagUsesBinding(self: *Transformer, tag_idx: NodeIndex) bool {
             else => return false,
         }
     }
+}
+
+/// object_property 의 key 노드에서 displayName 으로 사용할 이름을 추출.
+/// `stmt_info.plainObjectKeyName` 재사용 — escape 포함 문자열 (`{ "A\"B": ... }`) 은
+/// 보수적으로 reject 하여 raw vs decoded 시맨틱 차이로 인한 잘못된 매칭 방지.
+pub fn objectPropertyKeyName(self: *Transformer, key_idx: NodeIndex) ?[]const u8 {
+    const name = stmt_info.plainObjectKeyName(self.ast, key_idx) orelse return null;
+    if (name.len == 0) return null;
+    return name;
 }
 
 /// `visitVariableDeclarator` 의 post-visit hook. caller 가 init.tag 를 사전 검사한 뒤


### PR DESCRIPTION
## Summary

`{ One: styled.div\`...\` }` 형태에서 property key 이름을 displayName 으로 사용하여 자동 wrap. babel-plugin-styled-components 의 `add-display-names` fixture 와 동일.

\`\`\`tsx
// 입력
import styled from \"styled-components\";
const styles = { One: styled.div\`color: red;\`, Two: styled.span\`color: blue;\` };

// 출력
const styles = {
  One: styled.div.withConfig({ displayName: \"One\", componentId: \"sc-...-0\" })\`color: red;\`,
  Two: styled.span.withConfig({ displayName: \"Two\", componentId: \"sc-...-1\" })\`color: blue;\`,
};
\`\`\`

## 변경 내용

- `src/transformer/transformer.zig:visitObjectProperty`
  visit_variable_declarator 와 동일 fast-path hook (옵션 ON + binding 감지 + value 가 tagged_template 일 때만 진입)
- `src/transformer/transformer/styled_components.zig:objectPropertyKeyName`
  helper. `bundler/stmt_info.plainObjectKeyName` 재사용 (shared 헬퍼로 promote).
- `src/bundler/stmt_info.zig`
  `plainStringLiteralValue` / `plainObjectKeyName` 을 `pub` 으로 promote — transformer 에서 재사용.

## 인식 매트릭스

| 케이스 | 상태 |
|---|---|
| `{ One: styled.div\`\` }` (identifier key) | ✅ |
| `{ \"MyComp\": styled.div\`\` }` (string key) | ✅ |
| `{ One: styled.div.attrs({})\`\` }` (chain) | ✅ (chain walker 와 호환) |
| `{ \"A\\\"B\": styled.div\`\` }` (escape) | ❌ (보수적 reject — raw vs decoded 차이) |
| `{ [key]: styled.div\`\` }` (computed) | ❌ (정적 이름 추출 불가) |
| `{ One: getValue() }` (non-tagged-template) | ❌ (의도) |

## /simplify 결과 반영

리뷰에서 **objectPropertyKeyName 자체구현이 stmt_info.plainObjectKeyName 과 중복** 지적. fix 적용:
- `plainStringLiteralValue` / `plainObjectKeyName` 을 `pub` 으로 promote (3-clone 패턴 회피)
- escape 포함 string key 는 보수적으로 reject (latent bug 회피)
- escape 케이스 회귀 테스트 신규 추가

## 검증

- ✅ `zig build test`: 4135/4135 pass (3 신규 — 2개 인식 + 2개 reject 케이스)
- ✅ `examples/web` 빌드 무회귀

## 후속 PR

- [ ] 사용자 명시 `.withConfig({...})` 인식 시 merge / skip
- [ ] 조건부 (`cond ? styled.div\`\` : styled.div\`\``)
- [ ] 클래스 정적 필드 (`class { static Child = styled.div\`\` }`)
- [ ] 할당 (`Component = styled.div\`\``)
- [ ] string key 의 escape decode (옵션)
- [ ] `transpileTemplateLiterals` / CSS minify

🤖 Generated with [Claude Code](https://claude.com/claude-code)