### PR TITLE
feat(transformer): styled-components assignment 패턴 인식

### DIFF
--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -212,6 +212,37 @@ test "styled-components: object property string-key { \"My Comp\": ... } 도 인
     try expectDisplayName(r.output, "MyComp");
 }
 
+test "styled-components: assignment `Component = styled.div\\`...\\`` 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\let Component;
+        \\Component = styled.div`color: red;`;
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "Component");
+}
+
+test "styled-components: assignment 의 LHS 가 member expression 이면 skip" {
+    // obj.field = styled.div`` — 정적 이름 추출 불가 (member 의 어떤 이름을 쓸지 모호) → skip.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const obj = {};
+        \\obj.field = styled.div`color: red;`;
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") == null);
+}
+
 test "styled-components: object property string-key 의 escape 는 보수적으로 reject" {
     // plainStringLiteralValue 는 raw vs decoded 시맨틱 차이를 피하려고 backslash 포함 문자열을
     // 거절. 후속 PR 에서 decode 후 매칭 도입 시 이 케이스를 변환하도록 변경 가능.

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1028,6 +1028,15 @@ pub const Transformer = struct {
                         }
                     }
                 }
+                // styled-components: `Component = styled.div\`...\`` 도 wrap 대상.
+                // visitBinaryNode 결과의 right 가 styled tagged template 이면 LHS identifier
+                // 이름을 displayName 으로 사용해 wrap. =, +=, ||= 등 모든 연산자에서 동작
+                // (의미상 = 만 styled component 할당이지만 가드 추가 비용 vs 자연스러운 케이스
+                // 커버 trade-off — 비-= 연산자 + tagged template 조합은 거의 없음).
+                if (self.options.styled_components and self.plugins.styled_components.default_binding != null) {
+                    const new_idx = try self.visitBinaryNode(idx);
+                    return styled_components_mod.maybeWrapAssignment(self, new_idx);
+                }
                 return self.visitBinaryNode(idx);
             },
             .while_statement,

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -137,6 +137,34 @@ pub fn objectPropertyKeyName(self: *Transformer, key_idx: NodeIndex) ?[]const u8
     return name;
 }
 
+/// `Component = styled.div\`...\`` 형태 처리. visitBinaryNode 의 결과 (assignment_expression)
+/// 를 받아 right 가 styled tagged template 이면 LHS identifier 이름으로 wrap.
+/// LHS 가 member / computed / destructuring 이면 skip — 정적 이름 추출 불가.
+pub fn maybeWrapAssignment(self: *Transformer, assignment_idx: NodeIndex) Error!NodeIndex {
+    if (assignment_idx.isNone()) return assignment_idx;
+    const node = self.ast.getNode(assignment_idx);
+    if (node.tag != .assignment_expression) return assignment_idx;
+    const left = node.data.binary.left;
+    const right = node.data.binary.right;
+    if (left.isNone() or right.isNone()) return assignment_idx;
+    if (self.ast.getNode(right).tag != .tagged_template_expression) return assignment_idx;
+    const left_node = self.ast.getNode(left);
+    // 일반 assignment: LHS 가 assignment_target_identifier (parser 가 destructuring 컨텍스트
+    // 외에서도 단순 식별자 LHS 를 이 태그로 변환).
+    // identifier_reference 경로는 일부 변환 후 노드 (block-scope rename 등) 대응.
+    if (left_node.tag != .assignment_target_identifier and left_node.tag != .identifier_reference) return assignment_idx;
+    const var_name = self.ast.getText(left_node.data.string_ref);
+    if (var_name.len == 0) return assignment_idx;
+
+    const new_right = try wrapStyledTag(self, right, var_name);
+    if (new_right == right) return assignment_idx;
+    return self.ast.addNode(.{
+        .tag = .assignment_expression,
+        .span = node.span,
+        .data = .{ .binary = .{ .left = left, .right = new_right, .flags = node.data.binary.flags } },
+    });
+}
+
 /// `visitVariableDeclarator` 의 post-visit hook. caller 가 init.tag 를 사전 검사한 뒤
 /// tagged_template_expression 일 때만 호출 — 옵션 비활성 / binding 미감지 / 다른 tag 면
 /// caller 가 미리 거른다.


### PR DESCRIPTION
## Summary

`Component = styled.div\`...\`` 형태 assignment 도 인식하여 wrap. babel-plugin-styled-components 의 `add-display-names` fixture 의 \"let / Component = ...\" 케이스에 해당.

\`\`\`tsx
// 입력
import styled from \"styled-components\";
let Component;
Component = styled.div\`color: red;\`;

// 출력
let Component;
Component = styled.div.withConfig({
  displayName: \"Component\",
  componentId: \"sc-...\",
})\`color: red;\`;
\`\`\`

## 인식 매트릭스

| LHS 형태 | 상태 |
|---|---|
| `Component = styled.div\`\`` (identifier) | ✅ |
| `obj.field = styled.div\`\`` (member) | ❌ (정적 이름 모호 — 의도) |
| `[a, b] = styled.div\`\`` (destructuring) | ❌ (pattern — 단일 이름 없음) |
| `(expr).x = styled.div\`\`` (computed) | ❌ |
| `var X = Y = styled.div\`\`` 에서 outer X | ❌ → babel 은 X 우선, 현재는 inner Y. 후속 PR |

## 변경 내용

- `transformer.zig:visitAssignmentExpression`
  styled_components 옵션 ON + binding 추적 시 visitBinaryNode 결과를 maybeWrapAssignment 후처리. fast-path 미적용 시 기존 경로 그대로.
- `styled_components.zig:maybeWrapAssignment`
  LHS = `assignment_target_identifier` 또는 `identifier_reference` 일 때만 처리. parser 가 단순 식별자 LHS 를 `assignment_target_identifier` 로 변환하는 점 발견 → 두 tag 모두 인식.

## 검증

- ✅ `zig build test`: 4137/4137 pass (2 신규)
- ✅ examples/web 무회귀

## 후속 PR

- [ ] 사용자 명시 `.withConfig` 인식 시 merge / skip
- [ ] 조건부 / 클래스 정적 필드
- [ ] chained `var X = Y = styled.div\`\`` 의 outermost name 우선
- [ ] `transpileTemplateLiterals` / CSS minify

🤖 Generated with [Claude Code](https://claude.com/claude-code)