### PR TITLE
feat(transformer): styled-components 조건부 / 괄호 expression 인식

### DIFF
--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -212,6 +212,55 @@ test "styled-components: object property string-key { \"My Comp\": ... } 도 인
     try expectDisplayName(r.output, "MyComp");
 }
 
+test "styled-components: 조건부 ternary — 양쪽 branch 에 같은 displayName" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Test = isDark ? styled.div`color: white;` : styled.div`color: black;`;
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // 두 branch 가 모두 wrap 되어야 함 — Test displayName 이 두 번 등장.
+    var count: usize = 0;
+    var i: usize = 0;
+    while (std.mem.indexOfPos(u8, r.output, i, "displayName: \"Test\"")) |pos| : (i = pos + 1) {
+        count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 2), count);
+}
+
+test "styled-components: 괄호 안 styled.div 도 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Wrapped = (styled.div`color: red;`);
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "Wrapped");
+}
+
+test "styled-components: 조건부 한쪽 branch 만 styled — wrap 후에도 다른 쪽 보존" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Test = cond ? styled.div`color: red;` : null;
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "Test");
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "null") != null);
+}
+
 test "styled-components: assignment `Component = styled.div\\`...\\`` 인식" {
     var r = try e2eFull(
         std.testing.allocator,

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2930,11 +2930,7 @@ pub const Transformer = struct {
         // styled-components: tag 를 `.withConfig({displayName})` 로 wrap. fast-path 로 1) 옵션,
         // 2) binding 감지, 3) init.tag == tagged_template_expression 을 사전 거른 뒤에만
         // 본 helper 호출. var_name 은 block-scoping rename 후 안전하도록 new_name 에서 읽음.
-        if (self.options.styled_components and
-            self.plugins.styled_components.default_binding != null and
-            !new_init.isNone() and !new_name.isNone() and
-            styled_components_mod.isWrappableExpr(self.ast.getNode(new_init).tag))
-        {
+        if (!new_name.isNone() and styled_components_mod.shouldAttemptWrap(self, new_init)) {
             const new_name_node = self.ast.getNode(new_name);
             if (new_name_node.tag == .binding_identifier or new_name_node.tag == .identifier_reference) {
                 const var_name = self.ast.getText(new_name_node.data.string_ref);
@@ -4385,11 +4381,7 @@ pub const Transformer = struct {
         var new_value = try self.visitNode(node.data.binary.right);
         // styled-components: { One: styled.div`...` } 의 value 가 styled tagged template 이면
         // property key 이름을 displayName 으로 사용해 wrap. variable_declarator 와 동일 패턴.
-        if (self.options.styled_components and
-            self.plugins.styled_components.default_binding != null and
-            !new_value.isNone() and !new_key.isNone() and
-            styled_components_mod.isWrappableExpr(self.ast.getNode(new_value).tag))
-        {
+        if (!new_key.isNone() and styled_components_mod.shouldAttemptWrap(self, new_value)) {
             if (styled_components_mod.objectPropertyKeyName(self, new_key)) |prop_name| {
                 new_value = try styled_components_mod.wrapStyledTagInExpr(self, new_value, prop_name);
             }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2933,12 +2933,12 @@ pub const Transformer = struct {
         if (self.options.styled_components and
             self.plugins.styled_components.default_binding != null and
             !new_init.isNone() and !new_name.isNone() and
-            self.ast.getNode(new_init).tag == .tagged_template_expression)
+            styled_components_mod.isWrappableExpr(self.ast.getNode(new_init).tag))
         {
             const new_name_node = self.ast.getNode(new_name);
             if (new_name_node.tag == .binding_identifier or new_name_node.tag == .identifier_reference) {
                 const var_name = self.ast.getText(new_name_node.data.string_ref);
-                new_init = try styled_components_mod.wrapStyledTag(self, new_init, var_name);
+                new_init = try styled_components_mod.wrapStyledTagInExpr(self, new_init, var_name);
             }
         }
         const none = @intFromEnum(NodeIndex.none);
@@ -4388,10 +4388,10 @@ pub const Transformer = struct {
         if (self.options.styled_components and
             self.plugins.styled_components.default_binding != null and
             !new_value.isNone() and !new_key.isNone() and
-            self.ast.getNode(new_value).tag == .tagged_template_expression)
+            styled_components_mod.isWrappableExpr(self.ast.getNode(new_value).tag))
         {
             if (styled_components_mod.objectPropertyKeyName(self, new_key)) |prop_name| {
-                new_value = try styled_components_mod.wrapStyledTag(self, new_value, prop_name);
+                new_value = try styled_components_mod.wrapStyledTagInExpr(self, new_value, prop_name);
             }
         }
         return self.ast.addNode(.{

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -31,11 +31,12 @@
 //!
 //! ## 미지원 케이스 (후속 PR)
 //!
-//! - 조건부: `cond ? styled.div\`\` : styled.div\`\`` (var 이름 단일)
 //! - 클래스 정적 필드: `class { static Child = styled.div\`\` }` (이름 = "Child")
-//! - 객체 프로퍼티: `{ One: styled.div\`\` }` (이름 = "One")
-//! - 체인: `styled.div.attrs({...})\`\`` / `styled.div.withConfig({...})\`\``
-//! - 할당: `var X = Y = styled.div\`\``
+//! - 사용자 명시 `.withConfig({...})` 인식 시 merge / skip
+//! - 논리 (`cond && styled.div\`\``)
+//! - IIFE (`(() => styled.div\`\`)()`)
+//! - chained `var X = Y = styled.div\`\`` 의 outermost name 우선
+//! - TS cast: `(styled.div\`\` as any)` / `... satisfies T`
 
 const std = @import("std");
 const ast_mod = @import("../../parser/ast.zig");
@@ -209,18 +210,24 @@ pub fn wrapStyledTagInExpr(self: *Transformer, expr_idx: NodeIndex, var_name: []
     }
 }
 
-/// caller 의 fast-path 사전 필터 — wrapStyledTagInExpr 가 처리할 수 있는 형태인지.
-/// 옵션 OFF / binding 미감지 / 단순 식별자 init (`= 5`, `= other`) 같은 케이스에서 var_name
-/// 추출 + 함수 호출 비용을 회피.
-pub fn isWrappableExpr(tag: ast_mod.Node.Tag) bool {
+fn isWrappableExpr(tag: ast_mod.Node.Tag) bool {
     return tag == .tagged_template_expression or
         tag == .conditional_expression or
         tag == .parenthesized_expression;
 }
 
-/// 직접 styled tagged template 일 때만 호출되는 wrap (caller 가 tag 검증 후 호출).
-/// `wrapStyledTagInExpr` 의 재귀 base case.
-pub fn wrapStyledTag(self: *Transformer, init_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
+/// caller 의 fast-path 사전 필터 — visitVariableDeclarator / visitObjectProperty 가 매
+/// declarator 마다 호출. 옵션 OFF / binding 미감지 / wrappable 하지 않은 init 면 var_name
+/// 추출 + 함수 호출 비용을 회피.
+pub fn shouldAttemptWrap(self: *Transformer, expr_idx: NodeIndex) bool {
+    if (!self.options.styled_components) return false;
+    if (self.plugins.styled_components.default_binding == null) return false;
+    if (expr_idx.isNone()) return false;
+    return isWrappableExpr(self.ast.getNode(expr_idx).tag);
+}
+
+/// `wrapStyledTagInExpr` 의 재귀 base case — 직접 tagged_template 일 때만 호출.
+fn wrapStyledTag(self: *Transformer, init_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
     if (var_name.len == 0) return init_idx;
     const init_node = self.ast.getNode(init_idx);
 

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -147,7 +147,7 @@ pub fn maybeWrapAssignment(self: *Transformer, assignment_idx: NodeIndex) Error!
     const left = node.data.binary.left;
     const right = node.data.binary.right;
     if (left.isNone() or right.isNone()) return assignment_idx;
-    if (self.ast.getNode(right).tag != .tagged_template_expression) return assignment_idx;
+    if (!isWrappableExpr(self.ast.getNode(right).tag)) return assignment_idx;
     const left_node = self.ast.getNode(left);
     // 일반 assignment: LHS 가 assignment_target_identifier (parser 가 destructuring 컨텍스트
     // 외에서도 단순 식별자 LHS 를 이 태그로 변환).
@@ -156,7 +156,7 @@ pub fn maybeWrapAssignment(self: *Transformer, assignment_idx: NodeIndex) Error!
     const var_name = self.ast.getText(left_node.data.string_ref);
     if (var_name.len == 0) return assignment_idx;
 
-    const new_right = try wrapStyledTag(self, right, var_name);
+    const new_right = try wrapStyledTagInExpr(self, right, var_name);
     if (new_right == right) return assignment_idx;
     return self.ast.addNode(.{
         .tag = .assignment_expression,
@@ -165,9 +165,61 @@ pub fn maybeWrapAssignment(self: *Transformer, assignment_idx: NodeIndex) Error!
     });
 }
 
-/// `visitVariableDeclarator` 의 post-visit hook. caller 가 init.tag 를 사전 검사한 뒤
-/// tagged_template_expression 일 때만 호출 — 옵션 비활성 / binding 미감지 / 다른 tag 면
-/// caller 가 미리 거른다.
+/// 표현식이 styled tagged template 을 (직접 / 조건부 / 괄호 안에) 포함하면 wrap.
+/// caller 가 init.tag 를 사전 검사 (`isWrappableExpr`) 한 뒤 호출.
+///
+/// 인식 expression 형태:
+///   - `styled.div\`...\`` (직접)
+///   - `cond ? styled.div\`\` : styled.div\`\`` (양쪽 branch 에 같은 var_name 적용 — babel 동작)
+///   - `(styled.div\`\`)` (괄호 안)
+///   - 위 조합 (조건부 안의 괄호 등)
+pub fn wrapStyledTagInExpr(self: *Transformer, expr_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
+    if (expr_idx.isNone()) return expr_idx;
+    const node = self.ast.getNode(expr_idx);
+    switch (node.tag) {
+        .tagged_template_expression => return wrapStyledTag(self, expr_idx, var_name),
+        .conditional_expression => {
+            // ternary: a=test, b=consequent, c=alternate. test 는 전파하지 않음 (boolean expr).
+            const old_b = node.data.ternary.b;
+            const old_c = node.data.ternary.c;
+            const new_b = try wrapStyledTagInExpr(self, old_b, var_name);
+            const new_c = try wrapStyledTagInExpr(self, old_c, var_name);
+            if (new_b == old_b and new_c == old_c) return expr_idx;
+            return self.ast.addNode(.{
+                .tag = .conditional_expression,
+                .span = node.span,
+                .data = .{ .ternary = .{
+                    .a = node.data.ternary.a,
+                    .b = new_b,
+                    .c = new_c,
+                } },
+            });
+        },
+        .parenthesized_expression => {
+            const old_inner = node.data.unary.operand;
+            const new_inner = try wrapStyledTagInExpr(self, old_inner, var_name);
+            if (new_inner == old_inner) return expr_idx;
+            return self.ast.addNode(.{
+                .tag = .parenthesized_expression,
+                .span = node.span,
+                .data = .{ .unary = .{ .operand = new_inner, .flags = node.data.unary.flags } },
+            });
+        },
+        else => return expr_idx,
+    }
+}
+
+/// caller 의 fast-path 사전 필터 — wrapStyledTagInExpr 가 처리할 수 있는 형태인지.
+/// 옵션 OFF / binding 미감지 / 단순 식별자 init (`= 5`, `= other`) 같은 케이스에서 var_name
+/// 추출 + 함수 호출 비용을 회피.
+pub fn isWrappableExpr(tag: ast_mod.Node.Tag) bool {
+    return tag == .tagged_template_expression or
+        tag == .conditional_expression or
+        tag == .parenthesized_expression;
+}
+
+/// 직접 styled tagged template 일 때만 호출되는 wrap (caller 가 tag 검증 후 호출).
+/// `wrapStyledTagInExpr` 의 재귀 base case.
 pub fn wrapStyledTag(self: *Transformer, init_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
     if (var_name.len == 0) return init_idx;
     const init_node = self.ast.getNode(init_idx);


### PR DESCRIPTION
## Summary

조건부 (`cond ? styled.div\`\` : styled.div\`\``) 와 괄호 (`(styled.div\`\`)`) 안의 styled tagged template 도 wrap. babel-plugin-styled-components 의 `add-display-names` fixture 의 \"Test3\" 케이스에 해당.

\`\`\`tsx
// 입력
import styled from \"styled-components\";
const Test = isDark ? styled.div\`color: white;\` : styled.div\`color: black;\`;

// 출력 — 두 branch 가 모두 같은 displayName 으로 wrap
const Test = isDark
  ? styled.div.withConfig({ displayName: \"Test\", componentId: \"sc-...\" })\`color: white;\`
  : styled.div.withConfig({ displayName: \"Test\", componentId: \"sc-...\" })\`color: black;\`;
\`\`\`

## ⚠️ SSR componentId counter shift (영향 명시)

이전 PR 까지 ternary 안의 styled.div 는 **인식 안 되어** counter slot 을 차지하지 않았음. 이번 PR 부터 인식되므로 `cond ? styled.div\`\` : styled.div\`\`` 가 counter 2개 차지 → 같은 파일에서 그 뒤에 선언된 styled 컴포넌트들의 `componentId` 가 모두 +N shift.

- partial deploy SSR 환경에서 server (이전 빌드) ↔ client (이번 PR 빌드) 의 `componentId` 가 mismatch 되어 hydration 경고 가능
- 영구 안정화는 babel-style name-based hash 옵션 도입 필요 (이전 PR `feat/sc-component-id` 의 trade-off 주석 참고)
- 회피책: 한 번에 모두 재배포 (server + client 같이)

## 인식 매트릭스

| 케이스 | 상태 |
|---|---|
| `styled.div\`\`` (직접) | ✅ |
| `cond ? styled.div\`\` : styled.div\`\`` | ✅ (양쪽 branch 같은 displayName) |
| `cond ? styled.div\`\` : null` | ✅ (한쪽만 wrap, 다른쪽 보존) |
| `(styled.div\`\`)` (괄호) | ✅ |
| `(styled.div\`\` as any)` (TS cast) | ❌ → 후속 PR |
| `cond && styled.div\`\`` (논리) | ❌ → 후속 PR |
| `(() => styled.div\`\`)()` (IIFE) | ❌ → 후속 PR |

## 변경 내용

### `src/transformer/transformer/styled_components.zig`
- `wrapStyledTagInExpr` (recursive walker) — `tagged_template_expression` / `conditional_expression` / `parenthesized_expression` 을 walk. ternary 의 두 branch (b/c) 에 같은 var_name 적용 (test 식 a 는 그대로 유지).
- `shouldAttemptWrap` (fast-path 가드) — 옵션/binding/wrappable-tag 사전 필터, 3 callsite 통합.
- 기존 `wrapStyledTag` 는 base case 로 demote (`fn`, 모듈 내부 전용).

### `src/transformer/transformer.zig`
세 hook (`visitVariableDeclarator` / `visitObjectProperty` / `maybeWrapAssignment`) 모두 `shouldAttemptWrap` 로 가드 통합. 옵션 OFF / binding 미감지 / 단순 식별자 init 같은 hot path 는 단일 helper 호출에서 즉시 return.

## /simplify 결과 반영

3 agent 리뷰에서 적용한 fix:
- 가드 표현 3 callsite 통합 → `shouldAttemptWrap` helper
- `wrapStyledTag` / `isWrappableExpr` 모듈 내부 전용으로 demote
- 미지원 케이스 doc 블록 stale 라인 제거 (ternary / object property / .attrs / assignment 모두 인식)

defer (follow-up):
- TS cast (`as`, `satisfies`, `!`) 인식
- paren recursion → while loop (micro-opt)
- `null : styled.div\`\`` 대칭 테스트

## 검증

- ✅ `zig build test`: 4140/4140 pass (3 신규 — ternary / 괄호 / 한쪽 branch null)
- ✅ examples/web 빌드 무회귀

## 후속 PR

- [ ] 사용자 명시 `.withConfig({...})` 인식 시 merge / skip
- [ ] 클래스 정적 필드 (`class { static Child = styled.div\`\` }`)
- [ ] 논리 (`cond && styled.div\`\``) / IIFE / TS cast
- [ ] `transpileTemplateLiterals` / CSS minify
- [ ] componentId 의 babel-style name-based hash 옵션 (reorder 안정성)

🤖 Generated with [Claude Code](https://claude.com/claude-code)