### PR TITLE
feat(transformer): styled-components 사용자 명시 .withConfig 보존 (skip)

### DIFF
--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -212,6 +212,57 @@ test "styled-components: object property string-key { \"My Comp\": ... } 도 인
     try expectDisplayName(r.output, "MyComp");
 }
 
+test "styled-components: 사용자 명시 .withConfig 가 있으면 wrap 안 함" {
+    // 사용자가 자신의 componentId 를 박은 경우, 우리가 추가 .withConfig 를 chain 에 더하면
+    // styled-components 의 later-wins 시맨틱으로 user 의 ID 가 우리 자동 ID 로 override 됨.
+    // 이를 footgun 으로 보고 보수적으로 skip — user 의 명시 의도 존중.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const X = styled.div.withConfig({ componentId: "user-id" })`color: red;`;
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // 우리 자동 wrap 은 없어야 함 — user 의 withConfig 는 보존.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "user-id") != null);
+    // displayName 자동 부여도 안 됨.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "displayName") == null);
+}
+
+test "styled-components: 사용자 .withConfig + .attrs 체인도 skip" {
+    // chain 에 user 의 withConfig 가 어디든 있으면 skip — order 무관.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Y = styled.div.attrs({ id: "y" }).withConfig({ componentId: "y-id" })`color: red;`;
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "y-id") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "displayName") == null);
+}
+
+test "styled-components: .attrs 만 있는 chain 은 정상 wrap" {
+    // attrs 는 user-config 가 아니므로 정상 wrap — 회귀 보호.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Z = styled.div.attrs({ id: "z" })`color: red;`;
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "Z");
+}
+
 test "styled-components: 조건부 ternary — 양쪽 branch 에 같은 displayName" {
     var r = try e2eFull(
         std.testing.allocator,

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -95,36 +95,56 @@ pub fn detectStyledImport(self: *Transformer, node: Node) Error!void {
     // 이 PR 은 default binding 만 처리. named (`{ styled }`) 는 후속.
 }
 
-/// tag 표현식의 chain root 가 styled binding 인지 확인.
+/// chain 분석 결과 — `wrapStyledTag` 가 wrap 여부를 결정하는 데 사용.
+const ChainAnalysis = struct {
+    /// chain root identifier 가 styled binding 과 일치
+    matches_binding: bool,
+    /// chain 어딘가에 사용자 명시 `.withConfig({...})` 가 있음 — wrap 시 user 의 ID 가 우리
+    /// 자동 ID 로 override 되는 footgun 회피용 skip 신호
+    has_user_with_config: bool,
+};
+
+/// tag 표현식의 chain root 가 styled binding 인지 + 사용자 명시 withConfig 가 있는지 확인.
 /// 인식 (모두):
 ///   - `<binding>.X` (static_member)
 ///   - `<binding>(arg)` (call)
 ///   - `<binding>.X.attrs({...})` / `<binding>(X).attrs({...})` (chain: call→member→identifier)
 ///   - `<binding>.X.attrs({...}).attrs({...})` (다중 체인)
-///   - `<binding>.X.withConfig({...})` (사용자 명시 withConfig — 본 PR 은 추가 .withConfig
-///     를 한 번 더 append 하므로 styled-components 의 later-wins 시맨틱에 의존; 후속 PR 에서
-///     기존 withConfig 인식 시 merge / skip 분기)
-fn tagUsesBinding(self: *Transformer, tag_idx: NodeIndex) bool {
-    const binding = self.plugins.styled_components.default_binding orelse return false;
+///   - `<binding>.X.withConfig({...})` — matches_binding 이지만 has_user_with_config=true 라서
+///     wrap 시 skip 됨 (later-wins 로 user 의 componentId 가 override 되는 것을 방지)
+fn analyzeTagChain(self: *Transformer, tag_idx: NodeIndex) ChainAnalysis {
+    const result_no_match: ChainAnalysis = .{ .matches_binding = false, .has_user_with_config = false };
+    const binding = self.plugins.styled_components.default_binding orelse return result_no_match;
+    var has_with_config = false;
     var current = tag_idx;
     while (true) {
-        if (current.isNone()) return false;
+        if (current.isNone()) return result_no_match;
         const node = self.ast.getNode(current);
         switch (node.tag) {
             .identifier_reference => {
-                return std.mem.eql(u8, self.ast.getText(node.data.string_ref), binding);
+                const matches = std.mem.eql(u8, self.ast.getText(node.data.string_ref), binding);
+                return .{ .matches_binding = matches, .has_user_with_config = has_with_config };
             },
             .static_member_expression => {
-                // extra = [object, property, flags] — root 방향으로 object 만 따라감.
-                if (!self.ast.hasExtra(node.data.extra, 1)) return false;
+                // extra = [object, property, flags] — property 가 "withConfig" 면 표시.
+                if (!self.ast.hasExtra(node.data.extra, 1)) return result_no_match;
+                const prop_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[node.data.extra + 1]);
+                if (!prop_idx.isNone()) {
+                    const prop_node = self.ast.getNode(prop_idx);
+                    if (prop_node.tag == .identifier_reference) {
+                        if (std.mem.eql(u8, self.ast.getText(prop_node.data.string_ref), "withConfig")) {
+                            has_with_config = true;
+                        }
+                    }
+                }
                 current = @enumFromInt(self.ast.extra_data.items[node.data.extra]);
             },
             .call_expression => {
                 // extra = [callee, args_start, args_len, flags] — root 방향으로 callee 만 따라감.
-                if (!self.ast.hasExtra(node.data.extra, 0)) return false;
+                if (!self.ast.hasExtra(node.data.extra, 0)) return result_no_match;
                 current = @enumFromInt(self.ast.extra_data.items[node.data.extra]);
             },
-            else => return false,
+            else => return result_no_match,
         }
     }
 }
@@ -238,7 +258,12 @@ fn wrapStyledTag(self: *Transformer, init_idx: NodeIndex, var_name: []const u8) 
     const template_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 1]);
     const flags = self.ast.extra_data.items[e + 2];
 
-    if (!tagUsesBinding(self, tag_idx)) return init_idx;
+    const chain = analyzeTagChain(self, tag_idx);
+    if (!chain.matches_binding) return init_idx;
+    // 사용자가 명시 `.withConfig({...})` 작성한 경우 wrap 시 later-wins 시맨틱으로 user 의
+    // componentId 가 우리 자동 ID 로 override 되는 footgun. 보수적 skip — user 의 명시 의도
+    // 존중.
+    if (chain.has_user_with_config) return init_idx;
 
     const new_tag = try buildWithConfigCall(self, tag_idx, var_name);
     const new_extra = try self.ast.addExtras(&.{


### PR DESCRIPTION
## Summary

사용자가 직접 `.withConfig({...})` 작성한 경우 ZTS 자동 wrap 을 **skip** — 사용자의 `componentId` / `displayName` 이 ZTS 자동값으로 override 되는 footgun 회피.

\`\`\`tsx
// 입력 — 사용자가 직접 componentId 박음
import styled from \"styled-components\";
const X = styled.div.withConfig({ componentId: \"user-id\" })\`color: red;\`;

// 본 PR 출력 — 변경 없음 (사용자 설정 보존)
const X = styled.div.withConfig({ componentId: \"user-id\" })\`color: red;\`;

// 이전 PR 까지의 출력 — 사용자 ID 가 ZTS 자동 ID 로 override (footgun)
const X = styled.div
  .withConfig({ componentId: \"user-id\" })
  .withConfig({ displayName: \"X\", componentId: \"sc-...-0\" })\`color: red;\`;
\`\`\`

## Why

styled-components 의 `.withConfig` 는 **later-wins** 시맨틱 — chain 의 마지막 호출 값이 이긴다. ZTS 가 사용자 chain 끝에 자동 `.withConfig` 를 append 하면 사용자가 박은 `componentId` (예: SSR 의 stable-ID 정책) 가 ZTS 의 file-hash + counter 기반 자동 ID 로 override 되어 의도와 다른 값이 emit 됨.

3가지 정책 가능성:
1. **SKIP** (본 PR): 사용자 의도 100% 존중, 자동 displayName 도 부여 안 함
2. **MERGE**: 사용자 object 에 displayName 만 추가 (componentId 는 사용자값 유지) — 옵션화 후속 PR
3. **OVERRIDE** (현행): later-wins 로 ZTS 가 이김 — footgun

본 PR 은 가장 보수적인 SKIP. 후속 PR 에서 `compiler.styledComponents: { mergeUserWithConfig: true }` 같은 옵션으로 MERGE 도입 가능.

## 변경 내용

- `tagUsesBinding` (bool) → `analyzeTagChain` (`ChainAnalysis { matches_binding, has_user_with_config }`).
  chain 한 번 walk 하면서 root binding 매칭 + 사용자 withConfig 존재 여부 두 신호 동시 수집.
- static_member_expression descend 시 property identifier_reference 의 텍스트를 `\"withConfig\"` 와 비교 — chain 어디든 발견되면 `has_user_with_config = true`.
- `wrapStyledTag` (base case) 가 두 신호 모두 체크: `matches_binding && !has_user_with_config` 일 때만 wrap.

## Caveats

- private (`#`) / computed (`[expr]`) member 는 다른 노드 tag (`private_field_expression` / `computed_member_expression`) — walker 의 switch 밖으로 빠져 chain detection 자체가 끊김. 일반 wrap 도 발생 안 함 (의도된 보수적 skip).
- chain 외부의 wrapping (`someOtherFn(styled.div.withConfig({...})\`\`)`) 은 walker 가 root identifier 까지 도달 못 하므로 영향 없음.

## /simplify 결과

1-agent 통합 리뷰: clean — property shape 정확 (parser 가 `#private` 을 다른 tag 로 분류, computed 는 다른 member tag), hot-path 영향 미미, boolean state 안전, 테스트 견고, 주석 WHY-flavored.

## 검증

- ✅ `zig build test`: 4143/4143 pass (3 신규)
  - `styled.div.withConfig({...})\`\`` skip
  - `styled.div.attrs({}).withConfig({...})\`\`` chain 도 skip (order 무관)
  - `styled.div.attrs({})\`\`` (withConfig 없음) 정상 wrap (회귀 보호)
- ✅ examples/web 무회귀

## 후속 PR

- [ ] 클래스 정적 필드 (`class { static Child = styled.div\`\` }`)
- [ ] 논리 (`cond && styled.div\`\``) / IIFE / TS cast
- [ ] MERGE 정책 옵션화 (`compiler.styledComponents.mergeUserWithConfig`)
- [ ] `transpileTemplateLiterals` / CSS minify

🤖 Generated with [Claude Code](https://claude.com/claude-code)