### PR TITLE
feat(transformer): styled-components 논리 / TS cast / Flow cast 인식

### DIFF
--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -224,6 +224,7 @@ test "styled-components: 논리 `cond && styled.div\\`\\`` 우변 wrap" {
     );
     defer r.deinit();
     try expectDisplayName(r.output, "Lazy");
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "&&") != null); // wrapper 보존
 }
 
 test "styled-components: 논리 `default || styled.div\\`\\`` 우변 wrap" {
@@ -238,6 +239,22 @@ test "styled-components: 논리 `default || styled.div\\`\\`` 우변 wrap" {
     );
     defer r.deinit();
     try expectDisplayName(r.output, "Fallback");
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "||") != null); // wrapper 보존
+}
+
+test "styled-components: 좌변이 styled 인 `styled.div\\`\\` || fallback` 은 미인식 (의도)" {
+    // 좌변 wrap 은 단락평가 시맨틱 영향 위험으로 skip — 가드 회귀 보호.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const X = styled.div`color: red;` || LegacyBtn;
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") == null);
 }
 
 test "styled-components: TS cast `styled.div\\`\\` as Component` 인식" {
@@ -252,6 +269,7 @@ test "styled-components: TS cast `styled.div\\`\\` as Component` 인식" {
     );
     defer r.deinit();
     try expectDisplayName(r.output, "Casted");
+    // TS cast 자체는 codegen 에서 strip — operand (= wrap 된 styled tag) 만 남음.
 }
 
 test "styled-components: TS satisfies `... satisfies T` 인식" {
@@ -266,6 +284,7 @@ test "styled-components: TS satisfies `... satisfies T` 인식" {
     );
     defer r.deinit();
     try expectDisplayName(r.output, "Sat");
+    // satisfies 는 codegen 에서 strip — wrap 된 operand 만 남음.
 }
 
 test "styled-components: TS non-null `...!` 인식" {
@@ -280,6 +299,7 @@ test "styled-components: TS non-null `...!` 인식" {
     );
     defer r.deinit();
     try expectDisplayName(r.output, "NN");
+    // non-null assertion (!) 은 TS 전용 — codegen 에서 strip.
 }
 
 test "styled-components: 사용자 명시 .withConfig 가 있으면 wrap 안 함" {

--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -212,6 +212,76 @@ test "styled-components: object property string-key { \"My Comp\": ... } 도 인
     try expectDisplayName(r.output, "MyComp");
 }
 
+test "styled-components: 논리 `cond && styled.div\\`\\`` 우변 wrap" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Lazy = enabled && styled.div`color: red;`;
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "Lazy");
+}
+
+test "styled-components: 논리 `default || styled.div\\`\\`` 우변 wrap" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Fallback = userOverride || styled.div`color: blue;`;
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "Fallback");
+}
+
+test "styled-components: TS cast `styled.div\\`\\` as Component` 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Casted = styled.div`color: red;` as React.FC;
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "Casted");
+}
+
+test "styled-components: TS satisfies `... satisfies T` 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Sat = styled.div`color: red;` satisfies React.FC;
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "Sat");
+}
+
+test "styled-components: TS non-null `...!` 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const NN = styled.div`color: red;`!;
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "NN");
+}
+
 test "styled-components: 사용자 명시 .withConfig 가 있으면 wrap 안 함" {
     // 사용자가 자신의 componentId 를 박은 경우, 우리가 추가 .withConfig 를 chain 에 더하면
     // styled-components 의 later-wins 시맨틱으로 user 의 ID 가 우리 자동 ID 로 override 됨.

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -186,14 +186,17 @@ pub fn maybeWrapAssignment(self: *Transformer, assignment_idx: NodeIndex) Error!
     });
 }
 
-/// 표현식이 styled tagged template 을 (직접 / 조건부 / 괄호 안에) 포함하면 wrap.
+/// 표현식이 styled tagged template 을 (직접 / wrapper 안에) 포함하면 wrap.
 /// caller 가 init.tag 를 사전 검사 (`isWrappableExpr`) 한 뒤 호출.
 ///
-/// 인식 expression 형태:
+/// 인식 expression wrapper:
 ///   - `styled.div\`...\`` (직접)
-///   - `cond ? styled.div\`\` : styled.div\`\`` (양쪽 branch 에 같은 var_name 적용 — babel 동작)
-///   - `(styled.div\`\`)` (괄호 안)
-///   - 위 조합 (조건부 안의 괄호 등)
+///   - `cond ? styled.div\`\` : styled.div\`\`` (양쪽 branch — babel 동작)
+///   - `(styled.div\`\`)` (괄호)
+///   - `cond && styled.div\`\`` / `default || styled.div\`\`` / `?? styled.div\`\`` (논리 — 우변만)
+///   - `styled.div\`\` as Component` / `... satisfies T` / `...!` / legacy `<T>...` (TS 캐스트)
+///   - `styled.div\`\` as Foo` (Flow 캐스트)
+///   - 위 조합 (캐스트 안의 괄호 등)
 pub fn wrapStyledTagInExpr(self: *Transformer, expr_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
     if (expr_idx.isNone()) return expr_idx;
     const node = self.ast.getNode(expr_idx);
@@ -216,12 +219,37 @@ pub fn wrapStyledTagInExpr(self: *Transformer, expr_idx: NodeIndex, var_name: []
                 } },
             });
         },
-        .parenthesized_expression => {
+        .logical_expression => {
+            // binary: left, right, flags. && 의 right 가 결과값. || / ?? 도 fallback 위치
+            // 가 right 라 동일하게 처리. left 는 전파하지 않음 (대부분 condition / default 가
+            // styled 컴포넌트가 아니어서 false-positive 위험).
+            const old_right = node.data.binary.right;
+            const new_right = try wrapStyledTagInExpr(self, old_right, var_name);
+            if (new_right == old_right) return expr_idx;
+            return self.ast.addNode(.{
+                .tag = .logical_expression,
+                .span = node.span,
+                .data = .{ .binary = .{
+                    .left = node.data.binary.left,
+                    .right = new_right,
+                    .flags = node.data.binary.flags,
+                } },
+            });
+        },
+        .parenthesized_expression,
+        .ts_as_expression,
+        .ts_satisfies_expression,
+        .ts_type_assertion,
+        .ts_non_null_expression,
+        .flow_as_expression,
+        .flow_type_cast_expression,
+        => {
+            // 모두 unary { operand, flags } — operand 만 walk.
             const old_inner = node.data.unary.operand;
             const new_inner = try wrapStyledTagInExpr(self, old_inner, var_name);
             if (new_inner == old_inner) return expr_idx;
             return self.ast.addNode(.{
-                .tag = .parenthesized_expression,
+                .tag = node.tag,
                 .span = node.span,
                 .data = .{ .unary = .{ .operand = new_inner, .flags = node.data.unary.flags } },
             });
@@ -231,9 +259,20 @@ pub fn wrapStyledTagInExpr(self: *Transformer, expr_idx: NodeIndex, var_name: []
 }
 
 fn isWrappableExpr(tag: ast_mod.Node.Tag) bool {
-    return tag == .tagged_template_expression or
-        tag == .conditional_expression or
-        tag == .parenthesized_expression;
+    return switch (tag) {
+        .tagged_template_expression,
+        .conditional_expression,
+        .logical_expression,
+        .parenthesized_expression,
+        .ts_as_expression,
+        .ts_satisfies_expression,
+        .ts_type_assertion,
+        .ts_non_null_expression,
+        .flow_as_expression,
+        .flow_type_cast_expression,
+        => true,
+        else => false,
+    };
 }
 
 /// caller 의 fast-path 사전 필터 — visitVariableDeclarator / visitObjectProperty 가 매

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -186,6 +186,26 @@ pub fn maybeWrapAssignment(self: *Transformer, assignment_idx: NodeIndex) Error!
     });
 }
 
+/// `parenthesized_expression` + 모든 type assertion 류 — 공통적으로 unary { operand, flags }
+/// 데이터 변형. wrapStyledTagInExpr 와 isWrappableExpr 가 이 set 을 공유.
+///
+/// 주의: codegen / semantic / worklet 등 다른 pass 도 비슷한 set 을 가짐. 향후 cross-cutting
+/// refactor 로 es_helpers 의 `TRANSPARENT_WRAPPER_TAGS` 같은 단일 source 화 권장 (별도 PR).
+fn isUnaryWrapperTag(tag: ast_mod.Node.Tag) bool {
+    return switch (tag) {
+        .parenthesized_expression,
+        .ts_as_expression,
+        .ts_satisfies_expression,
+        .ts_type_assertion,
+        .ts_non_null_expression,
+        .ts_instantiation_expression,
+        .flow_as_expression,
+        .flow_type_cast_expression,
+        => true,
+        else => false,
+    };
+}
+
 /// 표현식이 styled tagged template 을 (직접 / wrapper 안에) 포함하면 wrap.
 /// caller 가 init.tag 를 사전 검사 (`isWrappableExpr`) 한 뒤 호출.
 ///
@@ -194,85 +214,69 @@ pub fn maybeWrapAssignment(self: *Transformer, assignment_idx: NodeIndex) Error!
 ///   - `cond ? styled.div\`\` : styled.div\`\`` (양쪽 branch — babel 동작)
 ///   - `(styled.div\`\`)` (괄호)
 ///   - `cond && styled.div\`\`` / `default || styled.div\`\`` / `?? styled.div\`\`` (논리 — 우변만)
-///   - `styled.div\`\` as Component` / `... satisfies T` / `...!` / legacy `<T>...` (TS 캐스트)
-///   - `styled.div\`\` as Foo` (Flow 캐스트)
-///   - 위 조합 (캐스트 안의 괄호 등)
+///   - `styled.div\`\` as T` / `... satisfies T` / `...!` / legacy `<T>...` / Foo<T> 인스턴스화 (TS)
+///   - `styled.div\`\` as Foo` (Flow)
+///   - 위 조합
+///
+/// 미인식 (의도된 한계):
+///   - `styled.div\`\` || fallback` 처럼 좌변이 styled 인 논리 — wrap 시 단락평가 시맨틱이
+///     변할 수 있어 보수적 skip
 pub fn wrapStyledTagInExpr(self: *Transformer, expr_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
     if (expr_idx.isNone()) return expr_idx;
     const node = self.ast.getNode(expr_idx);
-    switch (node.tag) {
-        .tagged_template_expression => return wrapStyledTag(self, expr_idx, var_name),
-        .conditional_expression => {
-            // ternary: a=test, b=consequent, c=alternate. test 는 전파하지 않음 (boolean expr).
-            const old_b = node.data.ternary.b;
-            const old_c = node.data.ternary.c;
-            const new_b = try wrapStyledTagInExpr(self, old_b, var_name);
-            const new_c = try wrapStyledTagInExpr(self, old_c, var_name);
-            if (new_b == old_b and new_c == old_c) return expr_idx;
-            return self.ast.addNode(.{
-                .tag = .conditional_expression,
-                .span = node.span,
-                .data = .{ .ternary = .{
-                    .a = node.data.ternary.a,
-                    .b = new_b,
-                    .c = new_c,
-                } },
-            });
-        },
-        .logical_expression => {
-            // binary: left, right, flags. && 의 right 가 결과값. || / ?? 도 fallback 위치
-            // 가 right 라 동일하게 처리. left 는 전파하지 않음 (대부분 condition / default 가
-            // styled 컴포넌트가 아니어서 false-positive 위험).
-            const old_right = node.data.binary.right;
-            const new_right = try wrapStyledTagInExpr(self, old_right, var_name);
-            if (new_right == old_right) return expr_idx;
-            return self.ast.addNode(.{
-                .tag = .logical_expression,
-                .span = node.span,
-                .data = .{ .binary = .{
-                    .left = node.data.binary.left,
-                    .right = new_right,
-                    .flags = node.data.binary.flags,
-                } },
-            });
-        },
-        .parenthesized_expression,
-        .ts_as_expression,
-        .ts_satisfies_expression,
-        .ts_type_assertion,
-        .ts_non_null_expression,
-        .flow_as_expression,
-        .flow_type_cast_expression,
-        => {
-            // 모두 unary { operand, flags } — operand 만 walk.
-            const old_inner = node.data.unary.operand;
-            const new_inner = try wrapStyledTagInExpr(self, old_inner, var_name);
-            if (new_inner == old_inner) return expr_idx;
-            return self.ast.addNode(.{
-                .tag = node.tag,
-                .span = node.span,
-                .data = .{ .unary = .{ .operand = new_inner, .flags = node.data.unary.flags } },
-            });
-        },
-        else => return expr_idx,
+    if (node.tag == .tagged_template_expression) return wrapStyledTag(self, expr_idx, var_name);
+
+    if (node.tag == .conditional_expression) {
+        // ternary: a=test, b=consequent, c=alternate. test 는 전파 안 함 (boolean expr).
+        const old_b = node.data.ternary.b;
+        const old_c = node.data.ternary.c;
+        const new_b = try wrapStyledTagInExpr(self, old_b, var_name);
+        const new_c = try wrapStyledTagInExpr(self, old_c, var_name);
+        if (new_b == old_b and new_c == old_c) return expr_idx;
+        return self.ast.addNode(.{
+            .tag = .conditional_expression,
+            .span = node.span,
+            .data = .{ .ternary = .{ .a = node.data.ternary.a, .b = new_b, .c = new_c } },
+        });
     }
+
+    if (node.tag == .logical_expression) {
+        // && 의 right 가 결과값. || / ?? 도 fallback 위치가 right. left 는 condition/default
+        // 라 보통 styled 가 아닐뿐더러, 좌변이 styled 인 `styled.div\`\` || fallback` 케이스는
+        // wrap 시 단락평가 시맨틱이 영향 받을 수 있어 보수적 skip.
+        const old_right = node.data.binary.right;
+        const new_right = try wrapStyledTagInExpr(self, old_right, var_name);
+        if (new_right == old_right) return expr_idx;
+        return self.ast.addNode(.{
+            .tag = .logical_expression,
+            .span = node.span,
+            .data = .{ .binary = .{
+                .left = node.data.binary.left,
+                .right = new_right,
+                .flags = node.data.binary.flags,
+            } },
+        });
+    }
+
+    if (isUnaryWrapperTag(node.tag)) {
+        const old_inner = node.data.unary.operand;
+        const new_inner = try wrapStyledTagInExpr(self, old_inner, var_name);
+        if (new_inner == old_inner) return expr_idx;
+        return self.ast.addNode(.{
+            .tag = node.tag,
+            .span = node.span,
+            .data = .{ .unary = .{ .operand = new_inner, .flags = node.data.unary.flags } },
+        });
+    }
+
+    return expr_idx;
 }
 
 fn isWrappableExpr(tag: ast_mod.Node.Tag) bool {
-    return switch (tag) {
-        .tagged_template_expression,
-        .conditional_expression,
-        .logical_expression,
-        .parenthesized_expression,
-        .ts_as_expression,
-        .ts_satisfies_expression,
-        .ts_type_assertion,
-        .ts_non_null_expression,
-        .flow_as_expression,
-        .flow_type_cast_expression,
-        => true,
-        else => false,
-    };
+    return tag == .tagged_template_expression or
+        tag == .conditional_expression or
+        tag == .logical_expression or
+        isUnaryWrapperTag(tag);
 }
 
 /// caller 의 fast-path 사전 필터 — visitVariableDeclarator / visitObjectProperty 가 매


### PR DESCRIPTION
## Summary

`wrapStyledTagInExpr` 의 walker 를 확장 — 논리 표현식 우변 + 모든 type assertion 형태 (TS / Flow) 안에 styled tagged template 이 있으면 wrap.

\`\`\`tsx
// 논리
const Lazy = enabled && styled.div\`color: red;\`;
// → const Lazy = enabled && styled.div.withConfig({ displayName: \"Lazy\", componentId: \"sc-...\" })\`...\`;

// TS as cast
const Casted = styled.div\`...\` as React.FC;
// → const Casted = styled.div.withConfig({ ... })\`...\` as React.FC;

// satisfies
const Sat = styled.div\`...\` satisfies React.FC;

// non-null assertion
const NN = styled.div\`...\`!;
\`\`\`

## 새로 인식되는 wrapper expression

| 노드 | 케이스 | 처리 |
|---|---|---|
| `logical_expression` | `cond && X` / `default \\|\\| X` / `X ?? Y` | 우변만 walk (좌변은 condition/default 라 false-positive 회피) |
| `ts_as_expression` | `X as T` | operand walk |
| `ts_satisfies_expression` | `X satisfies T` | operand walk |
| `ts_type_assertion` | legacy `<T>X` | operand walk |
| `ts_non_null_expression` | `X!` | operand walk |
| `flow_as_expression` | Flow `X as T` | operand walk |
| `flow_type_cast_expression` | Flow `(X: T)` | operand walk |

이전 PR 까지 인식되던 케이스 (`tagged_template`, `conditional`, `parenthesized`) 은 그대로.

## 코드 단순화

7개 unary 형태가 모두 같은 데이터 변형 (`{ operand, flags }`) 이라 switch 의 한 분기로 통합:

\`\`\`zig
.parenthesized_expression,
.ts_as_expression,
.ts_satisfies_expression,
.ts_type_assertion,
.ts_non_null_expression,
.flow_as_expression,
.flow_type_cast_expression,
=> {
    const old_inner = node.data.unary.operand;
    const new_inner = try wrapStyledTagInExpr(self, old_inner, var_name);
    if (new_inner == old_inner) return expr_idx;
    return self.ast.addNode(.{ .tag = node.tag, .span = node.span, .data = .{ .unary = ... } });
},
\`\`\`

`isWrappableExpr` 도 switch 로 변환 (10개 케이스 가독성).

## 인식 매트릭스 (이번 PR 후 누적)

| 케이스 | 상태 |
|---|---|
| `styled.div\`\`` (직접) | ✅ |
| `cond ? styled.div\`\` : styled.div\`\`` | ✅ |
| `(styled.div\`\`)` (괄호) | ✅ |
| `cond && styled.div\`\`` (논리) | ✅ **(이번 PR)** |
| `default \\|\\| styled.div\`\`` (논리 fallback) | ✅ **(이번 PR)** |
| `styled.div\`\` as T` (TS cast) | ✅ **(이번 PR)** |
| `styled.div\`\` satisfies T` | ✅ **(이번 PR)** |
| `styled.div\`\`!` (non-null) | ✅ **(이번 PR)** |
| `class { static Child = styled.div\`\` }` | ❌ → 후속 PR |
| `(() => styled.div\`\`)()` (IIFE) | ❌ → 후속 PR |

## 검증

- ✅ `zig build test`: 4148/4148 pass (5 신규)
- ✅ examples/web 빌드 무회귀

## 후속 PR

- [ ] 클래스 정적 필드 (`class { static Child = styled.div\`\` }`)
- [ ] IIFE
- [ ] MERGE 정책 옵션화 (사용자 `.withConfig` 와 merge)
- [ ] `transpileTemplateLiterals` / CSS minify

🤖 Generated with [Claude Code](https://claude.com/claude-code)