### PR TITLE
feat(transformer): styled-components 클래스 정적/인스턴스 필드 인식

### DIFF
--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -212,6 +212,55 @@ test "styled-components: object property string-key { \"My Comp\": ... } 도 인
     try expectDisplayName(r.output, "MyComp");
 }
 
+test "styled-components: 클래스 정적 필드 `static Child = styled.div\\`\\``" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\class Comp {
+        \\  static Child = styled.div`color: red;`;
+        \\}
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "Child");
+}
+
+test "styled-components: 클래스 인스턴스 필드 `field = styled.div\\`\\`` 도 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\class Comp {
+        \\  Inner = styled.div`color: red;`;
+        \\}
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "Inner");
+}
+
+test "styled-components: 클래스 computed key `[expr] = ...` 는 미인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const key = "X";
+        \\class Comp {
+        \\  static [key] = styled.div`color: red;`;
+        \\}
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") == null);
+}
+
 test "styled-components: 논리 `cond && styled.div\\`\\`` 우변 wrap" {
     var r = try e2eFull(
         std.testing.allocator,

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -4333,7 +4333,15 @@ pub const Transformer = struct {
         // abstract(0x20), declare(0x40), Flow variance(0x80)는 타입 전용이므로 완전히 스트리핑
         if (self.options.strip_types and (flags & 0xE0) != 0) return NodeIndex.none;
         const new_key = try self.visitNode(self.readNodeIdx(e, 0));
-        const new_value = try self.visitNode(self.readNodeIdx(e, 1));
+        var new_value = try self.visitNode(self.readNodeIdx(e, 1));
+        // styled-components: `class { static Child = styled.div\`\` }` 의 value 가 styled
+        // tagged template 이면 field key 를 displayName 으로 사용해 wrap. 인스턴스 필드도
+        // 동일하게 처리 (드물지만 가능). objectProperty 패턴 재사용.
+        if (!new_key.isNone() and styled_components_mod.shouldAttemptWrap(self, new_value)) {
+            if (styled_components_mod.objectPropertyKeyName(self, new_key)) |key_name| {
+                new_value = try styled_components_mod.wrapStyledTagInExpr(self, new_value, key_name);
+            }
+        }
         // experimentalDecorators 모드에서는 decorator를 class 수준에서 처리하므로
         // property_definition에서는 제거한다.
         const new_decos = if (self.options.experimental_decorators)
@@ -4353,7 +4361,14 @@ pub const Transformer = struct {
         // declare accessor는 타입 전용이므로 완전히 스트리핑
         if (self.options.strip_types and (flags & ast_mod.PropertyFlags.is_declare) != 0) return NodeIndex.none;
         const new_key = try self.visitNode(self.readNodeIdx(e, 0));
-        const new_value = try self.visitNode(self.readNodeIdx(e, 1));
+        var new_value = try self.visitNode(self.readNodeIdx(e, 1));
+        // styled-components: property_definition 와 동일 — accessor 필드도 init 이 styled
+        // tagged template 이면 wrap. 드물지만 symmetry.
+        if (!new_key.isNone() and styled_components_mod.shouldAttemptWrap(self, new_value)) {
+            if (styled_components_mod.objectPropertyKeyName(self, new_key)) |key_name| {
+                new_value = try styled_components_mod.wrapStyledTagInExpr(self, new_value, key_name);
+            }
+        }
         const new_decos = try self.visitExtraList(.{ .start = self.readU32(e, 3), .len = self.readU32(e, 4) });
         return self.addExtraNode(.accessor_property, node.span, &.{
             @intFromEnum(new_key), @intFromEnum(new_value), self.readU32(e, 2),


### PR DESCRIPTION
## Summary

`class { static Child = styled.div\`\` }` / `Inner = styled.div\`\`` 형태의 class field 도 wrap. field key 를 displayName 으로 사용. babel-plugin-styled-components 의 `add-display-names` fixture 의 ClassComponent.Child 케이스에 해당.

\`\`\`tsx
// 입력
import styled from \"styled-components\";
class Comp {
  static Child = styled.div\`color: red;\`;
}

// 출력
class Comp {
  static Child = styled.div.withConfig({ displayName: \"Child\", componentId: \"sc-...\" })\`color: red;\`;
}
\`\`\`

## 변경 내용

- `transformer.zig:visitPropertyDefinition` — `visitObjectProperty` 와 동일 hook (`objectPropertyKeyName` + `wrapStyledTagInExpr`) 추가. `shouldAttemptWrap` fast-path.
- `transformer.zig:visitAccessorProperty` — 동일 hook 미러링 (symmetry — /simplify 리뷰에서 누락 지적).

## 인식 매트릭스

| 케이스 | 상태 |
|---|---|
| `class { static Child = styled.div\`\` }` (정적 필드) | ✅ |
| `class { Inner = styled.div\`\` }` (인스턴스 필드) | ✅ |
| `class { static accessor X = styled.div\`\` }` (accessor) | ✅ |
| `class { #name = styled.div\`\` }` (private) | ❌ (private_identifier — styled-components 컨벤션과 어긋남) |
| `class { static [key] = styled.div\`\` }` (computed) | ❌ (정적 이름 추출 불가) |

## /simplify 결과

1-agent 리뷰에서 `visitAccessorProperty` 의 누락 지적 → 동일 hook 추가로 symmetry 확보.

## 검증

- ✅ `zig build test`: 4153/4153 pass (3 신규 — static / instance / computed-reject)
- ✅ examples/web 무회귀

## 후속 PR

- [ ] IIFE (`(() => styled.div\`\`)()`)
- [ ] MERGE 정책 옵션화 (사용자 `.withConfig` 와 merge)
- [ ] `transpileTemplateLiterals` / CSS minify
- [ ] `es_helpers.TRANSPARENT_WRAPPER_TAGS` 단일 source 추출 (cross-cutting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)