### PR TITLE
feat(transformer): styled-components IIFE 패턴 인식

### DIFF
--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -212,6 +212,87 @@ test "styled-components: object property string-key { \"My Comp\": ... } 도 인
     try expectDisplayName(r.output, "MyComp");
 }
 
+test "styled-components: IIFE `(() => styled.div\\`\\`)()` 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Lazy = (() => styled.div`color: red;`)();
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "Lazy");
+    // IIFE 외형 보존 — wrap 이 안쪽에서 일어나야 함.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "()=>") != null or
+        std.mem.indexOf(u8, r.output, "() =>") != null);
+}
+
+test "styled-components: IIFE 의 arrow params + closure 보존" {
+    // arrow 가 param 받는 경우 — 우리 wrap 은 body 의 tagged_template 만 변환,
+    // 원본 template 노드는 그대로 참조되므로 ${color} 같은 closure binding 유지.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Themed = ((color) => styled.div`color: ${color};`)("red");
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "Themed");
+    // closure binding `${color}` 보존 — wrap 이 template 변형 안 함.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "color") != null);
+}
+
+test "styled-components: 다중 paren `((() => ...))()` 도 처리" {
+    // formatter 가 보통 collapse 하지만 source 그대로 들어오면 다중 unwrap 필요.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Deep = ((() => styled.div`color: red;`))();
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "Deep");
+}
+
+test "styled-components: IIFE block body `(() => { return ... })()` 미지원" {
+    // 첫 iteration 은 expression body 만 — return statement walker 는 후속.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Lazy = (() => { return styled.div`color: red;`; })();
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") == null);
+}
+
+test "styled-components: 일반 함수 호출 `someFn(...)` 은 IIFE 가 아님 (회귀 가드)" {
+    // call_expression 이 isWrappableExpr 에 추가되었지만 callee 가 arrow 가 아니면
+    // 즉시 early-return 해야 함 — 일반 함수 호출에서 false-positive 없어야.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const X = createSomething(styled.div`color: red;`);
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") == null);
+}
+
 test "styled-components: 클래스 정적 필드 `static Child = styled.div\\`\\``" {
     var r = try e2eFull(
         std.testing.allocator,

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -216,6 +216,7 @@ fn isUnaryWrapperTag(tag: ast_mod.Node.Tag) bool {
 ///   - `cond && styled.div\`\`` / `default || styled.div\`\`` / `?? styled.div\`\`` (논리 — 우변만)
 ///   - `styled.div\`\` as T` / `... satisfies T` / `...!` / legacy `<T>...` / Foo<T> 인스턴스화 (TS)
 ///   - `styled.div\`\` as Foo` (Flow)
+///   - `(() => styled.div\`\`)()` IIFE — 단일 expression body 만 (block body `{ return ... }` 미지원)
 ///   - 위 조합
 ///
 /// 미인식 (의도된 한계):
@@ -269,13 +270,93 @@ pub fn wrapStyledTagInExpr(self: *Transformer, expr_idx: NodeIndex, var_name: []
         });
     }
 
+    if (node.tag == .call_expression) {
+        return wrapStyledInIife(self, expr_idx, var_name);
+    }
+
     return expr_idx;
+}
+
+/// IIFE `(() => <body>)()` / `(() => <body>)(...args)` — body 에 styled tagged template 이
+/// 있으면 body 를 wrap 한 새 call_expression 빌드.
+/// 첫 iteration: arrow expression body 만 인식 (block body `{ return X }` 는 후속).
+/// callee 가 arrow function 이 아니면 (일반 함수 호출) early-return — hot path 보호.
+fn wrapStyledInIife(self: *Transformer, call_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
+    const call_node = self.ast.getNode(call_idx);
+    // call extra = [callee, args_start, args_len, flags]
+    if (!self.ast.hasExtra(call_node.data.extra, 2)) return call_idx;
+    const callee_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[call_node.data.extra]);
+    if (callee_idx.isNone()) return call_idx;
+
+    // 다중 paren `((() => X))()` 도 처리 — while 로 unwrap.
+    var arrow_idx = callee_idx;
+    var arrow_node = self.ast.getNode(arrow_idx);
+    while (arrow_node.tag == .parenthesized_expression) {
+        arrow_idx = arrow_node.data.unary.operand;
+        if (arrow_idx.isNone()) return call_idx;
+        arrow_node = self.ast.getNode(arrow_idx);
+    }
+    if (arrow_node.tag != .arrow_function_expression) return call_idx;
+
+    // arrow extra = [params(0), body(1), flags(2)]
+    if (!self.ast.hasExtra(arrow_node.data.extra, 1)) return call_idx;
+    const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[arrow_node.data.extra + 1]);
+    if (body_idx.isNone()) return call_idx;
+
+    // block body (`() => { return ... }`) 는 후속 PR — return statement walking 필요.
+    const body_node = self.ast.getNode(body_idx);
+    if (body_node.tag == .block_statement) return call_idx;
+
+    const new_body = try wrapStyledTagInExpr(self, body_idx, var_name);
+    if (new_body == body_idx) return call_idx;
+
+    // Rebuild arrow with new body (params / flags 그대로).
+    const params_idx_raw = self.ast.extra_data.items[arrow_node.data.extra];
+    const arrow_flags = if (self.ast.hasExtra(arrow_node.data.extra, 2))
+        self.ast.extra_data.items[arrow_node.data.extra + 2]
+    else
+        0;
+    const new_arrow = try self.addExtraNode(.arrow_function_expression, arrow_node.span, &.{
+        params_idx_raw,
+        @intFromEnum(new_body),
+        arrow_flags,
+    });
+
+    // Re-wrap parens — 원본의 paren chain 깊이만큼 다시 감쌈 (callee 부터 다시 walk).
+    var new_callee = new_arrow;
+    var paren_walk_idx = callee_idx;
+    var paren_walk_node = self.ast.getNode(paren_walk_idx);
+    while (paren_walk_node.tag == .parenthesized_expression) {
+        new_callee = try self.ast.addNode(.{
+            .tag = .parenthesized_expression,
+            .span = paren_walk_node.span,
+            .data = .{ .unary = .{ .operand = new_callee, .flags = paren_walk_node.data.unary.flags } },
+        });
+        paren_walk_idx = paren_walk_node.data.unary.operand;
+        if (paren_walk_idx.isNone()) break;
+        paren_walk_node = self.ast.getNode(paren_walk_idx);
+    }
+
+    // Rebuild call (args / flags 그대로).
+    const args_start = self.ast.extra_data.items[call_node.data.extra + 1];
+    const args_len = self.ast.extra_data.items[call_node.data.extra + 2];
+    const call_flags = if (self.ast.hasExtra(call_node.data.extra, 3))
+        self.ast.extra_data.items[call_node.data.extra + 3]
+    else
+        0;
+    return try self.addExtraNode(.call_expression, call_node.span, &.{
+        @intFromEnum(new_callee),
+        args_start,
+        args_len,
+        call_flags,
+    });
 }
 
 fn isWrappableExpr(tag: ast_mod.Node.Tag) bool {
     return tag == .tagged_template_expression or
         tag == .conditional_expression or
         tag == .logical_expression or
+        tag == .call_expression or // IIFE — wrapStyledInIife 가 non-IIFE 는 fast early-return
         isUnaryWrapperTag(tag);
 }
 


### PR DESCRIPTION
## Summary

`(() => styled.div\`\`)()` IIFE 패턴 인식 — babel-plugin-styled-components / @swc/plugin-styled-components 와 parity 확보. arrow expression body 만 우선, block body 는 후속.

\`\`\`tsx
// 입력
import styled from \"styled-components\";
const Lazy = (() => styled.div\`color: red;\`)();

// 출력
const Lazy = (() => styled.div.withConfig({
  displayName: \"Lazy\",
  componentId: \"sc-...\",
})\`color: red;\`)();
\`\`\`

## Why now

ZTS 의 단방향 visit (`NodeIndex → NodeIndex`) 모델은 babel/swc 의 parent-context propagation 과 달라 wrapper 별 명시적 walker 필요. 흔한 패턴들 (직접 / 조건부 / 논리 / 클래스 정적 / TS cast / 사용자 .withConfig 등) 은 지난 PR 들에서 모두 cover. IIFE 가 마지막 babel-fixture 패턴.

## 인식 매트릭스 (이번 PR 후 누적)

| 케이스 | 상태 |
|---|---|
| `styled.div\`\`` (직접) | ✅ |
| `styled(X)\`\`` (call) | ✅ |
| `styled.div.attrs({}).withConfig({})\`\`` (chain) | ✅ |
| `cond ? styled.div\`\` : styled.div\`\`` (ternary) | ✅ |
| `cond && styled.div\`\`` (논리 우변) | ✅ |
| `(styled.div\`\`)` (paren) | ✅ |
| `styled.div\`\` as T` / `satisfies` / `!` (TS/Flow cast) | ✅ |
| `class { static Child = styled.div\`\` }` | ✅ |
| `Component = styled.div\`\`` (assignment) | ✅ |
| `{ One: styled.div\`\` }` (object property) | ✅ |
| `(() => styled.div\`\`)()` (IIFE expression body) | ✅ **(이번 PR)** |
| `(() => { return styled.div\`\` })()` (IIFE block body) | ❌ → 후속 PR |
| `styled.div\`\` || fallback` (좌변 styled 논리) | ❌ (단락평가 시맨틱 위험) |
| `styled.div.withConfig({...})\`\`` 사용자 명시 | ❌ skip (footgun 회피) |

## 변경 내용

### `src/transformer/transformer/styled_components.zig:wrapStyledInIife`
- `call_expression` → `callee` → optional 다중 `paren` unwrap → `arrow_function_expression` → expression body
- 다중 paren `((() => X))()` while-loop 으로 unwrap (formatter 가 보통 collapse 하지만 source 그대로 들어오면 처리 필요)
- 원본 paren 깊이만큼 다시 감싸 rebuild
- `isWrappableExpr` 에 `.call_expression` 추가 — non-IIFE call 은 walker 가 ~2 getNode + 1 extra read 후 fast bailout

## /simplify 결과

1-agent 리뷰 적용:
- 다중 paren 처리 (`if` → `while`)
- 첫 PR 에서 paren 없는 IIFE 테스트가 fixture 중복이었음 → arrow params + closure 보존 케이스로 교체

## 검증

- ✅ `zig build test`: 4157/4157 pass (5 신규)
  - 단순 IIFE / params + closure / 다중 paren / block body 미지원 / 일반 함수 호출 false-positive 가드
- ✅ examples/web 무회귀

## 후속 PR

- [ ] IIFE block body (`{ return ... }`) — return statement walker
- [ ] `compiler.styledComponents.ssr: false` 옵션
- [ ] MERGE 정책 옵션화
- [ ] `transpileTemplateLiterals` / CSS minify

🤖 Generated with [Claude Code](https://claude.com/claude-code)