### PR TITLE
feat(transformer): compiler.styledComponents.ssr 옵션 (componentId opt-out)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1238,14 +1238,14 @@ function prepareNapiOptions(options: BuildOptions): Record<string, unknown> {
     delete napiOptions.browserslist;
   }
   // compiler.styledComponents / compiler.emotion → flat NAPI fields.
-  // boolean 또는 객체 (세밀 제어 옵션). 현재는 enabled 여부만 Zig 로 전달.
-  // 후속 PR 에서 객체 옵션 (displayName / ssr / fileName / minify 등) 도 throughpass.
+  // boolean 또는 객체 (세밀 제어 옵션). 현재 인식 객체 옵션: ssr.
   delete napiOptions.compiler;
-  if (
-    options.compiler?.styledComponents !== undefined &&
-    options.compiler.styledComponents !== false
-  ) {
+  const sc = options.compiler?.styledComponents;
+  if (sc !== undefined && sc !== false) {
     napiOptions.styledComponents = true;
+    if (typeof sc === "object" && sc.ssr === false) {
+      napiOptions.styledComponentsSsr = false;
+    }
   }
   if (options.compiler?.emotion !== undefined && options.compiler.emotion !== false) {
     napiOptions.emotion = true;
@@ -1401,9 +1401,12 @@ export function buildAppSync(options: AppBuildOptions = {}): BuildResult {
       : publicDir !== undefined
         ? { publicDir }
         : {}),
-    // compiler.* → flat NAPI fields. enabled boolean 만 우선 (옵션 객체는 후속 PR).
+    // compiler.* → flat NAPI fields. boolean / 객체 form 양쪽 인식.
     ...(compiler?.styledComponents !== undefined && compiler.styledComponents !== false
       ? { styledComponents: true }
+      : {}),
+    ...(typeof compiler?.styledComponents === "object" && compiler.styledComponents.ssr === false
+      ? { styledComponentsSsr: false }
       : {}),
     ...(compiler?.emotion !== undefined && compiler.emotion !== false ? { emotion: true } : {}),
   });

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -563,6 +563,7 @@ fn napiBuildAppSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.
         .sourcemap = getObjectBool(env, opts_obj, "sourcemap", false),
         .splitting = getObjectBool(env, opts_obj, "splitting", true),
         .styled_components = getObjectBool(env, opts_obj, "styledComponents", false),
+        .styled_components_ssr = getObjectBool(env, opts_obj, "styledComponentsSsr", true),
     }) catch |err| {
         return throwError(env, @errorName(err));
     };
@@ -3566,6 +3567,7 @@ fn parseBuildOptions(
         .root_dir = root_dir,
         .react_refresh = getObjectBool(env, opts_obj, "reactRefresh", false),
         .styled_components = getObjectBool(env, opts_obj, "styledComponents", false),
+        .styled_components_ssr = getObjectBool(env, opts_obj, "styledComponentsSsr", true),
         .collect_module_codes = getObjectBool(env, opts_obj, "collectModuleCodes", false),
         // RN 프리셋(bundler.zig의 RN_BOOL_PRESET 단일 소스): platform=react-native이면
         // 사용자가 명시하지 않아도 CLI와 동일하게 auto-enable. worklet_transform 없이는

--- a/src/app/build.zig
+++ b/src/app/build.zig
@@ -22,6 +22,8 @@ pub const AppBuildOptions = struct {
     splitting: bool = true,
     /// styled-components 1st-party transform 활성화 (compiler.styledComponents).
     styled_components: bool = false,
+    /// styled-components.ssr 옵션 — false 면 componentId 생략.
+    styled_components_ssr: bool = true,
 };
 
 pub const AppDevPrepareOptions = struct {
@@ -114,6 +116,7 @@ pub fn buildApp(allocator: std.mem.Allocator, opts: AppBuildOptions) !usize {
         .output_filename = "bundle.js",
         .root_dir = root,
         .styled_components = opts.styled_components,
+        .styled_components_ssr = opts.styled_components_ssr,
     });
     defer bundler.deinit();
 

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -124,8 +124,10 @@ pub const BundleOptions = struct {
     /// React Fast Refresh 활성화. $RefreshReg$/$RefreshSig$ 주입.
     react_refresh: bool = false,
     /// styled-components 1st-party transform (compiler.styledComponents).
-    /// 현재 PR 은 displayName 만 — componentId / SSR / minify 는 후속.
     styled_components: bool = false,
+    /// styled-components.ssr 옵션 — false 면 componentId 생략 (displayName 만).
+    /// `@next/swc` 의 compiler.styledComponents.ssr 와 동일.
+    styled_components_ssr: bool = true,
     /// dev mode에서 per-module codes 수집 (HMR rebuild용). 초기 빌드에서는 false로 메모리 절감.
     collect_module_codes: bool = false,
     /// define 글로벌 치환 (--define:KEY=VALUE)
@@ -629,6 +631,7 @@ pub const Bundler = struct {
         worker_graph.worklet_transform = self.options.worklet_transform;
         worker_graph.react_refresh = self.options.react_refresh;
         worker_graph.styled_components = self.options.styled_components;
+        worker_graph.styled_components_ssr = self.options.styled_components_ssr;
         worker_graph.code_splitting = self.options.code_splitting;
         worker_graph.minify_identifiers = self.options.minify_identifiers;
         worker_graph.transform_options_base = self.buildTransformOptionsBase();
@@ -788,6 +791,7 @@ pub const Bundler = struct {
         graph.worklet_transform = self.options.worklet_transform;
         graph.react_refresh = self.options.react_refresh;
         graph.styled_components = self.options.styled_components;
+        graph.styled_components_ssr = self.options.styled_components_ssr;
         graph.code_splitting = self.options.code_splitting;
         graph.minify_identifiers = self.options.minify_identifiers;
         graph.transform_options_base = self.buildTransformOptionsBase();

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -140,6 +140,8 @@ pub const ModuleGraph = struct {
     /// styled-components 1st-party transform — user_code 에 displayName 주입.
     /// react_refresh 와 동일하게 node_modules 는 건드리지 않음 (선언자 이름 수집 무의미).
     styled_components: bool = false,
+    /// styled-components.ssr 옵션 — false 면 componentId 생략 (displayName 만).
+    styled_components_ssr: bool = true,
     /// code splitting 활성화. helper module virtual import (#1961) 는 splitting 모드에서만
     /// 활성 — single-bundle 모드는 helper module 의 declaration 이 statement-level shake
     /// 로 elide 되는 회귀가 있어 기존 preamble 모델 유지.
@@ -1717,6 +1719,7 @@ pub const ModuleGraph = struct {
         var opts = self.transform_options_base;
         opts.react_refresh = self.react_refresh and is_user_code;
         opts.styled_components = self.styled_components and is_user_code;
+        opts.styled_components_ssr = self.styled_components_ssr;
         opts.plugins = merged_plugins;
         opts.jsx_transform = ast_ptr.has_jsx;
         opts.jsx_filename = module.path;

--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -595,6 +595,35 @@ test "styled-components: computed property key 는 미인식" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") == null);
 }
 
+test "styled-components: ssr=false 시 componentId 생략, displayName 만" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Btn = styled.div`color: red;`;
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx", .styled_components_ssr = false },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "displayName: \"Btn\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "componentId") == null);
+}
+
+test "styled-components: ssr=true (default) 시 componentId emit" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Btn = styled.div`color: red;`;
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" }, // ssr defaults to true
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "componentId: \"sc-") != null);
+}
+
 test "styled-components: jsx_filename 빈 문자열 시 componentId 생략 (displayName 만)" {
     // SSR 안전성: filename 없으면 cross-file ID 충돌 위험 → componentId 생략 (graceful degradation).
     var r = try e2eFull(

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -111,6 +111,10 @@ pub const TransformOptions = struct {
     /// 활성 시 `const X = styled.div\`...\`` 같은 선언에 displayName 자동 부여.
     /// componentId / SSR / CSS minify 등 추가 변환은 후속 PR.
     styled_components: bool = false,
+    /// styled-components.ssr 옵션 — false 면 componentId 생략 (displayName 만).
+    /// 비-SSR 프로젝트에서 file-hash + counter 기반 deterministic ID 비용 회피.
+    /// `@next/swc` 의 `compiler.styledComponents.ssr` 와 동일 surface.
+    styled_components_ssr: bool = true,
     /// useDefineForClassFields=false: instance field를 constructor의 this.x = value 할당으로 변환.
     /// true(기본값)이면 class field를 그대로 유지 (TC39 [[Define]] semantics).
     /// false이면 TS 4.x 이전 동작 — field를 constructor body로 이동 ([[Set]] semantics).

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -417,8 +417,11 @@ fn buildWithConfigCall(self: *Transformer, tag_idx: NodeIndex, var_name: []const
 
     const with_config_span = state.with_config_span.?;
     const display_name_key_span = state.display_name_span.?;
-    const has_filename = self.options.jsx_filename.len > 0;
-    if (has_filename) {
+    // componentId 는 두 조건 모두 만족 시 emit:
+    //  1. ssr 옵션 활성 (default true) — 사용자가 명시적으로 끄지 않음
+    //  2. jsx_filename 존재 — file 부분 hash 의 입력
+    const emit_component_id = self.options.styled_components_ssr and self.options.jsx_filename.len > 0;
+    if (emit_component_id) {
         if (state.component_id_span == null) state.component_id_span = try self.ast.addString("componentId");
         if (state.file_hash_hex == null) state.file_hash_hex = wyhash.hashHex8(self.options.jsx_filename);
     }
@@ -441,7 +444,7 @@ fn buildWithConfigCall(self: *Transformer, tag_idx: NodeIndex, var_name: []const
 
     const display_property = try buildKeyStringProperty(self, display_name_key_span, display_value_span);
 
-    const obj_list = if (has_filename) blk: {
+    const obj_list = if (emit_component_id) blk: {
         var component_id_buf: [64]u8 = undefined;
         const component_index = state.component_counter;
         state.component_counter += 1;


### PR DESCRIPTION
## Summary

`compiler.styledComponents: { ssr: false }` 옵션 도입 — 비-SSR 프로젝트에서 componentId 비용 회피. `@next/swc` 의 `compiler.styledComponents.ssr` 와 동일 surface.

\`\`\`tsx
// zts.config.ts — SSR 사용 (default 동작 유지)
defineConfig({ compiler: { styledComponents: true } });
// → const X = styled.div.withConfig({ displayName: \"X\", componentId: \"sc-...\" })\`\`;

// SSR 미사용 — componentId 생략
defineConfig({ compiler: { styledComponents: { ssr: false } } });
// → const X = styled.div.withConfig({ displayName: \"X\" })\`\`;
\`\`\`

## Why

componentId 는 SSR hydration 시 server↔client 가 같은 클래스명을 생성하기 위한 결정론적 ID. SSR 안 쓰는 프로젝트 (CSR-only / RN / static export) 는:
- file hash 계산 (wyhash) 비용
- counter 관리 / object property 추가 노드 비용
- bundle 내 ID 문자열 차지하는 byte
- partial-deploy 시 reorder 영향 분석 부담

모두 불필요. `@next/swc` 도 같은 이유로 `ssr` 옵션 제공.

## 변경 내용 (multi-layer plumbing)

각 layer 는 1-3 라인 수준의 동일 패턴 추가:

| 레이어 | 추가 |
|---|---|
| `TransformOptions` | `styled_components_ssr: bool = true` |
| `BundleOptions` | 동일 |
| `Graph` | 동일 + `parseModule` mirror |
| `bundler.zig` | worker_graph + 메인 graph mirror 2 사이트 |
| `AppBuildOptions` | 동일 + `Bundler.init` 전파 |
| `napi_entry.zig` | 2 entry points 모두 `styledComponentsSsr` (default true) |
| `prepareNapiOptions` (TS) | `compiler.styledComponents.ssr === false` → flat NAPI |
| `buildAppSync` (TS) | 동일 추출 |
| `buildWithConfigCall` | `emit_component_id = ssr AND jsx_filename.len > 0` 단일 가드 |

## 핵심 동작

`buildWithConfigCall` 의 `emit_component_id` 는 두 조건 AND 로 단순화:
1. `ssr` 옵션 활성 (default true)
2. `jsx_filename` 존재 (file hash 입력)

둘 중 하나라도 false 면 componentId 생략. span allocation / counter 증가 모두 skip — ssr=false 일 때 해당 비용 0.

## /simplify 결과

1-agent 통합 리뷰: clean.
- Plumbing 패턴이 `react_refresh` / `styled_components` 와 정확히 일치
- `emit_component_id` 단일 source 로 dead allocation 회피 (이전 `has_filename` 두 번 읽던 것 통합)
- JS 레이어 boolean / 객체 form 양쪽 정확
- ssr=false 시 counter 도 안 증가 — 미래 mixed-mode 대비 정합성

## 검증

- ✅ `zig build test`: 4159/4159 pass (2 신규)
- ✅ TypeScript type check 통과

## 후속 PR

- [ ] IIFE block body (`{ return ... }`)
- [ ] MERGE 정책 옵션화 — 사용자 `.withConfig` 와 자동 displayName merge
- [ ] `compiler.styledComponents` 의 추가 객체 옵션 (`displayName` / `fileName` / `minify` / `pure` / `namespace`)
- [ ] `transpileTemplateLiterals` / CSS minify

🤖 Generated with [Claude Code](https://claude.com/claude-code)