### PR TITLE
feat(transformer): styled-components IIFE block body 인식

### DIFF
--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -262,8 +262,7 @@ test "styled-components: 다중 paren `((() => ...))()` 도 처리" {
     try expectDisplayName(r.output, "Deep");
 }
 
-test "styled-components: IIFE block body `(() => { return ... })()` 미지원" {
-    // 첫 iteration 은 expression body 만 — return statement walker 는 후속.
+test "styled-components: IIFE block body `(() => { return ... })()` 인식" {
     var r = try e2eFull(
         std.testing.allocator,
         \\import styled from "styled-components";
@@ -274,6 +273,39 @@ test "styled-components: IIFE block body `(() => { return ... })()` 미지원" {
         ".tsx",
     );
     defer r.deinit();
+    try expectDisplayName(r.output, "Lazy");
+}
+
+test "styled-components: IIFE block body 다중 statement + return" {
+    // pre-statement 가 있어도 return 의 operand 만 wrap.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Lazy = (() => { console.log("setup"); return styled.div`color: red;`; })();
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "Lazy");
+    // pre-statement 보존
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "console.log") != null);
+}
+
+test "styled-components: IIFE block body 의 중첩 return 은 미인식 (top-level only)" {
+    // top-level statement 의 return 만 walk — `if (...) return X` 형태는 후속 PR.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Lazy = (() => { if (cond) return styled.div`color: red;`; return null; })();
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // 첫 return 은 if 안 — top-level 이 아니라 wrap 안 됨.
     try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") == null);
 }
 

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -216,7 +216,7 @@ fn isUnaryWrapperTag(tag: ast_mod.Node.Tag) bool {
 ///   - `cond && styled.div\`\`` / `default || styled.div\`\`` / `?? styled.div\`\`` (논리 — 우변만)
 ///   - `styled.div\`\` as T` / `... satisfies T` / `...!` / legacy `<T>...` / Foo<T> 인스턴스화 (TS)
 ///   - `styled.div\`\` as Foo` (Flow)
-///   - `(() => styled.div\`\`)()` IIFE — 단일 expression body 만 (block body `{ return ... }` 미지원)
+///   - `(() => styled.div\`\`)()` IIFE — expression body + block body `{ return X }` 둘 다
 ///   - 위 조합
 ///
 /// 미인식 (의도된 한계):
@@ -279,7 +279,7 @@ pub fn wrapStyledTagInExpr(self: *Transformer, expr_idx: NodeIndex, var_name: []
 
 /// IIFE `(() => <body>)()` / `(() => <body>)(...args)` — body 에 styled tagged template 이
 /// 있으면 body 를 wrap 한 새 call_expression 빌드.
-/// 첫 iteration: arrow expression body 만 인식 (block body `{ return X }` 는 후속).
+/// expression body + block body (`{ ...; return X }`) 둘 다 인식.
 /// callee 가 arrow function 이 아니면 (일반 함수 호출) early-return — hot path 보호.
 fn wrapStyledInIife(self: *Transformer, call_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
     const call_node = self.ast.getNode(call_idx);
@@ -303,11 +303,12 @@ fn wrapStyledInIife(self: *Transformer, call_idx: NodeIndex, var_name: []const u
     const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[arrow_node.data.extra + 1]);
     if (body_idx.isNone()) return call_idx;
 
-    // block body (`() => { return ... }`) 는 후속 PR — return statement walking 필요.
+    // expression body 또는 block body 분기.
     const body_node = self.ast.getNode(body_idx);
-    if (body_node.tag == .block_statement) return call_idx;
-
-    const new_body = try wrapStyledTagInExpr(self, body_idx, var_name);
+    const new_body = if (body_node.tag == .block_statement)
+        try wrapStyledInBlockReturns(self, body_idx, var_name)
+    else
+        try wrapStyledTagInExpr(self, body_idx, var_name);
     if (new_body == body_idx) return call_idx;
 
     // Rebuild arrow with new body (params / flags 그대로).
@@ -349,6 +350,53 @@ fn wrapStyledInIife(self: *Transformer, call_idx: NodeIndex, var_name: []const u
         args_start,
         args_len,
         call_flags,
+    });
+}
+
+/// arrow block body `{ ...; return X }` — return statement 의 operand 만 walk. 변경 없으면
+/// 원본 block_idx 반환 (identity 보존).
+///
+/// **Top-level only**: `if (...) return X` / `try { return X } catch {}` / `switch (...) { case
+/// ...: return X }` 같이 중첩 statement 안의 return 은 미인식. ZTS 의 단방향 visitor
+/// 모델에서 control-flow 노드를 일반화 walk 하는 건 후속 epic.
+fn wrapStyledInBlockReturns(self: *Transformer, block_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
+    const block_node = self.ast.getNode(block_idx);
+    const list = block_node.data.list;
+    const stmts = self.ast.extra_data.items[list.start .. list.start + list.len];
+
+    const scratch_top = self.scratch.items.len;
+    defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+    var changed = false;
+    for (stmts) |raw| {
+        const stmt_idx: NodeIndex = @enumFromInt(raw);
+        const stmt_node = self.ast.getNode(stmt_idx);
+        if (stmt_node.tag == .return_statement) {
+            const old_operand = stmt_node.data.unary.operand;
+            if (!old_operand.isNone() and shouldAttemptWrap(self, old_operand)) {
+                const new_operand = try wrapStyledTagInExpr(self, old_operand, var_name);
+                if (new_operand != old_operand) {
+                    changed = true;
+                    const new_return = try self.ast.addNode(.{
+                        .tag = .return_statement,
+                        .span = stmt_node.span,
+                        .data = .{ .unary = .{ .operand = new_operand, .flags = stmt_node.data.unary.flags } },
+                    });
+                    try self.scratch.append(self.allocator, new_return);
+                    continue;
+                }
+            }
+        }
+        try self.scratch.append(self.allocator, stmt_idx);
+    }
+
+    if (!changed) return block_idx;
+
+    const new_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+    return self.ast.addNode(.{
+        .tag = .block_statement,
+        .span = block_node.span,
+        .data = .{ .list = new_list },
     });
 }
 


### PR DESCRIPTION
## Summary

`(() => { return styled.div\`\` })()` 형태의 arrow block body IIFE 도 wrap. 직전 PR (#2239) 에서 expression body 만 처리하던 한계 보완 — top-level return 의 operand 까지 walk.

\`\`\`tsx
// 입력
import styled from \"styled-components\";
const Lazy = (() => {
  setupSomething();
  return styled.div\`color: red;\`;
})();

// 출력
const Lazy = (() => {
  setupSomething();
  return styled.div.withConfig({ displayName: \"Lazy\", componentId: \"sc-...\" })\`color: red;\`;
})();
\`\`\`

## 변경 내용

- `wrapStyledInBlockReturns` helper:
  - `block_statement` 의 statements 순회
  - `return_statement` 발견 시 operand 가 wrappable 이면 wrap (`shouldAttemptWrap` pre-filter 로 false-positive 회피)
  - `self.scratch` 사용 — `refresh.zig` 패턴, identity 보존 (no-op 시 원본 idx 반환)
- `wrapStyledInIife` 가 body.tag 로 분기:
  - `block_statement` → `wrapStyledInBlockReturns`
  - 그 외 (expression body) → `wrapStyledTagInExpr` 직접

## 인식 매트릭스

| 케이스 | 상태 |
|---|---|
| `(() => styled.div\`\`)()` (expression body) | ✅ (PR #2239) |
| `(() => { return styled.div\`\` })()` (block body, top-level return) | ✅ **(이번 PR)** |
| `(() => { setup(); return styled.div\`\` })()` (다중 statement) | ✅ **(이번 PR)** |
| `(() => { if (cond) return styled.div\`\`; })()` (중첩 if) | ❌ → 후속 |
| `(() => { try { return styled.div\`\` } catch {} })()` (try/catch) | ❌ → 후속 |
| `(() => { switch (x) { case 1: return styled.div\`\`; } })()` (switch) | ❌ → 후속 |

## /simplify 결과

1-agent 통합 리뷰: clean.
- `self.scratch` 패턴 idiomatic (refresh.zig 일치)
- `shrinkRetainingCapacity(scratch_top)` 의 `defer` 가 error path 에서도 정리 보장
- `if (!changed) return block_idx` 으로 identity 보존, 상위 `wrapStyledInIife` 가 short-circuit
- `shouldAttemptWrap` pre-filter 가 `return null` / `return foo()` 같은 non-wrappable 빠르게 reject

리뷰 권고대로 try/switch/if 중첩 미인식 한계를 doc-comment 에 명시.

## 검증

- ✅ `zig build test`: 4160/4160 pass (3 신규)
  - block body wrap / 다중 statement (pre-statement 보존) / 중첩 return reject

## 후속 PR

- [ ] 중첩 control flow return walker (try / if / switch)
- [ ] MERGE 정책 옵션화 (사용자 `.withConfig` 와 displayName merge)
- [ ] `transpileTemplateLiterals` / CSS minify

🤖 Generated with [Claude Code](https://claude.com/claude-code)