### PR TITLE
feat(transformer): styled-components 중첩 control flow return walker

### DIFF
--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -293,8 +293,7 @@ test "styled-components: IIFE block body 다중 statement + return" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "console.log") != null);
 }
 
-test "styled-components: IIFE block body 의 중첩 return 은 미인식 (top-level only)" {
-    // top-level statement 의 return 만 walk — `if (...) return X` 형태는 후속 PR.
+test "styled-components: IIFE block 안 if-statement 의 return 도 wrap" {
     var r = try e2eFull(
         std.testing.allocator,
         \\import styled from "styled-components";
@@ -305,7 +304,65 @@ test "styled-components: IIFE block body 의 중첩 return 은 미인식 (top-le
         ".tsx",
     );
     defer r.deinit();
-    // 첫 return 은 if 안 — top-level 이 아니라 wrap 안 됨.
+    try expectDisplayName(r.output, "Lazy");
+}
+
+test "styled-components: if-else 양쪽 branch 의 return 모두 wrap" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Pick = (() => {
+        \\  if (cond) return styled.div`color: red;`;
+        \\  else return styled.span`color: blue;`;
+        \\})();
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "Pick");
+    // 두 번 wrap 되었어야 — withConfig 가 2번 등장.
+    var count: usize = 0;
+    var i: usize = 0;
+    while (std.mem.indexOfPos(u8, r.output, i, "withConfig(")) |pos| : (i = pos + 1) {
+        count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 2), count);
+}
+
+test "styled-components: 중첩 if 안 block 안의 return 도 wrap" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Deep = (() => {
+        \\  if (cond) {
+        \\    setup();
+        \\    return styled.div`color: red;`;
+        \\  }
+        \\  return null;
+        \\})();
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "Deep");
+}
+
+test "styled-components: try/switch 중첩은 아직 미인식 (회귀 가드)" {
+    // try / switch 안의 return 은 후속 PR — 현재는 wrap 안 됨.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Tried = (() => { try { return styled.div`color: red;`; } catch {} })();
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
     try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") == null);
 }
 

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -352,12 +352,49 @@ fn wrapStyledInIife(self: *Transformer, call_idx: NodeIndex, var_name: []const u
     });
 }
 
-/// arrow block body `{ ...; return X }` — return statement 의 operand 만 walk. 변경 없으면
-/// 원본 block_idx 반환 (identity 보존).
-///
-/// **Top-level only**: `if (...) return X` / `try { return X } catch {}` / `switch (...) { case
-/// ...: return X }` 같이 중첩 statement 안의 return 은 미인식. ZTS 의 단방향 visitor
-/// 모델에서 control-flow 노드를 일반화 walk 하는 건 후속 epic.
+/// arrow body 내 return 들을 재귀 walk — return 의 operand 가 styled tagged template 이면 wrap.
+/// 인식 case:
+///   - `return X;` (직접)
+///   - `{ ...; return X; }` (block 안)
+///   - `if (cond) return X;` / `if (cond) return X; else return Y;` (if/else)
+///   - `if (cond) { ... return X; }` (if + block)
+/// 미인식 (후속 PR):
+///   - `try { return X } catch {}` / `switch (cond) { case 1: return X; }`
+fn wrapStyledInStmt(self: *Transformer, stmt_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
+    if (stmt_idx.isNone()) return stmt_idx;
+    const node = self.ast.getNode(stmt_idx);
+    switch (node.tag) {
+        .return_statement => {
+            const old_operand = node.data.unary.operand;
+            if (old_operand.isNone() or !shouldAttemptWrap(self, old_operand)) return stmt_idx;
+            const new_operand = try wrapStyledTagInExpr(self, old_operand, var_name);
+            if (new_operand == old_operand) return stmt_idx;
+            return self.ast.addNode(.{
+                .tag = .return_statement,
+                .span = node.span,
+                .data = .{ .unary = .{ .operand = new_operand, .flags = node.data.unary.flags } },
+            });
+        },
+        .block_statement => return wrapStyledInBlockReturns(self, stmt_idx, var_name),
+        .if_statement => {
+            // ternary: a=test, b=consequent, c=alternate. consequent / alternate 둘 다 walk
+            // (자식 stmt 일 수도, block 일 수도, 또는 다시 if 일 수도).
+            const old_b = node.data.ternary.b;
+            const old_c = node.data.ternary.c;
+            const new_b = try wrapStyledInStmt(self, old_b, var_name);
+            const new_c = try wrapStyledInStmt(self, old_c, var_name);
+            if (new_b == old_b and new_c == old_c) return stmt_idx;
+            return self.ast.addNode(.{
+                .tag = .if_statement,
+                .span = node.span,
+                .data = .{ .ternary = .{ .a = node.data.ternary.a, .b = new_b, .c = new_c } },
+            });
+        },
+        else => return stmt_idx,
+    }
+}
+
+/// block_statement 의 statements 순회 — 각 stmt 를 wrapStyledInStmt 로 재귀 walk.
 fn wrapStyledInBlockReturns(self: *Transformer, block_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
     const block_node = self.ast.getNode(block_idx);
     const list = block_node.data.list;
@@ -369,24 +406,9 @@ fn wrapStyledInBlockReturns(self: *Transformer, block_idx: NodeIndex, var_name: 
     var changed = false;
     for (stmts) |raw| {
         const stmt_idx: NodeIndex = @enumFromInt(raw);
-        const stmt_node = self.ast.getNode(stmt_idx);
-        if (stmt_node.tag == .return_statement) {
-            const old_operand = stmt_node.data.unary.operand;
-            if (!old_operand.isNone() and shouldAttemptWrap(self, old_operand)) {
-                const new_operand = try wrapStyledTagInExpr(self, old_operand, var_name);
-                if (new_operand != old_operand) {
-                    changed = true;
-                    const new_return = try self.ast.addNode(.{
-                        .tag = .return_statement,
-                        .span = stmt_node.span,
-                        .data = .{ .unary = .{ .operand = new_operand, .flags = stmt_node.data.unary.flags } },
-                    });
-                    try self.scratch.append(self.allocator, new_return);
-                    continue;
-                }
-            }
-        }
-        try self.scratch.append(self.allocator, stmt_idx);
+        const new_stmt = try wrapStyledInStmt(self, stmt_idx, var_name);
+        if (new_stmt != stmt_idx) changed = true;
+        try self.scratch.append(self.allocator, new_stmt);
     }
 
     if (!changed) return block_idx;


### PR DESCRIPTION
## Summary

IIFE block body 의 return statement 가 `if` / `else` / 중첩 block 안에 있어도 walk. 이전 PR (#2241) 이 top-level return 만 처리하던 한계 보완.

\`\`\`tsx
// 입력
const Pick = (() => {
  if (cond) return styled.div\`color: red;\`;
  else return styled.span\`color: blue;\`;
})();

// 출력 — 양쪽 branch 의 return 모두 wrap
const Pick = (() => {
  if (cond) return styled.div.withConfig({ displayName: \"Pick\", componentId: \"...\" })\`...\`;
  else return styled.span.withConfig({ displayName: \"Pick\", componentId: \"...\" })\`...\`;
})();
\`\`\`

## 변경 내용

### `wrapStyledInStmt` — 재귀 dispatch
- `return_statement` → operand 가 wrappable 이면 wrap
- `block_statement` → `wrapStyledInBlockReturns` 위임 (각 stmt 를 다시 `wrapStyledInStmt` 호출)
- `if_statement` → ternary 의 b/c (consequent/alternate) 양쪽 재귀
- 그 외 → identity (`stmt_idx` 그대로)

`es2015_block_scoping.transformStmtFlow` 와 동일한 패턴 — recursive ternary descent + identity preservation.

## 인식 매트릭스 누적

| 케이스 | 상태 |
|---|---|
| `() => styled.div\`\`` (expression body) | ✅ |
| `() => { return styled.div\`\` }` (top-level return) | ✅ (PR #2241) |
| `() => { if (cond) return styled.div\`\` }` (if 안) | ✅ **(이번 PR)** |
| `() => { if (a) return X; else return Y; }` (if-else 양쪽) | ✅ **(이번 PR)** |
| `() => { if (cond) { ...; return X; } }` (중첩 block) | ✅ **(이번 PR)** |
| `() => { try { return X } catch {} }` | ❌ → 후속 |
| `() => { switch (x) { case 1: return X; } }` | ❌ → 후속 |

## /simplify 결과

1-agent 통합 리뷰: clean.
- `es2015_block_scoping.transformStmtFlow:578` 의 동일 dispatch 패턴 — naming/identity 검증 일치
- identity 보존 정확 (`block_idx` 반환 + `stmt_idx` early return)
- empty `if (cond) ;` (consequent) 와 alternate `.none` 모두 안전
- branch 이름 stale (`sc-css-minify`) → `sc-nested-cf-walker` 로 정정

## 검증

- ✅ `zig build test`: 4167/4167 pass (4 신규)

## 후속 PR

- [ ] try / catch / finally / switch return walker
- [ ] `transpileTemplateLiterals` / CSS minify

🤖 Generated with [Claude Code](https://claude.com/claude-code)