### PR TITLE
feat(transformer): styled-components compiler.styledComponents.minify 옵션 (no-interp)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1243,8 +1243,9 @@ function prepareNapiOptions(options: BuildOptions): Record<string, unknown> {
   const sc = options.compiler?.styledComponents;
   if (sc !== undefined && sc !== false) {
     napiOptions.styledComponents = true;
-    if (typeof sc === "object" && sc.ssr === false) {
-      napiOptions.styledComponentsSsr = false;
+    if (typeof sc === "object") {
+      if (sc.ssr === false) napiOptions.styledComponentsSsr = false;
+      if (sc.minify === true) napiOptions.styledComponentsMinify = true;
     }
   }
   if (options.compiler?.emotion !== undefined && options.compiler.emotion !== false) {
@@ -1407,6 +1408,9 @@ export function buildAppSync(options: AppBuildOptions = {}): BuildResult {
       : {}),
     ...(typeof compiler?.styledComponents === "object" && compiler.styledComponents.ssr === false
       ? { styledComponentsSsr: false }
+      : {}),
+    ...(typeof compiler?.styledComponents === "object" && compiler.styledComponents.minify === true
+      ? { styledComponentsMinify: true }
       : {}),
     ...(compiler?.emotion !== undefined && compiler.emotion !== false ? { emotion: true } : {}),
   });

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -564,6 +564,7 @@ fn napiBuildAppSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.
         .splitting = getObjectBool(env, opts_obj, "splitting", true),
         .styled_components = getObjectBool(env, opts_obj, "styledComponents", false),
         .styled_components_ssr = getObjectBool(env, opts_obj, "styledComponentsSsr", true),
+        .styled_components_minify = getObjectBool(env, opts_obj, "styledComponentsMinify", false),
     }) catch |err| {
         return throwError(env, @errorName(err));
     };
@@ -3568,6 +3569,7 @@ fn parseBuildOptions(
         .react_refresh = getObjectBool(env, opts_obj, "reactRefresh", false),
         .styled_components = getObjectBool(env, opts_obj, "styledComponents", false),
         .styled_components_ssr = getObjectBool(env, opts_obj, "styledComponentsSsr", true),
+        .styled_components_minify = getObjectBool(env, opts_obj, "styledComponentsMinify", false),
         .collect_module_codes = getObjectBool(env, opts_obj, "collectModuleCodes", false),
         // RN 프리셋(bundler.zig의 RN_BOOL_PRESET 단일 소스): platform=react-native이면
         // 사용자가 명시하지 않아도 CLI와 동일하게 auto-enable. worklet_transform 없이는

--- a/src/app/build.zig
+++ b/src/app/build.zig
@@ -24,6 +24,8 @@ pub const AppBuildOptions = struct {
     styled_components: bool = false,
     /// styled-components.ssr 옵션 — false 면 componentId 생략.
     styled_components_ssr: bool = true,
+    /// styled-components.minify 옵션 — CSS template whitespace collapse.
+    styled_components_minify: bool = false,
 };
 
 pub const AppDevPrepareOptions = struct {
@@ -117,6 +119,7 @@ pub fn buildApp(allocator: std.mem.Allocator, opts: AppBuildOptions) !usize {
         .root_dir = root,
         .styled_components = opts.styled_components,
         .styled_components_ssr = opts.styled_components_ssr,
+        .styled_components_minify = opts.styled_components_minify,
     });
     defer bundler.deinit();
 

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -128,6 +128,8 @@ pub const BundleOptions = struct {
     /// styled-components.ssr 옵션 — false 면 componentId 생략 (displayName 만).
     /// `@next/swc` 의 compiler.styledComponents.ssr 와 동일.
     styled_components_ssr: bool = true,
+    /// styled-components.minify 옵션 — CSS template whitespace collapse.
+    styled_components_minify: bool = false,
     /// dev mode에서 per-module codes 수집 (HMR rebuild용). 초기 빌드에서는 false로 메모리 절감.
     collect_module_codes: bool = false,
     /// define 글로벌 치환 (--define:KEY=VALUE)
@@ -632,6 +634,7 @@ pub const Bundler = struct {
         worker_graph.react_refresh = self.options.react_refresh;
         worker_graph.styled_components = self.options.styled_components;
         worker_graph.styled_components_ssr = self.options.styled_components_ssr;
+        worker_graph.styled_components_minify = self.options.styled_components_minify;
         worker_graph.code_splitting = self.options.code_splitting;
         worker_graph.minify_identifiers = self.options.minify_identifiers;
         worker_graph.transform_options_base = self.buildTransformOptionsBase();
@@ -792,6 +795,7 @@ pub const Bundler = struct {
         graph.react_refresh = self.options.react_refresh;
         graph.styled_components = self.options.styled_components;
         graph.styled_components_ssr = self.options.styled_components_ssr;
+        graph.styled_components_minify = self.options.styled_components_minify;
         graph.code_splitting = self.options.code_splitting;
         graph.minify_identifiers = self.options.minify_identifiers;
         graph.transform_options_base = self.buildTransformOptionsBase();

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -142,6 +142,8 @@ pub const ModuleGraph = struct {
     styled_components: bool = false,
     /// styled-components.ssr 옵션 — false 면 componentId 생략 (displayName 만).
     styled_components_ssr: bool = true,
+    /// styled-components.minify 옵션 — CSS template whitespace collapse.
+    styled_components_minify: bool = false,
     /// code splitting 활성화. helper module virtual import (#1961) 는 splitting 모드에서만
     /// 활성 — single-bundle 모드는 helper module 의 declaration 이 statement-level shake
     /// 로 elide 되는 회귀가 있어 기존 preamble 모델 유지.
@@ -1720,6 +1722,7 @@ pub const ModuleGraph = struct {
         opts.react_refresh = self.react_refresh and is_user_code;
         opts.styled_components = self.styled_components and is_user_code;
         opts.styled_components_ssr = self.styled_components_ssr;
+        opts.styled_components_minify = self.styled_components_minify;
         opts.plugins = merged_plugins;
         opts.jsx_transform = ast_ptr.has_jsx;
         opts.jsx_filename = module.path;

--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -860,6 +860,64 @@ test "styled-components: computed property key 는 미인식" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") == null);
 }
 
+test "styled-components: minify=true 시 CSS whitespace collapse" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Card = styled.div`
+        \\  color: red;
+        \\  padding: 8px;
+        \\`;
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx", .styled_components_minify = true },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "Card");
+    // newlines / 다중 스페이스가 single space 로 collapse — `\n  color` 같은 패턴 사라짐.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\n  color") == null);
+    // 단일 space 로 분리된 ` color: red; padding: 8px;` 형태로 합쳐짐 (basic minify).
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "color: red; padding: 8px;") != null);
+}
+
+test "styled-components: minify=false (default) 면 CSS 보존" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Card = styled.div`
+        \\  color: red;
+        \\`;
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" }, // minify defaults false
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "Card");
+    // 원본 newline 보존 — minify 안 함.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\n  color") != null);
+}
+
+test "styled-components: minify — interpolation 있는 template 은 보존 (후속 PR)" {
+    // 보간 있는 template_literal (data.list.len > 0) 는 첫 iteration 에서 skip.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Btn = styled.div`
+        \\  color: ${color};
+        \\`;
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx", .styled_components_minify = true },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectDisplayName(r.output, "Btn");
+    // interpolation 있으면 minify skip — newline 보존.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\n  color") != null);
+}
+
 test "styled-components: ssr=false 시 componentId 생략, displayName 만" {
     var r = try e2eFull(
         std.testing.allocator,

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -115,6 +115,10 @@ pub const TransformOptions = struct {
     /// 비-SSR 프로젝트에서 file-hash + counter 기반 deterministic ID 비용 회피.
     /// `@next/swc` 의 `compiler.styledComponents.ssr` 와 동일 surface.
     styled_components_ssr: bool = true,
+    /// styled-components.minify 옵션 — true 면 CSS template 의 whitespace collapse.
+    /// no-interp 템플릿 (`\`color: red;\``) 만 우선 처리. interp 있는 경우는 후속.
+    /// `babel-plugin-styled-components.minify` 와 동일 의도, default 는 false (안전).
+    styled_components_minify: bool = false,
     /// useDefineForClassFields=false: instance field를 constructor의 this.x = value 할당으로 변환.
     /// true(기본값)이면 class field를 그대로 유지 (TC39 [[Define]] semantics).
     /// false이면 TS 4.x 이전 동작 — field를 constructor body로 이동 ([[Set]] semantics).

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -644,6 +644,71 @@ fn scanObjectKeys(self: *Transformer, obj_idx: NodeIndex) ObjectKeyScan {
     return result;
 }
 
+/// no-interpolation template_literal (`\`color: red;\``) 의 CSS whitespace 를 minify.
+/// codegen.zig:2270 의 convention 따라 `data.none == 0` 으로 no-interp 판정.
+/// 보간 있는 template (`data.list.len > 0`) 은 후속 PR. 변경 없으면 identity (template_idx).
+fn minifyCssTemplate(self: *Transformer, template_idx: NodeIndex) Error!NodeIndex {
+    if (template_idx.isNone()) return template_idx;
+    const node = self.ast.getNode(template_idx);
+    if (node.tag != .template_literal) return template_idx;
+    if (node.data.none != 0) return template_idx; // 보간 있음 — codegen.zig:2270 convention.
+
+    const raw = self.ast.getText(node.span);
+    if (raw.len < 2 or raw[0] != '`' or raw[raw.len - 1] != '`') return template_idx;
+    const inner = raw[1 .. raw.len - 1];
+
+    // Fast-path: 이미 minimal (collapse 할 ws run / leading-trailing ws 없음) 이면 alloc 회피.
+    if (!needsCssMinify(inner)) return template_idx;
+
+    // 단일 버퍼 — `\`` + collapsed + `\`` 한 번에 빌드.
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(self.allocator);
+    try buf.append(self.allocator, '`');
+    var prev_ws = true; // leading whitespace skip
+    for (inner) |c| {
+        if (c == ' ' or c == '\t' or c == '\n' or c == '\r') {
+            if (!prev_ws) {
+                try buf.append(self.allocator, ' ');
+                prev_ws = true;
+            }
+        } else {
+            try buf.append(self.allocator, c);
+            prev_ws = false;
+        }
+    }
+    // trailing whitespace strip — closing backtick 직전 ws 제거.
+    while (buf.items.len > 1 and buf.items[buf.items.len - 1] == ' ') {
+        _ = buf.pop();
+    }
+    try buf.append(self.allocator, '`');
+
+    const new_span = try self.ast.addString(buf.items);
+    return self.ast.addNode(.{
+        .tag = .template_literal,
+        .span = new_span,
+        .data = .{ .list = .{ .start = 0, .len = 0 } },
+    });
+}
+
+/// CSS minify 가 변경을 만들지 검사 — leading/trailing whitespace, 또는 ws run (>1) 이 있으면 true.
+/// alloc 회피 fast-path.
+fn needsCssMinify(inner: []const u8) bool {
+    if (inner.len == 0) return false;
+    if (isCssWhitespace(inner[0]) or isCssWhitespace(inner[inner.len - 1])) return true;
+    var prev_ws = false;
+    for (inner) |c| {
+        const ws = isCssWhitespace(c);
+        if (ws and prev_ws) return true; // 다중 ws run
+        if (c == '\t' or c == '\n' or c == '\r') return true; // non-space ws 는 항상 collapse 대상
+        prev_ws = ws;
+    }
+    return false;
+}
+
+inline fn isCssWhitespace(c: u8) bool {
+    return c == ' ' or c == '\t' or c == '\n' or c == '\r';
+}
+
 /// `wrapStyledTagInExpr` 의 재귀 base case — 직접 tagged_template 일 때만 호출.
 fn wrapStyledTag(self: *Transformer, init_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
     if (var_name.len == 0) return init_idx;
@@ -667,9 +732,13 @@ fn wrapStyledTag(self: *Transformer, init_idx: NodeIndex, var_name: []const u8) 
     }
 
     const new_tag = try buildWithConfigCall(self, tag_idx, var_name);
+    const final_template = if (self.options.styled_components_minify)
+        try minifyCssTemplate(self, template_idx)
+    else
+        template_idx;
     const new_extra = try self.ast.addExtras(&.{
         @intFromEnum(new_tag),
-        @intFromEnum(template_idx),
+        @intFromEnum(final_template),
         flags,
     });
     return self.ast.addNode(.{
@@ -778,10 +847,14 @@ fn mergeIntoUserWithConfig(
     // 4. chain 의 target_call 을 new_call 로 swap (recursive rebuild).
     const new_tag = try rewriteChainAt(self, tag_idx, target_call_idx, new_call);
 
-    // 5. 새 tagged_template 빌드.
+    // 5. 새 tagged_template 빌드 (minify 옵션 시 template 도 minify).
+    const final_template = if (self.options.styled_components_minify)
+        try minifyCssTemplate(self, template_idx)
+    else
+        template_idx;
     const new_tt_extra = try self.ast.addExtras(&.{
         @intFromEnum(new_tag),
-        @intFromEnum(template_idx),
+        @intFromEnum(final_template),
         template_flags,
     });
     return self.ast.addNode(.{


### PR DESCRIPTION
## Summary

`compiler.styledComponents: { minify: true }` 옵션 도입 — CSS template whitespace collapse. babel-plugin-styled-components 의 `minify` 옵션과 동등. 첫 PR 은 **no-interpolation** template 만 (보간 있는 template 은 후속).

\`\`\`tsx
// 입력
import styled from \"styled-components\";
const Card = styled.div\`
  color: red;
  padding: 8px;
\`;

// minify=true 출력 — 다중 whitespace → single space, leading/trailing strip
const Card = styled.div.withConfig({...})\`color: red; padding: 8px;\`;

// minify=false (default) 출력 — 원본 보존
const Card = styled.div.withConfig({...})\`
  color: red;
  padding: 8px;
\`;
\`\`\`

## 인식 매트릭스

| 케이스 | 상태 |
|---|---|
| `styled.div\`color: red;\`` (단순) | ✅ |
| 다중 라인 / 들여쓰기 | ✅ |
| 이미 minimal → identity (alloc 회피) | ✅ (fast-path) |
| `styled.div\`color: ${c};\`` (보간) | ❌ → 후속 PR (각 quasi 별 처리) |
| CSS-aware (`;{}:` 주변 정리) | ❌ → 후속 PR |

## 변경 내용

### `minifyCssTemplate` 핵심
- `codegen.zig:2270` 의 `data.none == 0` convention 으로 no-interp 판정 (codebase consistency)
- 단일 buffer 에 backtick + collapsed + backtick 한 번에 빌드 (alloc 1번)
- `string_table` 에 저장 → `template_literal` 노드의 span 으로 사용

### `needsCssMinify` fast-path
- alloc 전 pre-scan: leading/trailing whitespace 또는 ws run (>1) 또는 non-space ws 발견 시 true
- 이미 minimal 이면 즉시 identity 반환 (no allocation)

### Multi-layer plumbing
ssr 옵션과 동일 패턴 — `TransformOptions` → `BundleOptions` → `Graph` → `AppBuildOptions` → NAPI → JS layer.

## /simplify (3-agent) 결과 반영

- **Reuse**: `data.none == 0` (codegen 의 canonical convention) ← `data.list.len == 0` 에서 변경
- **Efficiency**: pre-scan fast-path 도입 (alloc 회피)
- **Efficiency**: 2 ArrayList → 1 buffer (backtick 직접 prepend/append)
- **Quality**: 코멘트 / 테스트 / dual call site 일관성 확인

## 검증

- ✅ `zig build test`: 4174/4174 pass (3 신규)
- ✅ examples/web 무회귀

## 후속 PR

- [ ] 보간 있는 template minify (각 quasi 별 처리, marker 보존)
- [ ] CSS-aware minify (`;{}:` 주변 정리)
- [ ] `transpileTemplateLiterals`

🤖 Generated with [Claude Code](https://claude.com/claude-code)