### PR TITLE
feat(transformer): emotion autoLabel 1st-party transform (첫 emotion PR)

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -565,6 +565,7 @@ fn napiBuildAppSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.
         .styled_components = getObjectBool(env, opts_obj, "styledComponents", false),
         .styled_components_ssr = getObjectBool(env, opts_obj, "styledComponentsSsr", true),
         .styled_components_minify = getObjectBool(env, opts_obj, "styledComponentsMinify", false),
+        .emotion = getObjectBool(env, opts_obj, "emotion", false),
     }) catch |err| {
         return throwError(env, @errorName(err));
     };
@@ -3570,6 +3571,7 @@ fn parseBuildOptions(
         .styled_components = getObjectBool(env, opts_obj, "styledComponents", false),
         .styled_components_ssr = getObjectBool(env, opts_obj, "styledComponentsSsr", true),
         .styled_components_minify = getObjectBool(env, opts_obj, "styledComponentsMinify", false),
+        .emotion = getObjectBool(env, opts_obj, "emotion", false),
         .collect_module_codes = getObjectBool(env, opts_obj, "collectModuleCodes", false),
         // RN 프리셋(bundler.zig의 RN_BOOL_PRESET 단일 소스): platform=react-native이면
         // 사용자가 명시하지 않아도 CLI와 동일하게 auto-enable. worklet_transform 없이는

--- a/src/app/build.zig
+++ b/src/app/build.zig
@@ -26,6 +26,8 @@ pub const AppBuildOptions = struct {
     styled_components_ssr: bool = true,
     /// styled-components.minify 옵션 — CSS template whitespace collapse.
     styled_components_minify: bool = false,
+    /// emotion 1st-party transform (compiler.emotion).
+    emotion: bool = false,
 };
 
 pub const AppDevPrepareOptions = struct {
@@ -120,6 +122,7 @@ pub fn buildApp(allocator: std.mem.Allocator, opts: AppBuildOptions) !usize {
         .styled_components = opts.styled_components,
         .styled_components_ssr = opts.styled_components_ssr,
         .styled_components_minify = opts.styled_components_minify,
+        .emotion = opts.emotion,
     });
     defer bundler.deinit();
 

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -130,6 +130,8 @@ pub const BundleOptions = struct {
     styled_components_ssr: bool = true,
     /// styled-components.minify 옵션 — CSS template whitespace collapse.
     styled_components_minify: bool = false,
+    /// emotion 1st-party transform (compiler.emotion). 활성 시 css 템플릿에 autoLabel 적용.
+    emotion: bool = false,
     /// dev mode에서 per-module codes 수집 (HMR rebuild용). 초기 빌드에서는 false로 메모리 절감.
     collect_module_codes: bool = false,
     /// define 글로벌 치환 (--define:KEY=VALUE)
@@ -635,6 +637,7 @@ pub const Bundler = struct {
         worker_graph.styled_components = self.options.styled_components;
         worker_graph.styled_components_ssr = self.options.styled_components_ssr;
         worker_graph.styled_components_minify = self.options.styled_components_minify;
+        worker_graph.emotion = self.options.emotion;
         worker_graph.code_splitting = self.options.code_splitting;
         worker_graph.minify_identifiers = self.options.minify_identifiers;
         worker_graph.transform_options_base = self.buildTransformOptionsBase();
@@ -796,6 +799,7 @@ pub const Bundler = struct {
         graph.styled_components = self.options.styled_components;
         graph.styled_components_ssr = self.options.styled_components_ssr;
         graph.styled_components_minify = self.options.styled_components_minify;
+        graph.emotion = self.options.emotion;
         graph.code_splitting = self.options.code_splitting;
         graph.minify_identifiers = self.options.minify_identifiers;
         graph.transform_options_base = self.buildTransformOptionsBase();

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -144,6 +144,8 @@ pub const ModuleGraph = struct {
     styled_components_ssr: bool = true,
     /// styled-components.minify 옵션 — CSS template whitespace collapse.
     styled_components_minify: bool = false,
+    /// emotion 1st-party transform (compiler.emotion).
+    emotion: bool = false,
     /// code splitting 활성화. helper module virtual import (#1961) 는 splitting 모드에서만
     /// 활성 — single-bundle 모드는 helper module 의 declaration 이 statement-level shake
     /// 로 elide 되는 회귀가 있어 기존 preamble 모델 유지.
@@ -1723,6 +1725,7 @@ pub const ModuleGraph = struct {
         opts.styled_components = self.styled_components and is_user_code;
         opts.styled_components_ssr = self.styled_components_ssr;
         opts.styled_components_minify = self.styled_components_minify;
+        opts.emotion = self.emotion and is_user_code;
         opts.plugins = merged_plugins;
         opts.jsx_transform = ast_ptr.has_jsx;
         opts.jsx_filename = module.path;

--- a/src/transformer/emotion_test.zig
+++ b/src/transformer/emotion_test.zig
@@ -1,0 +1,132 @@
+//! emotion 1st-party transform 회귀 테스트.
+
+const std = @import("std");
+const helpers = @import("../codegen/codegen_test/helpers.zig");
+const e2eFull = helpers.e2eFull;
+const TransformOptions = helpers.TransformOptions;
+const CodegenOptions = helpers.CodegenOptions;
+
+const default_cg: CodegenOptions = .{ .minify_whitespace = false };
+
+fn expectAutoLabel(output: []const u8, expected: []const u8) !void {
+    var buf: [256]u8 = undefined;
+    const needle = std.fmt.bufPrint(&buf, "label:{s};", .{expected}) catch return error.OutOfMemory;
+    try std.testing.expect(std.mem.indexOf(u8, output, needle) != null);
+}
+
+test "emotion: const X = css`...` 에 label:X; prepend" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const button = css`color: red;`;
+    ,
+        .{ .emotion = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "button");
+    // 원본 CSS 보존
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "color: red;") != null);
+}
+
+test "emotion: 보간 있는 css 도 첫 quasi 에 label prepend" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const themed = css`color: ${color}; padding: 8px;`;
+    ,
+        .{ .emotion = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "themed");
+    // 보간 marker 보존
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "${color}") != null);
+}
+
+test "emotion: alias `import { css as cx }` 도 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css as cx } from "@emotion/react";
+        \\const button = cx`color: red;`;
+    ,
+        .{ .emotion = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "button");
+}
+
+test "emotion: @emotion/css source 도 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/css";
+        \\const card = css`padding: 8px;`;
+    ,
+        .{ .emotion = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "card");
+}
+
+test "emotion: 옵션 비활성 시 변환 없음" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const button = css`color: red;`;
+    ,
+        .{ .emotion = false, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "label:") == null);
+}
+
+test "emotion: import 없으면 binding 미감지 → no-op" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\const css = (s) => s;
+        \\const button = css`color: red;`;
+    ,
+        .{ .emotion = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "label:") == null);
+}
+
+test "emotion: 다른 라이브러리 source (`stitches`) 는 미감지" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@stitches/react";
+        \\const button = css`color: red;`;
+    ,
+        .{ .emotion = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "label:") == null);
+}
+
+test "emotion: tag 가 css.something 같은 chain 이면 미인식" {
+    // chain 형태는 후속 PR. 단순 css binding 만 인식.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const ext = css.x`color: red;`;
+    ,
+        .{ .emotion = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "label:") == null);
+}

--- a/src/transformer/mod.zig
+++ b/src/transformer/mod.zig
@@ -51,4 +51,5 @@ test {
     _ = @import("worklet_test.zig");
     _ = @import("worklet_babel_parity_test.zig");
     _ = @import("styled_components_test.zig");
+    _ = @import("emotion_test.zig");
 }

--- a/src/transformer/plugin_state.zig
+++ b/src/transformer/plugin_state.zig
@@ -64,6 +64,12 @@ pub const RefreshState = struct {
     suppress_registration: bool = false,
 };
 
+pub const EmotionState = struct {
+    /// `import { css } from "@emotion/react"` 의 local binding 이름 (alias 포함).
+    /// import 가 없으면 null — autoLabel transform 미적용.
+    css_binding: ?[]const u8 = null,
+};
+
 pub const StyledComponentsState = struct {
     /// `import styled from "styled-components"` 의 default binding 로컬 이름.
     /// alias 가 있으면 그 이름 (예: `import s from "styled-components"` → "s").
@@ -93,4 +99,5 @@ pub const PluginState = struct {
     worklet: WorkletState = .{},
     refresh: RefreshState = .{},
     styled_components: StyledComponentsState = .{},
+    emotion: EmotionState = .{},
 };

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -56,6 +56,7 @@ const es_helpers = @import("es_helpers.zig");
 const Symbol = @import("../semantic/symbol.zig").Symbol;
 const worklet_mod = @import("transformer/worklet.zig");
 const styled_components_mod = @import("transformer/styled_components.zig");
+const emotion_mod = @import("transformer/emotion.zig");
 pub const ast_plugin_mod = @import("ast_plugin.zig");
 pub const AstTransformCtx = ast_plugin_mod.AstTransformCtx;
 pub const FunctionInfo = ast_plugin_mod.FunctionInfo;
@@ -119,6 +120,10 @@ pub const TransformOptions = struct {
     /// no-interp 템플릿 (`\`color: red;\``) 만 우선 처리. interp 있는 경우는 후속.
     /// `babel-plugin-styled-components.minify` 와 동일 의도, default 는 false (안전).
     styled_components_minify: bool = false,
+    /// emotion 1st-party transform (compiler.emotion).
+    /// 활성 시 `const X = css\`...\`` 같은 선언에 `label:X;` 자동 prepend (autoLabel).
+    /// `import { css } from "@emotion/react"` 의 named binding 추적.
+    emotion: bool = false,
     /// useDefineForClassFields=false: instance field를 constructor의 this.x = value 할당으로 변환.
     /// true(기본값)이면 class field를 그대로 유지 (TC39 [[Define]] semantics).
     /// false이면 TS 4.x 이전 동작 — field를 constructor body로 이동 ([[Set]] semantics).
@@ -2945,6 +2950,14 @@ pub const Transformer = struct {
                 new_init = try styled_components_mod.wrapStyledTagInExpr(self, new_init, var_name);
             }
         }
+        // emotion autoLabel: const X = css`...` → css`label:X;...`
+        if (self.options.emotion and !new_name.isNone() and !new_init.isNone()) {
+            const new_name_node = self.ast.getNode(new_name);
+            if (new_name_node.tag == .binding_identifier or new_name_node.tag == .identifier_reference) {
+                const var_name = self.ast.getText(new_name_node.data.string_ref);
+                new_init = try emotion_mod.maybeApplyAutoLabel(self, new_init, var_name);
+            }
+        }
         const none = @intFromEnum(NodeIndex.none);
         return self.addExtraNode(.variable_declarator, node.span, &.{ @intFromEnum(new_name), none, @intFromEnum(new_init) });
     }
@@ -4444,6 +4457,7 @@ pub const Transformer = struct {
 
     fn visitImportDeclaration(self: *Transformer, node: Node) Error!NodeIndex {
         try styled_components_mod.detectStyledImport(self, node);
+        try emotion_mod.detectEmotionImport(self, node);
 
         const x = module_parser.readImportDeclExtras(self.ast, node.data.extra);
 

--- a/src/transformer/transformer/emotion.zig
+++ b/src/transformer/transformer/emotion.zig
@@ -1,0 +1,227 @@
+//! emotion 1st-party transform — `compiler.emotion`.
+//!
+//! ## 변환 의도
+//!
+//! Reference: `references/emotion/packages/babel-plugin/` (MIT) /
+//! `references/swc-plugins/packages/emotion/` (Apache 2.0).
+//!
+//! ```js
+//! // 입력
+//! import { css } from "@emotion/react";
+//! const button = css`color: red;`;
+//!
+//! // 출력 (autoLabel)
+//! import { css } from "@emotion/react";
+//! const button = css`label:button;color: red;`;
+//! ```
+//!
+//! ## 첫 PR 범위 — autoLabel
+//!
+//! - 변수명을 CSS class label 로 자동 부여 — DevTools 가독성
+//! - `import { css } from "@emotion/react"` 의 named binding 추적
+//! - `const X = css\`...\`` 형태에서 첫 quasi text 에 `label:X;` prepend
+//! - styled-components 와 별개: emotion 은 named import (`{ css }`),
+//!   styled-components 는 default import (`styled`).
+//!
+//! ## 후속 PR (미지원)
+//!
+//! - sourceMap 라벨링
+//! - `<div css={...}>` prop hoist
+//! - `@emotion/styled` (default styled — styled-components 와 동일 패턴)
+//! - `keyframes` / `Global` / `injectGlobal`
+
+const std = @import("std");
+const ast_mod = @import("../../parser/ast.zig");
+const Node = ast_mod.Node;
+const NodeIndex = ast_mod.NodeIndex;
+const token_mod = @import("../../lexer/token.zig");
+const Span = token_mod.Span;
+const module_parser = @import("../../parser/module.zig");
+const import_scanner = @import("../../bundler/import_scanner.zig");
+const transformer_mod = @import("../transformer.zig");
+const Transformer = transformer_mod.Transformer;
+const Error = Transformer.Error;
+
+/// emotion `css` import source 문자열 — 흔한 4가지 entry 모두 인정.
+pub const EMOTION_CSS_SOURCES: []const []const u8 = &.{
+    "@emotion/react",
+    "@emotion/css",
+    "@emotion/core", // legacy v10
+    "@emotion/native", // RN
+};
+
+pub fn isEmotionCssSource(source: []const u8) bool {
+    for (EMOTION_CSS_SOURCES) |s| {
+        if (std.mem.eql(u8, s, source)) return true;
+    }
+    return false;
+}
+
+/// `visitImportDeclaration` hook — source 가 emotion 이고 `{ css }` named specifier 가 있으면
+/// local binding 이름을 state.css_binding 에 저장.
+pub fn detectEmotionImport(self: *Transformer, node: Node) Error!void {
+    if (!self.options.emotion) return;
+    if (self.plugins.emotion.css_binding != null) return;
+
+    const x = module_parser.readImportDeclExtras(self.ast, node.data.extra);
+    if (x.source.isNone()) return;
+    const source_node = self.ast.getNode(x.source);
+    if (source_node.tag != .string_literal) return;
+    const source_text = import_scanner.stripQuotes(self.ast.getText(source_node.span)) orelse return;
+    if (!isEmotionCssSource(source_text)) return;
+
+    var i: u32 = 0;
+    while (i < x.specs_len) : (i += 1) {
+        const spec_idx_raw = self.ast.extra_data.items[x.specs_start + i];
+        const spec_idx: NodeIndex = @enumFromInt(spec_idx_raw);
+        if (spec_idx.isNone()) continue;
+        const spec_node = self.ast.getNode(spec_idx);
+        if (spec_node.tag != .import_specifier) continue;
+        // import_specifier: binary { left=imported, right=local }
+        const imported_idx = spec_node.data.binary.left;
+        const local_idx = spec_node.data.binary.right;
+        if (imported_idx.isNone() or local_idx.isNone()) continue;
+        const imported_node = self.ast.getNode(imported_idx);
+        if (imported_node.tag != .identifier_reference) continue;
+        if (!std.mem.eql(u8, self.ast.getText(imported_node.data.string_ref), "css")) continue;
+        // local 이름 추출 (alias 있을 수 있음).
+        const local_node = self.ast.getNode(local_idx);
+        if (local_node.tag != .identifier_reference and local_node.tag != .binding_identifier) continue;
+        const local_name = self.ast.getText(local_node.data.string_ref);
+        if (local_name.len == 0) continue;
+        self.plugins.emotion.css_binding = local_name;
+        return;
+    }
+}
+
+/// `visitVariableDeclarator` 의 post-visit hook — emotion `css\`...\`` 형태면 첫 quasi 에
+/// `label:<var_name>;` prepend.
+pub fn maybeApplyAutoLabel(self: *Transformer, init_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
+    if (!self.options.emotion) return init_idx;
+    const binding = self.plugins.emotion.css_binding orelse return init_idx;
+    if (var_name.len == 0) return init_idx;
+    if (init_idx.isNone()) return init_idx;
+
+    const init_node = self.ast.getNode(init_idx);
+    if (init_node.tag != .tagged_template_expression) return init_idx;
+
+    // tagged_template extra = [tag, template, flags]
+    const e = init_node.data.extra;
+    if (!self.ast.hasExtra(e, 2)) return init_idx;
+    const tag_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+    const template_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 1]);
+    const flags = self.ast.extra_data.items[e + 2];
+
+    // tag 가 emotion css binding 인지 확인 — `css` 식별자만 (chain `css.something` 은 skip).
+    if (tag_idx.isNone()) return init_idx;
+    const tag_node = self.ast.getNode(tag_idx);
+    if (tag_node.tag != .identifier_reference) return init_idx;
+    if (!std.mem.eql(u8, self.ast.getText(tag_node.data.string_ref), binding)) return init_idx;
+
+    const new_template = try prependLabelToTemplate(self, template_idx, var_name);
+    if (new_template == template_idx) return init_idx;
+
+    const new_extra = try self.ast.addExtras(&.{
+        @intFromEnum(tag_idx),
+        @intFromEnum(new_template),
+        flags,
+    });
+    return self.ast.addNode(.{
+        .tag = .tagged_template_expression,
+        .span = init_node.span,
+        .data = .{ .extra = new_extra },
+    });
+}
+
+/// template_literal 의 첫 quasi 시작에 `label:<name>;` prepend. no-interp / interp 둘 다 처리.
+fn prependLabelToTemplate(self: *Transformer, template_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
+    const node = self.ast.getNode(template_idx);
+    if (node.tag != .template_literal) return template_idx;
+
+    if (node.data.none == 0) {
+        return try prependLabelToNoInterpTemplate(self, template_idx, node, var_name);
+    }
+    return try prependLabelToInterpTemplate(self, template_idx, node, var_name);
+}
+
+/// no-interp `\`text\`` — `\`label:<name>;text\`` 빌드.
+fn prependLabelToNoInterpTemplate(
+    self: *Transformer,
+    template_idx: NodeIndex,
+    node: ast_mod.Node,
+    var_name: []const u8,
+) Error!NodeIndex {
+    const raw = self.ast.getText(node.span);
+    if (raw.len < 2 or raw[0] != '`' or raw[raw.len - 1] != '`') return template_idx;
+    const inner = raw[1 .. raw.len - 1];
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(self.allocator);
+    try buf.append(self.allocator, '`');
+    try writeLabelPrefix(self.allocator, &buf, var_name);
+    try buf.appendSlice(self.allocator, inner);
+    try buf.append(self.allocator, '`');
+
+    const new_span = try self.ast.addString(buf.items);
+    return self.ast.addNode(.{
+        .tag = .template_literal,
+        .span = new_span,
+        .data = .{ .list = .{ .start = 0, .len = 0 } },
+    });
+}
+
+/// interp template — 첫 template_element 시작에 `label:<name>;` prepend.
+fn prependLabelToInterpTemplate(
+    self: *Transformer,
+    template_idx: NodeIndex,
+    node: ast_mod.Node,
+    var_name: []const u8,
+) Error!NodeIndex {
+    const list = node.data.list;
+    if (list.len == 0) return template_idx;
+    const items = self.ast.extra_data.items[list.start .. list.start + list.len];
+
+    const first_idx: NodeIndex = @enumFromInt(items[0]);
+    const first_node = self.ast.getNode(first_idx);
+    if (first_node.tag != .template_element) return template_idx;
+
+    // 첫 element span: `\`text${` (head) — 첫 char 가 backtick, 끝이 `${`.
+    const raw = self.ast.getText(first_node.span);
+    if (raw.len < 3 or raw[0] != '`') return template_idx;
+    if (raw[raw.len - 2] != '$' or raw[raw.len - 1] != '{') return template_idx;
+    const inner = raw[1 .. raw.len - 2];
+
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(self.allocator);
+    try buf.append(self.allocator, '`');
+    try writeLabelPrefix(self.allocator, &buf, var_name);
+    try buf.appendSlice(self.allocator, inner);
+    try buf.append(self.allocator, '$');
+    try buf.append(self.allocator, '{');
+
+    const new_first_span = try self.ast.addString(buf.items);
+    const new_first = try self.ast.addNode(.{
+        .tag = .template_element,
+        .span = new_first_span,
+        .data = .{ .none = 0 },
+    });
+
+    // children list 재구성 — 첫 번째만 교체, 나머지는 그대로.
+    const top = self.scratch.items.len;
+    defer self.scratch.shrinkRetainingCapacity(top);
+    try self.scratch.append(self.allocator, new_first);
+    for (items[1..]) |raw_idx| try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
+
+    const new_list = try self.ast.addNodeList(self.scratch.items[top..]);
+    return self.ast.addNode(.{
+        .tag = .template_literal,
+        .span = node.span,
+        .data = .{ .list = new_list },
+    });
+}
+
+fn writeLabelPrefix(allocator: std.mem.Allocator, buf: *std.ArrayList(u8), var_name: []const u8) Error!void {
+    try buf.appendSlice(allocator, "label:");
+    try buf.appendSlice(allocator, var_name);
+    try buf.append(allocator, ';');
+}


### PR DESCRIPTION
## Summary

styled-components 17 PR 후 **emotion 첫 PR** — autoLabel 변환 도입. 변수명을 CSS class label 로 자동 부여 (DevTools 가독성).

\`\`\`tsx
// 입력
import { css } from \"@emotion/react\";
const button = css\`color: red;\`;

// 출력 (autoLabel)
const button = css\`label:button;color: red;\`;

// 보간 있는 경우 — 첫 quasi 에만 prepend, ${marker} 보존
const themed = css\`color: ${color}; padding: 8px;\`;
// → const themed = css\`label:themed;color: ${color}; padding: 8px;\`;
\`\`\`

## 구조

emotion 은 styled-components 와 별개 모듈 (`emotion.zig`). 차이:
- styled-components: **default import** (`styled`), tag 는 chain (`styled.div`/`styled(X)`)
- emotion: **named import** (`{ css }`), tag 는 단순 identifier (`css`)

## 인식 매트릭스

| 케이스 | 상태 |
|---|---|
| `import { css } from \"@emotion/react\"` + `css\`...\`` | ✅ |
| `import { css as cx }` (alias) + `cx\`...\`` | ✅ |
| `@emotion/css` / `@emotion/core` (v10) / `@emotion/native` source | ✅ |
| 보간 있는 css (`\`...${expr}...\``) | ✅ (첫 quasi 에만 prepend) |
| `css.x\`...\`` (chain) | ❌ → 후속 PR |
| `@emotion/styled` default styled | ❌ → 후속 (styled-components 패턴 재사용) |
| `keyframes` / `Global` / `injectGlobal` | ❌ → 후속 |
| `<div css={...}>` prop hoist | ❌ → 후속 |
| sourceMap 라벨링 | ❌ → 후속 |
| 다른 라이브러리 (`@stitches/react`) | ❌ (의도 — 회귀 가드) |

## 변경 내용

### 신규 `src/transformer/transformer/emotion.zig`
- `EMOTION_CSS_SOURCES` — `@emotion/react` / `@emotion/css` / `@emotion/core` / `@emotion/native`
- `detectEmotionImport` — named specifier walking, alias 추적
- `maybeApplyAutoLabel` — variable_declarator post-visit, tag 검증, label prepend
- `prependLabelTo[NoInterp|Interp]Template` — no-interp 통째 vs 첫 element marker 보존

### `PluginState` 확장
\`EmotionState { css_binding: ?[]const u8 = null }\` 추가.

### Multi-layer plumbing (styled_components 와 동일)
TransformOptions / BundleOptions / Graph / AppBuildOptions / NAPI / JS layer.

## 검증

- ✅ `zig build test`: 4182/4182 pass (8 신규 emotion 테스트)
- ✅ examples/web 무회귀

## 후속 PR (emotion epic)

- [ ] `@emotion/styled` default — styled-components 패턴 재사용
- [ ] `<div css={...}>` prop optimization
- [ ] `keyframes` / `Global` autoLabel
- [ ] sourceMap 라벨링
- [ ] chain `css.x\`...\`` (Object Styles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)