### PR TITLE
feat(transformer): emotion keyframes autoLabel

### DIFF
--- a/src/transformer/emotion_test.zig
+++ b/src/transformer/emotion_test.zig
@@ -159,6 +159,50 @@ test "emotion: styled alias `import s from \"@emotion/styled\"` 도 추적" {
     try expectAutoLabel(r.output, "Btn");
 }
 
+test "emotion: keyframes`...` 도 autoLabel" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { keyframes } from "@emotion/react";
+        \\const fadeIn = keyframes`from { opacity: 0; } to { opacity: 1; }`;
+    ,
+        .{ .emotion = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "fadeIn");
+}
+
+test "emotion: 같은 import 의 css + keyframes 동시 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css, keyframes } from "@emotion/react";
+        \\const spin = keyframes`from { rotate: 0; } to { rotate: 360deg; }`;
+        \\const card = css`color: red;`;
+    ,
+        .{ .emotion = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "spin");
+    try expectAutoLabel(r.output, "card");
+}
+
+test "emotion: keyframes alias `import { keyframes as kf }` 도 추적" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { keyframes as kf } from "@emotion/react";
+        \\const fadeIn = kf`from { opacity: 0; }`;
+    ,
+        .{ .emotion = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "fadeIn");
+}
+
 test "emotion: tag 가 css.something 같은 chain 이면 미인식" {
     // chain 형태는 후속 PR. 단순 css binding 만 인식.
     var r = try e2eFull(

--- a/src/transformer/plugin_state.zig
+++ b/src/transformer/plugin_state.zig
@@ -66,12 +66,15 @@ pub const RefreshState = struct {
 
 pub const EmotionState = struct {
     /// `import { css } from "@emotion/react"` 의 local binding 이름 (alias 포함).
-    /// import 가 없으면 null — css autoLabel 미적용.
     css_binding: ?[]const u8 = null,
 
     /// `import styled from "@emotion/styled"` 의 default binding 이름 (alias 포함).
-    /// `styled.div\`...\`` / `styled(X)\`...\`` 의 첫 quasi 에 label prepend.
     styled_binding: ?[]const u8 = null,
+
+    /// `import { keyframes } from "@emotion/react"` 의 local binding 이름 (alias 포함).
+    /// `keyframes\`...\`` 도 첫 quasi 에 label prepend — emotion 런타임이 animation name
+    /// 으로 사용.
+    keyframes_binding: ?[]const u8 = null,
 };
 
 pub const StyledComponentsState = struct {

--- a/src/transformer/transformer/emotion.zig
+++ b/src/transformer/transformer/emotion.zig
@@ -82,9 +82,9 @@ pub fn detectEmotionImport(self: *Transformer, node: Node) Error!void {
     if (source_node.tag != .string_literal) return;
     const source_text = import_scanner.stripQuotes(self.ast.getText(source_node.span)) orelse return;
 
-    const want_css = isEmotionCssSource(source_text) and self.plugins.emotion.css_binding == null;
+    const want_css_or_keyframes = isEmotionCssSource(source_text);
     const want_styled = isEmotionStyledSource(source_text) and self.plugins.emotion.styled_binding == null;
-    if (!want_css and !want_styled) return;
+    if (!want_css_or_keyframes and !want_styled) return;
 
     var i: u32 = 0;
     while (i < x.specs_len) : (i += 1) {
@@ -100,19 +100,23 @@ pub fn detectEmotionImport(self: *Transformer, node: Node) Error!void {
                 self.plugins.emotion.styled_binding = local_name;
             },
             .import_specifier => {
-                if (!want_css) continue;
+                if (!want_css_or_keyframes) continue;
                 // binary { left=imported, right=local }
                 const imported_idx = spec_node.data.binary.left;
                 const local_idx = spec_node.data.binary.right;
                 if (imported_idx.isNone() or local_idx.isNone()) continue;
                 const imported_node = self.ast.getNode(imported_idx);
                 if (imported_node.tag != .identifier_reference) continue;
-                if (!std.mem.eql(u8, self.ast.getText(imported_node.data.string_ref), "css")) continue;
+                const imported_name = self.ast.getText(imported_node.data.string_ref);
                 const local_node = self.ast.getNode(local_idx);
                 if (local_node.tag != .identifier_reference and local_node.tag != .binding_identifier) continue;
                 const local_name = self.ast.getText(local_node.data.string_ref);
                 if (local_name.len == 0) continue;
-                self.plugins.emotion.css_binding = local_name;
+                if (std.mem.eql(u8, imported_name, "css") and self.plugins.emotion.css_binding == null) {
+                    self.plugins.emotion.css_binding = local_name;
+                } else if (std.mem.eql(u8, imported_name, "keyframes") and self.plugins.emotion.keyframes_binding == null) {
+                    self.plugins.emotion.keyframes_binding = local_name;
+                }
             },
             else => {},
         }
@@ -160,16 +164,22 @@ pub fn maybeApplyAutoLabel(self: *Transformer, init_idx: NodeIndex, var_name: []
     });
 }
 
-/// tag 가 emotion 인식 패턴 (css binding, styled.X, styled(X)) 인지 확인.
+/// tag 가 emotion 인식 패턴 (css binding, keyframes binding, styled.X, styled(X)) 인지 확인.
 fn tagMatchesEmotion(self: *Transformer, tag_idx: NodeIndex) bool {
     if (tag_idx.isNone()) return false;
     const state = &self.plugins.emotion;
     const tag_node = self.ast.getNode(tag_idx);
     switch (tag_node.tag) {
         .identifier_reference => {
-            // `css\`...\`` — css_binding 일치만 인식.
-            const binding = state.css_binding orelse return false;
-            return std.mem.eql(u8, self.ast.getText(tag_node.data.string_ref), binding);
+            // `css\`...\`` 또는 `keyframes\`...\`` — 둘 중 어느 binding 이든 일치.
+            const text = self.ast.getText(tag_node.data.string_ref);
+            if (state.css_binding) |b| {
+                if (std.mem.eql(u8, text, b)) return true;
+            }
+            if (state.keyframes_binding) |b| {
+                if (std.mem.eql(u8, text, b)) return true;
+            }
+            return false;
         },
         .static_member_expression => {
             // `styled.div\`...\`` — object 가 styled_binding 일치.


### PR DESCRIPTION
## Summary

`import { keyframes } from \"@emotion/react\"` 의 named binding 추적 + `keyframes\`...\`` 첫 quasi 에 label prepend. emotion 런타임이 animation name 으로 사용.

\`\`\`tsx
// 입력
import { keyframes } from \"@emotion/react\";
const fadeIn = keyframes\`
  from { opacity: 0; }
  to { opacity: 1; }
\`;

// 출력
const fadeIn = keyframes\`label:fadeIn;
  from { opacity: 0; }
  to { opacity: 1; }
\`;
\`\`\`

## 변경 내용

### `EmotionState.keyframes_binding` 추가
css_binding 과 별개 slot — 같은 import 에서 `{ css, keyframes }` 동시 destructure 도 둘 다 추적.

### `detectEmotionImport` 의 import_specifier 분기
imported name 이 \"css\" 든 \"keyframes\" 든 적절한 slot 에 저장. early-return 가드는 `want_css_or_keyframes` 로 통합.

### `tagMatchesEmotion` 의 identifier_reference arm
css_binding 또는 keyframes_binding 둘 중 어느 것이든 일치하면 인식.

## 인식 매트릭스 (emotion 누적)

| 케이스 | 상태 |
|---|---|
| `import { css }` + `css\`...\`` | ✅ |
| `import { keyframes }` + `keyframes\`...\`` | ✅ **(이번 PR)** |
| `import { css, keyframes }` 동시 | ✅ **(이번 PR)** |
| alias `import { keyframes as kf }` | ✅ **(이번 PR)** |
| `import styled from \"@emotion/styled\"` + `styled.X\`...\`` | ✅ |
| chain `css.x\`...\`` / `styled.div.attrs({})\`...\`` | ❌ → 후속 |
| `<div css={...}>` prop hoist | ❌ → 후속 |
| `Global` / `injectGlobal` | ❌ → 후속 |

## 검증

- ✅ `zig build test`: 4188/4188 pass (3 신규)
- ✅ examples/web 무회귀

## 후속 PR

- [ ] `<div css={...}>` prop hoist (JSX attribute work)
- [ ] `Global` / `injectGlobal` autoLabel
- [ ] chain `css.x\`...\`` / `styled.div.attrs({})\`...\``
- [ ] sourceMap 라벨링

🤖 Generated with [Claude Code](https://claude.com/claude-code)