### PR TITLE
feat(transformer): emotion compiler.emotion.autoLabel: false opt-out

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1248,8 +1248,12 @@ function prepareNapiOptions(options: BuildOptions): Record<string, unknown> {
       if (sc.minify === true) napiOptions.styledComponentsMinify = true;
     }
   }
-  if (options.compiler?.emotion !== undefined && options.compiler.emotion !== false) {
+  const em = options.compiler?.emotion;
+  if (em !== undefined && em !== false) {
     napiOptions.emotion = true;
+    if (typeof em === "object" && em.autoLabel === false) {
+      napiOptions.emotionAutoLabel = false;
+    }
   }
   return napiOptions;
 }
@@ -1413,6 +1417,9 @@ export function buildAppSync(options: AppBuildOptions = {}): BuildResult {
       ? { styledComponentsMinify: true }
       : {}),
     ...(compiler?.emotion !== undefined && compiler.emotion !== false ? { emotion: true } : {}),
+    ...(typeof compiler?.emotion === "object" && compiler.emotion.autoLabel === false
+      ? { emotionAutoLabel: false }
+      : {}),
   });
 }
 

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -566,6 +566,7 @@ fn napiBuildAppSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.
         .styled_components_ssr = getObjectBool(env, opts_obj, "styledComponentsSsr", true),
         .styled_components_minify = getObjectBool(env, opts_obj, "styledComponentsMinify", false),
         .emotion = getObjectBool(env, opts_obj, "emotion", false),
+        .emotion_auto_label = getObjectBool(env, opts_obj, "emotionAutoLabel", true),
     }) catch |err| {
         return throwError(env, @errorName(err));
     };
@@ -3572,6 +3573,7 @@ fn parseBuildOptions(
         .styled_components_ssr = getObjectBool(env, opts_obj, "styledComponentsSsr", true),
         .styled_components_minify = getObjectBool(env, opts_obj, "styledComponentsMinify", false),
         .emotion = getObjectBool(env, opts_obj, "emotion", false),
+        .emotion_auto_label = getObjectBool(env, opts_obj, "emotionAutoLabel", true),
         .collect_module_codes = getObjectBool(env, opts_obj, "collectModuleCodes", false),
         // RN 프리셋(bundler.zig의 RN_BOOL_PRESET 단일 소스): platform=react-native이면
         // 사용자가 명시하지 않아도 CLI와 동일하게 auto-enable. worklet_transform 없이는

--- a/src/app/build.zig
+++ b/src/app/build.zig
@@ -28,6 +28,8 @@ pub const AppBuildOptions = struct {
     styled_components_minify: bool = false,
     /// emotion 1st-party transform (compiler.emotion).
     emotion: bool = false,
+    /// emotion.autoLabel 옵션 — false 면 autoLabel skip.
+    emotion_auto_label: bool = true,
 };
 
 pub const AppDevPrepareOptions = struct {
@@ -123,6 +125,7 @@ pub fn buildApp(allocator: std.mem.Allocator, opts: AppBuildOptions) !usize {
         .styled_components_ssr = opts.styled_components_ssr,
         .styled_components_minify = opts.styled_components_minify,
         .emotion = opts.emotion,
+        .emotion_auto_label = opts.emotion_auto_label,
     });
     defer bundler.deinit();
 

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -132,6 +132,8 @@ pub const BundleOptions = struct {
     styled_components_minify: bool = false,
     /// emotion 1st-party transform (compiler.emotion). 활성 시 css 템플릿에 autoLabel 적용.
     emotion: bool = false,
+    /// emotion.autoLabel 옵션 — false 면 autoLabel skip.
+    emotion_auto_label: bool = true,
     /// dev mode에서 per-module codes 수집 (HMR rebuild용). 초기 빌드에서는 false로 메모리 절감.
     collect_module_codes: bool = false,
     /// define 글로벌 치환 (--define:KEY=VALUE)
@@ -638,6 +640,7 @@ pub const Bundler = struct {
         worker_graph.styled_components_ssr = self.options.styled_components_ssr;
         worker_graph.styled_components_minify = self.options.styled_components_minify;
         worker_graph.emotion = self.options.emotion;
+        worker_graph.emotion_auto_label = self.options.emotion_auto_label;
         worker_graph.code_splitting = self.options.code_splitting;
         worker_graph.minify_identifiers = self.options.minify_identifiers;
         worker_graph.transform_options_base = self.buildTransformOptionsBase();
@@ -800,6 +803,7 @@ pub const Bundler = struct {
         graph.styled_components_ssr = self.options.styled_components_ssr;
         graph.styled_components_minify = self.options.styled_components_minify;
         graph.emotion = self.options.emotion;
+        graph.emotion_auto_label = self.options.emotion_auto_label;
         graph.code_splitting = self.options.code_splitting;
         graph.minify_identifiers = self.options.minify_identifiers;
         graph.transform_options_base = self.buildTransformOptionsBase();

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -146,6 +146,8 @@ pub const ModuleGraph = struct {
     styled_components_minify: bool = false,
     /// emotion 1st-party transform (compiler.emotion).
     emotion: bool = false,
+    /// emotion.autoLabel 옵션 — false 면 autoLabel skip.
+    emotion_auto_label: bool = true,
     /// code splitting 활성화. helper module virtual import (#1961) 는 splitting 모드에서만
     /// 활성 — single-bundle 모드는 helper module 의 declaration 이 statement-level shake
     /// 로 elide 되는 회귀가 있어 기존 preamble 모델 유지.
@@ -1726,6 +1728,7 @@ pub const ModuleGraph = struct {
         opts.styled_components_ssr = self.styled_components_ssr;
         opts.styled_components_minify = self.styled_components_minify;
         opts.emotion = self.emotion and is_user_code;
+        opts.emotion_auto_label = self.emotion_auto_label;
         opts.plugins = merged_plugins;
         opts.jsx_transform = ast_ptr.has_jsx;
         opts.jsx_filename = module.path;

--- a/src/transformer/emotion_test.zig
+++ b/src/transformer/emotion_test.zig
@@ -74,6 +74,23 @@ test "emotion: @emotion/css source 도 인식" {
     try expectAutoLabel(r.output, "card");
 }
 
+test "emotion: { autoLabel: false } 옵션 — emotion 활성이지만 label skip" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const button = css`color: red;`;
+    ,
+        .{ .emotion = true, .emotion_auto_label = false, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // emotion 활성이지만 autoLabel 명시적 disable — label 추가 안 됨.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "label:") == null);
+    // 원본 css 보존
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "color: red;") != null);
+}
+
 test "emotion: 옵션 비활성 시 변환 없음" {
     var r = try e2eFull(
         std.testing.allocator,

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -124,6 +124,10 @@ pub const TransformOptions = struct {
     /// 활성 시 `const X = css\`...\`` 같은 선언에 `label:X;` 자동 prepend (autoLabel).
     /// `import { css } from "@emotion/react"` 의 named binding 추적.
     emotion: bool = false,
+    /// emotion.autoLabel 옵션 — false 면 autoLabel transform 만 skip (binding tracking
+    /// 자체는 동작 — 향후 Global / sourceMap 같은 다른 emotion features 와 분리).
+    /// `compiler.emotion: { autoLabel: false }` 로 설정.
+    emotion_auto_label: bool = true,
     /// useDefineForClassFields=false: instance field를 constructor의 this.x = value 할당으로 변환.
     /// true(기본값)이면 class field를 그대로 유지 (TC39 [[Define]] semantics).
     /// false이면 TS 4.x 이전 동작 — field를 constructor body로 이동 ([[Set]] semantics).

--- a/src/transformer/transformer/emotion.zig
+++ b/src/transformer/transformer/emotion.zig
@@ -135,6 +135,7 @@ pub fn detectEmotionImport(self: *Transformer, node: Node) Error!void {
 ///   - `css.x\`...\`` / `styled.div.attrs({})\`...\`` 같은 추가 chain
 pub fn maybeApplyAutoLabel(self: *Transformer, init_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
     if (!self.options.emotion) return init_idx;
+    if (!self.options.emotion_auto_label) return init_idx; // opt-out: emotion 활성이지만 autoLabel skip
     if (var_name.len == 0) return init_idx;
     if (init_idx.isNone()) return init_idx;
 


### PR DESCRIPTION
## Summary

emotion transform 활성하지만 autoLabel 만 끄기 — 향후 sourceMap / Global / cssPropOptimization 같은 다른 emotion features 와 분리해서 fine-grained 제어.

\`\`\`ts
// 기본 (autoLabel 활성)
defineConfig({ compiler: { emotion: true } });

// emotion 전체 비활성
defineConfig({ compiler: { emotion: false } });

// 객체 form — 향후 다른 emotion features 와 fine-grained 제어
defineConfig({ compiler: { emotion: { autoLabel: false } } });
\`\`\`

## 의도

emotion 의 다른 babel-plugin-emotion options 와의 alignment:
- `autoLabel: 'always' | 'dev-only' | 'never'` (현재 ZTS 는 boolean false 만 — `'never'` 에 해당)
- `sourceMap: true` (후속 PR)
- `cssPropOptimization: true` (후속 PR)

`autoLabel: false` 만으로도 production build 에서 label 제거 (bundle size 절감) 같은 use case 지원.

## 변경 내용 (multi-layer plumbing)

- `TransformOptions.emotion_auto_label: bool = true`
- `BundleOptions` / `Graph` / `AppBuildOptions` 동일 필드
- 2 NAPI entry points + JS prepareNapiOptions/buildAppSync 의 객체 form 인식
- `emotion.zig:maybeApplyAutoLabel` 가 옵션 false 면 즉시 identity 반환

## 검증

- ✅ `zig build test`: 4191/4191 pass (1 신규)
- ✅ examples/web 무회귀

## 후속 PR

- [ ] `<div css={...}>` prop hoist (cssPropOptimization)
- [ ] emotion sourceMap (label 에 source location)
- [ ] `Global` / `injectGlobal` 명시 처리
- [ ] `autoLabel: 'dev-only'` (dev_mode 연동)

🤖 Generated with [Claude Code](https://claude.com/claude-code)