### PR TITLE
feat(transformer): emotion source list 확장 — primitives / styled-base

### DIFF
--- a/src/transformer/emotion_test.zig
+++ b/src/transformer/emotion_test.zig
@@ -119,6 +119,34 @@ test "emotion: import 없으면 binding 미감지 → no-op" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "label:") == null);
 }
 
+test "emotion: @emotion/primitives source 도 인식 (RN)" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/primitives";
+        \\const card = css`padding: 8px;`;
+    ,
+        .{ .emotion = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "card");
+}
+
+test "emotion: @emotion/styled-base default 도 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "@emotion/styled-base";
+        \\const Btn = styled.div`color: red;`;
+    ,
+        .{ .emotion = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "Btn");
+}
+
 test "emotion: 다른 라이브러리 source (`stitches`) 는 미감지" {
     var r = try e2eFull(
         std.testing.allocator,

--- a/src/transformer/transformer/emotion.zig
+++ b/src/transformer/transformer/emotion.zig
@@ -42,18 +42,22 @@ const transformer_mod = @import("../transformer.zig");
 const Transformer = transformer_mod.Transformer;
 const Error = Transformer.Error;
 
-/// emotion `css` import source 문자열 — 흔한 4가지 entry 모두 인정.
+/// emotion `css` / `keyframes` named import 가 export 되는 source 들.
 pub const EMOTION_CSS_SOURCES: []const []const u8 = &.{
     "@emotion/react",
     "@emotion/css",
     "@emotion/core", // legacy v10
     "@emotion/native", // RN
+    "@emotion/primitives", // RN primitives
+    "@emotion/primitives-core", // RN primitives 의 core
 };
 
-/// emotion `styled` default import source 문자열.
+/// emotion default `styled` import 가 export 되는 source 들.
 pub const EMOTION_STYLED_SOURCES: []const []const u8 = &.{
     "@emotion/styled",
     "@emotion/native", // @emotion/native 는 default styled 도 export
+    "@emotion/primitives", // RN primitives 도 default styled
+    "@emotion/styled-base", // 저레벨 패키지 — 일부 사용자 직접 import
 };
 
 fn isInList(source: []const u8, list: []const []const u8) bool {


### PR DESCRIPTION
## Summary

emotion source list 확장 — RN primitives + 저레벨 패키지 사용자도 autoLabel 혜택.

## 추가된 source

### `EMOTION_CSS_SOURCES` (named css/keyframes)
- `@emotion/primitives` — RN primitives
- `@emotion/primitives-core` — primitives 의 internal core

### `EMOTION_STYLED_SOURCES` (default styled)
- `@emotion/primitives` — RN primitives 의 default styled
- `@emotion/styled-base` — 저레벨 패키지, 일부 사용자 직접 import

## 인식 매트릭스 (emotion 누적)

| source | css/keyframes | styled |
|---|---|---|
| `@emotion/react` | ✅ | ❌ |
| `@emotion/css` | ✅ | ❌ |
| `@emotion/core` (legacy v10) | ✅ | ❌ |
| `@emotion/native` | ✅ | ✅ |
| `@emotion/primitives` | ✅ **(이번 PR)** | ✅ **(이번 PR)** |
| `@emotion/primitives-core` | ✅ **(이번 PR)** | ❌ |
| `@emotion/styled` | ❌ | ✅ |
| `@emotion/styled-base` | ❌ | ✅ **(이번 PR)** |

## 검증

- ✅ `zig build test`: 4193/4193 pass (2 신규)

## 후속 PR (이전 PR 들의 미해결 항목)

- [ ] `<div css={...}>` JSX inline css prop autoLabel — JSX lowering 인터셉트 필요
- [ ] emotion sourceMap (label 에 source location)
- [ ] styled-components `labelFormat` / `namespace` / `pure` 옵션
- [ ] styled-components `transpileTemplateLiterals` (ES5 target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)