### PR TITLE
feat(transformer): emotion JSX inline css autoLabel

### DIFF
--- a/src/transformer/emotion_test.zig
+++ b/src/transformer/emotion_test.zig
@@ -263,3 +263,114 @@ test "emotion: tag 가 css.something 같은 chain 이면 미인식" {
     defer r.deinit();
     try std.testing.expect(std.mem.indexOf(u8, r.output, "label:") == null);
 }
+
+test "emotion: JSX inline `<div css={css`...`}>` autoLabel — element 이름 prepend" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const el = <div css={css`color: red;`} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "div");
+    // 원본 css 보존
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "color: red;") != null);
+}
+
+test "emotion: JSX inline `<Button css={css`...`}>` — Component 이름 prepend" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const el = <Button css={css`color: red;`} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "Button");
+}
+
+test "emotion: JSX inline css — emotion_auto_label=false 면 skip" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const el = <div css={css`color: red;`} />;
+    ,
+        .{ .emotion = true, .emotion_auto_label = false, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "label:") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "color: red;") != null);
+}
+
+test "emotion: JSX 의 css 와 다른 attr 동시 — css 만 label 추가" {
+    // pair-test: 같은 element 에 className+css 둘 다 있을 때 css 만 처리되는지.
+    // label 갯수 1 이어야 함 — css 는 인식, className 은 인식 안 됨.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const el = <div className={css`padding: 8px;`} css={css`color: red;`} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // label:div; 가 정확히 1번 — css attr 의 value 에만.
+    var count: usize = 0;
+    var search_from: usize = 0;
+    while (std.mem.indexOfPos(u8, r.output, search_from, "label:div;")) |pos| {
+        count += 1;
+        search_from = pos + 1;
+    }
+    try std.testing.expectEqual(@as(usize, 1), count);
+}
+
+test "emotion: JSX inline css — 보간 있는 css 도 첫 quasi 에 prepend" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const el = <div css={css`color: ${color}; padding: 8px;`} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "div");
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "${color}") != null);
+}
+
+test "emotion: JSX inline css — non-emotion tag (`<div css={foo`...`}>`) 미인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\const foo = (s) => s;
+        \\const el = <div css={foo`color: red;`} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "label:") == null);
+}
+
+test "emotion: JSX inline css — classic runtime 에서도 동작" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const el = <div css={css`color: red;`} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .classic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "div");
+}

--- a/src/transformer/jsx_lowering.zig
+++ b/src/transformer/jsx_lowering.zig
@@ -24,6 +24,7 @@ const CallFlags = ast_mod.CallFlags;
 const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
 const helpers = @import("es_helpers.zig");
+const emotion = @import("transformer/emotion.zig");
 
 /// JSX 런타임 모드 (codegen의 JsxRuntime을 그대로 사용)
 pub const JsxRuntime = @import("../codegen/codegen.zig").JsxRuntime;
@@ -182,7 +183,7 @@ pub fn JsxLowering(comptime Transformer: type) type {
             const tag_arg = try lowerTagName(self, tag_name_idx);
 
             // 2nd arg: props object or null
-            const props_arg = try buildClassicProps(self, attrs_start, attrs_len, span);
+            const props_arg = try buildClassicProps(self, attrs_start, attrs_len, span, tag_name_idx);
 
             // remaining args: children
             const children = try collectChildren(self, children_start, children_len);
@@ -268,7 +269,7 @@ pub fn JsxLowering(comptime Transformer: type) type {
             const tag_arg = try lowerTagName(self, tag_name_idx);
 
             // 2nd arg: props object { ...attrs(key제외), children }
-            const props_arg = try buildAutomaticProps(self, attrs_start, attrs_len, children_start, children_len, key_result.key_idx, effective_children, span);
+            const props_arg = try buildAutomaticProps(self, attrs_start, attrs_len, children_start, children_len, key_result.key_idx, effective_children, span, tag_name_idx);
 
             const scratch_top = self.scratch.items.len;
             defer self.scratch.shrinkRetainingCapacity(scratch_top);
@@ -343,7 +344,7 @@ pub fn JsxLowering(comptime Transformer: type) type {
             const fragment_ref = try helpers.makeIdentifierRef(self, "_Fragment");
 
             // props: {children: ...} or {}
-            const props_arg = try buildAutomaticProps(self, 0, 0, children_start, children_len, null, effective_children, span);
+            const props_arg = try buildAutomaticProps(self, 0, 0, children_start, children_len, null, effective_children, span, .none);
 
             const scratch_top = self.scratch.items.len;
             defer self.scratch.shrinkRetainingCapacity(scratch_top);
@@ -395,7 +396,7 @@ pub fn JsxLowering(comptime Transformer: type) type {
             const tag_arg = try lowerTagName(self, tag_name_idx);
 
             // classic-style props (key 포함)
-            const props_arg = try buildClassicProps(self, attrs_start, attrs_len, span);
+            const props_arg = try buildClassicProps(self, attrs_start, attrs_len, span, tag_name_idx);
 
             const children = try collectChildren(self, children_start, children_len);
 
@@ -509,7 +510,7 @@ pub fn JsxLowering(comptime Transformer: type) type {
         // ================================================================
 
         /// Classic 모드: attrs → {key: val, ...} or null
-        fn buildClassicProps(self: *Transformer, attrs_start: u32, attrs_len: u32, span: Span) Transformer.Error!NodeIndex {
+        fn buildClassicProps(self: *Transformer, attrs_start: u32, attrs_len: u32, span: Span, element_tag_idx: NodeIndex) Transformer.Error!NodeIndex {
             if (attrs_len == 0) return makeNullLiteral(self, span);
 
             const scratch_top = self.scratch.items.len;
@@ -520,7 +521,7 @@ pub fn JsxLowering(comptime Transformer: type) type {
             while (j < attrs_len) : (j += 1) {
                 const raw_idx = self.ast.extra_data.items[attrs_start + j];
                 const attr = self.ast.getNode(@enumFromInt(raw_idx));
-                const prop = try lowerAttribute(self, attr, span);
+                const prop = try lowerAttribute(self, attr, span, element_tag_idx);
                 if (!prop.isNone()) {
                     try self.scratch.append(self.allocator, prop);
                 }
@@ -542,6 +543,7 @@ pub fn JsxLowering(comptime Transformer: type) type {
             key_idx: ?u32,
             effective_children: u32,
             span: Span,
+            element_tag_idx: NodeIndex,
         ) Transformer.Error!NodeIndex {
             const has_attrs = attrs_len > (if (key_idx != null) @as(u32, 1) else @as(u32, 0));
 
@@ -566,7 +568,7 @@ pub fn JsxLowering(comptime Transformer: type) type {
                     if (key_idx != null and j == key_idx.?) continue;
                     const raw_idx = self.ast.extra_data.items[attrs_start + j];
                     const attr = self.ast.getNode(@enumFromInt(raw_idx));
-                    const prop = try lowerAttribute(self, attr, span);
+                    const prop = try lowerAttribute(self, attr, span, element_tag_idx);
                     if (!prop.isNone()) {
                         try self.scratch.append(self.allocator, prop);
                     }
@@ -631,9 +633,9 @@ pub fn JsxLowering(comptime Transformer: type) type {
         // ================================================================
 
         /// JSX attribute → object_property or spread_element
-        fn lowerAttribute(self: *Transformer, attr: Node, span: Span) Transformer.Error!NodeIndex {
+        fn lowerAttribute(self: *Transformer, attr: Node, span: Span, element_tag_idx: NodeIndex) Transformer.Error!NodeIndex {
             if (attr.tag == .jsx_attribute) {
-                return lowerJSXAttribute(self, attr, span);
+                return lowerJSXAttribute(self, attr, span, element_tag_idx);
             } else if (attr.tag == .jsx_spread_attribute) {
                 // {...props} → spread_element
                 const inner = try self.visitNode(attr.data.unary.operand);
@@ -648,7 +650,7 @@ pub fn JsxLowering(comptime Transformer: type) type {
 
         /// jsx_attribute: binary = {left=name, right=value}
         /// → object_property: binary = {left=key, right=val}
-        fn lowerJSXAttribute(self: *Transformer, attr: Node, span: Span) Transformer.Error!NodeIndex {
+        fn lowerJSXAttribute(self: *Transformer, attr: Node, span: Span, element_tag_idx: NodeIndex) Transformer.Error!NodeIndex {
             _ = span;
             const name_idx = attr.data.binary.left;
             const value_idx = attr.data.binary.right;
@@ -676,15 +678,22 @@ pub fn JsxLowering(comptime Transformer: type) type {
                 });
             };
 
+            // emotion autoLabel hook — visitNode 전에 실행해야 binding 이 없는 inline
+            // tagged_template_expression 의 label source (element 이름) 를 식별 가능.
+            const effective_value_idx = if (self.options.emotion)
+                try emotion.maybeApplyAutoLabelForJsxAttr(self, name_text, value_idx, element_tag_idx)
+            else
+                value_idx;
+
             // value: 없으면 true
-            const val_node = if (value_idx.isNone()) blk: {
+            const val_node = if (effective_value_idx.isNone()) blk: {
                 const true_span = try self.ast.addString("true");
                 break :blk try self.ast.addNode(.{
                     .tag = .boolean_literal,
                     .span = true_span,
                     .data = .{ .none = 0 },
                 });
-            } else try self.visitNode(value_idx);
+            } else try self.visitNode(effective_value_idx);
 
             return self.ast.addNode(.{
                 .tag = .object_property,

--- a/src/transformer/transformer/emotion.zig
+++ b/src/transformer/transformer/emotion.zig
@@ -165,6 +165,39 @@ pub fn maybeApplyAutoLabel(self: *Transformer, init_idx: NodeIndex, var_name: []
     });
 }
 
+/// JSX attribute value autoLabel hook — `lowerJSXAttribute` 에서 호출.
+///
+/// `<X css={css\`...\`}>` 처럼 binding 이 없는 inline 시나리오를 위해 element 이름을
+/// label source 로 사용한다. `<Button css={...}>` → `label:Button;`,
+/// `<div css={...}>` → `label:div;`.
+///
+/// 처리 흐름:
+///   1. attribute 이름이 `css` 가 아니면 통과
+///   2. parser 가 attribute value 에는 jsx_expression_container 를 만들지 않고
+///      내부 expression 을 직접 저장 (parser/jsx.zig:301-325). value 가
+///      tagged_template_expression 이 아니면 통과.
+///   3. element label 추출 후 `maybeApplyAutoLabel` 로 template 변형 (emotion + autoLabel
+///      옵션 검사도 거기서 수행).
+pub fn maybeApplyAutoLabelForJsxAttr(
+    self: *Transformer,
+    attr_name: []const u8,
+    value_idx: NodeIndex,
+    tag_name_idx: NodeIndex,
+) Error!NodeIndex {
+    if (!std.mem.eql(u8, attr_name, "css")) return value_idx;
+    if (value_idx.isNone()) return value_idx;
+    const label = jsxElementLabel(self, tag_name_idx) orelse return value_idx;
+    return try maybeApplyAutoLabel(self, value_idx, label);
+}
+
+/// JSX element label 추출. jsx_identifier 만 — member/namespaced 는 후속 PR.
+fn jsxElementLabel(self: *Transformer, tag_name_idx: NodeIndex) ?[]const u8 {
+    if (tag_name_idx.isNone()) return null;
+    const tag_node = self.ast.getNode(tag_name_idx);
+    if (tag_node.tag != .jsx_identifier) return null;
+    return self.ast.getText(tag_node.span);
+}
+
 /// tag 가 emotion 인식 패턴인지 확인.
 ///   - `css\`...\`` / `keyframes\`...\`` — 직접 identifier 만
 ///   - `styled.X\`...\`` / `styled(X)\`...\`` / `styled.div.withComponent(...)\`...\`` —


### PR DESCRIPTION
## 배경

PR #2253 (emotion source list 확장) 머지 후 사용자 피드백:

> JSX runtime 인터셉트 / 무명 tagged template 둘 다 큰 작업. 대신 emotion source list 확장 (간단/안전). 이게 나아요? 루트커즈는 뭔데요?
> 루트커즈로 잡고 가는게 낫지 않아요? 명확하게 해결 가능하다면 그렇게 하시죠

⇒ 본 PR 은 그동안 우회해 온 root cause 를 정타로 처리.

## Root cause

`jsx_transform=true` 일 때 `jsx_element` 가 `transformer.zig:899-901` 에서 `lowerJSXElement` 로 직접 dispatch 됨 — `visitJSXOpeningElement` 우회. 이 때문에 OpeningElement hook 만으로는 inline `css={css``}` 를 절대 잡지 못한다.

## 변환

```tsx
// 입력
import { css } from "@emotion/react";
const el = <div css={css`color: red;`} />;

// 출력 (autoLabel)
const el = _jsx("div", { css: css`label:div;color: red;` });
```

`<Button css={...}>` 이면 `label:Button;`. binding 이 없는 inline 시나리오라 element 이름을 label source 로 사용.

## 구현

1. **`emotion.zig`** — `maybeApplyAutoLabelForJsxAttr(name, value, tag)` 추가. attr 이름이 `css` 일 때만 동작, 기존 `maybeApplyAutoLabel` 재사용. element 이름은 `jsxElementLabel` 로 jsx_identifier 에서 추출 (member/namespaced 는 후속).
2. **`jsx_lowering.zig`** — `buildClassicProps` / `buildAutomaticProps` / `lowerAttribute` / `lowerJSXAttribute` 에 `element_tag_idx: NodeIndex` plumbing. `lowerJSXAttribute` 에서 `visitNode` 전에 hook 호출 — visit 후엔 element 이름 정보가 사라져 늦음.
3. **gating** — jsx_lowering 에서 `if (self.options.emotion)` 으로 short-circuit. emotion 비활성 프로젝트는 영향 없음.

## 비-emotion 프로젝트 영향

`options.emotion == false` 일 때 hook 호출 자체가 안 일어남. 추가 비용 = bool load 1회/attribute. 새 기능을 위한 plumbing 만 추가.

## 테스트 (emotion_test.zig +8 케이스)

- `<div css={css`...`}>` / `<Button css={css`...`}>` 양쪽 element label
- 보간 있는 css / classic runtime / autoLabel disable / non-emotion tag (`foo``` `) 미인식
- **pair test** — `<div className={css`...`} css={css`...`}>` 에서 label 정확히 1번 (css 만 인식되는지 양성/음성 동시 검증)

## Out of scope (후속)

- `<Foo.Bar css={...}>` member expression / `<x:y css={...}>` namespaced
- `<div css={[css`a`, css`b`]}>` array 형태
- sourceMap 기반 label (file:line hash)

## 코드 리뷰 (3-agent /simplify)

첫 시도 후 발견된 문제 모두 반영:
- `jsx_expression_container` dead branch 제거 — parser 가 attr value 에는 안 만듦 (parser/jsx.zig:301-325 확인)
- `"css"` magic string 을 emotion.zig 로 이동 — leaky abstraction 제거
- `options.emotion` early-exit 을 jsx_lowering 에 추가 — non-emotion hot path 보호
- className 미인식 테스트 강화 — pair test 로 양성+음성 동시 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)