### PR TITLE
test(integration): emotion v10 격리 fixture + e2e 커버리지 + bundle config 버그 수정

### DIFF
--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -1761,6 +1761,10 @@ async function runBundle(opts, config) {
     jobs: opts.jobs,
     outbase: opts.outbase,
     plugins: plugins.length > 0 ? plugins : undefined,
+    // compiler.styledComponents / compiler.emotion 도 bundle 모드에서 forward.
+    // 누락 시 `zts.config.json` 의 `compiler` 설정이 silently drop 돼 1st-party transform
+    // (autoLabel 등) 이 활성화 안 됨.
+    compiler: config?.compiler,
   };
 
   const result = plugins.length > 0 ? await build(buildOpts) : buildSync(buildOpts);

--- a/src/transformer/emotion_test.zig
+++ b/src/transformer/emotion_test.zig
@@ -74,6 +74,81 @@ test "emotion: @emotion/css source 도 인식" {
     try expectAutoLabel(r.output, "card");
 }
 
+// `@emotion/core` 는 v10 의 메인 entry. v11 에서 `@emotion/react` 로 rename 됨 —
+// 하위호환 유지 차원 (v10 사용자 코드 그대로 동작).
+
+test "emotion: @emotion/core (v10) css 도 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/core";
+        \\const card = css`padding: 8px;`;
+    ,
+        .{ .emotion = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "card");
+}
+
+test "emotion: @emotion/core (v10) keyframes 도 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { keyframes } from "@emotion/core";
+        \\const fadeIn = keyframes`from { opacity: 0; }`;
+    ,
+        .{ .emotion = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "fadeIn");
+}
+
+test "emotion: @emotion/core (v10) css + keyframes 동시 import 도 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css, keyframes } from "@emotion/core";
+        \\const spin = keyframes`from { rotate: 0; }`;
+        \\const card = css`color: red;`;
+    ,
+        .{ .emotion = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "spin");
+    try expectAutoLabel(r.output, "card");
+}
+
+test "emotion: @emotion/core (v10) JSX inline `<div css={css`...`}>` 도 동작" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/core";
+        \\const el = <div css={css`color: red;`} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "div");
+}
+
+test "emotion: @emotion/core (v10) alias `import { css as cx }` 도 추적" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css as cx } from "@emotion/core";
+        \\const button = cx`color: red;`;
+    ,
+        .{ .emotion = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "button");
+}
+
 test "emotion: { autoLabel: false } 옵션 — emotion 활성이지만 label skip" {
     var r = try e2eFull(
         std.testing.allocator,

--- a/tests/integration/fixtures/emotion-v10/.gitignore
+++ b/tests/integration/fixtures/emotion-v10/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+bun.lockb
+package-lock.json

--- a/tests/integration/fixtures/emotion-v10/bun.lock
+++ b/tests/integration/fixtures/emotion-v10/bun.lock
@@ -1,0 +1,150 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "emotion-v10-fixture",
+      "dependencies": {
+        "@emotion/core": "^10.3.1",
+        "@emotion/css": "^10.0.27",
+        "@emotion/styled": "^10.3.0",
+        "react": "^16.14.0",
+      },
+    },
+  },
+  "packages": {
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@emotion/cache": ["@emotion/cache@10.0.29", "", { "dependencies": { "@emotion/sheet": "0.9.4", "@emotion/stylis": "0.8.5", "@emotion/utils": "0.11.3", "@emotion/weak-memoize": "0.2.5" } }, "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ=="],
+
+    "@emotion/core": ["@emotion/core@10.3.1", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@emotion/cache": "^10.0.27", "@emotion/css": "^10.0.27", "@emotion/serialize": "^0.11.15", "@emotion/sheet": "0.9.4", "@emotion/utils": "0.11.3" }, "peerDependencies": { "react": ">=16.3.0" } }, "sha512-447aUEjPIm0MnE6QYIaFz9VQOHSXf4Iu6EWOIqq11EAPqinkSZmfymPTmlOE3QjLv846lH4JVZBUOtwGbuQoww=="],
+
+    "@emotion/css": ["@emotion/css@10.0.27", "", { "dependencies": { "@emotion/serialize": "^0.11.15", "@emotion/utils": "0.11.3", "babel-plugin-emotion": "^10.0.27" } }, "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw=="],
+
+    "@emotion/hash": ["@emotion/hash@0.8.0", "", {}, "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="],
+
+    "@emotion/is-prop-valid": ["@emotion/is-prop-valid@0.8.8", "", { "dependencies": { "@emotion/memoize": "0.7.4" } }, "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA=="],
+
+    "@emotion/memoize": ["@emotion/memoize@0.7.4", "", {}, "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="],
+
+    "@emotion/serialize": ["@emotion/serialize@0.11.16", "", { "dependencies": { "@emotion/hash": "0.8.0", "@emotion/memoize": "0.7.4", "@emotion/unitless": "0.7.5", "@emotion/utils": "0.11.3", "csstype": "^2.5.7" } }, "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg=="],
+
+    "@emotion/sheet": ["@emotion/sheet@0.9.4", "", {}, "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="],
+
+    "@emotion/styled": ["@emotion/styled@10.3.0", "", { "dependencies": { "@emotion/styled-base": "^10.3.0", "babel-plugin-emotion": "^10.0.27" }, "peerDependencies": { "@emotion/core": "^10.0.27", "react": ">=16.3.0" } }, "sha512-GgcUpXBBEU5ido+/p/mCT2/Xx+Oqmp9JzQRuC+a4lYM4i4LBBn/dWvc0rQ19N9ObA8/T4NWMrPNe79kMBDJqoQ=="],
+
+    "@emotion/styled-base": ["@emotion/styled-base@10.3.0", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@emotion/is-prop-valid": "0.8.8", "@emotion/serialize": "^0.11.15", "@emotion/utils": "0.11.3" }, "peerDependencies": { "@emotion/core": "^10.0.28", "react": ">=16.3.0" } }, "sha512-PBRqsVKR7QRNkmfH78hTSSwHWcwDpecH9W6heujWAcyp2wdz/64PP73s7fWS1dIPm8/Exc8JAzYS8dEWXjv60w=="],
+
+    "@emotion/stylis": ["@emotion/stylis@0.8.5", "", {}, "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="],
+
+    "@emotion/unitless": ["@emotion/unitless@0.7.5", "", {}, "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="],
+
+    "@emotion/utils": ["@emotion/utils@0.11.3", "", {}, "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="],
+
+    "@emotion/weak-memoize": ["@emotion/weak-memoize@0.2.5", "", {}, "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@types/parse-json": ["@types/parse-json@4.0.2", "", {}, "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="],
+
+    "babel-plugin-emotion": ["babel-plugin-emotion@10.2.2", "", { "dependencies": { "@babel/helper-module-imports": "^7.0.0", "@emotion/hash": "0.8.0", "@emotion/memoize": "0.7.4", "@emotion/serialize": "^0.11.16", "babel-plugin-macros": "^2.0.0", "babel-plugin-syntax-jsx": "^6.18.0", "convert-source-map": "^1.5.0", "escape-string-regexp": "^1.0.5", "find-root": "^1.1.0", "source-map": "^0.5.7" } }, "sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA=="],
+
+    "babel-plugin-macros": ["babel-plugin-macros@2.8.0", "", { "dependencies": { "@babel/runtime": "^7.7.2", "cosmiconfig": "^6.0.0", "resolve": "^1.12.0" } }, "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg=="],
+
+    "babel-plugin-syntax-jsx": ["babel-plugin-syntax-jsx@6.18.0", "", {}, "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="],
+
+    "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "convert-source-map": ["convert-source-map@1.9.0", "", {}, "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="],
+
+    "cosmiconfig": ["cosmiconfig@6.0.0", "", { "dependencies": { "@types/parse-json": "^4.0.0", "import-fresh": "^3.1.0", "parse-json": "^5.0.0", "path-type": "^4.0.0", "yaml": "^1.7.2" } }, "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg=="],
+
+    "csstype": ["csstype@2.6.21", "", {}, "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
+
+    "find-root": ["find-root@1.1.0", "", {}, "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
+    "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
+
+    "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
+
+    "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+
+    "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
+
+    "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
+
+    "react": ["react@16.14.0", "", { "dependencies": { "loose-envify": "^1.1.0", "object-assign": "^4.1.1", "prop-types": "^15.6.2" } }, "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g=="],
+
+    "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
+
+    "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "source-map": ["source-map@0.5.7", "", {}, "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="],
+
+    "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
+  }
+}

--- a/tests/integration/fixtures/emotion-v10/package.json
+++ b/tests/integration/fixtures/emotion-v10/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "emotion-v10-fixture",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Isolated emotion v10 install for v10 user coverage. v10 packages (@emotion/core 등) 가 v11 (@emotion/react) 와 공존하기 어려운 케이스를 격리.",
+  "dependencies": {
+    "@emotion/core": "^10.3.1",
+    "@emotion/css": "^10.0.27",
+    "@emotion/styled": "^10.3.0",
+    "react": "^16.14.0"
+  }
+}

--- a/tests/integration/tests/emotion-v10.test.ts
+++ b/tests/integration/tests/emotion-v10.test.ts
@@ -38,15 +38,17 @@ const V10_STYLED_PACKAGES = [
 ];
 
 /// v10 fixture 패키지 + emotion config 로 번들. 9× boilerplate 흡수.
+/// 번들이 실패 (exitCode != 0) 하면 stderr 를 포함해 throw — silent 빈 `out` 으로
+/// 다운스트림 assertion 이 헷갈리는 메시지를 내는 것을 방지.
 async function runV10Bundle(opts: {
   source: string;
   config: object;
-  /** 기본 `index.tsx`. 파일명 그대로 entry 가 됨. */
+  /** 기본 `index.ts`. JSX 가 필요하면 `index.tsx` 로 override. */
   entry?: string;
   /** 기본 V10_CSS_PACKAGES. styled 가 필요하면 V10_STYLED_PACKAGES. */
   packages?: string[];
 }): Promise<{ out: string; cleanup: () => Promise<void>; exitCode: number }> {
-  const entry = opts.entry ?? "index.tsx";
+  const entry = opts.entry ?? "index.ts";
   const fixture = await createFixture({
     [entry]: opts.source,
     "zts.config.json": JSON.stringify(opts.config),
@@ -59,7 +61,13 @@ async function runV10Bundle(opts: {
   const result = await runZtsInDir(fixture.dir, ["--bundle", entry, "-o", outFile], {
     bin: "js",
   });
-  const out = result.exitCode === 0 ? await readFile(outFile, "utf-8") : "";
+  if (result.exitCode !== 0) {
+    await fixture.cleanup();
+    throw new Error(
+      `zts bundle failed (exit ${result.exitCode})\nstderr:\n${result.stderr}\nstdout:\n${result.stdout}`,
+    );
+  }
+  const out = await readFile(outFile, "utf-8");
   return { out, cleanup: fixture.cleanup, exitCode: result.exitCode };
 }
 
@@ -81,7 +89,6 @@ describe.skipIf(!hasV10)("Emotion v10 — autoLabel + 번들링", () => {
         const card = css\`color: hotpink; font-size: 20px;\`;
         console.log(card);
       `,
-      entry: "index.ts",
       config: { compiler: { emotion: true } },
     });
     cleanup = r.cleanup;
@@ -97,7 +104,6 @@ describe.skipIf(!hasV10)("Emotion v10 — autoLabel + 번들링", () => {
         const fadeIn = keyframes\`from { opacity: 0; } to { opacity: 1; }\`;
         console.log(fadeIn);
       `,
-      entry: "index.ts",
       config: { compiler: { emotion: true } },
     });
     cleanup = r.cleanup;
@@ -114,7 +120,6 @@ describe.skipIf(!hasV10)("Emotion v10 — autoLabel + 번들링", () => {
         const card = css\`color: red; animation: \${spin} 1s linear;\`;
         console.log(card);
       `,
-      entry: "index.ts",
       config: { compiler: { emotion: true } },
     });
     cleanup = r.cleanup;
@@ -167,6 +172,7 @@ describe.skipIf(!hasV10)("Emotion v10 — autoLabel + 번들링", () => {
         const el = <div css={css\`color: hotpink;\`}>hello</div>;
         console.log(el);
       `,
+      entry: "index.tsx",
       config: { compiler: { emotion: true } },
     });
     cleanup = r.cleanup;
@@ -184,7 +190,6 @@ describe.skipIf(!hasV10)("Emotion v10 — autoLabel + 번들링", () => {
         const card = css\`color: red;\`;
         console.log(card);
       `,
-      entry: "index.ts",
       config: { compiler: { emotion: false } },
     });
     cleanup = r.cleanup;
@@ -202,7 +207,6 @@ describe.skipIf(!hasV10)("Emotion v10 — autoLabel + 번들링", () => {
         const card = css\`color: red;\`;
         console.log(card);
       `,
-      entry: "index.ts",
       config: { compiler: { emotion: { autoLabel: false } } },
     });
     cleanup = r.cleanup;

--- a/tests/integration/tests/emotion-v10.test.ts
+++ b/tests/integration/tests/emotion-v10.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import {
+  createFixture,
+  hasEmotionV10Fixture,
+  EMOTION_V10_FIXTURE_NODE_MODULES,
+  linkNodeModules,
+  runZtsInDir,
+} from "./helpers";
+import { join } from "node:path";
+import { readFile } from "node:fs/promises";
+
+// emotion v10 (legacy) 사용자 커버리지.
+// v10 의 entry (`@emotion/core`) 가 v11 (`@emotion/react`) 와 별도 패키지라 같은
+// node_modules 트리에 공존이 어려움. `tests/integration/fixtures/emotion-v10/` 에
+// 격리 설치 (`bun install`) — fixture 가 없으면 모든 테스트 skip.
+
+const hasV10 = hasEmotionV10Fixture();
+
+const V10_CSS_PACKAGES = [
+  "@emotion/core",
+  "@emotion/css",
+  "@emotion/cache",
+  "@emotion/serialize",
+  "@emotion/sheet",
+  "@emotion/utils",
+  "@emotion/hash",
+  "@emotion/unitless",
+  "@emotion/memoize",
+  "@emotion/stylis",
+  "@emotion/weak-memoize",
+];
+
+const V10_STYLED_PACKAGES = [
+  ...V10_CSS_PACKAGES,
+  "@emotion/styled",
+  "@emotion/styled-base",
+  "@emotion/is-prop-valid",
+];
+
+/// v10 fixture 패키지 + emotion config 로 번들. 9× boilerplate 흡수.
+async function runV10Bundle(opts: {
+  source: string;
+  config: object;
+  /** 기본 `index.tsx`. 파일명 그대로 entry 가 됨. */
+  entry?: string;
+  /** 기본 V10_CSS_PACKAGES. styled 가 필요하면 V10_STYLED_PACKAGES. */
+  packages?: string[];
+}): Promise<{ out: string; cleanup: () => Promise<void>; exitCode: number }> {
+  const entry = opts.entry ?? "index.tsx";
+  const fixture = await createFixture({
+    [entry]: opts.source,
+    "zts.config.json": JSON.stringify(opts.config),
+  });
+  await linkNodeModules(fixture.dir, opts.packages ?? V10_CSS_PACKAGES, {
+    extraRoots: [EMOTION_V10_FIXTURE_NODE_MODULES],
+  });
+
+  const outFile = join(fixture.dir, "out.js");
+  const result = await runZtsInDir(fixture.dir, ["--bundle", entry, "-o", outFile], {
+    bin: "js",
+  });
+  const out = result.exitCode === 0 ? await readFile(outFile, "utf-8") : "";
+  return { out, cleanup: fixture.cleanup, exitCode: result.exitCode };
+}
+
+describe.skipIf(!hasV10)("Emotion v10 — autoLabel + 번들링", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  // ─── @emotion/core (v10 메인 entry) ───
+
+  it("@emotion/core css binding — autoLabel prepend", async () => {
+    const r = await runV10Bundle({
+      source: `
+        import { css } from "@emotion/core";
+        const card = css\`color: hotpink; font-size: 20px;\`;
+        console.log(card);
+      `,
+      entry: "index.ts",
+      config: { compiler: { emotion: true } },
+    });
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.out).toContain("label:card;");
+    expect(r.out).toContain("color: hotpink");
+  });
+
+  it("@emotion/core keyframes — autoLabel prepend", async () => {
+    const r = await runV10Bundle({
+      source: `
+        import { keyframes } from "@emotion/core";
+        const fadeIn = keyframes\`from { opacity: 0; } to { opacity: 1; }\`;
+        console.log(fadeIn);
+      `,
+      entry: "index.ts",
+      config: { compiler: { emotion: true } },
+    });
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.out).toContain("label:fadeIn;");
+    expect(r.out).toContain("opacity: 0");
+  });
+
+  it("@emotion/core css + keyframes 동시 import — 양쪽 다 인식", async () => {
+    const r = await runV10Bundle({
+      source: `
+        import { css, keyframes } from "@emotion/core";
+        const spin = keyframes\`from { rotate: 0; } to { rotate: 360deg; }\`;
+        const card = css\`color: red; animation: \${spin} 1s linear;\`;
+        console.log(card);
+      `,
+      entry: "index.ts",
+      config: { compiler: { emotion: true } },
+    });
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.out).toContain("label:spin;");
+    expect(r.out).toContain("label:card;");
+  });
+
+  // ─── @emotion/styled v10 (default styled) ───
+
+  it("@emotion/styled v10 — styled.div 도 autoLabel", async () => {
+    const r = await runV10Bundle({
+      source: `
+        import styled from "@emotion/styled";
+        const Btn = styled.div\`color: white; background: dodgerblue;\`;
+        console.log(Btn);
+      `,
+      config: { compiler: { emotion: true } },
+      packages: V10_STYLED_PACKAGES,
+    });
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.out).toContain("label:Btn;");
+    expect(r.out).toContain("dodgerblue");
+  });
+
+  it("@emotion/styled v10 — styled(Component) chain 도 인식", async () => {
+    const r = await runV10Bundle({
+      source: `
+        import styled from "@emotion/styled";
+        const Inner = (props: any) => null;
+        const Wrapped = styled(Inner)\`color: blue;\`;
+        console.log(Wrapped);
+      `,
+      config: { compiler: { emotion: true } },
+      packages: V10_STYLED_PACKAGES,
+    });
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.out).toContain("label:Wrapped;");
+  });
+
+  // ─── JSX inline css prop (v10 jsx pragma 패턴) ───
+
+  it("@emotion/core JSX inline `<div css={css`...`}>` autoLabel", async () => {
+    const r = await runV10Bundle({
+      source: `
+        /** @jsx jsx */
+        import { jsx, css } from "@emotion/core";
+        const el = <div css={css\`color: hotpink;\`}>hello</div>;
+        console.log(el);
+      `,
+      config: { compiler: { emotion: true } },
+    });
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.out).toContain("label:div;");
+    expect(r.out).toContain("hotpink");
+  });
+
+  // ─── 옵션 비활성 / 격리 검증 ───
+
+  it("emotion 비활성 — v10 패키지 import 해도 label 추가 안 됨", async () => {
+    const r = await runV10Bundle({
+      source: `
+        import { css } from "@emotion/core";
+        const card = css\`color: red;\`;
+        console.log(card);
+      `,
+      entry: "index.ts",
+      config: { compiler: { emotion: false } },
+    });
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    // emotion v10 런타임 자체에 `label:` 문자열이 있어 단순 substring 검사로는 부족.
+    // 우리 transform 이 prepend 하는 `label:<var>;` 패턴을 직접 확인.
+    expect(r.out).not.toContain("label:card;");
+    expect(r.out).toContain("color: red");
+  });
+
+  it("autoLabel 명시적 disable — v10 에서도 옵션 존중", async () => {
+    const r = await runV10Bundle({
+      source: `
+        import { css } from "@emotion/core";
+        const card = css\`color: red;\`;
+        console.log(card);
+      `,
+      entry: "index.ts",
+      config: { compiler: { emotion: { autoLabel: false } } },
+    });
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.out).not.toContain("label:card;");
+    expect(r.out).toContain("color: red");
+  });
+
+  it("v10 격리 검증 — fixture 의 @emotion/core 가 v10.x 인지", async () => {
+    const pkgPath = join(EMOTION_V10_FIXTURE_NODE_MODULES, "@emotion/core/package.json");
+    const pkg = JSON.parse(await readFile(pkgPath, "utf-8"));
+    expect(pkg.version).toMatch(/^10\./);
+  });
+});

--- a/tests/integration/tests/helpers.ts
+++ b/tests/integration/tests/helpers.ts
@@ -6,6 +6,9 @@ import { dirname, join, resolve } from "node:path";
 
 const PROJECT_ROOT = resolve(import.meta.dir, "../../..");
 export const ZTS_BIN = join(PROJECT_ROOT, "zig-out/bin/zts");
+/// JS CLI (NAPI 기반). `compiler.emotion` / `compiler.styledComponents` 같은 JS-only
+/// 옵션을 검증하려면 Zig CLI 대신 이 경로를 사용해야 함.
+export const ZTS_JS_CLI = join(PROJECT_ROOT, "packages/core/bin/zts.mjs");
 const INTEGRATION_NODE_MODULES = resolve(import.meta.dir, "../node_modules");
 const LOOKUP_ROOTS = [join(PROJECT_ROOT, "node_modules"), INTEGRATION_NODE_MODULES];
 
@@ -77,14 +80,22 @@ export async function createReactStubFixture(
 ///
 /// symlink 자체는 존재하지 않는 target으로도 생성되므로, 먼저 target 존재를
 /// 확인한 뒤에 심볼릭 링크를 만든다 (broken symlink 방지).
-export async function linkNodeModules(dir: string, packages: string[]): Promise<void> {
+///
+/// `extraRoots` 옵션: 기본 LOOKUP_ROOTS 보다 우선해서 검색할 추가 root.
+/// 격리 fixture (예: emotion v10) 의 node_modules 를 v11 보다 먼저 매칭하기 위함.
+export async function linkNodeModules(
+  dir: string,
+  packages: string[],
+  options: { extraRoots?: string[] } = {},
+): Promise<void> {
+  const roots = [...(options.extraRoots ?? []), ...LOOKUP_ROOTS];
   const nmDir = join(dir, "node_modules");
   await mkdir(nmDir, { recursive: true });
   const scopes = new Set(packages.filter((p) => p.startsWith("@")).map((p) => p.split("/")[0]));
   await Promise.all([...scopes].map((s) => mkdir(join(nmDir, s), { recursive: true })));
   await Promise.all(
     packages.map(async (pkg) => {
-      for (const root of LOOKUP_ROOTS) {
+      for (const root of roots) {
         const target = join(root, pkg);
         try {
           await stat(join(target, "package.json"));
@@ -98,6 +109,24 @@ export async function linkNodeModules(dir: string, packages: string[]): Promise<
       }
     }),
   );
+}
+
+/// emotion v10 격리 fixture (`tests/integration/fixtures/emotion-v10/node_modules`).
+/// `linkNodeModules({ extraRoots: [EMOTION_V10_FIXTURE_NODE_MODULES] })` 형태로 사용.
+export const EMOTION_V10_FIXTURE_NODE_MODULES = resolve(
+  import.meta.dir,
+  "../fixtures/emotion-v10/node_modules",
+);
+
+/// emotion v10 fixture 가 설치돼 있는지 검사 — `bun install` 이 실행됐는지.
+/// CI 에서 fixture install 을 빼먹은 경우 `describe.skipIf` 로 우회 가능.
+export function hasEmotionV10Fixture(): boolean {
+  try {
+    statSync(join(EMOTION_V10_FIXTURE_NODE_MODULES, "@emotion/core/package.json"));
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 interface RunOptions {
@@ -258,11 +287,18 @@ export async function waitForNdjsonLines<T = Record<string, unknown>>(
   );
 }
 
+/// `bin` 옵션:
+///   - `"zig"` (기본) — Zig CLI (`zts` 바이너리). 빠르고 standalone.
+///   - `"js"` — JS CLI (`packages/core/bin/zts.mjs` via bun). NAPI 기반.
+///     `compiler.emotion` / `compiler.styledComponents` 같은 JS-only 옵션이
+///     `zts.config.json` 으로부터 NAPI 로 forward 되는지 검증할 때 사용.
 export async function runZtsInDir(
   dir: string,
   args: string[],
+  options: { bin?: "zig" | "js" } = {},
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-  const proc = spawn({ cmd: [ZTS_BIN, ...args], stdout: "pipe", stderr: "pipe", cwd: dir });
+  const cmd = options.bin === "js" ? ["bun", ZTS_JS_CLI, ...args] : [ZTS_BIN, ...args];
+  const proc = spawn({ cmd, stdout: "pipe", stderr: "pipe", cwd: dir });
   const [stdout, stderr, exitCode] = await Promise.all([
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),


### PR DESCRIPTION
## 배경

emotion 100% 지원 목표 — v10 (legacy) 사용자 케이스 검증. v10 의 `@emotion/core` entry 는 v11 의 `@emotion/react` 와 별도 패키지라 같은 node_modules 트리에 공존이 어려움. **격리 fixture** 로 해결.

## 발견 + 수정한 버그

`packages/core/bin/zts.mjs` 의 `runBundle` 이 `compiler:` 옵션을 forward 누락 — `zts.config.json` 의 `compiler.emotion` / `compiler.styledComponents` 가 **bundle 모드에서 silently drop** 됐다. `zts build` (app 모드) 는 이미 forward 하고 있어 mode 간 split 이 원인. v10 e2e 테스트가 이 버그를 노출.

```diff
  // packages/core/bin/zts.mjs:1764 (runBundle)
+ // compiler.styledComponents / compiler.emotion 도 bundle 모드에서 forward.
+ compiler: config?.compiler,
```

이 버그는 `zts --bundle entry.ts -o out.js` 를 쓰는 모든 사용자 영향. `zts build` 만 쓰던 사용자는 영향 없음.

## 추가 인프라

### 격리 fixture
```
tests/integration/fixtures/emotion-v10/
├── package.json    # @emotion/core@10, @emotion/styled@10, react@16
├── bun.lock        # commit (재현성)
└── .gitignore      # node_modules 제외
```

CI: `cd tests/integration/fixtures/emotion-v10 && bun install` 사전 실행 필요.

### helpers 확장
- `EMOTION_V10_FIXTURE_NODE_MODULES` / `hasEmotionV10Fixture()`
- `linkNodeModules({ extraRoots })` — v10 fixture 를 lookup 우선순위 첫째로
- `runZtsInDir(dir, args, { bin: "zig" | "js" })` — JS CLI (bun + `bin/zts.mjs`) 통한 NAPI 검증 옵션 추가. `compiler.emotion` 같은 JS-only 옵션은 Zig CLI 미노출이라 JS CLI 경로 필수.

## 테스트 커버리지

**유닛 (`emotion_test.zig` +5 케이스)**:
- `@emotion/core` 의 css / keyframes / 동시 import / JSX inline / alias

**통합 (`emotion-v10.test.ts` 9 케이스)** — `runV10Bundle({source, config, packages?})` 헬퍼로 boilerplate 흡수:
- `@emotion/core`: css binding / keyframes / css+keyframes 동시 / JSX inline css (jsx pragma 포함)
- `@emotion/styled` v10: `styled.div` / `styled(Component)` chain
- 옵션: `emotion: false` 비활성 / `emotion.autoLabel: false`
- 격리 검증: fixture 의 `@emotion/core` 가 실제 `^10.` 인지

## 코드 리뷰 (3-agent /simplify)

발견된 모든 P1/P2 반영:

| 이슈 | 수정 |
|---|---|
| `runZtsInDir` / `runZtsJsInDir` 17 줄 byte-for-byte 중복 | `bin` discriminator 통합 |
| v10 통합 테스트 9× boilerplate (~150 줄) | `runV10Bundle` 헬퍼로 흡수 |
| 무의미한 `out.length > 5000` byte count 체크 | 제거 |
| 유닛 테스트 naming `(v10):` 일관성 깨짐 | `@emotion/core (v10)` 형태로 |
| WHAT-narrating 주석 | 의미 있는 WHY 만 유지 |

순효과: +502 / -3 lines, 테스트는 +14 케이스 (유닛 5 + 통합 9).

## 검증

- `zig build test` — 4203/4203 통과
- `bun test tests/emotion-v10.test.ts` — 9/9 통과
- `bun test tests/css-library-smoke.test.ts` (v11 회귀) — 9/9 통과
- `bun test tests/zts-config-bundler.test.ts` (helpers 시그니처 변경 회귀) — 13/13 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)