### PR TITLE
feat(transformer): emotion Global / injectGlobal autoLabel

### DIFF
--- a/src/transformer/emotion_test.zig
+++ b/src/transformer/emotion_test.zig
@@ -477,3 +477,148 @@ test "emotion: JSX inline css — classic runtime 에서도 동작" {
     defer r.deinit();
     try expectAutoLabel(r.output, "div");
 }
+
+// ─── Global / injectGlobal ───
+// 글로벌 스타일 API. `injectGlobal\`...\`` 는 tagged template (binding 추적), `<Global
+// styles={...}>` 는 JSX (element 매칭 + styles attr) — 두 시나리오 다 처리.
+
+test "emotion: injectGlobal binding form 도 autoLabel" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { injectGlobal } from "@emotion/css";
+        \\const reset = injectGlobal`* { box-sizing: border-box; }`;
+    ,
+        .{ .emotion = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "reset");
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "box-sizing: border-box") != null);
+}
+
+test "emotion: injectGlobal alias `import { injectGlobal as ig }` 도 추적" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { injectGlobal as ig } from "@emotion/css";
+        \\const reset = ig`body { margin: 0; }`;
+    ,
+        .{ .emotion = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "reset");
+}
+
+test "emotion: <Global styles={css`...`}> JSX — element 이름 (Global) 으로 label" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { Global, css } from "@emotion/react";
+        \\const el = <Global styles={css`body { color: red; }`} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "Global");
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "color: red") != null);
+}
+
+test "emotion: <Global> alias `import { Global as G }` 도 element 매칭" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { Global as G, css } from "@emotion/react";
+        \\const el = <G styles={css`body { margin: 0; }`} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // alias 된 이름 "G" 가 label 로 사용 (사용자가 코드에서 보는 이름)
+    try expectAutoLabel(r.output, "G");
+}
+
+test "emotion: 비-Global element 의 styles attr 은 미인식 — false-positive 방지" {
+    // `styles` 는 너무 일반적이라 다른 라이브러리/사용자 컴포넌트와 충돌 위험.
+    // global_binding 매칭 시에만 처리.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const el = <SomeComponent styles={css`color: red;`} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // Global binding 이 import 되지 않았으므로 SomeComponent.styles 는 처리 안 됨
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "label:") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "color: red") != null);
+}
+
+test "emotion: Global import 없이 <Global> 만 사용 — 미인식 (binding 없음)" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const el = <Global styles={css`body { color: red; }`} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // emotion 의 Global 을 import 안 했으므로 styles attr 처리 안 됨
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "label:Global;") == null);
+}
+
+test "emotion: <Global styles={css`color: ${x};`}> 보간 있는 styles 도 처리" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { Global, css } from "@emotion/react";
+        \\const el = <Global styles={css`color: ${color}; padding: 8px;`} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "Global");
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "${color}") != null);
+}
+
+test "emotion: bare `injectGlobal`...`` (binding 없음) — no-op 으로 통과" {
+    // 흔한 사용 패턴: side-effect call. binding 이 없으니 autoLabel 적용 안 됨 — 하지만
+    // 변환이 깨지거나 크래시 나면 안 됨.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { injectGlobal } from "@emotion/css";
+        \\injectGlobal`* { box-sizing: border-box; }`;
+    ,
+        .{ .emotion = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // binding 없으므로 label 없음
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "label:") == null);
+    // 원본 css 보존
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "box-sizing: border-box") != null);
+}
+
+test "emotion: <Global css={...}> 는 css attr 로 처리 (styles 가 아니라)" {
+    // Global 이라도 css attr 을 쓰면 일반 inline css 경로 — 정상 동작 확인.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { Global, css } from "@emotion/react";
+        \\const el = <Global css={css`color: red;`} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "Global");
+}

--- a/src/transformer/plugin_state.zig
+++ b/src/transformer/plugin_state.zig
@@ -75,6 +75,16 @@ pub const EmotionState = struct {
     /// `keyframes\`...\`` 도 첫 quasi 에 label prepend — emotion 런타임이 animation name
     /// 으로 사용.
     keyframes_binding: ?[]const u8 = null,
+
+    /// `import { injectGlobal } from "@emotion/css"` 의 local binding 이름 (alias 포함).
+    /// `const X = injectGlobal\`...\`` 형태에서 첫 quasi 에 `label:X;` prepend.
+    /// 일반적으로 side-effect call 로 쓰이지만 binding 형태도 유효한 사용 패턴.
+    inject_global_binding: ?[]const u8 = null,
+
+    /// `import { Global } from "@emotion/react"` 의 local binding 이름 (alias 포함).
+    /// `<Global styles={css\`...\`} />` JSX element 의 `styles` attr 에 element 이름
+    /// 기반 label prepend (`label:Global;`).
+    global_binding: ?[]const u8 = null,
 };
 
 pub const StyledComponentsState = struct {

--- a/src/transformer/transformer/emotion.zig
+++ b/src/transformer/transformer/emotion.zig
@@ -75,6 +75,28 @@ pub fn isEmotionStyledSource(source: []const u8) bool {
     return isInList(source, EMOTION_STYLED_SOURCES);
 }
 
+/// emotion named-import (`{ X }` 형태) 별 EmotionState 필드 매핑. 새 named API 가
+/// 추가되면 여기에 한 줄만 더하면 import 인식 + tagMatchesEmotion (해당 시) 까지 자동.
+const NamedImportSpec = struct {
+    imported: []const u8,
+    field: []const u8,
+};
+
+const NAMED_IMPORT_SPECS = [_]NamedImportSpec{
+    .{ .imported = "css", .field = "css_binding" },
+    .{ .imported = "keyframes", .field = "keyframes_binding" },
+    .{ .imported = "injectGlobal", .field = "inject_global_binding" },
+    .{ .imported = "Global", .field = "global_binding" },
+};
+
+/// `tagMatchesEmotion` 의 identifier 형태 매칭에 참여하는 binding 필드들.
+/// `Global` 은 JSX element 매칭이라 제외, `styled` 는 chain 처리라 제외.
+const TAG_BINDING_FIELDS = [_][]const u8{
+    "css_binding",
+    "keyframes_binding",
+    "inject_global_binding",
+};
+
 /// `visitImportDeclaration` hook — emotion source 의 `{ css }` named specifier 또는
 /// `@emotion/styled` 의 default specifier 를 binding 으로 저장.
 pub fn detectEmotionImport(self: *Transformer, node: Node) Error!void {
@@ -116,10 +138,13 @@ pub fn detectEmotionImport(self: *Transformer, node: Node) Error!void {
                 if (local_node.tag != .identifier_reference and local_node.tag != .binding_identifier) continue;
                 const local_name = self.ast.getText(local_node.data.string_ref);
                 if (local_name.len == 0) continue;
-                if (std.mem.eql(u8, imported_name, "css") and self.plugins.emotion.css_binding == null) {
-                    self.plugins.emotion.css_binding = local_name;
-                } else if (std.mem.eql(u8, imported_name, "keyframes") and self.plugins.emotion.keyframes_binding == null) {
-                    self.plugins.emotion.keyframes_binding = local_name;
+                inline for (NAMED_IMPORT_SPECS) |spec| {
+                    if (std.mem.eql(u8, imported_name, spec.imported) and
+                        @field(self.plugins.emotion, spec.field) == null)
+                    {
+                        @field(self.plugins.emotion, spec.field) = local_name;
+                        break;
+                    }
                 }
             },
             else => {},
@@ -171,27 +196,41 @@ pub fn maybeApplyAutoLabel(self: *Transformer, init_idx: NodeIndex, var_name: []
 
 /// JSX attribute value autoLabel hook — `lowerJSXAttribute` 에서 호출.
 ///
-/// `<X css={css\`...\`}>` 처럼 binding 이 없는 inline 시나리오를 위해 element 이름을
-/// label source 로 사용한다. `<Button css={...}>` → `label:Button;`,
-/// `<div css={...}>` → `label:div;`.
+/// 두 가지 시나리오 처리:
+///   1. **모든 element 의 `css` attr** — `<Button css={css\`...\`}>` → `label:Button;`,
+///      `<div css={css\`...\`}>` → `label:div;`.
+///   2. **`<Global>` element 의 `styles` attr** — `<Global styles={css\`...\`}>` →
+///      `label:Global;` (alias 시 alias 이름). emotion 이 import 한 `Global` binding 과
+///      element name 이 일치할 때만 `styles` 를 인식 — `styles` 자체는 너무 일반적이라
+///      false-positive 위험 (다른 라이브러리의 styles prop) 방지.
 ///
-/// 처리 흐름:
-///   1. attribute 이름이 `css` 가 아니면 통과
-///   2. parser 가 attribute value 에는 jsx_expression_container 를 만들지 않고
-///      내부 expression 을 직접 저장 (parser/jsx.zig:301-325). value 가
-///      tagged_template_expression 이 아니면 통과.
-///   3. element label 추출 후 `maybeApplyAutoLabel` 로 template 변형 (emotion + autoLabel
-///      옵션 검사도 거기서 수행).
+/// 공통 흐름: parser 가 attribute value 에 jsx_expression_container 를 만들지 않고
+/// 내부 expression 을 직접 저장 (parser/jsx.zig:301-325). label 추출 후 기존
+/// `maybeApplyAutoLabel` 로 template 변형 (emotion + autoLabel 옵션 검사도 거기서).
 pub fn maybeApplyAutoLabelForJsxAttr(
     self: *Transformer,
     attr_name: []const u8,
     value_idx: NodeIndex,
     tag_name_idx: NodeIndex,
 ) Error!NodeIndex {
-    if (!std.mem.eql(u8, attr_name, "css")) return value_idx;
+    // hot path: 모든 JSX attribute (className/onClick/id/...) 마다 호출 — attr-name
+    // 빠른 reject 를 AST 접근 (`jsxElementLabel`) 보다 먼저 수행.
+    const is_css = std.mem.eql(u8, attr_name, "css");
+    const is_styles = std.mem.eql(u8, attr_name, "styles");
+    if (!is_css and !is_styles) return value_idx;
     if (value_idx.isNone()) return value_idx;
+
     const label = jsxElementLabel(self, tag_name_idx) orelse return value_idx;
+    const is_global_styles = is_styles and elementMatchesGlobal(self, label);
+    if (!is_css and !is_global_styles) return value_idx;
+
     return try maybeApplyAutoLabel(self, value_idx, label);
+}
+
+/// JSX element 이름 (label) 이 import 된 `Global` binding 과 일치하는지.
+fn elementMatchesGlobal(self: *Transformer, element_label: []const u8) bool {
+    const binding = self.plugins.emotion.global_binding orelse return false;
+    return std.mem.eql(u8, element_label, binding);
 }
 
 /// JSX element label 추출. jsx_identifier 만 — member/namespaced 는 후속 PR.
@@ -215,11 +254,10 @@ fn tagMatchesEmotion(self: *Transformer, tag_idx: NodeIndex) bool {
     // 의 `css` 는 member API 가 없어 chain 시 부정확한 라벨 위험).
     if (tag_node.tag == .identifier_reference) {
         const text = self.ast.getText(tag_node.data.string_ref);
-        if (state.css_binding) |b| {
-            if (std.mem.eql(u8, text, b)) return true;
-        }
-        if (state.keyframes_binding) |b| {
-            if (std.mem.eql(u8, text, b)) return true;
+        inline for (TAG_BINDING_FIELDS) |field_name| {
+            if (@field(state, field_name)) |b| {
+                if (std.mem.eql(u8, text, b)) return true;
+            }
         }
         return false;
     }

--- a/tests/integration/tests/emotion-v10.test.ts
+++ b/tests/integration/tests/emotion-v10.test.ts
@@ -215,6 +215,40 @@ describe.skipIf(!hasV10)("Emotion v10 — autoLabel + 번들링", () => {
     expect(r.out).toContain("color: red");
   });
 
+  // ─── Global / injectGlobal (v10) ───
+
+  it("@emotion/css v10 — injectGlobal binding autoLabel", async () => {
+    const r = await runV10Bundle({
+      source: `
+        import { injectGlobal } from "@emotion/css";
+        const reset = injectGlobal\`* { box-sizing: border-box; }\`;
+        console.log(reset);
+      `,
+      config: { compiler: { emotion: true } },
+    });
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.out).toContain("label:reset;");
+    expect(r.out).toContain("box-sizing: border-box");
+  });
+
+  it("@emotion/core v10 — <Global styles={css`...`}> autoLabel", async () => {
+    const r = await runV10Bundle({
+      source: `
+        /** @jsx jsx */
+        import { jsx, css, Global } from "@emotion/core";
+        const el = <Global styles={css\`body { color: red; }\`} />;
+        console.log(el);
+      `,
+      entry: "index.tsx",
+      config: { compiler: { emotion: true } },
+    });
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.out).toContain("label:Global;");
+    expect(r.out).toContain("color: red");
+  });
+
   it("v10 격리 검증 — fixture 의 @emotion/core 가 v10.x 인지", async () => {
     const pkgPath = join(EMOTION_V10_FIXTURE_NODE_MODULES, "@emotion/core/package.json");
     const pkg = JSON.parse(await readFile(pkgPath, "utf-8"));


### PR DESCRIPTION
## 변환 의도

emotion 의 글로벌 스타일 API 두 가지에 autoLabel 적용 — DevTools/번들에서 글로벌 스타일 출처를 추적 가능.

```tsx
// 입력
import { injectGlobal } from "@emotion/css";
import { Global, css } from "@emotion/react";

const reset = injectGlobal`* { box-sizing: border-box; }`;
const el = <Global styles={css`body { color: red; }`} />;

// 출력
const reset = injectGlobal`label:reset;* { box-sizing: border-box; }`;
const el = _jsx(Global, { styles: css`label:Global;body { color: red; }` });
```

## 두 가지 시나리오

### `injectGlobal` (tagged template)

`css`/`keyframes` 와 동일한 binding 패턴 — `tagMatchesEmotion` 에 추가만 하면 기존 `maybeApplyAutoLabel` 이 작동. binding 없는 bare call (`injectGlobal\`\`` 만) 은 no-op (안전 통과).

### `<Global styles={...}>` (JSX)

기존 JSX inline css hook (`maybeApplyAutoLabelForJsxAttr`) 확장. **`styles` attr 은 element 가 emotion 의 `Global` binding 과 매칭될 때만 처리** — `styles` 자체는 너무 일반적이라 다른 라이브러리/사용자 컴포넌트 false-positive 위험.

```ts
// 인식
import { Global } from "@emotion/react";
<Global styles={css`...`} />              // ✅ label:Global

// alias 도 추적
import { Global as G } from "@emotion/react";
<G styles={css`...`} />                   // ✅ label:G

// 미인식 (의도적)
<SomeComponent styles={css`...`} />       // ❌ Global binding 없음
<Global styles={css`...`} />              // ❌ Global import 안 했으면 처리 안 함
```

## 구조 정리

다음 emotion named API 추가 (`isPropValid` 등) 시 비용 최소화:

- `EmotionState` 에 `inject_global_binding` / `global_binding` 필드 추가
- `detectEmotionImport` 의 4-way `if/else if` → comptime `NAMED_IMPORT_SPECS` table + `inline for` + `@field`. 추가 = 1 줄
- `tagMatchesEmotion` 의 3-way binding 체크 → comptime `TAG_BINDING_FIELDS` table

## Hot-path 효율 fix

이전: `maybeApplyAutoLabelForJsxAttr` 가 모든 JSX attr 마다 `jsxElementLabel` (AST `getNode` + tag check) 호출.

이후: attr-name 빠른 reject (`is_css || is_styles`) 를 AST 접근 앞으로 이동. ~95% 의 attr (className/onClick/id/...) 은 2번의 `mem.eql` 만으로 단락.

## 테스트

**유닛 (+9 케이스)**:
- `injectGlobal` binding / alias 추적
- `<Global>` 매칭 / alias / non-Global element 의 styles 무시 / Global import 없을 때 미인식 / Global 의 css attr 도 정상
- 보간 있는 styles
- bare `injectGlobal` call (binding 없음) — no-op

**통합 (+2 v10 케이스)**:
- `@emotion/css` v10 injectGlobal 실제 번들
- `@emotion/core` v10 `<Global>` 실제 번들 (jsx pragma 포함)

## 코드 리뷰 (3-agent /simplify)

발견 P1 모두 반영:
- Hot-path: attr-name reject 를 AST 접근 앞으로
- Reuse: 4-way + 3-way 체인 → comptime table 통합
- Coverage: Global+interpolation / bare injectGlobal call 누락 보강

## 검증

- `zig build test` 통과 (4203/4203 + 신규 9 케이스)
- `bun test tests/emotion-v10.test.ts` 11/11 통과 (기존 9 + 신규 2)
- v11 회귀 (`css-library-smoke.test.ts`) 9/9 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)