### PR TITLE
feat(transformer): emotion JSX member expression autoLabel

### DIFF
--- a/src/transformer/emotion_test.zig
+++ b/src/transformer/emotion_test.zig
@@ -608,6 +608,55 @@ test "emotion: bare `injectGlobal`...`` (binding 없음) — no-op 으로 통과
     try std.testing.expect(std.mem.indexOf(u8, r.output, "box-sizing: border-box") != null);
 }
 
+// ─── JSX member expression ───
+// `<Components.Button css={...}>` 같은 member expression 의 rightmost identifier 를
+// label 로 사용 (babel-plugin-emotion 동작과 일치).
+
+test "emotion: JSX member `<Foo.Bar css={...}>` — rightmost (Bar) 로 label" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const el = <Foo.Bar css={css`color: red;`} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "Bar");
+}
+
+test "emotion: JSX deep member `<Foo.Bar.Baz css={...}>` — rightmost (Baz) 로 label" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const el = <Foo.Bar.Baz css={css`color: red;`} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "Baz");
+}
+
+test "emotion: <Foo.Global styles={...}> false-positive 방지 — member 면 미인식" {
+    // rightmost 가 "Global" 이라도 사용자 컴포넌트의 member 면 emotion Global 이 아님.
+    // 단순 jsx_identifier 만 elementMatchesGlobal 매칭.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { Global, css } from "@emotion/react";
+        \\const el = <Foo.Global styles={css`color: red;`} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // <Foo.Global> 의 styles 는 처리 안 됨 — Foo.Global 은 emotion Global 이 아님
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "label:") == null);
+}
+
 test "emotion: <Global css={...}> 는 css attr 로 처리 (styles 가 아니라)" {
     // Global 이라도 css attr 을 쓰면 일반 inline css 경로 — 정상 동작 확인.
     var r = try e2eFull(

--- a/src/transformer/transformer/emotion.zig
+++ b/src/transformer/transformer/emotion.zig
@@ -221,24 +221,46 @@ pub fn maybeApplyAutoLabelForJsxAttr(
     if (value_idx.isNone()) return value_idx;
 
     const label = jsxElementLabel(self, tag_name_idx) orelse return value_idx;
-    const is_global_styles = is_styles and elementMatchesGlobal(self, label);
+    const is_global_styles = is_styles and elementMatchesGlobal(self, tag_name_idx);
     if (!is_css and !is_global_styles) return value_idx;
 
     return try maybeApplyAutoLabel(self, value_idx, label);
 }
 
-/// JSX element 이름 (label) 이 import 된 `Global` binding 과 일치하는지.
-fn elementMatchesGlobal(self: *Transformer, element_label: []const u8) bool {
+/// JSX element 가 import 된 `Global` binding 과 일치하는지.
+///
+/// **단순 jsx_identifier 만 매칭** — `<Foo.Global>` 같은 member expression 은 거부.
+/// 이유: rightmost 가 "Global" 이라도 사용자 컴포넌트 (`<Foo.Global>`) 가 emotion 의
+/// `Global` 일 가능성은 0 → false-positive 방지. 정식으로 지원하려면 namespace import
+/// (`import * as Em`) 추적이 필요한데 현재 범위 밖.
+fn elementMatchesGlobal(self: *Transformer, tag_name_idx: NodeIndex) bool {
     const binding = self.plugins.emotion.global_binding orelse return false;
-    return std.mem.eql(u8, element_label, binding);
+    if (tag_name_idx.isNone()) return false;
+    const tag_node = self.ast.getNode(tag_name_idx);
+    if (tag_node.tag != .jsx_identifier) return false;
+    return std.mem.eql(u8, self.ast.getText(tag_node.span), binding);
 }
 
-/// JSX element label 추출. jsx_identifier 만 — member/namespaced 는 후속 PR.
+/// JSX element label 추출 — autoLabel 의 source 로 쓰일 이름.
+///
+/// 처리:
+///   - `jsx_identifier` (`<Button>`) → "Button"
+///   - `jsx_member_expression` (`<Foo.Bar>`, `<Foo.Bar.Baz>`) → rightmost identifier
+///     (babel-plugin-emotion 동작과 일치 — 의미 있는 부분이 rightmost).
 fn jsxElementLabel(self: *Transformer, tag_name_idx: NodeIndex) ?[]const u8 {
     if (tag_name_idx.isNone()) return null;
-    const tag_node = self.ast.getNode(tag_name_idx);
-    if (tag_node.tag != .jsx_identifier) return null;
-    return self.ast.getText(tag_node.span);
+    var current = tag_name_idx;
+    while (true) {
+        const node = self.ast.getNode(current);
+        switch (node.tag) {
+            .jsx_identifier => return self.ast.getText(node.span),
+            .jsx_member_expression => {
+                current = node.data.binary.right;
+                if (current.isNone()) return null;
+            },
+            else => return null,
+        }
+    }
 }
 
 /// tag 가 emotion 인식 패턴인지 확인.


### PR DESCRIPTION
## 변환

```tsx
// 입력
import { css } from "@emotion/react";
const el = <Foo.Bar css={css`color: red;`} />;

// 출력
const el = _jsx(Foo.Bar, { css: css`label:Bar;color: red;` });
```

`<Foo.Bar.Baz>` 처럼 deep 도 rightmost (`Baz`) 사용. babel-plugin-emotion 과 동일.

## 구현

- `jsxElementLabel` 가 `jsx_member_expression.right` 를 leaf 까지 descend
- `elementMatchesGlobal` 시그니처 `(label)` → `(tag_name_idx)`. **단순 jsx_identifier 만** 매칭 — `<Foo.Global styles={...}>` 의 rightmost 가 "Global" 이라도 emotion Global 이 아니므로 거부 (false-positive 가드)

## namespace import 미지원

`import * as Em from "@emotion/react"` + `<Em.Global>` 은 별도 작업 (namespace import 추적 필요). 현재는 named import (`import { Global }`) + alias 만.

## 테스트 (+4)

- `<Foo.Bar css={css\`...\`}>` → label:Bar
- `<Foo.Bar.Baz css={css\`...\`}>` → label:Baz
- `<Foo.Global styles={css\`...\`}>` 미인식 (false-positive 가드)

🤖 Generated with [Claude Code](https://claude.com/claude-code)