### PR TITLE
feat(transformer): emotion ClassNames render-prop autoLabel — scope frame infra

### DIFF
--- a/src/transformer/emotion_test.zig
+++ b/src/transformer/emotion_test.zig
@@ -640,6 +640,176 @@ test "emotion: JSX deep member `<Foo.Bar.Baz css={...}>` — rightmost (Baz) 로
     try expectAutoLabel(r.output, "Baz");
 }
 
+// ─── ClassNames render-prop ───
+// `<ClassNames>{({css}) => <div className={css`...`}/>}</ClassNames>` 패턴.
+// destructured `css` 는 import 가 아니라 render-prop 함수 매개변수 — scope frame
+// infra 로 그 함수 안에서만 emotion css 로 인식.
+
+test "emotion: <ClassNames> render-prop 의 destructured css 도 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { ClassNames } from "@emotion/react";
+        \\const el = <ClassNames>{({ css }) => <div className={css`color: red;`} />}</ClassNames>;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "div");
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "color: red") != null);
+}
+
+test "emotion: ClassNames 의 const X = css`...` binding form 도 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { ClassNames } from "@emotion/react";
+        \\const el = <ClassNames>{({ css }) => {
+        \\  const card = css`color: red;`;
+        \\  return <div className={card} />;
+        \\}}</ClassNames>;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // `const card = css`...`` 형태도 scope-local css binding 으로 인식 → label:card
+    try expectAutoLabel(r.output, "card");
+}
+
+test "emotion: ClassNames destructure alias `{ css: cs }` 도 추적" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { ClassNames } from "@emotion/react";
+        \\const el = <ClassNames>{({ css: cs }) => <div className={cs`color: blue;`} />}</ClassNames>;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "div");
+}
+
+test "emotion: ClassNames import alias `import { ClassNames as CN }` 도 추적" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { ClassNames as CN } from "@emotion/react";
+        \\const el = <CN>{({ css }) => <div className={css`color: red;`} />}</CN>;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "div");
+}
+
+test "emotion: ClassNames scope 밖에서는 className attr 처리 안 함" {
+    // `<div className={fn`...`}/>` 가 ClassNames 밖에서는 일반 className 으로 처리 →
+    // autoLabel 적용 안 됨. scope 격리 검증.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const el = <div className={css`color: red;`} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // import 된 css 가 className 에 쓰여도 (ClassNames 밖이므로) 처리 안 됨.
+    // css attr 만 인식 — className 은 ClassNames scope 안에서만.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "label:") == null);
+    // 원본 css 보존
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "color: red") != null);
+}
+
+test "emotion: ClassNames nested — outer/inner scope frame 독립" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { ClassNames } from "@emotion/react";
+        \\const el = <ClassNames>{({ css: outerCss }) =>
+        \\  <ClassNames>{({ css: innerCss }) =>
+        \\    <div className={innerCss`color: red;`} />
+        \\  }</ClassNames>
+        \\}</ClassNames>;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // inner scope frame 의 innerCss 가 우선 — div 에 label 적용됨
+    try expectAutoLabel(r.output, "div");
+}
+
+test "emotion: ClassNames function_expression render-prop 도 인식" {
+    // arrow 가 아닌 function expression 도 처리.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { ClassNames } from "@emotion/react";
+        \\const el = <ClassNames>{function ({ css }) {
+        \\  return <div className={css`color: red;`} />;
+        \\}}</ClassNames>;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "div");
+}
+
+test "emotion: ClassNames render-prop param 이 destructure 아니면 no-op" {
+    // `(props) => ...` 형태는 css local 이 추출 안 됨 → scope frame push 안 함.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { ClassNames } from "@emotion/react";
+        \\const el = <ClassNames>{(props) => <div className={props.css`color: red;`} />}</ClassNames>;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // scope 미진입 — className 처리 안 됨. crash 도 없어야 함.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "label:") == null);
+}
+
+test "emotion: <ClassNames> 에 render-prop child 없어도 crash 없음" {
+    // children 이 text/element/없음 — render-prop 함수 못 찾음 → no-op.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { ClassNames } from "@emotion/react";
+        \\const el = <ClassNames>fallback text</ClassNames>;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "label:") == null);
+}
+
+test "emotion: ClassNames render-prop 안에 import css 가 있어도 scope-local 우선" {
+    // import 된 `css` 와 destructured local `cs` 가 공존 — destructured 가 우선.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css, ClassNames } from "@emotion/react";
+        \\const outer = css`color: blue;`;
+        \\const el = <ClassNames>{({ css: cs }) => <div className={cs`color: red;`} />}</ClassNames>;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "outer"); // import css 의 binding form
+    try expectAutoLabel(r.output, "div"); // ClassNames render-prop 의 className inline
+}
+
 test "emotion: <Foo.Global styles={...}> false-positive 방지 — member 면 미인식" {
     // rightmost 가 "Global" 이라도 사용자 컴포넌트의 member 면 emotion Global 이 아님.
     // 단순 jsx_identifier 만 elementMatchesGlobal 매칭.

--- a/src/transformer/plugin_state.zig
+++ b/src/transformer/plugin_state.zig
@@ -85,6 +85,21 @@ pub const EmotionState = struct {
     /// `<Global styles={css\`...\`} />` JSX element 의 `styles` attr 에 element 이름
     /// 기반 label prepend (`label:Global;`).
     global_binding: ?[]const u8 = null,
+
+    /// `import { ClassNames } from "@emotion/react"` 의 local binding 이름 (alias 포함).
+    /// `<ClassNames>{({css}) => ...}</ClassNames>` render-prop 패턴 인식에 사용.
+    class_names_binding: ?[]const u8 = null,
+
+    /// `<ClassNames>` render-prop 진입 시 push, exit 시 pop 되는 scope frame stack.
+    /// 현재 frame 의 binding 들이 outer (import 기반) binding 보다 우선 적용 →
+    /// destructured local 이름 (`{ css: cs }` 의 `cs`) 도 emotion css 로 인식.
+    scope_stack: std.ArrayList(EmotionScopeFrame) = .empty,
+};
+
+/// `<ClassNames>` render-prop 함수 매개변수에서 destructure 된 local binding 이름들.
+/// css 만 추적 — `cx`/`theme` 는 autoLabel 에 무관.
+pub const EmotionScopeFrame = struct {
+    css_binding: ?[]const u8 = null,
 };
 
 pub const StyledComponentsState = struct {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -586,6 +586,7 @@ pub const Transformer = struct {
         self.plugins.refresh.registrations.deinit(self.allocator);
         for (self.plugins.refresh.signatures.items) |s| self.allocator.free(s.signature);
         self.plugins.refresh.signatures.deinit(self.allocator);
+        self.plugins.emotion.scope_stack.deinit(self.allocator);
         self.trailing_nodes.deinit(self.allocator);
         self.generator_label_stack.deinit(self.allocator);
         self.generator_temp_var_spans.deinit(self.allocator);
@@ -897,6 +898,12 @@ pub const Transformer = struct {
 
             // JSX element/opening_element: .extra 형식 (tag, attrs, children)
             .jsx_element => {
+                // `<ClassNames>{({css}) => ...}</ClassNames>` 진입 시 destructured `css`
+                // 의 local 이름을 scope frame 에 push — render-prop 함수 안의
+                // tagged_template_expression 이 visit 될 때 인식되도록.
+                const pushed_emotion_scope = try emotion_mod.maybeEnterClassNamesScope(self, node);
+                defer if (pushed_emotion_scope) emotion_mod.exitClassNamesScope(self);
+
                 if (self.options.jsx_transform) {
                     return jsx_lowering_mod.JsxLowering(Transformer).lowerJSXElement(self, node);
                 }

--- a/src/transformer/transformer/emotion.zig
+++ b/src/transformer/transformer/emotion.zig
@@ -41,6 +41,7 @@ const import_scanner = @import("../../bundler/import_scanner.zig");
 const transformer_mod = @import("../transformer.zig");
 const Transformer = transformer_mod.Transformer;
 const Error = Transformer.Error;
+const plugin_state = @import("../plugin_state.zig");
 
 /// emotion `css` / `keyframes` named import 가 export 되는 source 들.
 pub const EMOTION_CSS_SOURCES: []const []const u8 = &.{
@@ -87,6 +88,7 @@ const NAMED_IMPORT_SPECS = [_]NamedImportSpec{
     .{ .imported = "keyframes", .field = "keyframes_binding" },
     .{ .imported = "injectGlobal", .field = "inject_global_binding" },
     .{ .imported = "Global", .field = "global_binding" },
+    .{ .imported = "ClassNames", .field = "class_names_binding" },
 };
 
 /// `tagMatchesEmotion` 의 identifier 형태 매칭에 참여하는 binding 필드들.
@@ -217,28 +219,25 @@ pub fn maybeApplyAutoLabelForJsxAttr(
     // 빠른 reject 를 AST 접근 (`jsxElementLabel`) 보다 먼저 수행.
     const is_css = std.mem.eql(u8, attr_name, "css");
     const is_styles = std.mem.eql(u8, attr_name, "styles");
-    if (!is_css and !is_styles) return value_idx;
+    // className 은 ClassNames render-prop scope 안에서만 인식 (밖에서는 일반 className
+    // 이라 절대 처리 금지 — scope_stack 비어있으면 즉시 false).
+    const is_classnames_inline = self.plugins.emotion.scope_stack.items.len > 0 and
+        std.mem.eql(u8, attr_name, "className");
+    if (!is_css and !is_styles and !is_classnames_inline) return value_idx;
     if (value_idx.isNone()) return value_idx;
 
-    const label = jsxElementLabel(self, tag_name_idx) orelse return value_idx;
-    const is_global_styles = is_styles and elementMatchesGlobal(self, tag_name_idx);
-    if (!is_css and !is_global_styles) return value_idx;
+    // styles attr 은 `<Global>` element 일 때만 통과 — 다른 element 에서는 false-positive
+    // 위험 (다른 라이브러리/사용자 컴포넌트의 styles prop).
+    if (is_styles and !elementMatchesGlobal(self, tag_name_idx)) return value_idx;
 
+    const label = jsxElementLabel(self, tag_name_idx) orelse return value_idx;
     return try maybeApplyAutoLabel(self, value_idx, label);
 }
 
-/// JSX element 가 import 된 `Global` binding 과 일치하는지.
-///
-/// **단순 jsx_identifier 만 매칭** — `<Foo.Global>` 같은 member expression 은 거부.
-/// 이유: rightmost 가 "Global" 이라도 사용자 컴포넌트 (`<Foo.Global>`) 가 emotion 의
-/// `Global` 일 가능성은 0 → false-positive 방지. 정식으로 지원하려면 namespace import
-/// (`import * as Em`) 추적이 필요한데 현재 범위 밖.
+/// JSX element 가 import 된 `Global` binding 과 일치하는지 — 단순 identifier 만.
 fn elementMatchesGlobal(self: *Transformer, tag_name_idx: NodeIndex) bool {
     const binding = self.plugins.emotion.global_binding orelse return false;
-    if (tag_name_idx.isNone()) return false;
-    const tag_node = self.ast.getNode(tag_name_idx);
-    if (tag_node.tag != .jsx_identifier) return false;
-    return std.mem.eql(u8, self.ast.getText(tag_node.span), binding);
+    return jsxIdentifierEquals(self, tag_name_idx, binding);
 }
 
 /// JSX element label 추출 — autoLabel 의 source 로 쓰일 이름.
@@ -263,6 +262,111 @@ fn jsxElementLabel(self: *Transformer, tag_name_idx: NodeIndex) ?[]const u8 {
     }
 }
 
+/// `<ClassNames>` JSX element 진입 시 scope frame 을 push.
+/// 반환 true: scope 가 push 됐으니 caller 가 `exitClassNamesScope` 로 pop 책임.
+/// 반환 false: ClassNames 가 아니거나 render-prop 패턴이 아님 → no-op.
+///
+/// 인식하는 패턴:
+/// ```
+/// <ClassNames>
+///   {({ css }) => <div className={css`...`}/>}
+/// </ClassNames>
+/// ```
+/// children 첫 노드가 jsx_expression_container 의 arrow_function/function_expression,
+/// 그 첫 param 이 object_pattern 으로 `css` 를 destructure (alias 도 추적).
+pub fn maybeEnterClassNamesScope(self: *Transformer, jsx_node: ast_mod.Node) Error!bool {
+    if (!self.options.emotion) return false;
+    const binding = self.plugins.emotion.class_names_binding orelse return false;
+
+    // jsx_element extra: [tag_name, attrs_start, attrs_len, children_start, children_len]
+    const e = jsx_node.data.extra;
+    if (!self.ast.hasExtra(e, 4)) return false;
+    const tag_name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+    if (!jsxIdentifierEquals(self, tag_name_idx, binding)) return false;
+
+    const children_start = self.ast.extra_data.items[e + 3];
+    const children_len = self.ast.extra_data.items[e + 4];
+
+    const fn_idx = findRenderPropFunction(self, children_start, children_len) orelse return false;
+    const css_local = extractDestructuredCssLocal(self, fn_idx) orelse return false;
+
+    try self.plugins.emotion.scope_stack.append(
+        self.allocator,
+        .{ .css_binding = css_local },
+    );
+    return true;
+}
+
+/// `maybeEnterClassNamesScope` 가 true 반환했을 때 caller 가 호출 (defer pattern).
+pub fn exitClassNamesScope(self: *Transformer) void {
+    _ = self.plugins.emotion.scope_stack.pop();
+}
+
+/// 단순 jsx_identifier 의 텍스트가 `expected` 와 일치하는지.
+/// `<Foo.X>` 같은 member expression / namespaced 는 거부 — false-positive 방지
+/// (사용자 컴포넌트의 member 가 emotion binding 일 가능성 0).
+fn jsxIdentifierEquals(self: *Transformer, idx: NodeIndex, expected: []const u8) bool {
+    if (idx.isNone()) return false;
+    const node = self.ast.getNode(idx);
+    if (node.tag != .jsx_identifier) return false;
+    return std.mem.eql(u8, self.ast.getText(node.span), expected);
+}
+
+/// children 중 첫 번째 jsx_expression_container 안의 arrow/function_expression 을 반환.
+/// 텍스트 노드 / 다른 element 는 skip.
+fn findRenderPropFunction(self: *Transformer, children_start: u32, children_len: u32) ?NodeIndex {
+    if (children_len == 0) return null;
+    const indices = self.ast.extra_data.items[children_start .. children_start + children_len];
+    for (indices) |raw_idx| {
+        const child_idx: NodeIndex = @enumFromInt(raw_idx);
+        const child = self.ast.getNode(child_idx);
+        if (child.tag != .jsx_expression_container) continue;
+        const inner = child.data.unary.operand;
+        if (inner.isNone()) continue;
+        const inner_node = self.ast.getNode(inner);
+        if (inner_node.tag == .arrow_function_expression or
+            inner_node.tag == .function_expression)
+        {
+            return inner;
+        }
+    }
+    return null;
+}
+
+/// 함수 첫 param 의 object_pattern 에서 destructured `css` 의 local 이름 추출.
+/// 처리: shorthand `{ css }` → "css", aliased `{ css: cs }` → "cs".
+/// nested pattern / default value 등은 first PR 범위 밖 → null.
+fn extractDestructuredCssLocal(self: *Transformer, fn_idx: NodeIndex) ?[]const u8 {
+    const fn_node = self.ast.getNode(fn_idx);
+    const params = self.ast.functionParams(fn_node);
+    if (params.len == 0) return null;
+    const first_param_idx: NodeIndex = @enumFromInt(params[0]);
+    const first_param = self.ast.getNode(first_param_idx);
+    if (first_param.tag != .object_pattern) return null;
+
+    const list = first_param.data.list;
+    if (list.len == 0) return null;
+    const props = self.ast.extra_data.items[list.start .. list.start + list.len];
+
+    for (props) |raw_idx| {
+        const prop_idx: NodeIndex = @enumFromInt(raw_idx);
+        const prop = self.ast.getNode(prop_idx);
+        if (prop.tag != .binding_property) continue;
+
+        const key_idx = prop.data.binary.left;
+        const value_idx = prop.data.binary.right;
+        if (key_idx.isNone() or value_idx.isNone()) continue;
+
+        const key_node = self.ast.getNode(key_idx);
+        if (!std.mem.eql(u8, self.ast.getText(key_node.span), "css")) continue;
+
+        const value_node = self.ast.getNode(value_idx);
+        if (value_node.tag != .binding_identifier) return null;
+        return self.ast.getText(value_node.span);
+    }
+    return null;
+}
+
 /// tag 가 emotion 인식 패턴인지 확인.
 ///   - `css\`...\`` / `keyframes\`...\`` — 직접 identifier 만
 ///   - `styled.X\`...\`` / `styled(X)\`...\`` / `styled.div.withComponent(...)\`...\`` —
@@ -276,6 +380,14 @@ fn tagMatchesEmotion(self: *Transformer, tag_idx: NodeIndex) bool {
     // 의 `css` 는 member API 가 없어 chain 시 부정확한 라벨 위험).
     if (tag_node.tag == .identifier_reference) {
         const text = self.ast.getText(tag_node.data.string_ref);
+        // scope frame 우선 — `<ClassNames>` render-prop 의 destructured `css` 는 outer
+        // import binding 보다 우선해야 함 (정확히 그 함수 안에서만 유효).
+        if (state.scope_stack.items.len > 0) {
+            const top = state.scope_stack.items[state.scope_stack.items.len - 1];
+            if (top.css_binding) |b| {
+                if (std.mem.eql(u8, text, b)) return true;
+            }
+        }
         inline for (TAG_BINDING_FIELDS) |field_name| {
             if (@field(state, field_name)) |b| {
                 if (std.mem.eql(u8, text, b)) return true;


### PR DESCRIPTION
## 변환

```tsx
import { ClassNames } from "@emotion/react";

<ClassNames>
  {({ css }) => <div className={css`color: red;`} />}
</ClassNames>

// 출력
<ClassNames>
  {({ css }) => <div className={css`label:div;color: red;`} />}
</ClassNames>
```

## Root cause

destructured `css` 는 import 가 아니라 **render-prop 함수 매개변수** — 기존 import binding 추적으로는 인식 불가. `tagMatchesEmotion` 가 그 함수 안에서만 local `css` 를 emotion 으로 인식해야 함.

## Scope frame infra

`EmotionState` 에 `scope_stack: ArrayList(EmotionScopeFrame)` 추가:
- `<ClassNames>` JSX element 진입 시 `maybeEnterClassNamesScope` 가 render-prop 함수 → 첫 param 의 `object_pattern` → destructured `{ css }` (alias 포함) 추출 → frame push
- `transformer.zig:899` jsx_element dispatch 에서 `defer exitClassNamesScope`
- `tagMatchesEmotion` 가 stack top 의 `css_binding` 을 outer import binding 보다 우선 검사

```zig
pub const EmotionScopeFrame = struct {
    css_binding: ?[]const u8 = null,  // cx/theme 는 autoLabel 무관, 추적 안 함
};
```

## className inline 인식 (의도적 제한)

`<div className={css\`...\`}/>` 는 일반적으로 처리 안 함 — className 은 너무 generic. **ClassNames scope 안에서만** 예외적으로 인식 (`scope_stack.len > 0` fast guard). 밖에서는 일반 className 으로 변환 안 함.

## 인식 패턴

| 패턴 | 동작 |
|---|---|
| `<ClassNames>{({css}) => ...}` | ✅ shorthand |
| `<ClassNames>{({css: cs}) => ...}` | ✅ aliased local |
| `import { ClassNames as CN } ... <CN>` | ✅ import alias |
| arrow + `function () {...}` | ✅ 양쪽 |
| nested `<ClassNames>{({css: outer}) => <ClassNames>{({css: inner}) => ...}}` | ✅ stack 으로 inner override |
| `(props) => ...` (destructure 없음) | no-op |
| `<ClassNames>text</ClassNames>` (render-prop child 없음) | no-op |
| `<div className={css\`...\`}/>` (ClassNames 밖) | no-op (일반 className) |

## 코드 리뷰 (3-agent /simplify) P1 모두 반영

| 이슈 | 수정 |
|---|---|
| `maybeApplyAutoLabelForJsxAttr` 의 redundant 2nd guard | `is_styles and !global` 직접 표현 |
| `extractDestructuredCss` frame pointer mutation | `?[]const u8` 반환으로 명료화 |
| `isJsxIdentifierMatching` / `elementMatchesGlobal` 중복 | `jsxIdentifierEquals` 헬퍼 통합 |

## 테스트 (+10)

- shorthand / binding form / destructure alias / import alias / scope 격리 / outer+inner 공존
- **nested ClassNames** (stack 검증) / **function_expression** / **no-destructure** / **no-render-prop**

## 검증

- `zig build test` 통과 (4203 + 신규 10 케이스)
- v10 통합 (`emotion-v10.test.ts`) + v11 (`css-library-smoke.test.ts`) 회귀 통과 (20/20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)