### PR TITLE
fix(transform): preserve downlevel edge semantics

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -338,8 +338,8 @@ export interface StyledComponentsOptions {
 export interface EmotionOptions {
   /** sourceMap 생성 (default: true) */
   sourceMap?: boolean;
-  /** 변수명을 CSS class label 로 자동 부여 (default: "dev-only") */
-  autoLabel?: "always" | "dev-only" | "never";
+  /** 변수명을 CSS class label 로 자동 부여 (default: "dev-only"). `false` 는 autoLabel 을 끈다. */
+  autoLabel?: "always" | "dev-only" | "never" | false;
   /** label format string. tokens: `[local]`, `[filename]`, `[dirname]` (default: "[local]") */
   labelFormat?: string;
   /** import 경로 alias — fork 또는 vendored emotion 사용 시 */

--- a/scripts/syntax-audit.mjs
+++ b/scripts/syntax-audit.mjs
@@ -1,0 +1,361 @@
+#!/usr/bin/env node
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const root = resolve(import.meta.dirname, "..");
+const zts = join(root, "zig-out/bin/zts");
+const tmp = mkdtempSync(join(tmpdir(), "zts-syntax-audit-"));
+
+const singleFileCases = [
+  {
+    name: "default-param-tdz-and-order",
+    code: `
+const events = [];
+function mark(v) { events.push(v); return v; }
+function f(a = mark("a"), b = a + mark("b")) { return [a, b, events.join("")]; }
+try { function g(a = b, b = 1) { return a + b; } g(); } catch (e) { events.push(e.name); }
+console.log(JSON.stringify([f(1), f(), events]));
+`,
+  },
+  {
+    name: "destructuring-iterator-close",
+    code: `
+let log = [];
+const iter = {
+  [Symbol.iterator]() {
+    let i = 0;
+    return {
+      next() { log.push("n" + i); return { value: i++, done: i > 4 }; },
+      return() { log.push("return"); return { done: true }; },
+    };
+  },
+};
+const [a, b] = iter;
+console.log(JSON.stringify({ a, b, log }));
+`,
+  },
+  {
+    name: "computed-key-single-eval",
+    code: `
+let i = 0;
+const key = () => "k" + ++i;
+const obj = { [key()]: 1, [key()]: 2 };
+obj[key()] = (obj[key()] ?? 3) + 4;
+console.log(JSON.stringify({ keys: Object.keys(obj), values: Object.values(obj), i }));
+`,
+  },
+  {
+    name: "optional-call-this-binding",
+    code: `
+const box = {
+  value: 41,
+  get nested() {
+    return { value: this.value + 1, inc() { return this.value + 1; } };
+  },
+};
+const missing = null;
+console.log(JSON.stringify([box.nested?.inc?.(), missing?.nested?.inc?.()]));
+`,
+  },
+  {
+    name: "logical-assignment-receiver",
+    code: `
+const log = [];
+const obj = {
+  _x: 0,
+  get x() { log.push("get:" + this._x); return this._x; },
+  set x(v) { log.push("set:" + v); this._x = v; },
+};
+obj.x ||= 2;
+obj.x &&= 3;
+obj.x ??= 4;
+console.log(JSON.stringify({ x: obj.x, log }));
+`,
+  },
+  {
+    name: "class-super-receiver",
+    code: `
+class Base {
+  get x() { return this.tag + ":get"; }
+  set x(v) { this.log.push(this.tag + ":" + v); }
+  m(v) { return this.tag + ":" + v; }
+}
+class Child extends Base {
+  tag = "child";
+  log = [];
+  run(k) {
+    super.x = super.m(super.x + ":" + k);
+    return this.log[0];
+  }
+}
+console.log(JSON.stringify(new Child().run("ok")));
+`,
+  },
+  {
+    name: "derived-constructor-return-order",
+    code: `
+const log = [];
+class Base { constructor(v) { log.push("base:" + v); this.v = v; } }
+class Child extends Base {
+  field = log.push("field:" + this.v);
+  constructor() {
+    log.push("before");
+    const result = super(log.push("arg"));
+    log.push("after:" + (result === this));
+  }
+}
+new Child();
+console.log(JSON.stringify(log));
+`,
+  },
+  {
+    name: "private-field-brand-and-update",
+    code: `
+class Counter {
+  #value = 1;
+  static has(x) { return #value in x; }
+  bump() { return [this.#value++, ++this.#value, this.#value]; }
+}
+const c = new Counter();
+console.log(JSON.stringify([Counter.has(c), Counter.has({}), c.bump()]));
+`,
+  },
+  {
+    name: "static-block-order",
+    code: `
+const log = [];
+class A {
+  static a = log.push("a");
+  static { log.push("block:" + this.a); }
+  static b = log.push("b");
+}
+console.log(JSON.stringify([A.a, A.b, log]));
+`,
+  },
+  {
+    name: "tagged-template-identity-and-raw",
+    code: `
+const seen = new WeakSet();
+function tag(strings, value) {
+  const first = seen.has(strings);
+  seen.add(strings);
+  return [first, strings.raw[0], strings[0], value].join("|");
+}
+console.log(JSON.stringify([tag\`a\\nb\${1}\`, tag\`a\\nb\${2}\`]));
+`,
+  },
+  {
+    name: "async-generator-finally",
+    code: `
+async function* gen() {
+  try {
+    yield 1;
+    yield await Promise.resolve(2);
+  } finally {
+    yield 3;
+  }
+}
+(async () => {
+  const out = [];
+  for await (const v of gen()) {
+    out.push(v);
+    if (v === 2) break;
+  }
+  console.log(JSON.stringify(out));
+})();
+`,
+  },
+  {
+    name: "for-of-let-closure-continue",
+    code: `
+const fns = [];
+for (let x of [1, 2, 3, 4]) {
+  if (x % 2) continue;
+  fns.push(() => x);
+}
+console.log(JSON.stringify(fns.map((fn) => fn())));
+`,
+  },
+];
+
+const bundleCases = [
+  {
+    name: "live-binding-reexport",
+    files: {
+      "entry.mjs": `
+import { value, inc } from "./barrel.mjs";
+console.log(JSON.stringify([value, inc(), value, inc(), value]));
+`,
+      "barrel.mjs": `export { value, inc } from "./state.mjs";`,
+      "state.mjs": `
+export let value = 0;
+export function inc() {
+  value += 1;
+  return value;
+}
+`,
+    },
+  },
+  {
+    name: "cycle-function-before-value",
+    files: {
+      "entry.mjs": `
+import { fromA } from "./a.mjs";
+console.log(JSON.stringify(fromA()));
+`,
+      "a.mjs": `
+import { b, callB } from "./b.mjs";
+export const a = "a";
+export function fromA() { return ["fromA", b, callB()]; }
+`,
+      "b.mjs": `
+import { a } from "./a.mjs";
+export const b = "b";
+export function callB() { return ["callB", a]; }
+`,
+    },
+  },
+  {
+    name: "dynamic-import-namespace",
+    files: {
+      "entry.mjs": `
+const ns1 = await import("./lazy.mjs");
+const ns2 = await import("./lazy.mjs");
+console.log(JSON.stringify([ns1 === ns2, ns1.default, ns1.named]));
+`,
+      "lazy.mjs": `
+export const named = 7;
+export default named + 1;
+`,
+    },
+  },
+  {
+    name: "namespace-dynamic-key",
+    files: {
+      "entry.mjs": `
+import * as ns from "./mod.mjs";
+const k = "beta";
+console.log(JSON.stringify([Object.keys(ns).sort(), ns[k], ns.alpha]));
+`,
+      "mod.mjs": `
+export const alpha = 1;
+export const beta = 2;
+`,
+    },
+  },
+];
+
+function run(cmd, args, options = {}) {
+  const result = spawnSync(cmd, args, {
+    cwd: options.cwd ?? root,
+    encoding: "utf8",
+    timeout: options.timeout ?? 10000,
+  });
+  return {
+    ok: result.status === 0,
+    status: result.status,
+    stdout: result.stdout.trimEnd(),
+    stderr: result.stderr.trimEnd(),
+  };
+}
+
+function write(path, content) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+}
+
+function fail(label, details) {
+  console.error(`\nFAIL ${label}`);
+  console.error(details);
+  process.exitCode = 1;
+}
+
+function assertEqual(label, actual, expected, extra = "") {
+  if (actual !== expected) {
+    fail(label, `expected: ${expected}\nactual:   ${actual}${extra ? `\n${extra}` : ""}`);
+  }
+}
+
+try {
+  console.log(`syntax audit temp: ${tmp}`);
+
+  for (const test of singleFileCases) {
+    const dir = join(tmp, "single", test.name);
+    const input = join(dir, "input.mjs");
+    write(input, test.code);
+
+    const native = run("node", [input]);
+    if (!native.ok) {
+      fail(`${test.name}: native`, native.stderr || native.stdout);
+      continue;
+    }
+
+    for (const target of ["es5", "es2015", "es2019", "es2022"]) {
+      const out = join(dir, `zts-${target}.mjs`);
+      const built = run(zts, [input, "--target=" + target, "--format=esm", "-o", out]);
+      if (!built.ok) {
+        fail(`${test.name}: transpile ${target}`, built.stderr || built.stdout);
+        continue;
+      }
+      const checked = run("node", ["--check", out]);
+      if (!checked.ok) {
+        fail(`${test.name}: syntax ${target}`, checked.stderr || checked.stdout);
+        continue;
+      }
+      const actual = run("node", [out]);
+      if (!actual.ok) {
+        fail(`${test.name}: run ${target}`, actual.stderr || actual.stdout);
+        continue;
+      }
+      assertEqual(`${test.name}: ${target}`, actual.stdout, native.stdout);
+    }
+    console.log(`ok single ${test.name}`);
+  }
+
+  for (const test of bundleCases) {
+    const dir = join(tmp, "bundle", test.name);
+    for (const [name, content] of Object.entries(test.files)) {
+      write(join(dir, name), content);
+    }
+    const entry = join(dir, "entry.mjs");
+    const native = run("node", [entry]);
+    if (!native.ok) {
+      fail(`${test.name}: native`, native.stderr || native.stdout);
+      continue;
+    }
+
+    for (const target of ["es5", "es2015", "es2022"]) {
+      const out = join(dir, `bundle-${target}.mjs`);
+      const built = run(zts, ["--bundle", entry, "--target=" + target, "--format=esm", "-o", out]);
+      if (!built.ok) {
+        fail(`${test.name}: bundle ${target}`, built.stderr || built.stdout);
+        continue;
+      }
+      const checked = run("node", ["--check", out]);
+      if (!checked.ok) {
+        fail(`${test.name}: bundle syntax ${target}`, checked.stderr || checked.stdout);
+        continue;
+      }
+      const actual = run("node", [out]);
+      if (!actual.ok) {
+        fail(`${test.name}: bundle run ${target}`, actual.stderr || actual.stdout);
+        continue;
+      }
+      assertEqual(
+        `${test.name}: bundle ${target}`,
+        actual.stdout,
+        native.stdout,
+        readFileSync(out, "utf8").slice(0, 500),
+      );
+    }
+    console.log(`ok bundle ${test.name}`);
+  }
+} finally {
+  if (process.exitCode) {
+    console.error(`kept failing temp dir: ${tmp}`);
+  } else {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}

--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -562,7 +562,7 @@ pub const ASYNC_GENERATOR_RUNTIME =
     \\var __asyncGenerator = function(thisArg, _arguments, generator) {
     \\  if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
     \\  var g = generator.apply(thisArg, _arguments || []), q = [], i;
-    \\  return i = {}, verb("next"), verb("throw", function(e) { return Promise.reject(e); }), verb("return"),
+    \\  return i = {}, verb("next"), verb("throw"), verb("return"),
     \\    i[Symbol.asyncIterator] = function() { return this; }, i;
     \\  function verb(n, f) {
     \\    if (g[n]) i[n] = function(v) { return new Promise(function(a, b) { q.push([n, v, a, b]) > 1 || resume(n, v); }); };
@@ -580,7 +580,7 @@ pub const ASYNC_GENERATOR_RUNTIME =
     \\};
     \\
 ;
-pub const ASYNC_GENERATOR_RUNTIME_MIN = "var __asyncGenerator=function(thisArg,_arguments,generator){if(!Symbol.asyncIterator)throw new TypeError(\"Symbol.asyncIterator is not defined.\");var g=generator.apply(thisArg,_arguments||[]),q=[],i;return i={},verb(\"next\"),verb(\"throw\",function(e){return Promise.reject(e)}),verb(\"return\"),i[Symbol.asyncIterator]=function(){return this},i;function verb(n,f){if(g[n])i[n]=function(v){return new Promise(function(a,b){q.push([n,v,a,b])>1||resume(n,v)})};if(f)i[n]=f(i[n])}function resume(n,v){try{step(g[n](v))}catch(e){settle(q[0][3],e)}}function step(r){r.value instanceof __await?Promise.resolve(r.value.v).then(fulfill,reject):settle(q[0][2],r)}function fulfill(value){resume(\"next\",value)}function reject(value){resume(\"throw\",value)}function settle(f,v){if(f(v),q.shift(),q.length)resume(q[0][0],q[0][1])}};";
+pub const ASYNC_GENERATOR_RUNTIME_MIN = "var __asyncGenerator=function(thisArg,_arguments,generator){if(!Symbol.asyncIterator)throw new TypeError(\"Symbol.asyncIterator is not defined.\");var g=generator.apply(thisArg,_arguments||[]),q=[],i;return i={},verb(\"next\"),verb(\"throw\"),verb(\"return\"),i[Symbol.asyncIterator]=function(){return this},i;function verb(n,f){if(g[n])i[n]=function(v){return new Promise(function(a,b){q.push([n,v,a,b])>1||resume(n,v)})};if(f)i[n]=f(i[n])}function resume(n,v){try{step(g[n](v))}catch(e){settle(q[0][3],e)}}function step(r){r.value instanceof __await?Promise.resolve(r.value.v).then(fulfill,reject):settle(q[0][2],r)}function fulfill(value){resume(\"next\",value)}function reject(value){resume(\"throw\",value)}function settle(f,v){if(f(v),q.shift(),q.length)resume(q[0][0],q[0][1])}};";
 
 /// __values: iterable → iterator 변환 (ES2015 yield* / for-of helper). tslib 호환.
 /// `Symbol.iterator` 호출 가능하면 그 결과 반환. 없으면 `length` 기반 array-like fallback.

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -98,7 +98,13 @@ test "ES2021: ??= to es2020" {
 test "ES2021: ??= to es2019 (double lowering)" {
     var r = try e2eTarget(std.testing.allocator, "a ??= b;", .es2019);
     defer r.deinit();
-    try std.testing.expectEqualStrings("var _a;(_a=a)!=null?_a:(a=b);", r.output);
+    try std.testing.expectEqualStrings("a!=null?a:(a=b);", r.output);
+}
+
+test "ES2021: ??= member to es2019 captures to temp" {
+    var r = try e2eTarget(std.testing.allocator, "obj.x ??= b;", .es2019);
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var _a;(_a=obj.x)!=null?_a:(obj.x=b);", r.output);
 }
 
 test "ES2021: ??= no transform on esnext" {

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -98,7 +98,7 @@ test "ES2021: ??= to es2020" {
 test "ES2021: ??= to es2019 (double lowering)" {
     var r = try e2eTarget(std.testing.allocator, "a ??= b;", .es2019);
     defer r.deinit();
-    try std.testing.expectEqualStrings("a!=null?a:(a=b);", r.output);
+    try std.testing.expectEqualStrings("var _a;(_a=a)!=null?_a:(a=b);", r.output);
 }
 
 test "ES2021: ??= no transform on esnext" {

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -223,13 +223,15 @@ pub fn ES2015Class(comptime Transformer: type) type {
             // static fields/blocks 는 class evaluation 중 실행된다. extends class 의 경우 IIFE
             // 밖으로 내보내면 super lowering 이 참조하는 _super scope가 사라지므로 IIFE 내부에서
             // __extends 이후, return 이전에 실행한다.
-            for (cm.static_fields.items) |field| {
-                const class_ref = try es_helpers.makeIdentifierRefFromSpan(self, fresh_name_span);
-                const static_assign = try buildStaticFieldAssignWithCtx(self, class_ref, field.key, field.init, fresh_name_span, span);
-                try self.scratch.append(self.allocator, static_assign);
-            }
-            for (cm.static_block_stmts.items) |sb_stmt| {
-                try self.scratch.append(self.allocator, sb_stmt);
+            for (cm.static_elements.items) |element| {
+                switch (element) {
+                    .field => |field| {
+                        const class_ref = try es_helpers.makeIdentifierRefFromSpan(self, fresh_name_span);
+                        const static_assign = try buildStaticFieldAssignWithCtx(self, class_ref, field.key, field.init, fresh_name_span, span);
+                        try self.scratch.append(self.allocator, static_assign);
+                    },
+                    .stmt => |sb_stmt| try self.scratch.append(self.allocator, sb_stmt),
+                }
             }
 
             // return ClassName;
@@ -369,10 +371,10 @@ pub fn ES2015Class(comptime Transformer: type) type {
             }
 
             // has_extra를 먼저 계산하여 func_node를 올바른 이름으로 한 번만 빌드
-            const has_extra = cm.methods.items.len > 0 or cm.static_fields.items.len > 0 or
+            const has_extra = cm.methods.items.len > 0 or cm.static_elements.items.len > 0 or
                 cm.accessors.items.len > 0 or cm.private_fields.items.len > 0 or
                 cm.static_private_fields.items.len > 0 or cm.private_methods.items.len > 0 or
-                cm.static_block_stmts.items.len > 0 or (has_super and super_span != null);
+                (has_super and super_span != null);
 
             // IIFE 경로면 fresh identifier (symbol 없음), 단순 경로면 원본 name_node.
             // `name_span`은 이미 addString/source에 저장된 stable Span이므로 그대로 재사용.
@@ -480,11 +482,11 @@ pub fn ES2015Class(comptime Transformer: type) type {
             }
             try self.scratch.appendSlice(self.allocator, self.pending_nodes.items[pending_top..]);
 
-            for (cm.static_fields.items) |field| {
-                try self.scratch.append(self.allocator, try buildStaticFieldAssignWithCtx(self, try es_helpers.makeIdentifierRefFromSpan(self, name_span), field.key, field.init, name_span, span));
-            }
-            for (cm.static_block_stmts.items) |sb_stmt| {
-                try self.scratch.append(self.allocator, sb_stmt);
+            for (cm.static_elements.items) |element| {
+                switch (element) {
+                    .field => |field| try self.scratch.append(self.allocator, try buildStaticFieldAssignWithCtx(self, try es_helpers.makeIdentifierRefFromSpan(self, name_span), field.key, field.init, name_span, span)),
+                    .stmt => |sb_stmt| try self.scratch.append(self.allocator, sb_stmt),
+                }
             }
 
             // return ClassName;
@@ -1594,6 +1596,11 @@ pub fn ES2015Class(comptime Transformer: type) type {
             init: NodeIndex,
         };
 
+        const StaticElement = union(enum) {
+            field: FieldInfo,
+            stmt: NodeIndex,
+        };
+
         const AccessorInfo = struct {
             member_idx: NodeIndex,
             is_static: bool,
@@ -1615,6 +1622,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             methods: std.ArrayList(MethodInfo),
             instance_fields: std.ArrayList(NodeIndex),
             static_fields: std.ArrayList(FieldInfo),
+            static_elements: std.ArrayList(StaticElement),
             accessors: std.ArrayList(AccessorInfo),
             private_fields: std.ArrayList(PrivateFieldInfo),
             /// static private fields: descriptor 객체 패턴.
@@ -1648,6 +1656,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 cm.methods.deinit(allocator);
                 cm.instance_fields.deinit(allocator);
                 cm.static_fields.deinit(allocator);
+                cm.static_elements.deinit(allocator);
                 cm.accessors.deinit(allocator);
                 cm.private_fields.deinit(allocator);
                 cm.static_private_fields.deinit(allocator);
@@ -1704,6 +1713,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 .methods = .empty,
                 .instance_fields = .empty,
                 .static_fields = .empty,
+                .static_elements = .empty,
                 .accessors = .empty,
                 .private_fields = .empty,
                 .static_private_fields = .empty,
@@ -1800,7 +1810,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     }
 
                     if (is_static and !init_val.isNone()) {
-                        try cm.static_fields.append(self.allocator, .{ .key = key, .init = init_val });
+                        const field_info = FieldInfo{ .key = key, .init = init_val };
+                        try cm.static_fields.append(self.allocator, field_info);
+                        try cm.static_elements.append(self.allocator, .{ .field = field_info });
                     } else if (!is_static and !init_val.isNone()) {
                         const this_node = try self.ast.addNode(.{
                             .tag = .this_expression,
@@ -1857,6 +1869,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                                 const new_stmt = try self.visitNode(@enumFromInt(sb_raw));
                                 if (!new_stmt.isNone()) {
                                     try cm.static_block_stmts.append(self.allocator, new_stmt);
+                                    try cm.static_elements.append(self.allocator, .{ .stmt = new_stmt });
                                 }
                             }
                         }
@@ -2491,7 +2504,20 @@ pub fn ES2015Class(comptime Transformer: type) type {
                         } },
                     });
                 },
-                else => return stmt_idx,
+                else => {
+                    const scratch_top = self.scratch.items.len;
+                    defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+                    try self.scratch.append(self.allocator, stmt_idx);
+                    try appendInstanceFields(self, instance_fields, span);
+
+                    const new_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+                    return self.ast.addNode(.{
+                        .tag = .block_statement,
+                        .span = stmt.span,
+                        .data = .{ .list = new_list },
+                    });
+                },
             }
         }
 
@@ -2525,11 +2551,24 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     }
                     return false;
                 },
+                .variable_declaration => {
+                    const start = self.ast.extra_data.items[node.data.extra + 1];
+                    const len = self.ast.extra_data.items[node.data.extra + 2];
+                    for (self.ast.extra_data.items[start .. start + len]) |raw_idx| {
+                        if (containsSuperCallAssignment(self, @enumFromInt(raw_idx))) return true;
+                    }
+                    return false;
+                },
+                .variable_declarator => {
+                    const init: NodeIndex = @enumFromInt(self.ast.extra_data.items[node.data.extra + 2]);
+                    return containsSuperCallAssignment(self, init);
+                },
+                .call_expression => return isSuperCallLike(self, node),
                 .assignment_expression => {
                     const left = self.ast.getNode(node.data.binary.left);
-                    if (left.tag != .identifier_reference) return false;
+                    if (left.tag != .identifier_reference and left.tag != .assignment_target_identifier) return false;
                     const right = self.ast.getNode(node.data.binary.right);
-                    return isCallSuperCall(self, right);
+                    return isSuperCallLike(self, right);
                 },
                 .if_statement, .conditional_expression => {
                     if (containsSuperCallAssignment(self, node.data.ternary.b)) return true;
@@ -2558,6 +2597,16 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const helper_names = @import("../runtime_helper_names.zig");
             return std.mem.eql(u8, name, "__callSuper") or
                 std.mem.eql(u8, name, helper_names.NAMES.CALL_SUPER_MIN);
+        }
+
+        fn isSuperCallLike(self: *Transformer, node: Node) bool {
+            if (node.tag != .call_expression) return false;
+            const e = node.data.extra;
+            const callee_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+            if (callee_idx.isNone()) return false;
+            const callee = self.ast.getNode(callee_idx);
+            if (callee.tag == .super_expression) return true;
+            return isCallSuperCall(self, node);
         }
 
         /// 빈 function declaration (constructor가 없는 경우)

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1616,12 +1616,14 @@ pub fn ES2015Class(comptime Transformer: type) type {
             init: NodeIndex, // 초기값 (none이면 undefined)
         };
 
-        /// 클래스 바디 멤버를 분류: constructor, methods, instance_fields, static_fields, accessors, private_fields, static_private_fields, private_methods.
+        /// 클래스 바디 멤버를 분류: constructor, methods, instance_fields, static_elements, accessors, private_fields, static_private_fields, private_methods.
+        /// `static_elements`: static field/static block 을 소스 순서대로 보존한다 (TC39 spec — class evaluation 시
+        /// 필드와 블록이 선언 순서대로 실행). 별도 array 로 나누면 순서 정보가 사라져 `static a; { use a; } static b;` 같은
+        /// 의존 체인이 깨진다.
         const ClassifiedMembers = struct {
             constructor_idx: ?NodeIndex,
             methods: std.ArrayList(MethodInfo),
             instance_fields: std.ArrayList(NodeIndex),
-            static_fields: std.ArrayList(FieldInfo),
             static_elements: std.ArrayList(StaticElement),
             accessors: std.ArrayList(AccessorInfo),
             private_fields: std.ArrayList(PrivateFieldInfo),
@@ -1629,7 +1631,6 @@ pub fn ES2015Class(comptime Transformer: type) type {
             /// instance private fields와 달리 WeakMap이 아닌 { writable: true, value: init } 객체로 변환.
             static_private_fields: std.ArrayList(PrivateFieldInfo),
             private_methods: std.ArrayList(Transformer.PrivateMethodMapping),
-            static_block_stmts: std.ArrayList(NodeIndex),
             /// accessor_property 합성으로 만드는 `#_<name>_acc` 원본 이름.
             /// `PrivateFieldInfo.original_name`은 `findPrivateFieldMapping`의 `std.mem.eql` 키라 안정적 slice가 필요.
             /// string_table slice는 후속 `addString` 호출의 realloc으로 dangling이 되므로 heap-owned 복사본을 유지한다.
@@ -1655,13 +1656,11 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 for (cm.synthesized_private_names.items) |s| allocator.free(s);
                 cm.methods.deinit(allocator);
                 cm.instance_fields.deinit(allocator);
-                cm.static_fields.deinit(allocator);
                 cm.static_elements.deinit(allocator);
                 cm.accessors.deinit(allocator);
                 cm.private_fields.deinit(allocator);
                 cm.static_private_fields.deinit(allocator);
                 cm.private_methods.deinit(allocator);
-                cm.static_block_stmts.deinit(allocator);
                 cm.synthesized_private_names.deinit(allocator);
             }
         };
@@ -1712,13 +1711,11 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 .constructor_idx = null,
                 .methods = .empty,
                 .instance_fields = .empty,
-                .static_fields = .empty,
                 .static_elements = .empty,
                 .accessors = .empty,
                 .private_fields = .empty,
                 .static_private_fields = .empty,
                 .private_methods = .empty,
-                .static_block_stmts = .empty,
             };
 
             // visitNode/addNode/buildFieldAssign이 extra_data를 재할당할 수 있으므로 인덱스 루프 사용
@@ -1810,9 +1807,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     }
 
                     if (is_static and !init_val.isNone()) {
-                        const field_info = FieldInfo{ .key = key, .init = init_val };
-                        try cm.static_fields.append(self.allocator, field_info);
-                        try cm.static_elements.append(self.allocator, .{ .field = field_info });
+                        try cm.static_elements.append(self.allocator, .{ .field = .{ .key = key, .init = init_val } });
                     } else if (!is_static and !init_val.isNone()) {
                         const this_node = try self.ast.addNode(.{
                             .tag = .this_expression,
@@ -1868,7 +1863,6 @@ pub fn ES2015Class(comptime Transformer: type) type {
                                 const sb_raw = self.ast.extra_data.items[sb_stmts_start + i_loop];
                                 const new_stmt = try self.visitNode(@enumFromInt(sb_raw));
                                 if (!new_stmt.isNone()) {
-                                    try cm.static_block_stmts.append(self.allocator, new_stmt);
                                     try cm.static_elements.append(self.allocator, .{ .stmt = new_stmt });
                                 }
                             }
@@ -2504,7 +2498,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
                         } },
                     });
                 },
-                else => {
+                // `const result = super(...)` / `let r = super(...)` 같은 declarator-init super 케이스.
+                // 선언문 자체를 살린 뒤 같은 control-flow 위치에 instance field init 을 잇도록 block 으로 감싼다.
+                .variable_declaration => {
                     const scratch_top = self.scratch.items.len;
                     defer self.scratch.shrinkRetainingCapacity(scratch_top);
 
@@ -2518,6 +2514,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                         .data = .{ .list = new_list },
                     });
                 },
+                else => return stmt_idx,
             }
         }
 
@@ -2586,27 +2583,19 @@ pub fn ES2015Class(comptime Transformer: type) type {
             }
         }
 
-        fn isCallSuperCall(self: *Transformer, node: Node) bool {
+        /// `super(...)` 또는 lowering 후의 `_this = __callSuper(...)` 같은 super 호출 패턴인지 판별.
+        /// raw super 호출은 lowering 전, helper 호출은 lowering 후 형태.
+        fn isSuperCallLike(self: *Transformer, node: Node) bool {
             if (node.tag != .call_expression) return false;
-            const e = node.data.extra;
-            const callee_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+            const callee_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[node.data.extra]);
             if (callee_idx.isNone()) return false;
             const callee = self.ast.getNode(callee_idx);
+            if (callee.tag == .super_expression) return true;
             if (callee.tag != .identifier_reference) return false;
             const name = self.ast.getText(callee.data.string_ref);
             const helper_names = @import("../runtime_helper_names.zig");
             return std.mem.eql(u8, name, "__callSuper") or
                 std.mem.eql(u8, name, helper_names.NAMES.CALL_SUPER_MIN);
-        }
-
-        fn isSuperCallLike(self: *Transformer, node: Node) bool {
-            if (node.tag != .call_expression) return false;
-            const e = node.data.extra;
-            const callee_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
-            if (callee_idx.isNone()) return false;
-            const callee = self.ast.getNode(callee_idx);
-            if (callee.tag == .super_expression) return true;
-            return isCallSuperCall(self, node);
         }
 
         /// 빈 function declaration (constructor가 없는 경우)

--- a/src/transformer/es2021.zig
+++ b/src/transformer/es2021.zig
@@ -28,11 +28,13 @@ pub fn ES2021(comptime Transformer: type) type {
             const paren_assign = try es_helpers.makeParenExpr(self, assign, node.span);
 
             if (self.options.unsupported.nullish_coalescing) {
-                const neq_null = try es_helpers.makeNeqNull(self, target.read, node.span);
+                const captured = try es_helpers.captureToTemp(self, target.read, node.span);
+                const captured_value = try es_helpers.makeTempVarRef(self, captured.span, node.span);
+                const neq_null = try es_helpers.makeNeqNull(self, captured.paren_assign, node.span);
                 return self.ast.addNode(.{
                     .tag = .conditional_expression,
                     .span = node.span,
-                    .data = .{ .ternary = .{ .a = neq_null, .b = target.value, .c = paren_assign } },
+                    .data = .{ .ternary = .{ .a = neq_null, .b = captured_value, .c = paren_assign } },
                 });
             }
 

--- a/src/transformer/es2021.zig
+++ b/src/transformer/es2021.zig
@@ -28,6 +28,18 @@ pub fn ES2021(comptime Transformer: type) type {
             const paren_assign = try es_helpers.makeParenExpr(self, assign, node.span);
 
             if (self.options.unsupported.nullish_coalescing) {
+                // ternary lowering 은 condition 과 truthy branch 두 자리에 read 표현을 emit 한다.
+                // member access 는 두 자리에 두면 getter 가 두 번 호출되므로 임시 변수에 캡처해야 한다.
+                // 그러나 plain identifier 는 부작용이 없어 캡처가 불필요한 noise 다 (#1287 follow-up).
+                const read_tag = self.ast.getNode(target.read).tag;
+                if (read_tag == .identifier_reference or read_tag == .assignment_target_identifier) {
+                    const neq_null = try es_helpers.makeNeqNull(self, target.read, node.span);
+                    return self.ast.addNode(.{
+                        .tag = .conditional_expression,
+                        .span = node.span,
+                        .data = .{ .ternary = .{ .a = neq_null, .b = target.value, .c = paren_assign } },
+                    });
+                }
                 const captured = try es_helpers.captureToTemp(self, target.read, node.span);
                 const captured_value = try es_helpers.makeTempVarRef(self, captured.span, node.span);
                 const neq_null = try es_helpers.makeNeqNull(self, captured.paren_assign, node.span);

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -97,6 +97,9 @@ pub fn ES2022(comptime Transformer: type) type {
                     // static block → IIFE로 변환
                     const iife = try buildStaticBlockIIFE(self, member, class_name_span);
                     try static_block_iifes.append(self.allocator, iife);
+                } else if (class_name_span != null and member.tag == .property_definition and isPublicStaticField(self, member)) {
+                    const static_assign = try buildStaticFieldAssign(self, member, class_name_span.?, already_visited);
+                    try static_block_iifes.append(self.allocator, static_assign);
                 } else if (already_visited) {
                     try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
                 } else {
@@ -130,6 +133,51 @@ pub fn ES2022(comptime Transformer: type) type {
         // Private Fields (#field) → WeakMap + ctor init
         // lowerPrivateMembers (아래) 참조.
         // ================================================================
+
+        fn isPublicStaticField(self: *Transformer, member: Node) bool {
+            const pe = member.data.extra;
+            const key: NodeIndex = self.readNodeIdx(pe, ast_mod.PropertyExtra.key);
+            if (key.isNone()) return false;
+            const key_node = self.ast.getNode(key);
+            if (key_node.tag == .private_identifier) return false;
+
+            const flags = self.readU32(pe, ast_mod.PropertyExtra.flags);
+            return (flags & ast_mod.PropertyFlags.is_static) != 0;
+        }
+
+        fn buildStaticFieldAssign(self: *Transformer, member: Node, class_name_span: Span, already_visited: bool) Transformer.Error!NodeIndex {
+            const pe = member.data.extra;
+            const key: NodeIndex = self.readNodeIdx(pe, ast_mod.PropertyExtra.key);
+            const init: NodeIndex = self.readNodeIdx(pe, ast_mod.PropertyExtra.init);
+
+            const saved_static = self.current_super_is_static;
+            const saved_receiver = self.current_super_static_receiver;
+            self.current_super_is_static = true;
+            self.current_super_static_receiver = class_name_span;
+            defer {
+                self.current_super_is_static = saved_static;
+                self.current_super_static_receiver = saved_receiver;
+            }
+
+            const class_ref = try es_helpers.makeIdentifierRefFromSpan(self, class_name_span);
+            const member_ref = try es_helpers.makeMemberFromKeyIdx(self, class_ref, key, member.span);
+            const value = if (init.isNone())
+                try es_helpers.makeVoidZero(self, member.span)
+            else if (already_visited)
+                init
+            else
+                try self.visitNode(init);
+            const assign = try self.ast.addNode(.{
+                .tag = .assignment_expression,
+                .span = member.span,
+                .data = .{ .binary = .{ .left = member_ref, .right = value, .flags = 0 } },
+            });
+            return self.ast.addNode(.{
+                .tag = .expression_statement,
+                .span = member.span,
+                .data = .{ .unary = .{ .operand = assign, .flags = 0 } },
+            });
+        }
 
         /// method_definition의 body 앞에 문들을 삽입하여 새 method_definition 반환.
         fn injectIntoMethod(self: *Transformer, method_node_idx: NodeIndex, stmts: []const NodeIndex, has_super: bool) Transformer.Error!NodeIndex {

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, afterEach } from "bun:test";
-import { bundleAndRun } from "./helpers";
+import { bundleAndRun, transpileAndRun } from "./helpers";
 
 describe("ES 다운레벨링 엣지케이스 (복합 조합)", () => {
   let cleanup: (() => Promise<void>) | undefined;
@@ -111,6 +111,201 @@ describe("ES 다운레벨링 엣지케이스 (복합 조합)", () => {
       cleanup = result.cleanup;
       expect(result.exitCode).toBe(0);
       expect(result.runOutput).toBe("5");
+    });
+  });
+
+  describe("syntax audit regressions", () => {
+    test("logical nullish assignment reads member value only once", async () => {
+      const result = await transpileAndRun(
+        `
+          const log: string[] = [];
+          const obj = {
+            _x: 0,
+            get x() { log.push("get:" + this._x); return this._x; },
+            set x(v: number) { log.push("set:" + v); this._x = v; },
+          };
+          obj.x ||= 2;
+          obj.x &&= 3;
+          obj.x ??= 4;
+          console.log(JSON.stringify({ x: obj.x, log }));
+        `,
+        ["--target=es2019"],
+      );
+      cleanup = result.cleanup;
+      expect(result.transpileExitCode).toBe(0);
+      expect(result.runStderr).toBe("");
+      expect(result.runOutput).toBe(
+        JSON.stringify({
+          x: 3,
+          log: ["get:0", "set:2", "get:2", "set:3", "get:3", "get:3"],
+        }),
+      );
+    });
+
+    test("logical assignment preserves complex receiver and computed key single evaluation", async () => {
+      const result = await transpileAndRun(
+        `
+          const log: string[] = [];
+          const state = { value: 1 };
+          function getObj() {
+            log.push("obj");
+            return {
+              get value() { log.push("get:" + state.value); return state.value; },
+              set value(v: number) { log.push("set:" + v); state.value = v; },
+            };
+          }
+          function key() {
+            log.push("key");
+            return "value";
+          }
+          getObj()[key()] ??= 9;
+          getObj()[key()] &&= 5;
+          console.log(JSON.stringify({ value: state.value, log }));
+        `,
+        ["--target=es2019"],
+      );
+      cleanup = result.cleanup;
+      expect(result.transpileExitCode).toBe(0);
+      expect(result.runStderr).toBe("");
+      expect(result.runOutput).toBe(
+        JSON.stringify({
+          value: 5,
+          log: ["obj", "key", "get:1", "obj", "key", "get:1", "set:5"],
+        }),
+      );
+    });
+
+    test("derived constructor fields initialize after super assigned through variable initializer", async () => {
+      const result = await transpileAndRun(
+        `
+          const log: string[] = [];
+          class Base {
+            v: number;
+            constructor(v: number) { log.push("base:" + v); this.v = v; }
+          }
+          class Child extends Base {
+            field = log.push("field:" + this.v);
+            constructor() {
+              log.push("before");
+              const result = super(log.push("arg"));
+              log.push("after:" + (result === this));
+            }
+          }
+          new Child();
+          console.log(JSON.stringify(log));
+        `,
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.transpileExitCode).toBe(0);
+      expect(result.runStderr).toBe("");
+      expect(result.runOutput).toBe(
+        JSON.stringify(["before", "arg", "base:2", "field:2", "after:true"]),
+      );
+    });
+
+    test("derived constructor fields initialize on nested super assignment paths", async () => {
+      const result = await transpileAndRun(
+        `
+          const log: string[] = [];
+          class Base {
+            v: number;
+            constructor(v: number) { log.push("base:" + v); this.v = v; }
+          }
+          class Child extends Base {
+            a = log.push("a:" + this.v);
+            b = log.push("b:" + this.v);
+            constructor(flag: boolean) {
+              log.push("before");
+              if (flag) {
+                const first = (log.push("branch"), super(7));
+                log.push("after:" + (first === this));
+              } else {
+                super(9);
+              }
+            }
+          }
+          new Child(true);
+          console.log(JSON.stringify(log));
+        `,
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.transpileExitCode).toBe(0);
+      expect(result.runStderr).toBe("");
+      expect(result.runOutput).toBe(
+        JSON.stringify(["before", "branch", "base:7", "a:7", "b:7", "after:true"]),
+      );
+    });
+
+    test("static blocks stay interleaved with static fields", async () => {
+      const result = await transpileAndRun(
+        `
+          const log: string[] = [];
+          class A {
+            static a = log.push("a");
+            static { log.push("block:" + this.a); }
+            static b = log.push("b");
+          }
+          console.log(JSON.stringify([A.a, A.b, log]));
+        `,
+        ["--target=es2019"],
+      );
+      cleanup = result.cleanup;
+      expect(result.transpileExitCode).toBe(0);
+      expect(result.runStderr).toBe("");
+      expect(result.runOutput).toBe(JSON.stringify([1, 3, ["a", "block:1", "b"]]));
+    });
+
+    test("static fields and multiple static blocks preserve class evaluation order in ES5 class lowering", async () => {
+      const result = await transpileAndRun(
+        `
+          const log: string[] = [];
+          class A {
+            static a = log.push("a");
+            static { log.push("block1:" + this.a); }
+            static b = log.push("b");
+            static { log.push("block2:" + this.b); }
+            static c = log.push("c");
+          }
+          console.log(JSON.stringify([A.a, A.b, A.c, log]));
+        `,
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.transpileExitCode).toBe(0);
+      expect(result.runStderr).toBe("");
+      expect(result.runOutput).toBe(
+        JSON.stringify([1, 3, 5, ["a", "block1:1", "b", "block2:3", "c"]]),
+      );
+    });
+
+    test("async generator finally yield works when for-await breaks", async () => {
+      const result = await transpileAndRun(
+        `
+          async function* gen() {
+            try {
+              yield 1;
+              yield await Promise.resolve(2);
+            } finally {
+              yield 3;
+            }
+          }
+          (async () => {
+            const out: number[] = [];
+            for await (const v of gen()) {
+              out.push(v);
+              if (v === 2) break;
+            }
+            console.log(JSON.stringify(out));
+          })();
+        `,
+        ["--target=es5"],
+      );
+      cleanup = result.cleanup;
+      expect(result.transpileExitCode).toBe(0);
+      expect(result.runStderr).toBe("");
+      expect(result.runOutput).toBe(JSON.stringify([1, 2]));
     });
   });
 


### PR DESCRIPTION
## 요약
- 실제 JS 감사 스크립트를 추가해 native Node 실행 결과와 ZTS transpile/bundle 결과를 비교합니다.
- `??=` ES2019 이하 변환에서 member getter 값을 중복 read하지 않도록 temp capture를 사용합니다.
- derived constructor의 `super()`가 변수 초기화식/sequence/분기 안에 있어도 instance field 초기화를 `super()` 실행 경로 뒤에 삽입합니다.
- static field/static block 평가 순서를 보존하고 async generator `return()` cleanup helper 동작을 수정합니다.
- TypeDoc CI 실패 원인이던 `EmotionOptions.autoLabel: false` 타입 누락을 런타임 동작과 맞췄습니다.

## 검증
- `zig build test --summary all`
- `bun test tests/downlevel-edge.test.ts --timeout 600000` (`tests/integration`)
- `node scripts/syntax-audit.mjs`
- `cd documents && bun run build`
- `bunx oxlint packages/core/index.ts tests/integration/tests/downlevel-edge.test.ts scripts/syntax-audit.mjs`
- `bunx oxfmt --check packages/core/index.ts tests/integration/tests/downlevel-edge.test.ts scripts/syntax-audit.mjs`
- `bun test --timeout 600000` (`tests/integration`)
- pre-push hook 통과 (`zig fmt --check`, `zig build test`, `oxlint`, `oxfmt --check`; 기존 unused 경고 5개만 출력)
