### PR TITLE
feat(transformer): emotion sourceMap — compiler.emotion.sourceMap 정식 스펙 지원

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1251,8 +1251,9 @@ function prepareNapiOptions(options: BuildOptions): Record<string, unknown> {
   const em = options.compiler?.emotion;
   if (em !== undefined && em !== false) {
     napiOptions.emotion = true;
-    if (typeof em === "object" && em.autoLabel === false) {
-      napiOptions.emotionAutoLabel = false;
+    if (typeof em === "object") {
+      if (em.autoLabel === false) napiOptions.emotionAutoLabel = false;
+      if (em.sourceMap === true) napiOptions.emotionSourceMap = true;
     }
   }
   return napiOptions;
@@ -1419,6 +1420,9 @@ export function buildAppSync(options: AppBuildOptions = {}): BuildResult {
     ...(compiler?.emotion !== undefined && compiler.emotion !== false ? { emotion: true } : {}),
     ...(typeof compiler?.emotion === "object" && compiler.emotion.autoLabel === false
       ? { emotionAutoLabel: false }
+      : {}),
+    ...(typeof compiler?.emotion === "object" && compiler.emotion.sourceMap === true
+      ? { emotionSourceMap: true }
       : {}),
   });
 }

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -567,6 +567,7 @@ fn napiBuildAppSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.
         .styled_components_minify = getObjectBool(env, opts_obj, "styledComponentsMinify", false),
         .emotion = getObjectBool(env, opts_obj, "emotion", false),
         .emotion_auto_label = getObjectBool(env, opts_obj, "emotionAutoLabel", true),
+        .emotion_source_map = getObjectBool(env, opts_obj, "emotionSourceMap", false),
     }) catch |err| {
         return throwError(env, @errorName(err));
     };
@@ -3574,6 +3575,7 @@ fn parseBuildOptions(
         .styled_components_minify = getObjectBool(env, opts_obj, "styledComponentsMinify", false),
         .emotion = getObjectBool(env, opts_obj, "emotion", false),
         .emotion_auto_label = getObjectBool(env, opts_obj, "emotionAutoLabel", true),
+        .emotion_source_map = getObjectBool(env, opts_obj, "emotionSourceMap", false),
         .collect_module_codes = getObjectBool(env, opts_obj, "collectModuleCodes", false),
         // RN 프리셋(bundler.zig의 RN_BOOL_PRESET 단일 소스): platform=react-native이면
         // 사용자가 명시하지 않아도 CLI와 동일하게 auto-enable. worklet_transform 없이는

--- a/src/app/build.zig
+++ b/src/app/build.zig
@@ -30,6 +30,8 @@ pub const AppBuildOptions = struct {
     emotion: bool = false,
     /// emotion.autoLabel 옵션 — false 면 autoLabel skip.
     emotion_auto_label: bool = true,
+    /// emotion.sourceMap 옵션 — true 면 css 템플릿 끝에 inline sourceMap 주석을 append.
+    emotion_source_map: bool = false,
 };
 
 pub const AppDevPrepareOptions = struct {
@@ -126,6 +128,7 @@ pub fn buildApp(allocator: std.mem.Allocator, opts: AppBuildOptions) !usize {
         .styled_components_minify = opts.styled_components_minify,
         .emotion = opts.emotion,
         .emotion_auto_label = opts.emotion_auto_label,
+        .emotion_source_map = opts.emotion_source_map,
     });
     defer bundler.deinit();
 

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -134,6 +134,8 @@ pub const BundleOptions = struct {
     emotion: bool = false,
     /// emotion.autoLabel 옵션 — false 면 autoLabel skip.
     emotion_auto_label: bool = true,
+    /// emotion.sourceMap 옵션 — true 면 css 템플릿 끝에 inline sourceMap 주석을 append.
+    emotion_source_map: bool = false,
     /// dev mode에서 per-module codes 수집 (HMR rebuild용). 초기 빌드에서는 false로 메모리 절감.
     collect_module_codes: bool = false,
     /// define 글로벌 치환 (--define:KEY=VALUE)
@@ -641,6 +643,7 @@ pub const Bundler = struct {
         worker_graph.styled_components_minify = self.options.styled_components_minify;
         worker_graph.emotion = self.options.emotion;
         worker_graph.emotion_auto_label = self.options.emotion_auto_label;
+        worker_graph.emotion_source_map = self.options.emotion_source_map;
         worker_graph.code_splitting = self.options.code_splitting;
         worker_graph.minify_identifiers = self.options.minify_identifiers;
         worker_graph.transform_options_base = self.buildTransformOptionsBase();
@@ -804,6 +807,7 @@ pub const Bundler = struct {
         graph.styled_components_minify = self.options.styled_components_minify;
         graph.emotion = self.options.emotion;
         graph.emotion_auto_label = self.options.emotion_auto_label;
+        graph.emotion_source_map = self.options.emotion_source_map;
         graph.code_splitting = self.options.code_splitting;
         graph.minify_identifiers = self.options.minify_identifiers;
         graph.transform_options_base = self.buildTransformOptionsBase();

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -148,6 +148,8 @@ pub const ModuleGraph = struct {
     emotion: bool = false,
     /// emotion.autoLabel 옵션 — false 면 autoLabel skip.
     emotion_auto_label: bool = true,
+    /// emotion.sourceMap 옵션 — true 면 css 템플릿 끝에 inline sourceMap 주석을 append.
+    emotion_source_map: bool = false,
     /// code splitting 활성화. helper module virtual import (#1961) 는 splitting 모드에서만
     /// 활성 — single-bundle 모드는 helper module 의 declaration 이 statement-level shake
     /// 로 elide 되는 회귀가 있어 기존 preamble 모델 유지.
@@ -1729,6 +1731,7 @@ pub const ModuleGraph = struct {
         opts.styled_components_minify = self.styled_components_minify;
         opts.emotion = self.emotion and is_user_code;
         opts.emotion_auto_label = self.emotion_auto_label;
+        opts.emotion_source_map = self.emotion_source_map;
         opts.plugins = merged_plugins;
         opts.jsx_transform = ast_ptr.has_jsx;
         opts.jsx_filename = module.path;

--- a/src/transformer/emotion_test.zig
+++ b/src/transformer/emotion_test.zig
@@ -810,6 +810,177 @@ test "emotion: ClassNames render-prop 안에 import css 가 있어도 scope-loca
     try expectAutoLabel(r.output, "div"); // ClassNames render-prop 의 className inline
 }
 
+// ─── emotion sourceMap (babel-plugin-emotion source-maps.js 호환) ───
+// `compiler.emotion: { sourceMap: true }` 일 때 css template 끝에 inline sourceMap
+// 주석을 append. DevTools 가 CSS 위치 → source 위치 추적 가능.
+
+fn expectSourceMapComment(output: []const u8) !void {
+    try std.testing.expect(
+        std.mem.indexOf(u8, output, "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,") != null,
+    );
+}
+
+test "emotion (sourceMap): css binding form — 템플릿 끝에 sourceMappingURL 주석 append" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const card = css`color: red;`;
+    ,
+        .{ .emotion = true, .emotion_source_map = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "card"); // autoLabel 도 동시 적용
+    try expectSourceMapComment(r.output);
+}
+
+test "emotion (sourceMap): autoLabel false + sourceMap true — sourceMap 만 적용" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const card = css`color: red;`;
+    ,
+        .{ .emotion = true, .emotion_auto_label = false, .emotion_source_map = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "label:card;") == null);
+    try expectSourceMapComment(r.output);
+}
+
+test "emotion (sourceMap): 옵션 비활성 시 sourceMap 주석 추가 안 됨" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const card = css`color: red;`;
+    ,
+        .{ .emotion = true, .jsx_filename = "test.tsx" }, // emotion_source_map 기본 false
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "card");
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "sourceMappingURL") == null);
+}
+
+test "emotion (sourceMap): 보간 있는 css — 마지막 quasi 끝에 append (첫 quasi 의 label 과 분리)" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const themed = css`color: ${color}; padding: 8px;`;
+    ,
+        .{ .emotion = true, .emotion_source_map = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "themed");
+    try expectSourceMapComment(r.output);
+    // sourceMap 주석이 마지막 quasi 안에 있어야 — backtick 직전에 위치
+    const backtick_pos = std.mem.lastIndexOf(u8, r.output, "`") orelse return error.NotFound;
+    const sm_pos = std.mem.indexOf(u8, r.output, "sourceMappingURL") orelse return error.NotFound;
+    try std.testing.expect(sm_pos < backtick_pos);
+}
+
+test "emotion (sourceMap): keyframes 도 sourceMap 적용" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { keyframes } from "@emotion/react";
+        \\const fadeIn = keyframes`from { opacity: 0; }`;
+    ,
+        .{ .emotion = true, .emotion_source_map = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "fadeIn");
+    try expectSourceMapComment(r.output);
+}
+
+test "emotion (sourceMap): styled.div 도 sourceMap 적용" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "@emotion/styled";
+        \\const Btn = styled.div`color: red;`;
+    ,
+        .{ .emotion = true, .emotion_source_map = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "Btn");
+    try expectSourceMapComment(r.output);
+}
+
+test "emotion (sourceMap): JSX inline `<div css={css`...`}>` 도 sourceMap 적용" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const el = <div css={css`color: red;`} />;
+    ,
+        .{ .emotion = true, .emotion_source_map = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "div");
+    try expectSourceMapComment(r.output);
+}
+
+test "emotion (sourceMap): base64 디코딩 → JSON 구조 정합성 검증" {
+    // 실제 base64 를 디코딩해 JSON 이 valid 한지, 핵심 필드가 들어있는지 확인.
+    // VLQ 인코딩 회귀 (sign bit / continuation bit 순서 등) 를 잡기 위함.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const card = css`color: red;`;
+    ,
+        .{ .emotion = true, .emotion_source_map = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+
+    // base64 추출 — `base64,` 와 ` */` 사이.
+    const prefix = "base64,";
+    const suffix = " */";
+    const start = std.mem.indexOf(u8, r.output, prefix) orelse return error.NoBase64Prefix;
+    const after_prefix = start + prefix.len;
+    const end = std.mem.indexOfPos(u8, r.output, after_prefix, suffix) orelse return error.NoBase64Suffix;
+    const b64 = r.output[after_prefix..end];
+
+    // 디코드.
+    const decoder = std.base64.standard.Decoder;
+    const json_len = try decoder.calcSizeForSlice(b64);
+    const json_buf = try std.testing.allocator.alloc(u8, json_len);
+    defer std.testing.allocator.free(json_buf);
+    try decoder.decode(json_buf, b64);
+
+    // sourceMap v3 spec 의 핵심 필드 검증.
+    try std.testing.expect(std.mem.startsWith(u8, json_buf, "{\"version\":3,"));
+    try std.testing.expect(std.mem.indexOf(u8, json_buf, "\"sources\":[\"test.tsx\"]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json_buf, "\"sourcesContent\":[") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json_buf, "\"mappings\":\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json_buf, "\"names\":[]") != null);
+}
+
+test "emotion (sourceMap): non-emotion tag 는 sourceMap 도 추가 안 됨" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\const foo = (s) => s;
+        \\const x = foo`color: red;`;
+    ,
+        .{ .emotion = true, .emotion_source_map = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // emotion binding 이 아니므로 sourceMap 도 적용 안 됨
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "sourceMappingURL") == null);
+}
+
 test "emotion: <Foo.Global styles={...}> false-positive 방지 — member 면 미인식" {
     // rightmost 가 "Global" 이라도 사용자 컴포넌트의 member 면 emotion Global 이 아님.
     // 단순 jsx_identifier 만 elementMatchesGlobal 매칭.

--- a/src/transformer/plugin_state.zig
+++ b/src/transformer/plugin_state.zig
@@ -94,6 +94,12 @@ pub const EmotionState = struct {
     /// 현재 frame 의 binding 들이 outer (import 기반) binding 보다 우선 적용 →
     /// destructured local 이름 (`{ css: cs }` 의 `cs`) 도 emotion css 로 인식.
     scope_stack: std.ArrayList(EmotionScopeFrame) = .empty,
+
+    /// sourceMap 활성 시 byte offset → (line, col) 변환을 위한 캐시. 각 entry 가
+    /// `\n` 의 byte offset. lazy-build (첫 sourceMap 호출 시 source 전체 스캔), 이후
+    /// binary search 로 O(log n) per template — 다수 emotion template 이 있는 파일에서
+    /// 전체 source re-scan 회피.
+    newline_offsets: ?std.ArrayList(u32) = null,
 };
 
 /// `<ClassNames>` render-prop 함수 매개변수에서 destructure 된 local binding 이름들.

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -128,6 +128,10 @@ pub const TransformOptions = struct {
     /// 자체는 동작 — 향후 Global / sourceMap 같은 다른 emotion features 와 분리).
     /// `compiler.emotion: { autoLabel: false }` 로 설정.
     emotion_auto_label: bool = true,
+    /// emotion.sourceMap 옵션 — true 면 css 템플릿 끝에 inline sourceMap 주석을 append.
+    /// `compiler.emotion: { sourceMap: true }`. babel-plugin-emotion 동작과 일치 —
+    /// DevTools 에서 CSS 위치 → source 위치 추적 가능.
+    emotion_source_map: bool = false,
     /// useDefineForClassFields=false: instance field를 constructor의 this.x = value 할당으로 변환.
     /// true(기본값)이면 class field를 그대로 유지 (TC39 [[Define]] semantics).
     /// false이면 TS 4.x 이전 동작 — field를 constructor body로 이동 ([[Set]] semantics).
@@ -587,6 +591,7 @@ pub const Transformer = struct {
         for (self.plugins.refresh.signatures.items) |s| self.allocator.free(s.signature);
         self.plugins.refresh.signatures.deinit(self.allocator);
         self.plugins.emotion.scope_stack.deinit(self.allocator);
+        if (self.plugins.emotion.newline_offsets) |*list| list.deinit(self.allocator);
         self.trailing_nodes.deinit(self.allocator);
         self.generator_label_stack.deinit(self.allocator);
         self.generator_temp_var_spans.deinit(self.allocator);
@@ -2966,7 +2971,7 @@ pub const Transformer = struct {
             const new_name_node = self.ast.getNode(new_name);
             if (new_name_node.tag == .binding_identifier or new_name_node.tag == .identifier_reference) {
                 const var_name = self.ast.getText(new_name_node.data.string_ref);
-                new_init = try emotion_mod.maybeApplyAutoLabel(self, new_init, var_name);
+                new_init = try emotion_mod.maybeTransformEmotionTemplate(self, new_init, var_name);
             }
         }
         const none = @intFromEnum(NodeIndex.none);

--- a/src/transformer/transformer/emotion.zig
+++ b/src/transformer/transformer/emotion.zig
@@ -42,6 +42,7 @@ const transformer_mod = @import("../transformer.zig");
 const Transformer = transformer_mod.Transformer;
 const Error = Transformer.Error;
 const plugin_state = @import("../plugin_state.zig");
+const sourcemap_mod = @import("../../codegen/sourcemap.zig");
 
 /// emotion `css` / `keyframes` named import 가 export 되는 source 들.
 pub const EMOTION_CSS_SOURCES: []const []const u8 = &.{
@@ -154,20 +155,21 @@ pub fn detectEmotionImport(self: *Transformer, node: Node) Error!void {
     }
 }
 
-/// `visitVariableDeclarator` 의 post-visit hook. tag 가 emotion binding 이면 첫 quasi 에
-/// `label:<var_name>;` prepend.
+/// `visitVariableDeclarator` 의 post-visit hook + JSX inline css attr hook 의 공용 코어.
+/// tag 가 emotion binding 이면 두 가지 transform 중 활성된 것 적용:
+///   - **autoLabel** — 첫 quasi 시작에 `label:<var_name>;` prepend (`emotion_auto_label`).
+///   - **sourceMap** — 마지막 quasi 끝에 inline `/*# sourceMappingURL=... */` append
+///     (`emotion_source_map`). babel-plugin-emotion 동작과 동일.
 ///
 /// 인식 형태:
 ///   - `css\`...\`` (css_binding identifier 직접)
-///   - `styled.div\`...\`` (styled_binding 의 static_member 첫 단계)
-///   - `styled(Component)\`...\`` (styled_binding 의 call 첫 단계)
-///
-/// 미인식 (후속 PR):
-///   - `css.x\`...\`` / `styled.div.attrs({})\`...\`` 같은 추가 chain
-pub fn maybeApplyAutoLabel(self: *Transformer, init_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
+///   - `styled.div\`...\`` / `styled(Component)\`...\`` (styled_binding chain)
+pub fn maybeTransformEmotionTemplate(
+    self: *Transformer,
+    init_idx: NodeIndex,
+    var_name: []const u8,
+) Error!NodeIndex {
     if (!self.options.emotion) return init_idx;
-    if (!self.options.emotion_auto_label) return init_idx; // opt-out: emotion 활성이지만 autoLabel skip
-    if (var_name.len == 0) return init_idx;
     if (init_idx.isNone()) return init_idx;
 
     const init_node = self.ast.getNode(init_idx);
@@ -181,7 +183,23 @@ pub fn maybeApplyAutoLabel(self: *Transformer, init_idx: NodeIndex, var_name: []
 
     if (!tagMatchesEmotion(self, tag_idx)) return init_idx;
 
-    const new_template = try prependLabelToTemplate(self, template_idx, var_name);
+    const apply_label = self.options.emotion_auto_label and var_name.len > 0;
+    const apply_sm = self.options.emotion_source_map;
+    if (!apply_label and !apply_sm) return init_idx;
+
+    const label_text: ?[]const u8 = if (apply_label) var_name else null;
+
+    var sm_buf: std.ArrayList(u8) = .empty;
+    defer sm_buf.deinit(self.allocator);
+    if (apply_sm) {
+        try ensureNewlineCache(self);
+        const pos = byteOffsetToLineColCached(self, init_node.span.start);
+        const filename = if (self.options.jsx_filename.len > 0) self.options.jsx_filename else "unknown";
+        try buildSourceMapComment(self.allocator, &sm_buf, self.ast.source, filename, pos);
+    }
+    const sm_text: ?[]const u8 = if (apply_sm) sm_buf.items else null;
+
+    const new_template = try transformEmotionTemplate(self, template_idx, label_text, sm_text);
     if (new_template == template_idx) return init_idx;
 
     const new_extra = try self.ast.addExtras(&.{
@@ -208,7 +226,8 @@ pub fn maybeApplyAutoLabel(self: *Transformer, init_idx: NodeIndex, var_name: []
 ///
 /// 공통 흐름: parser 가 attribute value 에 jsx_expression_container 를 만들지 않고
 /// 내부 expression 을 직접 저장 (parser/jsx.zig:301-325). label 추출 후 기존
-/// `maybeApplyAutoLabel` 로 template 변형 (emotion + autoLabel 옵션 검사도 거기서).
+/// `maybeTransformEmotionTemplate` 로 template 변형 (emotion + autoLabel + sourceMap
+/// 옵션 검사도 거기서).
 pub fn maybeApplyAutoLabelForJsxAttr(
     self: *Transformer,
     attr_name: []const u8,
@@ -231,7 +250,7 @@ pub fn maybeApplyAutoLabelForJsxAttr(
     if (is_styles and !elementMatchesGlobal(self, tag_name_idx)) return value_idx;
 
     const label = jsxElementLabel(self, tag_name_idx) orelse return value_idx;
-    return try maybeApplyAutoLabel(self, value_idx, label);
+    return try maybeTransformEmotionTemplate(self, value_idx, label);
 }
 
 /// JSX element 가 import 된 `Global` binding 과 일치하는지 — 단순 identifier 만.
@@ -426,23 +445,32 @@ fn chainRootIsStyledBinding(self: *Transformer, tag_idx: NodeIndex) bool {
     }
 }
 
-/// template_literal 의 첫 quasi 시작에 `label:<name>;` prepend. no-interp / interp 둘 다 처리.
-fn prependLabelToTemplate(self: *Transformer, template_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
+/// template_literal 변환 — `label_text` 가 있으면 첫 quasi 에 prepend, `source_map_text` 가
+/// 있으면 마지막 quasi 에 append. no-interp / interp 둘 다 처리.
+/// 둘 다 null 이면 호출되지 않음 (caller 가 가드).
+fn transformEmotionTemplate(
+    self: *Transformer,
+    template_idx: NodeIndex,
+    label_text: ?[]const u8,
+    source_map_text: ?[]const u8,
+) Error!NodeIndex {
     const node = self.ast.getNode(template_idx);
     if (node.tag != .template_literal) return template_idx;
 
     if (node.data.none == 0) {
-        return try prependLabelToNoInterpTemplate(self, template_idx, node, var_name);
+        return try transformNoInterpTemplate(self, template_idx, node, label_text, source_map_text);
     }
-    return try prependLabelToInterpTemplate(self, template_idx, node, var_name);
+    return try transformInterpTemplate(self, template_idx, node, label_text, source_map_text);
 }
 
-/// no-interp `\`text\`` — `\`label:<name>;text\`` 빌드.
-fn prependLabelToNoInterpTemplate(
+/// no-interp: 단일 span (`\`text\``) — label 은 backtick 다음, sourceMap 은 closing
+/// backtick 직전에 삽입.
+fn transformNoInterpTemplate(
     self: *Transformer,
     template_idx: NodeIndex,
     node: ast_mod.Node,
-    var_name: []const u8,
+    label_text: ?[]const u8,
+    source_map_text: ?[]const u8,
 ) Error!NodeIndex {
     const raw = self.ast.getText(node.span);
     if (raw.len < 2 or raw[0] != '`' or raw[raw.len - 1] != '`') return template_idx;
@@ -451,8 +479,9 @@ fn prependLabelToNoInterpTemplate(
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(self.allocator);
     try buf.append(self.allocator, '`');
-    try writeLabelPrefix(self.allocator, &buf, var_name);
+    if (label_text) |l| try writeLabelPrefix(self.allocator, &buf, l);
     try buf.appendSlice(self.allocator, inner);
+    if (source_map_text) |sm| try buf.appendSlice(self.allocator, sm);
     try buf.append(self.allocator, '`');
 
     const new_span = try self.ast.addString(buf.items);
@@ -463,12 +492,14 @@ fn prependLabelToNoInterpTemplate(
     });
 }
 
-/// interp template — 첫 template_element 시작에 `label:<name>;` prepend.
-fn prependLabelToInterpTemplate(
+/// interp: children = [te0, expr0, te1, expr1, ..., teN]. label 은 te0 시작에,
+/// sourceMap 은 teN (마지막 template_element) 끝에 삽입.
+fn transformInterpTemplate(
     self: *Transformer,
     template_idx: NodeIndex,
     node: ast_mod.Node,
-    var_name: []const u8,
+    label_text: ?[]const u8,
+    source_map_text: ?[]const u8,
 ) Error!NodeIndex {
     const list = node.data.list;
     if (list.len == 0) return template_idx;
@@ -478,32 +509,75 @@ fn prependLabelToInterpTemplate(
     const first_node = self.ast.getNode(first_idx);
     if (first_node.tag != .template_element) return template_idx;
 
-    // 첫 element span: `\`text${` (head) — 첫 char 가 backtick, 끝이 `${`.
-    const raw = self.ast.getText(first_node.span);
-    if (raw.len < 3 or raw[0] != '`') return template_idx;
-    if (raw[raw.len - 2] != '$' or raw[raw.len - 1] != '{') return template_idx;
-    const inner = raw[1 .. raw.len - 2];
+    // 마지막 template_element 위치 (children 중 가장 큰 i where items[i].tag == template_element).
+    var last_te_pos: usize = 0;
+    for (items, 0..) |raw_idx, i| {
+        const idx: NodeIndex = @enumFromInt(raw_idx);
+        if (self.ast.getNode(idx).tag == .template_element) last_te_pos = i;
+    }
+    const last_idx: NodeIndex = @enumFromInt(items[last_te_pos]);
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(self.allocator);
-    try buf.append(self.allocator, '`');
-    try writeLabelPrefix(self.allocator, &buf, var_name);
-    try buf.appendSlice(self.allocator, inner);
-    try buf.append(self.allocator, '$');
-    try buf.append(self.allocator, '{');
+    // First element 재작성 — `\`text${` → `\`label:<name>;text${`
+    var new_first: NodeIndex = first_idx;
+    if (label_text) |l| {
+        const raw = self.ast.getText(first_node.span);
+        if (raw.len < 3 or raw[0] != '`') return template_idx;
+        if (raw[raw.len - 2] != '$' or raw[raw.len - 1] != '{') return template_idx;
+        const inner = raw[1 .. raw.len - 2];
 
-    const new_first_span = try self.ast.addString(buf.items);
-    const new_first = try self.ast.addNode(.{
-        .tag = .template_element,
-        .span = new_first_span,
-        .data = .{ .none = 0 },
-    });
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(self.allocator);
+        try buf.append(self.allocator, '`');
+        try writeLabelPrefix(self.allocator, &buf, l);
+        try buf.appendSlice(self.allocator, inner);
+        try buf.appendSlice(self.allocator, "${");
 
-    // children list 재구성 — 첫 번째만 교체, 나머지는 그대로.
+        const new_first_span = try self.ast.addString(buf.items);
+        new_first = try self.ast.addNode(.{
+            .tag = .template_element,
+            .span = new_first_span,
+            .data = .{ .none = 0 },
+        });
+    }
+
+    // Last element 재작성 — `}text\`` → `}text<sourcemap>\``
+    var new_last: NodeIndex = last_idx;
+    if (source_map_text) |sm| {
+        const last_node = self.ast.getNode(last_idx);
+        const raw = self.ast.getText(last_node.span);
+        if (raw.len < 2 or raw[raw.len - 1] != '`') return template_idx;
+        if (raw[0] != '}') return template_idx;
+        const inner = raw[1 .. raw.len - 1];
+
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(self.allocator);
+        try buf.append(self.allocator, '}');
+        try buf.appendSlice(self.allocator, inner);
+        try buf.appendSlice(self.allocator, sm);
+        try buf.append(self.allocator, '`');
+
+        const new_last_span = try self.ast.addString(buf.items);
+        new_last = try self.ast.addNode(.{
+            .tag = .template_element,
+            .span = new_last_span,
+            .data = .{ .none = 0 },
+        });
+    }
+
+    if (new_first == first_idx and new_last == last_idx) return template_idx;
+
+    // children list 재구성 — first/last 만 교체.
     const top = self.scratch.items.len;
     defer self.scratch.shrinkRetainingCapacity(top);
-    try self.scratch.append(self.allocator, new_first);
-    for (items[1..]) |raw_idx| try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
+    for (items, 0..) |raw_idx, i| {
+        if (i == 0 and new_first != first_idx) {
+            try self.scratch.append(self.allocator, new_first);
+        } else if (i == last_te_pos and new_last != last_idx) {
+            try self.scratch.append(self.allocator, new_last);
+        } else {
+            try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
+        }
+    }
 
     const new_list = try self.ast.addNodeList(self.scratch.items[top..]);
     return self.ast.addNode(.{
@@ -517,4 +591,80 @@ fn writeLabelPrefix(allocator: std.mem.Allocator, buf: *std.ArrayList(u8), var_n
     try buf.appendSlice(allocator, "label:");
     try buf.appendSlice(allocator, var_name);
     try buf.append(allocator, ';');
+}
+
+// ─── sourceMap 생성 (babel-plugin-emotion source-maps.js 호환) ───
+//
+// 한 css template 마다 inline sourceMap 1개 매핑: `generated:{1,0} → source:{line, col}`.
+// CSS 안에 `/*# sourceMappingURL=data:application/json;base64,... */` 주석으로 embed —
+// emotion 런타임이 CSS 출력에 보존, DevTools 가 해석해 source 위치 점프 가능.
+
+pub const LineCol = struct { line: u32, col: u32 };
+
+/// 첫 sourceMap 호출 시 source 전체를 한 번 스캔해 newline 위치를 캐시. 이후 호출에서는
+/// binary search 로 O(log n) lookup — 다수 emotion template 이 있는 파일에서 O(n²) 회피.
+fn ensureNewlineCache(self: *Transformer) Error!void {
+    if (self.plugins.emotion.newline_offsets != null) return;
+    var list: std.ArrayList(u32) = .empty;
+    errdefer list.deinit(self.allocator);
+    for (self.ast.source, 0..) |c, i| {
+        if (c == '\n') try list.append(self.allocator, @intCast(i));
+    }
+    self.plugins.emotion.newline_offsets = list;
+}
+
+/// 캐시된 newline offset 들로 byte offset → 0-indexed (line, col) — sourceMap VLQ 호환.
+fn byteOffsetToLineColCached(self: *Transformer, offset: u32) LineCol {
+    const offsets = if (self.plugins.emotion.newline_offsets) |list| list.items else return .{ .line = 0, .col = 0 };
+    // first index where offsets[i] >= offset
+    var lo: usize = 0;
+    var hi: usize = offsets.len;
+    while (lo < hi) {
+        const mid = (lo + hi) / 2;
+        if (offsets[mid] < offset) lo = mid + 1 else hi = mid;
+    }
+    const line: u32 = @intCast(lo);
+    const col: u32 = if (lo == 0) offset else offset - offsets[lo - 1] - 1;
+    return .{ .line = line, .col = col };
+}
+
+/// inline sourceMap 주석을 `buf` 에 빌드: `/*# sourceMappingURL=data:application/json;
+/// charset=utf-8;base64,<b64> */` 형식.
+fn buildSourceMapComment(
+    allocator: std.mem.Allocator,
+    buf: *std.ArrayList(u8),
+    source: []const u8,
+    filename: []const u8,
+    pos: LineCol,
+) Error!void {
+    // VLQ mappings — 단일 segment: gen_col=0, src_idx=0, src_line=pos.line, src_col=pos.col.
+    var vlq_buf: std.ArrayList(u8) = .empty;
+    defer vlq_buf.deinit(allocator);
+    try sourcemap_mod.encodeVLQ(allocator, &vlq_buf, 0);
+    try sourcemap_mod.encodeVLQ(allocator, &vlq_buf, 0);
+    try sourcemap_mod.encodeVLQ(allocator, &vlq_buf, @intCast(pos.line));
+    try sourcemap_mod.encodeVLQ(allocator, &vlq_buf, @intCast(pos.col));
+
+    // JSON: {"version":3,"sources":["<filename>"],"sourcesContent":["<source>"],
+    //        "mappings":"<vlq>","names":[]}
+    var json: std.ArrayList(u8) = .empty;
+    defer json.deinit(allocator);
+    try json.appendSlice(allocator, "{\"version\":3,\"sources\":[");
+    try sourcemap_mod.appendJsonStringTo(allocator, &json, filename);
+    try json.appendSlice(allocator, "],\"sourcesContent\":[");
+    try sourcemap_mod.appendJsonStringTo(allocator, &json, source);
+    try json.appendSlice(allocator, "],\"mappings\":\"");
+    try json.appendSlice(allocator, vlq_buf.items);
+    try json.appendSlice(allocator, "\",\"names\":[]}");
+
+    // base64 encode JSON
+    const enc = std.base64.standard.Encoder;
+    const b64_len = enc.calcSize(json.items.len);
+    const b64_buf = try allocator.alloc(u8, b64_len);
+    defer allocator.free(b64_buf);
+    _ = enc.encode(b64_buf, json.items);
+
+    try buf.appendSlice(allocator, "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,");
+    try buf.appendSlice(allocator, b64_buf);
+    try buf.appendSlice(allocator, " */");
 }

--- a/tests/integration/tests/emotion-v10.test.ts
+++ b/tests/integration/tests/emotion-v10.test.ts
@@ -249,6 +249,25 @@ describe.skipIf(!hasV10)("Emotion v10 — autoLabel + 번들링", () => {
     expect(r.out).toContain("color: red");
   });
 
+  // ─── sourceMap (babel-plugin-emotion 호환) ───
+
+  it("@emotion/core v10 — sourceMap: true 일 때 inline sourceMap 주석 추가", async () => {
+    const r = await runV10Bundle({
+      source: `
+        import { css } from "@emotion/core";
+        const card = css\`color: hotpink;\`;
+        console.log(card);
+      `,
+      config: { compiler: { emotion: { sourceMap: true } } },
+    });
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.out).toContain("label:card;");
+    expect(r.out).toContain("/*# sourceMappingURL=data:application/json;charset=utf-8;base64,");
+    // base64 안에 source filename 이 인코딩됐는지 (decoding 검증은 unit 테스트가 함)
+    expect(r.out).toContain("hotpink");
+  });
+
   it("v10 격리 검증 — fixture 의 @emotion/core 가 v10.x 인지", async () => {
     const pkgPath = join(EMOTION_V10_FIXTURE_NODE_MODULES, "@emotion/core/package.json");
     const pkg = JSON.parse(await readFile(pkgPath, "utf-8"));


### PR DESCRIPTION
## 변환

```ts
// 입력
import { css } from "@emotion/react";
const card = css`color: red;`;

// 출력 (sourceMap: true 일 때)
const card = css`label:card;color: red;/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbInRlc3QudHN4Il0sLi4ufQ== */`;
```

base64 디코드 = sourceMap v3 JSON. DevTools 가 CSS 위치 → source 위치 역추적.

## babel-plugin-emotion 호환

`references/emotion/packages/babel-plugin/src/utils/source-maps.js` 동일 출력 형식:
- 한 css template 마다 단일 매핑 (`generated 1:0 → source line:col`)
- `sourcesContent` 에 전체 소스 embed (DevTools 점프 가능)
- VLQ + base64 인코딩

## 옵션

```ts
// zts.config.ts
export default defineConfig({
  compiler: {
    emotion: { sourceMap: true },
  },
});
```

기본값 `false` (babel-plugin-emotion 동일). 비-emotion 프로젝트 영향 0.

## 적용 범위

`maybeTransformEmotionTemplate` 가 인식하는 모든 패턴 — css / keyframes / styled chain / JSX inline css / `<Global styles>` / `<ClassNames>` 의 destructured css / injectGlobal — 전부 sourceMap 적용.

## 구조 변경

| Before | After |
|---|---|
| `maybeApplyAutoLabel` | `maybeTransformEmotionTemplate` (label + sourceMap 둘 다 처리) |
| `prependLabelToTemplate` | `transformEmotionTemplate(label?, source_map?)` |
| `prependLabelTo{NoInterp,Interp}Template` | `transform{NoInterp,Interp}Template` (양쪽 quasi 처리) |

interp template 의 경우 첫 quasi 에 label, **마지막 quasi 에 sourceMap** (다른 element).

## 성능 — newline offset 캐시

byte offset → (line, col) 변환을 매 template 마다 source 전체 스캔하면 다수 template 파일에서 O(n²). `EmotionState.newline_offsets: ?ArrayList(u32)` 에 lazy 빌드 (첫 호출 시 1회 source scan), 이후 binary search → O(log n) per template.

## 옵션 plumbing (8 layer)

`TransformOptions` / `BundleOptions` / `Graph` / `AppBuildOptions` / NAPI / `packages/core/index.ts` 에 `emotion_source_map` (또는 `emotionSourceMap`) 추가. 기존 `emotion_auto_label` 패턴과 동일.

## 코드 리뷰 (3-agent /simplify) P1 모두 반영

| 이슈 | 수정 |
|---|---|
| 함수명 `maybeApplyAutoLabel` 가 sourceMap 도 처리하면서 misleading | `maybeTransformEmotionTemplate` 로 rename |
| `byteOffsetToLineCol` O(n) per template = O(n²) 전체 | `newline_offsets` 캐시 + binary search |
| 모든 sourceMap 테스트가 substring 만 검사 → VLQ encoding 회귀 가드 부족 | base64 decode + JSON 구조 검증 테스트 추가 |

## 테스트

**유닛 (+9 케이스)**:
- css binding / autoLabel false + sourceMap true (sourceMap 만 적용)
- 옵션 비활성 시 sourceMap 추가 안 됨
- 보간 있는 css (마지막 quasi 에 위치 검증)
- keyframes / styled.div / JSX inline css
- non-emotion tag 미인식
- **base64 디코딩 → JSON 정합성** (version 3 / sources / sourcesContent / mappings / names 필드 검증)

**통합 (+1 v10)**: `@emotion/core` v10 에서 sourceMap 활성 + 실제 번들에 주석 포함 검증.

## 검증

- `zig build test` 통과 (전체 4212 + 신규 9 케이스)
- v10 통합 (12/12) + v11 회귀 (9/9) 통과
- 비-emotion 프로젝트 영향 0 (option 기본값 false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)