### PR TITLE
feat(transformer): emotion autoLabel mode (never/always/dev-only)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1252,7 +1252,15 @@ function prepareNapiOptions(options: BuildOptions): Record<string, unknown> {
   if (em !== undefined && em !== false) {
     napiOptions.emotion = true;
     if (typeof em === "object") {
-      if (em.autoLabel === false) napiOptions.emotionAutoLabel = false;
+      // autoLabel: string ("never"|"always"|"dev-only") 또는 boolean (legacy false=never).
+      // 누락 시 NAPI 측 default `.always`.
+      if (em.autoLabel === false) {
+        napiOptions.emotionAutoLabel = "never";
+      } else if (em.autoLabel === true) {
+        napiOptions.emotionAutoLabel = "always";
+      } else if (typeof em.autoLabel === "string") {
+        napiOptions.emotionAutoLabel = em.autoLabel;
+      }
       if (em.sourceMap === true) napiOptions.emotionSourceMap = true;
       if (typeof em.labelFormat === "string" && em.labelFormat.length > 0) {
         napiOptions.emotionLabelFormat = em.labelFormat;
@@ -1422,8 +1430,12 @@ export function buildAppSync(options: AppBuildOptions = {}): BuildResult {
       : {}),
     ...(compiler?.emotion !== undefined && compiler.emotion !== false ? { emotion: true } : {}),
     ...(typeof compiler?.emotion === "object" && compiler.emotion.autoLabel === false
-      ? { emotionAutoLabel: false }
-      : {}),
+      ? { emotionAutoLabel: "never" }
+      : typeof compiler?.emotion === "object" && compiler.emotion.autoLabel === true
+        ? { emotionAutoLabel: "always" }
+        : typeof compiler?.emotion === "object" && typeof compiler.emotion.autoLabel === "string"
+          ? { emotionAutoLabel: compiler.emotion.autoLabel }
+          : {}),
     ...(typeof compiler?.emotion === "object" && compiler.emotion.sourceMap === true
       ? { emotionSourceMap: true }
       : {}),

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -224,6 +224,30 @@ fn getObjectString(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, alloc
     return getStringArg(env, val, alloc);
 }
 
+/// `emotionAutoLabel` 옵션을 enum 값으로 파싱. JS 측에서 string ("never"/"always"/
+/// "dev-only") 또는 boolean (legacy: false=never, true=always) 으로 보낼 수 있음.
+/// 누락 시 기본 `.always`.
+fn getAutoLabelMode(env: c.napi_env, obj: c.napi_value, alloc: std.mem.Allocator) @import("zts_lib").transformer.transformer.AutoLabelMode {
+    const val = getNamedProperty(env, obj, "emotionAutoLabel") orelse return .always;
+    var ty: c.napi_valuetype = undefined;
+    if (c.napi_typeof(env, val, &ty) != c.napi_ok) return .always;
+    switch (ty) {
+        c.napi_boolean => {
+            var b: bool = true;
+            _ = c.napi_get_value_bool(env, val, &b);
+            return if (b) .always else .never;
+        },
+        c.napi_string => {
+            const s = getStringArg(env, val, alloc) orelse return .always;
+            if (std.mem.eql(u8, s, "never")) return .never;
+            if (std.mem.eql(u8, s, "always")) return .always;
+            if (std.mem.eql(u8, s, "dev-only")) return .dev_only;
+            return .always;
+        },
+        else => return .always,
+    }
+}
+
 /// plugin onLoad 의 `contents` 가 string 일 수도 있고 Uint8Array/Buffer 일 수도 있음.
 /// 후자는 binary-safe (PNG/JPG 등 raw bytes 가 utf-8 invalid 일 수 있음). (#2157 follow-up)
 /// - string: utf-8 디코드된 byte slice 그대로 (빈 string 도 valid — `loader: 'empty'` 등)
@@ -566,7 +590,7 @@ fn napiBuildAppSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.
         .styled_components_ssr = getObjectBool(env, opts_obj, "styledComponentsSsr", true),
         .styled_components_minify = getObjectBool(env, opts_obj, "styledComponentsMinify", false),
         .emotion = getObjectBool(env, opts_obj, "emotion", false),
-        .emotion_auto_label = getObjectBool(env, opts_obj, "emotionAutoLabel", true),
+        .emotion_auto_label = getAutoLabelMode(env, opts_obj, native_alloc),
         .emotion_source_map = getObjectBool(env, opts_obj, "emotionSourceMap", false),
         .emotion_label_format = getObjectString(env, opts_obj, "emotionLabelFormat", native_alloc) orelse "",
     }) catch |err| {
@@ -3575,7 +3599,7 @@ fn parseBuildOptions(
         .styled_components_ssr = getObjectBool(env, opts_obj, "styledComponentsSsr", true),
         .styled_components_minify = getObjectBool(env, opts_obj, "styledComponentsMinify", false),
         .emotion = getObjectBool(env, opts_obj, "emotion", false),
-        .emotion_auto_label = getObjectBool(env, opts_obj, "emotionAutoLabel", true),
+        .emotion_auto_label = getAutoLabelMode(env, opts_obj, native_alloc),
         .emotion_source_map = getObjectBool(env, opts_obj, "emotionSourceMap", false),
         .emotion_label_format = getObjectString(env, opts_obj, "emotionLabelFormat", native_alloc) orelse "",
         .collect_module_codes = getObjectBool(env, opts_obj, "collectModuleCodes", false),

--- a/src/app/build.zig
+++ b/src/app/build.zig
@@ -28,8 +28,8 @@ pub const AppBuildOptions = struct {
     styled_components_minify: bool = false,
     /// emotion 1st-party transform (compiler.emotion).
     emotion: bool = false,
-    /// emotion.autoLabel 옵션 — false 면 autoLabel skip.
-    emotion_auto_label: bool = true,
+    /// emotion.autoLabel 모드 — `.never` / `.always` (default) / `.dev_only`.
+    emotion_auto_label: @import("../transformer/transformer.zig").AutoLabelMode = .always,
     /// emotion.sourceMap 옵션 — true 면 css 템플릿 끝에 inline sourceMap 주석을 append.
     emotion_source_map: bool = false,
     /// emotion.labelFormat 옵션 — label 포맷 템플릿.

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -132,8 +132,8 @@ pub const BundleOptions = struct {
     styled_components_minify: bool = false,
     /// emotion 1st-party transform (compiler.emotion). 활성 시 css 템플릿에 autoLabel 적용.
     emotion: bool = false,
-    /// emotion.autoLabel 옵션 — false 면 autoLabel skip.
-    emotion_auto_label: bool = true,
+    /// emotion.autoLabel 모드 — `.never` / `.always` (default) / `.dev_only`.
+    emotion_auto_label: @import("../transformer/transformer.zig").AutoLabelMode = .always,
     /// emotion.sourceMap 옵션 — true 면 css 템플릿 끝에 inline sourceMap 주석을 append.
     emotion_source_map: bool = false,
     /// emotion.labelFormat 옵션 — label 이름 포맷 템플릿 (e.g. `[filename]--[local]`).

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -146,8 +146,8 @@ pub const ModuleGraph = struct {
     styled_components_minify: bool = false,
     /// emotion 1st-party transform (compiler.emotion).
     emotion: bool = false,
-    /// emotion.autoLabel 옵션 — false 면 autoLabel skip.
-    emotion_auto_label: bool = true,
+    /// emotion.autoLabel 모드 — `.never` / `.always` (default) / `.dev_only`.
+    emotion_auto_label: @import("../transformer/transformer.zig").AutoLabelMode = .always,
     /// emotion.sourceMap 옵션 — true 면 css 템플릿 끝에 inline sourceMap 주석을 append.
     emotion_source_map: bool = false,
     /// emotion.labelFormat 옵션 — label 이름 포맷 템플릿 (`[local]`/`[filename]`/`[dirname]`).

--- a/src/transformer/emotion_test.zig
+++ b/src/transformer/emotion_test.zig
@@ -155,7 +155,7 @@ test "emotion: { autoLabel: false } 옵션 — emotion 활성이지만 label ski
         \\import { css } from "@emotion/react";
         \\const button = css`color: red;`;
     ,
-        .{ .emotion = true, .emotion_auto_label = false, .jsx_filename = "test.tsx" },
+        .{ .emotion = true, .emotion_auto_label = .never, .jsx_filename = "test.tsx" },
         default_cg,
         ".tsx",
     );
@@ -403,7 +403,7 @@ test "emotion: JSX inline css — emotion_auto_label=false 면 skip" {
         \\import { css } from "@emotion/react";
         \\const el = <div css={css`color: red;`} />;
     ,
-        .{ .emotion = true, .emotion_auto_label = false, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        .{ .emotion = true, .emotion_auto_label = .never, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
         default_cg,
         ".tsx",
     );
@@ -841,7 +841,7 @@ test "emotion (sourceMap): autoLabel false + sourceMap true — sourceMap 만 �
         \\import { css } from "@emotion/react";
         \\const card = css`color: red;`;
     ,
-        .{ .emotion = true, .emotion_auto_label = false, .emotion_source_map = true, .jsx_filename = "test.tsx" },
+        .{ .emotion = true, .emotion_auto_label = .never, .emotion_source_map = true, .jsx_filename = "test.tsx" },
         default_cg,
         ".tsx",
     );
@@ -964,6 +964,101 @@ test "emotion (sourceMap): base64 디코딩 → JSON 구조 정합성 검증" {
     try std.testing.expect(std.mem.indexOf(u8, json_buf, "\"sourcesContent\":[") != null);
     try std.testing.expect(std.mem.indexOf(u8, json_buf, "\"mappings\":\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, json_buf, "\"names\":[]") != null);
+}
+
+// ─── autoLabel mode (never / always / dev-only) ───
+// `.dev_only` 는 `process.env.NODE_ENV` define 이 `"production"` 이면 `.never`,
+// 아니면 `.always`. compile-time 결정 — runtime conditional 아님.
+
+const transformer_mod = @import("transformer.zig");
+
+const define_prod = [_]transformer_mod.DefineEntry{
+    .{ .key = "process.env.NODE_ENV", .value = "\"production\"" },
+};
+const define_dev = [_]transformer_mod.DefineEntry{
+    .{ .key = "process.env.NODE_ENV", .value = "\"development\"" },
+};
+
+test "emotion (autoLabel mode): .always — 기존 동작 유지" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const card = css`color: red;`;
+    ,
+        .{ .emotion = true, .emotion_auto_label = .always, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "card");
+}
+
+test "emotion (autoLabel mode): .never — label 추가 안 됨" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const card = css`color: red;`;
+    ,
+        .{ .emotion = true, .emotion_auto_label = .never, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "label:") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "color: red") != null);
+}
+
+test "emotion (autoLabel mode): .dev_only + NODE_ENV=production → .never 동작" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const card = css`color: red;`;
+    ,
+        .{
+            .emotion = true,
+            .emotion_auto_label = .dev_only,
+            .define = &define_prod,
+            .jsx_filename = "test.tsx",
+        },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // production define → label 안 들어감
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "label:card;") == null);
+}
+
+test "emotion (autoLabel mode): .dev_only + NODE_ENV=development → .always 동작" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const card = css`color: red;`;
+    ,
+        .{
+            .emotion = true,
+            .emotion_auto_label = .dev_only,
+            .define = &define_dev,
+            .jsx_filename = "test.tsx",
+        },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "card");
+}
+
+test "emotion (autoLabel mode): .dev_only — define 없으면 .always (기본 dev 가정)" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const card = css`color: red;`;
+    ,
+        .{ .emotion = true, .emotion_auto_label = .dev_only, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "card");
 }
 
 // ─── labelFormat ───

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -67,6 +67,19 @@ pub const Plugin = plugin_mod.Plugin;
 /// `parser.scan_results.DefineEntry` 와 동일 정의 — parser 의 inline scan 도 같은 entries 사용.
 pub const DefineEntry = @import("../parser/scan_results.zig").DefineEntry;
 
+/// emotion.autoLabel 모드. 다른 emotion 도구들 (`@emotion/babel-plugin` 등) 의
+/// `'always' | 'dev-only' | 'never'` 와 동일 의미.
+pub const AutoLabelMode = enum {
+    /// label 적용 안 함.
+    never,
+    /// 항상 label 적용 (ZTS 기본 — 기존 사용자 영향 없음).
+    always,
+    /// `process.env.NODE_ENV` define 이 `"production"` 이면 .never, 아니면 .always.
+    /// runtime conditional 이 아니라 compile-time 단정 — `--define:process.env.NODE_ENV=...`
+    /// 가 설정돼 있어야 의미 있음.
+    dev_only,
+};
+
 /// 정규화 버퍼 크기. `process.env.NODE_ENV`류 식별자 체인은 훨씬 짧지만 여유.
 /// 초과 시 normalizeOptionalChain은 null을 반환해 치환을 스킵한다.
 const DEFINE_KEY_NORM_BUF: usize = 256;
@@ -124,10 +137,13 @@ pub const TransformOptions = struct {
     /// 활성 시 `const X = css\`...\`` 같은 선언에 `label:X;` 자동 prepend (autoLabel).
     /// `import { css } from "@emotion/react"` 의 named binding 추적.
     emotion: bool = false,
-    /// emotion.autoLabel 옵션 — false 면 autoLabel transform 만 skip (binding tracking
-    /// 자체는 동작 — 향후 Global / sourceMap 같은 다른 emotion features 와 분리).
-    /// `compiler.emotion: { autoLabel: false }` 로 설정.
-    emotion_auto_label: bool = true,
+    /// emotion.autoLabel 옵션. 3 모드:
+    ///   - `.always` — 항상 label 적용 (기본).
+    ///   - `.never` — 절대 label 적용 안 함.
+    ///   - `.dev_only` — `process.env.NODE_ENV` define 이 `"production"` 이면 .never,
+    ///     아니면 .always (compile-time 결정 — runtime conditional emit 아님).
+    /// `compiler.emotion: { autoLabel: "always" | "dev-only" | "never" | false (=never) }`.
+    emotion_auto_label: AutoLabelMode = .always,
     /// emotion.sourceMap 옵션 — true 면 css 템플릿 끝에 inline sourceMap 주석을 append.
     /// `compiler.emotion: { sourceMap: true }`. babel-plugin-emotion 동작과 일치 —
     /// DevTools 에서 CSS 위치 → source 위치 추적 가능.

--- a/src/transformer/transformer/emotion.zig
+++ b/src/transformer/transformer/emotion.zig
@@ -183,7 +183,7 @@ pub fn maybeTransformEmotionTemplate(
 
     if (!tagMatchesEmotion(self, tag_idx)) return init_idx;
 
-    const apply_label = self.options.emotion_auto_label and var_name.len > 0;
+    const apply_label = labelEnabledNow(self) and var_name.len > 0;
     const apply_sm = self.options.emotion_source_map;
     if (!apply_label and !apply_sm) return init_idx;
 
@@ -585,6 +585,34 @@ fn transformInterpTemplate(
         .span = node.span,
         .data = .{ .list = new_list },
     });
+}
+
+/// 현재 빌드에서 autoLabel 적용 여부. `.always` 즉시 true, `.never` 즉시 false,
+/// `.dev_only` 는 `process.env.NODE_ENV` define 이 `"production"` 인지 확인 — 그러면
+/// false (production build), 아니면 true (development build).
+fn labelEnabledNow(self: *Transformer) bool {
+    return switch (self.options.emotion_auto_label) {
+        .never => false,
+        .always => true,
+        .dev_only => !defineMatchesProduction(self),
+    };
+}
+
+/// `process.env.NODE_ENV` define entry 가 `"production"` 으로 설정됐는지.
+/// value 는 JS 표현식 string (e.g. `"\"production\""` JSON-encoded). quote 제거 후 비교.
+fn defineMatchesProduction(self: *Transformer) bool {
+    for (self.options.define) |entry| {
+        if (!std.mem.eql(u8, entry.key, "process.env.NODE_ENV")) continue;
+        const v = entry.value;
+        if (v.len < 2) return false;
+        const first = v[0];
+        const last = v[v.len - 1];
+        if ((first == '"' and last == '"') or (first == '\'' and last == '\'')) {
+            return std.mem.eql(u8, v[1 .. v.len - 1], "production");
+        }
+        return false;
+    }
+    return false;
 }
 
 fn writeLabelPrefix(self: *Transformer, buf: *std.ArrayList(u8), var_name: []const u8) Error!void {


### PR DESCRIPTION
## 변환

```ts
// zts.config.ts
export default defineConfig({
  compiler: {
    emotion: { autoLabel: "dev-only" },  // ← 신규: 정식 스펙 지원
  },
});
```

## autoLabel 모드

| 모드 | 동작 |
|---|---|
| `"always"` (default) | 항상 label 적용. 기존 ZTS 동작 — 기존 사용자 영향 없음 |
| `"never"` | 절대 label 적용 안 함 |
| `"dev-only"` | `process.env.NODE_ENV` define 이 `"production"` 이면 never, 아니면 always |
| `false` (legacy) | `"never"` 로 매핑 |
| `true` (legacy) | `"always"` 로 매핑 |

## dev_only 동작 모델

다른 emotion 도구들 (`@emotion/babel-plugin` 등) 은 runtime conditional 출력 후 minifier constant fold:
```js
process.env.NODE_ENV !== "production" ? css`label:card;...` : css`...`
```

ZTS 는 `--define:process.env.NODE_ENV=...` 가 이미 build-time 환경 결정의 표준이라 **직접 단정** — 한 분기만 emit. trade-off:
- ✅ runtime 분기 없음 (bundle size 약간 작음, parse cost 줄어듦)
- ⚠️ `--define` 미설정 시 default development 가정 (label 포함)

production 빌드 시 사용자가 `--define:process.env.NODE_ENV=\"production\"` 를 반드시 설정해야 label 이 빠짐. Vite/Next.js 같은 표준 도구들은 자동 설정.

## 옵션 plumbing

`emotion_auto_label: bool` → `AutoLabelMode` enum 으로 타입 변경 (8 layer). NAPI 측에서 string ("never"/"always"/"dev-only") 또는 boolean (legacy) 둘 다 받음.

## 테스트 (+5 + 회귀 갱신)

- `.always` 기본 동작 / `.never` label skip
- **`.dev_only` + NODE_ENV="production"** → never 동작
- **`.dev_only` + NODE_ENV="development"** → always 동작
- `.dev_only` + define 없음 → always (기본 dev 가정)

기존 `emotion_auto_label = false` 테스트 3개 → `.never` 로 일괄 갱신 (enum 변경 회귀 가드).

## 검증

zig build test 4227/4227 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)