### PR TITLE
feat(transformer): styled-components named helper imports 인식 + minify

### DIFF
--- a/src/transformer/plugin_state.zig
+++ b/src/transformer/plugin_state.zig
@@ -114,6 +114,17 @@ pub const StyledComponentsState = struct {
     /// import 가 없으면 null — 이후 모든 wrap 이 no-op.
     default_binding: ?[]const u8 = null,
 
+    /// `import { css } from "styled-components"` named import 의 local binding 이름.
+    /// minify 적용에 사용 (`styled.X` 처럼 displayName/componentId 는 부여 안 함 —
+    /// helper 는 컴포넌트 아닌 CSS 조각 빌더).
+    css_binding: ?[]const u8 = null,
+    /// `import { keyframes } from "styled-components"` named import.
+    keyframes_binding: ?[]const u8 = null,
+    /// `import { createGlobalStyle } from "styled-components"` named import.
+    create_global_style_binding: ?[]const u8 = null,
+    /// `import { injectGlobal } from "styled-components"` named import.
+    inject_global_binding: ?[]const u8 = null,
+
     /// `.withConfig({...})` 래핑 시 매 컴포넌트마다 동일 문자열을 string_table 에 추가하는
     /// 비용을 피하기 위한 lazy 캐시. 첫 wrap 시점에 채워짐.
     with_config_span: ?Span = null,

--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -1006,3 +1006,134 @@ test "styled-components: componentId counter 가 같은 파일 내 0,1,2 로 증
     try std.testing.expect(std.mem.indexOf(u8, r.output, "-1\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "-2\"") != null);
 }
+
+// ─── named helper imports (css / keyframes / createGlobalStyle / injectGlobal) ───
+// `import { css, keyframes, ... } from "styled-components"` 인식 + minify 옵션
+// 적용. helper 는 컴포넌트 아니라 CSS 조각이라 displayName/componentId 안 붙임.
+
+test "styled (helper): import { css } 인식 + minify 옵션 적용" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "styled-components";
+        \\const styles = css`
+        \\  color:   red;
+        \\  padding: 8px;
+        \\`;
+    ,
+        .{ .styled_components = true, .styled_components_minify = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // CSS minify 적용 — 다중 공백 collapse
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "color: red") != null);
+    // 원본 indented 다중라인 형태가 아니어야 함 (collapsed)
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "  color:   red;") == null);
+    // helper 라 displayName 안 들어감
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "displayName") == null);
+}
+
+test "styled (helper): import { keyframes } 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { keyframes } from "styled-components";
+        \\const fadeIn = keyframes`
+        \\  from { opacity: 0; }
+        \\  to   { opacity: 1; }
+        \\`;
+    ,
+        .{ .styled_components = true, .styled_components_minify = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "opacity: 0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "  to   {") == null);
+}
+
+test "styled (helper): import { createGlobalStyle } 인식 + minify" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { createGlobalStyle } from "styled-components";
+        \\const Global = createGlobalStyle`
+        \\  body  {  margin: 0;  }
+        \\`;
+    ,
+        .{ .styled_components = true, .styled_components_minify = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "margin: 0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "  body  {  ") == null);
+}
+
+test "styled (helper): import alias `import { css as cx }` 도 추적" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css as cx } from "styled-components";
+        \\const s = cx`
+        \\  color:  blue;
+        \\`;
+    ,
+        .{ .styled_components = true, .styled_components_minify = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "color: blue") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "  color:  blue;") == null);
+}
+
+test "styled (helper): default `styled` 와 named `css` 동시 import" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled, { css } from "styled-components";
+        \\const helper = css`
+        \\  color:  red;
+        \\`;
+        \\const Btn = styled.div`color: blue;`;
+    ,
+        .{ .styled_components = true, .styled_components_minify = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // helper 의 css 도 minify, styled.div 도 wrap (displayName 등) + minify
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "displayName: \"Btn\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "  color:  red;") == null);
+}
+
+test "styled (helper): non-styled-components source 의 css 는 미인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const styles = css`
+        \\  color:   red;
+        \\`;
+    ,
+        .{ .styled_components = true, .styled_components_minify = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // emotion 의 css 는 styled-components helper 로 인식 안 됨 — minify 적용 안 됨
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "  color:   red;") != null);
+}
+
+test "styled (helper): minify 옵션 비활성 — 인식만 하고 변환 안 함" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "styled-components";
+        \\const styles = css`
+        \\  color:  red;
+        \\`;
+    ,
+        .{ .styled_components = true, .jsx_filename = "test.tsx" }, // minify 미설정
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // minify 비활성 — 원본 그대로
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "  color:  red;") != null);
+}

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2995,6 +2995,11 @@ pub const Transformer = struct {
                 new_init = try emotion_mod.maybeTransformEmotionTemplate(self, new_init, var_name);
             }
         }
+        // styled-components named helper minify: const X = css`...` / keyframes`...` 등.
+        // helper 는 컴포넌트가 아니라 CSS 조각이라 displayName/componentId 는 안 붙임.
+        if (self.options.styled_components and !new_init.isNone()) {
+            new_init = try styled_components_mod.maybeMinifyHelperTemplate(self, new_init);
+        }
         const none = @intFromEnum(NodeIndex.none);
         return self.addExtraNode(.variable_declarator, node.span, &.{ @intFromEnum(new_name), none, @intFromEnum(new_init) });
     }

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -65,12 +65,26 @@ pub fn isStyledImportSource(source: []const u8) bool {
     return false;
 }
 
-/// `visitImportDeclaration` hook — source 가 styled-components 면 default specifier 의 로컬
-/// 이름을 binding 으로 등록. 옵션 비활성 시 즉시 return (hot path).
+/// styled-components 의 named helper imports — minify 등 transform 에 사용.
+const NamedHelperSpec = struct {
+    imported: []const u8,
+    field: []const u8,
+};
+
+const NAMED_HELPER_SPECS = [_]NamedHelperSpec{
+    .{ .imported = "css", .field = "css_binding" },
+    .{ .imported = "keyframes", .field = "keyframes_binding" },
+    .{ .imported = "createGlobalStyle", .field = "create_global_style_binding" },
+    .{ .imported = "injectGlobal", .field = "inject_global_binding" },
+};
+
+/// `visitImportDeclaration` hook — source 가 styled-components 면:
+///   - default specifier 의 local 이름을 `default_binding` 에 저장 (`styled.X\`\``).
+///   - named specifier (`{ css, keyframes, createGlobalStyle, injectGlobal }`) 은
+///     각각 helper binding 필드에 저장 — minify 등 helper-level transform 에 사용.
+/// 옵션 비활성 시 즉시 return (hot path).
 pub fn detectStyledImport(self: *Transformer, node: Node) Error!void {
     if (!self.options.styled_components) return;
-    // 첫 styled-components import 만 사용 (babel-plugin 동작과 일치).
-    if (self.plugins.styled_components.default_binding != null) return;
 
     const x = module_parser.readImportDeclExtras(self.ast, node.data.extra);
     if (x.source.isNone()) return;
@@ -85,14 +99,95 @@ pub fn detectStyledImport(self: *Transformer, node: Node) Error!void {
         const spec_idx: NodeIndex = @enumFromInt(spec_idx_raw);
         if (spec_idx.isNone()) continue;
         const spec_node = self.ast.getNode(spec_idx);
-        if (spec_node.tag != .import_default_specifier) continue;
-        const local_name = self.ast.getText(spec_node.data.string_ref);
-        if (local_name.len == 0) continue;
-        self.plugins.styled_components.default_binding = local_name;
-        return;
+        switch (spec_node.tag) {
+            .import_default_specifier => {
+                if (self.plugins.styled_components.default_binding != null) continue;
+                const local_name = self.ast.getText(spec_node.data.string_ref);
+                if (local_name.len == 0) continue;
+                self.plugins.styled_components.default_binding = local_name;
+            },
+            .import_specifier => {
+                // binary { left=imported, right=local }
+                const imported_idx = spec_node.data.binary.left;
+                const local_idx = spec_node.data.binary.right;
+                if (imported_idx.isNone() or local_idx.isNone()) continue;
+                const imported_node = self.ast.getNode(imported_idx);
+                if (imported_node.tag != .identifier_reference) continue;
+                const imported_name = self.ast.getText(imported_node.data.string_ref);
+                const local_node = self.ast.getNode(local_idx);
+                if (local_node.tag != .identifier_reference and local_node.tag != .binding_identifier) continue;
+                const local_name = self.ast.getText(local_node.data.string_ref);
+                if (local_name.len == 0) continue;
+                inline for (NAMED_HELPER_SPECS) |spec| {
+                    if (std.mem.eql(u8, imported_name, spec.imported) and
+                        @field(self.plugins.styled_components, spec.field) == null)
+                    {
+                        @field(self.plugins.styled_components, spec.field) = local_name;
+                        break;
+                    }
+                }
+            },
+            else => {},
+        }
     }
-    // default specifier 없음 — `import { css } from "styled-components"` 같은 named-only.
-    // 이 PR 은 default binding 만 처리. named (`{ styled }`) 는 후속.
+}
+
+/// helper binding 필드 이름 (`maybeMinifyHelperTemplate` 의 tag 매칭에 사용).
+const HELPER_BINDING_FIELDS = [_][]const u8{
+    "css_binding",
+    "keyframes_binding",
+    "create_global_style_binding",
+    "inject_global_binding",
+};
+
+/// `visitVariableDeclarator` post-hook — tag 가 styled-components named helper 면
+/// minify 옵션 적용. helper 는 컴포넌트 아닌 CSS 조각이라 displayName/componentId
+/// injection 은 안 함 (그건 `wrapStyledTag` 의 `styled.X` 만).
+pub fn maybeMinifyHelperTemplate(self: *Transformer, init_idx: NodeIndex) Error!NodeIndex {
+    if (!self.options.styled_components) return init_idx;
+    if (!self.options.styled_components_minify) return init_idx;
+    if (init_idx.isNone()) return init_idx;
+
+    const init_node = self.ast.getNode(init_idx);
+    if (init_node.tag != .tagged_template_expression) return init_idx;
+
+    const e = init_node.data.extra;
+    if (!self.ast.hasExtra(e, 2)) return init_idx;
+    const tag_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+    const template_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 1]);
+    const flags = self.ast.extra_data.items[e + 2];
+
+    if (!tagMatchesStyledHelper(self, tag_idx)) return init_idx;
+
+    const new_template = try minifyCssTemplate(self, template_idx);
+    if (new_template == template_idx) return init_idx;
+
+    const new_extra = try self.ast.addExtras(&.{
+        @intFromEnum(tag_idx),
+        @intFromEnum(new_template),
+        flags,
+    });
+    return self.ast.addNode(.{
+        .tag = .tagged_template_expression,
+        .span = init_node.span,
+        .data = .{ .extra = new_extra },
+    });
+}
+
+/// tag 가 styled-components helper binding 의 단순 identifier 인지 확인.
+/// `css.x\`\`` 같은 chain 은 미인식 — helper 는 chain 없이 직접 tagged template.
+fn tagMatchesStyledHelper(self: *Transformer, tag_idx: NodeIndex) bool {
+    if (tag_idx.isNone()) return false;
+    const tag_node = self.ast.getNode(tag_idx);
+    if (tag_node.tag != .identifier_reference) return false;
+    const text = self.ast.getText(tag_node.data.string_ref);
+    const state = &self.plugins.styled_components;
+    inline for (HELPER_BINDING_FIELDS) |field_name| {
+        if (@field(state, field_name)) |b| {
+            if (std.mem.eql(u8, text, b)) return true;
+        }
+    }
+    return false;
 }
 
 /// chain 분석 결과 — `wrapStyledTag` 가 wrap / merge 결정에 사용.


### PR DESCRIPTION
## 변환

```ts
// 입력 (minify: true 일 때)
import { css, keyframes } from "styled-components";

const styles = css`
  color:   red;
  padding: 8px;
`;

const fadeIn = keyframes`
  from { opacity: 0; }
  to   { opacity: 1; }
`;

// 출력
const styles = css`color: red; padding: 8px;`;
const fadeIn = keyframes`from { opacity: 0; } to { opacity: 1; }`;
```

## Root cause

기존엔 `import styled from "styled-components"` 의 **default specifier 만** 추적 → named helper import (`import { css, keyframes, createGlobalStyle, injectGlobal }`) 는 인식 자체가 안 됨. 결과: `styled_components_minify` 옵션이 켜져있어도 helper 사용 시 미적용.

## 추적 helpers

| imported | StyledComponentsState 필드 | 용도 |
|---|---|---|
| `css` | `css_binding` | CSS 조각 빌더 |
| `keyframes` | `keyframes_binding` | animation |
| `createGlobalStyle` | `create_global_style_binding` | global style component |
| `injectGlobal` | `inject_global_binding` | global style side-effect |

각각 alias 까지 보존 (`{ css as cx }` → binding="cx"). 다음 named API 추가 시 `NAMED_HELPER_SPECS` 테이블에 한 줄 추가.

## 적용 transform — minify

`compiler.styledComponents: { minify: true }` 일 때 helper 의 tagged template 도 minify 적용.

helper 는 컴포넌트가 아니라 CSS 조각이라 **displayName/componentId injection 은 안 함** (그건 `wrapStyledTag` 의 `styled.X` 전용).

## 인식 패턴

- shorthand: `import { css }` ✅
- aliased: `import { css as cx }` ✅
- `import styled, { css }` 동시 ✅
- chain `css.x\`\`` 미인식 (helper 는 chain 없이 직접 호출만)
- non-styled-components source 의 `css` (예: emotion) 는 미인식 (격리)

## 테스트 (+7)

- import { css } 인식 + minify
- import { keyframes } / { createGlobalStyle }
- alias `{ css as cx }` 추적
- default + named 동시 import
- non-styled-components source (emotion) 분리
- minify 옵션 비활성 시 변환 안 함

## 검증

zig build test 4234/4234 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)