### PR TITLE
fix(transform): 추가 다운레벨 엣지 케이스 보정

### DIFF
--- a/scripts/syntax-audit.mjs
+++ b/scripts/syntax-audit.mjs
@@ -75,6 +75,27 @@ console.log(JSON.stringify({ x: obj.x, log }));
 `,
   },
   {
+    name: "logical-assignment-super-computed-get-set",
+    code: `
+const log = [];
+class Base {
+  get x() { log.push("base.get:" + this.v); return this.v; }
+  set x(v) { log.push("base.set:" + v + ":" + this.name); this.v = v; }
+}
+class Child extends Base {
+  name = "child";
+  v = 0;
+  run(k) {
+    super[k] ||= 5;
+    super[k] &&= 7;
+    super[k] ??= 9;
+    return [this.v, log];
+  }
+}
+console.log(JSON.stringify(new Child().run("x")));
+`,
+  },
+  {
     name: "class-super-receiver",
     code: `
 class Base {
@@ -111,6 +132,22 @@ console.log(JSON.stringify(log));
 `,
   },
   {
+    name: "derived-constructor-return-expression-super-fields",
+    code: `
+const log = [];
+class Base { constructor(v) { log.push("base:" + v); this.v = v; } }
+class Child extends Base {
+  a = log.push("a:" + this.v);
+  constructor(flag) {
+    log.push("before");
+    return flag ? (log.push("ret"), super(3)) : super(4);
+  }
+}
+new Child(true);
+console.log(JSON.stringify(log));
+`,
+  },
+  {
     name: "private-field-brand-and-update",
     code: `
 class Counter {
@@ -132,6 +169,34 @@ class A {
   static b = log.push("b");
 }
 console.log(JSON.stringify([A.a, A.b, log]));
+`,
+  },
+  {
+    name: "static-private-and-public-order",
+    code: `
+const log = [];
+class A {
+  static #x = log.push("priv");
+  static a = log.push("a:" + this.#x);
+  static { log.push("block:" + this.a); }
+  static b = log.push("b:" + this.#x);
+  static read() { return [this.#x, this.a, this.b, log]; }
+}
+console.log(JSON.stringify(A.read()));
+`,
+  },
+  {
+    name: "static-computed-key-order-with-blocks",
+    code: `
+const log = [];
+let i = 0;
+function key(label) { log.push("key:" + label + ":" + ++i); return label + i; }
+class A {
+  static [key("a")] = log.push("fieldA");
+  static { log.push("block:" + Object.keys(this).join(",")); }
+  static [key("b")] = log.push("fieldB");
+}
+console.log(JSON.stringify([Object.keys(A), log]));
 `,
   },
   {
@@ -163,8 +228,38 @@ async function* gen() {
     out.push(v);
     if (v === 2) break;
   }
+console.log(JSON.stringify(out));
+})();
+`,
+  },
+  {
+    name: "async-generator-throw-finally-yield",
+    code: `
+async function* gen() {
+  try {
+    yield 1;
+  } finally {
+    yield 2;
+  }
+}
+(async () => {
+  const it = gen();
+  const out = [];
+  out.push(await it.next());
+  try { out.push(await it.throw(new Error("boom"))); } catch (e) { out.push("caught:" + e.message); }
+  try { out.push(await it.next()); } catch (e) { out.push("next-caught:" + e.message); }
   console.log(JSON.stringify(out));
 })();
+`,
+  },
+  {
+    name: "object-rest-computed-eval-order",
+    code: `
+const log = [];
+const src = { a: 1, b: 2, c: 3 };
+function k() { log.push("key"); return "b"; }
+const { [k()]: picked, ...rest } = src;
+console.log(JSON.stringify({ picked, rest, log }));
 `,
   },
   {

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -2271,8 +2271,13 @@ test "ES2015: class with computed method uses bracket notation" {
 test "ES2015: static computed field uses bracket notation" {
     var r = try e2eTarget(std.testing.allocator, "var k='x';class F{static [k]=1;}", .es5);
     defer r.deinit();
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "F[") != null);
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "]=1") != null);
+    // computed key 는 hoist 된 임시 변수 (`var _a=k;`) 로 캡쳐된 뒤 `F[_a]=1` 형태로 emit 된다.
+    // 정확한 temp 이름에 결합되지 않도록 prefix/suffix 사이의 식별자만 검증한다.
+    const prefix = std.mem.indexOf(u8, r.output, "F[") orelse return error.TestUnexpectedResult;
+    const suffix = std.mem.indexOfPos(u8, r.output, prefix + 2, "]=1") orelse return error.TestUnexpectedResult;
+    const key = r.output[prefix + 2 .. suffix];
+    try std.testing.expect(key.len > 0);
+    try std.testing.expect(std.ascii.isAlphabetic(key[0]) or key[0] == '_');
     try std.testing.expectEqual(std.mem.indexOf(u8, r.output, "F.[k]"), null);
 }
 

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -2271,7 +2271,8 @@ test "ES2015: class with computed method uses bracket notation" {
 test "ES2015: static computed field uses bracket notation" {
     var r = try e2eTarget(std.testing.allocator, "var k='x';class F{static [k]=1;}", .es5);
     defer r.deinit();
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "F[k]=1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "F[") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "]=1") != null);
     try std.testing.expectEqual(std.mem.indexOf(u8, r.output, "F.[k]"), null);
 }
 

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -888,8 +888,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 }
 
                 if (self.options.unsupported.nullish_coalescing) {
-                    const neq_null = try es_helpers.makeNeqNull(self, get_read, span);
-                    const get_value = try buildSuperPropGet(self, prop_ref.value, span);
+                    const read_capture = try es_helpers.captureToTemp(self, get_read, span);
+                    const neq_null = try es_helpers.makeNeqNull(self, read_capture.paren_assign, span);
+                    const get_value = try es_helpers.makeTempVarRef(self, read_capture.span, span);
                     const cond = try self.ast.addNode(.{
                         .tag = .conditional_expression,
                         .span = span,
@@ -1807,7 +1808,11 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     }
 
                     if (is_static and !init_val.isNone()) {
-                        try cm.static_elements.append(self.allocator, .{ .field = .{ .key = key, .init = init_val } });
+                        const static_key = if (key_node.tag == .computed_property_key)
+                            try memoizeStaticComputedFieldKey(self, &cm, key_node.data.unary.operand, span)
+                        else
+                            key;
+                        try cm.static_elements.append(self.allocator, .{ .field = .{ .key = static_key, .init = init_val } });
                     } else if (!is_static and !init_val.isNone()) {
                         const this_node = try self.ast.addNode(.{
                             .tag = .this_expression,
@@ -2089,6 +2094,18 @@ pub fn ES2015Class(comptime Transformer: type) type {
             });
         }
 
+        fn memoizeStaticComputedFieldKey(self: *Transformer, cm: anytype, key_expr: NodeIndex, span: Span) Transformer.Error!NodeIndex {
+            const temp_span = try es_helpers.makeTempVarSpan(self);
+            const temp_binding = try es_helpers.makeBindingIdentifier(self, temp_span);
+            const temp_init = try self.visitNode(key_expr);
+            const temp_decl = try es_helpers.makeDeclarator(self, temp_binding, temp_init, span);
+            try cm.accessor_key_memos.append(
+                self.allocator,
+                try es_helpers.makeVarDeclaration(self, &.{temp_decl}, .@"var", span),
+            );
+            return makeComputedKeyRef(self, temp_span, span);
+        }
+
         /// computed accessor getter method_definition 생성. `get [_acc_key_N]() { return return_expr; }`.
         fn buildComputedAccessorGetter(self: *Transformer, computed_key: NodeIndex, return_expr: NodeIndex, is_static: bool, span: Span) Transformer.Error!NodeIndex {
             return self.buildGetterMethod(computed_key, return_expr, is_static, span);
@@ -2194,11 +2211,17 @@ pub fn ES2015Class(comptime Transformer: type) type {
         fn buildStaticFieldAssignWithCtx(self: *Transformer, obj: NodeIndex, key_idx: NodeIndex, init_idx: NodeIndex, class_name_span: Span, span: Span) Transformer.Error!NodeIndex {
             const saved_static = self.current_super_is_static;
             const saved_receiver = self.current_super_static_receiver;
+            const saved_class_name = self.static_block_class_name;
+            const saved_this_depth = self.this_depth;
             self.current_super_is_static = true;
             self.current_super_static_receiver = class_name_span;
+            self.static_block_class_name = class_name_span;
+            self.this_depth = 0;
             defer {
                 self.current_super_is_static = saved_static;
                 self.current_super_static_receiver = saved_receiver;
+                self.static_block_class_name = saved_class_name;
+                self.this_depth = saved_this_depth;
             }
             return buildFieldAssign(self, obj, key_idx, init_idx, span);
         }
@@ -2514,6 +2537,31 @@ pub fn ES2015Class(comptime Transformer: type) type {
                         .data = .{ .list = new_list },
                     });
                 },
+                .return_statement => {
+                    const scratch_top = self.scratch.items.len;
+                    defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+                    const ret_span = try es_helpers.makeTempVarSpan(self);
+                    const ret_binding = try es_helpers.makeBindingIdentifier(self, ret_span);
+                    const ret_decl = try es_helpers.makeDeclarator(self, ret_binding, stmt.data.unary.operand, stmt.span);
+                    try self.scratch.append(
+                        self.allocator,
+                        try es_helpers.makeVarDeclaration(self, &.{ret_decl}, .@"var", stmt.span),
+                    );
+                    try appendInstanceFields(self, instance_fields, span);
+                    try self.scratch.append(self.allocator, try self.ast.addNode(.{
+                        .tag = .return_statement,
+                        .span = stmt.span,
+                        .data = .{ .unary = .{ .operand = try es_helpers.makeTempVarRef(self, ret_span, stmt.span), .flags = 0 } },
+                    }));
+
+                    const new_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+                    return self.ast.addNode(.{
+                        .tag = .block_statement,
+                        .span = stmt.span,
+                        .data = .{ .list = new_list },
+                    });
+                },
                 else => return stmt_idx,
             }
         }
@@ -2538,6 +2586,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     if (expr_idx.isNone()) return false;
                     return containsSuperCallAssignment(self, expr_idx);
                 },
+                .return_statement => {
+                    return containsSuperCallAssignment(self, node.data.unary.operand);
+                },
                 .parenthesized_expression => {
                     return containsSuperCallAssignment(self, node.data.unary.operand);
                 },
@@ -2560,7 +2611,16 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     const init: NodeIndex = @enumFromInt(self.ast.extra_data.items[node.data.extra + 2]);
                     return containsSuperCallAssignment(self, init);
                 },
-                .call_expression => return isSuperCallLike(self, node),
+                .call_expression => {
+                    if (isSuperCallLike(self, node)) return true;
+                    const e = node.data.extra;
+                    const args_start = self.ast.extra_data.items[e + 1];
+                    const args_len = self.ast.extra_data.items[e + 2];
+                    for (self.ast.extra_data.items[args_start .. args_start + args_len]) |raw_idx| {
+                        if (containsSuperCallAssignment(self, @enumFromInt(raw_idx))) return true;
+                    }
+                    return false;
+                },
                 .assignment_expression => {
                     const left = self.ast.getNode(node.data.binary.left);
                     if (left.tag != .identifier_reference and left.tag != .assignment_target_identifier) return false;

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -2059,7 +2059,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             try cm.accessor_key_memos.append(self.allocator, var_decl);
 
             // computed key 노드: computed_property_key(identifier_reference("_acc_key_N")) — getter/setter 각 1개씩.
-            const getter_key = try makeComputedKeyRef(self, mem_var_span, span);
+            const getter_key = try es_helpers.makeComputedKeyRef(self, mem_var_span, span);
             const getter_return = try makePrivateFieldAccess(self, storage_span, span);
             const getter_idx = try buildComputedAccessorGetter(self, getter_key, getter_return, is_static, span);
             try cm.accessors.append(self.allocator, .{
@@ -2069,7 +2069,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 .member_span = member_span,
             });
 
-            const setter_key = try makeComputedKeyRef(self, mem_var_span, span);
+            const setter_key = try es_helpers.makeComputedKeyRef(self, mem_var_span, span);
             const setter_target = try makePrivateFieldAccess(self, storage_span, span);
             const setter_idx = try buildComputedAccessorSetter(self, setter_key, setter_target, is_static, span);
             try cm.accessors.append(self.allocator, .{
@@ -2080,30 +2080,10 @@ pub fn ES2015Class(comptime Transformer: type) type {
             });
         }
 
-        /// computed_property_key(identifier_reference(name)) 노드 생성 — accessor method key 로 사용.
-        fn makeComputedKeyRef(self: *Transformer, var_span: Span, span: Span) Transformer.Error!NodeIndex {
-            const id_ref = try self.ast.addNode(.{
-                .tag = .identifier_reference,
-                .span = var_span,
-                .data = .{ .string_ref = var_span },
-            });
-            return self.ast.addNode(.{
-                .tag = .computed_property_key,
-                .span = span,
-                .data = .{ .unary = .{ .operand = id_ref, .flags = 0 } },
-            });
-        }
-
         fn memoizeStaticComputedFieldKey(self: *Transformer, cm: anytype, key_expr: NodeIndex, span: Span) Transformer.Error!NodeIndex {
-            const temp_span = try es_helpers.makeTempVarSpan(self);
-            const temp_binding = try es_helpers.makeBindingIdentifier(self, temp_span);
-            const temp_init = try self.visitNode(key_expr);
-            const temp_decl = try es_helpers.makeDeclarator(self, temp_binding, temp_init, span);
-            try cm.accessor_key_memos.append(
-                self.allocator,
-                try es_helpers.makeVarDeclaration(self, &.{temp_decl}, .@"var", span),
-            );
-            return makeComputedKeyRef(self, temp_span, span);
+            const memo = try es_helpers.memoizeComputedKey(self, key_expr, span);
+            try cm.accessor_key_memos.append(self.allocator, memo.decl);
+            return memo.computed_key;
         }
 
         /// computed accessor getter method_definition 생성. `get [_acc_key_N]() { return return_expr; }`.

--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -509,39 +509,10 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             const opd_start = pattern.data.list.start;
             const split = self.ast.nodeListSplitRest(pattern.data.list);
 
-            // 1단계: rest가 아닌 property key 이름을 수집 (__rest의 exclude 배열용)
-            // 이 루프는 visitNode를 호출하지 않으므로 슬라이스 안전
-            var exclude_keys: [64][]const u8 = undefined;
+            var exclude_keys: [64]NodeIndex = undefined;
             var exclude_count: usize = 0;
 
-            {
-                for (split.elements) |raw_idx| {
-                    const prop = self.ast.getNode(@enumFromInt(raw_idx));
-                    if (prop.tag != .binding_property) continue;
-                    // key 이름 수집
-                    const key_idx_inner = prop.data.binary.left;
-                    if (!key_idx_inner.isNone()) {
-                        const key_node_inner = self.ast.getNode(key_idx_inner);
-                        if (exclude_count < exclude_keys.len) {
-                            if (key_node_inner.tag == .identifier_reference or key_node_inner.tag == .binding_identifier) {
-                                exclude_keys[exclude_count] = self.ast.getText(key_node_inner.span);
-                                exclude_count += 1;
-                            } else if (key_node_inner.tag == .string_literal) {
-                                // 'aria-busy' 같은 string literal key — 따옴표를 제외한 내용
-                                const raw = self.ast.getText(key_node_inner.span);
-                                if (raw.len >= 2 and (raw[0] == '\'' or raw[0] == '"')) {
-                                    exclude_keys[exclude_count] = raw[1 .. raw.len - 1];
-                                } else {
-                                    exclude_keys[exclude_count] = raw;
-                                }
-                                exclude_count += 1;
-                            }
-                        }
-                    }
-                }
-            }
-
-            // 2단계: 각 property를 declarator로 변환
+            // 각 property를 declarator로 변환하면서 rest exclude key도 같은 평가 결과로 수집한다.
             // visitNode가 AST를 변형하므로 인덱스 루프 사용 (split.elements 슬라이스는 stale 가능)
             const non_rest_len: u32 = @intCast(split.elements.len);
             var i_loop: u32 = 0;
@@ -557,7 +528,24 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                 const ref = try es_helpers.makeTempVarRef(self, ref_span, ref_span);
                 const key_node = self.ast.getNode(key_idx);
 
-                const member_access = try es_helpers.makeMemberFromKeyIdx(self, ref, key_idx, span);
+                const member_access = if (key_node.tag == .computed_property_key) blk: {
+                    const key_span = try es_helpers.makeTempVarSpan(self);
+                    const key_binding = try es_helpers.makeBindingIdentifier(self, key_span);
+                    const key_value = try self.visitNode(key_node.data.unary.operand);
+                    const key_decl = try es_helpers.makeDeclarator(self, key_binding, key_value, span);
+                    try self.scratch.append(self.allocator, key_decl);
+                    if (exclude_count < exclude_keys.len) {
+                        exclude_keys[exclude_count] = try es_helpers.makeTempVarRef(self, key_span, span);
+                        exclude_count += 1;
+                    }
+                    break :blk try es_helpers.makeComputedMember(self, ref, try es_helpers.makeTempVarRef(self, key_span, span), span);
+                } else blk: {
+                    if (exclude_count < exclude_keys.len) {
+                        exclude_keys[exclude_count] = try makeRestExcludeKey(self, key_node);
+                        exclude_count += 1;
+                    }
+                    break :blk try es_helpers.makeMemberFromKeyIdx(self, ref, key_idx, span);
+                };
 
                 // value 처리: shorthand vs long-form, default value
                 if (value_idx.isNone() or @intFromEnum(value_idx) == @intFromEnum(key_idx)) {
@@ -782,12 +770,34 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             }
         }
 
-        /// rest = __rest(_ref, ["key1", "key2"]) declarator 생성.
+        fn makeRestExcludeKey(self: *Transformer, key_node: Node) Transformer.Error!NodeIndex {
+            const raw = switch (key_node.tag) {
+                .identifier_reference, .binding_identifier => self.ast.getText(key_node.span),
+                .string_literal => blk: {
+                    const text = self.ast.getText(key_node.span);
+                    if (text.len >= 2 and (text[0] == '\'' or text[0] == '"')) break :blk text[1 .. text.len - 1];
+                    break :blk text;
+                },
+                else => "",
+            };
+            var buf: [256]u8 = undefined;
+            buf[0] = '"';
+            @memcpy(buf[1 .. 1 + raw.len], raw);
+            buf[1 + raw.len] = '"';
+            const str_span = try self.ast.addString(buf[0 .. raw.len + 2]);
+            return self.ast.addNode(.{
+                .tag = .string_literal,
+                .span = str_span,
+                .data = .{ .string_ref = str_span },
+            });
+        }
+
+        /// rest = __rest(_ref, ["key1", key2]) declarator 생성.
         fn buildRestDeclarator(
             self: *Transformer,
             rest_idx: NodeIndex,
             ref_span: Span,
-            exclude_keys: []const []const u8,
+            exclude_keys: []const NodeIndex,
             span: Span,
         ) Transformer.Error!NodeIndex {
             const binding = try self.visitNode(rest_idx);
@@ -803,18 +813,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             defer self.scratch.shrinkRetainingCapacity(scratch_top);
 
             for (exclude_keys) |key| {
-                // 따옴표 포함 문자열 리터럴
-                var buf: [256]u8 = undefined;
-                buf[0] = '"';
-                @memcpy(buf[1 .. 1 + key.len], key);
-                buf[1 + key.len] = '"';
-                const str_span = try self.ast.addString(buf[0 .. key.len + 2]);
-                const str_node = try self.ast.addNode(.{
-                    .tag = .string_literal,
-                    .span = str_span,
-                    .data = .{ .string_ref = str_span },
-                });
-                try self.scratch.append(self.allocator, str_node);
+                try self.scratch.append(self.allocator, key);
             }
 
             const arr_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);

--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -780,11 +780,23 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                 },
                 else => "",
             };
-            var buf: [256]u8 = undefined;
-            buf[0] = '"';
-            @memcpy(buf[1 .. 1 + raw.len], raw);
-            buf[1 + raw.len] = '"';
-            const str_span = try self.ast.addString(buf[0 .. raw.len + 2]);
+            // 256 byte 스택 버퍼는 일반 식별자/짧은 string literal 을 커버. 그 이상은 heap 으로 fallback —
+            // base64 encoded key 등 긴 literal 에서 stack overflow 회피.
+            const total = raw.len + 2;
+            const str_span = if (total <= 256) span: {
+                var buf: [256]u8 = undefined;
+                buf[0] = '"';
+                @memcpy(buf[1 .. 1 + raw.len], raw);
+                buf[1 + raw.len] = '"';
+                break :span try self.ast.addString(buf[0..total]);
+            } else span: {
+                const heap_buf = try self.allocator.alloc(u8, total);
+                defer self.allocator.free(heap_buf);
+                heap_buf[0] = '"';
+                @memcpy(heap_buf[1 .. 1 + raw.len], raw);
+                heap_buf[1 + raw.len] = '"';
+                break :span try self.ast.addString(heap_buf);
+            };
             return self.ast.addNode(.{
                 .tag = .string_literal,
                 .span = str_span,

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -1098,16 +1098,19 @@ pub fn ES2015Generator(comptime Transformer: type) type {
 
             try collectBodyOperations(self, try_body, ops, next_label);
 
-            const catch_label = next_label.*;
-            next_label.* += 1;
+            const catch_label: ?u32 = if (!catch_clause.isNone()) blk: {
+                const label = next_label.*;
+                next_label.* += 1;
+                break :blk label;
+            } else null;
 
             // try body 끝 break placeholder
             const try_break_slot = ops.items.len;
             try ops.append(self.allocator, .{ .code = .break_op, .arg = .{ .label = 0 } });
 
-            try ops.append(self.allocator, .{ .code = .nop, .arg = .{ .none = {} } });
-
             if (!catch_clause.isNone()) {
+                try ops.append(self.allocator, .{ .code = .nop, .arg = .{ .none = {} } });
+
                 const catch_node = self.ast.getNode(catch_clause);
                 const catch_param = catch_node.data.binary.left;
                 const catch_body_idx = catch_node.data.binary.right;
@@ -1128,8 +1131,11 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             }
 
             // catch body 끝 break placeholder
-            const catch_break_slot = ops.items.len;
-            try ops.append(self.allocator, .{ .code = .break_op, .arg = .{ .label = 0 } });
+            const catch_break_slot: ?usize = if (!catch_clause.isNone()) blk: {
+                const slot = ops.items.len;
+                try ops.append(self.allocator, .{ .code = .break_op, .arg = .{ .label = 0 } });
+                break :blk slot;
+            } else null;
 
             var finally_label: ?u32 = null;
             if (!finally_body.isNone()) {
@@ -1151,7 +1157,9 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             // finally가 있으면 __generator 런타임이 _.label < t[2] 체크로
             // finally로 자동 우회 + _.ops.push(op)로 원래 목적지 보존.
             ops.items[try_break_slot] = .{ .code = .break_op, .arg = .{ .label = end_label } };
-            ops.items[catch_break_slot] = .{ .code = .break_op, .arg = .{ .label = end_label } };
+            if (catch_break_slot) |slot| {
+                ops.items[slot] = .{ .code = .break_op, .arg = .{ .label = end_label } };
+            }
 
             const trys_push = try buildTrysPush(self, try_label, catch_label, finally_label, end_label, stmt.span);
             ops.items[trys_push_slot] = .{ .code = .statement, .arg = .{ .node = trys_push } };
@@ -1159,7 +1167,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
 
         /// _state.trys.push([try_label, catch_label, finally_label, end_label]) expression_statement 생성.
         /// finally_label이 null이면 void 0을 출력하여 런타임의 _.label < t[2] 체크를 skip시킨다.
-        fn buildTrysPush(self: *Transformer, try_label: u32, catch_label: u32, finally_label: ?u32, end_label: u32, span: Span) Transformer.Error!NodeIndex {
+        fn buildTrysPush(self: *Transformer, try_label: u32, catch_label: ?u32, finally_label: ?u32, end_label: u32, span: Span) Transformer.Error!NodeIndex {
             const state_ref = try es_helpers.makeIdentifierRef(self, "_state");
 
             // _state.trys
@@ -1172,7 +1180,10 @@ pub fn ES2015Generator(comptime Transformer: type) type {
 
             // [try_label, catch_label, finally_label, end_label] 배열 (TypeScript __generator 스펙)
             const n0 = try es_helpers.makeNumericLiteral(self, try_label);
-            const n1 = try es_helpers.makeNumericLiteral(self, catch_label);
+            const n1 = if (catch_label) |cl|
+                try es_helpers.makeNumericLiteral(self, cl)
+            else
+                try es_helpers.makeVoidZero(self, span);
             const n2 = if (finally_label) |fl|
                 try es_helpers.makeNumericLiteral(self, fl)
             else

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -88,8 +88,14 @@ pub fn ES2022(comptime Transformer: type) type {
             const pending_top = self.pending_nodes.items.len;
             defer self.pending_nodes.shrinkRetainingCapacity(pending_top);
 
-            var static_key_memos = std.AutoHashMap(u32, NodeIndex).init(self.allocator);
-            defer static_key_memos.deinit();
+            // pre-pass: 공개 static field 의 computed key 를 `var _N = <expr>;` 로 캡쳐해 클래스 평가 직전에 hoist.
+            // 메인 루프와 분리한 이유 — TC39 spec 상 모든 computed key 는 class body 평가 전에 한 번만 평가되어야
+            // 하므로, 사이에 끼어들 수 있는 static block 보다 먼저 emit 되어야 한다 (test fixture
+            // `static-computed-key-order-with-blocks` 참조).
+            // 항목 수 ≤ 클래스 내 공개 static computed-key field 개수(통상 0–3) → linear scan 이 HashMap 보다 저렴.
+            const KeyMemo = struct { raw_idx: u32, key_ref: NodeIndex };
+            var static_key_memos: std.ArrayList(KeyMemo) = .empty;
+            defer static_key_memos.deinit(self.allocator);
 
             if (class_name_span != null) {
                 var key_i: u32 = 0;
@@ -102,15 +108,9 @@ pub fn ES2022(comptime Transformer: type) type {
                     const key_node = self.ast.getNode(key);
                     if (key_node.tag != .computed_property_key) continue;
 
-                    const temp_span = try es_helpers.makeTempVarSpan(self);
-                    const temp_binding = try es_helpers.makeBindingIdentifier(self, temp_span);
-                    const temp_init = try self.visitNode(key_node.data.unary.operand);
-                    const temp_decl = try es_helpers.makeDeclarator(self, temp_binding, temp_init, member.span);
-                    try static_block_iifes.append(
-                        self.allocator,
-                        try es_helpers.makeVarDeclaration(self, &.{temp_decl}, .@"var", member.span),
-                    );
-                    try static_key_memos.put(raw_idx, try makeComputedKeyRef(self, temp_span, member.span));
+                    const memo = try es_helpers.memoizeComputedKey(self, key_node.data.unary.operand, member.span);
+                    try static_block_iifes.append(self.allocator, memo.decl);
+                    try static_key_memos.append(self.allocator, .{ .raw_idx = raw_idx, .key_ref = memo.computed_key });
                 }
             }
 
@@ -124,7 +124,7 @@ pub fn ES2022(comptime Transformer: type) type {
                     const iife = try buildStaticBlockIIFE(self, member, class_name_span);
                     try static_block_iifes.append(self.allocator, iife);
                 } else if (class_name_span != null and member.tag == .property_definition and isPublicStaticField(self, member)) {
-                    const static_assign = try buildStaticFieldAssign(self, member, class_name_span.?, already_visited, static_key_memos.get(raw_idx));
+                    const static_assign = try buildStaticFieldAssign(self, member, class_name_span.?, lookupKeyMemo(static_key_memos.items, raw_idx));
                     try static_block_iifes.append(self.allocator, static_assign);
                 } else if (already_visited) {
                     try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
@@ -171,21 +171,20 @@ pub fn ES2022(comptime Transformer: type) type {
             return (flags & ast_mod.PropertyFlags.is_static) != 0;
         }
 
-        fn makeComputedKeyRef(self: *Transformer, var_span: Span, span: Span) Transformer.Error!NodeIndex {
-            const id_ref = try self.ast.addNode(.{
-                .tag = .identifier_reference,
-                .span = var_span,
-                .data = .{ .string_ref = var_span },
-            });
-            return self.ast.addNode(.{
-                .tag = .computed_property_key,
-                .span = span,
-                .data = .{ .unary = .{ .operand = id_ref, .flags = 0 } },
-            });
+        fn lookupKeyMemo(memos: anytype, raw_idx: u32) ?NodeIndex {
+            for (memos) |m| {
+                if (m.raw_idx == raw_idx) return m.key_ref;
+            }
+            return null;
         }
 
-        fn buildStaticFieldAssign(self: *Transformer, member: Node, class_name_span: Span, already_visited: bool, key_override: ?NodeIndex) Transformer.Error!NodeIndex {
-            _ = already_visited;
+        /// public static field 의 `Class.key = init;` assignment 를 합성한다.
+        /// `key_override` 가 있으면 (computed key memo 결과) raw key 대신 사용한다.
+        /// init 은 항상 `static_block_class_name`/`current_super_static_receiver` 가 설정된 채
+        /// 재방문된다 — `lowerPrivateMembers` 가 먼저 visit 했더라도 `super.x` / `this.#priv` 가
+        /// static 컨텍스트 기준으로 재 lowering 되어야 정상 동작 (test fixture
+        /// `static-private-and-public-order` 참조).
+        fn buildStaticFieldAssign(self: *Transformer, member: Node, class_name_span: Span, key_override: ?NodeIndex) Transformer.Error!NodeIndex {
             const pe = member.data.extra;
             const key: NodeIndex = key_override orelse self.readNodeIdx(pe, ast_mod.PropertyExtra.key);
             const init: NodeIndex = self.readNodeIdx(pe, ast_mod.PropertyExtra.init);

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -88,6 +88,32 @@ pub fn ES2022(comptime Transformer: type) type {
             const pending_top = self.pending_nodes.items.len;
             defer self.pending_nodes.shrinkRetainingCapacity(pending_top);
 
+            var static_key_memos = std.AutoHashMap(u32, NodeIndex).init(self.allocator);
+            defer static_key_memos.deinit();
+
+            if (class_name_span != null) {
+                var key_i: u32 = 0;
+                while (key_i < body_len) : (key_i += 1) {
+                    const raw_idx = self.ast.extra_data.items[body_start + key_i];
+                    const member = self.ast.getNode(@enumFromInt(raw_idx));
+                    if (member.tag != .property_definition or !isPublicStaticField(self, member)) continue;
+                    const pe = member.data.extra;
+                    const key: NodeIndex = self.readNodeIdx(pe, ast_mod.PropertyExtra.key);
+                    const key_node = self.ast.getNode(key);
+                    if (key_node.tag != .computed_property_key) continue;
+
+                    const temp_span = try es_helpers.makeTempVarSpan(self);
+                    const temp_binding = try es_helpers.makeBindingIdentifier(self, temp_span);
+                    const temp_init = try self.visitNode(key_node.data.unary.operand);
+                    const temp_decl = try es_helpers.makeDeclarator(self, temp_binding, temp_init, member.span);
+                    try static_block_iifes.append(
+                        self.allocator,
+                        try es_helpers.makeVarDeclaration(self, &.{temp_decl}, .@"var", member.span),
+                    );
+                    try static_key_memos.put(raw_idx, try makeComputedKeyRef(self, temp_span, member.span));
+                }
+            }
+
             // while 인덱스 루프: visitNode/buildStaticBlockIIFE가 extra_data를 재할당할 수 있으므로 슬라이스 캐시 금지
             var j: u32 = 0;
             while (j < body_len) : (j += 1) {
@@ -98,7 +124,7 @@ pub fn ES2022(comptime Transformer: type) type {
                     const iife = try buildStaticBlockIIFE(self, member, class_name_span);
                     try static_block_iifes.append(self.allocator, iife);
                 } else if (class_name_span != null and member.tag == .property_definition and isPublicStaticField(self, member)) {
-                    const static_assign = try buildStaticFieldAssign(self, member, class_name_span.?, already_visited);
+                    const static_assign = try buildStaticFieldAssign(self, member, class_name_span.?, already_visited, static_key_memos.get(raw_idx));
                     try static_block_iifes.append(self.allocator, static_assign);
                 } else if (already_visited) {
                     try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
@@ -145,26 +171,44 @@ pub fn ES2022(comptime Transformer: type) type {
             return (flags & ast_mod.PropertyFlags.is_static) != 0;
         }
 
-        fn buildStaticFieldAssign(self: *Transformer, member: Node, class_name_span: Span, already_visited: bool) Transformer.Error!NodeIndex {
+        fn makeComputedKeyRef(self: *Transformer, var_span: Span, span: Span) Transformer.Error!NodeIndex {
+            const id_ref = try self.ast.addNode(.{
+                .tag = .identifier_reference,
+                .span = var_span,
+                .data = .{ .string_ref = var_span },
+            });
+            return self.ast.addNode(.{
+                .tag = .computed_property_key,
+                .span = span,
+                .data = .{ .unary = .{ .operand = id_ref, .flags = 0 } },
+            });
+        }
+
+        fn buildStaticFieldAssign(self: *Transformer, member: Node, class_name_span: Span, already_visited: bool, key_override: ?NodeIndex) Transformer.Error!NodeIndex {
+            _ = already_visited;
             const pe = member.data.extra;
-            const key: NodeIndex = self.readNodeIdx(pe, ast_mod.PropertyExtra.key);
+            const key: NodeIndex = key_override orelse self.readNodeIdx(pe, ast_mod.PropertyExtra.key);
             const init: NodeIndex = self.readNodeIdx(pe, ast_mod.PropertyExtra.init);
 
             const saved_static = self.current_super_is_static;
             const saved_receiver = self.current_super_static_receiver;
+            const saved_class_name = self.static_block_class_name;
+            const saved_this_depth = self.this_depth;
             self.current_super_is_static = true;
             self.current_super_static_receiver = class_name_span;
+            self.static_block_class_name = class_name_span;
+            self.this_depth = 0;
             defer {
                 self.current_super_is_static = saved_static;
                 self.current_super_static_receiver = saved_receiver;
+                self.static_block_class_name = saved_class_name;
+                self.this_depth = saved_this_depth;
             }
 
             const class_ref = try es_helpers.makeIdentifierRefFromSpan(self, class_name_span);
             const member_ref = try es_helpers.makeMemberFromKeyIdx(self, class_ref, key, member.span);
             const value = if (init.isNone())
                 try es_helpers.makeVoidZero(self, member.span)
-            else if (already_visited)
-                init
             else
                 try self.visitNode(init);
             const assign = try self.ast.addNode(.{

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -135,6 +135,40 @@ pub fn unwrapTransparentWrappers(self: anytype, idx: NodeIndex) NodeIndex {
     }
 }
 
+/// `computed_property_key(identifier_reference(var_span))` 노드 생성.
+/// 임시 변수에 캡쳐된 computed key 식을 다시 key 위치로 참조할 때 사용 (#1511, static field key memoization).
+pub fn makeComputedKeyRef(self: anytype, var_span: Span, span: Span) !NodeIndex {
+    const id_ref = try self.ast.addNode(.{
+        .tag = .identifier_reference,
+        .span = var_span,
+        .data = .{ .string_ref = var_span },
+    });
+    return self.ast.addNode(.{
+        .tag = .computed_property_key,
+        .span = span,
+        .data = .{ .unary = .{ .operand = id_ref, .flags = 0 } },
+    });
+}
+
+/// computed key 식을 `var _N = <expr>;` 으로 캡쳐하고, 그 자리에는 `[_N]` 참조를 둘 수 있게 한다.
+/// 반환값: 변수 선언 statement + key 위치에 끼워넣을 computed_property_key.
+/// 호출자는 `decl` 을 적절한 hoist 위치(class IIFE 위/accessor_key_memos)에 추가하고,
+/// `computed_key` 를 method_definition / property_definition 의 key 로 사용한다.
+pub const ComputedKeyMemo = struct {
+    decl: NodeIndex,
+    computed_key: NodeIndex,
+};
+pub fn memoizeComputedKey(self: anytype, key_expr: NodeIndex, span: Span) !ComputedKeyMemo {
+    const temp_span = try makeTempVarSpan(self);
+    const temp_binding = try makeBindingIdentifier(self, temp_span);
+    const temp_init = try self.visitNode(key_expr);
+    const temp_decl = try makeDeclarator(self, temp_binding, temp_init, span);
+    return .{
+        .decl = try makeVarDeclaration(self, &.{temp_decl}, .@"var", span),
+        .computed_key = try makeComputedKeyRef(self, temp_span, span),
+    };
+}
+
 /// `void 0` 노드를 새 AST에 생성.
 pub fn makeVoidZero(self: anytype, span: Span) !NodeIndex {
     const zero_span = try self.ast.addString("0");


### PR DESCRIPTION
## Summary
- super logical assignment, derived constructor return, static field/block ordering, object rest computed key, async generator throw/finally edge cases fixed
- static computed field key evaluation is memoized before static field/block execution
- syntax audit coverage extended with the newly found regressions

## Tests
- `node scripts/syntax-audit.mjs`
- `cd tests/integration && bun test tests/downlevel-edge.test.ts --timeout 600000`
- `zig build test --summary all`
- `bunx oxlint scripts/syntax-audit.mjs`
- `bunx oxfmt --check scripts/syntax-audit.mjs`
- `zig fmt --check src/transformer/es2015_class.zig src/transformer/es2022.zig src/transformer/es2015_generator.zig src/transformer/es2015_destructuring.zig src/codegen/codegen_test/es_downlevel.zig`