### PR TITLE
refactor(transform): string_literal builder heap path 단일화

### DIFF
--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -780,28 +780,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                 },
                 else => "",
             };
-            // 256 byte 스택 버퍼는 일반 식별자/짧은 string literal 을 커버. 그 이상은 heap 으로 fallback —
-            // base64 encoded key 등 긴 literal 에서 stack overflow 회피.
-            const total = raw.len + 2;
-            const str_span = if (total <= 256) span: {
-                var buf: [256]u8 = undefined;
-                buf[0] = '"';
-                @memcpy(buf[1 .. 1 + raw.len], raw);
-                buf[1 + raw.len] = '"';
-                break :span try self.ast.addString(buf[0..total]);
-            } else span: {
-                const heap_buf = try self.allocator.alloc(u8, total);
-                defer self.allocator.free(heap_buf);
-                heap_buf[0] = '"';
-                @memcpy(heap_buf[1 .. 1 + raw.len], raw);
-                heap_buf[1 + raw.len] = '"';
-                break :span try self.ast.addString(heap_buf);
-            };
-            return self.ast.addNode(.{
-                .tag = .string_literal,
-                .span = str_span,
-                .data = .{ .string_ref = str_span },
-            });
+            return self.wrapInStringLiteral(raw);
         }
 
         /// rest = __rest(_ref, ["key1", key2]) declarator 생성.

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -2684,14 +2684,14 @@ pub fn memberKeyToStringLiteral(self: *Transformer, key: NodeIndex) Error!NodeIn
     return key;
 }
 
-/// 텍스트를 따옴표로 감싸서 string_literal 노드 생성
+/// 텍스트를 따옴표로 감싸서 string_literal 노드 생성.
+/// `addString` 이 string_table 로 복사하므로 임시 버퍼는 함수 종료시 free 된다.
+/// 길이 제한 없음 — 이전의 `[256]u8` 스택 버퍼는 긴 키(base64 / 합성 식별자)를 silent
+/// truncate 하던 latent bug 였다.
 pub fn wrapInStringLiteral(self: *Transformer, text: []const u8) Error!NodeIndex {
-    var buf: [256]u8 = undefined;
-    buf[0] = '"';
-    const len = @min(text.len, buf.len - 2);
-    @memcpy(buf[1 .. 1 + len], text[0..len]);
-    buf[1 + len] = '"';
-    const span = try self.ast.addString(buf[0 .. 2 + len]);
+    const quoted = try std.fmt.allocPrint(self.allocator, "\"{s}\"", .{text});
+    defer self.allocator.free(quoted);
+    const span = try self.ast.addString(quoted);
     return self.ast.addNode(.{ .tag = .string_literal, .span = span, .data = .{ .string_ref = span } });
 }
 


### PR DESCRIPTION
## Summary
- `wrapInStringLiteral` (class_decorator) 의 `[256]u8` 스택 버퍼는 긴 키를 `@min(text.len, buf.len - 2)` 로 **silent truncate** 하던 latent bug. base64 인코딩 키나 합성 식별자에서 잘못된 결과 emit 가능.
- `makeRestExcludeKey` (es2015_destructuring, #2264 에서 추가) 의 stack/heap 이중 분기도 같은 결함을 우회하던 과설계. exclude key 는 hot path 가 아닌데 분기/버퍼관리 비용만 추가.
- 두 함수를 `std.fmt.allocPrint` 단일 heap path 로 통일. `addString` 이 string_table 로 복사하므로 임시 버퍼는 함수 종료시 free.
- `makeRestExcludeKey` 는 `wrapInStringLiteral` 을 위임 호출 — 동일 패턴 한 군데 유지.

## Test plan
- [x] `zig build test` (4232/4232)
- [x] `bun test tests/integration/tests/{downlevel-edge,downlevel,stage3-decorator}.test.ts` (471 pass)
- [x] `node scripts/syntax-audit.mjs` (22/22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)