### PR TITLE
feat(transformer): emotion object/array css prop — css(value, label) wrap

### DIFF
--- a/src/transformer/emotion_test.zig
+++ b/src/transformer/emotion_test.zig
@@ -1198,6 +1198,176 @@ test "emotion (labelFormat): jsx_filename 없으면 [filename]/[dirname] = 빈 �
     try expectAutoLabel(r.output, "--card");
 }
 
+// ─── Object/Array css prop ───
+// `<div css={{color:'red'}}>` / `<div css={[a, b]}>` 를 `css(value, "label:div;")` call
+// 로 wrap. `/* @__PURE__ */` annotation 까지 부여 — minifier tree-shaking 활성.
+// css binding 이 import 안 됐으면 no-op (auto-inject 별도 작업).
+
+test "emotion (object css): `<div css={{color:'red'}}>` → css(...) call wrap" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const el = <div css={{ color: 'red' }} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // css(...) call 로 wrap + label 인자 + PURE annotation
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "/* @__PURE__ */") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "css({") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"label:div;\"") != null);
+}
+
+test "emotion (object css): `<Button css={[a, b]}>` array literal 도 wrap" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const el = <Button css={[styleA, styleB]} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "/* @__PURE__ */") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "css([") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"label:Button;\"") != null);
+}
+
+test "emotion (object css): css alias `import { css as cx }` 도 wrap" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css as cx } from "@emotion/react";
+        \\const el = <div css={{ color: 'red' }} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // alias 'cx' 가 callee
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "cx({") != null);
+}
+
+test "emotion (object css): css import 없으면 no-op" {
+    // css binding 이 import 안 됐으니 wrap 안 함 — 사용자 코드 그대로.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\const el = <div css={{ color: 'red' }} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // wrap 안 됨 → object literal 그대로 css prop 으로
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "css({") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"label:") == null);
+}
+
+test "emotion (object css): autoLabel .never — wrap 은 하되 label 인자 생략" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const el = <div css={{ color: 'red' }} />;
+    ,
+        .{ .emotion = true, .emotion_auto_label = .never, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // wrap + PURE 는 적용, label 인자만 생략
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "/* @__PURE__ */") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "css({") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"label:") == null);
+}
+
+test "emotion (object css): non-css attr (className 등) 는 wrap 안 함" {
+    // className 의 object literal 은 emotion css prop 이 아니므로 wrap 금지.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const el = <div className={{ foo: 'bar' }} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "css({") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"label:") == null);
+}
+
+test "emotion (object css): non-object/array value (identifier) 는 wrap 안 함" {
+    // someStyles 같은 변수 참조는 사용자가 이미 적절한 형태로 만들었다고 가정 — wrap 금지.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const el = <div css={someStyles} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "css(someStyles") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"label:") == null);
+}
+
+test "emotion (object css): `<Global styles={obj}/>` 도 css(...) wrap" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { Global, css } from "@emotion/react";
+        \\const el = <Global styles={{ body: { margin: 0 } }} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "/* @__PURE__ */") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "css({") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"label:Global;\"") != null);
+}
+
+test "emotion (object css): non-Global element 의 styles 는 wrap 안 함" {
+    // styles attr 의 element-match 가드는 wrap 경로에도 동일 적용.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const el = <SomeComp styles={{ color: 'red' }} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // Global binding 없거나 element 가 Global 아님 → wrap 안 됨
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "css({") == null);
+}
+
+test "emotion (object css): tagged template + object 둘 다 처리 (분기 검증)" {
+    // 같은 파일 안에 두 형태 공존 — tagged template 은 prepend, object 는 wrap.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@emotion/react";
+        \\const a = <div css={css`color: red;`} />;
+        \\const b = <div css={{ color: 'blue' }} />;
+    ,
+        .{ .emotion = true, .jsx_transform = true, .jsx_runtime = .automatic, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // tagged template path: label 이 quasi 안에 prepend
+    try expectAutoLabel(r.output, "div");
+    // object path: css({...}) wrap 형태
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "css({") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"label:div;\"") != null);
+}
+
 test "emotion (sourceMap): non-emotion tag 는 sourceMap 도 추가 안 됨" {
     var r = try e2eFull(
         std.testing.allocator,

--- a/src/transformer/transformer/emotion.zig
+++ b/src/transformer/transformer/emotion.zig
@@ -250,7 +250,72 @@ pub fn maybeApplyAutoLabelForJsxAttr(
     if (is_styles and !elementMatchesGlobal(self, tag_name_idx)) return value_idx;
 
     const label = jsxElementLabel(self, tag_name_idx) orelse return value_idx;
+
+    // value 형태별 분기:
+    //   - tagged_template_expression — 기존 path (label/sourceMap 적용)
+    //   - object_expression / array_expression — `css(...)` call 로 wrap (PURE + label arg)
+    //   - 그 외 (identifier, call_expression 등) — 통과 (사용자가 이미 변환한 값으로 가정)
+    const value_node = self.ast.getNode(value_idx);
+    const is_obj_or_arr = value_node.tag == .object_expression or value_node.tag == .array_expression;
+    // `<Global styles={obj}>` 도 처리 — is_styles 는 위에서 elementMatchesGlobal 가드 통과.
+    if (is_obj_or_arr and (is_css or is_styles or is_classnames_inline)) {
+        return try wrapCssPropInCssCall(self, value_idx, label);
+    }
     return try maybeTransformEmotionTemplate(self, value_idx, label);
+}
+
+/// `<X css={obj_or_arr}/>` 의 obj/array literal 을 `css(value, "label:X;")` call 로 wrap.
+/// `/* @__PURE__ */` annotation 도 부여 (CallFlags.is_pure) — minifier tree-shaking.
+///
+/// css binding 이 import 안 됐으면 no-op (auto-inject 는 별도 작업, 사용자가 import 가정).
+/// autoLabel 비활성 (.never / dev_only + production define) 이면 label 인자 생략.
+fn wrapCssPropInCssCall(self: *Transformer, value_idx: NodeIndex, label: []const u8) Error!NodeIndex {
+    const css_binding = self.plugins.emotion.css_binding orelse return value_idx;
+    const value_node = self.ast.getNode(value_idx);
+
+    // Callee: `<css_binding>` identifier_reference (alias 도 포함).
+    const callee_span = try self.ast.addString(css_binding);
+    const callee = try self.ast.addNode(.{
+        .tag = .identifier_reference,
+        .span = callee_span,
+        .data = .{ .string_ref = callee_span },
+    });
+
+    // Args: [value, optional label string]
+    var args_buf: [2]u32 = undefined;
+    args_buf[0] = @intFromEnum(value_idx);
+    var args_count: u32 = 1;
+
+    if (labelEnabledNow(self) and label.len > 0) {
+        var buf: std.ArrayList(u8) = .empty;
+        defer buf.deinit(self.allocator);
+        try buf.append(self.allocator, '"');
+        try writeLabelPrefix(self, &buf, label);
+        try buf.append(self.allocator, '"');
+        const label_span = try self.ast.addString(buf.items);
+        const label_node = try self.ast.addNode(.{
+            .tag = .string_literal,
+            .span = label_span,
+            .data = .{ .string_ref = label_span },
+        });
+        args_buf[1] = @intFromEnum(label_node);
+        args_count = 2;
+    }
+
+    // call_expression extras = [callee, args_start, args_len, flags]
+    const args_start = try self.ast.addExtras(args_buf[0..args_count]);
+    const flags: u32 = ast_mod.CallFlags.is_pure;
+    const call_extra = try self.ast.addExtras(&.{
+        @intFromEnum(callee),
+        args_start,
+        args_count,
+        flags,
+    });
+    return self.ast.addNode(.{
+        .tag = .call_expression,
+        .span = value_node.span,
+        .data = .{ .extra = call_extra },
+    });
 }
 
 /// JSX element 가 import 된 `Global` binding 과 일치하는지 — 단순 identifier 만.

--- a/tests/integration/tests/emotion-v10.test.ts
+++ b/tests/integration/tests/emotion-v10.test.ts
@@ -268,6 +268,26 @@ describe.skipIf(!hasV10)("Emotion v10 — autoLabel + 번들링", () => {
     expect(r.out).toContain("hotpink");
   });
 
+  it("@emotion/core v10 — `<div css={{color:'red'}}>` object literal 도 css(...) wrap", async () => {
+    const r = await runV10Bundle({
+      source: `
+        /** @jsx jsx */
+        import { jsx, css } from "@emotion/core";
+        const el = <div css={{ color: 'hotpink' }} />;
+        console.log(el);
+      `,
+      entry: "index.tsx",
+      config: { compiler: { emotion: true } },
+    });
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    // css({...}) call 형태 + PURE annotation + label arg
+    expect(r.out).toContain("/* @__PURE__ */");
+    expect(r.out).toContain("css({");
+    expect(r.out).toContain('"label:div;"');
+    expect(r.out).toContain("hotpink");
+  });
+
   it("v10 격리 검증 — fixture 의 @emotion/core 가 v10.x 인지", async () => {
     const pkgPath = join(EMOTION_V10_FIXTURE_NODE_MODULES, "@emotion/core/package.json");
     const pkg = JSON.parse(await readFile(pkgPath, "utf-8"));


### PR DESCRIPTION
## 변환

```tsx
// 입력
import { css } from "@emotion/react";
const el = <div css={{ color: 'red' }} />;

// 출력
const el = <div css={/* @__PURE__ */ css({ color: 'red' }, "label:div;")} />;
```

```tsx
// array literal
<Button css={[styleA, styleB]} />
// → <Button css={/* @__PURE__ */ css([styleA, styleB], "label:Button;")} />
```

## 적용 범위

`maybeApplyAutoLabelForJsxAttr` 의 분기에 추가:
- `tagged_template_expression` → 기존 path (label/sourceMap prepend)
- **`object_expression` / `array_expression` → wrap path (이번 PR)**
- 그 외 (identifier, call_expression 등) → 통과 (사용자가 변환했다 가정)

attr 별:
- `<X css={...}>` — 모든 element
- **`<Global styles={...}>` — Global binding 매칭 element 만** (false-positive 가드 유지)
- `<div className={...}>` — ClassNames render-prop scope 안에서만

## 동작 디테일

- **PURE annotation 항상 적용** (autoLabel 모드와 무관) — babel 동일. minifier tree-shaking 활성.
- **autoLabel 모드별**:
  - `.always` — `css(value, "label:X;")` (default)
  - `.never` — `css(value)` (label arg 생략, wrap+PURE 만)
  - `.dev_only` — production define 시 .never 동작
- **css binding 미import 시 no-op** — babel 은 auto-inject 하지만 ZTS 는 사용자 import 가정 (auto-inject 는 별도 작업)

## 테스트

**유닛 (+10)**:
- object literal / array literal wrap
- css alias (`{ css as cx }`) callee
- css 미import 시 no-op
- autoLabel .never 시 label arg 생략
- non-css attr (className) 는 wrap 안 함
- non-object/array value (identifier) 는 wrap 안 함
- tagged template + object 동시 (분기 검증)
- `<Global styles={obj}/>` wrap
- non-Global element 의 styles 는 wrap 안 함

**통합 (+1 v10)**: `@emotion/core` v10 의 `<div css={{color:'hotpink'}}>` 실제 번들 → wrap + PURE + label 모두 출력 검증

## 코드 리뷰 (1-agent simplify)

- 분기 조건 단순화 — `is_obj_or_arr and (is_css or is_styles or is_classnames_inline)` 로 통합 (`<Global styles={obj}>` 도 자동 처리)
- `flags: u32 = CallFlags.is_pure` const binding 으로 가독성 일관

## 검증

- `zig build test` 통과 (전체 + 신규 10)
- v10 통합 (13/13) + v11 (10/10) 회귀 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)