### PR TITLE
fix(transform): 더 깊은 다운레벨 엣지 케이스 보정

### DIFF
--- a/scripts/syntax-audit.mjs
+++ b/scripts/syntax-audit.mjs
@@ -148,6 +148,23 @@ console.log(JSON.stringify(log));
 `,
   },
   {
+    name: "derived-constructor-return-super-in-expression",
+    code: `
+const log = [];
+function wrap(x) { log.push("wrap:" + x.v); return x; }
+class Base { constructor(v) { log.push("base:" + v); this.v = v; } }
+class Child extends Base {
+  field = log.push("field:" + this.v);
+  constructor() {
+    log.push("before");
+    return wrap(super(5));
+  }
+}
+new Child();
+console.log(JSON.stringify(log));
+`,
+  },
+  {
     name: "private-field-brand-and-update",
     code: `
 class Counter {
@@ -197,6 +214,22 @@ class A {
   static [key("b")] = log.push("fieldB");
 }
 console.log(JSON.stringify([Object.keys(A), log]));
+`,
+  },
+  {
+    name: "static-computed-method-field-and-private-order",
+    code: `
+const log = [];
+let i = 0;
+function key(label) { log.push("key:" + label + ":" + ++i); return label + i; }
+class A {
+  [key("m")]() { return 1; }
+  static #x = log.push("priv");
+  static [key("s")] = log.push("field:" + this.#x);
+  static { log.push("block"); }
+  static read() { return [this.#x, Object.getOwnPropertyNames(this.prototype), Object.keys(this), log]; }
+}
+console.log(JSON.stringify(A.read()));
 `,
   },
   {
@@ -259,6 +292,17 @@ const log = [];
 const src = { a: 1, b: 2, c: 3 };
 function k() { log.push("key"); return "b"; }
 const { [k()]: picked, ...rest } = src;
+console.log(JSON.stringify({ picked, rest, log }));
+`,
+  },
+  {
+    name: "assignment-object-rest-computed-eval-order",
+    code: `
+const log = [];
+const src = { a: 1, b: 2, c: 3 };
+let picked, rest;
+function k() { log.push("key"); return "b"; }
+({ [k()]: picked, ...rest } = src);
 console.log(JSON.stringify({ picked, rest, log }));
 `,
   },

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -2263,7 +2263,8 @@ test "ES2015: class with computed method uses bracket notation" {
     // [Symbol.iterator]() → Object.defineProperty(prototype, Symbol.iterator, ...) (dot 없이)
     var r = try e2eTarget(std.testing.allocator, "class F{[Symbol.iterator](){return this;}}", .es5);
     defer r.deinit();
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.defineProperty(F.prototype,Symbol.iterator") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.defineProperty(F.prototype,") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Symbol.iterator") != null);
     // prototype.[Symbol.iterator] (잘못된 dot notation) 금지
     try std.testing.expectEqual(std.mem.indexOf(u8, r.output, "prototype.["), null);
 }

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -2260,10 +2260,16 @@ test "ES2015: class with computed method" {
 }
 
 test "ES2015: class with computed method uses bracket notation" {
-    // [Symbol.iterator]() → Object.defineProperty(prototype, Symbol.iterator, ...) (dot 없이)
+    // [Symbol.iterator]() → Object.defineProperty(prototype, <key>, ...) (dot 없이).
+    // computed key 는 hoist 된 임시 변수로 캡쳐되거나 직접 emit 될 수 있어 prefix/suffix 사이의
+    // 식별자만 검증한다 (정확한 temp 이름에 결합하지 않음).
     var r = try e2eTarget(std.testing.allocator, "class F{[Symbol.iterator](){return this;}}", .es5);
     defer r.deinit();
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.defineProperty(F.prototype,") != null);
+    const prefix = std.mem.indexOf(u8, r.output, "Object.defineProperty(F.prototype,") orelse return error.TestUnexpectedResult;
+    const after_prefix = prefix + "Object.defineProperty(F.prototype,".len;
+    try std.testing.expect(after_prefix < r.output.len);
+    const first = r.output[after_prefix];
+    try std.testing.expect(std.ascii.isAlphabetic(first) or first == '_');
     try std.testing.expect(std.mem.indexOf(u8, r.output, "Symbol.iterator") != null);
     // prototype.[Symbol.iterator] (잘못된 dot notation) 금지
     try std.testing.expectEqual(std.mem.indexOf(u8, r.output, "prototype.["), null);

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1766,16 +1766,21 @@ pub fn ES2015Class(comptime Transformer: type) type {
                         }
                     }
 
+                    const member_idx = if (!key.isNone() and self.ast.getNode(key).tag == .computed_property_key) blk: {
+                        const memo_key = try memoizeStaticComputedFieldKey(self, &cm, self.ast.getNode(key).data.unary.operand, member.span);
+                        break :blk try replaceMethodDefinitionKey(self, @enumFromInt(raw_idx), memo_key);
+                    } else @as(NodeIndex, @enumFromInt(raw_idx));
+
                     if (kind == 1 or kind == 2) {
                         try cm.accessors.append(self.allocator, .{
-                            .member_idx = @enumFromInt(raw_idx),
+                            .member_idx = member_idx,
                             .is_static = is_static,
                             .is_getter = kind == 1,
                             .member_span = member.span,
                         });
                     } else {
                         try cm.methods.append(self.allocator, .{
-                            .member_idx = @enumFromInt(raw_idx),
+                            .member_idx = member_idx,
                             .is_static = is_static,
                             .member_span = member.span,
                         });
@@ -2084,6 +2089,24 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const memo = try es_helpers.memoizeComputedKey(self, key_expr, span);
             try cm.accessor_key_memos.append(self.allocator, memo.decl);
             return memo.computed_key;
+        }
+
+        fn replaceMethodDefinitionKey(self: *Transformer, method_idx: NodeIndex, new_key: NodeIndex) Transformer.Error!NodeIndex {
+            const method = self.ast.getNode(method_idx);
+            const me = method.data.extra;
+            const new_extra = try self.ast.addExtras(&.{
+                @intFromEnum(new_key),
+                self.ast.extra_data.items[me + MethodExtra.params],
+                self.ast.extra_data.items[me + MethodExtra.body],
+                self.ast.extra_data.items[me + MethodExtra.flags],
+                self.ast.extra_data.items[me + MethodExtra.deco_start],
+                self.ast.extra_data.items[me + MethodExtra.deco_len],
+            });
+            return self.ast.addNode(.{
+                .tag = .method_definition,
+                .span = method.span,
+                .data = .{ .extra = new_extra },
+            });
         }
 
         /// computed accessor getter method_definition 생성. `get [_acc_key_N]() { return return_expr; }`.
@@ -2518,32 +2541,110 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     });
                 },
                 .return_statement => {
-                    const scratch_top = self.scratch.items.len;
-                    defer self.scratch.shrinkRetainingCapacity(scratch_top);
-
-                    const ret_span = try es_helpers.makeTempVarSpan(self);
-                    const ret_binding = try es_helpers.makeBindingIdentifier(self, ret_span);
-                    const ret_decl = try es_helpers.makeDeclarator(self, ret_binding, stmt.data.unary.operand, stmt.span);
-                    try self.scratch.append(
-                        self.allocator,
-                        try es_helpers.makeVarDeclaration(self, &.{ret_decl}, .@"var", stmt.span),
-                    );
-                    try appendInstanceFields(self, instance_fields, span);
-                    try self.scratch.append(self.allocator, try self.ast.addNode(.{
+                    return self.ast.addNode(.{
                         .tag = .return_statement,
                         .span = stmt.span,
-                        .data = .{ .unary = .{ .operand = try es_helpers.makeTempVarRef(self, ret_span, stmt.span), .flags = 0 } },
-                    }));
-
-                    const new_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
-                    return self.ast.addNode(.{
-                        .tag = .block_statement,
-                        .span = stmt.span,
-                        .data = .{ .list = new_list },
+                        .data = .{ .unary = .{
+                            .operand = try injectInstanceFieldsAfterSuperExpr(self, stmt.data.unary.operand, instance_fields, span),
+                            .flags = 0,
+                        } },
                     });
                 },
                 else => return stmt_idx,
             }
+        }
+
+        fn injectInstanceFieldsAfterSuperExpr(self: *Transformer, expr_idx: NodeIndex, instance_fields: []const NodeIndex, span: Span) Transformer.Error!NodeIndex {
+            if (expr_idx.isNone() or instance_fields.len == 0) return expr_idx;
+            const node = self.ast.getNode(expr_idx);
+
+            if (isSuperThisAssignment(self, node)) {
+                const scratch_top = self.scratch.items.len;
+                defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+                try self.scratch.append(self.allocator, expr_idx);
+                for (instance_fields) |field_stmt| {
+                    const replaced = try replaceThisWithThisAlias(self, field_stmt, span);
+                    const field_node = self.ast.getNode(replaced);
+                    if (field_node.tag == .expression_statement) {
+                        try self.scratch.append(self.allocator, field_node.data.unary.operand);
+                    } else {
+                        try self.scratch.append(self.allocator, replaced);
+                    }
+                }
+                try self.scratch.append(self.allocator, try es_helpers.makeIdentifierRef(self, "_this"));
+
+                const list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+                const seq = try self.ast.addNode(.{
+                    .tag = .sequence_expression,
+                    .span = node.span,
+                    .data = .{ .list = list },
+                });
+                return es_helpers.makeParenExpr(self, seq, node.span);
+            }
+
+            switch (node.tag) {
+                .parenthesized_expression => return es_helpers.makeParenExpr(
+                    self,
+                    try injectInstanceFieldsAfterSuperExpr(self, node.data.unary.operand, instance_fields, span),
+                    node.span,
+                ),
+                .sequence_expression, .array_expression => {
+                    const list = node.data.list;
+                    const scratch_top = self.scratch.items.len;
+                    defer self.scratch.shrinkRetainingCapacity(scratch_top);
+                    for (self.ast.extra_data.items[list.start .. list.start + list.len]) |raw_idx| {
+                        try self.scratch.append(self.allocator, try injectInstanceFieldsAfterSuperExpr(self, @enumFromInt(raw_idx), instance_fields, span));
+                    }
+                    const new_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+                    return self.ast.addNode(.{ .tag = node.tag, .span = node.span, .data = .{ .list = new_list } });
+                },
+                .call_expression, .new_expression => {
+                    const e = node.data.extra;
+                    const callee = self.ast.extra_data.items[e];
+                    const args_start = self.ast.extra_data.items[e + 1];
+                    const args_len = self.ast.extra_data.items[e + 2];
+                    const flags = self.ast.extra_data.items[e + 3];
+                    const scratch_top = self.scratch.items.len;
+                    defer self.scratch.shrinkRetainingCapacity(scratch_top);
+                    for (self.ast.extra_data.items[args_start .. args_start + args_len]) |raw_idx| {
+                        try self.scratch.append(self.allocator, try injectInstanceFieldsAfterSuperExpr(self, @enumFromInt(raw_idx), instance_fields, span));
+                    }
+                    const args = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+                    const new_extra = try self.ast.addExtras(&.{ callee, args.start, args.len, flags });
+                    return self.ast.addNode(.{ .tag = node.tag, .span = node.span, .data = .{ .extra = new_extra } });
+                },
+                .static_member_expression, .computed_member_expression => {
+                    const e = node.data.extra;
+                    const new_obj = try injectInstanceFieldsAfterSuperExpr(self, @enumFromInt(self.ast.extra_data.items[e]), instance_fields, span);
+                    const new_prop = try injectInstanceFieldsAfterSuperExpr(self, @enumFromInt(self.ast.extra_data.items[e + 1]), instance_fields, span);
+                    const new_extra = try self.ast.addExtras(&.{
+                        @intFromEnum(new_obj),
+                        @intFromEnum(new_prop),
+                        self.ast.extra_data.items[e + 2],
+                    });
+                    return self.ast.addNode(.{ .tag = node.tag, .span = node.span, .data = .{ .extra = new_extra } });
+                },
+                .conditional_expression => return self.ast.addNode(.{
+                    .tag = .conditional_expression,
+                    .span = node.span,
+                    .data = .{ .ternary = .{
+                        .a = node.data.ternary.a,
+                        .b = try injectInstanceFieldsAfterSuperExpr(self, node.data.ternary.b, instance_fields, span),
+                        .c = try injectInstanceFieldsAfterSuperExpr(self, node.data.ternary.c, instance_fields, span),
+                    } },
+                }),
+                else => return expr_idx,
+            }
+        }
+
+        fn isSuperThisAssignment(self: *Transformer, node: Node) bool {
+            if (node.tag != .assignment_expression) return false;
+            const left = self.ast.getNode(node.data.binary.left);
+            if (left.tag != .identifier_reference and left.tag != .assignment_target_identifier) return false;
+            if (!std.mem.eql(u8, self.ast.getText(left.data.string_ref), "_this")) return false;
+            const right = self.ast.getNode(node.data.binary.right);
+            return isSuperCallLike(self, right);
         }
 
         fn isSuperCallAssignmentStatement(self: *Transformer, node_idx: NodeIndex) bool {
@@ -2572,7 +2673,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 .parenthesized_expression => {
                     return containsSuperCallAssignment(self, node.data.unary.operand);
                 },
-                .sequence_expression => {
+                .sequence_expression, .array_expression => {
                     const list = node.data.list;
                     for (self.ast.extra_data.items[list.start .. list.start + list.len]) |raw_idx| {
                         if (containsSuperCallAssignment(self, @enumFromInt(raw_idx))) return true;
@@ -2600,6 +2701,11 @@ pub fn ES2015Class(comptime Transformer: type) type {
                         if (containsSuperCallAssignment(self, @enumFromInt(raw_idx))) return true;
                     }
                     return false;
+                },
+                .static_member_expression, .computed_member_expression => {
+                    const e = node.data.extra;
+                    return containsSuperCallAssignment(self, @enumFromInt(self.ast.extra_data.items[e])) or
+                        containsSuperCallAssignment(self, @enumFromInt(self.ast.extra_data.items[e + 1]));
                 },
                 .assignment_expression => {
                     const left = self.ast.getNode(node.data.binary.left);

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1768,7 +1768,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
                     const member_idx = if (!key.isNone() and self.ast.getNode(key).tag == .computed_property_key) blk: {
                         const memo_key = try memoizeStaticComputedFieldKey(self, &cm, self.ast.getNode(key).data.unary.operand, member.span);
-                        break :blk try replaceMethodDefinitionKey(self, @enumFromInt(raw_idx), memo_key);
+                        break :blk try es_helpers.replaceMethodDefinitionKey(self, @enumFromInt(raw_idx), memo_key);
                     } else @as(NodeIndex, @enumFromInt(raw_idx));
 
                     if (kind == 1 or kind == 2) {
@@ -2089,24 +2089,6 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const memo = try es_helpers.memoizeComputedKey(self, key_expr, span);
             try cm.accessor_key_memos.append(self.allocator, memo.decl);
             return memo.computed_key;
-        }
-
-        fn replaceMethodDefinitionKey(self: *Transformer, method_idx: NodeIndex, new_key: NodeIndex) Transformer.Error!NodeIndex {
-            const method = self.ast.getNode(method_idx);
-            const me = method.data.extra;
-            const new_extra = try self.ast.addExtras(&.{
-                @intFromEnum(new_key),
-                self.ast.extra_data.items[me + MethodExtra.params],
-                self.ast.extra_data.items[me + MethodExtra.body],
-                self.ast.extra_data.items[me + MethodExtra.flags],
-                self.ast.extra_data.items[me + MethodExtra.deco_start],
-                self.ast.extra_data.items[me + MethodExtra.deco_len],
-            });
-            return self.ast.addNode(.{
-                .tag = .method_definition,
-                .span = method.span,
-                .data = .{ .extra = new_extra },
-            });
         }
 
         /// computed accessor getter method_definition 생성. `get [_acc_key_N]() { return return_expr; }`.
@@ -2556,6 +2538,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
         fn injectInstanceFieldsAfterSuperExpr(self: *Transformer, expr_idx: NodeIndex, instance_fields: []const NodeIndex, span: Span) Transformer.Error!NodeIndex {
             if (expr_idx.isNone() or instance_fields.len == 0) return expr_idx;
+            // sub-tree 안에 super-call 이 없으면 AST 재구성 비용을 들일 필요가 없다.
+            // `containsSuperCallAssignment` 는 read-only 라 비용이 작다.
+            if (!containsSuperCallAssignment(self, expr_idx)) return expr_idx;
             const node = self.ast.getNode(expr_idx);
 
             if (isSuperThisAssignment(self, node)) {
@@ -2692,7 +2677,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     const init: NodeIndex = @enumFromInt(self.ast.extra_data.items[node.data.extra + 2]);
                     return containsSuperCallAssignment(self, init);
                 },
-                .call_expression => {
+                .call_expression, .new_expression => {
                     if (isSuperCallLike(self, node)) return true;
                     const e = node.data.extra;
                     const args_start = self.ast.extra_data.items[e + 1];

--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -369,30 +369,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
 
                 const ref = try es_helpers.makeTempVarRef(self, ref_span, ref_span);
                 const key_node = self.ast.getNode(key_idx);
-                const access = if (key_node.tag == .computed_property_key) blk: {
-                    const key_span = try es_helpers.makeTempVarSpan(self);
-                    const key_assign = try self.ast.addNode(.{
-                        .tag = .assignment_expression,
-                        .span = span,
-                        .data = .{ .binary = .{
-                            .left = try es_helpers.makeTempVarRef(self, key_span, span),
-                            .right = try self.visitNode(key_node.data.unary.operand),
-                            .flags = @intFromEnum(token_mod.Kind.eq),
-                        } },
-                    });
-                    try self.scratch.append(self.allocator, key_assign);
-                    if (exclude_count < exclude_keys.len) {
-                        exclude_keys[exclude_count] = try es_helpers.makeTempVarRef(self, key_span, span);
-                        exclude_count += 1;
-                    }
-                    break :blk try es_helpers.makeComputedMember(self, ref, try es_helpers.makeTempVarRef(self, key_span, span), span);
-                } else blk: {
-                    if (exclude_count < exclude_keys.len) {
-                        exclude_keys[exclude_count] = try makeRestExcludeKey(self, key_node);
-                        exclude_count += 1;
-                    }
-                    break :blk try es_helpers.makeMemberFromKeyIdx(self, ref, key_idx, span);
-                };
+                const access = try emitObjectMemberAccessForRest(self, ref, key_node, key_idx, &exclude_keys, &exclude_count, .assign, span);
 
                 if (prop.tag == .assignment_target_property_identifier) {
                     const target_node = try self.ast.addNode(.{
@@ -555,24 +532,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                 const ref = try es_helpers.makeTempVarRef(self, ref_span, ref_span);
                 const key_node = self.ast.getNode(key_idx);
 
-                const member_access = if (key_node.tag == .computed_property_key) blk: {
-                    const key_span = try es_helpers.makeTempVarSpan(self);
-                    const key_binding = try es_helpers.makeBindingIdentifier(self, key_span);
-                    const key_value = try self.visitNode(key_node.data.unary.operand);
-                    const key_decl = try es_helpers.makeDeclarator(self, key_binding, key_value, span);
-                    try self.scratch.append(self.allocator, key_decl);
-                    if (exclude_count < exclude_keys.len) {
-                        exclude_keys[exclude_count] = try es_helpers.makeTempVarRef(self, key_span, span);
-                        exclude_count += 1;
-                    }
-                    break :blk try es_helpers.makeComputedMember(self, ref, try es_helpers.makeTempVarRef(self, key_span, span), span);
-                } else blk: {
-                    if (exclude_count < exclude_keys.len) {
-                        exclude_keys[exclude_count] = try makeRestExcludeKey(self, key_node);
-                        exclude_count += 1;
-                    }
-                    break :blk try es_helpers.makeMemberFromKeyIdx(self, ref, key_idx, span);
-                };
+                const member_access = try emitObjectMemberAccessForRest(self, ref, key_node, key_idx, &exclude_keys, &exclude_count, .decl, span);
 
                 // value 처리: shorthand vs long-form, default value
                 if (value_idx.isNone() or @intFromEnum(value_idx) == @intFromEnum(key_idx)) {
@@ -797,6 +757,59 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             }
         }
 
+        const ComputedKeyMode = enum { decl, assign };
+
+        /// object pattern 의 한 property 에 대해 `_ref[key]` member access 를 만들고, rest 가 있으면
+        /// exclude key 도 같은 capture 결과로 모아둔다.
+        ///
+        /// computed key (`{[k()]: a}`) 는 평가 순서 보존을 위해 한 번 임시 변수로 캡쳐 — destructuring
+        /// declarator 컨텍스트에서는 `_key=expr` declarator, assignment-target 컨텍스트에서는
+        /// `(_key=expr)` assignment_expression 형태로 `self.scratch` 에 push 한다.
+        ///
+        /// non-computed key (identifier/string/number) 는 캡쳐 없이 곧장 member access 를 만들고,
+        /// rest exclude 는 raw key 를 따옴표로 감싼 string literal 로 등록한다.
+        fn emitObjectMemberAccessForRest(
+            self: *Transformer,
+            ref: NodeIndex,
+            key_node: Node,
+            key_idx: NodeIndex,
+            exclude_keys: []NodeIndex,
+            exclude_count: *usize,
+            mode: ComputedKeyMode,
+            span: Span,
+        ) Transformer.Error!NodeIndex {
+            if (key_node.tag == .computed_property_key) {
+                const key_span = try es_helpers.makeTempVarSpan(self);
+                const capture: NodeIndex = switch (mode) {
+                    .decl => blk: {
+                        const key_binding = try es_helpers.makeBindingIdentifier(self, key_span);
+                        const key_value = try self.visitNode(key_node.data.unary.operand);
+                        break :blk try es_helpers.makeDeclarator(self, key_binding, key_value, span);
+                    },
+                    .assign => try self.ast.addNode(.{
+                        .tag = .assignment_expression,
+                        .span = span,
+                        .data = .{ .binary = .{
+                            .left = try es_helpers.makeTempVarRef(self, key_span, span),
+                            .right = try self.visitNode(key_node.data.unary.operand),
+                            .flags = @intFromEnum(token_mod.Kind.eq),
+                        } },
+                    }),
+                };
+                try self.scratch.append(self.allocator, capture);
+                if (exclude_count.* < exclude_keys.len) {
+                    exclude_keys[exclude_count.*] = try es_helpers.makeTempVarRef(self, key_span, span);
+                    exclude_count.* += 1;
+                }
+                return es_helpers.makeComputedMember(self, ref, try es_helpers.makeTempVarRef(self, key_span, span), span);
+            }
+            if (exclude_count.* < exclude_keys.len) {
+                exclude_keys[exclude_count.*] = try makeRestExcludeKey(self, key_node);
+                exclude_count.* += 1;
+            }
+            return es_helpers.makeMemberFromKeyIdx(self, ref, key_idx, span);
+        }
+
         fn makeRestExcludeKey(self: *Transformer, key_node: Node) Transformer.Error!NodeIndex {
             const raw = switch (key_node.tag) {
                 .identifier_reference, .binding_identifier => self.ast.getText(key_node.span),
@@ -810,7 +823,35 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             return self.wrapInStringLiteral(raw);
         }
 
-        /// rest = __rest(_ref, ["key1", key2]) declarator 생성.
+        /// `__rest(_ref, [exclude_keys...])` 호출과 visit 된 binding 을 한 쌍으로 빌드.
+        /// declarator 컨텍스트와 assignment 컨텍스트가 같은 11-step 보일러플레이트를 공유 (#1287).
+        fn buildRestCall(
+            self: *Transformer,
+            rest_idx: NodeIndex,
+            ref_span: Span,
+            exclude_keys: []const NodeIndex,
+            span: Span,
+        ) Transformer.Error!struct { binding: NodeIndex, call: NodeIndex } {
+            const binding = try self.visitNode(rest_idx);
+            const rest_callee = try es_helpers.makeRuntimeHelperRef(self, "__rest");
+            const ref = try es_helpers.makeTempVarRef(self, ref_span, ref_span);
+
+            const scratch_top = self.scratch.items.len;
+            defer self.scratch.shrinkRetainingCapacity(scratch_top);
+            for (exclude_keys) |key| {
+                try self.scratch.append(self.allocator, key);
+            }
+            const arr_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+            const arr_node = try self.ast.addNode(.{
+                .tag = .array_expression,
+                .span = span,
+                .data = .{ .list = arr_list },
+            });
+            const call = try es_helpers.makeCallExpr(self, rest_callee, &.{ ref, arr_node }, span);
+            return .{ .binding = binding, .call = call };
+        }
+
+        /// rest = __rest(_ref, [...]) declarator (declaration 컨텍스트).
         fn buildRestDeclarator(
             self: *Transformer,
             rest_idx: NodeIndex,
@@ -818,35 +859,11 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             exclude_keys: []const NodeIndex,
             span: Span,
         ) Transformer.Error!NodeIndex {
-            const binding = try self.visitNode(rest_idx);
-
-            // __rest 호출: __rest(_ref, ["key1", "key2"])
-            const rest_callee = try es_helpers.makeRuntimeHelperRef(self, "__rest");
-
-            // _ref 참조
-            const ref = try es_helpers.makeTempVarRef(self, ref_span, ref_span);
-
-            // exclude 배열: ["key1", "key2"]
-            const scratch_top = self.scratch.items.len;
-            defer self.scratch.shrinkRetainingCapacity(scratch_top);
-
-            for (exclude_keys) |key| {
-                try self.scratch.append(self.allocator, key);
-            }
-
-            const arr_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
-            const arr_node = try self.ast.addNode(.{
-                .tag = .array_expression,
-                .span = span,
-                .data = .{ .list = arr_list },
-            });
-
-            // __rest(_ref, [...])
-            const call = try es_helpers.makeCallExpr(self, rest_callee, &.{ ref, arr_node }, span);
-
-            return es_helpers.makeDeclarator(self, binding, call, span);
+            const parts = try buildRestCall(self, rest_idx, ref_span, exclude_keys, span);
+            return es_helpers.makeDeclarator(self, parts.binding, parts.call, span);
         }
 
+        /// rest = __rest(_ref, [...]) assignment (assignment-target 컨텍스트).
         fn buildRestAssignment(
             self: *Transformer,
             rest_idx: NodeIndex,
@@ -854,26 +871,11 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             exclude_keys: []const NodeIndex,
             span: Span,
         ) Transformer.Error!NodeIndex {
-            const binding = try self.visitNode(rest_idx);
-            const rest_callee = try es_helpers.makeRuntimeHelperRef(self, "__rest");
-            const ref = try es_helpers.makeTempVarRef(self, ref_span, ref_span);
-
-            const scratch_top = self.scratch.items.len;
-            defer self.scratch.shrinkRetainingCapacity(scratch_top);
-            for (exclude_keys) |key| {
-                try self.scratch.append(self.allocator, key);
-            }
-            const arr_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
-            const arr_node = try self.ast.addNode(.{
-                .tag = .array_expression,
-                .span = span,
-                .data = .{ .list = arr_list },
-            });
-            const call = try es_helpers.makeCallExpr(self, rest_callee, &.{ ref, arr_node }, span);
+            const parts = try buildRestCall(self, rest_idx, ref_span, exclude_keys, span);
             return self.ast.addNode(.{
                 .tag = .assignment_expression,
                 .span = span,
-                .data = .{ .binary = .{ .left = binding, .right = call, .flags = 0 } },
+                .data = .{ .binary = .{ .left = parts.binding, .right = parts.call, .flags = 0 } },
             });
         }
         /// for_in_statement를 기본적으로 visit (ternary 자식 3개 재귀 방문).

--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -354,10 +354,10 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
         /// object_assignment_target의 각 property를 assignment로 변환.
         fn emitObjectAssignments(self: *Transformer, target: Node, ref_span: Span, span: Span) Transformer.Error!void {
             const oa_start = target.data.list.start;
-            // assignment 컨텍스트의 rest는 declaration 컨텍스트의 __rest 같은 런타임 헬퍼가
-            // 없어 현재 미지원 — split으로 elements만 처리하고 rest는 무시.
             const split = self.ast.nodeListSplitRest(target.data.list);
             const non_rest_len: u32 = @intCast(split.elements.len);
+            var exclude_keys: [64]NodeIndex = undefined;
+            var exclude_count: usize = 0;
             // visitNode가 AST를 변형하므로 인덱스 루프 사용
             var i_loop: u32 = 0;
             while (i_loop < non_rest_len) : (i_loop += 1) {
@@ -369,9 +369,30 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
 
                 const ref = try es_helpers.makeTempVarRef(self, ref_span, ref_span);
                 const key_node = self.ast.getNode(key_idx);
-                // makeMemberFromKeyIdx: computed_property_key를 자동 unwrap하여
-                // _ref[expr] (bracket) 또는 _ref.name (dot) 생성
-                const access = try es_helpers.makeMemberFromKeyIdx(self, ref, key_idx, span);
+                const access = if (key_node.tag == .computed_property_key) blk: {
+                    const key_span = try es_helpers.makeTempVarSpan(self);
+                    const key_assign = try self.ast.addNode(.{
+                        .tag = .assignment_expression,
+                        .span = span,
+                        .data = .{ .binary = .{
+                            .left = try es_helpers.makeTempVarRef(self, key_span, span),
+                            .right = try self.visitNode(key_node.data.unary.operand),
+                            .flags = @intFromEnum(token_mod.Kind.eq),
+                        } },
+                    });
+                    try self.scratch.append(self.allocator, key_assign);
+                    if (exclude_count < exclude_keys.len) {
+                        exclude_keys[exclude_count] = try es_helpers.makeTempVarRef(self, key_span, span);
+                        exclude_count += 1;
+                    }
+                    break :blk try es_helpers.makeComputedMember(self, ref, try es_helpers.makeTempVarRef(self, key_span, span), span);
+                } else blk: {
+                    if (exclude_count < exclude_keys.len) {
+                        exclude_keys[exclude_count] = try makeRestExcludeKey(self, key_node);
+                        exclude_count += 1;
+                    }
+                    break :blk try es_helpers.makeMemberFromKeyIdx(self, ref, key_idx, span);
+                };
 
                 if (prop.tag == .assignment_target_property_identifier) {
                     const target_node = try self.ast.addNode(.{
@@ -407,6 +428,12 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                         try emitTargetAssignOrRecurse(self, right_idx, access, span);
                     }
                 }
+            }
+
+            if (split.rest_operand) |rest_inner| {
+                const rest_assign = try buildRestAssignment(self, rest_inner, ref_span, exclude_keys[0..exclude_count], span);
+                try self.scratch.append(self.allocator, rest_assign);
+                self.runtime_helpers.rest = true;
             }
         }
 
@@ -818,6 +845,36 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             const call = try es_helpers.makeCallExpr(self, rest_callee, &.{ ref, arr_node }, span);
 
             return es_helpers.makeDeclarator(self, binding, call, span);
+        }
+
+        fn buildRestAssignment(
+            self: *Transformer,
+            rest_idx: NodeIndex,
+            ref_span: Span,
+            exclude_keys: []const NodeIndex,
+            span: Span,
+        ) Transformer.Error!NodeIndex {
+            const binding = try self.visitNode(rest_idx);
+            const rest_callee = try es_helpers.makeRuntimeHelperRef(self, "__rest");
+            const ref = try es_helpers.makeTempVarRef(self, ref_span, ref_span);
+
+            const scratch_top = self.scratch.items.len;
+            defer self.scratch.shrinkRetainingCapacity(scratch_top);
+            for (exclude_keys) |key| {
+                try self.scratch.append(self.allocator, key);
+            }
+            const arr_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+            const arr_node = try self.ast.addNode(.{
+                .tag = .array_expression,
+                .span = span,
+                .data = .{ .list = arr_list },
+            });
+            const call = try es_helpers.makeCallExpr(self, rest_callee, &.{ ref, arr_node }, span);
+            return self.ast.addNode(.{
+                .tag = .assignment_expression,
+                .span = span,
+                .data = .{ .binary = .{ .left = binding, .right = call, .flags = 0 } },
+            });
         }
         /// for_in_statement를 기본적으로 visit (ternary 자식 3개 재귀 방문).
         fn visitForInDefault(self: *Transformer, node: Node) Transformer.Error!NodeIndex {

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -135,7 +135,7 @@ pub fn ES2022(comptime Transformer: type) type {
                     try static_block_iifes.append(self.allocator, static_assign);
                 } else if (member.tag == .method_definition) {
                     if (lookupKeyMemo(static_key_memos.items, raw_idx)) |memo_key| {
-                        try self.scratch.append(self.allocator, try replaceMethodDefinitionKey(self, @enumFromInt(raw_idx), memo_key));
+                        try self.scratch.append(self.allocator, try es_helpers.replaceMethodDefinitionKey(self, @enumFromInt(raw_idx), memo_key));
                     } else if (already_visited) {
                         try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
                     } else {
@@ -192,24 +192,6 @@ pub fn ES2022(comptime Transformer: type) type {
                 if (m.raw_idx == raw_idx) return m.key_ref;
             }
             return null;
-        }
-
-        fn replaceMethodDefinitionKey(self: *Transformer, method_idx: NodeIndex, new_key: NodeIndex) Transformer.Error!NodeIndex {
-            const method = self.ast.getNode(method_idx);
-            const me = method.data.extra;
-            const new_extra = try self.ast.addExtras(&.{
-                @intFromEnum(new_key),
-                self.ast.extra_data.items[me + ast_mod.MethodExtra.params],
-                self.ast.extra_data.items[me + ast_mod.MethodExtra.body],
-                self.ast.extra_data.items[me + ast_mod.MethodExtra.flags],
-                self.ast.extra_data.items[me + ast_mod.MethodExtra.deco_start],
-                self.ast.extra_data.items[me + ast_mod.MethodExtra.deco_len],
-            });
-            return self.ast.addNode(.{
-                .tag = .method_definition,
-                .span = method.span,
-                .data = .{ .extra = new_extra },
-            });
         }
 
         /// public static field 의 `Class.key = init;` assignment 를 합성한다.

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -57,6 +57,7 @@ pub fn ES2022(comptime Transformer: type) type {
             self: *Transformer,
             body_idx: NodeIndex,
             new_body_out: *NodeIndex,
+            static_key_memos_out: *std.ArrayList(NodeIndex),
             static_block_iifes: *std.ArrayList(NodeIndex),
             class_name_span: ?Span,
             already_visited: bool,
@@ -88,11 +89,11 @@ pub fn ES2022(comptime Transformer: type) type {
             const pending_top = self.pending_nodes.items.len;
             defer self.pending_nodes.shrinkRetainingCapacity(pending_top);
 
-            // pre-pass: 공개 static field 의 computed key 를 `var _N = <expr>;` 로 캡쳐해 클래스 평가 직전에 hoist.
+            // pre-pass: class element computed key 를 `var _N = <expr>;` 로 캡쳐해 클래스 평가 직전에 hoist.
             // 메인 루프와 분리한 이유 — TC39 spec 상 모든 computed key 는 class body 평가 전에 한 번만 평가되어야
             // 하므로, 사이에 끼어들 수 있는 static block 보다 먼저 emit 되어야 한다 (test fixture
             // `static-computed-key-order-with-blocks` 참조).
-            // 항목 수 ≤ 클래스 내 공개 static computed-key field 개수(통상 0–3) → linear scan 이 HashMap 보다 저렴.
+            // 항목 수 ≤ 클래스 내 computed-key element 개수(통상 0–3) → linear scan 이 HashMap 보다 저렴.
             const KeyMemo = struct { raw_idx: u32, key_ref: NodeIndex };
             var static_key_memos: std.ArrayList(KeyMemo) = .empty;
             defer static_key_memos.deinit(self.allocator);
@@ -102,14 +103,20 @@ pub fn ES2022(comptime Transformer: type) type {
                 while (key_i < body_len) : (key_i += 1) {
                     const raw_idx = self.ast.extra_data.items[body_start + key_i];
                     const member = self.ast.getNode(@enumFromInt(raw_idx));
-                    if (member.tag != .property_definition or !isPublicStaticField(self, member)) continue;
-                    const pe = member.data.extra;
-                    const key: NodeIndex = self.readNodeIdx(pe, ast_mod.PropertyExtra.key);
+                    const key: NodeIndex = switch (member.tag) {
+                        .method_definition => self.readNodeIdx(member.data.extra, ast_mod.MethodExtra.key),
+                        .property_definition => if (isPublicStaticField(self, member))
+                            self.readNodeIdx(member.data.extra, ast_mod.PropertyExtra.key)
+                        else
+                            .none,
+                        else => .none,
+                    };
+                    if (key.isNone()) continue;
                     const key_node = self.ast.getNode(key);
                     if (key_node.tag != .computed_property_key) continue;
 
                     const memo = try es_helpers.memoizeComputedKey(self, key_node.data.unary.operand, member.span);
-                    try static_block_iifes.append(self.allocator, memo.decl);
+                    try static_key_memos_out.append(self.allocator, memo.decl);
                     try static_key_memos.append(self.allocator, .{ .raw_idx = raw_idx, .key_ref = memo.computed_key });
                 }
             }
@@ -126,6 +133,15 @@ pub fn ES2022(comptime Transformer: type) type {
                 } else if (class_name_span != null and member.tag == .property_definition and isPublicStaticField(self, member)) {
                     const static_assign = try buildStaticFieldAssign(self, member, class_name_span.?, lookupKeyMemo(static_key_memos.items, raw_idx));
                     try static_block_iifes.append(self.allocator, static_assign);
+                } else if (member.tag == .method_definition) {
+                    if (lookupKeyMemo(static_key_memos.items, raw_idx)) |memo_key| {
+                        try self.scratch.append(self.allocator, try replaceMethodDefinitionKey(self, @enumFromInt(raw_idx), memo_key));
+                    } else if (already_visited) {
+                        try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
+                    } else {
+                        const new_member = try self.visitNode(@enumFromInt(raw_idx));
+                        if (!new_member.isNone()) try self.scratch.append(self.allocator, new_member);
+                    }
                 } else if (already_visited) {
                     try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
                 } else {
@@ -176,6 +192,24 @@ pub fn ES2022(comptime Transformer: type) type {
                 if (m.raw_idx == raw_idx) return m.key_ref;
             }
             return null;
+        }
+
+        fn replaceMethodDefinitionKey(self: *Transformer, method_idx: NodeIndex, new_key: NodeIndex) Transformer.Error!NodeIndex {
+            const method = self.ast.getNode(method_idx);
+            const me = method.data.extra;
+            const new_extra = try self.ast.addExtras(&.{
+                @intFromEnum(new_key),
+                self.ast.extra_data.items[me + ast_mod.MethodExtra.params],
+                self.ast.extra_data.items[me + ast_mod.MethodExtra.body],
+                self.ast.extra_data.items[me + ast_mod.MethodExtra.flags],
+                self.ast.extra_data.items[me + ast_mod.MethodExtra.deco_start],
+                self.ast.extra_data.items[me + ast_mod.MethodExtra.deco_len],
+            });
+            return self.ast.addNode(.{
+                .tag = .method_definition,
+                .span = method.span,
+                .data = .{ .extra = new_extra },
+            });
         }
 
         /// public static field 의 `Class.key = init;` assignment 를 합성한다.

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -169,6 +169,27 @@ pub fn memoizeComputedKey(self: anytype, key_expr: NodeIndex, span: Span) !Compu
     };
 }
 
+/// 기존 method_definition 의 key 만 새 노드로 교체한 사본을 반환.
+/// 나머지 extra slot (params/body/flags/deco_start/deco_len) 은 그대로 복사.
+/// computed key memoization 결과를 method/accessor 에 끼워넣을 때 호출자 양쪽에서 공유.
+pub fn replaceMethodDefinitionKey(self: anytype, method_idx: NodeIndex, new_key: NodeIndex) !NodeIndex {
+    const method = self.ast.getNode(method_idx);
+    const me = method.data.extra;
+    const new_extra = try self.ast.addExtras(&.{
+        @intFromEnum(new_key),
+        self.ast.extra_data.items[me + ast_mod.MethodExtra.params],
+        self.ast.extra_data.items[me + ast_mod.MethodExtra.body],
+        self.ast.extra_data.items[me + ast_mod.MethodExtra.flags],
+        self.ast.extra_data.items[me + ast_mod.MethodExtra.deco_start],
+        self.ast.extra_data.items[me + ast_mod.MethodExtra.deco_len],
+    });
+    return self.ast.addNode(.{
+        .tag = .method_definition,
+        .span = method.span,
+        .data = .{ .extra = new_extra },
+    });
+}
+
 /// `void 0` 노드를 새 AST에 생성.
 pub fn makeVoidZero(self: anytype, span: Span) !NodeIndex {
     const zero_span = try self.ast.addString("0");

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1036,7 +1036,7 @@ pub const Transformer = struct {
                 // Parent.prototype.x 직접 접근이 아니라 receiver(this)를 보존하는 get/set
                 // 헬퍼로 먼저 lowering한다. 이후 generic logical/compound lowering으로 넘기면
                 // helper call에 대입하는 잘못된 target이 생성된다.
-                if (self.options.unsupported.class and self.current_super_class != null) {
+                if ((self.options.unsupported.class or self.current_super_is_static) and self.current_super_class != null) {
                     if (es2015_class.ES2015Class(Transformer).lowerSuperPropertyAssignment(self, node)) |result| {
                         return result;
                     }
@@ -1121,7 +1121,7 @@ pub const Transformer = struct {
                     }
                 }
                 // ES2015: super.method → Parent.prototype.method
-                if (self.options.unsupported.class and self.current_super_class != null) {
+                if ((self.options.unsupported.class or self.current_super_is_static) and self.current_super_class != null) {
                     if (es2015_class.ES2015Class(Transformer).isSuperMember(self, node)) {
                         return es2015_class.ES2015Class(Transformer).lowerSuperMember(self, node);
                     }
@@ -1157,7 +1157,7 @@ pub const Transformer = struct {
                     }
                 }
                 // ES2015: super["prop"] → Parent.prototype["prop"]
-                if (self.options.unsupported.class and self.current_super_class != null) {
+                if ((self.options.unsupported.class or self.current_super_is_static) and self.current_super_class != null) {
                     if (es2015_class.ES2015Class(Transformer).isSuperComputedMember(self, node)) {
                         return es2015_class.ES2015Class(Transformer).lowerSuperComputedMember(self, node);
                     }
@@ -1322,7 +1322,7 @@ pub const Transformer = struct {
                 }
                 // ES2015: super(args) → Parent.call(this, args)
                 // ES2015: super.method(args) → Parent.prototype.method.call(this, args)
-                if (self.options.unsupported.class and self.current_super_class != null) {
+                if ((self.options.unsupported.class or self.current_super_is_static) and self.current_super_class != null) {
                     if (es2015_class.ES2015Class(Transformer).isSuperCall(self, node)) {
                         return es2015_class.ES2015Class(Transformer).lowerSuperCall(self, node);
                     }
@@ -1785,7 +1785,7 @@ pub const Transformer = struct {
         // private field update: this.#x++ → _x.set(this, _x.get(this) + 1)
         if (node.tag == .update_expression and (self.options.unsupported.class or self.options.unsupported.class_private_field)) {
             const operand = self.ast.getNode(operand_idx);
-            if (self.options.unsupported.class and self.current_super_class != null) {
+            if ((self.options.unsupported.class or self.current_super_is_static) and self.current_super_class != null) {
                 if (es2015_class.ES2015Class(Transformer).lowerSuperPropertyUpdate(self, operand, op_flags, node.span)) |result| {
                     return try result;
                 }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -552,6 +552,15 @@ pub const Transformer = struct {
 
     /// 파서 AST 를 transformer 가 별도 cell 에 복제 후 transform — 원본 보존 모드.
     /// 일반적인 single-shot transpile / emit 단계의 first-time transform 진입점.
+    /// super 참조가 Parent.prototype.* / Parent.* 호출 형태로 lowering 되어야 하는지 판정.
+    /// - `unsupported.class`: ES2015 미만 타겟이라 class 자체가 lowering 됨
+    /// - `current_super_is_static`: target 이 class 를 지원해도 static field init/static block 은
+    ///   IIFE/`Class.foo = …` 로 들어내져 super 가 더 이상 lexical 로 의미를 가지지 않음
+    /// - `current_super_class != null`: derived class 안 (extends 가 있어 super 의미 자체가 존재)
+    pub inline fn needsSuperLowering(self: *const Transformer) bool {
+        return (self.options.unsupported.class or self.current_super_is_static) and self.current_super_class != null;
+    }
+
     pub fn init(allocator: std.mem.Allocator, source_ast: *const Ast, options: TransformOptions) Error!Transformer {
         var opts = options;
         if (opts.experimental_decorators) opts.use_define_for_class_fields = false;
@@ -1036,7 +1045,7 @@ pub const Transformer = struct {
                 // Parent.prototype.x 직접 접근이 아니라 receiver(this)를 보존하는 get/set
                 // 헬퍼로 먼저 lowering한다. 이후 generic logical/compound lowering으로 넘기면
                 // helper call에 대입하는 잘못된 target이 생성된다.
-                if ((self.options.unsupported.class or self.current_super_is_static) and self.current_super_class != null) {
+                if (self.needsSuperLowering()) {
                     if (es2015_class.ES2015Class(Transformer).lowerSuperPropertyAssignment(self, node)) |result| {
                         return result;
                     }
@@ -1121,7 +1130,7 @@ pub const Transformer = struct {
                     }
                 }
                 // ES2015: super.method → Parent.prototype.method
-                if ((self.options.unsupported.class or self.current_super_is_static) and self.current_super_class != null) {
+                if (self.needsSuperLowering()) {
                     if (es2015_class.ES2015Class(Transformer).isSuperMember(self, node)) {
                         return es2015_class.ES2015Class(Transformer).lowerSuperMember(self, node);
                     }
@@ -1157,7 +1166,7 @@ pub const Transformer = struct {
                     }
                 }
                 // ES2015: super["prop"] → Parent.prototype["prop"]
-                if ((self.options.unsupported.class or self.current_super_is_static) and self.current_super_class != null) {
+                if (self.needsSuperLowering()) {
                     if (es2015_class.ES2015Class(Transformer).isSuperComputedMember(self, node)) {
                         return es2015_class.ES2015Class(Transformer).lowerSuperComputedMember(self, node);
                     }
@@ -1322,7 +1331,7 @@ pub const Transformer = struct {
                 }
                 // ES2015: super(args) → Parent.call(this, args)
                 // ES2015: super.method(args) → Parent.prototype.method.call(this, args)
-                if ((self.options.unsupported.class or self.current_super_is_static) and self.current_super_class != null) {
+                if (self.needsSuperLowering()) {
                     if (es2015_class.ES2015Class(Transformer).isSuperCall(self, node)) {
                         return es2015_class.ES2015Class(Transformer).lowerSuperCall(self, node);
                     }
@@ -1785,7 +1794,7 @@ pub const Transformer = struct {
         // private field update: this.#x++ → _x.set(this, _x.get(this) + 1)
         if (node.tag == .update_expression and (self.options.unsupported.class or self.options.unsupported.class_private_field)) {
             const operand = self.ast.getNode(operand_idx);
-            if ((self.options.unsupported.class or self.current_super_is_static) and self.current_super_class != null) {
+            if (self.needsSuperLowering()) {
                 if (es2015_class.ES2015Class(Transformer).lowerSuperPropertyUpdate(self, operand, op_flags, node.span)) |result| {
                     return try result;
                 }

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -144,13 +144,10 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
                 });
 
                 if (node.tag == .class_expression) {
-                    var combined_pre: std.ArrayList(NodeIndex) = .empty;
-                    defer combined_pre.deinit(self.allocator);
-                    try combined_pre.appendSlice(self.allocator, static_key_memos.items);
-                    try combined_pre.appendSlice(self.allocator, pre_stmts.items);
                     return wrapClassExprInIIFE(
                         self,
-                        combined_pre.items,
+                        static_key_memos.items,
+                        pre_stmts.items,
                         class_result,
                         static_block_iifes.items,
                         new_name,
@@ -186,6 +183,7 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
             if (node.tag == .class_expression) {
                 return wrapClassExprInIIFE(
                     self,
+                    &.{},
                     pre_stmts.items,
                     class_result,
                     &.{},
@@ -224,7 +222,8 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
 /// 동일하므로 재복사 불필요).
 fn wrapClassExprInIIFE(
     self: *Transformer,
-    pre_stmts: []const NodeIndex,
+    pre_stmts_a: []const NodeIndex,
+    pre_stmts_b: []const NodeIndex,
     class_expr_node: NodeIndex,
     post_stmts: []const NodeIndex,
     new_name: NodeIndex,
@@ -249,7 +248,8 @@ fn wrapClassExprInIIFE(
 
     const scratch_top = self.scratch.items.len;
     defer self.scratch.shrinkRetainingCapacity(scratch_top);
-    try self.scratch.appendSlice(self.allocator, pre_stmts);
+    try self.scratch.appendSlice(self.allocator, pre_stmts_a);
+    try self.scratch.appendSlice(self.allocator, pre_stmts_b);
     try self.scratch.append(self.allocator, class_decl);
     try self.scratch.appendSlice(self.allocator, post_stmts);
 

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -113,6 +113,8 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
         // private member가 이미 body를 visit한 경우 `already_visited=true`로 재방문을 막는다.
         if (self.options.unsupported.class_static_block) {
             var new_body: NodeIndex = .none;
+            var static_key_memos: std.ArrayList(NodeIndex) = .empty;
+            defer static_key_memos.deinit(self.allocator);
             var static_block_iifes: std.ArrayList(NodeIndex) = .empty;
             defer static_block_iifes.deinit(self.allocator);
 
@@ -124,6 +126,7 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
                 self,
                 current_body_idx,
                 &new_body,
+                &static_key_memos,
                 &static_block_iifes,
                 class_name_span,
                 already_visited,
@@ -141,9 +144,13 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
                 });
 
                 if (node.tag == .class_expression) {
+                    var combined_pre: std.ArrayList(NodeIndex) = .empty;
+                    defer combined_pre.deinit(self.allocator);
+                    try combined_pre.appendSlice(self.allocator, static_key_memos.items);
+                    try combined_pre.appendSlice(self.allocator, pre_stmts.items);
                     return wrapClassExprInIIFE(
                         self,
-                        pre_stmts.items,
+                        combined_pre.items,
                         class_result,
                         static_block_iifes.items,
                         new_name,
@@ -151,7 +158,10 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
                     );
                 }
 
-                // pre_stmts (WeakMap + WeakSet + function) → class → static block IIFE
+                // computed static keys → pre_stmts (WeakMap + WeakSet + function) → class → static block IIFE
+                for (static_key_memos.items) |stmt| {
+                    try self.pending_nodes.append(self.allocator, stmt);
+                }
                 for (pre_stmts.items) |stmt| {
                     try self.pending_nodes.append(self.allocator, stmt);
                 }


### PR DESCRIPTION
## Summary
- derived constructor return expression 안의 super() 뒤 instance field 초기화 위치를 보정했습니다.
- class computed method/static field/private static descriptor 평가 순서를 class element source order에 맞게 정렬했습니다.
- static field/block 추출 경로에서도 super/this receiver 컨텍스트가 유지되도록 했습니다.
- assignment destructuring의 object rest + computed key를 __rest exclude로 처리합니다.
- syntax audit에 추가 회귀 케이스를 보강했습니다.

## Tests
- `node scripts/syntax-audit.mjs`
- extra native-vs-zts temporary audit for derived/static/rest/generator combinations
- `cd tests/integration && bun test tests/downlevel-edge.test.ts --timeout 600000`
- `zig build test --summary all`
- `bunx oxlint scripts/syntax-audit.mjs`
- `bunx oxfmt --check scripts/syntax-audit.mjs`
- pre-push hook passed