### PR TITLE
feat(transformer): emotion expression-statement form 에 sourceMap 적용

### DIFF
--- a/src/transformer/emotion_test.zig
+++ b/src/transformer/emotion_test.zig
@@ -929,6 +929,42 @@ test "emotion (sourceMap): JSX inline `<div css={css`...`}>` 도 sourceMap 적�
     try expectSourceMapComment(r.output);
 }
 
+test "emotion (sourceMap): expression-statement `injectGlobal`...`;` 에도 sourceMap 적용" {
+    // babel-plugin-emotion 동작: side-effect call 형태에도 dev-build sourceMap 부여.
+    // autoLabel 은 var 이름이 없어 적용 안 됨 (tag binding 만 매칭하면 sourceMap 만).
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { injectGlobal } from "@emotion/css";
+        \\injectGlobal`* { box-sizing: border-box; }`;
+    ,
+        .{ .emotion = true, .emotion_source_map = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectSourceMapComment(r.output);
+    // var 이름이 없으니 label: 없음 — false-positive 방지
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "label:") == null);
+    // 원본 css 보존
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "box-sizing: border-box") != null);
+}
+
+test "emotion (sourceMap): expression-statement form — sourceMap 옵션 비활성 시 미변경" {
+    // sourceMap 옵션 false 면 expression-statement hook 도 no-op 이어야 함.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { injectGlobal } from "@emotion/css";
+        \\injectGlobal`* { box-sizing: border-box; }`;
+    ,
+        .{ .emotion = true, .jsx_filename = "test.tsx" },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "sourceMappingURL") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "box-sizing: border-box") != null);
+}
+
 test "emotion (sourceMap): base64 디코딩 → JSON 구조 정합성 검증" {
     // 실제 base64 를 디코딩해 JSON 이 valid 한지, 핵심 필드가 들어있는지 확인.
     // VLQ 인코딩 회귀 (sign bit / continuation bit 순서 등) 를 잡기 위함.

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -950,7 +950,15 @@ pub const Transformer = struct {
             .jsx_opening_element => self.visitJSXOpeningElement(node),
 
             // === 단항 노드: 자식 1개 재귀 방문 ===
-            .expression_statement,
+            .expression_statement => {
+                // emotion `injectGlobal\`...\`;` 같은 expression-statement form 에 sourceMap
+                // 적용. autoLabel 은 var 이름이 없어 미적용 — sourceMap 만 부여.
+                if (self.options.emotion and self.options.emotion_source_map) {
+                    const new_idx = try self.visitUnaryNode(idx);
+                    return emotion_mod.maybeTransformExpressionStatement(self, new_idx);
+                }
+                return self.visitUnaryNode(idx);
+            },
             .return_statement,
             .throw_statement,
             .spread_element,

--- a/src/transformer/transformer/emotion.zig
+++ b/src/transformer/transformer/emotion.zig
@@ -214,6 +214,28 @@ pub fn maybeTransformEmotionTemplate(
     });
 }
 
+/// `visitNode(.expression_statement)` post-hook — operand 가 emotion tagged template 이면
+/// sourceMap 적용. binding 이 없으니 autoLabel 은 적용 불가, sourceMap 만 부여
+/// (babel-plugin-emotion 의 expression-statement 형태 파리티).
+///
+/// `stmt_idx` 는 이미 `visitUnaryNode` 가 처리한 `expression_statement` 노드. 여기서는
+/// 그 operand 만 다시 보고 필요하면 노드 한 번 더 만든다.
+pub fn maybeTransformExpressionStatement(self: *Transformer, stmt_idx: NodeIndex) Error!NodeIndex {
+    if (!self.options.emotion or !self.options.emotion_source_map) return stmt_idx;
+    if (stmt_idx.isNone()) return stmt_idx;
+
+    const stmt_node = self.ast.getNode(stmt_idx);
+    const operand = stmt_node.data.unary.operand;
+    const transformed = try maybeTransformEmotionTemplate(self, operand, "");
+    if (transformed == operand) return stmt_idx;
+
+    return self.ast.addNode(.{
+        .tag = .expression_statement,
+        .span = stmt_node.span,
+        .data = .{ .unary = .{ .operand = transformed, .flags = stmt_node.data.unary.flags } },
+    });
+}
+
 /// JSX attribute value autoLabel hook — `lowerJSXAttribute` 에서 호출.
 ///
 /// 두 가지 시나리오 처리:


### PR DESCRIPTION
## Summary
- `injectGlobal\`...\`;` 같은 side-effect tagged-template (binding 없는 expression-statement) 에 emotion sourceMap 주석 부여 — babel-plugin-emotion 파리티
- autoLabel 은 변수명이 없으니 미적용, sourceMap 만 부여
- `maybeTransformExpressionStatement` 헬퍼를 emotion.zig 에 추가하고 transformer 의 `.expression_statement` 분기는 styled-components `maybeWrapAssignment` 패턴과 동일하게 `visitUnaryNode` 결과를 post-process

## 변경
- `src/transformer/transformer/emotion.zig` — `maybeTransformExpressionStatement(stmt_idx)` 추가
- `src/transformer/transformer.zig` — `.expression_statement` 분기에서 emotion + emotion_source_map 양쪽 켜진 경우만 hook 호출 (hot path 최소 비용)
- `src/transformer/emotion_test.zig` — sourceMap 적용 + 옵션 비활성 시 미변경 회귀 테스트 2개

## Test plan
- [x] `zig build test` — Debug
- [x] `zig build test -Doptimize=ReleaseFast`
- [x] 신규 테스트 `emotion (sourceMap): expression-statement \`injectGlobal\`...\`;\` 에도 sourceMap 적용` 통과
- [x] 신규 테스트 `emotion (sourceMap): expression-statement form — sourceMap 옵션 비활성 시 미변경` 통과
- [x] /simplify — 3 reviewer agent 피드백 반영 (visitUnaryNode reuse + identity-check 정리 + 중복 테스트 제거)

🤖 Generated with [Claude Code](https://claude.com/claude-code)