### PR TITLE
feat(transformer): emotion importMap 옵션 — vendored re-export 인식

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1270,9 +1270,53 @@ function prepareNapiOptions(options: BuildOptions): Record<string, unknown> {
       if (typeof em.labelFormat === "string" && em.labelFormat.length > 0) {
         napiOptions.emotionLabelFormat = em.labelFormat;
       }
+      const extras = collectEmotionImportMapExtras(em.importMap);
+      if (extras.css.length > 0) napiOptions.emotionExtraCssSources = extras.css;
+      if (extras.styled.length > 0) napiOptions.emotionExtraStyledSources = extras.styled;
     }
   }
   return napiOptions;
+}
+
+/**
+ * babel-plugin-emotion `importMap.canonicalImport[0]` 의 css 분류 패키지 목록.
+ * Zig 측 `EMOTION_CSS_SOURCES` (`src/transformer/transformer/emotion.zig`) 와 동기화.
+ */
+const EMOTION_CSS_CANONICAL_SOURCES: ReadonlySet<string> = new Set([
+  "@emotion/react",
+  "@emotion/css",
+  "@emotion/core",
+  "@emotion/native",
+  "@emotion/primitives",
+  "@emotion/primitives-core",
+]);
+
+/**
+ * babel-plugin-emotion `importMap` 의 vendored re-export 케이스를 ZTS 의 단순화된
+ * `extraCssSources` / `extraStyledSources` array 로 collapse.
+ *
+ * 같은 source 안에 styled / css canonicalImport 가 섞여 있으면 양쪽에 모두 등록.
+ * import 인식이 source 단위라 alias-by-alias 라우팅은 미지원 — 흔치 않은 케이스라 의도적
+ * 단순화 (babel parity).
+ */
+function collectEmotionImportMapExtras(importMap: EmotionOptions["importMap"]): {
+  css: string[];
+  styled: string[];
+} {
+  const css = new Set<string>();
+  const styled = new Set<string>();
+  if (!importMap) return { css: [], styled: [] };
+  for (const [source, locals] of Object.entries(importMap)) {
+    for (const spec of Object.values(locals)) {
+      const [pkg, exportName] = spec.canonicalImport;
+      if (pkg === "@emotion/styled" && exportName === "default") {
+        styled.add(source);
+      } else if (EMOTION_CSS_CANONICAL_SOURCES.has(pkg)) {
+        css.add(source);
+      }
+    }
+  }
+  return { css: [...css], styled: [...styled] };
 }
 
 /**
@@ -1455,6 +1499,9 @@ function buildCompilerNapiFields(compiler: AppBuildOptions["compiler"]): Record<
     if (typeof em.labelFormat === "string" && em.labelFormat.length > 0) {
       out.emotionLabelFormat = em.labelFormat;
     }
+    const extras = collectEmotionImportMapExtras(em.importMap);
+    if (extras.css.length > 0) out.emotionExtraCssSources = extras.css;
+    if (extras.styled.length > 0) out.emotionExtraStyledSources = extras.styled;
   }
 
   return out;

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -573,6 +573,17 @@ fn napiBuildAppSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.
     }
     defer if (define_entries.len > 0) native_alloc.free(define_entries);
 
+    const emotion_extra_css = getObjectStringArray(env, opts_obj, "emotionExtraCssSources", native_alloc);
+    if (emotion_extra_css) |arr| {
+        for (arr) |s| owned_strings.append(native_alloc, s) catch return throwError(env, "OutOfMemory");
+        owned_arrays.append(native_alloc, arr) catch return throwError(env, "OutOfMemory");
+    }
+    const emotion_extra_styled = getObjectStringArray(env, opts_obj, "emotionExtraStyledSources", native_alloc);
+    if (emotion_extra_styled) |arr| {
+        for (arr) |s| owned_strings.append(native_alloc, s) catch return throwError(env, "OutOfMemory");
+        owned_arrays.append(native_alloc, arr) catch return throwError(env, "OutOfMemory");
+    }
+
     const output_count = @import("zts_lib").app.build.buildApp(native_alloc, .{
         .root = root,
         .outdir = outdir,
@@ -596,6 +607,8 @@ fn napiBuildAppSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.
         .emotion_auto_label = getAutoLabelMode(env, opts_obj, native_alloc),
         .emotion_source_map = getObjectBool(env, opts_obj, "emotionSourceMap", false),
         .emotion_label_format = getObjectString(env, opts_obj, "emotionLabelFormat", native_alloc) orelse "",
+        .emotion_extra_css_sources = emotion_extra_css orelse &.{},
+        .emotion_extra_styled_sources = emotion_extra_styled orelse &.{},
     }) catch |err| {
         return throwError(env, @errorName(err));
     };
@@ -3489,6 +3502,18 @@ fn parseBuildOptions(
         if (!trackArr(owned_string_arrays, arr)) return null;
     }
 
+    // emotionExtraCssSources / emotionExtraStyledSources: string[]
+    const emotion_extra_css = getObjectStringArray(env, opts_obj, "emotionExtraCssSources", native_alloc);
+    if (emotion_extra_css) |arr| {
+        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
+        if (!trackArr(owned_string_arrays, arr)) return null;
+    }
+    const emotion_extra_styled = getObjectStringArray(env, opts_obj, "emotionExtraStyledSources", native_alloc);
+    if (emotion_extra_styled) |arr| {
+        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
+        if (!trackArr(owned_string_arrays, arr)) return null;
+    }
+
     // pure: string[]
     const pure = getObjectStringArray(env, opts_obj, "pure", native_alloc);
     if (pure) |arr| {
@@ -3608,6 +3633,8 @@ fn parseBuildOptions(
         .emotion_auto_label = getAutoLabelMode(env, opts_obj, native_alloc),
         .emotion_source_map = getObjectBool(env, opts_obj, "emotionSourceMap", false),
         .emotion_label_format = getObjectString(env, opts_obj, "emotionLabelFormat", native_alloc) orelse "",
+        .emotion_extra_css_sources = emotion_extra_css orelse &.{},
+        .emotion_extra_styled_sources = emotion_extra_styled orelse &.{},
         .collect_module_codes = getObjectBool(env, opts_obj, "collectModuleCodes", false),
         // RN 프리셋(bundler.zig의 RN_BOOL_PRESET 단일 소스): platform=react-native이면
         // 사용자가 명시하지 않아도 CLI와 동일하게 auto-enable. worklet_transform 없이는

--- a/src/app/build.zig
+++ b/src/app/build.zig
@@ -40,6 +40,10 @@ pub const AppBuildOptions = struct {
     emotion_source_map: bool = false,
     /// emotion.labelFormat 옵션 — label 포맷 템플릿.
     emotion_label_format: []const u8 = "",
+    /// emotion.importMap re-export 케이스 단순화 — vendored emotion css source.
+    emotion_extra_css_sources: []const []const u8 = &.{},
+    /// emotion.importMap re-export 케이스 단순화 — vendored emotion styled source.
+    emotion_extra_styled_sources: []const []const u8 = &.{},
 };
 
 pub const AppDevPrepareOptions = struct {
@@ -141,6 +145,8 @@ pub fn buildApp(allocator: std.mem.Allocator, opts: AppBuildOptions) !usize {
         .emotion_auto_label = opts.emotion_auto_label,
         .emotion_source_map = opts.emotion_source_map,
         .emotion_label_format = opts.emotion_label_format,
+        .emotion_extra_css_sources = opts.emotion_extra_css_sources,
+        .emotion_extra_styled_sources = opts.emotion_extra_styled_sources,
     });
     defer bundler.deinit();
 

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -144,6 +144,10 @@ pub const BundleOptions = struct {
     emotion_source_map: bool = false,
     /// emotion.labelFormat 옵션 — label 이름 포맷 템플릿 (e.g. `[filename]--[local]`).
     emotion_label_format: []const u8 = "",
+    /// emotion.importMap re-export 케이스 단순화 — vendored emotion css source list.
+    emotion_extra_css_sources: []const []const u8 = &.{},
+    /// emotion.importMap re-export 케이스 단순화 — vendored emotion styled source list.
+    emotion_extra_styled_sources: []const []const u8 = &.{},
     /// dev mode에서 per-module codes 수집 (HMR rebuild용). 초기 빌드에서는 false로 메모리 절감.
     collect_module_codes: bool = false,
     /// define 글로벌 치환 (--define:KEY=VALUE)
@@ -656,6 +660,8 @@ pub const Bundler = struct {
         worker_graph.emotion_auto_label = self.options.emotion_auto_label;
         worker_graph.emotion_source_map = self.options.emotion_source_map;
         worker_graph.emotion_label_format = self.options.emotion_label_format;
+        worker_graph.emotion_extra_css_sources = self.options.emotion_extra_css_sources;
+        worker_graph.emotion_extra_styled_sources = self.options.emotion_extra_styled_sources;
         worker_graph.code_splitting = self.options.code_splitting;
         worker_graph.minify_identifiers = self.options.minify_identifiers;
         worker_graph.transform_options_base = self.buildTransformOptionsBase();
@@ -824,6 +830,8 @@ pub const Bundler = struct {
         graph.emotion_auto_label = self.options.emotion_auto_label;
         graph.emotion_source_map = self.options.emotion_source_map;
         graph.emotion_label_format = self.options.emotion_label_format;
+        graph.emotion_extra_css_sources = self.options.emotion_extra_css_sources;
+        graph.emotion_extra_styled_sources = self.options.emotion_extra_styled_sources;
         graph.code_splitting = self.options.code_splitting;
         graph.minify_identifiers = self.options.minify_identifiers;
         graph.transform_options_base = self.buildTransformOptionsBase();

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -158,6 +158,10 @@ pub const ModuleGraph = struct {
     emotion_source_map: bool = false,
     /// emotion.labelFormat 옵션 — label 이름 포맷 템플릿 (`[local]`/`[filename]`/`[dirname]`).
     emotion_label_format: []const u8 = "",
+    /// emotion.importMap re-export 케이스 단순화 — vendored emotion css source list.
+    emotion_extra_css_sources: []const []const u8 = &.{},
+    /// emotion.importMap re-export 케이스 단순화 — vendored emotion styled source list.
+    emotion_extra_styled_sources: []const []const u8 = &.{},
     /// code splitting 활성화. helper module virtual import (#1961) 는 splitting 모드에서만
     /// 활성 — single-bundle 모드는 helper module 의 declaration 이 statement-level shake
     /// 로 elide 되는 회귀가 있어 기존 preamble 모델 유지.
@@ -1744,6 +1748,8 @@ pub const ModuleGraph = struct {
         opts.emotion_auto_label = self.emotion_auto_label;
         opts.emotion_source_map = self.emotion_source_map;
         opts.emotion_label_format = self.emotion_label_format;
+        opts.emotion_extra_css_sources = self.emotion_extra_css_sources;
+        opts.emotion_extra_styled_sources = self.emotion_extra_styled_sources;
         opts.plugins = merged_plugins;
         opts.jsx_transform = ast_ptr.has_jsx;
         opts.jsx_filename = module.path;

--- a/src/transformer/emotion_test.zig
+++ b/src/transformer/emotion_test.zig
@@ -236,6 +236,60 @@ test "emotion: 다른 라이브러리 source (`stitches`) 는 미감지" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "label:") == null);
 }
 
+test "emotion (importMap): extraCssSources 로 vendored re-export 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@my-org/emotion-utils";
+        \\const button = css`color: red;`;
+    ,
+        .{
+            .emotion = true,
+            .emotion_extra_css_sources = &.{"@my-org/emotion-utils"},
+            .jsx_filename = "test.tsx",
+        },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "button");
+}
+
+test "emotion (importMap): extraStyledSources 로 vendored styled fork 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "@my-org/emotion-styled";
+        \\const Btn = styled.div`color: red;`;
+    ,
+        .{
+            .emotion = true,
+            .emotion_extra_styled_sources = &.{"@my-org/emotion-styled"},
+            .jsx_filename = "test.tsx",
+        },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try expectAutoLabel(r.output, "Btn");
+}
+
+test "emotion (importMap): extraCssSources 미등록 source 는 여전히 미감지" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import { css } from "@my-org/emotion-utils";
+        \\const button = css`color: red;`;
+    ,
+        .{
+            .emotion = true,
+            .emotion_extra_css_sources = &.{"@other-org/emotion-utils"},
+            .jsx_filename = "test.tsx",
+        },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "label:") == null);
+}
+
 test "emotion: @emotion/styled default — styled.div`` 도 autoLabel" {
     var r = try e2eFull(
         std.testing.allocator,

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -165,6 +165,17 @@ pub const TransformOptions = struct {
     /// `[local]` 동작 (기본). babel-plugin-emotion 동작과 동일 — invalid CSS char
     /// (`!"#$%&'()*+,./:;<=>?@[]^|}~{`) 는 `-` 로 sanitize.
     emotion_label_format: []const u8 = "",
+    /// emotion.importMap 의 vendored re-export 케이스 단순화 — `@emotion/react|css|core`
+    /// 의 named import (`{ css, keyframes, Global, ClassNames, injectGlobal }`) 를
+    /// re-export 하는 사용자 패키지를 emotion 으로 인식. babel-plugin-emotion 의
+    /// `importMap[source][name].canonicalImport` 가 emotion 의 css source 를 가리키는
+    /// 가장 흔한 케이스를 커버.
+    emotion_extra_css_sources: []const []const u8 = &.{},
+    /// emotion.importMap 의 vendored re-export 케이스 단순화 — `@emotion/styled` 의
+    /// default import (styled) 를 re-export 하는 사용자 패키지. babel-plugin-emotion
+    /// 의 `importMap[source].default.canonicalImport == ["@emotion/styled","default"]`
+    /// 케이스 동등.
+    emotion_extra_styled_sources: []const []const u8 = &.{},
     /// useDefineForClassFields=false: instance field를 constructor의 this.x = value 할당으로 변환.
     /// true(기본값)이면 class field를 그대로 유지 (TC39 [[Define]] semantics).
     /// false이면 TS 4.x 이전 동작 — field를 constructor body로 이동 ([[Set]] semantics).

--- a/src/transformer/transformer/emotion.zig
+++ b/src/transformer/transformer/emotion.zig
@@ -45,6 +45,8 @@ const plugin_state = @import("../plugin_state.zig");
 const sourcemap_mod = @import("../../codegen/sourcemap.zig");
 
 /// emotion `css` / `keyframes` named import 가 export 되는 source 들.
+/// JS 측 `EMOTION_CSS_CANONICAL_SOURCES` (`packages/core/index.ts`) 와 동기화 — babel
+/// importMap 의 `canonicalImport[0]` 분류에 사용.
 pub const EMOTION_CSS_SOURCES: []const []const u8 = &.{
     "@emotion/react",
     "@emotion/css",
@@ -75,6 +77,17 @@ pub fn isEmotionCssSource(source: []const u8) bool {
 
 pub fn isEmotionStyledSource(source: []const u8) bool {
     return isInList(source, EMOTION_STYLED_SOURCES);
+}
+
+/// 사용자 옵션 (`emotion.extraCssSources`) 에 등록된 vendored re-export 패키지 매칭.
+fn isEmotionCssSourceWithExtras(self: *const Transformer, source: []const u8) bool {
+    if (isEmotionCssSource(source)) return true;
+    return isInList(source, self.options.emotion_extra_css_sources);
+}
+
+fn isEmotionStyledSourceWithExtras(self: *const Transformer, source: []const u8) bool {
+    if (isEmotionStyledSource(source)) return true;
+    return isInList(source, self.options.emotion_extra_styled_sources);
 }
 
 /// emotion named-import (`{ X }` 형태) 별 EmotionState 필드 매핑. 새 named API 가
@@ -111,8 +124,8 @@ pub fn detectEmotionImport(self: *Transformer, node: Node) Error!void {
     if (source_node.tag != .string_literal) return;
     const source_text = import_scanner.stripQuotes(self.ast.getText(source_node.span)) orelse return;
 
-    const want_css_or_keyframes = isEmotionCssSource(source_text);
-    const want_styled = isEmotionStyledSource(source_text) and self.plugins.emotion.styled_binding == null;
+    const want_css_or_keyframes = isEmotionCssSourceWithExtras(self, source_text);
+    const want_styled = isEmotionStyledSourceWithExtras(self, source_text) and self.plugins.emotion.styled_binding == null;
     if (!want_css_or_keyframes and !want_styled) return;
 
     var i: u32 = 0;


### PR DESCRIPTION
## Summary
- babel-plugin-emotion 의 `importMap` 옵션 (vendored re-export 케이스) 을 ZTS 의 단순화된 `extraCssSources`/`extraStyledSources` 로 collapse
- `canonicalImport[0]` 가 `@emotion/styled` (default export) → styled 분류, `@emotion/{react,css,core,native,primitives,primitives-core}` → css 분류
- alias-by-alias 라우팅 미지원 (babel parity 와 동일한 단순화)

## 변경
- `src/transformer/transformer/emotion.zig` — `isEmotionCssSourceWithExtras` / `isEmotionStyledSourceWithExtras` 추가, `detectEmotionImport` 에서 사용
- 8-layer plumbing: `TransformOptions` → `BundleOptions` → `Graph` → `AppBuildOptions` → `napi_entry.zig` 2 사이트 → `packages/core/index.ts`
- `napi_entry.zig` ownership 추적 (`owned_strings` + `owned_arrays`) — leak 방지
- `packages/core/index.ts` — `collectEmotionImportMapExtras(importMap)` 헬퍼, 모듈 scope `EMOTION_CSS_CANONICAL_SOURCES` set (Zig 측 `EMOTION_CSS_SOURCES` 와 sync 마커 추가)
- `src/transformer/emotion_test.zig` — 3 회귀 테스트

## Test plan
- [x] `zig build test` Debug
- [x] `zig build test -Doptimize=ReleaseFast`
- [x] `extraCssSources 로 vendored re-export 인식` 통과
- [x] `extraStyledSources 로 vendored styled fork 인식` 통과
- [x] `extraCssSources 미등록 source 는 여전히 미감지` 통과
- [x] /simplify — 메모리 leak (NAPI ownership 추적 누락) + JS Set 매 호출 재생성 fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)