### PR TITLE
feat(transformer): styled-components meaninglessFileNames 옵션

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -330,6 +330,11 @@ export interface StyledComponentsOptions {
   pure?: boolean;
   /** displayName / componentId 의 namespace prefix — 다중 styled 인스턴스 격리 */
   namespace?: string;
+  /**
+   * basename 이 의미 없을 때 displayName prefix 를 parent dir 로 fallback 시키는 list
+   * (default: `["index"]`). babel-plugin-styled-components 의 동일 옵션과 동등.
+   */
+  meaninglessFileNames?: string[];
   /** [meta] 표시 (default: false) */
   meta?: boolean;
 }
@@ -1251,6 +1256,9 @@ function prepareNapiOptions(options: BuildOptions): Record<string, unknown> {
       if (typeof sc.namespace === "string" && sc.namespace.length > 0) {
         napiOptions.styledComponentsNamespace = sc.namespace;
       }
+      if (Array.isArray(sc.meaninglessFileNames)) {
+        napiOptions.styledComponentsMeaninglessFileNames = sc.meaninglessFileNames;
+      }
     }
   }
   const em = options.compiler?.emotion;
@@ -1486,6 +1494,9 @@ function buildCompilerNapiFields(compiler: AppBuildOptions["compiler"]): Record<
     if (sc.pure === true) out.styledComponentsPure = true;
     if (typeof sc.namespace === "string" && sc.namespace.length > 0) {
       out.styledComponentsNamespace = sc.namespace;
+    }
+    if (Array.isArray(sc.meaninglessFileNames)) {
+      out.styledComponentsMeaninglessFileNames = sc.meaninglessFileNames;
     }
   }
 

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -583,6 +583,11 @@ fn napiBuildAppSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.
         for (arr) |s| owned_strings.append(native_alloc, s) catch return throwError(env, "OutOfMemory");
         owned_arrays.append(native_alloc, arr) catch return throwError(env, "OutOfMemory");
     }
+    const sc_meaningless = getObjectStringArray(env, opts_obj, "styledComponentsMeaninglessFileNames", native_alloc);
+    if (sc_meaningless) |arr| {
+        for (arr) |s| owned_strings.append(native_alloc, s) catch return throwError(env, "OutOfMemory");
+        owned_arrays.append(native_alloc, arr) catch return throwError(env, "OutOfMemory");
+    }
 
     const output_count = @import("zts_lib").app.build.buildApp(native_alloc, .{
         .root = root,
@@ -603,6 +608,7 @@ fn napiBuildAppSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.
         .styled_components_file_name = getObjectBool(env, opts_obj, "styledComponentsFileName", true),
         .styled_components_pure = getObjectBool(env, opts_obj, "styledComponentsPure", false),
         .styled_components_namespace = getObjectString(env, opts_obj, "styledComponentsNamespace", native_alloc) orelse "",
+        .styled_components_meaningless_file_names = sc_meaningless orelse &.{"index"},
         .emotion = getObjectBool(env, opts_obj, "emotion", false),
         .emotion_auto_label = getAutoLabelMode(env, opts_obj, native_alloc),
         .emotion_source_map = getObjectBool(env, opts_obj, "emotionSourceMap", false),
@@ -3514,6 +3520,13 @@ fn parseBuildOptions(
         if (!trackArr(owned_string_arrays, arr)) return null;
     }
 
+    // styledComponentsMeaninglessFileNames: string[]
+    const sc_meaningless = getObjectStringArray(env, opts_obj, "styledComponentsMeaninglessFileNames", native_alloc);
+    if (sc_meaningless) |arr| {
+        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
+        if (!trackArr(owned_string_arrays, arr)) return null;
+    }
+
     // pure: string[]
     const pure = getObjectStringArray(env, opts_obj, "pure", native_alloc);
     if (pure) |arr| {
@@ -3629,6 +3642,7 @@ fn parseBuildOptions(
         .styled_components_file_name = getObjectBool(env, opts_obj, "styledComponentsFileName", true),
         .styled_components_pure = getObjectBool(env, opts_obj, "styledComponentsPure", false),
         .styled_components_namespace = getObjectString(env, opts_obj, "styledComponentsNamespace", native_alloc) orelse "",
+        .styled_components_meaningless_file_names = sc_meaningless orelse &.{"index"},
         .emotion = getObjectBool(env, opts_obj, "emotion", false),
         .emotion_auto_label = getAutoLabelMode(env, opts_obj, native_alloc),
         .emotion_source_map = getObjectBool(env, opts_obj, "emotionSourceMap", false),

--- a/src/app/build.zig
+++ b/src/app/build.zig
@@ -32,6 +32,8 @@ pub const AppBuildOptions = struct {
     styled_components_pure: bool = false,
     /// styled-components.namespace 옵션 — componentId 에 `<namespace>__` prefix.
     styled_components_namespace: []const u8 = "",
+    /// styled-components.meaninglessFileNames 옵션 — basename fallback list (default `["index"]`).
+    styled_components_meaningless_file_names: []const []const u8 = &.{"index"},
     /// emotion 1st-party transform (compiler.emotion).
     emotion: bool = false,
     /// emotion.autoLabel 모드 — `.never` / `.always` (default) / `.dev_only`.
@@ -141,6 +143,7 @@ pub fn buildApp(allocator: std.mem.Allocator, opts: AppBuildOptions) !usize {
         .styled_components_file_name = opts.styled_components_file_name,
         .styled_components_pure = opts.styled_components_pure,
         .styled_components_namespace = opts.styled_components_namespace,
+        .styled_components_meaningless_file_names = opts.styled_components_meaningless_file_names,
         .emotion = opts.emotion,
         .emotion_auto_label = opts.emotion_auto_label,
         .emotion_source_map = opts.emotion_source_map,

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -136,6 +136,8 @@ pub const BundleOptions = struct {
     styled_components_pure: bool = false,
     /// styled-components.namespace 옵션 — componentId 에 `<namespace>__` prefix.
     styled_components_namespace: []const u8 = "",
+    /// styled-components.meaninglessFileNames 옵션 — displayName fallback basename list.
+    styled_components_meaningless_file_names: []const []const u8 = &.{"index"},
     /// emotion 1st-party transform (compiler.emotion). 활성 시 css 템플릿에 autoLabel 적용.
     emotion: bool = false,
     /// emotion.autoLabel 모드 — `.never` / `.always` (default) / `.dev_only`.
@@ -656,6 +658,7 @@ pub const Bundler = struct {
         worker_graph.styled_components_file_name = self.options.styled_components_file_name;
         worker_graph.styled_components_pure = self.options.styled_components_pure;
         worker_graph.styled_components_namespace = self.options.styled_components_namespace;
+        worker_graph.styled_components_meaningless_file_names = self.options.styled_components_meaningless_file_names;
         worker_graph.emotion = self.options.emotion;
         worker_graph.emotion_auto_label = self.options.emotion_auto_label;
         worker_graph.emotion_source_map = self.options.emotion_source_map;
@@ -826,6 +829,7 @@ pub const Bundler = struct {
         graph.styled_components_file_name = self.options.styled_components_file_name;
         graph.styled_components_pure = self.options.styled_components_pure;
         graph.styled_components_namespace = self.options.styled_components_namespace;
+        graph.styled_components_meaningless_file_names = self.options.styled_components_meaningless_file_names;
         graph.emotion = self.options.emotion;
         graph.emotion_auto_label = self.options.emotion_auto_label;
         graph.emotion_source_map = self.options.emotion_source_map;

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -150,6 +150,8 @@ pub const ModuleGraph = struct {
     styled_components_pure: bool = false,
     /// styled-components.namespace 옵션 — componentId 에 `<namespace>__` prefix.
     styled_components_namespace: []const u8 = "",
+    /// styled-components.meaninglessFileNames 옵션 — displayName fallback basename list.
+    styled_components_meaningless_file_names: []const []const u8 = &.{"index"},
     /// emotion 1st-party transform (compiler.emotion).
     emotion: bool = false,
     /// emotion.autoLabel 모드 — `.never` / `.always` (default) / `.dev_only`.
@@ -1744,6 +1746,7 @@ pub const ModuleGraph = struct {
         opts.styled_components_file_name = self.styled_components_file_name;
         opts.styled_components_pure = self.styled_components_pure;
         opts.styled_components_namespace = self.styled_components_namespace;
+        opts.styled_components_meaningless_file_names = self.styled_components_meaningless_file_names;
         opts.emotion = self.emotion and is_user_code;
         opts.emotion_auto_label = self.emotion_auto_label;
         opts.emotion_source_map = self.emotion_source_map;

--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -1223,6 +1223,44 @@ test "styled (fileName): false 옵션 — prefix 없이 var 만" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "Button__") == null);
 }
 
+test "styled (meaninglessFileNames): 사용자 list 의 basename 도 fallback" {
+    // 사용자 옵션으로 `styles` 도 의미 없는 basename 으로 등록 — parent dir 로 fallback.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Inner = styled.div`color: red;`;
+    ,
+        .{
+            .styled_components = true,
+            .styled_components_meaningless_file_names = &.{ "index", "styles" },
+            .jsx_filename = "src/Button/styles.tsx",
+        },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "displayName: \"Button__Inner\"") != null);
+}
+
+test "styled (meaninglessFileNames): 빈 list 면 `index` fallback 도 비활성" {
+    // 빈 array 로 override 하면 babel 기본 `index` fallback 도 안 적용 — 그대로 `index__Inner`.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Inner = styled.div`color: red;`;
+    ,
+        .{
+            .styled_components = true,
+            .styled_components_meaningless_file_names = &.{},
+            .jsx_filename = "src/Button/index.tsx",
+        },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "displayName: \"index__Inner\"") != null);
+}
+
 test "styled (fileName): jsx_filename 빈 문자열 — prefix 안 붙음" {
     var r = try e2eFull(
         std.testing.allocator,

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -145,6 +145,10 @@ pub const TransformOptions = struct {
     /// `<namespace>__sc-<hash>-<counter>`. monorepo / library 환경에서 같은 styled-components
     /// 가 다른 의존성 트리에 들어가도 componentId 충돌 회피. babel-plugin 동일 동작.
     styled_components_namespace: []const u8 = "",
+    /// styled-components.meaninglessFileNames 옵션 — `<basename>__<var>` displayName 의
+    /// basename 이 의미 없는 이름 (default `index`) 이면 parent dir 명으로 fallback.
+    /// babel-plugin-styled-components 의 동일 옵션과 동등 — 빈 array 면 fallback 비활성.
+    styled_components_meaningless_file_names: []const []const u8 = &.{"index"},
     /// emotion 1st-party transform (compiler.emotion).
     /// 활성 시 `const X = css\`...\`` 같은 선언에 `label:X;` 자동 prepend (autoLabel).
     /// `import { css } from "@emotion/react"` 의 named binding 추적.

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -1161,7 +1161,7 @@ fn ensureDisplayNameBlock(self: *Transformer) ?[]const u8 {
     const ext = std.fs.path.extension(basename_full);
     const basename_no_ext = basename_full[0 .. basename_full.len - ext.len];
 
-    const block = if (std.mem.eql(u8, basename_no_ext, "index")) blk: {
+    const block = if (isMeaninglessBasename(self, basename_no_ext)) blk: {
         const dir = std.fs.path.dirname(filename) orelse return null;
         break :blk std.fs.path.basename(dir);
     } else basename_no_ext;
@@ -1169,6 +1169,15 @@ fn ensureDisplayNameBlock(self: *Transformer) ?[]const u8 {
     if (block.len == 0) return null;
     state.display_name_block = block;
     return block;
+}
+
+/// `meaninglessFileNames` 옵션의 basename 매칭 — list 에 포함되면 parent dir 로 fallback.
+/// 기본 list 는 `["index"]` (babel parity), 사용자가 빈 array 로 override 하면 비활성.
+fn isMeaninglessBasename(self: *Transformer, basename_no_ext: []const u8) bool {
+    for (self.options.styled_components_meaningless_file_names) |name| {
+        if (std.mem.eql(u8, basename_no_ext, name)) return true;
+    }
+    return false;
 }
 
 /// componentId 의 따옴표 포함 string literal span 빌드. namespace 옵션 활성 시


### PR DESCRIPTION
## Summary
- displayName prefix 의 basename 이 의미 없을 때 parent dir 로 fallback 시키는 list 를 사용자 옵션으로 노출 (babel-plugin-styled-components parity)
- default `["index"]` (기존 동작 유지), 빈 array 면 fallback 비활성
- 기존 hardcoded `index` 매칭을 `isMeaninglessBasename` helper 로 일반화

## 변경
- `src/transformer/transformer/styled_components.zig` — `isMeaninglessBasename(self, basename)` helper, `ensureDisplayNameBlock` 에서 사용
- 8-layer plumbing: `TransformOptions` → `BundleOptions` → `Graph` → `AppBuildOptions` → `napi_entry.zig` 2 사이트 → `packages/core/index.ts`
- `napi_entry.zig` ownership 추적 (`owned_strings` + `owned_arrays`)
- `packages/core/index.ts` — `StyledComponentsOptions.meaninglessFileNames?: string[]`
- `src/transformer/styled_components_test.zig` — 2 회귀 테스트 (extended list / empty list)

## Test plan
- [x] `zig build test` Debug
- [x] `zig build test -Doptimize=ReleaseFast`
- [x] `사용자 list 의 basename 도 fallback` 통과
- [x] `빈 list 면 \`index\` fallback 도 비활성` 통과
- [x] /simplify — 코드 이미 클린, 3 reviewer 의견 검토 후 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)