### PR TITLE
feat(transformer): styled-components topLevelImportPaths 옵션

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -335,6 +335,12 @@ export interface StyledComponentsOptions {
    * (default: `["index"]`). babel-plugin-styled-components 의 동일 옵션과 동등.
    */
   meaninglessFileNames?: string[];
+  /**
+   * vendored fork (e.g. `@my-org/styled`) 도 styled-components 처럼 인식할 import source
+   * 목록. babel-plugin-styled-components 는 picomatch glob 을 받지만 ZTS 는 fixed string
+   * equality 로 단순화 — 대부분의 실용 케이스 (vendored fork) 커버.
+   */
+  topLevelImportPaths?: string[];
   /** [meta] 표시 (default: false) */
   meta?: boolean;
 }
@@ -1259,6 +1265,9 @@ function prepareNapiOptions(options: BuildOptions): Record<string, unknown> {
       if (Array.isArray(sc.meaninglessFileNames)) {
         napiOptions.styledComponentsMeaninglessFileNames = sc.meaninglessFileNames;
       }
+      if (Array.isArray(sc.topLevelImportPaths)) {
+        napiOptions.styledComponentsTopLevelImportPaths = sc.topLevelImportPaths;
+      }
     }
   }
   const em = options.compiler?.emotion;
@@ -1497,6 +1506,9 @@ function buildCompilerNapiFields(compiler: AppBuildOptions["compiler"]): Record<
     }
     if (Array.isArray(sc.meaninglessFileNames)) {
       out.styledComponentsMeaninglessFileNames = sc.meaninglessFileNames;
+    }
+    if (Array.isArray(sc.topLevelImportPaths)) {
+      out.styledComponentsTopLevelImportPaths = sc.topLevelImportPaths;
     }
   }
 

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -588,6 +588,11 @@ fn napiBuildAppSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.
         for (arr) |s| owned_strings.append(native_alloc, s) catch return throwError(env, "OutOfMemory");
         owned_arrays.append(native_alloc, arr) catch return throwError(env, "OutOfMemory");
     }
+    const sc_top_level = getObjectStringArray(env, opts_obj, "styledComponentsTopLevelImportPaths", native_alloc);
+    if (sc_top_level) |arr| {
+        for (arr) |s| owned_strings.append(native_alloc, s) catch return throwError(env, "OutOfMemory");
+        owned_arrays.append(native_alloc, arr) catch return throwError(env, "OutOfMemory");
+    }
 
     const output_count = @import("zts_lib").app.build.buildApp(native_alloc, .{
         .root = root,
@@ -609,6 +614,7 @@ fn napiBuildAppSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.
         .styled_components_pure = getObjectBool(env, opts_obj, "styledComponentsPure", false),
         .styled_components_namespace = getObjectString(env, opts_obj, "styledComponentsNamespace", native_alloc) orelse "",
         .styled_components_meaningless_file_names = sc_meaningless orelse &.{"index"},
+        .styled_components_top_level_import_paths = sc_top_level orelse &.{},
         .emotion = getObjectBool(env, opts_obj, "emotion", false),
         .emotion_auto_label = getAutoLabelMode(env, opts_obj, native_alloc),
         .emotion_source_map = getObjectBool(env, opts_obj, "emotionSourceMap", false),
@@ -3527,6 +3533,13 @@ fn parseBuildOptions(
         if (!trackArr(owned_string_arrays, arr)) return null;
     }
 
+    // styledComponentsTopLevelImportPaths: string[]
+    const sc_top_level = getObjectStringArray(env, opts_obj, "styledComponentsTopLevelImportPaths", native_alloc);
+    if (sc_top_level) |arr| {
+        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
+        if (!trackArr(owned_string_arrays, arr)) return null;
+    }
+
     // pure: string[]
     const pure = getObjectStringArray(env, opts_obj, "pure", native_alloc);
     if (pure) |arr| {
@@ -3643,6 +3656,7 @@ fn parseBuildOptions(
         .styled_components_pure = getObjectBool(env, opts_obj, "styledComponentsPure", false),
         .styled_components_namespace = getObjectString(env, opts_obj, "styledComponentsNamespace", native_alloc) orelse "",
         .styled_components_meaningless_file_names = sc_meaningless orelse &.{"index"},
+        .styled_components_top_level_import_paths = sc_top_level orelse &.{},
         .emotion = getObjectBool(env, opts_obj, "emotion", false),
         .emotion_auto_label = getAutoLabelMode(env, opts_obj, native_alloc),
         .emotion_source_map = getObjectBool(env, opts_obj, "emotionSourceMap", false),

--- a/src/app/build.zig
+++ b/src/app/build.zig
@@ -34,6 +34,8 @@ pub const AppBuildOptions = struct {
     styled_components_namespace: []const u8 = "",
     /// styled-components.meaninglessFileNames 옵션 — basename fallback list (default `["index"]`).
     styled_components_meaningless_file_names: []const []const u8 = &.{"index"},
+    /// styled-components.topLevelImportPaths 옵션 — vendored fork import source list.
+    styled_components_top_level_import_paths: []const []const u8 = &.{},
     /// emotion 1st-party transform (compiler.emotion).
     emotion: bool = false,
     /// emotion.autoLabel 모드 — `.never` / `.always` (default) / `.dev_only`.
@@ -144,6 +146,7 @@ pub fn buildApp(allocator: std.mem.Allocator, opts: AppBuildOptions) !usize {
         .styled_components_pure = opts.styled_components_pure,
         .styled_components_namespace = opts.styled_components_namespace,
         .styled_components_meaningless_file_names = opts.styled_components_meaningless_file_names,
+        .styled_components_top_level_import_paths = opts.styled_components_top_level_import_paths,
         .emotion = opts.emotion,
         .emotion_auto_label = opts.emotion_auto_label,
         .emotion_source_map = opts.emotion_source_map,

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -138,6 +138,8 @@ pub const BundleOptions = struct {
     styled_components_namespace: []const u8 = "",
     /// styled-components.meaninglessFileNames 옵션 — displayName fallback basename list.
     styled_components_meaningless_file_names: []const []const u8 = &.{"index"},
+    /// styled-components.topLevelImportPaths 옵션 — vendored fork import source list.
+    styled_components_top_level_import_paths: []const []const u8 = &.{},
     /// emotion 1st-party transform (compiler.emotion). 활성 시 css 템플릿에 autoLabel 적용.
     emotion: bool = false,
     /// emotion.autoLabel 모드 — `.never` / `.always` (default) / `.dev_only`.
@@ -659,6 +661,7 @@ pub const Bundler = struct {
         worker_graph.styled_components_pure = self.options.styled_components_pure;
         worker_graph.styled_components_namespace = self.options.styled_components_namespace;
         worker_graph.styled_components_meaningless_file_names = self.options.styled_components_meaningless_file_names;
+        worker_graph.styled_components_top_level_import_paths = self.options.styled_components_top_level_import_paths;
         worker_graph.emotion = self.options.emotion;
         worker_graph.emotion_auto_label = self.options.emotion_auto_label;
         worker_graph.emotion_source_map = self.options.emotion_source_map;
@@ -830,6 +833,7 @@ pub const Bundler = struct {
         graph.styled_components_pure = self.options.styled_components_pure;
         graph.styled_components_namespace = self.options.styled_components_namespace;
         graph.styled_components_meaningless_file_names = self.options.styled_components_meaningless_file_names;
+        graph.styled_components_top_level_import_paths = self.options.styled_components_top_level_import_paths;
         graph.emotion = self.options.emotion;
         graph.emotion_auto_label = self.options.emotion_auto_label;
         graph.emotion_source_map = self.options.emotion_source_map;

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -152,6 +152,8 @@ pub const ModuleGraph = struct {
     styled_components_namespace: []const u8 = "",
     /// styled-components.meaninglessFileNames 옵션 — displayName fallback basename list.
     styled_components_meaningless_file_names: []const []const u8 = &.{"index"},
+    /// styled-components.topLevelImportPaths 옵션 — vendored fork import source list.
+    styled_components_top_level_import_paths: []const []const u8 = &.{},
     /// emotion 1st-party transform (compiler.emotion).
     emotion: bool = false,
     /// emotion.autoLabel 모드 — `.never` / `.always` (default) / `.dev_only`.
@@ -1747,6 +1749,7 @@ pub const ModuleGraph = struct {
         opts.styled_components_pure = self.styled_components_pure;
         opts.styled_components_namespace = self.styled_components_namespace;
         opts.styled_components_meaningless_file_names = self.styled_components_meaningless_file_names;
+        opts.styled_components_top_level_import_paths = self.styled_components_top_level_import_paths;
         opts.emotion = self.emotion and is_user_code;
         opts.emotion_auto_label = self.emotion_auto_label;
         opts.emotion_source_map = self.emotion_source_map;

--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -1242,6 +1242,45 @@ test "styled (meaninglessFileNames): 사용자 list 의 basename 도 fallback" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "displayName: \"Button__Inner\"") != null);
 }
 
+test "styled (topLevelImportPaths): vendored fork 도 styled 인식" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "@my-org/styled";
+        \\const Btn = styled.div`color: red;`;
+    ,
+        .{
+            .styled_components = true,
+            .styled_components_top_level_import_paths = &.{"@my-org/styled"},
+            .jsx_filename = "test.tsx",
+        },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // vendored fork 의 default import 도 styled 처럼 wrap → withConfig + displayName
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Btn") != null);
+}
+
+test "styled (topLevelImportPaths): 미등록 source 는 무시 (보호 회귀)" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "@my-org/styled";
+        \\const Btn = styled.div`color: red;`;
+    ,
+        .{
+            .styled_components = true,
+            .styled_components_top_level_import_paths = &.{"@other-org/styled"},
+            .jsx_filename = "test.tsx",
+        },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // 매칭 안 되는 fork 는 그대로 → withConfig 없음
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") == null);
+}
+
 test "styled (meaninglessFileNames): 빈 list 면 `index` fallback 도 비활성" {
     // 빈 array 로 override 하면 babel 기본 `index` fallback 도 안 적용 — 그대로 `index__Inner`.
     var r = try e2eFull(

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -149,6 +149,11 @@ pub const TransformOptions = struct {
     /// basename 이 의미 없는 이름 (default `index`) 이면 parent dir 명으로 fallback.
     /// babel-plugin-styled-components 의 동일 옵션과 동등 — 빈 array 면 fallback 비활성.
     styled_components_meaningless_file_names: []const []const u8 = &.{"index"},
+    /// styled-components.topLevelImportPaths 옵션 — vendored fork (e.g. `@my-org/styled`)
+    /// 도 styled-components import 처럼 인식. babel-plugin-styled-components 는 picomatch
+    /// 패턴을 받지만 ZTS 는 fixed string equality 로 단순화 — 대부분의 실용 케이스 커버,
+    /// glob 필요 시 후속 PR.
+    styled_components_top_level_import_paths: []const []const u8 = &.{},
     /// emotion 1st-party transform (compiler.emotion).
     /// 활성 시 `const X = css\`...\`` 같은 선언에 `label:X;` 자동 prepend (autoLabel).
     /// `import { css } from "@emotion/react"` 의 named binding 추적.

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -65,6 +65,16 @@ pub fn isStyledImportSource(source: []const u8) bool {
     return false;
 }
 
+/// 사용자 옵션 (`styled_components_top_level_import_paths`) 매칭 포함 — vendored fork
+/// 인식. babel-plugin-styled-components 의 `topLevelImportPaths` 단순화 (fixed string).
+fn isStyledImportSourceWithExtras(self: *const Transformer, source: []const u8) bool {
+    if (isStyledImportSource(source)) return true;
+    for (self.options.styled_components_top_level_import_paths) |s| {
+        if (std.mem.eql(u8, s, source)) return true;
+    }
+    return false;
+}
+
 /// styled-components 의 named helper imports — minify 등 transform 에 사용.
 const NamedHelperSpec = struct {
     imported: []const u8,
@@ -94,7 +104,7 @@ pub fn detectStyledImport(self: *Transformer, node: Node) Error!void {
     const source_node = self.ast.getNode(x.source);
     if (source_node.tag != .string_literal) return;
     const source_text = import_scanner.stripQuotes(self.ast.getText(source_node.span)) orelse return;
-    if (!isStyledImportSource(source_text)) return;
+    if (!isStyledImportSourceWithExtras(self, source_text)) return;
 
     var i: u32 = 0;
     while (i < x.specs_len) : (i += 1) {


### PR DESCRIPTION
## Summary
- vendored fork (e.g. `@my-org/styled`) 도 styled-components 처럼 인식하는 옵션 (babel-plugin-styled-components parity)
- babel 의 picomatch glob 대신 fixed string equality 로 단순화 — 대부분 실용 케이스 (vendored fork) 커버. glob 필요 시 후속 PR
- `isStyledImportSourceWithExtras` helper 추가, `detectStyledImport` 에서 사용

## 변경
- `src/transformer/transformer/styled_components.zig` — vendored fork import 인식
- 8-layer plumbing: `TransformOptions` → `BundleOptions` → `Graph` → `AppBuildOptions` → `napi_entry.zig` 2 사이트 → `packages/core/index.ts`
- `napi_entry.zig` ownership 추적 (`owned_strings` + `owned_arrays`)
- `packages/core/index.ts` — `StyledComponentsOptions.topLevelImportPaths?: string[]`
- `src/transformer/styled_components_test.zig` — 2 회귀 테스트 (positive vendored / negative source mismatch)

## Test plan
- [x] `zig build test` Debug
- [x] `zig build test -Doptimize=ReleaseFast`
- [x] `vendored fork 도 styled 인식` 통과
- [x] `미등록 source 는 무시 (보호 회귀)` 통과
- [x] /simplify — 코드 클린, 3 reviewer 모두 변경 없음 (`isInList` 6 사이트 중복은 별도 follow-up PR 권장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)