### PR TITLE
fix(transform): wide downlevel audit regressions 보정

### DIFF
--- a/scripts/syntax-audit.mjs
+++ b/scripts/syntax-audit.mjs
@@ -165,6 +165,21 @@ console.log(JSON.stringify(log));
 `,
   },
   {
+    name: "derived-constructor-return-super-in-object-member",
+    code: `
+const log = [];
+class Base { constructor(v) { log.push("base:" + v); this.v = v; } }
+class Child extends Base {
+  field = log.push("field:" + this.v);
+  constructor() {
+    return ({ x: super(8) }).x;
+  }
+}
+new Child();
+console.log(JSON.stringify(log));
+`,
+  },
+  {
     name: "private-field-brand-and-update",
     code: `
 class Counter {
@@ -230,6 +245,20 @@ class A {
   static read() { return [this.#x, Object.getOwnPropertyNames(this.prototype), Object.keys(this), log]; }
 }
 console.log(JSON.stringify(A.read()));
+`,
+  },
+  {
+    name: "static-optional-super-method-field",
+    code: `
+const log = [];
+class Base {
+  static m(v) { log.push("m:" + v); return v + 1; }
+}
+class A extends Base {
+  static x = super.m?.(1);
+  static { log.push("block:" + this.x); }
+}
+console.log(JSON.stringify([A.x, log]));
 `,
   },
   {
@@ -304,6 +333,22 @@ let picked, rest;
 function k() { log.push("key"); return "b"; }
 ({ [k()]: picked, ...rest } = src);
 console.log(JSON.stringify({ picked, rest, log }));
+`,
+  },
+  {
+    name: "private-optional-chain-still-lowers-private-field",
+    code: `
+class A {
+  #x = 0;
+  get self() { return this; }
+  run() {
+    this.self?.#x;
+    this.#x ||= 2;
+    this.#x &&= 3;
+    return this.#x;
+  }
+}
+console.log(JSON.stringify(new A().run()));
 `,
   },
   {

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -2616,24 +2616,34 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     defer self.scratch.shrinkRetainingCapacity(scratch_top);
                     for (self.ast.extra_data.items[list.start .. list.start + list.len]) |raw_idx| {
                         const prop_idx: NodeIndex = @enumFromInt(raw_idx);
-                        const prop = self.ast.getNode(prop_idx);
-                        if (prop.tag == .object_property) {
-                            try self.scratch.append(self.allocator, try self.ast.addNode(.{
-                                .tag = .object_property,
-                                .span = prop.span,
-                                .data = .{ .binary = .{
-                                    .left = prop.data.binary.left,
-                                    .right = try injectInstanceFieldsAfterSuperExpr(self, prop.data.binary.right, instance_fields, span),
-                                    .flags = prop.data.binary.flags,
-                                } },
-                            }));
-                        } else {
+                        // 부작용 없는 prop 은 그대로 통과 — 매번 복제하면 N props 중 1 개만 super 가 있어도
+                        // 전체 list 가 새로 만들어지는 낭비가 발생.
+                        if (!containsSuperCallAssignment(self, prop_idx)) {
                             try self.scratch.append(self.allocator, prop_idx);
+                            continue;
                         }
+                        try self.scratch.append(self.allocator, try injectInstanceFieldsAfterSuperExpr(self, prop_idx, instance_fields, span));
                     }
                     const new_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
                     return self.ast.addNode(.{ .tag = .object_expression, .span = node.span, .data = .{ .list = new_list } });
                 },
+                .object_property => return self.ast.addNode(.{
+                    .tag = .object_property,
+                    .span = node.span,
+                    .data = .{ .binary = .{
+                        .left = try injectInstanceFieldsAfterSuperExpr(self, node.data.binary.left, instance_fields, span),
+                        .right = try injectInstanceFieldsAfterSuperExpr(self, node.data.binary.right, instance_fields, span),
+                        .flags = node.data.binary.flags,
+                    } },
+                }),
+                .spread_element, .computed_property_key => return self.ast.addNode(.{
+                    .tag = node.tag,
+                    .span = node.span,
+                    .data = .{ .unary = .{
+                        .operand = try injectInstanceFieldsAfterSuperExpr(self, node.data.unary.operand, instance_fields, span),
+                        .flags = node.data.unary.flags,
+                    } },
+                }),
                 .conditional_expression => return self.ast.addNode(.{
                     .tag = .conditional_expression,
                     .span = node.span,
@@ -2719,10 +2729,18 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 .object_expression => {
                     const list = node.data.list;
                     for (self.ast.extra_data.items[list.start .. list.start + list.len]) |raw_idx| {
-                        const prop = self.ast.getNode(@enumFromInt(raw_idx));
-                        if (prop.tag == .object_property and containsSuperCallAssignment(self, prop.data.binary.right)) return true;
+                        if (containsSuperCallAssignment(self, @enumFromInt(raw_idx))) return true;
                     }
                     return false;
+                },
+                // object_property: key(left) 와 value(right) 둘 다 super-call 을 품을 수 있다
+                // (`{ [super(1)]: 'x' }` 처럼 computed key 안에 들어간 경우 포함).
+                .object_property => {
+                    return containsSuperCallAssignment(self, node.data.binary.left) or
+                        containsSuperCallAssignment(self, node.data.binary.right);
+                },
+                .spread_element, .computed_property_key => {
+                    return containsSuperCallAssignment(self, node.data.unary.operand);
                 },
                 .assignment_expression => {
                     const left = self.ast.getNode(node.data.binary.left);

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -2610,6 +2610,30 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     });
                     return self.ast.addNode(.{ .tag = node.tag, .span = node.span, .data = .{ .extra = new_extra } });
                 },
+                .object_expression => {
+                    const list = node.data.list;
+                    const scratch_top = self.scratch.items.len;
+                    defer self.scratch.shrinkRetainingCapacity(scratch_top);
+                    for (self.ast.extra_data.items[list.start .. list.start + list.len]) |raw_idx| {
+                        const prop_idx: NodeIndex = @enumFromInt(raw_idx);
+                        const prop = self.ast.getNode(prop_idx);
+                        if (prop.tag == .object_property) {
+                            try self.scratch.append(self.allocator, try self.ast.addNode(.{
+                                .tag = .object_property,
+                                .span = prop.span,
+                                .data = .{ .binary = .{
+                                    .left = prop.data.binary.left,
+                                    .right = try injectInstanceFieldsAfterSuperExpr(self, prop.data.binary.right, instance_fields, span),
+                                    .flags = prop.data.binary.flags,
+                                } },
+                            }));
+                        } else {
+                            try self.scratch.append(self.allocator, prop_idx);
+                        }
+                    }
+                    const new_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+                    return self.ast.addNode(.{ .tag = .object_expression, .span = node.span, .data = .{ .list = new_list } });
+                },
                 .conditional_expression => return self.ast.addNode(.{
                     .tag = .conditional_expression,
                     .span = node.span,
@@ -2691,6 +2715,14 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     const e = node.data.extra;
                     return containsSuperCallAssignment(self, @enumFromInt(self.ast.extra_data.items[e])) or
                         containsSuperCallAssignment(self, @enumFromInt(self.ast.extra_data.items[e + 1]));
+                },
+                .object_expression => {
+                    const list = node.data.list;
+                    for (self.ast.extra_data.items[list.start .. list.start + list.len]) |raw_idx| {
+                        const prop = self.ast.getNode(@enumFromInt(raw_idx));
+                        if (prop.tag == .object_property and containsSuperCallAssignment(self, prop.data.binary.right)) return true;
+                    }
+                    return false;
                 },
                 .assignment_expression => {
                     const left = self.ast.getNode(node.data.binary.left);

--- a/src/transformer/es2020.zig
+++ b/src/transformer/es2020.zig
@@ -430,8 +430,10 @@ pub fn ES2020(comptime Transformer: type) type {
             const new_prop = try self.visitNode(old_prop);
             const new_flags = member_flags & ~ast_mod.MemberFlags.optional_chain;
 
-            if (self.options.unsupported.class or self.current_super_is_static) {
-                const super_class_span = self.current_super_class orelse return makeRawSuperMember(self, member_tag, new_prop, new_flags, span);
+            if (self.needsSuperLowering()) {
+                const super_class_span = self.current_super_class.?;
+                // static method super → bare class identifier (`Parent.m()`),
+                // instance super → prototype access (`Parent.prototype.m()`).
                 const super_base = if (self.current_super_is_static)
                     try self.makeIdentifierRefWithSymbol(super_class_span, self.current_super_class_old_idx)
                 else

--- a/src/transformer/es2020.zig
+++ b/src/transformer/es2020.zig
@@ -430,12 +430,15 @@ pub fn ES2020(comptime Transformer: type) type {
             const new_prop = try self.visitNode(old_prop);
             const new_flags = member_flags & ~ast_mod.MemberFlags.optional_chain;
 
-            if (self.options.unsupported.class) {
+            if (self.options.unsupported.class or self.current_super_is_static) {
                 const super_class_span = self.current_super_class orelse return makeRawSuperMember(self, member_tag, new_prop, new_flags, span);
-                const proto = try makePrototypeRef(self, super_class_span, self.current_super_class_old_idx, span);
+                const super_base = if (self.current_super_is_static)
+                    try self.makeIdentifierRefWithSymbol(super_class_span, self.current_super_class_old_idx)
+                else
+                    try makePrototypeRef(self, super_class_span, self.current_super_class_old_idx, span);
                 return switch (member_tag) {
-                    .static_member_expression => helpers.makeStaticMember(self, proto, new_prop, span),
-                    .computed_member_expression => helpers.makeComputedMember(self, proto, new_prop, span),
+                    .static_member_expression => helpers.makeStaticMember(self, super_base, new_prop, span),
+                    .computed_member_expression => helpers.makeComputedMember(self, super_base, new_prop, span),
                     else => unreachable,
                 };
             }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1171,6 +1171,13 @@ pub const Transformer = struct {
                 return self.visitMemberExpression(node);
             },
             .private_field_expression => {
+                if (self.options.unsupported.optional_chaining or
+                    ((self.options.unsupported.class or self.options.unsupported.class_private_field) and self.current_private_fields.len > 0))
+                {
+                    if (es2020.ES2020(Transformer).findOptionalChainBase(self, node)) |base_idx| {
+                        return es2020.ES2020(Transformer).lowerOptionalChain(self, node, base_idx);
+                    }
+                }
                 // ES2022: this.#method → _method_fn.bind(this) (참조만, 호출 아닌 경우)
                 if (self.current_private_methods.len > 0) {
                     if (es2022.ES2022(Transformer).lowerPrivateMethodGet(self, node)) |result| {
@@ -1181,12 +1188,6 @@ pub const Transformer = struct {
                 if ((self.options.unsupported.class or self.options.unsupported.class_private_field) and self.current_private_fields.len > 0) {
                     if (es2015_class.ES2015Class(Transformer).lowerPrivateFieldGet(self, node)) |result| {
                         return result;
-                    }
-                }
-                // ES 다운레벨링: ?. → ternary (target < es2020)
-                if (self.options.unsupported.optional_chaining) {
-                    if (es2020.ES2020(Transformer).findOptionalChainBase(self, node)) |base_idx| {
-                        return es2020.ES2020(Transformer).lowerOptionalChain(self, node, base_idx);
                     }
                 }
                 return self.visitMemberExpression(node);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -586,6 +586,13 @@ pub const Transformer = struct {
         return (self.options.unsupported.class or self.current_super_is_static) and self.current_super_class != null;
     }
 
+    /// 현재 scope 의 private field 가 `WeakMap.get/set` lowering 대상인지 판정.
+    /// `class` / `class_private_field` 옵션 둘 중 하나라도 켜져 있고, 현재 visit 중인
+    /// class 가 private field 를 갖고 있을 때 true.
+    pub inline fn hasActivePrivateFieldLowering(self: *const Transformer) bool {
+        return (self.options.unsupported.class or self.options.unsupported.class_private_field) and self.current_private_fields.len > 0;
+    }
+
     pub fn init(allocator: std.mem.Allocator, source_ast: *const Ast, options: TransformOptions) Error!Transformer {
         var opts = options;
         if (opts.experimental_decorators) opts.use_define_for_class_fields = false;
@@ -1087,7 +1094,7 @@ pub const Transformer = struct {
                 // lowerPrivateFieldSet 단일 경로에서 처리 — es2021/es2016 등은 좌변에
                 // `(a = b)` 패턴을 만들어 get()/helper call에 대입하게 되므로 먼저 가로챈다.
                 // (esbuild의 lowerAssign이나 SWC/Babel plugin 순서와 동일한 선점 패턴.)
-                if ((self.options.unsupported.class or self.options.unsupported.class_private_field) and self.current_private_fields.len > 0) {
+                if (self.hasActivePrivateFieldLowering()) {
                     const left_idx = node.data.binary.left;
                     if (!left_idx.isNone()) {
                         const left_node = self.ast.getNode(left_idx);
@@ -1171,9 +1178,12 @@ pub const Transformer = struct {
                 return self.visitMemberExpression(node);
             },
             .private_field_expression => {
-                if (self.options.unsupported.optional_chaining or
-                    ((self.options.unsupported.class or self.options.unsupported.class_private_field) and self.current_private_fields.len > 0))
-                {
+                // 순서 중요: `?.` 를 먼저 ternary 로 풀어야 한다. 아래의 lowerPrivateMethodGet /
+                // lowerPrivateFieldGet 이 만든 `_x.get(this)` 호출이 `?.` short-circuit 안에 들어가면
+                // base 가 null/undefined 일 때도 evaluate 되어 spec 위반이다.
+                // class_private_field 가 lowering 대상이면 target 이 ES2020+ 라도 chain 자체를
+                // 미리 풀어야 같은 회피가 가능 — `unsupported.optional_chaining` 만으로는 부족.
+                if (self.options.unsupported.optional_chaining or self.hasActivePrivateFieldLowering()) {
                     if (es2020.ES2020(Transformer).findOptionalChainBase(self, node)) |base_idx| {
                         return es2020.ES2020(Transformer).lowerOptionalChain(self, node, base_idx);
                     }
@@ -1185,7 +1195,7 @@ pub const Transformer = struct {
                     }
                 }
                 // ES2015/ES2022: this.#x → _x.get(this)
-                if ((self.options.unsupported.class or self.options.unsupported.class_private_field) and self.current_private_fields.len > 0) {
+                if (self.hasActivePrivateFieldLowering()) {
                     if (es2015_class.ES2015Class(Transformer).lowerPrivateFieldGet(self, node)) |result| {
                         return result;
                     }


### PR DESCRIPTION
## 요약
- 메인 기준 wide downlevel audit에서 추가로 발견된 3개 변환 회귀를 루트 경로에서 수정했습니다.
- derived constructor의 object literal 내부 `super()` 반환 경로에도 instance field init을 주입합니다.
- static field initializer의 `super.m?.()`가 target별로 올바른 static super receiver를 쓰도록 보정했습니다.
- private field lowering이 필요한 target에서 `this.self?.#x` optional chain도 함께 낮추도록 수정했습니다.
- 재발 방지를 위해 `scripts/syntax-audit.mjs`에 실제 실패 케이스 3개를 추가했습니다.

## 검증
- `zig build -Doptimize=ReleaseFast`
- `node scripts/syntax-audit.mjs`
- `cd tests/integration && bun test tests/downlevel-edge.test.ts --timeout 600000`
- `zig build test --summary all`
- `zig fmt --check src/transformer/es2015_class.zig src/transformer/es2020.zig src/transformer/transformer.zig`
- `bunx oxlint scripts/syntax-audit.mjs`
- `bunx oxfmt --check scripts/syntax-audit.mjs`

## 메모
- push 시 pre-push 훅도 통과했습니다. 기존 unused import warning 5개는 warning-only로 남아 있습니다.