### PR TITLE
chore(util): isInList shared util 추출

### DIFF
--- a/src/transformer/transformer/emotion.zig
+++ b/src/transformer/transformer/emotion.zig
@@ -43,6 +43,7 @@ const Transformer = transformer_mod.Transformer;
 const Error = Transformer.Error;
 const plugin_state = @import("../plugin_state.zig");
 const sourcemap_mod = @import("../../codegen/sourcemap.zig");
+const string_list = @import("../../util/string_list.zig");
 
 /// emotion `css` / `keyframes` named import 가 export 되는 source 들.
 /// JS 측 `EMOTION_CSS_CANONICAL_SOURCES` (`packages/core/index.ts`) 와 동기화 — babel
@@ -64,30 +65,23 @@ pub const EMOTION_STYLED_SOURCES: []const []const u8 = &.{
     "@emotion/styled-base", // 저레벨 패키지 — 일부 사용자 직접 import
 };
 
-fn isInList(source: []const u8, list: []const []const u8) bool {
-    for (list) |s| {
-        if (std.mem.eql(u8, s, source)) return true;
-    }
-    return false;
-}
-
 pub fn isEmotionCssSource(source: []const u8) bool {
-    return isInList(source, EMOTION_CSS_SOURCES);
+    return string_list.contains(EMOTION_CSS_SOURCES, source);
 }
 
 pub fn isEmotionStyledSource(source: []const u8) bool {
-    return isInList(source, EMOTION_STYLED_SOURCES);
+    return string_list.contains(EMOTION_STYLED_SOURCES, source);
 }
 
 /// 사용자 옵션 (`emotion.extraCssSources`) 에 등록된 vendored re-export 패키지 매칭.
 fn isEmotionCssSourceWithExtras(self: *const Transformer, source: []const u8) bool {
     if (isEmotionCssSource(source)) return true;
-    return isInList(source, self.options.emotion_extra_css_sources);
+    return string_list.contains(self.options.emotion_extra_css_sources, source);
 }
 
 fn isEmotionStyledSourceWithExtras(self: *const Transformer, source: []const u8) bool {
     if (isEmotionStyledSource(source)) return true;
-    return isInList(source, self.options.emotion_extra_styled_sources);
+    return string_list.contains(self.options.emotion_extra_styled_sources, source);
 }
 
 /// emotion named-import (`{ X }` 형태) 별 EmotionState 필드 매핑. 새 named API 가

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -48,6 +48,7 @@ const module_parser = @import("../../parser/module.zig");
 const import_scanner = @import("../../bundler/import_scanner.zig");
 const stmt_info = @import("../../bundler/stmt_info.zig");
 const wyhash = @import("../../util/wyhash.zig");
+const string_list = @import("../../util/string_list.zig");
 const transformer_mod = @import("../transformer.zig");
 const Transformer = transformer_mod.Transformer;
 const Error = Transformer.Error;
@@ -59,20 +60,14 @@ pub const STYLED_SOURCES: []const []const u8 = &.{
 };
 
 pub fn isStyledImportSource(source: []const u8) bool {
-    for (STYLED_SOURCES) |s| {
-        if (std.mem.eql(u8, s, source)) return true;
-    }
-    return false;
+    return string_list.contains(STYLED_SOURCES, source);
 }
 
 /// 사용자 옵션 (`styled_components_top_level_import_paths`) 매칭 포함 — vendored fork
 /// 인식. babel-plugin-styled-components 의 `topLevelImportPaths` 단순화 (fixed string).
 fn isStyledImportSourceWithExtras(self: *const Transformer, source: []const u8) bool {
     if (isStyledImportSource(source)) return true;
-    for (self.options.styled_components_top_level_import_paths) |s| {
-        if (std.mem.eql(u8, s, source)) return true;
-    }
-    return false;
+    return string_list.contains(self.options.styled_components_top_level_import_paths, source);
 }
 
 /// styled-components 의 named helper imports — minify 등 transform 에 사용.
@@ -1184,10 +1179,7 @@ fn ensureDisplayNameBlock(self: *Transformer) ?[]const u8 {
 /// `meaninglessFileNames` 옵션의 basename 매칭 — list 에 포함되면 parent dir 로 fallback.
 /// 기본 list 는 `["index"]` (babel parity), 사용자가 빈 array 로 override 하면 비활성.
 fn isMeaninglessBasename(self: *Transformer, basename_no_ext: []const u8) bool {
-    for (self.options.styled_components_meaningless_file_names) |name| {
-        if (std.mem.eql(u8, basename_no_ext, name)) return true;
-    }
-    return false;
+    return string_list.contains(self.options.styled_components_meaningless_file_names, basename_no_ext);
 }
 
 /// componentId 의 따옴표 포함 string literal span 빌드. namespace 옵션 활성 시

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -22,6 +22,7 @@ const Span = token_mod.Span;
 const transformer_mod = @import("../transformer.zig");
 const Transformer = transformer_mod.Transformer;
 const Error = Transformer.Error;
+const string_list = @import("../../util/string_list.zig");
 
 /// Closure 변수 정보. name + 원본 identifier_reference NodeIndex (scope hoisting rename용).
 pub const ClosureVar = struct {
@@ -191,14 +192,7 @@ pub fn collectClosureVars(
         if (locals.contains(name)) continue;
         if (isGlobal(name)) continue;
         // 사용자 설정 globals (옵션)도 closure에서 제외
-        var is_user_global = false;
-        for (self.options.worklet_globals) |g| {
-            if (std.mem.eql(u8, g, name)) {
-                is_user_global = true;
-                break;
-            }
-        }
-        if (is_user_global) continue;
+        if (string_list.contains(self.options.worklet_globals, name)) continue;
         const duped = self.allocator.dupe(u8, name) catch return error.OutOfMemory;
         try result.append(self.allocator, .{ .name = duped, .ref_idx = entry.value_ptr.* });
     }
@@ -209,14 +203,7 @@ pub fn collectClosureVars(
         const base_name = entry.key_ptr.*;
         if (locals.contains(base_name)) continue;
         if (isGlobal(base_name)) continue;
-        var is_user_global = false;
-        for (self.options.worklet_globals) |g| {
-            if (std.mem.eql(u8, g, base_name)) {
-                is_user_global = true;
-                break;
-            }
-        }
-        if (is_user_global) continue;
+        if (string_list.contains(self.options.worklet_globals, base_name)) continue;
         const base_duped = self.allocator.dupe(u8, base_name) catch return error.OutOfMemory;
         // factory key: "<BaseClass>__classFactory"
         const factory_name = std.fmt.allocPrint(self.allocator, "{s}__classFactory", .{base_name}) catch return error.OutOfMemory;

--- a/src/util/mod.zig
+++ b/src/util/mod.zig
@@ -1,3 +1,4 @@
 //! 공용 유틸리티 모음.
 
 pub const wyhash = @import("wyhash.zig");
+pub const string_list = @import("string_list.zig");

--- a/src/util/string_list.zig
+++ b/src/util/string_list.zig
@@ -1,0 +1,12 @@
+//! 문자열 슬라이스 리스트 헬퍼 — 다중 plugin (emotion/styled-components/worklet) 에서
+//! 공유. 짧은 list (1-N items) 의 linear 매칭에 최적.
+
+const std = @import("std");
+
+/// `needle` 이 `list` 에 정확히 등장하는지 (`std.mem.eql` equality).
+pub fn contains(list: []const []const u8, needle: []const u8) bool {
+    for (list) |s| {
+        if (std.mem.eql(u8, s, needle)) return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary
- emotion / styled-components / worklet 3 plugin 의 6 사이트에서 반복되던 linear scan + equality 체크 패턴을 shared util `string_list.contains(list, needle)` 으로 통일
- 코드 라인 -14 (39 → 25)

## 배경
Round 3 simplify 에서 발견 — 같은 4-line 패턴이 다음 사이트에 카피:
- `emotion.zig` — file-private `isInList` (4 호출)
- `styled_components.zig` — `isStyledImportSource` (2개), `isMeaninglessBasename` 인라인 loop
- `worklet.zig` — `collectClosureVars` 의 `worklet_globals` 매칭 2 사이트 (`is_user_global` flag pattern)

## 변경
- `src/util/string_list.zig` — `pub fn contains(list, needle) bool`
- 6 사이트 모두 `string_list.contains(...)` 호출로 단순화

## Test plan
- [x] `zig build test` Debug
- [x] `zig build test -Doptimize=ReleaseFast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)