### PR TITLE
feat(transformer): styled topLevelImportPaths 단일 `*` glob 지원

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -336,9 +336,9 @@ export interface StyledComponentsOptions {
    */
   meaninglessFileNames?: string[];
   /**
-   * vendored fork (e.g. `@my-org/styled`) 도 styled-components 처럼 인식할 import source
-   * 목록. babel-plugin-styled-components 는 picomatch glob 을 받지만 ZTS 는 fixed string
-   * equality 로 단순화 — 대부분의 실용 케이스 (vendored fork) 커버.
+   * vendored fork (e.g. `@my-org/styled`, `@my-org/*`) 도 styled-components 처럼 인식할
+   * import source 목록. 단일 `*` glob 지원 — picomatch 풀 스펙 (multi `*`, `?`, `[]`,
+   * brace expansion) 은 미지원.
    */
   topLevelImportPaths?: string[];
   /**

--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -1262,6 +1262,42 @@ test "styled (topLevelImportPaths): vendored fork 도 styled 인식" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "Btn") != null);
 }
 
+test "styled (topLevelImportPaths): glob `@my-org/*` 도 vendored fork 매칭" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "@my-org/styled-fork";
+        \\const Btn = styled.div`color: red;`;
+    ,
+        .{
+            .styled_components = true,
+            .styled_components_top_level_import_paths = &.{"@my-org/*"},
+            .jsx_filename = "test.tsx",
+        },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") != null);
+}
+
+test "styled (topLevelImportPaths): glob 미매칭 fork 는 무시" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "@other-org/styled";
+        \\const Btn = styled.div`color: red;`;
+    ,
+        .{
+            .styled_components = true,
+            .styled_components_top_level_import_paths = &.{"@my-org/*"},
+            .jsx_filename = "test.tsx",
+        },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") == null);
+}
+
 test "styled (topLevelImportPaths): 미등록 source 는 무시 (보호 회귀)" {
     var r = try e2eFull(
         std.testing.allocator,

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -149,10 +149,9 @@ pub const TransformOptions = struct {
     /// basename 이 의미 없는 이름 (default `index`) 이면 parent dir 명으로 fallback.
     /// babel-plugin-styled-components 의 동일 옵션과 동등 — 빈 array 면 fallback 비활성.
     styled_components_meaningless_file_names: []const []const u8 = &.{"index"},
-    /// styled-components.topLevelImportPaths 옵션 — vendored fork (e.g. `@my-org/styled`)
-    /// 도 styled-components import 처럼 인식. babel-plugin-styled-components 는 picomatch
-    /// 패턴을 받지만 ZTS 는 fixed string equality 로 단순화 — 대부분의 실용 케이스 커버,
-    /// glob 필요 시 후속 PR.
+    /// styled-components.topLevelImportPaths 옵션 — vendored fork (e.g. `@my-org/styled`,
+    /// `@my-org/*`) 도 styled-components import 처럼 인식. 단일 `*` glob 지원 — picomatch
+    /// 풀 스펙 (multi `*`, `?`, `[]`, brace expansion) 은 미지원.
     styled_components_top_level_import_paths: []const []const u8 = &.{},
     /// styled-components.cssProp 옵션 — `<div css={...}>` JSX prop 을 module-level
     /// hoisted styled component 로 추출. babel-plugin-styled-components default true 와

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -64,10 +64,11 @@ pub fn isStyledImportSource(source: []const u8) bool {
 }
 
 /// 사용자 옵션 (`styled_components_top_level_import_paths`) 매칭 포함 — vendored fork
-/// 인식. babel-plugin-styled-components 의 `topLevelImportPaths` 단순화 (fixed string).
+/// 인식. babel-plugin-styled-components 의 `topLevelImportPaths` 와 동등 — 단일 `*`
+/// glob 지원 (e.g. `@my-org/*`). picomatch 풀 스펙은 미지원.
 fn isStyledImportSourceWithExtras(self: *const Transformer, source: []const u8) bool {
     if (isStyledImportSource(source)) return true;
-    return string_list.contains(self.options.styled_components_top_level_import_paths, source);
+    return string_list.anyGlobMatch(self.options.styled_components_top_level_import_paths, source);
 }
 
 /// styled-components 의 named helper imports — minify 등 transform 에 사용.

--- a/src/util/string_list.zig
+++ b/src/util/string_list.zig
@@ -10,3 +10,46 @@ pub fn contains(list: []const []const u8, needle: []const u8) bool {
     }
     return false;
 }
+
+/// 단일 `*` wildcard glob 매칭 — `prefix*suffix` 형태 1 회만 지원. picomatch 풀 스펙
+/// (multi `*`, `?`, `[]`, brace expansion) 까진 안 감 — 대부분의 vendored fork 사용
+/// 케이스 (`@my-org/*`, `*-styled`) 커버. `*` 미포함 시 정확 일치.
+pub fn matchesGlob(pattern: []const u8, source: []const u8) bool {
+    const star_pos = std.mem.indexOfScalar(u8, pattern, '*') orelse {
+        return std.mem.eql(u8, pattern, source);
+    };
+    const prefix = pattern[0..star_pos];
+    const suffix = pattern[star_pos + 1 ..];
+    if (source.len < prefix.len + suffix.len) return false;
+    if (!std.mem.startsWith(u8, source, prefix)) return false;
+    return std.mem.endsWith(u8, source, suffix);
+}
+
+/// `list` 의 패턴 중 하나라도 `source` 와 glob 매칭되는지.
+pub fn anyGlobMatch(list: []const []const u8, source: []const u8) bool {
+    for (list) |pat| {
+        if (matchesGlob(pat, source)) return true;
+    }
+    return false;
+}
+
+test "matchesGlob: exact match (no star)" {
+    try std.testing.expect(matchesGlob("styled-components", "styled-components"));
+    try std.testing.expect(!matchesGlob("styled-components", "styled-components/native"));
+}
+
+test "matchesGlob: prefix wildcard" {
+    try std.testing.expect(matchesGlob("@my-org/*", "@my-org/styled"));
+    try std.testing.expect(matchesGlob("@my-org/*", "@my-org/"));
+    try std.testing.expect(!matchesGlob("@my-org/*", "@other/styled"));
+}
+
+test "matchesGlob: suffix wildcard" {
+    try std.testing.expect(matchesGlob("*-styled", "my-styled"));
+    try std.testing.expect(!matchesGlob("*-styled", "styled-x"));
+}
+
+test "matchesGlob: middle wildcard" {
+    try std.testing.expect(matchesGlob("@*/styled", "@my-org/styled"));
+    try std.testing.expect(!matchesGlob("@*/styled", "@my-org/css"));
+}


### PR DESCRIPTION
## Summary
- `topLevelImportPaths` 가 단일 `*` wildcard 패턴 매칭 지원 (`@my-org/*`, `*-styled`, `@*/styled`)
- picomatch 풀 스펙 (multi `*`, `?`, `[]`, brace expansion) 은 미지원 — 대부분의 vendored fork 패턴 커버
- `util/string_list.zig` 에 `matchesGlob` / `anyGlobMatch` 추가 (단위 테스트 포함)

## 변경
- `src/util/string_list.zig` — glob 매칭 helper + 단위 테스트
- `src/transformer/transformer/styled_components.zig` — `isStyledImportSourceWithExtras` 가 `anyGlobMatch` 사용
- doc 업데이트 (`TransformOptions`, JS API)
- `src/transformer/styled_components_test.zig` — glob 매칭/미매칭 회귀 테스트 2개

## Test plan
- [x] `zig build test` Debug
- [x] `zig build test -Doptimize=ReleaseFast`
- [x] `glob \`@my-org/*\` 도 vendored fork 매칭` 통과
- [x] `glob 미매칭 fork 는 무시` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)