### PR TITLE
feat(transformer): styled cssProp Step 1 — intrinsic tag MVP

### DIFF
--- a/src/transformer/jsx_lowering.zig
+++ b/src/transformer/jsx_lowering.zig
@@ -25,6 +25,7 @@ const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
 const helpers = @import("es_helpers.zig");
 const emotion = @import("transformer/emotion.zig");
+const styled_components_mod = @import("transformer/styled_components.zig");
 
 /// JSX 런타임 모드 (codegen의 JsxRuntime을 그대로 사용)
 pub const JsxRuntime = @import("../codegen/codegen.zig").JsxRuntime;
@@ -104,7 +105,11 @@ pub fn JsxLowering(comptime Transformer: type) type {
 
         /// jsx_element → call_expression 변환
         pub fn lowerJSXElement(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
-            const e = node.data.extra;
+            // cssProp pre-processing — `<X css={...}>` 를 styled component 로 추출하고
+            // tag 를 generated identifier 로 교체. 미매칭 (옵션 비활성/형태 미지원) 시 원본 유지.
+            const working_node = (try styled_components_mod.maybeExtractCssProp(self, node)) orelse node;
+
+            const e = working_node.data.extra;
             const tag_name_idx = self.readNodeIdx(e, 0);
             const attrs_start = self.readU32(e, 1);
             const attrs_len = self.readU32(e, 2);
@@ -112,9 +117,9 @@ pub fn JsxLowering(comptime Transformer: type) type {
             const children_len = self.readU32(e, 4);
 
             return switch (self.options.jsx_runtime) {
-                .classic => lowerElementClassic(self, node.span, tag_name_idx, attrs_start, attrs_len, children_start, children_len),
-                .automatic => lowerElementAutomatic(self, node.span, tag_name_idx, attrs_start, attrs_len, children_start, children_len, false),
-                .automatic_dev => lowerElementAutomatic(self, node.span, tag_name_idx, attrs_start, attrs_len, children_start, children_len, true),
+                .classic => lowerElementClassic(self, working_node.span, tag_name_idx, attrs_start, attrs_len, children_start, children_len),
+                .automatic => lowerElementAutomatic(self, working_node.span, tag_name_idx, attrs_start, attrs_len, children_start, children_len, false),
+                .automatic_dev => lowerElementAutomatic(self, working_node.span, tag_name_idx, attrs_start, attrs_len, children_start, children_len, true),
             };
         }
 

--- a/src/transformer/plugin_state.zig
+++ b/src/transformer/plugin_state.zig
@@ -147,6 +147,10 @@ pub const StyledComponentsState = struct {
     /// 주의: 컴포넌트 추가/순서 변경 시 이후 ID 가 모두 shift → partial-deploy SSR
     /// mismatch 가능. Babel 의 name-based hash 와 trade-off (SWC fixture 호환 우선).
     component_counter: u32 = 0,
+
+    /// cssProp transform 으로 추출된 styled component 의 0-based counter — generated
+    /// identifier (`_styled_<n>`) 의 unique suffix. 파일별 reset.
+    css_prop_counter: u32 = 0,
 };
 
 pub const PluginState = struct {

--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -1543,6 +1543,98 @@ test "styled (namespace): displayName 은 영향 없음 (componentId 만 prefix)
     try std.testing.expect(std.mem.indexOf(u8, r.output, "componentId: \"myapp__sc-") != null);
 }
 
+// ─── cssProp transform (Round 4) ───
+// 본 PR (Step 1) 은 hook entry + counter + stub. transform 검증 테스트는 후속 PR 에서.
+// 옵션 켜도 transform 미적용 (사용자 코드 안전) 만 검증.
+
+// ─── cssProp transform (Round 4 Step 1: MVP) ───
+// `<div css={\`color: red;\`}>` → `<_styled_0>` + nearest list 에 styled.div 컴포넌트 decl.
+// MVP 범위: intrinsic tag (lowercase) + template_literal css value + styled default_binding 존재 시.
+
+test "styled (cssProp): intrinsic tag + template_literal css value 추출" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const el = <div css={`color: red;`}>x</div>;
+    ,
+        .{
+            .styled_components = true,
+            .styled_components_css_prop = true,
+            .jsx_transform = true,
+            .jsx_runtime = .automatic,
+            .jsx_filename = "test.tsx",
+        },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // generated identifier `_styled_0` 가 module-level decl 로 추가되어야
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_styled_0") != null);
+    // styled.div 호출이 있어야 (withConfig wrap 결과)
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "styled.div") != null);
+    // 원본 css 보존
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "color: red") != null);
+}
+
+test "styled (cssProp): 옵션 비활성 시 변환 없음 (안전한 기본 동작)" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const el = <div css={`color: red;`}>x</div>;
+    ,
+        .{
+            .styled_components = true,
+            // styled_components_css_prop 미지정 (default false)
+            .jsx_transform = true,
+            .jsx_runtime = .automatic,
+            .jsx_filename = "test.tsx",
+        },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_styled_") == null);
+}
+
+test "styled (cssProp): styled import 없으면 no-op (auto-inject 후속 PR)" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\const el = <div css={`color: red;`}>x</div>;
+    ,
+        .{
+            .styled_components = true,
+            .styled_components_css_prop = true,
+            .jsx_transform = true,
+            .jsx_runtime = .automatic,
+            .jsx_filename = "test.tsx",
+        },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_styled_") == null);
+}
+
+test "styled (cssProp): Custom component (PascalCase) 는 미지원 (후속 PR)" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const el = <Button css={`color: red;`}>x</Button>;
+    ,
+        .{
+            .styled_components = true,
+            .styled_components_css_prop = true,
+            .jsx_transform = true,
+            .jsx_runtime = .automatic,
+            .jsx_filename = "test.tsx",
+        },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_styled_") == null);
+}
+
 test "styled (namespace): ssr=false 시 componentId 자체 생략 — namespace 도 영향 없음" {
     var r = try e2eFull(
         std.testing.allocator,

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2892,7 +2892,10 @@ pub const Transformer = struct {
     /// jsx_element: extra = [tag_name, attrs_start, attrs_len, children_start, children_len]
     /// 항상 5 fields. self-closing은 children_len=0.
     fn visitJSXElement(self: *Transformer, node: Node) Error!NodeIndex {
-        const e = node.data.extra;
+        // cssProp pre-processing — `<X css={...}>` 를 styled component 로 추출 (jsx_transform=false
+        // 경로 — jsx 가 그대로 출력되는 케이스).
+        const working_node = (try styled_components_mod.maybeExtractCssProp(self, node)) orelse node;
+        const e = working_node.data.extra;
         const new_tag = try self.visitNode(self.readNodeIdx(e, 0));
         const new_attrs = try self.visitExtraList(.{ .start = self.readU32(e, 1), .len = self.readU32(e, 2) });
         const children_len = self.readU32(e, 4);
@@ -2900,7 +2903,7 @@ pub const Transformer = struct {
             try self.visitExtraList(.{ .start = self.readU32(e, 3), .len = children_len })
         else
             NodeList{ .start = 0, .len = 0 };
-        return self.addExtraNode(.jsx_element, node.span, &.{
+        return self.addExtraNode(.jsx_element, working_node.span, &.{
             @intFromEnum(new_tag),
             new_attrs.start,
             new_attrs.len,

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -1226,3 +1226,142 @@ fn buildKeyStringProperty(self: *Transformer, key_span: Span, quoted_value_span:
         .data = .{ .binary = .{ .left = key, .right = value, .flags = 0 } },
     });
 }
+
+// ─── cssProp transform (Round 4: 단계별 구현) ───
+//
+// 본 PR (Step 1) 은 hook entry + state counter + stub 만. 실제 transform 은 후속 PR:
+//   Step 2: intrinsic tag (lowercase) + template_literal css value MVP
+//   Step 3: tagged template (`css\`\``) css value
+//   Step 4: custom component (`<Foo css>`) → `styled(Foo)\`\``
+//   Step 5: object form
+//   Step 6: styled import auto-inject + program-level hoisting
+
+/// `<X css={...}>` JSX prop 을 styled component 추출 시도. MVP: intrinsic tag +
+/// template_literal css value + styled default_binding 존재 시. 미매칭 시 null 반환.
+pub fn maybeExtractCssProp(self: *Transformer, jsx_node: ast_mod.Node) Error!?ast_mod.Node {
+    if (!self.options.styled_components or !self.options.styled_components_css_prop) return null;
+    if (jsx_node.tag != .jsx_element) return null;
+    const default_binding = self.plugins.styled_components.default_binding orelse return null;
+
+    const e = jsx_node.data.extra;
+    const tag_name_idx = self.readNodeIdx(e, 0);
+    const attrs_start = self.readU32(e, 1);
+    const attrs_len = self.readU32(e, 2);
+    const children_start = self.readU32(e, 3);
+    const children_len = self.readU32(e, 4);
+
+    if (tag_name_idx.isNone()) return null;
+    const tag_name_node = self.ast.getNode(tag_name_idx);
+    if (tag_name_node.tag != .jsx_identifier) return null;
+    const tag_text = self.ast.getText(tag_name_node.span);
+    if (tag_text.len == 0) return null;
+    if (tag_text[0] < 'a' or tag_text[0] > 'z') return null;
+
+    var css_attr_pos: ?u32 = null;
+    var css_value_idx: NodeIndex = .none;
+    var i: u32 = 0;
+    while (i < attrs_len) : (i += 1) {
+        const attr_idx_raw = self.ast.extra_data.items[attrs_start + i];
+        const attr_idx: NodeIndex = @enumFromInt(attr_idx_raw);
+        if (attr_idx.isNone()) continue;
+        const attr_node = self.ast.getNode(attr_idx);
+        if (attr_node.tag != .jsx_attribute) continue;
+        const name_idx = attr_node.data.binary.left;
+        if (name_idx.isNone()) continue;
+        const name_node = self.ast.getNode(name_idx);
+        if (name_node.tag != .jsx_identifier) continue;
+        if (!std.mem.eql(u8, self.ast.getText(name_node.span), "css")) continue;
+        css_attr_pos = i;
+        css_value_idx = attr_node.data.binary.right;
+        break;
+    }
+    if (css_attr_pos == null) return null;
+    if (css_value_idx.isNone()) return null;
+
+    const css_value_node = self.ast.getNode(css_value_idx);
+    if (css_value_node.tag != .template_literal) return null;
+
+    const state = &self.plugins.styled_components;
+    const counter = state.css_prop_counter;
+    state.css_prop_counter += 1;
+
+    var name_buf: [64]u8 = undefined;
+    const generated_name = std.fmt.bufPrint(&name_buf, "_styled_{d}", .{counter}) catch return null;
+    const generated_span = try self.ast.addString(generated_name);
+    const zero = Span{ .start = 0, .end = 0 };
+
+    const styled_ref_span = try self.ast.addString(default_binding);
+    const styled_ref = try self.ast.addNode(.{
+        .tag = .identifier_reference,
+        .span = styled_ref_span,
+        .data = .{ .string_ref = styled_ref_span },
+    });
+    const tag_prop_span = try self.ast.addString(tag_text);
+    const tag_prop = try self.ast.addNode(.{
+        .tag = .identifier_reference,
+        .span = tag_prop_span,
+        .data = .{ .string_ref = tag_prop_span },
+    });
+    const styled_tag = try self.addExtraNode(.static_member_expression, zero, &.{
+        @intFromEnum(styled_ref),
+        @intFromEnum(tag_prop),
+        0,
+    });
+
+    const tagged_template = try self.addExtraNode(.tagged_template_expression, zero, &.{
+        @intFromEnum(styled_tag),
+        @intFromEnum(css_value_idx),
+        0,
+    });
+
+    const binding_id = try self.ast.addNode(.{
+        .tag = .binding_identifier,
+        .span = generated_span,
+        .data = .{ .string_ref = generated_span },
+    });
+    const none_idx = @intFromEnum(NodeIndex.none);
+    const declarator = try self.addExtraNode(.variable_declarator, zero, &.{
+        @intFromEnum(binding_id),
+        none_idx,
+        @intFromEnum(tagged_template),
+    });
+
+    const decl_list = try self.ast.addNodeList(&.{declarator});
+    const var_decl = try self.addExtraNode(.variable_declaration, zero, &.{
+        @intFromEnum(ast_mod.VariableDeclarationKind.@"const"),
+        decl_list.start,
+        decl_list.len,
+    });
+
+    try self.trailing_nodes.append(self.allocator, var_decl);
+
+    const top = self.scratch.items.len;
+    defer self.scratch.shrinkRetainingCapacity(top);
+    var j: u32 = 0;
+    while (j < attrs_len) : (j += 1) {
+        if (j == css_attr_pos.?) continue;
+        const idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[attrs_start + j]);
+        try self.scratch.append(self.allocator, idx);
+    }
+    const new_attrs_list = try self.ast.addNodeList(self.scratch.items[top..]);
+
+    const new_tag = try self.ast.addNode(.{
+        .tag = .jsx_identifier,
+        .span = generated_span,
+        .data = .{ .string_ref = generated_span },
+    });
+
+    const new_extra = try self.ast.addExtras(&.{
+        @intFromEnum(new_tag),
+        new_attrs_list.start,
+        new_attrs_list.len,
+        children_start,
+        children_len,
+    });
+
+    return ast_mod.Node{
+        .tag = .jsx_element,
+        .span = jsx_node.span,
+        .data = .{ .extra = new_extra },
+    };
+}


### PR DESCRIPTION
## Summary
- `<div css={\`color: red;\`}>x</div>` → `<_styled_0>x</_styled_0>` + nearest list 에 `const _styled_0 = styled.div\`color: red;\`;` decl
- counter 기반 generated identifier (`_styled_<n>`), 기존 `trailing_nodes` 메커니즘 재사용
- 변환 자체는 `maybeExtractCssProp` 가 `jsx_lowering` / `visitJSXElement` 의 entry 에서 호출 — 양쪽 path (jsx_transform=true|false) 모두 처리

## MVP scope
- intrinsic tag (lowercase 시작) + template_literal css value
- styled default_binding 존재 시만 (auto-inject 는 Step 5)

## 후속 PR 단계
- **Step 2**: tagged template (`css\`\``) css value
- **Step 3**: custom component (`<Foo css>`) → `styled(Foo)\`\``
- **Step 4**: object form (`<div css={{...}}>`)
- **Step 5**: styled import auto-inject (`default_binding == null` 일 때 자동 import 추가)
- **Step 6**: program-level hoisting (현재 nearest list 에 들어가서 함수 closure 안에 갇히는 정확도 이슈 해결)

## 변경
- `src/transformer/transformer/styled_components.zig` — `maybeExtractCssProp` helper
- `src/transformer/plugin_state.zig` — `css_prop_counter`
- `src/transformer/jsx_lowering.zig` — `lowerJSXElement` entry hook
- `src/transformer/transformer.zig` — `visitJSXElement` entry hook (jsx_transform=false 경로)
- `src/transformer/styled_components_test.zig` — 4 회귀 테스트

## Test plan
- [x] `zig build test` Debug
- [x] `zig build test -Doptimize=ReleaseFast`
- [x] intrinsic tag + template_literal 변환 통과
- [x] 옵션 비활성 시 변환 없음
- [x] styled import 없으면 no-op
- [x] Custom component 미지원 (Step 3 까지 명시적)

🤖 Generated with [Claude Code](https://claude.com/claude-code)