### PR TITLE
feat(transformer): styled cssProp Step 4 — object form

### DIFF
--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -1682,6 +1682,51 @@ test "styled (cssProp Step 3): Custom component (PascalCase) 는 styled(Foo) 로
     try std.testing.expect(std.mem.indexOf(u8, r.output, "color: red") != null);
 }
 
+test "styled (cssProp Step 4): object form `<div css={{...}}>` → styled.div({...})" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const el = <div css={{ color: "red" }}>x</div>;
+    ,
+        .{
+            .styled_components = true,
+            .styled_components_css_prop = true,
+            .jsx_transform = true,
+            .jsx_runtime = .automatic,
+            .jsx_filename = "test.tsx",
+        },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_styled_0") != null);
+    // styled.div({ ... }) call form
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "styled.div({") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "color:") != null);
+}
+
+test "styled (cssProp Step 4): object form 으로 Custom component 도 wrap" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "styled-components";
+        \\const Button = (props) => null;
+        \\const el = <Button css={{ color: "red" }}>x</Button>;
+    ,
+        .{
+            .styled_components = true,
+            .styled_components_css_prop = true,
+            .jsx_transform = true,
+            .jsx_runtime = .automatic,
+            .jsx_filename = "test.tsx",
+        },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_styled_0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "styled(Button)({") != null);
+}
+
 test "styled (cssProp Step 3): jsx_member_expression `<Foo.Bar css>` → styled(Foo.Bar)" {
     var r = try e2eFull(
         std.testing.allocator,

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -1359,10 +1359,17 @@ pub fn maybeExtractCssProp(self: *Transformer, jsx_node: ast_mod.Node) Error!?as
     if (css_attr_pos == null) return null;
     if (css_value_idx.isNone()) return null;
 
-    // css value 가:
-    //   - template_literal 직접 (`css={\`...\`}`) → 그대로
-    //   - styled-components 의 `css\`...\`` tagged template → quasi (template_literal) 만 추출
-    const css_template_idx = extractCssTemplateIdx(self, css_value_idx) orelse return null;
+    // css value 분기:
+    //   - object_expression (`css={{...}}`) → `styled.div({...})` call
+    //   - template_literal (`css={\`...\`}`) → `styled.div\`...\``
+    //   - styled `css\`...\`` tagged template → quasi 추출 후 tagged template
+    //   - 기타 (identifier 등) → 미지원 (후속 PR)
+    const css_value_node_kind = self.ast.getNode(css_value_idx).tag;
+    const use_object_form = css_value_node_kind == .object_expression;
+    const css_template_idx: NodeIndex = if (use_object_form)
+        .none
+    else
+        extractCssTemplateIdx(self, css_value_idx) orelse return null;
 
     const state = &self.plugins.styled_components;
     const counter = state.css_prop_counter;
@@ -1404,7 +1411,16 @@ pub fn maybeExtractCssProp(self: *Transformer, jsx_node: ast_mod.Node) Error!?as
         });
     };
 
-    const tagged_template = try self.addExtraNode(.tagged_template_expression, zero, &.{
+    // styled component init expression — object form 은 call, 그 외는 tagged template
+    const init_expr: NodeIndex = if (use_object_form) blk: {
+        const args_list = try self.ast.addNodeList(&.{css_value_idx});
+        break :blk try self.addExtraNode(.call_expression, zero, &.{
+            @intFromEnum(styled_tag),
+            args_list.start,
+            args_list.len,
+            0,
+        });
+    } else try self.addExtraNode(.tagged_template_expression, zero, &.{
         @intFromEnum(styled_tag),
         @intFromEnum(css_template_idx),
         0,
@@ -1419,7 +1435,7 @@ pub fn maybeExtractCssProp(self: *Transformer, jsx_node: ast_mod.Node) Error!?as
     const declarator = try self.addExtraNode(.variable_declarator, zero, &.{
         @intFromEnum(binding_id),
         none_idx,
-        @intFromEnum(tagged_template),
+        @intFromEnum(init_expr),
     });
 
     const decl_list = try self.ast.addNodeList(&.{declarator});


### PR DESCRIPTION
## Summary
- `<div css={{ color: \"red\" }}>` → `styled.div({color:\"red\"})` call
- `<Foo css={{...}}>` → `styled(Foo)({...})` (Custom component 호환)
- object_expression 인 경우 tagged template 대신 call_expression 사용

## 미지원 (후속 PR)
- prop interpolation (object 안 dynamic key/value 의 prop forwarding)

## 변경
- `src/transformer/transformer/styled_components.zig` — object form 분기 추가
- `src/transformer/styled_components_test.zig` — intrinsic + Custom component 양쪽 회귀 테스트

## Test plan
- [x] `zig build test` Debug
- [x] `zig build test -Doptimize=ReleaseFast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)