### PR TITLE
feat(transformer): styled cssProp Step 5+6 — auto-inject + program-level hoist

### DIFF
--- a/src/transformer/plugin_state.zig
+++ b/src/transformer/plugin_state.zig
@@ -13,6 +13,8 @@
 const std = @import("std");
 const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
+const ast_mod = @import("../parser/ast.zig");
+const NodeIndex = ast_mod.NodeIndex;
 
 pub const WorkletState = struct {
     /// auto-workletization 플래그.
@@ -151,6 +153,16 @@ pub const StyledComponentsState = struct {
     /// cssProp transform 으로 추출된 styled component 의 0-based counter — generated
     /// identifier (`_styled_<n>`) 의 unique suffix. 파일별 reset.
     css_prop_counter: u32 = 0,
+
+    /// cssProp transform 시 사용자 코드에 `import styled from "styled-components"` 가
+    /// 없어 transpile.zig 가 자동 prepend 해야 함. JSX import auto-inject 패턴과 동일.
+    css_prop_needs_import: bool = false,
+
+    /// cssProp transform 으로 만들어진 module-level decl 들 — program body 끝에 hoist.
+    /// `trailing_nodes` 는 nearest list 가 program 이 아니면 declarator list 같은
+    /// 부적절한 위치에 들어가 invalid syntax 가 되므로 별도 list 로 관리. visitProgram
+    /// 에서 drain.
+    css_prop_pending_decls: std.ArrayList(NodeIndex) = .empty,
 };
 
 pub const PluginState = struct {

--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -1596,7 +1596,7 @@ test "styled (cssProp): 옵션 비활성 시 변환 없음 (안전한 기본 동
     try std.testing.expect(std.mem.indexOf(u8, r.output, "_styled_") == null);
 }
 
-test "styled (cssProp): styled import 없으면 no-op (auto-inject 후속 PR)" {
+test "styled (cssProp Step 5): styled import 없으면 자동 import 추가" {
     var r = try e2eFull(
         std.testing.allocator,
         \\const el = <div css={`color: red;`}>x</div>;
@@ -1612,7 +1612,32 @@ test "styled (cssProp): styled import 없으면 no-op (auto-inject 후속 PR)" {
         ".tsx",
     );
     defer r.deinit();
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "_styled_") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_styled_0") != null);
+    // 본 PR scope: transform 자체는 동작 + needs_import flag set. 실제 prepend 는
+    // transpile.zig 의 6.6 hook 이 담당하므로 e2eFull 의 raw codegen 출력엔 import 가
+    // 안 들어감 — 통합 테스트에서 검증.
+    // hoisting 검증 — `const _styled_0` 이 별도 statement 로 program body 에 있어야 (이전
+    // 버그: declarator list 안에 들어가서 `const el = ...,const _styled_0=...,;` 형태 invalid).
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "const _styled_0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, ",const _styled_") == null);
+}
+
+test "styled (cssProp Step 5): cssProp transform 안 일어나면 auto-inject 도 안 함" {
+    // 옵션 활성이지만 jsx 안 쓰면 transform 자체가 안 일어남 → auto-inject 도 안 됨.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\const x = 1;
+    ,
+        .{
+            .styled_components = true,
+            .styled_components_css_prop = true,
+            .jsx_filename = "test.tsx",
+        },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "import styled") == null);
 }
 
 test "styled (cssProp Step 2): css tagged template 도 인식 (quasi 만 추출)" {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -665,6 +665,7 @@ pub const Transformer = struct {
         self.plugins.refresh.signatures.deinit(self.allocator);
         self.plugins.emotion.scope_stack.deinit(self.allocator);
         if (self.plugins.emotion.newline_offsets) |*list| list.deinit(self.allocator);
+        self.plugins.styled_components.css_prop_pending_decls.deinit(self.allocator);
         self.trailing_nodes.deinit(self.allocator);
         self.generator_label_stack.deinit(self.allocator);
         self.generator_temp_var_spans.deinit(self.allocator);
@@ -907,7 +908,31 @@ pub const Transformer = struct {
                         return wrapped;
                     }
                 }
-                return self.visitListNode(idx);
+                const result = try self.visitListNode(idx);
+                // styled-components cssProp transform 으로 추출된 module-level decl 들을
+                // program body 끝에 hoist. trailing_nodes 가 nearest list (declarator list 등)
+                // 에 들어가는 케이스 회피.
+                const pending = &self.plugins.styled_components.css_prop_pending_decls;
+                if (pending.items.len > 0) {
+                    const result_node = self.ast.getNode(result);
+                    const old_list = result_node.data.list;
+                    const top = self.scratch.items.len;
+                    defer self.scratch.shrinkRetainingCapacity(top);
+                    for (self.ast.extra_data.items[old_list.start .. old_list.start + old_list.len]) |raw| {
+                        try self.scratch.append(self.allocator, @as(NodeIndex, @enumFromInt(raw)));
+                    }
+                    for (pending.items) |decl_idx| {
+                        try self.scratch.append(self.allocator, decl_idx);
+                    }
+                    const new_list = try self.ast.addNodeList(self.scratch.items[top..]);
+                    pending.clearRetainingCapacity();
+                    return self.ast.addNode(.{
+                        .tag = .program,
+                        .span = result_node.span,
+                        .data = .{ .list = new_list },
+                    });
+                }
+                return result;
             },
             .block_statement,
             .sequence_expression,

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -1316,7 +1316,9 @@ fn extractCssTemplateIdx(self: *Transformer, css_value_idx: NodeIndex) ?NodeInde
 pub fn maybeExtractCssProp(self: *Transformer, jsx_node: ast_mod.Node) Error!?ast_mod.Node {
     if (!self.options.styled_components or !self.options.styled_components_css_prop) return null;
     if (jsx_node.tag != .jsx_element) return null;
-    const default_binding = self.plugins.styled_components.default_binding orelse return null;
+    // styled binding: 사용자 import 가 있으면 그 이름, 없으면 "styled" 사용 + auto-inject flag.
+    // transpile.zig 가 flag 보고 program 시작에 `import styled from "styled-components"` prepend.
+    const default_binding: []const u8 = self.plugins.styled_components.default_binding orelse "styled";
 
     const e = jsx_node.data.extra;
     const tag_name_idx = self.readNodeIdx(e, 0);
@@ -1372,6 +1374,7 @@ pub fn maybeExtractCssProp(self: *Transformer, jsx_node: ast_mod.Node) Error!?as
         extractCssTemplateIdx(self, css_value_idx) orelse return null;
 
     const state = &self.plugins.styled_components;
+    if (state.default_binding == null) state.css_prop_needs_import = true;
     const counter = state.css_prop_counter;
     state.css_prop_counter += 1;
 
@@ -1445,7 +1448,9 @@ pub fn maybeExtractCssProp(self: *Transformer, jsx_node: ast_mod.Node) Error!?as
         decl_list.len,
     });
 
-    try self.trailing_nodes.append(self.allocator, var_decl);
+    // program body 끝에 hoist — `trailing_nodes` 는 nearest list 라 declarator list 같은
+    // 부적절한 위치에 들어갈 수 있음. visitProgram 의 후처리로 drain.
+    try self.plugins.styled_components.css_prop_pending_decls.append(self.allocator, var_decl);
 
     const top = self.scratch.items.len;
     defer self.scratch.shrinkRetainingCapacity(top);

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -545,16 +545,27 @@ pub fn transpileWithCallback(
         } else break :blk raw_output;
     } else raw_output;
 
+    // 6.6. styled-components cssProp auto-inject — 사용자 코드에 styled import 가 없는데
+    // cssProp transform 이 일어난 경우 program 시작에 `import styled from "styled-components"`.
+    const css_prop_output = if (transformer.plugins.styled_components.css_prop_needs_import) blk: {
+        const styled_import = "import styled from \"styled-components\";\n";
+        var combined: std.ArrayList(u8) = .empty;
+        combined.ensureTotalCapacity(arena_alloc, styled_import.len + jsx_output.len) catch break :blk jsx_output;
+        combined.appendSliceAssumeCapacity(styled_import);
+        combined.appendSliceAssumeCapacity(jsx_output);
+        break :blk combined.items;
+    } else jsx_output;
+
     // 7. 런타임 헬퍼 prepend
     const rh = transformer.runtime_helpers;
     const has_helpers = @as(u32, @bitCast(rh)) != 0;
     const output = if (has_helpers) blk: {
         var buf: std.ArrayList(u8) = .empty;
         rt.appendRuntimeHelpers(&buf, arena_alloc, rh, options.minify_whitespace, transformer.runtime_es5_compat) catch
-            break :blk jsx_output;
-        buf.appendSlice(arena_alloc, jsx_output) catch break :blk jsx_output;
+            break :blk css_prop_output;
+        buf.appendSlice(arena_alloc, css_prop_output) catch break :blk css_prop_output;
         break :blk buf.items;
-    } else jsx_output;
+    } else css_prop_output;
 
     // 8. Sentry Debug ID (UUID v4) — sourcemap_debug_ids 활성화 시 생성
     var debug_id_buf: [36]u8 = undefined;


### PR DESCRIPTION
## Summary
**Critical bug fix + auto-inject 동시 진행** — Step 5 와 Step 6 이 의미적으로 짝.

### Step 6: program-level hoisting (critical bug fix)
**기존 회귀**: `trailing_nodes` 메커니즘이 nearest list 에 var_decl 을 push 했는데, 사용자 코드가 `const el = <div css>...` 처럼 jsx 가 declarator init 에 있으면 nearest list = declarator list 가 되어 var_decl 이 declarator 자리에 들어가 `const el = ..., const _styled_0 = ...,;` invalid syntax 출력.

**Fix**: `css_prop_pending_decls: ArrayList(NodeIndex)` 별도 list 도입. `maybeExtractCssProp` 이 그 list 에 push, `visitNode` 의 `.program` 분기가 `visitListNode` 후 drain 하여 program body 끝에 append.

### Step 5: auto-inject styled import
사용자 코드에 `import styled from "styled-components"` 가 없어도 cssProp transform 진행. 사용 시 `css_prop_needs_import` flag set, `transpile.zig` 의 6.6 hook 이 program 시작에 `import styled from "styled-components";` prepend.

## 변경
- `src/transformer/plugin_state.zig` — `css_prop_pending_decls` + `css_prop_needs_import` 추가
- `src/transformer/transformer.zig` — `.program` 분기에서 pending decls drain, deinit 추가
- `src/transformer/transformer/styled_components.zig` — `default_binding == null` 시 `"styled"` fallback + flag set, `trailing_nodes` 대신 pending list 사용
- `src/transpile.zig` — 6.6 cssProp auto-inject prepend hook
- `src/transformer/styled_components_test.zig` — auto-inject + hoisting 회귀 테스트

## Test plan
- [x] `zig build test` Debug
- [x] `zig build test -Doptimize=ReleaseFast`
- [x] `_styled_0` declared as separate statement (not inside declarator list)
- [x] `,const _styled_` 형태 invalid syntax 회귀 안 남

🤖 Generated with [Claude Code](https://claude.com/claude-code)