### PR TITLE
fix(transform): deeper main audit regressions 보정

### DIFF
--- a/scripts/syntax-audit.mjs
+++ b/scripts/syntax-audit.mjs
@@ -180,6 +180,36 @@ console.log(JSON.stringify(log));
 `,
   },
   {
+    name: "derived-constructor-return-super-in-logical-expression",
+    code: `
+const log = [];
+class Base { constructor(v) { log.push("base:" + v); this.v = v; } }
+class Child extends Base {
+  field = log.push("field:" + this.v);
+  constructor() {
+    return false || super(5);
+  }
+}
+new Child();
+console.log(JSON.stringify(log));
+`,
+  },
+  {
+    name: "derived-constructor-default-param-super-fields",
+    code: `
+const log = [];
+class Base { constructor(v) { log.push("base:" + v); this.v = v; } }
+class Child extends Base {
+  field = log.push("field:" + this.v);
+  constructor(arg = super(10)) {
+    return arg;
+  }
+}
+new Child();
+console.log(JSON.stringify(log));
+`,
+  },
+  {
     name: "private-field-brand-and-update",
     code: `
 class Counter {
@@ -259,6 +289,60 @@ class A extends Base {
   static { log.push("block:" + this.x); }
 }
 console.log(JSON.stringify([A.x, log]));
+`,
+  },
+  {
+    name: "static-name-field-uses-define-property",
+    code: `
+class A {
+  static name = "Custom";
+  static x = this.name;
+}
+console.log(JSON.stringify([A.name, A.x, Object.prototype.propertyIsEnumerable.call(A, "name")]));
+`,
+  },
+  {
+    name: "static-optional-super-computed-method-field",
+    code: `
+const log = [];
+class Base {
+  static m(v) { log.push("m:" + v + ":" + this.label); return v + 1; }
+}
+class A extends Base {
+  static label = "A";
+  static key = "m";
+  static x = super[this.key]?.(1);
+  static { log.push("block:" + this.x); }
+}
+console.log(JSON.stringify([A.x, log]));
+`,
+  },
+  {
+    name: "static-super-logical-assignment-field",
+    code: `
+const log = [];
+class Base {
+  static get x() { log.push("get:" + this.label); return this._x; }
+  static set x(v) { log.push("set:" + v + ":" + this.label); this._x = v; }
+}
+class A extends Base {
+  static label = "A";
+  static _x = 0;
+  static y = (super.x ||= 9);
+}
+console.log(JSON.stringify([A.y, A._x, log]));
+`,
+  },
+  {
+    name: "static-block-private-optional-chain",
+    code: `
+const log = [];
+class A {
+  static #x = 1;
+  static { log.push(this?.#x); }
+  static y = log.push("field");
+}
+console.log(JSON.stringify(log));
 `,
   },
   {
@@ -352,12 +436,52 @@ console.log(JSON.stringify(new A().run()));
 `,
   },
   {
+    name: "object-rest-private-optional-computed-key",
+    code: `
+class A {
+  #x = 1;
+  get self() { return this; }
+  run(obj) {
+    const { [this.self?.#x]: picked, ...rest } = obj;
+    return [picked, rest];
+  }
+}
+console.log(JSON.stringify(new A().run({ 1: "one", a: 2 })));
+`,
+  },
+  {
+    name: "computed-public-field-reads-private-field-order",
+    code: `
+const log = [];
+function key() { log.push("key"); return "x"; }
+class A {
+  #v = 2;
+  [key()] = this.#v;
+  read() { return [this.x, log]; }
+}
+console.log(JSON.stringify(new A().read()));
+`,
+  },
+  {
     name: "for-of-let-closure-continue",
     code: `
 const fns = [];
 for (let x of [1, 2, 3, 4]) {
   if (x % 2) continue;
   fns.push(() => x);
+}
+console.log(JSON.stringify(fns.map((fn) => fn())));
+`,
+  },
+  {
+    name: "for-of-let-closure-labeled-continue",
+    code: `
+const fns = [];
+outer: for (let x of [1, 2, 3]) {
+  for (let y of [4]) {
+    if (x === 2) continue outer;
+    fns.push(() => x + y);
+  }
 }
 console.log(JSON.stringify(fns.map((fn) => fn())));
 `,

--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -610,6 +610,8 @@ pub const TAGGED_TEMPLATE_RUNTIME_MIN = "var " ++ NAMES.TAGGED_TEMPLATE_MIN ++ "
 
 /// __rest: object destructuring rest (ES2018). TypeScript __rest 호환.
 /// exclude 배열에 없는 own 프로퍼티 + Symbol 프로퍼티 복사.
+/// `e[]` in-place String 정규화: computed key 가 number/Symbol 일 수 있어 indexOf 비교 전에 String 화 (Symbol 제외).
+/// transformer 가 매 호출마다 새 array literal 을 만드므로 (es2015_destructuring.buildRestCall) cache 충돌 없음.
 pub const REST_RUNTIME =
     \\var __rest = function(s, e) {
     \\  var t = {};

--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -613,6 +613,7 @@ pub const TAGGED_TEMPLATE_RUNTIME_MIN = "var " ++ NAMES.TAGGED_TEMPLATE_MIN ++ "
 pub const REST_RUNTIME =
     \\var __rest = function(s, e) {
     \\  var t = {};
+    \\  for (var i = 0; i < e.length; i++) e[i] = typeof e[i] === "symbol" ? e[i] : String(e[i]);
     \\  for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0) t[p] = s[p];
     \\  if (typeof Object.getOwnPropertySymbols === "function")
     \\    for (var i = 0, symbols = Object.getOwnPropertySymbols(s); i < symbols.length; i++)
@@ -622,7 +623,7 @@ pub const REST_RUNTIME =
     \\};
     \\
 ;
-pub const REST_RUNTIME_MIN = "var " ++ NAMES.REST_MIN ++ "=function(s,e){var t={};for(var p in s)if(Object.prototype.hasOwnProperty.call(s,p)&&e.indexOf(p)<0)t[p]=s[p];if(typeof Object.getOwnPropertySymbols===\"function\")for(var i=0,symbols=Object.getOwnPropertySymbols(s);i<symbols.length;i++)if(e.indexOf(symbols[i])<0&&Object.prototype.propertyIsEnumerable.call(s,symbols[i]))t[symbols[i]]=s[symbols[i]];return t};";
+pub const REST_RUNTIME_MIN = "var " ++ NAMES.REST_MIN ++ "=function(s,e){var t={};for(var i=0;i<e.length;i++)e[i]=typeof e[i]===\"symbol\"?e[i]:String(e[i]);for(var p in s)if(Object.prototype.hasOwnProperty.call(s,p)&&e.indexOf(p)<0)t[p]=s[p];if(typeof Object.getOwnPropertySymbols===\"function\")for(var i=0,symbols=Object.getOwnPropertySymbols(s);i<symbols.length;i++)if(e.indexOf(symbols[i])<0&&Object.prototype.propertyIsEnumerable.call(s,symbols[i]))t[symbols[i]]=s[symbols[i]];return t};";
 
 // ============================================================
 // Asset Loader

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -1201,7 +1201,7 @@ test "ES2015: class method default param lowered" {
 test "ES2015: class constructor destructuring params lowered" {
     var r = try e2eTarget(std.testing.allocator, "class Foo { constructor({x,...rest}:any) { console.log(rest); } }", .es5);
     defer r.deinit();
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "function Foo(_b)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function Foo(_") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__rest") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "...rest") == null);
 }
@@ -1574,7 +1574,9 @@ test "ES2015: class with static field" {
     var r = try e2eTarget(std.testing.allocator, "class Foo{static y=2;}", .es5);
     defer r.deinit();
     try std.testing.expect(std.mem.indexOf(u8, r.output, "function Foo()") != null);
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "Foo.y=2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "defineProperty(Foo") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"y\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "value") != null);
 }
 
 test "ES2015: class no transform on esnext" {
@@ -2278,13 +2280,9 @@ test "ES2015: class with computed method uses bracket notation" {
 test "ES2015: static computed field uses bracket notation" {
     var r = try e2eTarget(std.testing.allocator, "var k='x';class F{static [k]=1;}", .es5);
     defer r.deinit();
-    // computed key 는 hoist 된 임시 변수 (`var _a=k;`) 로 캡쳐된 뒤 `F[_a]=1` 형태로 emit 된다.
-    // 정확한 temp 이름에 결합되지 않도록 prefix/suffix 사이의 식별자만 검증한다.
-    const prefix = std.mem.indexOf(u8, r.output, "F[") orelse return error.TestUnexpectedResult;
-    const suffix = std.mem.indexOfPos(u8, r.output, prefix + 2, "]=1") orelse return error.TestUnexpectedResult;
-    const key = r.output[prefix + 2 .. suffix];
-    try std.testing.expect(key.len > 0);
-    try std.testing.expect(std.ascii.isAlphabetic(key[0]) or key[0] == '_');
+    // computed key 는 hoist 된 임시 변수 (`var _a=k;`) 로 캡쳐된 뒤 defineProperty key로 사용된다.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "defineProperty(F") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "value") != null);
     try std.testing.expectEqual(std.mem.indexOf(u8, r.output, "F.[k]"), null);
 }
 

--- a/src/parser/declaration.zig
+++ b/src/parser/declaration.zig
@@ -40,6 +40,20 @@ fn isModifierTerminator(kind: Kind) bool {
         kind == .semicolon or kind == .r_curly or kind == .bang or kind == .question;
 }
 
+/// class member key 의 식별자 텍스트를 source 에서 추출.
+/// `identifier_reference` 는 span 그대로, `string_literal` 은 따옴표 제거. 그 외는 빈 문자열.
+fn classMemberKeyText(self: *Parser, key: NodeIndex) []const u8 {
+    if (key.isNone()) return "";
+    const key_node = self.ast.getNode(key);
+    if (key_node.tag == .identifier_reference) {
+        return self.ast.source[key_node.span.start..key_node.span.end];
+    }
+    if (key_node.tag == .string_literal and key_node.span.end > key_node.span.start + 2) {
+        return self.ast.source[key_node.span.start + 1 .. key_node.span.end - 1];
+    }
+    return "";
+}
+
 /// 함수 body 또는 TS 오버로드 시그니처 (세미콜론으로 끝나면 body 없음)
 fn parseFunctionBodyOrOverload(self: *Parser) ParseError2!NodeIndex {
     // TS function overload: 세미콜론 또는 EOF로 body 없음
@@ -658,17 +672,8 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
 
     // 키
     const key = try self.parsePropertyKey();
-    const is_constructor_member = blk: {
-        if (key.isNone() or (flags & ast_mod.MethodFlags.is_static) != 0) break :blk false;
-        const key_node = self.ast.getNode(key);
-        const key_text = if (key_node.tag == .identifier_reference)
-            self.ast.source[key_node.span.start..key_node.span.end]
-        else if (key_node.tag == .string_literal and key_node.span.end > key_node.span.start + 2)
-            self.ast.source[key_node.span.start + 1 .. key_node.span.end - 1]
-        else
-            @as([]const u8, "");
-        break :blk std.mem.eql(u8, key_text, "constructor");
-    };
+    const is_constructor_member = (flags & ast_mod.MethodFlags.is_static) == 0 and
+        std.mem.eql(u8, classMemberKeyText(self, key), "constructor");
 
     // TS optional class field: foo?: Type (프로퍼티 이름 뒤의 ?)
     // TS definite assignment: foo!: Type (프로퍼티 이름 뒤의 !)
@@ -821,13 +826,7 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
     // class field 이름 검증 (ECMAScript 15.7.1)
     if (!key.isNone()) {
         const key_node = self.ast.getNode(key);
-        // identifier 또는 string literal 키에서 이름 추출
-        const key_text = if (key_node.tag == .identifier_reference)
-            self.ast.source[key_node.span.start..key_node.span.end]
-        else if (key_node.tag == .string_literal and key_node.span.end > key_node.span.start + 2)
-            self.ast.source[key_node.span.start + 1 .. key_node.span.end - 1] // 따옴표 제거
-        else
-            @as([]const u8, "");
+        const key_text = classMemberKeyText(self, key);
 
         if (key_text.len > 0) {
             // class field 이름 'constructor' 금지 — static/non-static 모두 (ECMAScript 15.7.1)

--- a/src/parser/declaration.zig
+++ b/src/parser/declaration.zig
@@ -658,6 +658,17 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
 
     // 키
     const key = try self.parsePropertyKey();
+    const is_constructor_member = blk: {
+        if (key.isNone() or (flags & ast_mod.MethodFlags.is_static) != 0) break :blk false;
+        const key_node = self.ast.getNode(key);
+        const key_text = if (key_node.tag == .identifier_reference)
+            self.ast.source[key_node.span.start..key_node.span.end]
+        else if (key_node.tag == .string_literal and key_node.span.end > key_node.span.start + 2)
+            self.ast.source[key_node.span.start + 1 .. key_node.span.end - 1]
+        else
+            @as([]const u8, "");
+        break :blk std.mem.eql(u8, key_text, "constructor");
+    };
 
     // TS optional class field: foo?: Type (프로퍼티 이름 뒤의 ?)
     // TS definite assignment: foo!: Type (프로퍼티 이름 뒤의 !)
@@ -684,6 +695,7 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
         const saved_in_async_for_params = self.ctx.in_async;
         const saved_in_generator_for_params = self.ctx.in_generator;
         const saved_super_prop_for_params = self.allow_super_property;
+        const saved_super_call_for_params = self.allow_super_call;
         self.in_static_initializer = false;
         self.in_class_field = false;
         // 메서드의 파라미터에서 async/generator 컨텍스트 설정
@@ -692,6 +704,7 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
         self.ctx.in_generator = (flags & ast_mod.MethodFlags.is_generator) != 0;
         // class 메서드의 파라미터에서 super.prop 허용 (ECMAScript 15.7.5)
         self.allow_super_property = true;
+        self.allow_super_call = self.has_super_class and is_constructor_member;
         try self.expect(.l_paren);
         self.in_formal_parameters = true;
         try self.trySkipThisParameter();
@@ -783,6 +796,7 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
         self.ctx.in_async = saved_in_async_for_params;
         self.ctx.in_generator = saved_in_generator_for_params;
         self.allow_super_property = saved_super_prop_for_params;
+        self.allow_super_call = saved_super_call_for_params;
         const param_list = try self.ast.addNodeList(self.scratch.items[param_top..]);
         self.restoreScratch(param_top);
         const params_node = try self.wrapAsFormalParametersFromList(param_list, .{ .start = 0, .end = 0 });

--- a/src/transformer/es2015_block_scoping.zig
+++ b/src/transformer/es2015_block_scoping.zig
@@ -220,6 +220,7 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
             visited_body: NodeIndex,
             lexical_names: []const []const u8,
             flow: *const FlowResult,
+            local_label: ?[]const u8,
             span: Span,
         ) Transformer.Error!struct { loop_fn: NodeIndex, call_and_check: NodeIndex } {
             // --- _loop 함수명 생성 ---
@@ -311,7 +312,7 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
             // --- 제어 흐름 후처리: var _ret = _loop(i); if (...) ... ---
             var final_stmt: NodeIndex = undefined;
             if (needs_ret_var) {
-                final_stmt = try buildControlFlowCheck(self, loop_call, flow, span);
+                final_stmt = try buildControlFlowCheck(self, loop_call, flow, local_label, span);
             } else {
                 final_stmt = try self.ast.addNode(.{
                     .tag = .expression_statement,
@@ -708,6 +709,7 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
             self: *Transformer,
             loop_call: NodeIndex,
             flow: *const FlowResult,
+            local_label: ?[]const u8,
             span: Span,
         ) Transformer.Error!NodeIndex {
             const scratch_top = self.scratch.items.len;
@@ -787,17 +789,23 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
                         .span = span,
                         .data = .{ .binary = .{ .left = ret_ref, .right = sentinel_str, .flags = @intFromEnum(token_mod.Kind.eq3) } },
                     });
-                    const label_span = try self.ast.addString(label);
-                    const label_node = try self.ast.addNode(.{
-                        .tag = .identifier_reference,
-                        .span = label_span,
-                        .data = .{ .string_ref = label_span },
-                    });
-                    const ctrl_tag: Tag = if (std.mem.eql(u8, kw, "break")) .break_statement else .continue_statement;
-                    const ctrl_stmt = try self.ast.addNode(.{
-                        .tag = ctrl_tag,
+                    const ctrl_stmt = if (local_label != null and std.mem.eql(u8, local_label.?, label)) blk: {
+                        const label_span = try self.ast.addString(label);
+                        const label_node = try self.ast.addNode(.{
+                            .tag = .identifier_reference,
+                            .span = label_span,
+                            .data = .{ .string_ref = label_span },
+                        });
+                        const ctrl_tag: Tag = if (std.mem.eql(u8, kw, "break")) .break_statement else .continue_statement;
+                        break :blk try self.ast.addNode(.{
+                            .tag = ctrl_tag,
+                            .span = span,
+                            .data = .{ .unary = .{ .operand = label_node, .flags = 0 } },
+                        });
+                    } else try self.ast.addNode(.{
+                        .tag = .return_statement,
                         .span = span,
-                        .data = .{ .unary = .{ .operand = label_node, .flags = 0 } },
+                        .data = .{ .unary = .{ .operand = sentinel_str, .flags = 0 } },
                     });
                     const if_ctrl = try self.ast.addNode(.{
                         .tag = .if_statement,

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -39,6 +39,7 @@ const Tag = Node.Tag;
 const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
 const es_helpers = @import("es_helpers.zig");
+const es2015_params = @import("es2015_params.zig");
 const es2022 = @import("es2022.zig");
 // #1752: 공용 helper 이름 모듈 (transformer → bundler 역의존 회피).
 const rt = @import("../runtime_helper_names.zig");
@@ -227,7 +228,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 switch (element) {
                     .field => |field| {
                         const class_ref = try es_helpers.makeIdentifierRefFromSpan(self, fresh_name_span);
-                        const static_assign = try buildStaticFieldAssignWithCtx(self, class_ref, field.key, field.init, fresh_name_span, span);
+                        const static_assign = try buildStaticFieldDefinePropertyWithCtx(self, class_ref, field.key, field.init, fresh_name_span, span);
                         try self.scratch.append(self.allocator, static_assign);
                     },
                     .stmt => |sb_stmt| try self.scratch.append(self.allocator, sb_stmt),
@@ -484,7 +485,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
             for (cm.static_elements.items) |element| {
                 switch (element) {
-                    .field => |field| try self.scratch.append(self.allocator, try buildStaticFieldAssignWithCtx(self, try es_helpers.makeIdentifierRefFromSpan(self, name_span), field.key, field.init, name_span, span)),
+                    .field => |field| try self.scratch.append(self.allocator, try buildStaticFieldDefinePropertyWithCtx(self, try es_helpers.makeIdentifierRefFromSpan(self, name_span), field.key, field.init, name_span, span)),
                     .stmt => |sb_stmt| try self.scratch.append(self.allocator, sb_stmt),
                 }
             }
@@ -1642,6 +1643,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             /// instance field init에 arrow this 캡처가 필요한 경우 true.
             /// super class 없는 class에서 var _this = this; 삽입에 사용.
             fields_need_this_alias: bool = false,
+            private_field_inits_emitted: usize = 0,
 
             fn deinit(cm: *ClassifiedMembers, allocator: std.mem.Allocator) void {
                 for (cm.private_fields.items) |pf| {
@@ -1666,17 +1668,36 @@ pub fn ES2015Class(comptime Transformer: type) type {
             }
         };
 
+        fn appendPrivateFieldInfo(self: *Transformer, cm: *ClassifiedMembers, key_node: Node, init_val: NodeIndex, is_static: bool) Transformer.Error!void {
+            // getText는 source_text 또는 string_table(Stage 3 생성 span)을 가리키는데,
+            // 후자는 후속 addString realloc으로 dangling된다 (#1481 · findPrivateFieldMapping 키).
+            const orig_name_owned = try self.allocator.dupe(u8, self.ast.getText(key_node.span));
+            try cm.synthesized_private_names.append(self.allocator, orig_name_owned);
+            const field_info = PrivateFieldInfo{
+                .name = try es_helpers.makePrivateVarName(self.allocator, orig_name_owned),
+                .original_name = orig_name_owned,
+                .init = init_val,
+            };
+            if (is_static) {
+                try cm.static_private_fields.append(self.allocator, field_info);
+            } else {
+                try cm.private_fields.append(self.allocator, field_info);
+            }
+        }
+
         /// private field init을 빌드하여 instance_fields에 추가.
         /// arrow function의 this 캡처를 감지하여 fields_need_this_alias 설정.
         fn appendPrivateFieldInits(self: *Transformer, cm: *ClassifiedMembers, span: Span) Transformer.Error!void {
             const saved_needs_this = self.needs_this_var;
-            for (cm.private_fields.items) |pf| {
+            if (cm.private_field_inits_emitted >= cm.private_fields.items.len) return;
+            for (cm.private_fields.items[cm.private_field_inits_emitted..]) |pf| {
                 const init_stmt = try buildPrivateFieldInit(self, pf.name, pf.init, span);
                 if (self.needs_this_var and !saved_needs_this) {
                     cm.fields_need_this_alias = true;
                 }
                 self.needs_this_var = saved_needs_this;
                 try cm.instance_fields.append(self.allocator, init_stmt);
+                cm.private_field_inits_emitted += 1;
             }
         }
 
@@ -1719,8 +1740,32 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 .private_methods = .empty,
             };
 
+            var private_scan_loop: u32 = 0;
+            while (private_scan_loop < members_len) : (private_scan_loop += 1) {
+                const raw_idx = self.ast.extra_data.items[members_start + private_scan_loop];
+                const member = self.ast.getNode(@enumFromInt(raw_idx));
+                if (member.tag != .property_definition) continue;
+                const pe = member.data.extra;
+                const key: NodeIndex = self.readNodeIdx(pe, PropertyExtra.key);
+                if (key.isNone()) continue;
+                const key_node = self.ast.getNode(key);
+                if (key_node.tag != .private_identifier) continue;
+                const init_val: NodeIndex = self.readNodeIdx(pe, PropertyExtra.init);
+                const flags = self.readU32(pe, PropertyExtra.flags);
+                const is_static = (flags & ast_mod.PropertyFlags.is_static) != 0;
+                try appendPrivateFieldInfo(self, &cm, key_node, init_val, is_static);
+            }
+
+            const saved_private_fields = self.current_private_fields;
+            const temp_private_count = try setupPrivateFieldMappings(self, &cm, class_name_span);
+            defer {
+                if (temp_private_count > 0) self.allocator.free(self.current_private_fields);
+                self.current_private_fields = saved_private_fields;
+            }
+
             // visitNode/addNode/buildFieldAssign이 extra_data를 재할당할 수 있으므로 인덱스 루프 사용
             var m_loop: u32 = 0;
+            var instance_private_field_idx: usize = 0;
             while (m_loop < members_len) : (m_loop += 1) {
                 const raw_idx = self.ast.extra_data.items[members_start + m_loop];
                 const member = self.ast.getNode(@enumFromInt(raw_idx));
@@ -1795,19 +1840,17 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     // private field (#x) → instance: WeakMap, static: descriptor 객체
                     const key_node = self.ast.getNode(key);
                     if (key_node.tag == .private_identifier) {
-                        // getText는 source_text 또는 string_table(Stage 3 생성 span)을 가리키는데,
-                        // 후자는 후속 addString realloc으로 dangling된다 (#1481 · findPrivateFieldMapping 키).
-                        const orig_name_owned = try self.allocator.dupe(u8, self.ast.getText(key_node.span));
-                        try cm.synthesized_private_names.append(self.allocator, orig_name_owned);
-                        const field_info = PrivateFieldInfo{
-                            .name = try es_helpers.makePrivateVarName(self.allocator, orig_name_owned),
-                            .original_name = orig_name_owned,
-                            .init = init_val,
-                        };
-                        if (is_static) {
-                            try cm.static_private_fields.append(self.allocator, field_info);
-                        } else {
-                            try cm.private_fields.append(self.allocator, field_info);
+                        if (!is_static and instance_private_field_idx < cm.private_fields.items.len) {
+                            const saved_needs_this = self.needs_this_var;
+                            const pf = cm.private_fields.items[instance_private_field_idx];
+                            instance_private_field_idx += 1;
+                            const init_stmt = try buildPrivateFieldInit(self, pf.name, pf.init, span);
+                            if (self.needs_this_var and !saved_needs_this) {
+                                cm.fields_need_this_alias = true;
+                            }
+                            self.needs_this_var = saved_needs_this;
+                            try cm.instance_fields.append(self.allocator, init_stmt);
+                            cm.private_field_inits_emitted += 1;
                         }
                         continue;
                     }
@@ -2193,7 +2236,31 @@ pub fn ES2015Class(comptime Transformer: type) type {
             });
         }
 
-        fn buildStaticFieldAssignWithCtx(self: *Transformer, obj: NodeIndex, key_idx: NodeIndex, init_idx: NodeIndex, class_name_span: Span, span: Span) Transformer.Error!NodeIndex {
+        fn buildStaticFieldDefineProperty(self: *Transformer, obj: NodeIndex, key_idx: NodeIndex, init_idx: NodeIndex, span: Span) Transformer.Error!NodeIndex {
+            const new_init = try self.visitNode(init_idx);
+            const config_prop = try buildBooleanProp(self, "configurable", true, span);
+            const enumerable_prop = try buildBooleanProp(self, "enumerable", true, span);
+            const writable_prop = try buildBooleanProp(self, "writable", true, span);
+            const value_prop = try buildValueProp(self, new_init, span);
+            const desc_list = try self.ast.addNodeList(&.{ config_prop, enumerable_prop, writable_prop, value_prop });
+            const desc_obj = try self.ast.addNode(.{
+                .tag = .object_expression,
+                .span = span,
+                .data = .{ .list = desc_list },
+            });
+
+            const obj_str_span = try self.ast.addString("Object");
+            const dp_str_span = try self.ast.addString("defineProperty");
+            const key_arg = try es_helpers.buildDefinePropertyKeyArg(self, key_idx);
+            const call = try es_helpers.buildObjectDefinePropertyCall(self, obj_str_span, dp_str_span, obj, key_arg, desc_obj, span);
+            return self.ast.addNode(.{
+                .tag = .expression_statement,
+                .span = span,
+                .data = .{ .unary = .{ .operand = call, .flags = 0 } },
+            });
+        }
+
+        fn buildStaticFieldDefinePropertyWithCtx(self: *Transformer, obj: NodeIndex, key_idx: NodeIndex, init_idx: NodeIndex, class_name_span: Span, span: Span) Transformer.Error!NodeIndex {
             const saved_static = self.current_super_is_static;
             const saved_receiver = self.current_super_static_receiver;
             const saved_class_name = self.static_block_class_name;
@@ -2208,7 +2275,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 self.static_block_class_name = saved_class_name;
                 self.this_depth = saved_this_depth;
             }
-            return buildFieldAssign(self, obj, key_idx, init_idx, span);
+            return buildStaticFieldDefineProperty(self, obj, key_idx, init_idx, span);
         }
 
         /// function_declaration의 body 앞에 문들을 삽입 (in-place).
@@ -2248,7 +2315,12 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
             // TS parameter property(`constructor(public x)`)는 modifier 만 strip 되어 일반 형태로 visit 되지만,
             // 이 경로는 visitMethodDefinition 을 거치지 않으므로 `this.x = x` 삽입을 직접 수행해야 함 (#1471).
-            const pp = try self.visitParamsCollectProperties(params_list_old);
+            var pp = try self.visitParamsCollectProperties(params_list_old);
+            var param_lowering: ?es2015_params.ES2015Params(Transformer).LowerResult = null;
+            if (es2015_params.ES2015Params(Transformer).hasDefaultOrRest(self, pp.new_params)) {
+                param_lowering = try es2015_params.ES2015Params(Transformer).lowerParamsPass2(self, pp.new_params, span);
+            }
+            defer if (param_lowering) |*lr| lr.body_stmts.deinit(self.allocator);
 
             // new.target: class constructor → function_named (ES5 class 변환 후 일반 함수)
             const saved_new_target_ctx = self.new_target_ctx;
@@ -2258,6 +2330,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
             defer self.new_target_ctx = saved_new_target_ctx;
 
             var new_body = try visitMethodBody(self, body_idx, span);
+
+            const lowered_params = if (param_lowering) |lr| lr.new_params else pp.new_params;
+            const param_stmts = if (param_lowering) |lr| lr.body_stmts.items else &[_]NodeIndex{};
 
             if (is_derived) {
                 // derived class 의 parameter property `this.x = x` 는 super() 이후에 와야 한다.
@@ -2272,18 +2347,25 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     for (pp_stmts) |raw_idx| try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
                     for (instance_fields) |f| try self.scratch.append(self.allocator, f);
                     try transformDerivedConstructorReturns(self, new_body);
-                    new_body = try postProcessDerivedConstructorBody(self, new_body, self.scratch.items[scratch_top..], span);
+                    new_body = try postProcessDerivedConstructorBody(self, new_body, param_stmts, self.scratch.items[scratch_top..], span);
                 } else {
                     try transformDerivedConstructorReturns(self, new_body);
-                    new_body = try postProcessDerivedConstructorBody(self, new_body, instance_fields, span);
+                    new_body = try postProcessDerivedConstructorBody(self, new_body, param_stmts, instance_fields, span);
                 }
-            } else if (pp.prop_count > 0 and !new_body.isNone()) {
-                // base class: super() 가 없으므로 body 앞에 `this.x = x` prepend.
-                new_body = try self.insertParameterPropertyAssignments(new_body, pp.prop_names[0..pp.prop_count]);
+            } else if ((param_stmts.len > 0 or pp.prop_count > 0) and !new_body.isNone()) {
+                const scratch_top = self.scratch.items.len;
+                defer self.scratch.shrinkRetainingCapacity(scratch_top);
+                for (param_stmts) |stmt| try self.scratch.append(self.allocator, stmt);
+                if (pp.prop_count > 0) {
+                    const pp_stmts_list = try self.buildParameterPropertyStatements(pp.prop_names[0..pp.prop_count]);
+                    const pp_stmts = self.ast.extra_data.items[pp_stmts_list.start .. pp_stmts_list.start + pp_stmts_list.len];
+                    for (pp_stmts) |raw_idx| try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
+                }
+                new_body = try self.prependStatementsToBody(new_body, self.scratch.items[scratch_top..]);
             }
 
             const none = @intFromEnum(NodeIndex.none);
-            const new_params_node = try self.ast.addFormalParameters(pp.new_params, span);
+            const new_params_node = try self.ast.addFormalParameters(lowered_params, span);
             const func_extra = try self.ast.addExtras(&.{
                 @intFromEnum(name),
                 @intFromEnum(new_params_node),
@@ -2384,7 +2466,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
         /// ES6 스펙: class fields는 super() 직후, constructor body 이전에 초기화.
         /// lowerSuperCall이 _this = __callSuper(...) 대입식을 생성하므로,
         /// 해당 대입식을 포함하는 statement를 찾아 그 직후에 fields를 삽입한다.
-        fn postProcessDerivedConstructorBody(self: *Transformer, body: NodeIndex, instance_fields: []const NodeIndex, span: Span) Transformer.Error!NodeIndex {
+        fn postProcessDerivedConstructorBody(self: *Transformer, body: NodeIndex, param_stmts: []const NodeIndex, instance_fields: []const NodeIndex, span: Span) Transformer.Error!NodeIndex {
             const body_node = self.ast.getNode(body);
             if (body_node.tag != .block_statement) return body;
 
@@ -2408,6 +2490,14 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
             // var _this; (초기화 없는 선언) — extra_data grow 가능
             try self.scratch.append(self.allocator, try self.buildVarDecl("_this", .none, span));
+
+            for (param_stmts) |stmt| {
+                if (containsSuperCallAssignment(self, stmt)) {
+                    try self.scratch.append(self.allocator, try insertInstanceFieldsAfterSuper(self, stmt, instance_fields, span));
+                } else {
+                    try self.scratch.append(self.allocator, stmt);
+                }
+            }
 
             for (self.ast.extra_data.items[stmts_start .. stmts_start + stmts_len]) |raw_idx| {
                 const stmt_idx: NodeIndex = @enumFromInt(raw_idx);
@@ -2636,6 +2726,24 @@ pub fn ES2015Class(comptime Transformer: type) type {
                         .flags = node.data.binary.flags,
                     } },
                 }),
+                .logical_expression => return self.ast.addNode(.{
+                    .tag = .logical_expression,
+                    .span = node.span,
+                    .data = .{ .binary = .{
+                        .left = try injectInstanceFieldsAfterSuperExpr(self, node.data.binary.left, instance_fields, span),
+                        .right = try injectInstanceFieldsAfterSuperExpr(self, node.data.binary.right, instance_fields, span),
+                        .flags = node.data.binary.flags,
+                    } },
+                }),
+                .assignment_expression => return self.ast.addNode(.{
+                    .tag = .assignment_expression,
+                    .span = node.span,
+                    .data = .{ .binary = .{
+                        .left = try injectInstanceFieldsAfterSuperExpr(self, node.data.binary.left, instance_fields, span),
+                        .right = try injectInstanceFieldsAfterSuperExpr(self, node.data.binary.right, instance_fields, span),
+                        .flags = node.data.binary.flags,
+                    } },
+                }),
                 .spread_element, .computed_property_key => return self.ast.addNode(.{
                     .tag = node.tag,
                     .span = node.span,
@@ -2739,14 +2847,21 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     return containsSuperCallAssignment(self, node.data.binary.left) or
                         containsSuperCallAssignment(self, node.data.binary.right);
                 },
+                .logical_expression => {
+                    return containsSuperCallAssignment(self, node.data.binary.left) or
+                        containsSuperCallAssignment(self, node.data.binary.right);
+                },
                 .spread_element, .computed_property_key => {
                     return containsSuperCallAssignment(self, node.data.unary.operand);
                 },
                 .assignment_expression => {
                     const left = self.ast.getNode(node.data.binary.left);
-                    if (left.tag != .identifier_reference and left.tag != .assignment_target_identifier) return false;
                     const right = self.ast.getNode(node.data.binary.right);
-                    return isSuperCallLike(self, right);
+                    if ((left.tag == .identifier_reference or left.tag == .assignment_target_identifier) and isSuperCallLike(self, right)) {
+                        return true;
+                    }
+                    return containsSuperCallAssignment(self, node.data.binary.left) or
+                        containsSuperCallAssignment(self, node.data.binary.right);
                 },
                 .if_statement, .conditional_expression => {
                     if (containsSuperCallAssignment(self, node.data.ternary.b)) return true;

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -114,6 +114,8 @@ pub fn ES2015Class(comptime Transformer: type) type {
             var cm = try classifyMembers(self, body_idx, span, name_span);
             defer cm.deinit(self.allocator);
 
+            // classifyMembers 안의 inner 매핑은 main loop visit 동안만 유효 (accessor_property 가
+            // 추가하는 backing private 은 그 매핑에 빠져 있음). 여기서 외부 lifetime 으로 다시 build.
             const saved_private_fields = self.current_private_fields;
             const total_private = try setupPrivateFieldMappings(self, &cm, name_span);
             defer {
@@ -349,6 +351,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             var cm = try classifyMembers(self, body_idx, span, name_span);
             defer cm.deinit(self.allocator);
 
+            // 외부 lifetime 매핑 — accessor_property 가 main loop 에서 추가한 backing private 까지 포함.
             const saved_private_fields = self.current_private_fields;
             const total_private_ce = try setupPrivateFieldMappings(self, &cm, name_span);
             defer {
@@ -1643,6 +1646,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
             /// instance field init에 arrow this 캡처가 필요한 경우 true.
             /// super class 없는 class에서 var _this = this; 삽입에 사용.
             fields_need_this_alias: bool = false,
+            /// main loop 가 source order 로 emit 한 instance private field init 의 개수.
+            /// `appendPrivateFieldInits` 가 이 다음 인덱스부터 (accessor_property 가 추가한 backing 등)
+            /// 마저 emit 하기 위한 cursor. 두 emission 사이트의 좌표 (#1287 follow-up).
             private_field_inits_emitted: usize = 0,
 
             fn deinit(cm: *ClassifiedMembers, allocator: std.mem.Allocator) void {
@@ -1685,11 +1691,13 @@ pub fn ES2015Class(comptime Transformer: type) type {
             }
         }
 
-        /// private field init을 빌드하여 instance_fields에 추가.
-        /// arrow function의 this 캡처를 감지하여 fields_need_this_alias 설정.
+        /// classifyMembers main loop 가 emit 하지 못한 instance private field init 을 마저 emit.
+        /// 주로 `classifyAccessorProperty` 가 main loop 안에서 `cm.private_fields` 에 추가로 넣은
+        /// accessor backing (`#_x_acc` 등) 이 대상. 카운터 `private_field_inits_emitted` 가 main loop 가
+        /// 이미 처리한 instance private 의 개수를 가리키므로 그 인덱스부터 끝까지가 미emit 분이다.
         fn appendPrivateFieldInits(self: *Transformer, cm: *ClassifiedMembers, span: Span) Transformer.Error!void {
-            const saved_needs_this = self.needs_this_var;
             if (cm.private_field_inits_emitted >= cm.private_fields.items.len) return;
+            const saved_needs_this = self.needs_this_var;
             for (cm.private_fields.items[cm.private_field_inits_emitted..]) |pf| {
                 const init_stmt = try buildPrivateFieldInit(self, pf.name, pf.init, span);
                 if (self.needs_this_var and !saved_needs_this) {
@@ -1740,6 +1748,10 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 .private_methods = .empty,
             };
 
+            // pre-scan: private field info 를 main loop 앞에서 모은다. method/field body 안의 #x 참조를
+            // visitNode 가 lowering 하려면 self.current_private_fields 가 미리 채워져 있어야 한다 — 후속
+            // setupPrivateFieldMappings 가 cm.private_fields / cm.static_private_fields 를 참조해 매핑을 빌드하므로
+            // 여기서 정보만 수집해 둔다. emission 자체는 main loop 가 source order 로 처리.
             var private_scan_loop: u32 = 0;
             while (private_scan_loop < members_len) : (private_scan_loop += 1) {
                 const raw_idx = self.ast.extra_data.items[members_start + private_scan_loop];
@@ -1756,6 +1768,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 try appendPrivateFieldInfo(self, &cm, key_node, init_val, is_static);
             }
 
+            // inner 매핑 set up: main loop 가 [computed_key] = this.#priv 같은 init 을 visit 할 때 #priv 가
+            // current_private_fields 에 있어야 lowering 됨. accessor_property 는 main loop 가 진행되며
+            // cm.private_fields 에 더 추가하므로, 여기 매핑은 일시적이고 caller 가 outer lifetime 으로 다시 build 한다.
             const saved_private_fields = self.current_private_fields;
             const temp_private_count = try setupPrivateFieldMappings(self, &cm, class_name_span);
             defer {
@@ -1837,7 +1852,11 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     const flags = self.readU32(pe, PropertyExtra.flags);
                     const is_static = (flags & ast_mod.PropertyFlags.is_static) != 0;
 
-                    // private field (#x) → instance: WeakMap, static: descriptor 객체
+                    // private field (#x) 는 pre-scan 에서 cm.private_fields 에 수집됐다.
+                    // 여기서는 source order 에 맞춰 instance_fields 에 init 을 emit —
+                    // 같은 클래스의 public field init (`[k()]=this.#v`) 보다 앞 위치에서 visit 되도록.
+                    // 후속 `appendPrivateFieldInits` 가 카운터 (`private_field_inits_emitted`) 를 보고
+                    // 이미 emit 된 만큼 skip 하고, 메인 루프가 못 본 accessor backing 만 처리한다.
                     const key_node = self.ast.getNode(key);
                     if (key_node.tag == .private_identifier) {
                         if (!is_static and instance_private_field_idx < cm.private_fields.items.len) {
@@ -2236,6 +2255,10 @@ pub fn ES2015Class(comptime Transformer: type) type {
             });
         }
 
+        /// `Object.defineProperty(Class, key, { configurable: true, enumerable: true, writable: true, value: init })`.
+        /// 단순 `Class.key = init` 대입 대신 [[DefineOwnProperty]] 시맨틱이 필요한 이유 — TC39
+        /// `ClassFieldDefinitionEvaluation` 은 항상 fresh data descriptor 를 install 한다. 예: `static name = "Custom"`
+        /// 의 경우 Function.prototype 으로부터 상속된 `name` 슬롯이 non-writable 이라 단순 대입은 strict mode 에서 throw 한다.
         fn buildStaticFieldDefineProperty(self: *Transformer, obj: NodeIndex, key_idx: NodeIndex, init_idx: NodeIndex, span: Span) Transformer.Error!NodeIndex {
             const new_init = try self.visitNode(init_idx);
             const config_prop = try buildBooleanProp(self, "configurable", true, span);

--- a/src/transformer/es2015_for_of.zig
+++ b/src/transformer/es2015_for_of.zig
@@ -192,12 +192,17 @@ pub fn ES2015ForOf(comptime Transformer: type) type {
                     flow.labels = .empty;
                     defer flow.labels.deinit(self.allocator);
                     BlockScoping.analyzeControlFlow(self, body, &flow, 0, 0);
+                    const local_label = if (label_name_idx.isNone())
+                        null
+                    else
+                        self.ast.getText(self.ast.getNode(label_name_idx).span);
 
                     const result = try BlockScoping.buildLoopClosureWithFlow(
                         self,
                         new_body,
                         lexical_names.items,
                         &flow,
+                        local_label,
                         span,
                     );
                     loop_fn_decl = result.loop_fn;

--- a/src/transformer/es2020.zig
+++ b/src/transformer/es2020.zig
@@ -465,6 +465,14 @@ pub fn ES2020(comptime Transformer: type) type {
         }
 
         fn makeThisOrAlias(self: *Transformer, span: Span) Transformer.Error!NodeIndex {
+            if (self.current_super_is_static) {
+                const receiver_span = self.current_super_static_receiver orelse return self.ast.addNode(.{
+                    .tag = .this_expression,
+                    .span = span,
+                    .data = .{ .none = 0 },
+                });
+                return helpers.makeIdentifierRefFromSpan(self, receiver_span);
+            }
             if (self.options.unsupported.arrow and self.arrow_this_depth > 0) {
                 self.needs_this_var = true;
                 return helpers.makeIdentifierRef(self, "_this");

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -401,6 +401,7 @@ pub fn ES2022(comptime Transformer: type) type {
             while (j < body_len) : (j += 1) {
                 const raw_idx = self.ast.extra_data.items[body_start + j];
                 const member_idx: NodeIndex = @enumFromInt(raw_idx);
+                const member = self.ast.getNode(member_idx);
 
                 if (method_mapping_idx < method_mappings.items.len and
                     @intFromEnum(method_mappings.items[method_mapping_idx].member_idx) == raw_idx)
@@ -424,6 +425,27 @@ pub fn ES2022(comptime Transformer: type) type {
                         try ctor_init_stmts.append(self.allocator, init_stmt);
                     }
                     continue;
+                }
+
+                if (lower_fields and member.tag == .property_definition) {
+                    const pe = member.data.extra;
+                    const key: NodeIndex = self.readNodeIdx(pe, ast_mod.PropertyExtra.key);
+                    const flags = self.readU32(pe, ast_mod.PropertyExtra.flags);
+                    const is_static = (flags & ast_mod.PropertyFlags.is_static) != 0;
+                    if (!is_static and !key.isNone()) {
+                        const key_node = self.ast.getNode(key);
+                        if (key_node.tag != .private_identifier) {
+                            const lowered_key = if (key_node.tag == .computed_property_key) blk: {
+                                const memo = try es_helpers.memoizeComputedKey(self, key_node.data.unary.operand, member.span);
+                                try pre_stmts.append(self.allocator, memo.decl);
+                                break :blk memo.computed_key;
+                            } else key;
+                            const init_val: NodeIndex = self.readNodeIdx(pe, ast_mod.PropertyExtra.init);
+                            const init_stmt = try buildPublicFieldSetInit(self, lowered_key, init_val, span);
+                            try ctor_init_stmts.append(self.allocator, init_stmt);
+                            continue;
+                        }
+                    }
                 }
 
                 const new_member = try self.visitNode(member_idx);
@@ -459,6 +481,22 @@ pub fn ES2022(comptime Transformer: type) type {
                 .data = .{ .list = new_list },
             });
             return true;
+        }
+
+        fn buildPublicFieldSetInit(self: *Transformer, key_idx: NodeIndex, init_idx: NodeIndex, span: Span) Transformer.Error!NodeIndex {
+            const this_node = try self.ast.addNode(.{
+                .tag = .this_expression,
+                .span = span,
+                .data = .{ .none = 0 },
+            });
+            const member = try es_helpers.makeMemberFromKeyIdx(self, this_node, key_idx, span);
+            const init = if (init_idx.isNone()) try es_helpers.makeVoidZero(self, span) else try self.visitNode(init_idx);
+            const assign = try self.ast.addNode(.{
+                .tag = .assignment_expression,
+                .span = span,
+                .data = .{ .binary = .{ .left = member, .right = init, .flags = 0 } },
+            });
+            return es_helpers.makeExprStmt(self, assign, span);
         }
 
         /// 빈 constructor method_definition에 init_stmts를 넣어 생성.

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -4086,6 +4086,7 @@ pub const Transformer = struct {
                         new_body,
                         lexical_names.items,
                         &flow,
+                        null,
                         node.span,
                     );
 


### PR DESCRIPTION
## 요약
- 최신 main 기준 추가 syntax/runtime audit에서 발견된 변환 회귀를 루트 경로에서 수정했습니다.
- derived constructor `super()`가 logical/default-param/assignment/conditional 경로에 있을 때 instance field init이 빠지지 않도록 super-call walker를 보강했습니다.
- public static field lowering을 assignment 대신 `Object.defineProperty` 기반으로 바꿔 `static name` 같은 read-only 함수 프로퍼티 충돌을 피했습니다.
- static field initializer의 optional `super[expr]?.()` receiver를 class receiver로 보존했습니다.
- private field lowering 시 public field/static block/optional chain/object rest와의 순서 및 key 변환을 보정했습니다.
- 중첩 loop closure의 labeled continue/break sentinel 전파를 보정했습니다.
- 발견된 케이스를 `scripts/syntax-audit.mjs`와 관련 Zig 테스트에 회귀 커버리지로 추가했습니다.

## 검증
- 최신 `origin/main` 위로 rebase 후 `git rev-list --left-right --count origin/main...HEAD` = `0 1`
- `zig build -Doptimize=ReleaseFast`
- `node scripts/syntax-audit.mjs`
- `cd tests/integration && bun test tests/downlevel-edge.test.ts --timeout 600000`
- `zig build test --summary all`
- `bunx oxlint scripts/syntax-audit.mjs`
- `bunx oxfmt --check scripts/syntax-audit.mjs`
- push pre-push hook 통과

## 메모
- pre-push의 unused import 5개는 기존 warning-only 상태입니다.