### PR TITLE
chore: post-Round 4 simplify findings 적용

### DIFF
--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -1313,12 +1313,16 @@ fn extractCssTemplateIdx(self: *Transformer, css_value_idx: NodeIndex) ?NodeInde
 /// `<X css={...}>` JSX prop 을 styled component 추출 시도. MVP: intrinsic tag +
 /// template_literal 또는 `css\`\`` tagged template + styled default_binding 존재 시.
 /// 미매칭 시 null 반환.
+/// auto-inject 시 사용할 styled default binding 이름. 사용자 코드에 같은 이름의 다른
+/// 선언 (`const styled = ...` 같은 module-scope 변수) 이 있으면 prepended import 와 충돌 —
+/// babel 처럼 unique mangling 은 미적용. follow-up: collision detection + `_styled` fallback.
+const DEFAULT_STYLED_BINDING = "styled";
+
 pub fn maybeExtractCssProp(self: *Transformer, jsx_node: ast_mod.Node) Error!?ast_mod.Node {
     if (!self.options.styled_components or !self.options.styled_components_css_prop) return null;
     if (jsx_node.tag != .jsx_element) return null;
-    // styled binding: 사용자 import 가 있으면 그 이름, 없으면 "styled" 사용 + auto-inject flag.
-    // transpile.zig 가 flag 보고 program 시작에 `import styled from "styled-components"` prepend.
-    const default_binding: []const u8 = self.plugins.styled_components.default_binding orelse "styled";
+    // 사용자 import 가 있으면 그 이름, 없으면 DEFAULT_STYLED_BINDING + auto-inject flag.
+    const default_binding: []const u8 = self.plugins.styled_components.default_binding orelse DEFAULT_STYLED_BINDING;
 
     const e = jsx_node.data.extra;
     const tag_name_idx = self.readNodeIdx(e, 0);
@@ -1379,7 +1383,8 @@ pub fn maybeExtractCssProp(self: *Transformer, jsx_node: ast_mod.Node) Error!?as
     state.css_prop_counter += 1;
 
     var name_buf: [64]u8 = undefined;
-    const generated_name = std.fmt.bufPrint(&name_buf, "_styled_{d}", .{counter}) catch return null;
+    // `_styled_<u32>` 최대 길이 18 bytes — 64 byte buffer 에 항상 fit (overflow 불가).
+    const generated_name = std.fmt.bufPrint(&name_buf, "_styled_{d}", .{counter}) catch unreachable;
     const generated_span = try self.ast.addString(generated_name);
     const zero = Span{ .start = 0, .end = 0 };
 

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -342,6 +342,19 @@ pub const TranspileResult = struct {
     }
 };
 
+/// `prefix` 가 null/빈 문자열이면 `body` 그대로, 아니면 `prefix + body` 의 새 buffer 반환.
+/// OOM 시 fallback 으로 body 그대로 반환 (transpile output 보존). JSX/cssProp 의 module-level
+/// import auto-inject 둘 다 같은 모양이라 공유.
+fn prependImportLine(allocator: std.mem.Allocator, prefix: ?[]const u8, body: []const u8) []const u8 {
+    const p = prefix orelse return body;
+    if (p.len == 0) return body;
+    var combined: std.ArrayList(u8) = .empty;
+    combined.ensureTotalCapacity(allocator, p.len + body.len) catch return body;
+    combined.appendSliceAssumeCapacity(p);
+    combined.appendSliceAssumeCapacity(body);
+    return combined.items;
+}
+
 /// 소스 문자열을 트랜스파일한다. I/O 없음, 순수 함수.
 ///
 /// file_path는 확장자 감지용으로만 사용 (실제 파일 읽기 안 함).
@@ -534,27 +547,19 @@ pub fn transpileWithCallback(
     const raw_output = cg.generate(root) catch return error.CodegenError;
 
     // 6.5. JSX import prepend (transformer가 JSX lowering 수행한 경우)
-    const jsx_output = if (transformer.jsx_import_info.hasImports()) blk: {
+    const jsx_import_str: ?[]const u8 = if (transformer.jsx_import_info.hasImports()) blk: {
         const is_dev = options.jsx_runtime == .automatic_dev;
-        if (transformer.jsx_import_info.buildImportString(arena_alloc, options.jsx_import_source, is_dev)) |import_str| {
-            var combined: std.ArrayList(u8) = .empty;
-            combined.ensureTotalCapacity(arena_alloc, import_str.len + raw_output.len) catch break :blk raw_output;
-            combined.appendSliceAssumeCapacity(import_str);
-            combined.appendSliceAssumeCapacity(raw_output);
-            break :blk combined.items;
-        } else break :blk raw_output;
-    } else raw_output;
+        break :blk transformer.jsx_import_info.buildImportString(arena_alloc, options.jsx_import_source, is_dev);
+    } else null;
+    const jsx_output = prependImportLine(arena_alloc, jsx_import_str, raw_output);
 
     // 6.6. styled-components cssProp auto-inject — 사용자 코드에 styled import 가 없는데
     // cssProp transform 이 일어난 경우 program 시작에 `import styled from "styled-components"`.
-    const css_prop_output = if (transformer.plugins.styled_components.css_prop_needs_import) blk: {
-        const styled_import = "import styled from \"styled-components\";\n";
-        var combined: std.ArrayList(u8) = .empty;
-        combined.ensureTotalCapacity(arena_alloc, styled_import.len + jsx_output.len) catch break :blk jsx_output;
-        combined.appendSliceAssumeCapacity(styled_import);
-        combined.appendSliceAssumeCapacity(jsx_output);
-        break :blk combined.items;
-    } else jsx_output;
+    const css_prop_import: ?[]const u8 = if (transformer.plugins.styled_components.css_prop_needs_import)
+        "import styled from \"styled-components\";\n"
+    else
+        null;
+    const css_prop_output = prependImportLine(arena_alloc, css_prop_import, jsx_output);
 
     // 7. 런타임 헬퍼 prepend
     const rh = transformer.runtime_helpers;


### PR DESCRIPTION
## Summary
본 세션 cssProp 시리즈 7 PR (#2278~#2284) 머지 시 simplify 생략 (CLAUDE.md "PR 올리기 전 /simplify 필수" 위반). 머지된 변경 통합으로 retroactive 검토 후 3 finding fix.

## 변경
- **`src/transpile.zig`** — `prependImportLine(allocator, prefix, body)` helper 추출. 6.5 (jsx import) + 6.6 (cssProp import) 의 prepend 코드 통합.
- **`src/transformer/transformer/styled_components.zig`**:
  - `bufPrint catch return null` → `catch unreachable` (`_styled_<u32>` max 18 bytes < 64 buffer)
  - `"styled"` magic string → `DEFAULT_STYLED_BINDING` const + collision 위험 주석

## Skipped findings (정당화)
- attrs lookup helper 통합: `findKeyAttr` (jsx_lowering generic Transformer) 와 cssProp 의 attrs loop pattern 호환성 떨어짐
- `maybeExtractCssProp` 분리: 200 LoC linear flow, 잘 sectioned — 분리 비용 > 이득

## Test plan
- [x] `zig build test` Debug
- [x] `zig build test -Doptimize=ReleaseFast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)