### PR TITLE
feat(util): picomatch 호환 glob — multi `*` + `?` + bracket + brace

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -336,9 +336,9 @@ export interface StyledComponentsOptions {
    */
   meaninglessFileNames?: string[];
   /**
-   * vendored fork (e.g. `@my-org/styled`, `@my-org/*`) 도 styled-components 처럼 인식할
-   * import source 목록. 단일 `*` glob 지원 — picomatch 풀 스펙 (multi `*`, `?`, `[]`,
-   * brace expansion) 은 미지원.
+   * vendored fork 인식할 import source 목록 (e.g. `@my-org/styled`, `@my-org/*`,
+   * `@{my-org,co}/*`). picomatch 호환 glob — `*`, `?`, `[abc]`/`[a-z]`/`[!abc]`,
+   * `{a,b}` (nested 가능).
    */
   topLevelImportPaths?: string[];
   /**

--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -1280,6 +1280,24 @@ test "styled (topLevelImportPaths): glob `@my-org/*` 도 vendored fork 매칭" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") != null);
 }
 
+test "styled (topLevelImportPaths): brace expansion 매칭" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\import styled from "@my-org/styled";
+        \\const Btn = styled.div`color: red;`;
+    ,
+        .{
+            .styled_components = true,
+            .styled_components_top_level_import_paths = &.{"@{my-org,co}/*"},
+            .jsx_filename = "test.tsx",
+        },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "withConfig") != null);
+}
+
 test "styled (topLevelImportPaths): glob 미매칭 fork 는 무시" {
     var r = try e2eFull(
         std.testing.allocator,

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -149,9 +149,9 @@ pub const TransformOptions = struct {
     /// basename 이 의미 없는 이름 (default `index`) 이면 parent dir 명으로 fallback.
     /// babel-plugin-styled-components 의 동일 옵션과 동등 — 빈 array 면 fallback 비활성.
     styled_components_meaningless_file_names: []const []const u8 = &.{"index"},
-    /// styled-components.topLevelImportPaths 옵션 — vendored fork (e.g. `@my-org/styled`,
-    /// `@my-org/*`) 도 styled-components import 처럼 인식. 단일 `*` glob 지원 — picomatch
-    /// 풀 스펙 (multi `*`, `?`, `[]`, brace expansion) 은 미지원.
+    /// styled-components.topLevelImportPaths 옵션 — vendored fork 인식 (e.g. `@my-org/styled`,
+    /// `@my-org/*`, `@{my-org,co}/*`). picomatch 호환 glob: `*` (0+ chars), `?` (1 char),
+    /// `[abc]`/`[a-z]`/`[!abc]` (bracket class + negation), `{a,b}` (brace expansion, nested).
     styled_components_top_level_import_paths: []const []const u8 = &.{},
     /// styled-components.cssProp 옵션 — `<div css={...}>` JSX prop 을 module-level
     /// hoisted styled component 로 추출. babel-plugin-styled-components default true 와

--- a/src/util/string_list.zig
+++ b/src/util/string_list.zig
@@ -11,18 +11,114 @@ pub fn contains(list: []const []const u8, needle: []const u8) bool {
     return false;
 }
 
-/// 단일 `*` wildcard glob 매칭 — `prefix*suffix` 형태 1 회만 지원. picomatch 풀 스펙
-/// (multi `*`, `?`, `[]`, brace expansion) 까진 안 감 — 대부분의 vendored fork 사용
-/// 케이스 (`@my-org/*`, `*-styled`) 커버. `*` 미포함 시 정확 일치.
+/// picomatch 호환 glob 매칭 — `*` (0+ chars), `?` (1 char), `[abc]`/`[a-z]`/`[!abc]`
+/// (bracket class + negation), `{a,b,c}` (brace expansion, nested 가능). path-segment
+/// `/` 는 일반 char 로 취급 — npm package 이름 매칭 use case 라 picomatch 의 segment
+/// 경계 동작 (`*` 가 `/` 못 넘음) 은 disable.
 pub fn matchesGlob(pattern: []const u8, source: []const u8) bool {
-    const star_pos = std.mem.indexOfScalar(u8, pattern, '*') orelse {
-        return std.mem.eql(u8, pattern, source);
-    };
-    const prefix = pattern[0..star_pos];
-    const suffix = pattern[star_pos + 1 ..];
-    if (source.len < prefix.len + suffix.len) return false;
-    if (!std.mem.startsWith(u8, source, prefix)) return false;
-    return std.mem.endsWith(u8, source, suffix);
+    return matchesGlobInternal(pattern, source);
+}
+
+/// brace expansion 처리 후 simple glob 매칭. 비-nested `{a,b}` 가 가장 단순. nested 는
+/// 재귀. 합성된 alt 가 길 수 있어 stack-allocated buffer 사용 (실용 패턴 < 512 bytes).
+fn matchesGlobInternal(pattern: []const u8, source: []const u8) bool {
+    if (std.mem.indexOfScalar(u8, pattern, '{')) |open| {
+        const close = findMatchingBrace(pattern, open) orelse return matchSimple(pattern, source);
+        const prefix = pattern[0..open];
+        const suffix = pattern[close + 1 ..];
+        const inner = pattern[open + 1 .. close];
+
+        var buf: [512]u8 = undefined;
+        var alt_start: usize = 0;
+        var depth: usize = 0;
+        var i: usize = 0;
+        while (i <= inner.len) : (i += 1) {
+            const at_end = i == inner.len;
+            const c: u8 = if (at_end) ',' else inner[i];
+            if (!at_end and c == '{') depth += 1;
+            if (!at_end and c == '}') depth -= 1;
+            const at_split = (c == ',' and depth == 0) or at_end;
+            if (!at_split) continue;
+            const alt = inner[alt_start..i];
+            const total = prefix.len + alt.len + suffix.len;
+            if (total <= buf.len) {
+                @memcpy(buf[0..prefix.len], prefix);
+                @memcpy(buf[prefix.len..][0..alt.len], alt);
+                @memcpy(buf[prefix.len + alt.len ..][0..suffix.len], suffix);
+                if (matchesGlobInternal(buf[0..total], source)) return true;
+            }
+            alt_start = i + 1;
+        }
+        return false;
+    }
+    return matchSimple(pattern, source);
+}
+
+/// `{` 와 매칭되는 `}` 위치 (nested brace 고려). 미발견 시 null.
+fn findMatchingBrace(pattern: []const u8, open: usize) ?usize {
+    var depth: usize = 1;
+    var i: usize = open + 1;
+    while (i < pattern.len) : (i += 1) {
+        switch (pattern[i]) {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if (depth == 0) return i;
+            },
+            else => {},
+        }
+    }
+    return null;
+}
+
+/// brace 없는 패턴의 backtracking 매칭 — `*`, `?`, `[...]` 처리.
+fn matchSimple(pattern: []const u8, source: []const u8) bool {
+    var pi: usize = 0;
+    var si: usize = 0;
+    while (pi < pattern.len) {
+        const c = pattern[pi];
+        switch (c) {
+            '*' => {
+                pi += 1;
+                if (pi == pattern.len) return true;
+                while (si <= source.len) : (si += 1) {
+                    if (matchSimple(pattern[pi..], source[si..])) return true;
+                }
+                return false;
+            },
+            '?' => {
+                if (si >= source.len) return false;
+                pi += 1;
+                si += 1;
+            },
+            '[' => {
+                const end = std.mem.indexOfScalarPos(u8, pattern, pi + 1, ']') orelse return false;
+                if (si >= source.len) return false;
+                const negated = pattern[pi + 1] == '!' or pattern[pi + 1] == '^';
+                const class_start: usize = if (negated) pi + 2 else pi + 1;
+                var matched = false;
+                var bi = class_start;
+                while (bi < end) {
+                    if (bi + 2 < end and pattern[bi + 1] == '-') {
+                        if (source[si] >= pattern[bi] and source[si] <= pattern[bi + 2]) matched = true;
+                        bi += 3;
+                    } else {
+                        if (source[si] == pattern[bi]) matched = true;
+                        bi += 1;
+                    }
+                }
+                if (matched == negated) return false;
+                pi = end + 1;
+                si += 1;
+            },
+            else => {
+                if (si >= source.len or source[si] != c) return false;
+                pi += 1;
+                si += 1;
+            },
+        }
+    }
+    return si == source.len;
 }
 
 /// `list` 의 패턴 중 하나라도 `source` 와 glob 매칭되는지.
@@ -33,23 +129,67 @@ pub fn anyGlobMatch(list: []const []const u8, source: []const u8) bool {
     return false;
 }
 
-test "matchesGlob: exact match (no star)" {
+test "matchesGlob: exact match (no special)" {
     try std.testing.expect(matchesGlob("styled-components", "styled-components"));
     try std.testing.expect(!matchesGlob("styled-components", "styled-components/native"));
 }
 
-test "matchesGlob: prefix wildcard" {
+test "matchesGlob: single star — prefix/suffix/middle" {
     try std.testing.expect(matchesGlob("@my-org/*", "@my-org/styled"));
     try std.testing.expect(matchesGlob("@my-org/*", "@my-org/"));
     try std.testing.expect(!matchesGlob("@my-org/*", "@other/styled"));
-}
-
-test "matchesGlob: suffix wildcard" {
     try std.testing.expect(matchesGlob("*-styled", "my-styled"));
     try std.testing.expect(!matchesGlob("*-styled", "styled-x"));
-}
-
-test "matchesGlob: middle wildcard" {
     try std.testing.expect(matchesGlob("@*/styled", "@my-org/styled"));
     try std.testing.expect(!matchesGlob("@*/styled", "@my-org/css"));
+}
+
+test "matchesGlob: multi star" {
+    try std.testing.expect(matchesGlob("a*b*c", "axxxbyc"));
+    try std.testing.expect(matchesGlob("a*b*c", "abc"));
+    try std.testing.expect(!matchesGlob("a*b*c", "axxxc"));
+}
+
+test "matchesGlob: question mark" {
+    try std.testing.expect(matchesGlob("a?c", "abc"));
+    try std.testing.expect(matchesGlob("a?c", "axc"));
+    try std.testing.expect(!matchesGlob("a?c", "ac"));
+    try std.testing.expect(!matchesGlob("a?c", "abxc"));
+}
+
+test "matchesGlob: bracket class" {
+    try std.testing.expect(matchesGlob("[abc]", "a"));
+    try std.testing.expect(matchesGlob("[abc]", "b"));
+    try std.testing.expect(!matchesGlob("[abc]", "d"));
+    try std.testing.expect(matchesGlob("[a-z]", "m"));
+    try std.testing.expect(!matchesGlob("[a-z]", "M"));
+    try std.testing.expect(matchesGlob("[A-Z]", "M"));
+}
+
+test "matchesGlob: bracket negation" {
+    try std.testing.expect(matchesGlob("[!abc]", "d"));
+    try std.testing.expect(!matchesGlob("[!abc]", "a"));
+    try std.testing.expect(matchesGlob("[^a-z]", "X"));
+    try std.testing.expect(!matchesGlob("[^a-z]", "x"));
+}
+
+test "matchesGlob: brace expansion" {
+    try std.testing.expect(matchesGlob("{foo,bar}", "foo"));
+    try std.testing.expect(matchesGlob("{foo,bar}", "bar"));
+    try std.testing.expect(!matchesGlob("{foo,bar}", "baz"));
+    try std.testing.expect(matchesGlob("a-{b,c}-d", "a-b-d"));
+    try std.testing.expect(matchesGlob("a-{b,c}-d", "a-c-d"));
+}
+
+test "matchesGlob: brace nested" {
+    try std.testing.expect(matchesGlob("{a,{b,c}}", "a"));
+    try std.testing.expect(matchesGlob("{a,{b,c}}", "b"));
+    try std.testing.expect(matchesGlob("{a,{b,c}}", "c"));
+    try std.testing.expect(!matchesGlob("{a,{b,c}}", "d"));
+}
+
+test "matchesGlob: combined star + brace + class" {
+    try std.testing.expect(matchesGlob("@{my-org,co}/*", "@my-org/styled"));
+    try std.testing.expect(matchesGlob("@{my-org,co}/*", "@co/anything"));
+    try std.testing.expect(!matchesGlob("@{my-org,co}/*", "@other/x"));
 }


### PR DESCRIPTION
## Summary
- `util/string_list.zig` 의 glob 매처를 picomatch 호환으로 확장
- babel-plugin-styled-components 의 `topLevelImportPaths` parity 달성

## 지원 spec
- `*` (0+ chars), `?` (1 char) — multi `*` 도 OK
- `[abc]`, `[a-z]`, `[!abc]`/`[^abc]` (bracket class + negation)
- `{a,b,c}` brace expansion, nested 가능 (`{a,{b,c}}`)
- path-segment `/` 는 일반 char (npm package 매칭 use case)

## 변경
- `src/util/string_list.zig` — `matchSimple` (backtracking matcher) + `matchesGlobInternal` (brace expansion 재귀) + 8 단위 테스트
- `src/transformer/transformer.zig` + `packages/core/index.ts` — 옵션 doc 업데이트
- `src/transformer/styled_components_test.zig` — brace expansion 회귀 테스트

## Test plan
- [x] `zig build test` Debug
- [x] `zig build test -Doptimize=ReleaseFast`

🤖 Generated with [Claude Code](https://claude.com/claude-code)