### PR TITLE
feat(transformer): styled cssProp B2 — auto-inject binding collision detection

### DIFF
--- a/src/transformer/plugin_state.zig
+++ b/src/transformer/plugin_state.zig
@@ -158,6 +158,15 @@ pub const StyledComponentsState = struct {
     /// 없어 transpile.zig 가 자동 prepend 해야 함. JSX import auto-inject 패턴과 동일.
     css_prop_needs_import: bool = false,
 
+    /// auto-inject 된 styled binding 의 실제 이름. collision 시 `_styled`, `_styled2`,
+    /// ... 로 mangled. transpile.zig 의 prepend 도 같은 이름 사용. default `"styled"`.
+    css_prop_inject_name: []const u8 = "styled",
+
+    /// `css_prop_inject_name` 이 heap-owned 인지 (mangling 발생 시 true). deinit 시
+    /// pointer 비교 대신 이 flag 보고 free 결정 — Zig 의 string-literal pooling 은
+    /// 컴파일러 implementation-defined 이라 ptr 비교 fragile.
+    css_prop_inject_name_owned: bool = false,
+
     /// cssProp transform 으로 만들어진 module-level decl 들 — program body 끝에 hoist.
     /// `trailing_nodes` 는 nearest list 가 program 이 아니면 declarator list 같은
     /// 부적절한 위치에 들어가 invalid syntax 가 되므로 별도 list 로 관리. visitProgram

--- a/src/transformer/styled_components_test.zig
+++ b/src/transformer/styled_components_test.zig
@@ -1640,6 +1640,52 @@ test "styled (cssProp Step 5): styled import 없으면 자동 import 추가" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, ",const _styled_") == null);
 }
 
+test "styled (cssProp B2): collision 시 _styled mangling — `const styled` 충돌" {
+    // 사용자 module-level 에 `const styled = ...` 이 이미 있으면 prepended import 와
+    // redeclaration 충돌. 우리는 `_styled` 로 mangling 후 사용.
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\const styled = somethingElse;
+        \\const el = <div css={`color: red;`}>x</div>;
+    ,
+        .{
+            .styled_components = true,
+            .styled_components_css_prop = true,
+            .jsx_transform = true,
+            .jsx_runtime = .automatic,
+            .jsx_filename = "test.tsx",
+        },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    // generated decl 의 RHS 가 `_styled.div` 형태여야 (mangled binding)
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_styled.div") != null);
+    // 사용자 const styled 는 그대로 보존
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "const styled = somethingElse") != null);
+}
+
+test "styled (cssProp B2): 다중 collision — `const styled, _styled` 둘 다 있으면 _styled2" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        \\const styled = a;
+        \\const _styled = b;
+        \\const el = <div css={`color: red;`}>x</div>;
+    ,
+        .{
+            .styled_components = true,
+            .styled_components_css_prop = true,
+            .jsx_transform = true,
+            .jsx_runtime = .automatic,
+            .jsx_filename = "test.tsx",
+        },
+        default_cg,
+        ".tsx",
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_styled2.div") != null);
+}
+
 test "styled (cssProp Step 5): cssProp transform 안 일어나면 auto-inject 도 안 함" {
     // 옵션 활성이지만 jsx 안 쓰면 transform 자체가 안 일어남 → auto-inject 도 안 됨.
     var r = try e2eFull(

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -666,6 +666,10 @@ pub const Transformer = struct {
         self.plugins.emotion.scope_stack.deinit(self.allocator);
         if (self.plugins.emotion.newline_offsets) |*list| list.deinit(self.allocator);
         self.plugins.styled_components.css_prop_pending_decls.deinit(self.allocator);
+        // collision 발생 시 mangled name 은 heap-owned. owned flag 로 free 판정 (Zig 의
+        // string-literal pooling 이 implementation-defined 이라 ptr 비교 fragile).
+        const sc = &self.plugins.styled_components;
+        if (sc.css_prop_inject_name_owned) self.allocator.free(sc.css_prop_inject_name);
         self.trailing_nodes.deinit(self.allocator);
         self.generator_label_stack.deinit(self.allocator);
         self.generator_temp_var_spans.deinit(self.allocator);

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -1310,19 +1310,152 @@ fn extractCssTemplateIdx(self: *Transformer, css_value_idx: NodeIndex) ?NodeInde
     return null;
 }
 
-/// `<X css={...}>` JSX prop 을 styled component 추출 시도. MVP: intrinsic tag +
-/// template_literal 또는 `css\`\`` tagged template + styled default_binding 존재 시.
-/// 미매칭 시 null 반환.
-/// auto-inject 시 사용할 styled default binding 이름. 사용자 코드에 같은 이름의 다른
-/// 선언 (`const styled = ...` 같은 module-scope 변수) 이 있으면 prepended import 와 충돌 —
-/// babel 처럼 unique mangling 은 미적용. follow-up: collision detection + `_styled` fallback.
+/// auto-inject 시 사용할 styled default binding 의 base name. collision 발생 시
+/// `_styled`, `_styled2`, ... 로 mangled (`resolveStyledInjectName`).
 const DEFAULT_STYLED_BINDING = "styled";
+
+/// program body 의 module-level binding 이름을 sink 에 수집 — semantic analyzer 가
+/// 안 돌았을 때의 fallback. 처리 statement: import / var-let-const / function / class /
+/// export-named / export-default. destructuring pattern 은 skip (false-positive 위험
+/// 보다 false-negative 더 안전).
+fn collectModuleLevelBindingsFallback(
+    self: *Transformer,
+    program_idx: NodeIndex,
+    sink: *std.StringHashMap(void),
+) Error!void {
+    const program = self.ast.getNode(program_idx);
+    if (program.tag != .program) return;
+    const list = program.data.list;
+    for (self.ast.extra_data.items[list.start .. list.start + list.len]) |raw| {
+        try collectBindingsFromStatement(self, @enumFromInt(raw), sink);
+    }
+}
+
+fn collectBindingsFromStatement(
+    self: *Transformer,
+    stmt_idx: NodeIndex,
+    sink: *std.StringHashMap(void),
+) Error!void {
+    if (stmt_idx.isNone()) return;
+    const node = self.ast.getNode(stmt_idx);
+    switch (node.tag) {
+        .import_declaration => {
+            const x = module_parser.readImportDeclExtras(self.ast, node.data.extra);
+            var i: u32 = 0;
+            while (i < x.specs_len) : (i += 1) {
+                const spec_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[x.specs_start + i]);
+                if (spec_idx.isNone()) continue;
+                const spec = self.ast.getNode(spec_idx);
+                switch (spec.tag) {
+                    .import_default_specifier, .import_namespace_specifier => {
+                        try sink.put(self.ast.getText(spec.data.string_ref), {});
+                    },
+                    .import_specifier => {
+                        const local_idx = spec.data.binary.right;
+                        if (!local_idx.isNone()) {
+                            try sink.put(self.ast.getText(self.ast.getNode(local_idx).span), {});
+                        }
+                    },
+                    else => {},
+                }
+            }
+        },
+        .variable_declaration => {
+            const e = node.data.extra;
+            const list_start = self.ast.extra_data.items[e + 1];
+            const list_len = self.ast.extra_data.items[e + 2];
+            for (self.ast.extra_data.items[list_start .. list_start + list_len]) |raw| {
+                const decl_idx: NodeIndex = @enumFromInt(raw);
+                if (decl_idx.isNone()) continue;
+                const decl = self.ast.getNode(decl_idx);
+                if (decl.tag != .variable_declarator) continue;
+                const name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[decl.data.extra]);
+                if (name_idx.isNone()) continue;
+                const name_node = self.ast.getNode(name_idx);
+                if (name_node.tag == .binding_identifier) {
+                    try sink.put(self.ast.getText(name_node.span), {});
+                }
+            }
+        },
+        .function_declaration, .class_declaration => {
+            const name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[node.data.extra]);
+            if (!name_idx.isNone()) {
+                try sink.put(self.ast.getText(self.ast.getNode(name_idx).span), {});
+            }
+        },
+        .export_named_declaration => {
+            // extras[0] 자리의 inner declaration 재귀 (`export const x = ...` 등)
+            const e = node.data.extra;
+            if (self.ast.hasExtra(e, 0)) {
+                const inner: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+                if (!inner.isNone()) try collectBindingsFromStatement(self, inner, sink);
+            }
+        },
+        .export_default_declaration => {
+            // export_default_declaration 은 unary layout — `node.data.unary.operand` 가
+            // inner. (extras 가정은 OOB / garbage 인덱스 회귀 — module.zig:653 와 동일
+            // layout 사용해야 함.)
+            const inner = node.data.unary.operand;
+            if (!inner.isNone()) try collectBindingsFromStatement(self, inner, sink);
+        },
+        else => {},
+    }
+}
+
+/// auto-inject styled binding 이름 결정 — root-scope binding collision 시 `_styled`,
+/// `_styled2`, ... 후보 순회. 첫 cssProp transform 시 lazy 호출 후 결과 캐싱
+/// (`css_prop_inject_name`).
+///
+/// 우선 `symbols` (semantic analyzer 결과) 활용 — root-scope symbol 만 순회. analyzer
+/// 미실행 시 (e.g. transformer-only 단위 테스트 path) program body 를 직접 walk.
+fn resolveStyledInjectName(self: *Transformer) Error![]const u8 {
+    const state = &self.plugins.styled_components;
+    if (state.css_prop_needs_import) return state.css_prop_inject_name;
+
+    var bindings: std.StringHashMap(void) = .init(self.allocator);
+    defer bindings.deinit();
+    if (self.symbols.len > 0) {
+        for (self.symbols) |sym| {
+            if (sym.scope_id.isNone()) continue;
+            if (sym.scope_id.toIndex() != 0) continue;
+            try bindings.put(sym.nameText(self.ast.source), {});
+        }
+    } else {
+        const root_idx: NodeIndex = @enumFromInt(self.parser_node_count - 1);
+        try collectModuleLevelBindingsFallback(self, root_idx, &bindings);
+    }
+
+    if (!bindings.contains(DEFAULT_STYLED_BINDING)) {
+        state.css_prop_inject_name = DEFAULT_STYLED_BINDING;
+        state.css_prop_needs_import = true;
+        return DEFAULT_STYLED_BINDING;
+    }
+
+    var name_buf: [32]u8 = undefined;
+    var i: u32 = 1;
+    while (true) : (i += 1) {
+        const candidate = if (i == 1)
+            std.fmt.bufPrint(&name_buf, "_styled", .{}) catch unreachable
+        else
+            std.fmt.bufPrint(&name_buf, "_styled{d}", .{i}) catch unreachable;
+        if (!bindings.contains(candidate)) {
+            const owned = try self.allocator.dupe(u8, candidate);
+            state.css_prop_inject_name = owned;
+            state.css_prop_inject_name_owned = true;
+            state.css_prop_needs_import = true;
+            return owned;
+        }
+    }
+}
 
 pub fn maybeExtractCssProp(self: *Transformer, jsx_node: ast_mod.Node) Error!?ast_mod.Node {
     if (!self.options.styled_components or !self.options.styled_components_css_prop) return null;
     if (jsx_node.tag != .jsx_element) return null;
-    // 사용자 import 가 있으면 그 이름, 없으면 DEFAULT_STYLED_BINDING + auto-inject flag.
-    const default_binding: []const u8 = self.plugins.styled_components.default_binding orelse DEFAULT_STYLED_BINDING;
+    // 사용자 import 있으면 그 이름. 없으면 collision detection 후 unique 이름 + auto-inject flag.
+    const default_binding: []const u8 = if (self.plugins.styled_components.default_binding) |b|
+        b
+    else
+        try resolveStyledInjectName(self);
 
     const e = jsx_node.data.extra;
     const tag_name_idx = self.readNodeIdx(e, 0);
@@ -1378,7 +1511,6 @@ pub fn maybeExtractCssProp(self: *Transformer, jsx_node: ast_mod.Node) Error!?as
         extractCssTemplateIdx(self, css_value_idx) orelse return null;
 
     const state = &self.plugins.styled_components;
-    if (state.default_binding == null) state.css_prop_needs_import = true;
     const counter = state.css_prop_counter;
     state.css_prop_counter += 1;
 

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -554,11 +554,12 @@ pub fn transpileWithCallback(
     const jsx_output = prependImportLine(arena_alloc, jsx_import_str, raw_output);
 
     // 6.6. styled-components cssProp auto-inject — 사용자 코드에 styled import 가 없는데
-    // cssProp transform 이 일어난 경우 program 시작에 `import styled from "styled-components"`.
-    const css_prop_import: ?[]const u8 = if (transformer.plugins.styled_components.css_prop_needs_import)
-        "import styled from \"styled-components\";\n"
-    else
-        null;
+    // cssProp transform 이 일어난 경우 program 시작에 styled import 추가. binding 이름은
+    // collision detection 후 결정된 `css_prop_inject_name` 사용.
+    const css_prop_import: ?[]const u8 = if (transformer.plugins.styled_components.css_prop_needs_import) blk: {
+        const name = transformer.plugins.styled_components.css_prop_inject_name;
+        break :blk std.fmt.allocPrint(arena_alloc, "import {s} from \"styled-components\";\n", .{name}) catch null;
+    } else null;
     const css_prop_output = prependImportLine(arena_alloc, css_prop_import, jsx_output);
 
     // 7. 런타임 헬퍼 prepend


### PR DESCRIPTION
## Summary
사용자 module-level scope 에 `const styled = ...` 같은 선언이 있을 때 cssProp auto-inject 가 `import styled from "styled-components"` redeclaration 충돌 → babel parity 위반.

**Fix**: collision detection 후 unique mangling — `styled` → `_styled` → `_styled2` ...

## 변경
- `src/transformer/transformer/styled_components.zig`:
  - `resolveStyledInjectName` — 우선 `self.symbols` (semantic analyzer 결과) 활용, fallback 으로 program body 직접 walk
  - `collectModuleLevelBindingsFallback` + `collectBindingsFromStatement` — analyzer 없을 때 fallback
- `src/transformer/plugin_state.zig` — `css_prop_inject_name`, `css_prop_inject_name_owned` flag
- `src/transformer/transformer.zig` — deinit 에서 owned flag 보고 free
- `src/transpile.zig` — 6.6 prepend 가 동적 binding 이름 사용 (`allocPrint`)
- `src/transformer/styled_components_test.zig` — single + double collision 회귀 테스트

## /simplify findings 적용
- **Bug**: `export_default_declaration` 의 layout 은 `data.unary.operand` (parser/module.zig:653 와 동일) — `data.extra` 사용 시 garbage 인덱스 OOB
- **Fragile**: deinit 의 `ptr != "styled".ptr` 비교 → `css_prop_inject_name_owned` flag 로 변경
- **Reuse**: `self.symbols` 활용 — analyzer 결과를 재사용해 130 LoC walk 회피
- **Magic 1M loop**: `while (true)` 로 단순화 (collision count 는 source size 로 자연 bounded)

## Test plan
- [x] `zig build test` Debug
- [x] `zig build test -Doptimize=ReleaseFast`
- [x] `_styled` mangling on collision
- [x] `_styled2` mangling on double collision

🤖 Generated with [Claude Code](https://claude.com/claude-code)