### PR TITLE
fix(examples/web): process.env.NODE_ENV define 추가 — 브라우저 ReferenceError 회피

### DIFF
--- a/examples/web/zts.config.ts
+++ b/examples/web/zts.config.ts
@@ -8,6 +8,12 @@ export default defineConfig({
   target: "es2022",
   jsx: "automatic",
   sourcemap: true,
+  // styled-components / react / emotion 의 production guard (`process.env.NODE_ENV`)
+  // 가 번들에 살아남으면 브라우저에서 `ReferenceError: process is not defined`.
+  // Vite 가 dev mode 에서 자동 주입하는 것과 동등.
+  define: {
+    "process.env.NODE_ENV": '"development"',
+  },
   // compiler 네임스페이스 — @next/swc 와 동일한 surface.
   // styled-components: displayName / componentId / withConfig 래핑 / chain 인식 / 사용자
   //                    .withConfig MERGE / IIFE & control-flow return walker / CSS minify


### PR DESCRIPTION
## Summary
styled-components / react / emotion 의 `process.env.NODE_ENV !== \"production\"` production guard 가 번들에 살아남아 브라우저에서 `ReferenceError: process is not defined` 발생. Vite 가 dev mode 에 자동 주입하는 것과 동등하게 사용자 config 에서 명시 주입 (임시 fix).

## 근본 fix
`zts dev` 가 `process.env.NODE_ENV` 를 default 주입하도록 — issue #2295 backlog.

Refs #2295

🤖 Generated with [Claude Code](https://claude.com/claude-code)