### PR TITLE
fix(cli): help와 unknown flag 처리

### DIFF
--- a/packages/core/bin/cli-flags.mjs
+++ b/packages/core/bin/cli-flags.mjs
@@ -20,6 +20,7 @@
  *   aliases: 추가 flag 이름 (`-o`, `--tsconfig-path`).
  *   extra:   부수효과 — 매칭 시 함께 set 할 키-값 (`{ watch: true }`).
  *   default: bool 단독 등장 시 default 값 (kind="string-default" 의 metafile 패턴).
+ *   value:   bool flag 가 설정할 값. 생략 시 true (`--no-*` alias 는 false 지정).
  *   enum:    enum→bool 매핑 (`{ utf8: true }` → `--charset=utf8` 시 charsetUtf8=true).
  *   noop:    true 면 매칭만 하고 set 안 함 (deprecated/TODO flag).
  *
@@ -39,6 +40,7 @@
  */
 export const FLAG_REGISTRY = [
   // ─── kind=bool — boolean toggle ───
+  { kind: "bool", flag: "--help", target: "help", aliases: ["-h"] },
   { kind: "bool", flag: "--bundle", target: "bundle" },
   { kind: "bool", flag: "--watch", target: "watch", aliases: ["-w"] },
   { kind: "bool", flag: "--watch-json", target: "watchJson", extra: { watch: true } },
@@ -59,6 +61,7 @@ export const FLAG_REGISTRY = [
   },
   { kind: "bool", flag: "--sourcemap-debug-ids", target: "sourcemapDebugIds" },
   { kind: "bool", flag: "--splitting", target: "splitting" },
+  { kind: "bool", flag: "--no-splitting", target: "splitting", value: false },
   { kind: "bool", flag: "--analyze", target: "analyze", extra: { metafile: "meta.json" } },
   { kind: "bool", flag: "--flow", target: "flow" },
   { kind: "bool", flag: "--experimental-decorators", target: "experimentalDecorators" },
@@ -206,7 +209,7 @@ function tryMatchSpec(spec, arg, args, i) {
       if (allFlags.includes(arg)) {
         return spec.noop
           ? { spec, action: { type: "noop" }, consumed: 1 }
-          : { spec, action: { type: "set", value: true }, consumed: 1 };
+          : { spec, action: { type: "set", value: spec.value ?? true }, consumed: 1 };
       }
       return null;
 

--- a/packages/core/bin/zts-cli-schema-sync.test.ts
+++ b/packages/core/bin/zts-cli-schema-sync.test.ts
@@ -268,11 +268,13 @@ describe("CLI flag ↔ BuildOptions / TranspileOptions schema sync", () => {
   // 새 CLI-only flag 추가 시 여기 등록.
   const cliOnlyFlags: ReadonlySet<string> = new Set([
     // 빌드 모드 / 명령
+    "--help",
     "--bundle",
     "--watch",
     "--watch-json",
     "--watch-delay=",
     "--serve",
+    "--no-splitting",
     "--open",
     "--clean",
     // 설정 / 환경

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -46,7 +46,6 @@ import {
   rmSync,
   mkdtempSync,
   symlinkSync,
-  statSync,
   writeFileSync,
 } from "node:fs";
 import { resolve, relative, dirname, basename, extname, join, sep } from "node:path";
@@ -67,12 +66,83 @@ let postcssCleanupRegistered = false;
 
 // ─── CLI 인자 파싱 ───
 
+function usageLines(command) {
+  if (command === "dev") {
+    return [
+      "Usage: zts dev [root] [options]",
+      "",
+      "Options:",
+      "  --host [host]              Host to listen on (default: localhost)",
+      "  --port <port>              Port to listen on (default: 12300)",
+      "  --open                     Open the app URL in the browser",
+      "  --mode <mode>              Load mode-specific config and .env files",
+      "  --base <path>              Base public path",
+      "  --entry-html <path>        HTML entry file",
+      "  --public-dir <path|false>  Public directory to serve",
+      "  --help, -h                 Show this help message",
+    ];
+  }
+  if (command === "build") {
+    return [
+      "Usage: zts build [root] [options]",
+      "",
+      "Options:",
+      "  --outdir <dir>             Output directory",
+      "  --mode <mode>              Load mode-specific config and .env files",
+      "  --base <path>              Base public path",
+      "  --entry-html <path>        HTML entry file",
+      "  --public-dir <path|false>  Public directory to copy",
+      "  --minify                   Minify output",
+      "  --sourcemap[=mode]         Emit source maps",
+      "  --help, -h                 Show this help message",
+    ];
+  }
+  if (command === "preview") {
+    return [
+      "Usage: zts preview [outdir] [options]",
+      "",
+      "Options:",
+      "  --host [host]              Host to listen on (default: localhost)",
+      "  --port <port>              Port to listen on (default: 12300)",
+      "  --open                     Open the preview URL in the browser",
+      "  --base <path>              Base public path",
+      "  --spa-fallback[=path]      Serve an HTML fallback for app routes",
+      "  --certfile <path>          HTTPS certificate file",
+      "  --keyfile <path>           HTTPS key file",
+      "  --help, -h                 Show this help message",
+    ];
+  }
+  return [
+    "Usage: zts [options] <file.ts>",
+    "       zts --bundle <entry.ts> -o out.js",
+    "       zts --serve --bundle <entry.ts>",
+    "       zts dev [root]",
+    "       zts build [root]",
+    "       zts preview [outdir]",
+    "",
+    "Options:",
+    "  --bundle                   Bundle dependencies",
+    "  --outdir <dir>             Output directory",
+    "  --outfile <file>, -o <file> Output file",
+    "  --watch, -w                Rebuild on changes",
+    "  --serve [dir]              Serve bundled output",
+    "  --config <path>            Config file path",
+    "  --help, -h                 Show this help message",
+  ];
+}
+
+function printUsage(command, stream = console.log) {
+  stream(usageLines(command).join("\n"));
+}
+
 function parseArgs(argv) {
   const args = argv.slice(2);
   const appCommands = new Set(["dev", "build", "preview"]);
   const appCommand = appCommands.has(args[0]) ? args.shift() : undefined;
   const opts = {
     appCommand,
+    help: false,
+    parseError: false,
     appRoot: undefined,
     previewDir: undefined,
     entryPoints: [],
@@ -249,6 +319,7 @@ function parseArgs(argv) {
           : `warning: unknown option '${arg}'`,
       );
     }
+    opts.parseError = true;
   }
 
   // jsx-dev 단축어
@@ -2396,6 +2467,17 @@ async function runWorkspace(opts, workspacePath) {
 
 async function main() {
   const opts = parseArgs(process.argv);
+
+  if (opts.help) {
+    printUsage(opts.appCommand);
+    return;
+  }
+
+  if (opts.parseError) {
+    printUsage(opts.appCommand, console.error);
+    process.exit(1);
+  }
+
   if ((opts.appCommand === "dev" || opts.appCommand === "build") && !opts.envDir) {
     opts.envDir = resolve(opts.appRoot ?? ".");
   }
@@ -2439,12 +2521,7 @@ async function main() {
   }
 
   if (opts.entryPoints.length === 0 && !opts.stdin && !opts.serve && !opts.appCommand) {
-    console.error("Usage: zts [options] <file.ts>");
-    console.error("       zts --bundle <entry.ts> -o out.js");
-    console.error("       zts --serve --bundle <entry.ts>");
-    console.error("       zts dev [root]");
-    console.error("       zts build [root]");
-    console.error("       zts preview [outdir]");
+    printUsage(undefined, console.error);
     process.exit(1);
   }
 

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -1313,10 +1313,27 @@ describe("CLI: arg parsing", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("unknown 옵션 → warning", () => {
+  test("--help exits before starting subcommands", () => {
+    for (const command of ["dev", "build", "preview"]) {
+      const { stdout, stderr, exitCode } = runCli([command, "--help", "--port", "12799"], {
+        timeout: 2000,
+      });
+      expect(exitCode).toBe(0);
+      expect(stderr).toBe("");
+      expect(stdout).toContain(`Usage: zts ${command}`);
+    }
+
+    const short = runCli(["dev", "-h"], { timeout: 2000 });
+    expect(short.exitCode).toBe(0);
+    expect(short.stdout).toContain("Usage: zts dev");
+    expect(short.stderr).toBe("");
+  });
+
+  test("unknown 옵션 → warning 후 abort", () => {
     const { stderr, exitCode } = runCli([join(dir, "input.ts"), "--unknown-flag"]);
-    expect(exitCode).toBe(0); // warning이지 에러는 아님
+    expect(exitCode).toBe(1);
     expect(stderr).toContain("unknown option");
+    expect(stderr).toContain("Usage: zts");
   });
 });
 


### PR DESCRIPTION
## 요약
- `--help`/`-h`를 CLI flag registry에 등록하고 subcommand별 usage를 출력한 뒤 즉시 종료하도록 수정했습니다.
- unknown option은 경고만 내고 계속 실행하지 않고 usage 출력 후 exit(1) 하도록 변경했습니다.
- unknown abort 변경으로 드러난 기존 `--no-splitting` 사용 경로를 registry에 명시했습니다.

## 테스트
- `bun test packages/core/bin/zts.test.ts --test-name-pattern "--help exits before starting subcommands|unknown 옵션|build does not collide when JS imports CSS that HTML also references"`
- `bun test packages/core/bin/zts-cli-schema-sync.test.ts`
- `bun test packages/core/bin/zts.test.ts`
- `bun run oxlint packages/core/bin/zts.mjs packages/core/bin/cli-flags.mjs packages/core/bin/zts.test.ts packages/core/bin/zts-cli-schema-sync.test.ts`
- `bun run oxfmt --check packages/core/bin/zts.mjs packages/core/bin/cli-flags.mjs packages/core/bin/zts.test.ts packages/core/bin/zts-cli-schema-sync.test.ts`
- pre-push hook: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`

Closes #2292