### PR TITLE
test(transform): RN private field arrow init 안 #method 호출 회귀 가드 +2

### DIFF
--- a/src/codegen/codegen_test/private_jsx_advanced.zig
+++ b/src/codegen/codegen_test/private_jsx_advanced.zig
@@ -233,6 +233,43 @@ test "private getter: class expression wrapped in IIFE (es2021)" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "},var ") == null);
 }
 
+// 회귀 가드: private *field* 의 arrow init 안에서 다른 private *method* 호출이
+// lowering 되는지. classifyMembers 의 inner setup 이 current_private_methods 를
+// 빠뜨리면 arrow body 의 `this.#m()` 호출이 raw 로 남아 hermesc/Node syntax error
+// (RN DebuggingOverlayRegistry 의 #onDrawTraceUpdates → #drawTraceUpdatesModern 패턴).
+test "private field arrow init: this.#method() inside arrow lowers (es2021)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Foo {
+        \\  #handler = () => { this.#flush(); };
+        \\  #flush() { return 1; }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    // arrow body 안의 #flush() 호출이 helper 경유로 변환됨 (_this 또는 this — alias 변수명은 무관)
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_flush_fn") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__classPrivateMethodGet") != null);
+    // raw `.#flush(` 호출이 남아있지 않아야 함
+    try std.testing.expect(std.mem.indexOf(u8, r.output, ".#flush(") == null);
+}
+
+test "private field arrow init: this.#method() inside nested arrow lowers (es5)" {
+    // ES5 다운레벨은 arrow 도 function expression 으로 풀어 _this alias 가 명시적으로 등장.
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Reg {
+        \\  #onUpdate = (x) => { if (x) { this.#applyModern(x); } else { this.#applyLegacy(); } };
+        \\  #applyModern(x) { return x; }
+        \\  #applyLegacy() { return 0; }
+        \\}
+    , .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_applyModern_fn") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_applyLegacy_fn") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__classPrivateMethodGet") != null);
+    // raw private method call 이 남으면 안 됨
+    try std.testing.expect(std.mem.indexOf(u8, r.output, ".#applyModern(") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, ".#applyLegacy(") == null);
+}
+
 test "private method: es2022 target preserves original" {
     var r = try e2eTarget(std.testing.allocator,
         \\class Foo {


### PR DESCRIPTION
## Summary
- main 의 phase split refactor (1453d9f3, 46afbfae) 가 `classifyMembers` 를 collect/setup/visit phase 로 분리하면서 RN private field arrow init 안 cross-reference (`#field = e => { this.#method() }`) lowering 회귀의 root cause 를 이미 해결
- 본 PR 은 같은 패턴이 향후 phase split 변경 시 또 깨지지 않도록 **회귀 가드 테스트 2개만** 추가

## 회귀 사례 (해결 전)
RN `DebuggingOverlayRegistry` 의 `#onDrawTraceUpdates` field arrow 안 `#drawTraceUpdatesModern` / `#drawTraceUpdatesLegacy` 호출 4건이 raw 그대로 남아 `Hermes Validation (RN Bundle)` 워크플로우 fail + RN ES5 ExampleApp 번들 Node 실행 fail (`FATAL: Private field '#drawTraceUpdatesModern' must be declared in an enclosing class`).

main 의 phase split 적용 후 출력:
```js
// before (broken)
_this.#drawTraceUpdatesModern(modernNodesUpdates);

// after (main's phase split)
__classPrivateMethodGet(_this, _drawTraceUpdatesModern, _drawTraceUpdatesModern_fn).call(_this, modernNodesUpdates);
```

## 추가된 가드

`src/codegen/codegen_test/private_jsx_advanced.zig` +2:
1. **es2021 target** — `class Foo { #handler = () => { this.#flush(); }; #flush() {} }` 가 `__classPrivateMethodGet` helper 경유로 lowering 되고 raw `.#flush(` 가 잔존하지 않음
2. **es5 target** — arrow 가 function expression 으로 풀리는 multi-method 케이스: `#onUpdate = (x) => { if (x) this.#applyModern(x); else this.#applyLegacy(); }` 가 두 method 모두 lowering

## Test plan
- [x] `zig build test` 통과 (debug)
- [x] `zig build test -Doptimize=ReleaseFast` 통과
- [x] RN ExampleApp 번들 hermesc 통과 (main 만으로도 통과 확인)

## 배경
원래 이 PR 은 `classifyMembers` 의 inner pre-scan 을 직접 수정하려 했지만, main 에 머지된 phase split refactor 가 같은 root cause 를 더 깔끔하게 해결 — 코드 변경분은 redundant 가 되어 drop 하고 회귀 가드만 남김. follow-up issue #2301 (Layer 2 phase split) 은 main 머지로 이미 해결.

🤖 Generated with [Claude Code](https://claude.com/claude-code)