### PR TITLE
fix(cli): Node CLI에서 빌드된 core JS만 로드

### DIFF
--- a/examples/web/README.md
+++ b/examples/web/README.md
@@ -18,6 +18,9 @@ cd examples/web && bun run build
 cd examples/web && bun run preview
 ```
 
+`dev` / `build` / `preview` script 는 실행 전에 `packages/core` JS dist 를 자동으로 빌드한다.
+CLI 를 직접 실행할 때 dist 가 없다면 루트에서 `bun run --cwd packages/core build:js` 를 먼저 실행한다.
+
 `zts.config.ts` 에서 `compiler.styledComponents` / `compiler.emotion` 활성. 두 transform 모두 1st-party 로 ZTS 안에서 동작 (별도 babel/swc plugin 불필요).
 
 ## 현재 지원되는 transform

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -4,8 +4,11 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "predev": "bun run --cwd ../../packages/core build:js",
     "dev": "zts dev",
+    "prebuild": "bun run --cwd ../../packages/core build:js",
     "build": "zts build",
+    "prepreview": "bun run --cwd ../../packages/core build:js",
     "preview": "zts preview"
   },
   "dependencies": {

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -7,13 +7,50 @@
  * Watch/Serve는 JS 레이어에서 구현.
  */
 
-// Node.js: dist/index.js, Bun: index.ts 직접
-let coreModule;
-try {
-  coreModule = await import("../dist/index.js");
-} catch {
-  coreModule = await import("../index.ts");
+import {
+  mkdirSync,
+  cpSync,
+  existsSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  mkdtempSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { resolve, relative, dirname, basename, extname, join, sep } from "node:path";
+import { tmpdir } from "node:os";
+import { createServer } from "node:http";
+import { createServer as createHttpsServer } from "node:https";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { createHash } from "node:crypto";
+
+import { applyFlagAction, KNOWN_FLAGS, matchFlagFromRegistry } from "./cli-flags.mjs";
+
+function isMissingBuiltCore(error) {
+  if (!error || error.code !== "ERR_MODULE_NOT_FOUND") return false;
+  const builtCorePath = fileURLToPath(new URL("../dist/index.js", import.meta.url));
+  return String(error.message ?? "").includes(builtCorePath);
 }
+
+async function loadCoreModule() {
+  try {
+    return await import("../dist/index.js");
+  } catch (error) {
+    if (!isMissingBuiltCore(error)) throw error;
+    console.error("error: @zts/core JS bundle is missing");
+    console.error("");
+    console.error("note: zts CLI runs the built JS entry at packages/core/dist/index.js.");
+    console.error("note: source TypeScript is not loaded directly by Node.");
+    console.error("");
+    console.error("help: run `bun run --cwd packages/core build:js` from the repository root.");
+    console.error("help: for a full local build, run `bun run --cwd packages/core build`.");
+    process.exit(1);
+  }
+}
+
+const coreModule = await loadCoreModule();
 const {
   init,
   transpile,
@@ -37,26 +74,6 @@ const {
   suggestKey,
   warnUnknownKeys,
 } = coreModule;
-import {
-  mkdirSync,
-  cpSync,
-  existsSync,
-  readFileSync,
-  readdirSync,
-  rmSync,
-  mkdtempSync,
-  symlinkSync,
-  writeFileSync,
-} from "node:fs";
-import { resolve, relative, dirname, basename, extname, join, sep } from "node:path";
-import { tmpdir } from "node:os";
-import { createServer } from "node:http";
-import { createServer as createHttpsServer } from "node:https";
-import { createRequire } from "node:module";
-import { fileURLToPath } from "node:url";
-import { createHash } from "node:crypto";
-
-import { applyFlagAction, KNOWN_FLAGS, matchFlagFromRegistry } from "./cli-flags.mjs";
 
 export { KNOWN_FLAGS };
 const requireFromCli = createRequire(import.meta.url);

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -7,7 +7,15 @@
 
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import { spawn, spawnSync, execSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync, mkdirSync } from "node:fs";
+import {
+  cpSync,
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  rmSync,
+  existsSync,
+  mkdirSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -77,6 +85,30 @@ function runNodeEval(
   const command = [RUNTIME, "-e", code].map(shellQuote).join(" ");
   return readRedirectedProcessOutput(command, options);
 }
+
+describe("CLI: bootstrap", () => {
+  test("prints actionable setup error when built JS dist is missing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-cli-bootstrap-"));
+    try {
+      const binDir = join(dir, "bin");
+      mkdirSync(binDir, { recursive: true });
+      cpSync(CLI, join(binDir, "zts.mjs"));
+      cpSync(resolve(import.meta.dir, "cli-flags.mjs"), join(binDir, "cli-flags.mjs"));
+
+      const result = readRedirectedProcessOutput(
+        [RUNTIME, join(binDir, "zts.mjs"), "--help"].map(shellQuote).join(" "),
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("error: @zts/core JS bundle is missing");
+      expect(result.stderr).toContain("help: run `bun run --cwd packages/core build:js`");
+      expect(result.stderr).not.toContain("../index.ts");
+      expect(result.stderr).not.toContain("packages/shared/index");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
 
 // ─── Transpile 모드 ───
 


### PR DESCRIPTION
## 요약
- Node CLI의 `../index.ts` fallback을 제거하고 `packages/core/dist/index.js`만 로드하도록 변경했습니다.
- dist가 없을 때 Node resolver stack trace 대신 `error` / `note` / `help` 형식의 setup 안내를 출력합니다.
- `examples/web`의 dev/build/preview script가 실행 전 `packages/core` JS dist를 자동 빌드하도록 했습니다.

Closes #2293

## 검증
- `bun run --cwd packages/core build:js`
- `bun test packages/core/bin/zts.test.ts --test-name-pattern "CLI: bootstrap"`
- `bun test packages/core/bin/zts.test.ts`
- `bun run lint` (기존 unused import 경고 4개, 오류 없음)
- `bun run fmt:check`
- `git diff --check`
- pre-push hook: `zig fmt --check`, `zig build test`, `oxlint`, `oxfmt --check` 통과
