### PR TITLE
fix(cli): restart dev on config changes

### DIFF
--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -2014,19 +2014,27 @@ function computeRestartTriggers(opts) {
 }
 
 function emitRestart(opts, reason) {
+  return emitRestartAfter(opts, reason, null);
+}
+
+async function emitRestartAfter(opts, reason, beforeSpawn) {
   if (opts.watchJson) {
     console.log(JSON.stringify({ type: "restart", reason }));
   } else if (opts.logLevel !== "silent") {
     console.error(`[watch] ${reason} — restarting CLI...`);
   }
+  if (beforeSpawn) await beforeSpawn();
   // 자식 프로세스 spawn 후 종료 — 새 프로세스가 fresh config/env 로 시작.
   // stdio inherit 으로 부모의 출력 스트림을 그대로 이어받는다.
-  import("node:child_process").then(({ spawn }) => {
-    const child = spawn(process.argv[0], process.argv.slice(1), {
-      stdio: "inherit",
-      env: process.env,
-    });
-    child.on("exit", (code) => process.exit(code ?? 0));
+  const { spawn } = await import("node:child_process");
+  const child = spawn(process.argv[0], process.argv.slice(1), {
+    stdio: "inherit",
+    env: process.env,
+  });
+  child.on("exit", (code) => process.exit(code ?? 0));
+  child.on("error", (err) => {
+    console.error(`[watch] restart failed: ${err}`);
+    process.exit(1);
   });
 }
 
@@ -2035,6 +2043,7 @@ function emitRestart(opts, reason) {
 async function runServe(opts, config, { appDev = null } = {}) {
   const isBun = typeof globalThis.Bun !== "undefined";
   const hmr = appDev ? createAppDevHmrChannel() : null;
+  let serverHandle = null;
   const mimeTypes = {
     ".html": "text/html",
     ".js": "application/javascript",
@@ -2152,7 +2161,7 @@ async function runServe(opts, config, { appDev = null } = {}) {
         key: globalThis.Bun.file(opts.keyfile),
       };
     }
-    globalThis.Bun.serve(serveOpts);
+    serverHandle = globalThis.Bun.serve(serveOpts);
   } else {
     // Node.js http/https
     const handler = async (req, res) => {
@@ -2201,6 +2210,20 @@ async function runServe(opts, config, { appDev = null } = {}) {
       });
     }
     server.listen(opts.port, opts.host);
+    serverHandle = server;
+  }
+
+  async function closeServerForRestart() {
+    if (!serverHandle) return;
+    if (typeof serverHandle.stop === "function") {
+      await serverHandle.stop();
+      return;
+    }
+    if (typeof serverHandle.close === "function") {
+      await new Promise((resolveClose, rejectClose) => {
+        serverHandle.close((err) => (err ? rejectClose(err) : resolveClose()));
+      });
+    }
   }
 
   const protocol = useTls ? "https" : "http";
@@ -2304,8 +2327,8 @@ async function runServe(opts, config, { appDev = null } = {}) {
         if (!filename || filename.includes("node_modules") || filename.includes(".git")) return;
         const absPath = resolve(dir, filename);
         if (outdirAbs && (absPath === outdirAbs || absPath.startsWith(outdirPrefix))) return;
-        if (!appDev && restartTriggers.matches(filename)) {
-          emitRestart(opts, "config 또는 .env 파일 변경 감지");
+        if (restartTriggers.matches(filename)) {
+          void emitRestartAfter(opts, "config 또는 .env 파일 변경 감지", closeServerForRestart);
           return;
         }
         dirty.add(absPath);

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -2586,6 +2586,65 @@ describe("CLI: Vite-style app builder", () => {
     }
   });
 
+  test("dev restarts and reloads zts.config changes", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-dev-config-restart-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "index.html"), '<script type="module" src="/src/main.ts"></script>');
+    writeFileSync(
+      join(dir, "src", "main.ts"),
+      "document.body.textContent = __APP_LABEL__; console.log(__APP_LABEL__);",
+    );
+    const writeConfig = (label: string) => {
+      writeFileSync(
+        join(dir, "zts.config.json"),
+        JSON.stringify({ define: { __APP_LABEL__: JSON.stringify(label) } }),
+      );
+    };
+    writeConfig("before");
+
+    const port = 12650 + Math.floor(Math.random() * 100);
+    const proc = spawn(RUNTIME, [CLI, "dev", dir, `--port=${port}`], {
+      cwd: dir,
+      detached: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stderr = "";
+    proc.stderr?.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    await waitForServer(port);
+
+    async function waitForBundleText(expected: string) {
+      const started = Date.now();
+      while (Date.now() - started < 8000) {
+        try {
+          const js = await fetch(`http://localhost:${port}/bundle.js`).then((r) => r.text());
+          if (js.includes(expected)) return js;
+        } catch {
+          // 서버가 재시작 중이면 잠깐 connection refused 가 날 수 있다.
+        }
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      throw new Error(`bundle did not contain ${expected}`);
+    }
+
+    try {
+      expect(await waitForBundleText('"before"')).toContain('"before"');
+      writeConfig("after");
+      expect(await waitForBundleText('"after"')).toContain('"after"');
+      expect(stderr).toContain("config");
+    } finally {
+      if (proc.pid) {
+        try {
+          process.kill(-proc.pid, "SIGTERM");
+        } catch {
+          proc.kill();
+        }
+      }
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15000);
+
   test("preview [outdir] serves built files under base without rebuilding", async () => {
     const dir = mkdtempSync(join(tmpdir(), "zts-app-preview-"));
     mkdirSync(join(dir, "src"), { recursive: true });


### PR DESCRIPTION
## 요약
- `zts dev` app-builder watch 경로에서도 `zts.config.*` / `.env*` 변경을 restart trigger로 처리하도록 수정했습니다.
- dev 서버 재시작 전에 현재 HTTP/Bun 서버를 닫아 같은 포트로 새 프로세스가 정상 기동되도록 했습니다.
- config 변경 후 define 값이 새 번들에 반영되는 회귀 테스트를 추가했습니다.

## 검증
- `bun test packages/core/bin/zts.test.ts --test-name-pattern "dev restarts and reloads zts.config changes"`
- `bun test packages/core/bin/zts.test.ts --test-name-pattern "Vite-style app builder"`
- `bun test packages/core/bin/zts.test.ts --test-name-pattern "CLI: watch"`
- `bunx oxfmt format --check packages/core/bin/zts.mjs packages/core/bin/zts.test.ts`
- `git diff --check`
- pre-push hook: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check` 통과

Closes #2296