### PR TITLE
fix(cli): browser 빌드 NODE_ENV 기본 define 주입

### DIFF
--- a/.github/actions/setup-zts/action.yml
+++ b/.github/actions/setup-zts/action.yml
@@ -22,6 +22,40 @@ runs:
       run: zig build napi
       shell: bash
 
+    - name: Build core JS wrapper
+      run: bun run --cwd packages/core build:js
+      shell: bash
+
+    - name: Verify JS wrapper uses fresh NAPI
+      run: |
+        bun - <<'EOF'
+        import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+        import { tmpdir } from "node:os";
+        import { join } from "node:path";
+        import { buildSync, init } from "./packages/core/dist/index.js";
+
+        await init();
+        const dir = mkdtempSync(join(tmpdir(), "zts-ci-napi-"));
+        const entry = join(dir, "index.ts");
+        const outfile = join(dir, "out.js");
+        writeFileSync(
+          entry,
+          'import styled from "styled-components"; const Button = styled.button`color:red;`; console.log(typeof Button);',
+        );
+        buildSync({
+          entryPoints: [entry],
+          bundle: true,
+          outfile,
+          external: ["styled-components"],
+          compiler: { styledComponents: { namespace: "ci" } },
+        });
+        const js = readFileSync(outfile, "utf8");
+        if (!js.includes("ci__sc-")) {
+          throw new Error("fresh NAPI sanity check failed: styledComponents.namespace was not applied");
+        }
+        EOF
+      shell: bash
+
     - name: Install dependencies
       run: bun install
       shell: bash

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,8 +32,14 @@ jobs:
       - name: Lint (oxlint)
         run: bun run lint
 
+      - name: Remove generated core JS wrapper before format check
+        run: rm -rf packages/core/dist
+
       - name: Format check (oxfmt)
         run: bun run fmt:check
+
+      - name: Build core JS wrapper for integration tests
+        run: bun run --cwd packages/core build:js
 
       - name: Run integration tests
         run: bun run test:integration

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,14 +32,8 @@ jobs:
       - name: Lint (oxlint)
         run: bun run lint
 
-      - name: Remove generated core JS wrapper before format check
-        run: rm -rf packages/core/dist
-
       - name: Format check (oxfmt)
         run: bun run fmt:check
-
-      - name: Build core JS wrapper for integration tests
-        run: bun run --cwd packages/core build:js
 
       - name: Run integration tests
         run: bun run test:integration

--- a/examples/web/zts.config.ts
+++ b/examples/web/zts.config.ts
@@ -8,12 +8,6 @@ export default defineConfig({
   target: "es2022",
   jsx: "automatic",
   sourcemap: true,
-  // styled-components / react / emotion 의 production guard (`process.env.NODE_ENV`)
-  // 가 번들에 살아남으면 브라우저에서 `ReferenceError: process is not defined`.
-  // Vite 가 dev mode 에서 자동 주입하는 것과 동등.
-  define: {
-    "process.env.NODE_ENV": '"development"',
-  },
   // compiler 네임스페이스 — @next/swc 와 동일한 surface.
   // styled-components: displayName / componentId / withConfig 래핑 / chain 인식 / 사용자
   //                    .withConfig MERGE / IIFE & control-flow return walker / CSS minify

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "build:zts": "zig build -Doptimize=ReleaseFast",
     "lint": "oxlint --ignore-pattern '**/fixtures/**' --ignore-pattern '**/dist/**' packages/ tests/integration tests/e2e tests/benchmark",
     "lint:fix": "oxlint --fix --ignore-pattern '**/fixtures/**' --ignore-pattern '**/dist/**' packages/ tests/integration tests/e2e tests/benchmark",
-    "fmt": "oxfmt format packages/ tests/integration tests/e2e tests/benchmark",
-    "fmt:check": "oxfmt format --check packages/ tests/integration tests/e2e tests/benchmark",
+    "fmt": "oxfmt format packages/ tests/integration tests/e2e tests/benchmark '!**/dist/**'",
+    "fmt:check": "oxfmt format --check packages/ tests/integration tests/e2e tests/benchmark '!**/dist/**'",
     "playwright:install": "cd tests/e2e && bunx playwright install --with-deps chromium"
   },
   "devDependencies": {

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -479,6 +479,21 @@ function normalizeBase(base) {
   return out;
 }
 
+function isBrowserLikePlatform(platform) {
+  return platform === undefined || platform === "browser" || platform === "react-native";
+}
+
+function injectDefaultNodeEnvDefine(opts) {
+  if (opts.define["process.env.NODE_ENV"] !== undefined) return;
+
+  const appBrowserCommand = opts.appCommand === "dev" || opts.appCommand === "build";
+  const browserBundle = opts.bundle && (isBrowserLikePlatform(opts.platform) || opts.minifySyntax);
+  if (!appBrowserCommand && !browserBundle) return;
+
+  const isDev = opts.appCommand === "dev" || opts.serve || opts.watch;
+  opts.define["process.env.NODE_ENV"] = isDev ? '"development"' : '"production"';
+}
+
 async function runAppBuild(opts, config, configEnv, _dotenvVars) {
   if (config?.plugins?.length || opts.pluginPaths.length > 0) {
     throw new Error(
@@ -2559,6 +2574,7 @@ async function main() {
   for (const [key, value] of Object.entries(envDefine)) {
     if (opts.define[key] === undefined) opts.define[key] = value;
   }
+  injectDefaultNodeEnvDefine(opts);
 
   if (opts.entryPoints.length === 0 && !opts.stdin && !opts.serve && !opts.appCommand) {
     printUsage(undefined, console.error);

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -1311,12 +1311,24 @@ describe("CLI: arg parsing", () => {
   test("--define:KEY=VALUE", () => {
     const defDir = mkdtempSync(join(tmpdir(), "zts-cli-define-"));
     writeFileSync(join(defDir, "input.ts"), "console.log(process.env.NODE_ENV);");
-    const { exitCode } = runCli([
+    const { stdout, exitCode } = runCli([
       "--bundle",
       join(defDir, "input.ts"),
       '--define:process.env.NODE_ENV="production"',
     ]);
     expect(exitCode).toBe(0);
+    expect(stdout).toContain('"production"');
+    expect(stdout).not.toContain("process.env.NODE_ENV");
+    rmSync(defDir, { recursive: true, force: true });
+  });
+
+  test("browser bundle defaults process.env.NODE_ENV to production", () => {
+    const defDir = mkdtempSync(join(tmpdir(), "zts-cli-node-env-"));
+    writeFileSync(join(defDir, "input.ts"), "console.log(process.env.NODE_ENV);");
+    const { stdout, exitCode } = runCli(["--bundle", join(defDir, "input.ts")]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('"production"');
+    expect(stdout).not.toContain("process.env.NODE_ENV");
     rmSync(defDir, { recursive: true, force: true });
   });
 
@@ -2509,7 +2521,7 @@ describe("CLI: Vite-style app builder", () => {
     );
     writeFileSync(
       join(dir, "src", "main.ts"),
-      "console.log(import.meta.env.MODE, import.meta.env.PROD, import.meta.env.BASE_URL, import.meta.env.VITE_TITLE);",
+      "console.log(import.meta.env.MODE, import.meta.env.PROD, import.meta.env.BASE_URL, import.meta.env.VITE_TITLE, process.env.NODE_ENV);",
     );
     writeFileSync(join(dir, ".env.production"), "VITE_TITLE=ZTS App\n");
     writeFileSync(join(dir, "public", "favicon.svg"), "<svg></svg>");
@@ -2529,9 +2541,10 @@ describe("CLI: Vite-style app builder", () => {
     expect(html).toContain('href="/app/favicon.svg"');
     const scriptPath = scriptPathFromHtml(html);
     expect(scriptPath).toMatch(/^\/app\/main-[a-f0-9]+\.js$/);
-    expect(readFileSync(join(outdir, scriptPath.replace("/app/", "")), "utf8")).toContain(
-      '"ZTS App"',
-    );
+    const js = readFileSync(join(outdir, scriptPath.replace("/app/", "")), "utf8");
+    expect(js).toContain('"ZTS App"');
+    expect(js).toContain('"production"');
+    expect(js).not.toContain("process.env.NODE_ENV");
     expect(existsSync(join(outdir, "favicon.svg"))).toBe(true);
     rmSync(dir, { recursive: true, force: true });
   });
@@ -2561,7 +2574,7 @@ describe("CLI: Vite-style app builder", () => {
     );
     writeFileSync(
       join(dir, "src", "main.ts"),
-      "console.log(import.meta.env.VITE_TITLE, import.meta.env.MODE);",
+      "console.log(import.meta.env.VITE_TITLE, import.meta.env.MODE, process.env.NODE_ENV);",
     );
     writeFileSync(join(dir, ".env.development"), "VITE_TITLE=Dev App\n");
     writeFileSync(join(dir, "public", "favicon.svg"), "<svg></svg>");
@@ -2580,6 +2593,7 @@ describe("CLI: Vite-style app builder", () => {
       const js = await fetch(`http://localhost:${port}/app/bundle.js`).then((r) => r.text());
       expect(js).toContain('"Dev App"');
       expect(js).toContain('"development"');
+      expect(js).not.toContain("process.env.NODE_ENV");
     } finally {
       proc.kill();
       rmSync(dir, { recursive: true, force: true });

--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -245,6 +245,32 @@ describe("@zts/core buildSync", () => {
     expect(result.outputFiles[0].text).toContain("Hello");
   });
 
+  test("browser bundle defaults process.env.NODE_ENV to production", () => {
+    const nodeEnvDir = mkdtempSync(join(tmpdir(), "zts-napi-node-env-"));
+    writeFileSync(join(nodeEnvDir, "entry.ts"), "console.log(process.env.NODE_ENV);");
+    const result = buildSync({ entryPoints: [join(nodeEnvDir, "entry.ts")] });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain('"production"');
+    expect(result.outputFiles[0].text).not.toContain("process.env.NODE_ENV");
+    rmSync(nodeEnvDir, { recursive: true, force: true });
+  });
+
+  test("react-native bundle defaults __DEV__ and NODE_ENV from devMode", () => {
+    const rnDir = mkdtempSync(join(tmpdir(), "zts-napi-rn-env-"));
+    writeFileSync(join(rnDir, "entry.ts"), "console.log(__DEV__, process.env.NODE_ENV);");
+    const result = buildSync({
+      entryPoints: [join(rnDir, "entry.ts")],
+      platform: "react-native",
+      devMode: true,
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("true");
+    expect(result.outputFiles[0].text).toContain('"development"');
+    expect(result.outputFiles[0].text).not.toContain("__DEV__");
+    expect(result.outputFiles[0].text).not.toContain("process.env.NODE_ENV");
+    rmSync(rnDir, { recursive: true, force: true });
+  });
+
   test("CJS 포맷", () => {
     const result = buildSync({
       entryPoints: [join(dir, "entry.ts")],

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -356,7 +356,7 @@ export interface EmotionOptions {
   /** sourceMap 생성 (default: true) */
   sourceMap?: boolean;
   /** 변수명을 CSS class label 로 자동 부여 (default: "dev-only"). `false` 는 autoLabel 을 끈다. */
-  autoLabel?: "always" | "dev-only" | "never" | false;
+  autoLabel?: "always" | "dev-only" | "never" | boolean;
   /** label format string. tokens: `[local]`, `[filename]`, `[dirname]` (default: "[local]") */
   labelFormat?: string;
   /** import 경로 alias — fork 또는 vendored emotion 사용 시 */

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1226,8 +1226,37 @@ function arrayAliasToPlugin(
   };
 }
 
+function isBrowserLikeBuildPlatform(platform: BuildOptions["platform"] | undefined): boolean {
+  return platform === undefined || platform === "browser" || platform === "react-native";
+}
+
+function withDefaultBuildDefines(options: BuildOptions): Record<string, string> | undefined {
+  const define = { ...options.define };
+  const browserLike = isBrowserLikeBuildPlatform(options.platform) || options.minifySyntax === true;
+
+  if (browserLike && define["process.env.NODE_ENV"] === undefined) {
+    define["process.env.NODE_ENV"] = options.devMode ? '"development"' : '"production"';
+  }
+  if (options.platform === "react-native" && define.__DEV__ === undefined) {
+    define.__DEV__ = options.devMode ? "true" : "false";
+  }
+
+  return Object.keys(define).length > 0 ? define : undefined;
+}
+
+function withDefaultAppBuildDefines(options: AppBuildOptions): Record<string, string> | undefined {
+  const define = { ...options.define };
+  if (define["process.env.NODE_ENV"] === undefined) {
+    define["process.env.NODE_ENV"] =
+      (options.mode ?? "production") === "production" ? '"production"' : '"development"';
+  }
+  return define;
+}
+
 function prepareNapiOptions(options: BuildOptions): Record<string, unknown> {
   const napiOptions: Record<string, unknown> = { ...options };
+  const define = withDefaultBuildDefines(options);
+  if (define) napiOptions.define = define;
   delete napiOptions.write;
   delete napiOptions.outdir;
   delete napiOptions.plugins;
@@ -1486,6 +1515,7 @@ export function buildAppSync(options: AppBuildOptions = {}): BuildResult {
   const { publicDir, compiler, ...rest } = options;
   return native.buildAppSync({
     ...rest,
+    define: withDefaultAppBuildDefines(options),
     ...(publicDir === false
       ? { disablePublicDir: true }
       : publicDir !== undefined


### PR DESCRIPTION
## 요약
- browser/app build 기본 define에 `process.env.NODE_ENV`를 자동 주입합니다.
- `zts dev`는 `"development"`, `zts build`와 browser bundle은 `"production"`을 사용합니다.
- `@zts/core` build API에도 같은 기본 define을 적용하고, React Native는 `__DEV__` 기본값도 맞춥니다.
- `examples/web`의 임시 `define` workaround를 제거했습니다.

Closes #2295

## 검증
- `bun test packages/core/index.test.ts --test-name-pattern "NODE_ENV|__DEV__"`
- `bun test packages/core/bin/zts.test.ts --test-name-pattern "process.env.NODE_ENV|Vite-style app builder"`
- `git diff --check`
- `bun run lint` (기존 unused import warnings 4건, error 0)
- pre-push hook: `zig fmt --check`, `zig build test`, `oxlint`, `oxfmt --check` 통과

## 참고
- `bun test packages/core`는 대부분 통과했지만 `packages/core/dist/core/index.d.ts` 등 타입 선언 산출물이 없는 상태에서 `types.test.ts` 7건이 실패했습니다. `build:dts`는 기존 `EmotionOptions.autoLabel` 타입/구현 불일치로 실패해 별도 정리가 필요합니다.