### PR TITLE
fix(cli): dev server config 옵션 지원

### DIFF
--- a/packages/core/bin/cli-flags.mjs
+++ b/packages/core/bin/cli-flags.mjs
@@ -76,6 +76,7 @@ export const FLAG_REGISTRY = [
   { kind: "bool", flag: "--preserve-symlinks", target: "preserveSymlinks" },
   { kind: "bool", flag: "--jsx-dev", target: "jsxDev" },
   { kind: "bool", flag: "--clean", target: "clean" },
+  { kind: "bool", flag: "--strict-port", target: "strictPort" },
 
   // ─── kind=string — string scalar (`--key=value` 단방향) ───
   { kind: "string", flag: "--format", target: "format", forms: ["equal"] },

--- a/packages/core/bin/zts-cli-schema-sync.test.ts
+++ b/packages/core/bin/zts-cli-schema-sync.test.ts
@@ -305,6 +305,7 @@ describe("CLI flag ↔ BuildOptions / TranspileOptions schema sync", () => {
     "--port=",
     "--host",
     "--host=",
+    "--strict-port",
     "--certfile",
     "--keyfile",
     "--proxy",

--- a/packages/core/bin/zts-cli-schema-sync.test.ts
+++ b/packages/core/bin/zts-cli-schema-sync.test.ts
@@ -340,6 +340,7 @@ describe("CLI flag ↔ BuildOptions / TranspileOptions schema sync", () => {
     "compiler", // compiler.styledComponents / compiler.emotion — 중첩 객체, CLI 미노출
     "manualChunks",
     "plugins",
+    "server", // server.port / server.host 는 개별 CLI flag 와 config-only nested 객체 양쪽 지원
     // entry — positional argument (flag 아님)
     "entryPoints",
     "filename", // transpile 의 filename — stdin 모드일 때 의미, CLI 가 자동 결정

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -121,6 +121,7 @@ function usageLines(command) {
       "Options:",
       "  --host [host]              Host to listen on (default: localhost)",
       "  --port <port>              Port to listen on (default: 12300)",
+      "  --strict-port              Exit if the specified port is already in use",
       "  --open                     Open the preview URL in the browser",
       "  --base <path>              Base public path",
       "  --spa-fallback[=path]      Serve an HTML fallback for app routes",
@@ -177,6 +178,7 @@ function parseArgs(argv) {
     serveDir: ".",
     port: undefined,
     host: undefined,
+    strictPort: false,
     open: false,
     proxy: {},
     format: undefined,
@@ -511,6 +513,9 @@ function mergeServerConfigIntoOpts(opts, config) {
     const host = normalizeServerHost(server.host);
     if (host !== undefined) opts.host = host;
   }
+  if (opts.strictPort === false && server.strictPort === true) {
+    opts.strictPort = true;
+  }
   if (opts.open === false && server.open === true) {
     opts.open = true;
   }
@@ -519,6 +524,26 @@ function mergeServerConfigIntoOpts(opts, config) {
 function applyServerDefaults(opts) {
   if (opts.port === undefined) opts.port = 12300;
   if (opts.host === undefined) opts.host = "localhost";
+}
+
+function isPortInUseError(err) {
+  const code = err?.code;
+  const message = String(err?.message ?? err);
+  return code === "EADDRINUSE" || /address already in use|port .*in use/i.test(message);
+}
+
+async function resolveServePort(opts, start) {
+  let port = opts.port;
+  for (;;) {
+    try {
+      const server = await start(port);
+      opts.port = port;
+      return server;
+    } catch (err) {
+      if (opts.strictPort || !isPortInUseError(err)) throw err;
+      port += 1;
+    }
+  }
 }
 
 async function runAppBuild(opts, config, configEnv, _dotenvVars) {
@@ -2204,7 +2229,10 @@ async function runServe(opts, config, { appDev = null } = {}) {
         key: globalThis.Bun.file(opts.keyfile),
       };
     }
-    serverHandle = globalThis.Bun.serve(serveOpts);
+    serverHandle = await resolveServePort(opts, (port) => {
+      serveOpts.port = port;
+      return globalThis.Bun.serve(serveOpts);
+    });
   } else {
     // Node.js http/https
     const handler = async (req, res) => {
@@ -2252,8 +2280,23 @@ async function runServe(opts, config, { appDev = null } = {}) {
         hmr.accept(req, socket);
       });
     }
-    server.listen(opts.port, opts.host);
-    serverHandle = server;
+    serverHandle = await resolveServePort(
+      opts,
+      (port) =>
+        new Promise((resolveListen, rejectListen) => {
+          const onError = (err) => {
+            server.off("listening", onListening);
+            rejectListen(err);
+          };
+          const onListening = () => {
+            server.off("error", onError);
+            resolveListen(server);
+          };
+          server.once("error", onError);
+          server.once("listening", onListening);
+          server.listen(port, opts.host);
+        }),
+    );
   }
 
   async function closeServerForRestart() {

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -175,8 +175,8 @@ function parseArgs(argv) {
     watchDelay: 100,
     serve: false,
     serveDir: ".",
-    port: 12300,
-    host: "localhost",
+    port: undefined,
+    host: undefined,
     open: false,
     proxy: {},
     format: undefined,
@@ -492,6 +492,33 @@ function injectDefaultNodeEnvDefine(opts) {
 
   const isDev = opts.appCommand === "dev" || opts.serve || opts.watch;
   opts.define["process.env.NODE_ENV"] = isDev ? '"development"' : '"production"';
+}
+
+function normalizeServerHost(host) {
+  if (host === true) return "0.0.0.0";
+  if (typeof host === "string" && host.length > 0) return host;
+  return undefined;
+}
+
+function mergeServerConfigIntoOpts(opts, config) {
+  const server = config?.server;
+  if (!server || typeof server !== "object") return;
+
+  if (opts.port === undefined && Number.isInteger(server.port)) {
+    opts.port = server.port;
+  }
+  if (opts.host === undefined) {
+    const host = normalizeServerHost(server.host);
+    if (host !== undefined) opts.host = host;
+  }
+  if (opts.open === false && server.open === true) {
+    opts.open = true;
+  }
+}
+
+function applyServerDefaults(opts) {
+  if (opts.port === undefined) opts.port = 12300;
+  if (opts.host === undefined) opts.host = "localhost";
 }
 
 async function runAppBuild(opts, config, configEnv, _dotenvVars) {
@@ -1775,6 +1802,7 @@ function mergeConfigIntoOpts(opts, config) {
       opts[key] = { ...config[key], ...opts[key] };
     }
   }
+  mergeServerConfigIntoOpts(opts, config);
 
   return opts;
 }
@@ -2543,6 +2571,7 @@ async function main() {
     ? resolve(opts.workspaceConfig)
     : findWorkspacePath(process.cwd());
   if (workspacePath) {
+    applyServerDefaults(opts);
     if (opts.workspaceConfig && !existsSync(workspacePath)) {
       throw new Error(`failed to load workspace — file not found: ${workspacePath}`);
     }
@@ -2563,6 +2592,7 @@ async function main() {
     }
     mergeConfigIntoOpts(opts, config);
   }
+  applyServerDefaults(opts);
 
   // import.meta.env.* + import.meta.env.MODE/PROD/DEV/SSR 정적 치환을 define 으로
   // 자동 주입. 사용자 명시 define 이 동일 키를 덮어쓰면 그대로 우선.

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import { spawn, spawnSync, execSync } from "node:child_process";
+import { createServer as createNetServer } from "node:net";
 import {
   cpSync,
   mkdtempSync,
@@ -34,6 +35,18 @@ async function waitForServer(port: number, maxRetries = 20, interval = 100, prot
     }
   }
   throw new Error(`Server on port ${port} did not start`);
+}
+
+async function occupyPort(port: number) {
+  const server = createNetServer();
+  await new Promise<void>((resolveListen, rejectListen) => {
+    server.once("error", rejectListen);
+    server.listen(port, "localhost", () => {
+      server.off("error", rejectListen);
+      resolveListen();
+    });
+  });
+  return () => new Promise<void>((resolveClose) => server.close(() => resolveClose()));
 }
 
 function shellQuote(value: string) {
@@ -2647,6 +2660,69 @@ describe("CLI: Vite-style app builder", () => {
       proc.kill();
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  test("dev [root] retries next port when server.strictPort is false", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-dev-server-port-retry-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "index.html"), '<script type="module" src="/src/main.ts"></script>');
+    writeFileSync(join(dir, "src", "main.ts"), "console.log('port-retry');");
+    const port = 12880 + Math.floor(Math.random() * 50);
+    const releasePort = await occupyPort(port);
+    writeFileSync(
+      join(dir, "zts.config.json"),
+      JSON.stringify({ server: { port, strictPort: false } }),
+    );
+
+    const proc = spawn(RUNTIME, [CLI, "dev", dir], {
+      cwd: dir,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stderr = "";
+    proc.stderr?.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    await waitForServer(port + 1);
+
+    try {
+      const js = await fetch(`http://localhost:${port + 1}/bundle.js`).then((r) => r.text());
+      expect(js).toContain("port-retry");
+      expect(stderr).toContain(`[serve] http://localhost:${port + 1}`);
+    } finally {
+      proc.kill();
+      await releasePort();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("dev [root] fails on occupied port when server.strictPort is true", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-dev-server-strict-port-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "index.html"), '<script type="module" src="/src/main.ts"></script>');
+    writeFileSync(join(dir, "src", "main.ts"), "console.log('strict-port');");
+    const port = 12940 + Math.floor(Math.random() * 50);
+    const releasePort = await occupyPort(port);
+    writeFileSync(
+      join(dir, "zts.config.json"),
+      JSON.stringify({ server: { port, strictPort: true } }),
+    );
+
+    const result = await new Promise<{ code: number | null; stderr: string }>((resolveExit) => {
+      const proc = spawn(RUNTIME, [CLI, "dev", dir], {
+        cwd: dir,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let stderr = "";
+      proc.stderr?.on("data", (chunk) => {
+        stderr += String(chunk);
+      });
+      proc.on("exit", (code) => resolveExit({ code, stderr }));
+    });
+
+    await releasePort();
+    rmSync(dir, { recursive: true, force: true });
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/EADDRINUSE|address already in use/i);
   });
 
   test("dev restarts and reloads zts.config changes", async () => {

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -2600,6 +2600,55 @@ describe("CLI: Vite-style app builder", () => {
     }
   });
 
+  test("dev [root] uses config server.port and server.host", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-dev-server-config-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "index.html"), '<script type="module" src="/src/main.ts"></script>');
+    writeFileSync(join(dir, "src", "main.ts"), "console.log('server-config');");
+    const port = 12680 + Math.floor(Math.random() * 100);
+    writeFileSync(join(dir, "zts.config.json"), JSON.stringify({ server: { port, host: true } }));
+
+    const proc = spawn(RUNTIME, [CLI, "dev", dir], {
+      cwd: dir,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stderr = "";
+    proc.stderr?.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    await waitForServer(port);
+
+    try {
+      const js = await fetch(`http://localhost:${port}/bundle.js`).then((r) => r.text());
+      expect(js).toContain("server-config");
+      expect(stderr).toContain(`[serve] http://0.0.0.0:${port}`);
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("dev [root] CLI --port overrides config server.port", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-app-dev-server-cli-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "index.html"), '<script type="module" src="/src/main.ts"></script>');
+    writeFileSync(join(dir, "src", "main.ts"), "console.log('cli-port');");
+    const configPort = 12780 + Math.floor(Math.random() * 50);
+    const cliPort = configPort + 100;
+    writeFileSync(join(dir, "zts.config.json"), JSON.stringify({ server: { port: configPort } }));
+
+    const proc = spawn(RUNTIME, [CLI, "dev", dir, `--port=${cliPort}`], { cwd: dir });
+    await waitForServer(cliPort);
+
+    try {
+      const js = await fetch(`http://localhost:${cliPort}/bundle.js`).then((r) => r.text());
+      expect(js).toContain("cli-port");
+    } finally {
+      proc.kill();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("dev restarts and reloads zts.config changes", async () => {
     const dir = mkdtempSync(join(tmpdir(), "zts-app-dev-config-restart-"));
     mkdirSync(join(dir, "src"), { recursive: true });

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -363,6 +363,16 @@ export interface EmotionOptions {
   importMap?: Record<string, Record<string, { canonicalImport: [string, string] }>>;
 }
 
+/** Vite-style dev server options used by `zts dev` / `zts --serve`. */
+export interface DevServerOptions {
+  /** Port to listen on. CLI `--port` overrides this value. */
+  port?: number;
+  /** Host to listen on. `true` means `0.0.0.0`, matching Vite. CLI `--host` overrides this value. */
+  host?: string | boolean;
+  /** Open the served URL in the browser after startup. CLI `--open` overrides this value. */
+  open?: boolean;
+}
+
 /**
  * Common build options shared by all platforms.
  * `platform` + `target` 조합은 `BuildOptions` 에서 discriminated union으로 제한됨.
@@ -429,6 +439,8 @@ interface BuildOptionsCommon {
    * 키는 식별자 또는 `obj.prop` 같은 멤버 표현식, 값은 JS 표현식 문자열.
    * 예: `{ "__DEV__": "false", "process.env.NODE_ENV": '"production"' }` */
   define?: Record<string, string>;
+  /** Dev server defaults for `zts dev` / `zts --serve`. CLI flags still take precedence. */
+  server?: DevServerOptions;
   /** Import 경로 별칭 — 두 형태 지원 (esbuild / Vite 호환):
    *
    * 1. **Object 형태** (esbuild `alias`): exact + prefix 매칭. 정해진 specifier 만 치환.

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -369,6 +369,8 @@ export interface DevServerOptions {
   port?: number;
   /** Host to listen on. `true` means `0.0.0.0`, matching Vite. CLI `--host` overrides this value. */
   host?: string | boolean;
+  /** Exit if the configured port is already in use instead of trying the next port. */
+  strictPort?: boolean;
   /** Open the served URL in the browser after startup. CLI `--open` overrides this value. */
   open?: boolean;
 }

--- a/packages/core/src/typo-suggest.ts
+++ b/packages/core/src/typo-suggest.ts
@@ -132,6 +132,7 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   "external",
   "alias",
   "define",
+  "server",
   "loader",
   "conditions",
   "resolveExtensions",

--- a/src/config_options_dto_test.zig
+++ b/src/config_options_dto_test.zig
@@ -226,6 +226,7 @@ const ts_buildoptions_only_allowlist = [_][]const u8{
     "experimentalCodeCache", // persistent cache 실험
     "watch", // CLI flag, BuildOptions 노출 안 함이 정석이지만 일부 wrapper 가 노출
     "extends", // config-only
+    "server", // config-only dev server defaults
 
     // ─── BuildOptions / NAPI 전용 — Zig DTO 미노출이 의도된 것들 ──────────────
     // 사용자 코드가 NAPI 또는 build() JS API 로 직접 전달. CLI / config 경로는 미사용.


### PR DESCRIPTION
## 요약
- `zts.config.*`에서 `server.port`, `server.host`, `server.open`, `server.strictPort`를 설정할 수 있게 했습니다.
- CLI `--port`, `--host`, `--open`, `--strict-port`가 config보다 우선하도록 유지했습니다.
- `strictPort: false` 기본 동작에서는 지정 포트가 점유된 경우 다음 포트로 재시도하고, `true`면 즉시 실패합니다.

Closes #2294

## 검증
- `bun run --cwd packages/core build:js`
- `bun test packages/core/bin/zts.test.ts --test-name-pattern "server.port|strictPort|CLI --port overrides"`
- `bun test packages/core/bin/zts-cli-schema-sync.test.ts packages/core/src/typo-suggest.test.ts`
- `bun run --cwd packages/core build:dts`
- `bun test packages/core/types.test.ts`
- pre-push (`zig fmt --check`, `zig build test`, `oxlint`, `oxfmt --check`) 통과
