### PR TITLE
fix(cli): app root 기준 config 로드

### DIFF
--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -546,6 +546,13 @@ async function resolveServePort(opts, start) {
   }
 }
 
+function getAutoConfigSearchDir(opts) {
+  if (opts.appCommand === "dev" || opts.appCommand === "build") {
+    return resolve(opts.appRoot ?? ".");
+  }
+  return process.cwd();
+}
+
 async function runAppBuild(opts, config, configEnv, _dotenvVars) {
   if (config?.plugins?.length || opts.pluginPaths.length > 0) {
     throw new Error(
@@ -1678,13 +1685,14 @@ async function loadAutoConfig(opts) {
   if (explicit && !existsSync(explicit)) {
     throw new Error(`failed to load config — file not found: ${explicit}`);
   }
-  const configPath = explicit ?? findConfigPath(process.cwd());
+  const configSearchDir = getAutoConfigSearchDir(opts);
+  const configPath = explicit ?? findConfigPath(configSearchDir);
 
   const command = opts.serve ? "serve" : opts.watch ? "watch" : "bundle";
   const mode = opts.mode ?? (command === "bundle" ? "production" : "development");
 
   // .env 파일 4단계 우선순위로 로드 (#2106). prefix 미지정 시 default `["VITE_", "ZTS_"]`.
-  const envDir = opts.envDir ? resolve(opts.envDir) : process.cwd();
+  const envDir = opts.envDir ? resolve(opts.envDir) : configSearchDir;
   const dotenvVars = loadEnv(mode, envDir, opts.envPrefixes);
 
   // dotenv 키 중 shell env 에도 정의된 건 shell 값으로 override (CI/배포 시 .env
@@ -1702,7 +1710,7 @@ async function loadAutoConfig(opts) {
 
   // mode-specific config 자동 탐색 + 머지 (#2110). `--config <path>` 명시 시
   // 그 파일이 단독 source — mode-specific 자동 탐색 안 함 (사용자 의도 존중).
-  const modeConfigPath = explicit ? null : findModeConfigPath(process.cwd(), mode);
+  const modeConfigPath = explicit ? null : findModeConfigPath(configSearchDir, mode);
 
   if (!configPath && !modeConfigPath) return { config: null, env, dotenvVars };
 
@@ -2053,16 +2061,17 @@ async function runWatch(opts, config) {
  */
 function computeRestartTriggers(opts) {
   const dirs = new Set();
-  const envDir = opts.envDir ? resolve(opts.envDir) : process.cwd();
+  const configSearchDir = getAutoConfigSearchDir(opts);
+  const envDir = opts.envDir ? resolve(opts.envDir) : configSearchDir;
   dirs.add(envDir);
 
   const explicitConfig = opts.configPath ? resolve(opts.configPath) : null;
-  const autoConfig = explicitConfig ?? findConfigPath(process.cwd());
+  const autoConfig = explicitConfig ?? findConfigPath(configSearchDir);
   if (autoConfig) dirs.add(dirname(autoConfig));
 
   const mode = opts.mode ?? (opts.serve || opts.watch ? "development" : "production");
   // mode-specific config (`zts.config.${mode}.{ext}`) 변경도 restart trigger (#2110).
-  const modeConfig = explicitConfig ? null : findModeConfigPath(process.cwd(), mode);
+  const modeConfig = explicitConfig ? null : findModeConfigPath(configSearchDir, mode);
   if (modeConfig) dirs.add(dirname(modeConfig));
 
   const configBase = autoConfig ? basename(autoConfig) : null;

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -2562,6 +2562,37 @@ describe("CLI: Vite-style app builder", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  test("build [root] loads root argument config from outside cwd", () => {
+    const parent = mkdtempSync(join(tmpdir(), "zts-app-build-parent-config-"));
+    const dir = join(parent, "app");
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "index.html"), '<script type="module" src="/src/main.ts"></script>');
+    writeFileSync(
+      join(dir, "src", "main.ts"),
+      "document.body.textContent = __APP_LABEL__; console.log(__APP_LABEL__);",
+    );
+    writeFileSync(
+      join(dir, "zts.config.json"),
+      JSON.stringify({ define: { __APP_LABEL__: JSON.stringify("base-config") } }),
+    );
+    writeFileSync(
+      join(dir, "zts.config.production.json"),
+      JSON.stringify({ define: { __APP_LABEL__: JSON.stringify("root-mode-config") } }),
+    );
+
+    const outdir = join(parent, "dist");
+    const { exitCode, stderr } = runCli(["build", dir, "--outdir", outdir], { cwd: parent });
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toContain("error:");
+
+    const html = readFileSync(join(outdir, "index.html"), "utf8");
+    const scriptPath = scriptPathFromHtml(html);
+    const js = readFileSync(join(outdir, scriptPath.replace(/^\//, "")), "utf8");
+    expect(js).toContain('"root-mode-config"');
+    expect(js).not.toContain("__APP_LABEL__");
+    rmSync(parent, { recursive: true, force: true });
+  });
+
   test("public output collision fails deterministically", () => {
     const dir = mkdtempSync(join(tmpdir(), "zts-app-public-collision-"));
     mkdirSync(join(dir, "src"), { recursive: true });
@@ -2610,6 +2641,38 @@ describe("CLI: Vite-style app builder", () => {
     } finally {
       proc.kill();
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("dev [root] loads root argument config from outside cwd", async () => {
+    const parent = mkdtempSync(join(tmpdir(), "zts-app-dev-parent-config-"));
+    const dir = join(parent, "app");
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "index.html"), '<script type="module" src="/src/main.ts"></script>');
+    writeFileSync(
+      join(dir, "src", "main.ts"),
+      "document.body.textContent = __APP_LABEL__; console.log(__APP_LABEL__);",
+    );
+    writeFileSync(
+      join(dir, "zts.config.json"),
+      JSON.stringify({ define: { __APP_LABEL__: JSON.stringify("base-config") } }),
+    );
+    writeFileSync(
+      join(dir, "zts.config.development.json"),
+      JSON.stringify({ define: { __APP_LABEL__: JSON.stringify("root-dev-config") } }),
+    );
+
+    const port = 12620 + Math.floor(Math.random() * 100);
+    const proc = spawn(RUNTIME, [CLI, "dev", dir, `--port=${port}`], { cwd: parent });
+    await waitForServer(port);
+
+    try {
+      const js = await fetch(`http://localhost:${port}/bundle.js`).then((r) => r.text());
+      expect(js).toContain('"root-dev-config"');
+      expect(js).not.toContain("__APP_LABEL__");
+    } finally {
+      proc.kill();
+      rmSync(parent, { recursive: true, force: true });
     }
   });
 


### PR DESCRIPTION
## 요약
- `zts dev <root>`, `zts build <root>`에서 자동 config 탐색 기준을 cwd가 아니라 app root로 변경했습니다.
- mode-specific config와 restart trigger의 config/env 감시 기준도 같은 app root 기준으로 맞췄습니다.
- cwd가 parent인 상태에서 app root의 base/mode config가 적용되는 dev/build 회귀 테스트를 추가했습니다.

Closes #2306

## 검증
- `bun run --cwd packages/core build:js`
- `bun test packages/core/bin/zts.test.ts --test-name-pattern "root argument config from outside cwd"`
- `bun test packages/core/bin/zts.test.ts --test-name-pattern "Vite-style app builder"`
- `bun run fmt:check`
- `bun run lint` (기존 unused-import 경고 4개만 출력)
- `git diff --check`
- pre-push hook: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`