### PR TITLE
fix(transform): private syntax debug invariant 추가

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1566,6 +1566,9 @@ pub fn emitModule(
         .dev_module_id = if (options.dev_mode and module.dev_id.len > 0) module.dev_id else null,
         .import_records = module.import_records,
         .worker_map = if (options.worker_map_per_module) |outer| outer.getPtr(module.path) else null,
+        .assert_no_raw_private_syntax = options.unsupported.class or
+            options.unsupported.class_private_field or
+            options.unsupported.class_private_method,
     });
     // 소스맵용: line_offsets와 소스 파일 등록
     if (options.sourcemap.enable) {

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1566,9 +1566,7 @@ pub fn emitModule(
         .dev_module_id = if (options.dev_mode and module.dev_id.len > 0) module.dev_id else null,
         .import_records = module.import_records,
         .worker_map = if (options.worker_map_per_module) |outer| outer.getPtr(module.path) else null,
-        .assert_no_raw_private_syntax = options.unsupported.class or
-            options.unsupported.class_private_field or
-            options.unsupported.class_private_method,
+        .assert_no_raw_private_syntax = options.unsupported.requiresPrivateDownlevel(),
     });
     // 소스맵용: line_offsets와 소스 파일 등록
     if (options.sourcemap.enable) {

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -332,6 +332,9 @@ pub fn emitEsmWrappedModule(
             .source_root = options.sourcemap.source_root orelse "",
             .sources_content = options.sourcemap.sources_content,
             .import_records = module.import_records,
+            .assert_no_raw_private_syntax = options.unsupported.class or
+                options.unsupported.class_private_field or
+                options.unsupported.class_private_method,
         });
         if (options.sourcemap.enable) {
             hoist_cg.line_offsets = module.line_offsets;
@@ -530,6 +533,9 @@ pub fn emitEsmWrappedModule(
         .source_root = options.sourcemap.source_root orelse "",
         .sources_content = options.sourcemap.sources_content,
         .import_records = module.import_records,
+        .assert_no_raw_private_syntax = options.unsupported.class or
+            options.unsupported.class_private_field or
+            options.unsupported.class_private_method,
     });
     // 소스맵: 소스 파일 등록 + line_offsets 설정
     if (options.sourcemap.enable) {
@@ -554,6 +560,9 @@ pub fn emitEsmWrappedModule(
             .source_root = options.sourcemap.source_root orelse "",
             .sources_content = options.sourcemap.sources_content,
             .import_records = module.import_records,
+            .assert_no_raw_private_syntax = options.unsupported.class or
+                options.unsupported.class_private_field or
+                options.unsupported.class_private_method,
         });
         if (options.sourcemap.enable) {
             func_cg.line_offsets = module.line_offsets;

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -332,9 +332,7 @@ pub fn emitEsmWrappedModule(
             .source_root = options.sourcemap.source_root orelse "",
             .sources_content = options.sourcemap.sources_content,
             .import_records = module.import_records,
-            .assert_no_raw_private_syntax = options.unsupported.class or
-                options.unsupported.class_private_field or
-                options.unsupported.class_private_method,
+            .assert_no_raw_private_syntax = options.unsupported.requiresPrivateDownlevel(),
         });
         if (options.sourcemap.enable) {
             hoist_cg.line_offsets = module.line_offsets;
@@ -533,9 +531,7 @@ pub fn emitEsmWrappedModule(
         .source_root = options.sourcemap.source_root orelse "",
         .sources_content = options.sourcemap.sources_content,
         .import_records = module.import_records,
-        .assert_no_raw_private_syntax = options.unsupported.class or
-            options.unsupported.class_private_field or
-            options.unsupported.class_private_method,
+        .assert_no_raw_private_syntax = options.unsupported.requiresPrivateDownlevel(),
     });
     // 소스맵: 소스 파일 등록 + line_offsets 설정
     if (options.sourcemap.enable) {
@@ -560,9 +556,7 @@ pub fn emitEsmWrappedModule(
             .source_root = options.sourcemap.source_root orelse "",
             .sources_content = options.sourcemap.sources_content,
             .import_records = module.import_records,
-            .assert_no_raw_private_syntax = options.unsupported.class or
-                options.unsupported.class_private_field or
-                options.unsupported.class_private_method,
+            .assert_no_raw_private_syntax = options.unsupported.requiresPrivateDownlevel(),
         });
         if (options.sourcemap.enable) {
             func_cg.line_offsets = module.line_offsets;

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -10,7 +10,6 @@
 //! - references/esbuild/internal/js_printer/js_printer.go
 
 const std = @import("std");
-const builtin = @import("builtin");
 const ast_mod = @import("../parser/ast.zig");
 const Node = ast_mod.Node;
 const Tag = Node.Tag;
@@ -260,12 +259,9 @@ pub const Codegen = struct {
     /// 특정 statement 노드 목록만 코드로 생성한다 (__esm var 호이스팅용).
     /// root는 collectTopLevelDeclNames에만 사용. 실제 출력은 stmt_indices에서.
     pub fn generateStatements(self: *Codegen, root: NodeIndex, stmt_indices: []const u32) ![]const u8 {
-        if (builtin.mode == .Debug and self.options.assert_no_raw_private_syntax) {
+        if (self.options.assert_no_raw_private_syntax) {
             for (stmt_indices) |raw_idx| {
-                const node_idx: NodeIndex = @enumFromInt(raw_idx);
-                if (hasRawPrivateSyntax(self.ast, node_idx)) {
-                    @panic("internal compiler invariant violated: raw private syntax reached codegen after downlevel transform");
-                }
+                std.debug.assert(!hasRawPrivateSyntax(self.ast, @enumFromInt(raw_idx)));
             }
         }
         try self.buf.ensureTotalCapacity(self.allocator, self.ast.source.len / 2);
@@ -287,10 +283,8 @@ pub const Codegen = struct {
         var scope = @import("../profile.zig").begin(.codegen);
         defer scope.end();
 
-        if (builtin.mode == .Debug and self.options.assert_no_raw_private_syntax and
-            hasRawPrivateSyntax(self.ast, root))
-        {
-            @panic("internal compiler invariant violated: raw private syntax reached codegen after downlevel transform");
+        if (self.options.assert_no_raw_private_syntax) {
+            std.debug.assert(!hasRawPrivateSyntax(self.ast, root));
         }
 
         // 출력 크기는 보통 소스 크기와 비슷 → 사전 할당
@@ -4041,56 +4035,4 @@ pub const Codegen = struct {
     }
 };
 
-pub fn hasRawPrivateSyntax(ast: *const Ast, root: NodeIndex) bool {
-    if (root.isNone()) return false;
-    const raw = @intFromEnum(root);
-    if (raw >= ast.nodes.items.len) return false;
-
-    const node = ast.getNode(root);
-    switch (node.tag) {
-        .private_field_expression, .private_identifier => return true,
-        else => {},
-    }
-
-    switch (Node.Tag.dataKind(node.tag)) {
-        .leaf => return false,
-        .unary => return hasRawPrivateSyntax(ast, node.data.unary.operand),
-        .binary => return hasRawPrivateSyntax(ast, node.data.binary.left) or
-            hasRawPrivateSyntax(ast, node.data.binary.right),
-        .ternary => return hasRawPrivateSyntax(ast, node.data.ternary.a) or
-            hasRawPrivateSyntax(ast, node.data.ternary.b) or
-            hasRawPrivateSyntax(ast, node.data.ternary.c),
-        .list => return nodeListHasRawPrivateSyntax(ast, node.data.list),
-        .extra => {
-            const base = node.data.extra;
-            for (Node.Tag.extraChildOffsets(node.tag)) |offset| {
-                const extra_idx = base + offset;
-                if (extra_idx >= ast.extra_data.items.len) continue;
-                if (hasRawPrivateSyntax(ast, @enumFromInt(ast.extra_data.items[extra_idx]))) {
-                    return true;
-                }
-            }
-            for (Node.Tag.extraListOffsets(node.tag)) |offsets| {
-                const start_idx = base + offsets[0];
-                const len_idx = base + offsets[1];
-                if (start_idx >= ast.extra_data.items.len or len_idx >= ast.extra_data.items.len) continue;
-                const list = NodeList{
-                    .start = ast.extra_data.items[start_idx],
-                    .len = ast.extra_data.items[len_idx],
-                };
-                if (nodeListHasRawPrivateSyntax(ast, list)) return true;
-            }
-            return false;
-        },
-    }
-}
-
-fn nodeListHasRawPrivateSyntax(ast: *const Ast, list: NodeList) bool {
-    if (list.start > ast.extra_data.items.len) return false;
-    const end = list.start + list.len;
-    if (end > ast.extra_data.items.len) return false;
-    for (ast.extra_data.items[list.start..end]) |raw_child| {
-        if (hasRawPrivateSyntax(ast, @enumFromInt(raw_child))) return true;
-    }
-    return false;
-}
+pub const hasRawPrivateSyntax = @import("../parser/ast_walk.zig").hasRawPrivateSyntax;

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -10,6 +10,7 @@
 //! - references/esbuild/internal/js_printer/js_printer.go
 
 const std = @import("std");
+const builtin = @import("builtin");
 const ast_mod = @import("../parser/ast.zig");
 const Node = ast_mod.Node;
 const Tag = Node.Tag;
@@ -137,6 +138,9 @@ pub const CodegenOptions = struct {
     /// 로 직접 emit. bundler 가 모듈별로 sub-map 을 추출해 주입한다 (graph.worker_entries 에서
     /// 도출). null/empty 면 fast-exit — worker 가 없는 모듈에서 추가 비용 0.
     worker_map: ?*const std.StringHashMap([]const u8) = null,
+    /// Debug 빌드 전용 내부 invariant. private syntax downlevel 대상인데 transformer 후
+    /// raw private AST가 codegen까지 도달하면 사용자 입력 에러가 아니라 transformer 버그다.
+    assert_no_raw_private_syntax: bool = false,
 };
 
 /// keepNames 엔트리. codegen이 수집하고 emitter가 __name() 호출로 변환.
@@ -256,6 +260,14 @@ pub const Codegen = struct {
     /// 특정 statement 노드 목록만 코드로 생성한다 (__esm var 호이스팅용).
     /// root는 collectTopLevelDeclNames에만 사용. 실제 출력은 stmt_indices에서.
     pub fn generateStatements(self: *Codegen, root: NodeIndex, stmt_indices: []const u32) ![]const u8 {
+        if (builtin.mode == .Debug and self.options.assert_no_raw_private_syntax) {
+            for (stmt_indices) |raw_idx| {
+                const node_idx: NodeIndex = @enumFromInt(raw_idx);
+                if (hasRawPrivateSyntax(self.ast, node_idx)) {
+                    @panic("internal compiler invariant violated: raw private syntax reached codegen after downlevel transform");
+                }
+            }
+        }
         try self.buf.ensureTotalCapacity(self.allocator, self.ast.source.len / 2);
         self.collectTopLevelDeclNames(root);
         var emitted = false;
@@ -274,6 +286,12 @@ pub const Codegen = struct {
     pub fn generate(self: *Codegen, root: NodeIndex) ![]const u8 {
         var scope = @import("../profile.zig").begin(.codegen);
         defer scope.end();
+
+        if (builtin.mode == .Debug and self.options.assert_no_raw_private_syntax and
+            hasRawPrivateSyntax(self.ast, root))
+        {
+            @panic("internal compiler invariant violated: raw private syntax reached codegen after downlevel transform");
+        }
 
         // 출력 크기는 보통 소스 크기와 비슷 → 사전 할당
         try self.buf.ensureTotalCapacity(self.allocator, self.ast.source.len);
@@ -4022,3 +4040,57 @@ pub const Codegen = struct {
         }
     }
 };
+
+pub fn hasRawPrivateSyntax(ast: *const Ast, root: NodeIndex) bool {
+    if (root.isNone()) return false;
+    const raw = @intFromEnum(root);
+    if (raw >= ast.nodes.items.len) return false;
+
+    const node = ast.getNode(root);
+    switch (node.tag) {
+        .private_field_expression, .private_identifier => return true,
+        else => {},
+    }
+
+    switch (Node.Tag.dataKind(node.tag)) {
+        .leaf => return false,
+        .unary => return hasRawPrivateSyntax(ast, node.data.unary.operand),
+        .binary => return hasRawPrivateSyntax(ast, node.data.binary.left) or
+            hasRawPrivateSyntax(ast, node.data.binary.right),
+        .ternary => return hasRawPrivateSyntax(ast, node.data.ternary.a) or
+            hasRawPrivateSyntax(ast, node.data.ternary.b) or
+            hasRawPrivateSyntax(ast, node.data.ternary.c),
+        .list => return nodeListHasRawPrivateSyntax(ast, node.data.list),
+        .extra => {
+            const base = node.data.extra;
+            for (Node.Tag.extraChildOffsets(node.tag)) |offset| {
+                const extra_idx = base + offset;
+                if (extra_idx >= ast.extra_data.items.len) continue;
+                if (hasRawPrivateSyntax(ast, @enumFromInt(ast.extra_data.items[extra_idx]))) {
+                    return true;
+                }
+            }
+            for (Node.Tag.extraListOffsets(node.tag)) |offsets| {
+                const start_idx = base + offsets[0];
+                const len_idx = base + offsets[1];
+                if (start_idx >= ast.extra_data.items.len or len_idx >= ast.extra_data.items.len) continue;
+                const list = NodeList{
+                    .start = ast.extra_data.items[start_idx],
+                    .len = ast.extra_data.items[len_idx],
+                };
+                if (nodeListHasRawPrivateSyntax(ast, list)) return true;
+            }
+            return false;
+        },
+    }
+}
+
+fn nodeListHasRawPrivateSyntax(ast: *const Ast, list: NodeList) bool {
+    if (list.start > ast.extra_data.items.len) return false;
+    const end = list.start + list.len;
+    if (end > ast.extra_data.items.len) return false;
+    for (ast.extra_data.items[list.start..end]) |raw_child| {
+        if (hasRawPrivateSyntax(ast, @enumFromInt(raw_child))) return true;
+    }
+    return false;
+}

--- a/src/codegen/codegen_test/helpers.zig
+++ b/src/codegen/codegen_test/helpers.zig
@@ -168,9 +168,7 @@ pub fn e2eTarget(allocator: std.mem.Allocator, source: []const u8, target: Trans
     const unsupported = TransformOptions.compat.fromESTarget(target);
     return e2eFull(allocator, source, .{ .unsupported = unsupported }, .{
         .minify_whitespace = true,
-        .assert_no_raw_private_syntax = unsupported.class or
-            unsupported.class_private_field or
-            unsupported.class_private_method,
+        .assert_no_raw_private_syntax = unsupported.requiresPrivateDownlevel(),
     }, ".ts");
 }
 

--- a/src/codegen/codegen_test/helpers.zig
+++ b/src/codegen/codegen_test/helpers.zig
@@ -165,7 +165,13 @@ pub fn e2eWithOptions(allocator: std.mem.Allocator, source: []const u8, cg_optio
 // --- ES downlevel helpers ---
 
 pub fn e2eTarget(allocator: std.mem.Allocator, source: []const u8, target: TransformOptions.compat.ESTarget) !TestResult {
-    return e2eFull(allocator, source, .{ .unsupported = TransformOptions.compat.fromESTarget(target) }, .{ .minify_whitespace = true }, ".ts");
+    const unsupported = TransformOptions.compat.fromESTarget(target);
+    return e2eFull(allocator, source, .{ .unsupported = unsupported }, .{
+        .minify_whitespace = true,
+        .assert_no_raw_private_syntax = unsupported.class or
+            unsupported.class_private_field or
+            unsupported.class_private_method,
+    }, ".ts");
 }
 
 pub fn expectAsyncStateMachine(output: []const u8) !void {

--- a/src/codegen/codegen_test/private_jsx_advanced.zig
+++ b/src/codegen/codegen_test/private_jsx_advanced.zig
@@ -14,6 +14,7 @@ const e2eJSXAutomatic = helpers.e2eJSXAutomatic;
 const e2eJSXDev = helpers.e2eJSXDev;
 const e2eJSXAutomaticTarget = helpers.e2eJSXAutomaticTarget;
 const e2eJSXClassicTarget = helpers.e2eJSXClassicTarget;
+const codegen_mod = helpers.codegen_mod;
 
 // Private Method (#method → WeakSet + standalone function)
 // ============================================================
@@ -206,14 +207,17 @@ test "private method: nested class expression inside outer class body (es2021)" 
     try std.testing.expect(std.mem.indexOf(u8, r.output, ",var _n") == null);
 }
 
-test "private static method: class expression — no stitching even if passthrough (es2021)" {
-    // 현재 static private method는 다운레벨링 대상이 아니어서 원본 class expression 유지.
-    // 최소한의 회귀 방지: 쉼표 stitching 버그가 재발하지 않는지 확인.
-    // TODO(es2021): static private method 다운레벨링 구현 시 IIFE 래핑도 같이 검증.
+test "private static method: class expression lowers without stitching (es2021)" {
     var r = try e2eTarget(std.testing.allocator,
-        \\const W = class { static #m() { return 1; } };
+        \\const W = class {
+        \\  static #m() { return 1; }
+        \\  static call() { return this.#m(); }
+        \\};
     , .es2021);
     defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__classStaticPrivateFieldSpecGet") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_m_fn") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, ".#m(") == null);
     // 쉼표 stitching 부재 (버그 증상)
     try std.testing.expect(std.mem.indexOf(u8, r.output, ",var _m") == null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "},var ") == null);
@@ -231,6 +235,57 @@ test "private getter: class expression wrapped in IIFE (es2021)" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "})()") != null);
     // 쉼표 stitching 없음
     try std.testing.expect(std.mem.indexOf(u8, r.output, "},var ") == null);
+}
+
+test "private static method: class declaration call lowers (es2021)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Foo {
+        \\  static #m() { return 1; }
+        \\  static call() { return Foo.#m(); }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var _m={writable:true,value:_m_fn}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function _m_fn()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__classStaticPrivateFieldSpecGet(Foo,Foo,_m).call(Foo)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, ".#m(") == null);
+}
+
+test "private static method: method reference binds receiver (es2021)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Foo {
+        \\  static #m() { return this; }
+        \\  static ref() { return this.#m; }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__classStaticPrivateFieldSpecGet(this,Foo,_m).bind(this)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, ".#m") == null);
+}
+
+test "private static method: brand check lowers to class identity (es2021)" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Foo {
+        \\  static #m() { return 1; }
+        \\  static has(o) { return #m in o; }
+        \\}
+    , .es2021);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "o===Foo") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "#m in") == null);
+}
+
+test "private static method: es2022 target preserves original" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Foo {
+        \\  static #m() { return 1; }
+        \\  static call() { return this.#m(); }
+        \\}
+    , .es2022);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "static #m()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "this.#m()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__classStaticPrivateFieldSpecGet") == null);
 }
 
 // 회귀 가드: private *field* 의 arrow init 안에서 다른 private *method* 호출이
@@ -268,6 +323,31 @@ test "private field arrow init: this.#method() inside nested arrow lowers (es5)"
     // raw private method call 이 남으면 안 됨
     try std.testing.expect(std.mem.indexOf(u8, r.output, ".#applyModern(") == null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, ".#applyLegacy(") == null);
+}
+
+test "private downlevel debug invariant: raw private syntax absent after transform" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const source =
+        \\class Foo {
+        \\  #handler = () => { this.#flush(); };
+        \\  #flush() { return 1; }
+        \\}
+    ;
+
+    var scanner = try helpers.Scanner.init(allocator, source);
+    var parser = helpers.Parser.init(allocator, &scanner);
+    parser.configureFromExtension(".ts");
+    const parsed_root = try parser.parse();
+    try std.testing.expect(codegen_mod.hasRawPrivateSyntax(&parser.ast, parsed_root));
+
+    const unsupported = TransformOptions.compat.fromESTarget(.es2021);
+    var transformer = try helpers.Transformer.init(allocator, &parser.ast, .{
+        .unsupported = unsupported,
+    });
+    const transformed_root = try transformer.transform();
+    try std.testing.expect(!codegen_mod.hasRawPrivateSyntax(transformer.ast, transformed_root));
 }
 
 test "private method: es2022 target preserves original" {

--- a/src/parser/ast_walk.zig
+++ b/src/parser/ast_walk.zig
@@ -145,6 +145,26 @@ pub fn children(ast: *const Ast, node: Node) ChildIterator {
     };
 }
 
+/// `root` 서브트리에 raw `#x` private syntax (`private_field_expression` /
+/// `private_identifier`) 가 남아 있는지 검사. transformer 가 lowering 했어야 할 노드가
+/// codegen 까지 도달했는지 검증하는 debug invariant 용도 — 정상 코드 경로에서는 항상 false.
+pub fn hasRawPrivateSyntax(ast: *const Ast, root: NodeIndex) bool {
+    if (root.isNone()) return false;
+    if (@intFromEnum(root) >= ast.nodes.items.len) return false;
+
+    const node = ast.nodes.items[@intFromEnum(root)];
+    switch (node.tag) {
+        .private_field_expression, .private_identifier => return true,
+        else => {},
+    }
+
+    var it = children(ast, node);
+    while (it.next()) |child_idx| {
+        if (hasRawPrivateSyntax(ast, child_idx)) return true;
+    }
+    return false;
+}
+
 /// AST 루트(마지막 program 노드)에서 도달 가능한 노드 인덱스를 pre-order로 수집한다.
 /// transformer는 새 노드를 append하면서 이전 노드를 orphan으로 남길 수 있으므로,
 /// post-transform 분석은 `ast.nodes.items` 전체 순회 대신 이 결과를 사용해야 한다.

--- a/src/transformer/compat.zig
+++ b/src/transformer/compat.zig
@@ -184,6 +184,13 @@ pub const UnsupportedFeatures = packed struct(u32) {
     pub fn merge(self: UnsupportedFeatures, other: UnsupportedFeatures) UnsupportedFeatures {
         return @bitCast(@as(u32, @bitCast(self)) | @as(u32, @bitCast(other)));
     }
+
+    /// class / class_private_field / class_private_method 중 하나라도 unsupported 면 true.
+    /// transformer 가 raw private syntax 를 lowering 할 책임이 있는 경우 — codegen 의 invariant
+    /// assert 와 emitter/transpile 옵션 전파에 사용.
+    pub fn requiresPrivateDownlevel(self: UnsupportedFeatures) bool {
+        return self.class or self.class_private_field or self.class_private_method;
+    }
 };
 
 // ─── 엔진 버전 ───

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1240,7 +1240,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             if (mapping.is_static) {
                 const helper = try es_helpers.makeRuntimeHelperRef(self, "__classStaticPrivateFieldSpecSet");
                 const new_obj = try self.visitNode(obj_idx);
-                const class_ref = try es_helpers.makeIdentifierRef(self, mapping.class_name orelse "undefined");
+                const class_ref = try es_helpers.makeIdentifierRef(self, mapping.class_name.?);
                 const desc_ref = try es_helpers.makeIdentifierRef(self, mapping.var_name);
                 self.runtime_helpers.class_static_private_field = true;
                 return es_helpers.makeCallExpr(self, helper, &.{ new_obj, class_ref, desc_ref, new_value }, span);
@@ -1258,7 +1258,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const mapping = findPrivateFieldMapping(self, prop_old_idx) orelse return null;
             if (mapping.is_static) {
                 const helper = try es_helpers.makeRuntimeHelperRef(self, "__classStaticPrivateFieldSpecGet");
-                const class_ref = try es_helpers.makeIdentifierRef(self, mapping.class_name orelse "undefined");
+                const class_ref = try es_helpers.makeIdentifierRef(self, mapping.class_name.?);
                 const desc_ref = try es_helpers.makeIdentifierRef(self, mapping.var_name);
                 self.runtime_helpers.class_static_private_field = true;
                 const call = try es_helpers.makeCallExpr(self, helper, &.{ obj_new, class_ref, desc_ref }, span);
@@ -1469,7 +1469,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
         fn buildStaticPrivateFieldGet(self: *Transformer, mapping: Transformer.PrivateFieldMapping, obj_idx: NodeIndex, span: Span) Transformer.Error!NodeIndex {
             const helper = try es_helpers.makeRuntimeHelperRef(self, "__classStaticPrivateFieldSpecGet");
             const new_obj = try self.visitNode(obj_idx);
-            const class_ref = try es_helpers.makeIdentifierRef(self, mapping.class_name orelse "undefined");
+            const class_ref = try es_helpers.makeIdentifierRef(self, mapping.class_name.?);
             const desc_ref = try es_helpers.makeIdentifierRef(self, mapping.var_name);
             self.runtime_helpers.class_static_private_field = true;
             return es_helpers.makeCallExpr(self, helper, &.{ new_obj, class_ref, desc_ref }, span);
@@ -1501,7 +1501,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 if (pf.is_static) {
                     // static: obj === ClassName (class identity 비교)
                     const new_obj = try self.visitNode(right_idx);
-                    const class_ref = try es_helpers.makeIdentifierRef(self, pf.class_name orelse "undefined");
+                    const class_ref = try es_helpers.makeIdentifierRef(self, pf.class_name.?);
                     return self.ast.addNode(.{
                         .tag = .binary_expression,
                         .span = node.span,
@@ -1521,7 +1521,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 if (!std.mem.eql(u8, pm.original_name, orig)) continue;
                 if (pm.is_static) {
                     const new_obj = try self.visitNode(right_idx);
-                    const class_ref = try es_helpers.makeIdentifierRef(self, pm.class_name orelse "undefined");
+                    const class_ref = try es_helpers.makeIdentifierRef(self, pm.class_name.?);
                     return self.ast.addNode(.{
                         .tag = .binary_expression,
                         .span = node.span,
@@ -1542,7 +1542,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
         fn buildStaticPrivateFieldSet(self: *Transformer, mapping: Transformer.PrivateFieldMapping, obj_idx: NodeIndex, value_idx: NodeIndex, span: Span) Transformer.Error!NodeIndex {
             const helper = try es_helpers.makeRuntimeHelperRef(self, "__classStaticPrivateFieldSpecSet");
             const new_obj = try self.visitNode(obj_idx);
-            const class_ref = try es_helpers.makeIdentifierRef(self, mapping.class_name orelse "undefined");
+            const class_ref = try es_helpers.makeIdentifierRef(self, mapping.class_name.?);
             const desc_ref = try es_helpers.makeIdentifierRef(self, mapping.var_name);
             const new_value = try self.visitNode(value_idx);
             self.runtime_helpers.class_static_private_field = true;

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1519,6 +1519,19 @@ pub fn ES2015Class(comptime Transformer: type) type {
             // private method 매핑 조회
             for (self.current_private_methods) |pm| {
                 if (!std.mem.eql(u8, pm.original_name, orig)) continue;
+                if (pm.is_static) {
+                    const new_obj = try self.visitNode(right_idx);
+                    const class_ref = try es_helpers.makeIdentifierRef(self, pm.class_name orelse "undefined");
+                    return self.ast.addNode(.{
+                        .tag = .binary_expression,
+                        .span = node.span,
+                        .data = .{ .binary = .{
+                            .left = new_obj,
+                            .right = class_ref,
+                            .flags = @intFromEnum(token_mod.Kind.eq3),
+                        } },
+                    });
+                }
                 return buildWeakMapCall(self, pm.weakset_name, "has", right_idx, &.{}, node.span);
             }
 

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1289,12 +1289,12 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 const prop_node_pre = self.ast.getNode(prop_idx);
                 if (prop_node_pre.tag == .private_identifier) {
                     const orig_name = self.ast.getText(prop_node_pre.span);
-                    if (es2022.ES2022(Transformer).findPrivateMethodMappingOfKind(self, orig_name, 2)) |setter_mapping| {
+                    if (es2022.ES2022(Transformer).findPrivateMethodMappingOfKind(self, orig_name, .setter)) |setter_mapping| {
                         if (op_kind_pre == .eq) {
                             return lowerPrivateSetterCall(self, setter_mapping, obj_idx, node.data.binary.right, node.span);
                         }
                         if (compoundAssignBaseOp(node.data.binary.flags)) |bin_op| {
-                            if (es2022.ES2022(Transformer).findPrivateMethodMappingOfKind(self, orig_name, 1)) |getter_mapping| {
+                            if (es2022.ES2022(Transformer).findPrivateMethodMappingOfKind(self, orig_name, .getter)) |getter_mapping| {
                                 return lowerPrivateAccessorCompoundAssign(self, getter_mapping, setter_mapping, obj_idx, bin_op, node.data.binary.right, node.span);
                             }
                         }
@@ -1855,7 +1855,8 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     const is_static = (flags & ast_mod.MethodFlags.is_static) != 0;
                     const is_abstract = (flags & ast_mod.MethodFlags.is_abstract) != 0;
                     const is_declare = (flags & ast_mod.MethodFlags.is_declare) != 0;
-                    const kind = (flags >> 1) & 0x03; // 0=method, 1=get, 2=set (MethodFlags.is_getter/is_setter를 >>1 shift해 0/1/2 값으로)
+                    const pm_kind = es_helpers.privateMethodKindFromFlags(flags);
+                    const kind = @intFromEnum(pm_kind);
 
                     // 본문 없는 메서드 스트리핑: abstract, declare, TS 오버로드 시그니처
                     const method_body: NodeIndex = @enumFromInt(self.readU32(me, MethodExtra.body));
@@ -1874,8 +1875,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                         if (key_node.tag == .private_identifier) {
                             const orig_name = self.ast.getText(key_node.span); // "#bar"
 
-                            const pm_kind: u8 = if (kind == 1) 1 else if (kind == 2) 2 else 0;
-                            const names = try es_helpers.makePrivateMethodNamesWithKind(self.allocator, orig_name, pm_kind);
+                            const names = try es_helpers.makePrivateMethodNames(self.allocator, orig_name, pm_kind);
 
                             try cm.private_methods.append(self.allocator, .{
                                 .member_idx = @enumFromInt(raw_idx),
@@ -2093,24 +2093,24 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const setter_target = try makePrivateFieldAccess(self, storage_span, span);
             const setter_idx = try self.buildSetterMethod(priv_key_set, setter_target, false, span);
 
-            const get_names = try es_helpers.makePrivateMethodNamesWithKind(self.allocator, orig_name, 1);
+            const get_names = try es_helpers.makePrivateMethodNames(self.allocator, orig_name, .getter);
             try cm.private_methods.append(self.allocator, .{
                 .member_idx = getter_idx,
                 .original_name = orig_name,
                 .weakset_name = get_names.ws_name,
                 .func_name = get_names.fn_name,
                 .member_span = member_span,
-                .kind = 1,
+                .kind = .getter,
             });
 
-            const set_names = try es_helpers.makePrivateMethodNamesWithKind(self.allocator, orig_name, 2);
+            const set_names = try es_helpers.makePrivateMethodNames(self.allocator, orig_name, .setter);
             try cm.private_methods.append(self.allocator, .{
                 .member_idx = setter_idx,
                 .original_name = orig_name,
                 .weakset_name = set_names.ws_name,
                 .func_name = set_names.fn_name,
                 .member_span = member_span,
-                .kind = 2,
+                .kind = .setter,
             });
         }
 

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -673,7 +673,7 @@ pub fn ES2022(comptime Transformer: type) type {
             if (mapping.is_static) {
                 self.runtime_helpers.class_static_private_field = true;
                 const helper_ref = try es_helpers.makeRuntimeHelperRef(self, "__classStaticPrivateFieldSpecGet");
-                const class_ref = try es_helpers.makeIdentifierRef(self, mapping.class_name orelse "undefined");
+                const class_ref = try es_helpers.makeIdentifierRef(self, mapping.class_name.?);
                 const desc_ref = try es_helpers.makeIdentifierRef(self, mapping.weakset_name);
                 return es_helpers.makeCallExpr(self, helper_ref, &.{ new_obj, class_ref, desc_ref }, span);
             }

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -317,17 +317,23 @@ pub fn ES2022(comptime Transformer: type) type {
                         const key: NodeIndex = @enumFromInt(extras[me + ast_mod.MethodExtra.key]);
                         const flags = extras[me + ast_mod.MethodExtra.flags];
                         const is_static = (flags & ast_mod.MethodFlags.is_static) != 0;
-                        if (key.isNone() or is_static) continue;
+                        if (key.isNone()) continue;
+                        if (is_static and class_name_text == null) continue;
                         const key_node = self.ast.getNode(key);
                         if (key_node.tag != .private_identifier) continue;
 
                         const orig_name = self.ast.getText(key_node.span);
-                        const names = try es_helpers.makePrivateMethodNames(self.allocator, orig_name);
+                        const kind = (flags >> 1) & 0x03;
+                        const pm_kind: u8 = if (kind == 1) 1 else if (kind == 2) 2 else 0;
+                        const names = try es_helpers.makePrivateMethodNamesWithKind(self.allocator, orig_name, pm_kind);
                         try method_mappings.append(self.allocator, .{
                             .original_name = orig_name,
                             .weakset_name = names.ws_name,
                             .func_name = names.fn_name,
                             .member_idx = @enumFromInt(raw_idx),
+                            .kind = pm_kind,
+                            .is_static = is_static,
+                            .class_name = if (is_static) class_name_text else null,
                         });
                     } else if (lower_fields and member.tag == .property_definition) {
                         const pe = member.data.extra;
@@ -381,8 +387,15 @@ pub fn ES2022(comptime Transformer: type) type {
                 }
             }
             for (method_mappings.items) |m| {
-                const ws_decl = try es_helpers.buildWeakCollectionDecl(self, "WeakSet", m.weakset_name, span);
-                try pre_stmts.append(self.allocator, ws_decl);
+                if (m.is_static) {
+                    const fn_ref = try es_helpers.makeIdentifierRef(self, m.func_name);
+                    const desc = try es_helpers.buildStaticPrivateFieldDescriptor(self, m.weakset_name, fn_ref, span);
+                    try pre_stmts.append(self.allocator, desc);
+                    self.runtime_helpers.class_static_private_field = true;
+                } else {
+                    const ws_decl = try es_helpers.buildWeakCollectionDecl(self, "WeakSet", m.weakset_name, span);
+                    try pre_stmts.append(self.allocator, ws_decl);
+                }
                 const fn_decl = try es_helpers.buildStandaloneFunc(self, m.func_name, m.member_idx, span);
                 try pre_stmts.append(self.allocator, fn_decl);
             }
@@ -408,8 +421,10 @@ pub fn ES2022(comptime Transformer: type) type {
                 {
                     const m = method_mappings.items[method_mapping_idx];
                     method_mapping_idx += 1;
-                    const init_stmt = try es_helpers.buildPrivateMethodInit(self, m.weakset_name, span);
-                    try ctor_init_stmts.append(self.allocator, init_stmt);
+                    if (!m.is_static) {
+                        const init_stmt = try es_helpers.buildPrivateMethodInit(self, m.weakset_name, span);
+                        try ctor_init_stmts.append(self.allocator, init_stmt);
+                    }
                     continue;
                 }
 
@@ -656,6 +671,13 @@ pub fn ES2022(comptime Transformer: type) type {
 
         /// __classPrivateMethodGet(obj, _set, _fn) 호출 노드 생성.
         fn buildMethodGetCall(self: *Transformer, new_obj: NodeIndex, mapping: Transformer.PrivateMethodMapping, span: Span) Transformer.Error!NodeIndex {
+            if (mapping.is_static) {
+                self.runtime_helpers.class_static_private_field = true;
+                const helper_ref = try es_helpers.makeRuntimeHelperRef(self, "__classStaticPrivateFieldSpecGet");
+                const class_ref = try es_helpers.makeIdentifierRef(self, mapping.class_name orelse "undefined");
+                const desc_ref = try es_helpers.makeIdentifierRef(self, mapping.weakset_name);
+                return es_helpers.makeCallExpr(self, helper_ref, &.{ new_obj, class_ref, desc_ref }, span);
+            }
             self.runtime_helpers.class_private_method_get = true;
             const helper_ref = try es_helpers.makeRuntimeHelperRef(self, "__classPrivateMethodGet");
             const ws_ref = try es_helpers.makeIdentifierRef(self, mapping.weakset_name);

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -323,9 +323,8 @@ pub fn ES2022(comptime Transformer: type) type {
                         if (key_node.tag != .private_identifier) continue;
 
                         const orig_name = self.ast.getText(key_node.span);
-                        const kind = (flags >> 1) & 0x03;
-                        const pm_kind: u8 = if (kind == 1) 1 else if (kind == 2) 2 else 0;
-                        const names = try es_helpers.makePrivateMethodNamesWithKind(self.allocator, orig_name, pm_kind);
+                        const pm_kind = es_helpers.privateMethodKindFromFlags(flags);
+                        const names = try es_helpers.makePrivateMethodNames(self.allocator, orig_name, pm_kind);
                         try method_mappings.append(self.allocator, .{
                             .original_name = orig_name,
                             .weakset_name = names.ws_name,
@@ -611,7 +610,7 @@ pub fn ES2022(comptime Transformer: type) type {
 
             // this.#m() 호출 — 오직 kind=0 (메서드) 만 매칭. getter/setter 는 this.#x() 형태가
             // 아니라 this.#x / this.#x = v 패턴이므로 lowerPrivateMethodGet / lowerPrivateFieldSet 에서 처리 (#1523).
-            const mapping = findPrivateMethodMappingOfKind(self, orig_name, 0) orelse return null;
+            const mapping = findPrivateMethodMappingOfKind(self, orig_name, .method) orelse return null;
 
             const args_start = self.readU32(ce, 1);
             const args_len = self.readU32(ce, 2);
@@ -655,15 +654,15 @@ pub fn ES2022(comptime Transformer: type) type {
 
             const orig_name = self.ast.getText(prop_node.span);
             // getter 우선 — 같은 name 의 setter 와 method 는 공존 불가하므로 분기 안전.
-            const mapping = findPrivateMethodMappingOfKind(self, orig_name, 1) orelse
-                findPrivateMethodMappingOfKind(self, orig_name, 0) orelse
+            const mapping = findPrivateMethodMappingOfKind(self, orig_name, .getter) orelse
+                findPrivateMethodMappingOfKind(self, orig_name, .method) orelse
                 return null;
 
             const new_obj = try self.visitNode(obj_idx);
             const get_call = try buildMethodGetCall(self, new_obj, mapping, node.span);
 
             // getter → `.call(this)` 즉시 호출 (값 반환). 메서드 → `.bind(this)` 바운드 참조.
-            const access_prop_name: []const u8 = if (mapping.kind == 1) "call" else "bind";
+            const access_prop_name: []const u8 = if (mapping.kind == .getter) "call" else "bind";
             const access_prop = try es_helpers.makeIdentifierRef(self, access_prop_name);
             const callee = try es_helpers.makeStaticMember(self, get_call, access_prop, node.span);
             return es_helpers.makeCallExpr(self, callee, &.{new_obj}, node.span);
@@ -694,7 +693,7 @@ pub fn ES2022(comptime Transformer: type) type {
         }
 
         /// 같은 name 에 method/getter/setter 가 공존할 경우 kind 필터링 매핑 검색 (#1523).
-        pub fn findPrivateMethodMappingOfKind(self: *const Transformer, orig_name: []const u8, kind: u8) ?Transformer.PrivateMethodMapping {
+        pub fn findPrivateMethodMappingOfKind(self: *const Transformer, orig_name: []const u8, kind: es_helpers.PrivateMethodKind) ?Transformer.PrivateMethodMapping {
             for (self.current_private_methods) |m| {
                 if (m.kind == kind and std.mem.eql(u8, m.original_name, orig_name)) return m;
             }

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -1011,26 +1011,36 @@ pub fn makePrivateVarName(allocator: std.mem.Allocator, orig_name: []const u8) !
     return buf;
 }
 
-/// "#bar" → { ws_name="_bar", fn_name="_bar_fn" }
-pub fn makePrivateMethodNames(allocator: std.mem.Allocator, orig_name: []const u8) !PrivateMethodNames {
-    return makePrivateMethodNamesWithKind(allocator, orig_name, 0);
-}
-
-/// kind 별 suffix: 0=method → "_fn", 1=getter → "_get", 2=setter → "_set" (#1523).
-/// "#x" + kind=1 → { ws_name="_x", fn_name="_x_get" }
-pub fn makePrivateMethodNamesWithKind(allocator: std.mem.Allocator, orig_name: []const u8, kind: u8) !PrivateMethodNames {
+/// kind 별 suffix: method → "_fn", getter → "_get", setter → "_set" (#1523).
+/// "#x" + .getter → { ws_name="_x", fn_name="_x_get" }
+pub fn makePrivateMethodNames(allocator: std.mem.Allocator, orig_name: []const u8, kind: PrivateMethodKind) !PrivateMethodNames {
     const ws_name = try makePrivateVarName(allocator, orig_name);
     const bare = orig_name[1..];
     const suffix: []const u8 = switch (kind) {
-        1 => "_get",
-        2 => "_set",
-        else => "_fn",
+        .method => "_fn",
+        .getter => "_get",
+        .setter => "_set",
     };
     const fn_name = try allocator.alloc(u8, 1 + bare.len + suffix.len);
     fn_name[0] = '_';
     @memcpy(fn_name[1 .. 1 + bare.len], bare);
     @memcpy(fn_name[1 + bare.len ..], suffix);
     return .{ .ws_name = ws_name, .fn_name = fn_name };
+}
+
+/// private method 종류. kind 비트(`(method_flags >> 1) & 0x03`) 와 1:1 (#1523).
+pub const PrivateMethodKind = enum(u8) {
+    method = 0,
+    getter = 1,
+    setter = 2,
+};
+
+/// MethodFlags 의 is_getter(bit 1) / is_setter(bit 2) 를 PrivateMethodKind 로 추출.
+/// getter+setter 동시 set 은 parser invariant 상 불가 → debug assert.
+pub fn privateMethodKindFromFlags(method_flags: u32) PrivateMethodKind {
+    const bits = (method_flags >> 1) & 0x03;
+    std.debug.assert(bits <= 2);
+    return @enumFromInt(@as(u8, @intCast(bits)));
 }
 
 /// var _name = new Constructor(); 선언 생성. (WeakMap, WeakSet 등)

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -565,8 +565,8 @@ pub const Transformer = struct {
         // standalone function_declaration 의 span 으로 사용 — leading comment 가
         // `function _fn()` 뒤가 아니라 함수 앞에서 flush 되도록 (#1516).
         member_span: Span = .{ .start = 0, .end = 0 },
-        /// 0 = method, 1 = getter, 2 = setter (#1523).
-        kind: u8 = 0,
+        /// method / getter / setter (#1523).
+        kind: @import("es_helpers.zig").PrivateMethodKind = .method,
         is_static: bool = false,
         class_name: ?[]const u8 = null,
     };

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -567,6 +567,8 @@ pub const Transformer = struct {
         member_span: Span = .{ .start = 0, .end = 0 },
         /// 0 = method, 1 = getter, 2 = setter (#1523).
         kind: u8 = 0,
+        is_static: bool = false,
+        class_name: ?[]const u8 = null,
     };
 
     // RefreshRegistration / RefreshSignature 타입 정의는 plugin_state.zig로 이사.

--- a/src/transformer/transformer/class_decorator.zig
+++ b/src/transformer/transformer/class_decorator.zig
@@ -35,7 +35,7 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
         // #1592로 ClassExpression name이 body scope 심볼로 등록되어
         // reference_count == 0이 정확한 "미참조" 시그널. ClassDeclaration은 외부
         // scope 심볼이라 body 내부 ref만 count되지 않으므로 대상에서 제외.
-        const new_name = if (shouldDropClassExprName(self, node.tag, raw_name_idx))
+        var new_name = if (shouldDropClassExprName(self, node.tag, raw_name_idx))
             ast_mod.NodeIndex.none
         else
             try self.visitNode(raw_name_idx);
@@ -76,6 +76,12 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
 
         const lower_pm = self.options.unsupported.class_private_method;
         const lower_pf = self.options.unsupported.class_private_field;
+        if ((lower_pm or lower_pf) and node.tag == .class_expression and new_name.isNone() and
+            classBodyHasStaticPrivateMember(self, current_body_idx, lower_pm, lower_pf))
+        {
+            const tmp_span = try es_helpers.makeTempVarSpan(self);
+            new_name = try es_helpers.makeBindingIdentifier(self, tmp_span);
+        }
         var had_private_methods = false;
         var had_private_fields = false;
 
@@ -212,6 +218,44 @@ pub fn visitClass(self: *Transformer, node: Node) Error!NodeIndex {
     // Slow path: useDefineForClassFields=false 또는 experimentalDecorators
     // 클래스 바디의 멤버들을 개별로 분석해야 하므로, class_body를 직접 순회한다.
     return self.visitClassWithAssignSemantics(node);
+}
+
+fn classBodyHasStaticPrivateMember(self: *Transformer, body_idx: NodeIndex, lower_methods: bool, lower_fields: bool) bool {
+    if (body_idx.isNone()) return false;
+    const body_node = self.ast.getNode(body_idx);
+    if (body_node.tag != .class_body) return false;
+
+    const start = body_node.data.list.start;
+    const len = body_node.data.list.len;
+    if (start + len > self.ast.extra_data.items.len) return false;
+
+    var i: u32 = 0;
+    while (i < len) : (i += 1) {
+        const member = self.ast.getNode(@enumFromInt(self.ast.extra_data.items[start + i]));
+        switch (member.tag) {
+            .method_definition => {
+                if (!lower_methods) continue;
+                const e = member.data.extra;
+                if (e + ast_mod.MethodExtra.flags >= self.ast.extra_data.items.len) continue;
+                const flags = self.readU32(e, ast_mod.MethodExtra.flags);
+                if ((flags & ast_mod.MethodFlags.is_static) == 0) continue;
+                const key = self.readNodeIdx(e, ast_mod.MethodExtra.key);
+                if (!key.isNone() and self.ast.getNode(key).tag == .private_identifier) return true;
+            },
+            .property_definition => {
+                if (!lower_fields) continue;
+                const e = member.data.extra;
+                if (e + ast_mod.PropertyExtra.flags >= self.ast.extra_data.items.len) continue;
+                const flags = self.readU32(e, ast_mod.PropertyExtra.flags);
+                if ((flags & ast_mod.PropertyFlags.is_static) == 0) continue;
+                const key = self.readNodeIdx(e, ast_mod.PropertyExtra.key);
+                if (!key.isNone() and self.ast.getNode(key).tag == .private_identifier) return true;
+            },
+            else => {},
+        }
+    }
+
+    return false;
 }
 
 /// class_expression의 private method / static block 다운레벨 결과를 IIFE로 래핑한다.

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -537,6 +537,9 @@ pub fn transpileWithCallback(
         .source_root = options.source_root,
         .sources_content = options.sources_content,
         .strip_hashbang = options.unsupported.hashbang,
+        .assert_no_raw_private_syntax = options.unsupported.class or
+            options.unsupported.class_private_field or
+            options.unsupported.class_private_method,
         // JSX: Transformer가 이미 call_expression으로 lowering 완료. codegen에 JSX 옵션 불필요.
     });
     cg.comments = scanner.comments.items;

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -537,9 +537,7 @@ pub fn transpileWithCallback(
         .source_root = options.source_root,
         .sources_content = options.sources_content,
         .strip_hashbang = options.unsupported.hashbang,
-        .assert_no_raw_private_syntax = options.unsupported.class or
-            options.unsupported.class_private_field or
-            options.unsupported.class_private_method,
+        .assert_no_raw_private_syntax = options.unsupported.requiresPrivateDownlevel(),
         // JSX: Transformer가 이미 call_expression으로 lowering 완료. codegen에 JSX 옵션 불필요.
     });
     cg.comments = scanner.comments.items;


### PR DESCRIPTION
## 요약
- private syntax downlevel 대상에서 codegen 직전 raw private AST가 남으면 Debug 빌드에서 panic하는 내부 invariant를 추가했습니다.
- invariant 적용 중 발견된 static private method downlevel 누락을 함께 수정했습니다.
- static private method는 static private field descriptor helper 경로로 낮춰 class identity brand check를 사용하게 했습니다.
- class expression 래핑은 static private 멤버가 실제로 있을 때만 임시 이름을 부여하도록 좁혀 기존 anonymous static block 동작을 유지했습니다.

Closes #2302

## 검증
- `zig build test`
- `bun run fmt:check`
- `bun run lint` (기존 unused-import 경고 4개만 출력)
- `git diff --check`
- pre-push hook: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`