### PR TITLE
refactor(transform): private mapping struct 의 is_static 중복 제거

### DIFF
--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -1086,7 +1086,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             if ((flags & ast_mod.MemberFlags.optional_chain) != 0) return null;
             const obj_idx: NodeIndex = self.readNodeIdx(e, 0);
             const mapping = findPrivateFieldMapping(self, self.readNodeIdx(e, 1)) orelse return null;
-            if (mapping.is_static) {
+            if (mapping.class_name != null) {
                 return buildStaticPrivateFieldGet(self, mapping, obj_idx, node.span);
             }
             return buildWeakMapCall(self, mapping.var_name, "get", obj_idx, &.{}, node.span);
@@ -1115,7 +1115,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
         /// instance/static 분기해서 private field get 호출을 구성.
         fn buildPrivateFieldGetCall(self: *Transformer, mapping: Transformer.PrivateFieldMapping, obj_idx: NodeIndex, span: Span) Transformer.Error!NodeIndex {
-            if (mapping.is_static) return buildStaticPrivateFieldGet(self, mapping, obj_idx, span);
+            if (mapping.class_name != null) return buildStaticPrivateFieldGet(self, mapping, obj_idx, span);
             return buildWeakMapCall(self, mapping.var_name, "get", obj_idx, &.{}, span);
         }
 
@@ -1237,10 +1237,10 @@ pub fn ES2015Class(comptime Transformer: type) type {
         /// obj_idx는 old AST 노드로, 내부에서 visit 수행.
         /// instance는 `__classPrivateFieldSet` helper, static은 수정된 spec helper 모두 value를 반환 (#1488).
         fn buildPrivateFieldSetWithComputedValue(self: *Transformer, mapping: Transformer.PrivateFieldMapping, obj_idx: NodeIndex, new_value: NodeIndex, span: Span) Transformer.Error!NodeIndex {
-            if (mapping.is_static) {
+            if (mapping.class_name) |class_name| {
                 const helper = try es_helpers.makeRuntimeHelperRef(self, "__classStaticPrivateFieldSpecSet");
                 const new_obj = try self.visitNode(obj_idx);
-                const class_ref = try es_helpers.makeIdentifierRef(self, mapping.class_name.?);
+                const class_ref = try es_helpers.makeIdentifierRef(self, class_name);
                 const desc_ref = try es_helpers.makeIdentifierRef(self, mapping.var_name);
                 self.runtime_helpers.class_static_private_field = true;
                 return es_helpers.makeCallExpr(self, helper, &.{ new_obj, class_ref, desc_ref, new_value }, span);
@@ -1256,9 +1256,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
         /// optional chain lowering 등 재구성된 private_field_expression 교체용 (#1492).
         pub fn emitPrivateFieldGetWithNewObj(self: *Transformer, prop_old_idx: NodeIndex, obj_new: NodeIndex, span: Span) Transformer.Error!?NodeIndex {
             const mapping = findPrivateFieldMapping(self, prop_old_idx) orelse return null;
-            if (mapping.is_static) {
+            if (mapping.class_name) |class_name| {
                 const helper = try es_helpers.makeRuntimeHelperRef(self, "__classStaticPrivateFieldSpecGet");
-                const class_ref = try es_helpers.makeIdentifierRef(self, mapping.class_name.?);
+                const class_ref = try es_helpers.makeIdentifierRef(self, class_name);
                 const desc_ref = try es_helpers.makeIdentifierRef(self, mapping.var_name);
                 self.runtime_helpers.class_static_private_field = true;
                 const call = try es_helpers.makeCallExpr(self, helper, &.{ obj_new, class_ref, desc_ref }, span);
@@ -1498,10 +1498,10 @@ pub fn ES2015Class(comptime Transformer: type) type {
             // instance field / static field 매핑 우선 조회
             for (self.current_private_fields) |pf| {
                 if (!std.mem.eql(u8, pf.original_name, orig)) continue;
-                if (pf.is_static) {
+                if (pf.class_name) |class_name| {
                     // static: obj === ClassName (class identity 비교)
                     const new_obj = try self.visitNode(right_idx);
-                    const class_ref = try es_helpers.makeIdentifierRef(self, pf.class_name.?);
+                    const class_ref = try es_helpers.makeIdentifierRef(self, class_name);
                     return self.ast.addNode(.{
                         .tag = .binary_expression,
                         .span = node.span,
@@ -1519,9 +1519,9 @@ pub fn ES2015Class(comptime Transformer: type) type {
             // private method 매핑 조회
             for (self.current_private_methods) |pm| {
                 if (!std.mem.eql(u8, pm.original_name, orig)) continue;
-                if (pm.is_static) {
+                if (pm.class_name) |class_name| {
                     const new_obj = try self.visitNode(right_idx);
-                    const class_ref = try es_helpers.makeIdentifierRef(self, pm.class_name.?);
+                    const class_ref = try es_helpers.makeIdentifierRef(self, class_name);
                     return self.ast.addNode(.{
                         .tag = .binary_expression,
                         .span = node.span,
@@ -1815,7 +1815,6 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 mappings[cm.private_fields.items.len + i] = .{
                     .original_name = pf.original_name,
                     .var_name = pf.name,
-                    .is_static = true,
                     .class_name = class_name,
                 };
             }

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -331,7 +331,6 @@ pub fn ES2022(comptime Transformer: type) type {
                             .func_name = names.fn_name,
                             .member_idx = @enumFromInt(raw_idx),
                             .kind = pm_kind,
-                            .is_static = is_static,
                             .class_name = if (is_static) class_name_text else null,
                         });
                     } else if (lower_fields and member.tag == .property_definition) {
@@ -354,7 +353,6 @@ pub fn ES2022(comptime Transformer: type) type {
                         try field_mappings.append(self.allocator, .{
                             .original_name = orig_name,
                             .var_name = var_name,
-                            .is_static = is_static,
                             .class_name = if (is_static) class_name_text else null,
                         });
                         try field_member_raw.append(self.allocator, raw_idx);
@@ -375,7 +373,7 @@ pub fn ES2022(comptime Transformer: type) type {
             defer self.current_private_fields = saved_private_fields;
 
             for (field_mappings.items, field_init_idx.items) |m, init_val| {
-                if (m.is_static) {
+                if (m.class_name != null) {
                     // static: `var _x = { writable: true, value: init };` — init이 descriptor 내부.
                     const desc = try es_helpers.buildStaticPrivateFieldDescriptor(self, m.var_name, init_val, span);
                     try pre_stmts.append(self.allocator, desc);
@@ -386,7 +384,7 @@ pub fn ES2022(comptime Transformer: type) type {
                 }
             }
             for (method_mappings.items) |m| {
-                if (m.is_static) {
+                if (m.class_name != null) {
                     const fn_ref = try es_helpers.makeIdentifierRef(self, m.func_name);
                     const desc = try es_helpers.buildStaticPrivateFieldDescriptor(self, m.weakset_name, fn_ref, span);
                     try pre_stmts.append(self.allocator, desc);
@@ -420,7 +418,7 @@ pub fn ES2022(comptime Transformer: type) type {
                 {
                     const m = method_mappings.items[method_mapping_idx];
                     method_mapping_idx += 1;
-                    if (!m.is_static) {
+                    if (m.class_name == null) {
                         const init_stmt = try es_helpers.buildPrivateMethodInit(self, m.weakset_name, span);
                         try ctor_init_stmts.append(self.allocator, init_stmt);
                     }
@@ -434,7 +432,7 @@ pub fn ES2022(comptime Transformer: type) type {
                     const fi = field_init_idx.items[field_mapping_idx];
                     field_mapping_idx += 1;
                     // static은 descriptor가 init 값을 이미 담고 있으므로 ctor 주입 없음, body에서 제거만.
-                    if (!fm.is_static) {
+                    if (fm.class_name == null) {
                         const init_stmt = try buildPrivateFieldSetInit(self, fm.var_name, fi, span);
                         try ctor_init_stmts.append(self.allocator, init_stmt);
                     }
@@ -670,10 +668,10 @@ pub fn ES2022(comptime Transformer: type) type {
 
         /// __classPrivateMethodGet(obj, _set, _fn) 호출 노드 생성.
         fn buildMethodGetCall(self: *Transformer, new_obj: NodeIndex, mapping: Transformer.PrivateMethodMapping, span: Span) Transformer.Error!NodeIndex {
-            if (mapping.is_static) {
+            if (mapping.class_name) |class_name| {
                 self.runtime_helpers.class_static_private_field = true;
                 const helper_ref = try es_helpers.makeRuntimeHelperRef(self, "__classStaticPrivateFieldSpecGet");
-                const class_ref = try es_helpers.makeIdentifierRef(self, mapping.class_name.?);
+                const class_ref = try es_helpers.makeIdentifierRef(self, class_name);
                 const desc_ref = try es_helpers.makeIdentifierRef(self, mapping.weakset_name);
                 return es_helpers.makeCallExpr(self, helper_ref, &.{ new_obj, class_ref, desc_ref }, span);
             }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -550,13 +550,16 @@ pub const Transformer = struct {
         symbol_id: ?u32,
     };
 
+    /// `class_name` 으로 instance/static 을 구분 — null 이면 instance (WeakMap 기반),
+    /// non-null 이면 static (descriptor 객체 + class brand check).
     pub const PrivateFieldMapping = struct {
         original_name: []const u8, // "#x"
         var_name: []const u8, // "_x"
-        is_static: bool = false, // static private field → descriptor 객체 패턴
-        class_name: ?[]const u8 = null, // static일 때 클래스명 (brand check용)
+        class_name: ?[]const u8 = null, // null → instance, non-null → static (brand check 클래스명)
     };
 
+    /// `class_name` 으로 instance/static 을 구분 — null 이면 instance (WeakSet 기반),
+    /// non-null 이면 static (descriptor 객체 + class brand check).
     pub const PrivateMethodMapping = struct {
         original_name: []const u8, // "#method" (원본 소스 텍스트)
         weakset_name: []const u8, // "_method" (WeakSet 변수명 — 같은 name 의 getter/setter 공유)
@@ -567,8 +570,7 @@ pub const Transformer = struct {
         member_span: Span = .{ .start = 0, .end = 0 },
         /// method / getter / setter (#1523).
         kind: @import("es_helpers.zig").PrivateMethodKind = .method,
-        is_static: bool = false,
-        class_name: ?[]const u8 = null,
+        class_name: ?[]const u8 = null, // null → instance, non-null → static
     };
 
     // RefreshRegistration / RefreshSignature 타입 정의는 plugin_state.zig로 이사.


### PR DESCRIPTION
## Summary
- `PrivateFieldMapping` / `PrivateMethodMapping` 의 `is_static: bool` 필드는 `class_name != null` 로 완전히 인코딩되는 이중 표현이라 제거.
- 사용처를 capture 패턴 (`if (mapping.class_name) |class_name|`) 또는 단순 비교 (`!= null`) 로 일관 변경. 기존 `.?` unwrap 도 capture 변수로 대체되며 자연스럽게 사라짐.
- 의미 변화 없음 — invariant 가 깨지면 컴파일러가 잡지 못하는 약한 표현 → 한 source of truth 로 강화.

## Background
직전 PR #2309 정리 단계에서 이 redundancy 가 짚혔으나, 기존 `PrivateFieldMapping` 도 같은 패턴이라 일관성 위해 보류. 별도 PR 로 둘 다 같이 정리.

## 변경 사항
- `transformer.zig`: 두 struct 정의에서 `is_static` 필드 제거 + docstring 추가.
- `es2022.zig` / `es2015_class.zig`: 매핑 생성 측 `.is_static = ...` 리터럴 제거, 사용처 7곳을 capture/`!= null` 로 변경.
- `buildStaticPrivateFieldGet` / `buildStaticPrivateFieldSet` 의 `mapping.class_name.?` 는 항상 static 경로에서만 호출되므로 그대로 유지.

## Test plan
- [x] `zig build` 통과
- [x] `zig build test` 전체 통과 (Pipeline Profile 정상)
- [x] 기존 private syntax 다운레벨 테스트 + invariant 어설션 테스트 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)