### PR TITLE
refactor(linker): typed final export entry 전달

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -1229,6 +1229,25 @@ describe("@zts/core 번들 포맷/플랫폼", () => {
     expect(result.outputFiles[0].text).toContain("MyLib");
   });
 
+  test("IIFE + globalName: aliased/default exports become return object properties", () => {
+    const aliasDir = mkdtempSync(join(tmpdir(), "zts-iife-export-return-"));
+    writeFileSync(
+      join(aliasDir, "index.ts"),
+      "const internal = 1;\nexport { internal as answer };\nexport default internal;",
+    );
+
+    const result = buildSync({
+      entryPoints: [join(aliasDir, "index.ts")],
+      format: "iife",
+      globalName: "MyLib",
+    });
+    expect(result.errors.length).toBe(0);
+    const text = result.outputFiles[0].text;
+    expect(text).toContain("return { answer: internal, default: internal };");
+    expect(text).not.toContain(" as ");
+    rmSync(aliasDir, { recursive: true, force: true });
+  });
+
   test("platform=node", () => {
     const result = buildSync({
       entryPoints: [join(dir, "index.ts")],

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1661,35 +1661,33 @@ pub fn emitModule(
 
     // __esm 래핑은 emitEsmWrappedModule()에서 처리 (early return)
 
-    // CJS import preamble + final_exports를 하나의 concat으로 합침 (중간 할당 누수 방지)
+    // CJS import preamble + final exports를 하나의 concat으로 합침 (중간 할당 누수 방지)
     const preamble = if (metadata) |md| md.cjs_import_preamble else null;
+    const final_export_entries = if (metadata) |md| md.final_export_entries else null;
     const raw_final_exports = if (metadata) |md| md.final_exports else null;
 
-    // 래핑 포맷 (IIFE/UMD/AMD): "export { x }" → "return { x }" 변환 (factory 반환값).
+    // 래핑 포맷 (IIFE/UMD/AMD): entry export entries → factory 반환값.
     // 래핑 + globalName 없음: export 구문은 syntax error → 제거.
     // CJS: export 구문은 불필요 (CJS 래핑이 exports 처리).
-    // linker는 format-agnostic하게 "export {}" 를 생성하므로, emitter에서 포맷별 치환/제거.
     var wrapped_return_buf: ?[]const u8 = null;
     defer if (wrapped_return_buf) |buf| allocator.free(buf);
 
     var cjs_exports_buf: ?[]const u8 = null;
     defer if (cjs_exports_buf) |buf| allocator.free(buf);
 
-    const final_exports = if (raw_final_exports) |fe| blk: {
+    const final_exports = if (final_export_entries) |entries| blk: {
         if (options.format.isWrappedFormat()) {
             if (options.format != .iife or options.global_name != null) {
-                if (std.mem.startsWith(u8, fe, "export {")) {
-                    wrapped_return_buf = try std.mem.concat(allocator, u8, &.{ "return {", fe["export {".len..] });
-                    break :blk wrapped_return_buf.?;
-                }
+                wrapped_return_buf = try emitWrappedEntryExports(allocator, entries);
+                break :blk wrapped_return_buf.?;
             }
             // 래핑 포맷 (globalName 없음, IIFE): export는 syntax error이므로 제거
             break :blk @as(?[]const u8, null);
         }
         if (options.format == .cjs) {
-            // #2159: ESM `export { ... };` 를 CJS 의 `module.exports` / `exports.X` 형태로 변환.
+            // #2176: linker가 전달한 typed entry를 CJS의 `module.exports` / `exports.X` 형태로 변환.
             // mode 별 분기 (auto/named/default_/none) 는 emitCjsEntryExports 에서 결정.
-            cjs_exports_buf = emitCjsEntryExports(allocator, fe, options.output_exports) catch |err| switch (err) {
+            cjs_exports_buf = emitCjsEntryExports(allocator, entries, options.output_exports) catch |err| switch (err) {
                 error.OutputExportsDefaultRequiresSingleDefault => {
                     // default mode 인데 named 섞임 — Rollup 도 동일 케이스 throw.
                     // graph diagnostic 으로 emit (result.errors 노출, 사용자 fail-fast).
@@ -1700,8 +1698,9 @@ pub fn emitModule(
             };
             break :blk cjs_exports_buf;
         }
-        break :blk fe;
-    } else null;
+        cjs_exports_buf = try emitEsmEntryExports(allocator, entries);
+        break :blk cjs_exports_buf;
+    } else raw_final_exports;
 
     if (preamble != null or final_exports != null) {
         // RSC: 디렉티브가 preamble보다 위에 와야 인식 (preserve-modules에서 자체 파일이 되는 경우).
@@ -1730,6 +1729,7 @@ pub fn emitModule(
 // --- #2159 output.exports CJS 변환 ---
 
 const OutputExports = @import("bundler.zig").OutputExports;
+const FinalExportEntry = LinkingMetadata.FinalExportEntry;
 
 /// `output.exports = "default"` + named 섞인 케이스를 graph diagnostic 으로 emit (#2159).
 /// pending_diagnostics 와 동일하게 linker 의 `fatal_diagnostics` 에 append — `result.errors`
@@ -1759,7 +1759,57 @@ fn emitOutputExportsConflictDiag(
     });
 }
 
-/// ESM `export { local, local2 as exported, default_local as default };\n` 를 CJS 출력으로 변환.
+/// Entry export struct를 ESM `export { ... }` 구문으로 출력.
+fn emitEsmEntryExports(
+    allocator: std.mem.Allocator,
+    entries: []const FinalExportEntry,
+) ![]const u8 {
+    if (entries.len == 0) return try allocator.dupe(u8, "");
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.appendSlice(allocator, "export {");
+    for (entries, 0..) |e, i| {
+        if (i > 0) try out.appendSlice(allocator, ",");
+        try out.append(allocator, ' ');
+        try out.appendSlice(allocator, e.local);
+        if (!std.mem.eql(u8, e.local, e.exported)) {
+            try out.appendSlice(allocator, " as ");
+            try out.appendSlice(allocator, e.exported);
+        }
+    }
+    try out.appendSlice(allocator, " };\n");
+    return try out.toOwnedSlice(allocator);
+}
+
+/// IIFE/UMD/AMD factory 반환값으로 entry exports를 출력.
+fn emitWrappedEntryExports(
+    allocator: std.mem.Allocator,
+    entries: []const FinalExportEntry,
+) ![]const u8 {
+    if (entries.len == 0) return try allocator.dupe(u8, "");
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.appendSlice(allocator, "return {");
+    for (entries, 0..) |e, i| {
+        if (i > 0) try out.appendSlice(allocator, ",");
+        try out.append(allocator, ' ');
+        if (!e.is_default and std.mem.eql(u8, e.local, e.exported)) {
+            try out.appendSlice(allocator, e.local);
+        } else {
+            try out.appendSlice(allocator, e.exported);
+            try out.appendSlice(allocator, ": ");
+            try out.appendSlice(allocator, e.local);
+        }
+    }
+    try out.appendSlice(allocator, " };\n");
+    return try out.toOwnedSlice(allocator);
+}
+
+/// Entry export struct를 CJS 출력으로 변환.
 /// mode 별 emit 분기:
 ///   auto    : default-only → `module.exports = X`, named-only → `exports.X = X`, mixed → 양쪽 + esModule
 ///   named   : 항상 named (`exports.X = X`) + esModule (default 있으면)
@@ -1769,41 +1819,17 @@ fn emitOutputExportsConflictDiag(
 /// caller-owned slice 반환. 빈 결과는 빈 string (null 아님 — caller 가 final_exports 자리에 넣음).
 fn emitCjsEntryExports(
     allocator: std.mem.Allocator,
-    esm_export_str: []const u8,
+    entries: []const FinalExportEntry,
     mode: OutputExports,
 ) ![]const u8 {
     if (mode == .none) return try allocator.dupe(u8, "");
-
-    // ESM 형태 strip — `export { ... };\n` 의 `{` 와 `};` 사이 본문만.
-    // linker (linker/metadata.zig:buildFinalExports) 가 이 형식을 보장. mismatch 시
-    // debug assert 가 회귀 catch (release 는 silent fallback 으로 빈 출력).
-    const open = std.mem.indexOfScalar(u8, esm_export_str, '{') orelse return try allocator.dupe(u8, "");
-    const close = std.mem.lastIndexOfScalar(u8, esm_export_str, '}') orelse return try allocator.dupe(u8, "");
-    std.debug.assert(open < close);
-    if (close <= open + 1) return try allocator.dupe(u8, "");
-    const body = std.mem.trim(u8, esm_export_str[open + 1 .. close], " \t\n");
-
-    // entries 파싱 — `, ` 분리 → 각 entry `local` 또는 `local as exported`.
-    var entries: std.ArrayListUnmanaged(struct { local: []const u8, exported: []const u8 }) = .empty;
-    defer entries.deinit(allocator);
-
-    var it = std.mem.splitScalar(u8, body, ',');
-    while (it.next()) |raw_entry| {
-        const entry = std.mem.trim(u8, raw_entry, " \t\n");
-        if (entry.len == 0) continue;
-        const as_idx = std.mem.indexOf(u8, entry, " as ");
-        const local = if (as_idx) |i| std.mem.trim(u8, entry[0..i], " \t") else entry;
-        const exported = if (as_idx) |i| std.mem.trim(u8, entry[i + 4 ..], " \t") else entry;
-        try entries.append(allocator, .{ .local = local, .exported = exported });
-    }
-
-    if (entries.items.len == 0) return try allocator.dupe(u8, "");
+    if (entries.len == 0) return try allocator.dupe(u8, "");
 
     // default / named 분리
     var default_local: ?[]const u8 = null;
     var has_named = false;
-    for (entries.items) |e| {
-        if (std.mem.eql(u8, e.exported, "default")) {
+    for (entries) |e| {
+        if (e.is_default) {
             default_local = e.local;
         } else {
             has_named = true;
@@ -1820,7 +1846,7 @@ fn emitCjsEntryExports(
             try out.writer(allocator).print("module.exports = {s};\n", .{default_local.?});
         },
         .named => {
-            for (entries.items) |e| {
+            for (entries) |e| {
                 try out.writer(allocator).print("exports.{s} = {s};\n", .{ e.exported, e.local });
             }
             if (default_local != null) {
@@ -1834,14 +1860,14 @@ fn emitCjsEntryExports(
                     try out.writer(allocator).print("module.exports = {s};\n", .{dl});
                 } else {
                     // mixed — named 형태 + esModule flag
-                    for (entries.items) |e| {
+                    for (entries) |e| {
                         try out.writer(allocator).print("exports.{s} = {s};\n", .{ e.exported, e.local });
                     }
                     try out.appendSlice(allocator, "Object.defineProperty(exports, \"__esModule\", {value: true});\n");
                 }
             } else {
                 // named-only — esModule flag 없음 (Rollup 기본 auto 동작)
-                for (entries.items) |e| {
+                for (entries) |e| {
                     try out.writer(allocator).print("exports.{s} = {s};\n", .{ e.exported, e.local });
                 }
             }
@@ -1852,19 +1878,28 @@ fn emitCjsEntryExports(
 }
 
 test "emitCjsEntryExports: auto mode default-only → module.exports" {
-    const out = try emitCjsEntryExports(std.testing.allocator, "export { x as default };\n", .auto);
+    const entries = &.{FinalExportEntry{ .local = "x", .exported = "default", .is_default = true }};
+    const out = try emitCjsEntryExports(std.testing.allocator, entries, .auto);
     defer std.testing.allocator.free(out);
     try std.testing.expectEqualStrings("module.exports = x;\n", out);
 }
 
 test "emitCjsEntryExports: auto mode named-only → exports.X (no esModule)" {
-    const out = try emitCjsEntryExports(std.testing.allocator, "export { a, b };\n", .auto);
+    const entries = &.{
+        FinalExportEntry{ .local = "a", .exported = "a", .is_default = false },
+        FinalExportEntry{ .local = "b", .exported = "b", .is_default = false },
+    };
+    const out = try emitCjsEntryExports(std.testing.allocator, entries, .auto);
     defer std.testing.allocator.free(out);
     try std.testing.expectEqualStrings("exports.a = a;\nexports.b = b;\n", out);
 }
 
 test "emitCjsEntryExports: auto mode mixed → exports.X + esModule" {
-    const out = try emitCjsEntryExports(std.testing.allocator, "export { a, b as default };\n", .auto);
+    const entries = &.{
+        FinalExportEntry{ .local = "a", .exported = "a", .is_default = false },
+        FinalExportEntry{ .local = "b", .exported = "default", .is_default = true },
+    };
+    const out = try emitCjsEntryExports(std.testing.allocator, entries, .auto);
     defer std.testing.allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "exports.a = a;") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "exports.default = b;") != null);
@@ -1872,27 +1907,59 @@ test "emitCjsEntryExports: auto mode mixed → exports.X + esModule" {
 }
 
 test "emitCjsEntryExports: named mode → 항상 named + esModule (default 있으면)" {
-    const out = try emitCjsEntryExports(std.testing.allocator, "export { x as default };\n", .named);
+    const entries = &.{FinalExportEntry{ .local = "x", .exported = "default", .is_default = true }};
+    const out = try emitCjsEntryExports(std.testing.allocator, entries, .named);
     defer std.testing.allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "exports.default = x;") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "__esModule") != null);
 }
 
 test "emitCjsEntryExports: default_ mode default-only → module.exports" {
-    const out = try emitCjsEntryExports(std.testing.allocator, "export { x as default };\n", .default_);
+    const entries = &.{FinalExportEntry{ .local = "x", .exported = "default", .is_default = true }};
+    const out = try emitCjsEntryExports(std.testing.allocator, entries, .default_);
     defer std.testing.allocator.free(out);
     try std.testing.expectEqualStrings("module.exports = x;\n", out);
 }
 
 test "emitCjsEntryExports: default_ mode named 섞이면 error" {
-    const result = emitCjsEntryExports(std.testing.allocator, "export { a, b as default };\n", .default_);
+    const entries = &.{
+        FinalExportEntry{ .local = "a", .exported = "a", .is_default = false },
+        FinalExportEntry{ .local = "b", .exported = "default", .is_default = true },
+    };
+    const result = emitCjsEntryExports(std.testing.allocator, entries, .default_);
     try std.testing.expectError(error.OutputExportsDefaultRequiresSingleDefault, result);
 }
 
 test "emitCjsEntryExports: none mode → 빈 string" {
-    const out = try emitCjsEntryExports(std.testing.allocator, "export { a, b };\n", .none);
+    const entries = &.{
+        FinalExportEntry{ .local = "a", .exported = "a", .is_default = false },
+        FinalExportEntry{ .local = "b", .exported = "b", .is_default = false },
+    };
+    const out = try emitCjsEntryExports(std.testing.allocator, entries, .none);
     defer std.testing.allocator.free(out);
     try std.testing.expectEqualStrings("", out);
+}
+
+test "emitEsmEntryExports: emits export statement from typed entries" {
+    const entries = &.{
+        FinalExportEntry{ .local = "a", .exported = "a", .is_default = false },
+        FinalExportEntry{ .local = "b$1", .exported = "b", .is_default = false },
+        FinalExportEntry{ .local = "x", .exported = "default", .is_default = true },
+    };
+    const out = try emitEsmEntryExports(std.testing.allocator, entries);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("export { a, b$1 as b, x as default };\n", out);
+}
+
+test "emitWrappedEntryExports: emits object return from typed entries" {
+    const entries = &.{
+        FinalExportEntry{ .local = "a", .exported = "a", .is_default = false },
+        FinalExportEntry{ .local = "b$1", .exported = "b", .is_default = false },
+        FinalExportEntry{ .local = "x", .exported = "default", .is_default = true },
+    };
+    const out = try emitWrappedEntryExports(std.testing.allocator, entries);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("return { a, b: b$1, default: x };\n", out);
 }
 
 // --- CJS wrap functions (emitter/cjs_wrap.zig) ---

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1685,8 +1685,7 @@ pub fn emitModule(
             break :blk @as(?[]const u8, null);
         }
         if (options.format == .cjs) {
-            // #2176: linker가 전달한 typed entry를 CJS의 `module.exports` / `exports.X` 형태로 변환.
-            // mode 별 분기 (auto/named/default_/none) 는 emitCjsEntryExports 에서 결정.
+            // mode (auto/named/default_/none) 별 emit 분기는 emitCjsEntryExports 에서 결정.
             cjs_exports_buf = emitCjsEntryExports(allocator, entries, options.output_exports) catch |err| switch (err) {
                 error.OutputExportsDefaultRequiresSingleDefault => {
                     // default mode 인데 named 섞임 — Rollup 도 동일 케이스 throw.

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -190,11 +190,13 @@ pub const LinkingMetadata = struct {
     skip_nodes: std.DynamicBitSet,
     /// symbol_id → 새 이름. codegen이 식별자 출력 시 symbol_ids[node_idx]로 조회.
     renames: std.AutoHashMap(u32, []const u8),
-    /// dev metadata의 exports 할당 문자열. scope-hoisted entry export는
-    /// final_export_entries를 사용한다.
+    /// dev 모드(`buildDevMetadata`) 가 채우는 모듈 단위 `exports.x = x;` 문자열.
+    /// scope-hoisted 번들(`buildMetadataForAst`/`buildMetadata`) 은 `final_export_entries`
+    /// 를 채우고 이 필드는 null.
     final_exports: ?[]const u8,
-    /// 엔트리 포인트의 최종 export entry. scope-hoisted entry export를 emitter가
-    /// 포맷별로 출력할 때 사용한다.
+    /// scope-hoisted 엔트리의 최종 export entry. emitter 가 포맷별 (ESM/CJS/IIFE/UMD/AMD)
+    /// 로 출력할 때 사용. `local`/`exported` 는 borrowed — 모듈 parse arena 또는 symbol
+    /// table 소유 (deinit 은 slice 자체만 free).
     final_export_entries: ?[]const FinalExportEntry = null,
     /// 노드 인덱스 → 심볼 인덱스 매핑. 빌림 — deinit에서 해제하지 않음.
     /// module.parse_arena 또는 transformer.symbol_ids(emit_arena)가 소유.

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -190,8 +190,12 @@ pub const LinkingMetadata = struct {
     skip_nodes: std.DynamicBitSet,
     /// symbol_id → 새 이름. codegen이 식별자 출력 시 symbol_ids[node_idx]로 조회.
     renames: std.AutoHashMap(u32, []const u8),
-    /// 엔트리 포인트의 최종 export 문 (e.g. "export { x, y$1 as y };\n")
+    /// dev metadata의 exports 할당 문자열. scope-hoisted entry export는
+    /// final_export_entries를 사용한다.
     final_exports: ?[]const u8,
+    /// 엔트리 포인트의 최종 export entry. scope-hoisted entry export를 emitter가
+    /// 포맷별로 출력할 때 사용한다.
+    final_export_entries: ?[]const FinalExportEntry = null,
     /// 노드 인덱스 → 심볼 인덱스 매핑. 빌림 — deinit에서 해제하지 않음.
     /// module.parse_arena 또는 transformer.symbol_ids(emit_arena)가 소유.
     symbol_ids: []const ?u32,
@@ -253,6 +257,12 @@ pub const LinkingMetadata = struct {
         }
     };
 
+    pub const FinalExportEntry = struct {
+        local: []const u8,
+        exported: []const u8,
+        is_default: bool,
+    };
+
     pub const NsInlineObjects = struct {
         entries: []const Entry = &.{},
 
@@ -285,6 +295,7 @@ pub const LinkingMetadata = struct {
         self.owned_rename_values.deinit(self.allocator);
         self.renames.deinit();
         if (self.final_exports) |fe| self.allocator.free(fe);
+        if (self.final_export_entries) |entries| self.allocator.free(entries);
         if (self.cjs_import_preamble) |p| self.allocator.free(p);
         self.const_values.deinit(self.allocator);
         // require_rewrites 해제 (keys는 import record 소유, values만 해제)

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -814,8 +814,9 @@ pub fn buildRequireRewrites(self: *const Linker, m: *const Module) !std.StringHa
     return require_rewrites;
 }
 
-/// 엔트리 포인트의 최종 export 문을 생성한다. (e.g. "export { x, y$1 as y };\n")
-/// is_entry가 false이거나 export가 없으면 null 반환.
+/// 엔트리 포인트의 최종 export entry를 생성한다.
+/// is_entry가 false이거나 emit 대상 export가 없으면 null 반환. 반환 slice 의
+/// `local`/`exported` 는 모듈 소유 — caller 는 slice 자체만 free.
 pub fn buildFinalExports(
     self: *const Linker,
     is_entry: bool,
@@ -824,20 +825,32 @@ pub fn buildFinalExports(
 ) !?[]const LinkingMetadata.FinalExportEntry {
     if (!is_entry or export_bindings.len == 0) return null;
 
-    var entries: std.ArrayListUnmanaged(LinkingMetadata.FinalExportEntry) = .empty;
-    errdefer entries.deinit(self.allocator);
+    // re-export-all / `*` 가 섞여 있어도 export_bindings.len 이 entry 수의 상한.
+    // 단일 alloc + resize-shrink 로 ArrayList grow/realloc 회피.
+    const buf = try self.allocator.alloc(LinkingMetadata.FinalExportEntry, export_bindings.len);
+    errdefer self.allocator.free(buf);
+    var n: usize = 0;
     for (export_bindings) |eb| {
         if (eb.kind.isReExportAll()) continue;
         if (std.mem.eql(u8, eb.exported_name, "*")) continue;
         const actual_name = self.getCanonicalForExport(eb, module_index);
-        try entries.append(self.allocator, .{
+        buf[n] = .{
             .local = actual_name,
             .exported = eb.exported_name,
             .is_default = std.mem.eql(u8, eb.exported_name, "default"),
-        });
+        };
+        n += 1;
     }
-    if (entries.items.len == 0) return null;
-    return try entries.toOwnedSlice(self.allocator);
+    if (n == 0) {
+        self.allocator.free(buf);
+        return null;
+    }
+    if (n == export_bindings.len) return buf;
+    if (self.allocator.resize(buf, n)) return buf[0..n];
+    // resize 실패: 정확한 크기로 dupe 후 원본 free.
+    const shrunk = try self.allocator.dupe(LinkingMetadata.FinalExportEntry, buf[0..n]);
+    self.allocator.free(buf);
+    return shrunk;
 }
 
 /// 크로스-모듈 상수 인라인 맵을 생성한다.

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -688,7 +688,7 @@ pub fn buildMetadataForAst(
     }
 
     // 3. 엔트리 포인트 final exports
-    const final_exports = try self.buildFinalExports(is_entry, module_index, m.export_bindings);
+    const final_export_entries = try self.buildFinalExports(is_entry, module_index, m.export_bindings);
 
     // 크로스-모듈 상수 인라인: import binding의 canonical export가 상수이면 매핑
     const const_values = try self.buildCrossModuleConstValues(self.getModule(module_index).?, sem);
@@ -720,7 +720,8 @@ pub fn buildMetadataForAst(
     return .{
         .skip_nodes = skip_nodes,
         .renames = renames,
-        .final_exports = final_exports,
+        .final_exports = null,
+        .final_export_entries = final_export_entries,
         .symbol_ids = sem.symbol_ids,
         .cjs_import_preamble = combined_preamble,
         .require_rewrites = require_rewrites,
@@ -820,31 +821,23 @@ pub fn buildFinalExports(
     is_entry: bool,
     module_index: u32,
     export_bindings: []const ExportBinding,
-) !?[]const u8 {
+) !?[]const LinkingMetadata.FinalExportEntry {
     if (!is_entry or export_bindings.len == 0) return null;
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(self.allocator);
-    try buf.appendSlice(self.allocator, "export {");
-    var first = true;
+    var entries: std.ArrayListUnmanaged(LinkingMetadata.FinalExportEntry) = .empty;
+    errdefer entries.deinit(self.allocator);
     for (export_bindings) |eb| {
         if (eb.kind.isReExportAll()) continue;
         if (std.mem.eql(u8, eb.exported_name, "*")) continue;
-        if (!first) try buf.appendSlice(self.allocator, ",");
-        first = false;
         const actual_name = self.getCanonicalForExport(eb, module_index);
-        try buf.append(self.allocator, ' ');
-        try buf.appendSlice(self.allocator, actual_name);
-        if (!std.mem.eql(u8, actual_name, eb.exported_name)) {
-            try buf.appendSlice(self.allocator, " as ");
-            try buf.appendSlice(self.allocator, eb.exported_name);
-        }
+        try entries.append(self.allocator, .{
+            .local = actual_name,
+            .exported = eb.exported_name,
+            .is_default = std.mem.eql(u8, eb.exported_name, "default"),
+        });
     }
-    try buf.appendSlice(self.allocator, " };\n");
-    if (!first) {
-        return try self.allocator.dupe(u8, buf.items);
-    }
-    return null;
+    if (entries.items.len == 0) return null;
+    return try entries.toOwnedSlice(self.allocator);
 }
 
 /// 크로스-모듈 상수 인라인 맵을 생성한다.
@@ -1309,38 +1302,13 @@ pub fn buildMetadata(self: *const Linker, module_index: u32, is_entry: bool) !Li
     }
 
     // 5. 엔트리 포인트: final exports
-    var final_exports: ?[]const u8 = null;
-    if (is_entry and m.export_bindings.len > 0) {
-        var buf: std.ArrayList(u8) = .empty;
-        defer buf.deinit(self.allocator);
-        try buf.appendSlice(self.allocator, "export {");
-        var first = true;
-        for (m.export_bindings) |eb| {
-            if (eb.kind.isReExportAll()) continue;
-            if (std.mem.eql(u8, eb.exported_name, "*")) continue;
-
-            if (!first) try buf.appendSlice(self.allocator, ",");
-            first = false;
-
-            const actual_name = self.getCanonicalForExport(eb, module_index);
-
-            try buf.append(self.allocator, ' ');
-            try buf.appendSlice(self.allocator, actual_name);
-            if (!std.mem.eql(u8, actual_name, eb.exported_name)) {
-                try buf.appendSlice(self.allocator, " as ");
-                try buf.appendSlice(self.allocator, eb.exported_name);
-            }
-        }
-        try buf.appendSlice(self.allocator, " };\n");
-        if (!first) {
-            final_exports = try self.allocator.dupe(u8, buf.items);
-        }
-    }
+    const final_export_entries = try self.buildFinalExports(is_entry, module_index, m.export_bindings);
 
     return .{
         .skip_nodes = skip_nodes,
         .renames = renames,
-        .final_exports = final_exports,
+        .final_exports = null,
+        .final_export_entries = final_export_entries,
         .symbol_ids = sem.symbol_ids,
         .allocator = self.allocator,
     };


### PR DESCRIPTION
## 요약
- linker가 entry final exports를 `export { ... }` 문자열로 직렬화하지 않고 `FinalExportEntry` struct slice로 전달하도록 변경
- emitter의 CJS `output.exports` 변환에서 ESM export 문자열 재파싱 로직 제거
- ESM / IIFE / UMD / AMD final export 출력도 typed entry 순회 기반 helper로 정리

## 테스트
- `zig fmt --check src/bundler/linker.zig src/bundler/linker/metadata.zig src/bundler/emitter.zig`
- `zig build test`
- `zig build napi`
- `bun test packages/core/index.test.ts -t outputExports`
- `bun test packages/core/index.test.ts -t "IIFE \+ globalName"`
- `bunx oxfmt format --check packages/core/index.test.ts`
- `git diff --check`
- push hook: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`

Closes #2176