### PR TITLE
chore(tests): install smoke-fixture deps to enable skipped tests

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,19 +8,27 @@
         "@emotion/css": "^11.13.5",
         "@emotion/react": "^11.14.0",
         "@tailwindcss/postcss": "^4.2.2",
+        "clsx": "^2.1.1",
+        "date-fns": "^4.1.0",
         "hermes-engine-cli": "^0.12.0",
+        "immer": "^11.1.4",
         "lodash-es": "^4.17.21",
         "mobx": "^6.13.0",
+        "nanoid": "^5.1.9",
         "oxfmt": "^0.41.0",
         "oxlint": "^1.56.0",
         "postcss": "^8.5.8",
         "postcss-load-config": "^6.0.1",
+        "preact": "^10.29.1",
         "react": "^19.0.0",
+        "react-dom": "^19.2.5",
+        "rxjs": "^7.8.2",
         "sass": "^1.99.0",
         "styled-components": "^6.4.0",
         "tailwindcss": "^4.2.2",
         "typescript": "^6.0.3",
         "vite": "^8.0.8",
+        "zod": "^4.4.1",
       },
     },
     "documents": {
@@ -2098,7 +2106,7 @@
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
-    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
+    "immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
     "immutable": ["immutable@5.1.5", "", {}, "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A=="],
 
@@ -2528,7 +2536,7 @@
 
     "nanoevents": ["nanoevents@9.1.0", "", {}, "sha512-Jd0fILWG44a9luj8v5kED4WI+zfkkgwKyRQKItTtlPfEsh7Lznfi1kr8/iZ+XAIss4Qq5GqRB0qtWbaz9ceO/A=="],
 
-    "nanoid": ["nanoid@5.1.7", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ=="],
+    "nanoid": ["nanoid@5.1.9", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw=="],
 
     "nanostores": ["nanostores@0.11.4", "", {}, "sha512-k1oiVNN4hDK8NcNERSZLQiMfRzEGtfnvZvdBvey3SQbgn8Dcrk0h1I6vpxApjb10PFUflZrgJ2WEZyJQ+5v7YQ=="],
 
@@ -2704,7 +2712,7 @@
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
-    "preact": ["preact@10.29.0", "", {}, "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg=="],
+    "preact": ["preact@10.29.1", "", {}, "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg=="],
 
     "prelude-ls": ["prelude-ls@1.1.2", "", {}, "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="],
 
@@ -3330,7 +3338,7 @@
 
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.4.1", "", {}, "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q=="],
 
     "zrender": ["zrender@6.0.0", "", { "dependencies": { "tslib": "2.3.0" } }, "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg=="],
 
@@ -3385,8 +3393,6 @@
     "@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 
     "@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
-
-    "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
     "@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
 
@@ -3450,7 +3456,15 @@
 
     "@xhmikosr/bin-check/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "@zts/benchmark/immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
+
+    "@zts/benchmark/nanoid": ["nanoid@5.1.7", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ=="],
+
+    "@zts/benchmark/preact": ["preact@10.29.0", "", {}, "sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg=="],
+
     "@zts/benchmark/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
+
+    "@zts/benchmark/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@zts/example-web/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -36,6 +36,14 @@ cd tests/integration && bun test         # CLI/NAPI 통합 테스트
 cd tests/e2e && bun test                 # Playwright E2E (dev server, 브라우저)
 ```
 
+### 실 라이브러리 fixture
+- 루트 `bun install` 로 `clsx`/`nanoid`/`zod`/`react`/`react-dom`/`preact`/`immer`/`date-fns`/`rxjs`/`lodash-es` 등 자동 설치 → `manual-chunks-smoke` / `inline-dynamic-imports-smoke` 의 `test.skipIf(!hasPackage(...))` 통과.
+- **emotion v10** 은 v11 과 동일 트리에 공존 불가 → 별도 격리 install 필요:
+  ```bash
+  cd tests/integration/fixtures/emotion-v10 && bun install
+  ```
+  미설치 시 `emotion-v10.test.ts` 의 `describe.skipIf(!hasV10)` 로 전체 skip.
+
 `tests/integration/tests/` 주요 스위트 (총 60+):
 
 **번들러 / 코드젠**

--- a/package.json
+++ b/package.json
@@ -27,18 +27,26 @@
     "@emotion/css": "^11.13.5",
     "@emotion/react": "^11.14.0",
     "@tailwindcss/postcss": "^4.2.2",
+    "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "hermes-engine-cli": "^0.12.0",
+    "immer": "^11.1.4",
     "lodash-es": "^4.17.21",
     "mobx": "^6.13.0",
+    "nanoid": "^5.1.9",
     "oxfmt": "^0.41.0",
     "oxlint": "^1.56.0",
     "postcss": "^8.5.8",
     "postcss-load-config": "^6.0.1",
+    "preact": "^10.29.1",
     "react": "^19.0.0",
+    "react-dom": "^19.2.5",
+    "rxjs": "^7.8.2",
     "sass": "^1.99.0",
     "styled-components": "^6.4.0",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.3",
-    "vite": "^8.0.8"
+    "vite": "^8.0.8",
+    "zod": "^4.4.1"
   }
 }


### PR DESCRIPTION
## Summary

- 루트 \`devDependencies\` 에 \`clsx\` / \`nanoid\` / \`zod\` / \`react-dom\` / \`preact\` / \`immer\` / \`date-fns\` / \`rxjs\` 추가 — \`manual-chunks-smoke\` / \`inline-dynamic-imports-smoke\` 의 \`test.skipIf(!hasPackage(...))\` 자동 통과
- \`docs/TESTING.md\` 에 fixture install 안내 추가 (특히 emotion v10 격리 fixture 별도 \`bun install\`)

## 배경

PR #2313 (\`/simplify\`) 검토 후 fixture 미설치로 인한 conditional skip 케이스 정리. \`hasPackage(name)\` 은 루트 \`node_modules\` 만 체크하므로 \`devDependencies\` 추가만으로 자동 활성화됨.

남은 명시적 \`test.skip\` (4건, TS 타입 체커 / for-await-of downlevel 미구현) 은 별도 이슈 #2314, #2315 로 트래킹.

## 검증

\`\`\`
manual-chunks-smoke.test.ts:           32 pass / 0 fail / 0 skip   (이전 대비 +12 unskip)
inline-dynamic-imports-smoke.test.ts:  12 pass / 0 fail / 0 skip   (+1 unskip)
emotion-v10.test.ts:                   13 pass / 0 fail (fixture install 후)
\`\`\`

emotion v10 은 v11 과 동일 트리 공존 불가능해서 \`tests/integration/fixtures/emotion-v10/\` 격리 fixture 별도 \`bun install\` 필요. 본 PR 의 \`bun.lock\` 에는 포함 안 됨 — \`docs/TESTING.md\` 에 가이드 추가.

## Test plan

- [x] 루트 \`bun install\` 후 \`manual-chunks-smoke\` 32/32 통과
- [x] \`inline-dynamic-imports-smoke\` 12/12 통과
- [x] (옵션) fixture \`bun install\` 후 emotion-v10 13/13 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)