### PR TITLE
fix(parser): enforce js loader syntax strictness

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -40,6 +40,24 @@ describe("@zts/core", () => {
     expect(result.map).toBeUndefined();
   });
 
+  test("transpile: 명시적 .js/.jsx filename은 TypeScript syntax를 거부", () => {
+    expect(() => transpile("const x: number = 1;", { filename: "input.js" })).toThrow("ParseError");
+    expect(() =>
+      transpile("const h = (tag) => tag;\nconst x: string = <div />;", {
+        filename: "input.jsx",
+        jsx: "classic",
+        jsxFactory: "h",
+      }),
+    ).toThrow("ParseError");
+
+    const jsxOnly = transpile("const h = (tag) => tag;\nconst x = <div />;", {
+      filename: "input.jsx",
+      jsx: "classic",
+      jsxFactory: "h",
+    });
+    expect(jsxOnly.code).not.toContain("<div");
+  });
+
   test("인터페이스 스트리핑", () => {
     const result = transpile("interface Foo { bar: string; }\nconst x = 1;");
     expect(result.code).not.toContain("interface");
@@ -2519,6 +2537,37 @@ describe("BuildOptions: 누락 옵션 노출 (#1005)", () => {
     expect(result.errors.length).toBe(0);
     expect(result.outputFiles[0].text).not.toContain("<span");
     expect(await runBundleStdout(result.outputFiles[0].text)).toBe("span");
+  });
+
+  test("loader: .foo=js/jsx → TypeScript syntax를 거부", async () => {
+    writeFileSync(
+      join(dir, "entry-loader-js-strict.ts"),
+      'import { value } from "./value-js-strict.foo";\nconsole.log(value);',
+    );
+    writeFileSync(join(dir, "value-js-strict.foo"), "export const value: number = 1;");
+    const jsResult = await build({
+      entryPoints: [join(dir, "entry-loader-js-strict.ts")],
+      loader: { ".foo": "js" },
+    });
+    expect(jsResult.errors.length).toBeGreaterThan(0);
+    expect(jsResult.errors[0].text).toContain("TypeScript");
+
+    writeFileSync(
+      join(dir, "entry-loader-jsx-strict.ts"),
+      'import { value } from "./value-jsx-strict.foo";\nconsole.log(value);',
+    );
+    writeFileSync(
+      join(dir, "value-jsx-strict.foo"),
+      "const h = (tag) => tag;\nexport const value: string = <span />;",
+    );
+    const jsxResult = await build({
+      entryPoints: [join(dir, "entry-loader-jsx-strict.ts")],
+      loader: { ".foo": "jsx" },
+      jsx: "classic",
+      jsxFactory: "h",
+    });
+    expect(jsxResult.errors.length).toBeGreaterThan(0);
+    expect(jsxResult.errors[0].text).toContain("TypeScript");
   });
 
   test("resolveExtensions: 커스텀 확장자 순서가 적용됨", () => {
@@ -6251,8 +6300,6 @@ describe("@zts/core plugin lifecycle", () => {
 
 // ─── plugin onLoad loader override (#2157) ───
 
-import { spawnSync } from "node:child_process";
-
 /** 출력 코드를 dynamic import 로 실행해 console.log 결과를 캡처. plugin loader override 의
  *  end-to-end 동작 검증 — bundle 결과가 실제 런타임에서 import 바인딩과 default export 가
  *  올바르게 매칭됨을 검증한다. */
@@ -6475,6 +6522,60 @@ describe("@zts/core plugin onLoad loader", () => {
     expect(r.outputFiles[0].text).not.toContain(": string");
     expect(await runBundleStdout(r.outputFiles[0].text)).toBe("div");
     rmSync(dir, { recursive: true });
+  });
+
+  test("loader='js'/'jsx'/'ts'/'tsx': onLoad parser mode strictness", async () => {
+    async function runOnLoadCase(loader: "js" | "jsx" | "ts" | "tsx", contents: string) {
+      const dir = mkdtempSync(join(tmpdir(), `zts-onload-${loader}-strict-`));
+      writeFileSync(
+        join(dir, "entry.ts"),
+        "import { value } from './virtual.foo';\nconsole.log(value);",
+      );
+      writeFileSync(join(dir, "virtual.foo"), "");
+      const plugin: ZtsPlugin = {
+        name: `foo-as-${loader}`,
+        setup(build) {
+          build.onLoad({ filter: /\.foo$/ }, () => ({ contents, loader }));
+        },
+      };
+      const r = await build({
+        entryPoints: [join(dir, "entry.ts")],
+        plugins: [plugin],
+        jsx: "classic",
+        jsxFactory: "h",
+      });
+      rmSync(dir, { recursive: true, force: true });
+      return r;
+    }
+
+    const jsResult = await runOnLoadCase("js", "export const value: number = 1;");
+    expect(jsResult.errors.length).toBeGreaterThan(0);
+    expect(jsResult.errors[0].text).toContain("TypeScript");
+
+    const tsResult = await runOnLoadCase("ts", "export const value: number = 1;");
+    expect(tsResult.errors.length).toBe(0);
+    expect(await runBundleStdout(tsResult.outputFiles[0].text)).toBe("1");
+
+    const jsxResult = await runOnLoadCase(
+      "jsx",
+      "const h = (tag) => tag;\nexport const value = <span />;",
+    );
+    expect(jsxResult.errors.length).toBe(0);
+    expect(await runBundleStdout(jsxResult.outputFiles[0].text)).toBe("span");
+
+    const jsxTsResult = await runOnLoadCase(
+      "jsx",
+      "const h = (tag) => tag;\nexport const value: string = <span />;",
+    );
+    expect(jsxTsResult.errors.length).toBeGreaterThan(0);
+    expect(jsxTsResult.errors[0].text).toContain("TypeScript");
+
+    const tsxResult = await runOnLoadCase(
+      "tsx",
+      "const h = (tag: string) => tag;\nexport const value: string = <div />;",
+    );
+    expect(tsxResult.errors.length).toBe(0);
+    expect(await runBundleStdout(tsxResult.outputFiles[0].text)).toBe("div");
   });
 
   test("loader='bogus' (미지원 string): override 무시 → JS 모듈로 처리 (fromString null)", async () => {

--- a/src/error_codes.zig
+++ b/src/error_codes.zig
@@ -185,6 +185,7 @@ pub const Code = enum(u16) {
     ts_index_sig_modifier = 915,
     ts_index_sig_optional = 916,
     yield_outside_generator = 917,
+    ts_syntax_in_js = 918,
 
     // ═══════════════════════════════════════════════════════
     // 1000-1099: 시맨틱 — 재선언/스코프
@@ -402,6 +403,7 @@ pub const Code = enum(u16) {
             .flow_opaque_type => "Expected 'type' after 'opaque'",
             .ts_index_sig_modifier => "Modifiers cannot appear on index signature parameters",
             .ts_index_sig_optional => "An index signature parameter cannot have a question mark",
+            .ts_syntax_in_js => "TypeScript syntax is not allowed in JavaScript source",
             // 시맨틱: 재선언
             .identifier_redeclared => "Identifier has already been declared",
             .binding_strict_mode => "Cannot be used as a binding identifier in strict mode",

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -127,6 +127,11 @@ pub const Parser = struct {
     /// TypeScript 모드 (.ts/.tsx/.mts). TS에서는 function overload, duplicate export 등이 합법.
     is_ts: bool = false,
 
+    /// 명시적으로 JS/JSX source type 으로 파싱 중이면 TypeScript-only syntax 를 거부한다.
+    /// 기본 standalone parser 는 기존 호환성을 위해 permissive 이고, bundler loader 또는
+    /// standalone transpile filename 이 js/jsx 계열로 확정된 경우에만 활성화한다.
+    reject_ts_syntax_in_js: bool = false,
+
     /// Flow 모드 (.js/.jsx + @flow pragma, .js.flow, 또는 --flow CLI).
     /// Flow 타입 어노테이션 파싱 및 스트리핑을 활성화한다.
     is_flow: bool = false,
@@ -289,11 +294,13 @@ pub const Parser = struct {
     /// 번들러용: .ts/.tsx를 확정 module로 파싱 (await 키워드, strict mode 항상 적용)
     pub fn configureForBundler(self: *Parser, ext: []const u8) void {
         self.applyExtension(ext, false);
+        self.rejectTypeScriptSyntaxForJavaScriptSource(ext);
     }
 
     /// 번들러용: 확장자 매칭을 거치지 않고 TS/JSX 플래그를 직접 적용한다.
     /// `--loader:.foo=tsx` 처럼 확장자와 parser 의미가 어긋날 때 사용.
     pub fn configureForBundlerKind(self: *Parser, is_ts: bool, is_jsx: bool) void {
+        self.reject_ts_syntax_in_js = !is_ts;
         if (is_ts) {
             self.is_module = true;
             self.scanner.is_module = true;
@@ -319,6 +326,16 @@ pub const Parser = struct {
         }
         if (std.mem.eql(u8, ext, ".tsx") or std.mem.eql(u8, ext, ".jsx")) {
             self.is_jsx = true;
+        }
+    }
+
+    /// 명시 JS 계열 source type 은 TS syntax 를 허용하지 않는다.
+    /// `transpile(source)` 기본 filename 은 여전히 input.ts 이므로 기존 permissive 기본값은 유지된다.
+    pub fn rejectTypeScriptSyntaxForJavaScriptSource(self: *Parser, ext: []const u8) void {
+        if (std.mem.eql(u8, ext, ".js") or std.mem.eql(u8, ext, ".jsx") or
+            std.mem.eql(u8, ext, ".mjs") or std.mem.eql(u8, ext, ".cjs"))
+        {
+            self.reject_ts_syntax_in_js = true;
         }
     }
 
@@ -2074,6 +2091,7 @@ pub const Parser = struct {
 
     pub fn parseTsTypeParameterDeclaration(self: *Parser) ParseError2!NodeIndex {
         if (self.is_flow) return flow.parseTypeParameterDeclaration(self);
+        try self.rejectTypeScriptSyntaxInJavaScript("TypeScript type parameters are not allowed when parsing as JavaScript");
         return ts.parseTsTypeParameterDeclaration(self);
     }
 
@@ -2099,6 +2117,9 @@ pub const Parser = struct {
 
     pub fn tryParseTypeAnnotation(self: *Parser) ParseError2!NodeIndex {
         if (self.is_flow) return flow.tryParseTypeAnnotation(self);
+        if (self.current() == .colon) {
+            try self.rejectTypeScriptSyntaxInJavaScript("TypeScript type annotations are not allowed when parsing as JavaScript");
+        }
         return ts.tryParseTypeAnnotation(self);
     }
 
@@ -2110,6 +2131,7 @@ pub const Parser = struct {
         if (self.current() == .kw_this) {
             const next = try self.peekNextKind();
             if (next == .colon) {
+                try self.rejectTypeScriptSyntaxInJavaScript("TypeScript this parameters are not allowed when parsing as JavaScript");
                 try self.advance(); // skip 'this'
                 _ = try self.tryParseTypeAnnotation(); // skip ': Type'
                 _ = try self.eat(.comma);
@@ -2119,7 +2141,15 @@ pub const Parser = struct {
 
     pub fn tryParseReturnType(self: *Parser) ParseError2!NodeIndex {
         if (self.is_flow) return flow.tryParseReturnType(self);
+        if (self.current() == .colon) {
+            try self.rejectTypeScriptSyntaxInJavaScript("TypeScript return type annotations are not allowed when parsing as JavaScript");
+        }
         return ts.tryParseReturnType(self);
+    }
+
+    fn rejectTypeScriptSyntaxInJavaScript(self: *Parser, message: []const u8) ParseError2!void {
+        if (!self.reject_ts_syntax_in_js or self.is_ts or self.is_flow) return;
+        try self.addErrorCode(self.currentSpan(), message, .ts_syntax_in_js);
     }
 
     pub fn parseType(self: *Parser) ParseError2!NodeIndex {

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -294,7 +294,6 @@ pub const Parser = struct {
     /// 번들러용: .ts/.tsx를 확정 module로 파싱 (await 키워드, strict mode 항상 적용)
     pub fn configureForBundler(self: *Parser, ext: []const u8) void {
         self.applyExtension(ext, false);
-        self.rejectTypeScriptSyntaxForJavaScriptSource(ext);
     }
 
     /// 번들러용: 확장자 매칭을 거치지 않고 TS/JSX 플래그를 직접 적용한다.
@@ -327,11 +326,8 @@ pub const Parser = struct {
         if (std.mem.eql(u8, ext, ".tsx") or std.mem.eql(u8, ext, ".jsx")) {
             self.is_jsx = true;
         }
-    }
-
-    /// 명시 JS 계열 source type 은 TS syntax 를 허용하지 않는다.
-    /// `transpile(source)` 기본 filename 은 여전히 input.ts 이므로 기존 permissive 기본값은 유지된다.
-    pub fn rejectTypeScriptSyntaxForJavaScriptSource(self: *Parser, ext: []const u8) void {
+        // 명시 JS 계열 source type 은 TS syntax 를 허용하지 않는다.
+        // `transpile(source)` 기본 filename 은 여전히 input.ts 이므로 기존 permissive 기본값은 유지된다.
         if (std.mem.eql(u8, ext, ".js") or std.mem.eql(u8, ext, ".jsx") or
             std.mem.eql(u8, ext, ".mjs") or std.mem.eql(u8, ext, ".cjs"))
         {

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -394,7 +394,9 @@ pub fn transpileWithCallback(
     }
 
     var parser = Parser.init(arena_alloc, &scanner);
-    parser.configureFromExtension(std.fs.path.extension(file_path));
+    const ext = std.fs.path.extension(file_path);
+    parser.configureFromExtension(ext);
+    parser.rejectTypeScriptSyntaxForJavaScriptSource(ext);
 
     if (!parser.is_ts) {
         if (options.flow) {

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -394,9 +394,7 @@ pub fn transpileWithCallback(
     }
 
     var parser = Parser.init(arena_alloc, &scanner);
-    const ext = std.fs.path.extension(file_path);
-    parser.configureFromExtension(ext);
-    parser.rejectTypeScriptSyntaxForJavaScriptSource(ext);
+    parser.configureFromExtension(std.fs.path.extension(file_path));
 
     if (!parser.is_ts) {
         if (options.flow) {

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -67,6 +67,80 @@ describe("번들 스모크 테스트", () => {
     expect(result.runOutput).toBe("test");
   });
 
+  test("CLI --loader:.foo=js/jsx/ts/tsx parser strictness", async () => {
+    const { dir, cleanup: c } = await createFixture({
+      "entry-js.ts": `import { value } from "./value-js.foo"; console.log(value);`,
+      "value-js.foo": `export const value: number = 1;`,
+      "entry-ts.ts": `import { value } from "./value-ts.foo"; console.log(value);`,
+      "value-ts.foo": `export const value: number = 1;`,
+      "entry-jsx.ts": `import { value } from "./value-jsx.foo"; console.log(value);`,
+      "value-jsx.foo": `const h = (tag) => tag; export const value = <span />;`,
+      "entry-jsx-ts.ts": `import { value } from "./value-jsx-ts.foo"; console.log(value);`,
+      "value-jsx-ts.foo": `const h = (tag) => tag; export const value: string = <span />;`,
+      "entry-tsx.ts": `import { value } from "./value-tsx.foo"; console.log(value);`,
+      "value-tsx.foo": `const h = (tag: string) => tag; export const value: string = <div />;`,
+    });
+    cleanup = c;
+
+    const jsOut = join(dir, "js.js");
+    const jsResult = await runZts([
+      "--bundle",
+      join(dir, "entry-js.ts"),
+      "-o",
+      jsOut,
+      "--loader:.foo=js",
+    ]);
+    expect(jsResult.exitCode).not.toBe(0);
+    expect(jsResult.stderr).toContain("TypeScript");
+
+    const tsOut = join(dir, "ts.js");
+    const tsResult = await runZts([
+      "--bundle",
+      join(dir, "entry-ts.ts"),
+      "-o",
+      tsOut,
+      "--loader:.foo=ts",
+    ]);
+    expect(tsResult.exitCode).toBe(0);
+
+    const jsxOut = join(dir, "jsx.js");
+    const jsxResult = await runZts([
+      "--bundle",
+      join(dir, "entry-jsx.ts"),
+      "-o",
+      jsxOut,
+      "--loader:.foo=jsx",
+      "--jsx=classic",
+      "--jsx-factory=h",
+    ]);
+    expect(jsxResult.exitCode).toBe(0);
+
+    const jsxTsOut = join(dir, "jsx-ts.js");
+    const jsxTsResult = await runZts([
+      "--bundle",
+      join(dir, "entry-jsx-ts.ts"),
+      "-o",
+      jsxTsOut,
+      "--loader:.foo=jsx",
+      "--jsx=classic",
+      "--jsx-factory=h",
+    ]);
+    expect(jsxTsResult.exitCode).not.toBe(0);
+    expect(jsxTsResult.stderr).toContain("TypeScript");
+
+    const tsxOut = join(dir, "tsx.js");
+    const tsxResult = await runZts([
+      "--bundle",
+      join(dir, "entry-tsx.ts"),
+      "-o",
+      tsxOut,
+      "--loader:.foo=tsx",
+      "--jsx=classic",
+      "--jsx-factory=h",
+    ]);
+    expect(tsxResult.exitCode).toBe(0);
+  });
+
   test("forward reference — 같은 이름 변수의 올바른 참조", async () => {
     // 두 모듈이 같은 이름의 top-level 변수(helper)를 갖고,
     // forward reference(helper가 greet보다 뒤에 선언)가 있을 때


### PR DESCRIPTION
## 요약

- `loader=js/jsx`로 결정된 JS 계열 source type에서 TypeScript 문법을 진단하도록 parser strictness를 추가했습니다.
- `loader=ts/tsx`는 기존처럼 TypeScript 문법을 허용하고, `jsx/tsx`의 JSX 허용 여부도 유지합니다.
- standalone `transpile()`도 `filename: "*.js"` / `"*.jsx"`처럼 source type이 명시된 경우 TypeScript 문법을 거부하도록 맞췄습니다. 기본 `transpile(source)`는 기존처럼 `input.ts` 기본값이라 public API 기본 동작은 유지됩니다.

## 범위 조정 메모

초기 구현 계획은 bundler 전용 `loader=js/jsx` strictness만 다루고 standalone parser/transformer의 permissive path는 그대로 두는 쪽이었습니다.

중간 논의에서 "다른 번들러처럼 source type 기준 정책으로 갈 거라면 이 구현이 맞는가"를 다시 확인했고, 최종 방향은 Rolldown 모델처럼 `js/jsx/ts/tsx` source type을 분리해서 보는 쪽으로 정했습니다. 그래서 이번 PR 범위를 다음처럼 조정했습니다.

- bundler loader strictness는 그대로 구현합니다.
- standalone도 `filename`으로 `.js`/`.jsx` source type이 명시된 경우에는 TS syntax를 거부합니다.
- 단, `transpile(source)` 기본값은 현재 `input.ts`라 기존 public API 기본 동작은 유지합니다.
- `Loader`/`ModuleType` 자체를 Rolldown식 source type 모델로 정리하는 큰 리팩터는 이번 PR에서 하지 않고 #2319로 분리했습니다.

## 후속 리팩터

- 장기적으로 Rolldown처럼 JS 계열 source type을 내부 모델 중심으로 정리하는 작업은 #2319에서 추적합니다.

## 검증

- `zig build napi`
- `bun test packages/core/index.test.ts --timeout 30000`
- `zig build`
- `bun test tests/integration/tests/bundle-smoke.test.ts --timeout 30000`
- `zig build test --summary all`
- push 전 pre-push hook 통과
