### PR TITLE
refactor(parser): unify is_ts + reject_ts_syntax_in_js into SourceMode enum

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1419,8 +1419,8 @@ pub const ModuleGraph = struct {
         configureParserForModule(&parser, module, ext);
 
         // Flow 모드: --flow CLI 또는 .js.flow/.jsx.flow 확장자 (pragma는 parse() 내부에서 감지)
-        // is_ts와 is_flow는 상호 배타 — TS 파일에서는 Flow 무시
-        if (!parser.is_ts) {
+        // TS 와 Flow 는 상호 배타 — TS 파일에서는 Flow 무시
+        if (parser.source_mode != .ts) {
             if (self.flow) {
                 parser.is_flow = true;
                 scanner.has_flow_pragma = true; // flow comment 활성화
@@ -1431,7 +1431,7 @@ pub const ModuleGraph = struct {
         // .js 파일에서 JSX 파싱 활성화 (--platform=react-native 프리셋)
         // .ts 파일은 이미 configureForBundler에서 JSX 설정됨 (.tsx만 true)
         // .ts에 강제 jsx=true하면 <T> 제네릭이 JSX로 오파싱됨
-        if (self.jsx_in_js and !parser.is_ts) {
+        if (self.jsx_in_js and parser.source_mode != .ts) {
             parser.is_jsx = true;
         }
 
@@ -1512,7 +1512,7 @@ pub const ModuleGraph = struct {
         var analyzer = SemanticAnalyzer.init(arena_alloc, &parser.ast);
         analyzer.is_strict_mode = parser.is_strict_mode;
         analyzer.is_module = parser.is_module;
-        analyzer.is_ts = parser.is_ts;
+        analyzer.is_ts = parser.source_mode == .ts;
         analyzer.is_flow = parser.is_flow;
         analyzer.enable_stmt_info = true; // tree_shaker가 AST 재순회 없이 StmtInfo 사용
         const analyze_ok = if (analyzer.analyze()) |_| true else |_| false;

--- a/src/codegen/codegen_test/class_expr_anonymize.zig
+++ b/src/codegen/codegen_test/class_expr_anonymize.zig
@@ -32,7 +32,7 @@ fn runSemanticPipeline(
     var analyzer = SemanticAnalyzer.init(allocator, &parser.ast);
     analyzer.is_strict_mode = parser.is_strict_mode;
     analyzer.is_module = parser.is_module;
-    analyzer.is_ts = parser.is_ts;
+    analyzer.is_ts = parser.source_mode == .ts;
     analyzer.is_flow = parser.is_flow;
     try analyzer.analyze();
 

--- a/src/parser/jsx.zig
+++ b/src/parser/jsx.zig
@@ -131,7 +131,7 @@ fn parseJSXElementImpl(self: *Parser, as_child: bool) ParseError2!NodeIndex {
     // TS JSX type arguments: <Foo<T> ... /> or <Foo<<T>(x:T)=>T> ... />
     // 태그 이름 뒤에 '<'가 오면 type arguments로 파싱하여 스트리핑.
     // type args 파싱은 일반 scanner 모드를 쓰므로, 끝난 후 JSX 모드로 재스캔.
-    if (self.is_ts and self.current() == .l_angle) {
+    if (self.source_mode == .ts and self.current() == .l_angle) {
         _ = try self.parseTypeArguments();
         // type args 닫는 > 이후 토큰이 일반 모드로 스캔됨 → JSX 모드로 재스캔
         try self.scanner.nextInsideJSXElement();

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -41,9 +41,9 @@ const BracketInfo = struct {
     span: Span,
 };
 
-/// 파서 입력의 source-type. 과거 `is_ts: bool` 과 `reject_ts_syntax_in_js: bool` 두 필드로
-/// 표현하던 3-state 를 명시적 enum 으로 통합. 두 boolean 의 (true,true) 조합이 의미상
-/// 불가능했던 것이 enum 으로는 자명해진다.
+/// 파서 입력의 source-type 3-state. "TS 문법을 거부하지 않으면서도 TS 가 아닌" js_lenient 와
+/// "명시 JS 라서 TS 문법을 거부하는" js_strict 가 별개 상태라 두 boolean 으로는 (true,true)
+/// 같은 불가능 조합이 표현 가능했고, 이를 enum 으로 차단한다.
 pub const SourceMode = enum {
     /// JS 입력이지만 source-type signal 이 없는 legacy 모드 (standalone transpile + unknown
     /// extension 등). TS 문법은 silent 통과. 새 입력 경로에는 사용하지 말 것.
@@ -137,11 +137,7 @@ pub const Parser = struct {
     /// false이면 <T>()=>{}가 제네릭 arrow로 해석.
     is_jsx: bool = false,
 
-    /// 파서가 보는 source-type. is_ts/reject_ts_syntax_in_js 두 boolean 으로 표현하던
-    /// 3-state 를 단일 enum 으로 통합한 것. `js_lenient` 는 standalone transpile 의 unknown
-    /// extension 등 source-type signal 이 없는 legacy 입력 (TS 문법 silent 통과). `js_strict`
-    /// 는 .js/.jsx 또는 loader=js/jsx 로 명시된 JS 입력 (TS 문법 거부). `ts` 는 .ts/.tsx
-    /// 또는 loader=ts/tsx 로 명시된 TS 입력 (TS 문법 허용 + module/strict).
+    /// 파서가 보는 source-type. 변형별 의미는 SourceMode 정의 참고.
     source_mode: SourceMode = .js_lenient,
 
     /// Flow 모드 (.js/.jsx + @flow pragma, .js.flow, 또는 --flow CLI).

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -41,6 +41,19 @@ const BracketInfo = struct {
     span: Span,
 };
 
+/// 파서 입력의 source-type. 과거 `is_ts: bool` 과 `reject_ts_syntax_in_js: bool` 두 필드로
+/// 표현하던 3-state 를 명시적 enum 으로 통합. 두 boolean 의 (true,true) 조합이 의미상
+/// 불가능했던 것이 enum 으로는 자명해진다.
+pub const SourceMode = enum {
+    /// JS 입력이지만 source-type signal 이 없는 legacy 모드 (standalone transpile + unknown
+    /// extension 등). TS 문법은 silent 통과. 새 입력 경로에는 사용하지 말 것.
+    js_lenient,
+    /// .js/.jsx/.mjs/.cjs 또는 loader=js/jsx 로 source-type 이 명시된 JS. TS 문법 거부.
+    js_strict,
+    /// .ts/.tsx/.mts/.cts 또는 loader=ts/tsx 로 source-type 이 명시된 TS.
+    ts,
+};
+
 /// 재귀 하강 파서.
 /// Scanner에서 토큰을 하나씩 읽어 AST를 구축한다.
 pub const Parser = struct {
@@ -124,13 +137,12 @@ pub const Parser = struct {
     /// false이면 <T>()=>{}가 제네릭 arrow로 해석.
     is_jsx: bool = false,
 
-    /// TypeScript 모드 (.ts/.tsx/.mts). TS에서는 function overload, duplicate export 등이 합법.
-    is_ts: bool = false,
-
-    /// JS/JSX source type 으로 파싱 중이면 TypeScript-only syntax 를 거부한다.
-    /// standalone transpile 의 filename 생략 기본값도 JS라서 TypeScript 문법은 filename/loader로
-    /// ts/tsx source type을 명시해야 한다.
-    reject_ts_syntax_in_js: bool = false,
+    /// 파서가 보는 source-type. is_ts/reject_ts_syntax_in_js 두 boolean 으로 표현하던
+    /// 3-state 를 단일 enum 으로 통합한 것. `js_lenient` 는 standalone transpile 의 unknown
+    /// extension 등 source-type signal 이 없는 legacy 입력 (TS 문법 silent 통과). `js_strict`
+    /// 는 .js/.jsx 또는 loader=js/jsx 로 명시된 JS 입력 (TS 문법 거부). `ts` 는 .ts/.tsx
+    /// 또는 loader=ts/tsx 로 명시된 TS 입력 (TS 문법 허용 + module/strict).
+    source_mode: SourceMode = .js_lenient,
 
     /// Flow 모드 (.js/.jsx + @flow pragma, .js.flow, 또는 --flow CLI).
     /// Flow 타입 어노테이션 파싱 및 스트리핑을 활성화한다.
@@ -302,9 +314,8 @@ pub const Parser = struct {
     /// 어긋날 때 사용. parser는 standalone 모듈이라 bundler의 ModuleType 을 직접 참조하지
     /// 않고 호출자가 (is_ts, is_jsx) 로 변환해서 넘긴다.
     pub fn configureForBundlerKind(self: *Parser, is_ts: bool, is_jsx: bool) void {
-        self.is_ts = is_ts;
+        self.source_mode = if (is_ts) .ts else .js_strict;
         self.is_jsx = is_jsx;
-        self.reject_ts_syntax_in_js = !is_ts;
         if (is_ts) {
             self.is_module = true;
             self.scanner.is_module = true;
@@ -324,24 +335,23 @@ pub const Parser = struct {
         if (std.mem.eql(u8, ext, ".ts") or std.mem.eql(u8, ext, ".tsx") or
             std.mem.eql(u8, ext, ".mts") or std.mem.eql(u8, ext, ".cts"))
         {
-            self.is_ts = true;
+            self.source_mode = .ts;
+        } else if (std.mem.eql(u8, ext, ".js") or std.mem.eql(u8, ext, ".jsx") or
+            std.mem.eql(u8, ext, ".mjs") or std.mem.eql(u8, ext, ".cjs"))
+        {
+            self.source_mode = .js_strict;
         }
         if (std.mem.eql(u8, ext, ".tsx") or std.mem.eql(u8, ext, ".jsx")) {
             self.is_jsx = true;
-        }
-        if (std.mem.eql(u8, ext, ".js") or std.mem.eql(u8, ext, ".jsx") or
-            std.mem.eql(u8, ext, ".mjs") or std.mem.eql(u8, ext, ".cjs"))
-        {
-            self.reject_ts_syntax_in_js = true;
         }
     }
 
     /// 파일 경로에서 .js.flow / .jsx.flow 이중 확장자를 감지하여 Flow 모드를 설정한다.
     /// std.fs.path.extension()은 마지막 확장자(.flow)만 반환하므로
     /// 전체 경로를 확인해야 한다.
-    /// is_ts와 is_flow는 상호 배타적이므로, TS 파일에서는 설정하지 않는다.
+    /// TS 와 Flow 는 상호 배타적이므로, TS 파일에서는 설정하지 않는다.
     pub fn configureFlowFromPath(self: *Parser, file_path: []const u8) void {
-        if (self.is_ts) return; // TS와 Flow는 상호 배타
+        if (self.source_mode == .ts) return; // TS와 Flow는 상호 배타
         if (std.mem.endsWith(u8, file_path, ".js.flow")) {
             self.is_flow = true;
             self.scanner.has_flow_pragma = true; // flow comment 활성화
@@ -355,9 +365,9 @@ pub const Parser = struct {
     /// 스캐너가 @flow pragma를 감지했으면 is_flow를 활성화한다.
     /// 내부 전용 — statement.parse()의 advance() 직후에서만 호출.
     /// advance()가 첫 주석을 스캔하므로 이 시점에서 has_flow_pragma가 설정되어 있다.
-    /// is_ts와 is_flow는 상호 배타적이므로, TS 모드에서는 무시한다.
+    /// TS 와 Flow 는 상호 배타적이므로, TS 모드에서는 무시한다.
     pub fn applyFlowPragma(self: *Parser) void {
-        if (self.is_ts) return; // TS와 Flow는 상호 배타
+        if (self.source_mode == .ts) return; // TS와 Flow는 상호 배타
         if (self.scanner.has_flow_pragma) {
             self.is_flow = true;
         }
@@ -2145,7 +2155,7 @@ pub const Parser = struct {
     }
 
     fn rejectTypeScriptSyntaxInJavaScript(self: *Parser, message: []const u8) ParseError2!void {
-        if (!self.reject_ts_syntax_in_js or self.is_ts or self.is_flow) return;
+        if (self.source_mode != .js_strict or self.is_flow) return;
         try self.addErrorCode(self.currentSpan(), message, .ts_syntax_in_js);
     }
 

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -85,7 +85,7 @@ pub fn parseStatementChecked(self: *Parser, comptime is_loop_body: bool) ParseEr
     switch (self.current()) {
         .kw_const => {
             // TS const enum은 완전히 지워지므로 label 위치 허용
-            if (!self.is_ts or try self.peekNextKind() != .kw_enum) {
+            if (self.source_mode != .ts or try self.peekNextKind() != .kw_enum) {
                 try self.addErrorCode(self.currentSpan(), "Lexical declaration is not allowed in statement position", .lexical_in_statement);
             }
         },
@@ -817,7 +817,7 @@ fn validateForInOfDeclaration(self: *Parser, init_expr: NodeIndex) ParseError2!v
         // TS 모드에서는 for-in var initializer를 허용 (esbuild 호환).
         // TS에서 `for (var x = Array<number> in y)` 같은 패턴에서 타입 인자가
         // 스트리핑되어 initializer가 남을 수 있다. codegen에서 hoisting 처리.
-        if (self.is_ts) return;
+        if (self.source_mode == .ts) return;
 
         if (!self.is_strict_mode) {
             // BindingIdentifier인지 확인 — destructuring이면 허용 불가

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -850,7 +850,7 @@ fn analyzeModule(source: []const u8) !AnalyzeResult {
     scanner.is_module = true;
     var parser = Parser.init(std.testing.allocator, &scanner);
     errdefer parser.deinit();
-    parser.is_ts = true;
+    parser.source_mode = .ts;
     parser.is_module = true;
     _ = try parser.parse();
 
@@ -1068,7 +1068,7 @@ fn analyzeModuleWithTarget(source: []const u8, target: @import("../transformer/c
     scanner.is_module = true;
     var parser = Parser.init(std.testing.allocator, &scanner);
     errdefer parser.deinit();
-    parser.is_ts = true;
+    parser.source_mode = .ts;
     parser.is_module = true;
     _ = try parser.parse();
 

--- a/src/test262/runner.zig
+++ b/src/test262/runner.zig
@@ -203,7 +203,7 @@ pub fn runTest(allocator: mem.Allocator, source: []const u8, meta: TestMetadata,
         var analyzer = SemanticAnalyzer.init(arena_alloc, &parser.ast);
         analyzer.is_strict_mode = parser.is_strict_mode;
         analyzer.is_module = parser.is_module;
-        analyzer.is_ts = parser.is_ts;
+        analyzer.is_ts = parser.source_mode == .ts;
         analyzer.is_flow = parser.is_flow;
         analyzer.analyze() catch {
             semantic_error_count = 1; // OOM during analysis — treat as error

--- a/src/test_arena.zig
+++ b/src/test_arena.zig
@@ -22,7 +22,7 @@ fn runPipeline(allocator: std.mem.Allocator, source: []const u8) ![]const u8 {
     var analyzer = SemanticAnalyzer.init(allocator, &parser.ast);
     analyzer.is_strict_mode = parser.is_strict_mode;
     analyzer.is_module = parser.is_module;
-    analyzer.is_ts = parser.is_ts;
+    analyzer.is_ts = parser.source_mode == .ts;
     analyzer.is_flow = parser.is_flow;
     try analyzer.analyze();
     if (analyzer.errors.items.len > 0) return error.SemanticError;

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -396,7 +396,7 @@ pub fn transpileWithCallback(
     var parser = Parser.init(arena_alloc, &scanner);
     parser.configureFromExtension(std.fs.path.extension(file_path));
 
-    if (!parser.is_ts) {
+    if (parser.source_mode != .ts) {
         if (options.flow) {
             parser.is_flow = true;
             scanner.has_flow_pragma = true;
@@ -409,7 +409,7 @@ pub fn transpileWithCallback(
             parser.configureFlowFromPath(file_path);
         }
     }
-    if (options.jsx_in_js and !parser.is_ts) {
+    if (options.jsx_in_js and parser.source_mode != .ts) {
         parser.is_jsx = true;
     }
     _ = parser.parse() catch return error.ParseError;
@@ -428,7 +428,7 @@ pub fn transpileWithCallback(
     var analyzer = SemanticAnalyzer.init(arena_alloc, &parser.ast);
     analyzer.is_strict_mode = parser.is_strict_mode;
     analyzer.is_module = parser.is_module;
-    analyzer.is_ts = parser.is_ts;
+    analyzer.is_ts = parser.source_mode == .ts;
     analyzer.is_flow = parser.is_flow;
     analyzer.es_target = options.es_target;
     analyzer.unsupported = options.unsupported;


### PR DESCRIPTION
## 요약
- 파서의 `is_ts: bool` 과 `reject_ts_syntax_in_js: bool` 두 boolean 으로 표현하던 3-state 를 단일 enum `SourceMode { js_lenient, js_strict, ts }` 로 통합.
- (true,true) 조합이 의미상 불가능하던 것이 enum 으로는 자명해짐.
- `rejectTypeScriptSyntaxInJavaScript` 의 중복 `is_ts` 가드도 자연 소멸 — `source_mode != .js_strict` 가 `.ts` 와 `.js_lenient` 를 모두 배제.

## 후속 작업 배경
직전 PR #2321 (`refactor(bundler): JS 계열 source type을 ModuleType으로 통일`) 의 `/simplify` 검토에서 발견된 redundant state. 큰 변경이라 별도 PR 로 분리.

## 변경 범위
| 파일 | 내용 |
|------|------|
| `src/parser/parser.zig` | `SourceMode` enum 정의, 두 필드 제거 → `source_mode` 추가, `applyExtension`/`configureForBundlerKind`/helper 갱신 |
| `src/bundler/graph.zig` | `parser.is_ts` 읽는 3곳 갱신 |
| `src/transpile.zig` | `parser.is_ts` 읽는 3곳 갱신 |
| `src/parser/{statement,jsx}.zig` | `self.is_ts` → `self.source_mode == .ts` |
| `src/{test_arena,test262/runner,codegen/...}` | `parser.is_ts` → `parser.source_mode == .ts` |
| `src/semantic/analyzer_test.zig` | `parser.is_ts = true` → `parser.source_mode = .ts` |

## 상태별 의미 (참고)
- `js_lenient` — standalone transpile 의 unknown extension 등 source-type signal 이 없는 legacy 입력. TS 문법 silent 통과. 새 입력 경로에는 사용 X.
- `js_strict` — `.js/.jsx/.mjs/.cjs` 또는 `loader=js/jsx` 로 명시된 JS. TS 문법 거부.
- `ts` — `.ts/.tsx/.mts/.cts` 또는 `loader=ts/tsx` 로 명시된 TS.

## 테스트
- `zig build test --summary all`
- `zig build napi`
- `bun test packages/core/index.test.ts --timeout 30000` (TS/JSX strict 26 tests pass)
- `bun test tests/integration/tests/bundle-smoke.test.ts --timeout 30000` (149 tests pass)
- `bun run fmt:check`
- pre-push hook 통과