### PR TITLE
fix(transformer): downlevel for-await-of for es2017

### DIFF
--- a/src/transformer/compat.zig
+++ b/src/transformer/compat.zig
@@ -191,6 +191,12 @@ pub const UnsupportedFeatures = packed struct(u32) {
     pub fn requiresPrivateDownlevel(self: UnsupportedFeatures) bool {
         return self.class or self.class_private_field or self.class_private_method;
     }
+
+    /// `for await (... of ...)` is ES2018 syntax. There is no dedicated bit yet,
+    /// so use the ES2018 feature cluster as the target-derived gate.
+    pub fn needsForAwaitOfDownlevel(self: UnsupportedFeatures) bool {
+        return self.async_await or self.object_spread or self.regex_dotall or self.regex_named_groups;
+    }
 };
 
 // ─── 엔진 버전 ───

--- a/src/transformer/compat.zig
+++ b/src/transformer/compat.zig
@@ -192,8 +192,10 @@ pub const UnsupportedFeatures = packed struct(u32) {
         return self.class or self.class_private_field or self.class_private_method;
     }
 
-    /// `for await (... of ...)` is ES2018 syntax. There is no dedicated bit yet,
-    /// so use the ES2018 feature cluster as the target-derived gate.
+    /// `for await (... of ...)` 는 ES2018 문법. 전용 feature 비트가 없어서, ES2018 비트
+    /// (object_spread / regex_dotall / regex_named_groups) 중 하나라도 unsupported 면
+    /// "타겟이 ES2018 미만" 으로 간주. async_await (ES2017) 도 같이 OR — ES2017 미지원 타겟은
+    /// 당연히 ES2018 도 미지원이므로 별도 분기 없이 동일 경로로 처리.
     pub fn needsForAwaitOfDownlevel(self: UnsupportedFeatures) bool {
         return self.async_await or self.object_spread or self.regex_dotall or self.regex_named_groups;
     }

--- a/src/transformer/es2015_for_of.zig
+++ b/src/transformer/es2015_for_of.zig
@@ -48,9 +48,6 @@ const es2015_block_scoping = @import("es2015_block_scoping.zig");
 
 pub fn ES2015ForOf(comptime Transformer: type) type {
     return struct {
-        // for_await_of_statement (ES2018) is not downleveled at any target —
-        // matches SWC/esbuild behavior. Full downlevel requires an async
-        // iterator protocol helper (cf. Babel's plugin-proposal-async-generator-functions).
         /// for (const x of iterable) { body }
         /// → iterator protocol (try-catch-finally 포함)
         pub fn lowerForOfStatement(self: *Transformer, node: Node) Transformer.Error!NodeIndex {

--- a/src/transformer/es2018_for_await.zig
+++ b/src/transformer/es2018_for_await.zig
@@ -1,6 +1,6 @@
 //! ES2018 다운레벨링: for-await-of loop
 //!
-//! --target < es2017 (async_await unsupported) 일 때 활성화.
+//! --target < es2018 일 때 활성화.
 //! Hermes / ES5는 `for await` 키워드 자체를 파싱하지 못하므로, async function body 가
 //! `__async(function*() { ... })` 로 래핑되기 전에 미리 `while` 루프로 변환해야 한다.
 //!
@@ -26,10 +26,7 @@
 //! 내부의 `await` 는 `yield` 로 재변환된다. 즉 이 변환은 for-await 키워드/구조만 제거하고
 //! `await` 자체는 그대로 둠. 후속 ES2017 lowering 이 yield 변환을 처리.
 //!
-//! Flow gate: `options.unsupported.async_await` (= ES2017 미지원 = for-await 도 동시에 미지원).
-//! 별도의 for_await 피쳐 플래그를 두지 않은 이유: for-await 는 async function 안에서만 쓸 수
-//! 있고, 엔진 관점에서 for-await 만 구현/async_await 만 구현 같은 비대칭 조합이 실질적으로
-//! 존재하지 않음.
+//! Flow gate: `options.unsupported.needsForAwaitOfDownlevel()` (= ES2018 미지원).
 //!
 //! 참고:
 //! - TypeScript: src/compiler/transformers/es2018.ts (visitForAwaitOfStatement)
@@ -98,7 +95,7 @@ pub fn ES2018ForAwait(comptime Transformer: type) type {
 
             // await _iter.next()
             const await_next = try self.ast.addNode(.{
-                .tag = .yield_expression,
+                .tag = .await_expression,
                 .span = span,
                 .data = .{ .unary = .{ .operand = iter_next_call, .flags = 0 } },
             });
@@ -265,7 +262,7 @@ pub fn ES2018ForAwait(comptime Transformer: type) type {
 
             // await _ret.call(_iter)
             const await_ret_call = try self.ast.addNode(.{
-                .tag = .yield_expression,
+                .tag = .await_expression,
                 .span = span,
                 .data = .{ .unary = .{ .operand = ret_call, .flags = 0 } },
             });

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1277,10 +1277,9 @@ pub const Transformer = struct {
             .try_statement,
             => self.visitTernaryNode(node),
             .for_await_of_statement => {
-                // for-await 키워드는 ES2018. async_await 자체를 다운레벨링해야 하는 타겟
-                // (Hermes / ES5 등)은 for-await 파싱도 불가 — async function wrap 전에
-                // 미리 __asyncValues + while 로 변환. (#1381)
-                if (self.options.unsupported.async_await) {
+                // for-await 키워드는 ES2018. ES2018 미만 타겟에서는 async function 자체를
+                // 보존하더라도 for-await 구문만 __asyncValues + while 로 제거해야 한다.
+                if (self.options.unsupported.needsForAwaitOfDownlevel()) {
                     return es2018_for_await.ES2018ForAwait(Transformer).lowerForAwaitOf(self, node);
                 }
                 return self.visitForInOfTernary(node);
@@ -1303,7 +1302,7 @@ pub const Transformer = struct {
                 const child_idx = node.data.binary.right;
                 if (!child_idx.isNone()) {
                     const child = self.ast.getNode(child_idx);
-                    if (self.options.unsupported.async_await and child.tag == .for_await_of_statement) {
+                    if (self.options.unsupported.needsForAwaitOfDownlevel() and child.tag == .for_await_of_statement) {
                         const new_label = try self.visitNode(node.data.binary.left);
                         return es2018_for_await.ES2018ForAwait(Transformer).lowerForAwaitOfLabeled(self, child, new_label);
                     }

--- a/tests/integration/tests/tsc/es6-for-ofStatements.test.ts
+++ b/tests/integration/tests/tsc/es6-for-ofStatements.test.ts
@@ -1,5 +1,6 @@
-import { describe, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { expectPass, expectError } from "./helpers";
+import { createFixture, runZts } from "../helpers";
 
 describe("TSC: es6/for-ofStatements", () => {
   test("for-of-excess-declarations", async () => {
@@ -729,6 +730,69 @@ for (v of "hello") { }`,
       [],
     );
   });
-  // for-await-of (ES2018) is not downleveled — matches SWC/esbuild behavior.
-  test.skip("for-await-of downlevel (not implemented; parity with SWC/esbuild)", async () => {});
+  test("for-await-of downlevel to ES2017", async () => {
+    const fixture = await createFixture({
+      "input.ts": `
+async function collect(iter) {
+  const out = [];
+  for await (const value of iter) {
+    out.push(value);
+  }
+  return out;
+}
+`,
+    });
+    try {
+      const result = await runZts(["--target=es2017", `${fixture.dir}/input.ts`]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).not.toContain("for await");
+      expect(result.stdout).toContain("__asyncValues");
+      expect(result.stdout).toContain("await");
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+  test("labeled for-await-of downlevel to ES2017", async () => {
+    const fixture = await createFixture({
+      "input.ts": `
+async function collect(iter) {
+  const out = [];
+  outer: for await (const value of iter) {
+    if (value == null) continue outer;
+    out.push(value);
+  }
+  return out;
+}
+`,
+    });
+    try {
+      const result = await runZts(["--target=es2017", `${fixture.dir}/input.ts`]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).not.toContain("for await");
+      expect(result.stdout).toContain("__asyncValues");
+      expect(result.stdout).toContain("outer:");
+      expect(result.stdout).toContain("continue outer");
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+  test("for-await-of preserved at ES2018", async () => {
+    const fixture = await createFixture({
+      "input.ts": `
+async function collect(iter) {
+  for await (const value of iter) {
+    console.log(value);
+  }
+}
+`,
+    });
+    try {
+      const result = await runZts(["--target=es2018", `${fixture.dir}/input.ts`]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("for await");
+      expect(result.stdout).not.toContain("__asyncValues");
+    } finally {
+      await fixture.cleanup();
+    }
+  });
 });


### PR DESCRIPTION
## 요약
- ES2018 미만 타겟에서 `for await...of`가 그대로 출력되던 문제를 수정했습니다.
- 기존 ES5/Hermes용 `__asyncValues` lowering을 ES2017 타겟에도 적용하되, async/await 자체는 보존되도록 합성 대기 노드를 `await_expression`으로 생성합니다.
- TSC 통합 테스트에서 기존 skip을 실제 회귀 테스트로 전환하고, labeled loop 및 ES2018 보존 케이스를 추가했습니다.

## 검증
- `zig build`
- `bun test tests/integration/tests/tsc/es6-for-ofStatements.test.ts --filter "for-await-of"`
- `zig build test --summary all`
- pre-push: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`

Closes #2315