### PR TITLE
refactor(transformer): extract await/yield expression builders

### DIFF
--- a/src/transformer/es2017.zig
+++ b/src/transformer/es2017.zig
@@ -141,12 +141,7 @@ pub fn ES2017(comptime Transformer: type) type {
         /// `await expr` → `(yield expr)`
         pub fn lowerAwaitExpression(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
             const new_operand = try self.visitNode(node.data.unary.operand);
-            // yield_expression: data.unary = { operand, flags } (flags bit 0 = yield*)
-            const yield_node = try self.ast.addNode(.{
-                .tag = .yield_expression,
-                .span = node.span,
-                .data = .{ .unary = .{ .operand = new_operand, .flags = 0 } },
-            });
+            const yield_node = try es_helpers.makeYieldExpression(self, new_operand, node.span);
             return es_helpers.makeParenExpr(self, yield_node, node.span);
         }
 

--- a/src/transformer/es2018_for_await.zig
+++ b/src/transformer/es2018_for_await.zig
@@ -94,11 +94,7 @@ pub fn ES2018ForAwait(comptime Transformer: type) type {
             const iter_next_call = try es_helpers.makeCallExpr(self, iter_next, &.{}, span);
 
             // await _iter.next()
-            const await_next = try self.ast.addNode(.{
-                .tag = .await_expression,
-                .span = span,
-                .data = .{ .unary = .{ .operand = iter_next_call, .flags = 0 } },
-            });
+            const await_next = try es_helpers.makeAwaitExpression(self, iter_next_call, span);
 
             // _step = await _iter.next()
             const step_ref_assign = try es_helpers.makeIdentifierRefFromSpan(self, step_span);
@@ -261,11 +257,7 @@ pub fn ES2018ForAwait(comptime Transformer: type) type {
             const ret_call = try es_helpers.makeCallExpr(self, ret_call_method, &.{iter_ref_arg}, span);
 
             // await _ret.call(_iter)
-            const await_ret_call = try self.ast.addNode(.{
-                .tag = .await_expression,
-                .span = span,
-                .data = .{ .unary = .{ .operand = ret_call, .flags = 0 } },
-            });
+            const await_ret_call = try es_helpers.makeAwaitExpression(self, ret_call, span);
             const await_stmt = try es_helpers.makeExprStmt(self, await_ret_call, span);
 
             // if (_step && !_step.done && (_ret = _iter.return)) await _ret.call(_iter);

--- a/src/transformer/es2025_using.zig
+++ b/src/transformer/es2025_using.zig
@@ -346,13 +346,10 @@ pub fn ES2025Using(comptime Transformer: type) type {
             const call = try es_helpers.makeCallExpr(self, dispose_ref, &.{ stack_ref, error_ref, has_error_ref }, span);
 
             // await __callDispose(...) for await using
-            const expr = if (has_await) blk: {
-                break :blk try self.ast.addNode(.{
-                    .tag = .await_expression,
-                    .span = span,
-                    .data = .{ .unary = .{ .operand = call, .flags = 0 } },
-                });
-            } else call;
+            const expr = if (has_await)
+                try es_helpers.makeAwaitExpression(self, call, span)
+            else
+                call;
 
             const expr_stmt = try es_helpers.makeExprStmt(self, expr, span);
             const body_list = try self.ast.addNodeList(&.{expr_stmt});

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -824,6 +824,26 @@ pub fn makeUnaryNot(self: anytype, operand: NodeIndex, span: Span) !NodeIndex {
     });
 }
 
+/// `await <operand>` 표현식 노드 생성. flags 는 항상 0 — await 는 yield 와 달리 delegate 형태가
+/// 없음. yield* 같은 변형이 await 측에는 존재하지 않아 시그니처에서 flags 를 노출하지 않는다.
+pub fn makeAwaitExpression(self: anytype, operand: NodeIndex, span: Span) !NodeIndex {
+    return self.ast.addNode(.{
+        .tag = .await_expression,
+        .span = span,
+        .data = .{ .unary = .{ .operand = operand, .flags = 0 } },
+    });
+}
+
+/// `yield <operand>` 표현식 노드 생성 (delegate 아닌 일반 yield). flags bit 0 = yield* delegate
+/// 인데 현 호출자들 모두 flags=0 이라 인자에서 제외. delegate 가 필요해지면 별도 헬퍼 추가.
+pub fn makeYieldExpression(self: anytype, operand: NodeIndex, span: Span) !NodeIndex {
+    return self.ast.addNode(.{
+        .tag = .yield_expression,
+        .span = span,
+        .data = .{ .unary = .{ .operand = operand, .flags = 0 } },
+    });
+}
+
 /// for-of / for-await-of 의 left 를 loop body 에 prepend 할 statement 로 변환.
 ///
 /// - `variable_declaration` (const/let/var) → `var <binding> = elem;` (kind 는 항상 `.var` 로 강등)


### PR DESCRIPTION
## Summary

`await` / `yield` 식 노드 생성이 4개 transformer 사이트에 inline 으로 산재해 있었음. 모두 동일 layout (`.unary = { operand, flags = 0 }`) 이라 `es_helpers.zig` 에 두 헬퍼로 통합.

- `makeAwaitExpression(self, operand, span)` — await 는 delegate 형태가 없어 flags 노출 안 함
- `makeYieldExpression(self, operand, span)` — yield* delegate (flags bit 0) 가 필요해지면 별도 헬퍼

마이그레이션 사이트:
- `es2017.zig:144` — `lowerAwaitExpression` 의 `(yield expr)` 생성
- `es2018_for_await.zig:97` — for-await 다운레벨의 `await _iter.next()`
- `es2018_for_await.zig:260` — for-await cleanup `await _ret.call(_iter)`
- `es2025_using.zig:349` — `await __callDispose(...)` for `await using`

`es2017.zig:41` 의 `replaceNode` 사이트는 in-place 교체라 헬퍼화 제외 (`addNode` 와 시맨틱 다름).

부수 정리: `es2025_using.zig` 의 `if (has_await) blk: { break :blk ...; } else call` 블록을 단일식 헬퍼 호출로 바꿔 `blk:` 제거.

## Test plan

- [x] `zig build test` 통과
- [x] `bun test tests/integration/tests/tsc/es6-for-ofStatements.test.ts` 통과 (62/62)
- [x] for-await downlevel / await using / async-to-generator 회귀 없음

## 배경 (Zig 초보자용)

`anytype` 시그니처는 호출자 타입을 컴파일타임에 결정 (Zig 의 monomorphization). 헬퍼 본문이 단일 `addNode` 호출이라 인라이닝되어 inline 작성 시와 동일 머신코드 산출. zero-cost abstraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)