### PR TITLE
refactor(tests): add runFixture helper to dedupe fixture+runZts boilerplate

### DIFF
--- a/tests/integration/tests/helpers.ts
+++ b/tests/integration/tests/helpers.ts
@@ -157,6 +157,24 @@ export async function runZts(
   return runCmd([ZTS_BIN, ...args], options);
 }
 
+/// fixture 생성 → ZTS 실행 → 자동 cleanup 한 번에 묶는 헬퍼. caller 의 try/finally
+/// 보일러플레이트 제거. `entry` 는 `files` 의 key 중 하나여야 하며, 절대경로로
+/// 변환되어 args 의 마지막에 추가된다. 호출자는 result 의 stdout/stderr/exitCode 만
+/// 검증하면 됨 — cleanup 은 throw 경로에서도 보장.
+export async function runFixture(
+  files: Record<string, string>,
+  entry: string = "input.ts",
+  args: string[] = [],
+  options?: RunOptions,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const fixture = await createFixture(files);
+  try {
+    return await runZts([...args, join(fixture.dir, entry)], options);
+  } finally {
+    await fixture.cleanup();
+  }
+}
+
 /// Transpile-only (no `--bundle`) helper. ZTS 의 *transpile* path 단독 동작을
 /// 격리 검증할 때 사용. `bundleAndRun` 은 `--bundle` 을 강제하므로 inner-name
 /// elision 같은 별도 pass 와 섞여 transpile 단독 동작을 잡아내기 어렵다 (#2194,

--- a/tests/integration/tests/tsc/es6-for-ofStatements.test.ts
+++ b/tests/integration/tests/tsc/es6-for-ofStatements.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { expectPass, expectError } from "./helpers";
-import { createFixture, runZts } from "../helpers";
+import { runFixture } from "../helpers";
 
 describe("TSC: es6/for-ofStatements", () => {
   test("for-of-excess-declarations", async () => {
@@ -731,8 +731,9 @@ for (v of "hello") { }`,
     );
   });
   test("for-await-of downlevel to ES2017", async () => {
-    const fixture = await createFixture({
-      "input.ts": `
+    const result = await runFixture(
+      {
+        "input.ts": `
 async function collect(iter) {
   const out = [];
   for await (const value of iter) {
@@ -741,20 +742,19 @@ async function collect(iter) {
   return out;
 }
 `,
-    });
-    try {
-      const result = await runZts(["--target=es2017", `${fixture.dir}/input.ts`]);
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout).not.toContain("for await");
-      expect(result.stdout).toContain("__asyncValues");
-      expect(result.stdout).toContain("await");
-    } finally {
-      await fixture.cleanup();
-    }
+      },
+      "input.ts",
+      ["--target=es2017"],
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain("for await");
+    expect(result.stdout).toContain("__asyncValues");
+    expect(result.stdout).toContain("await");
   });
   test("labeled for-await-of downlevel to ES2017", async () => {
-    const fixture = await createFixture({
-      "input.ts": `
+    const result = await runFixture(
+      {
+        "input.ts": `
 async function collect(iter) {
   const out = [];
   outer: for await (const value of iter) {
@@ -764,35 +764,32 @@ async function collect(iter) {
   return out;
 }
 `,
-    });
-    try {
-      const result = await runZts(["--target=es2017", `${fixture.dir}/input.ts`]);
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout).not.toContain("for await");
-      expect(result.stdout).toContain("__asyncValues");
-      expect(result.stdout).toContain("outer:");
-      expect(result.stdout).toContain("continue outer");
-    } finally {
-      await fixture.cleanup();
-    }
+      },
+      "input.ts",
+      ["--target=es2017"],
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain("for await");
+    expect(result.stdout).toContain("__asyncValues");
+    expect(result.stdout).toContain("outer:");
+    expect(result.stdout).toContain("continue outer");
   });
   test("for-await-of preserved at ES2018", async () => {
-    const fixture = await createFixture({
-      "input.ts": `
+    const result = await runFixture(
+      {
+        "input.ts": `
 async function collect(iter) {
   for await (const value of iter) {
     console.log(value);
   }
 }
 `,
-    });
-    try {
-      const result = await runZts(["--target=es2018", `${fixture.dir}/input.ts`]);
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain("for await");
-      expect(result.stdout).not.toContain("__asyncValues");
-    } finally {
-      await fixture.cleanup();
-    }
+      },
+      "input.ts",
+      ["--target=es2018"],
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("for await");
+    expect(result.stdout).not.toContain("__asyncValues");
   });
 });


### PR DESCRIPTION
## Summary

\`createFixture\` + try/finally + \`runZts\` 패턴이 통합 테스트에 367 사이트로 반복. 자동 cleanup 이 보장되는 단일 헬퍼 \`runFixture\` 로 묶어 caller 의 보일러플레이트 제거.

\`\`\`ts
export async function runFixture(
  files: Record<string, string>,
  entry: string = \"input.ts\",
  args: string[] = [],
  options?: RunOptions,
): Promise<{ stdout: string; stderr: string; exitCode: number }>;
\`\`\`

내부적으로 try/finally 로 cleanup 보장 — throw 경로에서도 임시 디렉토리 누수 없음.

## Scope

본 PR 은 다음만 포함:
- \`tests/integration/tests/helpers.ts\` 에 \`runFixture\` 추가
- 직전 PR (#2323) 에서 추가된 for-await downlevel 3개 신규 테스트만 마이그레이션

다른 사이트 (~360+) 마이그레이션은 후속 PR 에서. PR 가치 입증은 신규 사이트 3개로 충분 — 일괄 마이그레이션은 conflict 위험 + 리뷰 부담.

## 디자인 결정

- **entry 디폴트 'input.ts'**: \`bundleAndRun\` 이 'index.ts' 디폴트를 갖는 패턴과 일관.
- **dir 미반환**: 호출자가 fixture 경로를 더 다룰 필요가 있으면 기존 \`createFixture\` 직접 사용 — 그 경우 자동 cleanup 의 이득이 없으니 헬퍼 대상 아님.
- **args 위치 (3번째)**: \`runZts(args, options)\` 와 위치 다름. 도메인이 달라 파라미터 우선순위가 다름 (fixture 정의가 가장 핵심) — 의도된 차이.

## Test plan

- [x] \`bun test tests/integration/tests/tsc/es6-for-ofStatements.test.ts\` 62/62 통과
- [x] cleanup 누락 시 임시 디렉토리 leak 없는지 확인 (try/finally 보장)
- [x] throw 경로에서도 cleanup 동작 (finally 가 error 를 swallow 하지 않음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)