### PR TITLE
feat(plugin): watch lifecycle hook 연결

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -4261,6 +4261,359 @@ describe("watch()", () => {
     rmSync(dir, { recursive: true });
   }, 10000);
 
+  test("plugin lifecycle hooks: 초기 build 와 rebuild 마다 buildStart → buildEnd → callback → closeBundle 순서", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-watch-lifecycle-"));
+    writeFileSync(join(dir, "entry.ts"), "export const x = 1;");
+
+    const events: string[] = [];
+    const { promise: initialCloseP, resolve: initialCloseDone } = Promise.withResolvers<void>();
+    const { promise: rebuildCloseP, resolve: rebuildCloseDone } = Promise.withResolvers<void>();
+    let closeCount = 0;
+    let handle: ReturnType<typeof watch> | undefined;
+
+    const plugin: ZtsPlugin = {
+      name: "watch-lifecycle",
+      setup(build) {
+        build.onBuildStart(() => {
+          events.push("buildStart");
+        });
+        build.onBuildEnd((err) => {
+          events.push(err ? `buildEnd:${err.message}` : "buildEnd");
+        });
+        build.onCloseBundle(() => {
+          events.push("closeBundle");
+          closeCount++;
+          if (closeCount === 1) initialCloseDone();
+          if (closeCount === 2) rebuildCloseDone();
+        });
+      },
+    };
+
+    try {
+      handle = watch({
+        entryPoints: [join(dir, "entry.ts")],
+        plugins: [plugin],
+        onReady() {
+          events.push("onReady");
+        },
+        onRebuild(event) {
+          events.push(`onRebuild:${event.success ? "ok" : "err"}`);
+        },
+      });
+
+      await initialCloseP;
+      expect(events).toEqual(["buildStart", "buildEnd", "onReady", "closeBundle"]);
+
+      await new Promise((r) => setTimeout(r, 100));
+      writeFileSync(join(dir, "entry.ts"), "export const x = 2;");
+
+      await rebuildCloseP;
+      expect(events).toEqual([
+        "buildStart",
+        "buildEnd",
+        "onReady",
+        "closeBundle",
+        "buildStart",
+        "buildEnd",
+        "onRebuild:ok",
+        "closeBundle",
+      ]);
+      expect(events.filter((event) => event === "buildStart").length).toBe(2);
+      expect(events.filter((event) => event === "buildEnd").length).toBe(2);
+      expect(events.filter((event) => event === "closeBundle").length).toBe(2);
+    } finally {
+      handle?.stop();
+      rmSync(dir, { recursive: true });
+    }
+  }, 10000);
+
+  test("vitePlugin watch lifecycle: Rollup buildStart / buildEnd / closeBundle 을 초기 build 와 rebuild 에서 호출", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-watch-vite-lifecycle-"));
+    writeFileSync(join(dir, "entry.ts"), "export const x = 1;");
+
+    const events: string[] = [];
+    const { promise: initialCloseP, resolve: initialCloseDone } = Promise.withResolvers<void>();
+    const { promise: rebuildCloseP, resolve: rebuildCloseDone } = Promise.withResolvers<void>();
+    let closeCount = 0;
+    let handle: ReturnType<typeof watch> | undefined;
+
+    const rollupPlugin: RollupPlugin = {
+      name: "rollup-watch-lifecycle",
+      buildStart() {
+        events.push("rollup-buildStart");
+      },
+      buildEnd(err) {
+        events.push(err ? `rollup-buildEnd:${err.message}` : "rollup-buildEnd");
+      },
+      closeBundle() {
+        events.push("rollup-closeBundle");
+        closeCount++;
+        if (closeCount === 1) initialCloseDone();
+        if (closeCount === 2) rebuildCloseDone();
+      },
+    };
+
+    try {
+      handle = watch({
+        entryPoints: [join(dir, "entry.ts")],
+        plugins: [vitePlugin(rollupPlugin)],
+        onReady() {
+          events.push("onReady");
+        },
+        onRebuild(event) {
+          events.push(`onRebuild:${event.success ? "ok" : "err"}`);
+        },
+      });
+
+      await initialCloseP;
+      expect(events).toEqual([
+        "rollup-buildStart",
+        "rollup-buildEnd",
+        "onReady",
+        "rollup-closeBundle",
+      ]);
+
+      await new Promise((r) => setTimeout(r, 100));
+      writeFileSync(join(dir, "entry.ts"), "export const x = 2;");
+
+      await rebuildCloseP;
+      expect(events).toEqual([
+        "rollup-buildStart",
+        "rollup-buildEnd",
+        "onReady",
+        "rollup-closeBundle",
+        "rollup-buildStart",
+        "rollup-buildEnd",
+        "onRebuild:ok",
+        "rollup-closeBundle",
+      ]);
+      expect(events.filter((event) => event === "rollup-buildStart").length).toBe(2);
+      expect(events.filter((event) => event === "rollup-buildEnd").length).toBe(2);
+      expect(events.filter((event) => event === "rollup-closeBundle").length).toBe(2);
+    } finally {
+      handle?.stop();
+      rmSync(dir, { recursive: true });
+    }
+  }, 10000);
+
+  test("plugin lifecycle hooks: watch 사용자 콜백 실패 후에도 closeBundle 호출", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-watch-lifecycle-error-"));
+    writeFileSync(join(dir, "entry.ts"), "export const x = 1;");
+
+    const events: string[] = [];
+    const { promise: initialCloseP, resolve: initialCloseDone } = Promise.withResolvers<void>();
+    const { promise: rebuildCloseP, resolve: rebuildCloseDone } = Promise.withResolvers<void>();
+    let closeCount = 0;
+    let handle: ReturnType<typeof watch> | undefined;
+
+    const plugin: ZtsPlugin = {
+      name: "watch-lifecycle-error",
+      setup(build) {
+        build.onCloseBundle(() => {
+          events.push("closeBundle");
+          closeCount++;
+          if (closeCount === 1) initialCloseDone();
+          if (closeCount === 2) rebuildCloseDone();
+        });
+      },
+    };
+
+    try {
+      handle = watch({
+        entryPoints: [join(dir, "entry.ts")],
+        plugins: [plugin],
+        onReady() {
+          events.push("onReady");
+          throw new Error("ready failed");
+        },
+        async onRebuild() {
+          events.push("onRebuild");
+          throw new Error("rebuild failed");
+        },
+      });
+
+      await initialCloseP;
+      expect(events).toEqual(["onReady", "closeBundle"]);
+
+      await new Promise((r) => setTimeout(r, 100));
+      writeFileSync(join(dir, "entry.ts"), "export const x = 2;");
+
+      await rebuildCloseP;
+      expect(events).toEqual(["onReady", "closeBundle", "onRebuild", "closeBundle"]);
+    } finally {
+      handle?.stop();
+      rmSync(dir, { recursive: true });
+    }
+  }, 10000);
+
+  test("plugin lifecycle hooks: watch 사용자 콜백이 없어도 closeBundle 호출", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-watch-lifecycle-no-callback-"));
+    writeFileSync(join(dir, "entry.ts"), "export const x = 1;");
+
+    const events: string[] = [];
+    const { promise: initialCloseP, resolve: initialCloseDone } = Promise.withResolvers<void>();
+    const { promise: rebuildCloseP, resolve: rebuildCloseDone } = Promise.withResolvers<void>();
+    let closeCount = 0;
+    let handle: ReturnType<typeof watch> | undefined;
+
+    const plugin: ZtsPlugin = {
+      name: "watch-lifecycle-no-callback",
+      setup(build) {
+        build.onBuildStart(() => events.push("buildStart"));
+        build.onBuildEnd(() => events.push("buildEnd"));
+        build.onCloseBundle(() => {
+          events.push("closeBundle");
+          closeCount++;
+          if (closeCount === 1) initialCloseDone();
+          if (closeCount === 2) rebuildCloseDone();
+        });
+      },
+    };
+
+    try {
+      handle = watch({
+        entryPoints: [join(dir, "entry.ts")],
+        plugins: [plugin],
+      });
+
+      await initialCloseP;
+      expect(events).toEqual(["buildStart", "buildEnd", "closeBundle"]);
+
+      await new Promise((r) => setTimeout(r, 100));
+      writeFileSync(join(dir, "entry.ts"), "export const x = 2;");
+
+      await rebuildCloseP;
+      expect(events).toEqual([
+        "buildStart",
+        "buildEnd",
+        "closeBundle",
+        "buildStart",
+        "buildEnd",
+        "closeBundle",
+      ]);
+    } finally {
+      handle?.stop();
+      rmSync(dir, { recursive: true });
+    }
+  }, 10000);
+
+  test("plugin lifecycle hooks: watch rebuild diagnostic 은 buildEnd error 후 closeBundle 호출", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-watch-lifecycle-diagnostic-"));
+    writeFileSync(join(dir, "entry.ts"), "export const x = 1;");
+
+    const events: string[] = [];
+    const { promise: initialCloseP, resolve: initialCloseDone } = Promise.withResolvers<void>();
+    const { promise: rebuildCloseP, resolve: rebuildCloseDone } = Promise.withResolvers<void>();
+    let closeCount = 0;
+    let handle: ReturnType<typeof watch> | undefined;
+
+    const plugin: ZtsPlugin = {
+      name: "watch-lifecycle-diagnostic",
+      setup(build) {
+        build.onBuildStart(() => events.push("buildStart"));
+        build.onBuildEnd((err) => {
+          events.push(err ? "buildEnd:error" : "buildEnd");
+        });
+        build.onCloseBundle(() => {
+          events.push("closeBundle");
+          closeCount++;
+          if (closeCount === 1) initialCloseDone();
+          if (closeCount === 2) rebuildCloseDone();
+        });
+      },
+    };
+
+    try {
+      handle = watch({
+        entryPoints: [join(dir, "entry.ts")],
+        plugins: [plugin],
+        onReady() {
+          events.push("onReady");
+        },
+        onRebuild(event) {
+          events.push(`onRebuild:${event.success ? "ok" : "err"}`);
+        },
+      });
+
+      await initialCloseP;
+      expect(events).toEqual(["buildStart", "buildEnd", "onReady", "closeBundle"]);
+
+      await new Promise((r) => setTimeout(r, 100));
+      writeFileSync(join(dir, "entry.ts"), "import value from './missing';\nconsole.log(value);");
+
+      await rebuildCloseP;
+      expect(events).toEqual([
+        "buildStart",
+        "buildEnd",
+        "onReady",
+        "closeBundle",
+        "buildStart",
+        "buildEnd:error",
+        "onRebuild:ok",
+        "closeBundle",
+      ]);
+    } finally {
+      handle?.stop();
+      rmSync(dir, { recursive: true });
+    }
+  }, 10000);
+
+  test("plugin lifecycle hooks: watch closeBundle throw 는 다른 plugin 과 watch 를 막지 않음", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-watch-lifecycle-close-throw-"));
+    writeFileSync(join(dir, "entry.ts"), "export const x = 1;");
+
+    const events: string[] = [];
+    const { promise: initialCloseP, resolve: initialCloseDone } = Promise.withResolvers<void>();
+    const { promise: rebuildCloseP, resolve: rebuildCloseDone } = Promise.withResolvers<void>();
+    let trackingCloseCount = 0;
+    let handle: ReturnType<typeof watch> | undefined;
+
+    const throwingPlugin: ZtsPlugin = {
+      name: "watch-close-thrower",
+      setup(build) {
+        build.onCloseBundle(() => {
+          events.push("throwing-close");
+          throw new Error("close failed");
+        });
+      },
+    };
+    const trackingPlugin: ZtsPlugin = {
+      name: "watch-close-tracker",
+      setup(build) {
+        build.onCloseBundle(() => {
+          events.push("tracking-close");
+          trackingCloseCount++;
+          if (trackingCloseCount === 1) initialCloseDone();
+          if (trackingCloseCount === 2) rebuildCloseDone();
+        });
+      },
+    };
+
+    try {
+      handle = watch({
+        entryPoints: [join(dir, "entry.ts")],
+        plugins: [throwingPlugin, trackingPlugin],
+      });
+
+      await initialCloseP;
+      expect(events).toEqual(["throwing-close", "tracking-close"]);
+
+      await new Promise((r) => setTimeout(r, 100));
+      writeFileSync(join(dir, "entry.ts"), "export const x = 2;");
+
+      await rebuildCloseP;
+      expect(events).toEqual([
+        "throwing-close",
+        "tracking-close",
+        "throwing-close",
+        "tracking-close",
+      ]);
+    } finally {
+      handle?.stop();
+      rmSync(dir, { recursive: true });
+    }
+  }, 10000);
+
   test("devMode에서 moduleCodes diff → updates 전달", async () => {
     const dir = mkdtempSync(join(tmpdir(), "zts-watch-"));
     writeFileSync(join(dir, "entry.ts"), "export const x = 1;");

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1240,9 +1240,8 @@ function arrayAliasToPlugin(
   };
 }
 
-// Array 형태 alias (#2153) 가 있으면 onResolve plugin 으로 변환해 user plugins 앞에
-// prepend — 다른 plugin 보다 먼저 매칭돼 alias 치환 우선 적용 (Vite 동작). plugin 이
-// 하나도 없으면 null. build() 와 watch() 가 동일한 머지 규칙을 공유.
+// Array 형태 alias (#2153) 는 onResolve plugin 으로 변환해 user plugins 앞에 prepend —
+// 다른 plugin 보다 먼저 매칭돼 alias 치환이 우선 적용된다 (Vite 동작).
 function resolveDispatcher(options: BuildOptions) {
   const arrayAlias = Array.isArray(options.alias) ? options.alias : null;
   const userPlugins = options.plugins ?? [];
@@ -1841,15 +1840,12 @@ export function watch(options: BuildOptions): WatchHandle {
   if (dispatcher) {
     nativeOpts._pluginDispatcher = dispatcher;
 
-    // closeBundle 은 native callback 안에서 fire-and-forget — 호출자가 await 받지 못하므로
-    // rejection 은 swallow (unhandledRejection 노이즈 방지). build() 가 await 하는 것과는
-    // 구조적으로 다른 환경.
+    // native 측은 onReady/onRebuild 결과 promise 를 await 하지 않으므로 모든 rejection 을
+    // swallow — 그렇지 않으면 user callback throw 와 closeBundle dispatch 실패가
+    // unhandledRejection 으로 샌다. build() 는 await 가능해 이 래핑이 필요 없다.
     const dispatchCloseBundle = () => {
       void dispatcher("closeBundle", undefined, null).catch(() => {});
     };
-
-    // user callback throw / rejection 은 swallow — 호출자가 await 못 받으므로
-    // unhandledRejection 으로 새지 않게 `.catch` 로 닫는다. closeBundle 은 항상 1회.
     const wrapWatchCallback =
       <T>(callback?: (event: T) => void | Promise<void>) =>
       (event: T) => {

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -649,9 +649,9 @@ interface BuildOptionsCommon {
   /** watchFolders 스캔 시 제외할 파일 glob (루트 기준 상대 경로). */
   watchExclude?: string[];
   /** watch 모드 빌드 완료 콜백 */
-  onReady?: (event: WatchReadyEvent) => void;
+  onReady?: (event: WatchReadyEvent) => void | Promise<void>;
   /** watch 모드 리빌드 콜백 */
-  onRebuild?: (event: WatchRebuildEvent) => void;
+  onRebuild?: (event: WatchRebuildEvent) => void | Promise<void>;
   /**
    * `.map` 파일을 디스크에 기록할지 여부 (Issue #1727 Phase B).
    *
@@ -1240,6 +1240,16 @@ function arrayAliasToPlugin(
   };
 }
 
+// Array 형태 alias (#2153) 가 있으면 onResolve plugin 으로 변환해 user plugins 앞에
+// prepend — 다른 plugin 보다 먼저 매칭돼 alias 치환 우선 적용 (Vite 동작). plugin 이
+// 하나도 없으면 null. build() 와 watch() 가 동일한 머지 규칙을 공유.
+function resolveDispatcher(options: BuildOptions) {
+  const arrayAlias = Array.isArray(options.alias) ? options.alias : null;
+  const userPlugins = options.plugins ?? [];
+  const allPlugins = arrayAlias ? [arrayAliasToPlugin(arrayAlias), ...userPlugins] : userPlugins;
+  return allPlugins.length ? createPluginDispatcher(allPlugins) : null;
+}
+
 function isBrowserLikeBuildPlatform(platform: BuildOptions["platform"] | undefined): boolean {
   return platform === undefined || platform === "browser" || platform === "react-native";
 }
@@ -1476,13 +1486,7 @@ export async function build(options: BuildOptions): Promise<BuildResult> {
   if (!options.entryPoints?.length) throw new Error("@zts/core: entryPoints is required");
 
   const napiOptions = prepareNapiOptions(options);
-
-  // Array 형태 alias (#2153) — onResolve plugin 으로 변환해 user plugins 앞에 prepend.
-  // 다른 plugin 의 onResolve 보다 먼저 매칭되어 alias 치환이 우선 적용 (Vite 동작).
-  const arrayAlias = Array.isArray(options.alias) ? options.alias : null;
-  const userPlugins = options.plugins ?? [];
-  const allPlugins = arrayAlias ? [arrayAliasToPlugin(arrayAlias), ...userPlugins] : userPlugins;
-  const dispatcher = allPlugins.length ? createPluginDispatcher(allPlugins) : null;
+  const dispatcher = resolveDispatcher(options);
   if (dispatcher) napiOptions._pluginDispatcher = dispatcher;
 
   // lifecycle hook (#2156): buildStart / buildEnd 는 native bundler 가 dispatch (single source).
@@ -1832,9 +1836,31 @@ export function watch(options: BuildOptions): WatchHandle {
   if (!native) throw new Error("call init() first");
 
   const nativeOpts = prepareNapiOptions(options);
+  const dispatcher = resolveDispatcher(options);
 
-  if (options.plugins && options.plugins.length > 0) {
-    nativeOpts._pluginDispatcher = createPluginDispatcher(options.plugins);
+  if (dispatcher) {
+    nativeOpts._pluginDispatcher = dispatcher;
+
+    // closeBundle 은 native callback 안에서 fire-and-forget — 호출자가 await 받지 못하므로
+    // rejection 은 swallow (unhandledRejection 노이즈 방지). build() 가 await 하는 것과는
+    // 구조적으로 다른 환경.
+    const dispatchCloseBundle = () => {
+      void dispatcher("closeBundle", undefined, null).catch(() => {});
+    };
+
+    // user callback throw / rejection 은 swallow — 호출자가 await 못 받으므로
+    // unhandledRejection 으로 새지 않게 `.catch` 로 닫는다. closeBundle 은 항상 1회.
+    const wrapWatchCallback =
+      <T>(callback?: (event: T) => void | Promise<void>) =>
+      (event: T) => {
+        void Promise.resolve()
+          .then(() => callback?.(event))
+          .finally(dispatchCloseBundle)
+          .catch(() => {});
+      };
+
+    nativeOpts.onReady = wrapWatchCallback(options.onReady);
+    nativeOpts.onRebuild = wrapWatchCallback(options.onRebuild);
   }
 
   return native.watch(nativeOpts);


### PR DESCRIPTION
## 요약
- `watch()` 경로도 `build()`와 동일한 plugin dispatcher 생성 규칙을 사용하도록 `resolveDispatcher()`로 통합
- watch 초기 build / rebuild 후 `onReady` / `onRebuild` 사용자 콜백이 끝난 뒤 `closeBundle`을 1회 dispatch
- watch 경로에서도 array alias(#2153)를 user plugin 앞의 onResolve plugin으로 prepend
- `onReady` / `onRebuild` 타입을 async callback까지 허용하도록 확장

## 동작 순서
```
buildStart → (NAPI build/rebuild) → buildEnd → onReady/onRebuild → closeBundle
```

`buildStart` / `buildEnd`는 기존 native lifecycle dispatch를 그대로 사용하고, `closeBundle`만 JS watch callback wrapper에서 write 완료 이후 의미로 보강합니다. 사용자 callback throw/rejection이 있어도 `closeBundle`은 실행하고 unhandled rejection으로 새지 않게 swallow합니다.

## 회귀 테스트
- raw `watch()` plugin lifecycle: 초기 build와 rebuild 각각 순서 및 1회 호출 검증
- `vitePlugin()` adapter lifecycle: Rollup `buildStart` / `buildEnd` / `closeBundle`이 watch에서도 forward되는지 검증
- `onReady` / `onRebuild` 실패 후에도 `closeBundle`이 호출되는지 검증
- `onReady` / `onRebuild` 미등록 상태에서도 `closeBundle`이 호출되는지 검증
- rebuild diagnostic 경로에서 `buildEnd(error)` 이후 `onRebuild`와 `closeBundle` 순서 검증
- `closeBundle` hook이 throw해도 다음 plugin과 watch rebuild가 막히지 않는지 검증

## /simplify 자체 점검
- build/watch의 array alias + plugin dispatcher merge 규칙을 helper로 공유해 drift를 줄였습니다.
- `buildStart` / `buildEnd`는 native 단일 dispatch를 유지해 이중 호출을 피했습니다.
- watch callback은 호출자가 await할 수 없는 구조라 fire-and-forget + catch로 closeBundle 보장과 unhandled rejection 방지를 우선했습니다.

## 검증
- `bun test packages/core/index.test.ts -t "plugin lifecycle hooks: watch"` → 4 pass
- `bun test packages/core/index.test.ts` → 368 pass
- `bun run fmt:check` → pass
- `git push` pre-push hook → `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check` pass
- `bun run lint` / pre-push `oxlint` → 0 errors, 기존 `tests/integration/tests/bundle-dynamic-import.test.ts` unused import warning 3개

Closes #2160
Refs #2151, #2156