### PR TITLE
feat(cli): support --packages=external

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -30,6 +30,7 @@ CLI > config > tsconfig > defaults. 같은 옵션이 여러 곳에 정의되면 
 | `jsx` | `--jsx=automatic` | ✅ | `jsx` | preserve/transform/automatic |
 | `jsxFactory` / `jsxFragment` | flag | ✅ | `jsxFactory` 등 | tsconfig fallback |
 | `external` | `--external:lib` | ✅ | ❌ | 배열 — CLI 비어있으면 config |
+| `packagesExternal` | `--packages=external` | ✅ | ❌ | bare package import 전체 external, relative/absolute는 번들 |
 | `alias` | `--alias:K=V` | ✅ | tsconfig `paths` | 객체 머지: 키 단위 CLI override |
 | `define` | `--define:K=V` | ✅ | ❌ | 객체 머지: 키 단위 CLI override |
 | `loader` | `--loader:.ext=type` | ✅ | ❌ | 객체 머지 |
@@ -154,6 +155,8 @@ zts --bundle entry.ts
 zts --bundle entry.ts                              # → ["node:fs", "node:path"] (config)
 zts --bundle --external=react entry.ts             # → ["react"] (CLI 가 비어있지 않으면 CLI 만 사용 — concat 안 함)
 ```
+
+`packagesExternal`은 esbuild 호환 `--packages=external`과 동일하게 모든 bare package import를 external 처리한다. `./local`, `../local`, `/abs/local` 같은 relative/absolute import는 계속 번들 대상이다.
 
 ### 5. `tsconfig` + `zts.config` + CLI 3-way (jsx)
 ```json

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -258,8 +258,9 @@ esbuild / rolldown / rspack 기준으로 ZTS에 빠진 기능 목록.
 배치 E 부분 완료 ────────────────────────────────────────────────
   완료: --outbase, --log-limit, inlineDynamicImports, cleanDir,
   --watch-delay, --serve <dir>, shimMissingExports, extensionAlias,
+  --packages=external,
   sanitizeFileName
-  미완료/미노출: --packages=external, --drop-labels, --pure:fn,
+  미완료/미노출: --drop-labels, --pure:fn,
   --line-limit, --allow-overwrite, --tsconfig-raw, --node-paths,
   output.intro/outro, output.globals, --jsx-side-effects,
   --ignore-annotations

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -111,6 +111,7 @@ esbuild 스타일: `onResolve`, `onLoad`, `onTransform`, `onRenderChunk`, `onGen
 - `--platform=browser` + `--bundle` → IIFE 출력 + `NODE_ENV=production` 자동 define + Node 빌트인 빈 모듈 대체
 - `--platform=node` → Node 빌트인(`node:fs`, `fs`, 서브패스 포함) 자동 external
 - `--platform=react-native` → RN 프리셋: `.ios.*` / `.android.*` / `.native.*` 확장자, `react-native` main-field / exports 조건, `--flow` 자동 활성화
+- `--packages=external` → 모든 bare package import를 external 처리. relative/absolute import는 기존처럼 번들
 
 ### Watch / Serve
 - `--watch` / `--serve` — 증분 빌드 (PersistentModuleStore + ResolveCache 보존, 변경 모듈만 재파싱)

--- a/packages/core/bin/cli-flags.mjs
+++ b/packages/core/bin/cli-flags.mjs
@@ -161,6 +161,12 @@ export const FLAG_REGISTRY = [
   { kind: "ns-string", flag: "--out-extension:.js", target: "outExtensionJs" },
 
   // ─── kind=enum-bool — `--key=enumValue` → opts[target] = spec.enum[enumValue] ───
+  {
+    kind: "enum-bool",
+    flag: "--packages",
+    target: "packagesExternal",
+    enum: { external: true },
+  },
   { kind: "enum-bool", flag: "--charset", target: "charsetUtf8", enum: { utf8: true } },
 
   // ─── kind=string-bool — default=true 의 toggle. `--key=false` → false, 그 외 → true ───

--- a/packages/core/bin/zts-cli-schema-sync.test.ts
+++ b/packages/core/bin/zts-cli-schema-sync.test.ts
@@ -323,6 +323,9 @@ describe("CLI flag ↔ BuildOptions / TranspileOptions schema sync", () => {
     // charset — CLI 는 `--charset=utf8/ascii` 식 enum, BuildOptions/TranspileOptions 는
     // `charsetUtf8: boolean` (1:N 매핑). zts.mjs 에서 enum→boolean 변환.
     "--charset=",
+    // packages — CLI 는 esbuild 호환 `--packages=external` enum 형태, BuildOptions 는
+    // `packagesExternal: boolean`.
+    "--packages=",
     // banner/footer — `--banner=`/`--footer=` 가 정식 (BuildOptions 와 1:1).
     // `--banner:js=`/`--footer:js=` 는 esbuild 호환 silent alias — 동일 키로 매핑.
     "--banner:js=",
@@ -356,7 +359,6 @@ describe("CLI flag ↔ BuildOptions / TranspileOptions schema sync", () => {
     "lineLimit",
     "outExtension", // namespace 객체 — `--out-extension:.js=` 가 일부 cover
     "outbase",
-    "packagesExternal",
     "pure",
     "stopAfter", // transpile 단독 — CLI 미노출 (디버그 옵션)
     "treeShaking",

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -140,6 +140,7 @@ function usageLines(command) {
     "",
     "Options:",
     "  --bundle                   Bundle dependencies",
+    "  --packages=external        Treat all bare package imports as external",
     "  --outdir <dir>             Output directory",
     "  --outfile <file>, -o <file> Output file",
     "  --watch, -w                Rebuild on changes",
@@ -199,6 +200,7 @@ function parseArgs(argv) {
     analyze: false,
     treeShaking: true,
     external: [],
+    packagesExternal: false,
     define: {},
     alias: {},
     banner: undefined,
@@ -1802,6 +1804,7 @@ function mergeConfigIntoOpts(opts, config) {
     "jsxDev",
     "preserveModules",
     "verbatimModuleSyntax",
+    "packagesExternal",
   ];
   for (const key of BOOL_KEYS) {
     if (opts[key] === false && config[key] === true) {
@@ -1866,6 +1869,7 @@ async function runBundle(opts, config) {
     target: opts.target,
     browserslist: opts.browserslist,
     external: opts.external,
+    packagesExternal: opts.packagesExternal,
     // `--alias:K=V` 플래그 (webpack/rollup 스타일) — JS 옵션이 tsconfig paths 보다 우선 적용됨.
     alias: Object.keys(opts.alias).length > 0 ? opts.alias : undefined,
     define: Object.keys(opts.define).length > 0 ? opts.define : undefined,

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -331,23 +331,26 @@ describe("CLI: bundle", () => {
 
   test("번들 + --packages=external 은 bare package만 external 처리", () => {
     const extDir = mkdtempSync(join(tmpdir(), "zts-cli-packages-ext-"));
-    writeFileSync(
-      join(extDir, "app.ts"),
-      'import React from "react";\nimport { local } from "./local";\nconsole.log(React, local);',
-    );
-    writeFileSync(join(extDir, "local.ts"), "export const local = 'LOCAL_INCLUDED';");
-    const { stdout, stderr, exitCode } = runCli([
-      "--bundle",
-      join(extDir, "app.ts"),
-      "--packages=external",
-      "--format=esm",
-    ]);
-    expect(exitCode).toBe(0);
-    expect(stderr).not.toContain("unknown option");
-    expect(stdout).toContain('"react"');
-    expect(stdout).toContain("LOCAL_INCLUDED");
-    expect(stdout).not.toContain('from "./local"');
-    rmSync(extDir, { recursive: true, force: true });
+    try {
+      writeFileSync(
+        join(extDir, "app.ts"),
+        'import React from "react";\nimport { local } from "./local";\nconsole.log(React, local);',
+      );
+      writeFileSync(join(extDir, "local.ts"), "export const local = 'LOCAL_INCLUDED';");
+      const { stdout, stderr, exitCode } = runCli([
+        "--bundle",
+        join(extDir, "app.ts"),
+        "--packages=external",
+        "--format=esm",
+      ]);
+      expect(exitCode).toBe(0);
+      expect(stderr).not.toContain("unknown option");
+      expect(stdout).toContain('"react"');
+      expect(stdout).toContain("LOCAL_INCLUDED");
+      expect(stdout).not.toContain('from "./local"');
+    } finally {
+      rmSync(extDir, { recursive: true, force: true });
+    }
   });
 
   test("번들 + --banner:js + --footer:js (esbuild 호환 alias)", () => {
@@ -1973,22 +1976,25 @@ describe("CLI: zts.config 자동 탐색 + BuildOptions 머지", () => {
 
   test("zts.config.json 의 packagesExternal 이 적용됨", () => {
     const dir = mkdtempSync(join(tmpdir(), "zts-config-packages-external-"));
-    writeFileSync(
-      join(dir, "entry.ts"),
-      'import React from "react";\nimport { local } from "./local";\nconsole.log(React, local);',
-    );
-    writeFileSync(join(dir, "local.ts"), "export const local = 'CONFIG_LOCAL_INCLUDED';");
-    writeFileSync(
-      join(dir, "zts.config.json"),
-      JSON.stringify({ entryPoints: ["./entry.ts"], packagesExternal: true, format: "esm" }),
-    );
-    const { stdout, stderr, exitCode } = runCli(["--bundle"], { cwd: dir });
-    expect(exitCode).toBe(0);
-    expect(stderr).not.toContain("error");
-    expect(stdout).toContain('"react"');
-    expect(stdout).toContain("CONFIG_LOCAL_INCLUDED");
-    expect(stdout).not.toContain('from "./local"');
-    rmSync(dir, { recursive: true, force: true });
+    try {
+      writeFileSync(
+        join(dir, "entry.ts"),
+        'import React from "react";\nimport { local } from "./local";\nconsole.log(React, local);',
+      );
+      writeFileSync(join(dir, "local.ts"), "export const local = 'CONFIG_LOCAL_INCLUDED';");
+      writeFileSync(
+        join(dir, "zts.config.json"),
+        JSON.stringify({ entryPoints: ["./entry.ts"], packagesExternal: true, format: "esm" }),
+      );
+      const { stdout, stderr, exitCode } = runCli(["--bundle"], { cwd: dir });
+      expect(exitCode).toBe(0);
+      expect(stderr).not.toContain("error");
+      expect(stdout).toContain('"react"');
+      expect(stdout).toContain("CONFIG_LOCAL_INCLUDED");
+      expect(stdout).not.toContain('from "./local"');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test("zts.config.ts 의 plugins 가 적용됨", () => {

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -329,6 +329,27 @@ describe("CLI: bundle", () => {
     rmSync(extDir, { recursive: true, force: true });
   });
 
+  test("번들 + --packages=external 은 bare package만 external 처리", () => {
+    const extDir = mkdtempSync(join(tmpdir(), "zts-cli-packages-ext-"));
+    writeFileSync(
+      join(extDir, "app.ts"),
+      'import React from "react";\nimport { local } from "./local";\nconsole.log(React, local);',
+    );
+    writeFileSync(join(extDir, "local.ts"), "export const local = 'LOCAL_INCLUDED';");
+    const { stdout, stderr, exitCode } = runCli([
+      "--bundle",
+      join(extDir, "app.ts"),
+      "--packages=external",
+      "--format=esm",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toContain("unknown option");
+    expect(stdout).toContain('"react"');
+    expect(stdout).toContain("LOCAL_INCLUDED");
+    expect(stdout).not.toContain('from "./local"');
+    rmSync(extDir, { recursive: true, force: true });
+  });
+
   test("번들 + --banner:js + --footer:js (esbuild 호환 alias)", () => {
     const { stdout, exitCode } = runCli([
       "--bundle",
@@ -1947,6 +1968,26 @@ describe("CLI: zts.config 자동 탐색 + BuildOptions 머지", () => {
     // external 이면 require/import 가 그대로 보존됨.
     expect(stdout).toMatch(/node:fs|require.*fs/);
     expect(stderr).not.toContain("error");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("zts.config.json 의 packagesExternal 이 적용됨", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-config-packages-external-"));
+    writeFileSync(
+      join(dir, "entry.ts"),
+      'import React from "react";\nimport { local } from "./local";\nconsole.log(React, local);',
+    );
+    writeFileSync(join(dir, "local.ts"), "export const local = 'CONFIG_LOCAL_INCLUDED';");
+    writeFileSync(
+      join(dir, "zts.config.json"),
+      JSON.stringify({ entryPoints: ["./entry.ts"], packagesExternal: true, format: "esm" }),
+    );
+    const { stdout, stderr, exitCode } = runCli(["--bundle"], { cwd: dir });
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toContain("error");
+    expect(stdout).toContain('"react"');
+    expect(stdout).toContain("CONFIG_LOCAL_INCLUDED");
+    expect(stdout).not.toContain('from "./local"');
     rmSync(dir, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
## 요약
- JS CLI flag registry에 esbuild 호환 `--packages=external`을 추가했습니다.
- `packagesExternal`을 CLI 기본값, config merge, NAPI build 옵션 전달 경로에 연결했습니다.
- bare package import만 external 처리하고 relative import는 계속 번들되는 회귀 테스트를 JS CLI/config 경로에 추가했습니다.
- CLI/config 문서와 roadmap의 미노출 표기를 갱신했습니다.

## 검증
- `bun run --cwd packages/core build:js`
- `node packages/core/bin/zts.mjs --bundle tests/integration/tests/fixtures/round1/11-optional-chain.ts --packages=external --format=esm`
- `bun test packages/core/bin/zts.test.ts`
- `bun test packages/core/bin/zts-cli-schema-sync.test.ts`
- `bun test packages/core/bin/zts-cli-schema-sync.test.ts tests/integration/tests/batch-e-cli.test.ts --test-name-pattern "packages=external|schema"`
- `bunx oxlint packages/core/bin/cli-flags.mjs packages/core/bin/zts.mjs packages/core/bin/zts-cli-schema-sync.test.ts packages/core/bin/zts.test.ts`
- `git diff --check`
- `git push` pre-push: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check` 통과

## 참고
- pre-push `oxlint`에서 기존 `tests/integration/tests/bundle-dynamic-import.test.ts` 미사용 import 경고 3개가 출력됐지만 에러는 아니며 이번 변경 범위 밖입니다.

Fixes #2329