### PR TITLE
feat(tsconfig): merge raw + jsx in Zig (esbuild-style single source of truth)

### DIFF
--- a/packages/core/bin/zts-cli-schema-sync.test.ts
+++ b/packages/core/bin/zts-cli-schema-sync.test.ts
@@ -312,9 +312,6 @@ describe("CLI flag ↔ BuildOptions / TranspileOptions schema sync", () => {
     // tsconfig — CLI 용 alias (`--project`, `--tsconfig-path` 둘 다 BuildOptions 의 `tsconfigPath` 와 매핑)
     "--project",
     "--project=",
-    // tsconfig raw — CLI 입력 어댑터. `loadTsConfig` 가 풀어 jsx/target/decorators 등 다른
-    // 옵션으로 변환해 NAPI 로 보냄. BuildOptions 표면에는 없음 (Zig 측 jsx tsconfig 통합 후 노출 검토).
-    "--tsconfig-raw=",
     // RN — CLI 만 노출
     "--rn-platform",
     "--rn-platform=",

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -364,127 +364,42 @@ function parseArgs(argv) {
   return opts;
 }
 
-// ─── tsconfig.json 로드 ───
-
-function stripJsonComments(raw) {
-  return raw.replace(/"(?:[^"\\]|\\.)*"|\/\/.*$|\/\*[\s\S]*?\*\//gm, (m) =>
-    m.startsWith('"') ? m : "",
-  );
-}
-
-function applyTsConfigCompilerOptions(opts, co) {
-  if (!co || typeof co !== "object" || Array.isArray(co)) return;
-
-  // CLI 옵션이 명시적으로 지정되지 않은 경우에만 tsconfig 값 적용
-  if (co.experimentalDecorators && !opts.experimentalDecorators) {
-    opts.experimentalDecorators = true;
-  }
-  if (co.emitDecoratorMetadata) {
-    opts.emitDecoratorMetadata = true;
-  }
-  if (co.useDefineForClassFields === false) {
-    opts.useDefineForClassFields = false;
-  }
-  // verbatimModuleSyntax (TS 5.0+): 미사용 값 import 보존. CLI 이 설정 안 했으면 tsconfig 반영.
-  if (co.verbatimModuleSyntax === true && opts.verbatimModuleSyntax === undefined) {
-    opts.verbatimModuleSyntax = true;
-  }
-
-  // jsx: "react" → classic, "react-jsx" → automatic, "react-jsxdev" → automatic-dev
-  if (co.jsx && !opts.jsx) {
-    const jsxMap = {
-      react: "classic",
-      "react-jsx": "automatic",
-      "react-jsxdev": "automatic-dev",
-      preserve: undefined, // ZTS가 기본적으로 preserve하지 않으므로 무시
-    };
-    const mapped = jsxMap[co.jsx];
-    if (mapped) opts.jsx = mapped;
-  }
-
-  if (co.jsxFactory && !opts.jsxFactory) opts.jsxFactory = co.jsxFactory;
-  if (co.jsxFragmentFactory && !opts.jsxFragment) opts.jsxFragment = co.jsxFragmentFactory;
-  if (co.jsxImportSource && !opts.jsxImportSource) opts.jsxImportSource = co.jsxImportSource;
-
-  if (co.target && !opts.target && typeof co.target === "string") {
-    const targetMap = {
-      es5: "es5",
-      es6: "es2015",
-      es2015: "es2015",
-      es2016: "es2016",
-      es2017: "es2017",
-      es2018: "es2018",
-      es2019: "es2019",
-      es2020: "es2020",
-      es2021: "es2021",
-      es2022: "es2022",
-      es2023: "es2023",
-      es2024: "es2024",
-      esnext: "esnext",
-    };
-    opts.target = targetMap[co.target.toLowerCase()] || undefined;
-  }
-}
-
-function loadTsConfig(opts) {
-  if (opts.tsconfigRaw !== undefined) {
-    // raw 는 사용자가 방금 친 CLI 입력이므로 silent fallthrough 대신 즉시 실패.
-    // 파일 기반(아래)은 IDE/툴이 만든 ambient tsconfig 가 깨졌다고 빌드를 죽이지 않도록 warn 만 남긴다.
-    let config;
-    try {
-      config = JSON.parse(opts.tsconfigRaw);
-    } catch (err) {
-      const reason = err instanceof Error ? err.message : String(err);
-      throw new Error(`failed to parse --tsconfig-raw: ${reason}`);
-    }
-    if (!config || typeof config !== "object" || Array.isArray(config)) {
-      throw new Error("failed to parse --tsconfig-raw: expected a JSON object");
-    }
-    applyTsConfigCompilerOptions(opts, config.compilerOptions);
-    return;
-  }
-
-  // --project/--tsconfig-path 로 지정하거나 자동 탐색
-  let tsconfigPath = opts.project;
-  // 경로가 디렉토리면 내부의 tsconfig.json 을 대상 파일로 보정 (NAPI `loadFromPath` 와 동일 규칙).
-  if (tsconfigPath && existsSync(tsconfigPath)) {
-    try {
-      const { statSync } = require("node:fs");
-      if (statSync(tsconfigPath).isDirectory()) {
-        tsconfigPath = join(tsconfigPath, "tsconfig.json");
-      }
-    } catch {}
-  }
-  if (!tsconfigPath) {
-    // 엔트리 파일 기준으로 상위 디렉토리 탐색
-    const startDir =
-      opts.entryPoints.length > 0 ? dirname(resolve(opts.entryPoints[0])) : process.cwd();
-    let dir = startDir;
-    while (true) {
-      const candidate = join(dir, "tsconfig.json");
-      if (existsSync(candidate)) {
-        tsconfigPath = candidate;
-        break;
-      }
-      const parent = dirname(dir);
-      if (parent === dir) break;
-      dir = parent;
-    }
-  }
-
-  if (!tsconfigPath || !existsSync(tsconfigPath)) return;
-
+// ─── tsconfig 검증 + 자동 탐색 ───
+//
+// tsconfig 파싱/머지는 Zig (`src/tsconfig_merge.zig` + `TsConfig.parseFromString`/`loadFromPath`)
+// 가 단일 진실 원천. JS 측 책임은 두 가지:
+//   1) raw 사용자 입력 사전 검증 (NAPI 가 silent fallback 이라 명시 에러로 디버깅 도움).
+//   2) `--project` 미지정 시 entry 디렉토리에서 cwd 까지 자동 탐색해 `opts.project` 에 채움
+//      — bundler 진입점은 NAPI 가 직접 탐색하지만 transpile 진입점은 안 해서, 모드 비대칭을 JS 가 보정.
+function validateTsConfigRaw(raw) {
+  if (raw === undefined) return;
+  let config;
   try {
-    // JSON with comments 파싱 — 문자열 리터럴 내의 // 를 보호
-    const raw = readFileSync(resolve(tsconfigPath), "utf8");
-    const stripped = stripJsonComments(raw);
-    const config = JSON.parse(stripped);
-    applyTsConfigCompilerOptions(opts, config.compilerOptions);
-  } catch {
-    // tsconfig 파싱 실패는 무시 (경고만)
-    if (opts.logLevel !== "silent") {
-      console.error(`warning: failed to parse ${tsconfigPath}`);
+    config = JSON.parse(raw);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(`failed to parse --tsconfig-raw: ${reason}`);
+  }
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    throw new Error("failed to parse --tsconfig-raw: expected a JSON object");
+  }
+}
+
+function autodiscoverTsConfig(opts) {
+  if (opts.tsconfigRaw !== undefined) return; // raw 가 file 무시 우선.
+  if (opts.project) return; // 사용자 명시.
+  const startDir =
+    opts.entryPoints.length > 0 ? dirname(resolve(opts.entryPoints[0])) : process.cwd();
+  let dir = startDir;
+  while (true) {
+    const candidate = join(dir, "tsconfig.json");
+    if (existsSync(candidate)) {
+      opts.project = candidate;
+      return;
     }
+    const parent = dirname(dir);
+    if (parent === dir) return;
+    dir = parent;
   }
 }
 
@@ -1707,6 +1622,7 @@ async function runTranspile(opts) {
     dropDebugger: opts.drop.includes("debugger"),
     target: opts.target,
     browserslist: opts.browserslist,
+    tsconfigRaw: opts.tsconfigRaw,
   });
 
   if (opts.outfile || opts.outdir) {
@@ -1974,6 +1890,7 @@ async function runBundle(opts, config) {
     mainFields: opts.mainFields.length > 0 ? opts.mainFields : undefined,
     // NAPI 가 tsconfig paths / baseUrl 을 alias 로 변환해 resolver 에 주입하도록 전달.
     tsconfigPath: opts.project,
+    tsconfigRaw: opts.tsconfigRaw,
     banner: opts.banner,
     footer: opts.footer,
     globalName: opts.globalName,
@@ -2735,8 +2652,11 @@ async function main() {
   }
 
   try {
-    // tsconfig.json 자동 로드 (CLI/config 보다 낮은 우선순위)
-    loadTsConfig(opts);
+    // raw tsconfig 입력 사전 검증 — NAPI 가 silent fallback 이라 invalid 라도 진입은 가능,
+    // 사용자 디버깅 편의를 위해 여기서 명시 에러로 실패시킨다.
+    validateTsConfigRaw(opts.tsconfigRaw);
+    // bundler 진입점은 NAPI 가 자동 탐색하지만 transpile 진입점은 안 함 — JS 가 보정.
+    autodiscoverTsConfig(opts);
     init();
     const r = await dispatchBuild(opts, config, configEnv, dotenvVars);
     if (r.errors > 0) process.exit(1);

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -73,6 +73,7 @@ const {
   loadWorkspace,
   mergeUserConfigs,
   suggestKey,
+  validateTsConfigRaw,
   warnUnknownKeys,
 } = coreModule;
 
@@ -364,27 +365,11 @@ function parseArgs(argv) {
   return opts;
 }
 
-// ─── tsconfig 검증 + 자동 탐색 ───
+// ─── tsconfig 자동 탐색 ───
 //
 // tsconfig 파싱/머지는 Zig (`src/tsconfig_merge.zig` + `TsConfig.parseFromString`/`loadFromPath`)
-// 가 단일 진실 원천. JS 측 책임은 두 가지:
-//   1) raw 사용자 입력 사전 검증 (NAPI 가 silent fallback 이라 명시 에러로 디버깅 도움).
-//   2) `--project` 미지정 시 entry 디렉토리에서 cwd 까지 자동 탐색해 `opts.project` 에 채움
-//      — bundler 진입점은 NAPI 가 직접 탐색하지만 transpile 진입점은 안 해서, 모드 비대칭을 JS 가 보정.
-function validateTsConfigRaw(raw) {
-  if (raw === undefined) return;
-  let config;
-  try {
-    config = JSON.parse(raw);
-  } catch (err) {
-    const reason = err instanceof Error ? err.message : String(err);
-    throw new Error(`failed to parse --tsconfig-raw: ${reason}`);
-  }
-  if (!config || typeof config !== "object" || Array.isArray(config)) {
-    throw new Error("failed to parse --tsconfig-raw: expected a JSON object");
-  }
-}
-
+// 가 단일 진실 원천. raw 입력 검증은 `@zts/core` 의 `validateTsConfigRaw` (JS API/CLI 공유) 가 담당.
+// 자동 탐색은 bundler NAPI 진입점이 자체 처리하지만 transpile 진입점은 안 해서, 모드 비대칭을 JS 가 보정.
 function autodiscoverTsConfig(opts) {
   if (opts.tsconfigRaw !== undefined) return; // raw 가 file 무시 우선.
   if (opts.project) return; // 사용자 명시.

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -311,9 +311,7 @@ describe("CLI: transpile", () => {
   });
 
   test("file-based jsx tsconfig (jsxImportSource=preact) is honored via NAPI", () => {
-    // 회귀 가드: 이전엔 JS 측 `applyTsConfigCompilerOptions` 가 풀어 NAPI 에 jsx="automatic" 등을
-    // 직접 set 해 동작했음. JS 매핑을 걷어내고 Zig `tsconfig_merge` 가 jsx 를 처리하도록 옮긴 후에도
-    // 동일한 사용자 동작이 유지되는지 보장한다.
+    // tsconfig 의 jsx/jsxImportSource 가 NAPI(Zig `tsconfig_merge`) 경로로 적용되는지 회귀 가드.
     const projectDir = mkdtempSync(join(tmpdir(), "zts-cli-tsconfig-jsx-"));
     try {
       writeFileSync(

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -310,6 +310,26 @@ describe("CLI: transpile", () => {
     }
   });
 
+  test("file-based jsx tsconfig (jsxImportSource=preact) is honored via NAPI", () => {
+    // 회귀 가드: 이전엔 JS 측 `applyTsConfigCompilerOptions` 가 풀어 NAPI 에 jsx="automatic" 등을
+    // 직접 set 해 동작했음. JS 매핑을 걷어내고 Zig `tsconfig_merge` 가 jsx 를 처리하도록 옮긴 후에도
+    // 동일한 사용자 동작이 유지되는지 보장한다.
+    const projectDir = mkdtempSync(join(tmpdir(), "zts-cli-tsconfig-jsx-"));
+    try {
+      writeFileSync(
+        join(projectDir, "tsconfig.json"),
+        JSON.stringify({
+          compilerOptions: { jsx: "react-jsx", jsxImportSource: "preact" },
+        }),
+      );
+      const { stdout, exitCode } = runCli([join(dir, "jsx.tsx"), "--project", projectDir]);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("preact/jsx-runtime");
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
   test("--drop=console", () => {
     const { stdout, exitCode } = runCli([join(dir, "input.ts"), "--drop=console"]);
     expect(exitCode).toBe(0);

--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -104,8 +104,7 @@ describe("@zts/core", () => {
   });
 
   test("tsconfigRaw 의 jsx + jsxImportSource 가 자동 매핑돼 적용", () => {
-    // esbuild 식 인라인 override — file 시스템 접근 없이 JS API 만으로 jsx 동작 변경.
-    // Zig 의 `tsconfig_merge` 가 "react-jsx" → automatic + jsxImportSource="preact" 를 적용.
+    // esbuild 식 인라인 override — file 시스템 접근 없이 JS API 로 jsx 동작 변경.
     const result = transpile('<div className="app">hello</div>', {
       filename: "app.tsx",
       tsconfigRaw: JSON.stringify({

--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -103,6 +103,30 @@ describe("@zts/core", () => {
     expect(result.code).toContain("jsx");
   });
 
+  test("tsconfigRaw 의 jsx + jsxImportSource 가 자동 매핑돼 적용", () => {
+    // esbuild 식 인라인 override — file 시스템 접근 없이 JS API 만으로 jsx 동작 변경.
+    // Zig 의 `tsconfig_merge` 가 "react-jsx" → automatic + jsxImportSource="preact" 를 적용.
+    const result = transpile('<div className="app">hello</div>', {
+      filename: "app.tsx",
+      tsconfigRaw: JSON.stringify({
+        compilerOptions: { jsx: "react-jsx", jsxImportSource: "preact" },
+      }),
+    });
+    expect(result.code).toContain("preact/jsx-runtime");
+  });
+
+  test("tsconfigRaw 위에 명시 옵션이 우선", () => {
+    const result = transpile('<div className="app">hello</div>', {
+      filename: "app.tsx",
+      jsx: "classic",
+      tsconfigRaw: JSON.stringify({
+        compilerOptions: { jsx: "react-jsx", jsxImportSource: "preact" },
+      }),
+    });
+    expect(result.code).toContain("React.createElement");
+    expect(result.code).not.toContain("preact/jsx-runtime");
+  });
+
   test("소스맵 생성", () => {
     const result = transpile("const x: number = 1;", { filename: "input.ts", sourcemap: true });
     expect(result.code).toContain("const x = 1;");

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -554,6 +554,15 @@ interface BuildOptionsCommon {
    */
   outputExports?: "auto" | "named" | "default" | "none";
   /**
+   * inline tsconfig JSON 문자열 (esbuild 의 `tsconfigRaw` 와 동일 의미).
+   * 설정 시 `tsconfigPath` 와 자동 탐색을 모두 무시 — raw 가 단일 진실 원천.
+   * compilerOptions 의 jsx/target/decorators 등이 Zig 측 `tsconfig_merge` 에서 적용된다.
+   *
+   * @example
+   *   tsconfigRaw: JSON.stringify({ compilerOptions: { jsx: "react-jsx", jsxImportSource: "preact" } })
+   */
+  tsconfigRaw?: string;
+  /**
    * tsconfig.json 경로 (파일 또는 디렉토리). 설정 시 compilerOptions 를 자동 로드해서 머지한다.
    * JS 옵션이 명시적으로 설정된 필드가 우선 — 미지정 필드만 tsconfig 값으로 채워진다.
    * 예) "./tsconfig.json" 또는 "./project-dir"

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -20,7 +20,14 @@ import { fileURLToPath } from "url";
 
 export type { Target, Platform, TranspileOptions, TranspileResult } from "../shared/index";
 import type { TranspileOptions, TranspileResult } from "../shared/index";
-import { buildOptionsJson, ES_TARGET_BITS, browserslistToUnsupported } from "../shared/index";
+import {
+  buildOptionsJson,
+  ES_TARGET_BITS,
+  browserslistToUnsupported,
+  validateTsConfigRaw,
+} from "../shared/index";
+
+export { validateTsConfigRaw };
 
 // ─── NAPI Module ───
 
@@ -240,6 +247,7 @@ function resolveUnsupported(options: TranspileOptions): number {
 export function transpile(source: string, options: TranspileOptions = {}): TranspileResult {
   if (!native) throw new Error("@zts/core: not initialized. Call init() first.");
   if (!source) throw new Error("@zts/core: empty source");
+  validateTsConfigRaw(options.tsconfigRaw);
 
   const optionsJson = buildOptionsJson(options, resolveUnsupported(options));
   return native.transpile(source, options.filename ?? "input.js", optionsJson);
@@ -1490,6 +1498,7 @@ function writeOutputFiles(result: BuildResult, options: BuildOptions): void {
 export async function build(options: BuildOptions): Promise<BuildResult> {
   if (!native) throw new Error("@zts/core: not initialized. Call init() first.");
   if (!options.entryPoints?.length) throw new Error("@zts/core: entryPoints is required");
+  validateTsConfigRaw(options.tsconfigRaw);
 
   const napiOptions = prepareNapiOptions(options);
   const dispatcher = resolveDispatcher(options);
@@ -1515,6 +1524,7 @@ export async function build(options: BuildOptions): Promise<BuildResult> {
 export function buildSync(options: BuildOptions): BuildResult {
   if (!native) throw new Error("@zts/core: not initialized. Call init() first.");
   if (!options.entryPoints?.length) throw new Error("@zts/core: entryPoints is required");
+  validateTsConfigRaw(options.tsconfigRaw);
   if (options.plugins?.length) {
     throw new Error(
       "@zts/core: plugins are only supported with build() (async). Use build() instead of buildSync().",

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -3307,12 +3307,13 @@ fn parseBuildOptions(
 
     // JSX — string→enum 변환만 여기서. 최종 런타임/factory 결정은 tsconfig_merge 에 위임
     // (file/raw tsconfig 의 "jsx"/"jsxFactory" 등을 함께 고려).
+    // 인식 못 하는 jsx 문자열은 `.classic` 으로 fallback (이전 NAPI 동작 보존) — typo 가 silently
+    // tsconfig fallthrough 로 다른 결과를 만들지 않도록.
     const jsx_str = ownStr(env, opts_obj, "jsx", owned_strings);
     const jsx_runtime_explicit: ?JsxRuntime = if (jsx_str) |s| blk: {
         if (std.mem.eql(u8, s, "automatic")) break :blk .automatic;
         if (std.mem.eql(u8, s, "automatic-dev")) break :blk .automatic_dev;
-        if (std.mem.eql(u8, s, "classic")) break :blk .classic;
-        break :blk null;
+        break :blk .classic;
     } else null;
     const jsx_factory = ownStr(env, opts_obj, "jsxFactory", owned_strings);
     const jsx_fragment = ownStr(env, opts_obj, "jsxFragment", owned_strings);

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -3305,12 +3305,15 @@ fn parseBuildOptions(
         break :blk null;
     };
 
-    // JSX
+    // JSX — string→enum 변환만 여기서. 최종 런타임/factory 결정은 tsconfig_merge 에 위임
+    // (file/raw tsconfig 의 "jsx"/"jsxFactory" 등을 함께 고려).
     const jsx_str = ownStr(env, opts_obj, "jsx", owned_strings);
-    const jsx_runtime: JsxRuntime = if (jsx_str) |s|
-        if (std.mem.eql(u8, s, "automatic")) .automatic else if (std.mem.eql(u8, s, "automatic-dev")) .automatic_dev else .classic
-    else
-        .classic;
+    const jsx_runtime_explicit: ?JsxRuntime = if (jsx_str) |s| blk: {
+        if (std.mem.eql(u8, s, "automatic")) break :blk .automatic;
+        if (std.mem.eql(u8, s, "automatic-dev")) break :blk .automatic_dev;
+        if (std.mem.eql(u8, s, "classic")) break :blk .classic;
+        break :blk null;
+    } else null;
     const jsx_factory = ownStr(env, opts_obj, "jsxFactory", owned_strings);
     const jsx_fragment = ownStr(env, opts_obj, "jsxFragment", owned_strings);
     const jsx_import_source = ownStr(env, opts_obj, "jsxImportSource", owned_strings);
@@ -3421,15 +3424,16 @@ fn parseBuildOptions(
     const tsconfig_raw = ownStr(env, opts_obj, "tsconfigRaw", owned_strings);
     const tsconfig_path_js = ownStr(env, opts_obj, "tsconfigPath", owned_strings);
 
-    // tsconfig.json 로드 + 머지 — JS 옵션이 명시적으로 설정된 필드가 있으면 그게 우선.
-    // 머지 규칙은 `src/tsconfig_merge.zig` 의 공용 helper 에 위임 — transpile.zig / main.zig 와 일관.
-    // JS 가 tsconfigPath 를 주지 않았으면 entry 디렉토리에서 상위로 자동 탐색 (esbuild/vite 스타일).
+    // tsconfig 로드 + 머지 — JS 옵션이 명시적으로 설정된 필드가 우선 (ExplicitFlags 경로).
+    // raw 우선 (esbuild 동등): `tsconfigRaw` 가 있으면 file 기반 path / 자동 탐색을 모두 무시.
+    // raw parse 실패는 silent (빈 TsConfig) — JS 측이 NAPI 호출 전 사전 검증해 명시 에러를 던진다.
+    // 머지 규칙은 `src/tsconfig_merge.zig` 의 공용 helper — transpile.zig 와 일관.
     const TsConfig = @import("zts_lib").config.TsConfig;
     const tsconfig_merge = @import("zts_lib").tsconfig_merge;
     var tsconfig_holder: TsConfig = .{};
     var autodiscovered_dir: ?[]const u8 = null;
     defer if (autodiscovered_dir) |d| native_alloc.free(d);
-    const tsconfig_path_opt: ?[]const u8 = tsconfig_path_js orelse blk: {
+    const tsconfig_path_opt: ?[]const u8 = if (tsconfig_raw != null) null else tsconfig_path_js orelse blk: {
         // entry 가 하나라도 있으면 그 디렉토리 기준, 없으면 CWD 기준으로 탐색.
         const start_dir: []const u8 = if (entries.len > 0)
             std.fs.path.dirname(entries[0]) orelse "."
@@ -3438,7 +3442,9 @@ fn parseBuildOptions(
         autodiscovered_dir = TsConfig.findTsconfigUpward(native_alloc, start_dir) catch null;
         break :blk autodiscovered_dir;
     };
-    if (tsconfig_path_opt) |p| {
+    if (tsconfig_raw) |raw| {
+        tsconfig_holder = TsConfig.parseFromString(native_alloc, raw) catch TsConfig{};
+    } else if (tsconfig_path_opt) |p| {
         tsconfig_holder = TsConfig.loadFromPath(native_alloc, p) catch TsConfig{};
     }
     defer tsconfig_holder.deinit();
@@ -3448,11 +3454,19 @@ fn parseBuildOptions(
         .emit_decorator_metadata = getObjectBoolOptional(env, opts_obj, "emitDecoratorMetadata"),
         .use_define_for_class_fields = getObjectBoolOptional(env, opts_obj, "useDefineForClassFields"),
         .verbatim_module_syntax = getObjectBoolOptional(env, opts_obj, "verbatimModuleSyntax"),
+        .jsx_runtime = jsx_runtime_explicit,
+        .jsx_factory = jsx_factory,
+        .jsx_fragment = jsx_fragment,
+        .jsx_import_source = jsx_import_source,
     });
     const experimental_decorators_eff = merged_tsconfig.experimental_decorators;
     const emit_decorator_metadata_eff = merged_tsconfig.emit_decorator_metadata;
     const use_define_for_class_fields_eff = merged_tsconfig.use_define_for_class_fields;
     const verbatim_module_syntax_eff = merged_tsconfig.verbatim_module_syntax;
+    const jsx_runtime_eff = merged_tsconfig.jsx_runtime;
+    const jsx_factory_eff = merged_tsconfig.jsx_factory;
+    const jsx_fragment_eff = merged_tsconfig.jsx_fragment;
+    const jsx_import_source_eff = merged_tsconfig.jsx_import_source;
 
     const alias_entries: []const bundler_mod.types.AliasEntry = alias_list.toOwnedSlice(native_alloc) catch return null;
 
@@ -3623,10 +3637,10 @@ fn parseBuildOptions(
         .chunk_names = chunk_names orelse "[name]-[hash]",
         .asset_names = asset_names orelse "[name]-[hash]",
         .asset_registry = asset_registry,
-        .jsx_runtime = jsx_runtime,
-        .jsx_factory = jsx_factory orelse "React.createElement",
-        .jsx_fragment = jsx_fragment orelse "React.Fragment",
-        .jsx_import_source = jsx_import_source orelse "react",
+        .jsx_runtime = jsx_runtime_eff,
+        .jsx_factory = jsx_factory_eff,
+        .jsx_fragment = jsx_fragment_eff,
+        .jsx_import_source = jsx_import_source_eff,
         .inject = inject orelse &.{},
         .max_threads = getObjectUint32(env, opts_obj, "jobs", 0),
         .loader_overrides = loader_overrides,

--- a/packages/core/src/typo-suggest.ts
+++ b/packages/core/src/typo-suggest.ts
@@ -173,6 +173,7 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   "useDefineForClassFields",
   "verbatimModuleSyntax",
   "tsconfigPath",
+  "tsconfigRaw",
   // ─── Rollup 호환 ───
   "globalName",
   "globals",

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -165,6 +165,28 @@ export function targetToUnsupported(target?: Target): number {
   return ES_TARGET_BITS[target] ?? 0;
 }
 
+/**
+ * `tsconfigRaw` 사용자 입력 사전 검증.
+ *
+ * NAPI (`napi_entry.zig` / `transpile.zig`) 는 raw parse 실패 시 silent fallback (빈 TsConfig)
+ * 정책이라, 잘못된 raw 가 그대로 전달되면 사용자 입장에선 옵션이 무시된 것처럼 보인다. CLI 와
+ * JS API 양쪽 진입점에서 호출해 동일한 명시 에러 (`failed to parse --tsconfig-raw: ...`) 를
+ * 던지도록 통일. undefined 면 no-op.
+ */
+export function validateTsConfigRaw(raw: string | undefined): void {
+  if (raw === undefined) return;
+  let config: unknown;
+  try {
+    config = JSON.parse(raw);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(`failed to parse --tsconfig-raw: ${reason}`);
+  }
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    throw new Error("failed to parse --tsconfig-raw: expected a JSON object");
+  }
+}
+
 // ─── JSON payload 구성 (Zig optionsFromJson과 1:1 매핑) ───
 
 /**

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -72,6 +72,12 @@ export interface TranspileOptions {
    * 예) "./tsconfig.json" 또는 "./project-dir"
    */
   tsconfigPath?: string;
+  /**
+   * inline tsconfig JSON 문자열 (esbuild 의 `tsconfigRaw` 와 동일 의미).
+   * 설정 시 `tsconfigPath` 와 자동 탐색을 모두 무시 — raw 가 단일 진실 원천.
+   * Zig 측 `tsconfig_merge` 에서 jsx/target/decorators 등 compilerOptions 를 직접 적용한다.
+   */
+  tsconfigRaw?: string;
   /** 모듈 포맷 */
   format?: "esm" | "cjs";
   /** 문자열 따옴표 스타일 */
@@ -198,6 +204,7 @@ export function buildOptionsJson(
   if (opts.verbatimModuleSyntax !== undefined)
     payload.verbatimModuleSyntax = opts.verbatimModuleSyntax;
   if (opts.tsconfigPath) payload.tsconfigPath = opts.tsconfigPath;
+  if (opts.tsconfigRaw) payload.tsconfigRaw = opts.tsconfigRaw;
   if (opts.format) payload.format = opts.format;
   if (opts.quotes) payload.quotes = opts.quotes;
   if (opts.platform === "react-native") payload.platform = "react_native";

--- a/src/config.zig
+++ b/src/config.zig
@@ -231,59 +231,90 @@ pub const TsConfig = struct {
             }
         }
 
-        // compilerOptions 추출
-        if (root.object.get("compilerOptions")) |co_val| {
-            if (co_val == .object) {
-                const co = co_val.object;
+        try extractCompilerOptions(&config, root.object, allocator);
 
-                // 문자열 옵션 추출
-                // JSON에서 가져온 문자열은 parsed가 소유하므로,
-                // config가 오래 살기 위해 allocator로 복사(dupe)한다.
-                // 키가 JSON에 있을 때만 덮어씀 — extends로 merge된 값을 보존.
-                if (try dupeJsonString(co, "target", allocator, &config._allocated_strings.?)) |v| config.target = v;
-                if (try dupeJsonString(co, "module", allocator, &config._allocated_strings.?)) |v| config.module = v;
-                if (try dupeJsonString(co, "jsx", allocator, &config._allocated_strings.?)) |v| config.jsx = v;
-                if (try dupeJsonString(co, "jsxFactory", allocator, &config._allocated_strings.?)) |v| config.jsx_factory = v;
-                if (try dupeJsonString(co, "jsxFragmentFactory", allocator, &config._allocated_strings.?)) |v| config.jsx_fragment_factory = v;
-                if (try dupeJsonString(co, "jsxImportSource", allocator, &config._allocated_strings.?)) |v| config.jsx_import_source = v;
-                if (try dupeJsonString(co, "outDir", allocator, &config._allocated_strings.?)) |v| config.out_dir = v;
-                if (try dupeJsonString(co, "rootDir", allocator, &config._allocated_strings.?)) |v| config.root_dir = v;
-                if (try dupeJsonString(co, "baseUrl", allocator, &config._allocated_strings.?)) |v| config.base_url = v;
+        return config;
+    }
 
-                // paths: {"@/*": ["./src/*"], ...} → []PathEntry
-                if (co.get("paths")) |v| {
-                    if (v == .object) {
-                        const entries = try parsePathsObject(v.object, allocator, &config._allocated_strings.?);
-                        config.paths = entries;
-                    }
-                }
+    /// inline JSON 문자열에서 `TsConfig` 를 파싱한다.
+    /// `loadFile` 과 달리 `extends` chain 은 무시 — raw 문자열은 inline 이라 의미가 없다 (esbuild 동등).
+    /// 파싱 실패 / 비-object root → `error.TsConfigParseError`.
+    pub fn parseFromString(allocator: std.mem.Allocator, source: []const u8) !TsConfig {
+        const stripped = try stripJsonComments(allocator, source);
+        defer allocator.free(stripped);
 
-                // bool 옵션 추출
-                if (co.get("sourceMap")) |v| {
-                    if (v == .bool) config.source_map = v.bool;
-                }
-                if (co.get("declaration")) |v| {
-                    if (v == .bool) config.declaration = v.bool;
-                }
-                if (co.get("strict")) |v| {
-                    if (v == .bool) config.strict = v.bool;
-                }
-                if (co.get("experimentalDecorators")) |v| {
-                    if (v == .bool) config.experimental_decorators = v.bool;
-                }
-                if (co.get("emitDecoratorMetadata")) |v| {
-                    if (v == .bool) config.emit_decorator_metadata = v.bool;
-                }
-                if (co.get("useDefineForClassFields")) |v| {
-                    if (v == .bool) config.use_define_for_class_fields = v.bool;
-                }
-                if (co.get("verbatimModuleSyntax")) |v| {
-                    if (v == .bool) config.verbatim_module_syntax = v.bool;
-                }
+        const parsed = std.json.parseFromSlice(
+            std.json.Value,
+            allocator,
+            stripped,
+            .{ .allocate = .alloc_always },
+        ) catch return error.TsConfigParseError;
+        defer parsed.deinit();
+
+        if (parsed.value != .object) return error.TsConfigParseError;
+
+        var config = TsConfig{
+            ._allocator = allocator,
+            ._allocated_strings = .empty,
+        };
+        errdefer config.deinit();
+
+        try extractCompilerOptions(&config, parsed.value.object, allocator);
+        return config;
+    }
+
+    /// `loadFile` 과 `parseFromString` 가 공유하는 compilerOptions 추출 로직.
+    /// 키가 JSON 에 있을 때만 덮어씀 — extends 로 merge 된 값을 보존.
+    fn extractCompilerOptions(
+        config: *TsConfig,
+        root_obj: std.json.ObjectMap,
+        allocator: std.mem.Allocator,
+    ) !void {
+        const co_val = root_obj.get("compilerOptions") orelse return;
+        if (co_val != .object) return;
+        const co = co_val.object;
+
+        // 문자열 옵션 추출. JSON 에서 가져온 문자열은 parsed 가 소유하므로 allocator 로 복사(dupe).
+        if (try dupeJsonString(co, "target", allocator, &config._allocated_strings.?)) |v| config.target = v;
+        if (try dupeJsonString(co, "module", allocator, &config._allocated_strings.?)) |v| config.module = v;
+        if (try dupeJsonString(co, "jsx", allocator, &config._allocated_strings.?)) |v| config.jsx = v;
+        if (try dupeJsonString(co, "jsxFactory", allocator, &config._allocated_strings.?)) |v| config.jsx_factory = v;
+        if (try dupeJsonString(co, "jsxFragmentFactory", allocator, &config._allocated_strings.?)) |v| config.jsx_fragment_factory = v;
+        if (try dupeJsonString(co, "jsxImportSource", allocator, &config._allocated_strings.?)) |v| config.jsx_import_source = v;
+        if (try dupeJsonString(co, "outDir", allocator, &config._allocated_strings.?)) |v| config.out_dir = v;
+        if (try dupeJsonString(co, "rootDir", allocator, &config._allocated_strings.?)) |v| config.root_dir = v;
+        if (try dupeJsonString(co, "baseUrl", allocator, &config._allocated_strings.?)) |v| config.base_url = v;
+
+        // paths: {"@/*": ["./src/*"], ...} → []PathEntry
+        if (co.get("paths")) |v| {
+            if (v == .object) {
+                const entries = try parsePathsObject(v.object, allocator, &config._allocated_strings.?);
+                config.paths = entries;
             }
         }
 
-        return config;
+        // bool 옵션 추출
+        if (co.get("sourceMap")) |v| {
+            if (v == .bool) config.source_map = v.bool;
+        }
+        if (co.get("declaration")) |v| {
+            if (v == .bool) config.declaration = v.bool;
+        }
+        if (co.get("strict")) |v| {
+            if (v == .bool) config.strict = v.bool;
+        }
+        if (co.get("experimentalDecorators")) |v| {
+            if (v == .bool) config.experimental_decorators = v.bool;
+        }
+        if (co.get("emitDecoratorMetadata")) |v| {
+            if (v == .bool) config.emit_decorator_metadata = v.bool;
+        }
+        if (co.get("useDefineForClassFields")) |v| {
+            if (v == .bool) config.use_define_for_class_fields = v.bool;
+        }
+        if (co.get("verbatimModuleSyntax")) |v| {
+            if (v == .bool) config.verbatim_module_syntax = v.bool;
+        }
     }
 
     /// base config의 값을 target config에 merge한다.

--- a/src/config_test.zig
+++ b/src/config_test.zig
@@ -254,3 +254,84 @@ test "TsConfig.load - partial compilerOptions" {
     try std.testing.expect(config.source_map == false);
     try std.testing.expect(config.strict == false);
 }
+
+// ─── parseFromString ───
+
+test "parseFromString: extracts compilerOptions" {
+    const allocator = std.testing.allocator;
+    const source =
+        \\{
+        \\  "compilerOptions": {
+        \\    "jsx": "react-jsx",
+        \\    "jsxFactory": "h",
+        \\    "jsxFragmentFactory": "Frag",
+        \\    "jsxImportSource": "preact",
+        \\    "target": "es2020",
+        \\    "experimentalDecorators": true
+        \\  }
+        \\}
+    ;
+    var config = try TsConfig.parseFromString(allocator, source);
+    defer config.deinit();
+
+    try std.testing.expectEqualStrings("react-jsx", config.jsx.?);
+    try std.testing.expectEqualStrings("h", config.jsx_factory);
+    try std.testing.expectEqualStrings("Frag", config.jsx_fragment_factory);
+    try std.testing.expectEqualStrings("preact", config.jsx_import_source);
+    try std.testing.expectEqualStrings("es2020", config.target.?);
+    try std.testing.expect(config.experimental_decorators == true);
+}
+
+test "parseFromString: tolerates JSONC comments" {
+    const allocator = std.testing.allocator;
+    const source =
+        \\{
+        \\  // top-level comment
+        \\  "compilerOptions": {
+        \\    /* block comment */
+        \\    "target": "esnext"
+        \\  }
+        \\}
+    ;
+    var config = try TsConfig.parseFromString(allocator, source);
+    defer config.deinit();
+    try std.testing.expectEqualStrings("esnext", config.target.?);
+}
+
+test "parseFromString: ignores extends (raw is inline)" {
+    // extends 가 있어도 base 를 로드하지 않고 자기 자신만 추출 — esbuild 동등.
+    const allocator = std.testing.allocator;
+    const source =
+        \\{
+        \\  "extends": "./this/path/does-not-exist.json",
+        \\  "compilerOptions": {
+        \\    "target": "es2020"
+        \\  }
+        \\}
+    ;
+    var config = try TsConfig.parseFromString(allocator, source);
+    defer config.deinit();
+    try std.testing.expectEqualStrings("es2020", config.target.?);
+}
+
+test "parseFromString: rejects malformed JSON" {
+    const allocator = std.testing.allocator;
+    const result = TsConfig.parseFromString(allocator, "{ invalid json");
+    try std.testing.expectError(error.TsConfigParseError, result);
+}
+
+test "parseFromString: rejects non-object root" {
+    const allocator = std.testing.allocator;
+    try std.testing.expectError(error.TsConfigParseError, TsConfig.parseFromString(allocator, "null"));
+    try std.testing.expectError(error.TsConfigParseError, TsConfig.parseFromString(allocator, "[]"));
+    try std.testing.expectError(error.TsConfigParseError, TsConfig.parseFromString(allocator, "42"));
+}
+
+test "parseFromString: empty object yields default TsConfig" {
+    const allocator = std.testing.allocator;
+    var config = try TsConfig.parseFromString(allocator, "{}");
+    defer config.deinit();
+    try std.testing.expect(config.target == null);
+    try std.testing.expect(config.jsx == null);
+    try std.testing.expectEqualStrings("React.createElement", config.jsx_factory);
+}

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -128,6 +128,9 @@ pub const ConfigOptionsDto = struct {
     useDefineForClassFields: ?bool = null,
     verbatimModuleSyntax: ?bool = null,
     tsconfigPath: ?[]const u8 = null,
+    /// inline tsconfig JSON 문자열 (esbuild 의 `tsconfigRaw` 와 동일 의미).
+    /// 설정 시 파일 기반 `tsconfigPath` 와 자동 탐색을 모두 무시 — raw 가 단일 진실 원천.
+    tsconfigRaw: ?[]const u8 = null,
     format: ?@import("codegen/codegen.zig").ModuleFormat = null,
     quotes: ?@import("codegen/codegen.zig").QuoteStyle = null,
     platform: ?@import("codegen/codegen.zig").Platform = null,
@@ -269,34 +272,48 @@ pub fn optionsFromJson(allocator: std.mem.Allocator, json: []const u8) !Transpil
     if (parsed.define) |d| opts.define = d;
     if (parsed.stopAfter) |v| opts.stop_after = v;
 
-    // tsconfig.json 로드 + merge — JSON에 명시적으로 설정된 값이 tsconfig 값을 덮어쓴다.
-    // `parsed.<field> == null` 인 필드만 tsconfig 값으로 채움. 이로써 JSON > tsconfig > default 우선순위 유지.
-    // WASM 타겟에선 filesystem 접근(path_open 등)이 preopen 없이 불가하므로 링크 단계에서
-    // 해당 import 가 바인딩되지 못해 실패한다. 런타임에서도 호출할 수 없으므로 아예 스킵.
-    const can_load_tsconfig = @import("builtin").os.tag != .wasi and @import("builtin").os.tag != .freestanding;
-    if (can_load_tsconfig) if (opts.tsconfig_path) |path| {
-        const TsConfig = @import("config.zig").TsConfig;
-        const tsconfig_merge = @import("tsconfig_merge.zig");
-        var ts = TsConfig.loadFromPath(allocator, path) catch return opts; // tsconfig 읽기 실패는 조용히 무시 (CLI와 동일)
-        defer ts.deinit();
-
-        const merged = tsconfig_merge.merge(&ts, .{
-            .experimental_decorators = parsed.experimentalDecorators,
-            .emit_decorator_metadata = parsed.emitDecoratorMetadata,
-            .use_define_for_class_fields = parsed.useDefineForClassFields,
-            .verbatim_module_syntax = parsed.verbatimModuleSyntax,
-            .sourcemap = parsed.sourcemap,
-            .es_target = parsed.target,
-            .unsupported = if (parsed.unsupported) |u| @bitCast(u) else null,
-        });
-        opts.experimental_decorators = merged.experimental_decorators;
-        opts.emit_decorator_metadata = merged.emit_decorator_metadata;
-        opts.use_define_for_class_fields = merged.use_define_for_class_fields;
-        opts.verbatim_module_syntax = merged.verbatim_module_syntax;
-        opts.sourcemap = merged.sourcemap;
-        opts.es_target = merged.es_target;
-        opts.unsupported = merged.unsupported;
+    // tsconfig 로드 + merge — JSON 에 명시적으로 설정된 값이 tsconfig 값을 덮어쓴다.
+    // raw 우선 (esbuild 동등): `tsconfigRaw` 가 있으면 file 기반 path 무시.
+    // raw 파싱 실패는 사용자 입력 에러로 명시적 propagate, file 실패는 ambient 라 silent.
+    // WASM 타겟은 file 시스템 접근 불가 — file 분기만 스킵 (raw 는 무관하게 동작).
+    const TsConfig = @import("config.zig").TsConfig;
+    const tsconfig_merge = @import("tsconfig_merge.zig");
+    const can_load_tsconfig_file = @import("builtin").os.tag != .wasi and @import("builtin").os.tag != .freestanding;
+    const ts: TsConfig = blk: {
+        if (parsed.tsconfigRaw) |raw| {
+            break :blk TsConfig.parseFromString(allocator, raw) catch return error.InvalidOptions;
+        }
+        if (can_load_tsconfig_file) if (opts.tsconfig_path) |path| {
+            break :blk TsConfig.loadFromPath(allocator, path) catch TsConfig{};
+        };
+        break :blk TsConfig{};
     };
+    // arena 가 ts._allocated_strings 도 reap — 개별 deinit 금지 (CLAUDE.md memory 가이드).
+
+    const merged = tsconfig_merge.merge(&ts, .{
+        .experimental_decorators = parsed.experimentalDecorators,
+        .emit_decorator_metadata = parsed.emitDecoratorMetadata,
+        .use_define_for_class_fields = parsed.useDefineForClassFields,
+        .verbatim_module_syntax = parsed.verbatimModuleSyntax,
+        .sourcemap = parsed.sourcemap,
+        .es_target = parsed.target,
+        .unsupported = if (parsed.unsupported) |u| @bitCast(u) else null,
+        .jsx_runtime = parsed.jsx,
+        .jsx_factory = parsed.jsxFactory,
+        .jsx_fragment = parsed.jsxFragment,
+        .jsx_import_source = parsed.jsxImportSource,
+    });
+    opts.experimental_decorators = merged.experimental_decorators;
+    opts.emit_decorator_metadata = merged.emit_decorator_metadata;
+    opts.use_define_for_class_fields = merged.use_define_for_class_fields;
+    opts.verbatim_module_syntax = merged.verbatim_module_syntax;
+    opts.sourcemap = merged.sourcemap;
+    opts.es_target = merged.es_target;
+    opts.unsupported = merged.unsupported;
+    opts.jsx_runtime = merged.jsx_runtime;
+    opts.jsx_factory = merged.jsx_factory;
+    opts.jsx_fragment = merged.jsx_fragment;
+    opts.jsx_import_source = merged.jsx_import_source;
 
     return opts;
 }

--- a/src/tsconfig_merge.zig
+++ b/src/tsconfig_merge.zig
@@ -11,6 +11,7 @@
 
 const std = @import("std");
 const compat = @import("transformer/compat.zig");
+const codegen = @import("codegen/codegen.zig");
 const TsConfig = @import("config.zig").TsConfig;
 
 /// 사용자(CLI/JS/JSON)가 명시적으로 설정한 값. null = 미지정 → tsconfig fallback.
@@ -25,6 +26,14 @@ pub const ExplicitFlags = struct {
     /// 명시적으로 계산된 unsupported bitmask (browserslist 해석 결과 등).
     /// non-null 이면 es_target 기반 fallback 을 우회한다.
     unsupported: ?compat.UnsupportedFeatures = null,
+    /// 명시적으로 설정된 JSX 런타임. null 이면 tsconfig 의 "jsx" 문자열을 매핑.
+    jsx_runtime: ?codegen.JsxRuntime = null,
+    /// 명시적 jsx factory. null = 미지정 → tsconfig fallback.
+    jsx_factory: ?[]const u8 = null,
+    /// 명시적 jsx fragment. null = 미지정 → tsconfig fallback.
+    jsx_fragment: ?[]const u8 = null,
+    /// 명시적 jsx import source. null = 미지정 → tsconfig fallback.
+    jsx_import_source: ?[]const u8 = null,
 };
 
 /// 모든 필드가 확정된 최종 값.
@@ -36,7 +45,21 @@ pub const MergedFlags = struct {
     sourcemap: bool,
     es_target: ?compat.ESTarget,
     unsupported: compat.UnsupportedFeatures,
+    jsx_runtime: codegen.JsxRuntime,
+    jsx_factory: []const u8,
+    jsx_fragment: []const u8,
+    jsx_import_source: []const u8,
 };
+
+/// tsconfig 의 "jsx" 문자열 값을 ZTS 의 `JsxRuntime` 으로 매핑.
+/// "preserve" 와 인식 못 하는 값은 null — caller 가 default(`.classic`) 를 적용.
+fn mapTsConfigJsxToRuntime(tsconfig_jsx: ?[]const u8) ?codegen.JsxRuntime {
+    const s = tsconfig_jsx orelse return null;
+    if (std.mem.eql(u8, s, "react")) return .classic;
+    if (std.mem.eql(u8, s, "react-jsx")) return .automatic;
+    if (std.mem.eql(u8, s, "react-jsxdev")) return .automatic_dev;
+    return null;
+}
 
 /// `ExplicitFlags` 와 tsconfig 값을 우선순위 규칙에 따라 병합한다.
 /// `emit_decorator_metadata` 는 `experimental_decorators` 가 활성화된 경우에만
@@ -60,6 +83,10 @@ pub fn merge(ts: *const TsConfig, explicit: ExplicitFlags) MergedFlags {
             if (es_target) |t| break :blk compat.fromESTarget(t);
             break :blk .{};
         },
+        .jsx_runtime = explicit.jsx_runtime orelse mapTsConfigJsxToRuntime(ts.jsx) orelse .classic,
+        .jsx_factory = explicit.jsx_factory orelse ts.jsx_factory,
+        .jsx_fragment = explicit.jsx_fragment orelse ts.jsx_fragment_factory,
+        .jsx_import_source = explicit.jsx_import_source orelse ts.jsx_import_source,
     };
 }
 
@@ -118,4 +145,70 @@ test "merge: explicit unsupported wins over target-derived" {
         .unsupported = .{},
     });
     try std.testing.expect(merged.unsupported.top_level_await == false);
+}
+
+test "merge: jsx runtime maps tsconfig 'jsx' string" {
+    var ts = TsConfig{};
+
+    ts.jsx = "react";
+    try std.testing.expect(merge(&ts, .{}).jsx_runtime == .classic);
+
+    ts.jsx = "react-jsx";
+    try std.testing.expect(merge(&ts, .{}).jsx_runtime == .automatic);
+
+    ts.jsx = "react-jsxdev";
+    try std.testing.expect(merge(&ts, .{}).jsx_runtime == .automatic_dev);
+}
+
+test "merge: explicit jsx runtime wins over tsconfig" {
+    var ts = TsConfig{};
+    ts.jsx = "react-jsx";
+    const merged = merge(&ts, .{ .jsx_runtime = .classic });
+    try std.testing.expect(merged.jsx_runtime == .classic);
+}
+
+test "merge: preserve / unknown jsx falls back to default classic" {
+    var ts = TsConfig{};
+
+    ts.jsx = "preserve";
+    try std.testing.expect(merge(&ts, .{}).jsx_runtime == .classic);
+
+    ts.jsx = "react-native";
+    try std.testing.expect(merge(&ts, .{}).jsx_runtime == .classic);
+}
+
+test "merge: jsx factory/fragment/importSource pass through tsconfig" {
+    var ts = TsConfig{};
+    ts.jsx_factory = "h";
+    ts.jsx_fragment_factory = "Frag";
+    ts.jsx_import_source = "preact";
+    const merged = merge(&ts, .{});
+    try std.testing.expectEqualStrings("h", merged.jsx_factory);
+    try std.testing.expectEqualStrings("Frag", merged.jsx_fragment);
+    try std.testing.expectEqualStrings("preact", merged.jsx_import_source);
+}
+
+test "merge: explicit jsx factory wins over tsconfig" {
+    var ts = TsConfig{};
+    ts.jsx_factory = "tsconfigFactory";
+    ts.jsx_fragment_factory = "tsconfigFragment";
+    ts.jsx_import_source = "tsconfigSource";
+    const merged = merge(&ts, .{
+        .jsx_factory = "explicitFactory",
+        .jsx_fragment = "explicitFragment",
+        .jsx_import_source = "explicitSource",
+    });
+    try std.testing.expectEqualStrings("explicitFactory", merged.jsx_factory);
+    try std.testing.expectEqualStrings("explicitFragment", merged.jsx_fragment);
+    try std.testing.expectEqualStrings("explicitSource", merged.jsx_import_source);
+}
+
+test "merge: jsx defaults preserved when neither tsconfig nor explicit set" {
+    const ts = TsConfig{};
+    const merged = merge(&ts, .{});
+    // TsConfig 의 default 가 그대로 흘러 옴 — TsConfig 가 단일 진실 원천.
+    try std.testing.expect(merged.jsx_runtime == .classic);
+    try std.testing.expectEqualStrings("React.createElement", merged.jsx_factory);
+    try std.testing.expectEqualStrings("React.Fragment", merged.jsx_fragment);
+    try std.testing.expectEqualStrings("react", merged.jsx_import_source);
 }


### PR DESCRIPTION
## 요약

PR #2350 의 후속. esbuild 식 정식 모방을 완성한다.

PR #2350 은 \`--tsconfig-raw=<json>\` CLI flag 를 도입하면서 JS 측 \`loadTsConfig\` 가 raw 를 풀어 jsx/target/decorators 등 다른 옵션으로 변환해 NAPI 에 전달하는 방식이었다. 그 PR 정리 단계에서 \"JS API 의 \`tsconfigRaw\` 표면이 NAPI 에 도달하기는 하지만 Zig 측에서 받기만 하고 처리 안 해 misleading\" 이라는 문제를 발견해 일단 JS API 표면을 거뒀다 (현 main 상태).

본 PR 은 두 가지를 같이 해결한다:

1. **Zig 측 \`tsconfig_merge\` 가 jsx 까지 처리하도록 확장** — 이전엔 boolean flags + es_target 만 머지하고 jsx 는 napi_entry 가 자체 처리. file-based \`tsconfig.json\` 의 \`jsx: \"react-jsx\"\` 같은 설정이 NAPI 차원에선 무시되고 JS 측 매핑 우회로만 동작했다.
2. **\`tsconfigRaw\` 를 Zig 에서 직접 파싱 + 머지** — esbuild 처럼 raw 를 단일 string 으로 받아 \`TsConfig.parseFromString\` 으로 inline 파싱 후 같은 머지 파이프라인으로 흘려보냄. raw 우선 (file 무시) 정책도 esbuild 동등.

결과: JS 측은 더 이상 tsconfig 를 풀지 않고 NAPI 에 그대로 forward, Zig (\`config.TsConfig\` + \`tsconfig_merge\`) 가 단일 진실 원천. JS API consumer 도 \`tsconfigRaw\` 를 진짜로 사용 가능 (이전엔 dead surface).

## 구조 (3 commits)

- **\`feat(tsconfig): extend merge with jsx + add parseFromString\`** — \`ExplicitFlags\`/\`MergedFlags\` 에 jsx 4 필드 추가, \`mapTsConfigJsxToRuntime\` helper, \`TsConfig.parseFromString\` (extends 미지원), \`extractCompilerOptions\` 공유 helper, 단위 테스트.
- **\`feat(tsconfig): wire raw + jsx merge in transpile/napi entries\`** — \`transpile.zig::optionsFromJson\` 와 \`napi_entry.zig\` 에 raw 분기 추가, jsx 4 필드를 ExplicitFlags 로 전달, merged 결과를 BundleOptions / TranspileOptions 로 흘림.
- **\`feat(tsconfig): expose tsconfigRaw on JS API + drop JS-side parsing\`** — JS API 표면 복원 (\`BuildOptionsCommon\` / \`TranspileOptions\` / \`buildOptionsJson\`), \`zts.mjs\` 의 \`loadTsConfig\` / \`applyTsConfigCompilerOptions\` / \`stripJsonComments\` 제거, \`validateTsConfigRaw\` (NAPI silent fallback 보완) + \`autodiscoverTsConfig\` (transpile 진입점 자동 탐색 보정) 신규, 통합 테스트.

## 디자인 결정

- **raw vs file 우선순위**: raw 가 있으면 file/자동 탐색 모두 무시. esbuild 동등.
- **TsConfig.parseFromString extends 미지원**: inline raw 라 외부 파일 chain 의미 없음. esbuild 도 동일.
- **raw parse 실패 정책**: transpile 진입점은 \`error.InvalidOptions\` 명시 propagate, NAPI bundler 진입점은 silent fallback. JS 측 \`validateTsConfigRaw\` 가 NAPI 호출 전 사전 검증해 사용자에게 명시 에러를 던지도록 보완.
- **\`src/main.zig\` (Zig 네이티브 CLI) 는 이번 PR scope 외**: manual field-by-field merge 라 통합이 별도 리팩토링. \`--tsconfig-raw=\` argv 인자도 set 만 되고 처리 안 되는 dead path 인 채로 남김 (기존 상태 그대로).

## 검증

- \`zig build test\` 통과 (jsx 매핑 / parseFromString / 우선순위 단위 테스트 포함)
- \`bun test packages/core/bin/zts.test.ts --test-name-pattern \"tsconfig|jsx tsconfig\"\` 29/29 통과
- \`bun test packages/core/index.test.ts\` 369/369 통과 (JS API tsconfigRaw 동작 검증 포함)
- \`bun test packages/core/bin/zts-cli-schema-sync.test.ts\` 11/11 통과
- \`zig fmt --check\` / \`bun run fmt:check\` / pre-push hook (zig fmt + zig build test + oxlint + oxfmt) 모두 통과

\`zts.test.ts\` 전체 실행 시 6개 fail 은 이미 등록된 #2351 (Vite-style dev server / watch-json port 13146 flaky) 이슈로 본 PR 변경과 무관 — base 에서도 재현 확인됨.

## 회귀 가드

- file-based \`{\"compilerOptions\":{\"jsx\":\"react-jsx\",\"jsxImportSource\":\"preact\"}}\` 가 NAPI 경로로 정상 적용되는지 (이전엔 JS 매핑이 가려서 진짜 회귀 발견 못 했을 부분).
- JS API \`transpile(source, { tsconfigRaw: ... })\` 가 진짜 동작.
- 명시 옵션이 raw 보다 우선.

Closes (없음 — 직접 design issue 는 #2350 의 (B') discussion).