### PR TITLE
refactor(config): extract applyJsonBool helper for tsconfig boolean fields

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -294,27 +294,13 @@ pub const TsConfig = struct {
         }
 
         // bool 옵션 추출
-        if (co.get("sourceMap")) |v| {
-            if (v == .bool) config.source_map = v.bool;
-        }
-        if (co.get("declaration")) |v| {
-            if (v == .bool) config.declaration = v.bool;
-        }
-        if (co.get("strict")) |v| {
-            if (v == .bool) config.strict = v.bool;
-        }
-        if (co.get("experimentalDecorators")) |v| {
-            if (v == .bool) config.experimental_decorators = v.bool;
-        }
-        if (co.get("emitDecoratorMetadata")) |v| {
-            if (v == .bool) config.emit_decorator_metadata = v.bool;
-        }
-        if (co.get("useDefineForClassFields")) |v| {
-            if (v == .bool) config.use_define_for_class_fields = v.bool;
-        }
-        if (co.get("verbatimModuleSyntax")) |v| {
-            if (v == .bool) config.verbatim_module_syntax = v.bool;
-        }
+        applyJsonBool(co, "sourceMap", &config.source_map);
+        applyJsonBool(co, "declaration", &config.declaration);
+        applyJsonBool(co, "strict", &config.strict);
+        applyJsonBool(co, "experimentalDecorators", &config.experimental_decorators);
+        applyJsonBool(co, "emitDecoratorMetadata", &config.emit_decorator_metadata);
+        applyJsonBool(co, "useDefineForClassFields", &config.use_define_for_class_fields);
+        applyJsonBool(co, "verbatimModuleSyntax", &config.verbatim_module_syntax);
     }
 
     /// base config의 값을 target config에 merge한다.
@@ -584,6 +570,14 @@ fn dupeJsonString(
     const v = co.get(key) orelse return null;
     if (v != .string) return null;
     return try dupeAndTrack(allocator, v.string, allocated_strings);
+}
+
+/// JSON 객체의 boolean 을 `target` 에 적용한다 (in-place).
+/// 키가 없거나 boolean 이 아니면 no-op — extends 머지 값을 보존.
+/// `target` 은 `*bool` 또는 `*?bool` (nullable 은 자동 wrap).
+fn applyJsonBool(co: std.json.ObjectMap, key: []const u8, target: anytype) void {
+    const v = co.get(key) orelse return;
+    if (v == .bool) target.* = v.bool;
 }
 
 /// optional 문자열 merge: target이 null이고 base에 값이 있으면 복사.


### PR DESCRIPTION
## 요약

PR #2356 의 /simplify 리뷰 (Code Reuse Review #5) 후속 cleanup.

`extractCompilerOptions` (`src/config.zig:296-317`) 의 7 개 boolean 필드 추출이 동일 패턴을 3 줄씩 반복하고 있었음:

```zig
if (co.get("sourceMap")) |v| {
    if (v == .bool) config.source_map = v.bool;
}
if (co.get("declaration")) |v| {
    if (v == .bool) config.declaration = v.bool;
}
// ... 5번 더 ...
```

## 변경

`dupeJsonString` 옆에 in-place 적용 헬퍼 추가:

```zig
/// JSON 객체의 boolean 을 `target` 에 적용한다 (in-place).
/// 키가 없거나 boolean 이 아니면 no-op — extends 머지 값을 보존.
/// `target` 은 `*bool` 또는 `*?bool` (nullable 은 자동 wrap).
fn applyJsonBool(co: std.json.ObjectMap, key: []const u8, target: anytype) void {
    const v = co.get(key) orelse return;
    if (v == .bool) target.* = v.bool;
}
```

- 동사 `apply` — `get*` 는 getter 처럼 읽혀 misleading 한 반면 `apply` 는 mutate 의미 명시 (리뷰 권장 반영).
- `target: anytype` — `*bool` 과 `*?bool` 둘 다 받음. `useDefineForClassFields` 만 `?bool` 이라 분기 헬퍼 추가하기엔 비용 > 이득.
- 호출 7 곳이 한 줄씩으로 단순화: `+15 -21`.

## 동작

기존과 동일 — 키 없음 / 타입 불일치 (예: `"strict": "true"`) 시 no-op, extends 로 머지된 값 보존. 회귀 없음.

## 검증

- `zig build test` 통과
- `zig fmt --check` 통과
- pre-push hook (zig fmt + zig build test + oxlint + oxfmt) 통과
- /simplify 3 agents 리뷰: 재사용 / 품질 / 효율 모두 ship verdict — `mergeFrom` 의 boolean 처리는 다른 의미 (true 만 propagate) 라 제외, NAPI `getObjectBool` 도 다른 runtime 이라 통합 X.

## 후속 (별개 PR)

- A1#4: `napi_entry.zig` / `main.zig` / `tsconfig_merge.zig` 에 흩어진 jsx 매핑 통합 + `main.zig:818` vocab 섞임 latent bug
- A1#1: NAPI transpile 진입점에 자동 탐색 wiring (현재 JS 측 `autodiscoverTsConfig` 가 보정 중)
- 이슈 #2358: Zig 네이티브 CLI (`src/main.zig`) 의 manual tsconfig merge → `tsconfig_merge.merge` 통합 + `--tsconfig-raw=` wiring

## 참고

- PR #2356 (머지됨): feat(tsconfig): merge raw + jsx in Zig
- PR #2359 (open): refactor(shared): extract isPlainObject helper from 3 inline guards — A1#2