### PR TITLE
feat(codegen): add type alias / interface indexer

### DIFF
--- a/src/transformer/mod.zig
+++ b/src/transformer/mod.zig
@@ -52,4 +52,5 @@ test {
     _ = @import("worklet_babel_parity_test.zig");
     _ = @import("styled_components_test.zig");
     _ = @import("emotion_test.zig");
+    _ = @import("plugins/codegen/mod.zig");
 }

--- a/src/transformer/plugins/codegen/mod.zig
+++ b/src/transformer/plugins/codegen/mod.zig
@@ -1,0 +1,23 @@
+//! RN View Config Codegen 모듈 — 진입점.
+//!
+//! `@react-native/codegen` 의 view config 인라인 기능을 ZTS native 로 옮긴
+//! 플러그인 (#2348). 다음 단계:
+//!
+//!   schema.zig            — Schema 데이터 구조 (PR #1, merged)
+//!   type_index.zig        — 같은 파일 내 type alias / interface 인덱싱 (PR #2)
+//!   schema_builder.zig    — TODO (PR #3): NativeProps AST → ComponentShape
+//!   view_config_emitter.zig — TODO (PR #4): ComponentShape → JS 문자열
+//!   validator.zig         — TODO (PR #5): SchemaValidator 동등 + 진단
+//!   codegen_plugin.zig    — TODO (PR #6): 통합 + builtin / CLI / NAPI 노출
+//!
+//! 본 mod.zig 자체는 import 만 묶음. 외부에선 필요한 서브 모듈을 직접 import
+//! 하거나 본 파일을 통해 가져갈 수 있다.
+
+pub const schema = @import("schema.zig");
+pub const type_index = @import("type_index.zig");
+
+test {
+    _ = schema;
+    _ = type_index;
+    _ = @import("type_index_test.zig");
+}

--- a/src/transformer/plugins/codegen/type_index.zig
+++ b/src/transformer/plugins/codegen/type_index.zig
@@ -1,0 +1,124 @@
+//! Type alias / interface 인덱싱 — 같은 파일 내 top-level 선언 이름 → NodeIndex 맵
+//!
+//! `program` 노드의 직계 자식만 순회하면서 type-only declaration 태그를 이름 →
+//! NodeIndex 로 인덱싱한다. 재귀 안 함 (top-level only).
+//!
+//! 대상 태그는 `Tag.isTypeOnlyDeclaration()` (`ast.zig:390`) 이 true 인 5 종:
+//!   - `ts_type_alias_declaration`
+//!   - `ts_interface_declaration`
+//!   - `flow_type_alias_declaration`
+//!   - `flow_interface_declaration`
+//!   - `flow_opaque_type`
+//!
+//! 이 5 종 모두 `data.extra` 의 첫 슬롯에 binding_identifier NodeIndex 를 두는
+//! 컨벤션. 새 태그가 추가되면 같은 컨벤션을 따르는지 확인 필요 (현재 파서 코드
+//! 검증 결과 5 종 모두 일관).
+//!
+//! 사용 시점: codegen plugin 의 첫 패스. 두 번째 패스에서 NativeProps 같은 type
+//! reference 만났을 때 이 인덱스로 정의 노드를 찾는다.
+//!
+//! 알려진 한계:
+//!
+//!   - **`export type Foo = ...` 는 인덱싱 안 됨.** ZTS 파서 (`module.zig:885`) 가
+//!     type-only declaration 의 export wrapper 를 parse 시점에 program 에서
+//!     제거하기 때문. 해당 type alias 노드 자체는 `ast.nodes` 에 orphan 으로
+//!     남지만 program 에서 도달 불가. NativeComponent spec 파일에서 NativeProps
+//!     를 export 하는 패턴은 일반적이지 않으므로 (보통 unhindered `type
+//!     NativeProps = ...`) 실용적 영향 없음. 영향 받는 spec 은 schema_builder
+//!     (PR #3) 가 fail-fast 하고 Bungae 는 JS fallback 으로 처리.
+//!   - Cross-file 미지원 (#2348 § 5): import 한 type reference 도 동일 fallback.
+//!
+//! 메모리: 호출자가 alloc 제공. arena 권장 — `arena.deinit()` 으로 일괄 해제,
+//! `TypeIndex.deinit` 호출 불필요. 일반 allocator 쓰면 명시적으로 deinit.
+
+const std = @import("std");
+const ast_mod = @import("../../../parser/ast.zig");
+const Ast = ast_mod.Ast;
+const Node = ast_mod.Node;
+const NodeIndex = ast_mod.NodeIndex;
+
+/// 같은 파일 내 type alias / interface 선언의 이름 → NodeIndex 맵.
+///
+/// 반환된 NodeIndex 는 항상 type-only declaration 태그 중 하나를 가리킨다.
+/// `export <decl>` 같은 wrapper 노드는 ZTS 파서가 parse 시점에 program 에서
+/// 제거하므로 (`module.zig:885`) 이 인덱스에 들어오지 않는다.
+///
+/// **Lifetime 주의**: 키 (이름) 는 `Ast.string_table` 또는 source buffer 의
+/// 슬라이스 — 별도 dupe 안 함. 호출자는 이 인덱스를 사용하는 동안 ast (및
+/// 그 backing source buffer) 가 유효해야 한다. arena 기반에서 ast 와 함께
+/// schema_builder 가 끝나면 일괄 해제되는 패턴 권장.
+pub const TypeIndex = struct {
+    /// 키 (이름) 는 `Ast.string_table` 또는 source buffer 가 소유 — 별도 dupe 안 함.
+    /// 값은 declaration NodeIndex.
+    map: std.StringHashMapUnmanaged(NodeIndex) = .empty,
+
+    /// 일반 allocator 사용 시 명시 해제. arena 사용 시 호출 불필요.
+    pub fn deinit(self: *TypeIndex, alloc: std.mem.Allocator) void {
+        self.map.deinit(alloc);
+    }
+
+    /// 이름 lookup — 못 찾으면 null.
+    pub fn get(self: *const TypeIndex, name: []const u8) ?NodeIndex {
+        return self.map.get(name);
+    }
+
+    /// 인덱싱된 선언 수.
+    pub fn count(self: *const TypeIndex) usize {
+        return self.map.count();
+    }
+};
+
+/// `program` 노드의 직계 자식을 훑어 type alias / interface 를 인덱싱.
+///
+/// 중복 이름이면 마지막 정의가 이김 — codegen 은 단일 정의 가정 (파일 내 같은
+/// 이름 두 번 선언은 사실상 사용자 버그).
+///
+/// 에러: OOM 만 전파. `program_idx` 가 program 이 아니거나 손상된 AST 노드는
+/// silent skip — 빈 인덱스로 반환 (호출자는 `count() == 0` 으로 감지 가능).
+pub fn build(
+    ast: *const Ast,
+    program_idx: NodeIndex,
+    alloc: std.mem.Allocator,
+) !TypeIndex {
+    var index: TypeIndex = .{};
+
+    const program = ast.getNode(program_idx);
+    if (program.tag != .program) return index;
+
+    const list = program.data.list;
+    const items = ast.extra_data.items[list.start .. list.start + list.len];
+    for (items) |raw| {
+        const stmt_idx: NodeIndex = @enumFromInt(raw);
+        if (stmt_idx == .none) continue;
+
+        const decl = ast.getNode(stmt_idx);
+        const name = nameOfDecl(ast, decl) orelse continue;
+        try index.map.put(alloc, name, stmt_idx);
+    }
+    return index;
+}
+
+/// type-only declaration 의 첫 extra 슬롯에서 binding_identifier 를 읽어 텍스트 반환.
+/// type-only 가 아닌 태그면 null. 5 종 layout 모두 `extra[0] = name` 컨벤션:
+///
+///   - `ts_type_alias_declaration`:    extra = [name, type_params, ty]
+///   - `ts_interface_declaration`:     extra = [name, type_params, extends_start, extends_len, body]
+///   - `flow_type_alias_declaration`:  extra = [name, type_params, value]
+///   - `flow_interface_declaration`:   extra = [name, type_params, extends_start, extends_len]
+///   - `flow_opaque_type`:             extra = [name, type_params, supertype, value]
+///
+/// `Tag.isTypeOnlyDeclaration()` (`ast.zig:390`) 을 가드로 사용 — ast.zig 에 새
+/// type-only declaration 이 추가되면 자동으로 포함된다 (drift-proof). 단,
+/// 새 태그가 위 컨벤션을 따라야 한다.
+fn nameOfDecl(ast: *const Ast, node: Node) ?[]const u8 {
+    if (!node.tag.isTypeOnlyDeclaration()) return null;
+
+    const extra_start = node.data.extra;
+    if (extra_start >= ast.extra_data.items.len) return null;
+    const name_idx: NodeIndex = @enumFromInt(ast.extra_data.items[extra_start]);
+    if (name_idx == .none) return null;
+
+    const name_node = ast.getNode(name_idx);
+    if (name_node.tag != .binding_identifier) return null;
+    return ast.getText(name_node.data.string_ref);
+}

--- a/src/transformer/plugins/codegen/type_index_test.zig
+++ b/src/transformer/plugins/codegen/type_index_test.zig
@@ -1,0 +1,222 @@
+//! type_index.zig 단위 테스트.
+//!
+//! 4 종 declaration 태그 인식 + export wrapper 처리 + 중복 이름 처리 검증.
+
+const std = @import("std");
+const Scanner = @import("../../../lexer/scanner.zig").Scanner;
+const Parser = @import("../../../parser/parser.zig").Parser;
+const type_index = @import("type_index.zig");
+
+/// 소스를 파싱해서 program NodeIndex 반환. transformer 안 거침 — 타입 노드가
+/// strip 되기 전 raw AST 가 필요.
+const ParsedSource = struct {
+    scanner: Scanner,
+    parser: Parser,
+    program: @import("../../../parser/ast.zig").NodeIndex,
+
+    fn init(alloc: std.mem.Allocator, source: []const u8) !ParsedSource {
+        var scanner = try Scanner.init(alloc, source);
+        errdefer scanner.deinit();
+
+        var parser = Parser.init(alloc, &scanner);
+        errdefer parser.deinit();
+
+        const program = try parser.parse();
+        return .{ .scanner = scanner, .parser = parser, .program = program };
+    }
+
+    fn deinit(self: *ParsedSource) void {
+        self.parser.deinit();
+        self.scanner.deinit();
+    }
+};
+
+/// build()를 호출하고 caller 가 deinit 한 번에 정리할 수 있도록 묶음.
+const Indexed = struct {
+    parsed: ParsedSource,
+    index: type_index.TypeIndex,
+
+    fn deinit(self: *Indexed, alloc: std.mem.Allocator) void {
+        self.index.deinit(alloc);
+        self.parsed.deinit();
+    }
+};
+
+fn parseAndIndex(alloc: std.mem.Allocator, source: []const u8) !Indexed {
+    var parsed = try ParsedSource.init(alloc, source);
+    errdefer parsed.deinit();
+
+    const index = try type_index.build(&parsed.parser.ast, parsed.program, alloc);
+    return .{ .parsed = parsed, .index = index };
+}
+
+test "TypeIndex: TS type alias indexed" {
+    var r = try parseAndIndex(std.testing.allocator,
+        \\type Props = { color: string };
+    );
+    defer r.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), r.index.count());
+    try std.testing.expect(r.index.get("Props") != null);
+}
+
+test "TypeIndex: TS interface indexed" {
+    var r = try parseAndIndex(std.testing.allocator,
+        \\interface Props { color: string }
+    );
+    defer r.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), r.index.count());
+    try std.testing.expect(r.index.get("Props") != null);
+}
+
+test "TypeIndex: Flow type alias indexed" {
+    var r = try parseAndIndex(std.testing.allocator,
+        \\// @flow
+        \\type Props = {| color: string |};
+    );
+    defer r.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), r.index.count());
+    try std.testing.expect(r.index.get("Props") != null);
+}
+
+test "TypeIndex: Flow interface indexed" {
+    var r = try parseAndIndex(std.testing.allocator,
+        \\// @flow
+        \\interface Props { color: string }
+    );
+    defer r.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), r.index.count());
+    try std.testing.expect(r.index.get("Props") != null);
+}
+
+test "TypeIndex: Flow opaque type indexed" {
+    var r = try parseAndIndex(std.testing.allocator,
+        \\// @flow
+        \\opaque type Props = { color: string };
+    );
+    defer r.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), r.index.count());
+    try std.testing.expect(r.index.get("Props") != null);
+}
+
+test "TypeIndex: export type alias dropped at parse (known limitation)" {
+    // ZTS 파서가 type-only declaration 의 export wrapper 를 parse 시점에
+    // program 에서 제거 (`module.zig:885`). type alias 노드는 orphan 으로 남지만
+    // program 에서 도달 불가 → 인덱싱 안 됨.
+    var r = try parseAndIndex(std.testing.allocator,
+        \\export type Props = { color: string };
+    );
+    defer r.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 0), r.index.count());
+}
+
+test "TypeIndex: export interface dropped at parse (known limitation)" {
+    var r = try parseAndIndex(std.testing.allocator,
+        \\export interface Props { color: string }
+    );
+    defer r.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 0), r.index.count());
+}
+
+test "TypeIndex: multiple declarations all indexed" {
+    var r = try parseAndIndex(std.testing.allocator,
+        \\type Props = { color: string };
+        \\interface Events { onChange: () => void }
+        \\type ViewProps = { width: number };
+    );
+    defer r.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 3), r.index.count());
+    try std.testing.expect(r.index.get("Props") != null);
+    try std.testing.expect(r.index.get("Events") != null);
+    try std.testing.expect(r.index.get("ViewProps") != null);
+}
+
+test "TypeIndex: generic type alias indexed by name only" {
+    var r = try parseAndIndex(std.testing.allocator,
+        \\type Container<T> = { value: T };
+    );
+    defer r.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), r.index.count());
+    try std.testing.expect(r.index.get("Container") != null);
+}
+
+test "TypeIndex: duplicate name keeps last definition" {
+    var r = try parseAndIndex(std.testing.allocator,
+        \\type Props = { a: string };
+        \\type Props = { b: number };
+    );
+    defer r.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), r.index.count());
+
+    // program 자식을 직접 훑어 마지막 type_alias_declaration("Props") 의 NodeIndex 를
+    // 구한 뒤 인덱스가 그걸 가리키는지 확인.
+    const ast = &r.parsed.parser.ast;
+    const program = ast.getNode(r.parsed.program);
+    const list = program.data.list;
+    var expected_last: @import("../../../parser/ast.zig").NodeIndex = .none;
+    for (ast.extra_data.items[list.start .. list.start + list.len]) |raw| {
+        const stmt: @import("../../../parser/ast.zig").NodeIndex = @enumFromInt(raw);
+        if (stmt == .none) continue;
+        const node = ast.getNode(stmt);
+        if (node.tag != .ts_type_alias_declaration) continue;
+        const name_idx: @import("../../../parser/ast.zig").NodeIndex =
+            @enumFromInt(ast.extra_data.items[node.data.extra]);
+        const name = ast.getText(ast.getNode(name_idx).data.string_ref);
+        if (std.mem.eql(u8, name, "Props")) expected_last = stmt;
+    }
+
+    try std.testing.expect(expected_last != .none);
+    try std.testing.expectEqual(expected_last, r.index.get("Props").?);
+}
+
+test "TypeIndex: non-type top-level statements ignored" {
+    var r = try parseAndIndex(std.testing.allocator,
+        \\const x = 1;
+        \\function foo() {}
+        \\type Props = { color: string };
+        \\class Bar {}
+    );
+    defer r.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), r.index.count());
+    try std.testing.expect(r.index.get("Props") != null);
+    try std.testing.expect(r.index.get("x") == null);
+    try std.testing.expect(r.index.get("foo") == null);
+    try std.testing.expect(r.index.get("Bar") == null);
+}
+
+test "TypeIndex: empty program produces empty index" {
+    var r = try parseAndIndex(std.testing.allocator,
+        \\
+    );
+    defer r.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 0), r.index.count());
+    try std.testing.expect(r.index.get("Props") == null);
+}
+
+test "TypeIndex: nested type aliases not indexed" {
+    // 함수 안의 type alias 는 top-level 이 아니라 인덱싱 안 됨.
+    // (codegen spec 파일에선 이런 형태 안 나오지만 안전성 확인용)
+    var r = try parseAndIndex(std.testing.allocator,
+        \\function foo() {
+        \\  type Inner = string;
+        \\  return null;
+        \\}
+        \\type Outer = number;
+    );
+    defer r.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), r.index.count());
+    try std.testing.expect(r.index.get("Outer") != null);
+    try std.testing.expect(r.index.get("Inner") == null);
+}


### PR DESCRIPTION
## 요약

같은 파일 내 type alias / interface 선언을 **이름 → NodeIndex** 맵으로 인덱싱. codegen plugin 의 첫 패스에서 사용해 두 번째 패스 (#3 schema_builder) 가 NativeProps 같은 type reference 의 정의 노드를 lookup 할 수 있게 한다.

ohah/zts#2348 § 4 작업 분해의 **PR #2**. PR #1 (`feat(codegen): add schema data structures`, ca55aec7) 다음 단계.

## 구현

### 대상 태그 — `isTypeOnlyDeclaration()` 재사용 (drift-proof)

`Tag.isTypeOnlyDeclaration()` (`ast.zig:390`) 가 true 인 5 종 모두 처리:

| 태그 | extra layout |
| --- | --- |
| `ts_type_alias_declaration` | `[name, type_params, ty]` |
| `ts_interface_declaration` | `[name, type_params, extends_start, extends_len, body]` |
| `flow_type_alias_declaration` | `[name, type_params, value]` |
| `flow_interface_declaration` | `[name, type_params, extends_start, extends_len]` |
| `flow_opaque_type` | `[name, type_params, supertype, value]` |

5 종 모두 `data.extra[0] = name` (binding_identifier NodeIndex) 컨벤션이라 분기 단순. 새 type-only declaration 이 ast.zig 에 추가되면 같은 컨벤션 따라야 함 (현재 검증됨).

### API

```zig
pub const TypeIndex = struct {
    map: std.StringHashMapUnmanaged(NodeIndex) = .empty,

    pub fn deinit(self: *TypeIndex, alloc: std.mem.Allocator) void;
    pub fn get(self: *const TypeIndex, name: []const u8) ?NodeIndex;
    pub fn count(self: *const TypeIndex) usize;
};

pub fn build(
    ast: *const Ast,
    program_idx: NodeIndex,
    alloc: std.mem.Allocator,
) !TypeIndex;
```

- 중복 이름 → 마지막 정의가 이김 (codegen 은 단일 정의 가정)
- program 이 아닌 노드 / 손상된 AST → 빈 인덱스 반환 (silent skip)
- 에러 전파는 OOM 만

### 알려진 한계 — `export type` 인덱싱 안 됨

ZTS 파서 (`module.zig:885`) 가 type-only declaration 의 export wrapper 를 parse 시점에 program 에서 제거한다:

```zig
// module.zig parseExportDeclarationWithDecorators
const decl = try self.parseStatement();
if (decl.isNone()) return NodeIndex.none;
if (self.ast.getNode(decl).tag.isTypeOnlyDeclaration()) return NodeIndex.none;
```

따라서 `export type Foo = ...` 같은 형태는 program 에 도달하지 못해 인덱싱 안 됨. 실용 영향:
- RN core 의 NativeComponent spec 은 보통 unhindered `type NativeProps = ...` 사용 → 영향 없음
- 일부 라이브러리가 `export type NativeProps = ...` 쓰면 schema_builder (#3) 가 fail-fast → Bungae 가 JS fallback 으로 처리

테스트로 한계 명시 (\"known limitation\" 케이스 2 개).

## Lifetime

키 (이름) 는 `Ast.string_table` 또는 source buffer 의 슬라이스 — **dupe 안 함**. 호출자는 이 인덱스 사용 중 ast (및 backing source) 가 유효해야 한다. arena 패턴 권장 (#CLAUDE.md \"Memory ownership\"):

```zig
var arena = std.heap.ArenaAllocator.init(gpa.allocator());
defer arena.deinit();
const alloc = arena.allocator();

var index = try type_index.build(&parser.ast, program_idx, alloc);
// arena 살아있는 동안 index.get() 안전. arena.deinit() 시 일괄 해제.
```

## 테스트 (13 개)

- TS / Flow type alias 인식 (4 케이스)
- TS / Flow interface 인식 (2 케이스)
- Flow opaque type 인식 (1 케이스)
- 다중 declaration 인식 + 비-type 무시
- Generic type alias (이름만 인덱싱)
- 중복 이름 → 마지막 정의 (program 직접 walk 로 NodeIndex 대조)
- 빈 program / nested 함수 안의 type alias 무시 (top-level only)
- `export type` / `export interface` parse-time drop 한계 검증

`zig build test -Dtest-filter=TypeIndex` 통과. 전체 `zig build test` 통과.

## 부차

- `src/transformer/plugins/codegen/mod.zig` 신규 — codegen 서브디렉토리 진입점, schema + type_index re-export + test 등록
- `src/transformer/mod.zig` — codegen mod 테스트 import 한 줄 추가

## Zig 초보자용 메모

### `union(enum)` switch 가드 vs `isTypeOnlyDeclaration()`

처음엔 nameOfDecl 안에서 5 종 태그를 직접 switch 했는데, `Tag.isTypeOnlyDeclaration()` 이 이미 같은 정의를 갖고 있어서 그걸 가드로 사용하는 형태로 단순화:

```zig
// before
switch (node.tag) {
    .ts_type_alias_declaration, .ts_interface_declaration, ... => {},
    else => return null,
}
// after
if (!node.tag.isTypeOnlyDeclaration()) return null;
```

장점: ast.zig 에 새 type-only declaration 이 추가되면 자동으로 포함 (단, `extra[0] = name` 컨벤션 따라야 함).

### `StringHashMapUnmanaged`

\"Unmanaged\" 는 자기가 allocator 를 들고 있지 않다는 뜻. 메서드 호출 시마다 alloc 명시. arena 사용 시 deinit 안 불러도 OK.

```zig
var map: std.StringHashMapUnmanaged(NodeIndex) = .empty;
try map.put(alloc, \"key\", value); // alloc 매번 명시
```

## 후속 PR

- **PR #3** (~2일): `schema_builder.zig` — TypeIndex 사용해 NativeProps body 의 ObjectType properties → ComponentShape
- PR #4-7 은 #2348 § 4 참고

## 관련

- ohah/zts#2348 — meta: `@react-native/codegen` ZTS native 분석 & 플랜
- ca55aec7 — PR #1 (Schema 데이터 구조), 본 PR 의 prerequisite