### PR TITLE
refactor(shared): extract isPlainObject helper from 3 inline guards

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -24,10 +24,11 @@ import {
   buildOptionsJson,
   ES_TARGET_BITS,
   browserslistToUnsupported,
+  isPlainObject,
   validateTsConfigRaw,
 } from "../shared/index";
 
-export { validateTsConfigRaw };
+export { isPlainObject, validateTsConfigRaw };
 
 // ─── NAPI Module ───
 

--- a/packages/core/src/config-loader.ts
+++ b/packages/core/src/config-loader.ts
@@ -14,7 +14,7 @@ import { dirname, extname, join, resolve as pathResolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import type { BuildOptions } from "../index";
-import { init, transpile } from "../index";
+import { init, isPlainObject, transpile } from "../index";
 
 /**
  * config 객체 형태 — 모든 BuildOptions 의 부분 집합.
@@ -154,13 +154,13 @@ async function resolveConfigValue(
     return raw;
   }
   const result = await raw(env ?? defaultConfigEnv());
-  if (typeof result !== "object" || result === null || Array.isArray(result)) {
+  if (!isPlainObject(result)) {
     const got = Array.isArray(result) ? "array" : typeof result;
     throw new Error(
       `@zts/core: functional config must return an object (got ${got}) from ${absPath}`,
     );
   }
-  return result;
+  return result as UserConfig;
 }
 
 /**

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -19,6 +19,7 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { basename, join, resolve as pathResolve } from "node:path";
 
+import { isPlainObject } from "../index";
 import {
   type ConfigEnv,
   defaultConfigEnv,
@@ -156,7 +157,7 @@ export async function loadWorkspace(filePath: string, env?: ConfigEnv): Promise<
       }
       continue;
     }
-    if (e === null || typeof e !== "object" || Array.isArray(e)) {
+    if (!isPlainObject(e)) {
       throw new Error(
         `@zts/core: workspace[${i}] must be a string or object (got ${
           Array.isArray(e) ? "array" : e === null ? "null" : typeof e

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -166,6 +166,15 @@ export function targetToUnsupported(target?: Target): number {
 }
 
 /**
+ * value 가 plain object (non-null, 배열 아님) 인지 narrow.
+ * `JSON.parse` 결과나 동적 config 객체처럼 unknown shape 의 값을 `Record<string, unknown>`
+ * 으로 좁힐 때 사용. 함수형 config / workspace 항목 / tsconfigRaw 검증 등에서 공유.
+ */
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
  * `tsconfigRaw` 사용자 입력 사전 검증.
  *
  * NAPI (`napi_entry.zig` / `transpile.zig`) 는 raw parse 실패 시 silent fallback (빈 TsConfig)
@@ -182,7 +191,7 @@ export function validateTsConfigRaw(raw: string | undefined): void {
     const reason = err instanceof Error ? err.message : String(err);
     throw new Error(`failed to parse --tsconfig-raw: ${reason}`);
   }
-  if (!config || typeof config !== "object" || Array.isArray(config)) {
+  if (!isPlainObject(config)) {
     throw new Error("failed to parse --tsconfig-raw: expected a JSON object");
   }
 }


### PR DESCRIPTION
## 요약

PR #2356 의 /simplify 리뷰 (Code Reuse Review #2) 후속 cleanup.

`!value || typeof value !== "object" || Array.isArray(value)` 동치 가드가 세 곳에 미세한 표현 차이로 흩어져 있었음:

- `packages/shared/index.ts:185` — `validateTsConfigRaw` 안의 raw JSON 비-object 거부
- `packages/core/src/config-loader.ts:157` — 함수형 config 의 비-object 반환 거부
- `packages/core/src/workspace.ts:159` — workspace 항목의 비-object/배열/null 거부

세 곳 모두 동일한 의미라 `packages/shared/index.ts` 에 type guard 로 일원화.

## 변경

```ts
// packages/shared/index.ts
export function isPlainObject(value: unknown): value is Record<string, unknown> {
  return value !== null && typeof value === "object" && !Array.isArray(value);
}
```

- `packages/core/index.ts` 에서 reexport — JS API consumer 가 같은 type guard 사용 가능.
- 세 사용처는 `if (!isPlainObject(value))` 한 줄로 단순화.
- `config-loader.ts` 의 `return result;` 는 narrow 후 명시 `as UserConfig` cast 추가 — `Record<string, unknown>` 으로 좁힌 결과를 `UserConfig` 로 cast 해 type 일관성 유지 (런타임 동작 동일).

## 검증

- `bun test packages/core/index.test.ts` 369/369 통과 (JS API entry 영향 없음)
- `bun test packages/core/src/config-loader.test.ts packages/core/src/workspace.test.ts` 88/88 통과
- `bun run fmt:check` 통과
- pre-push hook (zig fmt + zig build test + oxlint + oxfmt) 통과

## 후속 (별개 PR)

- A1#5: `src/config.zig:298-318` 의 boolean 추출 7 회 반복 → `applyJsonBool` 헬퍼 (PR #2360 진행 중)
- A1#4: `napi_entry.zig` / `main.zig` / `tsconfig_merge.zig` 에 흩어진 jsx 매핑 통합 + `main.zig:818` vocab 섞임 latent bug
- A1#1: NAPI transpile 진입점에 자동 탐색 wiring (현재 JS 측 `autodiscoverTsConfig` 가 보정 중)
- 이슈 #2358: Zig 네이티브 CLI (`src/main.zig`) 의 manual tsconfig merge → `tsconfig_merge.merge` 통합

## 참고

- PR #2356 (머지됨): feat(tsconfig): merge raw + jsx in Zig
- 이전 PR #2359 는 잘못된 head branch 로 만들어져 close — 이 PR 이 대체.