### PR TITLE
refactor(tsconfig): wire NAPI transpile autodiscovery + drop JS-side helper

### DIFF
--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -365,29 +365,6 @@ function parseArgs(argv) {
   return opts;
 }
 
-// ─── tsconfig 자동 탐색 ───
-//
-// tsconfig 파싱/머지는 Zig (`src/tsconfig_merge.zig` + `TsConfig.parseFromString`/`loadFromPath`)
-// 가 단일 진실 원천. raw 입력 검증은 `@zts/core` 의 `validateTsConfigRaw` (JS API/CLI 공유) 가 담당.
-// 자동 탐색은 bundler NAPI 진입점이 자체 처리하지만 transpile 진입점은 안 해서, 모드 비대칭을 JS 가 보정.
-function autodiscoverTsConfig(opts) {
-  if (opts.tsconfigRaw !== undefined) return; // raw 가 file 무시 우선.
-  if (opts.project) return; // 사용자 명시.
-  const startDir =
-    opts.entryPoints.length > 0 ? dirname(resolve(opts.entryPoints[0])) : process.cwd();
-  let dir = startDir;
-  while (true) {
-    const candidate = join(dir, "tsconfig.json");
-    if (existsSync(candidate)) {
-      opts.project = candidate;
-      return;
-    }
-    const parent = dirname(dir);
-    if (parent === dir) return;
-    dir = parent;
-  }
-}
-
 // ─── 파일 출력 ───
 
 // realpathSync 가 throw 하면 (출력 파일은 보통 미존재) lexical resolve 로 fallback.
@@ -2640,8 +2617,6 @@ async function main() {
     // raw tsconfig 입력 사전 검증 — NAPI 가 silent fallback 이라 invalid 라도 진입은 가능,
     // 사용자 디버깅 편의를 위해 여기서 명시 에러로 실패시킨다.
     validateTsConfigRaw(opts.tsconfigRaw);
-    // bundler 진입점은 NAPI 가 자동 탐색하지만 transpile 진입점은 안 함 — JS 가 보정.
-    autodiscoverTsConfig(opts);
     init();
     const r = await dispatchBuild(opts, config, configEnv, dotenvVars);
     if (r.errors > 0) process.exit(1);

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -124,7 +124,7 @@ fn napiTranspile(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.nap
 
     const opts_json: []const u8 = if (argc > 2) (getStringArg(env, argv[2], opts_alloc) orelse "{}") else "{}";
 
-    const options = transpile_mod.optionsFromJson(opts_alloc, opts_json) catch {
+    const options = transpile_mod.optionsFromJson(opts_alloc, opts_json, filename) catch {
         return throwError(env, "invalid options JSON");
     };
 

--- a/packages/wasm/src/wasm_entry.zig
+++ b/packages/wasm/src/wasm_entry.zig
@@ -128,7 +128,6 @@ export fn transpile(
     else
         "{}";
 
-    // WASM 은 file 시스템 접근 불가 — entry_path null 로 자동 탐색 비활성.
     const options = transpile_mod.optionsFromJson(opts_alloc, opts_json, null) catch {
         setError("invalid options JSON");
         return 0;

--- a/packages/wasm/src/wasm_entry.zig
+++ b/packages/wasm/src/wasm_entry.zig
@@ -128,7 +128,8 @@ export fn transpile(
     else
         "{}";
 
-    const options = transpile_mod.optionsFromJson(opts_alloc, opts_json) catch {
+    // WASM 은 file 시스템 접근 불가 — entry_path null 로 자동 탐색 비활성.
+    const options = transpile_mod.optionsFromJson(opts_alloc, opts_json, null) catch {
         setError("invalid options JSON");
         return 0;
     };

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -261,9 +261,11 @@ pub fn applyTranspileSharedFields(
 
 /// JSON payload를 파싱해 `TranspileOptions`로 변환한다.
 /// allocator는 arena 권장 — 반환된 값의 문자열/슬라이스 수명을 책임진다.
+/// `findTsconfigUpward` / `loadFromPath` 가 dup 한 메모리도 같은 arena 가 reap.
 ///
 /// `entry_path` 가 non-null 이고 명시적 `tsconfigPath` 가 없으면, `dirname(entry_path)` 부터
 /// 위로 올라가며 `tsconfig.json` 을 자동 탐색한다 (esbuild/vite 식 zero-config).
+/// `entry_path` 가 디렉토리 부분이 없는 bare filename (예: `"input.ts"`) 이면 cwd 부터 탐색.
 /// 자동 탐색을 원치 않는 caller (예: file 시스템 접근이 없는 WASM) 는 `null` 을 전달.
 ///
 /// 오류: JSON 파싱 실패 / 알 수 없는 enum 문자열 → error 반환.

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -262,8 +262,16 @@ pub fn applyTranspileSharedFields(
 /// JSON payload를 파싱해 `TranspileOptions`로 변환한다.
 /// allocator는 arena 권장 — 반환된 값의 문자열/슬라이스 수명을 책임진다.
 ///
+/// `entry_path` 가 non-null 이고 명시적 `tsconfigPath` 가 없으면, `dirname(entry_path)` 부터
+/// 위로 올라가며 `tsconfig.json` 을 자동 탐색한다 (esbuild/vite 식 zero-config).
+/// 자동 탐색을 원치 않는 caller (예: file 시스템 접근이 없는 WASM) 는 `null` 을 전달.
+///
 /// 오류: JSON 파싱 실패 / 알 수 없는 enum 문자열 → error 반환.
-pub fn optionsFromJson(allocator: std.mem.Allocator, json: []const u8) !TranspileOptions {
+pub fn optionsFromJson(
+    allocator: std.mem.Allocator,
+    json: []const u8,
+    entry_path: ?[]const u8,
+) !TranspileOptions {
     const parsed = std.json.parseFromSliceLeaky(ConfigOptionsDto, allocator, json, .{ .ignore_unknown_fields = true }) catch return error.InvalidOptions;
 
     var opts: TranspileOptions = .{};
@@ -273,9 +281,9 @@ pub fn optionsFromJson(allocator: std.mem.Allocator, json: []const u8) !Transpil
     if (parsed.stopAfter) |v| opts.stop_after = v;
 
     // tsconfig 로드 + merge — JSON 에 명시적으로 설정된 값이 tsconfig 값을 덮어쓴다.
-    // raw 우선 (esbuild 동등): `tsconfigRaw` 가 있으면 file 기반 path 무시.
+    // raw 우선 (esbuild 동등): `tsconfigRaw` 가 있으면 file 기반 path / 자동 탐색 모두 무시.
     // raw 파싱 실패는 사용자 입력 에러로 명시적 propagate, file 실패는 ambient 라 silent.
-    // WASM 타겟은 file 시스템 접근 불가 — file 분기만 스킵 (raw 는 무관하게 동작).
+    // WASM 타겟은 file 시스템 접근 불가 — file/자동 탐색 분기 모두 스킵 (raw 는 무관하게 동작).
     const TsConfig = @import("config.zig").TsConfig;
     const tsconfig_merge = @import("tsconfig_merge.zig");
     const can_load_tsconfig_file = @import("builtin").os.tag != .wasi and @import("builtin").os.tag != .freestanding;
@@ -283,9 +291,17 @@ pub fn optionsFromJson(allocator: std.mem.Allocator, json: []const u8) !Transpil
         if (parsed.tsconfigRaw) |raw| {
             break :blk TsConfig.parseFromString(allocator, raw) catch return error.InvalidOptions;
         }
-        if (can_load_tsconfig_file) if (opts.tsconfig_path) |path| {
-            break :blk TsConfig.loadFromPath(allocator, path) catch TsConfig{};
-        };
+        if (can_load_tsconfig_file) {
+            // 명시 path > entry 디렉토리에서 위로 자동 탐색 (esbuild/vite 식 zero-config).
+            const resolved_path: ?[]const u8 = opts.tsconfig_path orelse find: {
+                const path = entry_path orelse break :find null;
+                const dir = std.fs.path.dirname(path) orelse ".";
+                break :find TsConfig.findTsconfigUpward(allocator, dir) catch null;
+            };
+            if (resolved_path) |p| {
+                break :blk TsConfig.loadFromPath(allocator, p) catch TsConfig{};
+            }
+        }
         break :blk TsConfig{};
     };
     // arena 가 ts._allocated_strings 도 reap — 개별 deinit 금지 (CLAUDE.md memory 가이드).


### PR DESCRIPTION
## 요약

PR #2356 의 /simplify 리뷰 (Code Reuse Review #1) 후속 cleanup.

bundler NAPI 진입점 (`napi_entry.zig:3438`) 은 entry 디렉토리 → cwd 까지 자동 탐색하지만 transpile NAPI 진입점은 안 했음. 모드 비대칭을 메우려 `zts.mjs::autodiscoverTsConfig` 가 JS 측에서 walk 후 `opts.project` 에 채워 NAPI 로 forward — JS 가 Zig 의 missing piece 를 외부에서 대신 처리.

이번 PR 은 `optionsFromJson` 자체가 자동 탐색을 책임지도록 옮김.

## 변경

- **`src/transpile.zig::optionsFromJson`** 시그니처에 `entry_path: ?[]const u8` 추가.
  - non-null + 명시 `tsconfigPath` 없음 → `dirname(entry_path)` 부터 위로 `findTsconfigUpward`. raw / 명시 path / 자동 탐색 모두 같은 분기에서 결정 후 `loadFromPath` 으로 머지.
- **`packages/core/src/napi_entry.zig:127`** (transpile NAPI) — caller 가 `filename` 인자 전달. 자동 탐색이 비로소 같은 진입점에서 작동.
- **`packages/wasm/src/wasm_entry.zig:131`** (WASM transpile) — `null` 전달. WASI stub 이 file syscall 을 어차피 실패시키므로 결과 동등하지만, 명시적 null 이 syscall 자체를 건너뛰어 깔끔. WASM bundler (`wasm_bundler_entry.zig`) 의 `VirtualFileSystem` 진입점은 `optionsFromJson` 미사용이라 무관.
- **`packages/core/bin/zts.mjs`** — `autodiscoverTsConfig` 함수 + `main()` 호출 제거. JS 측이 더 이상 tsconfig 위치 결정에 관여하지 않음.

## /simplify 적용 항목

- `entry_filename` → `entry_path` rename (`std.fs.path.dirname` 의 path 의도 명확화).
- WASM caller 가 null 전달하는 이유 한 줄 코멘트 추가.
- doc 코멘트의 "bundler 진입점은 자체 수행" 비교 부분 제거 — local contract 형태로 트림 (stale 위험 감소).

## 검증

- `zig build test` 통과
- `bun test packages/core/bin/zts.test.ts --test-name-pattern "tsconfig"` 29/29 통과 (자동 탐색 의존하는 "tsconfig 에 URL 이 포함된 문자열이 있어도 파싱 성공" 회귀 가드 포함)
- `bun test packages/core/index.test.ts --test-name-pattern "tsconfig|JSX"` 15/15 통과
- `bun run fmt:check`, `zig fmt --check` 모두 통과
- pre-push hook (zig fmt + zig build test + oxlint + oxfmt) 통과

## 후속 (별개 PR)

- `findTsconfigUpward` + path 결정 로직을 `transpile.zig` + `napi_entry.zig` 두 곳에서 공유 helper (`config.zig::resolveTsconfigPath`) 로 추출 — `main.zig` 는 fallback 의미가 달라 별도 유지.
- 다수 file `transpile()` 호출 시 ancestor walk 캐시 (per-NAPI-instance).
- A1#4 jsx mapper 통합 + `main.zig:818` vocab 섞임 latent bug.
- 이슈 #2358: Zig 네이티브 CLI 의 manual tsconfig merge → `tsconfig_merge.merge` 통합.

## 참고

- PR #2356 (머지됨): feat(tsconfig): merge raw + jsx in Zig
- PR #2360 (머지됨): refactor(config): extract applyJsonBool helper (A1#5)
- PR #2362 (머지됨): refactor(shared): extract isPlainObject helper (A1#2)