### PR TITLE
fix(cli): drop tsconfig vocab from --jsx CLI arg parser

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -812,10 +812,12 @@ fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator) !?C
         } else if (std.mem.eql(u8, arg, "--jsx-in-js")) {
             opts.jsx_in_js = true;
         } else if (std.mem.startsWith(u8, arg, "--jsx=")) {
+            // CLI vocab: automatic / automatic-dev / classic. tsconfig vocab ("react-jsx" /
+            // "react-jsxdev") 는 CLI 가 받지 않음 — tsconfig 파싱 (`tsconfig_merge`) 이 처리.
             const val = arg["--jsx=".len..];
             if (std.mem.eql(u8, val, "automatic")) {
                 opts.jsx_runtime = .automatic;
-            } else if (std.mem.eql(u8, val, "automatic-dev") or std.mem.eql(u8, val, "react-jsxdev")) {
+            } else if (std.mem.eql(u8, val, "automatic-dev")) {
                 opts.jsx_runtime = .automatic_dev;
             } else {
                 opts.jsx_runtime = .classic;


### PR DESCRIPTION
## 요약

PR #2356 의 /simplify 리뷰 (Code Reuse Review #4) 에서 발견된 latent bug 수정.

`src/main.zig` 의 `--jsx=` argv 파서가 CLI vocab 과 tsconfig vocab 을 한 분기에 섞어 받고 있었음:

```zig
} else if (std.mem.eql(u8, val, "automatic-dev") or std.mem.eql(u8, val, "react-jsxdev")) {
    opts.jsx_runtime = .automatic_dev;
}
```

`react-jsxdev` 는 `tsconfig.json` 의 `compilerOptions.jsx` 필드 값 (TS 공식 vocab) 이지 CLI 인자 형태가 아님. docs (`docs/CONFIG.md`, `docs/ROADMAP.md`) 와 NAPI 진입점 (`napi_entry.zig`) 모두 CLI vocab (`automatic` / `automatic-dev` / `classic`) 만 명시. 즉 dead path 면서 entry point 간 vocab 일관성을 깨는 latent bug.

## 변경

```zig
} else if (std.mem.startsWith(u8, arg, "--jsx=")) {
    // CLI vocab: automatic / automatic-dev / classic. tsconfig vocab ("react-jsx" /
    // "react-jsxdev") 는 CLI 가 받지 않음 — tsconfig 파싱 (`tsconfig_merge`) 이 처리.
    const val = arg["--jsx=".len..];
    if (std.mem.eql(u8, val, "automatic")) {
        opts.jsx_runtime = .automatic;
    } else if (std.mem.eql(u8, val, "automatic-dev")) {
        opts.jsx_runtime = .automatic_dev;
    } else {
        opts.jsx_runtime = .classic;
    }
}
```

vocab 책임 분리 의도를 코멘트로 명시.

## 검증

- repo 전역 grep — `--jsx=react-jsxdev` 형태 사용 **0건** (테스트/문서/예제 모두).
- `cli-flags.mjs:85` 의 `--jsx=` flag 가 enum 검증 없이 raw string 으로 받지만, 사용자가 `react-jsxdev` 를 의도적으로 CLI 에 넣었을 동기 없음 — breaking change 위험 무시할 수준.
- `src/main.zig:1998` 의 tsconfig 파일 파싱 분기는 그대로 — tsconfig 의 `jsx` 필드는 공식 TS vocab (`react-jsxdev`) 라 정당.
- `zig build test` 통과.
- `zig fmt --check`, pre-push hook 모두 통과.

## /simplify 리뷰 적용

처음 추가한 코멘트의 마지막 줄 (`NAPI 진입점과 동일한 vocab`) 은 stale 위험 (NAPI 가 변하면 거짓이 됨) — 약화/삭제 권고 받아 제거. 첫 두 줄 (vocab 분리 의도) 만 유지.

## 후속 (별개 PR)

- `napi_entry.zig:3309-3317` 의 jsx_str→enum 매핑이 tsconfig vocab 을 받으면 `.classic` 으로 silent fallback. JS API consumer 가 `{ jsx: "react-jsx" }` 식 옵션을 넘기면 의도치 않게 classic 으로 떨어짐 — 별도 fix 후보.
- main.zig + napi_entry.zig 의 jsx string→enum 매핑을 공유 helper (`codegen.zig::parseCliJsxRuntime`) 로 통합 — semantic split (비-옵셔널 vs 옵셔널) 때문에 trivial 하지 않아 보류.

## 참고

- PR #2356, #2360, #2362, #2363 — 같은 simplify 시리즈의 이전 follow-up PR (모두 머지됨).
- 이슈 #2358 — Zig 네이티브 CLI manual tsconfig merge → `tsconfig_merge.merge` 통합 (별개 큰 작업).