### PR TITLE
feat(parser): preserve TS property signature key/type/flags

### DIFF
--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -3309,3 +3309,161 @@ test "TS object type: computed key with member access `[ns.k]`" {
         \\interface A { [ns.k]: string; }
     , ".ts");
 }
+
+// ============================================================
+// TS property signature 의 key/type/flags 보존 (#2348 PR #3a-1)
+// ============================================================
+//
+// transformer 가 ts_property_signature 를 통째로 strip 하지만, codegen plugin
+// (#2348 § 4) 이 view config 빌드를 위해 key/type/flags 가 필요하므로 파서가
+// extras 에 보존한다. 본 테스트는 strip 동작 (transformer_test.zig) 과 별개로
+// 파서 단위에서 layout 이 올바른지 검증.
+
+const ts_mod = @import("ts.zig");
+
+/// 파싱 결과. Scanner / Parser 를 heap allocator 로 박아 안정된 주소 보장
+/// (`Parser` 가 `*Scanner` 포인터를 들고 있는데 stack 에 두면 함수 반환 시
+/// dangling — `transformer_test.zig:200` 와 동일 패턴).
+const ParsedTs = struct {
+    scanner: *Scanner,
+    parser: *Parser,
+    alloc: std.mem.Allocator,
+
+    fn deinit(self: *ParsedTs) void {
+        self.parser.deinit();
+        self.alloc.destroy(self.parser);
+        self.scanner.deinit();
+        self.alloc.destroy(self.scanner);
+    }
+};
+
+fn parseTs(alloc: std.mem.Allocator, source: []const u8) !ParsedTs {
+    const scanner = try alloc.create(Scanner);
+    errdefer alloc.destroy(scanner);
+    scanner.* = try Scanner.init(alloc, source);
+    errdefer scanner.deinit();
+
+    const parser = try alloc.create(Parser);
+    errdefer alloc.destroy(parser);
+    parser.* = Parser.init(alloc, scanner);
+    errdefer parser.deinit();
+
+    parser.configureFromExtension(".ts");
+    _ = try parser.parse();
+    try std.testing.expectEqual(@as(usize, 0), parser.errors.items.len);
+
+    return .{ .scanner = scanner, .parser = parser, .alloc = alloc };
+}
+
+/// 첫 번째 ts_property_signature 의 (key, type_ann, flags) 추출. 6 케이스 공통 setup.
+const PropSig = struct {
+    key: ast_mod.NodeIndex,
+    type_ann: ast_mod.NodeIndex,
+    flags: ts_mod.PropertySignatureFlags,
+};
+
+fn extractFirstPropSig(parser: *Parser) PropSig {
+    for (parser.ast.nodes.items) |node| {
+        if (node.tag != .ts_property_signature) continue;
+        const e = node.data.extra;
+        return .{
+            .key = @enumFromInt(parser.ast.extra_data.items[e]),
+            .type_ann = @enumFromInt(parser.ast.extra_data.items[e + 1]),
+            .flags = ts_mod.PropertySignatureFlags.fromU32(parser.ast.extra_data.items[e + 2]),
+        };
+    }
+    @panic("no ts_property_signature found in source");
+}
+
+test "TS property signature: preserves key + type + zero flags" {
+    var r = try parseTs(std.testing.allocator, "interface A { color: string }");
+    defer r.deinit();
+
+    const sig = extractFirstPropSig(r.parser);
+    try std.testing.expect(sig.key != .none);
+    try std.testing.expect(sig.type_ann != .none);
+    try std.testing.expectEqual(ts_mod.PropertySignatureFlags.NONE, sig.flags);
+
+    // parsePropertyKey 는 .identifier_reference 반환 (`expression.zig:1879`). type 은 ts_string_keyword.
+    try std.testing.expectEqual(Tag.identifier_reference, r.parser.ast.getNode(sig.key).tag);
+    try std.testing.expectEqual(Tag.ts_string_keyword, r.parser.ast.getNode(sig.type_ann).tag);
+}
+
+test "TS property signature: optional `?` sets flags.optional" {
+    var r = try parseTs(std.testing.allocator, "interface A { color?: string }");
+    defer r.deinit();
+
+    const sig = extractFirstPropSig(r.parser);
+    try std.testing.expect(sig.flags.optional);
+    try std.testing.expect(!sig.flags.readonly);
+}
+
+test "TS property signature: readonly sets flags.readonly" {
+    var r = try parseTs(std.testing.allocator, "interface A { readonly color: string }");
+    defer r.deinit();
+
+    const sig = extractFirstPropSig(r.parser);
+    try std.testing.expect(sig.flags.readonly);
+    try std.testing.expect(!sig.flags.optional);
+}
+
+test "TS property signature: readonly + optional both flags set" {
+    var r = try parseTs(std.testing.allocator, "interface A { readonly color?: string }");
+    defer r.deinit();
+
+    const sig = extractFirstPropSig(r.parser);
+    try std.testing.expect(sig.flags.optional);
+    try std.testing.expect(sig.flags.readonly);
+}
+
+test "TS property signature: missing type annotation has type_ann=none" {
+    // interface 의 `key;` 또는 `key?;` — 타입 어노테이션 없이도 유효.
+    var r = try parseTs(std.testing.allocator, "interface A { color }");
+    defer r.deinit();
+
+    const sig = extractFirstPropSig(r.parser);
+    try std.testing.expectEqual(ast_mod.NodeIndex.none, sig.type_ann);
+}
+
+test "TS property signature: type alias body preserves all members" {
+    var r = try parseTs(std.testing.allocator,
+        \\type Props = {
+        \\  color: string;
+        \\  size?: number;
+        \\  readonly disabled: boolean;
+        \\};
+    );
+    defer r.deinit();
+
+    var prop_count: usize = 0;
+    var seen_color = false;
+    var seen_size = false;
+    var seen_disabled = false;
+
+    for (r.parser.ast.nodes.items) |node| {
+        if (node.tag != .ts_property_signature) continue;
+        prop_count += 1;
+        const e = node.data.extra;
+        const key_idx: ast_mod.NodeIndex = @enumFromInt(r.parser.ast.extra_data.items[e]);
+        const flags = ts_mod.PropertySignatureFlags.fromU32(r.parser.ast.extra_data.items[e + 2]);
+
+        const key_node = r.parser.ast.getNode(key_idx);
+        const name = r.parser.ast.getText(key_node.data.string_ref);
+
+        if (std.mem.eql(u8, name, "color")) {
+            seen_color = true;
+            try std.testing.expectEqual(ts_mod.PropertySignatureFlags.NONE, flags);
+        } else if (std.mem.eql(u8, name, "size")) {
+            seen_size = true;
+            try std.testing.expect(flags.optional);
+        } else if (std.mem.eql(u8, name, "disabled")) {
+            seen_disabled = true;
+            try std.testing.expect(flags.readonly);
+        }
+    }
+
+    try std.testing.expectEqual(@as(usize, 3), prop_count);
+    try std.testing.expect(seen_color);
+    try std.testing.expect(seen_size);
+    try std.testing.expect(seen_disabled);
+}

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -1454,7 +1454,7 @@ fn parseTypeMember(self: *Parser) ParseError2!NodeIndex {
 
     // 6/7. 프로퍼티 이름 파싱 후 메서드 vs 프로퍼티 분기
     const key = try self.parsePropertyKey();
-    _ = try self.eat(.question); // optional
+    const is_optional = try self.eat(.question);
 
     // 6. 메서드 시그니처: 이름 뒤에 ( 또는 < 가 오면 메서드
     if (self.current() == .l_paren or self.isAtOpeningAngleBracket()) {
@@ -1481,21 +1481,55 @@ fn parseTypeMember(self: *Parser) ParseError2!NodeIndex {
         });
     }
 
-    // 7. 프로퍼티 시그니처: key: Type
+    // 7. 프로퍼티 시그니처: `key: Type` / `key?: Type` / `readonly key: Type` 등.
+    //
+    // extra layout: [key, type_ann, flags]
+    //   key       — property key NodeIndex (binding_identifier / string_literal / ...)
+    //   type_ann  — type annotation NodeIndex. `:` 없는 경우 (interface 의 `foo;`) 는 .none
+    //   flags     — `PropertySignatureFlags.toU32()` 로 직렬화된 비트필드
+    //
+    // transformer 는 ts_property_signature 를 통째로 strip 하므로 child_offsets 는 비워둠
+    // (`ast.zig` 참고). codegen plugin 은 manual indexing 으로 extras 를 읽어 view config
+    // 를 빌드한다 (#2348 § 4 PR #3b).
+    var type_ann: NodeIndex = NodeIndex.none;
     if (try self.eat(.colon)) {
-        _ = try parseType(self);
-        return try self.ast.addEmptyExtraNode(
-            .ts_property_signature,
-            .{ .start = start, .end = self.currentSpan().start },
-        );
+        type_ann = try parseType(self);
     }
 
-    // 타입 어노테이션 없는 프로퍼티 (예: interface에서 `foo;` 또는 `foo?;`)
-    return try self.ast.addEmptyExtraNode(
-        .ts_property_signature,
-        .{ .start = start, .end = self.currentSpan().start },
-    );
+    const flags: PropertySignatureFlags = .{
+        .optional = is_optional,
+        .readonly = is_readonly,
+    };
+
+    const extra = try self.ast.addExtras(&.{
+        @intFromEnum(key),
+        @intFromEnum(type_ann),
+        flags.toU32(),
+    });
+    return try self.ast.addNode(.{
+        .tag = .ts_property_signature,
+        .span = .{ .start = start, .end = self.currentSpan().start },
+        .data = .{ .extra = extra },
+    });
 }
+
+/// `ts_property_signature.extra[2]` 의 flags 비트필드.
+/// `TsTypeParamModifier` (line 422) 와 동일한 packed struct + toU32/fromU32 컨벤션.
+pub const PropertySignatureFlags = packed struct(u32) {
+    optional: bool = false,
+    readonly: bool = false,
+    _pad: u30 = 0,
+
+    pub const NONE: PropertySignatureFlags = .{};
+
+    pub fn toU32(self: PropertySignatureFlags) u32 {
+        return @bitCast(self);
+    }
+
+    pub fn fromU32(v: u32) PropertySignatureFlags {
+        return @bitCast(v);
+    }
+};
 
 /// 콜/컨스트럭트 시그니처 공통 파싱
 /// 콜: (): Type, <T>(): Type


### PR DESCRIPTION
## 요약

`ts_property_signature` 가 parse 시점에 property key + type annotation 을 폐기하던 **strip-only 동작 root-cause fix**. 변경 후 extras 에 `[key, type_ann, flags]` 형태로 보존.

ohah/zts#2348 의 codegen plugin (view config 인라이닝) 이 NativeProps 의 prop 정의를 읽기 위한 prerequisite. 자세한 결정 배경은 #2348 코멘트 참고.

## 변경 전후

**Before** (`ts.zig:1456-1497`):
```zig
const key = try self.parsePropertyKey();
_ = try self.eat(.question);  // optional 플래그 폐기
// ...
if (try self.eat(.colon)) {
    _ = try parseType(self);  // type annotation 폐기
    return addEmptyExtraNode(.ts_property_signature, span);
}
return addEmptyExtraNode(.ts_property_signature, span);
```

**After**:
```zig
const key = try self.parsePropertyKey();
const is_optional = try self.eat(.question);
// ...
var type_ann: NodeIndex = NodeIndex.none;
if (try self.eat(.colon)) {
    type_ann = try parseType(self);
}
const flags: PropertySignatureFlags = .{
    .optional = is_optional,
    .readonly = is_readonly,  // 기존 변수, 위에서 이미 capture
};
const extra = try self.ast.addExtras(&.{
    @intFromEnum(key),
    @intFromEnum(type_ann),
    flags.toU32(),
});
return addNode(.ts_property_signature, span, .{ .extra = extra });
```

## 새 타입: PropertySignatureFlags

`TsTypeParamModifier` (`ts.zig:422`) 와 동일한 packed struct + toU32/fromU32 컨벤션:

```zig
pub const PropertySignatureFlags = packed struct(u32) {
    optional: bool = false,
    readonly: bool = false,
    _pad: u30 = 0,

    pub const NONE: PropertySignatureFlags = .{};
    pub fn toU32(self) u32 { return @bitCast(self); }
    pub fn fromU32(v: u32) PropertySignatureFlags { return @bitCast(v); }
};
```

소비자는 `PropertySignatureFlags.fromU32(extra_data[i+2])` 로 읽음.

## 다운스트림 영향: 0

ts_property_signature 의 기존 소비자 검증:

| 위치 | 어떻게 사용 | body 보존 영향 |
| --- | --- | --- |
| `transformer/transformer.zig:4799` | strip 대상 리스트의 일원 (`=> true`). 노드 자체를 통째로 삭제 — body 구조 안 읽음 | 무관 |
| `semantic/analyzer.zig:1604` | generic `visitTypeContextNode` 마커로만 사용 | 무관 |

`ast.zig` 의 `getLayout` 에서 `child_offsets = &.{}` 유지 — walker (`ast_walk.ChildIterator`) 가 type body 를 **자동 traverse 하지 않도록** 의도적. 소비자는 manual indexing 으로 extras 를 읽는다.

## 테스트 6 개 (`parser_test.zig` 말미)

```
TS property signature: preserves key + type + zero flags
TS property signature: optional `?` sets flags.optional
TS property signature: readonly sets flags.readonly
TS property signature: readonly + optional both flags set
TS property signature: missing type annotation has type_ann=none
TS property signature: type alias body preserves all members
```

`parseTs(source) → !Parser` 헬퍼 + `extractFirstPropSig(parser) → PropSig` 헬퍼로 6 케이스 공통 setup 묶음. 마지막 테스트는 multi-property body 파싱 + 각 멤버 플래그 검증.

`zig build test -Dtest-filter=\"property signature\"` 통과 확인. 전체 `zig build test` 도 검증 (CI).

## Zig 초보자용 메모

### `packed struct(u32)` = 정확히 N 비트 비트필드

`packed` + 명시 비트수 = 메모리 layout 이 strict bit-packing 됨:
```zig
const flags = PropertySignatureFlags{ .optional = true, .readonly = false };
const raw = flags.toU32();  // = 0b01 = 1
```

`@bitCast` 로 u32 ↔ struct 무비용 변환.

### `is_optional = try self.eat(.question)`

`Parser.eat(kind: Kind) !bool` — 토큰이 매칭되면 소비 + true, 아니면 false. 기존엔 `_ = try self.eat(.question);` 로 결과 폐기 (사이드이펙트만 사용). 변경 후 결과를 `is_optional` 로 capture.

### Extras layout 컨벤션

ZTS 의 다른 노드들 (`ts_type_alias_declaration`, `ts_method_signature` 등) 모두 `addExtras(&.{...})` 패턴 사용. `data.extra` 는 첫 슬롯 인덱스, 후속 슬롯들은 그 옆에 연속 저장:
```
extra_data: [..., key_idx, type_ann_idx, flags_u32, ...]
                  ^
                  data.extra 가 가리킴
```

읽을 땐 `extra_data.items[node.data.extra + N]` 로 N 번째 슬롯 접근.

## 의도적 미적용 (이번 PR 스코프 밖)

- **Flow object body**: `flow_literal_type` / `flow_exact_object_type` 도 동일한 strip-only 문제 있음 (brace-skip). 별도 PR (#3a-2) 로 분리 — Flow 는 brace-skip 제거 + 새 `parseFlowTypeMember` 작성 필요해서 스코프 큼.
- **Array element type 보존** (`ts_array_type` / `flow_array_type` 의 `T[]` 형태): 사용자에게 `Array<T>` / `ReadonlyArray<T>` (이미 `*_type_reference` 로 보존됨) 권장. 향후 별도 PR 가능.
- **다른 signature 변형**: `ts_method_signature`, `ts_call_signature`, `ts_construct_signature`, `ts_index_signature`, `ts_getter_signature`, `ts_setter_signature` — codegen 미사용. 일부는 이미 `key`/`params`/`return_type` 보존하고 있음 (`ts.zig:1376-1385`, `1469-1480`).

## 관련

- ohah/zts#2348 — meta: `@react-native/codegen` ZTS native (분석 + root-cause 결정)
- ca55aec7 — PR #1 (Schema 데이터 구조)
- a5bb6984 — PR #2 (Type alias / interface indexer)