### PR TITLE
refactor(config): extract autodiscoverFromEntry helper

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -3435,12 +3435,9 @@ fn parseBuildOptions(
     var autodiscovered_dir: ?[]const u8 = null;
     defer if (autodiscovered_dir) |d| native_alloc.free(d);
     const tsconfig_path_opt: ?[]const u8 = if (tsconfig_raw != null) null else tsconfig_path_js orelse blk: {
-        // entry 가 하나라도 있으면 그 디렉토리 기준, 없으면 CWD 기준으로 탐색.
-        const start_dir: []const u8 = if (entries.len > 0)
-            std.fs.path.dirname(entries[0]) orelse "."
-        else
-            ".";
-        autodiscovered_dir = TsConfig.findTsconfigUpward(native_alloc, start_dir) catch null;
+        // entry 가 하나라도 있으면 그 dirname 기준, 없으면 cwd ("." → dirname → ".") 부터 탐색.
+        const start_path: []const u8 = if (entries.len > 0) entries[0] else ".";
+        autodiscovered_dir = TsConfig.autodiscoverFromEntry(native_alloc, start_path);
         break :blk autodiscovered_dir;
     };
     if (tsconfig_raw) |raw| {

--- a/src/config.zig
+++ b/src/config.zig
@@ -151,6 +151,15 @@ pub const TsConfig = struct {
         }
     }
 
+    /// `entry_path` (file or dir) 의 dirname 부터 위로 올라가며 첫 `tsconfig.json` 을 찾는다.
+    /// `findTsconfigUpward` 의 entry-path 친화 wrapper — `dirname(entry_path) orelse "."`
+    /// 정규화 + 실패 시 silent null. 디렉토리 부분이 없는 bare filename 이면 cwd 부터 탐색.
+    /// 결과는 directory string (caller 가 `allocator.free`). NAPI / transpile 진입점 공유.
+    pub fn autodiscoverFromEntry(allocator: std.mem.Allocator, entry_path: []const u8) ?[]const u8 {
+        const dir = std.fs.path.dirname(entry_path) orelse ".";
+        return findTsconfigUpward(allocator, dir) catch null;
+    }
+
     /// 특정 파일명으로 tsconfig를 로드한다 (extends 체인에서 사용).
     /// depth: extends 재귀 깊이 (무한 루프 방지, 최대 10단계)
     fn loadFile(

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -297,8 +297,7 @@ pub fn optionsFromJson(
             // 명시 path > entry 디렉토리에서 위로 자동 탐색 (esbuild/vite 식 zero-config).
             const resolved_path: ?[]const u8 = opts.tsconfig_path orelse find: {
                 const path = entry_path orelse break :find null;
-                const dir = std.fs.path.dirname(path) orelse ".";
-                break :find TsConfig.findTsconfigUpward(allocator, dir) catch null;
+                break :find TsConfig.autodiscoverFromEntry(allocator, path);
             };
             if (resolved_path) |p| {
                 break :blk TsConfig.loadFromPath(allocator, p) catch TsConfig{};


### PR DESCRIPTION
## 요약

PR #2356 의 /simplify 리뷰 (Code Reuse Review #1) 후속 cleanup.

`entry_path → dirname orelse "." → findTsconfigUpward → silent null fallback` 의 3-line 정규화 패턴이 두 진입점에 중복:

- `src/transpile.zig::optionsFromJson` (PR #2363 에서 추가) — single optional path.
- `packages/core/src/napi_entry.zig::parseBuildOptions` — `entries[0]` or `"."` (cwd).

`TsConfig.autodiscoverFromEntry(allocator, entry_path: []const u8) ?[]const u8` 로 통합.

## 변경

```zig
/// `entry_path` (file or dir) 의 dirname 부터 위로 올라가며 첫 `tsconfig.json` 을 찾는다.
/// `findTsconfigUpward` 의 entry-path 친화 wrapper — `dirname(entry_path) orelse "."`
/// 정규화 + 실패 시 silent null. 디렉토리 부분이 없는 bare filename 이면 cwd 부터 탐색.
pub fn autodiscoverFromEntry(allocator: std.mem.Allocator, entry_path: []const u8) ?[]const u8 {
    const dir = std.fs.path.dirname(entry_path) orelse ".";
    return findTsconfigUpward(allocator, dir) catch null;
}
```

caller 단순화:
- **transpile.zig**: `entry_path orelse null → autodiscoverFromEntry`.
- **napi_entry.zig**: `entries[0] orelse "." → autodiscoverFromEntry` (cwd fallback).

allocator 는 caller 가 결정 — transpile 은 arena (auto-reap), napi_entry 는 native_alloc + 명시 `defer free`.

## 검증

- `zig build test` 통과
- `bun test packages/core/bin/zts.test.ts --test-name-pattern "tsconfig"` 29/29 통과
- `bun test packages/core/index.test.ts --test-name-pattern "tsconfig|JSX"` 15/15 통과
- `zig fmt --check`, `bun run fmt:check`, pre-push hook 통과
- /simplify 3-in-1 리뷰: NEW 발견 없음 (LGTM verdict). napi_entry 의 `"."` placeholder 위 코멘트는 이미 cwd 의미 설명.

## 후속 (별개 PR)

- `src/main.zig:1946-1957` 의 같은 패턴은 fallback semantic 차이 (`autodiscovered_dir orelse entry_dir_start`) 로 helper 단순 적용 어려움. 이슈 #2358 의 main.zig 통합 작업에서 helper 시그니처 재검토.
- 풀 `resolveTsconfigPath(allocator, explicit, entry_path)` 통합 — allocator policy (arena vs native_alloc + defer free) 차이로 별도 디자인 작업.
- 다수 file `transpile()` 호출 시 ancestor walk 캐시 — perf refactor.

## 참고

- PR #2356, #2360, #2362, #2363, #2364 — 같은 simplify 시리즈 (모두 머지됨).
- 이슈 #2358 — Zig 네이티브 CLI manual tsconfig merge cleanup (별개 큰 작업).