### PR TITLE
refactor(cli): consolidate manual tsconfig merge into tsconfig_merge + wire --tsconfig-raw

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1976,8 +1976,10 @@ pub fn main() !void {
     var resolved_paths: lib.config.ResolvedPaths = .{ .entries = &.{}, .owned_strings = &.{} };
     defer resolved_paths.deinit(allocator);
 
-    // ExplicitFlags 빌드 — CLI 가 명시 set 한 옵션만 non-null 로 전달, default 인 채 두면 null.
-    // jsx_factory/fragment/import_source 의 default ("React.createElement" 등) 는 explicit 미설정 의미.
+    // ExplicitFlags 빌드 — `?bool` 필드는 직접 forward, `bool` 필드 (sourcemap /
+    // emit_decorator_metadata) 는 truthy 일 때만 explicit 으로 전달 (default false 와 explicit false
+    // 구분 불가 — 기존 manual merge 의 한계 그대로 보존). jsx_factory/fragment/import_source 의
+    // default 문자열 ("React.createElement" 등) 도 explicit 미설정으로 간주.
     const merged = lib.tsconfig_merge.merge(&tsconfig, .{
         .experimental_decorators = opts.experimental_decorators,
         .emit_decorator_metadata = if (opts.emit_decorator_metadata) true else null,

--- a/src/main.zig
+++ b/src/main.zig
@@ -1940,23 +1940,35 @@ pub fn main() !void {
         return;
     }
 
-    // tsconfig.json 로드 — 번들/트랜스파일 양쪽에서 사용.
-    // 우선순위: --project/--tsconfig-path 경로 > entry 디렉토리에서 상위로 자동 탐색 > CWD
-    // loadFromPath 는 파일/디렉토리 둘 다 받으므로 `-p ./tsconfig.json` 도 동작.
+    // tsconfig 로드 + 머지 — 번들/트랜스파일 양쪽에서 사용.
+    // 우선순위 (esbuild 동등): --tsconfig-raw inline JSON > --project/--tsconfig-path 경로
+    //                       > entry 디렉토리에서 상위로 자동 탐색.
+    // 머지 규칙은 `lib.tsconfig_merge.merge` 의 공용 helper — NAPI/transpile 진입점과 일관.
     const entry_dir_start: []const u8 = if (opts.input_file) |inp|
         if (!std.mem.eql(u8, inp, "-")) (std.fs.path.dirname(inp) orelse ".") else "."
     else
         ".";
     var autodiscovered_dir: ?[]const u8 = null;
     defer if (autodiscovered_dir) |d| allocator.free(d);
-    const tsconfig_dir_early: []const u8 = if (opts.project_path) |pp|
-        pp
-    else blk: {
-        // esbuild/vite 스타일 zero-config: entry 디렉토리에서 위로 올라가며 tsconfig.json 탐색.
-        autodiscovered_dir = TsConfig.findTsconfigUpward(allocator, entry_dir_start) catch null;
-        break :blk autodiscovered_dir orelse entry_dir_start;
+    // raw 가 있으면 file 기반 path 무시 (paths/baseUrl 도 base 디렉토리 미정이라 skip).
+    const tsconfig_dir_for_paths: ?[]const u8 = blk: {
+        if (opts.tsconfig_raw != null) break :blk null;
+        if (opts.project_path) |pp| break :blk pp;
+        autodiscovered_dir = TsConfig.autodiscoverFromEntry(allocator, entry_dir_start);
+        break :blk autodiscovered_dir;
     };
-    var tsconfig = TsConfig.loadFromPath(allocator, tsconfig_dir_early) catch TsConfig{};
+    var tsconfig: TsConfig = blk: {
+        if (opts.tsconfig_raw) |raw| {
+            break :blk TsConfig.parseFromString(allocator, raw) catch {
+                try stderr.print("zts: failed to parse --tsconfig-raw\n", .{});
+                std.process.exit(1);
+            };
+        }
+        if (tsconfig_dir_for_paths) |p| {
+            break :blk TsConfig.loadFromPath(allocator, p) catch TsConfig{};
+        }
+        break :blk TsConfig{};
+    };
     defer tsconfig.deinit();
 
     // tsconfig `paths` 를 resolver 용 절대 경로 형태로 정규화. main 함수 끝까지 유지해야
@@ -1964,7 +1976,34 @@ pub fn main() !void {
     var resolved_paths: lib.config.ResolvedPaths = .{ .entries = &.{}, .owned_strings = &.{} };
     defer resolved_paths.deinit(allocator);
 
-    // tsconfig 값 적용 — CLI 옵션이 우선, 미지정 옵션만 tsconfig에서 가져옴
+    // ExplicitFlags 빌드 — CLI 가 명시 set 한 옵션만 non-null 로 전달, default 인 채 두면 null.
+    // jsx_factory/fragment/import_source 의 default ("React.createElement" 등) 는 explicit 미설정 의미.
+    const merged = lib.tsconfig_merge.merge(&tsconfig, .{
+        .experimental_decorators = opts.experimental_decorators,
+        .emit_decorator_metadata = if (opts.emit_decorator_metadata) true else null,
+        .use_define_for_class_fields = opts.use_define_for_class_fields,
+        .verbatim_module_syntax = opts.verbatim_module_syntax,
+        .sourcemap = if (opts.sourcemap) true else null,
+        .es_target = opts.es_target,
+        .unsupported = if (@as(u32, @bitCast(opts.unsupported)) != 0) opts.unsupported else null,
+        .jsx_runtime = opts.jsx_runtime,
+        .jsx_factory = if (std.mem.eql(u8, opts.jsx_factory, "React.createElement")) null else opts.jsx_factory,
+        .jsx_fragment = if (std.mem.eql(u8, opts.jsx_fragment, "React.Fragment")) null else opts.jsx_fragment,
+        .jsx_import_source = if (std.mem.eql(u8, opts.jsx_import_source, "react")) null else opts.jsx_import_source,
+    });
+    opts.experimental_decorators = merged.experimental_decorators;
+    opts.emit_decorator_metadata = merged.emit_decorator_metadata;
+    opts.use_define_for_class_fields = merged.use_define_for_class_fields;
+    opts.verbatim_module_syntax = merged.verbatim_module_syntax;
+    opts.sourcemap = merged.sourcemap;
+    opts.es_target = merged.es_target;
+    opts.unsupported = merged.unsupported;
+    opts.jsx_runtime = merged.jsx_runtime;
+    opts.jsx_factory = merged.jsx_factory;
+    opts.jsx_fragment = merged.jsx_fragment;
+    opts.jsx_import_source = merged.jsx_import_source;
+
+    // main.zig 만의 inline 분기 — `tsconfig_merge` 가 처리하지 않는 필드 (module_format, output_dir).
     if (opts.module_format == .esm) {
         if (tsconfig.module) |mod| {
             if (std.ascii.eqlIgnoreCase(mod, "commonjs")) {
@@ -1972,56 +2011,24 @@ pub fn main() !void {
             }
         }
     }
-    if (!opts.sourcemap and tsconfig.source_map) {
-        opts.sourcemap = true;
-    }
     if (opts.output_dir == null) {
         if (tsconfig.out_dir) |od| {
             opts.output_dir = od;
         }
     }
-    if (opts.experimental_decorators == null and tsconfig.experimental_decorators) {
-        opts.experimental_decorators = true;
-    }
-    // emitDecoratorMetadata는 experimentalDecorators가 활성화된 경우에만 유효
-    if (tsconfig.emit_decorator_metadata and (opts.experimental_decorators orelse false)) {
-        opts.emit_decorator_metadata = true;
-    }
-    // verbatimModuleSyntax: CLI가 명시적 override하지 않았으면 tsconfig 값 사용.
-    if (opts.verbatim_module_syntax == null and tsconfig.verbatim_module_syntax) {
-        opts.verbatim_module_syntax = true;
-    }
-    // JSX: CLI/플랫폼 프리셋이 미지정이면 tsconfig에서 가져옴
-    if (opts.jsx_runtime == null) {
-        if (tsconfig.jsx) |jsx_mode| {
-            if (std.mem.eql(u8, jsx_mode, "react-jsx") or std.mem.eql(u8, jsx_mode, "react-jsxdev")) {
-                opts.jsx_runtime = if (std.mem.eql(u8, jsx_mode, "react-jsxdev")) .automatic_dev else .automatic;
-            }
-        }
-    }
-    // JSX 최종 fallback: CLI/플랫폼/tsconfig 어디서도 지정하지 않으면 classic
-    if (opts.jsx_runtime == null) {
-        opts.jsx_runtime = .classic;
-    }
-    if (std.mem.eql(u8, opts.jsx_factory, "React.createElement")) {
-        opts.jsx_factory = tsconfig.jsx_factory;
-    }
-    if (std.mem.eql(u8, opts.jsx_fragment, "React.Fragment")) {
-        opts.jsx_fragment = tsconfig.jsx_fragment_factory;
-    }
-    if (std.mem.eql(u8, opts.jsx_import_source, "react")) {
-        opts.jsx_import_source = tsconfig.jsx_import_source;
-    }
 
     // tsconfig `paths` / `baseUrl` → resolver 의 `ts_paths` 로 전달.
-    // TS 스펙: 다중 candidate + wildcard anywhere + 후보 순차 시도를 resolver 가 수행한다.
+    // raw 분기 (tsconfig_dir_for_paths == null) 는 base 디렉토리 미정이라 skip — esbuild 동등.
+    // TS 스펙: 다중 candidate + wildcard anywhere + 후보 순차 시도를 resolver 가 수행.
     // 사용자 `--alias` 는 alias 경로로 계속 처리 — 둘은 독립이며 paths 가 먼저 매칭된다.
     if (tsconfig.paths.len > 0) {
-        const dir_for_join = lib.config.tsconfigDirFromPath(tsconfig_dir_early);
-        resolved_paths = lib.config.resolveTsPaths(allocator, dir_for_join, &tsconfig) catch |err| blk: {
-            try stderr.print("zts: warning: tsconfig paths resolution failed: {}\n", .{err});
-            break :blk lib.config.ResolvedPaths{ .entries = &.{}, .owned_strings = &.{} };
-        };
+        if (tsconfig_dir_for_paths) |dir_str| {
+            const dir_for_join = lib.config.tsconfigDirFromPath(dir_str);
+            resolved_paths = lib.config.resolveTsPaths(allocator, dir_for_join, &tsconfig) catch |err| blk: {
+                try stderr.print("zts: warning: tsconfig paths resolution failed: {}\n", .{err});
+                break :blk lib.config.ResolvedPaths{ .entries = &.{}, .owned_strings = &.{} };
+            };
+        }
     }
 
     // --bundle


### PR DESCRIPTION
## 요약

이슈 #2358 해결.

PR #2356 가 NAPI / transpile 진입점에서 tsconfig 처리를 공용 helper (`src/tsconfig_merge.zig::merge`) 로 통일했지만 Zig 네이티브 CLI (`src/main.zig`) 는 두 가지 비대칭이 남아 있었음:

1. tsconfig 값 적용이 `tsconfig_merge.merge` 호출 대신 **manual field-by-field if/orelse 체인** (~60 줄, line 1965-2014). NAPI / transpile 과 같은 우선순위 규칙을 두 표현으로 산재.
2. **`--tsconfig-raw=` argv 인자가 dead path** — `opts.tsconfig_raw` 에 set 만 되고 어디서도 읽히지 않음. Zig 네이티브 CLI 사용자가 inline JSON 을 줘도 silently 무시.

또한 `use_define_for_class_fields` 가 manual merge 에서 적용 누락 (잠재 bug) — `tsconfig_merge.merge` 통합으로 자동 fix.

## 변경

- 기존 `findTsconfigUpward` + `loadFromPath` + entry_dir fallback 패턴을 `TsConfig.autodiscoverFromEntry` (PR #2366) helper 로 단순화.
- **raw 분기 추가**: `opts.tsconfig_raw` 가 있으면 `parseFromString` 으로 inline JSON 만 사용해 file 기반 path / 자동 탐색 모두 무시 (esbuild 동등). 파싱 실패 시 `zts: failed to parse --tsconfig-raw` 로 명시 종료.
- manual merge → `lib.tsconfig_merge.merge` 한 호출로 교체. ExplicitFlags 빌드 시 `?bool` 필드는 직접 forward, `bool` 필드 (sourcemap / emit_decorator_metadata) 는 truthy-only (default-false vs explicit-false 구분 불가는 기존 한계 보존), jsx_* string 의 default 와의 일치 검사로 explicit-vs-default 판정.
- main.zig 만의 분기 — `module_format` (commonjs override) 와 `output_dir` (out_dir) — `tsconfig_merge` 가 다루지 않는 필드라 inline 유지.
- tsconfig paths/baseUrl 처리: raw 분기 (base 디렉토리 미정) 는 skip, file 기반에서만 resolve — esbuild 동등.

## 검증

### Spot-check (native CLI binary)

```bash
$ /tmp/proj/tsconfig.json: { compilerOptions: { jsx: "react-jsx", jsxImportSource: "preact" } }
$ /tmp/proj/jsx.tsx: export default () => <div>hello</div>;

# 자동 탐색
$ zts jsx.tsx
import { jsx as _jsx } from "preact/jsx-runtime";
export default () => _jsx("div", { children: "hello" });

# raw inline (이전엔 dead path 였던 게 살아남)
$ zts --tsconfig-raw='{"compilerOptions":{"jsx":"react-jsx","jsxImportSource":"preact"}}' jsx.tsx
import { jsx as _jsx } from "preact/jsx-runtime";
export default () => _jsx("div", { children: "hello" });
```

### CI

- `zig build` (native CLI binary) + `zig build test` 통과.
- `zig fmt --check`, pre-push hook 모두 통과.
- 일부 통합 테스트 fail (`batch-e-cli.test.ts:--tsconfig-raw`, `zts-config-bundler.test.ts:--inline-dynamic-imports` 등) 은 **base 에서도 같은 fail 재현** — pre-existing 환경 / flaky 이슈로 본 PR 변경과 무관 (직접 spot-check 으로 회귀 없음 확인).

### /simplify 3-in-1 리뷰

- ExplicitFlags 빌드 코멘트가 truthy-only 변환의 한계를 명확히 표현하도록 보완 (follow-up commit).
- 다른 NEW 발견 없음 — fatal 분기 패턴 / fallback 정리 / helper 일관성 모두 OK.

## 동작 변화 (요약)

| 항목 | 이전 | 이후 |
|---|---|---|
| `--tsconfig-raw=<json>` (Zig 네이티브 CLI) | dead path (무시됨) | esbuild 식 inline override 동작 |
| `use_define_for_class_fields` 적용 | manual merge 에서 누락 | `tsconfig_merge.merge` 가 처리 |
| 자동 탐색 fallback | `autodiscovered_dir orelse entry_dir` (1 추가 syscall, 빈 결과) | 자동 탐색 실패 시 즉시 빈 TsConfig (1 syscall 절감, 동작 동등) |
| paths/baseUrl 처리 (raw 시) | (raw 자체가 dead 라 적용 X) | base 디렉토리 미정 → skip (esbuild 동등) |

## 후속 (별개 PR)

- `bool` 필드 (`sourcemap`, `emit_decorator_metadata`) 의 default-false vs explicit-false 구분이 안 되는 한계 — `?bool` 로 변경 + ExplicitFlags forward 도 직접화.
- `@as(u32, @bitCast(opts.unsupported)) != 0` 패턴 (main.zig + napi_entry.zig 중복) → `compat.UnsupportedFeatures.isAny()` helper 로 통합.
- 다수 file `transpile()` 호출 시 ancestor walk 캐시 — 이슈 #2367 (보류 결정).

## 참고

- 이슈 #2358 — 본 PR 이 해결.
- PR #2356, #2360, #2362, #2363, #2364, #2366 — 같은 simplify 시리즈 (모두 머지됨).