### PR TITLE
feat(parser): preserve Flow object body members

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -357,8 +357,18 @@ pub const Node = struct {
         flow_as_expression,
         /// (expr: Type) — Flow TypeCast expression
         flow_type_cast_expression,
-        /// {| key: Type |} — Flow exact object type
+        /// `{ key: Type }` — Flow inexact object type. data = .list (members).
+        /// 각 멤버는 `flow_property_signature` (지원되지 않는 멤버는 skip).
+        /// `parseObjectType` 가 생성. PR #2348 § 4 (codegen) 가 멤버를 읽어 schema 빌드.
+        flow_object_type,
+        /// {| key: Type |} — Flow exact object type. data = .list (members).
         flow_exact_object_type,
+        /// Flow object type 의 단일 property — `[+|-]?key[?]: Type`.
+        /// extra = [key, type_ann, flags] (TS 의 `ts_property_signature` 와 동일 layout).
+        /// flags 는 `parser/ts.zig` 의 `PropertySignatureFlags` 사용 — Flow 의 `+key`
+        /// (covariant) 는 `flags.readonly = true` 로 매핑. `-key` (contravariant) 는
+        /// 현재 별도 비트 없음 (codegen 미사용, drop).
+        flow_property_signature,
         /// match (expr) { ... } — Flow match expression
         flow_match_expression,
         /// match expression 의 개별 arm: `pattern => body`. binary = { left=pattern,
@@ -612,6 +622,7 @@ pub const Node = struct {
                 .flow_union_type,
                 .flow_intersection_type,
                 .flow_tuple_type,
+                .flow_object_type,
                 .flow_exact_object_type,
                 .flow_type_parameter_declaration,
                 .flow_type_parameter_instantiation,
@@ -715,6 +726,7 @@ pub const Node = struct {
                 .flow_opaque_type,
                 .flow_interface_declaration,
                 .flow_match_expression,
+                .flow_property_signature,
                 => .{ .kind = .extra, .child_offsets = &.{} },
             };
         }

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -18,6 +18,7 @@ const VariableDeclarationKind = ast_mod.VariableDeclarationKind;
 const Span = @import("../lexer/token.zig").Span;
 const Parser = @import("parser.zig").Parser;
 const ParseError2 = @import("parser.zig").ParseError2;
+const PropertySignatureFlags = @import("ts.zig").PropertySignatureFlags;
 
 /// Flow 타입 키워드 → AST 태그 매핑.
 /// TS와 달리 mixed, empty가 추가되고, unknown/object/undefined/intrinsic는 없다.
@@ -372,9 +373,11 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
         .identifier => return parseTypeReference(self),
         // 괄호 타입: (Type) 또는 함수 타입: (a: Type) => Type
         .l_paren => return parseParenOrFunctionType(self),
-        // exact object type: {| key: Type |} 또는 일반 object type: { key: Type }
+        // exact object type: `{| key: Type |}` (또는 빈 `{||}`) vs 일반 object type: `{ key: Type }`.
+        // 빈 `{||}` 는 lexer 가 `||` 를 `pipe2` 단일 토큰으로 토크나이즈하므로 dispatch 시 pipe2 도 인식.
         .l_curly => {
-            if (try self.peekNextKind() == .pipe) {
+            const next = try self.peekNextKind();
+            if (next == .pipe or next == .pipe2) {
                 return parseExactObjectType(self);
             }
             return parseObjectType(self);
@@ -733,64 +736,192 @@ fn parseObjectType(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
     try self.advance(); // skip '{'
 
-    // balanced brace counting: 중첩된 { } 를 정확히 매칭
-    var depth: u32 = 1;
-    while (depth > 0 and self.current() != .eof) {
-        switch (self.current()) {
-            .l_curly => depth += 1,
-            .r_curly => depth -= 1,
-            else => {},
-        }
-        if (depth > 0) try self.advance();
-    }
-
+    const members = try parseFlowObjectMembers(self, .r_curly);
     try self.expect(.r_curly);
-    return try self.ast.addNode(.{
-        .tag = .flow_literal_type,
-        .span = .{ .start = start, .end = self.currentSpan().start },
-        .data = .{ .none = 0 },
-    });
+
+    return try self.ast.addListNode(
+        .flow_object_type,
+        .{ .start = start, .end = self.currentSpan().start },
+        members,
+    );
 }
 
-/// Exact object type: {| key: Type, ... |}
-/// balanced brace+pipe counting으로 전체를 소비. {| 뒤의 |} 까지.
+/// Exact object type: `{| key: Type, ... |}` (또는 빈 `{||}`).
+///
+/// 토크나이즈 주의:
+///   `{| ... |}` 는 `{`, `|`, ..., `|`, `}` (5+ 토큰) 로 분해
+///   `{||}` (빈) 는 `{`, `||`, `}` (3 토큰) — lexer 가 `||` 를 `pipe2` 단일 토큰으로 처리
+///
+/// 후자 케이스를 별도 분기로 처리.
 fn parseExactObjectType(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
     try self.advance(); // skip '{'
-    try self.advance(); // skip '|'
 
-    // |} 를 찾을 때까지 토큰 소비. 중첩된 {| |} 도 추적.
-    var depth: u32 = 1;
-    while (depth > 0 and self.current() != .eof) {
-        const loop_guard_pos = self.scanner.token.span.start;
-        if (self.current() == .l_curly) {
-            // {| 중첩 감지
-            if (try self.peekNextKind() == .pipe) {
-                depth += 1;
-                try self.advance(); // skip '{'
-                try self.advance(); // skip '|'
-                continue;
-            }
-        }
-        if (self.current() == .pipe) {
-            if (try self.peekNextKind() == .r_curly) {
-                depth -= 1;
-                try self.advance(); // skip '|'
-                try self.advance(); // skip '}'
-                if (depth == 0) break;
-                continue;
-            }
-        }
-        try self.advance();
-        if (try self.ensureLoopProgress(loop_guard_pos)) break;
+    // 빈 `{||}` — pipe2 한 토큰만 소비.
+    if (self.current() == .pipe2) {
+        try self.advance(); // skip '||'
+        try self.expect(.r_curly);
+        return try self.ast.addListNode(
+            .flow_exact_object_type,
+            .{ .start = start, .end = self.currentSpan().start },
+            .{ .start = 0, .len = 0 },
+        );
     }
 
-    // strip-only — 내부 멤버는 파싱 후 버리므로 빈 NodeList 저장 (layout=.list).
+    // 일반 케이스: `{|` 다음 멤버 다음 `|}`.
+    try self.expect(.pipe); // skip '|'
+    const members = try parseFlowObjectMembers(self, .pipe);
+    try self.expect(.pipe);
+    try self.expect(.r_curly);
+
     return try self.ast.addListNode(
         .flow_exact_object_type,
         .{ .start = start, .end = self.currentSpan().start },
-        .{ .start = 0, .len = 0 },
+        members,
     );
+}
+
+/// `{...}` / `{|...|}` 양쪽 공통: 멤버를 `,` 또는 `;` 구분으로 반복 파싱하다가
+/// `terminator` 토큰을 만나면 멈춘다 (caller 가 terminator 소비).
+///
+/// 지원되지 않는 멤버 (spread, indexer, method, call signature) 는 `parseFlowTypeMember`
+/// 가 토큰만 소비하고 `.none` 반환 — 여기선 list 에 추가하지 않음. codegen
+/// (#2348 PR #3b) 은 알려진 property 만 처리하면 됨.
+fn parseFlowObjectMembers(self: *Parser, terminator: Kind) ParseError2!ast_mod.NodeList {
+    const scratch_top = self.saveScratch();
+    while (self.current() != terminator and self.current() != .eof) {
+        const loop_guard_pos = self.scanner.token.span.start;
+        const member = try parseFlowTypeMember(self);
+        if (member != .none) try self.scratch.append(self.allocator, member);
+        // 멤버 구분자: `,` 또는 `;`. 둘 다 없으면 종료 (단, terminator 인 경우 자연 종료).
+        if (!try self.eat(.comma) and !try self.eat(.semicolon)) {
+            if (self.current() != terminator) break;
+        }
+        if (try self.ensureLoopProgress(loop_guard_pos)) break;
+    }
+    const items = self.scratch.items[scratch_top..];
+    const list = try self.ast.addNodeList(items);
+    self.restoreScratch(scratch_top);
+    return list;
+}
+
+/// Flow object type 의 단일 멤버 파싱.
+///
+/// 지원 (`flow_property_signature` 반환):
+///   - `key: Type`
+///   - `key?: Type`        — optional
+///   - `+key: Type`        — covariant (readonly mapping)
+///   - `-key: Type`        — contravariant (변환기/codegen 미사용, 비트 미설정)
+///   - `+key?: Type`       — combined
+///
+/// 미지원 (토큰만 소비, `.none` 반환):
+///   - `...Type`           — spread (PR #3b 에서 별도 처리)
+///   - `[key: T]: U`       — indexer
+///   - `key(args): R`      — method
+///   - `(args): R`         — call signature
+///   - `new (args): R`     — construct signature
+///
+/// 미지원 케이스도 정상 파싱돼야 type alias 전체 파싱이 진행됨 — 그래서 토큰 소비
+/// 후 `.none` 반환 (silent skip). caller 가 list 에서 제외.
+fn parseFlowTypeMember(self: *Parser) ParseError2!NodeIndex {
+    const start = self.currentSpan().start;
+
+    // Variance marker: `+key` covariant (output position) → readonly 등가로 매핑.
+    // `-key` contravariant (input position) → 현재 PropertySignatureFlags 에 별도 비트
+    // 없음, 무시 (codegen view config 미사용 — RN spec 에서 거의 안 쓰임).
+    //
+    // 의미 차이 주의: TS readonly = "재할당 불가", Flow `+` = "covariant" (반환만 가능).
+    // 출력 위치에서는 동등하게 read-only 처럼 동작하므로 동일 비트로 매핑 가능.
+    var is_readonly = false;
+    if (self.current() == .plus) {
+        is_readonly = true;
+        try self.advance();
+    } else if (self.current() == .minus) {
+        try self.advance();
+    }
+
+    // `...` 처리. 두 형태:
+    //   1. inexact marker: `{ name: T, ... }` — `...` 가 단독 (`}`/`|`/`,`/`;` 직전).
+    //   2. spread: `...Type` — `...` 다음에 type reference.
+    //
+    // spread 시 `parsePrimaryType` 사용 (full `parseType` 아님) — `...A` 이후의 `|`
+    // 을 union 으로 잘못 흡수하면 outer object type 의 `|}` 종료를 깨뜨림. spread 에는
+    // 보통 단순 type reference 만 와서 primary 로 충분.
+    if (self.current() == .dot3) {
+        try self.advance();
+        const next = self.current();
+        const is_terminator = next == .r_curly or next == .pipe or
+            next == .comma or next == .semicolon;
+        if (!is_terminator) {
+            _ = try parsePrimaryType(self);
+        }
+        return NodeIndex.none;
+    }
+
+    // Indexer (`[key: T]: U`) 또는 call/construct signature (`(args): R`) — skip.
+    if (self.current() == .l_bracket) {
+        try skipBalanced(self, .l_bracket, .r_bracket);
+        if (try self.eat(.colon)) _ = try parseType(self);
+        return NodeIndex.none;
+    }
+    if (self.current() == .l_paren) {
+        try skipBalancedParens(self);
+        if (try self.eat(.colon)) _ = try parseType(self);
+        return NodeIndex.none;
+    }
+
+    // Property key — identifier, keyword, 또는 quoted (`'aria-label'?: ?string`).
+    // Flow object body 에선 reserved keyword (`delete`, `class`, ...) 도 property
+    // 이름으로 허용되므로 `parseSimpleIdentifier` 의 `checkKeywordBinding` 검사를
+    // 우회 (`binding.zig:309` 가 reserved keyword 에 에러). 직접 노드 생성.
+    //
+    // 그 외 (`[computed]` / spread 등은 위에서 분기) → unknown — fail-safe skip.
+    const c = self.current();
+    const is_ident_like = c == .identifier or c == .escaped_keyword or
+        c == .escaped_strict_reserved or c.isKeyword();
+    const is_string_key = c == .string_literal;
+    if (!is_ident_like and !is_string_key) return NodeIndex.none;
+    const key_span = self.currentSpan();
+    try self.advance();
+    const key = try self.ast.addNode(.{
+        .tag = if (is_string_key) Tag.string_literal else Tag.binding_identifier,
+        .span = key_span,
+        .data = .{ .string_ref = key_span },
+    });
+
+    // method signature: `key(args): R` 또는 `key<T>(args): R` — skip.
+    // 제네릭 type parameter (`<T>`) 가 앞에 올 수 있으므로 angle bracket 도 감지.
+    if (self.isAtOpeningAngleBracket()) {
+        try skipBalanced(self, .l_angle, .r_angle);
+    }
+    if (self.current() == .l_paren) {
+        try skipBalancedParens(self);
+        if (try self.eat(.colon)) _ = try parseType(self);
+        return NodeIndex.none;
+    }
+
+    const is_optional = try self.eat(.question);
+
+    var type_ann: NodeIndex = NodeIndex.none;
+    if (try self.eat(.colon)) {
+        type_ann = try parseType(self);
+    }
+
+    const flags: PropertySignatureFlags = .{
+        .optional = is_optional,
+        .readonly = is_readonly,
+    };
+
+    const extra = try self.ast.addExtras(&.{
+        @intFromEnum(key),
+        @intFromEnum(type_ann),
+        flags.toU32(),
+    });
+    return try self.ast.addNode(.{
+        .tag = .flow_property_signature,
+        .span = .{ .start = start, .end = self.currentSpan().start },
+        .data = .{ .extra = extra },
+    });
 }
 
 // ================================================================

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -3321,15 +3321,15 @@ test "TS object type: computed key with member access `[ns.k]`" {
 
 const ts_mod = @import("ts.zig");
 
-/// 파싱 결과. Scanner / Parser 를 heap allocator 로 박아 안정된 주소 보장
-/// (`Parser` 가 `*Scanner` 포인터를 들고 있는데 stack 에 두면 함수 반환 시
-/// dangling — `transformer_test.zig:200` 와 동일 패턴).
-const ParsedTs = struct {
+/// 파싱 결과 — TS / Flow 공통. Scanner / Parser 를 heap allocator 로 박아 안정된
+/// 주소 보장 (`Parser` 가 `*Scanner` 포인터를 들고 있는데 stack 에 두면 함수 반환
+/// 시 dangling — `transformer_test.zig:200` 와 동일 패턴).
+const ParsedSource = struct {
     scanner: *Scanner,
     parser: *Parser,
     alloc: std.mem.Allocator,
 
-    fn deinit(self: *ParsedTs) void {
+    fn deinit(self: *ParsedSource) void {
         self.parser.deinit();
         self.alloc.destroy(self.parser);
         self.scanner.deinit();
@@ -3337,7 +3337,9 @@ const ParsedTs = struct {
     }
 };
 
-fn parseTs(alloc: std.mem.Allocator, source: []const u8) !ParsedTs {
+const ParseMode = enum { ts, flow };
+
+fn parseSource(alloc: std.mem.Allocator, source: []const u8, mode: ParseMode) !ParsedSource {
     const scanner = try alloc.create(Scanner);
     errdefer alloc.destroy(scanner);
     scanner.* = try Scanner.init(alloc, source);
@@ -3348,23 +3350,30 @@ fn parseTs(alloc: std.mem.Allocator, source: []const u8) !ParsedTs {
     parser.* = Parser.init(alloc, scanner);
     errdefer parser.deinit();
 
-    parser.configureFromExtension(".ts");
+    switch (mode) {
+        .ts => parser.configureFromExtension(".ts"),
+        .flow => parser.is_flow = true,
+    }
     _ = try parser.parse();
     try std.testing.expectEqual(@as(usize, 0), parser.errors.items.len);
 
     return .{ .scanner = scanner, .parser = parser, .alloc = alloc };
 }
 
-/// 첫 번째 ts_property_signature 의 (key, type_ann, flags) 추출. 6 케이스 공통 setup.
+fn parseTs(alloc: std.mem.Allocator, source: []const u8) !ParsedSource {
+    return parseSource(alloc, source, .ts);
+}
+
+/// 첫 번째 property signature 의 (key, type_ann, flags) 추출. TS / Flow 공통 layout.
 const PropSig = struct {
     key: ast_mod.NodeIndex,
     type_ann: ast_mod.NodeIndex,
     flags: ts_mod.PropertySignatureFlags,
 };
 
-fn extractFirstPropSig(parser: *Parser) PropSig {
+fn extractFirstPropSig(parser: *Parser, tag: Tag) PropSig {
     for (parser.ast.nodes.items) |node| {
-        if (node.tag != .ts_property_signature) continue;
+        if (node.tag != tag) continue;
         const e = node.data.extra;
         return .{
             .key = @enumFromInt(parser.ast.extra_data.items[e]),
@@ -3372,14 +3381,14 @@ fn extractFirstPropSig(parser: *Parser) PropSig {
             .flags = ts_mod.PropertySignatureFlags.fromU32(parser.ast.extra_data.items[e + 2]),
         };
     }
-    @panic("no ts_property_signature found in source");
+    std.debug.panic("BUG: test source has no node with tag {s}", .{@tagName(tag)});
 }
 
 test "TS property signature: preserves key + type + zero flags" {
     var r = try parseTs(std.testing.allocator, "interface A { color: string }");
     defer r.deinit();
 
-    const sig = extractFirstPropSig(r.parser);
+    const sig = extractFirstPropSig(r.parser, .ts_property_signature);
     try std.testing.expect(sig.key != .none);
     try std.testing.expect(sig.type_ann != .none);
     try std.testing.expectEqual(ts_mod.PropertySignatureFlags.NONE, sig.flags);
@@ -3393,7 +3402,7 @@ test "TS property signature: optional `?` sets flags.optional" {
     var r = try parseTs(std.testing.allocator, "interface A { color?: string }");
     defer r.deinit();
 
-    const sig = extractFirstPropSig(r.parser);
+    const sig = extractFirstPropSig(r.parser, .ts_property_signature);
     try std.testing.expect(sig.flags.optional);
     try std.testing.expect(!sig.flags.readonly);
 }
@@ -3402,7 +3411,7 @@ test "TS property signature: readonly sets flags.readonly" {
     var r = try parseTs(std.testing.allocator, "interface A { readonly color: string }");
     defer r.deinit();
 
-    const sig = extractFirstPropSig(r.parser);
+    const sig = extractFirstPropSig(r.parser, .ts_property_signature);
     try std.testing.expect(sig.flags.readonly);
     try std.testing.expect(!sig.flags.optional);
 }
@@ -3411,7 +3420,7 @@ test "TS property signature: readonly + optional both flags set" {
     var r = try parseTs(std.testing.allocator, "interface A { readonly color?: string }");
     defer r.deinit();
 
-    const sig = extractFirstPropSig(r.parser);
+    const sig = extractFirstPropSig(r.parser, .ts_property_signature);
     try std.testing.expect(sig.flags.optional);
     try std.testing.expect(sig.flags.readonly);
 }
@@ -3421,7 +3430,7 @@ test "TS property signature: missing type annotation has type_ann=none" {
     var r = try parseTs(std.testing.allocator, "interface A { color }");
     defer r.deinit();
 
-    const sig = extractFirstPropSig(r.parser);
+    const sig = extractFirstPropSig(r.parser, .ts_property_signature);
     try std.testing.expectEqual(ast_mod.NodeIndex.none, sig.type_ann);
 }
 
@@ -3466,4 +3475,207 @@ test "TS property signature: type alias body preserves all members" {
     try std.testing.expect(seen_color);
     try std.testing.expect(seen_size);
     try std.testing.expect(seen_disabled);
+}
+
+// ============================================================
+// Flow property signature 보존 (#2348 PR #3a-2)
+// ============================================================
+//
+// Flow object body 가 brace-skip 되던 동작을 실제 멤버 파싱으로 교체.
+// flow_property_signature 노드가 [key, type_ann, flags] 보존.
+
+fn parseFlow(alloc: std.mem.Allocator, source: []const u8) !ParsedSource {
+    return parseSource(alloc, source, .flow);
+}
+
+test "Flow property signature: preserves key + type + zero flags" {
+    var r = try parseFlow(std.testing.allocator,
+        \\type Props = { color: string };
+    );
+    defer r.deinit();
+
+    const sig = extractFirstPropSig(r.parser, .flow_property_signature);
+    try std.testing.expect(sig.key != .none);
+    try std.testing.expect(sig.type_ann != .none);
+    try std.testing.expectEqual(ts_mod.PropertySignatureFlags.NONE, sig.flags);
+
+    // parseSimpleIdentifier 는 .binding_identifier 반환 (binding.zig).
+    try std.testing.expectEqual(Tag.binding_identifier, r.parser.ast.getNode(sig.key).tag);
+    try std.testing.expectEqual(Tag.flow_string_keyword, r.parser.ast.getNode(sig.type_ann).tag);
+}
+
+test "Flow property signature: optional `?` sets flags.optional" {
+    var r = try parseFlow(std.testing.allocator,
+        \\type Props = { color?: string };
+    );
+    defer r.deinit();
+
+    const sig = extractFirstPropSig(r.parser, .flow_property_signature);
+    try std.testing.expect(sig.flags.optional);
+    try std.testing.expect(!sig.flags.readonly);
+}
+
+test "Flow property signature: covariant `+` sets flags.readonly" {
+    var r = try parseFlow(std.testing.allocator,
+        \\type Props = { +color: string };
+    );
+    defer r.deinit();
+
+    const sig = extractFirstPropSig(r.parser, .flow_property_signature);
+    try std.testing.expect(sig.flags.readonly);
+    try std.testing.expect(!sig.flags.optional);
+}
+
+test "Flow property signature: contravariant `-` produces no flag" {
+    // 현재 PropertySignatureFlags 에 contravariant 비트 없음 — drop (codegen 미사용).
+    var r = try parseFlow(std.testing.allocator,
+        \\type Props = { -color: string };
+    );
+    defer r.deinit();
+
+    const sig = extractFirstPropSig(r.parser, .flow_property_signature);
+    try std.testing.expectEqual(ts_mod.PropertySignatureFlags.NONE, sig.flags);
+}
+
+test "Flow object type: empty inexact `{}` has empty member list" {
+    var r = try parseFlow(std.testing.allocator,
+        \\type Empty = {};
+    );
+    defer r.deinit();
+
+    var found_object_type = false;
+    for (r.parser.ast.nodes.items) |node| {
+        if (node.tag != .flow_object_type) continue;
+        found_object_type = true;
+        try std.testing.expectEqual(@as(u32, 0), node.data.list.len);
+    }
+    try std.testing.expect(found_object_type);
+}
+
+test "Flow exact object type: empty `{||}` has empty member list" {
+    // pipe2 토큰 처리 정상 확인.
+    var r = try parseFlow(std.testing.allocator,
+        \\type Empty = {||};
+    );
+    defer r.deinit();
+
+    var found_exact = false;
+    for (r.parser.ast.nodes.items) |node| {
+        if (node.tag != .flow_exact_object_type) continue;
+        found_exact = true;
+        try std.testing.expectEqual(@as(u32, 0), node.data.list.len);
+    }
+    try std.testing.expect(found_exact);
+}
+
+test "Flow object type: multiple members all preserved with flags" {
+    var r = try parseFlow(std.testing.allocator,
+        \\type Props = {|
+        \\  color: string,
+        \\  size?: number,
+        \\  +disabled: boolean,
+        \\|};
+    );
+    defer r.deinit();
+
+    var prop_count: usize = 0;
+    var seen_color = false;
+    var seen_size = false;
+    var seen_disabled = false;
+
+    for (r.parser.ast.nodes.items) |node| {
+        if (node.tag != .flow_property_signature) continue;
+        prop_count += 1;
+        const e = node.data.extra;
+        const key_idx: ast_mod.NodeIndex = @enumFromInt(r.parser.ast.extra_data.items[e]);
+        const flags = ts_mod.PropertySignatureFlags.fromU32(r.parser.ast.extra_data.items[e + 2]);
+
+        const name = r.parser.ast.getText(r.parser.ast.getNode(key_idx).data.string_ref);
+
+        if (std.mem.eql(u8, name, "color")) {
+            seen_color = true;
+            try std.testing.expectEqual(ts_mod.PropertySignatureFlags.NONE, flags);
+        } else if (std.mem.eql(u8, name, "size")) {
+            seen_size = true;
+            try std.testing.expect(flags.optional);
+        } else if (std.mem.eql(u8, name, "disabled")) {
+            seen_disabled = true;
+            try std.testing.expect(flags.readonly);
+        }
+    }
+
+    try std.testing.expectEqual(@as(usize, 3), prop_count);
+    try std.testing.expect(seen_color);
+    try std.testing.expect(seen_size);
+    try std.testing.expect(seen_disabled);
+}
+
+test "Flow object type: contextual keyword as property key (`get`)" {
+    // get/set/class/interface 등은 .kw_* 토큰이라 단순 .identifier 체크로는 누락됨.
+    // 실제 RN spec 에서 흔함 (`{ get: () => T }` — react-native Utilities/defineLazyObjectProperty).
+    var r = try parseFlow(std.testing.allocator,
+        \\type X = { get: T };
+    );
+    defer r.deinit();
+
+    const sig = extractFirstPropSig(r.parser, .flow_property_signature);
+    const name = r.parser.ast.getText(r.parser.ast.getNode(sig.key).data.string_ref);
+    try std.testing.expectEqualStrings("get", name);
+}
+
+test "Flow object type: reserved keyword as property key (`delete`)" {
+    // delete/class/if 등 reserved keyword 도 property 이름. parseSimpleIdentifier
+    // 의 checkKeywordBinding 검사를 우회해서 직접 binding_identifier 노드 생성 — 회귀 가드.
+    var r = try parseFlow(std.testing.allocator,
+        \\type X = { delete?: T };
+    );
+    defer r.deinit();
+
+    const sig = extractFirstPropSig(r.parser, .flow_property_signature);
+    const name = r.parser.ast.getText(r.parser.ast.getNode(sig.key).data.string_ref);
+    try std.testing.expectEqualStrings("delete", name);
+    try std.testing.expect(sig.flags.optional);
+}
+
+test "Flow object type: string literal as property key (`'aria-label'`)" {
+    // RN Button.js 의 `'aria-label'?: ?string` 형태.
+    var r = try parseFlow(std.testing.allocator,
+        \\type X = { 'aria-label'?: string };
+    );
+    defer r.deinit();
+
+    const sig = extractFirstPropSig(r.parser, .flow_property_signature);
+    try std.testing.expectEqual(Tag.string_literal, r.parser.ast.getNode(sig.key).tag);
+    try std.testing.expect(sig.flags.optional);
+}
+
+test "Flow object type: generic method signature skipped (`foo<T>(): R`)" {
+    // RN ReactNativeTypes.js 의 `findHostInstance_DEPRECATED<T: Foo>(arg: T): R` 형태.
+    // 제네릭 type param `<...>` + paren `(...)` 둘 다 method 표시.
+    var r = try parseFlow(std.testing.allocator,
+        \\type X = { foo<T>(arg: T): R };
+    );
+    defer r.deinit();
+
+    var prop_count: usize = 0;
+    for (r.parser.ast.nodes.items) |node| {
+        if (node.tag == .flow_property_signature) prop_count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 0), prop_count);
+}
+
+test "Flow object type: spread `...Type` is skipped (not in member list)" {
+    // `...ViewProps` 같은 spread 는 PR #3a-2 스코프 밖이라 silent skip.
+    // codegen (#3b) 이 RN ViewProps 등을 자체 처리하므로 의도적.
+    var r = try parseFlow(std.testing.allocator,
+        \\type Props = {| color: string, ...Other |};
+    );
+    defer r.deinit();
+
+    var prop_count: usize = 0;
+    for (r.parser.ast.nodes.items) |node| {
+        if (node.tag == .flow_property_signature) prop_count += 1;
+    }
+    // spread 는 skip → color 만 남음.
+    try std.testing.expectEqual(@as(usize, 1), prop_count);
 }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -4849,7 +4849,9 @@ pub const Transformer = struct {
             .flow_type_alias_declaration,
             .flow_opaque_type,
             .flow_interface_declaration,
+            .flow_object_type,
             .flow_exact_object_type,
+            .flow_property_signature,
             => true,
             else => false,
         };


### PR DESCRIPTION
## 요약

Flow `parseObjectType` / `parseExactObjectType` 의 brace-skipping (body 토큰 폐기) 동작을 실제 멤버 파싱으로 교체. ohah/zts#2348 의 Flow root-cause fix — TS 측 (#2365) 과 동일한 발상으로 codegen plugin (PR #3b) 이 NativeProps 의 prop 정의를 읽을 수 있게 함.

## 변경 전후

**Before**:
```zig
fn parseObjectType(self: *Parser) ParseError2!NodeIndex {
    try self.advance(); // skip '{'
    var depth: u32 = 1;
    while (depth > 0) {
        switch (self.current()) {
            .l_curly => depth += 1,
            .r_curly => depth -= 1,
            else => {},
        }
        if (depth > 0) try self.advance();
    }
    try self.expect(.r_curly);
    return addNode(.flow_literal_type, span, .none);  // body 폐기
}
```

**After**:
```zig
fn parseObjectType(self: *Parser) ParseError2!NodeIndex {
    try self.advance(); // skip '{'
    const members = try parseFlowObjectMembers(self, .r_curly);
    try self.expect(.r_curly);
    return addListNode(.flow_object_type, span, members);  // 멤버 보존
}
```

## 새 AST 태그 (`ast.zig`)

| Tag | layout | extra / list |
| --- | --- | --- |
| `flow_object_type` | `.list` | members |
| `flow_property_signature` | `.extra` | `[key, type_ann, flags]` (TS 와 동일 layout) |

`flow_exact_object_type` 은 기존 태그 유지 — layout 만 empty list → 실제 members 로 변경.

## 새 helper (`flow.zig`)

- **`parseFlowObjectMembers(self, terminator: Kind) → !NodeList`** — 멤버를 `,`/`;` 구분으로 반복 파싱하다 terminator 만나면 멈춤 (caller 가 terminator 소비). `{...}` 와 `{|...|}` 양쪽이 공통으로 호출.
- **`parseFlowTypeMember(self) → !NodeIndex`** — 단일 멤버. property signature 면 `flow_property_signature` 반환, 미지원 형태면 `.none` (silent skip).

## 멤버 형태별 처리

### 지원 (`flow_property_signature` 반환)

| Flow 문법 | flags |
| --- | --- |
| `key: T` | (none) |
| `key?: T` | optional |
| `+key: T` | readonly (covariant → output-safe 매핑) |
| `+key?: T` | optional + readonly |

### 미지원 (`.none` 반환, silent skip)

| 문법 | 이유 |
| --- | --- |
| `...Type` | spread — codegen (PR #3b) 에서 별도 처리 예정 |
| `...` 단독 | inexact marker — codegen 미사용 |
| `[k: T]: U` | indexer — codegen 미사용 |
| `key(args): R` | method — codegen 미사용 |
| `(args): R` | call signature |
| `-key: T` | contravariant — `PropertySignatureFlags` 에 별도 비트 없음 (codegen 미사용) |

## 토크나이즈 엣지 케이스 — `{||}`

빈 exact object `{||}` 는 lexer 가 `||` 를 `pipe2` 단일 토큰으로 분해:
```
{| key: T |}  →  {  |  key  :  T  |  }     (5+ tokens)
{||}          →  {  ||  }                  (3 tokens, pipe2)
```

`parseExactObjectType` 에서 `pipe2` 를 별도 분기로 처리. lexer 가 컨텍스트 무관하게 `||` 를 항상 `pipe2` 로 토크나이즈하므로 dispatch (`peekNextKind() == .pipe or .pipe2`) 도 양쪽 인식.

## Spread 와 union 충돌 회피

`...Type` 처리 시 `parsePrimaryType` 사용 (full `parseType` 아님). 이유:

```js
type X = {| color: string, ...Other |}
//                         ^^^^^^^^
//                         parseType 으로 파싱하면 |} 의 `|` 를 union 시작으로
//                         흡수 → outer object 의 종료 토큰이 사라짐
```

`parsePrimaryType` 은 union/intersection postfix 를 보지 않아 `Other` 까지만 소비. 이후 outer 의 `|}` 가 정상 매칭됨.

## 다운스트림 영향: 0

| 위치 | 어떻게 사용 | body 보존 영향 |
| --- | --- | --- |
| `transformer/transformer.zig:4849-4853` | strip 대상 리스트 (+2 새 태그) — 노드 통째 삭제 | 무관 |
| `semantic/analyzer.zig` | 새 태그 미사용 (else 분기 fallthrough) | 무관 |

## Zig 초보자용 메모

### `terminator: Kind` 매개변수

`{...}` 종료는 `r_curly`, `{|...|}` 종료는 `pipe` (그 다음 `r_curly` 가 옴). 같은 멤버 반복 로직을 두 케이스에서 공유하기 위해 종료 토큰을 매개변수로 받음.

```zig
fn parseFlowObjectMembers(self: *Parser, terminator: Kind) !NodeList {
    while (self.current() != terminator and self.current() != .eof) { ... }
}
```

### `parsePrimaryType` vs `parseType`

`parseType` 은 union > intersection > prefix > postfix > primary 를 통합 처리 (postfix 까지 흡수). `parsePrimaryType` 은 가장 좁은 layer — keyword type, type reference, parenthesized, object 만. spread 처럼 *제한된* 파싱이 필요할 때 사용.

## 테스트 8 개 (`parser_test.zig` 말미)

```
Flow property signature: preserves key + type + zero flags
Flow property signature: optional `?` sets flags.optional
Flow property signature: covariant `+` sets flags.readonly
Flow property signature: contravariant `-` produces no flag
Flow object type: empty inexact `{}` has empty member list
Flow exact object type: empty `{||}` has empty member list  ← pipe2 케이스
Flow object type: multiple members all preserved with flags
Flow object type: spread `...Type` is skipped (not in member list)
```

## 테스트 헬퍼 통합

`ParsedTs` + `ParsedFlow` → 단일 `ParsedSource` + `ParseMode` enum.
`parseTs` / `parseFlow` 는 thin wrapper.
`extractFirstPropSig(parser)` (TS 전용) + `extractFirstFlowPropSig(parser)` (Flow 전용) → `extractFirstPropSig(parser, tag: Tag)` 단일 함수.

## /simplify 처리

리뷰 결과 4 건 처리:
1. **`skipBalancedToCloser` 중복** — 기존 `skipBalanced(open, close)` (line 1044) / `skipBalancedParens` (line 1059) 가 이미 있음. 새 함수 제거하고 그쪽 호출로 변경.
2. **Variance 의미 모호** — covariant ≠ readonly 라 주석 강화 (output position 동등성 명시).
3. **테스트 헬퍼 중복** (ParsedFlow vs ParsedTs / extractFirstPropSig vs extractFirstFlowPropSig) — 통합.
4. **`@panic` 메시지 강화** — `std.debug.panic("BUG: ... tag {s}", .{@tagName(tag)})` 로 디버깅 정보 추가.

## 향후

- **PR #3b** (다음): `schema_builder.zig` — 보존된 type body 를 walk 해 ComponentShape 빌드. TS / Flow 양쪽 type 트리를 같은 `flow_property_signature` / `ts_property_signature` layout 으로 처리.
- 미적용 미세 항목 (방어적, 스코프 최소화):
  - Spread vs inexact marker 의미 차이 보존 — PR #3b 에서 codegen 이 ViewProps spread 를 안전 처리해야 할 때 별도 노드 태그 추가 검토.
  - Method/indexer 등을 `flow_*_signature` 노드로 보존 — 현재 codegen 미사용이라 silent skip.

## 관련

- #2348 — meta: `@react-native/codegen` ZTS native 분석
- #2365 — PR #3a-1 (TS property signature 보존)
- ca55aec7 / a5bb6984 — PR #1, #2 (Schema struct, Type indexer)