### PR TITLE
fix(napi)!: strict throw on invalid 'jsx' option (was silent classic fallback)

### DIFF
--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -356,6 +356,12 @@ function parseArgs(argv) {
   // jsx-dev 단축어
   if (opts.jsxDev) opts.jsx = "automatic-dev";
 
+  // esbuild legacy alias normalize: `--jsx=transform` / `--jsx=preserve` → classic.
+  // docs/CONFIG.md 가 명시한 CLI vocab (preserve/transform/automatic) 을 strict NAPI vocab
+  // (classic/automatic/automatic-dev) 로 변환. JS API 는 이 정규화를 받지 않고 strict union
+  // type 만 허용 — CLI argv 의 raw string 만 esbuild 호환을 위해 관대하게 처리.
+  if (opts.jsx === "transform" || opts.jsx === "preserve") opts.jsx = "classic";
+
   // drop 처리
   for (const d of opts.drop) {
     if (d === "console") opts.define["console.log"] = "undefined";

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -3307,13 +3307,19 @@ fn parseBuildOptions(
 
     // JSX — string→enum 변환만 여기서. 최종 런타임/factory 결정은 tsconfig_merge 에 위임
     // (file/raw tsconfig 의 "jsx"/"jsxFactory" 등을 함께 고려).
-    // 인식 못 하는 jsx 문자열은 `.classic` 으로 fallback (이전 NAPI 동작 보존) — typo 가 silently
-    // tsconfig fallthrough 로 다른 결과를 만들지 않도록.
+    // 유효 vocab: "automatic" / "automatic-dev" / "classic" (`transpile.zig::optionsFromJson`
+    // 의 enum-strict 동작과 일관). tsconfig vocab ("react" / "react-jsx" / "react-jsxdev") 또는
+    // typo 는 throw — 이전 silent classic fallback 은 사용자 디버깅을 어렵게 했음.
     const jsx_str = ownStr(env, opts_obj, "jsx", owned_strings);
     const jsx_runtime_explicit: ?JsxRuntime = if (jsx_str) |s| blk: {
         if (std.mem.eql(u8, s, "automatic")) break :blk .automatic;
         if (std.mem.eql(u8, s, "automatic-dev")) break :blk .automatic_dev;
-        break :blk .classic;
+        if (std.mem.eql(u8, s, "classic")) break :blk .classic;
+        // parseBuildOptions 반환 타입이 ?BundleOptions 라 throwError 의 napi_value 결과를 그대로
+        // return 못 함 — discard 후 null 반환. caller 의 `orelse return throwError(...)` 가
+        // already-pending exception 위에 다시 throw 시도하지만 NAPI spec 상 silent ignore 라 안전.
+        _ = throwError(env, "invalid 'jsx' option (expected automatic / automatic-dev / classic)");
+        return null;
     } else null;
     const jsx_factory = ownStr(env, opts_obj, "jsxFactory", owned_strings);
     const jsx_fragment = ownStr(env, opts_obj, "jsxFragment", owned_strings);

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -217,9 +217,12 @@ export function buildOptionsJson(
     payload.unsupported = unsupportedOverride;
   if (opts.flow) payload.flow = true;
   if (opts.jsxInJs) payload.jsxInJs = true;
-  if (opts.jsx === "automatic") payload.jsx = "automatic";
-  else if (opts.jsx === "automatic-dev") payload.jsx = "automatic_dev";
-  else if (opts.jsx === "classic") payload.jsx = "classic";
+  if (opts.jsx !== undefined) {
+    // CLI vocab → Zig enum tag (kebab-case → snake_case): automatic-dev → automatic_dev.
+    // 그 외 (`react-jsx` 등 tsconfig vocab, typo) 도 그대로 forward — NAPI / `optionsFromJson`
+    // 이 strict 검증해 invalid 면 throw (silent drop 방지).
+    payload.jsx = opts.jsx === "automatic-dev" ? "automatic_dev" : opts.jsx;
+  }
   if (opts.jsxFactory) payload.jsxFactory = opts.jsxFactory;
   if (opts.jsxFragment) payload.jsxFragment = opts.jsxFragment;
   if (opts.jsxImportSource) payload.jsxImportSource = opts.jsxImportSource;


### PR DESCRIPTION
## 요약

PR #2356 의 /simplify 리뷰 (Code Quality Review #1) 에서 발견된 latent bug 수정.

이전엔 NAPI bundler 진입점 (`parseBuildOptions`) 이 invalid jsx 문자열 받으면 silently `.classic` 으로 fallback. JS API consumer 가 typo (`automaitc`) 또는 tsconfig vocab (`react-jsx`) 보내면 의도치 않게 classic 로 동작 — 디버깅 어려움.

추가로 발견: `packages/shared/index.ts::buildOptionsJson` 의 jsx 분기가 `automatic`/`automatic-dev`/`classic` 만 forward 하고 그 외엔 silent drop — NAPI 까지 invalid 가 도달조차 안 함. 즉 strict throw 만 추가해도 효과 없음. 두 layer 모두 fix.

## 변경

1. **`napi_entry.zig::parseBuildOptions`** — `jsx_str` → enum 매핑 strict. 인식 못 하는 vocab 시 `throwError(env, "invalid 'jsx' option (expected automatic / automatic-dev / classic)")` + `return null`. caller 의 fallback `throwError` 는 NAPI 가 already-pending exception 인 경우 silent ignore — 안전 (코멘트로 명시).
2. **`packages/shared/index.ts::buildOptionsJson`** — jsx 분기 단순화. `undefined` 가 아니면 모두 forward, `automatic-dev` 만 `automatic_dev` 로 kebab→snake 변환. 그 외 (typo / tsconfig vocab) 도 그대로 forward 하면 NAPI 가 strict 검증해 throw.
3. **`packages/core/bin/zts.mjs::parseArgs`** — esbuild legacy alias normalize. `--jsx=transform` / `--jsx=preserve` (docs/CONFIG.md:33,178 명시 vocab) → `\"classic\"`. CLI argv 의 raw string 만 alias 처리 — JS API 의 strict union type 은 영향 없음.

## ⚠️ BREAKING

- 이전엔 `transpile(src, { jsx: \"react-jsx\" })` 같은 tsconfig vocab 또는 typo 가 silent classic fallback. **이제 throw**:
  - `transpile()` 진입점: `Error: invalid options JSON` (transpile.zig::optionsFromJson 의 std.json enum-strict)
  - `build()` / `buildSync()` 진입점: `Error: invalid 'jsx' option (expected ...)`
- **영향**:
  - TS strict union 사용자: **무영향** (compile-time 차단)
  - vanilla JS / `any` cast 사용자: 잘못된 vocab 보내던 코드 throw
- **마이그레이션**: jsx 옵션은 `\"classic\"` / `\"automatic\"` / `\"automatic-dev\"` 만 사용. tsconfig 의 `compilerOptions.jsx` (`react`/`react-jsx`/`react-jsxdev`) 는 `tsconfigRaw` 또는 file 기반 tsconfig 로 전달 — Zig `tsconfig_merge` 가 enum 매핑 처리.

## 검증

- `zig build napi`, `zig build test` 통과
- spot-check (JS API):
  ```
  transpile(src, { jsx: \"automatic\" })   → ✓ jsx-runtime
  transpile(src, { jsx: \"react-jsx\" })   → throw \"invalid options JSON\"
  transpile(src, { jsx: \"automaitc\" })   → throw \"invalid options JSON\"
  ```
- spot-check (CLI): `zts --jsx=transform App.tsx` 정상 (esbuild alias normalize), `zts --jsx=automatic-dev App.tsx` 정상.
- `bun test packages/core/index.test.ts` 369/369 통과
- `bun test packages/core/bin/zts.test.ts --test-name-pattern \"tsconfig|jsx|3-way\"` 31/31 통과 (3-way 우선순위 회귀 가드 포함)
- `bun test packages/core/bin/zts-cli-schema-sync.test.ts` 11/11 통과
- pre-push hook (zig fmt + zig build test + oxlint + oxfmt) 통과

## /simplify 3-in-1 리뷰 결과

- (c-throw) 디자인 결정 — strict throw 가 transpile NAPI 진입점 (std.json enum-strict) 과 일관.
- 코멘트 추가: `_ = throwError(...); return null;` 패턴 + caller fallback 의 already-pending 안전성 명시.
- BREAKING change 명시 (PR description).

## 후속 (별개 PR / issue)

- `src/main.zig:814-824` 의 Zig 네이티브 CLI argv 파서가 여전히 silent classic fallback. 진정한 vocab 일관성 위해 main.zig 도 strict 화 후속.
- `transpile.zig::optionsFromJson` 의 invalid jsx 시 generic `\"invalid options JSON\"` 메시지 — std.json error 분기로 specific 메시지 반환하는 후속 PR.

## 참고

- PR #2356, #2360, #2362, #2363, #2364, #2366, #2368 — 같은 simplify 시리즈 (모두 머지됨).