### PR TITLE
refactor(compat): extract hasAny helper for packed-struct bitmaps

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1987,7 +1987,7 @@ pub fn main() !void {
         .verbatim_module_syntax = opts.verbatim_module_syntax,
         .sourcemap = if (opts.sourcemap) true else null,
         .es_target = opts.es_target,
-        .unsupported = if (@as(u32, @bitCast(opts.unsupported)) != 0) opts.unsupported else null,
+        .unsupported = if (opts.unsupported.hasAny()) opts.unsupported else null,
         .jsx_runtime = opts.jsx_runtime,
         .jsx_factory = if (std.mem.eql(u8, opts.jsx_factory, "React.createElement")) null else opts.jsx_factory,
         .jsx_fragment = if (std.mem.eql(u8, opts.jsx_fragment, "React.Fragment")) null else opts.jsx_fragment,

--- a/src/transformer/compat.zig
+++ b/src/transformer/compat.zig
@@ -164,6 +164,12 @@ pub const UnsupportedFeatures = packed struct(u32) {
 
     _: u4 = 0,
 
+    /// 어떤 feature flag 라도 set 됐는지 (= packed struct 가 zero 가 아닌지).
+    /// `.{}` (기본값, 모든 비트 false) 와 명시적으로 어느 비트라도 set 된 상태를 구분할 때 사용.
+    pub fn hasAny(self: @This()) bool {
+        return @as(u32, @bitCast(self)) != 0;
+    }
+
     // Feature enum과 UnsupportedFeatures 필드 순서 1:1 대응 검증.
     // Feature 추가/재배치 시 여기서 컴파일 에러가 발생한다.
     comptime {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -327,6 +327,12 @@ pub const RuntimeHelpers = packed struct(u32) {
     /// 호출 emit 시 함께 set 한다.
     legacy_decorator: bool = false,
     _padding: u6 = 0,
+
+    /// 어떤 helper flag 라도 set 됐는지 — emitter 의 prepend 분기에서 빈 helper 시
+    /// no-op 결정에 사용.
+    pub fn hasAny(self: @This()) bool {
+        return @as(u32, @bitCast(self)) != 0;
+    }
 };
 
 /// 단일 AST append-only 변환기.

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -599,7 +599,7 @@ pub fn transpileWithCallback(
 
     // 7. 런타임 헬퍼 prepend
     const rh = transformer.runtime_helpers;
-    const has_helpers = @as(u32, @bitCast(rh)) != 0;
+    const has_helpers = rh.hasAny();
     const output = if (has_helpers) blk: {
         var buf: std.ArrayList(u8) = .empty;
         rt.appendRuntimeHelpers(&buf, arena_alloc, rh, options.minify_whitespace, transformer.runtime_es5_compat) catch


### PR DESCRIPTION
## 요약

PR #2356 의 /simplify 리뷰 (Code Reuse Review #b) 후속.

`@as(u32, @bitCast(packed_struct)) != 0` 패턴이 두 곳에 흩어져 있었음:

- `src/main.zig:1990` — `UnsupportedFeatures` (CLI 가 명시 set 했는지 판정).
- `src/transpile.zig:602` — `RuntimeHelpers` (emitter 의 prepend 분기 — 빈 helper 시 no-op).

각 packed struct(u32) 에 `hasAny()` 메서드 추가 — "비트맵이 zero 가 아닌가" 의도가 메서드 이름으로 노출.

## 변경

```zig
// UnsupportedFeatures (compat.zig) + RuntimeHelpers (transformer.zig) 둘 다:
pub fn hasAny(self: @This()) bool {
    return @as(u32, @bitCast(self)) != 0;
}
```

사용처 변환:

```zig
// 이전:
if (@as(u32, @bitCast(opts.unsupported)) != 0) ...
const has_helpers = @as(u32, @bitCast(rh)) != 0;

// 이후:
if (opts.unsupported.hasAny()) ...
const has_helpers = rh.hasAny();
```

## /simplify 3-in-1 리뷰 적용

- 처음 `isAny` 였던 네이밍을 `hasAny` 로 — 동사 의미 강함 (struct "has any flag set").
- doc comment 는 caller 맥락 (ExplicitFlags / emitter prepend) 의존하지 않게 일반화 — 미래 다른 사용처 mislead 방지.
- /simplify 의 NEW 발견: `transpile.zig:602` 의 `RuntimeHelpers` 도 같은 패턴 → 같이 통합.

## 검증

- `zig build test` 통과
- `zig fmt --check`, pre-push hook (zig fmt + zig build test + oxlint + oxfmt) 모두 통과

## 후속 (별개 PR / issue)

- 다른 packed-struct(u32) 들 (`Flags`, `parser.Context`, `TsTypeParamModifier`, `PropertySignatureFlags`, `DeclFlags`, `ReferenceFlags`) 도 비슷한 pattern 사용하는지 — 필요 시 같은 helper 추가.
- `src/bundler/emitter.zig:1466` 의 `@bitCast(... | ...)` 형태 (두 packed struct merge) — `RuntimeHelpers.merge()` helper 후보.

## 참고

- PR #2356, #2360, #2362, #2363, #2364, #2366, #2368, #2370 — 같은 simplify 시리즈 (모두 머지됨).