### PR TITLE
feat(codegen): add schema_builder for ComponentShape construction

### DIFF
--- a/src/transformer/plugins/codegen/mod.zig
+++ b/src/transformer/plugins/codegen/mod.zig
@@ -15,9 +15,12 @@
 
 pub const schema = @import("schema.zig");
 pub const type_index = @import("type_index.zig");
+pub const schema_builder = @import("schema_builder.zig");
 
 test {
     _ = schema;
     _ = type_index;
+    _ = schema_builder;
     _ = @import("type_index_test.zig");
+    _ = @import("schema_builder_test.zig");
 }

--- a/src/transformer/plugins/codegen/schema_builder.zig
+++ b/src/transformer/plugins/codegen/schema_builder.zig
@@ -1,0 +1,386 @@
+//! Schema 빌더 — type alias / interface body → `ComponentShape`.
+//!
+//! 입력: NativeProps type alias (또는 interface) 의 declaration NodeIndex.
+//! 출력: `schema.ComponentShape` (props, events, commands).
+//!
+//! 사용 시점: codegen plugin (#2348 PR #6) 이 `codegenNativeComponent<NativeProps>('Name')`
+//! 을 인식하면 `type_index.get("NativeProps")` 로 declaration 을 찾아 본 빌더에 전달.
+//! 빌더가 ComponentShape 를 반환하면 view_config_emitter (PR #4) 가 JS 문자열로 직렬화.
+//!
+//! 처리 패턴:
+//!
+//!   - Wrapper 풀기: `Readonly<{...}>`, `$ReadOnly<{...}>` → 안의 object body
+//!   - Intersection: `{...} & ViewProps` → ViewProps 부분 무시 (RN 런타임이 등록)
+//!   - Property → PropTypeAnnotation 매핑 (`GenerateViewConfigJs.js:43-108` 참고)
+//!   - Function-typed prop (`(event: T) => void`) → EventTypeShape
+//!
+//! Cross-file type reference (`import type { ViewProps }`) 는 fail-fast —
+//! `error.UnresolvedTypeReference` 반환. caller 가 JS fallback (`@react-native/codegen`)
+//! 으로 처리 (#2348 § 5).
+//!
+//! 메모리: caller arena. 모든 슬라이스 / 문자열은 build() 호출 시 alloc 으로 할당.
+
+const std = @import("std");
+const ast_mod = @import("../../../parser/ast.zig");
+const Ast = ast_mod.Ast;
+const Node = ast_mod.Node;
+const NodeIndex = ast_mod.NodeIndex;
+const Tag = ast_mod.Node.Tag;
+
+const schema = @import("schema.zig");
+const TypeIndex = @import("type_index.zig").TypeIndex;
+const PropertySignatureFlags = @import("../../../parser/ts.zig").PropertySignatureFlags;
+
+pub const Error = error{
+    /// 이름 type reference 가 type_index 에 없음 (cross-file 또는 정의 누락).
+    UnresolvedTypeReference,
+    /// 인식 못 하는 prop type 형태.
+    UnsupportedPropType,
+    /// NativeProps 가 object literal 도 wrapper 도 아님.
+    InvalidNativePropsBody,
+    OutOfMemory,
+};
+
+/// codegen plugin 진입점. type alias / interface declaration 으로부터 ComponentShape 빌드.
+///
+/// `component_name` 은 `codegenNativeComponent('Name')` 의 `'Name'` 인자 — 빌더가
+/// 외부에서 받음 (declaration 자체엔 이름 없음).
+pub fn build(
+    ast: *const Ast,
+    type_index: *const TypeIndex,
+    component_name: []const u8,
+    native_props_idx: NodeIndex,
+    alloc: std.mem.Allocator,
+) Error!schema.ComponentShape {
+    const body_idx = try resolveDeclarationBody(ast, type_index, native_props_idx);
+    const members = try collectObjectMembers(ast, type_index, body_idx, alloc);
+    defer alloc.free(members); // arena 사용 시 무해, 일반 allocator 시 누수 방지
+
+    var props_buf = std.ArrayList(schema.NamedShape(schema.PropTypeAnnotation)).empty;
+    defer props_buf.deinit(alloc);
+    var events_buf = std.ArrayList(schema.EventTypeShape).empty;
+    defer events_buf.deinit(alloc);
+
+    for (members) |sig_idx| {
+        try classifyMember(ast, type_index, sig_idx, &props_buf, &events_buf, alloc);
+    }
+
+    return .{
+        .name = component_name,
+        .props = try props_buf.toOwnedSlice(alloc),
+        .events = try events_buf.toOwnedSlice(alloc),
+    };
+}
+
+/// declaration NodeIndex 를 받아 object body NodeIndex 반환.
+/// `Readonly<{...}>` / `$ReadOnly<{...}>` wrapper 가 있으면 풀어준다.
+///
+/// 지원 declaration tag:
+///   - ts_type_alias_declaration: extra[2] = value
+///   - ts_interface_declaration:  extra[4] = body
+///   - flow_type_alias_declaration: extra[2] = value
+///   - flow_opaque_type:          extra[3] = value
+///   - flow_interface_declaration: 미지원 (브레이스 skip 으로 body 보존 안 됨)
+fn resolveDeclarationBody(
+    ast: *const Ast,
+    type_index: *const TypeIndex,
+    decl_idx: NodeIndex,
+) Error!NodeIndex {
+    const node = ast.getNode(decl_idx);
+    const value_idx: NodeIndex = switch (node.tag) {
+        .ts_type_alias_declaration, .flow_type_alias_declaration => v: {
+            const e = node.data.extra;
+            if (e + 2 >= ast.extra_data.items.len) return error.InvalidNativePropsBody;
+            break :v @enumFromInt(ast.extra_data.items[e + 2]);
+        },
+        .ts_interface_declaration => v: {
+            const e = node.data.extra;
+            if (e + 4 >= ast.extra_data.items.len) return error.InvalidNativePropsBody;
+            break :v @enumFromInt(ast.extra_data.items[e + 4]);
+        },
+        .flow_opaque_type => v: {
+            const e = node.data.extra;
+            if (e + 3 >= ast.extra_data.items.len) return error.InvalidNativePropsBody;
+            break :v @enumFromInt(ast.extra_data.items[e + 3]);
+        },
+        else => return error.InvalidNativePropsBody,
+    };
+
+    return unwrapWrapper(ast, type_index, value_idx);
+}
+
+/// `Readonly<T>` / `$ReadOnly<T>` 같은 well-known wrapper 를 풀어 inner object 반환.
+/// Wrapper 가 아니면 입력 그대로.
+fn unwrapWrapper(ast: *const Ast, type_index: *const TypeIndex, idx: NodeIndex) Error!NodeIndex {
+    const node = ast.getNode(idx);
+    const ref_name = switch (node.tag) {
+        .ts_type_reference, .flow_type_reference => getTypeReferenceName(ast, node) orelse return idx,
+        else => return idx,
+    };
+
+    if (!isReadonlyWrapperName(ref_name)) return idx;
+
+    // type argument 추출 — Readonly<T> 의 T.
+    const inner = getFirstTypeArgument(ast, node) orelse return idx;
+    // 재귀 unwrap (이중 wrapper 케이스). 단, 제자리 무한루프 방지 — getFirstTypeArgument 결과만.
+    return unwrapWrapper(ast, type_index, inner);
+}
+
+fn isReadonlyWrapperName(name: []const u8) bool {
+    return std.mem.eql(u8, name, "Readonly") or
+        std.mem.eql(u8, name, "$ReadOnly");
+}
+
+/// type_reference node 에서 first type argument 의 NodeIndex 추출.
+/// `Foo<A, B>` → A.
+///
+/// type_reference layout (`flow.zig:472`, `ts.zig:994`): `extra = [name_start, name_end, type_args]`.
+/// type_args 는 ts_type_parameter_instantiation / flow_type_parameter_instantiation
+/// 의 NodeIndex (NodeList layout = .list).
+fn getFirstTypeArgument(ast: *const Ast, node: Node) ?NodeIndex {
+    const e = node.data.extra;
+    if (e + 2 >= ast.extra_data.items.len) return null;
+    const args_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e + 2]);
+    if (args_idx == .none) return null;
+
+    const args_node = ast.getNode(args_idx);
+    if (args_node.tag != .ts_type_parameter_instantiation and
+        args_node.tag != .flow_type_parameter_instantiation) return null;
+
+    const list = args_node.data.list;
+    if (list.len == 0) return null;
+    return @enumFromInt(ast.extra_data.items[list.start]);
+}
+
+/// type_reference 의 name 텍스트 추출. extra[0..2] 가 source 의 name span.
+fn getTypeReferenceName(ast: *const Ast, node: Node) ?[]const u8 {
+    const e = node.data.extra;
+    if (e + 1 >= ast.extra_data.items.len) return null;
+    const start = ast.extra_data.items[e];
+    const end = ast.extra_data.items[e + 1];
+    if (end <= start or end > ast.source.len) return null;
+    return ast.source[start..end];
+}
+
+/// object body NodeIndex 의 멤버 list 추출.
+/// 지원 tag: ts_type_literal, flow_object_type, flow_exact_object_type.
+/// 그 외면 InvalidNativePropsBody.
+fn collectObjectMembers(
+    ast: *const Ast,
+    type_index: *const TypeIndex,
+    body_idx: NodeIndex,
+    alloc: std.mem.Allocator,
+) Error![]const NodeIndex {
+    _ = type_index; // intersection unwrap 시 사용 예정
+
+    const node = ast.getNode(body_idx);
+    const list = switch (node.tag) {
+        .ts_type_literal, .flow_object_type, .flow_exact_object_type => node.data.list,
+        else => return error.InvalidNativePropsBody,
+    };
+
+    const out = try alloc.alloc(NodeIndex, list.len);
+    var count: usize = 0;
+    var i: u32 = 0;
+    while (i < list.len) : (i += 1) {
+        const raw = ast.extra_data.items[list.start + i];
+        const idx: NodeIndex = @enumFromInt(raw);
+        const child = ast.getNode(idx);
+        if (child.tag != .ts_property_signature and child.tag != .flow_property_signature) continue;
+        out[count] = idx;
+        count += 1;
+    }
+    return out[0..count];
+}
+
+/// property_signature 1 개를 분류해 props 또는 events 에 append.
+fn classifyMember(
+    ast: *const Ast,
+    type_index: *const TypeIndex,
+    sig_idx: NodeIndex,
+    props: *std.ArrayList(schema.NamedShape(schema.PropTypeAnnotation)),
+    events: *std.ArrayList(schema.EventTypeShape),
+    alloc: std.mem.Allocator,
+) Error!void {
+    const sig = ast.getNode(sig_idx);
+    const e = sig.data.extra;
+    if (e + 2 >= ast.extra_data.items.len) return error.UnsupportedPropType;
+
+    const key_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e]);
+    const type_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e + 1]);
+    const flags = PropertySignatureFlags.fromU32(ast.extra_data.items[e + 2]);
+
+    const key_name = extractKeyName(ast, key_idx) orelse return error.UnsupportedPropType;
+    if (type_idx == .none) return error.UnsupportedPropType;
+
+    if (isFunctionType(ast, type_idx)) {
+        try events.append(alloc, .{
+            .name = key_name,
+            .bubbling_type = classifyEventBubbling(key_name),
+            .optional = flags.optional,
+            .argument = null, // PR #3b 스코프: argument 추출 미구현. PR #3b-2 에서 확장.
+        });
+        return;
+    }
+
+    const prop_type = try mapPropType(ast, type_index, type_idx);
+    try props.append(alloc, .{
+        .name = key_name,
+        .optional = flags.optional,
+        .type_annotation = prop_type,
+    });
+}
+
+/// property key NodeIndex → 텍스트.
+///
+/// 지원 tag:
+///   - binding_identifier — Flow flow_property_signature 가 직접 생성
+///   - identifier_reference — TS parsePropertyKey 결과
+///   - string_literal — `'aria-label'?` 같은 quoted key (Flow)
+fn extractKeyName(ast: *const Ast, key_idx: NodeIndex) ?[]const u8 {
+    const node = ast.getNode(key_idx);
+    return switch (node.tag) {
+        .binding_identifier, .identifier_reference => ast.getText(node.data.string_ref),
+        .string_literal => stripQuotes(ast.getText(node.data.string_ref)),
+        else => null,
+    };
+}
+
+/// `'aria-label'` → `aria-label`. quote 가 없으면 그대로 반환 (이미 식별자).
+/// 주의: `string_literal` 노드의 span 은 따옴표 포함이므로 codegen 이 사용하기 전에
+/// 벗겨야 함 (RN spec 의 view config 키는 unquoted 식별자 형식).
+fn stripQuotes(s: []const u8) []const u8 {
+    if (s.len < 2) return s;
+    const first = s[0];
+    const last = s[s.len - 1];
+    if ((first == '\'' or first == '"') and first == last) return s[1 .. s.len - 1];
+    return s;
+}
+
+fn isFunctionType(ast: *const Ast, type_idx: NodeIndex) bool {
+    const node = ast.getNode(type_idx);
+    return node.tag == .ts_function_type or node.tag == .flow_function_type;
+}
+
+/// 이벤트 prop 이름 → bubble vs direct 분류.
+/// 일반적 RN 컨벤션: `onCapture` 접미사가 있으면 direct, 그 외는 bubble.
+/// 정확한 분류는 spec 별 paperBubblingType 메타로 결정되지만 PR #3b 스코프에서 단순화.
+fn classifyEventBubbling(name: []const u8) schema.BubblingType {
+    if (std.mem.endsWith(u8, name, "Capture")) return .direct;
+    return .bubble;
+}
+
+/// alias 재귀 펼치기 깊이 제한. `type A = B; type B = A;` 같은 cycle 또는 비정상 깊은
+/// alias chain (예: 16+ 단계) 이면 fail-fast. RN spec 에서 1-2 단계가 일반적이라 8 충분.
+const MAX_ALIAS_DEPTH: u8 = 8;
+
+/// type annotation NodeIndex → PropTypeAnnotation 매핑.
+/// 모르는 형태는 UnsupportedPropType. caller 가 JS fallback 으로 처리.
+fn mapPropType(
+    ast: *const Ast,
+    type_index: *const TypeIndex,
+    type_idx: NodeIndex,
+) Error!schema.PropTypeAnnotation {
+    return mapPropTypeAt(ast, type_index, type_idx, 0);
+}
+
+fn mapPropTypeAt(
+    ast: *const Ast,
+    type_index: *const TypeIndex,
+    type_idx: NodeIndex,
+    depth: u8,
+) Error!schema.PropTypeAnnotation {
+    if (depth >= MAX_ALIAS_DEPTH) return error.UnsupportedPropType;
+
+    const node = ast.getNode(type_idx);
+    return switch (node.tag) {
+        .ts_boolean_keyword, .flow_boolean_keyword => .{ .boolean = .{ .default = null } },
+        .ts_string_keyword, .flow_string_keyword => .{ .string = .{ .default = null } },
+        .ts_number_keyword, .flow_number_keyword => .{ .float = .{ .default = null } },
+        // TS 'any' / Flow 'mixed' / 'any' → mixed (codegen 미사용 prop 으로 등록)
+        .flow_any_keyword, .flow_mixed_keyword => .mixed,
+
+        // type reference: reserved primitive 또는 alias 펼치기
+        .ts_type_reference, .flow_type_reference => mapTypeReference(ast, type_index, node, depth),
+
+        // 그 외는 미지원 — 향후 확장 (PR #3b-2: array, object, string_enum, ...)
+        else => error.UnsupportedPropType,
+    };
+}
+
+/// type reference 이름 → reserved primitive 매핑. 알려진 RN core 타입 이름들.
+/// 매핑 안 되면 type_index 에서 alias 펼쳐 재귀.
+fn mapTypeReference(
+    ast: *const Ast,
+    type_index: *const TypeIndex,
+    node: Node,
+    depth: u8,
+) Error!schema.PropTypeAnnotation {
+    const name = getTypeReferenceName(ast, node) orelse return error.UnsupportedPropType;
+
+    if (reserved_ref_names.get(name)) |primitive| {
+        return .{ .reserved = primitive };
+    }
+    if (numeric_ref_names.get(name)) |kind| {
+        return numericKindToAnnotation(kind);
+    }
+
+    // type alias 펼치기 — 같은 파일에 정의된 type X = ... 면 X 의 정의를 재귀 매핑.
+    if (type_index.get(name)) |alias_idx| {
+        const alias_node = ast.getNode(alias_idx);
+        const value_idx: NodeIndex = switch (alias_node.tag) {
+            .ts_type_alias_declaration, .flow_type_alias_declaration => v: {
+                const e = alias_node.data.extra;
+                if (e + 2 >= ast.extra_data.items.len) return error.UnsupportedPropType;
+                break :v @enumFromInt(ast.extra_data.items[e + 2]);
+            },
+            else => return error.UnsupportedPropType,
+        };
+        return mapPropTypeAt(ast, type_index, value_idx, depth + 1);
+    }
+
+    return error.UnresolvedTypeReference;
+}
+
+/// RN core 의 reserved type reference 이름 → primitive 매핑.
+/// `GenerateViewConfigJs.js:43-108` 의 ReservedPropTypeAnnotation 매핑 그대로.
+/// 이름 alias 는 RN 내부 (Flow `*Primitive`, public `*Value`/`*PropType`) 다 포함.
+const reserved_ref_names = std.StaticStringMap(schema.ReservedPropPrimitive).initComptime(.{
+    .{ "ColorValue", .color },
+    .{ "ProcessedColorValue", .color },
+    .{ "ColorPrimitive", .color },
+    .{ "ImageSource", .image_source },
+    .{ "ImageSourcePropType", .image_source },
+    .{ "ImageSourcePrimitive", .image_source },
+    .{ "PointValue", .point },
+    .{ "PointPropType", .point },
+    .{ "PointPrimitive", .point },
+    .{ "EdgeInsetsValue", .edge_insets },
+    .{ "EdgeInsetsPropType", .edge_insets },
+    .{ "EdgeInsetsPrimitive", .edge_insets },
+    .{ "ImageRequest", .image_request },
+    .{ "ImageRequestPrimitive", .image_request },
+    .{ "DimensionValue", .dimension },
+    .{ "DimensionPrimitive", .dimension },
+});
+
+/// codegen 명시적 numeric type alias — RN spec 에서 흔한 wrapper.
+/// `Float`, `Int32`, `Double` 은 AST 의 keyword 가 아니라 type_reference 로 들어옴
+/// (codegen 이 Flow `number` 와 구분해 명시적으로 사용하는 약속된 이름).
+///
+/// PropTypeAnnotation 자체를 StaticStringMap 값으로 두면 generic 타입 추론 실패 —
+/// `enum(@enumFromInt(...))` 같은 핸들러가 필요해서 지표만 매핑하고 dispatch.
+const NumericKind = enum { float, int32, double };
+const numeric_ref_names = std.StaticStringMap(NumericKind).initComptime(.{
+    .{ "Float", .float },
+    .{ "Int32", .int32 },
+    .{ "Double", .double },
+});
+
+fn numericKindToAnnotation(kind: NumericKind) schema.PropTypeAnnotation {
+    return switch (kind) {
+        .float => .{ .float = .{ .default = null } },
+        .int32 => .{ .int32 = .{ .default = 0 } },
+        .double => .{ .double = .{ .default = 0 } },
+    };
+}

--- a/src/transformer/plugins/codegen/schema_builder_test.zig
+++ b/src/transformer/plugins/codegen/schema_builder_test.zig
@@ -1,0 +1,276 @@
+//! schema_builder.zig 단위 테스트.
+//!
+//! 입력 패턴 (TS / Flow):
+//!   - 직접 object body
+//!   - `Readonly<{...}>` / `$ReadOnly<{...}>` wrapper unwrap
+//!   - primitive type, reserved type reference, function type (event)
+//!
+//! Cross-file type reference 는 의도적 fail-fast → UnresolvedTypeReference (#2348 § 5).
+
+const std = @import("std");
+const Scanner = @import("../../../lexer/scanner.zig").Scanner;
+const Parser = @import("../../../parser/parser.zig").Parser;
+const ast_mod = @import("../../../parser/ast.zig");
+const NodeIndex = ast_mod.NodeIndex;
+
+const schema = @import("schema.zig");
+const type_index_mod = @import("type_index.zig");
+const schema_builder = @import("schema_builder.zig");
+
+const ParseMode = enum { ts, flow };
+
+const Parsed = struct {
+    scanner: *Scanner,
+    parser: *Parser,
+    program: NodeIndex,
+    type_index: type_index_mod.TypeIndex,
+    alloc: std.mem.Allocator,
+
+    fn deinit(self: *Parsed) void {
+        self.type_index.deinit(self.alloc);
+        self.parser.deinit();
+        self.alloc.destroy(self.parser);
+        self.scanner.deinit();
+        self.alloc.destroy(self.scanner);
+    }
+};
+
+fn parseAndIndex(alloc: std.mem.Allocator, source: []const u8, mode: ParseMode) !Parsed {
+    const scanner = try alloc.create(Scanner);
+    errdefer alloc.destroy(scanner);
+    scanner.* = try Scanner.init(alloc, source);
+    errdefer scanner.deinit();
+
+    const parser = try alloc.create(Parser);
+    errdefer alloc.destroy(parser);
+    parser.* = Parser.init(alloc, scanner);
+    errdefer parser.deinit();
+
+    switch (mode) {
+        .ts => parser.configureFromExtension(".ts"),
+        .flow => parser.is_flow = true,
+    }
+    const program = try parser.parse();
+    try std.testing.expectEqual(@as(usize, 0), parser.errors.items.len);
+
+    const type_index = try type_index_mod.build(&parser.ast, program, alloc);
+
+    return .{
+        .scanner = scanner,
+        .parser = parser,
+        .program = program,
+        .type_index = type_index,
+        .alloc = alloc,
+    };
+}
+
+/// `name` 의 declaration NodeIndex 로부터 ComponentShape 빌드. caller 가 프리 free.
+fn buildShape(p: *Parsed, type_name: []const u8, component_name: []const u8) !schema.ComponentShape {
+    const decl_idx = p.type_index.get(type_name) orelse return error.TypeNotIndexed;
+    return schema_builder.build(&p.parser.ast, &p.type_index, component_name, decl_idx, p.alloc);
+}
+
+fn freeShape(alloc: std.mem.Allocator, shape: schema.ComponentShape) void {
+    alloc.free(shape.props);
+    alloc.free(shape.events);
+}
+
+test "schema_builder: TS interface with primitive props" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\interface NativeProps {
+        \\  color: string;
+        \\  enabled: boolean;
+        \\  count: number;
+        \\}
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "NativeProps", "MyComponent");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqualStrings("MyComponent", shape.name);
+    try std.testing.expectEqual(@as(usize, 3), shape.props.len);
+    try std.testing.expectEqualStrings("color", shape.props[0].name);
+    try std.testing.expect(shape.props[0].type_annotation == .string);
+    try std.testing.expectEqualStrings("enabled", shape.props[1].name);
+    try std.testing.expect(shape.props[1].type_annotation == .boolean);
+    try std.testing.expectEqualStrings("count", shape.props[2].name);
+    try std.testing.expect(shape.props[2].type_annotation == .float);
+}
+
+test "schema_builder: TS type alias with object body" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { name: string };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expectEqualStrings("name", shape.props[0].name);
+}
+
+test "schema_builder: Readonly<{...}> wrapper unwrap (TS)" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = Readonly<{ color: string }>;
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expectEqualStrings("color", shape.props[0].name);
+    try std.testing.expect(shape.props[0].type_annotation == .string);
+}
+
+test "schema_builder: $ReadOnly<{...}> wrapper unwrap (Flow inexact)" {
+    // 주의: `$ReadOnly<{|...|}>` (exact 안에 generic) 은 Flow 파서가 type argument
+    // 의 `|` 를 union 으로 흡수해서 파싱 실패 — RN spec 엔 거의 안 쓰이지만 별개 이슈.
+    // 본 테스트는 일반 inexact 케이스만 검증.
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = $ReadOnly<{ color: string }>;
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expectEqualStrings("color", shape.props[0].name);
+}
+
+test "schema_builder: ColorValue → reserved.color" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { tint: ColorValue };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .reserved);
+    try std.testing.expectEqual(schema.ReservedPropPrimitive.color, shape.props[0].type_annotation.reserved);
+}
+
+test "schema_builder: ImageSource / PointValue / EdgeInsetsValue 매핑" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = {
+        \\  src: ImageSource;
+        \\  origin: PointValue;
+        \\  insets: EdgeInsetsValue;
+        \\};
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 3), shape.props.len);
+    try std.testing.expectEqual(schema.ReservedPropPrimitive.image_source, shape.props[0].type_annotation.reserved);
+    try std.testing.expectEqual(schema.ReservedPropPrimitive.point, shape.props[1].type_annotation.reserved);
+    try std.testing.expectEqual(schema.ReservedPropPrimitive.edge_insets, shape.props[2].type_annotation.reserved);
+}
+
+test "schema_builder: optional prop sets NamedShape.optional" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { color?: string };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expect(shape.props[0].optional);
+}
+
+test "schema_builder: function-typed prop is classified as event" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = {
+        \\  color: string;
+        \\  onChange: (event: SyntheticEvent) => void;
+        \\};
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expectEqual(@as(usize, 1), shape.events.len);
+    try std.testing.expectEqualStrings("onChange", shape.events[0].name);
+    try std.testing.expectEqual(schema.BubblingType.bubble, shape.events[0].bubbling_type);
+}
+
+test "schema_builder: event with `Capture` suffix → direct" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = {
+        \\  onChangeCapture: () => void;
+        \\};
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.events.len);
+    try std.testing.expectEqual(schema.BubblingType.direct, shape.events[0].bubbling_type);
+}
+
+test "schema_builder: alias 펼치기 — 같은 파일 type X 를 재귀 매핑" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type MyColor = ColorValue;
+        \\type Props = { tint: MyColor };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .reserved);
+    try std.testing.expectEqual(schema.ReservedPropPrimitive.color, shape.props[0].type_annotation.reserved);
+}
+
+test "schema_builder: cross-file reference → UnresolvedTypeReference" {
+    // ViewProps 가 type_index 에 없음 (실제로는 react-native 에서 import).
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { extra: ViewProps };
+    , .ts);
+    defer p.deinit();
+
+    const result = buildShape(&p, "Props", "X");
+    try std.testing.expectError(error.UnresolvedTypeReference, result);
+}
+
+test "schema_builder: alias cycle → UnsupportedPropType (depth limit)" {
+    // type A = B; type B = A; — cycle. depth 가드가 발동해야 함 (MAX_ALIAS_DEPTH).
+    // 미가드 시 stack overflow.
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type A = B;
+        \\type B = A;
+        \\type Props = { x: A };
+    , .ts);
+    defer p.deinit();
+
+    const result = buildShape(&p, "Props", "X");
+    try std.testing.expectError(error.UnsupportedPropType, result);
+}
+
+test "schema_builder: invalid declaration → InvalidNativePropsBody" {
+    // ts_type_alias 가 아닌 노드 (variable_declaration) 를 native_props_idx 로 줌.
+    var p = try parseAndIndex(std.testing.allocator,
+        \\const x = 1;
+    , .ts);
+    defer p.deinit();
+
+    const program_node = p.parser.ast.getNode(p.program);
+    const list = program_node.data.list;
+    try std.testing.expect(list.len > 0);
+    const stmt: NodeIndex = @enumFromInt(p.parser.ast.extra_data.items[list.start]);
+
+    const result = schema_builder.build(&p.parser.ast, &p.type_index, "X", stmt, std.testing.allocator);
+    try std.testing.expectError(error.InvalidNativePropsBody, result);
+}


### PR DESCRIPTION
## 요약

NativeProps type alias / interface declaration 의 body 를 walk 해 `schema.ComponentShape` (PR #1 의 데이터 타입) 를 빌드. ohah/zts#2348 의 PR #3b — codegen plugin (PR #6) 의 핵심 변환 단계.

## 입출력

```zig
pub fn build(
    ast: *const Ast,
    type_index: *const TypeIndex,
    component_name: []const u8,
    native_props_idx: NodeIndex,  // type alias / interface declaration
    alloc: Allocator,
) Error!ComponentShape;

pub const Error = error{
    UnresolvedTypeReference,    // 모르는 type reference (cross-file)
    UnsupportedPropType,        // 미지원 prop type (cycle, complex 등)
    InvalidNativePropsBody,     // declaration 자체가 잘못
    OutOfMemory,
};
```

## 처리 흐름

```
NativeProps declaration NodeIndex
  ↓ resolveDeclarationBody
object body (`Readonly<{...}>` 등 wrapper unwrap)
  ↓ collectObjectMembers
property_signature[] 슬라이스
  ↓ classifyMember (각 멤버)
  ├─ function type → EventTypeShape (events 에 추가)
  └─ 그 외 → PropTypeAnnotation (props 에 추가)
ComponentShape { name, props, events }
```

## 처리 패턴

### Wrapper 풀기

```ts
type Props = Readonly<{ color: string }>;        // → unwrap to inner object
type Props = $ReadOnly<{ color: string }>;       // → unwrap (Flow utility)
type Props = Readonly<Readonly<{...}>>;          // → 재귀 unwrap
```

### Type 매핑 (`GenerateViewConfigJs.js:43-108` 따라)

| AST 형태 | PropTypeAnnotation |
| --- | --- |
| `boolean` | `.boolean` |
| `string` | `.string` |
| `number` | `.float` |
| `any` / `mixed` | `.mixed` |
| `ColorValue` / `ProcessedColorValue` / `ColorPrimitive` | `.reserved = .color` |
| `ImageSource` / `ImageSourcePropType` / `ImageSourcePrimitive` | `.reserved = .image_source` |
| `PointValue` / `PointPropType` / `PointPrimitive` | `.reserved = .point` |
| `EdgeInsetsValue` 등 | `.reserved = .edge_insets` |
| `ImageRequest` 등 | `.reserved = .image_request` |
| `DimensionValue` 등 | `.reserved = .dimension` |
| `Float` | `.float` (numeric wrapper) |
| `Int32` | `.int32` |
| `Double` | `.double` |
| (그 외 type reference) | `type_index` 에서 alias 펼치기 → 재귀 |
| (못 찾으면) | `error.UnresolvedTypeReference` |

매핑 테이블은 `std.StaticStringMap` (`flow_type_keywords` 와 같은 ZTS 컨벤션):

```zig
const reserved_ref_names = std.StaticStringMap(...).initComptime(.{
    .{ "ColorValue", .color },
    .{ "ProcessedColorValue", .color },
    ...
});
```

### Event 분류

property type 이 function type (`ts_function_type` / `flow_function_type`) 이면 EventTypeShape 로 분류:
- `onChange: (e: Event) => void` → bubbling (`bubble`)
- `onChangeCapture: () => void` → direct (이름 끝이 `Capture`)

### Cycle 가드

```ts
type A = B;
type B = A;     // ← 무한 alias chain
type Props = { x: A };
```

`MAX_ALIAS_DEPTH = 8` 깊이 제한으로 `error.UnsupportedPropType`. RN spec 의 alias chain 은 1-2 단계가 일반적이라 8 충분 + cycle 방어.

## 미지원 (의도적, 향후 PR)

- **Array type** (`T[]`, `Array<T>`, `ReadonlyArray<T>`): PR #3b-2
- **Nested object type** (`{ inner: { ... } }`): PR #3b-2
- **String enum union** (`'red' | 'blue'`): PR #3b-2
- **Function argument 추출**: 현재 event 는 name + bubbling 만 보존, argument 트리는 빈 상태. PR #3b-2.
- **Flow `interface NativeProps {...}`**: ZTS 가 Flow interface body 를 brace-skip 하므로 추출 불가 (#2348 § 4 known limitation). type alias 사용 권장.

## 테스트 13 개 (`schema_builder_test.zig`)

```
schema_builder: TS interface with primitive props
schema_builder: TS type alias with object body
schema_builder: Readonly<{...}> wrapper unwrap (TS)
schema_builder: $ReadOnly<{...}> wrapper unwrap (Flow inexact)
schema_builder: ColorValue → reserved.color
schema_builder: ImageSource / PointValue / EdgeInsetsValue 매핑
schema_builder: optional prop sets NamedShape.optional
schema_builder: function-typed prop is classified as event
schema_builder: event with `Capture` suffix → direct
schema_builder: alias 펼치기 — 같은 파일 type X 를 재귀 매핑
schema_builder: cross-file reference → UnresolvedTypeReference
schema_builder: alias cycle → UnsupportedPropType (depth limit)
schema_builder: invalid declaration → InvalidNativePropsBody
```

전체 4400+ 테스트 통과.

## /simplify 처리

리뷰 결과 2 건:
- **`mapReservedRefName` if-chain → `std.StaticStringMap`** (ZTS 의 `flow_type_keywords` 컨벤션 일관성, 16 entries 깔끔하게 처리)
- **`Float`/`Int32`/`Double` 도 동일 패턴** (`NumericKind` enum + dispatch — StaticStringMap value 가 `PropTypeAnnotation` 직접일 땐 generic 추론 실패라 indirection 한 단계)

부차: `stripQuotes` 주석에 "string_literal span 은 따옴표 포함" 명시 (codegen 이 사용 전 strip 필요).

## Zig 초보자용 메모

### `std.StaticStringMap` — comptime hash map

```zig
const map = std.StaticStringMap(ValueType).initComptime(.{
    .{ "key1", value1 },
    .{ "key2", value2 },
});
const result = map.get("key1");  // ?ValueType
```

런타임 hash 없이 comptime 에 perfect hash 빌드. ZTS 의 `flow_type_keywords` 와 동일.

### `mapPropTypeAt(... depth: u8)` 재귀 패턴

cycle 방어로 depth 카운터. 매 재귀 시 +1, MAX_ALIAS_DEPTH 도달하면 fail-fast. visited set 보다 단순 + 메모리 효율.

### Error union vs anyerror

`Error!ComponentShape` 로 명시 — caller 가 어떤 에러가 가능한지 컴파일 타임에 알 수 있음. 도메인-specific error set 으로 두면 `switch` 가 exhaustive 검증 가능.

## 후속 PR

- **PR #4**: `view_config_emitter.zig` — ComponentShape → JS 문자열 (`__INTERNAL_VIEW_CONFIG = {...}`)
- **PR #5**: schema validator + 진단 메시지
- **PR #6**: codegen plugin 통합 (CLI flag, NAPI 옵션)
- **PR #7**: snapshot 회귀

## 관련

- #2348 — meta: `@react-native/codegen` ZTS native 분석
- #2357, #2361 — PR #1, #2 (Schema struct, type indexer)
- #2365, #2369 — PR #3a-1, #3a-2 (TS / Flow property signature 보존)