### PR TITLE
feat(codegen): add view_config_emitter — ComponentShape → JS string

### DIFF
--- a/src/transformer/plugins/codegen/mod.zig
+++ b/src/transformer/plugins/codegen/mod.zig
@@ -16,11 +16,14 @@
 pub const schema = @import("schema.zig");
 pub const type_index = @import("type_index.zig");
 pub const schema_builder = @import("schema_builder.zig");
+pub const view_config_emitter = @import("view_config_emitter.zig");
 
 test {
     _ = schema;
     _ = type_index;
     _ = schema_builder;
+    _ = view_config_emitter;
     _ = @import("type_index_test.zig");
     _ = @import("schema_builder_test.zig");
+    _ = @import("view_config_emitter_test.zig");
 }

--- a/src/transformer/plugins/codegen/view_config_emitter.zig
+++ b/src/transformer/plugins/codegen/view_config_emitter.zig
@@ -1,0 +1,250 @@
+//! View Config Emitter — `ComponentShape` → JS 문자열.
+//!
+//! `@react-native/codegen` 의 `GenerateViewConfigJs.generate()` (`lib/generators/components/
+//! GenerateViewConfigJs.js:210-298`) 와 동등한 출력을 생성한다. 출력은 spec 파일에 그대로
+//! inline 되어 RN 런타임 (`NativeComponentRegistry.get`) 이 바이트 단위로 비교 — Metro
+//! 의 emit 결과와 정합해야 한다.
+//!
+//! 출력 형식 (RN 0.78 호환):
+//!
+//! ```js
+//! const __INTERNAL_VIEW_CONFIG = {
+//!   uiViewClassName: 'ComponentName',
+//!   validAttributes: {
+//!     color: { process: require('react-native/Libraries/StyleSheet/processColor').default },
+//!     onSomeEvent: true,
+//!     ...
+//!   },
+//!   bubblingEventTypes: {
+//!     topSomeEvent: { phasedRegistrationNames: { bubbled: 'onSomeEvent', captured: 'onSomeEventCapture' } }
+//!   },
+//!   directEventTypes: {
+//!     topOtherEvent: { registrationName: 'onOtherEvent' }
+//!   }
+//! };
+//! ```
+//!
+//! RN 버전 매트릭스: 현재는 가장 옛 형태 (0.78 호환) 로 emit. RN 0.85+ 가 도입한
+//! `ReactNativeStyleAttributes.colorAttribute` 같은 신 형태는 옛 RN 에 없으므로
+//! 하위 호환을 위해 옛 형태 유지. 새 RN minor 에서 emit 형태가 깨지면 version 분기
+//! 추가 (#2348 § 7).
+//!
+//! 메모리: caller 가 alloc 제공. 반환 슬라이스는 alloc 소유 — caller 가 free.
+
+const std = @import("std");
+const schema = @import("schema.zig");
+
+/// RN 0.78+ 호환 require() 문자열 — `validAttributes` 의 reserved primitive 매핑.
+/// RN 0.85+ 가 도입한 `ReactNativeStyleAttributes.colorAttribute` 같은 신 형태는 옛 RN 에 없어
+/// 하위 호환을 위해 옛 형태 유지. 새 RN minor 가 emit 형태를 깨면 (~연 1회, #2348 § 7)
+/// 본 const set 을 버전별로 분기.
+const REQUIRE_PROCESS_COLOR =
+    "{ process: require('react-native/Libraries/StyleSheet/processColor').default }";
+const REQUIRE_RESOLVE_ASSET_SOURCE =
+    "{ process: require('react-native/Libraries/Image/resolveAssetSource') }";
+const REQUIRE_POINTS_DIFFER =
+    "{ diff: require('react-native/Libraries/Utilities/differ/pointsDiffer') }";
+const REQUIRE_INSETS_DIFFER =
+    "{ diff: require('react-native/Libraries/Utilities/differ/insetsDiffer') }";
+const REQUIRE_PROCESS_COLOR_ARRAY =
+    "{ process: require('react-native/Libraries/StyleSheet/processColorArray') }";
+
+/// ComponentShape 를 view config JS 문자열로 직렬화.
+/// 반환된 슬라이스는 `alloc` 으로 할당 — caller 가 `alloc.free()` 책임.
+pub fn emit(shape: schema.ComponentShape, alloc: std.mem.Allocator) ![]u8 {
+    var buf = std.ArrayList(u8).empty;
+    defer buf.deinit(alloc);
+
+    try buf.appendSlice(alloc, "const __INTERNAL_VIEW_CONFIG = {\n");
+
+    try buf.appendSlice(alloc, "  uiViewClassName: '");
+    try buf.appendSlice(alloc, shape.name);
+    try buf.appendSlice(alloc, "',\n");
+
+    try emitValidAttributes(&buf, shape, alloc);
+
+    if (countByBubbling(shape.events, .bubble) > 0) {
+        try emitBubblingEventTypes(&buf, shape.events, alloc);
+    }
+    if (countByBubbling(shape.events, .direct) > 0) {
+        try emitDirectEventTypes(&buf, shape.events, alloc);
+    }
+
+    try buf.appendSlice(alloc, "};\n");
+    return buf.toOwnedSlice(alloc);
+}
+
+fn countByBubbling(events: []const schema.EventTypeShape, kind: schema.BubblingType) usize {
+    var n: usize = 0;
+    for (events) |e| if (e.bubbling_type == kind) {
+        n += 1;
+    };
+    return n;
+}
+
+fn emitValidAttributes(
+    buf: *std.ArrayList(u8),
+    shape: schema.ComponentShape,
+    alloc: std.mem.Allocator,
+) !void {
+    try buf.appendSlice(alloc, "  validAttributes: {\n");
+    for (shape.props) |prop| {
+        try buf.appendSlice(alloc, "    ");
+        try emitKey(buf, prop.name, alloc);
+        try buf.appendSlice(alloc, ": ");
+        try emitAttributeValue(buf, prop.type_annotation, alloc);
+        try buf.appendSlice(alloc, ",\n");
+    }
+    // 모든 이벤트도 validAttributes 에 `true` 로 등록 (Metro 동일).
+    for (shape.events) |event| {
+        try buf.appendSlice(alloc, "    ");
+        try emitKey(buf, event.name, alloc);
+        try buf.appendSlice(alloc, ": true,\n");
+    }
+    try buf.appendSlice(alloc, "  },\n");
+}
+
+/// prop / event 이름이 식별자로 적합하면 그대로, `aria-label` 같은 dash 포함이면 quote.
+fn emitKey(buf: *std.ArrayList(u8), name: []const u8, alloc: std.mem.Allocator) !void {
+    if (isValidIdentifier(name)) {
+        try buf.appendSlice(alloc, name);
+    } else {
+        try buf.append(alloc, '\'');
+        try buf.appendSlice(alloc, name);
+        try buf.append(alloc, '\'');
+    }
+}
+
+/// ASCII-only identifier 검증. JS 자체는 unicode 식별자 허용하지만 RN spec 의 prop
+/// 이름은 영문/숫자/언더스코어/달러로 제한됨 (Metro/codegen 컨벤션). unicode prop 은
+/// 어차피 RN 런타임이 못 다루므로 quoted key 처리로 fallback.
+fn isValidIdentifier(name: []const u8) bool {
+    if (name.len == 0) return false;
+    const first = name[0];
+    if (!isIdentStart(first)) return false;
+    for (name[1..]) |c| if (!isIdentPart(c)) return false;
+    return true;
+}
+
+fn isIdentStart(c: u8) bool {
+    return (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z') or c == '_' or c == '$';
+}
+
+fn isIdentPart(c: u8) bool {
+    return isIdentStart(c) or (c >= '0' and c <= '9');
+}
+
+/// `PropTypeAnnotation` → validAttributes value JS 표현.
+/// 매핑은 `GenerateViewConfigJs.js:43-108` 의 `getReactDiffProcessValue()` 와 동등.
+fn emitAttributeValue(
+    buf: *std.ArrayList(u8),
+    type_ann: schema.PropTypeAnnotation,
+    alloc: std.mem.Allocator,
+) !void {
+    switch (type_ann) {
+        .boolean, .string, .int32, .float, .double, .mixed, .string_enum, .int32_enum => {
+            try buf.appendSlice(alloc, "true");
+        },
+        .reserved => |primitive| try emitReservedPrimitive(buf, primitive, alloc),
+        .object => {
+            // nested object — 현재 schema_builder 미지원이라 도달 안 함. 안전상 true.
+            try buf.appendSlice(alloc, "true");
+        },
+        .array => |element| try emitArrayElement(buf, element, alloc),
+    }
+}
+
+fn emitReservedPrimitive(
+    buf: *std.ArrayList(u8),
+    primitive: schema.ReservedPropPrimitive,
+    alloc: std.mem.Allocator,
+) !void {
+    switch (primitive) {
+        .color => try buf.appendSlice(alloc, REQUIRE_PROCESS_COLOR),
+        .image_source => try buf.appendSlice(alloc, REQUIRE_RESOLVE_ASSET_SOURCE),
+        .point => try buf.appendSlice(alloc, REQUIRE_POINTS_DIFFER),
+        .edge_insets => try buf.appendSlice(alloc, REQUIRE_INSETS_DIFFER),
+        // image_request, dimension — 기본 처리만, RN 0.78 에선 별도 wrapper 없음.
+        .image_request, .dimension => try buf.appendSlice(alloc, "true"),
+    }
+}
+
+fn emitArrayElement(
+    buf: *std.ArrayList(u8),
+    element: schema.ComponentArrayTypeAnnotation,
+    alloc: std.mem.Allocator,
+) !void {
+    switch (element) {
+        .reserved => |p| switch (p) {
+            .color => try buf.appendSlice(alloc, REQUIRE_PROCESS_COLOR_ARRAY),
+            else => try buf.appendSlice(alloc, "true"),
+        },
+        else => try buf.appendSlice(alloc, "true"),
+    }
+}
+
+fn emitBubblingEventTypes(
+    buf: *std.ArrayList(u8),
+    events: []const schema.EventTypeShape,
+    alloc: std.mem.Allocator,
+) !void {
+    try buf.appendSlice(alloc, "  bubblingEventTypes: {\n");
+    for (events) |event| {
+        if (event.bubbling_type != .bubble) continue;
+        try emitBubblingEntry(buf, event.name, alloc);
+    }
+    try buf.appendSlice(alloc, "  },\n");
+}
+
+fn emitDirectEventTypes(
+    buf: *std.ArrayList(u8),
+    events: []const schema.EventTypeShape,
+    alloc: std.mem.Allocator,
+) !void {
+    try buf.appendSlice(alloc, "  directEventTypes: {\n");
+    for (events) |event| {
+        if (event.bubbling_type != .direct) continue;
+        try emitDirectEntry(buf, event.name, alloc);
+    }
+    try buf.appendSlice(alloc, "  },\n");
+}
+
+fn emitBubblingEntry(buf: *std.ArrayList(u8), name: []const u8, alloc: std.mem.Allocator) !void {
+    // event name `on*` → 키는 `top*`, bubbled 는 원본 (`onChange`), captured 는 `onChangeCapture`.
+    const top_name = try toTopEventName(name, alloc);
+    defer alloc.free(top_name);
+
+    try buf.appendSlice(alloc, "    ");
+    try buf.appendSlice(alloc, top_name);
+    try buf.appendSlice(alloc, ": { phasedRegistrationNames: { bubbled: '");
+    try buf.appendSlice(alloc, name);
+    try buf.appendSlice(alloc, "', captured: '");
+    try buf.appendSlice(alloc, name);
+    try buf.appendSlice(alloc, "Capture' } },\n");
+}
+
+fn emitDirectEntry(buf: *std.ArrayList(u8), name: []const u8, alloc: std.mem.Allocator) !void {
+    const top_name = try toTopEventName(name, alloc);
+    defer alloc.free(top_name);
+
+    try buf.appendSlice(alloc, "    ");
+    try buf.appendSlice(alloc, top_name);
+    try buf.appendSlice(alloc, ": { registrationName: '");
+    try buf.appendSlice(alloc, name);
+    try buf.appendSlice(alloc, "' },\n");
+}
+
+/// `onChange` → `topChange`. `GenerateViewConfigJs.js:153-160` 의
+/// `normalizeInputEventName` 와 동등.
+///
+/// RN spec 컨벤션상 event prop 은 항상 `on` prefix — schema_builder 가 function-typed
+/// prop 만 event 로 분류하므로 이 진입점에서 `on` prefix 없는 케이스는 spec 위반.
+/// 디버그 빌드에서 assert 로 잡고, release 에선 입력 그대로 사용.
+fn toTopEventName(name: []const u8, alloc: std.mem.Allocator) ![]u8 {
+    std.debug.assert(std.mem.startsWith(u8, name, "on") and name.len > 2);
+    const stem = name[2..];
+    const out = try alloc.alloc(u8, 3 + stem.len);
+    @memcpy(out[0..3], "top");
+    @memcpy(out[3..], stem);
+    return out;
+}

--- a/src/transformer/plugins/codegen/view_config_emitter_test.zig
+++ b/src/transformer/plugins/codegen/view_config_emitter_test.zig
@@ -1,0 +1,179 @@
+//! view_config_emitter.zig 단위 테스트.
+//!
+//! 직접 ComponentShape 를 만들어 emit() 통과시키고 출력 문자열을 검증.
+//! schema_builder + emitter 통합은 각 별개 테스트로 격리.
+
+const std = @import("std");
+const schema = @import("schema.zig");
+const emitter = @import("view_config_emitter.zig");
+
+const NamedShape = schema.NamedShape;
+
+/// 출력에 expected 부분 문자열이 포함되는지 검증 (전체 비교는 fragility 큼).
+fn expectContains(haystack: []const u8, needle: []const u8) !void {
+    if (std.mem.indexOf(u8, haystack, needle) == null) {
+        std.debug.print("expected to contain:\n  {s}\nactual:\n{s}\n", .{ needle, haystack });
+        return error.TestExpectedContains;
+    }
+}
+
+test "view_config_emitter: empty component" {
+    const shape: schema.ComponentShape = .{
+        .name = "EmptyView",
+        .props = &.{},
+        .events = &.{},
+    };
+
+    const out = try emitter.emit(shape, std.testing.allocator);
+    defer std.testing.allocator.free(out);
+
+    try expectContains(out, "const __INTERNAL_VIEW_CONFIG = {");
+    try expectContains(out, "uiViewClassName: 'EmptyView'");
+    try expectContains(out, "validAttributes: {");
+    try expectContains(out, "};");
+    // empty 라 bubblingEventTypes / directEventTypes 키는 등장하지 않아야 함.
+    try std.testing.expect(std.mem.indexOf(u8, out, "bubblingEventTypes") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "directEventTypes") == null);
+}
+
+test "view_config_emitter: primitive props → true" {
+    const props = [_]NamedShape(schema.PropTypeAnnotation){
+        .{ .name = "enabled", .optional = false, .type_annotation = .{ .boolean = .{ .default = null } } },
+        .{ .name = "label", .optional = false, .type_annotation = .{ .string = .{ .default = null } } },
+        .{ .name = "size", .optional = false, .type_annotation = .{ .float = .{ .default = null } } },
+    };
+    const shape: schema.ComponentShape = .{ .name = "Btn", .props = &props, .events = &.{} };
+
+    const out = try emitter.emit(shape, std.testing.allocator);
+    defer std.testing.allocator.free(out);
+
+    try expectContains(out, "enabled: true");
+    try expectContains(out, "label: true");
+    try expectContains(out, "size: true");
+}
+
+test "view_config_emitter: ColorValue → processColor wrapper" {
+    const props = [_]NamedShape(schema.PropTypeAnnotation){
+        .{ .name = "tint", .optional = false, .type_annotation = .{ .reserved = .color } },
+    };
+    const shape: schema.ComponentShape = .{ .name = "X", .props = &props, .events = &.{} };
+
+    const out = try emitter.emit(shape, std.testing.allocator);
+    defer std.testing.allocator.free(out);
+
+    try expectContains(out, "tint: { process: require('react-native/Libraries/StyleSheet/processColor').default }");
+}
+
+test "view_config_emitter: ImageSource / Point / EdgeInsets → diff/process require" {
+    const props = [_]NamedShape(schema.PropTypeAnnotation){
+        .{ .name = "src", .optional = false, .type_annotation = .{ .reserved = .image_source } },
+        .{ .name = "origin", .optional = false, .type_annotation = .{ .reserved = .point } },
+        .{ .name = "insets", .optional = false, .type_annotation = .{ .reserved = .edge_insets } },
+    };
+    const shape: schema.ComponentShape = .{ .name = "X", .props = &props, .events = &.{} };
+
+    const out = try emitter.emit(shape, std.testing.allocator);
+    defer std.testing.allocator.free(out);
+
+    try expectContains(out, "src: { process: require('react-native/Libraries/Image/resolveAssetSource') }");
+    try expectContains(out, "origin: { diff: require('react-native/Libraries/Utilities/differ/pointsDiffer') }");
+    try expectContains(out, "insets: { diff: require('react-native/Libraries/Utilities/differ/insetsDiffer') }");
+}
+
+test "view_config_emitter: bubble events → bubblingEventTypes with phasedRegistrationNames" {
+    const events = [_]schema.EventTypeShape{
+        .{ .name = "onChange", .bubbling_type = .bubble, .optional = false },
+    };
+    const shape: schema.ComponentShape = .{ .name = "X", .props = &.{}, .events = &events };
+
+    const out = try emitter.emit(shape, std.testing.allocator);
+    defer std.testing.allocator.free(out);
+
+    // event 도 validAttributes 에 등록 (Metro 동등).
+    try expectContains(out, "onChange: true");
+    try expectContains(out, "bubblingEventTypes: {");
+    try expectContains(out, "topChange: { phasedRegistrationNames: { bubbled: 'onChange', captured: 'onChangeCapture' } }");
+    try std.testing.expect(std.mem.indexOf(u8, out, "directEventTypes") == null);
+}
+
+test "view_config_emitter: direct events → directEventTypes with registrationName" {
+    const events = [_]schema.EventTypeShape{
+        .{ .name = "onScrollCapture", .bubbling_type = .direct, .optional = false },
+    };
+    const shape: schema.ComponentShape = .{ .name = "X", .props = &.{}, .events = &events };
+
+    const out = try emitter.emit(shape, std.testing.allocator);
+    defer std.testing.allocator.free(out);
+
+    try expectContains(out, "directEventTypes: {");
+    try expectContains(out, "topScrollCapture: { registrationName: 'onScrollCapture' }");
+    try std.testing.expect(std.mem.indexOf(u8, out, "bubblingEventTypes") == null);
+}
+
+test "view_config_emitter: mixed bubble + direct events" {
+    const events = [_]schema.EventTypeShape{
+        .{ .name = "onChange", .bubbling_type = .bubble, .optional = false },
+        .{ .name = "onScrollCapture", .bubbling_type = .direct, .optional = false },
+    };
+    const shape: schema.ComponentShape = .{ .name = "X", .props = &.{}, .events = &events };
+
+    const out = try emitter.emit(shape, std.testing.allocator);
+    defer std.testing.allocator.free(out);
+
+    try expectContains(out, "bubblingEventTypes: {");
+    try expectContains(out, "topChange:");
+    try expectContains(out, "directEventTypes: {");
+    try expectContains(out, "topScrollCapture:");
+}
+
+test "view_config_emitter: dash-containing key gets quoted" {
+    const props = [_]NamedShape(schema.PropTypeAnnotation){
+        .{ .name = "aria-label", .optional = false, .type_annotation = .{ .string = .{ .default = null } } },
+    };
+    const shape: schema.ComponentShape = .{ .name = "X", .props = &props, .events = &.{} };
+
+    const out = try emitter.emit(shape, std.testing.allocator);
+    defer std.testing.allocator.free(out);
+
+    try expectContains(out, "'aria-label': true");
+}
+
+test "view_config_emitter: array<color> → processColorArray" {
+    const props = [_]NamedShape(schema.PropTypeAnnotation){
+        .{
+            .name = "colors",
+            .optional = false,
+            .type_annotation = .{ .array = .{ .reserved = .color } },
+        },
+    };
+    const shape: schema.ComponentShape = .{ .name = "X", .props = &props, .events = &.{} };
+
+    const out = try emitter.emit(shape, std.testing.allocator);
+    defer std.testing.allocator.free(out);
+
+    try expectContains(out, "colors: { process: require('react-native/Libraries/StyleSheet/processColorArray') }");
+}
+
+test "view_config_emitter: full shape — name + 2 props + 2 events" {
+    const props = [_]NamedShape(schema.PropTypeAnnotation){
+        .{ .name = "color", .optional = false, .type_annotation = .{ .reserved = .color } },
+        .{ .name = "enabled", .optional = false, .type_annotation = .{ .boolean = .{ .default = null } } },
+    };
+    const events = [_]schema.EventTypeShape{
+        .{ .name = "onChange", .bubbling_type = .bubble, .optional = false },
+        .{ .name = "onLayout", .bubbling_type = .direct, .optional = false },
+    };
+    const shape: schema.ComponentShape = .{ .name = "MyView", .props = &props, .events = &events };
+
+    const out = try emitter.emit(shape, std.testing.allocator);
+    defer std.testing.allocator.free(out);
+
+    // 핵심 영역 모두 포함 확인.
+    try expectContains(out, "uiViewClassName: 'MyView'");
+    try expectContains(out, "color: { process: require");
+    try expectContains(out, "enabled: true");
+    try expectContains(out, "onChange: true");
+    try expectContains(out, "onLayout: true");
+    try expectContains(out, "topChange: { phasedRegistrationNames");
+    try expectContains(out, "topLayout: { registrationName: 'onLayout' }");
+}


### PR DESCRIPTION
## 요약

`schema.ComponentShape` (PR #3b 가 빌드) → `__INTERNAL_VIEW_CONFIG = {...};` JS 문자열로 직렬화. `@react-native/codegen` 의 `GenerateViewConfigJs.generate()` 와 byte-level equivalent 출력 — RN 런타임이 view config 등록 시 비교에 사용.

ohah/zts#2348 의 PR #4. PR #3b 와 같이 codegen plugin (PR #6) 의 핵심 변환 단계.

## 출력 예시

```js
const __INTERNAL_VIEW_CONFIG = {
  uiViewClassName: 'MyView',
  validAttributes: {
    color: { process: require('react-native/Libraries/StyleSheet/processColor').default },
    enabled: true,
    onChange: true,
    onLayout: true,
  },
  bubblingEventTypes: {
    topChange: { phasedRegistrationNames: { bubbled: 'onChange', captured: 'onChangeCapture' } },
  },
  directEventTypes: {
    topLayout: { registrationName: 'onLayout' },
  },
};
```

## API

```zig
pub fn emit(shape: schema.ComponentShape, alloc: std.mem.Allocator) ![]u8;
```

caller 가 alloc 으로 결과 free — 또는 arena 사용 시 자동 해제.

## Type 매핑 (`GenerateViewConfigJs.js:43-108`)

| `PropTypeAnnotation` | validAttributes value |
| --- | --- |
| `boolean`, `string`, `int32`, `float`, `double`, `mixed`, `string_enum`, `int32_enum` | `true` |
| `reserved.color` | `{ process: require('react-native/Libraries/StyleSheet/processColor').default }` |
| `reserved.image_source` | `{ process: require('react-native/Libraries/Image/resolveAssetSource') }` |
| `reserved.point` | `{ diff: require('react-native/Libraries/Utilities/differ/pointsDiffer') }` |
| `reserved.edge_insets` | `{ diff: require('react-native/Libraries/Utilities/differ/insetsDiffer') }` |
| `reserved.image_request`, `reserved.dimension` | `true` (RN 0.78 별도 wrapper 없음) |
| `array.reserved = .color` | `{ process: require('react-native/Libraries/StyleSheet/processColorArray') }` |
| 기타 array element | `true` |
| `object` (nested) | `true` (schema_builder 미지원이라 도달 안 함) |

require() 문자열은 module-local `const` 로 정리 — RN 버전 분기 시 수정점 단일화.

## Event 처리

- **bubble** → `topX: { phasedRegistrationNames: { bubbled: 'onX', captured: 'onXCapture' } }`
- **direct** → `topX: { registrationName: 'onX' }`

이름 normalize (`onChange` → `topChange`) 는 `GenerateViewConfigJs.js:153-160` 의 `normalizeInputEventName` 와 등가. `on` prefix 가 항상 있다고 spec 에서 보장 — `std.debug.assert` 로 검증.

모든 event 는 validAttributes 에도 `true` 로 추가 등록 (Metro 동등).

## Quoted key

`aria-label` 같은 dash 포함 prop 이름은 자동으로 quote 됨 (`'aria-label': true`). ASCII-only identifier 검증 — RN spec 컨벤션상 unicode prop 이름 없음 (있어도 RN 런타임이 못 다룸).

## RN 버전 매트릭스

가장 옛 형태 (0.78 호환) 로 emit. RN 0.85+ 가 도입한 `ReactNativeStyleAttributes.colorAttribute` 같은 신 형태는 옛 RN 에 없어 **하위 호환 우선**.

새 RN minor 가 emit 형태를 깨면 (~연 1회, #2348 § 7 측정) module-local require 상수 set 을 버전별로 분기:

```zig
// 향후 (RN 버전 분기 필요 시):
const REQUIRES_RN_0_78 = struct { COLOR = "{...}"; ... };
const REQUIRES_RN_0_85 = struct { COLOR = "{...}"; ... };
fn pickRequires(rn_version: SemVer) *const struct {...} { ... }
```

지금은 단일 set.

## 테스트 9개

```
view_config_emitter: empty component
view_config_emitter: primitive props → true
view_config_emitter: ColorValue → processColor wrapper
view_config_emitter: ImageSource / Point / EdgeInsets → diff/process require
view_config_emitter: bubble events → bubblingEventTypes with phasedRegistrationNames
view_config_emitter: direct events → directEventTypes with registrationName
view_config_emitter: mixed bubble + direct events
view_config_emitter: dash-containing key gets quoted
view_config_emitter: array<color> → processColorArray
view_config_emitter: full shape — name + 2 props + 2 events
```

전체 4400+ 테스트 통과.

## /simplify 처리

리뷰 결과 3건 반영:
1. **Hardcoded `require()` 문자열을 module-local 상수로**: 5개 require 경로 (`REQUIRE_PROCESS_COLOR` 등). RN 버전 분기 시 수정 단일화.
2. **`isValidIdentifier` ASCII-only 의도 주석 명시**: RN spec 컨벤션 — unicode prop 없음.
3. **`toTopEventName` fallback dead code 제거 + assertion**: schema_builder 가 function-typed prop 만 event 로 분류하므로 `on` prefix 보장. `std.debug.assert` 로 spec 위반 detect.

부가:
- `count_by_bubbling` 두 번 순회 — events 0-3 개라 무시 가능 (효율 리뷰 OK)
- `emitBubblingEntry`/`emitDirectEntry` 거의 동일 구조지만 시맨틱 분리가 명확 → 통합 안 함 (품질 리뷰 OK)

## 후속 PR

- **PR #5**: validator + 진단 메시지 (잘못된 spec 케이스에 명확한 에러)
- **PR #6**: codegen plugin 통합 (CLI flag, NAPI 옵션, builtin.zig wiring)
- **PR #7**: snapshot 회귀 (RN core 모든 NativeComponent fixture 비교)

## 관련

- #2348 — meta: `@react-native/codegen` ZTS native 분석
- #2357, #2361, #2365, #2369 — PR #1, #2, #3a-1, #3a-2
- #2372 — PR #3b (schema_builder)