### PR TITLE
feat(codegen): add validator + ZTS error codes (1400-1499)

### DIFF
--- a/src/error_codes.zig
+++ b/src/error_codes.zig
@@ -18,6 +18,7 @@
 //!   1100-1199  시맨틱: private member
 //!   1200-1299  시맨틱: export/label
 //!   1300-1399  시맨틱: class/getter/setter/object
+//!   1400-1499  codegen: RN view config 빌드
 
 /// 문서 사이트 에러 레퍼런스 base URL. Code.docsUrl이 여기에 코드를 붙여 전체 URL 생성.
 const docs_url_base = "https://ohah.github.io/zts/reference/errors/";
@@ -216,6 +217,20 @@ pub const Code = enum(u16) {
     getter_no_params = 1302,
     setter_one_param = 1303,
 
+    // ═══════════════════════════════════════════════════════
+    // 1400-1499: codegen — RN view config 빌드 (#2348)
+    // ═══════════════════════════════════════════════════════
+    /// type reference 가 같은 파일에 정의 안 됨 — 보통 cross-file import 상황.
+    /// codegen plugin 이 fail-fast 후 JS fallback (`@react-native/codegen`) 으로 위임.
+    codegen_unresolved_type_reference = 1400,
+    /// codegen 이 인식 못 하는 prop type 형태 (array of object, complex generic 등).
+    /// 향후 PR #3b-2 에서 확장.
+    codegen_unsupported_prop_type = 1401,
+    /// NativeProps declaration 이 object literal 도 wrapper 도 아님.
+    codegen_invalid_native_props_body = 1402,
+    /// 같은 schema 안에 같은 이름 component 가 2 개 이상 — `SchemaValidator.js` 동등.
+    codegen_duplicate_component = 1403,
+
     /// 에러 코드를 "ZTS0001" 형식의 문자열로 반환한다.
     pub fn format(self: Code) []const u8 {
         @setEvalBranchQuota(100_000);
@@ -257,6 +272,11 @@ pub const Code = enum(u16) {
             // 번들러
             .unresolved_import => "Check the import path spelling and confirm the file exists.",
             .missing_export => "Verify the exported name. Use 'export * from' or named re-exports if needed.",
+            // codegen (#2348)
+            .codegen_unresolved_type_reference => "Define the referenced type in the same file, or codegen will fall back to @react-native/codegen.",
+            .codegen_unsupported_prop_type => "Use a primitive (boolean/string/number), reserved type (ColorValue/PointValue/...), or function type for events. Complex shapes (nested objects, generic arrays) are not yet supported.",
+            .codegen_invalid_native_props_body => "NativeProps must be a `type X = { ... }` or `type X = $ReadOnly<{ ... }>` declaration referencing an object literal.",
+            .codegen_duplicate_component => "Each component name in a NativeComponent spec must be unique within the schema.",
             else => null,
         };
     }
@@ -421,6 +441,11 @@ pub const Code = enum(u16) {
             .proto_duplicate => "Property name __proto__ appears more than once in object literal",
             .getter_no_params => "Getter must not have any formal parameters",
             .setter_one_param => "Setter must have exactly one formal parameter",
+            // codegen (#2348)
+            .codegen_unresolved_type_reference => "Type reference is not defined in the same file",
+            .codegen_unsupported_prop_type => "Prop type is not supported by codegen",
+            .codegen_invalid_native_props_body => "NativeProps body is not an object literal or known wrapper",
+            .codegen_duplicate_component => "Duplicate component name in schema",
         };
     }
 };

--- a/src/transformer/plugins/codegen/mod.zig
+++ b/src/transformer/plugins/codegen/mod.zig
@@ -17,13 +17,16 @@ pub const schema = @import("schema.zig");
 pub const type_index = @import("type_index.zig");
 pub const schema_builder = @import("schema_builder.zig");
 pub const view_config_emitter = @import("view_config_emitter.zig");
+pub const validator = @import("validator.zig");
 
 test {
     _ = schema;
     _ = type_index;
     _ = schema_builder;
     _ = view_config_emitter;
+    _ = validator;
     _ = @import("type_index_test.zig");
     _ = @import("schema_builder_test.zig");
     _ = @import("view_config_emitter_test.zig");
+    _ = @import("validator_test.zig");
 }

--- a/src/transformer/plugins/codegen/validator.zig
+++ b/src/transformer/plugins/codegen/validator.zig
@@ -1,0 +1,48 @@
+//! Schema Validator — `ComponentSchema` 정합성 검증.
+//!
+//! `@react-native/codegen` 의 `SchemaValidator.js:14-48` 동등 — schema 안에서 같은
+//! component 이름이 두 번 이상 등장하지 않는지 확인.
+//!
+//! 단일 spec 파일 변환에서는 component 1 개라 사실상 trivial하지만, 향후 multi-component
+//! spec (한 파일에 `codegenNativeComponent` 두 개) 또는 schema aggregation 시점을
+//! 위해 추가.
+//!
+//! `schema_builder` 가 던지는 `error.UnresolvedTypeReference` / `UnsupportedPropType` /
+//! `InvalidNativePropsBody` 도 같은 codegen 에러 코드 family (1400-1499) 와 매핑.
+//! 코드 정의: `error_codes.zig:codegen_*`.
+
+const std = @import("std");
+const schema = @import("schema.zig");
+const schema_builder = @import("schema_builder.zig");
+const Code = @import("../../../error_codes.zig").Code;
+
+/// `ComponentSchema` 정합성 검증. duplicate component 발견 시 첫 충돌 이름 반환,
+/// 없으면 null. caller 가 진단 메시지 빌드 시 이름 사용 +
+/// `Code.codegen_duplicate_component` 로 분류.
+///
+/// 빈 schema (component 0 개) 는 null 반환.
+///
+/// 보통 component 1-3 개라 단순 nested loop O(N²) 가 hash table 보다 빠름 — RN core
+/// 의 가장 큰 spec 도 component < 5 개. components 가 20+ 으로 일반화되면 HashSet 으로 전환.
+pub fn validate(component_schema: schema.ComponentSchema) ?[]const u8 {
+    for (component_schema.components, 0..) |c, i| {
+        for (component_schema.components[i + 1 ..]) |other| {
+            if (std.mem.eql(u8, c.name, other.name)) return c.name;
+        }
+    }
+    return null;
+}
+
+/// `schema_builder.Error` → `error_codes.Code` 매핑. 진단 출력 시 사용 — 사용자가 docs 사이트
+/// (`https://ohah.github.io/zts/reference/errors/zts1400/`) 로 찾아갈 수 있도록 ZTS 표준 코드.
+///
+/// `OutOfMemory` 는 codegen 도메인 외 — caller 가 먼저 분기해 처리해야 함.
+/// 본 함수에 OOM 을 넘기는 건 프로그래밍 버그 (`unreachable`).
+pub fn schemaBuilderErrorCode(err: schema_builder.Error) Code {
+    return switch (err) {
+        error.UnresolvedTypeReference => .codegen_unresolved_type_reference,
+        error.UnsupportedPropType => .codegen_unsupported_prop_type,
+        error.InvalidNativePropsBody => .codegen_invalid_native_props_body,
+        error.OutOfMemory => unreachable, // caller 가 먼저 분기해야 함
+    };
+}

--- a/src/transformer/plugins/codegen/validator_test.zig
+++ b/src/transformer/plugins/codegen/validator_test.zig
@@ -1,0 +1,62 @@
+//! validator.zig 단위 테스트.
+
+const std = @import("std");
+const schema = @import("schema.zig");
+const validator = @import("validator.zig");
+const Code = @import("../../../error_codes.zig").Code;
+
+test "validator: empty schema → null" {
+    const cs: schema.ComponentSchema = .{ .components = &.{} };
+    try std.testing.expect(validator.validate(cs) == null);
+}
+
+test "validator: single component → null" {
+    const cs: schema.ComponentSchema = .{ .components = &[_]schema.ComponentShape{
+        .{ .name = "MyView", .props = &.{}, .events = &.{} },
+    } };
+    try std.testing.expect(validator.validate(cs) == null);
+}
+
+test "validator: distinct component names → null" {
+    const cs: schema.ComponentSchema = .{ .components = &[_]schema.ComponentShape{
+        .{ .name = "View", .props = &.{}, .events = &.{} },
+        .{ .name = "Text", .props = &.{}, .events = &.{} },
+        .{ .name = "Image", .props = &.{}, .events = &.{} },
+    } };
+    try std.testing.expect(validator.validate(cs) == null);
+}
+
+test "validator: duplicate component name → returns first conflict" {
+    const cs: schema.ComponentSchema = .{
+        .components = &[_]schema.ComponentShape{
+            .{ .name = "View", .props = &.{}, .events = &.{} },
+            .{ .name = "Text", .props = &.{}, .events = &.{} },
+            .{ .name = "View", .props = &.{}, .events = &.{} }, // 중복
+        },
+    };
+    const dup = validator.validate(cs);
+    try std.testing.expect(dup != null);
+    try std.testing.expectEqualStrings("View", dup.?);
+}
+
+test "validator: error code mapping — schema_builder errors" {
+    try std.testing.expectEqual(
+        Code.codegen_unresolved_type_reference,
+        validator.schemaBuilderErrorCode(error.UnresolvedTypeReference),
+    );
+    try std.testing.expectEqual(
+        Code.codegen_unsupported_prop_type,
+        validator.schemaBuilderErrorCode(error.UnsupportedPropType),
+    );
+    try std.testing.expectEqual(
+        Code.codegen_invalid_native_props_body,
+        validator.schemaBuilderErrorCode(error.InvalidNativePropsBody),
+    );
+}
+
+test "validator: error codes resolve to ZTS1400 series" {
+    try std.testing.expectEqualStrings("ZTS1400", Code.codegen_unresolved_type_reference.format());
+    try std.testing.expectEqualStrings("ZTS1401", Code.codegen_unsupported_prop_type.format());
+    try std.testing.expectEqualStrings("ZTS1402", Code.codegen_invalid_native_props_body.format());
+    try std.testing.expectEqualStrings("ZTS1403", Code.codegen_duplicate_component.format());
+}


### PR DESCRIPTION
## 요약

`@react-native/codegen` 의 `SchemaValidator.js:14-48` 동등 — schema 안에서 같은 component 이름이 두 번 등장하지 않는지 검증. 추가로 codegen 에러 4 종을 ZTS 표준 코드 (1400-1499 슬롯) 로 등록해 진단 메시지 + docs 링크 자동 생성.

ohah/zts#2348 의 PR #5. 다음 PR #6 (codegen plugin 통합) 의 진단 출력에 사용.

## 추가 ZTS 에러 코드 (1400-1499)

| Code | 이름 | 의미 |
| --- | --- | --- |
| 1400 | `codegen_unresolved_type_reference` | type reference 가 같은 파일에 정의 안 됨 (보통 cross-file import) |
| 1401 | `codegen_unsupported_prop_type` | codegen 이 인식 못 하는 prop type 형태 |
| 1402 | `codegen_invalid_native_props_body` | NativeProps 가 object literal 도 wrapper 도 아님 |
| 1403 | `codegen_duplicate_component` | 같은 schema 에 component 이름 중복 |

각 코드는 자동으로 docs 링크 생성: `https://ohah.github.io/zts/reference/errors/zts1400/`

`error_codes.zig` 의 4 군데 (header / enum entry / help() / message()) 동시 수정 — ZTS 컨벤션.

## API

```zig
/// duplicate component 검증. null=OK, non-null=충돌 이름.
pub fn validate(component_schema: schema.ComponentSchema) ?[]const u8;

/// schema_builder 에러 → ZTS 코드 매핑 (진단 출력 시 사용).
/// OOM 은 caller 가 먼저 분기 — 본 함수에 넘기면 unreachable.
pub fn schemaBuilderErrorCode(err: schema_builder.Error) Code;
```

알고리즘: nested O(N²). component 1-3 개라 hash table 보다 빠름. 20+ 으로 일반화 시 HashSet 전환 (주석에 명시).

## 테스트 7 개

```
validator: empty schema → null
validator: single component → null
validator: distinct component names → null
validator: duplicate component name → returns first conflict
validator: error code mapping — schema_builder errors
validator: error codes resolve to ZTS1400 series
```

전체 4400+ 테스트 통과.

## /simplify 처리

리뷰 결과 2 건 반영:

1. **Out parameter → optional return**: 기존
   ```zig
   pub fn validate(cs: ..., out_dup_name: *?[]const u8) Error!void
   ```
   는 C 포팅 패턴. Zig idiom 으로:
   ```zig
   pub fn validate(cs: ...) ?[]const u8
   ```
   error union 도 제거 (단일 에러 케이스라 optional 만으로 충분).

2. **`schemaBuilderErrorCode` 의 OOM fallback**: 기존
   ```zig
   error.OutOfMemory => .codegen_unsupported_prop_type, // 도달 안 함
   ```
   은 모순 ("도달 안 한다는데 fallback 코드 반환"). caller 가 OOM 을 먼저 분기해야 한다는 설계 의도를 명시화:
   ```zig
   error.OutOfMemory => unreachable, // caller 가 먼저 분기해야 함
   ```

부수: `validatorErrorCode` helper 제거 — single-error 라 caller 가 `.codegen_duplicate_component` 직접 사용.

3. **ZTS1400-ZTS1403 hardcoded test**: 의도적 — code 번호와 format() 의 정확한 매핑이 commit. 향후 코드 번호 변경 시 의식적으로 업데이트하라는 fragility-as-feature.

## Zig 초보자용 메모

### `?T` optional + `unreachable`

Zig optional `?T` 는 null 가능 값. caller 는 `if (validate(cs)) |dup_name| { ... }` 로 unwrap.

`unreachable` 은 "이 코드 경로는 도달 불가" 명시 — debug 빌드에서 assertion, release 에서 UB. caller 가 OOM 을 미리 분기하기로 약속 → `unreachable` 로 약속 위반 detect.

### `error_codes.zig` 의 4 군데 수정

새 코드 추가 시 동시 수정:
1. **Header 주석**: 슬롯 범위 (`1400-1499 codegen`)
2. **enum entry**: 코드 이름 + 번호
3. **help()**: 사용자 액션 가이드
4. **message()**: 짧은 영문 에러 메시지

`format()` 은 `inline else` 로 모든 enum 자동 처리 — 새 코드 추가해도 안 건드림.

## 후속 PR

- **PR #6**: codegen plugin 통합 — `BuiltinOptions.codegen`, CLI flag, NAPI 옵션, builtin.zig wiring. 본 PR 의 schema_builder + emitter + validator 를 묶어 단일 plugin 으로.
- **PR #7**: snapshot 회귀 — RN core 모든 NativeComponent fixture 와 ZTS native 출력 비교.

## 관련

- #2348 — meta: `@react-native/codegen` ZTS native 분석
- #2357, #2361, #2365, #2369, #2372, #2374 — PR #1, #2, #3a-1, #3a-2, #3b, #4