### PR TITLE
feat(napi): expose codegenTransform option

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -651,6 +651,11 @@ interface BuildOptionsCommon {
   /** worklet의 `__pluginVersion` 값 (Reanimated dev mode jsVersion 대조용).
    * 사용자 환경의 react-native-worklets 패키지 version을 전달해야 런타임 에러 없음. */
   workletPluginVersion?: string;
+  /** RN view config codegen — `*NativeComponent.{js,ts}` 의 `codegenNativeComponent`
+   * 호출을 inline view config 로 교체 (#2348). React Native 플랫폼에서 자동 활성화.
+   * `@react-native/codegen` 의 `GenerateViewConfigJs.generate()` fileTemplate 와 동일.
+   * Fabric early-register race (`View config not found for component 'X'`) 회피. */
+  codegenTransform?: boolean;
   /** scope hoisting 시 예약할 전역 식별자 */
   globalIdentifiers?: string[];
   /** 번들 시작 시 즉시 실행 폴리필 경로 */


### PR DESCRIPTION
## 개요 (#2348)

PR #2377 (codegen plugin 통합) 의 누락분. NAPI 사용자에게 ZTS 내장 codegen plugin 활성화 토글을 노출.

`workletTransform` 옆 (`packages/core/index.ts:650`) 에 배치 — 둘 다 RN-only 옵션 + ZTS RN preset 에서 CLI flow 시 자동 활성. NAPI 빌드 flow 는 RN preset 적용 안 하므로 호출자 (e.g. Bungae) 가 명시 전달 필요.

## 변경

| 파일 | 변경 |
| --- | --- |
| `packages/core/index.ts` | `BuildOptionsCommon.codegenTransform?: boolean` 추가 (line 654-658) |

`prepareNapiOptions` 는 `napiOptions: Record<string, unknown> = { ...options }` spread 라 자동 전달. 별도 변환 없음. Zig 측 `BuildOptions.codegen_transform` 은 PR #2377 에서 이미 추가됨 (`src/bundler/bundler.zig:290`).

## 검증

- `bun x tsc --noEmit -p packages/core` exit=0
- Bungae 측 e2e: `BUNGAE_CODEGEN_NATIVE=1` 환경변수 토글로 전환 시 실제 RN ExampleApp 빌드 성공
  - JS path (default): `[bungae:codegen] inlined=45` (RN codegen JS plugin)
  - ZTS native path: ZTS plugin 이 28/45 spec 변환 (나머지 17 은 미지원 패턴 silent skip → RN runtime lazy 등록)

## 후속

- Bungae PR — `BUNGAE_CODEGEN_NATIVE=1` 토글 추가
- ZTS — silent skip 케이스 (array, nested object, string enum 등) 점진 채우기

🤖 Generated with [Claude Code](https://claude.com/claude-code)