### PR TITLE
feat(codegen): recognize WithDefault<T, D> wrapper

### DIFF
--- a/src/config_options_dto_test.zig
+++ b/src/config_options_dto_test.zig
@@ -221,6 +221,7 @@ const ts_buildoptions_only_allowlist = [_][]const u8{
     "assetRegistry", // RN asset_registry 모듈 처리
     "scopeHoist", // bundler 옵션 (#1389)
     "workletTransform", // RN reanimated worklet
+    "codegenTransform", // RN view config codegen (#2348)
     "strictExecutionOrder", // 모듈 실행 순서 보장
     "experimentalCodeCache", // persistent cache 실험
     "watch", // CLI flag, BuildOptions 노출 안 함이 정석이지만 일부 wrapper 가 노출

--- a/src/transformer/plugins/codegen/schema_builder.zig
+++ b/src/transformer/plugins/codegen/schema_builder.zig
@@ -318,6 +318,16 @@ fn mapTypeReference(
 ) Error!schema.PropTypeAnnotation {
     const name = getTypeReferenceName(ast, node) orelse return error.UnsupportedPropType;
 
+    // `WithDefault<T, D>` — RN codegen 의 default value wrapper. RN core 0.85 의 40개
+    // spec 중 10개에서 사용 (`disabled?: WithDefault<boolean, false>` 등).
+    // 첫 type 인자 T 만 추출해서 재귀. 두번째 D (default literal) 는 향후 PR 에서
+    // ts_literal_type / flow_*_literal_type 추출해 PropTypeAnnotation.default 채울 예정 —
+    // 현재는 무시 (RN runtime 이 자체 default 사용).
+    if (std.mem.eql(u8, name, "WithDefault")) {
+        const inner = getFirstTypeArgument(ast, node) orelse return error.UnsupportedPropType;
+        return mapPropTypeAt(ast, type_index, inner, depth + 1);
+    }
+
     if (reserved_ref_names.get(name)) |primitive| {
         return .{ .reserved = primitive };
     }

--- a/src/transformer/plugins/codegen/schema_builder_test.zig
+++ b/src/transformer/plugins/codegen/schema_builder_test.zig
@@ -274,3 +274,50 @@ test "schema_builder: invalid declaration → InvalidNativePropsBody" {
     const result = schema_builder.build(&p.parser.ast, &p.type_index, "X", stmt, std.testing.allocator);
     try std.testing.expectError(error.InvalidNativePropsBody, result);
 }
+
+test "schema_builder: WithDefault<T, D> wrapper — inner T 만 추출 (TS)" {
+    // RN codegen 의 default value wrapper. RN 0.85 코어 spec 40개 중 10개에서 사용.
+    // 첫 type 인자만 추출하여 재귀 매핑 — D (default literal) 는 향후 PR.
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { disabled: WithDefault<boolean, false> };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expectEqualStrings("disabled", shape.props[0].name);
+    try std.testing.expect(shape.props[0].type_annotation == .boolean);
+}
+
+test "schema_builder: WithDefault<Float, 0> → float (Flow)" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { rate: WithDefault<Float, 0> };
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expectEqualStrings("rate", shape.props[0].name);
+    try std.testing.expect(shape.props[0].type_annotation == .float);
+}
+
+test "schema_builder: WithDefault<ColorValue, null> → reserved.color" {
+    // RN 의 nullable color: `WithDefault<?ColorValue, null>` 흔한 패턴.
+    // 단순화: nullable 없이 ColorValue 직접 — wrapper 만 검증.
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { tint: WithDefault<ColorValue, null> };
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expectEqualStrings("tint", shape.props[0].name);
+    try std.testing.expect(shape.props[0].type_annotation == .reserved);
+    try std.testing.expectEqual(schema.ReservedPropPrimitive.color, shape.props[0].type_annotation.reserved);
+}


### PR DESCRIPTION
## 개요 (#2348 Phase 2-A)

silent skip 보강 시리즈 첫 PR. RN 0.85 코어 spec 40개 중 10개에서 사용하는 `WithDefault<T, D>` wrapper 인식.

이전 동작:
```ts
disabled?: WithDefault<boolean, false>,  // type_reference 'WithDefault' 미인식
                                          // → UnresolvedTypeReference → silent skip
                                          // → 전체 spec 변환 포기
```

본 PR 후:
```zig
// schema_builder.mapTypeReference
if (std.mem.eql(u8, name, "WithDefault")) {
    const inner = getFirstTypeArgument(ast, node) orelse return error.UnsupportedPropType;
    return mapPropTypeAt(ast, type_index, inner, depth + 1);
}
```

첫 type 인자 T 만 추출해 재귀. D (default literal) 는 후속 PR — RN runtime 이 자체 default 사용하므로 view config 정확도는 그대로.

## 변경

| 파일 | 변경 |
| --- | --- |
| `src/transformer/plugins/codegen/schema_builder.zig` | `mapTypeReference` 에 WithDefault 분기 추가 (10줄) |
| `src/transformer/plugins/codegen/schema_builder_test.zig` | unit test 3개 (boolean/Float/ColorValue inner) |
| `src/config_options_dto_test.zig` | `bundler_only_fields` 에 `codegenTransform` 추가 — PR #2378 누락분 (schema drift 회귀 fix) |

## 검증

- `zig build test` exit=0 (전체 4445 테스트)
- `zig build test -Dtest-filter=WithDefault` exit=0 (3개 신규)
- 전체 4400+ 테스트 + Bungae ExampleApp 빌드 (`BUNGAE_CODEGEN_NATIVE=1`) exit=0

## ⚠️ ExampleApp 변환 spec 카운트 변화 없음 (28 그대로)

RN 코어 spec 들은 _여러 미지원 패턴_ 을 동시에 사용. 예:

```ts
type SwitchNativeProps = $ReadOnly<{
  ...ViewProps,                              // spread (Phase 2-D)
  disabled?: WithDefault<boolean, false>,    // ← 본 PR 해결
  tintColor?: ?ColorValue,                   // nullable (별도 후속)
}>;
```

WithDefault 하나만 unblock 해도 spread 가 막아 spec 통째 변환 실패. 후속 PR 합쳐야 단계적 변환 카운트 증가.

## 후속 (Phase 2 시리즈)

- **2-B**: `Array<T>` / `ReadonlyArray<T>` 지원 (5+5 spec 영향)
- **2-C**: `DirectEventHandler<T>` / `BubblingEventHandler<T>` 명시 분류 (7+3 spec)
- **2-D**: spread (`...ViewProps`) 무시 처리
- **2-E**: nullable (`?T`) unwrap
- **2-F**: WithDefault 의 default literal D 추출

🤖 Generated with [Claude Code](https://claude.com/claude-code)