### PR TITLE
test(config): codegenTransform schema drift 허용

### DIFF
--- a/src/config_options_dto_test.zig
+++ b/src/config_options_dto_test.zig
@@ -234,6 +234,7 @@ const ts_buildoptions_only_allowlist = [_][]const u8{
     "analyze", // metafile 분석 출력
     "blockList", // RN resolver block list
     "collectModuleCodes", // NAPI 만 사용 (HMR module codes)
+    "codegenTransform", // BuildOptions 전용 codegen transform hook
     "configurableExports", // RN configurable __toESM
     "devMode", // dev mode flag
     "emitDiskSourcemap", // sourcemap 디스크 emit


### PR DESCRIPTION
## Summary

`BuildOptionsCommon.codegenTransform`이 Zig schema drift 테스트에서 의도적 BuildOptions 전용 필드로 분류되도록 allowlist에 추가했습니다.

## Changes

- `src/config_options_dto_test.zig`의 `ts_buildoptions_only_allowlist`에 `codegenTransform` 등록
- TS BuildOptions ↔ Zig DTO schema sync 테스트가 새 BuildOptions 전용 필드를 drift로 오인하지 않도록 수정

## Test Plan

- [x] `zig build test` 통과
- [x] `zig fmt --check src/` 통과
- [ ] 관련 Test262 케이스 확인 (해당 없음)

## Decision Impact

None

## AST 신규 노드 체크리스트 (해당 시)

해당 없음
