### PR TITLE
feat(codegen): support Array<T> / ReadonlyArray<T>

### DIFF
--- a/src/transformer/plugins/codegen/schema_builder.zig
+++ b/src/transformer/plugins/codegen/schema_builder.zig
@@ -328,6 +328,16 @@ fn mapTypeReference(
         return mapPropTypeAt(ast, type_index, inner, depth + 1);
     }
 
+    // `Array<T>` / `ReadonlyArray<T>` — RN core spec 의 ~10개에서 사용
+    // (`colors?: ReadonlyArray<ColorValue>`, `data?: Array<ItemShape>` 등).
+    // ZTS 파서의 `ts_array_type` (T[]) 은 element 폐기로 미지원이지만 type_reference
+    // 형태는 type 인자가 보존되므로 처리 가능. (#2348 § 3a 참고)
+    if (std.mem.eql(u8, name, "Array") or std.mem.eql(u8, name, "ReadonlyArray")) {
+        const inner = getFirstTypeArgument(ast, node) orelse return error.UnsupportedPropType;
+        const inner_prop = try mapPropTypeAt(ast, type_index, inner, depth + 1);
+        return .{ .array = try toArrayElement(inner_prop) };
+    }
+
     if (reserved_ref_names.get(name)) |primitive| {
         return .{ .reserved = primitive };
     }
@@ -392,5 +402,24 @@ fn numericKindToAnnotation(kind: NumericKind) schema.PropTypeAnnotation {
         .float => .{ .float = .{ .default = null } },
         .int32 => .{ .int32 = .{ .default = 0 } },
         .double => .{ .double = .{ .default = 0 } },
+    };
+}
+
+/// `PropTypeAnnotation` → `ComponentArrayTypeAnnotation` (배열 element 한정).
+/// codegen 의 ArrayTypeAnnotation 은 default/options 등 prop 메타를 가지지 않으므로
+/// 단순 variant 매핑. `int32_enum` 과 중첩 array 는 RN codegen 에서도 미지원이라 동일.
+fn toArrayElement(prop: schema.PropTypeAnnotation) Error!schema.ComponentArrayTypeAnnotation {
+    return switch (prop) {
+        .boolean => .boolean,
+        .string => .string,
+        .double => .double,
+        .float => .float,
+        .int32 => .int32,
+        .mixed => .mixed,
+        .reserved => |p| .{ .reserved = p },
+        .string_enum => |e| .{ .string_enum = e },
+        .object => |o| .{ .object = o.properties },
+        // int32_enum, array (중첩) 는 RN codegen 도 미지원 — 동일 fail-fast.
+        .int32_enum, .array => error.UnsupportedPropType,
     };
 }

--- a/src/transformer/plugins/codegen/schema_builder_test.zig
+++ b/src/transformer/plugins/codegen/schema_builder_test.zig
@@ -305,6 +305,37 @@ test "schema_builder: WithDefault<Float, 0> → float (Flow)" {
     try std.testing.expect(shape.props[0].type_annotation == .float);
 }
 
+test "schema_builder: ReadonlyArray<ColorValue> → array.reserved.color" {
+    // RN core 의 ~10 spec 에서 사용하는 array prop. 예: `colors?: ReadonlyArray<ColorValue>`.
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { colors: ReadonlyArray<ColorValue> };
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expectEqualStrings("colors", shape.props[0].name);
+    try std.testing.expect(shape.props[0].type_annotation == .array);
+    try std.testing.expect(shape.props[0].type_annotation.array == .reserved);
+    try std.testing.expectEqual(schema.ReservedPropPrimitive.color, shape.props[0].type_annotation.array.reserved);
+}
+
+test "schema_builder: Array<string> → array.string (TS)" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { tags: Array<string> };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .array);
+    try std.testing.expect(shape.props[0].type_annotation.array == .string);
+}
+
 test "schema_builder: WithDefault<ColorValue, null> → reserved.color" {
     // RN 의 nullable color: `WithDefault<?ColorValue, null>` 흔한 패턴.
     // 단순화: nullable 없이 ColorValue 직접 — wrapper 만 검증.


### PR DESCRIPTION
## 개요 (#2348 Phase 2-B)

silent skip 보강 시리즈 두번째. RN core 0.85 의 ~10개 spec 에서 등장하는 `Array<T>` / `ReadonlyArray<T>` 인식.

ZTS 파서의 `ts_array_type` (T[]) 은 PR #3a 에서 element 폐기 의도적 미지원이지만, generic type_reference 형태는 type 인자가 보존되어 처리 가능 (#2348 § 3a 참고).

## 변경

```zig
// schema_builder.mapTypeReference
if (std.mem.eql(u8, name, "Array") or std.mem.eql(u8, name, "ReadonlyArray")) {
    const inner = getFirstTypeArgument(ast, node) orelse return error.UnsupportedPropType;
    const inner_prop = try mapPropTypeAt(ast, type_index, inner, depth + 1);
    return .{ .array = try toArrayElement(inner_prop) };
}
```

신규 헬퍼 `toArrayElement(PropTypeAnnotation) -> ComponentArrayTypeAnnotation` — boolean/string/float/int32/double/mixed/reserved/string_enum/object 매핑. `int32_enum` 과 중첩 array 는 RN codegen 도 미지원이라 동일 fail-fast.

`view_config_emitter` 의 `.array` 분기는 schema 설계 시점부터 존재 (PR #4) — schema_builder 추가만으로 endpoint 동작.

## 검증

- `zig build test` exit=0 (4400+ 테스트)
- 신규 unit test: `Array<string>` (TS), `ReadonlyArray<ColorValue>` (Flow)

## ⚠️ ExampleApp 변환 spec 카운트 변화 없음 (28 그대로)

Phase 2-A 와 동일 — RN spec 들이 동시에 spread (`...ViewProps`), nullable (`?T`) 패턴도 사용. 각 spec 통째 변환되려면 모든 미지원 패턴이 unblock 되어야 함. **Phase 2-D (spread 무시)** 가 가장 큰 unblock 효과 예상.

## 후속

- 2-C: `DirectEventHandler<T>` / `BubblingEventHandler<T>` 명시 분류
- 2-D: spread (`...ViewProps`) 무시 처리 — **카운트 증가의 단일 최대 영향**
- 2-E: nullable (`?T`) unwrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)