### PR TITLE
feat(codegen): unwrap Flow nullable type (?T)

### DIFF
--- a/src/transformer/plugins/codegen/schema_builder.zig
+++ b/src/transformer/plugins/codegen/schema_builder.zig
@@ -303,6 +303,11 @@ fn mapPropTypeAt(
         // type reference: reserved primitive 또는 alias 펼치기
         .ts_type_reference, .flow_type_reference => mapTypeReference(ast, type_index, node, depth),
 
+        // Flow nullable (`?T`) — RN core spec 의 ColorValue/ImageSource 등 거의 모든
+        // optional reserved type 이 이 형태로 등장. inner 만 매핑하면 됨 — RN runtime
+        // 이 nullable semantics 자체 (validAttributes 의 prop 자체가 optional) 처리.
+        .flow_nullable_type => mapPropTypeAt(ast, type_index, node.data.unary.operand, depth + 1),
+
         // 그 외는 미지원 — 향후 확장 (PR #3b-2: array, object, string_enum, ...)
         else => error.UnsupportedPropType,
     };

--- a/src/transformer/plugins/codegen/schema_builder_test.zig
+++ b/src/transformer/plugins/codegen/schema_builder_test.zig
@@ -305,6 +305,37 @@ test "schema_builder: WithDefault<Float, 0> → float (Flow)" {
     try std.testing.expect(shape.props[0].type_annotation == .float);
 }
 
+test "schema_builder: Flow nullable ?ColorValue → reserved.color" {
+    // RN core spec 에서 매우 흔한 패턴: `tintColor?: ?ColorValue`. nullable wrapper 풀고
+    // inner 만 매핑 — RN runtime 의 validAttributes 가 nullable semantics 자체 처리.
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { tintColor: ?ColorValue };
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expectEqualStrings("tintColor", shape.props[0].name);
+    try std.testing.expect(shape.props[0].type_annotation == .reserved);
+    try std.testing.expectEqual(schema.ReservedPropPrimitive.color, shape.props[0].type_annotation.reserved);
+}
+
+test "schema_builder: nullable inside WithDefault — WithDefault<?ColorValue, null>" {
+    // RN spec 흔한 조합 — wrapper 안 nullable.
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { color: WithDefault<?ColorValue, null> };
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .reserved);
+}
+
 test "schema_builder: ReadonlyArray<ColorValue> → array.reserved.color" {
     // RN core 의 ~10 spec 에서 사용하는 array prop. 예: `colors?: ReadonlyArray<ColorValue>`.
     var p = try parseAndIndex(std.testing.allocator,


### PR DESCRIPTION
## 개요 (#2348 Phase 2-E)

silent skip 보강 시리즈 세번째. RN core Flow spec 의 거의 모든 optional reserved type 이 사용하는 `?T` nullable wrapper 처리.

```ts
type Props = $ReadOnly<{
  ...ViewProps,
  tintColor?: ?ColorValue,    // ← 본 PR 해결
  thumbTintColor?: ?ColorValue,
  ...
}>;
```

이전엔 `flow_nullable_type` 노드 만나면 `UnsupportedPropType` → spec 통째 변환 실패.

## 변경

```zig
// schema_builder.mapPropTypeAt switch 에 한 줄 추가
.flow_nullable_type => mapPropTypeAt(ast, type_index, node.data.unary.operand, depth + 1),
```

inner type 만 매핑 — RN runtime 의 validAttributes 가 nullable semantics 자체 처리하므로 wrapper 정보는 버려도 view config 정확도 유지.

테스트 2개 추가:
- `?ColorValue` 직접
- `WithDefault<?ColorValue, null>` (nested wrapper)

## ⚠️ 변환 spec 카운트 그대로 (28)

같은 패턴 — Phase 2-A/B 와 동일하게 RN spec 들이 동시에 spread (`...ViewProps`) / intersection 도 사용. **Phase 2-D (spread/intersection)** 가 단계적 unblock 의 마지막 큰 조각.

## 후속

- 2-D: spread / intersection 처리 — 카운트 증가의 critical path
- 2-C: Direct/BubblingEventHandler wrapper 명시 분류
- 2-F: WithDefault default literal 추출

🤖 Generated with [Claude Code](https://claude.com/claude-code)