### PR TITLE
fix(napi): hydrate codegen_transform from JS options

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -3701,6 +3701,10 @@ fn parseBuildOptions(
         .entry_error_guard = getObjectBool(env, opts_obj, "entryErrorGuard", false) or (platform == .react_native and bundler_mod.RN_BOOL_PRESET.entry_error_guard),
         .worklet_transform = getObjectBool(env, opts_obj, "workletTransform", false) or (platform == .react_native and bundler_mod.RN_BOOL_PRESET.worklet_transform),
         .worklet_plugin_version = ownStr(env, opts_obj, "workletPluginVersion", owned_strings),
+        // ZTS native codegen — Bungae 토글이 NAPI 까지 닿지 않으면 RN preset 도 적용 안 됨.
+        // PR #2378 가 BuildOptions/main.zig 만 추가하고 NAPI 진입점 하이드레이션 누락한 것
+        // 수정 — `codegenTransform` 옵션을 받아 RN preset 과 OR.
+        .codegen_transform = getObjectBool(env, opts_obj, "codegenTransform", false) or (platform == .react_native and bundler_mod.RN_BOOL_PRESET.codegen_transform),
         .global_identifiers = global_identifiers orelse &.{},
         .polyfills = polyfills orelse &.{},
         .run_before_main = run_before_main orelse &.{},


### PR DESCRIPTION
## 개요 (#2348 — critical fix)

PR #2378 (NAPI BuildOptions 에 `codegenTransform` 추가) + PR #2377 (codegen plugin) 의 누락분. `napi_entry.zig:3702` 부근이 `workletTransform` 만 JS opts → Zig BuildOptions 매핑하고 `codegenTransform` 은 받지 않음.

**증상**: Bungae #74 의 `BUNGAE_CODEGEN_NATIVE=1` 토글이 NAPI 까지 옵션 전달했지만 `BuildOptions.codegen_transform` 이 항상 false → ZTS native codegen 이 한 번도 실제 활성 안 됨.

ExampleApp 빌드의 `__INTERNAL_VIEW_CONFIG=28` 은 우리 plugin 출력이 아니라 RN 런타임 자체 string 등장 (`NativeComponentRegistry.js` 의 reference) — false positive 였음.

## 변경

```zig
// napi_entry.zig:3702 부근
.worklet_transform = ... ,
.worklet_plugin_version = ... ,
+.codegen_transform = getObjectBool(env, opts_obj, "codegenTransform", false)
+    or (platform == .react_native and bundler_mod.RN_BOOL_PRESET.codegen_transform),
```

## 검증

ExampleApp `--platform ios --flow`, `BUNGAE_CODEGEN_NATIVE=1`:

| 측정 | Before fix | After fix |
| --- | --- | --- |
| `__INTERNAL_VIEW_CONFIG` | 28 (RN 런타임만) | 34 (RN + 우리 emit 6) |
| 번들 크기 | 4,991,444 bytes | 4,992,182 bytes |

Phase 2-A/B/E (WithDefault/Array/nullable) PR 들 합쳐서 **6 spec 통째 변환 성공**. 나머지 39 spec 은 다른 미지원 패턴 (string enum union, event handler wrapper, intersection 등).

## 다음 단계

이제 silent skip 분포를 정확히 측정 가능 — Phase 2-C/D/G 진행 우선순위 재검토.

🤖 Generated with [Claude Code](https://claude.com/claude-code)