### PR TITLE
fix(parser): keep type-only export decl in program

### DIFF
--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -878,11 +878,15 @@ pub fn parseExportDeclarationWithDecorators(self: *Parser, decorators: ast_mod.N
         try self.parseClassWithDecorators(.class_declaration, decorators)
     else
         try self.parseStatement();
-    // type-only 선언이면 export_named_declaration을 생성하지 않음.
-    // 남으면 import_scanner가 has_esm_syntax=true로 잘못 판별하여
-    // CJS 모듈이 __esm으로 래핑됨.
+    // type-only 선언이면 export_named_declaration wrapper 만 생략하고 decl 자체는
+    // program 자식으로 직접 추가. import_scanner 는 export_named_declaration 노드를
+    // 보고 has_esm_syntax 결정 — type-only 는 wrapper 가 없으므로 영향 없음.
+    //
+    // wrapper 자체를 NodeIndex.none 반환하던 이전 동작은 `export type Foo = ...` 형태가
+    // program 에서 도달 불가능 (orphan) 하게 만들어 codegen 의 type_index 가 NativeProps
+    // 등을 못 찾는 원인이었음 (#2348 Phase 2, react-native-svg 의 Fe* spec 7개 영향).
     if (decl.isNone()) return NodeIndex.none;
-    if (self.ast.getNode(decl).tag.isTypeOnlyDeclaration()) return NodeIndex.none;
+    if (self.ast.getNode(decl).tag.isTypeOnlyDeclaration()) return decl;
 
     // Inline scan: export var/let/const/function/class
     if (self.enable_scan) {

--- a/src/transformer/plugins/codegen/type_index_test.zig
+++ b/src/transformer/plugins/codegen/type_index_test.zig
@@ -103,25 +103,27 @@ test "TypeIndex: Flow opaque type indexed" {
     try std.testing.expect(r.index.get("Props") != null);
 }
 
-test "TypeIndex: export type alias dropped at parse (known limitation)" {
-    // ZTS 파서가 type-only declaration 의 export wrapper 를 parse 시점에
-    // program 에서 제거 (`module.zig:885`). type alias 노드는 orphan 으로 남지만
-    // program 에서 도달 불가 → 인덱싱 안 됨.
+test "TypeIndex: export type alias is indexed" {
+    // #2348 Phase 2 의 root-cause fix (`module.zig:885`) 이후 type-only declaration
+    // 의 export wrapper 만 생략하고 decl 자체는 program 에 직접 추가됨.
+    // import_scanner 는 export_named_declaration wrapper 부재 → has_esm_syntax 영향 X.
     var r = try parseAndIndex(std.testing.allocator,
         \\export type Props = { color: string };
     );
     defer r.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 0), r.index.count());
+    try std.testing.expectEqual(@as(usize, 1), r.index.count());
+    try std.testing.expect(r.index.get("Props") != null);
 }
 
-test "TypeIndex: export interface dropped at parse (known limitation)" {
+test "TypeIndex: export interface is indexed" {
     var r = try parseAndIndex(std.testing.allocator,
         \\export interface Props { color: string }
     );
     defer r.deinit(std.testing.allocator);
 
-    try std.testing.expectEqual(@as(usize, 0), r.index.count());
+    try std.testing.expectEqual(@as(usize, 1), r.index.count());
+    try std.testing.expect(r.index.get("Props") != null);
 }
 
 test "TypeIndex: multiple declarations all indexed" {


### PR DESCRIPTION
## 개요 (#2348 Phase 2 — root-cause)

`react-native-svg` 의 Fe* spec 7개 (`FeBlend`, `FeColorMatrix`, `FeComposite`, `FeFlood`, `FeGaussianBlur`, `FeMerge`, `FeOffset`) 가 `export interface NativeProps extends ...` 형태를 사용. ZTS 파서가 _decl 자체와 함께_ `NodeIndex.none` 반환해 program 에서 도달 불가 (orphan) → codegen type_index 가 NativeProps 못 찾음.

원래 의도는 `export_named_declaration` wrapper 만 생략하기 (import_scanner 의 has_esm_syntax 오인 회피). 그런데 wrapper 와 함께 decl 자체도 버려진 게 실수.

## 변경

```zig
// module.zig:885 — Before
if (self.ast.getNode(decl).tag.isTypeOnlyDeclaration()) return NodeIndex.none;
// After
if (self.ast.getNode(decl).tag.isTypeOnlyDeclaration()) return decl;
```

decl (ts_type_alias / ts_interface 등) 만 program 자식으로 직접 추가. `export_named_declaration` wrapper 부재 → import_scanner 가 has_esm_syntax 트리거 안 함 (기존 테스트 통과로 검증).

## 영향 받는 테스트 update

`type_index_test.zig` 의 두 "known limitation" 테스트 (`export type alias dropped`, `export interface dropped`) 는 _구 동작 검증_ 이라 의미 뒤집어 update — 이제 둘 다 indexed.

기존 import_scanner / transformer / semantic 테스트 영향 없음 (4400+ 테스트 모두 통과).

## 검증 (E2E ExampleApp `--platform ios --flow`, `BUNGAE_CODEGEN_NATIVE=1`)

| 측정 | Before | After |
| --- | --- | --- |
| `__INTERNAL_VIEW_CONFIG` | 34 | 37 (+3) |
| 번들 크기 | 4,992,182 | 4,992,527 |

7 spec 모두 unblock 가능하지만 일부는 `UnsafeMixed<T>` (RN-internal mixed wrapper), `DirectEventHandler<T>` 등 다른 미지원 패턴도 사용해 schema_builder 단계에서 추가 silent skip. 후속 PR 들로 보강 예정.

## 후속 PR 시리즈

- 2-C: `DirectEventHandler<T>` / `BubblingEventHandler<T>` 명시 분류
- 2-G: `UnsafeMixed<T>` wrapper (RN-internal `mixed` 타입)
- 2-H: TS string union → string_enum

🤖 Generated with [Claude Code](https://claude.com/claude-code)