### PR TITLE
feat(codegen): unwrap UnsafeMixed<T> identity wrapper

### DIFF
--- a/src/transformer/plugins/codegen/schema_builder.zig
+++ b/src/transformer/plugins/codegen/schema_builder.zig
@@ -328,7 +328,11 @@ fn mapTypeReference(
     // 첫 type 인자 T 만 추출해서 재귀. 두번째 D (default literal) 는 향후 PR 에서
     // ts_literal_type / flow_*_literal_type 추출해 PropTypeAnnotation.default 채울 예정 —
     // 현재는 무시 (RN runtime 이 자체 default 사용).
-    if (std.mem.eql(u8, name, "WithDefault")) {
+    //
+    // `UnsafeMixed<T>` — react-native-svg 의 identity wrapper (`UnsafeMixed<T> = T`).
+    // codegen 이 folly::dynamic 생성하도록 trick — 의미상 inner T 그대로.
+    // svg fabric spec 30개 거의 모두 사용 (`fill?: UnsafeMixed<ColorValue | ColorStruct>`).
+    if (std.mem.eql(u8, name, "WithDefault") or std.mem.eql(u8, name, "UnsafeMixed")) {
         const inner = getFirstTypeArgument(ast, node) orelse return error.UnsupportedPropType;
         return mapPropTypeAt(ast, type_index, inner, depth + 1);
     }

--- a/src/transformer/plugins/codegen/schema_builder_test.zig
+++ b/src/transformer/plugins/codegen/schema_builder_test.zig
@@ -305,6 +305,22 @@ test "schema_builder: WithDefault<Float, 0> → float (Flow)" {
     try std.testing.expect(shape.props[0].type_annotation == .float);
 }
 
+test "schema_builder: UnsafeMixed<T> identity unwrap" {
+    // react-native-svg 의 `UnsafeMixed<T> = T` identity wrapper. fabric spec 30개
+    // 거의 모두 사용. 의미상 T 그대로 → first type arg 만 추출해 재귀.
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { color: UnsafeMixed<ColorValue> };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .reserved);
+    try std.testing.expectEqual(schema.ReservedPropPrimitive.color, shape.props[0].type_annotation.reserved);
+}
+
 test "schema_builder: Flow nullable ?ColorValue → reserved.color" {
     // RN core spec 에서 매우 흔한 패턴: `tintColor?: ?ColorValue`. nullable wrapper 풀고
     // inner 만 매핑 — RN runtime 의 validAttributes 가 nullable semantics 자체 처리.


### PR DESCRIPTION
## 개요 (#2348 Phase 2-G)

`react-native-svg` 의 fabric spec 30개 거의 모두 사용하는 identity wrapper.

```ts
// node_modules/react-native-svg/src/fabric/codegenUtils.ts
export type UnsafeMixed<T> = T;
```

RN codegen 이 folly::dynamic 생성하도록 trick — TypeScript 만족시키면서 codegen 출력을 mixed 타입으로. 의미상 `T` 그대로이므로 WithDefault 와 같은 unwrap 패턴.

## 변경

```zig
// schema_builder.mapTypeReference — Phase 2-A 의 WithDefault 분기 확장
if (std.mem.eql(u8, name, "WithDefault") or std.mem.eql(u8, name, "UnsafeMixed")) {
    const inner = getFirstTypeArgument(ast, node) orelse return error.UnsupportedPropType;
    return mapPropTypeAt(ast, type_index, inner, depth + 1);
}
```

테스트 1개 추가.

## ⚠️ 단독 effect 카운트 변화 없음 (37 그대로)

svg spec 들이 inner 로 union 타입 사용:
- `UnsafeMixed<ColorValue | ColorStruct>`
- `UnsafeMixed<ReadonlyArray<NumberProp> | NumberProp>`
- `UnsafeMixed<NumberProp>` (NumberProp 은 cross-file → fail-fast 의도)

union 처리 PR 후 effect 가시. UnsafeMixed unwrap 자체는 필수 기반.

## 후속

- 2-H: `ts_union_type` / `flow_union_type` 처리 — 모든 string literal 이면 string_enum, 그 외는 mixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)