### PR TITLE
feat(codegen): map union types to string_enum or mixed

### DIFF
--- a/src/transformer/plugins/codegen/schema_builder.zig
+++ b/src/transformer/plugins/codegen/schema_builder.zig
@@ -308,9 +308,38 @@ fn mapPropTypeAt(
         // 이 nullable semantics 자체 (validAttributes 의 prop 자체가 optional) 처리.
         .flow_nullable_type => mapPropTypeAt(ast, type_index, node.data.unary.operand, depth + 1),
 
+        // Union (`A | B | C`) — 두 케이스 분기:
+        //   - 모든 element 가 string literal → `string_enum` (RN spec 의 흔한 enum)
+        //   - 그 외 (mixed type union, e.g. `ColorValue | ColorStruct`) → `mixed`
+        // RN codegen 도 동일 정책 (`GenerateViewConfigJs.js` 의 union → folly::dynamic).
+        .ts_union_type, .flow_union_type => mapUnion(ast, node),
+
         // 그 외는 미지원 — 향후 확장 (PR #3b-2: array, object, string_enum, ...)
         else => error.UnsupportedPropType,
     };
+}
+
+/// Union 의 모든 element 가 string literal 이면 string_enum, 그 외엔 mixed.
+fn mapUnion(ast: *const Ast, node: Node) Error!schema.PropTypeAnnotation {
+    const list = node.data.list;
+    if (list.len == 0) return .mixed;
+
+    var i: u32 = 0;
+    while (i < list.len) : (i += 1) {
+        const elem_idx: NodeIndex = @enumFromInt(ast.extra_data.items[list.start + i]);
+        const elem = ast.getNode(elem_idx);
+        if (elem.tag != .ts_literal_type and elem.tag != .flow_literal_type) return .mixed;
+        const text = ast.getText(elem.data.string_ref);
+        if (text.len < 2) return .mixed;
+        const first = text[0];
+        if (first != '\'' and first != '"') return .mixed;
+    }
+
+    // 모두 string literal — string_enum 으로 dispatch. emitter 가 현재
+    // string_enum 의 options 를 view config 에 직렬화하지 않고 단순 `true` 출력
+    // 하므로 default/options 슬라이스는 빈 값이라도 무방. 향후 emitter 가
+    // attribute 형태로 확장할 때 옵션 추출이 의미를 가짐.
+    return .{ .string_enum = .{ .default = "", .options = &.{} } };
 }
 
 /// type reference 이름 → reserved primitive 매핑. 알려진 RN core 타입 이름들.

--- a/src/transformer/plugins/codegen/schema_builder_test.zig
+++ b/src/transformer/plugins/codegen/schema_builder_test.zig
@@ -305,6 +305,33 @@ test "schema_builder: WithDefault<Float, 0> → float (Flow)" {
     try std.testing.expect(shape.props[0].type_annotation == .float);
 }
 
+test "schema_builder: TS string union → string_enum" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { rate: 'fast' | 'normal' };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .string_enum);
+}
+
+test "schema_builder: TS mixed union → mixed" {
+    // string literal 아닌 element 가 섞이면 string_enum 안 되고 mixed.
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { fill: ColorValue | string };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}
+
 test "schema_builder: UnsafeMixed<T> identity unwrap" {
     // react-native-svg 의 `UnsafeMixed<T> = T` identity wrapper. fabric spec 30개
     // 거의 모두 사용. 의미상 T 그대로 → first type arg 만 추출해 재귀.


### PR DESCRIPTION
## 개요 (#2348 Phase 2-H — single biggest unblock)

`react-native-svg` 의 18+ spec 한 번에 unblock — Phase 2 시리즈 중 단일 PR 최대 효과.

Union 처리 정책 (RN codegen `GenerateViewConfigJs.js` 와 동일):
- 모든 element 가 string literal → `string_enum` (e.g. `'fast' | 'normal'`)
- 그 외 (mixed type union, e.g. `ColorValue | ColorStruct`) → `mixed`

```zig
.ts_union_type, .flow_union_type => mapUnion(ast, node),

fn mapUnion(ast: *const Ast, node: Node) Error!schema.PropTypeAnnotation {
    // 모든 element 가 string literal 인지 검사 → string_enum / mixed
}
```

emitter 는 현재 string_enum 을 단순 `true` attribute 로 출력 (Phase 2-A 의 WithDefault 와 동일하게 RN runtime 이 자체 검증). 향후 emitter 가 enum options 를 attribute 에 직렬화할 때 schema_builder 의 options 추출 확장 가능.

## 검증 (ExampleApp `--platform ios --flow`, `BUNGAE_CODEGEN_NATIVE=1`)

| Phase | `__INTERNAL_VIEW_CONFIG` | spec 변환 (base 28 빼고) |
| --- | --- | --- |
| NAPI fix (#2383) | 34 | 6 |
| type-only export fix (#2384) | 37 | 9 |
| UnsafeMixed (#2385) | 37 | 9 |
| **union (이 PR)** | **55** | **27** |
| JS path 동등 | 73 (=28+45) | 45 |

ZTS 누적 변환 60% (27/45). 남은 18 spec 은:
- cross-file type reference (`NumberProp`, `ChangeEvent` import 등) — 의도적 미지원
- `DirectEventHandler<T>` / `BubblingEventHandler<T>` 명시 wrapper — Phase 2-C
- TS interface intersection / extends — Phase 2-D 일부

🤖 Generated with [Claude Code](https://claude.com/claude-code)