### PR TITLE
fix(dev): handle fs.watch error to keep dev server alive

### DIFF
--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -1993,7 +1993,7 @@ async function runWatch(opts, config) {
   for (const dir of restartTriggers.dirs) watchDirs.add(dir);
 
   for (const dir of watchDirs) {
-    watch(dir, { recursive: true }, (_event, filename) => {
+    const watcher = watch(dir, { recursive: true }, (_event, filename) => {
       if (!filename) return;
       // node_modules, .git, 출력 디렉토리 무시
       if (filename.includes("node_modules") || filename.includes(".git")) return;
@@ -2007,6 +2007,7 @@ async function runWatch(opts, config) {
       clearTimeout(debounceTimer);
       debounceTimer = setTimeout(rebuild, opts.watchDelay);
     });
+    attachWatcherErrorHandler(watcher, dir, opts.logLevel);
   }
 }
 
@@ -2044,6 +2045,30 @@ function computeRestartTriggers(opts) {
       return false;
     },
   };
+}
+
+/**
+ * fs.watch 의 'error' 이벤트는 unhandled 면 process crash 를 일으킨다. macOS Node v24
+ * 의 `recursive: true` 는 빈 디렉토리에서도 즉시 EMFILE 'error' 를 던질 수 있어
+ * (kqueue 기반 한계), watch 가 죽는 건 허용하되 dev server 자체는 살아있도록 한다
+ * — fail-soft. 첫 error 후 watcher 를 닫으므로 `once` 로 충분.
+ */
+function attachWatcherErrorHandler(watcher, dir, logLevel) {
+  watcher.once("error", (err) => {
+    if (logLevel !== "silent") {
+      if (err && (err.code === "EMFILE" || err.code === "ENOSPC")) {
+        console.error(
+          `[watch] ${dir} 파일 감시 비활성화 (${err.code}): 변경 시 재빌드가 동작하지 않습니다. ` +
+            `open-file 한도를 늘리거나 큰 하위 트리를 제거하세요.`,
+        );
+      } else {
+        console.error(`[watch] ${dir} 감시 오류: ${err?.message ?? err}`);
+      }
+    }
+    try {
+      watcher.close();
+    } catch {}
+  });
 }
 
 function emitRestart(opts, reason) {
@@ -2374,7 +2399,7 @@ async function runServe(opts, config, { appDev = null } = {}) {
     for (const dir of restartTriggers.dirs) watchDirs.add(dir);
 
     for (const dir of watchDirs) {
-      fsWatch(dir, { recursive: true }, (_event, filename) => {
+      const watcher = fsWatch(dir, { recursive: true }, (_event, filename) => {
         if (!filename || filename.includes("node_modules") || filename.includes(".git")) return;
         const absPath = resolve(dir, filename);
         if (outdirAbs && (absPath === outdirAbs || absPath.startsWith(outdirPrefix))) return;
@@ -2386,6 +2411,7 @@ async function runServe(opts, config, { appDev = null } = {}) {
         clearTimeout(debounceTimer);
         debounceTimer = setTimeout(drain, opts.watchDelay);
       });
+      attachWatcherErrorHandler(watcher, dir, opts.logLevel);
     }
   }
 


### PR DESCRIPTION
## 요약

- macOS Node v24 의 `fs.watch(dir, { recursive: true })` 가 빈 디렉토리에서도 즉시 `EMFILE` 'error' 이벤트를 던지는 케이스가 있고, ZTS 가 watcher 의 'error' 핸들러를 등록하지 않아 unhandled error 로 process 가 crash 했음. listen 직후 server 가 죽으니 dev server 테스트 5건이 일관되게 timeout.
- `runWatch` / `runServe` 두 곳의 `fsWatch` 호출에 `attachWatcherErrorHandler` 를 추가. 첫 error 시 watcher 만 닫고 server 는 계속 동작 (fail-soft). EMFILE/ENOSPC 는 친화 메시지, 그 외는 raw.

## 진단

- 이슈 #2375 본문은 fail 들을 stderr race / PostCSS / strictPort 3 카테고리로 추정했지만, 실측 결과 5 fail 모두 동일 원인 — `[serve]` 로그 직후 EMFILE 으로 인한 process crash.
- pure Node 로 같은 dir 에 `fs.watch(dir, { recursive: true })` 를 등록하면 즉시 EMFILE 'error' 발생을 재현.
- 수정 후: `Vite-style app builder` 41 테스트 중 40 pass / 1 skip / 0 fail (3회 연속 동일).

## 변경

`packages/core/bin/zts.mjs`
- `attachWatcherErrorHandler(watcher, dir, logLevel)` helper 신설 — `once('error', ...)` 로 EMFILE/ENOSPC 사용자 친화 메시지 또는 raw 출력 후 watcher 닫음.
- `runWatch` (1996), `runServe` (2402) 두 fsWatch 호출에 helper 등록.

## Test plan

- [x] 영향 받는 5 테스트 단독 실행 통과
- [x] `Vite-style app builder` 전체 41 테스트 통과 (3회 연속 안정)
- [x] 수동 재현: dev server 가 EMFILE 후에도 HTTP 200 응답
- [x] 수동 재현: zts.config 변경 시 restart 정상 동작 (`[watch] config 또는 .env 파일 변경 감지 — restarting CLI...` 로그 확인)

Closes #2375