### PR TITLE
feat(codegen): recognize DirectEventHandler<T> / BubblingEventHandler<T>

### DIFF
--- a/src/transformer/plugins/codegen/schema_builder.zig
+++ b/src/transformer/plugins/codegen/schema_builder.zig
@@ -223,6 +223,20 @@ fn classifyMember(
         return;
     }
 
+    // `DirectEventHandler<T>` / `BubblingEventHandler<T>` — RN codegen 의 명시적 event
+    // wrapper. react-native-svg 의 fabric spec 들이 `onSvgLayout?: DirectEventHandler<E>`
+    // 형태로 사용. wrapper 이름이 bubble vs direct 를 결정하므로 prop 이름 휴리스틱
+    // (`onCapture`) 보다 우선.
+    if (eventHandlerBubbling(ast, type_idx)) |bubbling| {
+        try events.append(alloc, .{
+            .name = key_name,
+            .bubbling_type = bubbling,
+            .optional = flags.optional,
+            .argument = null,
+        });
+        return;
+    }
+
     const prop_type = try mapPropType(ast, type_index, type_idx);
     try props.append(alloc, .{
         .name = key_name,
@@ -260,6 +274,17 @@ fn stripQuotes(s: []const u8) []const u8 {
 fn isFunctionType(ast: *const Ast, type_idx: NodeIndex) bool {
     const node = ast.getNode(type_idx);
     return node.tag == .ts_function_type or node.tag == .flow_function_type;
+}
+
+/// type 이 `DirectEventHandler<T>` / `BubblingEventHandler<T>` 면 해당 BubblingType 반환.
+/// 그 외엔 null.
+fn eventHandlerBubbling(ast: *const Ast, type_idx: NodeIndex) ?schema.BubblingType {
+    const node = ast.getNode(type_idx);
+    if (node.tag != .ts_type_reference and node.tag != .flow_type_reference) return null;
+    const name = getTypeReferenceName(ast, node) orelse return null;
+    if (std.mem.eql(u8, name, "DirectEventHandler")) return .direct;
+    if (std.mem.eql(u8, name, "BubblingEventHandler")) return .bubble;
+    return null;
 }
 
 /// 이벤트 prop 이름 → bubble vs direct 분류.

--- a/src/transformer/plugins/codegen/schema_builder_test.zig
+++ b/src/transformer/plugins/codegen/schema_builder_test.zig
@@ -305,6 +305,34 @@ test "schema_builder: WithDefault<Float, 0> → float (Flow)" {
     try std.testing.expect(shape.props[0].type_annotation == .float);
 }
 
+test "schema_builder: DirectEventHandler<T> → direct event" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { onLayout: DirectEventHandler<LayoutEvent> };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 0), shape.props.len);
+    try std.testing.expectEqual(@as(usize, 1), shape.events.len);
+    try std.testing.expectEqualStrings("onLayout", shape.events[0].name);
+    try std.testing.expectEqual(schema.BubblingType.direct, shape.events[0].bubbling_type);
+}
+
+test "schema_builder: BubblingEventHandler<T> → bubble event" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { onChange: BubblingEventHandler<ChangeEvent> };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.events.len);
+    try std.testing.expectEqual(schema.BubblingType.bubble, shape.events[0].bubbling_type);
+}
+
 test "schema_builder: TS string union → string_enum" {
     var p = try parseAndIndex(std.testing.allocator,
         \\type Props = { rate: 'fast' | 'normal' };


### PR DESCRIPTION
## 개요 (#2348 Phase 2-C)

`react-native-svg` 의 fabric spec 15+ 추가 unblock. RN codegen 의 명시적 event wrapper 인식.

```ts
// react-native-svg/src/fabric/CircleNativeComponent.ts
interface NativeProps extends ViewProps, ... {
  onSvgLayout?: DirectEventHandler<OnSvgLayoutEvent>;
}
```

이전엔 `DirectEventHandler` 가 type_reference 라 prop 으로 분류 → `mapTypeReference` 에서 cross-file `OnSvgLayoutEvent` 못 풀어 `UnresolvedTypeReference` → spec 통째 fail.

## 변경

```zig
// classifyMember — function-type 체크 후 wrapper 도 검사
if (eventHandlerBubbling(ast, type_idx)) |bubbling| {
    try events.append(alloc, .{
        .name = key_name,
        .bubbling_type = bubbling,
        .optional = flags.optional,
        .argument = null,
    });
    return;
}

fn eventHandlerBubbling(ast: *const Ast, type_idx: NodeIndex) ?schema.BubblingType {
    // type_reference 의 이름이 DirectEventHandler / BubblingEventHandler 면 매핑
}
```

bubbling 정보를 wrapper 이름에서 결정 — 기존 `onCapture` 휴리스틱보다 우선. T (event payload) 는 emitter 가 사용 안 하므로 추출 불필요.

테스트 2개 추가 (Direct / Bubbling 각각).

## 검증 (ExampleApp `--platform ios --flow`, `BUNGAE_CODEGEN_NATIVE=1`)

| Phase | spec 변환 |
| --- | --- |
| union (#2386) | 27 |
| **event handler (이 PR)** | **42 / 45 = 93%** |

남은 ~3 spec 은 cross-file type 만 사용 (`NumberProp` 등 import) — 의도적 미지원 (#2348 § 5), JS fallback 으로 처리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)