### PR TITLE
refactor(codegen): drop filename suffix gating, rely on AST-level detection

### DIFF
--- a/src/transformer/plugins/codegen_plugin.zig
+++ b/src/transformer/plugins/codegen_plugin.zig
@@ -64,7 +64,10 @@ fn onTransform(
 ) PluginError!?[]const u8 {
     _ = ctx;
 
-    if (!isSpecFilename(id)) return null;
+    // 확장자 fast-skip — .js/.ts 만 처리 (parser configureFromExtension 의존). spec
+    // 파일 식별은 filename suffix 가 아니라 AST 레벨 검증 (`findComponentName`) 으로 결정 —
+    // export default codegenNativeComponent(...) 패턴이 정확한 식별자.
+    if (!std.mem.endsWith(u8, id, ".js") and !std.mem.endsWith(u8, id, ".ts")) return null;
     if (std.mem.indexOf(u8, code, CODEGEN_MARKER) == null) return null;
 
     const props_type_name = extractTypeArg(code) orelse return null;
@@ -93,18 +96,6 @@ fn onTransform(
     defer alloc.free(view_config);
 
     return assembleFileReplacement(component_name, view_config, alloc) catch return null;
-}
-
-/// `*NativeComponent.{js,ts}` 패턴 매칭. spec 파일 컨벤션.
-fn isSpecFilename(path: []const u8) bool {
-    const is_js = std.mem.endsWith(u8, path, ".js");
-    const is_ts = std.mem.endsWith(u8, path, ".ts");
-    if (!is_js and !is_ts) return false;
-
-    const base = std.fs.path.basename(path);
-    const stem_end = if (is_js) base.len - 3 else base.len - 3;
-    const stem = base[0..stem_end];
-    return std.mem.endsWith(u8, stem, "NativeComponent");
 }
 
 /// `codegenNativeComponent<TYPE_NAME>` 에서 `TYPE_NAME` 추출.

--- a/src/transformer/plugins/codegen_plugin_test.zig
+++ b/src/transformer/plugins/codegen_plugin_test.zig
@@ -17,15 +17,39 @@ fn expectContains(haystack: []const u8, needle: []const u8) !void {
     }
 }
 
-test "codegen_plugin: non-spec filename → null" {
-    const code = "type X = { color: string };";
-    const out = try callTransform(std.testing.allocator, code, "/path/to/foo.ts");
+test "codegen_plugin: non-js/ts extension → null (fast skip)" {
+    const code = "export default codegenNativeComponent<X>('Foo');";
+    const out = try callTransform(std.testing.allocator, code, "/path/foo.css");
     try std.testing.expect(out == null);
 }
 
-test "codegen_plugin: spec filename without codegenNativeComponent → null" {
+test "codegen_plugin: file without codegenNativeComponent marker → null" {
     const code = "type X = { color: string };";
     const out = try callTransform(std.testing.allocator, code, "/path/to/FooNativeComponent.ts");
+    try std.testing.expect(out == null);
+}
+
+test "codegen_plugin: filename without NativeComponent suffix is processed" {
+    // filename suffix 제약 제거 — AST 레벨 (findComponentName) 이 spec 파일 정확히 식별.
+    // 사용자 정의 spec (e.g. `MySpec.ts`) 도 codegenNativeComponent 호출 있으면 변환.
+    const code =
+        \\type NativeProps = { color: string };
+        \\export default codegenNativeComponent<NativeProps>('My');
+    ;
+    const out_opt = try callTransform(std.testing.allocator, code, "/path/MySpec.ts");
+    try std.testing.expect(out_opt != null);
+    const out = out_opt.?;
+    defer std.testing.allocator.free(out);
+    try expectContains(out, "uiViewClassName: 'My'");
+}
+
+test "codegen_plugin: marker present but not in export default → null (AST-level reject)" {
+    // 단순 substring 매치는 통과하지만 AST 레벨에서 export default 가 아니므로 거부.
+    const code =
+        \\const codegenNativeComponent = require('rn');
+        \\const x = codegenNativeComponent('Foo');
+    ;
+    const out = try callTransform(std.testing.allocator, code, "/path/Helper.ts");
     try std.testing.expect(out == null);
 }
 


### PR DESCRIPTION
## 개요 (#2348 후속)

`*NativeComponent.{js,ts}` filename convention 제약 제거. spec 파일 식별은 이미 `findComponentName` 의 AST 레벨 검증이 정확히 수행 — filename suffix 는 _불완전한 식별자_ + 사용자 정의 spec convention 에 인위적 제약.

## Fast skip 두 단계 유지

```zig
// 1. 확장자 (parser configureFromExtension 의존)
if (!std.mem.endsWith(u8, id, ".js") and !std.mem.endsWith(u8, id, ".ts")) return null;
// 2. substring (parse 비용 회피)
if (std.mem.indexOf(u8, code, CODEGEN_MARKER) == null) return null;
```

substring 통과 후 false positive 는 AST 단계 (`findComponentName`) 가 거부 — `export_default_declaration` → `call_expression` → callee `identifier_reference("codegenNativeComponent")` + 첫 인자 `string_literal` 매칭만.

## 변경

| 파일 | 변경 |
| --- | --- |
| `codegen_plugin.zig` | `isSpecFilename` 함수 (11줄) 삭제 + 확장자 inline 검사 |
| `codegen_plugin_test.zig` | 테스트 4개 (2 update + 2 신규) |

신규 테스트:
- `filename without NativeComponent suffix is processed` — 사용자 정의 spec (e.g. `MySpec.ts`) 인식
- `marker present but not in export default → null` — `const codegenNativeComponent = require(...)` 같은 false positive 안전 검증

## ExampleApp E2E 측정

변화 없음 (`__INTERNAL_VIEW_CONFIG=202`, `[bungae:codegen] inlined=31`) — RN core / svg / screens / safe-area 등 메인 dep 의 모든 spec 이 이미 suffix 따름. 사용자 정의 spec 또는 비표준 third-party 에서 가치 가시.

## 검증

- `zig build test` exit=0 (4400+ 테스트)
- `zig build test -Dtest-filter=codegen_plugin` exit=0 (8개 테스트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)