### PR TITLE
fix(napi): codegenTransform 사용자 명시값 우선 (root-cause)

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -3701,10 +3701,10 @@ fn parseBuildOptions(
         .entry_error_guard = getObjectBool(env, opts_obj, "entryErrorGuard", false) or (platform == .react_native and bundler_mod.RN_BOOL_PRESET.entry_error_guard),
         .worklet_transform = getObjectBool(env, opts_obj, "workletTransform", false) or (platform == .react_native and bundler_mod.RN_BOOL_PRESET.worklet_transform),
         .worklet_plugin_version = ownStr(env, opts_obj, "workletPluginVersion", owned_strings),
-        // ZTS native codegen — Bungae 토글이 NAPI 까지 닿지 않으면 RN preset 도 적용 안 됨.
-        // PR #2378 가 BuildOptions/main.zig 만 추가하고 NAPI 진입점 하이드레이션 누락한 것
-        // 수정 — `codegenTransform` 옵션을 받아 RN preset 과 OR.
-        .codegen_transform = getObjectBool(env, opts_obj, "codegenTransform", false) or (platform == .react_native and bundler_mod.RN_BOOL_PRESET.codegen_transform),
+        // ZTS native codegen — default 가 RN preset (platform=react-native 시 true). 사용자가
+        // `codegenTransform: false` 명시하면 그게 우선 (escape hatch 동작 보장). OR 패턴은
+        // false override 가 RN preset 의 true 에 묻혀 무력화되는 버그 있었음.
+        .codegen_transform = getObjectBool(env, opts_obj, "codegenTransform", platform == .react_native and bundler_mod.RN_BOOL_PRESET.codegen_transform),
         .global_identifiers = global_identifiers orelse &.{},
         .polyfills = polyfills orelse &.{},
         .run_before_main = run_before_main orelse &.{},


### PR DESCRIPTION
## 개요 (#2348 후속, root-cause)

`getObjectBool(..., false) or (RN_BOOL_PRESET.codegen_transform)` 패턴의 root-cause 버그.

사용자가 `codegenTransform: false` 명시해도 RN preset (`true`) 와 OR 되어 결과는 항상 `true`. Bungae 측 escape hatch (`BUNGAE_CODEGEN_FALLBACK=js`) 무력화 — JS only 모드 전환 불가능.

## Symptom (Bungae ExampleApp 측정)

| Mode | 의도 | 실제 |
| --- | --- | --- |
| env 없음 | JS only | ZTS + JS hybrid (RN preset 으로 ZTS 자동 활성) |
| `FALLBACK=js` | JS only (force) | ZTS + JS hybrid (사용자 false 가 묻힘) |
| `BUNGAE_CODEGEN_NATIVE=1` | hybrid | hybrid |

세 모드가 모두 동일 동작 (`__INTERNAL_VIEW_CONFIG=202`, `inlined=31`).

## Fix

```zig
// Before
.codegen_transform = getObjectBool(env, opts_obj, "codegenTransform", false)
    or (platform == .react_native and bundler_mod.RN_BOOL_PRESET.codegen_transform);

// After  — default 가 RN preset, 사용자 명시 우선
.codegen_transform = getObjectBool(env, opts_obj, "codegenTransform",
    platform == .react_native and bundler_mod.RN_BOOL_PRESET.codegen_transform);
```

| 사용자 입력 | Before | After |
| --- | --- | --- |
| 명시 `true` | true | true |
| 명시 `false` | **true (버그)** | **false (override 작동)** |
| 미설정, RN | true | true |
| 미설정, web | false | false |

## 후속

`worklet_transform` 도 동일 OR 패턴 (`napi_entry.zig:3702`). 사용자 false override 필요한 케이스가 발견되면 같은 fix 적용 — 별개 PR.

## 검증

- `zig build test` exit=0 (4400+ 테스트)
- Bungae 측 escape hatch PR (다음) 에서 E2E 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)