### PR TITLE
feat(transformer): module_specifier_map cherry-pick split (#2393 3a+3b)

### DIFF
--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -67,6 +67,17 @@ pub const Plugin = plugin_mod.Plugin;
 /// `parser.scan_results.DefineEntry` 와 동일 정의 — parser 의 inline scan 도 같은 entries 사용.
 pub const DefineEntry = @import("../parser/scan_results.zig").DefineEntry;
 
+/// `import { x } from 'mod'` 의 cherry-pick 매핑 — `babel-plugin-lodash` 동등.
+///
+/// `template` 내 `{name}` placeholder 가 specifier 이름으로 치환. 예:
+///   `.{ .module = "lodash", .template = "lodash/{name}" }`
+///   → `import { map, filter } from 'lodash'` 가
+///     `import map from 'lodash/map'; import filter from 'lodash/filter'` 로 분해.
+pub const ModuleSpecifierMapEntry = struct {
+    module: []const u8,
+    template: []const u8,
+};
+
 /// emotion.autoLabel 모드. 다른 emotion 도구들 (`@emotion/babel-plugin` 등) 의
 /// `'always' | 'dev-only' | 'never'` 와 동일 의미.
 pub const AutoLabelMode = enum {
@@ -200,6 +211,15 @@ pub const TransformOptions = struct {
     /// emitDecoratorMetadata: __metadata("design:paramtypes", [...]) 호출 주입.
     /// NestJS, Angular, TypeORM 등 reflect-metadata 기반 DI에 필요.
     emit_decorator_metadata: bool = false,
+    /// `import { x } from 'mod'` → `import x from 'mod/x'` cherry-pick 분해. babel-plugin-lodash
+    /// 등 라이브러리별 babel plugin 의 ZTS 동등 — 사용자가 라이브러리 매핑 제공, ZTS 가
+    /// generic 하게 적용. 매핑 안 된 source 는 unchanged.
+    ///
+    /// 변환 조건 (안전):
+    ///   - source 가 매핑 entry 의 module 과 일치 (정확 매칭)
+    ///   - 모든 specifier 가 named (default/namespace 아님), alias 없음, value (type-only 아님)
+    ///   조건 미충족 시 unchanged — fallback (라이브러리가 path import 미지원 시 안전).
+    module_specifier_map: []const ModuleSpecifierMapEntry = &.{},
     /// verbatimModuleSyntax (TS 5.0+): true면 값 import를 elide하지 않는다.
     /// `import type`만 제거되고 `import { foo } from "./bar"`는 foo가 미사용이라도 보존.
     /// esbuild/vite/swc(isolatedModules) 표준 동작. 기본 false (tsc 기본과 동일).
@@ -4618,6 +4638,16 @@ pub const Transformer = struct {
             if (self.areAllSpecifiersUnused(x.specs_start, x.specs_len)) return .none;
         }
 
+        // module_specifier_map: cherry-pick 분해. 매핑 entry 와 source 일치 + 모든 specifier
+        // 가 named/no-alias/value 면 한 import 를 default + path 형태 N개로 split.
+        if (self.options.module_specifier_map.len > 0 and x.attrs_len == 0 and x.phase == .none) {
+            if (self.findModuleMapTemplate(x.source)) |template| {
+                if (try self.rewriteImportToPathSplits(node, x, template)) |rewritten| {
+                    return rewritten;
+                }
+            }
+        }
+
         const new_specs = try self.visitExtraList(.{ .start = x.specs_start, .len = x.specs_len });
         const new_source = try self.visitNode(x.source);
         // phase / attributes는 metadata — transform 대상 아님, 그대로 통과.
@@ -4625,6 +4655,117 @@ pub const Transformer = struct {
             new_specs.start,       new_specs.len, @intFromEnum(new_source),
             @intFromEnum(x.phase), x.attrs_start, x.attrs_len,
         });
+    }
+
+    /// import source string 이 module_specifier_map 의 entry 와 매칭되면 template 반환.
+    /// `'lodash'` 같은 구체 매칭만 — wildcard 미지원. unmatched 면 null.
+    fn findModuleMapTemplate(self: *Transformer, source_idx: NodeIndex) ?[]const u8 {
+        const source_node = self.ast.getNode(source_idx);
+        if (source_node.tag != .string_literal) return null;
+        const raw = self.ast.getText(source_node.data.string_ref);
+        const stripped = Ast.stripStringQuotes(raw);
+        for (self.options.module_specifier_map) |entry| {
+            if (std.mem.eql(u8, stripped, entry.module)) return entry.template;
+        }
+        return null;
+    }
+
+    /// 매핑 조건 충족 시 분해. 단일 named → 단일 default 노드 반환. 다중 → 첫 specifier 만
+    /// 반환하고 나머지는 trailing_nodes 로 같은 list 에 추가. 조건 미충족 (default/namespace/
+    /// alias/type-only) 이면 null 반환 — caller 가 unchanged path 진행.
+    fn rewriteImportToPathSplits(
+        self: *Transformer,
+        node: Node,
+        x: module_parser.ImportDeclExtras,
+        template: []const u8,
+    ) Error!?NodeIndex {
+        if (x.specs_len == 0) return null;
+
+        // 모든 specifier 검증 — named, no alias, no type-only
+        var i: u32 = 0;
+        while (i < x.specs_len) : (i += 1) {
+            const spec_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[x.specs_start + i]);
+            const spec_node = self.ast.getNode(spec_idx);
+            if (spec_node.tag != .import_specifier) return null;
+            // type-only specifier (flags & 1) — 분해 X (path 에 type 만 export 안 함)
+            if (spec_node.data.binary.flags & 1 != 0) return null;
+            // alias 없는지: imported == local (NodeIndex 동일성)
+            if (spec_node.data.binary.left != spec_node.data.binary.right) return null;
+        }
+
+        var first_result: ?NodeIndex = null;
+        i = 0;
+        while (i < x.specs_len) : (i += 1) {
+            const spec_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[x.specs_start + i]);
+            const spec_node = self.ast.getNode(spec_idx);
+            const name_node = self.ast.getNode(spec_node.data.binary.left);
+            const name_span = name_node.span;
+            const name_text = self.ast.getText(name_span);
+
+            const new_decl = try self.buildDefaultImportFromTemplate(
+                name_span,
+                name_text,
+                template,
+                node.span,
+            );
+
+            if (first_result == null) {
+                first_result = new_decl;
+            } else {
+                try self.trailing_nodes.append(self.allocator, new_decl);
+            }
+        }
+        return first_result;
+    }
+
+    /// `import <name> from '<template:name>'` 의 AST 노드 빌드.
+    fn buildDefaultImportFromTemplate(
+        self: *Transformer,
+        name_span: Span,
+        name_text: []const u8,
+        template: []const u8,
+        decl_span: Span,
+    ) Error!NodeIndex {
+        // path string: template 의 `{name}` 을 name_text 로 치환 + quote
+        const path_text = try self.renderTemplate(template, name_text);
+        defer self.allocator.free(path_text);
+        const quoted = try std.fmt.allocPrint(self.allocator, "'{s}'", .{path_text});
+        defer self.allocator.free(quoted);
+        const path_span = try self.ast.addString(quoted);
+
+        const default_spec = try self.ast.addNode(.{
+            .tag = .import_default_specifier,
+            .span = name_span,
+            .data = .{ .string_ref = name_span },
+        });
+        const source_node = try self.ast.addNode(.{
+            .tag = .string_literal,
+            .span = path_span,
+            .data = .{ .string_ref = path_span },
+        });
+
+        const specs_start = try self.ast.addExtras(&.{@intFromEnum(default_spec)});
+        return self.addExtraNode(.import_declaration, decl_span, &.{
+            specs_start,               1,
+            @intFromEnum(source_node), @intFromEnum(module_parser.ImportPhase.none),
+            0,                         0,
+        });
+    }
+
+    /// `'lodash/{name}'` 의 `{name}` placeholder 치환. 첫 occurrence 만 — 일반적 사용처.
+    /// placeholder 없는 template (e.g. `'lodash'`) 은 _malformed config_ — 모든 specifier
+    /// 가 동일 path 로 합쳐져 사실상 invalid. caller 책임으로 정상 매핑 제공 가정.
+    fn renderTemplate(self: *Transformer, template: []const u8, name: []const u8) ![]u8 {
+        const placeholder = "{name}";
+        if (std.mem.indexOf(u8, template, placeholder)) |idx| {
+            return std.fmt.allocPrint(
+                self.allocator,
+                "{s}{s}{s}",
+                .{ template[0..idx], name, template[idx + placeholder.len ..] },
+            );
+        }
+        // placeholder 없으면 template 그대로 — 거의 의미 없는 매핑이지만 caller 책임.
+        return self.allocator.dupe(u8, template);
     }
 
     /// import의 모든 specifier가 미사용인지 확인한다.

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -217,6 +217,32 @@ fn parseAndTransform(allocator: std.mem.Allocator, source: []const u8) !TestResu
     return .{ .ast = t.ast, .root = root, .scanner = scanner_ptr, .parser = parser_ptr, .allocator = allocator };
 }
 
+/// `parseAndTransform` 의 변형 — TransformOptions 명시 가능. parser 는 module mode 강제.
+fn parseAndTransformWithOpts(
+    allocator: std.mem.Allocator,
+    source: []const u8,
+    opts: TransformOptions,
+) !TestResult {
+    const scanner_ptr = try allocator.create(Scanner);
+    errdefer allocator.destroy(scanner_ptr);
+    scanner_ptr.* = try Scanner.init(allocator, source);
+    errdefer scanner_ptr.deinit();
+
+    const parser_ptr = try allocator.create(Parser);
+    errdefer allocator.destroy(parser_ptr);
+    parser_ptr.* = Parser.init(allocator, scanner_ptr);
+    parser_ptr.is_module = true;
+    errdefer parser_ptr.deinit();
+
+    _ = try parser_ptr.parse();
+
+    var t = try Transformer.init(allocator, &parser_ptr.ast, opts);
+    const root = try t.transform();
+    t.deinitExceptAst();
+
+    return .{ .ast = t.ast, .root = root, .scanner = scanner_ptr, .parser = parser_ptr, .allocator = allocator };
+}
+
 test "Integration: type alias stripped" {
     var r = try parseAndTransform(std.testing.allocator, "type Foo = string;");
     defer r.deinit();
@@ -1887,4 +1913,111 @@ test "HMR guard: variable declaration with complex initializers" {
         \\const y = (n) => n * 2;
         \\const z = typeof x === "object";
     );
+}
+
+// ===== module_specifier_map: cherry-pick split tests =====
+
+const lodash_map: []const transformer_mod.ModuleSpecifierMapEntry = &.{
+    .{ .module = "lodash", .template = "lodash/{name}" },
+};
+
+fn assertSplitImport(
+    result: *const TestResult,
+    expected_name: []const u8,
+    expected_path: []const u8,
+    stmt_idx: u32,
+) !void {
+    const program = result.ast.getNode(result.root);
+    const list = program.data.list;
+    try std.testing.expect(stmt_idx < list.len);
+    const decl_idx: NodeIndex = @enumFromInt(result.ast.extra_data.items[list.start + stmt_idx]);
+    const decl = result.ast.getNode(decl_idx);
+    try std.testing.expectEqual(Tag.import_declaration, decl.tag);
+
+    const e = decl.data.extra;
+    const specs_start = result.ast.extra_data.items[e];
+    const specs_len = result.ast.extra_data.items[e + 1];
+    const source_idx: NodeIndex = @enumFromInt(result.ast.extra_data.items[e + 2]);
+    try std.testing.expectEqual(@as(u32, 1), specs_len);
+
+    const spec_idx: NodeIndex = @enumFromInt(result.ast.extra_data.items[specs_start]);
+    const spec = result.ast.getNode(spec_idx);
+    try std.testing.expectEqual(Tag.import_default_specifier, spec.tag);
+    try std.testing.expectEqualStrings(expected_name, result.ast.getText(spec.data.string_ref));
+
+    const source = result.ast.getNode(source_idx);
+    try std.testing.expectEqual(Tag.string_literal, source.tag);
+    const source_text = result.ast.getText(source.data.string_ref);
+    // quoted ('lodash/map') — strip
+    try std.testing.expect(source_text.len >= 2);
+    try std.testing.expectEqualStrings(expected_path, source_text[1 .. source_text.len - 1]);
+}
+
+test "module_specifier_map: single named import → default + path" {
+    var r = try parseAndTransformWithOpts(
+        std.testing.allocator,
+        "import { map } from 'lodash';",
+        .{ .module_specifier_map = lodash_map },
+    );
+    defer r.deinit();
+    try std.testing.expectEqual(@as(u32, 1), r.statementCount());
+    try assertSplitImport(&r, "map", "lodash/map", 0);
+}
+
+test "module_specifier_map: multi named import → split into N defaults" {
+    var r = try parseAndTransformWithOpts(
+        std.testing.allocator,
+        "import { map, filter, reduce } from 'lodash';",
+        .{ .module_specifier_map = lodash_map },
+    );
+    defer r.deinit();
+    try std.testing.expectEqual(@as(u32, 3), r.statementCount());
+    try assertSplitImport(&r, "map", "lodash/map", 0);
+    try assertSplitImport(&r, "filter", "lodash/filter", 1);
+    try assertSplitImport(&r, "reduce", "lodash/reduce", 2);
+}
+
+test "module_specifier_map: unmapped source unchanged" {
+    var r = try parseAndTransformWithOpts(
+        std.testing.allocator,
+        "import { foo } from 'react';",
+        .{ .module_specifier_map = lodash_map },
+    );
+    defer r.deinit();
+    // 'react' 는 매핑 안 됨 — 원본 named 형태 유지 (1 statement, 1 named specifier)
+    try std.testing.expectEqual(@as(u32, 1), r.statementCount());
+    const program = r.ast.getNode(r.root);
+    const decl_idx: NodeIndex = @enumFromInt(r.ast.extra_data.items[program.data.list.start]);
+    const decl = r.ast.getNode(decl_idx);
+    const specs_start = r.ast.extra_data.items[decl.data.extra];
+    const spec_idx: NodeIndex = @enumFromInt(r.ast.extra_data.items[specs_start]);
+    try std.testing.expectEqual(Tag.import_specifier, r.ast.getNode(spec_idx).tag);
+}
+
+test "module_specifier_map: aliased specifier left unchanged" {
+    // alias (`{ map as m }`) 는 분해 X — caller 가 path import 후 추가 alias 필요한 케이스 회피.
+    var r = try parseAndTransformWithOpts(
+        std.testing.allocator,
+        "import { map as m } from 'lodash';",
+        .{ .module_specifier_map = lodash_map },
+    );
+    defer r.deinit();
+    try std.testing.expectEqual(@as(u32, 1), r.statementCount());
+    const program = r.ast.getNode(r.root);
+    const decl_idx: NodeIndex = @enumFromInt(r.ast.extra_data.items[program.data.list.start]);
+    const decl = r.ast.getNode(decl_idx);
+    const specs_start = r.ast.extra_data.items[decl.data.extra];
+    const spec_idx: NodeIndex = @enumFromInt(r.ast.extra_data.items[specs_start]);
+    try std.testing.expectEqual(Tag.import_specifier, r.ast.getNode(spec_idx).tag);
+}
+
+test "module_specifier_map: default + named mix unchanged" {
+    var r = try parseAndTransformWithOpts(
+        std.testing.allocator,
+        "import _, { map } from 'lodash';",
+        .{ .module_specifier_map = lodash_map },
+    );
+    defer r.deinit();
+    // default import 가 섞이면 분해 조건 미충족 — unchanged
+    try std.testing.expectEqual(@as(u32, 1), r.statementCount());
 }


### PR DESCRIPTION
## 개요 (#2393 3a + 3b)

`import { x } from 'mod'` → `import x from 'mod/x'` 분해. `babel-plugin-lodash` 의 ZTS 동등 — 사용자가 라이브러리 매핑 제공, ZTS 가 generic 하게 적용.

## 신규 API

```zig
pub const ModuleSpecifierMapEntry = struct {
    module: []const u8,    // 'lodash'
    template: []const u8,  // 'lodash/{name}'
};

TransformOptions.module_specifier_map: []const ModuleSpecifierMapEntry = &.{}
```

## 변환 조건 (모두 만족 시 분해)

- source 가 매핑 entry 의 `module` 과 정확 일치
- 모든 specifier 가 named (`import_specifier`, default/namespace 아님)
- alias 없음 (imported == local)
- type-only 아님 (`flags & 1 == 0`)
- attrs 없음, `phase = none`

미충족 시 unchanged — fallback. 라이브러리가 path import 미지원 / TS type import 같은 케이스 안전.

## 다중 specifier 분해

`trailing_nodes` 메커니즘 사용 — 첫 specifier 는 default import 노드 반환, 나머지는 같은 list 에 trailing 으로 추가. `visitExtraList` 가 자동 drain.

## 테스트 (5개)

- single named import → default + path
- multi named import → split into N defaults
- unmapped source unchanged
- aliased specifier left unchanged
- default + named mix unchanged

`parseAndTransformWithOpts` 헬퍼 + `assertSplitImport` AST 검증 (codegen emit 거치지 않음 — 직접 노드 tag/span/source path 비교).

## /simplify 적용

| 발견 | 적용 |
| --- | --- |
| `stripStringQuotesImpl` 중복 | `Ast.stripStringQuotes` 재사용 |
| placeholder 부재 시 `dupe(template)` 동작 | malformed config 임을 코멘트 명시 |
| 미적용 — silent unchanged 진단 | 후속 PR 후보 |
| 미적용 — `findModuleMapTemplate` HashMap | map size 작아 marginal |

## 검증

- `zig build test` exit=0 (전체 4400+ 테스트)
- `zig build test -Dtest-filter=module_specifier_map` exit=0 (5개 신규)

## 후속 PR

- NAPI 옵션 노출 (`moduleSpecifierMap`)
- Bungae `analyzeBabelPlugins` 가 babel-plugin-lodash 발견 시 자동 매핑
- ExampleApp E2E 부팅 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)