### PR TITLE
feat(napi): expose moduleSpecifierMap option (#2393 3c)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -429,6 +429,17 @@ interface BuildOptionsCommon {
   useDefineForClassFields?: boolean;
   experimentalDecorators?: boolean;
   emitDecoratorMetadata?: boolean;
+  /** `import { x } from 'mod'` cherry-pick 분해 매핑. babel-plugin-lodash 등의 ZTS 동등 (#2393).
+   * key = source module 이름 (정확 매칭), value = template (`{name}` placeholder 가
+   * specifier 이름으로 치환).
+   *
+   * 예: `{ lodash: 'lodash/{name}' }` 면 `import { map } from 'lodash'` 가
+   *     `import map from 'lodash/map'` 으로 변환.
+   *
+   * 변환 조건 (모두 만족 시): named specifier 만, alias 없음, type-only 아님. 미충족 시
+   * 원본 import 유지 — 라이브러리가 path import 미지원 시 안전망.
+   */
+  moduleSpecifierMap?: Record<string, string>;
   banner?: string;
   footer?: string;
   globalName?: string;

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -3347,6 +3347,21 @@ fn parseBuildOptions(
         define_entries = defs;
     }
 
+    // moduleSpecifierMap: { 'lodash': 'lodash/{name}' } → []ModuleSpecifierMapEntry (#2393).
+    // babel-plugin-lodash 등 cherry-pick 분해 generic 매핑.
+    const msm_pairs = getObjectKeyValuePairs(env, opts_obj, "moduleSpecifierMap", native_alloc);
+    var module_specifier_map: []const @import("zts_lib").transformer.transformer.ModuleSpecifierMapEntry = &.{};
+    if (msm_pairs) |pairs| {
+        defer native_alloc.free(pairs);
+        const entries = native_alloc.alloc(@import("zts_lib").transformer.transformer.ModuleSpecifierMapEntry, pairs.len) catch return null;
+        for (pairs, 0..) |pair, idx| {
+            if (!trackStr(owned_strings, pair[0])) return null;
+            if (!trackStr(owned_strings, pair[1])) return null;
+            entries[idx] = .{ .module = pair[0], .template = pair[1] };
+        }
+        module_specifier_map = entries;
+    }
+
     // alias: { "from": "to" } → []AliasEntry (tsconfig paths 는 tsconfig 로드 후 아래에서 append).
     const alias_pairs = getObjectKeyValuePairs(env, opts_obj, "alias", native_alloc);
     var alias_list: std.ArrayList(bundler_mod.types.AliasEntry) = .empty;
@@ -3632,6 +3647,7 @@ fn parseBuildOptions(
         .use_define_for_class_fields = use_define_for_class_fields_eff,
         .experimental_decorators = experimental_decorators_eff,
         .emit_decorator_metadata = emit_decorator_metadata_eff,
+        .module_specifier_map = module_specifier_map,
         .verbatim_module_syntax = verbatim_module_syntax_eff,
         .banner_js = banner_js,
         .footer_js = footer_js,

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -163,6 +163,8 @@ pub const BundleOptions = struct {
     experimental_decorators: bool = false,
     /// emitDecoratorMetadata: __metadata 호출 주입 (NestJS/Angular DI)
     emit_decorator_metadata: bool = false,
+    /// `import { x } from 'mod'` cherry-pick 분해 매핑. babel-plugin-lodash 동등 (#2393).
+    module_specifier_map: []const @import("../transformer/transformer.zig").ModuleSpecifierMapEntry = &.{},
     /// useDefineForClassFields=false (tsconfig)
     use_define_for_class_fields: bool = true,
     /// verbatimModuleSyntax=true (tsconfig/CLI): unused value import를 elide하지 않음.
@@ -550,6 +552,7 @@ pub const Bundler = struct {
             .define = self.options.define,
             .experimental_decorators = self.options.experimental_decorators,
             .emit_decorator_metadata = self.options.emit_decorator_metadata,
+            .module_specifier_map = self.options.module_specifier_map,
             .use_define_for_class_fields = self.options.use_define_for_class_fields,
             .verbatim_module_syntax = self.options.verbatim_module_syntax,
             .unsupported = self.options.unsupported,

--- a/src/config_options_dto_test.zig
+++ b/src/config_options_dto_test.zig
@@ -222,6 +222,7 @@ const ts_buildoptions_only_allowlist = [_][]const u8{
     "scopeHoist", // bundler 옵션 (#1389)
     "workletTransform", // RN reanimated worklet
     "codegenTransform", // RN view config codegen (#2348)
+    "moduleSpecifierMap", // cherry-pick import 분해 (#2393)
     "strictExecutionOrder", // 모듈 실행 순서 보장
     "experimentalCodeCache", // persistent cache 실험
     "watch", // CLI flag, BuildOptions 노출 안 함이 정석이지만 일부 wrapper 가 노출


### PR DESCRIPTION
## 개요 (#2393 3c)

PR #2394 의 transformer pass 를 NAPI 사용자에게 노출.

```ts
build({
  moduleSpecifierMap: {
    lodash: 'lodash/{name}',
    'date-fns': 'date-fns/{name}',
  },
})
```

→ Zig 측 `BuildOptions.module_specifier_map` → `buildTransformOptionsBase` 가 transform_options 로 전파.

## 변경

| 파일 | 변경 |
| --- | --- |
| `src/bundler/bundler.zig` | `BuildOptions.module_specifier_map` 필드 + `buildTransformOptionsBase` 전파 |
| `packages/core/src/napi_entry.zig` | `getObjectKeyValuePairs` 로 JS object → Zig array 변환 + BuildOptions 에 set |
| `packages/core/index.ts` | `BuildOptionsCommon.moduleSpecifierMap?: Record<string, string>` |
| `src/config_options_dto_test.zig` | allowlist 추가 (schema drift 회귀 방지) |

JS object → Zig array 변환은 `getObjectKeyValuePairs` 기존 helper 재사용 — `define` / `loader_overrides` 등 동일 패턴.

## /simplify

- ✅ Reuse: `getObjectKeyValuePairs` 기존 helper 활용
- ✅ Quality: `define` hydration block 과 _완전 동일 패턴_, consistency
- ⚠️ Memory: entries 배열 자체 lifecycle — 기존 `define_entries` 도 build path 에 free 없음 (`async_data.options` 에 저장되어 process lifetime). 우리 PR 만의 이슈가 아니라 _구조적_ — 별도 issue 후속 검증 권장.

## 검증

- `zig build test` exit=0 (전체 4400+)
- E2E 검증은 후속 PR (Bungae 자동 매핑 + ExampleApp 부팅)

## 후속 PR (Bungae)

- `analyzeBabelPlugins` 가 babel-plugin-lodash 발견 시 자동 매핑
- ExampleApp `[bungae:babel] loaded: lodash` 제거 → babel 완전 비활성 검증
- 부팅 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)