### PR TITLE
fix(napi): rename msm entries to avoid shadow in ReleaseFast

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -3353,13 +3353,13 @@ fn parseBuildOptions(
     var module_specifier_map: []const @import("zts_lib").transformer.transformer.ModuleSpecifierMapEntry = &.{};
     if (msm_pairs) |pairs| {
         defer native_alloc.free(pairs);
-        const entries = native_alloc.alloc(@import("zts_lib").transformer.transformer.ModuleSpecifierMapEntry, pairs.len) catch return null;
+        const msm_entries = native_alloc.alloc(@import("zts_lib").transformer.transformer.ModuleSpecifierMapEntry, pairs.len) catch return null;
         for (pairs, 0..) |pair, idx| {
             if (!trackStr(owned_strings, pair[0])) return null;
             if (!trackStr(owned_strings, pair[1])) return null;
-            entries[idx] = .{ .module = pair[0], .template = pair[1] };
+            msm_entries[idx] = .{ .module = pair[0], .template = pair[1] };
         }
-        module_specifier_map = entries;
+        module_specifier_map = msm_entries;
     }
 
     // alias: { "from": "to" } → []AliasEntry (tsconfig paths 는 tsconfig 로드 후 아래에서 append).


### PR DESCRIPTION
PR #2395 의 `entries` 가 같은 함수 안 line 3213 의 `entries` 와 shadow. Debug 빌드 통과했지만 ReleaseFast (napi build) 에서 strict shadow 검사 실패.

`msm_entries` 로 rename, 동작 변화 없음. zig build napi exit=0 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)