### PR TITLE
fix(napi): free typed entries arrays in build/watch deinit (#2396)

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1780,6 +1780,10 @@ fn buildCompleteTsfn(env: c.napi_env, _: c.napi_value, _: ?*anyopaque, data: ?*a
         // 배열 컨테이너만 해제 (내부 문자열은 owned_strings에서 이미 해제됨)
         for (async_data.owned_string_arrays.items) |arr| native_alloc.free(arr);
         async_data.owned_string_arrays.deinit(native_alloc);
+        // BundleOptions 의 typed entries 배열 — native_alloc 으로 alloc 했으므로 명시 free.
+        // 내부 문자열은 owned_strings 가 소유 (#2396).
+        if (async_data.options.define.len > 0) native_alloc.free(async_data.options.define);
+        if (async_data.options.module_specifier_map.len > 0) native_alloc.free(async_data.options.module_specifier_map);
         // NAPI 플러그인 해제
         for (async_data.napi_plugins.items) |np| np.deinit();
         async_data.napi_plugins.deinit(native_alloc);
@@ -1978,6 +1982,9 @@ const WatchAsyncData = struct {
         // 배열 컨테이너 해제 (내부 문자열은 owned_strings에서 이미 해제됨)
         for (self.owned_string_arrays.items) |arr| native_alloc.free(arr);
         self.owned_string_arrays.deinit(native_alloc);
+        // BundleOptions 의 typed entries 배열 — native_alloc 으로 alloc 했으므로 명시 free (#2396).
+        if (self.options.define.len > 0) native_alloc.free(self.options.define);
+        if (self.options.module_specifier_map.len > 0) native_alloc.free(self.options.module_specifier_map);
         // NAPI 플러그인 해제
         for (self.napi_plugins.items) |np| np.deinit();
         self.napi_plugins.deinit(native_alloc);


### PR DESCRIPTION
## 개요 — closes #2396

`define_entries` / `module_specifier_map` 가 native_alloc 으로 alloc 되지만 `BuildAsyncData` / `WatchAsyncData` 의 deinit 에서 명시 free 안 됨 — async_data 와 함께 process lifetime 까지 유지되는 작은 leak.

PR #2395 의 simplify 리뷰 시 발견. dev path (line 574 부근, sync 함수) 는 이미 `defer free` 로 처리되어 있어 build/watch path 만 누락된 상태.

## Fix

두 deinit 블록에 동일 패턴 추가:

```zig
if (options.define.len > 0) native_alloc.free(options.define);
if (options.module_specifier_map.len > 0) native_alloc.free(options.module_specifier_map);
```

내부 문자열은 `owned_strings` 가 track — entries 배열 자체만 free.

## 영향

| | Before | After |
| --- | --- | --- |
| BuildAsyncData deinit | entries 배열 leak | free |
| WatchAsyncData deinit | 동일 | free |
| dev path (sync) | 이미 OK | 변경 없음 |

ExampleApp 한 build 당 _수십 bytes_ — 진짜 user impact 작음, 기술 부채 정리.

## 검증

- `zig build test` exit=0 (4400+ 테스트)
- `zig build napi` exit=0 (ReleaseFast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)