### PR TITLE
fix(napi): also free options.alias in build/watch deinit (#2396)

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1784,6 +1784,7 @@ fn buildCompleteTsfn(env: c.napi_env, _: c.napi_value, _: ?*anyopaque, data: ?*a
         // 내부 문자열은 owned_strings 가 소유 (#2396).
         if (async_data.options.define.len > 0) native_alloc.free(async_data.options.define);
         if (async_data.options.module_specifier_map.len > 0) native_alloc.free(async_data.options.module_specifier_map);
+        if (async_data.options.alias.len > 0) native_alloc.free(async_data.options.alias);
         // NAPI 플러그인 해제
         for (async_data.napi_plugins.items) |np| np.deinit();
         async_data.napi_plugins.deinit(native_alloc);
@@ -1985,6 +1986,7 @@ const WatchAsyncData = struct {
         // BundleOptions 의 typed entries 배열 — native_alloc 으로 alloc 했으므로 명시 free (#2396).
         if (self.options.define.len > 0) native_alloc.free(self.options.define);
         if (self.options.module_specifier_map.len > 0) native_alloc.free(self.options.module_specifier_map);
+        if (self.options.alias.len > 0) native_alloc.free(self.options.alias);
         // NAPI 플러그인 해제
         for (self.napi_plugins.items) |np| np.deinit();
         self.napi_plugins.deinit(native_alloc);


### PR DESCRIPTION
## 개요 — #2396 후속

PR #2399 후속 — `alias` typed slice 도 native_alloc 으로 alloc 후 deinit free 누락. `alias_list.toOwnedSlice(native_alloc)` 결과가 process lifetime 까지 leak.

## 검증된 leak 후보 (PR #2399 의 simplify 발견)

| 필드 | 상태 |
| --- | --- |
| `define` | ✅ #2399 에서 fix |
| `module_specifier_map` | ✅ #2399 에서 fix |
| **`alias`** | **본 PR fix** |
| `drop_labels` | OK — `trackArr(owned_string_arrays, arr)` 로 이미 추적 |
| `loader_overrides` | trim 된 sub-slice (`overrides[0..valid_count]`) — free 시 원본 length 필요. 별도 더 깊은 작업, 후속 PR |

## 변경

build / watch deinit 양쪽에 한 줄씩:

```zig
if (self.options.alias.len > 0) native_alloc.free(self.options.alias);
```

## 후속

- `loader_overrides` 의 backing buffer length 추적 (별도 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)