### PR TITLE
chore(napi): extract freeOptionsTypedSlices helper (#2400 simplify)

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1732,6 +1732,15 @@ fn serializeFunctionInfo(
     return buf.toOwnedSlice(alloc);
 }
 
+/// BundleOptions 의 native_alloc-owned typed slices 일괄 free (#2396).
+/// 내부 문자열은 owned_strings 가 소유 — 본 함수는 entry 배열 자체만 free.
+/// 새 typed slice 옵션 추가 시 본 함수에 한 줄만 추가.
+fn freeOptionsTypedSlices(opts: *const BundleOptions) void {
+    if (opts.define.len > 0) native_alloc.free(opts.define);
+    if (opts.module_specifier_map.len > 0) native_alloc.free(opts.module_specifier_map);
+    if (opts.alias.len > 0) native_alloc.free(opts.alias);
+}
+
 // ─── build() 비동기 (Promise) ───
 
 const BuildAsyncData = struct {
@@ -1780,11 +1789,8 @@ fn buildCompleteTsfn(env: c.napi_env, _: c.napi_value, _: ?*anyopaque, data: ?*a
         // 배열 컨테이너만 해제 (내부 문자열은 owned_strings에서 이미 해제됨)
         for (async_data.owned_string_arrays.items) |arr| native_alloc.free(arr);
         async_data.owned_string_arrays.deinit(native_alloc);
-        // BundleOptions 의 typed entries 배열 — native_alloc 으로 alloc 했으므로 명시 free.
-        // 내부 문자열은 owned_strings 가 소유 (#2396).
-        if (async_data.options.define.len > 0) native_alloc.free(async_data.options.define);
-        if (async_data.options.module_specifier_map.len > 0) native_alloc.free(async_data.options.module_specifier_map);
-        if (async_data.options.alias.len > 0) native_alloc.free(async_data.options.alias);
+        // typed slices (define/module_specifier_map/alias) — native_alloc 소유, 명시 free (#2396).
+        freeOptionsTypedSlices(&async_data.options);
         // NAPI 플러그인 해제
         for (async_data.napi_plugins.items) |np| np.deinit();
         async_data.napi_plugins.deinit(native_alloc);
@@ -1983,10 +1989,8 @@ const WatchAsyncData = struct {
         // 배열 컨테이너 해제 (내부 문자열은 owned_strings에서 이미 해제됨)
         for (self.owned_string_arrays.items) |arr| native_alloc.free(arr);
         self.owned_string_arrays.deinit(native_alloc);
-        // BundleOptions 의 typed entries 배열 — native_alloc 으로 alloc 했으므로 명시 free (#2396).
-        if (self.options.define.len > 0) native_alloc.free(self.options.define);
-        if (self.options.module_specifier_map.len > 0) native_alloc.free(self.options.module_specifier_map);
-        if (self.options.alias.len > 0) native_alloc.free(self.options.alias);
+        // typed slices (define/module_specifier_map/alias) — native_alloc 소유, 명시 free (#2396).
+        freeOptionsTypedSlices(&self.options);
         // NAPI 플러그인 해제
         for (self.napi_plugins.items) |np| np.deinit();
         self.napi_plugins.deinit(native_alloc);


### PR DESCRIPTION
PR #2400 의 simplify — `define` / `module_specifier_map` / `alias` 의 free 패턴이 양쪽 deinit (BuildAsyncData / WatchAsyncData) 에 동일 3 lines. helper 추출.

```zig
fn freeOptionsTypedSlices(opts: *const BundleOptions) void { ... }
```

향후 새 typed slice 옵션 (loader_overrides 등 #2396 후속) 추가 시 본 함수 한 줄만, 양쪽 deinit 자동 일관.