### PR TITLE
fix(transformer/es2015_generator): switch_statement access via .extra (UB fix)

### DIFF
--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -1264,8 +1264,20 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 }
                 try collectHoistedVarFromNode(self, node.data.binary.right, hoisted);
             } else if (node.tag == .switch_statement) {
-                // switch.left = discriminant, switch.right = list of switch_case
-                try collectHoistedVarFromNode(self, node.data.binary.right, hoisted);
+                // switch_statement: extra = [discriminant, cases.start, cases.len].
+                // 이전엔 `node.data.binary.right` 로 access 했지만 switch_statement 의 data
+                // kind 는 .extra — binary.right 는 union padding 영역의 undefined 값. main
+                // 에선 우연히 valid index 였지만 새 AST tag 추가 시 padding 변동으로 panic.
+                const extras = self.ast.extra_data.items;
+                const e = node.data.extra;
+                if (e + 2 < extras.len) {
+                    const cases_start = extras[e + 1];
+                    const cases_len = extras[e + 2];
+                    var i: u32 = 0;
+                    while (i < cases_len) : (i += 1) {
+                        try collectHoistedVarFromNode(self, @enumFromInt(extras[cases_start + i]), hoisted);
+                    }
+                }
             } else if (node.tag == .for_await_of_statement) {
                 // (#1901) ternary.a = left (var v 인 경우), c = body. helper var 들 (_iter,
                 // _step, _ret, _errObj, _err) 은 lowerForAwaitOf 가 generator_temp_var_spans


### PR DESCRIPTION
## 개요 (root-cause fix)

`collectHoistedVarFromNode` 의 switch_statement 분기가 `node.data.binary.right` 로 access — switch_statement 의 data kind 는 `.extra` 라 binary.right 는 union padding 영역의 undefined 값.

main 에선 우연히 padding 이 valid ast.nodes 인덱스 (작은 값) 였지만, **새 AST tag 추가 시 padding 위치 변동으로 panic 트리거**:

```
panic: index out of bounds: index 1804950920, len 22
src/transformer/es2015_generator.zig:1268
```

#2401 (Flow enum parser) 작업 중 발견. 우리 PR 이 `flow_enum_declaration` / `flow_enum_member` tag 추가 → es_downlevel async state-machine 테스트 `signal 6` 발생 → root cause 추적 결과 본 UB.

## Fix

같은 함수의 다른 switch_statement access (line 1504, 1594) 는 이미 `extra` kind 로 정상 처리. 본 분기만 누락된 것을 동일 패턴으로 통일:

```zig
// extra = [discriminant, cases.start, cases.len]
const extras = self.ast.extra_data.items;
const e = node.data.extra;
if (e + 2 < extras.len) {
    const cases_start = extras[e + 1];
    const cases_len = extras[e + 2];
    var i: u32 = 0;
    while (i < cases_len) : (i += 1) {
        try collectHoistedVarFromNode(self, @enumFromInt(extras[cases_start + i]), hoisted);
    }
}
```

## Semantic 영향

이 버그는 **잠재적 silent semantic bug**. main 에서도 _wrong index_ 의 노드를 visit 했지만 _hoisted vars 결과가 기존 testcase 에 영향 없는 우연_. fix 후 정상 cases 만 hoist.

## 검증

- `zig build test` exit=0 (전체 4475+ 테스트, 본 #1887 self-loop 케이스 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)