### PR TITLE
feat(transformer/codegen): Flow enum transformer (#2401 part 2)

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -1031,6 +1031,9 @@ pub const Codegen = struct {
             // TS enum/namespace → IIFE 출력
             .ts_enum_declaration => try self.emitEnumIIFE(node),
             .ts_module_declaration => try self.emitNamespaceIIFE(node),
+            // Flow enum (#2401) → `const Name = Object.freeze({...})` 출력. members 의
+            // init expression 이 없으면 base_type 에 따라 default value (string/number/...).
+            .flow_enum_declaration => try self.emitFlowEnum(node),
 
             // TS/Flow expression 노드: operand만 출력 (type 부분 스트리핑).
             // pre-visit body를 codegen할 때 (e.g. worklet __initData.code) TS/Flow 노드가 남아있을 수 있음.
@@ -3653,6 +3656,80 @@ pub const Codegen = struct {
         raw: []const u8, // float 등 숫자 원본 텍스트
         str: []const u8, // 문자열 리터럴 원본 텍스트
     };
+
+    // ================================================================
+    // Flow enum → Object.freeze({...}) 출력 (#2401)
+    // ================================================================
+
+    /// Flow enum 의 codegen — `const Name = Object.freeze({ K: V, ... });`.
+    ///
+    /// extra = [name, members_start, members_len, base_type].
+    /// base_type (FlowEnumBaseType: 0=none/symbol-implicit, 1=string, 2=number,
+    /// 3=boolean, 4=symbol). init 가 .none 인 멤버는 base_type 에 따라 기본값:
+    ///   - none / symbol → `Symbol("Name")`
+    ///   - string → `"Name"` (멤버 이름)
+    ///   - number → 인덱스 (0, 1, 2, ...)
+    ///   - boolean → `false` (의미 없는 fallback)
+    ///
+    /// 현재는 `flow-enums-runtime` 패키지의 `Enum()` wrapper 미사용. Object.freeze
+    /// 만으로 _값 비교_ semantic 충족 — \`Status.cast(x)\` / \`.members()\` 같은 enum
+    /// 메서드 미지원 (사용처 적음).
+    fn emitFlowEnum(self: *Codegen, node: Node) Error!void {
+        const e = node.data.extra;
+        const name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+        const members_start = self.ast.extra_data.items[e + 1];
+        const members_len = self.ast.extra_data.items[e + 2];
+        const base_type = self.ast.extra_data.items[e + 3];
+
+        const name_node = self.ast.getNode(name_idx);
+        const name_text = self.ast.getText(name_node.span);
+
+        try self.write("const ");
+        try self.write(name_text);
+        try self.write("=Object.freeze({");
+
+        const members = self.ast.extra_data.items[members_start .. members_start + members_len];
+        var auto_idx: u32 = 0;
+        for (members, 0..) |raw_idx, i| {
+            if (i > 0) try self.writeByte(',');
+            const member = self.ast.getNode(@enumFromInt(raw_idx));
+            const member_name_node = self.ast.getNode(member.data.binary.left);
+            const member_name = Ast.stripStringQuotes(self.ast.getText(member_name_node.span));
+            try self.write(member_name);
+            try self.writeByte(':');
+
+            const init_idx = member.data.binary.right;
+            if (!init_idx.isNone()) {
+                try self.emitNode(init_idx);
+            } else {
+                try self.emitFlowEnumDefaultValue(base_type, member_name, auto_idx);
+            }
+            auto_idx += 1;
+        }
+        try self.write("});");
+    }
+
+    fn emitFlowEnumDefaultValue(self: *Codegen, base_type: u32, member_name: []const u8, auto_idx: u32) Error!void {
+        switch (base_type) {
+            0, 4 => {
+                try self.write("Symbol(\"");
+                try self.write(member_name);
+                try self.write("\")");
+            },
+            1 => {
+                try self.writeByte('"');
+                try self.write(member_name);
+                try self.writeByte('"');
+            },
+            2 => {
+                var buf: [16]u8 = undefined;
+                const slice = std.fmt.bufPrint(&buf, "{d}", .{auto_idx}) catch unreachable;
+                try self.write(slice);
+            },
+            3 => try self.write("false"),
+            else => try self.write("undefined"),
+        }
+    }
 
     // ================================================================
     // TS namespace → IIFE 출력

--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -380,3 +380,53 @@ test "Flow: Metro smoke — full module with all Flow features" {
 }
 
 // ============================================================
+
+// ===== Flow enum (#2401) — codegen e2e =====
+
+test "Flow enum: default → Object.freeze with Symbol values" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\enum Status { Active, Inactive }
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "const Status=Object.freeze({") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Active:Symbol(\"Active\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Inactive:Symbol(\"Inactive\")") != null);
+}
+
+test "Flow enum: of string → Object.freeze with string values" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\enum Color of string { Red = 'red', Blue = 'blue' }
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "const Color=Object.freeze({") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Red:\"red\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Blue:\"blue\"") != null);
+}
+
+test "Flow enum: of number → Object.freeze with number values" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\enum Level of number { Low = 1, High = 10 }
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Low:1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "High:10") != null);
+}
+
+test "Flow enum: of boolean" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\enum Toggle of boolean { On = true, Off = false }
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "On:true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Off:false") != null);
+}
+
+test "Flow enum: usage 후 frozen object 비교 작동" {
+    // Object.freeze 결과는 일반 object — `Status.Active` 접근, `===` 비교 가능.
+    var r = try e2eFlow(std.testing.allocator,
+        \\enum Color of string { Red = 'red' }
+        \\const x = Color.Red;
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "const x=Color.Red") != null);
+}

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1679,6 +1679,10 @@ pub const Transformer = struct {
             .ts_enum_declaration => self.visitEnumDeclaration(node),
             .ts_enum_member => self.visitBinaryNode(idx),
             .ts_enum_body => self.visitListNode(idx),
+            // === Flow enum (#2401): codegen 에서 Object.freeze({...}) 출력. members 의
+            // init expression 만 visit 필요 (다른 변환 영향 없음).
+            .flow_enum_declaration => self.visitFlowEnumDeclaration(node),
+            .flow_enum_member => self.visitBinaryNode(idx),
             .ts_module_declaration => self.visitNamespaceDeclaration(node),
             .ts_module_block => self.visitListNode(idx),
 
@@ -2547,6 +2551,19 @@ pub const Transformer = struct {
     // ================================================================
     // TS enum 변환
     // ================================================================
+
+    /// flow_enum_declaration: extra = [name, members_start, members_len, base_type]
+    /// codegen 단계에서 `const Name = Object.freeze({...})` 형태 emit. transformer 는
+    /// members 의 init expression 만 visit (define / global rename 등 일반 변환 적용).
+    fn visitFlowEnumDeclaration(self: *Transformer, node: Node) Error!NodeIndex {
+        const e = node.data.extra;
+        const new_name = try self.visitNode(self.readNodeIdx(e, 0));
+        const new_members = try self.visitExtraList(.{ .start = self.readU32(e, 1), .len = self.readU32(e, 2) });
+        const base_type = self.readU32(e, 3);
+        return self.addExtraNode(.flow_enum_declaration, node.span, &.{
+            @intFromEnum(new_name), new_members.start, new_members.len, base_type,
+        });
+    }
 
     /// ts_enum_declaration: extra = [name, members_start, members_len, flags]
     /// flags: 0=일반 enum (codegen에서 IIFE), 1=const enum (선언 삭제 + 멤버를 self.const_enums 에 보관 → visitMemberExpression 에서 literal 인라인).


### PR DESCRIPTION
## 개요 (closes #2401)

PR #2405 의 parser 후속 — `flow_enum_declaration` AST → runtime JS 변환.

## emit 형태

```js
const Name = Object.freeze({ K: V, ... });
```

init 없는 멤버는 base_type 별 default value:

| base_type | default |
| --- | --- |
| none / symbol | `Symbol("Name")` |
| string | `"Name"` (멤버 이름) |
| number | auto_idx (0, 1, 2, ...) |
| boolean | `false` |

## 디자인 결정

`flow-enums-runtime` 패키지의 `Enum()` wrapper 미사용 — `Object.freeze` 만으로 _값 비교_ semantic 충족. `Status.cast(x)` / `.members()` 같은 enum 메서드 미지원 (사용처 적음, 후속 작업 가능).

## 변경

| 파일 | 변경 |
| --- | --- |
| transformer.zig | dispatch + `visitFlowEnumDeclaration` (TS enum 패턴 모방) |
| codegen.zig | dispatch + `emitFlowEnum` + `emitFlowEnumDefaultValue` |
| codegen_test/flow.zig | 5 e2e 테스트 |

## 검증

- `zig build test` exit=0 (전체 4485+ 테스트, 5 신규 e2e 포함)

## #2401 close

Flow enum 은 ExampleApp 의 모든 RN deps 에 사용처 0건이지만 사용자 앱 / third-party 에서 사용 시 ZTS 가 babel forward 없이 native 처리 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)