### PR TITLE
fix(napi): free fallback/loader_overrides in build/watch deinit (#2396)

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1739,6 +1739,8 @@ fn freeOptionsTypedSlices(opts: *const BundleOptions) void {
     if (opts.define.len > 0) native_alloc.free(opts.define);
     if (opts.module_specifier_map.len > 0) native_alloc.free(opts.module_specifier_map);
     if (opts.alias.len > 0) native_alloc.free(opts.alias);
+    if (opts.fallback.len > 0) native_alloc.free(opts.fallback);
+    if (opts.loader_overrides.len > 0) native_alloc.free(opts.loader_overrides);
 }
 
 // ─── build() 비동기 (Promise) ───


### PR DESCRIPTION
## 요약

#2396 follow-up. NAPI `fallback` / `loader_overrides` typed slice 가 `freeOptionsTypedSlices` 에 빠져 있어 build/watch 한 번에 entry 배열 자체가 새던 문제 정리.

## 발견 경로

- #2396 본문: `define` / `module_specifier_map` 누락 → #2395 + 8fe83128 로 처리
- #2396 follow-up 댓글: \`drop_labels\`, \`alias\` 도 의심
- 6295c50b 에서 `alias` 추가, `drop_labels` 는 `trackArr` 로 owned_string_arrays 에 들어가 이미 free 됨 확인
- 본 PR 의 추가 검증: `fallback` (`[]FallbackEntry`) 과 `loader_overrides` (`[]LoaderOverride`) 도 `native_alloc.alloc` 으로 잡고 `BundleOptions` 에 저장만 하는데 helper 에서 free 안 됨 → 동일 leak

## 변경

`packages/core/src/napi_entry.zig` 의 `freeOptionsTypedSlices` 에 두 줄 추가:

```zig
if (opts.fallback.len > 0) native_alloc.free(opts.fallback);
if (opts.loader_overrides.len > 0) native_alloc.free(opts.loader_overrides);
```

## 영향

- 모두 process lifetime leak — build/watch 한 번에 entry 배열 자체 ~수십 bytes. user impact 미미.
- helper 의 doc-comment 가 명시적으로 "새 typed slice 옵션 추가 시 본 함수에 한 줄만 추가" 를 가이드 → 일관성 정리.

## 검증

- `zig build napi` 통과
- 기존 BuildAsyncData / WatchAsyncData deinit 두 곳 모두에서 helper 호출 → 양쪽 path 동시 fix

## Out of scope

- `globals` (`[]GlobalEntry`) 는 NAPI 측 파싱 자체가 아직 없음 (#2338 보류) → default `&.{}` → leak 없음
- string array 옵션 (`inject` / `polyfills` / `run_before_main` / `global_identifiers` 등) 은 `trackArr(owned_string_arrays, arr)` 로 일괄 처리 되므로 무관

## Checklist

- [x] zig fmt
- [x] zig build napi
- [x] /simplify 리뷰 (3 agents) — `fallback` 까지 함께 묶어달라는 reuse review 의견 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)