### PR TITLE
fix(transpile): BindingLite import elision 안전성 보강

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -201,8 +201,8 @@ pub fn extractImportBindings(
                 },
                 .import_specifier => {
                     // binary { left=imported, right=local, flags }
-                    // flags & 1 → inline type import (import { type X }) → 런타임 바인딩 불필요
-                    if (spec_node.data.binary.flags & 1 != 0) continue;
+                    // SPEC_FLAG_TYPE_ONLY → inline type import (import { type X }) → 런타임 바인딩 불필요
+                    if ((spec_node.data.binary.flags & module_parser.SPEC_FLAG_TYPE_ONLY) != 0) continue;
                     const imported_idx = spec_node.data.binary.left;
                     const local_idx = spec_node.data.binary.right;
                     if (imported_idx.isNone()) continue;

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -30,6 +30,11 @@ pub const ImportPhase = enum(u4) {
     source = 2,
 };
 
+/// `import_specifier` / `export_specifier` 의 `binary.flags` 비트.
+/// inline `type` modifier (`import { type X }`, `export { type X }`) 마킹용.
+/// 모든 read 사이트는 `(flags & SPEC_FLAG_TYPE_ONLY) != 0` 형태로 검사.
+pub const SPEC_FLAG_TYPE_ONLY: u16 = 1;
+
 /// `import_declaration` extra schema의 단일 source of truth.
 /// codegen / transformer 등 read 사이트가 이 헬퍼를 통해서만 슬롯 의미를 알도록 강제.
 pub const ImportDeclExtras = struct {
@@ -463,7 +468,7 @@ fn parseImportSpecifier(self: *Parser) ParseError2!NodeIndex {
     if (self.is_flow and self.current() == .kw_typeof) {
         const next = try self.peekNextKind();
         if (next == .identifier or next == .string_literal or (next.isKeyword() and next != .r_curly and next != .comma)) {
-            is_type_only = 1;
+            is_type_only = SPEC_FLAG_TYPE_ONLY;
             try self.advance(); // skip 'typeof'
         }
     }
@@ -489,19 +494,19 @@ fn parseImportSpecifier(self: *Parser) ParseError2!NodeIndex {
                 const after_as = try self.peekNextKind();
                 if (after_as == .r_curly or after_as == .comma) {
                     // "import { type as }" — 'as'가 imported name, type modifier 확정
-                    is_type_only = 1;
+                    is_type_only = SPEC_FLAG_TYPE_ONLY;
                 } else if (after_as == .identifier or after_as.isKeyword()) {
                     // 다음 토큰 텍스트를 확인: "type as as foo" vs "type as alias"
                     const saved2 = self.saveState();
                     try self.advance(); // skip 'as'
                     if (try resolveTypeAsAs(self, saved, saved2)) {
-                        is_type_only = 1;
+                        is_type_only = SPEC_FLAG_TYPE_ONLY;
                     }
                 } else {
                     self.restoreState(saved);
                 }
             } else {
-                is_type_only = 1;
+                is_type_only = SPEC_FLAG_TYPE_ONLY;
                 // 'type' modifier 확정 — 이미 advance됨
             }
         }
@@ -790,7 +795,7 @@ pub fn parseExportDeclarationWithDecorators(self: *Parser, decorators: ast_mod.N
                 const spec_node = self.ast.getNode(spec_idx);
                 if (spec_node.tag != .export_specifier) continue;
                 // skip type-only specifiers
-                if (spec_node.data.binary.flags & 1 != 0) continue;
+                if ((spec_node.data.binary.flags & SPEC_FLAG_TYPE_ONLY) != 0) continue;
 
                 const local_idx = spec_node.data.binary.left;
                 const exported_idx = spec_node.data.binary.right;
@@ -936,18 +941,18 @@ fn parseExportSpecifier(self: *Parser) ParseError2!NodeIndex {
                 const after_as = try self.peekNextKind();
                 if (after_as == .r_curly or after_as == .comma) {
                     // "export { type as }" — 'as'가 local name, type modifier 확정
-                    is_type_only = 1;
+                    is_type_only = SPEC_FLAG_TYPE_ONLY;
                 } else if (after_as == .identifier or after_as == .string_literal or after_as.isKeyword()) {
                     const saved2 = self.saveState();
                     try self.advance(); // skip 'as'
                     if (try resolveTypeAsAs(self, saved, saved2)) {
-                        is_type_only = 1;
+                        is_type_only = SPEC_FLAG_TYPE_ONLY;
                     }
                 } else {
                     self.restoreState(saved);
                 }
             } else {
-                is_type_only = 1;
+                is_type_only = SPEC_FLAG_TYPE_ONLY;
                 // 'type' modifier 확정 — 이미 advance됨
             }
         }
@@ -1180,8 +1185,8 @@ fn collectImportBindings(self: *Parser, scratch_top: usize, rec_idx: u32) void {
                 }) catch {};
             },
             .import_specifier => {
-                // binary: left=imported, right=local, flags (flags&1 = type-only)
-                if (spec_node.data.binary.flags & 1 != 0) continue; // skip type-only
+                // binary: left=imported, right=local, flags (SPEC_FLAG_TYPE_ONLY = type-only)
+                if ((spec_node.data.binary.flags & SPEC_FLAG_TYPE_ONLY) != 0) continue;
                 const imported_idx = spec_node.data.binary.left;
                 const local_idx = spec_node.data.binary.right;
                 if (imported_idx.isNone()) continue;

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1643,16 +1643,16 @@ pub const Transformer = struct {
             },
 
             // === import/export specifiers ===
-            // #1791 Phase D: inline `type` modifier (flags&1) 또는 named specifier 의
+            // #1791 Phase D: inline `type` modifier (SPEC_FLAG_TYPE_ONLY) 또는 named specifier 의
             // value-ref 0 (type 위치에서만 사용) 이면 elide. visitExtraList 가 `.none` 을
             // 필터링. default/namespace 는 JSX pragma 등 implicit value use 위험이 커
             // `shouldElideImportSpecifier` 에서 이미 false 를 반환하므로 elision 비활성.
             .import_specifier => blk: {
-                if (node.data.binary.flags & 1 != 0) break :blk NodeIndex.none;
+                if ((node.data.binary.flags & module_parser.SPEC_FLAG_TYPE_ONLY) != 0) break :blk NodeIndex.none;
                 if (self.shouldElideImportSpecifier(idx, node)) break :blk NodeIndex.none;
                 break :blk self.visitBinaryNode(idx);
             },
-            .export_specifier => if (node.data.binary.flags & 1 != 0) .none else self.visitBinaryNode(idx),
+            .export_specifier => if ((node.data.binary.flags & module_parser.SPEC_FLAG_TYPE_ONLY) != 0) .none else self.visitBinaryNode(idx),
             // default/namespace specifier는 string_ref(span) 복사 — 자식 노드 없음
             .import_default_specifier,
             .import_namespace_specifier,
@@ -4727,8 +4727,8 @@ pub const Transformer = struct {
             const spec_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[x.specs_start + i]);
             const spec_node = self.ast.getNode(spec_idx);
             if (spec_node.tag != .import_specifier) return null;
-            // type-only specifier (flags & 1) — 분해 X (path 에 type 만 export 안 함)
-            if (spec_node.data.binary.flags & 1 != 0) return null;
+            // type-only specifier — 분해 X (path 에 type 만 export 안 함)
+            if ((spec_node.data.binary.flags & module_parser.SPEC_FLAG_TYPE_ONLY) != 0) return null;
             // alias 없는지: imported == local (NodeIndex 동일성)
             if (spec_node.data.binary.left != spec_node.data.binary.right) return null;
         }
@@ -4818,8 +4818,8 @@ pub const Transformer = struct {
             if (spec_idx.isNone()) continue;
             const spec_node = self.ast.getNode(spec_idx);
 
-            // type-only specifier (flags & 1 != 0) → 이미 스트리핑됨, 무시
-            if (spec_node.tag == .import_specifier and spec_node.data.binary.flags & 1 != 0) continue;
+            // type-only specifier → 이미 스트리핑됨, 무시
+            if (spec_node.tag == .import_specifier and (spec_node.data.binary.flags & module_parser.SPEC_FLAG_TYPE_ONLY) != 0) continue;
             if (spec_node.tag == .export_specifier) continue; // 방어적: export specifier는 여기 없지만
 
             if (!self.isImportSpecifierUnused(spec_idx, spec_node)) return false;

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -48,6 +48,7 @@ const SemanticPlanReason = enum {
     module_format_requires_semantic,
     ast_requires_runtime_transform,
     import_shape_requires_full_semantic,
+    binding_shadow_requires_full_semantic,
     named_import_binding_elision,
 };
 
@@ -485,6 +486,33 @@ fn collectAstFacts(ast: *const Ast) AstFacts {
     return facts;
 }
 
+fn hasNamedImportLocalBindingShadow(ast: *const Ast) bool {
+    for (ast.nodes.items) |import_node| {
+        if (import_node.tag != .import_declaration) continue;
+        const import_decl = module_parser.readImportDeclExtras(ast, import_node.data.extra);
+        var i: u32 = 0;
+        while (i < import_decl.specs_len) : (i += 1) {
+            const spec_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[import_decl.specs_start + i]);
+            if (spec_idx.isNone()) continue;
+            const spec = ast.getNode(spec_idx);
+            if (spec.tag != .import_specifier) continue;
+            if (spec.data.binary.flags & 1 != 0) continue;
+
+            const local_idx = spec.data.binary.right;
+            if (local_idx.isNone()) continue;
+            const local = ast.getNode(local_idx);
+            const local_name = ast.getText(local.span);
+
+            for (ast.nodes.items, 0..) |node, raw_idx| {
+                if (@as(u32, @intCast(raw_idx)) == @intFromEnum(local_idx)) continue;
+                if (node.tag != .binding_identifier) continue;
+                if (std.mem.eql(u8, local_name, ast.getText(node.span))) return true;
+            }
+        }
+    }
+    return false;
+}
+
 fn optionsRequireTransformSemantic(options: TranspileOptions) bool {
     return options.minify_identifiers or
         options.minify_syntax or
@@ -537,6 +565,9 @@ fn buildTransformPlan(
         return .{ .semantic = .full, .reason = .ast_requires_runtime_transform };
     }
     if (facts.has_import_declaration) {
+        if (hasNamedImportLocalBindingShadow(ast)) {
+            return .{ .semantic = .full, .reason = .binding_shadow_requires_full_semantic };
+        }
         return .{
             .semantic = .bindings,
             .reason = .named_import_binding_elision,
@@ -681,6 +712,13 @@ fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *Bind
         },
         .formal_parameters => {
             markBindingLiteListValueUses(ast, node.data.list, lite, false);
+            return;
+        },
+        .assignment_pattern,
+        .assignment_target_with_default,
+        => {
+            markBindingLiteValueUses(ast, node.data.binary.left, lite, false);
+            markBindingLiteValueUses(ast, node.data.binary.right, lite, true);
             return;
         },
         .formal_parameter => {
@@ -1326,6 +1364,40 @@ test "TransformPlan parity: binding-lite named import elision matches full seman
             ,
         },
         .{
+            .name = "computed property key is value use",
+            .source =
+            \\import { A } from "./lib";
+            \\export const value = { [A]: 1 };
+            ,
+        },
+        .{
+            .name = "shorthand property is value use",
+            .source =
+            \\import { A } from "./lib";
+            \\export const value = { A };
+            ,
+        },
+        .{
+            .name = "default parameter initializer is value use",
+            .source =
+            \\import { A } from "./lib";
+            \\export function f(value = A()) {
+            \\  return value;
+            \\}
+            ,
+        },
+        .{
+            .name = "nested function body reference is value use",
+            .source =
+            \\import { A } from "./lib";
+            \\export function outer() {
+            \\  return function inner() {
+            \\    return A();
+            \\  };
+            \\}
+            ,
+        },
+        .{
             .name = "verbatim keeps value import but removes inline type specifier",
             .source =
             \\import { type A, B } from "./lib";
@@ -1368,6 +1440,8 @@ test "TransformPlan: full-route guards for binding-lite follow-up" {
         .{ .name = "cjs", .source = "import { Foo } from './x';\nFoo();\n", .options = .{ .module_format = .cjs } },
         .{ .name = "downlevel", .source = "import { Foo } from './x';\nFoo();\n", .options = .{ .unsupported = compat.fromESTarget(.es5), .es_target = .es5 } },
         .{ .name = "flow", .source = "import { Foo } from './x';\nexport const x: Foo = 1;\n", .path = "input.js", .options = .{ .flow = true } },
+        .{ .name = "import local shadowed by parameter", .source = "import { Foo } from './x';\nexport function f(Foo = Foo) { return Foo; }\n" },
+        .{ .name = "import local shadowed by local declaration", .source = "import { Foo } from './x';\nconst Foo = 1;\nexport { Foo };\n" },
     };
 
     for (cases) |case| {

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -486,7 +486,13 @@ fn collectAstFacts(ast: *const Ast) AstFacts {
     return facts;
 }
 
+// default/namespace specifier 는 collectAstFacts 에서 has_non_named_import 로 잡혀
+// buildTransformPlan 이 이미 full 로 라우팅하므로 여기서는 named 만 본다.
+// import local 노드는 identifier_reference 로 태깅되므로 binding_identifier 필터에 자연히 빠진다.
 fn hasNamedImportLocalBindingShadow(ast: *const Ast) bool {
+    var names_buf: [64][]const u8 = undefined;
+    var names_len: usize = 0;
+
     for (ast.nodes.items) |import_node| {
         if (import_node.tag != .import_declaration) continue;
         const import_decl = module_parser.readImportDeclExtras(ast, import_node.data.extra);
@@ -500,14 +506,21 @@ fn hasNamedImportLocalBindingShadow(ast: *const Ast) bool {
 
             const local_idx = spec.data.binary.right;
             if (local_idx.isNone()) continue;
-            const local = ast.getNode(local_idx);
-            const local_name = ast.getText(local.span);
+            // 64 개 초과 named import 는 보수적으로 full 로 우회 — barrel 파일 등 흔치 않은 경우.
+            if (names_len == names_buf.len) return true;
+            names_buf[names_len] = ast.getText(ast.getNode(local_idx).span);
+            names_len += 1;
+        }
+    }
 
-            for (ast.nodes.items, 0..) |node, raw_idx| {
-                if (@as(u32, @intCast(raw_idx)) == @intFromEnum(local_idx)) continue;
-                if (node.tag != .binding_identifier) continue;
-                if (std.mem.eql(u8, local_name, ast.getText(node.span))) return true;
-            }
+    if (names_len == 0) return false;
+
+    for (ast.nodes.items) |node| {
+        if (node.tag != .binding_identifier) continue;
+        const bind_name = ast.getText(node.span);
+        var j: usize = 0;
+        while (j < names_len) : (j += 1) {
+            if (std.mem.eql(u8, bind_name, names_buf[j])) return true;
         }
     }
     return false;

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -502,7 +502,7 @@ fn hasNamedImportLocalBindingShadow(ast: *const Ast) bool {
             if (spec_idx.isNone()) continue;
             const spec = ast.getNode(spec_idx);
             if (spec.tag != .import_specifier) continue;
-            if (spec.data.binary.flags & 1 != 0) continue;
+            if ((spec.data.binary.flags & module_parser.SPEC_FLAG_TYPE_ONLY) != 0) continue;
 
             const local_idx = spec.data.binary.right;
             if (local_idx.isNone()) continue;
@@ -608,7 +608,7 @@ fn collectBindingLite(allocator: std.mem.Allocator, ast: *const Ast) !BindingLit
             if (spec_idx.isNone()) continue;
             const spec = ast.getNode(spec_idx);
             if (spec.tag != .import_specifier) continue;
-            if (spec.data.binary.flags & 1 != 0) continue;
+            if ((spec.data.binary.flags & module_parser.SPEC_FLAG_TYPE_ONLY) != 0) continue;
 
             const local_idx = spec.data.binary.right;
             if (local_idx.isNone()) continue;


### PR DESCRIPTION
## 요약
- PR #2389 merge 직후 실패했던 check rollup은 현재 `origin/main`에서 재검증했고, 공통 원인은 당시 `napi_entry.zig`의 `entries` shadowing 컴파일 오류였습니다. 현재 main에서는 NAPI 빌드와 core 테스트가 통과합니다.
- BindingLite named import elision에서 default parameter initializer / computed key / shorthand property / nested function body / export specifier value-use parity fixture를 보강했습니다.
- BindingLite가 scope를 완전히 모델링하지 않는 현재 단계에서는 import local과 같은 이름의 지역 binding이 나오면 보수적으로 full semantic route를 타도록 가드했습니다.

## 변경 내용
- `assignment_pattern` / `assignment_target_with_default`의 우변을 value-use로 추적해 default initializer에서 import를 잘못 제거하지 않게 수정
- named import local shadowing 감지 시 `.full` route로 fallback
- BindingLite fast/full parity fixture와 full-route guard fixture 추가

## 검증
- `zig build test --summary all`
- `zig build napi -Doptimize=ReleaseFast --summary all`
- `bun test packages/core/index.test.ts --timeout 30000`
- `zig build -Doptimize=ReleaseFast --summary all`
- `bun run tests/benchmark/profile.ts`
- `ZTS_DISABLE_TRANSPILE_FAST_PATH=1 bun run tests/benchmark/profile.ts`
- push 전 hook: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check` 통과

## 참고
- profile fixture 기준 ZTS: enabled `5000=4ms / 10000=6ms`, disabled `5000=5ms / 10000=8ms`
- pre-push oxlint는 `tests/integration/tests/bundle-dynamic-import.test.ts`의 기존 미사용 import 경고 3개를 출력했지만 error는 없었습니다.

Refs #2352