### PR TITLE
docs(bundler): add tree-shaking implementation guide

### DIFF
--- a/docs/BUNDLER.md
+++ b/docs/BUNDLER.md
@@ -169,9 +169,147 @@ const Module = struct {
 - ✅ **2.1단계**: 사용자 pure hint — `--pure:callee` / `BuildOptions.pure`를 기존 pure flag로 반영
 - ✅ **2.5단계**: sideEffects 지원 — package.json `sideEffects: false` + 자동 순수 판별
 - ✅ **2.5b**: sideEffects 글롭 패턴 — `sideEffects: ["*.css"]` 배열 형태 (matchGlob 기반)
+- ✅ **statement-level**: rolldown 방식 symbol graph + BFS 도달성 (`stmt_info.zig` / `statement_shaker.zig`)
 - ⬜ **3단계**: 깊은 사이드 이펙트 분석 — getter/proxy/global 변수 판단 (후순위)
-- **문장 수준 tree-shaking은 구현하지 않음** — esbuild/Bun과 동일하게 모듈 수준만 (Rollup만 문장 수준 지원)
 - ZTS 유리점: semantic analyzer의 스코프/심볼이 이미 있고, `@__PURE__` 렉서 지원, 인덱스 기반 AST로 노드 제거가 태그 변경만으로 가능
+
+## Tree-shaking 구현 (모듈 수준 + statement 수준)
+
+번들러의 트리쉐이킹은 두 패스로 나뉜다. **모듈 수준** 은 어떤 모듈/export 가 도달 가능한지를 fixpoint 로 좁히고, **statement 수준** 은 모듈 안에서 어떤 top-level 문이 살아남는지를 symbol graph BFS 로 결정한다. 별도로 트랜스파일-only 경로 (번들러 미사용) 에는 `BindingLite` 라는 fast-path 가 named import elision 만 좁게 수행한다.
+
+```
+src/bundler/
+  tree_shaker.zig          ← 모듈 수준 fixpoint, used_exports, has_direct_used_export
+  stmt_info.zig            ← statement 단위 symbol graph (declared/referenced)
+  statement_shaker.zig     ← StmtInfo + reachable bitset → skip_nodes 계산
+  binding_scanner.zig      ← import_specifier → BindingRecord 추출 (SPEC_FLAG_TYPE_ONLY skip)
+  purity.zig               ← @__PURE__, builtin pure ctor, sideEffects 자동 판별
+
+src/transformer/transformer.zig
+  shouldElideImportSpecifier  ← named specifier 단위 elision (verbatim 가드)
+  namedImportValueUse          ← BindingLite 결과 조회
+
+src/transpile.zig
+  hasNamedImportLocalBindingShadow / collectBindingLite ← 트랜스파일 fast-path
+```
+
+### 1단계 — 모듈 수준 (`tree_shaker.zig`)
+
+진입점부터 fixpoint 반복으로 도달 가능한 모듈/export 를 좁힌다 (`max_fixpoint_iterations = 100`, 실측 2-3회 수렴). 핵심 자료구조:
+
+| 필드 | 의미 |
+|---|---|
+| `used_exports: HashMap("module_idx:export_name" → bool)` | export 단위 사용 여부 (`ALL_EXPORTS_SENTINEL = "*"` 로 entry/dynamic-import 모듈 마킹) |
+| `has_direct_used_export: []bool` | 모듈 단위 used export 유무 — `hasAnyUsedExport` 가 O(1) (#917) |
+| `re_export_star_targets: ?DynamicBitSet` | `export * from` source 모듈 마스크 — fixpoint 안 `tryMarkReExportNsSubset` O(M·E) 스캔 회피 (#1928) |
+| `module_stmt_infos: []ModuleStmtInfos` | 모듈별 StmtInfo (fixpoint **이전** 에 일괄 구축, BFS 진입 시 O(1) 조회 #1558) |
+
+알고리즘:
+1. 진입점 + dynamic import target → `used_exports[*]` seed (#1260: dynamic import 는 정적 분석 밖이라 entry 취급)
+2. 포함 모듈의 import specifier 스캔 → `(source_module, imported_name)` 키로 마킹
+3. re-export chain 따라 cascade — `buildSymToIbMaps()` 가 fixpoint 각 iteration 마다 lazy 갱신해 같은 iteration 내 `followImport` 가 정상 동작
+4. 모듈 inclusion: `!has_used_export && !is_entry && !has_evaluation_side_effects` → 제거 (bitset)
+
+성능 기록:
+- fixpoint oscillation 수정 (#1558): 100회 → 2회 — 미사용 모듈 제거를 fixpoint **밖** 으로 분리
+- StmtInfo 사전 구축 (#1558 / #920): tree-shake 29.8 → 5.6ms (-81%), 전체 transpile 82.7 → 56.9ms (-31%)
+
+### 2단계 — Statement 수준 (`stmt_info.zig` + `statement_shaker.zig`)
+
+semantic analyzer 가 만든 `symbol_ids` (node_index → symbol_index) 를 재활용해 top-level statement 단위 symbol graph 를 구축한다.
+
+```zig
+// stmt_info.zig
+pub const StmtInfo = struct {
+    node_idx: u32,
+    span: Span,
+    has_side_effects: bool,
+    declared_symbols: []const u32,    // 이 stmt 가 선언하는 top-level 심볼
+    referenced_symbols: []const u32,  // 참조 (declared 제외)
+};
+
+pub const ModuleStmtInfos = struct {
+    stmts: []StmtInfo,
+    cjs_export_facts: []const CjsExportFact,        // exports.foo = ... 정적 증명
+    symbol_to_stmt: []const ?u32,                    // symbol → 선언 stmt (O(1))
+    sym_to_referencing_stmts: []const []const u32,   // symbol → 참조 stmt 들
+    sym_to_writer_stmts: []const []const u32,        // 비선언 write (`var _a; _a = AST;` TS 패턴)
+    sym_to_side_effect_stmts: []const []const u32,   // side-effectful 참조
+    ...
+};
+```
+
+도달성 BFS (`computeReachable`):
+- **Seed**: side-effectful stmt + used export 의 선언 stmt + writer stmt
+- **전파**: `referenced_symbols` 재귀, `symbol_to_stmt`/`sym_to_writer_stmts` 로 의존 stmt enqueue
+- **출력**: stmt 도달성 bitset → emitter 가 skip_nodes 로 변환
+
+`statement_shaker.zig` 는 transformer 의 `newSymbolIds` (linker rename 후) 를 받아 도달성을 재계산해 스코프 호이스팅과 정합성을 맞춘다 (#1558 Phase 4).
+
+### 순수성 분석 (`purity.zig`)
+
+esbuild / rolldown 과 동일 기준. 재귀 깊이 128 제한.
+
+- **순수**: literal, identifier, function/arrow expression, `@__PURE__` 호출
+- **객체/배열**: 원소 모두 순수 (computed key 도 key+value 둘 다)
+- **Builtin pure constructor** (unresolved global 컨텍스트만):
+  - `Set/Map/WeakSet/WeakMap`: `new` 전용, 인자는 무인자/null/undefined/ArrayExpression 만 (iterator protocol side-effect 회피)
+  - `Array/Date/String`: 인자 재귀 pure 검사
+  - `Error` 계열: msg 인자가 Symbol 아님 정적 증명 필요
+  - `Object.freeze`/`Object.assign`: fresh literal 제약 special case
+- **Statement 순수**: function/class declaration, pure variable initialization, side-effect-free export
+- **`@__PURE__` 주석**: 렉서가 다음 call/new 노드의 `is_pure` 플래그 설정 → tree_shaker / statement_shaker 가 무시
+
+`sideEffects` 필드:
+- `false` → 모듈 전체 순수
+- `["*.css"]` → glob 매칭 (단조 적용, 예외 없음, INVARIANTS.md § sideEffects 참고)
+- 자동 순수 판별: entry 가 아닌 모듈의 top-level 이 모두 순수면 `side_effects = false` 자동 설정
+
+### Type-only import elision
+
+두 진입점이 협력한다.
+
+**번들러 경로** (`binding_scanner.zig` + `transformer.zig`):
+1. `extractImportBindings`: `import_specifier.binary.flags & SPEC_FLAG_TYPE_ONLY != 0` 인 specifier 는 BindingRecord 미생성 — 런타임 바인딩 자체가 없으므로 자연 elide
+2. `shouldElideImportSpecifier` (transformer.zig:4833): `verbatim_module_syntax = false` 가드 + named specifier 한정. symbol table 의 `reference_count` 와 `isValueUse()` 로 "값 위치 참조 0" 인 named import 만 제거 (#1791 Phase D)
+
+default/namespace specifier 는 JSX pragma, CSS-in-JS implicit-use 위험으로 elision 미지원 (#1793 revert 사유).
+
+**트랜스파일 fast-path** (`transpile.zig` BindingLite):
+- 번들러가 아닌 단일 파일 트랜스파일 모드에서 full semantic 없이 named import 제거를 노리는 경량 스코프 분석
+- `collectBindingLite` 가 named import local 을 수집, `markBindingLiteValueUses` 가 program 트리를 한 번 훑어 value-use 마킹
+- value-use 가 0 인 local 은 transformer 의 `namedImportValueUse(local_name)` 조회로 제거됨
+- BindingLite 는 scope 를 완전히 모델링하지 않아, **import local 과 같은 이름의 binding 이 다른 곳에서 다시 선언되면** 보수적으로 full semantic 경로로 fallback (`hasNamedImportLocalBindingShadow`, PR #2410)
+
+### CJS export facts (`stmt_info.zig`)
+
+CJS module 도 일부는 정적으로 export 를 증명할 수 있어 트리쉐이킹 가능하다.
+
+```zig
+pub const CjsExportFact = struct {
+    pub const Kind = enum {
+        assignment,             // exports.foo = rhs
+        object_property,        // module.exports = { foo: rhs, ... }
+        define_property_value,  // Object.defineProperty(exports, 'foo', { value: rhs })
+        define_property_getter, // ... { get: () => rhs }
+    };
+    export_name: []u8,
+    statement_index: u32,
+    rhs_symbol: ?u32,
+    kind: Kind,
+    is_safe_to_prune: bool,
+    ...
+};
+```
+
+증명 가능한 패턴만 fact 로 등록되고, dynamic property (`exports[k]`) / runtime branch (`if (cond) exports.foo = ...`) / getter side-effect 는 제외돼 보수적으로 보존된다.
+
+### 한계
+
+- **CJS wrap Asset 모듈**: `require_X()` 호출이 side-effect 로 간주돼 미사용 import 라도 트리쉐이킹 불가. esbuild 의 `NoSideEffects_PureData` 마킹은 미적용 (ROADMAP.md § "CJS wrap Asset"). JSON 모듈은 ESM AST 변환으로 우회 (#589).
+- **Namespace import barrel**: `import * as X; export { X }` 는 symbol 기반 추적 불가 → local export 로 분류, lazyBarrel 정밀화 미완료 (ROADMAP.md § lazyBarrel).
+- **getter/proxy/global side-effect**: 깊은 분석 미구현 (전략 3단계, 후순위).
+- **BindingLite shadow 한계**: 64 개 초과 named import 는 full semantic 으로 보수적 fallback (스택 버퍼 overflow — `transpile.zig` `hasNamedImportLocalBindingShadow`).
 
 ## 스코프 호이스팅 deconflict 개선 (TODO — 구조적 수정 필요)
 현재: well-known global 이름 목록(`isReservedName`)을 상수로 관리. 모듈의 top-level 변수가 글로벌을 shadowing하면 리네임.

--- a/documents/astro.config.mjs
+++ b/documents/astro.config.mjs
@@ -82,6 +82,7 @@ export default defineConfig({
           translations: { en: "Bundler" },
           items: [
             { label: "개요", slug: "guides/bundling", translations: { en: "Overview" } },
+            { label: "트리쉐이킹", slug: "guides/tree-shaking", translations: { en: "Tree-shaking" } },
             { label: "manualChunks", slug: "guides/manual-chunks", translations: { en: "manualChunks" } },
           ],
         },

--- a/documents/src/content/docs/en/guides/tree-shaking.md
+++ b/documents/src/content/docs/en/guides/tree-shaking.md
@@ -1,0 +1,222 @@
+---
+title: Tree-shaking
+description: ZTS bundler tree-shaking strategy — module-level fixpoint analysis, statement-level reachability BFS, and type-only import elision.
+---
+
+The ZTS bundler runs tree-shaking in two passes. **Module-level** narrows the set of reachable modules and exports through fixpoint iteration. **Statement-level** then decides which top-level statements survive inside each module via symbol-graph BFS.
+
+The goal is Rollup/Rolldown accuracy with esbuild-class speed. ZTS reuses the index-based AST and the semantic analyzer's scope/symbol tables to get both.
+
+## At a glance
+
+```bash
+# Tree-shaking is on by default in bundle mode — no flag needed.
+zts --bundle src/index.ts -o dist/bundle.js
+
+# package.json sideEffects is honored automatically.
+# @__PURE__ / @__NO_SIDE_EFFECTS__ comments are recognized.
+# Add user-supplied pure hints:
+zts --bundle src/index.ts -o dist/bundle.js --pure=myUtil --pure=invariant
+```
+
+## Stage 1 — Module level
+
+Starting from entry points, fixpoint iteration narrows reachable modules and exports (max 100 iterations, typically converges in 2–3).
+
+### Used-export tracking
+
+Each module records `(module_idx, export_name)` keys in a `used_exports` map.
+
+- **Entry points + dynamic-import targets**: outside static analysis, conservatively marked as using all exports (the `*` sentinel).
+- **Import-specifier scan in included modules**: registers which exports are imported under which local names.
+- **Re-export chain cascade**: `export * from './a'` and `export { X } from './a'` propagate upstream usage to downstream modules.
+
+```ts
+// a.ts
+export const used = 1;
+export const unused = 2;  // unreachable → removal candidate
+
+// entry.ts
+import { used } from './a';
+console.log(used);
+```
+
+### Side-effect verdict
+
+A module can be dropped entirely only if all of these hold:
+
+- No entries in `used_exports`
+- Not an entry point
+- Evaluating the module itself has no side effects (every top-level statement is pure)
+
+### `package.json sideEffects`
+
+```json
+{
+  "name": "my-lib",
+  "sideEffects": false
+}
+```
+
+When a library declares `sideEffects: false`, ZTS is free to drop unused imports. Glob patterns are also supported:
+
+```json
+{
+  "sideEffects": ["*.css", "./src/polyfills.ts"]
+}
+```
+
+:::caution
+The `sideEffects` policy is applied **monotonically** — once a file is marked `false`, it cannot be flipped back to `true`. This is intentional: it forces library authors to make their intent explicit.
+:::
+
+### Auto-purity inference
+
+Even without `sideEffects` in `package.json`, ZTS infers `side_effects = false` for non-entry modules whose top-level is entirely pure.
+
+### Performance milestones
+
+| Optimization | Effect |
+|---|---|
+| Fixpoint oscillation fix (#1558) | 100 iters → 2 iters; tree-shake 238ms → 51ms |
+| `has_direct_used_export` O(1) array (#917) | Module-level used-export lookup is O(1) |
+| Pre-built StmtInfo (#1558) | tree-shake 29.8ms → 5.6ms (-81%); transpile total -31% |
+| `re_export_star_targets` bitset (#1928) | Avoids O(M·E) `tryMarkReExportNsSubset` scan |
+
+## Stage 2 — Statement level
+
+Once a module is kept, ZTS decides which top-level statements are actually reachable. The semantic analyzer's symbol_id mapping is reused to build a per-statement symbol graph.
+
+### StmtInfo
+
+Each top-level statement records the symbols it **declares** and the symbols it **references**:
+
+```zig
+pub const StmtInfo = struct {
+    node_idx: u32,
+    has_side_effects: bool,
+    declared_symbols: []const u32,    // symbols this stmt declares
+    referenced_symbols: []const u32,  // references (excluding declared)
+};
+```
+
+From this, ZTS builds reverse indices: `symbol_to_stmt`, `sym_to_referencing_stmts`, `sym_to_writer_stmts`.
+
+### Reachability BFS
+
+```
+Seed:
+  - side-effectful statements
+  - declaring statements of used exports
+  - non-declaring writer statements (TS-emit pattern: var _a; ... _a = AST;)
+
+Propagate:
+  - referenced_symbols → enqueue dependent stmts via symbol_to_stmt
+  - only statements reachable inside the module survive
+```
+
+### Example
+
+```ts
+// utils.ts
+export function used() { return 1; }
+export function unused() { return 2; }
+
+const helper = () => 'helper';   // referenced only by unused → unreachable
+function unused() { return helper(); }
+```
+
+Both `unused` and `helper` are removed in the output — they are disconnected from `used`'s reachability graph.
+
+## Purity analysis
+
+`@__PURE__` / `@__NO_SIDE_EFFECTS__` annotations combined with a builtin allow-list drive expression-level purity (recursion limit: 128).
+
+### `@__PURE__` annotation
+
+```ts
+const x = /* @__PURE__ */ createComponent();  // dropped if x is unused
+```
+
+The lexer sets `is_pure` on the next call/new node; the tree-shaker then ignores it for side-effect purposes.
+
+### `@__NO_SIDE_EFFECTS__` annotation
+
+```ts
+// @__NO_SIDE_EFFECTS__
+function compute(x) { return x * 2; }
+
+const a = compute(1);  // if a is unused, the call itself is removed
+const b = compute(2);
+```
+
+Marking the function declaration treats every call site as pure.
+
+### Builtin pure constructors
+
+The following are auto-pure when bound to an unresolved global (no user redefinition):
+
+| Constructor | Constraint |
+|---|---|
+| `Set`, `Map`, `WeakSet`, `WeakMap` | `new` only; arg must be empty / `null` / `undefined` / ArrayExpression (avoids iterator-protocol side effects) |
+| `Array`, `Date`, `String` | Args must be recursively pure |
+| `Error` family | Must statically prove the message arg is not a Symbol |
+| `Object.freeze`, `Object.assign` | Fresh-literal constraint (special case) |
+
+### User-supplied pure hints
+
+Mark functions as pure via CLI or build options:
+
+```bash
+zts --bundle entry.ts --pure=invariant --pure=warning
+```
+
+```ts
+import { invariant } from 'tiny-invariant';
+
+invariant(condition, "msg");  // call is removable when condition is statically truthy
+```
+
+## Type-only import elision
+
+TypeScript's `import type` and inline `type` modifier produce no runtime bindings.
+
+```ts
+import type { User } from './types';        // fully removed
+import { type Config, helper } from './x';  // type Config removed, helper kept based on usage
+```
+
+ZTS performs elision via two paths:
+
+- **Bundler path**: `binding_scanner.zig` checks the `SPEC_FLAG_TYPE_ONLY` flag and skips creating a BindingRecord altogether.
+- **Transpile fast path** (BindingLite): without running full semantic analysis, BindingLite tracks value-use of named imports and removes only the truly-unused ones.
+
+:::note
+`default` and `namespace` imports are **not** elided — JSX pragmas and CSS-in-JS implicit-use risks make automatic removal unsafe. They are conservatively preserved.
+:::
+
+### `verbatimModuleSyntax`
+
+When `tsconfig.json` has `"verbatimModuleSyntax": true`, ZTS removes only `import type` and leaves regular imports intact (matching TypeScript's standard behavior).
+
+## Limitations
+
+:::caution[CJS-wrapped asset modules]
+CJS modules wrapped via `require()` keep their `require_X()` calls, which count as side effects — even unused ones survive. esbuild's `NoSideEffects_PureData` marking is not yet applied in ZTS.
+
+JSON modules sidestep this by being converted to an ESM AST — they support per-named-export tree-shaking.
+:::
+
+:::caution[Namespace barrels]
+`import * as X; export { X }` style namespace re-exports are hard to track via symbols and are classified as local exports. lazyBarrel refinement is in progress.
+:::
+
+:::caution[Getter / Proxy / Global side effects]
+Deep DCE for runtime-time side effects (getters, Proxy, global mutation) is not yet implemented (lower priority).
+:::
+
+## Further reading
+
+- Contributor implementation guide: [`docs/BUNDLER.md` § Tree-shaking 구현](https://github.com/ohah/zts/blob/main/docs/BUNDLER.md#tree-shaking-%EA%B5%AC%ED%98%84-%EB%AA%A8%EB%93%88-%EC%88%98%EC%A4%80--statement-%EC%88%98%EC%A4%80) — data structures, file:line citations, algorithm pseudocode
+- Architecture overview: [`docs/ARCHITECTURE.md` § Tree-shaking Design](https://github.com/ohah/zts/blob/main/docs/ARCHITECTURE.md)
+- Related PRs: #458, #460 (stage 1), #1558 (statement-level), #1791 (type-only elision), #1928 (re-export optimization)

--- a/documents/src/content/docs/guides/tree-shaking.md
+++ b/documents/src/content/docs/guides/tree-shaking.md
@@ -1,0 +1,222 @@
+---
+title: 트리쉐이킹
+description: ZTS 번들러의 트리쉐이킹 전략 — 모듈 수준 fixpoint 분석부터 statement 수준 도달성 BFS, type-only import elision 까지.
+---
+
+ZTS 번들러는 두 단계 트리쉐이킹을 수행합니다. **모듈 수준** 은 어떤 모듈/export 가 진입점에서 도달 가능한지를 fixpoint 로 좁히고, **statement 수준** 은 모듈 안에서 어떤 top-level 문이 살아남는지를 symbol graph BFS 로 결정합니다.
+
+목표는 Rollup/Rolldown 수준 정확도 + esbuild 수준 속도. 인덱스 기반 AST 와 semantic analyzer 의 스코프/심볼 정보를 재활용해 두 마리 토끼를 잡습니다.
+
+## 한눈에 보기
+
+```bash
+# 트리쉐이킹은 번들 모드의 기본 동작 — 따로 켤 필요 없음
+zts --bundle src/index.ts -o dist/bundle.js
+
+# package.json sideEffects 자동 적용
+# @__PURE__ / @__NO_SIDE_EFFECTS__ 주석 자동 인식
+# 사용자 pure hint 추가
+zts --bundle src/index.ts -o dist/bundle.js --pure=myUtil --pure=invariant
+```
+
+## 1단계 — 모듈 수준
+
+진입점부터 fixpoint 반복으로 도달 가능한 모듈/export 를 좁힙니다 (최대 100회 반복, 실측 2-3회 수렴).
+
+### Used export 추적
+
+각 모듈의 `(module_idx, export_name)` 키를 `used_exports` 맵에 마킹합니다.
+
+- **진입점 + dynamic import target**: 정적 분석 밖이라 모든 export 사용 (`*` sentinel) 으로 보수적 마킹
+- **포함된 모듈의 import specifier 스캔**: 어떤 export 를 어떤 이름으로 가져왔는지 등록
+- **Re-export chain cascade**: `export * from './a'`, `export { X } from './a'` 를 따라 상위 모듈 사용이 하위에 전파
+
+```ts
+// a.ts
+export const used = 1;
+export const unused = 2;  // 도달 안 됨 → 제거 후보
+
+// entry.ts
+import { used } from './a';
+console.log(used);
+```
+
+### Side-effect 판정
+
+모듈을 통째로 제거할 수 있는지는 다음 조건을 모두 만족해야 합니다.
+
+- `used_exports` 에 등록된 항목 없음
+- 진입점이 아님
+- 평가 자체에 side-effect 가 없음 (top-level 문이 모두 순수)
+
+### `package.json sideEffects`
+
+```json
+{
+  "name": "my-lib",
+  "sideEffects": false
+}
+```
+
+라이브러리가 `sideEffects: false` 를 선언하면 ZTS 는 미사용 import 를 자유롭게 제거합니다. 글롭 패턴도 지원:
+
+```json
+{
+  "sideEffects": ["*.css", "./src/polyfills.ts"]
+}
+```
+
+:::caution
+`sideEffects` 정책은 **단조** 적용됩니다 — 한 번 `false` 가 되면 같은 파일에 대해 다시 `true` 로 돌릴 수 없습니다. 이는 의도적인 설계로, 라이브러리 작성자가 의도를 명확히 표현하도록 강제합니다.
+:::
+
+### 자동 순수 판별
+
+`package.json` 에 `sideEffects` 가 없어도 ZTS 는 모듈의 top-level 이 모두 순수하면 자동으로 `side_effects = false` 를 추론합니다 (entry 가 아닌 모듈에 한해).
+
+### 성능 기록
+
+| 최적화 | 효과 |
+|---|---|
+| Fixpoint oscillation 수정 (#1558) | 100회 → 2회 수렴, tree-shake 238ms → 51ms |
+| `has_direct_used_export` O(1) 배열 (#917) | 모듈 단위 used export 조회 O(1) |
+| StmtInfo 사전 구축 (#1558) | tree-shake 29.8ms → 5.6ms (-81%), 전체 transpile -31% |
+| `re_export_star_targets` bitset (#1928) | `tryMarkReExportNsSubset` O(M·E) 스캔 회피 |
+
+## 2단계 — Statement 수준
+
+모듈이 살아남기로 결정되면, 그 안에서 어떤 top-level 문이 실제로 도달 가능한지를 다시 판정합니다. semantic analyzer 가 만든 symbol_id 매핑을 재활용해 statement 단위 symbol graph 를 구축합니다.
+
+### StmtInfo
+
+각 top-level 문에 대해 **선언하는 심볼** 과 **참조하는 심볼** 을 기록:
+
+```zig
+pub const StmtInfo = struct {
+    node_idx: u32,
+    has_side_effects: bool,
+    declared_symbols: []const u32,    // 이 stmt 가 선언하는 심볼
+    referenced_symbols: []const u32,  // 참조 (선언분 제외)
+};
+```
+
+이 정보로 `symbol_to_stmt`, `sym_to_referencing_stmts`, `sym_to_writer_stmts` 같은 역인덱스를 만듭니다.
+
+### 도달성 BFS
+
+```
+Seed:
+  - side-effectful statement
+  - used export 의 선언 statement
+  - 비선언 writer statement (var _a; ... _a = AST; 같은 TS 패턴)
+
+전파:
+  - referenced_symbols → symbol_to_stmt 로 의존 stmt enqueue
+  - 같은 모듈 안에서 도달 가능한 statement 만 살아남음
+```
+
+### 예시
+
+```ts
+// utils.ts
+export function used() { return 1; }
+export function unused() { return 2; }
+
+const helper = () => 'helper';   // unused 만 참조 → 도달 안 됨
+function unused() { return helper(); }
+```
+
+번들 결과에서 `unused`, `helper` 둘 다 제거됩니다 — `used` 의 도달성 그래프에서 분리되어 있기 때문.
+
+## 순수성 분석
+
+`@__PURE__` / `@__NO_SIDE_EFFECTS__` 주석과 builtin 화이트리스트를 결합해 표현식 수준 순수성을 판정합니다 (재귀 깊이 128 제한).
+
+### `@__PURE__` 주석
+
+```ts
+const x = /* @__PURE__ */ createComponent();  // 미사용이면 제거
+```
+
+렉서 단계에서 직후 call/new 노드의 `is_pure` 플래그를 설정하고, 트리쉐이커가 이를 무시합니다.
+
+### `@__NO_SIDE_EFFECTS__` 주석
+
+```ts
+// @__NO_SIDE_EFFECTS__
+function compute(x) { return x * 2; }
+
+const a = compute(1);  // a 가 미사용이면 호출 자체가 제거됨
+const b = compute(2);
+```
+
+함수 선언 자체에 마크하면 모든 호출이 자동으로 pure 처리됩니다.
+
+### Builtin pure constructor
+
+다음은 unresolved global (사용자 재정의 없음) 컨텍스트에서 자동 pure:
+
+| 생성자 | 조건 |
+|---|---|
+| `Set`, `Map`, `WeakSet`, `WeakMap` | `new` 전용, 무인자 / `null` / `undefined` / ArrayExpression 만 (iterator protocol side-effect 회피) |
+| `Array`, `Date`, `String` | 인자가 재귀적으로 pure |
+| `Error` 계열 | message 인자가 Symbol 이 아님이 정적으로 증명되어야 함 |
+| `Object.freeze`, `Object.assign` | fresh literal 제약 (special case) |
+
+### 사용자 pure hint
+
+CLI 또는 빌드 옵션으로 함수를 pure 로 표시:
+
+```bash
+zts --bundle entry.ts --pure=invariant --pure=warning
+```
+
+```ts
+import { invariant } from 'tiny-invariant';
+
+invariant(condition, "msg");  // condition 이 컴파일타임 truthy 면 호출 제거 가능
+```
+
+## Type-only import elision
+
+TypeScript 의 `import type` 과 inline `type` modifier 는 런타임 바인딩을 만들지 않습니다.
+
+```ts
+import type { User } from './types';        // 완전 제거
+import { type Config, helper } from './x';  // type Config 만 제거, helper 는 use 여부 따라
+```
+
+ZTS 는 두 경로에서 elision 을 수행:
+
+- **번들러 경로**: `binding_scanner.zig` 가 `SPEC_FLAG_TYPE_ONLY` 플래그를 체크해 BindingRecord 생성 자체를 스킵
+- **트랜스파일 fast-path** (BindingLite): full semantic 없이 named import 의 value-use 를 추적해 미사용 import 만 안전하게 제거
+
+:::note
+`default` / `namespace` import 는 JSX pragma, CSS-in-JS implicit-use 위험으로 elision 미지원. 안전하게 보존됩니다.
+:::
+
+### `verbatimModuleSyntax`
+
+`tsconfig.json` 에 `"verbatimModuleSyntax": true` 가 설정되어 있으면 ZTS 는 `import type` 만 제거하고 일반 import 는 그대로 둡니다 (TypeScript 표준 동작과 일치).
+
+## 한계
+
+:::caution[CJS wrap Asset 모듈]
+`require()` 로 wrap 된 CJS 모듈은 `require_X()` 호출이 side-effect 로 간주되어 미사용이라도 트리쉐이킹되지 않습니다. esbuild 의 `NoSideEffects_PureData` 마킹은 ZTS 에 아직 적용되지 않았습니다.
+
+JSON 모듈은 ESM AST 변환으로 우회 — named export 단위 트리쉐이킹 가능.
+:::
+
+:::caution[Namespace barrel]
+`import * as X; export { X }` 같은 namespace re-export 는 symbol 기반 추적이 어려워 local export 로 분류됩니다. lazyBarrel 정밀화는 진행 중.
+:::
+
+:::caution[Getter / Proxy / Global]
+런타임 시점 side-effect (getter, Proxy, global 변수 변경) 를 정적으로 분석하는 deep-DCE 단계는 미구현 (후순위).
+:::
+
+## 더 읽을거리
+
+- 컨트리뷰터용 구현 가이드: [`docs/BUNDLER.md` § Tree-shaking 구현](https://github.com/ohah/zts/blob/main/docs/BUNDLER.md#tree-shaking-%EA%B5%AC%ED%98%84-%EB%AA%A8%EB%93%88-%EC%88%98%EC%A4%80--statement-%EC%88%98%EC%A4%80) — 자료구조, file:line 인용, 알고리즘 의사코드
+- 아키텍처 개요: [`docs/ARCHITECTURE.md` § Tree-shaking Design](https://github.com/ohah/zts/blob/main/docs/ARCHITECTURE.md)
+- 관련 PR: #458, #460 (1단계), #1558 (statement-level), #1791 (type-only elision), #1928 (re-export 최적화)


### PR DESCRIPTION
## 요약

`docs/BUNDLER.md` 의 기존 high-level "Tree-shaking 전략" 요약 (☑️ 1단계/2단계/sideEffects 등) 을 그대로 두고, 그 아래에 코드 베이스 실 구현을 짚어주는 **상세 섹션** 을 추가했습니다.

번들러를 처음 보는 컨트리뷰터가 "어떤 파일에서 무엇이 일어나는지" 를 한 번에 파악할 수 있도록, 분산되어 있던 정보를 한 곳에 모았습니다.

## 추가된 섹션 — "Tree-shaking 구현 (모듈 수준 + statement 수준)"

- 파이프라인 ASCII 다이어그램 (`tree_shaker.zig` / `stmt_info.zig` / `statement_shaker.zig` / `binding_scanner.zig` / `purity.zig` + transformer 의 `shouldElideImportSpecifier` / transpile fast-path 의 BindingLite)
- **1단계 모듈 수준**: fixpoint 알고리즘, `used_exports` / `has_direct_used_export` / `re_export_star_targets` 자료구조, dynamic import 처리 (#1260), re-export cascade 와 `buildSymToIbMaps` lazy 갱신
- **2단계 statement 수준**: `StmtInfo` / `ModuleStmtInfos` 정의, `computeReachable` BFS seed/전파, statement_shaker 가 linker rename 후 재계산하는 흐름
- **순수성 분석**: `@__PURE__` / `@__NO_SIDE_EFFECTS__`, builtin pure constructor 화이트리스트 (Set/Map/Array/Date/Error/Object.freeze 등), sideEffects 필드 + 자동 순수 판별
- **Type-only import elision**: 번들러 경로 (binding_scanner + transformer.shouldElideImportSpecifier) 와 트랜스파일 fast-path (BindingLite) 가 협력하는 방식, default/namespace specifier 를 제외하는 이유 (#1791, #1793 revert)
- **CJS export facts**: `CjsExportFact.Kind` 4 종 (assignment, object_property, define_property_value, define_property_getter) 과 보수적으로 처리되는 패턴
- **한계**: CJS wrap Asset (esbuild `NoSideEffects_PureData` 미적용), namespace barrel 미지원 범위, BindingLite 의 64-import 보수 fallback

## 코드 인용 검증

문서에 등장하는 모든 file:line / 자료구조 / 상수는 origin/main 의 실제 코드와 직접 대조해 확인했습니다 — 추가 변경 없는 순수 docs PR.

- `src/bundler/tree_shaker.zig:39` `ALL_EXPORTS_SENTINEL`
- `src/bundler/tree_shaker.zig:82` `has_direct_used_export`
- `src/bundler/tree_shaker.zig:88` `re_export_star_targets`
- `src/bundler/tree_shaker.zig:90` `max_fixpoint_iterations = 100`
- `src/bundler/stmt_info.zig:21` `StmtInfo`
- `src/bundler/stmt_info.zig:31` `CjsExportFact`
- `src/bundler/stmt_info.zig:58` `ModuleStmtInfos`
- `src/bundler/purity.zig` 주석의 `@__PURE__` / 자동 판별 기준
- `src/transformer/transformer.zig:4833` `shouldElideImportSpecifier`
- `src/transformer/transformer.zig:92` `namedImportValueUse`
- `src/transpile.zig` `hasNamedImportLocalBindingShadow` (PR #2410)

## 검증

- `zig fmt --check` (docs 변경이라 영향 없음, pre-push hook 통과)
- 코드 변경 없음 → 테스트는 별도 영향 범위 없음

## 참고

- ARCHITECTURE.md § "Tree-shaking Design (#458, #460)" 의 high-level 설명을 보완 (덮어쓰지 않음 — 짧은 요약 그대로 유지)
- ROADMAP.md 의 fixpoint oscillation / StmtInfo 최적화 수치를 본 문서에서 한 번 더 인용해 추적 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)