### PR TITLE
perf(transpile): BindingLite 파라미터 shadow 처리

### DIFF
--- a/src/parser/ast_walk.zig
+++ b/src/parser/ast_walk.zig
@@ -145,6 +145,119 @@ pub fn children(ast: *const Ast, node: Node) ChildIterator {
     };
 }
 
+/// 바인딩 패턴 트리에서 leaf identifier 노드를 순회하는 iterator.
+///
+/// 방문 대상 (caller 가 tag 로 필터링):
+///   - `binding_identifier` (정통 binding context)
+///   - `identifier_reference`, `assignment_target_identifier` (cover-grammar 후 변환)
+///
+/// 자동 descend tags:
+///   - 패턴 wrapper: `formal_parameter`, `formal_parameters`, `assignment_pattern`,
+///     `assignment_target_with_default`, `binding_property`,
+///     `assignment_target_property_identifier`, `assignment_target_property_property`
+///   - 컨테이너: `array_pattern`, `object_pattern`, `array_assignment_target`, `object_assignment_target`
+///   - rest: `rest_element`, `binding_rest_element`, `assignment_target_rest`, `spread_element`
+///   - opt-in: `assignment_expression` (cover-grammar arrow param `(Foo = Bar()) =>`)
+///
+/// 이전에는 동일 패턴 walker 가 transformer / semantic / transpile 6 곳에 copy 되어
+/// 있었다. 호출 측의 출력 타입이 다 달라서 (Span list / 이름 list / StringHashMap /
+/// fixed buf) iterator 패턴으로 두고 wrapping 만 caller 가 결정.
+pub const BindingIdentifierWalker = struct {
+    pub const STACK_CAPACITY: usize = 256;
+
+    pub const Options = struct {
+        /// `(Foo = Bar()) =>` 같이 cover-grammar 로 패턴 자리에 남은 assignment_expression
+        /// 의 LHS 를 binding 으로 본다. 일반 expression 컨텍스트의 `Foo = expr` 와 충돌하지
+        /// 않게 caller 가 binding context 진입점에서만 켠다.
+        cover_grammar_assignment: bool = false,
+    };
+
+    ast: *const Ast,
+    options: Options,
+    /// 명시 stack — stack overflow 방지 + bound 명시. 깊이 256 초과 패턴은 비현실적.
+    stack: [STACK_CAPACITY]NodeIndex = undefined,
+    stack_len: usize,
+
+    pub fn next(self: *BindingIdentifierWalker) ?NodeIndex {
+        while (self.stack_len > 0) {
+            self.stack_len -= 1;
+            const idx = self.stack[self.stack_len];
+            if (idx.isNone()) continue;
+            const raw: u32 = @intFromEnum(idx);
+            if (raw >= self.ast.nodes.items.len) continue;
+            const node = self.ast.nodes.items[raw];
+            switch (node.tag) {
+                .binding_identifier,
+                .identifier_reference,
+                .assignment_target_identifier,
+                => return idx,
+                .formal_parameter => {
+                    if (node.data.extra >= self.ast.extra_data.items.len) continue;
+                    self.push(@enumFromInt(self.ast.extra_data.items[node.data.extra]));
+                },
+                .formal_parameters,
+                .array_pattern,
+                .object_pattern,
+                .array_assignment_target,
+                .object_assignment_target,
+                => self.pushList(node.data.list),
+                .assignment_pattern,
+                .assignment_target_with_default,
+                => self.push(node.data.binary.left),
+                .assignment_expression => {
+                    if (self.options.cover_grammar_assignment) self.push(node.data.binary.left);
+                },
+                .rest_element,
+                .binding_rest_element,
+                .assignment_target_rest,
+                .spread_element,
+                => self.push(node.data.unary.operand),
+                .binding_property,
+                .assignment_target_property_identifier,
+                .assignment_target_property_property,
+                => {
+                    const value = node.data.binary.right;
+                    self.push(if (value.isNone()) node.data.binary.left else value);
+                },
+                else => {},
+            }
+        }
+        return null;
+    }
+
+    fn push(self: *BindingIdentifierWalker, idx: NodeIndex) void {
+        if (idx.isNone()) return;
+        if (self.stack_len >= STACK_CAPACITY) return;
+        self.stack[self.stack_len] = idx;
+        self.stack_len += 1;
+    }
+
+    fn pushList(self: *BindingIdentifierWalker, list: ast_mod.NodeList) void {
+        if (list.start + list.len > self.ast.extra_data.items.len) return;
+        // 역순으로 push 해서 다음 next() 호출이 list[0] 부터 보도록 한다.
+        var i: u32 = list.len;
+        while (i > 0) {
+            i -= 1;
+            const raw = self.ast.extra_data.items[list.start + i];
+            self.push(@enumFromInt(raw));
+        }
+    }
+};
+
+/// 바인딩 패턴 (포함 cover-grammar 결과) 의 leaf identifier 를 순회하는 iterator.
+pub fn bindingIdentifiers(
+    ast: *const Ast,
+    idx: NodeIndex,
+    options: BindingIdentifierWalker.Options,
+) BindingIdentifierWalker {
+    var w: BindingIdentifierWalker = .{ .ast = ast, .options = options, .stack_len = 0 };
+    if (!idx.isNone() and @intFromEnum(idx) < ast.nodes.items.len) {
+        w.stack[0] = idx;
+        w.stack_len = 1;
+    }
+    return w;
+}
+
 /// `root` 서브트리에 raw `#x` private syntax (`private_field_expression` /
 /// `private_identifier`) 가 남아 있는지 검사. transformer 가 lowering 했어야 할 노드가
 /// codegen 까지 도달했는지 검증하는 debug invariant 용도 — 정상 코드 경로에서는 항상 false.

--- a/src/parser/ast_walk_test.zig
+++ b/src/parser/ast_walk_test.zig
@@ -150,3 +150,106 @@ test "ChildIterator: 같은 노드 두 번 iterate 해도 독립적 (state reset
     try std.testing.expectEqual(count1, count2);
     try std.testing.expectEqual(@as(usize, 2), count1);
 }
+
+fn collectBindingNames(
+    allocator: std.mem.Allocator,
+    ast: *const ast_mod.Ast,
+    idx: NodeIndex,
+    options: ast_walk.BindingIdentifierWalker.Options,
+) !std.ArrayList([]const u8) {
+    var out: std.ArrayList([]const u8) = .empty;
+    errdefer out.deinit(allocator);
+    var it = ast_walk.bindingIdentifiers(ast, idx, options);
+    while (it.next()) |leaf_idx| {
+        try out.append(allocator, ast.getText(ast.getNode(leaf_idx).span));
+    }
+    return out;
+}
+
+test "bindingIdentifiers: simple variable declarator" {
+    const a = std.testing.allocator;
+    var ctx = try parseSource(a, "let x = 1;");
+    defer ctx.parser.deinit();
+    defer ctx.scanner.deinit();
+
+    const bind_idx = findFirstTag(&ctx.parser.ast, .binding_identifier) orelse return error.NotFound;
+    var names = try collectBindingNames(a, &ctx.parser.ast, bind_idx, .{});
+    defer names.deinit(a);
+    try std.testing.expectEqual(@as(usize, 1), names.items.len);
+    try std.testing.expectEqualStrings("x", names.items[0]);
+}
+
+test "bindingIdentifiers: array pattern with rest and default" {
+    const a = std.testing.allocator;
+    var ctx = try parseSource(a, "let [x = 1, y, ...rest] = arr;");
+    defer ctx.parser.deinit();
+    defer ctx.scanner.deinit();
+
+    const arr_idx = findFirstTag(&ctx.parser.ast, .array_pattern) orelse return error.NotFound;
+    var names = try collectBindingNames(a, &ctx.parser.ast, arr_idx, .{});
+    defer names.deinit(a);
+    try std.testing.expectEqual(@as(usize, 3), names.items.len);
+    try std.testing.expectEqualStrings("x", names.items[0]);
+    try std.testing.expectEqualStrings("y", names.items[1]);
+    try std.testing.expectEqualStrings("rest", names.items[2]);
+}
+
+test "bindingIdentifiers: object pattern with shorthand and rename" {
+    const a = std.testing.allocator;
+    var ctx = try parseSource(a, "let { a, b: c, ...rest } = obj;");
+    defer ctx.parser.deinit();
+    defer ctx.scanner.deinit();
+
+    const obj_idx = findFirstTag(&ctx.parser.ast, .object_pattern) orelse return error.NotFound;
+    var names = try collectBindingNames(a, &ctx.parser.ast, obj_idx, .{});
+    defer names.deinit(a);
+    try std.testing.expectEqual(@as(usize, 3), names.items.len);
+    try std.testing.expectEqualStrings("a", names.items[0]);
+    try std.testing.expectEqualStrings("c", names.items[1]);
+    try std.testing.expectEqualStrings("rest", names.items[2]);
+}
+
+test "bindingIdentifiers: formal_parameters 와 nested default" {
+    const a = std.testing.allocator;
+    var ctx = try parseSource(a, "function f(a, b = 1, [c, d = 2], { e, f: g }) {}");
+    defer ctx.parser.deinit();
+    defer ctx.scanner.deinit();
+
+    const params_idx = findFirstTag(&ctx.parser.ast, .formal_parameters) orelse return error.NotFound;
+    var names = try collectBindingNames(a, &ctx.parser.ast, params_idx, .{});
+    defer names.deinit(a);
+    // 함수 이름 자신의 binding 은 별도 노드라 여기 들어오지 않음
+    try std.testing.expectEqual(@as(usize, 6), names.items.len);
+    try std.testing.expectEqualStrings("a", names.items[0]);
+    try std.testing.expectEqualStrings("b", names.items[1]);
+    try std.testing.expectEqualStrings("c", names.items[2]);
+    try std.testing.expectEqualStrings("d", names.items[3]);
+    try std.testing.expectEqualStrings("e", names.items[4]);
+    try std.testing.expectEqualStrings("g", names.items[5]);
+}
+
+test "bindingIdentifiers: cover_grammar_assignment 옵션이 arrow param 의 assignment_expression 을 처리" {
+    const a = std.testing.allocator;
+    var ctx = try parseSource(a, "const f = (x = 1) => x;");
+    defer ctx.parser.deinit();
+    defer ctx.scanner.deinit();
+
+    const params_idx = findFirstTag(&ctx.parser.ast, .formal_parameters) orelse return error.NotFound;
+
+    // 옵션 OFF: cover-grammar 로 남은 assignment_expression 의 LHS 를 못 찾는다.
+    var off = try collectBindingNames(a, &ctx.parser.ast, params_idx, .{});
+    defer off.deinit(a);
+
+    // 옵션 ON: LHS x 가 보인다.
+    var on = try collectBindingNames(a, &ctx.parser.ast, params_idx, .{ .cover_grammar_assignment = true });
+    defer on.deinit(a);
+
+    // arrow cover-grammar 결과는 파서 구현에 따라 assignment_pattern 으로 정착할 수도, assignment_expression
+    // 으로 남을 수도 있다. 후자라면 옵션 ON 일 때만 x 가 잡혀야 한다.
+    try std.testing.expect(on.items.len >= off.items.len);
+    var seen_x = false;
+    for (on.items) |n| if (std.mem.eql(u8, n, "x")) {
+        seen_x = true;
+    };
+    try std.testing.expect(seen_x);
+}

--- a/src/semantic/checker.zig
+++ b/src/semantic/checker.zig
@@ -14,6 +14,7 @@
 
 const std = @import("std");
 const ast_mod = @import("../parser/ast.zig");
+const ast_walk = @import("../parser/ast_walk.zig");
 const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const NodeList = ast_mod.NodeList;
@@ -355,6 +356,10 @@ fn recordSeenName(
 }
 
 /// 바인딩 패턴에서 이름을 재귀적으로 추출하여 중복 체크한다.
+/// 형식 파라미터에서 `binding_identifier` 만 의미가 있다 — cover-grammar 의
+/// identifier_reference / assignment_target_identifier 는 호출자 (parser 의 duplicate
+/// param check) 가 패턴 자리에서만 호출하므로 leaf 로 도달해도 안전하지만,
+/// 의미상 정통 바인딩 만 중복 검사한다.
 fn collectBindingNames(
     ast: *const Ast,
     idx: NodeIndex,
@@ -362,31 +367,11 @@ fn collectBindingNames(
     errors: *std.ArrayList(Diagnostic),
     allocator: std.mem.Allocator,
 ) AllocError!void {
-    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return;
-    const node = ast.getNode(idx);
-
-    switch (node.tag) {
-        .binding_identifier => {
-            try recordSeenName(ast.getText(node.span), node.span, seen, errors, allocator);
-        },
-        .array_pattern, .object_pattern => {
-            const split = ast.nodeListSplitRest(node.data.list);
-            for (split.elements) |raw_idx| {
-                try collectBindingNames(ast, @enumFromInt(raw_idx), seen, errors, allocator);
-            }
-            if (split.rest_operand) |op| {
-                try collectBindingNames(ast, op, seen, errors, allocator);
-            }
-        },
-        .binding_property => {
-            // binary: { left = key, right = value }
-            try collectBindingNames(ast, node.data.binary.right, seen, errors, allocator);
-        },
-        .assignment_pattern => {
-            // binary: { left = binding, right = default_value }
-            try collectBindingNames(ast, node.data.binary.left, seen, errors, allocator);
-        },
-        else => {},
+    var it = ast_walk.bindingIdentifiers(ast, idx, .{});
+    while (it.next()) |leaf_idx| {
+        const leaf = ast.getNode(leaf_idx);
+        if (leaf.tag != .binding_identifier) continue;
+        try recordSeenName(ast.getText(leaf.span), leaf.span, seen, errors, allocator);
     }
 }
 

--- a/src/transformer/es2015_block_scoping.zig
+++ b/src/transformer/es2015_block_scoping.zig
@@ -77,45 +77,18 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
 
         /// binding pattern에서 모든 identifier 이름을 수집한다.
         /// destructuring 포함 (array_pattern, object_pattern, rest_element, assignment_pattern).
+        /// `binding_identifier` 만 수집 — cover-grammar 의 identifier_reference /
+        /// assignment_target_identifier 는 lexical 선언 컨텍스트에서 등장하지 않는다.
         pub fn collectBindingNames(
             self: *Transformer,
             idx: NodeIndex,
             names: *std.ArrayList([]const u8),
         ) !void {
-            if (idx.isNone()) return;
-            const node = self.ast.getNode(idx);
-            switch (node.tag) {
-                .binding_identifier => {
-                    const text = self.ast.getText(node.span);
-                    try names.append(self.allocator, text);
-                },
-                .array_pattern => {
-                    const split = self.ast.nodeListSplitRest(node.data.list);
-                    for (split.elements) |raw| {
-                        try collectBindingNames(self, @enumFromInt(raw), names);
-                    }
-                    if (split.rest_operand) |op| {
-                        try collectBindingNames(self, op, names);
-                    }
-                },
-                .object_pattern => {
-                    const split = self.ast.nodeListSplitRest(node.data.list);
-                    for (split.elements) |raw| {
-                        const prop = self.ast.getNode(@enumFromInt(raw));
-                        // binding_property: binary = { left: key, right: value, flags }
-                        if (prop.tag == .binding_property) {
-                            try collectBindingNames(self, prop.data.binary.right, names);
-                        }
-                    }
-                    if (split.rest_operand) |op| {
-                        try collectBindingNames(self, op, names);
-                    }
-                },
-                .assignment_pattern => {
-                    // assignment_pattern은 binary: left = binding, right = default value
-                    try collectBindingNames(self, node.data.binary.left, names);
-                },
-                else => {},
+            var it = ast_walk.bindingIdentifiers(self.ast, idx, .{});
+            while (it.next()) |leaf_idx| {
+                const leaf = self.ast.getNode(leaf_idx);
+                if (leaf.tag != .binding_identifier) continue;
+                try names.append(self.allocator, self.ast.getText(leaf.span));
             }
         }
 

--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -19,6 +19,7 @@
 
 const std = @import("std");
 const ast_mod = @import("../parser/ast.zig");
+const ast_walk = @import("../parser/ast_walk.zig");
 const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const NodeList = ast_mod.NodeList;
@@ -733,27 +734,9 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
         }
 
         fn collectBindingNames(self: *Transformer, idx: NodeIndex, out: *std.ArrayList(Span)) Transformer.Error!void {
-            if (idx.isNone()) return;
-            const node = self.ast.getNode(idx);
-            switch (node.tag) {
-                .binding_identifier, .identifier_reference, .assignment_target_identifier => {
-                    try out.append(self.allocator, node.data.string_ref);
-                },
-                .assignment_pattern, .assignment_target_with_default => {
-                    try collectBindingNames(self, node.data.binary.left, out);
-                },
-                .rest_element, .binding_rest_element, .assignment_target_rest => {
-                    try collectBindingNames(self, node.data.unary.operand, out);
-                },
-                .binding_property, .assignment_target_property_identifier, .assignment_target_property_property => {
-                    const value = node.data.binary.right;
-                    try collectBindingNames(self, if (value.isNone()) node.data.binary.left else value, out);
-                },
-                .object_pattern, .array_pattern, .object_assignment_target, .array_assignment_target => {
-                    const items = self.ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
-                    for (items) |raw| try collectBindingNames(self, @enumFromInt(raw), out);
-                },
-                else => {},
+            var it = ast_walk.bindingIdentifiers(self.ast, idx, .{});
+            while (it.next()) |leaf_idx| {
+                try out.append(self.allocator, self.ast.getNode(leaf_idx).data.string_ref);
             }
         }
 

--- a/src/transformer/es2015_params.zig
+++ b/src/transformer/es2015_params.zig
@@ -19,6 +19,7 @@
 
 const std = @import("std");
 const ast_mod = @import("../parser/ast.zig");
+const ast_walk = @import("../parser/ast_walk.zig");
 const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const NodeList = ast_mod.NodeList;
@@ -377,30 +378,11 @@ pub fn ES2015Params(comptime Transformer: type) type {
         }
 
         fn collectBindingNames(self: *Transformer, idx: NodeIndex, out: *std.ArrayList(Span)) Transformer.Error!void {
-            if (idx.isNone()) return;
-            const node = self.ast.getNode(idx);
-            switch (node.tag) {
-                .binding_identifier, .identifier_reference, .assignment_target_identifier => {
-                    try out.append(self.allocator, node.data.string_ref);
-                },
-                .formal_parameter => {
-                    try collectBindingNames(self, self.readNodeIdx(node.data.extra, ast_mod.FormalParameterExtra.pattern), out);
-                },
-                .assignment_pattern, .assignment_target_with_default => {
-                    try collectBindingNames(self, node.data.binary.left, out);
-                },
-                .rest_element, .binding_rest_element, .assignment_target_rest => {
-                    try collectBindingNames(self, node.data.unary.operand, out);
-                },
-                .binding_property, .assignment_target_property_identifier, .assignment_target_property_property => {
-                    const value = node.data.binary.right;
-                    try collectBindingNames(self, if (value.isNone()) node.data.binary.left else value, out);
-                },
-                .object_pattern, .array_pattern, .object_assignment_target, .array_assignment_target => {
-                    const items = self.ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
-                    for (items) |raw| try collectBindingNames(self, @enumFromInt(raw), out);
-                },
-                else => {},
+            // cover-grammar 결과 (identifier_reference / assignment_target_identifier) 도
+            // 동일하게 spans 로 수집 — caller (param TDZ 검사) 가 그 형태를 기대한다.
+            var it = ast_walk.bindingIdentifiers(self.ast, idx, .{});
+            while (it.next()) |leaf_idx| {
+                try out.append(self.allocator, self.ast.getNode(leaf_idx).data.string_ref);
             }
         }
     };

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -225,59 +225,14 @@ pub fn collectClosureVars(
 }
 
 /// 바인딩 패턴에서 이름을 추출한다.
-/// binding_identifier, array_binding_pattern, object_binding_pattern 처리.
+/// arrow params without type annotations 는 expression 으로 파싱된 뒤
+/// coverExpressionToAssignmentTarget 로 변환되므로 cover-grammar 결과 (identifier_reference,
+/// assignment_target_identifier, assignment_expression) 도 binding 으로 본다.
 fn collectBindingNames(self: *Transformer, idx: NodeIndex, locals: *std.StringHashMap(void)) Error!void {
-    if (idx.isNone()) return;
-    const node = self.ast.getNode(idx);
-
-    switch (node.tag) {
-        // arrow params without type annotations are parsed as expressions then
-        // converted via coverExpressionToAssignmentTarget:
-        //   identifier_reference → assignment_target_identifier
-        .binding_identifier, .identifier_reference, .assignment_target_identifier => {
-            const name = self.ast.getText(node.data.string_ref);
-            if (name.len > 0) {
-                locals.put(name, {}) catch return error.OutOfMemory;
-            }
-        },
-        .formal_parameter => {
-            // extra = [pattern, type_ann, default, flags, ...]
-            const pattern_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[node.data.extra]);
-            try collectBindingNames(self, pattern_idx, locals);
-        },
-        .array_pattern => {
-            const list = node.data.list;
-            var i: u32 = 0;
-            while (i < list.len) : (i += 1) {
-                const elem_raw = self.ast.extra_data.items[list.start + i];
-                try collectBindingNames(self, @enumFromInt(elem_raw), locals);
-            }
-        },
-        .object_pattern => {
-            const list = node.data.list;
-            var i: u32 = 0;
-            while (i < list.len) : (i += 1) {
-                const prop_raw = self.ast.extra_data.items[list.start + i];
-                const prop_idx: NodeIndex = @enumFromInt(prop_raw);
-                if (prop_idx.isNone()) continue;
-                const prop = self.ast.getNode(prop_idx);
-                // binding_property: binary = { left: key, right: value }
-                if (prop.tag == .binding_property) {
-                    try collectBindingNames(self, prop.data.binary.right, locals);
-                } else {
-                    // shorthand 등
-                    try collectBindingNames(self, prop_idx, locals);
-                }
-            }
-        },
-        .rest_element, .spread_element => {
-            try collectBindingNames(self, node.data.unary.operand, locals);
-        },
-        .assignment_pattern, .assignment_expression => {
-            // default value: left = pattern/identifier, right = default
-            try collectBindingNames(self, node.data.binary.left, locals);
-        },
-        else => {},
+    var it = ast_walk.bindingIdentifiers(self.ast, idx, .{ .cover_grammar_assignment = true });
+    while (it.next()) |leaf_idx| {
+        const name = self.ast.getText(self.ast.getNode(leaf_idx).data.string_ref);
+        if (name.len > 0) locals.put(name, {}) catch return error.OutOfMemory;
     }
 }
 

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -671,43 +671,13 @@ fn appendBindingLiteShadowName(buf: [][]const u8, len: *usize, name: []const u8)
 }
 
 fn collectBindingLitePatternShadows(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *const BindingLite, buf: [][]const u8, len: *usize) void {
-    if (idx.isNone()) return;
-    const node = ast.getNode(idx);
-    switch (node.tag) {
-        .binding_identifier => {
-            const name = ast.getText(node.span);
-            if (lite.namedImportValueUse(name) != null) appendBindingLiteShadowName(buf, len, name);
-        },
-        .formal_parameters => {
-            if (node.data.list.start + node.data.list.len > ast.extra_data.items.len) return;
-            var i: u32 = 0;
-            while (i < node.data.list.len) : (i += 1) {
-                collectBindingLitePatternShadows(ast, @enumFromInt(ast.extra_data.items[node.data.list.start + i]), lite, buf, len);
-            }
-        },
-        .formal_parameter => collectBindingLitePatternShadows(ast, @enumFromInt(ast.extra_data.items[node.data.extra]), lite, buf, len),
-        .assignment_pattern,
-        .assignment_expression,
-        .assignment_target_with_default,
-        => collectBindingLitePatternShadows(ast, node.data.binary.left, lite, buf, len),
-        .array_pattern,
-        .object_pattern,
-        => {
-            if (node.data.list.start + node.data.list.len > ast.extra_data.items.len) return;
-            var i: u32 = 0;
-            while (i < node.data.list.len) : (i += 1) {
-                collectBindingLitePatternShadows(ast, @enumFromInt(ast.extra_data.items[node.data.list.start + i]), lite, buf, len);
-            }
-        },
-        .binding_rest_element,
-        .rest_element,
-        .assignment_target_rest,
-        => collectBindingLitePatternShadows(ast, node.data.unary.operand, lite, buf, len),
-        .binding_property,
-        .assignment_target_property_identifier,
-        .assignment_target_property_property,
-        => collectBindingLitePatternShadows(ast, node.data.binary.right, lite, buf, len),
-        else => {},
+    var it = ast_walk.bindingIdentifiers(ast, idx, .{ .cover_grammar_assignment = true });
+    while (it.next()) |leaf_idx| {
+        const leaf = ast.getNode(leaf_idx);
+        // import 이름과 매칭되는 binding 만 shadow set 에 추가. cover-grammar 결과인
+        // identifier_reference / assignment_target_identifier 도 동일 처리.
+        const name = ast.getText(leaf.span);
+        if (lite.namedImportValueUse(name) != null) appendBindingLiteShadowName(buf, len, name);
     }
 }
 

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -486,9 +486,29 @@ fn collectAstFacts(ast: *const Ast) AstFacts {
     return facts;
 }
 
+fn nodeTreeContains(ast: *const Ast, idx: ast_mod.NodeIndex, target: ast_mod.NodeIndex) bool {
+    if (idx.isNone()) return false;
+    if (idx == target) return true;
+    var it = ast_walk.children(ast, ast.getNode(idx));
+    while (it.next()) |child_idx| {
+        if (nodeTreeContains(ast, child_idx, target)) return true;
+    }
+    return false;
+}
+
+fn isInsideFormalParameters(ast: *const Ast, target: ast_mod.NodeIndex) bool {
+    for (ast.nodes.items, 0..) |node, raw_idx| {
+        if (node.tag != .formal_parameters) continue;
+        if (nodeTreeContains(ast, @enumFromInt(raw_idx), target)) return true;
+    }
+    return false;
+}
+
 // default/namespace specifier 는 collectAstFacts 에서 has_non_named_import 로 잡혀
 // buildTransformPlan 이 이미 full 로 라우팅하므로 여기서는 named 만 본다.
 // import local 노드는 identifier_reference 로 태깅되므로 binding_identifier 필터에 자연히 빠진다.
+// 함수 파라미터 shadow 는 binding-lite walker 가 scope-aware 로 처리할 수 있으므로 여기서는
+// full fallback 조건에서 제외한다. top-level/local 선언 shadow 는 아직 full 로 둔다.
 fn hasNamedImportLocalBindingShadow(ast: *const Ast) bool {
     var names_buf: [64][]const u8 = undefined;
     var names_len: usize = 0;
@@ -515,8 +535,9 @@ fn hasNamedImportLocalBindingShadow(ast: *const Ast) bool {
 
     if (names_len == 0) return false;
 
-    for (ast.nodes.items) |node| {
+    for (ast.nodes.items, 0..) |node, raw_idx| {
         if (node.tag != .binding_identifier) continue;
+        if (isInsideFormalParameters(ast, @enumFromInt(raw_idx))) continue;
         const bind_name = ast.getText(node.span);
         var j: usize = 0;
         while (j < names_len) : (j += 1) {
@@ -618,15 +639,28 @@ fn collectBindingLite(allocator: std.mem.Allocator, ast: *const Ast) !BindingLit
     }
 
     var lite = BindingLite{ .named_imports = try bindings.toOwnedSlice(allocator) };
+    const no_shadowed_names: []const []const u8 = &.{};
     for (ast.nodes.items, 0..) |node, raw_idx| {
         if (node.tag != .program) continue;
-        markBindingLiteValueUses(ast, @enumFromInt(raw_idx), &lite, true);
+        markBindingLiteValueUses(ast, @enumFromInt(raw_idx), &lite, true, no_shadowed_names);
         break;
     }
     return lite;
 }
 
-fn markBindingLiteUse(lite: *BindingLite, name: []const u8) void {
+fn isBindingLiteImportName(lite: *const BindingLite, name: []const u8) bool {
+    return lite.namedImportValueUse(name) != null;
+}
+
+fn isShadowedBindingLiteName(name: []const u8, shadowed_names: []const []const u8) bool {
+    for (shadowed_names) |shadowed| {
+        if (std.mem.eql(u8, name, shadowed)) return true;
+    }
+    return false;
+}
+
+fn markBindingLiteUse(lite: *BindingLite, name: []const u8, shadowed_names: []const []const u8) void {
+    if (isShadowedBindingLiteName(name, shadowed_names)) return;
     for (lite.named_imports) |*binding| {
         if (std.mem.eql(u8, binding.local_name, name)) {
             binding.used_as_value = true;
@@ -635,39 +669,91 @@ fn markBindingLiteUse(lite: *BindingLite, name: []const u8) void {
     }
 }
 
-fn markBindingPatternDefaultValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *BindingLite) void {
+fn appendBindingLiteShadowName(buf: []?[]const u8, len: *usize, name: []const u8) void {
+    for (buf[0..len.*]) |existing| {
+        if (std.mem.eql(u8, existing.?, name)) return;
+    }
+    if (len.* >= buf.len) return;
+    buf[len.*] = name;
+    len.* += 1;
+}
+
+fn collectBindingLitePatternShadows(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *const BindingLite, buf: []?[]const u8, len: *usize) void {
     if (idx.isNone()) return;
     const node = ast.getNode(idx);
     switch (node.tag) {
-        .assignment_pattern,
-        .assignment_target_with_default,
-        => {
-            markBindingPatternDefaultValueUses(ast, node.data.binary.left, lite);
-            markBindingLiteValueUses(ast, node.data.binary.right, lite, true);
+        .binding_identifier => {
+            const name = ast.getText(node.span);
+            if (isBindingLiteImportName(lite, name)) appendBindingLiteShadowName(buf, len, name);
         },
+        .formal_parameters => {
+            if (node.data.list.start + node.data.list.len > ast.extra_data.items.len) return;
+            var i: u32 = 0;
+            while (i < node.data.list.len) : (i += 1) {
+                collectBindingLitePatternShadows(ast, @enumFromInt(ast.extra_data.items[node.data.list.start + i]), lite, buf, len);
+            }
+        },
+        .formal_parameter => collectBindingLitePatternShadows(ast, @enumFromInt(ast.extra_data.items[node.data.extra]), lite, buf, len),
+        .assignment_pattern,
+        .assignment_expression,
+        .assignment_target_with_default,
+        => collectBindingLitePatternShadows(ast, node.data.binary.left, lite, buf, len),
         .array_pattern,
         .object_pattern,
-        => markBindingLiteListValueUses(ast, node.data.list, lite, false),
+        => {
+            if (node.data.list.start + node.data.list.len > ast.extra_data.items.len) return;
+            var i: u32 = 0;
+            while (i < node.data.list.len) : (i += 1) {
+                collectBindingLitePatternShadows(ast, @enumFromInt(ast.extra_data.items[node.data.list.start + i]), lite, buf, len);
+            }
+        },
         .binding_rest_element,
+        .rest_element,
         .assignment_target_rest,
-        => markBindingPatternDefaultValueUses(ast, node.data.unary.operand, lite),
+        => collectBindingLitePatternShadows(ast, node.data.unary.operand, lite, buf, len),
         .binding_property,
         .assignment_target_property_identifier,
         .assignment_target_property_property,
-        => markBindingPatternDefaultValueUses(ast, node.data.binary.right, lite),
+        => collectBindingLitePatternShadows(ast, node.data.binary.right, lite, buf, len),
         else => {},
     }
 }
 
-fn markBindingLiteListValueUses(ast: *const Ast, list: ast_mod.NodeList, lite: *BindingLite, value_context: bool) void {
-    if (list.start + list.len > ast.extra_data.items.len) return;
-    var i: u32 = 0;
-    while (i < list.len) : (i += 1) {
-        markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[list.start + i]), lite, value_context);
+fn markBindingPatternDefaultValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *BindingLite, shadowed_names: []const []const u8) void {
+    if (idx.isNone()) return;
+    const node = ast.getNode(idx);
+    switch (node.tag) {
+        .assignment_pattern,
+        .assignment_expression,
+        .assignment_target_with_default,
+        => {
+            markBindingPatternDefaultValueUses(ast, node.data.binary.left, lite, shadowed_names);
+            markBindingLiteValueUses(ast, node.data.binary.right, lite, true, shadowed_names);
+        },
+        .array_pattern,
+        .object_pattern,
+        => markBindingLiteListValueUses(ast, node.data.list, lite, false, shadowed_names),
+        .binding_rest_element,
+        .rest_element,
+        .assignment_target_rest,
+        => markBindingPatternDefaultValueUses(ast, node.data.unary.operand, lite, shadowed_names),
+        .binding_property,
+        .assignment_target_property_identifier,
+        .assignment_target_property_property,
+        => markBindingPatternDefaultValueUses(ast, node.data.binary.right, lite, shadowed_names),
+        else => {},
     }
 }
 
-fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *BindingLite, value_context: bool) void {
+fn markBindingLiteListValueUses(ast: *const Ast, list: ast_mod.NodeList, lite: *BindingLite, value_context: bool, shadowed_names: []const []const u8) void {
+    if (list.start + list.len > ast.extra_data.items.len) return;
+    var i: u32 = 0;
+    while (i < list.len) : (i += 1) {
+        markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[list.start + i]), lite, value_context, shadowed_names);
+    }
+}
+
+fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *BindingLite, value_context: bool, shadowed_names: []const []const u8) void {
     if (idx.isNone()) return;
     const node = ast.getNode(idx);
 
@@ -677,7 +763,7 @@ fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *Bind
         .identifier_reference,
         .assignment_target_identifier,
         => {
-            if (value_context) markBindingLiteUse(lite, ast.getText(node.span));
+            if (value_context) markBindingLiteUse(lite, ast.getText(node.span), shadowed_names);
             return;
         },
         .binding_identifier,
@@ -688,24 +774,24 @@ fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *Bind
         .import_attribute,
         => return,
         .export_specifier => {
-            markBindingLiteValueUses(ast, node.data.binary.left, lite, true);
+            markBindingLiteValueUses(ast, node.data.binary.left, lite, true, shadowed_names);
             return;
         },
         .export_named_declaration => {
             const x = module_parser.readExportNamedExtras(ast, node.data.extra);
-            markBindingLiteValueUses(ast, x.decl, lite, true);
-            markBindingLiteListValueUses(ast, .{ .start = x.specs_start, .len = x.specs_len }, lite, true);
+            markBindingLiteValueUses(ast, x.decl, lite, true, shadowed_names);
+            markBindingLiteListValueUses(ast, .{ .start = x.specs_start, .len = x.specs_len }, lite, true, shadowed_names);
             return;
         },
         .variable_declaration => {
             const list_start = ast.extra_data.items[node.data.extra + 1];
             const list_len = ast.extra_data.items[node.data.extra + 2];
-            markBindingLiteListValueUses(ast, .{ .start = list_start, .len = list_len }, lite, true);
+            markBindingLiteListValueUses(ast, .{ .start = list_start, .len = list_len }, lite, true, shadowed_names);
             return;
         },
         .variable_declarator => {
-            markBindingPatternDefaultValueUses(ast, @enumFromInt(ast.extra_data.items[node.data.extra]), lite);
-            markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[node.data.extra + 2]), lite, true);
+            markBindingPatternDefaultValueUses(ast, @enumFromInt(ast.extra_data.items[node.data.extra]), lite, shadowed_names);
+            markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[node.data.extra + 2]), lite, true, shadowed_names);
             return;
         },
         .function_declaration,
@@ -713,49 +799,70 @@ fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *Bind
         .function,
         => {
             const e = node.data.extra;
-            markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[e + 1]), lite, false);
-            markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[e + 2]), lite, true);
+            const params_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[e + 1]);
+            var shadow_buf: [32]?[]const u8 = undefined;
+            @memset(&shadow_buf, null);
+            var shadow_len: usize = 0;
+            for (shadowed_names) |name| appendBindingLiteShadowName(&shadow_buf, &shadow_len, name);
+            collectBindingLitePatternShadows(ast, params_idx, lite, &shadow_buf, &shadow_len);
+            var combined_buf: [32][]const u8 = undefined;
+            var i: usize = 0;
+            while (i < shadow_len) : (i += 1) combined_buf[i] = shadow_buf[i].?;
+            const combined_shadowed = combined_buf[0..shadow_len];
+            markBindingLiteValueUses(ast, params_idx, lite, false, combined_shadowed);
+            markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[e + 2]), lite, true, combined_shadowed);
             return;
         },
         .arrow_function_expression => {
             const e = node.data.extra;
-            markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[e]), lite, false);
-            markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[e + 1]), lite, true);
+            const params_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[e]);
+            var shadow_buf: [32]?[]const u8 = undefined;
+            @memset(&shadow_buf, null);
+            var shadow_len: usize = 0;
+            for (shadowed_names) |name| appendBindingLiteShadowName(&shadow_buf, &shadow_len, name);
+            collectBindingLitePatternShadows(ast, params_idx, lite, &shadow_buf, &shadow_len);
+            var combined_buf: [32][]const u8 = undefined;
+            var i: usize = 0;
+            while (i < shadow_len) : (i += 1) combined_buf[i] = shadow_buf[i].?;
+            const combined_shadowed = combined_buf[0..shadow_len];
+            markBindingLiteValueUses(ast, params_idx, lite, false, combined_shadowed);
+            markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[e + 1]), lite, true, combined_shadowed);
             return;
         },
         .formal_parameters => {
-            markBindingLiteListValueUses(ast, node.data.list, lite, false);
+            markBindingLiteListValueUses(ast, node.data.list, lite, false, shadowed_names);
             return;
         },
         .assignment_pattern,
+        .assignment_expression,
         .assignment_target_with_default,
         => {
-            markBindingLiteValueUses(ast, node.data.binary.left, lite, false);
-            markBindingLiteValueUses(ast, node.data.binary.right, lite, true);
+            markBindingLiteValueUses(ast, node.data.binary.left, lite, false, shadowed_names);
+            markBindingLiteValueUses(ast, node.data.binary.right, lite, true, shadowed_names);
             return;
         },
         .formal_parameter => {
             const e = node.data.extra;
-            markBindingPatternDefaultValueUses(ast, @enumFromInt(ast.extra_data.items[e]), lite);
-            markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[e + 2]), lite, true);
+            markBindingPatternDefaultValueUses(ast, @enumFromInt(ast.extra_data.items[e]), lite, shadowed_names);
+            markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[e + 2]), lite, true, shadowed_names);
             return;
         },
         .object_property => {
             const key = node.data.binary.left;
             const value = node.data.binary.right;
             if (value.isNone()) {
-                markBindingLiteValueUses(ast, key, lite, true);
+                markBindingLiteValueUses(ast, key, lite, true, shadowed_names);
             } else {
                 const key_node = ast.getNode(key);
-                if (key_node.tag == .computed_property_key) markBindingLiteValueUses(ast, key, lite, true);
-                markBindingLiteValueUses(ast, value, lite, true);
+                if (key_node.tag == .computed_property_key) markBindingLiteValueUses(ast, key, lite, true, shadowed_names);
+                markBindingLiteValueUses(ast, value, lite, true, shadowed_names);
             }
             return;
         },
         .static_member_expression,
         .private_field_expression,
         => {
-            markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[node.data.extra]), lite, true);
+            markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[node.data.extra]), lite, true, shadowed_names);
             return;
         },
         else => {},
@@ -763,7 +870,7 @@ fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *Bind
 
     var it = ast_walk.children(ast, node);
     while (it.next()) |child_idx| {
-        markBindingLiteValueUses(ast, child_idx, lite, value_context);
+        markBindingLiteValueUses(ast, child_idx, lite, value_context, shadowed_names);
     }
 }
 
@@ -1411,6 +1518,95 @@ test "TransformPlan parity: binding-lite named import elision matches full seman
             ,
         },
         .{
+            .name = "function parameter shadow does not keep import",
+            .source =
+            \\import { Foo, Bar } from "./lib";
+            \\export function f(Foo = Foo) {
+            \\  return Foo;
+            \\}
+            \\export const value = Bar();
+            ,
+        },
+        .{
+            .name = "arrow parameter shadow does not hide outer value use",
+            .source =
+            \\import { Foo, Bar } from "./lib";
+            \\export const before = Foo();
+            \\export const fn = (Foo) => Foo;
+            \\export const after = Bar();
+            ,
+        },
+        .{
+            .name = "parameter shadow default can still use another import",
+            .source =
+            \\import { Foo, Bar } from "./lib";
+            \\export function f(Foo = Bar()) {
+            \\  return Foo;
+            \\}
+            ,
+        },
+        .{
+            .name = "object destructuring parameter shadows import",
+            .source =
+            \\import { Foo, Bar } from "./lib";
+            \\export function f({ Foo }) {
+            \\  return Foo;
+            \\}
+            \\export const value = Bar();
+            ,
+        },
+        .{
+            .name = "object destructuring parameter default uses another import",
+            .source =
+            \\import { Foo, Bar } from "./lib";
+            \\export function f({ x: Foo = Bar() }) {
+            \\  return Foo;
+            \\}
+            ,
+        },
+        .{
+            .name = "array destructuring parameter default uses another import",
+            .source =
+            \\import { Foo, Bar } from "./lib";
+            \\export function f([Foo = Bar()]) {
+            \\  return Foo;
+            \\}
+            ,
+        },
+        .{
+            .name = "rest parameter shadows import",
+            .source =
+            \\import { Foo, Bar } from "./lib";
+            \\export function f(...Foo) {
+            \\  return Foo.length;
+            \\}
+            \\export const value = Bar();
+            ,
+        },
+        .{
+            .name = "nested function parameter shadow does not hide outer value use",
+            .source =
+            \\import { Foo, Bar } from "./lib";
+            \\export function outer() {
+            \\  const first = Foo();
+            \\  function inner(Foo = Bar()) {
+            \\    return Foo;
+            \\  }
+            \\  return first + inner();
+            \\}
+            ,
+        },
+        .{
+            .name = "nested arrow parameter shadow does not hide outer value use",
+            .source =
+            \\import { Foo, Bar } from "./lib";
+            \\export const outer = () => {
+            \\  const inner = (Foo = Bar()) => Foo;
+            \\  return Foo() + inner();
+            \\};
+            ,
+        },
+        .{
             .name = "verbatim keeps value import but removes inline type specifier",
             .source =
             \\import { type A, B } from "./lib";
@@ -1453,8 +1649,8 @@ test "TransformPlan: full-route guards for binding-lite follow-up" {
         .{ .name = "cjs", .source = "import { Foo } from './x';\nFoo();\n", .options = .{ .module_format = .cjs } },
         .{ .name = "downlevel", .source = "import { Foo } from './x';\nFoo();\n", .options = .{ .unsupported = compat.fromESTarget(.es5), .es_target = .es5 } },
         .{ .name = "flow", .source = "import { Foo } from './x';\nexport const x: Foo = 1;\n", .path = "input.js", .options = .{ .flow = true } },
-        .{ .name = "import local shadowed by parameter", .source = "import { Foo } from './x';\nexport function f(Foo = Foo) { return Foo; }\n" },
         .{ .name = "import local shadowed by local declaration", .source = "import { Foo } from './x';\nconst Foo = 1;\nexport { Foo };\n" },
+        .{ .name = "import local shadowed by catch binding", .source = "import { Foo } from './x';\ntry { Foo(); } catch (Foo) { console.log(Foo); }\n" },
     };
 
     for (cases) |case| {

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -29,6 +29,7 @@ const LinkingMetadata = @import("bundler/linker.zig").LinkingMetadata;
 const rt = @import("bundler/runtime_helpers.zig");
 const Diagnostic = @import("diagnostic.zig").Diagnostic;
 const OwnedDiagnostic = @import("diagnostic.zig").OwnedDiagnostic;
+const string_list = @import("util/string_list.zig");
 
 const SemanticRequirement = enum {
     none,
@@ -486,24 +487,6 @@ fn collectAstFacts(ast: *const Ast) AstFacts {
     return facts;
 }
 
-fn nodeTreeContains(ast: *const Ast, idx: ast_mod.NodeIndex, target: ast_mod.NodeIndex) bool {
-    if (idx.isNone()) return false;
-    if (idx == target) return true;
-    var it = ast_walk.children(ast, ast.getNode(idx));
-    while (it.next()) |child_idx| {
-        if (nodeTreeContains(ast, child_idx, target)) return true;
-    }
-    return false;
-}
-
-fn isInsideFormalParameters(ast: *const Ast, target: ast_mod.NodeIndex) bool {
-    for (ast.nodes.items, 0..) |node, raw_idx| {
-        if (node.tag != .formal_parameters) continue;
-        if (nodeTreeContains(ast, @enumFromInt(raw_idx), target)) return true;
-    }
-    return false;
-}
-
 // default/namespace specifier 는 collectAstFacts 에서 has_non_named_import 로 잡혀
 // buildTransformPlan 이 이미 full 로 라우팅하므로 여기서는 named 만 본다.
 // import local 노드는 identifier_reference 로 태깅되므로 binding_identifier 필터에 자연히 빠진다.
@@ -535,14 +518,33 @@ fn hasNamedImportLocalBindingShadow(ast: *const Ast) bool {
 
     if (names_len == 0) return false;
 
+    // program 부터 한 번만 내려가며 inside_params 플래그로 formal_parameters 서브트리를 건너뛴다.
+    // 이전 구현은 binding_identifier 마다 모든 formal_parameters 노드를 다시 탐색해 O(N²) 였다.
     for (ast.nodes.items, 0..) |node, raw_idx| {
-        if (node.tag != .binding_identifier) continue;
-        if (isInsideFormalParameters(ast, @enumFromInt(raw_idx))) continue;
+        if (node.tag != .program) continue;
+        return scanForNonParamBindingShadow(ast, @enumFromInt(raw_idx), names_buf[0..names_len], false);
+    }
+    return false;
+}
+
+fn scanForNonParamBindingShadow(
+    ast: *const Ast,
+    idx: ast_mod.NodeIndex,
+    names: []const []const u8,
+    inside_params: bool,
+) bool {
+    if (idx.isNone()) return false;
+    const node = ast.getNode(idx);
+    if (node.tag == .binding_identifier and !inside_params) {
         const bind_name = ast.getText(node.span);
-        var j: usize = 0;
-        while (j < names_len) : (j += 1) {
-            if (std.mem.eql(u8, bind_name, names_buf[j])) return true;
+        for (names) |n| {
+            if (std.mem.eql(u8, bind_name, n)) return true;
         }
+    }
+    const child_inside = inside_params or node.tag == .formal_parameters;
+    var it = ast_walk.children(ast, node);
+    while (it.next()) |child_idx| {
+        if (scanForNonParamBindingShadow(ast, child_idx, names, child_inside)) return true;
     }
     return false;
 }
@@ -639,6 +641,7 @@ fn collectBindingLite(allocator: std.mem.Allocator, ast: *const Ast) !BindingLit
     }
 
     var lite = BindingLite{ .named_imports = try bindings.toOwnedSlice(allocator) };
+    if (lite.named_imports.len == 0) return lite;
     const no_shadowed_names: []const []const u8 = &.{};
     for (ast.nodes.items, 0..) |node, raw_idx| {
         if (node.tag != .program) continue;
@@ -648,19 +651,8 @@ fn collectBindingLite(allocator: std.mem.Allocator, ast: *const Ast) !BindingLit
     return lite;
 }
 
-fn isBindingLiteImportName(lite: *const BindingLite, name: []const u8) bool {
-    return lite.namedImportValueUse(name) != null;
-}
-
-fn isShadowedBindingLiteName(name: []const u8, shadowed_names: []const []const u8) bool {
-    for (shadowed_names) |shadowed| {
-        if (std.mem.eql(u8, name, shadowed)) return true;
-    }
-    return false;
-}
-
 fn markBindingLiteUse(lite: *BindingLite, name: []const u8, shadowed_names: []const []const u8) void {
-    if (isShadowedBindingLiteName(name, shadowed_names)) return;
+    if (string_list.contains(shadowed_names, name)) return;
     for (lite.named_imports) |*binding| {
         if (std.mem.eql(u8, binding.local_name, name)) {
             binding.used_as_value = true;
@@ -669,22 +661,22 @@ fn markBindingLiteUse(lite: *BindingLite, name: []const u8, shadowed_names: []co
     }
 }
 
-fn appendBindingLiteShadowName(buf: []?[]const u8, len: *usize, name: []const u8) void {
-    for (buf[0..len.*]) |existing| {
-        if (std.mem.eql(u8, existing.?, name)) return;
-    }
+fn appendBindingLiteShadowName(buf: [][]const u8, len: *usize, name: []const u8) void {
+    if (string_list.contains(buf[0..len.*], name)) return;
+    // 64 개 초과 shadow 는 그대로 두면 outer import 가 used 로 잘못 마킹될 위험이 있다 — over-conservative
+    // 로 동작해 import 유지. 실제로는 한 함수에 64 개 import 이름 동시 shadow 는 비현실적.
     if (len.* >= buf.len) return;
     buf[len.*] = name;
     len.* += 1;
 }
 
-fn collectBindingLitePatternShadows(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *const BindingLite, buf: []?[]const u8, len: *usize) void {
+fn collectBindingLitePatternShadows(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *const BindingLite, buf: [][]const u8, len: *usize) void {
     if (idx.isNone()) return;
     const node = ast.getNode(idx);
     switch (node.tag) {
         .binding_identifier => {
             const name = ast.getText(node.span);
-            if (isBindingLiteImportName(lite, name)) appendBindingLiteShadowName(buf, len, name);
+            if (lite.namedImportValueUse(name) != null) appendBindingLiteShadowName(buf, len, name);
         },
         .formal_parameters => {
             if (node.data.list.start + node.data.list.len > ast.extra_data.items.len) return;
@@ -753,6 +745,22 @@ fn markBindingLiteListValueUses(ast: *const Ast, list: ast_mod.NodeList, lite: *
     }
 }
 
+fn markBindingLiteFunctionScope(
+    ast: *const Ast,
+    lite: *BindingLite,
+    parent_shadowed: []const []const u8,
+    params_idx: ast_mod.NodeIndex,
+    body_idx: ast_mod.NodeIndex,
+) void {
+    var shadow_buf: [64][]const u8 = undefined;
+    var shadow_len: usize = 0;
+    for (parent_shadowed) |name| appendBindingLiteShadowName(&shadow_buf, &shadow_len, name);
+    collectBindingLitePatternShadows(ast, params_idx, lite, &shadow_buf, &shadow_len);
+    const combined = shadow_buf[0..shadow_len];
+    markBindingLiteValueUses(ast, params_idx, lite, false, combined);
+    markBindingLiteValueUses(ast, body_idx, lite, true, combined);
+}
+
 fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *BindingLite, value_context: bool, shadowed_names: []const []const u8) void {
     if (idx.isNone()) return;
     const node = ast.getNode(idx);
@@ -799,34 +807,24 @@ fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *Bind
         .function,
         => {
             const e = node.data.extra;
-            const params_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[e + 1]);
-            var shadow_buf: [32]?[]const u8 = undefined;
-            @memset(&shadow_buf, null);
-            var shadow_len: usize = 0;
-            for (shadowed_names) |name| appendBindingLiteShadowName(&shadow_buf, &shadow_len, name);
-            collectBindingLitePatternShadows(ast, params_idx, lite, &shadow_buf, &shadow_len);
-            var combined_buf: [32][]const u8 = undefined;
-            var i: usize = 0;
-            while (i < shadow_len) : (i += 1) combined_buf[i] = shadow_buf[i].?;
-            const combined_shadowed = combined_buf[0..shadow_len];
-            markBindingLiteValueUses(ast, params_idx, lite, false, combined_shadowed);
-            markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[e + 2]), lite, true, combined_shadowed);
+            markBindingLiteFunctionScope(
+                ast,
+                lite,
+                shadowed_names,
+                @enumFromInt(ast.extra_data.items[e + 1]),
+                @enumFromInt(ast.extra_data.items[e + 2]),
+            );
             return;
         },
         .arrow_function_expression => {
             const e = node.data.extra;
-            const params_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[e]);
-            var shadow_buf: [32]?[]const u8 = undefined;
-            @memset(&shadow_buf, null);
-            var shadow_len: usize = 0;
-            for (shadowed_names) |name| appendBindingLiteShadowName(&shadow_buf, &shadow_len, name);
-            collectBindingLitePatternShadows(ast, params_idx, lite, &shadow_buf, &shadow_len);
-            var combined_buf: [32][]const u8 = undefined;
-            var i: usize = 0;
-            while (i < shadow_len) : (i += 1) combined_buf[i] = shadow_buf[i].?;
-            const combined_shadowed = combined_buf[0..shadow_len];
-            markBindingLiteValueUses(ast, params_idx, lite, false, combined_shadowed);
-            markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[e + 1]), lite, true, combined_shadowed);
+            markBindingLiteFunctionScope(
+                ast,
+                lite,
+                shadowed_names,
+                @enumFromInt(ast.extra_data.items[e]),
+                @enumFromInt(ast.extra_data.items[e + 1]),
+            );
             return;
         },
         .formal_parameters => {
@@ -834,12 +832,22 @@ fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *Bind
             return;
         },
         .assignment_pattern,
-        .assignment_expression,
         .assignment_target_with_default,
         => {
             markBindingLiteValueUses(ast, node.data.binary.left, lite, false, shadowed_names);
             markBindingLiteValueUses(ast, node.data.binary.right, lite, true, shadowed_names);
             return;
+        },
+        // `(Foo = Bar()) =>` 같이 cover-grammar 로 패턴 자리에 남은 assignment_expression 은
+        // value_context=false (formal_parameters 진입) 에서만 LHS=binding/RHS=value 로 쪼갠다.
+        // expression context (`Foo = expr;`) 는 LHS 가 assignment_target_identifier 라 default
+        // child walk 로 그대로 value_context=true 가 전파돼야 import 가 use 마킹된다.
+        .assignment_expression => {
+            if (!value_context) {
+                markBindingLiteValueUses(ast, node.data.binary.left, lite, false, shadowed_names);
+                markBindingLiteValueUses(ast, node.data.binary.right, lite, true, shadowed_names);
+                return;
+            }
         },
         .formal_parameter => {
             const e = node.data.extra;
@@ -1604,6 +1612,15 @@ test "TransformPlan parity: binding-lite named import elision matches full seman
             \\  const inner = (Foo = Bar()) => Foo;
             \\  return Foo() + inner();
             \\};
+            ,
+        },
+        .{
+            // assignment_expression LHS (`Foo = expr`) 가 expression context 에서 walker arm
+            // 에 잡혀 value_context=false 로 강제되면 import 가 잘못 elide 된다 — regression guard.
+            .name = "assignment to imported name in expression keeps import",
+            .source =
+            \\import { Foo } from "./lib";
+            \\Foo = something();
             ,
         },
         .{


### PR DESCRIPTION
## 요약
- BindingLite named import elision이 함수/화살표 함수 파라미터 shadow를 full semantic으로 우회하지 않고 처리하도록 했습니다.
- default import / namespace import / local declaration shadow는 계속 full semantic fallback으로 유지합니다.
- fast/full parity fixture에 parameter shadow 케이스를 넓게 추가했습니다.

## 변경 내용
- formal parameter 내부 binding은 `binding_shadow_requires_full_semantic` fallback에서 제외
- BindingLite value-use walker에 shadowed import-name context를 전달
- 함수/화살표 함수 진입 시 parameter pattern에서 import local shadow를 수집하고 body/default initializer reference를 scope-aware로 판정
- `rest_element`, `assignment_expression` cover grammar 경로까지 shadow/value-use 처리
- top-level/local declaration/catch binding shadow는 아직 full route로 유지해 안전 경계를 보존

## 추가한 회귀 케이스
- 일반 파라미터 shadow + default initializer
- object destructuring parameter shadow
- object/array destructuring default initializer
- rest parameter shadow
- nested function / nested arrow parameter shadow
- outer value-use와 nested shadow 동시 존재
- catch binding shadow는 full route guard 유지

## 검증
- `zig build test --summary all`
- `zig build napi -Doptimize=ReleaseFast --summary all`
- `bun test packages/core/index.test.ts --timeout 30000`
- `zig build -Doptimize=ReleaseFast --summary all`
- 대형 입력 fast-path on/off 측정
- push 전 hook: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check` 통과

## 성능 확인
작은 5K/10K profile은 노이즈가 커서, import-free TS strip 입력을 25K/50K/100K lines로 키워 fast path on/off만 15회 median으로 비교했습니다.

| Lines | Size KB | fast on ms | fast off ms | delta ms | speedup |
| --- | --- | --- | --- | --- | --- |
| 25000 | 996 | 13 | 17 | 4 | 1.31x |
| 50000 | 2014 | 25 | 33 | 8 | 1.32x |
| 100000 | 4050 | 48 | 65 | 17 | 1.35x |

## 참고
- pre-push oxlint는 `tests/integration/tests/bundle-dynamic-import.test.ts`의 기존 미사용 import 경고 3개를 출력했지만 error는 없었습니다.

Refs #2352