### PR TITLE
perf(transpile): reduce BindingLite shadow fallbacks

### DIFF
--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -487,6 +487,11 @@ fn collectAstFacts(ast: *const Ast) AstFacts {
     return facts;
 }
 
+// 한 함수 / 한 var 리스트 / 한 import 절에서 매칭되는 import 이름 수의 상한.
+// 초과 시 scan 은 over-conservative 로 full route 를 택하고 mark 는 shadow 를 누락해도
+// outer import 가 used 로 마킹되어 import 가 보존된다.
+const binding_lite_max_shadows: usize = 64;
+
 // default/namespace specifier 는 collectAstFacts 에서 has_non_named_import 로 잡혀
 // buildTransformPlan 이 이미 full 로 라우팅하므로 여기서는 named 만 본다.
 // import local 노드는 identifier_reference 로 태깅되므로 binding_identifier 필터에 자연히 빠진다.
@@ -494,7 +499,7 @@ fn collectAstFacts(ast: *const Ast) AstFacts {
 // 처리한다. top-level shadow, `var` shadow, walker buffer overflow 처럼 declaration-order
 // 또는 scope 의미가 애매한 케이스만 full 로 보낸다.
 fn hasUnsupportedNamedImportLocalBindingShadow(ast: *const Ast) bool {
-    var names_buf: [64][]const u8 = undefined;
+    var names_buf: [binding_lite_max_shadows][]const u8 = undefined;
     var names_len: usize = 0;
 
     for (ast.nodes.items) |import_node| {
@@ -510,7 +515,7 @@ fn hasUnsupportedNamedImportLocalBindingShadow(ast: *const Ast) bool {
 
             const local_idx = spec.data.binary.right;
             if (local_idx.isNone()) continue;
-            // 64 개 초과 named import 는 보수적으로 full 로 우회 — barrel 파일 등 흔치 않은 경우.
+            // barrel 파일 등 비현실적 import 수는 보수적으로 full route.
             if (names_len == names_buf.len) return true;
             names_buf[names_len] = ast.getText(ast.getNode(local_idx).span);
             names_len += 1;
@@ -526,14 +531,17 @@ fn hasUnsupportedNamedImportLocalBindingShadow(ast: *const Ast) bool {
     return false;
 }
 
-fn bindingPatternContainsImportName(ast: *const Ast, idx: ast_mod.NodeIndex, names: []const []const u8, match_count: *usize) bool {
+// match_count 는 호출자가 누적한다. binding pattern 하나(=formal_parameters/catch param)
+// 안에서는 fresh counter 로도 의미가 같지만, `var a, b, c` 처럼 한 var 리스트의
+// 누적 shadow 수를 봐야 하는 경우엔 호출자가 같은 counter 를 재사용한다.
+fn bindingPatternImportShadowOverflow(ast: *const Ast, idx: ast_mod.NodeIndex, names: []const []const u8, match_count: *usize) bool {
     var it = ast_walk.bindingIdentifiers(ast, idx, .{ .cover_grammar_assignment = true });
     while (it.next()) |leaf_idx| {
         const leaf = ast.getNode(leaf_idx);
         const name = ast.getText(leaf.span);
         if (string_list.contains(names, name)) {
             match_count.* += 1;
-            if (match_count.* > 64) return true;
+            if (match_count.* > binding_lite_max_shadows) return true;
         }
     }
     return false;
@@ -555,7 +563,7 @@ fn scanVariableDeclarationForUnsupportedBindingLiteShadow(
         const decl = ast.getNode(decl_idx);
         if (decl.tag != .variable_declarator) continue;
         const binding_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[decl.data.extra]);
-        if (bindingPatternContainsImportName(ast, binding_idx, names, &matching_shadows)) return true;
+        if (bindingPatternImportShadowOverflow(ast, binding_idx, names, &matching_shadows)) return true;
         const init_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[decl.data.extra + 2]);
         if (scanForUnsupportedBindingLiteShadow(ast, init_idx, names, scope_depth)) return true;
     }
@@ -563,6 +571,19 @@ fn scanVariableDeclarationForUnsupportedBindingLiteShadow(
     if (matching_shadows == 0) return false;
     if (scope_depth == 0) return true;
     return !ast.variableDeclarationKind(node).isLexical();
+}
+
+fn scanChildrenForUnsupportedBindingLiteShadow(
+    ast: *const Ast,
+    node: ast_mod.Node,
+    names: []const []const u8,
+    child_scope_depth: usize,
+) bool {
+    var it = ast_walk.children(ast, node);
+    while (it.next()) |child_idx| {
+        if (scanForUnsupportedBindingLiteShadow(ast, child_idx, names, child_scope_depth)) return true;
+    }
+    return false;
 }
 
 fn scanForUnsupportedBindingLiteShadow(
@@ -574,43 +595,24 @@ fn scanForUnsupportedBindingLiteShadow(
     if (idx.isNone()) return false;
     const node = ast.getNode(idx);
     switch (node.tag) {
-        .program => {
-            var it = ast_walk.children(ast, node);
-            while (it.next()) |child_idx| {
-                if (scanForUnsupportedBindingLiteShadow(ast, child_idx, names, 0)) return true;
-            }
-            return false;
-        },
+        // program 의 child 는 항상 top-level (scope_depth=0). block/function body 진입은
+        // scope_depth+1. 그 외 노드는 같은 scope_depth 로 children 만 내려간다.
+        .program => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, 0),
         .block_statement,
         .function_body,
-        => {
-            var it = ast_walk.children(ast, node);
-            while (it.next()) |child_idx| {
-                if (scanForUnsupportedBindingLiteShadow(ast, child_idx, names, scope_depth + 1)) return true;
-            }
-            return false;
-        },
+        => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, scope_depth + 1),
         .formal_parameters => {
             var matching_shadows: usize = 0;
-            return bindingPatternContainsImportName(ast, idx, names, &matching_shadows);
+            return bindingPatternImportShadowOverflow(ast, idx, names, &matching_shadows);
         },
         .catch_clause => {
             var matching_shadows: usize = 0;
-            if (bindingPatternContainsImportName(ast, node.data.binary.left, names, &matching_shadows)) return true;
+            if (bindingPatternImportShadowOverflow(ast, node.data.binary.left, names, &matching_shadows)) return true;
             return scanForUnsupportedBindingLiteShadow(ast, node.data.binary.right, names, scope_depth + 1);
         },
         .variable_declaration => return scanVariableDeclarationForUnsupportedBindingLiteShadow(ast, node, names, scope_depth),
-        .binding_identifier => {
-            if (string_list.contains(names, ast.getText(node.span))) return true;
-            return false;
-        },
-        else => {
-            var it = ast_walk.children(ast, node);
-            while (it.next()) |child_idx| {
-                if (scanForUnsupportedBindingLiteShadow(ast, child_idx, names, scope_depth)) return true;
-            }
-            return false;
-        },
+        .binding_identifier => return string_list.contains(names, ast.getText(node.span)),
+        else => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, scope_depth),
     }
 }
 
@@ -728,8 +730,8 @@ fn markBindingLiteUse(lite: *BindingLite, name: []const u8, shadowed_names: []co
 
 fn appendBindingLiteShadowName(buf: [][]const u8, len: *usize, name: []const u8) void {
     if (string_list.contains(buf[0..len.*], name)) return;
-    // 64 개 초과 shadow 는 그대로 두면 outer import 가 used 로 잘못 마킹될 위험이 있다 — over-conservative
-    // 로 동작해 import 유지. 실제로는 한 함수에 64 개 import 이름 동시 shadow 는 비현실적.
+    // 상한 초과 shadow 는 그대로 두면 outer import 가 used 로 잘못 마킹될 위험이 있다 — over-conservative
+    // 로 동작해 import 유지. 실제로는 한 함수에 binding_lite_max_shadows 개 동시 shadow 는 비현실적.
     if (len.* >= buf.len) return;
     buf[len.*] = name;
     len.* += 1;
@@ -779,7 +781,7 @@ fn markBindingLiteBlockScope(
     lite: *BindingLite,
     parent_shadowed: []const []const u8,
 ) void {
-    var shadow_buf: [64][]const u8 = undefined;
+    var shadow_buf: [binding_lite_max_shadows][]const u8 = undefined;
     var shadow_len: usize = 0;
     for (parent_shadowed) |name| appendBindingLiteShadowName(&shadow_buf, &shadow_len, name);
     collectBindingLiteListLexicalShadows(ast, node.data.list, lite, &shadow_buf, &shadow_len);
@@ -827,7 +829,7 @@ fn markBindingLiteFunctionScope(
     params_idx: ast_mod.NodeIndex,
     body_idx: ast_mod.NodeIndex,
 ) void {
-    var shadow_buf: [64][]const u8 = undefined;
+    var shadow_buf: [binding_lite_max_shadows][]const u8 = undefined;
     var shadow_len: usize = 0;
     for (parent_shadowed) |name| appendBindingLiteShadowName(&shadow_buf, &shadow_len, name);
     collectBindingLitePatternShadows(ast, params_idx, lite, &shadow_buf, &shadow_len);
@@ -863,7 +865,7 @@ fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *Bind
             return;
         },
         .catch_clause => {
-            var shadow_buf: [64][]const u8 = undefined;
+            var shadow_buf: [binding_lite_max_shadows][]const u8 = undefined;
             var shadow_len: usize = 0;
             for (shadowed_names) |name| appendBindingLiteShadowName(&shadow_buf, &shadow_len, name);
             collectBindingLitePatternShadows(ast, node.data.binary.left, lite, &shadow_buf, &shadow_len);

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -490,9 +490,10 @@ fn collectAstFacts(ast: *const Ast) AstFacts {
 // default/namespace specifier 는 collectAstFacts 에서 has_non_named_import 로 잡혀
 // buildTransformPlan 이 이미 full 로 라우팅하므로 여기서는 named 만 본다.
 // import local 노드는 identifier_reference 로 태깅되므로 binding_identifier 필터에 자연히 빠진다.
-// 함수 파라미터 shadow 는 binding-lite walker 가 scope-aware 로 처리할 수 있으므로 여기서는
-// full fallback 조건에서 제외한다. top-level/local 선언 shadow 는 아직 full 로 둔다.
-fn hasNamedImportLocalBindingShadow(ast: *const Ast) bool {
+// 함수 파라미터 / catch / block lexical shadow 는 binding-lite walker 가 scope-aware 로
+// 처리한다. top-level shadow, `var` shadow, walker buffer overflow 처럼 declaration-order
+// 또는 scope 의미가 애매한 케이스만 full 로 보낸다.
+fn hasUnsupportedNamedImportLocalBindingShadow(ast: *const Ast) bool {
     var names_buf: [64][]const u8 = undefined;
     var names_len: usize = 0;
 
@@ -518,35 +519,99 @@ fn hasNamedImportLocalBindingShadow(ast: *const Ast) bool {
 
     if (names_len == 0) return false;
 
-    // program 부터 한 번만 내려가며 inside_params 플래그로 formal_parameters 서브트리를 건너뛴다.
-    // 이전 구현은 binding_identifier 마다 모든 formal_parameters 노드를 다시 탐색해 O(N²) 였다.
     for (ast.nodes.items, 0..) |node, raw_idx| {
         if (node.tag != .program) continue;
-        return scanForNonParamBindingShadow(ast, @enumFromInt(raw_idx), names_buf[0..names_len], false);
+        return scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(raw_idx), names_buf[0..names_len], 0);
     }
     return false;
 }
 
-fn scanForNonParamBindingShadow(
+fn bindingPatternContainsImportName(ast: *const Ast, idx: ast_mod.NodeIndex, names: []const []const u8, match_count: *usize) bool {
+    var it = ast_walk.bindingIdentifiers(ast, idx, .{ .cover_grammar_assignment = true });
+    while (it.next()) |leaf_idx| {
+        const leaf = ast.getNode(leaf_idx);
+        const name = ast.getText(leaf.span);
+        if (string_list.contains(names, name)) {
+            match_count.* += 1;
+            if (match_count.* > 64) return true;
+        }
+    }
+    return false;
+}
+
+fn scanVariableDeclarationForUnsupportedBindingLiteShadow(
+    ast: *const Ast,
+    node: ast_mod.Node,
+    names: []const []const u8,
+    scope_depth: usize,
+) bool {
+    const list_start = ast.extra_data.items[node.data.extra + 1];
+    const list_len = ast.extra_data.items[node.data.extra + 2];
+    var matching_shadows: usize = 0;
+    var i: u32 = 0;
+    while (i < list_len) : (i += 1) {
+        const decl_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[list_start + i]);
+        if (decl_idx.isNone()) continue;
+        const decl = ast.getNode(decl_idx);
+        if (decl.tag != .variable_declarator) continue;
+        const binding_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[decl.data.extra]);
+        if (bindingPatternContainsImportName(ast, binding_idx, names, &matching_shadows)) return true;
+        const init_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[decl.data.extra + 2]);
+        if (scanForUnsupportedBindingLiteShadow(ast, init_idx, names, scope_depth)) return true;
+    }
+
+    if (matching_shadows == 0) return false;
+    if (scope_depth == 0) return true;
+    return !ast.variableDeclarationKind(node).isLexical();
+}
+
+fn scanForUnsupportedBindingLiteShadow(
     ast: *const Ast,
     idx: ast_mod.NodeIndex,
     names: []const []const u8,
-    inside_params: bool,
+    scope_depth: usize,
 ) bool {
     if (idx.isNone()) return false;
     const node = ast.getNode(idx);
-    if (node.tag == .binding_identifier and !inside_params) {
-        const bind_name = ast.getText(node.span);
-        for (names) |n| {
-            if (std.mem.eql(u8, bind_name, n)) return true;
-        }
+    switch (node.tag) {
+        .program => {
+            var it = ast_walk.children(ast, node);
+            while (it.next()) |child_idx| {
+                if (scanForUnsupportedBindingLiteShadow(ast, child_idx, names, 0)) return true;
+            }
+            return false;
+        },
+        .block_statement,
+        .function_body,
+        => {
+            var it = ast_walk.children(ast, node);
+            while (it.next()) |child_idx| {
+                if (scanForUnsupportedBindingLiteShadow(ast, child_idx, names, scope_depth + 1)) return true;
+            }
+            return false;
+        },
+        .formal_parameters => {
+            var matching_shadows: usize = 0;
+            return bindingPatternContainsImportName(ast, idx, names, &matching_shadows);
+        },
+        .catch_clause => {
+            var matching_shadows: usize = 0;
+            if (bindingPatternContainsImportName(ast, node.data.binary.left, names, &matching_shadows)) return true;
+            return scanForUnsupportedBindingLiteShadow(ast, node.data.binary.right, names, scope_depth + 1);
+        },
+        .variable_declaration => return scanVariableDeclarationForUnsupportedBindingLiteShadow(ast, node, names, scope_depth),
+        .binding_identifier => {
+            if (string_list.contains(names, ast.getText(node.span))) return true;
+            return false;
+        },
+        else => {
+            var it = ast_walk.children(ast, node);
+            while (it.next()) |child_idx| {
+                if (scanForUnsupportedBindingLiteShadow(ast, child_idx, names, scope_depth)) return true;
+            }
+            return false;
+        },
     }
-    const child_inside = inside_params or node.tag == .formal_parameters;
-    var it = ast_walk.children(ast, node);
-    while (it.next()) |child_idx| {
-        if (scanForNonParamBindingShadow(ast, child_idx, names, child_inside)) return true;
-    }
-    return false;
 }
 
 fn optionsRequireTransformSemantic(options: TranspileOptions) bool {
@@ -601,7 +666,7 @@ fn buildTransformPlan(
         return .{ .semantic = .full, .reason = .ast_requires_runtime_transform };
     }
     if (facts.has_import_declaration) {
-        if (hasNamedImportLocalBindingShadow(ast)) {
+        if (hasUnsupportedNamedImportLocalBindingShadow(ast)) {
             return .{ .semantic = .full, .reason = .binding_shadow_requires_full_semantic };
         }
         return .{
@@ -681,6 +746,46 @@ fn collectBindingLitePatternShadows(ast: *const Ast, idx: ast_mod.NodeIndex, lit
     }
 }
 
+fn collectBindingLiteVariableDeclarationShadows(ast: *const Ast, node: ast_mod.Node, lite: *const BindingLite, buf: [][]const u8, len: *usize) void {
+    if (!ast.variableDeclarationKind(node).isLexical()) return;
+    const list_start = ast.extra_data.items[node.data.extra + 1];
+    const list_len = ast.extra_data.items[node.data.extra + 2];
+    var i: u32 = 0;
+    while (i < list_len) : (i += 1) {
+        const decl_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[list_start + i]);
+        if (decl_idx.isNone()) continue;
+        const decl = ast.getNode(decl_idx);
+        if (decl.tag != .variable_declarator) continue;
+        collectBindingLitePatternShadows(ast, @enumFromInt(ast.extra_data.items[decl.data.extra]), lite, buf, len);
+    }
+}
+
+fn collectBindingLiteListLexicalShadows(ast: *const Ast, list: ast_mod.NodeList, lite: *const BindingLite, buf: [][]const u8, len: *usize) void {
+    if (list.start + list.len > ast.extra_data.items.len) return;
+    var i: u32 = 0;
+    while (i < list.len) : (i += 1) {
+        const child_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[list.start + i]);
+        if (child_idx.isNone()) continue;
+        const child = ast.getNode(child_idx);
+        if (child.tag == .variable_declaration) {
+            collectBindingLiteVariableDeclarationShadows(ast, child, lite, buf, len);
+        }
+    }
+}
+
+fn markBindingLiteBlockScope(
+    ast: *const Ast,
+    node: ast_mod.Node,
+    lite: *BindingLite,
+    parent_shadowed: []const []const u8,
+) void {
+    var shadow_buf: [64][]const u8 = undefined;
+    var shadow_len: usize = 0;
+    for (parent_shadowed) |name| appendBindingLiteShadowName(&shadow_buf, &shadow_len, name);
+    collectBindingLiteListLexicalShadows(ast, node.data.list, lite, &shadow_buf, &shadow_len);
+    markBindingLiteListValueUses(ast, node.data.list, lite, true, shadow_buf[0..shadow_len]);
+}
+
 fn markBindingPatternDefaultValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *BindingLite, shadowed_names: []const []const u8) void {
     if (idx.isNone()) return;
     const node = ast.getNode(idx);
@@ -751,6 +856,26 @@ fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *Bind
         .import_namespace_specifier,
         .import_attribute,
         => return,
+        .block_statement,
+        .function_body,
+        => {
+            markBindingLiteBlockScope(ast, node, lite, shadowed_names);
+            return;
+        },
+        .catch_clause => {
+            var shadow_buf: [64][]const u8 = undefined;
+            var shadow_len: usize = 0;
+            for (shadowed_names) |name| appendBindingLiteShadowName(&shadow_buf, &shadow_len, name);
+            collectBindingLitePatternShadows(ast, node.data.binary.left, lite, &shadow_buf, &shadow_len);
+            markBindingLiteValueUses(ast, node.data.binary.right, lite, true, shadow_buf[0..shadow_len]);
+            return;
+        },
+        .try_statement => {
+            markBindingLiteValueUses(ast, node.data.ternary.a, lite, true, shadowed_names);
+            markBindingLiteValueUses(ast, node.data.ternary.b, lite, true, shadowed_names);
+            markBindingLiteValueUses(ast, node.data.ternary.c, lite, true, shadowed_names);
+            return;
+        },
         .export_specifier => {
             markBindingLiteValueUses(ast, node.data.binary.left, lite, true, shadowed_names);
             return;
@@ -1298,6 +1423,101 @@ test "TransformPlan: named import TypeScript strip uses binding-lite semantic" {
     try std.testing.expect(plan.strip_types_only);
 }
 
+test "TransformPlan: scope-local named import shadows stay on binding-lite route" {
+    const cases = [_]struct {
+        name: []const u8,
+        source: []const u8,
+    }{
+        .{
+            .name = "block lexical shadow with outer value use",
+            .source =
+            \\import { Foo } from "./lib";
+            \\{ const Foo = 1; Foo; }
+            \\Foo();
+            ,
+        },
+        .{
+            .name = "catch binding shadow with try body value use",
+            .source =
+            \\import { Foo } from "./lib";
+            \\try { Foo(); } catch (Foo) { Foo; }
+            ,
+        },
+        .{
+            .name = "nested block shadow with outer value use",
+            .source =
+            \\import { Foo } from "./lib";
+            \\{
+            \\  { const Foo = 1; Foo; }
+            \\  Foo();
+            \\}
+            ,
+        },
+        .{
+            .name = "block lexical shadow covers earlier references in the same block",
+            .source =
+            \\import { Foo, Bar } from "./lib";
+            \\{
+            \\  Foo;
+            \\  const Foo = Bar();
+            \\}
+            \\Foo();
+            ,
+        },
+    };
+
+    for (cases) |case| {
+        const plan = try testTransformPlan(case.source, "input.ts", .{});
+        std.testing.expectEqual(SemanticRequirement.bindings, plan.semantic) catch |err| {
+            std.debug.print("scope-local route failed for case '{s}', reason={s}\n", .{ case.name, @tagName(plan.reason) });
+            return err;
+        };
+    }
+}
+
+test "TransformPlan: ambiguous or overflowing named import shadows keep full semantic" {
+    const top_level = try testTransformPlan(
+        "import { Foo } from './x';\nconst Foo = 1;\nexport { Foo };\n",
+        "input.ts",
+        .{},
+    );
+    try std.testing.expectEqual(SemanticRequirement.full, top_level.semantic);
+    try std.testing.expectEqual(SemanticPlanReason.binding_shadow_requires_full_semantic, top_level.reason);
+
+    const var_shadow = try testTransformPlan(
+        "import { Foo } from './x';\nfunction f() { var Foo = 1; return Foo; }\n",
+        "input.ts",
+        .{},
+    );
+    try std.testing.expectEqual(SemanticRequirement.full, var_shadow.semantic);
+    try std.testing.expectEqual(SemanticPlanReason.binding_shadow_requires_full_semantic, var_shadow.reason);
+
+    const function_decl_shadow = try testTransformPlan(
+        "import { Foo } from './x';\nfunction outer() { function Foo() {} return Foo; }\n",
+        "input.ts",
+        .{},
+    );
+    try std.testing.expectEqual(SemanticRequirement.full, function_decl_shadow.semantic);
+    try std.testing.expectEqual(SemanticPlanReason.binding_shadow_requires_full_semantic, function_decl_shadow.reason);
+
+    var overflow_source: std.ArrayList(u8) = .empty;
+    defer overflow_source.deinit(std.testing.allocator);
+    try overflow_source.appendSlice(std.testing.allocator, "import {");
+    var i: usize = 0;
+    while (i < 65) : (i += 1) {
+        try overflow_source.writer(std.testing.allocator).print(" I{d},", .{i});
+    }
+    try overflow_source.appendSlice(std.testing.allocator, " } from './x';\nfunction f(");
+    i = 0;
+    while (i < 65) : (i += 1) {
+        try overflow_source.writer(std.testing.allocator).print("I{d},", .{i});
+    }
+    try overflow_source.appendSlice(std.testing.allocator, ") {}\n");
+    const overflow_plan = try testTransformPlan(overflow_source.items, "input.ts", .{});
+    try std.testing.expectEqual(SemanticRequirement.full, overflow_plan.semantic);
+    try std.testing.expectEqual(SemanticPlanReason.binding_shadow_requires_full_semantic, overflow_plan.reason);
+}
+
 test "TransformPlan: default and namespace imports keep full semantic" {
     const default_plan = try testTransformPlan("import Foo from './bar';\nexport const x = 1;\n", "input.ts", .{});
     try std.testing.expectEqual(SemanticRequirement.full, default_plan.semantic);
@@ -1585,6 +1805,86 @@ test "TransformPlan parity: binding-lite named import elision matches full seman
             ,
         },
         .{
+            .name = "catch binding shadow does not hide try body import use",
+            .source =
+            \\import { Foo } from "./lib";
+            \\try { Foo(); } catch (Foo) { Foo; }
+            ,
+        },
+        .{
+            .name = "block lexical shadow does not hide outer import use",
+            .source =
+            \\import { Foo } from "./lib";
+            \\{ const Foo = 1; Foo; }
+            \\Foo();
+            ,
+        },
+        .{
+            .name = "nested block lexical shadow does not hide outer import use",
+            .source =
+            \\import { Foo } from "./lib";
+            \\{
+            \\  { const Foo = 1; Foo; }
+            \\  Foo();
+            \\}
+            ,
+        },
+        .{
+            .name = "nested function catch and block shadows stay scoped",
+            .source =
+            \\import { Foo, Bar, Baz } from "./lib";
+            \\export function outer(Foo = Bar()) {
+            \\  try {
+            \\    Baz();
+            \\  } catch (Bar) {
+            \\    { const Baz = Bar; Baz; }
+            \\  }
+            \\  return Foo;
+            \\}
+            \\export const value = Bar();
+            ,
+        },
+        .{
+            .name = "local declaration initializer can use another import",
+            .source =
+            \\import { Foo, Bar } from "./lib";
+            \\{
+            \\  const Foo = Bar();
+            \\  Foo;
+            \\}
+            ,
+        },
+        .{
+            .name = "type-only import use mixed with value import use",
+            .source =
+            \\import { Foo, Bar, type Baz } from "./lib";
+            \\type T = Foo | Baz;
+            \\{ const Foo = 1; Foo; }
+            \\export const value: T = Bar();
+            ,
+        },
+        .{
+            .name = "block lexical shadow covers declaration initializer order",
+            .source =
+            \\import { Foo, Bar } from "./lib";
+            \\{
+            \\  Foo;
+            \\  const Foo = Bar();
+            \\}
+            \\Foo();
+            ,
+        },
+        .{
+            .name = "destructuring local shadow initializer can use another import",
+            .source =
+            \\import { Foo, Bar } from "./lib";
+            \\{
+            \\  const { value: Foo = Bar() } = source;
+            \\  Foo;
+            \\}
+            ,
+        },
+        .{
             // assignment_expression LHS (`Foo = expr`) 가 expression context 에서 walker arm
             // 에 잡혀 value_context=false 로 강제되면 import 가 잘못 elide 된다 — regression guard.
             .name = "assignment to imported name in expression keeps import",
@@ -1636,8 +1936,6 @@ test "TransformPlan: full-route guards for binding-lite follow-up" {
         .{ .name = "cjs", .source = "import { Foo } from './x';\nFoo();\n", .options = .{ .module_format = .cjs } },
         .{ .name = "downlevel", .source = "import { Foo } from './x';\nFoo();\n", .options = .{ .unsupported = compat.fromESTarget(.es5), .es_target = .es5 } },
         .{ .name = "flow", .source = "import { Foo } from './x';\nexport const x: Foo = 1;\n", .path = "input.js", .options = .{ .flow = true } },
-        .{ .name = "import local shadowed by local declaration", .source = "import { Foo } from './x';\nconst Foo = 1;\nexport { Foo };\n" },
-        .{ .name = "import local shadowed by catch binding", .source = "import { Foo } from './x';\ntry { Foo(); } catch (Foo) { console.log(Foo); }\n" },
     };
 
     for (cases) |case| {

--- a/tests/benchmark/profile.ts
+++ b/tests/benchmark/profile.ts
@@ -33,18 +33,39 @@ function generateTS(lines: number): string {
   return parts.join("\n");
 }
 
+function generateImportBearingTS(lines: number): string {
+  const parts: string[] = [
+    `import { Foo, Bar, Baz, Qux, type Shape } from "./lib";`,
+    `type LocalShape = Shape | Foo;`,
+  ];
+  let i = 0;
+  while (parts.length < lines) {
+    parts.push(`export type Item${i} = Foo & Shape & { readonly id${i}: string };`);
+    parts.push(`export interface Box${i} { value: Item${i}; next?: Box${i}; }`);
+    parts.push(`type Mapper${i}<T extends Foo> = (input: T | Shape) => Box${i};`);
+    parts.push(`export type Result${i} = ReturnType<Mapper${i}<Foo>> | LocalShape;`);
+    parts.push(`export const value${i} = Bar(${i});`);
+    parts.push(`{ const Foo = value${i}; Foo; }`);
+    parts.push(`try { Baz(value${i}); } catch (Baz) { Baz; }`);
+    parts.push(`export const fn${i} = (Qux = Foo) => Qux;`);
+    i++;
+  }
+  return parts.slice(0, lines).join("\n");
+}
+
 function median(times: number[]): number {
   const sorted = [...times].sort((a, b) => a - b);
   return Math.round(sorted[Math.floor(sorted.length / 2)]);
 }
 
-function measure(bin: string, args: string[]): number {
+function measure(bin: string, args: string[], env?: Record<string, string>): number {
   const times: number[] = [];
+  const spawnEnv = env ? { ...process.env, ...env } : undefined;
   // warmup
-  spawnSync(bin, args, { stdio: "pipe", timeout: 30000 });
+  spawnSync(bin, args, { stdio: "pipe", timeout: 30000, env: spawnEnv });
   for (let i = 0; i < ITERATIONS; i++) {
     const start = performance.now();
-    spawnSync(bin, args, { stdio: "pipe", timeout: 30000 });
+    spawnSync(bin, args, { stdio: "pipe", timeout: 30000, env: spawnEnv });
     times.push(performance.now() - start);
   }
   return median(times);
@@ -120,6 +141,30 @@ for (const lines of scales) {
   );
 
   console.log(`| ${row.join(" | ")} |`);
+}
+
+console.log("\nZTS Fast Path A/B — import-bearing TS strip");
+const fastScales = [25_000, 50_000, 100_000];
+console.log(`| Lines | Size (KB) | fast on (ms) | fast off (ms) | delta (ms) | ratio |`);
+console.log(`| --- | --- | --- | --- | --- | --- |`);
+
+for (const lines of fastScales) {
+  const source = generateImportBearingTS(lines);
+  const inputFile = join(dir, `binding_lite_${lines}.ts`);
+  const fastOut = join(dir, `out_fast_on_${lines}.js`);
+  const fullOut = join(dir, `out_fast_off_${lines}.js`);
+  writeFileSync(inputFile, source);
+
+  const fastOn = measure(ZTS_BIN, [inputFile, "-o", fastOut]);
+  const fastOff = measure(ZTS_BIN, [inputFile, "-o", fullOut], {
+    ZTS_DISABLE_TRANSPILE_FAST_PATH: "1",
+  });
+  const delta = fastOff - fastOn;
+  const ratio = fastOn === 0 ? "n/a" : `${(fastOff / fastOn).toFixed(2)}x`;
+
+  console.log(
+    `| ${lines} | ${Math.round(source.length / 1024)} | ${fastOn} | ${fastOff} | ${delta} | ${ratio} |`,
+  );
 }
 
 rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## 요약
- `BindingLite` fast path가 named import와 같은 이름의 local/catch binding을 만나면 과하게 full semantic으로 fallback하던 조건을 줄였습니다.
- block lexical shadow, catch binding shadow, nested function/block shadow를 scope-aware로 처리해서 shadow 밖의 import value-use는 계속 보존합니다.
- default/namespace import, JSX, enum/namespace, decorators, downlevel, CJS, minify/define/drop 계열은 기존처럼 full semantic route를 유지합니다.

## root cause
기존 `binding_shadow_requires_full_semantic` 게이트는 import local과 같은 `binding_identifier`가 AST 어디든 있으면 해당 shadow가 실제로 어느 scope에만 적용되는지 보지 않고 full route로 보냈습니다. 그래서 `{ const Foo = 1; Foo; } Foo()`나 `try { Foo(); } catch (Foo) { Foo; }`처럼 import value-use가 shadow 밖에 남아 있는 TS strip 입력도 BindingLite route를 타지 못했습니다.

이번 변경은 fallback 판정을 top-level/var/function declaration shadow, shadow buffer overflow처럼 아직 애매한 케이스로 좁히고, BindingLite value-use walker가 block/catch/function scope의 shadow set을 누적해서 처리하도록 고쳤습니다.

## 테스트 / 엣지 케이스
- route test 추가:
  - block lexical shadow + outer value-use
  - catch binding shadow + try body value-use
  - nested block shadow + outer value-use
  - 같은 block의 선언 전 reference(TDZ 의미)는 local shadow로 처리
  - top-level shadow, `var` shadow, function declaration shadow, shadow overflow는 full 유지
- fast/full parity fixture 추가:
  - `try { Foo(); } catch (Foo) { Foo; }`
  - `{ const Foo = 1; Foo; } Foo();`
  - nested block/function/catch shadow 조합
  - local declaration initializer에서 다른 import value-use
  - destructuring local shadow initializer
  - type-only import use와 value import use 혼합

## 복잡도
- import local 수집은 1회, unsupported shadow scan은 AST 1회, BindingLite value-use mark도 AST 1회 구조입니다.
- block scope는 직계 lexical declarations만 pre-scan한 뒤 같은 block body를 방문하므로 중첩 subtree를 반복 재탐색하지 않습니다.
- named import/shadow buffer는 기존 정책처럼 64개 상한을 두고 overflow 시 full route로 보수적으로 fallback합니다.

## profile
`bun run tests/benchmark/profile.ts`에 import-bearing TS strip A/B 섹션을 추가했습니다. `ZTS_DISABLE_TRANSPILE_FAST_PATH=1`로 fast path off를 비교합니다.

로컬 ReleaseFast 결과 (darwin arm64, median 10회):

| Lines | Size (KB) | fast on (ms) | fast off (ms) | delta (ms) | ratio |
| --- | --- | --- | --- | --- | --- |
| 25000 | 1248 | 20 | 54 | 34 | 2.70x |
| 50000 | 2512 | 39 | 171 | 132 | 4.38x |
| 100000 | 5073 | 73 | 607 | 534 | 8.32x |

Refs #2352
