### PR TITLE
perf(transpile): report TransformPlan hit rates

### DIFF
--- a/src/debug_log.zig
+++ b/src/debug_log.zig
@@ -28,6 +28,9 @@ const std = @import("std");
 /// 로그 카테고리. 추가 시 이 enum 에만 이름 넣으면 됨.
 pub const Category = enum {
     compiled_cache,
+    /// Standalone transpile fast-path routing: `.none` / `.bindings` / `.full`
+    /// and `SemanticPlanReason` hit-rate diagnostics.
+    transform_plan,
     /// AST mutation 추적 — `Ast.addNode` / `addString` / `addNodeList` 시점 로그.
     /// RFC #1672 D1 (Ast mutable + clone 제거) 디버깅용. parse_arena 소유권과
     /// transformer 의 in-place append 상호작용 확인.

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -638,9 +638,11 @@ fn buildTransformPlan(
     if (fast_path_disabled) return .{ .semantic = .full, .reason = .disabled_by_env };
     if (options.stop_after == .semantic) return .{ .semantic = .full, .reason = .stop_after_semantic };
 
+    // Flow 는 `non_ts_source` 보다 먼저 분류 — `// @flow` 주석이 붙은 `.js` 입력이
+    // generic JS fallback 으로 잘못 집계되지 않도록 한다.
+    if (parser.is_flow) return .{ .semantic = .full, .reason = .flow_source };
     // JS 파일은 보존 의미가 TS 와 달라 (값 import 가 type-only 라도 side-effect 가능 등)
     // fast path 적용 범위에서 제외 — full semantic 경로에서 진단 손실 없이 처리.
-    if (parser.is_flow) return .{ .semantic = .full, .reason = .flow_source };
     if (parser.source_mode != .ts) return .{ .semantic = .full, .reason = .non_ts_source };
     if (ast.has_jsx) return .{ .semantic = .full, .reason = .jsx_source };
 
@@ -1066,6 +1068,8 @@ fn transpileWithCallbackInternal(
     }
 
     const transform_plan = buildTransformPlan(options, &parser, &parser.ast, fast_path_disabled);
+    // 포맷 문자열을 변경하면 `tests/benchmark/profile.ts` 의 `tracePlan` 정규식도
+    // 함께 갱신해야 한다 — `semantic=...`, `reason=...` 키 이름을 그대로 유지.
     debug_log.print(
         .transform_plan,
         "file={s} semantic={s} reason={s} strip_types_only={}\n",

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -30,6 +30,7 @@ const rt = @import("bundler/runtime_helpers.zig");
 const Diagnostic = @import("diagnostic.zig").Diagnostic;
 const OwnedDiagnostic = @import("diagnostic.zig").OwnedDiagnostic;
 const string_list = @import("util/string_list.zig");
+const debug_log = @import("debug_log.zig");
 
 const SemanticRequirement = enum {
     none,
@@ -639,8 +640,8 @@ fn buildTransformPlan(
 
     // JS 파일은 보존 의미가 TS 와 달라 (값 import 가 type-only 라도 side-effect 가능 등)
     // fast path 적용 범위에서 제외 — full semantic 경로에서 진단 손실 없이 처리.
-    if (parser.source_mode != .ts) return .{ .semantic = .full, .reason = .non_ts_source };
     if (parser.is_flow) return .{ .semantic = .full, .reason = .flow_source };
+    if (parser.source_mode != .ts) return .{ .semantic = .full, .reason = .non_ts_source };
     if (ast.has_jsx) return .{ .semantic = .full, .reason = .jsx_source };
 
     if (optionsRequireTransformSemantic(options)) {
@@ -1065,6 +1066,11 @@ fn transpileWithCallbackInternal(
     }
 
     const transform_plan = buildTransformPlan(options, &parser, &parser.ast, fast_path_disabled);
+    debug_log.print(
+        .transform_plan,
+        "file={s} semantic={s} reason={s} strip_types_only={}\n",
+        .{ file_path, @tagName(transform_plan.semantic), @tagName(transform_plan.reason), transform_plan.strip_types_only },
+    );
 
     // 2. Semantic analysis
     var analyzer_storage: ?SemanticAnalyzer = null;
@@ -1411,6 +1417,16 @@ test "TransformPlan: runtime-sensitive syntax keeps full semantic" {
         try std.testing.expectEqual(SemanticRequirement.full, plan.semantic);
         try std.testing.expectEqual(case.reason, plan.reason);
     }
+}
+
+test "TransformPlan: Flow source is classified before generic non-TS source" {
+    const flow_plan = try testTransformPlan("// @flow\nconst value: string = 'x';\n", "input.js", .{ .flow = true });
+    try std.testing.expectEqual(SemanticRequirement.full, flow_plan.semantic);
+    try std.testing.expectEqual(SemanticPlanReason.flow_source, flow_plan.reason);
+
+    const js_plan = try testTransformPlan("const value = 1;\n", "input.js", .{});
+    try std.testing.expectEqual(SemanticRequirement.full, js_plan.semantic);
+    try std.testing.expectEqual(SemanticPlanReason.non_ts_source, js_plan.reason);
 }
 
 test "TransformPlan: named import TypeScript strip uses binding-lite semantic" {

--- a/tests/benchmark/profile.ts
+++ b/tests/benchmark/profile.ts
@@ -14,6 +14,18 @@ const ROOT = resolve(__dirname, "../..");
 const ZTS_BIN = join(ROOT, "zig-out/bin/zts");
 const ITERATIONS = 10;
 
+type PlanSample = {
+  name: string;
+  filename: string;
+  source: string;
+  args?: string[];
+};
+
+type PlanHit = {
+  semantic: string;
+  reason: string;
+};
+
 function findBin(name: string): string | null {
   const local = join(__dirname, "node_modules/.bin", name);
   if (existsSync(local)) return local;
@@ -69,6 +81,127 @@ function measure(bin: string, args: string[], env?: Record<string, string>): num
     times.push(performance.now() - start);
   }
   return median(times);
+}
+
+function tracePlan(sample: PlanSample, dir: string): PlanHit {
+  const inputFile = join(dir, sample.filename);
+  const outFile = join(dir, `${sample.name.replaceAll(/[^a-zA-Z0-9_-]/g, "_")}.js`);
+  writeFileSync(inputFile, sample.source);
+  const result = spawnSync(ZTS_BIN, [inputFile, ...(sample.args ?? []), "-o", outFile], {
+    stdio: "pipe",
+    timeout: 30000,
+    env: { ...process.env, ZTS_DEBUG: "transform_plan" },
+    encoding: "utf8",
+  });
+  const match = result.stderr.match(
+    /\[transform_plan\]\s+file=.*?\s+semantic=([a-z_]+)\s+reason=([a-z_]+)/,
+  );
+  if (!match) {
+    const prefix = result.status === 0 ? "missing" : "failed before";
+    throw new Error(
+      `${prefix} transform_plan trace for ${sample.name}: ${result.stderr.slice(0, 500)}`,
+    );
+  }
+  return { semantic: match[1], reason: match[2] };
+}
+
+function formatPercent(count: number, total: number): string {
+  return `${((count / total) * 100).toFixed(1)}%`;
+}
+
+function printPlanHitRates(dir: string): void {
+  const samples: PlanSample[] = [
+    {
+      name: "simple-ts-strip",
+      filename: "simple.ts",
+      source: generateTS(1000),
+    },
+    {
+      name: "binding-lite-named-import",
+      filename: "binding-lite.ts",
+      source: generateImportBearingTS(1000),
+    },
+    {
+      name: "default-import",
+      filename: "default-import.ts",
+      source: `import Foo from "./lib";\nexport const value = Foo();\n`,
+    },
+    {
+      name: "namespace-import",
+      filename: "namespace-import.ts",
+      source: `import * as Foo from "./lib";\nexport const value = Foo.run();\n`,
+    },
+    {
+      name: "jsx",
+      filename: "component.tsx",
+      source: `import { Foo } from "./lib";\nexport const value = <Foo />;\n`,
+    },
+    {
+      name: "enum-runtime",
+      filename: "enum.ts",
+      source: `import { Foo } from "./lib";\nenum Kind { A }\nexport const value = Foo;\n`,
+    },
+    {
+      name: "minify-option",
+      filename: "minify.ts",
+      source: `import { Foo } from "./lib";\nexport const value = Foo();\n`,
+      args: ["--minify"],
+    },
+    {
+      name: "cjs-format",
+      filename: "cjs.ts",
+      source: `import { Foo } from "./lib";\nexport const value = Foo();\n`,
+      args: ["--format=cjs"],
+    },
+    {
+      name: "downlevel-target",
+      filename: "downlevel.ts",
+      source: `import { Foo } from "./lib";\nexport const value = () => Foo();\n`,
+      args: ["--target=es5"],
+    },
+    {
+      name: "top-level-shadow",
+      filename: "shadow.ts",
+      source: `import { Foo } from "./lib";\nconst Foo = 1;\nexport { Foo };\n`,
+    },
+    {
+      name: "js-source",
+      filename: "plain.js",
+      source: `const value = 1;\n`,
+    },
+    {
+      name: "flow-source",
+      filename: "flow.js",
+      source: `// @flow\nimport { Foo } from "./lib";\nexport const value: Foo = 1;\n`,
+      args: ["--flow"],
+    },
+  ];
+
+  const hits = new Map<string, PlanHit & { count: number }>();
+  for (const sample of samples) {
+    const hit = tracePlan(sample, dir);
+    const key = `${hit.semantic}:${hit.reason}`;
+    const current = hits.get(key);
+    if (current) {
+      current.count += 1;
+    } else {
+      hits.set(key, { ...hit, count: 1 });
+    }
+  }
+
+  console.log("\nZTS TransformPlan Hit Rates — representative route roots");
+  console.log(`| Semantic | Reason | Count | Share |`);
+  console.log(`| --- | --- | --- | --- |`);
+  const rows = [...hits.values()].sort((a, b) =>
+    a.semantic === b.semantic
+      ? a.reason.localeCompare(b.reason)
+      : a.semantic.localeCompare(b.semantic),
+  );
+  for (const row of rows) {
+    console.log(
+      `| ${row.semantic} | ${row.reason} | ${row.count} | ${formatPercent(row.count, samples.length)} |`,
+    );
+  }
 }
 
 const scales = [100, 500, 1000, 2000, 5000, 10000];
@@ -166,6 +299,8 @@ for (const lines of fastScales) {
     `| ${lines} | ${Math.round(source.length / 1024)} | ${fastOn} | ${fastOff} | ${delta} | ${ratio} |`,
   );
 }
+
+printPlanHitRates(dir);
 
 rmSync(dir, { recursive: true, force: true });
 console.log("\n(ms가 파일 크기에 비례하면 O(n), 제곱으로 증가하면 O(n²))");


### PR DESCRIPTION
## 요약
- `ZTS_DEBUG=transform_plan`으로 standalone transpile의 TransformPlan route(`none`/`bindings`/`full`)와 `SemanticPlanReason`을 파일 단위로 추적할 수 있게 했습니다.
- 실제 루트커즈 확인 중 `flow_source`가 `non_ts_source`보다 뒤에서 검사되어 Flow 입력이 generic JS fallback으로 집계되던 분류 오류를 수정했습니다.
- `tests/benchmark/profile.ts`에 대표 route root hit-rate 표를 추가해 fast path 확대 전에 어떤 fallback 이유가 남는지 확인할 수 있게 했습니다.

## 루트커즈
BindingLite fast path의 다음 병목을 보려면 `.full` fallback의 실제 reason 분포가 먼저 보여야 하는데, 기존에는 route/reason을 외부에서 관찰할 방법이 없었습니다. 또한 Flow 입력은 `parser.source_mode != .ts` 체크가 먼저 실행되어 `flow_source` reason이 사실상 가려졌습니다. 이 PR은 관측 지점을 추가하고 Flow 분류 순서를 바로잡아 다음 최적화 대상을 reason 단위로 좁힐 수 있게 합니다.

## 로컬 검증
- `zig build test --summary all`
- `zig build napi -Doptimize=ReleaseFast --summary all`
- `bun test packages/core/index.test.ts --timeout 30000`
- `zig build -Doptimize=ReleaseFast --summary all`
- `bun run tests/benchmark/profile.ts`
- `git diff --check`
- pre-push hook 통과: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`

## 측정 결과
`bun run tests/benchmark/profile.ts` 기준:


ZTS Fast Path A/B — import-bearing TS strip
| Lines | Size (KB) | fast on | fast off | delta | ratio |
| --- | ---: | ---: | ---: | ---: | ---: |
| 25000 | 1248 | 20 | 54 | 34 | 2.70x |
| 50000 | 2512 | 39 | 171 | 132 | 4.38x |
| 100000 | 5073 | 74 | 608 | 534 | 8.27x |

ZTS TransformPlan Hit Rates — representative route roots
| Semantic | Reason | Count | Share |
| --- | --- | --- | --- |
| bindings | named_import_binding_elision | 1 | 8.3% |
| full | ast_requires_runtime_transform | 1 | 8.3% |
| full | binding_shadow_requires_full_semantic | 1 | 8.3% |
| full | flow_source | 1 | 8.3% |
| full | import_shape_requires_full_semantic | 2 | 16.7% |
| full | jsx_source | 1 | 8.3% |
| full | module_format_requires_semantic | 1 | 8.3% |
| full | non_ts_source | 1 | 8.3% |
| full | option_requires_transform_semantic | 1 | 8.3% |
| full | target_requires_downlevel | 1 | 8.3% |
| none | simple_ts_strip | 1 | 8.3% |


Refs #2352