### PR TITLE
perf(transpile): handle function var import shadows

### DIFF
--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -527,7 +527,7 @@ fn hasUnsupportedNamedImportLocalBindingShadow(ast: *const Ast) bool {
 
     for (ast.nodes.items, 0..) |node, raw_idx| {
         if (node.tag != .program) continue;
-        return scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(raw_idx), names_buf[0..names_len], 0);
+        return scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(raw_idx), names_buf[0..names_len], 0, false);
     }
     return false;
 }
@@ -553,6 +553,7 @@ fn scanVariableDeclarationForUnsupportedBindingLiteShadow(
     node: ast_mod.Node,
     names: []const []const u8,
     scope_depth: usize,
+    inside_function: bool,
 ) bool {
     const list_start = ast.extra_data.items[node.data.extra + 1];
     const list_len = ast.extra_data.items[node.data.extra + 2];
@@ -566,12 +567,12 @@ fn scanVariableDeclarationForUnsupportedBindingLiteShadow(
         const binding_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[decl.data.extra]);
         if (bindingPatternImportShadowOverflow(ast, binding_idx, names, &matching_shadows)) return true;
         const init_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[decl.data.extra + 2]);
-        if (scanForUnsupportedBindingLiteShadow(ast, init_idx, names, scope_depth)) return true;
+        if (scanForUnsupportedBindingLiteShadow(ast, init_idx, names, scope_depth, inside_function)) return true;
     }
 
     if (matching_shadows == 0) return false;
-    if (scope_depth == 0) return true;
-    return !ast.variableDeclarationKind(node).isLexical();
+    if (ast.variableDeclarationKind(node).isLexical()) return scope_depth == 0;
+    return !inside_function;
 }
 
 fn scanChildrenForUnsupportedBindingLiteShadow(
@@ -579,10 +580,11 @@ fn scanChildrenForUnsupportedBindingLiteShadow(
     node: ast_mod.Node,
     names: []const []const u8,
     child_scope_depth: usize,
+    inside_function: bool,
 ) bool {
     var it = ast_walk.children(ast, node);
     while (it.next()) |child_idx| {
-        if (scanForUnsupportedBindingLiteShadow(ast, child_idx, names, child_scope_depth)) return true;
+        if (scanForUnsupportedBindingLiteShadow(ast, child_idx, names, child_scope_depth, inside_function)) return true;
     }
     return false;
 }
@@ -592,16 +594,16 @@ fn scanForUnsupportedBindingLiteShadow(
     idx: ast_mod.NodeIndex,
     names: []const []const u8,
     scope_depth: usize,
+    inside_function: bool,
 ) bool {
     if (idx.isNone()) return false;
     const node = ast.getNode(idx);
     switch (node.tag) {
         // program 의 child 는 항상 top-level (scope_depth=0). block/function body 진입은
         // scope_depth+1. 그 외 노드는 같은 scope_depth 로 children 만 내려간다.
-        .program => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, 0),
-        .block_statement,
-        .function_body,
-        => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, scope_depth + 1),
+        .program => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, 0, false),
+        .block_statement => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, scope_depth + 1, inside_function),
+        .function_body => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, scope_depth + 1, true),
         .formal_parameters => {
             var matching_shadows: usize = 0;
             return bindingPatternImportShadowOverflow(ast, idx, names, &matching_shadows);
@@ -609,11 +611,29 @@ fn scanForUnsupportedBindingLiteShadow(
         .catch_clause => {
             var matching_shadows: usize = 0;
             if (bindingPatternImportShadowOverflow(ast, node.data.binary.left, names, &matching_shadows)) return true;
-            return scanForUnsupportedBindingLiteShadow(ast, node.data.binary.right, names, scope_depth + 1);
+            return scanForUnsupportedBindingLiteShadow(ast, node.data.binary.right, names, scope_depth + 1, inside_function);
         },
-        .variable_declaration => return scanVariableDeclarationForUnsupportedBindingLiteShadow(ast, node, names, scope_depth),
+        .function_declaration,
+        .function_expression,
+        .function,
+        => {
+            const e = node.data.extra;
+            if (scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e]), names, scope_depth, inside_function)) return true;
+            if (scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e + 1]), names, scope_depth, inside_function)) return true;
+            return scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e + 2]), names, scope_depth + 1, true);
+        },
+        .arrow_function_expression => {
+            const e = node.data.extra;
+            if (scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e]), names, scope_depth, inside_function)) return true;
+            return scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e + 1]), names, scope_depth + 1, true);
+        },
+        .variable_declaration => return scanVariableDeclarationForUnsupportedBindingLiteShadow(ast, node, names, scope_depth, inside_function),
+        .variable_declarator => {
+            const init_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[node.data.extra + 2]);
+            return scanForUnsupportedBindingLiteShadow(ast, init_idx, names, scope_depth, inside_function);
+        },
         .binding_identifier => return string_list.contains(names, ast.getText(node.span)),
-        else => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, scope_depth),
+        else => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, scope_depth, inside_function),
     }
 }
 
@@ -765,6 +785,39 @@ fn collectBindingLiteVariableDeclarationShadows(ast: *const Ast, node: ast_mod.N
     }
 }
 
+fn collectBindingLiteVarDeclarationShadows(ast: *const Ast, node: ast_mod.Node, lite: *const BindingLite, buf: [][]const u8, len: *usize) void {
+    if (ast.variableDeclarationKind(node).isLexical()) return;
+    const list_start = ast.extra_data.items[node.data.extra + 1];
+    const list_len = ast.extra_data.items[node.data.extra + 2];
+    var i: u32 = 0;
+    while (i < list_len) : (i += 1) {
+        const decl_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[list_start + i]);
+        if (decl_idx.isNone()) continue;
+        const decl = ast.getNode(decl_idx);
+        if (decl.tag != .variable_declarator) continue;
+        collectBindingLitePatternShadows(ast, @enumFromInt(ast.extra_data.items[decl.data.extra]), lite, buf, len);
+    }
+}
+
+fn collectBindingLiteFunctionVarShadows(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *const BindingLite, buf: [][]const u8, len: *usize) void {
+    if (idx.isNone()) return;
+    const node = ast.getNode(idx);
+    switch (node.tag) {
+        .function_declaration,
+        .function_expression,
+        .function,
+        .arrow_function_expression,
+        => return,
+        .variable_declaration => collectBindingLiteVarDeclarationShadows(ast, node, lite, buf, len),
+        else => {},
+    }
+
+    var it = ast_walk.children(ast, node);
+    while (it.next()) |child_idx| {
+        collectBindingLiteFunctionVarShadows(ast, child_idx, lite, buf, len);
+    }
+}
+
 fn collectBindingLiteListLexicalShadows(ast: *const Ast, list: ast_mod.NodeList, lite: *const BindingLite, buf: [][]const u8, len: *usize) void {
     if (list.start + list.len > ast.extra_data.items.len) return;
     var i: u32 = 0;
@@ -836,6 +889,7 @@ fn markBindingLiteFunctionScope(
     var shadow_len: usize = 0;
     for (parent_shadowed) |name| appendBindingLiteShadowName(&shadow_buf, &shadow_len, name);
     collectBindingLitePatternShadows(ast, params_idx, lite, &shadow_buf, &shadow_len);
+    collectBindingLiteFunctionVarShadows(ast, body_idx, lite, &shadow_buf, &shadow_len);
     const combined = shadow_buf[0..shadow_len];
     markBindingLiteValueUses(ast, params_idx, lite, false, combined);
     markBindingLiteValueUses(ast, body_idx, lite, true, combined);
@@ -1486,6 +1540,25 @@ test "TransformPlan: scope-local named import shadows stay on binding-lite route
             \\Foo();
             ,
         },
+        .{
+            .name = "function var shadow with outer value use",
+            .source =
+            \\import { Foo, Bar } from "./lib";
+            \\function f() { var Foo = Bar(); return Foo; }
+            \\Foo();
+            ,
+        },
+        .{
+            .name = "function block var shadow stays function scoped",
+            .source =
+            \\import { Foo, Bar } from "./lib";
+            \\function f() {
+            \\  if (ok) { var Foo = Bar(); }
+            \\  return Foo;
+            \\}
+            \\Foo();
+            ,
+        },
     };
 
     for (cases) |case| {
@@ -1506,13 +1579,13 @@ test "TransformPlan: ambiguous or overflowing named import shadows keep full sem
     try std.testing.expectEqual(SemanticRequirement.full, top_level.semantic);
     try std.testing.expectEqual(SemanticPlanReason.binding_shadow_requires_full_semantic, top_level.reason);
 
-    const var_shadow = try testTransformPlan(
-        "import { Foo } from './x';\nfunction f() { var Foo = 1; return Foo; }\n",
+    const top_level_block_var_shadow = try testTransformPlan(
+        "import { Foo } from './x';\n{ var Foo = 1; }\nFoo();\n",
         "input.ts",
         .{},
     );
-    try std.testing.expectEqual(SemanticRequirement.full, var_shadow.semantic);
-    try std.testing.expectEqual(SemanticPlanReason.binding_shadow_requires_full_semantic, var_shadow.reason);
+    try std.testing.expectEqual(SemanticRequirement.full, top_level_block_var_shadow.semantic);
+    try std.testing.expectEqual(SemanticPlanReason.binding_shadow_requires_full_semantic, top_level_block_var_shadow.reason);
 
     const function_decl_shadow = try testTransformPlan(
         "import { Foo } from './x';\nfunction outer() { function Foo() {} return Foo; }\n",
@@ -1521,6 +1594,14 @@ test "TransformPlan: ambiguous or overflowing named import shadows keep full sem
     );
     try std.testing.expectEqual(SemanticRequirement.full, function_decl_shadow.semantic);
     try std.testing.expectEqual(SemanticPlanReason.binding_shadow_requires_full_semantic, function_decl_shadow.reason);
+
+    const function_var_shadow = try testTransformPlan(
+        "import { Foo } from './x';\nfunction f() { var Foo = 1; return Foo; }\n",
+        "input.ts",
+        .{},
+    );
+    try std.testing.expectEqual(SemanticRequirement.bindings, function_var_shadow.semantic);
+    try std.testing.expectEqual(SemanticPlanReason.named_import_binding_elision, function_var_shadow.reason);
 
     var overflow_source: std.ArrayList(u8) = .empty;
     defer overflow_source.deinit(std.testing.allocator);
@@ -1864,6 +1945,27 @@ test "TransformPlan parity: binding-lite named import elision matches full seman
             \\  return Foo;
             \\}
             \\export const value = Bar();
+            ,
+        },
+        .{
+            .name = "function var shadow does not keep import",
+            .source =
+            \\import { Foo, Bar } from "./lib";
+            \\export function f() {
+            \\  var Foo = Bar();
+            \\  return Foo;
+            \\}
+            ,
+        },
+        .{
+            .name = "nested function var shadow does not hide outer value use",
+            .source =
+            \\import { Foo, Bar } from "./lib";
+            \\export const before = Foo();
+            \\export function outer() {
+            \\  if (ok) { var Foo = Bar(); }
+            \\  return Foo;
+            \\}
             ,
         },
         .{

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -599,8 +599,9 @@ fn scanForUnsupportedBindingLiteShadow(
     if (idx.isNone()) return false;
     const node = ast.getNode(idx);
     switch (node.tag) {
-        // program 의 child 는 항상 top-level (scope_depth=0). block/function body 진입은
-        // scope_depth+1. 그 외 노드는 같은 scope_depth 로 children 만 내려간다.
+        // scope_depth: program 은 0, block/body 진입마다 +1. inside_function: function/arrow body
+        // 이하 ancestry. 두 값이 함께 쓰이는 이유는 transpile.zig:573-575 의 truth table 참고 — top-level
+        // var 은 import 를 가리지만 함수 내 var 는 nearest function scope 에만 머물러 outer use 를 안 가린다.
         .program => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, 0, false),
         .block_statement => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, scope_depth + 1, inside_function),
         .function_body => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, scope_depth + 1, true),
@@ -628,10 +629,6 @@ fn scanForUnsupportedBindingLiteShadow(
             return scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e + 1]), names, scope_depth + 1, true);
         },
         .variable_declaration => return scanVariableDeclarationForUnsupportedBindingLiteShadow(ast, node, names, scope_depth, inside_function),
-        .variable_declarator => {
-            const init_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[node.data.extra + 2]);
-            return scanForUnsupportedBindingLiteShadow(ast, init_idx, names, scope_depth, inside_function);
-        },
         .binding_identifier => return string_list.contains(names, ast.getText(node.span)),
         else => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, scope_depth, inside_function),
     }
@@ -761,6 +758,7 @@ fn appendBindingLiteShadowName(buf: [][]const u8, len: *usize, name: []const u8)
 }
 
 fn collectBindingLitePatternShadows(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *const BindingLite, buf: [][]const u8, len: *usize) void {
+    if (len.* >= buf.len) return;
     var it = ast_walk.bindingIdentifiers(ast, idx, .{ .cover_grammar_assignment = true });
     while (it.next()) |leaf_idx| {
         const leaf = ast.getNode(leaf_idx);
@@ -772,21 +770,6 @@ fn collectBindingLitePatternShadows(ast: *const Ast, idx: ast_mod.NodeIndex, lit
 }
 
 fn collectBindingLiteVariableDeclarationShadows(ast: *const Ast, node: ast_mod.Node, lite: *const BindingLite, buf: [][]const u8, len: *usize) void {
-    if (!ast.variableDeclarationKind(node).isLexical()) return;
-    const list_start = ast.extra_data.items[node.data.extra + 1];
-    const list_len = ast.extra_data.items[node.data.extra + 2];
-    var i: u32 = 0;
-    while (i < list_len) : (i += 1) {
-        const decl_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[list_start + i]);
-        if (decl_idx.isNone()) continue;
-        const decl = ast.getNode(decl_idx);
-        if (decl.tag != .variable_declarator) continue;
-        collectBindingLitePatternShadows(ast, @enumFromInt(ast.extra_data.items[decl.data.extra]), lite, buf, len);
-    }
-}
-
-fn collectBindingLiteVarDeclarationShadows(ast: *const Ast, node: ast_mod.Node, lite: *const BindingLite, buf: [][]const u8, len: *usize) void {
-    if (ast.variableDeclarationKind(node).isLexical()) return;
     const list_start = ast.extra_data.items[node.data.extra + 1];
     const list_len = ast.extra_data.items[node.data.extra + 2];
     var i: u32 = 0;
@@ -801,6 +784,7 @@ fn collectBindingLiteVarDeclarationShadows(ast: *const Ast, node: ast_mod.Node, 
 
 fn collectBindingLiteFunctionVarShadows(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *const BindingLite, buf: [][]const u8, len: *usize) void {
     if (idx.isNone()) return;
+    if (len.* >= buf.len) return;
     const node = ast.getNode(idx);
     switch (node.tag) {
         .function_declaration,
@@ -808,7 +792,9 @@ fn collectBindingLiteFunctionVarShadows(ast: *const Ast, idx: ast_mod.NodeIndex,
         .function,
         .arrow_function_expression,
         => return,
-        .variable_declaration => collectBindingLiteVarDeclarationShadows(ast, node, lite, buf, len),
+        .variable_declaration => if (!ast.variableDeclarationKind(node).isLexical()) {
+            collectBindingLiteVariableDeclarationShadows(ast, node, lite, buf, len);
+        },
         else => {},
     }
 
@@ -825,7 +811,7 @@ fn collectBindingLiteListLexicalShadows(ast: *const Ast, list: ast_mod.NodeList,
         const child_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[list.start + i]);
         if (child_idx.isNone()) continue;
         const child = ast.getNode(child_idx);
-        if (child.tag == .variable_declaration) {
+        if (child.tag == .variable_declaration and ast.variableDeclarationKind(child).isLexical()) {
             collectBindingLiteVariableDeclarationShadows(ast, child, lite, buf, len);
         }
     }

--- a/tests/benchmark/profile.ts
+++ b/tests/benchmark/profile.ts
@@ -165,6 +165,11 @@ function printPlanHitRates(dir: string): void {
       source: `import { Foo } from "./lib";\nconst Foo = 1;\nexport { Foo };\n`,
     },
     {
+      name: "function-var-shadow",
+      filename: "function-var-shadow.ts",
+      source: `import { Foo, Bar } from "./lib";\nfunction f() { var Foo = Bar(); return Foo; }\nFoo();\n`,
+    },
+    {
       name: "js-source",
       filename: "plain.js",
       source: `const value = 1;\n`,


### PR DESCRIPTION
## 요약
- BindingLite route scanner가 nested function scope의 `var` shadow를 full fallback으로 보내던 범위를 줄였습니다.
- BindingLite value-use walker도 함수 body의 `var` 선언을 nearest function scope shadow로 먼저 수집해 route scanner와 같은 스코프 모델을 쓰게 했습니다.
- top-level / top-level block `var` shadow, function declaration shadow, overflow, default/namespace/JSX/downlevel/minify/CJS 계열 full guard는 유지했습니다.

## 루트커즈
PR #2421에서 `ZTS_DEBUG=transform_plan`으로 fallback reason을 관측한 뒤, named import 범위에서 남은 안전한 후보를 다시 봤습니다. 기존 구현은 `var Foo`가 함수 내부에 있어도 `binding_shadow_requires_full_semantic`으로 분류했습니다. 하지만 `var`는 nearest function scope 안에서만 import value-use를 가리므로, top-level import의 함수 밖 value-use까지 full semantic으로 보낼 필요가 없습니다.

이번 변경은 function scope 진입을 route scanner에 명시하고, BindingLite walker가 함수 body를 표시하기 전에 해당 함수 body의 `var` shadow만 선수집합니다. nested function body는 별도 function scope라 건너뛰어 한 노드가 여러 함수 scope scan에 반복 포함되지 않게 했습니다. 따라서 shadow 수집은 기존 상한 64개를 유지하면서 AST 크기에 선형으로 동작합니다.

## 검증
- `zig build test --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- `zig build napi -Doptimize=ReleaseFast --summary all`
- `bun test packages/core/index.test.ts --timeout 30000`
- `bun run tests/benchmark/profile.ts`
- `git diff --check`
- pre-push hook 통과: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`

## 측정 결과
`bun run tests/benchmark/profile.ts` 기준:


ZTS Fast Path A/B — import-bearing TS strip
| Lines | Size (KB) | fast on (ms) | fast off (ms) | delta (ms) | ratio |
| --- | --- | --- | --- | --- | --- |
| 25000 | 1248 | 20 | 54 | 34 | 2.70x |
| 50000 | 2512 | 38 | 171 | 133 | 4.50x |
| 100000 | 5073 | 73 | 607 | 534 | 8.32x |

ZTS TransformPlan Hit Rates — representative route roots
| Semantic | Reason | Count | Share |
| --- | --- | --- | --- |
| bindings | named_import_binding_elision | 2 | 15.4% |
| full | ast_requires_runtime_transform | 1 | 7.7% |
| full | binding_shadow_requires_full_semantic | 1 | 7.7% |
| full | flow_source | 1 | 7.7% |
| full | import_shape_requires_full_semantic | 2 | 15.4% |
| full | jsx_source | 1 | 7.7% |
| full | module_format_requires_semantic | 1 | 7.7% |
| full | non_ts_source | 1 | 7.7% |
| full | option_requires_transform_semantic | 1 | 7.7% |
| full | target_requires_downlevel | 1 | 7.7% |
| none | simple_ts_strip | 1 | 7.7% |


Refs #2352