### PR TITLE
perf(transpile): handle function expression import shadows

### DIFF
--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -639,6 +639,10 @@ pub const SemanticAnalyzer = struct {
         }
     }
 
+    fn declareFunctionExprInnerName(self: *SemanticAnalyzer, name_span: Span, flags: u32, node_idx: u32) AllocError!void {
+        try self.declareSymbolWithNode(name_span, functionSymbolKind(flags), name_span, node_idx);
+    }
+
     /// 선언을 `references` 배열에 `flags.declare` 로 기록. #1669.
     /// 현재 `enable_stmt_info` + 유효 stmt_idx 가 있을 때만 기록.
     /// `scope_id` 는 선언 대상 scope — top-level 판별은 buildFromSemantic 에서 수행.
@@ -2259,22 +2263,29 @@ pub const SemanticAnalyzer = struct {
         const extra_start = node.data.extra;
         const extras = self.ast.extra_data.items;
         if (extra_start + 3 >= extras.len) return;
+        const name_idx: NodeIndex = @enumFromInt(extras[extra_start]);
         const body_idx: NodeIndex = @enumFromInt(extras[extra_start + 2]);
+        const fn_flags = extras[extra_start + 3];
+
+        const name_saved = if (!name_idx.isNone()) blk: {
+            const saved = try self.enterScope(.block, self.is_strict_mode);
+            const name_node = self.ast.getNode(name_idx);
+            try self.declareFunctionExprInnerName(name_node.span, fn_flags, @intFromEnum(name_idx));
+            break :blk saved;
+        } else ScopeId.none;
+        defer if (!name_saved.isNone()) self.exitScope(name_saved);
 
         const saved = try self.enterScope(.function, self.is_strict_mode);
         const saved_labels = self.saveLabelLen();
 
-        // 함수 표현식의 이름은 자체 스코프에만 등록 (외부에서 접근 불가).
-        // ECMAScript: 함수 표현식 이름은 implicit binding으로, body의 let/const/var로 섀도잉 가능.
-        // 재선언 충돌을 일으키지 않도록 symbol 등록을 생략한다.
-        // (이름의 read-only 접근은 런타임에서 처리)
-        _ = @as(NodeIndex, @enumFromInt(extras[extra_start])); // name_idx (사용하지 않음)
+        // 함수 표현식 이름은 외부 scope 에는 노출되지 않지만 parameter initializer 와
+        // body 안에서는 보이는 별도 inner binding 이다. 한 겹 바깥 block scope 에 둬야
+        // 같은 이름의 parameter / var / let 이 일반 lookup 으로 shadow 할 수 있다.
 
         const params_list = self.ast.functionParamsList(node);
         try self.registerParams(params_list);
 
         // 중복 파라미터 검증: flags에서 async/generator 판별
-        const fn_flags = extras[extra_start + 3];
         const FnFlags = ast_mod.FunctionFlags;
         const fn_is_async = (fn_flags & FnFlags.is_async) != 0;
         const fn_is_generator = (fn_flags & FnFlags.is_generator) != 0;

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -639,10 +639,6 @@ pub const SemanticAnalyzer = struct {
         }
     }
 
-    fn declareFunctionExprInnerName(self: *SemanticAnalyzer, name_span: Span, flags: u32, node_idx: u32) AllocError!void {
-        try self.declareSymbolWithNode(name_span, functionSymbolKind(flags), name_span, node_idx);
-    }
-
     /// 선언을 `references` 배열에 `flags.declare` 로 기록. #1669.
     /// 현재 `enable_stmt_info` + 유효 stmt_idx 가 있을 때만 기록.
     /// `scope_id` 는 선언 대상 scope — top-level 판별은 buildFromSemantic 에서 수행.
@@ -2267,20 +2263,19 @@ pub const SemanticAnalyzer = struct {
         const body_idx: NodeIndex = @enumFromInt(extras[extra_start + 2]);
         const fn_flags = extras[extra_start + 3];
 
+        // 함수 표현식 이름은 외부 scope 에는 노출되지 않지만 parameter initializer 와
+        // body 안에서는 보이는 별도 inner binding 이다. 한 겹 바깥 block scope 에 둬야
+        // 같은 이름의 parameter / var / let 이 일반 lookup 으로 shadow 할 수 있다.
         const name_saved = if (!name_idx.isNone()) blk: {
             const saved = try self.enterScope(.block, self.is_strict_mode);
             const name_node = self.ast.getNode(name_idx);
-            try self.declareFunctionExprInnerName(name_node.span, fn_flags, @intFromEnum(name_idx));
+            try self.declareSymbolWithNode(name_node.span, functionSymbolKind(fn_flags), name_node.span, @intFromEnum(name_idx));
             break :blk saved;
         } else ScopeId.none;
         defer if (!name_saved.isNone()) self.exitScope(name_saved);
 
         const saved = try self.enterScope(.function, self.is_strict_mode);
         const saved_labels = self.saveLabelLen();
-
-        // 함수 표현식 이름은 외부 scope 에는 노출되지 않지만 parameter initializer 와
-        // body 안에서는 보이는 별도 inner binding 이다. 한 겹 바깥 block scope 에 둬야
-        // 같은 이름의 parameter / var / let 이 일반 lookup 으로 shadow 할 수 있다.
 
         const params_list = self.ast.functionParamsList(node);
         try self.registerParams(params_list);

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -1268,6 +1268,70 @@ test "ClassExpression: name scoped to class body — not visible outside (#1592)
 }
 
 // ============================================================
+// FunctionExpression name binding
+// ============================================================
+
+test "FunctionExpression: self-reference resolves to inner function name" {
+    var scanner = try Scanner.init(std.testing.allocator,
+        \\const fn = function Foo(value = Foo) {
+        \\  return Foo;
+        \\};
+        \\const outer = Foo;
+    );
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
+    defer ana.deinit();
+    try ana.analyze();
+
+    try std.testing.expectEqual(@as(usize, 0), ana.errors.items.len);
+    var function_name_refs: u32 = 0;
+    var found = false;
+    for (ana.symbols.items) |sym| {
+        if (sym.kind.isFunctionLike() and std.mem.eql(u8, sym.nameText(parser.ast.source), "Foo")) {
+            found = true;
+            function_name_refs = sym.reference_count;
+        }
+    }
+    try std.testing.expect(found);
+    try std.testing.expectEqual(@as(u32, 2), function_name_refs);
+}
+
+test "FunctionExpression: parameter shadows inner function name" {
+    var scanner = try Scanner.init(std.testing.allocator,
+        \\const fn = function Foo(Foo = Foo) {
+        \\  return Foo;
+        \\};
+    );
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
+    defer ana.deinit();
+    try ana.analyze();
+
+    try std.testing.expectEqual(@as(usize, 0), ana.errors.items.len);
+    var function_name_refs: u32 = 0;
+    var parameter_refs: u32 = 0;
+    for (ana.symbols.items) |sym| {
+        if (std.mem.eql(u8, sym.nameText(parser.ast.source), "Foo")) {
+            if (sym.kind.isFunctionLike()) {
+                function_name_refs = sym.reference_count;
+            } else if (sym.kind == .parameter) {
+                parameter_refs = sym.reference_count;
+            }
+        }
+    }
+    try std.testing.expectEqual(@as(u32, 0), function_name_refs);
+    try std.testing.expectEqual(@as(u32, 2), parameter_refs);
+}
+
+// ============================================================
 // per-reference 배열 (references) 테스트
 // ============================================================
 

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -548,11 +548,15 @@ fn bindingPatternImportShadowOverflow(ast: *const Ast, idx: ast_mod.NodeIndex, n
     return false;
 }
 
-fn functionExpressionNameImportShadowOverflow(ast: *const Ast, node: ast_mod.Node, names: []const []const u8, match_count: *usize) bool {
-    if (node.tag != .function_expression and node.tag != .function) return false;
+fn functionExpressionInnerName(ast: *const Ast, node: ast_mod.Node) ?[]const u8 {
+    if (node.tag != .function_expression and node.tag != .function) return null;
     const name_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[node.data.extra]);
-    if (name_idx.isNone()) return false;
-    const name = ast.getText(ast.getNode(name_idx).span);
+    if (name_idx.isNone()) return null;
+    return ast.getText(ast.getNode(name_idx).span);
+}
+
+fn functionExpressionNameImportShadowOverflow(ast: *const Ast, node: ast_mod.Node, names: []const []const u8, match_count: *usize) bool {
+    const name = functionExpressionInnerName(ast, node) orelse return false;
     if (string_list.contains(names, name)) {
         match_count.* += 1;
         if (match_count.* > binding_lite_max_shadows) return true;
@@ -638,15 +642,18 @@ fn scanFunctionForUnsupportedBindingLiteShadow(
     names: []const []const u8,
     scope_depth: usize,
     inside_function: bool,
-    function_expression_self_name: bool,
 ) bool {
     const e = node.data.extra;
+    // function_expression / function 의 extras[0] 은 inner-only self-name 이라 outer scope binding
+    // 으로 스캔하면 안 되고 별도 overflow 카운트만 잡는다. function_declaration 은 extras[0] 이
+    // outer 에 노출되는 binding 이므로 일반 스캔 경로를 그대로 탄다.
+    const is_function_expression = node.tag != .function_declaration;
     var matching_shadows: usize = 0;
-    if (function_expression_self_name and functionExpressionNameImportShadowOverflow(ast, node, names, &matching_shadows)) return true;
+    if (is_function_expression and functionExpressionNameImportShadowOverflow(ast, node, names, &matching_shadows)) return true;
     if (bindingPatternImportShadowOverflow(ast, @enumFromInt(ast.extra_data.items[e + 1]), names, &matching_shadows)) return true;
     if (functionVarImportShadowOverflow(ast, @enumFromInt(ast.extra_data.items[e + 2]), names, &matching_shadows)) return true;
 
-    if (!function_expression_self_name and scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e]), names, scope_depth, inside_function)) return true;
+    if (!is_function_expression and scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e]), names, scope_depth, inside_function)) return true;
     if (scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e + 1]), names, scope_depth, inside_function)) return true;
     return scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e + 2]), names, scope_depth + 1, true);
 }
@@ -676,10 +683,10 @@ fn scanForUnsupportedBindingLiteShadow(
             if (bindingPatternImportShadowOverflow(ast, node.data.binary.left, names, &matching_shadows)) return true;
             return scanForUnsupportedBindingLiteShadow(ast, node.data.binary.right, names, scope_depth + 1, inside_function);
         },
-        .function_declaration => return scanFunctionForUnsupportedBindingLiteShadow(ast, node, names, scope_depth, inside_function, false),
+        .function_declaration,
         .function_expression,
         .function,
-        => return scanFunctionForUnsupportedBindingLiteShadow(ast, node, names, scope_depth, inside_function, true),
+        => return scanFunctionForUnsupportedBindingLiteShadow(ast, node, names, scope_depth, inside_function),
         .arrow_function_expression => {
             const e = node.data.extra;
             if (scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e]), names, scope_depth, inside_function)) return true;
@@ -862,10 +869,7 @@ fn collectBindingLiteFunctionVarShadows(ast: *const Ast, idx: ast_mod.NodeIndex,
 }
 
 fn collectBindingLiteFunctionExpressionNameShadow(ast: *const Ast, node: ast_mod.Node, lite: *const BindingLite, buf: [][]const u8, len: *usize) void {
-    if (node.tag != .function_expression and node.tag != .function) return;
-    const name_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[node.data.extra]);
-    if (name_idx.isNone()) return;
-    const name = ast.getText(ast.getNode(name_idx).span);
+    const name = functionExpressionInnerName(ast, node) orelse return;
     if (lite.namedImportValueUse(name) != null) appendBindingLiteShadowName(buf, len, name);
 }
 

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -548,6 +548,49 @@ fn bindingPatternImportShadowOverflow(ast: *const Ast, idx: ast_mod.NodeIndex, n
     return false;
 }
 
+fn functionExpressionNameImportShadowOverflow(ast: *const Ast, node: ast_mod.Node, names: []const []const u8, match_count: *usize) bool {
+    if (node.tag != .function_expression and node.tag != .function) return false;
+    const name_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[node.data.extra]);
+    if (name_idx.isNone()) return false;
+    const name = ast.getText(ast.getNode(name_idx).span);
+    if (string_list.contains(names, name)) {
+        match_count.* += 1;
+        if (match_count.* > binding_lite_max_shadows) return true;
+    }
+    return false;
+}
+
+fn functionVarImportShadowOverflow(ast: *const Ast, idx: ast_mod.NodeIndex, names: []const []const u8, match_count: *usize) bool {
+    if (idx.isNone()) return false;
+    const node = ast.getNode(idx);
+    switch (node.tag) {
+        .function_declaration,
+        .function_expression,
+        .function,
+        .arrow_function_expression,
+        => return false,
+        .variable_declaration => if (!ast.variableDeclarationKind(node).isLexical()) {
+            const list_start = ast.extra_data.items[node.data.extra + 1];
+            const list_len = ast.extra_data.items[node.data.extra + 2];
+            var i: u32 = 0;
+            while (i < list_len) : (i += 1) {
+                const decl_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[list_start + i]);
+                if (decl_idx.isNone()) continue;
+                const decl = ast.getNode(decl_idx);
+                if (decl.tag != .variable_declarator) continue;
+                if (bindingPatternImportShadowOverflow(ast, @enumFromInt(ast.extra_data.items[decl.data.extra]), names, match_count)) return true;
+            }
+        },
+        else => {},
+    }
+
+    var it = ast_walk.children(ast, node);
+    while (it.next()) |child_idx| {
+        if (functionVarImportShadowOverflow(ast, child_idx, names, match_count)) return true;
+    }
+    return false;
+}
+
 fn scanVariableDeclarationForUnsupportedBindingLiteShadow(
     ast: *const Ast,
     node: ast_mod.Node,
@@ -589,6 +632,25 @@ fn scanChildrenForUnsupportedBindingLiteShadow(
     return false;
 }
 
+fn scanFunctionForUnsupportedBindingLiteShadow(
+    ast: *const Ast,
+    node: ast_mod.Node,
+    names: []const []const u8,
+    scope_depth: usize,
+    inside_function: bool,
+    function_expression_self_name: bool,
+) bool {
+    const e = node.data.extra;
+    var matching_shadows: usize = 0;
+    if (function_expression_self_name and functionExpressionNameImportShadowOverflow(ast, node, names, &matching_shadows)) return true;
+    if (bindingPatternImportShadowOverflow(ast, @enumFromInt(ast.extra_data.items[e + 1]), names, &matching_shadows)) return true;
+    if (functionVarImportShadowOverflow(ast, @enumFromInt(ast.extra_data.items[e + 2]), names, &matching_shadows)) return true;
+
+    if (!function_expression_self_name and scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e]), names, scope_depth, inside_function)) return true;
+    if (scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e + 1]), names, scope_depth, inside_function)) return true;
+    return scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e + 2]), names, scope_depth + 1, true);
+}
+
 fn scanForUnsupportedBindingLiteShadow(
     ast: *const Ast,
     idx: ast_mod.NodeIndex,
@@ -614,15 +676,10 @@ fn scanForUnsupportedBindingLiteShadow(
             if (bindingPatternImportShadowOverflow(ast, node.data.binary.left, names, &matching_shadows)) return true;
             return scanForUnsupportedBindingLiteShadow(ast, node.data.binary.right, names, scope_depth + 1, inside_function);
         },
-        .function_declaration,
+        .function_declaration => return scanFunctionForUnsupportedBindingLiteShadow(ast, node, names, scope_depth, inside_function, false),
         .function_expression,
         .function,
-        => {
-            const e = node.data.extra;
-            if (scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e]), names, scope_depth, inside_function)) return true;
-            if (scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e + 1]), names, scope_depth, inside_function)) return true;
-            return scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e + 2]), names, scope_depth + 1, true);
-        },
+        => return scanFunctionForUnsupportedBindingLiteShadow(ast, node, names, scope_depth, inside_function, true),
         .arrow_function_expression => {
             const e = node.data.extra;
             if (scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e]), names, scope_depth, inside_function)) return true;
@@ -804,6 +861,14 @@ fn collectBindingLiteFunctionVarShadows(ast: *const Ast, idx: ast_mod.NodeIndex,
     }
 }
 
+fn collectBindingLiteFunctionExpressionNameShadow(ast: *const Ast, node: ast_mod.Node, lite: *const BindingLite, buf: [][]const u8, len: *usize) void {
+    if (node.tag != .function_expression and node.tag != .function) return;
+    const name_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[node.data.extra]);
+    if (name_idx.isNone()) return;
+    const name = ast.getText(ast.getNode(name_idx).span);
+    if (lite.namedImportValueUse(name) != null) appendBindingLiteShadowName(buf, len, name);
+}
+
 fn collectBindingLiteListLexicalShadows(ast: *const Ast, list: ast_mod.NodeList, lite: *const BindingLite, buf: [][]const u8, len: *usize) void {
     if (list.start + list.len > ast.extra_data.items.len) return;
     var i: u32 = 0;
@@ -868,12 +933,14 @@ fn markBindingLiteFunctionScope(
     ast: *const Ast,
     lite: *BindingLite,
     parent_shadowed: []const []const u8,
+    node: ast_mod.Node,
     params_idx: ast_mod.NodeIndex,
     body_idx: ast_mod.NodeIndex,
 ) void {
     var shadow_buf: [binding_lite_max_shadows][]const u8 = undefined;
     var shadow_len: usize = 0;
     for (parent_shadowed) |name| appendBindingLiteShadowName(&shadow_buf, &shadow_len, name);
+    collectBindingLiteFunctionExpressionNameShadow(ast, node, lite, &shadow_buf, &shadow_len);
     collectBindingLitePatternShadows(ast, params_idx, lite, &shadow_buf, &shadow_len);
     collectBindingLiteFunctionVarShadows(ast, body_idx, lite, &shadow_buf, &shadow_len);
     const combined = shadow_buf[0..shadow_len];
@@ -951,6 +1018,7 @@ fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *Bind
                 ast,
                 lite,
                 shadowed_names,
+                node,
                 @enumFromInt(ast.extra_data.items[e + 1]),
                 @enumFromInt(ast.extra_data.items[e + 2]),
             );
@@ -962,6 +1030,7 @@ fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *Bind
                 ast,
                 lite,
                 shadowed_names,
+                node,
                 @enumFromInt(ast.extra_data.items[e]),
                 @enumFromInt(ast.extra_data.items[e + 1]),
             );
@@ -1545,6 +1614,23 @@ test "TransformPlan: scope-local named import shadows stay on binding-lite route
             \\Foo();
             ,
         },
+        .{
+            .name = "named function expression self-name shadows import locally",
+            .source =
+            \\import { Foo, Bar } from "./lib";
+            \\const fn = function Foo() { return Foo; };
+            \\Foo();
+            \\Bar();
+            ,
+        },
+        .{
+            .name = "named function expression self-name shadows parameter default",
+            .source =
+            \\import { Foo, Bar } from "./lib";
+            \\const fn = function Foo(value = Foo) { return value; };
+            \\Bar();
+            ,
+        },
     };
 
     for (cases) |case| {
@@ -1588,6 +1674,23 @@ test "TransformPlan: ambiguous or overflowing named import shadows keep full sem
     );
     try std.testing.expectEqual(SemanticRequirement.bindings, function_var_shadow.semantic);
     try std.testing.expectEqual(SemanticPlanReason.named_import_binding_elision, function_var_shadow.reason);
+
+    var function_expression_overflow_source: std.ArrayList(u8) = .empty;
+    defer function_expression_overflow_source.deinit(std.testing.allocator);
+    try function_expression_overflow_source.appendSlice(std.testing.allocator, "import { Foo");
+    var j: usize = 0;
+    while (j < 64) : (j += 1) {
+        try function_expression_overflow_source.writer(std.testing.allocator).print(", I{d}", .{j});
+    }
+    try function_expression_overflow_source.appendSlice(std.testing.allocator, " } from './x';\nconst fn = function Foo(");
+    j = 0;
+    while (j < 64) : (j += 1) {
+        try function_expression_overflow_source.writer(std.testing.allocator).print("I{d},", .{j});
+    }
+    try function_expression_overflow_source.appendSlice(std.testing.allocator, ") { return Foo; };\n");
+    const function_expression_overflow_plan = try testTransformPlan(function_expression_overflow_source.items, "input.ts", .{});
+    try std.testing.expectEqual(SemanticRequirement.full, function_expression_overflow_plan.semantic);
+    try std.testing.expectEqual(SemanticPlanReason.binding_shadow_requires_full_semantic, function_expression_overflow_plan.reason);
 
     var overflow_source: std.ArrayList(u8) = .empty;
     defer overflow_source.deinit(std.testing.allocator);
@@ -1952,6 +2055,26 @@ test "TransformPlan parity: binding-lite named import elision matches full seman
             \\  if (ok) { var Foo = Bar(); }
             \\  return Foo;
             \\}
+            ,
+        },
+        .{
+            .name = "named function expression self-name does not keep import",
+            .source =
+            \\import { Foo, Bar } from "./lib";
+            \\export const fn = function Foo() {
+            \\  return Foo;
+            \\};
+            \\export const value = Bar();
+            ,
+        },
+        .{
+            .name = "named function expression self-name does not hide outer value use",
+            .source =
+            \\import { Foo, Bar } from "./lib";
+            \\export const fn = function Foo(value = Foo) {
+            \\  return value;
+            \\};
+            \\export const value = Foo() + Bar();
             ,
         },
         .{

--- a/tests/benchmark/profile.ts
+++ b/tests/benchmark/profile.ts
@@ -170,6 +170,11 @@ function printPlanHitRates(dir: string): void {
       source: `import { Foo, Bar } from "./lib";\nfunction f() { var Foo = Bar(); return Foo; }\nFoo();\n`,
     },
     {
+      name: "function-expression-shadow",
+      filename: "function-expression-shadow.ts",
+      source: `import { Foo, Bar } from "./lib";\nconst fn = function Foo(value = Foo) { return value; };\nBar();\n`,
+    },
+    {
       name: "js-source",
       filename: "plain.js",
       source: `const value = 1;\n`,


### PR DESCRIPTION
## 요약
- named function expression의 자기 이름을 semantic analyzer에서 별도 inner binding으로 등록해, parameter initializer/body 내부 참조가 외부 import로 잘못 resolve되지 않도록 수정했습니다.
- BindingLite shadow scanner/walker도 function expression self-name을 함수 scope shadow로 처리해 `.bindings` route를 탈 수 있게 확장했습니다.
- self-name + parameter + function-scope `var` shadow 합산이 `binding_lite_max_shadows`를 넘으면 기존처럼 full route로 보수 fallback합니다.

## 루트커즈
기존 full semantic은 `const fn = function Foo() { return Foo; }`의 body 내부 `Foo`를 function expression의 inner binding으로 등록하지 않았습니다. 그래서 같은 이름의 named import가 있으면 full route가 import를 사용된 값으로 오인했고, BindingLite만 확장하면 fast/full parity가 깨졌습니다.

이번 수정은 function expression name scope를 외부 scope와 분리하고, 그 안쪽에 실제 function scope를 둡니다. 이렇게 해야 `function Foo(value = Foo)`에서는 self-name을 볼 수 있고, `function Foo(Foo = Foo)`처럼 parameter가 같은 이름이면 parameter가 일반 lookup으로 shadow합니다.

## 검증
- `zig build test --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- `zig build napi -Doptimize=ReleaseFast --summary all`
- `bun test packages/core/index.test.ts --timeout 30000`
- `bun run tests/benchmark/profile.ts`
- `git diff --check`
- push 전 hook: `zig fmt --check`, `zig build test`, `oxlint`, `oxfmt --check` 통과

## Profile
`bun run tests/benchmark/profile.ts` 결과:

| Lines | Size (KB) | fast on (ms) | fast off (ms) | delta (ms) | ratio |
| --- | --- | --- | --- | --- | --- |
| 25000 | 1248 | 20 | 54 | 34 | 2.70x |
| 50000 | 2512 | 39 | 170 | 131 | 4.36x |
| 100000 | 5073 | 74 | 605 | 531 | 8.18x |

Representative route roots에서 `bindings | named_import_binding_elision` 샘플은 3/14로 증가했습니다.

Refs #2352
