### PR TITLE
refactor(transpile): unify binding-lite function-var walker via comptime visitor

### DIFF
--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -564,7 +564,15 @@ fn functionExpressionNameImportShadowOverflow(ast: *const Ast, node: ast_mod.Nod
     return false;
 }
 
-fn functionVarImportShadowOverflow(ast: *const Ast, idx: ast_mod.NodeIndex, names: []const []const u8, match_count: *usize) bool {
+// 함수 body 안에서 nested function/arrow 를 건너뛰며 non-lexical `var` 선언의 binding pattern 을
+// 모두 방문한다. visitor 가 true 를 반환하면 즉시 abort. overflow 검사 / shadow 수집 두 사용처가
+// 동일 트리 순회를 공유하도록 모은 헬퍼.
+fn walkFunctionVarBindingPatterns(
+    ast: *const Ast,
+    idx: ast_mod.NodeIndex,
+    ctx: anytype,
+    comptime onBindingPattern: fn (@TypeOf(ctx), ast_mod.NodeIndex) bool,
+) bool {
     if (idx.isNone()) return false;
     const node = ast.getNode(idx);
     switch (node.tag) {
@@ -582,7 +590,7 @@ fn functionVarImportShadowOverflow(ast: *const Ast, idx: ast_mod.NodeIndex, name
                 if (decl_idx.isNone()) continue;
                 const decl = ast.getNode(decl_idx);
                 if (decl.tag != .variable_declarator) continue;
-                if (bindingPatternImportShadowOverflow(ast, @enumFromInt(ast.extra_data.items[decl.data.extra]), names, match_count)) return true;
+                if (onBindingPattern(ctx, @enumFromInt(ast.extra_data.items[decl.data.extra]))) return true;
             }
         },
         else => {},
@@ -590,9 +598,28 @@ fn functionVarImportShadowOverflow(ast: *const Ast, idx: ast_mod.NodeIndex, name
 
     var it = ast_walk.children(ast, node);
     while (it.next()) |child_idx| {
-        if (functionVarImportShadowOverflow(ast, child_idx, names, match_count)) return true;
+        if (walkFunctionVarBindingPatterns(ast, child_idx, ctx, onBindingPattern)) return true;
     }
     return false;
+}
+
+fn functionVarImportShadowOverflow(ast: *const Ast, idx: ast_mod.NodeIndex, names: []const []const u8, match_count: *usize) bool {
+    const Ctx = struct {
+        ast: *const Ast,
+        names: []const []const u8,
+        match_count: *usize,
+    };
+    const visit = struct {
+        fn onBindingPattern(c: Ctx, binding_idx: ast_mod.NodeIndex) bool {
+            return bindingPatternImportShadowOverflow(c.ast, binding_idx, c.names, c.match_count);
+        }
+    }.onBindingPattern;
+    return walkFunctionVarBindingPatterns(
+        ast,
+        idx,
+        Ctx{ .ast = ast, .names = names, .match_count = match_count },
+        visit,
+    );
 }
 
 fn scanVariableDeclarationForUnsupportedBindingLiteShadow(
@@ -847,25 +874,25 @@ fn collectBindingLiteVariableDeclarationShadows(ast: *const Ast, node: ast_mod.N
 }
 
 fn collectBindingLiteFunctionVarShadows(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *const BindingLite, buf: [][]const u8, len: *usize) void {
-    if (idx.isNone()) return;
-    if (len.* >= buf.len) return;
-    const node = ast.getNode(idx);
-    switch (node.tag) {
-        .function_declaration,
-        .function_expression,
-        .function,
-        .arrow_function_expression,
-        => return,
-        .variable_declaration => if (!ast.variableDeclarationKind(node).isLexical()) {
-            collectBindingLiteVariableDeclarationShadows(ast, node, lite, buf, len);
-        },
-        else => {},
-    }
-
-    var it = ast_walk.children(ast, node);
-    while (it.next()) |child_idx| {
-        collectBindingLiteFunctionVarShadows(ast, child_idx, lite, buf, len);
-    }
+    const Ctx = struct {
+        ast: *const Ast,
+        lite: *const BindingLite,
+        buf: [][]const u8,
+        len: *usize,
+    };
+    const visit = struct {
+        fn onBindingPattern(c: Ctx, binding_idx: ast_mod.NodeIndex) bool {
+            collectBindingLitePatternShadows(c.ast, binding_idx, c.lite, c.buf, c.len);
+            // buf 가 가득 차면 더 append 해도 silent drop 이라 더 순회할 이유가 없다.
+            return c.len.* >= c.buf.len;
+        }
+    }.onBindingPattern;
+    _ = walkFunctionVarBindingPatterns(
+        ast,
+        idx,
+        Ctx{ .ast = ast, .lite = lite, .buf = buf, .len = len },
+        visit,
+    );
 }
 
 fn collectBindingLiteFunctionExpressionNameShadow(ast: *const Ast, node: ast_mod.Node, lite: *const BindingLite, buf: [][]const u8, len: *usize) void {


### PR DESCRIPTION
## 요약
- `functionVarImportShadowOverflow` 와 `collectBindingLiteFunctionVarShadows` 가 동일한 트리 순회 (function/arrow 진입 차단 + 비-lexical `var` declarator 만 방문) 를 평행하게 중복 구현하고 있었다.
- 새 `walkFunctionVarBindingPatterns` 헬퍼 가 recursion + tag 차단 + var-list 반복 을 한 곳으로 모으고, 두 호출자는 자기 leaf action 만 comptime visitor 로 주입한다.
- 미래에 차단 태그 추가 / `var` layout 변화 가 일어나도 한 곳만 손보면 된다.

## 컨텍스트
직전 #2424 리뷰에서 reuse agent 가 "두 walker 가 구조적 쌍둥이" 라고 짚었다. 본 PR 직접 변경 범위 밖이라 별도 follow-up 으로 분리.

## 디자인 노트 (Zig 초보자용)
- `walkFunctionVarBindingPatterns(ast, idx, ctx: anytype, comptime onBindingPattern: fn (@TypeOf(ctx), NodeIndex) bool) bool` 가 핵심.
- `comptime fn` 파라미터 라 visitor 는 호출자 별로 monomorphize 된다 → 런타임 dispatch 비용 0, 일반 함수 호출처럼 인라인 가능.
- `ctx` 는 호출자 로컬 struct (`Ctx{...}`). 익명 closure 가 없는 Zig 에서 캡처를 명시 struct 로 모은 패턴.
- visitor 가 `true` 를 반환하면 walker 가 즉시 조기 종료. overflow 검사는 카운터 초과 시 true, 수집 검사는 buf 가 가득 차면 true.

## 동작 동등성
- `functionVarImportShadowOverflow`: visitor 가 기존 `bindingPatternImportShadowOverflow` 호출을 그대로 위임 — 시맨틱 동일.
- `collectBindingLiteFunctionVarShadows`: 기존 코드는 함수 진입부에 `if (idx.isNone()) return; if (len.* >= buf.len) return;` 가드가 있었다. walker 가 `idx.isNone()` 을 자체 처리하고, `len.* >= buf.len` 은 visitor 가 첫 append 시 true 반환으로 처리해 의미 동일. `appendBindingLiteShadowName` 자체가 buf full 시 silent no-op 라 결과 동일.

## 검증
- `zig fmt --check src/transpile.zig`
- `zig build test --summary all` — 4518/4518 통과
- `zig build -Doptimize=ReleaseFast --summary all`
- `zig build napi -Doptimize=ReleaseFast --summary all`
- `bun test packages/core/index.test.ts --timeout 30000` — 369/0
- `bun run tests/benchmark/profile.ts` — fast/full delta·plan hit rate 표 #2424 측정값 그대로

## Profile (회귀 없음)
| Lines | fast on (ms) | fast off (ms) | ratio |
| --- | --- | --- | --- |
| 25000 | 20 | 54 | 2.70x |
| 50000 | 39 | 172 | 4.41x |
| 100000 | 73 | 605 | 8.29x |

대표 route plan hit rates 도 `bindings | named_import_binding_elision: 3/14` 그대로.

Refs #2424