### PR TITLE
fix(transformer): apply slice-realloc fix to 7 sibling sites (#2426)

### DIFF
--- a/src/transformer/es2015_block_scoping.zig
+++ b/src/transformer/es2015_block_scoping.zig
@@ -410,13 +410,13 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
                 return transformStmtFlow(self, body_idx, flow, 0, 0);
             }
 
-            const list = body.data.list;
             const scratch_top = self.scratch.items.len;
             defer self.scratch.shrinkRetainingCapacity(scratch_top);
 
-            const stmts = self.ast.extra_data.items[list.start .. list.start + list.len];
-            for (stmts) |raw| {
-                const transformed = try transformStmtFlow(self, @enumFromInt(raw), flow, 0, 0);
+            // realloc-safe — transformStmtFlow 재귀가 addNode/addNodeList 로 extra_data grow 가능 (#2426).
+            var iter = self.ast.iterateExtraList(body.data.list);
+            while (iter.next()) |stmt| {
+                const transformed = try transformStmtFlow(self, stmt, flow, 0, 0);
                 try self.scratch.append(self.allocator, transformed);
             }
 
@@ -533,12 +533,12 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
 
                 // block_statement: 내부 문들을 재귀 변환
                 .block_statement => {
-                    const list = node.data.list;
                     const scratch_top = self.scratch.items.len;
                     defer self.scratch.shrinkRetainingCapacity(scratch_top);
-                    const stmts = self.ast.extra_data.items[list.start .. list.start + list.len];
-                    for (stmts) |raw| {
-                        try self.scratch.append(self.allocator, try transformStmtFlow(self, @enumFromInt(raw), flow, loop_depth, switch_depth));
+                    // realloc-safe — transformStmtFlow 재귀가 extra_data grow 가능 (#2426).
+                    var iter = self.ast.iterateExtraList(node.data.list);
+                    while (iter.next()) |stmt| {
+                        try self.scratch.append(self.allocator, try transformStmtFlow(self, stmt, flow, loop_depth, switch_depth));
                     }
                     const new_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
                     return self.ast.addNode(.{

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -328,19 +328,21 @@ fn rewriteTDZReferencesInner(self: anytype, idx: NodeIndex, tdz_names: []const S
             try rewriteTDZReferencesInner(self, node.data.ternary.c, tdz_names);
         },
         .list => {
-            const items = self.ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
-            for (items) |child_raw| try rewriteTDZReferencesInner(self, @enumFromInt(child_raw), tdz_names);
+            // realloc-safe — TDZ name 매칭 시 makeTDZCall → makeStaticMember → addExtras 가
+            // extra_data 를 grow 시켜 캡처된 slice invalid (#2426).
+            var iter = self.ast.iterateExtraList(node.data.list);
+            while (iter.next()) |child| try rewriteTDZReferencesInner(self, child, tdz_names);
         },
         .extra => {
             const e = node.data.extra;
             for (Node.Tag.extraChildOffsets(node.tag)) |offset| {
-                try rewriteTDZReferencesInner(self, @enumFromInt(self.ast.extra_data.items[e + offset]), tdz_names);
+                try rewriteTDZReferencesInner(self, self.ast.readExtraNode(e, offset), tdz_names);
             }
             for (Node.Tag.extraListOffsets(node.tag)) |pair| {
-                const start = self.ast.extra_data.items[e + pair[0]];
-                const len = self.ast.extra_data.items[e + pair[1]];
-                const items = self.ast.extra_data.items[start .. start + len];
-                for (items) |child_raw| try rewriteTDZReferencesInner(self, @enumFromInt(child_raw), tdz_names);
+                const start = self.ast.readExtra(e, pair[0]);
+                const len = self.ast.readExtra(e, pair[1]);
+                var iter = self.ast.iterateExtraList(.{ .start = start, .len = len });
+                while (iter.next()) |child| try rewriteTDZReferencesInner(self, child, tdz_names);
             }
         },
     }

--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -1938,8 +1938,10 @@ fn rewriteArrayUnused(ast: *Ast, ctx: MinifyCtx, ni: u32, node: Node, changed: *
     var kept: std.ArrayListUnmanaged(NodeIndex) = .empty;
     defer kept.deinit(ast.allocator);
 
-    for (indices) |raw| {
-        const idx: NodeIndex = @enumFromInt(raw);
+    // realloc-safe 순회 — simplifyUnusedInPlace 재귀가 reduceToSequenceExpr → extra_data grow
+    // → ArrayList realloc → 캡처된 indices slice invalid (#2422 동일 패턴, #2426).
+    var iter = ast.iterateExtraList(list);
+    while (iter.next()) |idx| {
         // array hole — NodeIndex.none — drop
         if (idx.isNone()) continue;
         const child_rem = simplifyUnusedInPlace(ast, ctx, idx, changed, depth + 1);
@@ -1978,8 +1980,9 @@ fn rewriteCallOrNewUnused(ast: *Ast, ctx: MinifyCtx, ni: u32, node: Node, change
     var kept: std.ArrayListUnmanaged(NodeIndex) = .empty;
     defer kept.deinit(ast.allocator);
 
-    for (ast.extra_data.items[args_start .. args_start + args_len]) |raw| {
-        const idx: NodeIndex = @enumFromInt(raw);
+    // realloc-safe 순회 — simplifyUnusedInPlace 재귀가 extra_data grow 가능 (#2426).
+    var iter = ast.iterateExtraList(.{ .start = args_start, .len = args_len });
+    while (iter.next()) |idx| {
         if (idx.isNone()) continue;
         const child_rem = simplifyUnusedInPlace(ast, ctx, idx, changed, depth + 1);
         if (child_rem) continue;
@@ -2030,8 +2033,11 @@ fn rewriteObjectUnused(ast: *Ast, ctx: MinifyCtx, ni: u32, node: Node, changed: 
     var kept: std.ArrayListUnmanaged(NodeIndex) = .empty;
     defer kept.deinit(ast.allocator);
 
-    for (props) |raw| {
-        const prop = ast.nodes.items[raw];
+    // realloc-safe 순회 — simplifyUnusedInPlace 재귀가 extra_data grow 가능 (#2426).
+    var iter = ast.iterateExtraList(list);
+    while (iter.next()) |prop_idx| {
+        const prop_ni = @intFromEnum(prop_idx);
+        const prop = ast.nodes.items[prop_ni];
 
         switch (prop.tag) {
             .object_property => {

--- a/tests/integration/tests/fixtures/rn-example-app/zts-hermes.js
+++ b/tests/integration/tests/fixtures/rn-example-app/zts-hermes.js
@@ -3610,7 +3610,7 @@ var init_react_native_Libraries_vendor_emitter_EventEmitter = __esm({
 	EventEmitter = (function() {
 		var _registry = new WeakMap();
 		function EventEmitter() {
-			__classCallCheck(this, EventEmitter);
+			ªªªªªªªªªªªªªªªª(this, EventEmitter);
 			_registry.set(this, void 0);
 			__classPrivateFieldSet(_registry, this, {});
 		}
@@ -3733,7 +3733,7 @@ var init_react_native_Libraries_EventEmitter_RCTDeviceEventEmitter = __esm({
 	
 	RCTDeviceEventEmitterImpl = (function(_super) {
 		function RCTDeviceEventEmitterImpl() {
-			__classCallCheck(this, RCTDeviceEventEmitterImpl);
+			ªªªªªªªªªªªªªªªª(this, RCTDeviceEventEmitterImpl);
 			var _newTarget = this.constructor;
 			return __callSuper(_super, arguments, _newTarget);
 		}
@@ -3817,7 +3817,7 @@ var init_react_native_Libraries_Utilities_Dimensions = __esm({
 	dimensions = void 0;
 	Dimensions = (function() {
 		function Dimensions() {
-			__classCallCheck(this, Dimensions);
+			ªªªªªªªªªªªªªªªª(this, Dimensions);
 		}
 		Object.defineProperty(Dimensions, "get", { configurable: true, writable: true, value: function(dim) {
 			invariant$7(dimensions[dim], "No dimension set for key " + dim);
@@ -3878,7 +3878,7 @@ var init_react_native_Libraries_Utilities_PixelRatio = __esm({
 	Dimensions$1 = (init_react_native_Libraries_Utilities_Dimensions(), __toCommonJS(exports_react_native_Libraries_Utilities_Dimensions)).default;
 	PixelRatio = (function() {
 		function PixelRatio() {
-			__classCallCheck(this, PixelRatio);
+			ªªªªªªªªªªªªªªªª(this, PixelRatio);
 		}
 		Object.defineProperty(PixelRatio, "get", { configurable: true, writable: true, value: function() {
 			return Dimensions$1.get("window").scale;
@@ -4419,7 +4419,7 @@ var init_react_native_Libraries_Image_AssetSourceResolver = __esm({
 	;
 	AssetSourceResolver = (function() {
 		function AssetSourceResolver(serverUrl,jsbundleUrl,asset) {
-			__classCallCheck(this, AssetSourceResolver);
+			ªªªªªªªªªªªªªªªª(this, AssetSourceResolver);
 			this.serverUrl = serverUrl;
 			this.jsbundleUrl = jsbundleUrl;
 			this.asset = asset;
@@ -5914,7 +5914,7 @@ var init_react_native_src_private_devsupport_rndevtools_FuseboxSessionObserver =
 	FuseboxSessionObserver = (function() {
 		var _hasNativeSupport = new WeakMap();
 		function FuseboxSessionObserver() {
-			__classCallCheck(this, FuseboxSessionObserver);
+			ªªªªªªªªªªªªªªªª(this, FuseboxSessionObserver);
 			_hasNativeSupport.set(this, void 0);
 			__classPrivateFieldSet(_hasNativeSupport, this, global.hasOwnProperty("__DEBUGGER_SESSION_OBSERVER__"));
 		}
@@ -6790,7 +6790,7 @@ var init_react_native_Libraries_LogBox_Data_LogBoxLog = __esm({
 	LogBoxSymbolication=__toESM((init_react_native_Libraries_LogBox_Data_LogBoxSymbolication(), __toCommonJS(exports_react_native_Libraries_LogBox_Data_LogBoxSymbolication)));
 	LogBoxLog = (function() {
 		function LogBoxLog(data) {
-			__classCallCheck(this, LogBoxLog);
+			ªªªªªªªªªªªªªªªª(this, LogBoxLog);
 			this.symbolicated = { error: null, stack: null, status: "NONE" };
 			this.symbolicatedComponentStack = { error: null, componentStack: null, status: "NONE" };
 			this.level = data.level;
@@ -7531,7 +7531,7 @@ var init_react_native_Libraries_LogBox_Data_LogBoxData = __esm({
 	withSubscription = function(WrappedComponent) {
 		var LogBoxStateSubscription = (function(_super) {
 			function LogBoxStateSubscription() {
-				__classCallCheck(this, LogBoxStateSubscription);
+				ªªªªªªªªªªªªªªªª(this, LogBoxStateSubscription);
 				var _newTarget = this.constructor,_this = __callSuper(_super, arguments, _newTarget);
 				;
 				_this.state = { logs: new Set(), isDisabled: false, hasError: false, selectedLogIndex: -1 };
@@ -7789,7 +7789,7 @@ var init_react_native_Libraries_Core_ExceptionsManager = __esm({
 	"use strict";
 	SyntheticError = (function(_super) {
 		function SyntheticError() {
-			__classCallCheck(this, SyntheticError);
+			ªªªªªªªªªªªªªªªª(this, SyntheticError);
 			var _newTarget = this.constructor,_this = __callSuper(_super, arguments, _newTarget);
 			;
 			_this.name = "";
@@ -8394,7 +8394,7 @@ var init_react_native_src_private_webapis_dom_events_Event = __esm({
 	
 	Event = (function() {
 		function Event(type,options) {
-			__classCallCheck(this, Event);
+			ªªªªªªªªªªªªªªªª(this, Event);
 			this._defaultPrevented = false;
 			this._timeStamp = performance.now();
 			this[COMPOSED_PATH_KEY] = [];
@@ -8530,7 +8530,7 @@ var init_react_native_src_private_webapis_dom_events_CustomEvent = __esm({
 	
 	CustomEvent = (function(_super) {
 		function CustomEvent(type,options) {
-			__classCallCheck(this, CustomEvent);
+			ªªªªªªªªªªªªªªªª(this, CustomEvent);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [type, options], _newTarget);
@@ -8912,7 +8912,7 @@ var init_react_native_src_private_webapis_dom_oldstylecollections_HTMLCollection
 	HTMLCollection = (function() {
 		var _a = Symbol.iterator;
 		function HTMLCollection(elements) {
-			__classCallCheck(this, HTMLCollection);
+			ªªªªªªªªªªªªªªªª(this, HTMLCollection);
 			for (var i = 0; i < elements.length; i++) {
 				REUSABLE_PROPERTY_DESCRIPTOR.value = elements[i];
 				Object.defineProperty(this, i, REUSABLE_PROPERTY_DESCRIPTOR);
@@ -8982,7 +8982,7 @@ var init_react_native_src_private_webapis_dom_nodes_internals_ReactNativeDocumen
 		
 	ReactNativeDocumentElementInstanceHandleImpl = (function() {
 		function ReactNativeDocumentElementInstanceHandleImpl() {
-			__classCallCheck(this, ReactNativeDocumentElementInstanceHandleImpl);
+			ªªªªªªªªªªªªªªªª(this, ReactNativeDocumentElementInstanceHandleImpl);
 		}
 		return ReactNativeDocumentElementInstanceHandleImpl;
 	})();
@@ -9142,7 +9142,7 @@ var init_react_native_src_private_webapis_geometry_DOMRectReadOnly = __esm({
 	DOMRectReadOnly = (function() {
 		var _x = new WeakMap(),_y = new WeakMap(),_width = new WeakMap(),_height = new WeakMap();
 		function DOMRectReadOnly(x,y,width,height) {
-			__classCallCheck(this, DOMRectReadOnly);
+			ªªªªªªªªªªªªªªªª(this, DOMRectReadOnly);
 			_x.set(this, void 0);
 			_y.set(this, void 0);
 			_width.set(this, void 0);
@@ -9256,7 +9256,7 @@ var init_react_native_src_private_webapis_geometry_DOMRect = __esm({
 	
 	DOMRect = (function(_super) {
 		function DOMRect() {
-			__classCallCheck(this, DOMRect);
+			ªªªªªªªªªªªªªªªª(this, DOMRect);
 			var _newTarget = this.constructor;
 			return __callSuper(_super, arguments, _newTarget);
 		}
@@ -9317,7 +9317,7 @@ var init_react_native_src_private_webapis_dom_oldstylecollections_NodeList = __e
 	NodeList = (function() {
 		var _a = Symbol.iterator;
 		function NodeList(elements) {
-			__classCallCheck(this, NodeList);
+			ªªªªªªªªªªªªªªªª(this, NodeList);
 			for (var i = 0; i < elements.length; i++) {
 				REUSABLE_PROPERTY_DESCRIPTOR$1.value = elements[i];
 				Object.defineProperty(this, i, REUSABLE_PROPERTY_DESCRIPTOR$1);
@@ -9448,7 +9448,7 @@ var init_react_native_src_private_webapis_dom_nodes_ReadOnlyNode = __esm({
 	
 	ReadOnlyNode = (function() {
 		function ReadOnlyNode(instanceHandle,ownerDocument) {
-			__classCallCheck(this, ReadOnlyNode);
+			ªªªªªªªªªªªªªªªª(this, ReadOnlyNode);
 			setOwnerDocument(this, ownerDocument);
 			setInstanceHandle(this, instanceHandle);
 		}
@@ -9653,7 +9653,7 @@ var init_react_native_src_private_webapis_dom_nodes_ReadOnlyElement = __esm({
 	
 	ReadOnlyElement = (function(_super) {
 		function ReadOnlyElement() {
-			__classCallCheck(this, ReadOnlyElement);
+			ªªªªªªªªªªªªªªªª(this, ReadOnlyElement);
 			var _newTarget = this.constructor;
 			return __callSuper(_super, arguments, _newTarget);
 		}
@@ -9859,7 +9859,7 @@ var init_react_native_src_private_webapis_dom_nodes_ReactNativeElement = __esm({
 	};
 	ReactNativeElement = (function(_super) {
 		function ReactNativeElement(tag,viewConfig,instanceHandle,ownerDocument) {
-			__classCallCheck(this, ReactNativeElement);
+			ªªªªªªªªªªªªªªªª(this, ReactNativeElement);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [instanceHandle, ownerDocument], _newTarget);
@@ -9998,7 +9998,7 @@ var init_react_native_src_private_webapis_dom_nodes_ReactNativeDocument = __esm(
 	
 	ReactNativeDocument = (function(_super) {
 		function ReactNativeDocument(rootTag,instanceHandle) {
-			__classCallCheck(this, ReactNativeDocument);
+			ªªªªªªªªªªªªªªªª(this, ReactNativeDocument);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [instanceHandle, null], _newTarget);
@@ -10073,7 +10073,7 @@ var init_react_native_src_private_webapis_dom_nodes_ReadOnlyCharacterData = __es
 	
 	ReadOnlyCharacterData = (function(_super) {
 		function ReadOnlyCharacterData() {
-			__classCallCheck(this, ReadOnlyCharacterData);
+			ªªªªªªªªªªªªªªªª(this, ReadOnlyCharacterData);
 			var _newTarget = this.constructor;
 			return __callSuper(_super, arguments, _newTarget);
 		}
@@ -10138,7 +10138,7 @@ var init_react_native_src_private_webapis_dom_nodes_ReadOnlyText = __esm({
 	
 	ReadOnlyText = (function(_super) {
 		function ReadOnlyText() {
-			__classCallCheck(this, ReadOnlyText);
+			ªªªªªªªªªªªªªªªª(this, ReadOnlyText);
 			var _newTarget = this.constructor;
 			return __callSuper(_super, arguments, _newTarget);
 		}
@@ -10326,7 +10326,7 @@ var init_react_native_src_private_webapis_geometry_DOMRectList = __esm({
 	DOMRectList = (function() {
 		var _a = Symbol.iterator,_length = new WeakMap();
 		function DOMRectList(elements) {
-			__classCallCheck(this, DOMRectList);
+			ªªªªªªªªªªªªªªªª(this, DOMRectList);
 			_length.set(this, void 0);
 			for (var i = 0; i < elements.length; i++) {
 				Object.defineProperty(this, i, { value: elements[i], enumerable: true, configurable: false, writable: false });
@@ -10435,7 +10435,7 @@ var init_react_native_src_private_webapis_errors_DOMException = __esm({
 	DOMException = (function(_super) {
 		var _name = new WeakMap(),_code = new WeakMap();
 		function DOMException(message,name) {
-			__classCallCheck(this, DOMException);
+			ªªªªªªªªªªªªªªªª(this, DOMException);
 			var _newTarget = this.constructor,_this;
 			;
 			{
@@ -10749,7 +10749,7 @@ var init_react_native_src_private_webapis_performance_PerformanceEntry = __esm({
 	
 	PerformanceEntry = (function() {
 		function PerformanceEntry(entryType,init) {
-			__classCallCheck(this, PerformanceEntry);
+			ªªªªªªªªªªªªªªªª(this, PerformanceEntry);
 			this.__entryType = entryType;
 			this.__name = init.name;
 			this.__startTime = init.startTime;
@@ -10837,7 +10837,7 @@ var init_react_native_src_private_webapis_performance_EventTiming = __esm({
 	PerformanceEventTiming = (function(_super) {
 		var _processingStart = new WeakMap(),_processingEnd = new WeakMap(),_interactionId = new WeakMap();
 		function PerformanceEventTiming(init) {
-			__classCallCheck(this, PerformanceEventTiming);
+			ªªªªªªªªªªªªªªªª(this, PerformanceEventTiming);
 			var _newTarget = this.constructor,_this;
 			;
 			{
@@ -10879,7 +10879,7 @@ var init_react_native_src_private_webapis_performance_EventTiming = __esm({
 	cachedEventCounts = void 0;
 	EventCounts = (function() {
 		function EventCounts() {
-			__classCallCheck(this, EventCounts);
+			ªªªªªªªªªªªªªªªª(this, EventCounts);
 		}
 		Object.defineProperty(EventCounts.prototype, "entries", { configurable: true, writable: true, value: function() {
 			return getCachedEventCounts().entries();
@@ -10936,7 +10936,7 @@ var init_react_native_src_private_webapis_performance_LongTasks = __esm({
 	
 	TaskAttributionTiming = (function(_super) {
 		function TaskAttributionTiming() {
-			__classCallCheck(this, TaskAttributionTiming);
+			ªªªªªªªªªªªªªªªª(this, TaskAttributionTiming);
 			var _newTarget = this.constructor;
 			return __callSuper(_super, arguments, _newTarget);
 		}
@@ -10951,7 +10951,7 @@ var init_react_native_src_private_webapis_performance_LongTasks = __esm({
 	EMPTY_ATTRIBUTION = Object.preventExtensions([]);
 	PerformanceLongTaskTiming = (function(_super) {
 		function PerformanceLongTaskTiming(init) {
-			__classCallCheck(this, PerformanceLongTaskTiming);
+			ªªªªªªªªªªªªªªªª(this, PerformanceLongTaskTiming);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, ["longtask", init], _newTarget);
@@ -11000,7 +11000,7 @@ var init_react_native_src_private_webapis_performance_ResourceTiming = __esm({
 	PerformanceResourceTiming = (function(_super) {
 		var _fetchStart = new WeakMap(),_requestStart = new WeakMap(),_connectStart = new WeakMap(),_connectEnd = new WeakMap(),_responseStart = new WeakMap(),_responseEnd = new WeakMap(),_responseStatus = new WeakMap(),_contentType = new WeakMap(),_encodedBodySize = new WeakMap(),_decodedBodySize = new WeakMap();
 		function PerformanceResourceTiming(init) {
-			__classCallCheck(this, PerformanceResourceTiming);
+			ªªªªªªªªªªªªªªªª(this, PerformanceResourceTiming);
 			var _newTarget = this.constructor,_this;
 			;
 			{
@@ -11119,7 +11119,7 @@ var init_react_native_src_private_webapis_performance_UserTiming = __esm({
 	
 	PerformanceMarkTemplate = (function(_super) {
 		function PerformanceMarkTemplate(markName,markOptions) {
-			__classCallCheck(this, PerformanceMarkTemplate);
+			ªªªªªªªªªªªªªªªª(this, PerformanceMarkTemplate);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, ["mark", { name: markName, startTime: (_a = (markOptions == null ? void 0 : markOptions.startTime)) != null ? _a : getCurrentTimeStamp(), duration: 0 }], _newTarget);
@@ -11146,7 +11146,7 @@ var init_react_native_src_private_webapis_performance_UserTiming = __esm({
 	PerformanceMark.prototype = PerformanceMarkTemplate.prototype;
 	PerformanceMeasureTemplate = (function(_super) {
 		function PerformanceMeasureTemplate(init) {
-			__classCallCheck(this, PerformanceMeasureTemplate);
+			ªªªªªªªªªªªªªªªª(this, PerformanceMeasureTemplate);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, ["measure", init], _newTarget);
@@ -11269,7 +11269,7 @@ var init_react_native_src_private_webapis_performance_MemoryInfo = __esm({
 	MemoryInfo = (function() {
 		var _jsHeapSizeLimit = new WeakMap(),_totalJSHeapSize = new WeakMap(),_usedJSHeapSize = new WeakMap();
 		function MemoryInfo(memoryInfo) {
-			__classCallCheck(this, MemoryInfo);
+			ªªªªªªªªªªªªªªªª(this, MemoryInfo);
 			_jsHeapSizeLimit.set(this, void 0);
 			_totalJSHeapSize.set(this, void 0);
 			_usedJSHeapSize.set(this, void 0);
@@ -11313,7 +11313,7 @@ var init_react_native_src_private_webapis_performance_ReactNativeStartupTiming =
 	ReactNativeStartupTiming = (function() {
 		var _startTime = new WeakMap(),_initializeRuntimeStart = new WeakMap(),_executeJavaScriptBundleEntryPointStart = new WeakMap(),_endTime = new WeakMap();
 		function ReactNativeStartupTiming(startUpTiming) {
-			__classCallCheck(this, ReactNativeStartupTiming);
+			ªªªªªªªªªªªªªªªª(this, ReactNativeStartupTiming);
 			_startTime.set(this, void 0);
 			_initializeRuntimeStart.set(this, void 0);
 			_executeJavaScriptBundleEntryPointStart.set(this, void 0);
@@ -11387,7 +11387,7 @@ var init_react_native_src_private_webapis_performance_Performance = __esm({
 	Performance = (function() {
 		var _eventCounts = new WeakMap();
 		function Performance() {
-			__classCallCheck(this, Performance);
+			ªªªªªªªªªªªªªªªª(this, Performance);
 			_eventCounts.set(this, new EventCounts());
 			this.now = getCurrentTimeStamp;
 		}
@@ -11699,7 +11699,7 @@ var init_react_native_src_private_webapis_performance_PerformanceObserver = __es
 	PerformanceObserverEntryList = (function() {
 		var _entries = new WeakMap();
 		function PerformanceObserverEntryList(entries) {
-			__classCallCheck(this, PerformanceObserverEntryList);
+			ªªªªªªªªªªªªªªªª(this, PerformanceObserverEntryList);
 			_entries.set(this, void 0);
 			__classPrivateFieldSet(_entries, this, entries);
 		}
@@ -11774,7 +11774,7 @@ var init_react_native_src_private_webapis_performance_PerformanceObserver = __es
 			}
 		}
 		function PerformanceObserver(callback) {
-			__classCallCheck(this, PerformanceObserver);
+			ªªªªªªªªªªªªªªªª(this, PerformanceObserver);
 			_nativeObserverHandle.set(this, null);
 			_callback.set(this, void 0);
 			_type.set(this, void 0);
@@ -13043,7 +13043,7 @@ init_extends();
 	}
 	var PrettyFormatPluginError = (function(_super) {
 		function PrettyFormatPluginError(message,stack) {
-			__classCallCheck(this, PrettyFormatPluginError);
+			ªªªªªªªªªªªªªªªª(this, PrettyFormatPluginError);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [message], _newTarget);
@@ -14321,7 +14321,7 @@ var init_react_native_src_private_webapis_dom_events_EventTarget = __esm({
 	EventTarget = (function() {
 		var _a = EVENT_TARGET_GET_THE_PARENT_KEY,_b = INTERNAL_DISPATCH_METHOD_KEY;
 		function EventTarget() {
-			__classCallCheck(this, EventTarget);
+			ªªªªªªªªªªªªªªªª(this, EventTarget);
 		}
 		Object.defineProperty(EventTarget.prototype, "addEventListener", { configurable: true, writable: true, value: function(type,callback,optionsOrUseCapture) {
 			optionsOrUseCapture = optionsOrUseCapture === void 0 ? {} : optionsOrUseCapture;
@@ -14454,7 +14454,7 @@ var init_react_native_src_private_webapis_xhr_events_ProgressEvent = __esm({
 	
 	ProgressEvent = (function(_super) {
 		function ProgressEvent(type,options) {
-			__classCallCheck(this, ProgressEvent);
+			ªªªªªªªªªªªªªªªª(this, ProgressEvent);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [type, options], _newTarget);
@@ -14550,7 +14550,7 @@ var init_react_native_Libraries_Blob_Blob = __esm({
 	"use strict";
 	Blob$1 = (function() {
 		function Blob(parts,options) {
-			__classCallCheck(this, Blob);
+			ªªªªªªªªªªªªªªªª(this, Blob);
 			parts = parts === void 0 ? [] : parts;
 			var BlobManager = (init_react_native_Libraries_Blob_BlobManager(), __toCommonJS(exports_react_native_Libraries_Blob_BlobManager)).default;
 			this.data = BlobManager.createFromParts(parts, options).data;
@@ -14671,7 +14671,7 @@ var init_react_native_Libraries_Blob_BlobManager = __esm({
 	;
 	BlobManager = (function() {
 		function BlobManager() {
-			__classCallCheck(this, BlobManager);
+			ªªªªªªªªªªªªªªªª(this, BlobManager);
 		}
 		Object.defineProperty(BlobManager, "createFromParts", { configurable: true, writable: true, value: function(parts,options) {
 			invariant$13(NativeBlobModule, "NativeBlobModule is available.");
@@ -14751,7 +14751,7 @@ var init_react_native_Libraries_Utilities_createPerformanceLogger = __esm({
 	});
 	PerformanceLogger = (function() {
 		function PerformanceLogger() {
-			__classCallCheck(this, PerformanceLogger);
+			ªªªªªªªªªªªªªªªª(this, PerformanceLogger);
 			this._timespans = {};
 			this._extras = {};
 			this._points = {};
@@ -15008,7 +15008,7 @@ var init_react_native_Libraries_Network_FormData = __esm({
 	"use strict";
 	FormData$1 = (function() {
 		function FormData() {
-			__classCallCheck(this, FormData);
+			ªªªªªªªªªªªªªªªª(this, FormData);
 			this._parts = [];
 		}
 		Object.defineProperty(FormData.prototype, "append", { configurable: true, writable: true, value: function(key,value) {
@@ -15203,7 +15203,7 @@ var init_react_native_Libraries_Network_XMLHttpRequest = __esm({
 	SUPPORTED_RESPONSE_TYPES = { arraybuffer: typeof global.ArrayBuffer === "function", blob: typeof global.Blob === "function", document: false, json: true, text: true, "": true };
 	XMLHttpRequestEventTarget = (function(_super) {
 		function XMLHttpRequestEventTarget() {
-			__classCallCheck(this, XMLHttpRequestEventTarget);
+			ªªªªªªªªªªªªªªªª(this, XMLHttpRequestEventTarget);
 			var _newTarget = this.constructor;
 			return __callSuper(_super, arguments, _newTarget);
 		}
@@ -15247,7 +15247,7 @@ var init_react_native_Libraries_Network_XMLHttpRequest = __esm({
 	})(EventTarget);
 	XMLHttpRequest$1 = (function(_super) {
 		function XMLHttpRequest() {
-			__classCallCheck(this, XMLHttpRequest);
+			ªªªªªªªªªªªªªªªª(this, XMLHttpRequest);
 			var _newTarget = this.constructor,_this;
 			;
 			{
@@ -15694,14 +15694,14 @@ var init_react_native_src_private_webapis_html_events_MessageEvent = __esm({
 	
 	MessageEvent = (function(_super) {
 		function MessageEvent(type,options) {
-			__classCallCheck(this, MessageEvent);
+			ªªªªªªªªªªªªªªªª(this, MessageEvent);
 			var _newTarget = this.constructor,_this;
 			;
-			__assertThisUninitialized(_this),_this = __callSuper(_super, [type, options], _newTarget);
-			__assertThisInitialized(_this)._data = (options == null ? void 0 : options.data);
-			__assertThisInitialized(_this)._origin = String((_a = (options == null ? void 0 : options.origin)) != null ? _a : "");
-			__assertThisInitialized(_this)._lastEventId = String((_b = (options == null ? void 0 : options.lastEventId)) != null ? _b : "");
-			return __assertThisInitialized(_this);
+			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [type, options], _newTarget);
+			ªªªªªªªªªªªªªªªªªªªªªªª(_this)._data = (options == null ? void 0 : options.data);
+			ªªªªªªªªªªªªªªªªªªªªªªª(_this)._origin = String((_a = (options == null ? void 0 : options.origin)) != null ? _a : "");
+			ªªªªªªªªªªªªªªªªªªªªªªª(_this)._lastEventId = String((_b = (options == null ? void 0 : options.lastEventId)) != null ? _b : "");
+			return ªªªªªªªªªªªªªªªªªªªªªªª(_this);
 		}
 		__extends(MessageEvent, _super);
 		Object.defineProperty(MessageEvent.prototype, "data", { configurable: true, get: function() {
@@ -15742,7 +15742,7 @@ var init_react_native_src_private_webapis_websockets_events_CloseEvent = __esm({
 	
 	CloseEvent = (function(_super) {
 		function CloseEvent(type,options) {
-			__classCallCheck(this, CloseEvent);
+			ªªªªªªªªªªªªªªªª(this, CloseEvent);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [type, options], _newTarget);
@@ -15790,7 +15790,7 @@ var init_react_native_Libraries_EventEmitter_NativeEventEmitter = __esm({
 	
 	NativeEventEmitter = (function() {
 		function NativeEventEmitter(nativeModule) {
-			__classCallCheck(this, NativeEventEmitter);
+			ªªªªªªªªªªªªªªªª(this, NativeEventEmitter);
 			if (Platform.OS === "ios") {
 				invariant$15(nativeModule != null, "`new NativeEventEmitter()` requires a non-null argument.");
 			}
@@ -15931,7 +15931,7 @@ var init_react_native_Libraries_WebSocket_WebSocket = __esm({
 	nextWebSocketId = 0;
 	WebSocket = (function(_super) {
 		function WebSocket(url,protocols,options) {
-			__classCallCheck(this, WebSocket);
+			ªªªªªªªªªªªªªªªª(this, WebSocket);
 			var _newTarget = this.constructor,_this;
 			;
 			{
@@ -16142,7 +16142,7 @@ var init_react_native_Libraries_Blob_File = __esm({
 	invariant$17 = require_invariant_browser();
 	File = (function(_super) {
 		function File(parts,name,options) {
-			__classCallCheck(this, File);
+			ªªªªªªªªªªªªªªªª(this, File);
 			var _newTarget = this.constructor,_this;
 			;
 			invariant$17(parts != null && name != null, "Failed to construct `File`: Must pass both `parts` and `name` arguments.");
@@ -16229,7 +16229,7 @@ var init_react_native_Libraries_Blob_FileReader = __esm({
 	DONE$1 = 2;
 	FileReader$1 = (function(_super) {
 		function FileReader() {
-			__classCallCheck(this, FileReader);
+			ªªªªªªªªªªªªªªªª(this, FileReader);
 			var _newTarget = this.constructor,_this;
 			;
 			{
@@ -16403,7 +16403,7 @@ var init_react_native_Libraries_Blob_URLSearchParams = __esm({
 	URLSearchParams$1 = (function() {
 		var _a = Symbol.iterator;
 		function URLSearchParams(params) {
-			__classCallCheck(this, URLSearchParams);
+			ªªªªªªªªªªªªªªªª(this, URLSearchParams);
 			this._searchParams = new Map();
 			var _this = this;
 			if (params === null) {
@@ -16690,7 +16690,7 @@ var init_react_native_Libraries_Blob_URL = __esm({
 	
 	URL$1 = (function() {
 		function URL(url,base) {
-			__classCallCheck(this, URL);
+			ªªªªªªªªªªªªªªªª(this, URL);
 			this._searchParamsInstance = null;
 			var baseUrl = null;
 			if (!base || validateBaseUrl(url)) {
@@ -17155,7 +17155,7 @@ init_extends();
 	Object.defineProperty(exports, "__esModule", { value: true });
 	var eventTargetShim = require_event_target_shim_dist_event_target_shim(),AbortSignal = (function(_super) {
 		function AbortSignal() {
-			__classCallCheck(this, AbortSignal);
+			ªªªªªªªªªªªªªªªª(this, AbortSignal);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [], _newTarget);
@@ -17194,7 +17194,7 @@ init_extends();
 	}
 	var AbortController = (function() {
 		function AbortController() {
-			__classCallCheck(this, AbortController);
+			ªªªªªªªªªªªªªªªª(this, AbortController);
 			signals.set(this, createAbortSignal());
 		}
 		Object.defineProperty(AbortController.prototype, "abort", { configurable: true, writable: true, value: function() {
@@ -17380,7 +17380,7 @@ var init_react_native_Libraries_Alert_Alert = __esm({
 	
 	Alert = (function() {
 		function Alert() {
-			__classCallCheck(this, Alert);
+			ªªªªªªªªªªªªªªªª(this, Alert);
 		}
 		Object.defineProperty(Alert, "alert", { configurable: true, writable: true, value: function(title,message,buttons,options) {
 			if (Platform.OS === "ios") {
@@ -17762,7 +17762,7 @@ init_extends();
 		update.modified.forEach(inject);
 	},HMRClient = (function(_super) {
 		function HMRClient(url) {
-			__classCallCheck(this, HMRClient);
+			ªªªªªªªªªªªªªªªª(this, HMRClient);
 			var _newTarget = this.constructor,_this,_this = this;
 			;
 			;
@@ -18444,7 +18444,7 @@ var init_react_native_Libraries_ReactNative_HeadlessJsTaskError = __esm({
 	
 	HeadlessJsTaskError = (function(_super) {
 		function HeadlessJsTaskError() {
-			__classCallCheck(this, HeadlessJsTaskError);
+			ªªªªªªªªªªªªªªªª(this, HeadlessJsTaskError);
 			var _newTarget = this.constructor;
 			return __callSuper(_super, arguments, _newTarget);
 		}
@@ -18770,7 +18770,7 @@ var init_react_native_Libraries_Debugging_DebuggingOverlayRegistry = __esm({
 				;
 				try {
 					for (var _n3 = parentToTraceUpdatesMap.entries()[Symbol.iterator](),_o3; !(_k3 = (_o3 = _n3.next()).done); _k3 = true) {
-						var _s3 = ªªªªªª(_o3.value, 2),parent = _s3[0],traceUpdates = _s3[1],_q3 = parent,debuggingOverlayRef = _q3.debuggingOverlayRef;
+						var _s3 = __read(_o3.value, 2),parent = _s3[0],traceUpdates = _s3[1],_q3 = parent,debuggingOverlayRef = _q3.debuggingOverlayRef;
 						(_r3 = debuggingOverlayRef.current) == null || _r3.highlightTraceUpdates(traceUpdates);
 					}
 				} catch (_p3) {
@@ -18848,7 +18848,7 @@ var init_react_native_Libraries_Debugging_DebuggingOverlayRegistry = __esm({
 				;
 				try {
 					for (var _d4 = parentToTraceUpdatesPromisesMap.entries()[Symbol.iterator](),_e4; !(_a4 = (_e4 = _d4.next()).done); _a4 = true) {
-						var _h4 = ªªªªªª(_e4.value, 2),parent = _h4[0],traceUpdatesPromises = _h4[1];
+						var _h4 = __read(_e4.value, 2),parent = _h4[0],traceUpdatesPromises = _h4[1];
 						_loop2(parent, traceUpdatesPromises);
 					}
 				} catch (_f4) {
@@ -18908,7 +18908,7 @@ var init_react_native_Libraries_Debugging_DebuggingOverlayRegistry = __esm({
 				;
 				try {
 					for (var _r4 = parentToElementsMap.entries()[Symbol.iterator](),_s4; !(_o4 = (_s4 = _r4.next()).done); _o4 = true) {
-						var _x4 = ªªªªªª(_s4.value, 2),parent = _x4[0],elementsToHighlight = _x4[1],rootViewInstance = parent.rootViewRef.current;
+						var _x4 = __read(_s4.value, 2),parent = _x4[0],elementsToHighlight = _x4[1],rootViewInstance = parent.rootViewRef.current;
 						if (rootViewInstance == null) {
 							return;
 						}
@@ -18992,7 +18992,7 @@ var init_react_native_Libraries_Debugging_DebuggingOverlayRegistry = __esm({
 				;
 				try {
 					for (var _h5 = parentToElementsMap.entries()[Symbol.iterator](),_i5; !(_e5 = (_i5 = _h5.next()).done); _e5 = true) {
-						var _l5 = ªªªªªª(_i5.value, 2),parent = _l5[0],elementsToHighlight = _l5[1];
+						var _l5 = __read(_i5.value, 2),parent = _l5[0],elementsToHighlight = _l5[1];
 						_loop3(parent, elementsToHighlight);
 					}
 				} catch (_j5) {
@@ -19012,7 +19012,7 @@ var init_react_native_Libraries_Debugging_DebuggingOverlayRegistry = __esm({
 			}
 		}
 		function DebuggingOverlayRegistry() {
-			__classCallCheck(this, DebuggingOverlayRegistry);
+			ªªªªªªªªªªªªªªªª(this, DebuggingOverlayRegistry);
 			var _this = this;
 			_registry.set(this, new Set());
 			_reactDevToolsAgent.set(this, null);
@@ -19443,7 +19443,7 @@ var init_react_native_Libraries_Pressability_PressabilityPerformanceEventEmitter
 		
 	PressabilityPerformanceEventEmitter = (function() {
 		function PressabilityPerformanceEventEmitter() {
-			__classCallCheck(this, PressabilityPerformanceEventEmitter);
+			ªªªªªªªªªªªªªªªª(this, PressabilityPerformanceEventEmitter);
 			this._listeners = [];
 		}
 		Object.defineProperty(PressabilityPerformanceEventEmitter.prototype, "addListener", { configurable: true, writable: true, value: function(listener) {
@@ -19529,7 +19529,7 @@ var init_react_native_Libraries_Pressability_Pressability = __esm({
 	longPressDeactivationDistance = DEFAULT_LONG_PRESS_DEACTIVATION_DISTANCE;
 	Pressability = (function() {
 		function Pressability(config) {
-			__classCallCheck(this, Pressability);
+			ªªªªªªªªªªªªªªªª(this, Pressability);
 			var _this = this;
 			this._eventHandlers = null;
 			this._hoverInDelayTimeout = null;
@@ -21139,7 +21139,7 @@ var init_react_native_Libraries_Linking_Linking = __esm({
 	
 	LinkingImpl = (function(_super) {
 		function LinkingImpl() {
-			__classCallCheck(this, LinkingImpl);
+			ªªªªªªªªªªªªªªªª(this, LinkingImpl);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [Platform.OS === "ios" ? nullthrows$7(_default$51) : undefined], _newTarget);
@@ -22671,7 +22671,7 @@ var init_react_native_Libraries_Animated_nodes_AnimatedNode = __esm({
 	};
 	AnimatedNode = (function() {
 		function AnimatedNode(config) {
-			__classCallCheck(this, AnimatedNode);
+			ªªªªªªªªªªªªªªªª(this, AnimatedNode);
 			this._platformConfig = undefined;
 			this.__isNative = false;
 			this.__nativeTag = undefined;
@@ -22796,7 +22796,7 @@ var init_react_native_Libraries_Animated_nodes_AnimatedWithChildren = __esm({
 	disconnectAnimatedNodes = _a$45.disconnectAnimatedNodes;
 	AnimatedWithChildren = (function(_super) {
 		function AnimatedWithChildren() {
-			__classCallCheck(this, AnimatedWithChildren);
+			ªªªªªªªªªªªªªªªª(this, AnimatedWithChildren);
 			var _newTarget = this.constructor,_this = __callSuper(_super, arguments, _newTarget);
 			;
 			_this._children = [];
@@ -23042,7 +23042,7 @@ var init_react_native_Libraries_Animated_nodes_AnimatedInterpolation = __esm({
 	numericComponentRegex = /[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?/g;
 	AnimatedInterpolation = (function(_super) {
 		function AnimatedInterpolation(parent,config) {
-			__classCallCheck(this, AnimatedInterpolation);
+			ªªªªªªªªªªªªªªªª(this, AnimatedInterpolation);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [config], _newTarget);
@@ -23152,7 +23152,7 @@ var init_react_native_Libraries_Animated_nodes_AnimatedValue = __esm({
 	;
 	AnimatedValue = (function(_super) {
 		function AnimatedValue(value,config) {
-			__classCallCheck(this, AnimatedValue);
+			ªªªªªªªªªªªªªªªª(this, AnimatedValue);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [config], _newTarget);
@@ -23363,7 +23363,7 @@ var init_react_native_Libraries_Animated_nodes_AnimatedValueXY = __esm({
 	_uniqueId$1 = 1;
 	AnimatedValueXY = (function(_super) {
 		function AnimatedValueXY(valueIn,config) {
-			__classCallCheck(this, AnimatedValueXY);
+			ªªªªªªªªªªªªªªªª(this, AnimatedValueXY);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [config], _newTarget);
@@ -23541,7 +23541,7 @@ var init_react_native_Libraries_Animated_AnimatedEvent = __esm({
 	
 	AnimatedEvent = (function() {
 		function AnimatedEvent(argMapping,config) {
-			__classCallCheck(this, AnimatedEvent);
+			ªªªªªªªªªªªªªªªª(this, AnimatedEvent);
 			var _this = this;
 			this._listeners = [];
 			this._callListeners = function() {
@@ -23691,7 +23691,7 @@ var init_react_native_Libraries_Animated_nodes_AnimatedObject = __esm({
 	MAX_DEPTH = 5;
 	AnimatedObject = (function(_super) {
 		function AnimatedObject(nodes,value,config) {
-			__classCallCheck(this, AnimatedObject);
+			ªªªªªªªªªªªªªªªª(this, AnimatedObject);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [config], _newTarget);
@@ -23824,7 +23824,7 @@ var init_react_native_Libraries_Animated_nodes_AnimatedTransform = __esm({
 	
 	AnimatedTransform = (function(_super) {
 		function AnimatedTransform(nodes,transforms,config) {
-			__classCallCheck(this, AnimatedTransform);
+			ªªªªªªªªªªªªªªªª(this, AnimatedTransform);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [config], _newTarget);
@@ -23972,7 +23972,7 @@ var init_react_native_Libraries_Animated_nodes_AnimatedStyle = __esm({
 	
 	AnimatedStyle = (function(_super) {
 		function AnimatedStyle(nodeKeys,nodes,style,originalStyleForWeb,config) {
-			__classCallCheck(this, AnimatedStyle);
+			ªªªªªªªªªªªªªªªª(this, AnimatedStyle);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [config], _newTarget);
@@ -24173,7 +24173,7 @@ var init_react_native_Libraries_Animated_nodes_AnimatedProps = __esm({
 			target.connectedViewTag = null;
 		}
 		function AnimatedProps(inputProps,callback,allowlist,config) {
-			__classCallCheck(this, AnimatedProps);
+			ªªªªªªªªªªªªªªªª(this, AnimatedProps);
 			var _newTarget = this.constructor,_this;
 			;
 			{
@@ -24317,7 +24317,7 @@ var init_react_native_Libraries_Animated_nodes_AnimatedProps = __esm({
 //#endregion
 //#region Animation.js
 var exports_react_native_Libraries_Animated_animations_Animation = {};
-var __toConsumableArray, __classCallCheck, _a, _b, _c, _d, _e, _f, _g, _h, _i, ReactNativeFeatureFlags$11, startNativeAnimationNextId, Animation;
+var __toConsumableArray, ªªªªªªªªªªªªªªªª, _a, _b, _c, _d, _e, _f, _g, _h, _i, ReactNativeFeatureFlags$11, startNativeAnimationNextId, Animation;
 __export(exports_react_native_Libraries_Animated_animations_Animation, {
 	"default": function() { return Animation; },
 });
@@ -24337,7 +24337,7 @@ var init_react_native_Libraries_Animated_animations_Animation = __esm({
 	startNativeAnimationNextId = 1;
 	Animation = (function() {
 		function Animation(config) {
-			__classCallCheck(this, Animation);
+			ªªªªªªªªªªªªªªªª(this, Animation);
 			this._useNativeDriver = _default$61.shouldUseNativeDriver(config);
 			this.__active = false;
 			this.__isInteraction = (_a = config.isInteraction) != null ? _a : !this._useNativeDriver;
@@ -24472,7 +24472,7 @@ var init_react_native_Libraries_Animated_animations_DecayAnimation = __esm({
 	
 	DecayAnimation = (function(_super) {
 		function DecayAnimation(config) {
-			__classCallCheck(this, DecayAnimation);
+			ªªªªªªªªªªªªªªªª(this, DecayAnimation);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [config], _newTarget);
@@ -24598,7 +24598,7 @@ var init_react_native_Libraries_Animated_nodes_AnimatedColor = __esm({
 	;
 	AnimatedColor = (function(_super) {
 		function AnimatedColor(valueIn,config) {
-			__classCallCheck(this, AnimatedColor);
+			ªªªªªªªªªªªªªªªª(this, AnimatedColor);
 			var _newTarget = this.constructor,_this;
 			;
 			{
@@ -24831,7 +24831,7 @@ var init_react_native_Libraries_Animated_animations_SpringAnimation = __esm({
 	
 	SpringAnimation = (function(_super) {
 		function SpringAnimation(config) {
-			__classCallCheck(this, SpringAnimation);
+			ªªªªªªªªªªªªªªªª(this, SpringAnimation);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [config], _newTarget);
@@ -24992,7 +24992,7 @@ var init_react_native_Libraries_Animated_animations_TimingAnimation = __esm({
 	;
 	TimingAnimation = (function(_super) {
 		function TimingAnimation(config) {
-			__classCallCheck(this, TimingAnimation);
+			ªªªªªªªªªªªªªªªª(this, TimingAnimation);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [config], _newTarget);
@@ -25598,7 +25598,7 @@ var init_react_native_Libraries_Animated_nodes_AnimatedAddition = __esm({
 	
 	AnimatedAddition = (function(_super) {
 		function AnimatedAddition(a,b,config) {
-			__classCallCheck(this, AnimatedAddition);
+			ªªªªªªªªªªªªªªªª(this, AnimatedAddition);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [config], _newTarget);
@@ -25661,7 +25661,7 @@ var init_react_native_Libraries_Animated_nodes_AnimatedDiffClamp = __esm({
 	
 	AnimatedDiffClamp = (function(_super) {
 		function AnimatedDiffClamp(a,min,max,config) {
-			__classCallCheck(this, AnimatedDiffClamp);
+			ªªªªªªªªªªªªªªªª(this, AnimatedDiffClamp);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [config], _newTarget);
@@ -25730,7 +25730,7 @@ var init_react_native_Libraries_Animated_nodes_AnimatedDivision = __esm({
 	
 	AnimatedDivision = (function(_super) {
 		function AnimatedDivision(a,b,config) {
-			__classCallCheck(this, AnimatedDivision);
+			ªªªªªªªªªªªªªªªª(this, AnimatedDivision);
 			var _newTarget = this.constructor,_this;
 			;
 			{
@@ -25808,7 +25808,7 @@ var init_react_native_Libraries_Animated_nodes_AnimatedModulo = __esm({
 	
 	AnimatedModulo = (function(_super) {
 		function AnimatedModulo(a,modulus,config) {
-			__classCallCheck(this, AnimatedModulo);
+			ªªªªªªªªªªªªªªªª(this, AnimatedModulo);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [config], _newTarget);
@@ -25870,7 +25870,7 @@ var init_react_native_Libraries_Animated_nodes_AnimatedMultiplication = __esm({
 	
 	AnimatedMultiplication = (function(_super) {
 		function AnimatedMultiplication(a,b,config) {
-			__classCallCheck(this, AnimatedMultiplication);
+			ªªªªªªªªªªªªªªªª(this, AnimatedMultiplication);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [config], _newTarget);
@@ -25935,7 +25935,7 @@ var init_react_native_Libraries_Animated_nodes_AnimatedSubtraction = __esm({
 	
 	AnimatedSubtraction = (function(_super) {
 		function AnimatedSubtraction(a,b,config) {
-			__classCallCheck(this, AnimatedSubtraction);
+			ªªªªªªªªªªªªªªªª(this, AnimatedSubtraction);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [config], _newTarget);
@@ -25999,7 +25999,7 @@ var init_react_native_Libraries_Animated_nodes_AnimatedTracking = __esm({
 	
 	AnimatedTracking = (function(_super) {
 		function AnimatedTracking(value,parent,animationClass,animationConfig,callback,config) {
-			__classCallCheck(this, AnimatedTracking);
+			ªªªªªªªªªªªªªªªª(this, AnimatedTracking);
 			var _newTarget = this.constructor,_this;
 			;
 			ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [config], _newTarget);
@@ -26662,7 +26662,7 @@ var init_react_native_Libraries_Components_Keyboard_Keyboard = __esm({
 		
 	KeyboardImpl = (function() {
 		function KeyboardImpl() {
-			__classCallCheck(this, KeyboardImpl);
+			ªªªªªªªªªªªªªªªª(this, KeyboardImpl);
 			this._emitter = new NativeEventEmitter(Platform.OS !== "ios" ? null : _default$66);
 			var _this = this;
 			this.addListener("keyboardDidShow", function(ev) {
@@ -27079,7 +27079,7 @@ var init__react_native_virtualized_lists_Lists_CellRenderMask = __esm({
 	
 	CellRenderMask = (function() {
 		function CellRenderMask(numCells) {
-			__classCallCheck(this, CellRenderMask);
+			ªªªªªªªªªªªªªªªª(this, CellRenderMask);
 			invariant$30(numCells >= 0, "CellRenderMask must contain a non-negative number os cells");
 			this._numCells = numCells;
 			if (numCells === 0) {
@@ -27096,7 +27096,7 @@ var init__react_native_virtualized_lists_Lists_CellRenderMask = __esm({
 			if (cells.last < cells.first) {
 				return;
 			}
-			var _a = ªªªªªª(this._findRegion(cells.first), 2),firstIntersect = _a[0],firstIntersectIdx = _a[1],_b = ªªªªªª(this._findRegion(cells.last), 2),lastIntersect = _b[0],lastIntersectIdx = _b[1];
+			var _a = __read(this._findRegion(cells.first), 2),firstIntersect = _a[0],firstIntersectIdx = _a[1],_b = __read(this._findRegion(cells.last), 2),lastIntersect = _b[0],lastIntersectIdx = _b[1];
 			if (firstIntersectIdx === lastIntersectIdx && !firstIntersect.isSpacer) {
 				return;
 			}
@@ -27162,7 +27162,7 @@ var init__react_native_virtualized_lists_Lists_ChildListCollection = __esm({
 		
 	ChildListCollection = (function() {
 		function ChildListCollection() {
-			__classCallCheck(this, ChildListCollection);
+			ªªªªªªªªªªªªªªªª(this, ChildListCollection);
 			this._cellKeyToChildren = new Map();
 			this._childrenToCellKey = new Map();
 		}
@@ -27316,7 +27316,7 @@ var init__react_native_virtualized_lists_Lists_ListMetricsAggregator = __esm({
 		
 	ListMetricsAggregator = (function() {
 		function ListMetricsAggregator() {
-			__classCallCheck(this, ListMetricsAggregator);
+			ªªªªªªªªªªªªªªªª(this, ListMetricsAggregator);
 			this._averageCellLength = 0;
 			this._cellMetrics = new Map();
 			this._highestMeasuredCellIndex = 0;
@@ -27475,7 +27475,7 @@ var init__react_native_virtualized_lists_Lists_FillRateHelper = __esm({
 	
 	Info = (function() {
 		function Info() {
-			__classCallCheck(this, Info);
+			ªªªªªªªªªªªªªªªª(this, Info);
 			this.any_blank_count = 0;
 			this.any_blank_ms = 0;
 			this.any_blank_speed_sum = 0;
@@ -27495,7 +27495,7 @@ var init__react_native_virtualized_lists_Lists_FillRateHelper = __esm({
 	_sampleRate = DEBUG ? 1 : null;
 	FillRateHelper = (function() {
 		function FillRateHelper(listMetrics) {
-			__classCallCheck(this, FillRateHelper);
+			ªªªªªªªªªªªªªªªª(this, FillRateHelper);
 			this._anyBlankStartTime = null;
 			this._enabled = false;
 			this._info = new Info();
@@ -27644,7 +27644,7 @@ var init__react_native_virtualized_lists_Lists_StateSafePureComponent = __esm({
 	
 	StateSafePureComponent = (function(_super) {
 		function StateSafePureComponent(props) {
-			__classCallCheck(this, StateSafePureComponent);
+			ªªªªªªªªªªªªªªªª(this, StateSafePureComponent);
 			var _newTarget = this.constructor,_this;
 			;
 			{
@@ -27733,7 +27733,7 @@ var init__react_native_virtualized_lists_Lists_ViewabilityHelper = __esm({
 	invariant$34 = require_invariant_browser();
 	ViewabilityHelper = (function() {
 		function ViewabilityHelper(config) {
-			__classCallCheck(this, ViewabilityHelper);
+			ªªªªªªªªªªªªªªªª(this, ViewabilityHelper);
 			this._hasInteracted = false;
 			this._timers = new Set();
 			this._viewableIndices = [];
@@ -27901,7 +27901,7 @@ var init__react_native_virtualized_lists_Lists_VirtualizedListCellRenderer = __e
 	
 	CellRenderer = (function(_super) {
 		function CellRenderer() {
-			__classCallCheck(this, CellRenderer);
+			ªªªªªªªªªªªªªªªª(this, CellRenderer);
 			var _newTarget = this.constructor,_this = __callSuper(_super, arguments, _newTarget);
 			;
 			_this.state = { separatorProps: { highlighted: false, leadingItem: ªªªªªªªªªªªªªªªªªªªªªªª(_this).props.item } };
@@ -28007,7 +28007,7 @@ var init__react_native_virtualized_lists_Lists_VirtualizedListProps = __esm({
 //#endregion
 //#region VirtualizedList.js
 var exports__react_native_virtualized_lists_Lists_VirtualizedList = {};
-var __extends, __toConsumableArray, __rest, __classCallCheck, __callSuper, ªªªªªªªªªªªªªªªªªªªªªªª, ªªªªªªªªªªªªªªªªªªªªªªªªª, __possibleConstructorReturn, _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _a2, _b2, _c2, _d2, _e2, _f2, _g2, _h2, _i2, _j2, _k2, _l2, _m2, _n2, _o2, _p2, _q2, _r2, _s2, _t2, _u2, _v2, _w2, ReactNativeFeatureFlags$15, ON_EDGE_REACHED_EPSILON, _usedIndexForKey, _keylessItemComponentName, getScrollingThreshold, VirtualizedList, styles$11, invariant$36, nullthrows$10, React$37;
+var __extends, __toConsumableArray, __rest, ªªªªªªªªªªªªªªªª, __callSuper, ªªªªªªªªªªªªªªªªªªªªªªª, ªªªªªªªªªªªªªªªªªªªªªªªªª, __possibleConstructorReturn, _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _a2, _b2, _c2, _d2, _e2, _f2, _g2, _h2, _i2, _j2, _k2, _l2, _m2, _n2, _o2, _p2, _q2, _r2, _s2, _t2, _u2, _v2, _w2, ReactNativeFeatureFlags$15, ON_EDGE_REACHED_EPSILON, _usedIndexForKey, _keylessItemComponentName, getScrollingThreshold, VirtualizedList, styles$11, invariant$36, nullthrows$10, React$37;
 __export(exports__react_native_virtualized_lists_Lists_VirtualizedList, {
 	"default": function() { return VirtualizedList; },
 });
@@ -28070,7 +28070,7 @@ var init__react_native_virtualized_lists_Lists_VirtualizedList = __esm({
 	;
 	VirtualizedList = (function(_super) {
 		function VirtualizedList(props) {
-			__classCallCheck(this, VirtualizedList);
+			ªªªªªªªªªªªªªªªª(this, VirtualizedList);
 			var _newTarget = this.constructor,_this;
 			;
 			{
@@ -28948,7 +28948,7 @@ var init__react_native_virtualized_lists_Lists_VirtualizedSectionList = __esm({
 	
 	VirtualizedSectionList = (function(_super) {
 		function VirtualizedSectionList() {
-			__classCallCheck(this, VirtualizedSectionList);
+			ªªªªªªªªªªªªªªªª(this, VirtualizedSectionList);
 			var _newTarget = this.constructor,_this = __callSuper(_super, arguments, _newTarget);
 			;
 			_this._keyExtractor = function(item,index) {
@@ -29185,7 +29185,7 @@ var require_memoize_one_dist_memoize_one_cjs = __commonJS({
 //#endregion
 //#region FlatList.js
 var exports_react_native_Libraries_Lists_FlatList = {};
-var __extends, __toConsumableArray, __rest, __classCallCheck, __callSuper, ªªªªªªªªªªªªªªªªªªªªªªª, ªªªªªªªªªªªªªªªªªªªªªªªªª, __possibleConstructorReturn, _a, _b, _c, _d, _e, ReactNativeFeatureFlags$16, StyleSheet$12, deepDiffer$2, Platform$30, invariant$38, VirtualizedList$2, defaultKeyExtractor$3, removeClippedSubviewsOrDefault, numColumnsOrDefault, isArrayLike, FlatList, styles$12, memoizeOne, React$39;
+var __extends, __toConsumableArray, __rest, ªªªªªªªªªªªªªªªª, __callSuper, ªªªªªªªªªªªªªªªªªªªªªªª, ªªªªªªªªªªªªªªªªªªªªªªªªª, __possibleConstructorReturn, _a, _b, _c, _d, _e, ReactNativeFeatureFlags$16, StyleSheet$12, deepDiffer$2, Platform$30, invariant$38, VirtualizedList$2, defaultKeyExtractor$3, removeClippedSubviewsOrDefault, numColumnsOrDefault, isArrayLike, FlatList, styles$12, memoizeOne, React$39;
 __export(exports_react_native_Libraries_Lists_FlatList, {
 	"default": function() { return FlatList; },
 });
@@ -29240,7 +29240,7 @@ var init_react_native_Libraries_Lists_FlatList = __esm({
 	;
 	FlatList = (function(_super) {
 		function FlatList(props) {
-			__classCallCheck(this, FlatList);
+			ªªªªªªªªªªªªªªªª(this, FlatList);
 			var _newTarget = this.constructor,_this,_this = this;
 			;
 			;
@@ -29562,7 +29562,7 @@ var init_react_native_Libraries_Components_RefreshControl_RefreshControl = __esm
 	Platform$31 = (init_react_native_Libraries_Utilities_Platform_ios(), __toCommonJS(exports_react_native_Libraries_Utilities_Platform_ios)).default;
 	RefreshControl = (function(_super) {
 		function RefreshControl() {
-			__classCallCheck(this, RefreshControl);
+			ªªªªªªªªªªªªªªªª(this, RefreshControl);
 			var _newTarget = this.constructor,_this = __callSuper(_super, arguments, _newTarget);
 			;
 			_this._lastNativeRefreshing = false;
@@ -29718,7 +29718,7 @@ var init_react_native_Libraries_Lists_SectionList = __esm({
 	VirtualizedSectionList$1 = _default$70.VirtualizedSectionList;
 	SectionList = (function(_super) {
 		function SectionList() {
-			__classCallCheck(this, SectionList);
+			ªªªªªªªªªªªªªªªª(this, SectionList);
 			var _newTarget = this.constructor,_this = __callSuper(_super, arguments, _newTarget);
 			;
 			_this._captureRef = function(ref) {
@@ -30107,7 +30107,7 @@ var init_react_native_Libraries_Components_ScrollView_ScrollView = __esm({
 	IS_ANIMATING_TOUCH_START_THRESHOLD_MS = 16;
 	ScrollView$1 = (function(_super) {
 		function ScrollView(props) {
-			__classCallCheck(this, ScrollView);
+			ªªªªªªªªªªªªªªªª(this, ScrollView);
 			var _newTarget = this.constructor,_this;
 			;
 			{
@@ -30551,7 +30551,7 @@ var init_react_native_Libraries_Components_Touchable_TouchableHighlight = __esm(
 	
 	TouchableHighlightImpl = (function(_super) {
 		function TouchableHighlightImpl() {
-			__classCallCheck(this, TouchableHighlightImpl);
+			ªªªªªªªªªªªªªªªª(this, TouchableHighlightImpl);
 			var _newTarget = this.constructor,_this = __callSuper(_super, arguments, _newTarget);
 			;
 			_this._isMounted = false;
@@ -30699,7 +30699,7 @@ var init_react_native_src_private_devsupport_devmenu_perfmonitor_PerformanceOver
 	PerformanceLogger$1 = (init_react_native_Libraries_Utilities_GlobalPerformanceLogger(), __toCommonJS(exports_react_native_Libraries_Utilities_GlobalPerformanceLogger)).default;
 	PerformanceOverlay = (function(_super) {
 		function PerformanceOverlay() {
-			__classCallCheck(this, PerformanceOverlay);
+			ªªªªªªªªªªªªªªªª(this, PerformanceOverlay);
 			var _newTarget = this.constructor;
 			return __callSuper(_super, arguments, _newTarget);
 		}
@@ -30851,7 +30851,7 @@ var init_react_native_src_private_devsupport_devmenu_elementinspector_ElementPro
 	StyleInspector$1 = (init_react_native_src_private_devsupport_devmenu_elementinspector_StyleInspector(), __toCommonJS(exports_react_native_src_private_devsupport_devmenu_elementinspector_StyleInspector)).default;
 	ElementProperties = (function(_super) {
 		function ElementProperties() {
-			__classCallCheck(this, ElementProperties);
+			ªªªªªªªªªªªªªªªª(this, ElementProperties);
 			var _newTarget = this.constructor;
 			return __callSuper(_super, arguments, _newTarget);
 		}
@@ -31188,7 +31188,7 @@ var init_react_native_src_private_devsupport_devmenu_elementinspector_NetworkOve
 	XHR_ID_KEY = Symbol("XHR_ID");
 	NetworkOverlay = (function(_super) {
 		function NetworkOverlay() {
-			__classCallCheck(this, NetworkOverlay);
+			ªªªªªªªªªªªªªªªª(this, NetworkOverlay);
 			var _newTarget = this.constructor,_this = __callSuper(_super, arguments, _newTarget);
 			;
 			_this._requestsListViewScrollMetrics = { offset: 0, visibleLength: 0, contentLength: 0 };
@@ -31452,7 +31452,7 @@ var init_react_native_src_private_devsupport_devmenu_elementinspector_InspectorP
 	NetworkOverlay$1 = (init_react_native_src_private_devsupport_devmenu_elementinspector_NetworkOverlay(), __toCommonJS(exports_react_native_src_private_devsupport_devmenu_elementinspector_NetworkOverlay)).default;
 	InspectorPanel = (function(_super) {
 		function InspectorPanel() {
-			__classCallCheck(this, InspectorPanel);
+			ªªªªªªªªªªªªªªªª(this, InspectorPanel);
 			var _newTarget = this.constructor;
 			return __callSuper(_super, arguments, _newTarget);
 		}
@@ -31480,7 +31480,7 @@ var init_react_native_src_private_devsupport_devmenu_elementinspector_InspectorP
 	})(React$56.Component);
 	InspectorPanelButton = (function(_super) {
 		function InspectorPanelButton() {
-			__classCallCheck(this, InspectorPanelButton);
+			ªªªªªªªªªªªªªªªª(this, InspectorPanelButton);
 			var _newTarget = this.constructor;
 			return __callSuper(_super, arguments, _newTarget);
 		}
@@ -32955,7 +32955,7 @@ var init_react_native_Libraries_LogBox_UI_LogBoxInspectorBody = __esm({
 	"LogBoxInspectorBody.js"() {
 	LogBoxInspectorBody = function(props) {
 		;
-		var _a = ªªªªªª(require_react_index().useState(true), 2),collapsed = _a[0],setCollapsed = _a[1];
+		var _a = __read(require_react_index().useState(true), 2),collapsed = _a[0],setCollapsed = _a[1];
 		require_react_index().useEffect(function() {
 			setCollapsed(true);
 		}, [props.log]);
@@ -33230,7 +33230,7 @@ var init_react_native_Libraries_LogBox_LogBoxInspectorContainer = __esm({
 	
 	_LogBoxInspectorContainer = (function(_super) {
 		function _LogBoxInspectorContainer() {
-			__classCallCheck(this, _LogBoxInspectorContainer);
+			ªªªªªªªªªªªªªªªª(this, _LogBoxInspectorContainer);
 			var _newTarget = this.constructor,_this = __callSuper(_super, arguments, _newTarget);
 			;
 			_this._handleDismiss = function() {
@@ -33311,7 +33311,7 @@ var init_react_native_src_private_webapis_intersectionobserver_IntersectionObser
 	
 	IntersectionObserverEntry = (function() {
 		function IntersectionObserverEntry(nativeEntry,target) {
-			__classCallCheck(this, IntersectionObserverEntry);
+			ªªªªªªªªªªªªªªªª(this, IntersectionObserverEntry);
 			this._nativeEntry = nativeEntry;
 			this._target = target;
 		}
@@ -33700,7 +33700,7 @@ var init_react_native_src_private_webapis_intersectionobserver_IntersectionObser
 	IntersectionObserverManager=__toESM((init_react_native_src_private_webapis_intersectionobserver_internals_IntersectionObserverManager(), __toCommonJS(exports_react_native_src_private_webapis_intersectionobserver_internals_IntersectionObserverManager)));
 	IntersectionObserver = (function() {
 		function IntersectionObserver(callback,options) {
-			__classCallCheck(this, IntersectionObserver);
+			ªªªªªªªªªªªªªªªª(this, IntersectionObserver);
 			this._observationTargets = new Set();
 			if (callback == null) {
 				throw new TypeError("Failed to construct 'IntersectionObserver': 1 argument required, but only 0 present.");
@@ -33880,7 +33880,7 @@ var init_react_native_src_private_devsupport_rndevtools_setUpFuseboxReactDevTool
 	EventScope = (function() {
 		var _listeners = new WeakMap();
 		function EventScope() {
-			__classCallCheck(this, EventScope);
+			ªªªªªªªªªªªªªªªª(this, EventScope);
 			_listeners.set(this, new Set());
 		}
 		Object.defineProperty(EventScope.prototype, "addEventListener", { configurable: true, writable: true, value: function(listener) {
@@ -33919,7 +33919,7 @@ var init_react_native_src_private_devsupport_rndevtools_setUpFuseboxReactDevTool
 	})();
 	Domain = (function() {
 		function Domain(name) {
-			__classCallCheck(this, Domain);
+			ªªªªªªªªªªªªªªªª(this, Domain);
 			if (global[FuseboxReactDevToolsDispatcher.BINDING_NAME] == null) {
 				throw new Error("Could not create domain " + name + ": receiving end doesn't exist");
 			}
@@ -33935,7 +33935,7 @@ var init_react_native_src_private_devsupport_rndevtools_setUpFuseboxReactDevTool
 	FuseboxReactDevToolsDispatcher = (function() {
 		var _domainNameToDomainMap = { writable: true, value: new Map() };
 		function FuseboxReactDevToolsDispatcher() {
-			__classCallCheck(this, FuseboxReactDevToolsDispatcher);
+			ªªªªªªªªªªªªªªªª(this, FuseboxReactDevToolsDispatcher);
 		}
 		Object.defineProperty(FuseboxReactDevToolsDispatcher, "initializeDomain", { configurable: true, writable: true, value: function(domainName) {
 			var domain = new Domain(domainName);
@@ -45196,7 +45196,7 @@ var init_react_native_Libraries_AppState_AppState = __esm({
 	
 	AppStateImpl = (function() {
 		function AppStateImpl() {
-			__classCallCheck(this, AppStateImpl);
+			ªªªªªªªªªªªªªªªª(this, AppStateImpl);
 			this.currentState = null;
 			var _this = this;
 			if (_default$89 == null) {
@@ -45300,7 +45300,7 @@ var init_react_native_Libraries_Core_ReactNativeVersion = __esm({
 		
 	ReactNativeVersion = (function() {
 		function ReactNativeVersion() {
-			__classCallCheck(this, ReactNativeVersion);
+			ªªªªªªªªªªªªªªªª(this, ReactNativeVersion);
 		}
 		Object.defineProperty(ReactNativeVersion, "getVersionString", { configurable: true, writable: true, value: function() {
 			return "" + this.major + "." + this.minor + "." + this.patch + (this.prerelease != null ? "-" + this.prerelease : "");
@@ -45486,7 +45486,7 @@ var init_react_native_Libraries_Core_Devtools_loadBundleFromServer = __esm({
 	cachedPromisesByUrl = new Map();
 	LoadBundleFromServerError = (function(_super) {
 		function LoadBundleFromServerError(message,url,isTimeout,options) {
-			__classCallCheck(this, LoadBundleFromServerError);
+			ªªªªªªªªªªªªªªªª(this, LoadBundleFromServerError);
 			var _newTarget = this.constructor,_this;
 			;
 			__assertThisUninitialized(_this),_this = __callSuper(_super, [message, options], _newTarget);
@@ -45500,7 +45500,7 @@ var init_react_native_Libraries_Core_Devtools_loadBundleFromServer = __esm({
 	})(Error);
 	LoadBundleFromServerRequestError = (function(_super) {
 		function LoadBundleFromServerRequestError(message,url,isTimeout,options) {
-			__classCallCheck(this, LoadBundleFromServerRequestError);
+			ªªªªªªªªªªªªªªªª(this, LoadBundleFromServerRequestError);
 			var _newTarget = this.constructor,_this;
 			;
 			__assertThisUninitialized(_this),_this = __callSuper(_super, [message, url, isTimeout, options], _newTarget);
@@ -56587,7 +56587,7 @@ var init_react_native_Libraries_Components_UnimplementedViews_UnimplementedView 
 	
 	UnimplementedView = (function(_super) {
 		function UnimplementedView() {
-			__classCallCheck(this, UnimplementedView);
+			ªªªªªªªªªªªªªªªª(this, UnimplementedView);
 			var _newTarget = this.constructor;
 			return __callSuper(_super, arguments, _newTarget);
 		}
@@ -56743,7 +56743,7 @@ var init_react_native_Libraries_Components_Touchable_TouchableNativeFeedback = _
 	
 	TouchableNativeFeedback = (function(_super) {
 		function TouchableNativeFeedback() {
-			__classCallCheck(this, TouchableNativeFeedback);
+			ªªªªªªªªªªªªªªªª(this, TouchableNativeFeedback);
 			var _newTarget = this.constructor,_this = __callSuper(_super, arguments, _newTarget);
 			;
 			_this.state = { pressability: new Pressability(__assertThisInitialized(_this)._createPressabilityConfig()) };
@@ -56876,7 +56876,7 @@ var init_react_native_Libraries_Components_Touchable_TouchableOpacity = __esm({
 	
 	TouchableOpacity = (function(_super) {
 		function TouchableOpacity() {
-			__classCallCheck(this, TouchableOpacity);
+			ªªªªªªªªªªªªªªªª(this, TouchableOpacity);
 			var _newTarget = this.constructor,_this = __callSuper(_super, arguments, _newTarget);
 			;
 			_this.state = { anim: new Animated$1.Value(__assertThisInitialized(_this)._getChildStyleOpacityWithDefault()), pressability: new Pressability(__assertThisInitialized(_this)._createPressabilityConfig()) };
@@ -57045,7 +57045,7 @@ var init_react_native_Libraries_Components_DrawerAndroid_DrawerLayoutAndroidFall
 	
 	DrawerLayoutAndroid = (function(_super) {
 		function DrawerLayoutAndroid() {
-			__classCallCheck(this, DrawerLayoutAndroid);
+			ªªªªªªªªªªªªªªªª(this, DrawerLayoutAndroid);
 			var _newTarget = this.constructor;
 			return __callSuper(_super, arguments, _newTarget);
 		}
@@ -57125,7 +57125,7 @@ var init_react_native_Libraries_Image_ImageBackground = __esm({
 	
 	ImageBackground = (function(_super) {
 		function ImageBackground() {
-			__classCallCheck(this, ImageBackground);
+			ªªªªªªªªªªªªªªªª(this, ImageBackground);
 			var _newTarget = this.constructor,_this = __callSuper(_super, arguments, _newTarget);
 			;
 			_this._viewRef = null;
@@ -57536,7 +57536,7 @@ var init_react_native_Libraries_Components_Keyboard_KeyboardAvoidingView = __esm
 	
 	KeyboardAvoidingView = (function(_super) {
 		function KeyboardAvoidingView(props) {
-			__classCallCheck(this, KeyboardAvoidingView);
+			ªªªªªªªªªªªªªªªª(this, KeyboardAvoidingView);
 			var _newTarget = this.constructor,_this;
 			;
 			{
@@ -57885,7 +57885,7 @@ var init_react_native_Libraries_Modal_Modal = __esm({
 	;
 	Modal = (function(_super) {
 		function Modal(props) {
-			__classCallCheck(this, Modal);
+			ªªªªªªªªªªªªªªªª(this, Modal);
 			var _newTarget = this.constructor,_this;
 			;
 			__assertThisUninitialized(_this),_this = __callSuper(_super, [props], _newTarget);
@@ -58244,7 +58244,7 @@ var init_react_native_Libraries_Components_StatusBar_StatusBar = __esm({
 	
 	StatusBar = (function(_super) {
 		function StatusBar() {
-			__classCallCheck(this, StatusBar);
+			ªªªªªªªªªªªªªªªª(this, StatusBar);
 			var _newTarget = this.constructor,_this = __callSuper(_super, arguments, _newTarget);
 			;
 			_this._stackEntry = null;
@@ -58475,7 +58475,7 @@ var init_react_native_Libraries_Components_Switch_Switch = __esm({
 		return true;
 	};
 	Switch = function(_b) {
-		var forwardedRef = _b.ref,props = __rest(_b, ["ref"]),_c,_d,_e,_f,_g,_a = props,disabled = _a.disabled,ios_backgroundColor = _a.ios_backgroundColor,onChange = _a.onChange,onValueChange = _a.onValueChange,style = _a.style,thumbColor = _a.thumbColor,trackColor = _a.trackColor,value = _a.value,restProps = __rest(_a, ["disabled", "ios_backgroundColor", "onChange", "onValueChange", "style", "thumbColor", "trackColor", "value"]),trackColorForFalse = (trackColor == null ? void 0 : trackColor.false),trackColorForTrue = (trackColor == null ? void 0 : trackColor.true),nativeSwitchRef = require_react_index().useRef(null),ref = useMergeRefs(nativeSwitchRef, forwardedRef),_b = __read(require_react_index().useState({ value: null }), 2),native = _b[0],setNative = _b[1],handleChange = function(event) {
+		var forwardedRef = _b.ref,props = __rest(_b, ["ref"]),_c,_d,_e,_f,_g,_a = props,disabled = _a.disabled,ios_backgroundColor = _a.ios_backgroundColor,onChange = _a.onChange,onValueChange = _a.onValueChange,style = _a.style,thumbColor = _a.thumbColor,trackColor = _a.trackColor,value = _a.value,restProps = __rest(_a, ["disabled", "ios_backgroundColor", "onChange", "onValueChange", "style", "thumbColor", "trackColor", "value"]),trackColorForFalse = (trackColor == null ? void 0 : trackColor.false),trackColorForTrue = (trackColor == null ? void 0 : trackColor.true),nativeSwitchRef = require_react_index().useRef(null),ref = useMergeRefs(nativeSwitchRef, forwardedRef),_b = ªªªªªª(require_react_index().useState({ value: null }), 2),native = _b[0],setNative = _b[1],handleChange = function(event) {
 			onChange == null || onChange(event);
 			onValueChange == null || onValueChange(event.nativeEvent.value);
 			setNative({ value: event.nativeEvent.value });
@@ -59262,7 +59262,7 @@ var init_react_native_src_private_components_virtualview_VirtualView = __esm({
 	createVirtualView = function(initialState) {
 		var initialHidden = initialState !== NotHidden;
 		function VirtualView_withRef(_b,ref) {
-			var children = _b.children,hiddenStyle = _b.hiddenStyle === void 0 ? defaultHiddenStyle : _b.hiddenStyle,nativeID = _b.nativeID,style = _b.style,onModeChange = _b.onModeChange,removeClippedSubviews = _b.removeClippedSubviews,_b,_c,_d,_e,_a = ªªªªªª(require_react_index().useState(initialState), 2),state = _a[0],setState = _a[1];
+			var children = _b.children,hiddenStyle = _b.hiddenStyle === void 0 ? defaultHiddenStyle : _b.hiddenStyle,nativeID = _b.nativeID,style = _b.style,onModeChange = _b.onModeChange,removeClippedSubviews = _b.removeClippedSubviews,_b,_c,_d,_e,_a = __read(require_react_index().useState(initialState), 2),state = _a[0],setState = _a[1];
 			;
 			;
 			var isHidden = state !== NotHidden,handleModeChange = function(event) {
@@ -59859,7 +59859,7 @@ var init_react_native_Libraries_PermissionsAndroid_PermissionsAndroid = __esm({
 	PERMISSIONS = Object.freeze({ READ_CALENDAR: "android.permission.READ_CALENDAR", WRITE_CALENDAR: "android.permission.WRITE_CALENDAR", CAMERA: "android.permission.CAMERA", READ_CONTACTS: "android.permission.READ_CONTACTS", WRITE_CONTACTS: "android.permission.WRITE_CONTACTS", GET_ACCOUNTS: "android.permission.GET_ACCOUNTS", ACCESS_FINE_LOCATION: "android.permission.ACCESS_FINE_LOCATION", ACCESS_COARSE_LOCATION: "android.permission.ACCESS_COARSE_LOCATION", ACCESS_BACKGROUND_LOCATION: "android.permission.ACCESS_BACKGROUND_LOCATION", RECORD_AUDIO: "android.permission.RECORD_AUDIO", READ_PHONE_STATE: "android.permission.READ_PHONE_STATE", CALL_PHONE: "android.permission.CALL_PHONE", READ_CALL_LOG: "android.permission.READ_CALL_LOG", WRITE_CALL_LOG: "android.permission.WRITE_CALL_LOG", ADD_VOICEMAIL: "com.android.voicemail.permission.ADD_VOICEMAIL", READ_VOICEMAIL: "com.android.voicemail.permission.READ_VOICEMAIL", WRITE_VOICEMAIL: "com.android.voicemail.permission.WRITE_VOICEMAIL", USE_SIP: "android.permission.USE_SIP", PROCESS_OUTGOING_CALLS: "android.permission.PROCESS_OUTGOING_CALLS", BODY_SENSORS: "android.permission.BODY_SENSORS", BODY_SENSORS_BACKGROUND: "android.permission.BODY_SENSORS_BACKGROUND", SEND_SMS: "android.permission.SEND_SMS", RECEIVE_SMS: "android.permission.RECEIVE_SMS", READ_SMS: "android.permission.READ_SMS", RECEIVE_WAP_PUSH: "android.permission.RECEIVE_WAP_PUSH", RECEIVE_MMS: "android.permission.RECEIVE_MMS", READ_EXTERNAL_STORAGE: "android.permission.READ_EXTERNAL_STORAGE", READ_MEDIA_IMAGES: "android.permission.READ_MEDIA_IMAGES", READ_MEDIA_VIDEO: "android.permission.READ_MEDIA_VIDEO", READ_MEDIA_AUDIO: "android.permission.READ_MEDIA_AUDIO", READ_MEDIA_VISUAL_USER_SELECTED: "android.permission.READ_MEDIA_VISUAL_USER_SELECTED", WRITE_EXTERNAL_STORAGE: "android.permission.WRITE_EXTERNAL_STORAGE", BLUETOOTH_CONNECT: "android.permission.BLUETOOTH_CONNECT", BLUETOOTH_SCAN: "android.permission.BLUETOOTH_SCAN", BLUETOOTH_ADVERTISE: "android.permission.BLUETOOTH_ADVERTISE", ACCESS_MEDIA_LOCATION: "android.permission.ACCESS_MEDIA_LOCATION", ACCEPT_HANDOVER: "android.permission.ACCEPT_HANDOVER", ACTIVITY_RECOGNITION: "android.permission.ACTIVITY_RECOGNITION", ANSWER_PHONE_CALLS: "android.permission.ANSWER_PHONE_CALLS", READ_PHONE_NUMBERS: "android.permission.READ_PHONE_NUMBERS", UWB_RANGING: "android.permission.UWB_RANGING", POST_NOTIFICATIONS: "android.permission.POST_NOTIFICATIONS", NEARBY_WIFI_DEVICES: "android.permission.NEARBY_WIFI_DEVICES" });
 	PermissionsAndroidImpl = (function() {
 		function PermissionsAndroidImpl() {
-			__classCallCheck(this, PermissionsAndroidImpl);
+			ªªªªªªªªªªªªªªªª(this, PermissionsAndroidImpl);
 			this.PERMISSIONS = PERMISSIONS;
 			this.RESULTS = PERMISSION_REQUEST_RESULT;
 		}
@@ -60018,7 +60018,7 @@ var init_react_native_Libraries_PushNotificationIOS_PushNotificationIOS = __esm(
 	DEVICE_LOCAL_NOTIF_EVENT = "localNotificationReceived";
 	PushNotificationIOS = (function() {
 		function PushNotificationIOS(nativeNotif) {
-			__classCallCheck(this, PushNotificationIOS);
+			ªªªªªªªªªªªªªªªª(this, PushNotificationIOS);
 			var _this = this;
 			this._data = {};
 			this._remoteNotificationCompleteCallbackCalled = false;
@@ -60244,7 +60244,7 @@ var init_react_native_Libraries_Share_Share = __esm({
 	invariant$53 = require_invariant_browser();
 	Share = (function() {
 		function Share() {
-			__classCallCheck(this, Share);
+			ªªªªªªªªªªªªªªªª(this, Share);
 		}
 		Object.defineProperty(Share, "share", { configurable: true, writable: true, value: function(content,options) {
 			options = options === void 0 ? {} : options;

--- a/tests/integration/tests/fixtures/rn-example-app/zts-require-check.js
+++ b/tests/integration/tests/fixtures/rn-example-app/zts-require-check.js
@@ -684,7 +684,7 @@ var init_read = __esm({
 //#endregion
 //#region NativeModules.js
 var exports_react_native_Libraries_BatchedBridge_NativeModules = {};
-var ªªªªªª, BatchedBridge$1, invariant$2, genModule, loadModule, genMethod, arrayContains, updateErrorWithErrorData, NativeModules;
+var __read, BatchedBridge$1, invariant$2, genModule, loadModule, genMethod, arrayContains, updateErrorWithErrorData, NativeModules;
 __export(exports_react_native_Libraries_BatchedBridge_NativeModules, {
 	"default": function() { return NativeModules; },
 });
@@ -694,7 +694,7 @@ var init_react_native_Libraries_BatchedBridge_NativeModules = __esm({
 		if (!config) {
 			return null;
 		}
-		var _a = ªªªªªª(config, 5),moduleName = _a[0],constants = _a[1],methods = _a[2],promiseMethods = _a[3],syncMethods = _a[4];
+		var _a = __read(config, 5),moduleName = _a[0],constants = _a[1],methods = _a[2],promiseMethods = _a[3],syncMethods = _a[4];
 		invariant$2(!moduleName.startsWith("RCT") && !moduleName.startsWith("RK"), "Module name prefixes should've been stripped by the native side but wasn't for " + moduleName);
 		if (!constants && !methods) {
 			return { name: moduleName };
@@ -10439,18 +10439,18 @@ var init_react_native_src_private_webapis_errors_DOMException = __esm({
 			var _newTarget = this.constructor,_this;
 			;
 			{
-				ªªªªªªªªªªªªªªªªªªªªªªªªª(_this),_this = __callSuper(_super, [message], _newTarget);
+				__assertThisUninitialized(_this),_this = __callSuper(_super, [message], _newTarget);
 				_name.set(_this, void 0);
 				_code.set(_this, void 0);
 			}
 			if (typeof name === "undefined") {
-				__classPrivateFieldSet(_name, ªªªªªªªªªªªªªªªªªªªªªªª(_this), "Error");
-				__classPrivateFieldSet(_code, ªªªªªªªªªªªªªªªªªªªªªªª(_this), 0);
+				__classPrivateFieldSet(_name, __assertThisInitialized(_this), "Error");
+				__classPrivateFieldSet(_code, __assertThisInitialized(_this), 0);
 			} else {
-				__classPrivateFieldSet(_name, ªªªªªªªªªªªªªªªªªªªªªªª(_this), String(name));
-				__classPrivateFieldSet(_code, ªªªªªªªªªªªªªªªªªªªªªªª(_this), (_a = ERROR_NAME_TO_ERROR_CODE_MAP[ªªªªªªªªªªªªªªªªªªªªªªª(_this).name]) != null ? _a : 0);
+				__classPrivateFieldSet(_name, __assertThisInitialized(_this), String(name));
+				__classPrivateFieldSet(_code, __assertThisInitialized(_this), (_a = ERROR_NAME_TO_ERROR_CODE_MAP[__assertThisInitialized(_this).name]) != null ? _a : 0);
 			}
-			return ªªªªªªªªªªªªªªªªªªªªªªª(_this);
+			return __assertThisInitialized(_this);
 		}
 		__extends(DOMException, _super);
 		Object.defineProperty(DOMException.prototype, "name", { configurable: true, get: function() {
@@ -57167,7 +57167,7 @@ __export(exports_react_native_Libraries_Utilities_useWindowDimensions, {
 var init_react_native_Libraries_Utilities_useWindowDimensions = __esm({
 	"useWindowDimensions.js"() {
 	useWindowDimensions = function() {
-		var _a = __read(require_react_index().useState(function() {
+		var _a = ªªªªªª(require_react_index().useState(function() {
 			return Dimensions.get("window");
 		}), 2),dimensions = _a[0],setDimensions = _a[1];
 		require_react_index().useEffect(function() {


### PR DESCRIPTION
## Summary

- **Closes #2426** — PR #2425 의 review agent 가 식별한 동일 realloc-UAF 패턴 7 사이트 sweep
- 모두 PR #2425 에서 도입한 `Ast.iterateExtraList` 헬퍼로 교체 → realloc-safe contract 가 이름으로 명시
- es5-rn integration: 27 pass / 3 fail = main baseline (zero regression)

> 📌 **Stacked on PR #2425** — base 가 `fix/2422-extra-data-realloc-class`. #2425 머지 시 GitHub 자동 rebase to main.

## 사이트

### `src/transformer/minify.zig` (3 sites)
- `rewriteArrayUnused` — `simplifyUnusedInPlace` 재귀 → `reduceToSequenceExpr` 가 `extra_data.ensureUnusedCapacity` + `appendAssumeCapacity`
- `rewriteCallOrNewUnused` — 동일 패턴 (`@__PURE__` 호출 인자 drop 시 트리거)
- `rewriteObjectUnused` (third loop) — computed key + value 재귀 (다른 두 loop 은 read-only 라 안전)

### `src/transformer/es2015_block_scoping.zig` (2 sites)
- `BlockBodyTransformer` block_statement (line 417) — `transformStmtFlow` 재귀가 `addNode`/`addNodeList`
- `transformStmtFlow` block_statement arm (line 539) — 동일 패턴

### `src/transformer/es_helpers.zig` (2 sites)
- `rewriteTDZReferencesInner` `.list` arm — `makeTDZCall` → `makeStaticMember` → `addExtras`
- 동일 함수 `.extra` arm with `extraListOffsets` — 동일

## 변환 패턴

```zig
// AS-IS (캡처된 slice 가 재귀 호출 후 invalid)
const items = ast.extra_data.items[start .. start + len];
for (items) |raw| {
    try recurseFn(self, @enumFromInt(raw), ...);
}

// TO-BE (realloc-safe iterator)
var iter = self.ast.iterateExtraList(.{ .start = start, .len = len });
while (iter.next()) |child| {
    try recurseFn(self, child, ...);
}
```

## Test plan

- [x] `zig build test` — 전체 통과
- [x] `zig build napi` — 빌드 성공
- [x] `bun test es5-rn` — 27 pass / 3 fail (main baseline 동일)
- [x] `zig fmt src/` — clean
- [ ] CI 통과 (PR #2425 머지 후 main 으로 rebase 필요할 수 있음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)