### PR TITLE
perf(transpile): thread fn-scope shadow counter through binding-lite scan

### DIFF
--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -527,7 +527,7 @@ fn hasUnsupportedNamedImportLocalBindingShadow(ast: *const Ast) bool {
 
     for (ast.nodes.items, 0..) |node, raw_idx| {
         if (node.tag != .program) continue;
-        return scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(raw_idx), names_buf[0..names_len], 0, false);
+        return scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(raw_idx), names_buf[0..names_len], 0, false, null);
     }
     return false;
 }
@@ -603,35 +603,21 @@ fn walkFunctionVarBindingPatterns(
     return false;
 }
 
-fn functionVarImportShadowOverflow(ast: *const Ast, idx: ast_mod.NodeIndex, names: []const []const u8, match_count: *usize) bool {
-    const Ctx = struct {
-        ast: *const Ast,
-        names: []const []const u8,
-        match_count: *usize,
-    };
-    const visit = struct {
-        fn onBindingPattern(c: Ctx, binding_idx: ast_mod.NodeIndex) bool {
-            return bindingPatternImportShadowOverflow(c.ast, binding_idx, c.names, c.match_count);
-        }
-    }.onBindingPattern;
-    return walkFunctionVarBindingPatterns(
-        ast,
-        idx,
-        Ctx{ .ast = ast, .names = names, .match_count = match_count },
-        visit,
-    );
-}
-
 fn scanVariableDeclarationForUnsupportedBindingLiteShadow(
     ast: *const Ast,
     node: ast_mod.Node,
     names: []const []const u8,
     scope_depth: usize,
     inside_function: bool,
+    fn_shadow_count: ?*usize,
 ) bool {
     const list_start = ast.extra_data.items[node.data.extra + 1];
     const list_len = ast.extra_data.items[node.data.extra + 2];
-    var matching_shadows: usize = 0;
+    // 함수 scope 안이면 호출자가 누적 카운터를 넘기고, 모듈 scope 면 statement 로컬 카운터로 폴백.
+    // statement-local shadow 수는 before/after 차이로 계산해 lex/non-lex top-level 결정에 쓴다.
+    var local_count: usize = 0;
+    const counter = fn_shadow_count orelse &local_count;
+    const before = counter.*;
     var i: u32 = 0;
     while (i < list_len) : (i += 1) {
         const decl_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[list_start + i]);
@@ -639,12 +625,12 @@ fn scanVariableDeclarationForUnsupportedBindingLiteShadow(
         const decl = ast.getNode(decl_idx);
         if (decl.tag != .variable_declarator) continue;
         const binding_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[decl.data.extra]);
-        if (bindingPatternImportShadowOverflow(ast, binding_idx, names, &matching_shadows)) return true;
+        if (bindingPatternImportShadowOverflow(ast, binding_idx, names, counter)) return true;
         const init_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[decl.data.extra + 2]);
-        if (scanForUnsupportedBindingLiteShadow(ast, init_idx, names, scope_depth, inside_function)) return true;
+        if (scanForUnsupportedBindingLiteShadow(ast, init_idx, names, scope_depth, inside_function, fn_shadow_count)) return true;
     }
 
-    if (matching_shadows == 0) return false;
+    if (counter.* == before) return false;
     if (ast.variableDeclarationKind(node).isLexical()) return scope_depth == 0;
     return !inside_function;
 }
@@ -655,10 +641,11 @@ fn scanChildrenForUnsupportedBindingLiteShadow(
     names: []const []const u8,
     child_scope_depth: usize,
     inside_function: bool,
+    fn_shadow_count: ?*usize,
 ) bool {
     var it = ast_walk.children(ast, node);
     while (it.next()) |child_idx| {
-        if (scanForUnsupportedBindingLiteShadow(ast, child_idx, names, child_scope_depth, inside_function)) return true;
+        if (scanForUnsupportedBindingLiteShadow(ast, child_idx, names, child_scope_depth, inside_function, fn_shadow_count)) return true;
     }
     return false;
 }
@@ -672,17 +659,18 @@ fn scanFunctionForUnsupportedBindingLiteShadow(
 ) bool {
     const e = node.data.extra;
     // function_expression / function 의 extras[0] 은 inner-only self-name 이라 outer scope binding
-    // 으로 스캔하면 안 되고 별도 overflow 카운트만 잡는다. function_declaration 은 extras[0] 이
-    // outer 에 노출되는 binding 이므로 일반 스캔 경로를 그대로 탄다.
+    // 으로 스캔하면 안 되고 함수-스코프 카운터에만 누적한다. function_declaration 은 extras[0] 이
+    // outer 에 노출되는 binding 이므로 일반 스캔 경로 (fn_shadow_count=null) 를 그대로 탄다.
     const is_function_expression = node.tag != .function_declaration;
-    var matching_shadows: usize = 0;
-    if (is_function_expression and functionExpressionNameImportShadowOverflow(ast, node, names, &matching_shadows)) return true;
-    if (bindingPatternImportShadowOverflow(ast, @enumFromInt(ast.extra_data.items[e + 1]), names, &matching_shadows)) return true;
-    if (functionVarImportShadowOverflow(ast, @enumFromInt(ast.extra_data.items[e + 2]), names, &matching_shadows)) return true;
+    // 한 함수 scope 안에서 누적되는 shadow 수. 함수-식 self-name + params + body 안 var binding 합산.
+    // params/body 일반 scan 에 같은 카운터를 스레딩해 BindingLite 과 동일 set 에 대해 overflow 만 잡고,
+    // params/body 트리는 한 번씩만 순회한다.
+    var fn_shadow_count: usize = 0;
+    if (is_function_expression and functionExpressionNameImportShadowOverflow(ast, node, names, &fn_shadow_count)) return true;
 
-    if (!is_function_expression and scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e]), names, scope_depth, inside_function)) return true;
-    if (scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e + 1]), names, scope_depth, inside_function)) return true;
-    return scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e + 2]), names, scope_depth + 1, true);
+    if (!is_function_expression and scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e]), names, scope_depth, inside_function, null)) return true;
+    if (scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e + 1]), names, scope_depth, inside_function, &fn_shadow_count)) return true;
+    return scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e + 2]), names, scope_depth + 1, true, &fn_shadow_count);
 }
 
 fn scanForUnsupportedBindingLiteShadow(
@@ -691,6 +679,7 @@ fn scanForUnsupportedBindingLiteShadow(
     names: []const []const u8,
     scope_depth: usize,
     inside_function: bool,
+    fn_shadow_count: ?*usize,
 ) bool {
     if (idx.isNone()) return false;
     const node = ast.getNode(idx);
@@ -698,17 +687,20 @@ fn scanForUnsupportedBindingLiteShadow(
         // scope_depth: program 은 0, block/body 진입마다 +1. inside_function: function/arrow body
         // 이하 ancestry. 두 값이 함께 쓰이는 이유는 transpile.zig:573-575 의 truth table 참고 — top-level
         // var 은 import 를 가리지만 함수 내 var 는 nearest function scope 에만 머물러 outer use 를 안 가린다.
-        .program => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, 0, false),
-        .block_statement => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, scope_depth + 1, inside_function),
-        .function_body => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, scope_depth + 1, true),
+        .program => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, 0, false, null),
+        .block_statement => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, scope_depth + 1, inside_function, fn_shadow_count),
+        .function_body => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, scope_depth + 1, true, fn_shadow_count),
         .formal_parameters => {
-            var matching_shadows: usize = 0;
-            return bindingPatternImportShadowOverflow(ast, idx, names, &matching_shadows);
+            var local_count: usize = 0;
+            const counter = fn_shadow_count orelse &local_count;
+            return bindingPatternImportShadowOverflow(ast, idx, names, counter);
         },
         .catch_clause => {
-            var matching_shadows: usize = 0;
-            if (bindingPatternImportShadowOverflow(ast, node.data.binary.left, names, &matching_shadows)) return true;
-            return scanForUnsupportedBindingLiteShadow(ast, node.data.binary.right, names, scope_depth + 1, inside_function);
+            // catch 매개변수는 catch block scope 에만 binding 되어 BindingLite 의 함수-scope shadow set
+            // 에 합산되지 않는다. 단일 catch 안 overflow 만 별도 fresh counter 로 검사한다.
+            var local_count: usize = 0;
+            if (bindingPatternImportShadowOverflow(ast, node.data.binary.left, names, &local_count)) return true;
+            return scanForUnsupportedBindingLiteShadow(ast, node.data.binary.right, names, scope_depth + 1, inside_function, fn_shadow_count);
         },
         .function_declaration,
         .function_expression,
@@ -716,12 +708,14 @@ fn scanForUnsupportedBindingLiteShadow(
         => return scanFunctionForUnsupportedBindingLiteShadow(ast, node, names, scope_depth, inside_function),
         .arrow_function_expression => {
             const e = node.data.extra;
-            if (scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e]), names, scope_depth, inside_function)) return true;
-            return scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e + 1]), names, scope_depth + 1, true);
+            // arrow 도 자기 function scope 를 가지므로 새 카운터를 연다. params 와 body 가 함께 누적.
+            var arrow_shadow_count: usize = 0;
+            if (scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e]), names, scope_depth, inside_function, &arrow_shadow_count)) return true;
+            return scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e + 1]), names, scope_depth + 1, true, &arrow_shadow_count);
         },
-        .variable_declaration => return scanVariableDeclarationForUnsupportedBindingLiteShadow(ast, node, names, scope_depth, inside_function),
+        .variable_declaration => return scanVariableDeclarationForUnsupportedBindingLiteShadow(ast, node, names, scope_depth, inside_function, fn_shadow_count),
         .binding_identifier => return string_list.contains(names, ast.getText(node.span)),
-        else => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, scope_depth, inside_function),
+        else => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, scope_depth, inside_function, fn_shadow_count),
     }
 }
 

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -614,7 +614,8 @@ fn scanVariableDeclarationForUnsupportedBindingLiteShadow(
     const list_start = ast.extra_data.items[node.data.extra + 1];
     const list_len = ast.extra_data.items[node.data.extra + 2];
     // 함수 scope 안이면 호출자가 누적 카운터를 넘기고, 모듈 scope 면 statement 로컬 카운터로 폴백.
-    // statement-local shadow 수는 before/after 차이로 계산해 lex/non-lex top-level 결정에 쓴다.
+    // before snapshot 은 lex/non-lex top-level fallback 결정에 쓰는 statement-local 카운트를 분리해
+    // 둔다 — 같은 함수의 다른 var statement 가 누적한 값을 자기 것으로 오인하지 않게.
     var local_count: usize = 0;
     const counter = fn_shadow_count orelse &local_count;
     const before = counter.*;
@@ -650,6 +651,20 @@ fn scanChildrenForUnsupportedBindingLiteShadow(
     return false;
 }
 
+// 함수/arrow scope 의 params + body 를 같은 카운터로 한 번씩만 순회. arrow 와 function 양쪽이 공유.
+fn scanFunctionScopeParamsAndBody(
+    ast: *const Ast,
+    params_idx: ast_mod.NodeIndex,
+    body_idx: ast_mod.NodeIndex,
+    names: []const []const u8,
+    scope_depth: usize,
+    inside_function: bool,
+    fn_shadow_count: *usize,
+) bool {
+    if (scanForUnsupportedBindingLiteShadow(ast, params_idx, names, scope_depth, inside_function, fn_shadow_count)) return true;
+    return scanForUnsupportedBindingLiteShadow(ast, body_idx, names, scope_depth + 1, true, fn_shadow_count);
+}
+
 fn scanFunctionForUnsupportedBindingLiteShadow(
     ast: *const Ast,
     node: ast_mod.Node,
@@ -663,14 +678,19 @@ fn scanFunctionForUnsupportedBindingLiteShadow(
     // outer 에 노출되는 binding 이므로 일반 스캔 경로 (fn_shadow_count=null) 를 그대로 탄다.
     const is_function_expression = node.tag != .function_declaration;
     // 한 함수 scope 안에서 누적되는 shadow 수. 함수-식 self-name + params + body 안 var binding 합산.
-    // params/body 일반 scan 에 같은 카운터를 스레딩해 BindingLite 과 동일 set 에 대해 overflow 만 잡고,
-    // params/body 트리는 한 번씩만 순회한다.
+    // BindingLite collector (markBindingLiteFunctionScope) 가 모으는 set 과 동일 — overflow 시 fallback.
     var fn_shadow_count: usize = 0;
     if (is_function_expression and functionExpressionNameImportShadowOverflow(ast, node, names, &fn_shadow_count)) return true;
-
     if (!is_function_expression and scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e]), names, scope_depth, inside_function, null)) return true;
-    if (scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e + 1]), names, scope_depth, inside_function, &fn_shadow_count)) return true;
-    return scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e + 2]), names, scope_depth + 1, true, &fn_shadow_count);
+    return scanFunctionScopeParamsAndBody(
+        ast,
+        @enumFromInt(ast.extra_data.items[e + 1]),
+        @enumFromInt(ast.extra_data.items[e + 2]),
+        names,
+        scope_depth,
+        inside_function,
+        &fn_shadow_count,
+    );
 }
 
 fn scanForUnsupportedBindingLiteShadow(
@@ -708,10 +728,17 @@ fn scanForUnsupportedBindingLiteShadow(
         => return scanFunctionForUnsupportedBindingLiteShadow(ast, node, names, scope_depth, inside_function),
         .arrow_function_expression => {
             const e = node.data.extra;
-            // arrow 도 자기 function scope 를 가지므로 새 카운터를 연다. params 와 body 가 함께 누적.
+            // arrow 도 자기 function scope 를 가지므로 새 카운터를 연다. function 과 같은 헬퍼 공유.
             var arrow_shadow_count: usize = 0;
-            if (scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e]), names, scope_depth, inside_function, &arrow_shadow_count)) return true;
-            return scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e + 1]), names, scope_depth + 1, true, &arrow_shadow_count);
+            return scanFunctionScopeParamsAndBody(
+                ast,
+                @enumFromInt(ast.extra_data.items[e]),
+                @enumFromInt(ast.extra_data.items[e + 1]),
+                names,
+                scope_depth,
+                inside_function,
+                &arrow_shadow_count,
+            );
         },
         .variable_declaration => return scanVariableDeclarationForUnsupportedBindingLiteShadow(ast, node, names, scope_depth, inside_function, fn_shadow_count),
         .binding_identifier => return string_list.contains(names, ast.getText(node.span)),

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -705,8 +705,10 @@ fn scanForUnsupportedBindingLiteShadow(
     const node = ast.getNode(idx);
     switch (node.tag) {
         // scope_depth: program 은 0, block/body 진입마다 +1. inside_function: function/arrow body
-        // 이하 ancestry. 두 값이 함께 쓰이는 이유는 transpile.zig:573-575 의 truth table 참고 — top-level
-        // var 은 import 를 가리지만 함수 내 var 는 nearest function scope 에만 머물러 outer use 를 안 가린다.
+        // 이하 ancestry. 두 값을 함께 쓰는 이유는 scanVariableDeclarationForUnsupp 의 return 두 줄이
+        // truth table — top-level lexical (lex && depth==0) 또는 모듈-스코프 var (!lex && !inside_function)
+        // 만 import 를 가리는 fallback 조건이고, 함수 내 var 는 nearest function scope 에만 머물러 outer
+        // use 를 안 가린다.
         .program => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, 0, false, null),
         .block_statement => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, scope_depth + 1, inside_function, fn_shadow_count),
         .function_body => return scanChildrenForUnsupportedBindingLiteShadow(ast, node, names, scope_depth + 1, true, fn_shadow_count),


### PR DESCRIPTION
## 요약
`scanFunctionForUnsupportedBindingLiteShadow` 가 함수마다 params/body 트리를 두 번 순회 하던 패턴을 제거. 함수-스코프 shadow 카운터를 일반 scan 경로에 스레딩 해서 한 번의 walk 로 overflow 검사 + shadow 검출이 모두 끝난다.

## 컨텍스트
직전 #2424 리뷰에서 efficiency agent 가 "params/body 이중 순회" 를 medium severity 로 지적. 본 PR 직접 변경 범위 밖이라 별도 follow-up 으로 분리 (#2427 머지 후).

## Before
```zig
fn scanFunctionForUnsupportedBindingLiteShadow(...) bool {
    var matching_shadows: usize = 0;
    // 1차 walk: 함수-스코프 카운터로 params/body var overflow 만 누적
    bindingPatternImportShadowOverflow(params, names, &matching_shadows)
    functionVarImportShadowOverflow(body, names, &matching_shadows)
    // 2차 walk: 일반 재귀 scan (.formal_parameters 도 fresh counter 로 재 walk)
    scanForUnsupportedBindingLiteShadow(name)
    scanForUnsupportedBindingLiteShadow(params)  // 같은 트리 두 번째 walk
    scanForUnsupportedBindingLiteShadow(body)    // 같은 트리 두 번째 walk
}
```

## After
```zig
fn scanForUnsupportedBindingLiteShadow(..., fn_shadow_count: ?*usize) bool {
    // .formal_parameters / .variable_declaration / .catch_clause 가 호출자가 넘긴
    // 함수-스코프 카운터로 직접 누적. 모듈 scope / catch param 은 fresh local 폴백.
}

fn scanFunctionForUnsupportedBindingLiteShadow(...) bool {
    var fn_shadow_count: usize = 0;
    if (is_fn_expr and functionExpressionNameImportShadowOverflow(...)) return true;

    if (!is_fn_expr and scanForUnsupportedBindingLiteShadow(name, ..., null)) return true;
    if (scanForUnsupportedBindingLiteShadow(params, ..., &fn_shadow_count)) return true;
    return scanForUnsupportedBindingLiteShadow(body, ..., &fn_shadow_count);
}
```

핵심 포인트:
- `?*usize fn_shadow_count` 를 `scanForUnsupp` / `scanChildren` / `scanVarDecl` 에 스레딩.
- `.formal_parameters` 와 `.variable_declaration` 이 호출자 카운터로 직접 누적.
- `.arrow_function_expression` 도 자기 카운터를 연다 (별도 function scope).
- `.program` 과 `catch param` 은 함수 scope 누적 대상이 아니라 fresh local 폴백.
- `scanVarDecl` 의 lex/non-lex top-level fallback 결정은 statement-local shadow 수가 필요하므로 `before/after` 차이로 계산 — 호출자가 함수-스코프 카운터를 넘겨도 statement-local 의미를 유지.

## 부수 효과
- `functionVarImportShadowOverflow` 와 그 Ctx wrapper 삭제 (스레딩이 동일 역할 수행).
- `walkFunctionVarBindingPatterns` 는 `collectBindingLiteFunctionVarShadows` 가 계속 사용 (이번 변경 범위 밖). 호출자가 한 곳뿐이라 후속에서 인라인 검토 여지 있음.

## 동작 동등성
- function expression name 검사 로직 동일.
- 함수-스코프 overflow trigger: 함수-식 self-name + params + body var binding 합산이 `binding_lite_max_shadows` 초과 시 true. 이전과 동일 set.
- 단일 catch param overflow / 단일 var statement top-level fallback 결정도 동일.
- `binding_shadow_requires_full_semantic` plan reason 카운트 동일.

## 검증
- `zig fmt --check src/transpile.zig`
- `zig build test --summary all` — 4518/4518 통과
- `zig build -Doptimize=ReleaseFast --summary all`
- `zig build napi -Doptimize=ReleaseFast --summary all`
- `bun test packages/core/index.test.ts --timeout 30000` — 369/0
- `bun run tests/benchmark/profile.ts` — fast/full delta 표·plan hit rate 표 회귀 없음

## Profile (회귀 없음)
| Lines | fast on (ms) | fast off (ms) | ratio |
| --- | --- | --- | --- |
| 25000 | 20 | 54 | 2.70x |
| 50000 | 39 | 171 | 4.38x |
| 100000 | 73 | 604 | 8.27x |

대표 route plan hit rates `bindings | named_import_binding_elision: 3/14`, `binding_shadow_requires_full_semantic: 1` 동일 — overflow 검출 동등성 보장.

## 디자인 노트 (Zig 초보자용)
- `?*usize` 는 nullable pointer to usize. `null` 이면 호출자가 카운터 추적을 원치 않음 → 호출 사이트가 `var local: usize = 0; const counter = fn_shadow_count orelse &local;` 패턴으로 fresh 카운터로 폴백.
- `before/after` 패턴: shared counter 안에서 statement-local 변화량을 알고 싶을 때 호출 전 값을 저장하고 호출 후 차이를 본다. JS 의 `let before = counter;` 와 동일한 흐름.

Refs #2424 #2427