### PR TITLE
perf(parser): O(1) graph pre-pass gate + TS export = CJS lowering

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -476,6 +476,58 @@ describe("@zts/core buildSync", () => {
     rmSync(skipDir, { recursive: true, force: true });
   });
 
+  test("TS export = value → module.exports = value (rolldown/oxc 패턴)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-export-equals-value-"));
+    writeFileSync(join(dir, "app.ts"), 'const value = { name: "exp-eq", n: 42 };\nexport = value;');
+    const result = buildSync({ entryPoints: [join(dir, "app.ts")] });
+    expect(result.errors.length).toBe(0);
+    const out = result.outputFiles[0].text;
+    expect(out).toContain("module.exports");
+    expect(out).toContain('"exp-eq"');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("TS export = class → module.exports = class", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-export-equals-class-"));
+    writeFileSync(
+      join(dir, "app.ts"),
+      "export = class Foo { greet() { return 'hi from class'; } };",
+    );
+    const result = buildSync({ entryPoints: [join(dir, "app.ts")] });
+    expect(result.errors.length).toBe(0);
+    const out = result.outputFiles[0].text;
+    expect(out).toContain("module.exports");
+    expect(out).toContain("class Foo");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("TS export = function → module.exports = function", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-export-equals-function-"));
+    writeFileSync(
+      join(dir, "app.ts"),
+      "export = function add(a: number, b: number) { return a + b; };",
+    );
+    const result = buildSync({ entryPoints: [join(dir, "app.ts")] });
+    expect(result.errors.length).toBe(0);
+    const out = result.outputFiles[0].text;
+    expect(out).toContain("module.exports");
+    expect(out).toContain("function add");
+    expect(out).not.toContain(": number");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("TS export = require().default cherry-pick (CJS interop)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-export-equals-require-"));
+    writeFileSync(join(dir, "app.ts"), "export = require('foo').default;");
+    const result = buildSync({ entryPoints: [join(dir, "app.ts")], external: ["foo"] });
+    expect(result.errors.length).toBe(0);
+    const out = result.outputFiles[0].text;
+    expect(out).toContain("module.exports");
+    expect(out).toContain("require");
+    expect(out).toContain(".default");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   test("graph pre-pass keep: JSX and decorator/downlevel helper cases still transform", () => {
     const keepDir = mkdtempSync(join(tmpdir(), "zts-prepass-keep-transform-"));
     writeFileSync(join(keepDir, "jsx.tsx"), "export const App = () => <div>ok</div>;");

--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -528,6 +528,101 @@ describe("@zts/core buildSync", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
+  test("TS export = identifier (transpile + minify): export 식별자 보존, 다른 식별자만 mangle", () => {
+    // transpile 모드 — 단일 파일이라 export 된 이름이 외부 require() 호출로 노출.
+    // semantic analyzer 의 visitTsExportAssignment 가 inner identifier 를 export 로 mark
+    // 해서 mangler 가 declaration 을 rename 하지 않는다 (export default 와 동일 보호).
+    const r = transpile("class Box { v = 1; greet() { return this.v; } }\nexport = Box;", {
+      filename: "app.ts",
+      minifyIdentifiers: true,
+      minifyWhitespace: true,
+    });
+    expect(r.errors).toBeUndefined();
+    expect(r.code).toContain("class Box");
+    expect(r.code).toContain("module.exports=Box");
+  });
+
+  test("TS export = function (transpile + minify): export 식별자 보존, helper 식별자 mangle", () => {
+    const r = transpile(
+      "function add(a: number, b: number) { return a + b; }\nconst helper = (x: number) => x * 2;\nexport = add;",
+      { filename: "app.ts", minifyIdentifiers: true, minifyWhitespace: true },
+    );
+    expect(r.errors).toBeUndefined();
+    expect(r.code).toContain("function add");
+    expect(r.code).toContain("module.exports=add");
+    // helper 식별자는 다른 곳에서 참조되지 않으므로 mangle 됨.
+    expect(r.code).not.toContain("const helper");
+  });
+
+  test("TS export = identifier (bundle + minify): __commonJS wrapper 안에서 일관된 mangle", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-export-equals-bundle-minify-"));
+    writeFileSync(
+      join(dir, "app.ts"),
+      "class Box { v = 1; greet() { return this.v; } }\nexport = Box;",
+    );
+    const result = buildSync({ entryPoints: [join(dir, "app.ts")], minify: true });
+    expect(result.errors.length).toBe(0);
+    const out = result.outputFiles[0].text;
+    // bundle 모드에서는 declaration 과 reference 가 함께 mangle (정합성만 유지하면 OK).
+    expect(out).toMatch(/module\.exports=\w+/);
+    expect(out).toContain("class");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("TS export = class + target=es5: 다운레벨링과 export = 호환", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-export-equals-es5-class-"));
+    writeFileSync(join(dir, "app.ts"), "class Foo { greet() { return 'hi'; } }\nexport = Foo;");
+    const result = buildSync({ entryPoints: [join(dir, "app.ts")], target: "es5" });
+    expect(result.errors.length).toBe(0);
+    const out = result.outputFiles[0].text;
+    expect(out).toContain("module.exports");
+    expect(out).toContain("Foo");
+    expect(out).not.toContain("class Foo");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("TS export = async function + target=es5: __async helper 와 함께 lower", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-export-equals-es5-async-"));
+    writeFileSync(join(dir, "app.ts"), "export = async function () { return 42; };");
+    const result = buildSync({ entryPoints: [join(dir, "app.ts")], target: "es5" });
+    expect(result.errors.length).toBe(0);
+    const out = result.outputFiles[0].text;
+    expect(out).toContain("module.exports");
+    expect(out).not.toContain("async function");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("TS export = arrow + target=es5: 화살표가 function expression 으로 lower", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-export-equals-es5-arrow-"));
+    writeFileSync(join(dir, "app.ts"), "export = (x: number) => x * 2;");
+    const result = buildSync({ entryPoints: [join(dir, "app.ts")], target: "es5" });
+    expect(result.errors.length).toBe(0);
+    const out = result.outputFiles[0].text;
+    expect(out).toContain("module.exports");
+    // bundler 의 __commonJS 헬퍼 자체는 arrow — user-side 만 정확히 변환됐는지 확인.
+    expect(out).toMatch(/module\.exports\s*=\s*function/);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("TS export = process.env ternary + define: 컴파일 시 분기 결정 + constant fold", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-export-equals-define-"));
+    writeFileSync(
+      join(dir, "app.ts"),
+      'const value = process.env.NODE_ENV === "production" ? "prod" : "dev";\nexport = { mode: value };',
+    );
+    const result = buildSync({
+      entryPoints: [join(dir, "app.ts")],
+      define: { "process.env.NODE_ENV": '"production"' },
+    });
+    expect(result.errors.length).toBe(0);
+    const out = result.outputFiles[0].text;
+    expect(out).toContain("module.exports");
+    // define 치환 → constant fold → "prod" 만 남음 ("dev" 분기 dead-code).
+    expect(out).toContain('"prod"');
+    expect(out).not.toContain('"dev"');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
   test("graph pre-pass keep: JSX and decorator/downlevel helper cases still transform", () => {
     const keepDir = mkdtempSync(join(tmpdir(), "zts-prepass-keep-transform-"));
     writeFileSync(join(keepDir, "jsx.tsx"), "export const App = () => <div>ok</div>;");

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1767,7 +1767,9 @@ pub const ModuleGraph = struct {
         }
 
         const ast = &module.ast.?;
-        if (ast.has_jsx or ast.has_decorator or ast.has_ts_namespace_or_enum or ast.has_ts_import_equals) {
+        if (ast.has_jsx or ast.has_decorator or ast.has_ts_namespace_or_enum or
+            ast.has_ts_import_equals or ast.has_ts_export_equals)
+        {
             return true;
         }
 

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1760,22 +1760,18 @@ pub const ModuleGraph = struct {
         if (!module.module_type.isJavaScriptLike()) return false;
         if (plugin_transform_applied) return true;
 
-        const opts = self.transform_options_base;
-        if (opts.unsupported.hasAny()) return true;
-        if (opts.drop_console or opts.drop_debugger or opts.drop_labels.len > 0) return true;
-        if (opts.define.len > 0) return true;
-        if (opts.module_specifier_map.len > 0) return true;
-        if (opts.minify_syntax or opts.minify_whitespace or self.minify_identifiers) return true;
-        if (!opts.use_define_for_class_fields) return true;
-        if (opts.experimental_decorators or opts.emit_decorator_metadata) return true;
-
+        // 싸구려 bool 검사 먼저 (단일 byte load) → 비교적 비싼 옵션 predicate 마지막.
+        if (self.minify_identifiers) return true;
         if (self.react_refresh or self.styled_components or self.emotion or self.worklet_transform) {
             return true;
         }
 
         const ast = &module.ast.?;
-        if (ast.has_jsx) return true;
-        return astNeedsTransformerPrePass(ast);
+        if (ast.has_jsx or ast.has_decorator or ast.has_ts_namespace_or_enum or ast.has_ts_import_equals) {
+            return true;
+        }
+
+        return self.transform_options_base.requiresGraphPrePass();
     }
 
     /// transformer pre-pass — graph 단계에서 1회 실행.
@@ -2121,25 +2117,6 @@ pub const ModuleGraph = struct {
                 std.mem.eql(u8, binding.imported_name, needle.imported_name))
             {
                 return true;
-            }
-        }
-        return false;
-    }
-
-    /// 호출 전에 `ast.has_jsx` 가 이미 short-circuit 처리되므로 JSX 태그는 제외.
-    fn astNeedsTransformerPrePass(ast: *const Ast) bool {
-        for (ast.nodes.items) |node| {
-            switch (node.tag) {
-                .decorator,
-                .ts_enum_declaration,
-                .ts_module_declaration,
-                .ts_module_block,
-                .ts_import_equals_declaration,
-                .ts_external_module_reference,
-                .ts_export_assignment,
-                .ts_namespace_export_declaration,
-                => return true,
-                else => {},
             }
         }
         return false;

--- a/src/codegen/codegen_test/basic.zig
+++ b/src/codegen/codegen_test/basic.zig
@@ -70,6 +70,39 @@ test "Codegen CJS: export default" {
     try std.testing.expectEqualStrings("module.exports=42;", r.output);
 }
 
+test "Codegen: TS export = primitive → module.exports = primitive" {
+    var r = try e2e(std.testing.allocator, "export = 42;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("module.exports=42;", r.output);
+}
+
+test "Codegen: TS export = identifier → module.exports = identifier" {
+    var r = try e2e(std.testing.allocator,
+        \\const value = 42;
+        \\export = value;
+    );
+    defer r.deinit();
+    try std.testing.expectEqualStrings("const value=42;module.exports=value;", r.output);
+}
+
+test "Codegen: TS export = class expression → module.exports = class" {
+    var r = try e2e(std.testing.allocator, "export = class Foo { greet() { return 'hi'; } };");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("module.exports=class Foo{greet(){return \"hi\";}};", r.output);
+}
+
+test "Codegen: TS export = function expression → module.exports = function" {
+    var r = try e2e(std.testing.allocator, "export = function add(a: number, b: number) { return a + b; };");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("module.exports=function add(a,b){return a + b;};", r.output);
+}
+
+test "Codegen: TS export = require().default cherry-pick" {
+    var r = try e2e(std.testing.allocator, "export = require('foo').default;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("module.exports=require(\"foo\").default;", r.output);
+}
+
 test "Codegen: drop debugger" {
     var r = try e2eFull(std.testing.allocator, "debugger; const x = 1;", .{ .drop_debugger = true }, .{ .minify_whitespace = true }, ".ts");
     defer r.deinit();

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -303,10 +303,21 @@ pub const Node = struct {
         ts_enum_body,
         ts_enum_member,
         ts_module_declaration,
+        // 미emit. parseNamespaceBlock 이 .block_statement 로 emit — 일반 block visitor /
+        // dead-code 분석을 special case 없이 재사용. tsc/swc/oxc 는 별도 노드, esbuild/Bun 도
+        // 분리 안 하고 stmt list 직접 보유. 영구 dead 후보지만 enum parity 위해 유지.
         ts_module_block,
         ts_import_equals_declaration,
+        // 미emit. import-equals 의 require("x") 는 일반 .call_expression 으로 파싱되고
+        // expression.zig:888 inline scan 이 CJS import record 등록. tsc/swc/oxc 는 별도
+        // wrapper 노드, esbuild/Bun 은 SLocal flag 패턴. 영구 dead 후보지만 enum parity 위해 유지.
         ts_external_module_reference,
+        // emit 됨 (module.zig). transformer 가 `module.exports = expr;` 로 lowering
+        // (rolldown/oxc/esbuild/swc 동일 패턴). data.unary.operand = rhs expression.
         ts_export_assignment,
+        // 미emit. module.zig:860 가 NodeIndex.none 으로 strip 중. `export as namespace X;`
+        // 는 UMD global 선언 — 순수 declarative, runtime emission 없음. 모든 번들러가 strip
+        // (esbuild 는 STypeScriptShared no-op 노드로 보존). 영구 dead 후보지만 유지.
         ts_namespace_export_declaration,
         ts_type_parameter,
         ts_type_parameter_declaration,
@@ -541,6 +552,7 @@ pub const Node = struct {
                 .ts_rest_type,
                 .ts_type_operator,
                 .ts_non_null_expression,
+                .ts_export_assignment,
                 .flow_nullable_type,
                 // TS/Flow type-cast / assertion expressions — codegen emitter 가
                 // data.unary.operand 만 출력 (type 부분 스트리핑).
@@ -725,7 +737,6 @@ pub const Node = struct {
                 .ts_enum_declaration,
                 .flow_enum_declaration,
                 .ts_external_module_reference,
-                .ts_export_assignment,
                 .ts_namespace_export_declaration,
                 .ts_type_parameter,
                 .ts_this_parameter,
@@ -882,6 +893,10 @@ pub const Ast = struct {
     /// 게이트용 — value-bearing import-equals 는 strip 대상이 아니라 lowering 대상.
     has_ts_import_equals: bool = false,
 
+    /// `export = expr;` (TS CJS interop) 가 있는가. graph pre-pass 게이트용 —
+    /// transformer 가 `module.exports = expr;` 로 lowering 한다 (rolldown/oxc 패턴).
+    has_ts_export_equals: bool = false,
+
     /// D1 (RFC #1672) 디버그 인프라. Transformer.init 시점의 `nodes.items.len` snapshot.
     /// null = 미변환. boundary 이상의 노드는 transformer 가 append 한 것.
     /// D1a 부터 clone 경로 (Transformer.init → cloneForTransformer) 에서 활성.
@@ -933,6 +948,7 @@ pub const Ast = struct {
             .has_decorator = source_ast.has_decorator,
             .has_ts_namespace_or_enum = source_ast.has_ts_namespace_or_enum,
             .has_ts_import_equals = source_ast.has_ts_import_equals,
+            .has_ts_export_equals = source_ast.has_ts_export_equals,
             .allocator = allocator,
             // #1961: source_ast 가 이미 transform 된 상태면 transformed_root + boundary 도
             // 복사. 그렇지 않으면 emit 단계 transformer 가 graph pre-pass 결과를 무시하고

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -869,6 +869,19 @@ pub const Ast = struct {
     /// 주입 여부를 이 플래그로 결정.
     has_jsx_key_after_spread: bool = false,
 
+    /// `@decorator` 가 있는가. graph pre-pass 게이트가 O(1) 체크로 사용 — 레거시
+    /// decorator 변환은 graph 단계에서 transformer 결과를 link 단계 helper import
+    /// 등록에 반영해야 한다.
+    has_decorator: bool = false,
+
+    /// TS `enum` 또는 `namespace`/`module` 선언이 있는가. graph pre-pass 게이트용.
+    /// 두 구문 모두 IIFE 로 lowering 되어 graph-visible 변환을 유발한다.
+    has_ts_namespace_or_enum: bool = false,
+
+    /// `import X = require(...)` (또는 `import X = ns.Y`) 가 있는가. graph pre-pass
+    /// 게이트용 — value-bearing import-equals 는 strip 대상이 아니라 lowering 대상.
+    has_ts_import_equals: bool = false,
+
     /// D1 (RFC #1672) 디버그 인프라. Transformer.init 시점의 `nodes.items.len` snapshot.
     /// null = 미변환. boundary 이상의 노드는 transformer 가 append 한 것.
     /// D1a 부터 clone 경로 (Transformer.init → cloneForTransformer) 에서 활성.
@@ -917,6 +930,9 @@ pub const Ast = struct {
             .source = source_ast.source,
             .has_jsx = source_ast.has_jsx,
             .has_jsx_key_after_spread = source_ast.has_jsx_key_after_spread,
+            .has_decorator = source_ast.has_decorator,
+            .has_ts_namespace_or_enum = source_ast.has_ts_namespace_or_enum,
+            .has_ts_import_equals = source_ast.has_ts_import_equals,
             .allocator = allocator,
             // #1961: source_ast 가 이미 transform 된 상태면 transformed_root + boundary 도
             // 복사. 그렇지 않으면 emit 단계 transformer 가 graph pre-pass 결과를 무시하고

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -871,11 +871,17 @@ pub fn parseExportDeclarationWithDecorators(self: *Parser, decorators: ast_mod.N
         }
     }
 
-    // TS: export = expr — export assignment (타입 전용)
+    // TS: export = expr — CJS interop. transformer 가 `module.exports = expr;` 로
+    // lower (rolldown/oxc/esbuild/swc 동일). data.unary.operand = rhs expression.
     if (try self.eat(.eq)) {
-        _ = try self.parseAssignmentExpression();
+        self.ast.has_ts_export_equals = true;
+        const expr = try self.parseAssignmentExpression();
         _ = try self.eat(.semicolon);
-        return NodeIndex.none;
+        return try self.ast.addNode(.{
+            .tag = .ts_export_assignment,
+            .span = .{ .start = start, .end = self.currentSpan().start },
+            .data = .{ .unary = .{ .operand = expr, .flags = 0 } },
+        });
     }
 
     // export var/let/const/function/class

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -300,6 +300,7 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
     {
         const next = try self.peekNextKind();
         if (next == .eq) {
+            self.ast.has_ts_import_equals = true;
             // import-equals는 TS CJS 호환 구문 → module syntax로 취급하지 않음.
             //
             // ts_import_equals_declaration 은 strip target 이 *아님* —

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -128,6 +128,7 @@ pub fn parseTsEnumDeclaration(self: *Parser) ParseError2!NodeIndex {
 /// enum 파싱. flags: 0=일반 enum, 1=const enum.
 /// extra = [name, members_start, members_len, flags]
 fn parseTsEnumDeclarationWithFlags(self: *Parser, flags: u32) ParseError2!NodeIndex {
+    self.ast.has_ts_namespace_or_enum = true;
     const start = self.currentSpan().start;
     try self.advance(); // skip 'enum'
 
@@ -191,6 +192,7 @@ fn parseTsEnumMember(self: *Parser) ParseError2!NodeIndex {
 
 /// namespace Foo { ... } / module "name" { ... }
 pub fn parseTsModuleDeclaration(self: *Parser) ParseError2!NodeIndex {
+    self.ast.has_ts_namespace_or_enum = true;
     const start = self.currentSpan().start;
     try self.advance(); // skip 'namespace' or 'module'
     return parseTsModuleBody(self, start);
@@ -342,6 +344,7 @@ pub fn parseDecoratedStatement(self: *Parser) ParseError2!NodeIndex {
 
 /// @expr — 단일 데코레이터 파싱
 pub fn parseDecorator(self: *Parser) ParseError2!NodeIndex {
+    self.ast.has_decorator = true;
     const start = self.currentSpan().start;
     try self.advance(); // skip @
     // decorator expression에서 computed member access ([) 금지

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -1212,6 +1212,7 @@ pub const SemanticAnalyzer = struct {
             .export_named_declaration => try self.visitExportNamedDeclaration(node),
             .export_default_declaration => try self.visitExportDefaultDeclaration(node, idx),
             .export_all_declaration => try self.visitExportAllDeclaration(node),
+            .ts_export_assignment => try self.visitTsExportAssignment(node),
 
             // Flow component syntax: extra = [func_decl, const_decl]
             // func_decl의 이름/params가 합성 span이라 visitFunctionDeclaration을
@@ -3122,6 +3123,20 @@ pub const SemanticAnalyzer = struct {
                 },
                 else => {},
             }
+        }
+    }
+
+    /// `export = expr;` (TS CJS interop) — transformer 가 `module.exports = expr;` 로 lower.
+    /// inner identifier reference 의 symbol 에 `is_exported` 플래그를 set 해서 mangler 가
+    /// rename 하지 않도록 보호한다 (`export default someVar` 와 동일 패턴).
+    fn visitTsExportAssignment(self: *SemanticAnalyzer, node: Node) AllocError!void {
+        const inner_idx = node.data.unary.operand;
+        try self.visitNode(inner_idx);
+
+        if (inner_idx.isNone() or @intFromEnum(inner_idx) >= self.ast.nodes.items.len) return;
+        const inner = self.ast.getNode(inner_idx);
+        if (inner.tag == .identifier_reference) {
+            self.markSymbolExported(self.ast.getText(inner.span), false);
         }
     }
 

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -305,6 +305,22 @@ pub const TransformOptions = struct {
     emit_runtime_helper_imports: bool = false,
 
     pub const compat = @import("compat.zig");
+
+    /// graph 단계 transformer pre-pass 가 옵션-side 사유로 필요한지.
+    /// graph-level 플래그 (react_refresh / styled_components / emotion / worklet_transform /
+    /// minify_identifiers) 는 ModuleGraph 가 별도로 결합한다.
+    /// 새 transformer-driven 옵션을 추가하면 여기에도 반영해야 graph 의 게이트가
+    /// silent 하게 fall-through 하지 않는다.
+    pub fn requiresGraphPrePass(self: *const TransformOptions) bool {
+        if (self.unsupported.hasAny()) return true;
+        if (self.drop_console or self.drop_debugger or self.drop_labels.len > 0) return true;
+        if (self.define.len > 0) return true;
+        if (self.module_specifier_map.len > 0) return true;
+        if (self.minify_syntax or self.minify_whitespace) return true;
+        if (!self.use_define_for_class_fields) return true;
+        if (self.experimental_decorators or self.emit_decorator_metadata) return true;
+        return false;
+    }
 };
 
 /// 런타임 헬퍼 사용 추적 비트맵.

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -1705,6 +1705,9 @@ pub const Transformer = struct {
             // import x = require('y') → const x = require('y')
             .ts_import_equals_declaration => self.visitImportEqualsDeclaration(node),
 
+            // export = expr → module.exports = expr;
+            .ts_export_assignment => self.visitExportAssignment(node),
+
             // === 나머지: invalid + TS 타입 전용 노드 ===
             // TS 타입 노드는 isTypeOnlyNode 검사(위)에서 이미 .none으로 반환됨.
             // 여기 도달하면 strip_types=false인 경우 → 그대로 복사.
@@ -2970,6 +2973,20 @@ pub const Transformer = struct {
             .span = node.span,
             .data = .{ .extra = var_extra },
         });
+    }
+
+    /// `export = expr;` → `module.exports = expr;` ExpressionStatement.
+    /// ESM output context 에서는 런타임에서 `module is not defined` 으로 실패하지만
+    /// (tsc TS1203 동등), rewrite 는 무조건 — #1961 의 helper-import 패턴과 동일하게
+    /// 정책 (warn/strip/error) 은 호출자/codegen 이 결정.
+    fn visitExportAssignment(self: *Transformer, node: Node) Error!NodeIndex {
+        const new_expr = try self.visitNode(node.data.unary.operand);
+        if (new_expr.isNone()) return .none;
+
+        const module_id = try es_helpers.makeIdentifierRef(self, "module");
+        const exports_id = try es_helpers.makeIdentifierRef(self, "exports");
+        const member = try es_helpers.makeStaticMember(self, module_id, exports_id, node.span);
+        return es_helpers.makeAssignStmt(self, member, new_expr, node.span, 0);
     }
 
     fn visitNamespaceDeclaration(self: *Transformer, node: Node) Error!NodeIndex {
@@ -5027,9 +5044,9 @@ pub const Transformer = struct {
             // ts_namespace_export_declaration은 타입 전용 (export as namespace X)
             .ts_namespace_export_declaration,
             // TS import/export 특수 형태
-            // ts_import_equals_declaration은 런타임 코드 생성 — visitNode에서 별도 처리
+            // ts_import_equals_declaration / ts_export_assignment 는 런타임 코드 생성
+            // — visitNode 에서 별도 처리.
             .ts_external_module_reference,
-            .ts_export_assignment,
             // enum은 타입 전용이 아님 — 런타임 코드 생성이 필요
             // visitNode의 switch에서 별도 처리
             // Flow 타입 (flow.zig에서 생성)

--- a/tests/integration/tests/__snapshots__/round2-fuzz.test.ts.snap
+++ b/tests/integration/tests/__snapshots__/round2-fuzz.test.ts.snap
@@ -84,7 +84,7 @@ exports[`Round 2 fuzz 27-symbol-asynciter.ts 1`] = `"6"`;
 
 exports[`Round 2 fuzz 28-getter-setter-symbol.ts 1`] = `"8 s:5,g,s:8,g"`;
 
-exports[`Round 2 fuzz 29-export-equals.ts 1`] = `""`;
+exports[`Round 2 fuzz 29-export-equals.ts 1`] = `"{"name":"exp-eq","n":42}"`;
 
 exports[`Round 2 fuzz 30-import-equals.ts 1`] = `"function"`;
 
@@ -100,3 +100,9 @@ exports[`Round 2 fuzz 34-spread-call-rest.ts 1`] = `
 `;
 
 exports[`Round 2 fuzz 35-strict-mode.ts 1`] = `"TypeError"`;
+
+exports[`Round 2 fuzz 36-export-equals-class.ts 1`] = `"hi-from-export-equals-class"`;
+
+exports[`Round 2 fuzz 37-export-equals-function.ts 1`] = `"5"`;
+
+exports[`Round 2 fuzz 38-export-equals-primitive.ts 1`] = `"84"`;

--- a/tests/integration/tests/fixtures/round2/29-export-equals.ts
+++ b/tests/integration/tests/fixtures/round2/29-export-equals.ts
@@ -1,3 +1,4 @@
-// TS-only: export = ... (CJS interop)
+// TS-only: export = identifier (CJS interop, rolldown/oxc 패턴 — module.exports = value)
 const value = { name: "exp-eq", n: 42 };
+console.log(JSON.stringify(value));
 export = value;

--- a/tests/integration/tests/fixtures/round2/36-export-equals-class.ts
+++ b/tests/integration/tests/fixtures/round2/36-export-equals-class.ts
@@ -1,0 +1,8 @@
+// TS-only: export = class (CJS interop, rolldown/oxc 패턴 — module.exports = class)
+const Foo = class {
+  greet() {
+    return "hi-from-export-equals-class";
+  }
+};
+console.log(new Foo().greet());
+export = Foo;

--- a/tests/integration/tests/fixtures/round2/37-export-equals-function.ts
+++ b/tests/integration/tests/fixtures/round2/37-export-equals-function.ts
@@ -1,0 +1,6 @@
+// TS-only: export = function (CJS interop)
+function add(a: number, b: number): number {
+  return a + b;
+}
+console.log(add(2, 3));
+export = add;

--- a/tests/integration/tests/fixtures/round2/38-export-equals-primitive.ts
+++ b/tests/integration/tests/fixtures/round2/38-export-equals-primitive.ts
@@ -1,0 +1,4 @@
+// TS-only: export = primitive (CJS interop edge — bare expression)
+const ANSWER = 42;
+console.log(ANSWER * 2);
+export = ANSWER;

--- a/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
@@ -9492,6 +9492,7 @@ class ErrClass3 extends this {
 var SomeEnum = /* @__PURE__ */ ((SomeEnum) => {SomeEnum[SomeEnum["A"]=this]="A";SomeEnum[SomeEnum["B"]=// Should not be allowed
 this.spaaaace]="B";return SomeEnum;})(SomeEnum || {});
 // Also should not be allowed
+module.exports = this;
 // Should be an error
 "
 `;


### PR DESCRIPTION
PR #2432 follow-up. **세 가지 작업** 을 함께 묶음 — perf refactor 작업 중 graph 게이트의 `ts_export_assignment` strip-as-no-op 패턴이 frozen bug 임을 발견 → 정식 lowering 추가 → minify 호환성 회귀 발견 → semantic analyzer 도 fix.

---

## 1. graph pre-pass O(1) 게이트 (perf)

**커밋** `ea461f1e` + `7fbec951`

graph 단계 transformer pre-pass 게이트가 매 모듈마다 `ast.nodes` 를 선형 스캔(`astNeedsTransformerPrePass`)하던 부분을, 파서가 set 한 boolean 플래그의 O(1) OR 로 대체.

- `Ast` 신규 플래그 3개 (`has_jsx` 패턴 미러): `has_decorator`, `has_ts_namespace_or_enum`, `has_ts_import_equals`
- 파서 emit 사이트 wire-up (4사이트, 함수 진입 시 set)
- `TransformOptions.requiresGraphPrePass()` 추출
- `ModuleGraph.shouldRunTransformerPrePass` 리팩터 — O(n) `astNeedsTransformerPrePass` 헬퍼 제거, cheap-checks-first

## 2. TS `export = expr;` runtime CJS lowering (feat)

**커밋** `e5874756` + `0f952e29`

ZTS 가 그동안 누락하던 `export = X;` 런타임 변환을 rolldown/oxc/esbuild/swc 와 동일한 패턴으로 추가. 기존에는 NodeIndex.none 으로 strip → `.ts` 의 `export = SomeClass;` 가 출력에서 사라지는 문제 (`round2/29` snapshot `\"\"` 가 frozen bug).

- parser (`module.zig`): `export = expr` 를 `ts_export_assignment` 노드로 emit, `has_ts_export_equals` 플래그 set
- AST (`ast.zig`): `has_ts_export_equals` 플래그 + `cloneForTransformer` 전파, layout `.extra` → `.unary`
- transformer (`transformer.zig`): `visitExportAssignment` 가 `module.exports` static-member + assignment-statement 합성 (`es_helpers.makeAssignStmt` 사용). in-place 변환 — rolldown/oxc 패턴
- graph 게이트: `has_ts_export_equals` 추가

## 3. minify 호환 fix (semantic) ⚠️

**커밋** `81d2f139`

`--minify` 와 함께 transpile 시 `class Box { ... }; export = Box;` → `class e { ... }; module.exports = Box;` 회귀 발견. declaration 만 mangle 되고 transformer-합성 reference 는 stale → `ReferenceError`.

원인: semantic analyzer 가 `ts_export_assignment` 처리 안 해서 inner identifier 의 symbol 에 `is_exported` 가 set 되지 않음. mangler 가 "unreferenced" 로 오판.

수정: `visitTsExportAssignment` 추가 — `visitExportDefaultDeclaration` 의 identifier_reference 처리 패턴 그대로 미러.

---

## Test plan
- [x] `zig build test` 전체 통과
- [x] `bun test packages/core/index.test.ts` (**384 pass / 0 fail** — minify/target/define 조합 7건 신규 포함)
- [x] `bun test tests/integration/tests/round2-fuzz.test.ts` (38 pass / 0 fail)
- [x] CLI 스모크: `export = class/function/identifier/object` × `--minify`/`--define`/`--drop` 조합 런타임 검증
- [x] `tsc/expressions thisInInvalidContextsExternalModule` snapshot 정정
- [x] 전체 통합 회귀: 21 fail 모두 `main` 동등 (pre-existing)

## Follow-up 후보 (이번 PR 외)
- `__commonJS` 등 bundler 런타임 헬퍼의 arrow function 이 `target: es5` 모드에서도 유지됨 — esbuild/Bun 동일 패턴이지만 진짜 ES5-only 런타임 (IE11/구 RN) 호환을 원하면 별도 처리 필요. 별도 issue 후보.
- 실측 perf: 큰 TS 모듈 graph parse 시간 비교

🤖 Generated with [Claude Code](https://claude.com/claude-code)