### PR TITLE
perf(bundler): AST feature 기반 graph pre-pass gate 확장

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -443,6 +443,24 @@ describe("@zts/core buildSync", () => {
     rmSync(skipDir, { recursive: true, force: true });
   });
 
+  test("graph pre-pass skip: target downlevel without helper syntax stays stable", () => {
+    const skipDir = mkdtempSync(join(tmpdir(), "zts-prepass-skip-target-"));
+    writeFileSync(
+      join(skipDir, "app.ts"),
+      'export const value: number = 1;\nconsole.log("TARGET_SIMPLE_KEPT", value);',
+    );
+    const result = buildSync({
+      entryPoints: [join(skipDir, "app.ts")],
+      target: "es5",
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain("TARGET_SIMPLE_KEPT");
+    expect(result.outputFiles[0].text).not.toContain(": number");
+    expect(result.outputFiles[0].text).not.toContain("__async");
+    expect(result.outputFiles[0].text).not.toContain("__spreadArray");
+    rmSync(skipDir, { recursive: true, force: true });
+  });
+
   test("graph pre-pass skip: type-only imports do not pull runtime modules", () => {
     const skipDir = mkdtempSync(join(tmpdir(), "zts-prepass-skip-type-only-"));
     writeFileSync(

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1742,6 +1742,7 @@ pub const ModuleGraph = struct {
             self.runTransformerPrePass(module, arena_alloc);
         } else {
             module.transform_cache = null;
+            suppressRuntimeHelperInternalUnresolved(module);
         }
 
         module.state = .parsed;
@@ -1773,7 +1774,7 @@ pub const ModuleGraph = struct {
             return true;
         }
 
-        return self.transform_options_base.requiresGraphPrePass();
+        return self.transform_options_base.requiresGraphPrePass(ast);
     }
 
     /// transformer pre-pass — graph 단계에서 1회 실행.
@@ -3702,10 +3703,12 @@ test "graph pre-pass predicate: simple ESM and TS strip modules can skip" {
     try expectPrePassDecision(false, "interface Shape { x: number }\ntype Id<T> = T;\nexport const value: Id<number> = 1;", "types.ts", .{});
     try expectPrePassDecision(false, "import type { User } from './types'; import { value } from './dep'; export type { User }; export { value };", "mixed.ts", .{});
     try expectPrePassDecision(false, "export { value } from './dep'; export * from './other';", "barrel.ts", .{});
+    try expectPrePassDecision(false, "export const value: number = 1;", "target-es5-simple.ts", .{ .transform_options = .{ .unsupported = TransformOptions.compat.fromESTarget(.es5) } });
 }
 
 test "graph pre-pass predicate: synthetic no-op graphs skip every eligible module" {
     try expectAllBuiltModulesSkipPrePass(50);
+    try expectAllBuiltModulesSkipPrePass(200);
 }
 
 test "graph pre-pass predicate: syntax and options that mutate graph-visible surface keep pre-pass" {
@@ -3715,6 +3718,11 @@ test "graph pre-pass predicate: syntax and options that mutate graph-visible sur
     try expectPrePassDecision(true, "namespace N { export const x = 1 } export const y = N.x;", "namespace.ts", .{});
     try expectPrePassDecision(true, "import Foo = require('foo'); export = Foo;", "import-equals.ts", .{});
     try expectPrePassDecision(true, "export const run = async () => await value;", "downlevel.ts", .{ .transform_options = .{ .unsupported = TransformOptions.compat.fromESTarget(.es5) } });
+    try expectPrePassDecision(true, "export async function* g() { yield 1; await Promise.resolve(); }", "async-generator.ts", .{ .transform_options = .{ .unsupported = TransformOptions.compat.fromESTarget(.es5) } });
+    try expectPrePassDecision(true, "export function* ids() { yield 1; }", "generator.ts", .{ .transform_options = .{ .unsupported = TransformOptions.compat.fromESTarget(.es5) } });
+    try expectPrePassDecision(true, "export const xs = [...items];", "spread.ts", .{ .transform_options = .{ .unsupported = TransformOptions.compat.fromESTarget(.es5) } });
+    try expectPrePassDecision(true, "for (const item of items) console.log(item);", "for-of.ts", .{ .transform_options = .{ .unsupported = TransformOptions.compat.fromESTarget(.es5) } });
+    try expectPrePassDecision(true, "export class Child extends Parent {}", "class.ts", .{ .transform_options = .{ .unsupported = TransformOptions.compat.fromESTarget(.es5) } });
     try expectPrePassDecision(true, "class Foo { #x = 1; field = this.#x; }", "private.ts", .{ .transform_options = .{ .unsupported = TransformOptions.compat.fromESTarget(.es2021) } });
     try expectPrePassDecision(true, "console.log(__DEV__); debugger;", "minify-define-drop.ts", .{ .transform_options = .{ .minify_syntax = true } });
     try expectPrePassDecision(true, "console.log(__DEV__);", "define.ts", .{ .transform_options = .{ .define = &.{.{ .key = "__DEV__", .value = "false" }} } });

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -307,6 +307,9 @@ pub const TransformOptions = struct {
     pub const compat = @import("compat.zig");
 
     /// graph 단계 transformer pre-pass 가 필요한지.
+    /// 옵션-side 사유 (drop / define / minify / decorator 등) 를 먼저 cheap 하게 본 뒤,
+    /// `unsupported.*` 가 set 된 경우에 한해 AST 노드 사용을 스캔해 실제로 lowering 대상
+    /// 문법이 있을 때만 pre-pass 를 강제한다 (예: `target=es5` + 단순 TS strip → skip).
     /// graph-level 플래그 (react_refresh / styled_components / emotion / worklet_transform /
     /// minify_identifiers) 는 ModuleGraph 가 별도로 결합한다.
     /// 새 transformer-driven 옵션을 추가하면 여기에도 반영해야 graph 의 게이트가
@@ -342,11 +345,11 @@ pub const TransformOptions = struct {
                 .class_declaration,
                 .class_expression,
                 => {
-                    if (u.class or u.class_private_field or u.class_private_method or u.class_static_block) return true;
+                    if (u.requiresPrivateDownlevel() or u.class_static_block) return true;
                 },
                 .for_of_statement => if (u.for_of) return true,
                 .for_await_of_statement => if (u.needsForAwaitOfDownlevel()) return true,
-                .spread_element => if (u.spread or u.destructuring) return true,
+                .spread_element => if (u.spread) return true,
                 .array_pattern,
                 .object_pattern,
                 .array_assignment_target,
@@ -357,7 +360,7 @@ pub const TransformOptions = struct {
                 => if (u.destructuring) return true,
                 .private_identifier,
                 .private_field_expression,
-                => if (u.class or u.class_private_field or u.class_private_method) return true,
+                => if (u.requiresPrivateDownlevel()) return true,
                 .static_block => if (u.class_static_block) return true,
                 .tagged_template_expression => if (u.template_literal) return true,
                 .variable_declaration => {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -306,20 +306,73 @@ pub const TransformOptions = struct {
 
     pub const compat = @import("compat.zig");
 
-    /// graph 단계 transformer pre-pass 가 옵션-side 사유로 필요한지.
+    /// graph 단계 transformer pre-pass 가 필요한지.
     /// graph-level 플래그 (react_refresh / styled_components / emotion / worklet_transform /
     /// minify_identifiers) 는 ModuleGraph 가 별도로 결합한다.
     /// 새 transformer-driven 옵션을 추가하면 여기에도 반영해야 graph 의 게이트가
     /// silent 하게 fall-through 하지 않는다.
-    pub fn requiresGraphPrePass(self: *const TransformOptions) bool {
-        if (self.unsupported.hasAny()) return true;
+    pub fn requiresGraphPrePass(self: *const TransformOptions, ast: *const Ast) bool {
         if (self.drop_console or self.drop_debugger or self.drop_labels.len > 0) return true;
         if (self.define.len > 0) return true;
         if (self.module_specifier_map.len > 0) return true;
         if (self.minify_syntax or self.minify_whitespace) return true;
         if (!self.use_define_for_class_fields) return true;
         if (self.experimental_decorators or self.emit_decorator_metadata) return true;
+        if (self.unsupportedGraphPrePassFeatureUsed(ast)) return true;
         return false;
+    }
+
+    fn unsupportedGraphPrePassFeatureUsed(self: *const TransformOptions, ast: *const Ast) bool {
+        const u = self.unsupported;
+        if (!u.hasAny()) return false;
+
+        for (ast.nodes.items) |node| {
+            switch (node.tag) {
+                .arrow_function_expression => {
+                    if (u.arrow) return true;
+                    if (u.async_await and hasArrowFlag(ast, node, ast_mod.ArrowFlags.is_async)) return true;
+                },
+                .function_declaration,
+                .function_expression,
+                => {
+                    const flags = ast.readExtra(node.data.extra, 3);
+                    if (u.async_await and (flags & ast_mod.FunctionFlags.is_async) != 0) return true;
+                    if (u.generator and (flags & ast_mod.FunctionFlags.is_generator) != 0) return true;
+                },
+                .class_declaration,
+                .class_expression,
+                => {
+                    if (u.class or u.class_private_field or u.class_private_method or u.class_static_block) return true;
+                },
+                .for_of_statement => if (u.for_of) return true,
+                .for_await_of_statement => if (u.needsForAwaitOfDownlevel()) return true,
+                .spread_element => if (u.spread or u.destructuring) return true,
+                .array_pattern,
+                .object_pattern,
+                .array_assignment_target,
+                .object_assignment_target,
+                .assignment_target_with_default,
+                .binding_rest_element,
+                .assignment_target_rest,
+                => if (u.destructuring) return true,
+                .private_identifier,
+                .private_field_expression,
+                => if (u.class or u.class_private_field or u.class_private_method) return true,
+                .static_block => if (u.class_static_block) return true,
+                .tagged_template_expression => if (u.template_literal) return true,
+                .variable_declaration => {
+                    if (u.using and ast.variableDeclarationKind(node).isUsing()) return true;
+                },
+                .await_expression => if (u.top_level_await) return true,
+                else => {},
+            }
+        }
+        return false;
+    }
+
+    fn hasArrowFlag(ast: *const Ast, node: Node, flag: u32) bool {
+        const e = node.data.extra;
+        return ast.hasExtra(e, 2) and (ast.readExtra(e, 2) & flag) != 0;
     }
 };
 


### PR DESCRIPTION
## 요약
- 최신 `origin/main` 기준 새 브랜치에서 작업했습니다.
- graph transformer pre-pass gate를 `unsupported.hasAny()` 전체 옵션 기준에서 AST feature 사용 여부 기준으로 좁혔습니다.
- `target=es5` 같은 downlevel 옵션이 켜져 있어도 실제 helper/downlevel 문법이 없는 TS/ESM 모듈은 graph pre-pass/re-analysis를 skip합니다.
- helper 가상 모듈이 skip 경로를 탈 때도 내부 runtime helper unresolved-name suppress를 유지해 `__await` 같은 helper rename 회귀를 막았습니다.

## 안전 경계
- async/generator/class/for-of/spread/private/decorator/JSX/TS enum/namespace/import-equals/export-equals 등 graph-visible surface나 helper import가 바뀔 수 있는 문법은 기존 pre-pass 경로를 유지합니다.
- minify/define/drop/plugin transform/React Refresh/styled-components/emotion/worklet도 기존처럼 pre-pass를 유지합니다.
- public API/type 변경은 없습니다.

## 테스트
- `zig build test --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- `zig build napi -Doptimize=ReleaseFast --summary all`
- `bun test packages/core/index.test.ts --timeout 30000`
- `bun run tests/benchmark/bench.ts --bundle`
- `bun run tests/benchmark/bundle-perf.ts --no-fail --output /tmp/zts-bundle-perf-2353-next.json`
- `bun run fmt:check`
- `bun run lint` (기존 `tests/integration/tests/bundle-dynamic-import.test.ts` unused import 경고 3개, error 0)
- `git diff --check`

## 벤치 메모
- `bundle-perf`: no regression 판정
  - small: 4.36ms
  - medium: 40.94ms
  - large: 81.35ms
- 별도 최신 main worktree와 `target=es5` 50/200 module CLI 비교도 no-regression 수준이었습니다. CLI process overhead가 커서 이 PR에서는 성능 수치를 과장하지 않고 skip 가능 범위 확장과 회귀 방어에 초점을 둡니다.
