### PR TITLE
refactor(ast): FunctionExtra / ArrowExtra typed offset struct 도입

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1416,11 +1416,21 @@ fn decodeStringLiteralKey(
 // ============================================================
 
 /// function declaration/expression의 flags 비트.
-/// extra: [name, params.start, params.len, body, flags, return_type]
+/// 실제 extra 레이아웃은 `FunctionExtra` 참고 (params 는 wrapper 노드 1슬롯).
 pub const FunctionFlags = struct {
     pub const is_async: u32 = 0x01;
     pub const is_generator: u32 = 0x02;
     pub const no_side_effects: u32 = 0x04; // @__NO_SIDE_EFFECTS__
+};
+
+/// function_declaration / function_expression extras 레이아웃: [name, params, body, flags, return_type].
+/// 매직 offset 숫자 (`readU32(e, 3)`) 대신 `FunctionExtra.flags` 사용.
+pub const FunctionExtra = struct {
+    pub const name: u32 = 0;
+    pub const params: u32 = 1;
+    pub const body: u32 = 2;
+    pub const flags: u32 = 3;
+    pub const return_type: u32 = 4;
 };
 
 /// method_definition의 flags 비트 (extra[3] u16).
@@ -1521,10 +1531,18 @@ pub const UnaryFlags = struct {
 };
 
 /// arrow_function_expression의 flags (D082).
-/// extra: [params, body, flags]
+/// 실제 extra 레이아웃은 `ArrowExtra` 참고.
 pub const ArrowFlags = struct {
     pub const is_async: u32 = 0x01;
     pub const no_side_effects: u32 = 0x02; // @__NO_SIDE_EFFECTS__
+};
+
+/// arrow_function_expression extras 레이아웃: [params, body, flags].
+/// 매직 offset 숫자 (`readU32(e, 2)`) 대신 `ArrowExtra.flags` 사용.
+pub const ArrowExtra = struct {
+    pub const params: u32 = 0;
+    pub const body: u32 = 1;
+    pub const flags: u32 = 2;
 };
 
 /// tagged_template_expression의 flags (D082).

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -1021,8 +1021,8 @@ pub const SemanticAnalyzer = struct {
     fn isFunctionWithNoSideEffects(self: *const SemanticAnalyzer, node: Node) bool {
         const e = node.data.extra;
         return switch (node.tag) {
-            .function_expression, .function_declaration => self.ast.hasExtra(e, 3) and (self.ast.readExtra(e, 3) & ast_mod.FunctionFlags.no_side_effects) != 0,
-            .arrow_function_expression => self.ast.hasExtra(e, 2) and (self.ast.readExtra(e, 2) & ast_mod.ArrowFlags.no_side_effects) != 0,
+            .function_expression, .function_declaration => self.ast.hasExtra(e, ast_mod.FunctionExtra.flags) and (self.ast.readExtra(e, ast_mod.FunctionExtra.flags) & ast_mod.FunctionFlags.no_side_effects) != 0,
+            .arrow_function_expression => self.ast.hasExtra(e, ast_mod.ArrowExtra.flags) and (self.ast.readExtra(e, ast_mod.ArrowExtra.flags) & ast_mod.ArrowFlags.no_side_effects) != 0,
             else => false,
         };
     }

--- a/src/transformer/es2015_arrow.zig
+++ b/src/transformer/es2015_arrow.zig
@@ -42,7 +42,7 @@ pub fn ES2015Arrow(comptime Transformer: type) type {
 
             const params_idx: NodeIndex = self.readNodeIdx(e, 0);
             const body_idx: NodeIndex = self.readNodeIdx(e, 1);
-            const flags = self.readU32(e, 2);
+            const flags = self.readU32(e, ast_mod.ArrowExtra.flags);
 
             const param_list = try arrowParamsToList(self, params_idx);
 

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -89,7 +89,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             const params_start = params_list_old.start;
             const params_len = params_list_old.len;
             const body_idx: NodeIndex = self.readNodeIdx(e, 2);
-            const flags = self.readU32(e, 3);
+            const flags = self.readU32(e, ast_mod.FunctionExtra.flags);
 
             const new_name = try self.visitNode(name_idx);
 

--- a/src/transformer/es2017.zig
+++ b/src/transformer/es2017.zig
@@ -76,7 +76,7 @@ pub fn ES2017(comptime Transformer: type) type {
             const name_idx: NodeIndex = self.readNodeIdx(e, 0);
             const params_list = self.ast.functionParamsList(node);
             const body_idx: NodeIndex = self.readNodeIdx(e, 2);
-            const flags = self.readU32(e, 3);
+            const flags = self.readU32(e, ast_mod.FunctionExtra.flags);
 
             const new_name = try self.visitNode(name_idx);
             const new_params = try self.visitExtraList(.{ .start = params_list.start, .len = params_list.len });
@@ -153,7 +153,7 @@ pub fn ES2017(comptime Transformer: type) type {
             const params_start = params_list.start;
             const params_len = params_list.len;
             const body_idx: NodeIndex = self.readNodeIdx(e, 2);
-            const flags = self.readU32(e, 3);
+            const flags = self.readU32(e, ast_mod.FunctionExtra.flags);
 
             const new_name = try self.visitNode(name_idx);
             const new_body = try self.visitBodyWorkletAware(body_idx);
@@ -198,7 +198,7 @@ pub fn ES2017(comptime Transformer: type) type {
             const e = node.data.extra;
             const params_idx: NodeIndex = self.readNodeIdx(e, 0);
             const body_idx: NodeIndex = self.readNodeIdx(e, 1);
-            const flags = self.readU32(e, 2);
+            const flags = self.readU32(e, ast_mod.ArrowExtra.flags);
 
             const new_params = try self.visitNode(params_idx);
             const new_body = try self.visitBodyWorkletAware(body_idx);
@@ -249,7 +249,7 @@ pub fn ES2017(comptime Transformer: type) type {
             const params_start = params_list.start;
             const params_len = params_list.len;
             const body_idx: NodeIndex = self.readNodeIdx(e, 2);
-            const flags = self.readU32(e, 3);
+            const flags = self.readU32(e, ast_mod.FunctionExtra.flags);
 
             const new_name = try self.visitNode(name_idx);
 

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -338,7 +338,7 @@ pub const TransformOptions = struct {
                 .function_declaration,
                 .function_expression,
                 => {
-                    const flags = ast.readExtra(node.data.extra, 3);
+                    const flags = ast.readExtra(node.data.extra, ast_mod.FunctionExtra.flags);
                     if (u.async_await and (flags & ast_mod.FunctionFlags.is_async) != 0) return true;
                     if (u.generator and (flags & ast_mod.FunctionFlags.is_generator) != 0) return true;
                 },
@@ -375,7 +375,7 @@ pub const TransformOptions = struct {
 
     fn hasArrowFlag(ast: *const Ast, node: Node, flag: u32) bool {
         const e = node.data.extra;
-        return ast.hasExtra(e, 2) and (ast.readExtra(e, 2) & flag) != 0;
+        return ast.hasExtra(e, ast_mod.ArrowExtra.flags) and (ast.readExtra(e, ast_mod.ArrowExtra.flags) & flag) != 0;
     }
 };
 
@@ -1442,7 +1442,7 @@ pub const Transformer = struct {
             .function_expression,
             => {
                 const e = node.data.extra;
-                const flags = self.readU32(e, 3);
+                const flags = self.readU32(e, ast_mod.FunctionExtra.flags);
                 if (self.options.unsupported.async_await and (flags & ast_mod.FunctionFlags.is_async) != 0) {
                     // async generator (`async function*`) → __asyncGenerator wrapper. (#1911)
                     if ((flags & ast_mod.FunctionFlags.is_generator) != 0) {


### PR DESCRIPTION
## 요약

- `function_declaration` / `function_expression` / `arrow_function_expression` 의 extra_data layout 에 대해 매직 offset (`readU32(e, 3)` / `readU32(e, 2)`) 을 기존 `MethodExtra` / `PropertyExtra` / `ClassExtra` / `FormalParameterExtra` 패턴과 동일하게 named offset struct (`FunctionExtra` / `ArrowExtra`) 로 대체했습니다.
- 기존 `FunctionFlags` doc comment 의 `[name, params.start, params.len, body, flags, return_type]` 표기가 stale 이었습니다. parser emit (`declaration.zig:144-148, 254-258`) 은 params 를 단일 wrapper 노드 1 슬롯으로 기록하므로 실제 layout 은 `[name, params, body, flags, return_type]` (flags offset = 3). `ChildIterator` (`ast.zig:666`) 의 `child_offsets = .{ 0, 1, 2 }` (name / params / body) 가정과도 일치하고, 기존 `readU32(e, 3) → FunctionFlags` 사이트들과도 일치합니다. struct 도입과 함께 stale 주석을 정리했습니다.
- PR #2436 의 /simplify 검토에서 follow-up 으로 식별된 항목입니다 (#2437 의 자매 항목).

## 마이그레이션 사이트

### `FunctionExtra.flags` (offset 3)
- `src/transformer/transformer.zig:341` — `unsupportedGraphPrePassFeatureUsed`
- `src/transformer/transformer.zig:1445` — `visitNode` 의 async / generator dispatch
- `src/transformer/es2017.zig:79, 156, 252` — async function lowering 3 종
- `src/transformer/es2015_generator.zig:92` — generator state machine
- `src/semantic/analyzer.zig:1024` — `isFunctionWithNoSideEffects`

### `ArrowExtra.flags` (offset 2)
- `src/transformer/transformer.zig:378` — `hasArrowFlag`
- `src/transformer/es2017.zig:201` — `lowerAsyncArrow`
- `src/transformer/es2015_arrow.zig:45` — `lowerArrowFunction`
- `src/semantic/analyzer.zig:1025` — `isFunctionWithNoSideEffects`

## 안전 경계

- 본 PR 의 scope 은 `FunctionFlags` / `ArrowFlags` 만 입니다. 다른 매직 offset 사이트 (`CallFlags` / `MemberFlags` / 이미 named struct 보유한 `MethodExtra` 등) 와 `visitFunction` 처럼 method / function 공유 visitor 의 ambiguous 사이트는 손대지 않았습니다 — 별도 follow-up 으로 분리하면 PR diff 가 명확해집니다.
- 컴파일 타임 상수 사용이라 런타임 perf 변화 없음 (순수 가독성 / 유지보수성 리팩터).
- public API / type 변경 없음.

## 테스트
- `zig build test --summary all` — 4538 / 4538 통과
- `zig build -Doptimize=ReleaseFast --summary all`
- `zig build napi -Doptimize=ReleaseFast --summary all` — 성공
- `bun test packages/core/index.test.ts --timeout 30000` — 385 / 385 통과
- `bun run fmt:check` — clean
- pre-push hook (`zig fmt --check`, `zig build test`, `oxlint`, `oxfmt --check`) 모두 통과

## 참고
- PR #2436 (perf/prepass-ast-feature-gate-2353) 의 /simplify 검토 기록.
- 관련 follow-up issue: #2437 (parser O(1) `has_*` bitset 확장으로 graph pre-pass walker 제거).