### PR TITLE
test(bundler): runtime helper skip name suppress 회귀 보강

### DIFF
--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -1840,6 +1840,35 @@ test "Async generator: __asyncGenerator + __await runtime emit (#1911)" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__await(") != null);
 }
 
+test "Runtime helper virtual module skip preserves helper-internal names" {
+    // Regression for graph pre-pass skip on runtime helper virtual modules:
+    // the skip path must still suppress helper-internal unresolved refs, otherwise
+    // deconflict can rename the helper declaration to `__await$1` while helper
+    // bodies and call sites expect the public `__await` binding.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\export async function* g() { await Promise.resolve(1); }
+    );
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    const compat = @import("../../transformer/compat.zig");
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .unsupported = compat.fromESTarget(.es5),
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var __await = function") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "r.value instanceof __await ?") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__await(Promise.resolve(1))") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__await$") == null);
+}
+
 test "Async helper: multi-module with async in one — single emit (edge)" {
     // 여러 모듈 중 한 곳만 async 사용 → helper 1회만 emit
     var tmp = std.testing.tmpDir(.{});


### PR DESCRIPTION
## 요약
- #2436 후속으로 runtime helper virtual module skip 경로의 직접 회귀 테스트를 추가했습니다.
- graph pre-pass skip 경로에서도 helper 내부 unresolved suppress가 유지되어야 합니다.
- 이 suppress가 빠지면 `__await` helper declaration이 `__await$1`처럼 deconflict 되고, helper body/call site의 public helper 이름과 어긋날 수 있습니다.

## 테스트 내용
- ES5 async generator 번들을 만들고 `__await` virtual helper가 skip 경로를 타는 조건을 재현합니다.
- 출력에서 다음을 직접 검증합니다.
  - `var __await = function` 유지
  - `r.value instanceof __await ?` 유지
  - entry call site의 `__await(Promise.resolve(1))` 유지
  - `__await$` rename 없음

## 검증
- `zig build test --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- `git diff --check`
- push 전 hook 통과
  - `zig fmt --check src/...`
  - `zig build test`
  - `oxlint` (기존 unused import warning 3개, error 0)
  - `oxfmt --check`
