### PR TITLE
fix(codegen): namespace-qualified type refs (CT.X) in schema_builder

### DIFF
--- a/src/transformer/plugins/codegen/schema_builder.zig
+++ b/src/transformer/plugins/codegen/schema_builder.zig
@@ -240,7 +240,7 @@ fn collectMembersFromTypeRef(
     const ref_name = getTypeReferenceName(ast, ref_node) orelse return;
     const last = lastSegment(ref_name);
 
-    // wrapper (Readonly<T> 등) 이면 inner 로 풀어 재귀. Namespace alias (CT.Readonly) 도 동등 처리.
+    // wrapper (Readonly<T> 등) 이면 inner 로 풀어 재귀.
     if (isReadonlyWrapperName(last)) {
         const inner = getNthTypeArgument(ast, ref_node, 0) orelse return;
         try collectMembersFromValue(ast, type_index, inner, out, visited, depth + 1, alloc);
@@ -526,7 +526,6 @@ fn eventHandlerBubbling(ast: *const Ast, type_idx: NodeIndex) ?schema.BubblingTy
     const node = ast.getNode(type_idx);
     if (node.tag != .ts_type_reference and node.tag != .flow_type_reference) return null;
     const name = getTypeReferenceName(ast, node) orelse return null;
-    // Namespace alias (CT.DirectEventHandler 등 RN 0.85 표준) 도 last segment 로 매칭.
     return event_handler_names.get(lastSegment(name));
 }
 
@@ -611,8 +610,6 @@ fn mapTypeReference(
     depth: u8,
 ) Error!schema.PropTypeAnnotation {
     const name = getTypeReferenceName(ast, node) orelse return error.UnsupportedPropType;
-    // Namespace alias (CT.X 등 RN 0.85 표준) 의 last segment 로 well-known map 매칭.
-    // type_index lookup 은 full name 유지 — namespaced 면 자연스레 cross-file 처리.
     const last = lastSegment(name);
 
     if (wrapper_ref_names.get(last)) |kind| {

--- a/src/transformer/plugins/codegen/schema_builder.zig
+++ b/src/transformer/plugins/codegen/schema_builder.zig
@@ -238,9 +238,10 @@ fn collectMembersFromTypeRef(
     if (ref_node.tag != .ts_type_reference and ref_node.tag != .flow_type_reference) return;
 
     const ref_name = getTypeReferenceName(ast, ref_node) orelse return;
+    const last = lastSegment(ref_name);
 
-    // wrapper (Readonly<T> 등) 이면 inner 로 풀어 재귀.
-    if (isReadonlyWrapperName(ref_name)) {
+    // wrapper (Readonly<T> 등) 이면 inner 로 풀어 재귀. Namespace alias (CT.Readonly) 도 동등 처리.
+    if (isReadonlyWrapperName(last)) {
         const inner = getNthTypeArgument(ast, ref_node, 0) orelse return;
         try collectMembersFromValue(ast, type_index, inner, out, visited, depth + 1, alloc);
         return;
@@ -248,13 +249,14 @@ fn collectMembersFromTypeRef(
 
     // TS utility types `Pick<T, K>` / `Omit<T, K>` (#2417) — T 의 멤버 수집 후 K 의
     // string union 으로 필터. K 가 cross-file alias (예: `keyof RemoteX`) 면 silent skip.
-    if (std.mem.eql(u8, ref_name, "Pick") or std.mem.eql(u8, ref_name, "Omit")) {
-        const is_pick = std.mem.eql(u8, ref_name, "Pick");
+    if (std.mem.eql(u8, last, "Pick") or std.mem.eql(u8, last, "Omit")) {
+        const is_pick = std.mem.eql(u8, last, "Pick");
         try collectPickOmitMembers(ast, type_index, ref_node, is_pick, out, visited, depth + 1, alloc);
         return;
     }
 
-    // same-file lookup — found 면 declaration body 재귀.
+    // same-file lookup — found 면 declaration body 재귀. Namespace 가 있으면 (점 포함)
+    // local type_index 에 없으니 자연스레 cross-file 분기로 떨어짐.
     if (type_index.get(ref_name)) |decl_idx| {
         try collectAllMembers(ast, type_index, decl_idx, out, visited, depth + 1, alloc);
         return;
@@ -381,7 +383,7 @@ fn unwrapWrapper(ast: *const Ast, type_index: *const TypeIndex, idx: NodeIndex) 
         else => return idx,
     };
 
-    if (!isReadonlyWrapperName(ref_name)) return idx;
+    if (!isReadonlyWrapperName(lastSegment(ref_name))) return idx;
 
     // type argument 추출 — Readonly<T> 의 T.
     const inner = getNthTypeArgument(ast, node, 0) orelse return idx;
@@ -412,6 +414,8 @@ fn getNthTypeArgument(ast: *const Ast, node: Node, index: u32) ?NodeIndex {
 }
 
 /// type_reference 의 name 텍스트 추출. extra[0..2] 가 source 의 name span.
+/// Namespace-qualified (`NS.Foo`) 형태도 source 그대로 (점 포함) 반환 — caller 가
+/// well-known map lookup 시 `lastSegment` 로 마지막 segment 만 비교해야 한다.
 fn getTypeReferenceName(ast: *const Ast, node: Node) ?[]const u8 {
     const e = node.data.extra;
     if (e + 1 >= ast.extra_data.items.len) return null;
@@ -419,6 +423,18 @@ fn getTypeReferenceName(ast: *const Ast, node: Node) ?[]const u8 {
     const end = ast.extra_data.items[e + 1];
     if (end <= start or end > ast.source.len) return null;
     return ast.source[start..end];
+}
+
+/// Qualified name 의 마지막 segment 반환 — `import type { X as NS } from '...'` 후
+/// `NS.Foo` 형태의 RN 0.85+ 표준 패턴 (`CodegenTypes as CT` 등) 을 well-known map
+/// (event_handler_names / wrapper_ref_names / reserved_ref_names / numeric_ref_names)
+/// 매칭에 동등 처리하기 위한 helper. 점 없으면 입력 그대로.
+///
+/// 주의: type_index (사용자 정의 alias) lookup 에는 사용 X — `NS.LocalAlias` 가
+/// 우연히 같은 이름의 로컬 alias 와 매칭되어 cross-namespace pollution 일어남.
+fn lastSegment(name: []const u8) []const u8 {
+    if (std.mem.lastIndexOfScalar(u8, name, '.')) |dot| return name[dot + 1 ..];
+    return name;
 }
 
 /// property_signature 1 개를 분류해 props 또는 events 에 append.
@@ -510,7 +526,8 @@ fn eventHandlerBubbling(ast: *const Ast, type_idx: NodeIndex) ?schema.BubblingTy
     const node = ast.getNode(type_idx);
     if (node.tag != .ts_type_reference and node.tag != .flow_type_reference) return null;
     const name = getTypeReferenceName(ast, node) orelse return null;
-    return event_handler_names.get(name);
+    // Namespace alias (CT.DirectEventHandler 등 RN 0.85 표준) 도 last segment 로 매칭.
+    return event_handler_names.get(lastSegment(name));
 }
 
 /// RN codegen 의 명시적 event wrapper — 이름이 bubble vs direct 결정.
@@ -594,8 +611,11 @@ fn mapTypeReference(
     depth: u8,
 ) Error!schema.PropTypeAnnotation {
     const name = getTypeReferenceName(ast, node) orelse return error.UnsupportedPropType;
+    // Namespace alias (CT.X 등 RN 0.85 표준) 의 last segment 로 well-known map 매칭.
+    // type_index lookup 은 full name 유지 — namespaced 면 자연스레 cross-file 처리.
+    const last = lastSegment(name);
 
-    if (wrapper_ref_names.get(name)) |kind| {
+    if (wrapper_ref_names.get(last)) |kind| {
         const inner = getNthTypeArgument(ast, node, 0) orelse return error.UnsupportedPropType;
         const inner_prop = try mapPropTypeAt(ast, type_index, inner, depth + 1);
         return switch (kind) {
@@ -607,10 +627,10 @@ fn mapTypeReference(
         };
     }
 
-    if (reserved_ref_names.get(name)) |primitive| {
+    if (reserved_ref_names.get(last)) |primitive| {
         return .{ .reserved = primitive };
     }
-    if (numeric_ref_names.get(name)) |kind| {
+    if (numeric_ref_names.get(last)) |kind| {
         return numericKindToAnnotation(kind);
     }
 

--- a/src/transformer/plugins/codegen/schema_builder_test.zig
+++ b/src/transformer/plugins/codegen/schema_builder_test.zig
@@ -863,3 +863,211 @@ test "schema_builder: Omit + dedup 조합 — derived 가 Omit 결과를 overrid
     // Filtered: color, size. Props extends + own color → dedup → size + Props.color = 2.
     try std.testing.expectEqual(@as(usize, 2), shape.props.len);
 }
+
+// ============================================================
+// Namespace-qualified type references (RN 0.85+ CodegenTypes alias pattern).
+// `import type { CodegenTypes as CT } from 'react-native'` 후 `CT.X` 형태로
+// 노출되는 RN well-known type 이름들. 직접 import 형태(`X`)와 동등 처리.
+// react-native-screens / react-native-svg / react-native-safe-area-context 가
+// RN 0.85 부터 표준 채택 — 미지원 시 view config 누락으로 런타임 에러.
+// ============================================================
+
+test "schema_builder: namespace CT.DirectEventHandler → direct event (TS)" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { onLayout: CT.DirectEventHandler<LayoutEvent> };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 0), shape.props.len);
+    try std.testing.expectEqual(@as(usize, 1), shape.events.len);
+    try std.testing.expectEqualStrings("onLayout", shape.events[0].name);
+    try std.testing.expectEqual(schema.BubblingType.direct, shape.events[0].bubbling_type);
+}
+
+test "schema_builder: namespace CT.BubblingEventHandler → bubble event (TS)" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { onChange: CT.BubblingEventHandler<ChangeEvent> };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.events.len);
+    try std.testing.expectEqual(schema.BubblingType.bubble, shape.events[0].bubbling_type);
+}
+
+test "schema_builder: namespace CT.WithDefault<string, ''> → string with default (TS)" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { name?: CT.WithDefault<string, ''> };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .string);
+    try std.testing.expect(shape.props[0].optional);
+}
+
+test "schema_builder: namespace CT.UnsafeMixed<T> → identity unwrap (TS)" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { p: CT.UnsafeMixed<NumberProp> };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    // NumberProp 는 cross-file → mixed fallback. UnsafeMixed identity → 결과 mixed.
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}
+
+test "schema_builder: namespace CT.Float → float (TS)" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { f: CT.Float };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .float);
+}
+
+test "schema_builder: namespace CT.Int32 → int32 (TS)" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { i: CT.Int32 };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .int32);
+}
+
+test "schema_builder: namespace CT.Double → double (TS)" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { d: CT.Double };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .double);
+}
+
+test "schema_builder: namespace CT.ColorValue → reserved.color (TS)" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { c: CT.ColorValue };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .reserved);
+    try std.testing.expectEqual(schema.ReservedPropPrimitive.color, shape.props[0].type_annotation.reserved);
+}
+
+test "schema_builder: arbitrary namespace alias (Codegen.DirectEventHandler) recognized (TS)" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { onTap: Codegen.DirectEventHandler<TapEvent> };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.events.len);
+    try std.testing.expectEqual(schema.BubblingType.direct, shape.events[0].bubbling_type);
+}
+
+test "schema_builder: multi-segment namespace (A.B.DirectEventHandler) uses last segment (TS)" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { onPress: A.B.DirectEventHandler<PressEvent> };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.events.len);
+    try std.testing.expectEqual(schema.BubblingType.direct, shape.events[0].bubbling_type);
+}
+
+test "schema_builder: namespace CT.DirectEventHandler in interface body extends ViewProps (TS, RN screens 패턴)" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\interface NativeProps extends ViewProps {
+        \\  onFinishTransitioning?: CT.DirectEventHandler<FinishEvent>;
+        \\  iosPreventReattachmentOfDismissedScreens?: CT.WithDefault<boolean, false>;
+        \\}
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "NativeProps", "RNSScreenStack");
+    defer freeShape(std.testing.allocator, shape);
+
+    // ViewProps cross-file silent skip → 본 파일 멤버만.
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len); // iosPreventReattachment
+    try std.testing.expect(shape.props[0].type_annotation == .boolean);
+    try std.testing.expectEqual(@as(usize, 1), shape.events.len); // onFinishTransitioning
+    try std.testing.expectEqual(schema.BubblingType.direct, shape.events[0].bubbling_type);
+}
+
+test "schema_builder: Flow namespace CT.DirectEventHandler → direct event" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { onLayout: CT.DirectEventHandler<LayoutEvent> };
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.events.len);
+    try std.testing.expectEqual(schema.BubblingType.direct, shape.events[0].bubbling_type);
+}
+
+test "schema_builder: namespaced unknown last segment → mixed fallback (TS)" {
+    // Foo.Bar 가 알려진 wrapper/event/reserved/numeric 어디에도 없음 → cross-file
+    // 처럼 mixed permissive fallback.
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { p: NS.UnknownType };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}
+
+test "schema_builder: namespaced ref does NOT pollute local type_index (TS)" {
+    // 로컬 type_index 에 `DirectEventHandler` 라는 이름의 alias 가 있어도, namespaced
+    // `NS.DirectEventHandler` 는 namespace 의 it 으로 처리되어야지 로컬 alias 와 섞이면 안 됨.
+    // 본 케이스에서 로컬 alias 는 string → 만약 잘못 매칭되면 string prop 이 됨.
+    // 정상 동작: 마지막 segment "DirectEventHandler" 는 event_handler_names 에 매치 → event.
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type DirectEventHandler<T> = string;
+        \\type Props = { onTap: NS.DirectEventHandler<TapEvent> };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 0), shape.props.len);
+    try std.testing.expectEqual(@as(usize, 1), shape.events.len);
+}


### PR DESCRIPTION
## 배경

RN 0.85 부터 `@react-native/codegen` spec 파일들이 다음 패턴을 표준 채택:

```ts
import type { CodegenTypes as CT, ViewProps } from 'react-native';

export interface NativeProps extends ViewProps {
  onFinishTransitioning?: CT.DirectEventHandler<FinishEvent>;
  iosPreventReattachmentOfDismissedScreens?: CT.WithDefault<boolean, false>;
}
```

react-native-screens / react-native-svg / react-native-safe-area-context 가 0.85 이후 spec 을 모두 이 형태로 마이그레이션.

## 문제

`schema_builder.getTypeReferenceName` 가 type_reference 의 source span 을 raw 로 잘라서 반환 — `CT.DirectEventHandler` 면 `"CT.DirectEventHandler"` 통째로. 그런데 well-known map 들은 namespace 없는 키만 가짐:

```zig
event_handler_names = .{ "DirectEventHandler", .direct, "BubblingEventHandler", .bubble }
```

결과:
- `event_handler_names.get("CT.DirectEventHandler")` → null
- silent fallthrough → 일반 prop 으로 분류
- 생성된 view config 에 `directEventTypes` / `bubblingEventTypes` 섹션 누락
- 런타임에서 native 가 `topFinishTransitioning` event 를 dispatch → RN runtime view config lookup 실패 → `Unsupported top level event type "topFinishTransitioning" dispatched` 에러

react-native-screens 의 `<ScreenStack>` 등이 사용 불가능.

## 수정

`lastSegment(name)` helper 추가. qualified name 의 마지막 `.` 뒤 segment 만 반환 (점 없으면 그대로). 모든 well-known StaticStringMap lookup 사이트에 적용:

- `event_handler_names` (DirectEventHandler / BubblingEventHandler)
- `wrapper_ref_names` (WithDefault / UnsafeMixed / Array / ReadonlyArray)
- `reserved_ref_names` (ColorValue / ImageSource / PointValue / EdgeInsets / ImageRequest / Dimension)
- `numeric_ref_names` (Float / Int32 / Double)
- `isReadonlyWrapperName` (Readonly / \$ReadOnly)
- Pick / Omit utility-type detection

`type_index.get(name)` (사용자 정의 alias lookup) 은 의도적으로 full name 유지 — namespaced ref 는 자연스럽게 cross-file silent skip 경로로 떨어짐. 이로써 `NS.MyAlias` 가 우연히 로컬 `type MyAlias = ...` 와 매칭되는 cross-namespace pollution 차단.

## 테스트

`schema_builder_test.zig` 에 14 개 추가:

- 모든 4 well-known map 의 namespace 매칭 (TS):
  - `CT.DirectEventHandler<E>` / `CT.BubblingEventHandler<E>` → event 분류
  - `CT.WithDefault<string, ''>` / `CT.UnsafeMixed<T>` → wrapper unwrap
  - `CT.Float` / `CT.Int32` / `CT.Double` → numeric primitives
  - `CT.ColorValue` → reserved.color
- Flow parity: `CT.DirectEventHandler<E>` Flow 측도 동등 처리
- 다양한 namespace alias 이름 (`Codegen.X`)
- 다단계 namespace (`A.B.X`) — 마지막 segment 사용
- RN screens 패턴 (`interface NativeProps extends ViewProps` + `CT.DirectEventHandler` + `CT.WithDefault`)
- Negative:
  - 알려지지 않은 last segment 는 mixed fallback (cross-file 처럼)
  - Namespaced ref 가 동명 로컬 alias 를 오염 안 시킴

전 ZTS 테스트 스위트 통과.

## E2E 검증

bungae monorepo `examples/ExpoApp` (react-native-screens 사용):

**Before**:
\`\`\`js
Mde = {
  uiViewClassName: "RNSScreenStack",
  validAttributes: { iosPreventReattachmentOfDismissedScreens: !0, onFinishTransitioning: !0 }
  // directEventTypes 누락 → 런타임 에러
};
\`\`\`

**After**:
\`\`\`js
Mde = {
  uiViewClassName: "RNSScreenStack",
  validAttributes: { iosPreventReattachmentOfDismissedScreens: !0, onFinishTransitioning: !0 },
  directEventTypes: { topFinishTransitioning: { registrationName: "onFinishTransitioning" } }
};
\`\`\`

## 관련

- bungae #2393 (codegen native default 결정 추적)
- 후속 — schema_builder 의 다른 미지원 패턴 (콘솔 fallback 4 spec) 별도 audit