### PR TITLE
feat(codegen): T[] postfix array type support (#2348 후속)

### DIFF
--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -200,13 +200,16 @@ fn parsePostfixType(self: *Parser) ParseError2!NodeIndex {
             if (self.scanner.token.has_newline_before) break;
             const start = self.ast.getNode(base).span.start;
             if (try self.peekNextKind() == .r_bracket) {
-                // 배열 타입: T[]
+                // 배열 타입: T[]. element 를 extra[0] 으로 보존 — dataKind 는 그대로
+                // .extra (child_offsets = &.{} 라 ast_walk 미접근). TS parser 와 동일.
                 try self.advance(); // [
                 try self.advance(); // ]
-                base = try self.ast.addEmptyExtraNode(
-                    .flow_array_type,
-                    .{ .start = start, .end = self.currentSpan().start },
-                );
+                const extra_idx = try self.ast.addExtras(&.{@intFromEnum(base)});
+                base = try self.ast.addNode(.{
+                    .tag = .flow_array_type,
+                    .span = .{ .start = start, .end = self.currentSpan().start },
+                    .data = .{ .extra = extra_idx },
+                });
             } else {
                 // Indexed access type: Type['key'] / Type[number]
                 try self.advance(); // skip [

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -772,13 +772,16 @@ fn parsePostfixType(self: *Parser) ParseError2!NodeIndex {
             if (self.scanner.token.has_newline_before) break;
             const start = self.ast.getNode(base).span.start;
             if (try self.peekNextKind() == .r_bracket) {
-                // 배열 타입: T[]
+                // 배열 타입: T[]. element 를 extra[0] 으로 보존 — dataKind 는 그대로
+                // .extra (child_offsets = &.{} 라 ast_walk 미접근).
                 try self.advance(); // [
                 try self.advance(); // ]
-                base = try self.ast.addEmptyExtraNode(
-                    .ts_array_type,
-                    .{ .start = start, .end = self.currentSpan().start },
-                );
+                const extra_idx = try self.ast.addExtras(&.{@intFromEnum(base)});
+                base = try self.ast.addNode(.{
+                    .tag = .ts_array_type,
+                    .span = .{ .start = start, .end = self.currentSpan().start },
+                    .data = .{ .extra = extra_idx },
+                });
             } else {
                 // 인덱스 접근 타입: T[K]
                 try self.advance(); // [

--- a/src/transformer/plugins/rn_codegen/schema_builder.zig
+++ b/src/transformer/plugins/rn_codegen/schema_builder.zig
@@ -579,10 +579,27 @@ fn mapPropTypeAt(
         // RN runtime 이 nullable semantics 자체 처리 — wrapper 만 풀고 inner 매핑.
         .flow_nullable_type => mapPropTypeAt(ast, type_index, node.data.unary.operand, depth + 1),
 
+        // postfix `T[]` — parser (ts.zig / flow.zig) 가 element 를 extra[0] 으로 보존.
+        // `Array<T>` (type_reference) 와 동등 결과: array.<element prop>.
+        .ts_array_type, .flow_array_type => mapArrayType(ast, type_index, node, depth),
+
         .ts_union_type, .flow_union_type => mapUnion(ast, node),
 
         else => error.UnsupportedPropType,
     };
+}
+
+/// `T[]` element 를 extra[0] 에서 읽어 array prop 으로 lift.
+fn mapArrayType(
+    ast: *const Ast,
+    type_index: *const TypeIndex,
+    node: Node,
+    depth: u8,
+) Error!schema.PropTypeAnnotation {
+    const elem_idx = ast.readExtraNode(node.data.extra, 0);
+    if (elem_idx == .none) return error.UnsupportedPropType;
+    const inner = try mapPropTypeAt(ast, type_index, elem_idx, depth + 1);
+    return .{ .array = try toArrayElement(inner) };
 }
 
 /// Union 의 모든 element 가 string literal 이면 string_enum, 그 외엔 mixed.
@@ -613,7 +630,9 @@ fn mapTypeReference(
     const last = lastSegment(name);
 
     if (wrapper_ref_names.get(last)) |kind| {
-        const inner = getNthTypeArgument(ast, node, 0) orelse return error.UnsupportedPropType;
+        // type-arg 없는 wrapper (예: `CT.UnsafeMixed[]` 의 element). `@react-native/codegen`
+        // 의 reference 동작 동등 — typeAnnotation lookup 실패 시 mixed fall back.
+        const inner = getNthTypeArgument(ast, node, 0) orelse return .mixed;
         const inner_prop = try mapPropTypeAt(ast, type_index, inner, depth + 1);
         return switch (kind) {
             // WithDefault<T, D>: D (default literal) 는 향후 PR — ts_literal_type 추출해

--- a/src/transformer/plugins/rn_codegen/schema_builder_test.zig
+++ b/src/transformer/plugins/rn_codegen/schema_builder_test.zig
@@ -1071,3 +1071,97 @@ test "schema_builder: namespaced ref does NOT pollute local type_index (TS)" {
     try std.testing.expectEqual(@as(usize, 0), shape.props.len);
     try std.testing.expectEqual(@as(usize, 1), shape.events.len);
 }
+
+// ============================================================
+// `T[]` postfix array type — RN spec 의 흔한 형태
+//   - `sheetAllowedDetents?: number[]` (react-native-screens)
+//   - `headerLeftBarButtonItems?: CT.UnsafeMixed[]` (동)
+// `Array<T>` 는 type_reference 라 wrapper_ref_names 로 이미 처리. postfix 만 누락.
+// ============================================================
+
+test "schema_builder: TS number[] → array.float" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { items: number[] };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .array);
+    try std.testing.expect(shape.props[0].type_annotation.array == .float);
+}
+
+test "schema_builder: TS string[] → array.string" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { tags: string[] };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .array);
+    try std.testing.expect(shape.props[0].type_annotation.array == .string);
+}
+
+test "schema_builder: TS boolean[] → array.boolean" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { flags: boolean[] };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .array);
+    try std.testing.expect(shape.props[0].type_annotation.array == .boolean);
+}
+
+test "schema_builder: TS ColorValue[] → array.reserved.color" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { palette: ColorValue[] };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .array);
+    try std.testing.expect(shape.props[0].type_annotation.array == .reserved);
+    try std.testing.expectEqual(schema.ReservedPropPrimitive.color, shape.props[0].type_annotation.array.reserved);
+}
+
+test "schema_builder: Flow number[] → array.float" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { items: number[] };
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .array);
+    try std.testing.expect(shape.props[0].type_annotation.array == .float);
+}
+
+test "schema_builder: TS namespace CT.UnsafeMixed[] → array.mixed (rn-screens 패턴)" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { items: CT.UnsafeMixed[] };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    // CT.UnsafeMixed 는 type-arg 없는 form — `@react-native/codegen` reference 동작
+    // 동등하게 element 가 mixed 로 falls back, array wrapper 는 정상 lift.
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .array);
+    try std.testing.expect(shape.props[0].type_annotation.array == .mixed);
+}


### PR DESCRIPTION
## 배경

#2348 의 후속. PR #2443 의 4 fail spec (react-native-screens 4.23.0) 중 2 spec 의 fail 원인 = \`T[]\` 형태 postfix array type:

- \`ScreenNativeComponent.ts\`: \`sheetAllowedDetents?: number[]\`
- \`ScreenStackHeaderConfigNativeComponent.ts\`: \`headerLeftBarButtonItems?: CT.UnsafeMixed[]\`, \`headerRightBarButtonItems?: CT.UnsafeMixed[]\`

기존 ZTS schema_builder 의 \`mapPropTypeAt\` switch 에 \`ts_array_type\` / \`flow_array_type\` 분기 자체가 없어서 \`error.UnsupportedPropType\` → spec 전체 fail-fast.

근본 원인은 두 단계:
1. **Parser** 가 \`T[]\` 의 element 를 폐기 (\`addEmptyExtraNode\`) — schema_builder 가 element 알 길이 없음
2. **schema_builder** 의 switch 에 분기 자체 없음

## 변경

### Parser (ts.zig + flow.zig)
\`addEmptyExtraNode\` → \`addExtras + addNode\` 로 element NodeIndex 를 \`extra[0]\` 으로 보존. dataKind 는 그대로 \`.extra\` (\`child_offsets = &.{}\`) — \`ast_walk\` 미접근이라 다른 consumer (semantic, transformer) 영향 없음.

### schema_builder
- \`mapArrayType\` helper 추가 — \`ast.readExtraNode(node.data.extra, 0)\` 로 element 읽고 \`toArrayElement\` 로 array prop lift. 기존 \`Array<T>\` wrapper 와 동일 결과.
- mapTypeReference 의 wrapper-without-type-arg 동작 변경: \`error.UnsupportedPropType\` → \`.mixed\` fallback. \`@react-native/codegen\` reference 가 typeAnnotation lookup 실패 시 mixed 로 fall back 하는 동작과 동등. 부수효과로 비정상 spec 의 fail-fast 빈도 감소 → JS plugin fallback 비율 감소.

### 테스트 (TDD)
- 6 신규 테스트: \`number[]\`/\`string[]\`/\`boolean[]\`/\`ColorValue[]\` (TS), \`number[]\` (Flow), \`CT.UnsafeMixed[]\` (namespace + array)
- 모두 baseline fail → fix 후 pass

## 영향 — 4 spec 중

| Spec | fail 원인 | 본 PR 후 |
| --- | --- | --- |
| \`ScreenNativeComponent.ts\` | \`number[]\` | ✅ 처리 가능 |
| \`ScreenStackHeaderConfigNativeComponent.ts\` | \`CT.UnsafeMixed[]\` | ✅ 처리 가능 |
| \`ModalScreenNativeComponent.ts\` | 별개 패턴 (audit 필요) | 후속 PR |
| \`BottomTabsScreenNativeComponent.ts\` | 별개 패턴 | 후속 PR |

## 검증

- \`zig build test\` — 4559/4559 pass (회귀 0)
- 신규 6 테스트 pass
- snapshot byte-diff 검증은 별도 인프라 PR 에서 (현재 ZTS rn_codegen_plugin 의 출력 형태와 reference 의 wrapper code 형태가 달라서 object-level diff 가 더 적합)

## 후속

- PR #4: ModalScreenNativeComponent / BottomTabsScreenNativeComponent 의 추가 fail 패턴 audit + 패턴별 fix
- 별도 cleanup: schema_builder.zig 의 8 곳 \`e + N >= ast.extra_data.items.len\` guard → \`ast.hasExtra\` helper 로