### PR TITLE
feat(codegen): inline / nested object literal prop type → mixed (#2348 후속)

### DIFF
--- a/src/transformer/plugins/rn_codegen/schema_builder.zig
+++ b/src/transformer/plugins/rn_codegen/schema_builder.zig
@@ -583,6 +583,14 @@ fn mapPropTypeAt(
         // `Array<T>` (type_reference) 와 동등 결과: array.<element prop>.
         .ts_array_type, .flow_array_type => mapArrayType(ast, type_index, node, depth),
 
+        // inline / nested object literal. `@react-native/codegen` reference 의 schema 단계는
+        // `ObjectTypeAnnotation { properties }` 로 nested shape 풀지만, view config emitter
+        // (`GenerateViewConfigJs.js`) 가 attribute name 만 등록 (`prop: true`). ZTS 의 scope 가
+        // view config emit 한정이라 `.mixed` 가 동등 결과 — schema.zig 의 `.object: ObjectProp`
+        // variant 는 의도적으로 미사용. C++ component descriptor / props.h 등 native side 가
+        // 필요해지면 `.object` 로 보강 필요.
+        .ts_type_literal, .flow_object_type, .flow_exact_object_type => .mixed,
+
         .ts_union_type, .flow_union_type => mapUnion(ast, node),
 
         else => error.UnsupportedPropType,

--- a/src/transformer/plugins/rn_codegen/schema_builder_test.zig
+++ b/src/transformer/plugins/rn_codegen/schema_builder_test.zig
@@ -1165,3 +1165,51 @@ test "schema_builder: TS namespace CT.UnsafeMixed[] → array.mixed (rn-screens 
     try std.testing.expect(shape.props[0].type_annotation == .array);
     try std.testing.expect(shape.props[0].type_annotation.array == .mixed);
 }
+
+// ============================================================
+// Inline / nested object literal prop type — `prop?: { ... }` 형태.
+// `@react-native/codegen` reference 가 view config 에서 단순 `prop: true` 로 emit
+// (validAttributes 는 attribute 이름만 등록 — nested shape 는 native side 책임).
+// 따라서 ZTS 도 `.mixed` 로 매핑하면 byte-diff 0. 미지원 시 fail-fast.
+//
+// 영향: react-native-screens 4.23 의 BottomTabsScreenNativeComponent (`specialEffects?: {...}`).
+// ============================================================
+
+test "schema_builder: TS inline object literal prop type → mixed" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { specialEffects?: { popToRoot?: boolean } };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}
+
+test "schema_builder: TS deeply nested inline object literal → mixed" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { effects?: { repeatedTabSelection?: { popToRoot?: boolean; scrollToTop?: boolean } } };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}
+
+test "schema_builder: Flow inline object type → mixed" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { meta: { count: number } };
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}


### PR DESCRIPTION
## 배경

#2443 의 4 fail spec 중 마지막 1 개 — \`BottomTabsScreenNativeComponent.ts\` — 의 fail 원인.

\`\`\`ts
specialEffects?: {
  repeatedTabSelection?: {
    popToRoot?: CT.WithDefault<boolean, true>;
    scrollToTop?: CT.WithDefault<boolean, true>;
  };
};
\`\`\`

inline / nested object literal prop type 이 \`mapPropTypeAt\` switch 에 분기 없어 \`error.UnsupportedPropType\` → spec 전체 fail-fast.

## 변경

\`mapPropTypeAt\` switch 에 \`ts_type_literal\` / \`flow_object_type\` / \`flow_exact_object_type\` → \`.mixed\` 추가.

근거: \`@react-native/codegen\` reference 가 view config 의 \`validAttributes\` 에서 nested object 를 단순 \`prop: true\` 로 emit (attribute 이름만 등록, nested shape 는 native side 책임). \`.mixed\` 로 매핑하면 byte-diff 0 — \`.object\` variant 까지 풀 필요 없음.

## 테스트 (TDD)

3 신규 — TS inline / TS deeply nested / Flow inexact. baseline fail → fix 후 pass.

Flow exact \`{| ... |}\` 는 prop position 에서 parser 가 못 받음 (별개 parser issue). 본 PR scope 밖.

## E2E 검증

\`bungae build\` of ExpoApp (react-native-screens 4.23) — **4 spec 전부 ZTS native 처리**, \`[bungae:codegen]\` 콘솔 한 줄도 안 나옴. JS plugin fallback 0회.

| Spec | PR #2443 | PR #2444 (T[]) | 본 PR |
| --- | --- | --- | --- |
| ScreenNativeComponent | fail (T[]) | ✅ | ✅ |
| ScreenStackHeaderConfig | fail (T[]) | ✅ | ✅ |
| ModalScreenNativeComponent | fail (?) | ✅ | ✅ |
| BottomTabsScreenNativeComponent | fail (object literal) | fail (object literal) | ✅ |

## 후속

- 별개 issue: Flow exact object \`{| ... |}\` 의 prop position parsing
- byte-diff 0 회귀 인프라 (object-level diff) — 별도 PR