### PR TITLE
fix(parser): Flow exact object `{| ... |}` at prop position (#2447)

### DIFF
--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -123,17 +123,23 @@ pub fn parseType(self: *Parser) ParseError2!NodeIndex {
 
 /// Union 타입: A | B | C
 /// 선행 | 허용: | A | B
+///
+/// Exact object close 보호 (#2447): `{| count: number |}` 같이 prop position 의 inner
+/// exact object 가 union 처리 시 close `|` 까지 흡수되면 outer parser 가 깨짐. `|` 다음
+/// 토큰이 `}` 면 exact object close 로 간주하고 union 종료 (단순 type alias 의 trailing
+/// `|` 는 valid Flow syntax 가 아님 — Babel `flowParseUnionType` 도 동일 정책).
 fn parseUnionType(self: *Parser) ParseError2!NodeIndex {
+    if (try pipeIsExactClose(self)) return parseIntersectionType(self);
     if (self.current() == .pipe) try self.advance();
     const first = try parseIntersectionType(self);
-    if (self.current() != .pipe) return first;
+    if (self.current() != .pipe or try pipeIsExactClose(self)) return first;
 
     // `A | B | C` — flat NodeList 로 저장 (layout=.list).
     const scratch_top = self.saveScratch();
     defer self.restoreScratch(scratch_top);
     try self.scratch.append(self.allocator, first);
     const start = self.ast.getNode(first).span.start;
-    while (self.current() == .pipe) {
+    while (self.current() == .pipe and !try pipeIsExactClose(self)) {
         try self.advance();
         const next = try parseIntersectionType(self);
         try self.scratch.append(self.allocator, next);
@@ -144,6 +150,12 @@ fn parseUnionType(self: *Parser) ParseError2!NodeIndex {
         .{ .start = start, .end = self.currentSpan().start },
         list,
     );
+}
+
+/// 현재 토큰이 `|` 이고 직후가 `}` — exact object (`{| ... |}`) 의 close marker. union
+/// operator 로 흡수하면 안 됨 (#2447).
+fn pipeIsExactClose(self: *Parser) ParseError2!bool {
+    return self.current() == .pipe and try self.peekNextKind() == .r_curly;
 }
 
 /// Intersection 타입: A & B & C

--- a/src/transformer/plugins/rn_codegen/schema_builder_test.zig
+++ b/src/transformer/plugins/rn_codegen/schema_builder_test.zig
@@ -1213,3 +1213,56 @@ test "schema_builder: Flow inline object type → mixed" {
     try std.testing.expectEqual(@as(usize, 1), shape.props.len);
     try std.testing.expect(shape.props[0].type_annotation == .mixed);
 }
+
+test "schema_builder: Flow exact object type {| ... |} prop position → mixed (#2447)" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { meta: {| count: number |} };
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}
+
+test "schema_builder: Flow empty exact object {||} prop position → mixed (#2447)" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { meta: {||} };
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}
+
+test "schema_builder: Flow exact object as union member → mixed (#2447)" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { meta: string | {| count: number |} };
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    // mixed union (string + object) → mixed.
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}
+
+test "schema_builder: Flow nested exact objects → mixed (#2447)" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { meta: {| inner: {| n: number |} |} };
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}


### PR DESCRIPTION
Closes #2447.

## 배경

#2446 의 schema_builder 작업 중 발견. \`type Props = { meta: {| count: number |} };\` 같은 Flow exact object literal 이 type alias 내부의 prop position 에서 parser errors 3 개 emit. type alias 컨텍스트 (\`type X = {| ... |}\`) 에서는 정상 파싱되지만 prop position 에서만 fail.

## 원인

\`parseFlowTypeMember\` 가 prop value 를 \`parseType\` 로 파싱 → \`parseUnionType\` 이 \`|\` 토큰 만나면 union operator 로 흡수. inner exact object 의 close \`|\` (in \`|}\`) 도 함께 흡수 → outer parser 가 깨짐.

## Fix

\`parseUnionType\` 의 3 진입점 (leading \`|\`, post-first-item return, in-loop continuation) 에 \`current() == .pipe and peekNextKind() == .r_curly\` lookahead. pipe 다음이 \`}\` 면 exact object close marker 로 간주, union 시도 안 함. 단순 Flow type alias 의 trailing \`|\` 는 invalid syntax 라 lookahead 가 valid 케이스를 깨뜨릴 일 없음 (Babel \`flowParseUnionType\` 도 동일 정책).

\`pipeIsExactClose(self) !bool\` helper 로 3 lookahead 사이트 중복 제거.

## 테스트

\`schema_builder_test.zig\` 에 4 케이스 추가:
- Flow exact object at prop position (#2446 에서 제거된 baseline)
- 빈 exact object \`{||}\`
- exact object as union member: \`string | {| ... |}\`
- nested exact: \`{| inner: {| n: number |} |}\`

전 ZTS 테스트 통과 (회귀 0).

## 영향

#2447 closes — react-native-screens / svg / safe-area-context 의 향후 Flow exact object 패턴 지원. RN spec 의 Flow 비중은 줄어드는 추세지만 long-tail 라이브러리 호환성 확보.