### PR TITLE
test(parser): expand Flow exact object edge cases for #2447

### DIFF
--- a/src/transformer/plugins/rn_codegen/schema_builder_test.zig
+++ b/src/transformer/plugins/rn_codegen/schema_builder_test.zig
@@ -1266,3 +1266,94 @@ test "schema_builder: Flow nested exact objects → mixed (#2447)" {
     try std.testing.expectEqual(@as(usize, 1), shape.props.len);
     try std.testing.expect(shape.props[0].type_annotation == .mixed);
 }
+
+// 아래 케이스들은 #2447 fix (`pipeIsExactClose` lookahead) 의 정합성을 다양한 union/
+// intersection / leading-pipe / variance / multi-exact 경로에서 검증. 각 케이스가
+// `parseUnionType` 의 서로 다른 entry point (leading-pipe / post-first / in-loop) 를
+// exercise.
+
+test "schema_builder: Flow exact body 안의 inner union → close 직전 종료 (#2447)" {
+    // inner `count: number | string` union 이 outer exact close `|}` 직전에 멈춰야.
+    // pipeIsExactClose 의 in-loop guard 가 제대로 동작하는지 검증.
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { meta: {| count: number | string |} };
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}
+
+test "schema_builder: Flow union of two exact objects → mixed (#2447)" {
+    // 두 exact object 사이 `|` 는 정상 union operator (peek != `}`).
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { meta: {| a: number |} | {| b: string |} };
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}
+
+test "schema_builder: Flow exact object as first union member → mixed (#2447)" {
+    // post-first-item return guard — exact close 직후 다른 union 멤버 흡수 안 함.
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { meta: {| count: number |} | string };
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}
+
+test "schema_builder: Flow leading pipe + exact object → mixed (#2447)" {
+    // Flow 의 valid leading-pipe 형태 (`type X = | A | B`) 가 exact object 와 결합.
+    // leading-pipe guard 가 valid 케이스를 깨뜨리지 않는지 검증.
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { meta: | {| count: number |} | string };
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}
+
+test "schema_builder: Flow exact object with variance markers → mixed (#2447)" {
+    // `+key` covariant — Flow object 의 variance marker 가 exact body 안에서도 동작.
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { meta: {| +readOnly: number, name: string |} };
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}
+
+test "schema_builder: Flow exact object with string-literal key → mixed (#2447)" {
+    // string literal key (`'aria-label'`) — exact body 안에서 ident 외 key 도 정상.
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { meta: {| 'aria-label': string, count: number |} };
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}


### PR DESCRIPTION
## 배경

#2450 의 \`pipeIsExactClose\` lookahead fix 의 정합성을 다양한 union/leading-pipe/variance/multi-exact 경로에서 검증. 4 케이스로는 \`parseUnionType\` 의 entry point (leading-pipe / post-first / in-loop) 가 모두 exercise 안 됨.

## 추가 테스트 (schema_builder_test.zig)

| 케이스 | 검증 path |
| --- | --- |
| \`{\| count: number \| string \|}\` (inner union) | in-loop guard — close 직전 union 멈춤 |
| \`{\| a: number \|} \| {\| b: string \|}\` (multi-exact) | post-first 다음 valid union 흡수 |
| \`{\| count: number \|} \| string\` | post-first guard (close 후 흡수 안 함) |
| \`\| {\| count: number \|} \| string\` (leading pipe) | leading-pipe guard 가 valid 케이스 안 깨뜨림 |
| \`{\| +readOnly: number, name: string \|}\` (variance) | exact body 안의 \`+\` covariant marker 정상 |
| \`{\| 'aria-label': string, count: number \|}\` (string key) | exact body 안의 string-literal key |

## Out of scope

intersection 케이스 (\`{\| count: number \|} & Other\`) — \`flow_intersection_type\` 가 schema_builder 의 \`mapPropTypeAt\` switch 에 분기 없음. 별개 issue (mapPropTypeAt 의 미지원 패턴 한 묶음으로 처리할 수 있음).

## 검증

전 ZTS test suite 통과 (회귀 0). #2450 의 4 케이스 + 본 PR 의 6 케이스 = 10 개 exact-object edge case.