### PR TITLE
feat(codegen): remaining Flow / TS type nodes at prop position → mixed (#2348)

### DIFF
--- a/src/transformer/plugins/rn_codegen/schema_builder.zig
+++ b/src/transformer/plugins/rn_codegen/schema_builder.zig
@@ -591,7 +591,51 @@ fn mapPropTypeAt(
         // 필요해지면 `.object` 로 보강 필요.
         .ts_type_literal, .flow_object_type, .flow_exact_object_type => .mixed,
 
+        // intersection (`A & B`) — view config 단계에서 nested shape 풀 필요 없음 (.object
+        // variant 미사용 정책과 동일). reference 도 view config attribute 이름만 등록.
+        .ts_intersection_type, .flow_intersection_type => .mixed,
+
         .ts_union_type, .flow_union_type => mapUnion(ast, node),
+
+        // 그 외 type 노드들 — prop position 에 거의 안 등장하지만 RN spec 에서 발견 시
+        // reference 가 view config 에 attribute name 만 등록하는 동작과 동등. tuple /
+        // function (event 외) / typeof / literal / template-literal / parenthesized /
+        // conditional / mapped / indexed-access / type-predicate / import / operator /
+        // void / null / undefined / unknown / never / object / symbol / bigint 등.
+        .ts_void_keyword,
+        .ts_undefined_keyword,
+        .ts_null_keyword,
+        .ts_unknown_keyword,
+        .ts_never_keyword,
+        .ts_object_keyword,
+        .ts_symbol_keyword,
+        .ts_bigint_keyword,
+        .ts_function_type,
+        .ts_constructor_type,
+        .ts_tuple_type,
+        .ts_named_tuple_member,
+        .ts_literal_type,
+        .ts_template_literal_type,
+        .ts_indexed_access_type,
+        .ts_conditional_type,
+        .ts_mapped_type,
+        .ts_type_query,
+        .ts_parenthesized_type,
+        .ts_infer_type,
+        .ts_optional_type,
+        .ts_rest_type,
+        .ts_type_predicate,
+        .ts_import_type,
+        .ts_type_operator,
+        .flow_void_keyword,
+        .flow_null_keyword,
+        .flow_this_type,
+        .flow_function_type,
+        .flow_parenthesized_type,
+        .flow_type_query,
+        .flow_tuple_type,
+        .flow_literal_type,
+        => .mixed,
 
         else => error.UnsupportedPropType,
     };

--- a/src/transformer/plugins/rn_codegen/schema_builder_test.zig
+++ b/src/transformer/plugins/rn_codegen/schema_builder_test.zig
@@ -1357,3 +1357,137 @@ test "schema_builder: Flow exact object with string-literal key → mixed (#2447
     try std.testing.expectEqual(@as(usize, 1), shape.props.len);
     try std.testing.expect(shape.props[0].type_annotation == .mixed);
 }
+
+// ============================================================
+// Intersection type at prop position (`T & U`).
+// reference 가 view config 에서 attribute name 만 등록하므로 `.mixed` 매핑이 동등.
+// ============================================================
+
+test "schema_builder: TS intersection type prop → mixed" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Other = { tag: string };
+        \\type Props = { meta: { count: number } & Other };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}
+
+test "schema_builder: Flow intersection of exact objects → mixed" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Other = {| tag: string |};
+        \\type Props = { meta: {| count: number |} & Other };
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}
+
+// ============================================================
+// 그 외 미지원 type 노드들 — view config 단계에서 .mixed 로 매핑 (reference 동등).
+// prop position 에 거의 안 등장하지만 RN spec 발견 시 fail-fast 안 하도록.
+// ============================================================
+
+test "schema_builder: TS tuple type prop → mixed" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { coords: [number, number] };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}
+
+test "schema_builder: TS literal type prop → mixed" {
+    // 단독 literal type (`'on'`) — union 안이 아니라 prop value 자체가 literal.
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { kind: 'on' };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}
+
+test "schema_builder: TS template literal type prop → mixed" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { id: `prefix-${string}` };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}
+
+test "schema_builder: TS typeof query prop → mixed" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\const Foo = { x: 1 };
+        \\type Props = { v: typeof Foo };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}
+
+test "schema_builder: TS parenthesized type prop → mixed" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { v: (number) };
+    , .ts);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    // parenthesized 자체는 .mixed (inner unwrap 안 함) — view config 단계에선 동등.
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}
+
+test "schema_builder: Flow tuple type prop → mixed" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { coords: [number, number] };
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 1), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+}
+
+test "schema_builder: Flow void / null keyword prop → mixed" {
+    // 거의 등장 안 하지만 RN spec 일관성 — fail-fast 안 함.
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = { v: void, n: null };
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "X");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 2), shape.props.len);
+    try std.testing.expect(shape.props[0].type_annotation == .mixed);
+    try std.testing.expect(shape.props[1].type_annotation == .mixed);
+}


### PR DESCRIPTION
## 배경

#2451 작업 중 발견 — \`flow_intersection_type\` / \`ts_intersection_type\` 가 schema_builder 의 \`mapPropTypeAt\` switch 에 미지원. spec fail-fast 시 ZTS native 가 처리 못 하고 JS plugin fallback. 그 외 type 노드들도 같은 정책 (intersection, tuple, function, typeof 등) 적용.

## 변경

\`mapPropTypeAt\` switch 에 미지원 type 노드들 명시 추가, 모두 \`.mixed\` 로 매핑:

| 카테고리 | 노드 |
| --- | --- |
| intersection | \`ts_intersection_type\`, \`flow_intersection_type\` |
| keyword (그 외) | \`ts_void_keyword\`, \`ts_undefined_keyword\`, \`ts_null_keyword\`, \`ts_unknown_keyword\`, \`ts_never_keyword\`, \`ts_object_keyword\`, \`ts_symbol_keyword\`, \`ts_bigint_keyword\`, \`flow_void_keyword\`, \`flow_null_keyword\`, \`flow_this_type\` |
| function / constructor | \`ts_function_type\`, \`ts_constructor_type\`, \`flow_function_type\` |
| tuple | \`ts_tuple_type\`, \`ts_named_tuple_member\`, \`flow_tuple_type\` |
| literal | \`ts_literal_type\`, \`ts_template_literal_type\`, \`flow_literal_type\` |
| 그 외 | \`ts_indexed_access_type\`, \`ts_conditional_type\`, \`ts_mapped_type\`, \`ts_type_query\`, \`ts_parenthesized_type\`, \`ts_infer_type\`, \`ts_optional_type\`, \`ts_rest_type\`, \`ts_type_predicate\`, \`ts_import_type\`, \`ts_type_operator\`, \`flow_parenthesized_type\`, \`flow_type_query\` |

\`else\` 분기는 fail-fast 유지 — parser 가 새 syntax 노드 emit 시 silent skip 대신 회귀 detect.

## 근거 (#2446 와 동일 정책)

\`@react-native/codegen\` reference 의 view config emitter (\`GenerateViewConfigJs.js\`) 가 nested shape 를 풀지 않고 attribute name 만 등록 (\`prop: true\`). schema 단계의 detail 은 view config 출력에 반영 X. ZTS scope 가 view config emit 한정이라 \`.mixed\` 가 byte-eq 정합. C++ component descriptor / props.h 등 native side 가 필요해지면 그때 nested variant 추가.

## 테스트

8 신규 — TS intersection / Flow exact-objects intersection / TS tuple / TS single literal / TS template literal / TS typeof / TS parenthesized / Flow tuple / Flow void+null. 전 ZTS test 통과.

## 영향

- react-native-screens / svg / safe-area-context 등 RN 라이브러리의 long-tail spec 패턴 호환성 보장
- intersection 케이스가 자주 — \`type Props = { meta: {| count: number |} & Other }\` (#2451 의 out-of-scope 항목 해소)

## 후속

#2348 anchor close 가능 — view component codegen contract 완료 (4 fail spec 모두 ZTS native 처리 + semantic-diff snapshot 회귀 인프라 + 모든 type 노드 fail-soft 매핑).