### PR TITLE
fix(codegen): Flow enum → `flow-enums-runtime` callable (#1589 A-2)

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -3675,21 +3675,53 @@ pub const Codegen = struct {
     /// 현재는 `flow-enums-runtime` 패키지의 `Enum()` wrapper 미사용. Object.freeze
     /// 만으로 _값 비교_ semantic 충족 — \`Status.cast(x)\` / \`.members()\` 같은 enum
     /// 메서드 미지원 (사용처 적음).
+    /// Flow enum 출력 — `babel-plugin-transform-flow-enums` 와 동작 동등 (런타임 helper
+    /// API: \`X.cast(v)\` / \`X.members()\` / \`X.getName(v)\` 등). \`flow-enums-runtime\`
+    /// package 의 callable 결과를 사용. 예전 \`Object.freeze({...})\` 형태는 helper API
+    /// 미지원이라 RN core 의 `VirtualViewMode.cast(value)` 같은 호출에서 TypeError.
+    ///
+    /// emit 형태 (reference 와 동일):
+    ///   - string body + all defaulted (mirrored): \`require('flow-enums-runtime').Mirrored(['A', 'B'])\`
+    ///   - 그 외 (Symbol/number/boolean/string-with-init): \`require('flow-enums-runtime')({A:<v>, B:<v>})\`
+    ///   - Symbol body: 각 member 의 init 으로 \`Symbol('name')\` 자동 emit
+    ///   - number/boolean body + defaulted: ZTS 가 default value (auto-increment / false) 채움
     fn emitFlowEnum(self: *Codegen, node: Node) Error!void {
         const e = node.data.extra;
         const name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
         const members_start = self.ast.extra_data.items[e + 1];
         const members_len = self.ast.extra_data.items[e + 2];
-        const base_type = self.ast.extra_data.items[e + 3];
+        const base_type_raw = self.ast.extra_data.items[e + 3];
+        const base_type: FlowEnumBaseType = @enumFromInt(base_type_raw);
 
         const name_node = self.ast.getNode(name_idx);
         const name_text = self.ast.getText(name_node.span);
 
+        const members = self.ast.extra_data.items[members_start .. members_start + members_len];
+
+        // Mirrored 케이스: string body + 첫 멤버 init 없음 (= all defaulted 가정 — reference 동일).
+        const is_mirrored = base_type == .string and (members.len == 0 or
+            self.ast.getNode(@enumFromInt(members[0])).data.binary.right == .none);
+
         try self.write("const ");
         try self.write(name_text);
-        try self.write("=Object.freeze({");
+        try self.write("=require(\"flow-enums-runtime\")");
 
-        const members = self.ast.extra_data.items[members_start .. members_start + members_len];
+        if (is_mirrored) {
+            try self.write(".Mirrored([");
+            for (members, 0..) |raw_idx, i| {
+                if (i > 0) try self.writeByte(',');
+                const member = self.ast.getNode(@enumFromInt(raw_idx));
+                const member_name_node = self.ast.getNode(member.data.binary.left);
+                const member_name = Ast.stripStringQuotes(self.ast.getText(member_name_node.span));
+                try self.writeByte('"');
+                try self.write(member_name);
+                try self.writeByte('"');
+            }
+            try self.write("]);");
+            return;
+        }
+
+        try self.write("({");
         var auto_idx: u32 = 0;
         for (members, 0..) |raw_idx, i| {
             if (i > 0) try self.writeByte(',');
@@ -3703,7 +3735,7 @@ pub const Codegen = struct {
             if (!init_idx.isNone()) {
                 try self.emitNode(init_idx);
             } else {
-                try self.emitFlowEnumDefaultValue(base_type, member_name, auto_idx);
+                try self.emitFlowEnumDefaultValue(base_type_raw, member_name, auto_idx);
             }
             auto_idx += 1;
         }

--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -382,51 +382,67 @@ test "Flow: Metro smoke — full module with all Flow features" {
 // ============================================================
 
 // ===== Flow enum (#2401) — codegen e2e =====
+// `babel-plugin-transform-flow-enums` 동작 동등: `flow-enums-runtime` package
+// 의 callable / Mirrored helper 사용 — 결과 object 가 cast / members / getName
+// 같은 helper API 보유 (RN core 의 `X.cast(value)` 호출 호환).
 
-test "Flow enum: default → Object.freeze with Symbol values" {
+test "Flow enum: default (symbol) → flow-enums-runtime callable with Symbol values" {
     var r = try e2eFlow(std.testing.allocator,
         \\enum Status { Active, Inactive }
     );
     defer r.deinit();
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "const Status=Object.freeze({") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "const Status=require(\"flow-enums-runtime\")({") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "Active:Symbol(\"Active\")") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "Inactive:Symbol(\"Inactive\")") != null);
 }
 
-test "Flow enum: of string → Object.freeze with string values" {
+test "Flow enum: of string + all defaulted → Mirrored" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\enum Color of string { Red, Blue }
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "const Color=require(\"flow-enums-runtime\").Mirrored([\"Red\",\"Blue\"]);") != null);
+}
+
+test "Flow enum: of string with explicit init → callable with string values" {
     var r = try e2eFlow(std.testing.allocator,
         \\enum Color of string { Red = 'red', Blue = 'blue' }
     );
     defer r.deinit();
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "const Color=Object.freeze({") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "const Color=require(\"flow-enums-runtime\")({") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "Red:\"red\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "Blue:\"blue\"") != null);
 }
 
-test "Flow enum: of number → Object.freeze with number values" {
+test "Flow enum: of number → callable with number values" {
     var r = try e2eFlow(std.testing.allocator,
         \\enum Level of number { Low = 1, High = 10 }
     );
     defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "const Level=require(\"flow-enums-runtime\")({") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "Low:1") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "High:10") != null);
 }
 
-test "Flow enum: of boolean" {
+test "Flow enum: of boolean → callable" {
     var r = try e2eFlow(std.testing.allocator,
         \\enum Toggle of boolean { On = true, Off = false }
     );
     defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "const Toggle=require(\"flow-enums-runtime\")({") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "On:true") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "Off:false") != null);
 }
 
-test "Flow enum: usage 후 frozen object 비교 작동" {
-    // Object.freeze 결과는 일반 object — `Status.Active` 접근, `===` 비교 가능.
+test "Flow enum: usage — member access / cast helper 호출 정합" {
+    // `flow-enums-runtime` callable 결과는 RN core 의 `X.cast(value)` 호출 호환.
+    // 본 테스트는 codegen 단계만 — 실제 cast 호출 동작은 flow-enums-runtime 의 책임.
     var r = try e2eFlow(std.testing.allocator,
         \\enum Color of string { Red = 'red' }
         \\const x = Color.Red;
+        \\const y = Color.cast('red');
     );
     defer r.deinit();
     try std.testing.expect(std.mem.indexOf(u8, r.output, "const x=Color.Red") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "const y=Color.cast(\"red\")") != null);
 }


### PR DESCRIPTION
## 배경

\`#2453\` close 후 사용자 환경 검증 결과 ZTS 의 기존 emit (\`Object.freeze({...Symbol(...)...})\`) 이 helper API 미지원. RN 0.85+ core 가 Flow enum 의 \`X.cast(value)\` / \`X.members()\` / \`X.getName(value)\` 같은 helper API 를 호출 (예: \`VirtualViewMode.cast(value)\` in react-native/Libraries/Components/View/VirtualView). frozen object 엔 cast method 없어 **런타임 TypeError**.

## 수정

\`babel-plugin-transform-flow-enums\` reference 와 동작 동등하게 emit:

| Body type | reference / ZTS 결과 |
| --- | --- |
| string + all defaulted (mirrored) | \`const X=require("flow-enums-runtime").Mirrored(["A", "B"]);\` |
| string + explicit init | \`const X=require("flow-enums-runtime")({A:"a", B:"b"});\` |
| number | \`const X=require("flow-enums-runtime")({A:0, B:1});\` |
| boolean | \`const X=require("flow-enums-runtime")({A:true, B:false});\` |
| symbol | \`const X=require("flow-enums-runtime")({A:Symbol("A"), B:Symbol("B")});\` |

\`flow-enums-runtime\` package 의 callable 결과가 helper API (\`cast\`, \`members\`, \`getName\` 등) 를 가진 enum object 반환. RN core 의 \`X.cast(value)\` 호출 정합.

## 테스트

\`codegen_test/flow.zig\` 의 기존 5 테스트 + 신규 1 (cast 호출) — 총 6 케이스. 전 ZTS test suite 통과.

## E2E 검증

bungae build of ExampleApp (RN 0.85.1) release — VirtualViewMode / VirtualViewRenderState 모두 \`flow-enums-runtime\` callable 형태:

\`\`\`js
const VirtualViewMode = require("flow-enums-runtime")({Visible:0,Prerender:1,Hidden:2});
const VirtualViewRenderState = require("flow-enums-runtime")({Unknown:0,Rendered:1,None:2});
\`\`\`

런타임에 \`VirtualViewMode.cast(value)\` 등 helper 호출 가능 (flow-enums-runtime 의 책임).

## 추가 검증 — A-4 (#2455)

본 PR 작업 중 dev 빌드 검증 — \`_jsxDEV\` 720 hits, \`fileName:\` 437 hits. automatic_dev JSX runtime 정상 동작 (#2455 의 close 결정 정합).

Closes #2453.