### PR TITLE
fix(import-scanner): elide `import { type A, type B }` declaration (#2466)

### DIFF
--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -293,8 +293,15 @@ fn tryExtractImportDecl(ast: *const Ast, node: Node) ?ImportRecord {
     if (e + 2 >= ast.extra_data.items.len) return null;
 
     const extras = ast.extra_data.items[e .. e + 3];
+    const specs_start = extras[0];
     const specs_len = extras[1];
     const source_idx: NodeIndex = @enumFromInt(extras[2]);
+
+    // 모든 spec 이 individual `type` modifier 면 import 자체 elide — `import { type A, type B }
+    // from './foo'` 가 babel typescript preset 이 statement 통째 제거하는 것과 동등.
+    // `import type { ... }` (declaration-level type-only) 는 parser 가 이미 NodeIndex.none
+    // 반환 (`module.zig:430`).
+    if (specs_len > 0 and allSpecsAreTypeOnly(ast, specs_start, specs_len)) return null;
 
     const specifier = getStringLiteralText(ast, source_idx) orelse return null;
     const source_node = ast.getNode(source_idx);
@@ -304,6 +311,19 @@ fn tryExtractImportDecl(ast: *const Ast, node: Node) ?ImportRecord {
         .kind = if (specs_len == 0) .side_effect else .static_import,
         .span = source_node.span,
     };
+}
+
+fn allSpecsAreTypeOnly(ast: *const Ast, specs_start: u32, specs_len: u32) bool {
+    if (specs_start + specs_len > ast.extra_data.items.len) return false;
+    const spec_indices = ast.extra_data.items[specs_start .. specs_start + specs_len];
+    for (spec_indices) |raw_idx| {
+        const spec_idx: NodeIndex = @enumFromInt(raw_idx);
+        if (spec_idx.isNone()) return false;
+        const spec_node = ast.getNode(spec_idx);
+        // import_specifier / import_default_specifier / import_namespace_specifier 모두 binary.flags 사용.
+        if ((spec_node.data.binary.flags & module_parser.SPEC_FLAG_TYPE_ONLY) == 0) return false;
+    }
+    return true;
 }
 
 /// export * from "./foo": binary { left=exported_name, right=source_node }

--- a/src/bundler/import_scanner_test.zig
+++ b/src/bundler/import_scanner_test.zig
@@ -20,7 +20,12 @@ const NodeIndex = @import("../parser/ast.zig").NodeIndex;
 /// 테스트용 헬퍼. Arena로 파싱 후 import 추출.
 /// 반환된 records는 testing.allocator 소유 (caller가 free).
 /// Arena는 파싱 완료 후 해제되므로 specifier는 source를 직접 참조해야 동작.
+/// `ext` 가 주어지면 `configureFromExtension` 으로 source mode 지정 (예: ".ts").
 fn parseAndExtract(allocator: std.mem.Allocator, source: []const u8) ![]ImportRecord {
+    return parseAndExtractExt(allocator, source, null);
+}
+
+fn parseAndExtractExt(allocator: std.mem.Allocator, source: []const u8, ext: ?[]const u8) ![]ImportRecord {
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
     const arena_alloc = arena.allocator();
@@ -29,6 +34,7 @@ fn parseAndExtract(allocator: std.mem.Allocator, source: []const u8) ![]ImportRe
     var parser = Parser.init(arena_alloc, &scanner);
     parser.is_module = true;
     scanner.is_module = true;
+    if (ext) |e| parser.configureFromExtension(e);
     _ = try parser.parse();
 
     // records는 caller의 allocator로 할당 (arena 해제 후에도 유효).
@@ -65,6 +71,38 @@ fn parseAndExtractFullWithDefines(
     _ = try parser.parse();
 
     return extractImportsWithCjsDetectionAndDefines(allocator, &parser.ast, defines);
+}
+
+test "explicit `import type { X } from ...` → no record (parser already elides)" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtractExt(alloc, "import type { X } from './foo';", ".ts");
+    defer alloc.free(records);
+    try std.testing.expectEqual(@as(usize, 0), records.len);
+}
+
+test "explicit `import type X from ...` (default) → no record" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtractExt(alloc, "import type X from './foo';", ".ts");
+    defer alloc.free(records);
+    try std.testing.expectEqual(@as(usize, 0), records.len);
+}
+
+test "all individual type modifiers → no record (#2466)" {
+    // 모든 spec 이 `type` modifier 면 import 자체도 elide 되어야 함.
+    // babel-plugin-transform-typescript 가 statement 통째 제거하는 것과 동등.
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtractExt(alloc, "import { type A, type B } from './foo';", ".ts");
+    defer alloc.free(records);
+    try std.testing.expectEqual(@as(usize, 0), records.len);
+}
+
+test "type modifier mixed with value spec → record kept" {
+    // 한 spec 만 `type` modifier, 다른 spec 은 value → import 유지.
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtractExt(alloc, "import { type A, B } from './foo';", ".ts");
+    defer alloc.free(records);
+    try std.testing.expectEqual(@as(usize, 1), records.len);
+    try std.testing.expectEqualStrings("./foo", records[0].specifier);
 }
 
 test "side-effect import" {


### PR DESCRIPTION
## Summary

per-spec individual `type` modifier 가 모든 specifier 에 붙은 import 는 babel typescript preset 처럼 statement 통째 제거합니다. 이전엔 `ImportRecord` 가 생성되어 type-only re-export subpath (`react-native-screens/types` 같이 .d.ts 만 export 하는 경로) 의 모듈 resolution 시도가 hard fail 했습니다.

```ts
// 본 PR 적용 후 ImportRecord 안 나옴 — bundler resolution 도 시도 안 함
import { type Foo, type Bar } from 'react-native-screens/types';
```

declaration-level `import type { ... }` 는 parser 가 이미 elide 하므로 변경 없음.

## 범위 외 (의도)

implicit type-only — `import { Foo } from '...'; type X = Foo;` 처럼 binding 이 type position 에서만 쓰이는 패턴 — 은 본 PR 에서 처리하지 않습니다. 원인:

- ZTS 의 `ts_type_alias_declaration` / `ts_interface_declaration` / `ts_property_signature` 는 `child_offsets = &.{}` 로 선언되어 있어 `ast_walk.children` 으로 type body 의 `ts_type_reference` 에 도달 못합니다.
- 그래서 semantic analyzer 의 `Reference.flags.type_context` 가 type body 안 식별자에 붙지 않아 \"type-only reference만 있는 binding\" 판정 자체가 불가능.
- root-cause 는 plan 에 명시된 ZTS PR #3a (parser 가 type body 보존) 가 선행돼야 함.

#2466 의 ExpoApp \`prepareHeaderBarButtonItems.ts\` 케이스는 \`import { type A, type B }\` 형태이므로 본 PR 로 해결됩니다. 향후 implicit 케이스는 #3a 머지 후 follow-up 으로 추가할 예정.

## Test plan

- [x] \`zig build test\` 전체 통과
- [x] 신규 4 테스트:
  - \`import type { X } from '...'\` → record 없음 (parser elision 확인)
  - \`import type X from '...'\` → record 없음
  - \`import { type A, type B } from '...'\` → record 없음 (본 PR 변경)
  - \`import { type A, B } from '...'\` → record 1개 유지 (회귀 가드)
- [x] \`zig fmt src/\`
- [ ] bungae submodule 업데이트 후 ExpoApp release build 검증