### PR TITLE
fix(transformer): drop stack-bounded buffers in 3 silent-truncation paths (#2475 audit)

### DIFF
--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -2369,6 +2369,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
             // TS parameter property(`constructor(public x)`)는 modifier 만 strip 되어 일반 형태로 visit 되지만,
             // 이 경로는 visitMethodDefinition 을 거치지 않으므로 `this.x = x` 삽입을 직접 수행해야 함 (#1471).
             var pp = try self.visitParamsCollectProperties(params_list_old);
+            defer pp.prop_names.deinit(self.allocator);
             var param_lowering: ?es2015_params.ES2015Params(Transformer).LowerResult = null;
             if (es2015_params.ES2015Params(Transformer).hasDefaultOrRest(self, pp.new_params)) {
                 param_lowering = try es2015_params.ES2015Params(Transformer).lowerParamsPass2(self, pp.new_params, span);
@@ -2392,8 +2393,8 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 // super() 가 Reflect.construct 로 생성한 새 객체가 인스턴스이고, `this` 는 호출
                 // receiver 라 super() 전 할당은 새 인스턴스에 반영되지 않는다.
                 // instance_fields 와 합쳐 postProcessDerivedConstructorBody 에서 _this 별칭으로 emit.
-                if (pp.prop_count > 0 and !new_body.isNone()) {
-                    const pp_stmts_list = try self.buildParameterPropertyStatements(pp.prop_names[0..pp.prop_count]);
+                if (pp.prop_names.items.len > 0 and !new_body.isNone()) {
+                    const pp_stmts_list = try self.buildParameterPropertyStatements(pp.prop_names.items);
                     const pp_stmts = self.ast.extra_data.items[pp_stmts_list.start .. pp_stmts_list.start + pp_stmts_list.len];
                     const scratch_top = self.scratch.items.len;
                     defer self.scratch.shrinkRetainingCapacity(scratch_top);
@@ -2405,12 +2406,12 @@ pub fn ES2015Class(comptime Transformer: type) type {
                     try transformDerivedConstructorReturns(self, new_body);
                     new_body = try postProcessDerivedConstructorBody(self, new_body, param_stmts, instance_fields, span);
                 }
-            } else if ((param_stmts.len > 0 or pp.prop_count > 0) and !new_body.isNone()) {
+            } else if ((param_stmts.len > 0 or pp.prop_names.items.len > 0) and !new_body.isNone()) {
                 const scratch_top = self.scratch.items.len;
                 defer self.scratch.shrinkRetainingCapacity(scratch_top);
                 for (param_stmts) |stmt| try self.scratch.append(self.allocator, stmt);
-                if (pp.prop_count > 0) {
-                    const pp_stmts_list = try self.buildParameterPropertyStatements(pp.prop_names[0..pp.prop_count]);
+                if (pp.prop_names.items.len > 0) {
+                    const pp_stmts_list = try self.buildParameterPropertyStatements(pp.prop_names.items);
                     const pp_stmts = self.ast.extra_data.items[pp_stmts_list.start .. pp_stmts_list.start + pp_stmts_list.len];
                     for (pp_stmts) |raw_idx| try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
                 }

--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -357,8 +357,8 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             const oa_start = target.data.list.start;
             const split = self.ast.nodeListSplitRest(target.data.list);
             const non_rest_len: u32 = @intCast(split.elements.len);
-            var exclude_keys: [64]NodeIndex = undefined;
-            var exclude_count: usize = 0;
+            var exclude_keys: std.ArrayList(NodeIndex) = .empty;
+            defer exclude_keys.deinit(self.allocator);
             // visitNode가 AST를 변형하므로 인덱스 루프 사용
             var i_loop: u32 = 0;
             while (i_loop < non_rest_len) : (i_loop += 1) {
@@ -370,7 +370,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
 
                 const ref = try es_helpers.makeTempVarRef(self, ref_span, ref_span);
                 const key_node = self.ast.getNode(key_idx);
-                const access = try emitObjectMemberAccessForRest(self, ref, key_node, key_idx, &exclude_keys, &exclude_count, .assign, span);
+                const access = try emitObjectMemberAccessForRest(self, ref, key_node, key_idx, &exclude_keys, .assign, span);
 
                 if (prop.tag == .assignment_target_property_identifier) {
                     const target_node = try self.ast.addNode(.{
@@ -409,7 +409,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             }
 
             if (split.rest_operand) |rest_inner| {
-                const rest_assign = try buildRestAssignment(self, rest_inner, ref_span, exclude_keys[0..exclude_count], span);
+                const rest_assign = try buildRestAssignment(self, rest_inner, ref_span, exclude_keys.items, span);
                 try self.scratch.append(self.allocator, rest_assign);
                 self.runtime_helpers.rest = true;
             }
@@ -514,8 +514,8 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             const opd_start = pattern.data.list.start;
             const split = self.ast.nodeListSplitRest(pattern.data.list);
 
-            var exclude_keys: [64]NodeIndex = undefined;
-            var exclude_count: usize = 0;
+            var exclude_keys: std.ArrayList(NodeIndex) = .empty;
+            defer exclude_keys.deinit(self.allocator);
 
             // 각 property를 declarator로 변환하면서 rest exclude key도 같은 평가 결과로 수집한다.
             // visitNode가 AST를 변형하므로 인덱스 루프 사용 (split.elements 슬라이스는 stale 가능)
@@ -533,7 +533,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                 const ref = try es_helpers.makeTempVarRef(self, ref_span, ref_span);
                 const key_node = self.ast.getNode(key_idx);
 
-                const member_access = try emitObjectMemberAccessForRest(self, ref, key_node, key_idx, &exclude_keys, &exclude_count, .decl, span);
+                const member_access = try emitObjectMemberAccessForRest(self, ref, key_node, key_idx, &exclude_keys, .decl, span);
 
                 // value 처리: shorthand vs long-form, default value
                 if (value_idx.isNone() or @intFromEnum(value_idx) == @intFromEnum(key_idx)) {
@@ -589,7 +589,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
 
             // rest: var rest = __rest(_ref, ["a", "b"])
             if (split.rest_operand) |rest_inner| {
-                const rest_decl = try buildRestDeclarator(self, rest_inner, ref_span, exclude_keys[0..exclude_count], span);
+                const rest_decl = try buildRestDeclarator(self, rest_inner, ref_span, exclude_keys.items, span);
                 try self.scratch.append(self.allocator, rest_decl);
                 self.runtime_helpers.rest = true;
             }
@@ -756,8 +756,7 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
             ref: NodeIndex,
             key_node: Node,
             key_idx: NodeIndex,
-            exclude_keys: []NodeIndex,
-            exclude_count: *usize,
+            exclude_keys: *std.ArrayList(NodeIndex),
             mode: ComputedKeyMode,
             span: Span,
         ) Transformer.Error!NodeIndex {
@@ -780,16 +779,10 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
                     }),
                 };
                 try self.scratch.append(self.allocator, capture);
-                if (exclude_count.* < exclude_keys.len) {
-                    exclude_keys[exclude_count.*] = try es_helpers.makeTempVarRef(self, key_span, span);
-                    exclude_count.* += 1;
-                }
+                try exclude_keys.append(self.allocator, try es_helpers.makeTempVarRef(self, key_span, span));
                 return es_helpers.makeComputedMember(self, ref, try es_helpers.makeTempVarRef(self, key_span, span), span);
             }
-            if (exclude_count.* < exclude_keys.len) {
-                exclude_keys[exclude_count.*] = try makeRestExcludeKey(self, key_node);
-                exclude_count.* += 1;
-            }
+            try exclude_keys.append(self.allocator, try makeRestExcludeKey(self, key_node));
             return es_helpers.makeMemberFromKeyIdx(self, ref, key_idx, span);
         }
 

--- a/src/transformer/regex_lower.zig
+++ b/src/transformer/regex_lower.zig
@@ -89,12 +89,11 @@ fn rewritePattern(
     pattern: []const u8,
     opts: PatternOpts,
 ) !void {
-    // 일반 패턴에서 named group은 1-3개 수준. 32 한도를 초과하면 backref 변환이
-    // 누락되어 정합성이 깨지므로 silent skip 대신 assert 로 즉시 fail.
-    const max_named_groups = 32;
+    // ECMAScript named capture group 은 한도가 없다 (V8/SpiderMonkey 모두 unbounded).
+    // 자동 생성된 lexer/regex 등에서 32+ 도 합법이라 dynamic ArrayList 로 처리한다.
     const NamedEntry = struct { name: []const u8, idx: u32 };
-    var named: [max_named_groups]NamedEntry = undefined;
-    var named_count: usize = 0;
+    var named: std.ArrayList(NamedEntry) = .empty;
+    defer named.deinit(allocator);
     var group_idx: u32 = 0;
 
     var i: usize = 0;
@@ -120,7 +119,7 @@ fn rewritePattern(
                 if (std.mem.indexOfScalarPos(u8, pattern, i + 3, '>')) |gt| {
                     const name = pattern[i + 3 .. gt];
                     var found_idx: ?u32 = null;
-                    for (named[0..named_count]) |e| {
+                    for (named.items) |e| {
                         if (std.mem.eql(u8, e.name, name)) {
                             found_idx = e.idx;
                             break;
@@ -188,9 +187,7 @@ fn rewritePattern(
                         }
                         group_idx += 1;
                         if (std.mem.indexOfScalarPos(u8, pattern, i + 3, '>')) |gt| {
-                            std.debug.assert(named_count < max_named_groups);
-                            named[named_count] = .{ .name = pattern[i + 3 .. gt], .idx = group_idx };
-                            named_count += 1;
+                            try named.append(allocator, .{ .name = pattern[i + 3 .. gt], .idx = group_idx });
                             if (opts.strip_named) {
                                 try out.append(allocator, '(');
                                 i = gt + 1;
@@ -462,4 +459,24 @@ test "regex: named backref — character class 안의 \\k는 그대로" {
     const out = (try runLower("/(?<n>a)[\\k<n>]/", .{ .regex_named_groups = true })).?;
     defer testing.allocator.free(out);
     try testing.expectEqualStrings("/(a)[\\k<n>]/", out);
+}
+
+// #2472 회귀 가드: 32개 stack-cap 시 33번째부터 std.debug.assert 가 ReleaseFast 에서
+// 비활성화되어 OOB 쓰기 (UB) 가 발생했음. dynamic ArrayList 로 전환 후 50개도 정상 동작.
+test "#2472 regression: 50 named groups + last backref — no truncation" {
+    var pat: std.ArrayList(u8) = .empty;
+    defer pat.deinit(testing.allocator);
+    try pat.append(testing.allocator, '/');
+    var i: u32 = 0;
+    while (i < 50) : (i += 1) {
+        try pat.writer(testing.allocator).print("(?<n{d}>a)", .{i});
+    }
+    // 마지막 named group 의 backref — 50번째 capture 이므로 \50 으로 변환되어야 한다.
+    try pat.appendSlice(testing.allocator, "\\k<n49>/");
+
+    const out = (try runLower(pat.items, .{ .regex_named_groups = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expect(std.mem.indexOf(u8, out, "\\50") != null);
+    // 32-stack 회귀 시 named[32..] 가 누락되어 backref 변환 실패 → "\\k<n49>" 잔존했음.
+    try testing.expect(std.mem.indexOf(u8, out, "\\k<n") == null);
 }

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -3332,15 +3332,16 @@ pub const Transformer = struct {
         const scratch_top = self.scratch.items.len;
         defer self.scratch.shrinkRetainingCapacity(scratch_top);
 
-        const pp = try self.visitParamsCollectProperties(params_list_old);
+        var pp = try self.visitParamsCollectProperties(params_list_old);
+        defer pp.prop_names.deinit(self.allocator);
 
         // 바디 방문
         const old_body_idx = self.readNodeIdx(e, 2);
         var new_body = try self.visitBodyWorkletAware(old_body_idx);
 
         // parameter property가 있으면 바디 앞에 this.x = x 문 삽입
-        if (pp.prop_count > 0 and !new_body.isNone()) {
-            new_body = try self.insertParameterPropertyAssignments(new_body, pp.prop_names[0..pp.prop_count]);
+        if (pp.prop_names.items.len > 0 and !new_body.isNone()) {
+            new_body = try self.insertParameterPropertyAssignments(new_body, pp.prop_names.items);
         }
 
         // ES2015 arrow this/arguments 캡처: 이 함수 안의 arrow가 this/arguments를 사용했으면
@@ -3424,10 +3425,10 @@ pub const Transformer = struct {
 
     /// 파라미터 목록을 방문하면서 parameter property (public x 등)를 감지.
     /// modifier를 제거하고 this.x = x 삽입용 이름을 수집한다.
+    /// caller 는 반환된 result.prop_names 를 `deinit(self.allocator)` 해야 함.
     const ParamPropertyResult = struct {
         new_params: NodeList,
-        prop_names: [32]NodeIndex,
-        prop_count: usize,
+        prop_names: std.ArrayList(NodeIndex),
     };
 
     pub fn visitParamsCollectProperties(self: *Transformer, vp: NodeList) Error!ParamPropertyResult {
@@ -3436,9 +3437,9 @@ pub const Transformer = struct {
 
         var result = ParamPropertyResult{
             .new_params = NodeList{ .start = 0, .len = 0 },
-            .prop_names = undefined,
-            .prop_count = 0,
+            .prop_names = .empty,
         };
+        errdefer result.prop_names.deinit(self.allocator);
 
         // visitNode가 AST를 변형하므로 인덱스 루프 사용
         var i_loop: u32 = 0;
@@ -3452,10 +3453,7 @@ pub const Transformer = struct {
             if (param_node.tag == .formal_parameter and self.ast.extra_data.items[param_node.data.extra + 3] != 0) {
                 const inner = try self.visitNode(@enumFromInt(self.ast.extra_data.items[param_node.data.extra]));
                 try self.scratch.append(self.allocator, inner);
-                if (result.prop_count < result.prop_names.len) {
-                    result.prop_names[result.prop_count] = inner;
-                    result.prop_count += 1;
-                }
+                try result.prop_names.append(self.allocator, inner);
             } else {
                 const new_param = try self.visitNode(@enumFromInt(raw_idx));
                 if (!new_param.isNone()) {
@@ -4522,7 +4520,8 @@ pub const Transformer = struct {
                 params_span = pnode.span;
             }
         }
-        const pp = try self.visitParamsCollectProperties(params_list_old);
+        var pp = try self.visitParamsCollectProperties(params_list_old);
+        defer pp.prop_names.deinit(self.allocator);
 
         // arrow this/arguments 캡처: method도 자체 this 바인딩을 가짐 (visitFunction과 동일)
         const saved_arrow_depth = self.arrow_this_depth;
@@ -4551,11 +4550,11 @@ pub const Transformer = struct {
 
         // parameter property: derived class constructor 는 super() 후에, 그 외에는 body 앞에 prepend.
         // 전자에서 prepend 하면 `this` 가 super() 전 접근되어 ReferenceError.
-        if (pp.prop_count > 0 and !new_body.isNone()) {
+        if (pp.prop_names.items.len > 0 and !new_body.isNone()) {
             if (is_ctor and self.current_super_class != null) {
-                new_body = try self.insertParameterPropertyAssignmentsAfterSuper(new_body, pp.prop_names[0..pp.prop_count]);
+                new_body = try self.insertParameterPropertyAssignmentsAfterSuper(new_body, pp.prop_names.items);
             } else {
-                new_body = try self.insertParameterPropertyAssignments(new_body, pp.prop_names[0..pp.prop_count]);
+                new_body = try self.insertParameterPropertyAssignments(new_body, pp.prop_names.items);
             }
         }
 

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -2098,3 +2098,65 @@ test "module_specifier_map: default + named mix unchanged" {
     // default import 가 섞이면 분해 조건 미충족 — unchanged
     try std.testing.expectEqual(@as(u32, 1), r.statementCount());
 }
+
+// ============================================================
+// #2475 audit — stack-bounded buffer 회귀 가드
+// ============================================================
+
+test "#2470 regression: 50 TS parameter properties — all this.aN assignments emitted" {
+    // 이전 32-stack-cap 시 33번째부터 silently drop → this.a32 ~ this.a49 누락.
+    // dynamic ArrayList 로 전환 후 50개 모두 emit 되는지 확인.
+    const allocator = std.testing.allocator;
+    var src: std.ArrayList(u8) = .empty;
+    defer src.deinit(allocator);
+    try src.appendSlice(allocator, "class Service { constructor(");
+    var i: u32 = 0;
+    while (i < 50) : (i += 1) {
+        if (i > 0) try src.appendSlice(allocator, ", ");
+        try src.writer(allocator).print("public a{d}", .{i});
+    }
+    try src.appendSlice(allocator, ") {} }");
+
+    var r = try parseAndTransform(allocator, src.items);
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer allocator.free(code);
+
+    var idx: u32 = 0;
+    while (idx < 50) : (idx += 1) {
+        var needle_buf: [32]u8 = undefined;
+        const needle = try std.fmt.bufPrint(&needle_buf, "this.a{d}", .{idx});
+        try std.testing.expect(std.mem.indexOf(u8, code, needle) != null);
+    }
+}
+
+test "#2471 regression: 100-key object destructuring + rest — all keys excluded" {
+    // 이전 64-stack-cap 시 65번째부터 silently drop → __rest exclude list 가 짧아져
+    // rest 안에 누락돼야 할 키가 들어감. dynamic ArrayList 로 전환 후 100 키 모두 등록.
+    const allocator = std.testing.allocator;
+    var src: std.ArrayList(u8) = .empty;
+    defer src.deinit(allocator);
+    try src.appendSlice(allocator, "var { ");
+    var i: u32 = 0;
+    while (i < 100) : (i += 1) {
+        if (i > 0) try src.appendSlice(allocator, ", ");
+        try src.writer(allocator).print("k{d}", .{i});
+    }
+    try src.appendSlice(allocator, ", ...rest } = obj;");
+
+    // ES2018 object rest 는 target<es2018 에서 __rest 로 lowering. es5 target 사용.
+    var r = try parseAndTransformWithOptions(allocator, src.items, .{
+        .unsupported = TransformOptions.compat.fromESTarget(.es5),
+    });
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer allocator.free(code);
+
+    // exclude list 의 모든 "kN" 문자열 리터럴이 출력에 등장해야 한다.
+    var idx: u32 = 0;
+    while (idx < 100) : (idx += 1) {
+        var needle_buf: [32]u8 = undefined;
+        const needle = try std.fmt.bufPrint(&needle_buf, "\"k{d}\"", .{idx});
+        try std.testing.expect(std.mem.indexOf(u8, code, needle) != null);
+    }
+}


### PR DESCRIPTION
## 배경

#2475 epic 의 high-risk 3건을 한 PR 로 묶어 처리. 모두 stack 고정 크기 buffer 가 초과 시 silently drop 되어 correctness bug 가 되던 케이스이며, #2469 의 dynamic ArrayList 패턴을 그대로 적용했다.

## 변경 요약

| 이슈 | 위치 | 한계 (구) | 초과 시 (구) |
| --- | --- | --- | --- |
| #2470 | `transformer.zig` `prop_names[32]` | 32 | TS parameter property silently drop → runtime `this.x` 미할당 |
| #2471 | `es2015_destructuring.zig` `exclude_keys[64]` | 64 | `__rest` exclude list 짧아져 `rest` 에 있어선 안 될 키가 들어감 |
| #2472 | `regex_lower.zig` named groups `[32]` + `std.debug.assert` | 32 | ReleaseFast 에서 assert 제거되어 OOB 쓰기 (UB) |

세 곳 모두 `std.ArrayList(T) = .empty` + `defer X.deinit(allocator)` 로 전환. `.empty` 는 첫 append 까지 alloc 안 하므로 typical (0~3 element) 케이스는 perf 영향 0.

### 함수 시그니처 변경
- `ParamPropertyResult`: `prop_names: [32]NodeIndex, prop_count: usize` → `prop_names: std.ArrayList(NodeIndex)`. caller 3 곳 (`visitFunction`, `visitMethod`, `es2015_class.lowerClassDeclaration`) 에 `defer pp.prop_names.deinit(self.allocator)` 추가.
- `emitObjectMemberAccessForRest`: `(exclude_keys: []NodeIndex, exclude_count: *usize)` → `(exclude_keys: *std.ArrayList(NodeIndex))`. 두 caller (assignment / declaration context) 모두 업데이트.
- `regex_lower.rewritePattern`: `assert(named_count < 32)` 제거. ECMAScript spec 상 named capture group 한도 없음 (V8/SpiderMonkey 모두 unbounded).

## 회귀 가드 테스트

- `transformer_test.zig`
  - `#2470 regression: 50 TS parameter properties — all this.aN assignments emitted` — 50 개 parameter property 클래스를 생성해 `this.a0` ~ `this.a49` 모두 emit 확인.
  - `#2471 regression: 100-key object destructuring + rest — all keys excluded` — `var { k0, ..., k99, ...rest } = obj;` 를 ES5 target 으로 lowering, `__rest` exclude 배열에 `"k0"` ~ `"k99"` 모두 포함 확인.
- `regex_lower.zig`
  - `#2472 regression: 50 named groups + last backref — no truncation` — 50 개 named capture group 패턴의 backref `\k<n49>` 가 `\50` 으로 변환되는지 + 잔존 `\k<n` 없음.

## 검증

- `zig build test` — Debug 통과 (4595/4595 새 테스트 포함).
- `zig build test -Doptimize=ReleaseFast` — 본 PR 변경분 모두 통과. 사전 존재하는 main 의 ReleaseFast 회귀 2건 (binding_scanner / import_scanner) 은 본 PR 와 무관 (main 에서 baseline 확인).
- `zig fmt src/` 통과.

## /simplify 검토 (3 agent 병렬: reuse / quality / efficiency)

- **Reuse**: ✅ `.empty` + `defer deinit` 패턴 코드베이스 전반 (#2469, regex_lower 의 다른 ArrayList 들, es2015_template 등) 과 일치. 테스트도 기존 `parseAndTransform` / `parseAndTransformWithOptions` / `generateCode` / `runLower` 헬퍼 활용.
- **Quality**: ✅ 메모리 ownership clear (errdefer + defer 분기 명확), arena 와 분리. 시그니처 단순화. 테스트 needle buffer 적절. 한 가지 cosmetic — `#2472` regression tag 를 prefix 형식으로 통일.
- **Efficiency**: ✅ `.empty` 는 첫 append 전까지 zero-alloc. typical 0-property / 0-key / 0-named-group 케이스는 alloc 0. 1+ 일 때만 capacity-8 reservation 이라 hot path 영향 무시 가능.

Closes #2470
Closes #2471
Closes #2472
Closes #2475

🤖 Generated with [Claude Code](https://claude.com/claude-code)