### PR TITLE
fix(codegen): apply rootDir to require.context module lookup IDs

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1750,6 +1750,7 @@ pub fn emitModule(
         // codegen은 jsx_element/jsx_fragment를 만나지 않으므로 JSX 옵션 불필요.
         // dev mode: import.meta.hot → __zts_make_hot("dev_id")
         .dev_module_id = if (options.dev_mode and module.dev_id.len > 0) module.dev_id else null,
+        .require_context_module_id_root = options.root_dir,
         .import_records = module.import_records,
         .worker_map = if (options.worker_map_per_module) |outer| outer.getPtr(module.path) else null,
         .assert_no_raw_private_syntax = options.unsupported.requiresPrivateDownlevel(),

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -353,6 +353,7 @@ pub fn emitEsmWrappedModule(
             .source_root = options.sourcemap.source_root orelse "",
             .sources_content = options.sourcemap.sources_content,
             .import_records = module.import_records,
+            .require_context_module_id_root = options.root_dir,
             .assert_no_raw_private_syntax = options.unsupported.requiresPrivateDownlevel(),
         });
         if (options.sourcemap.enable) {
@@ -564,6 +565,7 @@ pub fn emitEsmWrappedModule(
         .source_root = options.sourcemap.source_root orelse "",
         .sources_content = options.sourcemap.sources_content,
         .import_records = module.import_records,
+        .require_context_module_id_root = options.root_dir,
         .assert_no_raw_private_syntax = options.unsupported.requiresPrivateDownlevel(),
     });
     // 소스맵: 소스 파일 등록 + line_offsets 설정
@@ -589,6 +591,7 @@ pub fn emitEsmWrappedModule(
             .source_root = options.sourcemap.source_root orelse "",
             .sources_content = options.sourcemap.sources_content,
             .import_records = module.import_records,
+            .require_context_module_id_root = options.root_dir,
             .assert_no_raw_private_syntax = options.unsupported.requiresPrivateDownlevel(),
         });
         if (options.sourcemap.enable) {

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -128,6 +128,10 @@ pub const CodegenOptions = struct {
     force_var_for_cycle: bool = false,
     /// dev mode 모듈 ID. 설정 시 import.meta.hot → __zts_make_hot("id") 변환.
     dev_module_id: ?[]const u8 = null,
+    /// require.context match 의 abs path → module ID 변환 base.
+    /// `__zts_modules[<id>]` lookup 이 모듈 등록 ID 와 일치해야 하므로 emitter 가 동일
+    /// `root_dir` 을 전달. null 이면 변환 없음 (legacy 절대 경로).
+    require_context_module_id_root: ?[]const u8 = null,
     /// import.meta.glob 레코드. codegen이 glob 호출을 객체 리터럴로 직접 출력.
     import_records: []const @import("../bundler/types.zig").ImportRecord = &.{},
     /// Metro x_facebook_sources function map emit 활성화.
@@ -2010,6 +2014,22 @@ pub const Codegen = struct {
         return false;
     }
 
+    /// `dev.makeModuleId` 와 동일 의미 — codegen 에서 emitter 모듈 import 회피용 inline.
+    /// abs path → root_dir 기준 상대 경로, root 밖이면 node_modules fallback, 둘 다 안 맞으면 abs.
+    fn makeRequireContextModuleId(abs: []const u8, root_dir: ?[]const u8) []const u8 {
+        const root = root_dir orelse return abs;
+        if (root.len == 0) return abs;
+        if (std.mem.startsWith(u8, abs, root)) {
+            var rel = abs[root.len..];
+            if (rel.len > 0 and rel[0] == '/') rel = rel[1..];
+            if (rel.len > 0) return rel;
+        }
+        if (std.mem.indexOf(u8, abs, "/node_modules/")) |nm_pos| {
+            return abs[nm_pos + 1 ..];
+        }
+        return abs;
+    }
+
     /// `require.context(...)` 호출을 webpackContext IIFE 로 emit.
     /// Metro `contextModuleTemplates.js` 의 sync mode 패턴 mirror.
     /// 매칭은 record.span (= call_expression span) 으로 — `tryExtractRequireContextFromCallee`
@@ -2046,10 +2066,13 @@ pub const Codegen = struct {
                     // 는 undefined — expo-router 가 `ctx(req)` 반환값을 route module 로 사용해
                     // tree 구성이 실패하고 "Unmatched Route" 로 fallback.
                     // 다른 require 호출과 동일한 `(fn(), __toCommonJS(.exports))` 패턴으로 emit.
+                    // `__zts_modules` 의 key 는 모듈 등록 ID — emitter 가 `dev.makeModuleId`
+                    // 로 normalize 해서 등록하므로 lookup 도 동일 normalize 적용 (#2466 follow-up).
+                    const id = makeRequireContextModuleId(abs, self.options.require_context_module_id_root);
                     try self.write("(__zts_modules[\"");
-                    try self.writeJsStringContent(abs);
+                    try self.writeJsStringContent(id);
                     try self.write("\"].fn(),__toCommonJS(__zts_modules[\"");
-                    try self.writeJsStringContent(abs);
+                    try self.writeJsStringContent(id);
                     try self.write("\"].exports))");
                 } else {
                     try self.write("(function(){throw new Error(\"require.context match unresolved: \"+");


### PR DESCRIPTION
## Summary

require.context expansion 의 \`__zts_modules[<abs>]\` lookup 이 절대 파일 경로를 hard-code 했는데, 모듈 등록 ID 는 emitter 가 \`makeModuleId(path, root_dir)\` 로 normalize 한 값. \`rootDir\` 옵션 적용 시 mismatch 로 \`undefined.fn\` runtime crash.

## 재현

bungae rootDir 옵션 활성화 + ExpoApp + expo-router 환경:

\`\`\`
runtime.js:820 TypeError: Cannot read property 'fn' of undefined
    at ./(tabs)/_layout.tsx (_ctx.ios.js:1:20)
    at ctx (_ctx.ios.js:1:20)
    at loadRoute (getRoutesCore.js:233:49)
\`\`\`

bundle 안:
\`\`\`js
// 모듈 등록 (rootDir 적용된 ID)
var init__layout = __esm({ "app/(tabs)/_layout.tsx"() { ... } });

// require.context lookup (절대 경로 그대로 — mismatch!)
__zts_modules["/Users/.../app/(tabs)/_layout.tsx"].fn()  // undefined!
\`\`\`

## 변경

- \`CodegenOptions\` 에 \`require_context_module_id_root: ?[]const u8\` 추가
- emitter (3 곳: \`emitter.zig\` + \`esm_wrap.zig\` × 3) 가 \`options.root_dir\` 전달
- codegen \`tryEmitRequireContextObject\` 에서 abs → module ID 변환 후 emit
- \`makeRequireContextModuleId\` helper 추가 (\`dev.makeModuleId\` 와 동일 의미, codegen↔emitter circular import 회피용 inline)

## 검증

- 전체 \`zig build test\` 통과
- ExpoApp release 빌드 (\`bun run build:bungae --platform ios\`) 5MB 번들 정상 생성
- bundle 안 \`__zts_modules[]\` lookup 이 \`app/(tabs)/_layout.tsx\` 형태로 모듈 ID 와 일치
- bungae 측 dev server 재시작 후 expo-router runtime crash 해소 (사용자 검증 대기)

## 관련

- bungae PR: [\`fix/zts-rootdir\`](packages/bungae/src/bundler/zts-bundler/napi-build.ts:215) — bungae 가 ZTS NAPI 에 \`rootDir\` 옵션 전달 (사용자 측 PR 예정)
- 시작점: #2466 (closed) — sourcemap 절대 경로 → DevTools URL 파싱 실패. rootDir 적용 fix 시도가 본 require.context regression 노출

## Test plan

- [x] \`zig build test\` 전체 통과
- [x] \`zig fmt src/\`
- [x] ExpoApp release 빌드 \`__zts_modules[]\` lookup 이 module ID 와 일치
- [ ] dev server 재시작 후 expo-router runtime crash 해소 확인 (사용자 검증)