### PR TITLE
fix(import-scanner): guard allSpecsAreTypeOnly against union punning UB

### DIFF
--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -320,7 +320,12 @@ fn allSpecsAreTypeOnly(ast: *const Ast, specs_start: u32, specs_len: u32) bool {
         const spec_idx: NodeIndex = @enumFromInt(raw_idx);
         if (spec_idx.isNone()) return false;
         const spec_node = ast.getNode(spec_idx);
-        // import_specifier / import_default_specifier / import_namespace_specifier 모두 binary.flags 사용.
+        // spec-level `type` modifier 는 named `import_specifier` 만 가짐 (module.zig:33-36
+        // SPEC_FLAG_TYPE_ONLY 정의). `import_default_specifier` / `import_namespace_specifier`
+        // 는 `data = .string_ref` 레이아웃이라 `data.binary.flags` 를 읽으면 union punning
+        // 으로 garbage 를 읽고, ReleaseFast 에서 비결정적으로 type-only 로 오판되어
+        // namespace/default import 의 record 가 누락됐었다.
+        if (spec_node.tag != .import_specifier) return false;
         if ((spec_node.data.binary.flags & module_parser.SPEC_FLAG_TYPE_ONLY) == 0) return false;
     }
     return true;

--- a/src/bundler/import_scanner_test.zig
+++ b/src/bundler/import_scanner_test.zig
@@ -105,6 +105,17 @@ test "type modifier mixed with value spec → record kept" {
     try std.testing.expectEqualStrings("./foo", records[0].specifier);
 }
 
+test "default + namespace import → record kept (#2466 regression)" {
+    // `import_default_specifier` / `import_namespace_specifier` 는 binary 레이아웃이 아니라
+    // `data.string_ref` 라서, allSpecsAreTypeOnly 가 binary.flags 로 union punning 하면
+    // ReleaseFast 에서 garbage bits 가 우연히 SPEC_FLAG_TYPE_ONLY 로 읽혀 record 가 누락됐었다.
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtractExt(alloc, "import dflt, * as ns from './foo';", ".ts");
+    defer alloc.free(records);
+    try std.testing.expectEqual(@as(usize, 1), records.len);
+    try std.testing.expectEqualStrings("./foo", records[0].specifier);
+}
+
 test "side-effect import" {
     const alloc = std.testing.allocator;
     const records = try parseAndExtract(alloc, "import './styles.css';");


### PR DESCRIPTION
## 배경

main 의 ReleaseFast CI 가 namespace import 관련 두 테스트에서 비결정적으로 fail (seed 마다 다른 테스트가 깨짐):
- `bundler.binding_scanner_test.test.import binding: namespace import`
- `bundler.import_scanner_test.test.namespace import`
- (다른 seed) `multiple imports`, `destructuring re-export ...` 등

증상: \`expected 1, found 0\` — `import * as ns from '...';` 의 ImportRecord 가 추출되지 않음.

## 근본 원인

#2466 fix (`daf4834c`) 가 추가한 `allSpecsAreTypeOnly` (src/bundler/import_scanner.zig:316) 가 모든 spec 에서 `data.binary.flags` 를 무조건 읽음:

```zig
// AS-WAS
if ((spec_node.data.binary.flags & module_parser.SPEC_FLAG_TYPE_ONLY) == 0) return false;
```

하지만 `data` 는 AST tag 별로 layout 이 다른 union:
- `import_specifier` → `.binary` (left/right/flags) ← spec-level `type` modifier 가 여기 들어감
- `import_default_specifier` / `import_namespace_specifier` → `.string_ref` ← **다른 layout**

따라서 default/namespace specifier 에서 `binary.flags` 를 읽으면 union punning 으로 다른 필드의 비트를 garbage 로 해석.

- Debug: 메모리가 zero-init 되거나 우연히 0 비트라 무난히 통과.
- ReleaseFast: 비결정적으로 SPEC_FLAG_TYPE_ONLY (1) 가 set → `allSpecsAreTypeOnly` 가 true 반환 → import statement 자체 elide → ImportRecord 누락.

`SPEC_FLAG_TYPE_ONLY` 정의 위치 (src/parser/module.zig:33-36) 자체가 "import_specifier / export_specifier 의 binary.flags 비트" 라고 명시.

## 수정

```zig
// AS-IS
if (spec_node.tag != .import_specifier) return false;
if ((spec_node.data.binary.flags & module_parser.SPEC_FLAG_TYPE_ONLY) == 0) return false;
```

named `import_specifier` 만 spec-level `type` modifier 를 가지므로, 다른 spec tag 면 type-only 가 아님 → 곧장 false. binary.flags 접근은 tag 검증 후에만 발생.

## 회귀 가드

`import dflt, * as ns from './foo';` (default + namespace 결합) 이 record 1개로 추출되는지 명시 테스트 추가. 기존 `namespace import` / `default import` 테스트도 ReleaseFast 에서 통과하므로 더 강한 회귀 가드 역할.

## 검증

- `zig build test --seed 0x71b3772a -Doptimize=ReleaseFast` (CI 와 동일 seed) — 통과
- `zig build test -Doptimize=ReleaseFast` (random seed) — 본 PR 영향 분 모두 통과 (별개 flaky `resolve_cache_test.profile .resolve` 1건 발견했으나 본 PR 범위 외).
- `zig build test` (Debug) — 통과
- `zig fmt src/` — 통과

## /simplify 검토

- 다른 `binary.flags` + `SPEC_FLAG_TYPE_ONLY` 호출 사이트 grep — `transpile.zig`, `transformer.zig`, `parser/module.zig`, `binding_scanner.zig` 모두 tag 검증 후 접근하거나 import_specifier 만 보는 컨텍스트라 동일 버그 없음.
- export 측 `tryExtractExportNamed` 는 `allSpecsAreTypeOnly` 미사용. export_specifier 만 사용하므로 대칭 버그 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)