### PR TITLE
fix(hmr): use module ID (not abs path) for reparsed_paths

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -879,7 +879,15 @@ pub const Bundler = struct {
                 if (inc_result.reparsed_indices.len > 0) {
                     const list = try self.allocator.alloc([]const u8, inc_result.reparsed_indices.len);
                     for (inc_result.reparsed_indices, 0..) |mod_idx, i| {
-                        const src = if (graph.getModule(mod_idx)) |m| m.path else "";
+                        // HMR diff 의 source-of-truth — emit 의 `ModuleDevCode.id` (=
+                        // `makeModuleId(m.path, root_dir)`) 와 동일 형식으로 채워야 napi_entry
+                        // 의 `reparsed_set.contains(dc.id)` 필터가 매칭된다. root_dir 옵션이
+                        // 적용된 후엔 절대 경로 (`m.path`) 와 module ID (`dc.id`) 가 달라져
+                        // 모든 update 가 silent drop → "no code change" (#bungae 실측).
+                        const src = if (graph.getModule(mod_idx)) |m|
+                            emitter.makeModuleId(m.path, self.options.root_dir)
+                        else
+                            "";
                         list[i] = try self.allocator.dupe(u8, src);
                     }
                     reparsed_paths_out = list;


### PR DESCRIPTION
## Summary

NAPI watch 의 HMR delta filter (\`napi_entry.zig:2856\`) 가 \`reparsed_set.contains(dc.id)\` 로 cache-hit 모듈을 거르는데, **\`dc.id\` 와 \`reparsed_paths\` 의 형식이 달라서** 모든 update 가 silent drop 됨.

## 증상

bungae 가 \`rootDir\` 옵션 전달 후 (PR #2478 후속), \`console.log\` 추가 같은 명백한 코드 변경에도 HMR update 가 발사 안 되고 \"Rebuilt [ios] (1 files, ..ms, no code change)\" 로 끝남.

\`\`\`tsx
// _layout.tsx 에 console.log('test') 추가 → 저장
\`\`\`

기대: HMR update broadcast 후 RN runtime 이 module 재실행
실제: silent drop, 변경 반영 안 됨

## 원인

| 변수 | 형식 | 출처 |
| --- | --- | --- |
| \`dc.id\` (HMR payload) | module ID — \`app/(tabs)/_layout.tsx\` | \`emitter.zig:736\` \`makeModuleId(m.path, root_dir)\` |
| \`reparsed_paths\` (delta filter) | abs path — \`/Users/.../app/(tabs)/_layout.tsx\` | \`bundler.zig:882\` \`m.path\` 그대로 dupe |

\`root_dir\` 가 null 이던 시절엔 \`makeModuleId\` 가 abs path fallback 이라 두 set 이 우연히 일치 → 필터 정상 동작. \`root_dir\` 적용 후 module ID 가 상대 경로로 normalize 되면서 mismatch 발생.

\`napi_entry.zig:2856\`:
\`\`\`zig
if (use_reparsed_filter and !reparsed_set.contains(dc.id)) continue;  // 항상 true → 모든 update skip
\`\`\`

## 변경

\`bundler.zig:882\`:
\`\`\`diff
- const src = if (graph.getModule(mod_idx)) |m| m.path else "";
+ const src = if (graph.getModule(mod_idx)) |m|
+     emitter.makeModuleId(m.path, self.options.root_dir)
+ else
+     "";
\`\`\`

emit 의 \`ModuleDevCode.id\` 와 정확히 동일한 함수/인자로 ID 생성. 두 set 이 항상 일치.

## 검증

- 전체 \`zig build test\` 통과
- 기존 \`incremental_test:586\` 회귀 없음 (\`endsWith\` 비교라 dev_id 든 abs path 든 통과)
- bungae 측 dev server 재시작 후 console.log 변경 시 HMR update 발사 확인 (사용자 검증 대기)

## 관련

- 시작점: bungae PR #84 (rootDir NAPI 전달) → DevTools sourceURL 파싱 + expo-router crash 해결
- 후속: PR #2478 (codegen require.context module ID normalize) — 같은 root cause (rootDir 적용 시 절대 경로 hard-coding 누락)
- 본 PR — HMR delta filter 의 마지막 누락 위치

## Test plan

- [x] \`zig build test\` 통과
- [x] \`zig fmt src/\`
- [ ] bungae dev server 재시작 후 console.log 추가 → HMR update 발사 확인 (사용자 검증)