### PR TITLE
fix(ast-walk,semantic): drop stack-bounded buffers in walker + catch_names (#2475 medium)

### DIFF
--- a/src/parser/ast_walk.zig
+++ b/src/parser/ast_walk.zig
@@ -163,8 +163,6 @@ pub fn children(ast: *const Ast, node: Node) ChildIterator {
 /// 있었다. 호출 측의 출력 타입이 다 달라서 (Span list / 이름 list / StringHashMap /
 /// fixed buf) iterator 패턴으로 두고 wrapping 만 caller 가 결정.
 pub const BindingIdentifierWalker = struct {
-    pub const STACK_CAPACITY: usize = 256;
-
     pub const Options = struct {
         /// `(Foo = Bar()) =>` 같이 cover-grammar 로 패턴 자리에 남은 assignment_expression
         /// 의 LHS 를 binding 으로 본다. 일반 expression 컨텍스트의 `Foo = expr` 와 충돌하지
@@ -173,15 +171,19 @@ pub const BindingIdentifierWalker = struct {
     };
 
     ast: *const Ast,
+    allocator: std.mem.Allocator,
     options: Options,
-    /// 명시 stack — stack overflow 방지 + bound 명시. 깊이 256 초과 패턴은 비현실적.
-    stack: [STACK_CAPACITY]NodeIndex = undefined,
-    stack_len: usize,
+    /// caller 가 만들어 주입한 stack. 첫 append 까지 alloc 안 함. 한도 없이 dynamic.
+    /// caller 는 walker 사용 후 `stack.deinit(allocator)` 호출 책임.
+    stack: std.ArrayList(NodeIndex),
 
-    pub fn next(self: *BindingIdentifierWalker) ?NodeIndex {
-        while (self.stack_len > 0) {
-            self.stack_len -= 1;
-            const idx = self.stack[self.stack_len];
+    pub fn deinit(self: *BindingIdentifierWalker) void {
+        self.stack.deinit(self.allocator);
+    }
+
+    pub fn next(self: *BindingIdentifierWalker) error{OutOfMemory}!?NodeIndex {
+        while (self.stack.items.len > 0) {
+            const idx = self.stack.pop().?;
             if (idx.isNone()) continue;
             const raw: u32 = @intFromEnum(idx);
             if (raw >= self.ast.nodes.items.len) continue;
@@ -193,31 +195,31 @@ pub const BindingIdentifierWalker = struct {
                 => return idx,
                 .formal_parameter => {
                     if (node.data.extra >= self.ast.extra_data.items.len) continue;
-                    self.push(@enumFromInt(self.ast.extra_data.items[node.data.extra]));
+                    try self.push(@enumFromInt(self.ast.extra_data.items[node.data.extra]));
                 },
                 .formal_parameters,
                 .array_pattern,
                 .object_pattern,
                 .array_assignment_target,
                 .object_assignment_target,
-                => self.pushList(node.data.list),
+                => try self.pushList(node.data.list),
                 .assignment_pattern,
                 .assignment_target_with_default,
-                => self.push(node.data.binary.left),
+                => try self.push(node.data.binary.left),
                 .assignment_expression => {
-                    if (self.options.cover_grammar_assignment) self.push(node.data.binary.left);
+                    if (self.options.cover_grammar_assignment) try self.push(node.data.binary.left);
                 },
                 .rest_element,
                 .binding_rest_element,
                 .assignment_target_rest,
                 .spread_element,
-                => self.push(node.data.unary.operand),
+                => try self.push(node.data.unary.operand),
                 .binding_property,
                 .assignment_target_property_identifier,
                 .assignment_target_property_property,
                 => {
                     const value = node.data.binary.right;
-                    self.push(if (value.isNone()) node.data.binary.left else value);
+                    try self.push(if (value.isNone()) node.data.binary.left else value);
                 },
                 else => {},
             }
@@ -225,35 +227,40 @@ pub const BindingIdentifierWalker = struct {
         return null;
     }
 
-    fn push(self: *BindingIdentifierWalker, idx: NodeIndex) void {
+    fn push(self: *BindingIdentifierWalker, idx: NodeIndex) error{OutOfMemory}!void {
         if (idx.isNone()) return;
-        if (self.stack_len >= STACK_CAPACITY) return;
-        self.stack[self.stack_len] = idx;
-        self.stack_len += 1;
+        try self.stack.append(self.allocator, idx);
     }
 
-    fn pushList(self: *BindingIdentifierWalker, list: ast_mod.NodeList) void {
+    fn pushList(self: *BindingIdentifierWalker, list: ast_mod.NodeList) error{OutOfMemory}!void {
         if (list.start + list.len > self.ast.extra_data.items.len) return;
         // 역순으로 push 해서 다음 next() 호출이 list[0] 부터 보도록 한다.
         var i: u32 = list.len;
         while (i > 0) {
             i -= 1;
             const raw = self.ast.extra_data.items[list.start + i];
-            self.push(@enumFromInt(raw));
+            try self.push(@enumFromInt(raw));
         }
     }
 };
 
 /// 바인딩 패턴 (포함 cover-grammar 결과) 의 leaf identifier 를 순회하는 iterator.
+/// caller 는 반환된 walker 를 `defer w.deinit()` 해야 함.
 pub fn bindingIdentifiers(
+    allocator: std.mem.Allocator,
     ast: *const Ast,
     idx: NodeIndex,
     options: BindingIdentifierWalker.Options,
-) BindingIdentifierWalker {
-    var w: BindingIdentifierWalker = .{ .ast = ast, .options = options, .stack_len = 0 };
+) error{OutOfMemory}!BindingIdentifierWalker {
+    var w: BindingIdentifierWalker = .{
+        .ast = ast,
+        .allocator = allocator,
+        .options = options,
+        .stack = .empty,
+    };
+    errdefer w.stack.deinit(allocator);
     if (!idx.isNone() and @intFromEnum(idx) < ast.nodes.items.len) {
-        w.stack[0] = idx;
-        w.stack_len = 1;
+        try w.stack.append(allocator, idx);
     }
     return w;
 }

--- a/src/parser/ast_walk_test.zig
+++ b/src/parser/ast_walk_test.zig
@@ -159,8 +159,9 @@ fn collectBindingNames(
 ) !std.ArrayList([]const u8) {
     var out: std.ArrayList([]const u8) = .empty;
     errdefer out.deinit(allocator);
-    var it = ast_walk.bindingIdentifiers(ast, idx, options);
-    while (it.next()) |leaf_idx| {
+    var it = try ast_walk.bindingIdentifiers(allocator, ast, idx, options);
+    defer it.deinit();
+    while (try it.next()) |leaf_idx| {
         try out.append(allocator, ast.getText(ast.getNode(leaf_idx).span));
     }
     return out;
@@ -226,6 +227,33 @@ test "bindingIdentifiers: formal_parameters 와 nested default" {
     try std.testing.expectEqualStrings("d", names.items[3]);
     try std.testing.expectEqualStrings("e", names.items[4]);
     try std.testing.expectEqualStrings("g", names.items[5]);
+}
+
+test "#2473 regression: 500-element array pattern — walker 가 모든 leaf 반환" {
+    // 이전 256-stack-cap 시 257번째부터 silently push 무시 → walker leaf 누락.
+    // dynamic ArrayList 로 전환 후 500개 모두 yield.
+    const a = std.testing.allocator;
+
+    var src: std.ArrayList(u8) = .empty;
+    defer src.deinit(a);
+    try src.appendSlice(a, "var [");
+    var i: u32 = 0;
+    while (i < 500) : (i += 1) {
+        if (i > 0) try src.appendSlice(a, ", ");
+        try src.writer(a).print("a{d}", .{i});
+    }
+    try src.appendSlice(a, "] = arr;");
+
+    var ctx = try parseSource(a, src.items);
+    defer ctx.parser.deinit();
+    defer ctx.scanner.deinit();
+
+    const arr_idx = findFirstTag(&ctx.parser.ast, .array_pattern) orelse return error.NotFound;
+    var names = try collectBindingNames(a, &ctx.parser.ast, arr_idx, .{});
+    defer names.deinit(a);
+    try std.testing.expectEqual(@as(usize, 500), names.items.len);
+    try std.testing.expectEqualStrings("a0", names.items[0]);
+    try std.testing.expectEqualStrings("a499", names.items[499]);
 }
 
 test "bindingIdentifiers: cover_grammar_assignment 옵션이 arrow param 의 assignment_expression 을 처리" {

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -2683,21 +2683,19 @@ pub const SemanticAnalyzer = struct {
         const saved = try self.enterScope(.catch_clause, self.is_strict_mode);
         const param_idx = node.data.binary.left;
 
-        // catch param 이름 수집 (중복 바인딩 검사 + block body 충돌 검사용)
-        var catch_names: [16]Span = undefined;
-        var catch_name_count: usize = 0;
+        // catch param 이름 수집 (중복 바인딩 검사 + block body 충돌 검사용).
+        // dynamic — 16+ binding 도 진단 누락 없이 처리 (#2474).
+        var catch_names: std.ArrayList(Span) = .empty;
+        defer catch_names.deinit(self.allocator);
 
         if (!param_idx.isNone()) {
             const param_node = self.ast.getNode(param_idx);
             if (param_node.tag == .binding_identifier) {
                 try self.declareSymbolWithNode(param_node.span, .catch_binding, param_node.span, @intFromEnum(param_idx));
-                if (catch_name_count < 16) {
-                    catch_names[catch_name_count] = param_node.span;
-                    catch_name_count += 1;
-                }
+                try catch_names.append(self.allocator, param_node.span);
             } else {
                 // Destructuring pattern — collect all binding names and check duplicates
-                try self.collectAndCheckCatchBindings(param_idx, &catch_names, &catch_name_count);
+                try self.collectAndCheckCatchBindings(param_idx, &catch_names);
             }
         }
 
@@ -2705,13 +2703,13 @@ pub const SemanticAnalyzer = struct {
         const body_idx = node.data.binary.right;
         if (!body_idx.isNone()) {
             const body_node = self.ast.getNode(body_idx);
-            if (body_node.tag == .block_statement and catch_name_count > 0) {
+            if (body_node.tag == .block_statement and catch_names.items.len > 0) {
                 // Enter block scope for the body
                 const block_saved = try self.enterScope(.block, self.is_strict_mode);
                 // Visit block body statements
                 try self.visitNodeList(body_node.data.list);
                 // Check for catch param conflicts with lexically-declared names in the block
-                try self.checkCatchBodyConflicts(catch_names[0..catch_name_count]);
+                try self.checkCatchBodyConflicts(catch_names.items);
                 self.exitScope(block_saved);
             } else {
                 try self.visitNode(body_idx);
@@ -2721,14 +2719,14 @@ pub const SemanticAnalyzer = struct {
     }
 
     /// Collect binding names from destructuring pattern and check for duplicate catch bindings.
-    fn collectAndCheckCatchBindings(self: *SemanticAnalyzer, idx: NodeIndex, names: *[16]Span, count: *usize) AllocError!void {
+    fn collectAndCheckCatchBindings(self: *SemanticAnalyzer, idx: NodeIndex, names: *std.ArrayList(Span)) AllocError!void {
         if (idx.isNone() or @intFromEnum(idx) >= self.ast.nodes.items.len) return;
         const node = self.ast.getNode(idx);
         switch (node.tag) {
             .binding_identifier => {
                 // Check for duplicate
                 const name_text = self.ast.getText(node.span);
-                for (names.*[0..count.*]) |existing_span| {
+                for (names.items) |existing_span| {
                     const existing_text = self.ast.getText(existing_span);
                     if (std.mem.eql(u8, name_text, existing_text)) {
                         try self.addRedeclarationError(node.span, name_text, existing_span);
@@ -2736,18 +2734,15 @@ pub const SemanticAnalyzer = struct {
                     }
                 }
                 try self.declareSymbolWithNode(node.span, .catch_binding, node.span, @intFromEnum(idx));
-                if (count.* < 16) {
-                    names.*[count.*] = node.span;
-                    count.* += 1;
-                }
+                try names.append(self.allocator, node.span);
             },
             .array_pattern => {
                 const split = self.ast.nodeListSplitRest(node.data.list);
                 for (split.elements) |raw_idx| {
-                    try self.collectAndCheckCatchBindings(@enumFromInt(raw_idx), names, count);
+                    try self.collectAndCheckCatchBindings(@enumFromInt(raw_idx), names);
                 }
                 if (split.rest_operand) |op| {
-                    try self.collectAndCheckCatchBindings(op, names, count);
+                    try self.collectAndCheckCatchBindings(op, names);
                 }
             },
             .object_pattern => {
@@ -2759,18 +2754,18 @@ pub const SemanticAnalyzer = struct {
                     if (prop.tag == .object_property or
                         prop.tag == .assignment_target_property_identifier)
                     {
-                        try self.collectAndCheckCatchBindings(prop.data.binary.right, names, count);
+                        try self.collectAndCheckCatchBindings(prop.data.binary.right, names);
                     } else {
-                        try self.collectAndCheckCatchBindings(prop_idx, names, count);
+                        try self.collectAndCheckCatchBindings(prop_idx, names);
                     }
                 }
                 if (split.rest_operand) |op| {
-                    try self.collectAndCheckCatchBindings(op, names, count);
+                    try self.collectAndCheckCatchBindings(op, names);
                 }
             },
             .assignment_pattern, .assignment_target_with_default => {
                 // binary: { left = pattern, right = default }
-                try self.collectAndCheckCatchBindings(node.data.binary.left, names, count);
+                try self.collectAndCheckCatchBindings(node.data.binary.left, names);
             },
             else => {},
         }

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -1821,3 +1821,63 @@ test "JSX: bare lowercase tag <div/> is intrinsic, not a variable ref" {
 
     try std.testing.expectEqual(@as(usize, 0), refs.items.len);
 }
+
+// ============================================================
+// #2474 catch_names dynamic — 회귀 가드
+// ============================================================
+
+test "#2474 regression: catch destructure duplicate at index 17+ — diagnostic emitted" {
+    // 이전 16-stack-cap 시 17번째 binding 부터 names 배열에 push 안 됨. 두 개의 동일
+    // 이름 (예: k16, k16) 이 모두 17+ 위치라면 둘 다 names 에 못 들어가 redeclaration 검사
+    // 자체가 비교 base 를 못 가져 silent 누락. dynamic ArrayList 로 전환 후 정상 검출.
+    //
+    // array_pattern 사용 (object pattern 의 binding_property 분기는 본 PR 범위 외).
+    const a = std.testing.allocator;
+    var src: std.ArrayList(u8) = .empty;
+    defer src.deinit(a);
+    try src.appendSlice(a, "try {} catch ([");
+    var i: u32 = 0;
+    while (i < 16) : (i += 1) {
+        if (i > 0) try src.appendSlice(a, ", ");
+        try src.writer(a).print("k{d}", .{i});
+    }
+    // 17번째와 18번째에 동일 이름 k16. 16-stack 이면 둘 다 names 에 못 들어감 → 진단 누락.
+    try src.appendSlice(a, ", k16, k16]) {}");
+
+    var r = try analyzeModule(src.items);
+    defer r.deinit();
+    var found = false;
+    for (r.analyzer.errors.items) |err| {
+        if (std.mem.indexOf(u8, err.message, "Identifier 'k16' has already been declared") != null) {
+            found = true;
+            break;
+        }
+    }
+    try std.testing.expect(found);
+}
+
+test "#2474 regression: 20-element catch destructure conflicts with body let — diagnostic emitted" {
+    // checkCatchBodyConflicts 가 16 초과 binding 도 검사하는지 확인.
+    // 17번째 binding 인 `k16` 이 body 의 let `k16` 와 conflict. 16-stack 이면 k16 이 catch_names 에 없음.
+    const a = std.testing.allocator;
+    var src: std.ArrayList(u8) = .empty;
+    defer src.deinit(a);
+    try src.appendSlice(a, "try {} catch ([");
+    var i: u32 = 0;
+    while (i < 17) : (i += 1) {
+        if (i > 0) try src.appendSlice(a, ", ");
+        try src.writer(a).print("k{d}", .{i});
+    }
+    try src.appendSlice(a, "]) { let k16 = 1; }");
+
+    var r = try analyzeModule(src.items);
+    defer r.deinit();
+    var found = false;
+    for (r.analyzer.errors.items) |err| {
+        if (std.mem.indexOf(u8, err.message, "Identifier 'k16' has already been declared") != null) {
+            found = true;
+            break;
+        }
+    }
+    try std.testing.expect(found);
+}

--- a/src/semantic/checker.zig
+++ b/src/semantic/checker.zig
@@ -367,8 +367,9 @@ fn collectBindingNames(
     errors: *std.ArrayList(Diagnostic),
     allocator: std.mem.Allocator,
 ) AllocError!void {
-    var it = ast_walk.bindingIdentifiers(ast, idx, .{});
-    while (it.next()) |leaf_idx| {
+    var it = try ast_walk.bindingIdentifiers(allocator, ast, idx, .{});
+    defer it.deinit();
+    while (try it.next()) |leaf_idx| {
         const leaf = ast.getNode(leaf_idx);
         if (leaf.tag != .binding_identifier) continue;
         try recordSeenName(ast.getText(leaf.span), leaf.span, seen, errors, allocator);

--- a/src/transformer/es2015_block_scoping.zig
+++ b/src/transformer/es2015_block_scoping.zig
@@ -84,8 +84,9 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
             idx: NodeIndex,
             names: *std.ArrayList([]const u8),
         ) !void {
-            var it = ast_walk.bindingIdentifiers(self.ast, idx, .{});
-            while (it.next()) |leaf_idx| {
+            var it = try ast_walk.bindingIdentifiers(self.allocator, self.ast, idx, .{});
+            defer it.deinit();
+            while (try it.next()) |leaf_idx| {
                 const leaf = self.ast.getNode(leaf_idx);
                 if (leaf.tag != .binding_identifier) continue;
                 try names.append(self.allocator, self.ast.getText(leaf.span));

--- a/src/transformer/es2015_destructuring.zig
+++ b/src/transformer/es2015_destructuring.zig
@@ -734,8 +734,9 @@ pub fn ES2015Destructuring(comptime Transformer: type) type {
         }
 
         fn collectBindingNames(self: *Transformer, idx: NodeIndex, out: *std.ArrayList(Span)) Transformer.Error!void {
-            var it = ast_walk.bindingIdentifiers(self.ast, idx, .{});
-            while (it.next()) |leaf_idx| {
+            var it = try ast_walk.bindingIdentifiers(self.allocator, self.ast, idx, .{});
+            defer it.deinit();
+            while (try it.next()) |leaf_idx| {
                 try out.append(self.allocator, self.ast.getNode(leaf_idx).data.string_ref);
             }
         }

--- a/src/transformer/es2015_params.zig
+++ b/src/transformer/es2015_params.zig
@@ -380,8 +380,9 @@ pub fn ES2015Params(comptime Transformer: type) type {
         fn collectBindingNames(self: *Transformer, idx: NodeIndex, out: *std.ArrayList(Span)) Transformer.Error!void {
             // cover-grammar 결과 (identifier_reference / assignment_target_identifier) 도
             // 동일하게 spans 로 수집 — caller (param TDZ 검사) 가 그 형태를 기대한다.
-            var it = ast_walk.bindingIdentifiers(self.ast, idx, .{});
-            while (it.next()) |leaf_idx| {
+            var it = try ast_walk.bindingIdentifiers(self.allocator, self.ast, idx, .{});
+            defer it.deinit();
+            while (try it.next()) |leaf_idx| {
                 try out.append(self.allocator, self.ast.getNode(leaf_idx).data.string_ref);
             }
         }

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -229,8 +229,9 @@ pub fn collectClosureVars(
 /// coverExpressionToAssignmentTarget 로 변환되므로 cover-grammar 결과 (identifier_reference,
 /// assignment_target_identifier, assignment_expression) 도 binding 으로 본다.
 fn collectBindingNames(self: *Transformer, idx: NodeIndex, locals: *std.StringHashMap(void)) Error!void {
-    var it = ast_walk.bindingIdentifiers(self.ast, idx, .{ .cover_grammar_assignment = true });
-    while (it.next()) |leaf_idx| {
+    var it = try ast_walk.bindingIdentifiers(self.allocator, self.ast, idx, .{ .cover_grammar_assignment = true });
+    defer it.deinit();
+    while (try it.next()) |leaf_idx| {
         const name = self.ast.getText(self.ast.getNode(leaf_idx).data.string_ref);
         if (name.len > 0) locals.put(name, {}) catch return error.OutOfMemory;
     }

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -536,8 +536,11 @@ fn hasUnsupportedNamedImportLocalBindingShadow(ast: *const Ast) bool {
 // 안에서는 fresh counter 로도 의미가 같지만, `var a, b, c` 처럼 한 var 리스트의
 // 누적 shadow 수를 봐야 하는 경우엔 호출자가 같은 counter 를 재사용한다.
 fn bindingPatternImportShadowOverflow(ast: *const Ast, idx: ast_mod.NodeIndex, names: []const []const u8, match_count: *usize) bool {
-    var it = ast_walk.bindingIdentifiers(ast, idx, .{ .cover_grammar_assignment = true });
-    while (it.next()) |leaf_idx| {
+    // walker 의 alloc 실패는 의미상 "scan 불완전" 이라 conservative-keep (overflow 로 간주) 로 fallback.
+    // 정상 path 는 ast.allocator 가 transpile arena 라 사실상 bump-allocator → 실패 거의 없음.
+    var it = ast_walk.bindingIdentifiers(ast.allocator, ast, idx, .{ .cover_grammar_assignment = true }) catch return true;
+    defer it.deinit();
+    while (it.next() catch return true) |leaf_idx| {
         const leaf = ast.getNode(leaf_idx);
         const name = ast.getText(leaf.span);
         if (string_list.contains(names, name)) {
@@ -873,8 +876,10 @@ fn appendBindingLiteShadowName(buf: [][]const u8, len: *usize, name: []const u8)
 
 fn collectBindingLitePatternShadows(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *const BindingLite, buf: [][]const u8, len: *usize) void {
     if (len.* >= buf.len) return;
-    var it = ast_walk.bindingIdentifiers(ast, idx, .{ .cover_grammar_assignment = true });
-    while (it.next()) |leaf_idx| {
+    // walker alloc 실패 시 그냥 중단 — 호출자는 buf 가 빈 상태면 기존대로 conservative path 가 잡는다.
+    var it = ast_walk.bindingIdentifiers(ast.allocator, ast, idx, .{ .cover_grammar_assignment = true }) catch return;
+    defer it.deinit();
+    while (it.next() catch return) |leaf_idx| {
         const leaf = ast.getNode(leaf_idx);
         // import 이름과 매칭되는 binding 만 shadow set 에 추가. cover-grammar 결과인
         // identifier_reference / assignment_target_identifier 도 동일 처리.


### PR DESCRIPTION
## 배경

#2475 audit 의 medium-risk 2건을 한 PR. #2469 패턴 (stack `[N]T` → `std.ArrayList(T)`) 그대로 적용.

| 이슈 | 위치 | 한계 (구) | 초과 시 (구) |
| --- | --- | --- | --- |
| #2473 | `ast_walk.zig` `BindingIdentifierWalker.stack[256]` | 256 | walker silent push 무시 → caller 별 다른 영향 (진단 누락 / elision miss) |
| #2474 | `analyzer.zig` `catch_names[16]` | 16 | 17번째 binding 부터 redeclaration / catch body conflict **진단 silent 누락** |

## #2473 변경 — BindingIdentifierWalker dynamic stack

- `stack: [256]NodeIndex` → `std.ArrayList(NodeIndex)`. `next()` / `push()` / `pushList()` 모두 `error{OutOfMemory}!` 전파.
- `bindingIdentifiers()` 시그니처에 `allocator` 추가 + `error!Walker` 반환.
- `BindingIdentifierWalker.deinit()` 추가 — caller 가 `defer it.deinit()`.
- caller 7곳 업데이트:
  - **transformer 4곳**: `es2015_block_scoping.zig`, `es2015_destructuring.zig`, `es2015_params.zig`, `transformer/worklet.zig` — `self.allocator` 사용 + 기존 `Error` enum 으로 자연 전파.
  - **semantic/checker.zig**: `allocator` 인자 이미 있어 그대로 전달.
  - **transpile.zig 2곳**: caller chain 깊어 (`scanForUnsupportedBindingLiteShadow` → `buildTransformPlan`) error 전파 부담. **walker OOM 을 의미상 \"scan 불완전 → conservative\" 와 동일시하여 catch fallback**:
    - `bindingPatternImportShadowOverflow` → `catch return true` (overflow 로 간주, full route 로 fallback)
    - `collectBindingLitePatternShadows` → `catch return` (buf 비운 채로 호출자가 conservative 처리)
  - 본래 의도 (\"shadow overflow conservative-keep\") 와 의미적으로 일치. `ast.allocator` 가 transpile arena 라 사실상 OOM 거의 없음.

## #2474 변경 — catch_names dynamic

- `catch_names: [16]Span` → `std.ArrayList(Span)`. `defer catch_names.deinit(self.allocator)`.
- `collectAndCheckCatchBindings` 시그니처 `*[16]Span, count: *usize` → `*std.ArrayList(Span)`. 8개 재귀 호출 사이트 모두 업데이트.
- 16 가드 모두 제거 — `if (count.* < 16)` 보호 코드 삭제.

## 회귀 가드 테스트

- `ast_walk_test.zig`
  - `#2473 regression: 500-element array pattern — walker 가 모든 leaf 반환` — 500 element array_pattern 에서 walker 가 500 leaf 모두 yield.
- `analyzer_test.zig`
  - `#2474 regression: catch destructure duplicate at index 17+ — diagnostic emitted` — `[k0..k15, k16, k16]` 의 17번째와 18번째 동일 이름이 16-stack 시 둘 다 names 에 못 들어가 비교 base 사라져 silent 누락 → dynamic 후 정상 검출.
  - `#2474 regression: 20-element catch destructure conflicts with body let — diagnostic emitted` — 17번째 binding `k16` 과 body 의 `let k16` conflict 진단.
  - **array_pattern 사용** — `collectAndCheckCatchBindings` 의 `binding_property` 분기 누락은 **본 PR 범위 외** (별도 pre-existing 버그).

## 검증

- `zig build test` (Debug) — 통과 (4599/4599).
- `zig build test -Doptimize=ReleaseFast` — 본 PR 변경분 모두 통과. main 의 두 baseline 회귀 (`binding_scanner_test` / `import_scanner_test` namespace import) 는 PR #2479 (union punning fix) 미머지 영향이라 본 PR 무관 — #2479 머지 후 자동 해소.
- `zig fmt src/` 통과.

## /simplify 3 agent 검토

- **Reuse**: ✅ `.empty + defer deinit` 패턴 코드베이스 (#2469, regex_lower, es2015_template, collectReachableNodeIndices 등) 와 일치. 테스트도 기존 `parseSource` / `analyzeModule` / `collectBindingNames` 헬퍼 활용.
- **Quality**: ✅ 메모리 ownership clear (defer / errdefer 분기 명확), 7 walker caller 모두 `defer it.deinit()` 검증 완료. catch_names 의 8개 재귀 call site 모두 시그니처 업데이트. SemanticAnalyzer 의 allocator 가 transpile arena 라 #1287 dual-cleanup 위험 없음.
- **Efficiency**: ✅ `.empty` 는 첫 append 전까지 zero-alloc. typical 1-3 binding 시 capacity-8 reservation 한 번 (~32-64 bytes from arena = bump-alloc 수십 ns). hot path 영향 무시 가능.

Closes #2473
Closes #2474

🤖 Generated with [Claude Code](https://claude.com/claude-code)