### PR TITLE
fix(semantic): handle binding_property in collectAndCheckCatchBindings (#2483)

### DIFF
--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -2719,55 +2719,30 @@ pub const SemanticAnalyzer = struct {
     }
 
     /// Collect binding names from destructuring pattern and check for duplicate catch bindings.
+    /// `BindingIdentifierWalker` 에 위임 — pattern tag 매트릭스를 단일 walker (single source of truth)
+    /// 로 통일해 \`binding_property\` 같은 tag 누락 회귀를 구조적으로 차단한다 (#2483).
     fn collectAndCheckCatchBindings(self: *SemanticAnalyzer, idx: NodeIndex, names: *std.ArrayList(Span)) AllocError!void {
-        if (idx.isNone() or @intFromEnum(idx) >= self.ast.nodes.items.len) return;
-        const node = self.ast.getNode(idx);
-        switch (node.tag) {
-            .binding_identifier => {
-                // Check for duplicate
-                const name_text = self.ast.getText(node.span);
-                for (names.items) |existing_span| {
-                    const existing_text = self.ast.getText(existing_span);
-                    if (std.mem.eql(u8, name_text, existing_text)) {
-                        try self.addRedeclarationError(node.span, name_text, existing_span);
-                        return;
-                    }
+        var it = try ast_walk.bindingIdentifiers(self.allocator, self.ast, idx, .{});
+        defer it.deinit();
+        while (try it.next()) |leaf_idx| {
+            const leaf = self.ast.getNode(leaf_idx);
+            // catch destructure 는 binding context 라 cover-grammar 결과 (identifier_reference /
+            // assignment_target_identifier) 가 없다. binding_identifier 만 의미 있음.
+            if (leaf.tag != .binding_identifier) continue;
+            const name_text = self.ast.getText(leaf.span);
+            var dup_span: ?Span = null;
+            for (names.items) |existing| {
+                if (std.mem.eql(u8, name_text, self.ast.getText(existing))) {
+                    dup_span = existing;
+                    break;
                 }
-                try self.declareSymbolWithNode(node.span, .catch_binding, node.span, @intFromEnum(idx));
-                try names.append(self.allocator, node.span);
-            },
-            .array_pattern => {
-                const split = self.ast.nodeListSplitRest(node.data.list);
-                for (split.elements) |raw_idx| {
-                    try self.collectAndCheckCatchBindings(@enumFromInt(raw_idx), names);
-                }
-                if (split.rest_operand) |op| {
-                    try self.collectAndCheckCatchBindings(op, names);
-                }
-            },
-            .object_pattern => {
-                const split = self.ast.nodeListSplitRest(node.data.list);
-                for (split.elements) |raw_idx| {
-                    const prop_idx: NodeIndex = @enumFromInt(raw_idx);
-                    if (prop_idx.isNone() or @intFromEnum(prop_idx) >= self.ast.nodes.items.len) continue;
-                    const prop = self.ast.getNode(prop_idx);
-                    if (prop.tag == .object_property or
-                        prop.tag == .assignment_target_property_identifier)
-                    {
-                        try self.collectAndCheckCatchBindings(prop.data.binary.right, names);
-                    } else {
-                        try self.collectAndCheckCatchBindings(prop_idx, names);
-                    }
-                }
-                if (split.rest_operand) |op| {
-                    try self.collectAndCheckCatchBindings(op, names);
-                }
-            },
-            .assignment_pattern, .assignment_target_with_default => {
-                // binary: { left = pattern, right = default }
-                try self.collectAndCheckCatchBindings(node.data.binary.left, names);
-            },
-            else => {},
+            }
+            if (dup_span) |existing| {
+                try self.addRedeclarationError(leaf.span, name_text, existing);
+                continue;
+            }
+            try self.declareSymbolWithNode(leaf.span, .catch_binding, leaf.span, @intFromEnum(leaf_idx));
+            try names.append(self.allocator, leaf.span);
         }
     }
 

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -1856,6 +1856,37 @@ test "#2474 regression: catch destructure duplicate at index 17+ — diagnostic 
     try std.testing.expect(found);
 }
 
+test "#2483 regression: catch ({a, a}) — duplicate diagnostic emitted" {
+    // collectAndCheckCatchBindings 가 object_pattern 의 binding_property 분기를 처리해야 함.
+    // 이전: object_property / assignment_target_property_identifier 만 인식 → binding_property 는 else 로 빠져
+    // 재귀해도 switch 의 binding_property case 가 없어 silent skip → duplicate 진단 누락.
+    var r = try analyzeModule("try {} catch ({a, a}) {}");
+    defer r.deinit();
+    var found = false;
+    for (r.analyzer.errors.items) |err| {
+        if (std.mem.indexOf(u8, err.message, "Identifier 'a' has already been declared") != null) {
+            found = true;
+            break;
+        }
+    }
+    try std.testing.expect(found);
+}
+
+test "#2483 regression: catch ({a}) { let a = 1; } — body conflict diagnostic emitted" {
+    // checkCatchBodyConflicts 가 동작하려면 catch_names 가 채워져야 한다.
+    // binding_property 가 silent skip 되면 catch_names 비어 conflict 검사 불가.
+    var r = try analyzeModule("try {} catch ({a}) { let a = 1; }");
+    defer r.deinit();
+    var found = false;
+    for (r.analyzer.errors.items) |err| {
+        if (std.mem.indexOf(u8, err.message, "Identifier 'a' has already been declared") != null) {
+            found = true;
+            break;
+        }
+    }
+    try std.testing.expect(found);
+}
+
 test "#2474 regression: 20-element catch destructure conflicts with body let — diagnostic emitted" {
     // checkCatchBodyConflicts 가 16 초과 binding 도 검사하는지 확인.
     // 17번째 binding 인 `k16` 이 body 의 let `k16` 와 conflict. 16-stack 이면 k16 이 catch_names 에 없음.


### PR DESCRIPTION
## 배경

`collectAndCheckCatchBindings` (src/semantic/analyzer.zig) 가 ad-hoc 재귀 walker 라 binding pattern tag 매트릭스 (binding_identifier / array_pattern / object_pattern / assignment_pattern …) 를 직접 나열했고, `binding_property` case 가 빠져 catch object destructure 의 redeclaration / body conflict 진단이 통째로 누락. **새 binding tag 추가 시 같은 누락이 재발할 수 있는 구조 자체가 root cause.**

#2475 audit 의 #2474 PR 작업 중 회귀 가드 테스트 작성 시 발견. 해당 PR 에선 \"본 PR 범위 외\" 로 처리하고 array_pattern 으로 우회한 테스트만 추가.

## TDD 진행

1. **Red** — 실패 테스트 두 개 먼저:
   - `try {} catch ({a, a}) {}` → duplicate 진단 누락 (fail 확인)
   - `try {} catch ({a}) { let a = 1; }` → body conflict 진단 누락 (fail 확인)
2. **Green** — root cause 해결: ad-hoc walker 를 코드베이스의 canonical binding walker (`ast_walk.BindingIdentifierWalker`) 로 위임.
3. **Verify** — Debug + ReleaseFast 모두 통과.

## 변경

- `collectAndCheckCatchBindings` 함수 본문 60줄 → 25줄.
- pattern tag 매트릭스 직접 나열 제거 → walker iterator + duplicate 검사 wrapper.
- 새 binding tag 추가 시 walker 한 곳만 업데이트하면 catch path 도 자동 수혜 (single source of truth).
- catch context 에서 walker 가 yield 하는 leaf 중 의미 있는 건 binding_identifier 뿐 (cover-grammar 결과 식별자는 binding context 에 없음) — 명시 필터.

```zig
fn collectAndCheckCatchBindings(self: *SemanticAnalyzer, idx: NodeIndex, names: *std.ArrayList(Span)) AllocError!void {
    var it = try ast_walk.bindingIdentifiers(self.allocator, self.ast, idx, .{});
    defer it.deinit();
    while (try it.next()) |leaf_idx| {
        const leaf = self.ast.getNode(leaf_idx);
        if (leaf.tag != .binding_identifier) continue;
        const name_text = self.ast.getText(leaf.span);
        var dup_span: ?Span = null;
        for (names.items) |existing| {
            if (std.mem.eql(u8, name_text, self.ast.getText(existing))) {
                dup_span = existing;
                break;
            }
        }
        if (dup_span) |existing| {
            try self.addRedeclarationError(leaf.span, name_text, existing);
            continue;
        }
        try self.declareSymbolWithNode(leaf.span, .catch_binding, leaf.span, @intFromEnum(leaf_idx));
        try names.append(self.allocator, leaf.span);
    }
}
```

## 행동 동등성 검증 (/simplify)

- 모든 binding pattern tag 가 walker 에서 동일 의미로 처리됨 — old switch 의 5 case 모두 walker 에서 cover.
- `assignment_pattern` (default value) / `binding_rest_element` / `assignment_target_with_default` 모두 walker 가 처리.
- pushList 가 역순 push + pop → declaration 순서 유지.
- old code 가 빠뜨린 `binding_property` 가 walker 에서 정확한 right-or-left fallback 로 처리됨.

## 검증

- `zig build test` (Debug) — 통과.
- `zig build test -Doptimize=ReleaseFast` — 통과.
- `zig fmt src/` 통과.

Closes #2483

🤖 Generated with [Claude Code](https://claude.com/claude-code)