### PR TITLE
fix(worklet): replace recursive depth-limited walkers with explicit stack (#2484)

### DIFF
--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -178,9 +178,9 @@ pub fn collectClosureVars(
     //      동시에 `new X()` 형태의 callee identifier를 new_classes에 수집
     //      (disable_worklet_classes 옵션이면 수집 안 함).
     if (self.options.disable_worklet_classes) {
-        try walkBodyForClosureAnalysis(self, body_idx, &locals, &refs, 0);
+        try walkBodyForClosureAnalysis(self, body_idx, &locals, &refs);
     } else {
-        try walkBodyForClosureAnalysisWithNew(self, body_idx, &locals, &refs, &new_classes, 0);
+        try walkBodyForClosureAnalysisWithNew(self, body_idx, &locals, &refs, &new_classes);
     }
 
     // 4. refs - locals - globals = closure vars
@@ -246,18 +246,17 @@ fn walkScopedBody(
     param_nodes: []const u32,
     outer_locals: *std.StringHashMap(void),
     outer_refs: *std.StringHashMap(NodeIndex),
-    depth: u32,
 ) Error!void {
     var inner_locals = std.StringHashMap(void).init(self.allocator);
     defer inner_locals.deinit();
 
     for (param_nodes) |raw| {
-        try collectAllIdentifiers(self, @enumFromInt(raw), &inner_locals, 0);
+        try collectAllIdentifiers(self, @enumFromInt(raw), &inner_locals);
     }
 
     var inner_refs = std.StringHashMap(NodeIndex).init(self.allocator);
     defer inner_refs.deinit();
-    try walkBodyForClosureAnalysis(self, body_idx, &inner_locals, &inner_refs, depth + 1);
+    try walkBodyForClosureAnalysis(self, body_idx, &inner_locals, &inner_refs);
 
     var iter = inner_refs.iterator();
     while (iter.next()) |entry| {
@@ -268,26 +267,31 @@ fn walkScopedBody(
 }
 
 /// 노드 트리에서 모든 identifier (identifier_reference, binding_identifier 등)를 수집.
-/// params에서 binding names를 추출하는 용도. generic 순회.
-fn collectAllIdentifiers(self: *Transformer, idx: NodeIndex, locals: *std.StringHashMap(void), depth: u32) Error!void {
-    if (idx.isNone()) return;
-    if (depth > 32) return;
-    if (@intFromEnum(idx) >= self.ast.nodes.items.len) return;
-
-    const node = self.ast.getNode(idx);
-    switch (node.tag) {
-        .identifier_reference, .binding_identifier, .assignment_target_identifier => {
-            const name = self.ast.getText(node.data.string_ref);
-            if (name.len > 0) locals.put(name, {}) catch return error.OutOfMemory;
-            return;
-        },
-        else => {},
+/// params에서 binding names를 추출하는 용도. generic pre-order 순회 — 명시 stack 사용으로
+/// 깊이 한도 없음 (#2484: 이전 depth>32 silent return 이 깊은 패턴에서 leaf 누락).
+fn collectAllIdentifiers(self: *Transformer, idx: NodeIndex, locals: *std.StringHashMap(void)) Error!void {
+    var stack: std.ArrayList(NodeIndex) = .empty;
+    defer stack.deinit(self.allocator);
+    if (!idx.isNone() and @intFromEnum(idx) < self.ast.nodes.items.len) {
+        try stack.append(self.allocator, idx);
     }
-    // generic 재귀 순회 — 공통 ChildIterator 사용
-    var it = ast_walk.children(self.ast, node);
-    while (it.next()) |child| {
-        if (child.isNone()) continue;
-        try collectAllIdentifiers(self, child, locals, depth + 1);
+    while (stack.pop()) |cur| {
+        if (cur.isNone()) continue;
+        if (@intFromEnum(cur) >= self.ast.nodes.items.len) continue;
+        const node = self.ast.getNode(cur);
+        switch (node.tag) {
+            .identifier_reference, .binding_identifier, .assignment_target_identifier => {
+                const name = self.ast.getText(node.data.string_ref);
+                if (name.len > 0) locals.put(name, {}) catch return error.OutOfMemory;
+                continue;
+            },
+            else => {},
+        }
+        var it = ast_walk.children(self.ast, node);
+        while (it.next()) |child| {
+            if (child.isNone()) continue;
+            try stack.append(self.allocator, child);
+        }
     }
 }
 
@@ -304,198 +308,203 @@ fn walkBodyForClosureAnalysisWithNew(
     locals: *std.StringHashMap(void),
     refs: *std.StringHashMap(NodeIndex),
     new_classes: *std.StringHashMap(NodeIndex),
-    depth: u32,
 ) Error!void {
-    try collectNewExpressionCallees(self, idx, new_classes, 0);
-    try walkBodyForClosureAnalysis(self, idx, locals, refs, depth);
+    try collectNewExpressionCallees(self, idx, new_classes);
+    try walkBodyForClosureAnalysis(self, idx, locals, refs);
 }
 
 /// AST를 순회하며 `new <Identifier>(...)` 형태의 callee identifier를 수집.
+/// 명시 stack pre-order — 깊이 한도 없음 (#2484: 이전 depth>128 silent return).
 fn collectNewExpressionCallees(
     self: *Transformer,
     idx: NodeIndex,
     new_classes: *std.StringHashMap(NodeIndex),
-    depth: u32,
 ) Error!void {
-    if (idx.isNone()) return;
-    if (depth > 128) return;
-    if (@intFromEnum(idx) >= self.ast.nodes.items.len) return;
-    const node = self.ast.getNode(idx);
-    if (node.tag == .new_expression) {
-        const e = node.data.extra;
-        if (e < self.ast.extra_data.items.len) {
-            const callee_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
-            if (!callee_idx.isNone()) {
-                const callee = self.ast.getNode(callee_idx);
-                if (callee.tag == .identifier_reference) {
-                    const name = self.ast.getText(callee.data.string_ref);
-                    if (name.len > 0) {
-                        new_classes.put(name, callee_idx) catch return error.OutOfMemory;
+    var stack: std.ArrayList(NodeIndex) = .empty;
+    defer stack.deinit(self.allocator);
+    if (!idx.isNone() and @intFromEnum(idx) < self.ast.nodes.items.len) {
+        try stack.append(self.allocator, idx);
+    }
+    while (stack.pop()) |cur| {
+        if (cur.isNone()) continue;
+        if (@intFromEnum(cur) >= self.ast.nodes.items.len) continue;
+        const node = self.ast.getNode(cur);
+        if (node.tag == .new_expression) {
+            const e = node.data.extra;
+            if (e < self.ast.extra_data.items.len) {
+                const callee_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+                if (!callee_idx.isNone()) {
+                    const callee = self.ast.getNode(callee_idx);
+                    if (callee.tag == .identifier_reference) {
+                        const name = self.ast.getText(callee.data.string_ref);
+                        if (name.len > 0) {
+                            new_classes.put(name, callee_idx) catch return error.OutOfMemory;
+                        }
                     }
                 }
             }
         }
-    }
-    // 자식 재귀 — 공통 ChildIterator 로 generic 순회
-    var it = ast_walk.children(self.ast, node);
-    while (it.next()) |child| {
-        if (child.isNone()) continue;
-        try collectNewExpressionCallees(self, child, new_classes, depth + 1);
+        var it = ast_walk.children(self.ast, node);
+        while (it.next()) |child| {
+            if (child.isNone()) continue;
+            try stack.append(self.allocator, child);
+        }
     }
 }
 
+/// 같은 스코프 내 generic descent 는 명시 stack 으로 처리해 표현 깊이 한도를 없앤다 (#2484).
+/// nested function/arrow/method 처럼 별도 스코프 진입은 그대로 자체 재귀 — 호출 깊이는
+/// 사용자 코드의 nested function 깊이만큼이라 stack overflow 위험 없음.
 fn walkBodyForClosureAnalysis(
     self: *Transformer,
     idx: NodeIndex,
     locals: *std.StringHashMap(void),
     refs: *std.StringHashMap(NodeIndex),
-    depth: u32,
 ) Error!void {
-    if (idx.isNone()) return;
-    if (depth > 64) return;
-    if (@intFromEnum(idx) >= self.ast.nodes.items.len) return;
-
-    const node = self.ast.getNode(idx);
-    const tag = node.tag;
-
-    // --- 특수 처리 노드 ---
-    switch (tag) {
-        // 식별자 참조 수집
-        .identifier_reference => {
-            const name = self.ast.getText(node.data.string_ref);
-            if (name.len > 0) {
-                refs.put(name, idx) catch return error.OutOfMemory;
-            }
-            return;
-        },
-
-        // 중첩 함수/arrow/method: 별도 스코프로 body를 순회하여 외부 참조를 수집.
-        // __initData.code에 body가 포함되므로, 그 안의 free variable을
-        // worklet closure에 전파해야 함 (Babel scope chain과 동일).
-        .function_declaration, .function_expression, .function => {
-            const e = node.data.extra;
-            if (tag == .function_declaration) {
-                try collectBindingNames(self, @enumFromInt(self.ast.extra_data.items[e]), locals);
-            }
-            if (!self.ast.hasExtra(e, 3)) return;
-            const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 2]);
-            if (body_idx.isNone()) return;
-            // name + params → param_nodes (extra_data 슬라이스 + name 앞에 추가)
-            const plist = self.ast.functionParamsList(node);
-            const p_start = plist.start;
-            const p_len = plist.len;
-            // name(e[0])은 항상 포함, params는 extra_data 슬라이스
-            // 두 소스를 합치기 위해 단일 배열 사용은 불가 → 두 번 호출 대신 inline 처리
-            var fn_locals = std.StringHashMap(void).init(self.allocator);
-            defer fn_locals.deinit();
-            try collectAllIdentifiers(self, @enumFromInt(self.ast.extra_data.items[e]), &fn_locals, 0); // name
-            var fpi: u32 = 0;
-            while (fpi < p_len) : (fpi += 1) {
-                if (p_start + fpi < self.ast.extra_data.items.len)
-                    try collectAllIdentifiers(self, @enumFromInt(self.ast.extra_data.items[p_start + fpi]), &fn_locals, 0);
-            }
-            var fn_refs = std.StringHashMap(NodeIndex).init(self.allocator);
-            defer fn_refs.deinit();
-            try walkBodyForClosureAnalysis(self, body_idx, &fn_locals, &fn_refs, depth + 1);
-            var fr_iter = fn_refs.iterator();
-            while (fr_iter.next()) |entry| {
-                if (!fn_locals.contains(entry.key_ptr.*) and !locals.contains(entry.key_ptr.*)) {
-                    refs.put(entry.key_ptr.*, entry.value_ptr.*) catch return error.OutOfMemory;
-                }
-            }
-            return;
-        },
-        .arrow_function_expression => {
-            const e = node.data.extra;
-            if (!self.ast.hasExtra(e, 2)) return;
-            const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 1]);
-            if (body_idx.isNone()) return;
-            // arrow params: formal_parameters 노드를 param_node로 전달
-            try walkScopedBody(self, body_idx, &.{self.ast.extra_data.items[e]}, locals, refs, depth);
-            return;
-        },
-        .method_definition => {
-            const e = node.data.extra;
-            if (!self.ast.hasExtra(e, 3)) return;
-            const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 2]);
-            if (body_idx.isNone()) return;
-            const plist = self.ast.functionParamsList(node);
-            const p_start = plist.start;
-            const p_len = plist.len;
-            if (p_start + p_len <= self.ast.extra_data.items.len) {
-                try walkScopedBody(self, body_idx, self.ast.extra_data.items[p_start .. p_start + p_len], locals, refs, depth);
-            }
-            return;
-        },
-
-        // 변수 선언: binding name → locals, init → generic 순회
-        .variable_declarator => {
-            const e = node.data.extra;
-            if (!self.ast.hasExtra(e, 3)) return;
-            try collectBindingNames(self, @enumFromInt(self.ast.extra_data.items[e]), locals);
-            // init(offset 2)만 순회 (name은 binding, type_ann은 TS 타입)
-            try walkBodyForClosureAnalysis(self, @enumFromInt(self.ast.extra_data.items[e + 2]), locals, refs, depth + 1);
-            return;
-        },
-
-        // catch: param → locals, body만 순회
-        .catch_clause => {
-            try collectBindingNames(self, node.data.binary.left, locals);
-            try walkBodyForClosureAnalysis(self, node.data.binary.right, locals, refs, depth + 1);
-            return;
-        },
-
-        // object_property: binary = [key, value]
-        // shorthand { x } → key는 참조 (value=none)
-        // long-form { key: value } → value 순회 + computed key도 순회 ([expr]: value)
-        .object_property => {
-            if (node.data.binary.right.isNone()) {
-                try walkBodyForClosureAnalysis(self, node.data.binary.left, locals, refs, depth + 1);
-            } else {
-                // computed key [expr] → expr 안의 identifier도 순회
-                const key_idx = node.data.binary.left;
-                if (!key_idx.isNone()) {
-                    const key_node = self.ast.getNode(key_idx);
-                    if (key_node.tag == .computed_property_key) {
-                        try walkBodyForClosureAnalysis(self, key_idx, locals, refs, depth + 1);
-                    }
-                }
-                try walkBodyForClosureAnalysis(self, node.data.binary.right, locals, refs, depth + 1);
-            }
-            return;
-        },
-
-        // TS/Flow type expression: 값(left)만 순회, 타입(right) 무시.
-        // parser가 binary(left=expr, right=type)로 저장하지만 layout은 extra로 정의되어
-        // generic walker가 자식을 찾지 못하므로 명시적 처리 필요.
-        .ts_as_expression,
-        .ts_satisfies_expression,
-        .ts_type_assertion,
-        .ts_instantiation_expression,
-        .flow_as_expression,
-        .flow_type_cast_expression,
-        => {
-            try walkBodyForClosureAnalysis(self, node.data.binary.left, locals, refs, depth + 1);
-            return;
-        },
-
-        // static member: object만 순회 (property는 외부 참조가 아님)
-        .static_member_expression, .private_field_expression => {
-            const me = node.data.extra;
-            if (self.ast.hasExtra(me, 2)) {
-                try walkBodyForClosureAnalysis(self, @enumFromInt(self.ast.extra_data.items[me]), locals, refs, depth + 1);
-            }
-            return;
-        },
-
-        else => {},
+    var stack: std.ArrayList(NodeIndex) = .empty;
+    defer stack.deinit(self.allocator);
+    if (!idx.isNone() and @intFromEnum(idx) < self.ast.nodes.items.len) {
+        try stack.append(self.allocator, idx);
     }
 
-    // --- Generic 순회: 공통 ChildIterator ---
-    var it = ast_walk.children(self.ast, node);
-    while (it.next()) |child| {
-        if (child.isNone()) continue;
-        try walkBodyForClosureAnalysis(self, child, locals, refs, depth + 1);
+    while (stack.pop()) |cur| {
+        if (cur.isNone()) continue;
+        if (@intFromEnum(cur) >= self.ast.nodes.items.len) continue;
+        const node = self.ast.getNode(cur);
+        const tag = node.tag;
+
+        switch (tag) {
+            // 식별자 참조 수집
+            .identifier_reference => {
+                const name = self.ast.getText(node.data.string_ref);
+                if (name.len > 0) {
+                    refs.put(name, cur) catch return error.OutOfMemory;
+                }
+                continue;
+            },
+
+            // 중첩 함수/arrow/method: 별도 스코프로 body를 순회하여 외부 참조를 수집.
+            // __initData.code에 body가 포함되므로, 그 안의 free variable을
+            // worklet closure에 전파해야 함 (Babel scope chain과 동일).
+            .function_declaration, .function_expression, .function => {
+                const e = node.data.extra;
+                if (tag == .function_declaration) {
+                    try collectBindingNames(self, @enumFromInt(self.ast.extra_data.items[e]), locals);
+                }
+                if (!self.ast.hasExtra(e, 3)) continue;
+                const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 2]);
+                if (body_idx.isNone()) continue;
+                const plist = self.ast.functionParamsList(node);
+                const p_start = plist.start;
+                const p_len = plist.len;
+                var fn_locals = std.StringHashMap(void).init(self.allocator);
+                defer fn_locals.deinit();
+                // name + params → param_nodes (extra_data 슬라이스 + name 앞에 추가)
+                try collectAllIdentifiers(self, @enumFromInt(self.ast.extra_data.items[e]), &fn_locals);
+                var fpi: u32 = 0;
+                while (fpi < p_len) : (fpi += 1) {
+                    if (p_start + fpi < self.ast.extra_data.items.len)
+                        try collectAllIdentifiers(self, @enumFromInt(self.ast.extra_data.items[p_start + fpi]), &fn_locals);
+                }
+                var fn_refs = std.StringHashMap(NodeIndex).init(self.allocator);
+                defer fn_refs.deinit();
+                try walkBodyForClosureAnalysis(self, body_idx, &fn_locals, &fn_refs);
+                var fr_iter = fn_refs.iterator();
+                while (fr_iter.next()) |entry| {
+                    if (!fn_locals.contains(entry.key_ptr.*) and !locals.contains(entry.key_ptr.*)) {
+                        refs.put(entry.key_ptr.*, entry.value_ptr.*) catch return error.OutOfMemory;
+                    }
+                }
+                continue;
+            },
+            .arrow_function_expression => {
+                const e = node.data.extra;
+                if (!self.ast.hasExtra(e, 2)) continue;
+                const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 1]);
+                if (body_idx.isNone()) continue;
+                try walkScopedBody(self, body_idx, &.{self.ast.extra_data.items[e]}, locals, refs);
+                continue;
+            },
+            .method_definition => {
+                const e = node.data.extra;
+                if (!self.ast.hasExtra(e, 3)) continue;
+                const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 2]);
+                if (body_idx.isNone()) continue;
+                const plist = self.ast.functionParamsList(node);
+                const p_start = plist.start;
+                const p_len = plist.len;
+                if (p_start + p_len <= self.ast.extra_data.items.len) {
+                    try walkScopedBody(self, body_idx, self.ast.extra_data.items[p_start .. p_start + p_len], locals, refs);
+                }
+                continue;
+            },
+
+            // 변수 선언: binding name → locals, init 만 stack 에 push (name 은 binding, type_ann 은 TS).
+            .variable_declarator => {
+                const e = node.data.extra;
+                if (!self.ast.hasExtra(e, 3)) continue;
+                try collectBindingNames(self, @enumFromInt(self.ast.extra_data.items[e]), locals);
+                try stack.append(self.allocator, @enumFromInt(self.ast.extra_data.items[e + 2]));
+                continue;
+            },
+
+            // catch: param → locals, body 만 stack 에 push.
+            .catch_clause => {
+                try collectBindingNames(self, node.data.binary.left, locals);
+                try stack.append(self.allocator, node.data.binary.right);
+                continue;
+            },
+
+            // object_property: shorthand `{x}` 는 key 가 참조, long-form `{key: value}` 는 value
+            // (computed key 면 key 도 함께) stack 에 push.
+            .object_property => {
+                if (node.data.binary.right.isNone()) {
+                    try stack.append(self.allocator, node.data.binary.left);
+                } else {
+                    const key_idx = node.data.binary.left;
+                    if (!key_idx.isNone()) {
+                        const key_node = self.ast.getNode(key_idx);
+                        if (key_node.tag == .computed_property_key) {
+                            try stack.append(self.allocator, key_idx);
+                        }
+                    }
+                    try stack.append(self.allocator, node.data.binary.right);
+                }
+                continue;
+            },
+
+            // TS/Flow type expression: 값(left)만 순회, 타입(right) 무시.
+            // parser 가 binary(left=expr, right=type) 로 저장하지만 layout 이 extra 라
+            // generic walker 가 자식을 못 찾아 명시 처리 필요.
+            .ts_as_expression,
+            .ts_satisfies_expression,
+            .ts_type_assertion,
+            .ts_instantiation_expression,
+            .flow_as_expression,
+            .flow_type_cast_expression,
+            => {
+                try stack.append(self.allocator, node.data.binary.left);
+                continue;
+            },
+
+            // static member: object 만 stack 에 push (property 는 외부 참조 아님).
+            .static_member_expression, .private_field_expression => {
+                const me = node.data.extra;
+                if (self.ast.hasExtra(me, 2)) {
+                    try stack.append(self.allocator, @enumFromInt(self.ast.extra_data.items[me]));
+                }
+                continue;
+            },
+
+            else => {},
+        }
+
+        // generic descent — 공통 ChildIterator
+        var it = ast_walk.children(self.ast, node);
+        while (it.next()) |child| {
+            if (child.isNone()) continue;
+            try stack.append(self.allocator, child);
+        }
     }
 }
 

--- a/src/transformer/worklet_test.zig
+++ b/src/transformer/worklet_test.zig
@@ -1027,3 +1027,77 @@ test "Worklet: __initData does NOT emit sourceMap when none generated" {
     defer std.testing.allocator.free(code);
     try std.testing.expect(std.mem.indexOf(u8, code, "sourceMap") == null);
 }
+
+// ============================================================
+// #2484 worklet walker depth 한계 회귀 가드
+// ============================================================
+
+test "#2484 regression: 100-deep nested expression — outer ref captured in closure" {
+    // walkBodyForClosureAnalysis 의 depth>64 silent return 으로 65+ 깊이 ref 누락.
+    // 명시 stack 으로 전환 후 100 depth 에서도 outerVar 가 closure 에 잡혀야 한다.
+    const a = std.testing.allocator;
+    var src: std.ArrayList(u8) = .empty;
+    defer src.deinit(a);
+    try src.appendSlice(a, "function w() {\n  \"worklet\";\n  return ");
+    var i: u32 = 0;
+    while (i < 100) : (i += 1) try src.appendSlice(a, "(");
+    try src.appendSlice(a, "outerVar");
+    while (i > 0) : (i -= 1) try src.appendSlice(a, ")");
+    try src.appendSlice(a, ";\n}\n");
+
+    var r = try transformWorklet(a, src.items);
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer a.free(code);
+
+    // closure 객체에 outerVar 가 포함되어야 한다 (worklet hoisted destructure 형태).
+    try std.testing.expect(std.mem.indexOf(u8, code, "{outerVar}=this.__closure") != null);
+}
+
+test "#2484 regression: 35-deep nested object pattern param — leaf binding registered as local" {
+    // collectAllIdentifiers 의 depth>32 silent return 으로 33+ 깊이의 param leaf 가
+    // fn_locals 에 등록 안 됨 → body 의 그 이름 reference 가 outer ref 로 오분류 →
+    // closure 에 잘못 포함. 명시 stack 으로 전환 후 35 깊이 leaf 도 정상 등록되어
+    // closure 가 비어 있음을 확인 (정확 매칭).
+    const a = std.testing.allocator;
+    var src: std.ArrayList(u8) = .empty;
+    defer src.deinit(a);
+    try src.appendSlice(a, "function w(");
+    var i: u32 = 0;
+    while (i < 35) : (i += 1) try src.appendSlice(a, "{a:");
+    try src.appendSlice(a, "x");
+    while (i > 0) : (i -= 1) try src.appendSlice(a, "}");
+    try src.appendSlice(a, ") {\n  \"worklet\";\n  return x;\n}\n");
+
+    var r = try transformWorklet(a, src.items);
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer a.free(code);
+
+    // x 가 deep nested param leaf 로 정상 잡히면 outer ref 가 없어 closure 가 비어야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, code, "__closure = {}") != null);
+}
+
+test "#2484 regression: deeply nested new expression — class factory captured" {
+    // collectNewExpressionCallees 의 depth>128 silent return 으로 129+ 깊이의
+    // new X() callee 가 new_classes 에 등록 안 됨 → factory 자동 import 누락.
+    // 명시 stack 으로 전환 후 150 depth 도 정상 등록.
+    const a = std.testing.allocator;
+    var src: std.ArrayList(u8) = .empty;
+    defer src.deinit(a);
+    try src.appendSlice(a, "function w() {\n  \"worklet\";\n  return ");
+    var i: u32 = 0;
+    while (i < 150) : (i += 1) try src.appendSlice(a, "(");
+    try src.appendSlice(a, "new DeepClass()");
+    while (i > 0) : (i -= 1) try src.appendSlice(a, ")");
+    try src.appendSlice(a, ";\n}\n");
+
+    var r = try transformWorklet(a, src.items);
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer a.free(code);
+
+    // worklet class factory: `new X()` 발견 시 closure 에 `X` 와 `X__classFactory` 함께 등록.
+    // 깊이 한도가 살아있으면 두 키 모두 누락되므로 정확 매칭으로 검증.
+    try std.testing.expect(std.mem.indexOf(u8, code, "{DeepClass,DeepClass__classFactory}=this.__closure") != null);
+}

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -499,7 +499,7 @@ const binding_lite_max_shadows: usize = 64;
 // 함수 파라미터 / catch / block lexical shadow 는 binding-lite walker 가 scope-aware 로
 // 처리한다. top-level shadow, `var` shadow, walker buffer overflow 처럼 declaration-order
 // 또는 scope 의미가 애매한 케이스만 full 로 보낸다.
-fn hasUnsupportedNamedImportLocalBindingShadow(ast: *const Ast) bool {
+fn hasUnsupportedNamedImportLocalBindingShadow(ast: *const Ast) error{OutOfMemory}!bool {
     var names_buf: [binding_lite_max_shadows][]const u8 = undefined;
     var names_len: usize = 0;
 
@@ -535,12 +535,10 @@ fn hasUnsupportedNamedImportLocalBindingShadow(ast: *const Ast) bool {
 // match_count 는 호출자가 누적한다. binding pattern 하나(=formal_parameters/catch param)
 // 안에서는 fresh counter 로도 의미가 같지만, `var a, b, c` 처럼 한 var 리스트의
 // 누적 shadow 수를 봐야 하는 경우엔 호출자가 같은 counter 를 재사용한다.
-fn bindingPatternImportShadowOverflow(ast: *const Ast, idx: ast_mod.NodeIndex, names: []const []const u8, match_count: *usize) bool {
-    // walker 의 alloc 실패는 의미상 "scan 불완전" 이라 conservative-keep (overflow 로 간주) 로 fallback.
-    // 정상 path 는 ast.allocator 가 transpile arena 라 사실상 bump-allocator → 실패 거의 없음.
-    var it = ast_walk.bindingIdentifiers(ast.allocator, ast, idx, .{ .cover_grammar_assignment = true }) catch return true;
+fn bindingPatternImportShadowOverflow(ast: *const Ast, idx: ast_mod.NodeIndex, names: []const []const u8, match_count: *usize) error{OutOfMemory}!bool {
+    var it = try ast_walk.bindingIdentifiers(ast.allocator, ast, idx, .{ .cover_grammar_assignment = true });
     defer it.deinit();
-    while (it.next() catch return true) |leaf_idx| {
+    while (try it.next()) |leaf_idx| {
         const leaf = ast.getNode(leaf_idx);
         const name = ast.getText(leaf.span);
         if (string_list.contains(names, name)) {
@@ -574,8 +572,8 @@ fn walkFunctionVarBindingPatterns(
     ast: *const Ast,
     idx: ast_mod.NodeIndex,
     ctx: anytype,
-    comptime onBindingPattern: fn (@TypeOf(ctx), ast_mod.NodeIndex) bool,
-) bool {
+    comptime onBindingPattern: fn (@TypeOf(ctx), ast_mod.NodeIndex) error{OutOfMemory}!bool,
+) error{OutOfMemory}!bool {
     if (idx.isNone()) return false;
     const node = ast.getNode(idx);
     switch (node.tag) {
@@ -593,7 +591,7 @@ fn walkFunctionVarBindingPatterns(
                 if (decl_idx.isNone()) continue;
                 const decl = ast.getNode(decl_idx);
                 if (decl.tag != .variable_declarator) continue;
-                if (onBindingPattern(ctx, @enumFromInt(ast.extra_data.items[decl.data.extra]))) return true;
+                if (try onBindingPattern(ctx, @enumFromInt(ast.extra_data.items[decl.data.extra]))) return true;
             }
         },
         else => {},
@@ -601,7 +599,7 @@ fn walkFunctionVarBindingPatterns(
 
     var it = ast_walk.children(ast, node);
     while (it.next()) |child_idx| {
-        if (walkFunctionVarBindingPatterns(ast, child_idx, ctx, onBindingPattern)) return true;
+        if (try walkFunctionVarBindingPatterns(ast, child_idx, ctx, onBindingPattern)) return true;
     }
     return false;
 }
@@ -613,7 +611,7 @@ fn scanVariableDeclarationForUnsupportedBindingLiteShadow(
     scope_depth: usize,
     inside_function: bool,
     fn_shadow_count: ?*usize,
-) bool {
+) error{OutOfMemory}!bool {
     const list_start = ast.extra_data.items[node.data.extra + 1];
     const list_len = ast.extra_data.items[node.data.extra + 2];
     // 함수 scope 안이면 호출자가 누적 카운터를 넘기고, 모듈 scope 면 statement 로컬 카운터로 폴백.
@@ -629,9 +627,9 @@ fn scanVariableDeclarationForUnsupportedBindingLiteShadow(
         const decl = ast.getNode(decl_idx);
         if (decl.tag != .variable_declarator) continue;
         const binding_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[decl.data.extra]);
-        if (bindingPatternImportShadowOverflow(ast, binding_idx, names, counter)) return true;
+        if (try bindingPatternImportShadowOverflow(ast, binding_idx, names, counter)) return true;
         const init_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[decl.data.extra + 2]);
-        if (scanForUnsupportedBindingLiteShadow(ast, init_idx, names, scope_depth, inside_function, fn_shadow_count)) return true;
+        if (try scanForUnsupportedBindingLiteShadow(ast, init_idx, names, scope_depth, inside_function, fn_shadow_count)) return true;
     }
 
     if (counter.* == before) return false;
@@ -646,10 +644,10 @@ fn scanChildrenForUnsupportedBindingLiteShadow(
     child_scope_depth: usize,
     inside_function: bool,
     fn_shadow_count: ?*usize,
-) bool {
+) error{OutOfMemory}!bool {
     var it = ast_walk.children(ast, node);
     while (it.next()) |child_idx| {
-        if (scanForUnsupportedBindingLiteShadow(ast, child_idx, names, child_scope_depth, inside_function, fn_shadow_count)) return true;
+        if (try scanForUnsupportedBindingLiteShadow(ast, child_idx, names, child_scope_depth, inside_function, fn_shadow_count)) return true;
     }
     return false;
 }
@@ -663,8 +661,8 @@ fn scanFunctionScopeParamsAndBody(
     scope_depth: usize,
     inside_function: bool,
     fn_shadow_count: *usize,
-) bool {
-    if (scanForUnsupportedBindingLiteShadow(ast, params_idx, names, scope_depth, inside_function, fn_shadow_count)) return true;
+) error{OutOfMemory}!bool {
+    if (try scanForUnsupportedBindingLiteShadow(ast, params_idx, names, scope_depth, inside_function, fn_shadow_count)) return true;
     return scanForUnsupportedBindingLiteShadow(ast, body_idx, names, scope_depth + 1, true, fn_shadow_count);
 }
 
@@ -674,7 +672,7 @@ fn scanFunctionForUnsupportedBindingLiteShadow(
     names: []const []const u8,
     scope_depth: usize,
     inside_function: bool,
-) bool {
+) error{OutOfMemory}!bool {
     const e = node.data.extra;
     // function_expression / function 의 extras[0] 은 inner-only self-name 이라 outer scope binding
     // 으로 스캔하면 안 되고 함수-스코프 카운터에만 누적한다. function_declaration 은 extras[0] 이
@@ -684,7 +682,7 @@ fn scanFunctionForUnsupportedBindingLiteShadow(
     // BindingLite collector (markBindingLiteFunctionScope) 가 모으는 set 과 동일 — overflow 시 fallback.
     var fn_shadow_count: usize = 0;
     if (is_function_expression and functionExpressionNameImportShadowOverflow(ast, node, names, &fn_shadow_count)) return true;
-    if (!is_function_expression and scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e]), names, scope_depth, inside_function, null)) return true;
+    if (!is_function_expression and try scanForUnsupportedBindingLiteShadow(ast, @enumFromInt(ast.extra_data.items[e]), names, scope_depth, inside_function, null)) return true;
     return scanFunctionScopeParamsAndBody(
         ast,
         @enumFromInt(ast.extra_data.items[e + 1]),
@@ -703,7 +701,7 @@ fn scanForUnsupportedBindingLiteShadow(
     scope_depth: usize,
     inside_function: bool,
     fn_shadow_count: ?*usize,
-) bool {
+) error{OutOfMemory}!bool {
     if (idx.isNone()) return false;
     const node = ast.getNode(idx);
     switch (node.tag) {
@@ -724,7 +722,7 @@ fn scanForUnsupportedBindingLiteShadow(
             // catch 매개변수는 catch block scope 에만 binding 되어 BindingLite 의 함수-scope shadow set
             // 에 합산되지 않는다. 단일 catch 안 overflow 만 별도 fresh counter 로 검사한다.
             var local_count: usize = 0;
-            if (bindingPatternImportShadowOverflow(ast, node.data.binary.left, names, &local_count)) return true;
+            if (try bindingPatternImportShadowOverflow(ast, node.data.binary.left, names, &local_count)) return true;
             return scanForUnsupportedBindingLiteShadow(ast, node.data.binary.right, names, scope_depth + 1, inside_function, fn_shadow_count);
         },
         .function_declaration,
@@ -768,7 +766,7 @@ fn buildTransformPlan(
     parser: *const Parser,
     ast: *const Ast,
     fast_path_disabled: bool,
-) TransformPlan {
+) error{OutOfMemory}!TransformPlan {
     if (fast_path_disabled) return .{ .semantic = .full, .reason = .disabled_by_env };
     if (options.stop_after == .semantic) return .{ .semantic = .full, .reason = .stop_after_semantic };
 
@@ -805,7 +803,7 @@ fn buildTransformPlan(
         return .{ .semantic = .full, .reason = .ast_requires_runtime_transform };
     }
     if (facts.has_import_declaration) {
-        if (hasUnsupportedNamedImportLocalBindingShadow(ast)) {
+        if (try hasUnsupportedNamedImportLocalBindingShadow(ast)) {
             return .{ .semantic = .full, .reason = .binding_shadow_requires_full_semantic };
         }
         return .{
@@ -849,7 +847,7 @@ fn collectBindingLite(allocator: std.mem.Allocator, ast: *const Ast) !BindingLit
     const no_shadowed_names: []const []const u8 = &.{};
     for (ast.nodes.items, 0..) |node, raw_idx| {
         if (node.tag != .program) continue;
-        markBindingLiteValueUses(ast, @enumFromInt(raw_idx), &lite, true, no_shadowed_names);
+        try markBindingLiteValueUses(ast, @enumFromInt(raw_idx), &lite, true, no_shadowed_names);
         break;
     }
     return lite;
@@ -874,12 +872,11 @@ fn appendBindingLiteShadowName(buf: [][]const u8, len: *usize, name: []const u8)
     len.* += 1;
 }
 
-fn collectBindingLitePatternShadows(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *const BindingLite, buf: [][]const u8, len: *usize) void {
+fn collectBindingLitePatternShadows(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *const BindingLite, buf: [][]const u8, len: *usize) error{OutOfMemory}!void {
     if (len.* >= buf.len) return;
-    // walker alloc 실패 시 그냥 중단 — 호출자는 buf 가 빈 상태면 기존대로 conservative path 가 잡는다.
-    var it = ast_walk.bindingIdentifiers(ast.allocator, ast, idx, .{ .cover_grammar_assignment = true }) catch return;
+    var it = try ast_walk.bindingIdentifiers(ast.allocator, ast, idx, .{ .cover_grammar_assignment = true });
     defer it.deinit();
-    while (it.next() catch return) |leaf_idx| {
+    while (try it.next()) |leaf_idx| {
         const leaf = ast.getNode(leaf_idx);
         // import 이름과 매칭되는 binding 만 shadow set 에 추가. cover-grammar 결과인
         // identifier_reference / assignment_target_identifier 도 동일 처리.
@@ -888,7 +885,7 @@ fn collectBindingLitePatternShadows(ast: *const Ast, idx: ast_mod.NodeIndex, lit
     }
 }
 
-fn collectBindingLiteVariableDeclarationShadows(ast: *const Ast, node: ast_mod.Node, lite: *const BindingLite, buf: [][]const u8, len: *usize) void {
+fn collectBindingLiteVariableDeclarationShadows(ast: *const Ast, node: ast_mod.Node, lite: *const BindingLite, buf: [][]const u8, len: *usize) error{OutOfMemory}!void {
     const list_start = ast.extra_data.items[node.data.extra + 1];
     const list_len = ast.extra_data.items[node.data.extra + 2];
     var i: u32 = 0;
@@ -897,11 +894,11 @@ fn collectBindingLiteVariableDeclarationShadows(ast: *const Ast, node: ast_mod.N
         if (decl_idx.isNone()) continue;
         const decl = ast.getNode(decl_idx);
         if (decl.tag != .variable_declarator) continue;
-        collectBindingLitePatternShadows(ast, @enumFromInt(ast.extra_data.items[decl.data.extra]), lite, buf, len);
+        try collectBindingLitePatternShadows(ast, @enumFromInt(ast.extra_data.items[decl.data.extra]), lite, buf, len);
     }
 }
 
-fn collectBindingLiteFunctionVarShadows(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *const BindingLite, buf: [][]const u8, len: *usize) void {
+fn collectBindingLiteFunctionVarShadows(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *const BindingLite, buf: [][]const u8, len: *usize) error{OutOfMemory}!void {
     const Ctx = struct {
         ast: *const Ast,
         lite: *const BindingLite,
@@ -909,13 +906,13 @@ fn collectBindingLiteFunctionVarShadows(ast: *const Ast, idx: ast_mod.NodeIndex,
         len: *usize,
     };
     const visit = struct {
-        fn onBindingPattern(c: Ctx, binding_idx: ast_mod.NodeIndex) bool {
-            collectBindingLitePatternShadows(c.ast, binding_idx, c.lite, c.buf, c.len);
+        fn onBindingPattern(c: Ctx, binding_idx: ast_mod.NodeIndex) error{OutOfMemory}!bool {
+            try collectBindingLitePatternShadows(c.ast, binding_idx, c.lite, c.buf, c.len);
             // buf 가 가득 차면 더 append 해도 silent drop 이라 더 순회할 이유가 없다.
             return c.len.* >= c.buf.len;
         }
     }.onBindingPattern;
-    _ = walkFunctionVarBindingPatterns(
+    _ = try walkFunctionVarBindingPatterns(
         ast,
         idx,
         Ctx{ .ast = ast, .lite = lite, .buf = buf, .len = len },
@@ -928,7 +925,7 @@ fn collectBindingLiteFunctionExpressionNameShadow(ast: *const Ast, node: ast_mod
     if (lite.namedImportValueUse(name) != null) appendBindingLiteShadowName(buf, len, name);
 }
 
-fn collectBindingLiteListLexicalShadows(ast: *const Ast, list: ast_mod.NodeList, lite: *const BindingLite, buf: [][]const u8, len: *usize) void {
+fn collectBindingLiteListLexicalShadows(ast: *const Ast, list: ast_mod.NodeList, lite: *const BindingLite, buf: [][]const u8, len: *usize) error{OutOfMemory}!void {
     if (list.start + list.len > ast.extra_data.items.len) return;
     var i: u32 = 0;
     while (i < list.len) : (i += 1) {
@@ -936,7 +933,7 @@ fn collectBindingLiteListLexicalShadows(ast: *const Ast, list: ast_mod.NodeList,
         if (child_idx.isNone()) continue;
         const child = ast.getNode(child_idx);
         if (child.tag == .variable_declaration and ast.variableDeclarationKind(child).isLexical()) {
-            collectBindingLiteVariableDeclarationShadows(ast, child, lite, buf, len);
+            try collectBindingLiteVariableDeclarationShadows(ast, child, lite, buf, len);
         }
     }
 }
@@ -946,15 +943,15 @@ fn markBindingLiteBlockScope(
     node: ast_mod.Node,
     lite: *BindingLite,
     parent_shadowed: []const []const u8,
-) void {
+) error{OutOfMemory}!void {
     var shadow_buf: [binding_lite_max_shadows][]const u8 = undefined;
     var shadow_len: usize = 0;
     for (parent_shadowed) |name| appendBindingLiteShadowName(&shadow_buf, &shadow_len, name);
-    collectBindingLiteListLexicalShadows(ast, node.data.list, lite, &shadow_buf, &shadow_len);
-    markBindingLiteListValueUses(ast, node.data.list, lite, true, shadow_buf[0..shadow_len]);
+    try collectBindingLiteListLexicalShadows(ast, node.data.list, lite, &shadow_buf, &shadow_len);
+    try markBindingLiteListValueUses(ast, node.data.list, lite, true, shadow_buf[0..shadow_len]);
 }
 
-fn markBindingPatternDefaultValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *BindingLite, shadowed_names: []const []const u8) void {
+fn markBindingPatternDefaultValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *BindingLite, shadowed_names: []const []const u8) error{OutOfMemory}!void {
     if (idx.isNone()) return;
     const node = ast.getNode(idx);
     switch (node.tag) {
@@ -962,29 +959,29 @@ fn markBindingPatternDefaultValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, l
         .assignment_expression,
         .assignment_target_with_default,
         => {
-            markBindingPatternDefaultValueUses(ast, node.data.binary.left, lite, shadowed_names);
-            markBindingLiteValueUses(ast, node.data.binary.right, lite, true, shadowed_names);
+            try markBindingPatternDefaultValueUses(ast, node.data.binary.left, lite, shadowed_names);
+            try markBindingLiteValueUses(ast, node.data.binary.right, lite, true, shadowed_names);
         },
         .array_pattern,
         .object_pattern,
-        => markBindingLiteListValueUses(ast, node.data.list, lite, false, shadowed_names),
+        => try markBindingLiteListValueUses(ast, node.data.list, lite, false, shadowed_names),
         .binding_rest_element,
         .rest_element,
         .assignment_target_rest,
-        => markBindingPatternDefaultValueUses(ast, node.data.unary.operand, lite, shadowed_names),
+        => try markBindingPatternDefaultValueUses(ast, node.data.unary.operand, lite, shadowed_names),
         .binding_property,
         .assignment_target_property_identifier,
         .assignment_target_property_property,
-        => markBindingPatternDefaultValueUses(ast, node.data.binary.right, lite, shadowed_names),
+        => try markBindingPatternDefaultValueUses(ast, node.data.binary.right, lite, shadowed_names),
         else => {},
     }
 }
 
-fn markBindingLiteListValueUses(ast: *const Ast, list: ast_mod.NodeList, lite: *BindingLite, value_context: bool, shadowed_names: []const []const u8) void {
+fn markBindingLiteListValueUses(ast: *const Ast, list: ast_mod.NodeList, lite: *BindingLite, value_context: bool, shadowed_names: []const []const u8) error{OutOfMemory}!void {
     if (list.start + list.len > ast.extra_data.items.len) return;
     var i: u32 = 0;
     while (i < list.len) : (i += 1) {
-        markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[list.start + i]), lite, value_context, shadowed_names);
+        try markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[list.start + i]), lite, value_context, shadowed_names);
     }
 }
 
@@ -995,19 +992,19 @@ fn markBindingLiteFunctionScope(
     node: ast_mod.Node,
     params_idx: ast_mod.NodeIndex,
     body_idx: ast_mod.NodeIndex,
-) void {
+) error{OutOfMemory}!void {
     var shadow_buf: [binding_lite_max_shadows][]const u8 = undefined;
     var shadow_len: usize = 0;
     for (parent_shadowed) |name| appendBindingLiteShadowName(&shadow_buf, &shadow_len, name);
     collectBindingLiteFunctionExpressionNameShadow(ast, node, lite, &shadow_buf, &shadow_len);
-    collectBindingLitePatternShadows(ast, params_idx, lite, &shadow_buf, &shadow_len);
-    collectBindingLiteFunctionVarShadows(ast, body_idx, lite, &shadow_buf, &shadow_len);
+    try collectBindingLitePatternShadows(ast, params_idx, lite, &shadow_buf, &shadow_len);
+    try collectBindingLiteFunctionVarShadows(ast, body_idx, lite, &shadow_buf, &shadow_len);
     const combined = shadow_buf[0..shadow_len];
-    markBindingLiteValueUses(ast, params_idx, lite, false, combined);
-    markBindingLiteValueUses(ast, body_idx, lite, true, combined);
+    try markBindingLiteValueUses(ast, params_idx, lite, false, combined);
+    try markBindingLiteValueUses(ast, body_idx, lite, true, combined);
 }
 
-fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *BindingLite, value_context: bool, shadowed_names: []const []const u8) void {
+fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *BindingLite, value_context: bool, shadowed_names: []const []const u8) error{OutOfMemory}!void {
     if (idx.isNone()) return;
     const node = ast.getNode(idx);
 
@@ -1030,42 +1027,42 @@ fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *Bind
         .block_statement,
         .function_body,
         => {
-            markBindingLiteBlockScope(ast, node, lite, shadowed_names);
+            try markBindingLiteBlockScope(ast, node, lite, shadowed_names);
             return;
         },
         .catch_clause => {
             var shadow_buf: [binding_lite_max_shadows][]const u8 = undefined;
             var shadow_len: usize = 0;
             for (shadowed_names) |name| appendBindingLiteShadowName(&shadow_buf, &shadow_len, name);
-            collectBindingLitePatternShadows(ast, node.data.binary.left, lite, &shadow_buf, &shadow_len);
-            markBindingLiteValueUses(ast, node.data.binary.right, lite, true, shadow_buf[0..shadow_len]);
+            try collectBindingLitePatternShadows(ast, node.data.binary.left, lite, &shadow_buf, &shadow_len);
+            try markBindingLiteValueUses(ast, node.data.binary.right, lite, true, shadow_buf[0..shadow_len]);
             return;
         },
         .try_statement => {
-            markBindingLiteValueUses(ast, node.data.ternary.a, lite, true, shadowed_names);
-            markBindingLiteValueUses(ast, node.data.ternary.b, lite, true, shadowed_names);
-            markBindingLiteValueUses(ast, node.data.ternary.c, lite, true, shadowed_names);
+            try markBindingLiteValueUses(ast, node.data.ternary.a, lite, true, shadowed_names);
+            try markBindingLiteValueUses(ast, node.data.ternary.b, lite, true, shadowed_names);
+            try markBindingLiteValueUses(ast, node.data.ternary.c, lite, true, shadowed_names);
             return;
         },
         .export_specifier => {
-            markBindingLiteValueUses(ast, node.data.binary.left, lite, true, shadowed_names);
+            try markBindingLiteValueUses(ast, node.data.binary.left, lite, true, shadowed_names);
             return;
         },
         .export_named_declaration => {
             const x = module_parser.readExportNamedExtras(ast, node.data.extra);
-            markBindingLiteValueUses(ast, x.decl, lite, true, shadowed_names);
-            markBindingLiteListValueUses(ast, .{ .start = x.specs_start, .len = x.specs_len }, lite, true, shadowed_names);
+            try markBindingLiteValueUses(ast, x.decl, lite, true, shadowed_names);
+            try markBindingLiteListValueUses(ast, .{ .start = x.specs_start, .len = x.specs_len }, lite, true, shadowed_names);
             return;
         },
         .variable_declaration => {
             const list_start = ast.extra_data.items[node.data.extra + 1];
             const list_len = ast.extra_data.items[node.data.extra + 2];
-            markBindingLiteListValueUses(ast, .{ .start = list_start, .len = list_len }, lite, true, shadowed_names);
+            try markBindingLiteListValueUses(ast, .{ .start = list_start, .len = list_len }, lite, true, shadowed_names);
             return;
         },
         .variable_declarator => {
-            markBindingPatternDefaultValueUses(ast, @enumFromInt(ast.extra_data.items[node.data.extra]), lite, shadowed_names);
-            markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[node.data.extra + 2]), lite, true, shadowed_names);
+            try markBindingPatternDefaultValueUses(ast, @enumFromInt(ast.extra_data.items[node.data.extra]), lite, shadowed_names);
+            try markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[node.data.extra + 2]), lite, true, shadowed_names);
             return;
         },
         .function_declaration,
@@ -1073,7 +1070,7 @@ fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *Bind
         .function,
         => {
             const e = node.data.extra;
-            markBindingLiteFunctionScope(
+            try markBindingLiteFunctionScope(
                 ast,
                 lite,
                 shadowed_names,
@@ -1085,7 +1082,7 @@ fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *Bind
         },
         .arrow_function_expression => {
             const e = node.data.extra;
-            markBindingLiteFunctionScope(
+            try markBindingLiteFunctionScope(
                 ast,
                 lite,
                 shadowed_names,
@@ -1096,14 +1093,14 @@ fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *Bind
             return;
         },
         .formal_parameters => {
-            markBindingLiteListValueUses(ast, node.data.list, lite, false, shadowed_names);
+            try markBindingLiteListValueUses(ast, node.data.list, lite, false, shadowed_names);
             return;
         },
         .assignment_pattern,
         .assignment_target_with_default,
         => {
-            markBindingLiteValueUses(ast, node.data.binary.left, lite, false, shadowed_names);
-            markBindingLiteValueUses(ast, node.data.binary.right, lite, true, shadowed_names);
+            try markBindingLiteValueUses(ast, node.data.binary.left, lite, false, shadowed_names);
+            try markBindingLiteValueUses(ast, node.data.binary.right, lite, true, shadowed_names);
             return;
         },
         // `(Foo = Bar()) =>` 같이 cover-grammar 로 패턴 자리에 남은 assignment_expression 은
@@ -1112,33 +1109,33 @@ fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *Bind
         // child walk 로 그대로 value_context=true 가 전파돼야 import 가 use 마킹된다.
         .assignment_expression => {
             if (!value_context) {
-                markBindingLiteValueUses(ast, node.data.binary.left, lite, false, shadowed_names);
-                markBindingLiteValueUses(ast, node.data.binary.right, lite, true, shadowed_names);
+                try markBindingLiteValueUses(ast, node.data.binary.left, lite, false, shadowed_names);
+                try markBindingLiteValueUses(ast, node.data.binary.right, lite, true, shadowed_names);
                 return;
             }
         },
         .formal_parameter => {
             const e = node.data.extra;
-            markBindingPatternDefaultValueUses(ast, @enumFromInt(ast.extra_data.items[e]), lite, shadowed_names);
-            markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[e + 2]), lite, true, shadowed_names);
+            try markBindingPatternDefaultValueUses(ast, @enumFromInt(ast.extra_data.items[e]), lite, shadowed_names);
+            try markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[e + 2]), lite, true, shadowed_names);
             return;
         },
         .object_property => {
             const key = node.data.binary.left;
             const value = node.data.binary.right;
             if (value.isNone()) {
-                markBindingLiteValueUses(ast, key, lite, true, shadowed_names);
+                try markBindingLiteValueUses(ast, key, lite, true, shadowed_names);
             } else {
                 const key_node = ast.getNode(key);
-                if (key_node.tag == .computed_property_key) markBindingLiteValueUses(ast, key, lite, true, shadowed_names);
-                markBindingLiteValueUses(ast, value, lite, true, shadowed_names);
+                if (key_node.tag == .computed_property_key) try markBindingLiteValueUses(ast, key, lite, true, shadowed_names);
+                try markBindingLiteValueUses(ast, value, lite, true, shadowed_names);
             }
             return;
         },
         .static_member_expression,
         .private_field_expression,
         => {
-            markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[node.data.extra]), lite, true, shadowed_names);
+            try markBindingLiteValueUses(ast, @enumFromInt(ast.extra_data.items[node.data.extra]), lite, true, shadowed_names);
             return;
         },
         else => {},
@@ -1146,7 +1143,7 @@ fn markBindingLiteValueUses(ast: *const Ast, idx: ast_mod.NodeIndex, lite: *Bind
 
     var it = ast_walk.children(ast, node);
     while (it.next()) |child_idx| {
-        markBindingLiteValueUses(ast, child_idx, lite, value_context, shadowed_names);
+        try markBindingLiteValueUses(ast, child_idx, lite, value_context, shadowed_names);
     }
 }
 
@@ -1235,7 +1232,7 @@ fn transpileWithCallbackInternal(
         return .{ .code = try allocator.dupe(u8, "") };
     }
 
-    const transform_plan = buildTransformPlan(options, &parser, &parser.ast, fast_path_disabled);
+    const transform_plan = try buildTransformPlan(options, &parser, &parser.ast, fast_path_disabled);
     // 포맷 문자열을 변경하면 `tests/benchmark/profile.ts` 의 `tracePlan` 정규식도
     // 함께 갱신해야 한다 — `semantic=...`, `reason=...` 키 이름을 그대로 유지.
     debug_log.print(


### PR DESCRIPTION
## 배경

#2475 audit 의 \"낮은 위험\" 으로 분류됐던 worklet walker 깊이 한계 + 같이 발견된 transpile.zig 의 silent fallback 모두 root cause 해결.

### #2484 worklet walker depth 한계

worklet.zig 의 세 walker 가 재귀 깊이 한계 도달 시 silent return — 깊은 worklet body 에서 leaf identifier / new callee / closure ref 누락:

| 함수 | 한계 (구) | 영향 |
| --- | --- | --- |
| \`collectAllIdentifiers\` | \`depth>32\` | param leaf 누락 → outer ref 오분류 |
| \`collectNewExpressionCallees\` | \`depth>128\` | \`new X()\` callee 누락 → factory 자동 import 누락 |
| \`walkBodyForClosureAnalysis\` | \`depth>64\` | 식별자 참조 누락 → closure 누락 → worklet 실행 시 ReferenceError |

### transpile.zig binding-lite walker OOM fallback

#2473 PR 작업 시 transpile.zig 의 두 caller (`bindingPatternImportShadowOverflow`, `collectBindingLitePatternShadows`) 가 caller chain 깊어 walker OOM 시 `catch return true` / `catch return` 으로 conservative fallback 처리. 의미적으로 옳지만 **silent diagnostic loss** 라 audit 정신과 모순.

## 해결 방향 — 모두 #2473 패턴 (single source of truth) 또는 정공 OOM 전파

### worklet 세 함수
\`std.ArrayList(NodeIndex) = .empty\` + \`defer deinit\` + \`while (stack.pop())\` 으로 변환:
- \`collectAllIdentifiers\` / \`collectNewExpressionCallees\`: 명시 stack pre-order. depth 인자 제거.
- \`walkBodyForClosureAnalysis\`: 외부 generic descent 만 stack 화, nested function/arrow/method scope 진입은 그대로 자체 재귀 (sub-frame). 사용자 코드의 nested function 깊이는 1-5 단계라 stack overflow 위험 없음. depth 인자 제거.
- \`walkScopedBody\` / \`walkBodyForClosureAnalysisWithNew\`: 의존 호출자라 depth 인자 같이 제거.

### transpile.zig fallback 제거
\`catch return true\` / \`catch return\` 모두 제거. 16 caller fn 시그니처에 \`error{OutOfMemory}!\` 추가:
- shadow scan chain: \`scanForUnsupportedBindingLiteShadow\`, \`scanFunctionScopeParamsAndBody\`, \`scanFunctionForUnsupportedBindingLiteShadow\`, \`scanChildrenForUnsupportedBindingLiteShadow\`, \`scanVariableDeclarationForUnsupportedBindingLiteShadow\`, \`hasUnsupportedNamedImportLocalBindingShadow\`, \`buildTransformPlan\`.
- shadow collect chain: \`collectBindingLiteVariableDeclarationShadows\`, \`collectBindingLiteFunctionVarShadows\`, \`collectBindingLiteListLexicalShadows\`, \`walkFunctionVarBindingPatterns\`.
- mark chain: \`markBindingLiteBlockScope\`, \`markBindingPatternDefaultValueUses\`, \`markBindingLiteListValueUses\`, \`markBindingLiteFunctionScope\`, \`markBindingLiteValueUses\`.

전체 chain 이 \`transpileWithCallbackInternal\` 의 \`TranspileError!TranspileResult\` 까지 자연 전파. **OOM 시 binding-lite 비활성 silent fallback 대신 사용자에게 즉시 \`error.OutOfMemory\` 노출**.

### \"어떨 때 터지는가\"
- arena allocator 가 OS 페이지 alloc 시 OOM (시스템 메모리 고갈, 32-bit address space 한계, ulimit/cgroup 한도, 컨테이너 메모리 제한).
- 일반 dev/CI 환경 99.999% 케이스 정상 path — fallback 시절과 동작 차이 0.
- 차이는 OOM 시점뿐: 전엔 silent 로 fast-path 비활성, 이젠 명확한 에러로 노출.

## 회귀 가드 — 모두 정확 매칭

\`\`\`zig
// 35-deep nested {a:{a:...{a:x}}} 파라미터 → x 가 fn_locals 에 등록되어 closure 비움.
try std.testing.expect(std.mem.indexOf(u8, code, \"__closure = {}\") != null);

// 100-deep ((((outerVar)))) → walkBody 가 outer ref 잡아 closure 에 정확 등록.
try std.testing.expect(std.mem.indexOf(u8, code, \"{outerVar}=this.__closure\") != null);

// 150-deep ((((new DeepClass())))) → class factory 가 두 키 동시 등록.
try std.testing.expect(std.mem.indexOf(u8, code, \"{DeepClass,DeepClass__classFactory}=this.__closure\") != null);
\`\`\`

worklet plugin 의 Phase 5 \"class factory\" 가 \`new X()\` 발견 시 자동으로 \`X__classFactory\` 도 closure 에 register 하므로 단순 reference 와 closure entry 수가 다름 — 정확 매칭으로 두 path 모두 검증.

## /simplify 6 agent (worklet + transpile fallback 각 3) 검토

- **Reuse**: ✅ #2473 패턴 일관. 두 단순 walker (\`collectAllIdentifiers\` / \`collectNewExpressionCallees\`) duplicate 는 본 PR 범위 밖 follow-up.
- **Quality**: ✅ 메모리 안전 (모든 \`defer stack.deinit\`), \`continue\` vs \`return\` 정확, scope-aware vs generic descent 분기 명확. fallback 제거 후 stale 주석 없음 (\`binding_lite_max_shadows\` overflow conservative 동작은 별개로 살아있음).
- **Efficiency**: ✅ Transformer / transpile arena bump-alloc — 알로케이션 cost 무시 가능. \`try\` 추가 비용은 nanoseconds (CPU 분기 예측기 처리).

## 검증

- \`zig build test\` (Debug) — 통과.
- \`zig build test -Doptimize=ReleaseFast\` — 통과 (main baseline \`resolve_cache_test\` flaky 1건은 본 PR 무관).
- \`zig fmt src/\` 통과.

Closes #2484

🤖 Generated with [Claude Code](https://claude.com/claude-code)