### PR TITLE
perf(bundler): Worker 보완 스캔 prefilter 추가

### DIFF
--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -906,6 +906,8 @@ fn isImportMetaUrl(ast: *const Ast, idx: NodeIndex) bool {
 /// inline scan 모드에서 Worker 감지를 보완하기 위해 사용.
 /// new Worker(new URL('./worker.ts', import.meta.url)) 패턴만 감지.
 pub fn extractWorkerRecords(allocator: std.mem.Allocator, ast: *const Ast) ![]ImportRecord {
+    if (!sourceMayContainWorkerUrlPattern(ast.source)) return &.{};
+
     var records = std.ArrayListUnmanaged(ImportRecord).empty;
     const reachable = try ast_walk.collectReachableNodeIndices(allocator, ast);
     defer allocator.free(reachable);
@@ -919,6 +921,14 @@ pub fn extractWorkerRecords(allocator: std.mem.Allocator, ast: *const Ast) ![]Im
         }
     }
     return records.toOwnedSlice(allocator);
+}
+
+fn sourceMayContainWorkerUrlPattern(source: []const u8) bool {
+    // Worker 보완 스캔은 전체 AST walk라서 대부분의 모듈에서 비용만 발생한다.
+    // 실제 지원 패턴은 Worker/SharedWorker + URL + import.meta 세 토큰이 모두 필요하다.
+    return std.mem.indexOf(u8, source, "Worker") != null and
+        std.mem.indexOf(u8, source, "URL") != null and
+        std.mem.indexOf(u8, source, "import.meta") != null;
 }
 
 /// 따옴표(`'`, `"`)를 벗긴다. 최소 2글자 이상이어야 함.

--- a/src/bundler/import_scanner_test.zig
+++ b/src/bundler/import_scanner_test.zig
@@ -3,6 +3,7 @@ const import_scanner = @import("import_scanner.zig");
 const extractImports = import_scanner.extractImports;
 const extractImportsWithCjsDetection = import_scanner.extractImportsWithCjsDetection;
 const extractImportsWithCjsDetectionAndDefines = import_scanner.extractImportsWithCjsDetectionAndDefines;
+const extractWorkerRecords = import_scanner.extractWorkerRecords;
 const ScanResult = import_scanner.ScanResult;
 const stripQuotes = import_scanner.stripQuotes;
 const types = @import("types.zig");
@@ -71,6 +72,20 @@ fn parseAndExtractFullWithDefines(
     _ = try parser.parse();
 
     return extractImportsWithCjsDetectionAndDefines(allocator, &parser.ast, defines);
+}
+
+fn parseAndExtractWorkers(allocator: std.mem.Allocator, source: []const u8) ![]ImportRecord {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    var scanner = try Scanner.init(arena_alloc, source);
+    var parser = Parser.init(arena_alloc, &scanner);
+    parser.is_module = true;
+    scanner.is_module = true;
+    _ = try parser.parse();
+
+    return extractWorkerRecords(allocator, &parser.ast);
 }
 
 test "explicit `import type { X } from ...` → no record (parser already elides)" {
@@ -290,6 +305,30 @@ test "stripQuotes" {
     try std.testing.expectEqualStrings("bar", stripQuotes("\"bar\"").?);
     try std.testing.expect(stripQuotes("x") == null);
     try std.testing.expect(stripQuotes("") == null);
+}
+
+test "worker records: supported Worker URL pattern is extracted" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtractWorkers(
+        alloc,
+        "const worker = new Worker(new URL('./worker.ts', import.meta.url));",
+    );
+    defer alloc.free(records);
+
+    try std.testing.expectEqual(@as(usize, 1), records.len);
+    try std.testing.expectEqual(ImportKind.worker, records[0].kind);
+    try std.testing.expectEqualStrings("./worker.ts", records[0].specifier);
+}
+
+test "worker records: modules without worker URL markers skip extraction" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtractWorkers(
+        alloc,
+        "const value = new URL('./asset.png', location.href); export { value };",
+    );
+    defer alloc.free(records);
+
+    try std.testing.expectEqual(@as(usize, 0), records.len);
 }
 
 // ============================================================


### PR DESCRIPTION
## 요약
- `extractWorkerRecords()`가 모든 JS 모듈에서 전체 AST walk를 수행하던 경로 앞에 cheap source marker prefilter를 추가했습니다.
- 현재 지원하는 Worker 자동 번들링 패턴은 `Worker`/`SharedWorker` + `URL` + `import.meta`가 모두 필요하므로, 세 marker가 없는 모듈은 보완 스캔을 바로 건너뜁니다.
- 실제 Worker 패턴 추출과 marker 없는 모듈의 no-op 동작을 단위 테스트로 고정했습니다.

## 측정
ReleaseFast `./zig-out/bin/zts`, synthetic fixture 7회 측정 기준입니다. 총합은 OS 캐시/스케줄링 노이즈가 있어 하위 버킷 중심으로 봤습니다.

- `fat` 500 large JS modules, Worker 패턴 없음
  - before median `graph.discover.pm.post.worker.records`: 5.506ms
  - after median: 1.223ms
  - 개선: -4.283ms, 약 77.8% 감소
- `env` 500 large JS modules, define 실제 사용, Worker 패턴 없음
  - before median `graph.discover.pm.post.worker.records`: 4.728ms
  - after median: 1.241ms
  - 개선: -3.487ms, 약 73.8% 감소
- `tiny` 1000 tiny JS modules, Worker 패턴 없음
  - before median `graph.discover.pm.post.worker.records`: 0.177ms
  - after median: 0.070ms
  - 개선: -0.107ms, 약 60.5% 감소

## 검증
- `zig build test --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- `bun test packages/core/index.test.ts --timeout 30000`
- `git diff --check`

## 리스크
- prefilter는 실제 추출 조건보다 넓은 marker 검사입니다. `SharedWorker`는 `Worker` substring에 포함되고, 실제 추출은 기존 AST matcher가 계속 담당합니다.
- marker가 있는 파일은 기존 full AST walk 경로를 그대로 탑니다.
- plugin/JSON/CSS/asset fallback 경로는 건드리지 않았습니다.