### PR TITLE
perf(bundler): Worker URL 레코드 inline scan 전환

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1727,7 +1727,7 @@ pub const ModuleGraph = struct {
         // import/export 추출: inline scan 결과를 bundler 타입으로 변환
         {
             // Parser scan records → bundler ImportRecord
-            const records: []ImportRecord = blk: {
+            {
                 var records_scope = profile.begin(.graph_discover_pm_post_records);
                 defer records_scope.end();
 
@@ -1787,9 +1787,7 @@ pub const ModuleGraph = struct {
                     module.export_bindings = ebindings;
                     module.exported_names = projectExportedNames(arena_alloc, ebindings);
                 } else |_| {}
-
-                break :blk records;
-            };
+            }
 
             // OOM 시 silent skip 하면 optional require 가 hard error 로 회귀하므로 module 을
             // ready 로 끝내고 graph 진행 중단 (1108줄 extractImports 와 동일 패턴).
@@ -1800,21 +1798,6 @@ pub const ModuleGraph = struct {
                     module.state = .ready;
                     return;
                 };
-            }
-
-            // Worker 패턴 보완: new Worker(new URL(...)) 는 inline scan에서 감지하지 않으므로
-            // 별도의 AST walk로 worker records를 추출하여 병합한다.
-            {
-                var worker_scope = profile.begin(.graph_discover_pm_post_worker_records);
-                defer worker_scope.end();
-                const worker_records = import_scanner.extractWorkerRecords(arena_alloc, &parser.ast) catch &[_]ImportRecord{};
-                if (worker_records.len > 0) {
-                    if (arena_alloc.alloc(ImportRecord, records.len + worker_records.len)) |merged| {
-                        @memcpy(merged[0..records.len], records);
-                        @memcpy(merged[records.len..], worker_records);
-                        module.import_records = merged;
-                    } else |_| {}
-                }
             }
 
             if (parser.ast.has_flow_enum_declaration) {

--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -902,35 +902,6 @@ fn isImportMetaUrl(ast: *const Ast, idx: NodeIndex) bool {
     return true;
 }
 
-/// AST를 순회하여 Worker 패턴만 추출한다.
-/// inline scan 모드에서 Worker 감지를 보완하기 위해 사용.
-/// new Worker(new URL('./worker.ts', import.meta.url)) 패턴만 감지.
-pub fn extractWorkerRecords(allocator: std.mem.Allocator, ast: *const Ast) ![]ImportRecord {
-    if (!sourceMayContainWorkerUrlPattern(ast.source)) return &.{};
-
-    var records = std.ArrayListUnmanaged(ImportRecord).empty;
-    const reachable = try ast_walk.collectReachableNodeIndices(allocator, ast);
-    defer allocator.free(reachable);
-
-    for (reachable) |ni| {
-        const node = ast.nodes.items[ni];
-        if (node.tag == .new_expression) {
-            if (tryExtractWorkerNew(ast, node)) |record| {
-                try records.append(allocator, record);
-            }
-        }
-    }
-    return records.toOwnedSlice(allocator);
-}
-
-fn sourceMayContainWorkerUrlPattern(source: []const u8) bool {
-    // Worker 보완 스캔은 전체 AST walk라서 대부분의 모듈에서 비용만 발생한다.
-    // 실제 지원 패턴은 Worker/SharedWorker + URL + import.meta 세 토큰이 모두 필요하다.
-    return std.mem.indexOf(u8, source, "Worker") != null and
-        std.mem.indexOf(u8, source, "URL") != null and
-        std.mem.indexOf(u8, source, "import.meta") != null;
-}
-
 /// 따옴표(`'`, `"`)를 벗긴다. 최소 2글자 이상이어야 함.
 pub fn stripQuotes(text: []const u8) ?[]const u8 {
     if (text.len < 2) return null;

--- a/src/bundler/import_scanner_test.zig
+++ b/src/bundler/import_scanner_test.zig
@@ -3,13 +3,14 @@ const import_scanner = @import("import_scanner.zig");
 const extractImports = import_scanner.extractImports;
 const extractImportsWithCjsDetection = import_scanner.extractImportsWithCjsDetection;
 const extractImportsWithCjsDetectionAndDefines = import_scanner.extractImportsWithCjsDetectionAndDefines;
-const extractWorkerRecords = import_scanner.extractWorkerRecords;
 const ScanResult = import_scanner.ScanResult;
 const stripQuotes = import_scanner.stripQuotes;
 const types = @import("types.zig");
 const ImportRecord = types.ImportRecord;
 const ImportKind = types.ImportKind;
 const RequireContextMode = types.RequireContextMode;
+const scan_results = @import("../parser/scan_results.zig");
+const ScanImportRecord = scan_results.ScanImportRecord;
 const Scanner = @import("../lexer/scanner.zig").Scanner;
 const Parser = @import("../parser/parser.zig").Parser;
 const NodeIndex = @import("../parser/ast.zig").NodeIndex;
@@ -74,7 +75,7 @@ fn parseAndExtractFullWithDefines(
     return extractImportsWithCjsDetectionAndDefines(allocator, &parser.ast, defines);
 }
 
-fn parseAndExtractWorkers(allocator: std.mem.Allocator, source: []const u8) ![]ImportRecord {
+fn parseInlineScanRecords(allocator: std.mem.Allocator, source: []const u8) ![]ScanImportRecord {
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
     const arena_alloc = arena.allocator();
@@ -83,9 +84,12 @@ fn parseAndExtractWorkers(allocator: std.mem.Allocator, source: []const u8) ![]I
     var parser = Parser.init(arena_alloc, &scanner);
     parser.is_module = true;
     scanner.is_module = true;
+    parser.enable_scan = true;
     _ = try parser.parse();
 
-    return extractWorkerRecords(allocator, &parser.ast);
+    const records = try allocator.alloc(ScanImportRecord, parser.scan_import_records.items.len);
+    @memcpy(records, parser.scan_import_records.items);
+    return records;
 }
 
 test "explicit `import type { X } from ...` → no record (parser already elides)" {
@@ -307,22 +311,36 @@ test "stripQuotes" {
     try std.testing.expect(stripQuotes("") == null);
 }
 
-test "worker records: supported Worker URL pattern is extracted" {
+test "inline scan: supported Worker URL pattern is extracted" {
     const alloc = std.testing.allocator;
-    const records = try parseAndExtractWorkers(
+    const records = try parseInlineScanRecords(
         alloc,
         "const worker = new Worker(new URL('./worker.ts', import.meta.url));",
     );
     defer alloc.free(records);
 
     try std.testing.expectEqual(@as(usize, 1), records.len);
-    try std.testing.expectEqual(ImportKind.worker, records[0].kind);
+    try std.testing.expectEqual(scan_results.ImportKind.worker, records[0].kind);
     try std.testing.expectEqualStrings("./worker.ts", records[0].specifier);
+    try std.testing.expect(records[0].url_span != null);
 }
 
-test "worker records: modules without worker URL markers skip extraction" {
+test "inline scan: supported SharedWorker URL pattern is extracted" {
     const alloc = std.testing.allocator;
-    const records = try parseAndExtractWorkers(
+    const records = try parseInlineScanRecords(
+        alloc,
+        "const worker = new SharedWorker(new URL('./shared.ts', import.meta.url));",
+    );
+    defer alloc.free(records);
+
+    try std.testing.expectEqual(@as(usize, 1), records.len);
+    try std.testing.expectEqual(scan_results.ImportKind.worker, records[0].kind);
+    try std.testing.expectEqualStrings("./shared.ts", records[0].specifier);
+}
+
+test "inline scan: non-worker new URL is ignored" {
+    const alloc = std.testing.allocator;
+    const records = try parseInlineScanRecords(
         alloc,
         "const value = new URL('./asset.png', location.href); export { value };",
     );

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -1114,6 +1114,21 @@ fn followedByParenOnly(self: *const Parser) bool {
     return self.current() == .l_paren;
 }
 
+fn finishNewExpressionWithArgs(self: *Parser, start: u32, callee: NodeIndex, arg_list: NodeList) !NodeIndex {
+    const ne = try self.ast.addExtras(&.{
+        @intFromEnum(callee), arg_list.start, arg_list.len, 0,
+    });
+    const new_expr = try self.ast.addNode(.{
+        .tag = .new_expression,
+        .span = .{ .start = start, .end = self.currentSpan().start },
+        .data = .{ .extra = ne },
+    });
+    if (self.enable_scan and self.scan_dead_depth == 0) {
+        scanWorkerNewExpression(self, callee, arg_list);
+    }
+    return new_expr;
+}
+
 /// new 표현식의 callee를 파싱한다.
 /// new는 중첩 가능하므로 new를 만나면 재귀한다.
 /// member access (.prop, [expr])만 허용하고 호출 ()은 상위에서 처리.
@@ -1143,18 +1158,7 @@ fn parseNewCallee(self: *Parser) ParseError2!NodeIndex {
         if (self.current() == .l_paren) {
             try self.advance();
             const arg_list = try parseArgumentList(self);
-            const ne = try self.ast.addExtras(&.{
-                @intFromEnum(callee), arg_list.start, arg_list.len, 0,
-            });
-            const new_expr = try self.ast.addNode(.{
-                .tag = .new_expression,
-                .span = .{ .start = span.start, .end = self.currentSpan().start },
-                .data = .{ .extra = ne },
-            });
-            if (self.enable_scan and self.scan_dead_depth == 0) {
-                scanWorkerNewExpression(self, callee, arg_list);
-            }
-            return new_expr;
+            return try finishNewExpressionWithArgs(self, span.start, callee, arg_list);
         }
         const ne_no_args = try self.ast.addExtras(&.{
             @intFromEnum(callee), 0, 0, 0,
@@ -1347,18 +1351,7 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
             if (self.current() == .l_paren) {
                 try self.advance(); // skip (
                 const arg_list = try parseArgumentList(self);
-                const ne2 = try self.ast.addExtras(&.{
-                    @intFromEnum(callee), arg_list.start, arg_list.len, 0,
-                });
-                const new_expr = try self.ast.addNode(.{
-                    .tag = .new_expression,
-                    .span = .{ .start = span.start, .end = self.currentSpan().start },
-                    .data = .{ .extra = ne2 },
-                });
-                if (self.enable_scan and self.scan_dead_depth == 0) {
-                    scanWorkerNewExpression(self, callee, arg_list);
-                }
-                return new_expr;
+                return try finishNewExpressionWithArgs(self, span.start, callee, arg_list);
             }
 
             // 인자 없는 new: new Foo

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -1146,11 +1146,15 @@ fn parseNewCallee(self: *Parser) ParseError2!NodeIndex {
             const ne = try self.ast.addExtras(&.{
                 @intFromEnum(callee), arg_list.start, arg_list.len, 0,
             });
-            return try self.ast.addNode(.{
+            const new_expr = try self.ast.addNode(.{
                 .tag = .new_expression,
                 .span = .{ .start = span.start, .end = self.currentSpan().start },
                 .data = .{ .extra = ne },
             });
+            if (self.enable_scan and self.scan_dead_depth == 0) {
+                scanWorkerNewExpression(self, callee, arg_list);
+            }
+            return new_expr;
         }
         const ne_no_args = try self.ast.addExtras(&.{
             @intFromEnum(callee), 0, 0, 0,
@@ -1346,11 +1350,15 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
                 const ne2 = try self.ast.addExtras(&.{
                     @intFromEnum(callee), arg_list.start, arg_list.len, 0,
                 });
-                return try self.ast.addNode(.{
+                const new_expr = try self.ast.addNode(.{
                     .tag = .new_expression,
                     .span = .{ .start = span.start, .end = self.currentSpan().start },
                     .data = .{ .extra = ne2 },
                 });
+                if (self.enable_scan and self.scan_dead_depth == 0) {
+                    scanWorkerNewExpression(self, callee, arg_list);
+                }
+                return new_expr;
             }
 
             // 인자 없는 new: new Foo
@@ -2330,6 +2338,77 @@ fn scanObjectDefinePropertyCjs(self: *Parser, callee: NodeIndex, arg_list: NodeL
             self.scan_result.has_esmodule_marker = true;
         }
     }
+}
+
+/// new Worker(new URL("./worker.ts", import.meta.url)) 패턴을 inline scan으로 수집한다.
+/// graph 후처리 AST walk를 피하기 위해 new_expression 생성 시점의 callee/args를 사용한다.
+fn scanWorkerNewExpression(self: *Parser, callee: NodeIndex, arg_list: NodeList) void {
+    if (!isIdentifierText(self, callee, "Worker") and !isIdentifierText(self, callee, "SharedWorker")) return;
+    if (arg_list.len < 1 or arg_list.start >= self.ast.extra_data.items.len) return;
+
+    const url_new_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[arg_list.start]);
+    if (url_new_idx.isNone() or @intFromEnum(url_new_idx) >= self.ast.nodes.items.len) return;
+    const url_new = self.ast.nodes.items[@intFromEnum(url_new_idx)];
+    if (url_new.tag != .new_expression) return;
+
+    const ue = url_new.data.extra;
+    if (!self.ast.hasExtra(ue, 2)) return;
+    const url_callee_idx = self.ast.readExtraNode(ue, 0);
+    if (!isIdentifierText(self, url_callee_idx, "URL")) return;
+
+    const url_args_len = self.ast.readExtra(ue, 2);
+    if (url_args_len < 2) return;
+
+    const url_args_start = self.ast.readExtra(ue, 1);
+    if (url_args_start + 1 >= self.ast.extra_data.items.len) return;
+
+    const spec_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[url_args_start]);
+    const specifier = getStringLiteralText(self, spec_idx) orelse return;
+    const spec_node = self.ast.getNode(spec_idx);
+
+    const meta_url_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[url_args_start + 1]);
+    if (!isImportMetaUrlNode(self, meta_url_idx)) return;
+
+    self.scan_import_records.append(self.allocator, .{
+        .specifier = specifier,
+        .kind = .worker,
+        .span = spec_node.span,
+        .url_span = url_new.span,
+    }) catch {};
+}
+
+fn isIdentifierText(self: *Parser, idx: NodeIndex, expected: []const u8) bool {
+    if (idx.isNone() or @intFromEnum(idx) >= self.ast.nodes.items.len) return false;
+    const node = self.ast.nodes.items[@intFromEnum(idx)];
+    if (node.tag != .identifier_reference) return false;
+    return std.mem.eql(u8, self.ast.source[node.span.start..node.span.end], expected);
+}
+
+fn getStringLiteralText(self: *Parser, idx: NodeIndex) ?[]const u8 {
+    if (idx.isNone() or @intFromEnum(idx) >= self.ast.nodes.items.len) return null;
+    const node = self.ast.nodes.items[@intFromEnum(idx)];
+    if (node.tag != .string_literal) return null;
+    const raw = self.ast.source[node.span.start..node.span.end];
+    return import_scanner.stripQuotes(raw) orelse raw;
+}
+
+fn isImportMetaUrlNode(self: *Parser, idx: NodeIndex) bool {
+    if (idx.isNone() or @intFromEnum(idx) >= self.ast.nodes.items.len) return false;
+    const node = self.ast.nodes.items[@intFromEnum(idx)];
+    if (node.tag != .static_member_expression) return false;
+
+    const me = node.data.extra;
+    if (!self.ast.hasExtra(me, 1)) return false;
+
+    const obj_idx = self.ast.readExtraNode(me, 0);
+    if (obj_idx.isNone() or @intFromEnum(obj_idx) >= self.ast.nodes.items.len) return false;
+    const obj = self.ast.nodes.items[@intFromEnum(obj_idx)];
+    if (obj.tag != .meta_property or obj.data.none != 0) return false;
+
+    const prop_idx = self.ast.readExtraNode(me, 1);
+    if (prop_idx.isNone() or @intFromEnum(prop_idx) >= self.ast.nodes.items.len) return false;
+    const prop = self.ast.nodes.items[@intFromEnum(prop_idx)];
+    return std.mem.eql(u8, self.ast.source[prop.span.start..prop.span.end], "url");
 }
 
 /// assignment_expression의 left에서 module.exports = ... / exports.x = ... 패턴을 감지한다.


### PR DESCRIPTION
## 요약
- `new Worker(new URL(..., import.meta.url))` / `new SharedWorker(...)` 감지를 parser inline scan으로 옮겼습니다.
- graph 단계의 Worker 보완 AST walk 및 병합 경로를 제거했습니다.
- legacy `extractImportsWithCjsDetection*` 경로의 단일 AST scan은 그대로 Worker를 감지하므로 비-inline 사용자는 유지됩니다.

## 변경 이유
- #2487에서 marker prefilter로 대부분의 no-op Worker 보완 스캔은 줄였지만, graph에는 여전히 별도 fallback AST walk 경로가 남아 있었습니다.
- parser는 이미 import/export/require/glob/require.context를 inline scan하고 있고, `ScanImportRecord.kind`에도 `.worker`가 존재합니다. Worker도 같은 경로로 수집하는 편이 graph 후처리보다 단순합니다.

## 측정
ReleaseFast `./zig-out/bin/zts`, synthetic fixture 7회 측정입니다. 총합은 OS 캐시/스케줄링 영향이 커서 동일 프로파일 하위 버킷 중심으로 봤습니다. 기준은 #2487 merge 후 main입니다.

- `tiny` 1000 tiny JS modules
  - `graph.discover.pm.post.worker.records`: 0.070ms → 0ms
  - `graph.discover.pm.post`: 0.907ms → 0.772ms
- `fat` 500 large JS modules
  - `graph.discover.pm.post.worker.records`: 1.223ms → 0ms
  - `graph.discover.pm.post`: 2.875ms → 1.603ms
- `env` 500 large JS modules with define usage
  - `graph.discover.pm.post.worker.records`: 1.241ms → 0ms
  - `graph.discover.pm.post`: 48.196ms → 45.681ms

## 검증
- `zig build test --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- `bun test packages/core/index.test.ts --timeout 30000`
- `git diff --check`
- pre-push hook 통과 (`zig fmt --check`, `zig build test`, `oxlint`, `oxfmt --check`)

## 리스크
- 지원 패턴은 기존과 동일하게 `Worker`/`SharedWorker` + `new URL(string, import.meta.url)`만 수집합니다.
- graph fallback 제거 후에도 기존 bundler Worker 회귀 테스트와 신규 inline scan 테스트가 통과합니다.
- plugin/JSON/CSS/asset 경로는 건드리지 않았습니다.