### PR TITLE
perf(profile): parser parse 세부 버킷 추가

### DIFF
--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -24,6 +24,7 @@ const ParseError2 = @import("parser.zig").ParseError2;
 const flow = @import("flow.zig");
 const scan_results_mod = @import("scan_results.zig");
 const import_scanner = @import("../bundler/import_scanner.zig");
+const profile = @import("../profile.zig");
 
 /// TypeScript의 canFollowTypeArgumentsInExpression 대응 (esbuild tsCanFollowTypeArgumentsInExpression).
 /// `f<Type>` 다음에 올 수 있는 토큰인지 판별한다.
@@ -212,6 +213,9 @@ pub fn parseArrowBody(self: *Parser, is_async: bool, param_idx: NodeIndex) Parse
 }
 
 pub fn parseAssignmentExpression(self: *Parser) ParseError2!NodeIndex {
+    var scope = profile.begin(.parse_expression_assignment);
+    defer scope.end();
+
     // TS 제네릭 arrow function: <T>() => body, <const T>() => body
     // TSX 모드에서는 trailing comma(<T,>), constraint(<T extends X>), default(<T = X>)가
     // 있을 때만 제네릭 arrow로 시도 (oxc arrow.rs:166-197 참고)

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -21,6 +21,7 @@ const ParseError2 = @import("parser.zig").ParseError2;
 const binding_mod = @import("binding.zig");
 const scan_results_mod = @import("scan_results.zig");
 const import_scanner = @import("../bundler/import_scanner.zig");
+const profile = @import("../profile.zig");
 
 /// `import_declaration` extra slot 3에 저장되는 phase modifier.
 /// Stage 3 proposals: `import defer` / `import source`.
@@ -166,6 +167,9 @@ pub fn parseImportCallArgs(self: *Parser, start: u32) ParseError2!NodeIndex {
 }
 
 pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
+    var scope = profile.begin(.parse_module_import);
+    defer scope.end();
+
     const start = self.currentSpan().start;
     // Unambiguous 모드: has_module_syntax 설정은 ESM import 확정 후 (아래 참조)
     // TS import-equals (import x = require('y'))는 module syntax가 아님
@@ -544,6 +548,9 @@ pub fn parseExportDeclaration(self: *Parser) ParseError2!NodeIndex {
 /// `@dec export [default] class`: decorators를 class_declaration으로 전파한다.
 /// parseDecoratedStatement가 이 경로로 위임하며, 일반 `parseExportDeclaration`은 빈 list로 호출.
 pub fn parseExportDeclarationWithDecorators(self: *Parser, decorators: ast_mod.NodeList) ParseError2!NodeIndex {
+    var scope = profile.begin(.parse_module_export);
+    defer scope.end();
+
     const start = self.currentSpan().start;
     // @__NO_SIDE_EFFECTS__ 주석이 export 키워드 앞에 있으면 캡처.
     // export function f() {} 형태에서 주석은 export 토큰에 붙지만,

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -19,9 +19,13 @@ const Span = token_mod.Span;
 const Parser = @import("parser.zig").Parser;
 const ParseError2 = @import("parser.zig").ParseError2;
 const import_scanner = @import("../bundler/import_scanner.zig");
+const profile = @import("../profile.zig");
 
 /// 소스 전체를 파싱하여 AST를 반환한다.
 pub fn parse(self: *Parser) !NodeIndex {
+    var program_scope = profile.begin(.parse_program);
+    defer program_scope.end();
+
     try self.advance(); // 첫 토큰 로드
 
     // Flow pragma 감지: 첫 토큰 스캔 시 파일 상단 주석이 처리되므로
@@ -136,6 +140,9 @@ pub fn parseStatementChecked(self: *Parser, comptime is_loop_body: bool) ParseEr
 }
 
 pub fn parseStatement(self: *Parser) ParseError2!NodeIndex {
+    var scope = profile.begin(.parse_statement);
+    defer scope.end();
+
     return switch (self.current()) {
         .l_curly => parseBlockStatement(self),
         .semicolon => parseEmptyStatement(self),

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -47,6 +47,11 @@ pub const Category = enum {
     scan,
     parse,
     parse_ast_build,
+    parse_program,
+    parse_statement,
+    parse_module_import,
+    parse_module_export,
+    parse_expression_assignment,
 
     // ── Analysis ──
     semantic,


### PR DESCRIPTION
## 요약
- `pm.parse` 내부를 더 볼 수 있도록 parser profile category를 추가했습니다.
- 추가 category: `parse.program`, `parse.statement`, `parse.module.import`, `parse.module.export`, `parse.expression.assignment`
- 런타임 동작/public API 변경은 없습니다. 기존 profile category enum에 하위 버킷만 추가합니다.

## 의도
- #2487/#2488 이후 `graph.discover.pm.post.worker.records`는 제거됐고, 남은 큰 비용은 `pm.parse` / `pm.semantic` / define 사용 시 `pm.prepass.run`입니다.
- parser 본체를 최적화하기 전에 import/export/statement/expression 어느 층이 비중을 차지하는지 먼저 보려는 계측 PR입니다.

## 측정 예시
ReleaseFast `./zig-out/bin/zts`, `fat` synthetic fixture 500 modules, `--profile=all --profile-level=detailed --profile-format=json`:

```
parse                         46.546ms  count=500
parse.program                 46.529ms  count=500
parse.statement               76.168ms  count=121499
parse.module.import            0.439ms  count=499
parse.module.export           42.004ms  count=60500
parse.expression.assignment   12.624ms  count=60500
graph.discover.pm.parse       46.561ms  count=500
```

주의: `parse.statement`와 `parse.expression.assignment`는 nested/inclusive 호출 누적입니다. 벽시계 합산용이 아니라 어떤 parser 계층 호출이 많이 쌓이는지 보는 신호로 사용해야 합니다.

## 검증
- `zig build test --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- `bun test packages/core/index.test.ts --timeout 30000`
- `git diff --check`
- pre-push hook 통과 (`zig fmt --check`, `zig build test`, `oxlint`, `oxfmt --check`)

## 참고
- #2488 merge 후 실패했던 `NAPI Build & Test (macos-latest)`는 failed job 재실행 후 `SUCCESS` 확인했습니다.