### PR TITLE
perf(resolve): 경로 import의 builtin 검사 생략

### DIFF
--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -653,8 +653,7 @@ pub const ResolveCache = struct {
 
         const is_path = resolver_mod.isRelativeOrAbsolute(specifier);
 
-        // platform=node 에서 bare builtin 만 자동 external. 상대/절대 경로는 Node builtin 이
-        // 될 수 없으므로 builtin 목록 선형 탐색을 피한다.
+        // 상대/절대 경로는 Node builtin 이 될 수 없으므로 builtin 목록 선형 탐색을 피한다.
         if (self.platform == .node and !is_path and isNodeBuiltin(specifier)) return true;
 
         // --packages=external: 모든 bare import를 external 처리

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -648,15 +648,17 @@ pub const ResolveCache = struct {
     /// specifier가 external인지 판별.
     /// exact match + `*` 글롭 매칭 (D069).
     pub fn isExternal(self: *const ResolveCache, specifier: []const u8) bool {
-        // node: 프리픽스 또는 platform=node에서 node 빌트인 자동 external
-        // isNodeBuiltin이 "node:" 프리픽스와 서브패스("fs/promises" 등)를 모두 처리
-        if (self.platform == .node and isNodeBuiltin(specifier)) return true;
-
         // node: 프리픽스는 platform과 무관하게 항상 external
         if (std.mem.startsWith(u8, specifier, "node:")) return true;
 
+        const is_path = resolver_mod.isRelativeOrAbsolute(specifier);
+
+        // platform=node 에서 bare builtin 만 자동 external. 상대/절대 경로는 Node builtin 이
+        // 될 수 없으므로 builtin 목록 선형 탐색을 피한다.
+        if (self.platform == .node and !is_path and isNodeBuiltin(specifier)) return true;
+
         // --packages=external: 모든 bare import를 external 처리
-        if (self.packages_external and !resolver_mod.isRelativeOrAbsolute(specifier)) return true;
+        if (self.packages_external and !is_path) return true;
 
         // 사용자 지정 external 패턴
         for (self.external_patterns) |pattern| {

--- a/src/bundler/resolve_cache_test.zig
+++ b/src/bundler/resolve_cache_test.zig
@@ -46,6 +46,9 @@ test "isExternal: node builtins when platform=node" {
     try std.testing.expect(cache.isExternal("path"));
     try std.testing.expect(cache.isExternal("crypto"));
     try std.testing.expect(!cache.isExternal("react"));
+    try std.testing.expect(!cache.isExternal("./fs"));
+    try std.testing.expect(!cache.isExternal("../path"));
+    try std.testing.expect(!cache.isExternal("/project/fs"));
 }
 
 test "isNodeBuiltin" {


### PR DESCRIPTION
## 요약
- platform=node resolve에서 상대/절대 specifier는 Node builtin이 될 수 없으므로 builtin 목록 검사를 건너뜁니다.
- 같은 isRelativeOrAbsolute() 결과를 packagesExternal 판정에도 재사용합니다.
- fs/path/crypto bare builtin은 external 유지, ./fs, ../path, /project/fs는 external 아님을 테스트로 고정했습니다.

## 측정
- origin/main ReleaseFast 바이너리와 현재 브랜치 ReleaseFast 바이너리를 분리해 synthetic relative import 그래프를 A/B 측정했습니다.
- 200/1000/2000 모듈 그래프에서는 약 2-3% 개선이 관찰됐고, 실제 패키지 샘플은 대부분 노이즈권이었습니다.
- 확장자 탐색 stack-buffer, builtin StaticStringMap, helper plugin dispatch gate도 실험했지만 성능/복잡도 기준을 넘지 못해 제외했습니다.

## 검증
- zig build test --summary all
- zig build -Doptimize=ReleaseFast --summary all
- bun test packages/core/index.test.ts --timeout 30000
- git diff --check
- pre-push hook 통과: zig fmt, zig build test, oxlint 경고만 기존 unrelated 파일, oxfmt