### PR TITLE
chore(benchmark): median 기반 측정 리포트로 정리

### DIFF
--- a/tests/benchmark/bench.ts
+++ b/tests/benchmark/bench.ts
@@ -10,6 +10,7 @@ import { spawnSync } from "node:child_process";
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { computeMetricStats, formatMetric, type MetricStats } from "./stats";
 
 const ROOT = resolve(__dirname, "../..");
 const ZTS_BIN = join(ROOT, "zig-out/bin/zts");
@@ -87,9 +88,7 @@ interface BenchResult {
   tool: string;
   task: string;
   scale: string;
-  avgMs: number;
-  minMs: number;
-  maxMs: number;
+  stats: MetricStats | null;
 }
 
 function runBench(name: string, task: string, scale: string, fn: () => void): BenchResult {
@@ -98,7 +97,7 @@ function runBench(name: string, task: string, scale: string, fn: () => void): Be
   try {
     fn();
   } catch {
-    return { tool: name, task, scale, avgMs: -1, minMs: -1, maxMs: -1 };
+    return { tool: name, task, scale, stats: null };
   }
 
   for (let i = 0; i < ITERATIONS; i++) {
@@ -106,7 +105,7 @@ function runBench(name: string, task: string, scale: string, fn: () => void): Be
     try {
       fn();
     } catch {
-      return { tool: name, task, scale, avgMs: -1, minMs: -1, maxMs: -1 };
+      return { tool: name, task, scale, stats: null };
     }
     times.push(performance.now() - start);
   }
@@ -115,9 +114,7 @@ function runBench(name: string, task: string, scale: string, fn: () => void): Be
     tool: name,
     task,
     scale,
-    avgMs: Math.round(times.reduce((a, b) => a + b) / times.length),
-    minMs: Math.round(Math.min(...times)),
-    maxMs: Math.round(Math.max(...times)),
+    stats: computeMetricStats(times),
   };
 }
 
@@ -315,21 +312,24 @@ function printResults(results: BenchResult[]) {
       const group = results
         .filter((r) => r.task === task && r.scale === scale)
         .sort((a, b) => {
-          if (a.avgMs === -1) return 1;
-          if (b.avgMs === -1) return -1;
-          return a.avgMs - b.avgMs;
+          if (a.stats === null) return 1;
+          if (b.stats === null) return -1;
+          return a.stats.median - b.stats.median;
         });
 
       console.log(`\n### ${task} — ${scale}`);
-      console.log("| Tool | Avg (ms) | Min (ms) | Max (ms) | vs fastest |");
-      console.log("|------|----------|----------|----------|------------|");
-      const fastest = group.find((r) => r.avgMs > 0)?.avgMs ?? 1;
+      console.log("| Tool | Median | Trimmed mean | Min | Max | p95 | vs fastest |");
+      console.log("|------|--------|--------------|-----|-----|-----|------------|");
+      const fastest = group.find((r) => r.stats !== null)?.stats?.median ?? 1;
       for (const r of group) {
-        const avg = r.avgMs === -1 ? "FAIL" : String(r.avgMs);
-        const min = r.minMs === -1 ? "-" : String(r.minMs);
-        const max = r.maxMs === -1 ? "-" : String(r.maxMs);
-        const ratio = r.avgMs > 0 ? `${(r.avgMs / fastest).toFixed(1)}x` : "-";
-        console.log(`| ${r.tool} | ${avg} | ${min} | ${max} | ${ratio} |`);
+        if (r.stats === null) {
+          console.log(`| ${r.tool} | FAIL | - | - | - | - | - |`);
+          continue;
+        }
+        const ratio = `${(r.stats.median / fastest).toFixed(1)}x`;
+        console.log(
+          `| ${r.tool} | ${formatMetric(r.stats.median)} | ${formatMetric(r.stats.trimmedMean)} | ${formatMetric(r.stats.min)} | ${formatMetric(r.stats.max)} | ${formatMetric(r.stats.p95)} | ${ratio} |`,
+        );
       }
     }
   }
@@ -344,7 +344,7 @@ const doTranspile = args.includes("--transpile") || args.includes("--all") || ar
 const doBundle = args.includes("--bundle") || args.includes("--all") || args.length === 0;
 
 console.log("ZTS Benchmark Suite");
-console.log(`  Iterations: ${ITERATIONS}`);
+console.log(`  Iterations: ${ITERATIONS} (median, trimmed mean)`);
 console.log("  Method: CLI binary direct execution (no npx overhead)");
 console.log(`  Platform: ${process.platform} ${process.arch}`);
 

--- a/tests/benchmark/bundle-perf.ts
+++ b/tests/benchmark/bundle-perf.ts
@@ -27,6 +27,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { computeMetricStats, formatMetric, type MetricStats } from "./stats";
 
 const ROOT = resolve(__dirname, "../..");
 const ZTS_BIN = join(ROOT, "zig-out/bin/zts");
@@ -113,19 +114,19 @@ interface Stats {
 }
 
 function computeStats(samples: number[]): Stats {
-  const sorted = [...samples].sort((a, b) => a - b);
-  const n = sorted.length;
-  const median = n % 2 ? sorted[(n - 1) / 2] : (sorted[n / 2 - 1] + sorted[n / 2]) / 2;
-  const mean = samples.reduce((a, b) => a + b, 0) / n;
-  const trimmed = sorted.slice(1, -1);
-  const trimmed_mean = trimmed.reduce((a, b) => a + b, 0) / trimmed.length;
-  // 선형 보간 percentile — `Math.floor(n*0.95)` 는 n=20 에서 19=max 가 돼 p95==max 가 됨.
-  // (n-1)*p 인덱스 + 보간으로 보편적 의미 회복.
-  const idx = (n - 1) * 0.95;
-  const lo = Math.floor(idx);
-  const hi = Math.ceil(idx);
-  const p95 = lo === hi ? sorted[lo] : sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
-  return { median, mean, min: sorted[0], max: sorted[n - 1], p95, trimmed_mean };
+  const stats = computeMetricStats(samples);
+  return toBaselineStats(stats);
+}
+
+function toBaselineStats(stats: MetricStats): Stats {
+  return {
+    median: stats.median,
+    mean: stats.mean,
+    min: stats.min,
+    max: stats.max,
+    p95: stats.p95,
+    trimmed_mean: stats.trimmedMean,
+  };
 }
 
 // ─── Fixture spec ───
@@ -216,6 +217,10 @@ function fmtMs(n: number): string {
   return n.toFixed(2) + "ms";
 }
 
+function fmtMarkdownMs(n: number): string {
+  return formatMetric(n, "ms");
+}
+
 interface CliArgs {
   write: boolean;
   noFail: boolean;
@@ -276,11 +281,18 @@ async function main(cli: CliArgs) {
   const baseline = JSON.parse(readFileSync(BASELINE_PATH, "utf8")) as BaselineFile;
   console.log();
   console.log(`Compared against baseline (${baseline.zts_commit} @ ${baseline.generated_at}):`);
+  console.log();
+  console.log("### bundle-perf — baseline comparison");
+  console.log("| Fixture | Median | Baseline | Delta | Trimmed mean | p95 | Status |");
+  console.log("|---------|--------|----------|-------|--------------|-----|--------|");
   let regressed = 0;
   for (const r of results) {
     const base = baseline.fixtures.find((f) => f.name === r.name);
     if (!base) {
       console.log(`  ${r.name}: NEW (no baseline)`);
+      console.log(
+        `| ${r.name} | ${fmtMarkdownMs(r.total_ms_stats.median)} | - | - | ${fmtMarkdownMs(r.total_ms_stats.trimmed_mean)} | ${fmtMarkdownMs(r.total_ms_stats.p95)} | NEW |`,
+      );
       continue;
     }
     const baseMs = base.total_ms_stats.median;
@@ -292,6 +304,9 @@ async function main(cli: CliArgs) {
     const tag = within ? "OK" : pct > 0 ? "REGRESS" : "IMPROVE";
     console.log(
       `  ${r.name}: ${fmtMs(curMs)} vs ${fmtMs(baseMs)} (${sign}${pct.toFixed(1)}%) [${tag}]`,
+    );
+    console.log(
+      `| ${r.name} | ${fmtMarkdownMs(curMs)} | ${fmtMarkdownMs(baseMs)} | ${sign}${pct.toFixed(1)}% | ${fmtMarkdownMs(r.total_ms_stats.trimmed_mean)} | ${fmtMarkdownMs(r.total_ms_stats.p95)} | ${tag} |`,
     );
     if (!within && pct > 0) regressed++;
   }

--- a/tests/benchmark/napi-bench.ts
+++ b/tests/benchmark/napi-bench.ts
@@ -15,6 +15,7 @@ import { spawnSync } from "node:child_process";
 import { resolve } from "node:path";
 import { writeFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
+import { computeMetricStats, formatMetric, type MetricStats } from "./stats";
 
 const ROOT = resolve(import.meta.dir, "../..");
 const WARMUP = 3;
@@ -73,11 +74,7 @@ for (let i = 0; i < ITERATIONS; i++) {
   times.push((Bun.nanoseconds() - start) / 1000);
 }
 times.sort((a, b) => a - b);
-console.log(JSON.stringify({
-  medianUs: Math.round(times[Math.floor(times.length / 2)]),
-  minUs: Math.round(times[0]),
-  maxUs: Math.round(times[times.length - 1]),
-}));
+console.log(JSON.stringify({ samplesUs: times }));
 `;
     const path = resolve(dir, "worker.ts");
     writeFileSync(path, script);
@@ -140,11 +137,7 @@ for (let i = 0; i < ITERATIONS; i++) {
   times.push((Bun.nanoseconds() - start) / 1000);
 }
 times.sort((a, b) => a - b);
-console.log(JSON.stringify({
-  medianUs: Math.round(times[Math.floor(times.length / 2)]),
-  minUs: Math.round(times[0]),
-  maxUs: Math.round(times[times.length - 1]),
-}));
+console.log(JSON.stringify({ samplesUs: times }));
 `;
     const path = resolve(dir, "worker.ts");
     writeFileSync(path, script);
@@ -173,11 +166,7 @@ for (let i = 0; i < ITERATIONS; i++) {
   times.push((Bun.nanoseconds() - start) / 1000);
 }
 times.sort((a, b) => a - b);
-console.log(JSON.stringify({
-  medianUs: Math.round(times[Math.floor(times.length / 2)]),
-  minUs: Math.round(times[0]),
-  maxUs: Math.round(times[times.length - 1]),
-}));
+console.log(JSON.stringify({ samplesUs: times }));
 `;
   const path = resolve(dir, "worker.ts");
   writeFileSync(path, script);
@@ -189,9 +178,7 @@ console.log(JSON.stringify({
 interface BenchResult {
   method: string;
   scale: string;
-  medianUs: number;
-  minUs: number;
-  maxUs: number;
+  stats: MetricStats | null;
 }
 
 function runWorker(
@@ -214,23 +201,26 @@ function runWorker(
     console.error(`  ${label}: FAILED`);
     if (result.stderr.length > 0)
       console.error(`  stderr: ${result.stderr.toString().slice(0, 200)}`);
-    return { method: label, scale, medianUs: -1, minUs: -1, maxUs: -1 };
+    return { method: label, scale, stats: null };
   }
 
   const stdout = result.stdout.toString().trim();
   try {
     const data = JSON.parse(stdout);
-    return { method: label, scale, ...data };
+    if (!Array.isArray(data.samplesUs)) {
+      throw new Error("missing samplesUs");
+    }
+    return { method: label, scale, stats: computeMetricStats(data.samplesUs) };
   } catch {
     console.error(`  ${label}: parse error: ${stdout.slice(0, 200)}`);
-    return { method: label, scale, medianUs: -1, minUs: -1, maxUs: -1 };
+    return { method: label, scale, stats: null };
   }
 }
 
 // ─── Main ───
 
 console.log("ZTS NAPI vs WASM vs CLI Benchmark");
-console.log(`  Warmup: ${WARMUP}, Iterations: ${ITERATIONS} (median)`);
+console.log(`  Warmup: ${WARMUP}, Iterations: ${ITERATIONS} (median, trimmed mean)`);
 console.log(`  Platform: ${process.platform} ${process.arch}\n`);
 
 const scales = [
@@ -256,8 +246,10 @@ for (const scale of scales) {
     const label = method === "napi" ? "NAPI" : method === "wasm" ? "WASM" : "CLI";
     process.stdout.write(`  ${label}... `);
     const r = runWorker(method, scale.name, sourceFile);
-    if (r.medianUs > 0) {
-      console.log(`${r.medianUs} us (min: ${r.minUs}, max: ${r.maxUs})`);
+    if (r.stats !== null) {
+      console.log(
+        `${formatMetric(r.stats.median, "us")} (min: ${formatMetric(r.stats.min, "us")}, max: ${formatMetric(r.stats.max, "us")})`,
+      );
     }
     results.push(r);
   }
@@ -273,23 +265,24 @@ for (const scale of scales) {
   const group = results
     .filter((r) => r.scale === scale.name)
     .sort((a, b) => {
-      if (a.medianUs === -1) return 1;
-      if (b.medianUs === -1) return -1;
-      return a.medianUs - b.medianUs;
+      if (a.stats === null) return 1;
+      if (b.stats === null) return -1;
+      return a.stats.median - b.stats.median;
     });
 
-  const fastest = group.find((r) => r.medianUs > 0)?.medianUs ?? 1;
+  const fastest = group.find((r) => r.stats !== null)?.stats?.median ?? 1;
 
   console.log(`### ${scale.name}`);
-  console.log("| Method          | Median (us) | Min (us) | Max (us) | vs fastest |");
-  console.log("|-----------------|-------------|----------|----------|------------|");
+  console.log("| Method          | Median | Trimmed mean | Min | Max | p95 | vs fastest |");
+  console.log("|-----------------|--------|--------------|-----|-----|-----|------------|");
   for (const r of group) {
-    const median = r.medianUs === -1 ? "FAIL" : String(r.medianUs);
-    const min = r.minUs === -1 ? "-" : String(r.minUs);
-    const max = r.maxUs === -1 ? "-" : String(r.maxUs);
-    const ratio = r.medianUs > 0 ? `${(r.medianUs / fastest).toFixed(1)}x` : "-";
+    if (r.stats === null) {
+      console.log(`| ${r.method.padEnd(15)} | FAIL | - | - | - | - | - |`);
+      continue;
+    }
+    const ratio = `${(r.stats.median / fastest).toFixed(1)}x`;
     console.log(
-      `| ${r.method.padEnd(15)} | ${median.padStart(11)} | ${min.padStart(8)} | ${max.padStart(8)} | ${ratio.padStart(10)} |`,
+      `| ${r.method.padEnd(15)} | ${formatMetric(r.stats.median, "us")} | ${formatMetric(r.stats.trimmedMean, "us")} | ${formatMetric(r.stats.min, "us")} | ${formatMetric(r.stats.max, "us")} | ${formatMetric(r.stats.p95, "us")} | ${ratio.padStart(10)} |`,
     );
   }
   console.log();

--- a/tests/benchmark/stats.test.ts
+++ b/tests/benchmark/stats.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { computeMetricStats, formatMetric } from "./stats";
+
+describe("benchmark stats", () => {
+  test("median, p95, trimmed mean을 한 곳에서 계산한다", () => {
+    const stats = computeMetricStats([10, 20, 30, 40, 1000]);
+
+    expect(stats.median).toBe(30);
+    expect(stats.mean).toBe(220);
+    expect(stats.min).toBe(10);
+    expect(stats.max).toBe(1000);
+    expect(stats.trimmedMean).toBe(30);
+    expect(stats.p95).toBeCloseTo(808, 6);
+  });
+
+  test("샘플이 2개 이하이면 trimmed mean은 일반 평균과 같다", () => {
+    expect(computeMetricStats([4]).trimmedMean).toBe(4);
+    expect(computeMetricStats([4, 8]).trimmedMean).toBe(6);
+  });
+
+  test("빈 샘플은 측정 오류로 처리한다", () => {
+    expect(() => computeMetricStats([])).toThrow("empty samples");
+  });
+
+  test("단위별 출력 포맷을 공유한다", () => {
+    expect(formatMetric(3.1415)).toBe("3.14ms");
+    expect(formatMetric(12.34)).toBe("12.3ms");
+    expect(formatMetric(123.4, "us")).toBe("123us");
+  });
+});

--- a/tests/benchmark/stats.ts
+++ b/tests/benchmark/stats.ts
@@ -1,0 +1,47 @@
+export interface MetricStats {
+  median: number;
+  mean: number;
+  min: number;
+  max: number;
+  p95: number;
+  trimmedMean: number;
+}
+
+export function computeMetricStats(samples: number[]): MetricStats {
+  if (samples.length === 0) {
+    throw new Error("cannot compute benchmark stats from empty samples");
+  }
+
+  const sorted = [...samples].sort((a, b) => a - b);
+  const n = sorted.length;
+  const median = n % 2 ? sorted[(n - 1) / 2] : (sorted[n / 2 - 1] + sorted[n / 2]) / 2;
+  const mean = samples.reduce((a, b) => a + b, 0) / n;
+  const trimmed = n > 2 ? sorted.slice(1, -1) : sorted;
+  const trimmedMean = trimmed.reduce((a, b) => a + b, 0) / trimmed.length;
+  const p95 = percentile(sorted, 0.95);
+
+  return {
+    median,
+    mean,
+    min: sorted[0],
+    max: sorted[n - 1],
+    p95,
+    trimmedMean,
+  };
+}
+
+export function formatMetric(n: number, unit: "ms" | "us" = "ms"): string {
+  const rounded = n >= 100 ? n.toFixed(0) : n >= 10 ? n.toFixed(1) : n.toFixed(2);
+  return `${rounded}${unit}`;
+}
+
+function percentile(sortedSamples: number[], p: number): number {
+  if (sortedSamples.length === 1) return sortedSamples[0];
+
+  // 선형 보간 percentile. p95가 max 하나에 끌려가는 것을 피한다.
+  const idx = (sortedSamples.length - 1) * p;
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  if (lo === hi) return sortedSamples[lo];
+  return sortedSamples[lo] + (sortedSamples[hi] - sortedSamples[lo]) * (idx - lo);
+}


### PR DESCRIPTION
## 요약
- `tests/benchmark/stats.ts`를 추가해 median/trimmed mean/p95/min/max 계산과 출력 포맷을 공용화했습니다.
- `bench.ts`의 정렬/`vs fastest` 기준을 avg에서 median으로 바꾸고, PR 코멘트에 trimmed mean과 p95도 노출되게 했습니다.
- `bundle-perf.ts`도 같은 통계 계산을 사용하고, CI comment grep에 잡히는 markdown baseline 비교 테이블을 출력합니다.
- `napi-bench.ts`는 워커가 raw sample을 반환하고 부모 프로세스가 공용 통계로 집계하게 정리했습니다.

Fixes #2355

## 검증
- `bun test tests/benchmark/stats.test.ts`
- `bun run tests/benchmark/bench.ts --transpile`
- `bun run tests/benchmark/bench.ts --bundle`
- `bun run tests/benchmark/bundle-perf.ts --no-fail --output /tmp/zts-bundle-perf-measurement-summary.json`
- `zig build wasm`
- `bun run tests/benchmark/napi-bench.ts` (WASM 행은 로컬 WebAssembly import LinkError로 기존처럼 FAIL 처리, NAPI/CLI와 markdown 출력은 정상)
- `git diff --check`
- pre-push hook: `zig build test`, `oxlint`, `oxfmt --check` 통과 (기존 unrelated oxlint warning 3개만 출력)

## 참고
- `bundle-perf.ts`의 baseline 비교는 로컬 머신 절대값 차이로 REGRESS가 출력될 수 있어, CI와 동일하게 `--no-fail` 경로로 결과 수집을 검증했습니다.