### PR TITLE
chore(benchmark): 대형 monorepo 번들 측정 추가

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -197,11 +197,11 @@ pub const ModuleGraph = struct {
     /// `graph.allocator` 소유. `ensureBuiltinPlugins` 에서 lazy 초기화 후 PluginRunner.init
     /// 호출 site 들이 이걸 참조.
     plugins_with_helpers: ?[]plugin_mod.Plugin = null,
-    /// 사용자 plugin 중 resolveId hook 보유 여부. false이면 helper virtual id 외 resolveId 호출을 생략.
+    /// Hook fast-path gate: 사용자 plugin 이 해당 hook 을 등록하지 않았고 helper virtual id
+    /// 도 아니면 PluginRunner 호출 자체를 생략한다. `ensureBuiltinPlugins` 에서 1회 채움.
     has_user_resolve_id_plugins: bool = false,
-    /// 사용자 plugin 중 load hook 보유 여부. false이면 helper virtual id 외 load 호출을 생략.
     has_user_load_plugins: bool = false,
-    /// 사용자 plugin 또는 builtin RN codegen transform 보유 여부. false이면 transform hook 호출을 생략.
+    /// transform 은 user plugin 또는 builtin RN codegen 이 활성이면 실행 — 둘을 합친 게이트.
     has_transform_plugins: bool = false,
 
     pub const PkgInfo = struct {
@@ -1322,18 +1322,19 @@ pub const ModuleGraph = struct {
                 if (record.kind == .glob) continue;
                 if (record.kind == .require_context) continue;
 
-                if (plugin_runner != null and self.shouldRunResolveId(record.specifier)) {
-                    const runner = plugin_runner.?;
-                    const resolve_result = runner.runResolveId(record.specifier, module_path, self.allocator) catch |err| switch (err) {
-                        error.PluginFailed => null,
-                        error.OutOfMemory => {
-                            self.addDiag(.resolve_error, .@"error", module_path, record.span, .resolve, "Out of memory during resolve", record.specifier);
+                if (plugin_runner) |runner| {
+                    if (self.shouldRunResolveId(record.specifier)) {
+                        const resolve_result = runner.runResolveId(record.specifier, module_path, self.allocator) catch |err| switch (err) {
+                            error.PluginFailed => null,
+                            error.OutOfMemory => {
+                                self.addDiag(.resolve_error, .@"error", module_path, record.span, .resolve, "Out of memory during resolve", record.specifier);
+                                continue;
+                            },
+                        };
+                        if (resolve_result) |plugin_result| {
+                            results[rec_i] = .{ .resolved = plugin_result, .is_error = false };
                             continue;
-                        },
-                    };
-                    if (resolve_result) |plugin_result| {
-                        results[rec_i] = .{ .resolved = plugin_result, .is_error = false };
-                        continue;
+                        }
                     }
                 }
 
@@ -1374,52 +1375,53 @@ pub const ModuleGraph = struct {
         // Plugin: load 훅 — 모든 module_type 분기 전에 플러그인에게 기회를 줌.
         // 플러그인이 내용을 반환하면 JS 모듈로 전환 (예: .css → JS export).
         var plugin_load_applied = false;
-        if (plugin_runner != null and self.shouldRunLoad(module.path)) {
-            const runner = plugin_runner.?;
-            // 임시 allocator로 load 결과만 확인 (성공 시 arena를 생성)
-            var tmp_arena = std.heap.ArenaAllocator.init(self.allocator);
-            const load_result = runner.runLoad(module.path, tmp_arena.allocator()) catch |err| switch (err) {
-                error.PluginFailed => null,
-                error.OutOfMemory => {
-                    tmp_arena.deinit();
-                    module.state = .ready;
-                    return;
-                },
-            };
-            if (load_result) |plugin_result| {
-                plugin_load_applied = true;
-                // 플러그인이 내용을 반환. (#2157) `loader` 가 명시되면 raw bytes 를 그 loader 의
-                // 값 표현식으로 변환 (parseAssetModule 와 동일한 assetSourceFromBytes 헬퍼).
-                // asset 변환 성공 시 parseAssetModule 와 동일하게 ast 없이 종료 → emitter 의
-                // emitAssetModule 가 `module.exports = <source>` 로 wrap. JS 파이프라인 진입 시
-                // source 가 단순 표현식 ("text") 이라 default export 없는 빈 모듈로 emit 되어
-                // import binding 이 깨진다.
-                module.parse_arena = tmp_arena;
-                const arena_alloc = tmp_arena.allocator();
-                if (plugin_result.loader) |loader_override| {
-                    module.loader = loader_override;
-                    module.module_type = plugin_result.module_type orelse
-                        moduleTypeForLoader(ModuleType.fromExtension(std.fs.path.extension(module.path)), loader_override);
-                    if (self.assetSourceFromBytes(arena_alloc, loader_override, plugin_result.contents, module.path)) |expr| {
-                        module.source = expr;
-                        module.module_type = .js;
-                        module.exports_kind = .commonjs;
-                        module.wrap_kind = .cjs;
-                        module.side_effects = false;
+        if (plugin_runner) |runner| {
+            if (self.shouldRunLoad(module.path)) {
+                // 임시 allocator로 load 결과만 확인 (성공 시 arena를 생성)
+                var tmp_arena = std.heap.ArenaAllocator.init(self.allocator);
+                const load_result = runner.runLoad(module.path, tmp_arena.allocator()) catch |err| switch (err) {
+                    error.PluginFailed => null,
+                    error.OutOfMemory => {
+                        tmp_arena.deinit();
                         module.state = .ready;
                         return;
+                    },
+                };
+                if (load_result) |plugin_result| {
+                    plugin_load_applied = true;
+                    // 플러그인이 내용을 반환. (#2157) `loader` 가 명시되면 raw bytes 를 그 loader 의
+                    // 값 표현식으로 변환 (parseAssetModule 와 동일한 assetSourceFromBytes 헬퍼).
+                    // asset 변환 성공 시 parseAssetModule 와 동일하게 ast 없이 종료 → emitter 의
+                    // emitAssetModule 가 `module.exports = <source>` 로 wrap. JS 파이프라인 진입 시
+                    // source 가 단순 표현식 ("text") 이라 default export 없는 빈 모듈로 emit 되어
+                    // import binding 이 깨진다.
+                    module.parse_arena = tmp_arena;
+                    const arena_alloc = tmp_arena.allocator();
+                    if (plugin_result.loader) |loader_override| {
+                        module.loader = loader_override;
+                        module.module_type = plugin_result.module_type orelse
+                            moduleTypeForLoader(ModuleType.fromExtension(std.fs.path.extension(module.path)), loader_override);
+                        if (self.assetSourceFromBytes(arena_alloc, loader_override, plugin_result.contents, module.path)) |expr| {
+                            module.source = expr;
+                            module.module_type = .js;
+                            module.exports_kind = .commonjs;
+                            module.wrap_kind = .cjs;
+                            module.side_effects = false;
+                            module.state = .ready;
+                            return;
+                        }
+                        // asset 변환 미지원 loader (file/copy/javascript/json/css/none): raw 그대로 JS 파이프라인.
+                        module.source = plugin_result.contents;
+                    } else {
+                        module.loader = .javascript;
+                        module.module_type = .js;
+                        module.source = plugin_result.contents;
                     }
-                    // asset 변환 미지원 loader (file/copy/javascript/json/css/none): raw 그대로 JS 파이프라인.
-                    module.source = plugin_result.contents;
+                    // module_type 분기를 건너뛰고 JS 파싱 경로로 직접 이동
+                    // (아래 "모듈별 Arena" 블록은 parse_arena가 이미 설정되어 있으므로 건너뜀)
                 } else {
-                    module.loader = .javascript;
-                    module.module_type = .js;
-                    module.source = plugin_result.contents;
+                    tmp_arena.deinit();
                 }
-                // module_type 분기를 건너뛰고 JS 파싱 경로로 직접 이동
-                // (아래 "모듈별 Arena" 블록은 parse_arena가 이미 설정되어 있으므로 건너뜀)
-            } else {
-                tmp_arena.deinit();
             }
         }
 
@@ -1572,18 +1574,19 @@ pub const ModuleGraph = struct {
         // 플러그인이 코드를 변환하면 변환된 소스로 파싱한다.
         // Babel 플러그인(예: react-native-reanimated/plugin)이 유저 코드를 변환할 수 있다.
         var plugin_transform_applied = false;
-        if (plugin_runner != null and self.has_transform_plugins) {
-            const runner = plugin_runner.?;
-            const transform_result = runner.runTransform(module.source, module.path, arena_alloc) catch |err| switch (err) {
-                error.PluginFailed => null,
-                error.OutOfMemory => {
-                    module.state = .ready;
-                    return;
-                },
-            };
-            if (transform_result) |result| {
-                module.source = result;
-                plugin_transform_applied = true;
+        if (plugin_runner) |runner| {
+            if (self.has_transform_plugins) {
+                const transform_result = runner.runTransform(module.source, module.path, arena_alloc) catch |err| switch (err) {
+                    error.PluginFailed => null,
+                    error.OutOfMemory => {
+                        module.state = .ready;
+                        return;
+                    },
+                };
+                if (transform_result) |result| {
+                    module.source = result;
+                    plugin_transform_applied = true;
+                }
             }
         }
 
@@ -2534,18 +2537,19 @@ pub const ModuleGraph = struct {
             if (record.kind == .require_context) continue;
 
             // Plugin: resolveId 훅 — 기본 resolver 전에 플러그인에게 경로 해석 기회를 줌
-            if (plugin_runner != null and self.shouldRunResolveId(record.specifier)) {
-                const runner = plugin_runner.?;
-                const resolve_result = runner.runResolveId(record.specifier, module_path, self.allocator) catch |err| switch (err) {
-                    error.PluginFailed => null,
-                    error.OutOfMemory => return error.OutOfMemory,
-                };
-                // non-null이면 플러그인이 resolve 완료 → 기본 resolver 건너뜀
-                if (resolve_result) |plugin_result| {
-                    try self.applyResolveResult(mod_idx, rec_i, record, plugin_result, false);
-                    continue;
+            if (plugin_runner) |runner| {
+                if (self.shouldRunResolveId(record.specifier)) {
+                    const resolve_result = runner.runResolveId(record.specifier, module_path, self.allocator) catch |err| switch (err) {
+                        error.PluginFailed => null,
+                        error.OutOfMemory => return error.OutOfMemory,
+                    };
+                    // non-null이면 플러그인이 resolve 완료 → 기본 resolver 건너뜀
+                    if (resolve_result) |plugin_result| {
+                        try self.applyResolveResult(mod_idx, rec_i, record, plugin_result, false);
+                        continue;
+                    }
+                    // null이면 기본 resolver로 fall through
                 }
-                // null이면 기본 resolver로 fall through
             }
 
             const resolved = self.resolve_cache.resolve(

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -197,6 +197,12 @@ pub const ModuleGraph = struct {
     /// `graph.allocator` 소유. `ensureBuiltinPlugins` 에서 lazy 초기화 후 PluginRunner.init
     /// 호출 site 들이 이걸 참조.
     plugins_with_helpers: ?[]plugin_mod.Plugin = null,
+    /// 사용자 plugin 중 resolveId hook 보유 여부. false이면 helper virtual id 외 resolveId 호출을 생략.
+    has_user_resolve_id_plugins: bool = false,
+    /// 사용자 plugin 중 load hook 보유 여부. false이면 helper virtual id 외 load 호출을 생략.
+    has_user_load_plugins: bool = false,
+    /// 사용자 plugin 또는 builtin RN codegen transform 보유 여부. false이면 transform hook 호출을 생략.
+    has_transform_plugins: bool = false,
 
     pub const PkgInfo = struct {
         is_module: bool,
@@ -253,6 +259,15 @@ pub const ModuleGraph = struct {
     /// 도 같이 hydrate. 단일 thread 진입점 (`build` 등) 에서만 호출.
     fn ensureBuiltinPlugins(self: *ModuleGraph) void {
         if (self.plugins_with_helpers != null) return;
+        self.has_user_resolve_id_plugins = false;
+        self.has_user_load_plugins = false;
+        self.has_transform_plugins = self.codegen_transform;
+        for (self.plugins) |p| {
+            if (p.resolveId != null) self.has_user_resolve_id_plugins = true;
+            if (p.load != null) self.has_user_load_plugins = true;
+            if (p.transform != null) self.has_transform_plugins = true;
+        }
+
         // SourceOptions 는 빌드 옵션 기반으로 1회 결정.
         const u = self.transform_options_base.unsupported;
         self.helper_plugin_opts = .{
@@ -287,6 +302,14 @@ pub const ModuleGraph = struct {
         const list = self.plugins_with_helpers orelse self.plugins;
         if (list.len == 0) return null;
         return plugin_mod.PluginRunner.init(list);
+    }
+
+    fn shouldRunResolveId(self: *const ModuleGraph, specifier: []const u8) bool {
+        return self.has_user_resolve_id_plugins or runtime_helper_modules.isVirtualId(specifier);
+    }
+
+    fn shouldRunLoad(self: *const ModuleGraph, path: []const u8) bool {
+        return self.has_user_load_plugins or runtime_helper_modules.isVirtualId(path);
     }
 
     // ============================================================
@@ -1299,7 +1322,8 @@ pub const ModuleGraph = struct {
                 if (record.kind == .glob) continue;
                 if (record.kind == .require_context) continue;
 
-                if (plugin_runner) |runner| {
+                if (plugin_runner != null and self.shouldRunResolveId(record.specifier)) {
+                    const runner = plugin_runner.?;
                     const resolve_result = runner.runResolveId(record.specifier, module_path, self.allocator) catch |err| switch (err) {
                         error.PluginFailed => null,
                         error.OutOfMemory => {
@@ -1350,7 +1374,8 @@ pub const ModuleGraph = struct {
         // Plugin: load 훅 — 모든 module_type 분기 전에 플러그인에게 기회를 줌.
         // 플러그인이 내용을 반환하면 JS 모듈로 전환 (예: .css → JS export).
         var plugin_load_applied = false;
-        if (plugin_runner) |runner| {
+        if (plugin_runner != null and self.shouldRunLoad(module.path)) {
+            const runner = plugin_runner.?;
             // 임시 allocator로 load 결과만 확인 (성공 시 arena를 생성)
             var tmp_arena = std.heap.ArenaAllocator.init(self.allocator);
             const load_result = runner.runLoad(module.path, tmp_arena.allocator()) catch |err| switch (err) {
@@ -1547,7 +1572,8 @@ pub const ModuleGraph = struct {
         // 플러그인이 코드를 변환하면 변환된 소스로 파싱한다.
         // Babel 플러그인(예: react-native-reanimated/plugin)이 유저 코드를 변환할 수 있다.
         var plugin_transform_applied = false;
-        if (plugin_runner) |runner| {
+        if (plugin_runner != null and self.has_transform_plugins) {
+            const runner = plugin_runner.?;
             const transform_result = runner.runTransform(module.source, module.path, arena_alloc) catch |err| switch (err) {
                 error.PluginFailed => null,
                 error.OutOfMemory => {
@@ -2508,7 +2534,8 @@ pub const ModuleGraph = struct {
             if (record.kind == .require_context) continue;
 
             // Plugin: resolveId 훅 — 기본 resolver 전에 플러그인에게 경로 해석 기회를 줌
-            if (plugin_runner) |runner| {
+            if (plugin_runner != null and self.shouldRunResolveId(record.specifier)) {
+                const runner = plugin_runner.?;
                 const resolve_result = runner.runResolveId(record.specifier, module_path, self.allocator) catch |err| switch (err) {
                     error.PluginFailed => null,
                     error.OutOfMemory => return error.OutOfMemory,

--- a/src/bundler/resolver_test.zig
+++ b/src/bundler/resolver_test.zig
@@ -73,6 +73,37 @@ test "resolve: extension search (.ts)" {
     try std.testing.expect(pathEndsWith(result.path, "bar.ts"));
 }
 
+test "resolve: simple nested dot-relative path" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try createFile(tmp.dir, "nested/util.ts");
+
+    const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dir_path);
+
+    var resolver = Resolver.init(std.testing.allocator);
+    const result = try resolver.resolve(dir_path, "./nested/util");
+    defer std.testing.allocator.free(result.path);
+
+    try std.testing.expect(pathEndsWith(result.path, "nested/util.ts"));
+}
+
+test "resolve: normalized dot-relative path still supports parent segment" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try createFile(tmp.dir, "bar.ts");
+    try createFile(tmp.dir, "nested/entry.ts");
+
+    const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dir_path);
+
+    var resolver = Resolver.init(std.testing.allocator);
+    const result = try resolver.resolve(dir_path, "./nested/../bar");
+    defer std.testing.allocator.free(result.path);
+
+    try std.testing.expect(pathEndsWith(result.path, "bar.ts"));
+}
+
 test "resolve: extension search (.tsx before .js)" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/tests/benchmark/monorepo-fixture.test.ts
+++ b/tests/benchmark/monorepo-fixture.test.ts
@@ -1,0 +1,41 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { makeSyntheticMonorepo, parseProfileOutput } from "./monorepo-fixture";
+
+describe("monorepo benchmark fixture", () => {
+  test("workspace package graph를 결정론적으로 생성한다", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-monorepo-fixture-test-"));
+    try {
+      const fixture = makeSyntheticMonorepo(dir, { packageCount: 3, modulesPerPackage: 4 });
+
+      expect(fixture.moduleCount).toBe(16);
+      expect(fixture.packages).toEqual([
+        "@zts-fixture/pkg-0",
+        "@zts-fixture/pkg-1",
+        "@zts-fixture/pkg-2",
+      ]);
+      expect(readFileSync(fixture.entry, "utf8")).toContain(
+        'import { pkgValue as pkg2 } from "@zts-fixture/pkg-2";',
+      );
+      expect(readFileSync(join(dir, "packages", "pkg-2", "src", "mod-0.ts"), "utf8")).toContain(
+        'from "@zts-fixture/pkg-1"',
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("profile text에서 dotted phase 이름까지 파싱한다", () => {
+    const parsed = parseProfileOutput(
+      "total                              123.456ms  100.00%\n" +
+        "graph.discover.scan.worker         30.000ms   24.30%\n" +
+        "link                               10.500ms    8.50%\n",
+    );
+
+    expect(parsed.totalMs).toBe(123.456);
+    expect(parsed.phases["graph.discover.scan.worker"]).toBe(30);
+    expect(parsed.phases.link).toBe(10.5);
+  });
+});

--- a/tests/benchmark/monorepo-fixture.ts
+++ b/tests/benchmark/monorepo-fixture.ts
@@ -91,7 +91,11 @@ export function makeSyntheticMonorepo(
     const linkPath = join(root, "node_modules", "@zts-fixture", `pkg-${p}`);
     try {
       symlinkSync(relative(join(root, "node_modules", "@zts-fixture"), pkgDir), linkPath, "dir");
-    } catch {
+    } catch (err) {
+      // Windows 는 비-Admin 에서 dir symlink 가 EPERM, 같은 경로 재실행이면 EEXIST.
+      // 그 외 에러는 fixture 셋업 자체의 버그라 surface 시킨다.
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "EPERM" && code !== "EEXIST") throw err;
       const proxySrcDir = join(linkPath, "src");
       mkdirSync(proxySrcDir, { recursive: true });
       writeFileSync(

--- a/tests/benchmark/monorepo-fixture.ts
+++ b/tests/benchmark/monorepo-fixture.ts
@@ -1,0 +1,147 @@
+import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+export interface SyntheticMonorepoOptions {
+  packageCount: number;
+  modulesPerPackage: number;
+}
+
+export interface SyntheticMonorepoFixture {
+  entry: string;
+  moduleCount: number;
+  packageCount: number;
+  packages: string[];
+}
+
+export interface ProfileRun {
+  totalMs: number;
+  phases: Record<string, number>;
+}
+
+export function makeSyntheticMonorepo(
+  root: string,
+  options: SyntheticMonorepoOptions,
+): SyntheticMonorepoFixture {
+  if (options.packageCount < 1) throw new Error("packageCount must be >= 1");
+  if (options.modulesPerPackage < 1) throw new Error("modulesPerPackage must be >= 1");
+
+  mkdirSync(join(root, "apps", "app", "src"), { recursive: true });
+  mkdirSync(join(root, "packages"), { recursive: true });
+  mkdirSync(join(root, "node_modules", "@zts-fixture"), { recursive: true });
+
+  writeFileSync(
+    join(root, "package.json"),
+    JSON.stringify(
+      { private: true, workspaces: ["apps/*", "packages/*"], type: "module" },
+      null,
+      2,
+    ),
+  );
+  writeFileSync(
+    join(root, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: "es2020",
+          module: "esnext",
+          moduleResolution: "bundler",
+          strict: true,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  const packages: string[] = [];
+  for (let p = 0; p < options.packageCount; p++) {
+    const pkgName = `@zts-fixture/pkg-${p}`;
+    packages.push(pkgName);
+    const pkgDir = join(root, "packages", `pkg-${p}`);
+    const srcDir = join(pkgDir, "src");
+    mkdirSync(srcDir, { recursive: true });
+    writeFileSync(
+      join(pkgDir, "package.json"),
+      JSON.stringify(
+        { name: pkgName, version: "0.0.0", type: "module", exports: "./src/index.ts" },
+        null,
+        2,
+      ),
+    );
+
+    const indexLines: string[] = [];
+    for (let m = 0; m < options.modulesPerPackage; m++) {
+      const prevImport = m === 0 ? "" : `import { v${p}_${m - 1} } from "./mod-${m - 1}";\n`;
+      const crossImport =
+        m === 0 && p > 0
+          ? `import { pkgValue as prevPkgValue } from "@zts-fixture/pkg-${p - 1}";\n`
+          : "";
+      const prevValue = m === 0 ? (p > 0 ? "prevPkgValue" : "0") : `v${p}_${m - 1}`;
+      writeFileSync(
+        join(srcDir, `mod-${m}.ts`),
+        `${crossImport}${prevImport}export const v${p}_${m}: number = ${prevValue} + ${p + m + 1};\n`,
+      );
+      indexLines.push(`export { v${p}_${m} } from "./mod-${m}";`);
+    }
+    indexLines.push(
+      `export { v${p}_${options.modulesPerPackage - 1} as pkgValue } from "./mod-${options.modulesPerPackage - 1}";`,
+    );
+    writeFileSync(join(srcDir, "index.ts"), indexLines.join("\n") + "\n");
+
+    const linkPath = join(root, "node_modules", "@zts-fixture", `pkg-${p}`);
+    try {
+      symlinkSync(relative(join(root, "node_modules", "@zts-fixture"), pkgDir), linkPath, "dir");
+    } catch {
+      const proxySrcDir = join(linkPath, "src");
+      mkdirSync(proxySrcDir, { recursive: true });
+      writeFileSync(
+        join(linkPath, "package.json"),
+        JSON.stringify(
+          { name: pkgName, version: "0.0.0", type: "module", exports: "./src/index.ts" },
+          null,
+          2,
+        ),
+      );
+      writeFileSync(
+        join(proxySrcDir, "index.ts"),
+        `export * from "${relative(proxySrcDir, join(srcDir, "index.ts")).replaceAll("\\", "/")}";\n`,
+      );
+    }
+  }
+
+  const entryLines: string[] = [];
+  for (let p = 0; p < options.packageCount; p++) {
+    entryLines.push(`import { pkgValue as pkg${p} } from "@zts-fixture/pkg-${p}";`);
+  }
+  entryLines.push(
+    `console.log(${Array.from({ length: options.packageCount }, (_, p) => `pkg${p}`).join(" + ")});`,
+  );
+  const entry = join(root, "apps", "app", "src", "entry.ts");
+  writeFileSync(entry, entryLines.join("\n") + "\n");
+
+  return {
+    entry,
+    moduleCount: options.packageCount * options.modulesPerPackage + options.packageCount + 1,
+    packageCount: options.packageCount,
+    packages,
+  };
+}
+
+export function parseProfileOutput(output: string): ProfileRun {
+  const phases: Record<string, number> = {};
+  let totalMs = 0;
+
+  for (const line of output.split("\n")) {
+    const m = line.match(/^([\w.]+)\s+([\d.]+)ms\s+/);
+    if (!m) continue;
+    const [, phase, msStr] = m;
+    const ms = Number.parseFloat(msStr);
+    if (phase === "total") totalMs = ms;
+    else phases[phase] = ms;
+  }
+
+  if (totalMs === 0) {
+    throw new Error("profile output did not contain total phase");
+  }
+  return { totalMs, phases };
+}

--- a/tests/benchmark/monorepo-perf.ts
+++ b/tests/benchmark/monorepo-perf.ts
@@ -90,8 +90,7 @@ function parseArgs(argv: string[]): CliArgs {
     if ((v = take("--packages")) !== undefined) args.packages = parsePositiveInt("--packages", v);
     else if ((v = take("--modules-per-package")) !== undefined)
       args.modulesPerPackage = parsePositiveInt("--modules-per-package", v);
-    else if ((v = take("--warmup")) !== undefined)
-      args.warmup = parseNonNegativeInt("--warmup", v);
+    else if ((v = take("--warmup")) !== undefined) args.warmup = parseNonNegativeInt("--warmup", v);
     else if ((v = take("--iterations")) !== undefined)
       args.iterations = parsePositiveInt("--iterations", v);
     else if ((v = take("--output")) !== undefined) args.output = v;

--- a/tests/benchmark/monorepo-perf.ts
+++ b/tests/benchmark/monorepo-perf.ts
@@ -80,22 +80,23 @@ function parseArgs(argv: string[]): CliArgs {
 
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
-    if (a === "--packages") args.packages = parsePositiveInt(a, argv[++i]);
-    else if (a.startsWith("--packages="))
-      args.packages = parsePositiveInt("--packages", a.slice(11));
-    else if (a === "--modules-per-package") args.modulesPerPackage = parsePositiveInt(a, argv[++i]);
-    else if (a.startsWith("--modules-per-package=")) {
-      args.modulesPerPackage = parsePositiveInt("--modules-per-package", a.slice(22));
-    } else if (a === "--warmup") args.warmup = parseNonNegativeInt(a, argv[++i]);
-    else if (a.startsWith("--warmup=")) args.warmup = parseNonNegativeInt("--warmup", a.slice(9));
-    else if (a === "--iterations") args.iterations = parsePositiveInt(a, argv[++i]);
-    else if (a.startsWith("--iterations="))
-      args.iterations = parsePositiveInt("--iterations", a.slice(13));
-    else if (a === "--output") args.output = argv[++i] ?? null;
-    else if (a.startsWith("--output=")) args.output = a.slice(9);
+    const take = (name: string): string | undefined => {
+      if (a === name) return argv[++i];
+      const prefix = `${name}=`;
+      return a.startsWith(prefix) ? a.slice(prefix.length) : undefined;
+    };
+
+    let v: string | undefined;
+    if ((v = take("--packages")) !== undefined) args.packages = parsePositiveInt("--packages", v);
+    else if ((v = take("--modules-per-package")) !== undefined)
+      args.modulesPerPackage = parsePositiveInt("--modules-per-package", v);
+    else if ((v = take("--warmup")) !== undefined)
+      args.warmup = parseNonNegativeInt("--warmup", v);
+    else if ((v = take("--iterations")) !== undefined)
+      args.iterations = parsePositiveInt("--iterations", v);
+    else if ((v = take("--output")) !== undefined) args.output = v;
+    else if ((v = take("--keep-fixture")) !== undefined) args.keepFixture = v;
     else if (a === "--compare") args.compare = true;
-    else if (a === "--keep-fixture") args.keepFixture = argv[++i] ?? null;
-    else if (a.startsWith("--keep-fixture=")) args.keepFixture = a.slice(15);
     else throw new Error(`unknown arg: ${a}`);
   }
 
@@ -158,19 +159,19 @@ function runTool(tool: "zts" | "esbuild" | "rolldown", entry: string, outDir: st
   const bin = tool === "zts" ? ZTS_BIN : findBin(tool);
   if (!bin) throw new Error(`${tool} binary not found`);
 
+  const args: string[] = (() => {
+    switch (tool) {
+      case "zts":
+        return ["--bundle", "--format=esm", "--splitting", entry, "--outdir", outDir];
+      case "esbuild":
+        return [entry, "--bundle", "--format=esm", "--splitting", `--outdir=${outDir}`];
+      case "rolldown":
+        return [entry, "--dir", outDir];
+    }
+  })();
+
   const start = performance.now();
-  const r =
-    tool === "zts"
-      ? spawnSync(bin, ["--bundle", "--format=esm", "--splitting", entry, "--outdir", outDir], {
-          stdio: "pipe",
-          timeout: 120000,
-        })
-      : tool === "esbuild"
-        ? spawnSync(bin, [entry, "--bundle", "--format=esm", "--splitting", `--outdir=${outDir}`], {
-            stdio: "pipe",
-            timeout: 120000,
-          })
-        : spawnSync(bin, [entry, "--dir", outDir], { stdio: "pipe", timeout: 120000 });
+  const r = spawnSync(bin, args, { stdio: "pipe", timeout: 120000 });
   if (r.status !== 0) {
     throw new Error(`${tool} failed: ${r.stderr.toString().slice(0, 500)}`);
   }
@@ -294,10 +295,14 @@ async function main(cli: CliArgs) {
 
     const wallStats = computeMetricStats(wallTotals);
 
-    const profileRun = runZts(fixture.entry, join(tmp, "dist-profile"), true);
-    profileTotals.push(profileRun.totalMs);
-    for (const [phase, ms] of Object.entries(profileRun.phases)) {
-      (phaseSeries[phase] ??= []).push(ms);
+    // profile mode 는 instrumentation 오버헤드가 있어 wall 측정과 분리해 별도로 N회 돌린다.
+    // wall stats 는 위의 비-profile 측정으로 고정, phase 통계는 여기서만 산출.
+    for (let i = 0; i < cli.iterations; i++) {
+      const profileRun = runZts(fixture.entry, join(tmp, "dist-profile"), true);
+      profileTotals.push(profileRun.totalMs);
+      for (const [phase, ms] of Object.entries(profileRun.phases)) {
+        (phaseSeries[phase] ??= []).push(ms);
+      }
     }
     const profileTotalStats = computeMetricStats(profileTotals);
     const phaseMedianMs: Record<string, number> = {};

--- a/tests/benchmark/monorepo-perf.ts
+++ b/tests/benchmark/monorepo-perf.ts
@@ -1,0 +1,353 @@
+#!/usr/bin/env bun
+/**
+ * Synthetic monorepo bundle benchmark (#1749).
+ *
+ * 수천 모듈 + 여러 workspace package.json 조합에서 graph discovery/link phase가
+ * 선형으로 증가하는지 확인하기 위한 측정 스크립트다.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { makeSyntheticMonorepo, parseProfileOutput, type ProfileRun } from "./monorepo-fixture";
+import { computeMetricStats, formatMetric, type MetricStats } from "./stats";
+
+const ROOT = resolve(__dirname, "../..");
+const ZTS_BIN = join(ROOT, "zig-out/bin/zts");
+const WARMUP = 2;
+const ITERATIONS = 5;
+
+interface CliArgs {
+  packages: number;
+  modulesPerPackage: number;
+  warmup: number;
+  iterations: number;
+  compare: boolean;
+  output: string | null;
+  keepFixture: string | null;
+}
+
+interface RunReport {
+  version: number;
+  generated_at: string;
+  zts_commit: string;
+  fixture: {
+    packages: number;
+    modules_per_package: number;
+    module_count: number;
+  };
+  wall_ms_stats: JsonStats;
+  profile_total_ms_stats: JsonStats;
+  phase_median_ms: Record<string, number>;
+  top_phases: Array<{ phase: string; median_ms: number; percent_of_total: number }>;
+  tool_comparison?: ToolResult[];
+}
+
+interface JsonStats {
+  median: number;
+  mean: number;
+  min: number;
+  max: number;
+  p95: number;
+  trimmed_mean: number;
+}
+
+interface ToolResult {
+  tool: string;
+  wall_ms_stats: JsonStats | null;
+  ratio_vs_zts: number | null;
+}
+
+interface ZtsRun extends ProfileRun {
+  wallMs: number;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    packages: 50,
+    modulesPerPackage: 100,
+    warmup: WARMUP,
+    iterations: ITERATIONS,
+    compare: false,
+    output: null,
+    keepFixture: null,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--packages") args.packages = parsePositiveInt(a, argv[++i]);
+    else if (a.startsWith("--packages="))
+      args.packages = parsePositiveInt("--packages", a.slice(11));
+    else if (a === "--modules-per-package") args.modulesPerPackage = parsePositiveInt(a, argv[++i]);
+    else if (a.startsWith("--modules-per-package=")) {
+      args.modulesPerPackage = parsePositiveInt("--modules-per-package", a.slice(22));
+    } else if (a === "--warmup") args.warmup = parseNonNegativeInt(a, argv[++i]);
+    else if (a.startsWith("--warmup=")) args.warmup = parseNonNegativeInt("--warmup", a.slice(9));
+    else if (a === "--iterations") args.iterations = parsePositiveInt(a, argv[++i]);
+    else if (a.startsWith("--iterations="))
+      args.iterations = parsePositiveInt("--iterations", a.slice(13));
+    else if (a === "--output") args.output = argv[++i] ?? null;
+    else if (a.startsWith("--output=")) args.output = a.slice(9);
+    else if (a === "--compare") args.compare = true;
+    else if (a === "--keep-fixture") args.keepFixture = argv[++i] ?? null;
+    else if (a.startsWith("--keep-fixture=")) args.keepFixture = a.slice(15);
+    else throw new Error(`unknown arg: ${a}`);
+  }
+
+  return args;
+}
+
+function findBin(name: string): string | null {
+  const local = join(__dirname, "node_modules", ".bin", name);
+  if (existsSync(local)) return local;
+  const root = join(ROOT, "node_modules", ".bin", name);
+  if (existsSync(root)) return root;
+  return null;
+}
+
+function parsePositiveInt(name: string, raw: string | undefined): number {
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1) throw new Error(`${name} must be a positive integer`);
+  return n;
+}
+
+function parseNonNegativeInt(name: string, raw: string | undefined): number {
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0) throw new Error(`${name} must be a non-negative integer`);
+  return n;
+}
+
+function buildBin() {
+  if (existsSync(ZTS_BIN)) return;
+  console.log("[monorepo-perf] zts binary not found, building Release...");
+  const r = spawnSync("zig", ["build", "-Doptimize=ReleaseFast"], { cwd: ROOT, stdio: "inherit" });
+  if (r.status !== 0) throw new Error("zig build failed");
+}
+
+function getCommit(): string {
+  const r = spawnSync("git", ["rev-parse", "--short", "HEAD"], { cwd: ROOT, stdio: "pipe" });
+  return r.stdout.toString().trim() || "unknown";
+}
+
+function runZts(entry: string, outDir: string): ZtsRun {
+  rmSync(outDir, { recursive: true, force: true });
+  mkdirSync(outDir, { recursive: true });
+  const start = performance.now();
+  const r = spawnSync(
+    ZTS_BIN,
+    ["--bundle", "--format=esm", "--splitting", entry, "--outdir", outDir, "--profile=all"],
+    { stdio: "pipe", timeout: 120000 },
+  );
+  const wallMs = performance.now() - start;
+  if (r.status !== 0) {
+    throw new Error(`zts failed: ${r.stderr.toString().slice(0, 800)}`);
+  }
+  return { ...parseProfileOutput(`${r.stdout.toString()}\n${r.stderr.toString()}`), wallMs };
+}
+
+function runTool(tool: "esbuild" | "rolldown", entry: string, outDir: string): number {
+  rmSync(outDir, { recursive: true, force: true });
+  mkdirSync(outDir, { recursive: true });
+
+  const bin = findBin(tool);
+  if (!bin) throw new Error(`${tool} binary not found`);
+
+  const start = performance.now();
+  const r =
+    tool === "esbuild"
+      ? spawnSync(bin, [entry, "--bundle", "--format=esm", "--splitting", `--outdir=${outDir}`], {
+          stdio: "pipe",
+          timeout: 120000,
+        })
+      : spawnSync(bin, [entry, "--dir", outDir], { stdio: "pipe", timeout: 120000 });
+  if (r.status !== 0) {
+    throw new Error(`${tool} failed: ${r.stderr.toString().slice(0, 500)}`);
+  }
+  return performance.now() - start;
+}
+
+function toJsonStats(stats: MetricStats): JsonStats {
+  return {
+    median: stats.median,
+    mean: stats.mean,
+    min: stats.min,
+    max: stats.max,
+    p95: stats.p95,
+    trimmed_mean: stats.trimmedMean,
+  };
+}
+
+function topPhases(
+  phaseMedianMs: Record<string, number>,
+  totalMedianMs: number,
+): Array<{ phase: string; median_ms: number; percent_of_total: number }> {
+  return Object.entries(phaseMedianMs)
+    .map(([phase, median_ms]) => ({
+      phase,
+      median_ms,
+      percent_of_total: totalMedianMs === 0 ? 0 : (median_ms / totalMedianMs) * 100,
+    }))
+    .sort((a, b) => b.median_ms - a.median_ms)
+    .slice(0, 12);
+}
+
+function printMarkdown(report: RunReport) {
+  console.log("\n### monorepo-perf — synthetic workspace");
+  console.log(
+    "| Packages | Modules/pkg | Total modules | Wall median | Wall trimmed mean | Wall p95 | Profile total median |",
+  );
+  console.log(
+    "|----------|-------------|---------------|-------------|-------------------|----------|----------------------|",
+  );
+  console.log(
+    `| ${report.fixture.packages} | ${report.fixture.modules_per_package} | ${report.fixture.module_count} | ${formatMetric(report.wall_ms_stats.median)} | ${formatMetric(report.wall_ms_stats.trimmed_mean)} | ${formatMetric(report.wall_ms_stats.p95)} | ${formatMetric(report.profile_total_ms_stats.median)} |`,
+  );
+
+  console.log("\n| Top phase | Median | % of total |");
+  console.log("|-----------|--------|------------|");
+  for (const p of report.top_phases) {
+    console.log(
+      `| ${p.phase} | ${formatMetric(p.median_ms)} | ${p.percent_of_total.toFixed(1)}% |`,
+    );
+  }
+
+  if (report.tool_comparison) {
+    console.log("\n| Tool | Median | Trimmed mean | p95 | vs ZTS |");
+    console.log("|------|--------|--------------|-----|--------|");
+    for (const tool of report.tool_comparison) {
+      if (!tool.wall_ms_stats) {
+        console.log(`| ${tool.tool} | FAIL | - | - | - |`);
+        continue;
+      }
+      console.log(
+        `| ${tool.tool} | ${formatMetric(tool.wall_ms_stats.median)} | ${formatMetric(tool.wall_ms_stats.trimmed_mean)} | ${formatMetric(tool.wall_ms_stats.p95)} | ${tool.ratio_vs_zts?.toFixed(2)}x |`,
+      );
+    }
+  }
+}
+
+function measureComparisonTool(
+  tool: "esbuild" | "rolldown",
+  entry: string,
+  outDir: string,
+  warmup: number,
+  iterations: number,
+  ztsMedianMs: number,
+): ToolResult {
+  try {
+    for (let i = 0; i < warmup; i++) runTool(tool, entry, outDir);
+    const times: number[] = [];
+    for (let i = 0; i < iterations; i++) {
+      times.push(runTool(tool, entry, outDir));
+    }
+    const stats = computeMetricStats(times);
+    return {
+      tool,
+      wall_ms_stats: toJsonStats(stats),
+      ratio_vs_zts: ztsMedianMs === 0 ? null : stats.median / ztsMedianMs,
+    };
+  } catch (err) {
+    console.error(
+      `[monorepo-perf] ${tool} skipped: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { tool, wall_ms_stats: null, ratio_vs_zts: null };
+  }
+}
+
+async function main(cli: CliArgs) {
+  buildBin();
+  const tmp = cli.keepFixture ?? mkdtempSync(join(tmpdir(), "zts-monorepo-perf-"));
+  if (cli.keepFixture) mkdirSync(tmp, { recursive: true });
+
+  try {
+    const fixture = makeSyntheticMonorepo(tmp, {
+      packageCount: cli.packages,
+      modulesPerPackage: cli.modulesPerPackage,
+    });
+    const outDir = join(tmp, "dist");
+
+    console.log(
+      `[monorepo-perf] zts ${getCommit()} | packages=${cli.packages} modules/pkg=${cli.modulesPerPackage} total_modules=${fixture.moduleCount} warmup=${cli.warmup} iter=${cli.iterations}`,
+    );
+
+    for (let i = 0; i < cli.warmup; i++) runZts(fixture.entry, outDir);
+
+    const wallTotals: number[] = [];
+    const profileTotals: number[] = [];
+    const phaseSeries: Record<string, number[]> = {};
+    for (let i = 0; i < cli.iterations; i++) {
+      const r = runZts(fixture.entry, outDir);
+      wallTotals.push(r.wallMs);
+      profileTotals.push(r.totalMs);
+      for (const [phase, ms] of Object.entries(r.phases)) {
+        (phaseSeries[phase] ??= []).push(ms);
+      }
+      console.log(
+        `  run ${i + 1}/${cli.iterations}: wall=${formatMetric(r.wallMs)} profile_total=${formatMetric(r.totalMs)}`,
+      );
+    }
+
+    const wallStats = computeMetricStats(wallTotals);
+    const profileTotalStats = computeMetricStats(profileTotals);
+    const phaseMedianMs: Record<string, number> = {};
+    for (const [phase, series] of Object.entries(phaseSeries)) {
+      phaseMedianMs[phase] = computeMetricStats(series).median;
+    }
+
+    const report: RunReport = {
+      version: 1,
+      generated_at: new Date().toISOString(),
+      zts_commit: getCommit(),
+      fixture: {
+        packages: cli.packages,
+        modules_per_package: cli.modulesPerPackage,
+        module_count: fixture.moduleCount,
+      },
+      wall_ms_stats: toJsonStats(wallStats),
+      profile_total_ms_stats: toJsonStats(profileTotalStats),
+      phase_median_ms: phaseMedianMs,
+      top_phases: topPhases(phaseMedianMs, profileTotalStats.median),
+    };
+
+    if (cli.compare) {
+      report.tool_comparison = [
+        {
+          tool: "zts",
+          wall_ms_stats: toJsonStats(wallStats),
+          ratio_vs_zts: 1,
+        },
+        measureComparisonTool(
+          "esbuild",
+          fixture.entry,
+          join(tmp, "dist-esbuild"),
+          cli.warmup,
+          cli.iterations,
+          wallStats.median,
+        ),
+        measureComparisonTool(
+          "rolldown",
+          fixture.entry,
+          join(tmp, "dist-rolldown"),
+          cli.warmup,
+          cli.iterations,
+          wallStats.median,
+        ),
+      ];
+    }
+
+    printMarkdown(report);
+
+    if (cli.output) {
+      writeFileSync(cli.output, JSON.stringify(report, null, 2) + "\n");
+      console.log(`\n[monorepo-perf] report written: ${cli.output}`);
+    }
+    if (cli.keepFixture) {
+      console.log(`[monorepo-perf] fixture kept: ${tmp}`);
+    }
+  } finally {
+    if (!cli.keepFixture) rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+await main(parseArgs(process.argv.slice(2)));

--- a/tests/benchmark/monorepo-perf.ts
+++ b/tests/benchmark/monorepo-perf.ts
@@ -63,6 +63,10 @@ interface ZtsRun extends ProfileRun {
   wallMs: number;
 }
 
+interface WallRun {
+  wallMs: number;
+}
+
 function parseArgs(argv: string[]): CliArgs {
   const args: CliArgs = {
     packages: 50,
@@ -130,41 +134,47 @@ function getCommit(): string {
   return r.stdout.toString().trim() || "unknown";
 }
 
-function runZts(entry: string, outDir: string): ZtsRun {
+function runZts(entry: string, outDir: string, profile: boolean): ZtsRun {
   rmSync(outDir, { recursive: true, force: true });
   mkdirSync(outDir, { recursive: true });
+  const args = ["--bundle", "--format=esm", "--splitting", entry, "--outdir", outDir];
+  if (profile) args.push("--profile=all");
   const start = performance.now();
-  const r = spawnSync(
-    ZTS_BIN,
-    ["--bundle", "--format=esm", "--splitting", entry, "--outdir", outDir, "--profile=all"],
-    { stdio: "pipe", timeout: 120000 },
-  );
+  const r = spawnSync(ZTS_BIN, args, { stdio: "pipe", timeout: 120000 });
   const wallMs = performance.now() - start;
   if (r.status !== 0) {
     throw new Error(`zts failed: ${r.stderr.toString().slice(0, 800)}`);
   }
-  return { ...parseProfileOutput(`${r.stdout.toString()}\n${r.stderr.toString()}`), wallMs };
+  const parsed = profile
+    ? parseProfileOutput(`${r.stdout.toString()}\n${r.stderr.toString()}`)
+    : { totalMs: 0, phases: {} };
+  return { ...parsed, wallMs };
 }
 
-function runTool(tool: "esbuild" | "rolldown", entry: string, outDir: string): number {
+function runTool(tool: "zts" | "esbuild" | "rolldown", entry: string, outDir: string): WallRun {
   rmSync(outDir, { recursive: true, force: true });
   mkdirSync(outDir, { recursive: true });
 
-  const bin = findBin(tool);
+  const bin = tool === "zts" ? ZTS_BIN : findBin(tool);
   if (!bin) throw new Error(`${tool} binary not found`);
 
   const start = performance.now();
   const r =
-    tool === "esbuild"
-      ? spawnSync(bin, [entry, "--bundle", "--format=esm", "--splitting", `--outdir=${outDir}`], {
+    tool === "zts"
+      ? spawnSync(bin, ["--bundle", "--format=esm", "--splitting", entry, "--outdir", outDir], {
           stdio: "pipe",
           timeout: 120000,
         })
-      : spawnSync(bin, [entry, "--dir", outDir], { stdio: "pipe", timeout: 120000 });
+      : tool === "esbuild"
+        ? spawnSync(bin, [entry, "--bundle", "--format=esm", "--splitting", `--outdir=${outDir}`], {
+            stdio: "pipe",
+            timeout: 120000,
+          })
+        : spawnSync(bin, [entry, "--dir", outDir], { stdio: "pipe", timeout: 120000 });
   if (r.status !== 0) {
     throw new Error(`${tool} failed: ${r.stderr.toString().slice(0, 500)}`);
   }
-  return performance.now() - start;
+  return { wallMs: performance.now() - start };
 }
 
 function toJsonStats(stats: MetricStats): JsonStats {
@@ -228,7 +238,7 @@ function printMarkdown(report: RunReport) {
 }
 
 function measureComparisonTool(
-  tool: "esbuild" | "rolldown",
+  tool: "zts" | "esbuild" | "rolldown",
   entry: string,
   outDir: string,
   warmup: number,
@@ -239,7 +249,7 @@ function measureComparisonTool(
     for (let i = 0; i < warmup; i++) runTool(tool, entry, outDir);
     const times: number[] = [];
     for (let i = 0; i < iterations; i++) {
-      times.push(runTool(tool, entry, outDir));
+      times.push(runTool(tool, entry, outDir).wallMs);
     }
     const stats = computeMetricStats(times);
     return {
@@ -271,24 +281,24 @@ async function main(cli: CliArgs) {
       `[monorepo-perf] zts ${getCommit()} | packages=${cli.packages} modules/pkg=${cli.modulesPerPackage} total_modules=${fixture.moduleCount} warmup=${cli.warmup} iter=${cli.iterations}`,
     );
 
-    for (let i = 0; i < cli.warmup; i++) runZts(fixture.entry, outDir);
+    for (let i = 0; i < cli.warmup; i++) runZts(fixture.entry, outDir, false);
 
     const wallTotals: number[] = [];
     const profileTotals: number[] = [];
     const phaseSeries: Record<string, number[]> = {};
     for (let i = 0; i < cli.iterations; i++) {
-      const r = runZts(fixture.entry, outDir);
+      const r = runZts(fixture.entry, outDir, false);
       wallTotals.push(r.wallMs);
-      profileTotals.push(r.totalMs);
-      for (const [phase, ms] of Object.entries(r.phases)) {
-        (phaseSeries[phase] ??= []).push(ms);
-      }
-      console.log(
-        `  run ${i + 1}/${cli.iterations}: wall=${formatMetric(r.wallMs)} profile_total=${formatMetric(r.totalMs)}`,
-      );
+      console.log(`  run ${i + 1}/${cli.iterations}: wall=${formatMetric(r.wallMs)}`);
     }
 
     const wallStats = computeMetricStats(wallTotals);
+
+    const profileRun = runZts(fixture.entry, join(tmp, "dist-profile"), true);
+    profileTotals.push(profileRun.totalMs);
+    for (const [phase, ms] of Object.entries(profileRun.phases)) {
+      (phaseSeries[phase] ??= []).push(ms);
+    }
     const profileTotalStats = computeMetricStats(profileTotals);
     const phaseMedianMs: Record<string, number> = {};
     for (const [phase, series] of Object.entries(phaseSeries)) {
@@ -312,11 +322,14 @@ async function main(cli: CliArgs) {
 
     if (cli.compare) {
       report.tool_comparison = [
-        {
-          tool: "zts",
-          wall_ms_stats: toJsonStats(wallStats),
-          ratio_vs_zts: 1,
-        },
+        measureComparisonTool(
+          "zts",
+          fixture.entry,
+          join(tmp, "dist-zts-compare"),
+          cli.warmup,
+          cli.iterations,
+          wallStats.median,
+        ),
         measureComparisonTool(
           "esbuild",
           fixture.entry,

--- a/tests/benchmark/package.json
+++ b/tests/benchmark/package.json
@@ -6,6 +6,7 @@
     "bench": "bun run bench.ts",
     "bench:transpile": "bun run bench.ts --transpile",
     "bench:bundle": "bun run bench.ts --bundle",
+    "bench:monorepo": "bun run monorepo-perf.ts",
     "bench:minify": "bun run minify-bench.ts",
     "pipeline": "bun run pipeline.ts"
   },


### PR DESCRIPTION
## 요약
- #1749용 합성 monorepo fixture 생성기와 `monorepo-perf.ts` 벤치마크를 추가했습니다.
- 기본값은 50 packages × 100 modules/package로 총 5051개 모듈을 생성합니다.
- ZTS wall time 비교에서는 `--profile=all`을 제거하고, profile은 별도 diagnostic run으로 분리했습니다.
- 사용자 plugin hook이 없을 때 builtin runtime helper plugin의 no-op `resolveId`/`load`/`transform` 호출을 건너뜁니다.
- `--compare` 옵션으로 같은 fixture를 esbuild/rolldown과 비교하고, JSON report와 markdown table을 출력합니다.
- symlink가 막힌 환경에서는 node_modules proxy package fallback으로 bare workspace import가 계속 동작하게 했습니다.

Fixes #1749

## 병목 분석
- 처음 비교는 ZTS만 `--profile=all`을 켠 wall time을 esbuild/rolldown과 비교하고 있어 불공정했습니다. 이 PR에서 wall 측정과 profile 측정을 분리했습니다.
- 공정 비교 후에도 큰 fixture에서 ZTS가 Rolldown보다 느립니다. profile 상위는 계속 `resolve`이며, 10101 모듈 기준 thread-summed `resolve` median이 3824ms입니다.
- 출력 비교상 Rolldown은 re-export 체인의 중간 모듈을 더 강하게 접고 출력도 더 작습니다. 5051 모듈 fixture에서 ZTS 출력은 약 305KB, Rolldown 출력은 약 33KB였습니다. 즉 남은 격차는 단순 hook overhead보다 resolve/tree-shaking 정밀도 쪽이 더 큽니다.
- 시도 후 버린 변경: relative resolve cache 우회, browser relative override skip, 단순 dot-relative path join fast path. 측정 이득이 없거나 악화되어 남기지 않았습니다.

## 측정 결과
명령:
```bash
bun run tests/benchmark/monorepo-perf.ts --packages=50 --modules-per-package=100 --warmup=1 --iterations=7 --compare --output /tmp/zts-monorepo-5000-final-plugin-only.json
bun run tests/benchmark/monorepo-perf.ts --packages=100 --modules-per-package=100 --warmup=1 --iterations=5 --compare --output /tmp/zts-monorepo-10000-final-plugin-only.json
```

5051 modules:
- ZTS main wall median: 292ms
- ZTS tool-comparison median: 278ms
- esbuild median: 249ms
- rolldown median: 243ms
- profile total median: 9047ms (thread-summed/internal profile, wall 비교용 아님)
- top profile: resolve 1854ms, graph 172ms, parse 18.2ms, emit 12.7ms

10101 modules:
- ZTS main wall median: 508ms
- ZTS tool-comparison median: 528ms
- esbuild median: 459ms
- rolldown median: 383ms
- profile total median: 17606ms (thread-summed/internal profile, wall 비교용 아님)
- top profile: resolve 3824ms, graph 335ms, parse 39.1ms, emit 23.9ms

#1749 성공 조건 기준:
- 5000 module bundle 2초 이하: 충족
- esbuild/rolldown 대비 2x 이내: 충족
- Rolldown보다 빠름: 아직 미충족. 다음 병목은 re-export/tree-shaking 정밀도와 resolve work 절감입니다.

## 검증
- `zig build test --summary all --prominent-compile-errors`
- `zig build -Doptimize=ReleaseFast --summary all`
- `bun test tests/benchmark/monorepo-fixture.test.ts tests/benchmark/stats.test.ts`
- `bun run tests/benchmark/monorepo-perf.ts --packages=50 --modules-per-package=100 --warmup=1 --iterations=7 --compare --output /tmp/zts-monorepo-5000-final-plugin-only.json`
- `bun run tests/benchmark/monorepo-perf.ts --packages=100 --modules-per-package=100 --warmup=1 --iterations=5 --compare --output /tmp/zts-monorepo-10000-final-plugin-only.json`
- `git diff --check`
- `bunx oxfmt --check tests/benchmark/monorepo-perf.ts`
- pre-push hook: `zig build test`, `oxlint`, `oxfmt --check` 통과 (기존 unrelated oxlint warning 3개만 출력)