### PR TITLE
docs: Astro CLI 옵션 문서 동기화

### DIFF
--- a/documents/src/content/docs/en/guides/migration.md
+++ b/documents/src/content/docs/en/guides/migration.md
@@ -9,64 +9,67 @@ ZTS provides a similar bundling model to esbuild, but the CLI flag surface is st
 
 ### CLI option mapping
 
-| esbuild | ZTS | Note |
-|---------|-----|------|
-| `esbuild src/index.ts --bundle` | `zts --bundle src/index.ts` | Same |
-| `--outfile=dist/out.js` | `-o dist/out.js` | Short form supported |
-| `--outdir=dist` | `--outdir dist` | Same |
-| `--outbase=src` | `--outbase=src` | Same |
-| `--format=esm` | `--format=esm` | Same (esm/cjs/iife/umd/amd) |
-| `--platform=node` | `--platform=node` | Same (browser/node/neutral/react-native) |
-| `--target=es2020` | `--target=es2020` | Same (engine targets: `chrome80`, `node20`) |
-| `--bundle` | `--bundle` | Same |
-| `--splitting` | `--splitting` | Same (`--outdir` required) |
-| `--packages=external` | Not supported | Repeat `--external` for individual packages |
-| `--external:react` | `--external react` | Space instead of `:` |
-| `--minify` | `--minify` | Same (`--minify-{whitespace,syntax,identifiers}` granular) |
-| `--sourcemap` | `--sourcemap` | Same |
-| (config only: `sourceRoot`) | `--source-root=...` | ZTS exposes as CLI flag |
-| `--sources-content=false` | `--sources-content=false` | Same |
-| `--define:X=Y` | `--define:X=Y` | Same |
-| `--alias:react=preact/compat` | `--alias:react=preact/compat` | Same |
-| `--inject:./shim.js` | `--inject:./shim.js` | Same |
-| `--pure:Pure.*` | Not supported | Use code annotations such as `/* @__PURE__ */` |
-| `--drop:console` | `--drop=console` | `=` instead of `:` (`console`/`debugger`) |
-| `--drop-labels=DEV` | `--drop-labels=DEV` | Same. Use commas for multiple labels |
-| `--keep-names` | `--keep-names` | Same |
-| `--banner:js=...` | `--banner:js=...` | Same |
-| `--footer:js=...` | `--footer:js=...` | Same |
-| `--global-name=foo` | `--global-name=foo` | IIFE/UMD global name |
-| `--public-path=/static/` | `--public-path=/static/` | Same |
-| `--out-extension:.js=.mjs` | `--out-extension:.js=.mjs` | Same |
-| `--entry-names=[name]-[hash]` | `--entry-names=[name]-[hash]` | Same |
-| `--chunk-names=chunks/[hash]` | `--chunk-names=chunks/[hash]` | Same |
-| `--asset-names=assets/[hash]` | `--asset-names=assets/[hash]` | Same |
-| `--loader:.css=text` | `--loader:.css=text` | Same (`text`/`file`/`dataurl`/`json`/`copy`) |
-| `--jsx=automatic` | `--jsx=automatic` | Same (`classic`/`automatic`/`automatic-dev`) |
-| `--jsx-dev` | `--jsx-dev` | Same |
-| `--jsx-factory=h` | `--jsx-factory=h` | Same |
-| `--jsx-fragment=Fragment` | `--jsx-fragment=Fragment` | Same |
-| `--jsx-import-source=preact` | `--jsx-import-source=preact` | Same |
-| `--jsx-side-effects` | Not supported | Use the default JSX DCE policy |
-| `--tsconfig=tsconfig.json` | `-p tsconfig.json` or `--tsconfig-path=...` | `-p` short form |
-| `--tsconfig-raw='{...}'` | Not supported | Use file-based `-p` / `--project` |
-| `--conditions=prod,foo` | Not supported | Uses the resolver's default conditions |
-| `--main-fields=browser,main` | `--main-fields=browser,main` | Same |
-| `--resolve-extensions=.ts,.js` | `--resolve-extensions=.ts,.js` | Same (RN `.ios.ts` etc.) |
-| `--preserve-symlinks` | `--preserve-symlinks` | Same |
-| `--node-paths=...` | Not supported | Use standard node_modules resolution or aliases |
-| `--charset=utf8` | `--charset=utf8` | Same (preserve UTF-8) |
-| `--charset=ascii` | `--ascii-only` | ZTS uses dedicated flag; escapes non-ASCII to `\uXXXX` |
-| `--legal-comments=eof` | `--legal-comments=eof` | Same (`none`/`inline`/`eof`/`linked`/`external`) |
-| `--metafile=meta.json` | `--metafile=meta.json` | Same |
-| `--analyze` | `--analyze` | Same (JSON now, tree format planned) |
-| `--log-level=warning` | `--log-level=warning` | Same (`silent`/`error`/`warning`/`info`/`debug`) |
-| `--log-limit=10` | `--log-limit=10` | Same |
-| `--line-limit=80` | `--line-limit=80` | Same (wraps long output lines at safe token boundaries) |
-| `--ignore-annotations` | Not supported | Uses default annotation handling |
-| `--allow-overwrite` | `--allow-overwrite` | Input=output is blocked by default; this flag explicitly permits it |
-| `--watch` | `--watch` or `-w` | Same |
-| `--serve` | `--serve` | Same (`--port` supported) |
+| esbuild                         | ZTS                                         | Note                                                                |
+| ------------------------------- | ------------------------------------------- | ------------------------------------------------------------------- |
+| `esbuild src/index.ts --bundle` | `zts --bundle src/index.ts`                 | Same                                                                |
+| `--outfile=dist/out.js`         | `-o dist/out.js`                            | Short form supported                                                |
+| `--outdir=dist`                 | `--outdir dist`                             | Same                                                                |
+| `--outbase=src`                 | `--outbase=src`                             | Same                                                                |
+| `--format=esm`                  | `--format=esm`                              | Same (esm/cjs/iife/umd/amd)                                         |
+| `--platform=node`               | `--platform=node`                           | Same (browser/node/neutral/react-native)                            |
+| `--target=es2020`               | `--target=es2020`                           | Same (engine targets: `chrome80`, `node20`)                         |
+| `--bundle`                      | `--bundle`                                  | Same                                                                |
+| `--splitting`                   | `--splitting`                               | Same (`--outdir` required)                                          |
+| `--packages=external`           | `--packages=external`                       | Treat all bare package imports as external                          |
+| `--external:react`              | `--external react`                          | Space instead of `:`                                                |
+| `--minify`                      | `--minify`                                  | Same (`--minify-{whitespace,syntax,identifiers}` granular)          |
+| `--sourcemap`                   | `--sourcemap`                               | Same                                                                |
+| (config only: `sourceRoot`)     | `--source-root=...`                         | ZTS exposes as CLI flag                                             |
+| `--sources-content=false`       | `--sources-content=false`                   | Same                                                                |
+| `--define:X=Y`                  | `--define:X=Y`                              | Same                                                                |
+| `--alias:react=preact/compat`   | `--alias:react=preact/compat`               | Same                                                                |
+| `--inject:./shim.js`            | `--inject:./shim.js`                        | Same                                                                |
+| `--pure:Pure.*`                 | `--pure:Pure.*`                             | Register a pure call pattern                                        |
+| `--drop:console`                | `--drop=console`                            | `=` instead of `:` (`console`/`debugger`)                           |
+| `--drop-labels=DEV`             | `--drop-labels=DEV`                         | Same. Use commas for multiple labels                                |
+| `--keep-names`                  | `--keep-names`                              | Same                                                                |
+| `--banner:js=...`               | `--banner:js=...`                           | Same                                                                |
+| `--footer:js=...`               | `--footer:js=...`                           | Same                                                                |
+| `--intro=...`                   | `--intro=...`                               | Insert text before bundle code inside the wrapper                   |
+| `--outro=...`                   | `--outro=...`                               | Insert text after bundle code inside the wrapper                    |
+| `--global-name=foo`             | `--global-name=foo`                         | IIFE/UMD global name                                                |
+| `--global:react=React`          | `--global:react=React`                      | external specifier → IIFE/UMD global                                |
+| `--public-path=/static/`        | `--public-path=/static/`                    | Same                                                                |
+| `--out-extension:.js=.mjs`      | `--out-extension:.js=.mjs`                  | Same                                                                |
+| `--entry-names=[name]-[hash]`   | `--entry-names=[name]-[hash]`               | Same                                                                |
+| `--chunk-names=chunks/[hash]`   | `--chunk-names=chunks/[hash]`               | Same                                                                |
+| `--asset-names=assets/[hash]`   | `--asset-names=assets/[hash]`               | Same                                                                |
+| `--loader:.css=text`            | `--loader:.css=text`                        | Same (`text`/`file`/`dataurl`/`json`/`copy`)                        |
+| `--jsx=automatic`               | `--jsx=automatic`                           | Same (`classic`/`automatic`/`automatic-dev`)                        |
+| `--jsx-dev`                     | `--jsx-dev`                                 | Same                                                                |
+| `--jsx-factory=h`               | `--jsx-factory=h`                           | Same                                                                |
+| `--jsx-fragment=Fragment`       | `--jsx-fragment=Fragment`                   | Same                                                                |
+| `--jsx-import-source=preact`    | `--jsx-import-source=preact`                | Same                                                                |
+| `--jsx-side-effects`            | `--jsx-side-effects`                        | Preserve unused JSX expressions                                     |
+| `--tsconfig=tsconfig.json`      | `-p tsconfig.json` or `--tsconfig-path=...` | `-p` short form                                                     |
+| `--tsconfig-raw='{...}'`        | `--tsconfig-raw='{...}'`                    | Inline tsconfig JSON                                                |
+| `--conditions=prod,foo`         | `--conditions=prod,foo`                     | Keep default conditions and add custom ones                         |
+| `--main-fields=browser,main`    | `--main-fields=browser,main`                | Same                                                                |
+| `--resolve-extensions=.ts,.js`  | `--resolve-extensions=.ts,.js`              | Same (RN `.ios.ts` etc.)                                            |
+| `--preserve-symlinks`           | `--preserve-symlinks`                       | Same                                                                |
+| `--node-paths=...`              | `--node-paths=...`                          | Additional lookup paths for bare specifiers                         |
+| `--charset=utf8`                | `--charset=utf8`                            | Same (preserve UTF-8)                                               |
+| `--charset=ascii`               | `--ascii-only`                              | ZTS uses dedicated flag; escapes non-ASCII to `\uXXXX`              |
+| `--legal-comments=eof`          | `--legal-comments=eof`                      | Same (`none`/`inline`/`eof`/`linked`/`external`)                    |
+| `--metafile=meta.json`          | `--metafile=meta.json`                      | Same                                                                |
+| `--analyze`                     | `--analyze`                                 | Same (JSON now, tree format planned)                                |
+| `--log-level=warning`           | `--log-level=warning`                       | Same (`silent`/`error`/`warning`/`info`/`debug`)                    |
+| `--log-limit=10`                | `--log-limit=10`                            | Same                                                                |
+| `--line-limit=80`               | `--line-limit=80`                           | Same (wraps long output lines at safe token boundaries)             |
+| `--ignore-annotations`          | `--ignore-annotations`                      | Ignore pure/sideEffects annotations                                 |
+| `--allow-overwrite`             | `--allow-overwrite`                         | Input=output is blocked by default; this flag explicitly permits it |
+| `--watch`                       | `--watch` or `-w`                           | Same                                                                |
+| `--serve`                       | `--serve`                                   | Same (`--port` supported)                                           |
 
 ### esbuild Build API migration
 
@@ -101,11 +104,11 @@ ZTS native plugins use the **esbuild-style** `setup(build)` structure directly. 
 const myPlugin = {
   name: 'my-plugin',
   setup(build) {
-    build.onResolve({ filter: /^virtual:/ }, args => ({
+    build.onResolve({ filter: /^virtual:/ }, (args) => ({
       path: args.path,
       namespace: 'virtual',
     }));
-    build.onLoad({ filter: /.*/, namespace: 'virtual' }, args => ({
+    build.onLoad({ filter: /.*/, namespace: 'virtual' }, (args) => ({
       contents: 'export default 42',
       loader: 'js',
     }));
@@ -118,10 +121,10 @@ import type { ZtsPlugin } from '@zts/core';
 const myPlugin: ZtsPlugin = {
   name: 'my-plugin',
   setup(build) {
-    build.onResolve({ filter: /^virtual:/ }, args => ({
+    build.onResolve({ filter: /^virtual:/ }, (args) => ({
       path: '\0' + args.path,
     }));
-    build.onLoad({ filter: /^\0virtual:/ }, args => ({
+    build.onLoad({ filter: /^\0virtual:/ }, (args) => ({
       contents: 'export default 42',
     }));
   },
@@ -152,20 +155,20 @@ export default defineConfig({
 
 ### Unsupported esbuild options
 
-| esbuild option | Alternative |
-|-------------|------|
-| `--mangle-props=<regex>` | Not supported (mangling limited to `--minify-identifiers` on internal names) |
-| `--mangle-cache=<path>` | Not supported |
-| `--mangle-quoted` | Not supported |
-| `--analyze` (tree format) | `--analyze` (JSON only, tree format planned) |
-| `--servedir=<path>` | `--serve <dir>` (positional arg) |
-| `--bundle=false` (off by default) | Same default. ZTS transpiles only without `--bundle` |
-| `--splitting=false` | Off by default. No flag means default |
-| `--tree-shaking=false` | Not supported. Per-package `--external` can reduce bundle scope |
-| `--color=true|false` | Not supported. Auto-detected from terminal |
-| `--log-override:X=Y` | Not supported. Only `--log-level` |
-| `--supported:bigint=false` | Not supported. Use `--target` for global control |
-| `--reserve-props=<regex>` | Not supported |
+| esbuild option                    | Alternative                                                                  |
+| --------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------ |
+| `--mangle-props=<regex>`          | Not supported (mangling limited to `--minify-identifiers` on internal names) |
+| `--mangle-cache=<path>`           | Not supported                                                                |
+| `--mangle-quoted`                 | Not supported                                                                |
+| `--analyze` (tree format)         | `--analyze` (JSON only, tree format planned)                                 |
+| `--servedir=<path>`               | `--serve <dir>` (positional arg)                                             |
+| `--bundle=false` (off by default) | Same default. ZTS transpiles only without `--bundle`                         |
+| `--splitting=false`               | Off by default. No flag means default                                        |
+| `--tree-shaking=false`            | Not supported. Per-package `--external` can reduce bundle scope              |
+| `--color=true                     | false`                                                                       | Not supported. Auto-detected from terminal |
+| `--log-override:X=Y`              | Not supported. Only `--log-level`                                            |
+| `--supported:bigint=false`        | Not supported. Use `--target` for global control                             |
+| `--reserve-props=<regex>`         | Not supported                                                                |
 
 ## Migrating from Vite
 
@@ -229,34 +232,34 @@ To write native-style plugins, use `setup(build) { build.onLoad(...) }`.
 
 ### Vite feature mapping
 
-| Vite feature | ZTS equivalent |
-|----------|---------|
-| `vite` (dev server) | `zts dev` (HTML/env/public prepare + CSS-only HMR) |
-| `vite build` | `zts build`, or `zts --bundle <entry> --outdir dist --splitting --minify --sourcemap` for library builds |
-| `vite preview` | `zts preview dist` |
-| `import.meta.env.MODE` | App mode auto-loads `.env*`; CLI bundles can use `--define:import.meta.env.MODE=\"production\"` |
-| `import.meta.env.DEV` | App mode injects dev/build mode automatically; CLI bundles can use `--define:import.meta.env.DEV=true` |
-| `.env` / `.env.production` auto-load | Supported in app mode (`--env-dir`, `--env-prefix`) |
-| `import.meta.glob` | Not supported (planned) |
-| `import.meta.hot` | Supported (`--serve --bundle`) |
-| `import.meta.url` | Supported (ESM standard) |
-| `@vitejs/plugin-react` | `--jsx=automatic` (automatic runtime built-in) |
-| `@vitejs/plugin-react` Fast Refresh | Built-in HMR (React Refresh) |
-| `@vitejs/plugin-vue` | Not supported |
-| `@vitejs/plugin-legacy` | Partial via `--target=es5` etc. |
-| CSS Modules (`.module.css`) | Supported in app mode. Provides default exports and valid named exports |
-| CSS `@import` | Built-in Lightning CSS or `--loader:.css=text` |
-| PostCSS (`postcss.config.js`) | Supported in app mode. `zts dev` watches PostCSS dependencies and sends CSS-only HMR |
-| Sass/Less/Stylus | Sass/SCSS is supported in app mode. Less/Stylus are not supported |
-| `public/` static directory | Supported in app mode (`--public-dir`) |
-| HTML entry (`index.html`) | Supported in app mode (`--entry-html`) |
-| SPA fallback | `zts preview --spa-fallback` |
-| `resolve.alias` | `--alias:name=target` |
-| `resolve.conditions` | Not supported. Uses the resolver's default conditions |
-| `optimizeDeps` (pre-bundling) | Not needed (handled during bundling) |
-| `ssr` / SSR build | Not supported |
-| `worker.format` | Not supported (general Worker bundle support separate) |
-| Rollup plugin compat | `resolveId`/`load`/`transform` hooks compatible |
+| Vite feature                         | ZTS equivalent                                                                                           |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `vite` (dev server)                  | `zts dev` (HTML/env/public prepare + CSS-only HMR)                                                       |
+| `vite build`                         | `zts build`, or `zts --bundle <entry> --outdir dist --splitting --minify --sourcemap` for library builds |
+| `vite preview`                       | `zts preview dist`                                                                                       |
+| `import.meta.env.MODE`               | App mode auto-loads `.env*`; CLI bundles can use `--define:import.meta.env.MODE=\"production\"`          |
+| `import.meta.env.DEV`                | App mode injects dev/build mode automatically; CLI bundles can use `--define:import.meta.env.DEV=true`   |
+| `.env` / `.env.production` auto-load | Supported in app mode (`--env-dir`, `--env-prefix`)                                                      |
+| `import.meta.glob`                   | Not supported (planned)                                                                                  |
+| `import.meta.hot`                    | Supported (`--serve --bundle`)                                                                           |
+| `import.meta.url`                    | Supported (ESM standard)                                                                                 |
+| `@vitejs/plugin-react`               | `--jsx=automatic` (automatic runtime built-in)                                                           |
+| `@vitejs/plugin-react` Fast Refresh  | Built-in HMR (React Refresh)                                                                             |
+| `@vitejs/plugin-vue`                 | Not supported                                                                                            |
+| `@vitejs/plugin-legacy`              | Partial via `--target=es5` etc.                                                                          |
+| CSS Modules (`.module.css`)          | Supported in app mode. Provides default exports and valid named exports                                  |
+| CSS `@import`                        | Built-in Lightning CSS or `--loader:.css=text`                                                           |
+| PostCSS (`postcss.config.js`)        | Supported in app mode. `zts dev` watches PostCSS dependencies and sends CSS-only HMR                     |
+| Sass/Less/Stylus                     | Sass/SCSS is supported in app mode. Less/Stylus are not supported                                        |
+| `public/` static directory           | Supported in app mode (`--public-dir`)                                                                   |
+| HTML entry (`index.html`)            | Supported in app mode (`--entry-html`)                                                                   |
+| SPA fallback                         | `zts preview --spa-fallback`                                                                             |
+| `resolve.alias`                      | `--alias:name=target`                                                                                    |
+| `resolve.conditions`                 | `conditions: ["prod", "foo"]` or `--conditions=prod,foo`                                                 |
+| `optimizeDeps` (pre-bundling)        | Not needed (handled during bundling)                                                                     |
+| `ssr` / SSR build                    | Not supported                                                                                            |
+| `worker.format`                      | Not supported (general Worker bundle support separate)                                                   |
+| Rollup plugin compat                 | `resolveId`/`load`/`transform` hooks compatible                                                          |
 
 ## Migrating from webpack
 
@@ -286,50 +289,50 @@ module.exports = {
 
 ### webpack loaders → ZTS loaders/plugins
 
-| webpack loader | ZTS equivalent |
-|-------------|---------|
-| `ts-loader` / `babel-loader` | Not needed. ZTS handles TS/JSX directly |
-| `@swc/swc-loader` / `esbuild-loader` | Not needed. Replaced by ZTS |
-| `css-loader` + `style-loader` | `--loader:.css=text` or built-in Lightning CSS post-processing |
-| `file-loader` / `asset/resource` | `--loader:.png=file` |
-| `url-loader` / `asset/inline` | `--loader:.png=dataurl` |
-| `raw-loader` / `asset/source` | `--loader:.txt=text` |
-| `svg-loader` / `@svgr/webpack` | `--loader:.svg=text`/`file`/`dataurl` or plugin |
-| `json-loader` | `--loader:.json=json` (built-in default) |
-| `sass-loader` / `less-loader` / `stylus-loader` | Sass/SCSS is supported in app mode. Pre-compile Less/Stylus |
-| `postcss-loader` | Not supported. Replaced by Lightning CSS post-processing |
-| `html-loader` | Not supported. `--loader:.html=text` for string conversion |
-| `worker-loader` | Not supported (general Worker bundle support separate) |
-| `thread-loader` | Not needed. ZTS has built-in parallel pipeline (`--jobs=N`) |
-| `cache-loader` | Not needed. Uses `.zig-cache` / module-level cache |
+| webpack loader                                  | ZTS equivalent                                                 |
+| ----------------------------------------------- | -------------------------------------------------------------- |
+| `ts-loader` / `babel-loader`                    | Not needed. ZTS handles TS/JSX directly                        |
+| `@swc/swc-loader` / `esbuild-loader`            | Not needed. Replaced by ZTS                                    |
+| `css-loader` + `style-loader`                   | `--loader:.css=text` or built-in Lightning CSS post-processing |
+| `file-loader` / `asset/resource`                | `--loader:.png=file`                                           |
+| `url-loader` / `asset/inline`                   | `--loader:.png=dataurl`                                        |
+| `raw-loader` / `asset/source`                   | `--loader:.txt=text`                                           |
+| `svg-loader` / `@svgr/webpack`                  | `--loader:.svg=text`/`file`/`dataurl` or plugin                |
+| `json-loader`                                   | `--loader:.json=json` (built-in default)                       |
+| `sass-loader` / `less-loader` / `stylus-loader` | Sass/SCSS is supported in app mode. Pre-compile Less/Stylus    |
+| `postcss-loader`                                | Not supported. Replaced by Lightning CSS post-processing       |
+| `html-loader`                                   | Not supported. `--loader:.html=text` for string conversion     |
+| `worker-loader`                                 | Not supported (general Worker bundle support separate)         |
+| `thread-loader`                                 | Not needed. ZTS has built-in parallel pipeline (`--jobs=N`)    |
+| `cache-loader`                                  | Not needed. Uses `.zig-cache` / module-level cache             |
 
 ### webpack plugins → ZTS equivalents
 
-| webpack plugin | ZTS equivalent |
-|----------------|---------|
-| `DefinePlugin` | `--define:KEY=VALUE` |
-| `ProvidePlugin` | `--inject:./shim.js` |
-| `IgnorePlugin` | `--external <pkg>` or `--block-list=<pattern>` |
-| `BannerPlugin` | `--banner:js=...` |
-| `SplitChunksPlugin` | `--splitting` (automatic) |
-| `MiniCssExtractPlugin` | Built-in Lightning CSS post-processing (separate CSS chunks) |
-| `HtmlWebpackPlugin` | Not supported. Manage static `index.html` manually |
-| `CopyWebpackPlugin` | Not supported. Per-asset copy via `--loader:.svg=copy` |
-| `TerserPlugin` | `--minify` built-in |
-| `CssMinimizerPlugin` | Handled by Lightning CSS post-processing |
-| `CompressionPlugin` (gzip/brotli) | Not supported. Handle in post-build |
-| `webpack.ContextReplacementPlugin` | Not supported |
-| Module Federation | Not supported |
-| DllPlugin / DllReferencePlugin | Not supported |
+| webpack plugin                     | ZTS equivalent                                               |
+| ---------------------------------- | ------------------------------------------------------------ |
+| `DefinePlugin`                     | `--define:KEY=VALUE`                                         |
+| `ProvidePlugin`                    | `--inject:./shim.js`                                         |
+| `IgnorePlugin`                     | `--external <pkg>` or `--block-list=<pattern>`               |
+| `BannerPlugin`                     | `--banner:js=...`                                            |
+| `SplitChunksPlugin`                | `--splitting` (automatic)                                    |
+| `MiniCssExtractPlugin`             | Built-in Lightning CSS post-processing (separate CSS chunks) |
+| `HtmlWebpackPlugin`                | Not supported. Manage static `index.html` manually           |
+| `CopyWebpackPlugin`                | Not supported. Per-asset copy via `--loader:.svg=copy`       |
+| `TerserPlugin`                     | `--minify` built-in                                          |
+| `CssMinimizerPlugin`               | Handled by Lightning CSS post-processing                     |
+| `CompressionPlugin` (gzip/brotli)  | Not supported. Handle in post-build                          |
+| `webpack.ContextReplacementPlugin` | Not supported                                                |
+| Module Federation                  | Not supported                                                |
+| DllPlugin / DllReferencePlugin     | Not supported                                                |
 
 ### Unsupported webpack features
 
-| webpack feature | Alternative |
-|-------------|------|
-| `require.context` | Supported (`require.context(dir, deep, regex)` — resolved via plugin `onResolveContext` hook) |
-| Lazy chunk (`import(/* webpackChunkName: "x" */ ...)`) | Dynamic import itself supported. Magic comments are not |
-| `webpack.config.js` function / multi-config | Not supported. Single-export `zts.config.ts` |
-| `devServer.proxy` | Not supported. `--serve` serves static/bundle only |
-| Dev server overlay | Not supported (HMR errors go to console) |
-| Persistent cache (`cache.type: 'filesystem'`) | Not needed. Built-in cache |
-| Stats JSON | `--metafile=meta.json` provides similar info |
+| webpack feature                                        | Alternative                                                                                   |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| `require.context`                                      | Supported (`require.context(dir, deep, regex)` — resolved via plugin `onResolveContext` hook) |
+| Lazy chunk (`import(/* webpackChunkName: "x" */ ...)`) | Dynamic import itself supported. Magic comments are not                                       |
+| `webpack.config.js` function / multi-config            | Not supported. Single-export `zts.config.ts`                                                  |
+| `devServer.proxy`                                      | Not supported. `--serve` serves static/bundle only                                            |
+| Dev server overlay                                     | Not supported (HMR errors go to console)                                                      |
+| Persistent cache (`cache.type: 'filesystem'`)          | Not needed. Built-in cache                                                                    |
+| Stats JSON                                             | `--metafile=meta.json` provides similar info                                                  |

--- a/documents/src/content/docs/en/reference/cli.md
+++ b/documents/src/content/docs/en/reference/cli.md
@@ -36,15 +36,15 @@ The default app layout is `index.html`, `public/`, `src/main.ts(x)`, and `.env*`
 for static split chunks. `zts dev` uses the same HTML/env/public prepare step and
 updates stylesheets for CSS edits without a full page reload.
 
-| Option | Description |
-|--------|-------------|
-| `--entry-html <file>` | HTML entry file (default: `index.html`) |
-| `--public-dir <dir\|false>` | public copy directory or disabled |
-| `--base <path>` | HTML/CSS asset URL prefix |
-| `--mode <name>` | env/config mode (`dev`: `development`, `build`: `production`) |
-| `--env-prefix <list>` | exposed env prefix CSV (default: `VITE_,ZTS_`) |
-| `--env-dir <dir>` | directory for `.env*` files |
-| `--spa-fallback[=file]` | in `preview`, fall back route-like 404 requests to `index.html` or the given file |
+| Option                      | Description                                                                       |
+| --------------------------- | --------------------------------------------------------------------------------- |
+| `--entry-html <file>`       | HTML entry file (default: `index.html`)                                           |
+| `--public-dir <dir\|false>` | public copy directory or disabled                                                 |
+| `--base <path>`             | HTML/CSS asset URL prefix                                                         |
+| `--mode <name>`             | env/config mode (`dev`: `development`, `build`: `production`)                     |
+| `--env-prefix <list>`       | exposed env prefix CSV (default: `VITE_,ZTS_`)                                    |
+| `--env-dir <dir>`           | directory for `.env*` files                                                       |
+| `--spa-fallback[=file]`     | in `preview`, fall back route-like 404 requests to `index.html` or the given file |
 
 If the app root contains `postcss.config.{js,mjs,cjs,json}` or `.postcssrc*`,
 ZTS automatically applies it to CSS. In `zts dev`, original CSS files and PostCSS
@@ -56,164 +56,179 @@ CSS before PostCSS when the optional `sass` dependency is installed.
 
 ## I/O
 
-| Option | Description |
-|--------|-------------|
-| `-o, --outfile <path>` | Output file path |
-| `--outdir <path>` | Output directory (required for dir input / splitting / preserve-modules) |
-| `--outbase=<dir>` | Base dir for computing output paths |
-| `--out-extension:.js=<ext>` | Change output extension (e.g. `.mjs`) |
-| `--clean` | Clear outdir before building |
+| Option                      | Description                                                              |
+| --------------------------- | ------------------------------------------------------------------------ |
+| `-o, --outfile <path>`      | Output file path                                                         |
+| `--outdir <path>`           | Output directory (required for dir input / splitting / preserve-modules) |
+| `--outbase=<dir>`           | Base dir for computing output paths                                      |
+| `--out-extension:.js=<ext>` | Change output extension (e.g. `.mjs`)                                    |
+| `--clean`                   | Clear outdir before building                                             |
 
 ## Format / Platform
 
-| Option | Description |
-|--------|-------------|
-| `--format=esm\|cjs\|iife\|umd\|amd` | Module format (default: `esm`) |
-| `--platform=browser\|node\|neutral\|react-native` | Target platform |
-| `--rn-platform=ios\|android` | RN sub-platform (`.ios.*`/`.android.*` extensions) |
-| `--target=<spec>` | ES target: `es2015`–`esnext` or engine versions (`chrome80,safari14`) |
-| `--global-name=<name>` | IIFE export name |
+| Option                                            | Description                                                           |
+| ------------------------------------------------- | --------------------------------------------------------------------- |
+| `--format=esm\|cjs\|iife\|umd\|amd`               | Module format (default: `esm`)                                        |
+| `--platform=browser\|node\|neutral\|react-native` | Target platform                                                       |
+| `--rn-platform=ios\|android`                      | RN sub-platform (`.ios.*`/`.android.*` extensions)                    |
+| `--target=<spec>`                                 | ES target: `es2015`–`esnext` or engine versions (`chrome80,safari14`) |
+| `--global-name=<name>`                            | IIFE export name                                                      |
 
 ## Minify
 
-| Option | Description |
-|--------|-------------|
-| `--minify` | Enable all three (shortcut) |
-| `--minify-whitespace` | Whitespace/semicolons/newlines only (debuggable) |
-| `--minify-syntax` | `true`→`!0`, paren removal, constant folding |
-| `--minify-identifiers` | Shorten local identifiers |
-| `--keep-names` | Preserve function/class `.name` |
-| `--charset=utf8\|ascii` | Output charset |
-| `--ascii-only` | Non-ASCII → `\uXXXX` (= `--charset=ascii`) |
-| `--quotes=double\|single\|preserve` | String quote style |
-| `--line-limit=<n>` | Wrap long output lines at safe token boundaries (`0` disables wrapping) |
+| Option                              | Description                                                             |
+| ----------------------------------- | ----------------------------------------------------------------------- |
+| `--minify`                          | Enable all three (shortcut)                                             |
+| `--minify-whitespace`               | Whitespace/semicolons/newlines only (debuggable)                        |
+| `--minify-syntax`                   | `true`→`!0`, paren removal, constant folding                            |
+| `--minify-identifiers`              | Shorten local identifiers                                               |
+| `--keep-names`                      | Preserve function/class `.name`                                         |
+| `--charset=utf8\|ascii`             | Output charset                                                          |
+| `--ascii-only`                      | Non-ASCII → `\uXXXX` (= `--charset=ascii`)                              |
+| `--quotes=double\|single\|preserve` | String quote style                                                      |
+| `--line-limit=<n>`                  | Wrap long output lines at safe token boundaries (`0` disables wrapping) |
 
 ## Source Maps
 
-| Option | Description |
-|--------|-------------|
-| `--sourcemap` | External `.js.map` with `sourceMappingURL` comment (linked, default) |
-| `--sourcemap=linked` | Explicit linked mode (#2152) — same as above |
-| `--sourcemap=inline` | Inline data URL |
-| `--sourcemap=external` | External file, no comment |
-| `--sourcemap=hidden` | External only (omit comment) |
-| `--sourcemap-debug-ids` | Sentry debugId support |
-| `--sources-content=false` | Omit `sourcesContent` |
-| `--source-root=<path>` | `sourceRoot` field |
+| Option                    | Description                                                          |
+| ------------------------- | -------------------------------------------------------------------- |
+| `--sourcemap`             | External `.js.map` with `sourceMappingURL` comment (linked, default) |
+| `--sourcemap=linked`      | Explicit linked mode (#2152) — same as above                         |
+| `--sourcemap=inline`      | Inline data URL                                                      |
+| `--sourcemap=external`    | External file, no comment                                            |
+| `--sourcemap=hidden`      | External only (omit comment)                                         |
+| `--sourcemap-debug-ids`   | Sentry debugId support                                               |
+| `--sources-content=false` | Omit `sourcesContent`                                                |
+| `--source-root=<path>`    | `sourceRoot` field                                                   |
 
 ## Transform / Replace
 
-| Option | Description |
-|--------|-------------|
-| `--define:KEY=VALUE` | Global replace (e.g. `process.env.NODE_ENV` → `"production"`) |
-| `--drop=console` | Remove `console.*` calls |
-| `--drop=debugger` | Remove `debugger` statements |
-| `--drop-labels=DEV,TEST` | Remove whole labeled statements for matching labels |
-| `--inject:<path>` | Auto-inject import (shim) |
+| Option                   | Description                                                                 |
+| ------------------------ | --------------------------------------------------------------------------- |
+| `--define:KEY=VALUE`     | Global replace (e.g. `process.env.NODE_ENV` → `"production"`)               |
+| `--drop=console`         | Remove `console.*` calls                                                    |
+| `--drop=debugger`        | Remove `debugger` statements                                                |
+| `--drop-labels=DEV,TEST` | Remove whole labeled statements for matching labels                         |
+| `--inject:<path>`        | Auto-inject import (shim)                                                   |
+| `--pure:CALL`            | Register a pure call pattern (for example `--pure:React.createElement`)     |
+| `--ignore-annotations`   | Ignore tree-shaking annotations such as `/* @__PURE__ */` and `sideEffects` |
 
 ## JSX
 
-| Option | Description |
-|--------|-------------|
-| `--jsx=classic\|automatic\|automatic-dev` | JSX runtime |
-| `--jsx-dev` | `--jsx=automatic-dev` shortcut |
-| `--jsx-factory=<fn>` | Classic factory (default: `React.createElement`) |
-| `--jsx-fragment=<fn>` | Classic Fragment |
-| `--jsx-import-source=<pkg>` | Automatic import source (default: `react`) |
-| `--jsx-in-js` | Allow JSX parsing in `.js` files |
+| Option                                    | Description                                       |
+| ----------------------------------------- | ------------------------------------------------- |
+| `--jsx=classic\|automatic\|automatic-dev` | JSX runtime                                       |
+| `--jsx-dev`                               | `--jsx=automatic-dev` shortcut                    |
+| `--jsx-factory=<fn>`                      | Classic factory (default: `React.createElement`)  |
+| `--jsx-fragment=<fn>`                     | Classic Fragment                                  |
+| `--jsx-import-source=<pkg>`               | Automatic import source (default: `react`)        |
+| `--jsx-in-js`                             | Allow JSX parsing in `.js` files                  |
+| `--jsx-side-effects`                      | Preserve unused JSX expressions as side-effectful |
 
 ## TypeScript
 
-| Option | Description |
-|--------|-------------|
-| `-p, --project <path>, --tsconfig-path <path>` | tsconfig.json path/directory |
-| `--experimental-decorators` | Legacy decorator (`__decorateClass`) |
-| `--emit-decorator-metadata` | Emit decorator metadata (requires `experimentalDecorators`) |
-| `--use-define-for-class-fields=false\|true` | Class field semantics |
-| `--verbatim-module-syntax` | Preserve TS `verbatimModuleSyntax` imports/exports |
+| Option                                         | Description                                                        |
+| ---------------------------------------------- | ------------------------------------------------------------------ |
+| `-p, --project <path>, --tsconfig-path <path>` | tsconfig.json path/directory                                       |
+| `--experimental-decorators`                    | Legacy decorator (`__decorateClass`)                               |
+| `--emit-decorator-metadata`                    | Emit decorator metadata (requires `experimentalDecorators`)        |
+| `--use-define-for-class-fields=false\|true`    | Class field semantics                                              |
+| `--verbatim-module-syntax`                     | Preserve TS `verbatimModuleSyntax` imports/exports                 |
+| `--tsconfig-raw=<json>`                        | Inline tsconfig JSON string, compatible with esbuild `tsconfigRaw` |
 
 ## Flow
 
-| Option | Description |
-|--------|-------------|
+| Option   | Description                                            |
+| -------- | ------------------------------------------------------ |
 | `--flow` | Flow type stripping (auto-detected via `@flow` pragma) |
 
 ## Bundle-specific
 
-| Option | Description |
-|--------|-------------|
-| `--bundle` | Enable bundle mode |
-| `--splitting` | Code splitting (requires `--outdir`) |
-| `--no-splitting` | Disable splitting from config at the CLI layer |
-| `--preserve-modules` | Per-module output (library build) |
-| `--preserve-modules-root=<dir>` | Root for output structure |
-| `--inline-dynamic-imports` | Absorb dynamic-import targets into the entry chunk (Rollup `inlineDynamicImports`, #2185) |
-| `--output-exports=<mode>` | CJS/UMD entry export shape — `auto\|named\|default\|none` (Rollup `output.exports`, #2159) |
-| `--entry-names=<pattern>` | Entry name pattern (`[name]`, `[hash]`) |
-| `--chunk-names=<pattern>` | Chunk name pattern |
-| `--asset-names=<pattern>` | Asset name pattern |
-| `--loader:.ext=type` | Loader by extension (`file\|dataurl\|base64\|text\|binary\|copy\|empty\|json\|css\|js\|ts\|jsx\|tsx`) |
-| `--metafile` / `--metafile=<path>` | Build meta JSON (stdout or file) |
-| `--analyze` | Bundle analysis report |
-| `--legal-comments=<mode>` | License comments: `none\|inline\|eof\|linked\|external` |
-| `--banner=<text>` / `--banner:js=<text>` | Prepend text |
-| `--footer=<text>` / `--footer:js=<text>` | Append text |
-| `--public-path=<url>` | Asset URL prefix |
-| `--shim-missing-exports` | Shim missing exports with `undefined` |
+| Option                                   | Description                                                                                           |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `--bundle`                               | Enable bundle mode                                                                                    |
+| `--splitting`                            | Code splitting (requires `--outdir`)                                                                  |
+| `--no-splitting`                         | Disable splitting from config at the CLI layer                                                        |
+| `--preserve-modules`                     | Per-module output (library build)                                                                     |
+| `--preserve-modules-root=<dir>`          | Root for output structure                                                                             |
+| `--inline-dynamic-imports`               | Absorb dynamic-import targets into the entry chunk (Rollup `inlineDynamicImports`, #2185)             |
+| `--output-exports=<mode>`                | CJS/UMD entry export shape — `auto\|named\|default\|none` (Rollup `output.exports`, #2159)            |
+| `--entry-names=<pattern>`                | Entry name pattern (`[name]`, `[hash]`)                                                               |
+| `--chunk-names=<pattern>`                | Chunk name pattern                                                                                    |
+| `--asset-names=<pattern>`                | Asset name pattern                                                                                    |
+| `--loader:.ext=type`                     | Loader by extension (`file\|dataurl\|base64\|text\|binary\|copy\|empty\|json\|css\|js\|ts\|jsx\|tsx`) |
+| `--metafile` / `--metafile=<path>`       | Build meta JSON (stdout or file)                                                                      |
+| `--analyze`                              | Bundle analysis report                                                                                |
+| `--legal-comments=<mode>`                | License comments: `none\|inline\|eof\|linked\|external`                                               |
+| `--packages=external`                    | Treat all bare package imports as external                                                            |
+| `--banner=<text>` / `--banner:js=<text>` | Prepend text                                                                                          |
+| `--footer=<text>` / `--footer:js=<text>` | Append text                                                                                           |
+| `--intro=<text>`                         | Prepend wrapper-internal bundle text                                                                  |
+| `--outro=<text>`                         | Append wrapper-internal bundle text                                                                   |
+| `--global:FROM=TO`                       | Map an IIFE/UMD external specifier to a global variable name                                          |
+| `--public-path=<url>`                    | Asset URL prefix                                                                                      |
+| `--shim-missing-exports`                 | Shim missing exports with `undefined`                                                                 |
 
 ## Resolve
 
-| Option | Description |
-|--------|-------------|
-| `--external <pkg>` / `--external=<pkg>` | Exclude from bundle (repeatable) |
-| `--alias:FROM=TO` | Import path alias |
-| `--resolve-extensions=<exts>` | Extension lookup order (e.g. `.ios.ts,.ts,.js`) |
-| `--main-fields=<fields>` | package.json field order (e.g. `react-native,browser,main`) |
-| `--preserve-symlinks` | Don't resolve symlinks |
+| Option                                  | Description                                                                      |
+| --------------------------------------- | -------------------------------------------------------------------------------- |
+| `--external <pkg>` / `--external=<pkg>` | Exclude from bundle (repeatable)                                                 |
+| `--alias:FROM=TO`                       | Import path alias                                                                |
+| `--resolve-extensions=<exts>`           | Extension lookup order (e.g. `.ios.ts,.ts,.js`)                                  |
+| `--main-fields=<fields>`                | package.json field order (e.g. `react-native,browser,main`)                      |
+| `--conditions=<list>`                   | Add package exports conditions from a CSV list (for example `prod,react-native`) |
+| `--node-paths=<list>`                   | Additional bare-specifier lookup paths from a CSV list                           |
+| `--preserve-symlinks`                   | Don't resolve symlinks                                                           |
 
 ## Watch / Dev Server
 
-| Option | Description |
-|--------|-------------|
-| `-w, --watch` | Watch for file changes (incremental rebuild) |
-| `--watch-json` | NDJSON event output (for external HMR integration) |
-| `--watch-delay=<ms>` | Debounce delay |
-| `--serve [dir]` | Static file server (default: `.`) |
-| `--port <n>` | Server port |
-| `--host [addr]` | Binding address |
-| `--strict-port` | Fail instead of falling through to the next port when the requested port is busy |
-| `--certfile <path>` | HTTPS certificate file (`preview`/serve) |
-| `--keyfile <path>` | HTTPS private key file (`preview`/serve) |
-| `--open` | Auto-open browser |
-| `--proxy /api=http://host:port` | API proxy |
+| Option                          | Description                                                                      |
+| ------------------------------- | -------------------------------------------------------------------------------- |
+| `-w, --watch`                   | Watch for file changes (incremental rebuild)                                     |
+| `--watch-json`                  | NDJSON event output (for external HMR integration)                               |
+| `--watch-delay=<ms>`            | Debounce delay                                                                   |
+| `--serve [dir]`                 | Static file server (default: `.`)                                                |
+| `--port <n>`                    | Server port                                                                      |
+| `--host [addr]`                 | Binding address                                                                  |
+| `--strict-port`                 | Fail instead of falling through to the next port when the requested port is busy |
+| `--certfile <path>`             | HTTPS certificate file (`preview`/serve)                                         |
+| `--keyfile <path>`              | HTTPS private key file (`preview`/serve)                                         |
+| `--open`                        | Auto-open browser                                                                |
+| `--proxy /api=http://host:port` | API proxy                                                                        |
 
 **Dev server external interfaces:** `/sse/events` (SSE build events), `/reset-cache` (Control API), `/mcp` (Model Context Protocol — for LLM agents like Claude Code).
 
 ## Plugins / Execution
 
-| Option | Description |
-|--------|-------------|
-| `--plugin <path>` | JS/TS plugin or config file |
-| `--jobs=<n>` | Parallel thread count |
-| `--config <path>` | Use an explicit `zts.config.*` instead of auto-discovery |
+| Option                      | Description                                                 |
+| --------------------------- | ----------------------------------------------------------- |
+| `--plugin <path>`           | JS/TS plugin or config file                                 |
+| `--jobs=<n>`                | Parallel thread count                                       |
+| `--config <path>`           | Use an explicit `zts.config.*` instead of auto-discovery    |
 | `--workspace-config <path>` | Use an explicit `zts.workspace.*` instead of auto-discovery |
-| `--workspace <name>` | Select one workspace entry |
+| `--workspace <name>`        | Select one workspace entry                                  |
 
 ## Diagnostics / Logging
 
-| Option | Description |
-|--------|-------------|
-| `--log-level=<level>` | `silent\|error\|warning\|info\|debug\|verbose` |
-| `--log-limit=<n>` | Max diagnostics shown |
-| `--allow-overwrite` | Explicitly permit an output path to overwrite an input file. Blocked by default. |
-| `-h, --help` | Show help |
+| Option                       | Description                                                                      |
+| ---------------------------- | -------------------------------------------------------------------------------- |
+| `--log-level=<level>`        | `silent\|error\|warning\|info\|debug\|verbose`                                   |
+| `--log-limit=<n>`            | Max diagnostics shown                                                            |
+| `--profile=<list>`           | Collect profile categories from a CSV list (`all`, `parse`, `transform`, etc.)   |
+| `--profile-level=<level>`    | Profile detail level: `summary\|detailed\|per-module\|per-pass`                  |
+| `--profile-format=<format>`  | Profile output: `table\|tree\|json\|csv`                                         |
+| `--tokenize[=false]`         | Print scanner tokens instead of generated code                                   |
+| `--tokenize-format=<format>` | Token output format: `text\|json`                                                |
+| `--stop-after=<phase>`       | Debug option to stop after a compiler phase                                      |
+| `--test262 <dir>`            | Run the Zig Test262 runner                                                       |
+| `--allow-overwrite`          | Explicitly permit an output path to overwrite an input file. Blocked by default. |
+| `-h, --help`                 | Show help                                                                        |
 
 ## Internal / Planned Options Not Exposed In The Current CLI
 
 These features exist as internal options or roadmap items, but are not present in the current
-`zts` CLI flag registry: `globalIdentifiers`, `pure`,
-`polyfills`, `jsxSideEffects`, `tsconfigRaw`, `ignoreAnnotations`, `packages=external`,
-`conditions`, `nodePaths`, `runBeforeMain`, `timing/profile`, `tokenize`, `test262`.
+`zts` CLI flag registry: `globalIdentifiers`, `polyfills`, `runBeforeMain`.
 
 ## See Also
 

--- a/documents/src/content/docs/guides/migration.md
+++ b/documents/src/content/docs/guides/migration.md
@@ -20,7 +20,7 @@ ZTS는 esbuild와 유사한 번들링 모델을 제공하지만 CLI flag surface
 | `--target=es2020`               | `--target=es2020`                             | 동일 (engine 타겟: `chrome80`, `node20` 등)                   |
 | `--bundle`                      | `--bundle`                                    | 동일                                                          |
 | `--splitting`                   | `--splitting`                                 | 동일 (`--outdir` 필수)                                        |
-| `--packages=external`           | 미지원                                        | 개별 패키지는 `--external` 반복 지정                          |
+| `--packages=external`           | `--packages=external`                         | bare package import를 모두 external 처리                      |
 | `--external:react`              | `--external react`                            | `:` 대신 공백                                                 |
 | `--minify`                      | `--minify`                                    | 동일 (`--minify-{whitespace,syntax,identifiers}` 세분화 지원) |
 | `--sourcemap`                   | `--sourcemap`                                 | 동일                                                          |
@@ -29,7 +29,7 @@ ZTS는 esbuild와 유사한 번들링 모델을 제공하지만 CLI flag surface
 | `--define:X=Y`                  | `--define:X=Y`                                | 동일                                                          |
 | `--alias:react=preact/compat`   | `--alias:react=preact/compat`                 | 동일                                                          |
 | `--inject:./shim.js`            | `--inject:./shim.js`                          | 동일                                                          |
-| `--pure:Pure.*`                 | 미지원                                        | 코드 어노테이션 `/* @__PURE__ */` 사용                        |
+| `--pure:Pure.*`                 | `--pure:Pure.*`                               | pure call pattern 등록                                        |
 | `--drop:console`                | `--drop=console`                              | `:` 대신 `=` (`console`/`debugger`)                           |
 | `--drop-labels=DEV`             | `--drop-labels=DEV`                           | 동일. 쉼표로 여러 label 지정 가능                             |
 | `--keep-names`                  | `--keep-names`                                | 동일                                                          |
@@ -52,7 +52,7 @@ ZTS는 esbuild와 유사한 번들링 모델을 제공하지만 CLI flag surface
 | `--jsx-import-source=preact`    | `--jsx-import-source=preact`                  | 동일                                                          |
 | `--jsx-side-effects`            | `--jsx-side-effects`                          | unused JSX expression 보존                                    |
 | `--tsconfig=tsconfig.json`      | `-p tsconfig.json` 또는 `--tsconfig-path=...` | 축약 `-p` 지원                                                |
-| `--tsconfig-raw='{...}'`        | 미지원                                        | 파일 기반 `-p` / `--project` 사용                             |
+| `--tsconfig-raw='{...}'`        | `--tsconfig-raw='{...}'`                      | inline tsconfig JSON                                          |
 | `--conditions=prod,foo`         | `--conditions=prod,foo`                       | 기본 conditions 유지 + 사용자 condition 추가                  |
 | `--main-fields=browser,main`    | `--main-fields=browser,main`                  | 동일                                                          |
 | `--resolve-extensions=.ts,.js`  | `--resolve-extensions=.ts,.js`                | 동일 (RN `.ios.ts` 등 지원)                                   |

--- a/documents/src/content/docs/reference/cli.md
+++ b/documents/src/content/docs/reference/cli.md
@@ -36,15 +36,15 @@ HTML asset URL, `%ENV%` 토큰을 rewrite하며 static split chunk는 `modulepre
 주입합니다. `zts dev`는 같은 HTML/env/public prepare 단계를 사용하고 CSS 변경은 페이지
 전체 reload 없이 stylesheet만 갱신합니다.
 
-| 옵션 | 설명 |
-|------|------|
-| `--entry-html <file>` | HTML entry 파일 (기본: `index.html`) |
-| `--public-dir <dir\|false>` | public 파일 복사 디렉토리 또는 비활성화 |
-| `--base <path>` | HTML/CSS asset URL prefix |
-| `--mode <name>` | env/config mode (`dev`: `development`, `build`: `production`) |
-| `--env-prefix <list>` | 노출할 env prefix CSV (기본: `VITE_,ZTS_`) |
-| `--env-dir <dir>` | `.env*` 파일 탐색 디렉토리 |
-| `--spa-fallback[=file]` | `preview`에서 route-like 404 요청을 `index.html` 또는 지정 파일로 fallback |
+| 옵션                        | 설명                                                                       |
+| --------------------------- | -------------------------------------------------------------------------- |
+| `--entry-html <file>`       | HTML entry 파일 (기본: `index.html`)                                       |
+| `--public-dir <dir\|false>` | public 파일 복사 디렉토리 또는 비활성화                                    |
+| `--base <path>`             | HTML/CSS asset URL prefix                                                  |
+| `--mode <name>`             | env/config mode (`dev`: `development`, `build`: `production`)              |
+| `--env-prefix <list>`       | 노출할 env prefix CSV (기본: `VITE_,ZTS_`)                                 |
+| `--env-dir <dir>`           | `.env*` 파일 탐색 디렉토리                                                 |
+| `--spa-fallback[=file]`     | `preview`에서 route-like 404 요청을 `index.html` 또는 지정 파일로 fallback |
 
 앱 root에 `postcss.config.{js,mjs,cjs,json}` 또는 `.postcssrc*`가 있으면 CSS에 자동
 적용됩니다. `zts dev`는 원본 CSS와 PostCSS `dependency` / `dir-dependency` 메시지를
@@ -55,164 +55,179 @@ scoped class map으로 변환하며 default export와 가능한 named export를 
 
 ## 입출력
 
-| 옵션 | 설명 |
-|------|------|
-| `-o, --outfile <path>` | 출력 파일 경로 |
-| `--outdir <path>` | 출력 디렉토리 (디렉토리 입력·`--splitting`·`--preserve-modules`) |
-| `--outbase=<dir>` | 출력 기준 디렉토리 (공통 prefix 계산) |
-| `--out-extension:.js=<ext>` | 출력 확장자 변경 (예: `.mjs`) |
-| `--clean` | 빌드 전 outdir 비우기 |
+| 옵션                        | 설명                                                             |
+| --------------------------- | ---------------------------------------------------------------- |
+| `-o, --outfile <path>`      | 출력 파일 경로                                                   |
+| `--outdir <path>`           | 출력 디렉토리 (디렉토리 입력·`--splitting`·`--preserve-modules`) |
+| `--outbase=<dir>`           | 출력 기준 디렉토리 (공통 prefix 계산)                            |
+| `--out-extension:.js=<ext>` | 출력 확장자 변경 (예: `.mjs`)                                    |
+| `--clean`                   | 빌드 전 outdir 비우기                                            |
 
 ## 모듈 포맷 / 플랫폼
 
-| 옵션 | 설명 |
-|------|------|
-| `--format=esm\|cjs\|iife\|umd\|amd` | 모듈 포맷 (기본: `esm`) |
-| `--platform=browser\|node\|neutral\|react-native` | 타겟 플랫폼 |
-| `--rn-platform=ios\|android` | RN 서브 플랫폼 (`.ios.*`/`.android.*` 확장자) |
-| `--target=<spec>` | ES 타겟: `es2015`~`esnext` 또는 엔진 버전 (`chrome80,safari14` 등) |
-| `--global-name=<name>` | IIFE export 변수명 |
+| 옵션                                              | 설명                                                               |
+| ------------------------------------------------- | ------------------------------------------------------------------ |
+| `--format=esm\|cjs\|iife\|umd\|amd`               | 모듈 포맷 (기본: `esm`)                                            |
+| `--platform=browser\|node\|neutral\|react-native` | 타겟 플랫폼                                                        |
+| `--rn-platform=ios\|android`                      | RN 서브 플랫폼 (`.ios.*`/`.android.*` 확장자)                      |
+| `--target=<spec>`                                 | ES 타겟: `es2015`~`esnext` 또는 엔진 버전 (`chrome80,safari14` 등) |
+| `--global-name=<name>`                            | IIFE export 변수명                                                 |
 
 ## 미니파이
 
-| 옵션 | 설명 |
-|------|------|
-| `--minify` | 세 가지 모두 켜기 (shortcut) |
-| `--minify-whitespace` | 공백/세미콜론/줄바꿈만 축약 (디버깅 가능) |
-| `--minify-syntax` | `true`→`!0`, 괄호 제거, constant folding |
-| `--minify-identifiers` | 지역 변수명 단축 |
-| `--keep-names` | 함수/클래스 `.name` 보존 |
-| `--charset=utf8\|ascii` | 출력 문자셋 |
-| `--ascii-only` | non-ASCII → `\uXXXX` (= `--charset=ascii`) |
-| `--quotes=double\|single\|preserve` | 문자열 따옴표 스타일 |
-| `--line-limit=<n>` | 안전한 토큰 경계에서 긴 출력 라인 줄바꿈 (`0`은 무제한) |
+| 옵션                                | 설명                                                    |
+| ----------------------------------- | ------------------------------------------------------- |
+| `--minify`                          | 세 가지 모두 켜기 (shortcut)                            |
+| `--minify-whitespace`               | 공백/세미콜론/줄바꿈만 축약 (디버깅 가능)               |
+| `--minify-syntax`                   | `true`→`!0`, 괄호 제거, constant folding                |
+| `--minify-identifiers`              | 지역 변수명 단축                                        |
+| `--keep-names`                      | 함수/클래스 `.name` 보존                                |
+| `--charset=utf8\|ascii`             | 출력 문자셋                                             |
+| `--ascii-only`                      | non-ASCII → `\uXXXX` (= `--charset=ascii`)              |
+| `--quotes=double\|single\|preserve` | 문자열 따옴표 스타일                                    |
+| `--line-limit=<n>`                  | 안전한 토큰 경계에서 긴 출력 라인 줄바꿈 (`0`은 무제한) |
 
 ## 소스맵
 
-| 옵션 | 설명 |
-|------|------|
-| `--sourcemap` | `.js.map` 외부 파일 + `sourceMappingURL` 주석 (linked, 기본) |
-| `--sourcemap=linked` | linked 명시 (#2152) — 동일 |
-| `--sourcemap=inline` | data URL 인라인 |
-| `--sourcemap=external` | sourceMappingURL 주석 없이 외부만 |
-| `--sourcemap=hidden` | 외부 파일 생성만 (주석 생략) |
-| `--sourcemap-debug-ids` | Sentry debugId 삽입 |
-| `--sources-content=false` | `sourcesContent` 필드 생략 |
-| `--source-root=<path>` | sourceRoot 필드 |
+| 옵션                      | 설명                                                         |
+| ------------------------- | ------------------------------------------------------------ |
+| `--sourcemap`             | `.js.map` 외부 파일 + `sourceMappingURL` 주석 (linked, 기본) |
+| `--sourcemap=linked`      | linked 명시 (#2152) — 동일                                   |
+| `--sourcemap=inline`      | data URL 인라인                                              |
+| `--sourcemap=external`    | sourceMappingURL 주석 없이 외부만                            |
+| `--sourcemap=hidden`      | 외부 파일 생성만 (주석 생략)                                 |
+| `--sourcemap-debug-ids`   | Sentry debugId 삽입                                          |
+| `--sources-content=false` | `sourcesContent` 필드 생략                                   |
+| `--source-root=<path>`    | sourceRoot 필드                                              |
 
 ## 변환 / 치환
 
-| 옵션 | 설명 |
-|------|------|
-| `--define:KEY=VALUE` | 글로벌 치환 (`process.env.NODE_ENV` → `"production"` 등) |
-| `--drop=console` | `console.*` 호출 제거 |
-| `--drop=debugger` | `debugger` 문 제거 |
-| `--drop-labels=DEV,TEST` | 지정한 labeled statement 전체 제거 |
-| `--inject:<path>` | 자동 import (shim) |
+| 옵션                     | 설명                                                             |
+| ------------------------ | ---------------------------------------------------------------- |
+| `--define:KEY=VALUE`     | 글로벌 치환 (`process.env.NODE_ENV` → `"production"` 등)         |
+| `--drop=console`         | `console.*` 호출 제거                                            |
+| `--drop=debugger`        | `debugger` 문 제거                                               |
+| `--drop-labels=DEV,TEST` | 지정한 labeled statement 전체 제거                               |
+| `--inject:<path>`        | 자동 import (shim)                                               |
+| `--pure:CALL`            | 순수 호출 패턴 등록 (예: `--pure:React.createElement`)           |
+| `--ignore-annotations`   | `/* @__PURE__ */`, `sideEffects` 등 tree-shaking annotation 무시 |
 
 ## JSX
 
-| 옵션 | 설명 |
-|------|------|
-| `--jsx=classic\|automatic\|automatic-dev` | JSX 런타임 |
-| `--jsx-dev` | `--jsx=automatic-dev` shortcut |
-| `--jsx-factory=<fn>` | classic factory (기본: `React.createElement`) |
-| `--jsx-fragment=<fn>` | classic Fragment |
-| `--jsx-import-source=<pkg>` | automatic import source (기본: `react`) |
-| `--jsx-in-js` | `.js` 파일에서도 JSX 파싱 허용 |
+| 옵션                                      | 설명                                                               |
+| ----------------------------------------- | ------------------------------------------------------------------ |
+| `--jsx=classic\|automatic\|automatic-dev` | JSX 런타임                                                         |
+| `--jsx-dev`                               | `--jsx=automatic-dev` shortcut                                     |
+| `--jsx-factory=<fn>`                      | classic factory (기본: `React.createElement`)                      |
+| `--jsx-fragment=<fn>`                     | classic Fragment                                                   |
+| `--jsx-import-source=<pkg>`               | automatic import source (기본: `react`)                            |
+| `--jsx-in-js`                             | `.js` 파일에서도 JSX 파싱 허용                                     |
+| `--jsx-side-effects`                      | 사용되지 않은 JSX expression을 side-effect가 있는 것으로 보고 보존 |
 
 ## TypeScript
 
-| 옵션 | 설명 |
-|------|------|
-| `-p, --project <path>, --tsconfig-path <path>` | tsconfig.json 경로/디렉토리 |
-| `--experimental-decorators` | legacy decorator (`__decorateClass`) |
-| `--emit-decorator-metadata` | decorator metadata emit (`experimentalDecorators` 필요) |
-| `--use-define-for-class-fields=false\|true` | 클래스 필드 의미론 |
-| `--verbatim-module-syntax` | TS `verbatimModuleSyntax` import/export 보존 |
+| 옵션                                           | 설명                                                     |
+| ---------------------------------------------- | -------------------------------------------------------- |
+| `-p, --project <path>, --tsconfig-path <path>` | tsconfig.json 경로/디렉토리                              |
+| `--experimental-decorators`                    | legacy decorator (`__decorateClass`)                     |
+| `--emit-decorator-metadata`                    | decorator metadata emit (`experimentalDecorators` 필요)  |
+| `--use-define-for-class-fields=false\|true`    | 클래스 필드 의미론                                       |
+| `--verbatim-module-syntax`                     | TS `verbatimModuleSyntax` import/export 보존             |
+| `--tsconfig-raw=<json>`                        | inline tsconfig JSON 문자열 (esbuild `tsconfigRaw` 호환) |
 
 ## Flow
 
-| 옵션 | 설명 |
-|------|------|
+| 옵션     | 설명                                          |
+| -------- | --------------------------------------------- |
 | `--flow` | Flow 타입 스트리핑 (`@flow` pragma 자동 감지) |
 
 ## 번들 전용
 
-| 옵션 | 설명 |
-|------|------|
-| `--bundle` | 번들 모드 활성화 |
-| `--splitting` | 코드 스플리팅 (`--outdir` 필요) |
-| `--no-splitting` | config에서 켠 splitting을 CLI에서 비활성화 |
-| `--preserve-modules` | 모듈별 출력 (라이브러리 빌드) |
-| `--preserve-modules-root=<dir>` | 출력 구조 기준 디렉토리 |
-| `--inline-dynamic-imports` | dynamic import target 을 entry chunk 에 흡수 (Rollup `inlineDynamicImports`, #2185) |
-| `--output-exports=<mode>` | CJS/UMD entry export 형식 — `auto\|named\|default\|none` (Rollup `output.exports`, #2159) |
-| `--entry-names=<pattern>` | 엔트리 파일명 패턴 (`[name]`, `[hash]`) |
-| `--chunk-names=<pattern>` | 청크 파일명 패턴 |
-| `--asset-names=<pattern>` | 에셋 파일명 패턴 |
-| `--loader:.ext=type` | 확장자별 로더 (`file\|dataurl\|base64\|text\|binary\|copy\|empty\|json\|css\|js\|ts\|jsx\|tsx`) |
-| `--metafile` / `--metafile=<path>` | 빌드 메타 JSON (stdout 또는 파일) |
-| `--analyze` | 번들 분석 리포트 |
-| `--legal-comments=<mode>` | 라이선스 주석: `none\|inline\|eof\|linked\|external` |
-| `--banner=<text>` / `--banner:js=<text>` | 출력 앞 텍스트 |
-| `--footer=<text>` / `--footer:js=<text>` | 출력 뒤 텍스트 |
-| `--public-path=<url>` | 에셋 URL prefix |
-| `--shim-missing-exports` | 없는 export에 `undefined` shim |
+| 옵션                                     | 설명                                                                                            |
+| ---------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `--bundle`                               | 번들 모드 활성화                                                                                |
+| `--splitting`                            | 코드 스플리팅 (`--outdir` 필요)                                                                 |
+| `--no-splitting`                         | config에서 켠 splitting을 CLI에서 비활성화                                                      |
+| `--preserve-modules`                     | 모듈별 출력 (라이브러리 빌드)                                                                   |
+| `--preserve-modules-root=<dir>`          | 출력 구조 기준 디렉토리                                                                         |
+| `--inline-dynamic-imports`               | dynamic import target 을 entry chunk 에 흡수 (Rollup `inlineDynamicImports`, #2185)             |
+| `--output-exports=<mode>`                | CJS/UMD entry export 형식 — `auto\|named\|default\|none` (Rollup `output.exports`, #2159)       |
+| `--entry-names=<pattern>`                | 엔트리 파일명 패턴 (`[name]`, `[hash]`)                                                         |
+| `--chunk-names=<pattern>`                | 청크 파일명 패턴                                                                                |
+| `--asset-names=<pattern>`                | 에셋 파일명 패턴                                                                                |
+| `--loader:.ext=type`                     | 확장자별 로더 (`file\|dataurl\|base64\|text\|binary\|copy\|empty\|json\|css\|js\|ts\|jsx\|tsx`) |
+| `--metafile` / `--metafile=<path>`       | 빌드 메타 JSON (stdout 또는 파일)                                                               |
+| `--analyze`                              | 번들 분석 리포트                                                                                |
+| `--legal-comments=<mode>`                | 라이선스 주석: `none\|inline\|eof\|linked\|external`                                            |
+| `--packages=external`                    | bare package import를 모두 external 처리                                                        |
+| `--banner=<text>` / `--banner:js=<text>` | 출력 앞 텍스트                                                                                  |
+| `--footer=<text>` / `--footer:js=<text>` | 출력 뒤 텍스트                                                                                  |
+| `--intro=<text>`                         | format wrapper 내부 bundle 앞 텍스트                                                            |
+| `--outro=<text>`                         | format wrapper 내부 bundle 뒤 텍스트                                                            |
+| `--global:FROM=TO`                       | IIFE/UMD external specifier를 global 변수명에 매핑                                              |
+| `--public-path=<url>`                    | 에셋 URL prefix                                                                                 |
+| `--shim-missing-exports`                 | 없는 export에 `undefined` shim                                                                  |
 
 ## Resolve
 
-| 옵션 | 설명 |
-|------|------|
-| `--external <pkg>` / `--external=<pkg>` | 번들에서 제외 (반복 가능) |
-| `--alias:FROM=TO` | import 경로 별칭 |
-| `--resolve-extensions=<exts>` | 확장자 탐색 순서 (예: `.ios.ts,.ts,.js`) |
-| `--main-fields=<fields>` | package.json 필드 순서 (예: `react-native,browser,main`) |
-| `--preserve-symlinks` | 심링크 실제 경로 해석 안 함 |
+| 옵션                                    | 설명                                                     |
+| --------------------------------------- | -------------------------------------------------------- |
+| `--external <pkg>` / `--external=<pkg>` | 번들에서 제외 (반복 가능)                                |
+| `--alias:FROM=TO`                       | import 경로 별칭                                         |
+| `--resolve-extensions=<exts>`           | 확장자 탐색 순서 (예: `.ios.ts,.ts,.js`)                 |
+| `--main-fields=<fields>`                | package.json 필드 순서 (예: `react-native,browser,main`) |
+| `--conditions=<list>`                   | package exports 조건 CSV 추가 (예: `prod,react-native`)  |
+| `--node-paths=<list>`                   | bare specifier 추가 탐색 경로 CSV                        |
+| `--preserve-symlinks`                   | 심링크 실제 경로 해석 안 함                              |
 
 ## Watch / Dev Server
 
-| 옵션 | 설명 |
-|------|------|
-| `-w, --watch` | 파일 변경 감시 (증분 리빌드) |
-| `--watch-json` | NDJSON 이벤트 출력 (외부 HMR 연동) |
-| `--watch-delay=<ms>` | 디바운스 지연 |
-| `--serve [dir]` | 정적 파일 서버 (기본: `.`) |
-| `--port <n>` | 서버 포트 |
-| `--host [addr]` | 바인딩 주소 |
-| `--strict-port` | 지정한 포트를 사용할 수 없으면 다음 포트로 넘어가지 않고 실패 |
-| `--certfile <path>` | HTTPS 인증서 파일 (`preview`/serve) |
-| `--keyfile <path>` | HTTPS 개인키 파일 (`preview`/serve) |
-| `--open` | 브라우저 자동 열기 |
-| `--proxy /api=http://host:port` | API 프록시 |
+| 옵션                            | 설명                                                          |
+| ------------------------------- | ------------------------------------------------------------- |
+| `-w, --watch`                   | 파일 변경 감시 (증분 리빌드)                                  |
+| `--watch-json`                  | NDJSON 이벤트 출력 (외부 HMR 연동)                            |
+| `--watch-delay=<ms>`            | 디바운스 지연                                                 |
+| `--serve [dir]`                 | 정적 파일 서버 (기본: `.`)                                    |
+| `--port <n>`                    | 서버 포트                                                     |
+| `--host [addr]`                 | 바인딩 주소                                                   |
+| `--strict-port`                 | 지정한 포트를 사용할 수 없으면 다음 포트로 넘어가지 않고 실패 |
+| `--certfile <path>`             | HTTPS 인증서 파일 (`preview`/serve)                           |
+| `--keyfile <path>`              | HTTPS 개인키 파일 (`preview`/serve)                           |
+| `--open`                        | 브라우저 자동 열기                                            |
+| `--proxy /api=http://host:port` | API 프록시                                                    |
 
 **Dev Server 외부 인터페이스:** `/sse/events` (SSE 빌드 이벤트), `/reset-cache` (Control API), `/mcp` (Model Context Protocol — Claude Code 등 LLM 에이전트 연동).
 
 ## 플러그인 / 실행
 
-| 옵션 | 설명 |
-|------|------|
-| `--plugin <path>` | JS/TS 플러그인 또는 설정 파일 |
-| `--jobs=<n>` | 병렬 스레드 수 |
-| `--config <path>` | `zts.config.*` 자동 탐색 대신 명시 config 사용 |
+| 옵션                        | 설명                                                 |
+| --------------------------- | ---------------------------------------------------- |
+| `--plugin <path>`           | JS/TS 플러그인 또는 설정 파일                        |
+| `--jobs=<n>`                | 병렬 스레드 수                                       |
+| `--config <path>`           | `zts.config.*` 자동 탐색 대신 명시 config 사용       |
 | `--workspace-config <path>` | `zts.workspace.*` 자동 탐색 대신 명시 workspace 사용 |
-| `--workspace <name>` | workspace entry 하나만 선택 |
+| `--workspace <name>`        | workspace entry 하나만 선택                          |
 
 ## 진단 / 로깅
 
-| 옵션 | 설명 |
-|------|------|
-| `--log-level=<level>` | `silent\|error\|warning\|info\|debug\|verbose` |
-| `--log-limit=<n>` | 표시할 진단 최대 개수 |
-| `--allow-overwrite` | 입력 파일과 같은 출력 경로를 명시적으로 허용합니다. 기본값은 차단입니다. |
-| `-h, --help` | 도움말 |
+| 옵션                         | 설명                                                                     |
+| ---------------------------- | ------------------------------------------------------------------------ |
+| `--log-level=<level>`        | `silent\|error\|warning\|info\|debug\|verbose`                           |
+| `--log-limit=<n>`            | 표시할 진단 최대 개수                                                    |
+| `--profile=<list>`           | profile category CSV 수집 (`all`, `parse`, `transform` 등)               |
+| `--profile-level=<level>`    | profile 상세 수준: `summary\|detailed\|per-module\|per-pass`             |
+| `--profile-format=<format>`  | profile 출력: `table\|tree\|json\|csv`                                   |
+| `--tokenize[=false]`         | 코드 생성 대신 scanner token 출력                                        |
+| `--tokenize-format=<format>` | token 출력 형식: `text\|json`                                            |
+| `--stop-after=<phase>`       | 지정 phase 이후 중단하는 디버그 옵션                                     |
+| `--test262 <dir>`            | Zig Test262 runner 실행                                                  |
+| `--allow-overwrite`          | 입력 파일과 같은 출력 경로를 명시적으로 허용합니다. 기본값은 차단입니다. |
+| `-h, --help`                 | 도움말                                                                   |
 
 ## 현재 CLI에 노출되지 않은 내부/계획 옵션
 
 다음 기능은 코드 내부 옵션 또는 roadmap 항목이지만 현재 `zts` CLI flag registry에는 없습니다:
-`globalIdentifiers`, `pure`, `polyfills`, `jsxSideEffects`,
-`tsconfigRaw`, `ignoreAnnotations`, `packages=external`, `conditions`, `nodePaths`,
-`runBeforeMain`, `timing/profile`, `tokenize`, `test262`.
+`globalIdentifiers`, `polyfills`, `runBeforeMain`.
 
 ## 참고
 


### PR DESCRIPTION
## 요약
- 새로 CLI에 노출된 옵션들을 Astro 문서의 한글/영문 CLI 레퍼런스에 반영했습니다.
- esbuild/Vite 마이그레이션 표에서 실제 CLI에 노출된 옵션이 더 이상 미지원으로 표시되지 않도록 정정했습니다.
- 현재 CLI에 노출되지 않은 내부/계획 옵션 목록에는 실제 미노출 항목만 남겼습니다.

## 검증
- `bunx oxfmt format documents/src/content/docs/reference/cli.md documents/src/content/docs/en/reference/cli.md documents/src/content/docs/guides/migration.md documents/src/content/docs/en/guides/migration.md`
- `bun run --cwd documents build`
- `git diff --check`