### PR TITLE
fix(minifier): inline pass ordering for single-use top-level const (#1631)

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -1077,6 +1077,19 @@ pub const Codegen = struct {
         return node_idx < meta.skip_nodes.capacity() and meta.skip_nodes.isSet(node_idx);
     }
 
+    /// program/block 안 statement 가 출력 단계에서 elide 되는지. mangle skip_nodes 외에
+    /// `minify_whitespace` 모드에서는 `empty_statement` 도 elide — minify pass 가
+    /// dead declaration 을 empty_statement 로 변환한 결과 (`;;;` 누적) 가 그대로 출력
+    /// 되던 cosmetic 갭 정리. esbuild/oxc 도 동일 동작.
+    inline fn isElidedStmt(self: *const Codegen, idx: NodeIndex) bool {
+        if (self.isSkipped(idx)) return true;
+        if (!self.options.minify_whitespace) return false;
+        // `NodeIndex.none` 은 sentinel max — bound check 가 자연 차단.
+        const ni = @intFromEnum(idx);
+        if (ni >= self.ast.nodes.items.len) return false;
+        return self.ast.nodes.items[ni].tag == .empty_statement;
+    }
+
     fn emitProgram(self: *Codegen, node: Node) !void {
         const list = node.data.list;
         const indices = self.ast.extra_data.items[list.start .. list.start + list.len];
@@ -1086,7 +1099,7 @@ pub const Codegen = struct {
             if (node_idx.isNone()) continue;
             // skip_nodes된 statement는 emitNode가 early-return하지만 newline은 이미 찍혀
             // 빈 줄이 남는다 (#1602). 사전 체크로 해당 slot 전체를 건너뛴다.
-            if (self.isSkipped(node_idx)) continue;
+            if (self.isElidedStmt(node_idx)) continue;
             if (emitted) try self.writeNewline();
             try self.emitNode(node_idx);
             emitted = true;
@@ -1116,7 +1129,7 @@ pub const Codegen = struct {
             self.indent_level += 1;
             for (indices) |raw_idx| {
                 const idx: NodeIndex = @enumFromInt(raw_idx);
-                if (self.isSkipped(idx)) continue;
+                if (self.isElidedStmt(idx)) continue;
                 try self.writeNewline();
                 try self.writeIndent();
                 try self.emitNode(idx);

--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -352,12 +352,13 @@ fn runOnce(
         }
     }
     if (ctx.hasSemantic()) {
-        inlineTopLevelPrimitiveConstants(ast, ctx, live_nodes, &changed, scratch);
-        // single-use inline 을 dead-store 보다 먼저 실행 — inline 이 삭제하는 선언은
-        // ref_count==1 (dead-store 는 0 대상) 이므로 간섭 없음. inline 이 먼저 돌면
-        // 연쇄된 새 dead expression 을 같은 iter 의 fold pass 들이 다음 runOnce 에서
-        // 포착하기 쉬움.
+        // single-use inline 이 먼저 — declaration 까지 정리하므로 single-use 케이스를
+        // 통째로 끝낸다. multi-use primitive inline 은 그 후에 돌아 read 만 swap.
+        // 순서를 뒤집으면 (#1631) `inlineTopLevelPrimitiveConstants` 가 ref_count 를
+        // 0 으로 떨궈 single-use case 의 declaration 이 안 지워지고 살아남음
+        // (예: `const kn="["; const out=`<!--${kn}-->`;` → `const e="["` 가 잔존).
         inlineSingleUse(ast, ctx, skip_for_binding, live_nodes, &changed, scratch);
+        inlineTopLevelPrimitiveConstants(ast, ctx, live_nodes, &changed, scratch);
         removeDeadStores(ast, ctx, skip_for_binding, live_nodes, &changed);
     }
     return changed;

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -989,6 +989,71 @@ test "dead store: top-level const 는 tree-shaker 영역 — 유지" {
     try std.testing.expect(std.mem.indexOf(u8, result, "const x = 1") != null);
 }
 
+/// `allow_top_level_inline = true` + `minify_whitespace = true` 로 `--minify` CLI
+/// 시나리오를 그대로 재현. emitter/transpile 양쪽 다 같은 ctx 로 호출하는 경로다.
+fn expectMinifyTopLevelInline(input: []const u8, expected: []const u8) !void {
+    const allocator = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var scanner = try Scanner.init(a, input);
+    var parser = Parser.init(a, &scanner);
+    _ = try parser.parse();
+    var analyzer = SemanticAnalyzer.init(a, &parser.ast);
+    try analyzer.analyze();
+    var transformer = try Transformer.init(a, &parser.ast, .{});
+    try transformer.initSymbolIds(analyzer.symbol_ids.items);
+    transformer.symbols = analyzer.symbols.items;
+    const root = try transformer.transform();
+    const ctx: minify_mod.MinifyCtx = .{
+        .symbols = analyzer.symbols.items,
+        .symbol_ids = transformer.symbol_ids.items,
+        .scopes = analyzer.scopes.items,
+        .unresolved_globals = null,
+        .allow_top_level_inline = true,
+    };
+    minify_mod.minify(transformer.ast, ctx, a, root);
+    minify_mod.mergeDecls(transformer.ast, null);
+
+    var cg = Codegen.initWithOptions(a, transformer.ast, .{ .minify_whitespace = true });
+    const result = try cg.generate(root);
+    const trimmed = std.mem.trimRight(u8, result, "\n");
+    try std.testing.expectEqualStrings(expected, trimmed);
+}
+
+// ---- top-level inline (#1631 ordering 회귀 가드) ----
+
+// `inlineTopLevelPrimitiveConstants` 가 먼저 돌면 single-use 케이스의 ref_count 를
+// 0 으로 떨궈 `inlineSingleUse` 가 declaration 정리할 기회를 빼앗았다 (#1631).
+// 두 pass 의 ordering 이 뒤집히면 아래 케이스의 declaration 이 살아남아 회귀.
+
+test "inline (top-level): single-use primitive const 의 declaration 도 제거 (#1631)" {
+    // 핵심 회귀 가드: kn = "[" 가 한 번만 읽혀 single-use → inline + declaration 정리.
+    // out 자신은 init 이 template_literal (substituted) 이라 isConstantExpr=false →
+    // single-use inline 대상 아님 — declaration 보존됨. mangle 는 helper 가 호출 안 함.
+    try expectMinifyTopLevelInline(
+        "const kn = \"[\"; const out = `<!--${kn}-->`; console.log(out);",
+        "const out=`<!--${\"[\"}-->`;console.log(out);",
+    );
+}
+
+test "inline (top-level): single-use 직접 사용 — declaration 정리 (#1631)" {
+    try expectMinifyTopLevelInline(
+        "const x = 42; console.log(x);",
+        "console.log(42);",
+    );
+}
+
+test "inline (top-level): multi-use primitive const — read swap, declaration 잔존" {
+    // 두 번 이상 사용되면 single-use 게이트 미충족 → inlineTopLevelPrimitiveConstants 만
+    // 동작. read 는 swap 되지만 declaration 은 보존 (read 외 site 가 더 있을 가능성 대비).
+    try expectMinifyTopLevelInline(
+        "const x = 1; console.log(x); console.log(x);",
+        "const x=1;console.log(1);console.log(1);",
+    );
+}
+
 // ---- reference_count decrement 검증 ----
 
 test "dead store: cascading — y dead 여부는 x 제거의 감산으로 결정" {


### PR DESCRIPTION
## 요약

이슈 #1631 의 single-use const inline 갭을 minify pass ordering 수정으로 해결합니다.

`--minify` 했을 때 아래 케이스의 `const kn = \"[\"` declaration 이 정리되지 않고 살아남던 문제:

```js
// 입력
const kn = \"[\";
const out = \`<!--\${kn}-->\`;
console.log(out);
```

```js
// Before (main):  ${kn} 자리는 inline 됐는데 const kn 자체는 잔존
const e=\"[\",t=\`<!--\${\"[\"}-->\`;console.log(t);

// After (this PR): kn declaration 깔끔하게 제거
const t=\`<!--\${\"[\"}-->\`;console.log(t);
```

## 원인

`src/transformer/minify.zig:runOnce` 안에서 두 inline pass 가 순서대로 돕니다:

1. `inlineTopLevelPrimitiveConstants` — top-level primitive const 의 **모든** read 위치에 in-place swap 하지만 declaration 은 보존 (multi-use 도 처리 가능). swap 마다 `ref_deltas[sym] += 1`.
2. `inlineSingleUse` — single-use (effective `ref_count == 1`) 인 경우 read swap + **declaration 도 empty_statement 로 변환**.

문제: 1번이 먼저 돌아 single-use 케이스의 `effective_ref_count` 를 0 으로 떨궈 버립니다. 2번이 돌 때 `if (ctx.effectiveRefCount(sym_id) != 1 or sym.write_count != 0) return;` 게이트에서 빠지므로 declaration 정리 기회를 잃음. `removeDeadStores` 도 `scope_idx == 0` 게이트로 top-level 은 skip — tree-shaker 영역으로 위임된다는 가정인데, transpile-only / inline 결과 dead 의 케이스가 누락됨.

## 수정

순서를 뒤집어 `inlineSingleUse` 가 먼저 single-use 케이스를 통째로 끝내고, 그 후 `inlineTopLevelPrimitiveConstants` 가 multi-use 만 read swap 합니다. 두 pass 모두 ref_delta 만 증가시키므로 순서 교체로 ref count 의미 자체는 보존되며, fixed-point 루프 횟수에도 영향 없음 (둘 다 O(n), 두 pass 사이 순환 의존성 없음).

## 부수 수정 (codegen cosmetic 갭)

dead store removal 결과 누적된 `empty_statement` 가 `;;;` 로 출력되던 cosmetic 갭도 같이 정리. `Codegen.isElidedStmt` helper 추가 — `minify_whitespace` 모드에선 program/block 안의 `empty_statement` 도 elide. esbuild/oxc 도 동일 동작.

```js
// Before
function f(x){;;return x}console.log(f(5));

// After
function f(x){return x}console.log(f(5));
```

## Zig 초보자 노트

`runOnce` 의 두 inline pass 는 **AST 노드를 in-place 로 swap** 만 함 (parser 가 만든 노드 슬롯 위에 다른 노드 데이터를 덮어쓰는 방식). 즉 새 노드 추가 비용이 없는 대신, **두 pass 가 같은 슬롯을 어떻게 다루는지의 ordering 이 의미를 갖게 됨**. 이번 버그가 그 hidden coupling 의 전형적 예시. fixed-point 루프 안에서 매 iter 호출되므로 다음 iter 에 다시 잡힐 것 같지만, 첫 iter 에 ref count 가 0 으로 떨어지면 single-use 게이트가 영구히 닫혀 결국 declaration 이 살아남게 됩니다.

## 검증

- 신규 회귀 가드 테스트 3건 (`src/transformer/minify_test.zig`):
  - single-use primitive const 의 declaration 도 제거 (#1631 핵심)
  - single-use 직접 사용 — declaration 정리
  - multi-use primitive const — read swap, declaration 잔존 (`inlineTopLevelPrimitiveConstants` 의 보존 동작 회귀 가드)
- zig 단위 테스트 4611개 전부 통과
- 통합 테스트 3675개 전부 통과
- ReleaseFast 빌드 + 통합 테스트 모두 통과
- `tests/benchmark/smoke.ts` size 비교 회귀 없음

## Follow-up

- `expectMinifyTopLevelInline` 가 `expectMinifyDead` 와 boilerplate 패턴이 겹침. 같은 패턴이 동일 파일 4-5 곳 (await using / cascading / super / tree-shaker) 에 있어, 일관된 통합은 별도 PR 로 진행 예정 (이번 PR scope 밖).
- codegen 의 `;` 정리는 program/block 단에만 적용. switch case body / try body 등에서 `empty_statement` 가 남는 케이스가 있는지는 별도 audit 필요 (실측상 minify path 에서 이슈 없음).

Closes #1631