### PR TITLE
perf(ast): dedupe addString storage

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -986,7 +986,11 @@ pub const Ast = struct {
         return cloned;
     }
 
+    /// 호출자(`cloneForTransformer`)의 `errdefer cloned.deinit()` 가 부분 채워진 map 의
+    /// 누적 owned key 를 정리한다. 이 함수의 inner `errdefer free(key)` 는 직전 dupe 만
+    /// 보호하므로, 다른 caller 에서 쓰려면 동등한 cleanup 을 직접 보장해야 한다.
     fn cloneStringInternsFrom(self: *Ast, source_ast: *const Ast) !void {
+        try self.string_interns.ensureTotalCapacity(self.allocator, source_ast.string_interns.count());
         var it = source_ast.string_interns.iterator();
         while (it.next()) |entry| {
             const key = try self.allocator.dupe(u8, entry.key_ptr.*);
@@ -1346,8 +1350,8 @@ pub const Ast = struct {
             .end = end | STRING_TABLE_BIT,
         };
 
-        // HashMap key는 append/realloc 전에 별도 소유권으로 복사한다.
-        // text가 string_table 내부 slice인 경우에도 이 복사본 덕분에 안전하다.
+        // string_table append 전에 dupe — text 가 self-slice 인 경우 append 의 realloc 으로
+        // text.ptr 이 dangling 이 되어 이후 hash/eql 이 use-after-free 됨.
         const owned_key = try self.allocator.dupe(u8, text);
         errdefer self.allocator.free(owned_key);
 

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -872,6 +872,11 @@ pub const Ast = struct {
     /// getText(span)으로 투명하게 접근.
     string_table: std.ArrayList(u8),
 
+    /// addString 전용 intern map.
+    /// key 는 string_table slice 가 아니라 별도 owned copy 다. string_table 은 addString 중
+    /// realloc 될 수 있으므로 내부 slice 를 key 로 쓰면 dangling 이 된다.
+    string_interns: std.StringHashMapUnmanaged(Span),
+
     /// 파싱 중 JSX element/fragment가 발견되었는지 (automatic JSX import 주입용)
     has_jsx: bool = false,
 
@@ -925,6 +930,7 @@ pub const Ast = struct {
             .nodes = .empty,
             .extra_data = .empty,
             .string_table = .empty,
+            .string_interns = .empty,
             .allocator = allocator,
             .source = source,
         };
@@ -934,6 +940,15 @@ pub const Ast = struct {
         self.nodes.deinit(self.allocator);
         self.extra_data.deinit(self.allocator);
         self.string_table.deinit(self.allocator);
+        self.deinitStringInterns();
+    }
+
+    fn deinitStringInterns(self: *Ast) void {
+        var it = self.string_interns.keyIterator();
+        while (it.next()) |key| {
+            self.allocator.free(key.*);
+        }
+        self.string_interns.deinit(self.allocator);
     }
 
     /// 트랜스포머용 AST 복제본을 생성한다.
@@ -946,6 +961,7 @@ pub const Ast = struct {
             .nodes = .empty,
             .extra_data = .empty,
             .string_table = .empty,
+            .string_interns = .empty,
             .source = source_ast.source,
             .has_jsx = source_ast.has_jsx,
             .has_jsx_key_after_spread = source_ast.has_jsx_key_after_spread,
@@ -966,7 +982,17 @@ pub const Ast = struct {
         try cloned.nodes.appendSlice(allocator, source_ast.nodes.items);
         try cloned.extra_data.appendSlice(allocator, source_ast.extra_data.items);
         try cloned.string_table.appendSlice(allocator, source_ast.string_table.items);
+        try cloned.cloneStringInternsFrom(source_ast);
         return cloned;
+    }
+
+    fn cloneStringInternsFrom(self: *Ast, source_ast: *const Ast) !void {
+        var it = source_ast.string_interns.iterator();
+        while (it.next()) |entry| {
+            const key = try self.allocator.dupe(u8, entry.key_ptr.*);
+            errdefer self.allocator.free(key);
+            try self.string_interns.put(self.allocator, key, entry.value_ptr.*);
+        }
     }
 
     /// 노드를 추가하고 인덱스를 반환한다.
@@ -1309,9 +1335,21 @@ pub const Ast = struct {
     ///   const span = try ast.addString("React");
     ///   // 나중에 ast.getText(span)으로 "React" 반환
     pub fn addString(self: *Ast, text: []const u8) !Span {
+        if (self.string_interns.get(text)) |span| return span;
+
         // string_table은 bit 31 미만이어야 함 (bit 31은 마커로 사용)
         std.debug.assert(self.string_table.items.len + text.len < STRING_TABLE_BIT);
         const start: u32 = @intCast(self.string_table.items.len);
+        const end: u32 = @intCast(start + text.len);
+        const span = Span{
+            .start = start | STRING_TABLE_BIT,
+            .end = end | STRING_TABLE_BIT,
+        };
+
+        // HashMap key는 append/realloc 전에 별도 소유권으로 복사한다.
+        // text가 string_table 내부 slice인 경우에도 이 복사본 덕분에 안전하다.
+        const owned_key = try self.allocator.dupe(u8, text);
+        errdefer self.allocator.free(owned_key);
 
         // text가 string_table 자기 자신의 슬라이스일 수 있다.
         // appendSlice는 ensureUnusedCapacity에서 realloc을 일으키면서
@@ -1337,11 +1375,8 @@ pub const Ast = struct {
         } else {
             try self.string_table.appendSlice(self.allocator, text);
         }
-        const end: u32 = @intCast(self.string_table.items.len);
-        return .{
-            .start = start | STRING_TABLE_BIT,
-            .end = end | STRING_TABLE_BIT,
-        };
+        try self.string_interns.put(self.allocator, owned_key, span);
+        return span;
     }
 
     /// Span이 가리키는 텍스트를 반환한다.

--- a/src/parser/ast_test.zig
+++ b/src/parser/ast_test.zig
@@ -115,3 +115,124 @@ test "Ast string_table: addString + getText" {
     // 이전 span은 여전히 유효
     try std.testing.expectEqualStrings("React", ast.getText(synth_span));
 }
+
+test "Ast string_table: addString deduplicates repeated text" {
+    var ast = Ast.init(std.testing.allocator, "");
+    defer ast.deinit();
+
+    const first = try ast.addString("Object");
+    const second = try ast.addString("Object");
+    const third = try ast.addString("defineProperty");
+    const fourth = try ast.addString("Object");
+
+    try std.testing.expectEqual(first.start, second.start);
+    try std.testing.expectEqual(first.end, second.end);
+    try std.testing.expectEqual(first.start, fourth.start);
+    try std.testing.expectEqual(first.end, fourth.end);
+    try std.testing.expect(first.start != third.start);
+    try std.testing.expectEqualStrings("Object", ast.getText(first));
+    try std.testing.expectEqualStrings("defineProperty", ast.getText(third));
+    try std.testing.expectEqual(@as(usize, "Object".len + "defineProperty".len), ast.string_table.items.len);
+}
+
+test "Ast string_table: addString deduplicates string_table self slices" {
+    var ast = Ast.init(std.testing.allocator, "");
+    defer ast.deinit();
+
+    const span = try ast.addString("React");
+    const text = ast.getText(span);
+    const again = try ast.addString(text);
+
+    try std.testing.expectEqual(span.start, again.start);
+    try std.testing.expectEqual(span.end, again.end);
+    try std.testing.expectEqual(@as(usize, "React".len), ast.string_table.items.len);
+}
+
+test "Ast string_table: cloned AST keeps string interning table" {
+    var ast = Ast.init(std.testing.allocator, "");
+    defer ast.deinit();
+
+    const original_span = try ast.addString("children");
+
+    var cloned = try Ast.cloneForTransformer(&ast, std.testing.allocator);
+    defer cloned.deinit();
+
+    const cloned_span = try cloned.addString("children");
+    const other_span = try cloned.addString("props");
+
+    try std.testing.expectEqual(original_span.start, cloned_span.start);
+    try std.testing.expectEqual(original_span.end, cloned_span.end);
+    try std.testing.expectEqualStrings("children", cloned.getText(cloned_span));
+    try std.testing.expectEqualStrings("props", cloned.getText(other_span));
+    try std.testing.expectEqual(@as(usize, "children".len + "props".len), cloned.string_table.items.len);
+}
+
+test "Ast string_table: addString deduplicates empty string" {
+    var ast = Ast.init(std.testing.allocator, "");
+    defer ast.deinit();
+
+    const first = try ast.addString("");
+    const second = try ast.addString("");
+
+    try std.testing.expectEqual(first.start, second.start);
+    try std.testing.expectEqual(first.end, second.end);
+    try std.testing.expectEqual(first.start, first.end);
+    try std.testing.expectEqualStrings("", ast.getText(first));
+    try std.testing.expectEqual(@as(usize, 0), ast.string_table.items.len);
+}
+
+test "Ast string_table: addString keeps distinct prefix and suffix strings separate" {
+    var ast = Ast.init(std.testing.allocator, "");
+    defer ast.deinit();
+
+    const obj = try ast.addString("Object");
+    const object_assign = try ast.addString("Object.assign");
+    const assign = try ast.addString("assign");
+    const obj_again = try ast.addString("Object");
+
+    try std.testing.expectEqual(obj.start, obj_again.start);
+    try std.testing.expectEqual(obj.end, obj_again.end);
+    try std.testing.expect(obj.start != object_assign.start);
+    try std.testing.expect(obj.start != assign.start);
+    try std.testing.expect(object_assign.start != assign.start);
+    try std.testing.expectEqualStrings("Object", ast.getText(obj));
+    try std.testing.expectEqualStrings("Object.assign", ast.getText(object_assign));
+    try std.testing.expectEqualStrings("assign", ast.getText(assign));
+}
+
+test "Ast string_table: interned spans survive later reallocations" {
+    var ast = Ast.init(std.testing.allocator, "");
+    defer ast.deinit();
+
+    const stable = try ast.addString("stable");
+    try ast.string_table.ensureTotalCapacity(ast.allocator, ast.string_table.items.len + 1);
+
+    var buf: [64]u8 = undefined;
+    for (0..256) |i| {
+        const text = try std.fmt.bufPrint(&buf, "generated_name_{d}", .{i});
+        _ = try ast.addString(text);
+    }
+
+    const stable_again = try ast.addString("stable");
+    try std.testing.expectEqual(stable.start, stable_again.start);
+    try std.testing.expectEqual(stable.end, stable_again.end);
+    try std.testing.expectEqualStrings("stable", ast.getText(stable_again));
+}
+
+test "Ast string_table: cloned intern table is independent from source AST" {
+    var ast = Ast.init(std.testing.allocator, "");
+
+    const first = try ast.addString("shared");
+    var cloned = try Ast.cloneForTransformer(&ast, std.testing.allocator);
+    ast.deinit();
+    defer cloned.deinit();
+
+    const cloned_same = try cloned.addString("shared");
+    const cloned_new = try cloned.addString("clone-only");
+
+    try std.testing.expectEqual(first.start, cloned_same.start);
+    try std.testing.expectEqual(first.end, cloned_same.end);
+    try std.testing.expectEqualStrings("shared", cloned.getText(cloned_same));
+    try std.testing.expectEqualStrings("clone-only", cloned.getText(cloned_new));
+    try std.testing.expectEqual(@as(usize, "shared".len + "clone-only".len), cloned.string_table.items.len);
+}


### PR DESCRIPTION
## 요약
- `Ast.addString`에 owned-key intern map을 추가해 동일 합성 문자열의 `string_table` 중복 append를 방지했습니다.
- `cloneForTransformer`가 intern table도 함께 복사하도록 처리했습니다.
- 반복 문자열, self-slice, clone, empty string, prefix/suffix, realloc 안정성 케이스를 테스트로 추가했습니다.

## 테스트
- `zig fmt src/parser/ast.zig src/parser/ast_test.zig --check`
- `zig build test -Dtest-filter="string_table" --summary all`
- `zig build test -Dtest-filter="parser" --summary all`
- `zig build test -Dtest-filter="transformer" --summary all`
- `zig build test --summary all`
- `git diff --check`

Closes #1512