### PR TITLE
perf(tree-shaking): fold numeric const chains

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "build:zts": "zig build -Doptimize=ReleaseFast",
     "lint": "oxlint --ignore-pattern '**/fixtures/**' --ignore-pattern '**/dist/**' packages/ tests/integration tests/e2e tests/benchmark",
     "lint:fix": "oxlint --fix --ignore-pattern '**/fixtures/**' --ignore-pattern '**/dist/**' packages/ tests/integration tests/e2e tests/benchmark",
-    "fmt": "oxfmt format packages/ tests/integration tests/e2e tests/benchmark '!**/dist/**'",
-    "fmt:check": "oxfmt format --check packages/ tests/integration tests/e2e tests/benchmark '!**/dist/**'",
+    "fmt": "oxfmt format packages/ tests/integration tests/e2e tests/benchmark '!**/dist/**' '!**/test-results/**'",
+    "fmt:check": "oxfmt format --check packages/ tests/integration tests/e2e tests/benchmark '!**/dist/**' '!**/test-results/**'",
     "playwright:install": "cd tests/e2e && bunx playwright install --with-deps chromium"
   },
   "devDependencies": {

--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -428,7 +428,7 @@ describe("@zts/core buildSync", () => {
     rmSync(keepDir, { recursive: true, force: true });
   });
 
-  test("graph pre-pass skip: no-op ESM/TS bundle output stays stable", () => {
+  test("graph pre-pass skip: no-op ESM/TS bundle still folds numeric const imports", () => {
     const skipDir = mkdtempSync(join(tmpdir(), "zts-prepass-skip-esm-"));
     writeFileSync(join(skipDir, "dep.ts"), "export const value: number = 41;");
     writeFileSync(
@@ -438,7 +438,8 @@ describe("@zts/core buildSync", () => {
     const result = buildSync({ entryPoints: [join(skipDir, "app.ts")] });
     expect(result.errors.length).toBe(0);
     expect(result.outputFiles[0].text).toContain("answer");
-    expect(result.outputFiles[0].text).toContain("value");
+    expect(result.outputFiles[0].text).toContain("42");
+    expect(result.outputFiles[0].text).not.toContain("value");
     expect(result.outputFiles[0].text).not.toContain(": number");
     rmSync(skipDir, { recursive: true, force: true });
   });

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -693,6 +693,7 @@ pub const Bundler = struct {
         worker_graph.emotion_extra_css_sources = self.options.emotion_extra_css_sources;
         worker_graph.emotion_extra_styled_sources = self.options.emotion_extra_styled_sources;
         worker_graph.code_splitting = self.options.code_splitting;
+        worker_graph.preserve_modules = self.options.preserve_modules;
         worker_graph.minify_identifiers = self.options.minify_identifiers;
         worker_graph.transform_options_base = self.buildTransformOptionsBase();
         defer worker_graph.deinit();
@@ -869,6 +870,7 @@ pub const Bundler = struct {
         graph.emotion_extra_css_sources = self.options.emotion_extra_css_sources;
         graph.emotion_extra_styled_sources = self.options.emotion_extra_styled_sources;
         graph.code_splitting = self.options.code_splitting;
+        graph.preserve_modules = self.options.preserve_modules;
         graph.minify_identifiers = self.options.minify_identifiers;
         graph.transform_options_base = self.buildTransformOptionsBase();
         defer graph.deinit();
@@ -1001,13 +1003,16 @@ pub const Bundler = struct {
         var shaker: ?TreeShaker = if (!self.options.dev_mode and self.options.scope_hoist and self.options.tree_shaking) blk: {
             var s = try TreeShaker.init(self.allocator, &graph, &(linker.?));
             try s.analyze(self.options.entry_points);
-            if (self.options.minify_syntax and !self.options.code_splitting) {
-                // tree-shaker 가 module.semantic 을 재생성한 뒤이므로 stale rename/mangling
-                // 을 비우고 다시 계산해야 emit 단계에서 새 symbol id 를 따라가는 산출물이 된다.
+            if (s.ast_mutated_after_link and !self.options.code_splitting) {
+                // tree-shaker 가 link 이후 module.semantic 을 재생성한 뒤이므로 stale
+                // rename/mangling 을 비우고 다시 계산해야 emit 단계에서 새 symbol id 를
+                // 따라가는 산출물이 된다. numeric post-pass 는 --minify 없이도 AST 를
+                // mutation 할 수 있으므로 minify_syntax 여부에 묶지 않는다.
                 try (&(linker.?)).finalize(.{
                     .compute_renames = true,
                     .compute_mangling = self.options.minify_identifiers,
                     .clear_first = true,
+                    .populate_namespace_accesses = false,
                 });
             }
             // metadata builder 가 `Module.is_included` 비트를 신뢰해 tree-shake 된 target 의

--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -762,7 +762,7 @@ test "Scope hoisting: import used in expression" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "WIDTH * 2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "const area = 200;") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "const WIDTH = 100;") != null);
 }
 

--- a/src/bundler/bundler_test/expressions.zig
+++ b/src/bundler/bundler_test/expressions.zig
@@ -476,7 +476,7 @@ test "Default: default export used in expression" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "* 10") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "const result = 50;") != null);
 }
 
 // ============================================================

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -1068,7 +1068,8 @@ test "ESM live binding: init only contains dependency init calls" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "dep.js",
-        \\export const value = 42;
+        \\export const value = getValue();
+        \\function getValue() { return 42; }
     );
     try writeFile(tmp.dir, "mod.js",
         \\import { value } from './dep.js';
@@ -2581,9 +2582,9 @@ test "entry_error_guard #5: 다중 chain entry — 각 import 의 init 호출이
     // 각 모듈 init 호출이 별 top-level `__zts_guarded(...)` statement 가 됨.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    try writeFile(tmp.dir, "a.js", "export const a = 1;\n");
-    try writeFile(tmp.dir, "b.js", "export const b = 2;\n");
-    try writeFile(tmp.dir, "c.js", "export const c = 3;\n");
+    try writeFile(tmp.dir, "a.js", "globalThis.__guardA = 1; export const a = globalThis.__guardA;\n");
+    try writeFile(tmp.dir, "b.js", "globalThis.__guardB = 2; export const b = globalThis.__guardB;\n");
+    try writeFile(tmp.dir, "c.js", "globalThis.__guardC = 3; export const c = globalThis.__guardC;\n");
     try writeFile(tmp.dir, "entry.js",
         \\import { a } from './a.js';
         \\import { b } from './b.js';
@@ -2798,7 +2799,7 @@ test "entry_error_guard #14: 비-entry 모듈의 chain 도 wrap (preamble + side
     // 패턴으로 emit (linker preamble + esm_wrap side-effect 양쪽).
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    try writeFile(tmp.dir, "leaf.js", "export const v = 1;\n");
+    try writeFile(tmp.dir, "leaf.js", "export const v = getV();\nfunction getV() { return 1; }\n");
     try writeFile(tmp.dir, "mid.js",
         \\import { v } from './leaf.js';
         \\export const m = v + 1;
@@ -2854,7 +2855,7 @@ test "entry_error_guard #16: GUARD_LAMBDA 매크로 형식 — esm_wrap / metada
     // 가 깨짐 (`__zts_guarded(function(){return X;})` 만 helper 가 받음).
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    try writeFile(tmp.dir, "leaf.js", "export const v = 1;\n");
+    try writeFile(tmp.dir, "leaf.js", "export const v = getV();\nfunction getV() { return 1; }\n");
     try writeFile(tmp.dir, "entry.js",
         \\import './leaf.js';
         \\import { v } from './leaf.js';

--- a/src/bundler/bundler_test/resolution.zig
+++ b/src/bundler/bundler_test/resolution.zig
@@ -365,7 +365,7 @@ test "Format: IIFE scope_hoist entry exports" {
 
     try std.testing.expect(!result.hasErrors());
     try std.testing.expect(std.mem.startsWith(u8, result.output, "(() => {\n"));
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "value * 2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "const doubled = 42;") != null);
 }
 
 // ============================================================

--- a/src/bundler/bundler_test/splitting_dev.zig
+++ b/src/bundler/bundler_test/splitting_dev.zig
@@ -704,7 +704,7 @@ test "CodeSplitting: CRITICAL — rename collision between import binding and lo
         \\import { val } from './shared';
         \\console.log(val);
     );
-    try writeFile(tmp.dir, "shared.ts", "export const val = 42;");
+    try writeFile(tmp.dir, "shared.ts", "export const val = getVal();\nfunction getVal() { return 42; }");
 
     const a_path = try absPath(&tmp, "a.ts");
     defer std.testing.allocator.free(a_path);
@@ -728,8 +728,8 @@ test "CodeSplitting: CRITICAL — rename collision between import binding and lo
     // shared 청크에 export { val } 있어야 함
     var shared_has_export = false;
     for (outputs) |o| {
-        if (std.mem.indexOf(u8, o.contents, "const val = 42") != null or
-            std.mem.indexOf(u8, o.contents, "const val=42") != null)
+        if (std.mem.indexOf(u8, o.contents, "const val = getVal()") != null or
+            std.mem.indexOf(u8, o.contents, "const val=getVal()") != null)
         {
             shared_has_export = std.mem.indexOf(u8, o.contents, "export") != null;
         }

--- a/src/bundler/bundler_test/typescript_format.zig
+++ b/src/bundler/bundler_test/typescript_format.zig
@@ -218,12 +218,10 @@ test "Deep chain: diamond dependency (A→B,C; B→D; C→D)" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // d가 b, c보다 먼저 (공유 leaf)
-    const d_pos = std.mem.indexOf(u8, result.output, "const d = 100;") orelse return error.TestUnexpectedResult;
-    const b_pos = std.mem.indexOf(u8, result.output, "d + 1") orelse return error.TestUnexpectedResult;
-    const c_pos = std.mem.indexOf(u8, result.output, "d + 2") orelse return error.TestUnexpectedResult;
-    try std.testing.expect(d_pos < b_pos);
-    try std.testing.expect(d_pos < c_pos);
+    // numeric const chain이 접혀 b, c에 직접 반영된다.
+    const b_pos = std.mem.indexOf(u8, result.output, "const b = 101;") orelse return error.TestUnexpectedResult;
+    const c_pos = std.mem.indexOf(u8, result.output, "const c = 102;") orelse return error.TestUnexpectedResult;
+    try std.testing.expect(b_pos < c_pos);
 }
 
 // ============================================================
@@ -828,12 +826,8 @@ test "Complex: transitive import chain with values" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // base, config 가 compute보다 먼저
-    const base_pos = std.mem.indexOf(u8, result.output, "base = 10") orelse return error.TestUnexpectedResult;
-    const mult_pos = std.mem.indexOf(u8, result.output, "multiplier = 5") orelse return error.TestUnexpectedResult;
-    const result_pos = std.mem.indexOf(u8, result.output, "base * multiplier") orelse return error.TestUnexpectedResult;
-    try std.testing.expect(base_pos < result_pos);
-    try std.testing.expect(mult_pos < result_pos);
+    // base/config numeric const chain이 result에 직접 fold된다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "result = 50") != null);
 }
 
 test "Complex: multiple entry points sharing a module" {
@@ -965,8 +959,8 @@ test "Complex: destructuring imports used in complex expressions" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "width * height") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "width + height") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "const area = 200") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "2 * (30)") != null);
 }
 
 // ============================================================

--- a/src/bundler/constant_facts.zig
+++ b/src/bundler/constant_facts.zig
@@ -25,6 +25,15 @@ fn constValueNode(ast: *Ast, cv: ConstValue) ?Node {
                 .data = .{ .none = 0 },
             };
         },
+        .number => blk: {
+            if (cv.number_text.len == 0) break :blk null;
+            const span = ast.addString(cv.number_text) catch return null;
+            break :blk .{
+                .tag = .numeric_literal,
+                .span = span,
+                .data = .{ .none = 0 },
+            };
+        },
         else => null,
     };
 }
@@ -62,4 +71,74 @@ pub fn materialize(
         changed = true;
     }
     return changed;
+}
+
+test "constant_facts: numeric const value materializes to numeric literal node" {
+    const Scanner = @import("../lexer/scanner.zig").Scanner;
+    const Parser = @import("../parser/parser.zig").Parser;
+
+    const allocator = std.testing.allocator;
+    var scanner = try Scanner.init(allocator, "console.log(n + 2);");
+    defer scanner.deinit();
+    var parser = Parser.init(allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    var symbol_ids = try allocator.alloc(?u32, parser.ast.nodes.items.len);
+    defer allocator.free(symbol_ids);
+    @memset(symbol_ids, null);
+
+    var target_idx: ?usize = null;
+    for (parser.ast.nodes.items, 0..) |node, i| {
+        if (node.tag == .identifier_reference and std.mem.eql(u8, parser.ast.getText(node.span), "n")) {
+            symbol_ids[i] = 7;
+            target_idx = i;
+            break;
+        }
+    }
+    const idx = target_idx orelse return error.MissingIdentifier;
+
+    var const_values: std.AutoHashMapUnmanaged(u32, ConstValue) = .{};
+    defer const_values.deinit(allocator);
+    try const_values.put(allocator, 7, .{ .kind = .number, .number_text = "123" });
+
+    try std.testing.expect(materialize(allocator, &parser.ast, symbol_ids, &const_values));
+    const node = parser.ast.nodes.items[idx];
+    try std.testing.expectEqual(Node.Tag.numeric_literal, node.tag);
+    try std.testing.expectEqualStrings("123", parser.ast.getText(node.span));
+}
+
+test "constant_facts: numeric const value does not replace object shorthand key" {
+    const Scanner = @import("../lexer/scanner.zig").Scanner;
+    const Parser = @import("../parser/parser.zig").Parser;
+
+    const allocator = std.testing.allocator;
+    var scanner = try Scanner.init(allocator, "const obj = { n };");
+    defer scanner.deinit();
+    var parser = Parser.init(allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    var symbol_ids = try allocator.alloc(?u32, parser.ast.nodes.items.len);
+    defer allocator.free(symbol_ids);
+    @memset(symbol_ids, null);
+
+    var target_idx: ?usize = null;
+    for (parser.ast.nodes.items, 0..) |node, i| {
+        if (node.tag == .identifier_reference and std.mem.eql(u8, parser.ast.getText(node.span), "n")) {
+            symbol_ids[i] = 7;
+            target_idx = i;
+            break;
+        }
+    }
+    const idx = target_idx orelse return error.MissingIdentifier;
+
+    var const_values: std.AutoHashMapUnmanaged(u32, ConstValue) = .{};
+    defer const_values.deinit(allocator);
+    try const_values.put(allocator, 7, .{ .kind = .number, .number_text = "123" });
+
+    try std.testing.expect(!materialize(allocator, &parser.ast, symbol_ids, &const_values));
+    const node = parser.ast.nodes.items[idx];
+    try std.testing.expectEqual(Node.Tag.identifier_reference, node.tag);
+    try std.testing.expectEqualStrings("n", parser.ast.getText(node.span));
 }

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -181,6 +181,9 @@ pub const ModuleGraph = struct {
     /// 활성 — single-bundle 모드는 helper module 의 declaration 이 statement-level shake
     /// 로 elide 되는 회귀가 있어 기존 preamble 모델 유지.
     code_splitting: bool = false,
+    /// preserve-modules 활성화. 원본 모듈별 출력 파일 보존이 계약이므로 tree-shaker의
+    /// cross-module 축약이 모듈 경계를 제거하지 않도록 한다.
+    preserve_modules: bool = false,
     /// identifier mangling 활성화. transformer pre-pass 이후 생성된 임시 binding도
     /// mangler 입력에 포함하려고 transformed AST semantic을 재구축할 때 사용.
     minify_identifiers: bool = false,

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -2660,6 +2660,7 @@ pub const Linker = struct {
         compute_renames: bool,
         compute_mangling: bool,
         clear_first: bool = false,
+        populate_namespace_accesses: bool = true,
     }) !void {
         if (opts.clear_first) {
             self.clearCanonicalNames();
@@ -2671,7 +2672,7 @@ pub const Linker = struct {
         }
         self.populateReExportAliases();
         self.populateImportSymbols();
-        self.populateNamespaceAccesses();
+        if (opts.populate_namespace_accesses) self.populateNamespaceAccesses();
         self.populateSymbolRefCounts();
     }
 

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -887,6 +887,7 @@ pub fn buildCrossModuleConstValues(
         if (rec.resolved.isNone()) continue;
         const canon = self.resolveExportChain(rec.resolved, ib.imported_name, 0) orelse continue;
         const target_module = self.graph.getModule(canon.module_index) orelse continue;
+        if (target_module.cycle_group != 0) continue;
         const target_sem = target_module.semantic orelse continue;
         if (target_sem.scope_maps.len == 0) continue;
         // export_name → local_name 매핑

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -17,7 +17,9 @@
 const std = @import("std");
 const types = @import("types.zig");
 const ModuleIndex = types.ModuleIndex;
-const Module = @import("module.zig").Module;
+const module_mod = @import("module.zig");
+const Module = module_mod.Module;
+const ModuleSemanticData = module_mod.ModuleSemanticData;
 const ModuleGraph = @import("graph.zig").ModuleGraph;
 const ExportBinding = @import("binding_scanner.zig").ExportBinding;
 const ImportBinding = @import("binding_scanner.zig").ImportBinding;
@@ -26,11 +28,13 @@ const ast_mod = @import("../parser/ast.zig");
 const Ast = ast_mod.Ast;
 const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
+const ast_walk = @import("../parser/ast_walk.zig");
 const Kind = @import("../lexer/token.zig").Kind;
 const purity = @import("purity.zig");
 const stmt_info_mod = @import("stmt_info.zig");
 const StmtInfos = stmt_info_mod.ModuleStmtInfos;
 const constant_facts = @import("constant_facts.zig");
+const ConstValue = @import("../semantic/symbol.zig").ConstValue;
 const runtime_helper_modules = @import("../runtime_helper_modules.zig");
 
 /// `used_exports`의 all-exports-used sentinel. 모듈의 전체 export가 사용됨을 표시.
@@ -59,12 +63,26 @@ inline fn moduleHasEvaluationEffect(mod: *const Module) bool {
     return false;
 }
 
+fn constValuesContainNumber(const_values: *const std.AutoHashMapUnmanaged(u32, ConstValue)) bool {
+    var it = const_values.valueIterator();
+    while (it.next()) |cv| {
+        if (cv.kind == .number) return true;
+    }
+    return false;
+}
+
+const ConstMaterializeFilter = enum {
+    all,
+    numeric,
+    numeric_export_chain,
+};
+
 pub const TreeShaker = struct {
     allocator: std.mem.Allocator,
     /// Module storage 접근 포인터 (#1779 PR #2). 기존 `[]const Module` slice
     /// 필드를 대체. `analyze` 내부에서 `module.side_effects` 를 mutate 하므로 non-const.
     graph: *ModuleGraph,
-    linker: *const Linker,
+    linker: *Linker,
     included: std.DynamicBitSet,
     used_exports: std.StringHashMap(void),
     entry_set: std.DynamicBitSet,
@@ -86,10 +104,18 @@ pub const TreeShaker = struct {
     /// 모듈 인덱스가 다른 모듈의 `export * from` source 인지 표시. tryMarkReExportNsSubset
     /// 에서 chain 추적 시 O(M·E) scan 대신 O(1) 조회 (#1928).
     re_export_star_targets: ?std.DynamicBitSet = null,
+    /// numeric const fact propagation 의 DFS 스크래치. propagateNumericExportConstFacts /
+    /// nodeContainsNumericConstRef / nodeIsNumericLiteralFoldSeed 가 매 호출마다
+    /// ArrayList 를 새로 만들지 않도록 재사용. clearRetainingCapacity 로만 비운다.
+    numeric_dfs_stack: std.ArrayList(NodeIndex) = .empty,
+    /// Linker finalize 이후 AST mutation + semantic resync가 발생했는지.
+    /// true면 old symbol id 기준 rename/mangle metadata를 재계산해야 한다.
+    ast_mutated_after_link: bool = false,
 
     const max_fixpoint_iterations: u32 = 100;
+    const max_numeric_const_post_passes: u32 = 2;
 
-    pub fn init(allocator: std.mem.Allocator, graph: *ModuleGraph, linker: *const Linker) !TreeShaker {
+    pub fn init(allocator: std.mem.Allocator, graph: *ModuleGraph, linker: *Linker) !TreeShaker {
         const mod_count = graph.moduleCount();
         var included = try std.DynamicBitSet.initEmpty(allocator, mod_count);
         errdefer included.deinit();
@@ -141,6 +167,7 @@ pub const TreeShaker = struct {
         if (self.has_direct_used_export.len > 0) {
             self.allocator.free(self.has_direct_used_export);
         }
+        self.numeric_dfs_stack.deinit(self.allocator);
     }
 
     /// 내부 단축 helper. `self.graph.getModule(ModuleIndex.fromUsize(idx))` 의 반복 방지.
@@ -151,6 +178,302 @@ pub const TreeShaker = struct {
     /// mutate 필요한 경로용.
     inline fn moduleAtMut(self: *const TreeShaker, idx: u32) ?*Module {
         return self.graph.moduleAtMut(ModuleIndex.fromUsize(idx));
+    }
+
+    /// `root` 에서 도달 가능한 노드를 DFS 로 순회하며 `visit_fn` 을 호출한다.
+    /// `visit_fn` 이 true 를 반환하면 즉시 short-circuit. scratch stack 은 TreeShaker
+    /// 가 보유한 것을 재사용 — 중첩 호출 금지.
+    fn anyReachableNode(
+        self: *TreeShaker,
+        ast: *const Ast,
+        root: NodeIndex,
+        ctx: anytype,
+        comptime visit_fn: fn (ctx: @TypeOf(ctx), ast: *const Ast, raw: u32, node: Node) bool,
+    ) bool {
+        if (root.isNone()) return false;
+        self.numeric_dfs_stack.clearRetainingCapacity();
+        self.numeric_dfs_stack.append(self.allocator, root) catch return false;
+        while (self.numeric_dfs_stack.pop()) |idx| {
+            if (idx.isNone()) continue;
+            const raw: u32 = @intFromEnum(idx);
+            if (raw >= ast.nodes.items.len) continue;
+            const node = ast.nodes.items[raw];
+            if (visit_fn(ctx, ast, raw, node)) return true;
+            var it = ast_walk.children(ast, node);
+            while (it.next()) |child| {
+                if (!child.isNone()) self.numeric_dfs_stack.append(self.allocator, child) catch return false;
+            }
+        }
+        return false;
+    }
+
+    /// top-level `export const` 의 initializer 노드 인덱스를 순회한다 (write_count == 0).
+    /// `visit_fn` 이 true 를 반환하면 즉시 short-circuit.
+    fn anyExportedConstInit(
+        self: *TreeShaker,
+        ast: *const Ast,
+        sem: ModuleSemanticData,
+        ctx: anytype,
+        comptime visit_fn: fn (self: *TreeShaker, ctx: @TypeOf(ctx), ast: *const Ast, init_idx: NodeIndex) bool,
+    ) bool {
+        for (ast.nodes.items) |node| {
+            if (node.tag != .variable_declarator) continue;
+            const extra = node.data.extra;
+            if (extra + 2 >= ast.extra_data.items.len) continue;
+            const name_idx: NodeIndex = @enumFromInt(ast.extra_data.items[extra]);
+            const init_idx: NodeIndex = @enumFromInt(ast.extra_data.items[extra + 2]);
+            if (name_idx.isNone() or init_idx.isNone()) continue;
+            const name_raw: u32 = @intFromEnum(name_idx);
+            if (name_raw >= sem.symbol_ids.len) continue;
+            const sym_id = sem.symbol_ids[name_raw] orelse continue;
+            if (sym_id >= sem.symbols.items.len) continue;
+            const sym = sem.symbols.items[sym_id];
+            if (!sym.decl_flags.is_exported and !sym.decl_flags.is_default_export) continue;
+            if (sym.write_count != 0) continue;
+            if (visit_fn(self, ctx, ast, init_idx)) return true;
+        }
+        return false;
+    }
+
+    const NumericConstRefCtx = struct {
+        symbol_ids: []const ?u32,
+        const_values: *const std.AutoHashMapUnmanaged(u32, ConstValue),
+    };
+
+    fn visitNumericConstRef(ctx: NumericConstRefCtx, _: *const Ast, raw: u32, node: Node) bool {
+        if (node.tag != .identifier_reference or raw >= ctx.symbol_ids.len) return false;
+        const sid = ctx.symbol_ids[raw] orelse return false;
+        const cv = ctx.const_values.get(sid) orelse return false;
+        return cv.kind == .number;
+    }
+
+    fn nodeContainsNumericConstRef(
+        self: *TreeShaker,
+        ast: *const Ast,
+        symbol_ids: []const ?u32,
+        root: NodeIndex,
+        const_values: *const std.AutoHashMapUnmanaged(u32, ConstValue),
+    ) bool {
+        return self.anyReachableNode(ast, root, NumericConstRefCtx{
+            .symbol_ids = symbol_ids,
+            .const_values = const_values,
+        }, visitNumericConstRef);
+    }
+
+    /// numeric literal + binary/paren 만으로 구성된 fold-able 표현인지 판정.
+    /// 도달 트리에 binary 가 1개라도 있어야 fold 가 의미 있으므로 그 신호도 함께 체크.
+    /// `accept_idx` 가 .none 으로 끝나면 `saw_binary` 를 봐서 결과를 결정.
+    const FoldSeedCtx = struct {
+        saw_binary: *bool,
+        rejected: *bool,
+    };
+
+    fn visitFoldSeed(ctx: FoldSeedCtx, _: *const Ast, _: u32, node: Node) bool {
+        switch (node.tag) {
+            .numeric_literal, .parenthesized_expression => return false,
+            .binary_expression => {
+                ctx.saw_binary.* = true;
+                return false;
+            },
+            else => {
+                ctx.rejected.* = true;
+                return true;
+            },
+        }
+    }
+
+    fn nodeIsNumericLiteralFoldSeed(self: *TreeShaker, ast: *const Ast, root: NodeIndex) bool {
+        if (root.isNone()) return false;
+        var saw_binary = false;
+        var rejected = false;
+        _ = self.anyReachableNode(ast, root, FoldSeedCtx{
+            .saw_binary = &saw_binary,
+            .rejected = &rejected,
+        }, visitFoldSeed);
+        return saw_binary and !rejected;
+    }
+
+    fn visitChainExportInit(self: *TreeShaker, ctx: NumericConstRefCtx, ast: *const Ast, init_idx: NodeIndex) bool {
+        return self.nodeContainsNumericConstRef(ast, ctx.symbol_ids, init_idx, ctx.const_values);
+    }
+
+    fn moduleHasNumericExportConstChain(
+        self: *TreeShaker,
+        ast: *const Ast,
+        sem: ModuleSemanticData,
+        const_values: *const std.AutoHashMapUnmanaged(u32, ConstValue),
+    ) bool {
+        if (!constValuesContainNumber(const_values)) return false;
+        return self.anyExportedConstInit(ast, sem, NumericConstRefCtx{
+            .symbol_ids = sem.symbol_ids,
+            .const_values = const_values,
+        }, visitChainExportInit);
+    }
+
+    fn visitSeedExportInit(self: *TreeShaker, _: void, ast: *const Ast, init_idx: NodeIndex) bool {
+        return self.nodeIsNumericLiteralFoldSeed(ast, init_idx);
+    }
+
+    fn moduleHasNumericExportSeed(self: *TreeShaker, ast: *const Ast, sem: ModuleSemanticData) bool {
+        return self.anyExportedConstInit(ast, sem, {}, visitSeedExportInit);
+    }
+
+    fn moduleHasExportedNumberConstValue(_: *TreeShaker, sem: ModuleSemanticData) bool {
+        for (sem.symbols.items) |sym| {
+            if (!sym.decl_flags.is_exported and !sym.decl_flags.is_default_export) continue;
+            if (sym.write_count != 0) continue;
+            if (sym.const_value.kind == .number) return true;
+        }
+        return false;
+    }
+
+    fn anyModuleHasExportedNumberConst(self: *TreeShaker, mod_count: usize) bool {
+        for (0..mod_count) |i| {
+            const m = self.getModule(@intCast(i)) orelse continue;
+            const sem = m.semantic orelse continue;
+            if (self.moduleHasExportedNumberConstValue(sem)) return true;
+        }
+        return false;
+    }
+
+    fn minifyAndResyncModule(self: *TreeShaker, m: *Module, sem: ModuleSemanticData, ast: *Ast) void {
+        const minify_mod = @import("../transformer/minify.zig");
+        const root = ast.transformed_root orelse NodeIndex.none;
+        const ctx = minify_mod.MinifyCtx.fromSemantic(&m.semantic.?, sem.symbol_ids, self.graph.transform_options_base.minify_syntax);
+        minify_mod.minify(ast, ctx, self.allocator, root);
+        // parse_arena 는 parse 단계에서 모든 모듈에 부착된다 (#1323). null 이면
+        // 분석 산출물이 self.allocator 로 새서 leak 되므로 invariant 로 강제.
+        std.debug.assert(m.parse_arena != null);
+        self.graph.resyncModuleMetadataAfterAstMutation(m, m.parse_arena.?.allocator()) catch {
+            m.prebuilt_stmt_info = null;
+        };
+        self.ast_mutated_after_link = true;
+    }
+
+    fn refreshLinkMetadataAfterPreShakeMutation(self: *TreeShaker) !void {
+        if (!self.ast_mutated_after_link) return;
+        if (self.graph.code_splitting) return;
+        try self.linker.finalize(.{
+            .compute_renames = true,
+            .compute_mangling = self.graph.minify_identifiers,
+            .clear_first = true,
+        });
+        self.ast_mutated_after_link = false;
+    }
+
+    fn shouldMaterializeConstFacts(
+        self: *TreeShaker,
+        ast: *const Ast,
+        sem: ModuleSemanticData,
+        const_values: *const std.AutoHashMapUnmanaged(u32, ConstValue),
+        filter: ConstMaterializeFilter,
+    ) bool {
+        return switch (filter) {
+            .all => const_values.count() > 0,
+            .numeric => constValuesContainNumber(const_values),
+            .numeric_export_chain => self.moduleHasNumericExportConstChain(ast, sem, const_values),
+        };
+    }
+
+    fn materializeCrossModuleConstFactsForIndex(
+        self: *TreeShaker,
+        module_index: usize,
+        filter: ConstMaterializeFilter,
+    ) !bool {
+        const m = self.moduleAtMut(@intCast(module_index)) orelse return false;
+        const sem = m.semantic orelse return false;
+        const ast = &(m.ast orelse return false);
+        var const_values = try self.linker.buildCrossModuleConstValues(m, sem);
+        if (!self.shouldMaterializeConstFacts(ast, sem, &const_values, filter)) {
+            const_values.deinit(self.allocator);
+            return false;
+        }
+
+        const changed = constant_facts.materialize(self.allocator, ast, sem.symbol_ids, &const_values);
+        const_values.deinit(self.allocator);
+        if (!changed) return false;
+
+        self.minifyAndResyncModule(m, sem, ast);
+        return true;
+    }
+
+    fn materializeCrossModuleConstFacts(
+        self: *TreeShaker,
+        mod_count: usize,
+        filter: ConstMaterializeFilter,
+        reverse: bool,
+    ) !bool {
+        var any_changed = false;
+        if (reverse) {
+            var i = mod_count;
+            while (i > 0) {
+                i -= 1;
+                if (try self.materializeCrossModuleConstFactsForIndex(i, filter)) any_changed = true;
+            }
+        } else {
+            for (0..mod_count) |i| {
+                if (try self.materializeCrossModuleConstFactsForIndex(i, filter)) any_changed = true;
+            }
+        }
+        return any_changed;
+    }
+
+    fn propagateNumericExportConstFacts(self: *TreeShaker, mod_count: usize) !void {
+        var reverse_deps = try self.allocator.alloc(std.ArrayList(u32), mod_count);
+        defer {
+            for (reverse_deps) |*deps| deps.deinit(self.allocator);
+            self.allocator.free(reverse_deps);
+        }
+        for (reverse_deps) |*deps| deps.* = .empty;
+
+        for (0..mod_count) |i| {
+            const m = self.getModule(@intCast(i)) orelse continue;
+            for (m.import_records) |rec| {
+                if (rec.resolved.isNone()) continue;
+                const target = @intFromEnum(rec.resolved);
+                if (target >= mod_count) continue;
+                try reverse_deps[target].append(self.allocator, @intCast(i));
+            }
+        }
+
+        var queue: std.ArrayList(u32) = .empty;
+        defer queue.deinit(self.allocator);
+        var forwarded_re_exports = try std.DynamicBitSet.initEmpty(self.allocator, mod_count);
+        defer forwarded_re_exports.deinit();
+        for (0..mod_count) |i| {
+            const m = self.moduleAtMut(@intCast(i)) orelse continue;
+            const sem = m.semantic orelse continue;
+            const ast = &(m.ast orelse continue);
+            if (self.moduleHasNumericExportSeed(ast, sem)) {
+                self.minifyAndResyncModule(m, sem, ast);
+                for (reverse_deps[i].items) |importer| try queue.append(self.allocator, importer);
+                continue;
+            }
+            if (self.moduleHasExportedNumberConstValue(sem)) {
+                for (reverse_deps[i].items) |importer| try queue.append(self.allocator, importer);
+            }
+        }
+
+        while (queue.pop()) |idx| {
+            if (idx >= mod_count) continue;
+            if (try self.materializeCrossModuleConstFactsForIndex(idx, .numeric_export_chain)) {
+                for (reverse_deps[idx].items) |importer| try queue.append(self.allocator, importer);
+                continue;
+            }
+
+            if (forwarded_re_exports.isSet(idx)) continue;
+            const m = self.getModule(idx) orelse continue;
+            var has_re_export = false;
+            for (m.export_bindings) |eb| {
+                if (eb.kind.isAnyReExport()) {
+                    has_re_export = true;
+                    break;
+                }
+            }
+            if (!has_re_export) continue;
+            forwarded_re_exports.set(idx);
+            for (reverse_deps[idx].items) |importer| try queue.append(self.allocator, importer);
+        }
     }
 
     /// Tree-shaking 분석 (fixpoint 방식).
@@ -189,34 +512,22 @@ pub const TreeShaker = struct {
             }
         }
 
-        if (self.graph.transform_options_base.minify_syntax) {
-            // Linker가 증명한 cross-module constant를 tree-shaking 전 AST에 먼저 반영한다.
-            // 그래야 `if (DEV) heavy()` 같은 dead branch 안 import가 BFS seed로 번지지 않는다.
-            for (0..mod_count) |i| {
-                const m = self.moduleAtMut(@intCast(i)) orelse continue;
-                const sem = m.semantic orelse continue;
-                const ast = &(m.ast orelse continue);
-                var const_values = try self.linker.buildCrossModuleConstValues(m, sem);
-                const changed = constant_facts.materialize(self.allocator, ast, sem.symbol_ids, &const_values);
-                const_values.deinit(self.allocator);
-                if (!changed) continue;
-
-                const minify_mod = @import("../transformer/minify.zig");
-                const root = ast.transformed_root orelse NodeIndex.none;
-                const ctx = minify_mod.MinifyCtx.fromSemantic(&m.semantic.?, sem.symbol_ids, true);
-                minify_mod.minify(ast, ctx, self.allocator, root);
-                // parse_arena 는 parse 단계에서 모든 모듈에 부착된다 (#1323). null 이면
-                // 분석 산출물이 self.allocator 로 새서 leak 되므로 invariant 로 강제.
-                std.debug.assert(m.parse_arena != null);
-                self.graph.resyncModuleMetadataAfterAstMutation(m, m.parse_arena.?.allocator()) catch {
-                    m.prebuilt_stmt_info = null;
-                };
+        // Linker가 증명한 cross-module constant를 tree-shaking 전 AST에 먼저 반영한다.
+        // 그래야 `if (DEV) heavy()` 같은 dead branch 안 import가 BFS seed로 번지지 않는다.
+        // preserve-modules는 원본 모듈 경계가 출력 계약이므로, import edge를 제거할 수
+        // 있는 materialize는 reachability 확정 뒤 numeric post-pass에서만 수행한다.
+        if (!self.graph.preserve_modules) {
+            if (self.graph.transform_options_base.minify_syntax) {
+                _ = try self.materializeCrossModuleConstFacts(mod_count, .all, false);
+            } else {
+                try self.propagateNumericExportConstFacts(mod_count);
             }
         }
 
         if (self.graph.resolve_cache.platform == .node) {
             try self.applyNodeBufferCapabilityFacts();
         }
+        try self.refreshLinkMetadataAfterPreShakeMutation();
 
         // 자동 순수 판별: 진입점이 아닌 모듈의 top-level이 모두 순수하면 side_effects=false
         // (rolldown/esbuild 동작: package.json sideEffects 없어도 자동 감지)
@@ -394,6 +705,18 @@ pub const TreeShaker = struct {
             if (m.is_context_dep) continue; // require.context match 는 runtime require 대상
             if (!self.hasAnyUsedExport(@intCast(i)) and !self.hasAnyUsedExportDirect(@intCast(i))) {
                 self.included.unset(i);
+            }
+        }
+
+        // Numeric chain 축약은 번들 크기/그래프 성능에 직접 영향을 주므로 `--minify` 없이도
+        // 실행한다. used_exports/reachability 판정이 끝난 뒤로 미루는 건 디버그용 tree-shaker
+        // 기대값 보존. 어떤 모듈도 numeric export 가 없으면 build/scan 비용 자체를 회피.
+        if ((self.graph.preserve_modules or !self.graph.transform_options_base.minify_syntax) and self.anyModuleHasExportedNumberConst(mod_count)) {
+            var pass: u32 = 0;
+            while (pass < max_numeric_const_post_passes) : (pass += 1) {
+                const forward_changed = try self.materializeCrossModuleConstFacts(mod_count, .numeric, false);
+                const reverse_changed = try self.materializeCrossModuleConstFacts(mod_count, .numeric, true);
+                if (!forward_changed and !reverse_changed) break;
             }
         }
 
@@ -1614,6 +1937,7 @@ pub const TreeShaker = struct {
             self.graph.resyncModuleMetadataAfterAstMutation(m, m.parse_arena.?.allocator()) catch {
                 m.prebuilt_stmt_info = null;
             };
+            self.ast_mutated_after_link = true;
         }
     }
 

--- a/src/bundler/tree_shaker_test.zig
+++ b/src/bundler/tree_shaker_test.zig
@@ -176,7 +176,7 @@ test "tree-shaking: circular dependency modules included" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "a.ts", "import { x } from './b'; export const a = x + 1;");
-    try writeFile(tmp.dir, "b.ts", "import { a } from './a'; export const x = 1;");
+    try writeFile(tmp.dir, "b.ts", "import { a } from './a'; export const x = getX(); function getX() { return 1; }");
 
     var r = try buildAndShake(std.testing.allocator, &tmp, "a.ts");
     defer r.deinit();
@@ -193,7 +193,7 @@ test "tree-shaking: included module's dependencies are propagated" {
     // a → b → c 체인. a가 b를 import하고, b가 c를 import.
     try writeFile(tmp.dir, "a.ts", "import { x } from './b'; console.log(x);");
     try writeFile(tmp.dir, "b.ts", "import { y } from './c'; export const x = y + 1;");
-    try writeFile(tmp.dir, "c.ts", "export const y = 42;");
+    try writeFile(tmp.dir, "c.ts", "export const y = getY(); function getY() { return 42; }");
 
     var r = try buildAndShake(std.testing.allocator, &tmp, "a.ts");
     defer r.deinit();
@@ -230,7 +230,7 @@ test "tree-shaking: diamond dependency — shared module included once" {
     try writeFile(tmp.dir, "a.ts", "import { x } from './b'; import { y } from './c'; console.log(x, y);");
     try writeFile(tmp.dir, "b.ts", "import { shared } from './d'; export const x = shared + 1;");
     try writeFile(tmp.dir, "c.ts", "import { shared } from './d'; export const y = shared + 2;");
-    try writeFile(tmp.dir, "d.ts", "export const shared = 100;");
+    try writeFile(tmp.dir, "d.ts", "export const shared = getShared(); function getShared() { return 100; }");
 
     var r = try buildAndShake(std.testing.allocator, &tmp, "a.ts");
     defer r.deinit();
@@ -494,7 +494,7 @@ test "rollup: diamond with sideEffects=false leaf — leaf included if used" {
     try writeFile(tmp.dir, "a.ts", "import { x } from './b'; import { y } from './c'; console.log(x, y);");
     try writeFile(tmp.dir, "b.ts", "import { shared } from './leaf'; export const x = shared + 1;");
     try writeFile(tmp.dir, "c.ts", "export const y = 99;");
-    try writeFile(tmp.dir, "leaf.ts", "export const shared = 42; export const dead = 'unused';");
+    try writeFile(tmp.dir, "leaf.ts", "export const shared = getShared(); function getShared() { return 42; } export const dead = 'unused';");
 
     var r = try buildAndShakeWithOpts(std.testing.allocator, &tmp, "a.ts", &.{"leaf.ts"});
     defer r.deinit();
@@ -509,7 +509,7 @@ test "rollup: entry exports all marked, dependency only used ones" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.ts", "import { x } from './dep'; export const result = x;");
-    try writeFile(tmp.dir, "dep.ts", "export const x = 1; export const y = 2; export const z = 3;");
+    try writeFile(tmp.dir, "dep.ts", "export const x = getX(); function getX() { return 1; } export const y = 2; export const z = 3;");
 
     var r = try buildAndShake(std.testing.allocator, &tmp, "entry.ts");
     defer r.deinit();
@@ -594,7 +594,7 @@ test "complex: circular dependency with sideEffects=false" {
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.ts", "import { a } from './ca'; console.log(a);");
     try writeFile(tmp.dir, "ca.ts", "import { b } from './cb'; export const a = b + 1;");
-    try writeFile(tmp.dir, "cb.ts", "import { a } from './ca'; export const b = 10;");
+    try writeFile(tmp.dir, "cb.ts", "import { a } from './ca'; export const b = getB(); function getB() { return 10; }");
 
     var r = try buildAndShakeWithOpts(std.testing.allocator, &tmp, "entry.ts", &.{ "ca.ts", "cb.ts" });
     defer r.deinit();
@@ -1092,7 +1092,7 @@ test "edge: 3-module cycle all sideEffects=false — used one pulls in cycle" {
     try writeFile(tmp.dir, "entry.ts", "import { a } from './cyc-a'; console.log(a);");
     try writeFile(tmp.dir, "cyc-a.ts", "import { b } from './cyc-b'; export const a = b + 1;");
     try writeFile(tmp.dir, "cyc-b.ts", "import { c } from './cyc-c'; export const b = c + 1;");
-    try writeFile(tmp.dir, "cyc-c.ts", "import { a } from './cyc-a'; export const c = 10;");
+    try writeFile(tmp.dir, "cyc-c.ts", "import { a } from './cyc-a'; export const c = getC(); function getC() { return 10; }");
 
     var r = try buildAndShakeWithOpts(std.testing.allocator, &tmp, "entry.ts", &.{ "cyc-a.ts", "cyc-b.ts", "cyc-c.ts" });
     defer r.deinit();
@@ -1144,7 +1144,7 @@ test "edge: same module imported by multiple — union of used exports" {
     try writeFile(tmp.dir, "entry.ts", "import { a } from './consumer1'; import { b } from './consumer2'; console.log(a, b);");
     try writeFile(tmp.dir, "consumer1.ts", "import { x } from './shared'; export const a = x;");
     try writeFile(tmp.dir, "consumer2.ts", "import { y } from './shared'; export const b = y;");
-    try writeFile(tmp.dir, "shared.ts", "export const x = 1; export const y = 2; export const z = 3;");
+    try writeFile(tmp.dir, "shared.ts", "export const x = getX(); function getX() { return 1; } export const y = getY(); function getY() { return 2; } export const z = 3;");
 
     var r = try buildAndShake(std.testing.allocator, &tmp, "entry.ts");
     defer r.deinit();

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -637,6 +637,7 @@ pub const Codegen = struct {
             .false_ => try self.write("false"),
             .null_ => try self.write("null"),
             .undefined_ => try self.write("void 0"),
+            .number => try self.write(cv.number_text),
             .none => {},
         }
     }
@@ -1252,13 +1253,14 @@ pub const Codegen = struct {
                 return switch (cv.kind) {
                     .true_ => true,
                     .false_ => false,
+                    .number => (ast_mod.parseNumericText(cv.number_text) orelse return null) != 0,
                     else => null,
                 };
             },
             .null_literal => false,
             .numeric_literal => {
                 const text = self.ast.getText(cond.span);
-                const n = std.fmt.parseFloat(f64, text) catch return null;
+                const n = ast_mod.parseNumericText(text) orelse return null;
                 return n != 0;
             },
             .logical_expression => {
@@ -1714,7 +1716,7 @@ pub const Codegen = struct {
             // shorthand: { x } — key만 출력.
             // 단, scope hoisting으로 식별자가 리네임된 경우 shorthand를 풀어야 함:
             // { x } → { x: x$1 }  (프로퍼티 이름은 원본, 값은 리네임된 이름)
-            if (self.identifierHasRename(key)) {
+            if (self.identifierHasRename(key) or self.identifierHasConstValue(key)) {
                 const key_node = self.ast.getNode(key);
                 try self.writeSpan(key_node.data.string_ref);
                 if (self.options.minify_whitespace) {
@@ -1773,6 +1775,16 @@ pub const Codegen = struct {
                 if (self.ns_exports) |exports| {
                     if (exports.contains(name)) return true;
                 }
+            }
+        }
+        return false;
+    }
+
+    fn identifierHasConstValue(self: *Codegen, idx: NodeIndex) bool {
+        if (idx.isNone()) return false;
+        if (self.options.linking_metadata) |meta| {
+            if (self.resolveSymbolId(idx, meta)) |sym_id| {
+                if (meta.const_values.get(sym_id)) |cv| return cv.isSafeToInline();
             }
         }
         return false;

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1528,6 +1528,24 @@ pub const MethodFlags = struct {
     pub const is_declare: u32 = 0x40;
 };
 
+/// JS numeric literal 텍스트 → f64. `0x` / `0o` / `0b` prefix 와 십진/지수 모두 처리.
+/// minify (binary fold) 와 codegen (truthy 판정) 모두에서 사용 — 한 곳에서 정의해
+/// prefix 처리 drift 를 막는다.
+pub fn parseNumericText(text: []const u8) ?f64 {
+    if (text.len == 0) return null;
+    if (text.len >= 2 and text[0] == '0') {
+        const digits = text[2..];
+        const v: u64 = switch (text[1]) {
+            'x', 'X' => std.fmt.parseInt(u64, digits, 16) catch return null,
+            'o', 'O' => std.fmt.parseInt(u64, digits, 8) catch return null,
+            'b', 'B' => std.fmt.parseInt(u64, digits, 2) catch return null,
+            else => return std.fmt.parseFloat(f64, text) catch null,
+        };
+        return @floatFromInt(v);
+    }
+    return std.fmt.parseFloat(f64, text) catch null;
+}
+
 /// method_definition → function_declaration/expression으로 추출할 때
 /// async/generator 비트를 FunctionFlags 위치로 옮긴다.
 /// 두 공간의 비트 위치가 달라 복사할 때마다 같은 매핑이 반복되던 것을 한 곳에 모았다.

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -998,6 +998,7 @@ pub const SemanticAnalyzer = struct {
                 break :blk .{ .kind = if (std.mem.eql(u8, text, "true")) .true_ else .false_ };
             },
             .null_literal => .{ .kind = .null_ },
+            .numeric_literal => .{ .kind = .number, .number_text = self.ast.getText(node.span) },
             .identifier_reference => blk: {
                 const text = self.ast.getText(node.span);
                 if (std.mem.eql(u8, text, "undefined")) break :blk ConstValue{ .kind = .undefined_ };

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -744,6 +744,59 @@ test "SemanticAnalyzer: valid code has no semantic errors" {
     }
 }
 
+test "SemanticAnalyzer: numeric literal const_value stores raw literal text" {
+    const src =
+        \\const dec = 123;
+        \\const exp = 1e3;
+        \\const hex = 0x10;
+        \\const neg = -1;
+        \\const big = 1n;
+        \\const expr = 1 + 2;
+    ;
+    var scanner = try Scanner.init(std.testing.allocator, src);
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
+    defer ana.deinit();
+    try ana.analyze();
+
+    var saw_dec = false;
+    var saw_exp = false;
+    var saw_hex = false;
+    var saw_neg = false;
+    var saw_big = false;
+    var saw_expr = false;
+    for (ana.symbols.items) |sym| {
+        const name = sym.nameText(parser.ast.source);
+        if (std.mem.eql(u8, name, "dec")) {
+            saw_dec = true;
+            try std.testing.expectEqual(symbol_mod.ConstValue.Kind.number, sym.const_value.kind);
+            try std.testing.expectEqualStrings("123", sym.const_value.number_text);
+        } else if (std.mem.eql(u8, name, "exp")) {
+            saw_exp = true;
+            try std.testing.expectEqual(symbol_mod.ConstValue.Kind.number, sym.const_value.kind);
+            try std.testing.expectEqualStrings("1e3", sym.const_value.number_text);
+        } else if (std.mem.eql(u8, name, "hex")) {
+            saw_hex = true;
+            try std.testing.expectEqual(symbol_mod.ConstValue.Kind.number, sym.const_value.kind);
+            try std.testing.expectEqualStrings("0x10", sym.const_value.number_text);
+        } else if (std.mem.eql(u8, name, "neg")) {
+            saw_neg = true;
+            try std.testing.expectEqual(symbol_mod.ConstValue.Kind.none, sym.const_value.kind);
+        } else if (std.mem.eql(u8, name, "big")) {
+            saw_big = true;
+            try std.testing.expectEqual(symbol_mod.ConstValue.Kind.none, sym.const_value.kind);
+        } else if (std.mem.eql(u8, name, "expr")) {
+            saw_expr = true;
+            try std.testing.expectEqual(symbol_mod.ConstValue.Kind.none, sym.const_value.kind);
+        }
+    }
+    try std.testing.expect(saw_dec and saw_exp and saw_hex and saw_neg and saw_big and saw_expr);
+}
+
 // ============================================================
 // Reference Tracking 테스트
 // ============================================================

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -218,6 +218,9 @@ pub const SyntheticKind = enum(u8) {
 /// `const x = false` → ConstValue{ .kind = .false_ }
 pub const ConstValue = struct {
     kind: Kind = .none,
+    /// `.number`일 때 원본 numeric_literal 텍스트.
+    /// target module source를 가리키며, consumer AST materialize 시 string table로 복사한다.
+    number_text: []const u8 = "",
 
     pub const Kind = enum(u8) {
         none,
@@ -225,10 +228,15 @@ pub const ConstValue = struct {
         false_,
         null_,
         undefined_,
+        number,
     };
 
     pub fn isSafeToInline(self: *const ConstValue) bool {
-        return self.kind != .none;
+        return switch (self.kind) {
+            .none => false,
+            .number => self.number_text.len > 0,
+            else => true,
+        };
     }
 };
 

--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -108,30 +108,7 @@ fn toF64Bitwise(val: i32) f64 {
 /// 숫자 리터럴의 값을 파싱한다. codegen은 span 텍스트를 직접 출력하므로
 /// number_bytes가 아닌 소스 텍스트에서 파싱해야 한다.
 fn parseNumericLiteral(ast: *const Ast, node: Node) ?f64 {
-    const text = ast.getText(node.span);
-    if (text.len == 0) return null;
-    // 0x, 0o, 0b prefix
-    if (text.len >= 2 and text[0] == '0') {
-        if (text[1] == 'x' or text[1] == 'X') return parseHex(text[2..]);
-        if (text[1] == 'o' or text[1] == 'O') return parseOct(text[2..]);
-        if (text[1] == 'b' or text[1] == 'B') return parseBin(text[2..]);
-    }
-    return std.fmt.parseFloat(f64, text) catch null;
-}
-
-fn parseHex(text: []const u8) ?f64 {
-    const v = std.fmt.parseInt(u64, text, 16) catch return null;
-    return @floatFromInt(v);
-}
-
-fn parseOct(text: []const u8) ?f64 {
-    const v = std.fmt.parseInt(u64, text, 8) catch return null;
-    return @floatFromInt(v);
-}
-
-fn parseBin(text: []const u8) ?f64 {
-    const v = std.fmt.parseInt(u64, text, 2) catch return null;
-    return @floatFromInt(v);
+    return ast_mod.parseNumericText(ast.getText(node.span));
 }
 
 /// 따옴표를 포함한 문자열 리터럴을 string_table에 추가한다.
@@ -352,11 +329,9 @@ fn runOnce(
         }
     }
     if (ctx.hasSemantic()) {
-        // single-use inline 이 먼저 — declaration 까지 정리하므로 single-use 케이스를
-        // 통째로 끝낸다. multi-use primitive inline 은 그 후에 돌아 read 만 swap.
-        // 순서를 뒤집으면 (#1631) `inlineTopLevelPrimitiveConstants` 가 ref_count 를
-        // 0 으로 떨궈 single-use case 의 declaration 이 안 지워지고 살아남음
-        // (예: `const kn="["; const out=`<!--${kn}-->`;` → `const e="["` 가 잔존).
+        // 순서 고정 (#1631): inlineSingleUse → inlineTopLevelPrimitiveConstants.
+        // 뒤집으면 multi-use inline 이 ref_count 를 0 으로 떨궈 single-use declaration 이
+        // 잔존 (e.g. `const kn="["; const out=\`<!--${kn}-->\`;` → `const e="["` 잔존).
         inlineSingleUse(ast, ctx, skip_for_binding, live_nodes, &changed, scratch);
         inlineTopLevelPrimitiveConstants(ast, ctx, live_nodes, &changed, scratch);
         removeDeadStores(ast, ctx, skip_for_binding, live_nodes, &changed);

--- a/tests/integration/tests/const-value-inline.test.ts
+++ b/tests/integration/tests/const-value-inline.test.ts
@@ -242,6 +242,161 @@ describe("const_value cross-module 인라인 correctness", () => {
     expect(r.runOutput).toBe("undefined");
   });
 
+  test("const number는 cross-module에서 materialize되고 산술 fold된다", async () => {
+    const fx = await createFixture({
+      "lib.ts": `export const n = 1;`,
+      "index.ts": `
+        import { n } from "./lib";
+        console.log(n + 2);
+      `,
+    });
+    cleanup = fx.cleanup;
+    const out = join(fx.dir, "out.js");
+    const r = await runZts(["--bundle", join(fx.dir, "index.ts"), "-o", out, "--platform=node"]);
+    expect(r.exitCode).toBe(0);
+    const src = readFileSync(out, "utf8");
+    expect(src).toMatch(/console\.log\(3\)/);
+    expect(src).not.toContain("n + 2");
+  });
+
+  test("const number는 exponent와 hex literal도 원본 숫자 literal로 전파한다", async () => {
+    const r = await bundleAndRun(
+      {
+        "lib.ts": `
+          export const exp = 1e3;
+          export const hex = 0x10;
+        `,
+        "index.ts": `
+          import { exp, hex } from "./lib";
+          console.log(exp + 2, hex + 2);
+        `,
+      },
+      "index.ts",
+      ["--platform=node"],
+    );
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.runOutput).toBe("1002 18");
+  });
+
+  test("numeric const chain은 deep cross-module export에서도 대량 축소된다", async () => {
+    const files: Record<string, string> = {
+      "mod-0.ts": `export const v0 = 1;`,
+    };
+    for (let i = 1; i < 40; i++) {
+      files[`mod-${i}.ts`] = `
+        import { v${i - 1} } from "./mod-${i - 1}";
+        export const v${i} = v${i - 1} + 1;
+      `;
+    }
+    files["index.ts"] = `
+      import { v39 } from "./mod-39";
+      console.log(v39);
+    `;
+
+    const fx = await createFixture(files);
+    cleanup = fx.cleanup;
+    const out = join(fx.dir, "out.js");
+    const r = await runZts(["--bundle", join(fx.dir, "index.ts"), "-o", out, "--platform=node"]);
+    expect(r.exitCode).toBe(0);
+    const src = readFileSync(out, "utf8");
+    expect(src).toMatch(/console\.log\(40\)/);
+    expect((src.match(/const v\d+/g) ?? []).length).toBeLessThanOrEqual(2);
+  });
+
+  test("numeric const는 object shorthand를 구문 깨지는 literal로 materialize하지 않는다", async () => {
+    const r = await bundleAndRun(
+      {
+        "lib.ts": `export const n = 1;`,
+        "index.ts": `
+          import { n } from "./lib";
+          console.log(JSON.stringify({ n }));
+        `,
+      },
+      "index.ts",
+      ["--platform=node"],
+    );
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.runOutput).toBe('{"n":1}');
+  });
+
+  test("numeric post-pass 이후 top-level rename metadata가 stale하지 않다", async () => {
+    const r = await bundleAndRun(
+      {
+        "seed.ts": `export const base = 1;`,
+        "left.ts": `
+          import { base } from "./seed";
+          export const _empty = base + 1;
+          export const left = _empty;
+        `,
+        "right.ts": `
+          export const _empty = 10;
+          export const right = _empty;
+        `,
+        "index.ts": `
+          import { left } from "./left";
+          import { right } from "./right";
+          console.log(left, right);
+        `,
+      },
+      "index.ts",
+      ["--platform=node"],
+    );
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.runOutput).toBe("2 10");
+  });
+
+  test("numeric post-pass는 기존 namespace reachability를 뒤늦게 바꾸지 않는다", async () => {
+    const fx = await createFixture({
+      "seed.ts": `export const base = 1;`,
+      "node.ts": `
+        export class EmptyNode {
+          tag = "EmptyNode";
+        }
+        export function isEmptyNode(value: unknown) {
+          return value instanceof EmptyNode;
+        }
+        export const unused = "drop";
+      `,
+      "map.ts": `
+        import * as Node from "./node";
+        import { base } from "./seed";
+        const _empty = new Node.EmptyNode();
+        export const value = Node.isEmptyNode(_empty) ? base + 1 : 0;
+      `,
+      "other.ts": `
+        export const _empty = 99;
+        export const other = _empty;
+      `,
+      "index.ts": `
+        import { value } from "./map";
+        import { other } from "./other";
+        console.log(value, other);
+      `,
+    });
+    cleanup = fx.cleanup;
+    const out = join(fx.dir, "out.js");
+    const build = await runZts([
+      "--bundle",
+      join(fx.dir, "index.ts"),
+      "-o",
+      out,
+      "--platform=node",
+    ]);
+    expect(build.exitCode).toBe(0);
+
+    const src = readFileSync(out, "utf8");
+    expect(src).toContain("class EmptyNode");
+    expect(src).not.toContain("unused");
+    expect(src).not.toContain(",_empty =");
+    expect(src.match(/\b(?:const|let|var)\s+_empty(?![$\w])/g) ?? []).toHaveLength(1);
+
+    const run = await Bun.$`node ${out}`.text();
+    expect(run.trim()).toBe("2 99");
+  });
+
   // ========================================================================
   // Edge cases: local let (not exported) / 같은 모듈 내 참조
   // ========================================================================


### PR DESCRIPTION
## 요약
- `ConstValue`에 numeric literal variant를 추가해 `export const n = 1` 형태의 숫자 const fact를 semantic 단계에서 기록합니다.
- cross-module const materialize가 numeric literal을 consumer AST에 복사하고, 기존 minify fold를 재사용해 숫자 const 체인을 접습니다.
- object shorthand, assignment target 등 금지된 inline 위치는 유지하고, `let` 재할당 값은 인라인하지 않는 회귀 테스트를 보강했습니다.
- `preserveModules`에서는 모듈 경계 판정 전에 import edge를 지우지 않고, reachability 확정 뒤 numeric post-pass로 expression만 접도록 조정했습니다.
- 순환 모듈의 live binding은 `var` 강등 의미를 보존해야 하므로 cycle group 안 export는 const fact 생성에서 제외했습니다.
- pre-shake AST mutation이 발생하면 reachability 전에 linker metadata를 재계산하고, post-tree-shake 재계산은 rename/mangle metadata 갱신으로 제한해 namespace access facts를 뒤늦게 늘리지 않습니다.
- Playwright `test-results` 산출물이 pre-push `oxfmt --check`에 잡히지 않도록 formatter 대상에서 제외했습니다. Git 기준으로는 기존 `.gitignore`가 이미 `tests/e2e/test-results/`를 무시합니다.

## Rolldown 참고
- `references/rolldown/crates/rolldown/src/stages/link_stage/mod.rs`에서 `optimization.is_inline_const_enabled()`로 constant export map을 구성합니다.
- `references/rolldown/crates/rolldown/src/stages/link_stage/cross_module_optimization.rs`에서 inline const pass를 별도 cross-module optimization으로 다룹니다.
- `preserve_modules`는 generate/cross-chunk 단계의 출력 경계 옵션으로 다뤄지고, inline const 최적화를 통째로 끄는 별도 게이트는 보이지 않았습니다. 따라서 ZTS도 preserveModules에서 최적화 자체를 끄지 않고 실행 시점만 뒤로 미뤘습니다.

## 확인한 효과
- 5051 module fixture: `entry.js` 304,805 bytes / `const v...` 5000개 -> 4,426 bytes / 50개
- 10101 module fixture: `entry.js` 614,130 bytes / `const v...` 10000개 -> 8,828 bytes / 100개
- wall-time은 노이즈 범위라 성능 개선 수치로 주장하지 않고, 출력 품질과 dead const 제거 개선으로 한정합니다.

## 추가한 회귀 테스트
- semantic/analyzer numeric const extraction
- `constant_facts` numeric literal materialize 및 object shorthand 금지 위치
- deep cross-module numeric const chain 대량 축소
- numeric const object shorthand 구문 보존
- post-pass 이후 top-level rename metadata stale 방지
- post-pass가 기존 namespace reachability를 뒤늦게 바꾸지 않는 케이스
- 순환 모듈 live binding const fact 제외
- NAPI graph pre-pass skip / preserveModules numeric folding 기대값 갱신
- browser smoke `effect`, `supabase` 로컬 재현 케이스 확인

## 검증
- `zig build test --summary all --prominent-compile-errors`
- `zig build -Doptimize=Debug --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- `zig build napi && cp zig-out/lib/zts.node packages/core/zts.node && cd packages/core && bun build index.ts --outdir dist --format esm --target node && bun test index.test.ts`
- `node --test packages/core/napi.test.mjs`
- `cd packages/core && bun test bin/zts.test.ts`
- `bun scripts/napi-bundler-bug-check.ts`
- `bun test tests/integration/tests/const-value-inline.test.ts`
- `bun test tests/integration/tests/bundle-circular-cycle.test.ts tests/integration/tests/const-value-inline.test.ts`
- `bun test tests/benchmark/monorepo-fixture.test.ts tests/benchmark/stats.test.ts`
- `bun run --cwd tests/e2e test tests/browser-smoke.test.ts --grep "browser: (effect|supabase)$"`
- `bun run fmt:check` with generated `tests/e2e/test-results/.last-run.json`
- `git diff --check`
- pre-push hook: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`

## Zig 구현 메모
- numeric const fact는 AST의 `numeric_literal`만 허용합니다. unary negative, bigint, string/template propagation은 이번 PR 범위에서 제외했습니다.
- AST mutation 이후에는 기존 metadata resync 경로를 유지하되, reachability 전/후 mutation의 의미가 달라서 linker finalize의 namespace access population을 단계별로 분리했습니다.