### PR TITLE
perf(ast): instrument addString intern hit/miss stats

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -13,6 +13,7 @@
 //! - references/swc/crates/swc_ecma_ast/src/
 
 const std = @import("std");
+const builtin = @import("builtin");
 const Span = @import("../lexer/token.zig").Span;
 const string_escape = @import("../string_escape.zig");
 
@@ -878,7 +879,9 @@ pub const Ast = struct {
     string_interns: std.StringHashMapUnmanaged(Span),
 
     /// addString intern map 의 hit/miss 통계. 측정 전용.
-    /// `ZTS_STRING_INTERN_STATS=1` 시 `Ast.deinit` 이 stderr 로 dump.
+    /// `ZTS_STRING_INTERN_STATS=1` 시 stderr 로 dump.
+    /// transpile 경로에서 Ast 가 arena 안에 살아 `Ast.deinit` 이 호출되지 않으므로
+    /// `transpile.zig` 가 arena 해제 직전 `dumpStringInternStatsIfEnabled` 를 직접 호출.
     /// 4 × u32 = 16B 추가, hot path 비용은 increment 4 회뿐.
     string_intern_hits: u32 = 0,
     string_intern_misses: u32 = 0,
@@ -953,6 +956,8 @@ pub const Ast = struct {
     }
 
     pub fn dumpStringInternStatsIfEnabled(self: *const Ast) void {
+        // WASI without libc 는 hasEnvVarConstant 가 @compileError. wasm 타겟 측정은 N/A.
+        if (comptime builtin.os.tag == .wasi and !builtin.link_libc) return;
         if (!std.process.hasEnvVarConstant("ZTS_STRING_INTERN_STATS")) return;
         const total = self.string_intern_hits + self.string_intern_misses;
         if (total == 0) return;

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -877,6 +877,14 @@ pub const Ast = struct {
     /// realloc 될 수 있으므로 내부 slice 를 key 로 쓰면 dangling 이 된다.
     string_interns: std.StringHashMapUnmanaged(Span),
 
+    /// addString intern map 의 hit/miss 통계. 측정 전용.
+    /// `ZTS_STRING_INTERN_STATS=1` 시 `Ast.deinit` 이 stderr 로 dump.
+    /// 4 × u32 = 16B 추가, hot path 비용은 increment 4 회뿐.
+    string_intern_hits: u32 = 0,
+    string_intern_misses: u32 = 0,
+    string_intern_bytes_saved: u32 = 0,
+    string_intern_bytes_overhead: u32 = 0,
+
     /// 파싱 중 JSX element/fragment가 발견되었는지 (automatic JSX import 주입용)
     has_jsx: bool = false,
 
@@ -937,10 +945,30 @@ pub const Ast = struct {
     }
 
     pub fn deinit(self: *Ast) void {
+        self.dumpStringInternStatsIfEnabled();
         self.nodes.deinit(self.allocator);
         self.extra_data.deinit(self.allocator);
         self.string_table.deinit(self.allocator);
         self.deinitStringInterns();
+    }
+
+    pub fn dumpStringInternStatsIfEnabled(self: *const Ast) void {
+        if (!std.process.hasEnvVarConstant("ZTS_STRING_INTERN_STATS")) return;
+        const total = self.string_intern_hits + self.string_intern_misses;
+        if (total == 0) return;
+        const hit_pct: f32 = @as(f32, @floatFromInt(self.string_intern_hits)) * 100.0 /
+            @as(f32, @floatFromInt(total));
+        std.debug.print(
+            "[ast-intern] hits={d} misses={d} hit%={d:.1} saved={d}B overhead={d}B entries={d}\n",
+            .{
+                self.string_intern_hits,
+                self.string_intern_misses,
+                hit_pct,
+                self.string_intern_bytes_saved,
+                self.string_intern_bytes_overhead,
+                self.string_interns.count(),
+            },
+        );
     }
 
     fn deinitStringInterns(self: *Ast) void {
@@ -1339,7 +1367,11 @@ pub const Ast = struct {
     ///   const span = try ast.addString("React");
     ///   // 나중에 ast.getText(span)으로 "React" 반환
     pub fn addString(self: *Ast, text: []const u8) !Span {
-        if (self.string_interns.get(text)) |span| return span;
+        if (self.string_interns.get(text)) |span| {
+            self.string_intern_hits +|= 1;
+            self.string_intern_bytes_saved +|= @intCast(text.len);
+            return span;
+        }
 
         // string_table은 bit 31 미만이어야 함 (bit 31은 마커로 사용)
         std.debug.assert(self.string_table.items.len + text.len < STRING_TABLE_BIT);
@@ -1380,6 +1412,8 @@ pub const Ast = struct {
             try self.string_table.appendSlice(self.allocator, text);
         }
         try self.string_interns.put(self.allocator, owned_key, span);
+        self.string_intern_misses +|= 1;
+        self.string_intern_bytes_overhead +|= @intCast(text.len);
         return span;
     }
 

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -1223,6 +1223,9 @@ fn transpileWithCallbackInternal(
         parser.is_jsx = true;
     }
     _ = parser.parse() catch return error.ParseError;
+    // Ast 가 arena 안에 살아 Ast.deinit() 가 호출되지 않으므로, intern stats dump 를
+    // arena 해제 직전(LIFO) 에 명시 호출. ZTS_STRING_INTERN_STATS=1 일 때만 출력.
+    defer parser.ast.dumpStringInternStatsIfEnabled();
     if (parser.errors.items.len > 0) {
         if (on_error) |cb| cb(source, file_path, &scanner, parser.errors.items);
         return error.ParseError;
@@ -1304,6 +1307,7 @@ fn transpileWithCallbackInternal(
         // #1621: standalone transpile 경로도 minify 시 runtime helper 축약 이름 사용.
         .minify_whitespace = options.minify_whitespace,
     });
+    defer transformer.ast.dumpStringInternStatsIfEnabled();
     if (analyzer_storage) |*analyzer| {
         transformer.initSymbolIds(analyzer.symbol_ids.items) catch return error.TransformError;
         transformer.symbols = analyzer.symbols.items;

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -1307,6 +1307,7 @@ fn transpileWithCallbackInternal(
         // #1621: standalone transpile 경로도 minify 시 runtime helper 축약 이름 사용.
         .minify_whitespace = options.minify_whitespace,
     });
+    // transformer.ast 도 arena owned (cloneForTransformer 결과). parser.ast 와 동일 이유.
     defer transformer.ast.dumpStringInternStatsIfEnabled();
     if (analyzer_storage) |*analyzer| {
         transformer.initSymbolIds(analyzer.symbol_ids.items) catch return error.TransformError;


### PR DESCRIPTION
## 요약

#2496 (`Ast.addString` intern map) 의 효과를 워크로드별로 실측하기 위한 dev-only counter. 측정 후 별도 PR 로 revert 또는 후속 마이그레이션과 함께 정리 예정.

## 변경
- `Ast` 에 4 × u32 counter (16B/instance): `string_intern_hits/misses/bytes_saved/bytes_overhead`
- `addString` hit/miss 분기에 saturating add (`+|=`)
- `dumpStringInternStatsIfEnabled` (env 게이트, stderr) — `ZTS_STRING_INTERN_STATS=1` 일 때만 출력
- `transpileWithCallbackInternal` 에 `defer parser.ast.dump(); defer transformer.ast.dump();` — Ast 가 arena 위에 살아 `Ast.deinit` 이 호출되지 않으므로 명시 호출 필요 (CLAUDE.md arena 패턴)

dump 형식:
```
[ast-intern] hits=N misses=N hit%=X.X saved=NB overhead=NB entries=N
```

## 측정 결과 (ReleaseFast, 본 브랜치 빌드)

| Workload | modules dump | hit % | bytes saved | bytes overhead | net (bytes) |
|---|---:|---:|---:|---:|---:|
| W1 round1 (TS lowering) | 3 | 47.4 | 430 | 412 | +18 |
| W2 examples/web/src (JSX/TSX) | 4 | 69.7 | 2018 | 1327 | **+691** |
| W3a round1 + `--minify` | 6 | 44.3 | 447 | 459 | -12 |
| W4 4 round dirs (TS, 140 files) | 10 | 41.6 | 911 | 1102 | -191 |
| W4 + `--minify` | 18 | 40.2 | 963 | 1195 | -232 |
| **W5a 합성 JSX 100 컴포넌트** | 1 | **93.6** | **14433** | 957 | **+13,476** |

awk aggregator: `tests/intern-bench/agg.awk` (commit 미포함, 측정용 스크립트).

### 해석

1. **JSX-heavy 워크로드 (W2/W5a) 에서 강한 net win**. `\"children\"`, `\"key\"`, `\"className\"`, `\"_jsx\"` 등이 컴포넌트마다 반복돼 hit% 가 70~94% 까지 올라감. JSX 100 컴포넌트는 14.4KB 절감.
2. **TS-only lowering (W1/W4) 은 marginal/약간 net loss**. enum/namespace lowering 은 `addString` 호출 자체가 적고 (W5c/d 에서 0회), unique identifier 가 많아 dedup 효과 적음.
3. **HashMap entry overhead (~32B/entry)** 추가 고려 시:
   - W4 TS-only: entries 135 × 32 = 4320B → net loss ~3.5KB
   - W2 JSX: entries 90 × 32 = 2880B + saved 2018B → 메모리 +862B
   - **W5a JSX-100: entries 109 × 32 = 3488B → 순 메모리 절감 +10.9KB**
4. `--minify` 자체는 hit ratio 에 큰 영향 없음 (W2 ↔ W3b 동일).

### 후속 권고

- **B 대안 (Span-key adapted HashMap)** 으로 마이그레이션하면 owned_key dupe 자체가 사라져 모든 워크로드에서 추가 절감. 특히 TS-only 의 net loss 케이스를 net wash 로.
- 또는 short-string-only intern (length ≤ 32) 로 좁혀 TS-only 의 entry overhead 줄임.

## 테스트
- `zig fmt src/parser/ast.zig src/transpile.zig --check`
- `zig build test --summary all` — 4620/4620 통과
- `ZTS_STRING_INTERN_STATS=1 ./zts /tmp/jsx-test.tsx -o /tmp/jsx-test.js 2>&1` 으로 dump 동작 확인