### PR TITLE
refactor(ast): integrate intern stats into debug_log category

### DIFF
--- a/src/debug_log.zig
+++ b/src/debug_log.zig
@@ -35,6 +35,9 @@ pub const Category = enum {
     /// RFC #1672 D1 (Ast mutable + clone 제거) 디버깅용. parse_arena 소유권과
     /// transformer 의 in-place append 상호작용 확인.
     ast_mutation,
+    /// `Ast.addString` intern map 의 hit/miss 통계. PR #2496 의 dedupe 효과
+    /// 측정용. 모듈별 (parser/transformer 두 ast 합산) dump.
+    string_intern,
 
     /// 카테고리 이름으로 enum 조회 (공백 제거 + 대소문자 무시).
     pub fn fromString(s: []const u8) ?Category {

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -13,7 +13,6 @@
 //! - references/swc/crates/swc_ecma_ast/src/
 
 const std = @import("std");
-const builtin = @import("builtin");
 const Span = @import("../lexer/token.zig").Span;
 const string_escape = @import("../string_escape.zig");
 
@@ -879,8 +878,7 @@ pub const Ast = struct {
     /// ctx 를 저장하지 않음 — Ast 가 옮겨져도 stale 문제 없음).
     string_interns: StringInternMap,
 
-    /// addString intern map 의 hit/miss 통계. 측정 전용.
-    /// `ZTS_STRING_INTERN_STATS=1` 시 stderr 로 dump.
+    /// addString intern map 의 hit/miss 통계. `ZTS_DEBUG=string_intern` 시 dump.
     /// transpile 경로에서 Ast 가 arena 안에 살아 `Ast.deinit` 이 호출되지 않으므로
     /// `transpile.zig` 가 arena 해제 직전 `dumpStringInternStatsIfEnabled` 를 직접 호출.
     /// 4 × u32 = 16B 추가, hot path 비용은 increment 4 회뿐.
@@ -990,15 +988,15 @@ pub const Ast = struct {
     }
 
     pub fn dumpStringInternStatsIfEnabled(self: *const Ast) void {
-        // WASI without libc 는 hasEnvVarConstant 가 @compileError. wasm 타겟 측정은 N/A.
-        if (comptime builtin.os.tag == .wasi and !builtin.link_libc) return;
-        if (!std.process.hasEnvVarConstant("ZTS_STRING_INTERN_STATS")) return;
+        const debug_log = @import("../debug_log.zig");
+        if (!debug_log.enabled(.string_intern)) return;
         const total = self.string_intern_hits + self.string_intern_misses;
         if (total == 0) return;
         const hit_pct: f32 = @as(f32, @floatFromInt(self.string_intern_hits)) * 100.0 /
             @as(f32, @floatFromInt(total));
-        std.debug.print(
-            "[ast-intern] hits={d} misses={d} hit%={d:.1} saved={d}B overhead={d}B entries={d}\n",
+        debug_log.print(
+            .string_intern,
+            "hits={d} misses={d} hit%={d:.1} saved={d}B overhead={d}B entries={d}\n",
             .{
                 self.string_intern_hits,
                 self.string_intern_misses,


### PR DESCRIPTION
## 요약
\`ZTS_STRING_INTERN_STATS\` ad-hoc env 를 기존 \`debug_log\` 인프라로 통합. counter 자체는 유지 (16B/Ast, hot-path increment 4 회만) — profile/debug 에 영구 유용. 사용자 제안 (#2498 머지 후 논의).

## 변경
- \`debug_log.Category\` enum 에 \`string_intern\` 추가 (3 줄)
- \`Ast.dumpStringInternStatsIfEnabled\`: \`hasEnvVarConstant + std.debug.print\` → \`debug_log.enabled + debug_log.print\` substitution
- WASI 가드 제거 (\`debug_log.enabled\` 는 mask AND — WASI 호환)
- prefix: \`[ast-intern]\` → \`[string_intern]\` (snake_case 통일)

LOC: +9 / -8.

## 사용법
- 이전: \`ZTS_STRING_INTERN_STATS=1 zts ...\`
- **이후**: \`ZTS_DEBUG=string_intern zts ...\`
- 다른 카테고리와 조합: \`ZTS_DEBUG=string_intern,compiled_cache\`
- 출력 예: \`[string_intern] hits=7 misses=9 hit%=43.8 saved=78B overhead=69B entries=9\`

## 테스트
- \`zig fmt --check\`
- \`zig build test --summary all\` — 4624/4624 통과
- \`zig build wasm\` — WASI 빌드 OK
- 트리거 검증: ZTS_DEBUG=string_intern 으로 dump 출력 확인

## 후속
- C 시리즈 (caller-side stale lazy span 캐시 정리) 측정 시 통일된 인터페이스 사용 가능