### PR TITLE
refactor(tree-shaker): use Module.importers for numeric BFS reverse-deps (#2506)

### DIFF
--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -418,24 +418,24 @@ pub const TreeShaker = struct {
         return any_changed;
     }
 
+    /// `Module.importers` (graph.linkDependency 가 채우는 양방향 인접 리스트) 의 항목을
+    /// numeric BFS 큐에 넣는다. dynamic_importers 는 별도 리스트라 자동 제외 — dynamic
+    /// import 는 runtime property 접근이라 numeric materialize 가 손댈 AST binding 이 없다.
+    fn enqueueStaticImporters(
+        self: *TreeShaker,
+        queue: *std.ArrayList(u32),
+        idx: u32,
+        mod_count: usize,
+    ) !void {
+        const m = self.getModule(idx) orelse return;
+        for (m.importers.items) |imp| {
+            const ii = @intFromEnum(imp);
+            if (ii >= mod_count) continue;
+            try queue.append(self.allocator, @intCast(ii));
+        }
+    }
+
     fn propagateNumericExportConstFacts(self: *TreeShaker, mod_count: usize) !void {
-        var reverse_deps = try self.allocator.alloc(std.ArrayList(u32), mod_count);
-        defer {
-            for (reverse_deps) |*deps| deps.deinit(self.allocator);
-            self.allocator.free(reverse_deps);
-        }
-        for (reverse_deps) |*deps| deps.* = .empty;
-
-        for (0..mod_count) |i| {
-            const m = self.getModule(@intCast(i)) orelse continue;
-            for (m.import_records) |rec| {
-                if (rec.resolved.isNone()) continue;
-                const target = @intFromEnum(rec.resolved);
-                if (target >= mod_count) continue;
-                try reverse_deps[target].append(self.allocator, @intCast(i));
-            }
-        }
-
         var queue: std.ArrayList(u32) = .empty;
         defer queue.deinit(self.allocator);
         var forwarded_re_exports = try std.DynamicBitSet.initEmpty(self.allocator, mod_count);
@@ -446,18 +446,18 @@ pub const TreeShaker = struct {
             const ast = &(m.ast orelse continue);
             if (self.moduleHasNumericExportSeed(ast, sem)) {
                 self.minifyAndResyncModule(m, sem, ast);
-                for (reverse_deps[i].items) |importer| try queue.append(self.allocator, importer);
+                try self.enqueueStaticImporters(&queue, @intCast(i), mod_count);
                 continue;
             }
             if (self.moduleHasExportedNumberConstValue(sem)) {
-                for (reverse_deps[i].items) |importer| try queue.append(self.allocator, importer);
+                try self.enqueueStaticImporters(&queue, @intCast(i), mod_count);
             }
         }
 
         while (queue.pop()) |idx| {
             if (idx >= mod_count) continue;
             if (try self.materializeCrossModuleConstFactsForIndex(idx, .numeric_export_chain)) {
-                for (reverse_deps[idx].items) |importer| try queue.append(self.allocator, importer);
+                try self.enqueueStaticImporters(&queue, idx, mod_count);
                 continue;
             }
 
@@ -472,7 +472,7 @@ pub const TreeShaker = struct {
             }
             if (!has_re_export) continue;
             forwarded_re_exports.set(idx);
-            for (reverse_deps[idx].items) |importer| try queue.append(self.allocator, importer);
+            try self.enqueueStaticImporters(&queue, idx, mod_count);
         }
     }
 

--- a/tests/integration/tests/const-value-inline.test.ts
+++ b/tests/integration/tests/const-value-inline.test.ts
@@ -397,6 +397,31 @@ describe("const_value cross-module 인라인 correctness", () => {
     expect(run.trim()).toBe("2 99");
   });
 
+  test("dynamic import 가 섞여도 numeric chain 이 static importer 까지 전파된다", async () => {
+    // #2506 회귀 방지: numeric BFS 가 reverse_deps 를 import_records 로부터 재구성하던
+    // 시절엔 dynamic_importers 까지 큐에 들어갔다 (헛일이지만 무해). Module.importers
+    // 직접 사용으로 바꾸면 dynamic 은 제외되는데, static chain 전파는 그대로 동작해야.
+    const r = await bundleAndRun(
+      {
+        "seed.ts": `export const N = 7;`,
+        "static.ts": `
+          import { N } from "./seed";
+          export const X = N + 1;
+        `,
+        "index.ts": `
+          import { X } from "./static";
+          // dynamic import 자체는 평가만 시도 (시드 모듈에 side-effect 없음).
+          import("./seed").then((m) => console.log(X, m.N));
+        `,
+      },
+      "index.ts",
+      ["--platform=node"],
+    );
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.runOutput).toBe("8 7");
+  });
+
   // ========================================================================
   // Edge cases: local let (not exported) / 같은 모듈 내 참조
   // ========================================================================


### PR DESCRIPTION
Closes #2506.

## 요약
`propagateNumericExportConstFacts` 가 매 호출마다 `mod_count` 만큼 `ArrayList(u32)` 를 새로 할당해 reverse_deps 를 `import_records` 로부터 재구성하던 것을, 이미 `graph.linkDependency` 가 채워둔 `Module.importers` (양방향 인접 리스트, D078) 직접 사용으로 교체.

## 이슈 본문 vs. 실제 fix
이슈는 `graph.zig` 의 `propagateTopLevelAwait` 와 헬퍼 공유 (`buildReverseImporterMap`) 를 제안했으나 — 실제 코드 확인 결과 더 단순한 fix 가 가능했다:

| | TLA propagation | numeric BFS |
|---|---|---|
| 필요한 importer | `static_import|side_effect|re_export` 만 | 모든 static (dynamic 제외) |
| `Module.importers` 로 충족? | ❌ kind 정보가 없어 필터 불가 | ✅ 정확히 일치 |

→ TLA 는 그대로 두고 numeric BFS 만 `Module.importers` 직접 사용. dynamic_importers 는 자동 제외 — dynamic import 는 runtime property 접근이라 numeric materialize 가 손댈 AST binding 이 없으니 strict 정합 + strict 개선.

## 변경
- `enqueueStaticImporters` 헬퍼 추가: `Module.importers` 를 큐에 넣음.
- `propagateNumericExportConstFacts` 의 reverse_deps alloc + import_records 순회 블록 제거.
- 회귀 방지 테스트 추가: dynamic import 가 같은 seed 모듈을 가리키더라도 static importer 의 chain fold 가 정상 전파되는지 e2e 검증.

## 성능
- alloc 감소: `[]ArrayList(u32)` × `mod_count` + 각 ArrayList 의 inner storage 제거.
- BFS 큐 크기 감소: dynamic_importers 가 더 이상 큐에 들어가지 않음 — 큰 그래프에서 헛돈 materialize 시도 (반드시 false 반환) 가 줄어든다.

## 검증
- `zig build test --summary all` — 4624/4624 pass
- `bun test tests/integration/tests/const-value-inline.test.ts` — 30 pass (29 + 새 회귀 테스트)
- `bun test tests/benchmark/monorepo-fixture.test.ts` — 2 pass
- `zig fmt --check src/`
- pre-push hook 통과

## Zig 메모
- `Module.importers: std.ArrayList(ModuleIndex)` (`module.zig:175`) 는 `ModuleIndex` (enum(u32)) 를 담음. `@intFromEnum` 으로 raw u32 추출.
- 양방향 등록은 `graph.linkDependency` (`graph.zig:863`) 에 일원화 — 즉, 새 import edge 를 graph 에 추가할 때 `Module.importers` 도 자동으로 채워진다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)