### PR TITLE
refactor(transformer): drop styled-components span cache + AstSnapshot 보강

### DIFF
--- a/src/transformer/plugin_state.zig
+++ b/src/transformer/plugin_state.zig
@@ -127,12 +127,6 @@ pub const StyledComponentsState = struct {
     /// `import { injectGlobal } from "styled-components"` named import.
     inject_global_binding: ?[]const u8 = null,
 
-    /// `.withConfig({...})` 래핑 시 매 컴포넌트마다 동일 문자열을 string_table 에 추가하는
-    /// 비용을 피하기 위한 lazy 캐시. 첫 wrap 시점에 채워짐.
-    with_config_span: ?Span = null,
-    display_name_span: ?Span = null,
-    component_id_span: ?Span = null,
-
     /// componentId hash 의 file 부분 — `options.jsx_filename` 의 wyhash 32-bit truncated 8-hex.
     /// SSR hydration 안정화: 같은 파일에서 같은 hash 보장 (counter 와 결합).
     /// 32-bit truncation 은 일반 monorepo (수만 파일) 에서도 collision 무시 가능.

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -967,13 +967,11 @@ fn mergeIntoUserWithConfig(
     const args_obj_idx = withConfigCallArgsObj(self, target_call_idx) orelse return init_idx;
 
     const state = &self.plugins.styled_components;
-    if (state.display_name_span == null) state.display_name_span = try self.ast.addString("displayName");
 
     const scan = scanObjectKeys(self, args_obj_idx);
     const want_component_id = self.options.styled_components_ssr and self.options.jsx_filename.len > 0;
-    if (want_component_id and state.component_id_span == null) {
-        state.component_id_span = try self.ast.addString("componentId");
-        if (state.file_hash_hex == null) state.file_hash_hex = wyhash.hashHex8(self.options.jsx_filename);
+    if (want_component_id and state.file_hash_hex == null) {
+        state.file_hash_hex = wyhash.hashHex8(self.options.jsx_filename);
     }
 
     const need_display = !scan.has_display;
@@ -990,15 +988,17 @@ fn mergeIntoUserWithConfig(
     defer self.scratch.shrinkRetainingCapacity(props_top);
 
     if (need_display) {
+        const display_name_key = try self.ast.addString("displayName");
         const display_value_span = try buildDisplayNameSpan(self, var_name);
-        const display_property = try buildKeyStringProperty(self, state.display_name_span.?, display_value_span);
+        const display_property = try buildKeyStringProperty(self, display_name_key, display_value_span);
         try self.scratch.append(self.allocator, display_property);
     }
     if (need_component_id) {
+        const component_id_key = try self.ast.addString("componentId");
         const component_index = state.component_counter;
         state.component_counter += 1;
         const component_id_value_span = try buildComponentIdSpan(self, state.file_hash_hex.?, component_index);
-        const component_id_property = try buildKeyStringProperty(self, state.component_id_span.?, component_id_value_span);
+        const component_id_property = try buildKeyStringProperty(self, component_id_key, component_id_value_span);
         try self.scratch.append(self.allocator, component_id_property);
     }
     for (old_props) |raw| try self.scratch.append(self.allocator, @enumFromInt(raw));
@@ -1066,18 +1066,14 @@ fn mergeIntoUserWithConfig(
 fn buildWithConfigCall(self: *Transformer, tag_idx: NodeIndex, var_name: []const u8) Error!NodeIndex {
     const zero = Span{ .start = 0, .end = 0 };
     const state = &self.plugins.styled_components;
-    if (state.with_config_span == null) state.with_config_span = try self.ast.addString("withConfig");
-    if (state.display_name_span == null) state.display_name_span = try self.ast.addString("displayName");
-
-    const with_config_span = state.with_config_span.?;
-    const display_name_key_span = state.display_name_span.?;
+    const with_config_span = try self.ast.addString("withConfig");
+    const display_name_key_span = try self.ast.addString("displayName");
     // componentId 는 두 조건 모두 만족 시 emit:
     //  1. ssr 옵션 활성 (default true) — 사용자가 명시적으로 끄지 않음
     //  2. jsx_filename 존재 — file 부분 hash 의 입력
     const emit_component_id = self.options.styled_components_ssr and self.options.jsx_filename.len > 0;
-    if (emit_component_id) {
-        if (state.component_id_span == null) state.component_id_span = try self.ast.addString("componentId");
-        if (state.file_hash_hex == null) state.file_hash_hex = wyhash.hashHex8(self.options.jsx_filename);
+    if (emit_component_id and state.file_hash_hex == null) {
+        state.file_hash_hex = wyhash.hashHex8(self.options.jsx_filename);
     }
 
     const display_value_span = try buildDisplayNameSpan(self, var_name);
@@ -1097,10 +1093,11 @@ fn buildWithConfigCall(self: *Transformer, tag_idx: NodeIndex, var_name: []const
     const display_property = try buildKeyStringProperty(self, display_name_key_span, display_value_span);
 
     const obj_list = if (emit_component_id) blk: {
+        const component_id_key = try self.ast.addString("componentId");
         const component_index = state.component_counter;
         state.component_counter += 1;
         const component_id_value_span = try buildComponentIdSpan(self, state.file_hash_hex.?, component_index);
-        const component_id_property = try buildKeyStringProperty(self, state.component_id_span.?, component_id_value_span);
+        const component_id_property = try buildKeyStringProperty(self, component_id_key, component_id_value_span);
         break :blk try self.ast.addNodeList(&.{ display_property, component_id_property });
     } else try self.ast.addNodeList(&.{display_property});
 

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1893,12 +1893,14 @@ const AstSnapshot = struct {
     nodes: []Node,
     extra_data: []u32,
     string_table: []u8,
+    string_interns_count: u32,
 
     fn take(allocator: std.mem.Allocator, ast: *const Ast) !AstSnapshot {
         return .{
             .nodes = try allocator.dupe(Node, ast.nodes.items),
             .extra_data = try allocator.dupe(u32, ast.extra_data.items),
             .string_table = try allocator.dupe(u8, ast.string_table.items),
+            .string_interns_count = ast.string_interns.count(),
         };
     }
 
@@ -1911,6 +1913,7 @@ const AstSnapshot = struct {
     fn assertMatches(self: AstSnapshot, ast: *const Ast) !void {
         try std.testing.expectEqual(self.extra_data.len, ast.extra_data.items.len);
         try std.testing.expectEqual(self.string_table.len, ast.string_table.items.len);
+        try std.testing.expectEqual(self.string_interns_count, ast.string_interns.count());
         try std.testing.expectEqualSlices(u32, self.extra_data, ast.extra_data.items);
         try std.testing.expectEqualSlices(u8, self.string_table, ast.string_table.items);
         // Node 는 extern struct 라 padding 없는 bit-identical 비교 가능.


### PR DESCRIPTION
## 요약
조사 보고 C-3 + C-5 묶음. 모두 PR #2496 의 \`Ast.addString\` intern map 도입 follow-up.

## C-3 styled-components lazy span 캐시 제거
3 spans 모두 literal — 첫 호출 후 intern hit:
- \`with_config_span\` ("withConfig")
- \`display_name_span\` ("displayName")
- \`component_id_span\` ("componentId")

변경:
- \`plugin_state.zig\`: 3 \`?Span\` 필드 삭제 (\`file_hash_hex\` 는 wyhash 결과라 유지)
- \`styled_components.zig\`: lazy null 가드 + \`state.X.?\` 사용 모두 제거, 함수 안에서 직접 \`addString\` 호출

LOC: -27 +14.

## C-5 AstSnapshot 보강
PR #2500 (Span-key intern map) 후 \`string_interns\` 가 transform 도중 mutate 가능. 기존 snapshot 가드는 nodes/extra_data/string_table 만 검사 → \`string_interns\` 누락. 한 줄 보강:
- \`string_interns_count: u32\` 필드 + take/assertMatches 비교

D1 in-place borrow 경로 재도입 시 invariant 가드 강화. 비용 ~0.

LOC: +3.

## 측정
- styled-components 145/145 테스트 통과
- emit 결과 unchanged
- intern hit lookup 비용 ~50ns × 컴포넌트당 2~3회 → 100 컴포넌트당 ~15μs (이전 캐시 vs intern hit 차이 측정 불가능 수준)

## 테스트
- \`zig fmt --check\`
- \`zig build test --summary all\` — 4624/4624 통과