### PR TITLE
perf(linker): narrow refreshAfterAstMutation API for tree-shaker pre-shake (#2502, #2507)

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -2676,6 +2676,22 @@ pub const Linker = struct {
         self.populateSymbolRefCounts();
     }
 
+    /// pre-shake AST mutation (cross-module const materialize) 직후, 후속 BFS 가
+    /// 읽는 populate* 만 좁게 재실행한다. rename/mangling/symbol_ref_counts 는
+    /// 의도적으로 제외:
+    ///   - rename/mangling: emit 단계 입력. 직후 numeric post-pass 가 또 mutation 할
+    ///     수 있어 bundler 가 모든 mutation 이 settle 된 뒤 한 번만 계산해야 한다
+    ///     (#2502: 두 번 호출되면 inner 결과가 outer `clear_first` 로 폐기 → 낭비).
+    ///   - populateSymbolRefCounts: 증분 (`+= 1`) 이라 멱등하지 않음 — 두 번 부르면
+    ///     2× 누적. mangler 가 rank-comparison 으로만 쓰니 결과는 같지만, 새 inner
+    ///     에서 빼고 outer 의 한 번만 신뢰하는 편이 명확.
+    /// `*const Linker` 시그니처 — populate* 모두 const-self interior mutation 만 함.
+    pub fn refreshAfterAstMutation(self: *const Linker) void {
+        self.populateReExportAliases();
+        self.populateImportSymbols();
+        self.populateNamespaceAccesses();
+    }
+
     /// 특정 모듈들만 대상으로 이름 충돌을 감지하고 리네임을 계산한다.
     /// code splitting에서 사용 — 각 청크는 독립된 네임스페이스이므로
     /// 같은 이름이 다른 청크에 있어도 충돌하지 않는다.

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -82,7 +82,7 @@ pub const TreeShaker = struct {
     /// Module storage 접근 포인터 (#1779 PR #2). 기존 `[]const Module` slice
     /// 필드를 대체. `analyze` 내부에서 `module.side_effects` 를 mutate 하므로 non-const.
     graph: *ModuleGraph,
-    linker: *Linker,
+    linker: *const Linker,
     included: std.DynamicBitSet,
     used_exports: std.StringHashMap(void),
     entry_set: std.DynamicBitSet,
@@ -115,7 +115,7 @@ pub const TreeShaker = struct {
     const max_fixpoint_iterations: u32 = 100;
     const max_numeric_const_post_passes: u32 = 2;
 
-    pub fn init(allocator: std.mem.Allocator, graph: *ModuleGraph, linker: *Linker) !TreeShaker {
+    pub fn init(allocator: std.mem.Allocator, graph: *ModuleGraph, linker: *const Linker) !TreeShaker {
         const mod_count = graph.moduleCount();
         var included = try std.DynamicBitSet.initEmpty(allocator, mod_count);
         errdefer included.deinit();
@@ -366,15 +366,14 @@ pub const TreeShaker = struct {
         self.ast_mutated_after_link = true;
     }
 
-    fn refreshLinkMetadataAfterPreShakeMutation(self: *TreeShaker) !void {
+    /// pre-shake materialize 직후 후속 BFS 가 읽는 linker populate* 만 좁게 재실행.
+    /// rename/mangling 은 numeric post-pass 가 또 mutation 할 수 있어 모든 mutation 이
+    /// settle 된 뒤 bundler 의 outer finalize 에서 한 번에 (#2502). `ast_mutated_after_link`
+    /// 는 sticky 유지 — outer 가 항상 발화해야 새 symbol id 의 rename 이 emit 단계에 반영됨.
+    fn refreshLinkMetadataAfterPreShakeMutation(self: *TreeShaker) void {
         if (!self.ast_mutated_after_link) return;
         if (self.graph.code_splitting) return;
-        try self.linker.finalize(.{
-            .compute_renames = true,
-            .compute_mangling = self.graph.minify_identifiers,
-            .clear_first = true,
-        });
-        self.ast_mutated_after_link = false;
+        self.linker.refreshAfterAstMutation();
     }
 
     fn shouldMaterializeConstFacts(
@@ -545,7 +544,7 @@ pub const TreeShaker = struct {
         if (self.graph.resolve_cache.platform == .node) {
             try self.applyNodeBufferCapabilityFacts();
         }
-        try self.refreshLinkMetadataAfterPreShakeMutation();
+        self.refreshLinkMetadataAfterPreShakeMutation();
 
         // 자동 순수 판별: 진입점이 아닌 모듈의 top-level이 모두 순수하면 side_effects=false
         // (rolldown/esbuild 동작: package.json sideEffects 없어도 자동 감지)

--- a/tests/integration/tests/const-value-inline.test.ts
+++ b/tests/integration/tests/const-value-inline.test.ts
@@ -396,6 +396,37 @@ describe("const_value cross-module 인라인 correctness", () => {
     expect(run.trim()).toBe("2 99");
   });
 
+  test("--minify 에서 pre-shake materialize 이후 numeric post-pass 미발화 경로도 emit 정상", async () => {
+    // #2502 회귀 방지. inner refreshLinkMetadataAfterPreShakeMutation 가 좁은 populate*
+    // 만 실행하고 ast_mutated_after_link 를 sticky 유지해 outer finalize 가 항상 발화해야
+    // resynced symbol id 가 emit 단계에 반영된다. 시드는 boolean 만 — numeric post-pass gate
+    // (`anyModuleHasExportedNumberConst`) 가 닫혀 inner 의 mutation 이 outer 발화를 일으키는
+    // 유일한 경로가 된다. helper 의 mangle 결과가 valid JS 로 실행되는 것으로 확인.
+    const r = await bundleAndRun(
+      {
+        "lib.ts": `
+          export const FLAG = true;
+          export const FALLBACK = false;
+        `,
+        "index.ts": `
+          import { FLAG, FALLBACK } from "./lib";
+          function helperFunctionThatGetsMangled() { return 84; }
+          function unusedFunctionThatGetsMangled() { return 99; }
+          if (FLAG && !FALLBACK) {
+            console.log(helperFunctionThatGetsMangled());
+          } else {
+            console.log(unusedFunctionThatGetsMangled());
+          }
+        `,
+      },
+      "index.ts",
+      ["--platform=node", "--minify"],
+    );
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+    expect(r.runOutput).toBe("84");
+  });
+
   test("dynamic import 가 섞여도 numeric chain 이 static importer 까지 전파된다", async () => {
     // #2506 회귀 방지: numeric BFS 가 reverse_deps 를 import_records 로부터 재구성하던
     // 시절엔 dynamic_importers 까지 큐에 들어갔다 (헛일이지만 무해). Module.importers


### PR DESCRIPTION
Closes #2502, #2507.

## 요약
`refreshLinkMetadataAfterPreShakeMutation` 가 `linker.finalize({ compute_renames=true, compute_mangling=<minify_identifiers>, clear_first=true })` 를 호출하던 것을, BFS 가 실제로 읽는 좁은 populate* 셋만 실행하는 새 API `Linker.refreshAfterAstMutation` 로 교체. 결과: `--minify-identifiers` 빌드의 단일 최대 비용 단계 (`computeMangling`) 가 두 번 → 한 번.

## 분석
이전 흐름:
1. pre-shake materialize → AST mutation
2. inner: `linker.finalize({ clear_first=true, compute_renames=true, compute_mangling=true })` ← rename + mangling 계산
3. tree-shake BFS / numeric post-pass → AST 추가 mutation 가능
4. outer (`bundler.zig:1006`): `linker.finalize({ clear_first=true, compute_renames=true, compute_mangling=true })` ← inner 결과 폐기 + 다시 계산

각 populate* 의 idempotence 검증:

| populate fn | 멱등? | BFS 가 읽음? |
|---|---|---|
| `populateReExportAliases` | ✅ assigns canonical | ✅ resolveExportChain |
| `populateImportSymbols` | ✅ assigns | ✅ 직접 |
| `populateNamespaceAccesses` | ✅ overwrites | ✅ namespace.member |
| `populateSymbolRefCounts` | ❌ `+= 1` 누적 | ❌ mangler-priority 전용 |

→ inner 가 상위 3개만 실행하면:
- ref_count 두 번 누적 문제 자동 회피 (outer 한 번이면 정확)
- BFS 가 필요로 하는 모든 metadata 채워짐
- rename/mangling 은 outer 에서만 — 모든 mutation settle 후 한 번만 계산

## 변경
- `Linker.refreshAfterAstMutation()` 새 API (`*const Linker`).
- `tree_shaker.refreshLinkMetadataAfterPreShakeMutation` 가 narrow API 호출, `ast_mutated_after_link` 를 sticky 유지 (outer 항상 발화 보장).
- `tree_shaker.linker: *Linker` → `*const Linker` 되돌림 — 더 이상 mutable widening 불필요 (#2507).
- 회귀 테스트: pre-shake mutate (boolean const) + numeric post-pass off + `--minify` 경로가 outer 의 rename/mangling 발화에 의존함을 검증.

## 성능 효과
`--minify-identifiers` + cross-module const 가 있는 빌드:
- inner: `computeRenames` + `computeMangling` + `clearCanonicalNames` + `clearMangling` 비용 제거.
- outer: 변경 없음.
- 결과: 동일 (오히려 mangler-priority 누적이 사라져 정확).

## 검증
- `zig build test --summary all` — 4624/4624 pass
- `bun test tests/integration/tests/const-value-inline.test.ts` — 31 pass (30 + 새 회귀)
- `bun test tests/benchmark/monorepo-fixture.test.ts` — 2 pass
- `zig fmt --check src/` · 변경 파일 oxlint/oxfmt 통과

## Zig 메모
- `populate*` 가 모두 `*const Linker` 인 이유: 안에서 `graph.moduleAtMut(...)` 로 module 필드를 mutate (interior mutability via graph 포인터). Linker self 는 read-only.
- sticky flag: 이전엔 inner 가 `ast_mutated_after_link = false` 로 떨궜다. 떨구면 outer 가 발화 안 해 resynced symbol id 의 rename 이 emit 단계에 안 반영되는 회귀 (#2502 fix 의 핵심 invariant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)