### PR TITLE
refactor(parser): flow Name_withRef → addString 통합

### DIFF
--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -1294,17 +1294,13 @@ pub fn parseFlowComponentDeclaration(self: *Parser) ParseError2!NodeIndex {
 
         const span: Span = .{ .start = start, .end = self.currentSpan().start };
 
-        // Name_withRef 합성 이름 생성 (string_table 통합으로 codegen에서 접근 가능)
+        // Name_withRef 합성 이름 → addString 으로 통합 (intern map 등록 + STRING_TABLE_BIT 자동).
+        // addString 이 byte 본문을 string_table 로 복사한 후 임시 buffer 는 free.
         const name_node = self.ast.getNode(name);
         const name_text = self.ast.source[name_node.span.start..name_node.span.end];
-        const st_start: u32 = @intCast(self.ast.string_table.items.len);
-        try self.ast.string_table.appendSlice(self.ast.allocator, name_text);
-        try self.ast.string_table.appendSlice(self.ast.allocator, "_withRef");
-        const st_end: u32 = @intCast(self.ast.string_table.items.len);
-        const with_ref_full: Span = .{
-            .start = st_start | ast_mod.Ast.STRING_TABLE_BIT,
-            .end = st_end | ast_mod.Ast.STRING_TABLE_BIT,
-        };
+        const combined = try std.fmt.allocPrint(self.ast.allocator, "{s}_withRef", .{name_text});
+        defer self.ast.allocator.free(combined);
+        const with_ref_full = try self.ast.addString(combined);
 
         const with_ref_name = try self.ast.addNode(.{
             .tag = .binding_identifier,


### PR DESCRIPTION
## 요약
\`flow.zig\` 의 \`Name_withRef\` 합성 이름 생성이 \`string_table.appendSlice\` 두 번으로 직접 mutate → \`Ast.string_interns\` 우회. 본 PR 은 \`allocPrint + addString\` 단일 호출로 통합.

## 변경
**이전** (`flow.zig:1300-1307`):
\`\`\`zig
const st_start: u32 = @intCast(self.ast.string_table.items.len);
try self.ast.string_table.appendSlice(self.ast.allocator, name_text);
try self.ast.string_table.appendSlice(self.ast.allocator, "_withRef");
const st_end: u32 = @intCast(self.ast.string_table.items.len);
const with_ref_full: Span = .{
    .start = st_start | ast_mod.Ast.STRING_TABLE_BIT,
    .end = st_end | ast_mod.Ast.STRING_TABLE_BIT,
};
\`\`\`

**이후**:
\`\`\`zig
const combined = try std.fmt.allocPrint(self.ast.allocator, "{s}_withRef", .{name_text});
defer self.ast.allocator.free(combined);
const with_ref_full = try self.ast.addString(combined);
\`\`\`

LOC: -9 +5.

## 의의
1. **invariant 일관성**: "외부에서 string_table 직접 mutation 0건" → 향후 maintainer 가 \`SpanCtx\` invariant 자명하게 받아들임
2. **dedup 가능성**: 같은 \`Name_withRef\` 가 한 파일에 두 번 등장하면 (현실엔 거의 없음) 자동 dedup
3. **STRING_TABLE_BIT 마커**: addString 이 자동 OR — 손수 비트 OR 코드 제거

## 테스트
- \`zig fmt --check\`
- \`zig build test --summary all\` — 4624/4624 통과
- Flow component fixture: \`MyButton_withRef\`, \`Card_withRef\` 합성 이름 정확

dump:
\`\`\`
[string_intern] hits=7 misses=10 hit%=41.2 saved=60B overhead=98B entries=10
\`\`\`