### PR TITLE
perf(constant_facts): cache forbidden + reachable per module across post-pass (#2504)

### DIFF
--- a/src/bundler/constant_facts.zig
+++ b/src/bundler/constant_facts.zig
@@ -38,6 +38,59 @@ fn constValueNode(ast: *Ast, cv: ConstValue) ?Node {
     };
 }
 
+/// `materialize` 가 모듈마다 forbidden bitset + reachable 리스트를 매번 새로 만들지
+/// 않도록 outer driver (tree_shaker post-pass) 가 보유하는 per-module 캐시.
+///
+/// 같은 모듈에 대해 numeric post-pass 가 forward/reverse × 최대 2 회 호출하면 inner
+/// 가 4 번 도는데 — `forbidden` 은 AST shape 만 의존, `reachable` 도 마찬가지라
+/// AST mutation (`tree_shaker.markAstMutatedAndResync`) 직전까지는 안전하게 재사용.
+///
+/// `materialize` 가 leaf identifier 노드를 leaf literal 로 바꾸는 in-place mutation 만
+/// 하므로 `nodes.items.len` 도 변화 없음 → 같은 bitset 크기 그대로.
+pub const Scratch = struct {
+    allocator: std.mem.Allocator,
+    /// per-module forbidden bitset. null = 아직 빌드 안 했거나 invalidate 직후.
+    forbidden: []?std.DynamicBitSet,
+    /// per-module reachable node 인덱스 리스트.
+    reachable: []?[]u32,
+
+    pub fn init(allocator: std.mem.Allocator, mod_count: usize) !Scratch {
+        const forbidden = try allocator.alloc(?std.DynamicBitSet, mod_count);
+        errdefer allocator.free(forbidden);
+        for (forbidden) |*f| f.* = null;
+        const reachable = try allocator.alloc(?[]u32, mod_count);
+        errdefer allocator.free(reachable);
+        for (reachable) |*r| r.* = null;
+        return .{
+            .allocator = allocator,
+            .forbidden = forbidden,
+            .reachable = reachable,
+        };
+    }
+
+    pub fn deinit(self: *Scratch) void {
+        for (self.forbidden) |*f| if (f.*) |*bs| bs.deinit();
+        self.allocator.free(self.forbidden);
+        for (self.reachable) |r| if (r) |slice| self.allocator.free(slice);
+        self.allocator.free(self.reachable);
+    }
+
+    /// 모듈의 캐시를 다음 호출에서 재빌드하도록 해제. tree_shaker 가 AST mutation
+    /// 후 호출 — `minifyAndResyncModule` / `applyNodeBufferCapabilityFacts` 양쪽
+    /// 경로 공통 진입점인 `markAstMutatedAndResync` 한 곳에서.
+    pub fn invalidate(self: *Scratch, mod_idx: usize) void {
+        if (mod_idx >= self.forbidden.len) return;
+        if (self.forbidden[mod_idx]) |*bs| {
+            bs.deinit();
+            self.forbidden[mod_idx] = null;
+        }
+        if (self.reachable[mod_idx]) |slice| {
+            self.allocator.free(slice);
+            self.reachable[mod_idx] = null;
+        }
+    }
+};
+
 /// Linker가 증명한 primitive constants를 AST read-site에 반영한다.
 /// codegen-only 치환은 branch body refs를 줄이지 못하므로, minify/DCE 전 literal로
 /// materialize해야 dead branch와 그 안의 imports가 다음 pass에서 사라질 수 있다.
@@ -47,15 +100,50 @@ pub fn materialize(
     symbol_ids: []const ?u32,
     const_values: *const std.AutoHashMapUnmanaged(u32, ConstValue),
 ) bool {
+    return materializeWithScratch(allocator, ast, symbol_ids, const_values, null, 0);
+}
+
+/// `materialize` + outer driver 가 forbidden/reachable 캐시 재사용. `scratch == null`
+/// 이면 `materialize` 와 동일 (매 호출 빌드).
+pub fn materializeWithScratch(
+    allocator: std.mem.Allocator,
+    ast: *Ast,
+    symbol_ids: []const ?u32,
+    const_values: *const std.AutoHashMapUnmanaged(u32, ConstValue),
+    scratch: ?*Scratch,
+    mod_idx: usize,
+) bool {
     if (const_values.count() == 0) return false;
 
-    var forbidden = std.DynamicBitSet.initEmpty(allocator, ast.nodes.items.len) catch return false;
-    defer forbidden.deinit();
-    minify_mod.markForbiddenInlineSites(ast, &forbidden);
+    // forbidden 확보: 캐시 hit 면 재사용, miss 면 빌드 후 캐시 또는 단발성 사용.
+    var owned_forbidden: ?std.DynamicBitSet = null;
+    defer if (owned_forbidden) |*bs| bs.deinit();
+    const forbidden_ptr: *const std.DynamicBitSet = blk: {
+        if (scratch) |s| if (mod_idx < s.forbidden.len) {
+            if (s.forbidden[mod_idx]) |*cached| break :blk cached;
+            var bs = std.DynamicBitSet.initEmpty(allocator, ast.nodes.items.len) catch return false;
+            minify_mod.markForbiddenInlineSites(ast, &bs);
+            s.forbidden[mod_idx] = bs;
+            break :blk &s.forbidden[mod_idx].?;
+        };
+        owned_forbidden = std.DynamicBitSet.initEmpty(allocator, ast.nodes.items.len) catch return false;
+        minify_mod.markForbiddenInlineSites(ast, &owned_forbidden.?);
+        break :blk &owned_forbidden.?;
+    };
 
     // transformer 가 만든 orphan 노드까지 스캔하지 않도록 reachable 만 순회 (#1797 패턴).
-    const reachable = ast_walk.collectReachableNodeIndices(allocator, ast) catch return false;
-    defer allocator.free(reachable);
+    var owned_reachable: ?[]u32 = null;
+    defer if (owned_reachable) |slice| allocator.free(slice);
+    const reachable: []const u32 = blk: {
+        if (scratch) |s| if (mod_idx < s.reachable.len) {
+            if (s.reachable[mod_idx]) |cached| break :blk cached;
+            const built = ast_walk.collectReachableNodeIndices(allocator, ast) catch return false;
+            s.reachable[mod_idx] = built;
+            break :blk built;
+        };
+        owned_reachable = ast_walk.collectReachableNodeIndices(allocator, ast) catch return false;
+        break :blk owned_reachable.?;
+    };
 
     var changed = false;
     for (reachable) |ni| {
@@ -63,7 +151,7 @@ pub fn materialize(
         const node = ast.nodes.items[i];
         if (node.tag != .identifier_reference) continue;
         if (i >= symbol_ids.len) continue;
-        if (forbidden.isSet(i)) continue;
+        if (forbidden_ptr.isSet(i)) continue;
         const sym_id = symbol_ids[i] orelse continue;
         const cv = const_values.get(sym_id) orelse continue;
         const replacement = constValueNode(ast, cv) orelse continue;

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -111,6 +111,10 @@ pub const TreeShaker = struct {
     /// Linker finalize 이후 AST mutation + semantic resync가 발생했는지.
     /// true면 old symbol id 기준 rename/mangle metadata를 재계산해야 한다.
     ast_mutated_after_link: bool = false,
+    /// constant_facts.materialize 의 per-module forbidden/reachable 캐시. lazy-init —
+    /// numeric pre-shake / post-pass 가 같은 모듈을 forward+reverse × 최대 2 회 호출하면
+    /// 매번 bitset + reachable 빌드를 재사용. AST mutation 시 해당 모듈만 invalidate.
+    materialize_scratch: ?constant_facts.Scratch = null,
 
     const max_fixpoint_iterations: u32 = 100;
     const max_numeric_const_post_passes: u32 = 2;
@@ -168,6 +172,7 @@ pub const TreeShaker = struct {
             self.allocator.free(self.has_direct_used_export);
         }
         self.numeric_dfs_stack.deinit(self.allocator);
+        if (self.materialize_scratch) |*s| s.deinit();
     }
 
     /// 내부 단축 helper. `self.graph.getModule(ModuleIndex.fromUsize(idx))` 의 반복 방지.
@@ -364,6 +369,7 @@ pub const TreeShaker = struct {
             m.prebuilt_stmt_info = null;
         };
         self.ast_mutated_after_link = true;
+        if (self.materialize_scratch) |*s| s.invalidate(@intFromEnum(m.index));
     }
 
     /// pre-shake materialize 직후 후속 BFS 가 읽는 linker populate* 만 좁게 재실행.
@@ -404,7 +410,11 @@ pub const TreeShaker = struct {
             return false;
         }
 
-        const changed = constant_facts.materialize(self.allocator, ast, sem.symbol_ids, &const_values);
+        if (self.materialize_scratch == null) {
+            self.materialize_scratch = constant_facts.Scratch.init(self.allocator, self.graph.moduleCount()) catch null;
+        }
+        const scratch_ptr: ?*constant_facts.Scratch = if (self.materialize_scratch) |*s| s else null;
+        const changed = constant_facts.materializeWithScratch(self.allocator, ast, sem.symbol_ids, &const_values, scratch_ptr, module_index);
         const_values.deinit(self.allocator);
         if (!changed) return false;
 


### PR DESCRIPTION
#2504 sub-item #3.

## 요약
numeric post-pass 가 forward + reverse × 최대 2 회 호출 → 모듈당 inner `materialize` 가 4 번까지 도는데, 매 호출마다 `forbidden` (DynamicBitSet) 과 `reachable` (collectReachableNodeIndices) 를 새로 빌드했다. 두 값 모두 AST shape 만 의존하고 `materialize` 의 leaf identifier→literal in-place swap 은 `nodes.items.len` 도 안 바꾸므로 같은 모듈에 대해 안전하게 재사용 가능.

## 변경
- `constant_facts.Scratch`: per-module `?DynamicBitSet` + `?[]u32` 슬롯 보유. lazy-fill, `invalidate(mod_idx)` 로 단일 모듈 캐시 해제. 모든 모듈이 정확히 한 번씩 빌드되고, mutation 후 그 모듈만 다시 빌드.
- `materializeWithScratch(... , scratch, mod_idx)`: 캐시 hit 면 재사용, miss 면 빌드 후 저장. `scratch == null` 이면 기존 `materialize` 와 동일 동작 (단발성 — 기존 unit test 호환).
- `tree_shaker`: `materialize_scratch: ?Scratch` 필드, `materializeCrossModuleConstFactsForIndex` 가 첫 호출 시 lazy-init. `markAstMutatedAndResync` 가 mutation 발생한 모듈만 `invalidate(mod_idx)` — minify / applyNodeBufferCapabilityFacts 양쪽 경로 공통 진입점이라 추가 fix 없이 cover.

## 성능 효과 (numeric post-pass 가 발화하는 빌드)
- 모듈당 최대 3 번의 (DynamicBitSet alloc + AST 전체 forbidden scan + reachable BFS) 절약.
- AST mutate 된 모듈은 정확히 한 번만 invalidate → 다음 호출에서 재빌드, 그 외 모듈은 outer pass 동안 캐시 유지.

## 안전성 분석
- `materialize` 의 mutation 은 leaf `identifier_reference` → leaf literal in-place swap. nodes.items.len 불변, children 관계 불변 → forbidden/reachable 둘 다 stable until `minifyAndResyncModule` (fold/simplify/dead-store) 가 돌아 새 노드 추가 또는 토폴로지 변화.
- 그 시점은 정확히 `markAstMutatedAndResync` 진입점이라 invalidate 가 짝.
- 캐시 size = bitset(`nodes.items.len`) + reachable(`mod_count` × O(reachable_nodes)). post-pass 동안만 보유, `TreeShaker.deinit` 에서 free.

## 검증
- `zig build test --summary all` — 4624/4624 pass
- `bun test tests/integration/tests/const-value-inline.test.ts` — 31 pass
- `bun test tests/benchmark/{monorepo-fixture,stats}.test.ts` — 6 pass
- `zig fmt --check src/`
- pre-push hook 통과

## 다른 sub-item 처리
- **sub-item #1 (CSR reverse_deps)**: #2509 에서 `Module.importers` 직접 사용으로 해결.
- **sub-item #2 (StmtInfo iteration)**: outer scan 의 단일 tag 비교는 µs 단위라 ROI 없음 — 보류. 자세한 내용은 [issue 코멘트](https://github.com/ohah/zts/issues/2504#issuecomment-4366457012).

## Zig 메모
- `Scratch.invalidate` 는 `bs.deinit()` 호출 후 슬롯을 null 로 — 다음 lazy-build 가 새 bitset alloc.
- `materializeWithScratch` 의 `forbidden_ptr: *const std.DynamicBitSet` 는 캐시 hit/miss 양쪽에서 동일 인터페이스. owned 버전은 `defer` 로 정리, cached 는 scratch 가 소유.
- `materialize_scratch: ?Scratch = null` lazy-init — TreeShaker 가 numeric pass 를 안 거치는 빌드 (e.g. dev_mode) 는 한 번도 alloc 안 됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)