### PR TITLE
perf(semantic): split Symbol.const_value into 1B kind + side-table text (#2505 sub-item #1)

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1477,6 +1477,7 @@ pub const ModuleGraph = struct {
                     .symbol_ids = analyzer.symbol_ids.items,
                     .unresolved_references = analyzer.unresolved_references,
                     .references = analyzer.references.items,
+                    .numeric_const_texts = analyzer.numeric_const_texts,
                 };
                 if (analyzer.stmt_info_count > 0) {
                     module.prebuilt_stmt_info = stmt_info_mod.buildFromSemantic(
@@ -1737,6 +1738,7 @@ pub const ModuleGraph = struct {
                     .symbol_ids = analyzer.symbol_ids.items,
                     .unresolved_references = analyzer.unresolved_references,
                     .references = analyzer.references.items,
+                    .numeric_const_texts = analyzer.numeric_const_texts,
                 };
                 // TLA 감지: semantic analyzer가 스코프 체인을 추적하며 정확히 판별
                 module.uses_top_level_await = analyzer.has_top_level_await;
@@ -2146,6 +2148,7 @@ pub const ModuleGraph = struct {
                 .symbol_ids = analyzer.symbol_ids.items,
                 .unresolved_references = analyzer.unresolved_references,
                 .references = analyzer.references.items,
+                .numeric_const_texts = analyzer.numeric_const_texts,
             };
             suppressRuntimeHelperInternalUnresolved(module);
             module.uses_top_level_await = analyzer.has_top_level_await;

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -902,7 +902,15 @@ pub fn buildCrossModuleConstValues(
         const target_sym_idx = target_sem.scope_maps[0].get(local_name) orelse continue;
         if (target_sym_idx >= target_sem.symbols.items.len) continue;
         const target_sym = target_sem.symbols.items[target_sym_idx];
-        const cv = target_sym.const_value;
+        // Symbol 은 kind 만 들고 numeric text 는 사이드테이블에서 lookup (#2505).
+        const cv = blk: {
+            if (target_sym.const_kind == .none) break :blk @import("../../semantic/symbol.zig").ConstValue{};
+            const text = if (target_sym.const_kind == .number)
+                target_sem.numericConstText(@intCast(target_sym_idx))
+            else
+                "";
+            break :blk @import("../../semantic/symbol.zig").ConstValue{ .kind = target_sym.const_kind, .number_text = text };
+        };
         if (cv.kind == .none or !cv.isSafeToInline()) continue;
         // const promotion: `let` 선언에 const_value가 설정되어 있어도 재할당이 있다면 skip.
         // `const`는 재할당 불가라 write_count가 무조건 0. `let` + write_count>0는 inline 금지.

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -70,11 +70,20 @@ pub const ModuleSemanticData = struct {
     unresolved_references: std.StringHashMap(void),
     /// per-reference 배열. 현재 consumer: mangler liveness.
     references: []const Reference = &.{},
+    /// `Symbol.const_kind == .number` 인 심볼의 원본 numeric_literal 텍스트 사이드테이블 (#2505).
+    /// Symbol 에 16B slice 를 박지 않으려고 분리 — 보통 numeric const 는 전체 심볼의 극소수.
+    /// parse_arena 가 backing — value slice 는 source 또는 string_table 참조.
+    numeric_const_texts: std.AutoHashMapUnmanaged(u32, []const u8) = .{},
 
     /// 심볼 id에 해당하는 이름을 반환. `Symbol.nameText` 래퍼.
     pub fn symbolName(self: *const ModuleSemanticData, id: u32, source: []const u8) []const u8 {
         if (id >= self.symbols.items.len) return "";
         return self.symbols.items[id].nameText(source);
+    }
+
+    /// `sym_id` 가 numeric const 면 원본 텍스트를, 아니면 빈 슬라이스를 반환.
+    pub fn numericConstText(self: *const ModuleSemanticData, sym_id: u32) []const u8 {
+        return self.numeric_const_texts.get(sym_id) orelse "";
     }
 };
 

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -327,7 +327,7 @@ pub const TreeShaker = struct {
         for (sem.symbols.items) |sym| {
             if (!sym.isExported()) continue;
             if (sym.write_count != 0) continue;
-            if (sym.const_value.kind == .number) return true;
+            if (sym.const_kind == .number) return true;
         }
         return false;
     }

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -94,6 +94,11 @@ pub const SemanticAnalyzer = struct {
     /// key: 내보낸 이름 (default 포함), value: 첫 선언의 span.
     exported_names: std.StringHashMap(Span),
 
+    /// numeric const symbol 의 원본 텍스트 사이드테이블 (#2505).
+    /// Symbol 에 16B slice 를 박지 않으려고 분리. 보통 numeric const 는 전체 심볼의 극소수.
+    /// `setSymbolConstValue` / default-export 경로에서 kind == .number 일 때만 fill.
+    numeric_const_texts: std.AutoHashMapUnmanaged(u32, []const u8) = .{},
+
     /// class private name 스택 (중첩 class 지원, oxc 방식).
     /// 각 항목은 해당 class body에서 선언된 private name 집합.
     class_private_declared: std.ArrayList(std.StringHashMap(PrivateNameInfo)),
@@ -242,6 +247,7 @@ pub const SemanticAnalyzer = struct {
         self.errors.deinit(self.allocator);
         self.symbol_ids.deinit(self.allocator);
         self.references.deinit(self.allocator);
+        self.numeric_const_texts.deinit(self.allocator);
         for (self.class_private_declared.items) |*map| map.deinit();
         self.class_private_declared.deinit(self.allocator);
         for (self.class_private_refs.items) |*list| list.deinit(self.allocator);
@@ -1015,7 +1021,10 @@ pub const SemanticAnalyzer = struct {
 
     fn setSymbolConstValue(self: *SemanticAnalyzer, name_span: Span, cv: ConstValue) void {
         const sym_idx = self.findSymbolInCurrentScope(name_span) orelse return;
-        self.symbols.items[sym_idx].const_value = cv;
+        self.symbols.items[sym_idx].const_kind = cv.kind;
+        if (cv.kind == .number and cv.number_text.len > 0) {
+            self.numeric_const_texts.put(self.allocator, @intCast(sym_idx), cv.number_text) catch {};
+        }
     }
 
     /// 노드가 @__NO_SIDE_EFFECTS__ 함수/arrow인지 확인.
@@ -3061,11 +3070,14 @@ pub const SemanticAnalyzer = struct {
                 try self.scope_maps.items[module_scope.toIndex()].put("_default", sym_index);
                 // StmtInfo 사전 수집: facade 심볼을 declared 로 기록 (#1669: scope 무관).
                 self.recordDeclareRef(@intCast(sym_index), module_scope);
-                // export default <literal> → facade 심볼에 const_value 설정
+                // export default <literal> → facade 심볼에 const_kind + 사이드테이블 텍스트 설정
                 if (!inner_idx.isNone() and @intFromEnum(inner_idx) < self.ast.nodes.items.len) {
                     const cv = self.extractConstValue(self.ast.getNode(inner_idx));
                     if (cv.kind != .none) {
-                        self.symbols.items[sym_index].const_value = cv;
+                        self.symbols.items[sym_index].const_kind = cv.kind;
+                        if (cv.kind == .number and cv.number_text.len > 0) {
+                            self.numeric_const_texts.put(self.allocator, @intCast(sym_index), cv.number_text) catch {};
+                        }
                     }
                 }
             }

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -769,29 +769,30 @@ test "SemanticAnalyzer: numeric literal const_value stores raw literal text" {
     var saw_neg = false;
     var saw_big = false;
     var saw_expr = false;
-    for (ana.symbols.items) |sym| {
+    for (ana.symbols.items, 0..) |sym, sym_idx| {
         const name = sym.nameText(parser.ast.source);
+        const text = ana.numeric_const_texts.get(@intCast(sym_idx)) orelse "";
         if (std.mem.eql(u8, name, "dec")) {
             saw_dec = true;
-            try std.testing.expectEqual(symbol_mod.ConstValue.Kind.number, sym.const_value.kind);
-            try std.testing.expectEqualStrings("123", sym.const_value.number_text);
+            try std.testing.expectEqual(symbol_mod.ConstValue.Kind.number, sym.const_kind);
+            try std.testing.expectEqualStrings("123", text);
         } else if (std.mem.eql(u8, name, "exp")) {
             saw_exp = true;
-            try std.testing.expectEqual(symbol_mod.ConstValue.Kind.number, sym.const_value.kind);
-            try std.testing.expectEqualStrings("1e3", sym.const_value.number_text);
+            try std.testing.expectEqual(symbol_mod.ConstValue.Kind.number, sym.const_kind);
+            try std.testing.expectEqualStrings("1e3", text);
         } else if (std.mem.eql(u8, name, "hex")) {
             saw_hex = true;
-            try std.testing.expectEqual(symbol_mod.ConstValue.Kind.number, sym.const_value.kind);
-            try std.testing.expectEqualStrings("0x10", sym.const_value.number_text);
+            try std.testing.expectEqual(symbol_mod.ConstValue.Kind.number, sym.const_kind);
+            try std.testing.expectEqualStrings("0x10", text);
         } else if (std.mem.eql(u8, name, "neg")) {
             saw_neg = true;
-            try std.testing.expectEqual(symbol_mod.ConstValue.Kind.none, sym.const_value.kind);
+            try std.testing.expectEqual(symbol_mod.ConstValue.Kind.none, sym.const_kind);
         } else if (std.mem.eql(u8, name, "big")) {
             saw_big = true;
-            try std.testing.expectEqual(symbol_mod.ConstValue.Kind.none, sym.const_value.kind);
+            try std.testing.expectEqual(symbol_mod.ConstValue.Kind.none, sym.const_kind);
         } else if (std.mem.eql(u8, name, "expr")) {
             saw_expr = true;
-            try std.testing.expectEqual(symbol_mod.ConstValue.Kind.none, sym.const_value.kind);
+            try std.testing.expectEqual(symbol_mod.ConstValue.Kind.none, sym.const_kind);
         }
     }
     try std.testing.expect(saw_dec and saw_exp and saw_hex and saw_neg and saw_big and saw_expr);

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -214,8 +214,10 @@ pub const SyntheticKind = enum(u8) {
     esm_init,
 };
 
-/// 컴파일 타임 상수 값. 번들러에서 크로스-모듈 인라인에 사용.
-/// `const x = false` → ConstValue{ .kind = .false_ }
+/// 컴파일 타임 상수 값. 번들러 cross-module 인라인 맵 (`linker.buildCrossModuleConstValues`)
+/// 의 value 타입으로 사용된다. Symbol 에 직접 임베드하지 않는다 — Symbol 은 `const_kind`
+/// 만 들고 number_text 는 `ModuleSemanticData.numeric_const_texts` 사이드테이블에 (#2505).
+/// 모든 Symbol 이 16B slice 를 들지 않게 함이 목적.
 pub const ConstValue = struct {
     kind: Kind = .none,
     /// `.number`일 때 원본 numeric_literal 텍스트.
@@ -272,9 +274,11 @@ pub const Symbol = struct {
     /// 크로스-모듈 인라인 대상. oxc/rolldown과 동일한 접근.
     write_count: u32 = 0,
 
-    /// 컴파일 타임 상수 값 (번들러 크로스-모듈 인라인용).
-    /// const/let 선언의 초기화 값이 리터럴이면 설정 (단 let은 `write_count == 0`일 때만 인라인).
-    const_value: ConstValue = .{},
+    /// 컴파일 타임 상수 종류 (번들러 cross-module 인라인용).
+    /// const/let 선언의 초기화 값이 리터럴이면 set. `.number` 일 때만 추가로
+    /// `ModuleSemanticData.numeric_const_texts` 에 텍스트가 같이 등록된다 — 16B slice 를
+    /// 모든 Symbol 에 박지 않으려는 분리 (#2505).
+    const_kind: ConstValue.Kind = .none,
 
     /// Bundler가 추가한 합성 심볼 종류. null = AST 선언에서 온 정규 심볼.
     /// #1328 Phase 4e-2: `extendSymbol`로 추가된 심볼만 non-null.


### PR DESCRIPTION
#2505 sub-item #1.

## 요약
Symbol 이 `ConstValue` (24B) 를 임베드해 모든 심볼당 16B `number_text` slice 가 따라붙던 것을, `kind` (1B) 만 임베드하고 numeric_literal 텍스트는 `ModuleSemanticData` 의 사이드테이블로 분리. 보통 numeric const 는 전체 심볼의 극소수.

## 크기 효과
- **Symbol**: ~104B → ~88B (16B 절약). 100K 심볼 번들에서 ~1.6MB. 캐시 라인에 더 많이 들어감.
- **사이드테이블**: 실제 numeric const 수에 비례 (HashMap 32B/entry).
- **net**: 10% 정도 numeric 비율의 일반 코드베이스에서 1MB 이상 절약. 100% numeric (artificial) 에서는 사이드테이블 overhead 가 더 커지지만, 그런 코드 자체가 비현실적.

## 변경
- `Symbol.const_value: ConstValue = .{}` → `Symbol.const_kind: ConstValue.Kind = .none`. `ConstValue` 타입 자체는 cross-module 인라인 맵 (`linker.buildCrossModuleConstValues` 의 return value) 의 value 타입으로 그대로 유지.
- `ModuleSemanticData.numeric_const_texts: AutoHashMapUnmanaged(u32, []const u8)` 추가 + `numericConstText(sym_id) []const u8` 헬퍼 (없으면 빈 슬라이스).
- `SemanticAnalyzer` 가 `numeric_const_texts` 필드 보유, `setSymbolConstValue` 와 default-export 경로에서 `kind == .number` 일 때만 fill. parse_arena 로 backing — `analyzer.deinit` 은 arena 위에선 no-op.
- `linker.buildCrossModuleConstValues`: `target_sym.const_kind` + `target_sem.numericConstText` 으로 cross-module ConstValue 를 빌드. 다운스트림 (codegen, constant_facts) 는 ConstValue 모양 변화 없어 영향 없음.
- 모든 `module.semantic = .{...}` 생성지 (graph.zig × 3) 에 `numeric_const_texts` 전달.
- `analyzer_test.zig`: 인덱스 순회로 `ana.numeric_const_texts.get(sym_idx)` lookup 변경.

## 성능 영향
- **일반 빌드**: net 변화 거의 없음 — Symbol 크기 축소로 약간 빠를 수도.
- **pipeline profile bench** (`Profile: pipeline stage timing`) 는 `export const v0=0; ...` × N 의 100% numeric synthetic 코드라 worst case — 1000-line 케이스에서 semantic +344µs (per-put ~34ns × 1000). 실제 사용 패턴 (const 비율 낮음) 에서는 미미.
- **monorepo-fixture bench** (5051/10101 모듈): 영향 없음.

## 안전성
- `analyzer.numeric_const_texts` 가 `analyzer.allocator` (parse_arena) 로 backing — analyzer.deinit 의 `numeric_const_texts.deinit(allocator)` 은 arena 위에선 no-op (`exported_names` 등 기존 필드와 같은 패턴).
- `ModuleSemanticData` 가 analyzer 의 map 을 struct copy 로 가져감 → backing 공유 (parse_arena 에 살아있음).
- write 경로 (`setSymbolConstValue`, default-export) 양쪽 모두 `const_kind` + 사이드테이블 fill 짝으로 처리. `kind == .number and number_text.len > 0` 가 사이드테이블 invariant.

## 검증
- `zig build test --summary all` — 4624/4624 pass
- `bun test tests/integration/tests/const-value-inline.test.ts` — 31 pass
- `bun test tests/benchmark/monorepo-fixture.test.ts` — 2 pass
- `zig fmt --check src/`
- pre-push hook 통과

## #2505 sub-item #2 (DynamicBitSet 변환) 은?
별도 PR 로 분리 진행. tree_shaker.nodeContainsNumericConstRef 의 hot 경로에서 `const_values.get(sid)` HashMap lookup 을 prebuilt DynamicBitSet bit test 로 대체. 이번 PR 의 ConstValue 레이아웃 변경과 독립적.

🤖 Generated with [Claude Code](https://claude.com/claude-code)