### PR TITLE
refactor(transformer): drop define_spans cache (intern map 흡수)

### DIFF
--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -534,10 +534,6 @@ pub const Transformer = struct {
     /// 판단하기 위한 lightweight binding facts.
     binding_lite: ?*const BindingLite = null,
 
-    /// define value의 string_table Span 캐시. options.define과 동일 인덱스.
-    /// transform() 시작 시 한 번 빌드하여, tryDefineReplace에서 addString 중복 호출을 방지.
-    define_spans: []Span = &.{},
-
     /// ES 다운레벨링 임시 변수 카운터.
     /// `foo() ?? bar` → `(_a = foo()) != null ? _a : bar`에서 _a, _b, _c, ... 생성에 사용.
     temp_var_counter: u32 = 0,
@@ -817,7 +813,6 @@ pub const Transformer = struct {
         self.scratch.deinit(self.allocator);
         self.pending_nodes.deinit(self.allocator);
         self.symbol_ids.deinit(self.allocator);
-        if (self.define_spans.len > 0) self.allocator.free(self.define_spans);
         self.plugins.refresh.registrations.deinit(self.allocator);
         for (self.plugins.refresh.signatures.items) |s| self.allocator.free(s.signature);
         self.plugins.refresh.signatures.deinit(self.allocator);
@@ -877,14 +872,6 @@ pub const Transformer = struct {
             return cached;
         }
         self.ast.assertInvariants();
-
-        // define value를 미리 string_table에 저장하여 tryDefineReplace에서 중복 addString 방지
-        if (self.options.define.len > 0) {
-            self.define_spans = self.allocator.alloc(Span, self.options.define.len) catch return Error.OutOfMemory;
-            for (self.options.define, 0..) |entry, i| {
-                self.define_spans[i] = self.ast.addString(entry.value) catch return Error.OutOfMemory;
-            }
-        }
 
         // worklet __pluginVersion 문자열 리터럴 span 사전 계산 (매 worklet당 할당 방지)
         if (self.options.worklet_plugin_version) |v| {
@@ -2630,9 +2617,10 @@ pub const Transformer = struct {
         else
             raw_text;
 
-        for (self.options.define, 0..) |entry, i| {
+        for (self.options.define) |entry| {
             if (!matchDefineKey(text, entry.key)) continue;
-            const value_span = self.define_spans[i];
+            // intern map 이 같은 entry.value 의 두 번째 호출부터 hit → 캐시 효과 흡수.
+            const value_span = self.ast.addString(entry.value) catch return Error.OutOfMemory;
             // 값이 따옴표로 시작하면 string_literal, 아니면 identifier_reference.
             // "production" → string_literal, false/true/숫자 → identifier_reference.
             const is_string = entry.value.len >= 2 and (entry.value[0] == '"' or entry.value[0] == '\'');


### PR DESCRIPTION
## 요약
조사 보고 C-2. \`define_spans\` (define value 의 string_table Span 캐시) 제거 — #2496 의 intern map 으로 흡수.

C 시리즈 마지막 PR. 누적 LOC -50.

## 변경
- transformer.zig 의 \`define_spans: []Span\` 필드 삭제
- alloc/free 삭제
- transform() 시작 시점 build 루프 삭제
- \`tryDefineReplace\` 의 \`self.define_spans[i]\` → 직접 \`addString(entry.value)\`

LOC: -13 +2.

## 측정 (define-heavy fixture, 401 lines, 4 define entries, transform phase)
50 runs after 10 warmup:

| | mean | median | p95 |
|---|---|---|---|
| BEFORE | 0.090ms | 0.090ms | 0.100ms |
| AFTER  | 0.096ms | 0.100ms | 0.100ms |

차이: median +0.010ms (+11%), 절대치는 profile 출력 round 단위 (측정 floor 근처).
실 워크로드 1000 모듈 환산 ~10ms (전체 transpile 의 <0.1%).

## 다른 번들러와의 정합성
- esbuild/swc/oxc: value 의 *parsed expression* AST 캐시 (필수, ZTS 도 \`options.define\` 으로 유지)
- ZTS \`define_spans\`: value 의 *string_table Span* 만 추가 캐시한 마이크로 최적화
- 제거해도 다른 번들러와 다른 패턴 안 됨 (각자 다른 차원의 캐시)

## 테스트
- \`zig fmt --check\`
- \`zig build test --summary all\` — 4624/4624 통과