### PR TITLE
perf(tree-shaker): prebuilt numeric-symbol bitset for nodeContainsNumericConstRef (#2505 sub-item #2)

### DIFF
--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -240,16 +240,20 @@ pub const TreeShaker = struct {
         return false;
     }
 
+    /// DFS hot path 의 `const_values.get(sid)` HashMap lookup 을 피하려고 caller 가 미리
+    /// 빌드한 numeric-symbol bitset 을 쓴다 (#2505 sub-item #2). bitset 은
+    /// `moduleHasNumericExportConstChain` 가 한 번만 build → 같은 모듈 내 여러 init 을
+    /// 도는 동안 재사용.
     const NumericConstRefCtx = struct {
         symbol_ids: []const ?u32,
-        const_values: *const std.AutoHashMapUnmanaged(u32, ConstValue),
+        numeric_bitset: *const std.DynamicBitSet,
     };
 
     fn visitNumericConstRef(ctx: NumericConstRefCtx, _: *const Ast, raw: u32, node: Node) bool {
         if (node.tag != .identifier_reference or raw >= ctx.symbol_ids.len) return false;
         const sid = ctx.symbol_ids[raw] orelse return false;
-        const cv = ctx.const_values.get(sid) orelse return false;
-        return cv.kind == .number;
+        if (sid >= ctx.numeric_bitset.capacity()) return false;
+        return ctx.numeric_bitset.isSet(sid);
     }
 
     fn nodeContainsNumericConstRef(
@@ -257,11 +261,11 @@ pub const TreeShaker = struct {
         ast: *const Ast,
         symbol_ids: []const ?u32,
         root: NodeIndex,
-        const_values: *const std.AutoHashMapUnmanaged(u32, ConstValue),
+        numeric_bitset: *const std.DynamicBitSet,
     ) bool {
         return self.anyReachableNode(ast, root, NumericConstRefCtx{
             .symbol_ids = symbol_ids,
-            .const_values = const_values,
+            .numeric_bitset = numeric_bitset,
         }, visitNumericConstRef);
     }
 
@@ -299,7 +303,7 @@ pub const TreeShaker = struct {
     }
 
     fn visitChainExportInit(self: *TreeShaker, ctx: NumericConstRefCtx, ast: *const Ast, init_idx: NodeIndex) bool {
-        return self.nodeContainsNumericConstRef(ast, ctx.symbol_ids, init_idx, ctx.const_values);
+        return self.nodeContainsNumericConstRef(ast, ctx.symbol_ids, init_idx, ctx.numeric_bitset);
     }
 
     fn moduleHasNumericExportConstChain(
@@ -309,9 +313,21 @@ pub const TreeShaker = struct {
         const_values: *const std.AutoHashMapUnmanaged(u32, ConstValue),
     ) bool {
         if (!constValuesContainNumber(const_values)) return false;
+        // numeric symbol_id 만 미리 bitset 으로 — DFS 안에서 매 identifier_reference 마다
+        // HashMap.get 하지 않도록 (#2505 sub-item #2). 모듈 안 export const 가 여러 개라도
+        // 같은 bitset 을 재사용. alloc 실패면 보수적으로 false (이번 모듈 chain 후보 없다고 처리).
+        var numeric_bitset = std.DynamicBitSet.initEmpty(self.allocator, sem.symbols.items.len) catch return false;
+        defer numeric_bitset.deinit();
+        var it = const_values.iterator();
+        while (it.next()) |entry| {
+            if (entry.value_ptr.kind != .number) continue;
+            const sid = entry.key_ptr.*;
+            if (sid >= sem.symbols.items.len) continue;
+            numeric_bitset.set(sid);
+        }
         return self.anyExportedConstInit(ast, sem, NumericConstRefCtx{
             .symbol_ids = sem.symbol_ids,
-            .const_values = const_values,
+            .numeric_bitset = &numeric_bitset,
         }, visitChainExportInit);
     }
 


### PR DESCRIPTION
#2505 sub-item #2 — sub-item #1 (Symbol shrink) 은 #2514 에서 별도 진행 중.

## 요약
`nodeContainsNumericConstRef` 의 DFS 가 매 `identifier_reference` 마다 `const_values.get(sid)` HashMap lookup 을 했다. `propagateNumericExportConstFacts` 큐 × `moduleHasNumericExportConstChain` 안에서 hot — BFS 스텝마다 모듈의 모든 export const init 을 다시 도므로 같은 cross-module map 에 대한 lookup 이 반복됐다.

## 변경
- `NumericConstRefCtx` 가 `*const std.AutoHashMapUnmanaged(u32, ConstValue)` 대신 `*const std.DynamicBitSet` 보유.
- `moduleHasNumericExportConstChain` 가 진입 시 `sem.symbols.items.len` 사이즈 bitset alloc + `kind == .number` entry 를 한 번 set. 같은 모듈의 여러 export init 이 같은 bitset 을 재사용.
- DFS 핫 루프 `visitNumericConstRef` 는 `ctx.numeric_bitset.isSet(sid)` — bit test 한 번.
- 다른 caller (`moduleHasNumericExportSeed` 의 `nodeIsNumericLiteralFoldSeed` 경로) 는 ctx 가 다른 타입 (`FoldSeedCtx`) 이라 영향 없음.

## 성능 분석
BFS 한 스텝에서 export init N 개, 각 init 의 식별자 K 개:
- **이전**: N × K 회 `HashMap.get(u32 → ConstValue)` — hash + slot scan + value decode.
- **이후**: 1 회 alloc (`(symbols.len + 63) / 64` u64 + 헤더) + numeric_count 회 set + N × K 회 bit test.
- K ≥ 2 면 bitset alloc 비용 흡수. 일반 const init (e.g. `base + 1`) 은 K ≥ 1 이고 BFS 가 같은 모듈을 여러 번 재방문하면 alloc 도 재시작되는데 모든 호출이 그 모듈의 numeric_count 만큼만 set.

## 안전성
- alloc 실패시 보수적 `false` (이번 모듈을 chain 후보 없음으로 처리) — analyze 가 죽지 않음.
- bitset capacity 는 `sem.symbols.items.len` 으로 sized — 그 모듈의 symbol 수에 비례. cross-module ConstValue 는 importer 측 symbol_id 로 keyed 라 동일 범위.
- 외부 entry 의 `sid >= sem.symbols.items.len` 은 set 단계에서 skip + DFS 단계에서도 capacity check.

## 검증
- `zig build test --summary all` — 4624/4624 pass
- `bun test tests/integration/tests/const-value-inline.test.ts` — 31 pass
- `bun test tests/benchmark/monorepo-fixture.test.ts` — 2 pass
- `zig fmt --check src/`
- pre-push hook 통과

## #2505 처리 현황
- sub-item #1 (Symbol shrink): [#2514](https://github.com/ohah/zts/pull/2514) — 진행 중.
- sub-item #2 (DynamicBitSet): 이번 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)