### PR TITLE
feat(core): core-js 런타임 폴리필 지원

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@emotion/css": "^11.13.5",
         "@emotion/react": "^11.14.0",
         "@tailwindcss/postcss": "^4.2.2",
+        "@tanstack/react-query": "^5",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "hermes-engine-cli": "^0.12.0",
@@ -89,7 +90,10 @@
         "@types/node": "^25.5.2",
       },
       "optionalDependencies": {
+        "@babel/parser": "^7.29.0",
         "browserslist": "^4.24.0",
+        "core-js": "^3.49.0",
+        "core-js-compat": "^3.49.0",
         "lightningcss": "^1.28.0",
         "postcss": "^8.5.8",
         "postcss-load-config": "^6.0.1",
@@ -1002,6 +1006,8 @@
 
     "@tanstack/query-core": ["@tanstack/query-core@5.96.1", "", {}, "sha512-u1yBgtavSy+N8wgtW3PiER6UpxcplMje65yXnnVgiHTqiMwLlxiw4WvQDrXyn+UD6lnn8kHaxmerJUzQcV/MMg=="],
 
+    "@tanstack/react-query": ["@tanstack/react-query@5.100.9", "", { "dependencies": { "@tanstack/query-core": "5.100.9" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A=="],
+
     "@tokenizer/inflate": ["@tokenizer/inflate@0.2.7", "", { "dependencies": { "debug": "^4.4.0", "fflate": "^0.8.2", "token-types": "^6.0.0" } }, "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg=="],
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
@@ -1532,7 +1538,11 @@
 
     "copy-anything": ["copy-anything@4.0.5", "", { "dependencies": { "is-what": "^5.2.0" } }, "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA=="],
 
+    "core-js": ["core-js@3.49.0", "", {}, "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="],
+
     "core-js-bundle": ["core-js-bundle@3.49.0", "", {}, "sha512-WXc7oOsePN3aKFOJVG5zQdi+h/Jm2W0WIPYvRc4IG3vkNcbC2w6LlSzTmnhOl6N1xmOJEzCSNieX3mwF+3zBGw=="],
+
+    "core-js-compat": ["core-js-compat@3.49.0", "", { "dependencies": { "browserslist": "^4.28.1" } }, "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA=="],
 
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
 
@@ -3421,6 +3431,8 @@
     "@tailwindcss/vite/@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.4", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.4", "@tailwindcss/oxide-darwin-arm64": "4.2.4", "@tailwindcss/oxide-darwin-x64": "4.2.4", "@tailwindcss/oxide-freebsd-x64": "4.2.4", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4", "@tailwindcss/oxide-linux-arm64-musl": "4.2.4", "@tailwindcss/oxide-linux-x64-gnu": "4.2.4", "@tailwindcss/oxide-linux-x64-musl": "4.2.4", "@tailwindcss/oxide-wasm32-wasi": "4.2.4", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4", "@tailwindcss/oxide-win32-x64-msvc": "4.2.4" } }, "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q=="],
 
     "@tailwindcss/vite/tailwindcss": ["tailwindcss@4.2.4", "", {}, "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA=="],
+
+    "@tanstack/react-query/@tanstack/query-core": ["@tanstack/query-core@5.100.9", "", {}, "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ=="],
 
     "@types/body-parser/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -30,7 +30,7 @@ CLI > config > `--tsconfig-raw` > tsconfig file > defaults. 같은 옵션이 여
 | `format`                                     |           `--format=esm`           |               ✅               |            ❌             | esm/cjs/iife/umd/amd                                               |
 | `platform`                                   |         `--platform=node`          |               ✅               |            ❌             | node/browser/react-native                                          |
 | `target`                                     |         `--target=es2020`          |               ✅               |         `target`          | tsconfig fallback                                                  |
-| `runtimePolyfills`                           |        `--runtime-polyfills`       |               ✅               |            ❌             | core-js 런타임 API 폴리필. 타겟은 `runtimePolyfills.targets` 사용  |
+| `runtimePolyfills`                           |        `--runtime-polyfills`       |               ✅               |            ❌             | core-js 런타임 API 폴리필. 타겟은 Rspack/SWC식 Browserslist query  |
 | `coreJs`                                     |          `--core-js=3.49`          |               ✅               |            ❌             | core-js-compat 계산에 사용할 core-js 버전                          |
 | `jsx`                                        |         `--jsx=automatic`          |               ✅               |           `jsx`           | preserve/transform/automatic                                       |
 | `jsxFactory` / `jsxFragment`                 |                flag                |               ✅               |      `jsxFactory` 등      | tsconfig fallback                                                  |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -30,7 +30,7 @@ CLI > config > `--tsconfig-raw` > tsconfig file > defaults. 같은 옵션이 여
 | `format`                                     |           `--format=esm`           |               ✅               |            ❌             | esm/cjs/iife/umd/amd                                               |
 | `platform`                                   |         `--platform=node`          |               ✅               |            ❌             | node/browser/react-native                                          |
 | `target`                                     |         `--target=es2020`          |               ✅               |         `target`          | tsconfig fallback                                                  |
-| `runtimePolyfills` / `runtimeTargets`        |   `--runtime-polyfills` / target   |               ✅               |            ❌             | core-js 런타임 API 폴리필. 기본 off, auto/usage/entry 명시 필요    |
+| `runtimePolyfills`                           |        `--runtime-polyfills`       |               ✅               |            ❌             | core-js 런타임 API 폴리필. 타겟은 `runtimePolyfills.targets` 사용  |
 | `coreJs`                                     |          `--core-js=3.49`          |               ✅               |            ❌             | core-js-compat 계산에 사용할 core-js 버전                          |
 | `jsx`                                        |         `--jsx=automatic`          |               ✅               |           `jsx`           | preserve/transform/automatic                                       |
 | `jsxFactory` / `jsxFragment`                 |                flag                |               ✅               |      `jsxFactory` 등      | tsconfig fallback                                                  |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -30,6 +30,8 @@ CLI > config > `--tsconfig-raw` > tsconfig file > defaults. 같은 옵션이 여
 | `format`                                     |           `--format=esm`           |               ✅               |            ❌             | esm/cjs/iife/umd/amd                                               |
 | `platform`                                   |         `--platform=node`          |               ✅               |            ❌             | node/browser/react-native                                          |
 | `target`                                     |         `--target=es2020`          |               ✅               |         `target`          | tsconfig fallback                                                  |
+| `runtimePolyfills` / `runtimeTargets`        |   `--runtime-polyfills` / target   |               ✅               |            ❌             | core-js 런타임 API 폴리필. 기본 off, auto/usage/entry 명시 필요    |
+| `coreJs`                                     |          `--core-js=3.49`          |               ✅               |            ❌             | core-js-compat 계산에 사용할 core-js 버전                          |
 | `jsx`                                        |         `--jsx=automatic`          |               ✅               |           `jsx`           | preserve/transform/automatic                                       |
 | `jsxFactory` / `jsxFragment`                 |                flag                |               ✅               |      `jsxFactory` 등      | tsconfig fallback                                                  |
 | `external`                                   |          `--external:lib`          |               ✅               |            ❌             | 배열 — CLI 비어있으면 config                                       |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -179,6 +179,18 @@ esbuild 스타일: `onResolve`, `onLoad`, `onTransform`, `onRenderChunk`, `onGen
 - ES2023: hashbang(`#!`) strip
 - ES2025: `using` / `await using` 다운레벨
 
+### 런타임 API 폴리필
+
+- 기본값은 `runtimePolyfills: "off"` — 자동 core-js 주입은 명시해야 켜진다.
+- CLI: `--runtime-polyfills=auto|usage|entry|off`, `--runtime-target=<query>` 반복, `--core-js=3.49`.
+- JS API/config: `runtimePolyfills`, `runtimeTargets`, `coreJs`.
+- `auto`/`usage`는 엔트리와 로컬 의존성에서 `replaceAll`, `Map`, `Set`, `Promise`,
+  `Array.prototype.at`, `Object.hasOwn`, `structuredClone` 사용을 스캔해 타겟 미지원 core-js 모듈만 주입한다.
+- `entry`는 타겟 기준 필요한 `core-js/modules/es.*` / `web.*`를 엔트리 prelude에 포괄 주입한다.
+- 타겟 예: `ios12`, `ios_saf 12`, `iOS >= 12`, `chrome >= 85`, `android >= 5`,
+  `samsung >= 14`, `hermes0.7`, `react-native 0.70`, `node18`. `iPhone 8`, `Galaxy S10`
+  같은 피지컬 디바이스 이름은 지원하지 않는다.
+
 ### CSS 번들링
 
 - `import './x.css'` → 별도 CSS 파일 자동 생성

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -183,7 +183,8 @@ esbuild 스타일: `onResolve`, `onLoad`, `onTransform`, `onRenderChunk`, `onGen
 
 - 기본값은 `runtimePolyfills: "off"` — 자동 core-js 주입은 명시해야 켜진다.
 - CLI: `--runtime-polyfills=auto|usage|entry|off`, `--runtime-target=<query>` 반복, `--core-js=3.49`.
-- JS API/config: `runtimePolyfills`, `runtimeTargets`, `coreJs`.
+- JS API/config: `runtimePolyfills`, `coreJs`. 타겟은 `runtimePolyfills: { targets: "ios12" }`처럼
+  nested `targets` 필드로 지정한다.
 - `auto`/`usage`는 엔트리와 로컬 의존성에서 `replaceAll`, `Map`, `Set`, `Promise`,
   `Array.prototype.at`, `Object.hasOwn`, `structuredClone` 사용을 스캔해 타겟 미지원 core-js 모듈만 주입한다.
 - `entry`는 타겟 기준 필요한 `core-js/modules/es.*` / `web.*`를 엔트리 prelude에 포괄 주입한다.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -183,14 +183,14 @@ esbuild 스타일: `onResolve`, `onLoad`, `onTransform`, `onRenderChunk`, `onGen
 
 - 기본값은 `runtimePolyfills: "off"` — 자동 core-js 주입은 명시해야 켜진다.
 - CLI: `--runtime-polyfills=auto|usage|entry|off`, `--runtime-target=<query>` 반복, `--core-js=3.49`.
-- JS API/config: `runtimePolyfills`, `coreJs`. 타겟은 `runtimePolyfills: { targets: "ios12" }`처럼
-  nested `targets` 필드로 지정한다.
+- JS API/config: `runtimePolyfills`, `coreJs`. 타겟은 Rspack/SWC `env.targets`와 같은 Browserslist query 배열로
+  `runtimePolyfills: { targets: ["chrome >= 87", "safari >= 14"] }`처럼 지정한다.
 - `auto`/`usage`는 엔트리와 로컬 의존성에서 `replaceAll`, `Map`, `Set`, `Promise`,
   `Array.prototype.at`, `Object.hasOwn`, `structuredClone` 사용을 스캔해 타겟 미지원 core-js 모듈만 주입한다.
 - `entry`는 타겟 기준 필요한 `core-js/modules/es.*` / `web.*`를 엔트리 prelude에 포괄 주입한다.
-- 타겟 예: `ios12`, `ios_saf 12`, `iOS >= 12`, `chrome >= 85`, `android >= 5`,
-  `samsung >= 14`, `hermes0.7`, `react-native 0.70`, `node18`. `iPhone 8`, `Galaxy S10`
-  같은 피지컬 디바이스 이름은 지원하지 않는다.
+- 타겟 예: `ios_saf 12`, `iOS >= 12`, `chrome >= 85`, `android >= 5`,
+  `samsung >= 14`, `node 18`. `ios12`, `node18`, `iPhone 8`, `Galaxy S10`
+  같은 compact shorthand와 피지컬 디바이스 이름은 지원하지 않는다.
 
 ### CSS 번들링
 

--- a/documents/src/content/docs/en/reference/cli.md
+++ b/documents/src/content/docs/en/reference/cli.md
@@ -72,6 +72,9 @@ CSS before PostCSS when the optional `sass` dependency is installed.
 | `--platform=browser\|node\|neutral\|react-native` | Target platform                                                       |
 | `--rn-platform=ios\|android`                      | RN sub-platform (`.ios.*`/`.android.*` extensions)                    |
 | `--target=<spec>`                                 | ES target: `es2015`–`esnext` or engine versions (`chrome80,safari14`) |
+| `--runtime-polyfills=auto\|usage\|entry\|off`     | Inject core-js runtime API polyfills                                  |
+| `--runtime-target=<query>`                        | core-js polyfill target. Repeatable (`ios12`, `hermes0.7`, `node18`)  |
+| `--core-js=<version>`                             | core-js version used by core-js-compat                                |
 | `--global-name=<name>`                            | IIFE export name                                                      |
 
 ## Minify

--- a/documents/src/content/docs/en/reference/cli.md
+++ b/documents/src/content/docs/en/reference/cli.md
@@ -73,7 +73,7 @@ CSS before PostCSS when the optional `sass` dependency is installed.
 | `--rn-platform=ios\|android`                      | RN sub-platform (`.ios.*`/`.android.*` extensions)                    |
 | `--target=<spec>`                                 | ES target: `es2015`–`esnext` or engine versions (`chrome80,safari14`) |
 | `--runtime-polyfills=auto\|usage\|entry\|off`     | Inject core-js runtime API polyfills                                  |
-| `--runtime-target=<query>`                        | core-js polyfill target. Repeatable (`ios12`, `hermes0.7`, `node18`)  |
+| `--runtime-target=<query>`                        | core-js polyfill Browserslist target. Repeatable (`chrome >= 87`)     |
 | `--core-js=<version>`                             | core-js version used by core-js-compat                                |
 | `--global-name=<name>`                            | IIFE export name                                                      |
 

--- a/documents/src/content/docs/en/reference/options.md
+++ b/documents/src/content/docs/en/reference/options.md
@@ -27,8 +27,7 @@ Use `$schema` to get autocomplete in VSCode / IntelliJ / any JSON-schema-aware e
 |---|---|---|---|
 | `target` | `es5`, `es2015`–`es2025`, `esnext` | `esnext` | ES downlevel target. When set, features introduced after the target version are auto-lowered |
 | `unsupported` | `integer` (u32) | `0` | Direct `UnsupportedFeatures` bitmask. Used to inject browserslist-derived feature sets — takes precedence over `target` |
-| `runtimePolyfills` | `"off" \| "auto" \| "usage" \| "entry" \| object` | `"off"` | Inject core-js runtime API polyfills. `auto`/`usage` inject used APIs only; `entry` injects target-required modules broadly |
-| `runtimeTargets` | `string \| string[] \| object` | `defaults` | core-js-compat runtime targets (`ios12`, `chrome >= 85`, `hermes0.7`, `node18`, etc.). Physical device names are unsupported |
+| `runtimePolyfills` | `"off" \| "auto" \| "usage" \| "entry" \| object` | `"off"` | Inject core-js runtime API polyfills. Set targets through the object form's `targets` field |
 | `coreJs` | `string` | installed version | core-js version used by core-js-compat |
 
 ### Parsing

--- a/documents/src/content/docs/en/reference/options.md
+++ b/documents/src/content/docs/en/reference/options.md
@@ -27,6 +27,9 @@ Use `$schema` to get autocomplete in VSCode / IntelliJ / any JSON-schema-aware e
 |---|---|---|---|
 | `target` | `es5`, `es2015`–`es2025`, `esnext` | `esnext` | ES downlevel target. When set, features introduced after the target version are auto-lowered |
 | `unsupported` | `integer` (u32) | `0` | Direct `UnsupportedFeatures` bitmask. Used to inject browserslist-derived feature sets — takes precedence over `target` |
+| `runtimePolyfills` | `"off" \| "auto" \| "usage" \| "entry" \| object` | `"off"` | Inject core-js runtime API polyfills. `auto`/`usage` inject used APIs only; `entry` injects target-required modules broadly |
+| `runtimeTargets` | `string \| string[] \| object` | `defaults` | core-js-compat runtime targets (`ios12`, `chrome >= 85`, `hermes0.7`, `node18`, etc.). Physical device names are unsupported |
+| `coreJs` | `string` | installed version | core-js version used by core-js-compat |
 
 ### Parsing
 

--- a/documents/src/content/docs/en/reference/options.md
+++ b/documents/src/content/docs/en/reference/options.md
@@ -27,7 +27,7 @@ Use `$schema` to get autocomplete in VSCode / IntelliJ / any JSON-schema-aware e
 |---|---|---|---|
 | `target` | `es5`, `es2015`–`es2025`, `esnext` | `esnext` | ES downlevel target. When set, features introduced after the target version are auto-lowered |
 | `unsupported` | `integer` (u32) | `0` | Direct `UnsupportedFeatures` bitmask. Used to inject browserslist-derived feature sets — takes precedence over `target` |
-| `runtimePolyfills` | `"off" \| "auto" \| "usage" \| "entry" \| object` | `"off"` | Inject core-js runtime API polyfills. Set targets through the object form's `targets` field |
+| `runtimePolyfills` | `"off" \| "auto" \| "usage" \| "entry" \| object` | `"off"` | Inject core-js runtime API polyfills. Set targets as Rspack/SWC `env.targets`-style Browserslist query arrays |
 | `coreJs` | `string` | installed version | core-js version used by core-js-compat |
 
 ### Parsing

--- a/documents/src/content/docs/reference/cli.md
+++ b/documents/src/content/docs/reference/cli.md
@@ -72,7 +72,7 @@ scoped class map으로 변환하며 default export와 가능한 named export를 
 | `--rn-platform=ios\|android`                      | RN 서브 플랫폼 (`.ios.*`/`.android.*` 확장자)                      |
 | `--target=<spec>`                                 | ES 타겟: `es2015`~`esnext` 또는 엔진 버전 (`chrome80,safari14` 등) |
 | `--runtime-polyfills=auto\|usage\|entry\|off`     | core-js 런타임 API 폴리필 주입                                     |
-| `--runtime-target=<query>`                        | core-js 폴리필 타겟. 반복 가능 (`ios12`, `hermes0.7`, `node18`)    |
+| `--runtime-target=<query>`                        | core-js 폴리필 Browserslist 타겟. 반복 가능 (`chrome >= 87`)       |
 | `--core-js=<version>`                             | core-js-compat 계산에 사용할 core-js 버전                          |
 | `--global-name=<name>`                            | IIFE export 변수명                                                 |
 

--- a/documents/src/content/docs/reference/cli.md
+++ b/documents/src/content/docs/reference/cli.md
@@ -71,6 +71,9 @@ scoped class map으로 변환하며 default export와 가능한 named export를 
 | `--platform=browser\|node\|neutral\|react-native` | 타겟 플랫폼                                                        |
 | `--rn-platform=ios\|android`                      | RN 서브 플랫폼 (`.ios.*`/`.android.*` 확장자)                      |
 | `--target=<spec>`                                 | ES 타겟: `es2015`~`esnext` 또는 엔진 버전 (`chrome80,safari14` 등) |
+| `--runtime-polyfills=auto\|usage\|entry\|off`     | core-js 런타임 API 폴리필 주입                                     |
+| `--runtime-target=<query>`                        | core-js 폴리필 타겟. 반복 가능 (`ios12`, `hermes0.7`, `node18`)    |
+| `--core-js=<version>`                             | core-js-compat 계산에 사용할 core-js 버전                          |
 | `--global-name=<name>`                            | IIFE export 변수명                                                 |
 
 ## 미니파이

--- a/documents/src/content/docs/reference/options.md
+++ b/documents/src/content/docs/reference/options.md
@@ -27,7 +27,7 @@ ZTS의 트랜스파일 옵션은 **Zig `TranspileOptionsDto` struct에서 compti
 |---|---|---|---|
 | `target` | `es5`, `es2015`–`es2025`, `esnext` | `esnext` | ES 다운레벨 타겟. 설정 시 해당 버전 이후 도입된 기능이 자동 downlowering됨 |
 | `unsupported` | `integer` (u32) | `0` | `UnsupportedFeatures` 비트마스크 직접 지정. browserslist 해석 결과를 주입할 때 사용 — `target`보다 우선 |
-| `runtimePolyfills` | `"off" \| "auto" \| "usage" \| "entry" \| object` | `"off"` | core-js 런타임 API 폴리필 주입. 타겟은 object form의 `targets` 필드로 지정 |
+| `runtimePolyfills` | `"off" \| "auto" \| "usage" \| "entry" \| object` | `"off"` | core-js 런타임 API 폴리필 주입. 타겟은 Rspack/SWC `env.targets`와 같은 Browserslist query 배열로 지정 |
 | `coreJs` | `string` | installed version | core-js-compat 계산에 사용할 core-js 버전 |
 
 ### 파싱

--- a/documents/src/content/docs/reference/options.md
+++ b/documents/src/content/docs/reference/options.md
@@ -27,6 +27,9 @@ ZTS의 트랜스파일 옵션은 **Zig `TranspileOptionsDto` struct에서 compti
 |---|---|---|---|
 | `target` | `es5`, `es2015`–`es2025`, `esnext` | `esnext` | ES 다운레벨 타겟. 설정 시 해당 버전 이후 도입된 기능이 자동 downlowering됨 |
 | `unsupported` | `integer` (u32) | `0` | `UnsupportedFeatures` 비트마스크 직접 지정. browserslist 해석 결과를 주입할 때 사용 — `target`보다 우선 |
+| `runtimePolyfills` | `"off" \| "auto" \| "usage" \| "entry" \| object` | `"off"` | core-js 런타임 API 폴리필 주입. `auto`/`usage`는 사용 API만, `entry`는 타겟 기준 포괄 주입 |
+| `runtimeTargets` | `string \| string[] \| object` | `defaults` | core-js-compat 런타임 타겟 (`ios12`, `chrome >= 85`, `hermes0.7`, `node18` 등). 디바이스 이름은 미지원 |
+| `coreJs` | `string` | installed version | core-js-compat 계산에 사용할 core-js 버전 |
 
 ### 파싱
 

--- a/documents/src/content/docs/reference/options.md
+++ b/documents/src/content/docs/reference/options.md
@@ -27,8 +27,7 @@ ZTS의 트랜스파일 옵션은 **Zig `TranspileOptionsDto` struct에서 compti
 |---|---|---|---|
 | `target` | `es5`, `es2015`–`es2025`, `esnext` | `esnext` | ES 다운레벨 타겟. 설정 시 해당 버전 이후 도입된 기능이 자동 downlowering됨 |
 | `unsupported` | `integer` (u32) | `0` | `UnsupportedFeatures` 비트마스크 직접 지정. browserslist 해석 결과를 주입할 때 사용 — `target`보다 우선 |
-| `runtimePolyfills` | `"off" \| "auto" \| "usage" \| "entry" \| object` | `"off"` | core-js 런타임 API 폴리필 주입. `auto`/`usage`는 사용 API만, `entry`는 타겟 기준 포괄 주입 |
-| `runtimeTargets` | `string \| string[] \| object` | `defaults` | core-js-compat 런타임 타겟 (`ios12`, `chrome >= 85`, `hermes0.7`, `node18` 등). 디바이스 이름은 미지원 |
+| `runtimePolyfills` | `"off" \| "auto" \| "usage" \| "entry" \| object` | `"off"` | core-js 런타임 API 폴리필 주입. 타겟은 object form의 `targets` 필드로 지정 |
 | `coreJs` | `string` | installed version | core-js-compat 계산에 사용할 core-js 버전 |
 
 ### 파싱

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "test": "bun run test:integration",
     "test:integration": "bun test --cwd tests/integration",
+    "test:runtime-polyfills:coverage": "bun run scripts/check-runtime-polyfill-coverage.mjs",
     "test:e2e": "bun run --cwd tests/e2e test",
     "test:all": "bun run test:integration && bun run test:e2e",
     "build:zts": "zig build -Doptimize=ReleaseFast",
@@ -27,6 +28,7 @@
     "@emotion/css": "^11.13.5",
     "@emotion/react": "^11.14.0",
     "@tailwindcss/postcss": "^4.2.2",
+    "@tanstack/react-query": "^5",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "hermes-engine-cli": "^0.12.0",

--- a/packages/core/bin/cli-flags.mjs
+++ b/packages/core/bin/cli-flags.mjs
@@ -114,6 +114,8 @@ export const FLAG_REGISTRY = [
   { kind: "string", flag: "--profile-format", target: "profileFormat", forms: ["equal"] },
   { kind: "string", flag: "--stop-after", target: "stopAfter", forms: ["equal"] },
   { kind: "string", flag: "--tokenize-format", target: "tokenizeFormat", forms: ["equal"] },
+  { kind: "string", flag: "--runtime-polyfills", target: "runtimePolyfills", forms: ["equal"] },
+  { kind: "string", flag: "--core-js", target: "coreJs", forms: ["equal"] },
 
   // ─── kind=string — `--key value` 또는 `--key=value` 둘 다 ───
   { kind: "string", flag: "--target", target: "target" },
@@ -151,6 +153,7 @@ export const FLAG_REGISTRY = [
   { kind: "array", flag: "--external", target: "external" },
   { kind: "array", flag: "--drop", target: "drop", forms: ["equal"] },
   { kind: "array", flag: "--plugin", target: "pluginPaths", forms: ["pair"] },
+  { kind: "array", flag: "--runtime-target", target: "runtimeTargets" },
 
   // ─── kind=csv — `,` 분리 → array ───
   { kind: "csv", flag: "--drop-labels", target: "dropLabels", forms: ["equal"] },

--- a/packages/core/bin/cli-flags.mjs
+++ b/packages/core/bin/cli-flags.mjs
@@ -153,7 +153,7 @@ export const FLAG_REGISTRY = [
   { kind: "array", flag: "--external", target: "external" },
   { kind: "array", flag: "--drop", target: "drop", forms: ["equal"] },
   { kind: "array", flag: "--plugin", target: "pluginPaths", forms: ["pair"] },
-  { kind: "array", flag: "--runtime-target", target: "runtimeTargets" },
+  { kind: "array", flag: "--runtime-target", target: "runtimeTargetQueries" },
 
   // ─── kind=csv — `,` 분리 → array ───
   { kind: "csv", flag: "--drop-labels", target: "dropLabels", forms: ["equal"] },

--- a/packages/core/bin/zts-cli-schema-sync.test.ts
+++ b/packages/core/bin/zts-cli-schema-sync.test.ts
@@ -334,6 +334,9 @@ describe("CLI flag ↔ BuildOptions / TranspileOptions schema sync", () => {
     // packages — CLI 는 esbuild 호환 `--packages=external` enum 형태, BuildOptions 는
     // `packagesExternal: boolean`.
     "--packages=",
+    // runtimeTargets — CLI 는 단수 반복형, BuildOptions 는 배열/객체/문자열 통합 field.
+    "--runtime-target",
+    "--runtime-target=",
     // banner/footer — `--banner=`/`--footer=` 가 정식 (BuildOptions 와 1:1).
     // `--banner:js=`/`--footer:js=` 는 esbuild 호환 silent alias — 동일 키로 매핑.
     "--banner:js=",

--- a/packages/core/bin/zts-cli-schema-sync.test.ts
+++ b/packages/core/bin/zts-cli-schema-sync.test.ts
@@ -334,7 +334,7 @@ describe("CLI flag ↔ BuildOptions / TranspileOptions schema sync", () => {
     // packages — CLI 는 esbuild 호환 `--packages=external` enum 형태, BuildOptions 는
     // `packagesExternal: boolean`.
     "--packages=",
-    // runtimeTargets — CLI 는 단수 반복형, BuildOptions 는 배열/객체/문자열 통합 field.
+    // --runtime-target — CLI 편의 flag. BuildOptions 에서는 runtimePolyfills.targets 로 병합된다.
     "--runtime-target",
     "--runtime-target=",
     // banner/footer — `--banner=`/`--footer=` 가 정식 (BuildOptions 와 1:1).

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -159,7 +159,7 @@ function usageLines(command) {
     "  --profile-level=<level>    Profile level: summary, detailed, per-module, per-pass",
     "  --profile-format=<format>  Profile output: table, tree, json, csv",
     "  --runtime-polyfills=<mode> Inject core-js runtime polyfills: auto, usage, entry, off",
-    "  --runtime-target=<query>   Runtime polyfill target (repeatable: ios12, chrome>=85, node18)",
+    "  --runtime-target=<query>   Runtime polyfill Browserslist target (repeatable: 'chrome >= 87', 'safari >= 14')",
     "  --core-js=<version>        core-js version used for runtime polyfill compatibility",
     "  --stop-after=<phase>       Stop transpile after a given phase (debug)",
     "  --tokenize[=false]         Print scanner tokens instead of generated code",
@@ -1870,8 +1870,7 @@ function mergeCliRuntimeTargets(runtimePolyfills, runtimeTargetQueries) {
     return runtimePolyfills;
   }
   if (runtimePolyfills === undefined || runtimePolyfills === "off") return runtimePolyfills;
-  const targets =
-    runtimeTargetQueries.length === 1 ? runtimeTargetQueries[0] : runtimeTargetQueries;
+  const targets = runtimeTargetQueries;
   if (typeof runtimePolyfills === "string") return { mode: runtimePolyfills, targets };
   if (runtimePolyfills && typeof runtimePolyfills === "object") {
     return { ...runtimePolyfills, targets };

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -158,6 +158,9 @@ function usageLines(command) {
     "  --profile=<csv>            Collect profile categories (all, parse, transform, ...)",
     "  --profile-level=<level>    Profile level: summary, detailed, per-module, per-pass",
     "  --profile-format=<format>  Profile output: table, tree, json, csv",
+    "  --runtime-polyfills=<mode> Inject core-js runtime polyfills: auto, usage, entry, off",
+    "  --runtime-target=<query>   Runtime polyfill target (repeatable: ios12, chrome>=85, node18)",
+    "  --core-js=<version>        core-js version used for runtime polyfill compatibility",
     "  --stop-after=<phase>       Stop transpile after a given phase (debug)",
     "  --tokenize[=false]         Print scanner tokens instead of generated code",
     "  --tokenize-format=<format> Token output: text or json",
@@ -297,6 +300,9 @@ function parseArgs(argv) {
     profile: [],
     profileLevel: undefined,
     profileFormat: undefined,
+    runtimePolyfills: undefined,
+    coreJs: undefined,
+    runtimeTargets: [],
     ignoreAnnotations: false,
     jsxSideEffects: false,
     stopAfter: undefined,
@@ -1780,6 +1786,8 @@ function mergeConfigIntoOpts(opts, config) {
     "stopAfter",
     "profileLevel",
     "profileFormat",
+    "runtimePolyfills",
+    "coreJs",
     "tokenizeFormat",
   ];
   for (const key of SCALAR_KEYS) {
@@ -1840,6 +1848,7 @@ function mergeConfigIntoOpts(opts, config) {
     "conditions",
     "nodePaths",
     "profile",
+    "runtimeTargets",
   ];
   for (const key of ARRAY_KEYS) {
     if (opts[key].length === 0 && Array.isArray(config[key]) && config[key].length > 0) {
@@ -1934,6 +1943,9 @@ async function runBundle(opts, config) {
     profile: opts.profile.length > 0 ? opts.profile : undefined,
     profileLevel: opts.profileLevel,
     profileFormat: opts.profileFormat,
+    runtimePolyfills: opts.runtimePolyfills,
+    coreJs: opts.coreJs,
+    runtimeTargets: opts.runtimeTargets.length > 0 ? opts.runtimeTargets : undefined,
     ignoreAnnotations: opts.ignoreAnnotations,
     jsxSideEffects: opts.jsxSideEffects,
     // NAPI 가 tsconfig paths / baseUrl 을 alias 로 변환해 resolver 에 주입하도록 전달.

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -302,7 +302,7 @@ function parseArgs(argv) {
     profileFormat: undefined,
     runtimePolyfills: undefined,
     coreJs: undefined,
-    runtimeTargets: [],
+    runtimeTargetQueries: [],
     ignoreAnnotations: false,
     jsxSideEffects: false,
     stopAfter: undefined,
@@ -1848,7 +1848,6 @@ function mergeConfigIntoOpts(opts, config) {
     "conditions",
     "nodePaths",
     "profile",
-    "runtimeTargets",
   ];
   for (const key of ARRAY_KEYS) {
     if (opts[key].length === 0 && Array.isArray(config[key]) && config[key].length > 0) {
@@ -1864,6 +1863,20 @@ function mergeConfigIntoOpts(opts, config) {
   mergeServerConfigIntoOpts(opts, config);
 
   return opts;
+}
+
+function mergeCliRuntimeTargets(runtimePolyfills, runtimeTargetQueries) {
+  if (!Array.isArray(runtimeTargetQueries) || runtimeTargetQueries.length === 0) {
+    return runtimePolyfills;
+  }
+  if (runtimePolyfills === undefined || runtimePolyfills === "off") return runtimePolyfills;
+  const targets =
+    runtimeTargetQueries.length === 1 ? runtimeTargetQueries[0] : runtimeTargetQueries;
+  if (typeof runtimePolyfills === "string") return { mode: runtimePolyfills, targets };
+  if (runtimePolyfills && typeof runtimePolyfills === "object") {
+    return { ...runtimePolyfills, targets };
+  }
+  return runtimePolyfills;
 }
 
 async function runBundle(opts, config) {
@@ -1943,9 +1956,8 @@ async function runBundle(opts, config) {
     profile: opts.profile.length > 0 ? opts.profile : undefined,
     profileLevel: opts.profileLevel,
     profileFormat: opts.profileFormat,
-    runtimePolyfills: opts.runtimePolyfills,
+    runtimePolyfills: mergeCliRuntimeTargets(opts.runtimePolyfills, opts.runtimeTargetQueries),
     coreJs: opts.coreJs,
-    runtimeTargets: opts.runtimeTargets.length > 0 ? opts.runtimeTargets : undefined,
     ignoreAnnotations: opts.ignoreAnnotations,
     jsxSideEffects: opts.jsxSideEffects,
     // NAPI 가 tsconfig paths / baseUrl 을 alias 로 변환해 resolver 에 주입하도록 전달.

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -526,6 +526,28 @@ describe("CLI: bundle", () => {
     }
   });
 
+  test("번들 + --runtime-target compact shorthand는 거부", () => {
+    const polyfillDir = mkdtempSync(join(tmpdir(), "zts-cli-runtime-shorthand-"));
+    try {
+      writeFileSync(
+        join(polyfillDir, "entry.ts"),
+        `globalThis.__VALUE__ = "a".replaceAll("a", "b");`,
+      );
+
+      const { stderr, exitCode } = runCli([
+        "--bundle",
+        join(polyfillDir, "entry.ts"),
+        "--runtime-polyfills=auto",
+        "--runtime-target=ios12",
+      ]);
+
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain("Compact runtime target shorthands");
+    } finally {
+      rmSync(polyfillDir, { recursive: true, force: true });
+    }
+  });
+
   test("번들 + --drop-labels=DEV,TEST 라벨 블록 제거", () => {
     const labelDir = mkdtempSync(join(tmpdir(), "zts-cli-drop-labels-"));
     try {
@@ -2436,6 +2458,24 @@ describe("CLI: zts.config 자동 탐색 + BuildOptions 머지", () => {
     expect(exitCode).toBe(0);
     // minify 시 식별자 축약으로 someLongName 같은 긴 이름이 사라짐.
     expect(stdout).not.toContain("someLongName");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("zts.config.json 의 runtimePolyfills 가 적용됨", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-config-runtime-polyfills-"));
+    writeFileSync(join(dir, "entry.ts"), `globalThis.__VALUE__ = "a".replaceAll("a", "b");`);
+    writeFileSync(
+      join(dir, "zts.config.json"),
+      JSON.stringify({
+        entryPoints: ["./entry.ts"],
+        format: "iife",
+        runtimePolyfills: { mode: "auto", targets: ["ios_saf 12"] },
+      }),
+    );
+    const { stdout, stderr, exitCode } = runCli(["--bundle"], { cwd: dir });
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("es.string.replace-all");
     rmSync(dir, { recursive: true, force: true });
   });
 

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -479,6 +479,53 @@ describe("CLI: bundle", () => {
     expect(minified.stdout.length).toBeLessThan(normal.stdout.length);
   });
 
+  test("번들 + --runtime-polyfills=auto + --runtime-target", () => {
+    const polyfillDir = mkdtempSync(join(tmpdir(), "zts-cli-runtime-polyfills-"));
+    try {
+      writeFileSync(
+        join(polyfillDir, "entry.ts"),
+        `globalThis.__VALUE__ = "a".replaceAll("a", "b");`,
+      );
+
+      const { stdout, stderr, exitCode } = runCli([
+        "--bundle",
+        join(polyfillDir, "entry.ts"),
+        "--runtime-polyfills=auto",
+        "--runtime-target=ios12",
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(stderr).toBe("");
+      expect(stdout).toContain("es.string.replace-all");
+    } finally {
+      rmSync(polyfillDir, { recursive: true, force: true });
+    }
+  });
+
+  test("번들 + --runtime-target device name은 actionable error", () => {
+    const polyfillDir = mkdtempSync(join(tmpdir(), "zts-cli-runtime-device-"));
+    try {
+      writeFileSync(
+        join(polyfillDir, "entry.ts"),
+        `globalThis.__VALUE__ = "a".replaceAll("a", "b");`,
+      );
+
+      const { stderr, exitCode } = runCli([
+        "--bundle",
+        join(polyfillDir, "entry.ts"),
+        "--runtime-polyfills=auto",
+        "--runtime-target",
+        "iPhone 8",
+      ]);
+
+      expect(exitCode).not.toBe(0);
+      expect(stderr).toContain("Physical device names are not supported");
+      expect(stderr).toContain("ios12");
+    } finally {
+      rmSync(polyfillDir, { recursive: true, force: true });
+    }
+  });
+
   test("번들 + --drop-labels=DEV,TEST 라벨 블록 제거", () => {
     const labelDir = mkdtempSync(join(tmpdir(), "zts-cli-drop-labels-"));
     try {

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -491,7 +491,7 @@ describe("CLI: bundle", () => {
         "--bundle",
         join(polyfillDir, "entry.ts"),
         "--runtime-polyfills=auto",
-        "--runtime-target=ios12",
+        "--runtime-target=ios_saf 12",
       ]);
 
       expect(exitCode).toBe(0);
@@ -520,7 +520,7 @@ describe("CLI: bundle", () => {
 
       expect(exitCode).not.toBe(0);
       expect(stderr).toContain("Physical device names are not supported");
-      expect(stderr).toContain("ios12");
+      expect(stderr).toContain("ios_saf 12");
     } finally {
       rmSync(polyfillDir, { recursive: true, force: true });
     }

--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -6696,7 +6696,7 @@ describe("@zts/core browserslist", () => {
       const r = buildSync({
         entryPoints: [join(dir, "entry.ts")],
         format: "iife",
-        runtimePolyfills: { mode: "auto", targets: "ios12" },
+        runtimePolyfills: { mode: "auto", targets: ["ios_saf 12"] },
       });
       const code = r.outputFiles[0].text;
       expect(code).toContain("es.string.replace-all");
@@ -6722,14 +6722,14 @@ describe("@zts/core browserslist", () => {
       const oldTarget = buildSync({
         entryPoints: [join(dir, "entry.ts")],
         format: "iife",
-        runtimePolyfills: { mode: "auto", targets: "ios12" },
+        runtimePolyfills: { mode: "auto", targets: ["ios_saf 12"] },
       }).outputFiles[0].text;
       expect(oldTarget).toContain("es.string.replace-all");
 
       const modernTarget = buildSync({
         entryPoints: [join(dir, "entry.ts")],
         format: "iife",
-        runtimePolyfills: { mode: "auto", targets: "node18" },
+        runtimePolyfills: { mode: "auto", targets: ["node 18"] },
       }).outputFiles[0].text;
       expect(modernTarget).not.toContain("es.string.replace-all");
     } finally {

--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -6696,8 +6696,7 @@ describe("@zts/core browserslist", () => {
       const r = buildSync({
         entryPoints: [join(dir, "entry.ts")],
         format: "iife",
-        runtimePolyfills: "auto",
-        runtimeTargets: "ios12",
+        runtimePolyfills: { mode: "auto", targets: "ios12" },
       });
       const code = r.outputFiles[0].text;
       expect(code).toContain("es.string.replace-all");
@@ -6723,16 +6722,14 @@ describe("@zts/core browserslist", () => {
       const oldTarget = buildSync({
         entryPoints: [join(dir, "entry.ts")],
         format: "iife",
-        runtimePolyfills: "auto",
-        runtimeTargets: "ios12",
+        runtimePolyfills: { mode: "auto", targets: "ios12" },
       }).outputFiles[0].text;
       expect(oldTarget).toContain("es.string.replace-all");
 
       const modernTarget = buildSync({
         entryPoints: [join(dir, "entry.ts")],
         format: "iife",
-        runtimePolyfills: "auto",
-        runtimeTargets: "node18",
+        runtimePolyfills: { mode: "auto", targets: "node18" },
       }).outputFiles[0].text;
       expect(modernTarget).not.toContain("es.string.replace-all");
     } finally {

--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -6689,6 +6689,57 @@ describe("@zts/core browserslist", () => {
     rmSync(dir, { recursive: true });
   });
 
+  test("runtimePolyfills auto: used replaceAll is injected before entry execution", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfills-auto-"));
+    try {
+      writeFileSync(join(dir, "entry.ts"), `globalThis.__RESULT__ = "a-a".replaceAll("a", "b");`);
+      const r = buildSync({
+        entryPoints: [join(dir, "entry.ts")],
+        format: "iife",
+        runtimePolyfills: "auto",
+        runtimeTargets: "ios12",
+      });
+      const code = r.outputFiles[0].text;
+      expect(code).toContain("es.string.replace-all");
+
+      const vm = require("node:vm") as typeof import("node:vm");
+      const sandbox: { __RESULT__?: string } = {};
+      vm.runInNewContext(`String.prototype.replaceAll = undefined;\n${code}`, sandbox);
+      expect(sandbox.__RESULT__).toBe("b-b");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("runtimePolyfills auto scans local dependencies and respects modern targets", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfills-dep-"));
+    try {
+      writeFileSync(
+        join(dir, "entry.ts"),
+        `import { value } from "./dep"; globalThis.__VALUE__ = value;`,
+      );
+      writeFileSync(join(dir, "dep.ts"), `export const value = "a".replaceAll("a", "b");`);
+
+      const oldTarget = buildSync({
+        entryPoints: [join(dir, "entry.ts")],
+        format: "iife",
+        runtimePolyfills: "auto",
+        runtimeTargets: "ios12",
+      }).outputFiles[0].text;
+      expect(oldTarget).toContain("es.string.replace-all");
+
+      const modernTarget = buildSync({
+        entryPoints: [join(dir, "entry.ts")],
+        format: "iife",
+        runtimePolyfills: "auto",
+        runtimeTargets: "node18",
+      }).outputFiles[0].text;
+      expect(modernTarget).not.toContain("es.string.replace-all");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("browserslist: build API — target + browserslist 동시 지정 시 browserslist 우선", () => {
     const dir = mkdtempSync(join(tmpdir(), "zts-bs-both-"));
     writeFileSync(

--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -6737,6 +6737,21 @@ describe("@zts/core browserslist", () => {
     }
   });
 
+  test("runtimePolyfills rejects compact target shorthand through build API", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfills-shorthand-"));
+    try {
+      writeFileSync(join(dir, "entry.ts"), `"a".replaceAll("a", "b");`);
+      expect(() =>
+        buildSync({
+          entryPoints: [join(dir, "entry.ts")],
+          runtimePolyfills: { mode: "auto", targets: ["ios12"] },
+        }),
+      ).toThrow("Compact runtime target shorthands");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("browserslist: build API — target + browserslist 동시 지정 시 browserslist 우선", () => {
     const dir = mkdtempSync(join(tmpdir(), "zts-bs-both-"));
     writeFileSync(

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -799,15 +799,11 @@ interface BuildOptionsCommon {
    * - `"off"` (default): 자동 런타임 폴리필 없음.
    * - `"auto"` / `"usage"`: 엔트리와 로컬 의존성의 실제 사용 API만 스캔해 타겟 미지원 모듈 주입.
    * - `"entry"`: 타겟 기준 필요한 core-js ES/Web 모듈을 엔트리 prelude에 포괄 주입.
+   * - 타겟 지정은 객체 form의 `targets` 필드를 사용한다.
    */
   runtimePolyfills?: RuntimePolyfillsOption;
   /** core-js-compat 계산에 사용할 core-js 버전 (예: `"3.49"`). */
   coreJs?: string;
-  /**
-   * core-js-compat 런타임 엔진 타겟.
-   * 예: `"ios12"`, `"chrome >= 85"`, `"hermes0.7"`, `"react-native 0.70"`, `{ node: "18" }`.
-   */
-  runtimeTargets?: RuntimeTarget | RuntimeTarget[] | RuntimeTargetObject;
   /** 엔트리 모듈 직전에 실행할 모듈 경로 */
   runBeforeMain?: string[];
   /** 번들 그래프 밖의 디렉토리를 감시 루트에 추가 (Metro watchFolders 호환).
@@ -1531,7 +1527,6 @@ function prepareNapiOptions(options: BuildOptions): {
     platform: options.platform,
     target: options.target,
     browserslist: options.browserslist,
-    runtimeTargets: options.runtimeTargets,
     runtimePolyfills: options.runtimePolyfills,
     coreJs: options.coreJs,
     runBeforeMain: options.runBeforeMain,

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -32,12 +32,10 @@ import {
   isEsTarget,
   type RuntimePolyfillOptions,
   type RuntimePolyfillsOption,
-  type RuntimeTarget,
-  type RuntimeTargetObject,
 } from "./src/runtime-polyfills.ts";
 
 export { isPlainObject, validateTsConfigRaw };
-export type { RuntimePolyfillOptions, RuntimePolyfillsOption, RuntimeTarget, RuntimeTargetObject };
+export type { RuntimePolyfillOptions, RuntimePolyfillsOption };
 
 // ─── NAPI Module ───
 
@@ -498,7 +496,7 @@ export interface DevServerOptions {
   open?: boolean;
 }
 
-type BuildTarget = import("../shared/index").Target | RuntimeTarget;
+type BuildTarget = import("../shared/index").Target | (string & {});
 
 /**
  * Common build options shared by all platforms.
@@ -799,10 +797,10 @@ interface BuildOptionsCommon {
    * - `"off"` (default): 자동 런타임 폴리필 없음.
    * - `"auto"` / `"usage"`: 엔트리와 로컬 의존성의 실제 사용 API만 스캔해 타겟 미지원 모듈 주입.
    * - `"entry"`: 타겟 기준 필요한 core-js ES/Web 모듈을 엔트리 prelude에 포괄 주입.
-   * - 타겟 지정은 객체 form의 `targets` 필드를 사용한다.
+   * - 타겟 지정은 Rspack/SWC `env.targets`와 같은 Browserslist query 배열을 사용한다.
    */
   runtimePolyfills?: RuntimePolyfillsOption;
-  /** core-js-compat 계산에 사용할 core-js 버전 (예: `"3.49"`). */
+  /** core-js-compat 계산에 사용할 core-js 버전 (예: `"3.49"`). `runtimePolyfills.coreJs`와 동일한 역할. */
   coreJs?: string;
   /** 엔트리 모듈 직전에 실행할 모듈 경로 */
   runBeforeMain?: string[];
@@ -855,12 +853,12 @@ export type BuildOptions =
   | (BuildOptionsCommon & {
       /** React Native (Hermes) 프리셋. target은 Hermes 매트릭스로 강제됨. */
       platform: Extract<import("../shared/index").Platform, "react-native">;
-      target?: RuntimeTarget;
+      target?: BuildTarget;
       browserslist?: never;
     })
   | (BuildOptionsCommon & {
       platform?: Exclude<import("../shared/index").Platform, "react-native">;
-      /** ES 다운레벨 타겟 또는 runtime polyfill engine target. */
+      /** ES 다운레벨 타겟. Rspack-style node/hermes target strings are accepted by the JS wrapper. */
       target?: BuildTarget;
       /** browserslist 쿼리 (string 또는 string[]). 지정 시 target보다 우선. */
       browserslist?: string | string[];

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -27,8 +27,17 @@ import {
   isPlainObject,
   validateTsConfigRaw,
 } from "../shared/index";
+import {
+  applyRuntimePolyfillsToNapiOptions,
+  isEsTarget,
+  type RuntimePolyfillOptions,
+  type RuntimePolyfillsOption,
+  type RuntimeTarget,
+  type RuntimeTargetObject,
+} from "./src/runtime-polyfills.ts";
 
 export { isPlainObject, validateTsConfigRaw };
+export type { RuntimePolyfillOptions, RuntimePolyfillsOption, RuntimeTarget, RuntimeTargetObject };
 
 // ─── NAPI Module ───
 
@@ -489,6 +498,8 @@ export interface DevServerOptions {
   open?: boolean;
 }
 
+type BuildTarget = import("../shared/index").Target | RuntimeTarget;
+
 /**
  * Common build options shared by all platforms.
  * `platform` + `target` 조합은 `BuildOptions` 에서 discriminated union으로 제한됨.
@@ -782,6 +793,21 @@ interface BuildOptionsCommon {
   globalIdentifiers?: string[];
   /** 번들 시작 시 즉시 실행 폴리필 경로 */
   polyfills?: string[];
+  /**
+   * core-js 기반 런타임 API 폴리필 자동 주입.
+   *
+   * - `"off"` (default): 자동 런타임 폴리필 없음.
+   * - `"auto"` / `"usage"`: 엔트리와 로컬 의존성의 실제 사용 API만 스캔해 타겟 미지원 모듈 주입.
+   * - `"entry"`: 타겟 기준 필요한 core-js ES/Web 모듈을 엔트리 prelude에 포괄 주입.
+   */
+  runtimePolyfills?: RuntimePolyfillsOption;
+  /** core-js-compat 계산에 사용할 core-js 버전 (예: `"3.49"`). */
+  coreJs?: string;
+  /**
+   * core-js-compat 런타임 엔진 타겟.
+   * 예: `"ios12"`, `"chrome >= 85"`, `"hermes0.7"`, `"react-native 0.70"`, `{ node: "18" }`.
+   */
+  runtimeTargets?: RuntimeTarget | RuntimeTarget[] | RuntimeTargetObject;
   /** 엔트리 모듈 직전에 실행할 모듈 경로 */
   runBeforeMain?: string[];
   /** 번들 그래프 밖의 디렉토리를 감시 루트에 추가 (Metro watchFolders 호환).
@@ -833,13 +859,13 @@ export type BuildOptions =
   | (BuildOptionsCommon & {
       /** React Native (Hermes) 프리셋. target은 Hermes 매트릭스로 강제됨. */
       platform: Extract<import("../shared/index").Platform, "react-native">;
-      target?: never;
+      target?: RuntimeTarget;
       browserslist?: never;
     })
   | (BuildOptionsCommon & {
       platform?: Exclude<import("../shared/index").Platform, "react-native">;
-      /** ES 다운레벨 타겟 ("es5" ~ "esnext") */
-      target?: import("../shared/index").Target;
+      /** ES 다운레벨 타겟 또는 runtime polyfill engine target. */
+      target?: BuildTarget;
       /** browserslist 쿼리 (string 또는 string[]). 지정 시 target보다 우선. */
       browserslist?: string | string[];
     });
@@ -1419,7 +1445,10 @@ function withDefaultAppBuildDefines(options: AppBuildOptions): Record<string, st
   return define;
 }
 
-function prepareNapiOptions(options: BuildOptions): Record<string, unknown> {
+function prepareNapiOptions(options: BuildOptions): {
+  napiOptions: Record<string, unknown>;
+  cleanup: () => void;
+} {
   const napiOptions: Record<string, unknown> = { ...options };
   const define = withDefaultBuildDefines(options);
   if (define) napiOptions.define = define;
@@ -1448,6 +1477,9 @@ function prepareNapiOptions(options: BuildOptions): Record<string, unknown> {
   if (options.browserslist) {
     napiOptions.unsupported = resolveUnsupported({ browserslist: options.browserslist });
     delete napiOptions.browserslist;
+  }
+  if (options.target && !isEsTarget(options.target)) {
+    delete napiOptions.target;
   }
   // compiler.styledComponents / compiler.emotion → flat NAPI fields.
   // boolean 또는 객체 (세밀 제어 옵션). 현재 인식 객체 옵션: ssr.
@@ -1494,7 +1526,18 @@ function prepareNapiOptions(options: BuildOptions): Record<string, unknown> {
       if (extras.styled.length > 0) napiOptions.emotionExtraStyledSources = extras.styled;
     }
   }
-  return napiOptions;
+  const runtimePolyfills = applyRuntimePolyfillsToNapiOptions(napiOptions, {
+    entryPoints: options.entryPoints,
+    platform: options.platform,
+    target: options.target,
+    browserslist: options.browserslist,
+    runtimeTargets: options.runtimeTargets,
+    runtimePolyfills: options.runtimePolyfills,
+    coreJs: options.coreJs,
+    runBeforeMain: options.runBeforeMain,
+    resolveExtensions: options.resolveExtensions,
+  });
+  return { napiOptions, cleanup: runtimePolyfills.cleanup };
 }
 
 /**
@@ -1628,7 +1671,7 @@ export async function build(options: BuildOptions): Promise<BuildResult> {
   if (!options.entryPoints?.length) throw new Error("@zts/core: entryPoints is required");
   validateTsConfigRaw(options.tsconfigRaw);
 
-  const napiOptions = prepareNapiOptions(options);
+  const { napiOptions, cleanup } = prepareNapiOptions(options);
   const dispatcher = resolveDispatcher(options);
   if (dispatcher) napiOptions._pluginDispatcher = dispatcher;
 
@@ -1636,13 +1679,17 @@ export async function build(options: BuildOptions): Promise<BuildResult> {
   // JS 측에서 별도 호출 시 이중 발화. 단 closeBundle 은 Rollup 의미 ("write 완료 후") 보존을
   // 위해 writeOutputFiles 다음에 JS layer 가 직접 호출 — native bundle() 끝 시점은 contents
   // 결정 직후라 disk write *전* 이므로 closeBundle 자리 부적합.
-  const result: BuildResult = await native.build(napiOptions);
+  try {
+    const result: BuildResult = await native.build(napiOptions);
 
-  postProcessCssOutputs(result, options);
-  writeOutputFiles(result, options);
+    postProcessCssOutputs(result, options);
+    writeOutputFiles(result, options);
 
-  if (dispatcher) await dispatcher("closeBundle", undefined, null);
-  return result;
+    if (dispatcher) await dispatcher("closeBundle", undefined, null);
+    return result;
+  } finally {
+    cleanup();
+  }
 }
 
 /**
@@ -1665,11 +1712,15 @@ export function buildSync(options: BuildOptions): BuildResult {
     );
   }
 
-  const napiOptions = prepareNapiOptions(options);
-  const result: BuildResult = native.buildSync(napiOptions);
-  postProcessCssOutputs(result, options);
-  writeOutputFiles(result, options);
-  return result;
+  const { napiOptions, cleanup } = prepareNapiOptions(options);
+  try {
+    const result: BuildResult = native.buildSync(napiOptions);
+    postProcessCssOutputs(result, options);
+    writeOutputFiles(result, options);
+    return result;
+  } finally {
+    cleanup();
+  }
 }
 
 export function buildAppSync(options: AppBuildOptions = {}): BuildResult {
@@ -1982,7 +2033,7 @@ export function vitePlugin(rollupPlugin: RollupPlugin): ZtsPlugin {
 export function watch(options: BuildOptions): WatchHandle {
   if (!native) throw new Error("call init() first");
 
-  const nativeOpts = prepareNapiOptions(options);
+  const { napiOptions: nativeOpts, cleanup } = prepareNapiOptions(options);
   const dispatcher = resolveDispatcher(options);
 
   if (dispatcher) {
@@ -2007,5 +2058,26 @@ export function watch(options: BuildOptions): WatchHandle {
     nativeOpts.onRebuild = wrapWatchCallback(options.onRebuild);
   }
 
-  return native.watch(nativeOpts);
+  let handle: WatchHandle;
+  try {
+    handle = native.watch(nativeOpts);
+  } catch (err) {
+    cleanup();
+    throw err;
+  }
+  return {
+    stop() {
+      try {
+        handle.stop();
+      } finally {
+        cleanup();
+      }
+    },
+    getBundleSourceMap() {
+      return handle.getBundleSourceMap();
+    },
+    getHmrSourceMap(moduleId: string) {
+      return handle.getHmrSourceMap(moduleId);
+    },
+  };
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,10 @@
     "@types/node": "^25.5.2"
   },
   "optionalDependencies": {
+    "@babel/parser": "^7.29.0",
     "browserslist": "^4.24.0",
+    "core-js": "^3.49.0",
+    "core-js-compat": "^3.49.0",
     "lightningcss": "^1.28.0",
     "postcss": "^8.5.8",
     "postcss-load-config": "^6.0.1",

--- a/packages/core/src/runtime-polyfills.test.ts
+++ b/packages/core/src/runtime-polyfills.test.ts
@@ -1,0 +1,400 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  __runtimePolyfillTestHooks,
+  applyRuntimePolyfillsToNapiOptions,
+  collectRuntimePolyfillUsageFromFiles,
+  computeCoreJsCompatModules,
+  createRuntimePolyfillPrelude,
+  isEsTarget,
+  normalizeRuntimePolyfillOptions,
+  normalizeRuntimeTargets,
+  scanRuntimePolyfillUsage,
+} from "./runtime-polyfills.ts";
+
+function withRuntimeRequire<T>(runtimeRequire: any, fn: () => T): T {
+  __runtimePolyfillTestHooks.setRuntimeRequire(runtimeRequire);
+  try {
+    return fn();
+  } finally {
+    __runtimePolyfillTestHooks.reset();
+  }
+}
+
+describe("runtime polyfill target normalization", () => {
+  test("normalizes compact and spaced engine targets", () => {
+    expect(normalizeRuntimeTargets("ios12")).toEqual({ ios: "12" });
+    expect(normalizeRuntimeTargets("ios_saf 12")).toEqual({ ios: "12" });
+    expect(normalizeRuntimeTargets("iOS >= 12")).toEqual({ ios: "12" });
+    expect(normalizeRuntimeTargets("chrome >= 85")).toEqual({ chrome: "85" });
+    expect(normalizeRuntimeTargets("android >= 5")).toEqual({ android: "5" });
+    expect(normalizeRuntimeTargets("samsung >= 14")).toEqual({ samsung: "14" });
+    expect(normalizeRuntimeTargets("hermes0.7")).toEqual({ hermes: "0.7" });
+    expect(normalizeRuntimeTargets("hermes 0.7")).toEqual({ hermes: "0.7" });
+    expect(normalizeRuntimeTargets("react-native 0.70")).toEqual({ "react-native": "0.70" });
+    expect(normalizeRuntimeTargets("node18")).toEqual({ node: "18" });
+  });
+
+  test("merges object targets and rejects device names", () => {
+    expect(normalizeRuntimeTargets([{ ios: "12" }, "chrome85", "node18"])).toEqual({
+      ios: "12",
+      chrome: "85",
+      node: "18",
+    });
+    expect(() => normalizeRuntimeTargets("iPhone 8")).toThrow("Physical device names");
+    expect(() => normalizeRuntimeTargets("Galaxy S10")).toThrow("Physical device names");
+  });
+
+  test("keeps browserslist queries when they are not engine-version targets", () => {
+    expect(normalizeRuntimeTargets("last 2 chrome versions")).toBe("last 2 chrome versions");
+    expect(() => normalizeRuntimeTargets(["last 2 versions", "hermes0.7"])).toThrow(
+      "cannot mix browserslist queries",
+    );
+  });
+
+  test("normalizes runtime polyfill options and validates invalid inputs", () => {
+    expect(isEsTarget("es2020")).toBe(true);
+    expect(isEsTarget(undefined)).toBe(false);
+
+    expect(
+      (
+        normalizeRuntimePolyfillOptions({
+          entryPoints: [],
+          runtimePolyfills: "entry",
+        }) as any
+      ).targets,
+    ).toBe("defaults");
+    expect(
+      (
+        normalizeRuntimePolyfillOptions({
+          entryPoints: [],
+          platform: "node",
+          runtimePolyfills: "entry",
+        }) as any
+      ).targets.node,
+    ).toMatch(/^\d+\.\d+$/);
+    expect(
+      (
+        normalizeRuntimePolyfillOptions({
+          entryPoints: [],
+          platform: "react-native",
+          runtimePolyfills: "entry",
+        }) as any
+      ).targets,
+    ).toEqual({ hermes: "0.7" });
+    expect(
+      (
+        normalizeRuntimePolyfillOptions({
+          entryPoints: [],
+          target: "hermes0.7",
+          runtimePolyfills: "entry",
+        }) as any
+      ).targets,
+    ).toEqual({ hermes: "0.7" });
+
+    expect(() =>
+      normalizeRuntimePolyfillOptions({
+        entryPoints: [],
+        runtimePolyfills: { mode: "bad" as any },
+      }),
+    ).toThrow("mode must be");
+    expect(() =>
+      normalizeRuntimePolyfillOptions({
+        entryPoints: [],
+        runtimePolyfills: { provider: "other" as any },
+      }),
+    ).toThrow("supports only 'core-js'");
+    expect(() =>
+      normalizeRuntimePolyfillOptions({
+        entryPoints: [],
+        runtimePolyfills: { include: ["not-a-core-js-module"] },
+      }),
+    ).toThrow("invalid core-js module");
+  });
+});
+
+describe("core-js-compat adapter", () => {
+  test("matches representative replaceAll support snapshots", () => {
+    expect(computeCoreJsCompatModules({ ios: "12" }, ["es.string.replace-all"])).toEqual([
+      "es.string.replace-all",
+    ]);
+    expect(computeCoreJsCompatModules({ ios: "13.4" }, ["es.string.replace-all"])).toEqual([]);
+    expect(computeCoreJsCompatModules({ hermes: "0.6" }, ["es.string.replace-all"])).toEqual([
+      "es.string.replace-all",
+    ]);
+    expect(computeCoreJsCompatModules({ hermes: "0.7" }, ["es.string.replace-all"])).toEqual([]);
+    expect(computeCoreJsCompatModules({ node: "14" }, ["es.string.replace-all"])).toEqual([
+      "es.string.replace-all",
+    ]);
+    expect(computeCoreJsCompatModules({ node: "18" }, ["es.string.replace-all"])).toEqual([]);
+  });
+
+  test("reports optional dependency load failures with actionable errors", () => {
+    const missingRequire = Object.assign(
+      () => {
+        throw new Error("missing");
+      },
+      {
+        resolve() {
+          throw new Error("missing");
+        },
+      },
+    );
+
+    withRuntimeRequire(missingRequire, () => {
+      expect(() => computeCoreJsCompatModules({ ios: "12" }, ["es.string.replace-all"])).toThrow(
+        "core-js-compat",
+      );
+      expect(() => computeCoreJsCompatModules({ ios: "12" }, ["es.string.replace-all"])).toThrow(
+        "core-js-compat",
+      );
+    });
+
+    withRuntimeRequire(missingRequire, () => {
+      expect(() => scanRuntimePolyfillUsage(`new Promise(() => {});`)).toThrow("@babel/parser");
+      expect(() => scanRuntimePolyfillUsage(`new Promise(() => {});`)).toThrow("@babel/parser");
+    });
+
+    withRuntimeRequire(missingRequire, () => {
+      expect(
+        (
+          normalizeRuntimePolyfillOptions({
+            entryPoints: [],
+            runtimePolyfills: "entry",
+          }) as any
+        ).coreJsVersion,
+      ).toBeUndefined();
+    });
+  });
+});
+
+describe("runtime polyfill usage scanner", () => {
+  test("finds supported v1 built-in usage", () => {
+    const modules = scanRuntimePolyfillUsage(`
+      const a = "a".replaceAll("a", "b");
+      const b = values.at(0);
+      const c = Object.hasOwn({ a: 1 }, "a");
+      const d = structuredClone(c);
+      const e = new Map();
+      const f = new Set();
+      const g = Promise.resolve(d);
+      void [a, b, e, f, g];
+    `);
+    expect(modules).toEqual([
+      "es.array.at",
+      "es.map",
+      "es.object.has-own",
+      "es.promise",
+      "es.set",
+      "es.string.replace-all",
+      "web.structured-clone",
+    ]);
+  });
+
+  test("ignores dynamic computed member access", () => {
+    expect(scanRuntimePolyfillUsage(`value[methodName]("x");`)).toEqual([]);
+  });
+
+  test("falls back to Flow parsing when TypeScript parsing fails", () => {
+    expect(scanRuntimePolyfillUsage(`opaque type ID = string;\nnew Promise(() => {});`)).toEqual([
+      "es.promise",
+    ]);
+  });
+
+  test("retries with Flow parser options after a parser failure", () => {
+    const parser = {
+      calls: 0,
+      parse() {
+        this.calls += 1;
+        if (this.calls === 1) throw new Error("typescript parse failed");
+        return {
+          type: "File",
+          program: {
+            type: "Program",
+            body: [
+              {
+                type: "ExpressionStatement",
+                expression: {
+                  type: "CallExpression",
+                  callee: { type: "Identifier", name: "Promise" },
+                  arguments: [],
+                },
+              },
+            ],
+          },
+        };
+      },
+    };
+    const runtimeRequire = Object.assign(
+      (id: string) => {
+        if (id === "@babel/parser") return parser;
+        throw new Error("unexpected require");
+      },
+      {
+        resolve() {
+          throw new Error("unexpected resolve");
+        },
+      },
+    );
+
+    withRuntimeRequire(runtimeRequire, () => {
+      expect(scanRuntimePolyfillUsage(`ignored`)).toEqual(["es.promise"]);
+      expect(parser.calls).toBe(2);
+    });
+  });
+
+  test("scans local dependency files", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfill-scan-"));
+    try {
+      writeFileSync(join(dir, "entry.ts"), `import { run } from "./dep"; run();`);
+      writeFileSync(join(dir, "dep.ts"), `export const run = () => "a".replaceAll("a", "b");`);
+      expect(
+        collectRuntimePolyfillUsageFromFiles([join(dir, "entry.ts")], {
+          resolveExtensions: [".ts", ".custom"],
+        }),
+      ).toEqual(["es.string.replace-all"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("scans require dependencies and directory index modules", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfill-scan-"));
+    try {
+      writeFileSync(
+        join(dir, "entry.ts"),
+        `require("./dep"); import "./folder"; import "./empty"; import "./missing"; import "./style.css";`,
+      );
+      writeFileSync(join(dir, "dep.js"), `new Set();`);
+      mkdirSync(join(dir, "folder"));
+      writeFileSync(join(dir, "folder", "index.ts"), `[1].at(0);`);
+      mkdirSync(join(dir, "empty"));
+      writeFileSync(join(dir, "style.css"), `.x { color: red; }`);
+      expect(collectRuntimePolyfillUsageFromFiles([join(dir, "entry.ts")])).toEqual([
+        "es.array.at",
+        "es.set",
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("runtime polyfill prelude", () => {
+  test("creates a removable side-effect import prelude", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfill-prelude-"));
+    try {
+      const entry = join(dir, "entry.ts");
+      writeFileSync(entry, `console.log("entry");`);
+      const prelude = createRuntimePolyfillPrelude(["es.string.replace-all"], {
+        entryPoints: [entry],
+      });
+      expect(prelude).not.toBeNull();
+      const path = prelude!.path;
+      expect(readFileSync(path, "utf8")).toContain("core-js/modules/es.string.replace-all.js");
+      prelude!.cleanup();
+      expect(existsSync(path)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("throws when a requested core-js module cannot be resolved", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfill-prelude-"));
+    try {
+      const entry = join(dir, "entry.ts");
+      writeFileSync(entry, `console.log("entry");`);
+      expect(() =>
+        createRuntimePolyfillPrelude(["es.not-real"], {
+          entryPoints: [entry],
+        }),
+      ).toThrow("could not resolve");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("applies include/exclude and prepends runtime prelude before runBeforeMain", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfill-apply-"));
+    try {
+      const entry = join(dir, "entry.ts");
+      const init = join(dir, "init.ts");
+      writeFileSync(entry, `"a".replaceAll("a", "b");`);
+      writeFileSync(init, `globalThis.__INIT__ = true;`);
+
+      const napiOptions: Record<string, unknown> = {};
+      const applied = applyRuntimePolyfillsToNapiOptions(napiOptions, {
+        entryPoints: [entry],
+        runtimePolyfills: {
+          mode: "auto",
+          targets: "ios12",
+          include: ["es.array.at"],
+          exclude: ["es.string.replace-all"],
+        },
+        runBeforeMain: [init],
+      });
+      try {
+        expect(applied.modules).toEqual(["es.array.at"]);
+        const runBeforeMain = napiOptions.runBeforeMain as string[];
+        expect(typeof runBeforeMain[0]).toBe("string");
+        expect(runBeforeMain[1]).toBe(init);
+        expect(readFileSync(runBeforeMain[0], "utf8")).toContain("core-js/modules/es.array.at.js");
+      } finally {
+        applied.cleanup();
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("entry mode injects the target-wide compat prelude", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfill-entry-"));
+    try {
+      const entry = join(dir, "entry.ts");
+      writeFileSync(entry, `console.log("entry");`);
+      const napiOptions: Record<string, unknown> = {};
+      const applied = applyRuntimePolyfillsToNapiOptions(napiOptions, {
+        entryPoints: [entry],
+        runtimePolyfills: "entry",
+        runtimeTargets: "node999",
+      });
+      try {
+        expect(applied.modules.length).toBeGreaterThan(0);
+        const runBeforeMain = napiOptions.runBeforeMain as string[];
+        expect(readFileSync(runBeforeMain[0], "utf8")).toContain("core-js/modules/");
+      } finally {
+        applied.cleanup();
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("off mode and empty module results return callable cleanup functions", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfill-empty-"));
+    try {
+      const entry = join(dir, "entry.ts");
+      writeFileSync(entry, `console.log("entry");`);
+
+      const off = applyRuntimePolyfillsToNapiOptions({}, { entryPoints: [entry] });
+      expect(off.modules).toEqual([]);
+      off.cleanup();
+
+      const empty = applyRuntimePolyfillsToNapiOptions(
+        {},
+        {
+          entryPoints: [entry],
+          runtimePolyfills: "auto",
+          runtimeTargets: "node18",
+        },
+      );
+      expect(empty.modules).toEqual([]);
+      empty.cleanup();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/core/src/runtime-polyfills.test.ts
+++ b/packages/core/src/runtime-polyfills.test.ts
@@ -358,8 +358,7 @@ describe("runtime polyfill prelude", () => {
       const napiOptions: Record<string, unknown> = {};
       const applied = applyRuntimePolyfillsToNapiOptions(napiOptions, {
         entryPoints: [entry],
-        runtimePolyfills: "entry",
-        runtimeTargets: "node999",
+        runtimePolyfills: { mode: "entry", targets: "node999" },
       });
       try {
         expect(applied.modules.length).toBeGreaterThan(0);
@@ -387,8 +386,7 @@ describe("runtime polyfill prelude", () => {
         {},
         {
           entryPoints: [entry],
-          runtimePolyfills: "auto",
-          runtimeTargets: "node18",
+          runtimePolyfills: { mode: "auto", targets: "node18" },
         },
       );
       expect(empty.modules).toEqual([]);

--- a/packages/core/src/runtime-polyfills.test.ts
+++ b/packages/core/src/runtime-polyfills.test.ts
@@ -25,34 +25,35 @@ function withRuntimeRequire<T>(runtimeRequire: any, fn: () => T): T {
 }
 
 describe("runtime polyfill target normalization", () => {
-  test("normalizes compact and spaced engine targets", () => {
-    expect(normalizeRuntimeTargets("ios12")).toEqual({ ios: "12" });
-    expect(normalizeRuntimeTargets("ios_saf 12")).toEqual({ ios: "12" });
-    expect(normalizeRuntimeTargets("iOS >= 12")).toEqual({ ios: "12" });
-    expect(normalizeRuntimeTargets("chrome >= 85")).toEqual({ chrome: "85" });
-    expect(normalizeRuntimeTargets("android >= 5")).toEqual({ android: "5" });
-    expect(normalizeRuntimeTargets("samsung >= 14")).toEqual({ samsung: "14" });
-    expect(normalizeRuntimeTargets("hermes0.7")).toEqual({ hermes: "0.7" });
-    expect(normalizeRuntimeTargets("hermes 0.7")).toEqual({ hermes: "0.7" });
-    expect(normalizeRuntimeTargets("react-native 0.70")).toEqual({ "react-native": "0.70" });
-    expect(normalizeRuntimeTargets("node18")).toEqual({ node: "18" });
+  test("keeps Rspack/SWC browserslist targets", () => {
+    expect(normalizeRuntimeTargets("ios_saf 12")).toBe("ios_saf 12");
+    expect(normalizeRuntimeTargets("iOS >= 12")).toBe("iOS >= 12");
+    expect(normalizeRuntimeTargets("chrome >= 85")).toBe("chrome >= 85");
+    expect(normalizeRuntimeTargets("android >= 5")).toBe("android >= 5");
+    expect(normalizeRuntimeTargets("samsung >= 14")).toBe("samsung >= 14");
+    expect(normalizeRuntimeTargets("node 18")).toBe("node 18");
+    expect(normalizeRuntimeTargets(["chrome >= 85", "safari >= 14"])).toEqual([
+      "chrome >= 85",
+      "safari >= 14",
+    ]);
   });
 
-  test("merges object targets and rejects device names", () => {
-    expect(normalizeRuntimeTargets([{ ios: "12" }, "chrome85", "node18"])).toEqual({
-      ios: "12",
-      chrome: "85",
-      node: "18",
-    });
+  test("rejects device names and unsupported shorthand targets", () => {
     expect(() => normalizeRuntimeTargets("iPhone 8")).toThrow("Physical device names");
     expect(() => normalizeRuntimeTargets("Galaxy S10")).toThrow("Physical device names");
+    expect(() => normalizeRuntimeTargets("ios12")).toThrow("Compact runtime target shorthands");
+    expect(() => normalizeRuntimeTargets("hermes0.7")).toThrow("Compact runtime target shorthands");
+    expect(() => normalizeRuntimeTargets("node18")).toThrow("Compact runtime target shorthands");
+    expect(() => normalizeRuntimeTargets("hermes 0.7")).toThrow("Rspack/SWC env.targets");
+    expect(() => normalizeRuntimeTargets("react-native 0.70")).toThrow("Rspack/SWC env.targets");
   });
 
   test("keeps browserslist queries when they are not engine-version targets", () => {
     expect(normalizeRuntimeTargets("last 2 chrome versions")).toBe("last 2 chrome versions");
-    expect(() => normalizeRuntimeTargets(["last 2 versions", "hermes0.7"])).toThrow(
-      "cannot mix browserslist queries",
-    );
+    expect(normalizeRuntimeTargets(["last 2 versions", "not dead"])).toEqual([
+      "last 2 versions",
+      "not dead",
+    ]);
   });
 
   test("normalizes runtime polyfill options and validates invalid inputs", () => {
@@ -94,6 +95,33 @@ describe("runtime polyfill target normalization", () => {
         }) as any
       ).targets,
     ).toEqual({ hermes: "0.7" });
+    expect(
+      (
+        normalizeRuntimePolyfillOptions({
+          entryPoints: [],
+          target: "node18",
+          runtimePolyfills: "entry",
+        }) as any
+      ).targets,
+    ).toEqual({ node: "18" });
+    expect(
+      (
+        normalizeRuntimePolyfillOptions({
+          entryPoints: [],
+          target: "chrome >= 85",
+          runtimePolyfills: "entry",
+        }) as any
+      ).targets,
+    ).toBe("chrome >= 85");
+    expect(
+      (
+        normalizeRuntimePolyfillOptions({
+          entryPoints: [],
+          runtimePolyfills: { mode: "entry", targets: ["safari >= 14"], coreJs: "3.49" },
+          coreJs: "3.48",
+        }) as any
+      ).coreJsVersion,
+    ).toBe("3.49");
 
     expect(() =>
       normalizeRuntimePolyfillOptions({
@@ -330,7 +358,7 @@ describe("runtime polyfill prelude", () => {
         entryPoints: [entry],
         runtimePolyfills: {
           mode: "auto",
-          targets: "ios12",
+          targets: ["ios_saf 12"],
           include: ["es.array.at"],
           exclude: ["es.string.replace-all"],
         },
@@ -358,7 +386,7 @@ describe("runtime polyfill prelude", () => {
       const napiOptions: Record<string, unknown> = {};
       const applied = applyRuntimePolyfillsToNapiOptions(napiOptions, {
         entryPoints: [entry],
-        runtimePolyfills: { mode: "entry", targets: "node999" },
+        runtimePolyfills: { mode: "entry", targets: ["ie 11"] },
       });
       try {
         expect(applied.modules.length).toBeGreaterThan(0);
@@ -386,7 +414,7 @@ describe("runtime polyfill prelude", () => {
         {},
         {
           entryPoints: [entry],
-          runtimePolyfills: { mode: "auto", targets: "node18" },
+          runtimePolyfills: { mode: "auto", targets: ["node 18"] },
         },
       );
       expect(empty.modules).toEqual([]);

--- a/packages/core/src/runtime-polyfills.test.ts
+++ b/packages/core/src/runtime-polyfills.test.ts
@@ -289,6 +289,16 @@ describe("runtime polyfill usage scanner", () => {
     }
   });
 
+  test("ignores entry files whose contents fail to read", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfill-scan-"));
+    try {
+      const missing = join(dir, "vanished.ts");
+      expect(collectRuntimePolyfillUsageFromFiles([missing])).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("scans require dependencies and directory index modules", () => {
     const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfill-scan-"));
     try {
@@ -325,6 +335,34 @@ describe("runtime polyfill prelude", () => {
       expect(readFileSync(path, "utf8")).toContain("core-js/modules/es.string.replace-all.js");
       prelude!.cleanup();
       expect(existsSync(path)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("uses the test-hook runtime require when overridden", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfill-prelude-"));
+    try {
+      const entry = join(dir, "entry.ts");
+      writeFileSync(entry, `console.log("entry");`);
+      const stub = {
+        resolve(specifier: string) {
+          return `/virtual/${specifier}`;
+        },
+      };
+      withRuntimeRequire(stub, () => {
+        const prelude = createRuntimePolyfillPrelude(["es.string.replace-all"], {
+          entryPoints: [entry],
+        });
+        expect(prelude).not.toBeNull();
+        try {
+          expect(readFileSync(prelude!.path, "utf8")).toContain(
+            "/virtual/core-js/modules/es.string.replace-all.js",
+          );
+        } finally {
+          prelude!.cleanup();
+        }
+      });
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/core/src/runtime-polyfills.ts
+++ b/packages/core/src/runtime-polyfills.ts
@@ -6,14 +6,66 @@ import { dirname, extname, isAbsolute, join, resolve } from "node:path";
 export type RuntimePolyfillMode = "auto" | "usage" | "entry";
 export type RuntimePolyfillProvider = "core-js";
 export type RuntimeTargetObject = Record<string, string | number>;
-export type RuntimeTarget = string;
+export type RuntimeTargetVersion =
+  | `${number}`
+  | `${number}.${number}`
+  | `${number}.${number}.${number}`;
+export type RuntimeTargetComparator = ">=" | ">" | "<=" | "<" | "=";
+export type RuntimeTargetName =
+  | "chrome"
+  | "firefox"
+  | "safari"
+  | "ios"
+  | "ios_saf"
+  | "iOS"
+  | "android"
+  | "samsung"
+  | "edge"
+  | "opera"
+  | "node"
+  | "hermes"
+  | "react-native";
+export type RuntimeTargetCompactName =
+  | "ios"
+  | "chrome"
+  | "firefox"
+  | "safari"
+  | "android"
+  | "samsung"
+  | "edge"
+  | "opera"
+  | "node"
+  | "hermes";
+export type RuntimeTargetQuery =
+  | `${RuntimeTargetName} ${RuntimeTargetVersion}`
+  | `${RuntimeTargetName} ${RuntimeTargetComparator} ${RuntimeTargetVersion}`;
+export type RuntimeTarget =
+  | `${RuntimeTargetCompactName}${RuntimeTargetVersion}`
+  | RuntimeTargetQuery
+  | (string & {});
 
 export interface RuntimePolyfillOptions {
+  /**
+   * Runtime polyfill injection strategy.
+   *
+   * `auto` and `usage` scan statically detectable API usage, while `entry`
+   * injects all target-required core-js ES/Web modules.
+   */
   mode?: RuntimePolyfillMode;
+  /** Polyfill provider. Only `core-js` is currently supported. */
   provider?: RuntimePolyfillProvider;
+  /**
+   * Runtime engine targets for core-js-compat.
+   *
+   * Examples: `"ios12"`, `"chrome >= 85"`, `"hermes0.7"`, `"react-native 0.70"`,
+   * or `{ node: "18" }`. Physical device names such as `"iPhone 8"` are rejected.
+   */
   targets?: RuntimeTarget | RuntimeTarget[] | RuntimeTargetObject;
+  /** Additional core-js modules to force into the synthetic prelude. */
   include?: string[];
+  /** core-js modules to remove after target and usage calculation. */
   exclude?: string[];
+  /** Include proposal polyfills when querying core-js-compat. */
   proposals?: boolean;
 }
 
@@ -24,7 +76,6 @@ export interface RuntimePolyfillBuildOptions {
   platform?: string;
   target?: string;
   browserslist?: string | string[];
-  runtimeTargets?: RuntimeTarget | RuntimeTarget[] | RuntimeTargetObject;
   runtimePolyfills?: RuntimePolyfillsOption;
   coreJs?: string;
   runBeforeMain?: string[];
@@ -276,7 +327,6 @@ function chooseRuntimeTargets(
 ): CoreJsTargets {
   const raw =
     runtime.targets ??
-    options.runtimeTargets ??
     (options.browserslist ? options.browserslist : undefined) ??
     (!isEsTarget(options.target) && options.target ? options.target : undefined);
   if (raw !== undefined) return normalizeRuntimeTargets(raw);
@@ -667,7 +717,6 @@ export function applyRuntimePolyfillsToNapiOptions(
   options: RuntimePolyfillBuildOptions,
 ): { cleanup: () => void; modules: string[] } {
   delete napiOptions.runtimePolyfills;
-  delete napiOptions.runtimeTargets;
   delete napiOptions.coreJs;
 
   if (options.target && !isEsTarget(options.target)) delete napiOptions.target;

--- a/packages/core/src/runtime-polyfills.ts
+++ b/packages/core/src/runtime-polyfills.ts
@@ -5,44 +5,6 @@ import { dirname, extname, isAbsolute, join, resolve } from "node:path";
 
 export type RuntimePolyfillMode = "auto" | "usage" | "entry";
 export type RuntimePolyfillProvider = "core-js";
-export type RuntimeTargetObject = Record<string, string | number>;
-export type RuntimeTargetVersion =
-  | `${number}`
-  | `${number}.${number}`
-  | `${number}.${number}.${number}`;
-export type RuntimeTargetComparator = ">=" | ">" | "<=" | "<" | "=";
-export type RuntimeTargetName =
-  | "chrome"
-  | "firefox"
-  | "safari"
-  | "ios"
-  | "ios_saf"
-  | "iOS"
-  | "android"
-  | "samsung"
-  | "edge"
-  | "opera"
-  | "node"
-  | "hermes"
-  | "react-native";
-export type RuntimeTargetCompactName =
-  | "ios"
-  | "chrome"
-  | "firefox"
-  | "safari"
-  | "android"
-  | "samsung"
-  | "edge"
-  | "opera"
-  | "node"
-  | "hermes";
-export type RuntimeTargetQuery =
-  | `${RuntimeTargetName} ${RuntimeTargetVersion}`
-  | `${RuntimeTargetName} ${RuntimeTargetComparator} ${RuntimeTargetVersion}`;
-export type RuntimeTarget =
-  | `${RuntimeTargetCompactName}${RuntimeTargetVersion}`
-  | RuntimeTargetQuery
-  | (string & {});
 
 export interface RuntimePolyfillOptions {
   /**
@@ -55,12 +17,15 @@ export interface RuntimePolyfillOptions {
   /** Polyfill provider. Only `core-js` is currently supported. */
   provider?: RuntimePolyfillProvider;
   /**
-   * Runtime engine targets for core-js-compat.
+   * Browserslist targets for core-js-compat, matching Rspack/SWC `env.targets`.
    *
-   * Examples: `"ios12"`, `"chrome >= 85"`, `"hermes0.7"`, `"react-native 0.70"`,
-   * or `{ node: "18" }`. Physical device names such as `"iPhone 8"` are rejected.
+   * Examples: `["chrome >= 87", "edge >= 88", "firefox >= 78", "safari >= 14"]`.
+   * Physical device names such as `"iPhone 8"` and compact shorthands such as
+   * `"ios12"` are rejected.
    */
-  targets?: RuntimeTarget | RuntimeTarget[] | RuntimeTargetObject;
+  targets?: string | string[];
+  /** core-js version used for compatibility calculation, matching Rspack/SWC `env.coreJs`. */
+  coreJs?: string;
   /** Additional core-js modules to force into the synthetic prelude. */
   include?: string[];
   /** core-js modules to remove after target and usage calculation. */
@@ -92,7 +57,8 @@ interface NormalizedRuntimePolyfills {
   coreJsVersion?: string;
 }
 
-type CoreJsTargets = string | string[] | RuntimeTargetObject;
+type CoreJsTargetObject = Record<string, string | number>;
+type CoreJsTargets = string | string[] | CoreJsTargetObject;
 
 type RuntimeRequire = ReturnType<typeof createRequire>;
 
@@ -147,19 +113,6 @@ const ES_TARGETS = new Set([
 
 const DEVICE_TARGET_RE =
   /\b(?:iphone|ipad|ipod|galaxy|pixel|nexus|oneplus|xiaomi|redmi|huawei|motorola|moto)\b/i;
-
-const TARGET_KEY_ALIASES: Record<string, string> = {
-  ios_saf: "ios",
-  ios: "ios",
-  safari: "safari",
-  chrome: "chrome",
-  android: "android",
-  samsung: "samsung",
-  hermes: "hermes",
-  "react-native": "react-native",
-  reactnative: "react-native",
-  node: "node",
-};
 
 const RUNTIME_USAGE_MODULES = new Set([
   "es.array.at",
@@ -239,77 +192,47 @@ function readInstalledCoreJsVersion(): string | undefined {
 function assertNotPhysicalDeviceTarget(raw: string): void {
   if (!DEVICE_TARGET_RE.test(raw)) return;
   throw new Error(
-    `@zts/core: unsupported runtime target '${raw}'. Physical device names are not supported; use engine targets such as 'ios12', 'ios_saf 12', 'chrome >= 85', 'hermes0.7', or 'node18'.`,
+    `@zts/core: unsupported runtime target '${raw}'. Physical device names are not supported; use Browserslist targets such as 'ios_saf 12', 'chrome >= 85', or 'node 18'.`,
   );
 }
 
-function normalizeTargetKey(raw: string): string | null {
-  return TARGET_KEY_ALIASES[raw.toLowerCase()] ?? null;
+function assertNotCompactRuntimeTarget(raw: string): void {
+  const compact = raw.match(
+    /^(ios_saf|ios|safari|chrome|android|samsung|hermes|node)v?\d+(?:\.\d+)*$/i,
+  );
+  if (!compact) return;
+  throw new Error(
+    `@zts/core: unsupported runtime target '${raw}'. Compact runtime target shorthands are not supported; use Browserslist targets such as 'ios_saf 12', 'chrome >= 85', or 'node 18'.`,
+  );
 }
 
-function normalizeTargetObject(targets: RuntimeTargetObject): RuntimeTargetObject {
-  const out: RuntimeTargetObject = {};
-  for (const [rawKey, rawValue] of Object.entries(targets)) {
-    const key = normalizeTargetKey(rawKey);
-    if (!key) throw new Error(`@zts/core: unsupported runtime target engine '${rawKey}'.`);
-    out[key] = String(rawValue);
-  }
-  return out;
+function assertBrowserslistRuntimeTarget(raw: string): void {
+  if (!/^(?:hermes|react-native|reactnative)\b/i.test(raw)) return;
+  throw new Error(
+    `@zts/core: unsupported runtime target '${raw}'. runtimePolyfills.targets follows Rspack/SWC env.targets and accepts Browserslist queries; use platform: 'react-native' for the default Hermes runtime target.`,
+  );
 }
 
-function mergeTargetObjects(targets: RuntimeTargetObject[]): RuntimeTargetObject {
-  const out: RuntimeTargetObject = {};
-  for (const target of targets) Object.assign(out, target);
-  return out;
-}
-
-function normalizeRuntimeTargetString(raw: string): RuntimeTargetObject | string {
+function normalizeRuntimeTargetString(raw: string): string {
   const value = raw.trim();
   assertNotPhysicalDeviceTarget(value);
-
-  const compact = value.match(
-    /^(ios_saf|ios|safari|chrome|android|samsung|hermes|node)\s*v?(\d+(?:\.\d+)*)$/i,
-  );
-  if (compact) {
-    const key = normalizeTargetKey(compact[1]);
-    if (!key) throw new Error(`@zts/core: unsupported runtime target '${raw}'.`);
-    return { [key]: compact[2] };
-  }
-
-  const spaced = value.match(
-    /^(ios_saf|ios|safari|chrome|android|samsung|hermes|react-native|reactnative|node)\s*(?:>=|=)?\s*v?(\d+(?:\.\d+)*)$/i,
-  );
-  if (spaced) {
-    const key = normalizeTargetKey(spaced[1]);
-    if (!key) throw new Error(`@zts/core: unsupported runtime target '${raw}'.`);
-    return { [key]: spaced[2] };
-  }
-
+  assertNotCompactRuntimeTarget(value);
+  assertBrowserslistRuntimeTarget(value);
   return value;
 }
 
-export function normalizeRuntimeTargets(
-  targets: RuntimeTarget | RuntimeTarget[] | RuntimeTargetObject,
-): CoreJsTargets {
-  if (Array.isArray(targets)) {
-    const objectTargets: RuntimeTargetObject[] = [];
-    const queries: string[] = [];
-    for (const target of targets) {
-      const normalized = normalizeRuntimeTargets(target);
-      if (typeof normalized === "string") queries.push(normalized);
-      else if (Array.isArray(normalized)) queries.push(...normalized);
-      else objectTargets.push(normalized);
-    }
-    if (queries.length > 0 && objectTargets.length > 0) {
-      throw new Error(
-        "@zts/core: runtime target arrays cannot mix browserslist queries with Hermes/React Native object targets.",
-      );
-    }
-    if (queries.length > 0) return queries;
-    return mergeTargetObjects(objectTargets);
-  }
-  if (typeof targets === "string") return normalizeRuntimeTargetString(targets);
-  return normalizeTargetObject(targets);
+export function normalizeRuntimeTargets(targets: string | string[]): string | string[] {
+  if (Array.isArray(targets)) return targets.map(normalizeRuntimeTargetString);
+  return normalizeRuntimeTargetString(targets);
+}
+
+function normalizeBuildTargetForRuntime(target: string | undefined): CoreJsTargets | undefined {
+  if (!target || isEsTarget(target)) return undefined;
+  const nodeTarget = target.match(/^node(\d+(?:\.\d+)*)$/i);
+  if (nodeTarget) return { node: nodeTarget[1] };
+  const hermesTarget = target.match(/^hermes(\d+(?:\.\d+)*)$/i);
+  if (hermesTarget) return { hermes: hermesTarget[1] };
+  return normalizeRuntimeTargets(target);
 }
 
 function defaultRuntimeTargets(options: RuntimePolyfillBuildOptions): CoreJsTargets {
@@ -325,11 +248,10 @@ function chooseRuntimeTargets(
   options: RuntimePolyfillBuildOptions,
   runtime: RuntimePolyfillOptions,
 ): CoreJsTargets {
-  const raw =
-    runtime.targets ??
-    (options.browserslist ? options.browserslist : undefined) ??
-    (!isEsTarget(options.target) && options.target ? options.target : undefined);
+  const raw = runtime.targets ?? (options.browserslist ? options.browserslist : undefined);
   if (raw !== undefined) return normalizeRuntimeTargets(raw);
+  const target = normalizeBuildTargetForRuntime(options.target);
+  if (target !== undefined) return target;
   return defaultRuntimeTargets(options);
 }
 
@@ -368,7 +290,7 @@ export function normalizeRuntimePolyfillOptions(
     include: (runtime.include ?? []).map(normalizeCoreJsModuleName),
     exclude: (runtime.exclude ?? []).map(normalizeCoreJsModuleName),
     proposals: runtime.proposals === true,
-    coreJsVersion: options.coreJs ?? readInstalledCoreJsVersion(),
+    coreJsVersion: runtime.coreJs ?? options.coreJs ?? readInstalledCoreJsVersion(),
   };
 }
 

--- a/packages/core/src/runtime-polyfills.ts
+++ b/packages/core/src/runtime-polyfills.ts
@@ -1,0 +1,685 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, extname, isAbsolute, join, resolve } from "node:path";
+
+export type RuntimePolyfillMode = "auto" | "usage" | "entry";
+export type RuntimePolyfillProvider = "core-js";
+export type RuntimeTargetObject = Record<string, string | number>;
+export type RuntimeTarget = string;
+
+export interface RuntimePolyfillOptions {
+  mode?: RuntimePolyfillMode;
+  provider?: RuntimePolyfillProvider;
+  targets?: RuntimeTarget | RuntimeTarget[] | RuntimeTargetObject;
+  include?: string[];
+  exclude?: string[];
+  proposals?: boolean;
+}
+
+export type RuntimePolyfillsOption = "off" | RuntimePolyfillMode | RuntimePolyfillOptions;
+
+export interface RuntimePolyfillBuildOptions {
+  entryPoints: string[];
+  platform?: string;
+  target?: string;
+  browserslist?: string | string[];
+  runtimeTargets?: RuntimeTarget | RuntimeTarget[] | RuntimeTargetObject;
+  runtimePolyfills?: RuntimePolyfillsOption;
+  coreJs?: string;
+  runBeforeMain?: string[];
+  resolveExtensions?: string[];
+}
+
+interface NormalizedRuntimePolyfills {
+  mode: RuntimePolyfillMode;
+  provider: RuntimePolyfillProvider;
+  targets: CoreJsTargets;
+  include: string[];
+  exclude: string[];
+  proposals: boolean;
+  coreJsVersion?: string;
+}
+
+type CoreJsTargets = string | string[] | RuntimeTargetObject;
+
+type RuntimeRequire = ReturnType<typeof createRequire>;
+
+type CoreJsCompat = (options: {
+  targets: CoreJsTargets;
+  version?: string;
+  modules?: string[] | RegExp;
+  proposals?: boolean;
+}) => { list: string[] };
+
+type BabelParser = {
+  parse(source: string, options: Record<string, unknown>): unknown;
+};
+
+let runtimeRequireOverride: RuntimeRequire | null = null;
+
+function getRuntimeRequire(): RuntimeRequire {
+  return runtimeRequireOverride ?? createRequire(import.meta.url);
+}
+
+/** @internal */
+export const __runtimePolyfillTestHooks = {
+  reset() {
+    coreJsCompatCache = undefined;
+    babelParserCache = undefined;
+    coreJsVersionCache = undefined;
+    runtimeRequireOverride = null;
+  },
+  setRuntimeRequire(runtimeRequire: RuntimeRequire | null) {
+    coreJsCompatCache = undefined;
+    babelParserCache = undefined;
+    coreJsVersionCache = undefined;
+    runtimeRequireOverride = runtimeRequire;
+  },
+};
+
+const ES_TARGETS = new Set([
+  "es5",
+  "es2015",
+  "es2016",
+  "es2017",
+  "es2018",
+  "es2019",
+  "es2020",
+  "es2021",
+  "es2022",
+  "es2023",
+  "es2024",
+  "es2025",
+  "esnext",
+]);
+
+const DEVICE_TARGET_RE =
+  /\b(?:iphone|ipad|ipod|galaxy|pixel|nexus|oneplus|xiaomi|redmi|huawei|motorola|moto)\b/i;
+
+const TARGET_KEY_ALIASES: Record<string, string> = {
+  ios_saf: "ios",
+  ios: "ios",
+  safari: "safari",
+  chrome: "chrome",
+  android: "android",
+  samsung: "samsung",
+  hermes: "hermes",
+  "react-native": "react-native",
+  reactnative: "react-native",
+  node: "node",
+};
+
+const RUNTIME_USAGE_MODULES = new Set([
+  "es.array.at",
+  "es.map",
+  "es.object.has-own",
+  "es.promise",
+  "es.set",
+  "es.string.replace-all",
+  "web.structured-clone",
+]);
+
+const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"];
+
+let coreJsCompatCache: CoreJsCompat | null | undefined;
+let babelParserCache: BabelParser | null | undefined;
+let coreJsVersionCache: string | null | undefined;
+
+export function isEsTarget(target: string | undefined): boolean {
+  return target !== undefined && ES_TARGETS.has(target);
+}
+
+function loadCoreJsCompat(): CoreJsCompat {
+  if (coreJsCompatCache !== undefined) {
+    if (coreJsCompatCache) return coreJsCompatCache;
+    throwCoreJsCompatMissing();
+  }
+  try {
+    const req = getRuntimeRequire();
+    coreJsCompatCache = req("core-js-compat") as CoreJsCompat;
+    return coreJsCompatCache;
+  } catch {
+    coreJsCompatCache = null;
+    throwCoreJsCompatMissing();
+  }
+}
+
+function throwCoreJsCompatMissing(): never {
+  throw new Error(
+    "@zts/core: runtimePolyfills requires the optional 'core-js-compat' package. Install it with `bun add core-js core-js-compat`.",
+  );
+}
+
+function loadBabelParser(): BabelParser {
+  if (babelParserCache !== undefined) {
+    if (babelParserCache) return babelParserCache;
+    throwBabelParserMissing();
+  }
+  try {
+    const req = getRuntimeRequire();
+    babelParserCache = req("@babel/parser") as BabelParser;
+    return babelParserCache;
+  } catch {
+    babelParserCache = null;
+    throwBabelParserMissing();
+  }
+}
+
+function throwBabelParserMissing(): never {
+  throw new Error(
+    "@zts/core: runtimePolyfills auto/usage mode requires the optional '@babel/parser' package. Install it with `bun add @babel/parser`.",
+  );
+}
+
+function readInstalledCoreJsVersion(): string | undefined {
+  if (coreJsVersionCache !== undefined) return coreJsVersionCache ?? undefined;
+  try {
+    const req = getRuntimeRequire();
+    const pkgPath = req.resolve("core-js/package.json");
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version?: string };
+    coreJsVersionCache = pkg.version ?? null;
+  } catch {
+    coreJsVersionCache = null;
+  }
+  return coreJsVersionCache ?? undefined;
+}
+
+function assertNotPhysicalDeviceTarget(raw: string): void {
+  if (!DEVICE_TARGET_RE.test(raw)) return;
+  throw new Error(
+    `@zts/core: unsupported runtime target '${raw}'. Physical device names are not supported; use engine targets such as 'ios12', 'ios_saf 12', 'chrome >= 85', 'hermes0.7', or 'node18'.`,
+  );
+}
+
+function normalizeTargetKey(raw: string): string | null {
+  return TARGET_KEY_ALIASES[raw.toLowerCase()] ?? null;
+}
+
+function normalizeTargetObject(targets: RuntimeTargetObject): RuntimeTargetObject {
+  const out: RuntimeTargetObject = {};
+  for (const [rawKey, rawValue] of Object.entries(targets)) {
+    const key = normalizeTargetKey(rawKey);
+    if (!key) throw new Error(`@zts/core: unsupported runtime target engine '${rawKey}'.`);
+    out[key] = String(rawValue);
+  }
+  return out;
+}
+
+function mergeTargetObjects(targets: RuntimeTargetObject[]): RuntimeTargetObject {
+  const out: RuntimeTargetObject = {};
+  for (const target of targets) Object.assign(out, target);
+  return out;
+}
+
+function normalizeRuntimeTargetString(raw: string): RuntimeTargetObject | string {
+  const value = raw.trim();
+  assertNotPhysicalDeviceTarget(value);
+
+  const compact = value.match(
+    /^(ios_saf|ios|safari|chrome|android|samsung|hermes|node)\s*v?(\d+(?:\.\d+)*)$/i,
+  );
+  if (compact) {
+    const key = normalizeTargetKey(compact[1]);
+    if (!key) throw new Error(`@zts/core: unsupported runtime target '${raw}'.`);
+    return { [key]: compact[2] };
+  }
+
+  const spaced = value.match(
+    /^(ios_saf|ios|safari|chrome|android|samsung|hermes|react-native|reactnative|node)\s*(?:>=|=)?\s*v?(\d+(?:\.\d+)*)$/i,
+  );
+  if (spaced) {
+    const key = normalizeTargetKey(spaced[1]);
+    if (!key) throw new Error(`@zts/core: unsupported runtime target '${raw}'.`);
+    return { [key]: spaced[2] };
+  }
+
+  return value;
+}
+
+export function normalizeRuntimeTargets(
+  targets: RuntimeTarget | RuntimeTarget[] | RuntimeTargetObject,
+): CoreJsTargets {
+  if (Array.isArray(targets)) {
+    const objectTargets: RuntimeTargetObject[] = [];
+    const queries: string[] = [];
+    for (const target of targets) {
+      const normalized = normalizeRuntimeTargets(target);
+      if (typeof normalized === "string") queries.push(normalized);
+      else if (Array.isArray(normalized)) queries.push(...normalized);
+      else objectTargets.push(normalized);
+    }
+    if (queries.length > 0 && objectTargets.length > 0) {
+      throw new Error(
+        "@zts/core: runtime target arrays cannot mix browserslist queries with Hermes/React Native object targets.",
+      );
+    }
+    if (queries.length > 0) return queries;
+    return mergeTargetObjects(objectTargets);
+  }
+  if (typeof targets === "string") return normalizeRuntimeTargetString(targets);
+  return normalizeTargetObject(targets);
+}
+
+function defaultRuntimeTargets(options: RuntimePolyfillBuildOptions): CoreJsTargets {
+  if (options.platform === "node") {
+    const [major, minor = "0"] = process.versions.node.split(".");
+    return { node: `${major}.${minor}` };
+  }
+  if (options.platform === "react-native") return { hermes: "0.7" };
+  return "defaults";
+}
+
+function chooseRuntimeTargets(
+  options: RuntimePolyfillBuildOptions,
+  runtime: RuntimePolyfillOptions,
+): CoreJsTargets {
+  const raw =
+    runtime.targets ??
+    options.runtimeTargets ??
+    (options.browserslist ? options.browserslist : undefined) ??
+    (!isEsTarget(options.target) && options.target ? options.target : undefined);
+  if (raw !== undefined) return normalizeRuntimeTargets(raw);
+  return defaultRuntimeTargets(options);
+}
+
+function normalizeCoreJsModuleName(raw: string): string {
+  let value = raw.trim();
+  if (value.startsWith("core-js/modules/")) value = value.slice("core-js/modules/".length);
+  if (value.endsWith(".js")) value = value.slice(0, -3);
+  if (!/^(?:es|web)\.[a-z0-9.-]+$/i.test(value)) {
+    throw new Error(
+      `@zts/core: invalid core-js module '${raw}'. Expected e.g. 'es.string.replace-all'.`,
+    );
+  }
+  return value;
+}
+
+export function normalizeRuntimePolyfillOptions(
+  options: RuntimePolyfillBuildOptions,
+): NormalizedRuntimePolyfills | null {
+  const raw = options.runtimePolyfills;
+  if (raw === undefined || raw === "off") return null;
+
+  const runtime: RuntimePolyfillOptions = typeof raw === "string" ? { mode: raw } : { ...raw };
+  const mode = runtime.mode ?? "auto";
+  if (mode !== "auto" && mode !== "usage" && mode !== "entry") {
+    throw new Error("@zts/core: runtimePolyfills.mode must be 'auto', 'usage', or 'entry'.");
+  }
+  const provider = runtime.provider ?? "core-js";
+  if (provider !== "core-js") {
+    throw new Error("@zts/core: runtimePolyfills.provider currently supports only 'core-js'.");
+  }
+
+  return {
+    mode,
+    provider,
+    targets: chooseRuntimeTargets(options, runtime),
+    include: (runtime.include ?? []).map(normalizeCoreJsModuleName),
+    exclude: (runtime.exclude ?? []).map(normalizeCoreJsModuleName),
+    proposals: runtime.proposals === true,
+    coreJsVersion: options.coreJs ?? readInstalledCoreJsVersion(),
+  };
+}
+
+export function computeCoreJsCompatModules(
+  targets: CoreJsTargets,
+  modules: string[] | RegExp,
+  options: { version?: string; proposals?: boolean } = {},
+): string[] {
+  const compat = loadCoreJsCompat();
+  const result = compat({
+    targets,
+    modules,
+    version: options.version,
+    proposals: options.proposals,
+  });
+  return result.list.map(normalizeCoreJsModuleName).sort();
+}
+
+function parseSource(source: string, filename: string): unknown {
+  const parser = loadBabelParser();
+  const baseOptions = {
+    sourceType: "unambiguous",
+    sourceFilename: filename,
+    errorRecovery: true,
+  };
+  try {
+    return parser.parse(source, {
+      ...baseOptions,
+      plugins: [
+        "typescript",
+        "jsx",
+        "classProperties",
+        "classPrivateProperties",
+        "classPrivateMethods",
+        "decorators-legacy",
+        "dynamicImport",
+        "importAttributes",
+        "topLevelAwait",
+      ],
+    });
+  } catch {
+    return parser.parse(source, {
+      ...baseOptions,
+      plugins: [
+        "flow",
+        "jsx",
+        "classProperties",
+        "classPrivateProperties",
+        "classPrivateMethods",
+        "decorators-legacy",
+        "dynamicImport",
+        "importAttributes",
+        "topLevelAwait",
+      ],
+    });
+  }
+}
+
+function isNode(value: unknown): value is Record<string, unknown> {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof (value as { type?: unknown }).type === "string"
+  );
+}
+
+function stringLiteralValue(value: unknown): string | null {
+  if (!isNode(value)) return null;
+  if (value.type === "StringLiteral" || value.type === "Literal") {
+    const raw = value.value;
+    return typeof raw === "string" ? raw : null;
+  }
+  return null;
+}
+
+function memberName(member: Record<string, unknown>): string | null {
+  const property = member.property;
+  if (!isNode(property)) return null;
+  if (property.type === "Identifier" && member.computed !== true) {
+    return typeof property.name === "string" ? property.name : null;
+  }
+  return stringLiteralValue(property);
+}
+
+function identifierName(node: unknown): string | null {
+  return isNode(node) && node.type === "Identifier" && typeof node.name === "string"
+    ? node.name
+    : null;
+}
+
+function recordIdentifierUsage(name: string, out: Set<string>): void {
+  if (name === "Map") out.add("es.map");
+  else if (name === "Set") out.add("es.set");
+  else if (name === "Promise") out.add("es.promise");
+  else if (name === "structuredClone") out.add("web.structured-clone");
+}
+
+function recordMemberUsage(member: Record<string, unknown>, out: Set<string>): void {
+  const prop = memberName(member);
+  if (prop === "replaceAll") out.add("es.string.replace-all");
+  else if (prop === "at") out.add("es.array.at");
+  else if (prop === "hasOwn" && identifierName(member.object) === "Object") {
+    out.add("es.object.has-own");
+  }
+
+  const objName = identifierName(member.object);
+  if (objName) recordIdentifierUsage(objName, out);
+}
+
+function shouldSkipIdentifier(
+  node: Record<string, unknown>,
+  parent: Record<string, unknown> | null,
+): boolean {
+  if (!parent) return false;
+  if (parent.type === "MemberExpression" && parent.property === node && parent.computed !== true)
+    return true;
+  if (parent.type === "ObjectProperty" && parent.key === node && parent.computed !== true)
+    return true;
+  if (parent.type === "ObjectMethod" && parent.key === node && parent.computed !== true)
+    return true;
+  if (parent.type === "VariableDeclarator" && parent.id === node) return true;
+  if (parent.type === "FunctionDeclaration" && parent.id === node) return true;
+  if (parent.type === "FunctionExpression" && parent.id === node) return true;
+  if (parent.type === "ClassDeclaration" && parent.id === node) return true;
+  if (parent.type === "ClassExpression" && parent.id === node) return true;
+  if (parent.type === "ImportSpecifier" || parent.type === "ImportDefaultSpecifier") return true;
+  if (parent.type === "ImportNamespaceSpecifier") return true;
+  return false;
+}
+
+function visitAst(
+  node: unknown,
+  parent: Record<string, unknown> | null,
+  cb: (node: Record<string, unknown>, parent: Record<string, unknown> | null) => void,
+): void {
+  if (!isNode(node)) return;
+  cb(node, parent);
+  for (const [key, value] of Object.entries(node)) {
+    if (
+      key === "loc" ||
+      key === "start" ||
+      key === "end" ||
+      key === "range" ||
+      key === "leadingComments" ||
+      key === "trailingComments" ||
+      key === "innerComments"
+    ) {
+      continue;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) visitAst(item, node, cb);
+    } else {
+      visitAst(value, node, cb);
+    }
+  }
+}
+
+export function scanRuntimePolyfillUsage(source: string, filename = "input.js"): string[] {
+  const ast = parseSource(source, filename);
+  const used = new Set<string>();
+  visitAst(ast, null, (node, parent) => {
+    if (node.type === "MemberExpression") {
+      recordMemberUsage(node, used);
+      return;
+    }
+    if (node.type === "NewExpression" || node.type === "CallExpression") {
+      const name = identifierName(node.callee);
+      if (name) recordIdentifierUsage(name, used);
+      return;
+    }
+    if (node.type === "Identifier" && !shouldSkipIdentifier(node, parent)) {
+      const name = identifierName(node);
+      if (name) recordIdentifierUsage(name, used);
+    }
+  });
+  return [...used].filter((moduleName) => RUNTIME_USAGE_MODULES.has(moduleName)).sort();
+}
+
+function importSpecifiersFromAst(ast: unknown): string[] {
+  const specs: string[] = [];
+  visitAst(ast, null, (node) => {
+    if (
+      (node.type === "ImportDeclaration" ||
+        node.type === "ExportNamedDeclaration" ||
+        node.type === "ExportAllDeclaration") &&
+      node.source
+    ) {
+      const spec = stringLiteralValue(node.source);
+      if (spec) specs.push(spec);
+    }
+    if (node.type === "CallExpression" && identifierName(node.callee) === "require") {
+      const args = Array.isArray(node.arguments) ? node.arguments : [];
+      const spec = stringLiteralValue(args[0]);
+      if (spec) specs.push(spec);
+    }
+  });
+  return specs;
+}
+
+function isRelativeSpecifier(specifier: string): boolean {
+  return specifier.startsWith("./") || specifier.startsWith("../") || isAbsolute(specifier);
+}
+
+function isSourceFile(path: string): boolean {
+  return SOURCE_EXTENSIONS.includes(extname(path));
+}
+
+function tryFile(path: string): string | null {
+  try {
+    if (statSync(path).isFile() && isSourceFile(path)) return path;
+  } catch {}
+  return null;
+}
+
+function resolveSourceImport(
+  importer: string,
+  specifier: string,
+  resolveExtensions: readonly string[] | undefined,
+): string | null {
+  if (!isRelativeSpecifier(specifier)) return null;
+  const base = isAbsolute(specifier) ? specifier : resolve(dirname(importer), specifier);
+  const explicit = tryFile(base);
+  if (explicit) return explicit;
+
+  const extensions = [
+    ...(resolveExtensions?.filter((ext) => SOURCE_EXTENSIONS.includes(ext)) ?? []),
+    ...SOURCE_EXTENSIONS,
+  ];
+  for (const ext of extensions) {
+    const found = tryFile(base + ext);
+    if (found) return found;
+  }
+
+  try {
+    if (statSync(base).isDirectory()) {
+      for (const ext of extensions) {
+        const found = tryFile(join(base, "index" + ext));
+        if (found) return found;
+      }
+    }
+  } catch {}
+  return null;
+}
+
+export function collectRuntimePolyfillUsageFromFiles(
+  entryPoints: readonly string[],
+  options: { resolveExtensions?: readonly string[] } = {},
+): string[] {
+  const queue = entryPoints.map((entry) => resolve(entry));
+  const seen = new Set<string>();
+  const used = new Set<string>();
+
+  while (queue.length > 0) {
+    const file = queue.shift()!;
+    if (seen.has(file) || !existsSync(file) || !isSourceFile(file)) continue;
+    seen.add(file);
+    const source = readFileSync(file, "utf8");
+    for (const moduleName of scanRuntimePolyfillUsage(source, file)) used.add(moduleName);
+
+    const ast = parseSource(source, file);
+    for (const specifier of importSpecifiersFromAst(ast)) {
+      const resolved = resolveSourceImport(file, specifier, options.resolveExtensions);
+      if (resolved && !seen.has(resolved)) queue.push(resolved);
+    }
+  }
+
+  return [...used].sort();
+}
+
+function computeRuntimePolyfillModules(
+  options: RuntimePolyfillBuildOptions,
+  runtime: NormalizedRuntimePolyfills,
+): string[] {
+  const include = new Set(runtime.include);
+  const exclude = new Set(runtime.exclude);
+  let modules: string[];
+
+  if (runtime.mode === "entry") {
+    modules = computeCoreJsCompatModules(runtime.targets, /^(?:es|web)\./, {
+      version: runtime.coreJsVersion,
+      proposals: runtime.proposals,
+    });
+  } else {
+    const used = collectRuntimePolyfillUsageFromFiles(options.entryPoints, {
+      resolveExtensions: options.resolveExtensions,
+    });
+    const unsupportedUsed = computeCoreJsCompatModules(runtime.targets, used, {
+      version: runtime.coreJsVersion,
+      proposals: runtime.proposals,
+    });
+    modules = unsupportedUsed;
+  }
+
+  const out = new Set(modules);
+  for (const moduleName of include) out.add(moduleName);
+  for (const moduleName of exclude) out.delete(moduleName);
+  return [...out].sort();
+}
+
+function resolveCoreJsModule(moduleName: string, entryPoints: readonly string[]): string {
+  const specifier = `core-js/modules/${moduleName}.js`;
+  const errors: string[] = [];
+  const roots = [
+    entryPoints[0] ? resolve(dirname(resolve(entryPoints[0])), "package.json") : null,
+    import.meta.url,
+  ].filter(Boolean) as string[];
+
+  for (const root of roots) {
+    try {
+      const req = createRequire(root);
+      return req.resolve(specifier);
+    } catch (err) {
+      errors.push(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  throw new Error(
+    `@zts/core: runtimePolyfills could not resolve '${specifier}'. Install core-js with \`bun add core-js\`.\n${errors[0] ?? ""}`,
+  );
+}
+
+export function createRuntimePolyfillPrelude(
+  modules: readonly string[],
+  options: RuntimePolyfillBuildOptions,
+): { path: string; cleanup: () => void } | null {
+  if (modules.length === 0) return null;
+  const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfills-"));
+  const path = join(dir, "prelude.mjs");
+  const imports = modules
+    .map((moduleName) => {
+      const resolved = resolveCoreJsModule(moduleName, options.entryPoints);
+      return `import ${JSON.stringify(resolved)};`;
+    })
+    .join("\n");
+  writeFileSync(path, `${imports}\n`, "utf8");
+  return {
+    path,
+    cleanup() {
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+export function applyRuntimePolyfillsToNapiOptions(
+  napiOptions: Record<string, unknown>,
+  options: RuntimePolyfillBuildOptions,
+): { cleanup: () => void; modules: string[] } {
+  delete napiOptions.runtimePolyfills;
+  delete napiOptions.runtimeTargets;
+  delete napiOptions.coreJs;
+
+  if (options.target && !isEsTarget(options.target)) delete napiOptions.target;
+
+  const runtime = normalizeRuntimePolyfillOptions(options);
+  if (!runtime) return { cleanup: () => {}, modules: [] };
+
+  const modules = computeRuntimePolyfillModules(options, runtime);
+  const prelude = createRuntimePolyfillPrelude(modules, options);
+  if (!prelude) return { cleanup: () => {}, modules };
+
+  const existing = Array.isArray(options.runBeforeMain) ? options.runBeforeMain : [];
+  napiOptions.runBeforeMain = [prelude.path, ...existing];
+  return { cleanup: prelude.cleanup, modules };
+}

--- a/packages/core/src/runtime-polyfills.ts
+++ b/packages/core/src/runtime-polyfills.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, extname, isAbsolute, join, resolve } from "node:path";
@@ -113,16 +113,6 @@ const ES_TARGETS = new Set([
 
 const DEVICE_TARGET_RE =
   /\b(?:iphone|ipad|ipod|galaxy|pixel|nexus|oneplus|xiaomi|redmi|huawei|motorola|moto)\b/i;
-
-const RUNTIME_USAGE_MODULES = new Set([
-  "es.array.at",
-  "es.map",
-  "es.object.has-own",
-  "es.promise",
-  "es.set",
-  "es.string.replace-all",
-  "web.structured-clone",
-]);
 
 const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"];
 
@@ -448,9 +438,9 @@ function visitAst(
   }
 }
 
-export function scanRuntimePolyfillUsage(source: string, filename = "input.js"): string[] {
-  const ast = parseSource(source, filename);
+function scanAst(ast: unknown): { used: Set<string>; specifiers: string[] } {
   const used = new Set<string>();
+  const specifiers: string[] = [];
   visitAst(ast, null, (node, parent) => {
     if (node.type === "MemberExpression") {
       recordMemberUsage(node, used);
@@ -459,19 +449,18 @@ export function scanRuntimePolyfillUsage(source: string, filename = "input.js"):
     if (node.type === "NewExpression" || node.type === "CallExpression") {
       const name = identifierName(node.callee);
       if (name) recordIdentifierUsage(name, used);
+      if (node.type === "CallExpression" && name === "require") {
+        const args = Array.isArray(node.arguments) ? node.arguments : [];
+        const spec = stringLiteralValue(args[0]);
+        if (spec) specifiers.push(spec);
+      }
       return;
     }
     if (node.type === "Identifier" && !shouldSkipIdentifier(node, parent)) {
       const name = identifierName(node);
       if (name) recordIdentifierUsage(name, used);
+      return;
     }
-  });
-  return [...used].filter((moduleName) => RUNTIME_USAGE_MODULES.has(moduleName)).sort();
-}
-
-function importSpecifiersFromAst(ast: unknown): string[] {
-  const specs: string[] = [];
-  visitAst(ast, null, (node) => {
     if (
       (node.type === "ImportDeclaration" ||
         node.type === "ExportNamedDeclaration" ||
@@ -479,15 +468,15 @@ function importSpecifiersFromAst(ast: unknown): string[] {
       node.source
     ) {
       const spec = stringLiteralValue(node.source);
-      if (spec) specs.push(spec);
-    }
-    if (node.type === "CallExpression" && identifierName(node.callee) === "require") {
-      const args = Array.isArray(node.arguments) ? node.arguments : [];
-      const spec = stringLiteralValue(args[0]);
-      if (spec) specs.push(spec);
+      if (spec) specifiers.push(spec);
     }
   });
-  return specs;
+  return { used, specifiers };
+}
+
+export function scanRuntimePolyfillUsage(source: string, filename = "input.js"): string[] {
+  const { used } = scanAst(parseSource(source, filename));
+  return [...used].sort();
 }
 
 function isRelativeSpecifier(specifier: string): boolean {
@@ -543,15 +532,19 @@ export function collectRuntimePolyfillUsageFromFiles(
   const seen = new Set<string>();
   const used = new Set<string>();
 
-  while (queue.length > 0) {
-    const file = queue.shift()!;
-    if (seen.has(file) || !existsSync(file) || !isSourceFile(file)) continue;
+  for (let head = 0; head < queue.length; head++) {
+    const file = queue[head]!;
+    if (seen.has(file) || !isSourceFile(file)) continue;
+    let source: string;
+    try {
+      source = readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
     seen.add(file);
-    const source = readFileSync(file, "utf8");
-    for (const moduleName of scanRuntimePolyfillUsage(source, file)) used.add(moduleName);
-
-    const ast = parseSource(source, file);
-    for (const specifier of importSpecifiersFromAst(ast)) {
+    const { used: fileUsed, specifiers } = scanAst(parseSource(source, file));
+    for (const moduleName of fileUsed) used.add(moduleName);
+    for (const specifier of specifiers) {
       const resolved = resolveSourceImport(file, specifier, options.resolveExtensions);
       if (resolved && !seen.has(resolved)) queue.push(resolved);
     }
@@ -577,11 +570,10 @@ function computeRuntimePolyfillModules(
     const used = collectRuntimePolyfillUsageFromFiles(options.entryPoints, {
       resolveExtensions: options.resolveExtensions,
     });
-    const unsupportedUsed = computeCoreJsCompatModules(runtime.targets, used, {
+    modules = computeCoreJsCompatModules(runtime.targets, used, {
       version: runtime.coreJsVersion,
       proposals: runtime.proposals,
     });
-    modules = unsupportedUsed;
   }
 
   const out = new Set(modules);
@@ -590,26 +582,30 @@ function computeRuntimePolyfillModules(
   return [...out].sort();
 }
 
-function resolveCoreJsModule(moduleName: string, entryPoints: readonly string[]): string {
-  const specifier = `core-js/modules/${moduleName}.js`;
-  const errors: string[] = [];
-  const roots = [
-    entryPoints[0] ? resolve(dirname(resolve(entryPoints[0])), "package.json") : null,
-    import.meta.url,
-  ].filter(Boolean) as string[];
-
-  for (const root of roots) {
-    try {
-      const req = createRequire(root);
-      return req.resolve(specifier);
-    } catch (err) {
-      errors.push(err instanceof Error ? err.message : String(err));
-    }
+function buildCoreJsResolver(entryPoints: readonly string[]): (moduleName: string) => string {
+  const override = runtimeRequireOverride;
+  const requires: RuntimeRequire[] = [];
+  if (override) {
+    requires.push(override);
+  } else {
+    const entry = entryPoints[0];
+    if (entry) requires.push(createRequire(resolve(dirname(resolve(entry)), "package.json")));
+    requires.push(createRequire(import.meta.url));
   }
-
-  throw new Error(
-    `@zts/core: runtimePolyfills could not resolve '${specifier}'. Install core-js with \`bun add core-js\`.\n${errors[0] ?? ""}`,
-  );
+  return (moduleName: string) => {
+    const specifier = `core-js/modules/${moduleName}.js`;
+    let firstError: string | undefined;
+    for (const req of requires) {
+      try {
+        return req.resolve(specifier);
+      } catch (err) {
+        firstError ??= err instanceof Error ? err.message : String(err);
+      }
+    }
+    throw new Error(
+      `@zts/core: runtimePolyfills could not resolve '${specifier}'. Install core-js with \`bun add core-js\`.\n${firstError ?? ""}`,
+    );
+  };
 }
 
 export function createRuntimePolyfillPrelude(
@@ -617,13 +613,11 @@ export function createRuntimePolyfillPrelude(
   options: RuntimePolyfillBuildOptions,
 ): { path: string; cleanup: () => void } | null {
   if (modules.length === 0) return null;
+  const resolveCoreJs = buildCoreJsResolver(options.entryPoints);
   const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfills-"));
   const path = join(dir, "prelude.mjs");
   const imports = modules
-    .map((moduleName) => {
-      const resolved = resolveCoreJsModule(moduleName, options.entryPoints);
-      return `import ${JSON.stringify(resolved)};`;
-    })
+    .map((moduleName) => `import ${JSON.stringify(resolveCoreJs(moduleName))};`)
     .join("\n");
   writeFileSync(path, `${imports}\n`, "utf8");
   return {

--- a/packages/core/src/typo-suggest.ts
+++ b/packages/core/src/typo-suggest.ts
@@ -109,6 +109,9 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   "platform",
   "target",
   "browserslist",
+  "runtimePolyfills",
+  "runtimeTargets",
+  "coreJs",
   // ─── JSX ───
   "jsx",
   "jsxDev",

--- a/packages/core/src/typo-suggest.ts
+++ b/packages/core/src/typo-suggest.ts
@@ -110,7 +110,6 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   "target",
   "browserslist",
   "runtimePolyfills",
-  "runtimeTargets",
   "coreJs",
   // ─── JSX ───
   "jsx",

--- a/packages/core/types.test.ts
+++ b/packages/core/types.test.ts
@@ -35,18 +35,17 @@ describe("@zts/core TypeScript declaration", () => {
     }
   });
 
-  test("runtime polyfill 타입은 nested targets 자동완성을 제공하고 top-level runtimeTargets는 노출하지 않음", () => {
+  test("runtime polyfill 타입은 Rspack/SWC targets 형태를 제공하고 top-level runtimeTargets는 노출하지 않음", () => {
     const dts = readFileSync(join(DIST, "core/index.d.ts"), "utf8");
     const runtimeDts = readFileSync(join(DIST, "core/src/runtime-polyfills.d.ts"), "utf8");
     expect(dts).toContain("runtimePolyfills?: RuntimePolyfillsOption");
     expect(dts).toContain("coreJs?: string");
     expect(dts).not.toContain("runtimeTargets?:");
     expect(runtimeDts).toContain("export interface RuntimePolyfillOptions");
-    expect(runtimeDts).toContain("export type RuntimeTarget =");
-    expect(runtimeDts).toContain('"hermes"');
-    expect(runtimeDts).toContain('"react-native"');
-    expect(runtimeDts).toContain("`${RuntimeTargetCompactName}${RuntimeTargetVersion}`");
-    expect(runtimeDts).toContain("targets?: RuntimeTarget | RuntimeTarget[] | RuntimeTargetObject");
+    expect(runtimeDts).not.toContain("export type RuntimeTarget =");
+    expect(runtimeDts).not.toContain("RuntimeTargetObject");
+    expect(runtimeDts).toContain("targets?: string | string[]");
+    expect(runtimeDts).toContain("coreJs?: string");
   });
 
   test("TranspileOptions가 browserslist 필드 포함", () => {

--- a/packages/core/types.test.ts
+++ b/packages/core/types.test.ts
@@ -35,6 +35,20 @@ describe("@zts/core TypeScript declaration", () => {
     }
   });
 
+  test("runtime polyfill 타입은 nested targets 자동완성을 제공하고 top-level runtimeTargets는 노출하지 않음", () => {
+    const dts = readFileSync(join(DIST, "core/index.d.ts"), "utf8");
+    const runtimeDts = readFileSync(join(DIST, "core/src/runtime-polyfills.d.ts"), "utf8");
+    expect(dts).toContain("runtimePolyfills?: RuntimePolyfillsOption");
+    expect(dts).toContain("coreJs?: string");
+    expect(dts).not.toContain("runtimeTargets?:");
+    expect(runtimeDts).toContain("export interface RuntimePolyfillOptions");
+    expect(runtimeDts).toContain("export type RuntimeTarget =");
+    expect(runtimeDts).toContain('"hermes"');
+    expect(runtimeDts).toContain('"react-native"');
+    expect(runtimeDts).toContain("`${RuntimeTargetCompactName}${RuntimeTargetVersion}`");
+    expect(runtimeDts).toContain("targets?: RuntimeTarget | RuntimeTarget[] | RuntimeTargetObject");
+  });
+
   test("TranspileOptions가 browserslist 필드 포함", () => {
     const dts = readFileSync(join(DIST, "shared/index.d.ts"), "utf8");
     expect(dts).toContain("browserslist");

--- a/scripts/check-runtime-polyfill-coverage.mjs
+++ b/scripts/check-runtime-polyfill-coverage.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env bun
+import { spawnSync } from "node:child_process";
+import { readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const coverageDir = join(tmpdir(), `zts-runtime-polyfill-coverage-${process.pid}`);
+rmSync(coverageDir, { recursive: true, force: true });
+
+const test = spawnSync(
+  "bun",
+  [
+    "test",
+    "--coverage",
+    "--coverage-reporter=lcov",
+    `--coverage-dir=${coverageDir}`,
+    "packages/core/src/runtime-polyfills.test.ts",
+  ],
+  { stdio: "inherit" },
+);
+
+if (test.status !== 0) process.exit(test.status ?? 1);
+
+const lcov = readFileSync(join(coverageDir, "lcov.info"), "utf8");
+rmSync(coverageDir, { recursive: true, force: true });
+
+const record = lcov
+  .split("end_of_record")
+  .find((entry) => entry.includes("SF:packages/core/src/runtime-polyfills.ts"));
+
+if (!record) {
+  console.error("runtime-polyfills coverage record not found");
+  process.exit(1);
+}
+
+function numberField(name) {
+  const match = record.match(new RegExp(`^${name}:(\\d+)`, "m"));
+  return match ? Number(match[1]) : null;
+}
+
+const checks = [
+  ["line", numberField("LH"), numberField("LF")],
+  ["function", numberField("FNH"), numberField("FNF")],
+];
+
+const branchHit = numberField("BRH");
+const branchFound = numberField("BRF");
+if (branchHit !== null || branchFound !== null) checks.push(["branch", branchHit, branchFound]);
+
+let failed = false;
+for (const [name, hit, found] of checks) {
+  if (hit === null || found === null || hit !== found) {
+    console.error(`runtime-polyfills ${name} coverage is not 100%: ${hit ?? 0}/${found ?? 0}`);
+    failed = true;
+  }
+}
+
+if (failed) process.exit(1);
+console.log("runtime-polyfills coverage: 100% line/function coverage");

--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -1180,6 +1180,50 @@ test "TreeShaking: side-effect-only import preserved" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "myPolyfill") != null);
 }
 
+test "TreeShaking: side-effect-only CJS import emits require call" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.mjs", "import './cjs.js';\nconsole.log('entry');");
+    try writeFile(tmp.dir, "cjs.js", "module.exports = {}; globalThis.cjsSideEffectImport = true;");
+
+    const entry = try absPath(&tmp, "entry.mjs");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "cjsSideEffectImport") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require_cjs();") != null);
+}
+
+test "TreeShaking: runBeforeMain import-only root preserves side-effect dependency" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "console.log('entry');");
+    try writeFile(tmp.dir, "prelude.ts", "import './polyfill';");
+    try writeFile(tmp.dir, "polyfill.ts", "globalThis.runBeforeMainPolyfill = true;");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    const prelude = try absPath(&tmp, "prelude.ts");
+    defer std.testing.allocator.free(prelude);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .run_before_main = &.{prelude},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "runBeforeMainPolyfill") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "init_prelude") == null);
+}
+
 test "TreeShaking CJS: named import prunes unused exports dot assignment" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1290,6 +1290,7 @@ pub fn appendIndented(wrapped: *std.ArrayList(u8), allocator: std.mem.Allocator,
 /// 모듈의 wrap_kind에 따라 require_xxx() 또는 init_xxx() 호출 코드를 생성한다.
 /// run-before-main, 엔트리 자동 호출, star export init 등에서 공용.
 pub fn appendModuleCall(output: *std.ArrayList(u8), allocator: std.mem.Allocator, mod: anytype) !void {
+    if (!mod.wrap_kind.isWrapped()) return;
     const call_name = if (mod.wrap_kind == .cjs)
         try mod.allocRequireName(allocator)
     else

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -699,6 +699,47 @@ pub fn buildMetadataForAst(
         mergeUnifiedPhaseB(self, module_index, &renames, &owned_nested_renames) catch {};
     }
 
+    // Side-effect-only import has no ImportBinding, so scope-hoisted modules that
+    // skip raw import declarations still need an explicit evaluation preamble for
+    // wrapped targets.
+    if (!m.wrap_kind.isWrapped()) {
+        for (m.import_records) |rec| {
+            if (rec.kind != .side_effect) continue;
+            if (rec.resolved.isNone()) continue;
+            const target_mod = self.graph.getModule(rec.resolved) orelse continue;
+            if (self.tree_shaker_active and !target_mod.is_included) continue;
+
+            switch (target_mod.wrap_kind) {
+                .none => {},
+                .cjs => {
+                    const req_var = try getOrCreateRequireVar(self, &cjs_var_cache, @intCast(@intFromEnum(rec.resolved)));
+                    try preamble.write(req_var);
+                    try preamble.write("();\n");
+                },
+                .esm => {
+                    const target = @intFromEnum(rec.resolved);
+                    if (esm_init_set.contains(@intCast(target))) continue;
+                    try esm_init_set.put(@intCast(target), {});
+                    const is_tla = target_mod.uses_top_level_await;
+                    const guard = target_mod.shouldGuard(self.entry_error_guard);
+                    if (is_tla) try preamble.write("await ");
+                    if (guard) try preamble.write(if (self.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN);
+                    if (self.dev_mode) {
+                        try preamble.write("__zts_modules[\"");
+                        try preamble.write(target_mod.dev_id);
+                        try preamble.write("\"].fn()");
+                    } else {
+                        const init_name = try target_mod.allocInitName(self.allocator);
+                        defer self.allocator.free(init_name);
+                        try preamble.write(init_name);
+                        try preamble.write("()");
+                    }
+                    try preamble.write(if (guard) rt.GUARD_LAMBDA_CLOSE else rt.INIT_CALL_END);
+                },
+            }
+        }
+    }
+
     // CJS import preamble 저장
     const cjs_import_preamble = try preamble.toOwned();
 

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -544,11 +544,21 @@ pub const TreeShaker = struct {
         }
         self.re_export_star_targets = re_star_targets;
 
-        // entry_set 먼저 계산 (자동 순수 판별에서 진입점 제외용)
+        // entry_set 먼저 계산 (자동 순수 판별에서 진입점 제외용).
+        // `graph.inject_files` includes both user `inject` and `runBeforeMain`.
+        // They are not output entries, but they are execution roots and may be
+        // import-only prelude modules.
         for (0..mod_count) |i| {
             const m = self.getModule(@intCast(i)) orelse continue;
             for (entry_points) |ep| {
                 if (std.mem.eql(u8, m.path, ep)) {
+                    self.entry_set.set(i);
+                    break;
+                }
+            }
+            if (self.entry_set.isSet(i)) continue;
+            for (self.graph.inject_files) |inject_path| {
+                if (std.mem.eql(u8, m.path, inject_path)) {
                     self.entry_set.set(i);
                     break;
                 }

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -2947,6 +2947,92 @@ test "ES5: compound assignment +/while await RHS preserves operator (#1896)" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "sum=_state.sent()") == null);
 }
 
+test "ES5: async method state machine captures this for nested arrows" {
+    var r = try e2eES5Async(std.testing.allocator,
+        \\class QueryLike {
+        \\  constructor() { this.value = 42; }
+        \\  async fetch() {
+        \\    const createContext = () => ({ value: this.value });
+        \\    const context = createContext();
+        \\    return context.value;
+        \\  }
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var _this=this") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "value:_this.value") != null);
+}
+
+test "ES5: Babel async-to-generator fixture async-arrow-in-method captures lexical this" {
+    var r = try e2eES5Async(std.testing.allocator,
+        \\let TestClass = {
+        \\  name: "John Doe",
+        \\  testMethodFailure() {
+        \\    return new Promise(async (resolve) => {
+        \\      console.log(this);
+        \\      setTimeout(resolve, 1000);
+        \\    });
+        \\  }
+        \\};
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var _this=this") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "console.log(_this)") != null);
+}
+
+test "ES5: Babel async-to-generator fixture object-method-with-arrows keeps function boundaries" {
+    var r = try e2eES5Async(std.testing.allocator,
+        \\class Class {
+        \\  async method() {
+        \\    this;
+        \\    () => this;
+        \\    () => {
+        \\      this;
+        \\      () => this;
+        \\      function x() {
+        \\        this;
+        \\        () => { this; }
+        \\        async () => { this; }
+        \\      }
+        \\    }
+        \\    function x() {
+        \\      this;
+        \\      () => { this; }
+        \\      async () => { this; }
+        \\    }
+        \\  }
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var _this=this") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_this;") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var _arguments=arguments") == null);
+}
+
+test "ES5: Babel async-to-generator fixture deeply-nested-asyncs captures this and arguments" {
+    var r = try e2eES5Async(std.testing.allocator,
+        \\async function s(x, ...args) {
+        \\  let t = async (y, a) => {
+        \\    let r = async (z, b, ...innerArgs) =>  {
+        \\      await z;
+        \\      console.log(this, innerArgs, arguments);
+        \\      return this.x;
+        \\    }
+        \\    await r();
+        \\    console.log(this, args, arguments);
+        \\    return this.g(r);
+        \\  }
+        \\  await t();
+        \\  return this.h(t);
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var _this=this") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var _arguments=arguments") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "console.log(_this") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_arguments)") != null);
+}
+
 test "ES5: for-await-of hoists loop var to function top (#1901)" {
     // `for await (var v of arr)` 의 `var v` 가 함수 top 에 hoist 안 되면 strict mode
     // 에서 `v is not defined` throw. Babel/TS 는 함수 top 에 모든 var (loop binding +

--- a/src/codegen/codegen_test/private_jsx_advanced.zig
+++ b/src/codegen/codegen_test/private_jsx_advanced.zig
@@ -1107,6 +1107,28 @@ test "#1278-1: standalone _method_fn 내부의 this.#field가 WeakMap get으로 
     try std.testing.expect(std.mem.indexOf(u8, r.output, "this.#field") == null);
 }
 
+test "ES5: standalone private method captures this for nested arrows" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\function batch(fn) { fn(); }
+        \\class Foo {
+        \\  constructor() {
+        \\    this.listeners = [listener => listener(this)];
+        \\  }
+        \\  #notify() {
+        \\    batch(() => {
+        \\      this.listeners.forEach((listener) => listener(this));
+        \\    });
+        \\  }
+        \\  run() { this.#notify(); }
+        \\}
+        \\new Foo().run();
+    , .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function _notify_fn()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var _this=this") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_this.listeners.forEach") != null);
+}
+
 // ES2022 Ergonomic Brand Checks: #x in obj
 // ================================================================
 // Spec: https://tc39.es/ecma262/#sec-relational-operators

--- a/src/config_options_dto_test.zig
+++ b/src/config_options_dto_test.zig
@@ -214,7 +214,6 @@ const ts_buildoptions_only_allowlist = [_][]const u8{
     "target",
     "browserslist",
     "runtimePolyfills", // JS wrapper가 core-js prelude 로 변환 후 runBeforeMain 으로 전달
-    "runtimeTargets", // runtimePolyfills 전용 core-js-compat 타겟
     "coreJs", // runtimePolyfills 전용 core-js 버전 힌트
     "plugins",
     "compiler", // 1st-party transform 네임스페이스 (compiler.styledComponents/emotion).

--- a/src/config_options_dto_test.zig
+++ b/src/config_options_dto_test.zig
@@ -213,6 +213,9 @@ const ts_buildoptions_only_allowlist = [_][]const u8{
     "platform", // discriminated union 으로 처리됨
     "target",
     "browserslist",
+    "runtimePolyfills", // JS wrapper가 core-js prelude 로 변환 후 runBeforeMain 으로 전달
+    "runtimeTargets", // runtimePolyfills 전용 core-js-compat 타겟
+    "coreJs", // runtimePolyfills 전용 core-js 버전 힌트
     "plugins",
     "compiler", // 1st-party transform 네임스페이스 (compiler.styledComponents/emotion).
     // 현재 stub — Zig transformer 가 아직 인식하지 않음. 후속 PR 에서 styled-components /

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -3274,28 +3274,11 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 const GenMod = @import("es2015_generator.zig").ES2015Generator(@TypeOf(self.*));
 
                 if (self.options.unsupported.generator) {
-                    // Class lowering builds the method function expression directly,
-                    // bypassing visitMethodBodyWithCtx(), so mirror its arrow
-                    // capture environment before the state-machine pass visits body.
-                    const saved_arrow_depth = self.arrow_this_depth;
-                    const saved_needs_this = self.needs_this_var;
-                    const saved_needs_args = self.needs_arguments_var;
-                    const saved_super_alias = self.super_call_this_alias;
-                    self.arrow_this_depth = 0;
-                    self.needs_this_var = false;
-                    self.needs_arguments_var = false;
-                    self.super_call_this_alias = false;
-                    defer {
-                        self.arrow_this_depth = saved_arrow_depth;
-                        self.needs_this_var = saved_needs_this;
-                        self.needs_arguments_var = saved_needs_args;
-                        self.super_call_this_alias = saved_super_alias;
-                    }
+                    const arrow_env = es_helpers.pushArrowEnv(self);
+                    defer es_helpers.popArrowEnv(self, arrow_env);
 
                     const sm_result = try GenMod.buildStateMachine(self, body_idx, span);
                     if (!sm_result.body.isNone()) {
-                        const needs_this_capture = self.options.unsupported.arrow and self.needs_this_var;
-                        const needs_arguments_capture = self.options.unsupported.arrow and self.needs_arguments_var;
                         const gen_call = try GenMod.buildGeneratorHelperCall(self, sm_result.body, span);
                         const gen_wrapper = try es_helpers.wrapInFunction(self, gen_call, span);
                         const async_call = try es_helpers.buildAsyncHelperCall(self, gen_wrapper, span);
@@ -3305,8 +3288,6 @@ pub fn ES2015Class(comptime Transformer: type) type {
                             sm_result.var_decl,
                             new_params,
                             span,
-                            needs_this_capture,
-                            needs_arguments_capture,
                         );
                         return buildMethodAssignment(self, info, class_name_span, key_idx, func_expr, span);
                     }
@@ -3314,7 +3295,7 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 const method_nt: ?Transformer.NewTargetCtx = if (self.options.unsupported.new_target) .method else null;
                 const gen_wrapper = try es_helpers.buildGeneratorWrapper(self, try visitMethodBodyWithCtx(self, body_idx, span, method_nt), span);
                 const async_call = try es_helpers.buildAsyncHelperCall(self, gen_wrapper, span);
-                const func_expr = try buildWrappedFunc(self, async_call, .none, new_params, span, false, false);
+                const func_expr = try buildWrappedFunc(self, async_call, .none, new_params, span);
                 return buildMethodAssignment(self, info, class_name_span, key_idx, func_expr, span);
             }
 
@@ -3348,14 +3329,14 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
         /// return call_expr 를 body로 하는 function expression 생성.
         /// var_decl이 있으면 body 앞에 추가 (hoisted vars).
+        /// arrow lowering 결과 `_this`/`_arguments` 캡처가 필요하면 호출자가 미리
+        /// arrow env 스코프 안에서 needs_this_var/needs_arguments_var 가 set 되도록 한다.
         fn buildWrappedFunc(
             self: *Transformer,
             call_expr: NodeIndex,
             var_decl: NodeIndex,
             params: ast_mod.NodeList,
             span: Span,
-            needs_this_capture: bool,
-            needs_arguments_capture: bool,
         ) Transformer.Error!NodeIndex {
             const return_stmt = try self.ast.addNode(.{
                 .tag = .return_statement,
@@ -3365,22 +3346,10 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const scratch_top = self.scratch.items.len;
             defer self.scratch.shrinkRetainingCapacity(scratch_top);
 
-            if (needs_this_capture) {
-                const this_init = try self.ast.addNode(.{
-                    .tag = .this_expression,
-                    .span = span,
-                    .data = .{ .none = 0 },
-                });
-                try self.scratch.append(self.allocator, try self.buildVarDecl("_this", this_init, span));
-            }
-            if (needs_arguments_capture) {
-                const args_span = try self.ast.addString("arguments");
-                const args_init = try self.ast.addNode(.{
-                    .tag = .identifier_reference,
-                    .span = args_span,
-                    .data = .{ .string_ref = args_span },
-                });
-                try self.scratch.append(self.allocator, try self.buildVarDecl("_arguments", args_init, span));
+            if (self.options.unsupported.arrow) {
+                var capture_stmts: [2]NodeIndex = undefined;
+                const count = try es_helpers.fillThisArgumentsCaptures(self, &capture_stmts, span);
+                try self.scratch.appendSlice(self.allocator, capture_stmts[0..count]);
             }
             if (!var_decl.isNone()) try self.scratch.append(self.allocator, var_decl);
             try self.scratch.append(self.allocator, return_stmt);

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -3274,19 +3274,47 @@ pub fn ES2015Class(comptime Transformer: type) type {
                 const GenMod = @import("es2015_generator.zig").ES2015Generator(@TypeOf(self.*));
 
                 if (self.options.unsupported.generator) {
+                    // Class lowering builds the method function expression directly,
+                    // bypassing visitMethodBodyWithCtx(), so mirror its arrow
+                    // capture environment before the state-machine pass visits body.
+                    const saved_arrow_depth = self.arrow_this_depth;
+                    const saved_needs_this = self.needs_this_var;
+                    const saved_needs_args = self.needs_arguments_var;
+                    const saved_super_alias = self.super_call_this_alias;
+                    self.arrow_this_depth = 0;
+                    self.needs_this_var = false;
+                    self.needs_arguments_var = false;
+                    self.super_call_this_alias = false;
+                    defer {
+                        self.arrow_this_depth = saved_arrow_depth;
+                        self.needs_this_var = saved_needs_this;
+                        self.needs_arguments_var = saved_needs_args;
+                        self.super_call_this_alias = saved_super_alias;
+                    }
+
                     const sm_result = try GenMod.buildStateMachine(self, body_idx, span);
                     if (!sm_result.body.isNone()) {
+                        const needs_this_capture = self.options.unsupported.arrow and self.needs_this_var;
+                        const needs_arguments_capture = self.options.unsupported.arrow and self.needs_arguments_var;
                         const gen_call = try GenMod.buildGeneratorHelperCall(self, sm_result.body, span);
                         const gen_wrapper = try es_helpers.wrapInFunction(self, gen_call, span);
                         const async_call = try es_helpers.buildAsyncHelperCall(self, gen_wrapper, span);
-                        const func_expr = try buildWrappedFunc(self, async_call, sm_result.var_decl, new_params, span);
+                        const func_expr = try buildWrappedFunc(
+                            self,
+                            async_call,
+                            sm_result.var_decl,
+                            new_params,
+                            span,
+                            needs_this_capture,
+                            needs_arguments_capture,
+                        );
                         return buildMethodAssignment(self, info, class_name_span, key_idx, func_expr, span);
                     }
                 }
                 const method_nt: ?Transformer.NewTargetCtx = if (self.options.unsupported.new_target) .method else null;
                 const gen_wrapper = try es_helpers.buildGeneratorWrapper(self, try visitMethodBodyWithCtx(self, body_idx, span, method_nt), span);
                 const async_call = try es_helpers.buildAsyncHelperCall(self, gen_wrapper, span);
-                const func_expr = try buildWrappedFunc(self, async_call, .none, new_params, span);
+                const func_expr = try buildWrappedFunc(self, async_call, .none, new_params, span, false, false);
                 return buildMethodAssignment(self, info, class_name_span, key_idx, func_expr, span);
             }
 
@@ -3320,16 +3348,44 @@ pub fn ES2015Class(comptime Transformer: type) type {
 
         /// return call_expr 를 body로 하는 function expression 생성.
         /// var_decl이 있으면 body 앞에 추가 (hoisted vars).
-        fn buildWrappedFunc(self: *Transformer, call_expr: NodeIndex, var_decl: NodeIndex, params: ast_mod.NodeList, span: Span) Transformer.Error!NodeIndex {
+        fn buildWrappedFunc(
+            self: *Transformer,
+            call_expr: NodeIndex,
+            var_decl: NodeIndex,
+            params: ast_mod.NodeList,
+            span: Span,
+            needs_this_capture: bool,
+            needs_arguments_capture: bool,
+        ) Transformer.Error!NodeIndex {
             const return_stmt = try self.ast.addNode(.{
                 .tag = .return_statement,
                 .span = span,
                 .data = .{ .unary = .{ .operand = call_expr, .flags = 0 } },
             });
-            const body_list = if (var_decl.isNone())
-                try self.ast.addNodeList(&.{return_stmt})
-            else
-                try self.ast.addNodeList(&.{ var_decl, return_stmt });
+            const scratch_top = self.scratch.items.len;
+            defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+            if (needs_this_capture) {
+                const this_init = try self.ast.addNode(.{
+                    .tag = .this_expression,
+                    .span = span,
+                    .data = .{ .none = 0 },
+                });
+                try self.scratch.append(self.allocator, try self.buildVarDecl("_this", this_init, span));
+            }
+            if (needs_arguments_capture) {
+                const args_span = try self.ast.addString("arguments");
+                const args_init = try self.ast.addNode(.{
+                    .tag = .identifier_reference,
+                    .span = args_span,
+                    .data = .{ .string_ref = args_span },
+                });
+                try self.scratch.append(self.allocator, try self.buildVarDecl("_arguments", args_init, span));
+            }
+            if (!var_decl.isNone()) try self.scratch.append(self.allocator, var_decl);
+            try self.scratch.append(self.allocator, return_stmt);
+
+            const body_list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
             const wrapper_body = try self.ast.addNode(.{
                 .tag = .block_statement,
                 .span = span,

--- a/src/transformer/es2017.zig
+++ b/src/transformer/es2017.zig
@@ -251,22 +251,8 @@ pub fn ES2017(comptime Transformer: type) type {
             const body_idx: NodeIndex = self.readNodeIdx(e, 2);
             const flags = self.readU32(e, ast_mod.FunctionExtra.flags);
 
-            // This path bypasses visitFunction(), so it must provide the same
-            // function-level lexical environment for arrows inside params/body.
-            const saved_arrow_depth = self.arrow_this_depth;
-            const saved_needs_this = self.needs_this_var;
-            const saved_needs_args = self.needs_arguments_var;
-            const saved_super_alias = self.super_call_this_alias;
-            self.arrow_this_depth = 0;
-            self.needs_this_var = false;
-            self.needs_arguments_var = false;
-            self.super_call_this_alias = false;
-            defer {
-                self.arrow_this_depth = saved_arrow_depth;
-                self.needs_this_var = saved_needs_this;
-                self.needs_arguments_var = saved_needs_args;
-                self.super_call_this_alias = saved_super_alias;
-            }
+            const arrow_env = es_helpers.pushArrowEnv(self);
+            defer es_helpers.popArrowEnv(self, arrow_env);
 
             const new_name = try self.visitNode(name_idx);
 
@@ -297,27 +283,10 @@ pub fn ES2017(comptime Transformer: type) type {
             const body_list = blk: {
                 const scratch_top = self.scratch.items.len;
                 defer self.scratch.shrinkRetainingCapacity(scratch_top);
-                const needs_this_capture = self.options.unsupported.arrow and self.needs_this_var;
-                const needs_arguments_capture = self.options.unsupported.arrow and self.needs_arguments_var;
-
-                if (needs_this_capture or needs_arguments_capture) {
-                    if (needs_this_capture) {
-                        const this_init = try self.ast.addNode(.{
-                            .tag = .this_expression,
-                            .span = span,
-                            .data = .{ .none = 0 },
-                        });
-                        try self.scratch.append(self.allocator, try self.buildVarDecl("_this", this_init, span));
-                    }
-                    if (needs_arguments_capture) {
-                        const args_span = try self.ast.addString("arguments");
-                        const args_init = try self.ast.addNode(.{
-                            .tag = .identifier_reference,
-                            .span = args_span,
-                            .data = .{ .string_ref = args_span },
-                        });
-                        try self.scratch.append(self.allocator, try self.buildVarDecl("_arguments", args_init, span));
-                    }
+                if (self.options.unsupported.arrow) {
+                    var capture_stmts: [2]NodeIndex = undefined;
+                    const count = try es_helpers.fillThisArgumentsCaptures(self, &capture_stmts, span);
+                    try self.scratch.appendSlice(self.allocator, capture_stmts[0..count]);
                 }
                 if (!sm_result.var_decl.isNone()) try self.scratch.append(self.allocator, sm_result.var_decl);
                 try self.scratch.append(self.allocator, return_stmt);

--- a/src/transformer/es2017.zig
+++ b/src/transformer/es2017.zig
@@ -251,6 +251,23 @@ pub fn ES2017(comptime Transformer: type) type {
             const body_idx: NodeIndex = self.readNodeIdx(e, 2);
             const flags = self.readU32(e, ast_mod.FunctionExtra.flags);
 
+            // This path bypasses visitFunction(), so it must provide the same
+            // function-level lexical environment for arrows inside params/body.
+            const saved_arrow_depth = self.arrow_this_depth;
+            const saved_needs_this = self.needs_this_var;
+            const saved_needs_args = self.needs_arguments_var;
+            const saved_super_alias = self.super_call_this_alias;
+            self.arrow_this_depth = 0;
+            self.needs_this_var = false;
+            self.needs_arguments_var = false;
+            self.super_call_this_alias = false;
+            defer {
+                self.arrow_this_depth = saved_arrow_depth;
+                self.needs_this_var = saved_needs_this;
+                self.needs_arguments_var = saved_needs_args;
+                self.super_call_this_alias = saved_super_alias;
+            }
+
             const new_name = try self.visitNode(name_idx);
 
             const new_params = try self.visitExtraList(.{ .start = params_start, .len = params_len });
@@ -280,6 +297,28 @@ pub fn ES2017(comptime Transformer: type) type {
             const body_list = blk: {
                 const scratch_top = self.scratch.items.len;
                 defer self.scratch.shrinkRetainingCapacity(scratch_top);
+                const needs_this_capture = self.options.unsupported.arrow and self.needs_this_var;
+                const needs_arguments_capture = self.options.unsupported.arrow and self.needs_arguments_var;
+
+                if (needs_this_capture or needs_arguments_capture) {
+                    if (needs_this_capture) {
+                        const this_init = try self.ast.addNode(.{
+                            .tag = .this_expression,
+                            .span = span,
+                            .data = .{ .none = 0 },
+                        });
+                        try self.scratch.append(self.allocator, try self.buildVarDecl("_this", this_init, span));
+                    }
+                    if (needs_arguments_capture) {
+                        const args_span = try self.ast.addString("arguments");
+                        const args_init = try self.ast.addNode(.{
+                            .tag = .identifier_reference,
+                            .span = args_span,
+                            .data = .{ .string_ref = args_span },
+                        });
+                        try self.scratch.append(self.allocator, try self.buildVarDecl("_arguments", args_init, span));
+                    }
+                }
                 if (!sm_result.var_decl.isNone()) try self.scratch.append(self.allocator, sm_result.var_decl);
                 try self.scratch.append(self.allocator, return_stmt);
                 break :blk try self.ast.addNodeList(self.scratch.items[scratch_top..]);
@@ -324,10 +363,18 @@ pub fn ES2017(comptime Transformer: type) type {
             const params_idx: NodeIndex = self.readNodeIdx(e, 0);
             const body_idx: NodeIndex = self.readNodeIdx(e, 1);
 
-            // arrow params → function params list로 변환
-            const params_list = try es2015_arrow.ES2015Arrow(Transformer).arrowParamsToList(self, params_idx);
+            const lowered = blk: {
+                // Async arrow skips ES2015Arrow.lowerArrowFunction(), so enter
+                // the arrow lexical environment while visiting params/body.
+                self.arrow_this_depth += 1;
+                defer self.arrow_this_depth -= 1;
 
-            const sm_result = try GenMod.buildStateMachine(self, body_idx, span);
+                const params_list = try es2015_arrow.ES2015Arrow(Transformer).arrowParamsToList(self, params_idx);
+                const sm_result = try GenMod.buildStateMachine(self, body_idx, span);
+                break :blk .{ .params_list = params_list, .sm_result = sm_result };
+            };
+            const params_list = lowered.params_list;
+            const sm_result = lowered.sm_result;
             if (sm_result.body.isNone()) return .none;
 
             const gen_call = try GenMod.buildGeneratorHelperCall(self, sm_result.body, span);

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -1085,6 +1085,63 @@ pub fn buildWeakCollectionDecl(self: anytype, constructor_name: []const u8, var_
     return self.buildVarDecl(var_name, new_expr, span);
 }
 
+/// 함수 경계를 진입할 때 arrow this/arguments 캡처 상태를 저장하고 0/false 로 초기화.
+/// `visitFunction` 을 거치지 않는 lowering 경로(async state-machine, class method 직접 lowering,
+/// standalone func 추출 등)가 같은 함수 스코프 의미를 갖도록 하기 위함.
+pub const ArrowEnvSnapshot = struct {
+    arrow_this_depth: u32,
+    needs_this_var: bool,
+    needs_arguments_var: bool,
+    super_call_this_alias: bool,
+};
+
+pub fn pushArrowEnv(self: anytype) ArrowEnvSnapshot {
+    const snap = ArrowEnvSnapshot{
+        .arrow_this_depth = self.arrow_this_depth,
+        .needs_this_var = self.needs_this_var,
+        .needs_arguments_var = self.needs_arguments_var,
+        .super_call_this_alias = self.super_call_this_alias,
+    };
+    self.arrow_this_depth = 0;
+    self.needs_this_var = false;
+    self.needs_arguments_var = false;
+    self.super_call_this_alias = false;
+    return snap;
+}
+
+pub fn popArrowEnv(self: anytype, snap: ArrowEnvSnapshot) void {
+    self.arrow_this_depth = snap.arrow_this_depth;
+    self.needs_this_var = snap.needs_this_var;
+    self.needs_arguments_var = snap.needs_arguments_var;
+    self.super_call_this_alias = snap.super_call_this_alias;
+}
+
+/// `_this = this`, `_arguments = arguments` capture var-decl 을 buf 에 채운다.
+/// 호출자는 `self.needs_this_var` / `self.needs_arguments_var` 가 lowering 결과를 반영한 뒤 호출.
+pub fn fillThisArgumentsCaptures(self: anytype, buf: *[2]NodeIndex, span: Span) !usize {
+    var count: usize = 0;
+    if (self.needs_this_var) {
+        const this_init = try self.ast.addNode(.{
+            .tag = .this_expression,
+            .span = span,
+            .data = .{ .none = 0 },
+        });
+        buf[count] = try self.buildVarDecl("_this", this_init, span);
+        count += 1;
+    }
+    if (self.needs_arguments_var) {
+        const args_span = try self.ast.addString("arguments");
+        const args_init = try self.ast.addNode(.{
+            .tag = .identifier_reference,
+            .span = args_span,
+            .data = .{ .string_ref = args_span },
+        });
+        buf[count] = try self.buildVarDecl("_arguments", args_init, span);
+        count += 1;
+    }
+    return count;
+}
+
 /// method_definition → standalone function declaration으로 추출.
 /// private generator method (`*#name`) / async method 를 `_name_fn` 으로 꺼낼 때
 /// method flags(is_async, is_generator)를 function flags로 옮겨 호이스팅한다.
@@ -1097,20 +1154,8 @@ pub fn buildStandaloneFunc(self: anytype, name: []const u8, method_idx: NodeInde
     const body_idx: NodeIndex = @enumFromInt(self.readU32(method_node.data.extra, ast_mod.MethodExtra.body));
     const method_flags = self.readU32(method_node.data.extra, ast_mod.MethodExtra.flags);
 
-    const saved_arrow_depth = self.arrow_this_depth;
-    const saved_needs_this = self.needs_this_var;
-    const saved_needs_args = self.needs_arguments_var;
-    const saved_super_alias = self.super_call_this_alias;
-    self.arrow_this_depth = 0;
-    self.needs_this_var = false;
-    self.needs_arguments_var = false;
-    self.super_call_this_alias = false;
-    defer {
-        self.arrow_this_depth = saved_arrow_depth;
-        self.needs_this_var = saved_needs_this;
-        self.needs_arguments_var = saved_needs_args;
-        self.super_call_this_alias = saved_super_alias;
-    }
+    const arrow_env = pushArrowEnv(self);
+    defer popArrowEnv(self, arrow_env);
 
     const new_params = try self.visitExtraList(.{ .start = params_start, .len = params_len });
 
@@ -1119,28 +1164,7 @@ pub fn buildStandaloneFunc(self: anytype, name: []const u8, method_idx: NodeInde
         (self.needs_this_var or self.needs_arguments_var))
     {
         var capture_stmts: [2]NodeIndex = undefined;
-        var capture_count: usize = 0;
-
-        if (self.needs_this_var) {
-            const this_init = try self.ast.addNode(.{
-                .tag = .this_expression,
-                .span = span,
-                .data = .{ .none = 0 },
-            });
-            capture_stmts[capture_count] = try self.buildVarDecl("_this", this_init, span);
-            capture_count += 1;
-        }
-        if (self.needs_arguments_var) {
-            const args_span = try self.ast.addString("arguments");
-            const args_init = try self.ast.addNode(.{
-                .tag = .identifier_reference,
-                .span = args_span,
-                .data = .{ .string_ref = args_span },
-            });
-            capture_stmts[capture_count] = try self.buildVarDecl("_arguments", args_init, span);
-            capture_count += 1;
-        }
-
+        const capture_count = try fillThisArgumentsCaptures(self, &capture_stmts, span);
         new_body = try self.prependStatementsToBody(new_body, capture_stmts[0..capture_count]);
     }
 

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -1097,9 +1097,52 @@ pub fn buildStandaloneFunc(self: anytype, name: []const u8, method_idx: NodeInde
     const body_idx: NodeIndex = @enumFromInt(self.readU32(method_node.data.extra, ast_mod.MethodExtra.body));
     const method_flags = self.readU32(method_node.data.extra, ast_mod.MethodExtra.flags);
 
+    const saved_arrow_depth = self.arrow_this_depth;
+    const saved_needs_this = self.needs_this_var;
+    const saved_needs_args = self.needs_arguments_var;
+    const saved_super_alias = self.super_call_this_alias;
+    self.arrow_this_depth = 0;
+    self.needs_this_var = false;
+    self.needs_arguments_var = false;
+    self.super_call_this_alias = false;
+    defer {
+        self.arrow_this_depth = saved_arrow_depth;
+        self.needs_this_var = saved_needs_this;
+        self.needs_arguments_var = saved_needs_args;
+        self.super_call_this_alias = saved_super_alias;
+    }
+
     const new_params = try self.visitExtraList(.{ .start = params_start, .len = params_len });
 
-    const new_body = try self.visitNode(body_idx);
+    var new_body = try self.visitNode(body_idx);
+    if (self.options.unsupported.arrow and !new_body.isNone() and
+        (self.needs_this_var or self.needs_arguments_var))
+    {
+        var capture_stmts: [2]NodeIndex = undefined;
+        var capture_count: usize = 0;
+
+        if (self.needs_this_var) {
+            const this_init = try self.ast.addNode(.{
+                .tag = .this_expression,
+                .span = span,
+                .data = .{ .none = 0 },
+            });
+            capture_stmts[capture_count] = try self.buildVarDecl("_this", this_init, span);
+            capture_count += 1;
+        }
+        if (self.needs_arguments_var) {
+            const args_span = try self.ast.addString("arguments");
+            const args_init = try self.ast.addNode(.{
+                .tag = .identifier_reference,
+                .span = args_span,
+                .data = .{ .string_ref = args_span },
+            });
+            capture_stmts[capture_count] = try self.buildVarDecl("_arguments", args_init, span);
+            capture_count += 1;
+        }
+
+        new_body = try self.prependStatementsToBody(new_body, capture_stmts[0..capture_count]);
+    }
 
     const name_span = try self.ast.addString(name);
     const name_node = try makeBindingIdentifier(self, name_span);

--- a/tests/integration/tests/polyfill-rbm.test.ts
+++ b/tests/integration/tests/polyfill-rbm.test.ts
@@ -131,7 +131,7 @@ describe("--run-before-main", () => {
     expect(initPos).toBeLessThan(entryPos);
   });
 
-  test("run-before-main 모듈의 require/init 호출이 엔트리 직전에 삽입된다", async () => {
+  test("run-before-main 모듈 실행 코드가 엔트리 직전에 배치된다", async () => {
     fixture = await createFixture(fixtures);
     const outFile = join(fixture.dir, "out.js");
 
@@ -147,16 +147,18 @@ describe("--run-before-main", () => {
     const bundle = readFileSync(outFile, "utf-8");
     const lines = bundle.split("\n");
 
-    // 엔트리 코드(__ENTRY_RAN__) 직전에 require_init_core() 또는 init_init_core() 호출이 있어야 함
+    // 엔트리 코드(__ENTRY_RAN__) 직전에 run-before-main 실행 코드가 있어야 함.
+    // 래핑 모듈이면 require_xxx()/init_xxx() 호출, scope-hoisted 모듈이면 본문 코드가 직접 배치된다.
     const entryLineIdx = lines.findLastIndex((l) => l.includes("__ENTRY_RAN__"));
     expect(entryLineIdx).toBeGreaterThan(0);
 
-    // 엔트리 이전 20줄 이내에 init-core 모듈의 호출(require_xxx() 또는 init_xxx())이 있어야 함
+    // 엔트리 이전 20줄 이내에 init-core 모듈의 호출 또는 본문이 있어야 함.
     const precedingLines = lines.slice(Math.max(0, entryLineIdx - 20), entryLineIdx).join("\n");
     const hasCall = /(?:require|init)_[a-zA-Z0-9_]*init[_-]core[a-zA-Z0-9_]*\(\)/.test(
       precedingLines,
     );
-    expect(hasCall).toBe(true);
+    const hasScopeHoistedBody = precedingLines.includes("__INIT_CORE_RAN__");
+    expect(hasCall || hasScopeHoistedBody).toBe(true);
   });
 
   test("존재하지 않는 run-before-main 경로는 에러 메시지를 출력한다", async () => {

--- a/tests/integration/tests/react-query-v5-smoke.test.ts
+++ b/tests/integration/tests/react-query-v5-smoke.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { createFixture, hasPackage, linkNodeModules, runNode, runZts } from "./helpers";
+import { createFixture, hasPackage, linkNodeModules, runNode, runZtsInDir } from "./helpers";
 
 const hasReactQuery = hasPackage("@tanstack/react-query");
 
@@ -15,12 +15,13 @@ describe.skipIf(!hasReactQuery)("React Query v5 smoke", () => {
     }
   });
 
-  it("@tanstack/react-query v5 bundles and executes QueryClient", async () => {
+  it("@tanstack/react-query v5 bundles to ES5 and runs replaceAll through runtime polyfills", async () => {
     const fixture = await createFixture({
       "index.ts": `
         import { QueryClient, QueryObserver } from "@tanstack/react-query";
 
         type Result = { ok: true; value: number };
+        const normalized = "react.query.v5".replaceAll(".", "-");
         const client = new QueryClient();
         const observer = new QueryObserver<Result>(client, {
           queryKey: ["runtime-polyfills", "react-query-v5"],
@@ -35,7 +36,7 @@ describe.skipIf(!hasReactQuery)("React Query v5 smoke", () => {
             queryFn: async () => ({ ok: true, value: 42 }),
           })
           .then((result) => {
-            console.log("react-query-v5", result?.ok === true, result.value);
+            console.log(normalized, result?.ok === true, result.value);
             unsubscribe();
             client.clear();
           });
@@ -46,21 +47,35 @@ describe.skipIf(!hasReactQuery)("React Query v5 smoke", () => {
     await linkNodeModules(fixture.dir, ["@tanstack/react-query", "@tanstack/query-core", "react"]);
 
     const outFile = join(fixture.dir, "out.cjs");
-    const bundle = await runZts([
-      "--bundle",
-      join(fixture.dir, "index.ts"),
-      "-o",
-      outFile,
-      "--format=cjs",
-      "--platform=node",
-    ]);
+    const bundle = await runZtsInDir(
+      fixture.dir,
+      [
+        "--bundle",
+        join(fixture.dir, "index.ts"),
+        "-o",
+        outFile,
+        "--format=cjs",
+        "--platform=node",
+        "--target=es5",
+        "--runtime-polyfills=auto",
+        "--runtime-target=ios12",
+      ],
+      { bin: "js" },
+    );
     expect(bundle.exitCode).toBe(0);
 
     const js = await readFile(outFile, "utf-8");
     expect(js).toContain("QueryClient");
+    expect(js).toContain("es.string.replace-all");
     expect(js).not.toContain("@tanstack/react-query");
+    expect(js).not.toContain("?.");
 
-    const run = await runNode(outFile);
+    const runner = join(fixture.dir, "run-without-native-replaceall.cjs");
+    await writeFile(
+      runner,
+      `String.prototype.replaceAll = undefined;\nrequire(${JSON.stringify(outFile)});\n`,
+    );
+    const run = await runNode(runner);
     expect(run.stdout).toBe("react-query-v5 true 42");
   });
 });

--- a/tests/integration/tests/react-query-v5-smoke.test.ts
+++ b/tests/integration/tests/react-query-v5-smoke.test.ts
@@ -58,7 +58,7 @@ describe.skipIf(!hasReactQuery)("React Query v5 smoke", () => {
         "--platform=node",
         "--target=es5",
         "--runtime-polyfills=auto",
-        "--runtime-target=ios12",
+        "--runtime-target=ios_saf 12",
       ],
       { bin: "js" },
     );

--- a/tests/integration/tests/react-query-v5-smoke.test.ts
+++ b/tests/integration/tests/react-query-v5-smoke.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createFixture, hasPackage, linkNodeModules, runNode, runZts } from "./helpers";
+
+const hasReactQuery = hasPackage("@tanstack/react-query");
+
+describe.skipIf(!hasReactQuery)("React Query v5 smoke", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  it("@tanstack/react-query v5 bundles and executes QueryClient", async () => {
+    const fixture = await createFixture({
+      "index.ts": `
+        import { QueryClient, QueryObserver } from "@tanstack/react-query";
+
+        type Result = { ok: true; value: number };
+        const client = new QueryClient();
+        const observer = new QueryObserver<Result>(client, {
+          queryKey: ["runtime-polyfills", "react-query-v5"],
+          queryFn: async () => ({ ok: true, value: 42 }),
+        });
+
+        const unsubscribe = observer.subscribe(() => {});
+
+        client
+          .fetchQuery({
+            queryKey: ["runtime-polyfills", "react-query-v5"],
+            queryFn: async () => ({ ok: true, value: 42 }),
+          })
+          .then((result) => {
+            console.log("react-query-v5", result?.ok === true, result.value);
+            unsubscribe();
+            client.clear();
+          });
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    await linkNodeModules(fixture.dir, ["@tanstack/react-query", "@tanstack/query-core", "react"]);
+
+    const outFile = join(fixture.dir, "out.cjs");
+    const bundle = await runZts([
+      "--bundle",
+      join(fixture.dir, "index.ts"),
+      "-o",
+      outFile,
+      "--format=cjs",
+      "--platform=node",
+    ]);
+    expect(bundle.exitCode).toBe(0);
+
+    const js = await readFile(outFile, "utf-8");
+    expect(js).toContain("QueryClient");
+    expect(js).not.toContain("@tanstack/react-query");
+
+    const run = await runNode(outFile);
+    expect(run.stdout).toBe("react-query-v5 true 42");
+  });
+});

--- a/tests/integration/tests/react-query-v5-smoke.test.ts
+++ b/tests/integration/tests/react-query-v5-smoke.test.ts
@@ -69,6 +69,7 @@ describe.skipIf(!hasReactQuery)("React Query v5 smoke", () => {
     expect(js).toContain("es.string.replace-all");
     expect(js).not.toContain("@tanstack/react-query");
     expect(js).not.toContain("?.");
+    expect(js.replace(/^\/\/#.*$/gm, "")).not.toMatch(/(^|[^\w$])#[A-Za-z_$][\w$]*/);
 
     const runner = join(fixture.dir, "run-without-native-replaceall.cjs");
     await writeFile(


### PR DESCRIPTION
## 요약
- `runtimePolyfills`/`coreJs` 기반 core-js 런타임 폴리필 자동 주입을 추가합니다. 타겟 지정은 top-level `runtimeTargets` 없이 `runtimePolyfills.targets`로만 노출합니다.
- `runtimePolyfills.targets`는 Rspack/SWC `env.targets`와 동일하게 Browserslist query 배열을 받습니다. `ios12`, `node18`, `hermes0.7` 같은 ZTS 전용 compact shorthand는 지원하지 않고 파서에서 명확히 거부합니다.
- CLI `--runtime-target`은 내부에서 `runtimePolyfills.targets` 배열로 병합되며, `runtimePolyfills`가 명시되지 않으면 자동 폴리필을 켜지 않습니다.
- `auto`/`usage`는 실제 사용 API를 스캔하고, `entry`는 타겟 기준 core-js ES/Web 모듈을 synthetic prelude로 주입합니다.
- React Query v5를 실제 번들해 `--target=es5` + `replaceAll` runtime polyfill 동작과 raw private `#` syntax 제거를 검증했습니다.

## Zig 변경 설명
- Babel/SWC와 동일하게 output string 탐색이 아니라 AST lowering 중 lexical `this`/`arguments` capture 상태를 전파합니다.
- private method standalone function, async state-machine function, class async method state-machine, async arrow state-machine 경로가 일반 function/method/arrow visitor와 같은 capture 환경을 갖도록 보강했습니다.
- Babel `async-to-generator` fixture 3개를 ZTS ES5 회귀 테스트로 이식했습니다.

## 타입/API
- `runtimeTargets` 옵션은 제거했고 타입/문서/CLI schema 테스트에서 노출되지 않도록 검증했습니다.
- `runtimePolyfills.targets`는 `string | string[]` Browserslist query 형태로 남겨 Rspack/SWC `env.targets`와 맞췄습니다.
- `runtimePolyfills.coreJs`도 지원하며, 기존 top-level `coreJs`와 동일한 역할을 합니다.
- d.ts는 NAPI 산출물이 아니라 `packages/core`의 TypeScript declaration emit(`bun x tsc --emitDeclarationOnly`)으로 생성됩니다.

## 레퍼런스 확인
- core-js-compat 원본 `data.json`에는 `ios12`, `node18`, `hermes0.7` 같은 compact shorthand가 없습니다.
- Rspack `builtin:swc-loader` 문서도 polyfill injection을 SWC `env.mode`/`env.coreJs`/`env.targets`로 안내하고, `env.targets` 예시는 Browserslist query 배열입니다.
- Babel은 `arrowFunctionToExpression`/`hoistFunctionEnvironment`/`unwrapFunctionEnvironment`에서 AST path를 수집해 `_this`/`_arguments` 바인딩을 주입합니다.
- SWC는 `FnEnvHoister`가 AST visitor state와 hygiene mark로 `this`/`arguments` alias를 만들고 참조를 치환합니다.
- 두 구현 모두 출력 문자열 검색이 아니라 AST 기반 lowering입니다.

## 검증
- `zig build test --summary all` (`4631/4631`)
- `zig build -Doptimize=ReleaseFast`
- `zig build napi`
- `bun run --cwd packages/core build:js`
- `bun run --cwd packages/core build:dts`
- `cd packages/core && bun test types.test.ts src/runtime-polyfills.test.ts bin/zts-cli-schema-sync.test.ts`
- `cd packages/core && bun test index.test.ts`
- `cd packages/core && bun test index.test.ts --test-name-pattern "runtimePolyfills"`
- `cd packages/core && bun test bin/zts.test.ts --test-name-pattern "runtime-polyfills|runtime-target"`
- `bun run test:runtime-polyfills:coverage` (`100% line/function coverage`)
- `cd tests/integration && bun test tests/react-query-v5-smoke.test.ts` (`replaceAll` polyfill 실행 + raw private `#` syntax 부재)
- `bun run test:integration` (`3684 pass`, `2 todo`)
- `bun run lint` (기존 unused import warning 3건, error 0)
- `bun run fmt:check`
- `git diff --check`
- push 전 hook: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`

## 확인된 비관련 실패
- `cd packages/core && bun test bin/zts.test.ts` 전체는 watch/dev 서버 이벤트 대기 테스트에서 timeout이 재현됩니다. runtime-polyfill 관련 CLI 테스트는 별도로 통과했습니다.

