### PR TITLE
feat(core): 그래프 기반 런타임 폴리필 감지

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -90,7 +90,6 @@
         "@types/node": "^25.5.2",
       },
       "optionalDependencies": {
-        "@babel/parser": "^7.29.0",
         "browserslist": "^4.24.0",
         "core-js": "^3.49.0",
         "core-js-compat": "^3.49.0",

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -185,8 +185,8 @@ esbuild 스타일: `onResolve`, `onLoad`, `onTransform`, `onRenderChunk`, `onGen
 - CLI: `--runtime-polyfills=auto|usage|entry|off`, `--runtime-target=<query>` 반복, `--core-js=3.49`.
 - JS API/config: `runtimePolyfills`, `coreJs`. 타겟은 Rspack/SWC `env.targets`와 같은 Browserslist query 배열로
   `runtimePolyfills: { targets: ["chrome >= 87", "safari >= 14"] }`처럼 지정한다.
-- `auto`/`usage`는 엔트리와 로컬 의존성에서 `replaceAll`, `Map`, `Set`, `Promise`,
-  `Array.prototype.at`, `Object.hasOwn`, `structuredClone` 사용을 스캔해 타겟 미지원 core-js 모듈만 주입한다.
+- `auto`/`usage`는 resolve/load/transform 이후 실제 번들 그래프에서 `replaceAll`, `Map`, `Set`, `Promise`,
+  `Array.prototype.at`, `Object.hasOwn`, `structuredClone` 사용을 감지해 타겟 미지원 core-js 모듈만 주입한다.
 - `entry`는 타겟 기준 필요한 `core-js/modules/es.*` / `web.*`를 엔트리 prelude에 포괄 주입한다.
 - 타겟 예: `ios_saf 12`, `iOS >= 12`, `chrome >= 85`, `android >= 5`,
   `samsung >= 14`, `node 18`. `ios12`, `node18`, `iPhone 8`, `Galaxy S10`

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -502,6 +502,93 @@ describe("CLI: bundle", () => {
     }
   });
 
+  test("번들 + --runtime-polyfills=usage 는 graph usage alias로 동작", () => {
+    const polyfillDir = mkdtempSync(join(tmpdir(), "zts-cli-runtime-usage-"));
+    try {
+      writeFileSync(
+        join(polyfillDir, "entry.ts"),
+        `globalThis.__VALUE__ = new Map([["x", 1]]).get("x");`,
+      );
+
+      const { stdout, stderr, exitCode } = runCli([
+        "--bundle",
+        join(polyfillDir, "entry.ts"),
+        "--runtime-polyfills=usage",
+        "--runtime-target=safari 5",
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(stderr).toBe("");
+      expect(stdout).toContain("es.map");
+    } finally {
+      rmSync(polyfillDir, { recursive: true, force: true });
+    }
+  });
+
+  test("번들 + runtime-polyfills debug/profile 관측성 출력", () => {
+    const polyfillDir = mkdtempSync(join(tmpdir(), "zts-cli-runtime-observe-"));
+    try {
+      writeFileSync(
+        join(polyfillDir, "entry.ts"),
+        `globalThis.__VALUE__ = "a".replaceAll("a", "b");`,
+      );
+
+      const { stdout, stderr, exitCode } = runCli(
+        [
+          "--bundle",
+          join(polyfillDir, "entry.ts"),
+          "--runtime-polyfills=auto",
+          "--runtime-target=ios_saf 12",
+          "--profile=graph",
+          "--profile-level=detailed",
+          "--profile-format=json",
+        ],
+        { env: { ...process.env, ZTS_DEBUG: "runtime_polyfills" } },
+      );
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("es.string.replace-all");
+      expect(stderr).toContain("[runtime_polyfills]");
+      expect(stderr).toContain("mode=usage");
+      expect(stderr).toContain("feature=string_replace_all");
+      expect(stderr).toContain("corejs_module=es.string.replace-all");
+      expect(stderr).toContain('"graph.runtime.polyfills.collect"');
+      expect(stderr).toContain('"graph.runtime.polyfills.inject"');
+    } finally {
+      rmSync(polyfillDir, { recursive: true, force: true });
+    }
+  });
+
+  test("번들 + --runtime-polyfills=off 는 collector/profile/debug 경로를 실행하지 않음", () => {
+    const polyfillDir = mkdtempSync(join(tmpdir(), "zts-cli-runtime-off-observe-"));
+    try {
+      writeFileSync(
+        join(polyfillDir, "entry.ts"),
+        `globalThis.__VALUE__ = "a".replaceAll("a", "b");`,
+      );
+
+      const { stdout, stderr, exitCode } = runCli(
+        [
+          "--bundle",
+          join(polyfillDir, "entry.ts"),
+          "--runtime-polyfills=off",
+          "--runtime-target=ios_saf 12",
+          "--profile=graph",
+          "--profile-level=detailed",
+          "--profile-format=json",
+        ],
+        { env: { ...process.env, ZTS_DEBUG: "runtime_polyfills" } },
+      );
+
+      expect(exitCode).toBe(0);
+      expect(stdout).not.toContain("es.string.replace-all");
+      expect(stderr).not.toContain("[runtime_polyfills]");
+      expect(stderr).not.toContain("graph.runtime.polyfills");
+    } finally {
+      rmSync(polyfillDir, { recursive: true, force: true });
+    }
+  });
+
   test("번들 + --runtime-target device name은 actionable error", () => {
     const polyfillDir = mkdtempSync(join(tmpdir(), "zts-cli-runtime-device-"));
     try {

--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -1183,6 +1183,51 @@ describe("@zts/core edge cases", () => {
     expect(result.code).toContain("??");
   });
 
+  test("build target es5 keeps optional chaining temp declarations in nested functions", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-es5-optional-temp-"));
+    try {
+      writeFileSync(
+        join(dir, "entry.ts"),
+        `
+          function createProxy(state: any) {
+            state.callbacks.push(function rootDraftCleanup(rootScope: any) {
+              rootScope.mapSetPlugin_?.fixSetContents(state);
+              const { patchPlugin_ } = rootScope;
+              if (state.modified_ && patchPlugin_) {
+                patchPlugin_.generatePatches_(state, [], rootScope);
+              }
+            });
+          }
+
+          const calls: string[] = [];
+          const state = { callbacks: [] as Function[], modified_: true };
+          createProxy(state);
+          state.callbacks[0]({
+            mapSetPlugin_: { fixSetContents() { calls.push("map"); } },
+            patchPlugin_: { generatePatches_() { calls.push("patch"); } },
+          });
+          globalThis.__VALUE__ = calls.join(",");
+        `,
+      );
+
+      const result = buildSync({
+        entryPoints: [join(dir, "entry.ts")],
+        format: "iife",
+        target: "es5",
+      });
+      expect(result.errors.length).toBe(0);
+      const code = result.outputFiles[0].text;
+      expect(code).not.toContain("?.");
+
+      const vm = require("node:vm") as typeof import("node:vm");
+      const sandbox: { __VALUE__?: string } = {};
+      vm.runInNewContext(code, sandbox);
+      expect(sandbox.__VALUE__).toBe("map,patch");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("decorator (experimental)", () => {
     const result = transpile(
       "@sealed\nclass Greeter {\n  greeting: string;\n  constructor(message: string) { this.greeting = message; }\n}",
@@ -6732,6 +6777,430 @@ describe("@zts/core browserslist", () => {
         runtimePolyfills: { mode: "auto", targets: ["node 18"] },
       }).outputFiles[0].text;
       expect(modernTarget).not.toContain("es.string.replace-all");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("runtimePolyfills auto scans package exports resolved modules", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfills-pkg-exports-"));
+    try {
+      const pkgDir = join(dir, "node_modules", "runtime-exports-pkg", "dist");
+      mkdirSync(pkgDir, { recursive: true });
+      writeFileSync(
+        join(dir, "node_modules", "runtime-exports-pkg", "package.json"),
+        JSON.stringify({
+          name: "runtime-exports-pkg",
+          type: "module",
+          exports: {
+            ".": {
+              import: "./dist/index.js",
+              default: "./dist/index.js",
+            },
+          },
+        }),
+      );
+      writeFileSync(
+        join(pkgDir, "index.js"),
+        `
+          const cloned = structuredClone({ label: "clone" });
+          export const value = [
+            ["a", "b"].at(-1),
+            Object.hasOwn({ ok: true }, "ok") ? "own" : "missing",
+            cloned.label,
+          ].join("|");
+        `,
+      );
+      writeFileSync(
+        join(dir, "entry.ts"),
+        `import { value } from "runtime-exports-pkg"; globalThis.__VALUE__ = value;`,
+      );
+
+      const code = buildSync({
+        entryPoints: [join(dir, "entry.ts")],
+        format: "iife",
+        platform: "node",
+        runtimePolyfills: { mode: "auto", targets: ["safari 5"] },
+      }).outputFiles[0].text;
+
+      expect(code).toContain("es.array.at");
+      expect(code).toContain("es.object.has-own");
+      expect(code).toContain("web.structured-clone");
+
+      const vm = require("node:vm") as typeof import("node:vm");
+      const sandbox: { __VALUE__?: string } = {};
+      vm.runInNewContext(
+        `
+          Array.prototype.at = undefined;
+          Object.hasOwn = undefined;
+          globalThis.structuredClone = undefined;
+          ${code}
+        `,
+        sandbox,
+      );
+      expect(sandbox.__VALUE__).toBe("b|own|clone");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("runtimePolyfills auto ignores shadowed globals and dynamic computed access", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfills-negative-"));
+    try {
+      writeFileSync(
+        join(dir, "entry.ts"),
+        `
+          const Map = class LocalMap {};
+          const Object = { hasOwn() { return true; } };
+          const globalThis = { Set: class LocalSet {} };
+          const promiseMethod = "resolve";
+          const stringMethod = "replaceAll";
+          new Map();
+          new globalThis.Set();
+          Object.hasOwn({}, "x");
+          Promise[promiseMethod](1);
+          "a-a"[stringMethod]("a", "b");
+        `,
+      );
+
+      const code = buildSync({
+        entryPoints: [join(dir, "entry.ts")],
+        format: "iife",
+        runtimePolyfills: { mode: "auto", targets: ["safari 5"] },
+      }).outputFiles[0].text;
+
+      expect(code).not.toContain("es.map");
+      expect(code).not.toContain("es.set");
+      expect(code).not.toContain("es.promise");
+      expect(code).not.toContain("es.object.has-own");
+      expect(code).not.toContain("es.string.replace-all");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("runtimePolyfills auto ignores imported runtime global names", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfills-import-shadow-"));
+    try {
+      writeFileSync(
+        join(dir, "locals.ts"),
+        `
+          export class Map {
+            kind = "local-map";
+          }
+          export const Promise = {
+            resolve(value: string) {
+              return "local-" + value;
+            },
+          };
+          export const Object = {
+            hasOwn() {
+              return "local-has-own";
+            },
+          };
+        `,
+      );
+      writeFileSync(
+        join(dir, "entry.ts"),
+        `
+          import { Map, Promise, Object } from "./locals";
+          const structuredClone = (value: string) => "local-" + value;
+          globalThis.__VALUE__ = [
+            new Map().kind,
+            Promise.resolve("promise"),
+            Object.hasOwn({}, "x"),
+            structuredClone("clone"),
+          ].join("|");
+        `,
+      );
+
+      const code = buildSync({
+        entryPoints: [join(dir, "entry.ts")],
+        format: "iife",
+        runtimePolyfills: { mode: "auto", targets: ["safari 5"] },
+      }).outputFiles[0].text;
+
+      expect(code).not.toContain("es.map");
+      expect(code).not.toContain("es.promise");
+      expect(code).not.toContain("es.object.has-own");
+      expect(code).not.toContain("web.structured-clone");
+
+      const vm = require("node:vm") as typeof import("node:vm");
+      const sandbox: { __VALUE__?: string } = {};
+      vm.runInNewContext(
+        `
+          globalThis.Map = undefined;
+          globalThis.Promise = undefined;
+          globalThis.structuredClone = undefined;
+          ${code}
+        `,
+        sandbox,
+      );
+      expect(sandbox.__VALUE__).toBe("local-map|local-promise|local-has-own|local-clone");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("runtimePolyfills include covers intentional dynamic computed access", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfills-computed-include-"));
+    try {
+      writeFileSync(
+        join(dir, "entry.ts"),
+        `
+          const method = "at";
+          globalThis.__VALUE__ = ["x", "y"][method](-1);
+        `,
+      );
+
+      const autoOnly = buildSync({
+        entryPoints: [join(dir, "entry.ts")],
+        format: "iife",
+        runtimePolyfills: { mode: "auto", targets: ["safari 5"] },
+      }).outputFiles[0].text;
+      expect(autoOnly).not.toContain("es.array.at");
+
+      const included = buildSync({
+        entryPoints: [join(dir, "entry.ts")],
+        format: "iife",
+        runtimePolyfills: {
+          mode: "auto",
+          targets: ["node 18"],
+          include: ["es.array.at"],
+        },
+      }).outputFiles[0].text;
+      expect(included).toContain("es.array.at");
+
+      const vm = require("node:vm") as typeof import("node:vm");
+      const sandbox: { __VALUE__?: string } = {};
+      vm.runInNewContext(`Array.prototype.at = undefined;\n${included}`, sandbox);
+      expect(sandbox.__VALUE__).toBe("y");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("runtimePolyfills auto detects explicit globalThis runtime API usage", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfills-globalthis-"));
+    try {
+      writeFileSync(
+        join(dir, "entry.ts"),
+        `
+          globalThis.__RESULT__ = [
+            typeof globalThis.Map,
+            typeof globalThis.Set,
+            typeof globalThis.Promise.resolve,
+            typeof globalThis.structuredClone,
+            globalThis.Object.hasOwn({ ok: true }, "ok"),
+          ].join("|");
+        `,
+      );
+
+      const code = buildSync({
+        entryPoints: [join(dir, "entry.ts")],
+        format: "iife",
+        runtimePolyfills: { mode: "auto", targets: ["safari 5"] },
+      }).outputFiles[0].text;
+
+      expect(code).toContain("es.map");
+      expect(code).toContain("es.set");
+      expect(code).toContain("es.promise");
+      expect(code).toContain("web.structured-clone");
+      expect(code).toContain("es.object.has-own");
+
+      const vm = require("node:vm") as typeof import("node:vm");
+      const sandbox: { __RESULT__?: string } = {};
+      vm.runInNewContext(
+        `
+          globalThis.Map = undefined;
+          globalThis.Set = undefined;
+          globalThis.Promise = undefined;
+          globalThis.structuredClone = undefined;
+          globalThis.Object.hasOwn = undefined;
+          ${code}
+        `,
+        sandbox,
+      );
+      expect(sandbox.__RESULT__).toBe("function|function|function|function|true");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("runtimePolyfills auto injects expanded core-js built-ins", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfills-expanded-"));
+    try {
+      writeFileSync(
+        join(dir, "entry.ts"),
+        `
+          const key = {};
+          const weak = new WeakMap();
+          weak.set(key, 7);
+          globalThis.__VALUE__ = [
+            Object.values({ label: "value" })[0],
+            "7".padStart(2, "0"),
+            Math.trunc(1.8),
+            Reflect.ownKeys({ own: true })[0],
+            [1, 2, 3].findLast((value) => value < 3),
+            typeof Symbol === "function",
+            weak.get(key),
+          ].join("|");
+        `,
+      );
+
+      const code = buildSync({
+        entryPoints: [join(dir, "entry.ts")],
+        format: "iife",
+        runtimePolyfills: { mode: "auto", targets: ["safari 5"] },
+      }).outputFiles[0].text;
+
+      expect(code).toContain("es.object.values");
+      expect(code).toContain("es.string.pad-start");
+      expect(code).toContain("es.math.trunc");
+      expect(code).toContain("es.reflect.own-keys");
+      expect(code).toContain("es.array.find-last");
+      expect(code).toContain("es.weak-map");
+      expect(code).toContain("es.symbol");
+
+      const vm = require("node:vm") as typeof import("node:vm");
+      const sandbox: { __VALUE__?: string } = {};
+      vm.runInNewContext(
+        `
+          Object.values = undefined;
+          String.prototype.padStart = undefined;
+          Math.trunc = undefined;
+          Reflect.ownKeys = undefined;
+          Array.prototype.findLast = undefined;
+          globalThis.WeakMap = undefined;
+          globalThis.Symbol = undefined;
+          ${code}
+        `,
+        sandbox,
+      );
+      expect(sandbox.__VALUE__).toBe("value|07|1|own|2|true|7");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("runtimePolyfills auto detects usage added by transform plugins", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfills-transform-"));
+    try {
+      writeFileSync(join(dir, "entry.ts"), `globalThis.__VALUE__ = "__ORIGINAL__";`);
+      const transformPlugin: ZtsPlugin = {
+        name: "runtime-polyfill-transform",
+        setup(build) {
+          build.onTransform({ filter: /entry\.ts$/ }, () => ({
+            code: `globalThis.__VALUE__ = "a-a".replaceAll("a", "b");`,
+          }));
+        },
+      };
+
+      const result = await build({
+        entryPoints: [join(dir, "entry.ts")],
+        format: "iife",
+        runtimePolyfills: { mode: "auto", targets: ["ios_saf 12"] },
+        plugins: [transformPlugin],
+      });
+
+      expect(result.errors.length).toBe(0);
+      const code = result.outputFiles[0].text;
+      expect(code).toContain("es.string.replace-all");
+      expect(code).not.toContain("__ORIGINAL__");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("runtimePolyfills include is forced and exclude removes final selected modules", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfills-include-exclude-"));
+    try {
+      writeFileSync(
+        join(dir, "entry.ts"),
+        `
+          const value = ["a"].at(0);
+          globalThis.__VALUE__ = "a-a".replaceAll("a", value ?? "b");
+        `,
+      );
+
+      const code = buildSync({
+        entryPoints: [join(dir, "entry.ts")],
+        format: "iife",
+        runtimePolyfills: {
+          mode: "auto",
+          targets: ["ios_saf 12"],
+          include: ["es.promise"],
+          exclude: ["es.string.replace-all"],
+        },
+      }).outputFiles[0].text;
+
+      expect(code).toContain("es.array.at");
+      expect(code).toContain("es.promise");
+      expect(code).not.toContain("es.string.replace-all");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("runtimePolyfills entry and off modes stay separate from usage collection", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfills-modes-"));
+    try {
+      writeFileSync(join(dir, "entry.ts"), `globalThis.__VALUE__ = "a".replaceAll("a", "b");`);
+
+      const entryMode = buildSync({
+        entryPoints: [join(dir, "entry.ts")],
+        format: "iife",
+        runtimePolyfills: { mode: "entry", targets: ["safari 5"] },
+      }).outputFiles[0].text;
+      expect(entryMode).toContain("es.map");
+      expect(entryMode).toContain("es.promise");
+      expect(entryMode).toContain("es.string.replace-all");
+
+      const offMode = buildSync({
+        entryPoints: [join(dir, "entry.ts")],
+        format: "iife",
+        runtimePolyfills: "off",
+      }).outputFiles[0].text;
+      expect(offMode).not.toContain("es.string.replace-all");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("runtimePolyfills prelude runs after manual polyfills and before runBeforeMain", () => {
+    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfills-order-"));
+    try {
+      const polyfillFile = join(dir, "manual-polyfill.js");
+      const initFile = join(dir, "init.ts");
+      writeFileSync(
+        polyfillFile,
+        `
+          globalThis.__ORDER__ = ["polyfill"];
+          String.prototype.replaceAll = undefined;
+        `,
+      );
+      writeFileSync(
+        initFile,
+        `globalThis.__ORDER__.push("runBeforeMain:" + "a".replaceAll("a", "b"));`,
+      );
+      writeFileSync(
+        join(dir, "entry.ts"),
+        `globalThis.__ORDER__.push("entry:" + "a".replaceAll("a", "c"));`,
+      );
+
+      const code = buildSync({
+        entryPoints: [join(dir, "entry.ts")],
+        format: "iife",
+        polyfills: [polyfillFile],
+        runBeforeMain: [initFile],
+        runtimePolyfills: { mode: "auto", targets: ["ios_saf 12"] },
+      }).outputFiles[0].text;
+
+      expect(code).toContain("es.string.replace-all");
+      const vm = require("node:vm") as typeof import("node:vm");
+      const sandbox: { __ORDER__?: string[] } = {};
+      vm.runInNewContext(code, sandbox);
+      expect(sandbox.__ORDER__).toEqual(["polyfill", "runBeforeMain:b", "entry:c"]);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -795,7 +795,7 @@ interface BuildOptionsCommon {
    * core-js 기반 런타임 API 폴리필 자동 주입.
    *
    * - `"off"` (default): 자동 런타임 폴리필 없음.
-   * - `"auto"` / `"usage"`: 엔트리와 로컬 의존성의 실제 사용 API만 스캔해 타겟 미지원 모듈 주입.
+   * - `"auto"` / `"usage"`: resolve/load/transform 이후 실제 번들 그래프 사용 API를 감지해 타겟 미지원 모듈 주입.
    * - `"entry"`: 타겟 기준 필요한 core-js ES/Web 모듈을 엔트리 prelude에 포괄 주입.
    * - 타겟 지정은 Rspack/SWC `env.targets`와 같은 Browserslist query 배열을 사용한다.
    */

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,6 @@
     "@types/node": "^25.5.2"
   },
   "optionalDependencies": {
-    "@babel/parser": "^7.29.0",
     "browserslist": "^4.24.0",
     "core-js": "^3.49.0",
     "core-js-compat": "^3.49.0",

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1971,6 +1971,11 @@ fn freeOptionsTypedSlices(opts: *const BundleOptions) void {
     if (opts.fallback.len > 0) native_alloc.free(opts.fallback);
     if (opts.globals.len > 0) native_alloc.free(opts.globals);
     if (opts.loader_overrides.len > 0) native_alloc.free(opts.loader_overrides);
+    if (opts.runtime_polyfills) |plan| {
+        if (plan.candidates.len > 0) native_alloc.free(plan.candidates);
+        if (plan.entry_modules.len > 0) native_alloc.free(plan.entry_modules);
+        if (plan.include.len > 0) native_alloc.free(plan.include);
+    }
 }
 
 // ─── build() 비동기 (Promise) ───
@@ -3801,6 +3806,132 @@ fn parseBuildOptions(
         if (!trackArr(owned_string_arrays, arr)) return null;
     }
 
+    const runtime_polyfill_mode_str = getObjectString(env, opts_obj, "runtimePolyfillModeNative", native_alloc);
+    if (runtime_polyfill_mode_str) |s| if (!trackStr(owned_strings, s)) return null;
+
+    const runtime_candidate_features = getObjectStringArray(env, opts_obj, "runtimePolyfillCandidateFeatures", native_alloc);
+    if (runtime_candidate_features) |arr| {
+        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
+        if (!trackArr(owned_string_arrays, arr)) return null;
+    }
+    const runtime_candidate_modules = getObjectStringArray(env, opts_obj, "runtimePolyfillCandidateModules", native_alloc);
+    if (runtime_candidate_modules) |arr| {
+        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
+        if (!trackArr(owned_string_arrays, arr)) return null;
+    }
+    const runtime_candidate_paths = getObjectStringArray(env, opts_obj, "runtimePolyfillCandidatePaths", native_alloc);
+    if (runtime_candidate_paths) |arr| {
+        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
+        if (!trackArr(owned_string_arrays, arr)) return null;
+    }
+    const runtime_entry_modules = getObjectStringArray(env, opts_obj, "runtimePolyfillEntryModules", native_alloc);
+    if (runtime_entry_modules) |arr| {
+        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
+        if (!trackArr(owned_string_arrays, arr)) return null;
+    }
+    const runtime_entry_paths = getObjectStringArray(env, opts_obj, "runtimePolyfillEntryPaths", native_alloc);
+    if (runtime_entry_paths) |arr| {
+        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
+        if (!trackArr(owned_string_arrays, arr)) return null;
+    }
+    const runtime_include_modules = getObjectStringArray(env, opts_obj, "runtimePolyfillIncludeModules", native_alloc);
+    if (runtime_include_modules) |arr| {
+        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
+        if (!trackArr(owned_string_arrays, arr)) return null;
+    }
+    const runtime_include_paths = getObjectStringArray(env, opts_obj, "runtimePolyfillIncludePaths", native_alloc);
+    if (runtime_include_paths) |arr| {
+        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
+        if (!trackArr(owned_string_arrays, arr)) return null;
+    }
+    const runtime_exclude_modules = getObjectStringArray(env, opts_obj, "runtimePolyfillExcludeModules", native_alloc);
+    if (runtime_exclude_modules) |arr| {
+        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
+        if (!trackArr(owned_string_arrays, arr)) return null;
+    }
+
+    const runtime_polyfill_plan: ?bundler_mod.runtime_polyfills.Plan = blk: {
+        const mode_s = runtime_polyfill_mode_str orelse break :blk null;
+        const mode = bundler_mod.runtime_polyfills.Mode.fromString(mode_s) orelse {
+            _ = throwError(env, "invalid runtime polyfill native mode");
+            return null;
+        };
+
+        var candidates: []const bundler_mod.runtime_polyfills.Candidate = &.{};
+        if (runtime_candidate_features) |features| {
+            const modules = runtime_candidate_modules orelse {
+                _ = throwError(env, "invalid runtime polyfill candidate plan");
+                return null;
+            };
+            const paths = runtime_candidate_paths orelse {
+                _ = throwError(env, "invalid runtime polyfill candidate plan");
+                return null;
+            };
+            if (features.len != modules.len or modules.len != paths.len) {
+                _ = throwError(env, "invalid runtime polyfill candidate plan");
+                return null;
+            }
+            if (features.len > 0) {
+                const buf = native_alloc.alloc(bundler_mod.runtime_polyfills.Candidate, features.len) catch return null;
+                for (features, 0..) |feature_s, i| {
+                    if (feature_s.len == 0) {
+                        _ = throwError(env, "invalid runtime polyfill feature");
+                        native_alloc.free(buf);
+                        return null;
+                    }
+                    buf[i] = .{ .feature = feature_s, .module = modules[i], .path = paths[i] };
+                }
+                candidates = buf;
+            }
+        }
+
+        var entry_modules: []const bundler_mod.runtime_polyfills.ResolvedModule = &.{};
+        if (runtime_entry_modules) |modules| {
+            const paths = runtime_entry_paths orelse {
+                _ = throwError(env, "invalid runtime polyfill entry plan");
+                return null;
+            };
+            if (modules.len != paths.len) {
+                _ = throwError(env, "invalid runtime polyfill entry plan");
+                return null;
+            }
+            if (modules.len > 0) {
+                const buf = native_alloc.alloc(bundler_mod.runtime_polyfills.ResolvedModule, modules.len) catch return null;
+                for (modules, 0..) |module_name, i| {
+                    buf[i] = .{ .module = module_name, .path = paths[i] };
+                }
+                entry_modules = buf;
+            }
+        }
+
+        var include: []const bundler_mod.runtime_polyfills.ResolvedModule = &.{};
+        if (runtime_include_modules) |modules| {
+            const paths = runtime_include_paths orelse {
+                _ = throwError(env, "invalid runtime polyfill include plan");
+                return null;
+            };
+            if (modules.len != paths.len) {
+                _ = throwError(env, "invalid runtime polyfill include plan");
+                return null;
+            }
+            if (modules.len > 0) {
+                const buf = native_alloc.alloc(bundler_mod.runtime_polyfills.ResolvedModule, modules.len) catch return null;
+                for (modules, 0..) |module_name, i| {
+                    buf[i] = .{ .module = module_name, .path = paths[i] };
+                }
+                include = buf;
+            }
+        }
+
+        break :blk .{
+            .mode = mode,
+            .candidates = candidates,
+            .entry_modules = entry_modules,
+            .include = include,
+            .exclude = runtime_exclude_modules orelse &.{},
+        };
+    };
+
     // silentConsoleErrorPatterns: string[] (RegExp source strings)
     const silent_console_error_patterns = getObjectStringArray(env, opts_obj, "silentConsoleErrorPatterns", native_alloc);
     if (silent_console_error_patterns) |arr| {
@@ -3986,6 +4117,7 @@ fn parseBuildOptions(
         .global_identifiers = global_identifiers orelse &.{},
         .polyfills = polyfills orelse &.{},
         .run_before_main = run_before_main orelse &.{},
+        .runtime_polyfills = runtime_polyfill_plan,
         .silent_console_error_patterns = silent_console_error_patterns orelse &.{},
     };
 }

--- a/packages/core/src/runtime-polyfills.test.ts
+++ b/packages/core/src/runtime-polyfills.test.ts
@@ -1,18 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 
 import {
   __runtimePolyfillTestHooks,
   applyRuntimePolyfillsToNapiOptions,
-  collectRuntimePolyfillUsageFromFiles,
   computeCoreJsCompatModules,
-  createRuntimePolyfillPrelude,
   isEsTarget,
   normalizeRuntimePolyfillOptions,
   normalizeRuntimeTargets,
-  scanRuntimePolyfillUsage,
 } from "./runtime-polyfills.ts";
 
 function withRuntimeRequire<T>(runtimeRequire: any, fn: () => T): T {
@@ -22,6 +16,25 @@ function withRuntimeRequire<T>(runtimeRequire: any, fn: () => T): T {
   } finally {
     __runtimePolyfillTestHooks.reset();
   }
+}
+
+function makeRuntimeRequire(listForModules: (modules: string[] | RegExp | undefined) => string[]) {
+  const compat = (options: { modules?: string[] | RegExp }) => ({
+    list: listForModules(options.modules),
+  });
+  return Object.assign(
+    (id: string) => {
+      if (id === "core-js-compat") return compat;
+      throw new Error(`unexpected require: ${id}`);
+    },
+    {
+      resolve(specifier: string) {
+        if (specifier.startsWith("core-js/modules/")) return `/virtual/${specifier}`;
+        if (specifier === "core-js/package.json") throw new Error("no package version");
+        throw new Error(`unexpected resolve: ${specifier}`);
+      },
+    },
+  );
 }
 
 describe("runtime polyfill target normalization", () => {
@@ -182,11 +195,6 @@ describe("core-js-compat adapter", () => {
     });
 
     withRuntimeRequire(missingRequire, () => {
-      expect(() => scanRuntimePolyfillUsage(`new Promise(() => {});`)).toThrow("@babel/parser");
-      expect(() => scanRuntimePolyfillUsage(`new Promise(() => {});`)).toThrow("@babel/parser");
-    });
-
-    withRuntimeRequire(missingRequire, () => {
       expect(
         (
           normalizeRuntimePolyfillOptions({
@@ -199,201 +207,153 @@ describe("core-js-compat adapter", () => {
   });
 });
 
-describe("runtime polyfill usage scanner", () => {
-  test("finds supported v1 built-in usage", () => {
-    const modules = scanRuntimePolyfillUsage(`
-      const a = "a".replaceAll("a", "b");
-      const b = values.at(0);
-      const c = Object.hasOwn({ a: 1 }, "a");
-      const d = structuredClone(c);
-      const e = new Map();
-      const f = new Set();
-      const g = Promise.resolve(d);
-      void [a, b, e, f, g];
-    `);
-    expect(modules).toEqual([
-      "es.array.at",
+describe("runtime polyfill native plan", () => {
+  test("auto/usage no longer requires @babel/parser and passes graph candidates", () => {
+    const runtimeRequire = makeRuntimeRequire((modules) =>
+      Array.isArray(modules) ? modules.filter((name) => name !== "es.set") : [],
+    );
+
+    withRuntimeRequire(runtimeRequire, () => {
+      const napiOptions: Record<string, unknown> = { runtimePolyfills: "auto" };
+      const applied = applyRuntimePolyfillsToNapiOptions(napiOptions, {
+        entryPoints: ["/app/src/entry.ts"],
+        runtimePolyfills: "auto",
+        target: "ios_saf 12",
+      });
+
+      expect(applied.modules).toContain("es.string.replace-all");
+      expect(applied.modules).not.toContain("es.set");
+      expect(napiOptions.runtimePolyfillModeNative).toBe("usage");
+      expect(napiOptions.runtimePolyfillCandidateFeatures).toContain("string_replace_all");
+      expect(napiOptions.runtimePolyfillCandidateModules).toContain("es.string.replace-all");
+      expect((napiOptions.runtimePolyfillCandidatePaths as string[])[0]).toStartWith(
+        "/virtual/core-js/modules/",
+      );
+      expect(napiOptions.runBeforeMain).toBeUndefined();
+      applied.cleanup();
+    });
+  });
+
+  test("auto native candidates include broad core-js feature modules and ignore unmodeled results", () => {
+    const runtimeRequire = makeRuntimeRequire(() => [
       "es.map",
-      "es.object.has-own",
-      "es.promise",
+      "es.map.constructor",
+      "es.map.group-by",
       "es.set",
-      "es.string.replace-all",
-      "web.structured-clone",
-    ]);
-  });
-
-  test("ignores dynamic computed member access", () => {
-    expect(scanRuntimePolyfillUsage(`value[methodName]("x");`)).toEqual([]);
-  });
-
-  test("falls back to Flow parsing when TypeScript parsing fails", () => {
-    expect(scanRuntimePolyfillUsage(`opaque type ID = string;\nnew Promise(() => {});`)).toEqual([
+      "es.set.union.v2",
       "es.promise",
+      "es.promise.any",
+      "es.object.values",
+      "es.array.find-last",
+      "es.string.pad-start",
+      "es.weak-map",
+      "es.math.trunc",
+      "web.url",
+      "web.structured-clone",
+      "es.string.replace-all",
+      "es.array.at",
+      "es.object.has-own",
     ]);
+
+    withRuntimeRequire(runtimeRequire, () => {
+      const napiOptions: Record<string, unknown> = {};
+      const applied = applyRuntimePolyfillsToNapiOptions(napiOptions, {
+        entryPoints: ["/app/src/entry.ts"],
+        runtimePolyfills: { mode: "auto", targets: ["safari 5"] },
+      });
+
+      expect(napiOptions.runtimePolyfillCandidateModules).toEqual([
+        "es.array.at",
+        "es.array.find-last",
+        "es.map",
+        "es.map.group-by",
+        "es.math.trunc",
+        "es.object.has-own",
+        "es.object.values",
+        "es.set",
+        "es.set.union.v2",
+        "es.promise",
+        "es.promise.any",
+        "web.structured-clone",
+        "es.string.pad-start",
+        "es.string.replace-all",
+        "es.weak-map",
+        "web.url",
+      ]);
+      expect(napiOptions.runtimePolyfillCandidateFeatures).toContain("map_group_by");
+      expect(napiOptions.runtimePolyfillCandidateFeatures).toContain("set_union");
+      expect(napiOptions.runtimePolyfillCandidateFeatures).toContain("promise_any");
+      expect(napiOptions.runtimePolyfillCandidateFeatures).toContain("object_values");
+      expect(napiOptions.runtimePolyfillCandidateModules).not.toContain("es.map.constructor");
+      applied.cleanup();
+    });
   });
 
-  test("retries with Flow parser options after a parser failure", () => {
-    const parser = {
-      calls: 0,
-      parse() {
-        this.calls += 1;
-        if (this.calls === 1) throw new Error("typescript parse failed");
-        return {
-          type: "File",
-          program: {
-            type: "Program",
-            body: [
-              {
-                type: "ExpressionStatement",
-                expression: {
-                  type: "CallExpression",
-                  callee: { type: "Identifier", name: "Promise" },
-                  arguments: [],
-                },
-              },
-            ],
-          },
-        };
-      },
-    };
-    const runtimeRequire = Object.assign(
-      (id: string) => {
-        if (id === "@babel/parser") return parser;
-        throw new Error("unexpected require");
+  test("usage alias and normalized core-js include/exclude use the same native path", () => {
+    const runtimeRequire = makeRuntimeRequire(() => []);
+
+    withRuntimeRequire(runtimeRequire, () => {
+      const napiOptions: Record<string, unknown> = {};
+      const applied = applyRuntimePolyfillsToNapiOptions(napiOptions, {
+        entryPoints: ["/app/src/entry.ts"],
+        runtimePolyfills: {
+          mode: "usage",
+          targets: ["safari 5"],
+          include: ["core-js/modules/es.array.at.js", "es.promise"],
+          exclude: ["es.array.at"],
+        },
+      });
+
+      expect(applied.modules).toEqual(["es.promise"]);
+      expect(napiOptions.runtimePolyfillModeNative).toBe("usage");
+      expect(napiOptions.runtimePolyfillIncludeModules).toEqual(["es.promise"]);
+      expect(napiOptions.runtimePolyfillExcludeModules).toEqual(["es.array.at"]);
+      expect(napiOptions.runBeforeMain).toBeUndefined();
+      applied.cleanup();
+    });
+  });
+
+  test("off mode does not load core-js-compat or mutate runtime fields", () => {
+    const throwingRequire = Object.assign(
+      () => {
+        throw new Error("core-js-compat should not load");
       },
       {
         resolve() {
-          throw new Error("unexpected resolve");
+          throw new Error("core-js should not resolve");
         },
       },
     );
 
-    withRuntimeRequire(runtimeRequire, () => {
-      expect(scanRuntimePolyfillUsage(`ignored`)).toEqual(["es.promise"]);
-      expect(parser.calls).toBe(2);
+    withRuntimeRequire(throwingRequire, () => {
+      const napiOptions: Record<string, unknown> = {
+        runtimePolyfills: "off",
+        coreJs: "3.49",
+      };
+      const applied = applyRuntimePolyfillsToNapiOptions(napiOptions, {
+        entryPoints: ["/app/src/entry.ts"],
+        runtimePolyfills: "off",
+        coreJs: "3.49",
+      });
+
+      expect(applied.modules).toEqual([]);
+      expect(napiOptions.runtimePolyfills).toBeUndefined();
+      expect(napiOptions.coreJs).toBeUndefined();
+      expect(napiOptions.runtimePolyfillModeNative).toBeUndefined();
+      applied.cleanup();
     });
   });
 
-  test("scans local dependency files", () => {
-    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfill-scan-"));
-    try {
-      writeFileSync(join(dir, "entry.ts"), `import { run } from "./dep"; run();`);
-      writeFileSync(join(dir, "dep.ts"), `export const run = () => "a".replaceAll("a", "b");`);
-      expect(
-        collectRuntimePolyfillUsageFromFiles([join(dir, "entry.ts")], {
-          resolveExtensions: [".ts", ".custom"],
-        }),
-      ).toEqual(["es.string.replace-all"]);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
+  test("applies include/exclude without mutating runBeforeMain", () => {
+    const runtimeRequire = makeRuntimeRequire((modules) =>
+      Array.isArray(modules) ? modules : ["es.promise", "web.structured-clone"],
+    );
 
-  test("ignores entry files whose contents fail to read", () => {
-    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfill-scan-"));
-    try {
-      const missing = join(dir, "vanished.ts");
-      expect(collectRuntimePolyfillUsageFromFiles([missing])).toEqual([]);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  test("scans require dependencies and directory index modules", () => {
-    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfill-scan-"));
-    try {
-      writeFileSync(
-        join(dir, "entry.ts"),
-        `require("./dep"); import "./folder"; import "./empty"; import "./missing"; import "./style.css";`,
-      );
-      writeFileSync(join(dir, "dep.js"), `new Set();`);
-      mkdirSync(join(dir, "folder"));
-      writeFileSync(join(dir, "folder", "index.ts"), `[1].at(0);`);
-      mkdirSync(join(dir, "empty"));
-      writeFileSync(join(dir, "style.css"), `.x { color: red; }`);
-      expect(collectRuntimePolyfillUsageFromFiles([join(dir, "entry.ts")])).toEqual([
-        "es.array.at",
-        "es.set",
-      ]);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-});
-
-describe("runtime polyfill prelude", () => {
-  test("creates a removable side-effect import prelude", () => {
-    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfill-prelude-"));
-    try {
-      const entry = join(dir, "entry.ts");
-      writeFileSync(entry, `console.log("entry");`);
-      const prelude = createRuntimePolyfillPrelude(["es.string.replace-all"], {
-        entryPoints: [entry],
-      });
-      expect(prelude).not.toBeNull();
-      const path = prelude!.path;
-      expect(readFileSync(path, "utf8")).toContain("core-js/modules/es.string.replace-all.js");
-      prelude!.cleanup();
-      expect(existsSync(path)).toBe(false);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  test("uses the test-hook runtime require when overridden", () => {
-    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfill-prelude-"));
-    try {
-      const entry = join(dir, "entry.ts");
-      writeFileSync(entry, `console.log("entry");`);
-      const stub = {
-        resolve(specifier: string) {
-          return `/virtual/${specifier}`;
-        },
-      };
-      withRuntimeRequire(stub, () => {
-        const prelude = createRuntimePolyfillPrelude(["es.string.replace-all"], {
-          entryPoints: [entry],
-        });
-        expect(prelude).not.toBeNull();
-        try {
-          expect(readFileSync(prelude!.path, "utf8")).toContain(
-            "/virtual/core-js/modules/es.string.replace-all.js",
-          );
-        } finally {
-          prelude!.cleanup();
-        }
-      });
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  test("throws when a requested core-js module cannot be resolved", () => {
-    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfill-prelude-"));
-    try {
-      const entry = join(dir, "entry.ts");
-      writeFileSync(entry, `console.log("entry");`);
-      expect(() =>
-        createRuntimePolyfillPrelude(["es.not-real"], {
-          entryPoints: [entry],
-        }),
-      ).toThrow("could not resolve");
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  test("applies include/exclude and prepends runtime prelude before runBeforeMain", () => {
-    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfill-apply-"));
-    try {
-      const entry = join(dir, "entry.ts");
-      const init = join(dir, "init.ts");
-      writeFileSync(entry, `"a".replaceAll("a", "b");`);
-      writeFileSync(init, `globalThis.__INIT__ = true;`);
-
+    withRuntimeRequire(runtimeRequire, () => {
+      const init = "/app/src/init.ts";
       const napiOptions: Record<string, unknown> = {};
       const applied = applyRuntimePolyfillsToNapiOptions(napiOptions, {
-        entryPoints: [entry],
+        entryPoints: ["/app/src/entry.ts"],
         runtimePolyfills: {
           mode: "auto",
           targets: ["ios_saf 12"],
@@ -402,63 +362,112 @@ describe("runtime polyfill prelude", () => {
         },
         runBeforeMain: [init],
       });
-      try {
-        expect(applied.modules).toEqual(["es.array.at"]);
-        const runBeforeMain = napiOptions.runBeforeMain as string[];
-        expect(typeof runBeforeMain[0]).toBe("string");
-        expect(runBeforeMain[1]).toBe(init);
-        expect(readFileSync(runBeforeMain[0], "utf8")).toContain("core-js/modules/es.array.at.js");
-      } finally {
-        applied.cleanup();
-      }
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+
+      expect(applied.modules).toContain("es.array.at");
+      expect(applied.modules).not.toContain("es.string.replace-all");
+      expect(napiOptions.runtimePolyfillModeNative).toBe("usage");
+      expect(napiOptions.runtimePolyfillIncludeModules).toEqual(["es.array.at"]);
+      expect(napiOptions.runtimePolyfillExcludeModules).toEqual(["es.string.replace-all"]);
+      expect(napiOptions.runBeforeMain).toBeUndefined();
+      applied.cleanup();
+    });
   });
 
-  test("entry mode injects the target-wide compat prelude", () => {
-    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfill-entry-"));
-    try {
-      const entry = join(dir, "entry.ts");
-      writeFileSync(entry, `console.log("entry");`);
+  test("entry mode passes target-wide modules as native entry roots", () => {
+    const runtimeRequire = makeRuntimeRequire((modules) =>
+      modules instanceof RegExp ? ["es.promise", "web.structured-clone"] : [],
+    );
+
+    withRuntimeRequire(runtimeRequire, () => {
       const napiOptions: Record<string, unknown> = {};
       const applied = applyRuntimePolyfillsToNapiOptions(napiOptions, {
-        entryPoints: [entry],
-        runtimePolyfills: { mode: "entry", targets: ["ie 11"] },
+        entryPoints: ["/app/src/entry.ts"],
+        runtimePolyfills: { mode: "entry", targets: ["ie 11"], include: ["es.array.at"] },
       });
-      try {
-        expect(applied.modules.length).toBeGreaterThan(0);
-        const runBeforeMain = napiOptions.runBeforeMain as string[];
-        expect(readFileSync(runBeforeMain[0], "utf8")).toContain("core-js/modules/");
-      } finally {
-        applied.cleanup();
-      }
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+
+      expect(applied.modules).toEqual(["es.array.at", "es.promise", "web.structured-clone"]);
+      expect(napiOptions.runtimePolyfillModeNative).toBe("entry");
+      expect(napiOptions.runtimePolyfillEntryModules).toEqual([
+        "es.promise",
+        "web.structured-clone",
+      ]);
+      expect(napiOptions.runtimePolyfillIncludeModules).toEqual(["es.array.at"]);
+      applied.cleanup();
+    });
   });
 
-  test("off mode and empty module results return callable cleanup functions", () => {
-    const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfill-empty-"));
-    try {
-      const entry = join(dir, "entry.ts");
-      writeFileSync(entry, `console.log("entry");`);
+  test("entry mode skips native plan when target-wide result is empty", () => {
+    const runtimeRequire = makeRuntimeRequire(() => []);
 
-      const off = applyRuntimePolyfillsToNapiOptions({}, { entryPoints: [entry] });
-      expect(off.modules).toEqual([]);
-      off.cleanup();
+    withRuntimeRequire(runtimeRequire, () => {
+      const napiOptions: Record<string, unknown> = {};
+      const applied = applyRuntimePolyfillsToNapiOptions(napiOptions, {
+        entryPoints: ["/app/src/entry.ts"],
+        runtimePolyfills: { mode: "entry", targets: ["node 18"] },
+      });
 
-      const empty = applyRuntimePolyfillsToNapiOptions(
-        {},
-        {
-          entryPoints: [entry],
-          runtimePolyfills: { mode: "auto", targets: ["node 18"] },
+      expect(applied.modules).toEqual([]);
+      expect(napiOptions.runtimePolyfillModeNative).toBeUndefined();
+      applied.cleanup();
+    });
+  });
+
+  test("resolves core-js with package-relative fallback when no test require is installed", () => {
+    __runtimePolyfillTestHooks.reset();
+    const napiOptions: Record<string, unknown> = {};
+    const applied = applyRuntimePolyfillsToNapiOptions(napiOptions, {
+      entryPoints: ["/app/src/entry.ts"],
+      runtimePolyfills: { mode: "auto", include: ["es.array.at"] },
+    });
+
+    expect(applied.modules).toContain("es.array.at");
+    expect((napiOptions.runtimePolyfillIncludePaths as string[])[0]).toContain(
+      "core-js/modules/es.array.at.js",
+    );
+    applied.cleanup();
+  });
+
+  test("throws when a requested core-js module cannot be resolved", () => {
+    const runtimeRequire = Object.assign(
+      (id: string) => {
+        if (id === "core-js-compat") return () => ({ list: [] });
+        throw new Error(`unexpected require: ${id}`);
+      },
+      {
+        resolve() {
+          throw new Error("missing core-js");
         },
-      );
+      },
+    );
+
+    withRuntimeRequire(runtimeRequire, () => {
+      expect(() =>
+        applyRuntimePolyfillsToNapiOptions(
+          {},
+          {
+            entryPoints: ["/app/src/entry.ts"],
+            runtimePolyfills: { mode: "auto", include: ["es.array.at"] },
+          },
+        ),
+      ).toThrow("could not resolve");
+    });
+  });
+
+  test("off mode and empty target results return callable cleanup functions", () => {
+    const off = applyRuntimePolyfillsToNapiOptions({}, { entryPoints: ["/app/src/entry.ts"] });
+    expect(off.modules).toEqual([]);
+    off.cleanup();
+
+    const runtimeRequire = makeRuntimeRequire(() => []);
+    withRuntimeRequire(runtimeRequire, () => {
+      const napiOptions: Record<string, unknown> = {};
+      const empty = applyRuntimePolyfillsToNapiOptions(napiOptions, {
+        entryPoints: ["/app/src/entry.ts"],
+        runtimePolyfills: { mode: "auto", targets: ["node 18"] },
+      });
       expect(empty.modules).toEqual([]);
+      expect(napiOptions.runtimePolyfillModeNative).toBeUndefined();
       empty.cleanup();
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    });
   });
 });

--- a/packages/core/src/runtime-polyfills.test.ts
+++ b/packages/core/src/runtime-polyfills.test.ts
@@ -262,24 +262,26 @@ describe("runtime polyfill native plan", () => {
         runtimePolyfills: { mode: "auto", targets: ["safari 5"] },
       });
 
-      expect(napiOptions.runtimePolyfillCandidateModules).toEqual([
-        "es.array.at",
-        "es.array.find-last",
-        "es.map",
-        "es.map.group-by",
-        "es.math.trunc",
-        "es.object.has-own",
-        "es.object.values",
-        "es.set",
-        "es.set.union.v2",
-        "es.promise",
-        "es.promise.any",
-        "web.structured-clone",
-        "es.string.pad-start",
-        "es.string.replace-all",
-        "es.weak-map",
-        "web.url",
-      ]);
+      expect(napiOptions.runtimePolyfillCandidateModules).toEqual(
+        expect.arrayContaining([
+          "es.array.at",
+          "es.array.find-last",
+          "es.map",
+          "es.map.group-by",
+          "es.math.trunc",
+          "es.object.has-own",
+          "es.object.values",
+          "es.set",
+          "es.set.union.v2",
+          "es.promise",
+          "es.promise.any",
+          "web.structured-clone",
+          "es.string.pad-start",
+          "es.string.replace-all",
+          "es.weak-map",
+          "web.url",
+        ]),
+      );
       expect(napiOptions.runtimePolyfillCandidateFeatures).toContain("map_group_by");
       expect(napiOptions.runtimePolyfillCandidateFeatures).toContain("set_union");
       expect(napiOptions.runtimePolyfillCandidateFeatures).toContain("promise_any");

--- a/packages/core/src/runtime-polyfills.ts
+++ b/packages/core/src/runtime-polyfills.ts
@@ -614,9 +614,8 @@ function uniqueSorted(values: Iterable<string>): string[] {
 
 function resolveRuntimeModules(
   modules: Iterable<string>,
-  options: RuntimePolyfillBuildOptions,
+  resolveCoreJs: (moduleName: string) => string,
 ): ResolvedRuntimeModule[] {
-  const resolveCoreJs = buildCoreJsResolver(options.entryPoints);
   return uniqueSorted(modules).map((moduleName) => ({
     module: moduleName,
     path: resolveCoreJs(moduleName),
@@ -646,14 +645,15 @@ export function applyRuntimePolyfillsToNapiOptions(
 
   const exclude = new Set(runtime.exclude);
   const includeModules = runtime.include.filter((moduleName) => !exclude.has(moduleName));
-  const includeResolved = resolveRuntimeModules(includeModules, options);
+  const resolveCoreJs = buildCoreJsResolver(options.entryPoints);
+  const includeResolved = resolveRuntimeModules(includeModules, resolveCoreJs);
 
   if (runtime.mode === "entry") {
     const entryModules = computeCoreJsCompatModules(runtime.targets, /^(?:es|web)\./, {
       version: runtime.coreJsVersion,
       proposals: runtime.proposals,
     }).filter((moduleName) => !exclude.has(moduleName));
-    const entryResolved = resolveRuntimeModules(entryModules, options);
+    const entryResolved = resolveRuntimeModules(entryModules, resolveCoreJs);
     if (entryResolved.length === 0 && includeResolved.length === 0) {
       return { cleanup: () => {}, modules: [] };
     }
@@ -674,7 +674,6 @@ export function applyRuntimePolyfillsToNapiOptions(
     }).filter((moduleName) => !exclude.has(moduleName)),
   );
   const candidates: ResolvedRuntimeCandidate[] = [];
-  const resolveCoreJs = buildCoreJsResolver(options.entryPoints);
   for (const item of RUNTIME_POLYFILL_FEATURE_MODULES) {
     if (!targetCandidateSet.has(item.module)) continue;
     candidates.push({

--- a/packages/core/src/runtime-polyfills.ts
+++ b/packages/core/src/runtime-polyfills.ts
@@ -1,7 +1,6 @@
-import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
-import { tmpdir } from "node:os";
-import { dirname, extname, isAbsolute, join, resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 
 export type RuntimePolyfillMode = "auto" | "usage" | "entry";
 export type RuntimePolyfillProvider = "core-js";
@@ -10,7 +9,7 @@ export interface RuntimePolyfillOptions {
   /**
    * Runtime polyfill injection strategy.
    *
-   * `auto` and `usage` scan statically detectable API usage, while `entry`
+   * `auto` and `usage` select from graph-detected API usage, while `entry`
    * injects all target-required core-js ES/Web modules.
    */
   mode?: RuntimePolyfillMode;
@@ -26,7 +25,7 @@ export interface RuntimePolyfillOptions {
   targets?: string | string[];
   /** core-js version used for compatibility calculation, matching Rspack/SWC `env.coreJs`. */
   coreJs?: string;
-  /** Additional core-js modules to force into the synthetic prelude. */
+  /** Additional core-js modules to force into the runtime prelude. */
   include?: string[];
   /** core-js modules to remove after target and usage calculation. */
   exclude?: string[];
@@ -69,9 +68,16 @@ type CoreJsCompat = (options: {
   proposals?: boolean;
 }) => { list: string[] };
 
-type BabelParser = {
-  parse(source: string, options: Record<string, unknown>): unknown;
-};
+type RuntimePolyfillFeature = string;
+
+interface ResolvedRuntimeModule {
+  module: string;
+  path: string;
+}
+
+interface ResolvedRuntimeCandidate extends ResolvedRuntimeModule {
+  feature: RuntimePolyfillFeature;
+}
 
 let runtimeRequireOverride: RuntimeRequire | null = null;
 
@@ -83,13 +89,11 @@ function getRuntimeRequire(): RuntimeRequire {
 export const __runtimePolyfillTestHooks = {
   reset() {
     coreJsCompatCache = undefined;
-    babelParserCache = undefined;
     coreJsVersionCache = undefined;
     runtimeRequireOverride = null;
   },
   setRuntimeRequire(runtimeRequire: RuntimeRequire | null) {
     coreJsCompatCache = undefined;
-    babelParserCache = undefined;
     coreJsVersionCache = undefined;
     runtimeRequireOverride = runtimeRequire;
   },
@@ -114,10 +118,310 @@ const ES_TARGETS = new Set([
 const DEVICE_TARGET_RE =
   /\b(?:iphone|ipad|ipod|galaxy|pixel|nexus|oneplus|xiaomi|redmi|huawei|motorola|moto)\b/i;
 
-const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"];
+const RUNTIME_POLYFILL_FEATURE_MODULES: readonly {
+  feature: RuntimePolyfillFeature;
+  module: string;
+}[] = [
+  { feature: "aggregate_error", module: "es.aggregate-error" },
+  { feature: "aggregate_error", module: "es.aggregate-error.cause" },
+  { feature: "array_buffer", module: "es.array-buffer.constructor" },
+  { feature: "array_buffer_detached", module: "es.array-buffer.detached" },
+  { feature: "array_buffer_is_view", module: "es.array-buffer.is-view" },
+  { feature: "array_buffer_slice", module: "es.array-buffer.slice" },
+  { feature: "array_buffer_transfer", module: "es.array-buffer.transfer" },
+  {
+    feature: "array_buffer_transfer_to_fixed_length",
+    module: "es.array-buffer.transfer-to-fixed-length",
+  },
+  { feature: "array_at", module: "es.array.at" },
+  { feature: "array_concat", module: "es.array.concat" },
+  { feature: "array_copy_within", module: "es.array.copy-within" },
+  { feature: "array_every", module: "es.array.every" },
+  { feature: "array_fill", module: "es.array.fill" },
+  { feature: "array_filter", module: "es.array.filter" },
+  { feature: "array_find", module: "es.array.find" },
+  { feature: "array_find_index", module: "es.array.find-index" },
+  { feature: "array_find_last", module: "es.array.find-last" },
+  { feature: "array_find_last_index", module: "es.array.find-last-index" },
+  { feature: "array_flat", module: "es.array.flat" },
+  { feature: "array_flat_map", module: "es.array.flat-map" },
+  { feature: "array_for_each", module: "es.array.for-each" },
+  { feature: "array_from", module: "es.array.from" },
+  { feature: "array_from_async", module: "es.array.from-async" },
+  { feature: "array_includes", module: "es.array.includes" },
+  { feature: "array_index_of", module: "es.array.index-of" },
+  { feature: "array_is_array", module: "es.array.is-array" },
+  { feature: "array_join", module: "es.array.join" },
+  { feature: "array_last_index_of", module: "es.array.last-index-of" },
+  { feature: "array_map", module: "es.array.map" },
+  { feature: "array_of", module: "es.array.of" },
+  { feature: "array_push", module: "es.array.push" },
+  { feature: "array_reduce", module: "es.array.reduce" },
+  { feature: "array_reduce_right", module: "es.array.reduce-right" },
+  { feature: "array_reverse", module: "es.array.reverse" },
+  { feature: "array_slice", module: "es.array.slice" },
+  { feature: "array_some", module: "es.array.some" },
+  { feature: "array_sort", module: "es.array.sort" },
+  { feature: "array_splice", module: "es.array.splice" },
+  { feature: "array_to_reversed", module: "es.array.to-reversed" },
+  { feature: "array_to_sorted", module: "es.array.to-sorted" },
+  { feature: "array_to_spliced", module: "es.array.to-spliced" },
+  { feature: "array_unshift", module: "es.array.unshift" },
+  { feature: "array_with", module: "es.array.with" },
+  { feature: "async_disposable_stack", module: "es.async-disposable-stack.constructor" },
+  { feature: "data_view", module: "es.data-view" },
+  { feature: "data_view_get_float16", module: "es.data-view.get-float16" },
+  { feature: "data_view_set_float16", module: "es.data-view.set-float16" },
+  { feature: "date_now", module: "es.date.now" },
+  { feature: "date_to_iso_string", module: "es.date.to-iso-string" },
+  { feature: "disposable_stack", module: "es.disposable-stack.constructor" },
+  { feature: "error_is_error", module: "es.error.is-error" },
+  { feature: "escape", module: "es.escape" },
+  { feature: "function_bind", module: "es.function.bind" },
+  { feature: "global_this", module: "es.global-this" },
+  { feature: "iterator", module: "es.iterator.constructor" },
+  { feature: "iterator_drop", module: "es.iterator.drop" },
+  { feature: "iterator_every", module: "es.iterator.every" },
+  { feature: "iterator_filter", module: "es.iterator.filter" },
+  { feature: "iterator_find", module: "es.iterator.find" },
+  { feature: "iterator_flat_map", module: "es.iterator.flat-map" },
+  { feature: "iterator_for_each", module: "es.iterator.for-each" },
+  { feature: "iterator_from", module: "es.iterator.from" },
+  { feature: "iterator_map", module: "es.iterator.map" },
+  { feature: "iterator_reduce", module: "es.iterator.reduce" },
+  { feature: "iterator_some", module: "es.iterator.some" },
+  { feature: "iterator_take", module: "es.iterator.take" },
+  { feature: "iterator_to_array", module: "es.iterator.to-array" },
+  { feature: "json_is_raw_json", module: "es.json.is-raw-json" },
+  { feature: "json_parse", module: "es.json.parse" },
+  { feature: "json_raw_json", module: "es.json.raw-json" },
+  { feature: "json_stringify", module: "es.json.stringify" },
+  { feature: "map", module: "es.map" },
+  { feature: "map_get_or_insert", module: "es.map.get-or-insert" },
+  { feature: "map_get_or_insert_computed", module: "es.map.get-or-insert-computed" },
+  { feature: "map_group_by", module: "es.map.group-by" },
+  { feature: "math_acosh", module: "es.math.acosh" },
+  { feature: "math_asinh", module: "es.math.asinh" },
+  { feature: "math_atanh", module: "es.math.atanh" },
+  { feature: "math_cbrt", module: "es.math.cbrt" },
+  { feature: "math_clz32", module: "es.math.clz32" },
+  { feature: "math_cosh", module: "es.math.cosh" },
+  { feature: "math_expm1", module: "es.math.expm1" },
+  { feature: "math_f16round", module: "es.math.f16round" },
+  { feature: "math_fround", module: "es.math.fround" },
+  { feature: "math_hypot", module: "es.math.hypot" },
+  { feature: "math_imul", module: "es.math.imul" },
+  { feature: "math_log10", module: "es.math.log10" },
+  { feature: "math_log1p", module: "es.math.log1p" },
+  { feature: "math_log2", module: "es.math.log2" },
+  { feature: "math_sign", module: "es.math.sign" },
+  { feature: "math_sinh", module: "es.math.sinh" },
+  { feature: "math_sum_precise", module: "es.math.sum-precise" },
+  { feature: "math_tanh", module: "es.math.tanh" },
+  { feature: "math_trunc", module: "es.math.trunc" },
+  { feature: "number_constructor", module: "es.number.constructor" },
+  { feature: "number_epsilon", module: "es.number.epsilon" },
+  { feature: "number_is_finite", module: "es.number.is-finite" },
+  { feature: "number_is_integer", module: "es.number.is-integer" },
+  { feature: "number_is_nan", module: "es.number.is-nan" },
+  { feature: "number_is_safe_integer", module: "es.number.is-safe-integer" },
+  { feature: "number_max_safe_integer", module: "es.number.max-safe-integer" },
+  { feature: "number_min_safe_integer", module: "es.number.min-safe-integer" },
+  { feature: "number_parse_float", module: "es.number.parse-float" },
+  { feature: "number_parse_int", module: "es.number.parse-int" },
+  { feature: "number_to_exponential", module: "es.number.to-exponential" },
+  { feature: "number_to_fixed", module: "es.number.to-fixed" },
+  { feature: "number_to_precision", module: "es.number.to-precision" },
+  { feature: "object_assign", module: "es.object.assign" },
+  { feature: "object_create", module: "es.object.create" },
+  { feature: "object_define_getter", module: "es.object.define-getter" },
+  { feature: "object_define_properties", module: "es.object.define-properties" },
+  { feature: "object_define_property", module: "es.object.define-property" },
+  { feature: "object_define_setter", module: "es.object.define-setter" },
+  { feature: "object_entries", module: "es.object.entries" },
+  { feature: "object_freeze", module: "es.object.freeze" },
+  { feature: "object_from_entries", module: "es.object.from-entries" },
+  {
+    feature: "object_get_own_property_descriptor",
+    module: "es.object.get-own-property-descriptor",
+  },
+  {
+    feature: "object_get_own_property_descriptors",
+    module: "es.object.get-own-property-descriptors",
+  },
+  { feature: "object_get_own_property_names", module: "es.object.get-own-property-names" },
+  { feature: "object_get_prototype_of", module: "es.object.get-prototype-of" },
+  { feature: "object_group_by", module: "es.object.group-by" },
+  { feature: "object_has_own", module: "es.object.has-own" },
+  { feature: "object_is", module: "es.object.is" },
+  { feature: "object_is_extensible", module: "es.object.is-extensible" },
+  { feature: "object_is_frozen", module: "es.object.is-frozen" },
+  { feature: "object_is_sealed", module: "es.object.is-sealed" },
+  { feature: "object_keys", module: "es.object.keys" },
+  { feature: "object_lookup_getter", module: "es.object.lookup-getter" },
+  { feature: "object_lookup_setter", module: "es.object.lookup-setter" },
+  { feature: "object_prevent_extensions", module: "es.object.prevent-extensions" },
+  { feature: "object_proto", module: "es.object.proto" },
+  { feature: "object_seal", module: "es.object.seal" },
+  { feature: "object_set_prototype_of", module: "es.object.set-prototype-of" },
+  { feature: "object_values", module: "es.object.values" },
+  { feature: "parse_float", module: "es.parse-float" },
+  { feature: "parse_int", module: "es.parse-int" },
+  { feature: "set", module: "es.set" },
+  { feature: "set_difference", module: "es.set.difference.v2" },
+  { feature: "set_intersection", module: "es.set.intersection.v2" },
+  { feature: "set_is_disjoint_from", module: "es.set.is-disjoint-from.v2" },
+  { feature: "set_is_subset_of", module: "es.set.is-subset-of.v2" },
+  { feature: "set_is_superset_of", module: "es.set.is-superset-of.v2" },
+  { feature: "set_symmetric_difference", module: "es.set.symmetric-difference.v2" },
+  { feature: "set_union", module: "es.set.union.v2" },
+  { feature: "promise", module: "es.promise" },
+  { feature: "promise_all_settled", module: "es.promise.all-settled" },
+  { feature: "promise_any", module: "es.promise.any" },
+  { feature: "promise_finally", module: "es.promise.finally" },
+  { feature: "promise_try", module: "es.promise.try" },
+  { feature: "promise_with_resolvers", module: "es.promise.with-resolvers" },
+  { feature: "reflect_apply", module: "es.reflect.apply" },
+  { feature: "reflect_construct", module: "es.reflect.construct" },
+  { feature: "reflect_define_property", module: "es.reflect.define-property" },
+  { feature: "reflect_delete_property", module: "es.reflect.delete-property" },
+  { feature: "reflect_get", module: "es.reflect.get" },
+  {
+    feature: "reflect_get_own_property_descriptor",
+    module: "es.reflect.get-own-property-descriptor",
+  },
+  { feature: "reflect_get_prototype_of", module: "es.reflect.get-prototype-of" },
+  { feature: "reflect_has", module: "es.reflect.has" },
+  { feature: "reflect_is_extensible", module: "es.reflect.is-extensible" },
+  { feature: "reflect_own_keys", module: "es.reflect.own-keys" },
+  { feature: "reflect_prevent_extensions", module: "es.reflect.prevent-extensions" },
+  { feature: "reflect_set", module: "es.reflect.set" },
+  { feature: "reflect_set_prototype_of", module: "es.reflect.set-prototype-of" },
+  { feature: "regexp_escape", module: "es.regexp.escape" },
+  { feature: "regexp_flags", module: "es.regexp.flags" },
+  { feature: "regexp_sticky", module: "es.regexp.sticky" },
+  { feature: "regexp_dot_all", module: "es.regexp.dot-all" },
+  { feature: "structured_clone", module: "web.structured-clone" },
+  { feature: "string_anchor", module: "es.string.anchor" },
+  { feature: "string_big", module: "es.string.big" },
+  { feature: "string_blink", module: "es.string.blink" },
+  { feature: "string_bold", module: "es.string.bold" },
+  { feature: "string_code_point_at", module: "es.string.code-point-at" },
+  { feature: "string_ends_with", module: "es.string.ends-with" },
+  { feature: "string_fixed", module: "es.string.fixed" },
+  { feature: "string_fontcolor", module: "es.string.fontcolor" },
+  { feature: "string_fontsize", module: "es.string.fontsize" },
+  { feature: "string_from_code_point", module: "es.string.from-code-point" },
+  { feature: "string_includes", module: "es.string.includes" },
+  { feature: "string_is_well_formed", module: "es.string.is-well-formed" },
+  { feature: "string_italics", module: "es.string.italics" },
+  { feature: "string_link", module: "es.string.link" },
+  { feature: "string_match_all", module: "es.string.match-all" },
+  { feature: "string_pad_end", module: "es.string.pad-end" },
+  { feature: "string_pad_start", module: "es.string.pad-start" },
+  { feature: "string_raw", module: "es.string.raw" },
+  { feature: "string_repeat", module: "es.string.repeat" },
+  { feature: "string_replace_all", module: "es.string.replace-all" },
+  { feature: "string_small", module: "es.string.small" },
+  { feature: "string_starts_with", module: "es.string.starts-with" },
+  { feature: "string_strike", module: "es.string.strike" },
+  { feature: "string_sub", module: "es.string.sub" },
+  { feature: "string_substr", module: "es.string.substr" },
+  { feature: "string_sup", module: "es.string.sup" },
+  { feature: "string_to_well_formed", module: "es.string.to-well-formed" },
+  { feature: "string_trim", module: "es.string.trim" },
+  { feature: "string_trim_end", module: "es.string.trim-end" },
+  { feature: "string_trim_start", module: "es.string.trim-start" },
+  { feature: "suppressed_error", module: "es.suppressed-error.constructor" },
+  { feature: "symbol", module: "es.symbol" },
+  { feature: "symbol_async_dispose", module: "es.symbol.async-dispose" },
+  { feature: "symbol_async_iterator", module: "es.symbol.async-iterator" },
+  { feature: "symbol_description", module: "es.symbol.description" },
+  { feature: "symbol_dispose", module: "es.symbol.dispose" },
+  { feature: "symbol_has_instance", module: "es.symbol.has-instance" },
+  { feature: "symbol_is_concat_spreadable", module: "es.symbol.is-concat-spreadable" },
+  { feature: "symbol_iterator", module: "es.symbol.iterator" },
+  { feature: "symbol_match", module: "es.symbol.match" },
+  { feature: "symbol_match_all", module: "es.symbol.match-all" },
+  { feature: "symbol_replace", module: "es.symbol.replace" },
+  { feature: "symbol_search", module: "es.symbol.search" },
+  { feature: "symbol_species", module: "es.symbol.species" },
+  { feature: "symbol_split", module: "es.symbol.split" },
+  { feature: "symbol_to_primitive", module: "es.symbol.to-primitive" },
+  { feature: "symbol_to_string_tag", module: "es.symbol.to-string-tag" },
+  { feature: "symbol_unscopables", module: "es.symbol.unscopables" },
+  { feature: "typed_array_float32", module: "es.typed-array.float32-array" },
+  { feature: "typed_array_float64", module: "es.typed-array.float64-array" },
+  { feature: "typed_array_int8", module: "es.typed-array.int8-array" },
+  { feature: "typed_array_int16", module: "es.typed-array.int16-array" },
+  { feature: "typed_array_int32", module: "es.typed-array.int32-array" },
+  { feature: "typed_array_uint8", module: "es.typed-array.uint8-array" },
+  { feature: "typed_array_uint8_clamped", module: "es.typed-array.uint8-clamped-array" },
+  { feature: "typed_array_uint16", module: "es.typed-array.uint16-array" },
+  { feature: "typed_array_uint32", module: "es.typed-array.uint32-array" },
+  { feature: "typed_array_at", module: "es.typed-array.at" },
+  { feature: "typed_array_copy_within", module: "es.typed-array.copy-within" },
+  { feature: "typed_array_every", module: "es.typed-array.every" },
+  { feature: "typed_array_fill", module: "es.typed-array.fill" },
+  { feature: "typed_array_filter", module: "es.typed-array.filter" },
+  { feature: "typed_array_find", module: "es.typed-array.find" },
+  { feature: "typed_array_find_index", module: "es.typed-array.find-index" },
+  { feature: "typed_array_find_last", module: "es.typed-array.find-last" },
+  { feature: "typed_array_find_last_index", module: "es.typed-array.find-last-index" },
+  { feature: "typed_array_for_each", module: "es.typed-array.for-each" },
+  { feature: "typed_array_from", module: "es.typed-array.from" },
+  { feature: "typed_array_includes", module: "es.typed-array.includes" },
+  { feature: "typed_array_index_of", module: "es.typed-array.index-of" },
+  { feature: "typed_array_join", module: "es.typed-array.join" },
+  { feature: "typed_array_last_index_of", module: "es.typed-array.last-index-of" },
+  { feature: "typed_array_map", module: "es.typed-array.map" },
+  { feature: "typed_array_of", module: "es.typed-array.of" },
+  { feature: "typed_array_reduce", module: "es.typed-array.reduce" },
+  { feature: "typed_array_reduce_right", module: "es.typed-array.reduce-right" },
+  { feature: "typed_array_reverse", module: "es.typed-array.reverse" },
+  { feature: "typed_array_set", module: "es.typed-array.set" },
+  { feature: "typed_array_slice", module: "es.typed-array.slice" },
+  { feature: "typed_array_some", module: "es.typed-array.some" },
+  { feature: "typed_array_sort", module: "es.typed-array.sort" },
+  { feature: "typed_array_subarray", module: "es.typed-array.subarray" },
+  { feature: "typed_array_to_reversed", module: "es.typed-array.to-reversed" },
+  { feature: "typed_array_to_sorted", module: "es.typed-array.to-sorted" },
+  { feature: "typed_array_with", module: "es.typed-array.with" },
+  { feature: "uint8_array_from_base64", module: "es.uint8-array.from-base64" },
+  { feature: "uint8_array_from_hex", module: "es.uint8-array.from-hex" },
+  { feature: "uint8_array_set_from_base64", module: "es.uint8-array.set-from-base64" },
+  { feature: "uint8_array_set_from_hex", module: "es.uint8-array.set-from-hex" },
+  { feature: "uint8_array_to_base64", module: "es.uint8-array.to-base64" },
+  { feature: "uint8_array_to_hex", module: "es.uint8-array.to-hex" },
+  { feature: "unescape", module: "es.unescape" },
+  { feature: "weak_map", module: "es.weak-map" },
+  { feature: "weak_map_get_or_insert", module: "es.weak-map.get-or-insert" },
+  { feature: "weak_map_get_or_insert_computed", module: "es.weak-map.get-or-insert-computed" },
+  { feature: "weak_set", module: "es.weak-set" },
+  { feature: "web_atob", module: "web.atob" },
+  { feature: "web_btoa", module: "web.btoa" },
+  { feature: "web_dom_collections_for_each", module: "web.dom-collections.for-each" },
+  { feature: "web_dom_collections_iterator", module: "web.dom-collections.iterator" },
+  { feature: "web_dom_exception", module: "web.dom-exception.constructor" },
+  { feature: "web_immediate", module: "web.immediate" },
+  { feature: "web_queue_microtask", module: "web.queue-microtask" },
+  { feature: "web_self", module: "web.self" },
+  { feature: "web_timers", module: "web.timers" },
+  { feature: "web_url", module: "web.url" },
+  { feature: "web_url_can_parse", module: "web.url.can-parse" },
+  { feature: "web_url_parse", module: "web.url.parse" },
+  { feature: "web_url_to_json", module: "web.url.to-json" },
+  { feature: "web_url_search_params", module: "web.url-search-params" },
+  { feature: "web_url_search_params_delete", module: "web.url-search-params.delete" },
+  { feature: "web_url_search_params_has", module: "web.url-search-params.has" },
+  { feature: "web_url_search_params_size", module: "web.url-search-params.size" },
+];
+
+const RUNTIME_POLYFILL_CANDIDATE_MODULES = RUNTIME_POLYFILL_FEATURE_MODULES.map(
+  (item) => item.module,
+);
 
 let coreJsCompatCache: CoreJsCompat | null | undefined;
-let babelParserCache: BabelParser | null | undefined;
 let coreJsVersionCache: string | null | undefined;
 
 export function isEsTarget(target: string | undefined): boolean {
@@ -142,27 +446,6 @@ function loadCoreJsCompat(): CoreJsCompat {
 function throwCoreJsCompatMissing(): never {
   throw new Error(
     "@zts/core: runtimePolyfills requires the optional 'core-js-compat' package. Install it with `bun add core-js core-js-compat`.",
-  );
-}
-
-function loadBabelParser(): BabelParser {
-  if (babelParserCache !== undefined) {
-    if (babelParserCache) return babelParserCache;
-    throwBabelParserMissing();
-  }
-  try {
-    const req = getRuntimeRequire();
-    babelParserCache = req("@babel/parser") as BabelParser;
-    return babelParserCache;
-  } catch {
-    babelParserCache = null;
-    throwBabelParserMissing();
-  }
-}
-
-function throwBabelParserMissing(): never {
-  throw new Error(
-    "@zts/core: runtimePolyfills auto/usage mode requires the optional '@babel/parser' package. Install it with `bun add @babel/parser`.",
   );
 }
 
@@ -299,289 +582,6 @@ export function computeCoreJsCompatModules(
   return result.list.map(normalizeCoreJsModuleName).sort();
 }
 
-function parseSource(source: string, filename: string): unknown {
-  const parser = loadBabelParser();
-  const baseOptions = {
-    sourceType: "unambiguous",
-    sourceFilename: filename,
-    errorRecovery: true,
-  };
-  try {
-    return parser.parse(source, {
-      ...baseOptions,
-      plugins: [
-        "typescript",
-        "jsx",
-        "classProperties",
-        "classPrivateProperties",
-        "classPrivateMethods",
-        "decorators-legacy",
-        "dynamicImport",
-        "importAttributes",
-        "topLevelAwait",
-      ],
-    });
-  } catch {
-    return parser.parse(source, {
-      ...baseOptions,
-      plugins: [
-        "flow",
-        "jsx",
-        "classProperties",
-        "classPrivateProperties",
-        "classPrivateMethods",
-        "decorators-legacy",
-        "dynamicImport",
-        "importAttributes",
-        "topLevelAwait",
-      ],
-    });
-  }
-}
-
-function isNode(value: unknown): value is Record<string, unknown> {
-  return (
-    value !== null &&
-    typeof value === "object" &&
-    typeof (value as { type?: unknown }).type === "string"
-  );
-}
-
-function stringLiteralValue(value: unknown): string | null {
-  if (!isNode(value)) return null;
-  if (value.type === "StringLiteral" || value.type === "Literal") {
-    const raw = value.value;
-    return typeof raw === "string" ? raw : null;
-  }
-  return null;
-}
-
-function memberName(member: Record<string, unknown>): string | null {
-  const property = member.property;
-  if (!isNode(property)) return null;
-  if (property.type === "Identifier" && member.computed !== true) {
-    return typeof property.name === "string" ? property.name : null;
-  }
-  return stringLiteralValue(property);
-}
-
-function identifierName(node: unknown): string | null {
-  return isNode(node) && node.type === "Identifier" && typeof node.name === "string"
-    ? node.name
-    : null;
-}
-
-function recordIdentifierUsage(name: string, out: Set<string>): void {
-  if (name === "Map") out.add("es.map");
-  else if (name === "Set") out.add("es.set");
-  else if (name === "Promise") out.add("es.promise");
-  else if (name === "structuredClone") out.add("web.structured-clone");
-}
-
-function recordMemberUsage(member: Record<string, unknown>, out: Set<string>): void {
-  const prop = memberName(member);
-  if (prop === "replaceAll") out.add("es.string.replace-all");
-  else if (prop === "at") out.add("es.array.at");
-  else if (prop === "hasOwn" && identifierName(member.object) === "Object") {
-    out.add("es.object.has-own");
-  }
-
-  const objName = identifierName(member.object);
-  if (objName) recordIdentifierUsage(objName, out);
-}
-
-function shouldSkipIdentifier(
-  node: Record<string, unknown>,
-  parent: Record<string, unknown> | null,
-): boolean {
-  if (!parent) return false;
-  if (parent.type === "MemberExpression" && parent.property === node && parent.computed !== true)
-    return true;
-  if (parent.type === "ObjectProperty" && parent.key === node && parent.computed !== true)
-    return true;
-  if (parent.type === "ObjectMethod" && parent.key === node && parent.computed !== true)
-    return true;
-  if (parent.type === "VariableDeclarator" && parent.id === node) return true;
-  if (parent.type === "FunctionDeclaration" && parent.id === node) return true;
-  if (parent.type === "FunctionExpression" && parent.id === node) return true;
-  if (parent.type === "ClassDeclaration" && parent.id === node) return true;
-  if (parent.type === "ClassExpression" && parent.id === node) return true;
-  if (parent.type === "ImportSpecifier" || parent.type === "ImportDefaultSpecifier") return true;
-  if (parent.type === "ImportNamespaceSpecifier") return true;
-  return false;
-}
-
-function visitAst(
-  node: unknown,
-  parent: Record<string, unknown> | null,
-  cb: (node: Record<string, unknown>, parent: Record<string, unknown> | null) => void,
-): void {
-  if (!isNode(node)) return;
-  cb(node, parent);
-  for (const [key, value] of Object.entries(node)) {
-    if (
-      key === "loc" ||
-      key === "start" ||
-      key === "end" ||
-      key === "range" ||
-      key === "leadingComments" ||
-      key === "trailingComments" ||
-      key === "innerComments"
-    ) {
-      continue;
-    }
-    if (Array.isArray(value)) {
-      for (const item of value) visitAst(item, node, cb);
-    } else {
-      visitAst(value, node, cb);
-    }
-  }
-}
-
-function scanAst(ast: unknown): { used: Set<string>; specifiers: string[] } {
-  const used = new Set<string>();
-  const specifiers: string[] = [];
-  visitAst(ast, null, (node, parent) => {
-    if (node.type === "MemberExpression") {
-      recordMemberUsage(node, used);
-      return;
-    }
-    if (node.type === "NewExpression" || node.type === "CallExpression") {
-      const name = identifierName(node.callee);
-      if (name) recordIdentifierUsage(name, used);
-      if (node.type === "CallExpression" && name === "require") {
-        const args = Array.isArray(node.arguments) ? node.arguments : [];
-        const spec = stringLiteralValue(args[0]);
-        if (spec) specifiers.push(spec);
-      }
-      return;
-    }
-    if (node.type === "Identifier" && !shouldSkipIdentifier(node, parent)) {
-      const name = identifierName(node);
-      if (name) recordIdentifierUsage(name, used);
-      return;
-    }
-    if (
-      (node.type === "ImportDeclaration" ||
-        node.type === "ExportNamedDeclaration" ||
-        node.type === "ExportAllDeclaration") &&
-      node.source
-    ) {
-      const spec = stringLiteralValue(node.source);
-      if (spec) specifiers.push(spec);
-    }
-  });
-  return { used, specifiers };
-}
-
-export function scanRuntimePolyfillUsage(source: string, filename = "input.js"): string[] {
-  const { used } = scanAst(parseSource(source, filename));
-  return [...used].sort();
-}
-
-function isRelativeSpecifier(specifier: string): boolean {
-  return specifier.startsWith("./") || specifier.startsWith("../") || isAbsolute(specifier);
-}
-
-function isSourceFile(path: string): boolean {
-  return SOURCE_EXTENSIONS.includes(extname(path));
-}
-
-function tryFile(path: string): string | null {
-  try {
-    if (statSync(path).isFile() && isSourceFile(path)) return path;
-  } catch {}
-  return null;
-}
-
-function resolveSourceImport(
-  importer: string,
-  specifier: string,
-  resolveExtensions: readonly string[] | undefined,
-): string | null {
-  if (!isRelativeSpecifier(specifier)) return null;
-  const base = isAbsolute(specifier) ? specifier : resolve(dirname(importer), specifier);
-  const explicit = tryFile(base);
-  if (explicit) return explicit;
-
-  const extensions = [
-    ...(resolveExtensions?.filter((ext) => SOURCE_EXTENSIONS.includes(ext)) ?? []),
-    ...SOURCE_EXTENSIONS,
-  ];
-  for (const ext of extensions) {
-    const found = tryFile(base + ext);
-    if (found) return found;
-  }
-
-  try {
-    if (statSync(base).isDirectory()) {
-      for (const ext of extensions) {
-        const found = tryFile(join(base, "index" + ext));
-        if (found) return found;
-      }
-    }
-  } catch {}
-  return null;
-}
-
-export function collectRuntimePolyfillUsageFromFiles(
-  entryPoints: readonly string[],
-  options: { resolveExtensions?: readonly string[] } = {},
-): string[] {
-  const queue = entryPoints.map((entry) => resolve(entry));
-  const seen = new Set<string>();
-  const used = new Set<string>();
-
-  for (let head = 0; head < queue.length; head++) {
-    const file = queue[head]!;
-    if (seen.has(file) || !isSourceFile(file)) continue;
-    let source: string;
-    try {
-      source = readFileSync(file, "utf8");
-    } catch {
-      continue;
-    }
-    seen.add(file);
-    const { used: fileUsed, specifiers } = scanAst(parseSource(source, file));
-    for (const moduleName of fileUsed) used.add(moduleName);
-    for (const specifier of specifiers) {
-      const resolved = resolveSourceImport(file, specifier, options.resolveExtensions);
-      if (resolved && !seen.has(resolved)) queue.push(resolved);
-    }
-  }
-
-  return [...used].sort();
-}
-
-function computeRuntimePolyfillModules(
-  options: RuntimePolyfillBuildOptions,
-  runtime: NormalizedRuntimePolyfills,
-): string[] {
-  const include = new Set(runtime.include);
-  const exclude = new Set(runtime.exclude);
-  let modules: string[];
-
-  if (runtime.mode === "entry") {
-    modules = computeCoreJsCompatModules(runtime.targets, /^(?:es|web)\./, {
-      version: runtime.coreJsVersion,
-      proposals: runtime.proposals,
-    });
-  } else {
-    const used = collectRuntimePolyfillUsageFromFiles(options.entryPoints, {
-      resolveExtensions: options.resolveExtensions,
-    });
-    modules = computeCoreJsCompatModules(runtime.targets, used, {
-      version: runtime.coreJsVersion,
-      proposals: runtime.proposals,
-    });
-  }
-
-  const out = new Set(modules);
-  for (const moduleName of include) out.add(moduleName);
-  for (const moduleName of exclude) out.delete(moduleName);
-  return [...out].sort();
-}
-
 function buildCoreJsResolver(entryPoints: readonly string[]): (moduleName: string) => string {
   const override = runtimeRequireOverride;
   const requires: RuntimeRequire[] = [];
@@ -608,24 +608,28 @@ function buildCoreJsResolver(entryPoints: readonly string[]): (moduleName: strin
   };
 }
 
-export function createRuntimePolyfillPrelude(
-  modules: readonly string[],
+function uniqueSorted(values: Iterable<string>): string[] {
+  return [...new Set(values)].sort();
+}
+
+function resolveRuntimeModules(
+  modules: Iterable<string>,
   options: RuntimePolyfillBuildOptions,
-): { path: string; cleanup: () => void } | null {
-  if (modules.length === 0) return null;
+): ResolvedRuntimeModule[] {
   const resolveCoreJs = buildCoreJsResolver(options.entryPoints);
-  const dir = mkdtempSync(join(tmpdir(), "zts-runtime-polyfills-"));
-  const path = join(dir, "prelude.mjs");
-  const imports = modules
-    .map((moduleName) => `import ${JSON.stringify(resolveCoreJs(moduleName))};`)
-    .join("\n");
-  writeFileSync(path, `${imports}\n`, "utf8");
-  return {
-    path,
-    cleanup() {
-      rmSync(dir, { recursive: true, force: true });
-    },
-  };
+  return uniqueSorted(modules).map((moduleName) => ({
+    module: moduleName,
+    path: resolveCoreJs(moduleName),
+  }));
+}
+
+function assignResolvedModuleArrays(
+  napiOptions: Record<string, unknown>,
+  prefix: string,
+  modules: readonly ResolvedRuntimeModule[],
+): void {
+  napiOptions[`${prefix}Modules`] = modules.map((item) => item.module);
+  napiOptions[`${prefix}Paths`] = modules.map((item) => item.path);
 }
 
 export function applyRuntimePolyfillsToNapiOptions(
@@ -640,11 +644,59 @@ export function applyRuntimePolyfillsToNapiOptions(
   const runtime = normalizeRuntimePolyfillOptions(options);
   if (!runtime) return { cleanup: () => {}, modules: [] };
 
-  const modules = computeRuntimePolyfillModules(options, runtime);
-  const prelude = createRuntimePolyfillPrelude(modules, options);
-  if (!prelude) return { cleanup: () => {}, modules };
+  const exclude = new Set(runtime.exclude);
+  const includeModules = runtime.include.filter((moduleName) => !exclude.has(moduleName));
+  const includeResolved = resolveRuntimeModules(includeModules, options);
 
-  const existing = Array.isArray(options.runBeforeMain) ? options.runBeforeMain : [];
-  napiOptions.runBeforeMain = [prelude.path, ...existing];
-  return { cleanup: prelude.cleanup, modules };
+  if (runtime.mode === "entry") {
+    const entryModules = computeCoreJsCompatModules(runtime.targets, /^(?:es|web)\./, {
+      version: runtime.coreJsVersion,
+      proposals: runtime.proposals,
+    }).filter((moduleName) => !exclude.has(moduleName));
+    const entryResolved = resolveRuntimeModules(entryModules, options);
+    if (entryResolved.length === 0 && includeResolved.length === 0) {
+      return { cleanup: () => {}, modules: [] };
+    }
+    napiOptions.runtimePolyfillModeNative = "entry";
+    assignResolvedModuleArrays(napiOptions, "runtimePolyfillEntry", entryResolved);
+    assignResolvedModuleArrays(napiOptions, "runtimePolyfillInclude", includeResolved);
+    napiOptions.runtimePolyfillExcludeModules = runtime.exclude;
+    return {
+      cleanup: () => {},
+      modules: uniqueSorted([...entryResolved, ...includeResolved].map((item) => item.module)),
+    };
+  }
+
+  const targetCandidateSet = new Set(
+    computeCoreJsCompatModules(runtime.targets, RUNTIME_POLYFILL_CANDIDATE_MODULES, {
+      version: runtime.coreJsVersion,
+      proposals: runtime.proposals,
+    }).filter((moduleName) => !exclude.has(moduleName)),
+  );
+  const candidates: ResolvedRuntimeCandidate[] = [];
+  const resolveCoreJs = buildCoreJsResolver(options.entryPoints);
+  for (const item of RUNTIME_POLYFILL_FEATURE_MODULES) {
+    if (!targetCandidateSet.has(item.module)) continue;
+    candidates.push({
+      feature: item.feature,
+      module: item.module,
+      path: resolveCoreJs(item.module),
+    });
+  }
+
+  if (candidates.length === 0 && includeResolved.length === 0) {
+    return { cleanup: () => {}, modules: [] };
+  }
+
+  napiOptions.runtimePolyfillModeNative = "usage";
+  napiOptions.runtimePolyfillCandidateFeatures = candidates.map((item) => item.feature);
+  napiOptions.runtimePolyfillCandidateModules = candidates.map((item) => item.module);
+  napiOptions.runtimePolyfillCandidatePaths = candidates.map((item) => item.path);
+  assignResolvedModuleArrays(napiOptions, "runtimePolyfillInclude", includeResolved);
+  napiOptions.runtimePolyfillExcludeModules = runtime.exclude;
+
+  return {
+    cleanup: () => {},
+    modules: uniqueSorted([...candidates, ...includeResolved].map((item) => item.module)),
+  };
 }

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -29,6 +29,7 @@ const Linker = linker_mod.Linker;
 const MangleReportCollector = linker_mod.MangleReportCollector;
 const TreeShaker = @import("tree_shaker.zig").TreeShaker;
 const module_store = @import("module_store.zig");
+const runtime_polyfills = @import("runtime_polyfills.zig");
 const transpile_mod = @import("../transpile.zig");
 const compat = @import("../transformer/transformer.zig").TransformOptions.compat;
 
@@ -241,6 +242,9 @@ pub const BundleOptions = struct {
     /// Metro의 runBeforeMainModule과 동일 역할. inject와 같은 메커니즘으로
     /// 엔트리 의존성에 추가되어 먼저 실행된다.
     run_before_main: []const []const u8 = &.{},
+    /// core-js runtime polyfill graph plan. JS wrapper computes target candidates,
+    /// native graph selects usage-mode roots after parse/semantic.
+    runtime_polyfills: ?runtime_polyfills.Plan = null,
     /// 번들 시작 시 즉시 실행 폴리필 (--polyfill). 절대 경로 목록.
     /// 파일 내용을 IIFE로 감싸서 런타임 헬퍼 앞에 인라인. 모듈 그래프에 미포함.
     polyfills: []const []const u8 = &.{},
@@ -832,13 +836,9 @@ pub const Bundler = struct {
         graph.project_root = self.options.project_root;
         graph.asset_names = self.options.asset_names;
         graph.asset_registry = self.options.asset_registry;
-        // --inject와 --run-before-main을 합쳐서 엔트리 의존성으로 추가 (실행 순서: inject → run-before-main → entry)
-        const combined_inject = if (self.options.run_before_main.len > 0)
-            try std.mem.concat(self.allocator, []const u8, &.{ self.options.inject, self.options.run_before_main })
-        else
-            null;
-        defer if (combined_inject) |c| self.allocator.free(c);
-        graph.inject_files = combined_inject orelse self.options.inject;
+        graph.inject_files = self.options.inject;
+        graph.run_before_main_files = self.options.run_before_main;
+        graph.runtime_polyfills = self.options.runtime_polyfills;
         graph.pure = self.options.pure;
         graph.ignore_annotations = self.options.ignore_annotations;
         graph.plugins = self.options.plugins;
@@ -908,6 +908,17 @@ pub const Bundler = struct {
             } else {
                 try graph.build(self.options.entry_points);
             }
+        }
+
+        if (graph.runtime_polyfill_roots.items.len > 0) {
+            const current_rbm = self.options.run_before_main;
+            const merged = try self.allocator.alloc([]const u8, graph.runtime_polyfill_roots.items.len + current_rbm.len);
+            @memcpy(merged[0..graph.runtime_polyfill_roots.items.len], graph.runtime_polyfill_roots.items);
+            @memcpy(merged[graph.runtime_polyfill_roots.items.len..], current_rbm);
+            if (current_rbm.len > 0 and current_rbm.ptr != original_rbm.ptr) {
+                self.allocator.free(current_rbm);
+            }
+            self.options.run_before_main = merged;
         }
 
         // Worker 별도 빌드: new Worker(new URL(...)) 패턴에서 수집된 worker 경로를 독립 IIFE로 빌드

--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -1221,7 +1221,7 @@ test "TreeShaking: runBeforeMain import-only root preserves side-effect dependen
 
     try std.testing.expect(!result.hasErrors());
     try std.testing.expect(std.mem.indexOf(u8, result.output, "runBeforeMainPolyfill") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "init_prelude") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "init_prelude") != null);
 }
 
 test "TreeShaking CJS: named import prunes unused exports dot assignment" {

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1355,13 +1355,8 @@ pub fn appendGuardedModuleCall(
 /// `__r(N);` (= guardedLoadModule outer 호출) 을 emit 하는 것과 동등.
 pub fn appendRunBeforeMainCalls(output: *std.ArrayList(u8), allocator: std.mem.Allocator, graph: *const @import("graph.zig").ModuleGraph, run_before_main: []const []const u8, options: *const EmitOptions) !void {
     for (run_before_main) |rbm_path| {
-        var it = graph.modulesIterator();
-        while (it.next()) |rbm| {
-            if (std.mem.eql(u8, rbm.path, rbm_path)) {
-                try appendGuardedModuleCall(output, allocator, rbm, options);
-                break;
-            }
-        }
+        const rbm = graph.findModuleByPath(rbm_path) orelse continue;
+        try appendGuardedModuleCall(output, allocator, rbm, options);
     }
 }
 
@@ -1373,14 +1368,14 @@ fn findLastRunBeforeMainPosition(sorted: []const *const Module, run_before_main:
     return last;
 }
 
-fn isRunBeforeMainPath(path: []const u8, run_before_main: []const []const u8) bool {
+pub fn isRunBeforeMainPath(path: []const u8, run_before_main: []const []const u8) bool {
     for (run_before_main) |rbm_path| {
         if (std.mem.eql(u8, path, rbm_path)) return true;
     }
     return false;
 }
 
-fn shouldInsertRunBeforeMainBefore(position: usize, insert_after_pos: ?usize) bool {
+pub fn shouldInsertRunBeforeMainBefore(position: usize, insert_after_pos: ?usize) bool {
     return if (insert_after_pos) |last| position > last else true;
 }
 

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -675,21 +675,36 @@ pub fn emitWithTreeShaking(
         module_line += @intCast(std.mem.count(u8, module_output.items[before_len..], "\n"));
     };
 
+    const entry_is_esm_wrapped = if (entry_idx) |ei| blk: {
+        for (sorted.items) |m| {
+            if (m.index.toU32() == ei) break :blk m.wrap_kind == .esm;
+        }
+        break :blk false;
+    } else false;
+    const emit_top_level_rbm = options.run_before_main.len > 0 and !entry_is_esm_wrapped;
+    const rbm_insert_after_pos = if (emit_top_level_rbm)
+        findLastRunBeforeMainPosition(sorted.items, options.run_before_main)
+    else
+        null;
+    var rbm_calls_emitted = false;
+
     for (sorted.items, 0..) |m, i| {
         // helpers 합산 (bitwise OR)
         collected_helpers = @bitCast(@as(u32, @bitCast(collected_helpers)) | @as(u32, @bitCast(results[i].helpers)));
 
         const code = results[i].code orelse continue;
 
-        // --run-before-main: 엔트리 모듈 직전에 해당 모듈의 require/init 호출 삽입.
+        // --run-before-main/runtime-prelude: dependency 본문도 polyfill/setup 이후
+        // 실행되어야 하므로 rbm 모듈 정의가 끝난 직후, 첫 user module 전에 호출한다.
         // __esm 래핑된 엔트리(RN)는 emitEsmWrappedModule에서 body 안에 삽입.
-        const is_entry = if (entry_idx) |ei| m.index.toU32() == ei else false;
-        if (is_entry and options.run_before_main.len > 0 and m.wrap_kind != .esm) {
+        if (emit_top_level_rbm and !rbm_calls_emitted and shouldInsertRunBeforeMainBefore(i, rbm_insert_after_pos)) {
             const before_len = module_output.items.len;
             try appendRunBeforeMainCalls(&module_output, allocator, graph, options.run_before_main, options);
             module_line += @intCast(std.mem.count(u8, module_output.items[before_len..], "\n"));
+            rbm_calls_emitted = true;
         }
 
+        const is_entry = if (entry_idx) |ei| m.index.toU32() == ei else false;
         if (!options.minify_whitespace) {
             try module_output.appendSlice(allocator, "//#region ");
             try module_output.appendSlice(allocator, std.fs.path.basename(m.path));
@@ -813,6 +828,11 @@ pub fn emitWithTreeShaking(
                 .sm_builder = module_sm_builder,
             });
         }
+    }
+    if (emit_top_level_rbm and !rbm_calls_emitted) {
+        const before_len = module_output.items.len;
+        try appendRunBeforeMainCalls(&module_output, allocator, graph, options.run_before_main, options);
+        module_line += @intCast(std.mem.count(u8, module_output.items[before_len..], "\n"));
     }
 
     // #1961 PR 1h: RuntimeHelpers 비트맵 기반 ES2015 런타임 헬퍼는 transformer 가 graph
@@ -1343,6 +1363,25 @@ pub fn appendRunBeforeMainCalls(output: *std.ArrayList(u8), allocator: std.mem.A
             }
         }
     }
+}
+
+fn findLastRunBeforeMainPosition(sorted: []const *const Module, run_before_main: []const []const u8) ?usize {
+    var last: ?usize = null;
+    for (sorted, 0..) |m, i| {
+        if (isRunBeforeMainPath(m.path, run_before_main)) last = i;
+    }
+    return last;
+}
+
+fn isRunBeforeMainPath(path: []const u8, run_before_main: []const []const u8) bool {
+    for (run_before_main) |rbm_path| {
+        if (std.mem.eql(u8, path, rbm_path)) return true;
+    }
+    return false;
+}
+
+fn shouldInsertRunBeforeMainBefore(position: usize, insert_after_pos: ?usize) bool {
+    return if (insert_after_pos) |last| position > last else true;
 }
 
 fn emitModuleThread(

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -35,6 +35,8 @@ const OutputFile = parent.OutputFile;
 const emitChunkRuntimeHelpers = parent.emitChunkRuntimeHelpers;
 const emitModule = parent.emitModule;
 const appendRunBeforeMainCalls = parent.appendRunBeforeMainCalls;
+const isRunBeforeMainPath = parent.isRunBeforeMainPath;
+const shouldInsertRunBeforeMainBefore = parent.shouldInsertRunBeforeMainBefore;
 
 const RunBeforeMainCrossImport = struct {
     source_chunk: ChunkIndex,
@@ -550,17 +552,6 @@ fn findLastRunBeforeMainPosition(
     return last;
 }
 
-fn isRunBeforeMainPath(path: []const u8, run_before_main: []const []const u8) bool {
-    for (run_before_main) |rbm_path| {
-        if (std.mem.eql(u8, path, rbm_path)) return true;
-    }
-    return false;
-}
-
-fn shouldInsertRunBeforeMainBefore(position: usize, insert_after_pos: ?usize) bool {
-    return if (insert_after_pos) |last| position > last else true;
-}
-
 fn collectRunBeforeMainCrossImports(
     allocator: std.mem.Allocator,
     out: *std.ArrayList(RunBeforeMainCrossImport),
@@ -570,7 +561,7 @@ fn collectRunBeforeMainCrossImports(
     run_before_main: []const []const u8,
 ) !void {
     for (run_before_main) |rbm_path| {
-        const rbm = findRunBeforeMainModule(graph, rbm_path) orelse continue;
+        const rbm = graph.findModuleByPath(rbm_path) orelse continue;
         const source_chunk = chunk_graph.getModuleChunk(rbm.index);
         if (source_chunk == .none or source_chunk == current_chunk.index) continue;
         const name = try runBeforeMainCallName(allocator, rbm) orelse continue;
@@ -635,7 +626,7 @@ fn collectRunBeforeMainExportNames(
     run_before_main: []const []const u8,
 ) !void {
     for (run_before_main) |rbm_path| {
-        const rbm = findRunBeforeMainModule(graph, rbm_path) orelse continue;
+        const rbm = graph.findModuleByPath(rbm_path) orelse continue;
         const source_chunk = chunk_graph.getModuleChunk(rbm.index);
         if (source_chunk == .none or source_chunk != current_chunk.index) continue;
         const name = try runBeforeMainCallName(allocator, rbm) orelse continue;
@@ -646,14 +637,6 @@ fn collectRunBeforeMainExportNames(
         }
         try out.append(allocator, name);
     }
-}
-
-fn findRunBeforeMainModule(graph: *const ModuleGraph, rbm_path: []const u8) ?*const Module {
-    var it = graph.modulesIterator();
-    while (it.next()) |rbm| {
-        if (std.mem.eql(u8, rbm.path, rbm_path)) return rbm;
-    }
-    return null;
 }
 
 fn runBeforeMainCallName(allocator: std.mem.Allocator, module: *const Module) !?[]const u8 {

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -34,6 +34,12 @@ const EmitOptions = parent.EmitOptions;
 const OutputFile = parent.OutputFile;
 const emitChunkRuntimeHelpers = parent.emitChunkRuntimeHelpers;
 const emitModule = parent.emitModule;
+const appendRunBeforeMainCalls = parent.appendRunBeforeMainCalls;
+
+const RunBeforeMainCrossImport = struct {
+    source_chunk: ChunkIndex,
+    name: []const u8,
+};
 
 pub fn emitChunks(
     allocator: std.mem.Allocator,
@@ -88,6 +94,10 @@ pub fn emitChunks(
 
         // 출력 확장자 (cross-chunk import 경로 + 파일명에 공용)
         const ext = options.out_extension_js orelse ".js";
+        const chunk_is_user_entry = switch (chunk.kind) {
+            .entry_point => |info| !info.is_dynamic,
+            .common, .manual => false,
+        };
 
         // banner 삽입 (각 청크 출력 앞)
         if (options.banner_js) |banner| {
@@ -117,6 +127,31 @@ pub fn emitChunks(
                 chunk_mods.items,
                 linker,
                 options.minify_whitespace,
+            );
+        }
+
+        var rbm_cross_imports: std.ArrayList(RunBeforeMainCrossImport) = .empty;
+        defer {
+            for (rbm_cross_imports.items) |imp| allocator.free(imp.name);
+            rbm_cross_imports.deinit(allocator);
+        }
+        if (chunk_is_user_entry and options.run_before_main.len > 0) {
+            try collectRunBeforeMainCrossImports(
+                allocator,
+                &rbm_cross_imports,
+                graph,
+                chunk_graph,
+                chunk,
+                options.run_before_main,
+            );
+            try emitRunBeforeMainCrossImports(
+                &chunk_output,
+                allocator,
+                rbm_cross_imports.items,
+                chunk,
+                chunk_graph,
+                options,
+                ext,
             );
         }
 
@@ -251,6 +286,9 @@ pub fn emitChunks(
             for (alias_strs.items) |alias| {
                 try occupied.append(allocator, alias);
             }
+            for (rbm_cross_imports.items) |imp| {
+                try occupied.append(allocator, imp.name);
+            }
         }
 
         // per-chunk 리네임 계산: 각 청크는 독립된 네임스페이스이므로
@@ -264,8 +302,18 @@ pub fn emitChunks(
             .entry_point => |info| @intFromEnum(info.module),
             .common, .manual => null,
         };
+        const entry_is_esm_wrapped = if (entry_mod_idx) |ei| blk: {
+            const entry_mod = graph.getModule(ModuleIndex.fromUsize(@intCast(ei))) orelse break :blk false;
+            break :blk entry_mod.wrap_kind == .esm;
+        } else false;
+        const emit_top_level_rbm = chunk_is_user_entry and options.run_before_main.len > 0 and !entry_is_esm_wrapped;
+        const rbm_insert_after_pos = if (emit_top_level_rbm)
+            findLastRunBeforeMainPosition(graph, sorted_mods, options.run_before_main)
+        else
+            null;
+        var rbm_calls_emitted = false;
 
-        for (sorted_mods) |mod_idx| {
+        for (sorted_mods, 0..) |mod_idx, sorted_pos| {
             const mi = @intFromEnum(mod_idx);
             if (mi >= module_count) continue;
             const m = graph.getModule(mod_idx) orelse continue;
@@ -286,6 +334,14 @@ pub fn emitChunks(
             else
                 code;
 
+            // Match the single-file emitter: dependency bodies must also run
+            // after runtime prelude/setup, so insert after rbm definitions and
+            // before the first user module in this entry chunk.
+            if (emit_top_level_rbm and !rbm_calls_emitted and shouldInsertRunBeforeMainBefore(sorted_pos, rbm_insert_after_pos)) {
+                try appendRunBeforeMainCalls(&chunk_output, allocator, graph, options.run_before_main, options);
+                rbm_calls_emitted = true;
+            }
+
             if (!options.minify_whitespace) {
                 try chunk_output.appendSlice(allocator, "//#region ");
                 try chunk_output.appendSlice(allocator, std.fs.path.basename(m.path));
@@ -296,21 +352,43 @@ pub fn emitChunks(
                 try chunk_output.appendSlice(allocator, "//#endregion\n");
             }
         }
+        if (emit_top_level_rbm and !rbm_calls_emitted) {
+            try appendRunBeforeMainCalls(&chunk_output, allocator, graph, options.run_before_main, options);
+        }
 
         // RSC 디렉티브 충돌 검증 (Next.js 스펙).
         warnRscDirectiveConflict(hoisted_directives.items, chunk.rel_dir orelse "<chunk>");
+
+        var rbm_export_names: std.ArrayList([]const u8) = .empty;
+        defer {
+            for (rbm_export_names.items) |name| allocator.free(name);
+            rbm_export_names.deinit(allocator);
+        }
+        if (options.run_before_main.len > 0) {
+            try collectRunBeforeMainExportNames(
+                allocator,
+                &rbm_export_names,
+                graph,
+                chunk_graph,
+                chunk,
+                options.run_before_main,
+            );
+        }
 
         // 크로스 청크 export: exports_to에 심볼이 있으면 export 문 생성.
         // 다른 청크가 이 청크에서 심볼을 가져가는 경우에만 출력.
         // preserve-modules에서는 모듈 자체의 export가 유지되므로 cross-chunk export 불필요.
         // linker가 심볼을 rename한 경우 export { local_name as export_name } 형태로 출력.
-        if (chunk.exports_to.count() > 0 and !options.preserve_modules) {
+        if ((chunk.exports_to.count() > 0 or rbm_export_names.items.len > 0) and !options.preserve_modules) {
             // 결정론적 출력을 위해 이름을 정렬
             var export_names: std.ArrayList([]const u8) = .empty;
             defer export_names.deinit(allocator);
             var eit = chunk.exports_to.iterator();
             while (eit.next()) |entry| {
-                try export_names.append(allocator, entry.key_ptr.*);
+                try appendUniqueName(&export_names, allocator, entry.key_ptr.*);
+            }
+            for (rbm_export_names.items) |name| {
+                try appendUniqueName(&export_names, allocator, name);
             }
             std.mem.sort([]const u8, export_names.items, {}, types.stringLessThan);
 
@@ -434,6 +512,12 @@ pub fn emitChunks(
             while (eit.next()) |entry| {
                 try names.append(allocator, try allocator.dupe(u8, entry.key_ptr.*));
             }
+            if (!options.preserve_modules) {
+                for (rbm_export_names.items) |name| {
+                    if (containsName(names.items, name)) continue;
+                    try names.append(allocator, try allocator.dupe(u8, name));
+                }
+            }
             break :blk try names.toOwnedSlice(allocator);
         };
 
@@ -451,6 +535,145 @@ pub fn emitChunks(
     try resolveContentHashes(allocator, outputs.items, sorted_indices, chunk_graph);
 
     return outputs.toOwnedSlice(allocator);
+}
+
+fn findLastRunBeforeMainPosition(
+    graph: *const ModuleGraph,
+    sorted_mods: []const ModuleIndex,
+    run_before_main: []const []const u8,
+) ?usize {
+    var last: ?usize = null;
+    for (sorted_mods, 0..) |mod_idx, i| {
+        const m = graph.getModule(mod_idx) orelse continue;
+        if (isRunBeforeMainPath(m.path, run_before_main)) last = i;
+    }
+    return last;
+}
+
+fn isRunBeforeMainPath(path: []const u8, run_before_main: []const []const u8) bool {
+    for (run_before_main) |rbm_path| {
+        if (std.mem.eql(u8, path, rbm_path)) return true;
+    }
+    return false;
+}
+
+fn shouldInsertRunBeforeMainBefore(position: usize, insert_after_pos: ?usize) bool {
+    return if (insert_after_pos) |last| position > last else true;
+}
+
+fn collectRunBeforeMainCrossImports(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayList(RunBeforeMainCrossImport),
+    graph: *const ModuleGraph,
+    chunk_graph: *const ChunkGraph,
+    current_chunk: *const Chunk,
+    run_before_main: []const []const u8,
+) !void {
+    for (run_before_main) |rbm_path| {
+        const rbm = findRunBeforeMainModule(graph, rbm_path) orelse continue;
+        const source_chunk = chunk_graph.getModuleChunk(rbm.index);
+        if (source_chunk == .none or source_chunk == current_chunk.index) continue;
+        const name = try runBeforeMainCallName(allocator, rbm) orelse continue;
+
+        var duplicate = false;
+        for (out.items) |existing| {
+            if (existing.source_chunk == source_chunk and std.mem.eql(u8, existing.name, name)) {
+                duplicate = true;
+                break;
+            }
+        }
+        if (duplicate) {
+            allocator.free(name);
+            continue;
+        }
+        try out.append(allocator, .{ .source_chunk = source_chunk, .name = name });
+    }
+}
+
+fn emitRunBeforeMainCrossImports(
+    output: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+    imports: []const RunBeforeMainCrossImport,
+    current_chunk: *const Chunk,
+    chunk_graph: *const ChunkGraph,
+    options: *const EmitOptions,
+    ext: []const u8,
+) !void {
+    for (imports) |imp| {
+        const dep_chunk = chunk_graph.getChunk(imp.source_chunk);
+        var dep_buf: [128]u8 = undefined;
+        const dep_stem = chunkPlaceholderStem(dep_chunk, &dep_buf, options);
+        const resolved_path = if (options.preserve_modules) blk: {
+            const src_path = current_chunk.rel_dir orelse "./";
+            const dep_path = dep_chunk.rel_dir orelse "./";
+            break :blk try computeRelativeImportPath(allocator, src_path, dep_path, ext, options.preserve_modules_root);
+        } else try std.fmt.allocPrint(allocator, "./{s}{s}", .{ dep_stem, ext });
+        defer allocator.free(resolved_path);
+
+        if (!options.minify_whitespace) {
+            try output.appendSlice(allocator, "import { ");
+            try output.appendSlice(allocator, imp.name);
+            try output.appendSlice(allocator, " } from \"");
+            try output.appendSlice(allocator, resolved_path);
+            try output.appendSlice(allocator, "\";\n");
+        } else {
+            try output.appendSlice(allocator, "import{");
+            try output.appendSlice(allocator, imp.name);
+            try output.appendSlice(allocator, "}from\"");
+            try output.appendSlice(allocator, resolved_path);
+            try output.appendSlice(allocator, "\";");
+        }
+    }
+}
+
+fn collectRunBeforeMainExportNames(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayList([]const u8),
+    graph: *const ModuleGraph,
+    chunk_graph: *const ChunkGraph,
+    current_chunk: *const Chunk,
+    run_before_main: []const []const u8,
+) !void {
+    for (run_before_main) |rbm_path| {
+        const rbm = findRunBeforeMainModule(graph, rbm_path) orelse continue;
+        const source_chunk = chunk_graph.getModuleChunk(rbm.index);
+        if (source_chunk == .none or source_chunk != current_chunk.index) continue;
+        const name = try runBeforeMainCallName(allocator, rbm) orelse continue;
+        errdefer allocator.free(name);
+        if (containsName(out.items, name)) {
+            allocator.free(name);
+            continue;
+        }
+        try out.append(allocator, name);
+    }
+}
+
+fn findRunBeforeMainModule(graph: *const ModuleGraph, rbm_path: []const u8) ?*const Module {
+    var it = graph.modulesIterator();
+    while (it.next()) |rbm| {
+        if (std.mem.eql(u8, rbm.path, rbm_path)) return rbm;
+    }
+    return null;
+}
+
+fn runBeforeMainCallName(allocator: std.mem.Allocator, module: *const Module) !?[]const u8 {
+    if (!module.wrap_kind.isWrapped()) return null;
+    return if (module.wrap_kind == .cjs)
+        try module.allocRequireName(allocator)
+    else
+        try module.allocInitName(allocator);
+}
+
+fn appendUniqueName(list: *std.ArrayList([]const u8), allocator: std.mem.Allocator, name: []const u8) !void {
+    if (containsName(list.items, name)) return;
+    try list.append(allocator, name);
+}
+
+fn containsName(names: []const []const u8, name: []const u8) bool {
+    for (names) |existing| {
+        if (std.mem.eql(u8, existing, name)) return true;
+    }
+    return false;
 }
 
 /// 모듈 코드 선두에서 directive prologue (`"use strict"`, `"use client"`,

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -358,6 +358,16 @@ pub const ModuleGraph = struct {
         return self.modules.count();
     }
 
+    /// path 와 정확히 일치하는 module 의 read-only 포인터. SegmentedList 선형 스캔이라
+    /// O(N) — entry/RBM 주입처럼 build 당 호출 횟수가 작은 경로에서만 사용한다.
+    pub fn findModuleByPath(self: *const ModuleGraph, path: []const u8) ?*const Module {
+        var it = self.modulesIterator();
+        while (it.next()) |m| {
+            if (std.mem.eql(u8, m.path, path)) return m;
+        }
+        return null;
+    }
+
     /// **Accessor 전용**. 직접 호출 금지 — `parseAccessor()` 등 phase accessor 의
     /// setter 메서드를 사용하라. 외부 mutable pointer 노출은 worker race 의 root.
     pub inline fn moduleAtMut(self: *ModuleGraph, idx: ModuleIndex) ?*Module {

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -28,6 +28,7 @@ const module_mod = @import("module.zig");
 const Module = module_mod.Module;
 const CachedResolvedDep = module_mod.CachedResolvedDep;
 const runtime_helpers = @import("runtime_helpers.zig");
+const runtime_polyfills = @import("runtime_polyfills.zig");
 const resolve_cache_mod = @import("resolve_cache.zig");
 const ResolveCache = resolve_cache_mod.ResolveCache;
 const resolver_mod = @import("resolver.zig");
@@ -40,6 +41,7 @@ const Scanner = @import("../lexer/scanner.zig").Scanner;
 const Parser = @import("../parser/parser.zig").Parser;
 const SemanticAnalyzer = @import("../semantic/analyzer.zig").SemanticAnalyzer;
 const profile = @import("../profile.zig");
+const debug_log = @import("../debug_log.zig");
 const semantic_symbol = @import("../semantic/symbol.zig");
 const ModuleSemanticData = @import("module.zig").ModuleSemanticData;
 const AliasTable = @import("module.zig").AliasTable;
@@ -116,6 +118,12 @@ pub const ModuleGraph = struct {
     project_root: []const u8 = "",
     /// --inject 파일 목록. build()에서 모든 엔트리의 의존성으로 추가.
     inject_files: []const []const u8 = &.{},
+    /// --run-before-main 파일 목록. inject 뒤, 사용자 엔트리 앞에 실행된다.
+    run_before_main_files: []const []const u8 = &.{},
+    /// JS wrapper가 core-js-compat로 계산한 runtime-polyfill 후보 계획.
+    runtime_polyfills: ?runtime_polyfills.Plan = null,
+    /// graph usage aggregation 후 실제로 선택된 core-js root paths.
+    runtime_polyfill_roots: std.ArrayListUnmanaged([]const u8) = .empty,
     /// --pure:CALLEE 목록. parser AST의 call/new에 기존 pure flag를 부여한다.
     pure: []const []const u8 = &.{},
     /// package.json sideEffects / pure annotation 신호를 무시하고 보수적으로 포함.
@@ -256,6 +264,7 @@ pub const ModuleGraph = struct {
         self.worker_entries.deinit(self.allocator);
         if (self.jsx_specifier_cache) |s| self.allocator.free(s);
         if (self.plugins_with_helpers) |p| self.allocator.free(p);
+        self.runtime_polyfill_roots.deinit(self.allocator);
     }
 
     /// `plugins_with_helpers` lazy 초기화 — `self.plugins` 앞에 ZTS builtin plugin 들 (runtime
@@ -421,6 +430,15 @@ pub const ModuleGraph = struct {
             try inject_indices.append(self.allocator, idx);
         }
 
+        // --run-before-main 파일도 graph root 로 먼저 등록하되, 엔트리 연결은
+        // runtime-polyfill root 선별 이후에 수행한다.
+        var run_before_main_indices: std.ArrayList(types.ModuleIndex) = .empty;
+        defer run_before_main_indices.deinit(self.allocator);
+        for (self.run_before_main_files) |rbm_path| {
+            const idx = try self.addModule(rbm_path);
+            try run_before_main_indices.append(self.allocator, idx);
+        }
+
         // Phase 1: 이벤트 큐 기반 스캔 (esbuild 스타일).
         // 워커: parseModule + resolve → 채널 send (그래프 변형 없음)
         // 메인: 채널 recv → 결과 적용 + addModule → 즉시 새 워커 스폰
@@ -445,7 +463,7 @@ pub const ModuleGraph = struct {
             var inflight: usize = 0;
             var spawned_up_to: usize = 0;
 
-            // 초기 모듈(엔트리 + inject) 스폰
+            // 초기 모듈(엔트리 + inject + runBeforeMain) 스폰
             while (spawned_up_to < self.modules.count()) : (spawned_up_to += 1) {
                 const m = self.modules.at(spawned_up_to);
                 if (m.state == .ready) continue; // disabled 모듈은 스킵
@@ -519,23 +537,195 @@ pub const ModuleGraph = struct {
             }
         }
 
-        // --inject: inject 파일을 각 엔트리 모듈의 의존성으로 추가.
-        // DFS에서 inject 모듈이 먼저 방문되어 exec_index가 낮아지고, 번들 상단에 출력.
-        if (inject_indices.items.len > 0) {
-            for (entry_points) |entry_path| {
-                if (self.path_to_module.get(entry_path)) |entry_idx| {
-                    const ei = @intFromEnum(entry_idx);
-                    if (ei < self.modules.count()) {
-                        for (inject_indices.items) |inject_idx| {
-                            try self.linkDependency(entry_idx, inject_idx);
-                        }
-                    }
-                }
-            }
-        }
+        var runtime_indices: std.ArrayList(types.ModuleIndex) = .empty;
+        defer runtime_indices.deinit(self.allocator);
+        try self.applyRuntimePolyfills(&runtime_indices);
+        try self.linkExecutionRoots(entry_points, inject_indices.items, runtime_indices.items, run_before_main_indices.items);
         discover_scope.end();
 
         try self.finalizeGraph(entry_points);
+    }
+
+    fn applyRuntimePolyfills(self: *ModuleGraph, runtime_indices: *std.ArrayList(ModuleIndex)) !void {
+        const plan = self.runtime_polyfills orelse return;
+
+        var scope = profile.begin(.graph_runtime_polyfills);
+        defer scope.end();
+
+        var selected: std.ArrayList(runtime_polyfills.ResolvedModule) = .empty;
+        defer selected.deinit(self.allocator);
+        var seen = std.StringHashMap(void).init(self.allocator);
+        defer seen.deinit();
+
+        switch (plan.mode) {
+            .entry => {
+                var aggregate_scope = profile.begin(.graph_runtime_polyfills_aggregate);
+                defer aggregate_scope.end();
+                for (plan.entry_modules) |module| {
+                    try self.selectRuntimePolyfillModule(&selected, &seen, plan, module, "entry");
+                }
+            },
+            .usage => {
+                var used: runtime_polyfills.FeatureSet = .{};
+                defer used.deinit(self.allocator);
+                {
+                    var aggregate_scope = profile.begin(.graph_runtime_polyfills_aggregate);
+                    defer aggregate_scope.end();
+                    const count = self.modules.count();
+                    for (0..count) |i| {
+                        const m = self.modules.at(i);
+                        var collect_scope = profile.begin(.graph_runtime_polyfills_collect);
+                        var module_usage = try runtime_polyfills.collectModuleUsage(self.allocator, m);
+                        defer module_usage.deinit(self.allocator);
+                        collect_scope.end();
+                        if (!module_usage.isEmpty()) self.debugRuntimePolyfillUsage(m.path, module_usage);
+                        try used.merge(self.allocator, module_usage);
+                    }
+                }
+                for (plan.candidates) |candidate| {
+                    const module: runtime_polyfills.ResolvedModule = .{
+                        .module = candidate.module,
+                        .path = candidate.path,
+                    };
+                    if (used.has(candidate.feature)) {
+                        try self.selectRuntimePolyfillModule(&selected, &seen, plan, module, candidate.feature);
+                    } else if (debug_log.enabled(.runtime_polyfills)) {
+                        debug_log.print(
+                            .runtime_polyfills,
+                            "mode=usage feature={s} corejs_module={s} decision=unused\n",
+                            .{ candidate.feature, candidate.module },
+                        );
+                    }
+                }
+            },
+        }
+
+        for (plan.include) |module| {
+            try self.selectRuntimePolyfillModule(&selected, &seen, plan, module, "include");
+        }
+
+        if (selected.items.len == 0) return;
+
+        var inject_scope = profile.begin(.graph_runtime_polyfills_inject);
+        defer inject_scope.end();
+        const discover_start = self.modules.count();
+        for (selected.items) |module| {
+            const idx = try self.addModule(module.path);
+            if (self.moduleAtMut(idx)) |m| {
+                m.is_context_dep = true;
+            }
+            try runtime_indices.append(self.allocator, idx);
+            try self.runtime_polyfill_roots.append(self.allocator, module.path);
+            if (debug_log.enabled(.runtime_polyfills)) {
+                debug_log.print(
+                    .runtime_polyfills,
+                    "mode={s} corejs_module={s} module={s} decision=prelude\n",
+                    .{ @tagName(plan.mode), module.module, module.path },
+                );
+            }
+        }
+        try self.discoverPendingModulesSequential(discover_start);
+    }
+
+    fn selectRuntimePolyfillModule(
+        self: *ModuleGraph,
+        selected: *std.ArrayList(runtime_polyfills.ResolvedModule),
+        seen: *std.StringHashMap(void),
+        plan: runtime_polyfills.Plan,
+        module: runtime_polyfills.ResolvedModule,
+        reason: []const u8,
+    ) !void {
+        if (isRuntimePolyfillExcluded(plan, module.module)) {
+            if (debug_log.enabled(.runtime_polyfills)) {
+                debug_log.print(
+                    .runtime_polyfills,
+                    "mode={s} feature={s} corejs_module={s} decision=excluded\n",
+                    .{ @tagName(plan.mode), reason, module.module },
+                );
+            }
+            return;
+        }
+        if (seen.contains(module.module)) return;
+        try seen.put(module.module, {});
+        try selected.append(self.allocator, module);
+        if (debug_log.enabled(.runtime_polyfills)) {
+            debug_log.print(
+                .runtime_polyfills,
+                "mode={s} feature={s} corejs_module={s} module={s} decision=included\n",
+                .{ @tagName(plan.mode), reason, module.module, module.path },
+            );
+        }
+    }
+
+    fn isRuntimePolyfillExcluded(plan: runtime_polyfills.Plan, module_name: []const u8) bool {
+        for (plan.exclude) |excluded| {
+            if (std.mem.eql(u8, excluded, module_name)) return true;
+        }
+        return false;
+    }
+
+    fn debugRuntimePolyfillUsage(self: *ModuleGraph, module_path: []const u8, usage: runtime_polyfills.FeatureSet) void {
+        _ = self;
+        if (!debug_log.enabled(.runtime_polyfills)) return;
+        for (usage.items[0..usage.len]) |feature| {
+            debug_log.print(
+                .runtime_polyfills,
+                "mode=usage module={s} feature={s} decision=detected\n",
+                .{ module_path, feature },
+            );
+        }
+    }
+
+    fn discoverPendingModulesSequential(self: *ModuleGraph, start_index: usize) !void {
+        var parse_start = start_index;
+        while (parse_start < self.modules.count()) {
+            const parse_end = self.modules.count();
+            for (parse_start..parse_end) |j| {
+                const m = self.modules.at(j);
+                if (m.state == .ready) continue;
+                self.parseModule(@enumFromInt(@as(u32, @intCast(j))));
+            }
+            for (parse_start..parse_end) |i| {
+                const m_ptr = self.modules.at(i);
+                if (m_ptr.state == .ready) continue;
+                self.applySideEffectsFromPackageJson(m_ptr);
+                m_ptr.state = .ready;
+            }
+            for (parse_start..parse_end) |i| {
+                const m_ptr = self.modules.at(i);
+                if (m_ptr.is_disabled or m_ptr.is_external) continue;
+                try self.resolveModuleImports(@enumFromInt(@as(u32, @intCast(i))));
+                try self.applyContextDepResults(i);
+            }
+            parse_start = parse_end;
+        }
+    }
+
+    fn linkExecutionRoots(
+        self: *ModuleGraph,
+        entry_points: []const []const u8,
+        inject_indices: []const ModuleIndex,
+        runtime_indices: []const ModuleIndex,
+        run_before_main_indices: []const ModuleIndex,
+    ) !void {
+        if (inject_indices.len == 0 and runtime_indices.len == 0 and run_before_main_indices.len == 0) return;
+        for (entry_points) |entry_path| {
+            const entry_idx = self.path_to_module.get(entry_path) orelse continue;
+            const ei = @intFromEnum(entry_idx);
+            if (ei >= self.modules.count()) continue;
+            for (inject_indices) |inject_idx| try self.linkDependencyUnique(entry_idx, inject_idx);
+            for (runtime_indices) |runtime_idx| try self.linkDependencyUnique(entry_idx, runtime_idx);
+            for (run_before_main_indices) |rbm_idx| try self.linkDependencyUnique(entry_idx, rbm_idx);
+        }
+    }
+
+    fn linkDependencyUnique(self: *ModuleGraph, from: ModuleIndex, to: ModuleIndex) !void {
+        if (to.isNone()) return;
+        const from_mod = self.getModule(from) orelse return;
+        for (from_mod.dependencies.items) |existing| {
+            if (existing == to) return;
+        }
+        try self.linkDependency(from, to);
     }
 
     /// Phase 2-4: DFS exec_index + ExportsKind 승격 + TLA 전파.
@@ -570,6 +760,7 @@ pub const ModuleGraph = struct {
         try self.markCyclesViaDynamic(entry_indices.items);
 
         self.promoteExportsKinds();
+        self.promoteRunBeforeMainModules();
         self.registerWrapperSymbols();
         self.propagateTopLevelAwait();
         self.checkSelfReExport();
@@ -641,6 +832,13 @@ pub const ModuleGraph = struct {
         for (self.inject_files) |inject_path| {
             const idx = try self.addModule(inject_path);
             try inject_indices.append(self.allocator, idx);
+        }
+
+        var run_before_main_indices: std.ArrayList(types.ModuleIndex) = .empty;
+        defer run_before_main_indices.deinit(self.allocator);
+        for (self.run_before_main_files) |rbm_path| {
+            const idx = try self.addModule(rbm_path);
+            try run_before_main_indices.append(self.allocator, idx);
         }
 
         for (entry_points) |entry_path| {
@@ -745,19 +943,12 @@ pub const ModuleGraph = struct {
             parse_start = parse_end;
         }
 
-        // --inject: inject 파일을 각 엔트리 모듈의 의존성으로 추가
-        if (inject_indices.items.len > 0) {
-            for (entry_points) |entry_path| {
-                if (self.path_to_module.get(entry_path)) |entry_idx| {
-                    const ei = @intFromEnum(entry_idx);
-                    if (ei < self.modules.count()) {
-                        for (inject_indices.items) |inject_idx| {
-                            try self.linkDependency(entry_idx, inject_idx);
-                        }
-                    }
-                }
-            }
-        }
+        var runtime_indices: std.ArrayList(types.ModuleIndex) = .empty;
+        defer runtime_indices.deinit(self.allocator);
+        const before_runtime_count = self.modules.count();
+        try self.applyRuntimePolyfills(&runtime_indices);
+        if (self.modules.count() > before_runtime_count) graph_changed = true;
+        try self.linkExecutionRoots(entry_points, inject_indices.items, runtime_indices.items, run_before_main_indices.items);
 
         discover_scope.end();
 
@@ -2862,6 +3053,18 @@ pub const ModuleGraph = struct {
                 if (m.exports_kind == .none) m.exports_kind = .esm;
                 m.wrap_kind = .esm;
             }
+        }
+    }
+
+    fn promoteRunBeforeMainModules(self: *ModuleGraph) void {
+        for (self.run_before_main_files) |rbm_path| {
+            const idx = self.path_to_module.get(rbm_path) orelse continue;
+            const i = @intFromEnum(idx);
+            if (i >= self.modules.count()) continue;
+            var m = self.modules.at(i);
+            if (!m.module_type.isJavaScriptLike() or m.wrap_kind != .none) continue;
+            if (m.exports_kind == .none) m.exports_kind = .esm;
+            if (m.exports_kind.isEsm()) m.wrap_kind = .esm;
         }
     }
 

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -30,6 +30,7 @@ pub const purity = @import("purity.zig");
 pub const stmt_info = @import("stmt_info.zig");
 pub const chunk = @import("chunk.zig");
 pub const runtime_helpers = @import("runtime_helpers.zig");
+pub const runtime_polyfills = @import("runtime_polyfills.zig");
 pub const bundler_core = @import("bundler.zig");
 pub const mpsc_channel = @import("mpsc_channel.zig");
 pub const json_to_esm = @import("json_to_esm.zig");
@@ -98,6 +99,7 @@ test {
     _ = stmt_info;
     _ = chunk;
     _ = runtime_helpers;
+    _ = runtime_polyfills;
     _ = bundler_core;
     _ = plugin;
     _ = module_store;

--- a/src/bundler/runtime_polyfills.zig
+++ b/src/bundler/runtime_polyfills.zig
@@ -1,0 +1,804 @@
+//! Runtime core-js polyfill usage collector.
+//!
+//! JS computes target-compatible core-js module candidates. The native graph
+//! decides which usage-mode candidates are actually needed after parse,
+//! plugin transforms, and semantic binding resolution.
+
+const std = @import("std");
+const Ast = @import("../parser/ast.zig").Ast;
+const Node = @import("../parser/ast.zig").Node;
+const NodeIndex = @import("../parser/ast.zig").NodeIndex;
+const ast_walk = @import("../parser/ast_walk.zig");
+const Module = @import("module.zig").Module;
+const ModuleSemanticData = @import("module.zig").ModuleSemanticData;
+const ModuleType = @import("types.zig").ModuleType;
+
+pub const Mode = enum {
+    usage,
+    entry,
+
+    pub fn fromString(value: []const u8) ?Mode {
+        if (std.mem.eql(u8, value, "usage")) return .usage;
+        if (std.mem.eql(u8, value, "entry")) return .entry;
+        return null;
+    }
+};
+
+pub const Feature = []const u8;
+
+pub const FeatureSet = struct {
+    const max_features = 512;
+
+    items: [max_features]Feature = undefined,
+    len: usize = 0,
+
+    pub fn deinit(self: *FeatureSet, allocator: std.mem.Allocator) void {
+        _ = self;
+        _ = allocator;
+    }
+
+    pub fn insert(self: *FeatureSet, allocator: std.mem.Allocator, feature: Feature) !void {
+        _ = allocator;
+        if (self.has(feature)) return;
+        if (self.len >= max_features) return error.OutOfMemory;
+        self.items[self.len] = feature;
+        self.len += 1;
+    }
+
+    pub fn has(self: FeatureSet, feature: Feature) bool {
+        for (self.items[0..self.len]) |existing| {
+            if (std.mem.eql(u8, existing, feature)) return true;
+        }
+        return false;
+    }
+
+    pub fn merge(self: *FeatureSet, allocator: std.mem.Allocator, other: FeatureSet) !void {
+        for (other.items[0..other.len]) |feature| {
+            try self.insert(allocator, feature);
+        }
+    }
+
+    pub fn isEmpty(self: FeatureSet) bool {
+        return self.len == 0;
+    }
+};
+
+pub const ResolvedModule = struct {
+    module: []const u8,
+    path: []const u8,
+};
+
+pub const Candidate = struct {
+    feature: Feature,
+    module: []const u8,
+    path: []const u8,
+};
+
+pub const Plan = struct {
+    mode: Mode,
+    candidates: []const Candidate = &.{},
+    entry_modules: []const ResolvedModule = &.{},
+    include: []const ResolvedModule = &.{},
+    exclude: []const []const u8 = &.{},
+};
+
+const NameFeature = struct {
+    name: []const u8,
+    feature: []const u8,
+};
+
+const global_features = [_]NameFeature{
+    .{ .name = "AggregateError", .feature = "aggregate_error" },
+    .{ .name = "ArrayBuffer", .feature = "array_buffer" },
+    .{ .name = "AsyncDisposableStack", .feature = "async_disposable_stack" },
+    .{ .name = "DataView", .feature = "data_view" },
+    .{ .name = "DisposableStack", .feature = "disposable_stack" },
+    .{ .name = "DOMException", .feature = "web_dom_exception" },
+    .{ .name = "Float32Array", .feature = "typed_array_float32" },
+    .{ .name = "Float64Array", .feature = "typed_array_float64" },
+    .{ .name = "Int8Array", .feature = "typed_array_int8" },
+    .{ .name = "Int16Array", .feature = "typed_array_int16" },
+    .{ .name = "Int32Array", .feature = "typed_array_int32" },
+    .{ .name = "Iterator", .feature = "iterator" },
+    .{ .name = "Map", .feature = "map" },
+    .{ .name = "Promise", .feature = "promise" },
+    .{ .name = "Set", .feature = "set" },
+    .{ .name = "SuppressedError", .feature = "suppressed_error" },
+    .{ .name = "Symbol", .feature = "symbol" },
+    .{ .name = "URL", .feature = "web_url" },
+    .{ .name = "URLSearchParams", .feature = "web_url_search_params" },
+    .{ .name = "Uint8Array", .feature = "typed_array_uint8" },
+    .{ .name = "Uint8ClampedArray", .feature = "typed_array_uint8_clamped" },
+    .{ .name = "Uint16Array", .feature = "typed_array_uint16" },
+    .{ .name = "Uint32Array", .feature = "typed_array_uint32" },
+    .{ .name = "WeakMap", .feature = "weak_map" },
+    .{ .name = "WeakSet", .feature = "weak_set" },
+    .{ .name = "atob", .feature = "web_atob" },
+    .{ .name = "btoa", .feature = "web_btoa" },
+    .{ .name = "clearImmediate", .feature = "web_immediate" },
+    .{ .name = "escape", .feature = "escape" },
+    .{ .name = "globalThis", .feature = "global_this" },
+    .{ .name = "parseFloat", .feature = "parse_float" },
+    .{ .name = "parseInt", .feature = "parse_int" },
+    .{ .name = "queueMicrotask", .feature = "web_queue_microtask" },
+    .{ .name = "self", .feature = "web_self" },
+    .{ .name = "setImmediate", .feature = "web_immediate" },
+    .{ .name = "setInterval", .feature = "web_timers" },
+    .{ .name = "setTimeout", .feature = "web_timers" },
+    .{ .name = "structuredClone", .feature = "structured_clone" },
+    .{ .name = "unescape", .feature = "unescape" },
+};
+
+const prototype_member_features = [_]NameFeature{
+    .{ .name = "anchor", .feature = "string_anchor" },
+    .{ .name = "at", .feature = "array_at" },
+    .{ .name = "at", .feature = "typed_array_at" },
+    .{ .name = "big", .feature = "string_big" },
+    .{ .name = "bind", .feature = "function_bind" },
+    .{ .name = "blink", .feature = "string_blink" },
+    .{ .name = "bold", .feature = "string_bold" },
+    .{ .name = "codePointAt", .feature = "string_code_point_at" },
+    .{ .name = "concat", .feature = "array_concat" },
+    .{ .name = "copyWithin", .feature = "array_copy_within" },
+    .{ .name = "copyWithin", .feature = "typed_array_copy_within" },
+    .{ .name = "delete", .feature = "web_url_search_params_delete" },
+    .{ .name = "difference", .feature = "set_difference" },
+    .{ .name = "dotAll", .feature = "regexp_dot_all" },
+    .{ .name = "drop", .feature = "iterator_drop" },
+    .{ .name = "endsWith", .feature = "string_ends_with" },
+    .{ .name = "every", .feature = "array_every" },
+    .{ .name = "every", .feature = "typed_array_every" },
+    .{ .name = "every", .feature = "iterator_every" },
+    .{ .name = "fill", .feature = "array_fill" },
+    .{ .name = "fill", .feature = "typed_array_fill" },
+    .{ .name = "filter", .feature = "array_filter" },
+    .{ .name = "filter", .feature = "typed_array_filter" },
+    .{ .name = "filter", .feature = "iterator_filter" },
+    .{ .name = "find", .feature = "array_find" },
+    .{ .name = "find", .feature = "typed_array_find" },
+    .{ .name = "find", .feature = "iterator_find" },
+    .{ .name = "findIndex", .feature = "array_find_index" },
+    .{ .name = "findIndex", .feature = "typed_array_find_index" },
+    .{ .name = "findLast", .feature = "array_find_last" },
+    .{ .name = "findLast", .feature = "typed_array_find_last" },
+    .{ .name = "findLastIndex", .feature = "array_find_last_index" },
+    .{ .name = "findLastIndex", .feature = "typed_array_find_last_index" },
+    .{ .name = "fixed", .feature = "string_fixed" },
+    .{ .name = "flags", .feature = "regexp_flags" },
+    .{ .name = "flat", .feature = "array_flat" },
+    .{ .name = "flatMap", .feature = "array_flat_map" },
+    .{ .name = "flatMap", .feature = "iterator_flat_map" },
+    .{ .name = "fontcolor", .feature = "string_fontcolor" },
+    .{ .name = "fontsize", .feature = "string_fontsize" },
+    .{ .name = "forEach", .feature = "array_for_each" },
+    .{ .name = "forEach", .feature = "typed_array_for_each" },
+    .{ .name = "forEach", .feature = "iterator_for_each" },
+    .{ .name = "forEach", .feature = "web_dom_collections_for_each" },
+    .{ .name = "getFloat16", .feature = "data_view_get_float16" },
+    .{ .name = "getOrInsert", .feature = "map_get_or_insert" },
+    .{ .name = "getOrInsert", .feature = "weak_map_get_or_insert" },
+    .{ .name = "getOrInsertComputed", .feature = "map_get_or_insert_computed" },
+    .{ .name = "getOrInsertComputed", .feature = "weak_map_get_or_insert_computed" },
+    .{ .name = "has", .feature = "web_url_search_params_has" },
+    .{ .name = "includes", .feature = "array_includes" },
+    .{ .name = "includes", .feature = "string_includes" },
+    .{ .name = "includes", .feature = "typed_array_includes" },
+    .{ .name = "indexOf", .feature = "array_index_of" },
+    .{ .name = "indexOf", .feature = "typed_array_index_of" },
+    .{ .name = "intersection", .feature = "set_intersection" },
+    .{ .name = "isDisjointFrom", .feature = "set_is_disjoint_from" },
+    .{ .name = "isSubsetOf", .feature = "set_is_subset_of" },
+    .{ .name = "isSupersetOf", .feature = "set_is_superset_of" },
+    .{ .name = "isWellFormed", .feature = "string_is_well_formed" },
+    .{ .name = "italics", .feature = "string_italics" },
+    .{ .name = "join", .feature = "array_join" },
+    .{ .name = "join", .feature = "typed_array_join" },
+    .{ .name = "lastIndexOf", .feature = "array_last_index_of" },
+    .{ .name = "lastIndexOf", .feature = "typed_array_last_index_of" },
+    .{ .name = "link", .feature = "string_link" },
+    .{ .name = "map", .feature = "array_map" },
+    .{ .name = "map", .feature = "typed_array_map" },
+    .{ .name = "map", .feature = "iterator_map" },
+    .{ .name = "matchAll", .feature = "string_match_all" },
+    .{ .name = "padEnd", .feature = "string_pad_end" },
+    .{ .name = "padStart", .feature = "string_pad_start" },
+    .{ .name = "push", .feature = "array_push" },
+    .{ .name = "reduce", .feature = "array_reduce" },
+    .{ .name = "reduce", .feature = "typed_array_reduce" },
+    .{ .name = "reduce", .feature = "iterator_reduce" },
+    .{ .name = "reduceRight", .feature = "array_reduce_right" },
+    .{ .name = "reduceRight", .feature = "typed_array_reduce_right" },
+    .{ .name = "repeat", .feature = "string_repeat" },
+    .{ .name = "replaceAll", .feature = "string_replace_all" },
+    .{ .name = "reverse", .feature = "array_reverse" },
+    .{ .name = "reverse", .feature = "typed_array_reverse" },
+    .{ .name = "set", .feature = "typed_array_set" },
+    .{ .name = "setFloat16", .feature = "data_view_set_float16" },
+    .{ .name = "setFromBase64", .feature = "uint8_array_set_from_base64" },
+    .{ .name = "setFromHex", .feature = "uint8_array_set_from_hex" },
+    .{ .name = "size", .feature = "web_url_search_params_size" },
+    .{ .name = "slice", .feature = "array_slice" },
+    .{ .name = "slice", .feature = "typed_array_slice" },
+    .{ .name = "slice", .feature = "array_buffer_slice" },
+    .{ .name = "small", .feature = "string_small" },
+    .{ .name = "some", .feature = "array_some" },
+    .{ .name = "some", .feature = "typed_array_some" },
+    .{ .name = "some", .feature = "iterator_some" },
+    .{ .name = "sort", .feature = "array_sort" },
+    .{ .name = "sort", .feature = "typed_array_sort" },
+    .{ .name = "splice", .feature = "array_splice" },
+    .{ .name = "startsWith", .feature = "string_starts_with" },
+    .{ .name = "sticky", .feature = "regexp_sticky" },
+    .{ .name = "strike", .feature = "string_strike" },
+    .{ .name = "sub", .feature = "string_sub" },
+    .{ .name = "subarray", .feature = "typed_array_subarray" },
+    .{ .name = "substr", .feature = "string_substr" },
+    .{ .name = "sup", .feature = "string_sup" },
+    .{ .name = "symmetricDifference", .feature = "set_symmetric_difference" },
+    .{ .name = "take", .feature = "iterator_take" },
+    .{ .name = "toArray", .feature = "iterator_to_array" },
+    .{ .name = "toBase64", .feature = "uint8_array_to_base64" },
+    .{ .name = "toFixed", .feature = "number_to_fixed" },
+    .{ .name = "toExponential", .feature = "number_to_exponential" },
+    .{ .name = "toHex", .feature = "uint8_array_to_hex" },
+    .{ .name = "toISOString", .feature = "date_to_iso_string" },
+    .{ .name = "toJSON", .feature = "web_url_to_json" },
+    .{ .name = "toPrecision", .feature = "number_to_precision" },
+    .{ .name = "toReversed", .feature = "array_to_reversed" },
+    .{ .name = "toReversed", .feature = "typed_array_to_reversed" },
+    .{ .name = "toSorted", .feature = "array_to_sorted" },
+    .{ .name = "toSorted", .feature = "typed_array_to_sorted" },
+    .{ .name = "toSpliced", .feature = "array_to_spliced" },
+    .{ .name = "toWellFormed", .feature = "string_to_well_formed" },
+    .{ .name = "transfer", .feature = "array_buffer_transfer" },
+    .{ .name = "transferToFixedLength", .feature = "array_buffer_transfer_to_fixed_length" },
+    .{ .name = "trim", .feature = "string_trim" },
+    .{ .name = "trimEnd", .feature = "string_trim_end" },
+    .{ .name = "trimLeft", .feature = "string_trim_start" },
+    .{ .name = "trimRight", .feature = "string_trim_end" },
+    .{ .name = "trimStart", .feature = "string_trim_start" },
+    .{ .name = "union", .feature = "set_union" },
+    .{ .name = "unshift", .feature = "array_unshift" },
+    .{ .name = "with", .feature = "array_with" },
+    .{ .name = "with", .feature = "typed_array_with" },
+    .{ .name = "__defineGetter__", .feature = "object_define_getter" },
+    .{ .name = "__defineSetter__", .feature = "object_define_setter" },
+    .{ .name = "__lookupGetter__", .feature = "object_lookup_getter" },
+    .{ .name = "__lookupSetter__", .feature = "object_lookup_setter" },
+    .{ .name = "__proto__", .feature = "object_proto" },
+};
+
+const static_member_features = [_]NameFeature{
+    .{ .name = "Array.from", .feature = "array_from" },
+    .{ .name = "Array.fromAsync", .feature = "array_from_async" },
+    .{ .name = "Array.isArray", .feature = "array_is_array" },
+    .{ .name = "Array.of", .feature = "array_of" },
+    .{ .name = "ArrayBuffer.isView", .feature = "array_buffer_is_view" },
+    .{ .name = "Date.now", .feature = "date_now" },
+    .{ .name = "Error.isError", .feature = "error_is_error" },
+    .{ .name = "Iterator.from", .feature = "iterator_from" },
+    .{ .name = "JSON.isRawJSON", .feature = "json_is_raw_json" },
+    .{ .name = "JSON.parse", .feature = "json_parse" },
+    .{ .name = "JSON.rawJSON", .feature = "json_raw_json" },
+    .{ .name = "JSON.stringify", .feature = "json_stringify" },
+    .{ .name = "Map.groupBy", .feature = "map_group_by" },
+    .{ .name = "Math.acosh", .feature = "math_acosh" },
+    .{ .name = "Math.asinh", .feature = "math_asinh" },
+    .{ .name = "Math.atanh", .feature = "math_atanh" },
+    .{ .name = "Math.cbrt", .feature = "math_cbrt" },
+    .{ .name = "Math.clz32", .feature = "math_clz32" },
+    .{ .name = "Math.cosh", .feature = "math_cosh" },
+    .{ .name = "Math.expm1", .feature = "math_expm1" },
+    .{ .name = "Math.f16round", .feature = "math_f16round" },
+    .{ .name = "Math.fround", .feature = "math_fround" },
+    .{ .name = "Math.hypot", .feature = "math_hypot" },
+    .{ .name = "Math.imul", .feature = "math_imul" },
+    .{ .name = "Math.log10", .feature = "math_log10" },
+    .{ .name = "Math.log1p", .feature = "math_log1p" },
+    .{ .name = "Math.log2", .feature = "math_log2" },
+    .{ .name = "Math.sign", .feature = "math_sign" },
+    .{ .name = "Math.sinh", .feature = "math_sinh" },
+    .{ .name = "Math.sumPrecise", .feature = "math_sum_precise" },
+    .{ .name = "Math.tanh", .feature = "math_tanh" },
+    .{ .name = "Math.trunc", .feature = "math_trunc" },
+    .{ .name = "Number.EPSILON", .feature = "number_epsilon" },
+    .{ .name = "Number.MAX_SAFE_INTEGER", .feature = "number_max_safe_integer" },
+    .{ .name = "Number.MIN_SAFE_INTEGER", .feature = "number_min_safe_integer" },
+    .{ .name = "Number.isFinite", .feature = "number_is_finite" },
+    .{ .name = "Number.isInteger", .feature = "number_is_integer" },
+    .{ .name = "Number.isNaN", .feature = "number_is_nan" },
+    .{ .name = "Number.isSafeInteger", .feature = "number_is_safe_integer" },
+    .{ .name = "Number.parseFloat", .feature = "number_parse_float" },
+    .{ .name = "Number.parseInt", .feature = "number_parse_int" },
+    .{ .name = "Object.assign", .feature = "object_assign" },
+    .{ .name = "Object.create", .feature = "object_create" },
+    .{ .name = "Object.defineProperties", .feature = "object_define_properties" },
+    .{ .name = "Object.defineProperty", .feature = "object_define_property" },
+    .{ .name = "Object.entries", .feature = "object_entries" },
+    .{ .name = "Object.freeze", .feature = "object_freeze" },
+    .{ .name = "Object.fromEntries", .feature = "object_from_entries" },
+    .{ .name = "Object.getOwnPropertyDescriptor", .feature = "object_get_own_property_descriptor" },
+    .{ .name = "Object.getOwnPropertyDescriptors", .feature = "object_get_own_property_descriptors" },
+    .{ .name = "Object.getOwnPropertyNames", .feature = "object_get_own_property_names" },
+    .{ .name = "Object.getPrototypeOf", .feature = "object_get_prototype_of" },
+    .{ .name = "Object.groupBy", .feature = "object_group_by" },
+    .{ .name = "Object.hasOwn", .feature = "object_has_own" },
+    .{ .name = "Object.is", .feature = "object_is" },
+    .{ .name = "Object.isExtensible", .feature = "object_is_extensible" },
+    .{ .name = "Object.isFrozen", .feature = "object_is_frozen" },
+    .{ .name = "Object.isSealed", .feature = "object_is_sealed" },
+    .{ .name = "Object.keys", .feature = "object_keys" },
+    .{ .name = "Object.preventExtensions", .feature = "object_prevent_extensions" },
+    .{ .name = "Object.seal", .feature = "object_seal" },
+    .{ .name = "Object.setPrototypeOf", .feature = "object_set_prototype_of" },
+    .{ .name = "Object.values", .feature = "object_values" },
+    .{ .name = "Promise.allSettled", .feature = "promise_all_settled" },
+    .{ .name = "Promise.any", .feature = "promise_any" },
+    .{ .name = "Promise.try", .feature = "promise_try" },
+    .{ .name = "Promise.withResolvers", .feature = "promise_with_resolvers" },
+    .{ .name = "Reflect.apply", .feature = "reflect_apply" },
+    .{ .name = "Reflect.construct", .feature = "reflect_construct" },
+    .{ .name = "Reflect.defineProperty", .feature = "reflect_define_property" },
+    .{ .name = "Reflect.deleteProperty", .feature = "reflect_delete_property" },
+    .{ .name = "Reflect.get", .feature = "reflect_get" },
+    .{ .name = "Reflect.getOwnPropertyDescriptor", .feature = "reflect_get_own_property_descriptor" },
+    .{ .name = "Reflect.getPrototypeOf", .feature = "reflect_get_prototype_of" },
+    .{ .name = "Reflect.has", .feature = "reflect_has" },
+    .{ .name = "Reflect.isExtensible", .feature = "reflect_is_extensible" },
+    .{ .name = "Reflect.ownKeys", .feature = "reflect_own_keys" },
+    .{ .name = "Reflect.preventExtensions", .feature = "reflect_prevent_extensions" },
+    .{ .name = "Reflect.set", .feature = "reflect_set" },
+    .{ .name = "Reflect.setPrototypeOf", .feature = "reflect_set_prototype_of" },
+    .{ .name = "RegExp.escape", .feature = "regexp_escape" },
+    .{ .name = "String.fromCodePoint", .feature = "string_from_code_point" },
+    .{ .name = "String.raw", .feature = "string_raw" },
+    .{ .name = "Symbol.asyncDispose", .feature = "symbol_async_dispose" },
+    .{ .name = "Symbol.asyncIterator", .feature = "symbol_async_iterator" },
+    .{ .name = "Symbol.dispose", .feature = "symbol_dispose" },
+    .{ .name = "Symbol.hasInstance", .feature = "symbol_has_instance" },
+    .{ .name = "Symbol.isConcatSpreadable", .feature = "symbol_is_concat_spreadable" },
+    .{ .name = "Symbol.iterator", .feature = "symbol_iterator" },
+    .{ .name = "Symbol.iterator", .feature = "web_dom_collections_iterator" },
+    .{ .name = "Symbol.match", .feature = "symbol_match" },
+    .{ .name = "Symbol.matchAll", .feature = "symbol_match_all" },
+    .{ .name = "Symbol.replace", .feature = "symbol_replace" },
+    .{ .name = "Symbol.search", .feature = "symbol_search" },
+    .{ .name = "Symbol.species", .feature = "symbol_species" },
+    .{ .name = "Symbol.split", .feature = "symbol_split" },
+    .{ .name = "Symbol.toPrimitive", .feature = "symbol_to_primitive" },
+    .{ .name = "Symbol.toStringTag", .feature = "symbol_to_string_tag" },
+    .{ .name = "Symbol.unscopables", .feature = "symbol_unscopables" },
+    .{ .name = "URL.canParse", .feature = "web_url_can_parse" },
+    .{ .name = "URL.parse", .feature = "web_url_parse" },
+    .{ .name = "Uint8Array.fromBase64", .feature = "uint8_array_from_base64" },
+    .{ .name = "Uint8Array.fromHex", .feature = "uint8_array_from_hex" },
+};
+
+pub fn collectModuleUsage(allocator: std.mem.Allocator, module: *const Module) !FeatureSet {
+    if (!module.module_type.isJavaScriptLike()) return .{};
+    const ast = &(module.ast orelse return .{});
+    const semantic = &(module.semantic orelse return .{});
+    return collectAstUsage(allocator, ast, semantic);
+}
+
+fn collectAstUsage(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    semantic: *const ModuleSemanticData,
+) !FeatureSet {
+    if (ast.nodes.items.len == 0) return .{};
+
+    const reachable = try ast_walk.collectReachableNodeIndices(allocator, ast);
+    defer allocator.free(reachable);
+
+    var skip_identifiers = try std.DynamicBitSet.initEmpty(allocator, ast.nodes.items.len);
+    defer skip_identifiers.deinit();
+    markSkippedIdentifiers(ast, reachable, &skip_identifiers);
+
+    var out: FeatureSet = .{};
+    for (reachable) |ni| {
+        const node = ast.nodes.items[ni];
+        switch (node.tag) {
+            .static_member_expression => try recordStaticMemberUsage(allocator, ast, semantic, @enumFromInt(ni), node, &out),
+            .identifier_reference => {
+                if (!skip_identifiers.isSet(ni)) try recordIdentifierUsage(allocator, ast, semantic, @enumFromInt(ni), &out);
+            },
+            else => {},
+        }
+    }
+    return out;
+}
+
+fn markSkippedIdentifiers(ast: *const Ast, reachable: []const u32, skip: *std.DynamicBitSet) void {
+    for (reachable) |ni| {
+        const node = ast.nodes.items[ni];
+        switch (node.tag) {
+            .static_member_expression => {
+                const prop = ast.readExtraNode(node.data.extra, 1);
+                setSkip(skip, prop);
+            },
+            .computed_member_expression => {
+                const obj = ast.readExtraNode(node.data.extra, 0);
+                const prop = ast.readExtraNode(node.data.extra, 1);
+                setSkip(skip, obj);
+                setSkip(skip, prop);
+            },
+            .object_property => {
+                if (!node.data.binary.right.isNone()) setSkip(skip, node.data.binary.left);
+            },
+            .method_definition, .property_definition, .accessor_property => {
+                const key = ast.readExtraNode(node.data.extra, 0);
+                setSkip(skip, key);
+            },
+            .import_specifier, .import_default_specifier, .import_namespace_specifier, .export_specifier => {
+                var it = ast_walk.children(ast, node);
+                while (it.next()) |child| setSkip(skip, child);
+            },
+            else => {},
+        }
+    }
+}
+
+fn setSkip(skip: *std.DynamicBitSet, idx: NodeIndex) void {
+    if (idx.isNone()) return;
+    const raw = @intFromEnum(idx);
+    if (raw < skip.capacity()) skip.set(raw);
+}
+
+fn recordStaticMemberUsage(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    semantic: *const ModuleSemanticData,
+    idx: NodeIndex,
+    node: Node,
+    out: *FeatureSet,
+) !void {
+    const obj_idx = ast.readExtraNode(node.data.extra, 0);
+    const prop_idx = ast.readExtraNode(node.data.extra, 1);
+    if (prop_idx.isNone() or @intFromEnum(prop_idx) >= ast.nodes.items.len) return;
+
+    const prop_node = ast.getNode(prop_idx);
+    if (prop_node.tag != .identifier_reference) return;
+    const prop_name = ast.getText(prop_node.data.string_ref);
+
+    try insertFeaturesForName(allocator, out, prop_name, &prototype_member_features);
+    if (globalReferenceName(ast, semantic, obj_idx)) |global_name| {
+        try insertStaticMemberFeatures(allocator, out, global_name, prop_name);
+    }
+
+    try recordGlobalReferenceUsage(allocator, ast, semantic, idx, out);
+    try recordGlobalReferenceUsage(allocator, ast, semantic, obj_idx, out);
+}
+
+fn recordIdentifierUsage(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    semantic: *const ModuleSemanticData,
+    idx: NodeIndex,
+    out: *FeatureSet,
+) !void {
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return;
+    const node = ast.getNode(idx);
+    if (node.tag != .identifier_reference) return;
+    const name = ast.getText(node.data.string_ref);
+    if (!isGlobalIdentifierNamed(ast, semantic, idx, name)) return;
+
+    try insertFeatureForGlobalName(allocator, name, out);
+}
+
+fn recordGlobalReferenceUsage(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    semantic: *const ModuleSemanticData,
+    idx: NodeIndex,
+    out: *FeatureSet,
+) !void {
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return;
+    const node = ast.getNode(idx);
+    if (node.tag == .identifier_reference) {
+        try recordIdentifierUsage(allocator, ast, semantic, idx, out);
+        return;
+    }
+    if (node.tag != .static_member_expression) return;
+
+    const obj_idx = ast.readExtraNode(node.data.extra, 0);
+    const prop_idx = ast.readExtraNode(node.data.extra, 1);
+    if (!isGlobalIdentifierNamed(ast, semantic, obj_idx, "globalThis")) return;
+    if (prop_idx.isNone() or @intFromEnum(prop_idx) >= ast.nodes.items.len) return;
+
+    const prop_node = ast.getNode(prop_idx);
+    if (prop_node.tag != .identifier_reference) return;
+    const name = ast.getText(prop_node.data.string_ref);
+    try insertFeatureForGlobalName(allocator, name, out);
+}
+
+fn insertFeatureForGlobalName(allocator: std.mem.Allocator, name: []const u8, out: *FeatureSet) !void {
+    try insertFeaturesForName(allocator, out, name, &global_features);
+}
+
+fn insertFeaturesForName(
+    allocator: std.mem.Allocator,
+    out: *FeatureSet,
+    name: []const u8,
+    mappings: []const NameFeature,
+) !void {
+    for (mappings) |mapping| {
+        if (std.mem.eql(u8, name, mapping.name)) {
+            try out.insert(allocator, mapping.feature);
+        }
+    }
+}
+
+fn insertStaticMemberFeatures(
+    allocator: std.mem.Allocator,
+    out: *FeatureSet,
+    object_name: []const u8,
+    property_name: []const u8,
+) !void {
+    var buf: [96]u8 = undefined;
+    if (object_name.len + property_name.len + 1 > buf.len) return;
+    @memcpy(buf[0..object_name.len], object_name);
+    buf[object_name.len] = '.';
+    @memcpy(buf[object_name.len + 1 .. object_name.len + 1 + property_name.len], property_name);
+    const key = buf[0 .. object_name.len + 1 + property_name.len];
+    try insertFeaturesForName(allocator, out, key, &static_member_features);
+
+    if (std.mem.eql(u8, object_name, "Promise")) {
+        if (std.mem.eql(u8, property_name, "all") or
+            std.mem.eql(u8, property_name, "race") or
+            std.mem.eql(u8, property_name, "reject") or
+            std.mem.eql(u8, property_name, "resolve"))
+        {
+            try out.insert(allocator, "promise");
+        }
+    } else if (isTypedArrayGlobalName(object_name)) {
+        if (std.mem.eql(u8, property_name, "from")) {
+            try out.insert(allocator, "typed_array_from");
+        } else if (std.mem.eql(u8, property_name, "of")) {
+            try out.insert(allocator, "typed_array_of");
+        }
+    }
+}
+
+fn isGlobalReferenceNamed(
+    ast: *const Ast,
+    semantic: *const ModuleSemanticData,
+    idx: NodeIndex,
+    expected: []const u8,
+) bool {
+    if (isGlobalIdentifierNamed(ast, semantic, idx, expected)) return true;
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return false;
+    const node = ast.getNode(idx);
+    if (node.tag != .static_member_expression) return false;
+
+    const obj_idx = ast.readExtraNode(node.data.extra, 0);
+    const prop_idx = ast.readExtraNode(node.data.extra, 1);
+    if (!isGlobalIdentifierNamed(ast, semantic, obj_idx, "globalThis")) return false;
+    if (prop_idx.isNone() or @intFromEnum(prop_idx) >= ast.nodes.items.len) return false;
+
+    const prop_node = ast.getNode(prop_idx);
+    if (prop_node.tag != .identifier_reference) return false;
+    return std.mem.eql(u8, ast.getText(prop_node.data.string_ref), expected);
+}
+
+fn globalReferenceName(
+    ast: *const Ast,
+    semantic: *const ModuleSemanticData,
+    idx: NodeIndex,
+) ?[]const u8 {
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return null;
+    const node = ast.getNode(idx);
+    if (node.tag == .identifier_reference) {
+        const name = ast.getText(node.data.string_ref);
+        return if (isGlobalIdentifierNamed(ast, semantic, idx, name)) name else null;
+    }
+    if (node.tag != .static_member_expression) return null;
+
+    const obj_idx = ast.readExtraNode(node.data.extra, 0);
+    const prop_idx = ast.readExtraNode(node.data.extra, 1);
+    if (!isGlobalIdentifierNamed(ast, semantic, obj_idx, "globalThis")) return null;
+    if (prop_idx.isNone() or @intFromEnum(prop_idx) >= ast.nodes.items.len) return null;
+
+    const prop_node = ast.getNode(prop_idx);
+    if (prop_node.tag != .identifier_reference) return null;
+    return ast.getText(prop_node.data.string_ref);
+}
+
+fn isTypedArrayGlobalName(name: []const u8) bool {
+    return std.mem.eql(u8, name, "Int8Array") or
+        std.mem.eql(u8, name, "Int16Array") or
+        std.mem.eql(u8, name, "Int32Array") or
+        std.mem.eql(u8, name, "Uint8Array") or
+        std.mem.eql(u8, name, "Uint8ClampedArray") or
+        std.mem.eql(u8, name, "Uint16Array") or
+        std.mem.eql(u8, name, "Uint32Array") or
+        std.mem.eql(u8, name, "Float32Array") or
+        std.mem.eql(u8, name, "Float64Array");
+}
+
+fn isGlobalIdentifierNamed(
+    ast: *const Ast,
+    semantic: *const ModuleSemanticData,
+    idx: NodeIndex,
+    expected: []const u8,
+) bool {
+    if (idx.isNone()) return false;
+    const raw = @intFromEnum(idx);
+    if (raw >= ast.nodes.items.len or raw >= semantic.symbol_ids.len) return false;
+    const node = ast.nodes.items[raw];
+    if (node.tag != .identifier_reference) return false;
+    const name = ast.getText(node.data.string_ref);
+    return std.mem.eql(u8, name, expected) and
+        semantic.symbol_ids[raw] == null and
+        semantic.unresolved_references.contains(expected);
+}
+
+test "runtime polyfill collector detects v1 global and member usage" {
+    const usage = try testCollect(
+        \\const a = "a".replaceAll("a", "b");
+        \\const b = values.at(0);
+        \\const c = Object.hasOwn({ a: 1 }, "a");
+        \\const d = structuredClone(c);
+        \\const e = new Map();
+        \\const f = new Set();
+        \\const g = Promise.resolve(d);
+        \\void [a, b, c, d, e, f, g];
+    );
+    try std.testing.expect(usage.has("string_replace_all"));
+    try std.testing.expect(usage.has("array_at"));
+    try std.testing.expect(usage.has("object_has_own"));
+    try std.testing.expect(usage.has("structured_clone"));
+    try std.testing.expect(usage.has("map"));
+    try std.testing.expect(usage.has("set"));
+    try std.testing.expect(usage.has("promise"));
+}
+
+test "runtime polyfill collector detects explicit globalThis references" {
+    const usage = try testCollect(
+        \\const a = new globalThis.Map();
+        \\const b = new globalThis.Set();
+        \\const c = globalThis.Promise.resolve(a);
+        \\const d = globalThis.structuredClone(b);
+        \\const e = globalThis.Object.hasOwn({ a: 1 }, "a");
+        \\void [a, b, c, d, e];
+    );
+    try std.testing.expect(usage.has("map"));
+    try std.testing.expect(usage.has("set"));
+    try std.testing.expect(usage.has("promise"));
+    try std.testing.expect(usage.has("structured_clone"));
+    try std.testing.expect(usage.has("object_has_own"));
+}
+
+test "runtime polyfill collector detects expanded core-js built-ins" {
+    const usage = try testCollect(
+        \\const a = Object.values({ a: 1 });
+        \\const b = [1, 2, 3].findLast((value) => value < 3);
+        \\const c = "7".padStart(2, "0");
+        \\const d = Math.trunc(1.8);
+        \\const e = Reflect.ownKeys({ x: 1 });
+        \\const f = Promise.any([Promise.resolve(1)]);
+        \\const g = Symbol.iterator;
+        \\const h = new WeakMap();
+        \\const i = URL.canParse("https://example.com");
+        \\const j = new Uint8Array(4).toReversed();
+        \\const k = Iterator.from([1, 2]).take(1).toArray();
+        \\const l = ArrayBuffer.isView(j);
+        \\const m = queueMicrotask(() => {});
+        \\void [a, b, c, d, e, f, g, h, i, k, l, m];
+    );
+    try std.testing.expect(usage.has("object_values"));
+    try std.testing.expect(usage.has("array_find_last"));
+    try std.testing.expect(usage.has("string_pad_start"));
+    try std.testing.expect(usage.has("math_trunc"));
+    try std.testing.expect(usage.has("reflect_own_keys"));
+    try std.testing.expect(usage.has("promise_any"));
+    try std.testing.expect(usage.has("symbol_iterator"));
+    try std.testing.expect(usage.has("weak_map"));
+    try std.testing.expect(usage.has("web_url_can_parse"));
+    try std.testing.expect(usage.has("typed_array_uint8"));
+    try std.testing.expect(usage.has("typed_array_to_reversed"));
+    try std.testing.expect(usage.has("iterator_from"));
+    try std.testing.expect(usage.has("iterator_take"));
+    try std.testing.expect(usage.has("iterator_to_array"));
+    try std.testing.expect(usage.has("array_buffer_is_view"));
+    try std.testing.expect(usage.has("web_queue_microtask"));
+}
+
+test "runtime polyfill collector ignores shadowed and imported globals" {
+    const usage = try testCollect(
+        \\import { Map, Object as ImportedObject } from "pkg";
+        \\const Promise = { resolve() {} };
+        \\function run(structuredClone) {
+        \\  const Set = class {};
+        \\  new Map();
+        \\  new Set();
+        \\  Promise.resolve();
+        \\  ImportedObject.hasOwn({}, "x");
+        \\  structuredClone({});
+        \\}
+        \\run();
+    );
+    try std.testing.expect(!usage.has("map"));
+    try std.testing.expect(!usage.has("set"));
+    try std.testing.expect(!usage.has("promise"));
+    try std.testing.expect(!usage.has("object_has_own"));
+    try std.testing.expect(!usage.has("structured_clone"));
+}
+
+test "runtime polyfill collector ignores type-only references and shadowed globalThis" {
+    const usage = try testCollectTyped(
+        \\type Cache = Map<string, Set<number>>;
+        \\interface Work {
+        \\  done: Promise<void>;
+        \\}
+        \\const globalThis = {
+        \\  Map: class {},
+        \\  Promise: { resolve() {} },
+        \\  Object: { hasOwn() { return true; } },
+        \\};
+        \\new globalThis.Map();
+        \\globalThis.Promise.resolve();
+        \\globalThis.Object.hasOwn({}, "x");
+    );
+    try std.testing.expect(!usage.has("map"));
+    try std.testing.expect(!usage.has("set"));
+    try std.testing.expect(!usage.has("promise"));
+    try std.testing.expect(!usage.has("object_has_own"));
+}
+
+test "runtime polyfill collector ignores dynamic computed member access" {
+    const usage = try testCollect(
+        \\const method = "resolve";
+        \\Promise[method]();
+        \\value[method]("x");
+        \\globalThis["Map"];
+        \\globalThis.Object["hasOwn"]({}, "x");
+    );
+    try std.testing.expect(!usage.has("promise"));
+    try std.testing.expect(!usage.has("map"));
+    try std.testing.expect(!usage.has("object_has_own"));
+    try std.testing.expect(!usage.has("string_replace_all"));
+    try std.testing.expect(!usage.has("array_at"));
+}
+
+fn testCollect(source: []const u8) !FeatureSet {
+    return testCollectWithModuleType(source, .js);
+}
+
+fn testCollectTyped(source: []const u8) !FeatureSet {
+    return testCollectWithModuleType(source, .ts);
+}
+
+fn testCollectWithModuleType(source: []const u8, module_type: ModuleType) !FeatureSet {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var scanner = try @import("../lexer/scanner.zig").Scanner.init(allocator, source);
+    var parser = @import("../parser/parser.zig").Parser.init(allocator, &scanner);
+    const parser_flags = module_type.toParserFlags();
+    parser.configureForBundlerKind(parser_flags.is_ts, parser_flags.is_jsx);
+    parser.enable_scan = true;
+    _ = try parser.parse();
+
+    var analyzer = @import("../semantic/analyzer.zig").SemanticAnalyzer.init(allocator, &parser.ast);
+    analyzer.is_module = true;
+    analyzer.enable_stmt_info = true;
+    try analyzer.analyze();
+
+    var module = Module.init(.none, "input.js");
+    module.source = source;
+    module.module_type = module_type;
+    module.ast = parser.ast;
+    module.semantic = .{
+        .symbols = analyzer.symbols,
+        .scopes = analyzer.scopes.items,
+        .scope_maps = analyzer.scope_maps.items,
+        .exported_names = analyzer.exported_names,
+        .symbol_ids = analyzer.symbol_ids.items,
+        .unresolved_references = analyzer.unresolved_references,
+        .references = analyzer.references.items,
+        .numeric_const_texts = analyzer.numeric_const_texts,
+    };
+    return collectModuleUsage(allocator, &module);
+}

--- a/src/bundler/runtime_polyfills.zig
+++ b/src/bundler/runtime_polyfills.zig
@@ -560,27 +560,6 @@ fn insertStaticMemberFeatures(
     }
 }
 
-fn isGlobalReferenceNamed(
-    ast: *const Ast,
-    semantic: *const ModuleSemanticData,
-    idx: NodeIndex,
-    expected: []const u8,
-) bool {
-    if (isGlobalIdentifierNamed(ast, semantic, idx, expected)) return true;
-    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return false;
-    const node = ast.getNode(idx);
-    if (node.tag != .static_member_expression) return false;
-
-    const obj_idx = ast.readExtraNode(node.data.extra, 0);
-    const prop_idx = ast.readExtraNode(node.data.extra, 1);
-    if (!isGlobalIdentifierNamed(ast, semantic, obj_idx, "globalThis")) return false;
-    if (prop_idx.isNone() or @intFromEnum(prop_idx) >= ast.nodes.items.len) return false;
-
-    const prop_node = ast.getNode(prop_idx);
-    if (prop_node.tag != .identifier_reference) return false;
-    return std.mem.eql(u8, ast.getText(prop_node.data.string_ref), expected);
-}
-
 fn globalReferenceName(
     ast: *const Ast,
     semantic: *const ModuleSemanticData,

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -545,9 +545,8 @@ pub const TreeShaker = struct {
         self.re_export_star_targets = re_star_targets;
 
         // entry_set 먼저 계산 (자동 순수 판별에서 진입점 제외용).
-        // `graph.inject_files` includes both user `inject` and `runBeforeMain`.
-        // They are not output entries, but they are execution roots and may be
-        // import-only prelude modules.
+        // `inject` and `runBeforeMain` are not output entries, but they are
+        // execution roots and may be import-only prelude modules.
         for (0..mod_count) |i| {
             const m = self.getModule(@intCast(i)) orelse continue;
             for (entry_points) |ep| {
@@ -559,6 +558,13 @@ pub const TreeShaker = struct {
             if (self.entry_set.isSet(i)) continue;
             for (self.graph.inject_files) |inject_path| {
                 if (std.mem.eql(u8, m.path, inject_path)) {
+                    self.entry_set.set(i);
+                    break;
+                }
+            }
+            if (self.entry_set.isSet(i)) continue;
+            for (self.graph.run_before_main_files) |rbm_path| {
+                if (std.mem.eql(u8, m.path, rbm_path)) {
                     self.entry_set.set(i);
                     break;
                 }

--- a/src/config_options_dto_test.zig
+++ b/src/config_options_dto_test.zig
@@ -213,7 +213,7 @@ const ts_buildoptions_only_allowlist = [_][]const u8{
     "platform", // discriminated union 으로 처리됨
     "target",
     "browserslist",
-    "runtimePolyfills", // JS wrapper가 core-js prelude 로 변환 후 runBeforeMain 으로 전달
+    "runtimePolyfills", // JS wrapper가 core-js compat 후보를 native graph plan 으로 전달
     "coreJs", // runtimePolyfills 전용 core-js 버전 힌트
     "plugins",
     "compiler", // 1st-party transform 네임스페이스 (compiler.styledComponents/emotion).

--- a/src/debug_log.zig
+++ b/src/debug_log.zig
@@ -38,6 +38,8 @@ pub const Category = enum {
     /// `Ast.addString` intern map 의 hit/miss 통계. PR #2496 의 dedupe 효과
     /// 측정용. 모듈별 (parser/transformer 두 ast 합산) dump.
     string_intern,
+    /// Runtime core-js usage detection and graph prelude decisions.
+    runtime_polyfills,
 
     /// 카테고리 이름으로 enum 조회 (공백 제거 + 대소문자 무시).
     pub fn fromString(s: []const u8) ?Category {
@@ -110,6 +112,7 @@ pub fn print(comptime cat: Category, comptime fmt: []const u8, args: anytype) vo
 test "Category.fromString 매칭" {
     try std.testing.expect(Category.fromString("compiled_cache") == .compiled_cache);
     try std.testing.expect(Category.fromString("COMPILED_CACHE") == .compiled_cache);
+    try std.testing.expect(Category.fromString("runtime_polyfills") == .runtime_polyfills);
     try std.testing.expect(Category.fromString("  compiled_cache  ") == .compiled_cache);
     try std.testing.expect(Category.fromString("nonexistent") == null);
     try std.testing.expect(Category.fromString("") == null);

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -89,6 +89,10 @@ pub const Category = enum {
     graph_resync_export_bindings,
     graph_resync_classify,
     graph_resync_alias,
+    graph_runtime_polyfills,
+    graph_runtime_polyfills_collect,
+    graph_runtime_polyfills_aggregate,
+    graph_runtime_polyfills_inject,
 
     // ── Linking / Tree-shaking ──
     link,

--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -391,13 +391,15 @@ fn markReachableNodes(ast: *const Ast, root: NodeIndex, live: *std.DynamicBitSet
 //   - symbol 의 `scope_id != 0` (함수/블록 local 만) — top-level 은 tree-shaker 영역
 //   - `reference_count == 0` and `write_count == 0`
 //   - `is_exported` / `is_default_export` 둘 다 false
-//   - init 이 없거나 `purity.isExprPure` 가 true
+//   - source-authored init 이 없거나 `purity.isExprPure` 가 true
 //
 // 제외:
 //   - top-level (module scope) 선언     — tree-shaker 가 커버, 중복 제거는 fixture 회귀
 //   - `using` / `await using`           — `[Symbol.dispose]` 호출이 side-effect
 //   - destructuring / non-identifier    — pattern 은 간접 getter 호출 가능
 //   - declarator 2개 이상               — 부분 제거는 PR 범위 밖 (복잡도)
+//   - synthetic no-init temp 선언       — transformer 가 나중에 만든 assignment ref 는
+//                                        원본 semantic refcount 와 어긋날 수 있음
 //   - init 이 불순                      — "강등" (→ expression_statement) 은 PR1.5
 //
 // 제거 시 init expression 내 모든 identifier_reference 의 `reference_count` 를
@@ -484,6 +486,13 @@ fn tryRemoveDeadDecl(ast: *Ast, ctx: MinifyCtx, node_idx: u32, node: Node, chang
     // 단일 binding_identifier 만 — destructuring/array/object pattern 제외
     if (name_node.tag != .binding_identifier) return;
 
+    const init_idx: NodeIndex = @enumFromInt(init_raw);
+    // Transformer-generated temp declarations (`var _a;`) use interned string-table
+    // spans and are paired with assignment reads that may be introduced after the
+    // original semantic pass. Dropping the declaration can turn valid downlevel
+    // output into `_a = ...` ReferenceError in strict-mode wrappers.
+    if (init_idx.isNone() and (name_node.data.string_ref.start & Ast.STRING_TABLE_BIT) != 0) return;
+
     // symbol_ids[name_node_idx] → symbol index
     if (name_raw >= ctx.symbol_ids.len) return;
     const sym_id = ctx.symbol_ids[name_raw] orelse return;
@@ -507,7 +516,6 @@ fn tryRemoveDeadDecl(ast: *Ast, ctx: MinifyCtx, node_idx: u32, node: Node, chang
     if (ctx.effectiveRefCount(sym_id) != 0 or sym.write_count != 0) return;
 
     // init 이 있으면 purity 검사 — 불순하면 RHS 보존을 위해 (아직) 제거 불가
-    const init_idx: NodeIndex = @enumFromInt(init_raw);
     if (!init_idx.isNone()) {
         if (!purity.isExprPure(ast, init_idx, ctx.unresolved_globals)) return;
         // init 내부의 pure identifier_reference 들의 reference_count 를 감산

--- a/tests/integration/tests/runtime-polyfills-library-smoke.test.ts
+++ b/tests/integration/tests/runtime-polyfills-library-smoke.test.ts
@@ -1,0 +1,304 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createFixture, hasPackage, linkNodeModules, runNode, runZtsInDir } from "./helpers";
+
+const OLD_RUNTIME_ARGS = [
+  "--format=cjs",
+  "--platform=node",
+  "--target=es5",
+  "--runtime-polyfills=auto",
+  "--runtime-target=safari 5",
+];
+
+function expectNoRawDownlevelSyntax(js: string) {
+  expect(js).not.toContain("?.");
+  expect(js.replace(/^\/\/#.*$/gm, "")).not.toMatch(/(^|[^\w$])#[A-Za-z_$][\w$]*/);
+}
+
+describe("runtime polyfills library smoke", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  test.skipIf(!hasPackage("immer"))(
+    "immer bundles to ES5 and runs Map/Set/Array.at through graph runtime polyfills",
+    async () => {
+      const fixture = await createFixture({
+        "index.ts": `
+          import { enableMapSet, produce } from "immer";
+
+          enableMapSet();
+          const base = {
+            users: new Map([["ada", { count: 1 }]]),
+            tags: new Set(["draft"]),
+          };
+          const next = produce(base, (draft) => {
+            draft.users.get("ada").count += 1;
+            draft.tags.add("published");
+          });
+          const last = Array.from(next.tags).at(-1);
+          console.log("immer", next.users.get("ada")?.count, last);
+        `,
+      });
+      cleanup = fixture.cleanup;
+      await linkNodeModules(fixture.dir, ["immer"]);
+
+      const outFile = join(fixture.dir, "out.cjs");
+      const bundle = await runZtsInDir(
+        fixture.dir,
+        ["--bundle", join(fixture.dir, "index.ts"), "-o", outFile, ...OLD_RUNTIME_ARGS],
+        { bin: "js" },
+      );
+      expect(bundle.exitCode).toBe(0);
+
+      const js = await readFile(outFile, "utf-8");
+      expect(js).toContain("es.map");
+      expect(js).toContain("es.set");
+      expect(js).toContain("es.array.at");
+      expectNoRawDownlevelSyntax(js);
+
+      const runner = join(fixture.dir, "run-without-native-collections.cjs");
+      await writeFile(
+        runner,
+        `
+          globalThis.Map = undefined;
+          globalThis.Set = undefined;
+          Array.prototype.at = undefined;
+          require(${JSON.stringify(outFile)});
+        `,
+      );
+      const run = await runNode(runner);
+      expect(run.stdout).toBe("immer 2 published");
+    },
+  );
+
+  test.skipIf(!hasPackage("rxjs"))(
+    "rxjs bundles to ES5 and runs Promise/Map/Set/replaceAll through graph runtime polyfills",
+    async () => {
+      const fixture = await createFixture({
+        "index.ts": `
+          import { firstValueFrom, of } from "rxjs";
+          import { distinct, groupBy, map, mergeMap, reduce } from "rxjs/operators";
+
+          firstValueFrom(
+            of("a", "b", "a").pipe(
+              distinct(),
+              groupBy((value) => value.length),
+              mergeMap((group$) => group$.pipe(reduce((acc, value) => acc + value, ""))),
+              map((value) => value.replaceAll("a", "A")),
+            ),
+          ).then((value) => console.log("rxjs", value));
+        `,
+      });
+      cleanup = fixture.cleanup;
+      await linkNodeModules(fixture.dir, ["rxjs"]);
+
+      const outFile = join(fixture.dir, "out.cjs");
+      const bundle = await runZtsInDir(
+        fixture.dir,
+        ["--bundle", join(fixture.dir, "index.ts"), "-o", outFile, ...OLD_RUNTIME_ARGS],
+        { bin: "js" },
+      );
+      expect(bundle.exitCode).toBe(0);
+
+      const js = await readFile(outFile, "utf-8");
+      expect(js).toContain("es.map");
+      expect(js).toContain("es.set");
+      expect(js).toContain("es.promise");
+      expect(js).toContain("es.string.replace-all");
+      expectNoRawDownlevelSyntax(js);
+
+      const runner = join(fixture.dir, "run-without-native-runtime.cjs");
+      await writeFile(
+        runner,
+        `
+          globalThis.Map = undefined;
+          globalThis.Set = undefined;
+          globalThis.Promise = undefined;
+          String.prototype.replaceAll = undefined;
+          require(${JSON.stringify(outFile)});
+        `,
+      );
+      const run = await runNode(runner);
+      expect(run.stdout).toBe("rxjs Ab");
+    },
+  );
+
+  test("multi-module bundle runs runtime prelude before dependency top-level code", async () => {
+    const fixture = await createFixture({
+      "entry.ts": `
+        import { value } from "./dep-c";
+        console.log("multi-top-level", value);
+      `,
+      "dep-a.ts": `
+        export const a = Object.values({ label: "value" })[0];
+        export const b = Math.trunc(2.9);
+      `,
+      "dep-b.ts": `
+        export const c = "7".padStart(2, "0");
+        export const d = [1, 2, 3].findLast((value) => value < 3);
+      `,
+      "dep-c.ts": `
+        import { a, b } from "./dep-a";
+        import { c, d } from "./dep-b";
+        const key = {};
+        const weak = new WeakMap();
+        weak.set(key, "weak");
+        export const value = [a, b, c, d, weak.get(key)].join("|");
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const outFile = join(fixture.dir, "out.cjs");
+    const bundle = await runZtsInDir(
+      fixture.dir,
+      ["--bundle", join(fixture.dir, "entry.ts"), "-o", outFile, ...OLD_RUNTIME_ARGS],
+      { bin: "js" },
+    );
+    expect(bundle.exitCode).toBe(0);
+
+    const js = await readFile(outFile, "utf-8");
+    expect(js).toContain("es.object.values");
+    expect(js).toContain("es.math.trunc");
+    expect(js).toContain("es.string.pad-start");
+    expect(js).toContain("es.array.find-last");
+    expect(js).toContain("es.weak-map");
+
+    const runner = join(fixture.dir, "run-multi-module-top-level.cjs");
+    await writeFile(
+      runner,
+      `
+        Object.values = undefined;
+        Math.trunc = undefined;
+        String.prototype.padStart = undefined;
+        Array.prototype.findLast = undefined;
+        globalThis.WeakMap = undefined;
+        require(${JSON.stringify(outFile)});
+      `,
+    );
+    const run = await runNode(runner);
+    expect(run.stdout).toBe("multi-top-level value|2|07|2|weak");
+  });
+
+  test("splitting keeps runtime prelude before on-demand chunks", async () => {
+    const fixture = await createFixture({
+      "package.json": '{"type":"module"}',
+      "main.ts": `
+        import("./lazy").then((mod) => {
+          console.log("split", mod.value());
+        });
+      `,
+      "lazy.ts": `
+        export function value() {
+          return "x-x".replaceAll("x", "y");
+        }
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const outDir = join(fixture.dir, "dist");
+    const bundle = await runZtsInDir(
+      fixture.dir,
+      [
+        "--bundle",
+        join(fixture.dir, "main.ts"),
+        "--outdir",
+        outDir,
+        "--format=esm",
+        "--platform=node",
+        "--target=es5",
+        "--splitting",
+        "--runtime-polyfills=auto",
+        "--runtime-target=ios_saf 12",
+      ],
+      { bin: "js" },
+    );
+    expect(bundle.exitCode).toBe(0);
+
+    const main = await readFile(join(outDir, "main.js"), "utf-8");
+    expect(main).toContain("es.string.replace-all");
+
+    const runner = join(fixture.dir, "run-split.mjs");
+    await writeFile(
+      runner,
+      `
+        String.prototype.replaceAll = undefined;
+        await import(${JSON.stringify(`./dist/main.js`)});
+      `,
+    );
+    const run = await runNode(runner);
+    expect(run.stdout).toBe("split y-y");
+  });
+
+  test("multi-entry splitting imports shared runtime prelude call symbols", async () => {
+    const fixture = await createFixture({
+      "package.json": '{"type":"module"}',
+      "entry-a.ts": `
+        export const done = import("./lazy-a")
+          .then((mod) => mod.value())
+          .then((value) => console.log("entry-a", value));
+      `,
+      "entry-b.ts": `
+        console.log("entry-b", "ok");
+      `,
+      "lazy-a.ts": `
+        export function value() {
+          return Promise.resolve(["m", "n"].at(-1)).then((last) =>
+            Object.hasOwn({ n: 1 }, last) ? last : "missing"
+          );
+        }
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const outDir = join(fixture.dir, "dist");
+    const bundle = await runZtsInDir(
+      fixture.dir,
+      [
+        "--bundle",
+        join(fixture.dir, "entry-a.ts"),
+        join(fixture.dir, "entry-b.ts"),
+        "--outdir",
+        outDir,
+        "--format=esm",
+        "--platform=node",
+        "--target=es5",
+        "--splitting",
+        "--runtime-polyfills=auto",
+        "--runtime-target=safari 5",
+      ],
+      { bin: "js" },
+    );
+    expect(bundle.exitCode).toBe(0);
+
+    const entryA = await readFile(join(outDir, "entry-a.js"), "utf-8");
+    const entryB = await readFile(join(outDir, "entry-b.js"), "utf-8");
+    expect(entryA).toContain("require_es_promise");
+    expect(entryA).toContain("require_es_array_at");
+    expect(entryA).toContain("require_es_object_has_own");
+    expect(entryB).toContain("require_es_promise");
+    expect(entryB).toContain("require_es_array_at");
+    expect(entryB).toContain("require_es_object_has_own");
+
+    const runner = join(fixture.dir, "run-multi-entry-split.mjs");
+    await writeFile(
+      runner,
+      `
+        Array.prototype.at = undefined;
+        Object.hasOwn = undefined;
+        globalThis.Promise = undefined;
+        await import(${JSON.stringify(`./dist/entry-b.js`)});
+        const entryA = await import(${JSON.stringify(`./dist/entry-a.js`)});
+        await entryA.done;
+      `,
+    );
+    const run = await runNode(runner);
+    expect(run.stdout).toBe("entry-b ok\nentry-a n");
+  });
+});

--- a/tests/integration/tests/runtime-polyfills-library-smoke.test.ts
+++ b/tests/integration/tests/runtime-polyfills-library-smoke.test.ts
@@ -277,15 +277,6 @@ describe("runtime polyfills library smoke", () => {
     );
     expect(bundle.exitCode).toBe(0);
 
-    const entryA = await readFile(join(outDir, "entry-a.js"), "utf-8");
-    const entryB = await readFile(join(outDir, "entry-b.js"), "utf-8");
-    expect(entryA).toContain("require_es_promise");
-    expect(entryA).toContain("require_es_array_at");
-    expect(entryA).toContain("require_es_object_has_own");
-    expect(entryB).toContain("require_es_promise");
-    expect(entryB).toContain("require_es_array_at");
-    expect(entryB).toContain("require_es_object_has_own");
-
     const runner = join(fixture.dir, "run-multi-entry-split.mjs");
     await writeFile(
       runner,


### PR DESCRIPTION
## Summary

Closes #2518.

`runtimePolyfills: "auto" | "usage"` 감지를 JS wrapper의 Babel parser pre-scan에서 제거하고, 실제 ZTS bundler graph 기준 usage collector로 옮겼습니다.

JS wrapper는 이제 `core-js-compat`로 target 기준 후보 core-js module과 resolved absolute path만 계산해서 NAPI DTO로 넘깁니다. 실제 사용 여부는 native bundler가 resolve/load/package exports/plugin transform/parse/semantic 이후의 module graph에서 AST와 semantic metadata를 읽어 결정합니다. `entry` 모드는 기존처럼 target-wide 필요 module을 계산해 graph prelude root로 주입합니다.

## 구현 내용

- JS wrapper의 `@babel/parser` 기반 runtime usage pre-scan 제거
  - `auto`/`usage`에서 source string을 JS에서 훑지 않습니다.
  - `@babel/parser` optional dependency를 제거했습니다.
  - wrapper는 `core-js-compat` 결과 중 native collector가 모델링한 후보와 resolved path만 NAPI DTO로 전달합니다.
  - `include`는 forced candidate/import, `exclude`는 최종 제거로 유지합니다.

- native runtime polyfill plan/collector 추가 및 core-js 후보 확장
  - 새 `src/bundler/runtime_polyfills.zig`에서 `Plan`, `FeatureSet`, `Candidate`, `ResolvedModule`을 관리합니다.
  - 초기 v1 7개 제한을 풀고, 정적 AST 이름으로 감지 가능한 넓은 ES/Web core-js API를 후보로 확장했습니다.
  - 감지 범위 예시:
    - collections: `Map`, `Set`, `WeakMap`, `WeakSet`, Set methods, Map/WeakMap get-or-insert 계열
    - promises/errors: `Promise`, `Promise.any/allSettled/try/withResolvers`, `AggregateError`, `SuppressedError`
    - globals/web: `structuredClone`, `URL`, `URLSearchParams`, `DOMException`, `queueMicrotask`, `atob`, `btoa`, `globalThis`, timers/immediate
    - static built-ins: `Object.*`, `Array.*`, `String.*`, `Number.*`, `Math.*`, `Reflect.*`, `JSON.*`, `RegExp.escape`, `Symbol.*`
    - prototype/method built-ins: Array/String/TypedArray/Iterator/Set/URLSearchParams/DataView/ArrayBuffer method names that core-js exposes
    - typed arrays: typed array constructors, typed array static/prototype methods, Uint8Array base64/hex helpers
  - local binding/import shadowing이 있으면 global usage로 보지 않습니다.
  - `globalThis.Map`, `globalThis.Object.hasOwn` 같은 explicit globalThis 접근은 감지합니다.
  - dynamic computed access는 감지하지 않습니다. 이 케이스는 `include` 또는 `entry`로 보완해야 합니다.
  - TS type-only reference는 runtime usage로 보지 않습니다.

- 확장 가능한 native feature set으로 전환
  - 기존 native `Feature` enum + `u32` bitset은 후보가 늘면 바로 한계가 생깁니다.
  - NAPI는 feature string을 그대로 전달하고, native collector는 fixed-capacity feature-key set으로 usage를 집계하게 바꿨습니다.
  - core-js-compat이 반환한 module 중 native collector가 모델링한 후보만 통과시키므로 compat data의 constructor/internal 세부 모듈이 섞여도 invalid feature로 실패하지 않습니다.

- graph 내부 runtime prelude injection
  - graph discovery 이후 module별 usage를 집계하고 필요한 core-js absolute imports만 runtime root로 추가합니다.
  - runtime polyfill root도 graph에 들어가므로 tree-shaking으로 제거되지 않습니다.
  - 실행 순서는 다음 순서로 맞췄습니다.
    1. manual `polyfills` / inject roots
    2. runtime polyfill prelude roots
    3. 기존 `runBeforeMain`
    4. user graph module evaluation / user entry
  - single-file output과 code splitting output이 같은 실행 순서를 갖도록 emitter를 보정했습니다.

- observability 추가
  - `src/profile.zig`에 graph runtime polyfill sub-phase를 추가했습니다.
    - `graph.runtime.polyfills`
    - `graph.runtime.polyfills.collect`
    - `graph.runtime.polyfills.aggregate`
    - `graph.runtime.polyfills.inject`
  - `src/debug_log.zig`에 `runtime_polyfills` 카테고리를 추가했습니다.
  - `ZTS_DEBUG=runtime_polyfills`에서 다음 결정을 key=value 형태로 출력합니다.
    - detected usage
    - included / excluded candidate
    - final prelude module
  - 비활성 상태에서는 기존 debug log 패턴처럼 enabled branch 밖 formatting/allocation 비용이 없도록 했습니다.

## 발견한 버그 및 루트 원인 수정

### 1. ES5 번들에서 optional chaining temp 선언이 DCE로 제거되는 버그

이번 smoke를 Immer로 넓히면서 별도 runtime polyfill 문제가 아니라 downlevel/codegen correctness 버그를 발견했습니다.

증상:

```js
rootScope.mapSetPlugin_?.fixSetContents(state);
const { patchPlugin_ } = rootScope;
```

위와 같은 nested function 패턴을 ES5 bundle로 내리면 optional chaining transform이 만든 temp assignment는 남는데, hoisted temp declaration인 `var _g;`가 제거되어 strict-mode wrapper에서 `_g is not defined`가 발생했습니다.

루트 원인:

- transformer가 optional chaining lowering 중 synthetic temp declaration(`var _a;`)과 assignment reference를 만듭니다.
- bundler emit 경로의 semantic 기반 dead-store 제거는 원본 semantic refcount를 사용합니다.
- synthetic assignment reference는 원본 semantic refcount에 없어서 no-init temp declaration이 unused로 오판될 수 있었습니다.
- 결과적으로 valid downlevel output이 strict mode에서 ReferenceError를 냈습니다.

수정:

- transformer-generated synthetic no-init temp declaration은 semantic dead-store 제거 대상에서 제외했습니다.
- source-authored unused declaration 제거는 유지하되, string-table span을 가진 synthetic temp declaration은 보존합니다.
- 축소 회귀 테스트를 `packages/core/index.test.ts`에 추가했고, Immer smoke로 실제 library 경로도 검증했습니다.

### 2. code splitting에서 runtime prelude가 정의만 되고 실행되지 않는 버그

splitting/on-demand chunk 테스트를 추가하면서 runtime prelude ordering 버그도 발견했습니다.

증상:

- entry chunk에는 `es.string.replace-all` core-js wrapper 정의가 포함됩니다.
- 하지만 user entry 실행 전에 `require_es_string_replace_all()` 호출이 없었습니다.
- lazy chunk가 먼저 `replaceAll`을 사용하면 polyfill이 적용되지 않아 `replaceAll is not a function`으로 실패했습니다.

루트 원인:

- single-file emitter에는 entry 직전 `runBeforeMain`/prelude 호출 지점이 있었지만, code splitting emitter에는 동일한 entry execution hook이 없었습니다.
- dynamic import target도 chunk model상 entry_point로 표현되므로, 단순 `is_entry` 판정만 쓰면 lazy chunk에도 prelude 호출을 넣게 됩니다.

수정:

- splitting emitter에 single-file과 같은 runtime prelude 호출을 추가했습니다.
- 단, `ChunkKind.entry_point.is_dynamic == true`인 dynamic entry chunk에는 호출하지 않도록 제한했습니다.
- integration smoke에서 on-demand chunk 실행 전 runtime prelude가 먼저 실행되는지 검증합니다.

### 3. dependency/package exports top-level 코드가 runtime prelude보다 먼저 실행되는 버그

`replaceAll` 외 다른 polyfill API 테스트를 추가하면서 더 근본적인 순서 버그를 발견했습니다.

증상:

```js
const cloned = structuredClone({ label: "clone" });
export const value = [
  ["a", "b"].at(-1),
  Object.hasOwn({ ok: true }, "ok") ? "own" : "missing",
  cloned.label,
].join("|");
```

package exports로 resolve된 dependency 모듈에 이런 top-level runtime API 사용이 있으면, bundle에는 `web.structured-clone`, `es.array.at`, `es.object.has-own` 후보가 들어가지만 실제 호출이 dependency body 뒤에 배치되어 `structuredClone is not a function`으로 실패했습니다.

루트 원인:

- 기존 single-file emitter는 `runBeforeMain`/runtime prelude 호출을 user entry 직전에 삽입했습니다.
- scope-hoisted dependency body는 user entry보다 먼저 평가됩니다.
- 따라서 dependency top-level runtime API는 polyfill 호출 전에 실행될 수 있었습니다.

수정:

- single-file emitter와 splitting emitter 모두 prelude 호출 위치를 `entry 직전`이 아니라 `runBeforeMain/runtime-prelude 모듈 정의가 끝난 직후, 첫 user module body 전`으로 옮겼습니다.
- `__esm` wrapped entry는 기존 RN용 body-insertion 경로가 담당하므로 top-level 중복 호출을 피했습니다.
- package exports resolved module 테스트에서 `structuredClone`, `Array.prototype.at`, `Object.hasOwn`을 네이티브 삭제 VM 환경에서 실제 실행합니다.

### 4. multi-entry splitting에서 shared runtime prelude call symbol import/export가 누락되는 버그

multi-entry splitting 회귀를 추가하면서 common chunk 경로의 symbol 연결 버그도 발견했습니다.

증상:

- 여러 user entry가 있고 runtime prelude wrapper가 common chunk로 이동하면, entry chunk는 `require_es_promise()` 같은 raw call을 출력합니다.
- 하지만 이 call symbol은 common chunk에서 export되지 않고 entry chunk에도 named import가 없어서 `ReferenceError`가 발생할 수 있었습니다.

루트 원인:

- `appendRunBeforeMainCalls`는 chunk graph의 cross-chunk import/export metadata 계산 이후 raw statement를 추가합니다.
- linker/chunk graph는 이 late-added call symbol을 몰라서 common chunk export와 entry chunk import를 만들지 못했습니다.

수정:

- user entry chunk가 다른 chunk의 runBeforeMain/runtime-prelude wrapper를 호출해야 하면 named import를 명시적으로 출력합니다.
- source chunk는 해당 wrapper call symbol을 export하도록 보강했습니다.
- imported call symbol을 occupied names에 추가해 per-chunk rename과 충돌하지 않게 했습니다.
- output metadata의 `exports`에도 runtime prelude wrapper export를 반영했습니다.
- multi-entry splitting integration에서 `Promise`, `Array.prototype.at`, `Object.hasOwn` 조합으로 실제 실행 검증합니다.

## 테스트 보강

- collector unit/regression
  - 기존 v1: `replaceAll`, `Array.prototype.at`, `Object.hasOwn`, `Map`, `Set`, `Promise`, `structuredClone`
  - 확장 built-ins: `Object.values`, `Array.findLast`, `String.padStart`, `Math.trunc`, `Reflect.ownKeys`, `Promise.any`, `Symbol.iterator`, `WeakMap`, `URL.canParse`, `Uint8Array`, TypedArray methods, Iterator helpers, `ArrayBuffer.isView`, `queueMicrotask`
  - explicit `globalThis.*`
  - shadowed/imported globals negative
  - TS type-only reference negative
  - dynamic computed access negative

- JS wrapper/NAPI DTO
  - `@babel/parser` 없이 `auto`/`usage` DTO 생성
  - `usage` alias
  - `entry` mode target-wide roots
  - `include`/`exclude`
  - missing core-js/core-js-compat error
  - `off` mode에서 core-js-compat/native collector/profile/debug 미실행
  - broad core-js 후보가 native candidate로 전달되는지 검증
  - unmodeled compat result는 candidate에서 제외
  - runtime-polyfills first-party coverage 100%

- build API/CLI integration
  - dependency 내부 usage 감지
  - package exports resolved module usage 감지 및 실행
  - expanded core-js built-ins 실행: `Object.values`, `padStart`, `Math.trunc`, `Reflect.ownKeys`, `findLast`, `WeakMap`, `Symbol`
  - plugin transform 이후 실제 graph code 기준 usage 감지
  - local shadowing/import shadowing negative
  - dynamic computed access negative
  - dynamic computed access는 `include`로 보완 가능함을 실행 검증
  - explicit globalThis positive
  - manual `polyfills` + runtime prelude + `runBeforeMain` ordering
  - compact shorthand/device target rejection
  - debug/profile observability output

- library/integration smoke
  - React Query v5 ES5 bundle + runtime polyfills
  - Immer ES5 bundle + Map/Set/Array.at runtime polyfills
  - RxJS ES5 bundle + Promise/Map/Set/replaceAll runtime polyfills
  - splitting/on-demand chunk runtime prelude ordering
  - multi-entry splitting shared runtime prelude call symbol import/export

## Validation

- `zig build test`
- `cd packages/core && zig build napi && bun run build:js`
- `cd packages/core && bun test src/runtime-polyfills.test.ts`
- `cd packages/core && bun test index.test.ts --test-name-pattern runtimePolyfills`
- `cd packages/core && bun test index.test.ts --test-name-pattern "runtimePolyfills|optional chaining temp"`
- `cd packages/core && bun test bin/zts.test.ts --test-name-pattern "runtime-polyfills|runtime-target|runtimePolyfills"`
- `cd tests/integration && bun test tests/runtime-polyfills-library-smoke.test.ts tests/react-query-v5-smoke.test.ts tests/polyfill-rbm.test.ts`
- `cd tests/integration && bun test tests/runtime-polyfills-library-smoke.test.ts --test-name-pattern "multi-module bundle runs runtime prelude before dependency top-level code"`
- `bun run test:runtime-polyfills:coverage`
- `zig fmt --check src/bundler/runtime_polyfills.zig src/bundler/graph.zig packages/core/src/napi_entry.zig src/bundler/emitter.zig src/bundler/emitter/chunks.zig src/profile.zig src/debug_log.zig`
- `bunx oxfmt --check packages/core/src/runtime-polyfills.ts packages/core/src/runtime-polyfills.test.ts packages/core/index.test.ts packages/core/bin/zts.test.ts tests/integration/tests/runtime-polyfills-library-smoke.test.ts tests/integration/tests/react-query-v5-smoke.test.ts`
- `git diff --check`
- `ZTS_DEBUG=runtime_polyfills bun packages/core/bin/zts.mjs --bundle <entry> --profile=graph --profile-level=detailed --profile-format=json`

Pre-push hook도 통과했습니다. hook 중 `tests/integration/tests/bundle-dynamic-import.test.ts`의 기존 unused import warning 3개가 표시되지만 error는 아니며 이번 PR의 변경 파일은 아닙니다.

