### PR TITLE
test(snapshot): codegen runtime contract 의 핵심 value 검증 추가 (#2462)

### DIFF
--- a/src/transformer/plugins/rn_codegen/snapshot_test.zig
+++ b/src/transformer/plugins/rn_codegen/snapshot_test.zig
@@ -1,10 +1,15 @@
 //! RN 버전별 spec snapshot 에 대해 ZTS rn_codegen_plugin 의 출력이
 //! `@react-native/codegen` reference 와 **의미적으로** 동등한지 검증.
 //!
-//! 비교 단위: view config 객체에 등록되는 키 set (= RN runtime contract).
+//! 비교 단위: view config 객체에 등록되는 키 set (= RN runtime contract) +
+//! runtime contract 에 영향을 주는 핵심 value:
 //!   - top-level: uiViewClassName, validAttributes, directEventTypes, bubblingEventTypes
 //!   - validAttributes 의 attribute 이름 set
 //!   - directEventTypes / bubblingEventTypes 의 event name set
+//!   - **uiViewClassName value** (RN native 측의 등록 클래스 이름과 1:1 매칭 필수 —
+//!     `paperComponentName` 옵션이 있으면 그 값이 와야 함)
+//!   - **`export const Commands` 존재 여부** (codegenNativeCommands → dispatchCommand
+//!     변환이 누락되면 imperative API 가 깨짐)
 //!
 //! cosmetic 차이 (quote style / prop order / trailing comma / value formatting / Object.assign +
 //! ConditionallyIgnoredEventHandlers wrapper) 는 무시 — 양쪽이 같은 attribute / event 를
@@ -395,6 +400,23 @@ fn compareKeySets(
     return error.TestKeySetMismatch;
 }
 
+/// `uiViewClassName: 'X'` 의 X 추출. quote 종류 무시. 없으면 null.
+fn extractUiViewClassName(obj_body: []const u8) ?[]const u8 {
+    const v = extractSection(obj_body, "uiViewClassName") orelse return null;
+    const trimmed = std.mem.trim(u8, v, " \t\n\r");
+    if (trimmed.len < 2) return null;
+    const q = trimmed[0];
+    if (q != '\'' and q != '"') return null;
+    if (trimmed[trimmed.len - 1] != q) return null;
+    return trimmed[1 .. trimmed.len - 1];
+}
+
+/// `export const Commands` 가 source 어디든 등장하는지 — codegenNativeCommands 가
+/// dispatchCommand 래퍼로 변환됐는지 검증. value 자체는 비교 안 함 (cosmetic 차이 큼).
+fn hasCommandsExport(src: []const u8) bool {
+    return std.mem.indexOf(u8, src, "export const Commands") != null;
+}
+
 fn compareCase(suite: []const u8, fixture_name: []const u8, golden_name: []const u8) !void {
     const alloc = std.testing.allocator;
 
@@ -428,6 +450,34 @@ fn compareCase(suite: []const u8, fixture_name: []const u8, golden_name: []const
     try compareSectionKeySets(alloc, "validAttributes", ref_obj, zts_obj);
     try compareSectionKeySets(alloc, "directEventTypes", ref_obj, zts_obj);
     try compareSectionKeySets(alloc, "bubblingEventTypes", ref_obj, zts_obj);
+
+    // uiViewClassName value 일치 — `paperComponentName` 옵션이 있는 spec 에서 잘못된
+    // 클래스 이름을 emit 하면 RN native 측에서 컴포넌트 not found.
+    const ref_cls = extractUiViewClassName(ref_obj);
+    const zts_cls = extractUiViewClassName(zts_obj);
+    if (ref_cls == null or zts_cls == null or !std.mem.eql(u8, ref_cls.?, zts_cls.?)) {
+        std.debug.print(
+            "[{s}] uiViewClassName mismatch — ref={s} zts={s}\n",
+            .{ fixture_name, ref_cls orelse "<missing>", zts_cls orelse "<missing>" },
+        );
+        return error.TestUiViewClassNameMismatch;
+    }
+
+    // `codegenNativeCommands` 호출이 fixture 에 있으면 reference 가 `export const Commands`
+    // 를 emit. ZTS 가 같은 emit 을 안 하면 imperative `Commands.X(ref, ...)` 호출이 깨짐.
+    const ref_has_cmds = hasCommandsExport(golden);
+    const zts_has_cmds = hasCommandsExport(zts_out);
+    if (ref_has_cmds != zts_has_cmds) {
+        std.debug.print(
+            "[{s}] Commands export presence mismatch — ref={s} zts={s}\n",
+            .{
+                fixture_name,
+                if (ref_has_cmds) "present" else "missing",
+                if (zts_has_cmds) "present" else "missing",
+            },
+        );
+        return error.TestCommandsExportMismatch;
+    }
 }
 
 fn compareSectionKeySets(


### PR DESCRIPTION
## 배경

기존 `snapshot_test.zig` 는 view config 의 **key set 만** 비교. 이 정책으로 다음 두 차이를 silent 통과 — RN runtime 에서는 critical:

### 갭 1: `uiViewClassName` value mismatch

```js
// fixture (RN 0.78 RN core spec)
export default codegenNativeComponent<NativeProps>('ActivityIndicatorView', {
  paperComponentName: 'RCTActivityIndicatorView',  // ← Paper architecture 의 native 클래스 이름
});
```

| | uiViewClassName |
| --- | --- |
| reference (`@react-native/codegen`) | `'RCTActivityIndicatorView'` |
| ZTS (현재) | `'ActivityIndicatorView'` |

→ RN native 가 `RCT*` 로 등록한 view 를 못 찾음. 기존 test 는 `uiViewClassName` 키 자체는 양쪽에 있어 통과.

### 갭 2: `export const Commands` 누락

```js
// fixture
export const Commands = codegenNativeCommands<NativeCommands>({
  supportedCommands: ['highlightTraceUpdates', 'highlightElements', 'clearElementsHighlights'],
});
```

reference 는 `dispatchCommand` 래퍼로 변환:
```js
export const Commands = {
  highlightTraceUpdates(ref, updates) { dispatchCommand(ref, "highlightTraceUpdates", [updates]); },
  ...
};
```

ZTS 출력엔 Commands export 자체가 **없음** → imperative `Commands.X(ref, ...)` 호출 전부 깨짐. 기존 test 는 `__INTERNAL_VIEW_CONFIG` 만 봐서 silent.

## 변경

`compareCase` 에 두 검증 추가:

1. **`extractUiViewClassName`** — `extractSection` 으로 `uiViewClassName` value 본문 추출 → quote 제거 → 양쪽 정확 일치 확인. 한쪽 missing 또는 mismatch 면 `TestUiViewClassNameMismatch`.
2. **`hasCommandsExport`** — source 에 `export const Commands` substring 존재 여부 일치 확인. value 자체는 cosmetic 차이 커서 비교 안 함 (parameter list / dispatchCommand vs invariant 등 emit 형태 다양). 한쪽 only 면 `TestCommandsExportMismatch`.

문서 docstring 도 갱신 — runtime contract value 까지 검증 포함 명시.

## 본 PR 시점 통과 / 회귀

main 의 rn-0.85 fixture 들 (react-native-screens 4 spec) 은 두 패턴 어느 것도 안 씀:
- `paperComponentName` 옵션 없음 (첫 인자가 final 'RNS*' 이름)
- `codegenNativeCommands` 호출 없음

→ 본 PR 단독 머지 시 main 의 rn-0.85 4 test 모두 **통과 유지**. 회귀 0.

`zig build test --summary all` → 4631/4631 pass.

## 후속 (epic 흐름)

이 PR 머지 후 #2520 (rebase) 가 ZTS plugin 의 두 미구현을 명시적으로 expose:

- rn-0.78/ActivityIndicatorViewNativeComponent → `TestUiViewClassNameMismatch` fail
- rn-0.78/RCTSafeAreaViewNativeComponent → `TestUiViewClassNameMismatch` fail
- rn-0.78/DebuggingOverlayNativeComponent → `TestCommandsExportMismatch` fail

→ 이후 ZTS plugin 패치 PR 들이 두 기능 구현 → #2520 의 fixture 가 다시 4634 pass.

이게 #2462 매트릭스 확장의 본 가치 — RN 버전별 spec 패턴 차이가 아니라 **fixture diversity 부족이 가린 ZTS plugin 미구현** 을 드러내는 것.

Refs #2462

## Test plan
- [x] `zig build test --summary all` → 4631/4631 pass (rn-0.85 4 test 강화 검증 통과)
- [x] `grep -l "codegenNativeCommands\\|paperComponentName" tests/codegen-snapshots/rn-0.85/fixtures/*.ts` → 빈 결과 (rn-0.85 가 두 패턴 안 씀 확인)
- [x] `grep -l "export const Commands" tests/codegen-snapshots/rn-0.85/golden/*.golden.js` → 빈 결과 (golden 도 Commands export 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)