### PR TITLE
feat(codegen): paperComponentName 옵션 처리 — uiViewClassName/nativeComponentName paper 이름 우선 (#2462)

### DIFF
--- a/src/transformer/plugins/rn_codegen/schema.zig
+++ b/src/transformer/plugins/rn_codegen/schema.zig
@@ -214,6 +214,12 @@ pub const ComponentShape = struct {
     events: []const EventTypeShape = &.{},
     props: []const NamedShape(PropTypeAnnotation) = &.{},
     commands: []const NamedShape(CommandTypeAnnotation) = &.{},
+
+    /// RN runtime 이 등록한 native 클래스 이름 — Paper 호환을 위해 paperComponentName
+    /// 우선. emitter / file wrapper 양쪽이 같은 lookup 을 하지 않게 한 곳에 모음.
+    pub fn nativeName(self: ComponentShape) []const u8 {
+        return self.paper_component_name orelse self.name;
+    }
 };
 
 /// 한 spec 파일에 들어있는 모든 ComponentShape (보통 1 개, 가끔 여러 개).

--- a/src/transformer/plugins/rn_codegen/schema_builder.zig
+++ b/src/transformer/plugins/rn_codegen/schema_builder.zig
@@ -70,10 +70,13 @@ const VisitedSet = std.AutoHashMapUnmanaged(NodeIndex, void);
 ///
 /// `component_name` 은 `codegenNativeComponent('Name')` 의 `'Name'` 인자 — 빌더가
 /// 외부에서 받음 (declaration 자체엔 이름 없음).
+/// `paper_component_name` 은 `codegenNativeComponent('Name', { paperComponentName: 'X' })`
+/// 의 옵션. 없으면 null. RN runtime 의 `uiViewClassName` 은 이 값을 우선 (#2462).
 pub fn build(
     ast: *const Ast,
     type_index: *const TypeIndex,
     component_name: []const u8,
+    paper_component_name: ?[]const u8,
     native_props_idx: NodeIndex,
     alloc: std.mem.Allocator,
 ) Error!schema.ComponentShape {
@@ -99,6 +102,7 @@ pub fn build(
 
     return .{
         .name = component_name,
+        .paper_component_name = paper_component_name,
         .props = try props_buf.toOwnedSlice(alloc),
         .events = try events_buf.toOwnedSlice(alloc),
     };

--- a/src/transformer/plugins/rn_codegen/schema_builder_test.zig
+++ b/src/transformer/plugins/rn_codegen/schema_builder_test.zig
@@ -67,7 +67,7 @@ fn parseAndIndex(alloc: std.mem.Allocator, source: []const u8, mode: ParseMode) 
 /// `name` 의 declaration NodeIndex 로부터 ComponentShape 빌드. caller 가 프리 free.
 fn buildShape(p: *Parsed, type_name: []const u8, component_name: []const u8) !schema.ComponentShape {
     const decl_idx = p.type_index.get(type_name) orelse return error.TypeNotIndexed;
-    return schema_builder.build(&p.parser.ast, &p.type_index, component_name, decl_idx, p.alloc);
+    return schema_builder.build(&p.parser.ast, &p.type_index, component_name, null, decl_idx, p.alloc);
 }
 
 fn freeShape(alloc: std.mem.Allocator, shape: schema.ComponentShape) void {
@@ -277,7 +277,7 @@ test "schema_builder: invalid declaration → InvalidNativePropsBody" {
     try std.testing.expect(list.len > 0);
     const stmt: NodeIndex = @enumFromInt(p.parser.ast.extra_data.items[list.start]);
 
-    const result = schema_builder.build(&p.parser.ast, &p.type_index, "X", stmt, std.testing.allocator);
+    const result = schema_builder.build(&p.parser.ast, &p.type_index, "X", null, stmt, std.testing.allocator);
     try std.testing.expectError(error.InvalidNativePropsBody, result);
 }
 

--- a/src/transformer/plugins/rn_codegen/view_config_emitter.zig
+++ b/src/transformer/plugins/rn_codegen/view_config_emitter.zig
@@ -57,8 +57,11 @@ pub fn emit(shape: schema.ComponentShape, alloc: std.mem.Allocator) ![]u8 {
 
     try buf.appendSlice(alloc, "const __INTERNAL_VIEW_CONFIG = {\n");
 
+    // RN runtime 의 `uiViewClassName` 은 Paper(legacy) 호환을 위해 `paperComponentName`
+    // 우선 사용 — `shape.nativeName()`. RN native 측이 RCT-prefix 형태로 등록한 클래스를
+    // 못 찾으면 컴포넌트 렌더링 자체가 깨짐 (#2462).
     try buf.appendSlice(alloc, "  uiViewClassName: '");
-    try buf.appendSlice(alloc, shape.name);
+    try buf.appendSlice(alloc, shape.nativeName());
     try buf.appendSlice(alloc, "',\n");
 
     try emitValidAttributes(&buf, shape, alloc);

--- a/src/transformer/plugins/rn_codegen_plugin.zig
+++ b/src/transformer/plugins/rn_codegen_plugin.zig
@@ -47,6 +47,7 @@ const codegen = @import("rn_codegen/mod.zig");
 const type_index_mod = codegen.type_index;
 const schema_builder = codegen.schema_builder;
 const view_config_emitter = codegen.view_config_emitter;
+const stmt_info = @import("../../bundler/stmt_info.zig");
 
 const CODEGEN_MARKER = "codegenNativeComponent";
 
@@ -93,16 +94,25 @@ fn onTransform(
     defer type_index.deinit(alloc);
 
     const decl_idx = type_index.get(props_type_name) orelse return null;
-    const component_name = findComponentName(&parser.ast, program) orelse return null;
+    const call_idx = findCodegenCall(&parser.ast, program) orelse return null;
+    const component_name = extractCallArg0String(&parser.ast, call_idx) orelse return null;
+    const paper_component_name = extractPaperComponentName(&parser.ast, call_idx);
 
-    const shape = schema_builder.build(&parser.ast, &type_index, component_name, decl_idx, alloc) catch return null;
+    const shape = schema_builder.build(
+        &parser.ast,
+        &type_index,
+        component_name,
+        paper_component_name,
+        decl_idx,
+        alloc,
+    ) catch return null;
     defer alloc.free(shape.props);
     defer alloc.free(shape.events);
 
     const view_config = view_config_emitter.emit(shape, alloc) catch return null;
     defer alloc.free(view_config);
 
-    return assembleFileReplacement(component_name, view_config, alloc) catch return null;
+    return assembleFileReplacement(shape.nativeName(), view_config, alloc) catch return null;
 }
 
 /// `codegenNativeComponent<TYPE_NAME>` 에서 `TYPE_NAME` 추출.
@@ -126,9 +136,9 @@ fn extractTypeArg(code: []const u8) ?[]const u8 {
     return null;
 }
 
-/// program 자식 중 `export default codegenNativeComponent('Name', ...)` 패턴을 찾아
-/// 첫 string 인자 (component name) 추출. quote 는 벗긴다.
-fn findComponentName(ast: *const ast_mod.Ast, program_idx: NodeIndex) ?[]const u8 {
+/// program 자식 중 `export default codegenNativeComponent('Name', { ... })` 패턴을
+/// 찾아 그 call_expression 의 NodeIndex 반환. 첫 매칭만 — spec 파일은 보통 한 개.
+fn findCodegenCall(ast: *const ast_mod.Ast, program_idx: NodeIndex) ?NodeIndex {
     const program = ast.getNode(program_idx);
     if (program.tag != .program) return null;
 
@@ -137,8 +147,7 @@ fn findComponentName(ast: *const ast_mod.Ast, program_idx: NodeIndex) ?[]const u
     while (i < list.len) : (i += 1) {
         const stmt: NodeIndex = @enumFromInt(ast.extra_data.items[list.start + i]);
         const node = ast.getNode(stmt);
-        const call_idx = unwrapToCallExpression(ast, stmt, node) orelse continue;
-        if (extractCallArg0String(ast, call_idx)) |name| return name;
+        if (unwrapToCallExpression(ast, stmt, node)) |call_idx| return call_idx;
     }
     return null;
 }
@@ -182,10 +191,44 @@ fn extractCallArg0String(ast: *const ast_mod.Ast, call_idx: NodeIndex) ?[]const 
     return stripQuotes(raw);
 }
 
+/// `codegenNativeComponent('Name', { paperComponentName: 'X', ... })` 의 두 번째 인자
+/// (options object) 안에서 `paperComponentName` string property 추출. 옵션이 없거나
+/// paperComponentName 키가 없으면 null. RN spec 의 Paper(legacy) 호환용 — RN runtime 의
+/// `uiViewClassName` 은 이 값을 우선 (없으면 첫 인자 사용).
+///
+/// 인식 한계: `{ paperComponentName: 'X' }` 와 `{ "paperComponentName": 'X' }` 만.
+/// computed key (`{ [k]: 'X' }`), shorthand, escape-bearing string 은 모두 reject —
+/// RN spec 에서 등장 가능성 0.
+fn extractPaperComponentName(ast: *const ast_mod.Ast, call_idx: NodeIndex) ?[]const u8 {
+    const node = ast.getNode(call_idx);
+    const e = node.data.extra;
+    if (e + 2 >= ast.extra_data.items.len) return null;
+    const args_start = ast.extra_data.items[e + 1];
+    const args_len = ast.extra_data.items[e + 2];
+    if (args_len < 2) return null;
+    const arg1_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start + 1]);
+    const arg1 = ast.getNode(arg1_idx);
+    if (arg1.tag != .object_expression) return null;
+
+    const props = arg1.data.list;
+    var i: u32 = 0;
+    while (i < props.len) : (i += 1) {
+        const prop_idx: NodeIndex = @enumFromInt(ast.extra_data.items[props.start + i]);
+        const prop = ast.getNode(prop_idx);
+        if (prop.tag != .object_property) continue;
+        const key_name = stmt_info.plainObjectKeyName(ast, prop.data.binary.left) orelse continue;
+        if (!std.mem.eql(u8, key_name, "paperComponentName")) continue;
+        return stmt_info.plainStringLiteralValue(ast, ast_mod.Ast.objectPropertyValue(prop));
+    }
+    return null;
+}
+
 /// 최종 파일 교체 문자열 조립. RN 런타임이 기대하는 정확한 형태:
 /// `@react-native/codegen` 의 `GenerateViewConfigJs.generate()` 의 fileTemplate 와 동일.
+/// `native_name` 은 caller 가 `shape.nativeName()` 으로 결정 (paper 우선) — 본 함수는
+/// 순수 문자열 어셈블리만 담당.
 fn assembleFileReplacement(
-    component_name: []const u8,
+    native_name: []const u8,
     view_config_js: []const u8,
     alloc: std.mem.Allocator,
 ) ![]u8 {
@@ -195,6 +238,6 @@ fn assembleFileReplacement(
             "let nativeComponentName = '{s}';\n" ++
             "{s}\n" ++
             "export default NativeComponentRegistry.get(nativeComponentName, () => __INTERNAL_VIEW_CONFIG);\n",
-        .{ component_name, view_config_js },
+        .{ native_name, view_config_js },
     );
 }

--- a/src/transformer/plugins/rn_codegen_plugin_test.zig
+++ b/src/transformer/plugins/rn_codegen_plugin_test.zig
@@ -139,3 +139,36 @@ test "codegen_plugin: function-typed prop → event in output" {
     try expectContains(out, "topChange:");
     try expectContains(out, "phasedRegistrationNames");
 }
+
+test "codegen_plugin: paperComponentName option → uiViewClassName / nativeComponentName 둘 다 paper 이름" {
+    const code =
+        \\type NativeProps = { color: string };
+        \\export default codegenNativeComponent<NativeProps>('SafeAreaView', {
+        \\  paperComponentName: 'RCTSafeAreaView',
+        \\  interfaceOnly: true,
+        \\});
+    ;
+    const out_opt = try callTransform(std.testing.allocator, code, "/path/RCTSafeAreaViewNativeComponent.ts");
+    try std.testing.expect(out_opt != null);
+    const out = out_opt.?;
+    defer std.testing.allocator.free(out);
+
+    try expectContains(out, "let nativeComponentName = 'RCTSafeAreaView'");
+    try expectContains(out, "uiViewClassName: 'RCTSafeAreaView'");
+    // 첫 인자 'SafeAreaView' 는 자취 없어야 — full word 검사로 substring 함정 회피.
+    try std.testing.expect(std.mem.indexOf(u8, out, "'SafeAreaView'") == null);
+}
+
+test "codegen_plugin: 옵션 object 있지만 paperComponentName 키 없으면 첫 인자 그대로" {
+    const code =
+        \\type NativeProps = { color: string };
+        \\export default codegenNativeComponent<NativeProps>('Plain', { interfaceOnly: true });
+    ;
+    const out_opt = try callTransform(std.testing.allocator, code, "/path/PlainNativeComponent.ts");
+    try std.testing.expect(out_opt != null);
+    const out = out_opt.?;
+    defer std.testing.allocator.free(out);
+
+    try expectContains(out, "let nativeComponentName = 'Plain'");
+    try expectContains(out, "uiViewClassName: 'Plain'");
+}


### PR DESCRIPTION
## 배경

RN core spec 의 다수 (RCTSafeAreaView / ActivityIndicator / Modal 등) 가 `codegenNativeComponent` 호출 시 첫 인자에는 짧은 이름, `paperComponentName` 옵션에 Paper architecture 의 RCT-prefix 풀 이름을 명시:

```js
export default codegenNativeComponent<NativeProps>('SafeAreaView', {
  paperComponentName: 'RCTSafeAreaView',
  interfaceOnly: true,
});
```

RN native 측은 `'RCTSafeAreaView'` 로 컴포넌트를 등록 → ZTS 가 첫 인자 (`'SafeAreaView'`) 만 쓰면 runtime 에서 컴포넌트 not found, 렌더링 깨짐.

`@react-native/codegen` reference 는 `uiViewClassName` 과 `nativeComponentName` 양쪽에 paper 이름 우선 emit. ZTS 도 동일 contract 따라야 함.

PR #2522 (snapshot test 강화) 가 이 갭을 명시 fail (`TestUiViewClassNameMismatch`) 로 노출 — 본 PR 이 fix.

## 변경

### `rn_codegen_plugin.zig`
- `findComponentName` 분해 → 3개 작은 함수:
  - `findCodegenCall(ast, program)` → call NodeIndex
  - `extractCallArg0String(ast, call_idx)` → component name (기존 그대로)
  - `extractPaperComponentName(ast, call_idx)` → 신규
- `extractPaperComponentName` 은 alloc-free — `stmt_info.plainObjectKeyName` + `plainStringLiteralValue` 기존 헬퍼 재사용
- `assembleFileReplacement` 시그니처 narrow: `ComponentShape` 통째 → `native_name: []const u8` (caller 가 `shape.nativeName()` 결정)

### `rn_codegen/schema.zig`
- `ComponentShape.nativeName()` 메서드 — `paper_component_name orelse name` lookup 을 한 곳에 모음 (emitter / wrapper 양쪽 중복 제거)

### `rn_codegen/schema_builder.zig`
- `build` 시그니처에 `paper_component_name: ?[]const u8` 추가 → ComponentShape 의 기존 필드 채움

### `rn_codegen/view_config_emitter.zig`
- `uiViewClassName` emit 에 `shape.nativeName()` 사용

### Unit test (`rn_codegen_plugin_test.zig`)
- `paperComponentName` 옵션 → uiViewClassName / nativeComponentName 둘 다 paper 이름 + 첫 인자가 출력에 자취 없음
- 옵션 object 있어도 paperComponentName 키 없으면 첫 인자 그대로

## 인식 한계 (의도)

`{ paperComponentName: 'X' }` 와 `{ "paperComponentName": 'X' }` 만 인식. computed key (`{ [k]: 'X' }`), shorthand, escape-bearing string 은 reject — RN spec 에서 등장 가능성 0.

## 후속

- PR x: `codegenNativeCommands` → `dispatchCommand` 변환 (PR #2522 가 노출한 `TestCommandsExportMismatch` fix)
- PR #2520 rebase: rn-0.78 fixture 의 ActivityIndicator/RCTSafeAreaView 가 본 PR 로 의미적-eq 통과, DebuggingOverlay 는 commands PR 후 통과 → all green

Refs #2462

## Test plan
- [x] `zig build test --summary all` → 4633/4633 pass
- [x] 신규 unit test: paperComponentName 옵션 → uiViewClassName/nativeComponentName paper 이름 emit 확인
- [x] 신규 unit test: 옵션 object 있지만 paperComponentName 키 없으면 첫 인자 그대로
- [ ] (수동) #2520 rebase 후 rn-0.78 의 RCTSafeAreaView/ActivityIndicator snapshot test 가 `TestUiViewClassNameMismatch` 안 나오고 통과하는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)