### PR TITLE
feat(codegen): codegenNativeCommands → dispatchCommand wrapper emit (#2462)

### DIFF
--- a/src/transformer/plugins/rn_codegen/schema.zig
+++ b/src/transformer/plugins/rn_codegen/schema.zig
@@ -220,6 +220,12 @@ pub const ComponentShape = struct {
     pub fn nativeName(self: ComponentShape) []const u8 {
         return self.paper_component_name orelse self.name;
     }
+
+    /// imperative commands (`codegenNativeCommands`) 가 있는지. emitter / wrapper /
+    /// plugin 의 free 분기에서 같은 식 (`commands.len > 0`) 반복하지 않게 한 곳에 모음.
+    pub fn hasCommands(self: ComponentShape) bool {
+        return self.commands.len > 0;
+    }
 };
 
 /// 한 spec 파일에 들어있는 모든 ComponentShape (보통 1 개, 가끔 여러 개).

--- a/src/transformer/plugins/rn_codegen/schema_builder.zig
+++ b/src/transformer/plugins/rn_codegen/schema_builder.zig
@@ -72,12 +72,15 @@ const VisitedSet = std.AutoHashMapUnmanaged(NodeIndex, void);
 /// 외부에서 받음 (declaration 자체엔 이름 없음).
 /// `paper_component_name` 은 `codegenNativeComponent('Name', { paperComponentName: 'X' })`
 /// 의 옵션. 없으면 null. RN runtime 의 `uiViewClassName` 은 이 값을 우선 (#2462).
+/// `commands_decl_idx` 는 `codegenNativeCommands<NativeCommands>(...)` 의 type argument
+/// 가 가리키는 interface declaration. 없으면 null (commands 미사용 spec).
 pub fn build(
     ast: *const Ast,
     type_index: *const TypeIndex,
     component_name: []const u8,
     paper_component_name: ?[]const u8,
     native_props_idx: NodeIndex,
+    commands_decl_idx: ?NodeIndex,
     alloc: std.mem.Allocator,
 ) Error!schema.ComponentShape {
     var visited: VisitedSet = .{};
@@ -100,12 +103,166 @@ pub fn build(
     try dedupByName(schema.NamedShape(schema.PropTypeAnnotation), &props_buf, alloc);
     try dedupByName(schema.EventTypeShape, &events_buf, alloc);
 
+    const commands: []const schema.NamedShape(schema.CommandTypeAnnotation) = if (commands_decl_idx) |c|
+        try buildCommands(ast, type_index, c, alloc)
+    else
+        &.{};
+
     return .{
         .name = component_name,
         .paper_component_name = paper_component_name,
         .props = try props_buf.toOwnedSlice(alloc),
         .events = try events_buf.toOwnedSlice(alloc),
+        .commands = commands,
     };
+}
+
+/// NativeCommands interface body → commands schema. interface 의 각 property_signature
+/// (`+commandName: (ref: ElementRef<T>, ...) => void` 또는 method shorthand) 마다 이름 +
+/// 첫 인자 `ref` 를 제외한 나머지 인자 names 를 추출.
+///
+/// reference (`@react-native/codegen` `flow/components/commands.js:35` 의
+/// `value.params.slice(1)`) 와 동일 contract — 첫 인자는 항상 viewRef, codegen 은 emit
+/// 에 그 자리에 `ref` 를 직접 식별자로 박음 (`GenerateViewConfigJs.js:323`).
+///
+/// param 의 type 은 emit 에 안 쓰므로 모두 `.string` fallback (CommandParamTypeAnnotation
+/// 에 `mixed` 가 없음). schema validation 측면에서 정확한 type 은 후속 PR.
+pub fn buildCommands(
+    ast: *const Ast,
+    type_index: *const TypeIndex,
+    commands_decl_idx: NodeIndex,
+    alloc: std.mem.Allocator,
+) Error![]const schema.NamedShape(schema.CommandTypeAnnotation) {
+    var visited: VisitedSet = .{};
+    defer visited.deinit(alloc);
+    var members_buf = std.ArrayList(NodeIndex).empty;
+    defer members_buf.deinit(alloc);
+    try collectAllMembers(ast, type_index, commands_decl_idx, &members_buf, &visited, 0, alloc);
+
+    var out = std.ArrayList(schema.NamedShape(schema.CommandTypeAnnotation)).empty;
+    defer out.deinit(alloc);
+
+    for (members_buf.items) |sig_idx| {
+        const sig = ast.getNode(sig_idx);
+        if (sig.tag != .ts_property_signature and sig.tag != .flow_property_signature) continue;
+        const e = sig.data.extra;
+        if (e + 2 >= ast.extra_data.items.len) continue;
+        const key_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e]);
+        const type_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e + 1]);
+
+        // 함수 시그니처 검증: TS 는 ts_function_type 으로 보존, Flow 는 type info 를
+        // strip 해 flow_literal_type 으로 만듦 (`flow.zig` arrow type → strip-only).
+        // 양쪽 모두 prop_signature 의 source text 에 `=>` 가 포함되므로 그걸로 검출.
+        const sig_src = ast.getText(sig.span);
+        const has_arrow = std.mem.indexOf(u8, sig_src, "=>") != null;
+        if (!isFunctionType(ast, type_idx) and !has_arrow) continue;
+
+        const name = extractKeyName(ast, key_idx) orelse continue;
+        // TS 면 ts_function_type 의 span 에 `(...)`, Flow 면 sig 전체 source 의 첫 `(...)`
+        // 가 함수 인자 list. extractCommandParams 가 첫 paren-balanced 부분을 split.
+        const params_src = if (isFunctionType(ast, type_idx))
+            ast.getText(ast.getNode(type_idx).span)
+        else
+            sig_src;
+        const params = try extractCommandParams(params_src, alloc);
+        try out.append(alloc, .{
+            .name = name,
+            .optional = PropertySignatureFlags.fromU32(ast.extra_data.items[e + 2]).optional,
+            .type_annotation = .{ .params = params },
+        });
+    }
+    return out.toOwnedSlice(alloc);
+}
+
+/// function_type 노드 (`(ref, p1, p2) => void`) 의 params list 에서 첫 인자 (`ref`) 를
+/// 제외한 나머지 인자 names 추출. 각 param 의 type 은 `.string` fallback (emit 에 안 씀).
+///
+/// ZTS parser 의 `parseTypeMemberParam` (`ts.zig:1316-1392`) 는 type-level function 의
+/// param 을 빈 `ts_property_signature` 로 strip-only 변환 — name 정보가 AST 에 없음.
+/// 따라서 ts_function_type / flow_function_type 의 **source text 자체** 를 depth-aware
+/// 스캔으로 outer paren 내용을 split 후 각 segment 의 leading identifier 추출.
+///
+/// RN spec 의 NativeCommands interface 의 method 시그니처는 단순 — generic / object
+/// literal / nested call 안 의 `,` 만 depth 카운팅 (`<>`, `()`, `{}`, `[]`) 으로 회피.
+fn extractCommandParams(
+    src: []const u8,
+    alloc: std.mem.Allocator,
+) Error![]const schema.NamedShape(schema.CommandParamTypeAnnotation) {
+    const paren_open = std.mem.indexOfScalar(u8, src, '(') orelse return &.{};
+    const paren_close = matchingParen(src, paren_open) orelse return &.{};
+    const inner = src[paren_open + 1 .. paren_close];
+
+    var out = std.ArrayList(schema.NamedShape(schema.CommandParamTypeAnnotation)).empty;
+    defer out.deinit(alloc);
+
+    var seg_start: usize = 0;
+    var i: usize = 0;
+    var depth: i32 = 0;
+    var first = true;
+    while (i <= inner.len) : (i += 1) {
+        const at_end = i == inner.len;
+        if (!at_end) {
+            switch (inner[i]) {
+                '<', '(', '{', '[' => depth += 1,
+                '>', ')', '}', ']' => depth -= 1,
+                else => {},
+            }
+        }
+        if ((!at_end and inner[i] == ',' and depth == 0) or at_end) {
+            const seg = std.mem.trim(u8, inner[seg_start..i], " \t\n\r");
+            seg_start = i + 1;
+            if (seg.len == 0) continue;
+            if (first) {
+                first = false;
+                continue; // ref 첫 인자 skip — reference contract.
+            }
+            const name = leadingIdentifier(seg) orelse continue;
+            try out.append(alloc, .{
+                .name = name,
+                .optional = false,
+                .type_annotation = .string,
+            });
+        }
+    }
+    return out.toOwnedSlice(alloc);
+}
+
+/// `src[open]` (`(`) 에 매칭하는 `)` 인덱스. depth 카운팅. 미매칭이면 null.
+fn matchingParen(src: []const u8, open: usize) ?usize {
+    var depth: i32 = 0;
+    var i = open;
+    while (i < src.len) : (i += 1) {
+        switch (src[i]) {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if (depth == 0) return i;
+            },
+            else => {},
+        }
+    }
+    return null;
+}
+
+/// segment 의 시작 부분에서 식별자 (`name`, `name?`, `name:`) 추출.
+fn leadingIdentifier(seg: []const u8) ?[]const u8 {
+    var i: usize = 0;
+    // identifier 첫 글자: a-z, A-Z, _, $.
+    if (i >= seg.len) return null;
+    const first = seg[i];
+    if (!((first >= 'a' and first <= 'z') or
+        (first >= 'A' and first <= 'Z') or
+        first == '_' or first == '$')) return null;
+    i += 1;
+    while (i < seg.len) : (i += 1) {
+        const c = seg[i];
+        if ((c >= 'a' and c <= 'z') or
+            (c >= 'A' and c <= 'Z') or
+            (c >= '0' and c <= '9') or
+            c == '_' or c == '$') continue;
+        break;
+    }
+    return seg[0..i];
 }
 
 /// 같은 `.name` 을 가진 항목을 dedup. **TS/Flow override 시멘틱 정합**:

--- a/src/transformer/plugins/rn_codegen/schema_builder_test.zig
+++ b/src/transformer/plugins/rn_codegen/schema_builder_test.zig
@@ -67,7 +67,7 @@ fn parseAndIndex(alloc: std.mem.Allocator, source: []const u8, mode: ParseMode) 
 /// `name` 의 declaration NodeIndex 로부터 ComponentShape 빌드. caller 가 프리 free.
 fn buildShape(p: *Parsed, type_name: []const u8, component_name: []const u8) !schema.ComponentShape {
     const decl_idx = p.type_index.get(type_name) orelse return error.TypeNotIndexed;
-    return schema_builder.build(&p.parser.ast, &p.type_index, component_name, null, decl_idx, p.alloc);
+    return schema_builder.build(&p.parser.ast, &p.type_index, component_name, null, decl_idx, null, p.alloc);
 }
 
 fn freeShape(alloc: std.mem.Allocator, shape: schema.ComponentShape) void {
@@ -277,7 +277,7 @@ test "schema_builder: invalid declaration → InvalidNativePropsBody" {
     try std.testing.expect(list.len > 0);
     const stmt: NodeIndex = @enumFromInt(p.parser.ast.extra_data.items[list.start]);
 
-    const result = schema_builder.build(&p.parser.ast, &p.type_index, "X", null, stmt, std.testing.allocator);
+    const result = schema_builder.build(&p.parser.ast, &p.type_index, "X", null, stmt, null, std.testing.allocator);
     try std.testing.expectError(error.InvalidNativePropsBody, result);
 }
 

--- a/src/transformer/plugins/rn_codegen/view_config_emitter.zig
+++ b/src/transformer/plugins/rn_codegen/view_config_emitter.zig
@@ -74,7 +74,44 @@ pub fn emit(shape: schema.ComponentShape, alloc: std.mem.Allocator) ![]u8 {
     }
 
     try buf.appendSlice(alloc, "};\n");
+
+    // commands 가 있으면 view config 다음에 `export const Commands = { ... };` block 추가.
+    // dispatchCommand import 는 plugin wrapper 측에서 prepend (NativeComponentRegistry import 옆).
+    // reference (`@react-native/codegen` 0.78~0.85+) 의 emit 형태와 동일 — method shorthand
+    // + dispatchCommand call. 0.78 (jscodeshift) ↔ 0.85 (babel/types) 사이 internal builder
+    // 만 다르고 emit output 100% 동일 (#2462 검증).
+    if (shape.hasCommands()) {
+        try emitCommandsExport(&buf, shape.commands, alloc);
+    }
+
     return buf.toOwnedSlice(alloc);
+}
+
+fn emitCommandsExport(
+    buf: *std.ArrayList(u8),
+    commands: []const schema.NamedShape(schema.CommandTypeAnnotation),
+    alloc: std.mem.Allocator,
+) !void {
+    try buf.appendSlice(alloc, "\nexport const Commands = {\n");
+    for (commands) |cmd| {
+        // method shorthand: `name(ref, p1, p2) { dispatchCommand(ref, "name", [p1, p2]); }`
+        try buf.appendSlice(alloc, "  ");
+        try buf.appendSlice(alloc, cmd.name);
+        try buf.appendSlice(alloc, "(ref");
+        for (cmd.type_annotation.params) |p| {
+            try buf.appendSlice(alloc, ", ");
+            try buf.appendSlice(alloc, p.name);
+        }
+        try buf.appendSlice(alloc, ") { dispatchCommand(ref, \"");
+        try buf.appendSlice(alloc, cmd.name);
+        try buf.appendSlice(alloc, "\", [");
+        for (cmd.type_annotation.params, 0..) |p, i| {
+            if (i > 0) try buf.appendSlice(alloc, ", ");
+            try buf.appendSlice(alloc, p.name);
+        }
+        try buf.appendSlice(alloc, "]); },\n");
+    }
+    try buf.appendSlice(alloc, "};\n");
 }
 
 fn countByBubbling(events: []const schema.EventTypeShape, kind: schema.BubblingType) usize {

--- a/src/transformer/plugins/rn_codegen_plugin.zig
+++ b/src/transformer/plugins/rn_codegen_plugin.zig
@@ -49,7 +49,9 @@ const schema_builder = codegen.schema_builder;
 const view_config_emitter = codegen.view_config_emitter;
 const stmt_info = @import("../../bundler/stmt_info.zig");
 
-const CODEGEN_MARKER = "codegenNativeComponent";
+// `@react-native/codegen` (`parsers-commons.js:689,968,1048` + `parsers-primitives.js:538`)
+// 와 `babel-plugin-codegen/index.js:74-149` 가 marker 이름을 inline literal 로 직접 비교.
+// ZTS 도 동일 패턴 — 별도 상수 없이 텍스트 스캔 / AST callee 비교에 inline 사용.
 
 pub fn plugin() Plugin {
     return .{
@@ -70,9 +72,9 @@ fn onTransform(
     // 파일 식별은 filename suffix 가 아니라 AST 레벨 검증 (`findComponentName`) 으로 결정 —
     // export default codegenNativeComponent(...) 패턴이 정확한 식별자.
     if (!std.mem.endsWith(u8, id, ".js") and !std.mem.endsWith(u8, id, ".ts")) return null;
-    if (std.mem.indexOf(u8, code, CODEGEN_MARKER) == null) return null;
+    if (std.mem.indexOf(u8, code, "codegenNativeComponent") == null) return null;
 
-    const props_type_name = extractTypeArg(code) orelse return null;
+    const props_type_name = extractTypeArg(code, "codegenNativeComponent") orelse return null;
 
     var scanner = Scanner.init(alloc, code) catch return null;
     defer scanner.deinit();
@@ -98,30 +100,46 @@ fn onTransform(
     const component_name = extractCallArg0String(&parser.ast, call_idx) orelse return null;
     const paper_component_name = extractPaperComponentName(&parser.ast, call_idx);
 
+    // commands 는 옵셔널 — `export const Commands = codegenNativeCommands<T>(...)` 패턴이
+    // 있으면 T 의 interface decl 을 builder 에 전달.
+    const commands_type_name = extractTypeArg(code, "codegenNativeCommands");
+    const commands_decl_idx = if (commands_type_name) |n| type_index.get(n) else null;
+
     const shape = schema_builder.build(
         &parser.ast,
         &type_index,
         component_name,
         paper_component_name,
         decl_idx,
+        commands_decl_idx,
         alloc,
     ) catch return null;
     defer alloc.free(shape.props);
     defer alloc.free(shape.events);
+    defer if (shape.hasCommands()) {
+        for (shape.commands) |c| alloc.free(c.type_annotation.params);
+        alloc.free(shape.commands);
+    };
 
     const view_config = view_config_emitter.emit(shape, alloc) catch return null;
     defer alloc.free(view_config);
 
-    return assembleFileReplacement(shape.nativeName(), view_config, alloc) catch return null;
+    return assembleFileReplacement(
+        shape.nativeName(),
+        view_config,
+        shape.hasCommands(),
+        alloc,
+    ) catch return null;
 }
 
-/// `codegenNativeComponent<TYPE_NAME>` 에서 `TYPE_NAME` 추출.
-/// 정상적인 spec 파일은 이 형태이므로 단순 텍스트 스캔으로 충분.
-/// AST 레벨에선 type argument 가 expression context 에서 speculative parse 후 폐기됨.
-fn extractTypeArg(code: []const u8) ?[]const u8 {
+/// `<MARKER><TYPE_NAME>` 에서 `TYPE_NAME` 추출 (예: `codegenNativeComponent<NativeProps>`,
+/// `codegenNativeCommands<NativeCommands>`). 정상적인 spec 파일은 이 형태이므로 단순
+/// 텍스트 스캔으로 충분. AST 레벨에선 type argument 가 expression context 에서
+/// speculative parse 후 폐기됨.
+fn extractTypeArg(code: []const u8, marker: []const u8) ?[]const u8 {
     var search_from: usize = 0;
-    while (std.mem.indexOfPos(u8, code, search_from, CODEGEN_MARKER)) |marker| {
-        const after = marker + CODEGEN_MARKER.len;
+    while (std.mem.indexOfPos(u8, code, search_from, marker)) |m| {
+        const after = m + marker.len;
         if (after >= code.len) return null;
         if (code[after] != '<') {
             search_from = after;
@@ -171,8 +189,7 @@ fn callIsCodegenMarker(ast: *const ast_mod.Ast, node: ast_mod.Node) bool {
     const callee_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e]);
     const callee = ast.getNode(callee_idx);
     if (callee.tag != .identifier_reference) return false;
-    const name = ast.getText(callee.span);
-    return std.mem.eql(u8, name, CODEGEN_MARKER);
+    return std.mem.eql(u8, ast.getText(callee.span), "codegenNativeComponent");
 }
 
 /// call_expression 의 첫 인자가 string literal 이면 unquoted 텍스트 반환.
@@ -226,18 +243,25 @@ fn extractPaperComponentName(ast: *const ast_mod.Ast, call_idx: NodeIndex) ?[]co
 /// 최종 파일 교체 문자열 조립. RN 런타임이 기대하는 정확한 형태:
 /// `@react-native/codegen` 의 `GenerateViewConfigJs.generate()` 의 fileTemplate 와 동일.
 /// `native_name` 은 caller 가 `shape.nativeName()` 으로 결정 (paper 우선) — 본 함수는
-/// 순수 문자열 어셈블리만 담당.
+/// 순수 문자열 어셈블리만 담당. `has_commands` true 면 `dispatchCommand` import 도
+/// prepend (commands export 가 emit 결과 안에 이미 포함됨).
 fn assembleFileReplacement(
     native_name: []const u8,
     view_config_js: []const u8,
+    has_commands: bool,
     alloc: std.mem.Allocator,
 ) ![]u8 {
+    const dispatch_import = if (has_commands)
+        "const {dispatchCommand} = require(\"react-native/Libraries/ReactNative/RendererProxy\");\n"
+    else
+        "";
     return std.fmt.allocPrint(
         alloc,
         "const NativeComponentRegistry = require('react-native/Libraries/NativeComponent/NativeComponentRegistry');\n" ++
+            "{s}" ++
             "let nativeComponentName = '{s}';\n" ++
             "{s}\n" ++
             "export default NativeComponentRegistry.get(nativeComponentName, () => __INTERNAL_VIEW_CONFIG);\n",
-        .{ native_name, view_config_js },
+        .{ dispatch_import, native_name, view_config_js },
     );
 }

--- a/src/transformer/plugins/rn_codegen_plugin_test.zig
+++ b/src/transformer/plugins/rn_codegen_plugin_test.zig
@@ -172,3 +172,45 @@ test "codegen_plugin: 옵션 object 있지만 paperComponentName 키 없으면 �
     try expectContains(out, "let nativeComponentName = 'Plain'");
     try expectContains(out, "uiViewClassName: 'Plain'");
 }
+
+test "codegen_plugin: codegenNativeCommands → dispatchCommand wrapper + Commands export" {
+    const code =
+        \\type NativeProps = { color: string };
+        \\interface NativeCommands {
+        \\  highlightTraceUpdates: (
+        \\    ref: React.ElementRef<View>,
+        \\    updates: ReadonlyArray<number>,
+        \\  ) => void;
+        \\  clearElements: (ref: React.ElementRef<View>) => void;
+        \\}
+        \\export const Commands = codegenNativeCommands<NativeCommands>({
+        \\  supportedCommands: ['highlightTraceUpdates', 'clearElements'],
+        \\});
+        \\export default codegenNativeComponent<NativeProps>('DebuggingOverlay');
+    ;
+    const out_opt = try callTransform(std.testing.allocator, code, "/path/DebuggingOverlayNativeComponent.ts");
+    try std.testing.expect(out_opt != null);
+    const out = out_opt.?;
+    defer std.testing.allocator.free(out);
+
+    try expectContains(out, "const {dispatchCommand} = require(\"react-native/Libraries/ReactNative/RendererProxy\")");
+    try expectContains(out, "export const Commands = {");
+    // 인자 있는 command — ref + updates
+    try expectContains(out, "highlightTraceUpdates(ref, updates) { dispatchCommand(ref, \"highlightTraceUpdates\", [updates]); }");
+    // 인자 없는 command — ref 만, [] 빈 배열
+    try expectContains(out, "clearElements(ref) { dispatchCommand(ref, \"clearElements\", []); }");
+}
+
+test "codegen_plugin: codegenNativeCommands 호출 없으면 Commands export / dispatchCommand 없음" {
+    const code =
+        \\type NativeProps = { color: string };
+        \\export default codegenNativeComponent<NativeProps>('NoCmds');
+    ;
+    const out_opt = try callTransform(std.testing.allocator, code, "/path/NoCmdsNativeComponent.ts");
+    try std.testing.expect(out_opt != null);
+    const out = out_opt.?;
+    defer std.testing.allocator.free(out);
+
+    try std.testing.expect(std.mem.indexOf(u8, out, "export const Commands") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "dispatchCommand") == null);
+}


### PR DESCRIPTION
## 배경

PR #2522 (snapshot test 강화) 가 노출한 `TestCommandsExportMismatch` 의 fix. ZTS plugin 이 `codegenNativeCommands` 호출을 인식 못 해서 `export const Commands = { ... }` block 자체가 emit 안 됐음 — RN imperative `Commands.X(ref, ...)` 호출 전부 깨짐.

## Reference 직접 확인 (#2462 plan)

| 단계 | reference 위치 | 동작 |
| --- | --- | --- |
| 패턴 detection | `parsers-commons.js:1040-1067` `getCommandTypeNameAndOptionsExpression` | `export const X = codegenNativeCommands<T>(opts)` |
| schema 변환 | `flow/components/commands.js:18-118` `buildCommandSchema` | 첫 인자 viewRef 제외 (`value.params.slice(1)`), 나머지 인자 names 추출 |
| emit | `GenerateViewConfigJs.js:295-338` `buildCommands` | method shorthand `name(ref, ...args) { dispatchCommand(ref, "name", [...args]); }` + `export const Commands = {...}` wrapper |

**RN 0.78 ↔ 0.85 비교**: emit output **100% 동일** (internal builder 만 jscodeshift → babel/types). ZTS 는 통합 form 1개로 0.78~0.85+ 모두 커버.

## 변경

### `rn_codegen_plugin.zig`
- **Marker 상수 inline literal 화** — reference 의 12 곳 inline 패턴과 일관 (`@react-native/codegen` 5 곳 + `babel-plugin-codegen/index.js` 7 곳). `CODEGEN_MARKER` 상수 제거
- `extractTypeArg` 일반화: marker 인자 받음 (`codegenNativeComponent` / `codegenNativeCommands` 둘 다 같은 함수)
- onTransform: commands_type_name 추출 → type_index lookup → builder 전달
- `assembleFileReplacement`: `has_commands` 인자 추가, true 시 `dispatchCommand` require 도 prepend (commands export 는 emit 결과 안에 이미 포함)

### `rn_codegen/schema_builder.zig`
- **`buildCommands` 신규**: NativeCommands interface body → commands schema. 각 method 의 인자 name list 추출 (첫 ref 제외)
- **`extractCommandParams` source-text 기반 depth-aware split**: ZTS Flow parser 가 type-level function 정보를 strip 함 (`flow_literal_type` data: none, `flow.zig` arrow type → strip-only) — AST 만으로는 인자 추출 불가. TS / Flow 양쪽 prop_signature 의 첫 paren-balanced 부분으로 fallback. depth-aware 카운팅 (`<>`, `()`, `{}`, `[]`)
- `build` 시그니처에 `commands_decl_idx: ?NodeIndex` 추가

### `rn_codegen/schema.zig`
- `ComponentShape.hasCommands()` 헬퍼 — 3 곳 (emitter / wrapper / plugin defer) 의 `commands.len > 0` 식 통일 (`nativeName()` 패턴과 일관)

### `rn_codegen/view_config_emitter.zig`
- `emitCommandsExport` 신규 — view config 다음에 method shorthand block emit

### Unit test
- `codegenNativeCommands → dispatchCommand wrapper + Commands export` (인자 있는 / 없는 command 둘 다)
- `codegenNativeCommands 호출 없으면 Commands export 와 dispatchCommand 둘 다 미출력`

## 후속

- 본 PR 머지 후 #2520 rebase → rn-0.78 의 **3 fixture 전체 통과** (#2520 은 ActivityIndicator/RCTSafeAreaView 가 paperComponentName 으로 #2523 통과, DebuggingOverlay 가 commands 변환으로 본 PR 통과)

Refs #2462

## Test plan
- [x] `zig build test --summary all` → 4635/4635 pass
- [x] 신규 unit test: `codegenNativeCommands` → `Commands` export emit 검증 (인자 있는/없는 method 둘 다)
- [x] 신규 unit test: commands 호출 없으면 Commands export / dispatchCommand 미출력
- [x] e2e (#2520 의 rn-0.78 DebuggingOverlay fixture cherry-pick): 본 PR 적용 시 `TestCommandsExportMismatch` 안 나오고 통과 — Flow type strip 한계도 source-text fallback 으로 우회됨 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)