### PR TITLE
feat(parser): TS / Flow type-level function param name 보존 (D103, #2462)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,12 +65,13 @@ Per-File Arena (단일 할당자, 파일 처리 후 한 번에 해제)
 - **Cover Grammar**: expression → assignment target 노드 변환. setTag로 24B 노드의 태그만 교체.
 - **AST 정규화**: function/method/arrow params는 모두 `formal_parameters` 노드로 wrap (arrow 기준 통일). `Ast.functionParamsList()` 로 태그 무관 unwrap. 범용 리스트 순회는 `visitExtraList(NodeList)` 시그니처. Class `get x() {} / set x() {}` 는 object와 동일하게 `method_definition + flags 0x02/0x04` (별도 태그 없음). `accessor_property` 태그는 TC39 auto-accessor 필드 전용.
 
-### TypeScript/Flow Handling (D002, D005, D024)
+### TypeScript/Flow Handling (D002, D005, D024, D103)
 - 타입 체크 안 함 (스트리핑만)
 - TS 5.8까지 전체 지원
 - ✅ Flow: TIER 1+2+3 타입 스트리핑 완료 (flow.zig 독립 구현, Metro 410/410 통과. 상세: [FLOW.md](./FLOW.md))
 - ✅ Legacy decorator 구현 완료 (experimentalDecorators)
 - Stage 3 decorator: 후순위 (스펙 안정화 후)
+- **Type-level function param name 보존** (D103, 2026-05-04): TS / Flow 양쪽의 `(name: T) => Return` 형태에서 `name` 을 AST 에 보존 (`ts_property_signature` / `flow_property_signature` 의 `[key, type_ann, flags]` layout). codegen plugin (#2462) 등 type-aware consumer 가 source-text fallback 없이 AST 직접 접근. esbuild/Bun 의 strip-only 정책에서 부분 이탈 — oxc/swc/babel/hermes 와 일관성. 다른 type 노드 (conditional / indexed access / keyof 등) 는 strip 정책 그대로.
 
 ### Output (D006, D008, D009, D012)
 - ESM + CJS + IIFE (UMD/AMD는 후순위)

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -856,5 +856,30 @@
   - `assert` → `with` 자동 마이그레이션 (static import 한정)
 - **미구현으로 남긴 것**: attrs → loader override, 알 수 없는 type 검증, 확장자 mismatch diagnostic. **필요 발생 시 재검토** 하되 현 시점엔 Won't Fix.
 
+### D103: Type-level function param name 보존 — esbuild/Bun strip-only 정책 부분 이탈 (2026-05-04)
+- **결정**: TS / Flow 의 type-level function (`(name: T, ...) => Return`) 의 param name 을 AST 에 보존. `parseTypeMemberParam` (TS) / `parseFunctionTypeParamList` (Flow) 가 빈 노드 만들지 말고 `ts_property_signature` / `flow_property_signature` 의 `[key, type_ann, flags]` layout 을 정보로 채움. Flow 의 arrow type 노드도 `flow_literal_type` sentinel 대신 `flow_function_type` 으로 보존.
+- **실측 비교 (2026-05-04)**:
+  | Parser | Top-level type 노드 보존 | Type-level function param.name 보존 |
+  | --- | --- | --- |
+  | **oxc** | ✅ `TSFunctionType.params: FormalParameters` | ✅ |
+  | **swc** | ✅ `TsFnType.params: Vec<TsFnParam>` | ✅ |
+  | **@babel/parser** | ✅ | ✅ (`param.name`) |
+  | **hermes-parser** | ✅ | ✅ (`param.name.name`) |
+  | **esbuild** | ❌ `skipTypeScriptFnArgs` strip | ❌ |
+  | **Bun** (esbuild fork) | ❌ `skipTypescriptFnArgs` strip | ❌ |
+  | **ZTS (이전)** | TS ✅ / Flow ❌ (`flow_literal_type` sentinel) | TS ❌ / Flow ❌ (둘 다 strip) |
+  | **ZTS (D103 후)** | TS ✅ / Flow ✅ | TS ✅ / Flow ✅ |
+- **이유**:
+  1. **Codegen plugin** (`@react-native/codegen` 등가) 의 `codegenNativeCommands<T>` 처리에 `T` interface 의 method param name 이 필요 (#2462). reference 가 `param.name.name` 직접 사용.
+  2. **TS 측은 이미 부분 보존** (top-level type 노드는 모두 별도 tag 로 정보 보존, type member param 만 strip) — Flow 도 같은 모델로 가야 일관성. 본 결정 전엔 TS / Flow 가 비대칭.
+  3. **성능 영향 측정 noise 안** — `Pipeline Profile` Parser 시간 변동 ±35% 가 측정 noise 자체 (Debug build 5-runs avg). Release 측정도 의미적 영향 없을 것으로 추정.
+  4. **메모리**: type 노드가 strip-only sentinel (8B `data: .none = 0`) 대신 정보 extras (16-32B). type-heavy 코드에서 노드 메모리 ~2-4x — 다만 transformer strip 단계에서 통째 버려져 영구 유지 X.
+- **trade-off (정직)**:
+  - ZTS 의 reference 인 Bun 이 strip-only 진영. ZTS 가 부분 이탈해서 oxc/swc/babel/hermes 진영으로 일부 이동. 기존 `flow_literal_type` 정책 (multi-purpose strip sentinel) 의 다른 사용처 (conditional / indexed access / keyof / typeof / 리터럴) 는 그대로 — TS 도 일부 strip (`ts_indexed_access_type` 는 `addEmptyExtraNode`) 하니 정책 일관성.
+- **영향 범위**:
+  - `parseTypeMemberParam` 9 callers (TS interface method, function type, mapped type 등) — 빈 ts_property_signature 가정 안 하던 caller 라 변경 영향 0 (자동 동작).
+  - `parseFunctionTypeParamList` 호출자 (Flow function type 4 path) — 동일.
+- **codegen plugin (#2462) 효과**: `extractCommandParams` 의 source-text 기반 depth-aware paren split fallback 제거 가능 → AST 기반으로 단순화.
+
 ### Phase 6 (Advanced) 미결정 사항
 - 개발 서버 고급 기능 (증분 재빌드, 프레임워크 통합)

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -106,12 +106,10 @@ pub fn parseType(self: *Parser) ParseError2!NodeIndex {
     // arrow 파라미터의 반환 타입 컨텍스트에서는 금지 — (): any => {} / (): any => 1
     if (self.current() == .arrow and !self.flow_in_return_type) {
         try self.advance();
-        _ = try parseType(self);
-        return try self.ast.addNode(.{
-            .tag = .flow_literal_type,
-            .span = self.ast.getNode(t).span,
-            .data = .{ .none = 0 },
-        });
+        const return_type = try parseType(self);
+        // shorthand 의 단일 positional param 은 t (이미 파싱된 type) 자체 — name 없음.
+        const params = try self.ast.addNodeList(&.{t});
+        return makeFunctionType(self, self.ast.getNode(t).span.start, NodeIndex.none, params, return_type);
     }
 
     return t;
@@ -405,17 +403,7 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
             try self.expect(.r_paren);
             try self.expect(.arrow);
             const return_type = try parseType(self);
-            const extra = try self.ast.addExtras(&.{
-                @intFromEnum(type_params),
-                params.start,
-                params.len,
-                @intFromEnum(return_type),
-            });
-            return try self.ast.addNode(.{
-                .tag = .flow_function_type,
-                .span = .{ .start = span.start, .end = self.currentSpan().start },
-                .data = .{ .extra = extra },
-            });
+            return makeFunctionType(self, span.start, type_params, params, return_type);
         },
         // 튜플 타입: [T, U]
         .l_bracket => return parseTupleType(self),
@@ -599,7 +587,8 @@ fn parseTypeParameter(self: *Parser) ParseError2!NodeIndex {
 /// 괄호 타입 (Type) 또는 함수 타입 (a: Type) => Type (Babel 방식).
 /// 1단계: `()`, `...`, `identifier:` → 확정적 function type
 /// 2단계: 그 외 → grouped type으로 먼저 파싱, `,` 또는 `) =>` 따르면 function type
-/// backtracking 없이 동작. 타입 스트리핑 전용이므로 결과는 flow_literal_type.
+/// backtracking 없이 동작. function type 형태는 `flow_function_type` 노드 (정보 보존),
+/// 단순 grouped type 은 `flow_literal_type` strip — TS 와 일관성.
 fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
     try self.advance(); // skip '('
@@ -608,8 +597,8 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
     if (self.current() == .r_paren) {
         try self.advance();
         try self.expect(.arrow);
-        _ = try parseType(self);
-        return makeLiteralType(self, start);
+        const return_type = try parseType(self);
+        return makeFunctionType(self, start, NodeIndex.none, .{ .start = 0, .len = 0 }, return_type);
     }
 
     // ...rest 또는 identifier: → 확정적 named/rest function param
@@ -623,18 +612,20 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
     };
 
     if (is_definite_fn) {
-        _ = try parseFunctionTypeParamList(self);
+        const params = try parseFunctionTypeParamList(self);
         try self.expect(.r_paren);
         try self.expect(.arrow);
-        _ = try parseType(self);
-        return makeLiteralType(self, start);
+        const return_type = try parseType(self);
+        return makeFunctionType(self, start, NodeIndex.none, params, return_type);
     }
 
     // grouped type으로 먼저 파싱
-    _ = try parseType(self);
+    const first_type = try parseType(self);
 
     // `,` → function type (positional params) — 나머지 params 소비
     if (try self.eat(.comma)) {
+        const scratch_top = self.saveScratch();
+        try self.scratch.append(self.allocator, first_type);
         while (self.current() != .r_paren and self.current() != .eof) {
             const loop_guard_pos = self.scanner.token.span.start;
             if (self.current() == .dot3) try self.advance();
@@ -642,18 +633,27 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
             if (self.current() == .identifier or (self.current().isKeyword() and !self.current().isReservedKeyword())) {
                 const next = try self.peekNextKind();
                 if (next == .colon or next == .question) {
-                    _ = try parseFunctionTypeParamList(self);
+                    const named = try parseFunctionTypeParamList(self);
+                    var i: u32 = 0;
+                    while (i < named.len) : (i += 1) {
+                        const idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[named.start + i]);
+                        try self.scratch.append(self.allocator, idx);
+                    }
                     break;
                 }
             }
-            _ = try parseType(self);
+            const param_type = try parseType(self);
+            try self.scratch.append(self.allocator, param_type);
             if (!try self.eat(.comma)) break;
             if (try self.ensureLoopProgress(loop_guard_pos)) break;
         }
         try self.expect(.r_paren);
         try self.expect(.arrow);
-        _ = try parseType(self);
-        return makeLiteralType(self, start);
+        const return_type = try parseType(self);
+        const items = self.scratch.items[scratch_top..];
+        const params = try self.ast.addNodeList(items);
+        self.scratch.shrinkRetainingCapacity(scratch_top);
+        return makeFunctionType(self, start, NodeIndex.none, params, return_type);
     }
 
     // `) =>` → single positional param function type
@@ -662,7 +662,9 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
         try self.advance();
         if (self.current() == .arrow and !self.flow_in_return_type) {
             try self.advance();
-            _ = try parseType(self);
+            const return_type = try parseType(self);
+            const params = try self.ast.addNodeList(&.{first_type});
+            return makeFunctionType(self, start, NodeIndex.none, params, return_type);
         }
         return makeLiteralType(self, start);
     }
@@ -670,6 +672,26 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
     // 그 외: 단순 괄호 타입
     try self.expect(.r_paren);
     return makeLiteralType(self, start);
+}
+
+fn makeFunctionType(
+    self: *Parser,
+    start: u32,
+    type_params: NodeIndex,
+    params: ast_mod.NodeList,
+    return_type: NodeIndex,
+) !NodeIndex {
+    const extra = try self.ast.addExtras(&.{
+        @intFromEnum(type_params),
+        params.start,
+        params.len,
+        @intFromEnum(return_type),
+    });
+    return self.ast.addNode(.{
+        .tag = .flow_function_type,
+        .span = .{ .start = start, .end = self.currentSpan().start },
+        .data = .{ .extra = extra },
+    });
 }
 
 fn makeLiteralType(self: *Parser, start: u32) !NodeIndex {
@@ -683,12 +705,18 @@ fn makeLiteralType(self: *Parser, start: u32) !NodeIndex {
 /// 함수 타입 파라미터 리스트: name: Type, name?: Type, ...rest: Type
 /// Flow는 `(t: number) => void` 형태에서 `t`가 파라미터 이름.
 /// 이름이 없는 `(number) => void` 형태도 허용 (positional).
+///
+/// 각 param 은 `flow_property_signature` 노드로 보존 — `[key, type_ann, flags]` layout
+/// (TS 의 `parseTypeMemberParam` 와 일관성). codegen plugin 등 type-level function
+/// param 의 name 이 필요한 consumer 가 AST 직접 접근 가능 (#2462 source-text fallback
+/// 제거).
 fn parseFunctionTypeParamList(self: *Parser) ParseError2!ast_mod.NodeList {
     const scratch_top = self.saveScratch();
     while (self.current() != .r_paren and self.current() != .eof) {
         const loop_guard_pos = self.scanner.token.span.start;
+        const param_start = self.currentSpan().start;
 
-        // ...rest 파라미터
+        // ...rest 파라미터 — name 정보 안 가짐, 단순 strip.
         if (self.current() == .dot3) {
             try self.advance();
         }
@@ -696,37 +724,40 @@ fn parseFunctionTypeParamList(self: *Parser) ParseError2!ast_mod.NodeList {
         // name: Type 또는 name?: Type — 이름 뒤에 : 또는 ?: 가 오면 named param
         if (self.current() == .identifier) {
             const next = try self.peekNextKind();
-            if (next == .colon) {
-                // name: Type
+            if (next == .colon or next == .question) {
+                const name_span = self.scanner.token.span;
+                const name_node = try self.ast.addNode(.{
+                    .tag = .binding_identifier,
+                    .span = name_span,
+                    .data = .{ .string_ref = name_span },
+                });
                 try self.advance(); // skip name
-                try self.advance(); // skip :
-                const param_type = try parseType(self);
-                try self.scratch.append(self.allocator, param_type);
-                if (!try self.eat(.comma)) break;
-                if (try self.ensureLoopProgress(loop_guard_pos)) break;
-                continue;
-            } else if (next == .question) {
-                // name?: Type (optional)
-                try self.advance(); // skip name
-                try self.advance(); // skip ?
+                const is_optional = try self.eat(.question);
+                var type_ann: NodeIndex = NodeIndex.none;
                 if (try self.eat(.colon)) {
-                    const param_type = try parseType(self);
-                    try self.scratch.append(self.allocator, param_type);
-                } else {
-                    // name? without colon — treat as type
-                    try self.scratch.append(self.allocator, try self.ast.addNode(.{
-                        .tag = .flow_literal_type,
-                        .span = .{ .start = loop_guard_pos, .end = self.currentSpan().start },
-                        .data = .{ .none = 0 },
-                    }));
+                    type_ann = try parseType(self);
                 }
+                const flags: PropertySignatureFlags = .{
+                    .optional = is_optional,
+                    .readonly = false,
+                };
+                const extra = try self.ast.addExtras(&.{
+                    @intFromEnum(name_node),
+                    @intFromEnum(type_ann),
+                    flags.toU32(),
+                });
+                try self.scratch.append(self.allocator, try self.ast.addNode(.{
+                    .tag = .flow_property_signature,
+                    .span = .{ .start = param_start, .end = self.currentSpan().start },
+                    .data = .{ .extra = extra },
+                }));
                 if (!try self.eat(.comma)) break;
                 if (try self.ensureLoopProgress(loop_guard_pos)) break;
                 continue;
             }
         }
 
-        // positional: Type (이름 없는 파라미터)
+        // positional: Type (이름 없는 파라미터) — strip-only.
         const param_type = try parseType(self);
         try self.scratch.append(self.allocator, param_type);
 

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -1598,18 +1598,25 @@ fn parseTypeMemberParam(self: *Parser) ParseError2!NodeIndex {
         is_rest = true;
     }
 
-    // this 파라미터: this: Type
-    // destructuring: [a, b]: Type, {x, y}: Type
-    // 결과 NodeIndex 는 strip-only 대상이라 소비처 없음 — parser 진행용 부수효과만.
+    // this 파라미터: this: Type — this 식별자를 binding_identifier 로 보존.
+    // destructuring: [a, b]: Type, {x, y}: Type — pattern NodeIndex 를 key 로 보존.
+    // 일반: name: Type — parsePropertyKey 결과를 key 로 보존.
+    var key: NodeIndex = NodeIndex.none;
     if (self.current() == .kw_this) {
+        const this_span = self.scanner.token.span;
         try self.advance();
+        key = try self.ast.addNode(.{
+            .tag = .binding_identifier,
+            .span = this_span,
+            .data = .{ .string_ref = this_span },
+        });
     } else if (self.current() == .l_bracket or self.current() == .l_curly) {
-        _ = try self.parseBindingName();
+        key = try self.parseBindingName();
     } else {
-        _ = try self.parsePropertyKey();
+        key = try self.parsePropertyKey();
     }
 
-    _ = try self.eat(.question); // optional
+    const is_optional = try self.eat(.question);
     var type_ann = NodeIndex.none;
     if (try self.eat(.colon)) {
         type_ann = try parseType(self);
@@ -1619,16 +1626,27 @@ fn parseTypeMemberParam(self: *Parser) ParseError2!NodeIndex {
         _ = try self.parseAssignmentExpression();
     }
 
-    // 두 tag 의 layout 이 다름:
-    //   ts_rest_type         = .unary (operand = rest 대상 타입)
-    //   ts_property_signature = .extra (strip-only; empty)
-    // 공통 NodeIndex 조합 (`name`/`type_ann`) 을 읽는 consumer 는 없으므로
-    // 각 layout 에 맞춰 분기 — audit cosmetic mismatch 해소.
+    // 두 tag 의 layout:
+    //   ts_rest_type          = .unary (operand = rest 대상 타입)
+    //   ts_property_signature = .extra `[key, type_ann, flags]` (Flow / TS 공통 — D103)
     const member_span: Span = .{ .start = param_start, .end = self.currentSpan().start };
     if (is_rest) {
         return try self.ast.addUnaryNode(.ts_rest_type, member_span, type_ann, 0);
     }
-    return try self.ast.addEmptyExtraNode(.ts_property_signature, member_span);
+    const flags: PropertySignatureFlags = .{
+        .optional = is_optional,
+        .readonly = false,
+    };
+    const extra = try self.ast.addExtras(&.{
+        @intFromEnum(key),
+        @intFromEnum(type_ann),
+        flags.toU32(),
+    });
+    return try self.ast.addNode(.{
+        .tag = .ts_property_signature,
+        .span = member_span,
+        .data = .{ .extra = extra },
+    });
 }
 
 /// Index signature 파라미터 앞에 올 수 있는 modifier 토큰 (error recovery 용).


### PR DESCRIPTION
## 배경

`(name: T) => Return` 형태에서 `param.name` 을 AST 에 보존. 이전엔 ZTS Flow 측이 arrow type 통째 `flow_literal_type` (data: `.none`) 으로 strip, TS / Flow 양쪽의 type-level function param 도 빈 `ts_property_signature` 또는 이름 없는 type 만 push 하는 식으로 strip — codegen plugin (#2462) 등 type-aware consumer 가 source-text fallback (paren-balanced text scan) 으로 우회해야 했음.

본 PR 은 architectural decision **D103** — esbuild/Bun 의 strip-only 진영에서 부분 이탈, oxc/swc/babel/hermes 와 일관성.

## 번들러 비교 (`@react-native/codegen` 의 commands schema 변환 path 직접 확인 후)

| Parser | top-level type 노드 보존 | type-level fn param.name 보존 |
| --- | --- | --- |
| **oxc** | ✅ `TSFunctionType.params: FormalParameters` | ✅ |
| **swc** | ✅ `TsFnType.params: Vec<TsFnParam>` | ✅ |
| **@babel/parser** | ✅ | ✅ (`param.name`) |
| **hermes-parser** | ✅ | ✅ (`param.name.name`) |
| **esbuild** | ❌ `skipTypeScriptFnArgs` strip | ❌ |
| **Bun** (esbuild fork) | ❌ `skipTypescriptFnArgs` strip | ❌ |
| **ZTS (이전)** | TS ✅ / Flow ❌ | TS ❌ / Flow ❌ |
| **ZTS (D103)** | TS ✅ / Flow ✅ | TS ✅ / Flow ✅ |

reference (`flow/components/commands.js:36`, `typescript/components/commands.js:42`) 가 `param.name.name` / `param.name` 직접 사용. 정보 strip 진영 (esbuild / Bun) 은 codegen 같은 type-aware 처리 시 source-text fallback 필요. **ZTS 가 부분 이탈** — TS 측은 이미 top-level 보존이라 일관성 측면에서 Flow 도 같은 수준으로 맞춤.

## 변경

### `src/parser/flow.zig`
- shorthand `T => R` (line 105) → `flow_function_type` 노드 + extras `[type_params, params, return_type]` 보존
- `parseParenOrFunctionType` 의 4 function type path → `flow_function_type` 사용
- 제네릭 `<T>(x) => R` path 도 통합 (4-tuple extras layout 한 곳에 모음)
- `parseFunctionTypeParamList`: 각 named param 마다 `flow_property_signature` 노드 (`[key, type_ann, flags]`) + binding_identifier 키 직접 생성. positional / rest 는 strip 유지
- 신규 helper `makeFunctionType(self, start, type_params, params, return_type)` — 5 호출처 (shorthand + generic + 4 paren path) 통합

### `src/parser/ts.zig`
- `parseTypeMemberParam`: 빈 `ts_property_signature` → `[key, type_ann, flags]` 정보 채움
- `this` 케이스도 binding_identifier 키 보존
- destructuring (`[a, b]: T`, `{x, y}: T`) 도 pattern NodeIndex 를 key 로 보존

## Caller 영향

| Caller | 영향 |
| --- | --- |
| `parseTypeMemberParam` 9 callers (interface method / function type / mapped type / call signature 등) | 빈 ts_property_signature 가정 안 하던 caller 라 변경 영향 0 |
| `parseFunctionTypeParamList` 호출자 (Flow function type 4 path) | 동일 |
| `transformer.zig` (5100, 5143, 5155) — strip 처리 | 새 layout 무시 (그냥 strip), 변경 영향 0 |
| `semantic/analyzer.zig` (1615) — type 검사 | 동일 |
| `schema_builder.zig` (codegen plugin) | 본 PR 후 `extractCommandParams` 의 source-text fallback 제거 가능 — 후속 commands PR scope |

## 성능 측정 (Debug build, 5-runs avg)

| Lines | Baseline Parser | After Parser |
| --- | --- | --- |
| 1000 | 3523us | 2204us |
| 5000 | 13507us | 9088us |
| 10000 | 29087us | 22331us |

Debug noise ±35% 라 측정 가능한 영향 없음. 회귀 0. Release 측정도 의미적 영향 미미할 것으로 추정 (alloc 추가는 type-heavy 코드만, parameter 수 보통 ≤ 5).

**메모리**: 각 named param 추가 alloc = 2 nodes (binding_identifier + property_signature) + 3 extras. 빈 노드 1개 → 2 노드 + 3 extras. type-heavy 코드 (RN spec 등) 영향 가시화될 수 있으나 transformer strip 단계에서 통째 버림 — 영구 유지 X.

## 문서

- `docs/DECISIONS.md` D103 추가 — 정직한 trade-off + 번들러 비교표 + 영향 범위
- `docs/ARCHITECTURE.md` TypeScript/Flow Handling 섹션 갱신 (D103 anchor)

## 후속

본 PR 머지 후:
1. **commands 변환 PR** 새로 작성 (이전 #2524 닫음): `schema_builder.extractCommandParams` 의 source-text 기반 paren split fallback 제거 → AST 기반 (`flow_property_signature.extra[0]` 로 binding_identifier 직접 추출) 으로 단순화. 본 PR 의 코드 90% 재사용.
2. #2520 rebase → rn-0.78 fixture 의 ActivityIndicator/RCTSafeAreaView (paperComponentName) + DebuggingOverlay (commands) 모두 통과.

Refs #2462

## Test plan
- [x] `zig build test --summary all` → 4633/4633 pass (parser 변경 회귀 0)
- [x] `Pipeline Profile` baseline / after 비교 → Debug noise 안 (영향 없음)
- [ ] (후속 commands PR) `extractCommandParams` AST 기반 단순화 → e2e #2520 DebuggingOverlay 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)