### PR TITLE
feat(codegen): codegenNativeCommands → dispatchCommand wrapper emit (#2462)

### DIFF
--- a/src/transformer/plugins/rn_codegen/schema.zig
+++ b/src/transformer/plugins/rn_codegen/schema.zig
@@ -220,6 +220,12 @@ pub const ComponentShape = struct {
     pub fn nativeName(self: ComponentShape) []const u8 {
         return self.paper_component_name orelse self.name;
     }
+
+    /// imperative commands (`codegenNativeCommands`) 가 있는지. emitter / wrapper /
+    /// plugin 의 free 분기에서 같은 식 (`commands.len > 0`) 반복하지 않게 한 곳에 모음.
+    pub fn hasCommands(self: ComponentShape) bool {
+        return self.commands.len > 0;
+    }
 };
 
 /// 한 spec 파일에 들어있는 모든 ComponentShape (보통 1 개, 가끔 여러 개).

--- a/src/transformer/plugins/rn_codegen/schema_builder.zig
+++ b/src/transformer/plugins/rn_codegen/schema_builder.zig
@@ -72,12 +72,15 @@ const VisitedSet = std.AutoHashMapUnmanaged(NodeIndex, void);
 /// 외부에서 받음 (declaration 자체엔 이름 없음).
 /// `paper_component_name` 은 `codegenNativeComponent('Name', { paperComponentName: 'X' })`
 /// 의 옵션. 없으면 null. RN runtime 의 `uiViewClassName` 은 이 값을 우선 (#2462).
+/// `commands_decl_idx` 는 `codegenNativeCommands<NativeCommands>(...)` 의 type argument
+/// 가 가리키는 interface declaration. 없으면 null (commands 미사용 spec).
 pub fn build(
     ast: *const Ast,
     type_index: *const TypeIndex,
     component_name: []const u8,
     paper_component_name: ?[]const u8,
     native_props_idx: NodeIndex,
+    commands_decl_idx: ?NodeIndex,
     alloc: std.mem.Allocator,
 ) Error!schema.ComponentShape {
     var visited: VisitedSet = .{};
@@ -100,11 +103,120 @@ pub fn build(
     try dedupByName(schema.NamedShape(schema.PropTypeAnnotation), &props_buf, alloc);
     try dedupByName(schema.EventTypeShape, &events_buf, alloc);
 
+    const commands: []const schema.NamedShape(schema.CommandTypeAnnotation) = if (commands_decl_idx) |c|
+        try buildCommands(ast, type_index, c, alloc)
+    else
+        &.{};
+
     return .{
         .name = component_name,
         .paper_component_name = paper_component_name,
         .props = try props_buf.toOwnedSlice(alloc),
         .events = try events_buf.toOwnedSlice(alloc),
+        .commands = commands,
+    };
+}
+
+/// NativeCommands interface body → commands schema. 각 method property 마다 이름 +
+/// 첫 인자 `ref` 를 제외한 나머지 인자 names 를 추출.
+///
+/// reference (`@react-native/codegen` `flow/components/commands.js:35-36` 의
+/// `value.params.slice(1).map(param => { const paramName = param.name.name; ... })`,
+/// `typescript/components/commands.js:42` 의 `param.name`) 와 동일 contract — 첫 인자는
+/// 항상 viewRef, codegen 은 emit 에 그 자리에 `ref` 식별자를 직접 박음
+/// (`GenerateViewConfigJs.js:323`).
+///
+/// D103 으로 type-level function param name 이 AST 에 보존됨 — flow_property_signature
+/// / ts_property_signature 의 extra[0] 의 binding_identifier 직접 추출. 이전엔
+/// source-text fallback 필요했음.
+///
+/// param 의 type 은 emit 에 안 쓰므로 `.string` fallback (CommandParamTypeAnnotation 에
+/// `mixed` 가 없음). 정확한 type 매핑은 후속 PR.
+pub fn buildCommands(
+    ast: *const Ast,
+    type_index: *const TypeIndex,
+    commands_decl_idx: NodeIndex,
+    alloc: std.mem.Allocator,
+) Error![]const schema.NamedShape(schema.CommandTypeAnnotation) {
+    var visited: VisitedSet = .{};
+    defer visited.deinit(alloc);
+    var members_buf = std.ArrayList(NodeIndex).empty;
+    defer members_buf.deinit(alloc);
+    try collectAllMembers(ast, type_index, commands_decl_idx, &members_buf, &visited, 0, alloc);
+
+    var out = std.ArrayList(schema.NamedShape(schema.CommandTypeAnnotation)).empty;
+    defer out.deinit(alloc);
+
+    for (members_buf.items) |sig_idx| {
+        const info = decodePropertySignature(ast, sig_idx) orelse continue;
+        if (!isFunctionType(ast, info.type_ann)) continue;
+
+        const name = extractKeyName(ast, info.key) orelse continue;
+        const params = try extractCommandParams(ast, info.type_ann, alloc);
+        try out.append(alloc, .{
+            .name = name,
+            .optional = info.flags.optional,
+            .type_annotation = .{ .params = params },
+        });
+    }
+    return out.toOwnedSlice(alloc);
+}
+
+/// function_type 노드 (`(ref, p1, p2) => void`) 의 params list 에서 첫 인자 (`ref`) 를
+/// 제외한 나머지 인자 names 추출. AST 직접 순회 (D103 후 type-level param 이
+/// flow_property_signature / ts_property_signature 의 `[key, type_ann, flags]` layout 으로
+/// 보존됨 — extra[0] 의 binding_identifier 에서 이름 추출).
+///
+/// 각 param 의 type 은 emit 에 안 쓰므로 `.string` fallback.
+fn extractCommandParams(
+    ast: *const Ast,
+    fn_type_idx: NodeIndex,
+    alloc: std.mem.Allocator,
+) Error![]const schema.NamedShape(schema.CommandParamTypeAnnotation) {
+    const fn_type = ast.getNode(fn_type_idx);
+    // ts_function_type / flow_function_type: extra = [type_params, params_start, params_len, return_type]
+    const e = fn_type.data.extra;
+    if (e + 3 >= ast.extra_data.items.len) return &.{};
+    const params_start = ast.extra_data.items[e + 1];
+    const params_len = ast.extra_data.items[e + 2];
+    if (params_len <= 1) return &.{}; // ref 만 있으면 빈 args.
+
+    var out = std.ArrayList(schema.NamedShape(schema.CommandParamTypeAnnotation)).empty;
+    defer out.deinit(alloc);
+    var i: u32 = 1; // 첫 인자 ref 는 skip — reference 의 `value.params.slice(1)` 와 동일.
+    while (i < params_len) : (i += 1) {
+        const p_idx: NodeIndex = @enumFromInt(ast.extra_data.items[params_start + i]);
+        // type-level function param: ts_property_signature / flow_property_signature
+        // (D103). extra = [key, type_ann, flags].
+        const info = decodePropertySignature(ast, p_idx) orelse continue;
+        const param_name = extractKeyName(ast, info.key) orelse continue;
+        try out.append(alloc, .{
+            .name = param_name,
+            .optional = false,
+            .type_annotation = .string,
+        });
+    }
+    return out.toOwnedSlice(alloc);
+}
+
+/// `ts_property_signature` / `flow_property_signature` 의 `[key, type_ann, flags]` extras
+/// 디코드. 다른 tag 또는 OOB 면 null. 같은 layout 을 3 callsite (classifyMember +
+/// buildCommands + extractCommandParams) 에서 사용.
+const PropertySignatureInfo = struct {
+    key: NodeIndex,
+    type_ann: NodeIndex,
+    flags: PropertySignatureFlags,
+};
+
+fn decodePropertySignature(ast: *const Ast, sig_idx: NodeIndex) ?PropertySignatureInfo {
+    const sig = ast.getNode(sig_idx);
+    if (sig.tag != .ts_property_signature and sig.tag != .flow_property_signature) return null;
+    const e = sig.data.extra;
+    if (e + 2 >= ast.extra_data.items.len) return null;
+    return .{
+        .key = @enumFromInt(ast.extra_data.items[e]),
+        .type_ann = @enumFromInt(ast.extra_data.items[e + 1]),
+        .flags = PropertySignatureFlags.fromU32(ast.extra_data.items[e + 2]),
     };
 }
 
@@ -450,22 +562,15 @@ fn classifyMember(
     events: *std.ArrayList(schema.EventTypeShape),
     alloc: std.mem.Allocator,
 ) Error!void {
-    const sig = ast.getNode(sig_idx);
-    const e = sig.data.extra;
-    if (e + 2 >= ast.extra_data.items.len) return error.UnsupportedPropType;
+    const info = decodePropertySignature(ast, sig_idx) orelse return error.UnsupportedPropType;
+    const key_name = extractKeyName(ast, info.key) orelse return error.UnsupportedPropType;
+    if (info.type_ann == .none) return error.UnsupportedPropType;
 
-    const key_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e]);
-    const type_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e + 1]);
-    const flags = PropertySignatureFlags.fromU32(ast.extra_data.items[e + 2]);
-
-    const key_name = extractKeyName(ast, key_idx) orelse return error.UnsupportedPropType;
-    if (type_idx == .none) return error.UnsupportedPropType;
-
-    if (isFunctionType(ast, type_idx)) {
+    if (isFunctionType(ast, info.type_ann)) {
         try events.append(alloc, .{
             .name = key_name,
             .bubbling_type = classifyEventBubbling(key_name),
-            .optional = flags.optional,
+            .optional = info.flags.optional,
             .argument = null, // PR #3b 스코프: argument 추출 미구현. PR #3b-2 에서 확장.
         });
         return;
@@ -475,20 +580,20 @@ fn classifyMember(
     // wrapper. react-native-svg 의 fabric spec 들이 `onSvgLayout?: DirectEventHandler<E>`
     // 형태로 사용. wrapper 이름이 bubble vs direct 를 결정하므로 prop 이름 휴리스틱
     // (`onCapture`) 보다 우선.
-    if (eventHandlerBubbling(ast, type_idx)) |bubbling| {
+    if (eventHandlerBubbling(ast, info.type_ann)) |bubbling| {
         try events.append(alloc, .{
             .name = key_name,
             .bubbling_type = bubbling,
-            .optional = flags.optional,
+            .optional = info.flags.optional,
             .argument = null,
         });
         return;
     }
 
-    const prop_type = try mapPropType(ast, type_index, type_idx);
+    const prop_type = try mapPropType(ast, type_index, info.type_ann);
     try props.append(alloc, .{
         .name = key_name,
-        .optional = flags.optional,
+        .optional = info.flags.optional,
         .type_annotation = prop_type,
     });
 }

--- a/src/transformer/plugins/rn_codegen/schema_builder_test.zig
+++ b/src/transformer/plugins/rn_codegen/schema_builder_test.zig
@@ -67,7 +67,7 @@ fn parseAndIndex(alloc: std.mem.Allocator, source: []const u8, mode: ParseMode) 
 /// `name` 의 declaration NodeIndex 로부터 ComponentShape 빌드. caller 가 프리 free.
 fn buildShape(p: *Parsed, type_name: []const u8, component_name: []const u8) !schema.ComponentShape {
     const decl_idx = p.type_index.get(type_name) orelse return error.TypeNotIndexed;
-    return schema_builder.build(&p.parser.ast, &p.type_index, component_name, null, decl_idx, p.alloc);
+    return schema_builder.build(&p.parser.ast, &p.type_index, component_name, null, decl_idx, null, p.alloc);
 }
 
 fn freeShape(alloc: std.mem.Allocator, shape: schema.ComponentShape) void {
@@ -277,7 +277,7 @@ test "schema_builder: invalid declaration → InvalidNativePropsBody" {
     try std.testing.expect(list.len > 0);
     const stmt: NodeIndex = @enumFromInt(p.parser.ast.extra_data.items[list.start]);
 
-    const result = schema_builder.build(&p.parser.ast, &p.type_index, "X", null, stmt, std.testing.allocator);
+    const result = schema_builder.build(&p.parser.ast, &p.type_index, "X", null, stmt, null, std.testing.allocator);
     try std.testing.expectError(error.InvalidNativePropsBody, result);
 }
 

--- a/src/transformer/plugins/rn_codegen/view_config_emitter.zig
+++ b/src/transformer/plugins/rn_codegen/view_config_emitter.zig
@@ -74,7 +74,44 @@ pub fn emit(shape: schema.ComponentShape, alloc: std.mem.Allocator) ![]u8 {
     }
 
     try buf.appendSlice(alloc, "};\n");
+
+    // commands 가 있으면 view config 다음에 `export const Commands = { ... };` block 추가.
+    // dispatchCommand import 는 plugin wrapper 측에서 prepend (NativeComponentRegistry import 옆).
+    // reference (`@react-native/codegen` 0.78~0.85+) 의 emit 형태와 동일 — method shorthand
+    // + dispatchCommand call. 0.78 (jscodeshift) ↔ 0.85 (babel/types) 사이 internal builder
+    // 만 다르고 emit output 100% 동일 (#2462 검증).
+    if (shape.hasCommands()) {
+        try emitCommandsExport(&buf, shape.commands, alloc);
+    }
+
     return buf.toOwnedSlice(alloc);
+}
+
+fn emitCommandsExport(
+    buf: *std.ArrayList(u8),
+    commands: []const schema.NamedShape(schema.CommandTypeAnnotation),
+    alloc: std.mem.Allocator,
+) !void {
+    try buf.appendSlice(alloc, "\nexport const Commands = {\n");
+    for (commands) |cmd| {
+        // method shorthand: `name(ref, p1, p2) { dispatchCommand(ref, "name", [p1, p2]); }`
+        try buf.appendSlice(alloc, "  ");
+        try buf.appendSlice(alloc, cmd.name);
+        try buf.appendSlice(alloc, "(ref");
+        for (cmd.type_annotation.params) |p| {
+            try buf.appendSlice(alloc, ", ");
+            try buf.appendSlice(alloc, p.name);
+        }
+        try buf.appendSlice(alloc, ") { dispatchCommand(ref, \"");
+        try buf.appendSlice(alloc, cmd.name);
+        try buf.appendSlice(alloc, "\", [");
+        for (cmd.type_annotation.params, 0..) |p, i| {
+            if (i > 0) try buf.appendSlice(alloc, ", ");
+            try buf.appendSlice(alloc, p.name);
+        }
+        try buf.appendSlice(alloc, "]); },\n");
+    }
+    try buf.appendSlice(alloc, "};\n");
 }
 
 fn countByBubbling(events: []const schema.EventTypeShape, kind: schema.BubblingType) usize {

--- a/src/transformer/plugins/rn_codegen_plugin.zig
+++ b/src/transformer/plugins/rn_codegen_plugin.zig
@@ -49,7 +49,9 @@ const schema_builder = codegen.schema_builder;
 const view_config_emitter = codegen.view_config_emitter;
 const stmt_info = @import("../../bundler/stmt_info.zig");
 
-const CODEGEN_MARKER = "codegenNativeComponent";
+// `@react-native/codegen` (`parsers-commons.js:689,968,1048` + `parsers-primitives.js:538`)
+// 와 `babel-plugin-codegen/index.js:74-149` 가 marker 이름을 inline literal 로 직접 비교.
+// ZTS 도 동일 패턴 — 별도 상수 없이 텍스트 스캔 / AST callee 비교에 inline 사용.
 
 pub fn plugin() Plugin {
     return .{
@@ -70,9 +72,9 @@ fn onTransform(
     // 파일 식별은 filename suffix 가 아니라 AST 레벨 검증 (`findComponentName`) 으로 결정 —
     // export default codegenNativeComponent(...) 패턴이 정확한 식별자.
     if (!std.mem.endsWith(u8, id, ".js") and !std.mem.endsWith(u8, id, ".ts")) return null;
-    if (std.mem.indexOf(u8, code, CODEGEN_MARKER) == null) return null;
+    if (std.mem.indexOf(u8, code, "codegenNativeComponent") == null) return null;
 
-    const props_type_name = extractTypeArg(code) orelse return null;
+    const props_type_name = extractTypeArg(code, "codegenNativeComponent") orelse return null;
 
     var scanner = Scanner.init(alloc, code) catch return null;
     defer scanner.deinit();
@@ -98,30 +100,46 @@ fn onTransform(
     const component_name = extractCallArg0String(&parser.ast, call_idx) orelse return null;
     const paper_component_name = extractPaperComponentName(&parser.ast, call_idx);
 
+    // commands 는 옵셔널 — `export const Commands = codegenNativeCommands<T>(...)` 패턴이
+    // 있으면 T 의 interface decl 을 builder 에 전달.
+    const commands_type_name = extractTypeArg(code, "codegenNativeCommands");
+    const commands_decl_idx = if (commands_type_name) |n| type_index.get(n) else null;
+
     const shape = schema_builder.build(
         &parser.ast,
         &type_index,
         component_name,
         paper_component_name,
         decl_idx,
+        commands_decl_idx,
         alloc,
     ) catch return null;
     defer alloc.free(shape.props);
     defer alloc.free(shape.events);
+    defer if (shape.hasCommands()) {
+        for (shape.commands) |c| alloc.free(c.type_annotation.params);
+        alloc.free(shape.commands);
+    };
 
     const view_config = view_config_emitter.emit(shape, alloc) catch return null;
     defer alloc.free(view_config);
 
-    return assembleFileReplacement(shape.nativeName(), view_config, alloc) catch return null;
+    return assembleFileReplacement(
+        shape.nativeName(),
+        view_config,
+        shape.hasCommands(),
+        alloc,
+    ) catch return null;
 }
 
-/// `codegenNativeComponent<TYPE_NAME>` 에서 `TYPE_NAME` 추출.
-/// 정상적인 spec 파일은 이 형태이므로 단순 텍스트 스캔으로 충분.
-/// AST 레벨에선 type argument 가 expression context 에서 speculative parse 후 폐기됨.
-fn extractTypeArg(code: []const u8) ?[]const u8 {
+/// `<MARKER><TYPE_NAME>` 에서 `TYPE_NAME` 추출 (예: `codegenNativeComponent<NativeProps>`,
+/// `codegenNativeCommands<NativeCommands>`). 정상적인 spec 파일은 이 형태이므로 단순
+/// 텍스트 스캔으로 충분. AST 레벨에선 type argument 가 expression context 에서
+/// speculative parse 후 폐기됨.
+fn extractTypeArg(code: []const u8, marker: []const u8) ?[]const u8 {
     var search_from: usize = 0;
-    while (std.mem.indexOfPos(u8, code, search_from, CODEGEN_MARKER)) |marker| {
-        const after = marker + CODEGEN_MARKER.len;
+    while (std.mem.indexOfPos(u8, code, search_from, marker)) |m| {
+        const after = m + marker.len;
         if (after >= code.len) return null;
         if (code[after] != '<') {
             search_from = after;
@@ -171,8 +189,7 @@ fn callIsCodegenMarker(ast: *const ast_mod.Ast, node: ast_mod.Node) bool {
     const callee_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e]);
     const callee = ast.getNode(callee_idx);
     if (callee.tag != .identifier_reference) return false;
-    const name = ast.getText(callee.span);
-    return std.mem.eql(u8, name, CODEGEN_MARKER);
+    return std.mem.eql(u8, ast.getText(callee.span), "codegenNativeComponent");
 }
 
 /// call_expression 의 첫 인자가 string literal 이면 unquoted 텍스트 반환.
@@ -226,18 +243,25 @@ fn extractPaperComponentName(ast: *const ast_mod.Ast, call_idx: NodeIndex) ?[]co
 /// 최종 파일 교체 문자열 조립. RN 런타임이 기대하는 정확한 형태:
 /// `@react-native/codegen` 의 `GenerateViewConfigJs.generate()` 의 fileTemplate 와 동일.
 /// `native_name` 은 caller 가 `shape.nativeName()` 으로 결정 (paper 우선) — 본 함수는
-/// 순수 문자열 어셈블리만 담당.
+/// 순수 문자열 어셈블리만 담당. `has_commands` true 면 `dispatchCommand` import 도
+/// prepend (commands export 가 emit 결과 안에 이미 포함됨).
 fn assembleFileReplacement(
     native_name: []const u8,
     view_config_js: []const u8,
+    has_commands: bool,
     alloc: std.mem.Allocator,
 ) ![]u8 {
+    const dispatch_import = if (has_commands)
+        "const {dispatchCommand} = require(\"react-native/Libraries/ReactNative/RendererProxy\");\n"
+    else
+        "";
     return std.fmt.allocPrint(
         alloc,
         "const NativeComponentRegistry = require('react-native/Libraries/NativeComponent/NativeComponentRegistry');\n" ++
+            "{s}" ++
             "let nativeComponentName = '{s}';\n" ++
             "{s}\n" ++
             "export default NativeComponentRegistry.get(nativeComponentName, () => __INTERNAL_VIEW_CONFIG);\n",
-        .{ native_name, view_config_js },
+        .{ dispatch_import, native_name, view_config_js },
     );
 }

--- a/src/transformer/plugins/rn_codegen_plugin_test.zig
+++ b/src/transformer/plugins/rn_codegen_plugin_test.zig
@@ -172,3 +172,45 @@ test "codegen_plugin: 옵션 object 있지만 paperComponentName 키 없으면 �
     try expectContains(out, "let nativeComponentName = 'Plain'");
     try expectContains(out, "uiViewClassName: 'Plain'");
 }
+
+test "codegen_plugin: codegenNativeCommands → dispatchCommand wrapper + Commands export (TS)" {
+    const code =
+        \\type NativeProps = { color: string };
+        \\interface NativeCommands {
+        \\  highlightTraceUpdates: (
+        \\    ref: React.ElementRef<View>,
+        \\    updates: ReadonlyArray<number>,
+        \\  ) => void;
+        \\  clearElements: (ref: React.ElementRef<View>) => void;
+        \\}
+        \\export const Commands = codegenNativeCommands<NativeCommands>({
+        \\  supportedCommands: ['highlightTraceUpdates', 'clearElements'],
+        \\});
+        \\export default codegenNativeComponent<NativeProps>('DebuggingOverlay');
+    ;
+    const out_opt = try callTransform(std.testing.allocator, code, "/path/DebuggingOverlayNativeComponent.ts");
+    try std.testing.expect(out_opt != null);
+    const out = out_opt.?;
+    defer std.testing.allocator.free(out);
+
+    try expectContains(out, "const {dispatchCommand} = require(\"react-native/Libraries/ReactNative/RendererProxy\")");
+    try expectContains(out, "export const Commands = {");
+    // 인자 있는 command — ref + updates
+    try expectContains(out, "highlightTraceUpdates(ref, updates) { dispatchCommand(ref, \"highlightTraceUpdates\", [updates]); }");
+    // 인자 없는 command — ref 만, [] 빈 배열
+    try expectContains(out, "clearElements(ref) { dispatchCommand(ref, \"clearElements\", []); }");
+}
+
+test "codegen_plugin: codegenNativeCommands 호출 없으면 Commands export / dispatchCommand 없음" {
+    const code =
+        \\type NativeProps = { color: string };
+        \\export default codegenNativeComponent<NativeProps>('NoCmds');
+    ;
+    const out_opt = try callTransform(std.testing.allocator, code, "/path/NoCmdsNativeComponent.ts");
+    try std.testing.expect(out_opt != null);
+    const out = out_opt.?;
+    defer std.testing.allocator.free(out);
+
+    try std.testing.expect(std.mem.indexOf(u8, out, "export const Commands") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "dispatchCommand") == null);
+}


### PR DESCRIPTION
## 배경

PR #2522 (snapshot test 강화) 가 노출한 `TestCommandsExportMismatch` 의 fix. ZTS plugin 이 `codegenNativeCommands` 호출을 인식 못 해서 `export const Commands = { ... }` block 자체가 emit 안 됐음 — RN imperative `Commands.X(ref, ...)` 호출 전부 깨짐.

본 PR 은 **PR #2524 의 v2** — D103 (parser type-level fn param 보존) 머지 후 작성. v1 의 source-text 기반 paren split fallback 제거 → AST 기반 단순화.

## Reference 직접 확인 (#2462 plan)

| 단계 | reference | 동작 |
| --- | --- | --- |
| detection | `parsers-commons.js:1040-1067` `getCommandTypeNameAndOptionsExpression` | `export const X = codegenNativeCommands<T>(opts)` |
| schema 변환 | `flow/components/commands.js:35-36` `value.params.slice(1).map(p => p.name.name)` | 첫 인자 viewRef 제외, 나머지 인자 names |
| emit | `GenerateViewConfigJs.js:295-338` `buildCommands` | method shorthand `name(ref, ...) { dispatchCommand(...) }` + Commands export |

**RN 0.78 ↔ 0.85**: emit output 100% 동일 (jscodeshift → babel/types 만 다름). ZTS 통합 form 1개로 0.78~0.85+ 커버.

## D103 활용 (parser fix) 차이

**v1 (#2524 닫음, source-text fallback)**:
```zig
// flow_property_signature 의 type_ann 이 flow_literal_type (strip) → AST 만으론 추출 불가
const sig_src = ast.getText(sig.span);
const has_arrow = std.mem.indexOf(u8, sig_src, "=>") != null;
const params_src = if (isFunctionType(...)) ast.getText(...) else sig_src;
const params = try extractCommandParams(params_src, alloc);  // depth-aware paren split, ~50 줄
```

**v2 (D103 후, AST 기반)**:
```zig
// flow_property_signature.extra[0] 의 binding_identifier 직접 추출
const info = decodePropertySignature(ast, p_idx) orelse continue;
const param_name = extractKeyName(ast, info.key) orelse continue;  // ~5 줄
```

코드 ~50 줄 → ~20 줄, 성능 O(L source) → O(N parameters), Flow strip 우회 코드 사라짐.

## 변경

### `rn_codegen_plugin.zig`
- **Marker 상수 inline literal 화** — reference 12 곳 inline 패턴과 일관 (`@react-native/codegen` 5 곳 + `babel-plugin-codegen/index.js` 7 곳)
- `extractTypeArg` 일반화: marker 인자 (`codegenNativeComponent` / `codegenNativeCommands` 둘 다)
- onTransform: commands_type_name 추출 → type_index lookup → builder 전달
- `assembleFileReplacement`: `has_commands` 인자 — true 시 `dispatchCommand` require 도 prepend (NativeComponentRegistry 옆)

### `rn_codegen/schema_builder.zig`
- **`buildCommands` 신규** — NativeCommands interface body → commands schema
- **`extractCommandParams`** — function_type extras 디코드 + 각 param 의 binding_identifier 직접 추출
- **`decodePropertySignature` 헬퍼 신규** — `[key, type_ann, flags]` 디코드 통합 (3 callsite: classifyMember + buildCommands + extractCommandParams)
- `build` 시그니처에 `commands_decl_idx: ?NodeIndex` 추가

### `rn_codegen/schema.zig`
- `ComponentShape.hasCommands()` 헬퍼 — 3 곳 일관성

### `rn_codegen/view_config_emitter.zig`
- `emitCommandsExport` 신규

### Unit test
- `codegenNativeCommands → dispatchCommand wrapper + Commands export` (인자 있는/없는)
- `codegenNativeCommands 호출 없으면 Commands export / dispatchCommand 둘 다 미출력`

## 검증

- `zig build test --summary all` → 4635/4635 pass
- e2e (#2520 cherry-pick): rn-0.78 의 3 fixture (DebuggingOverlay 포함) 모두 통과 — 17/17

## 후속 (본 PR scope 외)

- **supportedCommands ↔ interface 이름 set 일치 검증** (reference `parsers-commons.js:1180-1190`) — silent divergence 가능. 별도 issue 등록 권장
- **`ComponentShape.deinit(alloc)` 헬퍼** — props/events/commands free 통합 (현재 plugin 의 nested defer block 단순화)

본 PR 머지 후 #2520 rebase → rn-0.78 3 fixture 모두 통과 → ready for review.

Refs #2462

## Test plan
- [x] `zig build test --summary all` → 4635/4635 pass
- [x] 신규 unit test 2개 (commands wrapper emit / commands 없을 때)
- [x] e2e (#2520 cherry-pick) → 17/17, DebuggingOverlay 의 `TestCommandsExportMismatch` 해소
- [x] reference 직접 확인 (commands.js + GenerateViewConfigJs.js + parsers-commons.js)

🤖 Generated with [Claude Code](https://claude.com/claude-code)