### PR TITLE
perf(core): runtime polyfill collector hot path 자료구조 정리

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -698,6 +698,134 @@ fn resolveEntryPoint(alloc: std.mem.Allocator, path: []const u8) ?[]const u8 {
     return resolved;
 }
 
+// ─── runtimePolyfillPlan 객체 파싱 헬퍼 ───
+// JS wrapper 가 8 개 parallel 배열 대신 단일 객체로 plan 을 넘기게 했으므로
+// 여기서 한 번에 푼다. 길이 equality 같은 invariant 가 객체 구조에 자연스럽게 들어가
+// 별도 검증이 필요 없다.
+
+const RuntimePolyfillParseError = error{InvalidPlan} || std.mem.Allocator.Error;
+
+// 호출처에서 alloc 은 항상 native_alloc 이라, 양쪽이 갈라지면 owned_strings 와
+// 다른 allocator 로 free 시도해서 곧 망가진다. 시그니처에서 alloc 을 제거해
+// 일관성을 강제한다.
+fn ownPlanString(
+    env: c.napi_env,
+    elem: c.napi_value,
+    key: [*:0]const u8,
+    error_msg: [*:0]const u8,
+    owned_strings: *std.ArrayList([]const u8),
+) RuntimePolyfillParseError![]const u8 {
+    const s = getObjectString(env, elem, key, native_alloc) orelse {
+        _ = throwError(env, error_msg);
+        return error.InvalidPlan;
+    };
+    errdefer native_alloc.free(s);
+    try owned_strings.append(native_alloc, s);
+    return s;
+}
+
+fn planArrayLen(env: c.napi_env, arr_val: c.napi_value, error_msg: [*:0]const u8) RuntimePolyfillParseError!u32 {
+    var is_array: bool = false;
+    _ = c.napi_is_array(env, arr_val, &is_array);
+    if (!is_array) {
+        _ = throwError(env, error_msg);
+        return error.InvalidPlan;
+    }
+    var len: u32 = 0;
+    _ = c.napi_get_array_length(env, arr_val, &len);
+    return len;
+}
+
+fn parseRuntimePolyfillCandidatesArray(
+    env: c.napi_env,
+    plan_val: c.napi_value,
+    owned_strings: *std.ArrayList([]const u8),
+) RuntimePolyfillParseError![]const bundler_mod.runtime_polyfills.Candidate {
+    const arr_val = getNamedProperty(env, plan_val, "candidates") orelse return &.{};
+    const len = try planArrayLen(env, arr_val, "runtimePolyfillPlan.candidates must be an array");
+    if (len == 0) return &.{};
+    const buf = try native_alloc.alloc(bundler_mod.runtime_polyfills.Candidate, len);
+    errdefer native_alloc.free(buf);
+    for (0..len) |i| {
+        var elem: c.napi_value = undefined;
+        if (c.napi_get_element(env, arr_val, @intCast(i), &elem) != c.napi_ok) {
+            _ = throwError(env, "runtimePolyfillPlan.candidates entry inaccessible");
+            return error.InvalidPlan;
+        }
+        const feature = try ownPlanString(env, elem, "feature", "runtimePolyfillPlan.candidates[].feature missing", owned_strings);
+        if (feature.len == 0) {
+            _ = throwError(env, "runtimePolyfillPlan.candidates[].feature must be non-empty");
+            return error.InvalidPlan;
+        }
+        const module = try ownPlanString(env, elem, "module", "runtimePolyfillPlan.candidates[].module missing", owned_strings);
+        const path = try ownPlanString(env, elem, "path", "runtimePolyfillPlan.candidates[].path missing", owned_strings);
+        buf[i] = .{ .feature = feature, .module = module, .path = path };
+    }
+    return buf;
+}
+
+fn parseRuntimePolyfillResolvedArray(
+    env: c.napi_env,
+    plan_val: c.napi_value,
+    key: [*:0]const u8,
+    owned_strings: *std.ArrayList([]const u8),
+) RuntimePolyfillParseError![]const bundler_mod.runtime_polyfills.ResolvedModule {
+    const arr_val = getNamedProperty(env, plan_val, key) orelse return &.{};
+    const len = try planArrayLen(env, arr_val, "runtimePolyfillPlan resolved-module array must be an array");
+    if (len == 0) return &.{};
+    const buf = try native_alloc.alloc(bundler_mod.runtime_polyfills.ResolvedModule, len);
+    errdefer native_alloc.free(buf);
+    for (0..len) |i| {
+        var elem: c.napi_value = undefined;
+        if (c.napi_get_element(env, arr_val, @intCast(i), &elem) != c.napi_ok) {
+            _ = throwError(env, "runtimePolyfillPlan resolved-module entry inaccessible");
+            return error.InvalidPlan;
+        }
+        const module = try ownPlanString(env, elem, "module", "runtimePolyfillPlan resolved-module[].module missing", owned_strings);
+        const path = try ownPlanString(env, elem, "path", "runtimePolyfillPlan resolved-module[].path missing", owned_strings);
+        buf[i] = .{ .module = module, .path = path };
+    }
+    return buf;
+}
+
+fn parseRuntimePolyfillPlan(
+    env: c.napi_env,
+    opts_obj: c.napi_value,
+    owned_strings: *std.ArrayList([]const u8),
+    owned_string_arrays: *std.ArrayList([]const []const u8),
+) RuntimePolyfillParseError!?bundler_mod.runtime_polyfills.Plan {
+    const plan_val = getNamedProperty(env, opts_obj, "runtimePolyfillPlan") orelse return null;
+
+    const mode_str = try ownPlanString(env, plan_val, "mode", "runtimePolyfillPlan.mode missing", owned_strings);
+    const mode = bundler_mod.runtime_polyfills.Mode.fromString(mode_str) orelse {
+        _ = throwError(env, "runtimePolyfillPlan.mode unknown");
+        return error.InvalidPlan;
+    };
+
+    const candidates = try parseRuntimePolyfillCandidatesArray(env, plan_val, owned_strings);
+    const entry_modules = try parseRuntimePolyfillResolvedArray(env, plan_val, "entry", owned_strings);
+    const include = try parseRuntimePolyfillResolvedArray(env, plan_val, "include", owned_strings);
+
+    var exclude: []const []const u8 = &.{};
+    if (getNamedProperty(env, plan_val, "exclude")) |arr_val| {
+        const parsed = parseStringArray(env, arr_val, native_alloc) orelse {
+            _ = throwError(env, "runtimePolyfillPlan.exclude must be a string array");
+            return error.InvalidPlan;
+        };
+        for (parsed) |s| try owned_strings.append(native_alloc, s);
+        try owned_string_arrays.append(native_alloc, parsed);
+        exclude = parsed;
+    }
+
+    return .{
+        .mode = mode,
+        .candidates = candidates,
+        .entry_modules = entry_modules,
+        .include = include,
+        .exclude = exclude,
+    };
+}
+
 // ─── buildSync 함수 ───
 
 fn napiBuildSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
@@ -3806,131 +3934,7 @@ fn parseBuildOptions(
         if (!trackArr(owned_string_arrays, arr)) return null;
     }
 
-    const runtime_polyfill_mode_str = getObjectString(env, opts_obj, "runtimePolyfillModeNative", native_alloc);
-    if (runtime_polyfill_mode_str) |s| if (!trackStr(owned_strings, s)) return null;
-
-    const runtime_candidate_features = getObjectStringArray(env, opts_obj, "runtimePolyfillCandidateFeatures", native_alloc);
-    if (runtime_candidate_features) |arr| {
-        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
-        if (!trackArr(owned_string_arrays, arr)) return null;
-    }
-    const runtime_candidate_modules = getObjectStringArray(env, opts_obj, "runtimePolyfillCandidateModules", native_alloc);
-    if (runtime_candidate_modules) |arr| {
-        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
-        if (!trackArr(owned_string_arrays, arr)) return null;
-    }
-    const runtime_candidate_paths = getObjectStringArray(env, opts_obj, "runtimePolyfillCandidatePaths", native_alloc);
-    if (runtime_candidate_paths) |arr| {
-        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
-        if (!trackArr(owned_string_arrays, arr)) return null;
-    }
-    const runtime_entry_modules = getObjectStringArray(env, opts_obj, "runtimePolyfillEntryModules", native_alloc);
-    if (runtime_entry_modules) |arr| {
-        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
-        if (!trackArr(owned_string_arrays, arr)) return null;
-    }
-    const runtime_entry_paths = getObjectStringArray(env, opts_obj, "runtimePolyfillEntryPaths", native_alloc);
-    if (runtime_entry_paths) |arr| {
-        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
-        if (!trackArr(owned_string_arrays, arr)) return null;
-    }
-    const runtime_include_modules = getObjectStringArray(env, opts_obj, "runtimePolyfillIncludeModules", native_alloc);
-    if (runtime_include_modules) |arr| {
-        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
-        if (!trackArr(owned_string_arrays, arr)) return null;
-    }
-    const runtime_include_paths = getObjectStringArray(env, opts_obj, "runtimePolyfillIncludePaths", native_alloc);
-    if (runtime_include_paths) |arr| {
-        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
-        if (!trackArr(owned_string_arrays, arr)) return null;
-    }
-    const runtime_exclude_modules = getObjectStringArray(env, opts_obj, "runtimePolyfillExcludeModules", native_alloc);
-    if (runtime_exclude_modules) |arr| {
-        for (arr) |s| if (!trackStr(owned_strings, s)) return null;
-        if (!trackArr(owned_string_arrays, arr)) return null;
-    }
-
-    const runtime_polyfill_plan: ?bundler_mod.runtime_polyfills.Plan = blk: {
-        const mode_s = runtime_polyfill_mode_str orelse break :blk null;
-        const mode = bundler_mod.runtime_polyfills.Mode.fromString(mode_s) orelse {
-            _ = throwError(env, "invalid runtime polyfill native mode");
-            return null;
-        };
-
-        var candidates: []const bundler_mod.runtime_polyfills.Candidate = &.{};
-        if (runtime_candidate_features) |features| {
-            const modules = runtime_candidate_modules orelse {
-                _ = throwError(env, "invalid runtime polyfill candidate plan");
-                return null;
-            };
-            const paths = runtime_candidate_paths orelse {
-                _ = throwError(env, "invalid runtime polyfill candidate plan");
-                return null;
-            };
-            if (features.len != modules.len or modules.len != paths.len) {
-                _ = throwError(env, "invalid runtime polyfill candidate plan");
-                return null;
-            }
-            if (features.len > 0) {
-                const buf = native_alloc.alloc(bundler_mod.runtime_polyfills.Candidate, features.len) catch return null;
-                for (features, 0..) |feature_s, i| {
-                    if (feature_s.len == 0) {
-                        _ = throwError(env, "invalid runtime polyfill feature");
-                        native_alloc.free(buf);
-                        return null;
-                    }
-                    buf[i] = .{ .feature = feature_s, .module = modules[i], .path = paths[i] };
-                }
-                candidates = buf;
-            }
-        }
-
-        var entry_modules: []const bundler_mod.runtime_polyfills.ResolvedModule = &.{};
-        if (runtime_entry_modules) |modules| {
-            const paths = runtime_entry_paths orelse {
-                _ = throwError(env, "invalid runtime polyfill entry plan");
-                return null;
-            };
-            if (modules.len != paths.len) {
-                _ = throwError(env, "invalid runtime polyfill entry plan");
-                return null;
-            }
-            if (modules.len > 0) {
-                const buf = native_alloc.alloc(bundler_mod.runtime_polyfills.ResolvedModule, modules.len) catch return null;
-                for (modules, 0..) |module_name, i| {
-                    buf[i] = .{ .module = module_name, .path = paths[i] };
-                }
-                entry_modules = buf;
-            }
-        }
-
-        var include: []const bundler_mod.runtime_polyfills.ResolvedModule = &.{};
-        if (runtime_include_modules) |modules| {
-            const paths = runtime_include_paths orelse {
-                _ = throwError(env, "invalid runtime polyfill include plan");
-                return null;
-            };
-            if (modules.len != paths.len) {
-                _ = throwError(env, "invalid runtime polyfill include plan");
-                return null;
-            }
-            if (modules.len > 0) {
-                const buf = native_alloc.alloc(bundler_mod.runtime_polyfills.ResolvedModule, modules.len) catch return null;
-                for (modules, 0..) |module_name, i| {
-                    buf[i] = .{ .module = module_name, .path = paths[i] };
-                }
-                include = buf;
-            }
-        }
-
-        break :blk .{
-            .mode = mode,
-            .candidates = candidates,
-            .entry_modules = entry_modules,
-            .include = include,
-            .exclude = runtime_exclude_modules orelse &.{},
-        };
-    };
+    const runtime_polyfill_plan = parseRuntimePolyfillPlan(env, opts_obj, owned_strings, owned_string_arrays) catch return null;
 
     // silentConsoleErrorPatterns: string[] (RegExp source strings)
     const silent_console_error_patterns = getObjectStringArray(env, opts_obj, "silentConsoleErrorPatterns", native_alloc);

--- a/packages/core/src/runtime-polyfills.test.ts
+++ b/packages/core/src/runtime-polyfills.test.ts
@@ -1,12 +1,18 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
 import { describe, expect, test } from "bun:test";
 
 import {
   __runtimePolyfillTestHooks,
+  __runtimePolyfillTestInternals,
   applyRuntimePolyfillsToNapiOptions,
   computeCoreJsCompatModules,
   isEsTarget,
   normalizeRuntimePolyfillOptions,
   normalizeRuntimeTargets,
+  type RuntimePolyfillNativePlan,
 } from "./runtime-polyfills.ts";
 
 function withRuntimeRequire<T>(runtimeRequire: any, fn: () => T): T {
@@ -16,6 +22,10 @@ function withRuntimeRequire<T>(runtimeRequire: any, fn: () => T): T {
   } finally {
     __runtimePolyfillTestHooks.reset();
   }
+}
+
+function plan(napiOptions: Record<string, unknown>): RuntimePolyfillNativePlan | undefined {
+  return napiOptions.runtimePolyfillPlan as RuntimePolyfillNativePlan | undefined;
 }
 
 function makeRuntimeRequire(listForModules: (modules: string[] | RegExp | undefined) => string[]) {
@@ -223,12 +233,11 @@ describe("runtime polyfill native plan", () => {
 
       expect(applied.modules).toContain("es.string.replace-all");
       expect(applied.modules).not.toContain("es.set");
-      expect(napiOptions.runtimePolyfillModeNative).toBe("usage");
-      expect(napiOptions.runtimePolyfillCandidateFeatures).toContain("string_replace_all");
-      expect(napiOptions.runtimePolyfillCandidateModules).toContain("es.string.replace-all");
-      expect((napiOptions.runtimePolyfillCandidatePaths as string[])[0]).toStartWith(
-        "/virtual/core-js/modules/",
-      );
+      const p = plan(napiOptions)!;
+      expect(p.mode).toBe("usage");
+      expect(p.candidates!.map((c) => c.feature)).toContain("string_replace_all");
+      expect(p.candidates!.map((c) => c.module)).toContain("es.string.replace-all");
+      expect(p.candidates![0].path).toStartWith("/virtual/core-js/modules/");
       expect(napiOptions.runBeforeMain).toBeUndefined();
       applied.cleanup();
     });
@@ -262,7 +271,10 @@ describe("runtime polyfill native plan", () => {
         runtimePolyfills: { mode: "auto", targets: ["safari 5"] },
       });
 
-      expect(napiOptions.runtimePolyfillCandidateModules).toEqual(
+      const p = plan(napiOptions)!;
+      const candidateModules = p.candidates!.map((c) => c.module);
+      const candidateFeatures = p.candidates!.map((c) => c.feature);
+      expect(candidateModules).toEqual(
         expect.arrayContaining([
           "es.array.at",
           "es.array.find-last",
@@ -282,11 +294,11 @@ describe("runtime polyfill native plan", () => {
           "web.url",
         ]),
       );
-      expect(napiOptions.runtimePolyfillCandidateFeatures).toContain("map_group_by");
-      expect(napiOptions.runtimePolyfillCandidateFeatures).toContain("set_union");
-      expect(napiOptions.runtimePolyfillCandidateFeatures).toContain("promise_any");
-      expect(napiOptions.runtimePolyfillCandidateFeatures).toContain("object_values");
-      expect(napiOptions.runtimePolyfillCandidateModules).not.toContain("es.map.constructor");
+      expect(candidateFeatures).toContain("map_group_by");
+      expect(candidateFeatures).toContain("set_union");
+      expect(candidateFeatures).toContain("promise_any");
+      expect(candidateFeatures).toContain("object_values");
+      expect(candidateModules).not.toContain("es.map.constructor");
       applied.cleanup();
     });
   });
@@ -307,9 +319,10 @@ describe("runtime polyfill native plan", () => {
       });
 
       expect(applied.modules).toEqual(["es.promise"]);
-      expect(napiOptions.runtimePolyfillModeNative).toBe("usage");
-      expect(napiOptions.runtimePolyfillIncludeModules).toEqual(["es.promise"]);
-      expect(napiOptions.runtimePolyfillExcludeModules).toEqual(["es.array.at"]);
+      const p = plan(napiOptions)!;
+      expect(p.mode).toBe("usage");
+      expect(p.include!.map((i) => i.module)).toEqual(["es.promise"]);
+      expect(p.exclude).toEqual(["es.array.at"]);
       expect(napiOptions.runBeforeMain).toBeUndefined();
       applied.cleanup();
     });
@@ -341,7 +354,7 @@ describe("runtime polyfill native plan", () => {
       expect(applied.modules).toEqual([]);
       expect(napiOptions.runtimePolyfills).toBeUndefined();
       expect(napiOptions.coreJs).toBeUndefined();
-      expect(napiOptions.runtimePolyfillModeNative).toBeUndefined();
+      expect(plan(napiOptions)).toBeUndefined();
       applied.cleanup();
     });
   });
@@ -367,9 +380,10 @@ describe("runtime polyfill native plan", () => {
 
       expect(applied.modules).toContain("es.array.at");
       expect(applied.modules).not.toContain("es.string.replace-all");
-      expect(napiOptions.runtimePolyfillModeNative).toBe("usage");
-      expect(napiOptions.runtimePolyfillIncludeModules).toEqual(["es.array.at"]);
-      expect(napiOptions.runtimePolyfillExcludeModules).toEqual(["es.string.replace-all"]);
+      const p = plan(napiOptions)!;
+      expect(p.mode).toBe("usage");
+      expect(p.include!.map((i) => i.module)).toEqual(["es.array.at"]);
+      expect(p.exclude).toEqual(["es.string.replace-all"]);
       expect(napiOptions.runBeforeMain).toBeUndefined();
       applied.cleanup();
     });
@@ -388,12 +402,10 @@ describe("runtime polyfill native plan", () => {
       });
 
       expect(applied.modules).toEqual(["es.array.at", "es.promise", "web.structured-clone"]);
-      expect(napiOptions.runtimePolyfillModeNative).toBe("entry");
-      expect(napiOptions.runtimePolyfillEntryModules).toEqual([
-        "es.promise",
-        "web.structured-clone",
-      ]);
-      expect(napiOptions.runtimePolyfillIncludeModules).toEqual(["es.array.at"]);
+      const p = plan(napiOptions)!;
+      expect(p.mode).toBe("entry");
+      expect(p.entry!.map((e) => e.module)).toEqual(["es.promise", "web.structured-clone"]);
+      expect(p.include!.map((i) => i.module)).toEqual(["es.array.at"]);
       applied.cleanup();
     });
   });
@@ -409,7 +421,7 @@ describe("runtime polyfill native plan", () => {
       });
 
       expect(applied.modules).toEqual([]);
-      expect(napiOptions.runtimePolyfillModeNative).toBeUndefined();
+      expect(plan(napiOptions)).toBeUndefined();
       applied.cleanup();
     });
   });
@@ -423,9 +435,7 @@ describe("runtime polyfill native plan", () => {
     });
 
     expect(applied.modules).toContain("es.array.at");
-    expect((napiOptions.runtimePolyfillIncludePaths as string[])[0]).toContain(
-      "core-js/modules/es.array.at.js",
-    );
+    expect(plan(napiOptions)!.include![0].path).toContain("core-js/modules/es.array.at.js");
     applied.cleanup();
   });
 
@@ -468,8 +478,34 @@ describe("runtime polyfill native plan", () => {
         runtimePolyfills: { mode: "auto", targets: ["node 18"] },
       });
       expect(empty.modules).toEqual([]);
-      expect(napiOptions.runtimePolyfillModeNative).toBeUndefined();
+      expect(plan(napiOptions)).toBeUndefined();
       empty.cleanup();
     });
+  });
+});
+
+describe("Zig collector ↔ TS feature module table sync", () => {
+  // Zig 의 collector 가 emit 하는 feature 키마다 TS 측에 최소 하나의 core-js
+  // module 매핑이 있어야 한다. 누락되면 candidate 가 NAPI 로 전달되지 않아
+  // detection 은 일어나지만 polyfill 이 적용되지 않는 silent miss 가 된다.
+  test("every feature emitted by runtime_polyfills.zig has a matching core-js module entry", () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const repoRoot = resolve(here, "..", "..", "..");
+    const zigSource = readFileSync(resolve(repoRoot, "src/bundler/runtime_polyfills.zig"), "utf-8");
+
+    const zigFeatures = new Set<string>();
+    const featureRegex =
+      /\.feature\s*=\s*"([^"]+)"|out\.insert\s*\(\s*allocator\s*,\s*"([^"]+)"\s*\)/g;
+    for (const match of zigSource.matchAll(featureRegex)) {
+      const key = match[1] ?? match[2];
+      if (key) zigFeatures.add(key);
+    }
+    expect(zigFeatures.size).toBeGreaterThan(0);
+
+    const tsFeatures = new Set(
+      __runtimePolyfillTestInternals.featureModules.map((entry) => entry.feature),
+    );
+    const missingFromTs = [...zigFeatures].filter((f) => !tsFeatures.has(f)).sort();
+    expect(missingFromTs).toEqual([]);
   });
 });

--- a/packages/core/src/runtime-polyfills.ts
+++ b/packages/core/src/runtime-polyfills.ts
@@ -70,13 +70,22 @@ type CoreJsCompat = (options: {
 
 type RuntimePolyfillFeature = string;
 
-interface ResolvedRuntimeModule {
+export interface ResolvedRuntimeModule {
   module: string;
   path: string;
 }
 
-interface ResolvedRuntimeCandidate extends ResolvedRuntimeModule {
+export interface ResolvedRuntimeCandidate extends ResolvedRuntimeModule {
   feature: RuntimePolyfillFeature;
+}
+
+/** NAPI 로 전달되는 단일 plan 객체. usage 모드는 candidates, entry 모드는 entry 를 채운다. */
+export interface RuntimePolyfillNativePlan {
+  mode: "usage" | "entry";
+  candidates?: readonly ResolvedRuntimeCandidate[];
+  entry?: readonly ResolvedRuntimeModule[];
+  include?: readonly ResolvedRuntimeModule[];
+  exclude?: readonly string[];
 }
 
 let runtimeRequireOverride: RuntimeRequire | null = null;
@@ -96,6 +105,13 @@ export const __runtimePolyfillTestHooks = {
     coreJsCompatCache = undefined;
     coreJsVersionCache = undefined;
     runtimeRequireOverride = runtimeRequire;
+  },
+};
+
+/** @internal — Zig 매핑 테이블과의 sync 검증용. 외부 사용자는 사용 금지. */
+export const __runtimePolyfillTestInternals = {
+  get featureModules() {
+    return RUNTIME_POLYFILL_FEATURE_MODULES;
   },
 };
 
@@ -622,15 +638,6 @@ function resolveRuntimeModules(
   }));
 }
 
-function assignResolvedModuleArrays(
-  napiOptions: Record<string, unknown>,
-  prefix: string,
-  modules: readonly ResolvedRuntimeModule[],
-): void {
-  napiOptions[`${prefix}Modules`] = modules.map((item) => item.module);
-  napiOptions[`${prefix}Paths`] = modules.map((item) => item.path);
-}
-
 export function applyRuntimePolyfillsToNapiOptions(
   napiOptions: Record<string, unknown>,
   options: RuntimePolyfillBuildOptions,
@@ -657,10 +664,12 @@ export function applyRuntimePolyfillsToNapiOptions(
     if (entryResolved.length === 0 && includeResolved.length === 0) {
       return { cleanup: () => {}, modules: [] };
     }
-    napiOptions.runtimePolyfillModeNative = "entry";
-    assignResolvedModuleArrays(napiOptions, "runtimePolyfillEntry", entryResolved);
-    assignResolvedModuleArrays(napiOptions, "runtimePolyfillInclude", includeResolved);
-    napiOptions.runtimePolyfillExcludeModules = runtime.exclude;
+    napiOptions.runtimePolyfillPlan = {
+      mode: "entry",
+      entry: entryResolved,
+      include: includeResolved,
+      exclude: runtime.exclude,
+    };
     return {
       cleanup: () => {},
       modules: uniqueSorted([...entryResolved, ...includeResolved].map((item) => item.module)),
@@ -687,12 +696,12 @@ export function applyRuntimePolyfillsToNapiOptions(
     return { cleanup: () => {}, modules: [] };
   }
 
-  napiOptions.runtimePolyfillModeNative = "usage";
-  napiOptions.runtimePolyfillCandidateFeatures = candidates.map((item) => item.feature);
-  napiOptions.runtimePolyfillCandidateModules = candidates.map((item) => item.module);
-  napiOptions.runtimePolyfillCandidatePaths = candidates.map((item) => item.path);
-  assignResolvedModuleArrays(napiOptions, "runtimePolyfillInclude", includeResolved);
-  napiOptions.runtimePolyfillExcludeModules = runtime.exclude;
+  napiOptions.runtimePolyfillPlan = {
+    mode: "usage",
+    candidates,
+    include: includeResolved,
+    exclude: runtime.exclude,
+  };
 
   return {
     cleanup: () => {},

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -677,11 +677,12 @@ pub const ModuleGraph = struct {
     fn debugRuntimePolyfillUsage(self: *ModuleGraph, module_path: []const u8, usage: runtime_polyfills.FeatureSet) void {
         _ = self;
         if (!debug_log.enabled(.runtime_polyfills)) return;
-        for (usage.items[0..usage.len]) |feature| {
+        var it = usage.keyIterator();
+        while (it.next()) |feature| {
             debug_log.print(
                 .runtime_polyfills,
                 "mode=usage module={s} feature={s} decision=detected\n",
-                .{ module_path, feature },
+                .{ module_path, feature.* },
             );
         }
     }

--- a/src/bundler/runtime_polyfills.zig
+++ b/src/bundler/runtime_polyfills.zig
@@ -27,39 +27,33 @@ pub const Mode = enum {
 pub const Feature = []const u8;
 
 pub const FeatureSet = struct {
-    const max_features = 512;
+    const Map = std.StringHashMapUnmanaged(void);
 
-    items: [max_features]Feature = undefined,
-    len: usize = 0,
+    set: Map = .{},
 
     pub fn deinit(self: *FeatureSet, allocator: std.mem.Allocator) void {
-        _ = self;
-        _ = allocator;
+        self.set.deinit(allocator);
     }
 
     pub fn insert(self: *FeatureSet, allocator: std.mem.Allocator, feature: Feature) !void {
-        _ = allocator;
-        if (self.has(feature)) return;
-        if (self.len >= max_features) return error.OutOfMemory;
-        self.items[self.len] = feature;
-        self.len += 1;
+        try self.set.put(allocator, feature, {});
     }
 
     pub fn has(self: FeatureSet, feature: Feature) bool {
-        for (self.items[0..self.len]) |existing| {
-            if (std.mem.eql(u8, existing, feature)) return true;
-        }
-        return false;
+        return self.set.contains(feature);
     }
 
     pub fn merge(self: *FeatureSet, allocator: std.mem.Allocator, other: FeatureSet) !void {
-        for (other.items[0..other.len]) |feature| {
-            try self.insert(allocator, feature);
-        }
+        var it = other.set.keyIterator();
+        while (it.next()) |key| try self.set.put(allocator, key.*, {});
     }
 
     pub fn isEmpty(self: FeatureSet) bool {
-        return self.len == 0;
+        return self.set.count() == 0;
+    }
+
+    pub fn keyIterator(self: *const FeatureSet) Map.KeyIterator {
+        return self.set.keyIterator();
     }
 };
 
@@ -87,7 +81,32 @@ const NameFeature = struct {
     feature: []const u8,
 };
 
-const global_features = [_]NameFeature{
+fn lessByName(_: void, a: NameFeature, b: NameFeature) bool {
+    return std.mem.lessThan(u8, a.name, b.name);
+}
+
+fn comptimeSortByName(comptime entries: anytype) [entries.len]NameFeature {
+    @setEvalBranchQuota(50000);
+    var sorted: [entries.len]NameFeature = entries;
+    std.mem.sort(NameFeature, &sorted, {}, lessByName);
+    return sorted;
+}
+
+fn lowerBoundByName(haystack: []const NameFeature, name: []const u8) usize {
+    var lo: usize = 0;
+    var hi: usize = haystack.len;
+    while (lo < hi) {
+        const mid = lo + (hi - lo) / 2;
+        if (std.mem.lessThan(u8, haystack[mid].name, name)) {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    return lo;
+}
+
+const global_features_unsorted = [_]NameFeature{
     .{ .name = "AggregateError", .feature = "aggregate_error" },
     .{ .name = "ArrayBuffer", .feature = "array_buffer" },
     .{ .name = "AsyncDisposableStack", .feature = "async_disposable_stack" },
@@ -129,7 +148,7 @@ const global_features = [_]NameFeature{
     .{ .name = "unescape", .feature = "unescape" },
 };
 
-const prototype_member_features = [_]NameFeature{
+const prototype_member_features_unsorted = [_]NameFeature{
     .{ .name = "anchor", .feature = "string_anchor" },
     .{ .name = "at", .feature = "array_at" },
     .{ .name = "at", .feature = "typed_array_at" },
@@ -268,7 +287,7 @@ const prototype_member_features = [_]NameFeature{
     .{ .name = "__proto__", .feature = "object_proto" },
 };
 
-const static_member_features = [_]NameFeature{
+const static_member_features_unsorted = [_]NameFeature{
     .{ .name = "Array.from", .feature = "array_from" },
     .{ .name = "Array.fromAsync", .feature = "array_from_async" },
     .{ .name = "Array.isArray", .feature = "array_is_array" },
@@ -373,6 +392,10 @@ const static_member_features = [_]NameFeature{
     .{ .name = "Uint8Array.fromBase64", .feature = "uint8_array_from_base64" },
     .{ .name = "Uint8Array.fromHex", .feature = "uint8_array_from_hex" },
 };
+
+const global_features = comptimeSortByName(global_features_unsorted);
+const prototype_member_features = comptimeSortByName(prototype_member_features_unsorted);
+const static_member_features = comptimeSortByName(static_member_features_unsorted);
 
 pub fn collectModuleUsage(allocator: std.mem.Allocator, module: *const Module) !FeatureSet {
     if (!module.module_type.isJavaScriptLike()) return .{};
@@ -522,10 +545,9 @@ fn insertFeaturesForName(
     name: []const u8,
     mappings: []const NameFeature,
 ) !void {
-    for (mappings) |mapping| {
-        if (std.mem.eql(u8, name, mapping.name)) {
-            try out.insert(allocator, mapping.feature);
-        }
+    var i = lowerBoundByName(mappings, name);
+    while (i < mappings.len and std.mem.eql(u8, mappings[i].name, name)) : (i += 1) {
+        try out.insert(allocator, mappings[i].feature);
     }
 }
 
@@ -613,7 +635,7 @@ fn isGlobalIdentifierNamed(
 }
 
 test "runtime polyfill collector detects v1 global and member usage" {
-    const usage = try testCollect(
+    var usage = try testCollect(
         \\const a = "a".replaceAll("a", "b");
         \\const b = values.at(0);
         \\const c = Object.hasOwn({ a: 1 }, "a");
@@ -623,6 +645,7 @@ test "runtime polyfill collector detects v1 global and member usage" {
         \\const g = Promise.resolve(d);
         \\void [a, b, c, d, e, f, g];
     );
+    defer usage.deinit(std.testing.allocator);
     try std.testing.expect(usage.has("string_replace_all"));
     try std.testing.expect(usage.has("array_at"));
     try std.testing.expect(usage.has("object_has_own"));
@@ -633,7 +656,7 @@ test "runtime polyfill collector detects v1 global and member usage" {
 }
 
 test "runtime polyfill collector detects explicit globalThis references" {
-    const usage = try testCollect(
+    var usage = try testCollect(
         \\const a = new globalThis.Map();
         \\const b = new globalThis.Set();
         \\const c = globalThis.Promise.resolve(a);
@@ -641,6 +664,7 @@ test "runtime polyfill collector detects explicit globalThis references" {
         \\const e = globalThis.Object.hasOwn({ a: 1 }, "a");
         \\void [a, b, c, d, e];
     );
+    defer usage.deinit(std.testing.allocator);
     try std.testing.expect(usage.has("map"));
     try std.testing.expect(usage.has("set"));
     try std.testing.expect(usage.has("promise"));
@@ -649,7 +673,7 @@ test "runtime polyfill collector detects explicit globalThis references" {
 }
 
 test "runtime polyfill collector detects expanded core-js built-ins" {
-    const usage = try testCollect(
+    var usage = try testCollect(
         \\const a = Object.values({ a: 1 });
         \\const b = [1, 2, 3].findLast((value) => value < 3);
         \\const c = "7".padStart(2, "0");
@@ -665,6 +689,7 @@ test "runtime polyfill collector detects expanded core-js built-ins" {
         \\const m = queueMicrotask(() => {});
         \\void [a, b, c, d, e, f, g, h, i, k, l, m];
     );
+    defer usage.deinit(std.testing.allocator);
     try std.testing.expect(usage.has("object_values"));
     try std.testing.expect(usage.has("array_find_last"));
     try std.testing.expect(usage.has("string_pad_start"));
@@ -684,7 +709,7 @@ test "runtime polyfill collector detects expanded core-js built-ins" {
 }
 
 test "runtime polyfill collector ignores shadowed and imported globals" {
-    const usage = try testCollect(
+    var usage = try testCollect(
         \\import { Map, Object as ImportedObject } from "pkg";
         \\const Promise = { resolve() {} };
         \\function run(structuredClone) {
@@ -697,6 +722,7 @@ test "runtime polyfill collector ignores shadowed and imported globals" {
         \\}
         \\run();
     );
+    defer usage.deinit(std.testing.allocator);
     try std.testing.expect(!usage.has("map"));
     try std.testing.expect(!usage.has("set"));
     try std.testing.expect(!usage.has("promise"));
@@ -705,7 +731,7 @@ test "runtime polyfill collector ignores shadowed and imported globals" {
 }
 
 test "runtime polyfill collector ignores type-only references and shadowed globalThis" {
-    const usage = try testCollectTyped(
+    var usage = try testCollectTyped(
         \\type Cache = Map<string, Set<number>>;
         \\interface Work {
         \\  done: Promise<void>;
@@ -719,6 +745,7 @@ test "runtime polyfill collector ignores type-only references and shadowed globa
         \\globalThis.Promise.resolve();
         \\globalThis.Object.hasOwn({}, "x");
     );
+    defer usage.deinit(std.testing.allocator);
     try std.testing.expect(!usage.has("map"));
     try std.testing.expect(!usage.has("set"));
     try std.testing.expect(!usage.has("promise"));
@@ -726,13 +753,14 @@ test "runtime polyfill collector ignores type-only references and shadowed globa
 }
 
 test "runtime polyfill collector ignores dynamic computed member access" {
-    const usage = try testCollect(
+    var usage = try testCollect(
         \\const method = "resolve";
         \\Promise[method]();
         \\value[method]("x");
         \\globalThis["Map"];
         \\globalThis.Object["hasOwn"]({}, "x");
     );
+    defer usage.deinit(std.testing.allocator);
     try std.testing.expect(!usage.has("promise"));
     try std.testing.expect(!usage.has("map"));
     try std.testing.expect(!usage.has("object_has_own"));
@@ -779,5 +807,7 @@ fn testCollectWithModuleType(source: []const u8, module_type: ModuleType) !Featu
         .references = analyzer.references.items,
         .numeric_const_texts = analyzer.numeric_const_texts,
     };
-    return collectModuleUsage(allocator, &module);
+    // arena 는 helper 종료 시 deinit 되므로, FeatureSet 은 호출자가 직접 deinit 할 수
+    // 있도록 std.testing.allocator 로 분리해 빌드한다.
+    return collectModuleUsage(std.testing.allocator, &module);
 }

--- a/src/bundler/runtime_polyfills.zig
+++ b/src/bundler/runtime_polyfills.zig
@@ -92,18 +92,8 @@ fn comptimeSortByName(comptime entries: anytype) [entries.len]NameFeature {
     return sorted;
 }
 
-fn lowerBoundByName(haystack: []const NameFeature, name: []const u8) usize {
-    var lo: usize = 0;
-    var hi: usize = haystack.len;
-    while (lo < hi) {
-        const mid = lo + (hi - lo) / 2;
-        if (std.mem.lessThan(u8, haystack[mid].name, name)) {
-            lo = mid + 1;
-        } else {
-            hi = mid;
-        }
-    }
-    return lo;
+fn cmpNameVsEntry(needle: []const u8, item: NameFeature) std.math.Order {
+    return std.mem.order(u8, needle, item.name);
 }
 
 const global_features_unsorted = [_]NameFeature{
@@ -545,7 +535,7 @@ fn insertFeaturesForName(
     name: []const u8,
     mappings: []const NameFeature,
 ) !void {
-    var i = lowerBoundByName(mappings, name);
+    var i = std.sort.lowerBound(NameFeature, mappings, name, cmpNameVsEntry);
     while (i < mappings.len and std.mem.eql(u8, mappings[i].name, name)) : (i += 1) {
         try out.insert(allocator, mappings[i].feature);
     }


### PR DESCRIPTION
## Summary

PR #2521 리뷰 follow-up 3 건을 한 PR 로 묶었습니다. 동작 변경 없는 정합성/정리 위주이고, 모든 회귀 테스트 통과합니다.

1. runtime polyfill collector hot path 자료구조 정리 (b54fe36e)
2. NAPI DTO 8 키 → 단일 runtimePolyfillPlan 객체로 캡슐화 + TS↔Zig feature key sync 검증 추가 (d71611a8 / 999d2921)

리뷰에서 지적한 항목 중 두 가지 는 보류했습니다.
- parseRuntimePolyfillCandidatesArray / parseRuntimePolyfillResolvedArray 통합 — generic comptime field 으로 합치면 key path 포함된 에러 메시지 specificity 가 희석돼서 trade-off. 현재 형태가 디버깅 친화적이라 유지.
- sync test regex 강건성 — `.feature = "x"` 패턴이 다른 컨텍스트에서 false-match 할 가능성은 있지만, 현재 collector 는 해당 패턴을 collector 매핑 테이블에서만 사용. 실제 false positive 발생 시 강화 예정.

## 1. FeatureSet → StringHashMap (b54fe36e)

기존 `[512]Feature` 선형 스캔을 `std.StringHashMapUnmanaged(void)` 로 교체.

```zig
pub const FeatureSet = struct {
    const Map = std.StringHashMapUnmanaged(void);
    set: Map = .{},
    pub fn has(self, feature) bool { return self.set.contains(feature); }       // O(N) → O(1)
    pub fn insert(self, alloc, feature) !void { try self.set.put(alloc, feature, {}); } // O(N) → O(1)
    pub fn merge(self, alloc, other) !void { var it = other.set.keyIterator(); ... }   // O(N²) → O(N)
    pub fn keyIterator(self) Map.KeyIterator { ... }
    pub fn deinit(self, alloc) void { self.set.deinit(alloc); }
};
```

키는 정적 feature literal 들 (`"string_replace_all"` 등) 이라 hashmap 이 별도 string copy 없이 pointer 만 저장합니다.

매핑 테이블 (`global_features` / `prototype_member_features` / `static_member_features`) 은 unsorted 원본을 `comptimeSortByName` 으로 comptime 정렬해서, `insertFeaturesForName` 이 `std.sort.lowerBound + cmpNameVsEntry` 로 lower bound 를 잡고 이어지는 동안 forward walk 합니다. AST identifier 마다 130~140 entry 선형 비교가 `O(log N + |matches|)` 로 줄어듭니다. 같은 name 의 중복 매핑 (`at` → `array_at` + `typed_array_at` 등) 도 정렬 후 인접 위치라 그대로 처리됩니다.

graph.zig 의 `debugRuntimePolyfillUsage` 가 `usage.items[0..usage.len]` 로 내부 표현에 직접 접근하던 부분은 새 `keyIterator()` 를 쓰도록 정리했습니다.

테스트 헬퍼는 helper 안에서 `var arena = ArenaAllocator.init(...); defer arena.deinit();` 후 그 arena 로 빌드한 FeatureSet 을 그대로 반환했었는데, hashmap 전환 후 metadata 가 helper 종료 직후 dangling 됩니다. helper 안에서는 parser/scanner/semantic 만 arena 를 쓰고, FeatureSet 빌드만 `std.testing.allocator` 로 분리. 6 개 unit test 가 직접 `defer usage.deinit(std.testing.allocator)` 로 해제합니다 (leak detector 통과).

## 2. NAPI plan 객체 캡슐화 (d71611a8 + 999d2921)

기존: TS wrapper 가 9 개 parallel 배열을 napiOptions 에 분산 할당, Zig napi_entry.zig 가 각각을 `getObjectStringArray` 로 받은 뒤 4 군데에서 길이 equality 를 수동으로 검증.

```ts
// Before
napiOptions.runtimePolyfillModeNative = "usage";
napiOptions.runtimePolyfillCandidateFeatures = candidates.map(c => c.feature);
napiOptions.runtimePolyfillCandidateModules = candidates.map(c => c.module);
napiOptions.runtimePolyfillCandidatePaths = candidates.map(c => c.path);
// + Entry / Include 의 Modules / Paths 쌍 + ExcludeModules ...
```

```ts
// After
napiOptions.runtimePolyfillPlan = {
  mode: "usage",
  candidates: [{ feature, module, path }],
  include: [{ module, path }],
  exclude: [...],
};
```

길이 equality invariant 가 객체 구조에 들어가서 length-mismatch 검증 4 개가 사라집니다. `assignResolvedModuleArrays` 헬퍼도 제거.

Zig 측은 `parseRuntimePolyfillPlan` / `parseRuntimePolyfillCandidatesArray` / `parseRuntimePolyfillResolvedArray` / `ownPlanString` / `planArrayLen` helper 를 추가하고, `parseBuildOptions` 에서 124 줄 8 키 처리 블록을 helper 호출 한 줄로 교체했습니다.

세부 정리:
- `ownPlanString` 시그니처에서 alloc 파라미터를 제거하고 `native_alloc` 만 쓰게 강제. 이전 형태는 alloc 와 owned_strings.append 의 native_alloc 가 어긋나면 free 가 깨지는 footgun 이 있었는데 호출처에서 늘 `alloc == native_alloc` 였습니다.
- 에러 메시지에 key path 포함: "invalid runtime polyfill plan" → "runtimePolyfillPlan.candidates[].feature missing" 처럼 어느 필드가 깨졌는지 즉시 식별 가능.
- `RuntimePolyfillParseError` 는 `error{ InvalidPlan, OutOfMemory }` 임시 enum 에서 `error{ InvalidPlan } || std.mem.Allocator.Error` 로 변경. `try alloc.alloc(...)` 가 직접 propagate 되어 boilerplate 정리.

Plan 구조체 자체는 변경 없어 `freeOptionsTypedSlices` 의 candidates/entry_modules/include 해제 로직은 영향 없습니다.

## 3. TS↔Zig feature key sync 검증 (d71611a8)

`src/bundler/runtime_polyfills.zig` 의 collector 가 emit 하는 feature 키마다 TS 측 `RUNTIME_POLYFILL_FEATURE_MODULES` 에 매핑된 core-js 모듈이 있어야 합니다. 누락되면 candidate 가 NAPI 로 전달되지 않아 detection 은 일어나지만 polyfill 이 적용되지 않는 silent miss 가 됩니다.

- `runtime-polyfills.ts` 가 매핑 테이블을 `__runtimePolyfillTestInternals` 내부 hook 으로 노출.
- `runtime-polyfills.test.ts` 가 Zig 소스를 `readFileSync` 로 읽어 `.feature = "..."` / `out.insert(allocator, "...")` 패턴으로 키를 추출 → TS 측 feature 키 set 과 비교. 누락되면 `missingFromTs` 가 차서 즉시 fail.

## Validation

- `zig build test` (4641 pass)
- `cd packages/core && zig build napi && bun run build:js`
- `cd packages/core && bun test src/runtime-polyfills.test.ts` (17 pass, 79 expect)
- `cd packages/core && bun test index.test.ts --test-name-pattern runtimePolyfills` (13 pass)
- `cd packages/core && bun test bin/zts.test.ts --test-name-pattern "runtime-polyfills|runtime-target|runtimePolyfills"` (7 pass)
- `cd tests/integration && bun test tests/runtime-polyfills-library-smoke.test.ts tests/react-query-v5-smoke.test.ts tests/polyfill-rbm.test.ts` (14 pass)
- `bun run test:runtime-polyfills:coverage` (100% line/function)
- `zig fmt --check src/bundler/runtime_polyfills.zig src/bundler/graph.zig packages/core/src/napi_entry.zig`
- `bunx oxfmt --check packages/core/src/runtime-polyfills.ts packages/core/src/runtime-polyfills.test.ts`

Pre-push hook 도 통과했습니다 (기존 unused import warning 3 건은 이번 PR 변경 파일과 무관).