### PR TITLE
docs: core-js runtime polyfill 옵션 문서화

### DIFF
--- a/documents/src/content/docs/en/guides/bundling.md
+++ b/documents/src/content/docs/en/guides/bundling.md
@@ -133,6 +133,74 @@ zts --bundle entry.ts -o bundle.js --target=node18
 zts --bundle entry.ts -o bundle.js --target=hermes0.70
 ```
 
+## Runtime Polyfills (core-js)
+
+`--target` lowers syntax. `--runtime-polyfills` fills runtime API gaps with `core-js`. When APIs such as `String.prototype.replaceAll`, `Array.prototype.at`, `Object.hasOwn`, `Promise`, `Map`, `Set`, or `structuredClone` are detected in the bundle graph, ZTS injects the required `core-js/modules/*.js` prelude before the user entry runs.
+
+```bash
+bun add core-js core-js-compat
+
+zts --bundle entry.ts -o bundle.js \
+  --target=es5 \
+  --runtime-polyfills=auto \
+  --runtime-target="ios_saf 12" \
+  --core-js=3.49
+```
+
+Modes:
+
+| Mode | Behavior |
+|---|---|
+| `off` | Default. Does not load `core-js-compat` or run the graph collector |
+| `auto` | Injects only graph-used `core-js` modules that the target does not support |
+| `usage` | Alias for the same graph usage mode as `auto` |
+| `entry` | Injects every target-required `core-js` ES/Web module into the entry prelude regardless of usage |
+
+`auto`/`usage` does not use a Babel pre-scan in the JS wrapper. It runs from the native graph after resolve, package exports, aliases, plugin load, and plugin transform. Dependency code is included in detection, and when code splitting is enabled the runtime prelude remains a graph root that executes before user entries.
+
+Config/API usage can pass an object for `include`/`exclude` control.
+
+```ts
+import { build } from "@zts/core";
+
+await build({
+  entryPoints: ["src/index.ts"],
+  bundle: true,
+  outfile: "dist/index.js",
+  target: "es5",
+  runtimePolyfills: {
+    mode: "auto",
+    targets: ["safari 12", "ios_saf 12"],
+    coreJs: "3.49",
+    include: ["es.array.at"],
+    exclude: ["web.url"],
+  },
+});
+```
+
+`include` forces modules into the runtime prelude. `exclude` removes modules after target and usage calculation. Values can be written as `es.string.replace-all` or `core-js/modules/es.string.replace-all.js`.
+
+Runtime targets are Browserslist queries using the same shape as Rspack/SWC `env.targets`. Use explicit queries such as `ios_saf 12`, `safari 12`, or `node 18`; compact shorthand such as `ios12` or `node18`, and physical device names such as `"iPhone 8"`, are not supported. Use `--platform=react-native` for the default Hermes target.
+
+Detection is static AST based. Local bindings/imports that shadow globals are ignored, and dynamic computed access such as `obj["replaceAll"]()` is not inferred. Cover those cases with `include` or `entry` mode.
+
+Execution order preserves existing manual polyfills and entry hooks.
+
+```text
+manual polyfills / inject roots -> runtime core-js prelude -> runBeforeMain -> user entry
+```
+
+For observability, enable the runtime polyfill debug category with graph profiling.
+
+```bash
+ZTS_DEBUG=runtime_polyfills zts --bundle entry.ts \
+  --runtime-polyfills=auto \
+  --runtime-target="safari 12" \
+  --profile=graph \
+  --profile-level=detailed \
+  --profile-format=json
+```
+
 ## Output Format
 
 ```bash

--- a/documents/src/content/docs/en/reference/cli.md
+++ b/documents/src/content/docs/en/reference/cli.md
@@ -72,8 +72,8 @@ CSS before PostCSS when the optional `sass` dependency is installed.
 | `--platform=browser\|node\|neutral\|react-native` | Target platform                                                       |
 | `--rn-platform=ios\|android`                      | RN sub-platform (`.ios.*`/`.android.*` extensions)                    |
 | `--target=<spec>`                                 | ES target: `es2015`–`esnext` or engine versions (`chrome80,safari14`) |
-| `--runtime-polyfills=auto\|usage\|entry\|off`     | Inject core-js runtime API polyfills                                  |
-| `--runtime-target=<query>`                        | core-js polyfill Browserslist target. Repeatable (`chrome >= 87`)     |
+| `--runtime-polyfills=auto\|usage\|entry\|off`     | Inject core-js runtime API polyfills. `auto`/`usage` use graph usage  |
+| `--runtime-target=<query>`                        | core-js polyfill Browserslist target. Repeatable (`ios_saf 12`)       |
 | `--core-js=<version>`                             | core-js version used by core-js-compat                                |
 | `--global-name=<name>`                            | IIFE export name                                                      |
 

--- a/documents/src/content/docs/en/reference/options.md
+++ b/documents/src/content/docs/en/reference/options.md
@@ -27,8 +27,62 @@ Use `$schema` to get autocomplete in VSCode / IntelliJ / any JSON-schema-aware e
 |---|---|---|---|
 | `target` | `es5`, `es2015`–`es2025`, `esnext` | `esnext` | ES downlevel target. When set, features introduced after the target version are auto-lowered |
 | `unsupported` | `integer` (u32) | `0` | Direct `UnsupportedFeatures` bitmask. Used to inject browserslist-derived feature sets — takes precedence over `target` |
-| `runtimePolyfills` | `"off" \| "auto" \| "usage" \| "entry" \| object` | `"off"` | Inject core-js runtime API polyfills. Set targets as Rspack/SWC `env.targets`-style Browserslist query arrays |
-| `coreJs` | `string` | installed version | core-js version used by core-js-compat |
+| `runtimePolyfills` | `"off" \| "auto" \| "usage" \| "entry" \| object` | `"off"` | Inject core-js runtime API polyfills. `"auto"`/`"usage"` select from actual bundle graph usage; `"entry"` injects every target-required module |
+| `coreJs` | `string` | installed version | Version hint for core-js-compat; same role as `runtimePolyfills.coreJs` |
+
+#### Runtime Polyfills / core-js
+
+`target` handles syntax downleveling. `runtimePolyfills` handles runtime APIs such as `Promise`, `Map`, `Object.values`, `String.prototype.replaceAll`, `Array.prototype.at`, and `structuredClone` by adding a `core-js` prelude.
+
+```ts
+import { defineConfig } from "@zts/core";
+
+export default defineConfig({
+  entryPoints: ["src/index.ts"],
+  bundle: true,
+  target: "es5",
+  runtimePolyfills: {
+    mode: "auto",
+    targets: ["ios_saf 12", "safari 12"],
+    coreJs: "3.49",
+    include: ["es.array.at"],
+    exclude: ["web.url"],
+  },
+});
+```
+
+The `runtimePolyfills` object accepts these fields.
+
+| Field | Type | Description |
+|---|---|---|
+| `mode` | `"auto" \| "usage" \| "entry"` | `"auto"` and `"usage"` both select target-compatible modules from graph-detected usage. `"entry"` injects every ES/Web module that `core-js-compat` reports as required by the target |
+| `provider` | `"core-js"` | Only `core-js` is currently supported |
+| `targets` | `string \| string[]` | Browserslist queries passed to `core-js-compat`, using the same shape as Rspack/SWC `env.targets` |
+| `coreJs` | `string` | core-js version used by `core-js-compat`. When omitted, ZTS reads the installed `core-js/package.json` version |
+| `include` | `string[]` | `core-js` modules to always inject. Both `es.array.at` and `core-js/modules/es.array.at.js` are accepted |
+| `exclude` | `string[]` | `core-js` modules to remove after target and usage calculation |
+| `proposals` | `boolean` | Include proposal polyfills when querying `core-js-compat` |
+
+`runtimePolyfills: "off"` is the default. In this mode, ZTS does not load `core-js-compat`, run the graph collector, or enter the profile/debug paths. With `"auto"` or `"usage"`, the JS wrapper computes target-compatible `core-js` candidates and absolute paths, then the native bundler reads the real graph AST after resolve/load/plugin transforms and injects only the modules that were actually used.
+
+`core-js-compat` and `core-js` are optional dependencies. Install them in projects that enable runtime polyfills.
+
+```bash
+bun add core-js core-js-compat
+```
+
+Targets use Browserslist syntax.
+
+```ts
+runtimePolyfills: {
+  mode: "auto",
+  targets: ["chrome >= 87", "edge >= 88", "firefox >= 78", "safari >= 14"],
+}
+```
+
+Explicit queries such as `ios_saf 12`, `safari 12`, and `node 18` are supported. Compact shorthand such as `ios12` or `node18`, and physical device names such as `"iPhone 8"`, are not supported. Use `platform: "react-native"` for the default Hermes runtime target. ZTS does not expose a top-level `runtimeTargets` option.
+
+Detection is based on the static graph AST. Local bindings/imports that shadow `Map`, `Object`, `Promise`, and similar globals are not treated as global API usage, and dynamic computed access such as `obj["replaceAll"]()` is not inferred. Use `include` or `"entry"` for those cases.
 
 ### Parsing
 

--- a/documents/src/content/docs/guides/bundling.md
+++ b/documents/src/content/docs/guides/bundling.md
@@ -133,6 +133,74 @@ zts --bundle entry.ts -o bundle.js --target=node18
 zts --bundle entry.ts -o bundle.js --target=hermes0.70
 ```
 
+## Runtime Polyfills (core-js)
+
+`--target`은 문법을 낮추고, `--runtime-polyfills`는 타겟 런타임에 없는 API를 `core-js`로 보강합니다. `String.prototype.replaceAll`, `Array.prototype.at`, `Object.hasOwn`, `Promise`, `Map`, `Set`, `structuredClone` 같은 API가 번들 그래프에서 감지되면 필요한 `core-js/modules/*.js` prelude가 엔트리보다 먼저 실행됩니다.
+
+```bash
+bun add core-js core-js-compat
+
+zts --bundle entry.ts -o bundle.js \
+  --target=es5 \
+  --runtime-polyfills=auto \
+  --runtime-target="ios_saf 12" \
+  --core-js=3.49
+```
+
+모드는 네 가지입니다.
+
+| 모드 | 동작 |
+|---|---|
+| `off` | 기본값. `core-js-compat` 로드와 graph collector를 실행하지 않음 |
+| `auto` | 실제 번들 그래프에서 감지된 API 중 타겟이 지원하지 않는 `core-js` 모듈만 주입 |
+| `usage` | `auto`와 동일한 graph usage 모드 alias |
+| `entry` | 사용 여부와 무관하게 타겟에 필요한 `core-js` ES/Web 모듈 전체를 엔트리 prelude로 주입 |
+
+`auto`/`usage`는 JS wrapper의 Babel pre-scan이 아니라 resolve, package exports, alias, plugin load/transform 이후 만들어진 native graph 기준으로 동작합니다. dependency 내부 코드도 감지 대상이며, 코드 스플리팅을 켠 경우에도 runtime prelude가 user entry보다 먼저 실행되도록 graph root로 포함됩니다.
+
+Config/API에서는 object 형태로 `include`/`exclude`를 세밀하게 지정할 수 있습니다.
+
+```ts
+import { build } from "@zts/core";
+
+await build({
+  entryPoints: ["src/index.ts"],
+  bundle: true,
+  outfile: "dist/index.js",
+  target: "es5",
+  runtimePolyfills: {
+    mode: "auto",
+    targets: ["safari 12", "ios_saf 12"],
+    coreJs: "3.49",
+    include: ["es.array.at"],
+    exclude: ["web.url"],
+  },
+});
+```
+
+`include`는 강제 주입, `exclude`는 target/usage 계산 이후 최종 제거입니다. 값은 `es.string.replace-all` 또는 `core-js/modules/es.string.replace-all.js` 형식을 사용할 수 있습니다.
+
+Runtime target은 Rspack/SWC `env.targets`와 같은 Browserslist query입니다. `ios_saf 12`, `safari 12`, `node 18`처럼 명시적으로 쓰고, `ios12`, `node18` 같은 compact shorthand나 `"iPhone 8"` 같은 physical device name은 사용하지 않습니다. React Native 기본 Hermes 타겟은 `--platform=react-native`로 선택합니다.
+
+감지는 정적 AST 기반이므로 전역을 가리는 local binding/import는 제외되고, `obj["replaceAll"]()`처럼 동적 computed access는 추론하지 않습니다. 이런 코드는 `include` 또는 `entry` 모드로 보완합니다.
+
+실행 순서는 기존 수동 polyfill과 entry hook을 보존합니다.
+
+```text
+manual polyfills / inject roots -> runtime core-js prelude -> runBeforeMain -> user entry
+```
+
+디버깅이 필요하면 runtime polyfill debug category와 graph profile을 함께 켭니다.
+
+```bash
+ZTS_DEBUG=runtime_polyfills zts --bundle entry.ts \
+  --runtime-polyfills=auto \
+  --runtime-target="safari 12" \
+  --profile=graph \
+  --profile-level=detailed \
+  --profile-format=json
+```
+
 ## 출력 포맷
 
 ```bash

--- a/documents/src/content/docs/reference/cli.md
+++ b/documents/src/content/docs/reference/cli.md
@@ -71,8 +71,8 @@ scoped class map으로 변환하며 default export와 가능한 named export를 
 | `--platform=browser\|node\|neutral\|react-native` | 타겟 플랫폼                                                        |
 | `--rn-platform=ios\|android`                      | RN 서브 플랫폼 (`.ios.*`/`.android.*` 확장자)                      |
 | `--target=<spec>`                                 | ES 타겟: `es2015`~`esnext` 또는 엔진 버전 (`chrome80,safari14` 등) |
-| `--runtime-polyfills=auto\|usage\|entry\|off`     | core-js 런타임 API 폴리필 주입                                     |
-| `--runtime-target=<query>`                        | core-js 폴리필 Browserslist 타겟. 반복 가능 (`chrome >= 87`)       |
+| `--runtime-polyfills=auto\|usage\|entry\|off`     | core-js 런타임 API 폴리필 주입. `auto`/`usage`는 graph usage 기반  |
+| `--runtime-target=<query>`                        | core-js 폴리필 Browserslist 타겟. 반복 가능 (`ios_saf 12`)         |
 | `--core-js=<version>`                             | core-js-compat 계산에 사용할 core-js 버전                          |
 | `--global-name=<name>`                            | IIFE export 변수명                                                 |
 

--- a/documents/src/content/docs/reference/options.md
+++ b/documents/src/content/docs/reference/options.md
@@ -27,8 +27,62 @@ ZTS의 트랜스파일 옵션은 **Zig `TranspileOptionsDto` struct에서 compti
 |---|---|---|---|
 | `target` | `es5`, `es2015`–`es2025`, `esnext` | `esnext` | ES 다운레벨 타겟. 설정 시 해당 버전 이후 도입된 기능이 자동 downlowering됨 |
 | `unsupported` | `integer` (u32) | `0` | `UnsupportedFeatures` 비트마스크 직접 지정. browserslist 해석 결과를 주입할 때 사용 — `target`보다 우선 |
-| `runtimePolyfills` | `"off" \| "auto" \| "usage" \| "entry" \| object` | `"off"` | core-js 런타임 API 폴리필 주입. 타겟은 Rspack/SWC `env.targets`와 같은 Browserslist query 배열로 지정 |
-| `coreJs` | `string` | installed version | core-js-compat 계산에 사용할 core-js 버전 |
+| `runtimePolyfills` | `"off" \| "auto" \| "usage" \| "entry" \| object` | `"off"` | core-js 런타임 API 폴리필 주입. `"auto"`/`"usage"`는 실제 번들 그래프 사용량 기반, `"entry"`는 타겟 기준 전체 필요 모듈 주입 |
+| `coreJs` | `string` | installed version | `runtimePolyfills.coreJs`와 같은 core-js-compat 계산 버전 힌트 |
+
+#### Runtime Polyfills / core-js
+
+`target`은 문법 다운레벨링을 담당하고, `runtimePolyfills`는 `Promise`, `Map`, `Object.values`, `String.prototype.replaceAll`, `Array.prototype.at`, `structuredClone` 같은 런타임 API를 `core-js` prelude로 보강합니다.
+
+```ts
+import { defineConfig } from "@zts/core";
+
+export default defineConfig({
+  entryPoints: ["src/index.ts"],
+  bundle: true,
+  target: "es5",
+  runtimePolyfills: {
+    mode: "auto",
+    targets: ["ios_saf 12", "safari 12"],
+    coreJs: "3.49",
+    include: ["es.array.at"],
+    exclude: ["web.url"],
+  },
+});
+```
+
+`runtimePolyfills` object는 다음 필드를 받습니다.
+
+| 필드 | 타입 | 설명 |
+|---|---|---|
+| `mode` | `"auto" \| "usage" \| "entry"` | `"auto"`와 `"usage"`는 동일하게 그래프에서 감지된 사용 API만 후보에서 선택합니다. `"entry"`는 `core-js-compat`가 타겟에 필요하다고 판단한 ES/Web 모듈 전체를 주입합니다 |
+| `provider` | `"core-js"` | 현재는 `core-js`만 지원 |
+| `targets` | `string \| string[]` | `core-js-compat`에 전달할 Browserslist query. Rspack/SWC `env.targets`와 같은 형식 사용 |
+| `coreJs` | `string` | `core-js-compat` 계산에 사용할 core-js 버전. 생략 시 설치된 `core-js/package.json` 버전을 읽음 |
+| `include` | `string[]` | 항상 주입할 `core-js` 모듈. `es.array.at` 또는 `core-js/modules/es.array.at.js` 형식 허용 |
+| `exclude` | `string[]` | 타겟/usage 계산 뒤 최종 제거할 `core-js` 모듈 |
+| `proposals` | `boolean` | `core-js-compat` 조회 시 proposals 포함 |
+
+`runtimePolyfills: "off"`가 기본값이며, 이 경우 `core-js-compat` 로드, graph collector, profile/debug 경로를 실행하지 않습니다. `runtimePolyfills: "auto"` 또는 `"usage"`를 켜면 JS wrapper가 target 기준 주입 가능한 `core-js` 후보와 절대 경로를 계산하고, native bundler가 resolve/load/plugin transform 이후 실제 graph AST에서 사용 API를 집계해 필요한 모듈만 prelude에 넣습니다.
+
+`core-js-compat`와 `core-js`는 optional dependency입니다. 런타임 폴리필을 켤 프로젝트에서는 설치가 필요합니다.
+
+```bash
+bun add core-js core-js-compat
+```
+
+타겟 query는 Browserslist 문법을 사용합니다.
+
+```ts
+runtimePolyfills: {
+  mode: "auto",
+  targets: ["chrome >= 87", "edge >= 88", "firefox >= 78", "safari >= 14"],
+}
+```
+
+`ios_saf 12`, `safari 12`, `node 18`처럼 명시적인 query는 지원하지만 `ios12`, `node18` 같은 compact shorthand와 `"iPhone 8"` 같은 physical device name은 지원하지 않습니다. React Native 기본 Hermes 타겟은 `platform: "react-native"`에서 선택하고, top-level `runtimeTargets` 옵션은 제공하지 않습니다.
+
+감지는 정적 graph AST 기준입니다. 로컬 binding/import로 가려진 `Map`, `Object`, `Promise` 등은 전역 API 사용으로 보지 않고, `obj["replaceAll"]()` 같은 동적 computed access는 추론하지 않습니다. 그런 경우 `include`로 명시하거나 `"entry"` 모드를 사용합니다.
 
 ### 파싱
 


### PR DESCRIPTION
## 배경 / Root Cause

- graph 기반 runtime polyfill 기능이 `runtimePolyfills` / `coreJs` 옵션 surface를 제공하지만, Astro 문서에는 기존에 한 줄짜리 옵션 설명만 있었습니다.
- 이 상태에서는 사용자가 `--target` 문법 다운레벨링과 `core-js` 런타임 API 폴리필의 역할 차이, `auto`/`usage`/`entry` 모드 차이, `include`/`exclude` 적용 순서, target query 제한을 문서에서 확인하기 어려웠습니다.
- 특히 이번 기능은 JS wrapper pre-scan이 아니라 실제 native bundle graph 기준으로 dependency/plugin-transform 결과까지 감지하는 것이 핵심이라, 문서에도 그 실행 모델과 제한을 명확히 남겨야 했습니다.

## 변경 사항

### 옵션 레퍼런스 보강

- 한국어/영어 `reference/options.md`에 `Runtime Polyfills / core-js` 상세 섹션을 추가했습니다.
- `runtimePolyfills` object shape를 문서화했습니다.
  - `mode`: `auto` / `usage` / `entry`
  - `provider`: 현재 `core-js`만 지원
  - `targets`: Rspack/SWC `env.targets`와 같은 Browserslist query
  - `coreJs`: `core-js-compat` 계산 버전 힌트
  - `include`: 강제 주입 core-js module
  - `exclude`: target/usage 계산 이후 최종 제거 module
  - `proposals`: core-js proposal polyfill 포함 여부
- `runtimePolyfills: "off"`에서는 `core-js-compat` 로드와 graph collector/profile/debug 경로가 실행되지 않는 점을 명시했습니다.
- `core-js` / `core-js-compat`가 optional dependency이며, 런타임 폴리필 사용 시 설치해야 하는 점을 추가했습니다.
- 지원 target 예시와 제한을 문서화했습니다.
  - 지원 예: `ios_saf 12`, `safari 12`, `node 18`
  - 미지원: `ios12`, `node18` 같은 compact shorthand, `"iPhone 8"` 같은 physical device name
  - React Native 기본 Hermes target은 `platform: "react-native"`로 선택
  - top-level `runtimeTargets` 옵션은 제공하지 않음
- 정적 AST 기반 감지 한계를 명시했습니다.
  - local binding/import로 shadowing된 `Map`, `Object`, `Promise` 등은 전역 usage로 보지 않음
  - `obj["replaceAll"]()` 같은 dynamic computed access는 추론하지 않음
  - 이런 경우 `include` 또는 `entry` 사용

### 번들링 가이드 보강

- 한국어/영어 `guides/bundling.md`에 `Runtime Polyfills (core-js)` 섹션을 추가했습니다.
- CLI 예시를 추가했습니다.
  - `bun add core-js core-js-compat`
  - `--runtime-polyfills=auto`
  - `--runtime-target="ios_saf 12"`
  - `--core-js=3.49`
- Config/API 예시를 추가했습니다.
  - `runtimePolyfills: { mode, targets, coreJs, include, exclude }`
- graph 기반 감지 모델을 설명했습니다.
  - JS wrapper Babel pre-scan이 아님
  - resolve, package exports, alias, plugin load/transform 이후 native graph AST 기준
  - dependency 내부 코드도 감지 대상
  - splitting 사용 시에도 runtime prelude가 graph root로 포함되어 user entry보다 먼저 실행
- runtime prelude 실행 순서를 명시했습니다.
  - `manual polyfills / inject roots -> runtime core-js prelude -> runBeforeMain -> user entry`
- 관측성 예시를 추가했습니다.
  - `ZTS_DEBUG=runtime_polyfills`
  - `--profile=graph --profile-level=detailed --profile-format=json`

### CLI 레퍼런스 보강

- 한국어/영어 `reference/cli.md`에서 `--runtime-polyfills`가 graph usage 기반으로 동작한다는 설명을 보강했습니다.
- `--runtime-target` 예시를 현재 지원되는 Browserslist query 형태인 `ios_saf 12`로 맞췄습니다.

## 발견한 문제

- 이번 문서 작업에서 새 runtime code bug는 발견하지 않았습니다.
- 수정한 root cause는 기능 구현 대비 Astro 문서가 부족했던 문서화 gap입니다.

## 검증

- `git diff --check`
- `bun run --cwd documents build`
  - Astro/Starlight static build 성공
  - internal link validation 성공
  - 기존 Vite browser externalization / chunk size warning은 출력되지만 실패 아님
- `git push` pre-push hook 통과
  - `zig fmt --check src/...`
  - `zig build test`
  - `oxlint`
    - 기존 `tests/integration/tests/bundle-dynamic-import.test.ts` unused import warning 3개 출력, error 없음
  - `oxfmt --check`
