### PR TITLE
perf(tree-shake): dedupe numeric const propagation queue

### DIFF
--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -503,6 +503,7 @@ pub const TreeShaker = struct {
     fn enqueueStaticImporters(
         self: *TreeShaker,
         queue: *std.ArrayList(u32),
+        queued: *std.DynamicBitSet,
         idx: u32,
         mod_count: usize,
     ) !void {
@@ -510,7 +511,9 @@ pub const TreeShaker = struct {
         for (m.importers.items) |imp| {
             const ii = @intFromEnum(imp);
             if (ii >= mod_count) continue;
+            if (queued.isSet(ii)) continue;
             try queue.append(self.allocator, @intCast(ii));
+            queued.set(ii);
         }
     }
 
@@ -521,6 +524,11 @@ pub const TreeShaker = struct {
     ) !void {
         var queue: std.ArrayList(u32) = .empty;
         defer queue.deinit(self.allocator);
+        // Same importer can be reached from many exported numeric leaves. Keep the
+        // worklist unique while pending, but allow re-enqueue after a module is
+        // popped so later AST mutations still propagate to its importers.
+        var queued = try std.DynamicBitSet.initEmpty(self.allocator, mod_count);
+        defer queued.deinit();
         // re-export-only 모듈은 importer 가 큐를 비울 때마다 한 번만 forwarding 하면 충분 —
         // 다시 들어오면 같은 importer 들을 무한히 enqueue 해 BFS 가 폭발한다.
         var forwarded_re_exports = try std.DynamicBitSet.initEmpty(self.allocator, mod_count);
@@ -535,11 +543,11 @@ pub const TreeShaker = struct {
                 const ast = &(m.ast orelse continue);
                 if (self.moduleHasNumericExportSeed(ast, sem)) {
                     self.minifyAndResyncModule(m, sem, ast, const_profile.minify_resync);
-                    try self.enqueueStaticImporters(&queue, @intCast(i), mod_count);
+                    try self.enqueueStaticImporters(&queue, &queued, @intCast(i), mod_count);
                     continue;
                 }
                 if (self.moduleHasExportedNumberConstValue(sem)) {
-                    try self.enqueueStaticImporters(&queue, @intCast(i), mod_count);
+                    try self.enqueueStaticImporters(&queue, &queued, @intCast(i), mod_count);
                 }
             }
         }
@@ -549,9 +557,10 @@ pub const TreeShaker = struct {
             defer queue_scope.end();
 
             while (queue.pop()) |idx| {
+                if (idx < mod_count) queued.unset(idx);
                 if (idx >= mod_count) continue;
                 if (try self.materializeCrossModuleConstFactsForIndex(idx, .numeric_export_chain, const_profile)) {
-                    try self.enqueueStaticImporters(&queue, idx, mod_count);
+                    try self.enqueueStaticImporters(&queue, &queued, idx, mod_count);
                     continue;
                 }
 
@@ -566,7 +575,7 @@ pub const TreeShaker = struct {
                 }
                 if (!has_re_export) continue;
                 forwarded_re_exports.set(idx);
-                try self.enqueueStaticImporters(&queue, idx, mod_count);
+                try self.enqueueStaticImporters(&queue, &queued, idx, mod_count);
             }
         }
     }

--- a/tests/benchmark/const-prepass.ts
+++ b/tests/benchmark/const-prepass.ts
@@ -1,0 +1,367 @@
+#!/usr/bin/env bun
+/**
+ * Const prepass tree-shaking profile runner.
+ *
+ * This benchmark keeps the synthetic fixtures used while tuning
+ * `shake.const.prepass` reproducible. It is intentionally profile-oriented:
+ * compare the same machine before/after a tree-shaking change, then keep the
+ * JSON output for trend tracking.
+ *
+ * Examples:
+ *   bun run tests/benchmark/const-prepass.ts
+ *   bun run tests/benchmark/const-prepass.ts --warmup=3 --iterations=9
+ *   bun run tests/benchmark/const-prepass.ts --output /tmp/const-prepass.json
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { computeMetricStats, formatMetric, type MetricStats } from "./stats";
+
+const ROOT = resolve(__dirname, "../..");
+const ZTS_BIN = join(ROOT, "zig-out/bin/zts");
+
+const DEFAULT_WARMUP = 3;
+const DEFAULT_ITERATIONS = 9;
+
+const TARGET_PHASES = [
+  "shake.const.prepass",
+  "shake.const.prepass.numeric.propagate",
+  "shake.const.prepass.numeric.seed.scan",
+  "shake.const.prepass.numeric.queue",
+  "shake.const.prepass.build.facts",
+  "shake.const.prepass.candidate.gate",
+  "shake.const.prepass.materialize",
+  "shake.const.prepass.forbidden",
+  "shake.const.prepass.reachable",
+  "shake.const.prepass.replace",
+  "shake.const.prepass.minify.resync",
+  "shake.const.prepass.node.buffer",
+  "shake.const.prepass.link.refresh",
+] as const;
+
+type TargetPhase = (typeof TARGET_PHASES)[number];
+
+interface CliArgs {
+  warmup: number;
+  iterations: number;
+  output: string | null;
+}
+
+interface FixtureSpec {
+  name: string;
+  size: number;
+  write: (dir: string, size: number) => string;
+}
+
+interface ProfilePhase {
+  total_ms: number;
+  count: number;
+  pct: number;
+}
+
+interface ProfileJson {
+  profile_version: number;
+  total_ms: number;
+  level: string;
+  phases: Record<string, ProfilePhase | undefined>;
+}
+
+interface PhaseResult {
+  total_ms_stats: MetricStats;
+  count_median: number;
+}
+
+interface FixtureResult {
+  name: string;
+  size: number;
+  total_ms_stats: MetricStats;
+  phases: Partial<Record<TargetPhase, PhaseResult>>;
+}
+
+interface RunReport {
+  version: 1;
+  generated_at: string;
+  zts_commit: string;
+  warmup: number;
+  iterations: number;
+  fixtures: FixtureResult[];
+}
+
+const FIXTURES: FixtureSpec[] = [
+  { name: "flat-1000", size: 1000, write: writeFlatFixture },
+  { name: "reexport-500", size: 500, write: writeReExportFixture },
+  { name: "namespace-500", size: 500, write: writeNamespaceFixture },
+];
+
+function writeFlatFixture(dir: string, size: number): string {
+  mkdirSync(dir, { recursive: true });
+  const imports: string[] = [];
+  const values: string[] = [];
+  for (let i = 0; i < size; i++) {
+    imports.push(`import { v${i} } from "./mod${i}";`);
+    values.push(`v${i}`);
+    writeFileSync(join(dir, `mod${i}.ts`), `export const v${i} = ${i} + 1;\n`);
+  }
+  writeFileSync(
+    join(dir, "entry.ts"),
+    `${imports.join("\n")}\nconsole.log(${values.join(" + ")});\n`,
+  );
+  return join(dir, "entry.ts");
+}
+
+function writeReExportFixture(dir: string, size: number): string {
+  mkdirSync(dir, { recursive: true });
+  const exports: string[] = [];
+  const imports: string[] = [];
+  const values: string[] = [];
+  for (let i = 0; i < size; i++) {
+    exports.push(`export { v${i} } from "./mod${i}";`);
+    imports.push(`v${i}`);
+    values.push(`v${i}`);
+    writeFileSync(join(dir, `mod${i}.ts`), `export const v${i} = ${i} + 1;\n`);
+  }
+  writeFileSync(join(dir, "barrel.ts"), `${exports.join("\n")}\n`);
+  writeFileSync(
+    join(dir, "entry.ts"),
+    `import { ${imports.join(", ")} } from "./barrel";\nconsole.log(${values.join(" + ")});\n`,
+  );
+  return join(dir, "entry.ts");
+}
+
+function writeNamespaceFixture(dir: string, size: number): string {
+  mkdirSync(dir, { recursive: true });
+  const exports: string[] = [];
+  const imports: string[] = [];
+  const values: string[] = [];
+  for (let i = 0; i < size; i++) {
+    exports.push(`export * as ns${i} from "./mod${i}";`);
+    imports.push(`ns${i}`);
+    values.push(`ns${i}.v${i}`);
+    writeFileSync(join(dir, `mod${i}.ts`), `export const v${i} = ${i} + 1;\n`);
+  }
+  writeFileSync(join(dir, "barrel.ts"), `${exports.join("\n")}\n`);
+  writeFileSync(
+    join(dir, "entry.ts"),
+    `import { ${imports.join(", ")} } from "./barrel";\nconsole.log(${values.join(" + ")});\n`,
+  );
+  return join(dir, "entry.ts");
+}
+
+function buildBin(): void {
+  if (existsSync(ZTS_BIN)) return;
+  console.log("[const-prepass] zts binary not found, building ReleaseFast...");
+  const result = spawnSync("zig", ["build", "-Doptimize=ReleaseFast"], {
+    cwd: ROOT,
+    stdio: "inherit",
+  });
+  if (result.status !== 0) throw new Error("zig build failed");
+}
+
+function getCommit(): string {
+  const result = spawnSync("git", ["rev-parse", "--short", "HEAD"], {
+    cwd: ROOT,
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+  return result.stdout.trim() || "unknown";
+}
+
+function runOne(entry: string, outDir: string): ProfileJson {
+  rmSync(outDir, { recursive: true, force: true });
+  mkdirSync(outDir, { recursive: true });
+  const result = spawnSync(
+    ZTS_BIN,
+    [
+      "--bundle",
+      entry,
+      "--format=esm",
+      "-o",
+      join(outDir, "out.js"),
+      "--profile=shake.const.prepass",
+      "--profile-level=detailed",
+      "--profile-format=json",
+    ],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+      stdio: "pipe",
+      timeout: 30000,
+    },
+  );
+  if (result.status !== 0) {
+    throw new Error(`zts failed: ${result.stderr.slice(0, 800)}`);
+  }
+  return parseProfileJson(`${result.stdout}\n${result.stderr}`);
+}
+
+function parseProfileJson(output: string): ProfileJson {
+  const start = output.indexOf("{");
+  const end = output.lastIndexOf("}");
+  if (start < 0 || end < start) {
+    throw new Error(`missing profile JSON output: ${output.slice(0, 800)}`);
+  }
+  return JSON.parse(output.slice(start, end + 1)) as ProfileJson;
+}
+
+function median(values: number[]): number {
+  return computeMetricStats(values).median;
+}
+
+function measureFixture(spec: FixtureSpec, cli: CliArgs): FixtureResult {
+  const tmp = mkdtempSync(join(tmpdir(), "zts-const-prepass-"));
+  try {
+    const srcDir = join(tmp, "src");
+    const outDir = join(tmp, "dist");
+    const entry = spec.write(srcDir, spec.size);
+
+    for (let i = 0; i < cli.warmup; i++) runOne(entry, outDir);
+
+    const totalSamples: number[] = [];
+    const phaseTimeSamples: Partial<Record<TargetPhase, number[]>> = {};
+    const phaseCountSamples: Partial<Record<TargetPhase, number[]>> = {};
+    for (let i = 0; i < cli.iterations; i++) {
+      const profile = runOne(entry, outDir);
+      totalSamples.push(profile.total_ms);
+      for (const phase of TARGET_PHASES) {
+        const hit = profile.phases[phase];
+        (phaseTimeSamples[phase] ??= []).push(hit?.total_ms ?? 0);
+        (phaseCountSamples[phase] ??= []).push(hit?.count ?? 0);
+      }
+    }
+
+    const phases: Partial<Record<TargetPhase, PhaseResult>> = {};
+    for (const phase of TARGET_PHASES) {
+      const times = phaseTimeSamples[phase] ?? [];
+      const counts = phaseCountSamples[phase] ?? [];
+      phases[phase] = {
+        total_ms_stats: computeMetricStats(times),
+        count_median: median(counts),
+      };
+    }
+
+    return {
+      name: spec.name,
+      size: spec.size,
+      total_ms_stats: computeMetricStats(totalSamples),
+      phases,
+    };
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+function fmtMs(n: number): string {
+  return formatMetric(n, "ms");
+}
+
+function phaseMedian(result: FixtureResult, phase: TargetPhase): number {
+  return result.phases[phase]?.total_ms_stats.median ?? 0;
+}
+
+function phaseCount(result: FixtureResult, phase: TargetPhase): number {
+  return result.phases[phase]?.count_median ?? 0;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    warmup: DEFAULT_WARMUP,
+    iterations: DEFAULT_ITERATIONS,
+    output: null,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--output") {
+      args.output = argv[++i] ?? null;
+    } else if (arg.startsWith("--output=")) {
+      args.output = arg.slice("--output=".length);
+    } else if (arg === "--warmup") {
+      args.warmup = parsePositiveInt(argv[++i], "warmup");
+    } else if (arg.startsWith("--warmup=")) {
+      args.warmup = parsePositiveInt(arg.slice("--warmup=".length), "warmup");
+    } else if (arg === "--iterations") {
+      args.iterations = parsePositiveInt(argv[++i], "iterations");
+    } else if (arg.startsWith("--iterations=")) {
+      args.iterations = parsePositiveInt(arg.slice("--iterations=".length), "iterations");
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function parsePositiveInt(value: string | undefined, name: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`--${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function printHelp(): void {
+  console.log(`Usage: bun run tests/benchmark/const-prepass.ts [options]
+
+Options:
+  --warmup <n>       Warmup runs per fixture (default: ${DEFAULT_WARMUP})
+  --iterations <n>   Measured runs per fixture (default: ${DEFAULT_ITERATIONS})
+  --output <path>    Write JSON report
+  -h, --help         Show this help
+`);
+}
+
+async function main(cli: CliArgs): Promise<void> {
+  buildBin();
+  console.log(`[const-prepass] zts ${getCommit()} | warmup=${cli.warmup} iter=${cli.iterations}`);
+  console.log();
+
+  const results: FixtureResult[] = [];
+  for (const spec of FIXTURES) {
+    process.stdout.write(`  ${spec.name}... `);
+    const result = measureFixture(spec, cli);
+    results.push(result);
+    console.log(
+      `const=${fmtMs(phaseMedian(result, "shake.const.prepass"))} ` +
+        `build.facts=${fmtMs(phaseMedian(result, "shake.const.prepass.build.facts"))} ` +
+        `count=${phaseCount(result, "shake.const.prepass.build.facts")}`,
+    );
+  }
+
+  const report: RunReport = {
+    version: 1,
+    generated_at: new Date().toISOString(),
+    zts_commit: getCommit(),
+    warmup: cli.warmup,
+    iterations: cli.iterations,
+    fixtures: results,
+  };
+
+  if (cli.output) {
+    writeFileSync(cli.output, JSON.stringify(report, null, 2) + "\n");
+    console.log(`\n[const-prepass] run report written: ${cli.output}`);
+  }
+
+  console.log();
+  console.log("### const-prepass profile");
+  console.log(
+    "| Fixture | Total | Const prepass | Numeric propagate | Numeric queue | Build facts | Build count | Minify resync | Minify count |",
+  );
+  console.log("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |");
+  for (const result of results) {
+    console.log(
+      `| ${result.name} | ${fmtMs(result.total_ms_stats.median)} | ` +
+        `${fmtMs(phaseMedian(result, "shake.const.prepass"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.const.prepass.numeric.propagate"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.const.prepass.numeric.queue"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.const.prepass.build.facts"))} | ` +
+        `${phaseCount(result, "shake.const.prepass.build.facts")} | ` +
+        `${fmtMs(phaseMedian(result, "shake.const.prepass.minify.resync"))} | ` +
+        `${phaseCount(result, "shake.const.prepass.minify.resync")} |`,
+    );
+  }
+}
+
+await main(parseArgs(process.argv.slice(2)));

--- a/tests/benchmark/package.json
+++ b/tests/benchmark/package.json
@@ -6,6 +6,7 @@
     "bench": "bun run bench.ts",
     "bench:transpile": "bun run bench.ts --transpile",
     "bench:bundle": "bun run bench.ts --bundle",
+    "bench:const-prepass": "bun run const-prepass.ts",
     "bench:monorepo": "bun run monorepo-perf.ts",
     "bench:minify": "bun run minify-bench.ts",
     "pipeline": "bun run pipeline.ts"


### PR DESCRIPTION
## 요약
- `shake.const.prepass` numeric propagation queue에 pending bitset을 추가해 같은 importer가 동시에 여러 번 queue에 쌓이지 않게 했습니다.
- queue에서 pop할 때 pending bit을 해제하므로, 이후 AST mutation으로 생긴 재전파는 그대로 허용합니다.
- 추후 계측을 위해 `tests/benchmark/const-prepass.ts`와 `bench:const-prepass` script를 추가했습니다.

## 측정
이전 #2542 계측에서 `build.facts`가 같은 importer를 반복 스캔하면서 병목이 됐고, 이번 변경 후 같은 synthetic shape에서 pending 중복이 제거됐습니다.

| Fixture | const.prepass before | const.prepass after | build.facts before | build.facts after | build.facts count |
| --- | ---: | ---: | ---: | ---: | ---: |
| flat-1000 | 75.287ms | 1.12ms | 69.949ms | 0.10ms | 1000 -> 1 |
| reexport-500 | 18.910ms | 0.79ms | 16.973ms | 0.05ms | 1000 -> 2 |
| namespace-500 | 57.785ms | 0.75ms | 56.884ms | 0.12ms | 1000 -> 2 |

추가된 벤치마크 실행:

```sh
bun run --cwd tests/benchmark bench:const-prepass --warmup=3 --iterations=9 --output /tmp/const-prepass.json
```

## 검증
- `zig build test --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- `bun run tests/benchmark/const-prepass.ts --warmup=3 --iterations=9 --output /tmp/zts-const-queue-dedupe-profile.json`
- `bun run --cwd tests/benchmark bench:const-prepass --warmup=1 --iterations=1`
- `bun run tests/benchmark/bundle-perf.ts --no-fail --output /tmp/zts-const-queue-dedupe-bundle-perf.json` (baseline absolute comparison은 기존 baseline 대비 drift를 보고하므로 artifact 수집 용도로 확인)
- `bun run fmt:check`
- `bun run lint` (기존 `tests/integration/tests/bundle-dynamic-import.test.ts` unused import warning 3개만 존재)
- `bunx oxlint tests/benchmark/const-prepass.ts`
- `git diff --check`

Updates #2354