### PR TITLE
feat(profile): split fixpoint bfs timings

### DIFF
--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -1156,148 +1156,166 @@ pub const TreeShaker = struct {
         self.opaque_visited = ov;
 
         // 시드 1: entry module의 export 선언 statement + side-effect statement
-        for (0..mod_count) |i| {
-            const m = self.getModule(@intCast(i)) orelse continue;
-            const infos = module_stmt_infos[i] orelse {
-                // StmtInfo 없는 포함 모듈 (entry, CJS): import를 직접 시드
-                if (self.included.isSet(i) and (self.entry_set.isSet(i) or m.wrap_kind.isWrapped())) {
+        {
+            var seed_scope = profile.begin(.shake_fixpoint_bfs_seed);
+            defer seed_scope.end();
+
+            for (0..mod_count) |i| {
+                const m = self.getModule(@intCast(i)) orelse continue;
+                const infos = module_stmt_infos[i] orelse {
+                    // StmtInfo 없는 포함 모듈 (entry, CJS): import를 직접 시드
+                    if (self.included.isSet(i) and (self.entry_set.isSet(i) or m.wrap_kind.isWrapped())) {
+                        try self.seedOpaqueModule(@intCast(i), &queue, module_stmt_infos, reachable_stmts);
+                    }
+                    continue;
+                };
+                if (!self.included.isSet(i)) continue;
+
+                // reachable bitset 초기화
+                if (reachable_stmts[i] == null) {
+                    reachable_stmts[i] = try std.DynamicBitSet.initEmpty(self.allocator, infos.stmts.len);
+                }
+
+                // entry는 번들 진입점이지만 pure local declaration은 실행 의미가 없다.
+                // side-effect statement와 entry export seed만 살리고, local-only pure statement는
+                // BFS dependency로 필요할 때만 도달시킨다.
+                // side_effects=true 모듈은 side-effect stmt만 시드.
+                // side_effects=false 모듈은 enqueue의 lazy 시드로 처리 (사용 시에만).
+                if (self.entry_set.isSet(i)) {
+                    var has_entry_side_effect_stmt = false;
+                    for (infos.stmts) |stmt| {
+                        if (stmt.has_side_effects) {
+                            has_entry_side_effect_stmt = true;
+                            break;
+                        }
+                    }
+                    const prune_pure_entry_locals = self.graph.transform_options_base.minify_syntax and
+                        (has_entry_side_effect_stmt or m.export_bindings.len > 0);
+                    for (infos.stmts, 0..) |stmt, si| {
+                        if (!prune_pure_entry_locals or stmt.has_side_effects) {
+                            try self.enqueue(@intCast(i), @intCast(si), reachable_stmts, &queue);
+                        }
+                    }
+                } else if (m.side_effects and m.side_effects_user_defined) {
+                    for (infos.stmts, 0..) |_, si| {
+                        try self.enqueue(@intCast(i), @intCast(si), reachable_stmts, &queue);
+                    }
+                } else if (m.side_effects) {
+                    for (infos.stmts, 0..) |stmt, si| {
+                        if (stmt.has_side_effects) {
+                            try self.enqueue(@intCast(i), @intCast(si), reachable_stmts, &queue);
+                        }
+                    }
+                }
+
+                // used export 선언 statement 시드. 시드 대상:
+                //   (1) entry: 번들 외부 사용자가 접근 가능 — 모든 export live.
+                //   (2) ALL_EXPORTS_SENTINEL 마킹된 모듈: dynamic import target(#1260) 또는 export * 전파 대상.
+                // non-entry·sentinel 없음: followImport만으로 도달해야 가짜 used 확산을 막는다.
+                const is_bfs_seed = self.entry_set.isSet(i) or self.isExportUsed(@intCast(i), ALL_EXPORTS_SENTINEL);
+                if (is_bfs_seed) {
+                    const sem = m.semantic orelse continue;
+                    if (sem.scope_maps.len == 0) continue;
+                    for (m.export_bindings) |eb| {
+                        if (eb.kind.isReExportAll()) continue;
+                        const sym_idx = eb.symbol.semanticIndex() orelse continue;
+                        try self.enqueueSymbolLiveStatements(@intCast(i), infos, sym_idx, reachable_stmts, &queue);
+                    }
+                    // dynamic import target도 re-export 체인 따라 transitive 모듈까지
+                    // 전파해야 함(#1260). seedOpaqueModule은 opaque_visited로 중복 방지.
                     try self.seedOpaqueModule(@intCast(i), &queue, module_stmt_infos, reachable_stmts);
                 }
-                continue;
-            };
-            if (!self.included.isSet(i)) continue;
-
-            // reachable bitset 초기화
-            if (reachable_stmts[i] == null) {
-                reachable_stmts[i] = try std.DynamicBitSet.initEmpty(self.allocator, infos.stmts.len);
-            }
-
-            // entry는 번들 진입점이지만 pure local declaration은 실행 의미가 없다.
-            // side-effect statement와 entry export seed만 살리고, local-only pure statement는
-            // BFS dependency로 필요할 때만 도달시킨다.
-            // side_effects=true 모듈은 side-effect stmt만 시드.
-            // side_effects=false 모듈은 enqueue의 lazy 시드로 처리 (사용 시에만).
-            if (self.entry_set.isSet(i)) {
-                var has_entry_side_effect_stmt = false;
-                for (infos.stmts) |stmt| {
-                    if (stmt.has_side_effects) {
-                        has_entry_side_effect_stmt = true;
-                        break;
-                    }
-                }
-                const prune_pure_entry_locals = self.graph.transform_options_base.minify_syntax and
-                    (has_entry_side_effect_stmt or m.export_bindings.len > 0);
-                for (infos.stmts, 0..) |stmt, si| {
-                    if (!prune_pure_entry_locals or stmt.has_side_effects) {
-                        try self.enqueue(@intCast(i), @intCast(si), reachable_stmts, &queue);
-                    }
-                }
-            } else if (m.side_effects and m.side_effects_user_defined) {
-                for (infos.stmts, 0..) |_, si| {
-                    try self.enqueue(@intCast(i), @intCast(si), reachable_stmts, &queue);
-                }
-            } else if (m.side_effects) {
-                for (infos.stmts, 0..) |stmt, si| {
-                    if (stmt.has_side_effects) {
-                        try self.enqueue(@intCast(i), @intCast(si), reachable_stmts, &queue);
-                    }
-                }
-            }
-
-            // used export 선언 statement 시드. 시드 대상:
-            //   (1) entry: 번들 외부 사용자가 접근 가능 — 모든 export live.
-            //   (2) ALL_EXPORTS_SENTINEL 마킹된 모듈: dynamic import target(#1260) 또는 export * 전파 대상.
-            // non-entry·sentinel 없음: followImport만으로 도달해야 가짜 used 확산을 막는다.
-            const is_bfs_seed = self.entry_set.isSet(i) or self.isExportUsed(@intCast(i), ALL_EXPORTS_SENTINEL);
-            if (is_bfs_seed) {
-                const sem = m.semantic orelse continue;
-                if (sem.scope_maps.len == 0) continue;
-                for (m.export_bindings) |eb| {
-                    if (eb.kind.isReExportAll()) continue;
-                    const sym_idx = eb.symbol.semanticIndex() orelse continue;
-                    try self.enqueueSymbolLiveStatements(@intCast(i), infos, sym_idx, reachable_stmts, &queue);
-                }
-                // dynamic import target도 re-export 체인 따라 transitive 모듈까지
-                // 전파해야 함(#1260). seedOpaqueModule은 opaque_visited로 중복 방지.
-                try self.seedOpaqueModule(@intCast(i), &queue, module_stmt_infos, reachable_stmts);
             }
         }
 
         // BFS 루프
-        var head: u32 = 0;
-        while (head < queue.items.len) : (head += 1) {
-            const item = queue.items[head];
-            const infos = module_stmt_infos[item.mod] orelse continue;
-            if (item.stmt >= infos.stmts.len) continue;
+        {
+            var queue_scope = profile.begin(.shake_fixpoint_bfs_queue);
+            defer queue_scope.end();
 
-            // item 단위 invariant — referenced_symbols 루프 밖으로 한 번만 계산.
-            const owner = self.getModule(item.mod);
-            const skip_import_followup = if (owner) |o| isImportDeclarationStmt(o, infos, item.stmt) else true;
+            var head: u32 = 0;
+            while (head < queue.items.len) : (head += 1) {
+                const item = queue.items[head];
+                const infos = module_stmt_infos[item.mod] orelse continue;
+                if (item.stmt >= infos.stmts.len) continue;
 
-            for (infos.stmts[item.stmt].referenced_symbols) |ref_sym| {
-                // (1) 로컬 심볼: 같은 모듈의 종속 statement
-                if (infos.declaredStmtBySymbol(ref_sym)) |dep_stmt| {
-                    try self.enqueue(item.mod, dep_stmt, reachable_stmts, &queue);
-                }
+                // item 단위 invariant — referenced_symbols 루프 밖으로 한 번만 계산.
+                const owner = self.getModule(item.mod);
+                const skip_import_followup = if (owner) |o| isImportDeclarationStmt(o, infos, item.stmt) else true;
 
-                // (1b) 같은 심볼에 대한 비선언 writer (예: TS 가 emit 하는 `var _a; ... _a = AST;`).
-                // declare 경로로는 var-only 선언만 살아남고 실제 값을 채우는 후속 할당이 누락되어
-                // `_a is not a constructor` 류 회귀가 발생한다.
-                for (infos.writerStmts(ref_sym)) |writer_stmt| {
-                    try self.enqueue(item.mod, writer_stmt, reachable_stmts, &queue);
-                }
+                for (infos.stmts[item.stmt].referenced_symbols) |ref_sym| {
+                    // (1) 로컬 심볼: 같은 모듈의 종속 statement
+                    if (infos.declaredStmtBySymbol(ref_sym)) |dep_stmt| {
+                        try self.enqueue(item.mod, dep_stmt, reachable_stmts, &queue);
+                    }
 
-                // (2) import binding: 타겟 모듈로 점프
-                if (skip_import_followup) continue;
-                if (item.mod < self.sym_to_ib.len) {
-                    if (self.sym_to_ib[item.mod]) |sym_map| {
-                        if (ref_sym < sym_map.len) {
-                            if (sym_map[ref_sym]) |ib_idx| {
-                                try self.followImport(item.mod, ib_idx, item.stmt, &queue, module_stmt_infos, reachable_stmts);
+                    // (1b) 같은 심볼에 대한 비선언 writer (예: TS 가 emit 하는 `var _a; ... _a = AST;`).
+                    // declare 경로로는 var-only 선언만 살아남고 실제 값을 채우는 후속 할당이 누락되어
+                    // `_a is not a constructor` 류 회귀가 발생한다.
+                    for (infos.writerStmts(ref_sym)) |writer_stmt| {
+                        try self.enqueue(item.mod, writer_stmt, reachable_stmts, &queue);
+                    }
+
+                    // (2) import binding: 타겟 모듈로 점프
+                    if (skip_import_followup) continue;
+                    if (item.mod < self.sym_to_ib.len) {
+                        if (self.sym_to_ib[item.mod]) |sym_map| {
+                            if (ref_sym < sym_map.len) {
+                                if (sym_map[ref_sym]) |ib_idx| {
+                                    try self.followImport(item.mod, ib_idx, item.stmt, &queue, module_stmt_infos, reachable_stmts);
+                                }
                             }
                         }
                     }
                 }
-            }
 
-            if (owner) |o| {
-                for (o.import_records, 0..) |rec, rec_i| {
-                    if (rec.kind != .require) continue;
-                    if (rec.resolved.isNone()) continue;
-                    if (!self.importRecordBelongsToStmt(infos, @intCast(item.stmt), @intCast(rec_i), o)) continue;
-                    const target_mod_idx = @intFromEnum(rec.resolved);
-                    const target_module = self.graph.getModule(rec.resolved) orelse continue;
-                    if (target_module.wrap_kind != .cjs) continue;
-                    if (!self.isExportUsed(item.mod, ALL_EXPORTS_SENTINEL) and
-                        !self.isExportUsed(@intCast(target_mod_idx), ALL_EXPORTS_SENTINEL) and
-                        self.hasAnyUsedExportDirect(@intCast(target_mod_idx)) and
-                        moduleExportsRequireProxyMatches(o, infos, @intCast(item.stmt), rec.resolved))
-                    {
-                        const target_infos = module_stmt_infos[target_mod_idx] orelse {
-                            try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
+                if (owner) |o| {
+                    var require_scope = profile.begin(.shake_fixpoint_bfs_require_scan);
+                    defer require_scope.end();
+
+                    for (o.import_records, 0..) |rec, rec_i| {
+                        if (rec.kind != .require) continue;
+                        if (rec.resolved.isNone()) continue;
+                        if (!self.importRecordBelongsToStmt(infos, @intCast(item.stmt), @intCast(rec_i), o)) continue;
+                        const target_mod_idx = @intFromEnum(rec.resolved);
+                        const target_module = self.graph.getModule(rec.resolved) orelse continue;
+                        if (target_module.wrap_kind != .cjs) continue;
+                        if (!self.isExportUsed(item.mod, ALL_EXPORTS_SENTINEL) and
+                            !self.isExportUsed(@intCast(target_mod_idx), ALL_EXPORTS_SENTINEL) and
+                            self.hasAnyUsedExportDirect(@intCast(target_mod_idx)) and
+                            moduleExportsRequireProxyMatches(o, infos, @intCast(item.stmt), rec.resolved))
+                        {
+                            const target_infos = module_stmt_infos[target_mod_idx] orelse {
+                                try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
+                                continue;
+                            };
+                            try self.seedSideEffectStmts(@intCast(target_mod_idx), target_infos, &queue, reachable_stmts);
                             continue;
-                        };
-                        try self.seedSideEffectStmts(@intCast(target_mod_idx), target_infos, &queue, reachable_stmts);
-                        continue;
+                        }
+                        try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
                     }
-                    try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
                 }
             }
         }
 
         // BFS 후: reachable statement 기반 used_exports 추가 마킹
         // BFS 중 markExportUsed로 마킹된 것은 유지 (clearUsedExports 하지 않음)
-        for (0..mod_count) |i| {
-            const m = self.getModule(@intCast(i)) orelse continue;
-            const infos = module_stmt_infos[i] orelse continue;
-            const sem = m.semantic orelse continue;
-            if (sem.scope_maps.len == 0) continue;
-            for (m.export_bindings) |eb| {
-                if (eb.kind.isReExportAll()) continue;
-                const sym_idx = eb.symbol.semanticIndex() orelse continue;
-                if (infos.declaredStmtBySymbol(sym_idx)) |stmt_idx| {
-                    if (reachable_stmts[i] != null and reachable_stmts[i].?.isSet(stmt_idx)) {
-                        try self.markExportUsed(@intCast(i), eb.exported_name);
+        {
+            var final_scope = profile.begin(.shake_fixpoint_bfs_final_mark_exports);
+            defer final_scope.end();
+
+            for (0..mod_count) |i| {
+                const m = self.getModule(@intCast(i)) orelse continue;
+                const infos = module_stmt_infos[i] orelse continue;
+                const sem = m.semantic orelse continue;
+                if (sem.scope_maps.len == 0) continue;
+                for (m.export_bindings) |eb| {
+                    if (eb.kind.isReExportAll()) continue;
+                    const sym_idx = eb.symbol.semanticIndex() orelse continue;
+                    if (infos.declaredStmtBySymbol(sym_idx)) |stmt_idx| {
+                        if (reachable_stmts[i] != null and reachable_stmts[i].?.isSet(stmt_idx)) {
+                            try self.markExportUsed(@intCast(i), eb.exported_name);
+                        }
                     }
                 }
             }
@@ -1322,6 +1340,9 @@ pub const TreeShaker = struct {
         // 예: Object3D가 reachable → Object3D.DEFAULT_UP = ... 도 시드
         // 역인덱스 활용: O(D×K) where K = avg side-effect refs per symbol
         if (mod < self.module_stmt_infos.len) {
+            var side_effect_scope = profile.begin(.shake_fixpoint_bfs_enqueue_side_effects);
+            defer side_effect_scope.end();
+
             if (self.module_stmt_infos[mod]) |infos| {
                 if (stmt < infos.stmts.len) {
                     for (infos.stmts[stmt].declared_symbols) |declared_sym| {
@@ -1401,6 +1422,9 @@ pub const TreeShaker = struct {
         module_stmt_infos: []?StmtInfos,
         reachable_stmts: []?std.DynamicBitSet,
     ) std.mem.Allocator.Error!void {
+        var follow_scope = profile.begin(.shake_fixpoint_bfs_follow_import);
+        defer follow_scope.end();
+
         const m = self.getModule(mod_idx) orelse return;
         if (ib_idx >= m.import_bindings.len) return;
         const ib = m.import_bindings[ib_idx];
@@ -1487,6 +1511,9 @@ pub const TreeShaker = struct {
         module_stmt_infos: []?StmtInfos,
         reachable_stmts: []?std.DynamicBitSet,
     ) std.mem.Allocator.Error!void {
+        var seed_scope = profile.begin(.shake_fixpoint_bfs_seed_export);
+        defer seed_scope.end();
+
         const mod_count = self.graph.moduleCount();
         const canonical = self.linker.resolveExportChain(@enumFromInt(@as(u32, @intCast(target_mod))), imported_name, 0) orelse return;
         const canon_mod = canonical.module_index.toU32();

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -124,6 +124,13 @@ pub const Category = enum {
     shake_fixpoint,
     shake_fixpoint_sym_to_ib,
     shake_fixpoint_bfs,
+    shake_fixpoint_bfs_seed,
+    shake_fixpoint_bfs_queue,
+    shake_fixpoint_bfs_follow_import,
+    shake_fixpoint_bfs_seed_export,
+    shake_fixpoint_bfs_require_scan,
+    shake_fixpoint_bfs_final_mark_exports,
+    shake_fixpoint_bfs_enqueue_side_effects,
     shake_fixpoint_process_imports,
     shake_fixpoint_re_exports,
     shake_fixpoint_eval_deps,
@@ -269,10 +276,25 @@ var enabled_mask: u128 = 0;
 var current_level: Level = .summary;
 
 /// 각 category 별 누적 시간 (ns).
+/// Parent scope 전체 시간을 보존하는 inclusive total 이다.
 var totals_ns: [num_categories]u64 = [_]u64{0} ** num_categories;
+
+/// 각 category 별 child scope 제외 시간 (ns).
+/// `total_ms` 는 기존 호환성을 위해 inclusive 로 유지하고, 전체 합계/JSON self_ms 는
+/// 이 값을 사용해 nested phase 중복 합산을 피한다.
+var self_totals_ns: [num_categories]u64 = [_]u64{0} ** num_categories;
 
 /// 각 category 별 호출 횟수.
 var counts: [num_categories]u32 = [_]u32{0} ** num_categories;
+
+const max_scope_depth = 128;
+
+const ActiveScope = struct {
+    child_ns: u64 = 0,
+};
+
+var active_scopes: [max_scope_depth]ActiveScope = [_]ActiveScope{.{}} ** max_scope_depth;
+var active_scope_len: u8 = 0;
 
 // ============================================================================
 // Activation API (CLI / NAPI / env 공용)
@@ -360,7 +382,9 @@ pub fn initFromEnv(allocator: std.mem.Allocator) void {
 /// Zig upgrade 로 버그 사라지면 이 함수 제거하고 `@memset` 두 줄 복원.
 fn zeroCounters() void {
     totals_ns = [_]u64{0} ** num_categories;
+    self_totals_ns = [_]u64{0} ** num_categories;
     counts = [_]u32{0} ** num_categories;
+    active_scope_len = 0;
 }
 
 /// 테스트 / 재초기화용. 전체 상태 초기화 (mask + level + counters 모두).
@@ -403,11 +427,30 @@ fn enableCategoryAndChildren(parent: Category) void {
 pub const Scope = struct {
     timer: ?std.time.Timer = null,
     category: Category = .scan, // 비활성 시 사용 안 됨
+    stack_index: u8 = 0,
+    stack_active: bool = false,
 
     pub fn end(self: *Scope) void {
         if (self.timer) |*t| {
             const elapsed_ns = t.read();
-            recordTiming(self.category, elapsed_ns);
+            var child_ns: u64 = 0;
+            if (self.stack_active) {
+                if (active_scope_len == self.stack_index + 1) {
+                    child_ns = active_scopes[self.stack_index].child_ns;
+                    active_scope_len = self.stack_index;
+                    if (self.stack_index > 0) {
+                        active_scopes[self.stack_index - 1].child_ns += elapsed_ns;
+                    }
+                } else {
+                    // Scope 는 LIFO 로 닫혀야 child subtraction 이 정확하다. 혹시 깨지면
+                    // 이후 sample 오염을 막기 위해 stack 만 비우고 inclusive/self 동일 처리.
+                    active_scope_len = 0;
+                }
+                self.stack_active = false;
+            }
+            const self_ns = elapsed_ns -| child_ns;
+            recordTiming(self.category, elapsed_ns, self_ns);
+            self.timer = null;
         }
     }
 };
@@ -416,21 +459,38 @@ pub const Scope = struct {
 /// 활성 category 면 Timer 시작 + category 기록.
 pub inline fn begin(cat: Category) Scope {
     if (!enabled(cat)) return .{};
+    const timer = std.time.Timer.start() catch return .{};
+    if (active_scope_len >= max_scope_depth) {
+        return .{
+            .timer = timer,
+            .category = cat,
+        };
+    }
+    const stack_index = active_scope_len;
+    active_scopes[stack_index] = .{};
+    active_scope_len += 1;
     return .{
-        .timer = std.time.Timer.start() catch null,
+        .timer = timer,
         .category = cat,
+        .stack_index = stack_index,
+        .stack_active = true,
     };
 }
 
-fn recordTiming(cat: Category, ns: u64) void {
+fn recordTiming(cat: Category, ns: u64, self_ns: u64) void {
     const idx = @intFromEnum(cat);
     totals_ns[idx] += ns;
+    self_totals_ns[idx] += self_ns;
     counts[idx] += 1;
 }
 
 /// 수집된 원시 데이터 조회 (테스트 + 외부 리포터용).
 pub fn totalNs(cat: Category) u64 {
     return totals_ns[@intFromEnum(cat)];
+}
+
+pub fn selfNs(cat: Category) u64 {
+    return self_totals_ns[@intFromEnum(cat)];
 }
 
 pub fn count(cat: Category) u32 {
@@ -453,7 +513,7 @@ pub fn report(writer: anytype, format: Format) !void {
 
 fn totalAllNs() u64 {
     var sum: u64 = 0;
-    for (totals_ns) |ns| sum += ns;
+    for (self_totals_ns) |ns| sum += ns;
     return sum;
 }
 
@@ -473,8 +533,8 @@ fn isChildOf(cat: Category, parent: Category) bool {
 
 fn reportTable(writer: anytype) !void {
     try writer.writeAll("=== ZTS Profile ===\n");
-    try writer.writeAll("Phase                Total       %      Count\n");
-    try writer.writeAll("--------------------|-----------|-------|------\n");
+    try writer.writeAll("Phase                Total       Self        %      Count\n");
+    try writer.writeAll("--------------------|-----------|-----------|-------|------\n");
 
     const total = totalAllNs();
     if (total == 0) {
@@ -489,19 +549,21 @@ fn reportTable(writer: anytype) !void {
         const skip = counts[idx] == 0 or (current_level == .summary and is_sub);
         if (!skip) {
             const ns = totals_ns[idx];
+            const self_ns = self_totals_ns[idx];
             const ms = @as(f64, @floatFromInt(ns)) / 1_000_000.0;
-            const pct = @as(f64, @floatFromInt(ns)) / @as(f64, @floatFromInt(total)) * 100.0;
+            const self_ms = @as(f64, @floatFromInt(self_ns)) / 1_000_000.0;
+            const pct = @as(f64, @floatFromInt(self_ns)) / @as(f64, @floatFromInt(total)) * 100.0;
             const name = Category.displayName(cat);
 
-            try writer.print("{s: <20} {d: >7.2}ms  {d: >4.1}%  {d: >5}\n", .{
-                name, ms, pct, counts[idx],
+            try writer.print("{s: <20} {d: >7.2}ms  {d: >7.2}ms  {d: >4.1}%  {d: >5}\n", .{
+                name, ms, self_ms, pct, counts[idx],
             });
         }
     }
 
-    try writer.writeAll("--------------------|-----------|-------|------\n");
+    try writer.writeAll("--------------------|-----------|-----------|-------|------\n");
     const total_ms = @as(f64, @floatFromInt(total)) / 1_000_000.0;
-    try writer.print("{s: <20} {d: >7.2}ms  100.0%\n", .{ "total", total_ms });
+    try writer.print("{s: <20} {d: >7.2}ms  {d: >7.2}ms  100.0%\n", .{ "total", total_ms, total_ms });
 }
 
 fn reportTree(writer: anytype) !void {
@@ -525,9 +587,11 @@ fn reportTree(writer: anytype) !void {
         const idx = @intFromEnum(cat);
         if (counts[idx] > 0 and isTopLevel(cat)) {
             const ns = totals_ns[idx];
+            const self_ns = self_totals_ns[idx];
             const ms = @as(f64, @floatFromInt(ns)) / 1_000_000.0;
-            const pct = @as(f64, @floatFromInt(ns)) / @as(f64, @floatFromInt(total)) * 100.0;
-            try writer.print("├─ {s: <16} {d: >7.2}ms  ({d:.1}%)\n", .{ Category.displayName(cat), ms, pct });
+            const self_ms = @as(f64, @floatFromInt(self_ns)) / 1_000_000.0;
+            const pct = @as(f64, @floatFromInt(self_ns)) / @as(f64, @floatFromInt(total)) * 100.0;
+            try writer.print("├─ {s: <16} {d: >7.2}ms total  {d: >7.2}ms self  ({d:.1}%)\n", .{ Category.displayName(cat), ms, self_ms, pct });
 
             if (current_level != .summary) {
                 // Sub-phases.
@@ -536,11 +600,14 @@ fn reportTree(writer: anytype) !void {
                     const sub_idx = @intFromEnum(sub_cat);
                     if (counts[sub_idx] > 0 and isChildOf(sub_cat, cat)) {
                         const sub_ns = totals_ns[sub_idx];
+                        const sub_self_ns = self_totals_ns[sub_idx];
                         const sub_ms = @as(f64, @floatFromInt(sub_ns)) / 1_000_000.0;
-                        const sub_pct_of_parent = @as(f64, @floatFromInt(sub_ns)) / @as(f64, @floatFromInt(ns)) * 100.0;
-                        try writer.print("│  └─ {s: <13} {d: >7.2}ms  ({d:.1}% of {s})\n", .{
+                        const sub_self_ms = @as(f64, @floatFromInt(sub_self_ns)) / 1_000_000.0;
+                        const sub_pct_of_parent = @as(f64, @floatFromInt(sub_self_ns)) / @as(f64, @floatFromInt(ns)) * 100.0;
+                        try writer.print("│  └─ {s: <13} {d: >7.2}ms total  {d: >7.2}ms self  ({d:.1}% of {s})\n", .{
                             Category.displayName(sub_cat),
                             sub_ms,
+                            sub_self_ms,
                             sub_pct_of_parent,
                             Category.displayName(cat),
                         });
@@ -569,17 +636,23 @@ fn reportJson(writer: anytype) !void {
         const skip = counts[idx] == 0 or (current_level == .summary and is_sub);
         if (!skip) {
             const ns = totals_ns[idx];
+            const self_ns = self_totals_ns[idx];
             const ms = @as(f64, @floatFromInt(ns)) / 1_000_000.0;
+            const self_ms = @as(f64, @floatFromInt(self_ns)) / 1_000_000.0;
             const pct = if (total > 0)
                 @as(f64, @floatFromInt(ns)) / @as(f64, @floatFromInt(total)) * 100.0
+            else
+                0.0;
+            const self_pct = if (total > 0)
+                @as(f64, @floatFromInt(self_ns)) / @as(f64, @floatFromInt(total)) * 100.0
             else
                 0.0;
 
             if (!first) try writer.writeAll(",\n");
             first = false;
             try writer.print(
-                "    \"{s}\": {{ \"total_ms\": {d:.3}, \"count\": {d}, \"pct\": {d:.2} }}",
-                .{ Category.displayName(cat), ms, counts[idx], pct },
+                "    \"{s}\": {{ \"total_ms\": {d:.3}, \"self_ms\": {d:.3}, \"count\": {d}, \"pct\": {d:.2}, \"self_pct\": {d:.2} }}",
+                .{ Category.displayName(cat), ms, self_ms, counts[idx], pct, self_pct },
             );
         }
     }
@@ -587,7 +660,7 @@ fn reportJson(writer: anytype) !void {
 }
 
 fn reportCsv(writer: anytype) !void {
-    try writer.writeAll("phase,total_ms,count,pct\n");
+    try writer.writeAll("phase,total_ms,self_ms,count,pct,self_pct\n");
     const total = totalAllNs();
 
     inline for (@typeInfo(Category).@"enum".fields) |f| {
@@ -597,13 +670,19 @@ fn reportCsv(writer: anytype) !void {
         const skip = counts[idx] == 0 or (current_level == .summary and is_sub);
         if (!skip) {
             const ns = totals_ns[idx];
+            const self_ns = self_totals_ns[idx];
             const ms = @as(f64, @floatFromInt(ns)) / 1_000_000.0;
+            const self_ms = @as(f64, @floatFromInt(self_ns)) / 1_000_000.0;
             const pct = if (total > 0)
                 @as(f64, @floatFromInt(ns)) / @as(f64, @floatFromInt(total)) * 100.0
             else
                 0.0;
+            const self_pct = if (total > 0)
+                @as(f64, @floatFromInt(self_ns)) / @as(f64, @floatFromInt(total)) * 100.0
+            else
+                0.0;
 
-            try writer.print("{s},{d:.3},{d},{d:.2}\n", .{ Category.displayName(cat), ms, counts[idx], pct });
+            try writer.print("{s},{d:.3},{d:.3},{d},{d:.2},{d:.2}\n", .{ Category.displayName(cat), ms, self_ms, counts[idx], pct, self_pct });
         }
     }
 }
@@ -628,6 +707,7 @@ test "Category.fromString: dot notation 정규화" {
     try testing.expect(Category.fromString("Transform.JSX") == .transform_jsx);
     try testing.expect(Category.fromString("hmr.detect") == .hmr_detect);
     try testing.expect(Category.fromString("shake.fixpoint.bfs") == .shake_fixpoint_bfs);
+    try testing.expect(Category.fromString("shake.fixpoint.bfs.follow.import") == .shake_fixpoint_bfs_follow_import);
     try testing.expect(Category.fromString("shake.const.prepass.build.facts") == .shake_const_prepass_build_facts);
 }
 
@@ -637,6 +717,7 @@ test "Category.displayName: underscore → dot 역변환" {
     try testing.expectEqualStrings("transform.ts.strip", Category.displayName(.transform_ts_strip));
     try testing.expectEqualStrings("hmr.detect", Category.displayName(.hmr_detect));
     try testing.expectEqualStrings("shake.fixpoint.bfs", Category.displayName(.shake_fixpoint_bfs));
+    try testing.expectEqualStrings("shake.fixpoint.bfs.follow.import", Category.displayName(.shake_fixpoint_bfs_follow_import));
     try testing.expectEqualStrings("shake.const.prepass.build.facts", Category.displayName(.shake_const_prepass_build_facts));
 }
 
@@ -714,6 +795,7 @@ test "addFromCsv: shake parent → 모든 sub-phase 활성" {
     try testing.expect(enabled(.shake_const_prepass_build_facts));
     try testing.expect(enabled(.shake_fixpoint));
     try testing.expect(enabled(.shake_fixpoint_bfs));
+    try testing.expect(enabled(.shake_fixpoint_bfs_follow_import));
     try testing.expect(enabled(.shake_numeric_postpass));
 }
 
@@ -767,6 +849,7 @@ test "Scope: 비활성 category 는 zero-cost" {
     try testing.expect(scope.timer == null);
     scope.end();
     try testing.expectEqual(@as(u64, 0), totalNs(.parse));
+    try testing.expectEqual(@as(u64, 0), selfNs(.parse));
     try testing.expectEqual(@as(u32, 0), count(.parse));
 }
 
@@ -785,8 +868,10 @@ test "Scope: 활성 category 는 시간 누적" {
     s2.end();
 
     const total = totalNs(.parse);
+    const self_total = selfNs(.parse);
     // 실제 시간은 OS 스케줄링에 따라 다름. 최소 보장만 검증.
     try testing.expect(total >= 2_000_000);
+    try testing.expect(self_total >= 2_000_000);
     try testing.expectEqual(@as(u32, 2), count(.parse));
 }
 
@@ -809,6 +894,9 @@ test "Scope: nested 호출 누적" {
     try testing.expect(totalNs(.parse_ast_build) > 0);
     // Outer 가 inner 를 포함하는지 대략 검증 — parent 가 child 보다 크거나 같음.
     try testing.expect(totalNs(.parse) >= totalNs(.parse_ast_build));
+    try testing.expect(selfNs(.parse) <= totalNs(.parse));
+    try testing.expect(selfNs(.parse_ast_build) <= totalNs(.parse_ast_build));
+    try testing.expectEqual(totalNs(.parse), totalAllNs());
 }
 
 test "setLevel / level" {
@@ -855,6 +943,7 @@ test "report: json format 기본 구조" {
 
     try testing.expect(std.mem.indexOf(u8, output, "\"profile_version\": 1") != null);
     try testing.expect(std.mem.indexOf(u8, output, "\"total_ms\"") != null);
+    try testing.expect(std.mem.indexOf(u8, output, "\"self_ms\"") != null);
     try testing.expect(std.mem.indexOf(u8, output, "\"phases\"") != null);
     try testing.expect(std.mem.indexOf(u8, output, "\"parse\"") != null);
 }
@@ -873,7 +962,7 @@ test "report: csv format 기본 구조" {
     try report(fbs.writer(), .csv);
     const output = fbs.getWritten();
 
-    try testing.expect(std.mem.startsWith(u8, output, "phase,total_ms,count,pct\n"));
+    try testing.expect(std.mem.startsWith(u8, output, "phase,total_ms,self_ms,count,pct,self_pct\n"));
     try testing.expect(std.mem.indexOf(u8, output, "parse,") != null);
 }
 
@@ -954,5 +1043,6 @@ test "resetForTest 초기화" {
     try testing.expect(!enabled(.parse));
     try testing.expect(level() == .summary);
     try testing.expectEqual(@as(u64, 0), totalNs(.parse));
+    try testing.expectEqual(@as(u64, 0), selfNs(.parse));
     try testing.expectEqual(@as(u32, 0), count(.parse));
 }

--- a/tests/benchmark/const-prepass.ts
+++ b/tests/benchmark/const-prepass.ts
@@ -1,16 +1,16 @@
 #!/usr/bin/env bun
 /**
- * Const prepass tree-shaking profile runner.
+ * Tree-shaking profile runner.
  *
- * This benchmark keeps the synthetic fixtures used while tuning
- * `shake.const.prepass` reproducible. It is intentionally profile-oriented:
- * compare the same machine before/after a tree-shaking change, then keep the
- * JSON output for trend tracking.
+ * This benchmark keeps the synthetic fixtures used while tuning tree-shaking
+ * reproducible. It is intentionally profile-oriented: compare the same machine
+ * before/after a tree-shaking change, then keep the JSON output for trend
+ * tracking.
  *
  * Examples:
  *   bun run tests/benchmark/const-prepass.ts
  *   bun run tests/benchmark/const-prepass.ts --warmup=3 --iterations=9
- *   bun run tests/benchmark/const-prepass.ts --output /tmp/const-prepass.json
+ *   bun run tests/benchmark/const-prepass.ts --output /tmp/tree-shake-profile.json
  */
 
 import { spawnSync } from "node:child_process";
@@ -26,6 +26,17 @@ const DEFAULT_WARMUP = 3;
 const DEFAULT_ITERATIONS = 9;
 
 const TARGET_PHASES = [
+  "shake",
+  "shake.fixpoint",
+  "shake.fixpoint.bfs",
+  "shake.fixpoint.bfs.seed",
+  "shake.fixpoint.bfs.queue",
+  "shake.fixpoint.bfs.follow.import",
+  "shake.fixpoint.bfs.seed.export",
+  "shake.fixpoint.bfs.require.scan",
+  "shake.fixpoint.bfs.final.mark.exports",
+  "shake.fixpoint.bfs.enqueue.side.effects",
+  "shake.fixpoint.re.exports",
   "shake.const.prepass",
   "shake.const.prepass.numeric.propagate",
   "shake.const.prepass.numeric.seed.scan",
@@ -57,8 +68,10 @@ interface FixtureSpec {
 
 interface ProfilePhase {
   total_ms: number;
+  self_ms?: number;
   count: number;
   pct: number;
+  self_pct?: number;
 }
 
 interface ProfileJson {
@@ -70,6 +83,7 @@ interface ProfileJson {
 
 interface PhaseResult {
   total_ms_stats: MetricStats;
+  self_ms_stats: MetricStats;
   count_median: number;
 }
 
@@ -93,6 +107,7 @@ const FIXTURES: FixtureSpec[] = [
   { name: "flat-1000", size: 1000, write: writeFlatFixture },
   { name: "reexport-500", size: 500, write: writeReExportFixture },
   { name: "namespace-500", size: 500, write: writeNamespaceFixture },
+  { name: "namespace-2000", size: 2000, write: writeNamespaceFixture },
 ];
 
 function writeFlatFixture(dir: string, size: number): string {
@@ -151,7 +166,7 @@ function writeNamespaceFixture(dir: string, size: number): string {
 
 function buildBin(): void {
   if (existsSync(ZTS_BIN)) return;
-  console.log("[const-prepass] zts binary not found, building ReleaseFast...");
+  console.log("[tree-shake-profile] zts binary not found, building ReleaseFast...");
   const result = spawnSync("zig", ["build", "-Doptimize=ReleaseFast"], {
     cwd: ROOT,
     stdio: "inherit",
@@ -179,7 +194,7 @@ function runOne(entry: string, outDir: string): ProfileJson {
       "--format=esm",
       "-o",
       join(outDir, "out.js"),
-      "--profile=shake.const.prepass",
+      "--profile=shake",
       "--profile-level=detailed",
       "--profile-format=json",
     ],
@@ -210,7 +225,7 @@ function median(values: number[]): number {
 }
 
 function measureFixture(spec: FixtureSpec, cli: CliArgs): FixtureResult {
-  const tmp = mkdtempSync(join(tmpdir(), "zts-const-prepass-"));
+  const tmp = mkdtempSync(join(tmpdir(), "zts-tree-shake-profile-"));
   try {
     const srcDir = join(tmp, "src");
     const outDir = join(tmp, "dist");
@@ -220,6 +235,7 @@ function measureFixture(spec: FixtureSpec, cli: CliArgs): FixtureResult {
 
     const totalSamples: number[] = [];
     const phaseTimeSamples: Partial<Record<TargetPhase, number[]>> = {};
+    const phaseSelfTimeSamples: Partial<Record<TargetPhase, number[]>> = {};
     const phaseCountSamples: Partial<Record<TargetPhase, number[]>> = {};
     for (let i = 0; i < cli.iterations; i++) {
       const profile = runOne(entry, outDir);
@@ -227,6 +243,7 @@ function measureFixture(spec: FixtureSpec, cli: CliArgs): FixtureResult {
       for (const phase of TARGET_PHASES) {
         const hit = profile.phases[phase];
         (phaseTimeSamples[phase] ??= []).push(hit?.total_ms ?? 0);
+        (phaseSelfTimeSamples[phase] ??= []).push(hit?.self_ms ?? hit?.total_ms ?? 0);
         (phaseCountSamples[phase] ??= []).push(hit?.count ?? 0);
       }
     }
@@ -234,9 +251,11 @@ function measureFixture(spec: FixtureSpec, cli: CliArgs): FixtureResult {
     const phases: Partial<Record<TargetPhase, PhaseResult>> = {};
     for (const phase of TARGET_PHASES) {
       const times = phaseTimeSamples[phase] ?? [];
+      const selfTimes = phaseSelfTimeSamples[phase] ?? [];
       const counts = phaseCountSamples[phase] ?? [];
       phases[phase] = {
         total_ms_stats: computeMetricStats(times),
+        self_ms_stats: computeMetricStats(selfTimes),
         count_median: median(counts),
       };
     }
@@ -262,6 +281,10 @@ function phaseMedian(result: FixtureResult, phase: TargetPhase): number {
 
 function phaseCount(result: FixtureResult, phase: TargetPhase): number {
   return result.phases[phase]?.count_median ?? 0;
+}
+
+function phaseSelfMedian(result: FixtureResult, phase: TargetPhase): number {
+  return result.phases[phase]?.self_ms_stats.median ?? phaseMedian(result, phase);
 }
 
 function parseArgs(argv: string[]): CliArgs {
@@ -315,7 +338,9 @@ Options:
 
 async function main(cli: CliArgs): Promise<void> {
   buildBin();
-  console.log(`[const-prepass] zts ${getCommit()} | warmup=${cli.warmup} iter=${cli.iterations}`);
+  console.log(
+    `[tree-shake-profile] zts ${getCommit()} | warmup=${cli.warmup} iter=${cli.iterations}`,
+  );
   console.log();
 
   const results: FixtureResult[] = [];
@@ -324,7 +349,12 @@ async function main(cli: CliArgs): Promise<void> {
     const result = measureFixture(spec, cli);
     results.push(result);
     console.log(
-      `const=${fmtMs(phaseMedian(result, "shake.const.prepass"))} ` +
+      `shake=${fmtMs(phaseMedian(result, "shake"))} ` +
+        `bfs=${fmtMs(phaseMedian(result, "shake.fixpoint.bfs"))} ` +
+        `bfs.self=${fmtMs(phaseSelfMedian(result, "shake.fixpoint.bfs"))} ` +
+        `seed=${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.seed"))} ` +
+        `queue=${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.queue"))} ` +
+        `const=${fmtMs(phaseMedian(result, "shake.const.prepass"))} ` +
         `build.facts=${fmtMs(phaseMedian(result, "shake.const.prepass.build.facts"))} ` +
         `count=${phaseCount(result, "shake.const.prepass.build.facts")}`,
     );
@@ -341,25 +371,49 @@ async function main(cli: CliArgs): Promise<void> {
 
   if (cli.output) {
     writeFileSync(cli.output, JSON.stringify(report, null, 2) + "\n");
-    console.log(`\n[const-prepass] run report written: ${cli.output}`);
+    console.log(`\n[tree-shake-profile] run report written: ${cli.output}`);
   }
 
   console.log();
-  console.log("### const-prepass profile");
+  console.log("### tree-shake profile");
   console.log(
-    "| Fixture | Total | Const prepass | Numeric propagate | Numeric queue | Build facts | Build count | Minify resync | Minify count |",
+    "| Fixture | Profile total | Shake | Shake self | Const prepass | Build facts | Build count | Fixpoint | BFS | BFS self | BFS seed | BFS queue | Final mark | Re-exports |",
   );
-  console.log("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |");
+  console.log(
+    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+  );
   for (const result of results) {
     console.log(
       `| ${result.name} | ${fmtMs(result.total_ms_stats.median)} | ` +
+        `${fmtMs(phaseMedian(result, "shake"))} | ` +
+        `${fmtMs(phaseSelfMedian(result, "shake"))} | ` +
         `${fmtMs(phaseMedian(result, "shake.const.prepass"))} | ` +
-        `${fmtMs(phaseMedian(result, "shake.const.prepass.numeric.propagate"))} | ` +
-        `${fmtMs(phaseMedian(result, "shake.const.prepass.numeric.queue"))} | ` +
         `${fmtMs(phaseMedian(result, "shake.const.prepass.build.facts"))} | ` +
         `${phaseCount(result, "shake.const.prepass.build.facts")} | ` +
-        `${fmtMs(phaseMedian(result, "shake.const.prepass.minify.resync"))} | ` +
-        `${phaseCount(result, "shake.const.prepass.minify.resync")} |`,
+        `${fmtMs(phaseMedian(result, "shake.fixpoint"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs"))} | ` +
+        `${fmtMs(phaseSelfMedian(result, "shake.fixpoint.bfs"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.seed"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.queue"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.final.mark.exports"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.fixpoint.re.exports"))} |`,
+    );
+  }
+
+  console.log();
+  console.log("### nested bfs helper profile");
+  console.log(
+    "| Fixture | Follow import | Follow self | Seed export | Seed export self | Require scan | Side effects |",
+  );
+  console.log("| --- | ---: | ---: | ---: | ---: | ---: | ---: |");
+  for (const result of results) {
+    console.log(
+      `| ${result.name} | ${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.follow.import"))} | ` +
+        `${fmtMs(phaseSelfMedian(result, "shake.fixpoint.bfs.follow.import"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.seed.export"))} | ` +
+        `${fmtMs(phaseSelfMedian(result, "shake.fixpoint.bfs.seed.export"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.require.scan"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.enqueue.side.effects"))} |`,
     );
   }
 }

--- a/tests/benchmark/package.json
+++ b/tests/benchmark/package.json
@@ -6,6 +6,7 @@
     "bench": "bun run bench.ts",
     "bench:transpile": "bun run bench.ts --transpile",
     "bench:bundle": "bun run bench.ts --bundle",
+    "bench:tree-shake-profile": "bun run const-prepass.ts",
     "bench:const-prepass": "bun run const-prepass.ts",
     "bench:monorepo": "bun run monorepo-perf.ts",
     "bench:minify": "bun run minify-bench.ts",

--- a/tests/integration/tests/profile-flags.test.ts
+++ b/tests/integration/tests/profile-flags.test.ts
@@ -78,7 +78,7 @@ describe("profile CLI flags", () => {
     ]);
 
     expect(result.exitCode).toBe(0);
-    expect(result.stderr).toContain("phase,total_ms,count,pct");
+    expect(result.stderr).toContain("phase,total_ms,self_ms,count,pct,self_pct");
   });
 
   test("--profile-level=detailed 는 tree 포맷과 조합 가능", async () => {
@@ -225,6 +225,7 @@ describe("profile CLI flags", () => {
     const parsed = JSON.parse(result.stderr.slice(result.stderr.indexOf("{")));
     expect(parsed.phases.parse).toBeDefined();
     expect(parsed.phases.parse.total_ms).toBeGreaterThan(0);
+    expect(parsed.phases.parse.self_ms).toBeGreaterThanOrEqual(0);
     expect(parsed.phases.parse.count).toBeGreaterThanOrEqual(1);
   });
 
@@ -253,12 +254,16 @@ describe("profile CLI flags", () => {
     expect(result.exitCode).toBe(0);
     const parsed = JSON.parse(result.stderr.slice(result.stderr.indexOf("{")));
     expect(parsed.phases.shake).toBeDefined();
+    expect(parsed.phases.shake.self_ms).toBeGreaterThanOrEqual(0);
     expect(parsed.phases["shake.const.prepass"]).toBeDefined();
     expect(parsed.phases["shake.const.prepass.numeric.propagate"]).toBeDefined();
     expect(parsed.phases["shake.const.prepass.build.facts"]).toBeDefined();
     expect(parsed.phases["shake.const.prepass.candidate.gate"]).toBeDefined();
     expect(parsed.phases["shake.fixpoint"]).toBeDefined();
     expect(parsed.phases["shake.fixpoint.bfs"]).toBeDefined();
+    expect(parsed.phases["shake.fixpoint.bfs.queue"]).toBeDefined();
+    expect(parsed.phases["shake.fixpoint.bfs.follow.import"]).toBeDefined();
+    expect(parsed.phases["shake.fixpoint.bfs.seed.export"]).toBeDefined();
     expect(parsed.phases["shake.prune"]).toBeDefined();
   });
 });


### PR DESCRIPTION
## 요약
- `shake.fixpoint.bfs` 내부를 `seed`, `queue`, `follow.import`, `seed.export`, `require.scan`, `final.mark.exports`, `enqueue.side.effects`로 세분화했습니다.
- 기존 profiler가 nested scope를 모두 inclusive로 저장하면서 전체 합계도 inclusive phase를 단순 합산하던 문제를 같이 수정했습니다.
  - `total_ms`: 기존 호환성을 위해 해당 phase의 inclusive 시간 유지
  - `self_ms`: 활성 child scope 시간을 뺀 exclusive 시간 추가
  - profile 전체 `total_ms`: 중복 합산을 피하기 위해 `self_ms` 합으로 계산
- `--profile=shake`가 새 BFS 하위 phase와 `self_ms`를 노출하는지 profile CLI 회귀 테스트를 추가했습니다.
- 기존 `tests/benchmark/const-prepass.ts`는 제거하지 않고 tree-shake profile runner로 확장했습니다. 기존 `bench:const-prepass`는 유지하고 `bench:tree-shake-profile` alias를 추가했습니다.

## 루트커즈
처음 올린 표의 합계가 맞지 않았던 이유는 두 가지입니다.

1. profiler의 `Scope.end()`가 parent/child 구분 없이 elapsed time을 그대로 `totals_ns`에 더했습니다. 즉 `shake.fixpoint.bfs`와 그 안의 `shake.fixpoint.bfs.seed`가 동시에 켜지면 같은 시간이 두 번 합산됐습니다.
2. 벤치 출력이 nested helper(`seed.export`, `follow.import`)를 같은 sibling 컬럼처럼 보여줬습니다. `seed.export`는 `seed`와 `queue/follow.import` 내부에서도 호출될 수 있으므로 BFS 1단계 합산 컬럼으로 두면 안 됩니다.

이번 수정 후 합산 가능한 기준은 `self_ms`입니다. 벤치도 BFS 1단계 합산 표와 nested helper 표를 분리했습니다.

## 측정
`bun run tests/benchmark/const-prepass.ts --warmup=3 --iterations=9 --output /tmp/zts-bfs-subprofile-fixed.json`

### tree-shake profile
| Fixture | Profile total | Shake | Shake self | Const prepass | Build facts | Build count | Fixpoint | BFS | BFS self | BFS seed | BFS queue | Final mark | Re-exports |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| flat-1000 | 4.01ms | 4.01ms | 0.70ms | 1.13ms | 0.10ms | 1 | 1.07ms | 0.90ms | 0.00ms | 0.34ms | 0.53ms | 0.04ms | 0.01ms |
| reexport-500 | 2.38ms | 2.38ms | 0.34ms | 0.77ms | 0.05ms | 2 | 0.92ms | 0.67ms | 0.00ms | 0.43ms | 0.21ms | 0.02ms | 0.02ms |
| namespace-500 | 2.40ms | 2.40ms | 0.43ms | 0.72ms | 0.11ms | 2 | 1.03ms | 0.70ms | 0.00ms | 0.50ms | 0.18ms | 0.02ms | 0.10ms |
| namespace-2000 | 24.1ms | 24.1ms | 5.42ms | 5.29ms | 1.52ms | 2 | 10.2ms | 7.15ms | 0.00ms | 6.23ms | 0.83ms | 0.10ms | 0.44ms |

### nested bfs helper profile
| Fixture | Follow import | Follow self | Seed export | Seed export self | Require scan | Side effects |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| flat-1000 | 0.10ms | 0.04ms | 0.29ms | 0.27ms | 0.36ms | 0.04ms |
| reexport-500 | 0.18ms | 0.02ms | 0.56ms | 0.56ms | 0.01ms | 0.01ms |
| namespace-500 | 0.15ms | 0.05ms | 0.57ms | 0.56ms | 0.01ms | 0.01ms |
| namespace-2000 | 0.71ms | 0.18ms | 6.55ms | 6.51ms | 0.04ms | 0.05ms |

`namespace-2000` 기준으로 BFS 1단계 합계는 `7.15ms ~= seed 6.23 + queue 0.83 + final 0.10 + self 0.00`로 맞습니다.

## 검증
- `zig build test -Dtest-filter=profile --summary all`
- `zig build test -Dtest-filter="virtual ns" --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- `bun test tests/integration/tests/profile-flags.test.ts`
- `bun run --cwd tests/benchmark bench:tree-shake-profile --warmup=1 --iterations=1`
- `zig build test --summary all`
- `bun run fmt:check`
- `bun run lint` (기존 `tests/integration/tests/bundle-dynamic-import.test.ts` unused import 경고 3개, 에러 없음)
- `git diff --check`
- `bun run tests/benchmark/bundle-perf.ts --no-fail --output /tmp/zts-bfs-subprofile-bundle-perf.json` (저장 baseline이 오래되어 REGRESS 표시는 참고용)
- pre-push hook: `zig fmt --check src/...`, `zig build test`

Updates #2354
