### PR TITLE
perf(tree-shake): avoid opaque namespace seed fanout

### DIFF
--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -123,6 +123,9 @@ pub const TreeShaker = struct {
     /// 다시 훑지 않도록 module index -> exported namespace name -> source module index 를
     /// lazy 구축한다.
     re_export_namespace_sources: []?std.StringHashMapUnmanaged(u32) = &.{},
+    /// seedExport(target module, exported name) 중복 처리 방지용 per-BFS scratch.
+    /// 키 문자열은 모듈/바인딩 storage가 소유하므로 별도 복사하지 않는다.
+    seeded_exports: std.HashMapUnmanaged(SeededExportKey, void, SeededExportKeyContext, 80) = .empty,
     /// numeric const fact propagation 의 DFS 스크래치. propagateNumericExportConstFacts /
     /// nodeContainsNumericConstRef / nodeIsNumericLiteralFoldSeed 가 매 호출마다
     /// ArrayList 를 새로 만들지 않도록 재사용. clearRetainingCapacity 로만 비운다.
@@ -137,6 +140,24 @@ pub const TreeShaker = struct {
 
     const max_fixpoint_iterations: u32 = 100;
     const max_numeric_const_post_passes: u32 = 2;
+
+    const SeededExportKey = struct {
+        module_index: u32,
+        export_name: []const u8,
+    };
+
+    const SeededExportKeyContext = struct {
+        pub fn hash(_: SeededExportKeyContext, key: SeededExportKey) u64 {
+            var h = std.hash.Wyhash.init(0);
+            h.update(std.mem.asBytes(&key.module_index));
+            h.update(key.export_name);
+            return h.final();
+        }
+
+        pub fn eql(_: SeededExportKeyContext, a: SeededExportKey, b: SeededExportKey) bool {
+            return a.module_index == b.module_index and std.mem.eql(u8, a.export_name, b.export_name);
+        }
+    };
 
     const ReExportNsConsumerUsage = struct {
         opaque_all: bool = false,
@@ -227,6 +248,7 @@ pub const TreeShaker = struct {
             }
             self.allocator.free(self.re_export_namespace_sources);
         }
+        self.seeded_exports.deinit(self.allocator);
         if (self.reachable_stmts.len > 0) {
             for (self.reachable_stmts) |*rs| {
                 if (rs.*) |*bs| bs.deinit();
@@ -1006,6 +1028,14 @@ pub const TreeShaker = struct {
         return self.used_exports.contains(key);
     }
 
+    fn markSeedExportVisited(self: *TreeShaker, module_index: u32, export_name: []const u8) !bool {
+        const entry = try self.seeded_exports.getOrPut(self.allocator, .{
+            .module_index = module_index,
+            .export_name = export_name,
+        });
+        return !entry.found_existing;
+    }
+
     /// import binding의 심볼이 해당 모듈에서 reachable statement에서 참조되는지 확인.
     /// emitter가 export_bindings 필터링에 사용.
     pub fn isImportLiveInModule(self: *const TreeShaker, module_index: u32, local_name: []const u8) bool {
@@ -1146,6 +1176,8 @@ pub const TreeShaker = struct {
     ) std.mem.Allocator.Error!void {
         var scope = profile.begin(.shake_fixpoint_bfs);
         defer scope.end();
+
+        self.seeded_exports.clearRetainingCapacity();
 
         var queue: std.ArrayListUnmanaged(BfsItem) = .empty;
         defer queue.deinit(self.allocator);
@@ -1514,15 +1546,29 @@ pub const TreeShaker = struct {
         var seed_scope = profile.begin(.shake_fixpoint_bfs_seed_export);
         defer seed_scope.end();
 
+        if (!try self.markSeedExportVisited(@intCast(target_mod), imported_name)) return;
+
         const mod_count = self.graph.moduleCount();
-        const canonical = self.linker.resolveExportChain(@enumFromInt(@as(u32, @intCast(target_mod))), imported_name, 0) orelse return;
+        const canonical = blk: {
+            var resolve_scope = profile.begin(.shake_fixpoint_bfs_seed_export_resolve);
+            defer resolve_scope.end();
+            break :blk self.linker.resolveExportChain(@enumFromInt(@as(u32, @intCast(target_mod))), imported_name, 0) orelse return;
+        };
         const canon_mod = canonical.module_index.toU32();
         const canon_m = self.graph.getModule(canonical.module_index) orelse return;
 
-        try self.markExportUsed(canon_mod, canonical.export_name);
-        self.included.set(canon_mod);
+        {
+            var mark_scope = profile.begin(.shake_fixpoint_bfs_seed_export_mark);
+            defer mark_scope.end();
+
+            try self.markExportUsed(canon_mod, canonical.export_name);
+            self.included.set(canon_mod);
+        }
 
         if (canon_m.wrap_kind == .cjs) {
+            var cjs_scope = profile.begin(.shake_fixpoint_bfs_seed_export_cjs);
+            defer cjs_scope.end();
+
             if (canon_mod != target_mod) {
                 try self.markAndSeedAllStmts(canon_mod, queue, module_stmt_infos, reachable_stmts);
                 return;
@@ -1544,23 +1590,33 @@ pub const TreeShaker = struct {
 
         // namespace barrel re-export: canonical이 namespace import를 가리키면
         // 소스 모듈의 모든 export를 시드해야 함 (import * as z; export { z } 패턴)
-        const canon_local = self.linker.getExportLocalName(@intCast(canon_mod), canonical.export_name) orelse canonical.export_name;
-        for (canon_m.import_bindings) |cib| {
-            if (cib.kind == .namespace and std.mem.eql(u8, cib.local_name, canon_local)) {
-                if (cib.import_record_index < canon_m.import_records.len) {
-                    const ns_src_idx = canon_m.import_records[cib.import_record_index].resolved;
-                    if (self.graph.getModule(ns_src_idx) != null) {
-                        const ns_src = @intFromEnum(ns_src_idx);
-                        try self.markAllExportsUsed(@intCast(ns_src));
-                        self.included.set(ns_src);
-                        try self.seedAllStmts(@intCast(ns_src), queue, module_stmt_infos, reachable_stmts);
+        var cached_canon_local: ?[]const u8 = null;
+        if (canon_m.import_bindings.len > 0) {
+            var namespace_scope = profile.begin(.shake_fixpoint_bfs_seed_export_namespace_scan);
+            defer namespace_scope.end();
+
+            const canon_local = self.linker.getExportLocalName(@intCast(canon_mod), canonical.export_name) orelse canonical.export_name;
+            cached_canon_local = canon_local;
+            for (canon_m.import_bindings) |cib| {
+                if (cib.kind == .namespace and std.mem.eql(u8, cib.local_name, canon_local)) {
+                    if (cib.import_record_index < canon_m.import_records.len) {
+                        const ns_src_idx = canon_m.import_records[cib.import_record_index].resolved;
+                        if (self.graph.getModule(ns_src_idx) != null) {
+                            const ns_src = @intFromEnum(ns_src_idx);
+                            try self.markAllExportsUsed(@intCast(ns_src));
+                            self.included.set(ns_src);
+                            try self.seedAllStmts(@intCast(ns_src), queue, module_stmt_infos, reachable_stmts);
+                        }
                     }
+                    break;
                 }
-                break;
             }
         }
 
         if (canon_mod != target_mod and target_mod < mod_count) {
+            var intermediate_scope = profile.begin(.shake_fixpoint_bfs_seed_export_intermediate);
+            defer intermediate_scope.end();
+
             try self.markExportUsed(@intCast(target_mod), imported_name);
             self.included.set(target_mod);
             // 중간 모듈의 export 선언 statement도 reachable로 마킹
@@ -1578,19 +1634,43 @@ pub const TreeShaker = struct {
         }
 
         const target_module = canon_m;
+        var semantic_scope = profile.begin(.shake_fixpoint_bfs_seed_export_semantic_lookup);
         const target_sem = target_module.semantic orelse {
+            semantic_scope.end();
+            var opaque_scope = profile.begin(.shake_fixpoint_bfs_seed_export_opaque);
+            defer opaque_scope.end();
             try self.seedOpaqueModule(@intCast(canon_mod), queue, module_stmt_infos, reachable_stmts);
             return;
         };
-        if (target_sem.scope_maps.len == 0) return;
+        if (target_sem.scope_maps.len == 0) {
+            semantic_scope.end();
+            return;
+        }
 
-        const local_name = self.linker.getExportLocalName(@intCast(canon_mod), canonical.export_name) orelse canonical.export_name;
-        const sym_idx = target_sem.scope_maps[0].get(local_name) orelse return;
+        const sym_idx = if (target_module.findExportSymbol(canonical.export_name).semanticIndex()) |direct_sym|
+            direct_sym
+        else blk: {
+            const local_name = cached_canon_local orelse (self.linker.getExportLocalName(@intCast(canon_mod), canonical.export_name) orelse canonical.export_name);
+            break :blk target_sem.scope_maps[0].get(local_name) orelse {
+                semantic_scope.end();
+                return;
+            };
+        };
         const target_infos = module_stmt_infos[canon_mod] orelse {
+            semantic_scope.end();
+            var opaque_scope = profile.begin(.shake_fixpoint_bfs_seed_export_opaque);
+            defer opaque_scope.end();
             try self.seedOpaqueModule(@intCast(canon_mod), queue, module_stmt_infos, reachable_stmts);
             return;
         };
-        try self.enqueueSymbolLiveStatements(@intCast(canon_mod), target_infos, @intCast(sym_idx), reachable_stmts, queue);
+        semantic_scope.end();
+
+        {
+            var enqueue_scope = profile.begin(.shake_fixpoint_bfs_seed_export_enqueue_symbol);
+            defer enqueue_scope.end();
+
+            try self.enqueueSymbolLiveStatements(@intCast(canon_mod), target_infos, @intCast(sym_idx), reachable_stmts, queue);
+        }
 
         // side-effect statement는 enqueueStmt에서 lazy 시드됨
     }
@@ -1768,6 +1848,20 @@ pub const TreeShaker = struct {
                     try self.seedAllStmts(@intCast(target), queue, module_stmt_infos, reachable_stmts);
                 }
             } else {
+                if (ib.kind == .named and ib.namespace_used_properties != null) {
+                    const ns_source_map = try self.ensureReExportNamespaceSourceMap(@intCast(target));
+                    if (ns_source_map) |map| {
+                        if (map.get(ib.imported_name)) |inner_src| {
+                            if (!self.included.isSet(target)) self.included.set(target);
+                            if (!self.included.isSet(inner_src)) self.included.set(inner_src);
+                            for (ib.namespace_used_properties.?) |prop_name| {
+                                try self.seedExport(@intCast(inner_src), prop_name, queue, module_stmt_infos, reachable_stmts);
+                            }
+                            try self.markExportUsed(@intCast(target), ib.imported_name);
+                            continue;
+                        }
+                    }
+                }
                 try self.seedExport(target, ib.imported_name, queue, module_stmt_infos, reachable_stmts);
             }
         }

--- a/src/bundler/tree_shaker_test.zig
+++ b/src/bundler/tree_shaker_test.zig
@@ -69,6 +69,7 @@ fn buildAndShakeWithOpts(
     var linker = Linker.init(allocator, graph, .esm);
     try linker.link();
     linker.populateImportSymbols();
+    linker.populateNamespaceAccesses();
 
     var shaker = try TreeShaker.init(allocator, graph, &linker);
     try shaker.analyze(&.{entry});
@@ -2070,6 +2071,34 @@ test "#1558 Phase 5: namespace entry — 특정 prop만 쓰면 나머지 전체 
     try std.testing.expect(!r.shaker.isExportUsed(lib, "string"));
     try std.testing.expect(!r.shaker.isExportUsed(lib, "number"));
     try std.testing.expect(!r.shaker.isExportUsed(lib, "array"));
+}
+
+test "#1558 Phase 5: named re-export namespace entry — 사용된 prop만 source에 seed" {
+    // entry가 `export * as ns` barrel에서 named import를 하고 ns.used만 읽는 경로.
+    // seedOpaqueModule이 barrel.ns를 먼저 넓게 seed하면 source 전체가 live로 번질 수 있다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { ns } from './barrel';
+        \\console.log(ns.used());
+    );
+    try writeFile(tmp.dir, "barrel.ts", "export * as ns from './mod';");
+    try writeFile(tmp.dir, "mod.ts",
+        \\export function used() { return 1; }
+        \\export function unused() { return 2; }
+    );
+
+    var r = try buildAndShakeWithOpts(std.testing.allocator, &tmp, "entry.ts", &.{ "barrel.ts", "mod.ts" });
+    defer r.deinit();
+
+    const barrel = r.findModule("barrel.ts").?;
+    const mod = r.findModule("mod.ts").?;
+    try std.testing.expect(r.shaker.isIncluded(barrel));
+    try std.testing.expect(r.shaker.isIncluded(mod));
+    try std.testing.expect(r.shaker.isExportUsed(barrel, "ns"));
+    try std.testing.expect(r.shaker.isExportUsed(mod, "used"));
+    try std.testing.expect(!r.shaker.isExportUsed(mod, "unused"));
+    try std.testing.expect(!r.shaker.isExportUsed(mod, ALL_EXPORTS_SENTINEL));
 }
 
 test "#1558 Phase 5: non-entry 모듈의 dead export 안 import는 상위 전파하지 않는다" {

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -131,6 +131,14 @@ pub const Category = enum {
     shake_fixpoint_bfs_require_scan,
     shake_fixpoint_bfs_final_mark_exports,
     shake_fixpoint_bfs_enqueue_side_effects,
+    shake_fixpoint_bfs_seed_export_resolve,
+    shake_fixpoint_bfs_seed_export_mark,
+    shake_fixpoint_bfs_seed_export_cjs,
+    shake_fixpoint_bfs_seed_export_namespace_scan,
+    shake_fixpoint_bfs_seed_export_intermediate,
+    shake_fixpoint_bfs_seed_export_semantic_lookup,
+    shake_fixpoint_bfs_seed_export_enqueue_symbol,
+    shake_fixpoint_bfs_seed_export_opaque,
     shake_fixpoint_process_imports,
     shake_fixpoint_re_exports,
     shake_fixpoint_eval_deps,
@@ -708,6 +716,7 @@ test "Category.fromString: dot notation 정규화" {
     try testing.expect(Category.fromString("hmr.detect") == .hmr_detect);
     try testing.expect(Category.fromString("shake.fixpoint.bfs") == .shake_fixpoint_bfs);
     try testing.expect(Category.fromString("shake.fixpoint.bfs.follow.import") == .shake_fixpoint_bfs_follow_import);
+    try testing.expect(Category.fromString("shake.fixpoint.bfs.seed.export.resolve") == .shake_fixpoint_bfs_seed_export_resolve);
     try testing.expect(Category.fromString("shake.const.prepass.build.facts") == .shake_const_prepass_build_facts);
 }
 
@@ -718,6 +727,7 @@ test "Category.displayName: underscore → dot 역변환" {
     try testing.expectEqualStrings("hmr.detect", Category.displayName(.hmr_detect));
     try testing.expectEqualStrings("shake.fixpoint.bfs", Category.displayName(.shake_fixpoint_bfs));
     try testing.expectEqualStrings("shake.fixpoint.bfs.follow.import", Category.displayName(.shake_fixpoint_bfs_follow_import));
+    try testing.expectEqualStrings("shake.fixpoint.bfs.seed.export.resolve", Category.displayName(.shake_fixpoint_bfs_seed_export_resolve));
     try testing.expectEqualStrings("shake.const.prepass.build.facts", Category.displayName(.shake_const_prepass_build_facts));
 }
 
@@ -796,6 +806,7 @@ test "addFromCsv: shake parent → 모든 sub-phase 활성" {
     try testing.expect(enabled(.shake_fixpoint));
     try testing.expect(enabled(.shake_fixpoint_bfs));
     try testing.expect(enabled(.shake_fixpoint_bfs_follow_import));
+    try testing.expect(enabled(.shake_fixpoint_bfs_seed_export_resolve));
     try testing.expect(enabled(.shake_numeric_postpass));
 }
 

--- a/tests/benchmark/const-prepass.ts
+++ b/tests/benchmark/const-prepass.ts
@@ -36,6 +36,14 @@ const TARGET_PHASES = [
   "shake.fixpoint.bfs.require.scan",
   "shake.fixpoint.bfs.final.mark.exports",
   "shake.fixpoint.bfs.enqueue.side.effects",
+  "shake.fixpoint.bfs.seed.export.resolve",
+  "shake.fixpoint.bfs.seed.export.mark",
+  "shake.fixpoint.bfs.seed.export.cjs",
+  "shake.fixpoint.bfs.seed.export.namespace.scan",
+  "shake.fixpoint.bfs.seed.export.intermediate",
+  "shake.fixpoint.bfs.seed.export.semantic.lookup",
+  "shake.fixpoint.bfs.seed.export.enqueue.symbol",
+  "shake.fixpoint.bfs.seed.export.opaque",
   "shake.fixpoint.re.exports",
   "shake.const.prepass",
   "shake.const.prepass.numeric.propagate",
@@ -403,15 +411,25 @@ async function main(cli: CliArgs): Promise<void> {
   console.log();
   console.log("### nested bfs helper profile");
   console.log(
-    "| Fixture | Follow import | Follow self | Seed export | Seed export self | Require scan | Side effects |",
+    "| Fixture | Follow import | Follow self | Seed export | Seed export self | Resolve | Mark | CJS | Namespace scan | Intermediate | Semantic lookup | Enqueue symbol | Opaque | Require scan | Side effects |",
   );
-  console.log("| --- | ---: | ---: | ---: | ---: | ---: | ---: |");
+  console.log(
+    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+  );
   for (const result of results) {
     console.log(
       `| ${result.name} | ${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.follow.import"))} | ` +
         `${fmtMs(phaseSelfMedian(result, "shake.fixpoint.bfs.follow.import"))} | ` +
         `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.seed.export"))} | ` +
         `${fmtMs(phaseSelfMedian(result, "shake.fixpoint.bfs.seed.export"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.seed.export.resolve"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.seed.export.mark"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.seed.export.cjs"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.seed.export.namespace.scan"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.seed.export.intermediate"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.seed.export.semantic.lookup"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.seed.export.enqueue.symbol"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.seed.export.opaque"))} | ` +
         `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.require.scan"))} | ` +
         `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.enqueue.side.effects"))} |`,
     );

--- a/tests/integration/tests/profile-flags.test.ts
+++ b/tests/integration/tests/profile-flags.test.ts
@@ -264,6 +264,7 @@ describe("profile CLI flags", () => {
     expect(parsed.phases["shake.fixpoint.bfs.queue"]).toBeDefined();
     expect(parsed.phases["shake.fixpoint.bfs.follow.import"]).toBeDefined();
     expect(parsed.phases["shake.fixpoint.bfs.seed.export"]).toBeDefined();
+    expect(parsed.phases["shake.fixpoint.bfs.seed.export.resolve"]).toBeDefined();
     expect(parsed.phases["shake.prune"]).toBeDefined();
   });
 });


### PR DESCRIPTION
## 요약
- `seedExport` 내부를 resolve/mark/CJS/namespace scan/intermediate/semantic lookup/enqueue/opaque로 세분화해서 추후 병목을 계속 계측할 수 있게 했습니다.
- entry/opaque seed 경로가 `import { ns } from "./barrel"; ns.used` 형태의 `export * as ns`를 먼저 `barrel.ns`로 넓게 seed하던 경로를 줄였습니다.
- named virtual namespace는 이미 수집된 `namespace_used_properties`를 사용해 source member만 직접 seed하고, 중복 `seedExport(target, name)` 호출은 per-BFS scratch map으로 건너뜁니다.
- tree-shaker 단위 테스트 헬퍼가 실제 linker finalize 경로처럼 `populateNamespaceAccesses()`를 호출하도록 맞추고, named re-export namespace가 사용된 prop만 source에 seed하는 회귀 테스트를 추가했습니다.

## 측정
`bun run tests/benchmark/const-prepass.ts --warmup=3 --iterations=9` 기준입니다.

| Fixture | main shake | current shake | main BFS | current BFS | main seedExport | current seedExport |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| namespace-2000 | 24.3ms | 19.4ms | 7.12ms | 1.99ms | 6.57ms | 1.27ms |

추가로 동일 namespace fixture를 최신 main 바이너리와 이 브랜치 바이너리로 번들링한 뒤 `cmp`로 비교했고, 출력 `out.js`는 동일했습니다.

## 검증
- `zig build test -Dtest-filter="named re-export namespace entry" --summary all`
- `zig build test -Dtest-filter="virtual ns" --summary all`
- `zig build test -Dtest-filter=profile --summary all`
- `bun test tests/integration/tests/profile-flags.test.ts`
- `zig build -Doptimize=ReleaseFast --summary all`
- `bun run tests/benchmark/const-prepass.ts --warmup=3 --iterations=9 --output /tmp/zts-seedexport-final2.json`
- `bun run --cwd tests/benchmark bench:tree-shake-profile --warmup=1 --iterations=1`
- `zig build test --summary all`
- `bun run fmt:check`
- `bun run lint` (기존 `tests/integration/tests/bundle-dynamic-import.test.ts` unused import 경고 3개만 출력, 에러 없음)
- `git diff --check`

Updates #2354