### PR TITLE
refactor(profile): consolidate beginMaybe + benchmark helpers

### DIFF
--- a/src/bundler/constant_facts.zig
+++ b/src/bundler/constant_facts.zig
@@ -98,11 +98,6 @@ pub const MaterializeProfile = struct {
     replace: ?profile.Category = null,
 };
 
-inline fn beginMaybe(cat: ?profile.Category) profile.Scope {
-    if (cat) |c| return profile.begin(c);
-    return .{};
-}
-
 /// Linker가 증명한 primitive constants를 AST read-site에 반영한다.
 /// codegen-only 치환은 branch body refs를 줄이지 못하므로, minify/DCE 전 literal로
 /// materialize해야 dead branch와 그 안의 imports가 다음 pass에서 사라질 수 있다.
@@ -135,14 +130,14 @@ pub fn materializeWithScratch(
         if (scratch) |s| if (mod_idx < s.forbidden.len) {
             if (s.forbidden[mod_idx]) |*cached| break :blk cached;
             var bs = std.DynamicBitSet.initEmpty(allocator, ast.nodes.items.len) catch return false;
-            var forbidden_scope = beginMaybe(profile_cats.forbidden);
+            var forbidden_scope = profile.beginMaybe(profile_cats.forbidden);
             defer forbidden_scope.end();
             minify_mod.markForbiddenInlineSites(ast, &bs);
             s.forbidden[mod_idx] = bs;
             break :blk &s.forbidden[mod_idx].?;
         };
         owned_forbidden = std.DynamicBitSet.initEmpty(allocator, ast.nodes.items.len) catch return false;
-        var forbidden_scope = beginMaybe(profile_cats.forbidden);
+        var forbidden_scope = profile.beginMaybe(profile_cats.forbidden);
         defer forbidden_scope.end();
         minify_mod.markForbiddenInlineSites(ast, &owned_forbidden.?);
         break :blk &owned_forbidden.?;
@@ -154,13 +149,13 @@ pub fn materializeWithScratch(
     const reachable: []const u32 = blk: {
         if (scratch) |s| if (mod_idx < s.reachable.len) {
             if (s.reachable[mod_idx]) |cached| break :blk cached;
-            var reachable_scope = beginMaybe(profile_cats.reachable);
+            var reachable_scope = profile.beginMaybe(profile_cats.reachable);
             defer reachable_scope.end();
             const built = ast_walk.collectReachableNodeIndices(allocator, ast) catch return false;
             s.reachable[mod_idx] = built;
             break :blk built;
         };
-        var reachable_scope = beginMaybe(profile_cats.reachable);
+        var reachable_scope = profile.beginMaybe(profile_cats.reachable);
         defer reachable_scope.end();
         owned_reachable = ast_walk.collectReachableNodeIndices(allocator, ast) catch return false;
         break :blk owned_reachable.?;
@@ -168,7 +163,7 @@ pub fn materializeWithScratch(
 
     var changed = false;
     {
-        var replace_scope = beginMaybe(profile_cats.replace);
+        var replace_scope = profile.beginMaybe(profile_cats.replace);
         defer replace_scope.end();
 
         for (reachable) |ni| {

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -86,11 +86,6 @@ const ConstMaterializeProfile = struct {
     inner: constant_facts.MaterializeProfile = .{},
 };
 
-inline fn beginProfileMaybe(cat: ?profile.Category) profile.Scope {
-    if (cat) |c| return profile.begin(c);
-    return .{};
-}
-
 pub const TreeShaker = struct {
     allocator: std.mem.Allocator,
     /// Module storage 접근 포인터 (#1779 PR #2). 기존 `[]const Module` slice
@@ -465,7 +460,7 @@ pub const TreeShaker = struct {
         ast: *Ast,
         profile_cat: ?profile.Category,
     ) void {
-        var scope = beginProfileMaybe(profile_cat);
+        var scope = profile.beginMaybe(profile_cat);
         defer scope.end();
 
         const minify_mod = @import("../transformer/minify.zig");
@@ -524,12 +519,12 @@ pub const TreeShaker = struct {
         const sem = m.semantic orelse return false;
         const ast = &(m.ast orelse return false);
         var const_values = blk: {
-            var build_scope = beginProfileMaybe(const_profile.build_facts);
+            var build_scope = profile.beginMaybe(const_profile.build_facts);
             defer build_scope.end();
             break :blk try self.linker.buildCrossModuleConstValues(m, sem);
         };
         const should_materialize = blk: {
-            var gate_scope = beginProfileMaybe(const_profile.candidate_gate);
+            var gate_scope = profile.beginMaybe(const_profile.candidate_gate);
             defer gate_scope.end();
             break :blk self.shouldMaterializeConstFacts(ast, sem, &const_values, filter);
         };
@@ -543,7 +538,7 @@ pub const TreeShaker = struct {
         }
         const scratch_ptr: ?*constant_facts.Scratch = if (self.materialize_scratch) |*s| s else null;
         const changed = blk: {
-            var materialize_scope = beginProfileMaybe(const_profile.materialize);
+            var materialize_scope = profile.beginMaybe(const_profile.materialize);
             defer materialize_scope.end();
             break :blk constant_facts.materializeWithScratch(self.allocator, ast, sem.symbol_ids, &const_values, scratch_ptr, module_index, const_profile.inner);
         };
@@ -1543,10 +1538,10 @@ pub const TreeShaker = struct {
         module_stmt_infos: []?StmtInfos,
         reachable_stmts: []?std.DynamicBitSet,
     ) std.mem.Allocator.Error!void {
+        if (!try self.markSeedExportVisited(@intCast(target_mod), imported_name)) return;
+
         var seed_scope = profile.begin(.shake_fixpoint_bfs_seed_export);
         defer seed_scope.end();
-
-        if (!try self.markSeedExportVisited(@intCast(target_mod), imported_name)) return;
 
         const mod_count = self.graph.moduleCount();
         const canonical = blk: {

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -485,6 +485,12 @@ pub inline fn begin(cat: Category) Scope {
     };
 }
 
+/// sub-phase profile category 가 optional 일 때 (off → null) 사용.
+pub inline fn beginMaybe(cat: ?Category) Scope {
+    if (cat) |c| return begin(c);
+    return .{};
+}
+
 fn recordTiming(cat: Category, ns: u64, self_ns: u64) void {
     const idx = @intFromEnum(cat);
     totals_ns[idx] += ns;

--- a/tests/benchmark/_runner.ts
+++ b/tests/benchmark/_runner.ts
@@ -1,0 +1,62 @@
+/**
+ * Benchmark runner 들이 공유하는 zts 바이너리 호출/git/CLI 파싱 헬퍼.
+ *
+ * 동일한 buildBin/getCommit/parsePositiveInt/parseProfileJson 가
+ * bundle-perf / monorepo-perf / const-prepass 에 중복돼 있어 통합.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+export const ROOT = resolve(__dirname, "../..");
+export const ZTS_BIN = join(ROOT, "zig-out/bin/zts");
+
+export function buildBin(label: string): void {
+  if (existsSync(ZTS_BIN)) return;
+  console.log(`[${label}] zts binary not found, building ReleaseFast...`);
+  const r = spawnSync("zig", ["build", "-Doptimize=ReleaseFast"], {
+    cwd: ROOT,
+    stdio: "inherit",
+  });
+  if (r.status !== 0) throw new Error("zig build failed");
+}
+
+export function getCommit(): string {
+  const r = spawnSync("git", ["rev-parse", "--short", "HEAD"], {
+    cwd: ROOT,
+    stdio: "pipe",
+  });
+  return r.stdout.toString().trim() || "unknown";
+}
+
+export function parsePositiveInt(name: string, raw: string | undefined): number {
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1) throw new Error(`${name} must be a positive integer`);
+  return n;
+}
+
+export interface ProfilePhase {
+  total_ms: number;
+  count: number;
+  pct: number;
+  self_ms?: number;
+  self_pct?: number;
+}
+
+export interface ProfileJson {
+  profile_version: number;
+  total_ms: number;
+  level: string;
+  phases: Record<string, ProfilePhase | undefined>;
+}
+
+/// stdout/stderr 에 섞여 나온 `--profile-format=json` 블록을 추출해 파싱.
+export function parseProfileJson(output: string): ProfileJson {
+  const start = output.indexOf("{");
+  const end = output.lastIndexOf("}");
+  if (start < 0 || end < start) {
+    throw new Error(`missing profile JSON output: ${output.slice(0, 800)}`);
+  }
+  return JSON.parse(output.slice(start, end + 1)) as ProfileJson;
+}

--- a/tests/benchmark/bundle-perf.ts
+++ b/tests/benchmark/bundle-perf.ts
@@ -26,11 +26,10 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
+import { ROOT, ZTS_BIN, buildBin as buildBinShared, getCommit } from "./_runner";
 import { computeMetricStats, formatMetric, type MetricStats } from "./stats";
 
-const ROOT = resolve(__dirname, "../..");
-const ZTS_BIN = join(ROOT, "zig-out/bin/zts");
 const BASELINE_PATH = join(__dirname, "baselines", "bundle-perf.json");
 
 const WARMUP = 5;
@@ -165,18 +164,7 @@ interface BaselineFile {
 // ─── 메인 ───
 
 function buildBin() {
-  if (existsSync(ZTS_BIN)) return;
-  console.log("[bundle-perf] zts binary not found, building Release...");
-  const r = spawnSync("zig", ["build", "-Doptimize=ReleaseFast"], {
-    cwd: ROOT,
-    stdio: "inherit",
-  });
-  if (r.status !== 0) throw new Error("zig build failed");
-}
-
-function getCommit(): string {
-  const r = spawnSync("git", ["rev-parse", "--short", "HEAD"], { cwd: ROOT, stdio: "pipe" });
-  return r.stdout.toString().trim() || "unknown";
+  buildBinShared("bundle-perf");
 }
 
 async function measureFixture(spec: FixtureSpec): Promise<FixtureResult> {

--- a/tests/benchmark/const-prepass.ts
+++ b/tests/benchmark/const-prepass.ts
@@ -14,13 +14,23 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
+import {
+  ROOT,
+  ZTS_BIN,
+  buildBin as buildBinShared,
+  getCommit,
+  parsePositiveInt,
+  parseProfileJson,
+  type ProfileJson,
+} from "./_runner";
 import { computeMetricStats, formatMetric, type MetricStats } from "./stats";
 
-const ROOT = resolve(__dirname, "../..");
-const ZTS_BIN = join(ROOT, "zig-out/bin/zts");
+function buildBin(): void {
+  buildBinShared("tree-shake-profile");
+}
 
 const DEFAULT_WARMUP = 3;
 const DEFAULT_ITERATIONS = 9;
@@ -72,21 +82,6 @@ interface FixtureSpec {
   name: string;
   size: number;
   write: (dir: string, size: number) => string;
-}
-
-interface ProfilePhase {
-  total_ms: number;
-  self_ms?: number;
-  count: number;
-  pct: number;
-  self_pct?: number;
-}
-
-interface ProfileJson {
-  profile_version: number;
-  total_ms: number;
-  level: string;
-  phases: Record<string, ProfilePhase | undefined>;
 }
 
 interface PhaseResult {
@@ -172,25 +167,6 @@ function writeNamespaceFixture(dir: string, size: number): string {
   return join(dir, "entry.ts");
 }
 
-function buildBin(): void {
-  if (existsSync(ZTS_BIN)) return;
-  console.log("[tree-shake-profile] zts binary not found, building ReleaseFast...");
-  const result = spawnSync("zig", ["build", "-Doptimize=ReleaseFast"], {
-    cwd: ROOT,
-    stdio: "inherit",
-  });
-  if (result.status !== 0) throw new Error("zig build failed");
-}
-
-function getCommit(): string {
-  const result = spawnSync("git", ["rev-parse", "--short", "HEAD"], {
-    cwd: ROOT,
-    encoding: "utf8",
-    stdio: "pipe",
-  });
-  return result.stdout.trim() || "unknown";
-}
-
 function runOne(entry: string, outDir: string): ProfileJson {
   rmSync(outDir, { recursive: true, force: true });
   mkdirSync(outDir, { recursive: true });
@@ -217,15 +193,6 @@ function runOne(entry: string, outDir: string): ProfileJson {
     throw new Error(`zts failed: ${result.stderr.slice(0, 800)}`);
   }
   return parseProfileJson(`${result.stdout}\n${result.stderr}`);
-}
-
-function parseProfileJson(output: string): ProfileJson {
-  const start = output.indexOf("{");
-  const end = output.lastIndexOf("}");
-  if (start < 0 || end < start) {
-    throw new Error(`missing profile JSON output: ${output.slice(0, 800)}`);
-  }
-  return JSON.parse(output.slice(start, end + 1)) as ProfileJson;
 }
 
 function median(values: number[]): number {
@@ -308,13 +275,13 @@ function parseArgs(argv: string[]): CliArgs {
     } else if (arg.startsWith("--output=")) {
       args.output = arg.slice("--output=".length);
     } else if (arg === "--warmup") {
-      args.warmup = parsePositiveInt(argv[++i], "warmup");
+      args.warmup = parsePositiveInt("--warmup", argv[++i]);
     } else if (arg.startsWith("--warmup=")) {
-      args.warmup = parsePositiveInt(arg.slice("--warmup=".length), "warmup");
+      args.warmup = parsePositiveInt("--warmup", arg.slice("--warmup=".length));
     } else if (arg === "--iterations") {
-      args.iterations = parsePositiveInt(argv[++i], "iterations");
+      args.iterations = parsePositiveInt("--iterations", argv[++i]);
     } else if (arg.startsWith("--iterations=")) {
-      args.iterations = parsePositiveInt(arg.slice("--iterations=".length), "iterations");
+      args.iterations = parsePositiveInt("--iterations", arg.slice("--iterations=".length));
     } else if (arg === "--help" || arg === "-h") {
       printHelp();
       process.exit(0);
@@ -323,14 +290,6 @@ function parseArgs(argv: string[]): CliArgs {
     }
   }
   return args;
-}
-
-function parsePositiveInt(value: string | undefined, name: string): number {
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed < 1) {
-    throw new Error(`--${name} must be a positive integer`);
-  }
-  return parsed;
 }
 
 function printHelp(): void {

--- a/tests/benchmark/monorepo-perf.ts
+++ b/tests/benchmark/monorepo-perf.ts
@@ -9,12 +9,17 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
+import {
+  ROOT,
+  ZTS_BIN,
+  buildBin as buildBinShared,
+  getCommit,
+  parsePositiveInt,
+} from "./_runner";
 import { makeSyntheticMonorepo, parseProfileOutput, type ProfileRun } from "./monorepo-fixture";
 import { computeMetricStats, formatMetric, type MetricStats } from "./stats";
 
-const ROOT = resolve(__dirname, "../..");
-const ZTS_BIN = join(ROOT, "zig-out/bin/zts");
 const WARMUP = 2;
 const ITERATIONS = 5;
 
@@ -110,12 +115,6 @@ function findBin(name: string): string | null {
   return null;
 }
 
-function parsePositiveInt(name: string, raw: string | undefined): number {
-  const n = Number(raw);
-  if (!Number.isInteger(n) || n < 1) throw new Error(`${name} must be a positive integer`);
-  return n;
-}
-
 function parseNonNegativeInt(name: string, raw: string | undefined): number {
   const n = Number(raw);
   if (!Number.isInteger(n) || n < 0) throw new Error(`${name} must be a non-negative integer`);
@@ -123,15 +122,7 @@ function parseNonNegativeInt(name: string, raw: string | undefined): number {
 }
 
 function buildBin() {
-  if (existsSync(ZTS_BIN)) return;
-  console.log("[monorepo-perf] zts binary not found, building Release...");
-  const r = spawnSync("zig", ["build", "-Doptimize=ReleaseFast"], { cwd: ROOT, stdio: "inherit" });
-  if (r.status !== 0) throw new Error("zig build failed");
-}
-
-function getCommit(): string {
-  const r = spawnSync("git", ["rev-parse", "--short", "HEAD"], { cwd: ROOT, stdio: "pipe" });
-  return r.stdout.toString().trim() || "unknown";
+  buildBinShared("monorepo-perf");
 }
 
 function runZts(entry: string, outDir: string, profile: boolean): ZtsRun {


### PR DESCRIPTION
## Summary
PR #2541 + 7개 follow-up 머지 후 `/simplify` 검토에서 잡힌 항목 정리. 동작 변경 없음, 모두 dedup/리팩터.

### 1. `profile.beginMaybe` 통합 (`src/profile.zig` / `src/bundler/{constant_facts,tree_shaker}.zig`)

`constant_facts.zig` 의 `beginMaybe` 와 `tree_shaker.zig` 의 `beginProfileMaybe` 가 동일 본체 (`?Category` → `Scope`, null 이면 no-op) 로 두 곳에 복사돼 있었음. `profile.zig` 에 `pub inline fn beginMaybe` 추가하고 file-private 사본 제거.

```zig
pub inline fn beginMaybe(cat: ?Category) Scope {
    if (cat) |c| return begin(c);
    return .{};
}
```

> Zig 초보자 메모: `?Category` 는 \"optional Category\" 타입. `if (cat) |c|` 로 unwrap — null 아니면 `c` 에 값이 들어옴. `inline fn` 은 호출이 호출 지점에 펼쳐져 함수 호출 오버헤드 0 (sub-phase profile 이 비활성일 때 분기를 컴파일러가 dead-code-elim 가능).

### 2. `seedExport` dedup 순서 조정 (`src/bundler/tree_shaker.zig`)

before:
```zig
var seed_scope = profile.begin(.shake_fixpoint_bfs_seed_export);
defer seed_scope.end();

if (!try self.markSeedExportVisited(@intCast(target_mod), imported_name)) return;
```

after:
```zig
if (!try self.markSeedExportVisited(@intCast(target_mod), imported_name)) return;

var seed_scope = profile.begin(.shake_fixpoint_bfs_seed_export);
defer seed_scope.end();
```

기존엔 같은 `(module, export_name)` 으로 재진입한 dedup-skip 경로에서도 `profile.begin` 이 먼저 실행돼 `Timer.start()` + `active_scopes` push 비용을 무의미하게 지불. dedup 검사를 timer 시작 앞으로 옮겨 skip 경로는 zero-overhead.

profile 이 비활성일 땐 어차피 `enabled()` 에서 inline 가드돼 차이 없음. profile 활성 시점에만 의미 있는 최적화.

### 3. benchmark 공용 헬퍼 추출 (`tests/benchmark/_runner.ts` 신규)

`buildBin` / `getCommit` / `parsePositiveInt` / `parseProfileJson` 함수와 `ProfileJson` / `ProfilePhase` 타입이 `bundle-perf.ts` / `monorepo-perf.ts` / `const-prepass.ts` 3 곳에 거의 byte-identical 로 중복. 신규 `_runner.ts` 로 추출하고 3 파일 모두 import 로 전환.

`buildBin` 만 라벨 prefix (`[bundle-perf]` / `[monorepo-perf]` / `[tree-shake-profile]`) 차이가 있어 `buildBin(label: string)` 로 시그니처 통일.

```
tests/benchmark/_runner.ts (new, ~60 lines)
tests/benchmark/{const-prepass,bundle-perf,monorepo-perf}.ts: import 로 단순화
```

const-prepass.ts 의 `parsePositiveInt` 호출 시그니처 (`(value, name)` → `(name, raw)`) 와 에러 메시지 (`--${name}` 접두) 만 통일.

## Test plan
- [x] `zig build` ok
- [x] `zig build test --summary all` → 4664/4664 passed
- [x] `bun test tests/integration/tests/profile-flags.test.ts` → 12/12 passed
- [x] `bun run tests/benchmark/const-prepass.ts` end-to-end 정상 (warmup + iteration 모두 완료, profile JSON 파싱 OK)
- [x] `bun run tests/benchmark/bundle-perf.ts` import 정상
- [x] `bun run tests/benchmark/monorepo-perf.ts` import 정상

## Skip 한 항목
- `Linker.isReExportNsConsumer` 재사용 — `collectReExportNsConsumerUsage` 가 모든 named binding 을 발견하는 함수인데 비해 `isReExportNsConsumer` 는 특정 `(binding, reexport_name)` 쌍을 검증하는 predicate 라 시그니처가 달라 직접 대체 불가. 공유되는 prefix check 3줄을 헬퍼로 빼는 건 대체 이득보다 간접 비용이 커서 보류.

🤖 Generated with [Claude Code](https://claude.com/claude-code)