### PR TITLE
perf(tree-shake): post-link rename 재계산 회피

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1012,16 +1012,35 @@ pub const Bundler = struct {
         // dev_mode에서는 tree-shaking 스킵 (개발 중 모든 코드 필요)
         var shake_scope = profile.begin(.shake);
         var shaker: ?TreeShaker = if (!self.options.dev_mode and self.options.scope_hoist and self.options.tree_shaking) blk: {
-            var s = try TreeShaker.init(self.allocator, &graph, &(linker.?));
-            try s.analyze(self.options.entry_points);
+            var s = blk_init: {
+                var init_scope = profile.begin(.shake_init);
+                defer init_scope.end();
+                break :blk_init try TreeShaker.init(self.allocator, &graph, &(linker.?));
+            };
+            {
+                var analyze_scope = profile.begin(.shake_analyze);
+                defer analyze_scope.end();
+                try s.analyze(self.options.entry_points);
+            }
             if (s.ast_mutated_after_link and !self.options.code_splitting) {
-                // resync 로 새 symbol id 가 생긴 모듈이 있으니 rename/mangling 재계산.
-                try (&(linker.?)).finalize(.{
-                    .compute_renames = true,
-                    .compute_mangling = self.options.minify_identifiers,
-                    .clear_first = true,
-                    .populate_namespace_accesses = false,
-                });
+                var post_link_scope = profile.begin(.shake_post_link_finalize);
+                defer post_link_scope.end();
+                if (self.options.minify_identifiers) {
+                    // Mangling ranks depend on fresh semantic symbol IDs and ref counts.
+                    try (&(linker.?)).finalize(.{
+                        .compute_renames = true,
+                        .compute_mangling = true,
+                        .clear_first = true,
+                        .populate_namespace_accesses = false,
+                    });
+                } else {
+                    // Tree-shake constant folding only removes/replaces references. Graph
+                    // resync preserves existing canonical names, so emit only needs import
+                    // and re-export metadata refreshed for the final AST snapshot.
+                    const l = &(linker.?);
+                    l.populateReExportAliases();
+                    l.populateImportSymbols();
+                }
             }
             // metadata builder 가 `Module.is_included` 비트를 신뢰해 tree-shake 된 target 의
             // CJS preamble emit 을 건너뛸 수 있도록 plug. analyze() 가 끝난 뒤 mirror 가

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -2318,6 +2318,38 @@ pub const ModuleGraph = struct {
     /// 이 중앙 resync 경로를 우회해서 record/binding 만 수동 보정하면 linker, tree-shaker,
     /// chunking 이 서로 다른 AST/semantic 상태를 보게 되므로 여기서만 metadata 재구축
     /// 정책을 확장해야 한다 (#1913).
+    fn preserveCanonicalNamesAfterSemanticResync(
+        source: []const u8,
+        old_sem: ModuleSemanticData,
+        new_sem: *ModuleSemanticData,
+    ) void {
+        const module_scope: ?*const std.StringHashMap(usize) = if (new_sem.scope_maps.len > 0) &new_sem.scope_maps[0] else null;
+        for (old_sem.symbols.items) |old_sym| {
+            if (old_sym.canonical_name.len == 0) continue;
+
+            if (old_sym.synthetic_kind == null) {
+                const name = old_sym.nameText(source);
+                const new_idx = if (module_scope) |scope| scope.get(name) else null;
+                if (new_idx) |idx| {
+                    if (idx < new_sem.symbols.items.len) {
+                        const new_sym = &new_sem.symbols.items[idx];
+                        if (new_sym.synthetic_kind == null) {
+                            new_sym.canonical_name = old_sym.canonical_name;
+                        }
+                    }
+                }
+                continue;
+            }
+
+            for (new_sem.symbols.items) |*new_sym| {
+                if (new_sym.synthetic_kind != old_sym.synthetic_kind) continue;
+                if (!std.mem.eql(u8, new_sym.synthetic_name, old_sym.synthetic_name)) continue;
+                new_sym.canonical_name = old_sym.canonical_name;
+                break;
+            }
+        }
+    }
+
     pub fn resyncModuleMetadataAfterAstMutation(
         self: *ModuleGraph,
         module: *Module,
@@ -2329,6 +2361,7 @@ pub const ModuleGraph = struct {
         const ast = &(module.ast orelse return);
         const previous_import_records = module.import_records;
         const previous_import_bindings = module.import_bindings;
+        const previous_semantic = module.semantic;
 
         var analyzer = SemanticAnalyzer.init(arena_alloc, ast);
         {
@@ -2352,6 +2385,11 @@ pub const ModuleGraph = struct {
                 .references = analyzer.references.items,
                 .numeric_const_texts = analyzer.numeric_const_texts,
             };
+            if (!self.minify_identifiers) {
+                if (previous_semantic) |old_sem| {
+                    preserveCanonicalNamesAfterSemanticResync(module.source, old_sem, &module.semantic.?);
+                }
+            }
             suppressRuntimeHelperInternalUnresolved(module);
             module.uses_top_level_await = analyzer.has_top_level_await;
             if (module.transform_cache) |*cache| {

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -104,6 +104,9 @@ pub const Category = enum {
     link_populate_import_symbols,
     link_populate_namespace_accesses,
     shake,
+    shake_init,
+    shake_analyze,
+    shake_post_link_finalize,
     shake_setup,
     shake_const_prepass,
     shake_const_prepass_full_materialize,
@@ -274,6 +277,14 @@ comptime {
         @compileError("Category count exceeded u128 bitmask. Switch to ArrayBitSet.");
     }
 }
+
+const all_categories: [num_categories]Category = blk: {
+    var cats: [num_categories]Category = undefined;
+    for (@typeInfo(Category).@"enum".fields, 0..) |f, i| {
+        cats[i] = @field(Category, f.name);
+    }
+    break :blk cats;
+};
 
 /// 활성 카테고리 비트마스크. hot path 에서는 `enabled()` 의 single AND 로 검사.
 /// 프로세스 전역 — 초기화 후 read-only 로 다뤄 thread-safe. 수집 data array 는 현재
@@ -581,9 +592,6 @@ fn reportTable(writer: anytype) !void {
 }
 
 fn reportTree(writer: anytype) !void {
-    // Nested inline for 는 N² comptime branches 를 유발하므로 quota 상향.
-    @setEvalBranchQuota(num_categories * num_categories * 16);
-
     try writer.writeAll("=== ZTS Profile (detailed) ===\n");
 
     const total = totalAllNs();
@@ -596,8 +604,7 @@ fn reportTree(writer: anytype) !void {
     try writer.print("total: {d:.2}ms\n", .{total_ms});
 
     // Top-level categories.
-    inline for (@typeInfo(Category).@"enum".fields) |f_top| {
-        const cat = @field(Category, f_top.name);
+    for (all_categories) |cat| {
         const idx = @intFromEnum(cat);
         if (counts[idx] > 0 and isTopLevel(cat)) {
             const ns = totals_ns[idx];
@@ -609,8 +616,7 @@ fn reportTree(writer: anytype) !void {
 
             if (current_level != .summary) {
                 // Sub-phases.
-                inline for (@typeInfo(Category).@"enum".fields) |f_sub| {
-                    const sub_cat = @field(Category, f_sub.name);
+                for (all_categories) |sub_cat| {
                     const sub_idx = @intFromEnum(sub_cat);
                     if (counts[sub_idx] > 0 and isChildOf(sub_cat, cat)) {
                         const sub_ns = totals_ns[sub_idx];
@@ -720,6 +726,8 @@ test "Category.fromString: dot notation 정규화" {
     try testing.expect(Category.fromString("transform.ts_strip") == .transform_ts_strip);
     try testing.expect(Category.fromString("Transform.JSX") == .transform_jsx);
     try testing.expect(Category.fromString("hmr.detect") == .hmr_detect);
+    try testing.expect(Category.fromString("shake.analyze") == .shake_analyze);
+    try testing.expect(Category.fromString("shake.post.link.finalize") == .shake_post_link_finalize);
     try testing.expect(Category.fromString("shake.fixpoint.bfs") == .shake_fixpoint_bfs);
     try testing.expect(Category.fromString("shake.fixpoint.bfs.follow.import") == .shake_fixpoint_bfs_follow_import);
     try testing.expect(Category.fromString("shake.fixpoint.bfs.seed.export.resolve") == .shake_fixpoint_bfs_seed_export_resolve);
@@ -731,6 +739,8 @@ test "Category.displayName: underscore → dot 역변환" {
     try testing.expectEqualStrings("parse.ast.build", Category.displayName(.parse_ast_build));
     try testing.expectEqualStrings("transform.ts.strip", Category.displayName(.transform_ts_strip));
     try testing.expectEqualStrings("hmr.detect", Category.displayName(.hmr_detect));
+    try testing.expectEqualStrings("shake.analyze", Category.displayName(.shake_analyze));
+    try testing.expectEqualStrings("shake.post.link.finalize", Category.displayName(.shake_post_link_finalize));
     try testing.expectEqualStrings("shake.fixpoint.bfs", Category.displayName(.shake_fixpoint_bfs));
     try testing.expectEqualStrings("shake.fixpoint.bfs.follow.import", Category.displayName(.shake_fixpoint_bfs_follow_import));
     try testing.expectEqualStrings("shake.fixpoint.bfs.seed.export.resolve", Category.displayName(.shake_fixpoint_bfs_seed_export_resolve));
@@ -807,6 +817,9 @@ test "addFromCsv: shake parent → 모든 sub-phase 활성" {
 
     addFromCsv("shake");
     try testing.expect(enabled(.shake));
+    try testing.expect(enabled(.shake_init));
+    try testing.expect(enabled(.shake_analyze));
+    try testing.expect(enabled(.shake_post_link_finalize));
     try testing.expect(enabled(.shake_const_prepass));
     try testing.expect(enabled(.shake_const_prepass_build_facts));
     try testing.expect(enabled(.shake_fixpoint));

--- a/tests/benchmark/const-prepass.ts
+++ b/tests/benchmark/const-prepass.ts
@@ -37,7 +37,14 @@ const DEFAULT_ITERATIONS = 9;
 
 const TARGET_PHASES = [
   "shake",
+  "shake.init",
+  "shake.analyze",
+  "shake.post.link.finalize",
+  "shake.setup",
+  "shake.purity",
+  "shake.stmt.info",
   "shake.fixpoint",
+  "shake.fixpoint.sym.to.ib",
   "shake.fixpoint.bfs",
   "shake.fixpoint.bfs.seed",
   "shake.fixpoint.bfs.queue",
@@ -54,7 +61,10 @@ const TARGET_PHASES = [
   "shake.fixpoint.bfs.seed.export.semantic.lookup",
   "shake.fixpoint.bfs.seed.export.enqueue.symbol",
   "shake.fixpoint.bfs.seed.export.opaque",
+  "shake.fixpoint.process.imports",
   "shake.fixpoint.re.exports",
+  "shake.fixpoint.eval.deps",
+  "shake.prune",
   "shake.const.prepass",
   "shake.const.prepass.numeric.propagate",
   "shake.const.prepass.numeric.seed.scan",
@@ -68,6 +78,8 @@ const TARGET_PHASES = [
   "shake.const.prepass.minify.resync",
   "shake.const.prepass.node.buffer",
   "shake.const.prepass.link.refresh",
+  "shake.numeric.postpass",
+  "shake.mirror",
 ] as const;
 
 type TargetPhase = (typeof TARGET_PHASES)[number];
@@ -344,16 +356,19 @@ async function main(cli: CliArgs): Promise<void> {
   console.log();
   console.log("### tree-shake profile");
   console.log(
-    "| Fixture | Profile total | Shake | Shake self | Const prepass | Build facts | Build count | Fixpoint | BFS | BFS self | BFS seed | BFS queue | Final mark | Re-exports |",
+    "| Fixture | Profile total | Shake | Shake self | Init | Analyze | Analyze self | Const prepass | Build facts | Build count | Fixpoint | BFS | BFS self | BFS seed | BFS queue | Final mark | Re-exports |",
   );
   console.log(
-    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
   );
   for (const result of results) {
     console.log(
       `| ${result.name} | ${fmtMs(result.total_ms_stats.median)} | ` +
         `${fmtMs(phaseMedian(result, "shake"))} | ` +
         `${fmtMs(phaseSelfMedian(result, "shake"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.init"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.analyze"))} | ` +
+        `${fmtMs(phaseSelfMedian(result, "shake.analyze"))} | ` +
         `${fmtMs(phaseMedian(result, "shake.const.prepass"))} | ` +
         `${fmtMs(phaseMedian(result, "shake.const.prepass.build.facts"))} | ` +
         `${phaseCount(result, "shake.const.prepass.build.facts")} | ` +
@@ -364,6 +379,37 @@ async function main(cli: CliArgs): Promise<void> {
         `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.queue"))} | ` +
         `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.final.mark.exports"))} | ` +
         `${fmtMs(phaseMedian(result, "shake.fixpoint.re.exports"))} |`,
+    );
+  }
+
+  console.log();
+  console.log("### shake self profile");
+  console.log(
+    "| Fixture | Setup | Purity | Stmt info | Prune | Numeric postpass | Mirror | Post-link finalize |",
+  );
+  console.log("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |");
+  for (const result of results) {
+    console.log(
+      `| ${result.name} | ${fmtMs(phaseMedian(result, "shake.setup"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.purity"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.stmt.info"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.prune"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.numeric.postpass"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.mirror"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.post.link.finalize"))} |`,
+    );
+  }
+
+  console.log();
+  console.log("### fixpoint helper profile");
+  console.log("| Fixture | Sym to import | Process imports | Re-exports | Eval deps |");
+  console.log("| --- | ---: | ---: | ---: | ---: |");
+  for (const result of results) {
+    console.log(
+      `| ${result.name} | ${fmtMs(phaseMedian(result, "shake.fixpoint.sym.to.ib"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.fixpoint.process.imports"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.fixpoint.re.exports"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.fixpoint.eval.deps"))} |`,
     );
   }
 

--- a/tests/integration/tests/profile-flags.test.ts
+++ b/tests/integration/tests/profile-flags.test.ts
@@ -255,6 +255,8 @@ describe("profile CLI flags", () => {
     const parsed = JSON.parse(result.stderr.slice(result.stderr.indexOf("{")));
     expect(parsed.phases.shake).toBeDefined();
     expect(parsed.phases.shake.self_ms).toBeGreaterThanOrEqual(0);
+    expect(parsed.phases["shake.init"]).toBeDefined();
+    expect(parsed.phases["shake.analyze"]).toBeDefined();
     expect(parsed.phases["shake.const.prepass"]).toBeDefined();
     expect(parsed.phases["shake.const.prepass.numeric.propagate"]).toBeDefined();
     expect(parsed.phases["shake.const.prepass.build.facts"]).toBeDefined();


### PR DESCRIPTION
## 요약
- tree-shake AST mutation 이후 비압축/non-splitting 경로에서 전체 rename/mangling recompute 대신 import/re-export metadata만 refresh합니다.
- semantic resync 시 기존 canonical name을 모듈 스코프/합성 심볼 기준으로 보존해 emit 이름 충돌을 유지합니다.
- `shake.init`, `shake.analyze`, `shake.post.link.finalize` 및 helper subprofile을 추가해 다음 병목을 계속 볼 수 있게 했습니다.

## 측정
`bun run tests/benchmark/const-prepass.ts --warmup=3 --iterations=9`

| Fixture | origin/main | PR | Delta |
| --- | ---: | ---: | ---: |
| flat-1000 | 4.295ms | 3.618ms | -15.8% |
| reexport-500 | 2.360ms | 2.251ms | -4.6% |
| namespace-500 | 2.194ms | 1.924ms | -12.3% |
| namespace-2000 | 19.434ms | 15.338ms | -21.1% |

`namespace-2000` 기준 새 subprofile: post-link finalize 1.587ms, numeric postpass 3.084ms, eval deps 2.238ms.

## 안전 경계
- `minify_identifiers=true`는 기존처럼 full `finalize()`를 유지합니다. mangling rank/ref-count가 fresh semantic id에 의존하기 때문입니다.
- `code_splitting=true`는 기존 gate대로 fast path를 타지 않습니다.
- canonical name 보존은 source 전체 심볼 scan이 아니라 module scope map + synthetic symbol match로 제한해 nested local 오염과 O(S^2) 비용을 피합니다.

## 검증
- `zig build -Doptimize=ReleaseFast --summary all`
- `zig build test --summary all`
- `zig build test -Dtest-filter=profile --summary all`
- `zig build test -Dtest-filter=tree-shaking --summary all`
- `bun test tests/integration/tests/profile-flags.test.ts tests/integration/tests/const-value-inline.test.ts`
- `bun test tests/benchmark/stats.test.ts tests/benchmark/monorepo-fixture.test.ts`
- `bun run fmt:check`
- `bun run lint` (기존 `bundle-dynamic-import.test.ts` unused import warning 3개만 출력)

Refs #2354