### PR TITLE
perf(tree-shake): seed export fixpoint 캐시 유지

### DIFF
--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -955,6 +955,11 @@ pub const TreeShaker = struct {
         //   (b) processModuleImports(live_mod_idx): BFS-reachable statement 안 import만 마킹
         //   (c) re-export source include / side-effect 전파
         // used_exports 또는 included 변화 없으면 수렴. BFS만이 used_exports 진리 소스.
+        // seedExport 결과는 linker graph + StmtInfo 기준으로 결정적이다.
+        // fixpoint 전체에서 visited set을 유지해 두 번째 pass가 같은 export를 다시
+        // resolve/enqueue 하지 않고 새로 발견된 seed만 처리하게 한다.
+        self.seeded_exports.clearRetainingCapacity();
+
         var iteration: u32 = 0;
         while (iteration < max_fixpoint_iterations) : (iteration += 1) {
             var fixpoint_scope = profile.begin(.shake_fixpoint);
@@ -1226,8 +1231,6 @@ pub const TreeShaker = struct {
     ) std.mem.Allocator.Error!void {
         var scope = profile.begin(.shake_fixpoint_bfs);
         defer scope.end();
-
-        self.seeded_exports.clearRetainingCapacity();
 
         var queue: std.ArrayListUnmanaged(BfsItem) = .empty;
         defer queue.deinit(self.allocator);

--- a/tests/benchmark/const-prepass.ts
+++ b/tests/benchmark/const-prepass.ts
@@ -429,16 +429,17 @@ async function main(cli: CliArgs): Promise<void> {
   console.log();
   console.log("### nested bfs helper profile");
   console.log(
-    "| Fixture | Follow import | Follow self | Seed export | Seed export self | Resolve | Mark | CJS | Namespace scan | Intermediate | Semantic lookup | Enqueue symbol | Opaque | Require scan | Side effects |",
+    "| Fixture | Follow import | Follow self | Seed export | Seed count | Seed export self | Resolve | Mark | CJS | Namespace scan | Intermediate | Semantic lookup | Enqueue symbol | Opaque | Require scan | Side effects |",
   );
   console.log(
-    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
   );
   for (const result of results) {
     console.log(
       `| ${result.name} | ${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.follow.import"))} | ` +
         `${fmtMs(phaseSelfMedian(result, "shake.fixpoint.bfs.follow.import"))} | ` +
         `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.seed.export"))} | ` +
+        `${phaseCount(result, "shake.fixpoint.bfs.seed.export")} | ` +
         `${fmtMs(phaseSelfMedian(result, "shake.fixpoint.bfs.seed.export"))} | ` +
         `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.seed.export.resolve"))} | ` +
         `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.seed.export.mark"))} | ` +


### PR DESCRIPTION
## 요약
- `seedExport(target, export)` 중복 방지 캐시를 BFS 1회가 아니라 fixpoint 전체에서 유지합니다.
- 같은 linker graph + StmtInfo 안에서는 seed 결과가 결정적이므로, 2번째 fixpoint pass에서 같은 export를 다시 resolve/enqueue 하지 않습니다.
- `const-prepass` benchmark의 nested BFS 표에 `Seed count`를 추가해 이후에도 중복 호출 수를 직접 확인할 수 있게 했습니다.

## 벤치마크
`bun run tests/benchmark/const-prepass.ts --warmup=3 --iterations=9`

| Fixture | main shake | PR shake | 변화 | main BFS | PR BFS | main seed export count | PR seed export count |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| flat-1000 | 2.51ms | 2.37ms | -5.6% | 1.07ms | 0.90ms | 2000 | 1000 |
| reexport-500 | 1.35ms | 1.13ms | -16.0% | 0.64ms | 0.42ms | 1000 | 500 |
| namespace-500 | 0.82ms | 0.69ms | -16.3% | 0.45ms | 0.33ms | 1000 | 500 |
| namespace-2000 | 3.45ms | 3.12ms | -9.6% | 1.87ms | 1.50ms | 4000 | 2000 |

추가 smoke:
- `bun run tests/benchmark/bundle-perf.ts --no-fail --output /tmp/zts-seed-export-bundle-perf.json`

## 검증
- `zig fmt --check src/bundler/tree_shaker.zig`
- `zig build test --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- `bun run tests/benchmark/const-prepass.ts --warmup=3 --iterations=9 --output /tmp/zts-seed-export-fixpoint-cache-with-count.json`
- `bun run tests/benchmark/bundle-perf.ts --no-fail --output /tmp/zts-seed-export-bundle-perf.json`
- `bun run fmt:check`
- `bun run lint` (기존 `tests/integration/tests/bundle-dynamic-import.test.ts` unused import 경고 3개만 있음)

Refs #2354