### PR TITLE
perf(tree-shake): re-export fixpoint scan 후보 축소

### DIFF
--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -116,6 +116,9 @@ pub const TreeShaker = struct {
     /// 모듈 인덱스가 다른 모듈의 `export * from` source 인지 표시. tryMarkReExportNsSubset
     /// 에서 chain 추적 시 O(M·E) scan 대신 O(1) 조회 (#1928).
     re_export_star_targets: ?std.DynamicBitSet = null,
+    /// export source include fixpoint 에서 볼 re-export 보유 모듈 목록.
+    /// fixpoint 마다 전체 module graph 를 훑지 않고 후보만 순회한다.
+    re_export_modules: std.ArrayListUnmanaged(u32) = .empty,
     /// `export * as X from './src'` source lookup cache.
     /// followImport 가 named virtual namespace binding 마다 target.export_bindings 전체를
     /// 다시 훑지 않도록 module index -> exported namespace name -> source module index 를
@@ -239,6 +242,7 @@ pub const TreeShaker = struct {
         }
         if (self.prebuilt_mask) |*mask| mask.deinit();
         if (self.re_export_star_targets) |*mask| mask.deinit();
+        self.re_export_modules.deinit(self.allocator);
         if (self.re_export_namespace_sources.len > 0) {
             for (self.re_export_namespace_sources) |*maybe_map| {
                 if (maybe_map.*) |*map| map.deinit(self.allocator);
@@ -730,9 +734,13 @@ pub const TreeShaker = struct {
 
             var re_star_targets = try std.DynamicBitSet.initEmpty(self.allocator, mod_count);
             errdefer re_star_targets.deinit();
+            var re_export_modules: std.ArrayListUnmanaged(u32) = .empty;
+            errdefer re_export_modules.deinit(self.allocator);
             for (0..mod_count) |i| {
                 const m = self.getModule(@intCast(i)) orelse continue;
+                var has_re_export = false;
                 for (m.export_bindings) |eb| {
+                    if (eb.kind == .re_export or eb.kind.isReExportAll()) has_re_export = true;
                     if (eb.kind != .re_export_star) continue;
                     const rec_idx = eb.import_record_index orelse continue;
                     if (rec_idx >= m.import_records.len) continue;
@@ -740,8 +748,10 @@ pub const TreeShaker = struct {
                     if (src == .none) continue;
                     re_star_targets.set(@intFromEnum(src));
                 }
+                if (has_re_export) try re_export_modules.append(self.allocator, @intCast(i));
             }
             self.re_export_star_targets = re_star_targets;
+            self.re_export_modules = re_export_modules;
 
             // entry_set 먼저 계산 (자동 순수 판별에서 진입점 제외용).
             // `inject` and `runBeforeMain` are not output entries, but they are
@@ -979,7 +989,10 @@ pub const TreeShaker = struct {
                 if (try self.processModuleImportsInner(m.*, live_idx)) changed = true;
             }
 
-            if (try self.includeReExportSources(true)) changed = true;
+            if (self.used_exports.count() != used_count_before) changed = true;
+            if (self.included.count() != included_count_before) changed = true;
+
+            if ((iteration == 0 or changed) and try self.includeReExportSources(true)) changed = true;
 
             {
                 var eval_scope = profile.begin(.shake_fixpoint_eval_deps);
@@ -2124,7 +2137,11 @@ pub const TreeShaker = struct {
         defer scope.end();
 
         var changed = false;
-        for (0..self.graph.moduleCount()) |i| {
+        for (self.re_export_modules.items) |i| {
+            var module_scope = profile.begin(.shake_fixpoint_re_exports_module);
+            defer module_scope.end();
+
+            if (i >= self.graph.moduleCount()) continue;
             if (!self.included.isSet(i)) continue;
             const m = self.getModule(@intCast(i)) orelse continue;
             var ns_usage: ReExportNsConsumerUsage = .{};

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -146,6 +146,7 @@ pub const Category = enum {
     shake_fixpoint_bfs_seed_export_opaque,
     shake_fixpoint_process_imports,
     shake_fixpoint_re_exports,
+    shake_fixpoint_re_exports_module,
     shake_fixpoint_eval_deps,
     shake_prune,
     shake_numeric_postpass,
@@ -280,6 +281,11 @@ comptime {
     }
 }
 
+const all_categories_mask: u128 = if (num_categories == 128)
+    std.math.maxInt(u128)
+else
+    (@as(u128, 1) << @as(u7, @intCast(num_categories))) - 1;
+
 const all_categories: [num_categories]Category = blk: {
     var cats: [num_categories]Category = undefined;
     for (@typeInfo(Category).@"enum".fields, 0..) |f, i| {
@@ -352,7 +358,7 @@ pub fn addFromCsv(csv: []const u8) void {
         if (name.len == 0) continue;
 
         if (std.ascii.eqlIgnoreCase(name, "all")) {
-            enabled_mask = comptime (@as(u128, 1) << num_categories) - 1;
+            enabled_mask = all_categories_mask;
             continue;
         }
         if (std.ascii.eqlIgnoreCase(name, "none")) {
@@ -369,7 +375,7 @@ pub fn addFromCsv(csv: []const u8) void {
 pub fn addCategories(names: []const []const u8) void {
     for (names) |name| {
         if (std.ascii.eqlIgnoreCase(name, "all")) {
-            enabled_mask = comptime (@as(u128, 1) << num_categories) - 1;
+            enabled_mask = all_categories_mask;
             continue;
         }
         if (std.ascii.eqlIgnoreCase(name, "none")) {
@@ -733,6 +739,7 @@ test "Category.fromString: dot notation 정규화" {
     try testing.expect(Category.fromString("shake.fixpoint.bfs") == .shake_fixpoint_bfs);
     try testing.expect(Category.fromString("shake.fixpoint.bfs.follow.import") == .shake_fixpoint_bfs_follow_import);
     try testing.expect(Category.fromString("shake.fixpoint.bfs.seed.export.resolve") == .shake_fixpoint_bfs_seed_export_resolve);
+    try testing.expect(Category.fromString("shake.fixpoint.re.exports.module") == .shake_fixpoint_re_exports_module);
     try testing.expect(Category.fromString("shake.const.prepass.build.facts") == .shake_const_prepass_build_facts);
     try testing.expect(Category.fromString("shake.const.prepass.build.facts.lookup") == .shake_const_prepass_build_facts_lookup);
 }
@@ -747,6 +754,7 @@ test "Category.displayName: underscore → dot 역변환" {
     try testing.expectEqualStrings("shake.fixpoint.bfs", Category.displayName(.shake_fixpoint_bfs));
     try testing.expectEqualStrings("shake.fixpoint.bfs.follow.import", Category.displayName(.shake_fixpoint_bfs_follow_import));
     try testing.expectEqualStrings("shake.fixpoint.bfs.seed.export.resolve", Category.displayName(.shake_fixpoint_bfs_seed_export_resolve));
+    try testing.expectEqualStrings("shake.fixpoint.re.exports.module", Category.displayName(.shake_fixpoint_re_exports_module));
     try testing.expectEqualStrings("shake.const.prepass.build.facts", Category.displayName(.shake_const_prepass_build_facts));
     try testing.expectEqualStrings("shake.const.prepass.build.facts.lookup", Category.displayName(.shake_const_prepass_build_facts_lookup));
 }
@@ -1079,4 +1087,12 @@ test "resetForTest 초기화" {
     try testing.expectEqual(@as(u64, 0), totalNs(.parse));
     try testing.expectEqual(@as(u64, 0), selfNs(.parse));
     try testing.expectEqual(@as(u32, 0), count(.parse));
+}
+
+test "addFromCsv all enables last category" {
+    resetForTest();
+    defer resetForTest();
+
+    addFromCsv("all");
+    try testing.expect(enabled(.shake_fixpoint_re_exports_module));
 }

--- a/tests/benchmark/const-prepass.ts
+++ b/tests/benchmark/const-prepass.ts
@@ -63,6 +63,7 @@ const TARGET_PHASES = [
   "shake.fixpoint.bfs.seed.export.opaque",
   "shake.fixpoint.process.imports",
   "shake.fixpoint.re.exports",
+  "shake.fixpoint.re.exports.module",
   "shake.fixpoint.eval.deps",
   "shake.prune",
   "shake.const.prepass",
@@ -415,13 +416,16 @@ async function main(cli: CliArgs): Promise<void> {
 
   console.log();
   console.log("### fixpoint helper profile");
-  console.log("| Fixture | Sym to import | Process imports | Re-exports | Eval deps |");
-  console.log("| --- | ---: | ---: | ---: | ---: |");
+  console.log(
+    "| Fixture | Sym to import | Process imports | Re-exports | Re-export modules | Eval deps |",
+  );
+  console.log("| --- | ---: | ---: | ---: | ---: | ---: |");
   for (const result of results) {
     console.log(
       `| ${result.name} | ${fmtMs(phaseMedian(result, "shake.fixpoint.sym.to.ib"))} | ` +
         `${fmtMs(phaseMedian(result, "shake.fixpoint.process.imports"))} | ` +
         `${fmtMs(phaseMedian(result, "shake.fixpoint.re.exports"))} | ` +
+        `${phaseCount(result, "shake.fixpoint.re.exports.module")} | ` +
         `${fmtMs(phaseMedian(result, "shake.fixpoint.eval.deps"))} |`,
     );
   }


### PR DESCRIPTION
## 요약
- fixpoint re-export source include 단계에서 전체 module graph 대신 re-export binding을 가진 후보 모듈만 순회하도록 좁혔습니다.
- fixpoint 입력이 바뀌지 않은 2번째 이후 iteration에서는 no-op re-export source scan을 건너뜁니다. 단, 초기 entry/re-export 상태 보존을 위해 첫 iteration은 항상 실행합니다.
- `shake.fixpoint.re.exports.module` profile category와 `const-prepass` 벤치마크의 `Re-export modules` 카운트를 추가해 이후에도 후보 축소 여부를 계측할 수 있게 했습니다.
- profile category 수가 128개가 된 경계 조건을 `all_categories_mask`로 보정하고 회귀 테스트를 추가했습니다.

## 측정
`bun run tests/benchmark/const-prepass.ts --warmup=3 --iterations=9`

| Fixture | main shake | this PR shake | delta | main re-exports | this PR re-exports | re-export modules |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| flat-1000 | 2.395ms | 2.334ms | -2.5% | 0.005ms | 0.001ms | 0 |
| reexport-500 | 1.171ms | 1.156ms | -1.3% | 0.015ms | 0.007ms | 1 |
| namespace-500 | 0.700ms | 0.665ms | -5.0% | 0.098ms | 0.053ms | 1 |
| namespace-2000 | 3.065ms | 2.833ms | -7.6% | 0.424ms | 0.221ms | 1 |

`bundle-perf --no-fail` local ZTS-only smoke도 확인했습니다.

## 검증
- `zig fmt --check src/bundler/tree_shaker.zig src/profile.zig`
- `zig build test --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- `bun run fmt:check`
- `bun test tests/integration/tests/profile-flags.test.ts`
- `bun run lint` (기존 `tests/integration/tests/bundle-dynamic-import.test.ts` 미사용 import 경고 3개만 존재)
- `bun run tests/benchmark/const-prepass.ts --warmup=3 --iterations=9 --output /tmp/zts-reexport-candidates-v2-const-prepass.json`
- `bun run tests/benchmark/bundle-perf.ts --no-fail --output /tmp/zts-reexport-candidates-v2-bundle-perf.json`

Refs #2354