### PR TITLE
perf(tree-shake): require scan no-op 경로 건너뛰기

### DIFF
--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -80,6 +80,8 @@ const ConstMaterializeFilter = enum {
 
 const ConstMaterializeProfile = struct {
     build_facts: ?profile.Category = null,
+    build_facts_resolve: ?profile.Category = null,
+    build_facts_lookup: ?profile.Category = null,
     candidate_gate: ?profile.Category = null,
     materialize: ?profile.Category = null,
     minify_resync: ?profile.Category = null,
@@ -106,6 +108,9 @@ pub const TreeShaker = struct {
     /// 모듈별 import_record_index → top-level stmt_index 맵. eval dependency 판정과
     /// require scan 이 같은 span search 를 반복하지 않도록 lazy 구축한다.
     import_record_stmt_indices: []?[]?u32 = &.{},
+    /// BFS require scan 이 require 없는 모듈의 import_records 전체를 매번 훑지 않도록
+    /// analyze 시작 때 한 번 계산하는 모듈별 플래그.
+    module_has_require_records: []bool = &.{},
     /// seedOpaqueModule 재진입 방지용 visited bitset. crossModuleBFS에서 초기화.
     opaque_visited: ?std.DynamicBitSet = null,
     /// 모듈별 used export 존재 여부 (hasAnyUsedExportDirect 최적화: O(1) 조회).
@@ -267,6 +272,9 @@ pub const TreeShaker = struct {
                 if (s) |arr| self.allocator.free(arr);
             }
             self.allocator.free(self.import_record_stmt_indices);
+        }
+        if (self.module_has_require_records.len > 0) {
+            self.allocator.free(self.module_has_require_records);
         }
         if (self.has_direct_used_export.len > 0) {
             self.allocator.free(self.has_direct_used_export);
@@ -545,8 +553,8 @@ pub const TreeShaker = struct {
             defer build_scope.end();
             const build_profile = if (const_profile.build_facts != null)
                 Linker.ConstValuesProfile{
-                    .resolve = .shake_const_prepass_build_facts_resolve,
-                    .lookup = .shake_const_prepass_build_facts_lookup,
+                    .resolve = const_profile.build_facts_resolve,
+                    .lookup = const_profile.build_facts_lookup,
                 }
             else
                 Linker.ConstValuesProfile{};
@@ -628,16 +636,40 @@ pub const TreeShaker = struct {
         var queued = try std.DynamicBitSet.initEmpty(self.allocator, mod_count);
         defer queued.deinit();
 
-        for (0..mod_count) |i| {
-            try self.enqueueNumericPostPassModule(&queue, &queued, @intCast(i), mod_count);
+        const postpass_profile = ConstMaterializeProfile{
+            .build_facts = .shake_numeric_postpass_build_facts,
+            .build_facts_resolve = .shake_numeric_postpass_build_facts_resolve,
+            .build_facts_lookup = .shake_numeric_postpass_build_facts_lookup,
+            .candidate_gate = .shake_numeric_postpass_candidate_gate,
+            .materialize = .shake_numeric_postpass_materialize,
+            .minify_resync = .shake_numeric_postpass_minify_resync,
+            .inner = .{
+                .forbidden = .shake_numeric_postpass_forbidden,
+                .reachable = .shake_numeric_postpass_reachable,
+                .replace = .shake_numeric_postpass_replace,
+            },
+        };
+
+        {
+            var seed_scope = profile.begin(.shake_numeric_postpass_queue_seed);
+            defer seed_scope.end();
+
+            for (0..mod_count) |i| {
+                try self.enqueueNumericPostPassModule(&queue, &queued, @intCast(i), mod_count);
+            }
         }
 
-        while (queue.pop()) |idx| {
-            if (idx < mod_count) queued.unset(idx);
-            if (idx >= mod_count) continue;
-            if (!self.shouldVisitNumericPostPassModule(idx)) continue;
-            if (!try self.materializeCrossModuleConstFactsForIndex(idx, .numeric, .{})) continue;
-            try self.enqueueStaticImporters(&queue, &queued, idx, mod_count);
+        {
+            var queue_scope = profile.begin(.shake_numeric_postpass_queue);
+            defer queue_scope.end();
+
+            while (queue.pop()) |idx| {
+                if (idx < mod_count) queued.unset(idx);
+                if (idx >= mod_count) continue;
+                if (!self.shouldVisitNumericPostPassModule(idx)) continue;
+                if (!try self.materializeCrossModuleConstFactsForIndex(idx, .numeric, postpass_profile)) continue;
+                try self.enqueueStaticImporters(&queue, &queued, idx, mod_count);
+            }
         }
     }
 
@@ -736,9 +768,15 @@ pub const TreeShaker = struct {
             errdefer re_star_targets.deinit();
             var re_export_modules: std.ArrayListUnmanaged(u32) = .empty;
             errdefer re_export_modules.deinit(self.allocator);
+            const require_flags = try self.allocator.alloc(bool, mod_count);
+            errdefer self.allocator.free(require_flags);
             for (0..mod_count) |i| {
-                const m = self.getModule(@intCast(i)) orelse continue;
+                const m = self.getModule(@intCast(i)) orelse {
+                    require_flags[i] = false;
+                    continue;
+                };
                 var has_re_export = false;
+                var has_require = false;
                 for (m.export_bindings) |eb| {
                     if (eb.kind == .re_export or eb.kind.isReExportAll()) has_re_export = true;
                     if (eb.kind != .re_export_star) continue;
@@ -748,10 +786,18 @@ pub const TreeShaker = struct {
                     if (src == .none) continue;
                     re_star_targets.set(@intFromEnum(src));
                 }
+                for (m.import_records) |rec| {
+                    if (rec.kind == .require) {
+                        has_require = true;
+                        break;
+                    }
+                }
+                require_flags[i] = has_require;
                 if (has_re_export) try re_export_modules.append(self.allocator, @intCast(i));
             }
             self.re_export_star_targets = re_star_targets;
             self.re_export_modules = re_export_modules;
+            self.module_has_require_records = require_flags;
 
             // entry_set 먼저 계산 (자동 순수 판별에서 진입점 제외용).
             // `inject` and `runBeforeMain` are not output entries, but they are
@@ -791,6 +837,8 @@ pub const TreeShaker = struct {
 
             const prepass_const_profile = ConstMaterializeProfile{
                 .build_facts = .shake_const_prepass_build_facts,
+                .build_facts_resolve = .shake_const_prepass_build_facts_resolve,
+                .build_facts_lookup = .shake_const_prepass_build_facts_lookup,
                 .candidate_gate = .shake_const_prepass_candidate_gate,
                 .materialize = .shake_const_prepass_materialize,
                 .minify_resync = .shake_const_prepass_minify_resync,
@@ -1367,30 +1415,34 @@ pub const TreeShaker = struct {
                     }
                 }
 
-                if (owner) |o| {
-                    var require_scope = profile.begin(.shake_fixpoint_bfs_require_scan);
-                    defer require_scope.end();
+                const has_require_records = item.mod < self.module_has_require_records.len and
+                    self.module_has_require_records[item.mod];
+                if (has_require_records) {
+                    if (owner) |o| {
+                        var require_scope = profile.begin(.shake_fixpoint_bfs_require_scan);
+                        defer require_scope.end();
 
-                    for (o.import_records, 0..) |rec, rec_i| {
-                        if (rec.kind != .require) continue;
-                        if (rec.resolved.isNone()) continue;
-                        if (!try self.importRecordBelongsToStmt(@intCast(item.mod), infos, @intCast(item.stmt), @intCast(rec_i))) continue;
-                        const target_mod_idx = @intFromEnum(rec.resolved);
-                        const target_module = self.graph.getModule(rec.resolved) orelse continue;
-                        if (target_module.wrap_kind != .cjs) continue;
-                        if (!self.isExportUsed(item.mod, ALL_EXPORTS_SENTINEL) and
-                            !self.isExportUsed(@intCast(target_mod_idx), ALL_EXPORTS_SENTINEL) and
-                            self.hasAnyUsedExportDirect(@intCast(target_mod_idx)) and
-                            moduleExportsRequireProxyMatches(o, infos, @intCast(item.stmt), rec.resolved))
-                        {
-                            const target_infos = module_stmt_infos[target_mod_idx] orelse {
-                                try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
+                        for (o.import_records, 0..) |rec, rec_i| {
+                            if (rec.kind != .require) continue;
+                            if (rec.resolved.isNone()) continue;
+                            if (!try self.importRecordBelongsToStmt(@intCast(item.mod), infos, @intCast(item.stmt), @intCast(rec_i))) continue;
+                            const target_mod_idx = @intFromEnum(rec.resolved);
+                            const target_module = self.graph.getModule(rec.resolved) orelse continue;
+                            if (target_module.wrap_kind != .cjs) continue;
+                            if (!self.isExportUsed(item.mod, ALL_EXPORTS_SENTINEL) and
+                                !self.isExportUsed(@intCast(target_mod_idx), ALL_EXPORTS_SENTINEL) and
+                                self.hasAnyUsedExportDirect(@intCast(target_mod_idx)) and
+                                moduleExportsRequireProxyMatches(o, infos, @intCast(item.stmt), rec.resolved))
+                            {
+                                const target_infos = module_stmt_infos[target_mod_idx] orelse {
+                                    try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
+                                    continue;
+                                };
+                                try self.seedSideEffectStmts(@intCast(target_mod_idx), target_infos, &queue, reachable_stmts);
                                 continue;
-                            };
-                            try self.seedSideEffectStmts(@intCast(target_mod_idx), target_infos, &queue, reachable_stmts);
-                            continue;
+                            }
+                            try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
                         }
-                        try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
                     }
                 }
             }

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -150,6 +150,17 @@ pub const Category = enum {
     shake_fixpoint_eval_deps,
     shake_prune,
     shake_numeric_postpass,
+    shake_numeric_postpass_queue_seed,
+    shake_numeric_postpass_queue,
+    shake_numeric_postpass_build_facts,
+    shake_numeric_postpass_build_facts_resolve,
+    shake_numeric_postpass_build_facts_lookup,
+    shake_numeric_postpass_candidate_gate,
+    shake_numeric_postpass_materialize,
+    shake_numeric_postpass_forbidden,
+    shake_numeric_postpass_reachable,
+    shake_numeric_postpass_replace,
+    shake_numeric_postpass_minify_resync,
     shake_mirror,
     metadata,
     metadata_register_ns_rewrites,
@@ -272,19 +283,8 @@ pub const Format = enum {
 // State (process-global)
 // ============================================================================
 
-/// Category 수. u128 bitmask 안에 맞아야 함 (128 미만).
+/// Category 수. `ProfileMask` 크기와 counters 배열의 comptime 길이로 사용한다.
 pub const num_categories = @typeInfo(Category).@"enum".fields.len;
-
-comptime {
-    if (num_categories > 128) {
-        @compileError("Category count exceeded u128 bitmask. Switch to ArrayBitSet.");
-    }
-}
-
-const all_categories_mask: u128 = if (num_categories == 128)
-    std.math.maxInt(u128)
-else
-    (@as(u128, 1) << @as(u7, @intCast(num_categories))) - 1;
 
 const all_categories: [num_categories]Category = blk: {
     var cats: [num_categories]Category = undefined;
@@ -294,10 +294,12 @@ const all_categories: [num_categories]Category = blk: {
     break :blk cats;
 };
 
-/// 활성 카테고리 비트마스크. hot path 에서는 `enabled()` 의 single AND 로 검사.
+const ProfileMask = std.StaticBitSet(num_categories);
+
+/// 활성 카테고리 비트마스크. hot path 에서는 `enabled()` 의 bitset lookup 만 수행.
 /// 프로세스 전역 — 초기화 후 read-only 로 다뤄 thread-safe. 수집 data array 는 현재
 /// single-thread 가정 (PR 7 에서 per-thread merge 로 확장 예정).
-var enabled_mask: u128 = 0;
+var enabled_mask: ProfileMask = ProfileMask.initEmpty();
 
 /// 현재 level. Reporter 가 어떤 수준까지 노출할지 결정.
 var current_level: Level = .summary;
@@ -327,16 +329,15 @@ var active_scope_len: u8 = 0;
 // Activation API (CLI / NAPI / env 공용)
 // ============================================================================
 
-/// 활성 여부 조회 (inline + single AND — hot path 용).
+/// 활성 여부 조회 (inline bitset lookup — hot path 용).
 pub inline fn enabled(cat: Category) bool {
-    const bit = @as(u128, 1) << @intFromEnum(cat);
-    return (enabled_mask & bit) != 0;
+    return enabled_mask.isSet(@intFromEnum(cat));
 }
 
 /// 하나라도 활성화된 category 가 있는지. HMR rebuild 에서 counters reset 을 조건부로
 /// 수행할 때 사용 (비활성 상태의 불필요한 memset 회피).
 pub inline fn anyEnabled() bool {
-    return enabled_mask != 0;
+    return enabled_mask.count() != 0;
 }
 
 /// Level 조회.
@@ -358,11 +359,11 @@ pub fn addFromCsv(csv: []const u8) void {
         if (name.len == 0) continue;
 
         if (std.ascii.eqlIgnoreCase(name, "all")) {
-            enabled_mask = all_categories_mask;
+            enabled_mask = ProfileMask.initFull();
             continue;
         }
         if (std.ascii.eqlIgnoreCase(name, "none")) {
-            enabled_mask = 0;
+            enabled_mask = ProfileMask.initEmpty();
             continue;
         }
         if (Category.fromString(name)) |c| {
@@ -375,11 +376,11 @@ pub fn addFromCsv(csv: []const u8) void {
 pub fn addCategories(names: []const []const u8) void {
     for (names) |name| {
         if (std.ascii.eqlIgnoreCase(name, "all")) {
-            enabled_mask = all_categories_mask;
+            enabled_mask = ProfileMask.initFull();
             continue;
         }
         if (std.ascii.eqlIgnoreCase(name, "none")) {
-            enabled_mask = 0;
+            enabled_mask = ProfileMask.initEmpty();
             continue;
         }
         if (Category.fromString(name)) |c| {
@@ -416,7 +417,7 @@ fn zeroCounters() void {
 
 /// 테스트 / 재초기화용. 전체 상태 초기화 (mask + level + counters 모두).
 pub fn resetForTest() void {
-    enabled_mask = 0;
+    enabled_mask = ProfileMask.initEmpty();
     current_level = .summary;
     zeroCounters();
 }
@@ -439,7 +440,7 @@ fn enableCategoryAndChildren(parent: Category) void {
             child_name[parent_name.len] == '_';
         if (is_self or is_child) {
             const child = @field(Category, child_name);
-            enabled_mask |= @as(u128, 1) << @intFromEnum(child);
+            enabled_mask.set(@intFromEnum(child));
         }
     }
 }
@@ -740,6 +741,7 @@ test "Category.fromString: dot notation 정규화" {
     try testing.expect(Category.fromString("shake.fixpoint.bfs.follow.import") == .shake_fixpoint_bfs_follow_import);
     try testing.expect(Category.fromString("shake.fixpoint.bfs.seed.export.resolve") == .shake_fixpoint_bfs_seed_export_resolve);
     try testing.expect(Category.fromString("shake.fixpoint.re.exports.module") == .shake_fixpoint_re_exports_module);
+    try testing.expect(Category.fromString("shake.numeric.postpass.build.facts.resolve") == .shake_numeric_postpass_build_facts_resolve);
     try testing.expect(Category.fromString("shake.const.prepass.build.facts") == .shake_const_prepass_build_facts);
     try testing.expect(Category.fromString("shake.const.prepass.build.facts.lookup") == .shake_const_prepass_build_facts_lookup);
 }
@@ -755,6 +757,7 @@ test "Category.displayName: underscore → dot 역변환" {
     try testing.expectEqualStrings("shake.fixpoint.bfs.follow.import", Category.displayName(.shake_fixpoint_bfs_follow_import));
     try testing.expectEqualStrings("shake.fixpoint.bfs.seed.export.resolve", Category.displayName(.shake_fixpoint_bfs_seed_export_resolve));
     try testing.expectEqualStrings("shake.fixpoint.re.exports.module", Category.displayName(.shake_fixpoint_re_exports_module));
+    try testing.expectEqualStrings("shake.numeric.postpass.build.facts.resolve", Category.displayName(.shake_numeric_postpass_build_facts_resolve));
     try testing.expectEqualStrings("shake.const.prepass.build.facts", Category.displayName(.shake_const_prepass_build_facts));
     try testing.expectEqualStrings("shake.const.prepass.build.facts.lookup", Category.displayName(.shake_const_prepass_build_facts_lookup));
 }
@@ -1089,10 +1092,11 @@ test "resetForTest 초기화" {
     try testing.expectEqual(@as(u32, 0), count(.parse));
 }
 
-test "addFromCsv all enables last category" {
+test "addFromCsv all enables categories beyond u128 mask boundary" {
     resetForTest();
     defer resetForTest();
 
     addFromCsv("all");
     try testing.expect(enabled(.shake_fixpoint_re_exports_module));
+    try testing.expect(enabled(.cache));
 }

--- a/tests/benchmark/_runner.test.ts
+++ b/tests/benchmark/_runner.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { parseProfileJson } from "./_runner";
+
+describe("benchmark profile JSON parser", () => {
+  test("extracts the profile block when other braces are present", () => {
+    const parsed = parseProfileJson(`
+      warning: object-like text { not: "json" }
+      {
+        "profile_version": 1,
+        "total_ms": 1.25,
+        "level": "summary",
+        "phases": {
+          "shake": { "total_ms": 1.0, "self_ms": 0.5, "count": 1, "pct": 80, "self_pct": 40 }
+        }
+      }
+      trailing { text }
+    `);
+
+    expect(parsed.profile_version).toBe(1);
+    expect(parsed.total_ms).toBe(1.25);
+    expect(parsed.phases.shake?.total_ms).toBe(1);
+  });
+
+  test("handles braces inside JSON strings", () => {
+    const parsed = parseProfileJson(`
+      {
+        "profile_version": 1,
+        "total_ms": 0,
+        "level": "summary {still string}",
+        "phases": {}
+      }
+    `);
+
+    expect(parsed.level).toBe("summary {still string}");
+  });
+});

--- a/tests/benchmark/_runner.ts
+++ b/tests/benchmark/_runner.ts
@@ -53,10 +53,49 @@ export interface ProfileJson {
 
 /// stdout/stderr 에 섞여 나온 `--profile-format=json` 블록을 추출해 파싱.
 export function parseProfileJson(output: string): ProfileJson {
-  const start = output.indexOf("{");
-  const end = output.lastIndexOf("}");
-  if (start < 0 || end < start) {
+  const marker = '"profile_version"';
+  const markerIndex = output.indexOf(marker);
+  if (markerIndex < 0) {
     throw new Error(`missing profile JSON output: ${output.slice(0, 800)}`);
   }
-  return JSON.parse(output.slice(start, end + 1)) as ProfileJson;
+
+  const start = output.lastIndexOf("{", markerIndex);
+  if (start < 0) {
+    throw new Error(`malformed profile JSON output: ${output.slice(0, 800)}`);
+  }
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < output.length; i++) {
+    const ch = output[i];
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === "{") {
+      depth++;
+      continue;
+    }
+    if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        return JSON.parse(output.slice(start, i + 1)) as ProfileJson;
+      }
+    }
+  }
+
+  throw new Error(`unterminated profile JSON output: ${output.slice(start, start + 800)}`);
 }

--- a/tests/benchmark/const-prepass.ts
+++ b/tests/benchmark/const-prepass.ts
@@ -82,6 +82,17 @@ const TARGET_PHASES = [
   "shake.const.prepass.node.buffer",
   "shake.const.prepass.link.refresh",
   "shake.numeric.postpass",
+  "shake.numeric.postpass.queue.seed",
+  "shake.numeric.postpass.queue",
+  "shake.numeric.postpass.build.facts",
+  "shake.numeric.postpass.build.facts.resolve",
+  "shake.numeric.postpass.build.facts.lookup",
+  "shake.numeric.postpass.candidate.gate",
+  "shake.numeric.postpass.materialize",
+  "shake.numeric.postpass.forbidden",
+  "shake.numeric.postpass.reachable",
+  "shake.numeric.postpass.replace",
+  "shake.numeric.postpass.minify.resync",
   "shake.mirror",
 ] as const;
 
@@ -415,6 +426,30 @@ async function main(cli: CliArgs): Promise<void> {
   }
 
   console.log();
+  console.log("### numeric postpass profile");
+  console.log(
+    "| Fixture | Queue seed | Queue | Build facts | Resolve | Lookup | Candidate | Materialize | Forbidden | Reachable | Replace | Minify resync |",
+  );
+  console.log(
+    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+  );
+  for (const result of results) {
+    console.log(
+      `| ${result.name} | ${fmtMs(phaseMedian(result, "shake.numeric.postpass.queue.seed"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.numeric.postpass.queue"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.numeric.postpass.build.facts"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.numeric.postpass.build.facts.resolve"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.numeric.postpass.build.facts.lookup"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.numeric.postpass.candidate.gate"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.numeric.postpass.materialize"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.numeric.postpass.forbidden"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.numeric.postpass.reachable"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.numeric.postpass.replace"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.numeric.postpass.minify.resync"))} |`,
+    );
+  }
+
+  console.log();
   console.log("### fixpoint helper profile");
   console.log(
     "| Fixture | Sym to import | Process imports | Re-exports | Re-export modules | Eval deps |",
@@ -433,10 +468,10 @@ async function main(cli: CliArgs): Promise<void> {
   console.log();
   console.log("### nested bfs helper profile");
   console.log(
-    "| Fixture | Follow import | Follow self | Seed export | Seed count | Seed export self | Resolve | Mark | CJS | Namespace scan | Intermediate | Semantic lookup | Enqueue symbol | Opaque | Require scan | Side effects |",
+    "| Fixture | Follow import | Follow self | Seed export | Seed count | Seed export self | Resolve | Mark | CJS | Namespace scan | Intermediate | Semantic lookup | Enqueue symbol | Opaque | Require scan | Require count | Side effects |",
   );
   console.log(
-    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
   );
   for (const result of results) {
     console.log(
@@ -454,6 +489,7 @@ async function main(cli: CliArgs): Promise<void> {
         `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.seed.export.enqueue.symbol"))} | ` +
         `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.seed.export.opaque"))} | ` +
         `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.require.scan"))} | ` +
+        `${phaseCount(result, "shake.fixpoint.bfs.require.scan")} | ` +
         `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.enqueue.side.effects"))} |`,
     );
   }


### PR DESCRIPTION
## 요약
- BFS에서 현재 모듈에 `require` import record가 없으면 `shake.fixpoint.bfs.require.scan` 루프 자체를 건너뜁니다.
- numeric postpass 내부 단계를 profile/debug 출력에 추가해 다음 병목을 더 작게 추적할 수 있게 했습니다.
- profile category 수가 128개를 넘어도 동작하도록 활성 mask를 `u128`에서 `std.StaticBitSet`으로 바꿨습니다.
- CI benchmark helper의 profile JSON parser를 `profile_version` 마커 기반으로 보강해 로그/경고에 섞인 `{}` 때문에 파싱이 깨지지 않게 했습니다.

## 측정
`bun run tests/benchmark/const-prepass.ts --warmup=3 --iterations=9`

| Fixture | main shake | this PR shake | delta | main BFS queue | this PR BFS queue | main require.scan | this PR require.scan |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| flat-1000 | 2.231ms | 2.006ms | -10.1% | 0.427ms | 0.061ms | 0.341ms | 0.000ms |
| reexport-500 | 1.112ms | 1.164ms | +4.7% | 0.048ms | 0.031ms | 0.010ms | 0.000ms |
| namespace-500 | 0.644ms | 0.673ms | +4.5% | 0.055ms | 0.039ms | 0.010ms | 0.000ms |
| namespace-2000 | 2.843ms | 2.914ms | +2.5% | 0.232ms | 0.160ms | 0.040ms | 0.000ms |

비대상 fixture의 shake 총합은 세부 numeric profile timer 추가에 따른 profile-mode 오버헤드/노이즈로 보입니다. 타깃 경로인 require scan은 synthetic ESM fixture에서 count 0 / 0ms로 제거됐고, BFS queue도 감소했습니다.

추가로 numeric postpass profile에서 다음 병목은 `shake.numeric.postpass.minify.resync`로 확인됩니다.
- flat-1000: 0.756ms
- reexport-500: 0.158ms

`bun run tests/benchmark/bundle-perf.ts --no-fail`
- small: 2.48ms
- medium: 5.54ms
- large: 8.91ms

## 검증
- `zig fmt --check src/profile.zig src/bundler/tree_shaker.zig`
- `bun run fmt:check`
- `zig build test --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- `bun test tests/integration/tests/profile-flags.test.ts`
- `bun test tests/benchmark/_runner.test.ts`
- `bun run lint` (기존 bundle-dynamic-import unused warning만 있음)
- `bun run tests/benchmark/const-prepass.ts --warmup=3 --iterations=9 --output /tmp/zts-require-skip-numeric-profile-const-prepass.json`
- `bun run tests/benchmark/bundle-perf.ts --no-fail --output /tmp/zts-require-skip-numeric-profile-bundle-perf-v2.json`

Refs #2354
