### PR TITLE
perf(tree-shake): numeric postpass resync 좁히기

### DIFF
--- a/src/bundler/constant_facts.zig
+++ b/src/bundler/constant_facts.zig
@@ -98,6 +98,11 @@ pub const MaterializeProfile = struct {
     replace: ?profile.Category = null,
 };
 
+pub const MaterializeResult = struct {
+    changed: bool = false,
+    needs_minify: bool = false,
+};
+
 /// Linker가 증명한 primitive constants를 AST read-site에 반영한다.
 /// codegen-only 치환은 branch body refs를 줄이지 못하므로, minify/DCE 전 literal로
 /// materialize해야 dead branch와 그 안의 imports가 다음 pass에서 사라질 수 있다.
@@ -107,7 +112,7 @@ pub fn materialize(
     symbol_ids: []const ?u32,
     const_values: *const std.AutoHashMapUnmanaged(u32, ConstValue),
 ) bool {
-    return materializeWithScratch(allocator, ast, symbol_ids, const_values, null, 0, .{});
+    return materializeWithScratch(allocator, ast, symbol_ids, const_values, null, 0, .{}).changed;
 }
 
 /// `materialize` + outer driver 가 forbidden/reachable 캐시 재사용. `scratch == null`
@@ -120,8 +125,23 @@ pub fn materializeWithScratch(
     scratch: ?*Scratch,
     mod_idx: usize,
     profile_cats: MaterializeProfile,
-) bool {
-    if (const_values.count() == 0) return false;
+) MaterializeResult {
+    return materializeWithScratchDetailed(allocator, ast, symbol_ids, const_values, scratch, mod_idx, profile_cats, false);
+}
+
+/// `track_minify_need` 활성 시 치환된 read-site 가 minify/DCE 문맥인지 함께 반환한다.
+/// 단순 call argument 같은 문맥은 metadata resync 만 필요하고 full minify 는 생략 가능하다.
+pub fn materializeWithScratchDetailed(
+    allocator: std.mem.Allocator,
+    ast: *Ast,
+    symbol_ids: []const ?u32,
+    const_values: *const std.AutoHashMapUnmanaged(u32, ConstValue),
+    scratch: ?*Scratch,
+    mod_idx: usize,
+    profile_cats: MaterializeProfile,
+    track_minify_need: bool,
+) MaterializeResult {
+    if (const_values.count() == 0) return .{};
 
     // forbidden 확보: 캐시 hit 면 재사용, miss 면 빌드 후 캐시 또는 단발성 사용.
     var owned_forbidden: ?std.DynamicBitSet = null;
@@ -129,14 +149,14 @@ pub fn materializeWithScratch(
     const forbidden_ptr: *const std.DynamicBitSet = blk: {
         if (scratch) |s| if (mod_idx < s.forbidden.len) {
             if (s.forbidden[mod_idx]) |*cached| break :blk cached;
-            var bs = std.DynamicBitSet.initEmpty(allocator, ast.nodes.items.len) catch return false;
+            var bs = std.DynamicBitSet.initEmpty(allocator, ast.nodes.items.len) catch return .{};
             var forbidden_scope = profile.beginMaybe(profile_cats.forbidden);
             defer forbidden_scope.end();
             minify_mod.markForbiddenInlineSites(ast, &bs);
             s.forbidden[mod_idx] = bs;
             break :blk &s.forbidden[mod_idx].?;
         };
-        owned_forbidden = std.DynamicBitSet.initEmpty(allocator, ast.nodes.items.len) catch return false;
+        owned_forbidden = std.DynamicBitSet.initEmpty(allocator, ast.nodes.items.len) catch return .{};
         var forbidden_scope = profile.beginMaybe(profile_cats.forbidden);
         defer forbidden_scope.end();
         minify_mod.markForbiddenInlineSites(ast, &owned_forbidden.?);
@@ -151,17 +171,25 @@ pub fn materializeWithScratch(
             if (s.reachable[mod_idx]) |cached| break :blk cached;
             var reachable_scope = profile.beginMaybe(profile_cats.reachable);
             defer reachable_scope.end();
-            const built = ast_walk.collectReachableNodeIndices(allocator, ast) catch return false;
+            const built = ast_walk.collectReachableNodeIndices(allocator, ast) catch return .{};
             s.reachable[mod_idx] = built;
             break :blk built;
         };
         var reachable_scope = profile.beginMaybe(profile_cats.reachable);
         defer reachable_scope.end();
-        owned_reachable = ast_walk.collectReachableNodeIndices(allocator, ast) catch return false;
+        owned_reachable = ast_walk.collectReachableNodeIndices(allocator, ast) catch return .{};
         break :blk owned_reachable.?;
     };
 
+    var sensitive_refs: ?std.DynamicBitSet = null;
+    defer if (sensitive_refs) |*bs| bs.deinit();
+    if (track_minify_need) {
+        sensitive_refs = std.DynamicBitSet.initEmpty(allocator, ast.nodes.items.len) catch null;
+        if (sensitive_refs) |*bs| markMinifySensitiveIdentifierRefs(ast, reachable, bs);
+    }
+
     var changed = false;
+    var needs_minify = false;
     {
         var replace_scope = profile.beginMaybe(profile_cats.replace);
         defer replace_scope.end();
@@ -175,11 +203,60 @@ pub fn materializeWithScratch(
             const sym_id = symbol_ids[i] orelse continue;
             const cv = const_values.get(sym_id) orelse continue;
             const replacement = constValueNode(ast, cv) orelse continue;
+            if (track_minify_need and !needs_minify) {
+                needs_minify = if (sensitive_refs) |*bs|
+                    i >= bs.capacity() or bs.isSet(i)
+                else
+                    true;
+            }
             ast.nodes.items[i] = replacement;
             changed = true;
         }
     }
-    return changed;
+    return .{ .changed = changed, .needs_minify = needs_minify };
+}
+
+fn isMinifySensitiveParent(tag: Node.Tag) bool {
+    return switch (tag) {
+        .unary_expression,
+        .binary_expression,
+        .logical_expression,
+        .conditional_expression,
+        .sequence_expression,
+        .parenthesized_expression,
+        .expression_statement,
+        .if_statement,
+        .switch_statement,
+        .switch_case,
+        .while_statement,
+        .do_while_statement,
+        .variable_declarator,
+        => true,
+        else => false,
+    };
+}
+
+fn markMinifySensitiveIdentifierRefs(
+    ast: *const Ast,
+    reachable: []const u32,
+    sensitive_refs: *std.DynamicBitSet,
+) void {
+    for (reachable) |parent_ni| {
+        const parent_i: usize = @intCast(parent_ni);
+        if (parent_i >= ast.nodes.items.len) continue;
+        const parent = ast.nodes.items[parent_i];
+        if (!isMinifySensitiveParent(parent.tag)) continue;
+
+        var it = ast_walk.children(ast, parent);
+        while (it.next()) |child| {
+            if (child.isNone()) continue;
+            const child_i = @intFromEnum(child);
+            if (child_i >= ast.nodes.items.len or child_i >= sensitive_refs.capacity()) continue;
+            if (ast.nodes.items[child_i].tag == .identifier_reference) {
+                sensitive_refs.set(child_i);
+            }
+        }
+    }
 }
 
 test "constant_facts: numeric const value materializes to numeric literal node" {
@@ -250,4 +327,43 @@ test "constant_facts: numeric const value does not replace object shorthand key"
     const node = parser.ast.nodes.items[idx];
     try std.testing.expectEqual(Node.Tag.identifier_reference, node.tag);
     try std.testing.expectEqualStrings("n", parser.ast.getText(node.span));
+}
+
+fn expectMaterializeMinifyNeed(source: []const u8, expected_needs_minify: bool) !void {
+    const Scanner = @import("../lexer/scanner.zig").Scanner;
+    const Parser = @import("../parser/parser.zig").Parser;
+
+    const allocator = std.testing.allocator;
+    var scanner = try Scanner.init(allocator, source);
+    defer scanner.deinit();
+    var parser = Parser.init(allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    var symbol_ids = try allocator.alloc(?u32, parser.ast.nodes.items.len);
+    defer allocator.free(symbol_ids);
+    @memset(symbol_ids, null);
+
+    for (parser.ast.nodes.items, 0..) |node, i| {
+        if (node.tag == .identifier_reference and std.mem.eql(u8, parser.ast.getText(node.span), "n")) {
+            symbol_ids[i] = 7;
+            break;
+        }
+    }
+
+    var const_values: std.AutoHashMapUnmanaged(u32, ConstValue) = .{};
+    defer const_values.deinit(allocator);
+    try const_values.put(allocator, 7, .{ .kind = .number, .number_text = "123" });
+
+    const result = materializeWithScratchDetailed(allocator, &parser.ast, symbol_ids, &const_values, null, 0, .{}, true);
+    try std.testing.expect(result.changed);
+    try std.testing.expectEqual(expected_needs_minify, result.needs_minify);
+}
+
+test "constant_facts: call argument numeric replacement does not require minify" {
+    try expectMaterializeMinifyNeed("console.log(n);", false);
+}
+
+test "constant_facts: binary numeric replacement requires minify" {
+    try expectMaterializeMinifyNeed("console.log(n + 2);", true);
 }

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -2350,17 +2350,12 @@ pub const ModuleGraph = struct {
         }
     }
 
-    pub fn resyncModuleMetadataAfterAstMutation(
+    fn refreshSemanticAndStmtInfoAfterAstMutation(
         self: *ModuleGraph,
         module: *Module,
         arena_alloc: std.mem.Allocator,
     ) !void {
-        var resync_scope = profile.begin(.graph_resync);
-        defer resync_scope.end();
-
         const ast = &(module.ast orelse return);
-        const previous_import_records = module.import_records;
-        const previous_import_bindings = module.import_bindings;
         const previous_semantic = module.semantic;
 
         var analyzer = SemanticAnalyzer.init(arena_alloc, ast);
@@ -2419,6 +2414,74 @@ pub const ModuleGraph = struct {
                 );
             }
         }
+    }
+
+    fn refreshStableBindingRefsAfterSemanticResync(
+        self: *ModuleGraph,
+        module: *Module,
+        arena_alloc: std.mem.Allocator,
+        cat: profile.Category,
+    ) !void {
+        var binding_refs_scope = profile.begin(cat);
+        defer binding_refs_scope.end();
+
+        const sem = if (module.semantic) |*s| s else return;
+        const scope0: ?std.StringHashMap(usize) =
+            if (sem.scope_maps.len > 0) sem.scope_maps[0] else null;
+        for (module.import_bindings) |*ib| {
+            if (ib.isSynthetic()) continue;
+            ib.local_symbol = bundler_symbol.SymbolRef.invalid;
+            if (scope0) |module_scope| {
+                if (module_scope.get(ib.local_name)) |sym_idx| {
+                    ib.local_symbol = bundler_symbol.SymbolRef.makeSemantic(module.index, sym_idx);
+                }
+            }
+        }
+
+        if (module.alias_table) |*table| table.deinit();
+        module.alias_table = AliasTable.init(self.allocator);
+        try binding_scanner_mod.populateSyntheticSymbols(
+            &module.alias_table.?,
+            module.index,
+            module.export_bindings,
+            &sem.symbols,
+            arena_alloc,
+            scope0,
+        );
+    }
+
+    /// Numeric const materialization replaces identifier reads and may let minify fold
+    /// expressions, but it does not add/remove import or export declarations. Keep the
+    /// expensive syntax-level scanners intact for general transforms and use this path
+    /// only when the caller owns that invariant.
+    pub fn resyncModuleMetadataAfterConstMaterialization(
+        self: *ModuleGraph,
+        module: *Module,
+        arena_alloc: std.mem.Allocator,
+    ) !void {
+        var resync_scope = profile.begin(.graph_resync);
+        defer resync_scope.end();
+        var const_scope = profile.begin(.graph_resync_const);
+        defer const_scope.end();
+
+        _ = &(module.ast orelse return);
+        try self.refreshSemanticAndStmtInfoAfterAstMutation(module, arena_alloc);
+        try self.refreshStableBindingRefsAfterSemanticResync(module, arena_alloc, .graph_resync_binding_refs);
+    }
+
+    pub fn resyncModuleMetadataAfterAstMutation(
+        self: *ModuleGraph,
+        module: *Module,
+        arena_alloc: std.mem.Allocator,
+    ) !void {
+        var resync_scope = profile.begin(.graph_resync);
+        defer resync_scope.end();
+
+        const ast = &(module.ast orelse return);
+        const previous_import_records = module.import_records;
+        const previous_import_bindings = module.import_bindings;
+
+        try self.refreshSemanticAndStmtInfoAfterAstMutation(module, arena_alloc);
 
         var scan_result: import_scanner.ScanResult = undefined;
         {
@@ -2499,25 +2562,7 @@ pub const ModuleGraph = struct {
             );
         }
 
-        {
-            var alias_scope = profile.begin(.graph_resync_alias);
-            defer alias_scope.end();
-
-            if (module.alias_table) |*table| table.deinit();
-            module.alias_table = AliasTable.init(self.allocator);
-            if (module.semantic) |*sem| {
-                const scope0: ?std.StringHashMap(usize) =
-                    if (sem.scope_maps.len > 0) sem.scope_maps[0] else null;
-                try binding_scanner_mod.populateSyntheticSymbols(
-                    &module.alias_table.?,
-                    module.index,
-                    module.export_bindings,
-                    &sem.symbols,
-                    arena_alloc,
-                    scope0,
-                );
-            }
-        }
+        try self.refreshStableBindingRefsAfterSemanticResync(module, arena_alloc, .graph_resync_alias);
     }
 
     fn suppressRuntimeHelperInternalUnresolved(module: *Module) void {

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -85,7 +85,12 @@ const ConstMaterializeProfile = struct {
     candidate_gate: ?profile.Category = null,
     materialize: ?profile.Category = null,
     minify_resync: ?profile.Category = null,
+    minify: ?profile.Category = null,
+    resync: ?profile.Category = null,
+    minify_skip: ?profile.Category = null,
     inner: constant_facts.MaterializeProfile = .{},
+    skip_minify_if_safe: bool = false,
+    stable_import_export_syntax: bool = false,
 };
 
 pub const TreeShaker = struct {
@@ -479,15 +484,38 @@ pub const TreeShaker = struct {
         sem: ModuleSemanticData,
         ast: *Ast,
         profile_cat: ?profile.Category,
+        minify_cat: ?profile.Category,
+        resync_cat: ?profile.Category,
+        skip_cat: ?profile.Category,
+        skip_minify: bool,
+        stable_import_export_syntax: bool,
     ) void {
         var scope = profile.beginMaybe(profile_cat);
         defer scope.end();
 
-        const minify_mod = @import("../transformer/minify.zig");
-        const root = ast.transformed_root orelse NodeIndex.none;
-        const ctx = minify_mod.MinifyCtx.fromSemantic(&m.semantic.?, sem.symbol_ids, self.graph.transform_options_base.minify_syntax);
-        minify_mod.minify(ast, ctx, self.allocator, root);
-        self.markAstMutatedAndResync(m);
+        if (skip_minify) {
+            var skip_scope = profile.beginMaybe(skip_cat);
+            defer skip_scope.end();
+        } else {
+            var minify_scope = profile.beginMaybe(minify_cat);
+            defer minify_scope.end();
+
+            const minify_mod = @import("../transformer/minify.zig");
+            const root = ast.transformed_root orelse NodeIndex.none;
+            const ctx = minify_mod.MinifyCtx.fromSemantic(&m.semantic.?, sem.symbol_ids, self.graph.transform_options_base.minify_syntax);
+            minify_mod.minify(ast, ctx, self.allocator, root);
+        }
+
+        {
+            var resync_scope = profile.beginMaybe(resync_cat);
+            defer resync_scope.end();
+
+            if (stable_import_export_syntax) {
+                self.markConstMaterializedAndResync(m);
+            } else {
+                self.markAstMutatedAndResync(m);
+            }
+        }
     }
 
     /// AST mutation 후 모듈 metadata 재동기화 + linker rename/mangling 재계산 신호 set.
@@ -499,6 +527,16 @@ pub const TreeShaker = struct {
         // 분석 산출물이 self.allocator 로 새서 leak 되므로 invariant 로 강제.
         std.debug.assert(m.parse_arena != null);
         self.graph.resyncModuleMetadataAfterAstMutation(m, m.parse_arena.?.allocator()) catch {
+            m.prebuilt_stmt_info = null;
+        };
+        self.ast_mutated_after_link = true;
+        self.invalidateImportRecordStmtIndices(@intFromEnum(m.index));
+        if (self.materialize_scratch) |*s| s.invalidate(@intFromEnum(m.index));
+    }
+
+    fn markConstMaterializedAndResync(self: *TreeShaker, m: *Module) void {
+        std.debug.assert(m.parse_arena != null);
+        self.graph.resyncModuleMetadataAfterConstMaterialization(m, m.parse_arena.?.allocator()) catch {
             m.prebuilt_stmt_info = null;
         };
         self.ast_mutated_after_link = true;
@@ -574,15 +612,35 @@ pub const TreeShaker = struct {
             self.materialize_scratch = constant_facts.Scratch.init(self.allocator, self.graph.moduleCount()) catch null;
         }
         const scratch_ptr: ?*constant_facts.Scratch = if (self.materialize_scratch) |*s| s else null;
-        const changed = blk: {
+        const materialized = blk: {
             var materialize_scope = profile.beginMaybe(const_profile.materialize);
             defer materialize_scope.end();
-            break :blk constant_facts.materializeWithScratch(self.allocator, ast, sem.symbol_ids, &const_values, scratch_ptr, module_index, const_profile.inner);
+            break :blk constant_facts.materializeWithScratchDetailed(
+                self.allocator,
+                ast,
+                sem.symbol_ids,
+                &const_values,
+                scratch_ptr,
+                module_index,
+                const_profile.inner,
+                const_profile.skip_minify_if_safe,
+            );
         };
         const_values.deinit(self.allocator);
-        if (!changed) return false;
+        if (!materialized.changed) return false;
 
-        self.minifyAndResyncModule(m, sem, ast, const_profile.minify_resync);
+        const skip_minify = const_profile.skip_minify_if_safe and !materialized.needs_minify;
+        self.minifyAndResyncModule(
+            m,
+            sem,
+            ast,
+            const_profile.minify_resync,
+            const_profile.minify,
+            const_profile.resync,
+            const_profile.minify_skip,
+            skip_minify,
+            const_profile.stable_import_export_syntax,
+        );
         return true;
     }
 
@@ -643,6 +701,11 @@ pub const TreeShaker = struct {
             .candidate_gate = .shake_numeric_postpass_candidate_gate,
             .materialize = .shake_numeric_postpass_materialize,
             .minify_resync = .shake_numeric_postpass_minify_resync,
+            .minify = .shake_numeric_postpass_minify,
+            .resync = .shake_numeric_postpass_resync,
+            .minify_skip = .shake_numeric_postpass_minify_skip,
+            .skip_minify_if_safe = true,
+            .stable_import_export_syntax = true,
             .inner = .{
                 .forbidden = .shake_numeric_postpass_forbidden,
                 .reachable = .shake_numeric_postpass_reachable,

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -82,6 +82,7 @@ pub const Category = enum {
     graph_discover_pm_is_pkg_type,
     graph_finalize,
     graph_resync,
+    graph_resync_const,
     graph_resync_semantic,
     graph_resync_stmt_info,
     graph_resync_import_scan,
@@ -89,6 +90,7 @@ pub const Category = enum {
     graph_resync_export_bindings,
     graph_resync_classify,
     graph_resync_alias,
+    graph_resync_binding_refs,
     graph_runtime_polyfills,
     graph_runtime_polyfills_collect,
     graph_runtime_polyfills_aggregate,
@@ -161,6 +163,9 @@ pub const Category = enum {
     shake_numeric_postpass_reachable,
     shake_numeric_postpass_replace,
     shake_numeric_postpass_minify_resync,
+    shake_numeric_postpass_minify,
+    shake_numeric_postpass_resync,
+    shake_numeric_postpass_minify_skip,
     shake_mirror,
     metadata,
     metadata_register_ns_rewrites,
@@ -742,6 +747,9 @@ test "Category.fromString: dot notation 정규화" {
     try testing.expect(Category.fromString("shake.fixpoint.bfs.seed.export.resolve") == .shake_fixpoint_bfs_seed_export_resolve);
     try testing.expect(Category.fromString("shake.fixpoint.re.exports.module") == .shake_fixpoint_re_exports_module);
     try testing.expect(Category.fromString("shake.numeric.postpass.build.facts.resolve") == .shake_numeric_postpass_build_facts_resolve);
+    try testing.expect(Category.fromString("shake.numeric.postpass.minify.skip") == .shake_numeric_postpass_minify_skip);
+    try testing.expect(Category.fromString("graph.resync.const") == .graph_resync_const);
+    try testing.expect(Category.fromString("graph.resync.binding.refs") == .graph_resync_binding_refs);
     try testing.expect(Category.fromString("shake.const.prepass.build.facts") == .shake_const_prepass_build_facts);
     try testing.expect(Category.fromString("shake.const.prepass.build.facts.lookup") == .shake_const_prepass_build_facts_lookup);
 }
@@ -758,6 +766,9 @@ test "Category.displayName: underscore → dot 역변환" {
     try testing.expectEqualStrings("shake.fixpoint.bfs.seed.export.resolve", Category.displayName(.shake_fixpoint_bfs_seed_export_resolve));
     try testing.expectEqualStrings("shake.fixpoint.re.exports.module", Category.displayName(.shake_fixpoint_re_exports_module));
     try testing.expectEqualStrings("shake.numeric.postpass.build.facts.resolve", Category.displayName(.shake_numeric_postpass_build_facts_resolve));
+    try testing.expectEqualStrings("shake.numeric.postpass.minify.skip", Category.displayName(.shake_numeric_postpass_minify_skip));
+    try testing.expectEqualStrings("graph.resync.const", Category.displayName(.graph_resync_const));
+    try testing.expectEqualStrings("graph.resync.binding.refs", Category.displayName(.graph_resync_binding_refs));
     try testing.expectEqualStrings("shake.const.prepass.build.facts", Category.displayName(.shake_const_prepass_build_facts));
     try testing.expectEqualStrings("shake.const.prepass.build.facts.lookup", Category.displayName(.shake_const_prepass_build_facts_lookup));
 }

--- a/tests/benchmark/const-prepass.ts
+++ b/tests/benchmark/const-prepass.ts
@@ -93,6 +93,19 @@ const TARGET_PHASES = [
   "shake.numeric.postpass.reachable",
   "shake.numeric.postpass.replace",
   "shake.numeric.postpass.minify.resync",
+  "shake.numeric.postpass.minify",
+  "shake.numeric.postpass.resync",
+  "shake.numeric.postpass.minify.skip",
+  "graph.resync",
+  "graph.resync.const",
+  "graph.resync.semantic",
+  "graph.resync.stmt.info",
+  "graph.resync.import.scan",
+  "graph.resync.import.bindings",
+  "graph.resync.export.bindings",
+  "graph.resync.classify",
+  "graph.resync.alias",
+  "graph.resync.binding.refs",
   "shake.mirror",
 ] as const;
 
@@ -204,7 +217,7 @@ function runOne(entry: string, outDir: string): ProfileJson {
       "--format=esm",
       "-o",
       join(outDir, "out.js"),
-      "--profile=shake",
+      "--profile=shake,graph.resync",
       "--profile-level=detailed",
       "--profile-format=json",
     ],
@@ -428,10 +441,10 @@ async function main(cli: CliArgs): Promise<void> {
   console.log();
   console.log("### numeric postpass profile");
   console.log(
-    "| Fixture | Queue seed | Queue | Build facts | Resolve | Lookup | Candidate | Materialize | Forbidden | Reachable | Replace | Minify resync |",
+    "| Fixture | Queue seed | Queue | Build facts | Resolve | Lookup | Candidate | Materialize | Forbidden | Reachable | Replace | Minify resync | Minify | Resync | Skip count |",
   );
   console.log(
-    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
   );
   for (const result of results) {
     console.log(
@@ -445,7 +458,31 @@ async function main(cli: CliArgs): Promise<void> {
         `${fmtMs(phaseMedian(result, "shake.numeric.postpass.forbidden"))} | ` +
         `${fmtMs(phaseMedian(result, "shake.numeric.postpass.reachable"))} | ` +
         `${fmtMs(phaseMedian(result, "shake.numeric.postpass.replace"))} | ` +
-        `${fmtMs(phaseMedian(result, "shake.numeric.postpass.minify.resync"))} |`,
+        `${fmtMs(phaseMedian(result, "shake.numeric.postpass.minify.resync"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.numeric.postpass.minify"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.numeric.postpass.resync"))} | ` +
+        `${phaseCount(result, "shake.numeric.postpass.minify.skip")} |`,
+    );
+  }
+
+  console.log();
+  console.log("### numeric resync graph profile");
+  console.log(
+    "| Fixture | Graph resync | Const path | Semantic | Stmt info | Binding refs | Import scan | Import bindings | Export bindings | Classify | Alias |",
+  );
+  console.log("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |");
+  for (const result of results) {
+    console.log(
+      `| ${result.name} | ${fmtMs(phaseMedian(result, "graph.resync"))} | ` +
+        `${fmtMs(phaseMedian(result, "graph.resync.const"))} | ` +
+        `${fmtMs(phaseMedian(result, "graph.resync.semantic"))} | ` +
+        `${fmtMs(phaseMedian(result, "graph.resync.stmt.info"))} | ` +
+        `${fmtMs(phaseMedian(result, "graph.resync.binding.refs"))} | ` +
+        `${fmtMs(phaseMedian(result, "graph.resync.import.scan"))} | ` +
+        `${fmtMs(phaseMedian(result, "graph.resync.import.bindings"))} | ` +
+        `${fmtMs(phaseMedian(result, "graph.resync.export.bindings"))} | ` +
+        `${fmtMs(phaseMedian(result, "graph.resync.classify"))} | ` +
+        `${fmtMs(phaseMedian(result, "graph.resync.alias"))} |`,
     );
   }
 

--- a/tests/integration/tests/const-value-inline.test.ts
+++ b/tests/integration/tests/const-value-inline.test.ts
@@ -426,6 +426,39 @@ describe("const_value cross-module 인라인 correctness", () => {
     expect(run.trim()).toBe("2 99");
   });
 
+  test("numeric post-pass resync는 re-export alias symbol을 최신 semantic에 맞춘다", async () => {
+    const fx = await createFixture({
+      "seed.ts": `export const base = 1;`,
+      "left.ts": `
+        import { base } from "./seed";
+        const unusedLocal = 123;
+        export const value = base + 1;
+      `,
+      "barrel.ts": `export { value as answer } from "./left";`,
+      "index.ts": `
+        import { answer } from "./barrel";
+        console.log(answer);
+      `,
+    });
+    cleanup = fx.cleanup;
+    const out = join(fx.dir, "out.js");
+    const build = await runZts([
+      "--bundle",
+      join(fx.dir, "index.ts"),
+      "-o",
+      out,
+      "--platform=node",
+    ]);
+    expect(build.exitCode).toBe(0);
+
+    const src = readFileSync(out, "utf8");
+    expect(src).toMatch(/console\.log\(2\)/);
+    expect(src).not.toContain("unusedLocal");
+
+    const run = await Bun.$`node ${out}`.text();
+    expect(run.trim()).toBe("2");
+  });
+
   test("--minify 에서 pre-shake materialize 이후 numeric post-pass 미발화 경로도 emit 정상", async () => {
     // #2502 회귀 방지. inner refreshLinkMetadataAfterPreShakeMutation 가 좁은 populate*
     // 만 실행하고 ast_mutated_after_link 를 sticky 유지해 outer finalize 가 항상 발화해야


### PR DESCRIPTION
## 요약
- numeric const materialization 전용 graph resync 경로를 추가해 import/export scan, binding 재추출, classify를 건너뜁니다.
- 대신 semantic/stmt_info와 import local symbol, export alias symbol만 새 semantic 기준으로 갱신합니다.
- `const-prepass` 벤치마크에 numeric postpass minify/resync와 graph resync 세부 프로파일을 추가했습니다.
- re-export alias가 numeric postpass 이후 stale symbol을 보지 않도록 통합 회귀 테스트를 추가했습니다.

## 측정
`bun run tests/benchmark/const-prepass.ts --warmup=3 --iterations=9 --output /tmp/zts-numeric-resync-narrow-const-prepass.json`

- flat-1000: shake `2.08ms -> 1.57ms`, numeric postpass `1.01ms -> 0.51ms`, resync `0.13ms`
- reexport-500: shake `1.15ms -> 1.07ms`, numeric postpass `0.27ms -> 0.24ms`, resync `0.05ms`
- namespace fixtures: materialize가 없어 기존과 거의 동일

새 graph 세부 프로파일에서 numeric postpass resync의 import/export scan, import/export bindings, classify는 모두 `0.00ms`로 빠집니다.

## 검증
- `zig build test --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- `bun run fmt:check`
- `bun run lint` (기존 `bundle-dynamic-import.test.ts` unused import 경고 3개만 유지)
- `bun test tests/integration/tests/const-value-inline.test.ts`
- `bun test tests/benchmark/_runner.test.ts`
- `bun run tests/benchmark/const-prepass.ts --warmup=3 --iterations=9 --output /tmp/zts-numeric-resync-narrow-const-prepass.json`
- `bun run tests/benchmark/bundle-perf.ts --no-fail --output /tmp/zts-numeric-resync-narrow-bundle-perf.json`