### PR TITLE
perf(tree-shake): direct export seed fast-path 추가

### DIFF
--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -1715,6 +1715,64 @@ pub const TreeShaker = struct {
         try self.seedExport(target, ib.imported_name, queue, module_stmt_infos, reachable_stmts);
     }
 
+    fn seedDirectLocalExport(
+        self: *TreeShaker,
+        target_mod: usize,
+        imported_name: []const u8,
+        queue: *std.ArrayListUnmanaged(BfsItem),
+        module_stmt_infos: []?StmtInfos,
+        reachable_stmts: []?std.DynamicBitSet,
+    ) std.mem.Allocator.Error!bool {
+        const target_u32: u32 = @intCast(target_mod);
+        const target_idx: types.ModuleIndex = @enumFromInt(target_u32);
+        const target_module = self.graph.getModule(target_idx) orelse return false;
+        if (target_module.wrap_kind == .cjs) return false;
+        // Import-backed local exports (`import { x }; export { x }`, namespace barrels)
+        // still need resolveExportChain's fallback semantics.
+        if (target_module.import_records.len != 0 or target_module.import_bindings.len != 0) return false;
+
+        const binding = target_module.findExportBinding(imported_name) orelse return false;
+        if (binding.kind != .local) return false;
+
+        const target_infos = if (target_mod < module_stmt_infos.len)
+            (module_stmt_infos[target_mod] orelse return false)
+        else
+            return false;
+
+        const local_name = target_module.exportBindingLocalName(binding.*);
+        const target_sem = target_module.semantic orelse return false;
+        if (target_sem.scope_maps.len == 0) return false;
+        const direct_sym: u32 = switch (binding.symbol) {
+            .semantic => |sym| blk: {
+                if (sym.module != target_idx or sym.symbol.isNone()) return false;
+                const sym_idx = @intFromEnum(sym.symbol);
+                if (sym_idx >= target_sem.symbols.items.len) return false;
+                break :blk sym_idx;
+            },
+            .alias => @intCast(target_sem.scope_maps[0].get(local_name) orelse return false),
+        };
+
+        var direct_scope = profile.begin(.shake_fixpoint_bfs_seed_export_direct);
+        defer direct_scope.end();
+
+        {
+            var mark_scope = profile.begin(.shake_fixpoint_bfs_seed_export_mark);
+            defer mark_scope.end();
+
+            try self.markExportUsed(target_u32, binding.exported_name);
+            self.included.set(target_mod);
+        }
+
+        {
+            var enqueue_scope = profile.begin(.shake_fixpoint_bfs_seed_export_enqueue_symbol);
+            defer enqueue_scope.end();
+
+            try self.enqueueSymbolLiveStatements(target_u32, target_infos, direct_sym, reachable_stmts, queue);
+        }
+
+        return true;
+    }
+
     /// canonical export의 선언 statement를 BFS 큐에 추가.
     fn seedExport(
         self: *TreeShaker,
@@ -1728,6 +1786,8 @@ pub const TreeShaker = struct {
 
         var seed_scope = profile.begin(.shake_fixpoint_bfs_seed_export);
         defer seed_scope.end();
+
+        if (try self.seedDirectLocalExport(target_mod, imported_name, queue, module_stmt_infos, reachable_stmts)) return;
 
         const mod_count = self.graph.moduleCount();
         const canonical = blk: {

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -135,6 +135,7 @@ pub const Category = enum {
     shake_fixpoint_bfs_queue,
     shake_fixpoint_bfs_follow_import,
     shake_fixpoint_bfs_seed_export,
+    shake_fixpoint_bfs_seed_export_direct,
     shake_fixpoint_bfs_require_scan,
     shake_fixpoint_bfs_final_mark_exports,
     shake_fixpoint_bfs_enqueue_side_effects,
@@ -744,6 +745,7 @@ test "Category.fromString: dot notation 정규화" {
     try testing.expect(Category.fromString("shake.post.link.finalize") == .shake_post_link_finalize);
     try testing.expect(Category.fromString("shake.fixpoint.bfs") == .shake_fixpoint_bfs);
     try testing.expect(Category.fromString("shake.fixpoint.bfs.follow.import") == .shake_fixpoint_bfs_follow_import);
+    try testing.expect(Category.fromString("shake.fixpoint.bfs.seed.export.direct") == .shake_fixpoint_bfs_seed_export_direct);
     try testing.expect(Category.fromString("shake.fixpoint.bfs.seed.export.resolve") == .shake_fixpoint_bfs_seed_export_resolve);
     try testing.expect(Category.fromString("shake.fixpoint.re.exports.module") == .shake_fixpoint_re_exports_module);
     try testing.expect(Category.fromString("shake.numeric.postpass.build.facts.resolve") == .shake_numeric_postpass_build_facts_resolve);
@@ -763,6 +765,7 @@ test "Category.displayName: underscore → dot 역변환" {
     try testing.expectEqualStrings("shake.post.link.finalize", Category.displayName(.shake_post_link_finalize));
     try testing.expectEqualStrings("shake.fixpoint.bfs", Category.displayName(.shake_fixpoint_bfs));
     try testing.expectEqualStrings("shake.fixpoint.bfs.follow.import", Category.displayName(.shake_fixpoint_bfs_follow_import));
+    try testing.expectEqualStrings("shake.fixpoint.bfs.seed.export.direct", Category.displayName(.shake_fixpoint_bfs_seed_export_direct));
     try testing.expectEqualStrings("shake.fixpoint.bfs.seed.export.resolve", Category.displayName(.shake_fixpoint_bfs_seed_export_resolve));
     try testing.expectEqualStrings("shake.fixpoint.re.exports.module", Category.displayName(.shake_fixpoint_re_exports_module));
     try testing.expectEqualStrings("shake.numeric.postpass.build.facts.resolve", Category.displayName(.shake_numeric_postpass_build_facts_resolve));
@@ -851,6 +854,7 @@ test "addFromCsv: shake parent → 모든 sub-phase 활성" {
     try testing.expect(enabled(.shake_fixpoint));
     try testing.expect(enabled(.shake_fixpoint_bfs));
     try testing.expect(enabled(.shake_fixpoint_bfs_follow_import));
+    try testing.expect(enabled(.shake_fixpoint_bfs_seed_export_direct));
     try testing.expect(enabled(.shake_fixpoint_bfs_seed_export_resolve));
     try testing.expect(enabled(.shake_numeric_postpass));
 }

--- a/tests/benchmark/const-prepass.ts
+++ b/tests/benchmark/const-prepass.ts
@@ -50,6 +50,7 @@ const TARGET_PHASES = [
   "shake.fixpoint.bfs.queue",
   "shake.fixpoint.bfs.follow.import",
   "shake.fixpoint.bfs.seed.export",
+  "shake.fixpoint.bfs.seed.export.direct",
   "shake.fixpoint.bfs.require.scan",
   "shake.fixpoint.bfs.final.mark.exports",
   "shake.fixpoint.bfs.enqueue.side.effects",
@@ -505,10 +506,10 @@ async function main(cli: CliArgs): Promise<void> {
   console.log();
   console.log("### nested bfs helper profile");
   console.log(
-    "| Fixture | Follow import | Follow self | Seed export | Seed count | Seed export self | Resolve | Mark | CJS | Namespace scan | Intermediate | Semantic lookup | Enqueue symbol | Opaque | Require scan | Require count | Side effects |",
+    "| Fixture | Follow import | Follow self | Seed export | Seed count | Seed export self | Direct local | Resolve | Mark | CJS | Namespace scan | Intermediate | Semantic lookup | Enqueue symbol | Opaque | Require scan | Require count | Side effects |",
   );
   console.log(
-    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
   );
   for (const result of results) {
     console.log(
@@ -517,6 +518,7 @@ async function main(cli: CliArgs): Promise<void> {
         `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.seed.export"))} | ` +
         `${phaseCount(result, "shake.fixpoint.bfs.seed.export")} | ` +
         `${fmtMs(phaseSelfMedian(result, "shake.fixpoint.bfs.seed.export"))} | ` +
+        `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.seed.export.direct"))} | ` +
         `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.seed.export.resolve"))} | ` +
         `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.seed.export.mark"))} | ` +
         `${fmtMs(phaseMedian(result, "shake.fixpoint.bfs.seed.export.cjs"))} | ` +

--- a/tests/integration/tests/profile-flags.test.ts
+++ b/tests/integration/tests/profile-flags.test.ts
@@ -233,9 +233,10 @@ describe("profile CLI flags", () => {
     const fixture = await createFixture({
       "dep-a.ts": `export const a = 1; export const unusedA = 10;`,
       "dep-b.ts": `export const b = 2; export const unusedB = 20;`,
+      "barrel.ts": `export { b } from "./dep-b";`,
       "index.ts": `
         import { a } from "./dep-a";
-        import { b } from "./dep-b";
+        import { b } from "./barrel";
         console.log(a + b);
       `,
     });
@@ -266,6 +267,7 @@ describe("profile CLI flags", () => {
     expect(parsed.phases["shake.fixpoint.bfs.queue"]).toBeDefined();
     expect(parsed.phases["shake.fixpoint.bfs.follow.import"]).toBeDefined();
     expect(parsed.phases["shake.fixpoint.bfs.seed.export"]).toBeDefined();
+    expect(parsed.phases["shake.fixpoint.bfs.seed.export.direct"]).toBeDefined();
     expect(parsed.phases["shake.fixpoint.bfs.seed.export.resolve"]).toBeDefined();
     expect(parsed.phases["shake.prune"]).toBeDefined();
   });


### PR DESCRIPTION
### 요약
- import/re-export가 없는 leaf 모듈의 직접 local export는 resolveExportChain 없이 statement seed까지 바로 처리합니다.
- shake.fixpoint.bfs.seed.export.direct 프로파일 phase와 benchmark 표 컬럼을 추가했습니다.
- import-backed local export, namespace barrel, CJS는 기존 경로로 fallback합니다.

### 측정
- 기준: origin/main 1100b445, /tmp/zts-main-after-2558-const-prepass.json
- 변경 후: /tmp/zts-direct-export-leaf-const-prepass-15.json (warmup=5, iterations=15)
- flat-1000: shake 1.58ms -> 1.49ms, seed.export 0.244ms -> 0.200ms, direct hit 1000
- namespace-2000: shake 2.98ms -> 2.85ms, seed.export 0.654ms -> 0.500ms, direct hit 2000
- reexport-500: direct hit 0, 기존 resolve 경로 유지

### 검증
- zig build test --summary all
- zig build -Doptimize=ReleaseFast --summary all
- bun run fmt:check
- bun run lint (기존 bundle-dynamic-import unused import warning 3건)
- bun test tests/integration/tests/const-value-inline.test.ts
- bun test tests/integration/tests/profile-flags.test.ts
- bun run tests/benchmark/const-prepass.ts --warmup=5 --iterations=15 --output /tmp/zts-direct-export-leaf-const-prepass-15.json
- bun run tests/benchmark/bundle-perf.ts --no-fail --output /tmp/zts-direct-export-seed-bundle-perf.json