### PR TITLE
refactor: /simplify follow-up — dedupe tree-shaker + benchmark helpers

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -619,7 +619,7 @@ pub const Linker = struct {
         var it = self.graph.modulesIterator();
         while (it.next()) |m| {
             for (m.export_bindings) |eb| {
-                if (eb.kind == .re_export or eb.kind.isReExportAll()) {
+                if (eb.kind.isAnyReExport()) {
                     self.chain_cache_enabled = true;
                     break;
                 }

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -862,6 +862,26 @@ pub fn findStmtForPos(stmt_spans: []const Span, pos: u32) ?u32 {
     return null; // 어떤 statement span에도 속하지 않음
 }
 
+/// `ModuleStmtInfos.stmts` 의 span 으로부터 pos 를 포함하는 stmt index 를 binary search.
+/// `findStmtForPos` 와 동일 알고리즘이지만 SOA span 슬라이스가 별도로 존재하지 않는 호출부용.
+pub fn findStmtIndexFromInfos(infos: ModuleStmtInfos, pos: u32) ?u32 {
+    if (infos.stmts.len == 0) return null;
+    var lo: u32 = 0;
+    var hi: u32 = @intCast(infos.stmts.len);
+    while (lo < hi) {
+        const mid = lo + (hi - lo) / 2;
+        const span = infos.stmts[mid].span;
+        if (pos >= span.end) {
+            lo = mid + 1;
+        } else if (pos < span.start) {
+            hi = mid;
+        } else {
+            return mid;
+        }
+    }
+    return null;
+}
+
 const ReverseIndex = struct {
     sym_to_referencing_stmts: []const []const u32,
     sym_to_side_effect_stmts: []const []const u32,
@@ -1346,4 +1366,47 @@ pub fn build(
         .sym_to_writer_stmts = sym_to_writer_stmts,
         .allocator = allocator,
     };
+}
+
+test "findStmtIndexFromInfos maps pos to containing top-level statement" {
+    var stmts = [_]StmtInfo{
+        .{
+            .node_idx = 0,
+            .span = .{ .start = 0, .end = 10 },
+            .has_side_effects = false,
+            .declared_symbols = &.{},
+            .referenced_symbols = &.{},
+        },
+        .{
+            .node_idx = 1,
+            .span = .{ .start = 20, .end = 40 },
+            .has_side_effects = false,
+            .declared_symbols = &.{},
+            .referenced_symbols = &.{},
+        },
+        .{
+            .node_idx = 2,
+            .span = .{ .start = 50, .end = 70 },
+            .has_side_effects = false,
+            .declared_symbols = &.{},
+            .referenced_symbols = &.{},
+        },
+    };
+    const infos = ModuleStmtInfos{
+        .stmts = &stmts,
+        .symbol_to_stmt = &.{},
+        .sym_to_side_effect_stmts = &.{},
+        .sym_to_referencing_stmts = &.{},
+        .sym_to_writer_stmts = &.{},
+        .allocator = std.testing.allocator,
+    };
+
+    try std.testing.expectEqual(@as(?u32, 0), findStmtIndexFromInfos(infos, 0));
+    try std.testing.expectEqual(@as(?u32, 0), findStmtIndexFromInfos(infos, 9));
+    try std.testing.expectEqual(@as(?u32, 1), findStmtIndexFromInfos(infos, 20));
+    try std.testing.expectEqual(@as(?u32, 1), findStmtIndexFromInfos(infos, 39));
+    try std.testing.expectEqual(@as(?u32, 2), findStmtIndexFromInfos(infos, 50));
+    try std.testing.expectEqual(@as(?u32, null), findStmtIndexFromInfos(infos, 10));
+    try std.testing.expectEqual(@as(?u32, null), findStmtIndexFromInfos(infos, 45));
+    try std.testing.expectEqual(@as(?u32, null), findStmtIndexFromInfos(infos, 70));
 }

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -841,7 +841,7 @@ pub const TreeShaker = struct {
                 var has_re_export = false;
                 var has_require = false;
                 for (m.export_bindings) |eb| {
-                    if (eb.kind == .re_export or eb.kind.isReExportAll()) has_re_export = true;
+                    if (eb.kind.isAnyReExport()) has_re_export = true;
                     if (eb.kind != .re_export_star) continue;
                     const rec_idx = eb.import_record_index orelse continue;
                     if (rec_idx >= m.import_records.len) continue;
@@ -2048,7 +2048,7 @@ pub const TreeShaker = struct {
         }
         // re-export 처리
         for (m.export_bindings) |eb| {
-            if (eb.kind != .re_export and !eb.kind.isReExportAll()) continue;
+            if (!eb.kind.isAnyReExport()) continue;
             if (eb.import_record_index) |rec_idx| {
                 if (rec_idx < m.import_records.len) {
                     const src_idx = m.import_records[rec_idx].resolved;
@@ -2101,7 +2101,7 @@ pub const TreeShaker = struct {
         // re-export 체인 전파: export * / named re-export 대상 모듈도 시드.
         const m = self.getModule(mod_idx) orelse return;
         for (m.export_bindings) |eb| {
-            if (eb.kind != .re_export and !eb.kind.isReExportAll()) continue;
+            if (!eb.kind.isAnyReExport()) continue;
             const rec_idx = eb.import_record_index orelse continue;
             if (rec_idx >= m.import_records.len) continue;
             const src_idx = m.import_records[rec_idx].resolved;
@@ -2253,17 +2253,15 @@ pub const TreeShaker = struct {
 
         var changed = false;
         for (self.re_export_modules.items) |i| {
-            var module_scope = profile.begin(.shake_fixpoint_re_exports_module);
-            defer module_scope.end();
-
-            if (i >= self.graph.moduleCount()) continue;
             if (!self.included.isSet(i)) continue;
             const m = self.getModule(@intCast(i)) orelse continue;
+            var module_scope = profile.begin(.shake_fixpoint_re_exports_module);
+            defer module_scope.end();
             var ns_usage: ReExportNsConsumerUsage = .{};
             var ns_usage_built = false;
             defer ns_usage.deinit(self.allocator);
             for (m.export_bindings) |eb| {
-                if (eb.kind != .re_export and !eb.kind.isReExportAll()) continue;
+                if (!eb.kind.isAnyReExport()) continue;
                 const rec_idx = eb.import_record_index orelse continue;
                 if (rec_idx >= m.import_records.len) continue;
                 const src_idx = m.import_records[rec_idx].resolved;
@@ -2362,72 +2360,11 @@ pub const TreeShaker = struct {
             errdefer self.allocator.free(map);
             for (map) |*slot| slot.* = null;
             for (m.import_records, 0..) |rec, rec_i| {
-                map[rec_i] = stmtIndexForPos(infos, rec.span.start);
+                map[rec_i] = stmt_info_mod.findStmtIndexFromInfos(infos, rec.span.start);
             }
             self.import_record_stmt_indices[mod_idx] = map;
         }
         return self.import_record_stmt_indices[mod_idx].?;
-    }
-
-    fn stmtIndexForPos(infos: StmtInfos, pos: u32) ?u32 {
-        var lo: usize = 0;
-        var hi: usize = infos.stmts.len;
-        while (lo < hi) {
-            const mid = lo + (hi - lo) / 2;
-            const span = infos.stmts[mid].span;
-            if (pos < span.start) {
-                hi = mid;
-            } else if (pos >= span.end) {
-                lo = mid + 1;
-            } else {
-                return @intCast(mid);
-            }
-        }
-        return null;
-    }
-
-    test "stmtIndexForPos maps import record spans to containing top-level statement" {
-        const StmtInfo = stmt_info_mod.StmtInfo;
-        var stmts = [_]StmtInfo{
-            .{
-                .node_idx = 0,
-                .span = .{ .start = 0, .end = 10 },
-                .has_side_effects = false,
-                .declared_symbols = &.{},
-                .referenced_symbols = &.{},
-            },
-            .{
-                .node_idx = 1,
-                .span = .{ .start = 20, .end = 40 },
-                .has_side_effects = false,
-                .declared_symbols = &.{},
-                .referenced_symbols = &.{},
-            },
-            .{
-                .node_idx = 2,
-                .span = .{ .start = 50, .end = 70 },
-                .has_side_effects = false,
-                .declared_symbols = &.{},
-                .referenced_symbols = &.{},
-            },
-        };
-        const infos = StmtInfos{
-            .stmts = &stmts,
-            .symbol_to_stmt = &.{},
-            .sym_to_side_effect_stmts = &.{},
-            .sym_to_referencing_stmts = &.{},
-            .sym_to_writer_stmts = &.{},
-            .allocator = std.testing.allocator,
-        };
-
-        try std.testing.expectEqual(@as(?u32, 0), stmtIndexForPos(infos, 0));
-        try std.testing.expectEqual(@as(?u32, 0), stmtIndexForPos(infos, 9));
-        try std.testing.expectEqual(@as(?u32, 1), stmtIndexForPos(infos, 20));
-        try std.testing.expectEqual(@as(?u32, 1), stmtIndexForPos(infos, 39));
-        try std.testing.expectEqual(@as(?u32, 2), stmtIndexForPos(infos, 50));
-        try std.testing.expectEqual(@as(?u32, null), stmtIndexForPos(infos, 10));
-        try std.testing.expectEqual(@as(?u32, null), stmtIndexForPos(infos, 45));
-        try std.testing.expectEqual(@as(?u32, null), stmtIndexForPos(infos, 70));
     }
 
     /// `isImportLiveInModule` 은 reachable_stmts 미초기화 시 보수적으로 true 를 반환하지만,
@@ -2641,7 +2578,7 @@ pub const TreeShaker = struct {
         try self.markExportUsed(module_index, ALL_EXPORTS_SENTINEL);
         for (m.export_bindings) |eb| {
             // re-export 소스 include는 sentinel skip 전에 처리
-            if (eb.kind.isReExportAll() or eb.kind == .re_export) {
+            if (eb.kind.isAnyReExport()) {
                 if (eb.import_record_index) |rec_idx| {
                     if (rec_idx < m.import_records.len) {
                         const source_idx = m.import_records[rec_idx].resolved;

--- a/tests/benchmark/_runner.ts
+++ b/tests/benchmark/_runner.ts
@@ -22,6 +22,16 @@ export function buildBin(label: string): void {
   if (r.status !== 0) throw new Error("zig build failed");
 }
 
+/// `tests/benchmark/node_modules/.bin/<name>` → `<root>/node_modules/.bin/<name>` fallback.
+/// 비교 대상 (rolldown / rspack / esbuild) 가 어느 쪽에 설치돼 있어도 동작하도록.
+export function findNodeModulesBin(name: string): string | null {
+  const local = join(__dirname, "node_modules", ".bin", name);
+  if (existsSync(local)) return local;
+  const root = join(ROOT, "node_modules", ".bin", name);
+  if (existsSync(root)) return root;
+  return null;
+}
+
 export function getCommit(): string {
   const r = spawnSync("git", ["rev-parse", "--short", "HEAD"], {
     cwd: ROOT,

--- a/tests/benchmark/bundle-perf.ts
+++ b/tests/benchmark/bundle-perf.ts
@@ -30,12 +30,7 @@ import {
   getCommit,
   parseProfileJson,
 } from "./_runner";
-import {
-  computeMetricStats,
-  formatMetric,
-  type JsonStats,
-  toJsonStats,
-} from "./stats";
+import { computeMetricStats, formatMetric, type JsonStats, toJsonStats } from "./stats";
 
 const WARMUP = 5;
 const ITERATIONS = 20;
@@ -406,7 +401,9 @@ function parseArgs(argv: string[]): CliArgs {
 
 async function main(cli: CliArgs) {
   buildBin();
-  const available = TOOL_ORDER.filter((tool) => tool === "zts" || findNodeModulesBin(tool)).join(",");
+  const available = TOOL_ORDER.filter((tool) => tool === "zts" || findNodeModulesBin(tool)).join(
+    ",",
+  );
   console.log(`[bundle-perf] zts ${getCommit()} | warmup=${WARMUP} iter=${ITERATIONS}`);
   console.log(`[bundle-perf] available tools: ${available}`);
   console.log();

--- a/tests/benchmark/bundle-perf.ts
+++ b/tests/benchmark/bundle-perf.ts
@@ -18,12 +18,24 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { performance } from "node:perf_hooks";
-import { ROOT, ZTS_BIN, buildBin as buildBinShared, getCommit, parseProfileJson } from "./_runner";
-import { computeMetricStats, formatMetric, type MetricStats } from "./stats";
+import {
+  ROOT,
+  ZTS_BIN,
+  buildBin as buildBinShared,
+  findNodeModulesBin,
+  getCommit,
+  parseProfileJson,
+} from "./_runner";
+import {
+  computeMetricStats,
+  formatMetric,
+  type JsonStats,
+  toJsonStats,
+} from "./stats";
 
 const WARMUP = 5;
 const ITERATIONS = 20;
@@ -74,14 +86,6 @@ interface RunResult {
   wall_ms: number;
   zts_profile_total_ms?: number;
   phases?: Record<string, number>;
-}
-
-function findBin(name: string): string | null {
-  const local = join(__dirname, "node_modules", ".bin", name);
-  if (existsSync(local)) return local;
-  const root = join(ROOT, "node_modules", ".bin", name);
-  if (existsSync(root)) return root;
-  return null;
 }
 
 function runZts(entry: string, outDir: string, externals: string[]): RunResult {
@@ -166,29 +170,8 @@ function runRspack(bin: string, configPath: string, outDir: string): RunResult {
   return { wall_ms };
 }
 
-interface Stats {
-  median: number;
-  mean: number;
-  min: number;
-  max: number;
-  p95: number;
-  trimmed_mean: number; // min/max 제거한 평균
-}
-
-function computeStats(samples: number[]): Stats {
-  const stats = computeMetricStats(samples);
-  return toJsonStats(stats);
-}
-
-function toJsonStats(stats: MetricStats): Stats {
-  return {
-    median: stats.median,
-    mean: stats.mean,
-    min: stats.min,
-    max: stats.max,
-    p95: stats.p95,
-    trimmed_mean: stats.trimmedMean,
-  };
+function computeStats(samples: number[]): JsonStats {
+  return toJsonStats(computeMetricStats(samples));
 }
 
 // ─── Fixture spec ───
@@ -211,8 +194,8 @@ const FIXTURES: FixtureSpec[] = [
 
 interface ToolResult {
   tool: ToolName;
-  wall_ms_stats: Stats | null;
-  zts_profile_total_ms_stats?: Stats;
+  wall_ms_stats: JsonStats | null;
+  zts_profile_total_ms_stats?: JsonStats;
   phase_median_ms?: Record<string, number>;
   skipped?: string;
 }
@@ -244,8 +227,8 @@ function createRunners(
   tmp: string,
   externals: string[],
 ): Partial<Record<ToolName, () => RunResult>> {
-  const rolldownBin = findBin("rolldown");
-  const rspackBin = findBin("rspack");
+  const rolldownBin = findNodeModulesBin("rolldown");
+  const rspackBin = findNodeModulesBin("rspack");
   const rspackOut = join(tmp, "rspack-out");
   const rspackConfig = join(tmp, "rspack.config.cjs");
   writeRspackConfig(rspackConfig, entry, rspackOut, externals);
@@ -360,7 +343,7 @@ function ztsProfileMedian(fixture: FixtureResult): number | null {
 
 function fastestTool(fixture: FixtureResult): string {
   const candidates = fixture.tools
-    .filter((r): r is ToolResult & { wall_ms_stats: Stats } => r.wall_ms_stats !== null)
+    .filter((r): r is ToolResult & { wall_ms_stats: JsonStats } => r.wall_ms_stats !== null)
     .sort((a, b) => a.wall_ms_stats.median - b.wall_ms_stats.median);
   if (candidates.length === 0) return "-";
   const fastest = candidates[0];
@@ -423,7 +406,7 @@ function parseArgs(argv: string[]): CliArgs {
 
 async function main(cli: CliArgs) {
   buildBin();
-  const available = TOOL_ORDER.filter((tool) => tool === "zts" || findBin(tool)).join(",");
+  const available = TOOL_ORDER.filter((tool) => tool === "zts" || findNodeModulesBin(tool)).join(",");
   console.log(`[bundle-perf] zts ${getCommit()} | warmup=${WARMUP} iter=${ITERATIONS}`);
   console.log(`[bundle-perf] available tools: ${available}`);
   console.log();

--- a/tests/benchmark/monorepo-perf.ts
+++ b/tests/benchmark/monorepo-perf.ts
@@ -7,12 +7,24 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { ROOT, ZTS_BIN, buildBin as buildBinShared, getCommit, parsePositiveInt } from "./_runner";
+import {
+  ROOT,
+  ZTS_BIN,
+  buildBin as buildBinShared,
+  findNodeModulesBin,
+  getCommit,
+  parsePositiveInt,
+} from "./_runner";
 import { makeSyntheticMonorepo, parseProfileOutput, type ProfileRun } from "./monorepo-fixture";
-import { computeMetricStats, formatMetric, type MetricStats } from "./stats";
+import {
+  computeMetricStats,
+  formatMetric,
+  type JsonStats,
+  toJsonStats,
+} from "./stats";
 
 const WARMUP = 2;
 const ITERATIONS = 5;
@@ -41,15 +53,6 @@ interface RunReport {
   phase_median_ms: Record<string, number>;
   top_phases: Array<{ phase: string; median_ms: number; percent_of_total: number }>;
   tool_comparison?: ToolResult[];
-}
-
-interface JsonStats {
-  median: number;
-  mean: number;
-  min: number;
-  max: number;
-  p95: number;
-  trimmed_mean: number;
 }
 
 interface ToolResult {
@@ -101,14 +104,6 @@ function parseArgs(argv: string[]): CliArgs {
   return args;
 }
 
-function findBin(name: string): string | null {
-  const local = join(__dirname, "node_modules", ".bin", name);
-  if (existsSync(local)) return local;
-  const root = join(ROOT, "node_modules", ".bin", name);
-  if (existsSync(root)) return root;
-  return null;
-}
-
 function parseNonNegativeInt(name: string, raw: string | undefined): number {
   const n = Number(raw);
   if (!Number.isInteger(n) || n < 0) throw new Error(`${name} must be a non-negative integer`);
@@ -140,7 +135,7 @@ function runTool(tool: "zts" | "esbuild" | "rolldown", entry: string, outDir: st
   rmSync(outDir, { recursive: true, force: true });
   mkdirSync(outDir, { recursive: true });
 
-  const bin = tool === "zts" ? ZTS_BIN : findBin(tool);
+  const bin = tool === "zts" ? ZTS_BIN : findNodeModulesBin(tool);
   if (!bin) throw new Error(`${tool} binary not found`);
 
   const args: string[] = (() => {
@@ -160,17 +155,6 @@ function runTool(tool: "zts" | "esbuild" | "rolldown", entry: string, outDir: st
     throw new Error(`${tool} failed: ${r.stderr.toString().slice(0, 500)}`);
   }
   return { wallMs: performance.now() - start };
-}
-
-function toJsonStats(stats: MetricStats): JsonStats {
-  return {
-    median: stats.median,
-    mean: stats.mean,
-    min: stats.min,
-    max: stats.max,
-    p95: stats.p95,
-    trimmed_mean: stats.trimmedMean,
-  };
 }
 
 function topPhases(

--- a/tests/benchmark/monorepo-perf.ts
+++ b/tests/benchmark/monorepo-perf.ts
@@ -19,12 +19,7 @@ import {
   parsePositiveInt,
 } from "./_runner";
 import { makeSyntheticMonorepo, parseProfileOutput, type ProfileRun } from "./monorepo-fixture";
-import {
-  computeMetricStats,
-  formatMetric,
-  type JsonStats,
-  toJsonStats,
-} from "./stats";
+import { computeMetricStats, formatMetric, type JsonStats, toJsonStats } from "./stats";
 
 const WARMUP = 2;
 const ITERATIONS = 5;

--- a/tests/benchmark/profile.ts
+++ b/tests/benchmark/profile.ts
@@ -6,12 +6,11 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
+import { ROOT, ZTS_BIN, findNodeModulesBin } from "./_runner";
 
-const ROOT = resolve(__dirname, "../..");
-const ZTS_BIN = join(ROOT, "zig-out/bin/zts");
 const ITERATIONS = 10;
 
 type PlanSample = {
@@ -25,14 +24,6 @@ type PlanHit = {
   semantic: string;
   reason: string;
 };
-
-function findBin(name: string): string | null {
-  const local = join(__dirname, "node_modules/.bin", name);
-  if (existsSync(local)) return local;
-  const root = join(ROOT, "node_modules/.bin", name);
-  if (existsSync(root)) return root;
-  return null;
-}
 
 function generateTS(lines: number): string {
   const parts: string[] = [];
@@ -217,8 +208,8 @@ function printPlanHitRates(dir: string): void {
 const scales = [100, 500, 1000, 2000, 5000, 10000];
 const dir = mkdtempSync(join(tmpdir(), "zts-profile-"));
 
-const esbuildBin = findBin("esbuild");
-const swcBin = findBin("swc");
+const esbuildBin = findNodeModulesBin("esbuild");
+const swcBin = findNodeModulesBin("swc");
 
 console.log("ZTS Scaling Profiler — All Tools");
 console.log(`  Iterations: ${ITERATIONS} (median)`);

--- a/tests/benchmark/stats.ts
+++ b/tests/benchmark/stats.ts
@@ -7,6 +7,27 @@ export interface MetricStats {
   trimmedMean: number;
 }
 
+/// JSON 직렬화용 통계 형태 — `MetricStats` 와 동일하지만 `trimmed_mean` snake_case.
+export interface JsonStats {
+  median: number;
+  mean: number;
+  min: number;
+  max: number;
+  p95: number;
+  trimmed_mean: number;
+}
+
+export function toJsonStats(stats: MetricStats): JsonStats {
+  return {
+    median: stats.median,
+    mean: stats.mean,
+    min: stats.min,
+    max: stats.max,
+    p95: stats.p95,
+    trimmed_mean: stats.trimmedMean,
+  };
+}
+
 export function computeMetricStats(samples: number[]): MetricStats {
   if (samples.length === 0) {
     throw new Error("cannot compute benchmark stats from empty samples");


### PR DESCRIPTION
## Summary

PR #2550 이후 origin/main 9 개 커밋(트리쉐이커 perf opts + bundle-perf CI 비교)에 대한 /simplify 검토 라운드 1. 안전한 cleanup 만 묶었고 구조 변경/큰 변경은 후속 PR 로 분리한다.

### 변경
- **`stmt_info.zig`**: `findStmtIndexFromInfos(infos, pos)` 헬퍼 추가 + `tree_shaker.zig` 의 사본 `stmtIndexForPos` 와 그 unit test 를 stmt_info 로 이관.
- **`tree_shaker.zig` / `linker.zig`**: `eb.kind == .re_export or eb.kind.isReExportAll()` 형태의 수동 disjunction 7 군데를 기존 `Kind.isAnyReExport()` 헬퍼로 교체.
- **`tree_shaker.includeReExportSources`**: 모듈별 `profile.begin(.shake_fixpoint_re_exports_module)` 을 `included.isSet`/`getModule` early-skip 뒤로 이동(스킵된 모듈에서 scope push/pop 비용 제거) + `i >= moduleCount` dead bounds-check 제거.
- **benchmark 유틸 통합**:
  - `findBin` 3 사본(bundle-perf / monorepo-perf / profile) → `_runner.findNodeModulesBin`.
  - `toJsonStats` + `JsonStats` 인터페이스 2 사본(bundle-perf / monorepo-perf) → `stats.ts`.

순제거 11 라인 (147 추가 / 158 제거).

### 후속 PR 예정
- **🟠 구조 변경 PR**: `markConstMaterializedAndResync` invalidation 좁히기, worklist helper 추출, `markMinifySensitiveIdentifierRefs` 단축, `preserveCanonicalNamesAfterSemanticResync` hashmap 화, `enqueueNumericPostPassModule` 가드 통합, `anyModuleHasExportedNumberConst` 사전 스캔 제거, `ConstMaterializeProfile` 분리.
- **🔵 큰 변경 PR**: `metadata.zig` Lookup struct 분해, profile 카테고리 단일 소스(TARGET_PHASES), `unpackVariableDeclarator` cross-cutting helper, `enabled_mask` anyEnabled 마이크로 최적화, `bundler.zig` populate 통합.

## Test plan
- [x] `zig build test` 통과 (`findStmtIndexFromInfos` 단위 테스트 포함)
- [x] `bun build` 로 bundle-perf / monorepo-perf / profile 컴파일 성공
- [x] `_runner.test.ts` 2 pass
- [ ] CI: bundle-perf 비교 회귀 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)