### PR TITLE
refactor(bundler): /simplify R2 — narrow const-materialize cache invalidation + dedup postpass guards

### DIFF
--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -411,12 +411,11 @@ pub const TreeShaker = struct {
         }, visitChainExportInit);
     }
 
-    fn foldNumericExportSeeds(self: *TreeShaker, m: *Module, ast: *Ast) !bool {
+    fn foldNumericExportSeeds(_: *TreeShaker, m: *Module, ast: *Ast) !bool {
         const minify_mod = @import("../transformer/minify.zig");
         const sem = if (m.semantic) |*sem| sem else return false;
         const arena_alloc = if (m.parse_arena) |*arena| arena.allocator() else return false;
         var has_exported_number = false;
-        var folded = false;
 
         for (ast.nodes.items) |node| {
             if (node.tag != .variable_declarator) continue;
@@ -443,12 +442,11 @@ pub const TreeShaker = struct {
             try sem.numeric_const_texts.put(arena_alloc, @intCast(sym_id), number_text);
             sem.symbols.items[sym_id].const_kind = .number;
             has_exported_number = true;
-            folded = true;
         }
 
-        if (folded) {
-            if (self.materialize_scratch) |*s| s.invalidate(@intFromEnum(m.index));
-        }
+        // `foldNumericLiteralExpression` 은 init 노드를 in-place 로 numeric_literal 로
+        // 교체할 뿐 ast.nodes 길이/순서 / parent context 는 그대로다. forbidden/reachable
+        // 비트셋의 의미가 보존되므로 materialize_scratch 무효화 불필요.
         return has_exported_number;
     }
 
@@ -540,8 +538,10 @@ pub const TreeShaker = struct {
             m.prebuilt_stmt_info = null;
         };
         self.ast_mutated_after_link = true;
-        self.invalidateImportRecordStmtIndices(@intFromEnum(m.index));
-        if (self.materialize_scratch) |*s| s.invalidate(@intFromEnum(m.index));
+        // const-materialize 는 leaf identifier_reference 를 leaf literal 로 in-place 치환만 한다.
+        // ast.nodes 길이/순서, top-level 통계, import_records.span 모두 보존되므로
+        // import_record_stmt_indices / materialize_scratch (forbidden/reachable) 캐시는
+        // 그대로 유효 — 무효화 시 다음 호출에서 같은 결과를 재계산할 뿐.
     }
 
     fn invalidateImportRecordStmtIndices(self: *TreeShaker, idx: usize) void {
@@ -688,6 +688,22 @@ pub const TreeShaker = struct {
         queued.set(idx);
     }
 
+    /// `enqueueStaticImporters` 의 postpass 변형 — importer 를
+    /// `enqueueNumericPostPassModule` 가드(included/import_bindings)에 넣어 worklist
+    /// pop 시점에 같은 검사를 다시 할 필요 없게 한다.
+    fn enqueueNumericPostPassImporters(
+        self: *TreeShaker,
+        queue: *std.ArrayList(u32),
+        queued: *std.DynamicBitSet,
+        idx: u32,
+        mod_count: usize,
+    ) !void {
+        const m = self.getModule(idx) orelse return;
+        for (m.importers.items) |imp| {
+            try self.enqueueNumericPostPassModule(queue, queued, @intCast(@intFromEnum(imp)), mod_count);
+        }
+    }
+
     fn materializeNumericConstFactsWorklist(self: *TreeShaker, mod_count: usize) !void {
         var queue: std.ArrayList(u32) = .empty;
         defer queue.deinit(self.allocator);
@@ -727,11 +743,10 @@ pub const TreeShaker = struct {
             defer queue_scope.end();
 
             while (queue.pop()) |idx| {
-                if (idx < mod_count) queued.unset(idx);
                 if (idx >= mod_count) continue;
-                if (!self.shouldVisitNumericPostPassModule(idx)) continue;
+                queued.unset(idx);
                 if (!try self.materializeCrossModuleConstFactsForIndex(idx, .numeric, postpass_profile)) continue;
-                try self.enqueueStaticImporters(&queue, &queued, idx, mod_count);
+                try self.enqueueNumericPostPassImporters(&queue, &queued, idx, mod_count);
             }
         }
     }


### PR DESCRIPTION
## Summary

PR #2560 follow-up. /simplify 에이전트의 efficiency/quality 발견 중 안전성이 명확한 두 가지를 좁혀 적용. 알고리즘/구조 자체를 바꾸는 항목(worklist helper 추출, `ConstMaterializeProfile` policy 분리 등)은 별도 PR 로 분리한다.

### 1. const-materialize 경로의 캐시 무효화 제거

`markConstMaterializedAndResync` / `foldNumericExportSeeds` 가 호출하던 `invalidateImportRecordStmtIndices` + `materialize_scratch.invalidate` 제거.

**근거** — 두 경로 모두 leaf `identifier_reference` → leaf literal 의 in-place 치환만 한다:
- `constValueNode` / `foldNumericLiteralExpression` 은 ast.nodes 길이/순서를 바꾸지 않음 (`ast.nodes.items[i] = replacement` 단일 in-place 갱신).
- top-level statement 추가/제거 없음 → `prebuilt_stmt_info.stmts[].span` 보존 → `import_record_stmt_indices` 의 binary-search 결과 그대로 유효.
- parent tag 보존 → `markForbiddenInlineSites` 결과 보존 → `forbidden` 비트셋 의미 동일.
- reachable 노드 인덱스 집합 보존 → `reachable` 비트셋 의미 동일.

기존 무효화는 다음 호출에서 같은 결과를 재계산할 뿐. 결과가 달라질 수 있는 일반 AST mutation 경로(`markAstMutatedAndResync`) 의 무효화는 그대로 유지.

### 2. numeric postpass worklist 가드 단일화

`enqueueNumericPostPassModule` 의 가드(`shouldVisitNumericPostPassModule` + `import_bindings.len > 0` + dedup) 를 enqueue 시점에서만 평가하도록 worklist 흐름 정리.

기존엔 (a) enqueue 시 full guard, (b) pop 시 `shouldVisit*` re-check, (c) `materializeCrossModuleConstFactsForIndex` 진입 시 `import_bindings.len == 0` 체크 — 세 군데에서 같은 검사를 반복했다. importer fan-out (`enqueueStaticImporters`) 이 가드를 우회한 게 근본 원인이라 `enqueueNumericPostPassImporters` 헬퍼를 추가해 fan-out 도 동일 가드를 거치게 했고, pop 시점의 `shouldVisit*` re-check 제거.

## Test plan
- [x] `zig build test`: pipeline profile 포함 전체 통과
- [x] `tests/integration/tests/const-value-inline.test.ts`: 33/33 pass (#2550 회귀 가드)
- [x] `tests/integration/tests/profile-flags.test.ts`: 12/12 pass
- [ ] CI: bundle-perf 회귀 없는지 확인 (캐시 적중률 상승 → 시간 단축 기대)

## 후속 PR 예정 (R3 — 큰 변경)
- `markMinifySensitiveIdentifierRefs` short-circuit 화 (DynamicBitSet 제거)
- `preserveCanonicalNamesAfterSemanticResync` synthetic lookup hashmap 화
- `anyModuleHasExportedNumberConst` 사전 스캔 제거
- `ConstMaterializeProfile` policy 분리, worklist helper 추출
- `metadata.zig` Lookup struct 분해, profile 카테고리 단일 소스

🤖 Generated with [Claude Code](https://claude.com/claude-code)