### PR TITLE
perf(benchmark): ZTS wall 측정과 profile 진단 분리

### DIFF
--- a/tests/benchmark/bundle-perf.ts
+++ b/tests/benchmark/bundle-perf.ts
@@ -12,9 +12,9 @@
  *
  * 측정 방법론:
  *   - 워밍업 5회 (mtime/dentry 캐시 워밍)
- *   - 측정 20회
- *   - 비교값은 CLI wall time median
- *   - ZTS `--profile=all` total 은 내부 phase 진단용으로 별도 기록
+ *   - wall time 측정 20회
+ *   - 비교값은 no-profile CLI wall time median
+ *   - ZTS `--profile=all` 은 별도 진단 샘플로만 실행
  */
 
 import { spawnSync } from "node:child_process";
@@ -34,6 +34,7 @@ import { computeMetricStats, formatMetric, type JsonStats, toJsonStats } from ".
 
 const WARMUP = 5;
 const ITERATIONS = 20;
+const PROFILE_ITERATIONS = 5;
 
 type ToolName = "zts" | "rolldown" | "rspack";
 
@@ -83,7 +84,12 @@ interface RunResult {
   phases?: Record<string, number>;
 }
 
-function runZts(entry: string, outDir: string, externals: string[]): RunResult {
+function runZts(
+  entry: string,
+  outDir: string,
+  externals: string[],
+  withProfile = false,
+): RunResult {
   rmSync(outDir, { recursive: true, force: true });
   mkdirSync(outDir, { recursive: true });
   const args = [
@@ -94,15 +100,16 @@ function runZts(entry: string, outDir: string, externals: string[]): RunResult {
     entry,
     "--outdir",
     outDir,
-    "--profile=all",
-    "--profile-format=json",
   ];
+  if (withProfile) args.push("--profile=all", "--profile-format=json");
+
   const start = performance.now();
   const r = spawnSync(ZTS_BIN, args, { stdio: "pipe", timeout: 30000 });
   const wall_ms = performance.now() - start;
   if (r.status !== 0) {
     throw new Error(`zts failed: ${r.stderr?.toString().slice(0, 400)}`);
   }
+  if (!withProfile) return { wall_ms };
 
   const stdout = r.stdout.toString() + "\n" + r.stderr.toString();
   const profile = parseProfileJson(stdout);
@@ -208,6 +215,7 @@ interface RunReport {
   zts_commit: string;
   warmup: number;
   iterations: number;
+  profile_iterations: number;
   fixtures: FixtureResult[];
 }
 
@@ -258,12 +266,15 @@ async function measureFixture(spec: FixtureSpec): Promise<FixtureResult> {
         if (!run) continue;
         const r = run();
         (wallSamples[tool] ??= []).push(r.wall_ms);
-        if (tool === "zts") {
-          if (r.zts_profile_total_ms !== undefined) ztsProfileTotals.push(r.zts_profile_total_ms);
-          for (const [k, v] of Object.entries(r.phases ?? {})) {
-            (phaseSeries[k] ??= []).push(v);
-          }
-        }
+      }
+    }
+
+    runZts(entry, join(tmp, "zts-profile-warmup"), spec.externals, true);
+    for (let i = 0; i < PROFILE_ITERATIONS; i++) {
+      const r = runZts(entry, join(tmp, `zts-profile-${i}`), spec.externals, true);
+      if (r.zts_profile_total_ms !== undefined) ztsProfileTotals.push(r.zts_profile_total_ms);
+      for (const [k, v] of Object.entries(r.phases ?? {})) {
+        (phaseSeries[k] ??= []).push(v);
       }
     }
 
@@ -286,8 +297,10 @@ async function measureFixture(spec: FixtureSpec): Promise<FixtureResult> {
         wall_ms_stats: computeStats(samples),
       };
       if (tool === "zts") {
-        result.zts_profile_total_ms_stats = computeStats(ztsProfileTotals);
-        result.phase_median_ms = phase_median_ms;
+        if (ztsProfileTotals.length > 0) {
+          result.zts_profile_total_ms_stats = computeStats(ztsProfileTotals);
+          result.phase_median_ms = phase_median_ms;
+        }
       }
       return result;
     });
@@ -354,8 +367,11 @@ function printReport(runReport: RunReport): void {
   console.log("| Baseline | none; same-run CI wall-time comparison |");
   console.log("| Tools | ZTS / Rolldown / Rspack |");
   console.log("| Primary metric | CLI wall time median |");
-  console.log("| ZTS profile total | included only as internal phase diagnostic |");
+  console.log(
+    "| ZTS profile total | separate --profile=all diagnostic run; not part of wall median |",
+  );
   console.log(`| Warmup / iterations | ${runReport.warmup} / ${runReport.iterations} |`);
+  console.log(`| ZTS profile iterations | ${runReport.profile_iterations} |`);
   console.log();
   console.log("### bundle-perf — CI wall-time tool comparison");
   console.log(
@@ -422,11 +438,12 @@ async function main(cli: CliArgs) {
   }
 
   const runReport: RunReport = {
-    version: 2,
+    version: 3,
     generated_at: new Date().toISOString(),
     zts_commit: getCommit(),
     warmup: WARMUP,
     iterations: ITERATIONS,
+    profile_iterations: PROFILE_ITERATIONS,
     fixtures,
   };
 


### PR DESCRIPTION
## 요약
- `bundle-perf`의 ZTS primary wall time 측정에서 `--profile=all`을 제거했습니다.
- ZTS profile total/phase median은 별도 `--profile=all` 진단 샘플 5회로 분리했습니다.
- JSON 리포트에 `profile_iterations`를 추가하고 버전을 `3`으로 올렸습니다.

## 배경
이번 main 기준 측정에서 제품 코드 micro-opt 후보를 3개 확인했습니다.

- tree-shake direct export enqueue에서 import map 체크 생략: namespace-2000 기준 direct/enqueue가 노이즈 안에서 오히려 증가해 폐기
- resolver의 단순 `./foo` stack-buffer fast path: large bundle-perf 기준 resolve/wall이 증가해 폐기
- one-shot bundle에서 mtime 수집 생략: read 경로가 더 느려져 폐기

남긴 변경은 CI 벤치의 측정 정확도 개선입니다. 기존 `bundle-perf`는 ZTS wall 샘플 자체가 `--profile=all` 실행이어서 primary 비교값과 진단용 profile 값이 같은 실행에 섞였습니다. 이제 wall 비교는 no-profile CLI 실행만 사용하고, profile은 별도 진단 샘플로 기록합니다.

## 측정
main 기준 before:
- `const-prepass`: namespace-2000 `shake=2.81ms`, `bfs.seed=1.03ms`, `direct local=0.37ms`, `enqueue symbol=0.18ms`
- `bundle-perf`: small `3.19ms`, medium `6.24ms`, large `9.38ms`
- detailed graph profile: large graph 하위에서 worker read/parse 누적과 entry resolve가 주 병목

변경 후 `bundle-perf`:
- small: ZTS `3.14ms`, Rolldown `52.9ms`, Rspack `63.3ms`
- medium: ZTS `6.20ms`, Rolldown `56.7ms`, Rspack `67.5ms`
- large: ZTS `9.39ms`, Rolldown `59.8ms`, Rspack `71.5ms`
- profile phase median은 별도 샘플 기준으로 large `resolve=2.29ms`, `graph=4.85ms`, `shake=0.29ms`

## 검증
- `bun run tests/benchmark/bundle-perf.ts --no-fail --output /tmp/zts-bundle-perf-split-profile.json`
- `bun run fmt:check -- tests/benchmark/bundle-perf.ts`
- `git diff --check`
- `zig build test --summary all`
- pre-push hook 통과 (`zig fmt --check`, `zig build test`, `oxlint`, `oxfmt --check`)

## 참고
- oxlint는 기존 unused import 경고 5개가 계속 출력되지만 에러는 없습니다.
