### PR TITLE
perf(benchmark): resolve 하위 프로파일 노출

### DIFF
--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -294,31 +294,41 @@ pub const ResolveCache = struct {
         var scope = profile.begin(.resolve);
         defer scope.end();
 
-        if (self.isExternal(specifier)) return null;
+        {
+            var external_scope = profile.begin(.resolve_external);
+            defer external_scope.end();
+            if (self.isExternal(specifier)) return null;
+        }
 
         // 스택 버퍼로 캐시 키 생성 (alloc/free 제거)
         var key_buf: [8192]u8 = undefined;
         const kind_str = @tagName(kind);
         const key_len = source_dir.len + 1 + specifier.len + 1 + kind_str.len;
-        const cache_key = if (key_len <= key_buf.len) blk: {
-            var pos: usize = 0;
-            @memcpy(key_buf[pos .. pos + source_dir.len], source_dir);
-            pos += source_dir.len;
-            key_buf[pos] = 0;
-            pos += 1;
-            @memcpy(key_buf[pos .. pos + specifier.len], specifier);
-            pos += specifier.len;
-            key_buf[pos] = 0;
-            pos += 1;
-            @memcpy(key_buf[pos .. pos + kind_str.len], kind_str);
-            pos += kind_str.len;
-            break :blk key_buf[0..pos];
-        } else self.makeCacheKey(source_dir, specifier, kind) catch
-            return error.OutOfMemory;
+        const cache_key = blk: {
+            var key_scope = profile.begin(.resolve_cache_key);
+            defer key_scope.end();
+            break :blk if (key_len <= key_buf.len) stack_key: {
+                var pos: usize = 0;
+                @memcpy(key_buf[pos .. pos + source_dir.len], source_dir);
+                pos += source_dir.len;
+                key_buf[pos] = 0;
+                pos += 1;
+                @memcpy(key_buf[pos .. pos + specifier.len], specifier);
+                pos += specifier.len;
+                key_buf[pos] = 0;
+                pos += 1;
+                @memcpy(key_buf[pos .. pos + kind_str.len], kind_str);
+                pos += kind_str.len;
+                break :stack_key key_buf[0..pos];
+            } else self.makeCacheKey(source_dir, specifier, kind) catch
+                return error.OutOfMemory;
+        };
         defer if (key_len > key_buf.len) self.allocator.free(cache_key);
 
         // 캐시 조회
         {
+            var lookup_scope = profile.begin(.resolve_cache_lookup);
+            defer lookup_scope.end();
             if (thread_safe) self.cache_mutex.lock();
             defer if (thread_safe) self.cache_mutex.unlock();
             if (self.cache.get(cache_key)) |cached| {
@@ -348,27 +358,33 @@ pub const ResolveCache = struct {
         var effective_spec = specifier;
         var remap_buf: [MAX_REMAP_DEPTH][]const u8 = undefined;
         var remap_depth: u8 = 0;
-        if (self.platform.isBrowserLike()) {
-            while (remap_depth < MAX_REMAP_DEPTH) : (remap_depth += 1) {
-                // 동일 specifier 로 self-remap 이면 즉시 종료 (recursive-module fixture).
-                if (remap_depth > 0 and std.mem.eql(u8, effective_spec, remap_buf[remap_depth - 1])) break;
-                switch (self.getBareModuleOverride(source_dir, effective_spec)) {
-                    .disabled => {
-                        const disabled_path = std.fmt.allocPrint(self.allocator, "(disabled):{s}", .{effective_spec}) catch return error.OutOfMemory;
-                        if (thread_safe) self.cache_mutex.lock();
-                        defer if (thread_safe) self.cache_mutex.unlock();
-                        self.putCache(cache_key, .{ .resolved = .{ .disabled = .{
-                            .path = self.allocator.dupe(u8, disabled_path) catch return error.OutOfMemory,
-                            .module_type = .js,
-                        } } }) catch {};
-                        return disabledResult(disabled_path, .js);
-                    },
-                    .remap => |rep| {
-                        remap_buf[remap_depth] = effective_spec;
-                        effective_spec = rep;
-                        continue;
-                    },
-                    .none => break,
+        {
+            var browser_scope = profile.begin(.resolve_browser_override);
+            defer browser_scope.end();
+            if (self.platform.isBrowserLike()) {
+                while (remap_depth < MAX_REMAP_DEPTH) : (remap_depth += 1) {
+                    // 동일 specifier 로 self-remap 이면 즉시 종료 (recursive-module fixture).
+                    if (remap_depth > 0 and std.mem.eql(u8, effective_spec, remap_buf[remap_depth - 1])) break;
+                    switch (self.getBareModuleOverride(source_dir, effective_spec)) {
+                        .disabled => {
+                            const disabled_path = std.fmt.allocPrint(self.allocator, "(disabled):{s}", .{effective_spec}) catch return error.OutOfMemory;
+                            var store_scope = profile.begin(.resolve_cache_store);
+                            defer store_scope.end();
+                            if (thread_safe) self.cache_mutex.lock();
+                            defer if (thread_safe) self.cache_mutex.unlock();
+                            self.putCache(cache_key, .{ .resolved = .{ .disabled = .{
+                                .path = self.allocator.dupe(u8, disabled_path) catch return error.OutOfMemory,
+                                .module_type = .js,
+                            } } }) catch {};
+                            return disabledResult(disabled_path, .js);
+                        },
+                        .remap => |rep| {
+                            remap_buf[remap_depth] = effective_spec;
+                            effective_spec = rep;
+                            continue;
+                        },
+                        .none => break,
+                    }
                 }
             }
         }
@@ -383,77 +399,95 @@ pub const ResolveCache = struct {
         }
         const resolve_ptr = if (thread_safe) &local_resolver else &self.resolver;
 
-        const result = resolve_ptr.resolve(source_dir, effective_spec) catch |err| switch (err) {
-            error.ModuleNotFound => {
-                if (thread_safe) self.cache_mutex.lock();
-                defer if (thread_safe) self.cache_mutex.unlock();
-                self.putCache(cache_key, .not_found) catch {};
-                return error.ModuleNotFound;
-            },
-            else => return err,
+        const result = blk: {
+            var resolver_scope = profile.begin(.resolve_resolver);
+            defer resolver_scope.end();
+            break :blk resolve_ptr.resolve(source_dir, effective_spec) catch |err| switch (err) {
+                error.ModuleNotFound => {
+                    var store_scope = profile.begin(.resolve_cache_store);
+                    defer store_scope.end();
+                    if (thread_safe) self.cache_mutex.lock();
+                    defer if (thread_safe) self.cache_mutex.unlock();
+                    self.putCache(cache_key, .not_found) catch {};
+                    return error.ModuleNotFound;
+                },
+                else => return err,
+            };
         };
 
         // browser override 체크 + 캐시 저장 (disabled / remap / normal).
-        {
-            if (thread_safe) self.cache_mutex.lock();
-            defer if (thread_safe) self.cache_mutex.unlock();
+        if (thread_safe) self.cache_mutex.lock();
+        defer if (thread_safe) self.cache_mutex.unlock();
 
-            // resolver 가 `--fallback:NAME=false` (또는 다른 disabled 경로) 로 빈 모듈을
-            // 반환한 경우 — disabled variant 로 캐싱 + 반환. 이 분기 없이는 `.file` 로
-            // cache 되어 graph 단계에서 일반 파싱 시도 → "No loader configured" 에러.
-            if (result.disabled) {
-                const cache_path = self.allocator.dupe(u8, result.path) catch return error.OutOfMemory;
-                self.putCache(cache_key, .{ .resolved = .{ .disabled = .{
-                    .path = cache_path,
-                    .module_type = result.module_type,
-                } } }) catch {};
-                return disabledResult(result.path, result.module_type);
-            }
+        // resolver 가 `--fallback:NAME=false` (또는 다른 disabled 경로) 로 빈 모듈을
+        // 반환한 경우 — disabled variant 로 캐싱 + 반환. 이 분기 없이는 `.file` 로
+        // cache 되어 graph 단계에서 일반 파싱 시도 → "No loader configured" 에러.
+        if (result.disabled) {
+            var store_scope = profile.begin(.resolve_cache_store);
+            defer store_scope.end();
+            const cache_path = self.allocator.dupe(u8, result.path) catch return error.OutOfMemory;
+            self.putCache(cache_key, .{ .resolved = .{ .disabled = .{
+                .path = cache_path,
+                .module_type = result.module_type,
+            } } }) catch {};
+            return disabledResult(result.path, result.module_type);
+        }
 
-            if (self.platform.isBrowserLike()) {
-                const override = self.getBrowserOverride(result.path);
-                switch (override) {
-                    .disabled => {
-                        const cache_path = self.allocator.dupe(u8, result.path) catch return error.OutOfMemory;
-                        self.putCache(cache_key, .{ .resolved = .{ .disabled = .{
-                            .path = cache_path,
-                            .module_type = result.module_type,
-                        } } }) catch {};
-                        return disabledResult(result.path, result.module_type);
-                    },
-                    .remap => |rep| {
-                        // rep 는 package-root 상대. Resolver.resolve(pkg_root, "./rep") 로
-                        // 확장자 / directory index 등 정상 resolve path 재사용. 성공 시 대체 결과 반환.
-                        if (findPackageDirPath(result.path)) |pkg_root| {
-                            const spec_buf = std.fmt.allocPrint(self.allocator, "./{s}", .{rep}) catch {
-                                // fallthrough
-                                const cache_path = self.allocator.dupe(u8, result.path) catch return error.OutOfMemory;
-                                self.putCache(cache_key, .{ .resolved = .{ .file = .{
-                                    .path = cache_path,
-                                    .module_type = result.module_type,
-                                } } }) catch {};
-                                return fileResult(result.path, result.module_type, result.is_module_field);
-                            };
-                            defer self.allocator.free(spec_buf);
-                            if (thread_safe) self.cache_mutex.unlock();
-                            const maybe_replaced = self.resolver.resolve(pkg_root, spec_buf);
-                            if (thread_safe) self.cache_mutex.lock();
-                            if (maybe_replaced) |replaced| {
-                                const cache_path = self.allocator.dupe(u8, replaced.path) catch return error.OutOfMemory;
-                                self.putCache(cache_key, .{ .resolved = .{ .file = .{
-                                    .path = cache_path,
-                                    .module_type = replaced.module_type,
-                                } } }) catch {};
-                                return fileResult(replaced.path, replaced.module_type, replaced.is_module_field);
-                            } else |_| {
-                                // fallthrough — replacement 해결 실패 시 원본 사용.
-                            }
+        if (self.platform.isBrowserLike()) {
+            var browser_scope = profile.begin(.resolve_browser_override);
+            defer browser_scope.end();
+            const override = self.getBrowserOverride(result.path);
+            switch (override) {
+                .disabled => {
+                    var store_scope = profile.begin(.resolve_cache_store);
+                    defer store_scope.end();
+                    const cache_path = self.allocator.dupe(u8, result.path) catch return error.OutOfMemory;
+                    self.putCache(cache_key, .{ .resolved = .{ .disabled = .{
+                        .path = cache_path,
+                        .module_type = result.module_type,
+                    } } }) catch {};
+                    return disabledResult(result.path, result.module_type);
+                },
+                .remap => |rep| {
+                    // rep 는 package-root 상대. Resolver.resolve(pkg_root, "./rep") 로
+                    // 확장자 / directory index 등 정상 resolve path 재사용. 성공 시 대체 결과 반환.
+                    if (findPackageDirPath(result.path)) |pkg_root| {
+                        const spec_buf = std.fmt.allocPrint(self.allocator, "./{s}", .{rep}) catch {
+                            // fallthrough
+                            var store_scope = profile.begin(.resolve_cache_store);
+                            defer store_scope.end();
+                            const cache_path = self.allocator.dupe(u8, result.path) catch return error.OutOfMemory;
+                            self.putCache(cache_key, .{ .resolved = .{ .file = .{
+                                .path = cache_path,
+                                .module_type = result.module_type,
+                            } } }) catch {};
+                            return fileResult(result.path, result.module_type, result.is_module_field);
+                        };
+                        defer self.allocator.free(spec_buf);
+                        if (thread_safe) self.cache_mutex.unlock();
+                        const maybe_replaced = self.resolver.resolve(pkg_root, spec_buf);
+                        if (thread_safe) self.cache_mutex.lock();
+                        if (maybe_replaced) |replaced| {
+                            var store_scope = profile.begin(.resolve_cache_store);
+                            defer store_scope.end();
+                            const cache_path = self.allocator.dupe(u8, replaced.path) catch return error.OutOfMemory;
+                            self.putCache(cache_key, .{ .resolved = .{ .file = .{
+                                .path = cache_path,
+                                .module_type = replaced.module_type,
+                            } } }) catch {};
+                            return fileResult(replaced.path, replaced.module_type, replaced.is_module_field);
+                        } else |_| {
+                            // fallthrough — replacement 해결 실패 시 원본 사용.
                         }
-                    },
-                    .none => {},
-                }
+                    }
+                },
+                .none => {},
             }
+        }
 
+        {
+            var store_scope = profile.begin(.resolve_cache_store);
+            defer store_scope.end();
             const cache_path = self.allocator.dupe(u8, result.path) catch return error.OutOfMemory;
             self.putCache(cache_key, .{ .resolved = .{ .file = .{
                 .path = cache_path,

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -23,6 +23,7 @@ const ModuleType = types.ModuleType;
 const pkg_json = @import("package_json.zig");
 const fs = @import("fs.zig");
 const PackageJson = pkg_json.PackageJson;
+const profile = @import("../profile.zig");
 
 pub const ResolveResult = struct {
     /// 해석된 절대 파일 경로
@@ -358,8 +359,12 @@ pub const Resolver = struct {
         }
 
         // 경로 조합
-        const joined = std.fs.path.resolve(self.allocator, &.{ source_dir, effective_specifier }) catch
-            return error.OutOfMemory;
+        const joined = blk: {
+            var path_scope = profile.begin(.resolve_path);
+            defer path_scope.end();
+            break :blk std.fs.path.resolve(self.allocator, &.{ source_dir, effective_specifier }) catch
+                return error.OutOfMemory;
+        };
         defer self.allocator.free(joined);
 
         // 1. 정확한 경로가 파일로 존재하는지
@@ -388,6 +393,9 @@ pub const Resolver = struct {
     /// 확장자를 하나씩 붙여서 존재하는 파일을 찾는다.
     /// custom_extensions가 설정되어 있으면 그것을 사용, 아니면 default_extensions.
     fn tryExtensions(self: *Resolver, base: []const u8) ResolveError!?ResolveResult {
+        var scope = profile.begin(.resolve_extensions);
+        defer scope.end();
+
         const extensions = if (self.custom_extensions.len > 0) self.custom_extensions else default_extensions;
         for (extensions) |ext| {
             const path = std.mem.concat(self.allocator, u8, &.{ base, ext }) catch
@@ -404,6 +412,9 @@ pub const Resolver = struct {
     /// TS 확장자 매핑: .js → .ts/.tsx 등.
     /// import './foo.js' 했는데 foo.js는 없고 foo.ts가 있으면 foo.ts로 해석.
     fn tryTsExtensionMapping(self: *Resolver, path: []const u8) ResolveError!?ResolveResult {
+        var scope = profile.begin(.resolve_ts_extension_map);
+        defer scope.end();
+
         const ext = std.fs.path.extension(path);
         for (ts_extension_map) |mapping| {
             if (std.mem.eql(u8, ext, mapping.from)) {
@@ -426,6 +437,9 @@ pub const Resolver = struct {
 
     /// 디렉토리인 경우 index 파일을 탐색한다.
     fn tryDirectoryIndex(self: *Resolver, path: []const u8) ResolveError!?ResolveResult {
+        var scope = profile.begin(.resolve_directory_index);
+        defer scope.end();
+
         // path가 디렉토리인지 확인
         if (!self.dirExists(path)) return null;
 
@@ -647,11 +661,15 @@ pub const Resolver = struct {
         // preserve_symlinks=true이면 symlink를 따라가지 않고 경로 그대로 사용.
         // 기본(false)이면 bun(.bun/)과 pnpm(.pnpm/)의 symlink를 realpath로 해석하여
         // 중첩 node_modules 탐색이 올바른 계층에서 동작하도록 한다.
-        const resolved = if (self.preserve_symlinks)
-            self.allocator.dupe(u8, path) catch return error.OutOfMemory
-        else
-            fs.realpath(self.allocator, path) catch
-                self.allocator.dupe(u8, path) catch return error.OutOfMemory;
+        const resolved = blk: {
+            var realpath_scope = profile.begin(.resolve_realpath);
+            defer realpath_scope.end();
+            break :blk if (self.preserve_symlinks)
+                self.allocator.dupe(u8, path) catch return error.OutOfMemory
+            else
+                fs.realpath(self.allocator, path) catch
+                    self.allocator.dupe(u8, path) catch return error.OutOfMemory;
+        };
         const ext = std.fs.path.extension(resolved);
         return .{
             .path = resolved,
@@ -660,6 +678,9 @@ pub const Resolver = struct {
     }
 
     fn fileExists(self: *const Resolver, path: []const u8) bool {
+        var scope = profile.begin(.resolve_file_exists);
+        defer scope.end();
+
         if (self.dir_cache) |cache| {
             const dir_path = std.fs.path.dirname(path) orelse return false;
             const file_name = std.fs.path.basename(path);

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -56,6 +56,18 @@ pub const Category = enum {
     // ── Analysis ──
     semantic,
     resolve,
+    resolve_external,
+    resolve_cache_key,
+    resolve_cache_lookup,
+    resolve_browser_override,
+    resolve_resolver,
+    resolve_cache_store,
+    resolve_path,
+    resolve_file_exists,
+    resolve_extensions,
+    resolve_ts_extension_map,
+    resolve_directory_index,
+    resolve_realpath,
     graph,
     graph_build,
     graph_worker,
@@ -741,6 +753,9 @@ test "Category.fromString: dot notation 정규화" {
     try testing.expect(Category.fromString("transform.ts_strip") == .transform_ts_strip);
     try testing.expect(Category.fromString("Transform.JSX") == .transform_jsx);
     try testing.expect(Category.fromString("hmr.detect") == .hmr_detect);
+    try testing.expect(Category.fromString("resolve.cache.lookup") == .resolve_cache_lookup);
+    try testing.expect(Category.fromString("resolve.ts.extension.map") == .resolve_ts_extension_map);
+    try testing.expect(Category.fromString("resolve.directory.index") == .resolve_directory_index);
     try testing.expect(Category.fromString("shake.analyze") == .shake_analyze);
     try testing.expect(Category.fromString("shake.post.link.finalize") == .shake_post_link_finalize);
     try testing.expect(Category.fromString("shake.fixpoint.bfs") == .shake_fixpoint_bfs);
@@ -761,6 +776,9 @@ test "Category.displayName: underscore → dot 역변환" {
     try testing.expectEqualStrings("parse.ast.build", Category.displayName(.parse_ast_build));
     try testing.expectEqualStrings("transform.ts.strip", Category.displayName(.transform_ts_strip));
     try testing.expectEqualStrings("hmr.detect", Category.displayName(.hmr_detect));
+    try testing.expectEqualStrings("resolve.cache.lookup", Category.displayName(.resolve_cache_lookup));
+    try testing.expectEqualStrings("resolve.ts.extension.map", Category.displayName(.resolve_ts_extension_map));
+    try testing.expectEqualStrings("resolve.directory.index", Category.displayName(.resolve_directory_index));
     try testing.expectEqualStrings("shake.analyze", Category.displayName(.shake_analyze));
     try testing.expectEqualStrings("shake.post.link.finalize", Category.displayName(.shake_post_link_finalize));
     try testing.expectEqualStrings("shake.fixpoint.bfs", Category.displayName(.shake_fixpoint_bfs));

--- a/tests/benchmark/bundle-perf.ts
+++ b/tests/benchmark/bundle-perf.ts
@@ -14,7 +14,7 @@
  *   - 워밍업 5회 (mtime/dentry 캐시 워밍)
  *   - wall time 측정 20회
  *   - 비교값은 no-profile CLI wall time median
- *   - ZTS `--profile=all` 은 별도 진단 샘플로만 실행
+ *   - ZTS `--profile=all --profile-level=detailed` 는 별도 진단 샘플로만 실행
  */
 
 import { spawnSync } from "node:child_process";
@@ -82,6 +82,7 @@ interface RunResult {
   wall_ms: number;
   zts_profile_total_ms?: number;
   phases?: Record<string, number>;
+  phase_selfs?: Record<string, number>;
 }
 
 function runZts(
@@ -101,7 +102,9 @@ function runZts(
     "--outdir",
     outDir,
   ];
-  if (withProfile) args.push("--profile=all", "--profile-format=json");
+  if (withProfile) {
+    args.push("--profile=all", "--profile-level=detailed", "--profile-format=json");
+  }
 
   const start = performance.now();
   const r = spawnSync(ZTS_BIN, args, { stdio: "pipe", timeout: 30000 });
@@ -114,10 +117,12 @@ function runZts(
   const stdout = r.stdout.toString() + "\n" + r.stderr.toString();
   const profile = parseProfileJson(stdout);
   const phases: Record<string, number> = {};
+  const phase_selfs: Record<string, number> = {};
   for (const [phase, data] of Object.entries(profile.phases)) {
     if (data) phases[phase] = data.total_ms;
+    if (data?.self_ms !== undefined) phase_selfs[phase] = data.self_ms;
   }
-  return { wall_ms, zts_profile_total_ms: profile.total_ms, phases };
+  return { wall_ms, zts_profile_total_ms: profile.total_ms, phases, phase_selfs };
 }
 
 function runRolldown(bin: string, entry: string, outDir: string, externals: string[]): RunResult {
@@ -199,6 +204,7 @@ interface ToolResult {
   wall_ms_stats: JsonStats | null;
   zts_profile_total_ms_stats?: JsonStats;
   phase_median_ms?: Record<string, number>;
+  phase_self_median_ms?: Record<string, number>;
   skipped?: string;
 }
 
@@ -259,6 +265,7 @@ async function measureFixture(spec: FixtureSpec): Promise<FixtureResult> {
     const wallSamples: Partial<Record<ToolName, number[]>> = {};
     const ztsProfileTotals: number[] = [];
     const phaseSeries: Record<string, number[]> = {};
+    const phaseSelfSeries: Record<string, number[]> = {};
 
     for (let i = 0; i < ITERATIONS; i++) {
       for (const tool of TOOL_ORDER) {
@@ -276,11 +283,18 @@ async function measureFixture(spec: FixtureSpec): Promise<FixtureResult> {
       for (const [k, v] of Object.entries(r.phases ?? {})) {
         (phaseSeries[k] ??= []).push(v);
       }
+      for (const [k, v] of Object.entries(r.phase_selfs ?? {})) {
+        (phaseSelfSeries[k] ??= []).push(v);
+      }
     }
 
     const phase_median_ms: Record<string, number> = {};
     for (const [k, arr] of Object.entries(phaseSeries)) {
       phase_median_ms[k] = computeStats(arr).median;
+    }
+    const phase_self_median_ms: Record<string, number> = {};
+    for (const [k, arr] of Object.entries(phaseSelfSeries)) {
+      phase_self_median_ms[k] = computeStats(arr).median;
     }
 
     const tools: ToolResult[] = TOOL_ORDER.map((tool) => {
@@ -300,6 +314,7 @@ async function measureFixture(spec: FixtureSpec): Promise<FixtureResult> {
         if (ztsProfileTotals.length > 0) {
           result.zts_profile_total_ms_stats = computeStats(ztsProfileTotals);
           result.phase_median_ms = phase_median_ms;
+          result.phase_self_median_ms = phase_self_median_ms;
         }
       }
       return result;
@@ -368,7 +383,10 @@ function printReport(runReport: RunReport): void {
   console.log("| Tools | ZTS / Rolldown / Rspack |");
   console.log("| Primary metric | CLI wall time median |");
   console.log(
-    "| ZTS profile total | separate --profile=all diagnostic run; not part of wall median |",
+    "| ZTS profile total | separate --profile=all --profile-level=detailed diagnostic run; not part of wall median |",
+  );
+  console.log(
+    "| ZTS phase medians | inclusive total_ms; nested child rows overlap, self_ms medians are stored in JSON |",
   );
   console.log(`| Warmup / iterations | ${runReport.warmup} / ${runReport.iterations} |`);
   console.log(`| ZTS profile iterations | ${runReport.profile_iterations} |`);
@@ -389,13 +407,27 @@ function printReport(runReport: RunReport): void {
     );
   }
   console.log();
-  console.log("### bundle-perf — ZTS phase medians");
+  console.log("### bundle-perf — ZTS phase medians (inclusive)");
   console.log("| Fixture | Resolve | Graph | Link | Shake | Transform | Codegen | Emit |");
   console.log("|---------|---------|-------|------|-------|-----------|---------|------|");
   for (const fixture of runReport.fixtures) {
     const phases = toolResult(fixture, "zts")?.phase_median_ms ?? {};
     console.log(
       `| ${fixture.name} | ${fmtMarkdownMs(phases.resolve)} | ${fmtMarkdownMs(phases.graph)} | ${fmtMarkdownMs(phases.link)} | ${fmtMarkdownMs(phases.shake)} | ${fmtMarkdownMs(phases.transform)} | ${fmtMarkdownMs(phases.codegen)} | ${fmtMarkdownMs(phases.emit)} |`,
+    );
+  }
+  console.log();
+  console.log("### bundle-perf — ZTS resolve subphase medians (inclusive)");
+  console.log(
+    "| Fixture | External | Cache key | Cache lookup | Browser override | Resolver | Path | File exists | Extensions | TS map | Directory index | Realpath | Cache store |",
+  );
+  console.log(
+    "|---------|----------|-----------|--------------|------------------|----------|------|-------------|------------|--------|-----------------|----------|-------------|",
+  );
+  for (const fixture of runReport.fixtures) {
+    const phases = toolResult(fixture, "zts")?.phase_median_ms ?? {};
+    console.log(
+      `| ${fixture.name} | ${fmtMarkdownMs(phases["resolve.external"])} | ${fmtMarkdownMs(phases["resolve.cache.key"])} | ${fmtMarkdownMs(phases["resolve.cache.lookup"])} | ${fmtMarkdownMs(phases["resolve.browser.override"])} | ${fmtMarkdownMs(phases["resolve.resolver"])} | ${fmtMarkdownMs(phases["resolve.path"])} | ${fmtMarkdownMs(phases["resolve.file.exists"])} | ${fmtMarkdownMs(phases["resolve.extensions"])} | ${fmtMarkdownMs(phases["resolve.ts.extension.map"])} | ${fmtMarkdownMs(phases["resolve.directory.index"])} | ${fmtMarkdownMs(phases["resolve.realpath"])} | ${fmtMarkdownMs(phases["resolve.cache.store"])} |`,
     );
   }
 }


### PR DESCRIPTION
## 요약
- `resolve` 하위 profile category를 external/cache/browser/resolver/path/file-exists/extensions/realpath/store로 분해했습니다.
- `bundle-perf`의 ZTS profile 샘플을 `--profile-level=detailed`로 실행해 CI 표에서 resolve subphase median을 바로 확인하게 했습니다.
- phase/subphase 표가 inclusive total_ms임을 명시하고, JSON에는 `phase_self_median_ms`도 저장해 합계 혼동을 줄였습니다.

## 측정
- main 기준 large: ZTS wall 9.47ms, resolve 2.59ms/graph 5.00ms 수준이었습니다.
- 변경 후 large: ZTS wall 9.39ms, resolve 2.38ms, graph 4.88ms로 wall은 노이즈권입니다.
- resolve subphase large: resolver 2.28ms, extensions 2.12ms, realpath 2.09ms로 다음 병목은 realpath 호출로 좁혀졌습니다.

## 철회한 최적화 후보
- symlink-aware file realpath skip: large wall 13.5ms까지 악화되어 제외했습니다.
- directory realpath cache 기반 skip: profile상 realpath는 줄었지만 large wall 10.1ms로 악화되어 제외했습니다.

## 검증
- `zig build test --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- `bun run tests/benchmark/bundle-perf.ts --no-fail --output /tmp/zts-graph-resolve-profile-final.json`
