### PR TITLE
docs(core): refresh stale JSDoc on CompilerOptions / cssProp / phaseDurations

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -419,8 +419,8 @@ export interface ManualChunksMeta {
 /**
  * `compiler` 네임스페이스 — 라이브러리별 1st-party transform 설정 (`@next/swc` 호환 surface).
  *
- * 현재는 타입 stub. Zig transformer 가 아직 인식하지 않아 런타임 효과 없음.
- * 후속 epic 에서 styled-components / emotion 1st-party transform 도입 시 활성화.
+ * `babel-plugin-styled-components` / `@emotion/babel-plugin` 의 1st-party 대응.
+ * plugin 등록 없이 옵션만 켜면 동일한 변환 결과를 얻는다.
  */
 export interface CompilerOptions {
   /**
@@ -464,8 +464,10 @@ export interface StyledComponentsOptions {
   topLevelImportPaths?: string[];
   /**
    * `<div css={...}>` JSX prop 을 module-level styled component 로 추출 (default: false).
-   * babel-plugin-styled-components default true 와 다르게 ZTS 는 후속 PR 에서 단계별
-   * transform 구현 — 현재는 옵션 surface 만, true 켜도 transform 미적용 (사용자 코드 안전).
+   * babel-plugin-styled-components default true 와 다르게 opt-in.
+   * intrinsic / custom (jsx_member_expression 포함) / `css\`\`` 템플릿 / object form /
+   * `${expr}` 동적 prop forwarding 까지 지원. auto-inject 시 `styled` 바인딩 충돌은
+   * `_styled` / `_styled2` 로 자동 mangling.
    */
   cssProp?: boolean;
   /** [meta] 표시 (default: false) */
@@ -889,9 +891,10 @@ export interface WatchRebuildEvent {
    * 단계별 빌드 시간 (밀리초). 성공한 리빌드에서만 노출.
    *
    * **기본 phase** (항상 측정):
-   * - `detect` / `parse` / `semantic` / `emit` / `delta` / `total`
+   * - `detect` / `graph` / `link` / `shake` / `emit` / `delta` / `total`
    * 필드 이름과 실제 값이 정확히 일치. 2026-04-22 이전의 `parse` / `semantic` 은
-   * 사실 각각 `graph` / `link+shake` 를 담았던 레거시 이름이었으며 제거됨.
+   * 사실 각각 `graph` / `link+shake` 를 담았던 레거시 이름이었으며 제거됨 —
+   * 이제 sub-phase 로만 (실제 parser / SemanticAnalyzer 시간) 노출된다.
    *
    * **Sub-phase** (`ZTS_PROFILE=<cat>` / `BUNGAE_HMR_PROFILE=1` / `profile: ["<cat>"]` 활성 시):
    * - `scan` / `parse` / `resolve` / `semantic` / `transform` / `codegen` / `metadata`


### PR DESCRIPTION
## Summary

`packages/core/index.ts` 의 세 군데 JSDoc 이 실제 동작과 어긋나 TypeDoc 자동 생성 reference 와 IDE 호버 힌트에 잘못된 정보를 노출하던 것을 정정. PR #2566 에서 사용자 문서를 정리하던 중 발견한 source-vs-docs drift 의 후속.

JSDoc-only 변경. 동작 변화·타입 변화 없음.

## 변경 내역

### 1. `CompilerOptions` (line 419-424)
**기존:**
> 현재는 타입 stub. Zig transformer 가 아직 인식하지 않아 런타임 효과 없음.
> 후속 epic 에서 styled-components / emotion 1st-party transform 도입 시 활성화.

**문제:** `compiler.styledComponents` / `compiler.emotion` 1st-party transform 은 이미 작동. 관련 PR (#2253~#2290 일대) 모두 머지 완료.

**수정:** "babel-plugin-styled-components / @emotion/babel-plugin 의 1st-party 대응" 으로 정정.

### 2. `StyledComponentsOptions.cssProp` (line 466-473)
**기존:**
> babel-plugin-styled-components default true 와 다르게 ZTS 는 후속 PR 에서 단계별 transform 구현 — 현재는 옵션 surface 만, true 켜도 transform 미적용 (사용자 코드 안전).

**문제:** cssProp transform 의 Step 1~6 / A1·A2 / B2 가 모두 머지되어 intrinsic / custom (`jsx_member_expression` 포함) / `css\`\`` 템플릿 / object form / `\${expr}` 동적 prop forwarding 까지 지원.

**수정:** opt-in 임을 유지하되 실제 지원 범위 명시. auto-inject 시의 `styled` 바인딩 충돌 자동 mangling (`_styled` / `_styled2`) 도 부기.

### 3. `WatchRebuildEvent.phaseDurations` (line 888-898)
**기존:**
> **기본 phase** (항상 측정):
> - `detect` / `parse` / `semantic` / `emit` / `delta` / `total`
> 필드 이름과 실제 값이 정확히 일치.

**문제:** 자기모순. 실제 base 필드 선언 (line 904-916) 은 `detect` / `graph` / `link` / `shake` / `emit` / `delta` / `total`. 레거시 `parse` / `semantic` alias 는 2026-04-22 에 제거됨.

**수정:** base phase 목록을 실제 필드 이름과 정확히 일치시킴. 레거시 alias 제거 사실은 유지하되 "이제 sub-phase 로만 노출 (실제 parser / SemanticAnalyzer 시간)" 라는 후속 안내 추가.

## Test plan

- [ ] `bun run build` (또는 ZTS 의 typecheck) 가 통과하는지 (JSDoc-only 라 영향 없을 것으로 예상)
- [ ] TypeDoc 자동 생성 reference 가 새 JSDoc 으로 갱신되는지 (수동 빌드)
- [ ] IDE (VS Code / Cursor) 에서 호버 힌트가 변경된 내용으로 표시되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)