### PR TITLE
perf(bundler): cache source directory handles

### DIFF
--- a/src/bundler/fs.zig
+++ b/src/bundler/fs.zig
@@ -118,6 +118,108 @@ pub fn listDir(alloc: std.mem.Allocator, path: []const u8) FsError![]DirEntry {
     return Implementation.init().listDir(alloc, path);
 }
 
+pub const ReadFileCache = if (is_wasm_build) VirtualReadFileCache else RealReadFileCache;
+
+pub const RealReadFileCache = struct {
+    dirs: std.StringHashMapUnmanaged(std.fs.Dir) = .{},
+    mutex: std.Thread.Mutex = .{},
+
+    pub fn deinit(self: *RealReadFileCache, allocator: std.mem.Allocator) void {
+        var value_it = self.dirs.valueIterator();
+        while (value_it.next()) |dir| dir.close();
+        var key_it = self.dirs.keyIterator();
+        while (key_it.next()) |key| allocator.free(key.*);
+        self.dirs.deinit(allocator);
+    }
+
+    pub fn readFileWithStat(
+        self: *RealReadFileCache,
+        cache_allocator: std.mem.Allocator,
+        content_allocator: std.mem.Allocator,
+        path: []const u8,
+        max_bytes: usize,
+    ) FsError!LoadedModuleWithStat {
+        var with_stat_scope = profile.begin(.graph_discover_pm_setup_read_with_stat);
+        defer with_stat_scope.end();
+
+        const file = blk: {
+            var scope = profile.begin(.graph_discover_pm_setup_read_open);
+            defer scope.end();
+            break :blk self.openFile(cache_allocator, path) catch |err| return mapFsError(err);
+        };
+        defer file.close();
+
+        const stat = blk: {
+            var scope = profile.begin(.graph_discover_pm_setup_read_stat);
+            defer scope.end();
+            break :blk file.stat() catch |err| return mapFsError(err);
+        };
+        const bytes = blk: {
+            var scope = profile.begin(.graph_discover_pm_setup_read_bytes);
+            defer scope.end();
+            break :blk file.readToEndAllocOptions(
+                content_allocator,
+                max_bytes,
+                @intCast(stat.size),
+                .of(u8),
+                null,
+            ) catch |err| return mapFsError(err);
+        };
+        const kind = mapEntryKind(stat.kind);
+
+        return .{
+            .loaded = .{
+                .contents = bytes,
+                .path = path,
+                .namespace = .file,
+            },
+            .stat = .{
+                .size = stat.size,
+                .is_dir = kind == .directory,
+                .mtime = stat.mtime,
+                .kind = kind,
+            },
+        };
+    }
+
+    fn openFile(self: *RealReadFileCache, allocator: std.mem.Allocator, path: []const u8) !std.fs.File {
+        const dir_path = std.fs.path.dirname(path) orelse ".";
+        const file_name = std.fs.path.basename(path);
+        if (file_name.len == 0) return error.FileNotFound;
+
+        const dir = try self.getOrOpenDir(allocator, dir_path);
+        return dir.openFile(file_name, .{});
+    }
+
+    fn getOrOpenDir(self: *RealReadFileCache, allocator: std.mem.Allocator, dir_path: []const u8) !std.fs.Dir {
+        self.mutex.lock();
+        defer self.mutex.unlock();
+
+        if (self.dirs.get(dir_path)) |dir| return dir;
+
+        const key = try allocator.dupe(u8, dir_path);
+        errdefer allocator.free(key);
+        var dir = try std.fs.cwd().openDir(dir_path, .{});
+        errdefer dir.close();
+        try self.dirs.put(allocator, key, dir);
+        return dir;
+    }
+};
+
+pub const VirtualReadFileCache = struct {
+    pub fn deinit(_: *VirtualReadFileCache, _: std.mem.Allocator) void {}
+
+    pub fn readFileWithStat(
+        _: *VirtualReadFileCache,
+        _: std.mem.Allocator,
+        content_allocator: std.mem.Allocator,
+        path: []const u8,
+        max_bytes: usize,
+    ) FsError!LoadedModuleWithStat {
+        return Implementation.init().readFileWithStat(content_allocator, path, max_bytes);
+    }
+};
+
 /// 호스트 OS 의 std.fs.cwd() 를 wrapping. NAPI / CLI 빌드의 default 구현.
 pub const RealFS = struct {
     pub fn init() RealFS {

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -77,6 +77,7 @@ pub const ModuleGraph = struct {
     path_to_module: std.StringHashMap(ModuleIndex),
     diagnostics: std.ArrayList(BundlerDiagnostic),
     resolve_cache: *ResolveCache,
+    source_read_cache: fs.ReadFileCache = .{},
     /// 병렬 워커에서 diagnostics 접근 보호용 mutex
     diag_mutex: std.Thread.Mutex = .{},
 
@@ -257,6 +258,7 @@ pub const ModuleGraph = struct {
         var pi_it = self.pkg_info_cache.valueIterator();
         while (pi_it.next()) |info| info.side_effects.deinit(self.allocator);
         self.pkg_info_cache.deinit(self.allocator);
+        self.source_read_cache.deinit(self.allocator);
         self.diagnostics.deinit(self.allocator);
         for (self.worker_entries.items) |we| {
             self.allocator.free(we.resolved_path);
@@ -3632,7 +3634,7 @@ pub const ModuleGraph = struct {
     ) ?[]const u8 {
         if (module.mtime != 0) return self.readModuleSource(module, alloc, max_bytes, step);
 
-        const loaded = fs.readFileWithStat(alloc, module.path, max_bytes) catch {
+        const loaded = self.source_read_cache.readFileWithStat(self.allocator, alloc, module.path, max_bytes) catch {
             self.addDiag(.read_error, .@"error", module.path, Span.EMPTY, step, "Cannot read file", null);
             module.state = .ready;
             return null;


### PR DESCRIPTION
## 요약
- 번들러 source read 경로에서 파일마다 부모 디렉터리를 다시 여는 비용을 줄이기 위해 `ModuleGraph` 생애주기의 directory handle cache를 추가했습니다.
- native RealFS 경로만 캐시를 사용하고, WASM/VirtualFS 경로는 기존 `readFileWithStat` 구현을 그대로 타도록 분리했습니다.
- 파일 내용, stat, mtime, max size 제한, read error 처리 흐름은 유지했습니다.

## 측정
기준: 직전 main의 graph read/prepass profile 분리 후 로컬 측정(`/tmp/zts-graph-read-prepass-detail-r2.json`)

| Fixture | 기준 median | 현재 r1 | 현재 r2 |
| --- | ---: | ---: | ---: |
| small | 2.86ms | 2.77ms | 2.80ms |
| medium | 6.26ms | 6.09ms | 6.06ms |
| large | 9.42ms | 9.25ms | 9.08ms |

large fixture read profile:
- 기준 `read.open`: 18.4ms
- 현재 r1 `read.open`: 16.9ms
- 현재 r2 `read.open`: 17.6ms

효과는 작지만, 앞서 쪼갠 병목 중 file open 구간이 실제로 줄어드는 방향입니다.

## 검증
- `zig build test --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- `zig build wasm-bundler --summary all`
- `zig build wasm --summary all`
- `bun run fmt:check`
- `bun run tests/benchmark/bundle-perf.ts --no-fail --output /tmp/zts-source-dir-open-cache.json`
- `bun run tests/benchmark/bundle-perf.ts --no-fail --output /tmp/zts-source-dir-open-cache-r2.json`
- pre-push hook 통과
