### PR TITLE
perf(benchmark): add xlarge bundle fixture

### DIFF
--- a/tests/benchmark/bundle-perf.ts
+++ b/tests/benchmark/bundle-perf.ts
@@ -197,6 +197,11 @@ const FIXTURES: FixtureSpec[] = [
     module_count: 200,
     externals: ["react", "vue", "lodash", "rxjs", "zod"],
   },
+  {
+    name: "xlarge (1000 modules, 8 ext)",
+    module_count: 1000,
+    externals: ["react", "vue", "lodash", "rxjs", "zod", "axios", "date-fns", "three"],
+  },
 ];
 
 interface ToolResult {


### PR DESCRIPTION
## 요약
- `bundle-perf` 기본 fixture에 `xlarge (1000 modules, 8 ext)`를 추가했습니다.
- 기존 10/100/200 module fixture만으로는 Rolldown/Rspack의 fixed startup 비용이 너무 크게 보여서, 번들 크기 증가에 따른 scaling을 보기 어렵습니다.
- 1000 module fixture는 CI 기본 실행에 넣어도 로컬 기준 전체 `bundle-perf`가 약 15.6초로 유지되어 부담이 과하지 않습니다.

## 로컬 측정
명령:

```bash
bun run tests/benchmark/bundle-perf.ts --no-fail --output /tmp/zts-xlarge-fixture-check.json
```

| Fixture | ZTS | Rolldown | Rspack |
| --- | ---: | ---: | ---: |
| small (10 modules, 0 ext) | 2.78ms | 52.6ms | 61.7ms |
| medium (100 modules, 3 ext) | 6.04ms | 55.9ms | 66.0ms |
| large (200 modules, 5 ext) | 9.31ms | 58.3ms | 70.4ms |
| xlarge (1000 modules, 8 ext) | 35.9ms | 82.0ms | 98.9ms |

전체 실행 시간: 약 15.6초

## 검증
- `bun run fmt:check`
- `bun run tests/benchmark/bundle-perf.ts --no-fail --output /tmp/zts-xlarge-fixture-check.json`
- pre-push hook 통과
