### PR TITLE
feat(packages): scaffold @zts/web and @zts/server private (1/11)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -99,9 +99,34 @@
         "sass": "^1.99.0",
       },
     },
+    "packages/server": {
+      "name": "@zts/server",
+      "version": "0.1.0",
+      "dependencies": {
+        "@zts/core": "workspace:*",
+      },
+    },
+    "packages/vite-plugin-zts": {
+      "name": "vite-plugin-zts",
+      "version": "0.1.0",
+      "dependencies": {
+        "@zts/core": "workspace:*",
+      },
+      "peerDependencies": {
+        "vite": ">=5.0.0",
+      },
+    },
     "packages/wasm": {
       "name": "@zts/wasm",
       "version": "0.1.0",
+    },
+    "packages/web": {
+      "name": "@zts/web",
+      "version": "0.1.0",
+      "dependencies": {
+        "@zts/core": "workspace:*",
+        "@zts/server": "workspace:*",
+      },
     },
     "tests/benchmark": {
       "name": "@zts/benchmark",
@@ -1180,7 +1205,11 @@
 
     "@zts/integration": ["@zts/integration@workspace:tests/integration"],
 
+    "@zts/server": ["@zts/server@workspace:packages/server"],
+
     "@zts/wasm": ["@zts/wasm@workspace:packages/wasm"],
+
+    "@zts/web": ["@zts/web@workspace:packages/web"],
 
     "abab": ["abab@1.0.4", "", {}, "sha512-I+Wi+qiE2kUXyrRhNsWv6XsjUTBJjSoVSctKNBfLG5zG/Xe7Rjbxf13+vqYHNTwHaFU+FtSlVxOCTiMEVtPv0A=="],
 
@@ -3065,6 +3094,8 @@
     "vinyl": ["vinyl@2.2.1", "", { "dependencies": { "clone": "^2.1.1", "clone-buffer": "^1.0.0", "clone-stats": "^1.0.0", "cloneable-readable": "^1.0.0", "remove-trailing-separator": "^1.0.1", "replace-ext": "^1.0.0" } }, "sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw=="],
 
     "vite": ["vite@8.0.8", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.15", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw=="],
+
+    "vite-plugin-zts": ["vite-plugin-zts@workspace:packages/vite-plugin-zts"],
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "version": "0.1.0",
   "workspaces": [
     "./packages/core",
+    "./packages/server",
+    "./packages/web",
     "./packages/wasm",
+    "./packages/vite-plugin-zts",
     "./documents",
     "./examples/web",
     "./tests/integration",

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,0 +1,15 @@
+# @zts/server (internal)
+
+ZTS 의 internal server layer. **private 패키지** (`"private": true`) — npm 에 publish 되지 않습니다.
+
+`@zts/web` / `@zts/react-native` 빌드 시 dist 에 자동 inline 되어, 외부에 별도 패키지로 노출되지 않습니다.
+
+## 역할
+
+- HMR protocol (HMR_MSG enum, type 정의)
+- WS frame builder (RFC 6455)
+- file watcher wrapper (`fs.watch` 기반, 미래에 NAPI watch)
+- HMR channel (broadcast)
+- 미래: BoringSSL TLS wrapper, NAPI server start/stop
+
+자세한 계획: [#2539](https://github.com/ohah/zts/issues/2539).

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@zts/server",
+  "version": "0.1.0",
+  "private": true,
+  "description": "ZTS internal server layer — HMR protocol, WS frame, watcher, TLS",
+  "license": "MIT",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./src/index.ts",
+      "types": "./src/index.ts"
+    }
+  },
+  "files": [
+    "src/",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "exit 0",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@zts/core": "workspace:*"
+  }
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "description": "ZTS internal server layer — HMR protocol, WS frame, watcher, TLS",
   "license": "MIT",
+  "files": [
+    "src/",
+    "README.md"
+  ],
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
@@ -13,10 +17,6 @@
       "types": "./src/index.ts"
     }
   },
-  "files": [
-    "src/",
-    "README.md"
-  ],
   "scripts": {
     "build": "exit 0",
     "test": "bun test"

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,0 +1,4 @@
+// @zts/server — web / RN 공통 protocol / watcher / HMR / TLS layer.
+// private 패키지로 빌드 시 @zts/web · @zts/react-native 의 dist 에 inline.
+// 분리 진행: #2539.
+export {};

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../core/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "outDir": "dist",
+    "declarationDir": "dist"
+  },
+  "include": ["src/index.ts"]
+}

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -1,0 +1,13 @@
+# @zts/web
+
+ZTS web platform layer. dev server (HMR / HTTPS / overlay), postcss / sass / lightningcss pipeline 이 자리잡는 패키지.
+
+> 분리 진행 중 — [#2539](https://github.com/ohah/zts/issues/2539).
+
+## 사용
+
+```bash
+npm i -D @zts/web
+```
+
+`@zts/core` 가 dependencies 로 자동 따라옵니다. `zts dev`, `zts preview`, `zts build` (app mode) 명령에서 사용.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@zts/web",
+  "version": "0.1.0",
+  "description": "ZTS web platform — dev server, postcss/sass/lightningcss pipeline, HMR overlay",
+  "license": "MIT",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./src/index.ts",
+      "types": "./src/index.ts"
+    }
+  },
+  "files": [
+    "src/",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "exit 0",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "@zts/core": "workspace:*",
+    "@zts/server": "workspace:*"
+  }
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "description": "ZTS web platform — dev server, postcss/sass/lightningcss pipeline, HMR overlay",
   "license": "MIT",
+  "files": [
+    "src/",
+    "README.md"
+  ],
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
@@ -12,10 +16,6 @@
       "types": "./src/index.ts"
     }
   },
-  "files": [
-    "src/",
-    "README.md"
-  ],
   "scripts": {
     "build": "exit 0",
     "test": "bun test"

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,0 +1,3 @@
+// @zts/web — dev server / postcss·sass·lightningcss / HMR overlay 가 자리잡는 패키지.
+// 분리 진행: #2539.
+export {};

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../core/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "outDir": "dist",
+    "declarationDir": "dist"
+  },
+  "include": ["src/index.ts"]
+}


### PR DESCRIPTION
## Summary

#2539 epic 의 **PR 1/11**. dev server 분리 작업의 토대로 `@zts/web`, `@zts/server` 패키지 자리를 마련.

- **`packages/web/`** (PUBLIC) — 향후 dev server, postcss/sass/lightningcss, HMR overlay 가 자리잡을 패키지. 현재 빈 entry (`export {}`). PR #4-6 에서 코드 이전.
- **`packages/server/`** (PRIVATE — `\"private\": true`) — web/RN 공통 protocol/watcher/HMR/TLS layer. PR #3 에서 풀 구현.
- root `package.json` workspaces 갱신 — server/web 신규 추가 + 누락된 vite-plugin-zts 도 함께 등록 (drift 보정).
- `packages/plugin/` (잔여 빈 폴더) 제거.

## 변경 범위

| 종류 | 파일 |
|---|---|
| 신설 | `packages/web/{package.json,tsconfig.json,src/index.ts,README.md}` |
| 신설 | `packages/server/{package.json,tsconfig.json,src/index.ts,README.md}` |
| 수정 | root `package.json` (workspaces 갱신), `bun.lock` (자동) |
| 제거 | `packages/plugin/` |

## 향후 PR 과의 관계

본 PR 은 **scaffold only** — 빈 entry. 다음 PR 들이 이 자리 위에 얹음:

- **PR #2** — `@zts/web`/`@zts/server` 의 `zts bundle` self-build 도입 (외부 도구 X)
- **PR #3** — `@zts/server` 풀 구현 (HMR_MSG / WS frame / Watcher / HMR channel) + 단위 테스트 100%
- **PR #4** — `APP_DEV_HMR_CLIENT` runtime → `@zts/web/runtime/`
- **PR #5** — postcss/sass/lightningcss pipeline → `@zts/web/src/style/`
- **PR #6** — zts.mjs 의 dev server 코드를 server + web API 위로 cut over

## 결정사항 반영

#2569 research 의 결정 종합:
- React 패턴 platform 분리 (core 가 shared)
- `@zts/server` private + 빌드 시 web 의 dist 에 inline
- CLI 는 `@zts/core` 의 bin 에 유지 (lazy import 라우팅, 옵션 C)
- 빌드 도구 = ZTS 자체 self-host (PR #2 부터 도입)

## 검증

- [x] `bun install` 통과 (workspace 인식, 신규 deps 0개 — 모두 `workspace:*`)
- [x] `bun run --cwd packages/{web,server} build` 통과 (현재 placeholder)
- [x] `tsc --noEmit -p packages/{web,server}/tsconfig.json` type-check 통과

## /simplify 반영

3-agent 리뷰 결과 다음 fix 반영:
- `runtime/.gitkeep` 삭제 — PR #4 에서 자연 생성
- `build` script 의 `echo` placeholder → `exit 0` (PR 번호 박제 회피, CI 로그 오염 회피)
- `src/index.ts` 주석 간결화 (PR 번호 박제 제거, README + #2539 로 충분)
- `server/README.md` \"별도 install 불필요\" → \"외부에 별도 패키지로 노출되지 않음\" (private 패키지에 사용자 install 행위 언급 어색)

PR #2 까지 보류한 항목 (`tsconfig` rootDir 정리, `main`/`types` dist 전환 등) 은 self-build 도입 시 자연 해결되어 본 PR 에선 변경 안 함.

Refs #2539 (1/11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)