### PR TITLE
chore(web,server): adopt zts self-build (dogfooding) (2/11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,18 @@ jobs:
       - name: Run CLI tests (Bun)
         run: cd packages/core && bun test bin/zts.test.ts
 
+      # @zts/server (private, internal) + @zts/web 의 self-build 검증 (#2539).
+      # zts CLI 가 자기 자신을 빌드하는 dogfooding (외부 도구 없이
+      # `node ../core/bin/zts.mjs --bundle ...` + `tsc --emitDeclarationOnly`).
+      # @zts/server 의 src 가 @zts/web 의 dist 에 자동 inline 되는지 검증
+      # (workspace dep auto-inline). 본 시점은 server 가 빈 entry 라 inline
+      # 분량 0 — PR #3 후 grep 검증 추가 예정.
+      - name: Build @zts/server (self-build 검증)
+        run: bun run --cwd packages/server build
+
+      - name: Build @zts/web (self-build + inline 검증)
+        run: bun run --cwd packages/web build
+
       # ZTS 코어의 ES5 다운레벨링 / chunk split runtime helper / external 처리
       # 회귀 검증 (wasm 발견 버그가 NAPI 에서도 동일 발생 확인됨). known bugs
       # 는 #1960~#1962 추적 — fix 전까지 continue-on-error 로 정보용. fix 후

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,9 @@ documents/dist/
 
 # JS build output
 packages/core/dist/
+packages/server/dist/
 packages/wasm/dist/
+packages/web/dist/
 # 루트 cwd 에 떨어지는 임시 빌드 산출물 (NAPI 직접 호출 경로 / examples 빌드 leftover).
 /dist/
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -5,20 +5,22 @@
   "description": "ZTS internal server layer — HMR protocol, WS frame, watcher, TLS",
   "license": "MIT",
   "files": [
-    "src/",
+    "dist/",
     "README.md"
   ],
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./src/index.ts",
-      "types": "./src/index.ts"
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "scripts": {
-    "build": "exit 0",
+    "build:bundle": "node ../core/bin/zts.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --external @zts/core",
+    "build:dts": "bun x tsc --emitDeclarationOnly",
+    "build": "bun run build:bundle && bun run build:dts",
     "test": "bun test"
   },
   "dependencies": {

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "../core/tsconfig.json",
   "compilerOptions": {
-    "rootDir": "..",
+    "rootDir": "src",
     "outDir": "dist",
     "declarationDir": "dist"
   },
-  "include": ["src/index.ts"]
+  "include": ["src/**/*"]
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -4,20 +4,22 @@
   "description": "ZTS web platform — dev server, postcss/sass/lightningcss pipeline, HMR overlay",
   "license": "MIT",
   "files": [
-    "src/",
+    "dist/",
     "README.md"
   ],
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./src/index.ts",
-      "types": "./src/index.ts"
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "scripts": {
-    "build": "exit 0",
+    "build:bundle": "node ../core/bin/zts.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --external @zts/core --external lightningcss --external postcss --external postcss-load-config --external sass",
+    "build:dts": "bun x tsc --emitDeclarationOnly",
+    "build": "bun run build:bundle && bun run build:dts",
     "test": "bun test"
   },
   "dependencies": {

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "../core/tsconfig.json",
   "compilerOptions": {
-    "rootDir": "..",
+    "rootDir": "src",
     "outDir": "dist",
     "declarationDir": "dist"
   },
-  "include": ["src/index.ts"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary

#2539 epic 의 **PR 2/11**. `@zts/web` · `@zts/server` 의 빌드를 ZTS 자체 CLI 로 처리. 외부 도구 (tsup/esbuild) 도입 안 함 — Bun 식 통합 번들러 정체성에 맞춰 self-host.

## 변경

### `packages/{web,server}/package.json` — build script 분리 (core 패턴 일관)

```json
"build:bundle": "node ../core/bin/zts.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --external @zts/core ...",
"build:dts": "bun x tsc --emitDeclarationOnly",
"build": "bun run build:bundle && bun run build:dts"
```

`main`/`types`/`exports`/`files` 를 `./src` 직참조 → `./dist` 로 전환.

**External 명시**:
- 둘 다 `@zts/core` external (NAPI 바이너리 호스트)
- `@zts/web` 추가: `lightningcss`, `postcss`, `postcss-load-config`, `sass` (CSS 도구)

`@zts/server` 는 web 에서 external 명시 안 함 → workspace dep 으로 자동 inline (web 의 dist 에 server 코드 들어감). 본 시점 server 가 빈 entry 라 inline 분량 0, PR #3 후 grep 검증 추가 예정.

### `packages/{web,server}/tsconfig.json`

- `rootDir`: `\".\"` (core 가 `../shared` import 위해 쓰던 패턴) → `\"src\"`. 외부 import 없으니 src 가 root. emit 이 평탄한 `dist/index.d.ts` 로 떨어짐.
- `include`: `[\"src/index.ts\"]` → `[\"src/**/*\"]`.

### `.gitignore`

`packages/{web,server}/dist/` 추가.

### `.github/workflows/ci.yml`

`napi` job 에 web/server self-build step 추가:

```yaml
- name: Build @zts/server (self-build 검증)
  run: bun run --cwd packages/server build

- name: Build @zts/web (self-build + inline 검증)
  run: bun run --cwd packages/web build
```

## 결정 반영 (#2569)

- ✅ ZTS self-host (외부 도구 도입 안 함, dogfooding)
- ✅ `@zts/core` 자체 self-host 는 1.x 별도 (bootstrap 부담 회피, 본 PR 은 신규 web/server 만 적용)
- ✅ dts 는 `tsc --emitDeclarationOnly` (ZTS 영역 밖, swc/esbuild 동일 방침)

## 검증

- [x] `bun run --cwd packages/server build` 통과 → `dist/{index.d.ts,index.js}`
- [x] `bun run --cwd packages/web build` 통과 → 동일
- [x] `bun run fmt` 변경 없음

## /simplify 반영

- build script 를 `build:bundle` + `build:dts` + `build` 3 단계로 분리 — `packages/core/package.json:25-27` 의 `build:napi`/`build:js`/`build:dts` 패턴과 일관

`node ../core/bin/zts.mjs` path stringly-typed 는 후속 PR (#2540 RN, #2538 BoringSSL) 도 같은 패턴 쓸 가능성 → 3 callsite 이상 되면 root scripts helper 추출. 본 PR 시점은 2 callsite 라 YAGNI.

Refs #2539 (2/11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)