### PR TITLE
refactor(web): extract APP_DEV_HMR_CLIENT runtime to @zts/web (4/11)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@emotion/react": "^11.14.0",
         "@tailwindcss/postcss": "^4.2.2",
         "@tanstack/react-query": "^5",
+        "@zts/web": "workspace:*",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "hermes-engine-cli": "^0.12.0",
@@ -105,6 +106,9 @@
       "dependencies": {
         "@zts/core": "workspace:*",
       },
+      "devDependencies": {
+        "@types/node": "^25.5.2",
+      },
     },
     "packages/vite-plugin-zts": {
       "name": "vite-plugin-zts",
@@ -126,6 +130,9 @@
       "dependencies": {
         "@zts/core": "workspace:*",
         "@zts/server": "workspace:*",
+      },
+      "devDependencies": {
+        "@types/node": "^25.5.2",
       },
     },
     "tests/benchmark": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@emotion/react": "^11.14.0",
     "@tailwindcss/postcss": "^4.2.2",
     "@tanstack/react-query": "^5",
+    "@zts/web": "workspace:*",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "hermes-engine-cli": "^0.12.0",

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -601,9 +601,10 @@ const HMR_MSG = Object.freeze({
 const HMR_WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
 async function runAppDev(opts, config, configEnv, _dotenvVars) {
+  const web = await loadWebModule();
   const root = resolve(opts.appRoot ?? ".");
   opts.outdir = opts.outdir || join(root, ".zts-dev");
-  const appDev = createAppDevController(opts, root, configEnv);
+  const appDev = createAppDevController(opts, root, configEnv, web);
   const prepared = await appDev.prepare();
 
   opts.entryPoints = [prepared.entryPath];
@@ -612,7 +613,7 @@ async function runAppDev(opts, config, configEnv, _dotenvVars) {
   return runServe(opts, config, { appDev });
 }
 
-function createAppDevController(opts, root, configEnv) {
+function createAppDevController(opts, root, configEnv, web) {
   const outdir = resolve(opts.outdir || join(root, ".zts-dev"));
   const base = normalizeBase(opts.base ?? opts.publicPath ?? "/");
   let cssDeps = new Set();
@@ -661,7 +662,7 @@ function createAppDevController(opts, root, configEnv) {
         envDir: opts.envDir ? resolve(opts.envDir) : prepareRoot,
         envPrefixes: opts.envPrefixes,
       });
-      injectAppDevHmrClient(outdir);
+      web.injectAppDevHmrClient(outdir);
       // dev mode 한정 — bundler 가 dev splitting=false 라 CSS chunk 를 emit 하지
       // 않으므로 Sass / CSS Modules 결과를 outdir 로 mirror + `<link>` 주입.
       // mirror (cpSync) 는 sass/module 입력이 dirty 일 때만 — 그 외엔 outdir 의 직전 mirror
@@ -672,7 +673,7 @@ function createAppDevController(opts, root, configEnv) {
         const rels = sassOrModuleDirty
           ? mirrorPipelineCssToOutdir(pipelineRoot, outdir, pipeline.generatedCssAbsPaths)
           : pipeline.generatedCssAbsPaths.map((p) => relative(pipelineRoot, p));
-        injectAppDevPipelineCssLinks(outdir, base, rels);
+        web.injectAppDevPipelineCssLinks(outdir, base, rels);
       }
       return prepared;
     },
@@ -691,7 +692,7 @@ function createAppDevController(opts, root, configEnv) {
       return result;
     },
     injectBundleCssLinks(bundleResult) {
-      injectAppDevBundleCssLinks(outdir, base, bundleResult);
+      web.injectAppDevBundleCssLinks(outdir, base, bundleResult);
     },
     isPostcssConfig(absPath) {
       return isPostcssConfigFile(absPath);
@@ -742,43 +743,6 @@ function joinUrl(base, rel) {
   return `${base}${rel}`;
 }
 
-function injectIntoDevHtml(outdir, build) {
-  const htmlPath = join(outdir, "index.html");
-  let html;
-  try {
-    html = readFileSync(htmlPath, "utf8");
-  } catch (err) {
-    if (err?.code === "ENOENT") return;
-    throw err;
-  }
-  const tag = build(html);
-  if (!tag) return;
-  const next = html.includes("</head>")
-    ? html.replace("</head>", `${tag}\n</head>`)
-    : html.replace("<script", `${tag}\n<script`);
-  writeFileSync(htmlPath, next);
-}
-
-function injectAppDevHmrClient(outdir) {
-  injectIntoDevHtml(outdir, (html) => {
-    if (html.includes(APP_DEV_HMR_CLIENT_PATH)) return null;
-    return `<script type="module" src="${APP_DEV_HMR_CLIENT_PATH}"></script>`;
-  });
-}
-
-function injectAppDevBundleCssLinks(outdir, base, bundleResult) {
-  injectIntoDevHtml(outdir, (html) => {
-    const cssHrefs = [];
-    for (const file of bundleResult?.outputFiles ?? []) {
-      if (!file?.path || !isCssFile(file.path)) continue;
-      const href = joinUrl(base, basename(file.path));
-      if (!html.includes(`href="${href}"`) && !html.includes(`href='${href}'`)) cssHrefs.push(href);
-    }
-    if (cssHrefs.length === 0) return null;
-    return cssHrefs.map((href) => `<link rel="stylesheet" href="${href}">`).join("\n");
-  });
-}
-
 // 단일 파일 mirror — syncDirtyFilesIntoTempRoot, mirrorPipelineCssToOutdir,
 // rebuildScssIncremental 가 공용. mkdir + cp 패턴이 흩어졌던 걸 일원화.
 function mirrorFile(srcAbs, dstAbs) {
@@ -798,312 +762,28 @@ function mirrorPipelineCssToOutdir(pipelineRoot, outdir, absPaths) {
   return rels;
 }
 
-function injectAppDevPipelineCssLinks(outdir, base, cssRelPaths) {
-  if (cssRelPaths.length === 0) return;
-  injectIntoDevHtml(outdir, (html) => {
-    const tags = [];
-    for (const rel of cssRelPaths) {
-      const href = joinUrl(base, rel.replaceAll(sep, "/"));
-      if (html.includes(`href="${href}"`) || html.includes(`href='${href}'`)) continue;
-      tags.push(`<link rel="stylesheet" href="${href}">`);
-    }
-    return tags.length === 0 ? null : tags.join("\n");
-  });
-}
-
-const APP_DEV_HMR_CLIENT = `
-const socketProtocol = location.protocol === "https:" ? "wss:" : "ws:";
-let overlay = null;
-let closeOverlayOnEsc = null;
-function hideOverlay() {
-  if (closeOverlayOnEsc) document.removeEventListener("keydown", closeOverlayOnEsc);
-  closeOverlayOnEsc = null;
-  if (overlay && overlay.parentNode) overlay.parentNode.removeChild(overlay);
-  overlay = null;
-}
-function normalizeErrors(errors) {
-  if (!Array.isArray(errors) || errors.length === 0) {
-    return [{ file: "", message: "Unknown build error" }];
-  }
-  return errors.map((error) => {
-    if (typeof error === "string") return { file: "", message: error };
-    return {
-      file: error && typeof error.file === "string" ? error.file : "",
-      message: error && typeof error.message === "string" ? error.message : String(error),
-    };
-  });
-}
-function normalizeRuntimeError(error, file) {
-  if (error && typeof error.stack === "string" && error.stack) {
-    return { file: file || "", message: error.stack };
-  }
-  if (error && typeof error.message === "string" && error.message) {
-    const name = typeof error.name === "string" && error.name ? error.name : "Error";
-    return { file: file || "", message: name + ": " + error.message };
-  }
-  return { file: file || "", message: String(error || "Unknown runtime error") };
-}
-const sourceMapCache = new Map();
-const sourceMapVlqChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-function displaySourceName(source) {
-  if (!source) return "";
-  const clean = String(source).split("?")[0].split("#")[0];
-  const slash = Math.max(clean.lastIndexOf("/"), clean.lastIndexOf("\\\\"));
-  return slash >= 0 ? clean.slice(slash + 1) : clean;
-}
-function decodeSourceMapVlq(segment) {
-  const values = [];
-  let result = 0;
-  let shift = 0;
-  for (const ch of segment) {
-    let digit = sourceMapVlqChars.indexOf(ch);
-    if (digit < 0) return values;
-    const continuation = digit & 32;
-    digit &= 31;
-    result += digit << shift;
-    if (continuation) {
-      shift += 5;
-      continue;
-    }
-    const negative = result & 1;
-    const value = result >> 1;
-    values.push(negative ? -value : value);
-    result = 0;
-    shift = 0;
-  }
-  return values;
-}
-function parseSourceMapMappings(map) {
-  if (map.__ztsParsedMappings) return map.__ztsParsedMappings;
-  let source = 0;
-  let originalLine = 0;
-  let originalColumn = 0;
-  let name = 0;
-  const parsed = [];
-  for (const line of String(map.mappings || "").split(";")) {
-    let generatedColumn = 0;
-    const segments = [];
-    for (const segment of line.split(",")) {
-      if (!segment) continue;
-      const values = decodeSourceMapVlq(segment);
-      if (values.length === 0) continue;
-      generatedColumn += values[0];
-      if (values.length >= 4) {
-        source += values[1];
-        originalLine += values[2];
-        originalColumn += values[3];
-        if (values.length >= 5) name += values[4];
-        segments.push({ generatedColumn, source, originalLine, originalColumn });
+// app 모드 (dev/preview/build) 에서만 @zts/web 을 lazy import. bundle/transpile/watch
+// 모드에서는 web 패키지를 받지 않은 사용자도 동작해야 하기에 정적 import 회피.
+let webModulePromise = null;
+async function loadWebModule() {
+  if (webModulePromise) return webModulePromise;
+  webModulePromise = (async () => {
+    try {
+      return await import("@zts/web");
+    } catch (err) {
+      const code = err?.code;
+      const message = String(err?.message ?? "");
+      if (code === "ERR_MODULE_NOT_FOUND" || /Cannot find package "@zts\/web"/.test(message)) {
+        console.error("error: @zts/web 패키지가 필요합니다 (zts dev / preview / build app 모드).");
+        console.error("");
+        console.error("help: install with `bun add -D @zts/web` 또는 `npm i -D @zts/web`.");
+        process.exit(1);
       }
+      throw err;
     }
-    parsed.push(segments);
-  }
-  Object.defineProperty(map, "__ztsParsedMappings", { value: parsed });
-  return parsed;
-}
-function findOriginalPosition(map, line, column) {
-  const segments = parseSourceMapMappings(map)[line - 1];
-  if (!segments || segments.length === 0) return null;
-  let lo = 0;
-  let hi = segments.length - 1;
-  let best = null;
-  while (lo <= hi) {
-    const mid = (lo + hi) >> 1;
-    const segment = segments[mid];
-    if (segment.generatedColumn <= column) {
-      best = segment;
-      lo = mid + 1;
-    } else {
-      hi = mid - 1;
-    }
-  }
-  best = best || segments[0];
-  const source = map.sources && map.sources[best.source];
-  if (!source) return null;
-  const columnOffset = Math.max(0, column - best.generatedColumn);
-  return {
-    source: displaySourceName(source),
-    line: best.originalLine + 1,
-    column: best.originalColumn + columnOffset,
-  };
-}
-async function loadSourceMapForGeneratedUrl(url) {
-  const generatedUrl = new URL(url, location.href).href;
-  if (sourceMapCache.has(generatedUrl)) return sourceMapCache.get(generatedUrl);
-  const safeJson = async (response) => {
-    try { return await response.json(); } catch (_) { return null; }
-  };
-  const promise = (async () => {
-    const direct = await fetch(generatedUrl + ".map", { cache: "no-store" }).catch(() => null);
-    if (direct && direct.ok) return safeJson(direct);
-    const jsResponse = await fetch(generatedUrl, { cache: "no-store" }).catch(() => null);
-    if (!jsResponse || !jsResponse.ok) return null;
-    const code = await jsResponse.text();
-    const match =
-      code.match(/\\/\\/[#@]\\s*sourceMappingURL=([^\\n\\r]+)/) ||
-      code.match(/\\/\\*[#@]\\s*sourceMappingURL=([^*]+)\\*\\//);
-    if (!match) return null;
-    const ref = match[1].trim();
-    if (ref.startsWith("data:")) {
-      const comma = ref.indexOf(",");
-      if (comma < 0) return null;
-      const meta = ref.slice(0, comma);
-      const data = ref.slice(comma + 1);
-      try {
-        const json = meta.includes(";base64") ? atob(data) : decodeURIComponent(data);
-        return JSON.parse(json);
-      } catch (_) {
-        return null;
-      }
-    }
-    const mapResponse = await fetch(new URL(ref, generatedUrl).href, { cache: "no-store" }).catch(() => null);
-    return mapResponse && mapResponse.ok ? safeJson(mapResponse) : null;
   })();
-  sourceMapCache.set(generatedUrl, promise);
-  return promise;
+  return webModulePromise;
 }
-async function mapGeneratedLocation(url, line, column) {
-  const map = await loadSourceMapForGeneratedUrl(url);
-  return map ? findOriginalPosition(map, line, column) : null;
-}
-async function mapLocationText(text) {
-  if (!text) return text;
-  const match = String(text).match(/(https?:\\/\\/[^\\s)]+):(\\d+):(\\d+)/);
-  if (!match) return text;
-  const mapped = await mapGeneratedLocation(match[1], Number(match[2]), Number(match[3]));
-  if (!mapped) return text;
-  return String(text).replace(match[0], mapped.source + ":" + mapped.line + ":" + mapped.column);
-}
-async function mapStackTrace(stack) {
-  if (typeof stack !== "string") return stack;
-  const lines = await Promise.all(stack.split("\\n").map(mapLocationText));
-  return lines.join("\\n");
-}
-async function normalizeRuntimeErrorWithSourceMap(error, file) {
-  const item = normalizeRuntimeError(error, file);
-  item.file = await mapLocationText(item.file);
-  item.message = await mapStackTrace(item.message);
-  return item;
-}
-async function showRuntimeOverlay(error, file) {
-  let item;
-  try {
-    item = await normalizeRuntimeErrorWithSourceMap(error, file);
-  } catch (_) {
-    item = normalizeRuntimeError(error, file);
-  }
-  showOverlay([item], "Runtime Error");
-}
-function showOverlay(errors, titleText = "Build Error") {
-  hideOverlay();
-  const items = normalizeErrors(errors);
-  overlay = document.createElement("div");
-  overlay.id = "zts-error-overlay";
-  const root = overlay.attachShadow({ mode: "open" });
-  const style = document.createElement("style");
-  style.textContent = ":host{position:fixed;inset:0;z-index:2147483647;display:block;--font:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;--red:#fb7185;--text:#f8fafc;--blue:#93c5fd;--window:#181818;}" +
-    ".backdrop{position:fixed;inset:0;overflow:auto;padding:32px;box-sizing:border-box;background:rgba(0,0,0,.66);font:14px/1.5 var(--font);color:var(--text);}" +
-    ".window{max-width:980px;margin:0 auto;background:var(--window);border-top:8px solid var(--red);border-radius:6px 6px 8px 8px;box-shadow:0 19px 38px rgba(0,0,0,.30),0 15px 12px rgba(0,0,0,.22);overflow:hidden;}" +
-    ".header{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:18px 20px;border-bottom:1px solid rgba(255,255,255,.12);}" +
-    ".title{font-size:18px;font-weight:700;color:#fecdd3;}" +
-    ".close{width:30px;height:30px;border:1px solid rgba(255,255,255,.25);border-radius:4px;background:#111827;color:var(--text);cursor:pointer;font:18px/1 var(--font);}" +
-    ".card{padding:18px 20px;border-top:1px solid rgba(255,255,255,.08);}" +
-    ".file{margin-bottom:10px;color:var(--blue);word-break:break-all;}" +
-    ".message{margin:0;white-space:pre-wrap;color:#fff;word-break:break-word;font:14px/1.5 var(--font);}";
-  const backdrop = document.createElement("div");
-  backdrop.className = "backdrop";
-  const panel = document.createElement("div");
-  panel.className = "window";
-  panel.onclick = (event) => event.stopPropagation();
-  const header = document.createElement("div");
-  header.className = "header";
-  const title = document.createElement("div");
-  title.className = "title";
-  title.textContent = titleText;
-  const close = document.createElement("button");
-  close.type = "button";
-  close.textContent = "x";
-  close.className = "close";
-  close.setAttribute("aria-label", "Close error overlay");
-  close.onclick = hideOverlay;
-  header.appendChild(title);
-  header.appendChild(close);
-  panel.appendChild(header);
-  for (const item of items) {
-    const card = document.createElement("div");
-    card.className = "card";
-    if (item.file) {
-      const file = document.createElement("div");
-      file.className = "file";
-      file.textContent = item.file;
-      card.appendChild(file);
-    }
-    const message = document.createElement("pre");
-    message.className = "message";
-    message.textContent = item.message;
-    card.appendChild(message);
-    panel.appendChild(card);
-  }
-  backdrop.appendChild(panel);
-  root.appendChild(style);
-  root.appendChild(backdrop);
-  closeOverlayOnEsc = (event) => {
-    if (event.key === "Escape" || event.code === "Escape") hideOverlay();
-  };
-  document.addEventListener("keydown", closeOverlayOnEsc);
-  (document.body || document.documentElement).appendChild(overlay);
-}
-globalThis.__zts_show_error_overlay = showOverlay;
-globalThis.__zts_clear_error_overlay = hideOverlay;
-if (!globalThis.__zts_runtime_listeners_attached) {
-  globalThis.__zts_runtime_listeners_attached = true;
-  window.addEventListener("error", (event) => {
-    const file = event.filename ? event.filename + ":" + event.lineno + ":" + event.colno : "";
-    showRuntimeOverlay(event.error || event.message, file);
-  });
-  window.addEventListener("unhandledrejection", (event) => {
-    showRuntimeOverlay(event.reason, "");
-  });
-}
-const socket = new WebSocket(socketProtocol + "//" + location.host + "${APP_DEV_HMR_WS_PATH}");
-socket.addEventListener("message", (event) => {
-  const msg = JSON.parse(event.data);
-  if (msg.type === "${HMR_MSG.Error}") {
-    showOverlay(msg.errors);
-    return;
-  }
-  if (msg.type === "${HMR_MSG.ClearError}") {
-    hideOverlay();
-    return;
-  }
-  if (msg.type === "${HMR_MSG.FullReload}") {
-    hideOverlay();
-    location.reload();
-    return;
-  }
-  if (msg.type !== "${HMR_MSG.CssUpdate}") return;
-  hideOverlay();
-  const stamp = msg.timestamp || Date.now();
-  const links = Array.from(document.querySelectorAll('link[rel="stylesheet"]'));
-  let updated = false;
-  for (const link of links) {
-    const href = link.getAttribute("href");
-    if (!href) continue;
-    const current = new URL(href, location.href);
-    const target = new URL(msg.href || current.pathname, location.href);
-    if (msg.href && current.pathname !== target.pathname) continue;
-    const next = new URL(current.href);
-    next.searchParams.set("t", String(stamp));
-    const replacement = link.cloneNode();
-    replacement.href = next.href;
-    replacement.onload = () => link.remove();
-    replacement.onerror = () => location.reload();
-    link.after(replacement);
-    updated = true;
-  }
-  if (!updated) location.reload();
-});
-`;
 
 function createAppDevHmrChannel() {
   // Node 와 Bun runtime 의 WebSocket 표현이 다르므로 두 클라이언트 종류를 구분.
@@ -2511,6 +2191,9 @@ async function emitRestartAfter(opts, reason, beforeSpawn) {
 async function runServe(opts, config, { appDev = null } = {}) {
   const isBun = typeof globalThis.Bun !== "undefined";
   const hmr = appDev ? createAppDevHmrChannel() : null;
+  // appDev 모드에서만 web 의 APP_DEV_HMR_CLIENT 가 필요. handleRequest 가 sync 라
+  // 진입 시점에 한 번 load 후 closure 로 사용.
+  const web = appDev ? await loadWebModule() : null;
   let serverHandle = null;
   const mimeTypes = {
     ".html": "text/html",
@@ -2556,7 +2239,7 @@ async function runServe(opts, config, { appDev = null } = {}) {
     if (appDev && pathname === APP_DEV_HMR_CLIENT_PATH) {
       return {
         status: 200,
-        body: APP_DEV_HMR_CLIENT,
+        body: web.APP_DEV_HMR_CLIENT,
         type: "application/javascript",
       };
     }

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,8 +1,8 @@
-# @zts/server (internal)
+# @zts/server
 
-ZTS 의 internal server layer. **private 패키지** (`"private": true`) — npm 에 publish 되지 않습니다.
+ZTS 의 internal server layer. **`@zts/web` / `@zts/react-native` 가 의존성으로 사용** — 사용자가 직접 install 할 일 없음.
 
-`@zts/web` / `@zts/react-native` 빌드 시 dist 에 자동 inline 되어, 외부에 별도 패키지로 노출되지 않습니다.
+> 공개 npm 패키지지만 의도는 internal 라이브러리. ZTS bundler 가 workspace dep auto-inline 을 지원하기 전까지의 임시 노출 — 후속에 다시 private 로 전환 예정 (#2539).
 
 ## 역할
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@zts/server",
   "version": "0.1.0",
-  "private": true,
-  "description": "ZTS internal server layer — HMR protocol, WS frame, watcher, TLS",
+  "description": "ZTS internal server layer (HMR protocol, WS frame, watcher, TLS) — @zts/web · @zts/react-native 가 dep 으로 사용. 직접 install 비추",
   "license": "MIT",
   "files": [
     "dist/",
@@ -18,12 +17,13 @@
     }
   },
   "scripts": {
-    "build:bundle": "node ../core/bin/zts.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --external @zts/core",
-    "build:dts": "bun x tsc --emitDeclarationOnly",
-    "build": "bun run build:bundle && bun run build:dts",
+    "build": "bun x tsc",
     "test": "bun test"
   },
   "dependencies": {
     "@zts/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.2"
   }
 }

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "declarationDir": "dist"
+    "declarationDir": "dist",
+    "emitDeclarationOnly": false
   },
   "include": ["src/**/*"],
   "exclude": ["src/**/*.test.ts"]

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -17,7 +17,7 @@
     }
   },
   "scripts": {
-    "build:bundle": "node ../core/bin/zts.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --external @zts/core --external lightningcss --external postcss --external postcss-load-config --external sass",
+    "build:bundle": "node ../core/bin/zts.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --external @zts/core --external @zts/server --external lightningcss --external postcss --external postcss-load-config --external sass",
     "build:dts": "bun x tsc --emitDeclarationOnly",
     "build": "bun run build:bundle && bun run build:dts",
     "test": "bun test"
@@ -25,5 +25,8 @@
   "dependencies": {
     "@zts/core": "workspace:*",
     "@zts/server": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.2"
   }
 }

--- a/packages/web/runtime/dev-overlay-client.d.mts
+++ b/packages/web/runtime/dev-overlay-client.d.mts
@@ -1,0 +1,2 @@
+/** Browser inject 텍스트 — `<script>` body 로 사용. */
+export const APP_DEV_HMR_CLIENT: string;

--- a/packages/web/runtime/dev-overlay-client.mjs
+++ b/packages/web/runtime/dev-overlay-client.mjs
@@ -1,0 +1,307 @@
+// @zts/web 의 브라우저 inject 코드 — `<script type="module" src="/__zts_app_dev_hmr__">`
+// 로 dev server 가 내려보내는 텍스트. WebSocket 연결 + Shadow DOM error overlay
+// + sourcemap 디코더 + runtime error capture 를 모두 포함.
+//
+// 이 파일 자체는 module 로 평가되지만 export 하는 `APP_DEV_HMR_CLIENT` 는
+// **string** 이라 브라우저로 그대로 전송됨. template literal 안의 `${...}` 는
+// module 평가 시점에 치환되어 protocol 상수 (`/__hmr`, "error" 같은 것) 가
+// 정확히 박힘 — server 측 `@zts/server/protocol` 과 single source of truth.
+
+import { APP_DEV_HMR_WS_PATH, HMR_MSG } from "@zts/server";
+
+// biome-ignore format: 안의 코드는 브라우저 inject 텍스트라 zts.mjs 의 원본 (#2539
+// PR #4) 과 byte-for-byte parity 유지. 사소한 escape/들여쓰기 차이도 sourcemap
+// VLQ 디코더 정확성에 영향.
+export const APP_DEV_HMR_CLIENT = `
+const socketProtocol = location.protocol === "https:" ? "wss:" : "ws:";
+let overlay = null;
+let closeOverlayOnEsc = null;
+function hideOverlay() {
+  if (closeOverlayOnEsc) document.removeEventListener("keydown", closeOverlayOnEsc);
+  closeOverlayOnEsc = null;
+  if (overlay && overlay.parentNode) overlay.parentNode.removeChild(overlay);
+  overlay = null;
+}
+function normalizeErrors(errors) {
+  if (!Array.isArray(errors) || errors.length === 0) {
+    return [{ file: "", message: "Unknown build error" }];
+  }
+  return errors.map((error) => {
+    if (typeof error === "string") return { file: "", message: error };
+    return {
+      file: error && typeof error.file === "string" ? error.file : "",
+      message: error && typeof error.message === "string" ? error.message : String(error),
+    };
+  });
+}
+function normalizeRuntimeError(error, file) {
+  if (error && typeof error.stack === "string" && error.stack) {
+    return { file: file || "", message: error.stack };
+  }
+  if (error && typeof error.message === "string" && error.message) {
+    const name = typeof error.name === "string" && error.name ? error.name : "Error";
+    return { file: file || "", message: name + ": " + error.message };
+  }
+  return { file: file || "", message: String(error || "Unknown runtime error") };
+}
+const sourceMapCache = new Map();
+const sourceMapVlqChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+function displaySourceName(source) {
+  if (!source) return "";
+  const clean = String(source).split("?")[0].split("#")[0];
+  const slash = Math.max(clean.lastIndexOf("/"), clean.lastIndexOf("\\\\"));
+  return slash >= 0 ? clean.slice(slash + 1) : clean;
+}
+function decodeSourceMapVlq(segment) {
+  const values = [];
+  let result = 0;
+  let shift = 0;
+  for (const ch of segment) {
+    let digit = sourceMapVlqChars.indexOf(ch);
+    if (digit < 0) return values;
+    const continuation = digit & 32;
+    digit &= 31;
+    result += digit << shift;
+    if (continuation) {
+      shift += 5;
+      continue;
+    }
+    const negative = result & 1;
+    const value = result >> 1;
+    values.push(negative ? -value : value);
+    result = 0;
+    shift = 0;
+  }
+  return values;
+}
+function parseSourceMapMappings(map) {
+  if (map.__ztsParsedMappings) return map.__ztsParsedMappings;
+  let source = 0;
+  let originalLine = 0;
+  let originalColumn = 0;
+  let name = 0;
+  const parsed = [];
+  for (const line of String(map.mappings || "").split(";")) {
+    let generatedColumn = 0;
+    const segments = [];
+    for (const segment of line.split(",")) {
+      if (!segment) continue;
+      const values = decodeSourceMapVlq(segment);
+      if (values.length === 0) continue;
+      generatedColumn += values[0];
+      if (values.length >= 4) {
+        source += values[1];
+        originalLine += values[2];
+        originalColumn += values[3];
+        if (values.length >= 5) name += values[4];
+        segments.push({ generatedColumn, source, originalLine, originalColumn });
+      }
+    }
+    parsed.push(segments);
+  }
+  Object.defineProperty(map, "__ztsParsedMappings", { value: parsed });
+  return parsed;
+}
+function findOriginalPosition(map, line, column) {
+  const segments = parseSourceMapMappings(map)[line - 1];
+  if (!segments || segments.length === 0) return null;
+  let lo = 0;
+  let hi = segments.length - 1;
+  let best = null;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    const segment = segments[mid];
+    if (segment.generatedColumn <= column) {
+      best = segment;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  best = best || segments[0];
+  const source = map.sources && map.sources[best.source];
+  if (!source) return null;
+  const columnOffset = Math.max(0, column - best.generatedColumn);
+  return {
+    source: displaySourceName(source),
+    line: best.originalLine + 1,
+    column: best.originalColumn + columnOffset,
+  };
+}
+async function loadSourceMapForGeneratedUrl(url) {
+  const generatedUrl = new URL(url, location.href).href;
+  if (sourceMapCache.has(generatedUrl)) return sourceMapCache.get(generatedUrl);
+  const safeJson = async (response) => {
+    try { return await response.json(); } catch (_) { return null; }
+  };
+  const promise = (async () => {
+    const direct = await fetch(generatedUrl + ".map", { cache: "no-store" }).catch(() => null);
+    if (direct && direct.ok) return safeJson(direct);
+    const jsResponse = await fetch(generatedUrl, { cache: "no-store" }).catch(() => null);
+    if (!jsResponse || !jsResponse.ok) return null;
+    const code = await jsResponse.text();
+    const match =
+      code.match(/\\/\\/[#@]\\s*sourceMappingURL=([^\\n\\r]+)/) ||
+      code.match(/\\/\\*[#@]\\s*sourceMappingURL=([^*]+)\\*\\//);
+    if (!match) return null;
+    const ref = match[1].trim();
+    if (ref.startsWith("data:")) {
+      const comma = ref.indexOf(",");
+      if (comma < 0) return null;
+      const meta = ref.slice(0, comma);
+      const data = ref.slice(comma + 1);
+      try {
+        const json = meta.includes(";base64") ? atob(data) : decodeURIComponent(data);
+        return JSON.parse(json);
+      } catch (_) {
+        return null;
+      }
+    }
+    const mapResponse = await fetch(new URL(ref, generatedUrl).href, { cache: "no-store" }).catch(() => null);
+    return mapResponse && mapResponse.ok ? safeJson(mapResponse) : null;
+  })();
+  sourceMapCache.set(generatedUrl, promise);
+  return promise;
+}
+async function mapGeneratedLocation(url, line, column) {
+  const map = await loadSourceMapForGeneratedUrl(url);
+  return map ? findOriginalPosition(map, line, column) : null;
+}
+async function mapLocationText(text) {
+  if (!text) return text;
+  const match = String(text).match(/(https?:\\/\\/[^\\s)]+):(\\d+):(\\d+)/);
+  if (!match) return text;
+  const mapped = await mapGeneratedLocation(match[1], Number(match[2]), Number(match[3]));
+  if (!mapped) return text;
+  return String(text).replace(match[0], mapped.source + ":" + mapped.line + ":" + mapped.column);
+}
+async function mapStackTrace(stack) {
+  if (typeof stack !== "string") return stack;
+  const lines = await Promise.all(stack.split("\\n").map(mapLocationText));
+  return lines.join("\\n");
+}
+async function normalizeRuntimeErrorWithSourceMap(error, file) {
+  const item = normalizeRuntimeError(error, file);
+  item.file = await mapLocationText(item.file);
+  item.message = await mapStackTrace(item.message);
+  return item;
+}
+async function showRuntimeOverlay(error, file) {
+  let item;
+  try {
+    item = await normalizeRuntimeErrorWithSourceMap(error, file);
+  } catch (_) {
+    item = normalizeRuntimeError(error, file);
+  }
+  showOverlay([item], "Runtime Error");
+}
+function showOverlay(errors, titleText = "Build Error") {
+  hideOverlay();
+  const items = normalizeErrors(errors);
+  overlay = document.createElement("div");
+  overlay.id = "zts-error-overlay";
+  const root = overlay.attachShadow({ mode: "open" });
+  const style = document.createElement("style");
+  style.textContent = ":host{position:fixed;inset:0;z-index:2147483647;display:block;--font:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;--red:#fb7185;--text:#f8fafc;--blue:#93c5fd;--window:#181818;}" +
+    ".backdrop{position:fixed;inset:0;overflow:auto;padding:32px;box-sizing:border-box;background:rgba(0,0,0,.66);font:14px/1.5 var(--font);color:var(--text);}" +
+    ".window{max-width:980px;margin:0 auto;background:var(--window);border-top:8px solid var(--red);border-radius:6px 6px 8px 8px;box-shadow:0 19px 38px rgba(0,0,0,.30),0 15px 12px rgba(0,0,0,.22);overflow:hidden;}" +
+    ".header{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:18px 20px;border-bottom:1px solid rgba(255,255,255,.12);}" +
+    ".title{font-size:18px;font-weight:700;color:#fecdd3;}" +
+    ".close{width:30px;height:30px;border:1px solid rgba(255,255,255,.25);border-radius:4px;background:#111827;color:var(--text);cursor:pointer;font:18px/1 var(--font);}" +
+    ".card{padding:18px 20px;border-top:1px solid rgba(255,255,255,.08);}" +
+    ".file{margin-bottom:10px;color:var(--blue);word-break:break-all;}" +
+    ".message{margin:0;white-space:pre-wrap;color:#fff;word-break:break-word;font:14px/1.5 var(--font);}";
+  const backdrop = document.createElement("div");
+  backdrop.className = "backdrop";
+  const panel = document.createElement("div");
+  panel.className = "window";
+  panel.onclick = (event) => event.stopPropagation();
+  const header = document.createElement("div");
+  header.className = "header";
+  const title = document.createElement("div");
+  title.className = "title";
+  title.textContent = titleText;
+  const close = document.createElement("button");
+  close.type = "button";
+  close.textContent = "x";
+  close.className = "close";
+  close.setAttribute("aria-label", "Close error overlay");
+  close.onclick = hideOverlay;
+  header.appendChild(title);
+  header.appendChild(close);
+  panel.appendChild(header);
+  for (const item of items) {
+    const card = document.createElement("div");
+    card.className = "card";
+    if (item.file) {
+      const file = document.createElement("div");
+      file.className = "file";
+      file.textContent = item.file;
+      card.appendChild(file);
+    }
+    const message = document.createElement("pre");
+    message.className = "message";
+    message.textContent = item.message;
+    card.appendChild(message);
+    panel.appendChild(card);
+  }
+  backdrop.appendChild(panel);
+  root.appendChild(style);
+  root.appendChild(backdrop);
+  closeOverlayOnEsc = (event) => {
+    if (event.key === "Escape" || event.code === "Escape") hideOverlay();
+  };
+  document.addEventListener("keydown", closeOverlayOnEsc);
+  (document.body || document.documentElement).appendChild(overlay);
+}
+globalThis.__zts_show_error_overlay = showOverlay;
+globalThis.__zts_clear_error_overlay = hideOverlay;
+if (!globalThis.__zts_runtime_listeners_attached) {
+  globalThis.__zts_runtime_listeners_attached = true;
+  window.addEventListener("error", (event) => {
+    const file = event.filename ? event.filename + ":" + event.lineno + ":" + event.colno : "";
+    showRuntimeOverlay(event.error || event.message, file);
+  });
+  window.addEventListener("unhandledrejection", (event) => {
+    showRuntimeOverlay(event.reason, "");
+  });
+}
+const socket = new WebSocket(socketProtocol + "//" + location.host + "${APP_DEV_HMR_WS_PATH}");
+socket.addEventListener("message", (event) => {
+  const msg = JSON.parse(event.data);
+  if (msg.type === "${HMR_MSG.Error}") {
+    showOverlay(msg.errors);
+    return;
+  }
+  if (msg.type === "${HMR_MSG.ClearError}") {
+    hideOverlay();
+    return;
+  }
+  if (msg.type === "${HMR_MSG.FullReload}") {
+    hideOverlay();
+    location.reload();
+    return;
+  }
+  if (msg.type !== "${HMR_MSG.CssUpdate}") return;
+  hideOverlay();
+  const stamp = msg.timestamp || Date.now();
+  const links = Array.from(document.querySelectorAll('link[rel="stylesheet"]'));
+  let updated = false;
+  for (const link of links) {
+    const href = link.getAttribute("href");
+    if (!href) continue;
+    const current = new URL(href, location.href);
+    const target = new URL(msg.href || current.pathname, location.href);
+    if (msg.href && current.pathname !== target.pathname) continue;
+    const next = new URL(current.href);
+    next.searchParams.set("t", String(stamp));
+    const replacement = link.cloneNode();
+    replacement.href = next.href;
+    replacement.onload = () => link.remove();
+    replacement.onerror = () => location.reload();
+    link.after(replacement);
+    updated = true;
+  }
+  if (!updated) location.reload();
+});
+`;

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,3 +1,13 @@
 // @zts/web — dev server / postcss·sass·lightningcss / HMR overlay 가 자리잡는 패키지.
 // 분리 진행: #2539.
-export {};
+
+export {
+  type BundleResult,
+  injectAppDevBundleCssLinks,
+  injectAppDevHmrClient,
+  injectAppDevPipelineCssLinks,
+  injectIntoDevHtml,
+  joinUrl,
+} from "./inject.ts";
+// dev-overlay-client 는 .mjs 라 별도 export — 브라우저 inject 용 string.
+export { APP_DEV_HMR_CLIENT } from "../runtime/dev-overlay-client.mjs";

--- a/packages/web/src/inject.test.ts
+++ b/packages/web/src/inject.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  injectAppDevBundleCssLinks,
+  injectAppDevHmrClient,
+  injectAppDevPipelineCssLinks,
+  injectIntoDevHtml,
+  joinUrl,
+} from "./inject.ts";
+
+let outdir: string;
+let htmlPath: string;
+
+beforeEach(() => {
+  outdir = mkdtempSync(join(tmpdir(), "zts-web-inject-"));
+  htmlPath = join(outdir, "index.html");
+});
+
+afterEach(() => {
+  rmSync(outdir, { recursive: true, force: true });
+});
+
+function writeHtml(html: string): void {
+  mkdirSync(outdir, { recursive: true });
+  writeFileSync(htmlPath, html);
+}
+
+function readHtml(): string {
+  return readFileSync(htmlPath, "utf8");
+}
+
+describe("joinUrl", () => {
+  test("base 없으면 rel 그대로", () => {
+    expect(joinUrl(undefined, "/foo.css")).toBe("/foo.css");
+    expect(joinUrl("", "/foo.css")).toBe("/foo.css");
+  });
+
+  test("base + rel concat", () => {
+    expect(joinUrl("/app", "/foo.css")).toBe("/app/foo.css");
+    expect(joinUrl("/", "foo.css")).toBe("/foo.css");
+  });
+});
+
+describe("injectIntoDevHtml — head 주입", () => {
+  test("</head> 직전에 tag 삽입", () => {
+    writeHtml("<html><head><title>x</title></head><body></body></html>");
+    injectIntoDevHtml(outdir, () => `<meta name="x">`);
+    expect(readHtml()).toContain(`<meta name="x">\n</head>`);
+  });
+
+  test("</head> 없으면 첫 <script> 직전에 삽입", () => {
+    writeHtml('<html><body><script src="a.js"></script></body></html>');
+    injectIntoDevHtml(outdir, () => `<meta name="x">`);
+    expect(readHtml()).toContain(`<meta name="x">\n<script`);
+  });
+
+  test("build callback 가 null 반환하면 변경 없음", () => {
+    const original = "<html><head></head></html>";
+    writeHtml(original);
+    injectIntoDevHtml(outdir, () => null);
+    expect(readHtml()).toBe(original);
+  });
+
+  test("ENOENT (HTML 없음) 은 silent skip — throw 안 함", () => {
+    expect(() => injectIntoDevHtml(outdir, () => "<x>")).not.toThrow();
+  });
+
+  test("ENOENT 외 다른 에러는 propagate", () => {
+    // 디렉토리를 파일로 사용 → EISDIR 같은 에러 (ENOENT 아님).
+    mkdirSync(htmlPath, { recursive: true });
+    expect(() => injectIntoDevHtml(outdir, () => "<x>")).toThrow();
+  });
+});
+
+describe("injectAppDevHmrClient", () => {
+  test("HTML 에 client script 삽입", () => {
+    writeHtml("<html><head></head></html>");
+    injectAppDevHmrClient(outdir);
+    const html = readHtml();
+    expect(html).toContain(`<script type="module" src="/__zts_app_dev_hmr__"></script>`);
+    expect(html).toContain("</head>");
+  });
+
+  test("이미 client 가 있으면 중복 삽입 안 함", () => {
+    writeHtml(
+      `<html><head><script type="module" src="/__zts_app_dev_hmr__"></script></head></html>`,
+    );
+    injectAppDevHmrClient(outdir);
+    const html = readHtml();
+    const occurrences = html.match(/__zts_app_dev_hmr__/g) ?? [];
+    expect(occurrences.length).toBe(1);
+  });
+});
+
+describe("injectAppDevBundleCssLinks", () => {
+  test("css output 마다 <link> 삽입", () => {
+    writeHtml("<html><head></head></html>");
+    injectAppDevBundleCssLinks(outdir, "/", {
+      outputFiles: [{ path: "dist/styles.css" }, { path: "dist/main.js" }],
+    });
+    const html = readHtml();
+    expect(html).toContain(`<link rel="stylesheet" href="/styles.css">`);
+    expect(html).not.toContain("main.js");
+  });
+
+  test("이미 같은 href 가 있으면 중복 삽입 안 함", () => {
+    writeHtml(`<html><head><link rel="stylesheet" href="/styles.css"></head></html>`);
+    injectAppDevBundleCssLinks(outdir, "/", {
+      outputFiles: [{ path: "dist/styles.css" }],
+    });
+    const html = readHtml();
+    const occurrences = html.match(/href="\/styles\.css"/g) ?? [];
+    expect(occurrences.length).toBe(1);
+  });
+
+  test("작은따옴표 href 도 중복 검출", () => {
+    writeHtml(`<html><head><link rel='stylesheet' href='/styles.css'></head></html>`);
+    injectAppDevBundleCssLinks(outdir, "/", {
+      outputFiles: [{ path: "dist/styles.css" }],
+    });
+    expect(readHtml().match(/styles\.css/g)?.length).toBe(1);
+  });
+
+  test("base path 적용 (trailing slash 포함)", () => {
+    writeHtml("<html><head></head></html>");
+    injectAppDevBundleCssLinks(outdir, "/app/", {
+      outputFiles: [{ path: "dist/x.css" }],
+    });
+    expect(readHtml()).toContain(`href="/app/x.css"`);
+  });
+
+  test("css 가 없으면 변경 없음", () => {
+    const original = "<html><head></head></html>";
+    writeHtml(original);
+    injectAppDevBundleCssLinks(outdir, "/", {
+      outputFiles: [{ path: "dist/main.js" }],
+    });
+    expect(readHtml()).toBe(original);
+  });
+
+  test("bundleResult null 도 안전 (변경 없음)", () => {
+    const original = "<html><head></head></html>";
+    writeHtml(original);
+    injectAppDevBundleCssLinks(outdir, "/", null);
+    expect(readHtml()).toBe(original);
+  });
+
+  test("outputFiles 의 file.path 가 없으면 skip", () => {
+    writeHtml("<html><head></head></html>");
+    injectAppDevBundleCssLinks(outdir, "/", { outputFiles: [{}] });
+    expect(readHtml()).toBe("<html><head></head></html>");
+  });
+});
+
+describe("injectAppDevPipelineCssLinks", () => {
+  test("rel path 마다 <link>", () => {
+    writeHtml("<html><head></head></html>");
+    injectAppDevPipelineCssLinks(outdir, "/", ["styles/a.css", "styles/b.css"]);
+    const html = readHtml();
+    expect(html).toContain(`href="/styles/a.css"`);
+    expect(html).toContain(`href="/styles/b.css"`);
+  });
+
+  test("이미 있는 href 는 skip", () => {
+    writeHtml(`<html><head><link rel="stylesheet" href="/a.css"></head></html>`);
+    injectAppDevPipelineCssLinks(outdir, "/", ["a.css"]);
+    expect(readHtml().match(/a\.css/g)?.length).toBe(1);
+  });
+
+  test("작은따옴표 href 도 skip", () => {
+    writeHtml(`<html><head><link rel='stylesheet' href='/a.css'></head></html>`);
+    injectAppDevPipelineCssLinks(outdir, "/", ["a.css"]);
+    expect(readHtml().match(/a\.css/g)?.length).toBe(1);
+  });
+
+  test("빈 배열은 즉시 return — HTML touch 안 함", () => {
+    const original = "<html><head></head></html>";
+    writeHtml(original);
+    injectAppDevPipelineCssLinks(outdir, "/", []);
+    expect(readHtml()).toBe(original);
+  });
+
+  test("Windows path separator 를 forward slash 로 변환", () => {
+    writeHtml("<html><head></head></html>");
+    // path.sep 이 / 인 환경에서도 input 에 \\ 을 명시하면 변환 동작 보장.
+    injectAppDevPipelineCssLinks(outdir, "/", ["styles\\a.css"]);
+    // 유닉스 환경에서 path.sep 은 / 이라 replaceAll(sep, "/") 가 no-op.
+    // input 에 backslash 가 그대로 남음 — 환경 별 동작 검증은 통합 테스트로.
+    const html = readHtml();
+    expect(html).toMatch(/href="\/styles[\\\/]a\.css"/);
+  });
+});

--- a/packages/web/src/inject.ts
+++ b/packages/web/src/inject.ts
@@ -1,0 +1,83 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { basename, join, sep } from "node:path";
+
+import { APP_DEV_HMR_CLIENT_PATH } from "@zts/server";
+
+interface BundleOutputFile {
+  path?: string;
+}
+
+export interface BundleResult {
+  outputFiles?: readonly BundleOutputFile[];
+}
+
+const isCssFile = (path: string): boolean => path.endsWith(".css");
+
+export function joinUrl(base: string | undefined, rel: string): string {
+  if (!base) return rel;
+  return `${base}${rel}`;
+}
+
+/**
+ * `<outdir>/index.html` 을 읽어 `build(html)` 결과 (`<head>` 직전 / `<script>`
+ * 직전 삽입할 tag string) 를 끼워 넣는다. ENOENT 면 silent skip — dev mode 에서
+ * 아직 entry HTML 이 없을 수 있음.
+ */
+export function injectIntoDevHtml(outdir: string, build: (html: string) => string | null): void {
+  const htmlPath = join(outdir, "index.html");
+  let html: string;
+  try {
+    html = readFileSync(htmlPath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return;
+    throw err;
+  }
+  const tag = build(html);
+  if (!tag) return;
+  const next = html.includes("</head>")
+    ? html.replace("</head>", `${tag}\n</head>`)
+    : html.replace("<script", `${tag}\n<script`);
+  writeFileSync(htmlPath, next);
+}
+
+/** `<script type="module" src="/__zts_app_dev_hmr__"></script>` 를 head 에 1회 삽입. */
+export function injectAppDevHmrClient(outdir: string): void {
+  injectIntoDevHtml(outdir, (html) => {
+    if (html.includes(APP_DEV_HMR_CLIENT_PATH)) return null;
+    return `<script type="module" src="${APP_DEV_HMR_CLIENT_PATH}"></script>`;
+  });
+}
+
+export function injectAppDevBundleCssLinks(
+  outdir: string,
+  base: string | undefined,
+  bundleResult: BundleResult | null | undefined,
+): void {
+  injectIntoDevHtml(outdir, (html) => {
+    const cssHrefs: string[] = [];
+    for (const file of bundleResult?.outputFiles ?? []) {
+      if (!file?.path || !isCssFile(file.path)) continue;
+      const href = joinUrl(base, basename(file.path));
+      if (!html.includes(`href="${href}"`) && !html.includes(`href='${href}'`)) cssHrefs.push(href);
+    }
+    if (cssHrefs.length === 0) return null;
+    return cssHrefs.map((href) => `<link rel="stylesheet" href="${href}">`).join("\n");
+  });
+}
+
+export function injectAppDevPipelineCssLinks(
+  outdir: string,
+  base: string | undefined,
+  cssRelPaths: readonly string[],
+): void {
+  if (cssRelPaths.length === 0) return;
+  injectIntoDevHtml(outdir, (html) => {
+    const tags: string[] = [];
+    for (const rel of cssRelPaths) {
+      const href = joinUrl(base, rel.replaceAll(sep, "/"));
+      if (html.includes(`href="${href}"`) || html.includes(`href='${href}'`)) continue;
+      tags.push(`<link rel="stylesheet" href="${href}">`);
+    }
+    return tags.length === 0 ? null : tags.join("\n");
+  });
+}


### PR DESCRIPTION
## Summary

#2539 epic 의 **PR 4/11**. 기존 zts.mjs 의 브라우저 inject 코드 (~290줄) 와 HTML inject helper (~50줄) 를 `@zts/web` 패키지로 이전. zts CLI 는 dev/preview/build app 모드에서만 `@zts/web` 을 lazy import.

## 신설

| 파일 | 라인 | 역할 |
|---|---|---|
| `packages/web/runtime/dev-overlay-client.mjs` | ~290 | brower-side overlay UI + sourcemap decoder + runtime error capture. `@zts/server` 의 protocol 상수 (APP_DEV_HMR_WS_PATH, HMR_MSG) import 후 template literal 평가. byte-for-byte parity 보존 (escape 한 글자도 sourcemap VLQ 디코더에 영향). |
| `packages/web/runtime/dev-overlay-client.d.mts` | type | string export 단일. |
| `packages/web/src/inject.ts` | ~80 | joinUrl, injectIntoDevHtml, injectAppDevHmrClient, injectAppDevBundleCssLinks, injectAppDevPipelineCssLinks. |
| `packages/web/src/inject.test.ts` | ~200 | **21 케이스** — head/script 분기, 중복 방지 (큰따옴표/작은따옴표), base path, ENOENT silent skip, EISDIR propagate. |

## 수정

### `packages/core/bin/zts.mjs` (대규모 축소)

- L740-812 의 inject 4 함수 (~73줄) 제거 → `@zts/web` 으로
- L814-1106 의 `APP_DEV_HMR_CLIENT` 큰 string (~293줄) 제거 → `@zts/web/runtime/`
- `loadWebModule()` **lazy import wrapper** 추가:
  ```js
  let webModulePromise = null;
  async function loadWebModule() {
    if (webModulePromise) return webModulePromise;
    webModulePromise = (async () => {
      try { return await import(\"@zts/web\"); } catch (err) {
        if (err?.code === \"ERR_MODULE_NOT_FOUND\" ...) {
          console.error(\"error: @zts/web 패키지가 필요합니다 ...\");
          process.exit(1);
        }
        throw err;
      }
    })();
    return webModulePromise;
  }
  ```
- `runAppDev` / `createAppDevController` / `runServe` 에서 lazy import 후 사용. `bundle` / `transpile` / `watch` 모드는 web 의존 0 (사용자가 web 미설치도 동작).

### `packages/server/{tsconfig,package}.json`

server 빌드를 `zts bundle` → `tsc` 만으로 fallback. ZTS bundler 의 두 버그 회피:
- **#2575** — workspace dep (workspace:*) auto-inline 미지원
- **#2576** — `export *` re-export 의 ESM emit 누락

### `packages/server/package.json`

`\"private\": true\"` 제거 → npm publish 가능. README 에 \"internal — 직접 사용 비추\" 명시. ZTS bundler 의 workspace dep inline 지원 시 다시 private 로 (#2575 follow-up).

### `packages/web/package.json`

`@zts/server` external 명시 (publish 시 dependencies 로 사용자에게 자동 이전). `@types/node` devDep 추가.

### root `package.json`

devDeps 에 `@zts/web` 추가 — workspace 환경에서 zts CLI 가 root node_modules 통해 `@zts/web` resolve 가능. publish 측 영향 0 (root 는 private monorepo).

## 발견된 ZTS bundler 버그 — 별도 이슈

| 이슈 | 내용 | 본 PR 의 우회 |
|---|---|---|
| **#2575** | workspace dep (`workspace:*`) auto-inline 못 함. import 가 silent drop → free variable | `@zts/server` 를 publish (private 해제), web 의 build 에 `--external @zts/server` 명시 |
| **#2576** | `export * from \"./x.ts\"` re-export 의 ESM 출력에 export 문 emit 누락 | `@zts/server` 빌드를 `zts bundle` 대신 `tsc` 로 |

두 버그 fix 시 본 PR 의 우회 (private → publish, tsc fallback) 를 다시 ZTS self-host 로 전환 — 1줄 변경.

## /simplify 반영

본 PR 의 변경 면이 큼 (zts.mjs ~360줄 제거 + web 신규 ~570줄). simplify 의 핵심 fix 는 PR 작성 단계에서 이미 적용:
- byte-for-byte parity 보존 (escape, 들여쓰기)
- web 의 inject 가 `@zts/server` 의 single source of truth (`HMR_MSG`, paths) 사용
- `loadWebModule` 의 ERR_MODULE_NOT_FOUND + \"Cannot find package\" 양쪽 가드
- inject.test.ts 의 ENOENT silent skip + EISDIR propagate 양쪽 검증

## 검증

- [x] `bun test packages/web/src/inject.test.ts` 21 케이스 통과
- [x] `bun test --cwd packages/core bin/zts.test.ts` 의 app builder 테스트 통과 (dev/build/preview)
- [x] `bun test packages/server/src/` 67 케이스 (PR #3) 그대로 통과
- [x] `@zts/web` 빌드 산출물 (`dist/index.js`) 에 dev-overlay-client 290줄 inline 확인
- [x] `bun run fmt` 변경 없음

**watch/dev test 의 일부 fail (10건)** — main 도 동일 fail. 본 PR 회귀 아님 (별도 이슈).

## 향후

- **PR #5** — postcss/sass/lightningcss pipeline → `@zts/web/src/style/`. inject.ts 의 inline `isCssFile` 도 그쪽으로 통합
- **PR #6** — zts.mjs 의 dev server 코드 (createAppDevController, createAppDevHmrChannel, runServe) 를 `@zts/server` + `@zts/web` API 위로 cut over. HMR_MSG / APP_DEV_HMR_CLIENT_PATH 같은 zts.mjs 의 잔존 정의 제거

Refs #2539 (4/11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)