### PR TITLE
fix(bundler): emit `export *` re-export in ESM output (#2576)

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -2509,7 +2509,8 @@ pub const Linker = struct {
 
     /// 모듈의 모든 export를 재귀적으로 수집 (export * 체인 포함).
     /// seen: export 이름 dedup, visited: 모듈 수준 dedup (diamond export * 방지).
-    fn collectExportsRecursive(
+    /// metadata.zig 의 `buildFinalExports` (#2576) 도 entry 의 re-export-star 평탄화에 사용.
+    pub fn collectExportsRecursive(
         self: *const Linker,
         exports: *std.ArrayList(NsExportPair),
         seen: *std.StringHashMap(void),

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -758,7 +758,12 @@ pub fn buildMetadataForAst(
     }
 
     // 3. 엔트리 포인트 final exports
-    const final_export_entries = try self.buildFinalExports(is_entry, module_index, m.export_bindings);
+    const final_export_entries = try self.buildFinalExports(
+        is_entry,
+        module_index,
+        m.export_bindings,
+        &owned_nested_renames,
+    );
 
     // 크로스-모듈 상수 인라인: import binding의 canonical export가 상수이면 매핑
     const const_values = try self.buildCrossModuleConstValues(self.getModule(module_index).?, sem);
@@ -887,29 +892,63 @@ pub fn buildRequireRewrites(self: *const Linker, m: *const Module) !std.StringHa
 /// 엔트리 포인트의 최종 export entry를 생성한다.
 /// is_entry가 false이거나 emit 대상 export가 없으면 null 반환. 반환 slice 의
 /// `local`/`exported` 는 모듈 소유 — caller 는 slice 자체만 free.
+///
+/// `export * from "./x"` (re-export-all) 의 경우 source 모듈의 named export 를
+/// `collectExportsRecursive` 로 평탄화해 entry 의 export 로 포함시킨다 (esbuild
+/// 와 rolldown 의 scope-hoisted ESM 동작과 일치). #2576.
+///
+/// `owned_strings` 는 caller 의 `owned_rename_values` (LinkingMetadata 의 owned
+/// slice 영역). collectExportsRecursive 가 NsExportPair.owned=true 를 emit 하는
+/// case (e.g. namespace inline literal 의 안전한 식별자) 시 ownership 을 caller
+/// 로 이전 — LinkingMetadata.deinit 시 free.
 pub fn buildFinalExports(
     self: *const Linker,
     is_entry: bool,
     module_index: u32,
     export_bindings: []const ExportBinding,
+    owned_strings: *std.ArrayListUnmanaged([]const u8),
 ) !?[]const LinkingMetadata.FinalExportEntry {
     if (!is_entry or export_bindings.len == 0) return null;
 
-    // re-export-all / `*` 는 entry export 가 아니므로 skip — len 이 entry 상한.
+    // collectExportsRecursive 가 직접 export + re-export-star 재귀 + diamond/circular
+    // 를 한 번에 평탄화. ESM 스펙 (export * 는 default 제외) 도 처리.
+    var pairs: std.ArrayList(@import("../linker.zig").Linker.NsExportPair) = .empty;
+    defer {
+        // owned=true 가 아직 살아있는 (caller 로 이전 안 된) item 은 여기서 free.
+        // 정상 path 에선 모두 owned=false 로 reset 후 ownership 이전됐어야 함.
+        for (pairs.items) |p| if (p.owned) self.allocator.free(p.local);
+        pairs.deinit(self.allocator);
+    }
+    var seen = std.StringHashMap(void).init(self.allocator);
+    defer seen.deinit();
+    var visited = std.AutoHashMap(u32, void).init(self.allocator);
+    defer visited.deinit();
+
+    try self.collectExportsRecursive(
+        &pairs,
+        &seen,
+        &visited,
+        @enumFromInt(module_index),
+        0,
+    );
+
+    if (pairs.items.len == 0) return null;
+
     var entries: std.ArrayListUnmanaged(LinkingMetadata.FinalExportEntry) = .empty;
     errdefer entries.deinit(self.allocator);
-    try entries.ensureTotalCapacityPrecise(self.allocator, export_bindings.len);
-    for (export_bindings) |eb| {
-        if (eb.kind.isReExportAll()) continue;
-        if (std.mem.eql(u8, eb.exported_name, "*")) continue;
+    try entries.ensureTotalCapacityPrecise(self.allocator, pairs.items.len);
+    for (pairs.items) |*p| {
+        // owned=true 는 buildInlineObjectStr 가 만든 namespace inline literal.
+        // ownership 을 caller 의 owned_rename_values 로 이전해 LinkingMetadata.deinit
+        // 시 free 되도록 — entries 의 .local 은 그 slice 를 borrow.
+        if (p.owned) {
+            try owned_strings.append(self.allocator, p.local);
+            p.owned = false;
+        }
         entries.appendAssumeCapacity(.{
-            .local = self.getCanonicalForExport(eb, module_index),
-            .exported = eb.exported_name,
+            .local = p.local,
+            .exported = p.exported,
         });
-    }
-    if (entries.items.len == 0) {
-        entries.deinit(self.allocator);
-        return null;
     }
     return try entries.toOwnedSlice(self.allocator);
 }
@@ -1421,7 +1460,17 @@ pub fn buildMetadata(self: *const Linker, module_index: u32, is_entry: bool) !Li
     }
 
     // 5. 엔트리 포인트: final exports
-    const final_export_entries = try self.buildFinalExports(is_entry, module_index, m.export_bindings);
+    var owned_rename_values: std.ArrayListUnmanaged([]const u8) = .empty;
+    errdefer {
+        for (owned_rename_values.items) |v| self.allocator.free(v);
+        owned_rename_values.deinit(self.allocator);
+    }
+    const final_export_entries = try self.buildFinalExports(
+        is_entry,
+        module_index,
+        m.export_bindings,
+        &owned_rename_values,
+    );
 
     return .{
         .skip_nodes = skip_nodes,
@@ -1429,6 +1478,7 @@ pub fn buildMetadata(self: *const Linker, module_index: u32, is_entry: bool) !Li
         .final_exports = null,
         .final_export_entries = final_export_entries,
         .symbol_ids = sem.symbol_ids,
+        .owned_rename_values = owned_rename_values,
         .allocator = self.allocator,
     };
 }

--- a/tests/integration/tests/export-star-emit.test.ts
+++ b/tests/integration/tests/export-star-emit.test.ts
@@ -1,0 +1,145 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { build, close, init } from "../../../packages/core/index";
+import { createFixture } from "./helpers";
+
+// #2576 — entry 의 `export *` re-export 가 ESM 출력에 정확히 평탄화되는지 검증.
+// rolldown / esbuild 와 동일한 scope-hoisted 평탄화 (`export { a, b, c }` 단일 문).
+
+describe("export * re-export ESM emit (#2576)", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  beforeAll(() => init());
+  afterAll(() => close());
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  test("entry 의 export * from internal 이 평탄화된 ESM exports 로 emit", async () => {
+    const fixture = await createFixture({
+      "package.json": '{"type":"module"}',
+      "src/index.ts": `export * from "./hmr.ts";\nexport const v = 1;\n`,
+      "src/hmr.ts": `export const HMR_MSG = "hmr";\nexport function tick() {}\n`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "src/index.ts")],
+      outfile: join(fixture.dir, "dist/index.js"),
+      format: "esm",
+      target: "node",
+      write: true,
+    });
+    expect(result.errors.length).toBe(0);
+
+    const out = readFileSync(join(fixture.dir, "dist/index.js"), "utf8");
+    expect(out).toContain("export {");
+    expect(out).toContain("HMR_MSG");
+    expect(out).toContain("tick");
+    expect(out).toContain("v");
+  });
+
+  test("nested export * chain (a → b → c) 도 끝까지 평탄화", async () => {
+    const fixture = await createFixture({
+      "package.json": '{"type":"module"}',
+      "src/index.ts": `export * from "./a.ts";\n`,
+      "src/a.ts": `export * from "./b.ts";\n`,
+      "src/b.ts": `export * from "./c.ts";\n`,
+      "src/c.ts": `export const leaf = 42;\n`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "src/index.ts")],
+      outfile: join(fixture.dir, "dist/index.js"),
+      format: "esm",
+      target: "node",
+      write: true,
+    });
+    expect(result.errors.length).toBe(0);
+
+    const out = readFileSync(join(fixture.dir, "dist/index.js"), "utf8");
+    expect(out).toContain("leaf");
+  });
+
+  test("export * 의 default 는 ESM 스펙대로 제외", async () => {
+    const fixture = await createFixture({
+      "package.json": '{"type":"module"}',
+      "src/index.ts": `export * from "./b.ts";\n`,
+      "src/b.ts": `export default 1;\nexport const x = 2;\n`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "src/index.ts")],
+      outfile: join(fixture.dir, "dist/index.js"),
+      format: "esm",
+      target: "node",
+      write: true,
+    });
+    expect(result.errors.length).toBe(0);
+
+    const out = readFileSync(join(fixture.dir, "dist/index.js"), "utf8");
+    expect(out).toContain("x");
+    // export * 는 default 제외 — ECMAScript 15.2.3.5
+    const exportMatch = out.match(/export\s*\{([^}]+)\}/);
+    if (exportMatch) {
+      expect(exportMatch[1]).not.toMatch(/\bdefault\b/);
+    }
+  });
+
+  test("entry 의 직접 export 와 export * 의 이름 충돌 시 entry 가 우선 (first-wins)", async () => {
+    const fixture = await createFixture({
+      "package.json": '{"type":"module"}',
+      "src/index.ts": `export const foo = "from-entry";\nexport * from "./b.ts";\n`,
+      "src/b.ts": `export const foo = "from-b";\nexport const bar = "from-b";\n`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "src/index.ts")],
+      outfile: join(fixture.dir, "dist/index.js"),
+      format: "esm",
+      target: "node",
+      write: true,
+    });
+    expect(result.errors.length).toBe(0);
+
+    const out = readFileSync(join(fixture.dir, "dist/index.js"), "utf8");
+    // bar 는 b 의 export 가 평탄화되어 들어옴
+    expect(out).toContain("bar");
+    // foo 는 entry 의 정의가 우선 (collectExportsRecursive 의 seen first-wins)
+    expect(out).toContain("from-entry");
+  });
+
+  test("diamond export * (a → b, a → c, b/c → d) 에서 d 의 export 1회만", async () => {
+    const fixture = await createFixture({
+      "package.json": '{"type":"module"}',
+      "src/index.ts": `export * from "./b.ts";\nexport * from "./c.ts";\n`,
+      "src/b.ts": `export * from "./d.ts";\n`,
+      "src/c.ts": `export * from "./d.ts";\n`,
+      "src/d.ts": `export const shared = 99;\n`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "src/index.ts")],
+      outfile: join(fixture.dir, "dist/index.js"),
+      format: "esm",
+      target: "node",
+      write: true,
+    });
+    expect(result.errors.length).toBe(0);
+
+    const out = readFileSync(join(fixture.dir, "dist/index.js"), "utf8");
+    expect(out).toContain("shared");
+    // visited map 으로 중복 방문 방지 — `shared` export 가 단 한 번만
+    const matches = out.match(/\bshared\b/g) ?? [];
+    // 평탄화된 export { ... } 안에 1회 + declaration 1회 정도. 2~3회 이내.
+    expect(matches.length).toBeLessThanOrEqual(3);
+  });
+});


### PR DESCRIPTION
## Summary

#2576 의 **root cause fix**. entry 의 `export *` re-export 가 ESM 출력에 emit 안 되던 버그. esbuild / rolldown 과 동일한 scope-hoisted ESM 평탄화 동작.

## Root Cause

`src/bundler/linker/metadata.zig:903-904` 의 `buildFinalExports` 가 re-export-all 바인딩을 **무조건 skip**:
```zig
if (eb.kind.isReExportAll()) continue;  // ← 모든 export * drop
if (std.mem.eql(u8, eb.exported_name, \"*\")) continue;
```

→ `final_export_entries` 가 비어 entry 의 ESM 출력 끝에 export 문 자체가 emit 안 됨.

사용자 영향: `import { X } from \"@my-lib\"` 시 `SyntaxError: Export named X not found in module ...`.

## Fix

기존에 검증된 DFS `collectExportsRecursive` (linker.zig:2512) 를 재사용 — 직접 export + re-export-star 재귀 + diamond/circular + ESM `default` 제외를 한 번에 처리.

```zig
pub fn buildFinalExports(
    self: *const Linker,
    is_entry: bool,
    module_index: u32,
    export_bindings: []const ExportBinding,
    owned_strings: *std.ArrayListUnmanaged([]const u8),
) !?[]const LinkingMetadata.FinalExportEntry {
    if (!is_entry or export_bindings.len == 0) return null;

    var pairs: std.ArrayList(...) = .empty;
    defer { ... }
    var seen = std.StringHashMap(void).init(self.allocator);
    defer seen.deinit();
    var visited = std.AutoHashMap(u32, void).init(self.allocator);
    defer visited.deinit();

    try self.collectExportsRecursive(&pairs, &seen, &visited, ...);

    // owned=true (namespace inline literal) 는 caller 의 owned_rename_values 로
    // ownership 이전 → LinkingMetadata.deinit 시 free.
    for (pairs.items) |*p| {
        if (p.owned) {
            try owned_strings.append(self.allocator, p.local);
            p.owned = false;
        }
        entries.appendAssumeCapacity(.{ .local = p.local, .exported = p.exported });
    }
}
```

## 변경 사항

| 파일 | 변경 |
|---|---|
| `src/bundler/linker.zig` | `collectExportsRecursive` → `pub` (재사용 노출) |
| `src/bundler/linker/metadata.zig` | `buildFinalExports` 재구현 — collectExportsRecursive 활용 + owned_strings 인자 |
| `src/bundler/linker/metadata.zig` | 두 caller (`buildMetadataForAst` L761, `buildMetadata` L1463) 갱신 |
| `tests/integration/tests/export-star-emit.test.ts` | 5 케이스 신규 |

## Edge Case 처리

| 케이스 | 처리 |
|---|---|
| Nested chain (`a → b → c`) | `collectExportsRecursive` 재귀로 자동 |
| Diamond (`a → b, a → c, b/c → d`) | `visited` map 중복 방문 방지 |
| 충돌 (entry 와 source 의 같은 이름) | `seen` first-wins — **entry 우선** (ESM 스펙 일치) |
| Default 제외 | `seen` 에 \"default\" 등록 (ECMAScript 15.2.3.5) |
| Owned namespace inline literal | `owned_strings` 로 ownership 이전 (메모리 누수 0) |

## Tests — 5 integration 케이스

`tests/integration/tests/export-star-emit.test.ts`:
1. `entry 의 export * from internal 이 평탄화된 ESM exports 로 emit`
2. `nested export * chain (a → b → c) 도 끝까지 평탄화`
3. `export * 의 default 는 ESM 스펙대로 제외`
4. `entry 의 직접 export 와 export * 의 이름 충돌 시 entry 가 우선 (first-wins)`
5. `diamond export * (a → b, a → c, b/c → d) 에서 d 의 export 1회만`

## 검증

- [x] `zig build test` 통과 (회귀 0)
- [x] `bun test --cwd packages/core bin/zts.test.ts` 222 pass / 0 fail
- [x] `bun test packages/server/src/` 67 pass (기존)
- [x] `bun test packages/web/src/` 21 pass (기존)
- [x] `bun test tests/integration/tests/export-star-emit.test.ts` **5 pass**
- [x] **실제 효과**: `bun run --cwd packages/server build` 후 `dist/index.js` 끝에 `export { HMR_MSG, APP_DEV_HMR_CLIENT_PATH, ... }` 정확히 emit

## 참고 도구 동작

| 번들러 | 동작 |
|---|---|
| **esbuild** | scope-hoisted ESM 평탄화 (동일) |
| **rolldown** | 동일 (scope-hoisting + symbol linking) |
| **bun build** | rollup-호환 entry export preservation |

본 fix 는 esbuild/rolldown 과 동일한 평탄화 — 표준 동작 정합.

## 후속

- #2575 (workspace dep auto-inline) — 별도 fix
- #2539 PR #4 의 server 우회 (`private:true` 제거 + `tsc` fallback) → 본 fix 후 cleanup PR 으로 plan 원복

Closes #2576

🤖 Generated with [Claude Code](https://claude.com/claude-code)