### PR TITLE
chore(packages): restore @zts/server private + zts self-build (post #2576)

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,8 +1,8 @@
-# @zts/server
+# @zts/server (internal)
 
-ZTS 의 internal server layer. **`@zts/web` / `@zts/react-native` 가 의존성으로 사용** — 사용자가 직접 install 할 일 없음.
+ZTS 의 internal server layer. **private 패키지** (`"private": true`) — npm 에 publish 되지 않습니다.
 
-> 공개 npm 패키지지만 의도는 internal 라이브러리. ZTS bundler 가 workspace dep auto-inline 을 지원하기 전까지의 임시 노출 — 후속에 다시 private 로 전환 예정 (#2539).
+`@zts/web` / `@zts/react-native` 빌드 시 dist 에 자동 inline 되어, 외부에 별도 패키지로 노출되지 않습니다 (#2576 fix 후 ZTS bundler 의 workspace dep auto-inline 정상 동작).
 
 ## 역할
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@zts/server",
   "version": "0.1.0",
-  "description": "ZTS internal server layer (HMR protocol, WS frame, watcher, TLS) — @zts/web · @zts/react-native 가 dep 으로 사용. 직접 install 비추",
+  "private": true,
+  "description": "ZTS internal server layer — HMR protocol, WS frame, watcher, TLS",
   "license": "MIT",
   "files": [
     "dist/",
@@ -17,7 +18,9 @@
     }
   },
   "scripts": {
-    "build": "bun x tsc",
+    "build:bundle": "node ../core/bin/zts.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --external @zts/core",
+    "build:dts": "bun x tsc --emitDeclarationOnly",
+    "build": "bun run build:bundle && bun run build:dts",
     "test": "bun test"
   },
   "dependencies": {

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "declarationDir": "dist",
-    "emitDeclarationOnly": false
+    "declarationDir": "dist"
   },
   "include": ["src/**/*"],
   "exclude": ["src/**/*.test.ts"]

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -17,7 +17,7 @@
     }
   },
   "scripts": {
-    "build:bundle": "node ../core/bin/zts.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --external @zts/core --external @zts/server --external lightningcss --external postcss --external postcss-load-config --external sass",
+    "build:bundle": "node ../core/bin/zts.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --external @zts/core --external lightningcss --external postcss --external postcss-load-config --external sass",
     "build:dts": "bun x tsc --emitDeclarationOnly",
     "build": "bun run build:bundle && bun run build:dts",
     "test": "bun test"


### PR DESCRIPTION
## Summary

#2539 PR #4 의 임시 우회를 plan 원복. #2576 fix 후 ZTS bundler 의 workspace dep auto-inline 이 정상 동작 — server 가 다시 internal (private) 패키지로 web/dist 에 자동 inline.

## 복원

| 파일 | 변경 |
|---|---|
| `packages/server/package.json` | `\"private\": true\"` 복원 (npm 미공개), build script 를 `zts self-build` (zts bundle + tsc) 로 되돌림 |
| `packages/server/tsconfig.json` | `emitDeclarationOnly: false` override 제거 (core 의 default true 사용 — dts 만 emit, js 는 zts bundle) |
| `packages/server/README.md` | \"공개 npm 패키지지만 internal\" → \"private 패키지로 npm 미공개, web/RN dist 에 자동 inline\" |
| `packages/web/package.json` | build:bundle 의 `--external @zts/server` 제거. workspace dep auto-inline 으로 server 의 export 가 web/dist 에 inline |

## 검증

- [x] `packages/server` 빌드 (zts bundle) → `dist/index.js` 끝에 `export { HMR_MSG, APP_DEV_HMR_CLIENT_PATH, ... }` 정상 emit
- [x] `packages/web` 빌드 (server external 명시 안 함) → server 의 코드 inline 확인:
  ```bash
  $ grep -c \"HMR_MSG\\|258EAFA5\\|sec-websocket-key\" packages/web/dist/index.js
  5
  ```
- [x] `bun test --cwd packages/core bin/zts.test.ts`: 222 pass / 0 fail
- [x] `bun test packages/server/src/`: 67 pass
- [x] `bun test packages/web/src/`: 21 pass

## 관련

- #2576 (export * ESM emit fix) — 본 cleanup 의 토대
- #2575 (workspace dep auto-inline) — #2576 fix 와 함께 자동 해결, close

Refs #2539 (PR #4 cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)