### PR TITLE
feat(web): extract css-parser.ts (low-level CSS scanner) (5a/5e)

### DIFF
--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -9,5 +9,12 @@ export {
   injectIntoDevHtml,
   joinUrl,
 } from "./inject.ts";
+export {
+  isCssIdent,
+  isCssIdentStart,
+  skipCssString,
+  skipCssUrl,
+  startsWithCssIdent,
+} from "./style/css-parser.ts";
 // dev-overlay-client 는 .mjs 라 별도 export — 브라우저 inject 용 string.
 export { APP_DEV_HMR_CLIENT } from "../runtime/dev-overlay-client.mjs";

--- a/packages/web/src/style/css-parser.test.ts
+++ b/packages/web/src/style/css-parser.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isCssIdent,
+  isCssIdentStart,
+  skipCssString,
+  skipCssUrl,
+  startsWithCssIdent,
+} from "./css-parser.ts";
+
+describe("skipCssString", () => {
+  test("정상 종료 quote 까지 skip", () => {
+    const css = `"hello"end`;
+    // 0=" 1=h ... 6=" → return 7
+    expect(skipCssString(css, 0, '"')).toBe(7);
+  });
+
+  test("escape sequence 는 1 단위로 skip", () => {
+    const css = `"a\\"b"end`; // a\"b
+    expect(skipCssString(css, 0, '"')).toBe(6);
+  });
+
+  test("닫히지 않은 string 은 css 끝까지", () => {
+    expect(skipCssString(`"oops`, 0, '"')).toBe(5);
+  });
+
+  test("끝에 backslash 만 있어도 안전", () => {
+    expect(skipCssString(`"a\\`, 0, '"')).toBe(3);
+  });
+
+  test("작은따옴표 quote", () => {
+    expect(skipCssString(`'x'after`, 0, "'")).toBe(3);
+  });
+
+  test("내부 다른 quote 는 skip 대상 아님", () => {
+    expect(skipCssString(`"can't"x`, 0, '"')).toBe(7);
+  });
+});
+
+describe("skipCssUrl", () => {
+  test("plain url() 의 ) 다음 위치", () => {
+    const css = `url(./a.png) end`;
+    // start=4 (url( 다음). a.png) → ) at index 11, return 12
+    expect(skipCssUrl(css, 4)).toBe(12);
+  });
+
+  test("인용된 url 도 정상 처리", () => {
+    const css = `url("./a)b.png") end`;
+    expect(skipCssUrl(css, 4)).toBe(16);
+  });
+
+  test("작은따옴표 인용된 url", () => {
+    const css = `url('./a)b.png') end`;
+    expect(skipCssUrl(css, 4)).toBe(16);
+  });
+
+  test("닫히지 않은 url 은 css 끝까지", () => {
+    expect(skipCssUrl(`url(broken`, 4)).toBe(10);
+  });
+
+  test("escaped quote 는 string 시작 아님", () => {
+    const css = `url(a\\"b)c`;
+    expect(skipCssUrl(css, 4)).toBe(9);
+  });
+});
+
+describe("startsWithCssIdent", () => {
+  test("정확 일치", () => {
+    expect(startsWithCssIdent("@import xxx", 0, "@import")).toBe(true);
+  });
+
+  test("case-insensitive", () => {
+    expect(startsWithCssIdent("@IMPORT", 0, "@import")).toBe(true);
+    expect(startsWithCssIdent("@Import", 0, "@import")).toBe(true);
+  });
+
+  test("offset 적용", () => {
+    expect(startsWithCssIdent("xxx@import", 3, "@import")).toBe(true);
+  });
+
+  test("불일치", () => {
+    expect(startsWithCssIdent("@imp", 0, "@import")).toBe(false);
+    expect(startsWithCssIdent("@export", 0, "@import")).toBe(false);
+  });
+});
+
+describe("isCssIdentStart", () => {
+  test("underscore", () => {
+    expect(isCssIdentStart("_")).toBe(true);
+  });
+
+  test("대문자 A-Z", () => {
+    expect(isCssIdentStart("A")).toBe(true);
+    expect(isCssIdentStart("Z")).toBe(true);
+    expect(isCssIdentStart("M")).toBe(true);
+  });
+
+  test("소문자 a-z", () => {
+    expect(isCssIdentStart("a")).toBe(true);
+    expect(isCssIdentStart("z")).toBe(true);
+  });
+
+  test("숫자 거부", () => {
+    expect(isCssIdentStart("0")).toBe(false);
+    expect(isCssIdentStart("9")).toBe(false);
+  });
+
+  test("hyphen 거부 (start 아님)", () => {
+    expect(isCssIdentStart("-")).toBe(false);
+  });
+
+  test("공백 / 특수문자", () => {
+    expect(isCssIdentStart(" ")).toBe(false);
+    expect(isCssIdentStart("@")).toBe(false);
+    expect(isCssIdentStart(".")).toBe(false);
+  });
+});
+
+describe("isCssIdent", () => {
+  test("ident-start 전부 통과", () => {
+    expect(isCssIdent("_")).toBe(true);
+    expect(isCssIdent("A")).toBe(true);
+    expect(isCssIdent("z")).toBe(true);
+  });
+
+  test("hyphen 통과 (start 아닌 위치)", () => {
+    expect(isCssIdent("-")).toBe(true);
+  });
+
+  test("숫자 통과", () => {
+    expect(isCssIdent("0")).toBe(true);
+    expect(isCssIdent("5")).toBe(true);
+    expect(isCssIdent("9")).toBe(true);
+  });
+
+  test("공백 / 특수문자 거부", () => {
+    expect(isCssIdent(" ")).toBe(false);
+    expect(isCssIdent("@")).toBe(false);
+    expect(isCssIdent(".")).toBe(false);
+  });
+});

--- a/packages/web/src/style/css-parser.ts
+++ b/packages/web/src/style/css-parser.ts
@@ -1,0 +1,52 @@
+// CSS low-level scanner — postcss/sass/css-modules pipeline 의 공통 helper.
+// platform-agnostic 이지만 web 의 dev pipeline 안에서만 사용되므로 web 의 style/
+// 디렉토리에 자리잡음. zts.mjs 의 동등 함수 (L1177-1213) 는 PR #5e (css-modules
+// 추출) 시점에 본 모듈 import 로 redirect 후 zts.mjs 잔존본 제거.
+
+/**
+ * `start` 가 가리키는 css string literal 끝 다음 위치 반환. `\` escape 와
+ * 종료 quote 를 인식. 닫히지 않은 문자열은 css 끝까지 skip.
+ */
+export function skipCssString(css: string, start: number, quote: string): number {
+  let i = start + 1;
+  while (i < css.length) {
+    if (css[i] === "\\" && i + 1 < css.length) {
+      i += 2;
+      continue;
+    }
+    if (css[i] === quote) return i + 1;
+    i += 1;
+  }
+  return css.length;
+}
+
+/**
+ * `url(...)` 안의 끝 `)` 다음 위치 반환. 인용된 url 도 string skip 으로 안전 처리.
+ */
+export function skipCssUrl(css: string, start: number): number {
+  let i = start;
+  while (i < css.length) {
+    if ((css[i] === '"' || css[i] === "'") && css[i - 1] !== "\\") {
+      i = skipCssString(css, i, css[i]!);
+      continue;
+    }
+    if (css[i] === ")") return i + 1;
+    i += 1;
+  }
+  return css.length;
+}
+
+/** `css` 의 `offset` 부터 `value` 와 case-insensitive 일치하는지 확인. */
+export function startsWithCssIdent(css: string, offset: number, value: string): boolean {
+  return css.slice(offset, offset + value.length).toLowerCase() === value;
+}
+
+/** CSS identifier 시작 가능 문자 (`_`, `A-Z`, `a-z`). */
+export function isCssIdentStart(ch: string): boolean {
+  return ch === "_" || (ch >= "A" && ch <= "Z") || (ch >= "a" && ch <= "z");
+}
+
+/** CSS identifier 내부 가능 문자 (시작 문자 + `-` + `0-9`). */
+export function isCssIdent(ch: string): boolean {
+  return isCssIdentStart(ch) || ch === "-" || (ch >= "0" && ch <= "9");
+}


### PR DESCRIPTION
## Summary

#2539 epic 의 **PR 5a/5e** (css pipeline 분리 sub-PR 1/5). zts.mjs L1177-1213 의 low-level CSS scanner 5 함수를 `@zts/web/src/style/css-parser.ts` 로 추출. 의존 0 — sub-PR 시리즈 시작점.

## 신설

| 파일 | 라인 | 역할 |
|---|---|---|
| `packages/web/src/style/css-parser.ts` | ~50 | `skipCssString`, `skipCssUrl`, `startsWithCssIdent`, `isCssIdentStart`, `isCssIdent` |
| `packages/web/src/style/css-parser.test.ts` | ~150 | **25 케이스** — escape, unclosed, case-insensitive, boundary |

## 수정

- `packages/web/src/index.ts` — re-export 추가

## 점진적 마이그레이션

zts.mjs 의 동등 함수 정의 (L1177-1213) 는 일시 잔존. **PR #5e** (css-modules 추출) 에서 본 모듈 import 로 redirect 후 zts.mjs 정의 제거 — duplicate 35줄 일시적, sub-PR 5e 까지.

## 검증

- [x] `bun test packages/web/src/style/css-parser.test.ts`: **25 pass / 0 fail**
- [x] `packages/web` 빌드 후 `dist/index.js` 에 5 함수 정상 inline (grep `skipCssString|isCssIdentStart` = 5)
- [x] `packages/core/bin/zts.test.ts`: 222 pass / 0 fail (회귀 0)
- [x] `bun run fmt` 변경 없음

Refs #2539 (5a/5e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)