### PR TITLE
chore: /simplify follow-ups for #2578 / #2580

### DIFF
--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -1174,6 +1174,10 @@ function scanCssModuleClassTokens(css) {
   return tokens;
 }
 
+// 다음 5 함수 (skipCssString / skipCssUrl / startsWithCssIdent / isCssIdentStart /
+// isCssIdent) 는 packages/web/src/style/css-parser.ts 에 동등 사본이 있다.
+// PR #5e (css-modules 추출) 시점에 본 정의를 import 로 redirect 후 제거 — 그
+// 전까지 logic 변경 시 양쪽을 동시에 수정 (#2539).
 function skipCssString(css, start, quote) {
   let i = start + 1;
   while (i < css.length) {

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -2509,7 +2509,6 @@ pub const Linker = struct {
 
     /// 모듈의 모든 export를 재귀적으로 수집 (export * 체인 포함).
     /// seen: export 이름 dedup, visited: 모듈 수준 dedup (diamond export * 방지).
-    /// metadata.zig 의 `buildFinalExports` (#2576) 도 entry 의 re-export-star 평탄화에 사용.
     pub fn collectExportsRecursive(
         self: *const Linker,
         exports: *std.ArrayList(NsExportPair),

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -894,8 +894,8 @@ pub fn buildRequireRewrites(self: *const Linker, m: *const Module) !std.StringHa
 /// `local`/`exported` 는 모듈 소유 — caller 는 slice 자체만 free.
 ///
 /// `export * from "./x"` (re-export-all) 의 경우 source 모듈의 named export 를
-/// `collectExportsRecursive` 로 평탄화해 entry 의 export 로 포함시킨다 (esbuild
-/// 와 rolldown 의 scope-hoisted ESM 동작과 일치). #2576.
+/// `collectExportsRecursive` 로 평탄화해 entry 의 export 로 포함시킨다 — ECMAScript
+/// 15.2.3.5 의 default 제외 규정 포함. scope-hoisted ESM 출력 (#2576).
 ///
 /// `owned_strings` 는 caller 의 `owned_rename_values` (LinkingMetadata 의 owned
 /// slice 영역). collectExportsRecursive 가 NsExportPair.owned=true 를 emit 하는

--- a/tests/integration/tests/export-star-emit.test.ts
+++ b/tests/integration/tests/export-star-emit.test.ts
@@ -5,7 +5,22 @@ import { build, close, init } from "../../../packages/core/index";
 import { createFixture } from "./helpers";
 
 // #2576 — entry 의 `export *` re-export 가 ESM 출력에 정확히 평탄화되는지 검증.
-// rolldown / esbuild 와 동일한 scope-hoisted 평탄화 (`export { a, b, c }` 단일 문).
+// scope-hoisted 평탄화 (`export { a, b, c }` 단일 문).
+
+/** dist/index.js 에서 ESM `export { internal as exported }` 의 외부 노출 이름 set. */
+function extractExportNames(out: string): Set<string> {
+  const match = out.match(/export\s*\{([^}]+)\}/);
+  if (!match) return new Set();
+  return new Set(
+    match[1]
+      .split(",")
+      .map((s) => {
+        const parts = s.trim().split(/\s+as\s+/);
+        return parts[parts.length - 1]!.trim();
+      })
+      .filter((s) => s.length > 0),
+  );
+}
 
 describe("export * re-export ESM emit (#2576)", () => {
   let cleanup: (() => Promise<void>) | undefined;
@@ -37,10 +52,7 @@ describe("export * re-export ESM emit (#2576)", () => {
     expect(result.errors.length).toBe(0);
 
     const out = readFileSync(join(fixture.dir, "dist/index.js"), "utf8");
-    expect(out).toContain("export {");
-    expect(out).toContain("HMR_MSG");
-    expect(out).toContain("tick");
-    expect(out).toContain("v");
+    expect(extractExportNames(out)).toEqual(new Set(["HMR_MSG", "tick", "v"]));
   });
 
   test("nested export * chain (a → b → c) 도 끝까지 평탄화", async () => {
@@ -63,7 +75,7 @@ describe("export * re-export ESM emit (#2576)", () => {
     expect(result.errors.length).toBe(0);
 
     const out = readFileSync(join(fixture.dir, "dist/index.js"), "utf8");
-    expect(out).toContain("leaf");
+    expect(extractExportNames(out)).toEqual(new Set(["leaf"]));
   });
 
   test("export * 의 default 는 ESM 스펙대로 제외", async () => {
@@ -84,12 +96,8 @@ describe("export * re-export ESM emit (#2576)", () => {
     expect(result.errors.length).toBe(0);
 
     const out = readFileSync(join(fixture.dir, "dist/index.js"), "utf8");
-    expect(out).toContain("x");
-    // export * 는 default 제외 — ECMAScript 15.2.3.5
-    const exportMatch = out.match(/export\s*\{([^}]+)\}/);
-    if (exportMatch) {
-      expect(exportMatch[1]).not.toMatch(/\bdefault\b/);
-    }
+    // ECMAScript 15.2.3.5 — export * 는 default 제외.
+    expect(extractExportNames(out)).toEqual(new Set(["x"]));
   });
 
   test("entry 의 직접 export 와 export * 의 이름 충돌 시 entry 가 우선 (first-wins)", async () => {
@@ -110,9 +118,13 @@ describe("export * re-export ESM emit (#2576)", () => {
     expect(result.errors.length).toBe(0);
 
     const out = readFileSync(join(fixture.dir, "dist/index.js"), "utf8");
-    // bar 는 b 의 export 가 평탄화되어 들어옴
-    expect(out).toContain("bar");
-    // foo 는 entry 의 정의가 우선 (collectExportsRecursive 의 seen first-wins)
+    // entry 의 foo 가 우선. b 의 foo 는 `seen` first-wins 로 entry export 에 못
+    // 들어가지만 module 전체 scope 안에선 충돌 회피용 rename (`foo$1` 등) 가 본문에
+    // 잔존 가능. 확인할 invariant 는 (a) `foo` 가 export 됨, (b) entry 값 ("from-
+    // entry") 이 산출에 있음, (c) bar 도 entry export 에 포함.
+    const names = extractExportNames(out);
+    expect(names.has("foo")).toBe(true);
+    expect(names.has("bar")).toBe(true);
     expect(out).toContain("from-entry");
   });
 
@@ -136,10 +148,53 @@ describe("export * re-export ESM emit (#2576)", () => {
     expect(result.errors.length).toBe(0);
 
     const out = readFileSync(join(fixture.dir, "dist/index.js"), "utf8");
-    expect(out).toContain("shared");
-    // visited map 으로 중복 방문 방지 — `shared` export 가 단 한 번만
-    const matches = out.match(/\bshared\b/g) ?? [];
-    // 평탄화된 export { ... } 안에 1회 + declaration 1회 정도. 2~3회 이내.
-    expect(matches.length).toBeLessThanOrEqual(3);
+    // visited map 으로 중복 방문 방지 — d 의 `shared` export 가 export 문에 1회만.
+    expect(extractExportNames(out)).toEqual(new Set(["shared"]));
+  });
+
+  // namespace re-export 가 entry 의 export 로 들어오는 경우 — collectExportsRecursive
+  // 가 NsExportPair.ns_target_mod 를 채우는 path. buildFinalExports 의 평탄화에서
+  // namespace 객체 자체를 emit (선언은 emitter 의 ns_inline / hoisting 단계가 처리).
+  test("entry 의 `export * as ns from ./x` 는 ns 자체를 named export 로 emit", async () => {
+    const fixture = await createFixture({
+      "package.json": '{"type":"module"}',
+      "src/index.ts": `export * as helpers from "./helpers.ts";\n`,
+      "src/helpers.ts": `export const a = 1;\nexport const b = 2;\n`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "src/index.ts")],
+      outfile: join(fixture.dir, "dist/index.js"),
+      format: "esm",
+      target: "node",
+      write: true,
+    });
+    expect(result.errors.length).toBe(0);
+
+    const out = readFileSync(join(fixture.dir, "dist/index.js"), "utf8");
+    // helpers 가 entry 의 export 로 들어옴 — 단일 namespace 이름으로 평탄화.
+    expect(extractExportNames(out)).toEqual(new Set(["helpers"]));
+  });
+
+  test("entry 의 `import * as ns from ./x; export { ns }` 도 ns 1개 export", async () => {
+    const fixture = await createFixture({
+      "package.json": '{"type":"module"}',
+      "src/index.ts": `import * as utils from "./utils.ts";\nexport { utils };\n`,
+      "src/utils.ts": `export const x = 1;\n`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, "src/index.ts")],
+      outfile: join(fixture.dir, "dist/index.js"),
+      format: "esm",
+      target: "node",
+      write: true,
+    });
+    expect(result.errors.length).toBe(0);
+
+    const out = readFileSync(join(fixture.dir, "dist/index.js"), "utf8");
+    expect(extractExportNames(out)).toEqual(new Set(["utils"]));
   });
 });


### PR DESCRIPTION
## Summary

3 PR (#2578 export * fix, #2579 server cleanup, #2580 css-parser) 의 `/simplify` 3-agent 리뷰 후 발견된 5 항목 fix.

## Findings + Fix

### 1. 외부 출처 표기 제거 (CLAUDE.md `feedback_no_reference_comments`)

`src/bundler/linker/metadata.zig:898` 의 `buildFinalExports` docstring 에서 외부 번들러 이름 제거. 코드 주석에서 외부 출처 표기는 금지 (PR/커밋 메시지에만). \"ECMAScript 15.2.3.5 default 제외 규정 + scope-hoisted ESM 출력\" 만 유지.

### 2. `collectExportsRecursive` caller-list 주석 제거

`linker.zig:2510-2512` 의 \"metadata.zig 의 buildFinalExports (#2576) 도 사용\" 같은 caller enumerate 제거. `pub` 자체로 reuse 의도 충분, grep 가 호출처 추적.

### 3. `ns_target_mod` 회귀 zone 테스트 2 케이스 추가 (Agent 1 가장 중요한 발견)

`buildFinalExports` 가 `NsExportPair.ns_target_mod` 를 통해 namespace re-export 케이스도 entry export 평탄화에 포함되는지 검증:
- `entry 의 export * as ns from \"./x\"` 가 ns 자체를 named export
- `import * as ns; export { ns }` 도 동등 동작

### 4. Integration test assertion 강화

`expect(out).toContain(\"export {\")` 같은 약한 assertion → `extractExportNames(out)` helper 로 정확한 names set 비교. ESM `export { internal as exported }` 의 외부 노출 이름 (after `as`) 만 추출. 5 케이스 (기본/nested/default 제외/diamond/충돌) 모두 set 검증으로 강화.

### 5. zts.mjs ↔ css-parser.ts duplicate marker

`packages/core/bin/zts.mjs:1177` 위 주석 추가 — PR #5e 까지의 일시 duplicate 35줄 의 drift 위험 mitigation. 한쪽 수정 시 다른 쪽 동시 수정 또는 #5e 로 dedup 명시.

## 보류 (false positive 또는 별도 이슈)

- `owned` mutation 패턴 — 동작 정확, 우선순위 낮음
- `linker.zig:2529` `ns_imports` 재할당 — pre-existing, 별도 이슈
- `toLowerCase()` slice alloc — pre-existing, 측정 후 결정

## 검증

- [x] `zig build test` 회귀 0
- [x] `bun test --cwd packages/core bin/zts.test.ts`: 222 pass / 0 fail
- [x] `bun test tests/integration/tests/export-star-emit.test.ts`: **7 pass** (5 → 7, ns_target_mod 2 케이스 추가)
- [x] `bun run fmt` 변경 없음

Refs #2539, #2576

🤖 Generated with [Claude Code](https://claude.com/claude-code)