### PR TITLE
feat(web): extract loader.ts (requireFromAppOrFallback + collectAppFiles) (5b/5e)

### DIFF
--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -988,6 +988,10 @@ function cleanupPostcssTempRoot(tempRoot) {
   rmSync(tempRoot, { recursive: true, force: true });
 }
 
+// 다음 2 함수 (requireFromAppOrCli / collectAppFiles) 는 packages/web/src/style/
+// loader.ts 에 동등 사본이 있다 (시그니처는 cli context 제거 — fallbackRequire 인자).
+// PR #5e (css-modules 추출) 시점에 본 정의를 web 으로 redirect 후 제거 — 그 전까지
+// logic 변경 시 양쪽을 동시에 수정 (#2539).
 function requireFromAppOrCli(requireFromRoot, specifier) {
   try {
     return requireFromRoot(specifier);
@@ -998,20 +1002,32 @@ function requireFromAppOrCli(requireFromRoot, specifier) {
   }
 }
 
-function collectAppFiles(dir, { skipDir = null, predicate = () => true } = {}) {
-  if (!existsSync(dir)) return [];
-  const skipResolved = skipDir ? resolve(skipDir) : null;
-  const files = [];
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+function readEntriesOrEmpty(dir) {
+  try {
+    return readdirSync(dir, { withFileTypes: true });
+  } catch (err) {
+    if (err?.code === "ENOENT") return [];
+    throw err;
+  }
+}
+
+function walkAppFiles(dir, skipResolved, predicate, out) {
+  for (const entry of readEntriesOrEmpty(dir)) {
     if (entry.name === "node_modules" || entry.name === ".git") continue;
     const path = join(dir, entry.name);
     if (entry.isDirectory()) {
       if (skipResolved && resolve(path) === skipResolved) continue;
-      files.push(...collectAppFiles(path, { skipDir, predicate }));
+      walkAppFiles(path, skipResolved, predicate, out);
     } else if (entry.isFile() && predicate(path)) {
-      files.push(path);
+      out.push(path);
     }
   }
+}
+
+function collectAppFiles(dir, { skipDir = null, predicate = () => true } = {}) {
+  const skipResolved = skipDir ? resolve(skipDir) : null;
+  const files = [];
+  walkAppFiles(dir, skipResolved, predicate, files);
   return files;
 }
 

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -16,5 +16,10 @@ export {
   skipCssUrl,
   startsWithCssIdent,
 } from "./style/css-parser.ts";
+export {
+  collectAppFiles,
+  type CollectAppFilesOptions,
+  requireFromAppOrFallback,
+} from "./style/loader.ts";
 // dev-overlay-client 는 .mjs 라 별도 export — 브라우저 inject 용 string.
 export { APP_DEV_HMR_CLIENT } from "../runtime/dev-overlay-client.mjs";

--- a/packages/web/src/style/loader.test.ts
+++ b/packages/web/src/style/loader.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { collectAppFiles, requireFromAppOrFallback } from "./loader.ts";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "zts-loader-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("requireFromAppOrFallback", () => {
+  test("app require 성공 시 그 결과", () => {
+    const appRequire = mock((s: string) => `app:${s}`);
+    const fallback = mock((s: string) => `fallback:${s}`);
+    expect(requireFromAppOrFallback(appRequire, fallback, "x")).toBe("app:x");
+    expect(appRequire).toHaveBeenCalledTimes(1);
+    expect(fallback).toHaveBeenCalledTimes(0);
+  });
+
+  test("app 의 MODULE_NOT_FOUND 시 fallback", () => {
+    const appRequire = mock((_s: string) => {
+      const err = new Error("missing") as NodeJS.ErrnoException;
+      err.code = "MODULE_NOT_FOUND";
+      throw err;
+    });
+    const fallback = mock((s: string) => `fallback:${s}`);
+    expect(requireFromAppOrFallback(appRequire, fallback, "x")).toBe("fallback:x");
+    expect(fallback).toHaveBeenCalledTimes(1);
+  });
+
+  test("ERR_MODULE_NOT_FOUND (ESM) 도 fallback", () => {
+    const appRequire = mock((_s: string) => {
+      const err = new Error("esm missing") as NodeJS.ErrnoException;
+      err.code = "ERR_MODULE_NOT_FOUND";
+      throw err;
+    });
+    const fallback = mock(() => "fb");
+    expect(requireFromAppOrFallback(appRequire, fallback, "x")).toBe("fb");
+  });
+
+  test("그 외 에러는 propagate (fallback 호출 안 함)", () => {
+    const appRequire = mock((_s: string) => {
+      throw new TypeError("syntax error in app require");
+    });
+    const fallback = mock(() => "fb");
+    expect(() => requireFromAppOrFallback(appRequire, fallback, "x")).toThrow(TypeError);
+    expect(fallback).toHaveBeenCalledTimes(0);
+  });
+
+  test("err.code undefined 도 propagate (silent fallback 회피)", () => {
+    const appRequire = mock((_s: string) => {
+      throw new Error("plain error");
+    });
+    const fallback = mock(() => "fb");
+    expect(() => requireFromAppOrFallback(appRequire, fallback, "x")).toThrow();
+    expect(fallback).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe("collectAppFiles", () => {
+  function touch(rel: string, content = ""): string {
+    const path = join(dir, rel);
+    mkdirSync(join(path, ".."), { recursive: true });
+    writeFileSync(path, content);
+    return path;
+  }
+
+  test("존재하지 않는 디렉토리는 빈 배열", () => {
+    expect(collectAppFiles(join(dir, "nope"))).toEqual([]);
+  });
+
+  test("재귀 walk + 모든 파일 수집 (default predicate)", () => {
+    touch("a.txt");
+    touch("sub/b.txt");
+    touch("sub/deep/c.txt");
+    const files = collectAppFiles(dir);
+    expect(files.sort()).toEqual(
+      [join(dir, "a.txt"), join(dir, "sub/b.txt"), join(dir, "sub/deep/c.txt")].sort(),
+    );
+  });
+
+  test("node_modules 와 .git 은 자동 skip", () => {
+    touch("a.ts");
+    touch("node_modules/dep/index.js");
+    touch(".git/HEAD");
+    const files = collectAppFiles(dir);
+    expect(files).toEqual([join(dir, "a.ts")]);
+  });
+
+  test("predicate 가 false 인 파일은 제외", () => {
+    touch("a.ts");
+    touch("b.css");
+    touch("sub/c.ts");
+    const files = collectAppFiles(dir, {
+      predicate: (p) => p.endsWith(".ts"),
+    }).sort();
+    expect(files).toEqual([join(dir, "a.ts"), join(dir, "sub/c.ts")].sort());
+  });
+
+  test("skipDir 이 일치하는 sub-tree 는 walk 안 함", () => {
+    touch("a.ts");
+    touch("dist/out.js");
+    touch("dist/inner/x.js");
+    const files = collectAppFiles(dir, { skipDir: join(dir, "dist") });
+    expect(files).toEqual([join(dir, "a.ts")]);
+  });
+
+  test("ENOTDIR 같은 IO 에러는 propagate (silent swallow X)", () => {
+    touch("not-a-dir.txt");
+    expect(() => collectAppFiles(join(dir, "not-a-dir.txt"))).toThrow();
+  });
+
+  test("빈 디렉토리는 빈 배열", () => {
+    expect(collectAppFiles(dir)).toEqual([]);
+  });
+});

--- a/packages/web/src/style/loader.ts
+++ b/packages/web/src/style/loader.ts
@@ -1,0 +1,79 @@
+import { type Dirent, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+interface NodeRequire {
+  (specifier: string): unknown;
+}
+
+/**
+ * App 의 `require` 로 먼저 시도, MODULE_NOT_FOUND 발생 시 fallback `require` 로
+ * 재시도. zts dev/build pipeline 의 plugin / preprocessor 로딩 (postcss/sass 등)
+ * 에서 \"app deps 우선, CLI deps fallback\" 패턴을 명시화.
+ */
+export function requireFromAppOrFallback(
+  requireFromApp: NodeRequire,
+  fallbackRequire: NodeRequire,
+  specifier: string,
+): unknown {
+  try {
+    return requireFromApp(specifier);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code !== "MODULE_NOT_FOUND" && code !== "ERR_MODULE_NOT_FOUND") throw err;
+    return fallbackRequire(specifier);
+  }
+}
+
+export interface CollectAppFilesOptions {
+  /** 이 디렉토리 (절대 또는 상대 경로) 와 일치하는 sub-tree 는 walk 안 함. */
+  skipDir?: string | null;
+  /** file 마다 호출, true 면 결과에 포함. default: 모든 파일 포함. */
+  predicate?: (path: string) => boolean;
+}
+
+const RETURN_TRUE = (): boolean => true;
+
+/**
+ * 디렉토리 entries 를 안전하게 read. ENOENT (디렉토리 없음) 만 빈 배열로 swallow,
+ * 그 외 (ENOTDIR/EACCES 등) 는 propagate. existsSync TOCTOU 회피 + 중복 stat 제거.
+ */
+function readEntriesOrEmpty(dir: string): Dirent[] {
+  try {
+    return readdirSync(dir, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+}
+
+function walkFiles(
+  dir: string,
+  skipResolved: string | null,
+  predicate: (path: string) => boolean,
+  out: string[],
+): void {
+  for (const entry of readEntriesOrEmpty(dir)) {
+    if (entry.name === "node_modules" || entry.name === ".git") continue;
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (skipResolved && resolve(path) === skipResolved) continue;
+      walkFiles(path, skipResolved, predicate, out);
+    } else if (entry.isFile() && predicate(path)) {
+      out.push(path);
+    }
+  }
+}
+
+/**
+ * `dir` 의 모든 파일을 재귀적으로 수집. `node_modules` 와 `.git` 은 자동 skip.
+ * 파일 시스템 IO 만 사용 — 외부 모듈 의존 없음.
+ *
+ * @returns 디렉토리가 없으면 빈 배열 (ENOENT silent). ENOTDIR/EACCES 등 다른 IO 에러는 throw.
+ */
+export function collectAppFiles(dir: string, options: CollectAppFilesOptions = {}): string[] {
+  const skipResolved = options.skipDir ? resolve(options.skipDir) : null;
+  const predicate = options.predicate ?? RETURN_TRUE;
+  const files: string[] = [];
+  walkFiles(dir, skipResolved, predicate, files);
+  return files;
+}


### PR DESCRIPTION
## Summary

#2539 epic 의 **PR 5b/5e** (css pipeline 분리 sub-PR 2/5). zts.mjs 의 require/file walk helper 2 함수를 `@zts/web/src/style/loader.ts` 로 추출. cli context 의존 제거 — fallbackRequire 인자로 명시화.

## 신설

| 파일 | 라인 | 역할 |
|---|---|---|
| `packages/web/src/style/loader.ts` | ~80 | `requireFromAppOrFallback`, `collectAppFiles` + helper |
| `packages/web/src/style/loader.test.ts` | ~120 | **12 케이스** |

## /simplify 반영 (3-agent 5 findings → fix)

| # | Finding | Fix | 위치 |
|---|---|---|---|
| 1 | **`existsSync` TOCTOU + ENOTDIR silent swallow** (Agent 1+3, 가장 강력) | `readdirSync` try/catch ENOENT 패턴. 그 외 (ENOTDIR/EACCES) propagate | loader.ts + zts.mjs **양쪽 동시** |
| 2 | 재귀 매 frame `resolve(skipDir)` + `(() => true)` 재할당 (Agent 3) | inner `walkFiles` helper — 한 번만 계산 | 양쪽 동시 |
| 3 | `files.push(...recurse)` spread alloc/GC (Agent 3) | walkFiles 가 같은 array 에 직접 push | 양쪽 동시 |
| 4 | \"IO 외\" 주석 모호 (Agent 2) | \"파일 시스템 IO 만 사용 — 외부 모듈 의존 없음\" + JSDoc 으로 ENOENT/ENOTDIR 명시 | loader.ts |
| 5 | 중복 테스트 케이스 (Agent 2) | 한 케이스로 합치고 **ENOTDIR propagate 검증** 추가 | loader.test.ts |

**root cause fix** — 사용자 \"임시 우회 X\" 강조 따라 zts.mjs 의 동등 함수도 동시 수정.

## 보류 (별도 follow-up)

- **`isModuleNotFound` (zts.mjs:33) 의미 중복** (Agent 1) — PR #5e 에서 dedup 시 정리
- 다른 file walker (size-gap.ts / workspace.ts / tests/integration helpers) 와 통합 — 별도 epic

## 검증

- [x] `bun test packages/web/src/style/loader.test.ts`: **12 pass / 0 fail**
- [x] `packages/web` 빌드 → 두 함수 inline 확인 (grep `collectAppFiles|requireFromAppOrFallback` = 4)
- [x] `bun test --cwd packages/core bin/zts.test.ts`: 222 pass / 0 fail (회귀 0)
- [x] `bun run fmt` 변경 없음

Refs #2539 (5b/5e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)