### PR TITLE
feat(web): extract postcss.ts + url.ts (5c/5e)

### DIFF
--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -884,6 +884,11 @@ function writeWsText(socket, text) {
   socket.write(Buffer.concat([header, payload]));
 }
 
+// 다음 영역 (POSTCSS_CONFIG_NAMES / findPostcssConfig / isPostcssConfigFile /
+// isCssFile / loadPostcssConfig / collectPostcssMessages / logPostcssProcessed /
+// runPostcssIfConfigured / runPostcssForAppDev) 은 packages/web/src/style/
+// postcss.ts 에 동등 사본이 있다. PR #5e 시점에 본 정의를 web 으로 redirect 후
+// 제거 — 그 전까지 logic 변경 시 양쪽을 동시에 수정 (#2539).
 const POSTCSS_CONFIG_NAMES = [
   "postcss.config.mjs",
   "postcss.config.js",

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -7,8 +7,8 @@ export {
   injectAppDevHmrClient,
   injectAppDevPipelineCssLinks,
   injectIntoDevHtml,
-  joinUrl,
 } from "./inject.ts";
+export { joinUrl } from "./url.ts";
 export {
   isCssIdent,
   isCssIdentStart,
@@ -21,5 +21,19 @@ export {
   type CollectAppFilesOptions,
   requireFromAppOrFallback,
 } from "./style/loader.ts";
+export {
+  type AppDevPostcssOptions,
+  type AppDevPostcssResult,
+  collectPostcssMessages,
+  findPostcssConfig,
+  isCssFile,
+  isPostcssConfigFile,
+  loadPostcssConfig,
+  logPostcssProcessed,
+  type PostcssMessage,
+  POSTCSS_CONFIG_NAMES,
+  runPostcssForAppDev,
+  runPostcssIfConfigured,
+} from "./style/postcss.ts";
 // dev-overlay-client 는 .mjs 라 별도 export — 브라우저 inject 용 string.
 export { APP_DEV_HMR_CLIENT } from "../runtime/dev-overlay-client.mjs";

--- a/packages/web/src/inject.test.ts
+++ b/packages/web/src/inject.test.ts
@@ -8,8 +8,8 @@ import {
   injectAppDevHmrClient,
   injectAppDevPipelineCssLinks,
   injectIntoDevHtml,
-  joinUrl,
 } from "./inject.ts";
+import { joinUrl } from "./url.ts";
 
 let outdir: string;
 let htmlPath: string;

--- a/packages/web/src/inject.ts
+++ b/packages/web/src/inject.ts
@@ -3,19 +3,15 @@ import { basename, join, sep } from "node:path";
 
 import { APP_DEV_HMR_CLIENT_PATH } from "@zts/server";
 
+import { isCssFile } from "./style/postcss.ts";
+import { joinUrl } from "./url.ts";
+
 interface BundleOutputFile {
   path?: string;
 }
 
 export interface BundleResult {
   outputFiles?: readonly BundleOutputFile[];
-}
-
-const isCssFile = (path: string): boolean => path.endsWith(".css");
-
-export function joinUrl(base: string | undefined, rel: string): string {
-  if (!base) return rel;
-  return `${base}${rel}`;
 }
 
 /**

--- a/packages/web/src/style/postcss.test.ts
+++ b/packages/web/src/style/postcss.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  collectPostcssMessages,
+  findPostcssConfig,
+  isCssFile,
+  isPostcssConfigFile,
+  logPostcssProcessed,
+  POSTCSS_CONFIG_NAMES,
+} from "./postcss.ts";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "zts-postcss-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function touch(rel: string, content = ""): string {
+  const path = join(dir, rel);
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, content);
+  return path;
+}
+
+describe("POSTCSS_CONFIG_NAMES", () => {
+  test("zts.mjs L892-902 와 동일 순서/내용", () => {
+    expect([...POSTCSS_CONFIG_NAMES]).toEqual([
+      "postcss.config.mjs",
+      "postcss.config.js",
+      "postcss.config.cjs",
+      "postcss.config.json",
+      ".postcssrc",
+      ".postcssrc.json",
+      ".postcssrc.js",
+      ".postcssrc.cjs",
+      ".postcssrc.mjs",
+    ]);
+  });
+});
+
+describe("isCssFile", () => {
+  test(".css 만 true", () => {
+    expect(isCssFile("a.css")).toBe(true);
+    expect(isCssFile("/abs/path/a.css")).toBe(true);
+  });
+
+  test("그 외 false", () => {
+    expect(isCssFile("a.scss")).toBe(false);
+    expect(isCssFile("a.module.css.map")).toBe(false);
+    expect(isCssFile("a.tsx")).toBe(false);
+    expect(isCssFile("")).toBe(false);
+  });
+});
+
+describe("isPostcssConfigFile", () => {
+  test("표준 config 파일들 true", () => {
+    expect(isPostcssConfigFile("/x/postcss.config.mjs")).toBe(true);
+    expect(isPostcssConfigFile("postcss.config.cjs")).toBe(true);
+    expect(isPostcssConfigFile("/repo/.postcssrc")).toBe(true);
+    expect(isPostcssConfigFile("/repo/.postcssrc.json")).toBe(true);
+  });
+
+  test("그 외 false", () => {
+    expect(isPostcssConfigFile("postcss.config.txt")).toBe(false);
+    expect(isPostcssConfigFile("postcssrc")).toBe(false);
+    expect(isPostcssConfigFile("a.css")).toBe(false);
+  });
+});
+
+describe("findPostcssConfig", () => {
+  test("같은 디렉토리에 config 있으면 절대 path", () => {
+    touch("postcss.config.js", "module.exports = {};");
+    expect(findPostcssConfig(dir)).toBe(join(dir, "postcss.config.js"));
+  });
+
+  test("부모 디렉토리는 walk 안 함 (zts.mjs 동작과 일치)", () => {
+    touch("postcss.config.cjs");
+    mkdirSync(join(dir, "sub/deep"), { recursive: true });
+    // sub/deep 에서는 못 찾음 — single dir lookup.
+    expect(findPostcssConfig(join(dir, "sub/deep"))).toBe(null);
+  });
+
+  test("우선순위: postcss.config.* → .postcssrc → .postcssrc.*", () => {
+    touch(".postcssrc.json");
+    touch("postcss.config.js");
+    // POSTCSS_CONFIG_NAMES 의 postcss.config.js 가 .postcssrc.json 보다 우선.
+    expect(findPostcssConfig(dir)).toBe(join(dir, "postcss.config.js"));
+  });
+
+  test("config 없으면 null", () => {
+    expect(findPostcssConfig(dir)).toBe(null);
+  });
+});
+
+describe("collectPostcssMessages", () => {
+  test("dependency 메시지 → deps 에 추가", () => {
+    const deps = new Set<string>();
+    const dirDeps = new Set<string>();
+    collectPostcssMessages([{ type: "dependency", file: "/a/b.css" }], deps, dirDeps);
+    expect(deps.has(join("/a/b.css"))).toBe(true);
+    expect(dirDeps.size).toBe(0);
+  });
+
+  test("dir-dependency 메시지 → dirDeps", () => {
+    const deps = new Set<string>();
+    const dirDeps = new Set<string>();
+    collectPostcssMessages([{ type: "dir-dependency", dir: "/a" }], deps, dirDeps);
+    expect(dirDeps.has(join("/a"))).toBe(true);
+  });
+
+  test("dir-dependency 의 directory alias 도 인식", () => {
+    const deps = new Set<string>();
+    const dirDeps = new Set<string>();
+    collectPostcssMessages([{ type: "dir-dependency", directory: "/x" }], deps, dirDeps);
+    expect(dirDeps.has(join("/x"))).toBe(true);
+  });
+
+  test("context-dependency → deps", () => {
+    const deps = new Set<string>();
+    const dirDeps = new Set<string>();
+    collectPostcssMessages([{ type: "context-dependency", file: "/c.css" }], deps, dirDeps);
+    expect(deps.has(join("/c.css"))).toBe(true);
+  });
+
+  test("알 수 없는 type 무시", () => {
+    const deps = new Set<string>();
+    const dirDeps = new Set<string>();
+    collectPostcssMessages([{ type: "warning", file: "/a.css" }], deps, dirDeps);
+    expect(deps.size).toBe(0);
+    expect(dirDeps.size).toBe(0);
+  });
+
+  test("file/dir 가 string 아니면 skip", () => {
+    const deps = new Set<string>();
+    const dirDeps = new Set<string>();
+    collectPostcssMessages(
+      [
+        { type: "dependency", file: 123 as unknown as string },
+        { type: "dir-dependency", dir: undefined },
+      ],
+      deps,
+      dirDeps,
+    );
+    expect(deps.size).toBe(0);
+    expect(dirDeps.size).toBe(0);
+  });
+
+  test("null/undefined 메시지도 안전 — 빈 set 반환", () => {
+    const deps = new Set<string>();
+    const dirDeps = new Set<string>();
+    collectPostcssMessages(null, deps, dirDeps);
+    collectPostcssMessages(undefined, deps, dirDeps);
+    expect(deps.size).toBe(0);
+    expect(dirDeps.size).toBe(0);
+  });
+
+  test("여러 메시지 동시 누적 (dedup 자동)", () => {
+    const deps = new Set<string>();
+    const dirDeps = new Set<string>();
+    collectPostcssMessages(
+      [
+        { type: "dependency", file: "/a.css" },
+        { type: "dependency", file: "/a.css" },
+        { type: "dir-dependency", dir: "/d" },
+      ],
+      deps,
+      dirDeps,
+    );
+    expect(deps.size).toBe(1);
+    expect(dirDeps.size).toBe(1);
+  });
+});
+
+describe("logPostcssProcessed", () => {
+  let originalError: typeof console.error;
+  let captured: string[];
+
+  beforeEach(() => {
+    originalError = console.error;
+    captured = [];
+    console.error = (msg: string) => captured.push(msg);
+  });
+
+  afterEach(() => {
+    console.error = originalError;
+  });
+
+  test("logLevel silent 이면 출력 없음", () => {
+    logPostcssProcessed("silent", 5, "/x/postcss.config.js");
+    expect(captured.length).toBe(0);
+  });
+
+  test("logLevel undefined 이면 출력", () => {
+    logPostcssProcessed(undefined, 3, "/x/postcss.config.js");
+    expect(captured[0]).toContain("processed 3");
+    expect(captured[0]).toContain("postcss.config.js");
+  });
+
+  test("configFile null 이면 fallback 표시", () => {
+    logPostcssProcessed(undefined, 1, null);
+    expect(captured[0]).toContain("postcss config");
+  });
+});

--- a/packages/web/src/style/postcss.ts
+++ b/packages/web/src/style/postcss.ts
@@ -1,0 +1,242 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { basename, dirname, join, relative, resolve } from "node:path";
+
+import { joinUrl } from "../url.ts";
+import { collectAppFiles, requireFromAppOrFallback } from "./loader.ts";
+
+interface NodeRequire {
+  (specifier: string): unknown;
+}
+
+// 순서는 zts.mjs L892-902 와 동일 — postcss.config.* 이 .postcssrc.* 보다 우선.
+// PR #5e 의 redirect 시점까지 양쪽 sync 유지 (#2539).
+export const POSTCSS_CONFIG_NAMES: readonly string[] = [
+  "postcss.config.mjs",
+  "postcss.config.js",
+  "postcss.config.cjs",
+  "postcss.config.json",
+  ".postcssrc",
+  ".postcssrc.json",
+  ".postcssrc.js",
+  ".postcssrc.cjs",
+  ".postcssrc.mjs",
+];
+
+export const isCssFile = (path: string): boolean => path.endsWith(".css");
+
+export function isPostcssConfigFile(path: string): boolean {
+  return POSTCSS_CONFIG_NAMES.includes(basename(path));
+}
+
+/** `root` 디렉토리에 postcss config 가 있으면 절대 path 반환, 없으면 null. */
+export function findPostcssConfig(root: string): string | null {
+  for (const name of POSTCSS_CONFIG_NAMES) {
+    const path = join(root, name);
+    if (existsSync(path)) return path;
+  }
+  return null;
+}
+
+export interface PostcssMessage {
+  type?: string;
+  file?: unknown;
+  dir?: unknown;
+  directory?: unknown;
+}
+
+/** postcss result.messages 에서 dep 트래킹용 file/dir 항목을 set 에 누적. */
+export function collectPostcssMessages(
+  messages: readonly PostcssMessage[] | null | undefined,
+  deps: Set<string>,
+  dirDeps: Set<string>,
+): void {
+  if (!messages) return;
+  for (const message of messages) {
+    if (message.type === "dependency" && typeof message.file === "string") {
+      deps.add(resolve(message.file));
+    }
+    if (message.type === "dir-dependency") {
+      const dir =
+        (typeof message.dir === "string" && message.dir) ||
+        (typeof message.directory === "string" && message.directory);
+      if (dir) dirDeps.add(resolve(dir));
+    }
+    if (message.type === "context-dependency" && typeof message.file === "string") {
+      deps.add(resolve(message.file));
+    }
+  }
+}
+
+export function logPostcssProcessed(
+  logLevel: string | undefined,
+  count: number,
+  configFile: string | null | undefined,
+): void {
+  if (logLevel === "silent") return;
+  console.error(
+    `[postcss] processed ${count} CSS file(s) using ${basename(configFile ?? "postcss config")}`,
+  );
+}
+
+interface LoadedPostcss {
+  postcss: (plugins: unknown[]) => {
+    process: (input: string, options: unknown) => Promise<PostcssResult>;
+  };
+  plugins: unknown[];
+  options: Record<string, unknown>;
+  configFile: string | null;
+}
+
+interface PostcssResult {
+  css: string;
+  map?: { toString(): string };
+  messages?: PostcssMessage[];
+}
+
+interface PostcssrcConfig {
+  plugins?: unknown[];
+  options?: Record<string, unknown>;
+  file?: string;
+}
+
+interface ConfigEnv {
+  mode: string;
+}
+
+/**
+ * postcss + postcss-load-config 를 app-first / fallback-second 로 require 후
+ * config 로드. config 없거나 plugin 0 이면 null.
+ *
+ * `fallbackRequire` 는 caller 의 CLI context — postcss/postcss-load-config 를
+ * app 이 갖지 않을 때 fallback (e.g. ZTS CLI 의 node_modules).
+ */
+export async function loadPostcssConfig(
+  root: string,
+  configEnv: ConfigEnv,
+  fallbackRequire: NodeRequire,
+): Promise<LoadedPostcss | null> {
+  const requireFromRoot = createRequire(join(root, "package.json")) as unknown as NodeRequire;
+  const postcssrc = requireFromAppOrFallback(
+    requireFromRoot,
+    fallbackRequire,
+    "postcss-load-config",
+  ) as (env: { cwd: string; env: string }, root: string) => Promise<PostcssrcConfig>;
+  const postcssModule = requireFromAppOrFallback(requireFromRoot, fallbackRequire, "postcss") as {
+    default?: LoadedPostcss["postcss"];
+  } & LoadedPostcss["postcss"];
+  const postcss = (postcssModule.default ?? postcssModule) as LoadedPostcss["postcss"];
+  const config = await postcssrc({ cwd: root, env: configEnv.mode }, root).catch((err) => {
+    if ((err as { message?: string })?.message?.includes("No PostCSS Config found")) return null;
+    throw err;
+  });
+  if (!config) return null;
+  const plugins = config.plugins ?? [];
+  if (plugins.length === 0) return null;
+  return {
+    postcss,
+    plugins,
+    options: config.options ?? {},
+    configFile: config.file ?? null,
+  };
+}
+
+/**
+ * `cssDir` 의 모든 CSS 파일 (skipDir 제외) 에 postcss 실행 → in-place 덮어쓰기.
+ * postcss config 가 없으면 no-op. `runPostcssForAppDev` 와 달리 outdir 분리 안 함.
+ */
+export async function runPostcssIfConfigured(
+  root: string,
+  cssDir: string,
+  skipDir: string | null,
+  configEnv: ConfigEnv,
+  logLevel: string | undefined,
+  fallbackRequire: NodeRequire,
+): Promise<void> {
+  const loaded = await loadPostcssConfig(root, configEnv, fallbackRequire);
+  if (!loaded) return;
+  const cssFiles = collectAppFiles(cssDir, { skipDir, predicate: isCssFile });
+  await Promise.all(
+    cssFiles.map(async (file) => {
+      const input = readFileSync(file, "utf8");
+      const result = await loaded.postcss(loaded.plugins).process(input, {
+        ...loaded.options,
+        from: file,
+        to: file,
+      });
+      writeFileSync(file, result.css);
+      if (result.map) writeFileSync(`${file}.map`, result.map.toString());
+    }),
+  );
+  logPostcssProcessed(logLevel, cssFiles.length, loaded.configFile);
+}
+
+export interface AppDevPostcssOptions {
+  root: string;
+  outdir: string;
+  configEnv: ConfigEnv;
+  logLevel: string | undefined;
+  base: string | undefined;
+  changedPath?: string | null;
+  fallbackRequire: NodeRequire;
+}
+
+export interface AppDevPostcssResult {
+  deps: Set<string>;
+  dirDeps: Set<string>;
+  primaryHref: string | null;
+  processed: number;
+}
+
+/**
+ * Dev 모드 — `root` 의 CSS 파일들을 `outdir` 의 같은 rel path 로 emit (postcss
+ * pipeline 적용). config 없으면 첫 CSS 의 primaryHref 만 반환. 단일 변경 (.css)
+ * 이면 해당 파일만 reprocess, 그 외엔 전체.
+ */
+export async function runPostcssForAppDev(
+  options: AppDevPostcssOptions,
+): Promise<AppDevPostcssResult> {
+  const { root, outdir, configEnv, logLevel, base, changedPath = null, fallbackRequire } = options;
+  const deps = new Set<string>();
+  const dirDeps = new Set<string>();
+  let primaryHref: string | null = null;
+  const configPath = findPostcssConfig(root);
+  if (!configPath) {
+    const first = collectAppFiles(root, { skipDir: outdir, predicate: isCssFile })[0];
+    if (first) primaryHref = joinUrl(base, relative(root, first));
+    return { deps, dirDeps, primaryHref, processed: 0 };
+  }
+
+  const loaded = await loadPostcssConfig(root, configEnv, fallbackRequire);
+  if (!loaded) return { deps, dirDeps, primaryHref, processed: 0 };
+  deps.add(resolve(loaded.configFile ?? configPath));
+
+  mkdirSync(outdir, { recursive: true });
+  const allCssFiles = collectAppFiles(root, { skipDir: outdir, predicate: isCssFile });
+  const targets =
+    changedPath && changedPath.endsWith(".css") && allCssFiles.includes(changedPath)
+      ? [changedPath]
+      : allCssFiles;
+
+  await Promise.all(
+    targets.map(async (file) => {
+      const outputRel = relative(root, file);
+      const outputPath = join(outdir, outputRel);
+      mkdirSync(dirname(outputPath), { recursive: true });
+      const input = readFileSync(file, "utf8");
+      const result = await loaded.postcss(loaded.plugins).process(input, {
+        ...loaded.options,
+        from: file,
+        to: outputPath,
+      });
+      writeFileSync(outputPath, result.css);
+      if (result.map) writeFileSync(`${outputPath}.map`, result.map.toString());
+      deps.add(resolve(file));
+      collectPostcssMessages(result.messages, deps, dirDeps);
+    }),
+  );
+  if (allCssFiles.length > 0) primaryHref = joinUrl(base, relative(root, allCssFiles[0]!));
+
+  logPostcssProcessed(logLevel, targets.length, loaded.configFile);
+  return { deps, dirDeps, primaryHref, processed: targets.length };
+}

--- a/packages/web/src/url.ts
+++ b/packages/web/src/url.ts
@@ -1,0 +1,5 @@
+/** dev server / postcss / inject 공통 — base + rel path concat URL helper. */
+export function joinUrl(base: string | undefined, rel: string): string {
+  if (!base) return rel;
+  return `${base}${rel}`;
+}


### PR DESCRIPTION
## Summary

#2539 epic 의 **PR 5c/5e** (css pipeline 분리 sub-PR 3/5). zts.mjs 의 postcss config + load + run pipeline 9 함수와 joinUrl 을 web 으로 추출. circular dep 회피 위해 joinUrl 별도 url.ts 로 분리.

## 신설

| 파일 | 라인 | 역할 |
|---|---|---|
| `packages/web/src/url.ts` | ~5 | joinUrl 단일 (inject + postcss 공용) |
| `packages/web/src/style/postcss.ts` | ~250 | 9 함수 + 4 type. fallbackRequire 인자로 cli context 제거 |
| `packages/web/src/style/postcss.test.ts` | ~210 | **20 케이스** |

## /simplify 반영 (3-agent 후 4 fix)

| # | Finding | Fix |
|---|---|---|
| 1 | **`isCssFile` 중복 (블로커)** — inject.ts + postcss.ts 양쪽 정의 → dist 에 `isCssFile + isCssFile$1` 두 번 emit | inject.ts 가 postcss.ts 에서 import. **dedup 검증**: `grep -c \"function isCssFile\" = 1` |
| 2 | `findPostcssConfig` parent walk **동작 회귀** — zts.mjs 원본은 single dir lookup. 우리가 parent walk 추가했음 | parent walk 제거. 외부 monorepo config 자동 적용 위험 회피 |
| 3 | `POSTCSS_CONFIG_NAMES` 순서 회귀 — `.ts` 추가 + 다른 순서 | zts.mjs L892-902 와 정확히 sync (postcss.config.* → .postcssrc → .postcssrc.*). `.ts` 제거 |
| 4 | `joinUrl` DI over-engineering | url.ts 별도 모듈로 추출 (circular 회피 root fix) — postcss/inject 둘 다 import |

## 보류 (별도 follow-up)

- generic `<T>` requireFromAppOrFallback (as 캐스트 줄이기)
- POSTCSS_CONFIG_NAMES 확장 (`.cts/.mts/.yaml/.yml/package.json`) — zts.mjs 와 함께 sync
- test fixture 공통화 — sass/css-modules PR 후 일괄

## 검증

- [x] `bun test packages/web/src/style/postcss.test.ts`: **20 pass / 0 fail**
- [x] `bun test packages/web/src/`: **78 pass / 0 fail** (4 파일)
- [x] `bun test --cwd packages/core bin/zts.test.ts`: 222 pass / 0 fail (회귀 0)
- [x] `dist/index.js` 의 `isCssFile` 정의 1회만 emit (회귀 해소)
- [x] `bun run fmt` 변경 없음

Refs #2539 (5c/5e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)