### PR TITLE
feat(web): extract sass.ts + requireFromAppRoot helper (5d/5e)

### DIFF
--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -1039,6 +1039,12 @@ function collectAppFiles(dir, { skipDir = null, predicate = () => true } = {}) {
 const isCssFile = (path) => path.endsWith(".css");
 const isPostcssConfigFile = (path) => POSTCSS_CONFIG_NAMES.includes(basename(path));
 
+// 다음 영역 (CSS_PREPROCESSOR_EXTENSIONS / MODULE_PREPROCESSOR_RE / Sass helper 9
+// 함수: isCssPreprocessorFile, isCssModulePreprocessorFile, cssPreprocessorOutputPath,
+// cssPreprocessorProxyPath, loadSassCompiler, compileSassFile, rewriteSassReferences,
+// isStyleReferenceSource, buildCssPreprocessorProxy, transformCssPreprocessors) 은
+// packages/web/src/style/sass.ts 에 동등 사본이 있다. PR #5e 시점에 본 정의를
+// web 으로 redirect 후 제거 — 그 전까지 logic 변경 시 양쪽을 동시에 수정 (#2539).
 const CSS_PREPROCESSOR_EXTENSIONS = new Set([".scss", ".sass"]);
 const MODULE_PREPROCESSOR_RE = /\.module\.(?:scss|sass)$/;
 
@@ -1051,7 +1057,8 @@ function isCssModulePreprocessorFile(path) {
 }
 
 function cssPreprocessorOutputPath(file) {
-  return file.replace(/\.(?:scss|sass)$/i, ".css");
+  // case-sensitive — `isCssPreprocessorFile` (extname 기준 case-sensitive) gate 와 일치.
+  return file.replace(/\.(?:scss|sass)$/, ".css");
 }
 
 function cssPreprocessorProxyPath(file) {

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -35,5 +35,19 @@ export {
   runPostcssForAppDev,
   runPostcssIfConfigured,
 } from "./style/postcss.ts";
+export {
+  buildCssPreprocessorProxy,
+  CSS_PREPROCESSOR_EXTENSIONS,
+  compileSassFile,
+  cssPreprocessorOutputPath,
+  cssPreprocessorProxyPath,
+  isCssModulePreprocessorFile,
+  isCssPreprocessorFile,
+  isStyleReferenceSource,
+  loadSassCompiler,
+  rewriteSassReferences,
+  transformCssPreprocessors,
+  type TransformCssPreprocessorOptions,
+} from "./style/sass.ts";
 // dev-overlay-client 는 .mjs 라 별도 export — 브라우저 inject 용 string.
 export { APP_DEV_HMR_CLIENT } from "../runtime/dev-overlay-client.mjs";

--- a/packages/web/src/style/loader.ts
+++ b/packages/web/src/style/loader.ts
@@ -1,8 +1,23 @@
 import { type Dirent, readdirSync } from "node:fs";
+import { createRequire } from "node:module";
 import { join, resolve } from "node:path";
 
-interface NodeRequire {
+export interface NodeRequire {
   (specifier: string): unknown;
+}
+
+/**
+ * `root` 의 package.json 기준 `require` 로 specifier 를 로드, MODULE_NOT_FOUND
+ * 시 fallbackRequire 로 fallback. postcss/sass 같은 optional dev deps 가 app
+ * 또는 CLI 어느 쪽에 있는지 모를 때 양쪽 모두 시도.
+ */
+export function requireFromAppRoot(
+  root: string,
+  fallbackRequire: NodeRequire,
+  specifier: string,
+): unknown {
+  const requireFromRoot = createRequire(join(root, "package.json")) as unknown as NodeRequire;
+  return requireFromAppOrFallback(requireFromRoot, fallbackRequire, specifier);
 }
 
 /**

--- a/packages/web/src/style/postcss.ts
+++ b/packages/web/src/style/postcss.ts
@@ -1,13 +1,8 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { createRequire } from "node:module";
 import { basename, dirname, join, relative, resolve } from "node:path";
 
 import { joinUrl } from "../url.ts";
-import { collectAppFiles, requireFromAppOrFallback } from "./loader.ts";
-
-interface NodeRequire {
-  (specifier: string): unknown;
-}
+import { collectAppFiles, type NodeRequire, requireFromAppRoot } from "./loader.ts";
 
 // 순서는 zts.mjs L892-902 와 동일 — postcss.config.* 이 .postcssrc.* 보다 우선.
 // PR #5e 의 redirect 시점까지 양쪽 sync 유지 (#2539).
@@ -116,13 +111,11 @@ export async function loadPostcssConfig(
   configEnv: ConfigEnv,
   fallbackRequire: NodeRequire,
 ): Promise<LoadedPostcss | null> {
-  const requireFromRoot = createRequire(join(root, "package.json")) as unknown as NodeRequire;
-  const postcssrc = requireFromAppOrFallback(
-    requireFromRoot,
-    fallbackRequire,
-    "postcss-load-config",
-  ) as (env: { cwd: string; env: string }, root: string) => Promise<PostcssrcConfig>;
-  const postcssModule = requireFromAppOrFallback(requireFromRoot, fallbackRequire, "postcss") as {
+  const postcssrc = requireFromAppRoot(root, fallbackRequire, "postcss-load-config") as (
+    env: { cwd: string; env: string },
+    root: string,
+  ) => Promise<PostcssrcConfig>;
+  const postcssModule = requireFromAppRoot(root, fallbackRequire, "postcss") as {
     default?: LoadedPostcss["postcss"];
   } & LoadedPostcss["postcss"];
   const postcss = (postcssModule.default ?? postcssModule) as LoadedPostcss["postcss"];

--- a/packages/web/src/style/sass.test.ts
+++ b/packages/web/src/style/sass.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  buildCssPreprocessorProxy,
+  CSS_PREPROCESSOR_EXTENSIONS,
+  cssPreprocessorOutputPath,
+  cssPreprocessorProxyPath,
+  isCssModulePreprocessorFile,
+  isCssPreprocessorFile,
+  isStyleReferenceSource,
+  rewriteSassReferences,
+} from "./sass.ts";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "zts-sass-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function touch(rel: string, content = ""): string {
+  const path = join(dir, rel);
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, content);
+  return path;
+}
+
+describe("CSS_PREPROCESSOR_EXTENSIONS", () => {
+  test(".scss / .sass 만 포함", () => {
+    expect(CSS_PREPROCESSOR_EXTENSIONS.has(".scss")).toBe(true);
+    expect(CSS_PREPROCESSOR_EXTENSIONS.has(".sass")).toBe(true);
+    expect(CSS_PREPROCESSOR_EXTENSIONS.has(".css")).toBe(false);
+    expect(CSS_PREPROCESSOR_EXTENSIONS.has(".less")).toBe(false);
+  });
+});
+
+describe("isCssPreprocessorFile", () => {
+  test(".scss / .sass true", () => {
+    expect(isCssPreprocessorFile("a.scss")).toBe(true);
+    expect(isCssPreprocessorFile("/abs/x.sass")).toBe(true);
+  });
+
+  test("그 외 false", () => {
+    expect(isCssPreprocessorFile("a.css")).toBe(false);
+    expect(isCssPreprocessorFile("a.less")).toBe(false);
+    expect(isCssPreprocessorFile("a.ts")).toBe(false);
+    expect(isCssPreprocessorFile("")).toBe(false);
+  });
+});
+
+describe("isCssModulePreprocessorFile", () => {
+  test(".module.scss / .module.sass true", () => {
+    expect(isCssModulePreprocessorFile("a.module.scss")).toBe(true);
+    expect(isCssModulePreprocessorFile("/abs/x.module.sass")).toBe(true);
+  });
+
+  test("일반 .scss/.sass false", () => {
+    expect(isCssModulePreprocessorFile("a.scss")).toBe(false);
+    expect(isCssModulePreprocessorFile("a.sass")).toBe(false);
+  });
+
+  test(".module.css 는 false (preprocessor 아님)", () => {
+    expect(isCssModulePreprocessorFile("a.module.css")).toBe(false);
+  });
+});
+
+describe("cssPreprocessorOutputPath", () => {
+  test(".scss → .css", () => {
+    expect(cssPreprocessorOutputPath("a.scss")).toBe("a.css");
+  });
+
+  test(".sass → .css", () => {
+    expect(cssPreprocessorOutputPath("/abs/x.sass")).toBe("/abs/x.css");
+  });
+
+  test("case-sensitive — `.SCSS` 는 처리 안 함 (isCssPreprocessorFile gate 와 일치)", () => {
+    // `isCssPreprocessorFile` 의 extname 기반 lookup 이 case-sensitive 라
+    // .SCSS 는 처음부터 인식 안 됨. 두 함수 일관 (#2539).
+    expect(cssPreprocessorOutputPath("a.SCSS")).toBe("a.SCSS");
+  });
+
+  test(".module.scss → .module.css", () => {
+    expect(cssPreprocessorOutputPath("a.module.scss")).toBe("a.module.css");
+  });
+
+  test(".css 는 변경 없음", () => {
+    expect(cssPreprocessorOutputPath("a.css")).toBe("a.css");
+  });
+});
+
+describe("cssPreprocessorProxyPath", () => {
+  test(".scss → .css.js (proxy)", () => {
+    expect(cssPreprocessorProxyPath("a.scss")).toBe("a.css.js");
+  });
+
+  test(".sass → .css.js", () => {
+    expect(cssPreprocessorProxyPath("/abs/x.sass")).toBe("/abs/x.css.js");
+  });
+});
+
+describe("isStyleReferenceSource", () => {
+  test("HTML 과 JS/TS 변형 true", () => {
+    expect(isStyleReferenceSource("a.html")).toBe(true);
+    expect(isStyleReferenceSource("a.js")).toBe(true);
+    expect(isStyleReferenceSource("a.mjs")).toBe(true);
+    expect(isStyleReferenceSource("a.cjs")).toBe(true);
+    expect(isStyleReferenceSource("a.jsx")).toBe(true);
+    expect(isStyleReferenceSource("a.ts")).toBe(true);
+    expect(isStyleReferenceSource("a.tsx")).toBe(true);
+  });
+
+  test("CSS / 그 외 false", () => {
+    expect(isStyleReferenceSource("a.css")).toBe(false);
+    expect(isStyleReferenceSource("a.scss")).toBe(false);
+    expect(isStyleReferenceSource("a.json")).toBe(false);
+    expect(isStyleReferenceSource("a")).toBe(false);
+  });
+});
+
+describe("buildCssPreprocessorProxy", () => {
+  test("basename 만 import 하는 한 줄 proxy", () => {
+    expect(buildCssPreprocessorProxy("/abs/path/a.css")).toBe(`import "./a.css";\n`);
+  });
+
+  test("이름 안에 special char 도 JSON.stringify 로 escape", () => {
+    expect(buildCssPreprocessorProxy('/x/has"quote.css')).toContain(`"./has\\"quote.css"`);
+  });
+});
+
+describe("rewriteSassReferences", () => {
+  test('HTML 의 `<link href="x.scss">` → `.css`', () => {
+    const path = touch("index.html", `<link rel="stylesheet" href="./styles.scss">`);
+    rewriteSassReferences([path]);
+    expect(readFileSync(path, "utf8")).toBe(`<link rel="stylesheet" href="./styles.css">`);
+  });
+
+  test("JS/TS 의 import 는 `.css.js` proxy 로", () => {
+    const path = touch("entry.ts", `import "./styles.scss";\n`);
+    rewriteSassReferences([path]);
+    expect(readFileSync(path, "utf8")).toBe(`import "./styles.css.js";\n`);
+  });
+
+  test("작은따옴표 import 도 정상 처리", () => {
+    const path = touch("entry.ts", `import './a.sass';`);
+    rewriteSassReferences([path]);
+    expect(readFileSync(path, "utf8")).toBe(`import './a.css.js';`);
+  });
+
+  test("query/fragment suffix 보존", () => {
+    const path = touch("entry.ts", `import "./a.scss?inline";`);
+    rewriteSassReferences([path]);
+    expect(readFileSync(path, "utf8")).toBe(`import "./a.css.js?inline";`);
+  });
+
+  test(".scss / .sass 가 없는 파일은 변경 없음", () => {
+    const original = `import "./a.css";`;
+    const path = touch("entry.ts", original);
+    rewriteSassReferences([path]);
+    expect(readFileSync(path, "utf8")).toBe(original);
+  });
+
+  test("HTML 의 sass 도 .css 로 (proxy 아님)", () => {
+    const path = touch("index.html", `<link href="./x.sass">`);
+    rewriteSassReferences([path]);
+    expect(readFileSync(path, "utf8")).toBe(`<link href="./x.css">`);
+  });
+
+  test("여러 파일 동시 처리", () => {
+    const a = touch("a.ts", `import "./x.scss";`);
+    const b = touch("b.html", `<link href="./y.scss">`);
+    rewriteSassReferences([a, b]);
+    expect(readFileSync(a, "utf8")).toContain(`x.css.js`);
+    expect(readFileSync(b, "utf8")).toContain(`y.css`);
+  });
+});

--- a/packages/web/src/style/sass.ts
+++ b/packages/web/src/style/sass.ts
@@ -1,0 +1,147 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, extname } from "node:path";
+
+import { type NodeRequire, requireFromAppRoot } from "./loader.ts";
+
+interface SassCompiler {
+  compile: (file: string, options: SassCompileOptions) => SassCompileResult;
+}
+
+interface SassCompileOptions {
+  style?: "expanded" | "compressed";
+  loadPaths?: string[];
+  sourceMap?: boolean;
+}
+
+interface SassCompileResult {
+  css: string;
+}
+
+export const CSS_PREPROCESSOR_EXTENSIONS: ReadonlySet<string> = new Set([".scss", ".sass"]);
+const MODULE_PREPROCESSOR_RE = /\.module\.(?:scss|sass)$/;
+
+export function isCssPreprocessorFile(path: string): boolean {
+  return CSS_PREPROCESSOR_EXTENSIONS.has(extname(path));
+}
+
+export function isCssModulePreprocessorFile(path: string): boolean {
+  return MODULE_PREPROCESSOR_RE.test(path);
+}
+
+export function cssPreprocessorOutputPath(file: string): string {
+  return file.replace(/\.(?:scss|sass)$/, ".css");
+}
+
+export function cssPreprocessorProxyPath(file: string): string {
+  return `${cssPreprocessorOutputPath(file)}.js`;
+}
+
+/** Sass compiler 를 app-first / fallback-second 로 require. 모듈 미설치 시 친화 메시지 throw. */
+export function loadSassCompiler(root: string, fallbackRequire: NodeRequire): SassCompiler {
+  return requireFromAppRoot(root, fallbackRequire, "sass") as SassCompiler;
+}
+
+/**
+ * Sass 옵션 single source — full transform / dev fast-path / 어느 caller 가 부르
+ * 든 같은 옵션 사용 보장. drift 회피용 helper.
+ */
+export function compileSassFile(
+  sass: SassCompiler,
+  file: string,
+  loadRoot: string,
+): SassCompileResult {
+  return sass.compile(file, {
+    style: "expanded",
+    loadPaths: [dirname(file), loadRoot],
+    sourceMap: false,
+  });
+}
+
+const STYLE_REFERENCE_RE = /\.(?:html|mjs|cjs|js|jsx|ts|tsx)$/;
+
+export function isStyleReferenceSource(path: string): boolean {
+  return STYLE_REFERENCE_RE.test(path);
+}
+
+/**
+ * HTML 은 `<link href=\"x.scss\">` 를 그대로 컴파일된 CSS 로, JS/TS 는 `.css.js`
+ * proxy (`import \"./generated.css\"` 한 줄) 로 rewrite. CSS Modules 의 .module.css
+ * rewriter 는 HTML 미지원이라 별도 함수 (rewriteCssModuleReferences).
+ */
+export function rewriteSassReferences(sourceFiles: readonly string[]): void {
+  const pattern = /(["'])([^"']+\.(?:scss|sass))([?#][^"']*)?\1/g;
+  for (const source of sourceFiles) {
+    const input = readFileSync(source, "utf8");
+    if (!input.includes(".scss") && !input.includes(".sass")) continue;
+    const toExt = source.endsWith(".html") ? ".css" : ".css.js";
+    const output = input.replace(
+      pattern,
+      (_match, quote, spec, suffix = "") =>
+        `${quote}${spec.replace(/\.(?:scss|sass)$/, toExt)}${suffix}${quote}`,
+    );
+    if (output !== input) writeFileSync(source, output);
+  }
+}
+
+/**
+ * `cssPath` 의 basename 만 import 하는 한 줄 ESM proxy. bundler 가 module graph
+ * 에서 CSS 를 side-effect 로 추적하기 위한 entry — 실제 CSS 는 build 시 chunk
+ * 로 emit, dev 시 컴파일된 CSS 를 outdir 로 mirror 후 HTML `<link>` 로 서빙.
+ */
+export function buildCssPreprocessorProxy(cssPath: string): string {
+  const cssImport = `./${basename(cssPath)}`;
+  return `import ${JSON.stringify(cssImport)};\n`;
+}
+
+export interface TransformCssPreprocessorOptions {
+  /** dirty Set — 그 안에 들어있는 파일만 재컴파일. null 이면 전체. */
+  dirtyOnly?: ReadonlySet<string> | null;
+  /** dirty source files — `rewriteSassReferences` 의 대상 한정. null 이면 sourceFiles 전체. */
+  dirtySources?: readonly string[] | null;
+}
+
+/**
+ * `files` (Sass/SCSS 입력) 를 컴파일해 같은 path 의 `.css` + `.css.js` proxy 생성.
+ * `sourceFiles` (참조 HTML/JS/TS) 의 `import \"x.scss\"` 도 새 확장자로 rewrite.
+ *
+ * dirtyOnly 가 주어지면 그 안에 든 파일만 재컴파일하지만 반환 path 는 전체 (outdir
+ * mirror 가 stale 안 되도록).
+ */
+export function transformCssPreprocessors(
+  root: string,
+  files: readonly string[],
+  sourceFiles: readonly string[],
+  logLevel: string | undefined,
+  fallbackRequire: NodeRequire,
+  options: TransformCssPreprocessorOptions = {},
+): string[] {
+  if (files.length === 0) return [];
+  const { dirtyOnly = null, dirtySources = null } = options;
+  const targets = dirtyOnly ? files.filter((f) => dirtyOnly.has(f)) : files;
+  if (targets.length === 0) return files.map(cssPreprocessorOutputPath);
+
+  let sass: SassCompiler;
+  try {
+    sass = loadSassCompiler(root, fallbackRequire);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    const message =
+      code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND"
+        ? "Sass/SCSS support requires the optional `sass` package. Install it with `bun add -d sass` or `npm install -D sass`."
+        : `Failed to load sass: ${(err as { message?: string })?.message ?? err}`;
+    throw new Error(message);
+  }
+
+  for (const file of targets) {
+    const result = compileSassFile(sass, file, root);
+    const cssPath = cssPreprocessorOutputPath(file);
+    writeFileSync(cssPath, result.css);
+    writeFileSync(cssPreprocessorProxyPath(file), buildCssPreprocessorProxy(cssPath));
+  }
+
+  rewriteSassReferences(dirtySources ?? sourceFiles);
+  if (logLevel !== "silent") {
+    console.error(`[sass] processed ${targets.length} Sass/SCSS file(s)`);
+  }
+  return files.map(cssPreprocessorOutputPath);
+}


### PR DESCRIPTION
## Summary

#2539 epic 의 **PR 5d/5e** (css pipeline 분리 sub-PR 4/5). zts.mjs 의 sass / SCSS preprocessor pipeline 9 함수 + 2 const 를 web 으로 추출. 동시에 postcss/sass 공통 require 패턴을 loader.ts 의 helper 로 응집.

## 신설

| 파일 | 라인 | 역할 |
|---|---|---|
| `packages/web/src/style/sass.ts` | ~150 | 9 함수 + 2 const + 3 internal type |
| `packages/web/src/style/sass.test.ts` | ~180 | **24 케이스** |

## 수정

- `packages/web/src/style/loader.ts` — `requireFromAppRoot` helper 추가, NodeRequire export type 으로 승격
- `packages/web/src/style/postcss.ts` — `createRequire` + `requireFromAppOrFallback` 4-line 패턴 → `requireFromAppRoot` 1-line × 2
- `packages/web/src/index.ts` — sass.ts re-export
- `packages/core/bin/zts.mjs` — duplicate marker + `/i` flag 제거 (양쪽 sync)

## /simplify 반영 (3-agent 후 actionable 3 fix)

| # | Finding | Fix |
|---|---|---|
| 1 | postcss/sass 의 `createRequire(join(root, \"package.json\")) as unknown as NodeRequire` 4-line 패턴 동일 (Agent 1) | `requireFromAppRoot` helper 추출. cast 한 곳으로 격리. NodeRequire 두 정의 issue (Agent 2 #1) 도 같이 해결 |
| 2 | `/i` flag drift — `cssPreprocessorOutputPath` 의 case-insensitive 가 `isCssPreprocessorFile` (extname 기반 case-sensitive) 와 어긋남 (Agent 1) | `/i` 제거. gate 통과 파일만 들어오니 무관. **zts.mjs 동등 사본도 양쪽 sync** |
| 3 | `compileSassFile` docstring \"drift 감지는 본 함수 호출 일치성\" 모호 (Agent 2 #8) | \"Sass 옵션 single source — full transform / dev fast-path 어느 caller 가 부르든 같은 옵션 사용 보장\" 으로 정정 |

## 보류 (별도 follow-up)

- 테스트 fixture 공통화 — PR #5e 후 `__test/fixtures.ts` 일괄
- `rewriteSassReferences` mtime cache (Agent 3) — 측정 후
- proxy idempotent write skip (Agent 3) — 측정 후
- `transformCssPreprocessors` options 통합 — PR #5e redirect 시점에

## 검증

- [x] `bun test packages/web/src/style/sass.test.ts`: **24 pass / 0 fail**
- [x] `bun test packages/web/src/`: **102 pass / 0 fail** (5 파일)
- [x] `bun test --cwd packages/core bin/zts.test.ts`: 222 pass / 0 fail (회귀 0)
- [x] `dist/index.js` 에 sass 함수 inline (3 검증)
- [x] `bun run fmt` 변경 없음

Refs #2539 (5d/5e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)