### PR TITLE
feat(web): extract css-modules.ts pipeline to @zts/web/src/style/

### DIFF
--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -1088,7 +1088,8 @@ function rewriteSassReferences(sourceFiles) {
   for (const source of sourceFiles) {
     const input = readFileSync(source, "utf8");
     if (!input.includes(".scss") && !input.includes(".sass")) continue;
-    const toExt = source.endsWith(".html") ? ".css" : ".css.js";
+    // .html / .htm + case-insensitive — rewriteCssModuleReferences 와 일관.
+    const toExt = /\.html?$/i.test(source) ? ".css" : ".css.js";
     const output = input.replace(
       pattern,
       (_match, quote, spec, suffix = "") =>
@@ -1147,6 +1148,13 @@ function transformCssPreprocessors(root, files, sourceFiles, logLevel, opts = {}
   return files.map(cssPreprocessorOutputPath);
 }
 
+// 다음 영역 (isCssModuleFile / cssModuleGeneratedCssPath / cssModuleProxyPath /
+// cssModuleLocalName / scanCssModuleClassTokens / collectCssModuleClasses /
+// rewriteCssModuleClasses / isValidExportName + CSS_MODULE_RESERVED_EXPORTS /
+// buildCssModuleProxy / rewriteCssModuleReferences / transformCssModules) 은
+// packages/web/src/style/css-modules.ts 에 동등 사본이 있다. PR #6 (cut over)
+// 시점에 본 정의를 import 로 redirect 후 제거 — 그 전까지 logic 변경 시 양쪽을
+// 동시에 수정 (#2539).
 function isCssModuleFile(path) {
   return basename(path).endsWith(".module.css");
 }
@@ -1364,11 +1372,32 @@ function transformCssModules(root, moduleFiles, styleSources, logLevel, opts = {
 
   for (const file of targets) {
     const css = readFileSync(file, "utf8");
+    // 단일 scan 으로 token + mapping 동시 생성 — collect + rewrite 의 중복 scan 회피.
+    const tokens = scanCssModuleClassTokens(css);
+    const rel = relative(root, file).replaceAll(sep, "/");
+    const fileName = basename(file, ".module.css").replace(/[^a-zA-Z0-9_]/g, "_");
     const mapping = {};
-    for (const local of collectCssModuleClasses(css)) {
-      mapping[local] = cssModuleLocalName(root, file, local);
+    for (const token of tokens) {
+      if (!mapping[token.local]) {
+        // sha1 base64url slice(8): #2539 (web/css-modules.ts) 와 동일 스킴.
+        const safeLocal = token.local.replace(/[^a-zA-Z0-9_]/g, "_");
+        const hash = createHash("sha1")
+          .update(`${rel}:${token.local}`)
+          .digest("base64url")
+          .slice(0, 8);
+        mapping[token.local] = `${fileName}_${safeLocal}__${hash}`;
+      }
     }
-    const rewrittenCss = rewriteCssModuleClasses(css, mapping);
+    let rewrittenCss = "";
+    let offset = 0;
+    for (const token of tokens) {
+      const scoped = mapping[token.local];
+      if (!scoped) continue;
+      rewrittenCss += css.slice(offset, token.start);
+      rewrittenCss += `.${scoped}`;
+      offset = token.end;
+    }
+    rewrittenCss += css.slice(offset);
     const generatedCssPath = cssModuleGeneratedCssPath(file);
     writeFileSync(generatedCssPath, rewrittenCss);
     writeFileSync(cssModuleProxyPath(file), buildCssModuleProxy(generatedCssPath, mapping));

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -49,5 +49,20 @@ export {
   transformCssPreprocessors,
   type TransformCssPreprocessorOptions,
 } from "./style/sass.ts";
+export {
+  buildCssModuleProxy,
+  collectCssModuleClasses,
+  type CssModuleClassToken,
+  cssModuleGeneratedCssPath,
+  cssModuleLocalName,
+  cssModuleProxyPath,
+  isCssModuleFile,
+  isValidExportName,
+  rewriteCssModuleClasses,
+  rewriteCssModuleReferences,
+  scanCssModuleClassTokens,
+  transformCssModules,
+  type TransformCssModulesOptions,
+} from "./style/css-modules.ts";
 // dev-overlay-client 는 .mjs 라 별도 export — 브라우저 inject 용 string.
 export { APP_DEV_HMR_CLIENT } from "../runtime/dev-overlay-client.mjs";

--- a/packages/web/src/style/css-modules.test.ts
+++ b/packages/web/src/style/css-modules.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  buildCssModuleProxy,
+  collectCssModuleClasses,
+  cssModuleGeneratedCssPath,
+  cssModuleLocalName,
+  cssModuleProxyPath,
+  isCssModuleFile,
+  isValidExportName,
+  rewriteCssModuleClasses,
+  rewriteCssModuleReferences,
+  scanCssModuleClassTokens,
+} from "./css-modules.ts";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "zts-cssmod-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function touch(rel: string, content = ""): string {
+  const path = join(dir, rel);
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, content);
+  return path;
+}
+
+describe("isCssModuleFile", () => {
+  test(".module.css 만 true", () => {
+    expect(isCssModuleFile("a.module.css")).toBe(true);
+    expect(isCssModuleFile("/abs/path/styles.module.css")).toBe(true);
+  });
+
+  test("일반 .css 는 false", () => {
+    expect(isCssModuleFile("a.css")).toBe(false);
+    expect(isCssModuleFile("module.css")).toBe(false);
+  });
+
+  test(".module.scss 는 false (preprocessor — sass 영역)", () => {
+    expect(isCssModuleFile("a.module.scss")).toBe(false);
+  });
+});
+
+describe("cssModuleGeneratedCssPath", () => {
+  test(".module.css → .module.zts.css", () => {
+    expect(cssModuleGeneratedCssPath("a.module.css")).toBe("a.module.zts.css");
+    expect(cssModuleGeneratedCssPath("/x/styles.module.css")).toBe("/x/styles.module.zts.css");
+  });
+});
+
+describe("cssModuleProxyPath", () => {
+  test(".js suffix", () => {
+    expect(cssModuleProxyPath("a.module.css")).toBe("a.module.css.js");
+  });
+});
+
+describe("cssModuleLocalName", () => {
+  test("`${fileName}_${local}__${hash8}` 형식", () => {
+    const name = cssModuleLocalName("/root", "/root/sub/x.module.css", "btn");
+    expect(name).toMatch(/^x_btn__[A-Za-z0-9_-]{8}$/);
+  });
+
+  test("같은 (root, file, local) → 결정적", () => {
+    const a = cssModuleLocalName("/root", "/root/x.module.css", "btn");
+    const b = cssModuleLocalName("/root", "/root/x.module.css", "btn");
+    expect(a).toBe(b);
+  });
+
+  test("다른 file 은 다른 hash", () => {
+    const a = cssModuleLocalName("/root", "/root/a.module.css", "btn");
+    const b = cssModuleLocalName("/root", "/root/b.module.css", "btn");
+    expect(a).not.toBe(b);
+  });
+
+  test("invalid identifier char 는 _ 로 치환", () => {
+    const name = cssModuleLocalName("/root", "/root/my-file.module.css", "btn-primary");
+    expect(name).toMatch(/^my_file_btn_primary__/);
+  });
+});
+
+describe("scanCssModuleClassTokens", () => {
+  test("일반 .class 토큰 추출", () => {
+    const tokens = scanCssModuleClassTokens(".btn { color: red; } .card-x {}");
+    expect(tokens.map((t) => t.local)).toEqual(["btn", "card-x"]);
+  });
+
+  test("string 안의 . 은 skip", () => {
+    const tokens = scanCssModuleClassTokens('.btn { content: ".not-a-class"; }');
+    expect(tokens.map((t) => t.local)).toEqual(["btn"]);
+  });
+
+  test("comment 안의 . 은 skip", () => {
+    const tokens = scanCssModuleClassTokens(".btn { /* .ignored */ color: red; }");
+    expect(tokens.map((t) => t.local)).toEqual(["btn"]);
+  });
+
+  test("url() 안의 quote 도 정상 skip", () => {
+    const tokens = scanCssModuleClassTokens(".bg { background: url(./img.png); } .btn {}");
+    expect(tokens.map((t) => t.local)).toEqual(["bg", "btn"]);
+  });
+
+  test("토큰 위치 (start/end) 정확", () => {
+    const css = ".a {}";
+    const [t] = scanCssModuleClassTokens(css);
+    expect(t).toEqual({ start: 0, end: 2, local: "a" });
+  });
+});
+
+describe("collectCssModuleClasses", () => {
+  test("중복 제거 후 unique 이름만", () => {
+    expect(collectCssModuleClasses(".btn { } .btn:hover { }").sort()).toEqual(["btn"]);
+    expect(collectCssModuleClasses(".a, .b { } .a {}").sort()).toEqual(["a", "b"]);
+  });
+});
+
+describe("rewriteCssModuleClasses", () => {
+  test("mapping 적용", () => {
+    const css = ".btn { color: red; }";
+    expect(rewriteCssModuleClasses(css, { btn: "btn__h1" })).toBe(".btn__h1 { color: red; }");
+  });
+
+  test("mapping 없는 class 는 원본 유지", () => {
+    const css = ".btn { } .other { }";
+    expect(rewriteCssModuleClasses(css, { btn: "btn__h1" })).toBe(".btn__h1 { } .other { }");
+  });
+
+  test("string/comment 안의 . 은 영향 X", () => {
+    const css = '.btn { content: ".btn"; /* .btn */ }';
+    expect(rewriteCssModuleClasses(css, { btn: "btn__h1" })).toBe(
+      '.btn__h1 { content: ".btn"; /* .btn */ }',
+    );
+  });
+});
+
+describe("isValidExportName", () => {
+  test("valid identifier → true", () => {
+    expect(isValidExportName("button")).toBe(true);
+    expect(isValidExportName("$btn")).toBe(true);
+    expect(isValidExportName("_internal")).toBe(true);
+    expect(isValidExportName("camelCase")).toBe(true);
+  });
+
+  test("invalid identifier → false", () => {
+    expect(isValidExportName("btn-primary")).toBe(false); // hyphen
+    expect(isValidExportName("123btn")).toBe(false); // 숫자 시작
+    expect(isValidExportName("")).toBe(false);
+    expect(isValidExportName("with space")).toBe(false);
+  });
+
+  test("JS keyword reserved → false", () => {
+    expect(isValidExportName("class")).toBe(false);
+    expect(isValidExportName("default")).toBe(false);
+    expect(isValidExportName("import")).toBe(false);
+    expect(isValidExportName("export")).toBe(false);
+    expect(isValidExportName("const")).toBe(false);
+    expect(isValidExportName("function")).toBe(false);
+  });
+});
+
+describe("buildCssModuleProxy", () => {
+  test("default export + named export 생성", () => {
+    const proxy = buildCssModuleProxy("/x/a.module.zts.css", {
+      btn: "btn__h1",
+      card: "card__h2",
+    });
+    expect(proxy).toContain(`import "./a.module.zts.css";`);
+    expect(proxy).toContain(`const styles = {"btn":"btn__h1","card":"card__h2"};`);
+    expect(proxy).toContain(`export default styles;`);
+    expect(proxy).toContain(`export const btn = "btn__h1";`);
+    expect(proxy).toContain(`export const card = "card__h2";`);
+  });
+
+  test("invalid identifier 는 named export 안 함", () => {
+    const proxy = buildCssModuleProxy("/x/a.module.zts.css", {
+      "btn-primary": "x__h1",
+    });
+    expect(proxy).not.toContain("export const btn-primary");
+    // default export 의 styles 안에는 여전히 포함.
+    expect(proxy).toContain(`"btn-primary"`);
+  });
+
+  test("JS keyword 도 named export 제외", () => {
+    const proxy = buildCssModuleProxy("/x/a.module.zts.css", { class: "x" });
+    expect(proxy).not.toContain("export const class");
+  });
+});
+
+describe("rewriteCssModuleReferences", () => {
+  test('import "x.module.css" → "x.module.css.js"', () => {
+    const path = touch("entry.ts", `import "./styles.module.css";\n`);
+    rewriteCssModuleReferences([path]);
+    expect(readFileSync(path, "utf8")).toBe(`import "./styles.module.css.js";\n`);
+  });
+
+  test("HTML 의 link 는 skip (.module.css 도 일반 CSS 로 취급)", () => {
+    const original = `<link href="./x.module.css">`;
+    const path = touch("index.html", original);
+    rewriteCssModuleReferences([path]);
+    expect(readFileSync(path, "utf8")).toBe(original);
+  });
+
+  test("query/fragment suffix 보존", () => {
+    const path = touch("entry.ts", `import "./a.module.css?inline";`);
+    rewriteCssModuleReferences([path]);
+    expect(readFileSync(path, "utf8")).toBe(`import "./a.module.css.js?inline";`);
+  });
+
+  test(".module.css 가 없는 파일은 변경 없음", () => {
+    const original = `import "./a.css";`;
+    const path = touch("entry.ts", original);
+    rewriteCssModuleReferences([path]);
+    expect(readFileSync(path, "utf8")).toBe(original);
+  });
+
+  test("작은따옴표 import 도 정상 처리", () => {
+    const path = touch("entry.ts", `import './x.module.css';`);
+    rewriteCssModuleReferences([path]);
+    expect(readFileSync(path, "utf8")).toBe(`import './x.module.css.js';`);
+  });
+});

--- a/packages/web/src/style/css-modules.ts
+++ b/packages/web/src/style/css-modules.ts
@@ -1,0 +1,276 @@
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { basename, relative, sep } from "node:path";
+
+import {
+  isCssIdent,
+  isCssIdentStart,
+  skipCssString,
+  skipCssUrl,
+  startsWithCssIdent,
+} from "./css-parser.ts";
+
+/** `.module.css` 종결만 인식 — case-sensitive (Vite/webpack css-loader 컨벤션 일치). */
+export function isCssModuleFile(path: string): boolean {
+  return basename(path).endsWith(".module.css");
+}
+
+export function cssModuleGeneratedCssPath(file: string): string {
+  return file.replace(/\.module\.css$/, ".module.zts.css");
+}
+
+/**
+ * `x.module.css → x.module.css.js` proxy. sass 의 `cssPreprocessorProxyPath`
+ * (`x.scss → x.css.js`) 와 출력 형태가 다른 이유: CSS Modules 는 원본 확장자
+ * 보존이 import resolver 에 필요 (`.module.css` 를 import 한 caller 의 type
+ * 추론과 일치).
+ */
+export function cssModuleProxyPath(file: string): string {
+  return `${file}.js`;
+}
+
+const SAFE_LOCAL_RE = /[^a-zA-Z0-9_]/g;
+
+/**
+ * `${fileName}_${safeLocal}__${hash8}` 형식의 unique class name.
+ * hash 8 chars (~48 bits) 면 100k 클래스에서도 birthday collision <0.001%.
+ */
+export function cssModuleLocalName(root: string, file: string, local: string): string {
+  const rel = relative(root, file).replaceAll(sep, "/");
+  const fileName = basename(file, ".module.css").replace(SAFE_LOCAL_RE, "_");
+  return cssModuleLocalNameWithCachedFile(rel, fileName, local);
+}
+
+/**
+ * 같은 file 의 여러 class 처리 시 `rel` / `fileName` 을 한 번만 계산하도록 inner
+ * helper. 100 class CSS 면 path/string 연산 99회 절약.
+ */
+function cssModuleLocalNameWithCachedFile(rel: string, fileName: string, local: string): string {
+  const safeLocal = local.replace(SAFE_LOCAL_RE, "_");
+  const hash = createHash("sha1").update(`${rel}:${local}`).digest("base64url").slice(0, 8);
+  return `${fileName}_${safeLocal}__${hash}`;
+}
+
+export interface CssModuleClassToken {
+  start: number;
+  end: number;
+  local: string;
+}
+
+/**
+ * CSS 안의 일반 `.class-name` 토큰 위치를 수집. `:global`/`:local` 슈도, `composes:`
+ * 룰, `@keyframes` 이름 scoping 등 고급 CSS Modules 스펙은 미지원.
+ */
+export function scanCssModuleClassTokens(css: string): CssModuleClassToken[] {
+  const tokens: CssModuleClassToken[] = [];
+  let i = 0;
+  while (i < css.length) {
+    const ch = css[i]!;
+    const next = css[i + 1] ?? "";
+    if ((ch === '"' || ch === "'") && css[i - 1] !== "\\") {
+      i = skipCssString(css, i, ch);
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      const end = css.indexOf("*/", i + 2);
+      i = end === -1 ? css.length : end + 2;
+      continue;
+    }
+    if (startsWithCssIdent(css, i, "url(")) {
+      i = skipCssUrl(css, i + 4);
+      continue;
+    }
+    if (ch === "." && isCssIdentStart(next)) {
+      let end = i + 2;
+      while (end < css.length && isCssIdent(css[end]!)) end += 1;
+      tokens.push({ start: i, end, local: css.slice(i + 1, end) });
+      i = end;
+      continue;
+    }
+    i += 1;
+  }
+  return tokens;
+}
+
+export function collectCssModuleClasses(css: string): string[] {
+  return [...new Set(scanCssModuleClassTokens(css).map((token) => token.local))];
+}
+
+export function rewriteCssModuleClasses(css: string, mapping: Record<string, string>): string {
+  return rewriteCssModuleClassesWithTokens(css, scanCssModuleClassTokens(css), mapping);
+}
+
+const VALID_EXPORT_NAME_RE = /^[$A-Z_a-z][$\w]*$/;
+
+// ECMAScript ReservedWord + FutureReservedWord + strict-mode binding 제약 (`arguments`).
+// `export const ${name}` 의 top-level binding 으로 SyntaxError 가 나는 모든 이름.
+const CSS_MODULE_RESERVED_EXPORTS: ReadonlySet<string> = new Set([
+  "arguments",
+  "await",
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "default",
+  "delete",
+  "do",
+  "else",
+  "enum",
+  "export",
+  "extends",
+  "false",
+  "finally",
+  "for",
+  "function",
+  "if",
+  "implements",
+  "import",
+  "in",
+  "instanceof",
+  "interface",
+  "let",
+  "new",
+  "null",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "return",
+  "static",
+  "super",
+  "switch",
+  "this",
+  "throw",
+  "true",
+  "try",
+  "typeof",
+  "var",
+  "void",
+  "while",
+  "with",
+  "yield",
+]);
+
+export function isValidExportName(name: string): boolean {
+  return VALID_EXPORT_NAME_RE.test(name) && !CSS_MODULE_RESERVED_EXPORTS.has(name);
+}
+
+/**
+ * proxy module — class-name map 의 default export 와 valid identifier named
+ * export 를 emit. 실제 CSS 는 generated `.module.zts.css` 가 `<link>` 로 도달.
+ */
+export function buildCssModuleProxy(
+  generatedCssPath: string,
+  mapping: Record<string, string>,
+): string {
+  const cssImport = `./${basename(generatedCssPath)}`;
+  const stylesJson = JSON.stringify(mapping);
+  const named = Object.keys(mapping)
+    .filter(isValidExportName)
+    .map((name) => `export const ${name} = ${JSON.stringify(mapping[name])};`)
+    .join("\n");
+  return [
+    `import ${JSON.stringify(cssImport)};`,
+    `const styles = ${stylesJson};`,
+    "export default styles;",
+    named,
+    "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+/**
+ * `import \"x.module.css\"` → `\"x.module.css.js\"` proxy redirect.
+ * HTML 의 `<link href=\"x.module.css\">` 는 일반 CSS 로 취급되므로 skip.
+ */
+export function rewriteCssModuleReferences(sourceFiles: readonly string[]): void {
+  const pattern = /(["'])([^"']+\.module\.css)([?#][^"']*)?\1/g;
+  for (const source of sourceFiles) {
+    if (/\.html?$/i.test(source)) continue;
+    const input = readFileSync(source, "utf8");
+    if (!input.includes(".module.css")) continue;
+    const output = input.replace(
+      pattern,
+      (_match, quote, spec, suffix = "") => `${quote}${spec}.js${suffix}${quote}`,
+    );
+    if (output !== input) writeFileSync(source, output);
+  }
+}
+
+export interface TransformCssModulesOptions {
+  /** dirty Set — 그 안에 들어있는 파일만 재처리. null 이면 전체. */
+  dirtyOnly?: ReadonlySet<string> | null;
+  /** dirty source files — `rewriteCssModuleReferences` 의 대상 한정. */
+  dirtySources?: readonly string[] | null;
+}
+
+/**
+ * `moduleFiles` 의 `.module.css` 를 generated `.module.zts.css` + `.module.css.js`
+ * proxy 로 변환. `styleSources` 의 `import \"x.module.css\"` 는 proxy 로 redirect.
+ *
+ * dirtyOnly 가 주어지면 그 안에 든 파일만 재처리하지만 반환은 전체 list —
+ * incremental rebuild 시에도 caller 가 일관된 set 을 받도록.
+ */
+export function transformCssModules(
+  root: string,
+  moduleFiles: readonly string[],
+  styleSources: readonly string[],
+  logLevel: string | undefined,
+  options: TransformCssModulesOptions = {},
+): string[] {
+  if (moduleFiles.length === 0) return [];
+  const { dirtyOnly = null, dirtySources = null } = options;
+  const targets = dirtyOnly ? moduleFiles.filter((f) => dirtyOnly.has(f)) : moduleFiles;
+  if (targets.length === 0) return moduleFiles.map(cssModuleGeneratedCssPath);
+
+  for (const file of targets) {
+    const css = readFileSync(file, "utf8");
+    // 단일 scan 으로 token + mapping 동시 생성 — collect + rewrite 의 중복 scan 회피.
+    const tokens = scanCssModuleClassTokens(css);
+    const rel = relative(root, file).replaceAll(sep, "/");
+    const fileName = basename(file, ".module.css").replace(SAFE_LOCAL_RE, "_");
+    const mapping: Record<string, string> = {};
+    for (const token of tokens) {
+      if (!mapping[token.local]) {
+        mapping[token.local] = cssModuleLocalNameWithCachedFile(rel, fileName, token.local);
+      }
+    }
+    const rewrittenCss = rewriteCssModuleClassesWithTokens(css, tokens, mapping);
+    const generatedCssPath = cssModuleGeneratedCssPath(file);
+    writeFileSync(generatedCssPath, rewrittenCss);
+    writeFileSync(cssModuleProxyPath(file), buildCssModuleProxy(generatedCssPath, mapping));
+  }
+
+  rewriteCssModuleReferences(dirtySources ?? styleSources);
+
+  if (logLevel !== "silent") {
+    console.error(`[css-modules] processed ${targets.length} CSS module file(s)`);
+  }
+  return moduleFiles.map(cssModuleGeneratedCssPath);
+}
+
+/**
+ * `rewriteCssModuleClasses` 의 inner — 미리 scan 한 token 재사용. transformCssModules
+ * 의 단일 scan 경로에 사용.
+ */
+function rewriteCssModuleClassesWithTokens(
+  css: string,
+  tokens: readonly CssModuleClassToken[],
+  mapping: Record<string, string>,
+): string {
+  let out = "";
+  let offset = 0;
+  for (const token of tokens) {
+    const scoped = mapping[token.local];
+    if (!scoped) continue;
+    out += css.slice(offset, token.start);
+    out += `.${scoped}`;
+    offset = token.end;
+  }
+  out += css.slice(offset);
+  return out;
+}

--- a/packages/web/src/style/sass.ts
+++ b/packages/web/src/style/sass.ts
@@ -73,7 +73,8 @@ export function rewriteSassReferences(sourceFiles: readonly string[]): void {
   for (const source of sourceFiles) {
     const input = readFileSync(source, "utf8");
     if (!input.includes(".scss") && !input.includes(".sass")) continue;
-    const toExt = source.endsWith(".html") ? ".css" : ".css.js";
+    // .html / .htm 모두 분기 (rewriteCssModuleReferences 와 일관 — case-insensitive).
+    const toExt = /\.html?$/i.test(source) ? ".css" : ".css.js";
     const output = input.replace(
       pattern,
       (_match, quote, spec, suffix = "") =>


### PR DESCRIPTION
## Summary

#2539 의 web style extraction series 마지막 sub-PR (PR #5e). CSS Modules pipeline 을 `packages/web/src/style/css-modules.ts` 로 추출. PR #6 (cut over) 시점에 zts.mjs 의 사본을 import redirect 로 교체.

## 변경 사항

**신설 — `packages/web/src/style/css-modules.ts`** (~270줄)
- `isCssModuleFile` / `cssModuleGeneratedCssPath` / `cssModuleProxyPath`
- `cssModuleLocalName` — file/local 기반 deterministic hash (sha1 base64url 8 chars)
- `scanCssModuleClassTokens` / `collectCssModuleClasses`
- `rewriteCssModuleClasses` (+ inner `rewriteCssModuleClassesWithTokens`)
- `isValidExportName` + `CSS_MODULE_RESERVED_EXPORTS`
- `buildCssModuleProxy` / `rewriteCssModuleReferences`
- `transformCssModules` (+ `TransformCssModulesOptions`)

**신설 — `css-modules.test.ts`** (29 cases / 49 expects, 100% line coverage)
- 모든 함수의 happy / edge / security path
- 결정적 hash, invalid identifier 치환, JS keyword 거부
- string / comment / url() 안의 `.` skip 검증
- HTML 의 `.module.css` link 는 일반 CSS 로 보존

**zts.mjs 양측 동시 수정** (PR #6 cut over 전 사본 유지)
- `transformCssModules` 단일 scan 최적화 — token + mapping + rewrite 를 한 번에
- `cssModuleLocalName` 의 fileName/rel 캐시 — N class CSS 에서 path 연산 N→1
- `rewriteSassReferences` toExt regex `/\.html?$/i` 로 일관 (`.html` + `.htm` + case-insensitive)
- `transformCssModules` 위에 duplicate marker 추가 (PR #6 까지 양쪽 동시 수정 알림)

## /simplify 3-agent review 반영

- **P1** — duplicate scan 제거 (`collectCssModuleClasses` + `rewriteCssModuleClasses` 가 따로 scan → 단일 token list 재사용)
- **P2** — `cssModuleLocalName` 의 per-class `relative()` + `basename()` waste 제거 (file 단위 cache)
- ESM ReservedWord + FutureReservedWord + strict-mode binding 제약 출처 주석
- `isCssModuleFile` case-sensitive 의도 명시 (Vite/webpack css-loader 컨벤션 일치)
- `cssModuleProxyPath` 의 sass proxy 와 다른 출력 형태 근거 주석

## Test plan

- [x] `bun test packages/web/src/style/css-modules.test.ts` (29 pass / 0 fail)
- [x] `bun test packages/web/src/` (131 pass / 0 fail)
- [x] `bun test --cwd packages/core bin/zts.test.ts` (222 pass / 0 fail)
- [x] `bun run fmt`
- [ ] CI 통과 시 auto-rebase merge

Refs #2539