### PR TITLE
fix(ci): build @zts/web + @zts/server before CLI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,20 +131,13 @@ jobs:
       - name: Run NAPI tests (Node.js)
         run: node --test packages/core/napi.test.mjs
 
-      - name: Run CLI tests (Bun)
-        run: cd packages/core && bun test bin/zts.test.ts
-
-      # @zts/server (private, internal) + @zts/web 의 self-build 검증 (#2539).
-      # zts CLI 가 자기 자신을 빌드하는 dogfooding (외부 도구 없이
-      # `node ../core/bin/zts.mjs --bundle ...` + `tsc --emitDeclarationOnly`).
-      # @zts/server 의 src 가 @zts/web 의 dist 에 자동 inline 되는지 검증
-      # (workspace dep auto-inline). 본 시점은 server 가 빈 entry 라 inline
-      # 분량 0 — PR #3 후 grep 검증 추가 예정.
-      - name: Build @zts/server (self-build 검증)
-        run: bun run --cwd packages/server build
-
-      - name: Build @zts/web (self-build + inline 검증)
-        run: bun run --cwd packages/web build
+      # CLI 테스트의 dev/preview/build app 시나리오는 spawn 한 zts.mjs 가
+      # `import("@zts/web")` 을 호출 → packages/web/dist/index.js 필요.
+      # `bun run test` 가 packages/core/package.json 의 pretest hook 을 트리거 →
+      # @zts/server + @zts/web 빌드 → bin/zts.test.ts 실행 (arg passthrough).
+      # zts 자체 self-build (dogfooding) 도 같이 검증 (#2539).
+      - name: Run CLI tests (Bun, with @zts/server + @zts/web self-build via pretest)
+        run: cd packages/core && bun run test bin/zts.test.ts
 
       # ZTS 코어의 ES5 다운레벨링 / chunk split runtime helper / external 처리
       # 회귀 검증 (wasm 발견 버그가 NAPI 에서도 동일 발생 확인됨). known bugs

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,7 @@
     "build:dts": "bun x tsc --emitDeclarationOnly",
     "build": "bun run build:napi && cp ../../zig-out/lib/zts.node . && bun run build:js && bun run build:dts",
     "postinstall": "[ -f ../../zig-out/lib/zts.node ] && cp ../../zig-out/lib/zts.node . || true",
+    "pretest": "bun run --cwd ../server build && bun run --cwd ../web build",
     "test": "bun test"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

#2539 PR #2 (`6202678c chore(web,server): adopt zts self-build (dogfooding)`) 머지 직후부터 main 의 `NAPI Build & Test (ubuntu-latest, macos-latest)` 가 11회 연속 fail. PR #5e 시점까지 동일 회귀가 누적. root cause 잡고 main CI 정상화.

## Root cause

PR #2 가 `packages/{web,server}/package.json` 의 `main` / `types` / `exports` 를 `./src` 직참조에서 `./dist` 로 전환했다. 그런데 `packages/core/bin/zts.mjs` 의 `runAppDev` 경로 (dev/preview/build app 모드) 는 `import(\"@zts/web\")` 을 lazy 호출 → `packages/web/dist/index.js` 가 없으면 `ERR_MODULE_NOT_FOUND`.

기존 CI 흐름:

1. `bun install`
2. `zig build napi`
3. core dist build
4. **Run CLI tests (Bun)** ← 여기서 dev 시나리오 fail (web dist 없음)
5. Build `@zts/server` / `@zts/web` (← 너무 늦음)

dev 시나리오 5개 (`port allocation`, `config load`, `strictPort` 등) 가 모두 spawn 된 `zts dev` 의 5초 timeout 에 걸려 `Server on port XXX did not start` 로 fail.

```
(fail) CLI: Vite-style app builder > dev [root] serves prepared app HTML and development env [5001.14ms]
error: Server on port 50554 did not start
```

로컬에서 통과한 이유: 개발자가 한번이라도 web 을 빌드한 적 있으면 dist 가 남아 있어서. clean checkout 시엔 동일 fail (재현 확인).

## Fix

1. `packages/core/package.json` — `pretest` hook 추가:
   ```json
   \"pretest\": \"bun run --cwd ../server build && bun run --cwd ../web build\"
   ```
   `bun run test` 호출 시 자동 트리거 → server/web dist 보장.

2. `.github/workflows/ci.yml` — `Run CLI tests` step 을 `bun test` 에서 `bun run test` 로 변경. pretest hook 을 트리거해 web/server 를 사전 빌드. redundant 한 별도 `Build @zts/server` / `Build @zts/web` step 두 개 제거 (pretest 가 처리).

## Test plan

- [x] 로컬 재현: `rm -rf packages/{web,server}/dist && bun test bin/zts.test.ts -t \"dev \\[root\\]\"` → fail (5s timeout)
- [x] 로컬 fix 검증: clean dist 상태에서 `bun run test bin/zts.test.ts -t \"dev \\[root\\]\"` → 5 pass / 0 fail
- [x] 전체: `bun run test` → 797 pass / 1 skip / 0 fail
- [ ] CI 가 ubuntu/macos 모두 NAPI Build & Test green 으로 복구되는지 (이 PR 머지 시점)

Refs #2539