### PR TITLE
chore(packages): rebalance optional CSS deps + expose @zts/server watcher

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -95,9 +95,6 @@
         "core-js": "^3.49.0",
         "core-js-compat": "^3.49.0",
         "lightningcss": "^1.28.0",
-        "postcss": "^8.5.8",
-        "postcss-load-config": "^6.0.1",
-        "sass": "^1.99.0",
       },
     },
     "packages/server": {
@@ -133,6 +130,11 @@
       },
       "devDependencies": {
         "@types/node": "^25.5.2",
+      },
+      "optionalDependencies": {
+        "postcss": "^8.5.8",
+        "postcss-load-config": "^6.0.1",
+        "sass": "^1.99.0",
       },
     },
     "tests/benchmark": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,9 +36,6 @@
     "browserslist": "^4.24.0",
     "core-js": "^3.49.0",
     "core-js-compat": "^3.49.0",
-    "lightningcss": "^1.28.0",
-    "postcss": "^8.5.8",
-    "postcss-load-config": "^6.0.1",
-    "sass": "^1.99.0"
+    "lightningcss": "^1.28.0"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zts/web",
   "version": "0.1.0",
-  "description": "ZTS web platform — dev server, postcss/sass/lightningcss pipeline, HMR overlay",
+  "description": "ZTS web platform — dev server, postcss/sass pipeline, HMR overlay",
   "license": "MIT",
   "files": [
     "dist/",
@@ -17,7 +17,7 @@
     }
   },
   "scripts": {
-    "build:bundle": "node ../core/bin/zts.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --external @zts/core --external lightningcss --external postcss --external postcss-load-config --external sass",
+    "build:bundle": "node ../core/bin/zts.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --external @zts/core --external postcss --external postcss-load-config --external sass",
     "build:dts": "bun x tsc --emitDeclarationOnly",
     "build": "bun run build:bundle && bun run build:dts",
     "test": "bun test"
@@ -28,5 +28,10 @@
   },
   "devDependencies": {
     "@types/node": "^25.5.2"
+  },
+  "optionalDependencies": {
+    "postcss": "^8.5.8",
+    "postcss-load-config": "^6.0.1",
+    "sass": "^1.99.0"
   }
 }

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,14 +1,17 @@
 // @zts/web — dev server / postcss·sass·lightningcss / HMR overlay 가 자리잡는 패키지.
 // 분리 진행: #2539.
 
-// `@zts/server` 의 HMR 표면을 web 사용자 (zts.mjs CLI / RN bridge / future
-// edge runtime) 가 단일 entry 로 받도록 재수출. server 는 private 패키지라
+// `@zts/server` 의 HMR / Watcher 표면을 web 사용자 (zts.mjs CLI / RN bridge /
+// future edge runtime) 가 단일 entry 로 받도록 재수출. server 는 private 패키지라
 // web 의 dist 에 inline 되므로 consumer 는 별도 install 불필요.
 export {
   APP_DEV_HMR_CLIENT_PATH,
   APP_DEV_HMR_WS_PATH,
   type BunHmrClient,
   createHmrChannel,
+  createWatcher,
+  type CreateWatcherOptions,
+  HMR_MSG,
   type HmrChannel,
   type HmrConnectedMessage,
   type HmrCssUpdateMessage,
@@ -17,7 +20,11 @@ export {
   type HmrFullReloadMessage,
   type HmrMessage,
   type HmrMessageType,
-  HMR_MSG,
+  type WatchEventType,
+  type WatchFn,
+  type WatchListener,
+  type WatcherHandle,
+  type WatcherInstance,
 } from "@zts/server";
 export {
   type BundleResult,


### PR DESCRIPTION
## Summary

#2539 epic 의 PR #7. core 의 dev/preview 영역 deps 를 web 으로 이동 + `@zts/server` 의 `createWatcher` API 를 web 에 재수출.

## optionalDependencies 재배치

**`@zts/core/package.json` 에서 제거** (web 으로 이동):
- `postcss`
- `postcss-load-config`
- `sass`

**`@zts/core/package.json` 에 유지** (core 가 직접 사용):
- `lightningcss` — `index.ts` L1582-1611 의 CSS minify 후처리
- `browserslist`, `core-js`, `core-js-compat` — transpile 영역

**`@zts/web/package.json` 에 추가**:
- `postcss`, `postcss-load-config`, `sass` — `web/src/style/postcss.ts` / `web/src/style/sass.ts` 의 `requireFromAppRoot()` 가 동적 로드

**효과**: core 단독 install (transpile/bundle 만 사용) 시 sass (~10MB) 등 **~25-40MB install 절감**. web 추가 install 시 dev/preview/build app + CSS pipeline 동작.

## @zts/server watcher 재수출

`packages/web/src/index.ts` 에 `createWatcher` + 관련 type 6개 (`CreateWatcherOptions`, `WatcherHandle`, `WatcherInstance`, `WatchEventType`, `WatchFn`, `WatchListener`) 재수출.

PR #6b cut over 는 보류 (다른 번들러 조사 결과 — Vite/Rsbuild 는 dev server 내부에 watcher 를 inline; Rolldown 만 별도 패키지지만 \"test-\" prefix). 그러나 RN/edge integration (#2540) 시 import path 정리용으로 surface 는 미리 노출.

## /simplify 3-agent finding 반영

- `web/package.json` description drift — `lightningcss pipeline` 표기 제거 (core 영역)
- `build:bundle` 의 redundant `--external lightningcss` 제거 — web 이 lightningcss 안 씀
- `index.ts` re-export 알파벳 정렬 (Watcher* 와 Hmr* 묶음 정리)

## Test plan

- [x] `bun run test bin/zts.test.ts` → 222 pass / 1 skip / 0 fail
- [x] `@zts/web` 141 pass / 0 fail
- [x] `@zts/server` 67 pass / 0 fail
- [x] `examples/web build/dev` smoke 정상 (HTTP 200 + WebSocket handshake + connected msg)
- [ ] CI 통과 시 auto-rebase merge

Refs #2539