### PR TITLE
ci(packages): verify vite-plugin-zts integrity post-split

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,16 @@ jobs:
         continue-on-error: true
         run: bun scripts/napi-bundler-bug-check.ts
 
+      # vite-plugin-zts 가 dev server 영역 (HMR overlay / postcss / sass /
+      # lightningcss / @zts/web / @zts/server) 을 import / inline 하지 않는지
+      # 검증 — Vite 의 자체 dev server 가 처리하므로 이중 결합되면 안 됨 (#2539).
+      - name: vite-plugin-zts 의존 격리 검증
+        run: |
+          if grep -rE "APP_DEV_HMR_CLIENT|lightningcss|postcss-load-config|@zts/web|@zts/server" packages/vite-plugin-zts/src/; then
+            echo "::error::vite-plugin-zts 가 dev server 영역 (web/server/lightningcss/postcss-load-config) 을 참조함"
+            exit 1
+          fi
+
   wasm:
     name: WASM Build & Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

#2539 epic 의 PR #9. vite-plugin-zts 가 dev server 영역 (HMR overlay / postcss / sass / lightningcss / `@zts/web` / `@zts/server`) 을 참조하지 않는지 CI grep step 으로 회귀 방지.

## 이유

Vite 는 자체 dev server 를 운영 — `vite-plugin-zts` 는 transpile-only adapter 로 `@zts/core` 의 `transpile` / `init` / `TsconfigCache` 만 사용해야 합니다. dev server 영역이 우연히 새어 들어오면 (예: 오타 import) 이중 결합으로 Vite overlay / Vite HMR 이 깨질 수 있습니다.

## 검증 step (CI 추가)

```yaml
- name: vite-plugin-zts 의존 격리 검증
  run: |
    if grep -rE \"APP_DEV_HMR_CLIENT|lightningcss|postcss-load-config|@zts/web|@zts/server\" packages/vite-plugin-zts/src/; then
      echo \"::error::vite-plugin-zts 가 dev server 영역 ... 참조함\"
      exit 1
    fi
```

현재 main 기준 grep 결과 0 — guard 만 추가.

## Test plan

- [x] 로컬 검증 — `grep -rE \"APP_DEV_HMR_CLIENT|lightningcss|postcss-load-config|@zts/web|@zts/server\" packages/vite-plugin-zts/src/` → no matches
- [ ] CI 통과 시 auto-rebase merge

Refs #2539