### PR TITLE
docs(packages): document @zts/web + @zts/server split

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,18 @@ Vite 어댑터 — `vite-plugin-zts` 가 Vite 의 esbuild transform 을 ZTS 로 
 
 | 패키지 | 역할 |
 |--------|------|
-| `@zts/core` | NAPI .node 바인딩 + Node.js / Bun CLI (`zts` 커맨드) |
+| `@zts/core` | NAPI .node 바인딩 + Node.js / Bun CLI (`zts` 커맨드) + transpile / bundle / lightningcss |
+| `@zts/web` | dev server + HMR overlay + postcss / sass pipeline + dev controller (#2539) |
+| `@zts/server` | private — protocol / WS frame / watcher / HMR channel (web 의 dist 에 inline, 사용자 install 불필요) |
 | `@zts/wasm` | WASM 빌드 (브라우저 playground / Deno / Workers) |
 | `@zts/shared` | core / wasm 공유 타입 (TranspileOptions, Target, compat-engines) |
-| `vite-plugin-zts` | Vite 의 esbuild transform 을 ZTS 로 교체 |
+| `vite-plugin-zts` | Vite 의 esbuild transform 을 ZTS 로 교체 (`@zts/core` 만 사용) |
+
+### Install matrix
+
+- `@zts/core` 단독 — `zts transpile` / `zts bundle` (라이브러리 모드) / WASM 환경
+- `@zts/core` + `@zts/web` — `zts dev` / `zts preview` / `zts build` (app 모드 with postcss / sass / CSS Modules / HMR overlay)
+- `vite-plugin-zts` — Vite 사용자 (Vite 자체 dev server / HMR — `@zts/web` 불필요)
 
 ## References
 

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -210,17 +210,23 @@ src/
     wyhash.zig              #   wyhash 해시 (콘텐츠 해시 / mangler)
 
 packages/
-  core/                     # @zts/core — C NAPI .node addon + Node CLI (기본 경로)
-    bin/                    #   `zts` CLI 엔트리 (zts.mjs)
+  core/                     # @zts/core — C NAPI .node addon + Node CLI + lightningcss
+    bin/                    #   `zts` CLI 엔트리 (zts.mjs) — dev/preview/build app 시 @zts/web 을 lazy import
     src/                    #   napi_entry.zig + JS 사이드 (config-loader/load-env/workspace 등)
     index.ts                #   JS API (init/transpile/build) — NAPI .node 로드 + 옵션 검증
     dist/                   #   bun build 산출물 (배포용)
+  web/                      # @zts/web — dev server / postcss·sass / HMR overlay (#2539)
+    runtime/                #   APP_DEV_HMR_CLIENT (브라우저 inject 용)
+    src/                    #   inject / dev-controller / style/ (postcss · sass · css-modules · css-parser · loader)
+    dist/                   #   zts self-build (server 가 inline)
+  server/                   # @zts/server — private (npm 미공개, web/RN 공통 protocol/watcher/HMR)
+    src/                    #   protocol (HMR_MSG / 상수) / ws-frame (RFC 6455) / watcher / hmr-channel
+    dist/                   #   zts self-build — web 의 dist 에 자동 inline
   wasm/                     # @zts/wasm — WASM 빌드 (브라우저 playground, Deno/Workers)
     src/wasm_entry.zig      #   transpile only WASM 진입
     src/wasm_bundler_entry.zig  # 번들러 포함 WASM 진입 (wasm32-wasi + threads)
   shared/                   # core/wasm 공유 타입 (TranspileOptions, Target, compat-engines)
-  vite-plugin-zts/          # Vite 플러그인 (esbuild transform → ZTS 교체, @zts/core 기반)
-  plugin/                   # 사용자 플러그인 워크스페이스 (workspace 의존성용)
+  vite-plugin-zts/          # Vite 플러그인 (esbuild transform → ZTS 교체, @zts/core 만 사용)
 
 tests/
   test262/                  # TC39 공식 Test262 (서브모듈, 50,504건)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -26,6 +26,14 @@ zts preview [outdir]
 hashed JS/CSS/assets와 rewritten `dist/index.html`을 출력한다. `public/` 파일은
 변환 없이 outdir 루트로 복사하며 번들 산출물과 충돌하면 에러를 낸다.
 
+> **`@zts/web` 필요** (#2539) — `zts dev` / `zts preview` / `zts build` (app 모드) 는
+> `@zts/web` 패키지를 lazy import 한다. `@zts/core` 단독 install 사용자가 app
+> 모드를 호출하면 친화 에러 메시지 + exit 1. 설치:
+> ```bash
+> bun add -D @zts/web        # 또는 npm i -D @zts/web
+> ```
+> `zts transpile` / `zts bundle` (라이브러리 모드) 는 web 불필요.
+
 지원 옵션:
 
 - `--entry-html <file>` — 기본 `index.html`


### PR DESCRIPTION
## Summary

#2539 epic 의 PR #10. 패키지 분리 결과를 사용자 facing 문서에 반영.

## 변경 사항

### `README.md`

- Packages 표 갱신:
  - `@zts/core` — NAPI + CLI + transpile/bundle + lightningcss
  - `@zts/web` (신설) — dev server + HMR overlay + postcss/sass pipeline + dev controller
  - `@zts/server` (private) — protocol / ws-frame / watcher / hmr-channel (web dist 에 inline, npm 미공개)
  - `vite-plugin-zts` — `@zts/core` 만 사용
- Install matrix 추가 — core 단독 vs core+web vs vite-plugin 사용 시나리오

### `docs/STRUCTURE.md`

`packages/` tree 갱신 — `web/`, `server/` 추가. 각 디렉토리의 역할 (`runtime/`, `src/style/`, `src/inject.ts`, `dev-controller.ts` 등) 상세화.

### `docs/USAGE.md`

Vite-style app builder section 에 `@zts/web` 필요성 명시. `transpile`/`bundle` (라이브러리 모드) 와 `dev`/`preview`/`build` (app 모드) 의 install 차이 설명.

## Test plan

- [x] 문서만 변경, 코드 영향 없음
- [ ] CI 통과 시 auto-rebase merge

Refs #2539