### PR TITLE
fix(ci): emit @zts/core dts so @zts/web tsc can resolve imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,8 +119,11 @@ jobs:
         if: runner.os != 'Windows'
         run: zig build napi
 
-      - name: Build JS wrapper
-        run: cd packages/core && bun build index.ts --outdir dist --format esm --target node
+      # JS + dts 둘 다 emit. dts 는 web/server 의 `tsc --emitDeclarationOnly`
+      # 가 `import { prepareAppDevSync } from "@zts/core"` 의 declaration 을
+      # resolve 할 때 필요 (#2539 PR #6d 후 web 이 core 를 typed import).
+      - name: Build JS wrapper + dts
+        run: cd packages/core && bun run build:js && bun run build:dts
 
       - name: Copy .node to package
         run: cp zig-out/lib/zts.node packages/core/zts.node 2>/dev/null || true


### PR DESCRIPTION
## Summary

#2539 PR #6d 머지 직후부터 main `NAPI Build & Test (ubuntu-latest, macos-latest)` 가 fail. root cause 잡고 main CI 정상화.

## Root cause

PR #6d 가 `packages/web/src/dev-controller.ts` 에 다음을 추가:
```ts
import { prepareAppDevSync } from \"@zts/core\";
```

web 의 build script (`tsc --emitDeclarationOnly`) 가 이 import 의 declaration 을 `@zts/core` 의 `package.json` 의 `types: dist/core/index.d.ts` 로 resolve 하려는데 — CI 의 `Build JS wrapper` step 이 `bun build` (JS only) 만 했고 `tsc --emitDeclarationOnly` (dts emit) 는 안 함.

결과: `packages/core/dist/core/index.d.ts` 미존재 → web 의 dts emit 시 TS7016 `Could not find a declaration file for module '@zts/core'`.

로컬에서는 한번 `bun run --cwd packages/core build` (build:js + build:dts) 를 돌렸으면 dist/core/index.d.ts 가 남아 있어서 통과. clean checkout 시 재현됨 (확인).

## Fix

CI 의 `Build JS wrapper` step 을 `bun run build:js && bun run build:dts` 로 변경. step 이름도 `Build JS wrapper + dts` 로 갱신.

## Test plan

- [x] 로컬 재현 — `rm -rf packages/{core,web,server}/dist && cd packages/core && bun run build:js && cd ../.. && bun run --cwd packages/web build` → TS7016 fail
- [x] Fix 검증 — `bun run --cwd packages/core build:js && bun run build:dts && bun run --cwd packages/web build` → 통과
- [x] 전체 — `bun run --cwd packages/core test bin/zts.test.ts` → 222 pass / 0 fail
- [x] @zts/web 141 pass, @zts/server 67 pass

Refs #2539