### PR TITLE
chore(packages): apply /simplify follow-ups for #2539 PR #7-#10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,19 @@ jobs:
       - name: Run NAPI tests (Node.js)
         run: node --test packages/core/napi.test.mjs
 
+      # vite-plugin-zts 가 dev server 영역 (HMR overlay / postcss / sass /
+      # lightningcss / @zts/web / @zts/server) 을 import / inline 하지 않는지
+      # 검증 — Vite 의 자체 dev server 가 처리하므로 이중 결합되면 안 됨 (#2539).
+      # CLI 테스트보다 먼저 — fast-fail (격리 위반은 다른 회귀의 root cause 일
+      # 가능성 높음). Windows runner 의 grep 신뢰성 낮아 Linux/macOS 만 실행.
+      - name: vite-plugin-zts 의존 격리 검증
+        if: runner.os != 'Windows'
+        run: |
+          if grep -rE --include="*.ts" "APP_DEV_HMR_CLIENT|\\blightningcss\\b|\\bpostcss\\b|@zts/web|@zts/server" packages/vite-plugin-zts/src/; then
+            echo "::error::vite-plugin-zts 가 dev server 영역 (web/server/lightningcss/postcss) 을 참조함"
+            exit 1
+          fi
+
       # CLI 테스트의 dev/preview/build app 시나리오는 spawn 한 zts.mjs 가
       # `import("@zts/web")` 을 호출 → packages/web/dist/index.js 필요.
       # `bun run test` 가 packages/core/package.json 의 pretest hook 을 트리거 →
@@ -149,16 +162,6 @@ jobs:
       - name: Bundler 코어 회귀 검증 (#1960~#1962)
         continue-on-error: true
         run: bun scripts/napi-bundler-bug-check.ts
-
-      # vite-plugin-zts 가 dev server 영역 (HMR overlay / postcss / sass /
-      # lightningcss / @zts/web / @zts/server) 을 import / inline 하지 않는지
-      # 검증 — Vite 의 자체 dev server 가 처리하므로 이중 결합되면 안 됨 (#2539).
-      - name: vite-plugin-zts 의존 격리 검증
-        run: |
-          if grep -rE "APP_DEV_HMR_CLIENT|lightningcss|postcss-load-config|@zts/web|@zts/server" packages/vite-plugin-zts/src/; then
-            echo "::error::vite-plugin-zts 가 dev server 영역 (web/server/lightningcss/postcss-load-config) 을 참조함"
-            exit 1
-          fi
 
   wasm:
     name: WASM Build & Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,8 +119,11 @@ jobs:
         if: runner.os != 'Windows'
         run: zig build napi
 
-      - name: Build JS wrapper
-        run: cd packages/core && bun build index.ts --outdir dist --format esm --target node
+      # JS + dts 둘 다 emit. dts 는 web/server 의 `tsc --emitDeclarationOnly`
+      # 가 `import { prepareAppDevSync } from "@zts/core"` 의 declaration 을
+      # resolve 할 때 필요 (#2539 PR #6d 후 web 이 core 를 typed import).
+      - name: Build JS wrapper + dts
+        run: cd packages/core && bun run build:js && bun run build:dts
 
       - name: Copy .node to package
         run: cp zig-out/lib/zts.node packages/core/zts.node 2>/dev/null || true

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zts/web",
   "version": "0.1.0",
-  "description": "ZTS web platform — dev server, postcss/sass pipeline, HMR overlay",
+  "description": "ZTS web platform — dev server + HMR overlay + postcss/sass pipeline + dev controller",
   "license": "MIT",
   "files": [
     "dist/",

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,5 +1,5 @@
-// @zts/web — dev server / postcss·sass·lightningcss / HMR overlay 가 자리잡는 패키지.
-// 분리 진행: #2539.
+// @zts/web — dev server / postcss·sass / HMR overlay 가 자리잡는 패키지 (#2539).
+// lightningcss 는 @zts/core 가 직접 사용 (CSS minify 후처리), web 영역 아님.
 
 // `@zts/server` 의 HMR / Watcher 표면을 web 사용자 (zts.mjs CLI / RN bridge /
 // future edge runtime) 가 단일 entry 로 받도록 재수출. server 는 private 패키지라


### PR DESCRIPTION
## Summary

이전 sub-PR (#9 grep / #10 docs / #2593 dts fix) 머지 시 `/simplify` 누락한 4 PR 묶음에 대해 cross-file review 후 finding 반영.

## CI grep step 정밀화 (#9 → 개선)

- `--include=\"*.ts\"` 추가 — false positive (주석 / 문자열 매치) 회피
- regex 단어 경계 (`\\bword\\b`) — `lightningcss`, `postcss` 의 부분 매치 회피 (예: `composesPattern`)
- `postcss` 키워드 추가 — `postcss-load-config` 만 잡던 기존 패턴 보완 (vite-plugin-zts 가 standalone postcss import 도 안 해야 함)
- step 위치 — Bundler 회귀 검증 뒤 → CLI 테스트 *앞* 으로 이동 (fast-fail)
- `if: runner.os != 'Windows'` — Windows runner 의 grep 신뢰성 회피, Linux/macOS 만 실행

## description / comment drift 정정

- `packages/web/package.json` description — README install matrix 와 phrasing 통일 (`+ dev controller` 추가, separator 통일)
- `packages/web/src/index.ts` 첫 줄 코멘트 — `lightningcss` 표기 제거 (web 영역 아님, core 가 직접 사용)

## /simplify 3-agent finding

**Apply**:
- CI grep false positive (Agent 2)
- CI grep Windows 호환성 (Agent 3)
- CI step 순서 fast-fail (Agent 3)
- description drift README ↔ package.json (Agent 1)

**Skip**:
- `optionalDependencies → peerDependencies` (Agent 2) — 사용자가 postcss/sass 미사용 시 lazy load 안 함, optional 의도에 부합

## Test plan

- [x] 로컬 grep 검증 — `grep -rE --include=\"*.ts\" \"APP_DEV_HMR_CLIENT|\\bpostcss\\b|...\" packages/vite-plugin-zts/src/` → 매치 0 (PASS)
- [x] `@zts/web` 141 pass / 0 fail
- [ ] CI 통과 시 auto-rebase merge

Refs #2539