### PR TITLE
ci(packages): remove redundant vite-plugin-zts grep guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,19 +134,6 @@ jobs:
       - name: Run NAPI tests (Node.js)
         run: node --test packages/core/napi.test.mjs
 
-      # vite-plugin-zts 가 dev server 영역 (HMR overlay / postcss / sass /
-      # lightningcss / @zts/web / @zts/server) 을 import / inline 하지 않는지
-      # 검증 — Vite 의 자체 dev server 가 처리하므로 이중 결합되면 안 됨 (#2539).
-      # CLI 테스트보다 먼저 — fast-fail (격리 위반은 다른 회귀의 root cause 일
-      # 가능성 높음). Windows runner 의 grep 신뢰성 낮아 Linux/macOS 만 실행.
-      - name: vite-plugin-zts 의존 격리 검증
-        if: runner.os != 'Windows'
-        run: |
-          if grep -rE --include="*.ts" "APP_DEV_HMR_CLIENT|\\blightningcss\\b|\\bpostcss\\b|@zts/web|@zts/server" packages/vite-plugin-zts/src/; then
-            echo "::error::vite-plugin-zts 가 dev server 영역 (web/server/lightningcss/postcss) 을 참조함"
-            exit 1
-          fi
-
       # CLI 테스트의 dev/preview/build app 시나리오는 spawn 한 zts.mjs 가
       # `import("@zts/web")` 을 호출 → packages/web/dist/index.js 필요.
       # `bun run test` 가 packages/core/package.json 의 pretest hook 을 트리거 →


### PR DESCRIPTION
## Summary

#2539 PR #9 (#2591) 에서 추가했던 vite-plugin-zts 의존 격리 grep step 제거.

## 제거 이유

`vite-plugin-zts` 가 `@zts/web` / `@zts/server` / `lightningcss` / `postcss` 를 import 하려 하면:

1. **npm/bun install** — `vite-plugin-zts/package.json` 의 `dependencies` 에 없어서 resolution fail
2. **TypeScript 컴파일** — module not found 에러
3. **런타임** — `Cannot find module`

즉 npm + tsc 의 module resolution 이 **이미 처리하는 사항을 grep 으로 중복 검사**. 추가 보호 가치 없고 false positive 위험만 키움.

진짜 의미 있는 검증은 `vite-plugin-zts/package.json` 의 `dependencies` 변화 — 그건 PR review / git log 에서 잡으면 됨. CI grep step 은 redundant.

simplify follow-up (#2594) 에서 정밀화한 패턴조차 본질적으로 가치 없는 검증임. 제거.

## Test plan

- [x] CI grep step 제거 후 다른 step 영향 없음 (의존성 없음)
- [ ] CI 통과 시 auto-rebase merge

Refs #2539