### PR TITLE
fix(ci): build @zts/web + @zts/server before E2E tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -96,6 +96,16 @@ jobs:
           submodules: recursive
       - uses: ./.github/actions/setup-zts
 
+      # E2E test fixture 가 spawn 한 `zts build` (app 모드) 가 `@zts/web` 을
+      # lazy import. setup-zts 는 core build:js 까지만 — web/server 와 core
+      # dts 를 별도 빌드 (#2539 PR #6d 후 web 의 tsc emit 가 core 의
+      # `prepareAppDevSync` declaration 의존).
+      - name: Build @zts/core dts + @zts/server + @zts/web (E2E app 모드 의존)
+        run: |
+          bun run --cwd packages/core build:dts
+          bun run --cwd packages/server build
+          bun run --cwd packages/web build
+
       - name: Install Playwright browsers
         run: bun run playwright:install
 


### PR DESCRIPTION
## Summary

#2539 epic 머지 직후부터 main `Integration & E2E` 의 E2E job 이 fail 한 회귀. root cause 잡고 정상화.

## Root cause

E2E test fixture (`tests/e2e/tests/zts-app-builder-e2e.test.ts`) 가 spawn 한 `zts build` (app mode) 가 `loadWebModule()` → `import(\"@zts/web\")` 호출. 그런데:

1. `.github/actions/setup-zts/action.yml` 가 `bun run --cwd packages/core build:js` 까지만 — web/server 빌드 안 함, core dts emit 도 안 함
2. `integration.yml` 의 `e2e` job 도 별도 web build step 없음
3. 결과: `packages/web/dist/index.js` 미존재 → 친화 에러 메시지 + exit 1 → playwright fixture 의 `built.status !== 0` 분기에서 `Error: zts build css modules failed: error: @zts/web 패키지가 필요합니다`

CI 의 NAPI Build & Test job (`ci.yml`) 은 `packages/core/package.json` 의 `pretest` hook 으로 자동 처리됐지만, `integration.yml` 의 E2E job 은 `bun run test:e2e` 만 호출 (pretest 없음).

epic 의 모든 PR 머지에서 동일 fail 누적 (e088dd8a / 3f67d713 / 558f08cb 등 — `558f08cb` 가 PR #6d 머지 시점).

## Fix

E2E job 의 `setup-zts` 후, `Run E2E tests` 전에 build step 추가:

```yaml
- name: Build @zts/core dts + @zts/server + @zts/web (E2E app 모드 의존)
  run: |
    bun run --cwd packages/core build:dts
    bun run --cwd packages/server build
    bun run --cwd packages/web build
```

다른 jobs (Integration / Hermes / compat-table / Smoke) 는 `zts dev` / `zts build` (app mode) 호출 안 함 — bundle / transpile 만 — web 불필요.

## Test plan

- [x] 로컬 재현 — clean dist 에서 `zts build` 호출 시 친화 에러 메시지로 exit
- [x] Fix 검증 — `core build:dts && server build && web build` 후 `zts build` 정상 동작 (산출물 정상 emit)
- [ ] CI 통과 시 auto-rebase merge

Refs #2539