### PR TITLE
ci: trigger Integration & E2E on workflow + setup-zts changes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,12 +7,17 @@ on:
       - 'src/**'
       - 'packages/**'
       - 'tests/**'
+      - '.github/workflows/integration.yml'
+      - '.github/actions/setup-zts/**'
   pull_request:
     branches: [main]
     paths:
       - 'src/**'
       - 'packages/**'
       - 'tests/**'
+      - '.github/workflows/integration.yml'
+      - '.github/actions/setup-zts/**'
+  workflow_dispatch:
 
 jobs:
   integration:


### PR DESCRIPTION
## Summary

`integration.yml` 의 trigger paths 가 `src/**` / `packages/**` / `tests/**` 만 매치 — workflow 자체 (`integration.yml`) 또는 `setup-zts` action 변경 시 재실행 안 됨.

PR #2596 (E2E web build fix) 가 머지됐는데 워크플로 자체 변경이라 트리거 안 돼서 fix 효과를 새 run 에서 확인 불가. 다음 packages/ 변경 머지를 기다려야 하는 상황.

## Fix

- `paths` 에 `.github/workflows/integration.yml` + `.github/actions/setup-zts/**` 추가
- `workflow_dispatch:` 트리거 추가 (수동 `gh workflow run` 가능)

이제 워크플로 / setup-zts 변경 시 자동 재실행 + 필요 시 수동 실행.

Refs #2539