### PR TITLE
feat(react-native): RN runtime (zts-hmr-client.js) + runtime-loader

### DIFF
--- a/packages/react-native/runtime/zts-hmr-client.js
+++ b/packages/react-native/runtime/zts-hmr-client.js
@@ -1,0 +1,207 @@
+/**
+ * ZTS HMR Client - Metro HMRClient interface replacement for ZTS bundler.
+ * Connects to the dev server WebSocket and applies ZTS-format HMR updates
+ * via __zts_apply_update() (injected by ZTS dev mode runtime).
+ */
+"use strict";
+
+// Metro HMRClient 와 동일한 'Refreshing...' 배너 동작을 위해 NativeModules.DevLoadingView 접근.
+// RN global 이 채워지기 전/환경 부재 상황 (web, 테스트) 에선 조용히 no-op.
+function getDevLoadingView() {
+  try {
+    var nm =
+      (typeof global !== "undefined" && global.NativeModules) ||
+      (typeof window !== "undefined" && window.NativeModules) ||
+      null;
+    return nm && nm.DevLoadingView ? nm.DevLoadingView : null;
+  } catch (_e) {
+    return null;
+  }
+}
+
+var HMRClient = {
+  _socket: null,
+  _enabled: true,
+  // Metro 처럼 중첩 update 를 카운트 — 마지막 update-done 에서만 배너 hide.
+  _pendingUpdates: 0,
+
+  enable: function () {
+    this._enabled = true;
+  },
+
+  disable: function () {
+    this._enabled = false;
+  },
+
+  registerBundle: function (_requestUrl) {
+    // No-op: ZTS bundler does not require bundle registration
+  },
+
+  log: function (level, data) {
+    if (this._socket && this._socket.readyState === 1) {
+      try {
+        this._socket.send(JSON.stringify({ type: "log", level: level, data: data }));
+      } catch (_e) {
+        // ignore
+      }
+    }
+  },
+
+  setup: function (platform, bundleEntry, host, port, isEnabled, scheme) {
+    if (this._socket != null) {
+      return;
+    }
+    var protocol = scheme === "https" ? "wss" : "ws";
+    var portPart = port != null && port !== "" ? ":" + port : "";
+    var wsUrl = protocol + "://" + host + portPart + "/hot";
+    var socket = new (typeof WebSocket !== "undefined" ? WebSocket : global.WebSocket)(wsUrl);
+    this._socket = socket;
+    this._enabled = isEnabled !== false;
+
+    var self = this;
+
+    socket.onopen = function () {
+      socket.send(
+        JSON.stringify({
+          type: "hmr:connected",
+          bundleEntry: bundleEntry,
+          platform: platform,
+        }),
+      );
+
+      // Intercept console methods to forward logs to dev server terminal
+      var levels = ["log", "info", "warn", "error", "debug"];
+      for (var i = 0; i < levels.length; i++) {
+        (function (level) {
+          var original = console[level];
+          if (typeof original === "function") {
+            console[level] = function () {
+              // Call original first
+              original.apply(console, arguments);
+              // Forward to server
+              if (socket.readyState === 1) {
+                try {
+                  var args = [];
+                  for (var j = 0; j < arguments.length; j++) {
+                    var arg = arguments[j];
+                    // Serialize safely — avoid circular references
+                    if (arg instanceof Error) {
+                      args.push(arg.message);
+                    } else if (typeof arg === "object" && arg !== null) {
+                      try {
+                        args.push(JSON.parse(JSON.stringify(arg)));
+                      } catch (_e) {
+                        args.push(String(arg));
+                      }
+                    } else {
+                      args.push(arg);
+                    }
+                  }
+                  socket.send(JSON.stringify({ type: "log", level: level, data: args }));
+                } catch (_e) {
+                  // ignore serialization errors
+                }
+              }
+            };
+          }
+        })(levels[i]);
+      }
+    };
+
+    socket.onmessage = function (event) {
+      try {
+        var msg = JSON.parse(event.data);
+        if (!self._enabled && msg.type !== "hmr:error") {
+          return;
+        }
+        switch (msg.type) {
+          case "hmr:update-start":
+            self._pendingUpdates++;
+            // Initial update sequence (서버가 connect 시 전송해 로딩바 dismiss 용) 는
+            // 실제 코드 변경이 아니므로 "Refreshing..." 배너 노출 skip.
+            // Metro HMRClient 동일 동작 (isInitialUpdate flag 검사).
+            if (self._enabled && !msg.isInitialUpdate) {
+              var dlvStart = getDevLoadingView();
+              if (dlvStart && typeof dlvStart.showMessage === "function") {
+                try {
+                  dlvStart.showMessage("Refreshing...", "refresh");
+                } catch (_e) {
+                  // DevLoadingView 호출 실패는 HMR 동작과 무관 — 무시
+                }
+              }
+            }
+            break;
+          case "hmr:update":
+            console.log(
+              "[ZTS HMR] update received, modules:",
+              msg.modules ? msg.modules.length : 0,
+            );
+            console.log("[ZTS HMR] __zts_apply_update:", typeof __zts_apply_update);
+            console.log("[ZTS HMR] global.__zts_apply_update:", typeof global.__zts_apply_update);
+            var applyFn =
+              typeof __zts_apply_update === "function"
+                ? __zts_apply_update
+                : global.__zts_apply_update;
+            if (typeof applyFn === "function" && msg.modules && msg.modules.length > 0) {
+              console.log(
+                "[ZTS HMR] calling __zts_apply_update with",
+                msg.modules.length,
+                "modules",
+              );
+              try {
+                applyFn(msg.modules);
+                console.log("[ZTS HMR] __zts_apply_update completed successfully");
+              } catch (e) {
+                console.error("[ZTS HMR] __zts_apply_update threw:", e);
+              }
+            } else {
+              console.warn("[ZTS HMR] __zts_apply_update not available or no modules");
+            }
+            break;
+          case "hmr:update-done":
+            if (self._pendingUpdates > 0) self._pendingUpdates--;
+            if (self._pendingUpdates === 0) {
+              var dlvDone = getDevLoadingView();
+              if (dlvDone && typeof dlvDone.hide === "function") {
+                try {
+                  dlvDone.hide();
+                } catch (_e) {
+                  // 무시
+                }
+              }
+            }
+            break;
+          case "hmr:reload":
+            // Reuse __zts_reload() from ZTS HMR runtime (injected via --dev mode)
+            if (typeof __zts_reload === "function") {
+              __zts_reload();
+            } else if (typeof location !== "undefined") {
+              location.reload();
+            }
+            break;
+          case "hmr:error":
+            if (msg.message) {
+              console.error("[ZTS HMR]", msg.message);
+            }
+            break;
+          default:
+            break;
+        }
+      } catch (e) {
+        console.warn("[ZTS HMR] Invalid message", e);
+      }
+    };
+
+    socket.onerror = function () {
+      console.warn("[ZTS HMR] WebSocket error");
+    };
+
+    socket.onclose = function () {
+      self._socket = null;
+    };
+  },
+};
+
+// RN의 setUpBatchedBridge가 require('HMRClient').default로 접근하므로 default export 필요
+module.exports = HMRClient;
+module.exports.default = HMRClient;

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -25,3 +25,4 @@ export type {
   ResolutionContext,
 } from "./metro-resolver-types.ts";
 export { escapeRegex } from "./plugins/escape-regex.ts";
+export { HMR_CLIENT_SUFFIX, ZTS_HMR_CLIENT_CODE } from "./runtime-loader.ts";

--- a/packages/react-native/src/runtime-loader.test.ts
+++ b/packages/react-native/src/runtime-loader.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+
+import { HMR_CLIENT_SUFFIX, ZTS_HMR_CLIENT_CODE } from "./runtime-loader.ts";
+
+describe("ZTS_HMR_CLIENT_CODE", () => {
+  test("빈 string 아님 (runtime/zts-hmr-client.js 정상 로드)", () => {
+    expect(ZTS_HMR_CLIENT_CODE.length).toBeGreaterThan(0);
+  });
+
+  test("module.exports default 포함 — RN setUpBatchedBridge 호환", () => {
+    expect(ZTS_HMR_CLIENT_CODE).toContain("module.exports");
+    expect(ZTS_HMR_CLIENT_CODE).toContain(".default");
+  });
+
+  test("Metro HMRClient interface 의 핵심 method 포함", () => {
+    expect(ZTS_HMR_CLIENT_CODE).toContain("setup");
+    expect(ZTS_HMR_CLIENT_CODE).toContain("enable");
+    expect(ZTS_HMR_CLIENT_CODE).toContain("disable");
+    expect(ZTS_HMR_CLIENT_CODE).toContain("registerBundle");
+    expect(ZTS_HMR_CLIENT_CODE).toContain("log");
+  });
+
+  test("WebSocket 사용 (Metro `/hot` endpoint)", () => {
+    expect(ZTS_HMR_CLIENT_CODE).toContain("WebSocket");
+    expect(ZTS_HMR_CLIENT_CODE).toContain("/hot");
+  });
+
+  test("Metro 메시지 type 분기 모두 포함", () => {
+    expect(ZTS_HMR_CLIENT_CODE).toContain("hmr:connected");
+    expect(ZTS_HMR_CLIENT_CODE).toContain("hmr:update-start");
+    expect(ZTS_HMR_CLIENT_CODE).toContain("hmr:update");
+    expect(ZTS_HMR_CLIENT_CODE).toContain("hmr:update-done");
+    expect(ZTS_HMR_CLIENT_CODE).toContain("hmr:reload");
+    expect(ZTS_HMR_CLIENT_CODE).toContain("hmr:error");
+  });
+
+  test("ZTS HMR runtime hook 호출 (`__zts_apply_update`, `__zts_reload`)", () => {
+    expect(ZTS_HMR_CLIENT_CODE).toContain("__zts_apply_update");
+    expect(ZTS_HMR_CLIENT_CODE).toContain("__zts_reload");
+  });
+
+  test("DevLoadingView 의 'Refreshing...' 배너 호출", () => {
+    expect(ZTS_HMR_CLIENT_CODE).toContain("DevLoadingView");
+    expect(ZTS_HMR_CLIENT_CODE).toContain("Refreshing");
+  });
+
+  test("초기 update sequence (isInitialUpdate flag) 분기 존재", () => {
+    expect(ZTS_HMR_CLIENT_CODE).toContain("isInitialUpdate");
+  });
+});
+
+describe("HMR_CLIENT_SUFFIX", () => {
+  test("RN core 의 HMRClient.js path suffix", () => {
+    expect(HMR_CLIENT_SUFFIX).toBe("/Libraries/Utilities/HMRClient.js");
+  });
+
+  test("path 가 절대 (slash 시작)", () => {
+    expect(HMR_CLIENT_SUFFIX.startsWith("/")).toBe(true);
+  });
+
+  test(".js 확장자로 끝남 (Metro 가 transform 대상 인식)", () => {
+    expect(HMR_CLIENT_SUFFIX.endsWith(".js")).toBe(true);
+  });
+});

--- a/packages/react-native/src/runtime-loader.ts
+++ b/packages/react-native/src/runtime-loader.ts
@@ -1,0 +1,39 @@
+// RN runtime asset loader — `runtime/zts-hmr-client.js` 를 module load 시점에
+// readFileSync 로 읽어 string 으로 노출. plugin factory (createAssetPlugin) 가
+// HMRClient.js path 매칭 시 onLoad 응답으로 그대로 반환 — RN runtime 의
+// require('HMRClient') 가 bundle 안의 ZTS_HMR_CLIENT_CODE 에 도달.
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// dist/index.js 옆의 ../runtime/zts-hmr-client.js — package.json `files`
+// 에 `runtime/` 포함으로 npm publish 시 dist/ 와 같이 복사됨.
+const RUNTIME_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "runtime",
+  "zts-hmr-client.js",
+);
+
+/**
+ * RN runtime 의 HMRClient interface 호환 코드 (string).
+ * runtime/zts-hmr-client.js 가 dist 와 함께 publish 되어야 정상 로드.
+ *
+ * fallback dummy: build 직후 / 누락 환경에서 dynamic require 가 throw 안 하도록
+ * minimal no-op HMRClient 객체 export (RN 의 setUpBatchedBridge 가 default
+ * 접근 — `module.exports.default` 보존).
+ */
+export const ZTS_HMR_CLIENT_CODE: string = (() => {
+  try {
+    return readFileSync(RUNTIME_PATH, "utf-8");
+  } catch {
+    return "module.exports = { setup() {}, enable() {}, disable() {}, registerBundle() {}, log() {} }; module.exports.default = module.exports;";
+  }
+})();
+
+/**
+ * RN runtime 의 `HMRClient.js` 의 path suffix (Metro 의 모듈 path 가 이 suffix
+ * 로 끝남). plugin factory 가 onLoad path 매칭 시 사용.
+ */
+export const HMR_CLIENT_SUFFIX = "/Libraries/Utilities/HMRClient.js";

--- a/packages/react-native/src/runtime/zts-hmr-client.test.mjs
+++ b/packages/react-native/src/runtime/zts-hmr-client.test.mjs
@@ -1,0 +1,326 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname_ = dirname(fileURLToPath(import.meta.url));
+const HMR_CLIENT_PATH = join(__dirname_, "..", "..", "runtime", "zts-hmr-client.js");
+const HMR_CLIENT_SOURCE = readFileSync(HMR_CLIENT_PATH, "utf-8");
+
+// CommonJS 식 module.exports 패턴 — 평가 후 module.exports 회수.
+function loadHmrClient(globalEnv) {
+  const moduleObj = { exports: {} };
+  const fnSource = `
+    var module = arguments[0];
+    var global = arguments[1];
+    var WebSocket = arguments[2];
+    var console = arguments[3];
+    var __zts_apply_update = arguments[4];
+    var __zts_reload = arguments[5];
+    var location = arguments[6];
+    var window = arguments[7];
+    ${HMR_CLIENT_SOURCE}
+    return module.exports;
+  `;
+  const factory = new Function(fnSource);
+  return factory(
+    moduleObj,
+    globalEnv.global,
+    globalEnv.WebSocket,
+    globalEnv.console,
+    globalEnv.__zts_apply_update,
+    globalEnv.__zts_reload,
+    globalEnv.location,
+    globalEnv.window,
+  );
+}
+
+class MockWebSocket {
+  constructor(url) {
+    MockWebSocket.lastUrl = url;
+    MockWebSocket.instances.push(this);
+    this.readyState = 1;
+    this.url = url;
+    this.sent = [];
+    this.onopen = null;
+    this.onmessage = null;
+    this.onerror = null;
+    this.onclose = null;
+  }
+  send(data) {
+    this.sent.push(data);
+  }
+  close() {
+    this.readyState = 3;
+    if (this.onclose) this.onclose();
+  }
+  static reset() {
+    MockWebSocket.instances = [];
+    MockWebSocket.lastUrl = null;
+  }
+}
+MockWebSocket.instances = [];
+
+let HMRClient;
+let mockGlobal;
+let mockConsole;
+// wrap 전 console.X 의 mock 보존 — onopen 에서 console.X 가 wrappedFn 으로
+// 교체되므로 toHaveBeenCalledWith 검증 시 wrap 전 ref 사용 필요.
+let originalConsole;
+
+beforeEach(() => {
+  MockWebSocket.reset();
+  mockGlobal = {
+    NativeModules: {
+      DevLoadingView: { showMessage: mock(() => {}), hide: mock(() => {}) },
+    },
+    WebSocket: MockWebSocket,
+    __zts_apply_update: mock(() => {}),
+    __zts_reload: mock(() => {}),
+  };
+  mockConsole = {
+    log: mock(() => {}),
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    debug: mock(() => {}),
+  };
+  originalConsole = { ...mockConsole };
+  HMRClient = loadHmrClient({
+    global: mockGlobal,
+    WebSocket: MockWebSocket,
+    console: mockConsole,
+    __zts_apply_update: mockGlobal.__zts_apply_update,
+    __zts_reload: mockGlobal.__zts_reload,
+    location: { reload: mock(() => {}) },
+    window: undefined,
+  });
+});
+
+afterEach(() => {
+  MockWebSocket.reset();
+});
+
+describe("module.exports — Metro 호환", () => {
+  test("default export 가 module.exports 와 같은 객체 (setUpBatchedBridge 호환)", () => {
+    expect(HMRClient.default).toBe(HMRClient);
+  });
+
+  test("Metro HMRClient interface 의 method 모두 존재", () => {
+    expect(typeof HMRClient.setup).toBe("function");
+    expect(typeof HMRClient.enable).toBe("function");
+    expect(typeof HMRClient.disable).toBe("function");
+    expect(typeof HMRClient.registerBundle).toBe("function");
+    expect(typeof HMRClient.log).toBe("function");
+  });
+});
+
+describe("setup()", () => {
+  test("WebSocket URL 형성 (`wss://` for https scheme)", () => {
+    HMRClient.setup("ios", "/abs/index.js", "localhost", 8081, true, "https");
+    expect(MockWebSocket.lastUrl).toBe("wss://localhost:8081/hot");
+  });
+
+  test("WebSocket URL 형성 (`ws://` for non-https)", () => {
+    HMRClient.setup("ios", "/abs/index.js", "127.0.0.1", 8081, true, "http");
+    expect(MockWebSocket.lastUrl).toBe("ws://127.0.0.1:8081/hot");
+  });
+
+  test("port 미지정 시 portPart 생략", () => {
+    HMRClient.setup("android", "/abs/index.js", "localhost", null, true, "http");
+    expect(MockWebSocket.lastUrl).toBe("ws://localhost/hot");
+  });
+
+  test("port 빈 string 시 portPart 생략", () => {
+    HMRClient.setup("android", "/abs/index.js", "localhost", "", true, "http");
+    expect(MockWebSocket.lastUrl).toBe("ws://localhost/hot");
+  });
+
+  test("두 번째 setup 호출은 no-op (idempotent)", () => {
+    HMRClient.setup("ios", "/abs/idx.js", "localhost", 8081, true, "http");
+    HMRClient.setup("android", "/abs/idx.js", "localhost", 9000, true, "http");
+    expect(MockWebSocket.instances.length).toBe(1);
+  });
+
+  test("isEnabled=false 시 _enabled false", () => {
+    HMRClient.setup("ios", "/abs/idx.js", "localhost", 8081, false, "http");
+    expect(HMRClient._enabled).toBe(false);
+  });
+});
+
+describe("onopen — hmr:connected + console wrap", () => {
+  test("'hmr:connected' 메시지 송출 + bundleEntry/platform 포함", () => {
+    HMRClient.setup("ios", "/abs/idx.js", "localhost", 8081, true, "http");
+    const ws = MockWebSocket.instances[0];
+    ws.onopen();
+    const msg = JSON.parse(ws.sent[0]);
+    expect(msg).toEqual({ type: "hmr:connected", bundleEntry: "/abs/idx.js", platform: "ios" });
+  });
+
+  test("console method wrap — original 호출 + socket.send forward", () => {
+    HMRClient.setup("ios", "/abs/idx.js", "localhost", 8081, true, "http");
+    const ws = MockWebSocket.instances[0];
+    ws.onopen();
+    // wrap 후 mockConsole.log 자체가 wrappedFn — 호출은 wrap 된 함수로.
+    mockConsole.log("hello");
+    // wrap 안에서 original (originalConsole.log) 호출 검증.
+    expect(originalConsole.log).toHaveBeenCalledWith("hello");
+    // socket.send forward — 'hmr:connected' + 'log' 메시지
+    expect(ws.sent.length).toBe(2);
+    const log = JSON.parse(ws.sent[1]);
+    expect(log.type).toBe("log");
+    expect(log.level).toBe("log");
+    expect(log.data).toEqual(["hello"]);
+  });
+
+  test("Error object 는 message 만 send", () => {
+    HMRClient.setup("ios", "/abs/idx.js", "localhost", 8081, true, "http");
+    const ws = MockWebSocket.instances[0];
+    ws.onopen();
+    mockConsole.error(new Error("boom"));
+    const log = JSON.parse(ws.sent[1]);
+    expect(log.data).toEqual(["boom"]);
+  });
+
+  test("circular reference 객체 fallback (String 변환)", () => {
+    HMRClient.setup("ios", "/abs/idx.js", "localhost", 8081, true, "http");
+    const ws = MockWebSocket.instances[0];
+    ws.onopen();
+    const obj = { a: 1 };
+    obj.self = obj;
+    mockConsole.log(obj);
+    const log = JSON.parse(ws.sent[1]);
+    expect(typeof log.data[0]).toBe("string");
+    expect(log.data[0]).toContain("[object");
+  });
+});
+
+describe("onmessage — Metro 메시지 분기", () => {
+  function setupConnected() {
+    HMRClient.setup("ios", "/abs/idx.js", "localhost", 8081, true, "http");
+    const ws = MockWebSocket.instances[0];
+    ws.onopen();
+    return ws;
+  }
+
+  test("hmr:update-start (isInitial=true) — DevLoadingView.showMessage 호출 안 함", () => {
+    const ws = setupConnected();
+    ws.onmessage({ data: JSON.stringify({ type: "hmr:update-start", isInitialUpdate: true }) });
+    expect(mockGlobal.NativeModules.DevLoadingView.showMessage).not.toHaveBeenCalled();
+  });
+
+  test("hmr:update-start (incremental) — DevLoadingView.showMessage('Refreshing...', 'refresh')", () => {
+    const ws = setupConnected();
+    ws.onmessage({ data: JSON.stringify({ type: "hmr:update-start" }) });
+    expect(mockGlobal.NativeModules.DevLoadingView.showMessage).toHaveBeenCalledWith(
+      "Refreshing...",
+      "refresh",
+    );
+  });
+
+  test("hmr:update — __zts_apply_update 호출 with modules", () => {
+    const ws = setupConnected();
+    const modules = [{ id: "abc", code: "__d(...)" }];
+    ws.onmessage({ data: JSON.stringify({ type: "hmr:update", modules }) });
+    expect(mockGlobal.__zts_apply_update).toHaveBeenCalledWith(modules);
+  });
+
+  test("hmr:update — modules 없으면 __zts_apply_update 호출 안 함", () => {
+    const ws = setupConnected();
+    ws.onmessage({ data: JSON.stringify({ type: "hmr:update" }) });
+    expect(mockGlobal.__zts_apply_update).not.toHaveBeenCalled();
+  });
+
+  test("hmr:update-done — pendingUpdates 0 도달 시 DevLoadingView.hide", () => {
+    const ws = setupConnected();
+    ws.onmessage({ data: JSON.stringify({ type: "hmr:update-start" }) });
+    ws.onmessage({ data: JSON.stringify({ type: "hmr:update-done" }) });
+    expect(mockGlobal.NativeModules.DevLoadingView.hide).toHaveBeenCalled();
+  });
+
+  test("hmr:update-done 중첩 — 마지막 update-done 에서만 hide", () => {
+    const ws = setupConnected();
+    ws.onmessage({ data: JSON.stringify({ type: "hmr:update-start" }) });
+    ws.onmessage({ data: JSON.stringify({ type: "hmr:update-start" }) });
+    ws.onmessage({ data: JSON.stringify({ type: "hmr:update-done" }) });
+    expect(mockGlobal.NativeModules.DevLoadingView.hide).not.toHaveBeenCalled();
+    ws.onmessage({ data: JSON.stringify({ type: "hmr:update-done" }) });
+    expect(mockGlobal.NativeModules.DevLoadingView.hide).toHaveBeenCalledTimes(1);
+  });
+
+  test("hmr:reload — __zts_reload 호출", () => {
+    const ws = setupConnected();
+    ws.onmessage({ data: JSON.stringify({ type: "hmr:reload" }) });
+    expect(mockGlobal.__zts_reload).toHaveBeenCalled();
+  });
+
+  test("hmr:error — console.error", () => {
+    const ws = setupConnected();
+    ws.onmessage({ data: JSON.stringify({ type: "hmr:error", message: "boom" }) });
+    // setupConnected 의 onopen 이 console wrap — original 검증.
+    expect(originalConsole.error).toHaveBeenCalledWith("[ZTS HMR]", "boom");
+  });
+
+  test("disable() 후 hmr:error 만 통과, 그 외 메시지 무시", () => {
+    const ws = setupConnected();
+    HMRClient.disable();
+    ws.onmessage({ data: JSON.stringify({ type: "hmr:update-start" }) });
+    expect(mockGlobal.NativeModules.DevLoadingView.showMessage).not.toHaveBeenCalled();
+    ws.onmessage({ data: JSON.stringify({ type: "hmr:error", message: "x" }) });
+    expect(originalConsole.error).toHaveBeenCalledWith("[ZTS HMR]", "x");
+  });
+
+  test("invalid JSON — console.warn", () => {
+    const ws = setupConnected();
+    ws.onmessage({ data: "not-json{" });
+    expect(originalConsole.warn).toHaveBeenCalled();
+  });
+});
+
+describe("onerror / onclose / log()", () => {
+  test("onerror — console.warn", () => {
+    HMRClient.setup("ios", "/abs/idx.js", "localhost", 8081, true, "http");
+    const ws = MockWebSocket.instances[0];
+    ws.onerror();
+    // onerror 는 setup 후 onopen 호출 전에도 발생 가능 — wrap 안 됐으면
+    // mockConsole.warn 직접, wrap 후라면 originalConsole.warn 검증.
+    // 본 케이스는 onopen 호출 안 함 — wrap 안 된 상태이므로 mockConsole.warn 검증.
+    expect(mockConsole.warn).toHaveBeenCalledWith("[ZTS HMR] WebSocket error");
+  });
+
+  test("onclose — _socket null 로 reset", () => {
+    HMRClient.setup("ios", "/abs/idx.js", "localhost", 8081, true, "http");
+    const ws = MockWebSocket.instances[0];
+    ws.onclose();
+    expect(HMRClient._socket).toBeNull();
+  });
+
+  test("log() — readyState 1 일 때만 send", () => {
+    HMRClient.setup("ios", "/abs/idx.js", "localhost", 8081, true, "http");
+    const ws = MockWebSocket.instances[0];
+    HMRClient.log("warn", ["hello"]);
+    const msg = JSON.parse(ws.sent[0]);
+    expect(msg).toEqual({ type: "log", level: "warn", data: ["hello"] });
+  });
+
+  test("log() — _socket null 시 no-op", () => {
+    HMRClient.log("warn", ["x"]);
+    // 예외 없이 통과
+    expect(true).toBe(true);
+  });
+});
+
+describe("registerBundle() / enable()", () => {
+  test("registerBundle — no-op (ZTS bundler 는 등록 불필요)", () => {
+    expect(() => HMRClient.registerBundle("any-url")).not.toThrow();
+  });
+
+  test("enable() 후 disable() 후 enable() 토글", () => {
+    HMRClient.enable();
+    expect(HMRClient._enabled).toBe(true);
+    HMRClient.disable();
+    expect(HMRClient._enabled).toBe(false);
+    HMRClient.enable();
+    expect(HMRClient._enabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

#2540 epic 의 PR #3. Metro HMRClient interface 호환 RN runtime + plugin factory 가 inject 할 수 있도록 string 으로 노출하는 loader.

## 신설

**`packages/react-native/runtime/zts-hmr-client.js`** (207줄, **bungae 의 동등 사본 byte-for-byte 이전** — RN 런타임 호환성 critical):
- `setup(platform, bundleEntry, host, port, isEnabled, scheme)` — Metro 호환 WebSocket connect (`/hot` endpoint), `hmr:connected` 송출, console wrap (5 level, dev terminal forward)
- `enable()` / `disable()` / `registerBundle()` (no-op) / `log(level, data)`
- onmessage 분기 (Metro 6 type): `hmr:update-start` (isInitialUpdate flag 검사) / `hmr:update` (`__zts_apply_update(modules)`) / `hmr:update-done` (DevLoadingView.hide) / `hmr:reload` / `hmr:error` / log
- `module.exports.default = HMRClient` — RN setUpBatchedBridge 의 `require('HMRClient').default` 호환

**`packages/react-native/src/runtime-loader.ts`** (39줄):
- `ZTS_HMR_CLIENT_CODE` — module load 시 `readFileSync` of `runtime/zts-hmr-client.js`. fallback dummy (no-op HMRClient + default)
- `HMR_CLIENT_SUFFIX = '/Libraries/Utilities/HMRClient.js'` — Metro 의 HMRClient.js path suffix (plugin onLoad 매칭 키)

`src/index.ts` 에 export 추가.

## 단위 테스트 (37 cases / 100%)

**`runtime-loader.test.ts`** (11 cases) — substring 검증:
- ZTS_HMR_CLIENT_CODE 가 module.exports / default / 5 method / WebSocket / `/hot` / 6 message type / ZTS HMR runtime hook / DevLoadingView / Refreshing / isInitialUpdate 모두 포함
- HMR_CLIENT_SUFFIX value + slash 시작 + `.js` 확장자

**`runtime/zts-hmr-client.test.mjs`** (26 cases) — `new Function` factory + MockWebSocket + jsdom 식 global:
- module.exports default — Metro 호환
- setup() — wss/ws scheme, port 형성 (null/empty 분기), idempotent, isEnabled=false 시 _enabled false
- onopen — `hmr:connected` 송출 (bundleEntry/platform), console wrap 5 level (original 호출 + socket forward), Error.message 만, circular ref fallback to String
- onmessage 분기 모두 — update-start (initial vs incremental), update (modules 있을 때만 __zts_apply_update), update-done 중첩, reload, error, disable 후 error 만, invalid JSON
- onerror / onclose / log() readyState 분기

## /simplify 3-agent finding 정리

모두 skip — RN 호환성 byte-for-byte 보존 영역:

- Wrapped console `[ZTS HMR]` prefix (Agent 2) — 사용자 console.log forward 의 자연 동작
- `hmr:update` debug log 4회 + `__DEV__` gate (Agent 3) — bungae 원본 보존
- console wrap throttling/batching (Agent 3) — over-engineering
- 한국어 mix comment "무시" (Agent 2) — byte-for-byte 보존
- readFileSync lazy load (Agent 3) — 1ms, 무방
- originalConsole 보존 awkward (Agent 2) — alternative 불명

## Test plan

- [x] `@zts/react-native` 64 pass / 0 fail / 193 expects (5 files)
- [x] `@zts/server` 75 pass, `@zts/web` 141 pass, `@zts/core` 222 pass (회귀 0)
- [ ] CI 통과 시 auto-rebase merge

Refs #2540