### PR TITLE
feat(react-native): Metro HMR adapter on @zts/server.HmrChannel

### DIFF
--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -17,7 +17,7 @@ export {
   type HmrRnUpdateStartMessage,
 } from "@zts/server";
 
-export { resolveRnPolyfills, RN_GLOBAL_IDENTIFIERS, tryResolve } from "./rn-constants.ts";
+export { createMetroHmrAdapter, type MetroHmrAdapter } from "./metro-hmr-adapter.ts";
 export type {
   CustomResolver,
   MetroPlatform,
@@ -25,4 +25,5 @@ export type {
   ResolutionContext,
 } from "./metro-resolver-types.ts";
 export { escapeRegex } from "./plugins/escape-regex.ts";
+export { resolveRnPolyfills, RN_GLOBAL_IDENTIFIERS, tryResolve } from "./rn-constants.ts";
 export { HMR_CLIENT_SUFFIX, ZTS_HMR_CLIENT_CODE } from "./runtime-loader.ts";

--- a/packages/react-native/src/metro-hmr-adapter.test.ts
+++ b/packages/react-native/src/metro-hmr-adapter.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from "bun:test";
+
+import { type BunHmrClient, HMR_RN_MSG } from "@zts/server";
+
+import { createMetroHmrAdapter } from "./metro-hmr-adapter.ts";
+
+class MockBunClient implements BunHmrClient {
+  sent: string[] = [];
+  send(text: string): void {
+    this.sent.push(text);
+  }
+}
+
+function parsedSent(client: MockBunClient): unknown[] {
+  return client.sent.map((s) => JSON.parse(s));
+}
+
+/** addBunClient 후 자동 송출되는 web `connected` greeting 비우기 — RN 메시지만 검증. */
+function resetSent(client: MockBunClient): void {
+  client.sent.length = 0;
+}
+
+describe("createMetroHmrAdapter", () => {
+  test("channel 노출 — caller 가 accept / addBunClient 직접 호출 가능", () => {
+    const adapter = createMetroHmrAdapter();
+    expect(typeof adapter.channel.accept).toBe("function");
+    expect(typeof adapter.channel.addBunClient).toBe("function");
+    expect(typeof adapter.channel.removeBunClient).toBe("function");
+    expect(typeof adapter.channel.broadcast).toBe("function");
+    expect(adapter.channel.clientCount).toBe(0);
+  });
+
+  test("addBunClient 후 sendUpdate — UpdateStart / Update / UpdateDone 3개 메시지", () => {
+    const adapter = createMetroHmrAdapter();
+    const client = new MockBunClient();
+    adapter.channel.addBunClient(client);
+    // greeting (web 의 connected) 먼저 송출 — 첫 메시지는 web HMR_MSG.Connected.
+    expect(client.sent.length).toBe(1);
+    const greet = JSON.parse(client.sent[0]!);
+    expect(greet.type).toBe("connected");
+
+    const modules = [{ id: "abc", code: "__d(...)" }];
+    adapter.sendUpdate(modules);
+    const after = parsedSent(client).slice(1);
+    expect(after).toEqual([
+      { type: HMR_RN_MSG.UpdateStart },
+      { type: HMR_RN_MSG.Update, modules },
+      { type: HMR_RN_MSG.UpdateDone },
+    ]);
+  });
+
+  test("sendInitialGreeting — UpdateStart{isInitialUpdate:true} → UpdateDone", () => {
+    const adapter = createMetroHmrAdapter();
+    const client = new MockBunClient();
+    adapter.channel.addBunClient(client);
+    resetSent(client); // greeting 비우기
+
+    adapter.sendInitialGreeting();
+    expect(parsedSent(client)).toEqual([
+      { type: HMR_RN_MSG.UpdateStart, isInitialUpdate: true },
+      { type: HMR_RN_MSG.UpdateDone },
+    ]);
+  });
+
+  test("sendReload — Reload 단일 메시지", () => {
+    const adapter = createMetroHmrAdapter();
+    const client = new MockBunClient();
+    adapter.channel.addBunClient(client);
+    resetSent(client);
+
+    adapter.sendReload();
+    expect(parsedSent(client)).toEqual([{ type: HMR_RN_MSG.Reload }]);
+  });
+
+  test("sendError — Error{message}", () => {
+    const adapter = createMetroHmrAdapter();
+    const client = new MockBunClient();
+    adapter.channel.addBunClient(client);
+    resetSent(client);
+
+    adapter.sendError("boom");
+    expect(parsedSent(client)).toEqual([{ type: HMR_RN_MSG.Error, message: "boom" }]);
+  });
+
+  test("multi client broadcast — 모든 client 가 같은 메시지 받음", () => {
+    const adapter = createMetroHmrAdapter();
+    const a = new MockBunClient();
+    const b = new MockBunClient();
+    adapter.channel.addBunClient(a);
+    adapter.channel.addBunClient(b);
+    resetSent(a);
+    resetSent(b);
+
+    adapter.sendReload();
+    expect(parsedSent(a)).toEqual([{ type: HMR_RN_MSG.Reload }]);
+    expect(parsedSent(b)).toEqual([{ type: HMR_RN_MSG.Reload }]);
+  });
+
+  test("removeBunClient 후 broadcast — 제거된 client 는 받지 않음", () => {
+    const adapter = createMetroHmrAdapter();
+    const a = new MockBunClient();
+    const b = new MockBunClient();
+    adapter.channel.addBunClient(a);
+    adapter.channel.addBunClient(b);
+    adapter.channel.removeBunClient(b);
+    resetSent(a);
+    resetSent(b);
+
+    adapter.sendReload();
+    expect(a.sent.length).toBe(1);
+    expect(b.sent.length).toBe(0);
+  });
+
+  test("clientCount — addBunClient / removeBunClient 따라 갱신", () => {
+    const adapter = createMetroHmrAdapter();
+    const a = new MockBunClient();
+    const b = new MockBunClient();
+    expect(adapter.channel.clientCount).toBe(0);
+    adapter.channel.addBunClient(a);
+    expect(adapter.channel.clientCount).toBe(1);
+    adapter.channel.addBunClient(b);
+    expect(adapter.channel.clientCount).toBe(2);
+    adapter.channel.removeBunClient(a);
+    expect(adapter.channel.clientCount).toBe(1);
+  });
+
+  test("sendUpdate — modules 빈 배열도 정상 (3 메시지 송출)", () => {
+    const adapter = createMetroHmrAdapter();
+    const client = new MockBunClient();
+    adapter.channel.addBunClient(client);
+    resetSent(client);
+
+    adapter.sendUpdate([]);
+    expect(parsedSent(client)).toEqual([
+      { type: HMR_RN_MSG.UpdateStart },
+      { type: HMR_RN_MSG.Update, modules: [] },
+      { type: HMR_RN_MSG.UpdateDone },
+    ]);
+  });
+
+  test("sendUpdate — modules 의 map 필드 보존", () => {
+    const adapter = createMetroHmrAdapter();
+    const client = new MockBunClient();
+    adapter.channel.addBunClient(client);
+    resetSent(client);
+
+    const modules = [{ id: "x", code: "__d(...)", map: "//# sourceMappingURL=..." }];
+    adapter.sendUpdate(modules);
+    const update = parsedSent(client)[1] as { modules: Array<Record<string, unknown>> };
+    expect(update.modules[0]).toEqual({
+      id: "x",
+      code: "__d(...)",
+      map: "//# sourceMappingURL=...",
+    });
+  });
+
+  test("sendUpdate — readonly modules 입력 → adapter 내부 spread 후 broadcast (mutation 안전)", () => {
+    const adapter = createMetroHmrAdapter();
+    const client = new MockBunClient();
+    adapter.channel.addBunClient(client);
+    resetSent(client);
+
+    const original = Object.freeze([Object.freeze({ id: "y", code: "code" })]);
+    expect(() => adapter.sendUpdate(original)).not.toThrow();
+    const update = parsedSent(client)[1] as { modules: unknown[] };
+    expect(update.modules).toEqual([{ id: "y", code: "code" }]);
+  });
+
+  test("초기 connect 시 channel 의 자동 greeting (web HmrMessage.Connected) 은 RN adapter 와 무관하게 송출", () => {
+    // RN runtime 의 zts-hmr-client.js 는 onmessage 분기에서 'connected' type 을
+    // case 안에 두지 않아 default 로 빠짐 (silent ignore). adapter 는 추가
+    // greeting (sendInitialGreeting) 을 caller 가 명시 호출.
+    const adapter = createMetroHmrAdapter();
+    const client = new MockBunClient();
+    adapter.channel.addBunClient(client);
+    expect(client.sent.length).toBe(1);
+    const first = JSON.parse(client.sent[0]!);
+    expect(first.type).toBe("connected");
+  });
+});

--- a/packages/react-native/src/metro-hmr-adapter.ts
+++ b/packages/react-native/src/metro-hmr-adapter.ts
@@ -1,0 +1,59 @@
+// Metro HMR adapter — `@zts/server.HmrChannel` 위 thin wrapper. caller (번개
+// dev server) 가 RN runtime 의 HMRClient interface 호환 메시지 (`hmr:update-start`
+// / `hmr:update` / `hmr:update-done` / `hmr:reload` / `hmr:error`) 를 type-safe
+// 하게 송출. revisionId 기반 delta 자체는 caller 가 관리 — adapter 는 메시지
+// union 만 통과.
+
+import {
+  type BunHmrClient,
+  createHmrChannel,
+  type HmrChannel,
+  HMR_RN_MSG,
+  type HmrRnUpdateModule,
+} from "@zts/server";
+
+export interface MetroHmrAdapter {
+  /**
+   * 내부 HmrChannel — caller 가 직접 `accept(req, socket)` (Node http upgrade)
+   * 또는 `addBunClient(ws)` (Bun.serve websocket) 로 lifecycle 등록. adapter
+   * 는 send 만 wrapping 하므로 channel 자체에 직접 접근 가능.
+   */
+  readonly channel: HmrChannel;
+  /**
+   * Initial connection 직후 송출 — `update-start{isInitialUpdate:true}` →
+   * `update-done` sequence. RN runtime 의 'Refreshing...' 배너 회피용. caller
+   * 가 새 client connection 후 한 번 호출.
+   */
+  sendInitialGreeting(): void;
+  /** Module delta 송출. caller 가 revisionId 따라 modules 배열 구성. */
+  sendUpdate(modules: readonly HmrRnUpdateModule[]): void;
+  /** RN runtime 의 `__zts_reload()` 또는 `location.reload()` 호출. */
+  sendReload(): void;
+  /** RN runtime 의 `console.error('[ZTS HMR]', message)` 호출. */
+  sendError(message: string): void;
+}
+
+export function createMetroHmrAdapter(): MetroHmrAdapter {
+  const channel = createHmrChannel();
+
+  return {
+    channel,
+    sendInitialGreeting() {
+      channel.broadcast({ type: HMR_RN_MSG.UpdateStart, isInitialUpdate: true });
+      channel.broadcast({ type: HMR_RN_MSG.UpdateDone });
+    },
+    sendUpdate(modules) {
+      channel.broadcast({ type: HMR_RN_MSG.UpdateStart });
+      channel.broadcast({ type: HMR_RN_MSG.Update, modules: [...modules] });
+      channel.broadcast({ type: HMR_RN_MSG.UpdateDone });
+    },
+    sendReload() {
+      channel.broadcast({ type: HMR_RN_MSG.Reload });
+    },
+    sendError(message) {
+      channel.broadcast({ type: HMR_RN_MSG.Error, message });
+    },
+  };
+}
+
+export type { BunHmrClient, HmrChannel, HmrRnUpdateModule };

--- a/packages/server/src/hmr-channel.ts
+++ b/packages/server/src/hmr-channel.ts
@@ -6,6 +6,7 @@ import {
   type HmrError,
   type HmrErrorMessage,
   type HmrMessage,
+  type HmrRnMessage,
   normalizeHmrErrors,
 } from "./protocol.ts";
 import { buildHandshakeResponse, writeTextFrame } from "./ws-frame.ts";
@@ -24,8 +25,12 @@ export interface HmrChannel {
   /** Bun.serve 의 WebSocket client 등록. */
   addBunClient(ws: BunHmrClient): void;
   removeBunClient(ws: BunHmrClient): void;
-  /** 모든 client (Node + Bun) 에 메시지 송출. */
-  broadcast(message: HmrMessage): void;
+  /**
+   * 모든 client (Node + Bun) 에 메시지 송출. web overlay 의 `HmrMessage` 또는
+   * RN Metro 호환 `HmrRnMessage` (#2540) 모두 허용. send impl 은 JSON.stringify
+   * 만 — 메시지 schema 검증은 caller 책임 (type-safe 호출).
+   */
+  broadcast(message: HmrMessage | HmrRnMessage): void;
   /** Build error 를 전체 broadcast + 새 connection 에도 자동 송출. */
   reportError(errors: readonly unknown[] | unknown): void;
   /** 런타임 throw 를 stack 추출해 reportError 로 전달. */


### PR DESCRIPTION
## Summary

#2540 epic 의 PR #4. Metro HMR adapter — `@zts/server.HmrChannel` 위 thin wrapper. caller (번개 dev server) 가 RN runtime 의 HMRClient interface 호환 메시지 (`hmr:update-start` / `hmr:update` / `hmr:update-done` / `hmr:reload` / `hmr:error`) 를 type-safe 하게 송출.

## 변경

`packages/server/src/hmr-channel.ts` — `HmrChannel.broadcast` 의 message type 을 `HmrMessage | HmrRnMessage` union 으로 widen. impl 은 JSON.stringify 만 — schema 검증은 caller 책임. **web 사용자 영향 0**.

## 신설 — `packages/react-native/src/metro-hmr-adapter.ts` (59줄)

```ts
export interface MetroHmrAdapter {
  readonly channel: HmrChannel;
  sendInitialGreeting(): void;     // UpdateStart{isInitialUpdate:true} → UpdateDone
  sendUpdate(modules): void;       // UpdateStart → Update{modules} → UpdateDone
  sendReload(): void;
  sendError(message: string): void;
}
export function createMetroHmrAdapter(): MetroHmrAdapter;
```

- `channel` 노출 — caller 가 `accept(req, socket)` (Node http upgrade) 또는 `addBunClient(ws)` (Bun.serve websocket) 로 lifecycle 등록 + 자유 broadcast
- revisionId 기반 delta 는 caller 가 관리, adapter 는 메시지 union 만 통과
- `sendInitialGreeting` sequence (UpdateStart{isInitial:true} → UpdateDone) 는 Metro 의 'Refreshing...' 배너 회피 패턴 — RN runtime 의 `_pendingUpdates` 카운터가 0 도달 시 hide

## 단위 테스트 (`metro-hmr-adapter.test.ts`, 11 cases)

MockBunClient + parsedSent + resetSent helper. 모든 send method 검증, multi client broadcast, removeBunClient, clientCount, modules 빈 배열 / map 필드 / readonly spread, 초기 connect 시 web HmrMessage.Connected 자동 송출 (RN runtime 이 silent ignore — 무관).

## /simplify 3-agent finding

**Apply**:
- export 순서 알파벳 정렬 (Agent 2)
- `client.sent.length = 0` → `resetSent(client)` helper 화 (Agent 2, 6번 반복)

**Skip**:
- `adapter.channel` encapsulation — design 의도 (caller lifecycle 관리)
- `[...modules]` spread — readonly 보장 + defensive copy 정당
- type 재export — single import point UX
- sendInitialGreeting sequence — Metro 정확
- sendUpdate triple broadcast — protocol 그대로
- MockBunClient cross-package 통합 — over-engineering

## Test plan

- [x] `@zts/react-native` 76 pass / 0 fail / 218 expects (6 files)
- [x] `@zts/server` 75 pass (broadcast type widen 영향 0)
- [x] 다른 패키지 회귀 0
- [ ] CI 통과 시 auto-rebase merge

Refs #2540