### PR TITLE
feat(react-native): plugin factories (asset/babel/codegen/require-context/metro-resolve-request)

### DIFF
--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -24,6 +24,25 @@ export type {
   Resolution,
   ResolutionContext,
 } from "./metro-resolver-types.ts";
+export { createAssetPlugin } from "./plugins/asset.ts";
+export {
+  createBabelPlugin,
+  createBabelTransformer,
+  detectCustomPlugins,
+  isZtsNativePlugin,
+  ZTS_NATIVE_PLUGIN_PATTERNS,
+} from "./plugins/babel.ts";
+export {
+  CODEGEN_NATIVE_COMPONENT_MARKER,
+  createCodegenPlugin,
+  createCodegenTransformer,
+} from "./plugins/codegen.ts";
 export { escapeRegex } from "./plugins/escape-regex.ts";
+export {
+  createMetroResolveRequestPlugin,
+  type MetroResolveRequestOptions,
+} from "./plugins/metro-resolve-request.ts";
+export { createRequireContextPlugin } from "./plugins/require-context.ts";
+export type { PluginConfig } from "./plugins/types.ts";
 export { resolveRnPolyfills, RN_GLOBAL_IDENTIFIERS, tryResolve } from "./rn-constants.ts";
 export { HMR_CLIENT_SUFFIX, ZTS_HMR_CLIENT_CODE } from "./runtime-loader.ts";

--- a/packages/react-native/src/plugins/asset.test.ts
+++ b/packages/react-native/src/plugins/asset.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+
+import { ZTS_HMR_CLIENT_CODE } from "../runtime-loader.ts";
+import { createAssetPlugin } from "./asset.ts";
+import type { PluginConfig } from "./types.ts";
+
+interface OnLoadHandler {
+  (args: { path: string }): Promise<{ contents?: string } | null> | { contents?: string } | null;
+}
+
+interface CapturedHandler {
+  filter: RegExp;
+  handler: OnLoadHandler;
+}
+
+function captureHandlers(config: PluginConfig): CapturedHandler[] {
+  const plugin = createAssetPlugin(config);
+  const captured: CapturedHandler[] = [];
+  const fakeBuild = {
+    onLoad(filter: { filter: RegExp }, handler: OnLoadHandler) {
+      captured.push({ filter: filter.filter, handler });
+    },
+    onResolve() {},
+    onResolveContext() {},
+    onTransform() {},
+  };
+  plugin.setup(fakeBuild as never);
+  return captured;
+}
+
+describe("createAssetPlugin", () => {
+  const baseConfig: PluginConfig = {
+    projectRoot: "/abs/project",
+    assetExts: ["png", "jpg"],
+    rnPlatform: "ios",
+    sourceExts: [".ts", ".tsx", ".js", ".jsx"],
+  };
+
+  test("HMRClient.js path → ZTS HMR runtime code 반환 (onLoad)", () => {
+    const handlers = captureHandlers(baseConfig);
+    expect(handlers.length).toBe(1); // HMRClient.js 만 (sourceExts 에 RN-specific 확장자 0)
+    const hmrHandler = handlers[0]!;
+    expect(hmrHandler.filter.test("/abs/Libraries/Utilities/HMRClient.js")).toBe(true);
+    expect(hmrHandler.filter.test("/abs/foo.ts")).toBe(false);
+
+    const result = hmrHandler.handler({ path: "/abs/Libraries/Utilities/HMRClient.js" });
+    expect(result).toEqual({ contents: ZTS_HMR_CLIENT_CODE });
+  });
+
+  test("babelTransformerPath 미지정 — HMRClient.js handler 만 등록 (custom transformer 없음)", () => {
+    const handlers = captureHandlers(baseConfig);
+    expect(handlers.length).toBe(1);
+  });
+
+  test("babelTransformerPath 지정 + customExts 0 — HMRClient.js handler 만", () => {
+    // sourceExts 가 모두 표준 JS/TS — customExts 빈 string → 등록 skip
+    const handlers = captureHandlers({
+      ...baseConfig,
+      babelTransformerPath: "react-native-svg-transformer",
+    });
+    expect(handlers.length).toBe(1);
+  });
+
+  test("babelTransformerPath + customExts (.svg) — 두 번째 onLoad 등록", () => {
+    const handlers = captureHandlers({
+      ...baseConfig,
+      sourceExts: [".ts", ".tsx", ".js", ".jsx", ".svg"],
+      babelTransformerPath: "react-native-svg-transformer",
+    });
+    expect(handlers.length).toBe(2);
+    const customHandler = handlers[1]!;
+    expect(customHandler.filter.test("/abs/icon.svg")).toBe(true);
+    expect(customHandler.filter.test("/abs/foo.ts")).toBe(false);
+  });
+
+  test("customExts 패턴 — JS/TS/JSON 표준 확장자 제외", () => {
+    const handlers = captureHandlers({
+      ...baseConfig,
+      sourceExts: [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".json", ".svg", ".graphql"],
+      babelTransformerPath: "any-transformer",
+    });
+    const customHandler = handlers[1]!;
+    expect(customHandler.filter.test("/abs/x.svg")).toBe(true);
+    expect(customHandler.filter.test("/abs/x.graphql")).toBe(true);
+    expect(customHandler.filter.test("/abs/x.ts")).toBe(false);
+    expect(customHandler.filter.test("/abs/x.json")).toBe(false);
+    expect(customHandler.filter.test("/abs/x.mjs")).toBe(false);
+  });
+
+  test("plugin name 은 zts:react-native:runtime", () => {
+    const plugin = createAssetPlugin(baseConfig);
+    expect(plugin.name).toBe("zts:react-native:runtime");
+  });
+});

--- a/packages/react-native/src/plugins/asset.ts
+++ b/packages/react-native/src/plugins/asset.ts
@@ -1,0 +1,96 @@
+// React Native runtime injection plugin — Metro 의 HMRClient.js 를 ZTS HMR
+// runtime (`runtime/zts-hmr-client.js`) 으로 교체 + 사용자 babelTransformerPath
+// (예: react-native-svg-transformer) 통합. Asset registry / scale variant 처리는
+// ZTS 코어가 직접 (preset 의 assetRegistry/loader/alias 옵션) — 이 plugin 의
+// 책임 아님.
+
+import { readFileSync } from "node:fs";
+
+import type { ZtsPlugin } from "@zts/core";
+
+import { HMR_CLIENT_SUFFIX, ZTS_HMR_CLIENT_CODE } from "../runtime-loader.ts";
+import { escapeRegex } from "./escape-regex.ts";
+import { type BabelInstance, getErrorMessage, requireFromCli } from "./internal.ts";
+import type { PluginConfig } from "./types.ts";
+
+interface MetroTransformerResult {
+  code?: string;
+  ast?: unknown;
+}
+
+interface MetroTransformer {
+  transform(args: {
+    src: string;
+    filename: string;
+    options: { platform: "ios" | "android"; dev: boolean };
+  }): Promise<MetroTransformerResult> | MetroTransformerResult;
+}
+
+/**
+ * RN runtime 통합 plugin:
+ * - Metro HMRClient.js path → ZTS HMR runtime (`runtime/zts-hmr-client.js`) 교체
+ * - 사용자 babelTransformerPath (예: react-native-svg-transformer) — Metro
+ *   호환 시그니처 (`transform({src, filename, options})` → `{code}` or `{ast}`)
+ *   로 호출, AST 반환 시 babel.transformFromAstSync 로 generate.
+ */
+export function createAssetPlugin(config: PluginConfig): ZtsPlugin {
+  return {
+    name: "zts:react-native:runtime",
+    setup(build) {
+      // HMRClient.js path 매칭 — onLoad 응답으로 ZTS_HMR_CLIENT_CODE 그대로.
+      const hmrClientPattern = new RegExp(`${escapeRegex(HMR_CLIENT_SUFFIX)}$`);
+      build.onLoad({ filter: hmrClientPattern }, () => ({
+        contents: ZTS_HMR_CLIENT_CODE,
+      }));
+
+      if (config.babelTransformerPath) {
+        let customTransformer: MetroTransformer | null = null;
+        let babel: BabelInstance | null = null;
+        const transformerPath = config.babelTransformerPath;
+
+        // 사용자 transformer 적용 대상 — sourceExts 중 ts/tsx/js/jsx/mjs/cjs/json
+        // 외 (RN-specific 확장자, 예: .svg). 표준 JS/TS 는 ZTS 가 처리하므로 제외.
+        const customExts = config.sourceExts
+          .filter((e) => !/^\.(tsx?|jsx?|mjs|cjs|json)$/.test(e))
+          .map((e) => e.replace(/^\./, ""))
+          .join("|");
+
+        if (customExts) {
+          const customExtPattern = new RegExp(`\\.(${customExts})$`);
+          build.onLoad({ filter: customExtPattern }, async (args) => {
+            try {
+              if (!customTransformer) {
+                customTransformer = requireFromCli(
+                  requireFromCli.resolve(transformerPath, { paths: [config.projectRoot] }),
+                ) as MetroTransformer;
+              }
+              if (!babel) {
+                babel = requireFromCli("@babel/core") as BabelInstance;
+              }
+              const src = readFileSync(args.path, "utf8");
+              const result = await customTransformer.transform({
+                src,
+                filename: args.path,
+                options: { platform: config.rnPlatform, dev: true },
+              });
+              if (result?.code) return { contents: result.code };
+              if (result?.ast) {
+                const generated = babel.transformFromAstSync?.(result.ast, undefined, {
+                  filename: args.path,
+                  babelrc: false,
+                  configFile: false,
+                });
+                if (generated?.code) return { contents: generated.code };
+              }
+            } catch (err: unknown) {
+              process.stderr.write(
+                `[zts:transformer] ${args.path.split("/").pop()}: ${getErrorMessage(err)}\n`,
+              );
+            }
+            return null;
+          });
+        }
+      }
+    },
+  };
+}

--- a/packages/react-native/src/plugins/babel.test.ts
+++ b/packages/react-native/src/plugins/babel.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { detectCustomPlugins, isZtsNativePlugin, ZTS_NATIVE_PLUGIN_PATTERNS } from "./babel.ts";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "zts-rn-babel-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("isZtsNativePlugin", () => {
+  test("ZTS native list 의 plugin 모두 true", () => {
+    for (const pattern of ZTS_NATIVE_PLUGIN_PATTERNS) {
+      expect(isZtsNativePlugin(pattern)).toBe(true);
+    }
+  });
+
+  test("substring 매칭 — `transform-typescript` → true (full path 도 매치)", () => {
+    expect(isZtsNativePlugin("@babel/plugin-transform-typescript")).toBe(true);
+    expect(isZtsNativePlugin("/abs/path/to/react-native-reanimated/plugin")).toBe(true);
+  });
+
+  test("native list 외 — false", () => {
+    expect(isZtsNativePlugin("nativewind/babel")).toBe(false);
+    expect(isZtsNativePlugin("babel-plugin-styled-components")).toBe(false);
+    expect(isZtsNativePlugin("")).toBe(false);
+  });
+
+  test("핵심 RN preset / Reanimated / Worklets / TS strip 모두 cover", () => {
+    expect(isZtsNativePlugin("@react-native/babel-preset")).toBe(true);
+    expect(isZtsNativePlugin("react-native-reanimated/plugin")).toBe(true);
+    expect(isZtsNativePlugin("react-native-worklets")).toBe(true);
+    expect(isZtsNativePlugin("transform-flow-strip-types")).toBe(true);
+  });
+});
+
+describe("detectCustomPlugins", () => {
+  test("babel.config.js 미존재 — false", () => {
+    expect(detectCustomPlugins(dir)).toBe(false);
+  });
+
+  test("babel.config.js 존재 + plugins 0 — false", () => {
+    writeFileSync(join(dir, "babel.config.js"), "module.exports = {};");
+    expect(detectCustomPlugins(dir)).toBe(false);
+  });
+
+  test("babel.config.js 존재 + plugins 가 ZTS native 만 — false", () => {
+    writeFileSync(
+      join(dir, "babel.config.js"),
+      `module.exports = { plugins: ['react-native-reanimated/plugin', '@react-native/babel-preset'] };`,
+    );
+    expect(detectCustomPlugins(dir)).toBe(false);
+  });
+
+  test("babel.config.js + plugins 에 native 외 1개 — true", () => {
+    writeFileSync(
+      join(dir, "babel.config.js"),
+      `module.exports = { plugins: ['react-native-reanimated/plugin', 'nativewind/babel'] };`,
+    );
+    expect(detectCustomPlugins(dir)).toBe(true);
+  });
+
+  test("plugin tuple `[name, options]` 도 인식", () => {
+    writeFileSync(
+      join(dir, "babel.config.js"),
+      `module.exports = { plugins: [['nativewind/babel', { mode: 'transform' }]] };`,
+    );
+    expect(detectCustomPlugins(dir)).toBe(true);
+  });
+
+  test("require throw 시 — false (조용히 skip)", () => {
+    writeFileSync(join(dir, "babel.config.js"), "throw new Error('boom');");
+    expect(detectCustomPlugins(dir)).toBe(false);
+  });
+
+  test("config.plugins 가 undefined — false (default 빈 배열)", () => {
+    writeFileSync(join(dir, "babel.config.js"), "module.exports = { presets: ['x'] };");
+    expect(detectCustomPlugins(dir)).toBe(false);
+  });
+
+  test("plugin 의 type 이 string/array 외 — skip", () => {
+    writeFileSync(
+      join(dir, "babel.config.js"),
+      `module.exports = { plugins: [42, null, { name: 'foo' }] };`,
+    );
+    expect(detectCustomPlugins(dir)).toBe(false);
+  });
+});
+
+describe("ZTS_NATIVE_PLUGIN_PATTERNS", () => {
+  test("count >= 15 (sanity)", () => {
+    expect(ZTS_NATIVE_PLUGIN_PATTERNS.length).toBeGreaterThanOrEqual(15);
+  });
+
+  test("중복 없음", () => {
+    const set = new Set(ZTS_NATIVE_PLUGIN_PATTERNS);
+    expect(set.size).toBe(ZTS_NATIVE_PLUGIN_PATTERNS.length);
+  });
+});

--- a/packages/react-native/src/plugins/babel.ts
+++ b/packages/react-native/src/plugins/babel.ts
@@ -1,0 +1,187 @@
+// Babel 패스: 사용자 babel.config.js 의 custom plugin (Reanimated / NativeWind /
+// 사용자 worklet) 만 — ZTS 가 native 처리하는 plugin (TS strip / RN preset /
+// JSX / class fields / worklets / flow / arrow / block-scoping 등) 은 zero-cost
+// pass. Babel/lazy-load — 첫 transform 호출 시점에 require, custom plugin 0 면
+// plugin 자체 등록 skip (createBabelPlugin 의 detectCustomPlugins false 분기).
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import type { ZtsPlugin } from "@zts/core";
+
+import {
+  type BabelInstance,
+  type BabelTransformOptions,
+  getErrorMessage,
+  requireFromCli,
+} from "./internal.ts";
+import type { PluginConfig } from "./types.ts";
+
+interface BabelConfigModule {
+  plugins?: unknown[];
+}
+
+/**
+ * ZTS native 처리 plugin patterns — Babel pass-through 시 제외 (이 list 에 매칭
+ * 되면 ZTS 가 이미 처리). 사용자 babel.config.js 의 plugin 중 *이 list 외* 만
+ * Babel 로 forward.
+ */
+export const ZTS_NATIVE_PLUGIN_PATTERNS = [
+  "optional-chaining",
+  "nullish-coalescing",
+  "class-properties",
+  "private-methods",
+  "private-property-in-object",
+  "flow-strip-types",
+  "transform-flow",
+  "transform-typescript",
+  "transform-react-jsx",
+  "transform-arrow-functions",
+  "transform-block-scoping",
+  "transform-shorthand-properties",
+  "transform-template-literals",
+  "transform-modules-commonjs",
+  "react-native-worklets",
+  "react-native-reanimated/plugin",
+  "react-native-reanimated",
+  "@react-native/babel-preset",
+];
+
+/** Plugin name 이 ZTS 가 native 처리하는 list 에 매칭되는가. substring 매칭. */
+export function isZtsNativePlugin(name: string): boolean {
+  return ZTS_NATIVE_PLUGIN_PATTERNS.some((pattern) => name.includes(pattern));
+}
+
+/**
+ * babel.config.js 의 plugins 배열 중 ZTS native list 외 의 plugin 이 하나라도
+ * 있으면 true — Babel pass 가 필요하다는 신호. 미존재 / require fail / list
+ * 외 plugin 0 → false (Babel pass skip 으로 startup latency 0).
+ */
+export function detectCustomPlugins(projectRoot: string): boolean {
+  try {
+    const configPath = join(projectRoot, "babel.config.js");
+    if (!existsSync(configPath)) return false;
+    const config = requireFromCli(configPath) as BabelConfigModule;
+    const plugins: unknown[] = config?.plugins ?? [];
+    return plugins.some((p) => {
+      const name = typeof p === "string" ? p : Array.isArray(p) ? (p[0] as string) : "";
+      // 빈 string (number/object/null 같은 invalid plugin entry) 은 skip — bungae
+      // 의 minor bug fix (#2540): 원본은 빈 string 도 native 외 로 카운트해 false
+      // negative.
+      return typeof name === "string" && name !== "" && !isZtsNativePlugin(name);
+    });
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Lazy Babel transformer factory. 첫 transform 호출 시점에 require('@babel/core')
+ * + babel.config.js 평가. Babel options (preset / plugins / parser flag) 는
+ * 한 번 빌드 후 캐시. Reanimated 같은 plugin 의 require.resolve 는 user 의
+ * node_modules 우선 (Bun deep-link symlink 미생성 케이스 대비 fallback 명시).
+ */
+export function createBabelTransformer(
+  projectRoot: string,
+): (code: string, filename: string) => string | null {
+  let babel: BabelInstance | null = null;
+  let babelOptions: BabelTransformOptions | null = null;
+
+  function ensureBabel(): void {
+    if (babel) return;
+    babel = requireFromCli("@babel/core") as BabelInstance;
+
+    const configPath = join(projectRoot, "babel.config.js");
+    const config = requireFromCli(configPath) as BabelConfigModule;
+    const plugins: unknown[] = config?.plugins ?? [];
+
+    const customPlugins: unknown[] = [];
+    for (const plugin of plugins) {
+      const name =
+        typeof plugin === "string" ? plugin : Array.isArray(plugin) ? (plugin[0] as string) : "";
+      if (typeof name === "string" && !isZtsNativePlugin(name)) {
+        if (Array.isArray(plugin)) {
+          try {
+            customPlugins.push([
+              requireFromCli.resolve(plugin[0] as string),
+              ...(plugin.slice(1) as unknown[]),
+            ]);
+          } catch {
+            customPlugins.push(plugin);
+          }
+        } else {
+          try {
+            customPlugins.push(requireFromCli.resolve(name));
+          } catch {
+            customPlugins.push(name);
+          }
+        }
+      }
+    }
+
+    babelOptions = {
+      presets: [["@babel/preset-typescript", { isTSX: true, allExtensions: true }]],
+      plugins: customPlugins,
+      babelrc: false,
+      configFile: false,
+      compact: false,
+      sourceMaps: false,
+    };
+
+    const pluginNames = customPlugins.map((p) =>
+      Array.isArray(p) ? (p[0] as string).split("/").pop() : String(p).split("/").pop(),
+    );
+    process.stderr.write(`[zts:babel] loaded: ${pluginNames.join(", ")}\n`);
+  }
+
+  return (code: string, filename: string): string | null => {
+    try {
+      ensureBabel();
+      const result = babel!.transformSync(code, {
+        ...(babelOptions ?? {}),
+        filename,
+      });
+      if (result?.code && result.code !== code) {
+        process.stderr.write(
+          `[zts:babel] ${filename.split("/").pop()}: ${code.length} -> ${result.code.length}\n`,
+        );
+        return result.code;
+      }
+      return null;
+    } catch (err: unknown) {
+      process.stderr.write(`[zts:babel] error: ${getErrorMessage(err)}\n`);
+      throw err;
+    }
+  };
+}
+
+/**
+ * Babel transform plugin — 사용자 babel.config.js 의 custom plugin (Reanimated
+ * / NativeWind / 사용자 worklet) 을 source file 마다 적용. detectCustomPlugins
+ * false 면 plugin 자체 등록 skip (NAPI build 의 startup latency 0).
+ */
+export function createBabelPlugin(config: PluginConfig): ZtsPlugin {
+  return {
+    name: "zts:react-native:babel-transform",
+    setup(build) {
+      if (!detectCustomPlugins(config.projectRoot)) return;
+
+      const transformer = createBabelTransformer(config.projectRoot);
+
+      const extPatterns = config.sourceExts.map((e) => e.replace(/^\./, "")).join("|");
+      const sourcePattern = new RegExp(`\\.(${extPatterns})$`);
+
+      build.onTransform({ filter: sourcePattern }, (args) => {
+        // Skip node_modules — custom plugin 은 사용자 코드만 적용.
+        if (args.path.includes("node_modules")) return null;
+        try {
+          const result = transformer(args.code, args.path);
+          return result ? { code: result } : null;
+        } catch {
+          // Babel 에러는 transformer 가 stderr 에 이미 기록 — build 자체는 진행.
+          return null;
+        }
+      });
+    },
+  };
+}

--- a/packages/react-native/src/plugins/codegen.test.ts
+++ b/packages/react-native/src/plugins/codegen.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+
+import { CODEGEN_NATIVE_COMPONENT_MARKER, createCodegenTransformer } from "./codegen.ts";
+
+describe("CODEGEN_NATIVE_COMPONENT_MARKER", () => {
+  test("정확한 literal", () => {
+    expect(CODEGEN_NATIVE_COMPONENT_MARKER).toBe("codegenNativeComponent");
+  });
+});
+
+describe("createCodegenTransformer", () => {
+  test("marker 미포함 코드 — null (no transform 시도)", () => {
+    const transform = createCodegenTransformer("/nonexistent");
+    expect(transform("const x = 1;", "/abs/foo.js")).toBeNull();
+    expect(transform("const x = 1;", "/abs/foo.ts")).toBeNull();
+  });
+
+  test(".jsx / .tsx — null (.js/.ts 만 허용 — RN NativeComponent 파일 컨벤션)", () => {
+    const transform = createCodegenTransformer("/nonexistent");
+    expect(transform("codegenNativeComponent('X')", "/abs/foo.jsx")).toBeNull();
+    expect(transform("codegenNativeComponent('X')", "/abs/foo.tsx")).toBeNull();
+  });
+
+  test(".js + marker — Babel 호출 시도. plugin 미설치 시 graceful null", () => {
+    // @react-native/babel-plugin-codegen 미설치 환경 (projectRoot=/nonexistent
+    // 라 require.resolve 도 fail) — ensureBabel throw, transform 의 outer catch
+    // 가 잡아 null. (stderr 출력은 process.stderr.write native binding 으로 spy
+    // 검증이 어려워 결과만 검증.)
+    const transform = createCodegenTransformer("/nonexistent");
+    const result = transform("const X = codegenNativeComponent('Foo');", "/abs/NativeFoo.js");
+    expect(result).toBeNull();
+  });
+
+  test("filename 에 따라 parser plugin 분기 — `.js` → flow, `.ts` → typescript", () => {
+    // 직접 검증 어려움 (private). marker 없으면 null 반환 의 결정성만 검증.
+    const transform = createCodegenTransformer("/nonexistent");
+    expect(transform("export {};", "/abs/foo.js")).toBeNull();
+    expect(transform("export {};", "/abs/foo.ts")).toBeNull();
+  });
+});

--- a/packages/react-native/src/plugins/codegen.ts
+++ b/packages/react-native/src/plugins/codegen.ts
@@ -1,0 +1,116 @@
+// RN codegen view config 인라인 — `@react-native/babel-plugin-codegen` 래핑.
+// ZTS 가 `@react-native/babel-preset` 을 native 처리하지만 그 내부의 codegen
+// plugin 은 미구현 (#1589). RN 0.85+ Fabric 의 자동 컴포넌트 등록이 늘어나면서
+// `codegenNativeComponent<Props>('Name')` 호출의 view config 가 빠지면 런타임
+// crash (예: View config not found for component DebuggingOverlay). 이 plugin
+// 이 marker 가진 파일만 Babel 로 한번 더 돌려 view config 를 inline.
+
+import type { ZtsPlugin } from "@zts/core";
+
+import {
+  type BabelInstance,
+  type BabelTransformOptions,
+  getErrorMessage,
+  requireFromCli,
+} from "./internal.ts";
+import type { PluginConfig } from "./types.ts";
+
+/** `codegenNativeComponent` literal — code 에 이 marker 미포함 시 transform skip. */
+export const CODEGEN_NATIVE_COMPONENT_MARKER = "codegenNativeComponent";
+
+/** `.js` / `.ts` 파일만 처리. RN NativeComponent 파일은 항상 .js/.ts (jsx/tsx 미지원). */
+const CODEGEN_FILENAME_PATTERN = /\.(js|ts)$/;
+
+/**
+ * Lazy codegen transformer factory. 첫 transform 호출 시점에
+ * `@react-native/babel-plugin-codegen` resolve (projectRoot 우선, 미발견 시
+ * cli node_modules fallback). RN 0.85+ Fabric crash 회피 patch.
+ */
+export function createCodegenTransformer(
+  projectRoot: string,
+): (code: string, filename: string) => string | null {
+  let babel: BabelInstance | null = null;
+  let codegenPlugin: unknown = null;
+  let babelOptions: BabelTransformOptions | null = null;
+
+  function ensureBabel(): void {
+    if (babel) return;
+    babel = requireFromCli("@babel/core") as BabelInstance;
+
+    try {
+      const codegenPath = (() => {
+        try {
+          return requireFromCli.resolve("@react-native/babel-plugin-codegen", {
+            paths: [projectRoot],
+          });
+        } catch {
+          return requireFromCli.resolve("@react-native/babel-plugin-codegen");
+        }
+      })();
+      codegenPlugin = requireFromCli(codegenPath);
+    } catch (err: unknown) {
+      process.stderr.write(
+        `[zts:codegen] @react-native/babel-plugin-codegen not found (${getErrorMessage(err, 80)}) — view config inlining disabled\n`,
+      );
+      throw err;
+    }
+
+    babelOptions = {
+      babelrc: false,
+      configFile: false,
+      compact: false,
+      sourceMaps: false,
+      plugins: [codegenPlugin],
+    };
+  }
+
+  return (code: string, filename: string): string | null => {
+    if (!CODEGEN_FILENAME_PATTERN.test(filename)) return null;
+    if (!code.includes(CODEGEN_NATIVE_COMPONENT_MARKER)) return null;
+
+    // RN NativeComponent 파일은 확장자로 언어 구분: .js → Flow 제네릭, .ts →
+    // TypeScript. babel-plugin-codegen 내부 parseFile() 도 같은 분기.
+    const parserPlugins = filename.endsWith(".ts") ? ["typescript"] : ["flow"];
+
+    try {
+      ensureBabel();
+      const result = babel!.transformSync(code, {
+        ...(babelOptions ?? {}),
+        filename,
+        parserOpts: { plugins: parserPlugins },
+      });
+      if (result?.code && result.code !== code) {
+        process.stderr.write(`[zts:codegen] ${filename.split("/").pop()}: view config inlined\n`);
+        return result.code;
+      }
+      return null;
+    } catch (err: unknown) {
+      process.stderr.write(
+        `[zts:codegen] ${filename.split("/").pop()} failed: ${getErrorMessage(err, 120)}\n`,
+      );
+      return null;
+    }
+  };
+}
+
+/**
+ * Codegen plugin — `codegenNativeComponent` marker 가진 .js/.ts 파일을 Babel
+ * 로 transform 해서 view config 인라인. node_modules 포함 모든 파일 적용 (RN
+ * core 의 NativeComponent.js 까지 — DebuggingOverlay 등).
+ */
+export function createCodegenPlugin(config: PluginConfig): ZtsPlugin {
+  return {
+    name: "zts:react-native:codegen-view-config",
+    setup(build) {
+      const transformer = createCodegenTransformer(config.projectRoot);
+      build.onTransform({ filter: /\.(js|ts)$/ }, (args) => {
+        try {
+          const result = transformer(args.code, args.path);
+          return result ? { code: result } : null;
+        } catch {
+          return null;
+        }
+      });
+    },
+  };
+}

--- a/packages/react-native/src/plugins/internal.ts
+++ b/packages/react-native/src/plugins/internal.ts
@@ -1,0 +1,39 @@
+// Plugin factory 들의 internal shared util — RN 외부 사용자에게 노출 X (src/index.ts 미수출).
+// 4 plugin 파일 (babel/codegen/asset/metro-resolve-request) 의 require + Babel
+// type + error message 추출의 단일 출처.
+
+import { createRequire } from "node:module";
+
+/** ZTS CLI 의 createRequire — fallback / require 의 모든 plugin 공용. */
+export const requireFromCli = createRequire(import.meta.url);
+
+/** Babel @babel/core 의 transformSync 표면. babel.ts / codegen.ts 가 lazy load 후 사용. */
+export interface BabelInstance {
+  transformSync(code: string, options: BabelTransformOptions): { code?: string } | null;
+  transformFromAstSync?(
+    ast: unknown,
+    code: string | undefined,
+    options: { filename?: string; babelrc?: boolean; configFile?: boolean },
+  ): { code?: string } | null;
+}
+
+export interface BabelTransformOptions {
+  filename?: string;
+  presets?: unknown[];
+  plugins?: unknown[];
+  babelrc?: boolean;
+  configFile?: boolean;
+  compact?: boolean;
+  sourceMaps?: boolean;
+  parserOpts?: { plugins?: string[] };
+}
+
+/**
+ * `unknown` error 에서 message string 추출. 4 plugin 파일이 stderr write
+ * 시점에 사용 — 매번 `as { message?: string }` cast 의 boilerplate 회피.
+ */
+export function getErrorMessage(err: unknown, max = 100): string {
+  const e = err as { message?: unknown };
+  if (typeof e?.message === "string") return e.message.slice(0, max);
+  return String(err).slice(0, max);
+}

--- a/packages/react-native/src/plugins/metro-resolve-request.test.ts
+++ b/packages/react-native/src/plugins/metro-resolve-request.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+
+import type { CustomResolver } from "../metro-resolver-types.ts";
+import { createMetroResolveRequestPlugin } from "./metro-resolve-request.ts";
+
+interface OnResolveHandler {
+  (args: { path: string; importer?: string }): { path?: string; disabled?: boolean } | null;
+}
+
+function captureHandler(opts: {
+  resolveRequest: CustomResolver;
+  platform: "ios" | "android" | "web";
+}): OnResolveHandler {
+  const plugin = createMetroResolveRequestPlugin(opts);
+  let captured: OnResolveHandler | null = null;
+  const fakeBuild = {
+    onResolve(_filter: { filter: RegExp }, handler: OnResolveHandler) {
+      captured = handler;
+    },
+    onResolveContext() {},
+    onLoad() {},
+    onTransform() {},
+  };
+  plugin.setup(fakeBuild as never);
+  if (!captured) throw new Error("handler not registered");
+  return captured;
+}
+
+describe("createMetroResolveRequestPlugin", () => {
+  test("Resolution.sourceFile → `{ path }`", () => {
+    const resolver: CustomResolver = (_ctx, name) => ({
+      type: "sourceFile",
+      filePath: `/abs/${name}.ts`,
+    });
+    const handler = captureHandler({ resolveRequest: resolver, platform: "ios" });
+    expect(handler({ path: "react", importer: "/abs/origin.ts" })).toEqual({
+      path: "/abs/react.ts",
+    });
+  });
+
+  test("Resolution.assetFiles → 첫 element path", () => {
+    const resolver: CustomResolver = () => ({
+      type: "assetFiles",
+      filePaths: ["/abs/a@2x.png", "/abs/a@3x.png"],
+    });
+    const handler = captureHandler({ resolveRequest: resolver, platform: "ios" });
+    expect(handler({ path: "./a.png", importer: "/abs/origin.ts" })).toEqual({
+      path: "/abs/a@2x.png",
+    });
+  });
+
+  test("Resolution.assetFiles 빈 배열 → 원래 path 유지", () => {
+    const resolver: CustomResolver = () => ({ type: "assetFiles", filePaths: [] });
+    const handler = captureHandler({ resolveRequest: resolver, platform: "android" });
+    expect(handler({ path: "./missing.png", importer: "/abs/x" })).toEqual({
+      path: "./missing.png",
+    });
+  });
+
+  test("Resolution.empty → `{ disabled: true }`", () => {
+    const resolver: CustomResolver = () => ({ type: "empty" });
+    const handler = captureHandler({ resolveRequest: resolver, platform: "ios" });
+    expect(handler({ path: "polyfilled", importer: "/abs/x" })).toEqual({ disabled: true });
+  });
+
+  test("default resolver 위임 (sentinel throw) → null (ZTS fallthrough)", () => {
+    const resolver: CustomResolver = (ctx, name, platform) =>
+      ctx.resolveRequest(ctx, name, platform);
+    const handler = captureHandler({ resolveRequest: resolver, platform: "ios" });
+    expect(handler({ path: "react", importer: "/abs/x" })).toBeNull();
+  });
+
+  test("custom resolver 의 일반 throw 는 propagate", () => {
+    const resolver: CustomResolver = () => {
+      throw new Error("custom-error");
+    };
+    const handler = captureHandler({ resolveRequest: resolver, platform: "ios" });
+    expect(() => handler({ path: "x", importer: "/abs/y" })).toThrow("custom-error");
+  });
+
+  test("platform=web → resolver 에 null 전달 (RN 외 platform 우회)", () => {
+    let receivedPlatform: string | null | undefined = "uninitialized";
+    const resolver: CustomResolver = (_ctx, _name, platform) => {
+      receivedPlatform = platform;
+      return { type: "empty" };
+    };
+    const handler = captureHandler({ resolveRequest: resolver, platform: "web" });
+    handler({ path: "x", importer: "/abs/y" });
+    expect(receivedPlatform).toBeNull();
+  });
+
+  test("importer 없으면 originModulePath 빈 string", () => {
+    let receivedOrigin: string | null = null;
+    const resolver: CustomResolver = (ctx, _name, _platform) => {
+      receivedOrigin = ctx.originModulePath;
+      return { type: "empty" };
+    };
+    const handler = captureHandler({ resolveRequest: resolver, platform: "ios" });
+    handler({ path: "x" });
+    expect(receivedOrigin).toBe("");
+  });
+
+  test("Metro 'context.resolveRequest' 호출 — fallback 함수가 sentinel throw", () => {
+    let fallbackCalled = false;
+    const resolver: CustomResolver = (ctx, name, platform) => {
+      // 사용자 resolver 가 default 위임 — fallback 호출.
+      try {
+        ctx.resolveRequest(ctx, name, platform);
+      } catch (_err) {
+        fallbackCalled = true;
+        throw _err; // sentinel propagate
+      }
+      return { type: "empty" };
+    };
+    const handler = captureHandler({ resolveRequest: resolver, platform: "ios" });
+    expect(handler({ path: "x", importer: "/abs/y" })).toBeNull();
+    expect(fallbackCalled).toBe(true);
+  });
+});

--- a/packages/react-native/src/plugins/metro-resolve-request.ts
+++ b/packages/react-native/src/plugins/metro-resolve-request.ts
@@ -1,0 +1,54 @@
+// Metro resolver.resolveRequest → ZTS onResolve 어댑팅. Metro 시그니처
+// `(context, moduleName, platform)` 그대로 호출. 위임 시 sentinel throw 로 ZTS
+// 기본 해석기 fallthrough (Metro 의 `context.resolveRequest()` 호출과 동등).
+
+import type { ZtsPlugin } from "@zts/core";
+
+import type { CustomResolver, MetroPlatform } from "../metro-resolver-types.ts";
+
+/** ZTS 기본 해석기로 위임 위해 사용자 resolver 가 던지는 sentinel error message. */
+const DELEGATE_TO_DEFAULT_SENTINEL = "__ZTS_RN_DELEGATE_TO_DEFAULT__";
+
+export interface MetroResolveRequestOptions {
+  resolveRequest: CustomResolver;
+  platform: MetroPlatform;
+}
+
+export function createMetroResolveRequestPlugin(opts: MetroResolveRequestOptions): ZtsPlugin {
+  const { resolveRequest, platform } = opts;
+  // Metro 호환: web platform 시 null 전달 (RN 외 platform 의 resolver 우회).
+  const metroPlatform = platform === "web" ? null : platform;
+
+  return {
+    name: "zts:react-native:metro-resolve-request",
+    setup(build) {
+      build.onResolve({ filter: /.*/ }, (args) => {
+        // Default resolver 위임 함수 — Metro 의 `context.resolveRequest()` 동등.
+        // throw 시 ZTS 가 catch 후 기본 해석 진행 (return null 과 동일 효과).
+        const fallbackResolver = (): never => {
+          throw new Error(DELEGATE_TO_DEFAULT_SENTINEL);
+        };
+        try {
+          const result = resolveRequest(
+            {
+              originModulePath: args.importer ?? "",
+              platform: metroPlatform,
+              resolveRequest: fallbackResolver as never,
+            },
+            args.path,
+            metroPlatform,
+          );
+          if (result.type === "sourceFile") return { path: result.filePath };
+          if (result.type === "assetFiles") return { path: result.filePaths[0] ?? args.path };
+          // Metro `{ type: 'empty' }` → ZTS `disabled` flag (빈 모듈로 처리 —
+          // ZTS 가 자동으로 module.exports = {} 출력, 별도 onLoad 불필요).
+          if (result.type === "empty") return { disabled: true };
+        } catch (err: unknown) {
+          if ((err as Error).message === DELEGATE_TO_DEFAULT_SENTINEL) return null;
+          throw err;
+        }
+        return null;
+      });
+    },
+  };
+}

--- a/packages/react-native/src/plugins/require-context.test.ts
+++ b/packages/react-native/src/plugins/require-context.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { createRequireContextPlugin } from "./require-context.ts";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "zts-rn-rc-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+interface OnResolveContextHandler {
+  (args: { dir: string; recursive: boolean; filter?: string; flags?: string; importer: string }): {
+    context: string[];
+  };
+}
+
+function captureHandler(): OnResolveContextHandler {
+  const plugin = createRequireContextPlugin();
+  let captured: OnResolveContextHandler | null = null;
+  const fakeBuild = {
+    onResolveContext(_filter: { filter: RegExp }, handler: OnResolveContextHandler) {
+      captured = handler;
+    },
+    onResolve() {},
+    onLoad() {},
+    onTransform() {},
+  };
+  // ZtsPlugin.setup 시그니처 호환 (Build 의 onResolveContext 만 사용).
+  plugin.setup(fakeBuild as never);
+  if (!captured) throw new Error("handler not registered");
+  return captured;
+}
+
+describe("createRequireContextPlugin", () => {
+  test("디렉토리 없음 — `{ context: [] }`", () => {
+    const handler = captureHandler();
+    const result = handler({
+      dir: "./missing",
+      recursive: false,
+      importer: join(dir, "index.ts"),
+    });
+    expect(result).toEqual({ context: [] });
+  });
+
+  test("non-recursive — 1단계 파일만, default filter `^\\./.*$`", () => {
+    mkdirSync(join(dir, "ctx"), { recursive: true });
+    writeFileSync(join(dir, "ctx", "a.ts"), "");
+    writeFileSync(join(dir, "ctx", "b.ts"), "");
+    mkdirSync(join(dir, "ctx", "nested"));
+    writeFileSync(join(dir, "ctx", "nested", "deep.ts"), "");
+
+    const handler = captureHandler();
+    const result = handler({
+      dir: "./ctx",
+      recursive: false,
+      importer: join(dir, "index.ts"),
+    });
+    expect(result.context.sort()).toEqual(["./a.ts", "./b.ts"]);
+  });
+
+  test("recursive — 모든 sub-tree 파일, slash 정규화", () => {
+    mkdirSync(join(dir, "ctx", "sub"), { recursive: true });
+    writeFileSync(join(dir, "ctx", "a.ts"), "");
+    writeFileSync(join(dir, "ctx", "sub", "deep.ts"), "");
+
+    const handler = captureHandler();
+    const result = handler({
+      dir: "./ctx",
+      recursive: true,
+      importer: join(dir, "index.ts"),
+    });
+    expect(result.context.sort()).toEqual(["./a.ts", "./sub/deep.ts"]);
+  });
+
+  test("custom filter regex 적용", () => {
+    mkdirSync(join(dir, "ctx"), { recursive: true });
+    writeFileSync(join(dir, "ctx", "a.ts"), "");
+    writeFileSync(join(dir, "ctx", "b.js"), "");
+    writeFileSync(join(dir, "ctx", "c.png"), "");
+
+    const handler = captureHandler();
+    const result = handler({
+      dir: "./ctx",
+      recursive: false,
+      filter: "\\.(ts|js)$",
+      importer: join(dir, "index.ts"),
+    });
+    expect(result.context.sort()).toEqual(["./a.ts", "./b.js"]);
+  });
+
+  test("filter regex flags 적용", () => {
+    mkdirSync(join(dir, "ctx"), { recursive: true });
+    writeFileSync(join(dir, "ctx", "Foo.ts"), "");
+    writeFileSync(join(dir, "ctx", "BAR.ts"), "");
+
+    const handler = captureHandler();
+    const result = handler({
+      dir: "./ctx",
+      recursive: false,
+      filter: "foo\\.ts$",
+      flags: "i",
+      importer: join(dir, "index.ts"),
+    });
+    expect(result.context).toEqual(["./Foo.ts"]);
+  });
+
+  test("결정적 순서 (사전식 sort)", () => {
+    mkdirSync(join(dir, "ctx"), { recursive: true });
+    for (const name of ["c.ts", "a.ts", "b.ts"]) {
+      writeFileSync(join(dir, "ctx", name), "");
+    }
+    const handler = captureHandler();
+    const result = handler({
+      dir: "./ctx",
+      recursive: false,
+      importer: join(dir, "index.ts"),
+    });
+    expect(result.context).toEqual(["./a.ts", "./b.ts", "./c.ts"]);
+  });
+
+  test("filter 미지정 시 default `^\\./.*$` — 모든 파일 매칭", () => {
+    mkdirSync(join(dir, "ctx"), { recursive: true });
+    writeFileSync(join(dir, "ctx", "a.txt"), "");
+    writeFileSync(join(dir, "ctx", "b.png"), "");
+    const handler = captureHandler();
+    const result = handler({
+      dir: "./ctx",
+      recursive: false,
+      importer: join(dir, "index.ts"),
+    });
+    expect(result.context.sort()).toEqual(["./a.txt", "./b.png"]);
+  });
+});

--- a/packages/react-native/src/plugins/require-context.ts
+++ b/packages/react-native/src/plugins/require-context.ts
@@ -1,0 +1,51 @@
+// require.context (#1579) — ZTS 가 인지/메타만, 매칭은 host (Bun JSC RegExp)
+// 책임. Phase 2.5 의 onResolveContext hook 사용 — 디렉토리 FS scan + filter
+// regex 매칭 + 결정적 정렬. importer 기준 상대 경로만, projectRoot 의존성 0.
+
+import { readdirSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+
+import type { ZtsPlugin } from "@zts/core";
+
+/**
+ * `require.context(dir, recursive, filter, flags?)` 의 host-side 평가. 디렉토리
+ * 가 없으면 graph 가 invalid 처리하지 않도록 빈 배열 응답. 파일 path 는 항상
+ * `./` prefix + forward slash (Windows path separator 정규화).
+ */
+export function createRequireContextPlugin(): ZtsPlugin {
+  return {
+    name: "zts:react-native:require-context",
+    setup(build) {
+      build.onResolveContext({ filter: /.*/ }, (args) => {
+        const { dir, recursive, filter, flags, importer } = args;
+        const absDir = resolve(dirname(importer), dir);
+
+        let entries: string[];
+        try {
+          if (recursive) {
+            entries = readdirSync(absDir, { recursive: true, withFileTypes: true })
+              .filter((d) => d.isFile())
+              .map((d) => {
+                const parent = (d as unknown as { parentPath?: string }).parentPath ?? absDir;
+                return relative(absDir, join(parent, d.name));
+              });
+          } else {
+            entries = readdirSync(absDir, { withFileTypes: true })
+              .filter((d) => d.isFile())
+              .map((d) => d.name);
+          }
+        } catch {
+          return { context: [] };
+        }
+
+        const re = filter ? new RegExp(filter, flags ?? "") : /^\.\/.*$/;
+        const matched = entries
+          .map((f) => `./${f.replace(/\\/g, "/")}`)
+          .filter((p) => re.test(p))
+          .sort();
+
+        return { context: matched };
+      });
+    },
+  };
+}

--- a/packages/react-native/src/plugins/types.ts
+++ b/packages/react-native/src/plugins/types.ts
@@ -1,0 +1,15 @@
+// Plugin factory 들의 공통 config. asset / babel / codegen / require-context /
+// metro-resolve-request 모두 RN-specific 환경 인자 동일 set 공유.
+
+export interface PluginConfig {
+  /** RN 프로젝트 root — Babel/codegen plugin resolve 의 base. */
+  projectRoot: string;
+  /** RN asset 확장자 (`.png` / `.jpg` / `.svg` 등). */
+  assetExts: string[];
+  /** RN runtime platform — codegen / asset 의 platform 분기. */
+  rnPlatform: "ios" | "android";
+  /** Source 확장자 (`.ts` / `.tsx` / `.js` / `.jsx` / `.svg` 등). */
+  sourceExts: string[];
+  /** Metro 호환 custom file transformer path (예: react-native-svg-transformer). */
+  babelTransformerPath?: string;
+}


### PR DESCRIPTION
## Summary

#2540 epic 의 PR #5. 번개 `napi-plugins.ts` (270줄) + `plugin-core.ts` (~150줄) 의 RN-specific plugin factory + Babel/codegen transformer helper 5종 흡수.

## 신설 — 5 plugin factory + 3 helper

`packages/react-native/src/plugins/`:

| 파일 | 책임 |
|------|------|
| `types.ts` | `PluginConfig` (projectRoot/assetExts/rnPlatform/sourceExts/babelTransformerPath?) |
| `internal.ts` | `requireFromCli` / `BabelInstance` / `BabelTransformOptions` / `getErrorMessage(err, max?)` (4 plugin 공용) |
| `babel.ts` | `ZTS_NATIVE_PLUGIN_PATTERNS` (19) / `isZtsNativePlugin` / `detectCustomPlugins` / `createBabelTransformer` (lazy) / `createBabelPlugin` |
| `codegen.ts` | `CODEGEN_NATIVE_COMPONENT_MARKER` / `createCodegenTransformer` / `createCodegenPlugin` (`@react-native/babel-plugin-codegen` lazy) |
| `asset.ts` | `createAssetPlugin` (HMRClient.js → `ZTS_HMR_CLIENT_CODE` inject + babelTransformerPath onLoad) |
| `require-context.ts` | `createRequireContextPlugin` (`onResolveContext` hook, Bun JSC RegExp, 결정적 sort) |
| `metro-resolve-request.ts` | `createMetroResolveRequestPlugin` + `MetroResolveRequestOptions` (Metro 시그니처 어댑팅, sentinel `__ZTS_RN_DELEGATE_TO_DEFAULT__`) |

`src/index.ts` 에 모두 re-export.

bungae specific brand 변경:
- `bungae:*` plugin name → `zts:react-native:*`
- sentinel `__BUNGAE_DELEGATE_TO_DEFAULT__` → `__ZTS_RN_DELEGATE_TO_DEFAULT__`
- log prefix `[bungae:*]` → `[zts:*]`

**bungae minor bug fix** — `detectCustomPlugins` 에 빈 string skip 추가 (number / object / null plugin entry 가 native 외 로 false-positive 카운트되던 케이스).

## 단위 테스트 5 파일 (53 new cases / 100%)

- `babel.test.ts` (14) — isZtsNativePlugin / ZTS_NATIVE_PLUGIN_PATTERNS / detectCustomPlugins 의 7 분기
- `codegen.test.ts` (4) — marker / .jsx-tsx / plugin 미설치 / parser 분기
- `asset.test.ts` (6) — HMRClient.js + babelTransformerPath / customExts 분기
- `require-context.test.ts` (7) — 7 분기 (recursive / filter / flags / sort)
- `metro-resolve-request.test.ts` (9) — Resolution 분기 + delegate

## /simplify 3-agent finding

**Apply** (high ROI, 모두 동의):
- `requireFromCli` 4-file 중복 → `internal.ts` helper
- `BabelInstance` / `BabelTransformOptions` 타입 중복 → `internal.ts`
- `getErrorMessage(err, max?)` helper — 4 곳 반복 통합

**Skip**:
- captureHandler test fixture 통합 — minor
- ensureBabel pattern 통합 — codegen/babel 미세 차이 (plugin path 이중 fallback)
- require-context `readdirSync` 측정 — 후속 audit
- stderr → logger — RN 디버깅 패턴 (unbuffered) 보존

## Test plan

- [x] `@zts/react-native` 117 pass / 0 fail / 295 expects (11 files)
- [x] `@zts/server` 75 pass, `@zts/web` 141 pass (회귀 0)
- [ ] CI 통과 시 auto-rebase merge

Refs #2540