### PR TITLE
feat(react-native): RN preset (buildRnBundleOptions / bundleRn / watchRn)

### DIFF
--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -44,5 +44,12 @@ export {
 } from "./plugins/metro-resolve-request.ts";
 export { createRequireContextPlugin } from "./plugins/require-context.ts";
 export type { PluginConfig } from "./plugins/types.ts";
+export {
+  buildRnBundleOptions,
+  bundleRn,
+  type RnBundleInput,
+  type RnWatchInput,
+  watchRn,
+} from "./preset.ts";
 export { resolveRnPolyfills, RN_GLOBAL_IDENTIFIERS, tryResolve } from "./rn-constants.ts";
 export { HMR_CLIENT_SUFFIX, ZTS_HMR_CLIENT_CODE } from "./runtime-loader.ts";

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -1,0 +1,317 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { ZtsPlugin } from "@zts/core";
+
+import { buildRnBundleOptions, type RnBundleInput } from "./preset.ts";
+import { RN_GLOBAL_IDENTIFIERS } from "./rn-constants.ts";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "zts-rn-preset-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function baseInput(overrides: Partial<RnBundleInput> = {}): RnBundleInput {
+  return {
+    entry: "src/index.ts",
+    projectRoot: dir,
+    rnPlatform: "ios",
+    dev: false,
+    ...overrides,
+  };
+}
+
+describe("buildRnBundleOptions — 기본 RN preset 필드", () => {
+  test("entry 가 absolute path 로 정규화", () => {
+    const opts = buildRnBundleOptions(baseInput());
+    expect(opts.entryPoints).toEqual([join(dir, "src/index.ts")]);
+  });
+
+  test("platform = 'react-native'", () => {
+    const opts = buildRnBundleOptions(baseInput());
+    expect(opts.platform).toBe("react-native");
+  });
+
+  test("RN-specific 자동 활성 필드 (target/flow/jsxInJs/configurableExports/strictExecutionOrder/workletTransform)", () => {
+    const opts = buildRnBundleOptions(baseInput());
+    expect(opts.target).toBe("es5");
+    expect(opts.flow).toBe(true);
+    expect(opts.jsxInJs).toBe(true);
+    expect(opts.configurableExports).toBe(true);
+    expect(opts.strictExecutionOrder).toBe(true);
+    expect(opts.workletTransform).toBe(true);
+  });
+
+  test("emitDiskSourcemap — dev 시 false, prod 시 true", () => {
+    expect(buildRnBundleOptions(baseInput({ dev: true })).emitDiskSourcemap).toBe(false);
+    expect(buildRnBundleOptions(baseInput({ dev: false })).emitDiskSourcemap).toBe(true);
+  });
+
+  test("globalIdentifiers — RN_GLOBAL_IDENTIFIERS 의 snapshot", () => {
+    const opts = buildRnBundleOptions(baseInput());
+    expect(opts.globalIdentifiers).toEqual([...RN_GLOBAL_IDENTIFIERS]);
+  });
+
+  test("mainFields — react-native / browser / module / main", () => {
+    const opts = buildRnBundleOptions(baseInput());
+    expect(opts.mainFields).toEqual(["react-native", "browser", "module", "main"]);
+  });
+});
+
+describe("buildRnBundleOptions — platform 분기 (resolveExtensions)", () => {
+  test("iOS — `.ios.*` 가 prefix", () => {
+    const opts = buildRnBundleOptions(baseInput({ rnPlatform: "ios" }));
+    expect(opts.resolveExtensions?.[0]).toBe(".ios.ts");
+    expect(opts.resolveExtensions?.[1]).toBe(".ios.tsx");
+    expect(opts.resolveExtensions).toContain(".native.ts");
+    expect(opts.resolveExtensions).toContain(".ts");
+  });
+
+  test("Android — `.android.*` 가 prefix", () => {
+    const opts = buildRnBundleOptions(baseInput({ rnPlatform: "android" }));
+    expect(opts.resolveExtensions?.[0]).toBe(".android.ts");
+    expect(opts.resolveExtensions?.[1]).toBe(".android.tsx");
+    expect(opts.resolveExtensions).toContain(".native.ts");
+  });
+});
+
+describe("buildRnBundleOptions — define / banner / footer / polyfills", () => {
+  test("define — __DEV__ + process.env.NODE_ENV + Expo Router env + EXPO_OS", () => {
+    const opts = buildRnBundleOptions(baseInput({ dev: true, rnPlatform: "android" }));
+    expect(opts.define?.__DEV__).toBe("true");
+    expect(opts.define?.["process.env.NODE_ENV"]).toBe('"development"');
+    expect(opts.define?.["process.env.EXPO_ROUTER_APP_ROOT"]).toBe('"./app"');
+    expect(opts.define?.["process.env.EXPO_OS"]).toBe('"android"');
+    expect(opts.define?.global).toBe("__ZTS_RN_GLOBAL__");
+  });
+
+  test("define — prod 시 NODE_ENV=production", () => {
+    const opts = buildRnBundleOptions(baseInput({ dev: false }));
+    expect(opts.define?.__DEV__).toBe("false");
+    expect(opts.define?.["process.env.NODE_ENV"]).toBe('"production"');
+  });
+
+  test("banner — RN prelude 5 핵심 라인 포함", () => {
+    const opts = buildRnBundleOptions(baseInput({ dev: true }));
+    expect(opts.banner).toContain("__BUNDLE_START_TIME__");
+    expect(opts.banner).toContain("__DEV__=true");
+    expect(opts.banner).toContain("__ZTS_RN_GLOBAL__");
+    expect(opts.banner).toContain("__ZTS_RN_BUNDLER__");
+    expect(opts.banner).not.toContain("__BUNGAE_");
+  });
+
+  test("bannerExtras — RN prelude 끝에 append", () => {
+    const opts = buildRnBundleOptions(
+      baseInput({ bannerExtras: 'globalThis.__APP_VERSION__="1.0";' }),
+    );
+    expect(opts.banner).toContain("__APP_VERSION__");
+    expect(opts.banner?.endsWith('globalThis.__APP_VERSION__="1.0";')).toBe(true);
+  });
+
+  test("dev=true — footer (DevLoadingView hide) 포함", () => {
+    const opts = buildRnBundleOptions(baseInput({ dev: true }));
+    expect(opts.footer).toContain("DevLoadingView.hide");
+  });
+
+  test("dev=false — footer 미정의", () => {
+    const opts = buildRnBundleOptions(baseInput({ dev: false }));
+    expect(opts.footer).toBeUndefined();
+  });
+
+  test("polyfills — resolveRnPolyfills miss 시 미정의 (caller 가 default 빈 배열)", () => {
+    const opts = buildRnBundleOptions(baseInput());
+    // Fixture 에 RN 미설치 — polyfills 없음
+    expect(opts.polyfills).toBeUndefined();
+  });
+
+  test("runBeforeMain — InitializeCore 미해결 시 미정의", () => {
+    const opts = buildRnBundleOptions(baseInput());
+    expect(opts.runBeforeMain).toBeUndefined();
+  });
+});
+
+describe("buildRnBundleOptions — dev mode 분기 (jsx / devMode / reactRefresh / collectModuleCodes)", () => {
+  test("dev=true — jsx=automatic-dev / devMode / reactRefresh / collectModuleCodes 모두 활성", () => {
+    const opts = buildRnBundleOptions(baseInput({ dev: true }));
+    expect(opts.jsx).toBe("automatic-dev");
+    expect(opts.devMode).toBe(true);
+    expect(opts.reactRefresh).toBe(true);
+    expect(opts.collectModuleCodes).toBe(true);
+  });
+
+  test("dev=false — jsx 미정의 (NAPI default), devMode/reactRefresh/collectModuleCodes 미설정", () => {
+    const opts = buildRnBundleOptions(baseInput({ dev: false }));
+    expect(opts.jsx).toBeUndefined();
+    expect(opts.devMode).toBeUndefined();
+    expect(opts.reactRefresh).toBeUndefined();
+    expect(opts.collectModuleCodes).toBeUndefined();
+  });
+});
+
+describe("buildRnBundleOptions — plugins (asset/codegen/babel/require-context/[+metro-resolve])", () => {
+  test("기본 4 plugin (asset/codegen/babel/require-context)", () => {
+    const opts = buildRnBundleOptions(baseInput());
+    expect(opts.plugins?.length).toBe(4);
+    const names = opts.plugins?.map((p) => p.name);
+    expect(names).toEqual([
+      "zts:react-native:runtime",
+      "zts:react-native:codegen-view-config",
+      "zts:react-native:babel-transform",
+      "zts:react-native:require-context",
+    ]);
+  });
+
+  test("extra.metroResolveRequest 지정 시 5 plugin (metro-resolve-request 추가)", () => {
+    const opts = buildRnBundleOptions(
+      baseInput({
+        extra: {
+          metroResolveRequest: () => ({ type: "empty" }),
+        },
+      }),
+    );
+    expect(opts.plugins?.length).toBe(5);
+    expect(opts.plugins?.[4]?.name).toBe("zts:react-native:metro-resolve-request");
+  });
+
+  test("extra.additionalPlugins → plugins 끝에 append", () => {
+    const userPlugin: ZtsPlugin = { name: "user:custom", setup() {} };
+    const opts = buildRnBundleOptions(
+      baseInput({
+        extra: {
+          additionalPlugins: [userPlugin],
+        },
+      }),
+    );
+    expect(opts.plugins?.length).toBe(5);
+    expect(opts.plugins?.[4]).toBe(userPlugin);
+  });
+});
+
+describe("buildRnBundleOptions — extra (watchFolders / blockList / fallback)", () => {
+  test("watchFolders — 지정 시 absolute path 로 정규화", () => {
+    const opts = buildRnBundleOptions(
+      baseInput({ extra: { watchFolders: ["./shared", "/abs/other"] } }),
+    );
+    expect(opts.watchFolders).toEqual([join(dir, "shared"), "/abs/other"]);
+  });
+
+  test("blockList — 빈 배열은 미설정", () => {
+    const opts = buildRnBundleOptions(baseInput({ extra: { blockList: [] } }));
+    expect(opts.blockList).toBeUndefined();
+  });
+
+  test("blockList — 지정 시 그대로", () => {
+    const re = /\.test\.ts$/;
+    const opts = buildRnBundleOptions(baseInput({ extra: { blockList: [re, "string-pat"] } }));
+    expect(opts.blockList).toEqual([re, "string-pat"]);
+  });
+
+  test("fallback — 빈 객체는 미설정", () => {
+    const opts = buildRnBundleOptions(baseInput({ extra: { fallback: {} } }));
+    expect(opts.fallback).toBeUndefined();
+  });
+
+  test("fallback — 지정 시 그대로", () => {
+    const opts = buildRnBundleOptions(
+      baseInput({ extra: { fallback: { crypto: "/abs/crypto-shim", fs: false } } }),
+    );
+    expect(opts.fallback).toEqual({ crypto: "/abs/crypto-shim", fs: false });
+  });
+});
+
+describe("buildRnBundleOptions — loader / alias", () => {
+  test("loader — assetExts 마다 'file'", () => {
+    const opts = buildRnBundleOptions(baseInput());
+    expect(opts.loader?.[".png"]).toBe("file");
+    expect(opts.loader?.[".jpg"]).toBe("file");
+    expect(opts.loader?.[".svg"]).toBe("file");
+  });
+
+  test("loader — assetExts override 적용", () => {
+    const opts = buildRnBundleOptions(baseInput({ extra: { assetExts: [".webp", ".woff2"] } }));
+    expect(Object.keys(opts.loader ?? {}).sort()).toEqual([".webp", ".woff2"]);
+  });
+
+  test("alias — 빈 객체 (asset registry self-cycle 회피, comment 참조)", () => {
+    const opts = buildRnBundleOptions(baseInput());
+    expect(opts.alias).toEqual({});
+  });
+});
+
+describe("buildRnBundleOptions — override (deep merge)", () => {
+  test("define — preset 위에 user override 합쳐짐 (deep merge)", () => {
+    const opts = buildRnBundleOptions(
+      baseInput({
+        override: { define: { __MY_FLAG__: '"on"' } },
+      }),
+    );
+    expect(opts.define?.__DEV__).toBeDefined();
+    expect(opts.define?.__MY_FLAG__).toBe('"on"');
+  });
+
+  test("plugins — override 가 array 라 replace (deep merge 안 함)", () => {
+    const customPlugins: ZtsPlugin[] = [{ name: "user:only", setup() {} }];
+    const opts = buildRnBundleOptions(
+      baseInput({
+        override: { plugins: customPlugins },
+      }),
+    );
+    expect(opts.plugins).toBe(customPlugins);
+  });
+
+  test("primitive override — replace", () => {
+    const opts = buildRnBundleOptions(baseInput({ override: { minify: true, target: "es2020" } }));
+    expect(opts.minify).toBe(true);
+    expect(opts.target).toBe("es2020");
+  });
+
+  test("override 의 nested object — deep merge", () => {
+    const opts = buildRnBundleOptions(
+      baseInput({
+        override: {
+          loader: { ".graphql": "text" },
+        },
+      }),
+    );
+    expect(opts.loader?.[".png"]).toBe("file");
+    expect(opts.loader?.[".graphql"]).toBe("text");
+  });
+});
+
+describe("buildRnBundleOptions — workletPluginVersion", () => {
+  test("input override 우선", () => {
+    const opts = buildRnBundleOptions(baseInput({ workletPluginVersion: "0.1.2" }));
+    expect(opts.workletPluginVersion).toBe("0.1.2");
+  });
+
+  test("react-native-worklets 미설치 시 미정의", () => {
+    const opts = buildRnBundleOptions(baseInput());
+    expect(opts.workletPluginVersion).toBeUndefined();
+  });
+});
+
+describe("buildRnBundleOptions — sourcemap / minify", () => {
+  test("sourcemap default — dev 따라감", () => {
+    expect(buildRnBundleOptions(baseInput({ dev: true })).sourcemap).toBe(true);
+    expect(buildRnBundleOptions(baseInput({ dev: false })).sourcemap).toBe(false);
+  });
+
+  test("sourcemap explicit override", () => {
+    expect(buildRnBundleOptions(baseInput({ dev: false, sourcemap: true })).sourcemap).toBe(true);
+  });
+
+  test("minify default = false", () => {
+    expect(buildRnBundleOptions(baseInput()).minify).toBe(false);
+  });
+
+  test("minify explicit", () => {
+    expect(buildRnBundleOptions(baseInput({ minify: true })).minify).toBe(true);
+  });
+});

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -1,0 +1,341 @@
+// RN preset — `RnBundleInput` (사용자 입력) → `BuildOptions` (ZTS NAPI build/watch
+// 입력). 번개 napi-build.ts 의 RN 분기 (L74~L268) 와 동등 동작 + 번개 의존성 0.
+//
+// 자동 활성 필드 (RN platform 시): target=es5, flow=true, jsxInJs=true,
+// configurableExports=true, strictExecutionOrder=true, workletTransform=true,
+// resolveExtensions (ios/android prefix), mainFields (RN/browser/module/main),
+// banner (RN prelude), define (__DEV__/process.env), polyfills/runBeforeMain/
+// globalIdentifiers (resolveRnPolyfills + InitializeCore + RN_GLOBAL_IDENTIFIERS),
+// loader (asset 확장자), plugins (asset/codegen/babel/require-context/[metro-resolve-request]).
+//
+// dev 시 추가: jsx=automatic-dev, devMode=true, reactRefresh=true,
+// collectModuleCodes=true, footer (DevLoadingView hide).
+//
+// caller (번개 / RN 사용자) 가 input 으로 base config 전달 → preset 이 BuildOptions
+// 빌드 → 마지막에 input.override 로 사용자 override 가능.
+
+import { resolve } from "node:path";
+
+import {
+  build,
+  type BuildOptions,
+  type BuildResult,
+  init,
+  watch,
+  type WatchHandle,
+  type WatchReadyEvent,
+  type WatchRebuildEvent,
+  type ZtsPlugin,
+} from "@zts/core";
+
+import type { CustomResolver, MetroPlatform } from "./metro-resolver-types.ts";
+import { createAssetPlugin } from "./plugins/asset.ts";
+import { createBabelPlugin } from "./plugins/babel.ts";
+import { createCodegenPlugin } from "./plugins/codegen.ts";
+import { requireFromCli } from "./plugins/internal.ts";
+import {
+  createMetroResolveRequestPlugin,
+  type MetroResolveRequestOptions,
+} from "./plugins/metro-resolve-request.ts";
+import { createRequireContextPlugin } from "./plugins/require-context.ts";
+import { resolveRnPolyfills, RN_GLOBAL_IDENTIFIERS, tryResolve } from "./rn-constants.ts";
+
+export interface RnBundleInput {
+  /** 절대 경로 entry. */
+  entry: string;
+  /** 프로젝트 루트 — RN polyfill / InitializeCore / Reanimated worklets resolve 의 base. */
+  projectRoot: string;
+  /** RN platform — preset 의 default ext / mainFields / asset loaders 결정. */
+  rnPlatform: "ios" | "android";
+  /** dev mode — banner / jsx / devMode / reactRefresh / footer 분기. */
+  dev: boolean;
+  /** sourcemap emit. dev 시 inline 권장. */
+  sourcemap?: boolean;
+  /** prod build 의 minify. */
+  minify?: boolean;
+  /**
+   * preset 위에 user override. semantics:
+   * - **Object dict** (`define` / `loader` / `alias` / `fallback` 등) — preset
+   *   value 와 deep merge (key 단위 union, 충돌 시 override 우선)
+   * - **Array** (`plugins` / `resolveExtensions` / `mainFields` 등) — replace
+   *   (preset 의 array 무시)
+   * - **Primitive** (`target` / `minify` 등) — replace
+   *
+   * preset 의 default 가 ZTS RN 호환 보장 — array override 는 RN 동작 깨질
+   * 위험 있음 (caller 가 의도적 변경 시만 사용).
+   */
+  override?: Partial<BuildOptions>;
+  /** Metro 호환 추가 옵션 (caller 의 ResolvedConfig 에서 추출). */
+  extra?: {
+    watchFolders?: string[];
+    blockList?: (RegExp | string)[];
+    fallback?: Record<string, string | false>;
+    /** RN 외 사용자 plugin (asset/babel/codegen/require-context/metro-resolve-request 외 추가). */
+    additionalPlugins?: ZtsPlugin[];
+    /** Custom Metro resolveRequest — Metro 시그니처 그대로. */
+    metroResolveRequest?: CustomResolver;
+    /** Metro 호환 babel transformer path (svg-transformer 등). */
+    babelTransformerPath?: string;
+    /** RN sourceExts override (default RN preset). */
+    sourceExts?: string[];
+    /** RN assetExts override (default RN preset). */
+    assetExts?: string[];
+  };
+  /** RN prelude 끝에 append 할 사용자 banner string. */
+  bannerExtras?: string;
+  /** Reanimated worklets 의 jsVersion 검증용. 미지정 시 자동 resolve. */
+  workletPluginVersion?: string;
+}
+
+const DEFAULT_SOURCE_EXTS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".json"];
+const DEFAULT_ASSET_EXTS = [
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".webp",
+  ".svg",
+  ".ttf",
+  ".otf",
+  ".mp3",
+  ".mp4",
+  ".m4a",
+  ".m4v",
+  ".pdf",
+  ".html",
+];
+
+const NATIVE_AND_BASE = [
+  ".native.ts",
+  ".native.tsx",
+  ".native.js",
+  ".native.jsx",
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".json",
+];
+
+function buildResolveExtensions(rnPlatform: "ios" | "android"): string[] {
+  if (rnPlatform === "ios") {
+    return [".ios.ts", ".ios.tsx", ".ios.js", ".ios.jsx", ...NATIVE_AND_BASE];
+  }
+  return [".android.ts", ".android.tsx", ".android.js", ".android.jsx", ...NATIVE_AND_BASE];
+}
+
+function buildAssetLoaders(assetExts: readonly string[]): Record<string, string> {
+  const loaders: Record<string, string> = {};
+  for (const ext of assetExts) {
+    loaders[ext.startsWith(".") ? ext : `.${ext}`] = "file";
+  }
+  return loaders;
+}
+
+function buildPrelude(input: RnBundleInput): string {
+  const { dev, bannerExtras } = input;
+  const lines = [
+    `var __BUNDLE_START_TIME__=this.nativePerformanceNow?nativePerformanceNow():Date.now();`,
+    `var __DEV__=${dev};`,
+    `var __ZTS_RN_GLOBAL__=typeof globalThis!=='undefined'?globalThis:typeof global!=='undefined'?global:typeof window!=='undefined'?window:this;`,
+    `if(typeof global==='undefined')var global=__ZTS_RN_GLOBAL__;`,
+    `var process=__ZTS_RN_GLOBAL__.process||{};process.env=process.env||{};process.env.NODE_ENV=process.env.NODE_ENV||"${dev ? "development" : "production"}";`,
+    `globalThis.__ZTS_RN_BUNDLER__=true;`,
+  ];
+  if (bannerExtras) lines.push(bannerExtras);
+  return lines.join("");
+}
+
+function resolveWorkletPluginVersion(
+  projectRoot: string,
+  override: string | undefined,
+): string | undefined {
+  if (override) return override;
+  try {
+    const pkgPath = requireFromCli.resolve("react-native-worklets/package.json", {
+      paths: [projectRoot],
+    });
+    const pkg = requireFromCli(pkgPath) as { version?: string };
+    return pkg.version;
+  } catch {
+    return undefined;
+  }
+}
+
+function deepMerge<T extends Record<string, unknown>>(base: T, override: Partial<T>): T {
+  const result: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(override)) {
+    if (value === undefined) continue;
+    const existing = result[key];
+    if (
+      existing &&
+      typeof existing === "object" &&
+      !Array.isArray(existing) &&
+      value &&
+      typeof value === "object" &&
+      !Array.isArray(value)
+    ) {
+      result[key] = deepMerge(
+        existing as Record<string, unknown>,
+        value as Record<string, unknown>,
+      );
+    } else {
+      result[key] = value;
+    }
+  }
+  return result as T;
+}
+
+/**
+ * RN preset — RnBundleInput → BuildOptions. 번개 napi-build.ts L74-L268 의 RN
+ * 분기와 동등 동작.
+ */
+export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
+  const { entry, projectRoot, rnPlatform, dev, sourcemap, minify, extra } = input;
+
+  const sourceExts = extra?.sourceExts ?? DEFAULT_SOURCE_EXTS;
+  const assetExts = extra?.assetExts ?? DEFAULT_ASSET_EXTS;
+
+  // Plugin set — RN preset 기본 4 + (옵션) MetroResolveRequest + (옵션) additional.
+  const plugins: ZtsPlugin[] = [
+    createAssetPlugin({
+      projectRoot,
+      assetExts,
+      rnPlatform,
+      sourceExts,
+      babelTransformerPath: extra?.babelTransformerPath,
+    }),
+    createCodegenPlugin({
+      projectRoot,
+      assetExts,
+      rnPlatform,
+      sourceExts,
+    }),
+    createBabelPlugin({
+      projectRoot,
+      assetExts,
+      rnPlatform,
+      sourceExts,
+    }),
+    createRequireContextPlugin(),
+  ];
+  if (extra?.metroResolveRequest) {
+    const opts: MetroResolveRequestOptions = {
+      resolveRequest: extra.metroResolveRequest,
+      // RN preset 의 rnPlatform (ios/android) 을 MetroPlatform 으로. caller 가
+      // web 시나리오를 원하면 metro-resolve-request 를 직접 만들어 plugin 에 주입.
+      platform: rnPlatform as MetroPlatform,
+    };
+    plugins.push(createMetroResolveRequestPlugin(opts));
+  }
+  if (extra?.additionalPlugins) {
+    plugins.push(...extra.additionalPlugins);
+  }
+
+  const polyfills = resolveRnPolyfills(projectRoot);
+  const runBeforeMain: string[] = [];
+  const initCore = tryResolve("react-native/Libraries/Core/InitializeCore", projectRoot);
+  if (initCore) runBeforeMain.push(initCore);
+
+  const define: Record<string, string> = {
+    global: "__ZTS_RN_GLOBAL__",
+    __DEV__: String(dev),
+    "process.env.NODE_ENV": `"${dev ? "development" : "production"}"`,
+    // Expo Router 의 require.context 인자 정적 평가용 (Phase 2.6 import_scanner).
+    "process.env.EXPO_ROUTER_APP_ROOT": '"./app"',
+    "process.env.EXPO_ROUTER_IMPORT_MODE": '"sync"',
+    "process.env.EXPO_OS": `"${rnPlatform}"`,
+  };
+
+  const baseLoader = buildAssetLoaders(assetExts);
+
+  const preset: BuildOptions = {
+    entryPoints: [resolve(projectRoot, entry)],
+    platform: "react-native",
+    sourcemap: sourcemap ?? dev,
+    minify: minify ?? false,
+    plugins,
+    emitDiskSourcemap: !dev,
+    target: "es5",
+    flow: true,
+    jsxInJs: true,
+    configurableExports: true,
+    strictExecutionOrder: true,
+    workletTransform: true,
+    resolveExtensions: buildResolveExtensions(rnPlatform),
+    mainFields: ["react-native", "browser", "module", "main"],
+    loader: baseLoader,
+    alias: {},
+    define,
+    banner: buildPrelude(input),
+    globalIdentifiers: [...RN_GLOBAL_IDENTIFIERS],
+  };
+
+  if (polyfills.length > 0) preset.polyfills = polyfills;
+  if (runBeforeMain.length > 0) preset.runBeforeMain = runBeforeMain;
+
+  // Reanimated worklets 의 jsVersion 검증 — Reanimated runtime 의 serializable.native.ts:464
+  // 가 plugin 의 inject 와 mismatch 시 WorkletsError throw.
+  const workletVersion = resolveWorkletPluginVersion(projectRoot, input.workletPluginVersion);
+  if (workletVersion) preset.workletPluginVersion = workletVersion;
+
+  if (dev) {
+    preset.jsx = "automatic-dev";
+    preset.devMode = true;
+    preset.reactRefresh = true;
+    preset.collectModuleCodes = true;
+    preset.footer = "setTimeout(function(){try{NativeModules.DevLoadingView.hide()}catch(e){}},0);";
+  }
+
+  if (extra?.watchFolders && extra.watchFolders.length > 0) {
+    preset.watchFolders = extra.watchFolders.map((p) => resolve(projectRoot, p));
+  }
+  if (extra?.blockList && extra.blockList.length > 0) {
+    preset.blockList = extra.blockList;
+  }
+  if (extra?.fallback && Object.keys(extra.fallback).length > 0) {
+    preset.fallback = { ...extra.fallback };
+  }
+
+  // user override 는 마지막 — define / loader / alias 같은 dict 는 deep merge,
+  // 그 외 (plugins / banner 등) 는 replace.
+  if (input.override) {
+    return deepMerge(
+      preset as unknown as Record<string, unknown>,
+      input.override as unknown as Partial<Record<string, unknown>>,
+    ) as unknown as BuildOptions;
+  }
+  return preset;
+}
+
+/**
+ * One-shot wrapper — `init()` + `build(buildRnBundleOptions(input))`. caller 가
+ * NAPI direct 호출이 아니라 단순 prod bundle 시나리오.
+ *
+ * `init()` 은 idempotent (core 의 module-cache `if (native) return`) — caller
+ * 가 별도로 `init(path)` 호출 후 `bundleRn` 호출해도 안전 (앞선 path 가 우선).
+ */
+export async function bundleRn(input: RnBundleInput): Promise<BuildResult> {
+  init();
+  return build(buildRnBundleOptions(input));
+}
+
+export interface RnWatchInput extends RnBundleInput {
+  outfile: string;
+  onReady?: (event: WatchReadyEvent) => void;
+  onRebuild?: (event: WatchRebuildEvent) => void;
+}
+
+/**
+ * Watch wrapper — `init()` + `watch(buildRnBundleOptions(input))` + outfile +
+ * onReady/onRebuild wire-up. handle 반환 (caller 가 close). `init()` idempotent.
+ */
+export function watchRn(input: RnWatchInput): WatchHandle {
+  init();
+  const opts = buildRnBundleOptions(input);
+  opts.outfile = input.outfile;
+  opts.write = true;
+  if (input.onReady) opts.onReady = input.onReady;
+  if (input.onRebuild) opts.onRebuild = input.onRebuild;
+  return watch(opts);
+}


### PR DESCRIPTION
## Summary

#2540 epic 의 PR #6. 번개 `napi-build.ts` L74-L268 의 RN 분기와 동등 동작 + 번개 의존성 0 인 RN preset. high-level wrapper `bundleRn` / `watchRn` 동반.

## API 시그니처

```ts
export interface RnBundleInput {
  entry: string;
  projectRoot: string;
  rnPlatform: \"ios\" | \"android\";
  dev: boolean;
  sourcemap?: boolean;
  minify?: boolean;
  override?: Partial<BuildOptions>;  // dict deep merge / array replace
  extra?: {
    watchFolders?: string[];
    blockList?: (RegExp | string)[];
    fallback?: Record<string, string | false>;
    additionalPlugins?: ZtsPlugin[];
    metroResolveRequest?: CustomResolver;
    babelTransformerPath?: string;
    sourceExts?: string[];
    assetExts?: string[];
  };
  bannerExtras?: string;
  workletPluginVersion?: string;
}

export function buildRnBundleOptions(input: RnBundleInput): BuildOptions;
export function bundleRn(input): Promise<BuildResult>;
export function watchRn(input: RnWatchInput): WatchHandle;
```

## RN preset 자동 활성

`platform: 'react-native'` + target=es5 + flow + jsxInJs + configurableExports + strictExecutionOrder + workletTransform + resolveExtensions (ios/android prefix) + mainFields (RN/browser/module/main) + banner (RN prelude — `__BUNGAE_GLOBAL__` → `__ZTS_RN_GLOBAL__` generic 화) + define (`__DEV__` / `process.env.NODE_ENV` / Expo Router env / `EXPO_OS`) + globalIdentifiers + loader (asset `'file'`) + plugins (asset / codegen / babel / require-context / [metro-resolve-request if extra]).

dev=true 추가: `jsx=automatic-dev`, devMode, reactRefresh, collectModuleCodes, footer (DevLoadingView hide). `emitDiskSourcemap = !dev`. `workletPluginVersion` auto-resolve.

## 단위 테스트 (`preset.test.ts`, 31 cases / 100%)

기본 필드 / platform 분기 / define-banner-footer-polyfills / dev mode 분기 / plugins / extra / loader-alias / override deep merge / workletPluginVersion / sourcemap-minify 모두 cover.

## /simplify 3-agent finding

**Apply**:
- 테스트 typo `sapp` → `snapshot` (Agent 2)
- `RnBundleInput.override` jsdoc — deep merge / replace semantics 명확화 (Agent 2)
- `bundleRn`/`watchRn` jsdoc — `init()` idempotent (core 의 `if (native) return`) 명시 (Agent 3)

**Skip**:
- `deepMerge` core utils 추출 — RN scope 좁음
- `__ZTS_RN_VERSION__` 추가 — caller 가 `bannerExtras` 로 주입
- `readonly` 일관성 — 호출자 mutate 안 하는 컨벤션
- `extra` nested optional depth — extensibility 정당

## Test plan

- [x] `@zts/react-native` 156 pass / 0 fail / 370 expects (12 files)
- [x] `@zts/server` 75 pass, `@zts/web` 141 pass, `@zts/core` 222 pass (회귀 0)
- [ ] CI 통과 시 auto-rebase merge

Refs #2540