### PR TITLE
feat(core): zts bundle --platform=react-native dispatch (lazy import @zts/react-native)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@emotion/react": "^11.14.0",
         "@tailwindcss/postcss": "^4.2.2",
         "@tanstack/react-query": "^5",
+        "@zts/react-native": "workspace:*",
         "@zts/web": "workspace:*",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@emotion/react": "^11.14.0",
     "@tailwindcss/postcss": "^4.2.2",
     "@tanstack/react-query": "^5",
+    "@zts/react-native": "workspace:*",
     "@zts/web": "workspace:*",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/packages/core/bin/cli-flags.mjs
+++ b/packages/core/bin/cli-flags.mjs
@@ -103,6 +103,8 @@ export const FLAG_REGISTRY = [
     forms: ["equal"],
   },
   { kind: "string", flag: "--rn-platform", target: "rnPlatform", forms: ["equal"] },
+  // #2540 PR #7 — RN preset 의 projectRoot. 기본 cwd, 사용자 monorepo root 지정 시 사용.
+  { kind: "string", flag: "--rn-project-root", target: "rnProjectRoot", forms: ["equal"] },
   { kind: "string", flag: "--source-root", target: "sourceRoot", forms: ["equal"] },
   // #2159 — `--output-exports=auto|named|default|none` (Rollup output.exports 호환).
   { kind: "string", flag: "--output-exports", target: "outputExports", forms: ["equal"] },

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -618,6 +618,63 @@ async function loadWebModule() {
   return webModulePromise;
 }
 
+// RN 모드 (`zts bundle --platform=react-native`) — @zts/react-native 을 lazy
+// import. transpile/bundle 일반 사용자는 web 처럼 영향 0 (#2540 PR #7).
+let rnModulePromise = null;
+async function loadRnModule() {
+  if (rnModulePromise) return rnModulePromise;
+  rnModulePromise = (async () => {
+    try {
+      return await import("@zts/react-native");
+    } catch (err) {
+      const code = err?.code;
+      const message = String(err?.message ?? "");
+      if (
+        code === "ERR_MODULE_NOT_FOUND" ||
+        /Cannot find package "@zts\/react-native"/.test(message)
+      ) {
+        console.error(
+          "error: @zts/react-native 패키지가 필요합니다 (zts bundle --platform=react-native).",
+        );
+        console.error("");
+        console.error(
+          "help: install with `bun add -D @zts/react-native` 또는 `npm i -D @zts/react-native`.",
+        );
+        process.exit(1);
+      }
+      throw err;
+    }
+  })();
+  return rnModulePromise;
+}
+
+async function runRnBundle(opts, _config) {
+  const rn = await loadRnModule();
+  const projectRoot = resolve(opts.rnProjectRoot ?? ".");
+  const entry = opts.entryPoints?.[0];
+  if (!entry) {
+    console.error(
+      "error: zts bundle --platform=react-native 는 entry point 가 필요합니다 (예: `zts bundle index.ts --platform=react-native`)",
+    );
+    process.exit(1);
+  }
+  const rnPlatform = opts.rnPlatform === "android" ? "android" : "ios";
+  const result = await rn.bundleRn({
+    entry,
+    projectRoot,
+    rnPlatform,
+    dev: Boolean(opts.devMode),
+    sourcemap: Boolean(opts.sourcemap),
+    minify:
+      opts.minify || opts.minifyWhitespace || opts.minifyIdentifiers || opts.minifySyntax || false,
+    override: opts.outfile ? { outfile: opts.outfile, write: true } : undefined,
+  });
+  if (result.errors.length === 0 && opts.logLevel !== "silent") {
+    console.error(`[bundle] react-native ${rnPlatform} ${opts.outfile ?? "(in-memory)"}`);
+  }
+  return result;
+}
+
 async function runAppPreview(opts) {
   opts.serveDir = resolve(opts.previewDir ?? opts.outdir ?? "dist");
   opts.outdir = undefined;
@@ -1638,6 +1695,12 @@ async function dispatchBuild(opts, config, configEnv, dotenvVars) {
   if (opts.watch) {
     await runWatch(opts, config);
     return { errors: 0 };
+  }
+  if (opts.bundle && opts.platform === "react-native") {
+    // #2540 PR #7 — RN platform 시 @zts/react-native 의 preset 호출. lazy
+    // import 라 web/transpile/bundle 일반 사용자 영향 0.
+    const result = await runRnBundle(opts, config);
+    return { errors: result.errors.length };
   }
   if (opts.bundle) {
     const result = await runBundle(opts, config);

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -4982,3 +4982,61 @@ describe("CLI: workspace (#2111)", () => {
     expect(existsSync(join(dir, "shared", "dist"))).toBe(true);
   });
 });
+
+describe("CLI: bundle --platform=react-native (#2540 PR #7)", () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "zts-cli-rn-bundle-"));
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "index.ts"), 'console.log("rn-bundle");');
+  });
+
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("기본 RN bundle 산출 — banner / __DEV__=false / globalThis 식별자", () => {
+    const out = join(dir, "out.js");
+    const { exitCode } = runCli([
+      "--bundle",
+      join(dir, "src/index.ts"),
+      "--platform=react-native",
+      "--rn-platform=ios",
+      `--rn-project-root=${dir}`,
+      "-o",
+      out,
+    ]);
+    expect(exitCode).toBe(0);
+    expect(existsSync(out)).toBe(true);
+    // 산출물 내용으로 RN preset 적용 검증 — stderr logging 의 변동성에 의존 안 함.
+    const content = readFileSync(out, "utf8");
+    expect(content).toContain("__BUNDLE_START_TIME__");
+    expect(content).toContain("__ZTS_RN_GLOBAL__");
+    expect(content).toContain("__ZTS_RN_BUNDLER__");
+    expect(content).toContain("__DEV__=false");
+  });
+
+  test("entry 누락 시 친화 에러 메시지 + exit 1", () => {
+    const { exitCode, stderr } = runCli([
+      "--bundle",
+      "--platform=react-native",
+      "--rn-platform=ios",
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("entry");
+  });
+
+  test("--rn-platform=android 분기 — banner 동일 (preset 의 prelude 는 platform 무관)", () => {
+    const out = join(dir, "out-android.js");
+    const { exitCode } = runCli([
+      "--bundle",
+      join(dir, "src/index.ts"),
+      "--platform=react-native",
+      "--rn-platform=android",
+      `--rn-project-root=${dir}`,
+      "-o",
+      out,
+    ]);
+    expect(exitCode).toBe(0);
+    expect(existsSync(out)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

#2540 epic 의 PR #7. `zts.mjs` 의 `dispatchBuild` 에 RN 분기 추가 + lazy import `@zts/react-native` — web 패턴 그대로.

## 변경

**`packages/core/bin/zts.mjs`**:
- 신설 `loadRnModule()` — `@zts/react-native` lazy import, 미설치 시 친화 에러 + exit 1 (web 패턴 동일)
- 신설 `runRnBundle(opts, _config)` — opts → `RnBundleInput` 매핑 → `rn.bundleRn` 호출. entry 누락 시 친화 에러. minify 4 flag OR-chain.
- `dispatchBuild` — `if (opts.bundle && opts.platform === \"react-native\")` 분기 추가 (일반 bundle 분기 *전*)

**`packages/core/bin/cli-flags.mjs`**:
- 신설 `--rn-project-root` (target: `rnProjectRoot`, `forms: [\"equal\"]` — 다른 모든 string flag 와 일관)

**`package.json` (root)**:
- `@zts/react-native: workspace:*` devDependencies 추가 → root `node_modules` 에 symlink 생성 → `zts.mjs` 의 `import(\"@zts/react-native\")` resolve 가능

## 사용 예

```bash
zts --bundle src/index.ts \\
  --platform=react-native \\
  --rn-platform=ios \\
  --rn-project-root=/abs/project \\
  -o out.js
```

## 단위 테스트 (3 new cases)

- 기본 RN bundle 산출 — outfile 존재 + content (`__BUNDLE_START_TIME__` / `__ZTS_RN_GLOBAL__` / `__ZTS_RN_BUNDLER__` / `__DEV__=false`) 검증
- entry 누락 시 친화 에러 + exit 1
- `--rn-platform=android` 분기

**stderr logging 의 변동성에 의존 안 함** — 산출물 내용으로만 검증.

## /simplify 3-agent finding

**Apply**:
- 테스트 stderr 매칭 → 산출물 content 매칭 (Agent 2, 견고성)

**Skip**:
- `loadModule` generic helper — web/rn 둘만, 추상화 가치 작음
- minify OR-chain helper — 4 줄 미세 중복
- `--rn-project-root` space form — 다른 모든 string flag 와 일관 (zts 컨벤션)
- entry vs rnProjectRoot 일관 검증 — entry 필수, rnProjectRoot optional (cwd default)
- platform default 명시 — `ios` default 가 RN 자연스러운 default

## Test plan

- [x] `bun run test bin/zts.test.ts` → 225 pass / 1 skip / 0 fail (기존 222 + RN 3)
- [x] CLI smoke — `--bundle src/index.ts --platform=react-native -o out.js` outfile 정상
- [ ] CI 통과 시 auto-rebase merge

Refs #2540