### PR TITLE
feat(react-native): scaffold dev-server module + RnDevServerOptions

### DIFF
--- a/packages/react-native/src/dev-server/index.test.ts
+++ b/packages/react-native/src/dev-server/index.test.ts
@@ -1,0 +1,23 @@
+// PR #A scaffold smoke — public re-export 가 깨지지 않았는지 + 타입 contract.
+
+import { describe, expect, test } from "bun:test";
+
+import * as devServer from "./index.ts";
+
+describe("dev-server public surface — PR #A scaffold", () => {
+  test("buildRnDevServerOptions 가 함수로 export", () => {
+    expect(typeof devServer.buildRnDevServerOptions).toBe("function");
+  });
+
+  test("RnDevServerHandle 가 type-only (런타임 export 0)", () => {
+    // tsc 가 type-only re-export 를 검증. 런타임에서 키 누락은 OK.
+    expect("buildRnDevServerOptions" in devServer).toBe(true);
+  });
+});
+
+describe("@zts/react-native top-level re-export 정합성", () => {
+  test("buildRnDevServerOptions 가 패키지 entry 에서 import 가능", async () => {
+    const mod = await import("../index.ts");
+    expect(typeof mod.buildRnDevServerOptions).toBe("function");
+  });
+});

--- a/packages/react-native/src/dev-server/index.ts
+++ b/packages/react-native/src/dev-server/index.ts
@@ -1,0 +1,12 @@
+// dev-server public surface.
+
+export type { CustomizeFrame, RnDevServerOptions, RnDevServerOptionsInput } from "./options.ts";
+export { buildRnDevServerOptions } from "./options.ts";
+export type { FrameInfo, Middleware, MiddlewareEnhanceContext } from "./types.ts";
+
+/** Dev server lifecycle handle. */
+export interface RnDevServerHandle {
+  readonly url: string;
+  readonly port: number;
+  stop(): Promise<void>;
+}

--- a/packages/react-native/src/dev-server/options.test.ts
+++ b/packages/react-native/src/dev-server/options.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+
+import type { RnBundleInput } from "../preset.ts";
+import {
+  buildRnDevServerOptions,
+  type RnDevServerOptions,
+  type RnDevServerOptionsInput,
+} from "./options.ts";
+
+const BUNDLE: RnBundleInput = {
+  entry: "/proj/src/index.ts",
+  projectRoot: "/proj",
+  rnPlatform: "ios",
+  dev: true,
+};
+
+function input(
+  overrides: Partial<Omit<RnDevServerOptions, "bundle">> = {},
+): RnDevServerOptionsInput {
+  return { bundle: BUNDLE, ...overrides };
+}
+
+describe("buildRnDevServerOptions — Metro 호환 default", () => {
+  test("port=8081, host=localhost (Metro 기본)", () => {
+    const opts = buildRnDevServerOptions(input());
+    expect(opts.port).toBe(8081);
+    expect(opts.host).toBe("localhost");
+  });
+
+  test("terminalActions = true (default)", () => {
+    expect(buildRnDevServerOptions(input()).terminalActions).toBe(true);
+  });
+
+  test("hmr = true (default)", () => {
+    expect(buildRnDevServerOptions(input()).hmr).toBe(true);
+  });
+
+  test("symbolicator = undefined (customizeFrame 미지정)", () => {
+    expect(buildRnDevServerOptions(input()).symbolicator).toBeUndefined();
+  });
+
+  test("bundle reference 그대로 보존 (caller 가 RnBundleInput 책임)", () => {
+    expect(buildRnDevServerOptions(input()).bundle).toBe(BUNDLE);
+  });
+});
+
+describe("buildRnDevServerOptions — override", () => {
+  test("port=9000 / host=0.0.0.0 override", () => {
+    const opts = buildRnDevServerOptions(input({ port: 9000, host: "0.0.0.0" }));
+    expect(opts.port).toBe(9000);
+    expect(opts.host).toBe("0.0.0.0");
+  });
+
+  test("terminalActions=false override", () => {
+    expect(buildRnDevServerOptions(input({ terminalActions: false })).terminalActions).toBe(false);
+  });
+
+  test("hmr=false override", () => {
+    expect(buildRnDevServerOptions(input({ hmr: false })).hmr).toBe(false);
+  });
+});
+
+describe("buildRnDevServerOptions — hooks pass-through", () => {
+  test("enhanceMiddleware reference 보존", () => {
+    const fn: RnDevServerOptions["enhanceMiddleware"] = (mw) => mw;
+    expect(buildRnDevServerOptions(input({ enhanceMiddleware: fn })).enhanceMiddleware).toBe(fn);
+  });
+
+  test("enhanceMiddleware 미지정 시 undefined", () => {
+    expect(buildRnDevServerOptions(input()).enhanceMiddleware).toBeUndefined();
+  });
+
+  test("rewriteRequestUrl reference 보존", () => {
+    const fn = (url: string) => url + "?ok";
+    expect(buildRnDevServerOptions(input({ rewriteRequestUrl: fn })).rewriteRequestUrl).toBe(fn);
+  });
+
+  test("symbolicator.customizeFrame 지정 시 객체 생성", () => {
+    const fn = async () => ({ collapse: true });
+    const opts = buildRnDevServerOptions(input({ symbolicator: { customizeFrame: fn } }));
+    expect(opts.symbolicator).toEqual({ customizeFrame: fn });
+  });
+
+  test("symbolicator 빈 객체 (customizeFrame 미지정) → undefined 로 정규화", () => {
+    expect(buildRnDevServerOptions(input({ symbolicator: {} })).symbolicator).toBeUndefined();
+  });
+});

--- a/packages/react-native/src/dev-server/options.ts
+++ b/packages/react-native/src/dev-server/options.ts
@@ -1,0 +1,37 @@
+// preset RnBundleInput 와 mirror. zts 외부 의존성 0.
+
+import type { RnBundleInput } from "../preset.ts";
+import type { FrameInfo, Middleware, MiddlewareEnhanceContext } from "./types.ts";
+
+/** customizeFrame `collapse:true` → DevTools 에서 frame 숨김. caller 가 try/catch 로 swallow. */
+export type CustomizeFrame = (frame: FrameInfo) => Promise<{ collapse?: boolean } | void>;
+
+export interface RnDevServerOptions {
+  bundle: RnBundleInput;
+  port: number;
+  host: string;
+  enhanceMiddleware?: (mw: Middleware, ctx: MiddlewareEnhanceContext) => Middleware;
+  rewriteRequestUrl?: (url: string) => string;
+  symbolicator?: { customizeFrame?: CustomizeFrame };
+  terminalActions: boolean;
+  hmr: boolean;
+}
+
+export type RnDevServerOptionsInput = { bundle: RnBundleInput } & Partial<
+  Omit<RnDevServerOptions, "bundle">
+>;
+
+export function buildRnDevServerOptions(input: RnDevServerOptionsInput): RnDevServerOptions {
+  return {
+    bundle: input.bundle,
+    port: input.port ?? 8081,
+    host: input.host ?? "localhost",
+    enhanceMiddleware: input.enhanceMiddleware,
+    rewriteRequestUrl: input.rewriteRequestUrl,
+    symbolicator: input.symbolicator?.customizeFrame
+      ? { customizeFrame: input.symbolicator.customizeFrame }
+      : undefined,
+    terminalActions: input.terminalActions ?? true,
+    hmr: input.hmr ?? true,
+  };
+}

--- a/packages/react-native/src/dev-server/types.ts
+++ b/packages/react-native/src/dev-server/types.ts
@@ -1,0 +1,21 @@
+import type { IncomingMessage, Server, ServerResponse } from "node:http";
+
+/** Connect-style middleware (Metro / cli-server-api 호환). */
+export type Middleware = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  next: (err?: unknown) => void,
+) => void;
+
+/** RN runtime stack frame (metro `IntermediateStackFrame` 와 structural compat). */
+export interface FrameInfo {
+  file: string | null;
+  methodName: string | null;
+  lineNumber: number | null;
+  column: number | null;
+}
+
+/** enhanceMiddleware hook 의 두 번째 인자. */
+export interface MiddlewareEnhanceContext {
+  readonly httpServer: Server;
+}

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -17,6 +17,16 @@ export {
   type HmrRnUpdateStartMessage,
 } from "@zts/server";
 
+export {
+  buildRnDevServerOptions,
+  type CustomizeFrame,
+  type FrameInfo,
+  type Middleware,
+  type MiddlewareEnhanceContext,
+  type RnDevServerHandle,
+  type RnDevServerOptions,
+  type RnDevServerOptionsInput,
+} from "./dev-server/index.ts";
 export { createMetroHmrAdapter, type MetroHmrAdapter } from "./metro-hmr-adapter.ts";
 export type {
   CustomResolver,


### PR DESCRIPTION
## Summary

#2605 epic PR #A. RN dev server 흡수 epic 의 scaffold — interface 정의 + default helper + 단위 테스트. 후속 PR (#B-#I) 가 HTTP server / routes / hmr-bridge / middleware 를 채움.

## 변경

- **신규** `packages/react-native/src/dev-server/types.ts` — `Middleware` (connect 호환), `FrameInfo` (metro `IntermediateStackFrame` structural compat), `MiddlewareEnhanceContext`.
- **신규** `packages/react-native/src/dev-server/options.ts` — `RnDevServerOptions` (RnBundleInput composition) + `buildRnDevServerOptions` default 적용.
- **신규** `packages/react-native/src/dev-server/index.ts` — public surface + `RnDevServerHandle` stub.
- **수정** `packages/react-native/src/index.ts` — top-level re-export.

## 설계 결정 (/simplify 반영)

- `RnDevServerOptions.bundle: RnBundleInput` **composition** — preset 영역의 7개 필드 중복 제거. caller 가 RnBundleInput 그대로 전달, dev server 는 dev-server-only fields (port/host/symbolicator/terminalActions/hmr) 만 default 적용. PR #E 가 \`watchRn(opts.bundle)\` zero-mapping.
- \`terminalActions: boolean\` / \`hmr: boolean\` flat — 단일 enabled 필드 nested object indirection 제거.
- \`symbolicator?: { customizeFrame?: ... }\` — customizeFrame 미지정 시 undefined 정규화 (빈 객체 alloc 방지).

## 테스트

- \`options.test.ts\` — 100% 라인 커버리지 (default / override / hooks pass-through). 14 cases.
- \`index.test.ts\` — public re-export smoke. 2 cases.

## 검증

- \`bun test packages/react-native\` — 172 pass / 0 fail.
- \`bun run --cwd packages/react-native build\` — server inline 정상.
- \`oxlint --deny-warnings\` — 0 error / 0 warning.
- \`oxfmt --check\` — 통과.

## Test plan

- [x] 단위 테스트 100% 라인 커버리지
- [x] \`bun test\` 전 패키지
- [x] \`bun run build\` (react-native package)
- [x] /simplify 3-agent review (Reuse/Quality/Efficiency) finding 반영
- [ ] CI green 후 rebase merge

Refs #2605

🤖 Generated with [Claude Code](https://claude.com/claude-code)