### PR TITLE
docs(documents): RN dev server 가이드 (Closes #2605)

### DIFF
--- a/documents/src/content/docs/en/guides/react-native.md
+++ b/documents/src/content/docs/en/guides/react-native.md
@@ -92,9 +92,7 @@ Selectively swallow noise like the RN/Expo native immutable global polyfill conf
 ```ts
 defineConfig({
   platform: "react-native",
-  silentConsoleErrorPatterns: [
-    "^Failed to set polyfill\\.\\s+\\w+\\s+is not configurable\\.?$",
-  ],
+  silentConsoleErrorPatterns: ["^Failed to set polyfill\\.\\s+\\w+\\s+is not configurable\\.?$"],
 });
 ```
 
@@ -165,15 +163,111 @@ defineConfig({
 
 One-line summary of options commonly used on the RN platform. See each option's JSDoc / docs for full behavior.
 
-| Option | Description |
-|---|---|
-| `workletPluginVersion` | Reanimated worklet `__pluginVersion`. Must match the user's installed `react-native-worklets` version to avoid runtime errors. |
-| `codegenTransform` | Replaces `codegenNativeComponent` calls in `*NativeComponent.{js,ts}` with inline view configs. Auto-enabled on the RN platform. |
-| `entryErrorGuard` | Wraps entry trigger calls in `try/catch + ErrorUtils.reportFatalError` (Metro `guardedLoadModule` equivalent). Auto-enabled on the RN platform. |
-| `strictExecutionOrder` | Downgrades function declarations to in-factory assignments to prevent hoisting (Rolldown equivalent). Auto-enabled on the RN platform. |
-| `configurableExports` | Adds `configurable: true` to `Object.defineProperty` (RN/Hermes compatibility). |
-| `reactRefresh` | Enables React Fast Refresh. |
-| `devMode` | Wraps modules in a `__zts_register()` factory and injects the HMR runtime. |
-| `rootDir` | Base path for dev-mode module IDs. |
-| `collectModuleCodes` | Collects per-module codes in dev mode (for HMR rebuilds). |
-| `workletTransform` | Injects `__workletHash`/`__closure`/`__initData` into "worklet" directive functions. Auto-enabled on the RN platform. |
+| Option                 | Description                                                                                                                                     |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `workletPluginVersion` | Reanimated worklet `__pluginVersion`. Must match the user's installed `react-native-worklets` version to avoid runtime errors.                  |
+| `codegenTransform`     | Replaces `codegenNativeComponent` calls in `*NativeComponent.{js,ts}` with inline view configs. Auto-enabled on the RN platform.                |
+| `entryErrorGuard`      | Wraps entry trigger calls in `try/catch + ErrorUtils.reportFatalError` (Metro `guardedLoadModule` equivalent). Auto-enabled on the RN platform. |
+| `strictExecutionOrder` | Downgrades function declarations to in-factory assignments to prevent hoisting (Rolldown equivalent). Auto-enabled on the RN platform.          |
+| `configurableExports`  | Adds `configurable: true` to `Object.defineProperty` (RN/Hermes compatibility).                                                                 |
+| `reactRefresh`         | Enables React Fast Refresh.                                                                                                                     |
+| `devMode`              | Wraps modules in a `__zts_register()` factory and injects the HMR runtime.                                                                      |
+| `rootDir`              | Base path for dev-mode module IDs.                                                                                                              |
+| `collectModuleCodes`   | Collects per-module codes in dev mode (for HMR rebuilds).                                                                                       |
+| `workletTransform`     | Injects `__workletHash`/`__closure`/`__initData` into "worklet" directive functions. Auto-enabled on the RN platform.                           |
+
+## Dev server (#2605)
+
+`zts dev --platform=react-native` starts a Metro-compatible dev server.
+
+```bash
+zts dev --platform=react-native --rn-platform=ios index.js \
+  --port=8081 --host=localhost
+```
+
+Endpoints (Metro compatible):
+
+- `GET /status` — packager live check (`packager-status:running`).
+- `GET /index.bundle?platform=ios&dev=true` — main bundle. With `Accept: multipart/mixed`, returns progress + bundle chunks.
+- `GET /index.map?platform=ios` — bundle source map (lazy, build-scoped cache).
+- `GET /__zts_hmr_map/<id>?platform=ios` — per-module HMR source map.
+- `GET /assets/*`, `/node_modules/*` — asset registry (iOS @2x/@3x scale variants + 7-strategy package resolve).
+- `WS /hot` — HMR (`hmr:update-start` → `hmr:update` → `hmr:update-done` / `hmr:reload` / `hmr:error`).
+- `POST /symbolicate` — RN runtime LogBox stack trace symbolication.
+- `POST /reload` / `POST /devmenu` / `POST /open-url` — Metro message broadcast.
+
+### Peer-optional packages
+
+Some features lazy-load these packages; missing packages skip gracefully:
+
+| Package                                  | Feature                                                                                                                                                      |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `@react-native-community/cli-server-api` | `messageSocketEndpoint.broadcast` (`/reload` / `/devmenu` over WS) + cli websocket endpoints (`/message`, `/events`, `/debugger-proxy`).                     |
+| `@react-native/dev-middleware`           | DevTools inspector / `/json` / `/open-debugger` / `/launch-js-devtools` / fusebox. **Resolved from project context** to allow Rozenite-style monkey-patches. |
+
+Install (RN 0.83+ recommended):
+
+```bash
+bun add -D @react-native-community/cli-server-api @react-native/dev-middleware
+```
+
+### Keyboard shortcuts
+
+In the dev server terminal (Metro compatible):
+
+- `r` — Reload
+- `d` — Dev Menu
+- `j` — DevTools (`POST /open-debugger`)
+- `i` — iOS Simulator open (darwin only)
+- `a` — Android Emulator open (`ANDROID_HOME` required)
+- `c` — Clear cache
+- `?` — Help
+- Ctrl+C / Ctrl+D — graceful shutdown
+
+### Programmatic API
+
+```ts
+import { buildRnDevServerOptions, serveRn } from "@zts/react-native";
+
+const handle = await serveRn(
+  buildRnDevServerOptions({
+    bundle: {
+      entry: "index.js",
+      projectRoot: process.cwd(),
+      rnPlatform: "ios",
+      dev: true,
+    },
+    port: 8081,
+    host: "localhost",
+    // User enhanceMiddleware hook (Rozenite / other DevTools).
+    enhanceMiddleware: (base, ctx) => (req, res, next) => {
+      if (req.url?.startsWith("/rozenite/")) {
+        // Custom handling...
+        return;
+      }
+      base(req, res, next);
+    },
+    symbolicator: {
+      customizeFrame: async (frame) => ({
+        // Collapse node_modules frames in DevTools.
+        collapse: frame.file?.includes("/node_modules/") ?? false,
+      }),
+    },
+  }),
+);
+
+console.log(`Listening on ${handle.url}`);
+// ... handle.stop() for graceful shutdown.
+```
+
+### Examples
+
+Validation matrix (both use \`bun run start:zts\` for the ZTS dev server):
+
+- [`examples/react-native-bare/`](https://github.com/ohah/zts/tree/main/examples/react-native-bare) — RN 0.85 bare.
+- [`examples/react-native-expo/`](https://github.com/ohah/zts/tree/main/examples/react-native-expo) — Expo 55 / RN 0.83 (Expo Router).
+
+### Compatibility
+
+- RN `>= 0.83` peer optional. `@zts/react-native` is compatible with Hermes / the RN runtime HMRClient interface and sourceMappingURL route conventions.
+- Runs on Bun and Node 22+. Dev-server lifecycle guarantees graceful shutdown on SIGINT/SIGTERM.

--- a/documents/src/content/docs/guides/react-native.md
+++ b/documents/src/content/docs/guides/react-native.md
@@ -92,9 +92,7 @@ RN/Expo native immutable global polyfill 충돌 같은 noise 만 선택적으로
 ```ts
 defineConfig({
   platform: "react-native",
-  silentConsoleErrorPatterns: [
-    "^Failed to set polyfill\\.\\s+\\w+\\s+is not configurable\\.?$",
-  ],
+  silentConsoleErrorPatterns: ["^Failed to set polyfill\\.\\s+\\w+\\s+is not configurable\\.?$"],
 });
 ```
 
@@ -165,15 +163,111 @@ defineConfig({
 
 RN 플랫폼에서 자주 쓰는 옵션 한 줄 요약. 자세한 동작은 각 항목 JSDoc / docs 참조.
 
-| 옵션 | 설명 |
-|---|---|
-| `workletPluginVersion` | Reanimated worklet 의 `__pluginVersion` 값. 사용자 환경 `react-native-worklets` 패키지 버전과 일치해야 런타임 에러 없음. |
-| `codegenTransform` | `*NativeComponent.{js,ts}` 의 `codegenNativeComponent` 호출을 inline view config 로 교체. RN 플랫폼에서 자동 활성. |
-| `entryErrorGuard` | entry trigger 호출을 `try/catch + ErrorUtils.reportFatalError` 로 wrap (Metro `guardedLoadModule` 동등). RN 플랫폼에서 자동 활성. |
-| `strictExecutionOrder` | 함수 선언을 factory 내부 assignment 로 다운그레이드해 호이스팅 방지 (Rolldown 동등). RN 플랫폼에서 자동 활성. |
-| `configurableExports` | `Object.defineProperty` 에 `configurable: true` 추가 (RN/Hermes 호환). |
-| `reactRefresh` | React Fast Refresh 활성화. |
-| `devMode` | 모듈을 `__zts_register()` 팩토리로 래핑 + HMR 런타임 주입. |
-| `rootDir` | dev mode 모듈 ID 기준 경로. |
-| `collectModuleCodes` | dev mode per-module codes 수집 (HMR rebuild 용). |
-| `workletTransform` | "worklet" 디렉티브 함수에 `__workletHash`/`__closure`/`__initData` 주입. RN 플랫폼에서 자동 활성. |
+| 옵션                   | 설명                                                                                                                              |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `workletPluginVersion` | Reanimated worklet 의 `__pluginVersion` 값. 사용자 환경 `react-native-worklets` 패키지 버전과 일치해야 런타임 에러 없음.          |
+| `codegenTransform`     | `*NativeComponent.{js,ts}` 의 `codegenNativeComponent` 호출을 inline view config 로 교체. RN 플랫폼에서 자동 활성.                |
+| `entryErrorGuard`      | entry trigger 호출을 `try/catch + ErrorUtils.reportFatalError` 로 wrap (Metro `guardedLoadModule` 동등). RN 플랫폼에서 자동 활성. |
+| `strictExecutionOrder` | 함수 선언을 factory 내부 assignment 로 다운그레이드해 호이스팅 방지 (Rolldown 동등). RN 플랫폼에서 자동 활성.                     |
+| `configurableExports`  | `Object.defineProperty` 에 `configurable: true` 추가 (RN/Hermes 호환).                                                            |
+| `reactRefresh`         | React Fast Refresh 활성화.                                                                                                        |
+| `devMode`              | 모듈을 `__zts_register()` 팩토리로 래핑 + HMR 런타임 주입.                                                                        |
+| `rootDir`              | dev mode 모듈 ID 기준 경로.                                                                                                       |
+| `collectModuleCodes`   | dev mode per-module codes 수집 (HMR rebuild 용).                                                                                  |
+| `workletTransform`     | "worklet" 디렉티브 함수에 `__workletHash`/`__closure`/`__initData` 주입. RN 플랫폼에서 자동 활성.                                 |
+
+## Dev server (#2605)
+
+`zts dev --platform=react-native` 으로 Metro 호환 dev server 를 띄울 수 있습니다.
+
+```bash
+zts dev --platform=react-native --rn-platform=ios index.js \
+  --port=8081 --host=localhost
+```
+
+엔드포인트 (Metro 호환):
+
+- `GET /status` — packager live check (`packager-status:running`).
+- `GET /index.bundle?platform=ios&dev=true` — main bundle. `multipart/mixed` accept 시 progress + bundle chunk.
+- `GET /index.map?platform=ios` — bundle source map (lazy, build 단위 cache).
+- `GET /__zts_hmr_map/<id>?platform=ios` — per-module HMR source map.
+- `GET /assets/*`, `/node_modules/*` — asset registry (iOS @2x/@3x scale variant + 7-strategy package resolve).
+- `WS /hot` — HMR (`hmr:update-start` → `hmr:update` → `hmr:update-done` / `hmr:reload` / `hmr:error`).
+- `POST /symbolicate` — RN runtime LogBox stack trace 역매핑.
+- `POST /reload` / `POST /devmenu` / `POST /open-url` — Metro 메시지 송출.
+
+### peer optional 패키지
+
+dev server 가 일부 기능에 lazy load. 미설치 시 graceful skip:
+
+| 패키지                                   | 기능                                                                                                                                                |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@react-native-community/cli-server-api` | `messageSocketEndpoint.broadcast` (`/reload` / `/devmenu` 메시지 ws) + cli websocket endpoints (`/message`, `/events`, `/debugger-proxy`).          |
+| `@react-native/dev-middleware`           | DevTools inspector / `/json` / `/open-debugger` / `/launch-js-devtools` / fusebox. **project 기준 resolve** — Rozenite 같은 monkey-patch 도구 호환. |
+
+설치 (RN 0.83+ 권장):
+
+```bash
+bun add -D @react-native-community/cli-server-api @react-native/dev-middleware
+```
+
+### 키보드 단축키
+
+dev server 터미널에서 (Metro 호환):
+
+- `r` — Reload
+- `d` — Dev Menu
+- `j` — DevTools (`/open-debugger` POST)
+- `i` — iOS Simulator open (darwin only)
+- `a` — Android Emulator open (`ANDROID_HOME` 필요)
+- `c` — Clear cache
+- `?` — Help
+- Ctrl+C / Ctrl+D — graceful shutdown
+
+### Programmatic API
+
+```ts
+import { buildRnDevServerOptions, serveRn } from "@zts/react-native";
+
+const handle = await serveRn(
+  buildRnDevServerOptions({
+    bundle: {
+      entry: "index.js",
+      projectRoot: process.cwd(),
+      rnPlatform: "ios",
+      dev: true,
+    },
+    port: 8081,
+    host: "localhost",
+    // user enhanceMiddleware hook (Rozenite / 기타 DevTools).
+    enhanceMiddleware: (base, ctx) => (req, res, next) => {
+      if (req.url?.startsWith("/rozenite/")) {
+        // 사용자 정의 처리...
+        return;
+      }
+      base(req, res, next);
+    },
+    symbolicator: {
+      customizeFrame: async (frame) => ({
+        // node_modules frame 은 DevTools 에서 collapse.
+        collapse: frame.file?.includes("/node_modules/") ?? false,
+      }),
+    },
+  }),
+);
+
+console.log(`Listening on ${handle.url}`);
+// ... handle.stop() 시 graceful shutdown.
+```
+
+### 예제
+
+검증 매트릭스 (둘 다 \`bun run start:zts\` 로 ZTS dev server 사용):
+
+- [`examples/react-native-bare/`](https://github.com/ohah/zts/tree/main/examples/react-native-bare) — RN 0.85 bare.
+- [`examples/react-native-expo/`](https://github.com/ohah/zts/tree/main/examples/react-native-expo) — Expo 55 / RN 0.83 (Expo Router).
+
+### 호환성
+
+- RN `>= 0.83` peer optional. `@zts/react-native` 가 Hermes / RN runtime 의 HMRClient interface 와 sourceMappingURL 라우트 컨벤션 호환.
+- Bun + Node 22+ 에서 동작. dev server lifecycle 은 SIGINT/SIGTERM graceful shutdown 보장.


### PR DESCRIPTION
## Summary

#2605 epic close. \`guides/react-native.md\` (KO + EN) 에 dev server 섹션 추가.

## 추가 섹션

- \`zts dev --platform=react-native\` CLI + 모든 endpoint (Metro 호환).
- peer optional 패키지 (\`@react-native-community/cli-server-api\` / \`@react-native/dev-middleware\`) 안내.
- 키보드 단축키 (\`r\`/\`d\`/\`j\`/\`i\`/\`a\`/\`c\`/\`?\`).
- programmatic API (\`serveRn\` + \`buildRnDevServerOptions\` + \`enhanceMiddleware\` + \`customizeFrame\` hook).
- 예제 매트릭스 — \`react-native-bare\` (RN 0.85), \`react-native-expo\` (Expo 55 / RN 0.83) 링크.
- RN 호환성 매트릭스 (\`react-native >= 0.83\` peer optional).

## #2605 Epic 요약

총 13 PRs / ~2,500줄 코드 + ~2,400줄 테스트. RN 0.83/0.85 검증 매트릭스 완성:

| PR | 내용 | # |
|---|---|---|
| #A | scaffold dev-server module + RnDevServerOptions | #2606 |
| #B | HTTP server bootstrap + base routes (status/reload/devmenu/open-url) | #2607 |
| #C | asset registry handler + /assets/* (7-strategy resolve) | #2608 |
| #D | bundle/map routes + per-platform state + lazy sourcemap cache | #2609 |
| #E | HMR bridge — HmrChannel + watchRn 연결 | #2610 |
| #F | symbolicate endpoint + customizeFrame hook | #2611 |
| #G | cli-server-api + dev-middleware lazy integration | #2612 |
| #H | terminal actions (r/d/?/c/i/a/j 키보드) | #2613 |
| #I | serveRn entry + 단일 WS upgrade chain | #2614 |
| #J | zts dev --platform=react-native dispatch | #2615 |
| #K | examples/react-native-bare 이전 (RN 0.85) | #2616 |
| #L | examples/react-native-expo 이전 (Expo 55 / RN 0.83) | #2617 |
| #M | docs RN dev server (이번 PR) | this |

## 검증

- 매 PR 단위 테스트 100% 라인 커버리지 (CI gate).
- 매 PR \`/simplify\` 3-agent review (Reuse / Quality / Efficiency) finding 반영.
- 두 examples bun install + workspace 의존성 link 검증.

## Test plan

- [x] guides/react-native.md (KO + EN) dev server 섹션
- [x] CI green 후 rebase merge → epic close

Closes #2605

🤖 Generated with [Claude Code](https://claude.com/claude-code)