### PR TITLE
chore(react-native): #2605 epic test coverage audit + 2 bug fixes

### DIFF
--- a/packages/react-native/src/dev-server/http-server.test.ts
+++ b/packages/react-native/src/dev-server/http-server.test.ts
@@ -223,3 +223,133 @@ describe("createDevHttpServer — enhanceMiddleware", () => {
     ).rejects.toThrow();
   });
 });
+
+describe("attachWebSocketEndpoints — chain ordering (Finding #4)", () => {
+  test("listener: hmrBridge `/hot` 우선 → cli endpoints → dev endpoints → unmatched destroy", async () => {
+    const recorded: string[] = [];
+    const opts = buildRnDevServerOptions({ bundle: BUNDLE, port: 0 });
+    const fakeHmr = {
+      adapter: {} as never,
+      callbacks: {},
+      path: "/hot",
+      acceptUpgrade: () => recorded.push("hmr:/hot"),
+    };
+    const fakeCli = {
+      websocketEndpoints: {
+        "/message": {
+          handleUpgrade: () => recorded.push("cli:/message"),
+          emit: () => {},
+        },
+      },
+      broadcast: () => {},
+    };
+    const fakeDev = {
+      middleware: ((_req: never, _res: never, _next: never) => {}) as never,
+      websocketEndpoints: {
+        "/inspector": {
+          handleUpgrade: () => recorded.push("dev:/inspector"),
+          emit: () => {},
+        },
+      },
+    };
+    const h = await createDevHttpServer(opts, {
+      broadcast: () => {},
+      platforms: noopPlatforms,
+      hmrBridge: fakeHmr,
+      cliServerApi: fakeCli,
+      devMiddleware: fakeDev as never,
+    });
+
+    try {
+      // 단일 'upgrade' listener — server.listeners('upgrade')[0] 가져와 직접 호출.
+      const listeners = h.server.listeners("upgrade");
+      expect(listeners).toHaveLength(1);
+      const upgradeListener = listeners[0]! as (req: unknown, sock: unknown, head: unknown) => void;
+
+      const fakeSocket = { destroy: () => recorded.push("destroyed") };
+      const head = Buffer.alloc(0);
+
+      upgradeListener({ url: "/hot", headers: { host: "x:8081" } }, fakeSocket, head);
+      upgradeListener({ url: "/message", headers: { host: "x:8081" } }, fakeSocket, head);
+      upgradeListener({ url: "/inspector", headers: { host: "x:8081" } }, fakeSocket, head);
+      upgradeListener({ url: "/__nope__", headers: { host: "x:8081" } }, fakeSocket, head);
+
+      expect(recorded).toEqual(["hmr:/hot", "cli:/message", "dev:/inspector", "destroyed"]);
+    } finally {
+      await h.stop();
+    }
+  });
+
+  test("hmrBridge 만 — cli/dev 미설치 시 hmr 만 chain", async () => {
+    const recorded: string[] = [];
+    const opts = buildRnDevServerOptions({ bundle: BUNDLE, port: 0 });
+    const fakeHmr = {
+      adapter: {} as never,
+      callbacks: {},
+      path: "/hot",
+      acceptUpgrade: () => recorded.push("hmr"),
+    };
+    const h = await createDevHttpServer(opts, {
+      broadcast: () => {},
+      platforms: noopPlatforms,
+      hmrBridge: fakeHmr,
+    });
+    try {
+      const listeners = h.server.listeners("upgrade");
+      expect(listeners).toHaveLength(1);
+      const fn = listeners[0]! as (req: unknown, s: unknown, h: unknown) => void;
+      const sock = { destroy: () => recorded.push("destroyed") };
+      fn({ url: "/hot", headers: {} }, sock, Buffer.alloc(0));
+      fn({ url: "/other", headers: {} }, sock, Buffer.alloc(0));
+      expect(recorded).toEqual(["hmr", "destroyed"]);
+    } finally {
+      await h.stop();
+    }
+  });
+
+  test("아무 deps 없으면 'upgrade' listener 미등록 (Node default 동작)", async () => {
+    const opts = buildRnDevServerOptions({ bundle: BUNDLE, port: 0 });
+    const h = await createDevHttpServer(opts, {
+      broadcast: () => {},
+      platforms: noopPlatforms,
+    });
+    try {
+      expect(h.server.listenerCount("upgrade")).toBe(0);
+    } finally {
+      await h.stop();
+    }
+  });
+});
+
+describe("createDevHttpServer — listener cleanup (Finding #3)", () => {
+  test("stop() 후 server 의 'request' / 'upgrade' listener 가 모두 정리됨", async () => {
+    const opts = buildRnDevServerOptions({ bundle: BUNDLE, port: 0 });
+    const fakeHmr = {
+      adapter: {} as never,
+      callbacks: {},
+      path: "/hot",
+      acceptUpgrade: () => {},
+    };
+    const fakeCli = {
+      websocketEndpoints: {
+        "/message": { handleUpgrade: () => {}, emit: () => {} },
+      },
+      broadcast: () => {},
+    };
+    const h = await createDevHttpServer(opts, {
+      broadcast: () => {},
+      platforms: noopPlatforms,
+      hmrBridge: fakeHmr,
+      cliServerApi: fakeCli,
+    });
+    // listen 후 'request' 1 + 'upgrade' 1 (hmr/cli/dev 중 하나라도 있으면).
+    expect(h.server.listenerCount("request")).toBe(1);
+    expect(h.server.listenerCount("upgrade")).toBe(1);
+    await h.stop();
+    // 현재 createDevHttpServer.stop() 은 server.close() 만 호출 — listener 명시 제거
+    // 안 함. server.close() 는 listener 자동 제거 안 함 (Node API spec).
+    // 이 expect 는 fix 전 fail.
+    expect(h.server.listenerCount("request")).toBe(0);
+    expect(h.server.listenerCount("upgrade")).toBe(0);
+  });
+});

--- a/packages/react-native/src/dev-server/http-server.ts
+++ b/packages/react-native/src/dev-server/http-server.ts
@@ -147,17 +147,23 @@ function chainToHandler(
  * dev-middleware endpoints. 매칭 안 되면 socket destroy (bungae parity).
  * 모든 deps 가 absent 면 listener 미등록 (default Node 동작 — destroy).
  */
+type UpgradeListener = (
+  req: IncomingMessage,
+  socket: import("node:net").Socket,
+  head: Buffer,
+) => void;
+
 function attachWebSocketEndpoints(
   server: Server,
   deps: DevHttpServerDeps,
   options: RnDevServerOptions,
-): void {
+): UpgradeListener | null {
   const hmr = deps.hmrBridge;
   const cli = deps.cliServerApi?.websocketEndpoints;
   const dev = deps.devMiddleware?.websocketEndpoints;
-  if (!hmr && !cli && !dev) return;
+  if (!hmr && !cli && !dev) return null;
 
-  server.on("upgrade", (req, socket, head) => {
+  const listener: UpgradeListener = (req, socket, head) => {
     const url = parseRequestUrl(req, options.host, options.port);
     if (hmr && (url.pathname === hmr.path || url.pathname.startsWith(`${hmr.path}?`))) {
       hmr.acceptUpgrade(req, socket as never);
@@ -180,7 +186,9 @@ function attachWebSocketEndpoints(
       }
     }
     socket.destroy();
-  });
+  };
+  server.on("upgrade", listener);
+  return listener;
 }
 
 export async function createDevHttpServer(
@@ -194,8 +202,9 @@ export async function createDevHttpServer(
   const enhanced = options.enhanceMiddleware
     ? options.enhanceMiddleware(baseMiddleware, { httpServer: server })
     : baseMiddleware;
-  server.on("request", chainToHandler(enhanced));
-  attachWebSocketEndpoints(server, deps, options);
+  const requestHandler = chainToHandler(enhanced);
+  server.on("request", requestHandler);
+  const upgradeHandler = attachWebSocketEndpoints(server, deps, options);
 
   await new Promise<void>((resolve, reject) => {
     const onError = (err: Error) => {
@@ -217,6 +226,10 @@ export async function createDevHttpServer(
     port: options.port,
     stop: () =>
       new Promise<void>((resolve, reject) => {
+        // server.close() 는 listener 자동 제거 안 함. 명시 제거로 closure capture
+        // 해제 — watch handle / channel client refs 가 GC 대상이 되도록.
+        server.removeListener("request", requestHandler);
+        if (upgradeHandler) server.removeListener("upgrade", upgradeHandler);
         server.close((err) => (err ? reject(err) : resolve()));
       }),
   };

--- a/packages/react-native/src/dev-server/platform-state.test.ts
+++ b/packages/react-native/src/dev-server/platform-state.test.ts
@@ -192,4 +192,40 @@ describe("createPlatformStateRegistry — 캐싱", () => {
     await registry.stopAll();
     expect(registry.platforms.size).toBe(0);
   });
+
+  test("multi-platform — ios + android 동시 spawn 후 각자 별 watch handle (Finding #9)", async () => {
+    const opts = buildRnDevServerOptions({
+      bundle: { entry: entryPath, projectRoot: dir, rnPlatform: "ios", dev: true },
+    });
+    const registry = createPlatformStateRegistry(opts);
+    try {
+      const ios = registry.getOrCreate("ios");
+      const android = registry.getOrCreate("android");
+      // 첫 build 둘 다 대기 (동시).
+      await Promise.all([waitForBuild(ios), waitForBuild(android)]);
+      expect(ios.bundle !== null || ios.buildError !== null).toBe(true);
+      expect(android.bundle !== null || android.buildError !== null).toBe(true);
+      expect(ios.outputDir).not.toBe(android.outputDir);
+    } finally {
+      await registry.stopAll();
+    }
+  });
+});
+
+describe("createPlatformState — onReady/onRebuild 콜백 (Finding #7)", () => {
+  test("stopAll 시 watch handle 의 stop 이 throw 해도 silent", async () => {
+    // platform-state.ts 의 stopAll try/catch 분기 검증. handle.stop 이 throw 하면
+    // 다른 platform 의 cleanup 이 영향 받지 않아야 함.
+    const opts = buildRnDevServerOptions({
+      bundle: { entry: entryPath, projectRoot: dir, rnPlatform: "ios", dev: true },
+    });
+    const registry = createPlatformStateRegistry(opts);
+    const ios = registry.getOrCreate("ios");
+    // handle.stop 을 throw 로 monkey-patch.
+    (ios.handle as unknown as { stop: () => void }).stop = () => {
+      throw new Error("simulated stop fail");
+    };
+    await expect(registry.stopAll()).resolves.toBeUndefined();
+    expect(registry.platforms.size).toBe(0);
+  });
 });

--- a/packages/react-native/src/dev-server/routes/assets.test.ts
+++ b/packages/react-native/src/dev-server/routes/assets.test.ts
@@ -170,6 +170,41 @@ describe("resolveAssetPath — node_modules strategies", () => {
     });
     expect(path).toBe(join(dir, "monorepo-nm/qux/m.svg"));
   });
+
+  test("Strategy 4 — Bun .bun 디렉토리 (search by package name)", () => {
+    // /node_modules/.bun/<bunPackage@version+hash>/node_modules/<package>/<rest>
+    mkdirSync(join(dir, "node_modules/.bun/bunpkg@1.2.3+abc/node_modules/bunpkg/assets"), {
+      recursive: true,
+    });
+    writeFileSync(
+      join(dir, "node_modules/.bun/bunpkg@1.2.3+abc/node_modules/bunpkg/assets/icon.png"),
+      PNG_BYTES,
+    );
+    const path = resolveAssetPath("/node_modules/bunpkg/assets/icon.png", {
+      projectRoot: dir,
+      nodeModulesPaths: [],
+    });
+    expect(path).toBe(
+      join(dir, "node_modules/.bun/bunpkg@1.2.3+abc/node_modules/bunpkg/assets/icon.png"),
+    );
+  });
+
+  test("Strategy 4 — scoped package Bun directory (`@scope+pkg`)", () => {
+    mkdirSync(join(dir, "node_modules/.bun/@scope+pkg@1.0.0+xyz/node_modules/@scope/pkg/img"), {
+      recursive: true,
+    });
+    writeFileSync(
+      join(dir, "node_modules/.bun/@scope+pkg@1.0.0+xyz/node_modules/@scope/pkg/img/x.png"),
+      PNG_BYTES,
+    );
+    const path = resolveAssetPath("/node_modules/@scope/pkg/img/x.png", {
+      projectRoot: dir,
+      nodeModulesPaths: [],
+    });
+    expect(path).toBe(
+      join(dir, "node_modules/.bun/@scope+pkg@1.0.0+xyz/node_modules/@scope/pkg/img/x.png"),
+    );
+  });
 });
 
 describe("handleAssetRequest", () => {

--- a/packages/react-native/src/dev-server/routes/assets.ts
+++ b/packages/react-native/src/dev-server/routes/assets.ts
@@ -102,9 +102,20 @@ export function resolveAssetPath(urlPathname: string, opts: AssetResolverOptions
   if (!nmMatch) return null;
 
   const bunPackageDir = nmMatch[1];
-  const packageNameOrPath = nmMatch[2];
-  const restPath = nmMatch[3];
+  let packageNameOrPath = nmMatch[2];
+  let restPath = nmMatch[3];
   if (!packageNameOrPath || !restPath) return null;
+
+  // Scoped package: regex 의 `[^/\\]+` 가 first segment 만 잡으므로 `@scope` 가 들어오면
+  // restPath 의 first segment (`pkg`) 와 결합해 `@scope/pkg` 로 재구성. 이후 모든 strategy
+  // 가 scoped package 를 정확히 매칭.
+  if (packageNameOrPath.startsWith("@")) {
+    const slashIdx = restPath.indexOf(sep);
+    if (slashIdx > 0) {
+      packageNameOrPath = `${packageNameOrPath}/${restPath.slice(0, slashIdx)}`;
+      restPath = restPath.slice(slashIdx + 1);
+    }
+  }
 
   // Strategy 1: hoisted (npm/yarn standard) — node_modules/<package>/<rest>
   if (!bunPackageDir && !packageNameOrPath.includes("@")) {


### PR DESCRIPTION
## Summary

#2605 epic 머지 직후 audit 으로 발견한 **실제 버그 2개 fix** + 통합 테스트 보강. 단위 테스트로 재현 가능한 finding 만 수정.

## 실제 버그 fix

### 1. \`http-server.ts\` listener cleanup (Finding #3)

\`createDevHttpServer.stop()\` 이 \`server.close()\` 만 호출. \`server.close()\` 는 listener 자동 제거 안 함 (Node API spec) — closure capture 가 GC 까지 살아있어 watch handle / channel client refs 회수 지연.

**Fix**: \`removeListener('request')\` + \`removeListener('upgrade')\` 명시 호출. \`attachWebSocketEndpoints\` 가 listener 함수 반환 (\`UpgradeListener\` type).

### 2. \`routes/assets.ts\` Strategy 4 scoped package (Finding #6)

Strategy 4 (\`.bun\` directory) 의 scoped package 매칭 0. nmMatch regex \`[^/\\\\]+\` 가 \`@scope\` 만 first segment 로 잡고 두 번째 segment 를 restPath 로 미룸 → .bun directory 검색이 \`@scope+pkg@version\` 형태와 매치 실패.

**Fix**: nmMatch 직후 \`packageNameOrPath\` 가 \`@\` 시작이면 \`restPath\` 의 first segment 와 결합해 \`@scope/pkg\` 로 재구성.

## 테스트 추가 (재현 + 검증, +8 cases)

- \`http-server.test.ts\` — Finding #3 listener cleanup 재현 (stop 후 listener count 0). Finding #4 WS upgrade chain ordering 통합 (hmrBridge \`/hot\` + cli + dev + unmatched destroy / hmr 만 / no deps).
- \`assets.test.ts\` — Strategy 4 Bun directory regular + scoped (실제 버그 재현 후 fix 검증).
- \`platform-state.test.ts\` — multi-platform (ios+android) 동시 spawn + \`stopAll\` handle.stop throw silent swallow.

## 종합 점검 결과 — false alarm

- **HIGH "Promise.all fail-fast"** — \`loadCliServerApi\`/\`loadDevMiddleware\` 둘 다 try/catch 로 throw 안 함. Promise.all reject 발생 불가.
- **HIGH "race condition readFileSync"** — NAPI single-thread callback 으로 onRebuild 가 sequential. 실제 race 0.
- **MEDIUM "SIGINT cleanup race"** — 단위 테스트로 재현 어려움 (실제 process.kill 필요). OS 가 process exit 시 raw mode 자동 복구.

## 검증

- \`bun test packages/react-native\` — **340 pass / 0 fail** (이전 332 → +8).
- \`bun run build\` / \`oxlint --deny-warnings\` / \`tsc --noEmit\` — 통과.

## Test plan

- [x] 실제 버그 fix 재현 테스트 + 통과
- [x] /simplify 3-agent review (변경 의도와 일치, fix 필요 없음)
- [ ] CI green 후 rebase merge

Refs #2605

🤖 Generated with [Claude Code](https://claude.com/claude-code)