### PR TITLE
chore(examples): build:zts:core 스크립트 추가 (RN expo + bare)

### DIFF
--- a/examples/react-native-bare/package.json
+++ b/examples/react-native-bare/package.json
@@ -10,6 +10,7 @@
     "ios:release": "react-native run-ios --mode Release",
     "start": "react-native start",
     "start:zts": "zts dev --platform=react-native --rn-platform=ios index.js",
+    "build:zts:core": "bun run --cwd ../../packages/core build",
     "bundle:zts:ios": "zts bundle index.js --platform=react-native --rn-platform=ios -o ios/main.jsbundle",
     "bundle:zts:android": "zts bundle index.js --platform=react-native --rn-platform=android -o android/app/src/main/assets/index.android.bundle",
     "bundle:metro:ios": "react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ios/main.jsbundle --assets-dest ios",

--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "expo start",
     "start:zts": "zts dev --platform=react-native --rn-platform=ios index.js",
+    "build:zts:core": "bun run --cwd ../../packages/core build",
     "bundle:zts:ios": "zts bundle index.js --platform=react-native --rn-platform=ios -o dist/main.ios.jsbundle",
     "bundle:zts:android": "zts bundle index.js --platform=react-native --rn-platform=android -o dist/main.android.jsbundle",
     "reset-project": "node ./scripts/reset-project.js",


### PR DESCRIPTION
## Summary
- 각 RN 예제에서 한 줄로 ZTS core 전체 빌드(napi → `.node` 복사 → JS 번들 → `.d.ts`)를 돌릴 수 있는 `build:zts:core` 스크립트를 추가
- `react-native-expo`, `react-native-bare` 양쪽에 동일하게 적용
- 기존 `bundle:zts:ios` / `bundle:zts:android` 와 동일한 `<action>:zts:<sub>` 네이밍 패턴

## 동기
지금까지 예제에서 NAPI 변경분이 반영되려면 repo 루트로 이동 후 `bun run --cwd packages/core build` 를 직접 쳐야 했는데, 매번 cwd 전환이 번거로워 RN 예제 안에서 곧장 한 번에 끝낼 수 있게 함.

```bash
# react-native-expo / react-native-bare 둘 다
bun run build:zts:core
# 또는
npm run build:zts:core
```

## Test plan
- [ ] `cd examples/react-native-expo && bun run build:zts:core` 가 `packages/core/dist/index.js` + `packages/core/zts.node` 갱신
- [ ] `cd examples/react-native-bare && bun run build:zts:core` 동일하게 동작
- [ ] 기존 `bundle:zts:*` / `start:zts` 스크립트 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)