### PR TITLE
fix(core): RN dev start:zts ENOTDIR + entry routing (#2605)

### DIFF
--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -1917,6 +1917,19 @@ async function main() {
     return;
   }
 
+  // RN dev/build 의 positional arg 는 entry point (파일) — web 처럼 appRoot (디렉토리)
+  // 가 아니라서 그대로 두면 envDir 가 파일을 가리켜 `.env` 로딩에서 ENOTDIR 발생.
+  // entry → entryPoints[0] 로 옮기고 그 dirname 을 appRoot 로 사용.
+  if (
+    (opts.appCommand === "dev" || opts.appCommand === "build") &&
+    opts.platform === "react-native" &&
+    opts.appRoot
+  ) {
+    const entryArg = opts.appRoot;
+    if (opts.entryPoints.length === 0) opts.entryPoints.push(entryArg);
+    opts.appRoot = dirname(resolve(entryArg));
+  }
+
   if ((opts.appCommand === "dev" || opts.appCommand === "build") && !opts.envDir) {
     opts.envDir = resolve(opts.appRoot ?? ".");
   }

--- a/packages/core/src/config-loader.ts
+++ b/packages/core/src/config-loader.ts
@@ -323,14 +323,18 @@ function readFileOrThrowNotFound(absPath: string): string {
 }
 
 /**
- * 파일 부재를 정상 케이스로 처리하는 read. ENOENT 면 null, 그 외는 throw.
+ * 파일 부재를 정상 케이스로 처리하는 read. ENOENT/ENOTDIR 면 null, 그 외는 throw.
  * `.env` 같은 optional 파일 로딩 (`load-env.ts`) 에서 사용.
+ *
+ * ENOTDIR: 부모 경로가 디렉토리가 아닌 케이스 (예: envDir 가 실수로 파일을 가리키는 경우).
+ * optional lookup 의 의미상 "없음"과 동등하므로 swallow.
  */
 export function readFileIfExists(absPath: string): string | null {
   try {
     return readFileSync(absPath, "utf8");
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") return null;
     throw err;
   }
 }

--- a/packages/core/src/load-env.test.ts
+++ b/packages/core/src/load-env.test.ts
@@ -24,6 +24,16 @@ describe("loadEnv", () => {
     expect(loadEnv("production", dir)).toEqual({});
   });
 
+  test("envDir 가 파일을 가리키면 throw 대신 빈 객체 (ENOTDIR swallow)", () => {
+    // RN dev (#2605) 에서 positional arg 가 entry 파일이라 envDir 가 잘못
+    // 파일 경로가 되는 케이스 회귀 방지. readFileIfExists 의 ENOTDIR 처리.
+    reset();
+    const filePath = join(dir, "index.js");
+    writeFileSync(filePath, "// entry");
+    expect(() => loadEnv("production", filePath)).not.toThrow();
+    expect(loadEnv("production", filePath)).toEqual({});
+  });
+
   test(".env 단일 파일: prefix 일치 키만 노출", () => {
     reset();
     writeFileSync(


### PR DESCRIPTION
## Summary
`zts dev --platform=react-native index.js` 가 두 개의 별개 버그가 연쇄로 터져 dev server 가 뜨지 않던 문제 수정.

```
Error: ENOTDIR: not a directory, open '/.../examples/react-native-bare/index.js/.env'
    at readFileIfExists (.../packages/core/dist/index.js:...)
    at parseDotenvFile (...)
    at loadEnv (...)
    at loadAutoConfig (.../packages/core/bin/zts.mjs:850:22)
```

## Root cause / Fix

### 1. `bin/zts.mjs` — RN dev 의 entry 파일이 `appRoot` 자리로 라우팅되던 문제
parser 의 positional 인자 분기 (`opts.appCommand === "dev" || "build"` → `opts.appRoot = arg`) 가 web 만 가정되어 있었음. RN dev 는 `index.js` (파일) 가 들어오는데 그대로 `appRoot` 로 흡수되어 `envDir = resolve("index.js")` 가 파일 경로가 됨 → `loadEnv` 가 `index.js/.env` 를 열려고 하다 ENOTDIR.

`opts.platform === "react-native"` 분기에서 entry 를 `entryPoints[0]` 로 옮기고 그 `dirname` 을 `appRoot` 로 사용하도록 정규화. `runRnDev` 가 이미 `entryPoints[0]` 을 entry 로 읽고 있어서 의미상 정합.

### 2. `src/config-loader.ts` — `readFileIfExists` 의 ENOTDIR 미처리
`readFileIfExists` 는 ENOENT 만 swallow 하고 ENOTDIR 은 throw 했음. optional 파일 lookup 의 의미상 "부모 경로가 디렉토리가 아닌 케이스" 도 "없음" 과 동등하므로 `ENOTDIR` 도 swallow.

(1번 fix 만 있어도 이 경로는 막히지만, 다른 경로에서 동일 envDir 조합 발생 시 재발 가능 — 방어선 한 겹 더.)

## Test
- 회귀 테스트 추가: `load-env.test.ts` — envDir 가 파일을 가리키는 케이스에서 throw 대신 빈 객체 반환.
- 로컬 검증: `examples/react-native-bare && bun run start:zts` → `[zts/rn] dev server listening on http://localhost:8081 (platform=ios)` ✅, `/index.bundle?platform=ios` 200 OK 6.8MB ✅.

## Test plan
- [ ] `bun test packages/core/src/load-env.test.ts` 통과 (`14 pass`)
- [ ] `cd examples/react-native-bare && bun run start:zts` 가 8081 listen
- [ ] `cd examples/react-native-expo && bun run start:zts` 가 8081 listen
- [ ] 시뮬레이터 앱이 dev server 에 연결되어 bundle load

🤖 Generated with [Claude Code](https://claude.com/claude-code)