### PR TITLE
chore(examples): build:zts:core 에 @zts/server + @zts/react-native 체인

### DIFF
--- a/examples/react-native-bare/package.json
+++ b/examples/react-native-bare/package.json
@@ -10,7 +10,7 @@
     "ios:release": "react-native run-ios --mode Release",
     "start": "react-native start",
     "start:zts": "zts dev --platform=react-native --rn-platform=ios index.js",
-    "build:zts:core": "bun run --cwd ../../packages/core build",
+    "build:zts:core": "bun run --cwd ../../packages/core build && bun run --cwd ../../packages/server build && bun run --cwd ../../packages/react-native build",
     "bundle:zts:ios": "zts bundle index.js --platform=react-native --rn-platform=ios -o ios/main.jsbundle",
     "bundle:zts:android": "zts bundle index.js --platform=react-native --rn-platform=android -o android/app/src/main/assets/index.android.bundle",
     "bundle:metro:ios": "react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ios/main.jsbundle --assets-dest ios",

--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "expo start",
     "start:zts": "zts dev --platform=react-native --rn-platform=ios index.js",
-    "build:zts:core": "bun run --cwd ../../packages/core build",
+    "build:zts:core": "bun run --cwd ../../packages/core build && bun run --cwd ../../packages/server build && bun run --cwd ../../packages/react-native build",
     "bundle:zts:ios": "zts bundle index.js --platform=react-native --rn-platform=ios -o dist/main.ios.jsbundle",
     "bundle:zts:android": "zts bundle index.js --platform=react-native --rn-platform=android -o dist/main.android.jsbundle",
     "reset-project": "node ./scripts/reset-project.js",


### PR DESCRIPTION
## Summary
RN 예제에서 `bun run start:zts` 를 띄우려면 `@zts/react-native` 의 lazy import 가 성공해야 하는데, RN 패키지는 다시 `@zts/server` 에 의존. 두 패키지 모두 `dist/` 가 없으면 dev server 가 다음 메시지로 fail-fast:

```
error: @zts/react-native 패키지가 필요합니다 (zts bundle --platform=react-native).
help: install with `bun add -D @zts/react-native` 또는 `npm i -D @zts/react-native`.
```

`build:zts:core` 를 `core → server → react-native` 직렬 체인으로 확장해 RN 예제 안에서 한 번에 모든 의존 패키지를 빌드하도록 수정.

```diff
-"build:zts:core": "bun run --cwd ../../packages/core build"
+"build:zts:core": "bun run --cwd ../../packages/core build && bun run --cwd ../../packages/server build && bun run --cwd ../../packages/react-native build"
```

## 배경
원래 #2620 에서 추가한 `build:zts:core` 의 후속 커밋이었는데 머지 시점에 누락되어 별도 PR 로 재제출.

## Test plan
- [ ] `cd examples/react-native-bare && bun run build:zts:core` 가 `core` → `server` → `react-native` 순으로 3개 패키지 모두 dist 산출
- [ ] `cd examples/react-native-expo && bun run build:zts:core` 동일 동작
- [ ] 빌드 후 `bun run start:zts` 가 정상 listen (`@zts/react-native 패키지가 필요합니다` 미발생)

🤖 Generated with [Claude Code](https://claude.com/claude-code)