### PR TITLE
fix(react-native): babel plugin resolve 를 project 기준 require 로 (#2605 audit)

### DIFF
--- a/examples/react-native-bare/package.json
+++ b/examples/react-native-bare/package.json
@@ -10,6 +10,7 @@
     "ios:release": "react-native run-ios --mode Release",
     "start": "react-native start",
     "start:zts": "zts dev --platform=react-native --rn-platform=ios index.js",
+    "prestart:zts": "bun run build:zts:core",
     "build:zts:core": "bun run --cwd ../../packages/core build && bun run --cwd ../../packages/server build && bun run --cwd ../../packages/react-native build",
     "bundle:zts:ios": "zts bundle index.js --platform=react-native --rn-platform=ios -o ios/main.jsbundle",
     "bundle:zts:android": "zts bundle index.js --platform=react-native --rn-platform=android -o android/app/src/main/assets/index.android.bundle",

--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -1,12 +1,13 @@
 {
   "name": "zts-example-react-native-expo",
-  "main": "expo-router/entry",
   "version": "1.0.0",
   "private": true,
   "description": "ZTS dev server + bundler example — Expo 55 / RN 0.83",
+  "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",
     "start:zts": "zts dev --platform=react-native --rn-platform=ios index.js",
+    "prestart:zts": "bun run build:zts:core",
     "build:zts:core": "bun run --cwd ../../packages/core build && bun run --cwd ../../packages/server build && bun run --cwd ../../packages/react-native build",
     "bundle:zts:ios": "zts bundle index.js --platform=react-native --rn-platform=ios -o dist/main.ios.jsbundle",
     "bundle:zts:android": "zts bundle index.js --platform=react-native --rn-platform=android -o dist/main.android.jsbundle",

--- a/packages/react-native/src/dev-server/http-server.test.ts
+++ b/packages/react-native/src/dev-server/http-server.test.ts
@@ -43,6 +43,27 @@ function url(path: string): string {
   return `http://localhost:${addr.port}${path}`;
 }
 
+describe("createDevHttpServer — index page (`/` `/index.html`)", () => {
+  test("GET / → 200 HTML + bundle/map/HMR link 포함", async () => {
+    const res = await fetch(url("/"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/html; charset=utf-8");
+    const body = await res.text();
+    expect(body).toContain("ZTS RN Dev Server");
+    expect(body).toContain("/index.bundle?platform=ios&dev=true");
+    expect(body).toContain("/index.bundle?platform=android&dev=true");
+    expect(body).toContain("/index.bundle.map?platform=ios");
+    // ws:// link 의 port 가 응답에 반영 (port=0 으로 listen 시 actual port 가 다름이라
+    // body 에는 options.port=0 그대로 — caller-set port. dev 시 8081 일 때 정상).
+  });
+
+  test("GET /index.html — alias 동작", async () => {
+    const res = await fetch(url("/index.html"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/html; charset=utf-8");
+  });
+});
+
 describe("createDevHttpServer — base routes", () => {
   test("GET /status → 200 packager-status:running + project-root header", async () => {
     const res = await fetch(url("/status"));

--- a/packages/react-native/src/plugins/babel.test.ts
+++ b/packages/react-native/src/plugins/babel.test.ts
@@ -94,6 +94,41 @@ describe("detectCustomPlugins", () => {
   });
 });
 
+describe("detectCustomPlugins — project-기준 require (#2605 audit)", () => {
+  test("project node_modules 의 babel plugin 인식", () => {
+    // Fixture: project 디렉토리에 자체 node_modules + custom babel plugin install.
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "fix-test" }));
+    mkdirSync(join(dir, "node_modules/my-fake-plugin"), { recursive: true });
+    writeFileSync(
+      join(dir, "node_modules/my-fake-plugin/package.json"),
+      JSON.stringify({ name: "my-fake-plugin", main: "index.js" }),
+    );
+    writeFileSync(
+      join(dir, "node_modules/my-fake-plugin/index.js"),
+      "module.exports = function fake(){ return {}; };",
+    );
+    writeFileSync(
+      join(dir, "babel.config.js"),
+      `module.exports = { plugins: ['my-fake-plugin'] };`,
+    );
+    // detectCustomPlugins 가 project 의 node_modules 에서 require 성공 → ZTS
+    // native 외 plugin 으로 인식.
+    expect(detectCustomPlugins(dir)).toBe(true);
+  });
+
+  test("babel-plugin-root-import 같은 외부 plugin — config 만 detect", () => {
+    // detectCustomPlugins 는 plugin require 성공 안 해도 string name 만으로 판단.
+    // require 실패 시점은 createBabelTransformer 의 ensureBabel — 그 단계에서
+    // project-기준 resolve fallback 으로 처리.
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "fix-test" }));
+    writeFileSync(
+      join(dir, "babel.config.js"),
+      `module.exports = { plugins: [['babel-plugin-root-import', { rootPathPrefix: '~/' }]] };`,
+    );
+    expect(detectCustomPlugins(dir)).toBe(true);
+  });
+});
+
 describe("ZTS_NATIVE_PLUGIN_PATTERNS", () => {
   test("count >= 15 (sanity)", () => {
     expect(ZTS_NATIVE_PLUGIN_PATTERNS.length).toBeGreaterThanOrEqual(15);

--- a/packages/react-native/src/plugins/babel.ts
+++ b/packages/react-native/src/plugins/babel.ts
@@ -5,6 +5,7 @@
 // plugin 자체 등록 skip (createBabelPlugin 의 detectCustomPlugins false 분기).
 
 import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
 import { join } from "node:path";
 
 import type { ZtsPlugin } from "@zts/core";
@@ -61,7 +62,10 @@ export function detectCustomPlugins(projectRoot: string): boolean {
   try {
     const configPath = join(projectRoot, "babel.config.js");
     if (!existsSync(configPath)) return false;
-    const config = requireFromCli(configPath) as BabelConfigModule;
+    // project 기준 require — examples/<app>/node_modules 의 babel plugin 을
+    // 정확히 resolve 하기 위해 project 의 package.json 을 ref base 로.
+    const projectRequire = createRequire(`${projectRoot}/package.json`);
+    const config = projectRequire(configPath) as BabelConfigModule;
     const plugins: unknown[] = config?.plugins ?? [];
     return plugins.some((p) => {
       const name = typeof p === "string" ? p : Array.isArray(p) ? (p[0] as string) : "";
@@ -89,10 +93,26 @@ export function createBabelTransformer(
 
   function ensureBabel(): void {
     if (babel) return;
-    babel = requireFromCli("@babel/core") as BabelInstance;
+    // project 기준 require — examples/<app>/node_modules 의 babel plugin 을
+    // 정확히 resolve. fallback 으로 zts CLI require (workspace hoist case).
+    const projectRequire = createRequire(`${projectRoot}/package.json`);
+    function resolvePluginPath(name: string): string {
+      try {
+        return projectRequire.resolve(name);
+      } catch {
+        return requireFromCli.resolve(name);
+      }
+    }
+    babel = (() => {
+      try {
+        return projectRequire("@babel/core") as BabelInstance;
+      } catch {
+        return requireFromCli("@babel/core") as BabelInstance;
+      }
+    })();
 
     const configPath = join(projectRoot, "babel.config.js");
-    const config = requireFromCli(configPath) as BabelConfigModule;
+    const config = projectRequire(configPath) as BabelConfigModule;
     const plugins: unknown[] = config?.plugins ?? [];
 
     const customPlugins: unknown[] = [];
@@ -103,7 +123,7 @@ export function createBabelTransformer(
         if (Array.isArray(plugin)) {
           try {
             customPlugins.push([
-              requireFromCli.resolve(plugin[0] as string),
+              resolvePluginPath(plugin[0] as string),
               ...(plugin.slice(1) as unknown[]),
             ]);
           } catch {
@@ -111,7 +131,7 @@ export function createBabelTransformer(
           }
         } else {
           try {
-            customPlugins.push(requireFromCli.resolve(name));
+            customPlugins.push(resolvePluginPath(name));
           } catch {
             customPlugins.push(name);
           }


### PR DESCRIPTION
## Summary

번개 ExampleApp 에서는 동작하던 \`babel-plugin-root-import\` / lodash 등이 zts examples 에서 \`Cannot find module\` 로 fail 하던 root cause fix.

## Root cause

\`requireFromCli = createRequire(import.meta.url)\` 가 \`packages/react-native/dist/index.js\` 기준 require. \`examples/<app>/node_modules\` 는 Node module resolution 의 upward lookup 에서 닿지 않음.

**번개 vs zts 차이**: 번개의 ExampleApp 은 \`bungae: workspace:*\` 로 monorepo root 의 hoisted node_modules 에 babel plugin install. bungae dist 의 \`requireFromCli\` 가 root 에서 resolve 가능. zts 는 dist 가 \`packages/react-native/\` 안에 nested 라 hoist 효과 못 받음.

## Fix

**\`packages/react-native/src/plugins/babel.ts\`**:
- \`detectCustomPlugins\` / \`createBabelTransformer\` 가 \`createRequire(\\\`\${projectRoot}/package.json\\\`)\` 로 **project 기준 require** 사용.
- \`@babel/core\` 도 project 우선 resolve, 미존재 시 \`requireFromCli\` fallback.
- Node module resolution 의 standard upward lookup 으로 monorepo root 의 hoisted node_modules 까지 자동 search.

**\`examples/react-native-{bare,expo}/package.json\`**:
- \`prestart:zts\` hook — \`zts dev\` 시작 전에 자동 \`build:zts:core\` 호출. 사용자가 main pull 후 build 잊어 옛 dist 로 실행하는 함정 회피.

## 테스트 (+4 cases)

- \`babel.test.ts\` (2 cases) — project node_modules 의 fake plugin 인식 + \`babel-plugin-root-import\` 같은 외부 plugin string detect.
- \`http-server.test.ts\` (2 cases) — GET \`/\` 와 \`/index.html\` 의 HTML 응답 + bundle/map/HMR link 포함 검증 (사용자 보고 — localhost:8081 접속 안 됨 → dist stale 문제).

## 검증

- \`bun test packages/react-native\` — **361 pass / 0 fail** (이전 357 → +4).
- \`bun run build\` / \`oxlint --deny-warnings\` / \`tsc --noEmit\` — 통과.

## 사용자 환경

\`prestart:zts\` hook 가 자동 build. 만약 hook 안 도는 경우 수동:
\`\`\`sh
bun run --cwd packages/react-native build
\`\`\`

Refs #2605

🤖 Generated with [Claude Code](https://claude.com/claude-code)