### PR TITLE
chore(examples): @babel/preset-typescript devDep 추가 (RN 0.85 bare)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -86,6 +86,7 @@
         "@babel/plugin-transform-private-methods": "^7.28.6",
         "@babel/preset-env": "^7.25.3",
         "@babel/preset-flow": "^7.27.1",
+        "@babel/preset-typescript": "^7.27.1",
         "@babel/runtime": "^7.25.0",
         "@react-native-community/cli": "20.1.3",
         "@react-native-community/cli-platform-android": "20.1.3",

--- a/examples/react-native-bare/package.json
+++ b/examples/react-native-bare/package.json
@@ -36,6 +36,7 @@
     "@babel/plugin-transform-private-methods": "^7.28.6",
     "@babel/preset-env": "^7.25.3",
     "@babel/preset-flow": "^7.27.1",
+    "@babel/preset-typescript": "^7.27.1",
     "@babel/runtime": "^7.25.0",
     "@react-native-community/cli": "20.1.3",
     "@react-native-community/cli-platform-android": "20.1.3",


### PR DESCRIPTION
## Summary
ZTS RN babel transformer (`packages/react-native/src/plugins/babel.ts:143`) 가 `@babel/preset-typescript` 를 hardcoded preset 으로 쓰는데, bare 의 devDeps 에 누락 → bun isolated install 의 transitive 가 hoist 되지 않아 "Cannot find module '@babel/preset-typescript'" 로 babel transform 실패.

```
[zts:babel] error: Cannot find module '@babel/preset-typescript'
Require stack:
- /Users/yoon/Documents/workspace/zts/n[ode_modules/...]
```

#2627 의 babel plugin resolve fix (project 기준 require) 로 resolve 경로는 정상화됐지만, 정작 bare 의 node_modules 에 패키지 자체가 없어 발생.

## Why bare only
- `bare`: `babel.config.js` 가 lodash/decorators/private-methods 등 plugin 사용 → `detectCustomPlugins` true → babel pass 실행 → preset-typescript 필요.
- `expo`: `babel.config.js` 없음 → `detectCustomPlugins` false → babel pass skip → 추가 불필요.

번개 ExampleApp 의 package.json 도 `@babel/preset-typescript` 를 직접 listing 하고 있어 일관.

## Test plan
- [ ] `bun install` 후 `examples/react-native-bare/node_modules/@babel/preset-typescript` 존재
- [ ] `bun run start:zts` 시 `[zts:babel] error: Cannot find module '@babel/preset-typescript'` 미발생
- [ ] dev server 가 정상 listen + bundle 200 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)