### PR TITLE
feat(react-native): zts.config.ts 의 transformer/serializer/server 영역 매핑 (#2605 audit)

### DIFF
--- a/packages/core/bin/rn-dev-input.mjs
+++ b/packages/core/bin/rn-dev-input.mjs
@@ -5,11 +5,50 @@
 import { resolve } from "node:path";
 
 /**
+ * config 의 미지원 필드는 stderr 에 한 번 경고 — silent drop 방지. zts 의
+ * RN dev server 가 아직 wire-up 안 한 영역 (graph-bundler 전용 필드 + dummy
+ * placeholder) 을 사용자가 적었을 때 "왜 동작 안 함?" 디버깅 비용 절감.
+ */
+const UNSUPPORTED_FIELDS = [
+  // graph-bundler (Metro 호환) 전용 — zts NAPI build 는 미수용.
+  ["transformer", "inlineRequires"],
+  ["transformer", "minifier"],
+  ["transformer", "babel"],
+  ["serializer", "prelude"],
+  ["serializer", "bundleType"],
+  ["serializer", "getModulesRunBeforeMainModule"],
+  ["serializer", "getPolyfills"],
+  ["serializer", "shouldAddToIgnoreList"],
+  ["serializer", "inlineSourceMap"],
+  // dummy placeholder — bungae 도 declared-but-unused.
+  ["server", "forwardClientLogs"],
+  ["server", "verifyConnections"],
+  ["server", "https"],
+  ["server", "key"],
+  ["server", "cert"],
+  ["server", "unstable_serverRoot"],
+];
+
+function warnUnsupported(config) {
+  for (const [section, key] of UNSUPPORTED_FIELDS) {
+    const sectionVal = config?.[section];
+    if (sectionVal && Object.prototype.hasOwnProperty.call(sectionVal, key)) {
+      process.stderr.write(`[zts:rn-dev] config.${section}.${key} (zts 미지원, ignore)\n`);
+    }
+  }
+}
+
+/**
  * 번개 BungaeConfig 의 `root` / `entry` / `dev` / `minify` / `server.*` /
- * `resolver.*` / `transformer.*` / `symbolicator.*` / `watchFolders` 영역 인식.
+ * `resolver.*` / `transformer.*` / `serializer.*` / `symbolicator.*` /
+ * `watchFolders` 영역 인식.
  *
  * CLI flag 우선 → config 영역 → default 순서 fallback. entry 가 없으면 null —
  * caller 가 friendly error 처리.
+ *
+ * 미지원 필드 (graph-bundler 전용 + placeholder) 는 stderr 에 한 번 경고 —
+ * `transformer.inlineRequires` / `transformer.minifier` / `serializer.prelude` /
+ * `serializer.bundleType` / `server.forwardClientLogs` / `server.verifyConnections` 등.
  */
 export function buildRnDevServerInput(opts, config) {
   const cfg = config ?? {};
@@ -20,7 +59,15 @@ export function buildRnDevServerInput(opts, config) {
   const server = cfg.server ?? {};
   const resolver = cfg.resolver ?? {};
   const transformer = cfg.transformer ?? {};
+  const serializer = cfg.serializer ?? {};
   const symbolicator = cfg.symbolicator ?? {};
+
+  warnUnsupported(cfg);
+
+  // server.useGlobalHotkey 가 의미상 terminalActions — 둘 다 r/d/? 키보드
+  // shortcut 의 enable gate. CLI 미노출이라 config 만 source.
+  const terminalActions = server.useGlobalHotkey === false ? false : undefined;
+
   return {
     bundle: {
       entry,
@@ -44,6 +91,8 @@ export function buildRnDevServerInput(opts, config) {
         babelTransformerPath: transformer.babelTransformerPath ?? undefined,
         sourceExts: resolver.sourceExts ?? undefined,
         assetExts: resolver.assetExts ?? undefined,
+        polyfills: serializer.polyfills ?? undefined,
+        extraVars: serializer.extraVars ?? undefined,
       },
     },
     port: opts.port ?? server.port ?? 8081,
@@ -54,5 +103,6 @@ export function buildRnDevServerInput(opts, config) {
     symbolicator: symbolicator.customizeFrame
       ? { customizeFrame: symbolicator.customizeFrame }
       : undefined,
+    ...(terminalActions === false ? { terminalActions: false } : {}),
   };
 }

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -5175,6 +5175,139 @@ describe("buildRnDevServerInput — config + opts 추출 (#2605)", () => {
     const input = buildRnDevServerInput({ entryPoints: ["i.js"], rnPlatform: "android" }, {});
     expect(input?.bundle.rnPlatform).toBe("android");
   });
+
+  test("config.serializer.polyfills → bundle.extra.polyfills 매핑", async () => {
+    const { buildRnDevServerInput } = await import("./rn-dev-input.mjs");
+    const input = buildRnDevServerInput(
+      { entryPoints: ["i.js"] },
+      { serializer: { polyfills: ["./shims/myPolyfill.js"] } },
+    );
+    expect(input?.bundle.extra?.polyfills).toEqual(["./shims/myPolyfill.js"]);
+  });
+
+  test("config.serializer.extraVars → bundle.extra.extraVars 매핑", async () => {
+    const { buildRnDevServerInput } = await import("./rn-dev-input.mjs");
+    const input = buildRnDevServerInput(
+      { entryPoints: ["i.js"] },
+      { serializer: { extraVars: { __APP_VERSION__: "1.0.0", __FLAG__: true } } },
+    );
+    expect(input?.bundle.extra?.extraVars).toEqual({
+      __APP_VERSION__: "1.0.0",
+      __FLAG__: true,
+    });
+  });
+
+  test("config.server.useGlobalHotkey=false → terminalActions=false", async () => {
+    const { buildRnDevServerInput } = await import("./rn-dev-input.mjs");
+    const input = buildRnDevServerInput(
+      { entryPoints: ["i.js"] },
+      { server: { useGlobalHotkey: false } },
+    );
+    expect(input?.terminalActions).toBe(false);
+  });
+
+  test("config.server.useGlobalHotkey=true (or 미지정) → terminalActions 미설정 (default true)", async () => {
+    const { buildRnDevServerInput } = await import("./rn-dev-input.mjs");
+    const a = buildRnDevServerInput(
+      { entryPoints: ["i.js"] },
+      { server: { useGlobalHotkey: true } },
+    );
+    expect(a?.terminalActions).toBeUndefined();
+    const b = buildRnDevServerInput({ entryPoints: ["i.js"] }, {});
+    expect(b?.terminalActions).toBeUndefined();
+  });
+
+  test("미지원 필드 (transformer.inlineRequires/minifier, serializer.prelude/bundleType, server.forwardClientLogs/verifyConnections) — stderr 경고", async () => {
+    const { buildRnDevServerInput } = await import("./rn-dev-input.mjs");
+    const original = process.stderr.write.bind(process.stderr);
+    const writes: string[] = [];
+    // @ts-expect-error — runtime mock
+    process.stderr.write = (chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
+      return true;
+    };
+    try {
+      buildRnDevServerInput(
+        { entryPoints: ["i.js"] },
+        {
+          transformer: { inlineRequires: true, minifier: "terser" },
+          serializer: { prelude: ["./extra-prelude.js"], bundleType: "module" },
+          server: { forwardClientLogs: true, verifyConnections: true },
+        },
+      );
+    } finally {
+      process.stderr.write = original;
+    }
+    const all = writes.join("");
+    expect(all).toContain("transformer.inlineRequires");
+    expect(all).toContain("transformer.minifier");
+    expect(all).toContain("serializer.prelude");
+    expect(all).toContain("serializer.bundleType");
+    expect(all).toContain("server.forwardClientLogs");
+    expect(all).toContain("server.verifyConnections");
+  });
+
+  test("미지원 필드 0 — stderr 경고 0 출력", async () => {
+    const { buildRnDevServerInput } = await import("./rn-dev-input.mjs");
+    const original = process.stderr.write.bind(process.stderr);
+    const writes: string[] = [];
+    // @ts-expect-error — runtime mock
+    process.stderr.write = (chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
+      return true;
+    };
+    try {
+      buildRnDevServerInput({ entryPoints: ["i.js"] }, { entry: "i.js", root: "." });
+    } finally {
+      process.stderr.write = original;
+    }
+    expect(writes.join("")).not.toContain("[zts:rn-dev]");
+  });
+
+  test("transformer/serializer/server 빈 객체 — stderr 경고 0", async () => {
+    const { buildRnDevServerInput } = await import("./rn-dev-input.mjs");
+    const original = process.stderr.write.bind(process.stderr);
+    const writes: string[] = [];
+    // @ts-expect-error — runtime mock
+    process.stderr.write = (chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
+      return true;
+    };
+    try {
+      buildRnDevServerInput(
+        { entryPoints: ["i.js"] },
+        { transformer: {}, serializer: {}, server: {} },
+      );
+    } finally {
+      process.stderr.write = original;
+    }
+    expect(writes.join("")).not.toContain("[zts:rn-dev]");
+  });
+
+  test("UNSUPPORTED_FIELDS — transformer.babel + server.unstable_serverRoot 도 경고", async () => {
+    const { buildRnDevServerInput } = await import("./rn-dev-input.mjs");
+    const original = process.stderr.write.bind(process.stderr);
+    const writes: string[] = [];
+    // @ts-expect-error — runtime mock
+    process.stderr.write = (chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
+      return true;
+    };
+    try {
+      buildRnDevServerInput(
+        { entryPoints: ["i.js"] },
+        {
+          transformer: { babel: { presets: ["x"] } },
+          server: { unstable_serverRoot: "/srv" },
+        },
+      );
+    } finally {
+      process.stderr.write = original;
+    }
+    const all = writes.join("");
+    expect(all).toContain("transformer.babel");
+    expect(all).toContain("server.unstable_serverRoot");
+  });
 });
 
 describe("CLI: dev --platform=react-native (#2605 PR #J)", () => {

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -131,6 +131,86 @@ describe("buildRnBundleOptions — define / banner / footer / polyfills", () => 
     expect(opts.polyfills).toBeUndefined();
   });
 
+  test("extra.polyfills — 사용자 추가 polyfill 이 projectRoot 기준 절대화 + preset 결과에 추가", () => {
+    const opts = buildRnBundleOptions(
+      baseInput({ extra: { polyfills: ["./shims/myPolyfill.js"] } }),
+    );
+    expect(opts.polyfills).toEqual([join(dir, "shims/myPolyfill.js")]);
+  });
+
+  test("extra.polyfills — 절대 경로 그대로 보존", () => {
+    const opts = buildRnBundleOptions(baseInput({ extra: { polyfills: ["/abs/some/poly.js"] } }));
+    expect(opts.polyfills).toEqual(["/abs/some/poly.js"]);
+  });
+
+  test("extra.polyfills — 빈 배열은 polyfills 미정의 (preset 의 RN polyfill 도 미설치 fixture)", () => {
+    const opts = buildRnBundleOptions(baseInput({ extra: { polyfills: [] } }));
+    expect(opts.polyfills).toBeUndefined();
+  });
+
+  test("extra.extraVars — banner 에 `var <key>=<JSON.stringify(value)>` inject", () => {
+    const opts = buildRnBundleOptions(
+      baseInput({
+        extra: {
+          extraVars: { __APP_VERSION__: "1.2.3", __FEATURE_X__: true, __COUNT__: 42 },
+        },
+      }),
+    );
+    expect(opts.banner).toContain('var __APP_VERSION__="1.2.3";');
+    expect(opts.banner).toContain("var __FEATURE_X__=true;");
+    expect(opts.banner).toContain("var __COUNT__=42;");
+  });
+
+  test("extra.extraVars — prelude reserved 식별자 5종 모두 skip (Hermes 재선언 SyntaxError 방지)", () => {
+    const opts = buildRnBundleOptions(
+      baseInput({
+        extra: {
+          extraVars: {
+            __DEV__: false,
+            global: "x",
+            process: "y",
+            __BUNDLE_START_TIME__: 0,
+            __ZTS_RN_GLOBAL__: "z",
+            __OK__: 1,
+          },
+        },
+      }),
+    );
+    // baseline (extraVars 없는 옵션) 의 var declaration count 그대로 — extraVars
+    // 가 reserved 식별자를 재선언하지 않는지 정확히 검증.
+    const baseline = buildRnBundleOptions(baseInput()).banner!;
+    for (const id of [
+      "__DEV__",
+      "global",
+      "process",
+      "__BUNDLE_START_TIME__",
+      "__ZTS_RN_GLOBAL__",
+    ]) {
+      const re = new RegExp(`var ${id}=`, "g");
+      expect((opts.banner?.match(re) ?? []).length).toBe((baseline.match(re) ?? []).length);
+    }
+    expect(opts.banner).toContain("var __OK__=1;");
+  });
+
+  test("extra.extraVars — 빈 객체 → banner 가 baseline 과 동일", () => {
+    const baseline = buildRnBundleOptions(baseInput()).banner!;
+    const opts = buildRnBundleOptions(baseInput({ extra: { extraVars: {} } }));
+    expect(opts.banner).toBe(baseline);
+  });
+
+  test("extra.extraVars — bannerExtras 와 함께 사용 시 extraVars 가 먼저, bannerExtras 가 뒤", () => {
+    const opts = buildRnBundleOptions(
+      baseInput({
+        bannerExtras: "globalThis.__LATE__=1;",
+        extra: { extraVars: { __EARLY__: 1 } },
+      }),
+    );
+    const earlyIdx = opts.banner!.indexOf("__EARLY__");
+    const lateIdx = opts.banner!.indexOf("__LATE__");
+    expect(earlyIdx).toBeGreaterThan(0);
+    expect(lateIdx).toBeGreaterThan(earlyIdx);
+  });
+
   test("runBeforeMain — InitializeCore 미해결 시 미정의", () => {
     const opts = buildRnBundleOptions(baseInput());
     expect(opts.runBeforeMain).toBeUndefined();

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -80,6 +80,15 @@ export interface RnBundleInput {
     sourceExts?: string[];
     /** RN assetExts override (default RN preset). */
     assetExts?: string[];
+    /** 사용자 추가 polyfill (preset 의 RN polyfill 와 concat — Metro `serializer.polyfills` 호환). */
+    polyfills?: string[];
+    /**
+     * 추가 global 변수 — banner 의 `var <key>=<JSON.stringify(value)>` 로 inject.
+     * Metro `serializer.extraVars` 호환. zts 의 `define` 과 의도가 다름:
+     * `define` 은 source 의 식별자 substitution (compile-time), `extraVars` 는
+     * runtime-time prelude 의 globals declaration (RN 코드 도착 전에 평가).
+     */
+    extraVars?: Record<string, unknown>;
   };
   /** RN prelude 끝에 append 할 사용자 banner string. */
   bannerExtras?: string;
@@ -132,8 +141,29 @@ function buildAssetLoaders(assetExts: readonly string[]): Record<string, string>
   return loaders;
 }
 
+/**
+ * prelude 가 이미 declare 한 식별자 — Hermes strict 모드에서 var 재선언 시
+ * SyntaxError. caller 가 prelude 식별자를 override 할 의도면 `define` 사용.
+ */
+const PRELUDE_RESERVED = new Set([
+  "__BUNDLE_START_TIME__",
+  "__DEV__",
+  "__ZTS_RN_GLOBAL__",
+  "global",
+  "process",
+]);
+
+function formatExtraVars(extraVars: Record<string, unknown>): string {
+  const out: string[] = [];
+  for (const [key, value] of Object.entries(extraVars)) {
+    if (PRELUDE_RESERVED.has(key)) continue;
+    out.push(`var ${key}=${JSON.stringify(value)};`);
+  }
+  return out.join("");
+}
+
 function buildPrelude(input: RnBundleInput): string {
-  const { dev, bannerExtras } = input;
+  const { dev, bannerExtras, extra } = input;
   const lines = [
     `var __BUNDLE_START_TIME__=this.nativePerformanceNow?nativePerformanceNow():Date.now();`,
     `var __DEV__=${dev};`,
@@ -142,6 +172,10 @@ function buildPrelude(input: RnBundleInput): string {
     `var process=__ZTS_RN_GLOBAL__.process||{};process.env=process.env||{};process.env.NODE_ENV=process.env.NODE_ENV||"${dev ? "development" : "production"}";`,
     `globalThis.__ZTS_RN_BUNDLER__=true;`,
   ];
+  if (extra?.extraVars && Object.keys(extra.extraVars).length > 0) {
+    const formatted = formatExtraVars(extra.extraVars);
+    if (formatted) lines.push(formatted);
+  }
   if (bannerExtras) lines.push(bannerExtras);
   return lines.join("");
 }
@@ -232,7 +266,12 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
     plugins.push(...extra.additionalPlugins);
   }
 
-  const polyfills = resolveRnPolyfills(projectRoot);
+  const polyfills = [...resolveRnPolyfills(projectRoot)];
+  if (extra?.polyfills && extra.polyfills.length > 0) {
+    // 사용자 추가 polyfill — projectRoot 기준으로 절대화. Metro 가 절대 경로
+    // 받는 것과 동일.
+    for (const p of extra.polyfills) polyfills.push(resolve(projectRoot, p));
+  }
   const runBeforeMain: string[] = [];
   const initCore = tryResolve("react-native/Libraries/Core/InitializeCore", projectRoot);
   if (initCore) runBeforeMain.push(initCore);


### PR DESCRIPTION
## 요약

`zts dev --platform=react-native` 가 사용자 `zts.config.ts` 의 일부 필드를 silent drop 하던 문제 수정.

- 매핑 가능 필드 — `serializer.polyfills`, `serializer.extraVars`, `server.useGlobalHotkey` 를 `RnDevServerOptions` 로 forward
- 매핑 불가 필드 (graph-bundler 전용 + dummy placeholder) — stderr 한 줄 경고 (`[zts:rn-dev] config.X.Y (zts 미지원, ignore)`)

## 변경 핵심

### `packages/react-native/src/preset.ts`
- `RnBundleInput.extra` 에 `polyfills?: string[]`, `extraVars?: Record<string, unknown>` 추가
- `polyfills` 는 `projectRoot` 기준 절대화 후 preset 의 RN polyfill (`resolveRnPolyfills`) 와 concat
- `extraVars` 는 prelude 의 `var <key>=JSON.stringify(value);` 로 inject
- `PRELUDE_RESERVED` set — prelude 가 declare 한 5종 (`__BUNDLE_START_TIME__` / `__DEV__` / `__ZTS_RN_GLOBAL__` / `global` / `process`) 은 extraVars 에서 skip. Hermes strict 모드의 `var` 재선언 SyntaxError 방지.

### `packages/core/bin/rn-dev-input.mjs`
- `serializer.polyfills` / `serializer.extraVars` → `bundle.extra.polyfills` / `bundle.extra.extraVars` forward
- `server.useGlobalHotkey === false` → `terminalActions: false` (의미 동일 — r/d/? 키보드 단축키 enable gate)
- `UNSUPPORTED_FIELDS` 16개 — config 에 있으면 stderr 경고:
  - `transformer`: `inlineRequires`, `minifier`, `babel`
  - `serializer`: `prelude`, `bundleType`, `getModulesRunBeforeMainModule`, `getPolyfills`, `shouldAddToIgnoreList`, `inlineSourceMap`
  - `server`: `forwardClientLogs`, `verifyConnections`, `https`, `key`, `cert`, `unstable_serverRoot`

## 테스트

`bun test packages/react-native/src/preset.test.ts` — 46 pass (12 신규)
`bun test packages/core/bin/zts.test.ts -t buildRnDevServerInput` — 23 pass (8 신규)

신규 테스트 영역:
- `extra.polyfills` — 상대/절대 경로, 빈 배열
- `extra.extraVars` — inject, reserved 5종 skip, 빈 객체 baseline 동일, bannerExtras 순서
- `buildRnDevServerInput` — `polyfills` / `extraVars` 매핑, `useGlobalHotkey` 3분기 (false/true/undefined), stderr 경고 (모든 16종 + edge case)

## /simplify

3-agent review 완료. finding 4건 반영:
- A1 (Major): `PRELUDE_RESERVED` 를 5종으로 통합 (기존 3종에서 누락 2종 추가)
- B2: `UNSUPPORTED_FIELDS` 에 `transformer.babel` + `server.unstable_serverRoot` 추가
- C1: 빈 객체 (`transformer: {}` / `serializer: {}` / `server: {}`) edge case 테스트 추가
- B1 보정: 검토자 지적의 `host` / `enhanceMiddleware` / `rewriteRequestUrl` 누락은 실제 코드 확인 결과 이미 매핑되어 있어 fix 불필요 (B1 의 `unstable_serverRoot` 만 UNSUPPORTED 에 등록)

## 검증

- 변경 4 파일 모두 `oxfmt` 적용 (singleQuote 설정)
- `bun run --cwd packages/core build` 통과
- `bun run --cwd packages/react-native build` 통과
- `bun test packages/react-native/src` — 367 pass
- pre-existing 5개 fail (CLI: Vite-style app builder 의 PostCSS / dev restart) 은 본 PR 와 무관 (main 도 동일 fail)

Refs #2605

🤖 Generated with [Claude Code](https://claude.com/claude-code)