### PR TITLE
fix(react-native): apply babel plugin name prefix before resolve

### DIFF
--- a/packages/react-native/src/plugins/babel.test.ts
+++ b/packages/react-native/src/plugins/babel.test.ts
@@ -160,9 +160,7 @@ describe("applyBabelPluginPrefix", () => {
   });
 
   test("@scope/foo → @scope/babel-plugin-foo", () => {
-    expect(applyBabelPluginPrefix("@nativewind/preset")).toBe(
-      "@nativewind/babel-plugin-preset",
-    );
+    expect(applyBabelPluginPrefix("@nativewind/preset")).toBe("@nativewind/babel-plugin-preset");
   });
 
   test("이미 prefix 가진 이름은 그대로", () => {
@@ -182,9 +180,7 @@ describe("applyBabelPluginPrefix", () => {
   });
 
   test("preset prefix 도 보존", () => {
-    expect(applyBabelPluginPrefix("@babel/preset-typescript")).toBe(
-      "@babel/preset-typescript",
-    );
+    expect(applyBabelPluginPrefix("@babel/preset-typescript")).toBe("@babel/preset-typescript");
     expect(applyBabelPluginPrefix("babel-preset-expo")).toBe("babel-preset-expo");
   });
 });

--- a/packages/react-native/src/plugins/babel.test.ts
+++ b/packages/react-native/src/plugins/babel.test.ts
@@ -3,7 +3,12 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { detectCustomPlugins, isZtsNativePlugin, ZTS_NATIVE_PLUGIN_PATTERNS } from "./babel.ts";
+import {
+  applyBabelPluginPrefix,
+  detectCustomPlugins,
+  isZtsNativePlugin,
+  ZTS_NATIVE_PLUGIN_PATTERNS,
+} from "./babel.ts";
 
 let dir: string;
 
@@ -137,5 +142,49 @@ describe("ZTS_NATIVE_PLUGIN_PATTERNS", () => {
   test("중복 없음", () => {
     const set = new Set(ZTS_NATIVE_PLUGIN_PATTERNS);
     expect(set.size).toBe(ZTS_NATIVE_PLUGIN_PATTERNS.length);
+  });
+});
+
+describe("applyBabelPluginPrefix", () => {
+  test("plain name → babel-plugin-{name}", () => {
+    // bare 의 babel.config.js 가 `['lodash']` 를 쓰는데 prefix 없이 resolve 하면
+    // lodash 라이브러리 자체로 풀려 babel 이 reject — 핵심 회귀 케이스.
+    expect(applyBabelPluginPrefix("lodash")).toBe("babel-plugin-lodash");
+    expect(applyBabelPluginPrefix("root-import")).toBe("babel-plugin-root-import");
+  });
+
+  test("@babel/foo → @babel/plugin-foo", () => {
+    expect(applyBabelPluginPrefix("@babel/proposal-decorators")).toBe(
+      "@babel/plugin-proposal-decorators",
+    );
+  });
+
+  test("@scope/foo → @scope/babel-plugin-foo", () => {
+    expect(applyBabelPluginPrefix("@nativewind/preset")).toBe(
+      "@nativewind/babel-plugin-preset",
+    );
+  });
+
+  test("이미 prefix 가진 이름은 그대로", () => {
+    expect(applyBabelPluginPrefix("babel-plugin-lodash")).toBe("babel-plugin-lodash");
+    expect(applyBabelPluginPrefix("@babel/plugin-transform-flow-strip-types")).toBe(
+      "@babel/plugin-transform-flow-strip-types",
+    );
+    expect(applyBabelPluginPrefix("@scope/babel-plugin-foo")).toBe("@scope/babel-plugin-foo");
+  });
+
+  test("절대/상대 경로 + module: prefix 는 그대로", () => {
+    expect(applyBabelPluginPrefix("/abs/path/plugin.js")).toBe("/abs/path/plugin.js");
+    expect(applyBabelPluginPrefix("./local-plugin")).toBe("./local-plugin");
+    expect(applyBabelPluginPrefix("module:@react-native/babel-preset")).toBe(
+      "module:@react-native/babel-preset",
+    );
+  });
+
+  test("preset prefix 도 보존", () => {
+    expect(applyBabelPluginPrefix("@babel/preset-typescript")).toBe(
+      "@babel/preset-typescript",
+    );
+    expect(applyBabelPluginPrefix("babel-preset-expo")).toBe("babel-preset-expo");
   });
 });

--- a/packages/react-native/src/plugins/babel.ts
+++ b/packages/react-native/src/plugins/babel.ts
@@ -54,6 +54,39 @@ export function isZtsNativePlugin(name: string): boolean {
 }
 
 /**
+ * Babel plugin 이름 컨벤션을 적용 (`@babel/core` 의 `standardizeName` 와 동등).
+ *
+ *  - `'lodash'`         → `'babel-plugin-lodash'`
+ *  - `'@babel/foo'`     → `'@babel/plugin-foo'`
+ *  - `'@scope/foo'`     → `'@scope/babel-plugin-foo'`
+ *  - 절대/상대 경로, `module:` prefix, 이미 prefix 를 가진 이름은 그대로.
+ *
+ * babel CLI 는 이 prefix 를 자동 적용하지만 ZTS 는 plugin 을 사전 절대경로로 resolve
+ * 해 babel 에 넘기므로 직접 적용해야 한다. 안 그러면 `'lodash'` 가 lodash 라이브러리
+ * 자체로 풀려 babel 이 `.__wrapped__ is not a valid Plugin property` 로 reject.
+ */
+export function applyBabelPluginPrefix(name: string): string {
+  if (name.startsWith("./") || name.startsWith("/") || name.startsWith("module:")) return name;
+  if (name.startsWith("@babel/")) {
+    const rest = name.slice("@babel/".length);
+    if (rest.startsWith("plugin-") || rest.startsWith("preset-")) return name;
+    return `@babel/plugin-${rest}`;
+  }
+  if (name.startsWith("@")) {
+    const slashIdx = name.indexOf("/");
+    if (slashIdx > 0) {
+      const scope = name.slice(0, slashIdx);
+      const rest = name.slice(slashIdx + 1);
+      if (rest.startsWith("babel-plugin-") || rest.startsWith("babel-preset-")) return name;
+      return `${scope}/babel-plugin-${rest}`;
+    }
+    return name;
+  }
+  if (name.startsWith("babel-plugin-") || name.startsWith("babel-preset-")) return name;
+  return `babel-plugin-${name}`;
+}
+
+/**
  * babel.config.js 의 plugins 배열 중 ZTS native list 외 의 plugin 이 하나라도
  * 있으면 true — Babel pass 가 필요하다는 신호. 미존재 / require fail / list
  * 외 plugin 0 → false (Babel pass skip 으로 startup latency 0).
@@ -97,6 +130,24 @@ export function createBabelTransformer(
     // 정확히 resolve. fallback 으로 zts CLI require (workspace hoist case).
     const projectRequire = createRequire(`${projectRoot}/package.json`);
     function resolvePluginPath(name: string): string {
+      // Babel plugin 이름 컨벤션 적용: `'lodash'` → `'babel-plugin-lodash'`,
+      // `'@babel/foo'` → `'@babel/plugin-foo'`, `'@scope/foo'` → `'@scope/babel-plugin-foo'`.
+      // (절대/상대 경로, `module:` prefix, 이미 prefix 가진 이름은 그대로.)
+      // prefix 없이 raw require 하면 `'lodash'` 가 lodash 라이브러리 자체로 풀려
+      // babel 이 "__wrapped__ is not a valid Plugin property" 로 reject (#TBD).
+      const prefixed = applyBabelPluginPrefix(name);
+      if (prefixed !== name) {
+        try {
+          return projectRequire.resolve(prefixed);
+        } catch {
+          try {
+            return requireFromCli.resolve(prefixed);
+          } catch {
+            // prefixed 형태로 못 찾으면 raw 로 fallback (사용자가 직접 절대경로/scope plugin
+            // 을 적은 케이스).
+          }
+        }
+      }
       try {
         return projectRequire.resolve(name);
       } catch {


### PR DESCRIPTION
## Summary
bare 의 `babel.config.js` 가 `['lodash']` (babel-plugin-lodash 의 shorthand) 를 쓰는데, ZTS 가 raw `projectRequire.resolve('lodash')` 로 풀어 **lodash 라이브러리 자체** (`/.../lodash/lodash.js`) 를 babel plugin 으로 넘겼음. babel 이 lodash chain wrapper 의 `__wrapped__` 프로퍼티 감지하고 reject:

```
[zts:babel] error: [BABEL] /.../App.tsx: .__wrapped__ is not a valid Plugin property
    at validatePluginObject (.../@babel/core/lib/config/validation/plugins.js:48:20)
```

그 결과 babel pass 가 실패 → root-import alias (`~/foo`) / lodash cherry-pick 모두 누락 → bundle 안에서 `Cannot read property 'root' of undefined` 등 cascade 런타임 에러.

## Root cause
ZTS 가 plugin 이름을 사전 절대경로로 resolve 해서 babel 에 넘기는데, babel CLI 가 자동 적용하는 `babel-plugin-` / `babel-preset-` prefix 컨벤션을 ZTS 가 미적용. `'lodash'` 가 lodash 라이브러리로 풀린 것이 직접 원인.

## Fix
- `applyBabelPluginPrefix` 추가 — `@babel/core` 의 `standardizeName` 과 동등:
  - `'lodash'` → `'babel-plugin-lodash'`
  - `'@babel/foo'` → `'@babel/plugin-foo'`
  - `'@scope/foo'` → `'@scope/babel-plugin-foo'`
  - 절대/상대 경로, `module:` prefix, 이미 prefix 가진 이름은 보존
- `resolvePluginPath` 가 prefixed 형태로 먼저 resolve 시도 후 raw 로 fallback (사용자가 절대경로 직접 명시 등 edge case 보호).

## Test
- 회귀 테스트 6 케이스 (`'lodash'` → `'babel-plugin-lodash'`, `@babel/`/`@scope/`/`preset-` / 절대경로 보존).
- 로컬 검증: `examples/react-native-bare && bun run start:zts` 실행 시:
  - 이전: `[zts:babel] error: ... .__wrapped__ is not a valid Plugin property` × 3
  - 이후: `[zts:babel] App.tsx: 38301 -> 36763`, `greeting.ts: 304 -> 297` 등 정상 transform
  - bundle: 1044 → 1184 files (스킵됐던 파일 다시 포함), 6670KB → 7098KB
  - 시뮬레이터: AppContent 정상 렌더링 (`Cannot read property 'root' of undefined` 해소)

## 후속 (별건)
- bare 앱의 `LinearTransition.springify()` 등 Reanimated layout API 가 `undefined is not a function` — ZTS 의 native worklet 처리와 user 의 `react-native-reanimated` 버전 호환성 이슈. 본 PR scope 외.
- `babel-plugin-lodash` 가 deprecated `isModuleDeclaration` 호출 — 사용자 라이브러리 이슈, 무시 가능 (warning only).

## Test plan
- [ ] `bun test packages/react-native/src/plugins/babel.test.ts` 통과 (`22 pass`)
- [ ] `cd examples/react-native-bare && bun run start:zts` 시 babel error 미발생, App 화면 렌더링

🤖 Generated with [Claude Code](https://claude.com/claude-code)