### PR TITLE
feat(react-native): zts.config.ts 의 serializer.prelude / transformer.babel 매핑 (#2605 audit)

### DIFF
--- a/packages/core/bin/rn-dev-input.mjs
+++ b/packages/core/bin/rn-dev-input.mjs
@@ -13,8 +13,6 @@ const UNSUPPORTED_FIELDS = [
   // graph-bundler (Metro 호환) 전용 — zts NAPI build 는 미수용.
   ["transformer", "inlineRequires"],
   ["transformer", "minifier"],
-  ["transformer", "babel"],
-  ["serializer", "prelude"],
   ["serializer", "bundleType"],
   ["serializer", "getModulesRunBeforeMainModule"],
   ["serializer", "getPolyfills"],
@@ -93,6 +91,8 @@ export function buildRnDevServerInput(opts, config) {
         assetExts: resolver.assetExts ?? undefined,
         polyfills: serializer.polyfills ?? undefined,
         extraVars: serializer.extraVars ?? undefined,
+        prelude: serializer.prelude ?? undefined,
+        babel: transformer.babel ?? undefined,
       },
     },
     port: opts.port ?? server.port ?? 8081,

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -5231,7 +5231,7 @@ describe("buildRnDevServerInput — config + opts 추출 (#2605)", () => {
         { entryPoints: ["i.js"] },
         {
           transformer: { inlineRequires: true, minifier: "terser" },
-          serializer: { prelude: ["./extra-prelude.js"], bundleType: "module" },
+          serializer: { bundleType: "module" },
           server: { forwardClientLogs: true, verifyConnections: true },
         },
       );
@@ -5241,10 +5241,12 @@ describe("buildRnDevServerInput — config + opts 추출 (#2605)", () => {
     const all = writes.join("");
     expect(all).toContain("transformer.inlineRequires");
     expect(all).toContain("transformer.minifier");
-    expect(all).toContain("serializer.prelude");
     expect(all).toContain("serializer.bundleType");
     expect(all).toContain("server.forwardClientLogs");
     expect(all).toContain("server.verifyConnections");
+    // transformer.babel / serializer.prelude 는 매핑 가능해서 경고 없음.
+    expect(all).not.toContain("transformer.babel");
+    expect(all).not.toContain("serializer.prelude");
   });
 
   test("미지원 필드 0 — stderr 경고 0 출력", async () => {
@@ -5284,7 +5286,7 @@ describe("buildRnDevServerInput — config + opts 추출 (#2605)", () => {
     expect(writes.join("")).not.toContain("[zts:rn-dev]");
   });
 
-  test("UNSUPPORTED_FIELDS — transformer.babel + server.unstable_serverRoot 도 경고", async () => {
+  test("UNSUPPORTED_FIELDS — server.unstable_serverRoot 도 경고", async () => {
     const { buildRnDevServerInput } = await import("./rn-dev-input.mjs");
     const original = process.stderr.write.bind(process.stderr);
     const writes: string[] = [];
@@ -5294,19 +5296,59 @@ describe("buildRnDevServerInput — config + opts 추출 (#2605)", () => {
       return true;
     };
     try {
-      buildRnDevServerInput(
+      buildRnDevServerInput({ entryPoints: ["i.js"] }, { server: { unstable_serverRoot: "/srv" } });
+    } finally {
+      process.stderr.write = original;
+    }
+    expect(writes.join("")).toContain("server.unstable_serverRoot");
+  });
+
+  test("config.serializer.prelude → bundle.extra.prelude 매핑 (warning 없음)", async () => {
+    const { buildRnDevServerInput } = await import("./rn-dev-input.mjs");
+    const original = process.stderr.write.bind(process.stderr);
+    const writes: string[] = [];
+    // @ts-expect-error — runtime mock
+    process.stderr.write = (chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
+      return true;
+    };
+    let input: ReturnType<typeof buildRnDevServerInput>;
+    try {
+      input = buildRnDevServerInput(
         { entryPoints: ["i.js"] },
-        {
-          transformer: { babel: { presets: ["x"] } },
-          server: { unstable_serverRoot: "/srv" },
-        },
+        { serializer: { prelude: ["./shims/prelude.js"] } },
       );
     } finally {
       process.stderr.write = original;
     }
-    const all = writes.join("");
-    expect(all).toContain("transformer.babel");
-    expect(all).toContain("server.unstable_serverRoot");
+    expect(input?.bundle.extra?.prelude).toEqual(["./shims/prelude.js"]);
+    expect(writes.join("")).not.toContain("serializer.prelude");
+  });
+
+  test("config.transformer.babel → bundle.extra.babel 매핑 (warning 없음)", async () => {
+    const { buildRnDevServerInput } = await import("./rn-dev-input.mjs");
+    const original = process.stderr.write.bind(process.stderr);
+    const writes: string[] = [];
+    // @ts-expect-error — runtime mock
+    process.stderr.write = (chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
+      return true;
+    };
+    const inlineBabel = {
+      presets: ["@ohah/react-native-mcp-server/babel-preset"],
+      plugins: [["@babel/plugin-proposal-decorators", { legacy: true }] as [string, object]],
+    };
+    let input: ReturnType<typeof buildRnDevServerInput>;
+    try {
+      input = buildRnDevServerInput(
+        { entryPoints: ["i.js"] },
+        { transformer: { babel: inlineBabel } },
+      );
+    } finally {
+      process.stderr.write = original;
+    }
+    expect(input?.bundle.extra?.babel).toEqual(inlineBabel);
+    expect(writes.join("")).not.toContain("transformer.babel");
   });
 });
 

--- a/packages/react-native/src/plugins/babel.test.ts
+++ b/packages/react-native/src/plugins/babel.test.ts
@@ -134,6 +134,49 @@ describe("detectCustomPlugins — project-기준 require (#2605 audit)", () => {
   });
 });
 
+describe("detectCustomPlugins — inline config (#2605 transformer.babel)", () => {
+  test("inline.plugins 만 있고 babel.config.js 없음 — true", () => {
+    expect(detectCustomPlugins(dir, { plugins: ["nativewind/babel"] })).toBe(true);
+  });
+
+  test("inline.plugins 가 ZTS native 만 — false (babel.config.js 도 없음)", () => {
+    expect(detectCustomPlugins(dir, { plugins: ["react-native-reanimated/plugin"] })).toBe(false);
+  });
+
+  test("inline.presets non-native — true", () => {
+    expect(detectCustomPlugins(dir, { presets: ["module:metro-react-native-babel-preset"] })).toBe(
+      true,
+    );
+  });
+
+  test("inline.presets 가 ZTS native (`@react-native/babel-preset`) 만 — false (silent drop 방지)", () => {
+    expect(detectCustomPlugins(dir, { presets: ["@react-native/babel-preset"] })).toBe(false);
+  });
+
+  test("inline 비어있고 babel.config.js 도 없음 — false", () => {
+    expect(detectCustomPlugins(dir, { plugins: [], presets: [] })).toBe(false);
+    expect(detectCustomPlugins(dir, undefined)).toBe(false);
+  });
+
+  test("babel.config.js 의 plugins + inline.plugins 둘 다 인식", () => {
+    writeFileSync(
+      join(dir, "babel.config.js"),
+      `module.exports = { plugins: ['react-native-reanimated/plugin'] };`,
+    );
+    // file 의 plugins 는 native 만이라 file 만으로는 false. inline 이 추가되면 true.
+    expect(detectCustomPlugins(dir, undefined)).toBe(false);
+    expect(detectCustomPlugins(dir, { plugins: ["nativewind/babel"] })).toBe(true);
+  });
+
+  test("inline.plugins tuple `[name, options]` 도 인식", () => {
+    expect(
+      detectCustomPlugins(dir, {
+        plugins: [["babel-plugin-root-import", { rootPathPrefix: "~/" }]],
+      }),
+    ).toBe(true);
+  });
+});
+
 describe("ZTS_NATIVE_PLUGIN_PATTERNS", () => {
   test("count >= 15 (sanity)", () => {
     expect(ZTS_NATIVE_PLUGIN_PATTERNS.length).toBeGreaterThanOrEqual(15);

--- a/packages/react-native/src/plugins/babel.ts
+++ b/packages/react-native/src/plugins/babel.ts
@@ -16,11 +16,16 @@ import {
   getErrorMessage,
   requireFromCli,
 } from "./internal.ts";
-import type { PluginConfig } from "./types.ts";
+import type { InlineBabelConfig, PluginConfig } from "./types.ts";
 
 interface BabelConfigModule {
   plugins?: unknown[];
 }
+
+// Babel API: `name` 또는 `[name, options]` 또는 `[name, options, instanceName]`
+// (multi-instance plugin/preset 구분용 3번째 요소). 사용자 babel docs 그대로
+// 적은 3-tuple 도 silently drop 안 되도록 spread 보존.
+type BabelEntry = string | [string, Record<string, unknown>?, string?];
 
 /**
  * ZTS native 처리 plugin patterns — Babel pass-through 시 제외 (이 list 에 매칭
@@ -86,12 +91,32 @@ export function applyBabelPluginPrefix(name: string): string {
   return `babel-plugin-${name}`;
 }
 
+function entryName(p: unknown): string {
+  return typeof p === "string" ? p : Array.isArray(p) ? (p[0] as string) : "";
+}
+
+function hasNonNative(plugins: unknown[]): boolean {
+  return plugins.some((p) => {
+    const name = entryName(p);
+    // 빈 string (number/object/null 같은 invalid plugin entry) 은 skip — bungae
+    // 의 minor bug fix (#2540): 원본은 빈 string 도 native 외 로 카운트해 false
+    // negative.
+    return typeof name === "string" && name !== "" && !isZtsNativePlugin(name);
+  });
+}
+
 /**
- * babel.config.js 의 plugins 배열 중 ZTS native list 외 의 plugin 이 하나라도
- * 있으면 true — Babel pass 가 필요하다는 신호. 미존재 / require fail / list
- * 외 plugin 0 → false (Babel pass skip 으로 startup latency 0).
+ * Babel pass 가 필요한지 판정. (a) babel.config.js 의 plugins 또는 (b) inline
+ * config (zts.config.ts `transformer.babel`) 중 하나라도 ZTS native list 외
+ * plugin/preset 이 있으면 true. 둘 다 0 → false (Babel pass skip).
  */
-export function detectCustomPlugins(projectRoot: string): boolean {
+export function detectCustomPlugins(projectRoot: string, inline?: InlineBabelConfig): boolean {
+  // preset/plugin 모두 동일한 native filter 적용 — `@react-native/babel-preset`
+  // 같은 ZTS native 처리 항목을 inline 으로 적은 경우 detect=true 가 되면 transformer
+  // pass 가 켜진 후 filter 에서 제거되어 사용자 의도 (native preset 동작) 가 silent
+  // drop. 둘 다 hasNonNative 통과 시점부터 진정한 custom 인 것.
+  if (inline?.presets && hasNonNative(inline.presets)) return true;
+  if (inline?.plugins && hasNonNative(inline.plugins)) return true;
   try {
     const configPath = join(projectRoot, "babel.config.js");
     if (!existsSync(configPath)) return false;
@@ -100,13 +125,7 @@ export function detectCustomPlugins(projectRoot: string): boolean {
     const projectRequire = createRequire(`${projectRoot}/package.json`);
     const config = projectRequire(configPath) as BabelConfigModule;
     const plugins: unknown[] = config?.plugins ?? [];
-    return plugins.some((p) => {
-      const name = typeof p === "string" ? p : Array.isArray(p) ? (p[0] as string) : "";
-      // 빈 string (number/object/null 같은 invalid plugin entry) 은 skip — bungae
-      // 의 minor bug fix (#2540): 원본은 빈 string 도 native 외 로 카운트해 false
-      // negative.
-      return typeof name === "string" && name !== "" && !isZtsNativePlugin(name);
-    });
+    return hasNonNative(plugins);
   } catch {
     return false;
   }
@@ -114,12 +133,13 @@ export function detectCustomPlugins(projectRoot: string): boolean {
 
 /**
  * Lazy Babel transformer factory. 첫 transform 호출 시점에 require('@babel/core')
- * + babel.config.js 평가. Babel options (preset / plugins / parser flag) 는
- * 한 번 빌드 후 캐시. Reanimated 같은 plugin 의 require.resolve 는 user 의
+ * + babel.config.js 평가 + inline config (zts.config.ts `transformer.babel`)
+ * concat. Babel options 한 번 빌드 후 캐시. plugin require.resolve 는 user 의
  * node_modules 우선 (Bun deep-link symlink 미생성 케이스 대비 fallback 명시).
  */
 export function createBabelTransformer(
   projectRoot: string,
+  inline?: InlineBabelConfig,
 ): (code: string, filename: string) => string | null {
   let babel: BabelInstance | null = null;
   let babelOptions: BabelTransformOptions | null = null;
@@ -154,6 +174,21 @@ export function createBabelTransformer(
         return requireFromCli.resolve(name);
       }
     }
+    function resolveEntry(entry: BabelEntry): unknown {
+      if (Array.isArray(entry)) {
+        try {
+          // 2nd/3rd 요소 (options + instanceName) 그대로 보존 — slice spread.
+          return [resolvePluginPath(entry[0]), ...entry.slice(1)];
+        } catch {
+          return entry;
+        }
+      }
+      try {
+        return resolvePluginPath(entry);
+      } catch {
+        return entry;
+      }
+    }
     babel = (() => {
       try {
         return projectRequire("@babel/core") as BabelInstance;
@@ -163,35 +198,35 @@ export function createBabelTransformer(
     })();
 
     const configPath = join(projectRoot, "babel.config.js");
-    const config = projectRequire(configPath) as BabelConfigModule;
-    const plugins: unknown[] = config?.plugins ?? [];
+    const fileConfig = existsSync(configPath)
+      ? (projectRequire(configPath) as BabelConfigModule)
+      : { plugins: [] };
+    const filePlugins: unknown[] = fileConfig?.plugins ?? [];
+    const inlinePlugins: unknown[] = inline?.plugins ?? [];
 
     const customPlugins: unknown[] = [];
-    for (const plugin of plugins) {
-      const name =
-        typeof plugin === "string" ? plugin : Array.isArray(plugin) ? (plugin[0] as string) : "";
-      if (typeof name === "string" && !isZtsNativePlugin(name)) {
-        if (Array.isArray(plugin)) {
-          try {
-            customPlugins.push([
-              resolvePluginPath(plugin[0] as string),
-              ...(plugin.slice(1) as unknown[]),
-            ]);
-          } catch {
-            customPlugins.push(plugin);
-          }
-        } else {
-          try {
-            customPlugins.push(resolvePluginPath(name));
-          } catch {
-            customPlugins.push(name);
-          }
+    for (const plugin of [...filePlugins, ...inlinePlugins]) {
+      const name = entryName(plugin);
+      if (typeof name === "string" && name !== "" && !isZtsNativePlugin(name)) {
+        customPlugins.push(resolveEntry(plugin as BabelEntry));
+      }
+    }
+
+    // ZTS 가 항상 추가하는 preset (TS strip) + 사용자 inline preset.
+    const customPresets: unknown[] = [
+      ["@babel/preset-typescript", { isTSX: true, allExtensions: true }],
+    ];
+    if (inline?.presets) {
+      for (const preset of inline.presets) {
+        const name = entryName(preset);
+        if (typeof name === "string" && name !== "" && !isZtsNativePlugin(name)) {
+          customPresets.push(resolveEntry(preset as BabelEntry));
         }
       }
     }
 
     babelOptions = {
-      presets: [["@babel/preset-typescript", { isTSX: true, allExtensions: true }]],
+      presets: customPresets,
       plugins: customPlugins,
       babelrc: false,
       configFile: false,
@@ -235,9 +270,9 @@ export function createBabelPlugin(config: PluginConfig): ZtsPlugin {
   return {
     name: "zts:react-native:babel-transform",
     setup(build) {
-      if (!detectCustomPlugins(config.projectRoot)) return;
+      if (!detectCustomPlugins(config.projectRoot, config.inlineBabel)) return;
 
-      const transformer = createBabelTransformer(config.projectRoot);
+      const transformer = createBabelTransformer(config.projectRoot, config.inlineBabel);
 
       const extPatterns = config.sourceExts.map((e) => e.replace(/^\./, "")).join("|");
       const sourcePattern = new RegExp(`\\.(${extPatterns})$`);

--- a/packages/react-native/src/plugins/types.ts
+++ b/packages/react-native/src/plugins/types.ts
@@ -1,6 +1,12 @@
 // Plugin factory 들의 공통 config. asset / babel / codegen / require-context /
 // metro-resolve-request 모두 RN-specific 환경 인자 동일 set 공유.
 
+/** Inline babel config — Metro `transformer.babel` 호환. */
+export interface InlineBabelConfig {
+  presets?: (string | [string, Record<string, unknown>])[];
+  plugins?: (string | [string, Record<string, unknown>])[];
+}
+
 export interface PluginConfig {
   /** RN 프로젝트 root — Babel/codegen plugin resolve 의 base. */
   projectRoot: string;
@@ -12,4 +18,10 @@ export interface PluginConfig {
   sourceExts: string[];
   /** Metro 호환 custom file transformer path (예: react-native-svg-transformer). */
   babelTransformerPath?: string;
+  /**
+   * Inline babel preset / plugin (zts.config.ts 의 `transformer.babel`). 사용자
+   * babel.config.js 의 plugins 와 concat 되며 양쪽 모두 ZTS native filter 통과
+   * 후 babel pass 에 등록.
+   */
+  inlineBabel?: InlineBabelConfig;
 }

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -215,6 +215,27 @@ describe("buildRnBundleOptions — define / banner / footer / polyfills", () => 
     const opts = buildRnBundleOptions(baseInput());
     expect(opts.runBeforeMain).toBeUndefined();
   });
+
+  test("extra.prelude — 사용자 prelude 가 projectRoot 기준 절대화 + runBeforeMain 에 append", () => {
+    const opts = buildRnBundleOptions(
+      baseInput({ extra: { prelude: ["./shims/extra-prelude.js"] } }),
+    );
+    expect(opts.runBeforeMain).toEqual([join(dir, "shims/extra-prelude.js")]);
+  });
+
+  test("extra.prelude — 절대 경로 그대로 보존 + 다중 항목 순서 보존", () => {
+    const opts = buildRnBundleOptions(
+      baseInput({
+        extra: { prelude: ["/abs/early.js", "./relative-late.js"] },
+      }),
+    );
+    expect(opts.runBeforeMain).toEqual(["/abs/early.js", join(dir, "relative-late.js")]);
+  });
+
+  test("extra.prelude — 빈 배열은 runBeforeMain 미정의 (preset 의 InitializeCore 도 미설치 fixture)", () => {
+    const opts = buildRnBundleOptions(baseInput({ extra: { prelude: [] } }));
+    expect(opts.runBeforeMain).toBeUndefined();
+  });
 });
 
 describe("buildRnBundleOptions — dev mode 분기 (jsx / devMode / reactRefresh / collectModuleCodes)", () => {

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -38,6 +38,7 @@ import {
   type MetroResolveRequestOptions,
 } from "./plugins/metro-resolve-request.ts";
 import { createRequireContextPlugin } from "./plugins/require-context.ts";
+import type { InlineBabelConfig } from "./plugins/types.ts";
 import { resolveRnPolyfills, RN_GLOBAL_IDENTIFIERS, tryResolve } from "./rn-constants.ts";
 
 export interface RnBundleInput {
@@ -89,6 +90,23 @@ export interface RnBundleInput {
      * runtime-time prelude 의 globals declaration (RN 코드 도착 전에 평가).
      */
     extraVars?: Record<string, unknown>;
+    /**
+     * Entry 전 실행할 module path (Metro `serializer.prelude` 호환). 절대 경로 또는
+     * projectRoot 기준 상대 경로. preset 의 `runBeforeMain` (InitializeCore) 와 concat
+     * 되어 RN runtime 부팅 직후 / entry 전에 실행. babel.config.js 같은 transform 영역
+     * 이 아닌 **번들에 prepend 되는 module list**.
+     */
+    prelude?: string[];
+    /**
+     * 사용자 babel preset / plugin (Metro `transformer.babel` 호환). babel.config.js
+     * 외에 zts.config.ts 안에서 inline 으로 babel 설정. ZTS native 처리 plugin (TS
+     * strip / RN preset / Reanimated 등) 은 자동 제외 — 충돌 회피.
+     *
+     * 사용자 babel.config.js 의 plugins 와 concat 되며 양쪽 모두 ZTS native filter
+     * 통과 후 babel pass 에 forward. presets 는 zts 가 추가하는 `preset-typescript`
+     * 외에 추가됨.
+     */
+    babel?: InlineBabelConfig;
   };
   /** RN prelude 끝에 append 할 사용자 banner string. */
   bannerExtras?: string;
@@ -250,6 +268,7 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
       assetExts,
       rnPlatform,
       sourceExts,
+      inlineBabel: extra?.babel,
     }),
     createRequireContextPlugin(),
   ];
@@ -275,6 +294,11 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
   const runBeforeMain: string[] = [];
   const initCore = tryResolve("react-native/Libraries/Core/InitializeCore", projectRoot);
   if (initCore) runBeforeMain.push(initCore);
+  if (extra?.prelude && extra.prelude.length > 0) {
+    // 사용자 추가 prelude — InitializeCore 이후에 실행. 절대/상대 모두 projectRoot
+    // 기준으로 정규화.
+    for (const p of extra.prelude) runBeforeMain.push(resolve(projectRoot, p));
+  }
 
   const define: Record<string, string> = {
     global: "__ZTS_RN_GLOBAL__",


### PR DESCRIPTION
## 요약

PR #2630 audit 후속 — Metro 의 \`serializer.prelude\` (entry 전 실행 module list) 와 \`transformer.babel\` (사용자 inline babel preset/plugin) 을 zts 가 매핑. 번개 zts-bundler 도 silent drop 했던 영역이지만 zts NAPI 의 \`runBeforeMain\` / \`createBabelPlugin\` 으로 직접 forward 가능 — \`UNSUPPORTED_FIELDS\` 에서 제거.

## 매핑

| Metro 필드 | zts 매핑 위치 | 동작 |
|------|------|------|
| \`serializer.prelude\` (file path array) | \`BuildOptions.runBeforeMain\` | preset 의 InitializeCore 뒤에 projectRoot 정규화 후 push |
| \`transformer.babel.plugins\` | \`createBabelPlugin\` 의 \`inlineBabel\` | babel.config.js plugins 와 concat → ZTS native filter → Babel pass forward |
| \`transformer.babel.presets\` | 동일 | zts default \`preset-typescript\` 외에 추가 |

## 변경 파일

1. **\`packages/react-native/src/preset.ts\`**: \`RnBundleInput.extra\` 에 \`prelude?: string[]\` + \`babel?: InlineBabelConfig\` 추가. \`buildRnBundleOptions\` 가 prelude 를 InitializeCore 뒤에 정규화 후 push.
2. **\`packages/react-native/src/plugins/types.ts\`**: 새 \`InlineBabelConfig\` interface, \`PluginConfig.inlineBabel\` 추가.
3. **\`packages/react-native/src/plugins/babel.ts\`**:
   - \`entryName\` / \`hasNonNative\` 헬퍼 추출 — file/inline plugins 같은 detect 로직 공유.
   - \`detectCustomPlugins(projectRoot, inline?)\` — inline.presets 도 \`hasNonNative\` 통과 시 true (native preset silent drop 방지).
   - \`createBabelTransformer(projectRoot, inline?)\` — file + inline plugins concat, \`resolveEntry\` 가 babel 의 3-tuple \`[name, options, instanceName]\` spread 보존.
4. **\`packages/core/bin/rn-dev-input.mjs\`**: \`UNSUPPORTED_FIELDS\` 에서 \`serializer.prelude\` / \`transformer.babel\` 제거. \`bundle.extra\` 에 두 필드 forward.

## 테스트

신규 11건 (총 90+ pass):
- \`preset.test.ts\`: \`extra.prelude\` 3건 (절대화/다중항목/빈배열)
- \`babel.test.ts\`: \`detectCustomPlugins\` inline 6건 (native preset silent drop 방지 포함)
- \`zts.test.ts\`: \`buildRnDevServerInput\` 의 prelude/babel 매핑 + warning 부재 검증 2건

## /simplify

3-agent review 후 finding 3건 반영:
1. **Reuse**: \`InlineBabelConfig\` 중복 제거 — preset.ts 가 plugins/types.ts 에서 import
2. **Quality**: \`detectCustomPlugins\` 의 \`inline.presets\` 도 \`hasNonNative\` 통과 — 사용자가 \`@react-native/babel-preset\` 같은 native preset 을 inline 으로 적은 경우 detect=true → filter 에서 제거 → silent drop 시나리오 방지
3. **Quality**: \`BabelEntry\` 가 3-tuple \`[name, options, instanceName]\` 받도록 + \`slice(1)\` spread 로 보존 — Babel 의 multi-instance plugin/preset 구분용 3번째 요소 누락 안 함

## 검증

- \`bun test packages/react-native/src\` — 90+ pass
- \`bun test packages/core/bin/zts.test.ts -t buildRnDevServerInput\` — 25 pass
- \`bun run --cwd packages/react-native build\` 통과

## 후속

이번 매핑 후 \`UNSUPPORTED_FIELDS\` 에 남는 진짜 미지원 5종:
- \`transformer.inlineRequires\` (Metro lazy require — zts NAPI 미지원)
- \`transformer.minifier\` (zts 자체 minifier 만)
- \`serializer.bundleType\` (zts 단일 형식)
- \`server.forwardClientLogs\` / \`verifyConnections\` (bungae 도 declared-only placeholder)

이들은 Zig 측 변경이 필요한 큰 작업 — 별도 epic 으로.

Refs #2605

🤖 Generated with [Claude Code](https://claude.com/claude-code)