### PR TITLE
fix(react-native): preset banner 에 top-level globalThis 할당 제거 (iOS 26.4 Hermes parity)

### DIFF
--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -125,9 +125,13 @@ describe("buildRnBundleOptions — define / banner / footer / polyfills", () => 
     expect(opts.footer).toContain("DevLoadingView.hide");
   });
 
-  test("dev=false — footer 미정의", () => {
+  test("dev=false — footer 에 IIFE-wrapped __ZTS_RN_BUNDLER__ flag (DevLoadingView 없음)", () => {
     const opts = buildRnBundleOptions(baseInput({ dev: false }));
-    expect(opts.footer).toBeUndefined();
+    // prod 도 IIFE flag 는 emit (iOS 26.4 spec global trigger 회피 + identifier 표식 유지)
+    expect(opts.footer).toContain("__ZTS_RN_BUNDLER__");
+    expect(opts.footer).toMatch(/\(function\(g\)\{g\.__ZTS_RN_BUNDLER__/);
+    // dev-only 는 부재
+    expect(opts.footer).not.toContain("DevLoadingView.hide");
   });
 
   test("polyfills — resolveRnPolyfills miss 시 미정의 (caller 가 default 빈 배열)", () => {

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -98,12 +98,14 @@ describe("buildRnBundleOptions — define / banner / footer / polyfills", () => 
     expect(opts.define?.["process.env.NODE_ENV"]).toBe('"production"');
   });
 
-  test("banner — RN prelude 5 핵심 라인 포함", () => {
+  test("banner — RN prelude 4 핵심 라인 포함 (top-level globalThis assignment 없음 — iOS 26.4 회피)", () => {
     const opts = buildRnBundleOptions(baseInput({ dev: true }));
     expect(opts.banner).toContain("__BUNDLE_START_TIME__");
     expect(opts.banner).toContain("__DEV__=true");
     expect(opts.banner).toContain("__ZTS_RN_GLOBAL__");
-    expect(opts.banner).toContain("__ZTS_RN_BUNDLER__");
+    // __ZTS_RN_BUNDLER__ 는 footer 의 IIFE 안에서 set — banner 에 직접 두면 iOS 26.4+
+    // Hermes 가 spec global lazy registration trigger.
+    expect(opts.banner).not.toContain("globalThis.__ZTS_RN_BUNDLER__");
     expect(opts.banner).not.toContain("__BUNGAE_");
   });
 
@@ -115,8 +117,11 @@ describe("buildRnBundleOptions — define / banner / footer / polyfills", () => 
     expect(opts.banner?.endsWith('globalThis.__APP_VERSION__="1.0";')).toBe(true);
   });
 
-  test("dev=true — footer (DevLoadingView hide) 포함", () => {
+  test("dev=true — footer 에 IIFE-wrapped __ZTS_RN_BUNDLER__ flag + DevLoadingView hide 포함", () => {
     const opts = buildRnBundleOptions(baseInput({ dev: true }));
+    // top-level globalThis assignment 회피 — IIFE 안에서 set
+    expect(opts.footer).toContain("__ZTS_RN_BUNDLER__");
+    expect(opts.footer).toMatch(/\(function\(g\)\{g\.__ZTS_RN_BUNDLER__/);
     expect(opts.footer).toContain("DevLoadingView.hide");
   });
 

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -164,13 +164,18 @@ function formatExtraVars(extraVars: Record<string, unknown>): string {
 
 function buildPrelude(input: RnBundleInput): string {
   const { dev, bannerExtras, extra } = input;
+  // ⚠️ 중요: 이 prelude 에 **top-level `globalThis.X = ...` 또는 `globalThis.X = ...` 의 직접 assignment**
+  // 를 두면 안 된다. iOS 26.4+ Hermes 가 parse 시점에 spec global (`Location`, `TextEncoderStream`
+  // 등) placeholder 를 `configurable: false` 로 lazy 등록 → 그 후 Reanimated/Expo 의 가드 없는
+  // `Object.defineProperty(globalThis, ...)` 시도 → throw → 부팅 실패. Metro bundle 도 모든
+  // globalThis assignment 를 module factory 안 (nested scope) 에 두는 패턴이라 trigger 회피.
+  // 추가 식별자가 필요하면 `__ZTS_RN_BUNDLER__` 처럼 footer 의 IIFE 안에서 세팅.
   const lines = [
     `var __BUNDLE_START_TIME__=this.nativePerformanceNow?nativePerformanceNow():Date.now();`,
     `var __DEV__=${dev};`,
     `var __ZTS_RN_GLOBAL__=typeof globalThis!=='undefined'?globalThis:typeof global!=='undefined'?global:typeof window!=='undefined'?window:this;`,
     `if(typeof global==='undefined')var global=__ZTS_RN_GLOBAL__;`,
     `var process=__ZTS_RN_GLOBAL__.process||{};process.env=process.env||{};process.env.NODE_ENV=process.env.NODE_ENV||"${dev ? "development" : "production"}";`,
-    `globalThis.__ZTS_RN_BUNDLER__=true;`,
   ];
   if (extra?.extraVars && Object.keys(extra.extraVars).length > 0) {
     const formatted = formatExtraVars(extra.extraVars);
@@ -178,6 +183,21 @@ function buildPrelude(input: RnBundleInput): string {
   }
   if (bannerExtras) lines.push(bannerExtras);
   return lines.join("");
+}
+
+/**
+ * Footer 의 식별자 wrap — `globalThis.X = ...` 를 IIFE 안에서 실행해 iOS 26.4+ Hermes 의
+ * spec global lazy registration trigger 를 회피. `buildPrelude` 의 주석 참조.
+ */
+function buildFooter(dev: boolean): string {
+  const parts: string[] = [
+    // __ZTS_RN_BUNDLER__ flag — IIFE 안에서 set 해야 안전
+    `(function(g){g.__ZTS_RN_BUNDLER__=true;})(typeof globalThis!=='undefined'?globalThis:typeof global!=='undefined'?global:typeof window!=='undefined'?window:this);`,
+  ];
+  if (dev) {
+    parts.push(`setTimeout(function(){try{NativeModules.DevLoadingView.hide()}catch(e){}},0);`);
+  }
+  return parts.join("");
 }
 
 function resolveWorkletPluginVersion(
@@ -323,7 +343,9 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
     preset.devMode = true;
     preset.reactRefresh = true;
     preset.collectModuleCodes = true;
-    preset.footer = "setTimeout(function(){try{NativeModules.DevLoadingView.hide()}catch(e){}},0);";
+    // Footer 는 dev 시만 — `__ZTS_RN_BUNDLER__` flag 를 IIFE 로 wrap 해 iOS 26.4+ Hermes
+    // spec global trigger 회피 (`buildPrelude` 의 주석 참조) + DevLoadingView hide.
+    preset.footer = buildFooter(true);
   }
 
   if (extra?.watchFolders && extra.watchFolders.length > 0) {

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -338,14 +338,16 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
   const workletVersion = resolveWorkletPluginVersion(projectRoot, input.workletPluginVersion);
   if (workletVersion) preset.workletPluginVersion = workletVersion;
 
+  // Footer 는 항상 — `__ZTS_RN_BUNDLER__` flag 를 IIFE 로 wrap 해 iOS 26.4+ Hermes
+  // spec global trigger 회피 (`buildPrelude` 의 주석 참조). dev 시 DevLoadingView
+  // hide 도 추가.
+  preset.footer = buildFooter(dev);
+
   if (dev) {
     preset.jsx = "automatic-dev";
     preset.devMode = true;
     preset.reactRefresh = true;
     preset.collectModuleCodes = true;
-    // Footer 는 dev 시만 — `__ZTS_RN_BUNDLER__` flag 를 IIFE 로 wrap 해 iOS 26.4+ Hermes
-    // spec global trigger 회피 (`buildPrelude` 의 주석 참조) + DevLoadingView hide.
-    preset.footer = buildFooter(true);
   }
 
   if (extra?.watchFolders && extra.watchFolders.length > 0) {


### PR DESCRIPTION
## Summary
iOS 26.4+ Hermes 가 parse 시점에 **top-level `globalThis.X = ...`** 구문을 감지하면 spec global (`Location`, `TextEncoderStream` 등) placeholder 를 `configurable: false` 로 lazy 등록 → 그 후 Reanimated/Expo 의 가드 없는 `Object.defineProperty(globalThis, ...)` 시도 시 throw → 부팅 / 런타임 크래시.

ZTS preset 의 prelude 가 `globalThis.__ZTS_RN_BUNDLER__=true;` 를 top-level 에 직접 두고 있어 이 trigger 에 노출. **번개 napi-build.ts** 는 이미 명시적으로 IIFE wrap 으로 회피하는 패턴 — ZTS preset 도 동일하게 align.

## Why bungae 에선 됐나 (parity)

번개의 `napi-build.ts` (L380~) 는:
```js
const footer = [
  `(function(g){g.__BUNGAE_BUNDLER__=true;...})(typeof globalThis!=='undefined'?globalThis:...);`,
  'setTimeout(function(){try{NativeModules.DevLoadingView.hide()}catch(e){}},0);',
].join('');
```

footer 의 IIFE 안에서만 `globalThis.X` 할당. banner 에는 top-level globalThis assignment 일체 없음. 이 패턴이 iOS 26.4 회피.

ZTS preset 은 banner 마지막 줄이 `globalThis.__ZTS_RN_BUNDLER__=true;` (top-level) → 정확히 trigger 패턴.

## Fix

**preset.ts** `buildPrelude` 에서 `globalThis.__ZTS_RN_BUNDLER__=true;` 라인 제거 + 신규 `buildFooter(dev)` 헬퍼:

```ts
function buildFooter(dev: boolean): string {
  const parts = [
    `(function(g){g.__ZTS_RN_BUNDLER__=true;})(typeof globalThis!=='undefined'?globalThis:typeof global!=='undefined'?global:typeof window!=='undefined'?window:this);`,
  ];
  if (dev) {
    parts.push(`setTimeout(function(){try{NativeModules.DevLoadingView.hide()}catch(e){}},0);`);
  }
  return parts.join("");
}
```

dev 시 footer = IIFE flag + DevLoadingView hide. prod 시 IIFE flag 만. (번개와 동등 패턴)

## Test
- **banner**: `globalThis.__ZTS_RN_BUNDLER__` 미포함 검증
- **footer**: IIFE wrap 정규식 매치 + DevLoadingView hide 포함 검증

총 46 tests pass.

## Out of scope
이 fix 는 iOS 26.4 spec global trigger 회피 — bare RN 예제의 `LayoutAnimationsManager::startLayoutAnimation` worklet runtime 크래시 (`SIGABRT`) 는 별도 layer 의 이슈로 추가 조사 필요. 현재 PR 은 bungae 와의 parity 만.

## Test plan
- [ ] `bun test packages/react-native/src/preset.test.ts` 통과 (46 pass)
- [ ] iOS 26.4 시뮬레이터 부팅 시 spec global 충돌 미발생
- [ ] 번들 출력의 banner 첫 줄 ~ 마지막 줄에 `globalThis.X=` 패턴 부재
- [ ] footer 끝에 IIFE-wrapped flag 존재

🤖 Generated with [Claude Code](https://claude.com/claude-code)