### PR TITLE
feat(react-native): bungae parity cleanup — dev-middleware boundary + HMR BuildError + asset ext (#2605 audit)

### DIFF
--- a/packages/react-native/runtime/zts-hmr-client.js
+++ b/packages/react-native/runtime/zts-hmr-client.js
@@ -180,7 +180,21 @@ var HMRClient = {
             }
             break;
           case 'hmr:error':
-            if (msg.message) {
+            // body.errors 가 있으면 file:line:col 정보를 함께 출력 — RN LogBox 가
+            // source link 자동 추출 → 클릭 시 editor jump. backward-compat 으로
+            // body 가 없는 메시지는 단순 message 만 출력.
+            if (msg.body && msg.body.errors && msg.body.errors[0]) {
+              var err = msg.body.errors[0];
+              // filename / lineNumber / column 은 type 상 모두 optional.
+              // 셋 다 있을 때만 location 부착 — 없으면 'foo.ts:undefined:undefined' 같은
+              // false-positive 회피.
+              var hasLoc =
+                err.filename &&
+                typeof err.lineNumber === 'number' &&
+                typeof err.column === 'number';
+              var loc = hasLoc ? ' ' + err.filename + ':' + err.lineNumber + ':' + err.column : '';
+              console.error('[ZTS HMR]' + loc, err.description || msg.message);
+            } else if (msg.message) {
               console.error('[ZTS HMR]', msg.message);
             }
             break;

--- a/packages/react-native/src/dev-server/hmr-bridge.test.ts
+++ b/packages/react-native/src/dev-server/hmr-bridge.test.ts
@@ -86,13 +86,17 @@ describe('createHmrBridge — onRebuild', () => {
     expect(recorded).toEqual([]);
   });
 
-  test('success=false → error 메시지 (state.buildError 우선)', () => {
+  test('success=false → error 메시지 (state.buildError 우선) + body wrapper', () => {
     const bridge = createHmrBridge({ path: '/hot' });
     const recorded = recordMessages(bridge.adapter);
     const state = fakeState();
     state.buildError = 'from state';
     bridge.callbacks.onRebuild!(state, rebuild({ success: false, error: 'from event' } as never));
-    expect(recorded[0]).toEqual({ type: 'hmr:error', message: 'from state' });
+    expect(recorded[0]).toEqual({
+      type: 'hmr:error',
+      message: 'from state',
+      body: { type: 'BuildError', message: 'from state', errors: [{ description: 'from state' }] },
+    });
   });
 
   test('success=false + state.buildError null → event.error 사용', () => {
@@ -102,14 +106,26 @@ describe('createHmrBridge — onRebuild', () => {
       fakeState(),
       rebuild({ success: false, error: 'syntax bad' } as never),
     );
-    expect(recorded[0]).toEqual({ type: 'hmr:error', message: 'syntax bad' });
+    expect(recorded[0]).toEqual({
+      type: 'hmr:error',
+      message: 'syntax bad',
+      body: { type: 'BuildError', message: 'syntax bad', errors: [{ description: 'syntax bad' }] },
+    });
   });
 
   test('success=false 에서 둘 다 null → fallback 메시지', () => {
     const bridge = createHmrBridge({ path: '/hot' });
     const recorded = recordMessages(bridge.adapter);
     bridge.callbacks.onRebuild!(fakeState(), rebuild({ success: false } as never));
-    expect(recorded[0]).toEqual({ type: 'hmr:error', message: 'Unknown build error' });
+    expect(recorded[0]).toEqual({
+      type: 'hmr:error',
+      message: 'Unknown build error',
+      body: {
+        type: 'BuildError',
+        message: 'Unknown build error',
+        errors: [{ description: 'Unknown build error' }],
+      },
+    });
   });
 });
 

--- a/packages/react-native/src/dev-server/http-server.ts
+++ b/packages/react-native/src/dev-server/http-server.ts
@@ -9,7 +9,7 @@ import * as jscSafeUrl from 'jsc-safe-url';
 import type { HmrBridge } from './hmr-bridge.ts';
 import { parseRequestUrl, sendText } from './http-utils.ts';
 import type { CliServerApi } from './middleware/cli-server-api.ts';
-import { DEV_MIDDLEWARE_PATH_PREFIXES, type DevMiddleware } from './middleware/dev-middleware.ts';
+import { type DevMiddleware, isDevMiddlewareRoute } from './middleware/dev-middleware.ts';
 import type { RnDevServerOptions } from './options.ts';
 import type { PlatformStateRegistry } from './platform-state.ts';
 import { handleAssetRequest, isAssetRoute } from './routes/assets.ts';
@@ -133,7 +133,7 @@ export function createBaseMiddleware(
     }
     // dev-middleware (peer optional) — /json, /open-debugger, /debugger-frontend,
     // /launch-js-devtools 처리. 미설치 시 next() 로 fallthrough.
-    if (deps.devMiddleware && DEV_MIDDLEWARE_PATH_PREFIXES.some((p) => pathname.startsWith(p))) {
+    if (deps.devMiddleware && isDevMiddlewareRoute(pathname)) {
       deps.devMiddleware.middleware(req, res, next);
       return;
     }

--- a/packages/react-native/src/dev-server/middleware/dev-middleware.test.ts
+++ b/packages/react-native/src/dev-server/middleware/dev-middleware.test.ts
@@ -3,7 +3,11 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { DEV_MIDDLEWARE_PATH_PREFIXES, loadDevMiddleware } from './dev-middleware.ts';
+import {
+  DEV_MIDDLEWARE_PATH_PREFIXES,
+  isDevMiddlewareRoute,
+  loadDevMiddleware,
+} from './dev-middleware.ts';
 
 let dir: string;
 
@@ -25,6 +29,38 @@ describe('DEV_MIDDLEWARE_PATH_PREFIXES', () => {
       '/debugger-frontend',
       '/launch-js-devtools',
     ]);
+  });
+});
+
+describe('isDevMiddlewareRoute — 정확 경계 매칭 (#2605 audit)', () => {
+  test('정확한 prefix 매칭 — true', () => {
+    expect(isDevMiddlewareRoute('/json')).toBe(true);
+    expect(isDevMiddlewareRoute('/open-debugger')).toBe(true);
+    expect(isDevMiddlewareRoute('/debugger-frontend')).toBe(true);
+    expect(isDevMiddlewareRoute('/launch-js-devtools')).toBe(true);
+  });
+
+  test('슬래시 경계 + tail — true', () => {
+    expect(isDevMiddlewareRoute('/json/list')).toBe(true);
+    expect(isDevMiddlewareRoute('/debugger-frontend/index.html')).toBe(true);
+    expect(isDevMiddlewareRoute('/open-debugger/something')).toBe(true);
+  });
+
+  test('substring false-positive 방지 — `/jsonbomb` / `/jsonish` → false', () => {
+    expect(isDevMiddlewareRoute('/jsonbomb')).toBe(false);
+    expect(isDevMiddlewareRoute('/jsonish')).toBe(false);
+    expect(isDevMiddlewareRoute('/open-debugger-x')).toBe(false);
+    expect(isDevMiddlewareRoute('/debugger-frontends')).toBe(false);
+  });
+
+  test('비매치 path — false', () => {
+    expect(isDevMiddlewareRoute('/')).toBe(false);
+    expect(isDevMiddlewareRoute('/index.bundle')).toBe(false);
+    expect(isDevMiddlewareRoute('/status')).toBe(false);
+  });
+
+  test('빈 string — false', () => {
+    expect(isDevMiddlewareRoute('')).toBe(false);
   });
 });
 

--- a/packages/react-native/src/dev-server/middleware/dev-middleware.ts
+++ b/packages/react-native/src/dev-server/middleware/dev-middleware.ts
@@ -99,3 +99,12 @@ export const DEV_MIDDLEWARE_PATH_PREFIXES = [
   '/debugger-frontend',
   '/launch-js-devtools',
 ];
+
+/**
+ * dev-middleware path prefix 의 정확 경계 매칭. `/jsonbomb` 같은 우연한
+ * substring 일치를 막기 위해 정확한 path 또는 슬래시 경계 + tail 만 허용.
+ * bungae Server.js 의 prefix 매칭과 동일 패턴 (#2605 audit).
+ */
+export function isDevMiddlewareRoute(pathname: string): boolean {
+  return DEV_MIDDLEWARE_PATH_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+}

--- a/packages/react-native/src/metro-hmr-adapter.test.ts
+++ b/packages/react-native/src/metro-hmr-adapter.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import { type BunHmrClient, HMR_RN_MSG } from '@zts/server';
 
-import { createMetroHmrAdapter } from './metro-hmr-adapter.ts';
+import { createMetroHmrAdapter, formatBuildError } from './metro-hmr-adapter.ts';
 
 class MockBunClient implements BunHmrClient {
   sent: string[] = [];
@@ -72,14 +72,93 @@ describe('createMetroHmrAdapter', () => {
     expect(parsedSent(client)).toEqual([{ type: HMR_RN_MSG.Reload }]);
   });
 
-  test('sendError — Error{message}', () => {
+  test('sendError — Error{message, body:BuildError} (Metro LogBox 호환, #2605 audit)', () => {
     const adapter = createMetroHmrAdapter();
     const client = new MockBunClient();
     adapter.channel.addBunClient(client);
     resetSent(client);
 
     adapter.sendError('boom');
-    expect(parsedSent(client)).toEqual([{ type: HMR_RN_MSG.Error, message: 'boom' }]);
+    expect(parsedSent(client)).toEqual([
+      {
+        type: HMR_RN_MSG.Error,
+        message: 'boom',
+        body: { type: 'BuildError', message: 'boom', errors: [{ description: 'boom' }] },
+      },
+    ]);
+  });
+
+  test('sendError — file:line:col 추출 시 body.errors[0] 에 filename/lineNumber/column', () => {
+    const adapter = createMetroHmrAdapter();
+    const client = new MockBunClient();
+    adapter.channel.addBunClient(client);
+    resetSent(client);
+
+    const msg = "Failed to compile.\n/proj/src/App.tsx:42:7: error: Unexpected token '}'";
+    adapter.sendError(msg);
+    const sent = parsedSent(client)[0] as {
+      type: string;
+      message: string;
+      body: {
+        type: string;
+        errors: Array<{
+          description: string;
+          filename?: string;
+          lineNumber?: number;
+          column?: number;
+        }>;
+      };
+    };
+    expect(sent.body.errors[0]).toEqual({
+      description: msg,
+      filename: '/proj/src/App.tsx',
+      lineNumber: 42,
+      column: 7,
+    });
+  });
+});
+
+describe('formatBuildError — Metro 호환 BuildError body 변환 (#2605 audit)', () => {
+  test('file:line:col 매칭 — errors[0] 에 분리', () => {
+    const result = formatBuildError('/abs/path/foo.ts:10:5: error: bad');
+    expect(result).toEqual({
+      type: 'BuildError',
+      message: '/abs/path/foo.ts:10:5: error: bad',
+      errors: [
+        {
+          description: '/abs/path/foo.ts:10:5: error: bad',
+          filename: '/abs/path/foo.ts',
+          lineNumber: 10,
+          column: 5,
+        },
+      ],
+    });
+  });
+
+  test('.tsx / .jsx / .mjs 다양한 ext 매칭', () => {
+    expect(formatBuildError('a/b.tsx:1:2: x').errors[0]?.filename).toBe('a/b.tsx');
+    expect(formatBuildError('a/b.jsx:1:2: x').errors[0]?.filename).toBe('a/b.jsx');
+    expect(formatBuildError('a/b.js:1:2: x').errors[0]?.filename).toBe('a/b.js');
+  });
+
+  test('위치 매칭 실패 — description 만 (file/line/col undefined)', () => {
+    const result = formatBuildError('Generic error without location');
+    expect(result.errors).toEqual([{ description: 'Generic error without location' }]);
+    expect(result.message).toBe('Generic error without location');
+  });
+
+  test('빈 message — fallback (description 만)', () => {
+    const result = formatBuildError('');
+    expect(result.errors).toEqual([{ description: '' }]);
+    expect(result.message).toBe('');
+  });
+
+  test('multiline error — 첫 위치 매칭 추출', () => {
+    const msg = 'Build error:\n/proj/src/x.ts:5:3: SyntaxError\n  more lines\n  /proj/src/y.ts:9:1';
+    const result = formatBuildError(msg);
+    expect(result.errors[0]?.filename).toBe('/proj/src/x.ts');
+    expect(result.errors[0]?.lineNumber).toBe(5);
+    expect(result.errors[0]?.column).toBe(3);
   });
 
   test('multi client broadcast — 모든 client 가 같은 메시지 받음', () => {

--- a/packages/react-native/src/metro-hmr-adapter.ts
+++ b/packages/react-native/src/metro-hmr-adapter.ts
@@ -9,8 +9,34 @@ import {
   createHmrChannel,
   type HmrChannel,
   HMR_RN_MSG,
+  type HmrRnErrorBody,
+  type HmrRnErrorEntry,
   type HmrRnUpdateModule,
 } from '@zts/server';
+
+// ZTS error string 의 위치 추출 — `<file>.tsx?:<line>:<col>` 형태. Metro 의
+// BuildError 의 file:line:col 과 같은 형식으로 정규화 — RN LogBox 의 source link.
+const ZTS_LOCATION_RE = /([^\s]+\.[jt]sx?):(\d+):(\d+)/;
+
+/**
+ * ZTS build error → Metro 호환 `BuildError` body 로 변환. file:line:col 추출
+ * 실패해도 단일 entry 의 description 만으로 fallback. bungae 의 formatHmrError
+ * (zts-bundler/server/index.ts L824) 와 동일 로직 (#2605 audit).
+ */
+export function formatBuildError(message: string): HmrRnErrorBody {
+  const match = message.match(ZTS_LOCATION_RE);
+  const errors: HmrRnErrorEntry[] = match
+    ? [
+        {
+          description: message,
+          filename: match[1]!,
+          lineNumber: Number.parseInt(match[2]!, 10),
+          column: Number.parseInt(match[3]!, 10),
+        },
+      ]
+    : [{ description: message }];
+  return { type: 'BuildError', message, errors };
+}
 
 export interface MetroHmrAdapter {
   /**
@@ -51,7 +77,11 @@ export function createMetroHmrAdapter(): MetroHmrAdapter {
       channel.broadcast({ type: HMR_RN_MSG.Reload });
     },
     sendError(message) {
-      channel.broadcast({ type: HMR_RN_MSG.Error, message });
+      channel.broadcast({
+        type: HMR_RN_MSG.Error,
+        message,
+        body: formatBuildError(message),
+      });
     },
   };
 }

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -344,6 +344,26 @@ describe('buildRnBundleOptions — loader / alias', () => {
     expect(opts.loader?.['.svg']).toBe('file');
   });
 
+  test('loader — Metro 호환 default 폰트/이미지 확장자 모두 등록 (#2605 audit)', () => {
+    const opts = buildRnBundleOptions(baseInput());
+    // 폰트 — RN 흔한 use case (.woff/.woff2)
+    expect(opts.loader?.['.woff']).toBe('file');
+    expect(opts.loader?.['.woff2']).toBe('file');
+    // 이미지 — bmp/ico/avif 추가
+    expect(opts.loader?.['.bmp']).toBe('file');
+    expect(opts.loader?.['.ico']).toBe('file');
+    expect(opts.loader?.['.avif']).toBe('file');
+    // 비디오 — webm/mov
+    expect(opts.loader?.['.webm']).toBe('file');
+    expect(opts.loader?.['.mov']).toBe('file');
+    // 오디오 — aac/wav
+    expect(opts.loader?.['.aac']).toBe('file');
+    expect(opts.loader?.['.wav']).toBe('file');
+    // 문서 — yaml/yml
+    expect(opts.loader?.['.yaml']).toBe('file');
+    expect(opts.loader?.['.yml']).toBe('file');
+  });
+
   test('loader — assetExts override 적용', () => {
     const opts = buildRnBundleOptions(baseInput({ extra: { assetExts: ['.webp', '.woff2'] } }));
     expect(Object.keys(opts.loader ?? {}).sort()).toEqual(['.webp', '.woff2']);

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -115,21 +115,47 @@ export interface RnBundleInput {
 }
 
 const DEFAULT_SOURCE_EXTS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.json'];
+// Metro 호환 + RN 흔한 폰트/이미지 — bungae DEFAULT_RESOLVER.assetExts 와 동일.
+// caller 가 `extra.assetExts` 로 override 하면 이 list 무시.
 const DEFAULT_ASSET_EXTS = [
-  '.png',
+  // 이미지
+  '.bmp',
+  '.gif',
   '.jpg',
   '.jpeg',
-  '.gif',
-  '.webp',
+  '.png',
+  '.psd',
   '.svg',
-  '.ttf',
-  '.otf',
-  '.mp3',
-  '.mp4',
-  '.m4a',
+  '.webp',
+  '.tiff',
+  '.tif',
+  '.xml',
+  '.avif',
+  '.ico',
+  // 비디오
   '.m4v',
-  '.pdf',
+  '.mov',
+  '.mp4',
+  '.mpeg',
+  '.mpg',
+  '.webm',
+  // 오디오
+  '.aac',
+  '.aiff',
+  '.caf',
+  '.m4a',
+  '.mp3',
+  '.wav',
+  // 문서
   '.html',
+  '.pdf',
+  '.yaml',
+  '.yml',
+  // 폰트
+  '.otf',
+  '.ttf',
+  '.woff',
+  '.woff2',
 ];
 
 const NATIVE_AND_BASE = [

--- a/packages/react-native/src/runtime/zts-hmr-client.test.mjs
+++ b/packages/react-native/src/runtime/zts-hmr-client.test.mjs
@@ -254,11 +254,66 @@ describe('onmessage — Metro 메시지 분기', () => {
     expect(mockGlobal.__zts_reload).toHaveBeenCalled();
   });
 
-  test('hmr:error — console.error', () => {
+  test('hmr:error — console.error (backward-compat: body 없음)', () => {
     const ws = setupConnected();
     ws.onmessage({ data: JSON.stringify({ type: 'hmr:error', message: 'boom' }) });
     // setupConnected 의 onopen 이 console wrap — original 검증.
     expect(originalConsole.error).toHaveBeenCalledWith('[ZTS HMR]', 'boom');
+  });
+
+  test('hmr:error — body.errors[0].filename 있으면 file:line:col 포함 (#2605 audit)', () => {
+    const ws = setupConnected();
+    ws.onmessage({
+      data: JSON.stringify({
+        type: 'hmr:error',
+        message: 'fallback',
+        body: {
+          type: 'BuildError',
+          message: 'fallback',
+          errors: [
+            {
+              description: 'Unexpected token',
+              filename: '/proj/src/App.tsx',
+              lineNumber: 42,
+              column: 7,
+            },
+          ],
+        },
+      }),
+    });
+    expect(originalConsole.error).toHaveBeenCalledWith(
+      '[ZTS HMR] /proj/src/App.tsx:42:7',
+      'Unexpected token',
+    );
+  });
+
+  test('hmr:error — body.errors[0] 위치 정보 없음 → 단순 description', () => {
+    const ws = setupConnected();
+    ws.onmessage({
+      data: JSON.stringify({
+        type: 'hmr:error',
+        message: 'no-loc',
+        body: { type: 'BuildError', message: 'no-loc', errors: [{ description: 'no-loc' }] },
+      }),
+    });
+    expect(originalConsole.error).toHaveBeenCalledWith('[ZTS HMR]', 'no-loc');
+  });
+
+  test('hmr:error — filename 만 있고 lineNumber/column 누락 → location 부착 안 함 (#2605 audit)', () => {
+    const ws = setupConnected();
+    ws.onmessage({
+      data: JSON.stringify({
+        type: 'hmr:error',
+        message: 'partial',
+        body: {
+          type: 'BuildError',
+          message: 'partial',
+          errors: [{ description: 'partial', filename: '/proj/foo.ts' }],
+        },
+      }),
+    });
+    // 'foo.ts:undefined:undefined' 같은 false-positive 가 아닌 description 만.
+    expect(originalConsole.error).toHaveBeenCalledWith('[ZTS HMR]', 'partial');
   });
 
   test('disable() 후 hmr:error 만 통과, 그 외 메시지 무시', () => {

--- a/packages/server/src/protocol.ts
+++ b/packages/server/src/protocol.ts
@@ -119,9 +119,30 @@ export interface HmrRnReloadMessage {
   type: typeof HMR_RN_MSG.Reload;
 }
 
+/**
+ * Build error 한 항목 — file:line:col 정보 (가능한 경우). RN LogBox 의 source
+ * link 표시용.
+ */
+export interface HmrRnErrorEntry {
+  description: string;
+  filename?: string;
+  lineNumber?: number;
+  column?: number;
+}
+
+/** Metro `BuildError` body wrapper — RN HMRClient 의 LogBox 와 호환. */
+export interface HmrRnErrorBody {
+  type: 'BuildError';
+  message: string;
+  errors: HmrRnErrorEntry[];
+}
+
 export interface HmrRnErrorMessage {
   type: typeof HMR_RN_MSG.Error;
+  /** Backward-compat — 단순 텍스트 표시용 fallback. */
   message: string;
+  /** Metro 호환 nested wrapper — file:line:col 파싱 결과. */
+  body?: HmrRnErrorBody;
 }
 
 export interface HmrRnLogMessage {


### PR DESCRIPTION
## 요약

#2605 audit 의 P1 + P2 잔여 3건 단일 PR. 번개 zts-bundler 와의 parity 마무리.

## 변경 (P1 + P2)

### P1 #H — dev-middleware path 정확 경계 매칭
\`isDevMiddlewareRoute(pathname)\` helper — \`pathname === prefix || pathname.startsWith(prefix + '/')\` 로 \`/jsonbomb\` 같은 substring false-positive 방지. bungae Server.js 와 동일.

### P1 #I — HMR build-error Metro BuildError wrapper
RN LogBox 의 source link / editor jump 가 동작하도록 build error 응답을 Metro 호환 형식으로 변경.

\`\`\`ts
{
  type: 'hmr:error',
  message: string,
  body: {
    type: 'BuildError',
    message: string,
    errors: [{ description, filename?, lineNumber?, column? }]
  }
}
\`\`\`

- \`packages/server/src/protocol.ts\`: \`HmrRnErrorEntry\` / \`HmrRnErrorBody\` 신설, \`HmrRnErrorMessage.body?\` 추가 (backward-compat optional)
- \`packages/react-native/src/metro-hmr-adapter.ts\`: 새 \`formatBuildError(message)\` 가 ZTS error 의 file:line:col 추출 후 BuildError body 구성. \`sendError\` 가 body 포함 broadcast.
- \`packages/react-native/runtime/zts-hmr-client.js\`: \`hmr:error\` 분기가 body.errors[0] 의 위치 활용 — \`[ZTS HMR] /proj/src/App.tsx:42:7\` 형식 출력 → RN LogBox 가 source link 자동 추출 → 클릭 시 editor jump.

bungae \`zts-bundler/server/index.ts:824\` 의 \`formatHmrError\` 와 동일 로직.

### P2 #F — DEFAULT_ASSET_EXTS Metro 호환 확장
14개 → 33개. bungae \`DEFAULT_RESOLVER.assetExts\` 와 동등.

추가: \`bmp/psd/tiff/tif/xml/avif/ico\` (이미지), \`mov/mpeg/mpg/webm\` (비디오), \`aac/aiff/caf/wav\` (오디오), \`yaml/yml\` (문서), \`woff/woff2\` (폰트).

zero-config 사용자가 흔한 폰트(\`.woff2\`)/이미지(\`.bmp/.ico\`) require 시 'unknown asset type' 에러 해소.

## 테스트

신규 16건 (487 pass, 0 fail):
- \`dev-middleware.test.ts\` — \`isDevMiddlewareRoute\` 5건 (정확/슬래시/substring 방지/비매치/빈문자열)
- \`preset.test.ts\` — Metro 호환 폰트/이미지 12종 loader 등록
- \`metro-hmr-adapter.test.ts\` — sendError body wrapper + file:line:col 추출 + \`formatBuildError\` 5건 (다양한 ext / 위치 매칭 실패 / 빈 message / multiline)
- \`zts-hmr-client.test.mjs\` — body.errors 활용 location 출력 + backward-compat + partial filename false-positive 방지 3건
- \`hmr-bridge.test.ts\` — 기존 3건 body wrapper 형태로 갱신

## /simplify

3-axis review 후 1 finding 반영:
- \`HmrRnErrorEntry\` 의 \`lineNumber\` / \`column\` 이 type 상 optional → \`zts-hmr-client.js\` 가 filename 만 있을 때 \`'foo:undefined:undefined'\` false-positive 출력 가능. \`typeof === 'number'\` 검증 추가.

## 검증

- \`bun run --cwd packages/server build\` 통과
- \`bun run --cwd packages/react-native build\` 통과
- \`bun run fmt:check\` 통과 (286 files OK)
- RN+server src 487 tests pass

## 후속

audit P2 잔여 (\`server.unstable_serverRoot\` override, WS upgrade path 정밀화) 는 cosmetic — 별도 follow-up.

Refs #2605

🤖 Generated with [Claude Code](https://claude.com/claude-code)