### PR TITLE
feat(react-native): RN CLI flag 매트릭스 + sourcemap option 매핑 (#2605 audit P0+P1)

### DIFF
--- a/packages/core/bin/cli-flags.mjs
+++ b/packages/core/bin/cli-flags.mjs
@@ -45,6 +45,11 @@ export const FLAG_REGISTRY = [
   { kind: 'bool', flag: '--watch', target: 'watch', aliases: ['-w'] },
   { kind: 'bool', flag: '--watch-json', target: 'watchJson', extra: { watch: true } },
   { kind: 'bool', flag: '--open', target: 'open' },
+  // RN CLI 호환 (#2605 audit P0)
+  { kind: 'bool', flag: '--reset-cache', target: 'resetCache' },
+  { kind: 'bool', flag: '--sourcemap-use-absolute-path', target: 'sourcemapUseAbsolutePath' },
+  // Metro UI 의 `--no-interactive` 호환 — terminal actions 비활성. RN CLI 호출 시.
+  { kind: 'bool', flag: '--no-interactive', target: 'noInteractive' },
   { kind: 'bool', flag: '--minify', target: 'minify' },
   { kind: 'bool', flag: '--minify-whitespace', target: 'minifyWhitespace' },
   { kind: 'bool', flag: '--minify-identifiers', target: 'minifyIdentifiers' },
@@ -105,6 +110,17 @@ export const FLAG_REGISTRY = [
   { kind: 'string', flag: '--rn-platform', target: 'rnPlatform', forms: ['equal'] },
   // #2540 PR #7 — RN preset 의 projectRoot. 기본 cwd, 사용자 monorepo root 지정 시 사용.
   { kind: 'string', flag: '--rn-project-root', target: 'rnProjectRoot', forms: ['equal'] },
+  // ─── RN CLI 호환 flag 매트릭스 (#2605 audit P0) ───
+  // `react-native bundle` / Metro CLI 의 standard flag 들 — `zts bundle --platform=react-native`
+  // 가 dropin 으로 동작하기 위한 호환 layer. zts 내부 옵션 (outfile 등) 과 별개로 받아 매핑.
+  { kind: 'string', flag: '--bundle-output', target: 'bundleOutput' },
+  { kind: 'string', flag: '--sourcemap-output', target: 'sourcemapOutput' },
+  { kind: 'string', flag: '--source-map-url', target: 'sourceMapUrl' },
+  { kind: 'string', flag: '--sourcemap-sources-root', target: 'sourcemapSourcesRoot' },
+  { kind: 'string', flag: '--assets-dest', target: 'assetsDest' },
+  { kind: 'string', flag: '--asset-catalog-dest', target: 'assetCatalogDest' },
+  { kind: 'string', flag: '--bundle-encoding', target: 'bundleEncoding' },
+  { kind: 'string', flag: '--unstable-transform-profile', target: 'unstableTransformProfile' },
   { kind: 'string', flag: '--source-root', target: 'sourceRoot', forms: ['equal'] },
   // #2159 — `--output-exports=auto|named|default|none` (Rollup output.exports 호환).
   { kind: 'string', flag: '--output-exports', target: 'outputExports', forms: ['equal'] },
@@ -147,6 +163,8 @@ export const FLAG_REGISTRY = [
   { kind: 'int', flag: '--port', target: 'port' },
   { kind: 'int', flag: '--log-limit', target: 'logLimit', forms: ['equal'] },
   { kind: 'int', flag: '--line-limit', target: 'lineLimit', forms: ['equal'] },
+  // RN CLI 호환 — `--max-workers N` (Metro). zts `--jobs` 와 의미 동일이므로 alias.
+  { kind: 'int', flag: '--max-workers', target: 'jobs', forms: ['equal'] },
 
   // ─── kind=string-default — bool 단독 시 default, `--key=val` 시 val ───
   { kind: 'string-default', flag: '--metafile', target: 'metafile', default: 'meta.json' },
@@ -166,12 +184,21 @@ export const FLAG_REGISTRY = [
   { kind: 'csv', flag: '--conditions', target: 'conditions', forms: ['equal'] },
   { kind: 'csv', flag: '--node-paths', target: 'nodePaths', forms: ['equal'] },
   { kind: 'csv', flag: '--profile', target: 'profile', forms: ['equal'] },
+  // RN CLI 호환 (#2605 audit P0) — Metro 의 camelCase flag.
+  { kind: 'csv', flag: '--watchFolders', target: 'rnWatchFolders' },
+  { kind: 'csv', flag: '--sourceExts', target: 'rnSourceExts' },
 
   // ─── kind=key-value — `--key:K=V` → opts[target][K]=V ───
   { kind: 'key-value', flag: '--define', target: 'define' },
   { kind: 'key-value', flag: '--alias', target: 'alias' },
   { kind: 'key-value', flag: '--loader', target: 'loader' },
   { kind: 'key-value', flag: '--global', target: 'globals' },
+  // RN CLI 호환 (#2605 audit P0) — Metro `--transform-option key=value` /
+  // `--resolver-option key=value`. 반복 지정 가능. zts 내부에는 직접 매핑되지
+  // 않지만 `runRnBundle` 이 collected dict 를 platform-specific 처리 (현재는
+  // 무시 — Metro graph-bundler 전용. 미지원 stderr 경고만).
+  { kind: 'key-value', flag: '--transform-option', target: 'transformOptions' },
+  { kind: 'key-value', flag: '--resolver-option', target: 'resolverOptions' },
 
   // ─── kind=ns-array — `--key:VALUE` → opts[target].push(VALUE) ───
   { kind: 'ns-array', flag: '--inject', target: 'inject' },

--- a/packages/core/bin/rn-dev-input.mjs
+++ b/packages/core/bin/rn-dev-input.mjs
@@ -17,7 +17,6 @@ const UNSUPPORTED_FIELDS = [
   ['serializer', 'getModulesRunBeforeMainModule'],
   ['serializer', 'getPolyfills'],
   ['serializer', 'shouldAddToIgnoreList'],
-  ['serializer', 'inlineSourceMap'],
   // dummy placeholder — bungae 도 declared-but-unused.
   ['server', 'forwardClientLogs'],
   ['server', 'verifyConnections'],
@@ -93,6 +92,8 @@ export function buildRnDevServerInput(opts, config) {
         extraVars: serializer.extraVars ?? undefined,
         prelude: serializer.prelude ?? undefined,
         babel: transformer.babel ?? undefined,
+        inlineSourceMap: serializer.inlineSourceMap ?? undefined,
+        sourceRoot: cfg.sourcemapSourcesRoot ?? undefined,
       },
     },
     port: opts.port ?? server.port ?? 8081,

--- a/packages/core/bin/zts-cli-schema-sync.test.ts
+++ b/packages/core/bin/zts-cli-schema-sync.test.ts
@@ -328,6 +328,35 @@ describe('CLI flag ↔ BuildOptions / TranspileOptions schema sync', () => {
     // RN dev server (#2605) — CLI 만 노출
     '--host',
     '--host=',
+    // RN CLI 호환 flag 매트릭스 (#2605 audit P0) — `react-native bundle` / Metro
+    // CLI 의 standard flag 들. zts 내부 BuildOptions 와 1:1 매핑되지 않고 caller
+    // (runRnBundle) 에서 platform-specific 처리 — CLI 만 노출.
+    '--bundle-output',
+    '--bundle-output=',
+    '--sourcemap-output',
+    '--sourcemap-output=',
+    '--source-map-url',
+    '--source-map-url=',
+    '--sourcemap-sources-root',
+    '--sourcemap-sources-root=',
+    '--sourcemap-use-absolute-path',
+    '--assets-dest',
+    '--assets-dest=',
+    '--asset-catalog-dest',
+    '--asset-catalog-dest=',
+    '--bundle-encoding',
+    '--bundle-encoding=',
+    '--unstable-transform-profile',
+    '--unstable-transform-profile=',
+    '--reset-cache',
+    '--no-interactive',
+    '--max-workers=',
+    '--transform-option:*',
+    '--resolver-option:*',
+    '--watchFolders',
+    '--watchFolders=',
+    '--sourceExts',
+    '--sourceExts=',
     // jsx-dev — CLI shorthand for jsx="automatic-dev"
     '--jsx-dev',
     // drop — CLI 의 `--drop=console/debugger` 는 transpile 의 dropConsole/dropDebugger 와 매핑
@@ -437,10 +466,21 @@ describe('CLI flag ↔ BuildOptions / TranspileOptions schema sync', () => {
   });
 
   test('flag 명명 규칙 — 모든 CLI flag 는 lowercase + kebab + `:` namespace 만', () => {
+    // RN CLI / Metro 와의 호환을 위해 camelCase 를 그대로 받아야 하는 flag.
+    // `react-native bundle --watchFolders`, `--sourceExts` 가 RN CLI 의 정식
+    // 표기 — kebab-case 로 받으면 dropin 호환 깨짐. 본 PR (#2605 audit P0) 에서
+    // 의도적 예외 등록.
+    const camelCaseExceptions = new Set([
+      '--watchFolders',
+      '--watchFolders=',
+      '--sourceExts',
+      '--sourceExts=',
+    ]);
     const bad: string[] = [];
     for (const flag of cliFlags) {
       // single-letter short flag (`-o`, `-p`, `-w`) 는 별도 형식.
       if (/^-[a-z]$/.test(flag)) continue;
+      if (camelCaseExceptions.has(flag)) continue;
       const stripped = flag.replace(/^--/, '').replace(/[:=*]/g, '').replace(/\./g, '');
       if (!/^[a-z][a-z0-9-]*$/.test(stripped)) bad.push(flag);
     }

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -649,6 +649,35 @@ async function loadRnModule() {
   return rnModulePromise;
 }
 
+/**
+ * RN CLI 호환 미지원 영역 — 사용자가 `--asset-catalog-dest` 등을 지정해도 zts 가
+ * 처리 못 함을 한 줄 stderr 로 알림. silent drop 방지 (#2605 audit P0).
+ *
+ * graph-bundler 전용 + production asset 영역은 후속 PR (P0#2 — asset 복사) 에서
+ * 흡수 예정. 현재는 경고만.
+ */
+function warnRnBundleUnsupported(opts) {
+  // `--assets-dest` / `--asset-catalog-dest` 는 후속 PR (P0#2 — asset 복사) 에서
+  // 흡수 예정. `--sourcemap-sources-root` / `--sourcemap-use-absolute-path` 는
+  // zts core 의 sourcemap 생성 영역이라 caller-side 처리 어려움 — 미지원 유지.
+  // graph-bundler 전용 (`transform-option` / `resolver-option`) 도 미지원.
+  const map = {
+    assetsDest: '--assets-dest',
+    assetCatalogDest: '--asset-catalog-dest',
+    unstableTransformProfile: '--unstable-transform-profile',
+    transformOptions: '--transform-option',
+    resolverOptions: '--resolver-option',
+    sourcemapSourcesRoot: '--sourcemap-sources-root',
+    sourcemapUseAbsolutePath: '--sourcemap-use-absolute-path',
+  };
+  for (const [key, flag] of Object.entries(map)) {
+    const v = opts[key];
+    if (v === undefined) continue;
+    if (typeof v === 'object' && Object.keys(v).length === 0) continue;
+    process.stderr.write(`[zts:rn-bundle] ${flag} (zts 미지원, ignore)\n`);
+  }
+}
+
 async function runRnBundle(opts, _config) {
   const rn = await loadRnModule();
   const projectRoot = resolve(opts.rnProjectRoot ?? '.');
@@ -659,19 +688,57 @@ async function runRnBundle(opts, _config) {
     );
     process.exit(1);
   }
+  warnRnBundleUnsupported(opts);
   const rnPlatform = opts.rnPlatform === 'android' ? 'android' : 'ios';
+
+  // RN CLI 호환 — `--bundle-output X` 가 `--outfile X` 와 동일 의미. 양쪽 다 받되
+  // 명시 우선순위: --outfile > --bundle-output. 둘 다 미지정 시 in-memory.
+  const outfile = opts.outfile ?? opts.bundleOutput;
+
+  // `--sourcemap-output` 또는 `--source-map-url` 이 명시되면 sourcemap 자동 활성.
+  // bungae build.ts L38-79 와 동일 패턴 — caller-side write 로 path 처리.
+  const wantsSourcemap = Boolean(opts.sourcemap || opts.sourcemapOutput || opts.sourceMapUrl);
+
+  // outfile 명시 + 추가 path 옵션 (sourcemapOutput / sourceMapUrl / bundleEncoding)
+  // 이 있으면 caller-side 로 직접 write — NAPI write:true 회피.
+  const callerWrite = outfile && (opts.sourcemapOutput || opts.sourceMapUrl || opts.bundleEncoding);
+
   const result = await rn.bundleRn({
     entry,
     projectRoot,
     rnPlatform,
     dev: Boolean(opts.devMode),
-    sourcemap: Boolean(opts.sourcemap),
+    sourcemap: wantsSourcemap,
     minify:
       opts.minify || opts.minifyWhitespace || opts.minifyIdentifiers || opts.minifySyntax || false,
-    override: opts.outfile ? { outfile: opts.outfile, write: true } : undefined,
+    extra: {
+      watchFolders: opts.rnWatchFolders ?? undefined,
+      sourceExts: opts.rnSourceExts ?? undefined,
+    },
+    override: outfile && !callerWrite ? { outfile, write: true } : undefined,
   });
+
+  // caller-side write — bundle / sourcemap path 분리 + URL override 적용.
+  if (callerWrite && result.errors.length === 0 && result.outputFiles?.length) {
+    const bundlePath = resolve(outfile);
+    const mapPath = opts.sourcemapOutput ? resolve(opts.sourcemapOutput) : `${bundlePath}.map`;
+    const sourceMappingURL = opts.sourceMapUrl ?? basename(mapPath);
+    const encoding = opts.bundleEncoding ?? 'utf-8';
+    mkdirSync(dirname(bundlePath), { recursive: true });
+    let bundleCode = result.outputFiles[0].text;
+    // sourcemap 이 emit 됐으면 `//# sourceMappingURL=` 주석 append.
+    if (wantsSourcemap && result.outputFiles[1]) {
+      bundleCode = `${bundleCode}\n//# sourceMappingURL=${sourceMappingURL}`;
+    }
+    writeFileSync(bundlePath, bundleCode, encoding);
+    if (wantsSourcemap && result.outputFiles[1]) {
+      mkdirSync(dirname(mapPath), { recursive: true });
+      writeFileSync(mapPath, result.outputFiles[1].text);
+    }
+  }
+
   if (result.errors.length === 0 && opts.logLevel !== 'silent') {
-    console.error(`[bundle] react-native ${rnPlatform} ${opts.outfile ?? '(in-memory)'}`);
+    console.error(`[bundle] react-native ${rnPlatform} ${outfile ?? '(in-memory)'}`);
   }
   return result;
 }

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -5209,9 +5209,11 @@ describe('buildRnDevServerInput — config + opts 추출 (#2605)', () => {
     expect(all).toContain('serializer.bundleType');
     expect(all).toContain('server.forwardClientLogs');
     expect(all).toContain('server.verifyConnections');
-    // transformer.babel / serializer.prelude 는 매핑 가능해서 경고 없음.
+    // transformer.babel / serializer.prelude / serializer.inlineSourceMap 는
+    // 매핑 가능해서 경고 없음.
     expect(all).not.toContain('transformer.babel');
     expect(all).not.toContain('serializer.prelude');
+    expect(all).not.toContain('serializer.inlineSourceMap');
   });
 
   test('미지원 필드 0 — stderr 경고 0 출력', async () => {
@@ -5315,6 +5317,37 @@ describe('buildRnDevServerInput — config + opts 추출 (#2605)', () => {
     expect(input?.bundle.extra?.babel).toEqual(inlineBabel);
     expect(writes.join('')).not.toContain('transformer.babel');
   });
+
+  test('config.serializer.inlineSourceMap → bundle.extra.inlineSourceMap 매핑 (warning 없음, #2605 audit P1)', async () => {
+    const { buildRnDevServerInput } = await import('./rn-dev-input.mjs');
+    const original = process.stderr.write.bind(process.stderr);
+    const writes: string[] = [];
+    // @ts-expect-error — runtime mock
+    process.stderr.write = (chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
+      return true;
+    };
+    let input: ReturnType<typeof buildRnDevServerInput>;
+    try {
+      input = buildRnDevServerInput(
+        { entryPoints: ['i.js'] },
+        { serializer: { inlineSourceMap: true } },
+      );
+    } finally {
+      process.stderr.write = original;
+    }
+    expect(input?.bundle.extra?.inlineSourceMap).toBe(true);
+    expect(writes.join('')).not.toContain('serializer.inlineSourceMap');
+  });
+
+  test('config.sourcemapSourcesRoot → bundle.extra.sourceRoot 매핑 (Metro 호환)', async () => {
+    const { buildRnDevServerInput } = await import('./rn-dev-input.mjs');
+    const input = buildRnDevServerInput(
+      { entryPoints: ['i.js'] },
+      { sourcemapSourcesRoot: '/abs/proj' },
+    );
+    expect(input?.bundle.extra?.sourceRoot).toBe('/abs/proj');
+  });
 });
 
 describe('CLI: dev --platform=react-native (#2605 PR #J)', () => {
@@ -5337,5 +5370,52 @@ describe('CLI: dev --platform=react-native (#2605 PR #J)', () => {
   test.skip('@zts/react-native 미설치 환경 → friendly error (production npm publish e2e)', () => {
     // workspace 환경에서는 RN 패키지가 install 됨 → lazy load 항상 성공. peer
     // 미설치 환경 검증은 npm publish 후 별도 e2e 환경에서.
+  });
+});
+
+describe('CLI: bundle --platform=react-native — RN CLI flag 매트릭스 (#2605 audit P0)', () => {
+  test('--bundle-output / --sourcemap-output / --assets-dest 등 parse + opts target 매핑', () => {
+    // CLI invoke 자체는 entry 미지정으로 exit 1, parse 단의 stderr 에 미지원 경고
+    // (assetsDest 등) 가 emit 되는지로 flag parse 검증.
+    const { exitCode, stderr } = runCli([
+      '--bundle',
+      '--platform=react-native',
+      '--rn-platform=ios',
+      '--bundle-output=ios/main.jsbundle',
+      '--sourcemap-output=ios/main.jsbundle.map',
+      '--assets-dest=ios/assets',
+      '--asset-catalog-dest=ios/Images.xcassets',
+      '--bundle-encoding=utf-8',
+      '--reset-cache',
+      '--max-workers=4',
+      '--no-interactive',
+      '--unstable-transform-profile=hermes-stable',
+      '--source-map-url=https://example.com/main.jsbundle.map',
+      '--sourcemap-sources-root=/abs/proj',
+      '--sourcemap-use-absolute-path',
+      '--transform-option:foo=bar',
+      '--resolver-option:baz=qux',
+      '--watchFolders=../shared,../lib',
+      '--sourceExts=ts,tsx',
+    ]);
+    // entry 미지정 → exit 1 + entry 친화 에러
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('entry');
+    // 적어도 parse 가 unknown flag 로 실패하지 않음 (`--bundle-output=` typo-suggest 안 뜸).
+    expect(stderr).not.toContain("unknown CLI flag '--bundle-output'");
+    expect(stderr).not.toContain("unknown CLI flag '--max-workers'");
+    expect(stderr).not.toContain("unknown CLI flag '--watchFolders'");
+  });
+
+  test('--bundle-output / --sourcemap-output 미지원 stderr 경고 — 실제 bundle path 진입 (entry + RN 패키지 없음 시 lazy load fail 가능, parse 단계만 검증)', () => {
+    const { stderr } = runCli([
+      '--bundle',
+      '--platform=react-native',
+      '--asset-catalog-dest=foo',
+      '--bundle-encoding=utf-16',
+    ]);
+    // entry 누락이라 stderr 에 entry 메시지가 우선 — `--asset-catalog-dest` 는
+    // entry 검증 후 처리. 본 테스트는 flag parse 자체가 reject 안 하는지만 확인.
+    expect(stderr).toContain('entry');
   });
 });

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -245,6 +245,28 @@ describe('buildRnBundleOptions — define / banner / footer / polyfills', () => 
     const opts = buildRnBundleOptions(baseInput({ extra: { prelude: [] } }));
     expect(opts.runBeforeMain).toBeUndefined();
   });
+
+  test('extra.inlineSourceMap=true — sourcemapMode=inline (#2605 audit P1)', () => {
+    const opts = buildRnBundleOptions(baseInput({ extra: { inlineSourceMap: true } }));
+    expect(opts.sourcemapMode).toBe('inline');
+  });
+
+  test('extra.inlineSourceMap=false 또는 미지정 — sourcemapMode 미설정', () => {
+    const a = buildRnBundleOptions(baseInput({ extra: { inlineSourceMap: false } }));
+    expect(a.sourcemapMode).toBeUndefined();
+    const b = buildRnBundleOptions(baseInput({ extra: {} }));
+    expect(b.sourcemapMode).toBeUndefined();
+  });
+
+  test('extra.sourceRoot — Metro sourcemapSourcesRoot 호환', () => {
+    const opts = buildRnBundleOptions(baseInput({ extra: { sourceRoot: '/abs/proj' } }));
+    expect(opts.sourceRoot).toBe('/abs/proj');
+  });
+
+  test('extra.sourceRoot 미지정 — preset.sourceRoot 미설정', () => {
+    const opts = buildRnBundleOptions(baseInput());
+    expect(opts.sourceRoot).toBeUndefined();
+  });
 });
 
 describe('buildRnBundleOptions — dev mode 분기 (jsx / devMode / reactRefresh / collectModuleCodes)', () => {

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -107,6 +107,16 @@ export interface RnBundleInput {
      * 외에 추가됨.
      */
     babel?: InlineBabelConfig;
+    /**
+     * Sourcemap 을 bundle 에 inline 으로 embed (Metro `serializer.inlineSourceMap`
+     * 호환). zts core 의 `sourcemapMode='inline'` 으로 forward.
+     */
+    inlineSourceMap?: boolean;
+    /**
+     * Sourcemap 의 `sourceRoot` field (Metro `sourcemapSourcesRoot` 호환). 절대
+     * 경로를 source 로 변환하는 base. zts core 의 `sourceRoot` 으로 forward.
+     */
+    sourceRoot?: string;
   };
   /** RN prelude 끝에 append 할 사용자 banner string. */
   bannerExtras?: string;
@@ -408,6 +418,12 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
   }
   if (extra?.fallback && Object.keys(extra.fallback).length > 0) {
     preset.fallback = { ...extra.fallback };
+  }
+  if (extra?.inlineSourceMap === true) {
+    preset.sourcemapMode = 'inline';
+  }
+  if (extra?.sourceRoot) {
+    preset.sourceRoot = extra.sourceRoot;
   }
 
   // user override 는 마지막 — define / loader / alias 같은 dict 는 deep merge,


### PR DESCRIPTION
## 요약

#2605 audit 의 P0#1 (RN CLI flag dropin) + P1#3 (sourcemap option) 묶음.

번개 \`packages/bungae/src/build.ts\` L38-79 의 **caller-side write 패턴** 이식 — NAPI 가 in-memory 결과 emit 후 caller (zts.mjs) 가 직접 path 분리 + URL override + encoding 적용.

## P0#1 — RN CLI flag 매트릭스

\`react-native bundle\` / Metro CLI 의 standard flag 19개 등록:

**지원** (caller-side write 또는 alias):
- \`--bundle-output\` (= \`--outfile\` alias)
- \`--sourcemap-output\` (caller-side path 분리)
- \`--source-map-url\` (sourceMappingURL 주석 override)
- \`--bundle-encoding\` (writeFileSync encoding)
- \`--max-workers\` (= \`--jobs\` alias)
- \`--watchFolders\` (= \`bundle.extra.watchFolders\`)
- \`--sourceExts\` (= \`bundle.extra.sourceExts\`)

**미지원 stderr 경고** (silent drop 방지):
- \`--assets-dest\` / \`--asset-catalog-dest\` — P0#2 후속 PR (asset 복사)
- \`--sourcemap-sources-root\` / \`--sourcemap-use-absolute-path\` — zts core sourcemap 생성 영역
- \`--transform-option\` / \`--resolver-option\` — graph-bundler 전용
- \`--unstable-transform-profile\` — Metro 의 hermes profile flag, zts 적용 영역 미정

**parse 만 등록 (NAPI 영향 없음)**:
- \`--reset-cache\` / \`--no-interactive\`

## P1#3 — Sourcemap option 매핑

- \`serializer.inlineSourceMap\` → \`bundle.extra.inlineSourceMap\` → \`BuildOptions.sourcemapMode='inline'\`
- \`cfg.sourcemapSourcesRoot\` → \`bundle.extra.sourceRoot\` → \`BuildOptions.sourceRoot\`

UNSUPPORTED_FIELDS 에서 \`serializer.inlineSourceMap\` 제거.

## 사용자 질문 답변

**'기존에 번개에선 지원됐던거 아니야?'** — 네. 번개 \`build.ts\` L38-79 가 \`config.bundleOutput\` / \`sourcemapOutput\` / \`sourceMapUrl\` / \`bundleEncoding\` 을 caller-side 에서 처리. NAPI 에 forward 하지 않고 in-memory 결과 받아서 \`fs.writeFileSync\`. 본 PR 은 같은 패턴 이식.

## 변경 파일 (7)

1. \`packages/core/bin/cli-flags.mjs\` — 19 RN flag 등록
2. \`packages/core/bin/zts.mjs\` — \`warnRnBundleUnsupported\` 경고 + \`runRnBundle\` caller-side write 분기
3. \`packages/core/bin/rn-dev-input.mjs\` — \`inlineSourceMap\` UNSUPPORTED 에서 제거 + \`bundle.extra\` forward
4. \`packages/react-native/src/preset.ts\` — \`RnBundleInput.extra.inlineSourceMap\` / \`sourceRoot\` 추가, \`buildRnBundleOptions\` 가 BuildOptions 로 forward
5. \`packages/core/bin/zts-cli-schema-sync.test.ts\` — 19 신규 flag cliOnlyFlags 등록 + \`--watchFolders\` / \`--sourceExts\` camelCase 예외
6. \`packages/react-native/src/preset.test.ts\` — extra.inlineSourceMap / sourceRoot 4건
7. \`packages/core/bin/zts.test.ts\` — buildRnDevServerInput 매핑 2건 + RN CLI flag parse 2건

## 테스트

- \`packages/react-native/src/\` — 491 pass
- \`packages/core/bin/zts.test.ts\` (buildRnDevServerInput + RN CLI flag) — 29 pass
- \`packages/core/bin/zts-cli-schema-sync.test.ts\` — 11 pass

## /simplify

3-axis review 후 1 finding 반영:
- \`--sourcemap-output\` partial fallback (path 다르면 stderr 후 그래도 emit) → caller-side write 로 일관 구현. UNSUPPORTED 와 partial 사이 혼재 제거.

## 후속 (P0#2)

\`--assets-dest\` / \`--asset-catalog-dest\` — Android \`drawable-{density}\` 분기 + iOS \`ios/assets/\` 복사 + keep.xml 생성 + NAPI result 의 \`assets[]\` 메타 emit. 별도 PR (~250줄).

Refs #2605

🤖 Generated with [Claude Code](https://claude.com/claude-code)