### PR TITLE
feat(react-native): production asset 복사 + terminal actions 진단 (#2605 audit P0+UX)

### DIFF
--- a/packages/core/bin/rn-asset-copy.mjs
+++ b/packages/core/bin/rn-asset-copy.mjs
@@ -10,8 +10,8 @@
 //      `__<flatRel>_<basename>.<ext>` naming + keep.xml 생성.
 //   5. node_modules / .git / dist / build / .next / .turbo / .bun / .DS_Store skip.
 
-import { copyFileSync, existsSync, mkdirSync, readdirSync, statSync, writeFileSync } from 'node:fs';
-import { basename, dirname, extname, join, relative } from 'node:path';
+import { copyFileSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs';
+import { basename, extname, join, relative } from 'node:path';
 
 /** scale variant naming — `@2x.png` / `@3x.png` 등. capture group 1 이 scale 숫자. */
 export const SCALE_REGEX = /@(\d+(?:\.\d+)?)x/;
@@ -90,17 +90,14 @@ export function buildKeepXml(drawableNames) {
 }
 
 /**
- * project 안의 asset 파일 walk + scale variant 수집. visited set 으로 같은 파일을
- * 다중 방문 방지 (scale variant 발견 시 둘 다 등록).
- *
- * 반환: `[{ filePath, baseName, scale, ext, relDir }]`. relDir 은 projectRoot
+ * project 안의 asset 파일 walk + scale variant 수집. 반환:
+ * `[{ filePath, baseName, scale, ext, relDir }]`. relDir 은 projectRoot
  * 기준 상대 경로 (POSIX `/`).
  */
 export function discoverAssets(projectRoot, assetExts) {
   const exts = new Set(
     [...assetExts].map((e) => (e.startsWith('.') ? e.toLowerCase() : `.${e.toLowerCase()}`)),
   );
-  const visited = new Set();
   const out = [];
 
   function walk(dir) {
@@ -120,8 +117,6 @@ export function discoverAssets(projectRoot, assetExts) {
       if (!entry.isFile()) continue;
       const ext = extname(entry.name).toLowerCase();
       if (!exts.has(ext)) continue;
-      if (visited.has(full)) continue;
-      visited.add(full);
       const parsed = parseAssetName(entry.name);
       const relDir = relative(projectRoot, dir).replace(/\\/g, '/');
       out.push({ filePath: full, ...parsed, relDir });
@@ -186,9 +181,9 @@ export function copyAssetsForAndroid(assets, assetsDest) {
  * @returns 복사된 파일 수.
  */
 export function copyRnAssets({ projectRoot, assetsDest, rnPlatform, assetExts }) {
-  if (!assetsDest || !existsSync(projectRoot) || !statSync(projectRoot).isDirectory()) {
-    return 0;
-  }
+  // projectRoot 존재 / 디렉토리 검증은 discoverAssets 내부 walk 의 readdirSync
+  // try/catch 가 처리 — 미존재면 빈 array. 별도 guard 불필요.
+  if (!assetsDest) return 0;
   const assets = discoverAssets(projectRoot, assetExts);
   if (assets.length === 0) return 0;
   if (rnPlatform === 'android') {

--- a/packages/core/bin/rn-asset-copy.mjs
+++ b/packages/core/bin/rn-asset-copy.mjs
@@ -1,0 +1,198 @@
+// RN production bundle 의 asset 복사. bungae packages/bungae/src/build.ts L100~L260
+// + zts-bundler/build.ts copyAssets / plugin-core.ts SCALE_REGEX/IOS_SCALES 이식.
+//
+// caller (`runRnBundle`) 가 production (dev=false) + `--assets-dest` 명시 시 호출.
+// 동작:
+//   1. projectRoot 를 walkDir — assetExts 화이트리스트 매칭 file 수집.
+//   2. file 마다 scale variant 동일 디렉토리에서 추가 수집 (`@2x.png` 등).
+//   3. iOS — IOS_SCALES (1/2/3) 만 통과, `<assetsDest>/<relPath>/<file>` 복사.
+//   4. Android — Metro scaleToDrawable 매핑 (1→mdpi/1.5→hdpi/2→xhdpi/3→xxhdpi/4→xxxhdpi),
+//      `__<flatRel>_<basename>.<ext>` naming + keep.xml 생성.
+//   5. node_modules / .git / dist / build / .next / .turbo / .bun / .DS_Store skip.
+
+import { copyFileSync, existsSync, mkdirSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { basename, dirname, extname, join, relative } from 'node:path';
+
+/** scale variant naming — `@2x.png` / `@3x.png` 등. capture group 1 이 scale 숫자. */
+export const SCALE_REGEX = /@(\d+(?:\.\d+)?)x/;
+/** iOS 가 native 로 인식하는 scale set. 그 외 (`@4x` 등) 는 production bundle 에서 제외. */
+export const IOS_SCALES = new Set([1, 2, 3]);
+
+/** Metro scale → Android drawable folder. Metro `assetPathUtils.js` 와 동일. */
+const SCALE_TO_DRAWABLE = {
+  0.75: 'ldpi',
+  1: 'mdpi',
+  1.5: 'hdpi',
+  2: 'xhdpi',
+  3: 'xxhdpi',
+  4: 'xxxhdpi',
+};
+
+const SKIP_DIRS = new Set([
+  'node_modules',
+  '.git',
+  '.bungae',
+  'dist',
+  'build',
+  '.next',
+  '.turbo',
+  '.bun',
+  '.DS_Store',
+]);
+
+const DRAWABLE_EXT_RE = /\.(png|jpg|jpeg|gif|webp|bmp|avif|ico|icns|icxl)$/i;
+
+/**
+ * Metro 호환 Android drawable folder name. table miss 시 `drawable-{round(160*scale)}dpi`
+ * fallback (Metro custom scale). 음수/0 같은 invalid scale 은 `drawable-mdpi` (default).
+ */
+export function getAndroidDrawableFolder(scale) {
+  if (SCALE_TO_DRAWABLE[scale]) return `drawable-${SCALE_TO_DRAWABLE[scale]}`;
+  if (Number.isFinite(scale) && scale > 0) return `drawable-${Math.round(160 * scale)}dpi`;
+  return 'drawable-mdpi';
+}
+
+/**
+ * Asset 의 base name (scale variant suffix 제거) 과 scale 추출. `foo@2x.png` →
+ * `{ baseName: 'foo', scale: 2 }`, `foo.png` → `{ baseName: 'foo', scale: 1 }`.
+ */
+export function parseAssetName(filename) {
+  const ext = extname(filename);
+  const stem = basename(filename, ext);
+  const m = stem.match(SCALE_REGEX);
+  if (!m) return { baseName: stem, scale: 1, ext };
+  return {
+    baseName: stem.replace(SCALE_REGEX, ''),
+    scale: Number.parseFloat(m[1]),
+    ext,
+  };
+}
+
+/**
+ * Metro 의 Android filename convention — `<flatRelPath>_<baseName>.<ext>` 형식.
+ * relative path 의 `/` 를 `_` 로 치환 + 비-alnum 문자 제거 + `__` prefix
+ * (node_modules asset 표식 — Metro 가 그대로 따름).
+ */
+export function androidAssetFileName(relDir, baseName, ext) {
+  const flat = relDir.replace(/\//g, '_').replace(/[^a-z0-9_]/gi, '');
+  const prefix = flat ? (flat.startsWith('__') ? flat : `__${flat}`) : '__';
+  return `${prefix}_${baseName}${ext}`;
+}
+
+/** Android `keep.xml` body — drawable 자원 보존 list. */
+export function buildKeepXml(drawableNames) {
+  const items = drawableNames.map((n) => `@drawable/${n}`).join(',');
+  return [
+    '<?xml version="1.0" encoding="utf-8"?>',
+    `<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="${items}" />`,
+    '',
+  ].join('\n');
+}
+
+/**
+ * project 안의 asset 파일 walk + scale variant 수집. visited set 으로 같은 파일을
+ * 다중 방문 방지 (scale variant 발견 시 둘 다 등록).
+ *
+ * 반환: `[{ filePath, baseName, scale, ext, relDir }]`. relDir 은 projectRoot
+ * 기준 상대 경로 (POSIX `/`).
+ */
+export function discoverAssets(projectRoot, assetExts) {
+  const exts = new Set(
+    [...assetExts].map((e) => (e.startsWith('.') ? e.toLowerCase() : `.${e.toLowerCase()}`)),
+  );
+  const visited = new Set();
+  const out = [];
+
+  function walk(dir) {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (SKIP_DIRS.has(entry.name)) continue;
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const ext = extname(entry.name).toLowerCase();
+      if (!exts.has(ext)) continue;
+      if (visited.has(full)) continue;
+      visited.add(full);
+      const parsed = parseAssetName(entry.name);
+      const relDir = relative(projectRoot, dir).replace(/\\/g, '/');
+      out.push({ filePath: full, ...parsed, relDir });
+    }
+  }
+  walk(projectRoot);
+  return out;
+}
+
+/**
+ * iOS production 복사 — `<assetsDest>/<relDir>/<file>` 으로. IOS_SCALES (1/2/3) 외
+ * scale 은 제외. 같은 baseName 의 scale variant 들은 모두 같은 destDir 에 원래
+ * 파일명 그대로.
+ */
+export function copyAssetsForIos(assets, assetsDest) {
+  let copied = 0;
+  for (const a of assets) {
+    if (!IOS_SCALES.has(a.scale)) continue;
+    const destDir = a.relDir ? join(assetsDest, a.relDir) : assetsDest;
+    mkdirSync(destDir, { recursive: true });
+    copyFileSync(a.filePath, join(destDir, basename(a.filePath)));
+    copied++;
+  }
+  return copied;
+}
+
+/**
+ * Android production 복사 — Metro scale-to-drawable folder + flattened name +
+ * keep.xml. drawable resource name (확장자 제거) 을 keepNames 에 누적.
+ *
+ * `assetsDest` 가 명시되면 그 경로 기준, 미지정 시 `<projectRoot>/android/app/src/main/res`.
+ */
+export function copyAssetsForAndroid(assets, assetsDest) {
+  const baseDir = assetsDest;
+  const keepNames = new Set();
+  let copied = 0;
+  for (const a of assets) {
+    const folder = getAndroidDrawableFolder(a.scale);
+    const targetDir = join(baseDir, folder);
+    mkdirSync(targetDir, { recursive: true });
+    const fileName = androidAssetFileName(a.relDir, a.baseName, a.ext);
+    copyFileSync(a.filePath, join(targetDir, fileName));
+    copied++;
+    if (DRAWABLE_EXT_RE.test(fileName)) {
+      keepNames.add(fileName.replace(DRAWABLE_EXT_RE, ''));
+    }
+  }
+  // keep.xml — `res/raw/keep.xml` 위치. drawable resources 의 ProGuard/R8 미사용
+  // 보장.
+  if (keepNames.size > 0) {
+    const keepDir = join(baseDir, 'raw');
+    mkdirSync(keepDir, { recursive: true });
+    writeFileSync(join(keepDir, 'keep.xml'), buildKeepXml([...keepNames].sort()));
+  }
+  return copied;
+}
+
+/**
+ * Production asset 복사 entry — caller (runRnBundle) 에서 dev=false + assetsDest
+ * 명시 시 호출. discoverAssets + platform 분기.
+ *
+ * @returns 복사된 파일 수.
+ */
+export function copyRnAssets({ projectRoot, assetsDest, rnPlatform, assetExts }) {
+  if (!assetsDest || !existsSync(projectRoot) || !statSync(projectRoot).isDirectory()) {
+    return 0;
+  }
+  const assets = discoverAssets(projectRoot, assetExts);
+  if (assets.length === 0) return 0;
+  if (rnPlatform === 'android') {
+    return copyAssetsForAndroid(assets, assetsDest);
+  }
+  return copyAssetsForIos(assets, assetsDest);
+}

--- a/packages/core/bin/rn-asset-copy.test.ts
+++ b/packages/core/bin/rn-asset-copy.test.ts
@@ -1,0 +1,252 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  androidAssetFileName,
+  buildKeepXml,
+  copyRnAssets,
+  discoverAssets,
+  getAndroidDrawableFolder,
+  IOS_SCALES,
+  parseAssetName,
+  SCALE_REGEX,
+} from './rn-asset-copy.mjs';
+
+let dir: string;
+let dest: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'zts-rn-asset-src-'));
+  dest = mkdtempSync(join(tmpdir(), 'zts-rn-asset-dest-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  rmSync(dest, { recursive: true, force: true });
+});
+
+describe('SCALE_REGEX / IOS_SCALES — bungae plugin-core 호환', () => {
+  test('SCALE_REGEX — `@2x` / `@3x` / `@1.5x` 매칭', () => {
+    expect('foo@2x.png'.match(SCALE_REGEX)?.[1]).toBe('2');
+    expect('icon@3x'.match(SCALE_REGEX)?.[1]).toBe('3');
+    expect('img@1.5x.svg'.match(SCALE_REGEX)?.[1]).toBe('1.5');
+  });
+
+  test('SCALE_REGEX — scale 표기 없으면 null', () => {
+    expect('foo.png'.match(SCALE_REGEX)).toBeNull();
+  });
+
+  test('IOS_SCALES — 1/2/3 만 포함', () => {
+    expect(IOS_SCALES.has(1)).toBe(true);
+    expect(IOS_SCALES.has(2)).toBe(true);
+    expect(IOS_SCALES.has(3)).toBe(true);
+    expect(IOS_SCALES.has(4)).toBe(false);
+    expect(IOS_SCALES.has(0.5)).toBe(false);
+  });
+});
+
+describe('parseAssetName', () => {
+  test('scale 없는 단순 파일', () => {
+    expect(parseAssetName('foo.png')).toEqual({ baseName: 'foo', scale: 1, ext: '.png' });
+  });
+
+  test('scale 있는 파일', () => {
+    expect(parseAssetName('icon@2x.png')).toEqual({ baseName: 'icon', scale: 2, ext: '.png' });
+    expect(parseAssetName('logo@3x.svg')).toEqual({ baseName: 'logo', scale: 3, ext: '.svg' });
+  });
+
+  test('소수점 scale (1.5)', () => {
+    expect(parseAssetName('img@1.5x.png')).toEqual({ baseName: 'img', scale: 1.5, ext: '.png' });
+  });
+});
+
+describe('getAndroidDrawableFolder — Metro scaleToDrawable 매핑', () => {
+  test('표준 scale 매핑 (0.75/1/1.5/2/3/4)', () => {
+    expect(getAndroidDrawableFolder(0.75)).toBe('drawable-ldpi');
+    expect(getAndroidDrawableFolder(1)).toBe('drawable-mdpi');
+    expect(getAndroidDrawableFolder(1.5)).toBe('drawable-hdpi');
+    expect(getAndroidDrawableFolder(2)).toBe('drawable-xhdpi');
+    expect(getAndroidDrawableFolder(3)).toBe('drawable-xxhdpi');
+    expect(getAndroidDrawableFolder(4)).toBe('drawable-xxxhdpi');
+  });
+
+  test('비표준 scale — `drawable-{round(160*scale)}dpi` fallback', () => {
+    expect(getAndroidDrawableFolder(2.5)).toBe('drawable-400dpi');
+    expect(getAndroidDrawableFolder(0.5)).toBe('drawable-80dpi');
+  });
+
+  test('invalid scale — `drawable-mdpi` default', () => {
+    expect(getAndroidDrawableFolder(0)).toBe('drawable-mdpi');
+    expect(getAndroidDrawableFolder(-1)).toBe('drawable-mdpi');
+    expect(getAndroidDrawableFolder(Number.NaN)).toBe('drawable-mdpi');
+  });
+});
+
+describe('androidAssetFileName — Metro flat naming', () => {
+  test('빈 relDir — `__<baseName><ext>`', () => {
+    expect(androidAssetFileName('', 'logo', '.png')).toBe('___logo.png');
+  });
+
+  test('단순 디렉토리 — `__<dir>_<baseName><ext>`', () => {
+    expect(androidAssetFileName('src/assets', 'logo', '.png')).toBe('__src_assets_logo.png');
+  });
+
+  test('비-alnum 문자 제거', () => {
+    expect(androidAssetFileName('src/img-foo', 'icon', '.svg')).toBe('__src_imgfoo_icon.svg');
+  });
+});
+
+describe('buildKeepXml', () => {
+  test('drawable resource list 가 keep tools attribute 에 포함', () => {
+    const xml = buildKeepXml(['__src_logo', '__src_icon']);
+    expect(xml).toContain('tools:keep="@drawable/__src_logo,@drawable/__src_icon"');
+    expect(xml).toContain('<?xml version="1.0"');
+  });
+
+  test('빈 list — keep="" empty', () => {
+    expect(buildKeepXml([])).toContain('tools:keep=""');
+  });
+});
+
+describe('discoverAssets', () => {
+  test('assetExts 매칭 file 만 수집, node_modules / .git skip', () => {
+    writeFileSync(join(dir, 'logo.png'), 'a');
+    writeFileSync(join(dir, 'data.json'), 'b');
+    mkdirSync(join(dir, 'node_modules'), { recursive: true });
+    writeFileSync(join(dir, 'node_modules/skip.png'), 'c');
+    mkdirSync(join(dir, '.git'), { recursive: true });
+    writeFileSync(join(dir, '.git/skip.png'), 'd');
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(join(dir, 'src/icon.svg'), 'e');
+
+    const result = discoverAssets(dir, ['.png', '.svg']);
+    const names = result.map((r) => r.filePath.replace(`${dir}/`, '')).sort();
+    expect(names).toEqual(['logo.png', 'src/icon.svg']);
+  });
+
+  test('relDir — projectRoot 기준 POSIX 상대 경로', () => {
+    mkdirSync(join(dir, 'a/b'), { recursive: true });
+    writeFileSync(join(dir, 'a/b/icon.png'), 'x');
+    const result = discoverAssets(dir, ['.png']);
+    expect(result[0]?.relDir).toBe('a/b');
+  });
+
+  test('빈 디렉토리 / 매칭 없음 — 빈 array', () => {
+    expect(discoverAssets(dir, ['.png'])).toEqual([]);
+  });
+
+  test('확장자 case-insensitive', () => {
+    writeFileSync(join(dir, 'LOGO.PNG'), 'x');
+    const result = discoverAssets(dir, ['.png']);
+    expect(result.length).toBe(1);
+  });
+});
+
+describe('copyRnAssets — iOS', () => {
+  test('IOS_SCALES (1/2/3) 만 통과 + relDir 보존', () => {
+    mkdirSync(join(dir, 'src/assets'), { recursive: true });
+    writeFileSync(join(dir, 'src/assets/logo.png'), 'a');
+    writeFileSync(join(dir, 'src/assets/logo@2x.png'), 'b');
+    writeFileSync(join(dir, 'src/assets/logo@3x.png'), 'c');
+    writeFileSync(join(dir, 'src/assets/logo@4x.png'), 'd'); // skip
+
+    const copied = copyRnAssets({
+      projectRoot: dir,
+      assetsDest: dest,
+      rnPlatform: 'ios',
+      assetExts: ['.png'],
+    });
+    expect(copied).toBe(3); // 1x/2x/3x 만, 4x 제외
+    expect(existsSync(join(dest, 'src/assets/logo.png'))).toBe(true);
+    expect(existsSync(join(dest, 'src/assets/logo@2x.png'))).toBe(true);
+    expect(existsSync(join(dest, 'src/assets/logo@3x.png'))).toBe(true);
+    expect(existsSync(join(dest, 'src/assets/logo@4x.png'))).toBe(false);
+  });
+
+  test('asset 0 — copied 0', () => {
+    expect(
+      copyRnAssets({ projectRoot: dir, assetsDest: dest, rnPlatform: 'ios', assetExts: ['.png'] }),
+    ).toBe(0);
+  });
+});
+
+describe('copyRnAssets — Android', () => {
+  test('Metro scaleToDrawable folder + flat naming + keep.xml', () => {
+    mkdirSync(join(dir, 'src/img'), { recursive: true });
+    writeFileSync(join(dir, 'src/img/logo.png'), 'a');
+    writeFileSync(join(dir, 'src/img/logo@2x.png'), 'b');
+    writeFileSync(join(dir, 'src/img/logo@3x.png'), 'c');
+
+    const copied = copyRnAssets({
+      projectRoot: dir,
+      assetsDest: dest,
+      rnPlatform: 'android',
+      assetExts: ['.png'],
+    });
+    expect(copied).toBe(3);
+    // 1x → mdpi, 2x → xhdpi, 3x → xxhdpi (Metro 매핑)
+    expect(existsSync(join(dest, 'drawable-mdpi/__src_img_logo.png'))).toBe(true);
+    expect(existsSync(join(dest, 'drawable-xhdpi/__src_img_logo.png'))).toBe(true);
+    expect(existsSync(join(dest, 'drawable-xxhdpi/__src_img_logo.png'))).toBe(true);
+    // keep.xml 생성
+    const keepPath = join(dest, 'raw/keep.xml');
+    expect(existsSync(keepPath)).toBe(true);
+    const xml = readFileSync(keepPath, 'utf-8');
+    expect(xml).toContain('@drawable/__src_img_logo');
+  });
+
+  test('Android — 4x scale 도 통과 (iOS 와 다름)', () => {
+    mkdirSync(join(dir, 'a'), { recursive: true });
+    writeFileSync(join(dir, 'a/icon@4x.png'), 'x');
+    const copied = copyRnAssets({
+      projectRoot: dir,
+      assetsDest: dest,
+      rnPlatform: 'android',
+      assetExts: ['.png'],
+    });
+    expect(copied).toBe(1);
+    expect(existsSync(join(dest, 'drawable-xxxhdpi/__a_icon.png'))).toBe(true);
+  });
+
+  test('Non-image asset — keep.xml 의 drawable list 에서 제외', () => {
+    mkdirSync(join(dir, 'a'), { recursive: true });
+    writeFileSync(join(dir, 'a/font.ttf'), 'x');
+    copyRnAssets({
+      projectRoot: dir,
+      assetsDest: dest,
+      rnPlatform: 'android',
+      assetExts: ['.ttf'],
+    });
+    // ttf 는 drawable 자원 아님 → keep.xml 미생성
+    expect(existsSync(join(dest, 'raw/keep.xml'))).toBe(false);
+  });
+});
+
+describe('copyRnAssets — guards', () => {
+  test('assetsDest falsy — 0 반환', () => {
+    expect(
+      copyRnAssets({ projectRoot: dir, assetsDest: '', rnPlatform: 'ios', assetExts: ['.png'] }),
+    ).toBe(0);
+  });
+
+  test('projectRoot 미존재 — 0 반환', () => {
+    expect(
+      copyRnAssets({
+        projectRoot: '/__nope__',
+        assetsDest: dest,
+        rnPlatform: 'ios',
+        assetExts: ['.png'],
+      }),
+    ).toBe(0);
+  });
+});

--- a/packages/core/bin/rn-dev-input.mjs
+++ b/packages/core/bin/rn-dev-input.mjs
@@ -61,9 +61,10 @@ export function buildRnDevServerInput(opts, config) {
 
   warnUnsupported(cfg);
 
-  // server.useGlobalHotkey 가 의미상 terminalActions — 둘 다 r/d/? 키보드
-  // shortcut 의 enable gate. CLI 미노출이라 config 만 source.
-  const terminalActions = server.useGlobalHotkey === false ? false : undefined;
+  // server.useGlobalHotkey + CLI `--no-interactive` 둘 다 r/d/? 키보드
+  // shortcut 의 enable gate. CLI flag 우선 — 명시 시 config override.
+  const terminalActions =
+    opts.noInteractive === true ? false : server.useGlobalHotkey === false ? false : undefined;
 
   return {
     bundle: {

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -15,6 +15,7 @@ import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 
 import { applyFlagAction, KNOWN_FLAGS, matchFlagFromRegistry } from './cli-flags.mjs';
+import { copyRnAssets } from './rn-asset-copy.mjs';
 import { buildRnDevServerInput } from './rn-dev-input.mjs';
 
 function isMissingBuiltCore(error) {
@@ -657,12 +658,11 @@ async function loadRnModule() {
  * 흡수 예정. 현재는 경고만.
  */
 function warnRnBundleUnsupported(opts) {
-  // `--assets-dest` / `--asset-catalog-dest` 는 후속 PR (P0#2 — asset 복사) 에서
-  // 흡수 예정. `--sourcemap-sources-root` / `--sourcemap-use-absolute-path` 는
+  // `--asset-catalog-dest` 는 iOS Images.xcassets — Xcode catalog 별도 작업이라
+  // 본 스코프 외. `--sourcemap-sources-root` / `--sourcemap-use-absolute-path` 는
   // zts core 의 sourcemap 생성 영역이라 caller-side 처리 어려움 — 미지원 유지.
   // graph-bundler 전용 (`transform-option` / `resolver-option`) 도 미지원.
   const map = {
-    assetsDest: '--assets-dest',
     assetCatalogDest: '--asset-catalog-dest',
     unstableTransformProfile: '--unstable-transform-profile',
     transformOptions: '--transform-option',
@@ -734,6 +734,27 @@ async function runRnBundle(opts, _config) {
     if (wantsSourcemap && result.outputFiles[1]) {
       mkdirSync(dirname(mapPath), { recursive: true });
       writeFileSync(mapPath, result.outputFiles[1].text);
+    }
+  }
+
+  // production asset 복사 (`--assets-dest`) — dev=false + 명시 시. iOS 는
+  // `<assetsDest>/<relPath>/<file>`, Android 는 Metro scaleToDrawable folder
+  // + flattened naming + keep.xml. 미지정 시 skip (dev server 가 HTTP 서빙).
+  if (result.errors.length === 0 && !opts.devMode && opts.assetsDest) {
+    const assetsDestAbs = resolve(opts.assetsDest);
+    const assetExts = opts.rnAssetExts ?? rn.DEFAULT_ASSET_EXTS ?? [];
+    try {
+      const copied = copyRnAssets({
+        projectRoot,
+        assetsDest: assetsDestAbs,
+        rnPlatform,
+        assetExts,
+      });
+      if (opts.logLevel !== 'silent') {
+        console.error(`[bundle] copied ${copied} asset(s) to ${assetsDestAbs}`);
+      }
+    } catch (err) {
+      process.stderr.write(`[zts:rn-bundle] asset copy 실패: ${err?.message ?? err}\n`);
     }
   }
 

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -742,13 +742,12 @@ async function runRnBundle(opts, _config) {
   // + flattened naming + keep.xml. 미지정 시 skip (dev server 가 HTTP 서빙).
   if (result.errors.length === 0 && !opts.devMode && opts.assetsDest) {
     const assetsDestAbs = resolve(opts.assetsDest);
-    const assetExts = opts.rnAssetExts ?? rn.DEFAULT_ASSET_EXTS ?? [];
     try {
       const copied = copyRnAssets({
         projectRoot,
         assetsDest: assetsDestAbs,
         rnPlatform,
-        assetExts,
+        assetExts: rn.DEFAULT_ASSET_EXTS ?? [],
       });
       if (opts.logLevel !== 'silent') {
         console.error(`[bundle] copied ${copied} asset(s) to ${assetsDestAbs}`);

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -159,6 +159,7 @@ describe('CLI: bootstrap', () => {
       cpSync(CLI, join(binDir, 'zts.mjs'));
       cpSync(resolve(import.meta.dir, 'cli-flags.mjs'), join(binDir, 'cli-flags.mjs'));
       cpSync(resolve(import.meta.dir, 'rn-dev-input.mjs'), join(binDir, 'rn-dev-input.mjs'));
+      cpSync(resolve(import.meta.dir, 'rn-asset-copy.mjs'), join(binDir, 'rn-asset-copy.mjs'));
 
       const result = readRedirectedProcessOutput(
         [RUNTIME, join(binDir, 'zts.mjs'), '--help'].map(shellQuote).join(' '),
@@ -5180,6 +5181,19 @@ describe('buildRnDevServerInput — config + opts 추출 (#2605)', () => {
     expect(a?.terminalActions).toBeUndefined();
     const b = buildRnDevServerInput({ entryPoints: ['i.js'] }, {});
     expect(b?.terminalActions).toBeUndefined();
+  });
+
+  test('CLI --no-interactive → terminalActions=false (config.useGlobalHotkey 보다 우선, #2605 audit)', async () => {
+    const { buildRnDevServerInput } = await import('./rn-dev-input.mjs');
+    // CLI flag 가 명시적 disable.
+    const a = buildRnDevServerInput({ entryPoints: ['i.js'], noInteractive: true }, {});
+    expect(a?.terminalActions).toBe(false);
+    // CLI flag 가 config 보다 우선 — useGlobalHotkey:true 라도 noInteractive 가 우선.
+    const b = buildRnDevServerInput(
+      { entryPoints: ['i.js'], noInteractive: true },
+      { server: { useGlobalHotkey: true } },
+    );
+    expect(b?.terminalActions).toBe(false);
   });
 
   test('미지원 필드 (transformer.inlineRequires/minifier, serializer.prelude/bundleType, server.forwardClientLogs/verifyConnections) — stderr 경고', async () => {

--- a/packages/react-native/src/dev-server/terminal-actions.test.ts
+++ b/packages/react-native/src/dev-server/terminal-actions.test.ts
@@ -80,12 +80,46 @@ describe('setupTerminalActions — disabled / non-TTY', () => {
     expect(stdin.listenerCount('data')).toBe(0);
   });
 
-  test('stdin 비-TTY → no-op cleanup', () => {
+  test('stdin 비-TTY → no-op cleanup + stderr 알림 (#2605 audit)', () => {
     const cb = makeCallbacks();
     const stdin = makeStdin({ isTTY: false });
-    const cleanup = setupTerminalActions(cb, { enabled: true, stdin });
+    const original = process.stderr.write.bind(process.stderr);
+    const writes: string[] = [];
+    // @ts-expect-error — runtime mock
+    process.stderr.write = (chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
+      return true;
+    };
+    let cleanup: () => void;
+    try {
+      cleanup = setupTerminalActions(cb, { enabled: true, stdin });
+    } finally {
+      process.stderr.write = original;
+    }
     expect(stdin.isRaw).toBe(false);
-    cleanup();
+    // wrapper script 사용자가 디버그 가능하도록 한 번 stderr 알림.
+    expect(writes.join('')).toContain('stdin is not a TTY');
+    expect(writes.join('')).toContain('keyboard shortcuts');
+    cleanup!();
+  });
+
+  test('enabled=false → 알림 없이 no-op (silent)', () => {
+    const cb = makeCallbacks();
+    const stdin = makeStdin({ isTTY: false });
+    const original = process.stderr.write.bind(process.stderr);
+    const writes: string[] = [];
+    // @ts-expect-error — runtime mock
+    process.stderr.write = (chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
+      return true;
+    };
+    try {
+      setupTerminalActions(cb, { enabled: false, stdin });
+    } finally {
+      process.stderr.write = original;
+    }
+    // enabled=false 는 명시적 disable — 알림 불필요.
+    expect(writes.join('')).not.toContain('stdin is not a TTY');
   });
 });
 

--- a/packages/react-native/src/dev-server/terminal-actions.test.ts
+++ b/packages/react-native/src/dev-server/terminal-actions.test.ts
@@ -10,6 +10,7 @@ interface FakeStdin extends EventEmitter {
   resume(): FakeStdin;
   setEncoding(_encoding: string): FakeStdin;
   emitKey(key: string): void;
+  emitKeyBuffer(key: string): void;
 }
 
 function makeStdin(opts: { isTTY?: boolean } = {}): FakeStdin {
@@ -23,6 +24,8 @@ function makeStdin(opts: { isTTY?: boolean } = {}): FakeStdin {
   emitter.resume = () => emitter;
   emitter.setEncoding = () => emitter;
   emitter.emitKey = (key) => emitter.emit('data', key);
+  // Bun runtime 동작 — setEncoding('utf8') 후에도 Buffer 로 emit 되는 케이스 모사.
+  emitter.emitKeyBuffer = (key) => emitter.emit('data', Buffer.from(key, 'utf8'));
   return emitter;
 }
 
@@ -130,6 +133,31 @@ describe('setupTerminalActions — keypress 라우팅', () => {
     const cleanup = setupTerminalActions(cb, { enabled: true, stdin });
     stdin.emitKey('r');
     expect(cb.reloadCount).toBe(1);
+    cleanup();
+  });
+
+  test('Bun runtime — Buffer 로 emit 된 r 도 처리 (#2605 사용자 보고)', () => {
+    // Bun 의 stdin.setEncoding('utf8') 후에도 'data' event 가 Buffer 로 올 수 있음.
+    // bungae graph-bundler/terminal-actions.ts 가 동일 패턴으로 처리.
+    const cb = makeCallbacks();
+    const stdin = makeStdin();
+    const cleanup = setupTerminalActions(cb, { enabled: true, stdin });
+    stdin.emitKeyBuffer('r');
+    expect(cb.reloadCount).toBe(1);
+    cleanup();
+  });
+
+  test('Bun runtime — Buffer 로 emit 된 ?` (shortcut help) 도 처리', () => {
+    const cb = makeCallbacks();
+    const stdin = makeStdin();
+    const printed: string[] = [];
+    const cleanup = setupTerminalActions(cb, {
+      enabled: true,
+      stdin,
+      printShortcuts: () => printed.push('shown'),
+    });
+    stdin.emitKeyBuffer('?');
+    expect(printed).toEqual(['shown']);
     cleanup();
   });
 

--- a/packages/react-native/src/dev-server/terminal-actions.ts
+++ b/packages/react-native/src/dev-server/terminal-actions.ts
@@ -95,7 +95,16 @@ export function setupTerminalActions(
   options: TerminalActionsOptions = { enabled: true },
 ): () => void {
   const stdin = options.stdin ?? process.stdin;
-  if (!options.enabled || !stdin.isTTY) return () => {};
+  if (!options.enabled) return () => {};
+  if (!stdin.isTTY) {
+    // 사용자가 단축키 안 먹는다고 보고하는 흔한 원인 — wrapper script (npm run /
+    // bun run) 가 stdin 을 inherit 안 해서 child 의 isTTY false. silent skip 시
+    // 사용자가 디버그 어려움 → 한 번 stderr 알림 (#2605 audit).
+    process.stderr.write(
+      '[zts:rn-dev] stdin is not a TTY — keyboard shortcuts (r/d/j/i/a/c/?) disabled\n',
+    );
+    return () => {};
+  }
 
   const wasRaw = stdin.isRaw;
   if (!wasRaw) stdin.setRawMode(true);

--- a/packages/react-native/src/dev-server/terminal-actions.ts
+++ b/packages/react-native/src/dev-server/terminal-actions.ts
@@ -131,10 +131,16 @@ export function setupTerminalActions(
 
   const printShortcuts = options.printShortcuts ?? defaultPrintShortcuts;
 
-  const handleKey = (key: string): void => {
+  // Bun runtime 의 stdin 은 setEncoding('utf8') 호출해도 'data' event 가 Buffer 로
+  // emit 될 수 있다 (Node 와 다른 동작). bungae graph-bundler/terminal-actions.ts
+  // L283-288 가 동일 패턴. string|Buffer 둘 다 받아 toString 으로 정규화.
+  const handleKey = (chunk: string | Buffer): void => {
+    const key = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
     if (process.env.ZTS_DEBUG_TERMINAL === '1') {
       const hex = Buffer.from(key, 'utf8').toString('hex');
-      process.stderr.write(`[zts:rn-dev:debug] key received: hex=${hex} len=${key.length}\n`);
+      process.stderr.write(
+        `[zts:rn-dev:debug] key received: hex=${hex} len=${key.length} type=${typeof chunk}\n`,
+      );
     }
     // Bun event loop edge case — raw mode 가 외부에서 false 로 reset 될 수 있음.
     if (stdin.isTTY && !stdin.isRaw) {

--- a/packages/react-native/src/dev-server/terminal-actions.ts
+++ b/packages/react-native/src/dev-server/terminal-actions.ts
@@ -137,7 +137,11 @@ export function setupTerminalActions(
   const handleKey = (chunk: string | Buffer): void => {
     const key = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
     if (process.env.ZTS_DEBUG_TERMINAL === '1') {
-      const hex = Buffer.from(key, 'utf8').toString('hex');
+      // 원본 byte 보존 — UTF-8 invalid sequence 디버깅용. string→Buffer round-trip 회피.
+      const hex =
+        typeof chunk === 'string'
+          ? Buffer.from(chunk, 'utf8').toString('hex')
+          : chunk.toString('hex');
       process.stderr.write(
         `[zts:rn-dev:debug] key received: hex=${hex} len=${key.length} type=${typeof chunk}\n`,
       );

--- a/packages/react-native/src/dev-server/terminal-actions.ts
+++ b/packages/react-native/src/dev-server/terminal-actions.ts
@@ -107,13 +107,35 @@ export function setupTerminalActions(
   }
 
   const wasRaw = stdin.isRaw;
-  if (!wasRaw) stdin.setRawMode(true);
+  let rawModeOk = true;
+  if (!wasRaw) {
+    try {
+      stdin.setRawMode(true);
+    } catch (err) {
+      rawModeOk = false;
+      process.stderr.write(
+        `[zts:rn-dev] setRawMode failed (${(err as Error).message ?? err}) — keyboard shortcuts disabled\n`,
+      );
+      return () => {};
+    }
+  }
+  // 진단 — `ZTS_DEBUG_TERMINAL=1` 시 listener 등록 상태 출력. Bun runtime / wrapper
+  // script 의 stdin pipe 문제 추적용.
+  if (process.env.ZTS_DEBUG_TERMINAL === '1') {
+    process.stderr.write(
+      `[zts:rn-dev:debug] terminal-actions: isTTY=${stdin.isTTY} isRaw=${stdin.isRaw} rawModeOk=${rawModeOk} runtime=${process.versions.bun ? `bun-${process.versions.bun}` : `node-${process.versions.node}`}\n`,
+    );
+  }
   stdin.resume();
   stdin.setEncoding('utf8');
 
   const printShortcuts = options.printShortcuts ?? defaultPrintShortcuts;
 
   const handleKey = (key: string): void => {
+    if (process.env.ZTS_DEBUG_TERMINAL === '1') {
+      const hex = Buffer.from(key, 'utf8').toString('hex');
+      process.stderr.write(`[zts:rn-dev:debug] key received: hex=${hex} len=${key.length}\n`);
+    }
     // Bun event loop edge case — raw mode 가 외부에서 false 로 reset 될 수 있음.
     if (stdin.isTTY && !stdin.isRaw) {
       try {

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -113,6 +113,7 @@ export type { PluginConfig } from './plugins/types.ts';
 export {
   buildRnBundleOptions,
   bundleRn,
+  DEFAULT_ASSET_EXTS,
   type RnBundleInput,
   type RnWatchInput,
   watchRn,

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -127,7 +127,7 @@ export interface RnBundleInput {
 const DEFAULT_SOURCE_EXTS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.json'];
 // Metro 호환 + RN 흔한 폰트/이미지 — bungae DEFAULT_RESOLVER.assetExts 와 동일.
 // caller 가 `extra.assetExts` 로 override 하면 이 list 무시.
-const DEFAULT_ASSET_EXTS = [
+export const DEFAULT_ASSET_EXTS = [
   // 이미지
   '.bmp',
   '.gif',


### PR DESCRIPTION
## 요약

#2605 audit P0#2 (production asset 복사) + 사용자 보고 UX 이슈 (단축키 안 먹는 진단) 묶음.

## P0#2 — Production asset 복사 (\`--assets-dest\`)

번개 \`packages/bungae/src/build.ts\` L100~L260 + \`zts-bundler/build.ts\` copyAssets + \`plugin-core.ts\` SCALE_REGEX/IOS_SCALES 패턴 이식.

### 신규 module — \`packages/core/bin/rn-asset-copy.mjs\`

- \`SCALE_REGEX\` / \`IOS_SCALES\` (1/2/3) — bungae plugin-core 호환
- \`discoverAssets(projectRoot, exts)\` — walkDir + skip dirs (node_modules / .git / dist / build / .next / .turbo / .bun) + relDir 보존
- \`parseAssetName(file)\` — scale variant 파싱
- \`getAndroidDrawableFolder(scale)\` — Metro \`assetPathUtils.js\` 매핑 (0.75→ldpi / 1→mdpi / 1.5→hdpi / 2→xhdpi / 3→xxhdpi / 4→xxxhdpi). 비표준 scale 은 \`drawable-{round(160*scale)}dpi\`. invalid → mdpi default
- \`androidAssetFileName(relDir, base, ext)\` — Metro flat naming \`__<flatRel>_<base><ext>\`
- \`buildKeepXml(names)\` — Android resources keep tools attribute
- \`copyAssetsForIos\` / \`copyAssetsForAndroid\` / \`copyRnAssets\` 진입점

### \`runRnBundle\` 통합

- dev=false + \`--assets-dest\` 명시 시 \`copyRnAssets\` 호출
- **iOS**: \`<assetsDest>/<relPath>/<file>\` — scale 1/2/3 만 복사
- **Android**: Metro scaleToDrawable folder + flat naming + \`raw/keep.xml\` 생성
- assetExts default — \`@zts/react-native\` 의 \`DEFAULT_ASSET_EXTS\` export (Metro 호환 33개) 사용
- UNSUPPORTED 에서 \`--assets-dest\` 제거. \`--asset-catalog-dest\` (Xcode catalog) 만 잔여

## UX — 터미널 단축키 진단 (사용자 보고)

**보고**: "실제 터미널에서 단축키 안 먹는다"

진단: \`stdin.isTTY === false\` 시 \`setupTerminalActions\` 가 silent skip — wrapper script (\`npm run\` / \`bun run\`) 가 stdin inherit 안 해서 child 의 isTTY false 인 경우 사용자가 모름.

### 보강

- \`terminal-actions.ts\` — isTTY=false 시 \`stderr\` 알림: \`[zts:rn-dev] stdin is not a TTY — keyboard shortcuts (r/d/j/i/a/c/?) disabled\`. \`enabled=false\` 명시 disable 시는 알림 없음 (silent 의도).
- \`rn-dev-input.mjs\` — CLI \`--no-interactive\` 가 \`terminalActions=false\` 로 wire-up. 이전 PR #2638 에서 parse 만 등록, 동작 wire-up 누락이었던 것 fix. CLI flag 가 \`config.useGlobalHotkey\` 보다 우선.

## 테스트

신규 30+ + 기존 갱신:
- \`rn-asset-copy.test.ts\` 25건 (SCALE_REGEX / IOS_SCALES / parseAssetName / getAndroidDrawableFolder / androidAssetFileName / buildKeepXml / discoverAssets / copyRnAssets iOS·Android·guards)
- \`terminal-actions.test.ts\` — isTTY false stderr 알림 + enabled=false silent 2건
- \`zts.test.ts\` — \`--no-interactive\` → terminalActions=false 우선순위 1건
- bootstrap test 의 \`cpSync\` 에 \`rn-asset-copy.mjs\` 추가

## 검증

- \`bun test packages/core/bin/rn-asset-copy.test.ts\` — 25 pass
- \`bun test packages/react-native/src/\` — 409+ pass
- \`bun run --cwd packages/react-native build\` 통과
- \`bun run fmt:check\` 통과 (288 files)

## 후속 (audit 잔여)

- \`--asset-catalog-dest\` (iOS Images.xcassets — Xcode catalog 별도 작업)
- \`--sourcemap-sources-root\` / \`--sourcemap-use-absolute-path\` (zts core sourcemap 영역)

Refs #2605

🤖 Generated with [Claude Code](https://claude.com/claude-code)