### PR TITLE
perf(bundler): sideEffects:false barrel lazy load

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
-const Bundler = @import("../bundler.zig").Bundler;
+const bundler_mod = @import("../bundler.zig");
+const Bundler = bundler_mod.Bundler;
+const BundleResult = bundler_mod.BundleResult;
 const types = @import("../types.zig");
 const emitter = @import("../emitter.zig");
 const ResolveCache = @import("../resolve_cache.zig").ResolveCache;
@@ -7,6 +9,27 @@ const ModuleGraph = @import("../graph.zig").ModuleGraph;
 const test_helpers = @import("../test_helpers.zig");
 const writeFile = test_helpers.writeFile;
 const absPath = test_helpers.absPath;
+
+fn resultHasModulePathEnding(result: *const BundleResult, suffix: []const u8) bool {
+    const paths = result.module_paths orelse return false;
+    for (paths) |path| {
+        if (std.mem.endsWith(u8, path, suffix)) return true;
+    }
+    return false;
+}
+
+fn expectModulePathEnding(result: *const BundleResult, suffix: []const u8, expected: bool) !void {
+    try std.testing.expectEqual(expected, resultHasModulePathEnding(result, suffix));
+}
+
+fn countModulePathsContaining(result: *const BundleResult, needle: []const u8) usize {
+    const paths = result.module_paths orelse return 0;
+    var count: usize = 0;
+    for (paths) |path| {
+        if (std.mem.indexOf(u8, path, needle) != null) count += 1;
+    }
+    return count;
+}
 
 // ============================================================
 // Tree-shaking integration tests
@@ -3866,6 +3889,436 @@ test "TreeShaking: size regression — deep re-export chain only used exports (#
     for ([_][]const u8{ "UNUSED_A_MARKER", "USED_B_MARKER", "UNUSED_B_MARKER", "USED_C_MARKER", "UNUSED_C_MARKER" }) |m| {
         try std.testing.expect(std.mem.indexOf(u8, result.output, m) == null);
     }
+}
+
+test "LazyBarrel: sideEffects false named re-export scans only requested source" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used } from 'pkg';
+        \\console.log(used());
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/index.ts",
+        \\export { used } from './a';
+        \\export { unused } from './b';
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/a.ts", "export function used() { return 'LAZY_SCAN_USED'; }");
+    try writeFile(tmp.dir, "node_modules/pkg/b.ts", "export function unused() { return 'LAZY_SCAN_UNUSED'; }");
+    try writeFile(tmp.dir, "node_modules/pkg/package.json", "{\"name\":\"pkg\",\"main\":\"index.ts\",\"sideEffects\":false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+        .max_threads = 1,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_SCAN_USED") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_SCAN_UNUSED") == null);
+    try expectModulePathEnding(&result, "a.ts", true);
+    try expectModulePathEnding(&result, "b.ts", false);
+}
+
+test "LazyBarrel: import then export default with explicit extension scans requested source" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { value } from 'pkg';
+        \\console.log(value);
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/index.ts",
+        \\import value from './real.js';
+        \\export { value };
+        \\export { unused } from './unused.js';
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/real.js", "export default 'LAZY_IMPORT_EXPORT_DEFAULT';");
+    try writeFile(tmp.dir, "node_modules/pkg/unused.js", "export const unused = 'LAZY_IMPORT_EXPORT_UNUSED';");
+    try writeFile(tmp.dir, "node_modules/pkg/package.json", "{\"name\":\"pkg\",\"main\":\"index.ts\",\"sideEffects\":false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+        .max_threads = 1,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_IMPORT_EXPORT_DEFAULT") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "LAZY_IMPORT_EXPORT_UNUSED") == null);
+    try expectModulePathEnding(&result, "real.js", true);
+    try expectModulePathEnding(&result, "unused.js", false);
+}
+
+test "LazyBarrel: default-as-named re-export scans requested source" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used } from 'pkg';
+        \\console.log(used());
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/index.js",
+        \\export { default as used } from './used.js';
+        \\export { default as unused } from './unused.js';
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/used.js", "export default function used() { return 'DEFAULT_AS_USED'; }");
+    try writeFile(tmp.dir, "node_modules/pkg/unused.js", "export default function unused() { return 'DEFAULT_AS_UNUSED'; }");
+    try writeFile(tmp.dir, "node_modules/pkg/package.json", "{\"name\":\"pkg\",\"main\":\"index.js\",\"sideEffects\":false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+        .max_threads = 1,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "DEFAULT_AS_USED") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "DEFAULT_AS_UNUSED") == null);
+    try expectModulePathEnding(&result, "used.js", true);
+    try expectModulePathEnding(&result, "unused.js", false);
+}
+
+test "LazyBarrel: missing sideEffects field keeps conservative graph scan" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used } from 'pkg';
+        \\console.log(used());
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/index.ts",
+        \\export { used } from './a';
+        \\export { unused } from './b';
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/a.ts", "export function used() { return 'CONSERVATIVE_USED'; }");
+    try writeFile(tmp.dir, "node_modules/pkg/b.ts", "export function unused() { return 'CONSERVATIVE_UNUSED'; }");
+    try writeFile(tmp.dir, "node_modules/pkg/package.json", "{\"name\":\"pkg\",\"main\":\"index.ts\"}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+        .max_threads = 1,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try expectModulePathEnding(&result, "a.ts", true);
+    try expectModulePathEnding(&result, "b.ts", true);
+}
+
+test "LazyBarrel: sideEffects true and glob matched true keep conservative graph scan" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used as a } from 'pkgtrue';
+        \\import { used as c } from 'pkgglob';
+        \\console.log(a(), c());
+    );
+    try writeFile(tmp.dir, "node_modules/pkgtrue/index.js",
+        \\export { used } from './a.js';
+        \\export { unused } from './b.js';
+    );
+    try writeFile(tmp.dir, "node_modules/pkgtrue/a.js", "export function used() { return 'TRUE_USED'; }");
+    try writeFile(tmp.dir, "node_modules/pkgtrue/b.js", "export function unused() { return 'TRUE_UNUSED'; }");
+    try writeFile(tmp.dir, "node_modules/pkgtrue/package.json", "{\"name\":\"pkgtrue\",\"main\":\"index.js\",\"sideEffects\":true}");
+    try writeFile(tmp.dir, "node_modules/pkgglob/index.js",
+        \\export { used } from './c.js';
+        \\export { unused } from './d.js';
+    );
+    try writeFile(tmp.dir, "node_modules/pkgglob/c.js", "export function used() { return 'GLOB_USED'; }");
+    try writeFile(tmp.dir, "node_modules/pkgglob/d.js", "export function unused() { return 'GLOB_UNUSED'; }");
+    try writeFile(tmp.dir, "node_modules/pkgglob/package.json", "{\"name\":\"pkgglob\",\"main\":\"index.js\",\"sideEffects\":[\"./index.js\"]}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+        .max_threads = 1,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try expectModulePathEnding(&result, "node_modules/pkgtrue/a.js", true);
+    try expectModulePathEnding(&result, "node_modules/pkgtrue/b.js", true);
+    try expectModulePathEnding(&result, "node_modules/pkgglob/c.js", true);
+    try expectModulePathEnding(&result, "node_modules/pkgglob/d.js", true);
+}
+
+test "LazyBarrel: unused unresolved re-export still reports resolve error" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used } from 'pkg';
+        \\console.log(used());
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/index.js",
+        \\export { used } from './used.js';
+        \\export { missing } from './missing.js';
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/used.js", "export function used() { return 'UNRESOLVED_USED'; }");
+    try writeFile(tmp.dir, "node_modules/pkg/package.json", "{\"name\":\"pkg\",\"main\":\"index.js\",\"sideEffects\":false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+        .max_threads = 1,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.hasErrors());
+    var found = false;
+    if (result.diagnostics) |diags| {
+        for (diags) |d| {
+            if (d.code == .unresolved_import and std.mem.indexOf(u8, d.message, "Cannot resolve module") != null) {
+                found = true;
+                break;
+            }
+        }
+    }
+    try std.testing.expect(found);
+    try expectModulePathEnding(&result, "used.js", true);
+    try expectModulePathEnding(&result, "missing.js", false);
+}
+
+test "LazyBarrel: export star fallback scans only when direct binding is absent" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry-direct.ts",
+        \\import { direct } from 'pkg';
+        \\console.log(direct());
+    );
+    try writeFile(tmp.dir, "entry-star.ts",
+        \\import { star } from 'pkg';
+        \\console.log(star());
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/index.js",
+        \\export { direct } from './direct.js';
+        \\export * from './star.js';
+        \\export * from './unused-star.js';
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/direct.js", "export function direct() { return 'DIRECT_MARKER'; }");
+    try writeFile(tmp.dir, "node_modules/pkg/star.js", "export function star() { return 'STAR_MARKER'; }");
+    try writeFile(tmp.dir, "node_modules/pkg/unused-star.js", "export function other() { return 'OTHER_STAR_MARKER'; }");
+    try writeFile(tmp.dir, "node_modules/pkg/package.json", "{\"name\":\"pkg\",\"main\":\"index.js\",\"sideEffects\":false}");
+
+    const entry_direct = try absPath(&tmp, "entry-direct.ts");
+    defer std.testing.allocator.free(entry_direct);
+    const entry_star = try absPath(&tmp, "entry-star.ts");
+    defer std.testing.allocator.free(entry_star);
+
+    var direct_bundler = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry_direct},
+        .tree_shaking = true,
+        .max_threads = 1,
+    });
+    defer direct_bundler.deinit();
+    const direct_result = try direct_bundler.bundle();
+    defer direct_result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!direct_result.hasErrors());
+    try expectModulePathEnding(&direct_result, "direct.js", true);
+    try expectModulePathEnding(&direct_result, "star.js", false);
+    try expectModulePathEnding(&direct_result, "unused-star.js", false);
+
+    var star_bundler = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry_star},
+        .tree_shaking = true,
+        .max_threads = 1,
+    });
+    defer star_bundler.deinit();
+    const star_result = try star_bundler.bundle();
+    defer star_result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!star_result.hasErrors());
+    try expectModulePathEnding(&star_result, "direct.js", false);
+    try expectModulePathEnding(&star_result, "star.js", true);
+    try expectModulePathEnding(&star_result, "unused-star.js", true);
+}
+
+test "LazyBarrel: skipped resolved re-export is not reported unresolved in IIFE" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used } from 'pkg';
+        \\console.log(used());
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/index.js",
+        \\export { used } from './used.js';
+        \\export { unused } from './unused.js';
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/used.js", "export function used() { return 'IIFE_LAZY_USED'; }");
+    try writeFile(tmp.dir, "node_modules/pkg/unused.js", "export function unused() { return 'IIFE_LAZY_UNUSED'; }");
+    try writeFile(tmp.dir, "node_modules/pkg/package.json", "{\"name\":\"pkg\",\"main\":\"index.js\",\"sideEffects\":false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+        .format = .iife,
+        .max_threads = 1,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "IIFE_LAZY_USED") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "IIFE_LAZY_UNUSED") == null);
+    try expectModulePathEnding(&result, "used.js", true);
+    try expectModulePathEnding(&result, "unused.js", false);
+}
+
+test "LazyBarrel: namespace dynamic side-effect and require consumers scan all sources" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry-namespace.ts",
+        \\import * as ns from 'pkg';
+        \\const key = Math.random() > 0.5 ? 'a' : 'b';
+        \\console.log(ns[key]);
+    );
+    try writeFile(tmp.dir, "entry-dynamic.ts",
+        \\import('pkg').then((ns) => console.log(ns.a, ns.b));
+    );
+    try writeFile(tmp.dir, "entry-side-effect.ts",
+        \\import 'pkg';
+    );
+    try writeFile(tmp.dir, "entry-require.ts",
+        \\const ns = require('pkg');
+        \\console.log(ns.a, ns.b);
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/index.js",
+        \\export { a } from './a.js';
+        \\export { b } from './b.js';
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/a.js", "export const a = 'ALL_A_MARKER';");
+    try writeFile(tmp.dir, "node_modules/pkg/b.js", "export const b = 'ALL_B_MARKER';");
+    try writeFile(tmp.dir, "node_modules/pkg/package.json", "{\"name\":\"pkg\",\"main\":\"index.js\",\"sideEffects\":false}");
+
+    const entries = [_][]const u8{ "entry-namespace.ts", "entry-dynamic.ts", "entry-side-effect.ts", "entry-require.ts" };
+    for (entries) |entry_name| {
+        const entry = try absPath(&tmp, entry_name);
+        defer std.testing.allocator.free(entry);
+
+        var b = Bundler.init(std.testing.allocator, .{
+            .entry_points = &.{entry},
+            .tree_shaking = true,
+            .max_threads = 1,
+        });
+        defer b.deinit();
+        const result = try b.bundle();
+        defer result.deinit(std.testing.allocator);
+
+        try std.testing.expect(!result.hasErrors());
+        try expectModulePathEnding(&result, "a.js", true);
+        try expectModulePathEnding(&result, "b.js", true);
+    }
+}
+
+test "LazyBarrel: requested local export conservatively scans all records" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { own } from 'pkg';
+        \\console.log(own);
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/index.js",
+        \\export const own = 'OWN_MARKER';
+        \\export { unused } from './unused.js';
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/unused.js", "export const unused = 'LOCAL_EXPORT_UNUSED';");
+    try writeFile(tmp.dir, "node_modules/pkg/package.json", "{\"name\":\"pkg\",\"main\":\"index.js\",\"sideEffects\":false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+        .max_threads = 1,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "OWN_MARKER") != null);
+    try expectModulePathEnding(&result, "unused.js", true);
+}
+
+test "LazyBarrel: stress 320 sideEffects false re-exports scan three requested sources" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { fn0, fn127, fn319 } from 'pkg';
+        \\console.log(fn0(), fn127(), fn319());
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/package.json", "{\"name\":\"pkg\",\"main\":\"index.js\",\"sideEffects\":false}");
+
+    var barrel_buf: std.ArrayList(u8) = .empty;
+    defer barrel_buf.deinit(std.testing.allocator);
+    var i: usize = 0;
+    while (i < 320) : (i += 1) {
+        var line_buf: [96]u8 = undefined;
+        const line = try std.fmt.bufPrint(&line_buf, "export {{ fn{d} }} from './fn{d}.js';\n", .{ i, i });
+        try barrel_buf.appendSlice(std.testing.allocator, line);
+
+        const path = try std.fmt.allocPrint(std.testing.allocator, "node_modules/pkg/fn{d}.js", .{i});
+        defer std.testing.allocator.free(path);
+        const body = try std.fmt.allocPrint(std.testing.allocator, "export function fn{d}() {{ return 'STRESS_FN_{d}_MARKER'; }}\n", .{ i, i });
+        defer std.testing.allocator.free(body);
+        try writeFile(tmp.dir, path, body);
+    }
+    try writeFile(tmp.dir, "node_modules/pkg/index.js", barrel_buf.items);
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+        .max_threads = 1,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "STRESS_FN_0_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "STRESS_FN_127_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "STRESS_FN_319_MARKER") != null);
+    try std.testing.expectEqual(@as(usize, 3), countModulePathsContaining(&result, "node_modules/pkg/fn"));
 }
 
 test "TreeShaking: export star named import prunes unused source exports" {

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -75,6 +75,8 @@ pub const ModuleGraph = struct {
     /// heap chunk — Module 이 수백 바이트라 stack pre-alloc 비효율.
     modules: ModuleList = .{},
     path_to_module: std.StringHashMap(ModuleIndex),
+    requested_exports: std.AutoHashMapUnmanaged(u32, RequestedExports) = .{},
+    requested_exports_mutex: std.Thread.Mutex = .{},
     diagnostics: std.ArrayList(BundlerDiagnostic),
     resolve_cache: *ResolveCache,
     source_read_cache: fs.ReadFileCache = .{},
@@ -232,6 +234,15 @@ pub const ModuleGraph = struct {
         record_index: u32,
     };
 
+    const RequestedExports = struct {
+        all: bool = false,
+        names: std.StringHashMapUnmanaged(void) = .{},
+
+        fn deinit(self: *RequestedExports, allocator: std.mem.Allocator) void {
+            self.names.deinit(allocator);
+        }
+    };
+
     pub fn init(allocator: std.mem.Allocator, resolve_cache: *ResolveCache) ModuleGraph {
         return .{
             .allocator = allocator,
@@ -255,6 +266,9 @@ pub const ModuleGraph = struct {
             self.allocator.free(key.*);
         }
         self.path_to_module.deinit();
+        var req_it = self.requested_exports.valueIterator();
+        while (req_it.next()) |req| req.deinit(self.allocator);
+        self.requested_exports.deinit(self.allocator);
         var pi_it = self.pkg_info_cache.valueIterator();
         while (pi_it.next()) |info| info.side_effects.deinit(self.allocator);
         self.pkg_info_cache.deinit(self.allocator);
@@ -439,6 +453,7 @@ pub const ModuleGraph = struct {
         defer inject_indices.deinit(self.allocator);
         for (self.inject_files) |inject_path| {
             const idx = try self.addModule(inject_path);
+            _ = try self.requestAllExports(idx);
             try inject_indices.append(self.allocator, idx);
         }
 
@@ -448,6 +463,7 @@ pub const ModuleGraph = struct {
         defer run_before_main_indices.deinit(self.allocator);
         for (self.run_before_main_files) |rbm_path| {
             const idx = try self.addModule(rbm_path);
+            _ = try self.requestAllExports(idx);
             try run_before_main_indices.append(self.allocator, idx);
         }
 
@@ -457,7 +473,8 @@ pub const ModuleGraph = struct {
         // 배치 경계 없이 모듈 발견 즉시 파싱 시작 → CPU 유휴 시간 최소화.
         var discover_scope = profile.begin(.graph_discover);
         for (entry_points) |entry_path| {
-            _ = try self.addModule(entry_path);
+            const idx = try self.addModule(entry_path);
+            _ = try self.requestAllExports(idx);
         }
 
         var spawned_up_to: usize = 0;
@@ -595,6 +612,7 @@ pub const ModuleGraph = struct {
         const discover_start = self.modules.count();
         for (selected.items) |module| {
             const idx = try self.addModule(module.path);
+            _ = try self.requestAllExports(idx);
             if (self.moduleAtMut(idx)) |m| {
                 m.is_context_dep = true;
             }
@@ -713,6 +731,232 @@ pub const ModuleGraph = struct {
         try self.linkDependency(from, to);
     }
 
+    fn requestAllExports(self: *ModuleGraph, idx: ModuleIndex) !bool {
+        if (idx.isNone()) return false;
+        const key: u32 = @intFromEnum(idx);
+        self.requested_exports_mutex.lock();
+        defer self.requested_exports_mutex.unlock();
+
+        const gop = try self.requested_exports.getOrPut(self.allocator, key);
+        if (!gop.found_existing) {
+            gop.value_ptr.* = .{};
+        }
+        if (gop.value_ptr.all) return false;
+        gop.value_ptr.names.deinit(self.allocator);
+        gop.value_ptr.names = .{};
+        gop.value_ptr.all = true;
+        return true;
+    }
+
+    fn requestNamedExport(self: *ModuleGraph, idx: ModuleIndex, name: []const u8) !bool {
+        if (idx.isNone()) return false;
+        const key: u32 = @intFromEnum(idx);
+        self.requested_exports_mutex.lock();
+        defer self.requested_exports_mutex.unlock();
+
+        const gop = try self.requested_exports.getOrPut(self.allocator, key);
+        if (!gop.found_existing) {
+            gop.value_ptr.* = .{};
+        }
+        if (gop.value_ptr.all) return false;
+        if (gop.value_ptr.names.contains(name)) return false;
+        try gop.value_ptr.names.put(self.allocator, name, {});
+        return true;
+    }
+
+    fn isLazyBarrelCandidate(self: *const ModuleGraph, m: *const Module) bool {
+        if (self.dev_mode or self.preserve_modules) return false;
+        return m.side_effects_user_defined and
+            !m.side_effects and
+            m.exports_kind.isEsm() and
+            m.import_records.len > 0 and
+            m.export_bindings.len > 0;
+    }
+
+    fn requestedLocalExportNeedsAllRecords(m: *const Module, req: *const RequestedExports) bool {
+        if (req.all) return true;
+        var it = req.names.keyIterator();
+        while (it.next()) |name| {
+            for (m.export_bindings) |eb| {
+                if (eb.kind == .local and std.mem.eql(u8, eb.exported_name, name.*)) return true;
+            }
+        }
+        return false;
+    }
+
+    fn requestedNameHasDirectNonStarExport(m: *const Module, name: []const u8) bool {
+        for (m.export_bindings) |eb| {
+            if (eb.kind == .re_export_star) continue;
+            if (std.mem.eql(u8, eb.exported_name, name)) return true;
+        }
+        return false;
+    }
+
+    fn reExportRecordMatchesRequest(m: *const Module, rec_i: usize, req: *const RequestedExports) bool {
+        if (req.all) return true;
+        var names = req.names.keyIterator();
+        while (names.next()) |requested_name| {
+            for (m.export_bindings) |eb| {
+                const eb_rec = eb.import_record_index orelse continue;
+                if (eb_rec != rec_i) continue;
+                switch (eb.kind) {
+                    .re_export => {
+                        if (std.mem.eql(u8, eb.exported_name, requested_name.*)) return true;
+                    },
+                    .re_export_namespace => {
+                        if (std.mem.eql(u8, eb.exported_name, requested_name.*)) return true;
+                    },
+                    .re_export_star => {
+                        if (!requestedNameHasDirectNonStarExport(m, requested_name.*)) return true;
+                    },
+                    .local => {},
+                }
+            }
+        }
+        return false;
+    }
+
+    fn shouldLinkResolvedRecordForModule(self: *ModuleGraph, mod_idx: usize, rec_i: usize, record: ImportRecord) bool {
+        const m = self.modules.at(mod_idx);
+        switch (record.kind) {
+            .side_effect, .require, .dynamic_import, .worker, .glob, .require_context => return true,
+            .static_import, .re_export => {},
+        }
+
+        if (!self.isLazyBarrelCandidate(m)) return true;
+
+        const key: u32 = @intCast(mod_idx);
+        self.requested_exports_mutex.lock();
+        defer self.requested_exports_mutex.unlock();
+        const req = self.requested_exports.get(key) orelse return true;
+        if (req.all) return true;
+        if (requestedLocalExportNeedsAllRecords(m, &req)) return true;
+        return reExportRecordMatchesRequest(m, rec_i, &req);
+    }
+
+    fn shouldResolveRecordForModule(self: *ModuleGraph, mod_idx: usize, rec_i: usize, record: ImportRecord) bool {
+        if (record.resolved != .none or record.is_external) return false;
+        return self.shouldLinkResolvedRecordForModule(mod_idx, rec_i, record);
+    }
+
+    fn discardResolvedModule(self: *ModuleGraph, resolved: plugin_mod.ResolvedModule) void {
+        switch (resolved) {
+            .file => |f| self.allocator.free(f.path),
+            .disabled => |d| self.allocator.free(d.path),
+            .virtual, .dataurl, .external, .custom => {},
+        }
+    }
+
+    fn markRecordLazyResolved(self: *ModuleGraph, mod_idx: usize, rec_i: usize) void {
+        if (mod_idx >= self.modules.count()) return;
+        const m = self.modules.at(mod_idx);
+        if (rec_i >= m.import_records.len) return;
+        m.import_records[rec_i].is_lazy_resolved = true;
+    }
+
+    fn hasDeferredRequestedImports(self: *ModuleGraph, mod_idx: usize) bool {
+        if (mod_idx >= self.modules.count()) return false;
+        const m = self.modules.at(mod_idx);
+        for (m.import_records, 0..) |record, rec_i| {
+            if (self.shouldResolveRecordForModule(mod_idx, rec_i, record)) return true;
+        }
+        return false;
+    }
+
+    fn resolveDeferredRequestedImportsIfReady(self: *ModuleGraph, idx: ModuleIndex) anyerror!void {
+        const mod_idx = self.validModuleSlot(idx) orelse return;
+        const m = self.modules.at(mod_idx);
+        if (m.state != .ready or m.is_external or m.is_disabled) return;
+        if (!self.hasDeferredRequestedImports(mod_idx)) return;
+        try self.resolveModuleImports(idx);
+    }
+
+    fn requestedExportsForReExportRecord(
+        self: *ModuleGraph,
+        importer: *const Module,
+        rec_i: usize,
+        dep_idx: ModuleIndex,
+    ) !bool {
+        const importer_key: u32 = @intFromEnum(importer.index);
+        var changed = false;
+
+        var requested_names: std.ArrayList([]const u8) = .empty;
+        defer requested_names.deinit(self.allocator);
+
+        self.requested_exports_mutex.lock();
+        const maybe_req = self.requested_exports.get(importer_key);
+        const request_all = if (maybe_req) |req| req.all else true;
+        if (!request_all) {
+            if (maybe_req) |req| {
+                var it = req.names.keyIterator();
+                while (it.next()) |name| {
+                    requested_names.append(self.allocator, name.*) catch {
+                        self.requested_exports_mutex.unlock();
+                        return error.OutOfMemory;
+                    };
+                }
+            }
+        }
+        self.requested_exports_mutex.unlock();
+        if (request_all) return self.requestAllExports(dep_idx);
+
+        for (requested_names.items) |requested_name| {
+            for (importer.export_bindings) |eb| {
+                const eb_rec = eb.import_record_index orelse continue;
+                if (eb_rec != rec_i) continue;
+                switch (eb.kind) {
+                    .re_export => {
+                        if (std.mem.eql(u8, eb.exported_name, requested_name)) {
+                            changed = (try self.requestNamedExport(dep_idx, eb.local_name)) or changed;
+                        }
+                    },
+                    .re_export_namespace => {
+                        if (std.mem.eql(u8, eb.exported_name, requested_name)) {
+                            changed = (try self.requestAllExports(dep_idx)) or changed;
+                        }
+                    },
+                    .re_export_star => {
+                        if (!requestedNameHasDirectNonStarExport(importer, requested_name)) {
+                            changed = (try self.requestNamedExport(dep_idx, requested_name)) or changed;
+                        }
+                    },
+                    .local => {},
+                }
+            }
+        }
+        return changed;
+    }
+
+    fn requestDependencyExports(
+        self: *ModuleGraph,
+        importer_idx: usize,
+        rec_i: usize,
+        record: ImportRecord,
+        dep_idx: ModuleIndex,
+    ) !bool {
+        const importer = self.modules.at(importer_idx);
+        switch (record.kind) {
+            .static_import => {
+                var changed = false;
+                var found_binding = false;
+                for (importer.import_bindings) |ib| {
+                    if (ib.import_record_index != rec_i) continue;
+                    found_binding = true;
+                    switch (ib.kind) {
+                        .namespace => changed = (try self.requestAllExports(dep_idx)) or changed,
+                        .default, .named => changed = (try self.requestNamedExport(dep_idx, ib.imported_name)) or changed,
+                    }
+                }
+                if (!found_binding) {
+                    changed = (try self.requestAllExports(dep_idx)) or changed;
+                }
+                return changed;
+            },
+            .re_export => return self.requestedExportsForReExportRecord(importer, rec_i, dep_idx),
+            .side_effect, .require, .dynamic_import, .worker, .glob, .require_context => return self.requestAllExports(dep_idx),
+        }
+    }
+
     /// Phase 2-4: DFS exec_index + ExportsKind 승격 + TLA 전파.
     /// build()와 buildIncremental() 양쪽에서 호출.
     fn finalizeGraph(self: *ModuleGraph, entry_points: []const []const u8) !void {
@@ -816,6 +1060,7 @@ pub const ModuleGraph = struct {
         defer inject_indices.deinit(self.allocator);
         for (self.inject_files) |inject_path| {
             const idx = try self.addModule(inject_path);
+            _ = try self.requestAllExports(idx);
             try inject_indices.append(self.allocator, idx);
         }
 
@@ -823,11 +1068,13 @@ pub const ModuleGraph = struct {
         defer run_before_main_indices.deinit(self.allocator);
         for (self.run_before_main_files) |rbm_path| {
             const idx = try self.addModule(rbm_path);
+            _ = try self.requestAllExports(idx);
             try run_before_main_indices.append(self.allocator, idx);
         }
 
         for (entry_points) |entry_path| {
-            _ = try self.addModule(entry_path);
+            const idx = try self.addModule(entry_path);
+            _ = try self.requestAllExports(idx);
         }
 
         var reparsed: std.ArrayListUnmanaged(types.ModuleIndex) = .empty;
@@ -916,6 +1163,7 @@ pub const ModuleGraph = struct {
             for (parse_start..parse_end) |i| {
                 if (cache_hit_modules.contains(@intCast(i))) {
                     try self.replayCachedResolvedDeps(i);
+                    try self.resolveDeferredRequestedImportsIfReady(ModuleIndex.fromUsize(i));
                 } else {
                     try self.resolveModuleImports(@enumFromInt(@as(u32, @intCast(i))));
                 }
@@ -1093,6 +1341,7 @@ pub const ModuleGraph = struct {
                     if (dep.record_index) |rec_idx| {
                         if (rec_idx < mod_ptr.import_records.len) {
                             mod_ptr.import_records[rec_idx].is_external = true;
+                            _ = try self.requestDependencyExports(mod_idx, rec_idx, mod_ptr.import_records[rec_idx], ext_idx);
                         }
                     }
                     if (dep.kind == .dynamic_import) {
@@ -1126,9 +1375,12 @@ pub const ModuleGraph = struct {
         if (dep.record_index) |rec_idx| {
             const mod_ptr = self.modules.at(mod_idx);
             if (rec_idx >= mod_ptr.import_records.len) return;
+            const request_changed = try self.requestDependencyExports(mod_idx, rec_idx, mod_ptr.import_records[rec_idx], dep_idx);
             try self.recordResolvedDep(mod_index, mod_idx, rec_idx, dep_idx, dep.kind);
+            if (request_changed) try self.resolveDeferredRequestedImportsIfReady(dep_idx);
             return;
         }
+        _ = try self.requestAllExports(dep_idx);
         if (dep.kind == .dynamic_import) {
             try self.linkDynamicImport(mod_index, dep_idx);
         } else {
@@ -1167,6 +1419,7 @@ pub const ModuleGraph = struct {
                 .file => |f| {
                     defer self.allocator.free(f.path);
                     const dep_idx = try self.addModule(f.path);
+                    _ = try self.requestAllExports(dep_idx);
                     // tree-shaker 가 static import 없이도 이 모듈을 보존하도록 마킹.
                     self.modules.at(@intFromEnum(dep_idx)).is_context_dep = true;
                     try self.appendResolvedDep(mod_idx, .{
@@ -1198,6 +1451,7 @@ pub const ModuleGraph = struct {
     ) !void {
         const src_mod = self.modules.at(mod_idx);
         src_mod.import_records[rec_i].resolved = dep_idx;
+        src_mod.import_records[rec_i].is_lazy_resolved = false;
         if (kind == .dynamic_import) {
             try self.linkDynamicImport(mod_index, dep_idx);
         } else {
@@ -1382,6 +1636,7 @@ pub const ModuleGraph = struct {
                     if (f.is_module_field or self.modules.at(mod_idx).is_module_field) {
                         self.modules.at(@intFromEnum(dep_idx)).is_module_field = true;
                     }
+                    const request_changed = try self.requestDependencyExports(mod_idx, rec_i, record, dep_idx);
                     try self.appendResolvedDep(mod_idx, .{
                         .record_index = @intCast(rec_i),
                         .kind = record.kind,
@@ -1390,10 +1645,12 @@ pub const ModuleGraph = struct {
                         .target_is_module_field = f.is_module_field,
                     });
                     try self.recordResolvedDep(mod_index, mod_idx, rec_i, dep_idx, record.kind);
+                    if (request_changed) try self.resolveDeferredRequestedImportsIfReady(dep_idx);
                 },
                 .disabled => |d| {
                     defer self.allocator.free(d.path);
                     const dep_idx = try self.addDisabledModule(record.specifier);
+                    _ = try self.requestDependencyExports(mod_idx, rec_i, record, dep_idx);
                     try self.appendResolvedDep(mod_idx, .{
                         .record_index = @intCast(rec_i),
                         .kind = record.kind,
@@ -1408,6 +1665,7 @@ pub const ModuleGraph = struct {
                     // specifier (runtime_helper_modules) 일 수 있어 free 안 함 — plugin 이
                     // alloc 했으면 plugin context lifetime 동안 살아있어야 한다는 규약.
                     const dep_idx = try self.addModule(v.path);
+                    const request_changed = try self.requestDependencyExports(mod_idx, rec_i, record, dep_idx);
                     try self.appendResolvedDep(mod_idx, .{
                         .record_index = @intCast(rec_i),
                         .kind = record.kind,
@@ -1415,6 +1673,7 @@ pub const ModuleGraph = struct {
                         .path = v.path,
                     });
                     try self.recordResolvedDep(mod_index, mod_idx, rec_i, dep_idx, record.kind);
+                    if (request_changed) try self.resolveDeferredRequestedImportsIfReady(dep_idx);
                 },
                 .dataurl, .external, .custom => unreachable,
             }
@@ -1426,6 +1685,8 @@ pub const ModuleGraph = struct {
             const ext_idx = try self.addExternalModule(record.specifier);
             const src_mod = self.modules.at(mod_idx);
             src_mod.import_records[rec_i].is_external = true;
+            src_mod.import_records[rec_i].is_lazy_resolved = false;
+            _ = try self.requestDependencyExports(mod_idx, rec_i, record, ext_idx);
             try self.appendResolvedDep(mod_idx, .{
                 .record_index = @intCast(rec_i),
                 .kind = record.kind,
@@ -1444,6 +1705,7 @@ pub const ModuleGraph = struct {
     const ResolveOutput = struct {
         resolved: ?plugin_mod.ResolvedModule = null,
         is_error: bool = false,
+        skipped: bool = false,
     };
 
     /// 이벤트 큐 기반 스캔 결과. 워커가 채널로 전송, 메인이 수신.
@@ -1487,8 +1749,16 @@ pub const ModuleGraph = struct {
         // ArrayList-era drain/realloc path is no longer needed.
         for (records, 0..) |record, rec_i| {
             if (rec_i < resolves.len) {
+                if (resolves[rec_i].skipped and !resolves[rec_i].is_error) {
+                    self.markRecordLazyResolved(mod_idx, rec_i);
+                    if (resolves[rec_i].resolved) |resolved| self.discardResolvedModule(resolved);
+                    continue;
+                }
                 try self.applyResolveResult(mod_idx, rec_i, record, resolves[rec_i].resolved, resolves[rec_i].is_error);
             }
+        }
+        if (self.hasDeferredRequestedImports(mod_idx)) {
+            try self.resolveModuleImports(result.module_idx);
         }
         // Register require.context matches as graph dependencies (#1579 Phase 4).
         try self.applyContextDepResults(mod_idx);
@@ -1510,6 +1780,7 @@ pub const ModuleGraph = struct {
         }
 
         const mod_ptr = self.modules.at(mod_idx);
+        self.applySideEffectsFromPackageJson(mod_ptr);
         if (mod_ptr.import_records.len == 0) {
             return .{ .module_idx = idx, .resolve_outputs = &.{} };
         }
@@ -1537,8 +1808,15 @@ pub const ModuleGraph = struct {
             defer resolve_scope.end();
 
             for (records, 0..) |record, rec_i| {
-                if (record.kind == .glob) continue;
-                if (record.kind == .require_context) continue;
+                if (record.kind == .glob or record.kind == .require_context) {
+                    results[rec_i].skipped = true;
+                    continue;
+                }
+                if (record.resolved != .none or record.is_external) {
+                    results[rec_i].skipped = true;
+                    continue;
+                }
+                const should_link = self.shouldLinkResolvedRecordForModule(mod_idx, rec_i, record);
 
                 if (plugin_runner) |runner| {
                     if (self.shouldRunResolveId(record.specifier)) {
@@ -1550,7 +1828,7 @@ pub const ModuleGraph = struct {
                             },
                         };
                         if (resolve_result) |plugin_result| {
-                            results[rec_i] = .{ .resolved = plugin_result, .is_error = false };
+                            results[rec_i] = .{ .resolved = plugin_result, .is_error = false, .skipped = !should_link };
                             continue;
                         }
                     }
@@ -1562,7 +1840,7 @@ pub const ModuleGraph = struct {
                     record.kind,
                 ) catch |err| switch (err) {
                     error.ModuleNotFound => {
-                        results[rec_i] = .{ .is_error = true };
+                        results[rec_i] = .{ .is_error = true, .skipped = !should_link };
                         continue;
                     },
                     error.OutOfMemory => {
@@ -1570,7 +1848,7 @@ pub const ModuleGraph = struct {
                         continue;
                     },
                 };
-                results[rec_i] = .{ .resolved = resolved };
+                results[rec_i] = .{ .resolved = resolved, .skipped = !should_link };
             }
         }
 
@@ -2864,6 +3142,8 @@ pub const ModuleGraph = struct {
         for (records, 0..) |record, rec_i| {
             if (record.kind == .glob) continue;
             if (record.kind == .require_context) continue;
+            if (record.resolved != .none or record.is_external) continue;
+            const should_link = self.shouldLinkResolvedRecordForModule(mod_idx, rec_i, record);
 
             // Plugin: resolveId 훅 — 기본 resolver 전에 플러그인에게 경로 해석 기회를 줌
             if (plugin_runner) |runner| {
@@ -2874,7 +3154,12 @@ pub const ModuleGraph = struct {
                     };
                     // non-null이면 플러그인이 resolve 완료 → 기본 resolver 건너뜀
                     if (resolve_result) |plugin_result| {
-                        try self.applyResolveResult(mod_idx, rec_i, record, plugin_result, false);
+                        if (should_link) {
+                            try self.applyResolveResult(mod_idx, rec_i, record, plugin_result, false);
+                        } else {
+                            self.markRecordLazyResolved(mod_idx, rec_i);
+                            self.discardResolvedModule(plugin_result);
+                        }
                         continue;
                     }
                     // null이면 기본 resolver로 fall through
@@ -2892,7 +3177,12 @@ pub const ModuleGraph = struct {
                 },
                 error.OutOfMemory => return error.OutOfMemory,
             };
-            try self.applyResolveResult(mod_idx, rec_i, record, resolved, false);
+            if (should_link) {
+                try self.applyResolveResult(mod_idx, rec_i, record, resolved, false);
+            } else if (resolved) |resolved_module| {
+                self.markRecordLazyResolved(mod_idx, rec_i);
+                self.discardResolvedModule(resolved_module);
+            }
         }
 
         // require.context context_expansion_deps 도 resolve + addDep.

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -703,7 +703,7 @@ pub const Linker = struct {
                         if (!std.mem.eql(u8, ib.local_name, sym_name)) continue;
                         if (ib.import_record_index >= m.import_records.len) break :blk false;
                         const rec = m.import_records[ib.import_record_index];
-                        if (rec.resolved.isNone()) break :blk true;
+                        if (rec.resolved.isNone()) break :blk !rec.is_lazy_resolved;
                         const target_idx = @intFromEnum(rec.resolved);
                         if (target_idx >= self.graph.moduleCount()) break :blk m.wrap_kind == .esm;
                         const target_wrap = self.getModule(target_idx).?.wrap_kind;

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -297,6 +297,7 @@ pub fn buildMetadataForAst(
 
             // resolve 미완료: external 또는 resolve 실패.
             if (rec.resolved.isNone()) {
+                if (rec.is_lazy_resolved) continue;
                 if (rec.kind == .static_import or rec.kind == .side_effect or rec.kind == .re_export) {
                     if (!ib.isSynthetic() and !ib.local_symbol.isValid()) continue;
                     const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse m.importBindingLocalName(ib);

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -593,6 +593,10 @@ pub const ImportRecord = struct {
     url_span: ?Span = null,
     /// resolve 완료 후 채워지는 모듈 인덱스
     resolved: ModuleIndex = .none,
+    /// resolve는 성공했지만 `sideEffects:false` lazy barrel 최적화로 target module graph
+    /// 등록만 미룬 record. 성공 resolve와 실제 unresolved를 구분해 IIFE emit 진단이
+    /// unused re-export를 오탐하지 않도록 한다.
+    is_lazy_resolved: bool = false,
     /// --external로 명시적으로 제외된 모듈 (resolve 실패와 구분)
     is_external: bool = false,
     /// try-block 안의 `require("xxx")` 또는 동적 `import("xxx")` —


### PR DESCRIPTION
## 요약

- `sideEffects:false` ESM barrel에서 요청된 named export에 필요한 re-export source만 graph scan 하도록 lazy discovery를 추가했습니다.
- unused re-export source는 resolve 진단 정책을 유지하기 위해 resolver는 통과시키고, 성공한 resolve 결과의 `addModule`/recursive scan만 미룹니다.
- namespace import, dynamic import, side-effect import, `require`, own local export 사용, `sideEffects` 미명시/true/glob true 파일은 기존처럼 보수적으로 전체 record를 로드합니다.

## 검증

- `zig build test -Dtest-filter=LazyBarrel --summary all` — 24/24 pass
- `zig build`
- `zig build napi`
- `bun run tests/benchmark/smoke.ts --filter=lodash-es --json=/tmp/lodash-smoke.json` — 4/4 MATCH
- lodash-es graph probe — root `153 inputs / lodash 152`, direct `152 inputs / lodash 151`
- `bun test packages/core/index.test.ts packages/core/napi.test.mjs packages/core/bin/zts-cli-schema-sync.test.ts` — 431 pass
- `.git/hooks/pre-push` — pass

참고: pre-push 중 oxlint 기존 warning 19개가 출력되지만 error는 0개이며 훅은 통과했습니다.
