### PR TITLE
feat(react-native): HMR client log color/badge formatting (#2605 audit P2)

### DIFF
--- a/packages/react-native/src/dev-server/hmr-bridge.ts
+++ b/packages/react-native/src/dev-server/hmr-bridge.ts
@@ -12,7 +12,7 @@ import type { Socket } from 'node:net';
 import type { WatchRebuildEvent } from '@zts/core';
 
 import { createMetroHmrAdapter, type MetroHmrAdapter } from '../metro-hmr-adapter.ts';
-import { colors, logError, logInfo } from './logger.ts';
+import { colors, formatLogBadge, logError, logInfo } from './logger.ts';
 import type { PlatformState, PlatformStateCallbacks } from './platform-state.ts';
 
 export interface HmrBridgeOptions {
@@ -116,7 +116,7 @@ function buildIncomingHandler(adapter: MetroHmrAdapter) {
           return String(arg);
         })
         .join(' ');
-      console.log(`[${level.toUpperCase()}] ${formatted}`);
+      console.log(`${formatLogBadge(level)} ${formatted}`);
       // adapter 가 server-broadcast 하지 않음 — log 는 client→server one-way.
       void adapter;
     }

--- a/packages/react-native/src/dev-server/index.ts
+++ b/packages/react-native/src/dev-server/index.ts
@@ -22,7 +22,15 @@ export {
 export { parseRequestUrl, readJsonBody, sendJson, sendText } from './http-utils.ts';
 export type { CustomizeFrame, RnDevServerOptions, RnDevServerOptionsInput } from './options.ts';
 export { buildRnDevServerOptions } from './options.ts';
-export { colors, logBundle, logError, logInfo, logWarn, printZtsRnBanner } from './logger.ts';
+export {
+  colors,
+  formatLogBadge,
+  logBundle,
+  logError,
+  logInfo,
+  logWarn,
+  printZtsRnBanner,
+} from './logger.ts';
 export {
   createPlatformState,
   createPlatformStateRegistry,

--- a/packages/react-native/src/dev-server/logger.test.ts
+++ b/packages/react-native/src/dev-server/logger.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 
-import { colors, logBundle, logError, logInfo, logWarn, printZtsRnBanner } from './logger.ts';
+import {
+  colors,
+  formatLogBadge,
+  logBundle,
+  logError,
+  logInfo,
+  logWarn,
+  printZtsRnBanner,
+} from './logger.ts';
 
 let logSpy: ReturnType<typeof mock>;
 let warnSpy: ReturnType<typeof mock>;
@@ -110,5 +118,42 @@ describe('printZtsRnBanner', () => {
     expect(out).toContain('╔');
     expect(out).toContain('║');
     expect(out).toContain('╚');
+  });
+});
+
+describe('formatLogBadge — RN client console.log forwarding (#2605 audit P2)', () => {
+  test('error → red INVERSE BOLD ERROR', () => {
+    const badge = formatLogBadge('error');
+    expect(badge).toContain(colors.red);
+    expect(badge).toContain(colors.inverse);
+    expect(badge).toContain(colors.bold);
+    expect(badge).toContain(' ERROR ');
+    expect(badge.endsWith(colors.reset)).toBe(true);
+  });
+
+  test('warn → yellow', () => {
+    expect(formatLogBadge('warn')).toContain(colors.yellow);
+  });
+
+  test('debug → magenta', () => {
+    expect(formatLogBadge('debug')).toContain(colors.magenta);
+  });
+
+  test('info → cyan', () => {
+    expect(formatLogBadge('info')).toContain(colors.cyan);
+  });
+
+  test('log (default) → white', () => {
+    expect(formatLogBadge('log')).toContain(colors.white);
+  });
+
+  test('unknown level → white default', () => {
+    expect(formatLogBadge('verbose')).toContain(colors.white);
+    expect(formatLogBadge('verbose')).toContain(' VERBOSE ');
+  });
+
+  test('level uppercase 적용', () => {
+    expect(formatLogBadge('error')).toContain(' ERROR ');
+    expect(formatLogBadge('Warn')).toContain(' WARN ');
   });
 });

--- a/packages/react-native/src/dev-server/logger.ts
+++ b/packages/react-native/src/dev-server/logger.ts
@@ -30,6 +30,25 @@ export function logError(...args: unknown[]): void {
 }
 
 /**
+ * RN runtime 의 console.log 를 dev server 터미널로 forward 시 사용 — Metro 호환
+ * level 별 색상 INVERSE BOLD badge. error=red / warn=yellow / debug=magenta /
+ * info=cyan / log=white. bungae graph-bundler/utils.ts 패턴 동등.
+ */
+export function formatLogBadge(level: string): string {
+  const color =
+    level === 'error'
+      ? colors.red
+      : level === 'warn'
+        ? colors.yellow
+        : level === 'debug'
+          ? colors.magenta
+          : level === 'info'
+            ? colors.cyan
+            : colors.white;
+  return `${color}${colors.inverse}${colors.bold} ${level.toUpperCase()} ${colors.reset}`;
+}
+
+/**
  * Metro `TerminalReporter._getBundleStatusMessage` 호환 BUNDLE 상태 라인.
  * `done` 녹색 / `failed` 빨강 / `request` 노랑.
  */

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -66,6 +66,7 @@ export {
   type PlatformStateCallbacks,
   type PlatformStateRegistry,
   colors,
+  formatLogBadge,
   logBundle,
   logError,
   logInfo,


### PR DESCRIPTION
## 요약

4차 audit P2 — RN runtime 의 \`console.log\` forwarding 시 level 별 색상 INVERSE BOLD badge. bungae \`graph-bundler/server/index.ts\` L374-400 + \`utils.ts\` colors 패턴 이식.

## 변경

기존:
\`\`\`
[ERROR] something
\`\`\`

수정 후:
\`\`\`
 ERROR  something    ← red INVERSE BOLD badge
\`\`\`

### \`logger.ts\` — 새 \`formatLogBadge(level)\` helper

| level | color |
|---|---|
| error | red |
| warn | yellow |
| debug | magenta |
| info | cyan |
| log / 기타 | white |

### \`hmr-bridge.ts\` — log handler 가 helper 사용

기존 \`[${level.toUpperCase()}]\` 단순 텍스트 → \`formatLogBadge(level)\` 적용.

### exports

\`@zts/react-native\` 와 \`dev-server\` 의 index 에서 \`formatLogBadge\` re-export — caller 가 자체 log 영역에 사용 가능.

## 테스트

\`logger.test.ts\` 신규 7건:
- error → red INVERSE BOLD ERROR
- warn → yellow
- debug → magenta
- info → cyan
- log → white default
- unknown level → white default + uppercase
- 'Warn' 같은 mixed case → 'WARN' 으로 uppercase

총: \`logger.test.ts\` 18 pass, \`hmr-bridge.test.ts\` 8 pass.

## 4차 audit 잔여

| 우선 | 항목 | 비고 |
|------|------|------|
| ✅ P2 | HMR log color/badge | 본 PR |
| P1 | \`computeHttpServerLocation\` parity | Zig core asset emitter 영역 — 본 epic 외, 별도 audit |
| P2 | \`--asset-catalog-dest\` (Xcode catalog) | 별도 작업 (iOS 의 .xcassets 생성) |
| P2 | \`--transform-option\` / \`--resolver-option\` | graph-bundler 전용 — 자체 구현 어려움, UNSUPPORTED 유지 |
| P2 | \`--unstable-transform-profile\` | Metro hermes profile flag — zts core 미지원, UNSUPPORTED 유지 |

Refs #2605

🤖 Generated with [Claude Code](https://claude.com/claude-code)