### PR TITLE
debug(react-native): symbolicate 진단 로그 + 매핑 실패 원인 분석 (#2605 사용자 보고)

### DIFF
--- a/packages/react-native/src/dev-server/routes/symbolicate.ts
+++ b/packages/react-native/src/dev-server/routes/symbolicate.ts
@@ -43,17 +43,31 @@ export async function handleSymbolicateRequest(
   const state = resolvePlatform(url, registry, defaultPlatform);
   const sourceMap = getCachedSourceMap(state);
 
+  const debug = process.env.ZTS_DEBUG_SYMBOLICATE === '1';
+  if (debug) {
+    process.stderr.write(
+      `[zts:rn-dev:debug] /symbolicate stack[${stack.length}] sourceMap=${sourceMap ? `len=${sourceMap.length}` : 'null'}\n`,
+    );
+    for (const f of stack.slice(0, 5)) {
+      process.stderr.write(
+        `[zts:rn-dev:debug]   in: file=${f.file} line=${f.lineNumber} col=${f.column} method=${f.methodName}\n`,
+      );
+    }
+  }
+
   const fallback: SymbolicateResponse = {
     stack: stack.map(normalizeFrame),
     codeFrame: null,
   };
   if (!sourceMap) {
+    if (debug) process.stderr.write('[zts:rn-dev:debug]   sourceMap miss → fallback\n');
     sendJson(res, 200, fallback);
     return;
   }
 
   const consumer = await createSourceMapConsumer(sourceMap);
   if (!consumer) {
+    if (debug) process.stderr.write('[zts:rn-dev:debug]   consumer create fail → fallback\n');
     sendJson(res, 200, fallback);
     return;
   }
@@ -66,6 +80,16 @@ export async function handleSymbolicateRequest(
       }),
     );
     const codeFrame = await extractCodeFrame(symbolicated);
+    if (debug) {
+      for (const f of symbolicated.slice(0, 5)) {
+        process.stderr.write(
+          `[zts:rn-dev:debug]   out: file=${f.file} line=${f.lineNumber} col=${f.column} method=${f.methodName}${f.collapse ? ' collapse=true' : ''}\n`,
+        );
+      }
+      process.stderr.write(
+        `[zts:rn-dev:debug]   codeFrame: ${codeFrame ? `${codeFrame.fileName}:${codeFrame.location.row}` : 'null'}\n`,
+      );
+    }
     sendJson(res, 200, { stack: symbolicated, codeFrame } satisfies SymbolicateResponse);
   } finally {
     consumer.destroy?.();


### PR DESCRIPTION
## 사용자 보고

RN LogBox 의 stack trace 가 source 로 매핑 안 됨.

## 직접 검증 결과 (examples/react-native-bare)

\`\`\`
[0] line=1000 col=50    → 매핑 실패 (bundle URL 그대로 fallback)
[1] line=50000 col=100  → 매핑 실패
[2] line=124000 col=200 → react-jsx-runtime:274 매핑 성공 ✓
\`\`\`

zts symbolicate handler 자체는 정상 — \`source-map@0.7\` consumer 의 \`originalPositionFor\` 호출 → 일부 frame 매핑 OK, 일부 fail (Metro 호환 fallback).

## 원인 가설

zts core (Zig) 의 sourcemap \`mappings\` 가 줄 단위 첫 segment 만 emit:
\`\`\`
mappings: "A4nCAA;AACA;AACA;AACA;..."
                ^^^^  ^^^^
                줄 별 단일 segment, column 단위 매핑 빈약
\`\`\`

일부 line/col 조합이 매핑 정보 부재 → \`pos.source == null\` → fallback. **Zig core 의 sourcemap emitter 영역** — 본 epic #2605 (dev server 흡수) 외.

## 변경

진단 로그만 추가:
- \`ZTS_DEBUG_SYMBOLICATE=1\` 시 stack 의 input frame (file/line/col/method) + sourceMap len + consumer 생성 결과 + 매핑된 output frame + codeFrame 결과 stderr 출력

사용자가 실제 RN runtime 의 어느 frame 이 매핑 실패하는지 추적 가능:
\`\`\`bash
ZTS_DEBUG_SYMBOLICATE=1 zts dev --platform=react-native --rn-platform=ios index.js
# RN 앱에서 throw → LogBox → POST /symbolicate
\`\`\`

## 후속 (별도 epic)

zts core 의 sourcemap column 정보 개선:
- Zig 측 emitter 가 column 단위 매핑도 emit
- 또는 segment 별 mapping 더 dense
- 본 epic dev server 영역 외

Refs #2605

🤖 Generated with [Claude Code](https://claude.com/claude-code)