### PR TITLE
feat(bundler): wrapper closing brace 영역 sourcemap mapping 추가 (#2648)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -724,6 +724,7 @@ pub fn emitWithTreeShaking(
                     results[i].preamble_lines,
                     options.sourcemap.sources_content,
                     false,
+                    wrapCloseLines(m.wrap_kind, options.minify_whitespace),
                 );
                 // function map: source 추가 순서와 동기화
                 if (options.sourcemap.function_map) {
@@ -806,6 +807,7 @@ pub fn emitWithTreeShaking(
                         results[i].preamble_lines,
                         options.sourcemap.sources_content,
                         false,
+                        wrapCloseLines(m.wrap_kind, options.minify_whitespace),
                     );
                     if (options.sourcemap.lazy) {
                         const heap_sm = try allocator.create(SourceMap.SourceMapBuilder);
@@ -1227,6 +1229,18 @@ fn adjustMappingsForLineWraps(sm: *SourceMap.SourceMapBuilder, breaks: []const W
 const dev = @import("emitter/dev.zig");
 pub const addModuleMappings = dev.addModuleMappings;
 pub const makeModuleId = dev.makeModuleId;
+
+/// wrapper 의 closing brace 가 차지하는 line 수 (#2648 sourcemap density).
+/// CJS / ESM 둘 다 `\n\t}\n});\n` (3 newlines) — wrapper closing 후 \n 까지 포함.
+/// asset / disabled = 0 (단순 form). minify_whitespace 시 closing 단일 line —
+/// mapping 추가 불필요.
+fn wrapCloseLines(wrap_kind: anytype, minify_whitespace: bool) u32 {
+    if (minify_whitespace) return 0;
+    return switch (wrap_kind) {
+        .cjs, .esm => 3,
+        else => 0,
+    };
+}
 
 /// 소스맵 sources 배열에 사용할 경로를 반환.
 /// RN 플랫폼은 Metro 호환 절대 경로, 다른 플랫폼은 root_dir 기준 상대 경로.

--- a/src/bundler/emitter/dev.zig
+++ b/src/bundler/emitter/dev.zig
@@ -9,7 +9,14 @@ const SourceMap = @import("../../codegen/sourcemap.zig");
 /// 모듈 경로를 dev bundle용 ID로 변환.
 /// root_dir이 있으면 상대 경로, 없으면 절대 경로 그대로 사용.
 /// 모듈의 소스맵 매핑을 번들 레벨 SourceMapBuilder에 추가한다.
-/// sourcesContent 등록 + preamble/wrapper 오프셋 반영을 한 곳에서 처리.
+/// sourcesContent 등록 + preamble/wrapper 오프셋 반영 + wrapper closing brace
+/// 영역 mapping 보강을 한 곳에서 처리.
+///
+/// `wrap_close_lines` — wrapper 의 closing brace 가 차지하는 line 수. CJS
+/// `__commonJS({...\n\t}\n});\n}` = 3 (마지막 `\n` 까지), ESM `init_X = __esm({...});\n}` =
+/// 1, asset/disabled = 0. 모듈의 마지막 매핑된 source line 으로 추가 mapping
+/// 을 emit 해 빈 generated line (wrapper closing) 을 채움. 이게 없으면 RN
+/// LogBox 의 stack frame 이 source 매핑 안 되고 bundle URL 그대로 표시 (#2648).
 pub fn addModuleMappings(
     sm: *SourceMap.SourceMapBuilder,
     module_id: []const u8,
@@ -20,11 +27,15 @@ pub fn addModuleMappings(
     sources_content: bool,
     /// dev 모드에서 tab 들여쓰기 보정이 필요하면 true
     indent_offset: bool,
+    wrap_close_lines: u32,
 ) !void {
     const source_idx = try sm.addSource(module_id);
     if (sources_content and source.len > 0) {
         try sm.addSourceContent(source);
     }
+    var max_gen_line: u32 = 0;
+    var max_orig_line: u32 = 0;
+    var has_mapping: bool = false;
     for (maps) |mapping| {
         try sm.addMapping(.{
             .generated_line = base_line + preamble_lines + mapping.generated_line,
@@ -35,6 +46,24 @@ pub fn addModuleMappings(
             .source_index = source_idx,
             .original_line = mapping.original_line,
             .original_column = mapping.original_column,
+        });
+        if (!has_mapping or mapping.generated_line >= max_gen_line) {
+            max_gen_line = mapping.generated_line;
+            max_orig_line = mapping.original_line;
+            has_mapping = true;
+        }
+    }
+    if (wrap_close_lines == 0 or !has_mapping) return;
+    // wrapper closing brace 의 line 마다 module 의 마지막 source line 으로
+    // identity mapping. 정확한 location 보다 file 단위 frame 표시가 목적.
+    var i: u32 = 1;
+    while (i <= wrap_close_lines) : (i += 1) {
+        try sm.addMapping(.{
+            .generated_line = base_line + preamble_lines + max_gen_line + i,
+            .generated_column = 0,
+            .source_index = source_idx,
+            .original_line = max_orig_line,
+            .original_column = 0,
         });
     }
 }


### PR DESCRIPTION
## 요약

#2605 사용자 보고 (RN LogBox stack trace 가 source 매핑 안 됨) 의 진짜 root cause fix.

## 진단

zts dev 의 RN bundle (124877 lines) sourcemap 분석:
- 빈 mapping line: **46276 (37%)**
- 빈 line 의 실제 코드 = \`__commonJS\` / \`__esm\` wrapper 의 closing brace 영역 (\`\\n\\t}\\n});\\n\`)
- \`emitter.zig:1885-1896\` 의 \`__commonJS\` wrapper 가 closing brace 추가 시 mapping emit 안 함 → wrapped 안의 마지막 3 line 매핑 누락

## 수정

### \`addModuleMappings\` 에 \`wrap_close_lines\` 인자 추가

\`\`\`zig
pub fn addModuleMappings(
    sm: *SourceMap.SourceMapBuilder,
    ...
    wrap_close_lines: u32,  // 신규 — wrapper closing 의 \\n 갯수
) !void {
    ...
    var max_gen_line: u32 = 0;
    var max_orig_line: u32 = 0;
    for (maps) |mapping| {
        try sm.addMapping(...);
        if (mapping.generated_line >= max_gen_line) {
            max_gen_line = mapping.generated_line;
            max_orig_line = mapping.original_line;
        }
    }
    // wrapper closing brace 의 line 마다 module 의 마지막 source line 으로
    var i: u32 = 1;
    while (i <= wrap_close_lines) : (i += 1) {
        try sm.addMapping(.{
            .generated_line = base_line + preamble_lines + max_gen_line + i,
            .source_index = source_idx,
            .original_line = max_orig_line,
            ...
        });
    }
}
\`\`\`

### \`wrapCloseLines\` helper

\`\`\`zig
fn wrapCloseLines(wrap_kind, minify_whitespace) u32 {
    if (minify_whitespace) return 0;
    return switch (wrap_kind) {
        .cjs, .esm => 3,        // \\n\\t}\\n});\\n
        else => 0,              // asset / disabled
    };
}
\`\`\`

두 caller (L718, L800) 모두 \`wrapCloseLines(m.wrap_kind, options.minify_whitespace)\` 전달.

## 검증 (직접 실행)

examples/react-native-bare 의 RN bundle 에서 \`source-map\` consumer.originalPositionFor 호출:

| Line | 수정 전 | 수정 후 |
|------|------|------|
| 8307 | NULL | **generator:39** ✓ |
| 8259 | NULL | **generator:20** ✓ |
| 124375 | NULL | **App.tsx:306** ✓ |

사용자가 보고한 stack trace 의 진짜 frame (`Bungae Error Test:124375:21`) 이 source 매핑 됨.

empty mapping line 비율: **37% → 34.3%**.

## 한계

부분 fix — 일부 영역 (다른 generated boilerplate, runtime helpers, prologue/epilogue) 은 별도 mapping 누락. 후속 PR 로:
- entry chain emit 영역
- runtime helpers prologue
- HMR preamble 의 빈 line
- Asset/disabled module 의 mapping 영역

## 검증

- \`zig build\` 통과
- \`bun test packages/react-native/src/\` — 436 pass
- \`bun test packages/core/index.test.ts\` — 402 pass
- 직접 실행 검증 (3 frame 신규 매핑 OK)

Refs #2648

🤖 Generated with [Claude Code](https://claude.com/claude-code)