### PR TITLE
docs(site): 문서 기능 보강

### DIFF
--- a/documents/astro.config.mjs
+++ b/documents/astro.config.mjs
@@ -32,7 +32,9 @@ export default defineConfig({
         },
       },
       plugins: [
-        starlightLinksValidator({ exclude: ["/zts/playground/", "/zts/en/playground/"] }),
+        starlightLinksValidator({
+          exclude: ["/zts/playground/", "/zts/en/playground/", "/zts/analyze/", "/zts/en/analyze/"],
+        }),
         starlightTypeDoc({
           entryPoints: ["../packages/core/index.ts"],
           tsconfig: "../packages/core/tsconfig.json",
@@ -104,6 +106,7 @@ export default defineConfig({
           label: "마이그레이션",
           translations: { en: "Migration" },
           items: [
+            { label: "도구 비교", slug: "guides/comparison", translations: { en: "Tool Comparison" } },
             { label: "다른 도구에서 이관", slug: "guides/migration", translations: { en: "From Other Tools" } },
             { label: "Babel 이관 (RN)", slug: "guides/babel-migration", translations: { en: "Babel Migration (RN)" } },
           ],
@@ -122,7 +125,9 @@ export default defineConfig({
             { label: "CLI", slug: "reference/cli", translations: { en: "CLI" } },
             { label: "NAPI / JS API", slug: "reference/napi", translations: { en: "NAPI / JS API" } },
             { label: "Transpile 옵션", slug: "reference/options", translations: { en: "Transpile Options" } },
+            { label: "옵션 매트릭스", slug: "reference/options-matrix", translations: { en: "Options Matrix" } },
             { label: "벤치마크", slug: "reference/benchmarks", translations: { en: "Benchmarks" } },
+            { label: "Metafile 분석", link: "/analyze/", translations: { en: "Metafile Analyze" } },
             {
               label: "에러 코드",
               translations: { en: "Error Codes" },

--- a/documents/src/components/MetafileAnalyzer.tsx
+++ b/documents/src/components/MetafileAnalyzer.tsx
@@ -1,0 +1,299 @@
+import { useMemo, useState } from "react";
+
+type ImportRecord = {
+  path?: string;
+  kind?: string;
+  external?: boolean;
+  original?: string;
+};
+
+type InputMeta = {
+  bytes?: number;
+  imports?: ImportRecord[];
+  format?: string;
+};
+
+type OutputInputMeta = {
+  bytesInOutput?: number;
+};
+
+type OutputMeta = {
+  bytes?: number;
+  inputs?: Record<string, OutputInputMeta>;
+  imports?: ImportRecord[];
+  exports?: string[];
+  entryPoint?: string;
+  cssBundle?: string;
+};
+
+type Metafile = {
+  inputs?: Record<string, InputMeta>;
+  outputs?: Record<string, OutputMeta>;
+};
+
+type RankedModule = {
+  path: string;
+  bytes: number;
+};
+
+const sampleMetafile = JSON.stringify(
+  {
+    inputs: {
+      "src/main.ts": {
+        bytes: 420,
+        imports: [
+          { path: "src/ui.ts", kind: "import-statement" },
+          { path: "src/vendor.ts", kind: "dynamic-import" },
+        ],
+      },
+      "src/ui.ts": {
+        bytes: 860,
+        imports: [{ path: "src/theme.css", kind: "import-statement" }],
+      },
+      "src/theme.css": { bytes: 190, imports: [] },
+      "src/vendor.ts": { bytes: 2380, imports: [] },
+    },
+    outputs: {
+      "dist/main.js": {
+        bytes: 1720,
+        entryPoint: "src/main.ts",
+        inputs: {
+          "src/main.ts": { bytesInOutput: 330 },
+          "src/ui.ts": { bytesInOutput: 760 },
+          "src/theme.css": { bytesInOutput: 160 },
+        },
+      },
+      "dist/chunks/vendor.js": {
+        bytes: 1180,
+        inputs: { "src/vendor.ts": { bytesInOutput: 1080 } },
+      },
+    },
+  },
+  null,
+  2,
+);
+
+const nf = new Intl.NumberFormat("en-US");
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function parseMetafile(text: string): { meta?: Metafile; error?: string } {
+  try {
+    const parsed = JSON.parse(text) as Metafile;
+    if (!parsed || typeof parsed !== "object") {
+      return { error: "JSON object가 아닙니다." };
+    }
+    if (!parsed.inputs && !parsed.outputs) {
+      return { error: "inputs 또는 outputs 필드가 필요합니다." };
+    }
+    return { meta: parsed };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : "JSON parse 실패" };
+  }
+}
+
+function rankInputs(inputs: Record<string, InputMeta> | undefined): RankedModule[] {
+  return Object.entries(inputs ?? {})
+    .map(([path, meta]) => ({ path, bytes: meta.bytes ?? 0 }))
+    .sort((a, b) => b.bytes - a.bytes);
+}
+
+function outputContributions(output: OutputMeta): RankedModule[] {
+  return Object.entries(output.inputs ?? {})
+    .map(([path, meta]) => ({ path, bytes: meta.bytesInOutput ?? 0 }))
+    .sort((a, b) => b.bytes - a.bytes);
+}
+
+function countImports(inputs: Record<string, InputMeta> | undefined): number {
+  return Object.values(inputs ?? {}).reduce((sum, input) => sum + (input.imports?.length ?? 0), 0);
+}
+
+function BarRow({
+  label,
+  bytes,
+  maxBytes,
+  sublabel,
+}: {
+  label: string;
+  bytes: number;
+  maxBytes: number;
+  sublabel?: string;
+}) {
+  const pct = maxBytes > 0 ? Math.max(2, (bytes / maxBytes) * 100) : 0;
+  return (
+    <div className="grid grid-cols-[minmax(0,1fr)_92px] items-center gap-3">
+      <div className="min-w-0">
+        <div className="flex min-w-0 items-baseline justify-between gap-3 text-[13px]">
+          <span className="truncate font-medium text-neutral-100" title={label}>
+            {label}
+          </span>
+          {sublabel ? <span className="shrink-0 text-[11px] text-neutral-500">{sublabel}</span> : null}
+        </div>
+        <div className="mt-1 h-2 rounded bg-surface-800">
+          <div className="h-full rounded bg-zig-500" style={{ width: `${pct}%` }} />
+        </div>
+      </div>
+      <div className="text-right font-mono text-[12px] text-neutral-300">{formatBytes(bytes)}</div>
+    </div>
+  );
+}
+
+function SummaryTile({ label, value, hint }: { label: string; value: string; hint: string }) {
+  return (
+    <div className="rounded border border-surface-800 bg-surface-900 px-4 py-3">
+      <div className="text-[11px] font-semibold uppercase text-neutral-500">{label}</div>
+      <div className="mt-1 text-2xl font-semibold text-neutral-100">{value}</div>
+      <div className="mt-1 text-[12px] text-neutral-400">{hint}</div>
+    </div>
+  );
+}
+
+export function MetafileAnalyzer() {
+  const [text, setText] = useState(sampleMetafile);
+  const [filter, setFilter] = useState("");
+  const parsed = useMemo(() => parseMetafile(text), [text]);
+  const meta = parsed.meta;
+
+  const inputs = useMemo(() => rankInputs(meta?.inputs), [meta?.inputs]);
+  const outputs = useMemo(() => Object.entries(meta?.outputs ?? {}), [meta?.outputs]);
+  const inputTotal = inputs.reduce((sum, item) => sum + item.bytes, 0);
+  const outputTotal = outputs.reduce((sum, [, out]) => sum + (out.bytes ?? 0), 0);
+  const importTotal = countImports(meta?.inputs);
+  const maxInputBytes = inputs[0]?.bytes ?? 0;
+  const filteredInputs = inputs.filter((item) => item.path.toLowerCase().includes(filter.toLowerCase()));
+
+  async function loadFile(file: File | undefined) {
+    if (!file) return;
+    setText(await file.text());
+  }
+
+  return (
+    <main className="min-h-[calc(100vh-160px)] bg-surface-950 text-neutral-100">
+      <div className="mx-auto flex max-w-[1500px] flex-col gap-4 px-4 py-4 lg:px-6">
+        <header className="flex flex-col gap-3 border-b border-surface-800 pb-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-[12px] font-semibold uppercase text-zig-400">ZTS Metafile</p>
+            <h1 className="mt-1 text-2xl font-semibold tracking-normal text-neutral-50">Analyze bundle metadata</h1>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <label className="cursor-pointer rounded border border-surface-700 px-3 py-1.5 text-[13px] text-neutral-200 hover:border-zig-500 hover:text-zig-300">
+              Upload JSON
+              <input
+                type="file"
+                accept="application/json,.json"
+                className="hidden"
+                onChange={(event) => void loadFile(event.currentTarget.files?.[0])}
+              />
+            </label>
+            <button
+              type="button"
+              className="rounded border border-surface-700 px-3 py-1.5 text-[13px] text-neutral-200 hover:border-zig-500 hover:text-zig-300"
+              onClick={() => setText(sampleMetafile)}
+            >
+              Load sample
+            </button>
+          </div>
+        </header>
+
+        <section className="grid gap-4 lg:grid-cols-[minmax(320px,0.7fr)_minmax(0,1.3fr)]">
+          <div className="flex min-h-[520px] flex-col overflow-hidden rounded border border-surface-800 bg-surface-900">
+            <div className="border-b border-surface-800 px-3 py-2 text-[12px] font-semibold text-neutral-400">
+              meta.json
+            </div>
+            <textarea
+              spellCheck={false}
+              value={text}
+              onChange={(event) => setText(event.currentTarget.value)}
+              className="min-h-0 flex-1 resize-none bg-surface-950 p-3 font-mono text-[12px] leading-5 text-neutral-200 outline-none"
+            />
+          </div>
+
+          <div className="flex min-w-0 flex-col gap-4">
+            {parsed.error ? (
+              <div className="rounded border border-red-900 bg-red-950/40 px-4 py-3 text-[13px] text-red-200">
+                {parsed.error}
+              </div>
+            ) : null}
+
+            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+              <SummaryTile label="Inputs" value={nf.format(inputs.length)} hint={formatBytes(inputTotal)} />
+              <SummaryTile label="Outputs" value={nf.format(outputs.length)} hint={formatBytes(outputTotal)} />
+              <SummaryTile label="Imports" value={nf.format(importTotal)} hint="resolved graph edges" />
+              <SummaryTile label="Format" value={outputs.some(([, out]) => out.inputs) ? "Detailed" : "Basic"} hint="output attribution" />
+            </div>
+
+            <section className="rounded border border-surface-800 bg-surface-900">
+              <div className="flex flex-wrap items-center justify-between gap-3 border-b border-surface-800 px-4 py-3">
+                <h2 className="text-[14px] font-semibold text-neutral-100">Outputs</h2>
+                <span className="text-[12px] text-neutral-500">esbuild-compatible `outputs[*].inputs` is used when present</span>
+              </div>
+              <div className="grid gap-3 p-4 xl:grid-cols-2">
+                {outputs.map(([path, output]) => {
+                  const contributions = outputContributions(output);
+                  const maxBytes = contributions[0]?.bytes ?? 0;
+                  return (
+                    <article key={path} className="rounded border border-surface-800 bg-surface-950 p-3">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <h3 className="truncate text-[13px] font-semibold text-neutral-100" title={path}>
+                            {path}
+                          </h3>
+                          {output.entryPoint ? <p className="mt-1 text-[12px] text-neutral-500">entry: {output.entryPoint}</p> : null}
+                        </div>
+                        <div className="shrink-0 font-mono text-[12px] text-neutral-300">{formatBytes(output.bytes ?? 0)}</div>
+                      </div>
+                      <div className="mt-3 flex flex-col gap-2">
+                        {contributions.length > 0 ? (
+                          contributions
+                            .slice(0, 6)
+                            .map((item) => <BarRow key={item.path} label={item.path} bytes={item.bytes} maxBytes={maxBytes} />)
+                        ) : (
+                          <p className="text-[12px] leading-5 text-neutral-500">
+                            이 output에는 input 기여도 정보가 없습니다. 현재 ZTS metafile의 basic form에서는 output 크기와 graph
+                            input/import 목록을 함께 확인하세요.
+                          </p>
+                        )}
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+            </section>
+
+            <section className="rounded border border-surface-800 bg-surface-900">
+              <div className="flex flex-wrap items-center justify-between gap-3 border-b border-surface-800 px-4 py-3">
+                <h2 className="text-[14px] font-semibold text-neutral-100">Largest inputs</h2>
+                <input
+                  value={filter}
+                  placeholder="Filter path"
+                  onChange={(event) => setFilter(event.currentTarget.value)}
+                  className="w-[220px] rounded border border-surface-700 bg-surface-950 px-2 py-1 text-[12px] text-neutral-200 outline-none"
+                />
+              </div>
+              <div className="flex max-h-[420px] flex-col gap-3 overflow-auto p-4">
+                {filteredInputs.slice(0, 80).map((item) => {
+                  const input = meta?.inputs?.[item.path];
+                  const importCount = input?.imports?.length ?? 0;
+                  return (
+                    <BarRow
+                      key={item.path}
+                      label={item.path}
+                      bytes={item.bytes}
+                      maxBytes={maxInputBytes}
+                      sublabel={importCount === 1 ? "1 import" : `${importCount} imports`}
+                    />
+                  );
+                })}
+              </div>
+            </section>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/documents/src/components/metafile-analyzer-mount.ts
+++ b/documents/src/components/metafile-analyzer-mount.ts
@@ -1,0 +1,8 @@
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { MetafileAnalyzer } from "./MetafileAnalyzer";
+
+const el = document.getElementById("metafile-analyzer-mount");
+if (el) {
+  createRoot(el).render(createElement(MetafileAnalyzer));
+}

--- a/documents/src/content/docs/en/guides/bundling.md
+++ b/documents/src/content/docs/en/guides/bundling.md
@@ -167,6 +167,8 @@ zts --bundle entry.ts -o bundle.js --metafile=meta.json
 zts --bundle entry.ts -o bundle.js --analyze
 ```
 
+Upload `meta.json` to [Metafile Analyze](/zts/analyze/) to inspect output sizes, input sizes, and the import graph.
+
 ## Minify
 
 ```bash

--- a/documents/src/content/docs/en/guides/comparison.md
+++ b/documents/src/content/docs/en/guides/comparison.md
@@ -1,0 +1,91 @@
+---
+title: Tool Comparison
+description: Compare ZTS against Rolldown, esbuild, SWC, Rspack, and Vite.
+---
+
+ZTS focuses on providing a **TypeScript/Flow transpiler, library/app bundler, and dev server** from one binary/package. It is not trying to clone the entire Vite ecosystem or webpack loader/plugin universe.
+
+## Status Terms
+
+| Term | Meaning |
+| ---- | ------- |
+| Supported | Public surface is documented and covered by regression tests |
+| Partial | The main path works, but some options, hooks, formats, or edge cases are limited |
+| Policy difference | ZTS intentionally chooses different semantics |
+| Unsupported | No current public surface |
+
+## Bundling / Transpilation
+
+| Area | ZTS | Rolldown | esbuild | SWC | Rspack/Vite |
+| ---- | --- | -------- | ------- | --- | ----------- |
+| TS/JSX/Flow single-file transform | Supported | Partial | TS/JSX, no Flow | Supported | loader/plugin layer |
+| Library bundling | Supported | Supported | Supported | spack/swcpack planned to be dropped in v2 | Rspack supported, Vite uses Rollup/Rolldown |
+| App builder (`index.html`, env, public) | Supported | Recommended through Vite | serve/build primitives | Unsupported | Vite/Rspack strength |
+| Code splitting | Supported | Supported | Supported | Limited | Supported |
+| Manual chunks | Supported (`config`/API) | Supported | Unsupported | Unsupported | Supported |
+| Runtime core-js polyfills | Supported | plugin/user-managed | Unsupported | `env`-oriented | Rspack/SWC loader layer |
+| React Native preset | Supported | Unsupported | Unsupported | usable as transformer | Metro/Rspack separate |
+| WASM playground | Supported | Wasm build available | browser build available | wasm packages | varies |
+
+## Plugin/API Compatibility
+
+| Area | ZTS status | Notes |
+| ---- | ---------- | ----- |
+| esbuild-style `setup(build)` | Partial | Focused on `onResolve`, `onLoad`, `onTransform`, `onResolveContext`, `onAstFunction` |
+| Rollup/Vite-style `resolveId` / `load` / `transform` | Supported | Use the `vitePlugin()` wrapper |
+| Output hooks (`renderChunk`, `generateBundle`) | Partial | General post-processing works. Not every Rollup hook is implemented |
+| Lifecycle (`buildStart`, `buildEnd`, `closeBundle`) | Supported | Runs on initial build and every rebuild in `watch()` |
+| `this.resolve()` / `this.emitFile()` | Unsupported | Requires a separate graph mutation surface |
+| `buildSync()` + JS plugins | Unsupported | Conflicts with the native worker waiting on JS callbacks |
+| Plugin hook filter | Partial | esbuild-style filters are supported; not identical to Rolldown object-hook filters |
+
+Rolldown has a stronger Rollup-compatible plugin API and lifecycle reference. ZTS accepts common hooks through `vitePlugin()`, but advanced Rollup context APIs are still narrow.
+
+## CLI and Analysis
+
+| Area | ZTS | Comparison |
+| ---- | --- | ---------- |
+| CLI/JS API/config options | Mostly covered | See [Options Matrix](/zts/en/reference/options-matrix/) |
+| `metafile` JSON | Supported | esbuild-compatible basic format |
+| Interactive bundle analyzer | Supported | Upload `meta.json` at [/analyze/](/zts/analyze/) |
+| `--analyze` tree output | Partial | Currently JSON-oriented. CLI tree format is follow-up work |
+| Profile/benchmark | Supported | `--profile*`, `zts bench`, JS `benchmark()` |
+| Diagnostic docs URL | Supported | Linked to `ZTSxxxx` error-code docs |
+
+## App Features vs Vite/Rspack
+
+| Feature | ZTS | Notes |
+| ------- | --- | ----- |
+| `zts dev` / `zts build` / `zts preview` | Supported | dev/build/preview semantics are kept aligned |
+| HTML entry rewrite | Supported | uses `<script type="module" src>` as entry |
+| `.env*` / `import.meta.env.*` | Supported | `--env-dir`, `--env-prefix` |
+| `public/` copy | Supported | `--public-dir` |
+| CSS Modules | Supported | app mode |
+| PostCSS / Tailwind v4 | Supported | through `@tailwindcss/postcss` |
+| Sass/SCSS | Supported | optional `sass` dependency required |
+| Less/Stylus | Unsupported | precompile or use plugin-level handling |
+| CSS-only HMR | Supported | includes PostCSS dependency watch |
+| Error overlay | Supported | build/runtime overlay with sourcemap remapping |
+| `import.meta.glob` | Unsupported | candidate Vite-compatible surface |
+| SSR build | Unsupported | outside the current app-builder boundary |
+| Dev proxy | Supported | `--proxy /api=http://...` |
+
+## Intentional Policy Differences
+
+| Item | ZTS policy |
+| ---- | ---------- |
+| Import attributes loader override | `with { type }` is pass-through metadata. Loader selection is extension/loader-option based |
+| Physical device runtime target | physical names such as `iPhone 8` are rejected. Use Browserslist queries |
+| Auto node polyfill bundle | not provided. Use explicit `fallback`, `alias`, or plugins |
+| Property mangle | lower priority due to public API stability and debugging cost |
+| SSR | unlike Vite/Rspack, not in the current app-builder core boundary |
+
+## Official References
+
+- [esbuild API](https://esbuild.github.io/api/)
+- [esbuild Bundle Size Analyzer](https://esbuild.github.io/analyze/)
+- [Rolldown Getting Started](https://rolldown.rs/guide/getting-started)
+- [Rolldown Plugin API](https://rolldown.rs/apis/plugin-api)
+- [SWC Getting Started](https://swc.rs/docs/getting-started)
+- [SWC Bundling (swcpack)](https://swc.rs/docs/usage/bundling)
+- [SWC Plugin Guide](https://swc.rs/docs/plugin/ecmascript/getting-started)

--- a/documents/src/content/docs/en/guides/migration.md
+++ b/documents/src/content/docs/en/guides/migration.md
@@ -156,16 +156,16 @@ export default defineConfig({
 ### Unsupported esbuild options
 
 | esbuild option                    | Alternative                                                                  |
-| --------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------ |
+| --------------------------------- | ---------------------------------------------------------------------------- |
 | `--mangle-props=<regex>`          | Not supported (mangling limited to `--minify-identifiers` on internal names) |
 | `--mangle-cache=<path>`           | Not supported                                                                |
 | `--mangle-quoted`                 | Not supported                                                                |
-| `--analyze` (tree format)         | `--analyze` (JSON only, tree format planned)                                 |
+| `--analyze` (tree format)         | `--analyze` JSON + [/analyze/](/zts/analyze/) visualization. CLI tree format planned |
 | `--servedir=<path>`               | `--serve <dir>` (positional arg)                                             |
 | `--bundle=false` (off by default) | Same default. ZTS transpiles only without `--bundle`                         |
 | `--splitting=false`               | Off by default. No flag means default                                        |
 | `--tree-shaking=false`            | Not supported. Per-package `--external` can reduce bundle scope              |
-| `--color=true                     | false`                                                                       | Not supported. Auto-detected from terminal |
+| `--color=true\|false`             | Not supported. Auto-detected from terminal                                   |
 | `--log-override:X=Y`              | Not supported. Only `--log-level`                                            |
 | `--supported:bigint=false`        | Not supported. Use `--target` for global control                             |
 | `--reserve-props=<regex>`         | Not supported                                                                |
@@ -244,7 +244,7 @@ To write native-style plugins, use `setup(build) { build.onLoad(...) }`.
 
 | Vite feature                         | ZTS equivalent                                                                                           |
 | ------------------------------------ | -------------------------------------------------------------------------------------------------------- |
-| `vite` (dev server)                  | `zts dev` (HTML/env/public prepare + CSS-only HMR)                                                       |
+| `vite` (dev server)                  | `zts dev` (HTML/env/public prepare + HMR/Fast Refresh + CSS-only HMR)                                    |
 | `vite build`                         | `zts build`, or `zts --bundle <entry> --outdir dist --splitting --minify --sourcemap` for library builds |
 | `vite preview`                       | `zts preview dist`                                                                                       |
 | `import.meta.env.MODE`               | App mode auto-loads `.env*`; CLI bundles can use `--define:import.meta.env.MODE=\"production\"`          |
@@ -311,8 +311,8 @@ module.exports = {
 | `svg-loader` / `@svgr/webpack`                  | `--loader:.svg=text`/`file`/`dataurl` or plugin                |
 | `json-loader`                                   | `--loader:.json=json` (built-in default)                       |
 | `sass-loader` / `less-loader` / `stylus-loader` | Sass/SCSS is supported in app mode. Pre-compile Less/Stylus    |
-| `postcss-loader`                                | Not supported. Replaced by Lightning CSS post-processing       |
-| `html-loader`                                   | Not supported. `--loader:.html=text` for string conversion     |
+| `postcss-loader`                                | Supported in app mode. Use a plugin or pre-processing for library bundling |
+| `html-loader`                                   | App mode rewrites `index.html`; `--loader:.html=text` can stringify imports |
 | `worker-loader`                                 | Not supported (general Worker bundle support separate)         |
 | `thread-loader`                                 | Not needed. ZTS has built-in parallel pipeline (`--jobs=N`)    |
 | `cache-loader`                                  | Not needed. Uses `.zig-cache` / module-level cache             |
@@ -328,7 +328,7 @@ module.exports = {
 | `BannerPlugin`                     | `--banner:js=...`                                            |
 | `SplitChunksPlugin`                | `--splitting` (automatic)                                    |
 | `MiniCssExtractPlugin`             | Built-in Lightning CSS post-processing (separate CSS chunks) |
-| `HtmlWebpackPlugin`                | Not supported. Manage static `index.html` manually           |
+| `HtmlWebpackPlugin`                | App mode handles `index.html` plus `%ENV%`/asset rewriting   |
 | `CopyWebpackPlugin`                | Not supported. Per-asset copy via `--loader:.svg=copy`       |
 | `TerserPlugin`                     | `--minify` built-in                                          |
 | `CssMinimizerPlugin`               | Handled by Lightning CSS post-processing                     |
@@ -344,7 +344,7 @@ module.exports = {
 | `require.context`                                      | Supported (`require.context(dir, deep, regex)` — resolved via plugin `onResolveContext` hook) |
 | Lazy chunk (`import(/* webpackChunkName: "x" */ ...)`) | Dynamic import itself supported. Magic comments are not                                       |
 | `webpack.config.js` function / multi-config            | Not supported. Single-export `zts.config.ts`                                                  |
-| `devServer.proxy`                                      | Not supported. `--serve` serves static/bundle only                                            |
-| Dev server overlay                                     | Not supported (HMR errors go to console)                                                      |
+| `devServer.proxy`                                      | Supported (`--proxy /api=http://localhost:3000`)                                              |
+| Dev server overlay                                     | Supported (build/runtime error overlay + source map remap)                                    |
 | Persistent cache (`cache.type: 'filesystem'`)          | Not needed. Built-in cache                                                                    |
 | Stats JSON                                             | `--metafile=meta.json` provides similar info                                                  |

--- a/documents/src/content/docs/en/guides/plugins.md
+++ b/documents/src/content/docs/en/guides/plugins.md
@@ -7,6 +7,36 @@ description: Learn how to use the ZTS plugin system.
 
 ZTS provides a Rollup/Vite-compatible plugin interface. Plugins are written in JS/TS and run in-process via C NAPI (via `@zts/core`).
 
+## Compatibility Summary
+
+| Surface | Status | Use |
+| ------- | ------ | --- |
+| esbuild-style `setup(build)` | Partial | `build.onResolve`, `build.onLoad`, `build.onTransform`, `build.onResolveContext`, `build.onAstFunction` |
+| Rollup/Vite-style `resolveId` / `load` / `transform` | Supported | `vitePlugin()` wrapper or config plugin |
+| output hooks `renderChunk` / `generateBundle` | Partial | chunk post-processing and output-list access |
+| lifecycle `buildStart` / `buildEnd` / `closeBundle` | Supported | called for `build()` and for each initial/rebuild cycle in `watch()` |
+| Rollup context `this.resolve()` / `this.emitFile()` | Unsupported | needs a separate graph mutation surface |
+| `buildSync()` + JS plugins | Unsupported | use async `build()` / `watch()` |
+
+The native ZTS worker calls JS hooks through NAPI threadsafe functions when it reaches a module and waits for the response. Keep hook filters narrow, and prefer the built-in `loader` option for simple extension-based handling.
+
+## Hook Order
+
+```text
+buildStart
+  -> resolveId / onResolve
+  -> load / onLoad
+  -> transform / onTransform
+  -> native link / tree-shake / emit
+  -> renderChunk
+  -> generateBundle
+buildEnd
+write
+closeBundle
+```
+
+In `watch()`, the same order runs for the initial build and every rebuild. `onReady` or `onRebuild` runs after `buildEnd`. When multiple plugins implement the same hook, they run in registration order.
+
 ## Config File
 
 Create a `zts.config.ts` (or `.js`, `.mjs`, `.mts`, `.cjs`, `.cts`) at the project root.

--- a/documents/src/content/docs/en/reference/benchmarks.mdx
+++ b/documents/src/content/docs/en/reference/benchmarks.mdx
@@ -1,0 +1,24 @@
+---
+title: Performance Benchmarks
+description: Performance comparison between ZTS and other tools
+---
+
+import BenchmarkCharts from '../../../../components/BenchmarkCharts.tsx';
+
+ZTS compares transpile and bundle performance against esbuild, SWC, Bun, and related tools.
+
+## Environment
+
+- **Platform**: macOS Apple Silicon (M-series)
+- **Iterations**: average of 5 runs
+- **Method**: direct CLI execution, excluding npx overhead
+
+<BenchmarkCharts client:only="react" />
+
+## How to Run
+
+Benchmark script: `tests/benchmark/bench.ts`
+
+```bash
+cd tests/benchmark && bun run bench.ts
+```

--- a/documents/src/content/docs/en/reference/cli.md
+++ b/documents/src/content/docs/en/reference/cli.md
@@ -161,7 +161,7 @@ CSS before PostCSS when the optional `sass` dependency is installed.
 | `--asset-names=<pattern>`                | Asset name pattern                                                                                    |
 | `--loader:.ext=type`                     | Loader by extension (`file\|dataurl\|base64\|text\|binary\|copy\|empty\|json\|css\|js\|ts\|jsx\|tsx`) |
 | `--metafile` / `--metafile=<path>`       | Build meta JSON (stdout or file)                                                                      |
-| `--analyze`                              | Bundle analysis report (printed to stderr). Pair with `--metafile=<path>` to also write JSON to disk. |
+| `--analyze`                              | Bundle analysis report (printed to stderr). Pair with `--metafile=<path>` to also write JSON to disk; upload it at [/analyze/](/zts/analyze/) |
 | `--legal-comments=<mode>`                | License comments: `none\|inline\|eof\|linked\|external` (`linked`/`external` currently fall back to `eof`) |
 | `--packages=external`                    | Treat all bare package imports as external                                                            |
 | `--banner:js=<text>`                     | Prepend text (the bare `--banner=` form is JS-wrapper-only)                                           |
@@ -258,5 +258,7 @@ zts bench --phase=parse --compare=baseline.json src/main.ts
 ## See Also
 
 - JS API (`@zts/core`) in `packages/core/index.ts` provides the same options programmatically.
+- Surface-level option coverage is listed in the [Options Matrix](/zts/en/reference/options-matrix/).
+- Visualize `--metafile` output on the [Metafile Analyze](/zts/analyze/) page.
 - Use `vite-plugin-zts` or `vitePlugin()` for the Vite adapter.
 - Unsupported options and future plans: [docs/ROADMAP.md](https://github.com/ohah/zts/blob/main/docs/ROADMAP.md).

--- a/documents/src/content/docs/en/reference/options-matrix.md
+++ b/documents/src/content/docs/en/reference/options-matrix.md
@@ -1,0 +1,55 @@
+---
+title: Options Matrix
+description: Cross-reference ZTS option exposure across CLI, JS API, config, and schema.
+---
+
+ZTS exposes options through four public surfaces. Use this matrix to catch documentation and implementation drift when adding or checking a feature.
+
+- **CLI**: the `zts` command and `packages/core/bin/cli-flags.mjs`.
+- **JS API**: `@zts/core` `transpile()` / `build()` / `watch()` types.
+- **Config**: user config loaded from `zts.config.*` / `zts.workspace.*`.
+- **Schema**: transpile-only JSON schema. Bundler-only fields are intentionally excluded.
+
+## Surface Matrix
+
+| Feature group | CLI | JS API | Config | Schema | Notes |
+| ------------- | --- | ------ | ------ | ------ | ----- |
+| I/O (`outfile`, `outdir`, `outbase`, `outExtension`) | ✅ | ✅ | ✅ | ❌ | `outdir` and naming patterns are bundler output options |
+| Module format (`format`, `platform`) | ✅ | ✅ | ✅ | ✅ | `react-native` also enables the RN preset |
+| ES/runtime targets (`target`, `browserslist`) | ✅ | ✅ | ✅ | ✅ | `browserslist` is config/API-only and takes precedence over `target` |
+| Runtime polyfills (`runtimePolyfills`, `runtimeTarget`, `coreJs`) | ✅ | ✅ | ✅ | ❌ | core-js injection from graph usage |
+| JSX / TS / Flow transforms | ✅ | ✅ | ✅ | ✅ | selected `tsconfig` fields are used as fallback values |
+| define/drop/inject/pure | ✅ | ✅ | ✅ | partial | `dropLabels`, `pure`, and `inject` are mostly bundler-facing |
+| Granular minify | ✅ | ✅ | ✅ | ✅ | property mangle options are intentionally unsupported |
+| Source maps (`sourcemapMode`, `sourcesContent`, `sourceRoot`) | ✅ | ✅ | ✅ | ✅ | RN sourcemap output flags are covered by the RN CLI docs |
+| Resolver (`external`, `alias`, `fallback`, `conditions`) | ✅ | ✅ | ✅ | ❌ | array/RegExp alias requires async `build()` / `watch()` |
+| Loader / asset names / public path | ✅ | ✅ | ✅ | ❌ | separate from app-mode HTML/CSS asset rewriting |
+| Code splitting / preserve modules | ✅ | ✅ | ✅ | ❌ | `splitting` requires `outdir` |
+| `manualChunks` | ❌ | ✅ | ✅ | ❌ | function form requires `zts.config.{ts,js}` or JS API |
+| `metafile` / `analyze` | ✅ | ✅ | partial | ❌ | `metafile` is config-capable; `analyze` is CLI/API-oriented. Inspect `meta.json` at [/analyze/](/zts/analyze/) |
+| Watch / serve / dev server | ✅ | ✅ | ✅ | ❌ | `watch()` exposes rich events and lazy sourcemap APIs |
+| App builder (`dev`, `build`, `preview`) | ✅ | partial | ✅ | ❌ | HTML/env/public/CSS pipeline requires `@zts/web` |
+| Plugin hooks | ✅ (`--plugin`) | ✅ | ✅ | ❌ | JS plugins are not supported by `buildSync()` |
+| Diagnostics / profile / debug | ✅ | ✅ | partial | ❌ | profile is exposed through CLI and `configureProfile()` |
+| Workspace | ✅ | ✅ | ✅ | ❌ | `zts.workspace.*` manages multiple entries |
+
+## Sync API Limits
+
+`buildSync()` cannot run JS plugins, array/RegExp aliases, or host-RegExp hooks because the native worker would need to wait on JS callbacks. Use async `build()` or `watch()` for those features.
+
+## Update Checklist
+
+When adding a new option:
+
+1. Add the field to the public `@zts/core` type when it is part of the JS API.
+2. If the feature should be available from CLI, update `cli-flags.mjs`, `zts.mjs`, help text, and parse tests.
+3. If config should accept it, update `KNOWN_CONFIG_KEYS`, typo suggestions, and config merge tests.
+4. If it is transpile-only, regenerate the schema with `zig build schema` and update `reference/options`.
+5. If only some surfaces support it, document the limitation here and in the relevant guide.
+
+## See Also
+
+- [CLI Reference](/zts/en/reference/cli/)
+- [NAPI / JS API](/zts/en/reference/napi/)
+- [Transpile Options](/zts/en/reference/options/)
+- [Config File](/zts/en/guides/config-file/)

--- a/documents/src/content/docs/guides/bundling.md
+++ b/documents/src/content/docs/guides/bundling.md
@@ -167,6 +167,8 @@ zts --bundle entry.ts -o bundle.js --metafile=meta.json
 zts --bundle entry.ts -o bundle.js --analyze
 ```
 
+`meta.json`은 [Metafile 분석](/zts/analyze/) 페이지에 업로드해 output 크기, input 크기, import graph를 확인할 수 있습니다.
+
 ## Minify
 
 ```bash

--- a/documents/src/content/docs/guides/comparison.md
+++ b/documents/src/content/docs/guides/comparison.md
@@ -1,0 +1,91 @@
+---
+title: 도구 비교
+description: ZTS와 Rolldown, esbuild, SWC, Rspack, Vite의 기능 범위를 비교합니다.
+---
+
+ZTS는 **TypeScript/Flow 트랜스파일러 + library/app 번들러 + dev server**를 한 바이너리/패키지에서 제공하는 쪽에 초점을 둡니다. Vite 전체 생태계나 webpack loader/plugin universe를 그대로 복제하는 것이 목표는 아닙니다.
+
+## 상태 표기
+
+| 표기 | 의미 |
+| ---- | ---- |
+| 지원 | 문서화된 public surface와 회귀 테스트가 있음 |
+| 부분 | 핵심 경로는 지원하지만 일부 옵션, hook, format, edge case가 제한됨 |
+| 정책 차이 | 의도적으로 다른 의미론을 선택함 |
+| 미지원 | 현재 public surface 없음 |
+
+## 번들러/트랜스파일 기능
+
+| 영역 | ZTS | Rolldown | esbuild | SWC | Rspack/Vite |
+| ---- | --- | -------- | ------- | --- | ----------- |
+| TS/JSX/Flow 단일 파일 변환 | 지원 | 부분 | TS/JSX 지원, Flow 미지원 | 지원 | loader/plugin 조합 |
+| library bundling | 지원 | 지원 | 지원 | spack/swcpack은 v2에서 제거 예정 | Rspack 지원, Vite는 Rollup/Rolldown 사용 |
+| app builder (`index.html`, env, public) | 지원 | Vite 통합 경로 권장 | serve/build primitive 중심 | 미지원 | Vite/Rspack 강점 |
+| code splitting | 지원 | 지원 | 지원 | 제한적 | 지원 |
+| manual chunks | 지원 (`config`/API) | 지원 | 미지원 | 미지원 | 지원 |
+| runtime core-js polyfills | 지원 | 외부 plugin/사용자 처리 | 미지원 | `env` 중심 | Rspack/SWC loader 계층 |
+| React Native preset | 지원 | 미지원 | 미지원 | transformer로 사용 가능 | Metro/Rspack 별도 |
+| WASM playground | 지원 | WASM build 제공 | browser build 제공 | wasm package 제공 | 도구별 상이 |
+
+## Plugin/API 호환성
+
+| 영역 | ZTS 상태 | 비고 |
+| ---- | -------- | ---- |
+| esbuild-style `setup(build)` | 부분 | `onResolve`, `onLoad`, `onTransform`, `onResolveContext`, `onAstFunction` 중심 |
+| Rollup/Vite-style `resolveId` / `load` / `transform` | 지원 | `vitePlugin()` wrapper 사용 |
+| output hooks (`renderChunk`, `generateBundle`) | 부분 | 일반 후처리 가능. 모든 Rollup hook을 지원하지는 않음 |
+| lifecycle (`buildStart`, `buildEnd`, `closeBundle`) | 지원 | `watch()`에서도 초기 build와 rebuild마다 호출 |
+| `this.resolve()` / `this.emitFile()` | 미지원 | graph mutation surface로 별도 설계 필요 |
+| `buildSync()` + JS plugin | 미지원 | native worker가 JS callback을 기다리는 구조와 충돌 |
+| plugin hook filter | 부분 | esbuild-style filter는 지원. Rolldown object-hook filter와 완전 동일하지 않음 |
+
+Rolldown은 Rollup 호환 plugin API와 hook lifecycle 문서를 강하게 제공합니다. ZTS는 `vitePlugin()`로 주요 hook을 받지만, 고급 Rollup context API는 아직 좁습니다.
+
+## CLI와 분석 도구
+
+| 영역 | ZTS | 비교 |
+| ---- | --- | ---- |
+| CLI/JS API/config 옵션 | 대부분 대응 | [옵션 매트릭스](/zts/reference/options-matrix/)에서 surface별 확인 |
+| `metafile` JSON | 지원 | esbuild 호환 basic format |
+| interactive bundle analyzer | 지원 | [/analyze/](/zts/analyze/)에서 `meta.json` 업로드 |
+| `--analyze` tree 출력 | 부분 | 현재 JSON 중심. CLI tree format은 후속 |
+| profile/benchmark | 지원 | `--profile*`, `zts bench`, JS `benchmark()` |
+| diagnostic docs URL | 지원 | `ZTSxxxx` 에러 코드 문서와 연결 |
+
+## Vite/Rspack 대비 앱 기능
+
+| 기능 | ZTS | 비고 |
+| ---- | --- | ---- |
+| `zts dev` / `zts build` / `zts preview` | 지원 | dev/build/preview 의미를 맞추는 방향 |
+| HTML entry rewrite | 지원 | `<script type="module" src>` 엔트리 처리 |
+| `.env*` / `import.meta.env.*` | 지원 | `--env-dir`, `--env-prefix` |
+| `public/` 복사 | 지원 | `--public-dir` |
+| CSS Modules | 지원 | app mode |
+| PostCSS / Tailwind v4 | 지원 | `@tailwindcss/postcss` 설정 |
+| Sass/SCSS | 지원 | 선택 의존성 `sass` 필요 |
+| Less/Stylus | 미지원 | 사전 컴파일 또는 plugin 처리 |
+| CSS-only HMR | 지원 | PostCSS dependency watch 포함 |
+| error overlay | 지원 | build/runtime error overlay, sourcemap remap |
+| `import.meta.glob` | 미지원 | Vite 호환 surface로 후속 후보 |
+| SSR build | 미지원 | 현재 product boundary 밖 |
+| dev proxy | 지원 | `--proxy /api=http://...` |
+
+## 의도적인 정책 차이
+
+| 항목 | ZTS 정책 |
+| ---- | -------- |
+| import attributes loader override | `with { type }`은 pass-through metadata. loader 선택은 확장자/loader 옵션 기준 |
+| physical device runtime target | `iPhone 8` 같은 물리 디바이스 이름은 받지 않음. Browserslist query를 사용 |
+| auto node polyfill | 자동 polyfill 묶음은 제공하지 않음. `fallback`, `alias`, plugin으로 명시 |
+| property mangle | public API 안정성과 디버깅 비용 때문에 우선순위 낮음 |
+| SSR | Vite/Rspack과 달리 현재 앱 빌더의 핵심 범위가 아님 |
+
+## 관련 공식 문서
+
+- [esbuild API](https://esbuild.github.io/api/)
+- [esbuild Bundle Size Analyzer](https://esbuild.github.io/analyze/)
+- [Rolldown Getting Started](https://rolldown.rs/guide/getting-started)
+- [Rolldown Plugin API](https://rolldown.rs/apis/plugin-api)
+- [SWC Getting Started](https://swc.rs/docs/getting-started)
+- [SWC Bundling (swcpack)](https://swc.rs/docs/usage/bundling)
+- [SWC Plugin Guide](https://swc.rs/docs/plugin/ecmascript/getting-started)

--- a/documents/src/content/docs/guides/migration.md
+++ b/documents/src/content/docs/guides/migration.md
@@ -156,16 +156,16 @@ export default defineConfig({
 ### 지원하지 않는 esbuild 옵션
 
 | esbuild 옵션                | 대안                                                          |
-| --------------------------- | ------------------------------------------------------------- | ------------------------ |
+| --------------------------- | ------------------------------------------------------------- |
 | `--mangle-props=<regex>`    | 미지원 (mangle 자체는 `--minify-identifiers`로 내부 식별자만) |
 | `--mangle-cache=<path>`     | 미지원                                                        |
 | `--mangle-quoted`           | 미지원                                                        |
-| `--analyze` (tree 포맷)     | `--analyze` (현재 JSON만, tree 포맷 예정)                     |
+| `--analyze` (tree 포맷)     | `--analyze` JSON + [/analyze/](/zts/analyze/) 시각화. CLI tree 포맷은 예정 |
 | `--servedir=<path>`         | `--serve <dir>` (위치 인자)                                   |
 | `--bundle=false` (기본 off) | 기본 동작 동일. ZTS도 `--bundle` 없으면 트랜스파일만          |
 | `--splitting=false`         | 기본 off. 플래그 없는 상태가 기본                             |
 | `--tree-shaking=false`      | 미지원. 개별 `--external`로 번들 포함 범위를 줄일 수 있음     |
-| `--color=true               | false`                                                        | 미지원. 터미널 자동 감지 |
+| `--color=true\|false`       | 미지원. 터미널 자동 감지                                     |
 | `--log-override:X=Y`        | 미지원. `--log-level`만                                       |
 | `--supported:bigint=false`  | 미지원. `--target`으로 일괄 제어                              |
 | `--reserve-props=<regex>`   | 미지원                                                        |
@@ -244,7 +244,7 @@ export default defineConfig({
 
 | Vite 기능                            | ZTS 대응                                                                                               |
 | ------------------------------------ | ------------------------------------------------------------------------------------------------------ |
-| `vite` (dev server)                  | `zts dev` (HTML/env/public prepare + CSS-only HMR)                                                     |
+| `vite` (dev server)                  | `zts dev` (HTML/env/public prepare + HMR/Fast Refresh + CSS-only HMR)                                  |
 | `vite build`                         | `zts build` 또는 library build는 `zts --bundle <entry> --outdir dist --splitting --minify --sourcemap` |
 | `vite preview`                       | `zts preview dist`                                                                                     |
 | `import.meta.env.MODE`               | 앱 모드는 `.env*` 자동 로드, CLI 번들은 `--define:import.meta.env.MODE=\"production\"`                 |
@@ -311,8 +311,8 @@ module.exports = {
 | `svg-loader` / `@svgr/webpack`                  | `--loader:.svg=text`/`file`/`dataurl` 또는 플러그인          |
 | `json-loader`                                   | `--loader:.json=json` (기본 내장)                            |
 | `sass-loader` / `less-loader` / `stylus-loader` | Sass/SCSS는 앱 모드에서 지원. Less/Stylus는 사전 컴파일 필요 |
-| `postcss-loader`                                | 미지원. Lightning CSS 플러그인으로 대체                      |
-| `html-loader`                                   | 미지원. `--loader:.html=text` 로 문자열화는 가능             |
+| `postcss-loader`                                | 앱 모드에서 PostCSS 지원. library bundling은 plugin 또는 사전 처리 |
+| `html-loader`                                   | 앱 모드는 `index.html` rewrite 지원. 문자열 import는 `--loader:.html=text` |
 | `worker-loader`                                 | 미지원 (Bundle 내 Worker 일반 지원은 별도)                   |
 | `thread-loader`                                 | 불필요. ZTS 병렬 파이프라인 내장 (`--jobs=N`)                |
 | `cache-loader`                                  | 불필요. `.zig-cache` / 모듈 레벨 캐시                        |
@@ -328,7 +328,7 @@ module.exports = {
 | `BannerPlugin`                     | `--banner:js=...`                                  |
 | `SplitChunksPlugin`                | `--splitting` (자동)                               |
 | `MiniCssExtractPlugin`             | 내장 Lightning CSS 후처리 (별도 CSS 청크 출력)     |
-| `HtmlWebpackPlugin`                | 미지원. 정적 `index.html` 직접 관리                |
+| `HtmlWebpackPlugin`                | 앱 모드 `index.html` + `%ENV%`/asset rewrite로 대응 |
 | `CopyWebpackPlugin`                | 미지원. `--loader:.svg=copy` 등으로 에셋 단위 복사 |
 | `TerserPlugin`                     | `--minify` 내장                                    |
 | `CssMinimizerPlugin`               | Lightning CSS 플러그인에서 처리                    |
@@ -344,7 +344,7 @@ module.exports = {
 | `require.context`                                      | 지원 (`require.context(dir, deep, regex)` — 플러그인의 `onResolveContext` 훅으로 매칭) |
 | Lazy chunk (`import(/* webpackChunkName: "x" */ ...)`) | 동적 import 자체는 지원. 매직 코멘트는 미지원                                          |
 | `webpack.config.js` 함수형/멀티 컨피그                 | 미지원. `zts.config.ts` 단일 export                                                    |
-| `devServer.proxy`                                      | 미지원. `--serve` 는 정적/번들만                                                       |
-| Dev server overlay                                     | 미지원 (HMR 에러는 콘솔로 전달)                                                        |
+| `devServer.proxy`                                      | 지원 (`--proxy /api=http://localhost:3000`)                                             |
+| Dev server overlay                                     | 지원 (build/runtime error overlay + source map remap)                                   |
 | Persistent cache (`cache.type: 'filesystem'`)          | 불필요. 내장 캐시 사용                                                                 |
 | Stats JSON                                             | `--metafile=meta.json` 으로 유사 정보                                                  |

--- a/documents/src/content/docs/guides/plugins.md
+++ b/documents/src/content/docs/guides/plugins.md
@@ -7,6 +7,36 @@ description: ZTS 플러그인 시스템 사용법을 알아봅니다.
 
 ZTS 플러그인은 Rollup/Vite 호환 인터페이스로, `@zts/core`의 NAPI를 통해 in-process로 실행됩니다.
 
+## 호환성 요약
+
+| Surface | 상태 | 사용 경로 |
+| ------- | ---- | -------- |
+| esbuild-style `setup(build)` | 부분 지원 | `build.onResolve`, `build.onLoad`, `build.onTransform`, `build.onResolveContext`, `build.onAstFunction` |
+| Rollup/Vite-style `resolveId` / `load` / `transform` | 지원 | `vitePlugin()` wrapper 또는 config plugin |
+| output hook `renderChunk` / `generateBundle` | 부분 지원 | chunk 후처리, output 목록 접근 |
+| lifecycle `buildStart` / `buildEnd` / `closeBundle` | 지원 | `build()`와 `watch()` 초기 build/rebuild마다 호출 |
+| Rollup context `this.resolve()` / `this.emitFile()` | 미지원 | graph mutation이 필요한 별도 surface |
+| `buildSync()` + JS plugin | 미지원 | async `build()` / `watch()` 사용 |
+
+ZTS native worker는 module을 만날 때 NAPI threadsafe function으로 JS hook을 호출하고 응답을 기다립니다. 따라서 hook filter를 좁게 잡고, 단순 확장자 처리는 `loader` 옵션을 먼저 쓰는 편이 빠릅니다.
+
+## 실행 순서
+
+```text
+buildStart
+  -> resolveId / onResolve
+  -> load / onLoad
+  -> transform / onTransform
+  -> native link / tree-shake / emit
+  -> renderChunk
+  -> generateBundle
+buildEnd
+write
+closeBundle
+```
+
+`watch()`에서는 같은 순서가 초기 build와 매 rebuild마다 반복되고, `buildEnd` 이후 `onReady` 또는 `onRebuild` callback이 실행됩니다. 여러 플러그인이 같은 hook을 구현하면 등록 순서대로 처리됩니다.
+
 ## NAPI 플러그인
 
 ```typescript

--- a/documents/src/content/docs/reference/cli.md
+++ b/documents/src/content/docs/reference/cli.md
@@ -160,7 +160,7 @@ scoped class map으로 변환하며 default export와 가능한 named export를 
 | `--asset-names=<pattern>`                | 에셋 파일명 패턴                                                                                |
 | `--loader:.ext=type`                     | 확장자별 로더 (`file\|dataurl\|base64\|text\|binary\|copy\|empty\|json\|css\|js\|ts\|jsx\|tsx`) |
 | `--metafile` / `--metafile=<path>`       | 빌드 메타 JSON (stdout 또는 파일)                                                               |
-| `--analyze`                              | 번들 분석 리포트 (stderr 출력). 디스크에 JSON 으로 저장하려면 `--metafile=<path>` 명시.         |
+| `--analyze`                              | 번들 분석 리포트 (stderr 출력). 디스크에 JSON 으로 저장하려면 `--metafile=<path>` 명시. [/analyze/](/zts/analyze/)에서 업로드 가능 |
 | `--legal-comments=<mode>`                | 라이선스 주석: `none\|inline\|eof\|linked\|external` (`linked`/`external` 은 현재 `eof` fallback) |
 | `--packages=external`                    | bare package import를 모두 external 처리                                                        |
 | `--banner:js=<text>`                     | 출력 앞 텍스트 (bare `--banner=` 은 JS wrapper 만 지원)                                         |
@@ -257,5 +257,7 @@ zts bench --phase=parse --compare=baseline.json src/main.ts
 ## 참고
 
 - JS API(`@zts/core`)는 `packages/core/index.ts`에서 동일한 옵션을 프로그램적으로 제공합니다.
+- 옵션 surface별 지원 범위는 [옵션 매트릭스](/zts/reference/options-matrix/)에서 확인하세요.
+- `--metafile` 결과는 [Metafile 분석](/zts/analyze/) 페이지에서 시각화할 수 있습니다.
 - Vite 어댑터는 `vite-plugin-zts` 또는 `vitePlugin()`으로 사용하세요.
 - 미지원 옵션 / 향후 계획은 [docs/ROADMAP.md](https://github.com/ohah/zts/blob/main/docs/ROADMAP.md) 참고.

--- a/documents/src/content/docs/reference/options-matrix.md
+++ b/documents/src/content/docs/reference/options-matrix.md
@@ -1,0 +1,55 @@
+---
+title: 옵션 매트릭스
+description: CLI, JS API, config, schema 사이의 ZTS 옵션 노출 상태를 한곳에서 확인합니다.
+---
+
+ZTS 옵션은 네 개의 surface로 노출됩니다. 새 기능을 추가하거나 문서를 확인할 때는 이 표를 기준으로 누락을 점검하세요.
+
+- **CLI**: `zts` 명령과 `packages/core/bin/cli-flags.mjs`.
+- **JS API**: `@zts/core`의 `transpile()` / `build()` / `watch()` 타입.
+- **Config**: `zts.config.*` / `zts.workspace.*` 로더가 받는 사용자 설정.
+- **Schema**: transpile-only JSON schema. 번들러 전용 필드는 포함하지 않습니다.
+
+## 핵심 매트릭스
+
+| 기능군 | CLI | JS API | Config | Schema | 비고 |
+| ------ | --- | ------ | ------ | ------ | ---- |
+| 입출력 (`outfile`, `outdir`, `outbase`, `outExtension`) | ✅ | ✅ | ✅ | ❌ | `outdir`/패턴 옵션은 번들러 출력 전용 |
+| 모듈 포맷 (`format`, `platform`) | ✅ | ✅ | ✅ | ✅ | `react-native`는 RN preset을 함께 켭니다 |
+| ES/엔진 타겟 (`target`, `browserslist`) | ✅ | ✅ | ✅ | ✅ | `browserslist`는 config/API 전용, 지정 시 `target`보다 우선 |
+| 런타임 폴리필 (`runtimePolyfills`, `runtimeTarget`, `coreJs`) | ✅ | ✅ | ✅ | ❌ | graph usage 기반 core-js 주입 |
+| JSX / TS / Flow 변환 | ✅ | ✅ | ✅ | ✅ | `tsconfig` 일부 필드는 config 미지정 시 fallback |
+| define/drop/inject/pure | ✅ | ✅ | ✅ | 일부 | `dropLabels`, `pure`, `inject`는 번들러 쪽 의미가 큼 |
+| minify 세분화 | ✅ | ✅ | ✅ | ✅ | `mangle-props`류 property mangle은 정책상 미지원 |
+| source map (`sourcemapMode`, `sourcesContent`, `sourceRoot`) | ✅ | ✅ | ✅ | ✅ | RN sourcemap 출력 옵션은 RN CLI 문서 참고 |
+| resolver (`external`, `alias`, `fallback`, `conditions`) | ✅ | ✅ | ✅ | ❌ | array/RegExp alias는 async `build()`/`watch()`만 |
+| loader / asset names / public path | ✅ | ✅ | ✅ | ❌ | app mode의 HTML/CSS asset rewrite와 별도 |
+| code splitting / preserve modules | ✅ | ✅ | ✅ | ❌ | `splitting`은 `outdir` 필요 |
+| `manualChunks` | ❌ | ✅ | ✅ | ❌ | 함수형은 `zts.config.{ts,js}` 또는 JS API 전용 |
+| `metafile` / `analyze` | ✅ | ✅ | 부분 | ❌ | `metafile`은 config 가능, `analyze`는 CLI/API 중심. `meta.json`은 [/analyze/](/zts/analyze/)에서 확인 가능 |
+| watch / serve / dev server | ✅ | ✅ | ✅ | ❌ | `watch()`는 rich event payload와 lazy sourcemap API 제공 |
+| app builder (`dev`, `build`, `preview`) | ✅ | 일부 | ✅ | ❌ | HTML/env/public/CSS pipeline은 `@zts/web` 필요 |
+| plugin hooks | ✅ (`--plugin`) | ✅ | ✅ | ❌ | `buildSync()`에서는 JS plugin 미지원 |
+| diagnostics / profile / debug | ✅ | ✅ | 일부 | ❌ | profile은 CLI와 `configureProfile()` 양쪽 |
+| workspace | ✅ | ✅ | ✅ | ❌ | `zts.workspace.*`로 여러 entry를 관리 |
+
+## 동기 API 제약
+
+`buildSync()`는 native worker가 JS callback을 기다리는 구조와 충돌하므로 JS plugin, array/RegExp alias, host RegExp 기반 hook을 실행하지 않습니다. 같은 설정이 필요하면 async `build()` 또는 `watch()`를 사용하세요.
+
+## 갱신 체크리스트
+
+새 옵션을 추가할 때는 다음 순서로 확인합니다.
+
+1. `@zts/core` public type에 필드가 있는지 확인합니다.
+2. CLI로 노출해야 하는 기능이면 `cli-flags.mjs`와 `zts.mjs` help/parse 테스트를 갱신합니다.
+3. config에서 받아야 하면 `KNOWN_CONFIG_KEYS`, typo suggestion, config merge 테스트를 갱신합니다.
+4. transpile-only 옵션이면 `zig build schema`로 schema와 `reference/options`를 갱신합니다.
+5. CLI / JS API / config 중 일부만 가능한 경우 이 매트릭스와 관련 가이드에 제약을 명시합니다.
+
+## 관련 문서
+
+- [CLI 레퍼런스](/zts/reference/cli/)
+- [NAPI / JS API](/zts/reference/napi/)
+- [Transpile 옵션](/zts/reference/options/)
+- [설정 파일](/zts/guides/config-file/)

--- a/documents/src/pages/analyze.astro
+++ b/documents/src/pages/analyze.astro
@@ -1,0 +1,38 @@
+---
+import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
+---
+
+<StarlightPage
+  frontmatter={{
+    title: "Metafile Analyze",
+    description: "ZTS/esbuild-compatible metafile JSON을 브라우저에서 분석합니다.",
+    tableOfContents: false,
+    pagefind: false,
+    template: "splash",
+  }}
+>
+  <div id="metafile-analyzer-mount" class="not-content"></div>
+  <script>
+    import("../components/metafile-analyzer-mount.ts");
+  </script>
+</StarlightPage>
+
+<style>
+  :global(.analyze-page .content-panel) {
+    padding: 0 !important;
+  }
+  :global(.analyze-page h1) {
+    display: none !important;
+  }
+  :global(.analyze-page .sl-markdown-content) {
+    padding: 0 !important;
+    margin: 0 !important;
+  }
+  :global(.analyze-page .pagination-links) {
+    display: none !important;
+  }
+</style>
+
+<script is:inline>
+  document.documentElement.classList.add("analyze-page");
+</script>


### PR DESCRIPTION
## 변경 사항

- Rolldown/esbuild/SWC/Rspack/Vite 대비 기능 범위를 비교하는 도구 비교 문서를 추가했습니다.
- CLI/JS API/config/schema 옵션 노출 상태를 확인하는 옵션 매트릭스를 추가했습니다.
- GitHub Pages에서 `meta.json`을 업로드해 output/input/import graph를 볼 수 있는 Metafile 분석 페이지를 추가했습니다.
- plugin guide에 호환 surface, hook 실행 순서, NAPI callback 비용 경계를 보강했습니다.
- migration/CLI/bundling 문서의 `--analyze`, app dev server, PostCSS/HTML/proxy/overlay 설명 drift를 현재 지원 상태에 맞게 정리했습니다.
- 영어 benchmark 문서를 추가해 NAPI 문서의 benchmark 링크가 fallback 라우트 없이 검증되게 했습니다.

## 검증

- `bun run --cwd documents build`
- `git diff --check`
- push 전 hook: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check` 통과 (`oxlint`는 기존 warning만 출력, error 0)
