### PR TITLE
feat(bundler): sourcemap mapping 의 내부 gap fill — body 의 모든 줄 cover (#2651)

### DIFF
--- a/src/bundler/emitter/dev.zig
+++ b/src/bundler/emitter/dev.zig
@@ -6,26 +6,31 @@ const std = @import("std");
 const Module = @import("../module.zig").Module;
 const SourceMap = @import("../../codegen/sourcemap.zig");
 
-/// 모듈 경로를 dev bundle용 ID로 변환.
-/// root_dir이 있으면 상대 경로, 없으면 절대 경로 그대로 사용.
 /// 모듈의 소스맵 매핑을 번들 레벨 SourceMapBuilder에 추가한다.
 /// sourcesContent 등록 + preamble/wrapper 오프셋 반영 + module 영역 안의
-/// 매핑 누락 line (region/endregion marker, wrapper closing brace 등) 을
-/// module 의 first/last source line 으로 채움 (#2648).
+/// 매핑 누락 line (region/endregion marker, wrapper closing brace, 그리고
+/// codegen body 내부의 mapping 없는 줄 = blank line / 다행 statement 의 중간
+/// 줄 / esm_wrap merge 후 빈 줄 등) 을 직전 source line 으로 채움 (#2648, #2651).
 ///
 /// **bundle 의 module 영역 layout**:
 /// ```
 /// [base_line]
 ///   pre_lines (예: //#region <basename>\n) — 미매핑 시 first source line 으로
 ///   preamble_lines (wrap 의 prefix — module wrapper 의 var X = __commonJS({...)
-///   code_lines (codegen mapping 으로 cover — body) + closing brace
+///   code_lines (codegen mapping + 내부 gap fill — body + closing brace)
 ///   post_lines (예: //#endregion\n) — 미매핑 시 last source line 으로
 /// ```
 ///
-/// `total_code_lines` — wrap 적용 후 code 의 전체 \\n 갯수. codegen 의 마지막
-/// mapping 이후 ~ total 까지 (= wrapper closing brace) 를 last source line 으로
-/// 채움. 이게 없으면 RN LogBox stack frame 이 source 매핑 안 되고 bundle URL
-/// 그대로 표시 (#2648).
+/// `total_code_lines` — wrap 적용 후 code 의 전체 \\n 갯수. body 영역 안에서
+/// codegen mapping 이 없는 모든 줄을 직전 mapping 의 original_line 으로 채움.
+/// 마지막 mapping 이후 ~ total (= wrapper closing brace) 도 동일 처리.
+/// 이게 없으면 RN LogBox stack frame 이 source 매핑 안 되고 bundle URL
+/// 그대로 표시 (#2648). #2651: 내부 gap (statement 사이 빈 줄, 다행 statement
+/// 중간 줄) 도 채워서 empty mapping 비율 31.5% → ~5% 미만으로.
+///
+/// **호출자 invariant**: `maps` 는 `generated_line` 오름차순으로 정렬되어 있어야
+/// 한다. codegen / esm_wrap merge 둘 다 이 보장을 만족 (#2651 perf — 보장이
+/// 깨지면 builder 의 `is_sorted=false` 가 플립되어 bundle 전역 sort 비용 발생).
 pub fn addModuleMappings(
     sm: *SourceMap.SourceMapBuilder,
     module_id: []const u8,
@@ -47,31 +52,13 @@ pub fn addModuleMappings(
     if (sources_content and source.len > 0) {
         try sm.addSourceContent(source);
     }
-    var max_gen_line: u32 = 0;
-    var max_orig_line: u32 = 0;
-    var first_orig_line: u32 = 0;
-    var has_mapping: bool = false;
-    for (maps) |mapping| {
-        try sm.addMapping(.{
-            .generated_line = base_line + pre_lines + preamble_lines + mapping.generated_line,
-            .generated_column = if (indent_offset and mapping.generated_line != 0)
-                mapping.generated_column + 1
-            else
-                mapping.generated_column,
-            .source_index = source_idx,
-            .original_line = mapping.original_line,
-            .original_column = mapping.original_column,
-        });
-        if (!has_mapping) {
-            first_orig_line = mapping.original_line;
-            has_mapping = true;
-        }
-        if (mapping.generated_line >= max_gen_line) {
-            max_gen_line = mapping.generated_line;
-            max_orig_line = mapping.original_line;
-        }
-    }
-    if (!has_mapping) return;
+    if (maps.len == 0) return;
+
+    // maps 가 generated_line 순 정렬 가정 — codegen / esm_wrap merge 가 보장.
+    // 첫/마지막 mapping 의 original_line 으로 boilerplate 영역 (region marker,
+    // wrap header, wrap closing brace, endregion marker) 을 채움.
+    const first_orig_line = maps[0].original_line;
+
     // pre_lines (region marker) — module 의 first source line 으로 매핑.
     var i: u32 = 0;
     while (i < pre_lines) : (i += 1) {
@@ -83,18 +70,60 @@ pub fn addModuleMappings(
             .original_column = 0,
         });
     }
-    // codegen 마지막 mapping 이후 ~ total_code_lines (wrap closing brace 영역)
-    // — last source line 으로 매핑.
-    var gen_line: u32 = max_gen_line + 1;
-    while (gen_line < total_code_lines) : (gen_line += 1) {
-        try sm.addMapping(.{
-            .generated_line = base_line + pre_lines + preamble_lines + gen_line,
-            .generated_column = 0,
-            .source_index = source_idx,
-            .original_line = max_orig_line,
-            .original_column = 0,
-        });
+
+    // body 영역 single-pass: maps 의 mapping 을 정렬 순서로 emit + 매핑 없는
+    // 줄은 직전 줄의 orig 로 채움. generated_line 단조 증가 보장 → builder 의
+    // is_sorted 유지 (#2651 perf — 별도 sort pass 회피).
+    var prev_orig: u32 = first_orig_line;
+    var last_orig: u32 = first_orig_line;
+    var maps_idx: usize = 0;
+    var line: u32 = 0;
+    while (line < total_code_lines) : (line += 1) {
+        var line_had_mapping = false;
+        while (maps_idx < maps.len and maps[maps_idx].generated_line == line) : (maps_idx += 1) {
+            const m = maps[maps_idx];
+            try sm.addMapping(.{
+                .generated_line = base_line + pre_lines + preamble_lines + m.generated_line,
+                .generated_column = if (indent_offset and m.generated_line != 0)
+                    m.generated_column + 1
+                else
+                    m.generated_column,
+                .source_index = source_idx,
+                .original_line = m.original_line,
+                .original_column = m.original_column,
+            });
+            prev_orig = m.original_line;
+            last_orig = m.original_line;
+            line_had_mapping = true;
+        }
+        if (!line_had_mapping) {
+            try sm.addMapping(.{
+                .generated_line = base_line + pre_lines + preamble_lines + line,
+                .generated_column = 0,
+                .source_index = source_idx,
+                .original_line = prev_orig,
+                .original_column = 0,
+            });
+        }
     }
+
+    // total_code_lines 초과 mapping (안전망 — caller 가 잘못된 total 을 넘기면
+    // 발생). 정렬 invariant 유지를 위해 post_lines 전에 emit.
+    while (maps_idx < maps.len) : (maps_idx += 1) {
+        const m = maps[maps_idx];
+        try sm.addMapping(.{
+            .generated_line = base_line + pre_lines + preamble_lines + m.generated_line,
+            .generated_column = if (indent_offset and m.generated_line != 0)
+                m.generated_column + 1
+            else
+                m.generated_column,
+            .source_index = source_idx,
+            .original_line = m.original_line,
+            .original_column = m.original_column,
+        });
+        last_orig = m.original_line;
+    }
+
     // post_lines (endregion marker) — last source line 으로 매핑.
     i = 0;
     while (i < post_lines) : (i += 1) {
@@ -102,12 +131,14 @@ pub fn addModuleMappings(
             .generated_line = base_line + pre_lines + preamble_lines + total_code_lines + i,
             .generated_column = 0,
             .source_index = source_idx,
-            .original_line = max_orig_line,
+            .original_line = last_orig,
             .original_column = 0,
         });
     }
 }
 
+/// 모듈 경로를 dev bundle용 ID로 변환.
+/// root_dir이 있으면 상대 경로, 없으면 절대 경로 그대로 사용.
 pub fn makeModuleId(path: []const u8, root_dir: ?[]const u8) []const u8 {
     const root = root_dir orelse return path;
     if (root.len == 0) return path;
@@ -128,4 +159,184 @@ pub fn makeModuleId(path: []const u8, root_dir: ?[]const u8) []const u8 {
     }
 
     return path;
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+const testing = std.testing;
+
+test "addModuleMappings: codegen body 의 내부 빈 줄 (gap) 도 직전 orig 로 채워진다 (#2651)" {
+    var sm = SourceMap.SourceMapBuilder.init(testing.allocator);
+    defer sm.deinit();
+
+    // codegen output 6 줄 가정. 줄 0,2,5 만 mapping 존재 (1,3,4 = blank).
+    const maps = [_]SourceMap.Mapping{
+        .{ .generated_line = 0, .generated_column = 0, .original_line = 10, .original_column = 0 },
+        .{ .generated_line = 2, .generated_column = 0, .original_line = 12, .original_column = 0 },
+        .{ .generated_line = 5, .generated_column = 0, .original_line = 15, .original_column = 0 },
+    };
+
+    try addModuleMappings(
+        &sm,
+        "src/foo.ts",
+        "// dummy source",
+        &maps,
+        100, // base_line
+        0, // preamble_lines
+        false, // sources_content
+        false, // indent_offset
+        0, // pre_lines
+        6, // total_code_lines
+        0, // post_lines
+    );
+
+    // generated_line 100~105 (base + 0~5) 모두 mapping 존재해야 함.
+    var has_line = std.AutoHashMap(u32, u32).init(testing.allocator);
+    defer has_line.deinit();
+    for (sm.mappings.items) |m| {
+        try has_line.put(m.generated_line, m.original_line);
+    }
+    try testing.expectEqual(@as(u32, 10), has_line.get(100).?);
+    try testing.expectEqual(@as(u32, 10), has_line.get(101).?); // gap, prev = 10
+    try testing.expectEqual(@as(u32, 12), has_line.get(102).?);
+    try testing.expectEqual(@as(u32, 12), has_line.get(103).?); // gap, prev = 12
+    try testing.expectEqual(@as(u32, 12), has_line.get(104).?); // gap, prev = 12
+    try testing.expectEqual(@as(u32, 15), has_line.get(105).?);
+}
+
+test "addModuleMappings: 첫 매핑 이전의 wrap header 줄들도 first_orig 로 채워진다 (#2651)" {
+    var sm = SourceMap.SourceMapBuilder.init(testing.allocator);
+    defer sm.deinit();
+
+    // 줄 0,1 = wrap header (no codegen mapping). 줄 2 부터 mapping 시작.
+    const maps = [_]SourceMap.Mapping{
+        .{ .generated_line = 2, .generated_column = 0, .original_line = 5, .original_column = 0 },
+        .{ .generated_line = 3, .generated_column = 0, .original_line = 6, .original_column = 0 },
+    };
+
+    try addModuleMappings(
+        &sm,
+        "src/foo.ts",
+        "",
+        &maps,
+        0,
+        0,
+        false,
+        false,
+        0,
+        4, // total_code_lines (wrap header 2 + body 2)
+        0,
+    );
+
+    var has_line = std.AutoHashMap(u32, u32).init(testing.allocator);
+    defer has_line.deinit();
+    for (sm.mappings.items) |m| {
+        try has_line.put(m.generated_line, m.original_line);
+    }
+    try testing.expectEqual(@as(u32, 5), has_line.get(0).?); // header → first_orig
+    try testing.expectEqual(@as(u32, 5), has_line.get(1).?); // header → first_orig
+    try testing.expectEqual(@as(u32, 5), has_line.get(2).?);
+    try testing.expectEqual(@as(u32, 6), has_line.get(3).?);
+}
+
+test "addModuleMappings: tail (마지막 mapping 이후 wrap closing brace) 영역도 채워진다 (#2648 + #2651)" {
+    var sm = SourceMap.SourceMapBuilder.init(testing.allocator);
+    defer sm.deinit();
+
+    // 줄 0 만 mapping. 줄 1,2,3 = wrap closing brace 등 boilerplate.
+    const maps = [_]SourceMap.Mapping{
+        .{ .generated_line = 0, .generated_column = 0, .original_line = 7, .original_column = 0 },
+    };
+
+    try addModuleMappings(
+        &sm,
+        "src/foo.ts",
+        "",
+        &maps,
+        0,
+        0,
+        false,
+        false,
+        0,
+        4, // total_code_lines
+        0,
+    );
+
+    var has_line = std.AutoHashMap(u32, u32).init(testing.allocator);
+    defer has_line.deinit();
+    for (sm.mappings.items) |m| {
+        try has_line.put(m.generated_line, m.original_line);
+    }
+    try testing.expectEqual(@as(u32, 7), has_line.get(0).?);
+    try testing.expectEqual(@as(u32, 7), has_line.get(1).?); // tail
+    try testing.expectEqual(@as(u32, 7), has_line.get(2).?); // tail
+    try testing.expectEqual(@as(u32, 7), has_line.get(3).?); // tail
+}
+
+test "addModuleMappings: pre/post (region/endregion marker) + 내부 gap 동시 cover" {
+    var sm = SourceMap.SourceMapBuilder.init(testing.allocator);
+    defer sm.deinit();
+
+    // layout:
+    //   line 0      = //#region marker (pre_lines=1)
+    //   line 1,2,3  = body. line 1,3 mapped. line 2 gap.
+    //   line 4      = //#endregion marker (post_lines=1)
+    const maps = [_]SourceMap.Mapping{
+        .{ .generated_line = 0, .generated_column = 0, .original_line = 20, .original_column = 0 },
+        .{ .generated_line = 2, .generated_column = 0, .original_line = 22, .original_column = 0 },
+    };
+
+    try addModuleMappings(
+        &sm,
+        "src/foo.ts",
+        "",
+        &maps,
+        0, // base_line
+        0, // preamble_lines
+        false,
+        false,
+        1, // pre_lines (region marker)
+        3, // total_code_lines (body)
+        1, // post_lines (endregion marker)
+    );
+
+    var has_line = std.AutoHashMap(u32, u32).init(testing.allocator);
+    defer has_line.deinit();
+    for (sm.mappings.items) |m| {
+        try has_line.put(m.generated_line, m.original_line);
+    }
+    // generated_line 0 = pre_lines region → first_orig = 20
+    try testing.expectEqual(@as(u32, 20), has_line.get(0).?);
+    // generated_line 1 = body line 0 (offset by pre_lines=1) → mapping[0] = 20
+    try testing.expectEqual(@as(u32, 20), has_line.get(1).?);
+    // generated_line 2 = body line 1 → gap, prev = 20
+    try testing.expectEqual(@as(u32, 20), has_line.get(2).?);
+    // generated_line 3 = body line 2 → mapping[1] = 22
+    try testing.expectEqual(@as(u32, 22), has_line.get(3).?);
+    // generated_line 4 = post_lines endregion → last_orig = 22
+    try testing.expectEqual(@as(u32, 22), has_line.get(4).?);
+}
+
+test "addModuleMappings: maps 가 비어있으면 아무 mapping 도 추가 안 됨" {
+    var sm = SourceMap.SourceMapBuilder.init(testing.allocator);
+    defer sm.deinit();
+
+    try addModuleMappings(
+        &sm,
+        "src/foo.ts",
+        "",
+        &.{}, // empty maps
+        0,
+        0,
+        false,
+        false,
+        1,
+        5,
+        1,
+    );
+
+    // source 는 등록되지만 mapping 은 0 개.
+    try testing.expectEqual(@as(usize, 0), sm.mappings.items.len);
 }

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -105,6 +105,12 @@ test {
     _ = module_store;
     _ = symbol;
 
+    // emitter/ 하위 파일 (dev.zig 등) 의 인라인 test 블록을 test 빌드가
+    // 발견하도록 명시적으로 reference. emitter.zig 는 dev 를 사용하지만
+    // `pub const` 가 아닌 file-private const 로만 import → 다른 파일이
+    // dev 를 직접 reference 안 하면 test reachability 안 잡힘.
+    _ = @import("emitter/dev.zig");
+
     // test files
     _ = @import("bundler_test.zig");
     _ = @import("tree_shaker_test.zig");

--- a/tests/integration/tests/sourcemap.test.ts
+++ b/tests/integration/tests/sourcemap.test.ts
@@ -292,16 +292,16 @@ describe('소스맵', () => {
       expect(m.genLine).toBeLessThanOrEqual(bundleLines.length);
     }
 
-    // 매핑된 번들 줄에 lib.ts 관련 코드가 있어야 한다
-    const firstMapping = libMappings[0];
-    const mappedBundleLine = bundleLines[firstMapping.genLine - 1] || '';
-    expect(
-      mappedBundleLine.includes('greet') ||
-        mappedBundleLine.includes('function') ||
-        mappedBundleLine.includes('console') ||
-        mappedBundleLine.includes('VERSION') ||
-        mappedBundleLine.includes('1.0'),
-    ).toBe(true);
+    // 매핑된 번들 줄 중 적어도 하나는 lib.ts 관련 코드를 포함해야 한다.
+    // 새 single-pass 매핑은 wrap header 줄도 source 의 first line 으로 채우므로
+    // libMappings[0] 만 보면 boilerplate 줄이 잡힐 수 있음. 전체 매핑 중에서
+    // keyword 매칭 search 로 의도된 검증을 표현.
+    const KEYWORDS = ['greet', 'function', 'console', 'VERSION', '1.0'];
+    const hasKeywordMatch = libMappings.some((m) => {
+      const line = bundleLines[m.genLine - 1] || '';
+      return KEYWORDS.some((k) => line.includes(k));
+    });
+    expect(hasKeywordMatch).toBe(true);
   });
 
   test('TypeScript type 선언이 있어도 소스맵 줄 번호가 정확하다 (#954)', async () => {


### PR DESCRIPTION
## 배경

#2648 후속. PR #2649 / #2650 으로 region marker / wrap closing brace / endregion marker 영역까지는 cover 했지만 empty mapping 비율 **37% → 31.5%** 에서 정체. 사용자 RN LogBox stack trace 의 일부 frame (line 1000, 50000 등) 여전히 매핑 실패.

## 근본 원인

`addModuleMappings` (dev.zig) 가 채우는 영역:
- ✅ pre_lines (region marker) — first source line
- ✅ tail (max_gen_line+1 ~ total_code_lines) — last source line  
- ✅ post_lines (endregion marker) — last source line
- ❌ **body 영역 내부의 매핑 없는 줄** — 미처리

→ codegen 출력의 statement 사이 빈 줄, 다행 statement 의 중간 줄, esm_wrap merge 후의 col-only mapping 사이 줄들이 unmapped 로 남음. 이게 \"일부 frame은 매핑되고 일부는 안됨\" 패턴의 직접적 원인.

## 변경

### 1. body 의 모든 줄 cover
\`addModuleMappings\` 를 body 영역 \`[0, total_code_lines)\` 의 모든 줄에 대해 mapping 보장하도록 확장:
- mapping 있는 줄: maps 의 entry 그대로 emit
- 매핑 없는 줄: 직전 mapping 의 original_line 을 col 0 으로 채움
- 첫 mapping 이전 줄 (wrap header 등): first source line 으로 채움

### 2. Single-pass 알고리즘 (perf)
maps emit + gap fill 을 단일 loop 로 통합. \`generated_line\` 단조 증가 보장으로 \`SourceMapBuilder.is_sorted\` 유지. 별도 sort pass (\`std.mem.sort\` on 500K+ mappings) 회피.

호출자 invariant 를 docstring 에 명시: \`maps\` 는 \`generated_line\` 오름차순 정렬 가정 (codegen / esm_wrap merge 모두 보장).

### 3. 부산물 cleanup
- \`makeModuleId\` 의 docstring 위치 버그 fix (\`addModuleMappings\` 위에 잘못 붙어있었음 — 기존 #2648 이전부터 있던 것)
- \`bundler/mod.zig\` 에서 \`emitter/dev.zig\` 의 인라인 test 블록을 명시적 reference (현재까지 test reachability 안 잡혔음 → 신규 unit test 5개 포함 모두 검증)

## Unit tests (5개)
- 내부 빈 줄 (gap) 채우기 검증
- 첫 mapping 이전 wrap header 채우기 검증
- tail (wrap closing brace) 채우기 검증
- pre/post + 내부 gap 동시 cover
- empty maps edge case

## 영향

- empty mapping 비율 31.5% → ~5% 미만 추정. RN LogBox stack frame 의 거의 모든 줄이 source 매핑됨 (#2605).
- chunks.zig 의 sourcemap infra 는 별개 영역 (현재 미구현). 후속 PR 에서 단계 B 로 처리 예정.

## Test plan

- [x] zig build (Debug + ReleaseFast) 통과
- [x] zig build test 통과 (4684/4684)
- [x] 새 unit test 5개 모두 통과 (deliberate-fail sentinel 로 reachability 검증)
- [ ] 사용자 환경 RN bundle 에서 LogBox stack trace 실측 — 후속 분리 검증

Closes #2651

🤖 Generated with [Claude Code](https://claude.com/claude-code)