### PR TITLE
fix(react-native): port withExpo + EXPO_ROUTER_APP_ROOT 절대경로 (#2605)

### DIFF
--- a/examples/react-native-expo/zts.config.ts
+++ b/examples/react-native-expo/zts.config.ts
@@ -3,10 +3,12 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { withExpo } from "@zts/react-native";
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-export default {
+export default withExpo({
   root: __dirname,
   entry: "index.js",
   dev: true,
@@ -47,4 +49,4 @@ export default {
     forwardClientLogs: true,
     verifyConnections: false,
   },
-};
+});

--- a/packages/core/bin/rn-dev-input.mjs
+++ b/packages/core/bin/rn-dev-input.mjs
@@ -36,6 +36,38 @@ function warnUnsupported(config) {
 }
 
 /**
+ * Metro-shape config (`resolver` / `serializer` / `transformer` / `server` /
+ * `watchFolders` / `sourcemapSourcesRoot`) → `RnBundleInput.extra` 평탄화. dev
+ * server (rn-dev-input) 와 prod bundle (zts.mjs runRnBundle) 양쪽이 공유.
+ *
+ * `opts.rnWatchFolders` / `opts.rnSourceExts` 만 CLI flag 가 config 위에 우선 —
+ * 나머지 필드는 config-only.
+ */
+export function buildRnBundleExtra(config, opts = {}) {
+  const cfg = config ?? {};
+  const resolver = cfg.resolver ?? {};
+  const transformer = cfg.transformer ?? {};
+  const serializer = cfg.serializer ?? {};
+  const server = cfg.server ?? {};
+  return {
+    watchFolders: opts.rnWatchFolders ?? cfg.watchFolders ?? undefined,
+    sourceExts: opts.rnSourceExts ?? resolver.sourceExts ?? undefined,
+    assetExts: resolver.assetExts ?? undefined,
+    blockList: resolver.blockList ?? undefined,
+    fallback: resolver.extraNodeModules ?? undefined,
+    metroResolveRequest: resolver.resolveRequest ?? undefined,
+    babelTransformerPath: transformer.babelTransformerPath ?? undefined,
+    polyfills: serializer.polyfills ?? undefined,
+    extraVars: serializer.extraVars ?? undefined,
+    prelude: serializer.prelude ?? undefined,
+    babel: transformer.babel ?? undefined,
+    inlineSourceMap: serializer.inlineSourceMap ?? undefined,
+    sourceRoot: cfg.sourcemapSourcesRoot ?? undefined,
+    silentConsoleErrorPatterns: server.silentConsoleErrorPatterns ?? undefined,
+  };
+}
+
+/**
  * 번개 BungaeConfig 의 `root` / `entry` / `dev` / `minify` / `server.*` /
  * `resolver.*` / `transformer.*` / `serializer.*` / `symbolicator.*` /
  * `watchFolders` 영역 인식.
@@ -55,8 +87,6 @@ export function buildRnDevServerInput(opts, config) {
   const rnPlatform = opts.rnPlatform === 'android' ? 'android' : 'ios';
   const server = cfg.server ?? {};
   const resolver = cfg.resolver ?? {};
-  const transformer = cfg.transformer ?? {};
-  const serializer = cfg.serializer ?? {};
   const symbolicator = cfg.symbolicator ?? {};
 
   warnUnsupported(cfg);
@@ -64,7 +94,7 @@ export function buildRnDevServerInput(opts, config) {
   // server.useGlobalHotkey + CLI `--no-interactive` 둘 다 r/d/? 키보드
   // shortcut 의 enable gate. CLI flag 우선 — 명시 시 config override.
   const terminalActions =
-    opts.noInteractive === true ? false : server.useGlobalHotkey === false ? false : undefined;
+    opts.noInteractive === true || server.useGlobalHotkey === false ? false : undefined;
 
   return {
     bundle: {
@@ -85,21 +115,7 @@ export function buildRnDevServerInput(opts, config) {
         opts.minifySyntax ||
         cfg.minify ||
         false,
-      extra: {
-        watchFolders: cfg.watchFolders ?? undefined,
-        blockList: resolver.blockList ?? undefined,
-        fallback: resolver.extraNodeModules ?? undefined,
-        metroResolveRequest: resolver.resolveRequest ?? undefined,
-        babelTransformerPath: transformer.babelTransformerPath ?? undefined,
-        sourceExts: resolver.sourceExts ?? undefined,
-        assetExts: resolver.assetExts ?? undefined,
-        polyfills: serializer.polyfills ?? undefined,
-        extraVars: serializer.extraVars ?? undefined,
-        prelude: serializer.prelude ?? undefined,
-        babel: transformer.babel ?? undefined,
-        inlineSourceMap: serializer.inlineSourceMap ?? undefined,
-        sourceRoot: cfg.sourcemapSourcesRoot ?? undefined,
-      },
+      extra: buildRnBundleExtra(cfg, opts),
     },
     port: opts.port ?? server.port ?? 8081,
     host: opts.host ?? server.host ?? 'localhost',

--- a/packages/core/bin/zts.mjs
+++ b/packages/core/bin/zts.mjs
@@ -16,7 +16,7 @@ import { fileURLToPath } from 'node:url';
 
 import { applyFlagAction, KNOWN_FLAGS, matchFlagFromRegistry } from './cli-flags.mjs';
 import { copyRnAssets } from './rn-asset-copy.mjs';
-import { buildRnDevServerInput } from './rn-dev-input.mjs';
+import { buildRnBundleExtra, buildRnDevServerInput } from './rn-dev-input.mjs';
 
 function isMissingBuiltCore(error) {
   if (!error || error.code !== 'ERR_MODULE_NOT_FOUND') return false;
@@ -675,9 +675,10 @@ function warnRnBundleUnsupported(opts) {
   }
 }
 
-async function runRnBundle(opts, _config) {
+async function runRnBundle(opts, config) {
   const rn = await loadRnModule();
-  const projectRoot = resolve(opts.rnProjectRoot ?? '.');
+  const cfg = config ?? {};
+  const projectRoot = resolve(opts.rnProjectRoot ?? cfg.root ?? '.');
   const entry = opts.entryPoints?.[0];
   if (!entry) {
     console.error(
@@ -715,10 +716,7 @@ async function runRnBundle(opts, _config) {
     sourcemap: wantsSourcemap,
     minify:
       opts.minify || opts.minifyWhitespace || opts.minifyIdentifiers || opts.minifySyntax || false,
-    extra: {
-      watchFolders: opts.rnWatchFolders ?? undefined,
-      sourceExts: opts.rnSourceExts ?? undefined,
-    },
+    extra: buildRnBundleExtra(cfg, opts),
     override: outfile && !callerWrite ? { outfile, write: true } : undefined,
   });
 

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -5362,6 +5362,37 @@ describe('buildRnDevServerInput — config + opts 추출 (#2605)', () => {
     );
     expect(input?.bundle.extra?.sourceRoot).toBe('/abs/proj');
   });
+
+  test('config.server.silentConsoleErrorPatterns → bundle.extra.silentConsoleErrorPatterns 매핑 (Metro 호환, withExpo)', async () => {
+    const { buildRnDevServerInput } = await import('./rn-dev-input.mjs');
+    const original = process.stderr.write.bind(process.stderr);
+    const writes: string[] = [];
+    // @ts-expect-error — runtime mock
+    process.stderr.write = (chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
+      return true;
+    };
+    let input: ReturnType<typeof buildRnDevServerInput>;
+    try {
+      input = buildRnDevServerInput(
+        { entryPoints: ['i.js'] },
+        {
+          server: {
+            silentConsoleErrorPatterns: [
+              '^Failed to set polyfill\\.\\s+\\w+\\s+is not configurable\\.?$',
+            ],
+          },
+        },
+      );
+    } finally {
+      process.stderr.write = original;
+    }
+    expect(input?.bundle.extra?.silentConsoleErrorPatterns).toEqual([
+      '^Failed to set polyfill\\.\\s+\\w+\\s+is not configurable\\.?$',
+    ]);
+    // 매핑 가능한 필드라 unsupported 경고 없음.
+    expect(writes.join('')).not.toContain('server.silentConsoleErrorPatterns');
+  });
 });
 
 describe('CLI: dev --platform=react-native (#2605 PR #J)', () => {

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -123,3 +123,9 @@ export {
 } from './preset.ts';
 export { resolveRnPolyfills, RN_GLOBAL_IDENTIFIERS, tryResolve } from './rn-constants.ts';
 export { HMR_CLIENT_SUFFIX, ZTS_HMR_CLIENT_CODE } from './runtime-loader.ts';
+export {
+  detectExpo,
+  WINTER_POLYFILL_WARNING_PATTERN,
+  withExpo,
+  type ZtsRnExpoConfig,
+} from './withExpo.ts';

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -90,7 +90,9 @@ describe('buildRnBundleOptions — define / banner / footer / polyfills', () => 
     // EXPO_ROUTER_APP_ROOT 는 projectRoot 의 `app/` 절대 경로 — `_ctx.{ios,android,web}.js`
     // 가 node_modules 안에 있어 importer 기준 상대 경로면 ctx 매치 0 → "Welcome to Expo"
     // fallback 화면 트리거됨.
-    expect(opts.define?.['process.env.EXPO_ROUTER_APP_ROOT']).toBe(JSON.stringify(join(dir, 'app')));
+    expect(opts.define?.['process.env.EXPO_ROUTER_APP_ROOT']).toBe(
+      JSON.stringify(join(dir, 'app')),
+    );
     expect(opts.define?.['process.env.EXPO_OS']).toBe('"android"');
     expect(opts.define?.global).toBe('__ZTS_RN_GLOBAL__');
   });

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -87,7 +87,10 @@ describe('buildRnBundleOptions — define / banner / footer / polyfills', () => 
     const opts = buildRnBundleOptions(baseInput({ dev: true, rnPlatform: 'android' }));
     expect(opts.define?.__DEV__).toBe('true');
     expect(opts.define?.['process.env.NODE_ENV']).toBe('"development"');
-    expect(opts.define?.['process.env.EXPO_ROUTER_APP_ROOT']).toBe('"./app"');
+    // EXPO_ROUTER_APP_ROOT 는 projectRoot 의 `app/` 절대 경로 — `_ctx.{ios,android,web}.js`
+    // 가 node_modules 안에 있어 importer 기준 상대 경로면 ctx 매치 0 → "Welcome to Expo"
+    // fallback 화면 트리거됨.
+    expect(opts.define?.['process.env.EXPO_ROUTER_APP_ROOT']).toBe(JSON.stringify(join(dir, 'app')));
     expect(opts.define?.['process.env.EXPO_OS']).toBe('"android"');
     expect(opts.define?.global).toBe('__ZTS_RN_GLOBAL__');
   });
@@ -266,6 +269,21 @@ describe('buildRnBundleOptions — define / banner / footer / polyfills', () => 
   test('extra.sourceRoot 미지정 — preset.sourceRoot 미설정', () => {
     const opts = buildRnBundleOptions(baseInput());
     expect(opts.sourceRoot).toBeUndefined();
+  });
+
+  test('extra.silentConsoleErrorPatterns — Metro server.silentConsoleErrorPatterns 호환', () => {
+    const patterns = ['^Failed to set polyfill\\.\\s+\\w+\\s+is not configurable\\.?$'];
+    const opts = buildRnBundleOptions(
+      baseInput({ extra: { silentConsoleErrorPatterns: patterns } }),
+    );
+    expect(opts.silentConsoleErrorPatterns).toEqual(patterns);
+  });
+
+  test('extra.silentConsoleErrorPatterns — 빈 배열 또는 미지정 시 미설정', () => {
+    const a = buildRnBundleOptions(baseInput({ extra: { silentConsoleErrorPatterns: [] } }));
+    expect(a.silentConsoleErrorPatterns).toBeUndefined();
+    const b = buildRnBundleOptions(baseInput());
+    expect(b.silentConsoleErrorPatterns).toBeUndefined();
   });
 });
 

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -117,6 +117,13 @@ export interface RnBundleInput {
      * 경로를 source 로 변환하는 base. zts core 의 `sourceRoot` 으로 forward.
      */
     sourceRoot?: string;
+    /**
+     * `console.error` setter intercept 의 RegExp source string 배열 — match 시
+     * silent swallow. zts core 의 `silentConsoleErrorPatterns` 로 forward
+     * (Metro `server.silentConsoleErrorPatterns` 호환). consumer (e.g.
+     * `withExpo()`) 가 환경 감지 후 패턴 주입.
+     */
+    silentConsoleErrorPatterns?: string[];
   };
   /** RN prelude 끝에 append 할 사용자 banner string. */
   bannerExtras?: string;
@@ -360,8 +367,11 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
     global: '__ZTS_RN_GLOBAL__',
     __DEV__: String(dev),
     'process.env.NODE_ENV': `"${dev ? 'development' : 'production'}"`,
-    // Expo Router 의 require.context 인자 정적 평가용 (Phase 2.6 import_scanner).
-    'process.env.EXPO_ROUTER_APP_ROOT': '"./app"',
+    // expo-router `_ctx.{ios,android,web}.js` 의 require.context 인자 정적 평가용
+    // (Phase 2.6 import_scanner). 절대 경로 필수 — `_ctx` 가 node_modules 안에 있어
+    // 상대 경로면 require-context 플러그인의 `resolve(dirname(importer), dir)` 가
+    // `node_modules/expo-router/app/` 를 가리켜 ctx 매치 0.
+    'process.env.EXPO_ROUTER_APP_ROOT': JSON.stringify(resolve(projectRoot, 'app')),
     'process.env.EXPO_ROUTER_IMPORT_MODE': '"sync"',
     'process.env.EXPO_OS': `"${rnPlatform}"`,
   };
@@ -424,6 +434,9 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
   }
   if (extra?.sourceRoot) {
     preset.sourceRoot = extra.sourceRoot;
+  }
+  if (extra?.silentConsoleErrorPatterns && extra.silentConsoleErrorPatterns.length > 0) {
+    preset.silentConsoleErrorPatterns = [...extra.silentConsoleErrorPatterns];
   }
 
   // user override 는 마지막 — define / loader / alias 같은 dict 는 deep merge,

--- a/packages/react-native/src/withExpo.test.ts
+++ b/packages/react-native/src/withExpo.test.ts
@@ -144,7 +144,10 @@ describe('withExpo — Expo 모듈 resolve (real node_modules)', () => {
     // node_modules/expo/src/winter/index.ts (또는 build/winter/index.js) 가 있어야 picked up.
     // tmp 안에 simulate — expo/build/winter/index.js 실파일 생성 + package.json.
     mkdirSync(join(dir, 'node_modules/expo/build/winter'), { recursive: true });
-    writeFileSync(join(dir, 'node_modules/expo/package.json'), '{"name":"expo","version":"55.0.0","main":"build/index.js"}');
+    writeFileSync(
+      join(dir, 'node_modules/expo/package.json'),
+      '{"name":"expo","version":"55.0.0","main":"build/index.js"}',
+    );
     writeFileSync(join(dir, 'node_modules/expo/build/winter/index.js'), '// winter');
 
     const config = withExpo({ root: dir });

--- a/packages/react-native/src/withExpo.test.ts
+++ b/packages/react-native/src/withExpo.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { detectExpo, WINTER_POLYFILL_WARNING_PATTERN, withExpo } from './withExpo.ts';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'zts-rn-withexpo-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('detectExpo', () => {
+  test('expo dependency 감지', () => {
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ dependencies: { expo: '~55.0.15' } }),
+    );
+    const result = detectExpo(dir);
+    expect(result).toEqual({ name: 'expo', version: '~55.0.15' });
+  });
+
+  test('expo-router dependency (expo 미선언) 감지', () => {
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ dependencies: { 'expo-router': '~55.0.12' } }),
+    );
+    const result = detectExpo(dir);
+    expect(result).toEqual({ name: 'expo-router', version: '~55.0.12' });
+  });
+
+  test('devDependencies 만 있어도 감지', () => {
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ devDependencies: { expo: '^55.0.0' } }),
+    );
+    const result = detectExpo(dir);
+    expect(result).toEqual({ name: 'expo', version: '^55.0.0' });
+  });
+
+  test('Expo deps 없으면 undefined', () => {
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ dependencies: { 'react-native': '0.83.4' } }),
+    );
+    expect(detectExpo(dir)).toBeUndefined();
+  });
+
+  test('package.json 없으면 undefined (throw 안 함)', () => {
+    expect(detectExpo(dir)).toBeUndefined();
+  });
+
+  test('malformed package.json 도 undefined (throw 안 함)', () => {
+    writeFileSync(join(dir, 'package.json'), '{ this is not valid json');
+    expect(detectExpo(dir)).toBeUndefined();
+  });
+});
+
+describe('withExpo — config 변형', () => {
+  test('resolver.assetExts 에 .heic / .avif / .db 추가 (중복 제거)', () => {
+    const config = withExpo({
+      root: dir,
+      resolver: { assetExts: ['.png', '.avif'] },
+    });
+    expect(config.resolver?.assetExts).toEqual(['.png', '.avif', '.heic', '.db']);
+  });
+
+  test('resolver.assetExts 미지정 시 새로 생성', () => {
+    const config = withExpo({ root: dir });
+    expect(config.resolver?.assetExts).toEqual(['.heic', '.avif', '.db']);
+  });
+
+  test('resolver.blockList 에 .expo/types regex 추가', () => {
+    const config = withExpo({ root: dir });
+    expect(config.resolver?.blockList?.length).toBe(1);
+    const re = config.resolver?.blockList?.[0];
+    expect(re instanceof RegExp).toBe(true);
+    expect((re as RegExp).source).toBe('\\.expo[\\\\/]types');
+  });
+
+  test('기존 blockList 보존 후 append', () => {
+    const userPattern = /node_modules\/foo/;
+    const config = withExpo({
+      root: dir,
+      resolver: { blockList: [userPattern] },
+    });
+    expect(config.resolver?.blockList?.[0]).toBe(userPattern);
+    expect(config.resolver?.blockList?.length).toBe(2);
+  });
+
+  test('server.silentConsoleErrorPatterns 에 winter polyfill warning 패턴 추가', () => {
+    const config = withExpo({ root: dir });
+    expect(config.server?.silentConsoleErrorPatterns).toEqual([WINTER_POLYFILL_WARNING_PATTERN]);
+  });
+
+  test('기존 silentConsoleErrorPatterns 보존 + winter pattern append', () => {
+    const config = withExpo({
+      root: dir,
+      server: { silentConsoleErrorPatterns: ['^user pattern$'] },
+    });
+    expect(config.server?.silentConsoleErrorPatterns).toEqual([
+      '^user pattern$',
+      WINTER_POLYFILL_WARNING_PATTERN,
+    ]);
+  });
+
+  test('serializer.prelude — expo/winter / metro-runtime 미설치 시 빈 배열 (resolve 실패 → skip)', () => {
+    // tmp dir 에 expo 모듈 없으므로 둘 다 resolve 실패 → 사용자 prelude 만 보존.
+    const config = withExpo({
+      root: dir,
+      serializer: { prelude: ['/abs/user-prelude.js'] },
+    });
+    expect(config.serializer?.prelude).toEqual(['/abs/user-prelude.js']);
+  });
+
+  test('config 의 다른 필드는 그대로 통과 (root / entry / dev / minify 등)', () => {
+    const config = withExpo({
+      root: dir,
+      entry: 'index.js',
+      dev: true,
+      minify: false,
+    });
+    expect(config.root).toBe(dir);
+    expect(config.entry).toBe('index.js');
+    expect(config.dev).toBe(true);
+    expect(config.minify).toBe(false);
+  });
+
+  test('root 미지정 시 process.cwd() 로 fallback', () => {
+    const config = withExpo({});
+    // tmp dir 안 expo 모듈 없는 cwd 도 throw 안 하고 정상 반환.
+    expect(config).toBeDefined();
+    expect(config.resolver?.assetExts).toEqual(['.heic', '.avif', '.db']);
+  });
+});
+
+describe('withExpo — Expo 모듈 resolve (real node_modules)', () => {
+  test('expo 패키지가 설치된 root 에선 winter 가 prelude 에 포함', () => {
+    // node_modules/expo/src/winter/index.ts (또는 build/winter/index.js) 가 있어야 picked up.
+    // tmp 안에 simulate — expo/build/winter/index.js 실파일 생성 + package.json.
+    mkdirSync(join(dir, 'node_modules/expo/build/winter'), { recursive: true });
+    writeFileSync(join(dir, 'node_modules/expo/package.json'), '{"name":"expo","version":"55.0.0","main":"build/index.js"}');
+    writeFileSync(join(dir, 'node_modules/expo/build/winter/index.js'), '// winter');
+
+    const config = withExpo({ root: dir });
+    const prelude = config.serializer?.prelude ?? [];
+    expect(prelude.some((p) => p.includes('expo/build/winter/index.js'))).toBe(true);
+  });
+});

--- a/packages/react-native/src/withExpo.ts
+++ b/packages/react-native/src/withExpo.ts
@@ -1,0 +1,144 @@
+/**
+ * withExpo — Apply Expo-specific options to a ZTS RN config.
+ *
+ * Mirrors the runtime opt-in pattern of `@expo/metro-config`:
+ *   import { withExpo } from '@zts/react-native';
+ *   export default withExpo({ root: __dirname, entry: 'index.js', ... });
+ *
+ * Adds:
+ *   - serializer.prelude:                 `expo/winter` + `@expo/metro-runtime`
+ *   - resolver.assetExts:                 `.heic`, `.avif`, `.db` (expo-image, expo-sqlite)
+ *   - resolver.blockList:                 `.expo/types/**` (generated d.ts)
+ *   - server.silentConsoleErrorPatterns:  winter polyfill warning
+ *
+ * Resolves all paths from `config.root`, so monorepo hoisting in unrelated
+ * workspace packages cannot leak Expo into a vanilla RN config.
+ *
+ * 번개 packages/bungae/src/bundler/zts-bundler/withExpo.ts 의 ZTS 포팅.
+ * BungaeConfig 대신 ZTS 의 Metro-shape config (rn-dev-input.mjs 가 인식하는
+ * `resolver.assetExts` / `resolver.blockList` / `serializer.prelude` /
+ * `server.silentConsoleErrorPatterns` 영역) 를 변형.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { tryResolve } from './rn-constants.ts';
+
+/**
+ * Detect whether a project's own `package.json` declares Expo as a direct
+ * dependency. Used by zero-config mode to decide whether to auto-apply
+ * `withExpo()`. Hoisted-monorepo dependencies in workspace root do NOT
+ * trigger detection — only the project's own deps do.
+ */
+export function detectExpo(
+  projectRoot: string,
+): { name: 'expo' | 'expo-router'; version: string } | undefined {
+  try {
+    const pkg = JSON.parse(readFileSync(join(projectRoot, 'package.json'), 'utf8')) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+    if (deps.expo) return { name: 'expo', version: deps.expo };
+    if (deps['expo-router']) return { name: 'expo-router', version: deps['expo-router'] };
+  } catch {
+    // Missing or malformed package.json — treat as non-Expo project.
+  }
+  return undefined;
+}
+
+const EXPO_ASSET_EXTS = ['.heic', '.avif', '.db'] as const;
+
+/** Normalize "ext" / ".ext" → ".ext" for dedup comparisons. */
+function normalizeExt(ext: string): string {
+  return ext.startsWith('.') ? ext : `.${ext}`;
+}
+
+const EXPO_BLOCK_LIST: RegExp[] = [/\.expo[\\/]types/];
+
+/**
+ * expo `installGlobal.ts:96` 의 winter polyfill (TextEncoderStream/TextDecoderStream/
+ * Location) 이 Hermes 의 `configurable: false` spec global 위에 redefine 시도 →
+ * catch 후 무해 console.error. dev console 을 오염시키므로 silent swallow.
+ */
+export const WINTER_POLYFILL_WARNING_PATTERN =
+  '^Failed to set polyfill\\.\\s+\\w+\\s+is not configurable\\.?$';
+
+function resolveExpoModules(root: string): {
+  winter: string | undefined;
+  metroRuntime: string | undefined;
+} {
+  const winter =
+    tryResolve('expo/src/winter/index.ts', root) ??
+    tryResolve('expo/src/winter/index', root) ??
+    tryResolve('expo/build/winter/index.js', root) ??
+    undefined;
+
+  // expo-router 가 끌어오는 동일 인스턴스 보장 — top-level 패키지가 hoisted 된
+  // 경우 instance 가 갈라져 require chain 이 깨질 수 있어 expo-router 의 dirname
+  // 기준으로 resolve.
+  const expoRouterPkg = tryResolve('expo-router/package.json', root);
+  const metroRuntimeBase = expoRouterPkg ? dirname(expoRouterPkg) : root;
+  const metroRuntime = tryResolve('@expo/metro-runtime', metroRuntimeBase) ?? undefined;
+
+  return { winter, metroRuntime };
+}
+
+/**
+ * ZTS 의 Metro-shape config 가 가질 수 있는 영역 — withExpo 가 만지는 부분만
+ * 명시. caller 가 `defineConfig` 없이 plain object 로 export 하므로 `T extends`
+ * 형태로 generic 보존 — 추가 필드는 그대로 통과.
+ */
+export interface ZtsRnExpoConfig {
+  root?: string;
+  resolver?: {
+    assetExts?: string[];
+    blockList?: (RegExp | string)[];
+    [key: string]: unknown;
+  };
+  serializer?: {
+    prelude?: string[];
+    [key: string]: unknown;
+  };
+  server?: {
+    silentConsoleErrorPatterns?: string[];
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export function withExpo<T extends ZtsRnExpoConfig>(config: T): T {
+  const root = config.root ?? process.cwd();
+  const { winter, metroRuntime } = resolveExpoModules(root);
+
+  const expoModules: string[] = [];
+  if (winter) expoModules.push(winter);
+  if (metroRuntime) expoModules.push(metroRuntime);
+
+  const existingAssetExts = config.resolver?.assetExts ?? [];
+  const existingNormalized = new Set(existingAssetExts.map(normalizeExt));
+
+  return {
+    ...config,
+    resolver: {
+      ...config.resolver,
+      assetExts: [
+        ...existingAssetExts,
+        ...EXPO_ASSET_EXTS.filter((ext) => !existingNormalized.has(ext)),
+      ],
+      blockList: [...(config.resolver?.blockList ?? []), ...EXPO_BLOCK_LIST],
+    },
+    serializer: {
+      ...config.serializer,
+      prelude: [...(config.serializer?.prelude ?? []), ...expoModules],
+    },
+    server: {
+      ...config.server,
+      silentConsoleErrorPatterns: [
+        ...(config.server?.silentConsoleErrorPatterns ?? []),
+        WINTER_POLYFILL_WARNING_PATTERN,
+      ],
+    },
+  };
+}


### PR DESCRIPTION
## Summary

번개 → ZTS 이전(b0de40aa) 시 누락된 `withExpo()` 포팅 + `EXPO_ROUTER_APP_ROOT` 절대 경로 fix. expo-router 가 require.context 매치 0 으로 "Welcome to Expo" fallback 화면을 띄우는 사용자 보고 케이스 해결.

## 문제

사용자 스크린샷:
- 화면: "Welcome to Expo / Start by creating a file in the **app** directory."
- 토스트: "Failed to set polyfill. TextDecoderStream is not configurable."

원인 두 가지:

**(1) `EXPO_ROUTER_APP_ROOT` 가 상대 경로 `\"./app\"`** — `expo-router/_ctx.{ios,android,web}.js` 가 `node_modules/.bun/expo-router/...` 안에 있어 `require-context` 플러그인의 `resolve(dirname(importer), dir)` 가 `node_modules/expo-router/app/` (존재 안 함) 을 가리킴 → ctx 매치 0 → expo-router 가 fallback 화면 노출. 번개 `napi-build.ts:404` 에선 절대 경로로 전달하는데 ZTS 포팅 시 누락.

**(2) `withExpo()` 통째로 누락** — 번개 `packages/bungae/src/bundler/zts-bundler/withExpo.ts` 가 expo/winter + @expo/metro-runtime 부트스트랩, expo-specific assetExts/blockList, winter polyfill warning silent suppression 을 모두 처리. ZTS 에는 동등 기능 없음 → expo-router 정상 routing 의존성 누락.

## 수정

### `packages/react-native/src/preset.ts`
- `EXPO_ROUTER_APP_ROOT` 를 `JSON.stringify(resolve(projectRoot, 'app'))` 절대 경로로.
- `extra.silentConsoleErrorPatterns` 인터페이스 + `BuildOptions.silentConsoleErrorPatterns` 와이어 (Metro `server.silentConsoleErrorPatterns` 호환).

### 신규 `packages/react-native/src/withExpo.ts`
번개 `withExpo` 포팅. `withExpo({...})` 로 wrap 하면:
- `expo/winter` + `@expo/metro-runtime` 를 `serializer.prelude` 에 prepend
- `.heic` / `.avif` / `.db` assetExts 추가 (dedup)
- `.expo/types` blockList (generated d.ts 무시)
- `WINTER_POLYFILL_WARNING_PATTERN` 을 `server.silentConsoleErrorPatterns` 에 주입 → core prologue 의 console.error setter intercept 가 무해 warning 을 silent swallow

`detectExpo()` 도 export (zero-config auto-apply 용 — 본 PR 에서는 미사용).

### CLI 와이어업
- `packages/core/bin/rn-dev-input.mjs` — Metro-shape config → `RnBundleInput.extra` 평탄화 로직을 `buildRnBundleExtra(cfg, opts)` helper 로 추출. dev / prod 양쪽 공유 → 새 필드 추가 시 drift 방지.
- `packages/core/bin/zts.mjs:runRnBundle` — 기존엔 `watchFolders` / `sourceExts` 만 throughput. 이제 `buildRnBundleExtra` 사용으로 prod bundle 에도 withExpo 효과 (winter prelude / assetExts / silentConsoleErrorPatterns) 가 동일 적용.

### 예제 적용
- `examples/react-native-expo/zts.config.ts` 가 `withExpo({...})` 로 wrap.

### 코드 정리
- `rn-dev-input.mjs:67` 중첩 ternary `a ? false : b ? false : undefined` → `(a || b) ? false : undefined`.
- 변경 영역 verbose narrative 주석 trim (CLAUDE.md \"WHY only\" 정책).

## Test plan

- [x] `bun test packages/react-native/src/preset.test.ts packages/react-native/src/withExpo.test.ts` — 72/72 pass
- [x] `bun test packages/core/bin/zts.test.ts -t \"buildRnDevServerInput\"` — 29/29 pass
- [x] `bun test packages/core/bin/zts.test.ts -t \"bundle --platform=react-native\"` — 5/5 pass
- [x] 통합: `node packages/core/bin/zts.mjs --bundle index.js --platform=react-native --rn-platform=ios -o dist/main.ios.jsbundle`
  - require.context 매치: `app/(tabs)/explore.tsx`, `app/(tabs)/index.tsx`, `app/modal.tsx` (3 routes)
  - prologue 에 `/^Failed to set polyfill\\.\\s+\\w+\\s+is not configurable\\.?\$/` setter intercept emit
  - `expo/winter` (32 ref) + `@expo/metro-runtime` (polyfillObject 등 56 ref) 번들 포함
- [ ] iOS simulator 실측 — 사용자 환경 (Welcome to Expo 화면 → Tabs/Home 으로 변경 + winter toast 사라짐)

## Refs

- #2605 사용자 보고 (Welcome to Expo 화면)
- 번개 `withExpo`: `packages/bungae/src/bundler/zts-bundler/withExpo.ts`, `napi-build.ts:404`
- ZTS 이전 commit: b0de40aa

## Follow-up (별도 PR)

- `withExpo` 가 user 미지정 `assetExts` 의 경우 `DEFAULT_ASSET_EXTS` 와 머지하지 않는 이슈 (현재는 user 가 assetExts 명시해야 함).
- `RnBundleInput.extra` parameter sprawl (15+ 필드) — Metro shape 그대로 받는 리팩터.
- `EXPO_ROUTER_APP_ROOT` define 이 bare RN 도 받음 (무해 dead code 지만 leak).
- zero-config: `detectExpo()` 결과로 `withExpo()` 자동 적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)