### PR TITLE
feat(bundler): chunk 별 lazy sourcemap + SourceMapBuilder.moveToHeap helper (#2654 B2)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -222,9 +222,15 @@ pub const OutputFile = struct {
     exports: []const []const u8 = &.{},
     /// "chunk" (JS/TS 번들 결과) / "asset" (binary/text/file/dataurl 로더 output).
     kind: Kind = .chunk,
-    /// chunk 별 sourcemap JSON (V3). null 이면 sourcemap 미생성 혹은 asset output.
-    /// `EmitOptions.sourcemap.enable=true` + `kind == .chunk` 시 채워짐. allocator 소유 — deinit 에서 해제 (#2654).
+    /// chunk 별 eager sourcemap JSON (V3). null 이면 sourcemap 미생성 혹은
+    /// lazy 경로 혹은 asset output. allocator 소유 — deinit 에서 해제. `sourcemap_builder`
+    /// 와 상호 배타.
     sourcemap: ?[]const u8 = null,
+    /// chunk 별 lazy sourcemap builder. `EmitOptions.sourcemap.lazy=true` 일 때
+    /// JSON 을 emit 단계에서 생성하지 않고 builder 를 이관 — caller (NAPI getter
+    /// 등) 가 호출 시점에 generateJSON 수행. allocator 소유 — deinit 에서
+    /// destroy. `sourcemap` 과 상호 배타.
+    sourcemap_builder: ?*SourceMap.SourceMapBuilder = null,
 
     pub const Kind = enum { chunk, asset };
 
@@ -238,6 +244,7 @@ pub const OutputFile = struct {
         for (self.exports) |ex| allocator.free(ex);
         if (self.exports.len > 0) allocator.free(self.exports);
         if (self.sourcemap) |sm| allocator.free(sm);
+        if (self.sourcemap_builder) |sm| sm.destroy(allocator);
     }
 };
 
@@ -821,11 +828,8 @@ pub fn emitWithTreeShaking(
                         0, // endregion 도 없음
                     );
                     if (options.sourcemap.lazy) {
-                        const heap_sm = try allocator.create(SourceMap.SourceMapBuilder);
-                        heap_sm.* = mod_sm;
-                        heap_sm.fixSelfReferences();
+                        module_sm_builder = try mod_sm.moveToHeap(allocator);
                         mod_sm_moved = true;
-                        module_sm_builder = heap_sm;
                     } else {
                         module_map = try mod_sm.generateJSONOwned(mod_id);
                     }
@@ -1052,9 +1056,7 @@ pub fn emitWithTreeShaking(
     const output_slice = try output.toOwnedSlice(allocator);
     const module_codes_slice = if (dev_module_codes.items.len > 0) try dev_module_codes.toOwnedSlice(allocator) else null;
     const builder_to_return: ?*SourceMap.SourceMapBuilder = if (options.sourcemap.lazy and bundle_sm != null) blk: {
-        const heap_sm = try allocator.create(SourceMap.SourceMapBuilder);
-        heap_sm.* = bundle_sm.?;
-        heap_sm.fixSelfReferences();
+        const heap_sm = try bundle_sm.?.moveToHeap(allocator);
         bundle_sm_moved = true;
         break :blk heap_sm;
     } else null;

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -91,14 +91,18 @@ pub fn emitChunks(
         errdefer chunk_output.deinit(allocator);
 
         // chunk 별 sourcemap builder. eager 경로는 stack alloc 으로 zero-overhead.
-        // JSON 은 chunk 끝에서 생성 후 OutputFile.sourcemap 에 이관.
+        // lazy 경로는 chunk 끝에서 heap 으로 이관되어 OutputFile.sourcemap_builder
+        // 로 caller 에 전달 — 그때는 본 함수의 defer 가 deinit 을 skip 한다.
         var chunk_sm: ?SourceMap.SourceMapBuilder = if (options.sourcemap.enable) blk: {
             var sm = SourceMap.SourceMapBuilder.init(allocator);
             sm.source_root = options.sourcemap.source_root orelse "";
             sm.sources_content = options.sourcemap.sources_content;
             break :blk sm;
         } else null;
-        defer if (chunk_sm) |*sm| sm.deinit();
+        var chunk_sm_moved = false;
+        defer if (!chunk_sm_moved) {
+            if (chunk_sm) |*sm| sm.deinit();
+        };
 
         // RSC: 디렉티브가 파일 첫 문장이어야 React/Next가 인식.
         var hoisted_directives: std.ArrayList(u8) = .empty;
@@ -589,13 +593,23 @@ pub fn emitChunks(
             break :blk try names.toOwnedSlice(allocator);
         };
 
-        // sourcemap JSON 을 chunk 별로 생성. directive hoisting (위 insertSlice)
-        // 후의 줄 shift 는 의도적으로 보정 안 함 — 단일 번들 path 와 동일 동작.
-        const chunk_sourcemap: ?[]const u8 = if (chunk_sm) |*sm|
-            try sm.generateJSONOwned(filename)
-        else
-            null;
+        // sourcemap 결과: lazy 경로는 builder 자체를 OutputFile 에 이관 (caller 가
+        // 호출 시점에 generateJSON 수행). eager 는 즉시 JSON 생성. directive
+        // hoisting (위 insertSlice) 후의 줄 shift 는 의도적으로 보정 안 함 —
+        // 단일 번들 path 와 동일 동작.
+        var chunk_sourcemap: ?[]const u8 = null;
+        var chunk_sourcemap_builder: ?*SourceMap.SourceMapBuilder = null;
+        if (chunk_sm) |*sm| {
+            if (options.sourcemap.lazy) {
+                chunk_sourcemap_builder = try sm.moveToHeap(allocator);
+                chunk_sm_moved = true;
+            } else {
+                chunk_sourcemap = try sm.generateJSONOwned(filename);
+            }
+        }
+        // lazy/eager 가 mutually exclusive 라 두 errdefer 는 동시에 active 안 됨.
         errdefer if (chunk_sourcemap) |s| allocator.free(s);
+        errdefer if (chunk_sourcemap_builder) |b| b.destroy(allocator);
 
         try outputs.append(allocator, .{
             .path = filename,
@@ -603,6 +617,7 @@ pub fn emitChunks(
             .module_ids = module_ids,
             .exports = export_names,
             .sourcemap = chunk_sourcemap,
+            .sourcemap_builder = chunk_sourcemap_builder,
         });
     }
 

--- a/src/bundler/emitter_test.zig
+++ b/src/bundler/emitter_test.zig
@@ -549,6 +549,84 @@ test "emitChunks: 2 entries + shared module — 각 chunk 가 독립 sourcemap (
     }
 }
 
+test "emitChunks: sourcemap.lazy=true → builder 이관, JSON 은 caller 시점에 생성 (#2654)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "const x = 1;\nconst y = x + 2;");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    const dp = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dp);
+    const entry_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
+    defer std.testing.allocator.free(entry_path);
+
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, .{});
+    defer cg.deinit();
+
+    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, &.{ .sourcemap = .{ .enable = true, .lazy = true } }, null);
+    defer {
+        for (outputs) |o| {
+            o.deinit(std.testing.allocator);
+        }
+        std.testing.allocator.free(outputs);
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), outputs.len);
+    try std.testing.expect(outputs[0].sourcemap == null);
+    try std.testing.expect(outputs[0].sourcemap_builder != null);
+
+    // caller 가 호출 시점에 JSON 생성
+    const json = try outputs[0].sourcemap_builder.?.generateJSON(outputs[0].path);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"version\":3") != null);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"mappings\":") != null);
+}
+
+test "emitChunks: lazy 와 eager 의 JSON 은 바이트 동등 (#2654)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "const x = 1;\nconst y = x + 2;\nconsole.log(y);");
+
+    var dp_buf: [256]u8 = undefined;
+    const dp = try tmp.dir.realpath(".", &dp_buf);
+    var entry_buf: [512]u8 = undefined;
+    const entry_path = try std.fmt.bufPrint(&entry_buf, "{s}/index.ts", .{dp});
+
+    // eager
+    var result1 = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result1.graph.deinit();
+    defer result1.cache.deinit();
+    var cg1 = try chunk_mod.generateChunks(std.testing.allocator, &result1.graph, &.{entry_path}, .{});
+    defer cg1.deinit();
+    const eager_outputs = try emitter.emitChunks(std.testing.allocator, &result1.graph, &cg1, &.{ .sourcemap = .{ .enable = true } }, null);
+    defer {
+        for (eager_outputs) |o| o.deinit(std.testing.allocator);
+        std.testing.allocator.free(eager_outputs);
+    }
+
+    // lazy
+    var result2 = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result2.graph.deinit();
+    defer result2.cache.deinit();
+    var cg2 = try chunk_mod.generateChunks(std.testing.allocator, &result2.graph, &.{entry_path}, .{});
+    defer cg2.deinit();
+    const lazy_outputs = try emitter.emitChunks(std.testing.allocator, &result2.graph, &cg2, &.{ .sourcemap = .{ .enable = true, .lazy = true } }, null);
+    defer {
+        for (lazy_outputs) |o| o.deinit(std.testing.allocator);
+        std.testing.allocator.free(lazy_outputs);
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), eager_outputs.len);
+    try std.testing.expectEqual(@as(usize, 1), lazy_outputs.len);
+    try std.testing.expect(eager_outputs[0].sourcemap != null);
+    try std.testing.expect(lazy_outputs[0].sourcemap_builder != null);
+
+    const lazy_json = try lazy_outputs[0].sourcemap_builder.?.generateJSON(lazy_outputs[0].path);
+    try std.testing.expectEqualStrings(eager_outputs[0].sourcemap.?, lazy_json);
+}
+
 test "emitChunks: two entries with shared module — 3 OutputFiles" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/codegen/sourcemap.zig
+++ b/src/codegen/sourcemap.zig
@@ -189,6 +189,17 @@ pub const SourceMapBuilder = struct {
         allocator.destroy(self);
     }
 
+    /// stack/외부 builder 를 heap 으로 옮긴다 (얕은 복사 + self-ref pointer
+    /// 보정). 호출 후 원본 builder 는 drained — caller 는 그 deinit 을 skip
+    /// 해야 한다 (보통 `*_moved = true` flag 로). lazy sourcemap 경로의 다중
+    /// 호출 사이트 (단일 번들 / chunk / HMR per-module) 통합.
+    pub fn moveToHeap(self: *const SourceMapBuilder, allocator: std.mem.Allocator) !*SourceMapBuilder {
+        const heap_sm = try allocator.create(SourceMapBuilder);
+        heap_sm.* = self.*;
+        heap_sm.fixSelfReferences();
+        return heap_sm;
+    }
+
     /// UUID v4 문자열 (36 byte) 를 builder 내부 `debug_id_buf` 에 복사하고 `debug_id` 를
     /// 그 slice 로 설정. lazy 경로에서 builder 가 외부로 이관돼도 pointer 유효성 보장.
     pub fn setDebugId(self: *SourceMapBuilder, uuid: []const u8) void {


### PR DESCRIPTION
## 배경

#2654 단계 B2. 단계 B1 (#2655) 가 chunk 별 eager sourcemap 인프라를 깔았고, 본 PR 은 lazy 경로 (Issue #1727 Phase B 패턴) 를 chunk 에 적용한다. caller 가 모든 chunk 의 sourcemap 을 한 번에 필요로 하지 않는 경우 (NAPI 의 \`_processSourceMapRequest\` 처럼 요청 시점에 생성) cold emit 의 VLQ encoding 비용을 회피.

## 변경

### OutputFile.sourcemap_builder
- \`?*SourceMap.SourceMapBuilder\` 필드 추가
- \`sourcemap\` 과 상호 배타
- deinit 에서 destroy 호출

### emitChunks lazy 분기
- \`chunk_sm_moved\` flag 로 본 함수의 stack defer 가 deinit 을 skip
- \`options.sourcemap.lazy=true\` 시 builder 이관, false 시 \`generateJSONOwned\` (기존 동작)

### SourceMapBuilder.moveToHeap helper (DRY refactor)
3 호출 사이트가 동일한 4-step 패턴 (alloc + shallow copy + fixSelfReferences + flag) 을 가졌음:
- \`emitter.zig:1058\` — 단일 번들 lazy
- \`emitter.zig:828\` — HMR per-module lazy
- \`chunks.zig:602\` — chunk lazy (본 PR)

\`destroy()\` 와 대칭으로 \`moveToHeap(allocator) !*Self\` 추가 → 3 사이트 모두 1줄로 정리. \`fixSelfReferences\` 를 외부 caller 가 직접 부르는 의존성 제거 (encapsulation).

## 통합 테스트 (2개)
- \`sourcemap.lazy=true\` → OutputFile.sourcemap == null + sourcemap_builder != null + generateJSON 호출 시 valid V3
- lazy 와 eager 의 JSON 이 바이트 동등

## 영향

- code splitting + sourcemap 사용자가 lazy 옵션으로 cold emit 비용 회피 가능
- NAPI 측에서 chunk 별 sourcemap 을 lazy getter 로 노출 (B3 에서 wire-up)
- eager 동작은 그대로 (default)

## /simplify

3-agent 리뷰 후 fix:
- HIGH: \`SourceMapBuilder.moveToHeap\` helper 추출 (3 사이트 DRY)
- LOW: errdefer 안전성 주석 1줄 추가

후속 PR:
- B3: NAPI / CLI 의 disk emit 에서 OutputFile.sourcemap[_builder] 처리 + .js.map 파일 + sourceMappingURL 주석

## Test plan

- [x] zig build (Debug + ReleaseFast) 통과
- [x] zig build test 통과 (4689/4689 — 단계 A 의 5 + B1 의 3 + B2 의 2)
- [x] eager/lazy JSON 바이트 동등성 검증

Closes #2654

🤖 Generated with [Claude Code](https://claude.com/claude-code)