### PR TITLE
feat(bundler): chunk sourcemap 디스크 emit + sourceMappingURL 주석 + getSourceMapJSON helper (#2654 B3)

### DIFF
--- a/src/app/build.zig
+++ b/src/app/build.zig
@@ -182,6 +182,16 @@ pub fn buildApp(allocator: std.mem.Allocator, opts: AppBuildOptions) !usize {
             try writeOutput(allocator, outdir, out.path, out.contents);
             try addReserved(allocator, &reserved, &reserved_keys, out.path);
             output_count += 1;
+            // chunk 별 sourcemap — eager / lazy 두 분기 모두 OutputFile.getSourceMapJSON
+            // 로 통합 처리 (caller 소유 slice 반환, free 책임).
+            if (try out.getSourceMapJSON(allocator)) |sm| {
+                defer allocator.free(sm);
+                const map_path = try std.fmt.allocPrint(allocator, "{s}.map", .{out.path});
+                defer allocator.free(map_path);
+                try writeOutput(allocator, outdir, map_path, sm);
+                try addReserved(allocator, &reserved, &reserved_keys, map_path);
+                output_count += 1;
+            }
         }
     } else {
         try writeOutput(allocator, outdir, "bundle.js", result.output);

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -246,6 +246,15 @@ pub const OutputFile = struct {
         if (self.sourcemap) |sm| allocator.free(sm);
         if (self.sourcemap_builder) |sm| sm.destroy(allocator);
     }
+
+    /// eager (`sourcemap`) / lazy (`sourcemap_builder`) 두 분기의 sourcemap JSON
+    /// 을 caller 소유 slice 로 통합 반환. caller 가 free 책임. NAPI / CLI / dev
+    /// server 가 OutputFile 의 두 필드 분기를 각자 처리하지 않게 캡슐화.
+    pub fn getSourceMapJSON(self: OutputFile, allocator: std.mem.Allocator) !?[]const u8 {
+        if (self.sourcemap) |sm| return try allocator.dupe(u8, sm);
+        if (self.sourcemap_builder) |b| return try b.generateJSONOwned(self.path);
+        return null;
+    }
 };
 
 /// 번들 출력 결과. output + 소스맵.

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -597,10 +597,14 @@ pub fn emitChunks(
         // 호출 시점에 generateJSON 수행). eager 는 즉시 JSON 생성. directive
         // hoisting (위 insertSlice) 후의 줄 shift 는 의도적으로 보정 안 함 —
         // 단일 번들 path 와 동일 동작.
+        // mode=inline_ 은 base64 embed 가 contents 안에 들어가야 하므로 lazy 와
+        // 호환 안 됨 (lazy 면 emit 단계에 JSON 이 없어서 embed 불가). 이 조합은
+        // lazy 를 무시하고 eager 강제 — silent broken 회피.
+        const effective_lazy = options.sourcemap.lazy and options.sourcemap.mode != .inline_;
         var chunk_sourcemap: ?[]const u8 = null;
         var chunk_sourcemap_builder: ?*SourceMap.SourceMapBuilder = null;
         if (chunk_sm) |*sm| {
-            if (options.sourcemap.lazy) {
+            if (effective_lazy) {
                 chunk_sourcemap_builder = try sm.moveToHeap(allocator);
                 chunk_sm_moved = true;
             } else {
@@ -610,6 +614,38 @@ pub fn emitChunks(
         // lazy/eager 가 mutually exclusive 라 두 errdefer 는 동시에 active 안 됨.
         errdefer if (chunk_sourcemap) |s| allocator.free(s);
         errdefer if (chunk_sourcemap_builder) |b| b.destroy(allocator);
+
+        // sourceMappingURL 주석 — mode 별 분기 (단일 번들 emitter.zig 와 동일 정책).
+        // linked: `<basename>.map` 참조. external: 주석 없음. inline_: base64 embed.
+        // resolveContentHashes 가 contents 의 placeholder 를 hash 로 치환하므로
+        // 주석에 들어가는 filename 도 자동 치환됨.
+        if (options.sourcemap.enable) {
+            const map_basename = std.fs.path.basename(filename);
+            switch (options.sourcemap.mode) {
+                .linked => {
+                    try chunk_output.appendSlice(allocator, "//# sourceMappingURL=");
+                    try chunk_output.appendSlice(allocator, map_basename);
+                    try chunk_output.appendSlice(allocator, ".map\n");
+                },
+                .external => {},
+                .inline_ => {
+                    if (chunk_sourcemap) |json| {
+                        try chunk_output.appendSlice(allocator, "//# sourceMappingURL=data:application/json;base64,");
+                        const Encoder = std.base64.standard.Encoder;
+                        const encoded_len = Encoder.calcSize(json.len);
+                        const old_len = chunk_output.items.len;
+                        try chunk_output.resize(allocator, old_len + encoded_len);
+                        _ = Encoder.encode(chunk_output.items[old_len .. old_len + encoded_len], json);
+                        try chunk_output.append(allocator, '\n');
+                        // base64 embed 했으므로 외부 .map 미생성.
+                        allocator.free(json);
+                        chunk_sourcemap = null;
+                    }
+                    // lazy + inline 조합은 의미 충돌 — lazy 는 외부 fetch 가정.
+                    // 단일 번들 emitter 와 동일하게 lazy 시 inline 무시 (주석 없음).
+                },
+            }
+        }
 
         try outputs.append(allocator, .{
             .path = filename,
@@ -1133,6 +1169,15 @@ fn resolveContentHashes(
         const new_path = try replaceAllPlaceholders(allocator, out.path, infos, ph_total);
         allocator.free(out.path);
         out.path = new_path;
+
+        // sourcemap JSON 의 "file" 필드에 들어간 placeholder 도 치환. lazy 경로는
+        // builder 에 placeholder 없음 — caller 가 generateJSON 시점에 outputs.path
+        // (이미 치환된) 를 넘기면 됨.
+        if (out.sourcemap) |sm| {
+            const new_sm = try replaceAllPlaceholders(allocator, sm, infos, ph_total);
+            allocator.free(sm);
+            out.sourcemap = new_sm;
+        }
     }
 
     // 3단계: imports 메타 채우기 (rolldown `chunk.imports` 호환).

--- a/src/bundler/emitter_test.zig
+++ b/src/bundler/emitter_test.zig
@@ -584,6 +584,124 @@ test "emitChunks: sourcemap.lazy=true → builder 이관, JSON 은 caller 시점
     try std.testing.expect(std.mem.indexOf(u8, json, "\"mappings\":") != null);
 }
 
+test "emitChunks: sourcemap.mode=linked 시 contents 끝에 //# sourceMappingURL 주석 + .map basename (#2654)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "const x = 1;");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    const dp = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dp);
+    const entry_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
+    defer std.testing.allocator.free(entry_path);
+
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, .{});
+    defer cg.deinit();
+
+    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, &.{ .sourcemap = .{ .enable = true, .mode = .linked } }, null);
+    defer {
+        for (outputs) |o| o.deinit(std.testing.allocator);
+        std.testing.allocator.free(outputs);
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), outputs.len);
+    // contents 에 sourceMappingURL=index.js.map 주석 (basename only).
+    try std.testing.expect(std.mem.indexOf(u8, outputs[0].contents, "//# sourceMappingURL=index.js.map") != null);
+    try std.testing.expect(outputs[0].sourcemap != null);
+    // sourcemap JSON 의 "file" 필드도 placeholder 없이 final filename.
+    try std.testing.expect(std.mem.indexOf(u8, outputs[0].sourcemap.?, "\"file\":\"index.js\"") != null);
+}
+
+test "emitChunks: sourcemap.mode=external 시 .map 파일은 있지만 주석 없음 (#2654)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "const x = 1;");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    const dp = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dp);
+    const entry_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
+    defer std.testing.allocator.free(entry_path);
+
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, .{});
+    defer cg.deinit();
+
+    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, &.{ .sourcemap = .{ .enable = true, .mode = .external } }, null);
+    defer {
+        for (outputs) |o| o.deinit(std.testing.allocator);
+        std.testing.allocator.free(outputs);
+    }
+
+    try std.testing.expect(outputs[0].sourcemap != null);
+    try std.testing.expect(std.mem.indexOf(u8, outputs[0].contents, "sourceMappingURL") == null);
+}
+
+test "emitChunks: lazy + inline_ 조합 시 lazy 무시하고 eager 강제 (silent skip 회귀 방지, #2654)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "const x = 1;");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    const dp = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dp);
+    const entry_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
+    defer std.testing.allocator.free(entry_path);
+
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, .{});
+    defer cg.deinit();
+
+    // 사용자가 lazy=true + mode=inline_ 동시 요청 — inline 의 base64 embed 가 emit
+    // 단계에 JSON 을 필요로 하므로 lazy 무시하고 eager 강제. silent broken 회피.
+    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, &.{ .sourcemap = .{ .enable = true, .mode = .inline_, .lazy = true } }, null);
+    defer {
+        for (outputs) |o| o.deinit(std.testing.allocator);
+        std.testing.allocator.free(outputs);
+    }
+
+    // contents 에 base64 embed 가 정상 들어가야 함.
+    try std.testing.expect(std.mem.indexOf(u8, outputs[0].contents, "//# sourceMappingURL=data:application/json;base64,") != null);
+    // 외부 .map 미생성 + lazy builder 도 없음 (eager 로 처리 후 inline 분기가 free).
+    try std.testing.expect(outputs[0].sourcemap == null);
+    try std.testing.expect(outputs[0].sourcemap_builder == null);
+}
+
+test "emitChunks: sourcemap.mode=inline_ 시 contents 에 base64 embed + sourcemap 필드 null (#2654)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "const x = 1;");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    const dp = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dp);
+    const entry_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
+    defer std.testing.allocator.free(entry_path);
+
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, .{});
+    defer cg.deinit();
+
+    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, &.{ .sourcemap = .{ .enable = true, .mode = .inline_ } }, null);
+    defer {
+        for (outputs) |o| o.deinit(std.testing.allocator);
+        std.testing.allocator.free(outputs);
+    }
+
+    try std.testing.expect(std.mem.indexOf(u8, outputs[0].contents, "//# sourceMappingURL=data:application/json;base64,") != null);
+    // inline 은 외부 .map 파일 미생성.
+    try std.testing.expect(outputs[0].sourcemap == null);
+}
+
 test "emitChunks: lazy 와 eager 의 JSON 은 바이트 동등 (#2654)" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();


### PR DESCRIPTION
## 배경

#2654 단계 B3 — 마지막 단계. B1 (#2655) 가 chunk 별 sourcemap 인프라, B2 (#2657) 가 lazy 옵션을 깔았고, 본 PR 은 그 결과를 사용자가 실제 받도록 wire-up.

## 변경

### chunks.zig — sourceMappingURL 주석 + mode 별 분기
- chunk_output 끝에 \`//# sourceMappingURL\` 주석 부착
  - **linked (default)**: \`<basename>.map\` 참조
  - **external**: 주석 없음 (Sentry/CI 표준)
  - **inline_**: base64 embed (외부 .map 파일 미생성)
- resolveContentHashes 가 sourcemap JSON 안의 placeholder 도 치환 → "file" 필드의 hash 가 정확

### chunks.zig — lazy + inline_ 충돌 fix
사용자가 \`lazy=true\` + \`mode=inline_\` 동시 요청 시 silent broken 발생 (base64 embed 가 emit 단계 JSON 을 필요로 하는데 lazy 가 emit 미룸 → 주석 아예 없음). \`effective_lazy = lazy and mode != .inline_\` 로 inline 시 lazy 무시 강제.

### emitter.zig — OutputFile.getSourceMapJSON helper
\`sourcemap\` (eager) / \`sourcemap_builder\` (lazy) 두 분기를 caller 에 노출 안 하게 캡슐화. NAPI / CLI / dev server 모두 같은 helper 로 처리.

### app/build.zig — 디스크 emit
기존 단일 번들 path 와 동일 패턴으로 chunk outputs 의 sourcemap 도 \`.js.map\` 으로 디스크 write.

## 통합 테스트 (4개)
- linked / external / inline_ 모드별 contents + sourcemap 동작 검증
- lazy + inline_ 충돌 시 eager fallback 회귀 방지

## /simplify

3-agent 리뷰 후 fix:
- HIGH: lazy + inline_ silent broken 버그 — \`effective_lazy\` 가드 추가
- HIGH: \`OutputFile.getSourceMapJSON\` helper 추출 — caller 단순화

후속 PR 권장:
- 단일 번들 emitter.zig 와 chunks.zig 의 mode 분기 helper 통합 (DRY, 별도 scope)
- resolveContentHashes 의 sourcemap full-scan → \`file\` 필드만 직접 치환 (~6-10ms 절감 추정)

## Test plan

- [x] zig build (Debug + ReleaseFast) 통과
- [x] zig build test 통과 (4693/4693)
- [x] 새 통합 테스트 4개 모두 통과
- [x] 사용자 측 \`zts build --bundle --sourcemap\` (chunked) 시 \`.js.map\` 자동 생성 + DevTools 매핑 동작

Closes #2654

🤖 Generated with [Claude Code](https://claude.com/claude-code)