### PR TITLE
docs(site): 벤치마크 차트와 Mermaid 개선

### DIFF
--- a/documents/src/components/BenchmarkCharts.tsx
+++ b/documents/src/components/BenchmarkCharts.tsx
@@ -1,43 +1,48 @@
-import { useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import ReactEChartsCore from "echarts-for-react/lib/core";
 import * as echarts from "echarts/core";
 import { BarChart } from "echarts/charts";
-import {
-  TooltipComponent,
-  GridComponent,
-  LegendComponent,
-} from "echarts/components";
+import { TooltipComponent, GridComponent, LegendComponent } from "echarts/components";
 import { CanvasRenderer } from "echarts/renderers";
 
 import benchmarkData from "../data/benchmark-data.json";
 
-echarts.use([
-  BarChart,
-  TooltipComponent,
-  GridComponent,
-  LegendComponent,
-  CanvasRenderer,
-]);
+echarts.use([BarChart, TooltipComponent, GridComponent, LegendComponent, CanvasRenderer]);
 
-const TOOL_COLORS: Record<string, string> = {
+const SERIES_COLORS: Record<string, string> = {
   ZTS: "#f7a41d",
   esbuild: "#eab308",
   SWC: "#ef4444",
   Bun: "#a855f7",
-  oxc: "#f97316",
+  "oxc (node)": "#f97316",
+  Rolldown: "#14b8a6",
+  Rspack: "#f59e0b",
   rolldown: "#14b8a6",
   rspack: "#f59e0b",
   webpack: "#06b6d4",
+  "NAPI (.node)": "#22c55e",
+  "WASM (.wasm)": "#38bdf8",
+  "CLI (subprocess)": "#f97316",
+  simple: "#60a5fa",
+  expr: "#f472b6",
+  string: "#34d399",
+  object: "#fbbf24",
+  react: "#a78bfa",
 };
-
-const PIPELINE_COLORS = ["#60a5fa", "#f472b6", "#34d399", "#fbbf24", "#a78bfa"];
 
 type BenchEntry = {
   tool: string;
   scale: string;
-  avgMs: number;
-  minMs: number;
-  maxMs: number;
+  medianMs: number;
+  minMs?: number;
+  maxMs?: number;
+  p95Ms?: number;
+};
+
+type ChartDefinition = {
+  title: string;
+  description: string;
+  entries: BenchEntry[];
 };
 
 function useIsDark(): boolean {
@@ -59,47 +64,86 @@ function useIsDark(): boolean {
   return isDark;
 }
 
-function buildGroupedBarOption(
-  title: string,
-  entries: BenchEntry[],
-  isDark: boolean,
-) {
-  const scales = [...new Set(entries.map((e) => e.scale))];
-  const tools = [...new Set(entries.map((e) => e.tool))];
+function uniqueInOrder(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function formatMs(value: number): string {
+  if (!Number.isFinite(value)) return "-";
+  if (value === 0) return "0";
+  if (value < 1) {
+    const us = value * 1000;
+    return `${us >= 100 ? us.toFixed(0) : us.toFixed(1)}us`;
+  }
+  if (value < 10) return `${value.toFixed(2)}ms`;
+  if (value < 100) return `${value.toFixed(1)}ms`;
+  return `${value.toFixed(0)}ms`;
+}
+
+function chartHeight(entries: BenchEntry[]): number {
+  const scaleCount = uniqueInOrder(entries.map((entry) => entry.scale)).length;
+  const toolCount = uniqueInOrder(entries.map((entry) => entry.tool)).length;
+  return Math.max(320, 112 + scaleCount * Math.max(48, toolCount * 18));
+}
+
+function buildHorizontalBarOption(entries: BenchEntry[], isDark: boolean) {
+  const scales = uniqueInOrder(entries.map((entry) => entry.scale));
+  const tools = uniqueInOrder(entries.map((entry) => entry.tool));
 
   const textColor = isDark ? "#e5e7eb" : "#374151";
-  const axisLineColor = isDark ? "#4b5563" : "#d1d5db";
+  const axisLineColor = isDark ? "#57534e" : "#d6d3d1";
+  const gridLineColor = isDark ? "#2a2422" : "#e7e5e4";
 
   const series = tools.map((tool) => ({
     name: tool,
     type: "bar" as const,
-    barGap: "10%",
+    barMaxWidth: 14,
+    barGap: "16%",
     emphasis: { focus: "series" as const },
-    itemStyle: { color: TOOL_COLORS[tool] || "#888" },
+    itemStyle: {
+      color: SERIES_COLORS[tool] ?? "#78716c",
+      borderRadius: [0, 5, 5, 0],
+    },
+    label: {
+      show: true,
+      position: "right" as const,
+      color: textColor,
+      fontSize: 11,
+      formatter: ({ value }: { value: number | null }) =>
+        typeof value === "number" ? formatMs(value) : "",
+    },
     data: scales.map((scale) => {
-      const entry = entries.find((e) => e.tool === tool && e.scale === scale);
-      return entry ? entry.avgMs : 0;
+      const entry = entries.find((item) => item.tool === tool && item.scale === scale);
+      return entry ? Number(entry.medianMs.toFixed(4)) : null;
     }),
   }));
 
   return {
-    title: {
-      text: title,
-      left: "center",
-      textStyle: { color: textColor, fontSize: 16 },
-    },
+    animationDuration: 450,
     tooltip: {
       trigger: "axis" as const,
+      confine: true,
       axisPointer: { type: "shadow" as const },
-      formatter: (params: Array<{ seriesName: string; axisValue: string; value: number; marker: string }>) => {
-        let html = `<strong>${params[0].axisValue}</strong><br/>`;
-        for (const p of params) {
+      formatter: (
+        params: Array<{
+          seriesName: string;
+          axisValue: string;
+          value: number | null;
+          marker: string;
+        }>,
+      ) => {
+        let html = `<strong>${params[0]?.axisValue ?? ""}</strong><br/>`;
+        for (const param of params) {
+          if (typeof param.value !== "number") continue;
           const entry = entries.find(
-            (e) => e.tool === p.seriesName && e.scale === p.axisValue,
+            (item) => item.tool === param.seriesName && item.scale === param.axisValue,
           );
-          html += `${p.marker} ${p.seriesName}: <strong>${p.value}ms</strong>`;
-          if (entry) {
-            html += ` <span style="color:#999">(${entry.minMs}-${entry.maxMs}ms)</span>`;
+          html += `${param.marker} ${param.seriesName}: <strong>${formatMs(param.value)}</strong>`;
+          if (entry?.minMs !== undefined && entry.maxMs !== undefined) {
+            html += ` <span style="color:#8a8580">(${formatMs(entry.minMs)}-${formatMs(entry.maxMs)})</span>`;
+          }
+          if (entry?.p95Ms !== undefined) {
+            html += ` <span style="color:#8a8580">p95 ${formatMs(entry.p95Ms)}</span>`;
           }
           html += "<br/>";
         }
@@ -107,140 +151,113 @@ function buildGroupedBarOption(
       },
     },
     legend: {
-      top: 30,
-      textStyle: { color: textColor },
+      type: "scroll" as const,
+      top: 0,
+      left: 0,
+      right: 0,
+      itemWidth: 18,
+      itemHeight: 10,
+      textStyle: { color: textColor, fontSize: 12 },
     },
     grid: {
-      left: "3%",
-      right: "4%",
-      bottom: "3%",
-      top: 80,
-      containLabel: true,
+      left: 160,
+      right: 78,
+      bottom: 28,
+      top: 52,
+      containLabel: false,
     },
     xAxis: {
-      type: "category" as const,
-      data: scales,
-      axisLabel: { color: textColor, fontSize: 11 },
+      type: "value" as const,
+      name: "median wall time",
+      nameLocation: "middle" as const,
+      nameGap: 28,
+      nameTextStyle: { color: textColor, fontSize: 11 },
+      axisLabel: {
+        color: textColor,
+        formatter: (value: number) => formatMs(value),
+      },
       axisLine: { lineStyle: { color: axisLineColor } },
+      splitLine: { lineStyle: { color: gridLineColor } },
     },
     yAxis: {
-      type: "value" as const,
-      name: "ms",
-      nameTextStyle: { color: textColor },
-      axisLabel: { color: textColor },
+      type: "category" as const,
+      inverse: true,
+      data: scales,
+      axisLabel: {
+        color: textColor,
+        fontSize: 12,
+        width: 145,
+        overflow: "break" as const,
+      },
       axisLine: { lineStyle: { color: axisLineColor } },
-      splitLine: { lineStyle: { color: isDark ? "#374151" : "#e5e7eb" } },
+      axisTick: { show: false },
     },
     series,
   };
 }
 
-function buildPipelineOption(isDark: boolean) {
-  const { labels, data } = benchmarkData.results.pipeline;
-  const scaleKeys = Object.keys(data) as Array<keyof typeof data>;
+function ChartPanel({ chart, isDark }: { chart: ChartDefinition; isDark: boolean }) {
+  const option = useMemo(() => buildHorizontalBarOption(chart.entries, isDark), [chart.entries, isDark]);
 
-  const textColor = isDark ? "#e5e7eb" : "#374151";
-  const axisLineColor = isDark ? "#4b5563" : "#d1d5db";
-
-  const series = labels.map((label, i) => ({
-    name: label,
-    type: "bar" as const,
-    stack: "pipeline",
-    emphasis: { focus: "series" as const },
-    itemStyle: { color: PIPELINE_COLORS[i] },
-    data: scaleKeys.map((key) => data[key][i]),
-  }));
-
-  return {
-    title: {
-      text: "ZTS Pipeline Profile (us)",
-      left: "center",
-      textStyle: { color: textColor, fontSize: 16 },
-    },
-    tooltip: {
-      trigger: "axis" as const,
-      axisPointer: { type: "shadow" as const },
-      formatter: (params: Array<{ seriesName: string; value: number; marker: string; axisValue: string }>) => {
-        let html = `<strong>${params[0].axisValue}</strong><br/>`;
-        let total = 0;
-        for (const p of params) {
-          html += `${p.marker} ${p.seriesName}: <strong>${p.value}us</strong><br/>`;
-          total += p.value;
-        }
-        html += `<br/><strong>Total: ${total}us (${(total / 1000).toFixed(2)}ms)</strong>`;
-        return html;
-      },
-    },
-    legend: {
-      top: 30,
-      textStyle: { color: textColor },
-    },
-    grid: {
-      left: "3%",
-      right: "4%",
-      bottom: "3%",
-      top: 80,
-      containLabel: true,
-    },
-    xAxis: {
-      type: "category" as const,
-      data: scaleKeys,
-      axisLabel: { color: textColor },
-      axisLine: { lineStyle: { color: axisLineColor } },
-    },
-    yAxis: {
-      type: "value" as const,
-      name: "us",
-      nameTextStyle: { color: textColor },
-      axisLabel: { color: textColor },
-      axisLine: { lineStyle: { color: axisLineColor } },
-      splitLine: { lineStyle: { color: isDark ? "#374151" : "#e5e7eb" } },
-    },
-    series,
-  };
+  return (
+    <section className="not-content overflow-hidden rounded-lg border border-surface-200 bg-white shadow-sm dark:border-surface-800 dark:bg-surface-950/70">
+      <div className="border-b border-surface-200 px-4 py-3 dark:border-surface-800">
+        <h2 className="text-base font-semibold text-neutral-900 dark:text-neutral-100">{chart.title}</h2>
+        <p className="mt-1 text-sm leading-6 text-neutral-600 dark:text-neutral-400">{chart.description}</p>
+      </div>
+      <div className="overflow-x-auto px-2 py-4">
+        <ReactEChartsCore
+          echarts={echarts}
+          option={option}
+          style={{ height: chartHeight(chart.entries), minWidth: 720, width: "100%" }}
+          lazyUpdate
+        />
+      </div>
+    </section>
+  );
 }
 
 export default function BenchmarkCharts() {
   const isDark = useIsDark();
-
-  const transpileOption = buildGroupedBarOption(
-    "Transpile Performance",
-    benchmarkData.results.transpile,
-    isDark,
-  );
-
-  const bundleOption = buildGroupedBarOption(
-    "Bundle Performance",
-    benchmarkData.results.bundle,
-    isDark,
-  );
-
-  const pipelineOption = buildPipelineOption(isDark);
-
-  const chartStyle = { height: 400, width: "100%" };
+  const charts: ChartDefinition[] = [
+    {
+      title: "CLI Transpile",
+      description: "Single-file TypeScript transpilation through direct CLI binaries.",
+      entries: benchmarkData.results.transpileCli,
+    },
+    {
+      title: "CLI Bundle",
+      description: "Small to large deterministic module graphs through direct CLI binaries.",
+      entries: benchmarkData.results.bundleCli,
+    },
+    {
+      title: "NAPI vs WASM vs CLI",
+      description: "Public in-process bindings compared with subprocess CLI startup cost.",
+      entries: benchmarkData.results.napiWasmCli,
+    },
+    {
+      title: "Bundle Perf CI Matrix",
+      description: "Same-run CI-style wall time comparison for ZTS, Rolldown, and Rspack.",
+      entries: benchmarkData.results.bundlePerf,
+    },
+    {
+      title: "ZTS Pipeline Patterns",
+      description: "ZTS profile totals across generated simple, expression-heavy, string-heavy, object, and React-like sources.",
+      entries: benchmarkData.results.pipelineTotal,
+    },
+  ];
 
   return (
-    <div className="flex flex-col gap-8">
-      <ReactEChartsCore
-        echarts={echarts}
-        option={transpileOption}
-        style={chartStyle}
-        lazyUpdate
-      />
-      <ReactEChartsCore
-        echarts={echarts}
-        option={bundleOption}
-        style={chartStyle}
-        lazyUpdate
-      />
-      <ReactEChartsCore
-        echarts={echarts}
-        option={pipelineOption}
-        style={chartStyle}
-        lazyUpdate
-      />
+    <div className="not-content flex flex-col gap-5">
+      <div className="rounded-lg border border-surface-200 bg-white px-4 py-3 text-sm leading-6 text-neutral-700 shadow-sm dark:border-surface-800 dark:bg-surface-950/70 dark:text-neutral-300">
+        <strong className="text-neutral-900 dark:text-neutral-100">Measurement:</strong> {benchmarkData.platform}, {benchmarkData.date}.
+        CLI charts use median wall time. Lower is better.
+      </div>
+      {charts.map((chart) => (
+        <ChartPanel key={chart.title} chart={chart} isDark={isDark} />
+      ))}
       <p className="text-center text-sm text-neutral-500 dark:text-neutral-400">
-        Measured on {benchmarkData.platform} | {benchmarkData.date} | {benchmarkData.iterations} iterations avg
+        CLI iterations: {benchmarkData.runs.cli.iterations}. NAPI/WASM warmup: {benchmarkData.runs.napi.warmup}, iterations: {benchmarkData.runs.napi.iterations}. Bundle-perf warmup: {benchmarkData.runs.bundlePerf.warmup}, iterations: {benchmarkData.runs.bundlePerf.iterations}.
       </p>
     </div>
   );

--- a/documents/src/components/Mermaid.tsx
+++ b/documents/src/components/Mermaid.tsx
@@ -18,9 +18,32 @@ function loadMermaid(): Promise<MermaidApi> {
   mermaidPromise = import("mermaid").then(({ default: mermaid }) => {
     mermaid.initialize({
       startOnLoad: false,
-      theme: "default",
+      theme: "base",
       securityLevel: "loose",
       fontFamily: "var(--sl-font, sans-serif)",
+      themeVariables: {
+        primaryColor: "#fff7ed",
+        primaryBorderColor: "#f7a41d",
+        primaryTextColor: "#431407",
+        secondaryColor: "#ffedd5",
+        secondaryBorderColor: "#fb923c",
+        tertiaryColor: "#fafaf9",
+        tertiaryBorderColor: "#d6d3d1",
+        clusterBkg: "#1c1816",
+        clusterBorder: "#3a3432",
+        titleColor: "#f5f5f4",
+        edgeLabelBackground: "#141110",
+        lineColor: "#f7a41d",
+        fontSize: "15px",
+      },
+      flowchart: {
+        htmlLabels: true,
+        curve: "basis",
+        nodeSpacing: 44,
+        rankSpacing: 58,
+        padding: 28,
+        useMaxWidth: true,
+      },
     });
     return mermaid;
   });

--- a/documents/src/components/diagrams.ts
+++ b/documents/src/components/diagrams.ts
@@ -3,32 +3,42 @@
  * drift 차단. 노드 텍스트는 영어 위주 + 짧은 한글 keyword 만 (locale-neutral).
  */
 
-export const NAPI_ARCHITECTURE_CHART = `flowchart TD
-    UC["User Code<br/>Node / Bun / Vite"]
-    JS["<b>@zts/core JS layer</b><br/>transpile · build · watch<br/>defineConfig · vitePlugin"]
-    PD["Plugin Dispatcher<br/>onResolve · onLoad<br/>onTransform · lifecycle"]
-    NAPI["zts.node<br/>NAPI v8 addon"]
+export const NAPI_ARCHITECTURE_CHART = `flowchart TB
+    UC["User Code<br/>Node · Bun · Vite"]
+
+    subgraph JSLayer["JavaScript Surface"]
+        direction TB
+        API["Public API<br/>transpile · build · watch"]
+        Config["Config Layer<br/>defineConfig · vitePlugin"]
+        PD["Plugin Dispatcher<br/>resolve · load · transform"]
+        Config --> API
+        API <--> PD
+    end
+
+    NAPI["NAPI Bridge<br/>zts.node · JSON payload"]
 
     subgraph Native["Zig Native Engine"]
         direction TB
-        Lex["Lexer / Scanner"]
-        Parse["Parser<br/>TS · JSX · Flow · Decorators"]
-        Sem["Semantic Analyzer<br/>scope · symbol · references"]
-        Trans["Transformer<br/>type strip · JSX · downlevel"]
-        CG["Codegen"]
-        Bundle["Bundler<br/>resolver · graph"]
-        Link["Linker<br/>scope hoisting · imports"]
-        Shake["Tree Shaker<br/>statement · symbol · purity"]
-        Emit["Emitter<br/>chunk · sourcemap · assets"]
+        Frontend["Frontend<br/>scan · parse · semantic"]
+        Transform["Transform<br/>downlevel · minify · helpers"]
+        Bundle["Bundle<br/>resolver · graph · linker"]
+        Emit["Emit<br/>tree shake · chunks · sourcemaps"]
 
-        Lex --> Parse --> Sem --> Trans --> CG
-        Parse -.-> Bundle
-        Bundle --> Link --> Shake --> Emit
+        Frontend --> Transform --> Bundle --> Emit
     end
 
-    UC --> JS
-    JS <--> PD
-    JS --> NAPI
-    NAPI <--> Native
+    UC --> API
+    API --> NAPI
     PD -. "threadsafe callback" .-> NAPI
+    NAPI --> Frontend
+
+    classDef entry fill:#fff7ed,stroke:#f7a41d,color:#431407,stroke-width:1.4px;
+    classDef js fill:#ffedd5,stroke:#fb923c,color:#431407,stroke-width:1.2px;
+    classDef bridge fill:#f7a41d,stroke:#fed7aa,color:#1c1816,stroke-width:1.6px;
+    classDef native fill:#fafaf9,stroke:#d6d3d1,color:#1c1816,stroke-width:1.2px;
+
+    class UC entry;
+    class API,Config,PD js;
+    class NAPI bridge;
+    class Frontend,Transform,Bundle,Emit native;
 `;

--- a/documents/src/content/docs/en/reference/benchmarks.mdx
+++ b/documents/src/content/docs/en/reference/benchmarks.mdx
@@ -5,20 +5,30 @@ description: Performance comparison between ZTS and other tools
 
 import BenchmarkCharts from '../../../../components/BenchmarkCharts.tsx';
 
-ZTS compares transpile and bundle performance against esbuild, SWC, Bun, and related tools.
+ZTS compares transpile and bundle performance against esbuild, SWC, Bun, Rolldown, Rspack, and related tools.
 
 ## Environment
 
-- **Platform**: macOS Apple Silicon (M-series)
-- **Iterations**: average of 5 runs
-- **Method**: direct CLI execution, excluding npx overhead
+- **Platform**: `darwin arm64`
+- **Baseline date**: 2026-05-06
+- **CLI**: `bench.ts`, 5-run median, direct CLI binary execution without npx overhead
+- **NAPI / WASM / CLI**: `napi-bench.ts`, 3 warmups + 10-run median
+- **Bundle perf**: `bundle-perf.ts`, 5 warmups + 20-run median, CI-style same-run ZTS/Rolldown/Rspack comparison
+- **Pipeline**: `pipeline.ts`, 5-run median, profile total
+
+Lower values are faster. The number at the end of each bar is median wall time.
 
 <BenchmarkCharts client:only="react" />
 
 ## How to Run
 
-Benchmark script: `tests/benchmark/bench.ts`
-
 ```bash
-cd tests/benchmark && bun run bench.ts
+zig build -Doptimize=ReleaseFast
+zig build napi
+zig build wasm
+
+bun run tests/benchmark/bench.ts
+bun run tests/benchmark/napi-bench.ts
+bun run tests/benchmark/bundle-perf.ts --no-fail --output bundle-perf.json
+bun run tests/benchmark/pipeline.ts
 ```

--- a/documents/src/content/docs/reference/benchmarks.mdx
+++ b/documents/src/content/docs/reference/benchmarks.mdx
@@ -5,19 +5,30 @@ description: ZTS와 다른 도구들의 성능 비교
 
 import BenchmarkCharts from '../../../components/BenchmarkCharts.tsx';
 
-ZTS의 트랜스파일/번들 성능을 esbuild, SWC, Bun 등과 비교합니다.
+ZTS의 트랜스파일/번들 성능을 esbuild, SWC, Bun, Rolldown, Rspack 등과 비교합니다.
 
 ## 측정 환경
-- **Platform**: macOS Apple Silicon (M-series)
-- **반복 횟수**: 5회 평균
-- **방법**: CLI 바이너리 직접 실행 (npx 오버헤드 제거)
+
+- **Platform**: `darwin arm64`
+- **기준 일시**: 2026-05-06
+- **CLI**: `bench.ts` median 5회, 직접 CLI 바이너리 실행 (npx 오버헤드 제거)
+- **NAPI / WASM / CLI**: `napi-bench.ts` warmup 3회 + median 10회
+- **Bundle perf**: `bundle-perf.ts` warmup 5회 + median 20회, CI와 같은 ZTS/Rolldown/Rspack same-run 비교
+- **Pipeline**: `pipeline.ts` median 5회, profile total 기준
+
+차트는 낮을수록 빠른 값이며, 막대 끝 숫자는 median wall time입니다.
 
 <BenchmarkCharts client:only="react" />
 
 ## 측정 방법
 
-벤치마크 스크립트: `tests/benchmark/bench.ts`
-
 ```bash
-cd tests/benchmark && bun run bench.ts
+zig build -Doptimize=ReleaseFast
+zig build napi
+zig build wasm
+
+bun run tests/benchmark/bench.ts
+bun run tests/benchmark/napi-bench.ts
+bun run tests/benchmark/bundle-perf.ts --no-fail --output bundle-perf.json
+bun run tests/benchmark/pipeline.ts
 ```

--- a/documents/src/data/benchmark-data.json
+++ b/documents/src/data/benchmark-data.json
@@ -1,54 +1,110 @@
 {
-  "date": "2026-04-24",
+  "date": "2026-05-06",
   "platform": "darwin arm64",
-  "iterations": 5,
+  "runs": {
+    "cli": { "iterations": 5 },
+    "napi": { "warmup": 3, "iterations": 10 },
+    "bundlePerf": { "warmup": 5, "iterations": 20 },
+    "pipeline": { "iterations": 5 }
+  },
   "results": {
-    "transpile": [
-      { "tool": "ZTS", "scale": "small (100 lines)", "avgMs": 2, "minMs": 2, "maxMs": 2 },
-      { "tool": "esbuild", "scale": "small (100 lines)", "avgMs": 8, "minMs": 6, "maxMs": 11 },
-      { "tool": "Bun", "scale": "small (100 lines)", "avgMs": 6, "minMs": 6, "maxMs": 6 },
-      { "tool": "oxc", "scale": "small (100 lines)", "avgMs": 23, "minMs": 22, "maxMs": 26 },
-      { "tool": "SWC", "scale": "small (100 lines)", "avgMs": 57, "minMs": 56, "maxMs": 57 },
+    "transpileCli": [
+      { "tool": "ZTS", "scale": "small (100 lines)", "medianMs": 4.77, "minMs": 2.95, "maxMs": 8.19, "p95Ms": 7.9 },
+      { "tool": "esbuild", "scale": "small (100 lines)", "medianMs": 4.78, "minMs": 3.92, "maxMs": 5.18, "p95Ms": 5.11 },
+      { "tool": "Bun", "scale": "small (100 lines)", "medianMs": 3.71, "minMs": 3.63, "maxMs": 3.9, "p95Ms": 3.9 },
+      { "tool": "oxc (node)", "scale": "small (100 lines)", "medianMs": 16.3, "minMs": 16.1, "maxMs": 16.5, "p95Ms": 16.4 },
+      { "tool": "SWC", "scale": "small (100 lines)", "medianMs": 47.7, "minMs": 47.4, "maxMs": 47.8, "p95Ms": 47.8 },
 
-      { "tool": "ZTS", "scale": "medium (1K lines)", "avgMs": 3, "minMs": 3, "maxMs": 3 },
-      { "tool": "esbuild", "scale": "medium (1K lines)", "avgMs": 5, "minMs": 5, "maxMs": 5 },
-      { "tool": "Bun", "scale": "medium (1K lines)", "avgMs": 6, "minMs": 6, "maxMs": 7 },
-      { "tool": "oxc", "scale": "medium (1K lines)", "avgMs": 22, "minMs": 22, "maxMs": 23 },
-      { "tool": "SWC", "scale": "medium (1K lines)", "avgMs": 60, "minMs": 59, "maxMs": 61 },
+      { "tool": "ZTS", "scale": "medium (1K lines)", "medianMs": 2.3, "minMs": 2.29, "maxMs": 2.48, "p95Ms": 2.45 },
+      { "tool": "esbuild", "scale": "medium (1K lines)", "medianMs": 3.05, "minMs": 3.02, "maxMs": 3.12, "p95Ms": 3.12 },
+      { "tool": "Bun", "scale": "medium (1K lines)", "medianMs": 4.22, "minMs": 4.15, "maxMs": 4.29, "p95Ms": 4.28 },
+      { "tool": "oxc (node)", "scale": "medium (1K lines)", "medianMs": 16.4, "minMs": 16.3, "maxMs": 16.6, "p95Ms": 16.6 },
+      { "tool": "SWC", "scale": "medium (1K lines)", "medianMs": 55.2, "minMs": 50.6, "maxMs": 58.8, "p95Ms": 58.1 },
 
-      { "tool": "ZTS", "scale": "large (5K lines)", "avgMs": 7, "minMs": 6, "maxMs": 7 },
-      { "tool": "esbuild", "scale": "large (5K lines)", "avgMs": 5, "minMs": 5, "maxMs": 5 },
-      { "tool": "Bun", "scale": "large (5K lines)", "avgMs": 9, "minMs": 8, "maxMs": 9 },
-      { "tool": "oxc", "scale": "large (5K lines)", "avgMs": 23, "minMs": 22, "maxMs": 23 },
-      { "tool": "SWC", "scale": "large (5K lines)", "avgMs": 67, "minMs": 66, "maxMs": 68 }
+      { "tool": "ZTS", "scale": "large (5K lines)", "medianMs": 5.61, "minMs": 5.42, "maxMs": 5.63, "p95Ms": 5.62 },
+      { "tool": "esbuild", "scale": "large (5K lines)", "medianMs": 3.11, "minMs": 3.0, "maxMs": 3.28, "p95Ms": 3.26 },
+      { "tool": "Bun", "scale": "large (5K lines)", "medianMs": 5.99, "minMs": 5.86, "maxMs": 6.33, "p95Ms": 6.29 },
+      { "tool": "oxc (node)", "scale": "large (5K lines)", "medianMs": 16.6, "minMs": 16.4, "maxMs": 17.2, "p95Ms": 17.1 },
+      { "tool": "SWC", "scale": "large (5K lines)", "medianMs": 56.2, "minMs": 55.9, "maxMs": 56.4, "p95Ms": 56.3 }
     ],
-    "bundle": [
-      { "tool": "ZTS", "scale": "small (10 modules)", "avgMs": 3, "minMs": 3, "maxMs": 3 },
-      { "tool": "esbuild", "scale": "small (10 modules)", "avgMs": 12, "minMs": 11, "maxMs": 12 },
-      { "tool": "Bun", "scale": "small (10 modules)", "avgMs": 9, "minMs": 9, "maxMs": 9 },
-      { "tool": "rolldown", "scale": "small (10 modules)", "avgMs": 56, "minMs": 56, "maxMs": 57 },
-      { "tool": "rspack", "scale": "small (10 modules)", "avgMs": 60, "minMs": 60, "maxMs": 61 },
-      { "tool": "webpack", "scale": "small (10 modules)", "avgMs": 219, "minMs": 216, "maxMs": 226 },
+    "bundleCli": [
+      { "tool": "ZTS", "scale": "small (10 modules)", "medianMs": 2.56, "minMs": 2.4, "maxMs": 2.57, "p95Ms": 2.57 },
+      { "tool": "Bun", "scale": "small (10 modules)", "medianMs": 5.38, "minMs": 5.27, "maxMs": 5.44, "p95Ms": 5.43 },
+      { "tool": "esbuild", "scale": "small (10 modules)", "medianMs": 6.16, "minMs": 6.03, "maxMs": 6.32, "p95Ms": 6.31 },
+      { "tool": "rolldown", "scale": "small (10 modules)", "medianMs": 47.8, "minMs": 47.6, "maxMs": 49.1, "p95Ms": 49.0 },
+      { "tool": "rspack", "scale": "small (10 modules)", "medianMs": 51.6, "minMs": 51.0, "maxMs": 60.1, "p95Ms": 59.7 },
+      { "tool": "webpack", "scale": "small (10 modules)", "medianMs": 183, "minMs": 183, "maxMs": 184, "p95Ms": 184 },
 
-      { "tool": "ZTS", "scale": "medium (50 modules)", "avgMs": 4, "minMs": 4, "maxMs": 4 },
-      { "tool": "esbuild", "scale": "medium (50 modules)", "avgMs": 13, "minMs": 12, "maxMs": 13 },
-      { "tool": "Bun", "scale": "medium (50 modules)", "avgMs": 9, "minMs": 9, "maxMs": 10 },
-      { "tool": "rolldown", "scale": "medium (50 modules)", "avgMs": 59, "minMs": 57, "maxMs": 61 },
-      { "tool": "rspack", "scale": "medium (50 modules)", "avgMs": 63, "minMs": 62, "maxMs": 64 },
-      { "tool": "webpack", "scale": "medium (50 modules)", "avgMs": 218, "minMs": 217, "maxMs": 219 },
+      { "tool": "ZTS", "scale": "medium (50 modules)", "medianMs": 4.0, "minMs": 3.76, "maxMs": 4.05, "p95Ms": 4.04 },
+      { "tool": "Bun", "scale": "medium (50 modules)", "medianMs": 6.0, "minMs": 5.88, "maxMs": 6.18, "p95Ms": 6.15 },
+      { "tool": "esbuild", "scale": "medium (50 modules)", "medianMs": 7.0, "minMs": 6.9, "maxMs": 7.06, "p95Ms": 7.05 },
+      { "tool": "rolldown", "scale": "medium (50 modules)", "medianMs": 51.2, "minMs": 48.4, "maxMs": 52.3, "p95Ms": 52.2 },
+      { "tool": "rspack", "scale": "medium (50 modules)", "medianMs": 55.2, "minMs": 54.5, "maxMs": 55.9, "p95Ms": 55.8 },
+      { "tool": "webpack", "scale": "medium (50 modules)", "medianMs": 184, "minMs": 183, "maxMs": 185, "p95Ms": 184 },
 
-      { "tool": "ZTS", "scale": "large (200 modules)", "avgMs": 8, "minMs": 7, "maxMs": 8 },
-      { "tool": "esbuild", "scale": "large (200 modules)", "avgMs": 16, "minMs": 16, "maxMs": 16 },
-      { "tool": "Bun", "scale": "large (200 modules)", "avgMs": 12, "minMs": 12, "maxMs": 13 },
-      { "tool": "rolldown", "scale": "large (200 modules)", "avgMs": 62, "minMs": 61, "maxMs": 64 }
+      { "tool": "ZTS", "scale": "large (200 modules)", "medianMs": 8.12, "minMs": 7.96, "maxMs": 8.22, "p95Ms": 8.22 },
+      { "tool": "Bun", "scale": "large (200 modules)", "medianMs": 8.29, "minMs": 8.17, "maxMs": 8.45, "p95Ms": 8.43 },
+      { "tool": "esbuild", "scale": "large (200 modules)", "medianMs": 10.0, "minMs": 9.97, "maxMs": 10.2, "p95Ms": 10.2 },
+      { "tool": "rolldown", "scale": "large (200 modules)", "medianMs": 55.3, "minMs": 54.4, "maxMs": 56.1, "p95Ms": 56.1 }
     ],
-    "pipeline": {
-      "labels": ["Scanner", "Parser", "Semantic", "Transformer", "Codegen"],
-      "data": {
-        "1K lines": [8, 1491, 962, 450, 246],
-        "5K lines": [10, 7127, 4694, 2179, 1254],
-        "10K lines": [9, 14187, 9454, 4183, 2484]
-      }
-    }
+    "napiWasmCli": [
+      { "tool": "NAPI (.node)", "scale": "small (100 lines)", "medianMs": 0.335, "minMs": 0.324, "maxMs": 0.369, "p95Ms": 0.368 },
+      { "tool": "WASM (.wasm)", "scale": "small (100 lines)", "medianMs": 0.337, "minMs": 0.272, "maxMs": 1.143, "p95Ms": 0.972 },
+      { "tool": "CLI (subprocess)", "scale": "small (100 lines)", "medianMs": 3.368, "minMs": 3.19, "maxMs": 3.474, "p95Ms": 3.473 },
+
+      { "tool": "NAPI (.node)", "scale": "medium (1K lines)", "medianMs": 0.427, "minMs": 0.413, "maxMs": 0.447, "p95Ms": 0.445 },
+      { "tool": "WASM (.wasm)", "scale": "medium (1K lines)", "medianMs": 1.187, "minMs": 1.143, "maxMs": 2.327, "p95Ms": 2.006 },
+      { "tool": "CLI (subprocess)", "scale": "medium (1K lines)", "medianMs": 21.224, "minMs": 20.852, "maxMs": 22.102, "p95Ms": 22.029 },
+
+      { "tool": "NAPI (.node)", "scale": "large (5K lines)", "medianMs": 2.18, "minMs": 2.116, "maxMs": 2.28, "p95Ms": 2.242 },
+      { "tool": "WASM (.wasm)", "scale": "large (5K lines)", "medianMs": 5.312, "minMs": 5.029, "maxMs": 5.69, "p95Ms": 5.652 },
+      { "tool": "CLI (subprocess)", "scale": "large (5K lines)", "medianMs": 64.298, "minMs": 62.607, "maxMs": 78.121, "p95Ms": 74.239 },
+
+      { "tool": "NAPI (.node)", "scale": "xlarge (10K lines)", "medianMs": 4.332, "minMs": 4.314, "maxMs": 4.394, "p95Ms": 4.387 },
+      { "tool": "WASM (.wasm)", "scale": "xlarge (10K lines)", "medianMs": 9.453, "minMs": 9.17, "maxMs": 11.033, "p95Ms": 10.716 },
+      { "tool": "CLI (subprocess)", "scale": "xlarge (10K lines)", "medianMs": 65.941, "minMs": 64.56, "maxMs": 67.319, "p95Ms": 66.832 }
+    ],
+    "bundlePerf": [
+      { "tool": "ZTS", "scale": "small (10 modules, 0 ext)", "medianMs": 2.66 },
+      { "tool": "Rolldown", "scale": "small (10 modules, 0 ext)", "medianMs": 49.5 },
+      { "tool": "Rspack", "scale": "small (10 modules, 0 ext)", "medianMs": 53.1 },
+
+      { "tool": "ZTS", "scale": "medium (100 modules, 3 ext)", "medianMs": 5.96 },
+      { "tool": "Rolldown", "scale": "medium (100 modules, 3 ext)", "medianMs": 53.8 },
+      { "tool": "Rspack", "scale": "medium (100 modules, 3 ext)", "medianMs": 59.1 },
+
+      { "tool": "ZTS", "scale": "large (200 modules, 5 ext)", "medianMs": 9.12 },
+      { "tool": "Rolldown", "scale": "large (200 modules, 5 ext)", "medianMs": 56.3 },
+      { "tool": "Rspack", "scale": "large (200 modules, 5 ext)", "medianMs": 63.2 },
+
+      { "tool": "ZTS", "scale": "xlarge (1000 modules, 8 ext)", "medianMs": 35.5 },
+      { "tool": "Rolldown", "scale": "xlarge (1000 modules, 8 ext)", "medianMs": 76.6 },
+      { "tool": "Rspack", "scale": "xlarge (1000 modules, 8 ext)", "medianMs": 97.6 }
+    ],
+    "pipelineTotal": [
+      { "tool": "simple", "scale": "1K lines", "medianMs": 1.14 },
+      { "tool": "expr", "scale": "1K lines", "medianMs": 2.14 },
+      { "tool": "string", "scale": "1K lines", "medianMs": 0.507 },
+      { "tool": "object", "scale": "1K lines", "medianMs": 0.879 },
+      { "tool": "react", "scale": "1K lines", "medianMs": 1.55 },
+
+      { "tool": "simple", "scale": "5K lines", "medianMs": 4.72 },
+      { "tool": "expr", "scale": "5K lines", "medianMs": 11.0 },
+      { "tool": "string", "scale": "5K lines", "medianMs": 2.46 },
+      { "tool": "object", "scale": "5K lines", "medianMs": 4.26 },
+      { "tool": "react", "scale": "5K lines", "medianMs": 7.41 },
+
+      { "tool": "simple", "scale": "10K lines", "medianMs": 9.26 },
+      { "tool": "expr", "scale": "10K lines", "medianMs": 21.7 },
+      { "tool": "string", "scale": "10K lines", "medianMs": 4.85 },
+      { "tool": "object", "scale": "10K lines", "medianMs": 8.55 },
+      { "tool": "react", "scale": "10K lines", "medianMs": 14.9 },
+
+      { "tool": "simple", "scale": "50K lines", "medianMs": 47.5 },
+      { "tool": "expr", "scale": "50K lines", "medianMs": 111 },
+      { "tool": "string", "scale": "50K lines", "medianMs": 24.6 },
+      { "tool": "object", "scale": "50K lines", "medianMs": 44.0 },
+      { "tool": "react", "scale": "50K lines", "medianMs": 75.2 }
+    ]
   }
 }

--- a/documents/src/styles/custom.css
+++ b/documents/src/styles/custom.css
@@ -186,6 +186,46 @@ body {
   --sl-content-gap-y: 0;
 }
 
+.mermaid-diagram {
+  margin-block: 1.5rem;
+  overflow: visible;
+  padding: 1.25rem;
+  border: 1px solid rgba(247, 164, 29, 0.34);
+  border-radius: 0.75rem;
+  background:
+    radial-gradient(circle at 18% 8%, rgba(247, 164, 29, 0.22), transparent 28%),
+    linear-gradient(180deg, #24201d 0%, #141110 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 14px 32px rgba(0, 0, 0, 0.14);
+}
+
+.mermaid-diagram svg {
+  display: block;
+  width: 100%;
+  max-width: 760px !important;
+  height: auto;
+  margin-inline: auto;
+  overflow: visible;
+}
+
+.mermaid-diagram foreignObject {
+  overflow: visible;
+}
+
+.mermaid-diagram .node rect,
+.mermaid-diagram .node polygon,
+.mermaid-diagram .node path {
+  filter: drop-shadow(0 8px 18px rgba(0, 0, 0, 0.16));
+}
+
+@media (max-width: 768px) {
+  .mermaid-diagram {
+    margin-inline: -0.25rem;
+    padding: 0.9rem;
+  }
+}
+
 @media (max-width: 768px) {
   .playground-root .pg-config {
     position: absolute;

--- a/tests/benchmark/napi-bench.ts
+++ b/tests/benchmark/napi-bench.ts
@@ -13,6 +13,7 @@
 
 import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { computeMetricStats, formatMetric, type MetricStats } from './stats';
@@ -22,6 +23,7 @@ const WARMUP = 3;
 const ITERATIONS = 10;
 const IS_WINDOWS = process.platform === 'win32';
 const ZTS_BIN_NAME = IS_WINDOWS ? 'zts.exe' : 'zts';
+const WASM_WRAPPER_URL = pathToFileURL(resolve(ROOT, 'packages/wasm/index.ts')).href;
 
 // Windows 경로의 백슬래시는 템플릿 문자열에 그대로 삽입하면 이스케이프 시퀀스로
 // 해석돼 잘못된 경로가 됨. JSON.stringify로 감싸 literal string으로 안전하게 주입.
@@ -58,12 +60,11 @@ const NAPI_PATH = ${q(resolve(ROOT, 'zig-out/lib/zts.node'))};
 const native = require(NAPI_PATH);
 
 const source = readFileSync(${q(sourceFile)}, "utf8");
-const flags = (1 << 16) | (1 << 22);
 const WARMUP = ${WARMUP};
 const ITERATIONS = ${ITERATIONS};
 
 function run() {
-  native.transpile(source, "input.ts", flags, 0, "", "", "");
+  native.transpile(source, "input.ts", "{}");
 }
 
 for (let i = 0; i < WARMUP; i++) run();
@@ -86,47 +87,18 @@ console.log(JSON.stringify({ samplesUs: times }));
 import { readFileSync } from "node:fs";
 
 const WASM_PATH = ${q(resolve(ROOT, 'zig-out/bin/zts.wasm'))};
-const encoder = new TextEncoder();
+const WASM_WRAPPER_URL = ${q(WASM_WRAPPER_URL)};
+const { initSync, transpile } = await import(WASM_WRAPPER_URL);
 
 const wasmBytes = readFileSync(WASM_PATH);
-let memory;
-const imports = {
-  wasi_snapshot_preview1: {
-    fd_write(fd, iovs_ptr, iovs_len, nwritten_ptr) {
-      new DataView(memory.buffer).setUint32(nwritten_ptr, 0, true);
-      return 0;
-    },
-    fd_read: () => 8, fd_seek: () => 8, fd_pwrite: () => 8, fd_filestat_get: () => 8,
-    random_get(buf_ptr, buf_len) {
-      crypto.getRandomValues(new Uint8Array(memory.buffer, buf_ptr, buf_len));
-      return 0;
-    },
-  },
-};
-const mod = new WebAssembly.Module(wasmBytes);
-const instance = new WebAssembly.Instance(mod, imports);
-memory = instance.exports.memory;
-const w = instance.exports;
+initSync(wasmBytes);
 
 const source = readFileSync(${q(sourceFile)}, "utf8");
-const flags = (1 << 16) | (1 << 22);
 const WARMUP = ${WARMUP};
 const ITERATIONS = ${ITERATIONS};
 
 function run() {
-  const bytes = encoder.encode(source);
-  const srcPtr = w.alloc(bytes.length);
-  new Uint8Array(w.memory.buffer, srcPtr, bytes.length).set(bytes);
-  const fileBytes = encoder.encode("input.ts");
-  const filePtr = w.alloc(fileBytes.length);
-  new Uint8Array(w.memory.buffer, filePtr, fileBytes.length).set(fileBytes);
-  const packed = w.transpile(srcPtr, bytes.length, filePtr, fileBytes.length, flags, 0, 0, 0, 0, 0, 0, 0);
-  w.dealloc(srcPtr, bytes.length);
-  w.dealloc(filePtr, fileBytes.length);
-  const outPtr = Number(packed >> 32n);
-  const outLen = Number(packed & 0xffffffffn);
-  if (outPtr === 0) throw new Error("WASM failed");
-  w.dealloc(outPtr, outLen);
+  transpile(source, { filename: "input.ts" });
 }
 
 for (let i = 0; i < WARMUP; i++) run();


### PR DESCRIPTION
## 변경 사항

- 성능 벤치마크 페이지를 최신 `origin/main` 기반 2026-05-06 `darwin arm64` 재측정값으로 갱신했습니다.
  - `bench.ts`: CLI transpile/bundle 비교
  - `napi-bench.ts`: NAPI/WASM/CLI 비교
  - `bundle-perf.ts`: CI와 같은 ZTS/Rolldown/Rspack same-run 비교
  - `pipeline.ts`: ZTS pipeline pattern별 profile total
- Farm performance-compare 그래프처럼 가로 막대형 차트와 막대 끝 수치 라벨을 적용했습니다.
  - tooltip에는 min/max/p95를 같이 노출합니다.
  - 라이트/다크 테마 모두 대비가 맞도록 차트 패널 색을 조정했습니다.
- `napi-bench.ts`의 stale worker 경로를 현재 API에 맞게 고쳤습니다.
  - native NAPI 호출은 현재 options JSON payload를 사용합니다.
  - WASM 벤치는 raw export 직접 호출 대신 public `packages/wasm/index.ts` wrapper를 사용합니다.
- NAPI 아키텍처 Mermaid를 세로형 스타일 카드로 바꿔 본문 폭에서 글자가 잘리지 않도록 정리했습니다.

## 검증

- `zig build -Doptimize=ReleaseFast`
- `zig build napi`
- `zig build wasm`
- `bun run tests/benchmark/bench.ts`
- `bun run tests/benchmark/napi-bench.ts`
- `bun run tests/benchmark/bundle-perf.ts --no-fail --output /tmp/zts-doc-bundle-perf-mainbased.json`
- `bun run tests/benchmark/pipeline.ts`
- `bun run --cwd documents build`
- `git diff --check`
- Playwright screenshot 확인
  - `/reference/benchmarks/` canvas 렌더 확인
  - `/reference/napi/` Mermaid SVG 렌더 확인
- push 전 hook 통과: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`
  - `oxlint`는 기존 warning만 출력, error 0
