### PR TITLE
refactor(sourcemap): mode 분기 helper 통합 — appendSourceMappingURLComment (#2660)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1013,11 +1013,8 @@ pub fn emitWithTreeShaking(
         }
     }
 
-    // 소스맵 참조 추가 — mode 별 분기 (#2152):
-    //   linked   (default): `//# sourceMappingURL=<file>.map` 주석 + 외부 .map 파일.
-    //   external          : 주석 없음 + 외부 .map 파일 (Sentry/CI 표준, 위치 비공개).
-    //   inline_           : `//# sourceMappingURL=data:application/json;base64,...` 주석에 embed,
-    //                       외부 .map 파일 미생성.
+    // 소스맵 참조 추가 — mode 별 분기 (#2152). 실제 부착 정책은
+    // `SourceMap.appendSourceMappingURLComment` 가 통합 처리 (#2660).
     //
     // dev_mode 강제 linked: dev server 의 `/bundle.js.map` 라우트가 lazily serve (#1727).
     // - inline 이면 매 rebuild 마다 base64 인코딩 — HMR warm 100ms (#1747) 충돌.
@@ -1025,31 +1022,12 @@ pub fn emitWithTreeShaking(
     // 따라서 dev_mode 에서는 사용자 mode 무시. production 빌드에서만 mode 가 의미.
     if (options.sourcemap.enable) {
         const effective_mode = if (options.dev_mode) SourceMap.SourceMapMode.linked else options.sourcemap.mode;
-        switch (effective_mode) {
-            .linked => {
-                try output.appendSlice(allocator, "//# sourceMappingURL=");
-                if (options.dev_mode) try output.append(allocator, '/'); // dev 서버용 절대 경로
-                try output.appendSlice(allocator, options.output_filename);
-                try output.appendSlice(allocator, ".map\n");
-            },
-            .external => {
-                // 의도적 — 주석 없음.
-            },
-            .inline_ => {
-                if (sourcemap_json) |json| {
-                    try output.appendSlice(allocator, "//# sourceMappingURL=data:application/json;base64,");
-                    const Encoder = std.base64.standard.Encoder;
-                    const encoded_len = Encoder.calcSize(json.len);
-                    const old_len = output.items.len;
-                    try output.resize(allocator, old_len + encoded_len);
-                    _ = Encoder.encode(output.items[old_len .. old_len + encoded_len], json);
-                    try output.append(allocator, '\n');
-                    // 이미 base64 로 embed 했으므로 외부 .map 파일은 만들지 않음.
-                    allocator.free(json);
-                    sourcemap_json = null;
-                }
-            },
-        }
+        try SourceMap.appendSourceMappingURLComment(&output, allocator, .{
+            .mode = effective_mode,
+            .output_filename = options.output_filename,
+            .prefix_slash = options.dev_mode,
+            .inline_json = sourcemap_json,
+        }, &sourcemap_json);
     }
 
     // debugId 주석 추가 (sourceMappingURL 뒤)

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -615,36 +615,16 @@ pub fn emitChunks(
         errdefer if (chunk_sourcemap) |s| allocator.free(s);
         errdefer if (chunk_sourcemap_builder) |b| b.destroy(allocator);
 
-        // sourceMappingURL 주석 — mode 별 분기 (단일 번들 emitter.zig 와 동일 정책).
-        // linked: `<basename>.map` 참조. external: 주석 없음. inline_: base64 embed.
+        // sourceMappingURL 주석 — chunk 별 .map 파일 참조 / inline embed.
         // resolveContentHashes 가 contents 의 placeholder 를 hash 로 치환하므로
-        // 주석에 들어가는 filename 도 자동 치환됨.
+        // 주석에 들어가는 filename 도 자동 치환됨. 부착 정책은
+        // SourceMap.appendSourceMappingURLComment 가 통합 처리 (#2660).
         if (options.sourcemap.enable) {
-            const map_basename = std.fs.path.basename(filename);
-            switch (options.sourcemap.mode) {
-                .linked => {
-                    try chunk_output.appendSlice(allocator, "//# sourceMappingURL=");
-                    try chunk_output.appendSlice(allocator, map_basename);
-                    try chunk_output.appendSlice(allocator, ".map\n");
-                },
-                .external => {},
-                .inline_ => {
-                    if (chunk_sourcemap) |json| {
-                        try chunk_output.appendSlice(allocator, "//# sourceMappingURL=data:application/json;base64,");
-                        const Encoder = std.base64.standard.Encoder;
-                        const encoded_len = Encoder.calcSize(json.len);
-                        const old_len = chunk_output.items.len;
-                        try chunk_output.resize(allocator, old_len + encoded_len);
-                        _ = Encoder.encode(chunk_output.items[old_len .. old_len + encoded_len], json);
-                        try chunk_output.append(allocator, '\n');
-                        // base64 embed 했으므로 외부 .map 미생성.
-                        allocator.free(json);
-                        chunk_sourcemap = null;
-                    }
-                    // lazy + inline 조합은 의미 충돌 — lazy 는 외부 fetch 가정.
-                    // 단일 번들 emitter 와 동일하게 lazy 시 inline 무시 (주석 없음).
-                },
-            }
+            try SourceMap.appendSourceMappingURLComment(&chunk_output, allocator, .{
+                .mode = options.sourcemap.mode,
+                .output_filename = std.fs.path.basename(filename),
+                .inline_json = chunk_sourcemap,
+            }, &chunk_sourcemap);
         }
 
         try outputs.append(allocator, .{

--- a/src/codegen/sourcemap.zig
+++ b/src/codegen/sourcemap.zig
@@ -106,6 +106,66 @@ pub const SourceMapMode = enum {
     }
 };
 
+/// `appendSourceMappingURLComment` 의 입력. mode 별 conditional 인자를 struct
+/// 로 묶어 호출 사이트 명료성 + default 활용.
+pub const SourceMappingURLOptions = struct {
+    mode: SourceMapMode,
+    /// `linked` mode 에서 `<output_filename>.map` 형태로 부착되는 base 파일명.
+    /// helper 가 `.map` 확장자를 자동 추가하므로 caller 는 .map 빼고 전달.
+    /// `external` / `inline_` mode 에서는 무시.
+    output_filename: []const u8 = "",
+    /// `linked` mode 의 URL 앞에 `/` 를 부착해 dev server 절대 경로로 만든다.
+    /// 다른 mode 에서는 무시.
+    prefix_slash: bool = false,
+    /// `inline_` mode 에서 base64 embed 할 JSON. caller 소유 — helper 는 base64
+    /// encode 만 수행, free 는 `inline_json_slot` 가 담당. 다른 mode 에서는 무시.
+    inline_json: ?[]const u8 = null,
+};
+
+/// `//# sourceMappingURL=` 주석을 mode 별로 output 에 부착한다. emitter.zig
+/// (단일 번들) 와 chunks.zig 두 사이트가 동일한 분기 정책을 공유하도록 통합
+/// (#2660).
+///
+/// - `linked`: `//# sourceMappingURL=<output_filename>.map\n` (옵션의
+///   `prefix_slash` true 면 dev server 라우팅용 `/` prefix 부착)
+/// - `external`: 주석 없음
+/// - `inline_`: `options.inline_json` 의 base64 를 contents 에 embed. base64
+///   embed 후 `inline_json_slot.*` 을 `free` + `null` 로 갱신해 caller 의
+///   free 책임을 helper 가 인수. `inline_json_slot.*` 이 null 또는 mode 가
+///   inline_ 가 아니면 slot 갱신 안 함.
+///
+/// `options.inline_json` 과 `inline_json_slot` 은 보통 같은 변수의 값/포인터로
+/// caller 가 분리해서 넘긴다 (struct field 가 const 라서 분리 시그니처).
+pub fn appendSourceMappingURLComment(
+    output: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+    options: SourceMappingURLOptions,
+    inline_json_slot: *?[]const u8,
+) !void {
+    switch (options.mode) {
+        .linked => {
+            try output.appendSlice(allocator, "//# sourceMappingURL=");
+            if (options.prefix_slash) try output.append(allocator, '/');
+            try output.appendSlice(allocator, options.output_filename);
+            try output.appendSlice(allocator, ".map\n");
+        },
+        .external => {},
+        .inline_ => {
+            if (options.inline_json) |json| {
+                try output.appendSlice(allocator, "//# sourceMappingURL=data:application/json;base64,");
+                const Encoder = std.base64.standard.Encoder;
+                const encoded_len = Encoder.calcSize(json.len);
+                const old_len = output.items.len;
+                try output.resize(allocator, old_len + encoded_len);
+                _ = Encoder.encode(output.items[old_len .. old_len + encoded_len], json);
+                try output.append(allocator, '\n');
+                allocator.free(json);
+                inline_json_slot.* = null;
+            }
+        },
+    }
+}
+
 /// Bundler 레벨 sourcemap 옵션 묶음. `EmitOptions.sourcemap` / `BundleOptions.sourcemap`
 /// 양쪽에서 동일 구조체를 공유해 옵션 전파 중복을 제거한다. 단일-파일 경로
 /// (`codegen.zig`, `transpile.zig`) 는 별도 옵션 구조체가 있어 현재 범위 밖.

--- a/src/codegen/sourcemap_test.zig
+++ b/src/codegen/sourcemap_test.zig
@@ -69,3 +69,88 @@ test "SourceMapBuilder: multi-line mapping" {
     // 줄1 "AAAA" (0,0,0,0), 줄2 "AACA" (col=0, src=0, line=+1, col=0)
     try std.testing.expect(std.mem.indexOf(u8, json, "\"mappings\":\"AAAA;AACA\"") != null);
 }
+
+// ============================================================
+// appendSourceMappingURLComment (#2660)
+// ============================================================
+
+test "appendSourceMappingURLComment: linked → //# sourceMappingURL=<url>.map\\n" {
+    var output: std.ArrayList(u8) = .empty;
+    defer output.deinit(std.testing.allocator);
+    var slot: ?[]const u8 = null;
+    try sourcemap.appendSourceMappingURLComment(&output, std.testing.allocator, .{
+        .mode = .linked,
+        .output_filename = "bundle.js",
+    }, &slot);
+    try std.testing.expectEqualStrings("//# sourceMappingURL=bundle.js.map\n", output.items);
+}
+
+test "appendSourceMappingURLComment: linked + prefix_slash → //# sourceMappingURL=/<url>.map\\n" {
+    var output: std.ArrayList(u8) = .empty;
+    defer output.deinit(std.testing.allocator);
+    var slot: ?[]const u8 = null;
+    try sourcemap.appendSourceMappingURLComment(&output, std.testing.allocator, .{
+        .mode = .linked,
+        .output_filename = "bundle.js",
+        .prefix_slash = true,
+    }, &slot);
+    try std.testing.expectEqualStrings("//# sourceMappingURL=/bundle.js.map\n", output.items);
+}
+
+test "appendSourceMappingURLComment: external → 주석 없음" {
+    var output: std.ArrayList(u8) = .empty;
+    defer output.deinit(std.testing.allocator);
+    var slot: ?[]const u8 = null;
+    try sourcemap.appendSourceMappingURLComment(&output, std.testing.allocator, .{
+        .mode = .external,
+        .output_filename = "bundle.js",
+    }, &slot);
+    try std.testing.expectEqual(@as(usize, 0), output.items.len);
+}
+
+test "appendSourceMappingURLComment: inline_ → base64 embed + json consumed (slot null)" {
+    var output: std.ArrayList(u8) = .empty;
+    defer output.deinit(std.testing.allocator);
+    const json_owned = try std.testing.allocator.dupe(u8, "{\"version\":3}");
+    var slot: ?[]const u8 = json_owned;
+    try sourcemap.appendSourceMappingURLComment(&output, std.testing.allocator, .{
+        .mode = .inline_,
+        .inline_json = json_owned,
+    }, &slot);
+    // base64({"version":3}) = "eyJ2ZXJzaW9uIjozfQ=="
+    try std.testing.expectEqualStrings(
+        "//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozfQ==\n",
+        output.items,
+    );
+    // helper 가 json 을 consume + slot 갱신 — caller 의 free 책임 해제.
+    try std.testing.expect(slot == null);
+}
+
+test "appendSourceMappingURLComment: inline_ + null json → silent skip (lazy 시나리오)" {
+    var output: std.ArrayList(u8) = .empty;
+    defer output.deinit(std.testing.allocator);
+    var slot: ?[]const u8 = null;
+    try sourcemap.appendSourceMappingURLComment(&output, std.testing.allocator, .{
+        .mode = .inline_,
+    }, &slot);
+    // lazy 등으로 json 이 null 이면 noop — output 변동 없음.
+    try std.testing.expectEqual(@as(usize, 0), output.items.len);
+    try std.testing.expect(slot == null);
+}
+
+test "appendSourceMappingURLComment: inline_ + prefix_slash 는 무시됨 (linked-only 옵션)" {
+    var output: std.ArrayList(u8) = .empty;
+    defer output.deinit(std.testing.allocator);
+    const json_owned = try std.testing.allocator.dupe(u8, "{}");
+    var slot: ?[]const u8 = json_owned;
+    try sourcemap.appendSourceMappingURLComment(&output, std.testing.allocator, .{
+        .mode = .inline_,
+        .prefix_slash = true, // ignored
+        .inline_json = json_owned,
+    }, &slot);
+    try std.testing.expectEqualStrings(
+        "//# sourceMappingURL=data:application/json;base64,e30=\n",
+        output.items,
+    );
+    try std.testing.expect(slot == null);
+}


### PR DESCRIPTION
## 배경

#2651 epic 의 후속 cleanup. emitter.zig (단일 번들) 와 chunks.zig 의 sourcemap mode 별 \`//# sourceMappingURL\` 주석 부착 로직이 거의 1:1 복제. /simplify 에서 helper 추출 권장.

## 변경

### \`appendSourceMappingURLComment\` helper (sourcemap.zig)
- 위치: \`src/codegen/sourcemap.zig\` (SourceMapMode enum 옆)
- API:
  \`\`\`zig
  pub const SourceMappingURLOptions = struct {
      mode: SourceMapMode,
      output_filename: []const u8 = "",
      prefix_slash: bool = false,
      inline_json: ?[]const u8 = null,
  };
  pub fn appendSourceMappingURLComment(
      output: *std.ArrayList(u8),
      allocator: std.mem.Allocator,
      options: SourceMappingURLOptions,
      inline_json_slot: *?[]const u8,
  ) !void
  \`\`\`

### Caller 정리
- emitter.zig: dev_mode 시 \`prefix_slash=true\` (절대 경로 라우팅) — 33줄 → 7줄
- chunks.zig: \`output_filename=basename(filename)\` — 27줄 → 5줄

### Unit test 6개
- linked / linked+prefix / external / inline_+consume / inline_+null (lazy 시나리오) / inline_+prefix_slash 무시 (linked-only invariant)

## /simplify

3-agent 리뷰 후 fix:
- HIGH: \`inline_json: *?[]const u8\` ownership transfer 가 시그니처에 안 보이는 leak 위험 → struct + 별도 \`inline_json_slot\` 인자 분리로 명시
- MED: param sprawl (6 인자) → struct param 으로 묶음
- MED: stringly-typed \`map_url\` invariant 모호 → \`output_filename\` 으로 rename + doc 강화
- MED: prefix_slash dev_mode 누수 → struct field 의 default false 로 의미 분리

## 영향

- 기능 변경 없음 (refactor only)
- 두 사이트 mode 정책 단일화 — drift 위험 제거
- emit_ms 회귀 없음 (helper 호출 1회 overhead < 1us)

## Test plan

- [x] zig build (Debug + ReleaseFast) 통과
- [x] zig build test 통과 (4699/4699 — 기존 + 6 helper unit test)
- [x] 기존 mode 별 chunks 통합 테스트 (#2654) 가 회귀 검증
- [x] 기존 sourcemap.test.ts (RN) 회귀 검증

Closes #2660

🤖 Generated with [Claude Code](https://claude.com/claude-code)