### PR TITLE
perf(bundler): chunk sourcemap emit 을 hash 치환 후로 미뤄 file 필드 정확 (#2661)

### DIFF
--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -593,38 +593,25 @@ pub fn emitChunks(
             break :blk try names.toOwnedSlice(allocator);
         };
 
-        // sourcemap 결과: lazy 경로는 builder 자체를 OutputFile 에 이관 (caller 가
-        // 호출 시점에 generateJSON 수행). eager 는 즉시 JSON 생성. directive
-        // hoisting (위 insertSlice) 후의 줄 shift 는 의도적으로 보정 안 함 —
-        // 단일 번들 path 와 동일 동작.
-        // mode=inline_ 은 base64 embed 가 contents 안에 들어가야 하므로 lazy 와
-        // 호환 안 됨 (lazy 면 emit 단계에 JSON 이 없어서 embed 불가). 이 조합은
-        // lazy 를 무시하고 eager 강제 — silent broken 회피.
-        const effective_lazy = options.sourcemap.lazy and options.sourcemap.mode != .inline_;
-        var chunk_sourcemap: ?[]const u8 = null;
+        // sourcemap builder 를 heap 으로 보관. JSON generate 와 mode 분기
+        // (eager / lazy / inline_) 는 모두 finalizeChunkSourceMaps 가 hash 치환
+        // 후 단일 처리 — sourcemap "file" 필드가 placeholder 없이 정확 (#2661).
         var chunk_sourcemap_builder: ?*SourceMap.SourceMapBuilder = null;
         if (chunk_sm) |*sm| {
-            if (effective_lazy) {
-                chunk_sourcemap_builder = try sm.moveToHeap(allocator);
-                chunk_sm_moved = true;
-            } else {
-                chunk_sourcemap = try sm.generateJSONOwned(filename);
-            }
+            chunk_sourcemap_builder = try sm.moveToHeap(allocator);
+            chunk_sm_moved = true;
         }
-        // lazy/eager 가 mutually exclusive 라 두 errdefer 는 동시에 active 안 됨.
-        errdefer if (chunk_sourcemap) |s| allocator.free(s);
         errdefer if (chunk_sourcemap_builder) |b| b.destroy(allocator);
 
-        // sourceMappingURL 주석 — chunk 별 .map 파일 참조 / inline embed.
-        // resolveContentHashes 가 contents 의 placeholder 를 hash 로 치환하므로
-        // 주석에 들어가는 filename 도 자동 치환됨. 부착 정책은
-        // SourceMap.appendSourceMappingURLComment 가 통합 처리 (#2660).
-        if (options.sourcemap.enable) {
+        // sourceMappingURL 주석 (linked 만): placeholder filename 으로 부착해
+        // resolveContentHashes 가 final hash 로 치환. external 은 부착 안 함.
+        // inline_ 는 finalizeChunkSourceMaps 에서 base64 embed 와 함께 처리
+        // (base64 안 placeholder 가 못 치환되는 이슈 회피).
+        if (options.sourcemap.enable and options.sourcemap.mode == .linked) {
             try SourceMap.appendSourceMappingURLComment(&chunk_output, allocator, .{
-                .mode = options.sourcemap.mode,
+                .mode = .linked,
                 .output_filename = std.fs.path.basename(filename),
-                .inline_json = chunk_sourcemap,
-            }, &chunk_sourcemap);
+            }, null);
         }
 
         try outputs.append(allocator, .{
@@ -632,7 +619,6 @@ pub fn emitChunks(
             .contents = try chunk_output.toOwnedSlice(allocator),
             .module_ids = module_ids,
             .exports = export_names,
-            .sourcemap = chunk_sourcemap,
             .sourcemap_builder = chunk_sourcemap_builder,
         });
     }
@@ -641,6 +627,12 @@ pub fn emitChunks(
     // 각 청크의 content에서 placeholder를 찾아 content hash로 교체한다.
     // esbuild도 동일한 2패스 접근을 사용 (placeholder → content hash).
     try resolveContentHashes(allocator, outputs.items, sorted_indices, chunk_graph);
+
+    // sourcemap finalize: hash 치환 후 final filename 으로 builder generate.
+    // mode 별 분기 (lazy / eager / inline_) 는 finalize 안에서 처리.
+    if (options.sourcemap.enable) {
+        try finalizeChunkSourceMaps(allocator, outputs.items, options.sourcemap);
+    }
 
     return outputs.toOwnedSlice(allocator);
 }
@@ -1106,6 +1098,63 @@ fn rewriteImportCallToWrapper(
     return try std.mem.concat(allocator, u8, &.{ code[0..call_start], replacement, code[call_end..] });
 }
 
+/// hash 치환 후 chunk 별 sourcemap 마무리. chunk loop 는 모든 chunk 의
+/// builder 를 그대로 보관만 하고 mode 결정 (eager / lazy / inline_) 은 본
+/// 함수에 단일화:
+/// - lazy + (linked|external): builder 그대로 sourcemap_builder 유지 (caller 가
+///   호출 시점에 generateJSON)
+/// - eager + (linked|external): generateJSONOwned(out.path) → sourcemap, builder destroy
+/// - inline_: lazy 옵션 무시하고 항상 eager — generateJSONOwned(out.path) →
+///   base64 + contents 끝에 embed, sourcemap=null, builder destroy. base64 가
+///   contents 안에 들어가야 하므로 emit 단계 JSON 이 필수.
+///
+/// `out.path` 가 hash 치환 완료 상태라 sourcemap "file" 필드에 정확한
+/// final filename 이 들어가고, placeholder 치환 full-scan 불필요 (#2661).
+fn finalizeChunkSourceMaps(
+    allocator: std.mem.Allocator,
+    outputs: []OutputFile,
+    sm_options: SourceMap.SourceMapOptions,
+) !void {
+    for (outputs) |*out| {
+        const builder = out.sourcemap_builder orelse continue;
+
+        // inline_ 는 항상 eager 강제 (base64 가 contents 안에 들어가야 하므로
+        // emit 단계 JSON 필요).
+        const effective_lazy = sm_options.lazy and sm_options.mode != .inline_;
+        if (effective_lazy) continue;
+
+        const json = try builder.generateJSONOwned(out.path);
+        // builder 는 이제 사용 끝 — destroy.
+        builder.destroy(allocator);
+        out.sourcemap_builder = null;
+
+        switch (sm_options.mode) {
+            .linked, .external => {
+                // linked 의 sourceMappingURL 주석은 chunk loop 에서 contents 에
+                // 부착됨. external 은 주석 없음. 둘 다 sourcemap JSON 만 보관.
+                out.sourcemap = json;
+            },
+            .inline_ => {
+                // base64 embed → contents 끝에 sourceMappingURL=data: 주석 append.
+                // contents 는 owned slice 라 새 ArrayList 로 복사 후 helper 로
+                // base64 부착. helper 가 json 을 consume (free) — caller (이 함수)
+                // 의 free 책임 해제. slot 은 따로 추적 안 해도 됨 (json 변수
+                // 이후 미사용).
+                var buf: std.ArrayList(u8) = .empty;
+                errdefer buf.deinit(allocator);
+                try buf.appendSlice(allocator, out.contents);
+                try SourceMap.appendSourceMappingURLComment(&buf, allocator, .{
+                    .mode = .inline_,
+                    .inline_json = json,
+                }, null);
+                allocator.free(out.contents);
+                out.contents = try buf.toOwnedSlice(allocator);
+                out.sourcemap = null;
+            },
+        }
+    }
+}
+
 const PlaceholderInfo = struct {
     placeholder: [HASH_PLACEHOLDER_PREFIX.len + HASH_PLACEHOLDER_LEN]u8,
     real_hash: [HASH_PLACEHOLDER_LEN]u8,
@@ -1150,14 +1199,8 @@ fn resolveContentHashes(
         allocator.free(out.path);
         out.path = new_path;
 
-        // sourcemap JSON 의 "file" 필드에 들어간 placeholder 도 치환. lazy 경로는
-        // builder 에 placeholder 없음 — caller 가 generateJSON 시점에 outputs.path
-        // (이미 치환된) 를 넘기면 됨.
-        if (out.sourcemap) |sm| {
-            const new_sm = try replaceAllPlaceholders(allocator, sm, infos, ph_total);
-            allocator.free(sm);
-            out.sourcemap = new_sm;
-        }
+        // sourcemap 은 finalizeChunkSourceMaps 가 hash 치환 후 final filename 으로
+        // generate — 이 시점엔 builder 만 있고 generate 안 된 상태 (#2661).
     }
 
     // 3단계: imports 메타 채우기 (rolldown `chunk.imports` 호환).

--- a/src/bundler/emitter_test.zig
+++ b/src/bundler/emitter_test.zig
@@ -584,6 +584,53 @@ test "emitChunks: sourcemap.lazy=true → builder 이관, JSON 은 caller 시점
     try std.testing.expect(std.mem.indexOf(u8, json, "\"mappings\":") != null);
 }
 
+test "emitChunks: hash 들어간 chunk filename 의 sourcemap \"file\" 필드가 final hash 정확 (#2661)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "const x = 1;\nconsole.log(x);");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    const dp = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dp);
+    const entry_path = try std.fs.path.resolve(std.testing.allocator, &.{ dp, "index.ts" });
+    defer std.testing.allocator.free(entry_path);
+
+    var cg = try chunk_mod.generateChunks(std.testing.allocator, &result.graph, &.{entry_path}, .{});
+    defer cg.deinit();
+
+    const outputs = try emitter.emitChunks(std.testing.allocator, &result.graph, &cg, &.{
+        .entry_names = "[name]-[hash]",
+        .sourcemap = .{ .enable = true },
+    }, null);
+    defer {
+        for (outputs) |o| o.deinit(std.testing.allocator);
+        std.testing.allocator.free(outputs);
+    }
+
+    try std.testing.expectEqual(@as(usize, 1), outputs.len);
+    // path 가 "index-{hash}.js" — placeholder 가 final hash 로 치환된 형태.
+    try std.testing.expect(std.mem.startsWith(u8, outputs[0].path, "index-"));
+    try std.testing.expect(std.mem.endsWith(u8, outputs[0].path, ".js"));
+
+    // sourcemap JSON 의 "file" 필드가 outputs[0].path 와 정확히 일치해야 한다.
+    // #2661 이전: chunk loop 단계의 generateJSON 이 placeholder filename 을
+    // 박아넣음 → resolveContentHashes 의 sourcemap full-scan 으로 사후 치환.
+    // #2661 이후: generateJSON 호출 자체를 hash 치환 후로 미뤄 placeholder 미들어감.
+    try std.testing.expect(outputs[0].sourcemap != null);
+    const expected_file = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "\"file\":\"{s}\"",
+        .{outputs[0].path},
+    );
+    defer std.testing.allocator.free(expected_file);
+    try std.testing.expect(std.mem.indexOf(u8, outputs[0].sourcemap.?, expected_file) != null);
+    // placeholder marker (\x00ZH<hex>) 가 sourcemap 안에 절대 없어야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, outputs[0].sourcemap.?, "\x00ZH") == null);
+}
+
 test "emitChunks: sourcemap.mode=linked 시 contents 끝에 //# sourceMappingURL 주석 + .map basename (#2654)" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/codegen/sourcemap.zig
+++ b/src/codegen/sourcemap.zig
@@ -131,16 +131,17 @@ pub const SourceMappingURLOptions = struct {
 /// - `external`: 주석 없음
 /// - `inline_`: `options.inline_json` 의 base64 를 contents 에 embed. base64
 ///   embed 후 `inline_json_slot.*` 을 `free` + `null` 로 갱신해 caller 의
-///   free 책임을 helper 가 인수. `inline_json_slot.*` 이 null 또는 mode 가
-///   inline_ 가 아니면 slot 갱신 안 함.
+///   free 책임을 helper 가 인수. `inline_json_slot` 이 null 이면 (linked /
+///   external 호출 등) slot 갱신은 skip.
 ///
-/// `options.inline_json` 과 `inline_json_slot` 은 보통 같은 변수의 값/포인터로
-/// caller 가 분리해서 넘긴다 (struct field 가 const 라서 분리 시그니처).
+/// `inline_json_slot` 은 inline_ 호출자가 owned slice 의 slot pointer 를 넘겨
+/// helper 가 free + null 로 ownership 이전. linked / external 만 사용하는
+/// caller 는 null 전달 가능.
 pub fn appendSourceMappingURLComment(
     output: *std.ArrayList(u8),
     allocator: std.mem.Allocator,
     options: SourceMappingURLOptions,
-    inline_json_slot: *?[]const u8,
+    inline_json_slot: ?*?[]const u8,
 ) !void {
     switch (options.mode) {
         .linked => {
@@ -160,7 +161,7 @@ pub fn appendSourceMappingURLComment(
                 _ = Encoder.encode(output.items[old_len .. old_len + encoded_len], json);
                 try output.append(allocator, '\n');
                 allocator.free(json);
-                inline_json_slot.* = null;
+                if (inline_json_slot) |slot| slot.* = null;
             }
         },
     }


### PR DESCRIPTION
## 배경

#2651 epic 의 두 번째 후속. /simplify 가 발견한 perf 이슈 + 잠재 버그.

**기존**: chunk loop 안에서 \`generateJSONOwned\` 가 placeholder filename 으로 sourcemap JSON 을 즉시 생성. \`resolveContentHashes\` 가 모든 chunk 의 sourcemap (수십~수백 KB) 을 \`replaceAllPlaceholders\` 로 full-scan 해 사후 치환.

**문제**:
- 100 chunks × 200KB sourcemap = 20MB 추가 스캔 → ~6-10ms cold emit 비용
- \`inline_\` mode: base64 안 placeholder 는 못 치환 (silent broken — file 필드가 잘못된 placeholder hash 를 가리킴)

## 해결

### chunks.zig
- chunk loop 는 \`SourceMapBuilder\` 만 보관 (eager/lazy 분기 제거 — finalize 가 결정)
- \`resolveContentHashes\` 의 sourcemap full-scan 제거
- 새 \`finalizeChunkSourceMaps\` phase: hash 치환 후 final filename 으로 \`generateJSONOwned\` 호출. mode 별 분기 단일 처리:
  - **lazy + (linked|external)**: builder 그대로 \`sourcemap_builder\` 유지
  - **eager + (linked|external)**: \`generateJSONOwned(out.path)\` → \`sourcemap\`, builder destroy
  - **inline_**: lazy 옵션 무시 + 항상 eager → \`generateJSONOwned\` 후 base64 + contents 끝에 embed

### sourcemap.zig
- \`appendSourceMappingURLComment\` 의 \`inline_json_slot\` 을 optional (\`?*?[]const u8\`) 로 변경 → linked/external 만 사용하는 caller 가 null 전달 가능
- chunk loop 의 linked 부착도 helper 사용 (일관성)

## Trade-off

- chunk 당 추가 alloc: 모든 chunk 가 \`SourceMapBuilder.moveToHeap\` 으로 stack→heap. 단 \`replaceAllPlaceholders\` full-scan 절감 (~6-10ms / 100 chunks × 200KB) 이 더 큼
- inline_ + chunks 의 base64 정확성 동시 fix

## /simplify

3-agent 리뷰 후 fix:
- HIGH: chunk loop linked 부착이 helper 안 씀 → \`appendSourceMappingURLComment\` 의 slot 인자를 optional 로 만들어 helper 사용 일관성 회복
- MED: chunk loop 주석에서 lazy 결정 위치 모호함 명확화 (모든 분기는 finalize 단일 처리)
- MED: \`finalizeChunkSourceMaps\` docstring 의 lazy+inline 설명 오타 수정

후속 (별도 PR 권장, 본 PR scope 외):
- inline_ 분기의 contents 전체 복제 (\`appendSlice + toOwnedSlice\`) → \`ArrayList.fromOwnedSlice\` 등으로 zero-copy 가능. 단 inline_ + chunks 가 드문 조합

## 회귀 방지 테스트

- hash 들어간 chunk filename 의 sourcemap \`"file"\` 필드가 final hash 와 정확 일치
- placeholder marker (\`\\x00ZH\`) 가 sourcemap 안에 **절대 없음** (#2661 핵심 invariant)

## Test plan

- [x] zig build (Debug + ReleaseFast) 통과
- [x] zig build test 통과 (4700/4700)
- [x] 기존 sourcemap 통합 테스트 18개 모두 통과 (114 expect)
- [x] inline_ + multi-chunk 의 base64 정확성 검증 (기존 inline_ test)

Closes #2661

🤖 Generated with [Claude Code](https://claude.com/claude-code)