### PR TITLE
ci: 병렬화와 stale run 대기 줄이기

### DIFF
--- a/.github/actions/setup-zts/action.yml
+++ b/.github/actions/setup-zts/action.yml
@@ -1,6 +1,20 @@
 name: Setup ZTS
 description: Install Zig/Bun, build ZTS, and install dependencies
 
+inputs:
+  napi:
+    description: Build and sanity-check the NAPI wrapper.
+    required: false
+    default: "true"
+  install:
+    description: Install workspace dependencies after building ZTS.
+    required: false
+    default: "true"
+  cpu:
+    description: Optional Zig CPU feature set for portable CI artifacts.
+    required: false
+    default: ""
+
 runs:
   using: composite
   steps:
@@ -15,18 +29,31 @@ runs:
         bun-version: "1.3.11"
 
     - name: Build ZTS (ReleaseFast)
-      run: zig build -Doptimize=ReleaseFast
+      run: |
+        build_args=(-Doptimize=ReleaseFast)
+        if [ -n "${{ inputs.cpu }}" ]; then
+          build_args+=("-Dcpu=${{ inputs.cpu }}")
+        fi
+        zig build "${build_args[@]}"
       shell: bash
 
     - name: Build NAPI module
-      run: zig build napi
+      if: ${{ inputs.napi == 'true' }}
+      run: |
+        napi_args=()
+        if [ -n "${{ inputs.cpu }}" ]; then
+          napi_args+=("-Dcpu=${{ inputs.cpu }}")
+        fi
+        zig build napi "${napi_args[@]}"
       shell: bash
 
     - name: Build core JS wrapper
+      if: ${{ inputs.napi == 'true' }}
       run: bun run --cwd packages/core build:js
       shell: bash
 
     - name: Verify JS wrapper uses fresh NAPI
+      if: ${{ inputs.napi == 'true' }}
       run: |
         bun - <<'EOF'
         import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
@@ -56,6 +83,16 @@ runs:
         EOF
       shell: bash
 
+    - name: Cache Bun packages
+      if: ${{ inputs.install == 'true' }}
+      uses: actions/cache@v4
+      with:
+        path: ~/.bun/install/cache
+        key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock', 'tests/benchmark/bun.lock', 'tests/integration/fixtures/emotion-v10/bun.lock', 'package.json', 'tests/integration/package.json', 'tests/benchmark/package.json') }}
+        restore-keys: |
+          ${{ runner.os }}-bun-
+
     - name: Install dependencies
+      if: ${{ inputs.install == 'true' }}
       run: bun install
       shell: bash

--- a/.github/actions/use-zts-artifact/action.yml
+++ b/.github/actions/use-zts-artifact/action.yml
@@ -1,0 +1,62 @@
+name: Use ZTS Artifact
+description: Install Bun and restore prebuilt ZTS artifacts for CI jobs.
+
+inputs:
+  artifact-name:
+    description: Name of the uploaded ZTS build artifact.
+    required: true
+  bun-version:
+    description: Bun version to install.
+    required: false
+    default: "1.3.11"
+  napi:
+    description: Verify that the artifact includes NAPI and core JS wrapper outputs.
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: ${{ inputs.bun-version }}
+
+    - name: Cache Bun packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.bun/install/cache
+        key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock', 'tests/benchmark/bun.lock', 'tests/integration/fixtures/emotion-v10/bun.lock', 'package.json', 'tests/integration/package.json', 'tests/benchmark/package.json') }}
+        restore-keys: |
+          ${{ runner.os }}-bun-
+
+    - name: Download ZTS build artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: .
+
+    - name: Normalize CLI artifact layout
+      run: |
+        if [ ! -e zig-out/bin/zts ] && [ -e zts ]; then
+          mkdir -p zig-out/bin
+          mv zts zig-out/bin/zts
+        fi
+      shell: bash
+
+    - name: Restore executable bit
+      if: ${{ runner.os != 'Windows' }}
+      run: chmod +x zig-out/bin/zts
+      shell: bash
+
+    - name: Verify ZTS artifact
+      run: |
+        test -x zig-out/bin/zts
+      shell: bash
+
+    - name: Verify NAPI artifact
+      if: ${{ inputs.napi == 'true' }}
+      run: |
+        test -f zig-out/lib/zts.node
+        test -f packages/core/dist/index.js
+      shell: bash

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,6 +8,10 @@ on:
       - 'tests/benchmark/**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write
 
@@ -34,6 +38,14 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      - name: Cache Bun packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock', 'tests/benchmark/bun.lock', 'tests/integration/fixtures/emotion-v10/bun.lock', 'package.json', 'tests/integration/package.json', 'tests/benchmark/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
 
       - name: Build ZTS (ReleaseFast)
         run: zig build -Doptimize=ReleaseFast

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,47 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
-    name: Build & Test
+  debug-test:
+    name: Debug Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Build (Debug)
+        run: zig build
+
+      - name: Run Tests
+        run: zig build test
+
+      - name: Run Test262 Runner Tests
+        run: zig build test262
+
+  release-build:
+    name: Release Build (${{ matrix.os }}, ${{ matrix.optimize }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        optimize: [ReleaseSafe, ReleaseFast, ReleaseSmall]
 
     steps:
       - name: Checkout
@@ -29,26 +62,8 @@ jobs:
       # Windows GitHub runner (7GB RAM) 는 Debug LLVM 메모리 상한에 걸림
       # ("LLVM ERROR: out of memory"). Debug 빌드·테스트 커버리지는 Linux/macOS
       # 에서 유지하고, Windows 에서는 Release 빌드만 검증한다.
-      - name: Build (Debug)
-        if: runner.os != 'Windows'
-        run: zig build
-
-      - name: Run Tests
-        if: runner.os != 'Windows'
-        run: zig build test
-
-      - name: Run Test262 Runner Tests
-        if: runner.os != 'Windows'
-        run: zig build test262
-
-      - name: Build (ReleaseSafe)
-        run: zig build -Doptimize=ReleaseSafe
-
-      - name: Build (ReleaseFast)
-        run: zig build -Doptimize=ReleaseFast
-
-      - name: Build (ReleaseSmall)
-        run: zig build -Doptimize=ReleaseSmall
+      - name: Build (${{ matrix.optimize }})
+        run: zig build -Doptimize=${{ matrix.optimize }}
 
   lint:
     name: Lint
@@ -102,6 +117,14 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      - name: Cache Bun packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock', 'tests/benchmark/bun.lock', 'tests/integration/fixtures/emotion-v10/bun.lock', 'package.json', 'tests/integration/package.json', 'tests/benchmark/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -169,6 +192,14 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      - name: Cache Bun packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock', 'tests/benchmark/bun.lock', 'tests/integration/fixtures/emotion-v10/bun.lock', 'package.json', 'tests/integration/package.json', 'tests/benchmark/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,6 +9,7 @@ on:
       - 'tests/**'
       - '.github/workflows/integration.yml'
       - '.github/actions/setup-zts/**'
+      - '.github/actions/use-zts-artifact/**'
   pull_request:
     branches: [main]
     paths:
@@ -17,22 +18,36 @@ on:
       - 'tests/**'
       - '.github/workflows/integration.yml'
       - '.github/actions/setup-zts/**'
+      - '.github/actions/use-zts-artifact/**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  integration:
-    name: Integration Tests
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+  lint-format:
+    name: Lint & Format
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
         with:
-          submodules: recursive
-      - uses: ./.github/actions/setup-zts
+          bun-version: "1.3.11"
+
+      - name: Cache Bun packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock', 'tests/benchmark/bun.lock', 'tests/integration/fixtures/emotion-v10/bun.lock', 'package.json', 'tests/integration/package.json', 'tests/benchmark/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install
 
       - name: Lint (oxlint)
         run: bun run lint
@@ -40,11 +55,54 @@ jobs:
       - name: Format check (oxfmt)
         run: bun run fmt:check
 
-      - name: Run integration tests
-        run: bun run test:integration
+  prepare-zts-ubuntu:
+    name: Prepare ZTS (ubuntu-latest)
+    runs-on: ubuntu-latest
 
-  hermes:
-    name: Hermes Validation (RN Bundle)
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: ./.github/actions/setup-zts
+        with:
+          cpu: baseline
+          install: "false"
+
+      - name: Upload ZTS build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zts-build-ubuntu-latest
+          if-no-files-found: error
+          retention-days: 1
+          path: |
+            zig-out/bin/zts
+            zig-out/lib/zts.node
+            packages/core/dist/**
+
+  prepare-zts-cli-ubuntu:
+    name: Prepare ZTS CLI (ubuntu-latest)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: ./.github/actions/setup-zts
+        with:
+          cpu: baseline
+          napi: "false"
+          install: "false"
+
+      - name: Upload ZTS CLI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zts-cli-ubuntu-latest
+          if-no-files-found: error
+          retention-days: 1
+          path: zig-out/bin/zts
+
+  prepare-zts-macos:
+    name: Prepare ZTS (macos-latest)
     runs-on: macos-latest
 
     steps:
@@ -52,6 +110,64 @@ jobs:
         with:
           submodules: recursive
       - uses: ./.github/actions/setup-zts
+        with:
+          install: "false"
+
+      - name: Upload ZTS build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zts-build-macos-latest
+          if-no-files-found: error
+          retention-days: 1
+          path: |
+            zig-out/bin/zts
+            zig-out/lib/zts.node
+            packages/core/dist/**
+
+  integration-ubuntu:
+    name: Integration Tests (ubuntu-latest)
+    runs-on: ubuntu-latest
+    needs: prepare-zts-ubuntu
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/use-zts-artifact
+        with:
+          artifact-name: zts-build-ubuntu-latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run integration tests
+        run: bun run test:integration
+
+  integration-macos:
+    name: Integration Tests (macos-latest)
+    runs-on: macos-latest
+    needs: prepare-zts-macos
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/use-zts-artifact
+        with:
+          artifact-name: zts-build-macos-latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run integration tests
+        run: bun run test:integration
+
+  hermes:
+    name: Hermes Validation (RN Bundle)
+    runs-on: macos-latest
+    needs: prepare-zts-macos
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/use-zts-artifact
+        with:
+          artifact-name: zts-build-macos-latest
 
       - name: Install RN example app dependencies
         run: cd tests/integration/tests/fixtures/rn-example-app && bun install
@@ -65,12 +181,14 @@ jobs:
   compat-table:
     name: compat-table ES Downlevel
     runs-on: ubuntu-latest
+    needs: prepare-zts-cli-ubuntu
 
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/use-zts-artifact
         with:
-          submodules: recursive
-      - uses: ./.github/actions/setup-zts
+          artifact-name: zts-cli-ubuntu-latest
+          napi: "false"
 
       - name: Install compat-table
         run: cd tests/integration && bun install
@@ -94,15 +212,19 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
+    needs: prepare-zts-ubuntu
 
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/use-zts-artifact
         with:
-          submodules: recursive
-      - uses: ./.github/actions/setup-zts
+          artifact-name: zts-build-ubuntu-latest
+
+      - name: Install dependencies
+        run: bun install
 
       # E2E test fixture 가 spawn 한 `zts build` (app 모드) 가 `@zts/web` 을
-      # lazy import. setup-zts 는 core build:js 까지만 — web/server 와 core
+      # lazy import. ZTS artifact 는 core build:js 까지만 — web/server 와 core
       # dts 를 별도 빌드 (#2539 PR #6d 후 web 의 tsc emit 가 core 의
       # `prepareAppDevSync` declaration 의존).
       - name: Build @zts/core dts + @zts/server + @zts/web (E2E app 모드 의존)
@@ -120,12 +242,14 @@ jobs:
   smoke:
     name: Smoke Tests (Real Projects)
     runs-on: ubuntu-latest
+    needs: prepare-zts-cli-ubuntu
 
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/use-zts-artifact
         with:
-          submodules: recursive
-      - uses: ./.github/actions/setup-zts
+          artifact-name: zts-cli-ubuntu-latest
+          napi: "false"
 
       - name: Install smoke dependencies
         run: cd tests/benchmark && bun install

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -11,6 +11,10 @@ on:
       - 'src/**'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test262-unit:
     name: Test262 Runner Unit Tests


### PR DESCRIPTION
## 변경 사항

- `CI`, `Integration & E2E`, `Test262 Conformance`, `Benchmark` workflow에 concurrency group을 추가했습니다.
  - 같은 PR/branch에서 새 run이 시작되면 이전 run을 취소해 stale run 때문에 큐가 밀리는 문제를 줄입니다.
  - GitHub Pages 배포는 기존 정책대로 취소하지 않습니다.
- `CI`의 기존 `Build & Test` job을 `Debug Test`와 `Release Build` matrix로 분리했습니다.
  - Debug build / unit / test262 runner 검증은 Linux/macOS에서 유지합니다.
  - ReleaseSafe / ReleaseFast / ReleaseSmall 빌드는 OS x optimize matrix로 병렬 실행합니다.
  - 기존에는 각 OS job 안에서 release 3종을 순차 실행해서 Windows/Ubuntu build job의 wall time이 release 빌드 합산에 묶였습니다.
- `CI`의 NAPI/WASM job과 `Benchmark` job에도 Bun package cache를 추가했습니다.
  - 기존에 단축된 build/test 병렬화 위에 install 계열 시간을 추가로 줄이기 위한 변경입니다.
- `Integration & E2E`의 lint/format을 별도 `Lint & Format` Ubuntu job으로 분리했습니다.
  - 기존에는 `Integration Tests` matrix의 Ubuntu/macOS 양쪽에서 `bun run lint`, `bun run fmt:check`를 중복 실행했습니다.
  - 이제 integration matrix는 실제 integration test만 돌고, lint/format은 한 번만 실행합니다.
- `.github/actions/setup-zts`에 `napi` / `install` / `cpu` 옵션을 추가했습니다.
  - prepare job에서는 workspace install 없이 ZTS build 산출물만 만듭니다.
  - Ubuntu에서 공유하는 ZTS artifact는 `cpu: baseline`으로 빌드해 GitHub-hosted runner 간 CPU feature 차이로 생기는 `SIGILL` 위험을 줄입니다.
  - install이 필요한 기존 사용 경로는 Bun package cache를 복원한 뒤 `bun install`을 실행합니다.
- `Integration & E2E`에 ZTS artifact prepare/restore 경로를 추가했습니다.
  - `Prepare ZTS (ubuntu-latest)` / `Prepare ZTS (macos-latest)`가 `zig-out/bin/zts`, `zig-out/lib/zts.node`, `packages/core/dist/**`를 업로드합니다.
  - Integration/E2E는 full artifact를 내려받고, 테스트별 dependency install만 수행합니다.
  - Smoke/compat-table은 NAPI/JS CLI가 필요 없으므로 별도 `Prepare ZTS CLI (ubuntu-latest)`의 가벼운 CLI-only artifact를 사용합니다.
  - downstream checkout에서는 submodule checkout을 제거했습니다.
- `.github/actions/use-zts-artifact` composite action을 추가했습니다.
  - Bun setup, Bun package cache restore, artifact download, CLI-only artifact layout 정규화, 실행 권한 복원, artifact 검증을 공통화했습니다.

## 기대 효과

- 연속 push/force-push 시 오래된 CI run이 큐와 runner를 붙잡는 시간을 줄입니다.
- `CI` build bottleneck은 release 3종의 합산 시간이 아니라 가장 느린 release mode 시간에 가까워집니다.
  - 이전 run 기준 Windows build는 ReleaseSafe 3m02s + ReleaseFast 2m23s + ReleaseSmall 1m30s를 순차 실행했습니다.
  - Ubuntu build도 ReleaseSafe 2m05s + ReleaseFast 2m26s + ReleaseSmall 49s가 순차 실행됐습니다.
- Integration workflow에서 macOS/Ubuntu 중복 lint/format 실행을 제거합니다.
- Integration/E2E/Smoke/compat-table/Hermes가 각자 ZTS를 반복 빌드하는 구조를 줄입니다.
- Smoke/compat-table은 full NAPI artifact를 기다리지 않고 CLI-only artifact를 사용합니다.
- Bun install 계열 job은 package cache hit 시 install 시간을 더 줄일 수 있습니다.

## 검증

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci.yml .github/workflows/integration.yml .github/workflows/test262.yml .github/workflows/benchmark.yml`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/integration.yml .github/actions/setup-zts/action.yml .github/actions/use-zts-artifact/action.yml`
- `zig build -Doptimize=ReleaseFast -Dcpu=baseline`
- `zig build napi -Dcpu=baseline`
- `bun run lint`
  - 기존 warning 21개, error 0
- `bun run fmt:check`
- `git diff --check`
- push 전 hook 통과: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`
  - `oxlint`는 기존 warning만 출력, error 0
