### PR TITLE
test(bundler): pnpm/bun farm symlink 통합 회귀 가드 (#1924)

### DIFF
--- a/tests/integration/tests/helpers.ts
+++ b/tests/integration/tests/helpers.ts
@@ -75,21 +75,18 @@ export async function createReactStubFixture(
   });
 }
 
-/// pnpm/bun 의 `.pnpm/` farm symlink 레이아웃을 모방한 fixture 생성.
-/// resolver 의 `preserve_symlinks=false` 경로(`bundler/resolver.zig:661`)가
-/// farm 을 realpath 로 풀어 flat npm 과 동일 결과를 내는지 회귀 가드 목적.
-/// 현재는 unscoped 1-hop 만 지원 — scoped/peer/nested 는 후속 PR.
+/// pnpm/bun `.pnpm/` farm symlink 레이아웃 fixture (unscoped 1-hop).
 export async function createPnpmFarmFixture(opts: {
   files: Record<string, string>;
   packages: Record<string, Record<string, string>>;
 }): Promise<{ dir: string; cleanup: () => Promise<void> }> {
   const parsed = Object.entries(opts.packages).map(([key, files]) => {
     if (key.startsWith('@')) {
-      throw new Error(`createPnpmFarmFixture: scoped package '${key}' 는 후속 PR`);
+      throw new Error(`scoped package not supported: '${key}'`);
     }
     const at = key.indexOf('@');
     if (at < 0) {
-      throw new Error(`createPnpmFarmFixture: bad package key '${key}' — expected name@version`);
+      throw new Error(`bad package key '${key}' — expected name@version`);
     }
     return { name: key.slice(0, at), version: key.slice(at + 1), files };
   });

--- a/tests/integration/tests/helpers.ts
+++ b/tests/integration/tests/helpers.ts
@@ -75,6 +75,45 @@ export async function createReactStubFixture(
   });
 }
 
+/// pnpm/bun 의 `.pnpm/` farm symlink 레이아웃을 모방한 fixture 생성.
+/// resolver 의 `preserve_symlinks=false` 경로(`bundler/resolver.zig:661`)가
+/// farm 을 realpath 로 풀어 flat npm 과 동일 결과를 내는지 회귀 가드 목적.
+/// 현재는 unscoped 1-hop 만 지원 — scoped/peer/nested 는 후속 PR.
+export async function createPnpmFarmFixture(opts: {
+  files: Record<string, string>;
+  packages: Record<string, Record<string, string>>;
+}): Promise<{ dir: string; cleanup: () => Promise<void> }> {
+  const parsed = Object.entries(opts.packages).map(([key, files]) => {
+    if (key.startsWith('@')) {
+      throw new Error(`createPnpmFarmFixture: scoped package '${key}' 는 후속 PR`);
+    }
+    const at = key.indexOf('@');
+    if (at < 0) {
+      throw new Error(`createPnpmFarmFixture: bad package key '${key}' — expected name@version`);
+    }
+    return { name: key.slice(0, at), version: key.slice(at + 1), files };
+  });
+
+  const allFiles: Record<string, string> = { ...opts.files };
+  for (const { name, version, files } of parsed) {
+    const prefix = `.pnpm/${name}@${version}/node_modules/${name}`;
+    for (const [rel, content] of Object.entries(files)) {
+      allFiles[`${prefix}/${rel}`] = content;
+    }
+  }
+
+  const fixture = await createFixture(allFiles);
+  const nmDir = join(fixture.dir, 'node_modules');
+  await mkdir(nmDir, { recursive: true });
+  await Promise.all(
+    parsed.map(({ name, version }) =>
+      symlink(join('..', '.pnpm', `${name}@${version}`, 'node_modules', name), join(nmDir, name)),
+    ),
+  );
+
+  return fixture;
+}
+
 /// LOOKUP_ROOTS에서 패키지를 찾아 fixture dir로 symlink. 패키지 단위 병렬 실행.
 /// plugin host의 dynamic import + ZTS 번들 resolve 양쪽에서 사용.
 ///

--- a/tests/integration/tests/pnpm-bundle.test.ts
+++ b/tests/integration/tests/pnpm-bundle.test.ts
@@ -3,8 +3,6 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { createPnpmFarmFixture, runZts } from './helpers';
 
-/// 단위 테스트(`package_json_test.zig:159`)는 parsePackageJson 단계만 cover.
-/// 풀 번들 파이프라인까지 farm 이 동일 결과를 내는지는 통합에서 회귀 가드.
 describe('pnpm/bun farm symlink — bundle integration', () => {
   test('farm symlink resolves to real package and inlines source', async () => {
     const fixture = await createPnpmFarmFixture({

--- a/tests/integration/tests/pnpm-bundle.test.ts
+++ b/tests/integration/tests/pnpm-bundle.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createPnpmFarmFixture, runZts } from './helpers';
+
+/// 단위 테스트(`package_json_test.zig:159`)는 parsePackageJson 단계만 cover.
+/// 풀 번들 파이프라인까지 farm 이 동일 결과를 내는지는 통합에서 회귀 가드.
+describe('pnpm/bun farm symlink — bundle integration', () => {
+  test('farm symlink resolves to real package and inlines source', async () => {
+    const fixture = await createPnpmFarmFixture({
+      files: {
+        'src/index.ts': `import { greet } from 'foo';\nconsole.log(greet('zts'));\n`,
+        'package.json': JSON.stringify({ name: 'pnpm-app', version: '0.0.0', type: 'module' }),
+      },
+      packages: {
+        'foo@1.0.0': {
+          'package.json': JSON.stringify({ name: 'foo', version: '1.0.0', main: './index.js' }),
+          'index.js': `export function greet(name) { return 'hello, ' + name + '!'; }\n`,
+        },
+      },
+    });
+
+    try {
+      const outFile = join(fixture.dir, 'out.js');
+      const result = await runZts(['--bundle', join(fixture.dir, 'src/index.ts'), '-o', outFile]);
+
+      expect(result.exitCode).toBe(0);
+
+      const bundle = readFileSync(outFile, 'utf-8');
+      expect(bundle).toContain('hello, ');
+      expect(bundle).toContain('zts');
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## 배경
[#1924](https://github.com/ohah/zts/issues/1924) epic 의 첫 PR. 단위 테스트 (`src/bundler/package_json_test.zig:159` — `parsePackageJson: pnpm/bun farm symlink`) 는 이미 farm symlink 의 package.json 단계만 cover. **풀 번들 파이프라인까지 farm 이 flat npm 과 동일 결과를 내는지** 통합 레벨에서는 회귀 가드 없는 상태.

이 PR 은 통합 fixture helper + 첫 minimal 회귀 테스트 1개를 추가합니다.

## 변경

### `tests/integration/tests/helpers.ts`
`createPnpmFarmFixture(opts: { files, packages })` 추가. 실 `pnpm install` / `bun install` 결과와 동일한 layout 을 mkdtemp 위에 구성:

```
<dir>/.pnpm/<name>@<version>/node_modules/<name>/<file>
<dir>/node_modules/<name>  →  ../.pnpm/<name>@<version>/node_modules/<name>   (symlink)
```

내부 구현은 패키지 파일을 namespaced key 로 normalize 한 뒤 기존 `createFixture` 한 번에 위임 → mkdir/writeFile 루프 중복 제거. symlink 만 별도 단계.

현재는 **unscoped 1-hop minimal** 만 지원. scoped(`@scope/x`) / peer / nested farm 은 후속 PR.

### `tests/integration/tests/pnpm-bundle.test.ts`
첫 회귀 가드 — entry → `node_modules/foo` (symlink) → `.pnpm/foo@1.0.0/node_modules/foo` 경로로 resolve 되어 farm 의 source 가 bundle 에 inline 되는지 검증.

## 디자인 결정

이슈 본문은 `tests/integration/tests/fixtures/pnpm-app/` 영구 디렉토리 형태를 명시했지만, ZTS 의 다른 통합 테스트 (`bundle-smoke`, `resolve-fallback`, `preserve-modules` 등) 가 모두 `mkdtemp` runtime 패턴을 쓰고 있어 일관성을 우선해 helper 함수 형태로 진행. 영구 fixture 디렉토리는 입력 파일이 많은 케이스 (round1, rsc-directives 같은) 에만 적합.

## 검증

### TDD red/green 사이클
1. **Red** — helper 정의 전 테스트 실행 → `Export named 'createPnpmFarmFixture' not found` 으로 실패 확인
2. **Green** — helper 추가 후 테스트 통과 (3 expect / 21ms)

### Sensitivity
의도적으로 `node_modules/<pkg>` symlink 만 빼고 fixture 구성 → ZTS 가 `Cannot resolve module 'foo'` 로 정확히 떨어지는지 확인. **단순히 어떤 경로든 통과하는 것이 아니라, farm symlink 해석이 실제로 트리거되어야만 통과**하는 테스트.

### 회귀 가드
인접 162 테스트 (bundle-smoke / resolve-fallback / preserve-modules) 모두 통과 — helpers 리팩터가 다른 테스트에 영향 없음.

## 후속 (#1924 epic)
- PR 2: scoped 패키지 (`@scope/x`) + transitive farm dep (foo → bar) + nested farm
- PR 3: yarn pnp `.pnp.data.json` 파서 단위 테스트 + fixture
- PR 4: resolver yarn pnp 통합
- PR 5: `docs/USAGE.md` 호환성 매트릭스

## Test plan
- [x] `bun test tests/pnpm-bundle.test.ts` — 1 pass / 3 expect
- [x] `bun test tests/bundle-smoke.test.ts tests/resolve-fallback.test.ts tests/preserve-modules.test.ts` — 162 pass / 회귀 없음
- [x] symlink 누락 시 `Cannot resolve module 'foo'` 로 정확히 떨어지는지 sensitivity 검증
- [x] `bun run fmt` 통과 (pre-push hook OK)

Refs #1924

🤖 Generated with [Claude Code](https://claude.com/claude-code)