### PR TITLE
test(e2e): app builder 그룹 병렬 실행

### DIFF
--- a/tests/e2e/tests/zts-app-builder-e2e.test.ts
+++ b/tests/e2e/tests/zts-app-builder-e2e.test.ts
@@ -28,6 +28,8 @@ const OVERLAY_DEV_PORT = 3989;
 const RUNTIME_OVERLAY_DEV_PORT = 3988;
 const REJECTION_OVERLAY_DEV_PORT = 3987;
 
+test.describe.configure({ mode: 'parallel' });
+
 const FIXTURE: Record<string, string> = {
   'index.html': `<!doctype html>
 <html>
@@ -73,7 +75,7 @@ async function writeFixture(dir: string): Promise<void> {
 }
 
 // ─── zts build → zts preview → 브라우저 ───
-test.describe('zts build + preview E2E', () => {
+test.describe.serial('zts build + preview E2E', () => {
   let fixtureDir: string;
   let preview: ChildProcess | null = null;
 
@@ -148,7 +150,7 @@ test.describe('zts build + preview E2E', () => {
 });
 
 // ─── zts dev 직접 띄움 → 브라우저 ───
-test.describe('zts dev E2E', () => {
+test.describe.serial('zts dev E2E', () => {
   let fixtureDir: string;
   let server: ChildProcess | null = null;
 
@@ -312,7 +314,7 @@ test.describe('zts dev E2E', () => {
 });
 
 // ─── 서브디렉토리 같은 basename CSS 두 개가 build → preview 후 브라우저에 모두 적용된다 ───
-test.describe('zts build: nested CSS path preservation E2E', () => {
+test.describe.serial('zts build: nested CSS path preservation E2E', () => {
   let nestedDir: string;
   let nestedPreview: ChildProcess | null = null;
   const NESTED_PORT = 3996;
@@ -380,7 +382,7 @@ test.describe('zts build: nested CSS path preservation E2E', () => {
 });
 
 // ─── CSS Modules: JS class map + 실제 브라우저 스타일 적용까지 검증 ───
-test.describe('zts app CSS Modules E2E', () => {
+test.describe.serial('zts app CSS Modules E2E', () => {
   async function writeCssModuleFixture(dir: string): Promise<void> {
     const files: Record<string, string> = {
       'index.html': `<!doctype html>
@@ -502,7 +504,7 @@ el.textContent = styles.button.includes("button_button__") ? "scoped" : "raw";
 });
 
 // ─── Sass/SCSS: optional Sass compiler 경로를 실제 브라우저에서 검증 ───
-test.describe('zts app Sass/SCSS E2E', () => {
+test.describe.serial('zts app Sass/SCSS E2E', () => {
   async function writeScssFixture(dir: string): Promise<void> {
     const files: Record<string, string> = {
       'index.html': `<!doctype html>


### PR DESCRIPTION
## 변경 사항

- `zts-app-builder-e2e.test.ts` 파일에 Playwright `mode: parallel`을 적용했습니다.
- 기존 `describe` 묶음은 `test.describe.serial`로 유지해 각 묶음 내부의 fixture/server lifecycle은 그대로 직렬 실행합니다.
- 테스트 수와 케이스는 그대로 유지하고, 서로 다른 port를 쓰는 app-builder 그룹들만 병렬 스케줄되게 했습니다.

## 기대 효과

- app-builder E2E focused 실행 기준 `32.3s -> 11.8s`로 단축됐습니다.
- 전체 CI에서는 `E2E Tests` job의 app-builder 직렬 구간이 줄어드는지 확인합니다.

## 검증

- `git diff --check`
- `bun run --cwd tests/e2e test tests/zts-app-builder-e2e.test.ts --reporter=line`
  - 변경 전: `18 passed (32.1s)`, wall `32.315s`
  - 변경 후: `18 passed (11.6s)`, wall `11.853s`
- push 전 hook 통과: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`
  - `oxlint`는 기존 warning 21개, error 0
