### PR TITLE
test(bundler): pnpm/bun farm scoped 패키지 (`@scope/x`) 지원 (#1924)

### DIFF
--- a/tests/integration/tests/helpers.ts
+++ b/tests/integration/tests/helpers.ts
@@ -75,25 +75,25 @@ export async function createReactStubFixture(
   });
 }
 
-/// pnpm/bun `.pnpm/` farm symlink 레이아웃 fixture (unscoped 1-hop).
+/// pnpm/bun `.pnpm/` farm symlink 레이아웃 fixture (1-hop, scoped 포함).
+/// `@scope/x` 의 farm dir 은 `/` → `+` 로 escape (실 pnpm/bun 패턴).
 export async function createPnpmFarmFixture(opts: {
   files: Record<string, string>;
   packages: Record<string, Record<string, string>>;
 }): Promise<{ dir: string; cleanup: () => Promise<void> }> {
   const parsed = Object.entries(opts.packages).map(([key, files]) => {
-    if (key.startsWith('@')) {
-      throw new Error(`scoped package not supported: '${key}'`);
-    }
-    const at = key.indexOf('@');
-    if (at < 0) {
+    const at = key.lastIndexOf('@');
+    if (at <= 0) {
       throw new Error(`bad package key '${key}' — expected name@version`);
     }
-    return { name: key.slice(0, at), version: key.slice(at + 1), files };
+    const name = key.slice(0, at);
+    const version = key.slice(at + 1);
+    return { name, version, farmDirName: `${name.replace('/', '+')}@${version}`, files };
   });
 
   const allFiles: Record<string, string> = { ...opts.files };
-  for (const { name, version, files } of parsed) {
-    const prefix = `.pnpm/${name}@${version}/node_modules/${name}`;
+  for (const { name, farmDirName, files } of parsed) {
+    const prefix = `.pnpm/${farmDirName}/node_modules/${name}`;
     for (const [rel, content] of Object.entries(files)) {
       allFiles[`${prefix}/${rel}`] = content;
     }
@@ -102,10 +102,17 @@ export async function createPnpmFarmFixture(opts: {
   const fixture = await createFixture(allFiles);
   const nmDir = join(fixture.dir, 'node_modules');
   await mkdir(nmDir, { recursive: true });
+
+  const scopes = new Set(
+    parsed.filter(({ name }) => name.includes('/')).map(({ name }) => name.split('/')[0]),
+  );
+  await Promise.all([...scopes].map((s) => mkdir(join(nmDir, s), { recursive: true })));
+
   await Promise.all(
-    parsed.map(({ name, version }) =>
-      symlink(join('..', '.pnpm', `${name}@${version}`, 'node_modules', name), join(nmDir, name)),
-    ),
+    parsed.map(({ name, farmDirName }) => {
+      const ups = name.includes('/') ? '../..' : '..';
+      return symlink(join(ups, '.pnpm', farmDirName, 'node_modules', name), join(nmDir, name));
+    }),
   );
 
   return fixture;

--- a/tests/integration/tests/pnpm-bundle.test.ts
+++ b/tests/integration/tests/pnpm-bundle.test.ts
@@ -31,4 +31,36 @@ describe('pnpm/bun farm symlink — bundle integration', () => {
       await fixture.cleanup();
     }
   });
+
+  test('scoped package farm symlink resolves and inlines source', async () => {
+    const fixture = await createPnpmFarmFixture({
+      files: {
+        'src/index.ts': `import { greet } from '@scope/foo';\nconsole.log(greet('scoped'));\n`,
+        'package.json': JSON.stringify({ name: 'pnpm-app', version: '0.0.0', type: 'module' }),
+      },
+      packages: {
+        '@scope/foo@1.0.0': {
+          'package.json': JSON.stringify({
+            name: '@scope/foo',
+            version: '1.0.0',
+            main: './index.js',
+          }),
+          'index.js': `export function greet(name) { return 'scoped hello, ' + name + '!'; }\n`,
+        },
+      },
+    });
+
+    try {
+      const outFile = join(fixture.dir, 'out.js');
+      const result = await runZts(['--bundle', join(fixture.dir, 'src/index.ts'), '-o', outFile]);
+
+      expect(result.exitCode).toBe(0);
+
+      const bundle = readFileSync(outFile, 'utf-8');
+      expect(bundle).toContain('scoped hello, ');
+      expect(bundle).toContain('scoped');
+    } finally {
+      await fixture.cleanup();
+    }
+  });
 });


### PR DESCRIPTION
## 배경
[#1924](https://github.com/ohah/zts/issues/1924) epic 의 두 번째 PR. [#2666](https://github.com/ohah/zts/pull/2666) 에서 도입한 `createPnpmFarmFixture` 가 unscoped 1-hop 만 지원했는데, 실 pnpm/bun install 결과는 scoped 패키지 (`@scope/x`) 도 흔합니다. 회귀 가드의 cover 영역 확장.

## 실 pnpm/bun install 의 scoped 레이아웃

```
.pnpm/@scope+foo@1.0.0/node_modules/@scope/foo/<file>
node_modules/@scope/foo  →  ../../.pnpm/@scope+foo@1.0.0/node_modules/@scope/foo
```

핵심:
- farm 디렉토리 이름은 `/` 를 `+` 로 escape (`@scope/foo` → `@scope+foo`)
- 그 안의 `node_modules/<scope>/<name>/` 은 unescape (실제 scope dir)
- root symlink 의 `..` 깊이가 scoped 면 2, unscoped 면 1

## 변경

### `tests/integration/tests/helpers.ts`

- key 파싱: `indexOf('@')` → `lastIndexOf('@')` (scoped 의 첫 `@` 는 scope marker, version separator 는 마지막 `@`)
- `farmDirName` 미리 계산 — `name.replace('/', '+')` + `@version`
- `node_modules/@scope/` dir 을 Set 으로 dedup 후 한 번에 mkdir (`linkNodeModules` 의 패턴 mirror — helpers.ts:134)
- symlink target depth 를 명시적 ternary 로 (`name.includes('/') ? '../..' : '..'`)

### `tests/integration/tests/pnpm-bundle.test.ts`

scoped 케이스 추가 — entry → `node_modules/@scope/foo` (symlink) → `.pnpm/@scope+foo@1.0.0/node_modules/@scope/foo` 경로로 resolve 되어 farm 의 source 가 bundle 에 inline 되는지.

## 검증

### TDD red/green 사이클
1. **Red** — 기존 helper 가 scoped 를 reject (`scoped package not supported`) — 테스트 추가만으로 fail 확인
2. **Green** — helper 확장 후 통과 (2 pass / 6 expect / 25ms)

### 회귀 가드
- 인접 162 테스트 (`bundle-smoke`, `resolve-fallback`, `preserve-modules`) 모두 통과 — helper 리팩터가 다른 fixture 흐름에 영향 없음

## /simplify round 1 적용
- `Array(depth).fill('..')` → 명시적 ternary (가독성, 도메인이 binary)
- scope dir mkdir 호이스팅 + Set dedup (`linkNodeModules` 패턴 mirror)
- 두 번째 test 이름 layout-narrating → behavior-describing 으로 통일

## 후속 (#1924 epic)
- PR 3: transitive farm dep (foo → bar)
- PR 4: nested farm
- PR 5: yarn pnp `.pnp.data.json` 파서
- PR 6: resolver yarn pnp 통합
- PR 7: docs/USAGE.md 호환성 매트릭스

## Test plan
- [x] `bun test tests/pnpm-bundle.test.ts` — 2 pass / 6 expect (unscoped + scoped)
- [x] `bun test tests/bundle-smoke.test.ts tests/resolve-fallback.test.ts tests/preserve-modules.test.ts` — 162 pass / 회귀 없음
- [x] `bun run fmt` 통과 (pre-push hook OK)

Refs #1924

🤖 Generated with [Claude Code](https://claude.com/claude-code)