### PR TITLE
test(bundler): pnpm/bun farm transitive dep + helper 통합 (#1924)

### DIFF
--- a/tests/integration/tests/helpers.ts
+++ b/tests/integration/tests/helpers.ts
@@ -2,7 +2,7 @@ import { spawn } from 'bun';
 import { mkdtemp, rm, writeFile, mkdir, symlink, stat } from 'node:fs/promises';
 import { readFileSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
 
 const PROJECT_ROOT = resolve(import.meta.dir, '../../..');
 export const ZTS_BIN = join(PROJECT_ROOT, 'zig-out/bin/zts');
@@ -75,11 +75,13 @@ export async function createReactStubFixture(
   });
 }
 
-/// pnpm/bun `.pnpm/` farm symlink 레이아웃 fixture (1-hop, scoped 포함).
+/// pnpm/bun `.pnpm/` farm symlink 레이아웃 fixture.
 /// `@scope/x` 의 farm dir 은 `/` → `+` 로 escape (실 pnpm/bun 패턴).
 export async function createPnpmFarmFixture(opts: {
   files: Record<string, string>;
   packages: Record<string, Record<string, string>>;
+  hoist?: string[];
+  deps?: Record<string, string[]>;
 }): Promise<{ dir: string; cleanup: () => Promise<void> }> {
   const parsed = Object.entries(opts.packages).map(([key, files]) => {
     const at = key.lastIndexOf('@');
@@ -88,8 +90,9 @@ export async function createPnpmFarmFixture(opts: {
     }
     const name = key.slice(0, at);
     const version = key.slice(at + 1);
-    return { name, version, farmDirName: `${name.replace('/', '+')}@${version}`, files };
+    return { key, name, version, farmDirName: `${name.replace('/', '+')}@${version}`, files };
   });
+  const byKey = new Map(parsed.map((p) => [p.key, p]));
 
   const allFiles: Record<string, string> = { ...opts.files };
   for (const { name, farmDirName, files } of parsed) {
@@ -100,19 +103,42 @@ export async function createPnpmFarmFixture(opts: {
   }
 
   const fixture = await createFixture(allFiles);
-  const nmDir = join(fixture.dir, 'node_modules');
-  await mkdir(nmDir, { recursive: true });
 
-  const scopes = new Set(
-    parsed.filter(({ name }) => name.includes('/')).map(({ name }) => name.split('/')[0]),
-  );
-  await Promise.all([...scopes].map((s) => mkdir(join(nmDir, s), { recursive: true })));
+  const links: Array<{ linkRel: string; targetRel: string }> = [];
+
+  const hoistSet = new Set(opts.hoist ?? parsed.map(({ key }) => key));
+  for (const { key, name, farmDirName } of parsed) {
+    if (!hoistSet.has(key)) continue;
+    links.push({
+      linkRel: `node_modules/${name}`,
+      targetRel: `.pnpm/${farmDirName}/node_modules/${name}`,
+    });
+  }
+
+  for (const [dependerKey, depKeys] of Object.entries(opts.deps ?? {})) {
+    const depender = byKey.get(dependerKey);
+    if (!depender) {
+      throw new Error(`unknown depender '${dependerKey}' in opts.deps`);
+    }
+    for (const depKey of depKeys) {
+      const dep = byKey.get(depKey);
+      if (!dep) {
+        throw new Error(`unknown dep '${depKey}' for '${dependerKey}'`);
+      }
+      links.push({
+        linkRel: `.pnpm/${depender.farmDirName}/node_modules/${dep.name}`,
+        targetRel: `.pnpm/${dep.farmDirName}/node_modules/${dep.name}`,
+      });
+    }
+  }
+
+  const parentDirs = new Set(links.map(({ linkRel }) => dirname(linkRel)));
+  await Promise.all([...parentDirs].map((d) => mkdir(join(fixture.dir, d), { recursive: true })));
 
   await Promise.all(
-    parsed.map(({ name, farmDirName }) => {
-      const ups = name.includes('/') ? '../..' : '..';
-      return symlink(join(ups, '.pnpm', farmDirName, 'node_modules', name), join(nmDir, name));
-    }),
+    links.map(({ linkRel, targetRel }) =>
+      symlink(relative(dirname(linkRel), targetRel), join(fixture.dir, linkRel)),
+    ),
   );
 
   return fixture;

--- a/tests/integration/tests/pnpm-bundle.test.ts
+++ b/tests/integration/tests/pnpm-bundle.test.ts
@@ -32,6 +32,46 @@ describe('pnpm/bun farm symlink — bundle integration', () => {
     }
   });
 
+  test('transitive farm dep resolves and inlines source', async () => {
+    const fixture = await createPnpmFarmFixture({
+      files: {
+        'src/index.ts': `import { greet } from 'foo';\nconsole.log(greet());\n`,
+        'package.json': JSON.stringify({ name: 'pnpm-app', version: '0.0.0', type: 'module' }),
+      },
+      packages: {
+        'foo@1.0.0': {
+          'package.json': JSON.stringify({
+            name: 'foo',
+            version: '1.0.0',
+            main: './index.js',
+            dependencies: { bar: '1.0.0' },
+          }),
+          'index.js': `export { greet } from 'bar';\n`,
+        },
+        'bar@1.0.0': {
+          'package.json': JSON.stringify({ name: 'bar', version: '1.0.0', main: './index.js' }),
+          'index.js': `export function greet() { return 'transitive ok'; }\n`,
+        },
+      },
+      hoist: ['foo@1.0.0'],
+      deps: {
+        'foo@1.0.0': ['bar@1.0.0'],
+      },
+    });
+
+    try {
+      const outFile = join(fixture.dir, 'out.js');
+      const result = await runZts(['--bundle', join(fixture.dir, 'src/index.ts'), '-o', outFile]);
+
+      expect(result.exitCode).toBe(0);
+
+      const bundle = readFileSync(outFile, 'utf-8');
+      expect(bundle).toContain('transitive ok');
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
   test('scoped package farm symlink resolves and inlines source', async () => {
     const fixture = await createPnpmFarmFixture({
       files: {


### PR DESCRIPTION
## 배경
[#1924](https://github.com/ohah/zts/issues/1924) epic 의 세 번째 PR. PR [#2666](https://github.com/ohah/zts/pull/2666) (unscoped 1-hop) → [#2668](https://github.com/ohah/zts/pull/2668) (scoped) 에 이어 transitive farm dep 추가.

## 실 pnpm/bun install 의 transitive 레이아웃

```
.pnpm/foo@1.0.0/node_modules/foo/<file>
.pnpm/foo@1.0.0/node_modules/bar  →  ../../bar@1.0.0/node_modules/bar    (inner symlink)
.pnpm/bar@1.0.0/node_modules/bar/<file>
node_modules/foo  →  ../.pnpm/foo@1.0.0/node_modules/foo                  (직접 의존만 hoist)
```

핵심: foo 가 bar 를 의존하면 bar 는 root `node_modules/` 에 hoist 되지 *않고*, foo 의 farm 디렉토리 안에 inner symlink 로만 존재. ZTS resolver 가 foo source 위치에서 `bar` 를 찾을 때 inner symlink 를 따라 `.pnpm/bar@1.0.0` 로 해결.

## 변경

### `tests/integration/tests/helpers.ts`
helper 에 두 옵션 추가 + 내부 통합:

- `hoist?: string[]` — 명시 시 해당 keys 만 root `node_modules/` 에 link. **default = 모든 keys** → backwards-compat (PR #2666/#2668 의 호출 변경 불필요)
- `deps?: Record<string, string[]>` — `'depender@v': ['dep@v', ...]`. 각 entry 가 `.pnpm/<dependerFarmDir>/node_modules/<depName>` inner symlink 를 만듦
- root + inner symlink 를 단일 `links` 배열로 통합
- `path.relative(dirname(linkRel), targetRel)` 로 `..` 깊이 계산 통일 (root 1 ups, scoped root 2 ups, inner unscoped 2 ups, inner scoped 3 ups 모두 자동 계산)
- parent dirs Set dedup → 단일 mkdir + 단일 symlink Promise.all

### `tests/integration/tests/pnpm-bundle.test.ts`
3번째 케이스 추가 — `foo@1.0.0` 만 root hoist, `bar@1.0.0` 는 farm 안에서만 link. foo 의 `index.js` 가 `export { greet } from 'bar'` 로 transitive 호출.

## 검증

### TDD red/green 사이클
1. **Red 1** — 테스트만 추가 (helper 가 옵션 무시) → false green (모든 packages 자동 hoist 라 ZTS 가 root 에서 bar 발견)
2. **Red 2** — helper 에 `hoist` 만 먼저 추가 (deps 미처리) → bar 가 root 에서 빠지고 inner symlink 도 없음 → ZTS exit 1 (`Cannot resolve`)
3. **Green** — `deps` 처리 추가 → inner symlink 생성 → ZTS 정상 resolve, bundle 에 `'transitive ok'` 인라인

이 단계 분리로 진정한 transitive sensitivity 가 검증됨 — `deps` 누락 시 정확히 fail.

### 회귀 가드
- 기존 unscoped + scoped 테스트 (PR #2666/#2668) 모두 통과 — `hoist` default = 모든 keys 라 backwards-compat
- 인접 162 테스트 (`bundle-smoke`, `resolve-fallback`, `preserve-modules`) 통과

## /simplify round 1 적용
- `createPnpmFarmFixture` block comment 4-line → 2-line (`hoist`/`deps` 의미는 타입 + 본문이 표현)
- 3번째 test 이름 mechanism-narrating ("via inner farm symlink") → behavior ("transitive farm dep resolves and inlines source") — 형제 test 톤과 통일

## 후속 (#1924 epic)
- PR 4: nested farm
- PR 5: yarn pnp `.pnp.data.json` 파서
- PR 6: resolver yarn pnp 통합
- PR 7: docs/USAGE.md 호환성 매트릭스

## Test plan
- [x] `bun test tests/pnpm-bundle.test.ts` — 3 pass / 8 expect (unscoped + scoped + transitive)
- [x] `bun test tests/bundle-smoke.test.ts tests/resolve-fallback.test.ts tests/preserve-modules.test.ts` — 162 pass / 회귀 없음
- [x] sensitivity (deps 누락 시 ZTS exit 1) Red 단계에서 입증
- [x] `bun run fmt` 통과 (pre-push hook OK)

Refs #1924

🤖 Generated with [Claude Code](https://claude.com/claude-code)