### PR TITLE
test(bundler): pnpm/bun farm 다중 hop transitive 검증 (#1924)

### DIFF
--- a/tests/integration/tests/pnpm-bundle.test.ts
+++ b/tests/integration/tests/pnpm-bundle.test.ts
@@ -72,6 +72,46 @@ describe('pnpm/bun farm symlink — bundle integration', () => {
     }
   });
 
+  test('deeply nested farm dep resolves and inlines source', async () => {
+    const fixture = await createPnpmFarmFixture({
+      files: {
+        'src/index.ts': `import { greet } from 'foo';\nconsole.log(greet());\n`,
+        'package.json': JSON.stringify({ name: 'pnpm-app', version: '0.0.0', type: 'module' }),
+      },
+      packages: {
+        'foo@1.0.0': {
+          'package.json': JSON.stringify({ name: 'foo', version: '1.0.0', main: './index.js' }),
+          'index.js': `export { greet } from 'bar';\n`,
+        },
+        'bar@1.0.0': {
+          'package.json': JSON.stringify({ name: 'bar', version: '1.0.0', main: './index.js' }),
+          'index.js': `export { greet } from 'baz';\n`,
+        },
+        'baz@1.0.0': {
+          'package.json': JSON.stringify({ name: 'baz', version: '1.0.0', main: './index.js' }),
+          'index.js': `export function greet() { return 'nested ok'; }\n`,
+        },
+      },
+      hoist: ['foo@1.0.0'],
+      deps: {
+        'foo@1.0.0': ['bar@1.0.0'],
+        'bar@1.0.0': ['baz@1.0.0'],
+      },
+    });
+
+    try {
+      const outFile = join(fixture.dir, 'out.js');
+      const result = await runZts(['--bundle', join(fixture.dir, 'src/index.ts'), '-o', outFile]);
+
+      expect(result.exitCode).toBe(0);
+
+      const bundle = readFileSync(outFile, 'utf-8');
+      expect(bundle).toContain('nested ok');
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
   test('scoped package farm symlink resolves and inlines source', async () => {
     const fixture = await createPnpmFarmFixture({
       files: {


### PR DESCRIPTION
## 배경
[#1924](https://github.com/ohah/zts/issues/1924) epic 의 네 번째 PR. PR [#2669](https://github.com/ohah/zts/pull/2669) 가 1-hop transitive (foo → bar) 를 cover 했고, 이 PR 은 2-hop (foo → bar → baz) 으로 확장해 helper 의 `deps` chain 표현력을 검증.

## 레이아웃

```
node_modules/foo  →  ../.pnpm/foo@1.0.0/node_modules/foo                   (직접 의존만 hoist)
.pnpm/foo@1.0.0/node_modules/bar  →  ../../bar@1.0.0/node_modules/bar      (foo 의 inner)
.pnpm/bar@1.0.0/node_modules/baz  →  ../../baz@1.0.0/node_modules/baz      (bar 의 inner)
.pnpm/{bar,baz}@1.0.0/node_modules/{bar,baz}/<files>                       (실 source)
```

체인:
- entry → `import { greet } from 'foo'`
- foo `index.js`: `export { greet } from 'bar'`
- bar `index.js`: `export { greet } from 'baz'`
- baz `index.js`: `export function greet() { return 'nested ok'; }`

ZTS 가 3 단계 inner symlink 체인을 끝까지 따라가서 baz 의 source 를 bundle 에 인라인해야 통과 (`expect(bundle).toContain('nested ok')`).

## 변경
**helper 변경 없음.** `tests/integration/tests/pnpm-bundle.test.ts` 에 4번째 test 만 추가. PR #2669 의 `deps` 옵션이 이미 chain 표현 가능 (`{'foo@1.0.0': ['bar@1.0.0'], 'bar@1.0.0': ['baz@1.0.0']}`) — helper API 의 적정성 회귀 가드.

## /simplify round 1 적용
- test 이름 mechanism-narrating ("multi-level inner symlinks") → behavior ("deeply nested farm dep resolves and inlines source")
- bar/baz source 단순화 — bar 가 함수 가공 대신 pure re-export. baz 가 `greet` 함수 직접 export. assertion 도 `'nested ok'` 1개로 (chain 통과 여부 충분 입증)

## 검증
- [x] `bun test tests/pnpm-bundle.test.ts` — 4 pass / 10 expect
- [x] `bun test tests/bundle-smoke.test.ts tests/resolve-fallback.test.ts tests/preserve-modules.test.ts` — 162 pass / 회귀 없음
- [x] `bun run fmt` 통과

## 후속 (#1924 epic)
- PR 5: yarn pnp `.pnp.data.json` 파서
- PR 6: resolver yarn pnp 통합
- PR 7: docs/USAGE.md 호환성 매트릭스

Refs #1924

🤖 Generated with [Claude Code](https://claude.com/claude-code)