### PR TITLE
fix(react-native): align DevTools sourcemap ignore

### DIFF
--- a/examples/react-native-bare/zts.config.ts
+++ b/examples/react-native-bare/zts.config.ts
@@ -46,7 +46,7 @@ export default {
     port: 8081,
     host: "localhost",
     useGlobalHotkey: true,
-    forwardClientLogs: true,
+    forwardClientLogs: false,
     verifyConnections: false,
   },
 };

--- a/packages/core/bin/rn-dev-input.mjs
+++ b/packages/core/bin/rn-dev-input.mjs
@@ -18,7 +18,6 @@ const UNSUPPORTED_FIELDS = [
   ['serializer', 'getPolyfills'],
   ['serializer', 'shouldAddToIgnoreList'],
   // dummy placeholder — bungae 도 declared-but-unused.
-  ['server', 'forwardClientLogs'],
   ['server', 'verifyConnections'],
   ['server', 'https'],
   ['server', 'key'],
@@ -64,6 +63,7 @@ export function buildRnBundleExtra(config, opts = {}) {
     inlineSourceMap: serializer.inlineSourceMap ?? undefined,
     sourceRoot: cfg.sourcemapSourcesRoot ?? undefined,
     silentConsoleErrorPatterns: server.silentConsoleErrorPatterns ?? undefined,
+    forwardClientLogs: server.forwardClientLogs === true,
   };
 }
 
@@ -125,6 +125,7 @@ export function buildRnDevServerInput(opts, config) {
     symbolicator: symbolicator.customizeFrame
       ? { customizeFrame: symbolicator.customizeFrame }
       : undefined,
+    ...(server.hmr === false ? { hmr: false } : {}),
     ...(terminalActions === false ? { terminalActions: false } : {}),
   };
 }

--- a/packages/core/bin/zts.test.ts
+++ b/packages/core/bin/zts.test.ts
@@ -5217,7 +5217,7 @@ describe('buildRnDevServerInput — config + opts 추출 (#2605)', () => {
     expect(b?.terminalActions).toBe(false);
   });
 
-  test('미지원 필드 (transformer.inlineRequires/minifier, serializer.prelude/bundleType, server.forwardClientLogs/verifyConnections) — stderr 경고', async () => {
+  test('미지원 필드 (transformer.inlineRequires/minifier, serializer.bundleType, server.verifyConnections) — stderr 경고', async () => {
     const { buildRnDevServerInput } = await import('./rn-dev-input.mjs');
     const original = process.stderr.write.bind(process.stderr);
     const writes: string[] = [];
@@ -5242,13 +5242,23 @@ describe('buildRnDevServerInput — config + opts 추출 (#2605)', () => {
     expect(all).toContain('transformer.inlineRequires');
     expect(all).toContain('transformer.minifier');
     expect(all).toContain('serializer.bundleType');
-    expect(all).toContain('server.forwardClientLogs');
     expect(all).toContain('server.verifyConnections');
     // transformer.babel / serializer.prelude / serializer.inlineSourceMap 는
     // 매핑 가능해서 경고 없음.
     expect(all).not.toContain('transformer.babel');
     expect(all).not.toContain('serializer.prelude');
     expect(all).not.toContain('serializer.inlineSourceMap');
+    expect(all).not.toContain('server.forwardClientLogs');
+  });
+
+  test('config.server.forwardClientLogs / hmr → dev server input 매핑', async () => {
+    const { buildRnDevServerInput } = await import('./rn-dev-input.mjs');
+    const input = buildRnDevServerInput(
+      { entryPoints: ['i.js'] },
+      { server: { forwardClientLogs: true, hmr: false } },
+    );
+    expect(input?.bundle.extra?.forwardClientLogs).toBe(true);
+    expect(input?.hmr).toBe(false);
   });
 
   test('미지원 필드 0 — stderr 경고 0 출력', async () => {

--- a/packages/react-native/runtime/zts-hmr-client.js
+++ b/packages/react-native/runtime/zts-hmr-client.js
@@ -22,6 +22,7 @@ function getDevLoadingView() {
 var HMRClient = {
   _socket: null,
   _enabled: true,
+  _originalConsole: null,
   // Metro 처럼 중첩 update 를 카운트 — 마지막 update-done 에서만 배너 hide.
   _pendingUpdates: 0,
 
@@ -69,42 +70,48 @@ var HMRClient = {
         }),
       );
 
-      // Intercept console methods to forward logs to dev server terminal
-      var levels = ['log', 'info', 'warn', 'error', 'debug'];
-      for (var i = 0; i < levels.length; i++) {
-        (function (level) {
-          var original = console[level];
-          if (typeof original === 'function') {
-            console[level] = function () {
-              // Call original first
-              original.apply(console, arguments);
-              // Forward to server
-              if (socket.readyState === 1) {
-                try {
-                  var args = [];
-                  for (var j = 0; j < arguments.length; j++) {
-                    var arg = arguments[j];
-                    // Serialize safely — avoid circular references
-                    if (arg instanceof Error) {
-                      args.push(arg.message);
-                    } else if (typeof arg === 'object' && arg !== null) {
-                      try {
-                        args.push(JSON.parse(JSON.stringify(arg)));
-                      } catch (_e) {
-                        args.push(String(arg));
+      var forwardClientLogs =
+        typeof __ZTS_FORWARD_CLIENT_LOGS__ !== 'undefined' ? __ZTS_FORWARD_CLIENT_LOGS__ : false;
+      if (forwardClientLogs === true && self._originalConsole == null) {
+        self._originalConsole = {};
+        // Intercept console methods to forward logs to dev server terminal.
+        var levels = ['log', 'info', 'warn', 'error', 'debug'];
+        for (var i = 0; i < levels.length; i++) {
+          (function (level) {
+            var original = console[level];
+            if (typeof original === 'function') {
+              self._originalConsole[level] = original;
+              console[level] = function () {
+                // Call original first
+                original.apply(console, arguments);
+                // Forward to server
+                if (socket.readyState === 1) {
+                  try {
+                    var args = [];
+                    for (var j = 0; j < arguments.length; j++) {
+                      var arg = arguments[j];
+                      // Serialize safely — avoid circular references
+                      if (arg instanceof Error) {
+                        args.push(arg.message);
+                      } else if (typeof arg === 'object' && arg !== null) {
+                        try {
+                          args.push(JSON.parse(JSON.stringify(arg)));
+                        } catch (_e) {
+                          args.push(String(arg));
+                        }
+                      } else {
+                        args.push(arg);
                       }
-                    } else {
-                      args.push(arg);
                     }
+                    socket.send(JSON.stringify({ type: 'log', level: level, data: args }));
+                  } catch (_e) {
+                    // ignore serialization errors
                   }
-                  socket.send(JSON.stringify({ type: 'log', level: level, data: args }));
-                } catch (_e) {
-                  // ignore serialization errors
                 }
-              }
-            };
-          }
-        })(levels[i]);
+              };
+            }
+          })(levels[i]);
+        }
       }
     };
 

--- a/packages/react-native/src/dev-server/routes/bundle.test.ts
+++ b/packages/react-native/src/dev-server/routes/bundle.test.ts
@@ -153,6 +153,10 @@ describe('handleBundleRequest', () => {
     );
     expect(res.statusCode).toBe(200);
     expect(res.headers!['Content-Type']).toBe('application/javascript; charset=UTF-8');
+    expect(res.headers!['Cache-Control']).toBe(
+      'no-store, no-cache, must-revalidate, proxy-revalidate',
+    );
+    expect(res.headers!['Pragma']).toBe('no-cache');
     expect(res.headers!['X-React-Native-Project-Root']).toBe('/proj');
     const body = res.chunks.join('');
     expect(body).toContain('console.log(1);');
@@ -175,6 +179,9 @@ describe('handleBundleRequest', () => {
     );
     expect(res.statusCode).toBe(200);
     expect(res.headers!['Content-Type'] as string).toContain('multipart/mixed');
+    expect(res.headers!['Cache-Control']).toBe(
+      'no-store, no-cache, must-revalidate, proxy-revalidate',
+    );
     const all = res.chunks.join('');
     expect(all).toContain('{"done":3,"total":3}');
     expect(all).toContain('X-Metro-Files-Changed-Count: 3');
@@ -273,6 +280,9 @@ describe('handleMapRequest', () => {
     );
     expect(res.statusCode).toBe(200);
     expect(res.headers!['Content-Type']).toBe('application/json');
+    expect(res.headers!['Cache-Control']).toBe(
+      'no-store, no-cache, must-revalidate, proxy-revalidate',
+    );
     expect(JSON.parse(res.chunks.join('')).version).toBe(3);
   });
 
@@ -294,7 +304,15 @@ describe('handleMapRequest', () => {
 describe('handleHmrMapRequest', () => {
   test('module 매치 → 200 + JSON', () => {
     const state = makeState({
-      handle: fakeHandle({ hmrMaps: { 'src/x.ts': '{"v":3,"id":"x"}' } }),
+      handle: fakeHandle({
+        hmrMaps: {
+          'src/x.ts': JSON.stringify({
+            version: 3,
+            id: 'x',
+            sources: ['src/x.ts', '/node_modules/react/index.js'],
+          }),
+        },
+      }),
     });
     const registry = fixedRegistry(state);
     const res = makeRes();
@@ -306,7 +324,13 @@ describe('handleHmrMapRequest', () => {
       'ios',
     );
     expect(res.statusCode).toBe(200);
-    expect(res.chunks.join('')).toContain('"id":"x"');
+    expect(res.headers!['Cache-Control']).toBe(
+      'no-store, no-cache, must-revalidate, proxy-revalidate',
+    );
+    const body = JSON.parse(res.chunks.join(''));
+    expect(body.id).toBe('x');
+    expect(body.x_google_ignoreList).toEqual([1]);
+    expect(body.ignoreList).toBeUndefined();
   });
 
   test('module 미매치 → 404', () => {

--- a/packages/react-native/src/dev-server/routes/bundle.ts
+++ b/packages/react-native/src/dev-server/routes/bundle.ts
@@ -8,11 +8,18 @@ import * as jscSafeUrl from 'jsc-safe-url';
 
 import { sendText } from '../http-utils.ts';
 import { getCachedSourceMap, type PlatformStateRegistry, waitForBuild } from '../platform-state.ts';
+import { postProcessSourceMap } from '../sourcemap.ts';
 import { resolvePlatform } from './_shared.ts';
 
 const HMR_MAP_PREFIX = '/__zts_hmr_map/';
 const MULTIPART_BOUNDARY = '3beqjf3apnqeu3h5jqorms4i';
 const CRLF = '\r\n';
+const METRO_NO_STORE_HEADERS = {
+  'Surrogate-Control': 'no-store',
+  'Cache-Control': 'no-store, no-cache, must-revalidate, proxy-revalidate',
+  Pragma: 'no-cache',
+  Expires: '0',
+};
 
 export function isBundleRoute(pathname: string): boolean {
   return pathname.endsWith('.bundle') || pathname.endsWith('.bundle.js');
@@ -65,7 +72,7 @@ export async function handleBundleRequest(
   if (req.headers.accept === 'multipart/mixed') {
     res.writeHead(200, {
       'Content-Type': `multipart/mixed; boundary="${MULTIPART_BOUNDARY}"`,
-      'Cache-Control': 'no-cache',
+      ...METRO_NO_STORE_HEADERS,
       'X-React-Native-Project-Root': projectRoot,
     });
     res.write('If you are seeing this, your client does not support multipart response');
@@ -90,9 +97,10 @@ export async function handleBundleRequest(
   }
 
   res.writeHead(200, {
+    'X-Content-Type-Options': 'nosniff',
+    ...METRO_NO_STORE_HEADERS,
     'Content-Type': 'application/javascript; charset=UTF-8',
     'Content-Length': Buffer.byteLength(bundle),
-    'Cache-Control': 'no-cache',
     'X-React-Native-Project-Root': projectRoot,
     'Content-Location': bundleUrl,
   });
@@ -113,11 +121,11 @@ export function handleMapRequest(
     return;
   }
   res.writeHead(200, {
+    'X-Content-Type-Options': 'nosniff',
+    ...METRO_NO_STORE_HEADERS,
     'Content-Type': 'application/json',
     'Content-Length': Buffer.byteLength(json),
     'Access-Control-Allow-Origin': 'devtools://devtools',
-    'X-Content-Type-Options': 'nosniff',
-    'Cache-Control': 'no-cache',
   });
   res.end(json);
 }
@@ -131,17 +139,18 @@ export function handleHmrMapRequest(
 ): void {
   const state = resolvePlatform(url, registry, defaultPlatform);
   const moduleId = decodeURIComponent(url.pathname.slice(HMR_MAP_PREFIX.length));
-  const json = state.handle.getHmrSourceMap(moduleId);
-  if (!json) {
+  const rawJson = state.handle.getHmrSourceMap(moduleId);
+  if (!rawJson) {
     sendText(res, 404, 'HMR source map not found');
     return;
   }
+  const json = postProcessSourceMap(rawJson);
   res.writeHead(200, {
+    'X-Content-Type-Options': 'nosniff',
+    ...METRO_NO_STORE_HEADERS,
     'Content-Type': 'application/json',
     'Content-Length': Buffer.byteLength(json),
     'Access-Control-Allow-Origin': 'devtools://devtools',
-    'X-Content-Type-Options': 'nosniff',
-    'Cache-Control': 'no-cache',
   });
   res.end(json);
 }

--- a/packages/react-native/src/dev-server/sourcemap.test.ts
+++ b/packages/react-native/src/dev-server/sourcemap.test.ts
@@ -24,16 +24,32 @@ describe('postProcessSourceMap', () => {
     });
     const out = JSON.parse(postProcessSourceMap(input));
     expect(out.x_google_ignoreList).toEqual([1]);
+    expect(out.ignoreList).toBeUndefined();
   });
 
-  test('기존 x_google_ignoreList 보존 + node_modules 추가 (sort + dedup)', () => {
+  test('Metro 호환 — dev-server sourcemap 에서 file 과 기본 빈 sourceRoot 제거', () => {
     const input = JSON.stringify({
       version: 3,
-      sources: ['polyfill.js', 'src/app.ts', '/node_modules/react/index.js'],
-      x_google_ignoreList: [0],
+      file: '/tmp/zts-rn-ios/bundle.js',
+      sourceRoot: '',
+      sources: ['src/app.ts', '/node_modules/react/index.js'],
     });
     const out = JSON.parse(postProcessSourceMap(input));
-    expect(out.x_google_ignoreList).toEqual([0, 2]);
+    expect(out.file).toBeUndefined();
+    expect(out.sourceRoot).toBeUndefined();
+    expect(out.x_google_ignoreList).toEqual([1]);
+  });
+
+  test('기존 ignore hint input 소비 + node_modules 추가 (sort + dedup)', () => {
+    const input = JSON.stringify({
+      version: 3,
+      sources: ['polyfill.js', 'src/app.ts', '/node_modules/react/index.js', 'zts:runtime/foo'],
+      x_google_ignoreList: [0],
+      ignoreList: [3],
+    });
+    const out = JSON.parse(postProcessSourceMap(input));
+    expect(out.x_google_ignoreList).toEqual([0, 2, 3]);
+    expect(out.ignoreList).toBeUndefined();
   });
 
   test('중복 인덱스 dedup', () => {
@@ -44,6 +60,7 @@ describe('postProcessSourceMap', () => {
     });
     const out = JSON.parse(postProcessSourceMap(input));
     expect(out.x_google_ignoreList).toEqual([0]);
+    expect(out.ignoreList).toBeUndefined();
   });
 
   test('non-string source 항목 무시', () => {
@@ -59,9 +76,10 @@ describe('postProcessSourceMap', () => {
     const input = JSON.stringify({ version: 3, sources: ['src/app.ts'] });
     const out = JSON.parse(postProcessSourceMap(input));
     expect('x_google_ignoreList' in out).toBe(false);
+    expect('ignoreList' in out).toBe(false);
   });
 
-  test('zts internal source (`zts:` prefix) — DevTools ignoreList 에 추가 (#2605)', () => {
+  test('zts internal source (`zts:` prefix) — x_google_ignoreList 에 추가 (#2605)', () => {
     const input = JSON.stringify({
       version: 3,
       sources: ['src/app.ts', 'zts:runtime/spread-array', 'zts:runtime/class-call-check'],
@@ -89,7 +107,7 @@ describe('postProcessSourceMap', () => {
     expect(out.x_google_ignoreList).toEqual([1, 2]);
   });
 
-  test('node_modules + zts internal 혼재 — 둘 다 ignoreList', () => {
+  test('node_modules + zts internal 혼재 — 둘 다 x_google_ignoreList', () => {
     const input = JSON.stringify({
       version: 3,
       sources: [
@@ -102,10 +120,25 @@ describe('postProcessSourceMap', () => {
     const out = JSON.parse(postProcessSourceMap(input));
     expect(out.x_google_ignoreList).toEqual([1, 2, 3]);
   });
+
+  test('Metro ignore 기준 — __prelude__ / ?ctx= / node_modules', () => {
+    const input = JSON.stringify({
+      version: 3,
+      sources: [
+        '__prelude__',
+        'src/app.ts',
+        '/abs/project/app?ctx=src',
+        'node_modules/react/index.js',
+        'src/node_modules_like/file.ts',
+      ],
+    });
+    const out = JSON.parse(postProcessSourceMap(input));
+    expect(out.x_google_ignoreList).toEqual([0, 2, 3]);
+  });
 });
 
 describe('postProcessSourceMap — path 옵션 통합 (#2605 audit P2)', () => {
-  test('opts 없음 — ignoreList 만 (backward-compat)', () => {
+  test('opts 없음 — x_google_ignoreList 만 유지', () => {
     const raw = JSON.stringify({
       version: 3,
       sources: ['src/app.ts', '/node_modules/x/y.js'],
@@ -115,7 +148,7 @@ describe('postProcessSourceMap — path 옵션 통합 (#2605 audit P2)', () => {
     expect(out.sourceRoot).toBeUndefined();
   });
 
-  test('ignoreList + sourceRoot 동시 — round-trip 1회', () => {
+  test('x_google_ignoreList + sourceRoot 동시 — round-trip 1회', () => {
     const raw = JSON.stringify({
       version: 3,
       sources: ['src/app.ts', '/node_modules/x/y.js'],
@@ -125,7 +158,7 @@ describe('postProcessSourceMap — path 옵션 통합 (#2605 audit P2)', () => {
     expect(out.sourceRoot).toBe('/abs/proj');
   });
 
-  test('ignoreList + useAbsolutePath — virtual module skip + framework 표시', () => {
+  test('x_google_ignoreList + useAbsolutePath — virtual module skip + framework 표시', () => {
     const NUL = String.fromCharCode(0);
     const raw = JSON.stringify({
       version: 3,

--- a/packages/react-native/src/dev-server/sourcemap.ts
+++ b/packages/react-native/src/dev-server/sourcemap.ts
@@ -1,5 +1,5 @@
 // zts sourcemap 후처리 — DevTools 의 x_google_ignoreList 확장 + production
-// bundle 의 sourceRoot / 절대 경로 옵션. zts 가 emit 한 기존 ignoreList 항목
+// bundle 의 sourceRoot / 절대 경로 옵션. zts 가 emit 한 기존 ignore hint 항목
 // 보존 + node_modules + zts internal source (zts: prefix — runtime polyfill /
 // babel transform 등) 추가. 잘못된 JSON 이면 rawJson 반환 (caller 가 빈 응답 회피).
 
@@ -26,13 +26,23 @@ function isVirtualSource(stripped: string): boolean {
 
 /**
  * source string 이 user code 가 아닌 framework / polyfill 영역인지 판정.
+ * Metro `Server._shouldAddModuleToIgnoreList` 기준:
+ * - `__prelude__`
+ * - `?ctx=` context module
+ * - serializer.isThirdPartyModule 기본값인 node_modules path
+ *
  * `zts:` prefix 는 NAPI emitter 의 internal source naming 과 sync — 변경 시
  * zts core (Zig 측 emitter) 와 함께 업데이트 필요.
  */
 function isFrameworkSource(src: unknown): boolean {
   if (typeof src !== 'string') return false;
   const stripped = stripVirtualPrefix(src);
-  return stripped.includes('/node_modules/') || stripped.startsWith('zts:');
+  return (
+    stripped === '__prelude__' ||
+    stripped.includes('?ctx=') ||
+    /(?:^|[/\\])node_modules[/\\]/.test(stripped) ||
+    stripped.startsWith('zts:')
+  );
 }
 
 export interface SourcemapPathOptions {
@@ -55,18 +65,38 @@ export function postProcessSourceMap(rawJson: string, pathOpts?: SourcemapPathOp
     const map = JSON.parse(rawJson);
     if (map.version !== 3 || !map.sources) return rawJson;
 
-    // (1) x_google_ignoreList — 기존 보존 + framework source 추가.
+    // (1) Metro-compatible map shape.
+    // zts core 는 library/file output 을 위해 `file` 과 빈 `sourceRoot` 를 emit 한다.
+    // RN DevTools 는 loaded script URL (`index.bundle?...`) 을 기준으로 blackbox 처리를
+    // 하므로, dev-server map 에서는 Metro 처럼 `file` 을 생략한다. sourceRoot 도
+    // 사용자가 명시하지 않은 빈 값이면 생략해 Metro 기본값과 맞춘다.
+    delete map.file;
+    if (pathOpts?.sourceRoot === undefined && map.sourceRoot === '') {
+      delete map.sourceRoot;
+    }
+
+    // (2) x_google_ignoreList — 기존 보존 + framework source 추가.
+    // Metro-source-map Generator 는 legacy `x_google_ignoreList` 만 직렬화한다.
+    // RN DevTools 는 `ignoreList ?? x_google_ignoreList` 순서로 읽기 때문에,
+    // Metro shape 과 맞추기 위해 output 에서는 standard `ignoreList` 를 제거한다.
     const existing = new Set<number>(
-      Array.isArray(map.x_google_ignoreList) ? map.x_google_ignoreList : [],
+      [
+        ...(Array.isArray(map.x_google_ignoreList) ? map.x_google_ignoreList : []),
+        ...(Array.isArray(map.ignoreList) ? map.ignoreList : []),
+      ].filter((v): v is number => Number.isInteger(v) && v >= 0),
     );
     for (let i = 0; i < map.sources.length; i++) {
       if (isFrameworkSource(map.sources[i])) existing.add(i);
     }
     if (existing.size > 0) {
-      map.x_google_ignoreList = [...existing].sort((a, b) => a - b);
+      const ignoreList = [...existing].sort((a, b) => a - b);
+      map.x_google_ignoreList = ignoreList;
+    } else {
+      delete map.x_google_ignoreList;
     }
+    delete map.ignoreList;
 
-    // (2) path 옵션 (Metro 호환) — sourceRoot field + sources 절대화.
+    // (3) path 옵션 (Metro 호환) — sourceRoot field + sources 절대화.
     if (pathOpts) {
       if (pathOpts.sourceRoot !== undefined) {
         map.sourceRoot = pathOpts.sourceRoot;

--- a/packages/react-native/src/plugins/asset.test.ts
+++ b/packages/react-native/src/plugins/asset.test.ts
@@ -44,7 +44,16 @@ describe('createAssetPlugin', () => {
     expect(hmrHandler.filter.test('/abs/foo.ts')).toBe(false);
 
     const result = hmrHandler.handler({ path: '/abs/Libraries/Utilities/HMRClient.js' });
-    expect(result).toEqual({ contents: ZTS_HMR_CLIENT_CODE });
+    expect(result).toEqual({
+      contents: ZTS_HMR_CLIENT_CODE.replace(/__ZTS_FORWARD_CLIENT_LOGS__/g, 'false'),
+    });
+  });
+
+  test('forwardClientLogs=true — HMR runtime flag true 로 치환', () => {
+    const handlers = captureHandlers({ ...baseConfig, forwardClientLogs: true });
+    const result = handlers[0]!.handler({ path: '/abs/Libraries/Utilities/HMRClient.js' });
+    expect(result?.contents).toContain('typeof true');
+    expect(result?.contents).not.toContain('__ZTS_FORWARD_CLIENT_LOGS__');
   });
 
   test('babelTransformerPath 미지정 — HMRClient.js handler 만 등록 (custom transformer 없음)', () => {

--- a/packages/react-native/src/plugins/asset.ts
+++ b/packages/react-native/src/plugins/asset.ts
@@ -40,7 +40,10 @@ export function createAssetPlugin(config: PluginConfig): ZtsPlugin {
       // HMRClient.js path 매칭 — onLoad 응답으로 ZTS_HMR_CLIENT_CODE 그대로.
       const hmrClientPattern = new RegExp(`${escapeRegex(HMR_CLIENT_SUFFIX)}$`);
       build.onLoad({ filter: hmrClientPattern }, () => ({
-        contents: ZTS_HMR_CLIENT_CODE,
+        contents: ZTS_HMR_CLIENT_CODE.replace(
+          /__ZTS_FORWARD_CLIENT_LOGS__/g,
+          config.forwardClientLogs === true ? 'true' : 'false',
+        ),
       }));
 
       if (config.babelTransformerPath) {

--- a/packages/react-native/src/plugins/babel.ts
+++ b/packages/react-native/src/plugins/babel.ts
@@ -231,6 +231,10 @@ export function createBabelTransformer(
       babelrc: false,
       configFile: false,
       compact: false,
+      // Plugin 결과 sourcemap compose 는 아직 core transform hook 에 연결되어 있지 않다.
+      // Metro/Bungae 처럼 라인 구조를 유지해야 DevTools x_google_ignoreList 가 console.js 를
+      // 건너뛴 뒤 사용자 소스 프레임으로 올라갈 수 있다.
+      retainLines: true,
       sourceMaps: false,
     };
 

--- a/packages/react-native/src/plugins/internal.ts
+++ b/packages/react-native/src/plugins/internal.ts
@@ -24,6 +24,7 @@ export interface BabelTransformOptions {
   babelrc?: boolean;
   configFile?: boolean;
   compact?: boolean;
+  retainLines?: boolean;
   sourceMaps?: boolean;
   parserOpts?: { plugins?: string[] };
 }

--- a/packages/react-native/src/plugins/types.ts
+++ b/packages/react-native/src/plugins/types.ts
@@ -18,6 +18,8 @@ export interface PluginConfig {
   sourceExts: string[];
   /** Metro 호환 custom file transformer path (예: react-native-svg-transformer). */
   babelTransformerPath?: string;
+  /** RN runtime console.* forwarding to dev-server terminal. */
+  forwardClientLogs?: boolean;
   /**
    * Inline babel preset / plugin (zts.config.ts 의 `transformer.babel`). 사용자
    * babel.config.js 의 plugins 와 concat 되며 양쪽 모두 ZTS native filter 통과

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -124,6 +124,12 @@ export interface RnBundleInput {
      * `withExpo()`) 가 환경 감지 후 패턴 주입.
      */
     silentConsoleErrorPatterns?: string[];
+    /**
+     * Metro `server.forwardClientLogs` 호환. true면 RN runtime console.* 를 dev
+     * server 터미널로 forwarding. 기본 false — RN 내부/devtool 로그 직렬화가 앱
+     * 메모리를 계속 늘리는 시나리오를 피한다.
+     */
+    forwardClientLogs?: boolean;
   };
   /** RN prelude 끝에 append 할 사용자 banner string. */
   bannerExtras?: string;
@@ -319,6 +325,7 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
       rnPlatform,
       sourceExts,
       babelTransformerPath: extra?.babelTransformerPath,
+      forwardClientLogs: extra?.forwardClientLogs,
     }),
     createCodegenPlugin({
       projectRoot,

--- a/packages/react-native/src/runtime/zts-hmr-client.test.mjs
+++ b/packages/react-native/src/runtime/zts-hmr-client.test.mjs
@@ -19,6 +19,7 @@ function loadHmrClient(globalEnv) {
     var __zts_reload = arguments[5];
     var location = arguments[6];
     var window = arguments[7];
+    var __ZTS_FORWARD_CLIENT_LOGS__ = arguments[8];
     ${HMR_CLIENT_SOURCE}
     return module.exports;
   `;
@@ -32,6 +33,7 @@ function loadHmrClient(globalEnv) {
     globalEnv.__zts_reload,
     globalEnv.location,
     globalEnv.window,
+    globalEnv.forwardClientLogs,
   );
 }
 
@@ -94,6 +96,7 @@ beforeEach(() => {
     __zts_reload: mockGlobal.__zts_reload,
     location: { reload: mock(() => {}) },
     window: undefined,
+    forwardClientLogs: true,
   });
 });
 
@@ -171,6 +174,25 @@ describe('onopen — hmr:connected + console wrap', () => {
     expect(log.type).toBe('log');
     expect(log.level).toBe('log');
     expect(log.data).toEqual(['hello']);
+  });
+
+  test('forwardClientLogs=false — console wrap 하지 않음', () => {
+    HMRClient = loadHmrClient({
+      global: mockGlobal,
+      WebSocket: MockWebSocket,
+      console: mockConsole,
+      __zts_apply_update: mockGlobal.__zts_apply_update,
+      __zts_reload: mockGlobal.__zts_reload,
+      location: { reload: mock(() => {}) },
+      window: undefined,
+      forwardClientLogs: false,
+    });
+    HMRClient.setup('ios', '/abs/idx.js', 'localhost', 8081, true, 'http');
+    const ws = MockWebSocket.instances[0];
+    ws.onopen();
+    mockConsole.log('hello');
+    expect(originalConsole.log).toHaveBeenCalledWith('hello');
+    expect(ws.sent.length).toBe(1);
   });
 
   test('Error object 는 message 만 send', () => {

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1074,8 +1074,14 @@ pub const Bundler = struct {
                 std.log.err("zts: cannot read polyfill file '{s}': {}", .{ poly_path, err });
                 continue;
             };
+            const basename = std.fs.path.basename(poly_path);
             // Flow 모드일 때 트랜스파일하여 타입 구문 제거 (RN 폴리필은 Flow로 작성됨)
-            const content = if (self.options.flow) blk: {
+            //
+            // RN console.js 는 @noflow 이며 DevTools console callsite 의 기준 파일이다.
+            // 이를 변환하면 하단 originalConsole bridge 의 generated line 이 원본 line 과
+            // 어긋나 `console.js:<generated>` 로 노출된다. 원본이 JS 문법으로 parse 가능하므로
+            // 그대로 두고 identity sourcemap 을 유지한다.
+            const content = if (self.options.flow and !std.mem.eql(u8, basename, "console.js")) blk: {
                 const result = transpile_mod.transpile(self.allocator, raw, poly_path, .{
                     .flow = true,
                     .jsx_in_js = self.options.jsx_in_js,
@@ -1088,7 +1094,7 @@ pub const Bundler = struct {
                 break :blk result.code;
             } else raw;
             try polyfill_entries.append(self.allocator, .{
-                .name = std.fs.path.basename(poly_path),
+                .name = basename,
                 .content = content,
                 .path = try self.allocator.dupe(u8, poly_path),
             });


### PR DESCRIPTION
## 요약
- RN dev-server sourcemap 을 Metro 형태에 맞춰 `file`/기본 빈 `sourceRoot` 를 제거하고, 최종 출력은 `x_google_ignoreList` 만 사용하도록 정리했습니다.
- Metro 기준의 ignore 대상(`__prelude__`, `?ctx=`, `node_modules`)과 ZTS runtime source를 함께 반영하고, bundle/map/HMR map 응답에 no-store 헤더를 추가했습니다.
- DevTools console callsite 가 `console.js` 에 머무르지 않도록 RN `console.js` polyfill 변환을 건너뛰고 Babel transform 라인 구조를 보존했습니다.
- HMR client console forwarding 은 `server.forwardClientLogs` 옵션으로 명시 opt-in 하도록 바꿨습니다.

## 테스트
- `bun test packages/react-native/src/dev-server/routes/bundle.test.ts packages/react-native/src/dev-server/sourcemap.test.ts packages/react-native/src/plugins/babel.test.ts packages/react-native/src/preset.test.ts packages/react-native/src/plugins/asset.test.ts packages/react-native/src/runtime/zts-hmr-client.test.mjs --timeout 30000`
- `bun test packages/core/bin/zts.test.ts -t "buildRnDevServerInput" --timeout 30000`
- `git diff --check`
- `bun run --cwd packages/react-native build`
- `zig build napi`

참고: `packages/core/bin/zts.test.ts` 전체 실행은 현재 테스트 fixture에서 `@zts/web` 패키지를 찾지 못하는 기존 조건 때문에 관련 없는 app builder 케이스들이 실패해, 이번 변경 범위인 `buildRnDevServerInput` 필터 테스트로 검증했습니다.