### PR TITLE
chore(docs): 번개(bungae) 참조 정리 — archive 후 deprecated

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,16 +27,6 @@ Zig 0.15.2 · C NAPI v8 (vendor/node-api-headers/) · Node.js 24+ / Bun 1.3+ · 
 7. PR 본문, GitHub 이슈/PR 댓글, 리뷰 답변은 한국어로 작성
 8. Zig 초보자에게 설명 포함
 
-## 외부 Consumer 동기화
-- **bungae monorepo** (`/Users/yoonhb/Documents/workspace/bungae/`) 가 ZTS 를 git submodule 로 참조. `.gitmodules` 에 branch 추적 없어서 ZTS 머지 후 수동 sync 필요:
-  ```bash
-  cd /Users/yoonhb/Documents/workspace/bungae && git submodule update --remote zts
-  cd zts && zig build napi && cp zig-out/lib/zts.node packages/core/zts.node
-  cd packages/core && bun build index.ts --outdir dist --format esm --target bun
-  ```
-- 번개에서 HMR 실측 전에는 반드시 submodule update 먼저 — drift 상태면 최신 profile 측정점/NAPI 변경이 반영 안 됨
-- 근본 해결(bungae 측): `.gitmodules` 에 `branch = main` + postinstall 에 `git submodule update --remote` 추가 (별도 bungae PR 필요)
-
 ## Memory ownership
 - **Arena 안 리소스는 개별 deinit 금지**. `arena_alloc`으로 만든 `DynamicBitSet`/`ArrayList` 등은 `arena.deinit()`이 일괄 해제. 개별 `defer X.deinit()`을 함께 걸면 `arena.deinit()` 이후에 실행되어 해제된 메모리 접근 → segfault (#1287).
 - 성공 경로에서 `arena.deinit()`을 명시 호출하지 말 것. `defer arena.deinit()` 하나로 충분.

--- a/docs/DEBUG.md
+++ b/docs/DEBUG.md
@@ -21,7 +21,7 @@ ZTS 는 두 가지 경량 인프라를 제공한다:
 
 ```bash
 ZTS_DEBUG=compiled_cache zts --bundle entry.ts
-ZTS_DEBUG=compiled_cache,hmr bun run bungae:start
+ZTS_DEBUG=compiled_cache,hmr zts --watch entry.ts
 ```
 
 쉼표 구분. 공백과 대소문자 무시. 알 수 없는 이름은 조용히 무시된다.
@@ -178,7 +178,7 @@ transpile(source, {
 
 ```bash
 ZTS_PROFILE=all ZTS_PROFILE_LEVEL=detailed zts bundle entry.ts
-BUNGAE_HMR_PROFILE=1 bun run start:bungae    # 내부적으로 ZTS_PROFILE=hmr 매핑
+ZTS_PROFILE=hmr zts --watch entry.ts
 ```
 
 ## 2.2 카테고리
@@ -332,7 +332,7 @@ HMR rebuild 의 각 phase 는 `WatchRebuildEvent.phaseDurations` 에 노출.
 - `detect` / `graph` / `link` / `shake` / `emit` / `delta` / `total`
 - 필드 이름과 실제 값이 일치. 2026-04-22 이전의 `parse`/`semantic` 레거시 이름은 제거됨.
 
-Sub-phase (`ZTS_PROFILE=<cat>` / `BUNGAE_HMR_PROFILE=1` 활성 시):
+Sub-phase (`ZTS_PROFILE=<cat>` 활성 시):
 
 - 파이프라인: `scan` / `parse` / `resolve` / `semantic` / `transform` / `codegen` / `metadata`
 - Graph 내부: `graphBuild` / `graphWorker` / `graphDiscover` (BFS 스캔) / `graphFinalize` (DFS+승격)
@@ -340,16 +340,7 @@ Sub-phase (`ZTS_PROFILE=<cat>` / `BUNGAE_HMR_PROFILE=1` 활성 시):
 - emit_output 내부 (emitter 수준): `emitPrelude` / `emitModulePass` / `emitConcat` / `emitSourcemapFinalize`
 - 비활성 상태에선 모두 0. `parse`/`semantic` 은 진짜 parser/analyzer 시간.
 
-## 4.1 번개 (bungae) HMR 실측
-
-```bash
-BUNGAE_HMR_PROFILE=1 bun run start:bungae
-# Rebuilt [ios] (1 files, 175ms) [detect=27 graph=65 link=3 shake=2 emit=67 delta=1]
-```
-
-번개는 `phaseDurations.*` 필드를 읽어 log formatting. ZTS 는 필드만 제공 — UI 는 번개 쪽 책임.
-
-## 4.2 profile 활성 후 세부 breakdown
+## 4.1 profile 활성 후 세부 breakdown
 
 ```ts
 import { watch } from '@zts/core';

--- a/docs/HMR.md
+++ b/docs/HMR.md
@@ -111,7 +111,7 @@ Dev 서버 + Hot Module Replacement 상세 설계 문서.
 ## HMR Profiling
 
 HMR rebuild 의 각 phase 소요시간은 `WatchRebuildEvent.phaseDurations` 에 노출된다.
-`ZTS_PROFILE=hmr` 또는 `BUNGAE_HMR_PROFILE=1` 활성 시 sub-phase breakdown 수집 가능.
+`ZTS_PROFILE=hmr` 활성 시 sub-phase breakdown 수집 가능.
 
 자세한 내용: [`docs/DEBUG.md`](./DEBUG.md) § 4 HMR Profile.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -147,7 +147,7 @@
 
 - **Runtime helper virtual module** (#1961, PR 1a~1h, 2026-04-26) — splitting + single-bundle 양쪽에서 helper 를 가상 모듈로 모델링 (`__esm`, `__commonJS` 등). HelperBit enum 화 (#1982) 등 후속 정리 5건.
 - **ESM external import preserve** (#1962, #1983) — bare external 을 `require()` 로 변환하지 않고 `import` 그대로 보존.
-- **Lazy sourcemap** (#1727 Phase B, 5 PR) — `serialize` 비용 29ms→0.22ms, NAPI HMR 183→162ms. ZTS 는 `sourceURL` / bungae 는 `sourceMappingURL` 분리.
+- **Lazy sourcemap** (#1727 Phase B, 5 PR) — `serialize` 비용 29ms→0.22ms, NAPI HMR 183→162ms. `sourceURL` 주석 분리 emit.
 - **Type-only import elision** (#1791, #1797 + 7 PR) — named 한정 + oxc-style Reference flags. for-of `let` closure capture fix + sentinel AST layout 수정 동반.
 - **Worker race safety** (#1779 에픽 7 PR) — `StableSegmentedList` 도입, std.SegmentedList.dynamic_segments race 근본 해결.
 - **Tree shaker statement-level symbol graph** (#1558, #1560-1562) — rolldown 방식 단일 소스. reference_count 는 mangler 전용으로 분리.

--- a/docs/design/profile-infrastructure.md
+++ b/docs/design/profile-infrastructure.md
@@ -16,7 +16,6 @@ ZTS 에는 여러 측정 도구가 독립적으로 존재한다:
 | `--timing` CLI | single-file transpile | `scan / parse / semantic / transform / codegen` 5단계 |
 | `BundleTimings` struct | bundle 모드 내부 | `graph_ns / link_ns / shake_ns / emit_ns` 4 field |
 | HMR `phaseDurations` | NAPI watch 이벤트 | `detect / graph / link / shake / emit / delta / total` + sub |
-| `BUNGAE_HMR_PROFILE=1` | 번개 opt-in 로그 | phase breakdown 한 줄 |
 
 ### 1.2 파편화의 문제
 
@@ -24,7 +23,7 @@ ZTS 에는 여러 측정 도구가 독립적으로 존재한다:
 2. **CLI ↔ NAPI 불일치**: `--timing` 은 single-file 만. NAPI watch 는 HMR 전용 포맷. 공통 출력 형식/옵션 없음.
 3. **Sub-phase 없음**: `emit 67ms` 안의 transform / codegen / metadata 비중 모름.
 4. **벤치마크 부재**: 특정 phase 만 반복 측정하는 도구가 없음. 최적화 전후 비교 수동.
-5. **활성화 방식 파편화**: `ZTS_DEBUG=`, `--timing`, `BUNGAE_HMR_PROFILE=1`, `BundleOptions.debug` 각각 다른 규칙.
+5. **활성화 방식 파편화**: `ZTS_DEBUG=`, `--timing`, `BundleOptions.debug` 각각 다른 규칙.
 
 ### 1.3 요구사항 (2026-04-22 합의)
 
@@ -250,10 +249,6 @@ ZTS_PROFILE=all zts bundle ...
 
 # Specific
 ZTS_PROFILE=parse,transform ZTS_PROFILE_LEVEL=detailed zts bundle ...
-
-# 번개 호환
-BUNGAE_HMR_PROFILE=1 npm run start:bungae
-# → 내부적으로 ZTS_PROFILE=hmr 매핑
 ```
 
 ### 2.6 출력 포맷
@@ -366,7 +361,7 @@ parse           42.3ms    31.8ms   -10.5ms   -24.8%   ✓ improved
 | **6** | Semantic + Graph + Bundler timer | 100 | 0.5일 |
 | **7** | Emitter + Transformer + Codegen timer + Release overhead benchmark | 150 | 1일 |
 | **8** | Linker + TreeShaker timer | 50 | 0.5일 |
-| **9** | HMR `phaseDurations` sub-phase 노출 + 번개 호환 | 150 | 1일 |
+| **9** | HMR `phaseDurations` sub-phase 노출 | 150 | 1일 |
 | **10** | Report formats (table/tree/json/csv) + `tests/benchmark/pipeline.ts` 업데이트 | 200 | 1일 |
 | **11** | 문서 (DEBUG/USAGE/HMR) + `zts help` 최종 + CLI↔NAPI parity 통합 테스트 | 300 | 1일 |
 
@@ -374,7 +369,7 @@ parse           42.3ms    31.8ms   -10.5ms   -24.8%   ✓ improved
 
 **마일스톤**:
 - **PR 5 완료 시점** (~5일): `zts bench --phase=parse` 로 **파서만 격리 측정 가능**
-- **PR 9 완료 시점** (~8일): HMR detailed breakdown 번개에서 실측 가능
+- **PR 9 완료 시점** (~8일): HMR detailed breakdown 외부 host 에서 실측 가능
 - **PR 11 완료**: 설계 완성
 
 ---

--- a/documents/src/content/docs/en/guides/dev-server.md
+++ b/documents/src/content/docs/en/guides/dev-server.md
@@ -302,7 +302,7 @@ Key fields on `WatchRebuildEvent`:
 | `delta` | HMR delta extraction. |
 | `total` | Sum of `detect` through `delta`. |
 
-Sub-phases (only populated when `profile: ["..."]` / `ZTS_PROFILE=...` / `BUNGAE_HMR_PROFILE=1` is active; 0 otherwise):
+Sub-phases (only populated when `profile: ["..."]` / `ZTS_PROFILE=...` is active; 0 otherwise):
 
 `scan` / `parse` / `resolve` / `semantic` / `transform` / `codegen` / `metadata` / `graphBuild` / `graphWorker` / `graphDiscover` / `graphFinalize` / `emitPolyfill` / `emitRefresh` / `emitOutput` / `emitMetafile` / `emitCss` / `emitPrelude` / `emitModulePass` / `emitConcat` / `emitSourcemapFinalize`.
 

--- a/documents/src/content/docs/guides/dev-server.md
+++ b/documents/src/content/docs/guides/dev-server.md
@@ -302,7 +302,7 @@ watch({
 | `delta` | HMR delta 추출. |
 | `total` | `detect` ~ `delta` 합산. |
 
-Sub-phase (`profile: ["..."]` / `ZTS_PROFILE=...` / `BUNGAE_HMR_PROFILE=1` 활성 시에만 채워짐, 비활성 시 0):
+Sub-phase (`profile: ["..."]` / `ZTS_PROFILE=...` 활성 시에만 채워짐, 비활성 시 0):
 
 `scan` / `parse` / `resolve` / `semantic` / `transform` / `codegen` / `metadata` / `graphBuild` / `graphWorker` / `graphDiscover` / `graphFinalize` / `emitPolyfill` / `emitRefresh` / `emitOutput` / `emitMetafile` / `emitCss` / `emitPrelude` / `emitModulePass` / `emitConcat` / `emitSourcemapFinalize`.
 


### PR DESCRIPTION
## 배경
[#2540](https://github.com/ohah/zts/issues/2540) epic 으로 번개(bungae) 가 archive 되고 RN 부분이 `@zts/react-native` 로 흡수됨. 저장소의 doc/instruction 안에 남아있던 번개 참조가 모두 stale 상태 — 일괄 제거.

## 변경

### `CLAUDE.md`
- `## 외부 Consumer 동기화` 섹션 통째 삭제 — bungae submodule sync 안내, NAPI 빌드 후 `cp zig-out/lib/zts.node packages/core/zts.node` 수동 흐름 등 더 이상 무의미

### `docs/DEBUG.md`
- bash 예시 `bun run bungae:start` → `zts --watch entry.ts` 로 일반화
- `BUNGAE_HMR_PROFILE=1 bun run start:bungae` → `ZTS_PROFILE=hmr zts --watch entry.ts` 로 일반화
- `## 4.1 번개 (bungae) HMR 실측` 섹션 삭제 (`Rebuilt [ios]` 출력 예시 + "UI 는 번개 쪽 책임" 안내)
- 후속 `## 4.2` → `## 4.1` 재번호

### `docs/HMR.md`
- `BUNGAE_HMR_PROFILE=1` alias 언급 제거 — `ZTS_PROFILE=hmr` 단독 활성 안내로 단순화

### `docs/ROADMAP.md`
- Lazy sourcemap 항목의 "ZTS 는 `sourceURL` / bungae 는 `sourceMappingURL` 분리" → "`sourceURL` 주석 분리 emit"

### `docs/design/profile-infrastructure.md`
- 표 행 ``\`BUNGAE_HMR_PROFILE=1\` | 번개 opt-in 로그`` 삭제
- "활성화 방식 파편화" 리스트에서 `BUNGAE_HMR_PROFILE=1` 토큰 제거
- `# 번개 호환` shell 블록 삭제
- PR 9 row 의 "+ 번개 호환" 제거
- "PR 9 완료 시점 — HMR detailed breakdown 번개에서 실측 가능" → "외부 host 에서 실측 가능"

### `documents/src/content/docs/guides/dev-server.md` + `en/guides/dev-server.md`
- sub-phase 활성 조건 `profile: ["..."]` / `ZTS_PROFILE=...` / `BUNGAE_HMR_PROFILE=1` → 마지막 토큰 제거 (한/영 양쪽)

## scope 분리

`BUNGAE_HMR_PROFILE` env var **alias 코드 자체** (`packages/core/src/napi_entry.zig:4140-4142` + `packages/core/index.ts:899` JSDoc + `packages/core/src/napi_entry.zig:2456` 주석) 는 NAPI 리빌드 영향이 있어 **별도 PR** 로 분리. 이 PR 은 doc-only.

추가로 `src/main.zig`, `src/transformer/minify.zig`, `src/transformer/plugins/rn_codegen_plugin_test.zig`, `tests/integration/tests/minify-orphan-dead-store.test.ts`, `tests/integration/tests/downlevel.test.ts`, examples/fixtures, packages/ 등 코드/테스트 안의 번개 언급도 후속 PR 로.

## 검증
- [x] `grep -rn "번개\|bungae" CLAUDE.md docs/ documents/src/content/` → 0 hits
- [x] `docs/DEBUG.md` 의 `## 4.1` 재번호 후 stale `## 4.2` 참조 없음
- [x] `docs/ROADMAP.md` line 150 자연스럽게 읽힘
- [x] `bun run fmt` 통과 (pre-push hook OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)