### PR TITLE
fix(emitter): minify_whitespace 가 export getter 에 적용되지 않던 문제

### DIFF
--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -535,11 +535,11 @@ pub fn emitEsmWrappedModule(
                                 break :blk renamed;
                         }
                         break :blk local_name;
-                    }, options.configurable_exports);
+                    }, options);
                 }
             }
             for (star_entries.items) |entry| {
-                try appendExportGetter(&wrapped, allocator, entry.name, entry.getter_value, options.configurable_exports);
+                try appendExportGetter(&wrapped, allocator, entry.name, entry.getter_value, options);
             }
 
             try wrapped.appendSlice(allocator, "});\n");
@@ -1031,15 +1031,18 @@ fn appendWrappedInitCall(
 }
 
 /// __export() 내부의 "name: () => value,\n" 한 줄을 출력한다.
-/// property 이름에 따옴표가 필요하면 자동으로 감싼다.
+/// `configurable_exports` 가 true 면 RN/Hermes 호환을 위해 arrow 대신
+/// function expression getter 사용 (this binding / inline cache 시맨틱 차이).
 fn appendExportGetter(
     buf: *std.ArrayList(u8),
     allocator: std.mem.Allocator,
     name: []const u8,
     value: []const u8,
-    es5: bool,
+    options: anytype,
 ) !void {
-    try buf.appendSlice(allocator, "\t");
+    const es5 = options.configurable_exports;
+    const min = options.minify_whitespace;
+    if (!min) try buf.appendSlice(allocator, "\t");
     if (needsPropertyQuote(name)) {
         try buf.appendSlice(allocator, "\"");
         try buf.appendSlice(allocator, name);
@@ -1048,13 +1051,13 @@ fn appendExportGetter(
         try buf.appendSlice(allocator, name);
     }
     if (es5) {
-        try buf.appendSlice(allocator, ": function() { return ");
+        try buf.appendSlice(allocator, if (min) ":function(){return " else ": function() { return ");
         try buf.appendSlice(allocator, value);
-        try buf.appendSlice(allocator, "; },\n");
+        try buf.appendSlice(allocator, if (min) "}," else "; },\n");
     } else {
-        try buf.appendSlice(allocator, ": () => ");
+        try buf.appendSlice(allocator, if (min) ":()=>" else ": () => ");
         try buf.appendSlice(allocator, value);
-        try buf.appendSlice(allocator, ",\n");
+        try buf.appendSlice(allocator, if (min) "," else ",\n");
     }
 }
 


### PR DESCRIPTION
## 배경
RN bundle Metro vs ZTS 측정 (rn-example-app, RN 0.83, production `--minify`) 중 발견.

```
Build time:  Metro 2.79s → ZTS 1.26s   (2.21x faster)
Bundle size: Metro 980K  → ZTS 1000K   (+2%)
```

ZTS 가 약간 큰 게 의문이라 분석. ZTS bundle 의 **줄당 평균 247 chars / Metro 1815 chars** (7.5x 더 많은 줄). 줄바꿈 / 탭 / 공백이 그대로 emit 되고 있었음.

원인 추적: `src/bundler/emitter/esm_wrap.zig` 의 `appendExportGetter` 가 raw 형식으로 출력:
- 858 개 leading tab (`\t`)
- 900 개 `; }` (semicolon + space + brace)
- 모든 콜론 / 화살표 주변 공백
- 줄당 1 newline

같은 파일의 다른 emit 사이트는 `options.minify_whitespace` 를 사용 중이었음 (line 466, 554, 580, 653, 681, 708 등) — 이 함수만 flag 누락.

## ES5 design 은 그대로 유지

`configurable_exports` (== ES5 path) 는 **의도적**:
- arrow 의 `this` lexical binding / `prototype` 부재가 RN/Hermes inline cache hidden class 에 영향
- function expression getter 가 `Object.defineProperty` 의 함수 실행 시맨틱과 호환

이 design 은 건드리지 않고, 직교한 whitespace 압축만 분기 추가.

## 변경

### `appendExportGetter` 시그니처
```zig
// Before
fn appendExportGetter(buf, allocator, name, value, es5: bool) !void
//                                                    ^^^^^^^^
//                                                    호출처가 options.configurable_exports 를 넘기는 misnomer

// After
fn appendExportGetter(buf, allocator, name, value, options: anytype) !void
//                                                    ^^^^^^^^^^^^^^^^
//                                                    options.configurable_exports + options.minify_whitespace
```

호출처 2곳 (`options.configurable_exports` 만 넘기던 곳) 을 `options` 통째 전달로 변경. 인자 sprawl + boolean-blindness 동시 해결.

### Emit 형식
| 모드 | Before | After |
|---|---|---|
| dev | `\tname: () => value,\n` | (그대로) |
| dev + es5 | `\tname: function() { return value; },\n` | (그대로) |
| min | `\tname: () => value,\n` | `name:()=>value,` |
| min + es5 | `\tname: function() { return value; },\n` | `name:function(){return value},` |

## 측정 (rn-example-app)

| | Before | After | 차이 |
|---|---|---|---|
| Bundle (raw) | 1,023,672 | 1,017,666 | **-6,006 bytes** |
| Bundle (gzip) | 273,287 | 272,898 | -389 bytes |
| RN/ESM 통합 테스트 | 194 pass | 194 pass | 회귀 없음 |

gzip 차이가 raw 보다 작은 이유: 반복되는 whitespace 가 gzip 압축률이 높아서. raw 6KB 차이가 gzip 으론 0.4KB.

## 검증

- [x] `bun test tests/bundle-smoke.test.ts tests/resolve-fallback.test.ts tests/asset-registry.test.ts tests/es5-rn.test.ts` — 194 pass / 회귀 없음
- [x] RN bundle 출력에 `: function() { return X; },\n` (raw) 패턴 사라짐 — `:function(){return X},` (compact) 로 정확히 대체
- [x] dev 모드 (`--minify` 미지정) 출력 변화 없음 — branch 가 minify_whitespace=false 시 기존 형식 유지
- [x] `bun run fmt` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)