### PR TITLE
feat(import-scanner): conditional_expression dead branch require strip

### DIFF
--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -173,7 +173,10 @@ fn collectDeadIfRanges(
 
     for (reachable) |ni| {
         const node = ast.nodes.items[ni];
-        if (node.tag != .if_statement) continue;
+        // if_statement: `if (__DEV__) require(...)` — dead branch 의 stmt
+        // conditional_expression: `__DEV__ ? requireA : requireB` — dead branch 의 expr
+        // 둘 다 동일한 `data.ternary` layout (a=cond, b=consequent, c=alternate).
+        if (node.tag != .if_statement and node.tag != .conditional_expression) continue;
         const parts = node.data.ternary;
         const known = evalToBoolean(ast, parts.a, defines) orelse continue;
         const dead_idx = if (known) parts.c else parts.b;

--- a/src/bundler/import_scanner_test.zig
+++ b/src/bundler/import_scanner_test.zig
@@ -504,6 +504,24 @@ test "CJS: define boolean으로 죽은 if 분기의 require는 스캔하지 않�
     try std.testing.expectEqualStrings("./prod-only", result.records[0].specifier);
 }
 
+test "CJS: define boolean으로 죽은 ternary 분기의 require는 스캔하지 않음" {
+    // RN core 의 `const X = __DEV__ ? require('./X-dev').default : require('./X-prod').default`
+    // 패턴 — ternary expression 의 dead branch require strip.
+    const alloc = std.testing.allocator;
+    const result = try parseAndExtractFullWithDefines(
+        alloc,
+        \\const X = __DEV__
+        \\  ? require('./dev-only').default
+        \\  : require('./prod-only').default;
+    ,
+        &.{.{ .key = "__DEV__", .value = "false" }},
+    );
+    defer alloc.free(result.records);
+
+    try std.testing.expectEqual(@as(usize, 1), result.records.len);
+    try std.testing.expectEqualStrings("./prod-only", result.records[0].specifier);
+}
+
 test "CJS: require with non-string argument ignored" {
     const alloc = std.testing.allocator;
     const result = try parseAndExtractFull(alloc, "const x = require(variable);");


### PR DESCRIPTION
## 배경

\`collectDeadIfRanges\` (import_scanner.zig:165) 가 \`if_statement\` 만 cover. **ternary expression 미처리** — RN core 의 conditional require 패턴 누락.

\`react-native/Libraries/ReactNative/AppContainer.js\`:
\`\`\`js
const AppContainer: component(...Props) = __DEV__
  ? require('./AppContainer-dev').default
  : require('./AppContainer-prod').default;
\`\`\`

\`__DEV__ = false\` define 적용 후 첫 branch 가 dead. 그러나 ternary 가 dead range 분석에서 빠져 \`require('./AppContainer-dev')\` 가 import_record 등록 → 모듈이 graph 진입.

## 변경

1줄 추가 (\`if_statement\` 와 동일 layout 활용):

\`\`\`zig
- if (node.tag != .if_statement) continue;
+ // if_statement: \`if (__DEV__) require(...)\` — dead branch 의 stmt
+ // conditional_expression: \`__DEV__ ? requireA : requireB\` — dead branch 의 expr
+ // 둘 다 동일한 \`data.ternary\` layout (a=cond, b=consequent, c=alternate).
+ if (node.tag != .if_statement and node.tag != .conditional_expression) continue;
\`\`\`

\`if_statement\` 와 \`conditional_expression\` 모두 \`data.ternary\` (3-field a/b/c) layout (\`parser/ast.zig:614-621\` + \`expression.zig:521-523\` 검증).

## 단위 테스트 추가

\`\`\`zig
test "CJS: define boolean으로 죽은 ternary 분기의 require는 스캔하지 않음" {
    const result = try parseAndExtractFullWithDefines(
        alloc,
        \\\\const X = __DEV__
        \\\\  ? require('./dev-only').default
        \\\\  : require('./prod-only').default;
    ,
        &.{.{ .key = "__DEV__", .value = "false" }},
    );
    try std.testing.expectEqual(@as(usize, 1), result.records.len);
    try std.testing.expectEqualStrings("./prod-only", result.records[0].specifier);
}
\`\`\`

## 측정 (rn-example-app)

| | bytes |
|---|---|
| Before | 992,309 |
| After | 992,309 (변화 없음) |

**측정 fixture 에선 win 없음** — RN core 의 dev 모듈이 ternary 외에 다른 path (\`useSubscribeToDebuggingOverlayRegistry.js\` 의 무조건 ESM import) 로도 진입. 본 PR 은 ternary path 만 cover.

진짜 win 영역 = **cross-module DCE 정확도 개선** (RN core 의 `import` from dev module 도 strip). 별도 issue 로 추적.

## 검증

- [x] 신규 단위 테스트 통과 (\`ternary 분기\`)
- [x] zig unit test 4699 pass
- [x] 278 통합 테스트 pass (bundle-smoke / asset-registry / es5-rn / hermes-runtime / flow-rn / preserve-modules / tree-shake-precision)

## 후속

별도 이슈 — RN core 의 무조건 dev module import path strip (cross-module DCE 정확도). \`useSubscribeToDebuggingOverlayRegistry.js\` 같은 모듈이 production 에서 reachable 인지 분석 후 dead 면 strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)