### PR TITLE
feat(import-scanner): function/arrow/method body 안 require 의 lazy 마킹 (#2681 Phase 1α)

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1996,7 +1996,7 @@ pub const ModuleGraph = struct {
             }
             // OOM 시 silent skip 하면 axios/follow-redirects 같은 optional require 가 hard
             // error 로 회귀해 build 자체가 깨진다. 1108줄 extractImports 와 동일하게 fallback.
-            import_scanner.markOptionalRequiresInTryBlocks(arena_alloc, &(module.ast.?), module.import_records) catch {
+            import_scanner.markPostScanFlags(arena_alloc, &(module.ast.?), module.import_records) catch {
                 module.state = .ready;
                 return;
             };
@@ -2325,7 +2325,7 @@ pub const ModuleGraph = struct {
             {
                 var optional_scope = profile.begin(.graph_discover_pm_post_optional_requires);
                 defer optional_scope.end();
-                import_scanner.markOptionalRequiresInTryBlocks(arena_alloc, &(module.ast.?), module.import_records) catch {
+                import_scanner.markPostScanFlags(arena_alloc, &(module.ast.?), module.import_records) catch {
                     module.state = .ready;
                     return;
                 };
@@ -2795,7 +2795,7 @@ pub const ModuleGraph = struct {
             for (module.import_records) |*r| {
                 if (arena_alloc.dupe(u8, r.specifier)) |owned| r.specifier = owned else |_| {}
             }
-            try import_scanner.markOptionalRequiresInTryBlocks(arena_alloc, ast, module.import_records);
+            try import_scanner.markPostScanFlags(arena_alloc, ast, module.import_records);
         }
 
         {

--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -193,6 +193,55 @@ fn isInsideAnySpan(span: Span, ranges: []const Span) bool {
     return false;
 }
 
+/// `records` 중 require/dynamic import call 의 span 이 `ranges` 중 하나 안에
+/// 들어가면 `field` 에 해당하는 ImportRecord bool field 를 true 로 마킹.
+/// `markOptionalRequiresInTryBlocks` / `markLazyRequiresInCallbacks` 공통 코어.
+/// static `import` 선언은 try-block / callback 안에 못 들어가므로 require/dynamic
+/// import 만 검사.
+fn markRecordsInsideSpans(
+    records: []ImportRecord,
+    ranges: []const Span,
+    comptime field: []const u8,
+) void {
+    if (ranges.len == 0) return;
+    for (records) |*rec| {
+        if (rec.kind != .require and rec.kind != .dynamic_import) continue;
+        if (isInsideAnySpan(rec.span, ranges)) @field(rec, field) = true;
+    }
+}
+
+/// function/arrow/method body 안의 require/dynamic import call records 에
+/// `in_lazy_callback = true` 마킹. RN core `index.js` 의 lazy getter 패턴
+/// (`get X() { return require(...).default }`) 처럼 호출 시점에만 평가되는
+/// require 를 식별 (#2681 Phase 1). graph reachability 분석이 이 flag 를 보고
+/// 호출 사이트가 reachable 일 때만 source 모듈 included.
+///
+/// 보수 scope: function_declaration 은 hoisting 으로 module top-level 호출 가능
+/// 하므로 일단 제외. function/arrow/method_definition 은 expression context 라
+/// 호출 사이트 추적 가능.
+pub fn markLazyRequiresInCallbacks(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    records: []ImportRecord,
+) !void {
+    var lazy_ranges: std.ArrayList(Span) = .empty;
+    defer lazy_ranges.deinit(allocator);
+    for (ast.nodes.items) |node| {
+        switch (node.tag) {
+            .function_expression,
+            .function,
+            .arrow_function_expression,
+            .method_definition,
+            => {},
+            else => continue,
+        }
+        const body_idx = ast.functionBodyBlock(node) orelse continue;
+        if (@intFromEnum(body_idx) >= ast.nodes.items.len) continue;
+        try lazy_ranges.append(allocator, ast.getNode(body_idx).span);
+    }
+    markRecordsInsideSpans(records, lazy_ranges.items, "in_lazy_callback");
+}
+
 /// `try { ... } catch {}` 의 try-block 안에 있는 require/import call records 에
 /// `is_optional = true` 마킹. parser 가 만든 records 와 import_scanner 가 만든
 /// records 양쪽에서 공용. AST 평탄 순회로 try_statement.a (block) span 수집 후
@@ -214,12 +263,19 @@ pub fn markOptionalRequiresInTryBlocks(
         if (@intFromEnum(block_idx) >= ast.nodes.items.len) continue;
         try try_ranges.append(allocator, ast.getNode(block_idx).span);
     }
-    if (try_ranges.items.len == 0) return;
-    for (records) |*rec| {
-        // require / dynamic import 만 — static `import` 선언은 try-block 안에 못 들어감.
-        if (rec.kind != .require and rec.kind != .dynamic_import) continue;
-        if (isInsideAnySpan(rec.span, try_ranges.items)) rec.is_optional = true;
-    }
+    markRecordsInsideSpans(records, try_ranges.items, "is_optional");
+}
+
+/// `markOptionalRequiresInTryBlocks` + `markLazyRequiresInCallbacks` 한 호출.
+/// graph build 의 모든 import_scan 후처리 사이트가 이 두 마킹을 짝으로 호출하므로
+/// wrapper 로 묶어 일관성 유지 + 한쪽 누락 회귀 차단.
+pub fn markPostScanFlags(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    records: []ImportRecord,
+) !void {
+    try markOptionalRequiresInTryBlocks(allocator, ast, records);
+    try markLazyRequiresInCallbacks(allocator, ast, records);
 }
 
 pub fn evalToBoolean(ast: *const Ast, idx: NodeIndex, defines: []const DefineEntry) ?bool {

--- a/src/bundler/import_scanner_test.zig
+++ b/src/bundler/import_scanner_test.zig
@@ -27,6 +27,24 @@ fn parseAndExtract(allocator: std.mem.Allocator, source: []const u8) ![]ImportRe
     return parseAndExtractExt(allocator, source, null);
 }
 
+/// `extractImports` 후 `markLazyRequiresInCallbacks` 까지 적용해서 반환.
+/// graph.zig 가 호출하는 후처리와 동등 — record.in_lazy_callback 검증용.
+fn parseAndExtractWithLazyMarking(allocator: std.mem.Allocator, source: []const u8) ![]ImportRecord {
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    var scanner = try Scanner.init(arena_alloc, source);
+    var parser = Parser.init(arena_alloc, &scanner);
+    parser.is_module = true;
+    scanner.is_module = true;
+    _ = try parser.parse();
+
+    const records = try import_scanner.extractImports(allocator, &parser.ast);
+    try import_scanner.markLazyRequiresInCallbacks(allocator, &parser.ast, records);
+    return records;
+}
+
 fn parseAndExtractExt(allocator: std.mem.Allocator, source: []const u8, ext: ?[]const u8) ![]ImportRecord {
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
@@ -493,6 +511,172 @@ test "optional: try-block 이 없으면 모든 require 가 is_optional=false" {
     try std.testing.expectEqual(@as(usize, 2), records.len);
     try std.testing.expect(!records[0].is_optional);
     try std.testing.expect(!records[1].is_optional);
+}
+
+test "lazy: getter 안 require 는 in_lazy_callback=true (#2681 RN core 패턴)" {
+    // RN core `react-native/index.js` 의 `get DevSettings() { return require('...').default }`
+    // 패턴 — Group A 모듈 strip 의 핵심.
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtractWithLazyMarking(
+        alloc,
+        \\const RN = {
+        \\  get DevSettings() {
+        \\    return require('./DevSettings').default;
+        \\  },
+        \\};
+        ,
+    );
+    defer alloc.free(records);
+
+    try std.testing.expectEqual(@as(usize, 1), records.len);
+    try std.testing.expectEqualStrings("./DevSettings", records[0].specifier);
+    try std.testing.expect(records[0].in_lazy_callback);
+}
+
+test "lazy: arrow function 안 require 는 in_lazy_callback=true" {
+    // `Object.defineProperty(obj, 'X', { get: () => require('./X') })` 같은 패턴.
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtractWithLazyMarking(
+        alloc,
+        \\const lazyGetter = () => require('./lazy');
+        ,
+    );
+    defer alloc.free(records);
+
+    try std.testing.expectEqual(@as(usize, 1), records.len);
+    try std.testing.expect(records[0].in_lazy_callback);
+}
+
+test "lazy: method shorthand 안 require 는 in_lazy_callback=true" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtractWithLazyMarking(
+        alloc,
+        \\const obj = {
+        \\  load() { return require('./mod'); }
+        \\};
+        ,
+    );
+    defer alloc.free(records);
+
+    try std.testing.expectEqual(@as(usize, 1), records.len);
+    try std.testing.expect(records[0].in_lazy_callback);
+}
+
+test "lazy: function expression 안 require 는 in_lazy_callback=true" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtractWithLazyMarking(
+        alloc,
+        \\const f = function() { return require('./mod'); };
+        ,
+    );
+    defer alloc.free(records);
+
+    try std.testing.expectEqual(@as(usize, 1), records.len);
+    try std.testing.expect(records[0].in_lazy_callback);
+}
+
+test "lazy: top-level require 는 in_lazy_callback=false (회귀 가드)" {
+    // 일반 top-level require 는 eager — lazy 마킹되면 안 됨.
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtractWithLazyMarking(
+        alloc,
+        \\const a = require('./a');
+        \\const b = require('./b');
+        ,
+    );
+    defer alloc.free(records);
+
+    try std.testing.expectEqual(@as(usize, 2), records.len);
+    try std.testing.expect(!records[0].in_lazy_callback);
+    try std.testing.expect(!records[1].in_lazy_callback);
+}
+
+test "lazy: function_declaration 안 require 는 일단 eager (보수 scope)" {
+    // function_declaration 은 hoisting 으로 module top-level 호출 가능 — Phase 2
+    // (Metro inline-requires) 에서 별도 처리. PR α 는 conservative scope.
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtractWithLazyMarking(
+        alloc,
+        \\function load() { return require('./mod'); }
+        ,
+    );
+    defer alloc.free(records);
+
+    try std.testing.expectEqual(@as(usize, 1), records.len);
+    try std.testing.expect(!records[0].in_lazy_callback);
+}
+
+test "lazy: dynamic import 도 in_lazy_callback 처리" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtractWithLazyMarking(
+        alloc,
+        \\const load = () => import('./dyn');
+        ,
+    );
+    defer alloc.free(records);
+
+    try std.testing.expectEqual(@as(usize, 1), records.len);
+    try std.testing.expect(records[0].in_lazy_callback);
+}
+
+test "lazy: function_declaration 안 nested arrow 의 require 는 in_lazy_callback=true" {
+    // outer 가 function_declaration (보수 scope 제외) 이지만 inner arrow body 안의
+    // require 는 lazy callback. span containment 가 inner 의 body 안임을 확인.
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtractWithLazyMarking(
+        alloc,
+        \\function outer() {
+        \\  const inner = () => require('./mod');
+        \\}
+        ,
+    );
+    defer alloc.free(records);
+
+    try std.testing.expectEqual(@as(usize, 1), records.len);
+    try std.testing.expect(records[0].in_lazy_callback);
+}
+
+test "lazy: class method 안 require 는 in_lazy_callback=true" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtractWithLazyMarking(
+        alloc,
+        \\class Loader {
+        \\  load() { return require('./mod'); }
+        \\}
+        ,
+    );
+    defer alloc.free(records);
+
+    try std.testing.expectEqual(@as(usize, 1), records.len);
+    try std.testing.expect(records[0].in_lazy_callback);
+}
+
+test "lazy: try-block 안 lazy callback 의 require 는 두 flag 모두 true (직교성)" {
+    // function body 안 + try block 안 → in_lazy_callback + is_optional 둘 다.
+    // markPostScanFlags 가 두 마킹을 독립 적용 회귀 가드.
+    const alloc = std.testing.allocator;
+
+    var arena = std.heap.ArenaAllocator.init(alloc);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    var scanner = try Scanner.init(arena_alloc,
+        \\const f = function() {
+        \\  try { require('./mod'); } catch (e) {}
+        \\};
+    );
+    var parser = Parser.init(arena_alloc, &scanner);
+    parser.is_module = true;
+    scanner.is_module = true;
+    _ = try parser.parse();
+
+    const records = try import_scanner.extractImports(alloc, &parser.ast);
+    defer alloc.free(records);
+    try import_scanner.markPostScanFlags(alloc, &parser.ast, records);
+
+    try std.testing.expectEqual(@as(usize, 1), records.len);
+    try std.testing.expect(records[0].in_lazy_callback);
+    try std.testing.expect(records[0].is_optional);
 }
 
 test "CJS: define boolean으로 죽은 if 분기의 require는 스캔하지 않음" {

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -633,6 +633,12 @@ pub const ImportRecord = struct {
     /// 못 받기 때문에 wrapper module 호출로 emit (#1579 Phase 4 follow-up).
     /// element 가 null = 해당 매치 resolve 실패 (codegen 이 throw stub 으로 emit).
     context_resolved_paths: []const ?[]const u8 = &.{},
+    /// require/dynamic import call 이 function/arrow/method/getter body 안에 있어
+    /// 호출 시점에만 평가되는 lazy callback 인지. RN core `index.js` 의
+    /// `get DevSettings() { return require(...).default }` 같은 lazy getter 패턴
+    /// (#2681). graph reachability 분석이 이 flag 를 보고 호출 사이트가 reachable
+    /// 일 때만 source 모듈을 included 처리.
+    in_lazy_callback: bool = false,
 };
 
 // ============================================================


### PR DESCRIPTION
## 배경

#2681 epic 의 Phase 1 PR α. RN core \`index.js\` 의 lazy getter 패턴 (Group A/B 7 모듈) strip 을 위한 인프라.

\`\`\`js
// react-native/index.js
const RN = {
  get DevSettings() {                                    // ← lazy getter
    return require('./Libraries/Utilities/DevSettings').default;
  },
};
\`\`\`

호출 사이트 (\`require('react-native').DevSettings\`) 가 prod 에서 안 호출되면 require 도 안 일어남. ZTS 가 이 require 를 일반 top-level require 로 등록 → 항상 graph 진입. PR α 는 이걸 식별하는 인프라.

## 변경

- **\`ImportRecord.in_lazy_callback: bool = false\`** (types.zig) — 호출 시점에만 평가되는 lazy callback 안 require 인지
- **\`markLazyRequiresInCallbacks\`** (import_scanner.zig) — function_expression / function / arrow_function_expression / method_definition body span 수집 후 require/dynamic_import record span containment 검사로 마킹. \`markOptionalRequiresInTryBlocks\` 와 동일 패턴
- **\`markRecordsInsideSpans\`** helper — markOptional + markLazy 의 마킹 루프 공유 (comptime field 명)
- **\`markPostScanFlags\`** wrapper — graph.zig 3 호출 사이트 (JSON / inline scan post / resync) 의 markOptional + markLazy 묶음. 누락 회귀 차단

### 보수 scope

\`function_declaration\` 은 hoisting 으로 module top-level 호출 가능하므로 일단 제외. \`function_expression\` / \`arrow_function_expression\` / \`method_definition\` 만 lazy 처리. function_declaration 안 nested arrow 는 inner 의 body 검사로 자동 cover (회귀 가드 테스트 포함).

## behavior 변경 없음

인프라 only — \`in_lazy_callback\` flag 만 마킹. graph reachability 분석 (PR β) 이 이 flag 를 활용해 Group A/B 7 모듈을 strip 한다. PR α 자체는 사이즈/모듈 수 변동 없음 (rn-example-app 2,009,664 bytes / 12 dev modules — PR #2680 후와 동일).

## 검증

- [x] 단위 테스트 **4713/4713** (Debug + ReleaseFast)
- [x] 통합 테스트 **3706/3706**
- [x] 신규 단위 테스트 10 케이스 — getter / arrow / method shorthand / function expression / top-level (회귀 가드) / function_declaration 보수 scope / dynamic import / nested arrow inside function_declaration / class method / try+lazy 직교성

## /simplify

- \`ScanImportRecord.in_lazy_callback\` 제거 (dead field — parser 가 set 안 함, import_scanner 만 producer)
- \`markRecordsInsideSpans\` helper 추출 (markOptional + markLazy dedup)
- \`markPostScanFlags\` wrapper (3 호출 사이트 통합)
- nested test cases 3개 추가

## Phase 2 (PR β/γ) 로 분리

- PR β: tree_shaker 의 lazy require cross-module reachability — 호출 사이트 reachable 일 때만 included
- PR γ: Metro inline-requires transformer

Refs #2681