### PR TITLE
fix(examples): zntc 예제 빌드 전 workspace link 갱신

### DIFF
--- a/examples/react-native-bare/package.json
+++ b/examples/react-native-bare/package.json
@@ -11,7 +11,7 @@
     "start": "react-native start",
     "start:zntc": "zntc dev --platform=react-native --rn-platform=ios index.js",
     "prestart:zntc": "bun run build:zntc:core",
-    "build:zntc:core": "bun run --cwd ../../packages/core build && bun run --cwd ../../packages/server build && bun run --cwd ../../packages/react-native build",
+    "build:zntc:core": "bun install --cwd ../.. --frozen-lockfile && bun run --cwd ../../packages/core build && bun run --cwd ../../packages/server build && bun run --cwd ../../packages/react-native build",
     "bundle:zntc:ios": "zntc bundle index.js --platform=react-native --rn-platform=ios -o ios/main.jsbundle",
     "bundle:zntc:android": "zntc bundle index.js --platform=react-native --rn-platform=android -o android/app/src/main/assets/index.android.bundle",
     "bundle:metro:ios": "react-native bundle --platform ios --dev false --entry-file index.js --bundle-output ios/main.jsbundle --assets-dest ios",

--- a/examples/react-native-expo/package.json
+++ b/examples/react-native-expo/package.json
@@ -8,7 +8,7 @@
     "start": "expo start",
     "start:zntc": "zntc dev --platform=react-native --rn-platform=ios index.js",
     "prestart:zntc": "bun run build:zntc:core",
-    "build:zntc:core": "bun run --cwd ../../packages/core build && bun run --cwd ../../packages/server build && bun run --cwd ../../packages/react-native build",
+    "build:zntc:core": "bun install --cwd ../.. --frozen-lockfile && bun run --cwd ../../packages/core build && bun run --cwd ../../packages/server build && bun run --cwd ../../packages/react-native build",
     "bundle:zntc:ios": "zntc bundle index.js --platform=react-native --rn-platform=ios -o dist/main.ios.jsbundle",
     "bundle:zntc:android": "zntc bundle index.js --platform=react-native --rn-platform=android -o dist/main.android.jsbundle",
     "reset-project": "node ./scripts/reset-project.js",


### PR DESCRIPTION
## 요약
- React Native bare/expo 예제의 `build:zntc:core`가 root workspace install을 먼저 수행하도록 변경했습니다.
- rename PR 머지 후 `git pull && bun build:zntc:core && bun start:zntc`처럼 실행했을 때, 기존 `node_modules`가 `@zts/*`/`@znts/*` symlink 상태라 `@zntc/server` resolve가 실패하는 케이스를 막습니다.

## 검증
- `bun run --cwd examples/react-native-expo build:zntc:core`
- `bun run --cwd examples/react-native-bare build:zntc:core`
- `git diff --check`
- `bun run fmt:check`
- pre-push: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check` 통과