### PR TITLE
fix(napi): watch list 등록 시 virtual module path skip (panic 회피)

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -2880,6 +2880,9 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
     }
     if (result.module_paths) |paths| {
         for (paths) |p| {
+            // ZTS runtime helper 등 virtual module (`\x00zts:runtime/...` prefix) 은
+            // file system 에 없어 openFile 이 invalid path 로 panic. watch 대상 아니므로 skip.
+            if (zts_lib.runtime_helper_modules.isVirtualId(p)) continue;
             if (tracked.addPath(p, true)) initial_watch_count += 1;
         }
     }
@@ -3232,6 +3235,8 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         var dit = desired.keyIterator();
         while (dit.next()) |pkey| {
             if (tracked.contains(pkey.*)) continue;
+            // virtual module (zts:runtime/...) 은 file system 에 없어 openFile panic. skip.
+            if (zts_lib.runtime_helper_modules.isVirtualId(pkey.*)) continue;
             _ = tracked.addPath(pkey.*, false);
         }
     }


### PR DESCRIPTION
## 회귀

\`packages/core\` 의 NAPI \`watch\` 가 RN-example-app 같이 ZTS runtime helper inject 되는 fixture 에서 native panic — \`reached unreachable code\`. exit code 134 / 139.

\`\`\`
panic: reached unreachable code
src/util/wyhash.zig:27  hashFileStreaming
    const file = std.fs.cwd().openFile(path, .{}) catch return null;  // ← panic
src/server/tracked_file_set.zig:61  addPath
napi_entry.zig:2883  watchWorkerThread
    if (tracked.addPath(p, true)) initial_watch_count += 1;
\`\`\`

## Root cause

\`result.module_paths\` 가 ZTS runtime helper virtual module 17개 (\`\\x00zts:runtime/extends\`, \`\\x00zts:runtime/generator\` 등) 도 포함. \`tracked.addPath\` 가 file hash 시도 → \`openFile\` 이 invalid path 로 internal \`unreachable\` hit → panic.

\`hashFileStreaming\` 의 \`catch return null\` 이 일반 error 만 catch, \`unreachable\` 은 catch 불가.

## Fix

watch list 등록 두 사이트에서 \`runtime_helper_modules.isVirtualId(p)\` 로 virtual path skip:
- \`napi_entry.zig:2882\` (initial module_paths loop)
- \`napi_entry.zig:3236\` (rebuild 후 desired loop)

## 검증

- [x] 단위 4713/4713 (Debug + ReleaseFast)
- [x] ReleaseSafe 빌드로 panic stack trace 받아 root cause 확정
- [x] RN-example-app NAPI watch READY 정상 (581 → 564 files = virtual 17 제외)

## 후속 (별도 영역)

RN App.tsx 변경 시 onRebuild 가 호출 안 되는 별도 issue 발견:
- Bun \`writeFileSync\` 의 atomic write (rename) 가 kqueue fd 의 inode watch 와 비호환 의심
- root cause 추가 진단 + fix 별도 PR