### PR TITLE
fix(wyhash): hashFileStreaming NUL byte path panic 회귀

### DIFF
--- a/src/util/wyhash.zig
+++ b/src/util/wyhash.zig
@@ -24,6 +24,10 @@ pub fn hashHex8(data: []const u8) [8]u8 {
 /// `max_bytes` 초과 시 size+mtime 기반 pseudo-hash로 폴백 (RN 등 vendor 번들/locale JSON 대응 — #1233).
 /// 열기/stat/읽기 실패 시 null.
 pub fn hashFileStreaming(path: []const u8, max_bytes: usize) ?u64 {
+    // Zig std `toPosixPath` 는 NUL byte 포함 path 를 runtime_safety assertion 으로 panic.
+    // ZNTC virtual module id (`\x00zntc:runtime/...` 등) 가 watch 등록 시 hash 시도되어
+    // panic 으로 빠지는 회귀 방지 — contract "실패 시 null" 을 모든 경로에서 보장.
+    if (std.mem.indexOfScalar(u8, path, 0) != null) return null;
     const file = std.fs.cwd().openFile(path, .{}) catch return null;
     defer file.close();
     const stat = file.stat() catch return null;
@@ -90,4 +94,11 @@ test "hashFileStreaming over-limit falls back to size+mtime pseudo-hash" {
 
 test "hashFileStreaming missing file returns null" {
     try std.testing.expect(hashFileStreaming("/nonexistent/zntc_wyhash_test.txt", 1024) == null);
+}
+
+test "hashFileStreaming NUL byte path returns null (no panic)" {
+    // ZNTC virtual module id (`\x00zntc:runtime/...`) 가 file watch 등록 시 hash 시도됐을 때
+    // Zig std `toPosixPath` 의 NUL byte assertion panic 회귀 방지.
+    try std.testing.expect(hashFileStreaming("\x00zntc:runtime/extends", 1024) == null);
+    try std.testing.expect(hashFileStreaming("foo\x00bar", 1024) == null);
 }


### PR DESCRIPTION
## 회귀

NAPI \`watch\` 가 ZNTC runtime helper inject 되는 fixture (RN-example-app) 빌드 시 native panic. exit code 134/139.

\`\`\`
panic: reached unreachable code
src/util/wyhash.zig:27  hashFileStreaming
    const file = std.fs.cwd().openFile(path, .{}) catch return null;  ← panic
src/server/tracked_file_set.zig:61  addPath
napi_entry.zig:2883  watchWorkerThread
    if (tracked.addPath(p, true)) initial_watch_count += 1;
\`\`\`

## 진짜 root cause

\`std.fs.cwd().openFile([]const u8, ...)\` 가 내부 \`std.posix.toPosixPath\` 호출:

\`\`\`zig
// posix.zig:7350
pub fn toPosixPath(file_path: []const u8) ... {
    if (std.debug.runtime_safety) assert(mem.indexOfScalar(u8, file_path, 0) == null);
\`\`\`

**path 안 NUL byte 발견 시 runtime_safety assertion 으로 panic**. \`hashFileStreaming\` 의 \`catch return null\` 은 error union 만 catch — assertion panic 못 잡음.

ZNTC virtual module ID 가 \`\\x00zntc:runtime/...\` 형식 (첫 byte NUL). \`module_paths\` 가 graph 의 모든 module ID (virtual 포함) 노출 → \`tracked.addPath\` → \`hashFileStreaming\` → panic.

\`file_watcher.addPath\` 는 \`posix.openZ\` (raw C path) 사용해 NUL 안전. \`openFile([]const u8)\` 만 \`toPosixPath\` 거치므로 panic 가능 → 정확한 fix 영역 = \`hashFileStreaming\`.

## Fix (한 줄)

\`hashFileStreaming\` 가 contract "실패 시 null" 을 모든 경로에서 보장하도록 사전 NUL byte 검사:

\`\`\`zig
if (std.mem.indexOfScalar(u8, path, 0) != null) return null;
\`\`\`

**caller (NAPI watch / tracked_file_set 등) 변경 없음** — root cause 영역에서 fix.

이전 시도 (PR #2691, closed) 는 caller-side virtual path skip — 임시방편이었음. virtual path 자체가 watch list 에 들어오는 건 정상 (graph traversal 영역과 공유 path), \`hashFileStreaming\` 의 contract 가 NUL case 미커버였던 게 진짜 root cause.

## 검증

- [x] 단위 4714/4714 (Debug + ReleaseFast) — 신규 NUL byte 테스트
- [x] ReleaseSafe NAPI watch RN-example-app: \`READY 564 files\` 정상 (이전 panic)

## 후속

panic fix 후에도 RN App.tsx 변경 시 \`onRebuild\` 가 호출 안 되는 별도 issue 발견 — Bun \`writeFileSync\` atomic write 와 kqueue fd inode watch 비호환 의심. 별도 epic.