### PR TITLE
fix(emit): virtual runtime helper module 의 mtime=0 cache 우회 (#2694)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -39,6 +39,7 @@ const Codegen = @import("../codegen/codegen.zig").Codegen;
 const CodegenOptions = @import("../codegen/codegen.zig").CodegenOptions;
 const SourceMap = @import("../codegen/sourcemap.zig");
 const error_codes = @import("../error_codes.zig");
+const runtime_helper_modules = @import("../runtime_helper_modules.zig");
 
 /// ZNTC0002 TLA+non-ESM 경고 주석. comptime 고정 — 코드/메시지가 error_codes와 항상 일치.
 const tla_warning_comment = "/* [" ++ error_codes.Code.tla_requires_esm_format.format() ++ "] " ++ error_codes.Code.tla_requires_esm_format.message() ++ ". */\n";
@@ -562,9 +563,11 @@ pub fn emitWithTreeShaking(
     if (options.compiled_cache) |cache| {
         for (sorted.items, 0..) |m, i| {
             if (hit_mask[i]) continue;
-            if (m.mtime == 0) {
+            // virtual module (\x00zntc:runtime/...) 은 fs stat 불가로 mtime=0 인데
+            // source 가 process lifetime 동안 불변이라 mtime 가드를 우회해 cache 적용.
+            if (m.mtime == 0 and !runtime_helper_modules.isVirtualId(m.path)) {
                 cache.skipped_no_mtime += 1;
-                continue; // mtime unknown → cache 비활성
+                continue;
             }
             const used_names: ?[]const []const u8 = if (used_names_list[i].all_used) null else used_names_list[i].names;
             const input_hash = cache_mod.computeInputHash(m, options_hash, used_names, graph);
@@ -612,7 +615,8 @@ pub fn emitWithTreeShaking(
     if (options.compiled_cache) |cache| {
         for (sorted.items, 0..) |m, i| {
             if (hit_mask[i]) continue;
-            if (m.mtime == 0) continue;
+            // virtual module 은 mtime=0 라도 cache 적용 (lookup 분기와 대칭).
+            if (m.mtime == 0 and !runtime_helper_modules.isVirtualId(m.path)) continue;
             if (results[i].code == null) continue;
             cache.put(m.path, input_hashes[i], results[i]) catch continue;
         }


### PR DESCRIPTION
## Summary

- `\x00zntc:runtime/...` 가상 모듈은 fs stat 불가로 mtime=0 인데, `compiled_cache` 의 lookup/put 양쪽 분기가 `if (m.mtime == 0) continue` 로 skip 한다.
- 결과: 가상 모듈은 매 incremental rebuild 마다 emit 단계 (transformer + minify pass) 를 다시 탐 → production (`devMode: false`) watch + rebuild 시 minify 의 fold pass 가 ast.allocator 의 cross-rebuild ownership 으로 panic (#2694).
- 가상 모듈 source 는 process lifetime 동안 불변이므로 mtime 가드를 완화. 첫 빌드 emit 결과를 cache 에 put → 이후 rebuild 는 cache hit 으로 emit 자체를 우회 → panic 회피.

이 PR 은 panic 의 직접 노출 경로를 막는 정합성 fix. 진짜 root cause (ArenaAllocator struct copy ownership — putModule/getIfFresh 가 `parse_arena: ?ArenaAllocator` 를 struct copy 하면서 buffer_list ptr 만 따라가는 패턴) 는 #2694 본문에 후보 정리됨, 별도 PR 로 분리.

## Test plan

- [x] `tests/integration/tests/fixtures/rn-example-app` 에서 `devMode: false` + watch + App.tsx 변경 → 첫 rebuild 가 panic 없이 `onRebuild({success: true})` 발화 확인
- [x] 동일 fixture 의 `devMode: true` 시나리오에 회귀 없음 확인 (REBUILD callback 정상)
- [x] napi smoke matrix 통과 예상 — emitter 가드 완화만으로 다른 모듈 (mtime != 0) 동작 변화 없음
- [ ] CI

Refs #2694