### PR TITLE
fix(module): parse_arena 를 heap ptr 로 전환 — store 왕복 dangling BufNode panic 근본수정 (#2694)

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1874,11 +1874,14 @@ pub const ModuleGraph = struct {
         if (plugin_runner) |runner| {
             if (self.shouldRunLoad(module.path)) {
                 // 임시 allocator로 load 결과만 확인 (성공 시 arena를 생성)
-                var tmp_arena = std.heap.ArenaAllocator.init(self.allocator);
+                const tmp_arena = module_mod.createParseArena(self.allocator) orelse {
+                    module.state = .ready;
+                    return;
+                };
                 const load_result = runner.runLoad(module.path, tmp_arena.allocator()) catch |err| switch (err) {
                     error.PluginFailed => null,
                     error.OutOfMemory => {
-                        tmp_arena.deinit();
+                        module_mod.destroyParseArena(self.allocator, tmp_arena);
                         module.state = .ready;
                         return;
                     },
@@ -1916,7 +1919,7 @@ pub const ModuleGraph = struct {
                     // module_type 분기를 건너뛰고 JS 파싱 경로로 직접 이동
                     // (아래 "모듈별 Arena" 블록은 parse_arena가 이미 설정되어 있으므로 건너뜀)
                 } else {
-                    tmp_arena.deinit();
+                    module_mod.destroyParseArena(self.allocator, tmp_arena);
                 }
             }
         }
@@ -1940,7 +1943,10 @@ pub const ModuleGraph = struct {
         // `export default <json_value>;` 형태의 AST를 생성하여
         // semantic → import_scanner → binding_scanner를 공유한다.
         if (module.module_type == .json) {
-            module.parse_arena = std.heap.ArenaAllocator.init(self.allocator);
+            module.parse_arena = module_mod.createParseArena(self.allocator) orelse {
+                module.state = .ready;
+                return;
+            };
             const arena_alloc = module.parse_arena.?.allocator();
             module.source = self.readModuleSourceWithMtime(module, arena_alloc, 10 * 1024 * 1024, .parse) orelse return;
 
@@ -2054,7 +2060,10 @@ pub const ModuleGraph = struct {
         // 모듈별 Arena: Scanner/Parser/AST 메모리를 소유 (D061)
         // 플러그인 load 훅에서 이미 설정된 경우 건너뜀
         if (module.parse_arena == null) {
-            module.parse_arena = std.heap.ArenaAllocator.init(self.allocator);
+            module.parse_arena = module_mod.createParseArena(self.allocator) orelse {
+                module.state = .ready;
+                return;
+            };
         }
         const arena_alloc = module.parse_arena.?.allocator();
 
@@ -3518,7 +3527,7 @@ pub const ModuleGraph = struct {
             const needs_require = m.wrap_kind == .cjs and m.require_symbol == null;
             if (!needs_init and !needs_exports and !needs_require) continue;
             const sem_ptr = if (m.semantic) |*s| s else continue;
-            const arena = if (m.parse_arena) |*a| a.allocator() else continue;
+            const arena = if (m.parse_arena) |a| a.allocator() else continue;
 
             if (needs_init) {
                 const init_base = types.makeInitVarName(arena, m.path) catch continue;
@@ -3724,7 +3733,10 @@ pub const ModuleGraph = struct {
             return;
         }
 
-        module.parse_arena = std.heap.ArenaAllocator.init(self.allocator);
+        module.parse_arena = module_mod.createParseArena(self.allocator) orelse {
+            module.state = .ready;
+            return;
+        };
         const arena_alloc = module.parse_arena.?.allocator();
 
         // 파일 읽기
@@ -3814,7 +3826,10 @@ pub const ModuleGraph = struct {
     }
 
     fn parseAssetModule(self: *ModuleGraph, module: *Module) void {
-        module.parse_arena = std.heap.ArenaAllocator.init(self.allocator);
+        module.parse_arena = module_mod.createParseArena(self.allocator) orelse {
+            module.state = .ready;
+            return;
+        };
         const arena_alloc = module.parse_arena.?.allocator();
 
         switch (module.loader) {
@@ -4474,7 +4489,7 @@ fn expandRequireContextRecords(self: *ModuleGraph, mod_idx: usize) void {
     // require.context 는 parse 산출물이라 arena 가 항상 존재. 없으면 (disabled/asset 등)
     // expand 자체가 의미 없고, graph allocator fallback 은 module.deinit 에서 free 누락 →
     // leak. 안전하게 early return.
-    const arena = if (module.parse_arena) |*a| a else return;
+    const arena = if (module.parse_arena) |a| a else return;
     const arena_alloc = arena.allocator();
     var expansion = std.ArrayList(types.ImportRecord).empty;
 

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1933,7 +1933,7 @@ pub const Linker = struct {
             const ast = if (importer.ast) |*a| a else continue;
             // 결과 슬라이스는 module.parse_arena가 소유 — 모듈 수명 동안 유효하고
             // deinit 시 자동 해제. linker.allocator를 쓰면 누수 위험.
-            const arena = if (importer.parse_arena) |*pa| pa.allocator() else continue;
+            const arena = if (importer.parse_arena) |pa| pa.allocator() else continue;
 
             if (sem.scope_maps.len == 0) continue;
 

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -102,6 +102,20 @@ pub const TransformCache = struct {
     symbol_ids: []const ?u32,
 };
 
+/// `Module.parse_arena` 용 ArenaAllocator 를 heap 에 생성. 실패 시 null.
+/// 정리는 `destroyParseArena` 로.
+pub fn createParseArena(allocator: std.mem.Allocator) ?*std.heap.ArenaAllocator {
+    const ptr = allocator.create(std.heap.ArenaAllocator) catch return null;
+    ptr.* = std.heap.ArenaAllocator.init(allocator);
+    return ptr;
+}
+
+/// `createParseArena` 의 짝. arena 데이터 free 후 ptr 자체 free.
+pub fn destroyParseArena(allocator: std.mem.Allocator, arena: *std.heap.ArenaAllocator) void {
+    arena.deinit();
+    allocator.destroy(arena);
+}
+
 pub const Module = struct {
     index: ModuleIndex,
     /// 절대 파일 경로. graph의 path_to_module 키와 동일한 메모리를 참조 (빌림).
@@ -143,7 +157,13 @@ pub const Module = struct {
     /// 모든 export 가 사용 가능해야.
     is_context_dep: bool = false,
     /// 모듈별 Arena — Scanner/Parser/AST/Semantic 메모리를 소유. graph.deinit에서 해제.
-    parse_arena: ?std.heap.ArenaAllocator,
+    ///
+    /// 포인터로 보관 — graph ↔ store 사이의 transfer 가 Module struct copy 로 일어나는데,
+    /// `?ArenaAllocator` (value) 면 두 위치가 같은 buffer_list 를 가리키고 그 후 nullify
+    /// 패턴으로 ownership 을 표현해도 어느 한쪽이 dangling 노드를 통해 다음 alloc 에서
+    /// panic 한다 (#2694). ptr 으로 두면 struct copy 가 ptr 만 복사 — 두 위치가 같은
+    /// 객체 참조하고 nullify 한 쪽이 ownership 박탈을 명확히 표현한다.
+    parse_arena: ?*std.heap.ArenaAllocator,
     /// semantic analyzer 결과. parse_arena가 소유. linker에서 사용.
     semantic: ?ModuleSemanticData,
     /// Semantic Analyzer에서 사전 구축한 StmtInfo. parse_arena가 소유.
@@ -512,7 +532,7 @@ pub const Module = struct {
         }
         // parse_arena가 Scanner/Parser/AST/source 메모리를 전부 소유.
         // ast.deinit()는 불필요 — arena.deinit()이 일괄 해제.
-        if (self.parse_arena) |*arena| arena.deinit();
+        if (self.parse_arena) |arena| destroyParseArena(allocator, arena);
     }
 
     /// Lazy 초기화. graph allocator로 합성 심볼 테이블을 만든다.

--- a/src/bundler/module_store.zig
+++ b/src/bundler/module_store.zig
@@ -5,7 +5,8 @@
 //! Module.parse_arena가 데이터를 소유하므로, arena 소유권 이전으로 캐시를 구현.
 
 const std = @import("std");
-const Module = @import("module.zig").Module;
+const Module_mod = @import("module.zig");
+const Module = Module_mod.Module;
 const types = @import("types.zig");
 
 pub const PersistentModuleStore = struct {
@@ -49,7 +50,7 @@ pub const PersistentModuleStore = struct {
             }
         }
         // parse_arena / alias_table 가 아직 store 에 있으면 해제.
-        if (cached.module.parse_arena) |*arena| arena.deinit();
+        if (cached.module.parse_arena) |arena| Module_mod.destroyParseArena(self.allocator, arena);
         if (cached.module.alias_table) |*t| t.deinit();
         // dependencies/importers/dynamic_imports/dynamic_importers ArrayList 해제
         cached.module.dependencies.deinit(self.allocator);
@@ -111,14 +112,14 @@ pub const PersistentModuleStore = struct {
                 .module = cached_module,
                 .import_specifiers = specs,
             }) catch {
-                if (cached_module.parse_arena) |*a| a.deinit();
+                if (cached_module.parse_arena) |a| Module_mod.destroyParseArena(self.allocator, a);
                 if (cached_module.alias_table) |*t| t.deinit();
                 for (specs) |s| self.allocator.free(s);
                 self.allocator.free(specs);
             };
         } else {
             const key = self.allocator.dupe(u8, path) catch {
-                if (cached_module.parse_arena) |*a| a.deinit();
+                if (cached_module.parse_arena) |a| Module_mod.destroyParseArena(self.allocator, a);
                 if (cached_module.alias_table) |*t| t.deinit();
                 for (specs) |s| self.allocator.free(s);
                 self.allocator.free(specs);
@@ -131,7 +132,7 @@ pub const PersistentModuleStore = struct {
                 .import_specifiers = specs,
             }) catch {
                 self.allocator.free(key);
-                if (cached_module.parse_arena) |*a| a.deinit();
+                if (cached_module.parse_arena) |a| Module_mod.destroyParseArena(self.allocator, a);
                 if (cached_module.alias_table) |*t| t.deinit();
                 for (specs) |s| self.allocator.free(s);
                 self.allocator.free(specs);
@@ -228,4 +229,46 @@ test "PersistentModuleStore: alias_table ownership 왕복 (rebuild 2회)" {
     const cached2 = store.getIfFresh("/virtual/mod.ts", 2) orelse return error.CacheMiss;
     try testing.expect(cached2.module.alias_table != null);
     try testing.expectEqual(@as(u32, 3), cached2.module.alias_table.?.count());
+}
+
+// Regression #2694: 가상 모듈 (mtime=0) 이 cache-hit 으로 store ↔ graph 왕복할 때
+// 다음 rebuild 의 첫 alloc 이 panic 하지 않아야 한다. 과거에는 `parse_arena` 가
+// `?ArenaAllocator` (value) 라 putModule/getIfFresh 의 struct copy 가 buffer_list 의
+// first BufNode 를 두 위치에서 공유해 한쪽 deinit 이후 다른 쪽이 dangling 포인터로
+// alloc 시 `start index 16 is larger than end index 0` panic.
+test "PersistentModuleStore: parse_arena ownership 왕복 후 alloc 정상 (#2694)" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var store = PersistentModuleStore.init(allocator);
+    defer store.deinit();
+
+    var module = Module.init(@enumFromInt(0), "\x00zntc:runtime/extends");
+    module.parse_arena = Module_mod.createParseArena(allocator) orelse return error.OutOfMemory;
+    // 첫 빌드에서 arena 에 alloc — buffer_list 에 BufNode 등록.
+    _ = try module.parse_arena.?.allocator().alloc(u8, 256);
+
+    store.putModule("\x00zntc:runtime/extends", &module, 1);
+    try testing.expect(module.parse_arena == null);
+    module.deinit(allocator);
+
+    // build 2: cache-hit. graph 가 ownership 환수.
+    const cached = store.getIfFresh("\x00zntc:runtime/extends", 1) orelse return error.CacheMiss;
+    var mod2 = Module.init(@enumFromInt(0), "\x00zntc:runtime/extends");
+    const saved_deps = mod2.dependencies;
+    const saved_importers = mod2.importers;
+    mod2 = cached.module;
+    mod2.dependencies = saved_deps;
+    mod2.importers = saved_importers;
+    cached.module.parse_arena = null;
+    cached.module.alias_table = null;
+
+    // 두 번째 빌드 emit 단계의 fold pass 가 ast.allocator (= parse_arena) 로 새 노드
+    // 푸시하는 시나리오. 과거에는 buffer_list 의 first 가 dangling 이라 panic.
+    try testing.expect(mod2.parse_arena != null);
+    const buf2 = try mod2.parse_arena.?.allocator().alloc(u8, 512);
+    try testing.expectEqual(@as(usize, 512), buf2.len);
+
+    store.putModule("\x00zntc:runtime/extends", &mod2, 2);
+    mod2.deinit(allocator);
 }

--- a/src/bundler/phase.zig
+++ b/src/bundler/phase.zig
@@ -83,7 +83,7 @@ pub const ParseAccessor = struct {
         if (self.graph.moduleAtMut(idx)) |m| m.semantic = semantic;
     }
 
-    pub inline fn setParseArena(self: ParseAccessor, idx: ModuleIndex, arena: ?std.heap.ArenaAllocator) void {
+    pub inline fn setParseArena(self: ParseAccessor, idx: ModuleIndex, arena: ?*std.heap.ArenaAllocator) void {
         if (self.graph.moduleAtMut(idx)) |m| m.parse_arena = arena;
     }
 

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -437,7 +437,7 @@ pub const TreeShaker = struct {
     fn foldNumericExportSeeds(_: *TreeShaker, m: *Module, ast: *Ast) !bool {
         const minify_mod = @import("../transformer/minify.zig");
         const sem = if (m.semantic) |*sem| sem else return false;
-        const arena_alloc = if (m.parse_arena) |*arena| arena.allocator() else return false;
+        const arena_alloc = if (m.parse_arena) |arena| arena.allocator() else return false;
         var has_exported_number = false;
 
         for (ast.nodes.items) |node| {


### PR DESCRIPTION
## Summary

- `Module.parse_arena: ?std.heap.ArenaAllocator` → `?*std.heap.ArenaAllocator` (heap 에 alloc 한 ptr).
- struct copy 시 ptr 만 복사해 두 위치가 같은 ArenaAllocator 객체를 참조 → nullify 가 정확히 ownership 박탈을 표현하고 정확히 한 번만 deinit.
- Issue #2694 의 근본 원인 (dangling BufNode 로 인한 next-rebuild alloc panic) 직접 해결. PR #2695 의 mtime 우회 같은 방어코드 없이 동작.

## 진단

- panic 위치: `runOnce → ArrayList.ensureTotalCapacity → ArenaAllocator.alloc` 의 `cur_alloc_buf[16..]` 슬라이싱. cur_node.data=0 → length 0 인 buf 에 16 인덱스 → `start index 16 is larger than end index 0`. 또는 ReleaseSafe 의 freed memory marker 에서 0xAAA…A2.
- root cause: `putModule` / `getIfFresh` 의 `mod.* = cached.module` struct copy 가 ArenaAllocator state 의 buffer_list.first ptr 까지 양쪽에 복사. nullify 패턴으로 ownership 표현하지만 BufNode 자체는 한 쪽에서 free 되면 다른 쪽이 dangling.
- 발현 조건: cache-hit (특히 `mtime=0` 가상 module 처럼 emit cache 도 우회) → graph.deinit → 다음 rebuild 의 cache-hit → 다음 alloc 시도. user code 는 emit cache 가 hit 해서 우연히 우회됐을 뿐.

## 변경

- `src/bundler/module.zig`: 필드 type 변경 + `createParseArena` / `destroyParseArena` 헬퍼 추가
- `src/bundler/graph.zig`: 5개 init 사이트 (plugin load / json / generic parse / css / asset) 가 헬퍼 사용. by-reference unwrap (`|*pa|`) → by-ptr (`|pa|`)
- `src/bundler/module_store.zig`: deinit / 에러 경로가 `destroyParseArena` 사용. regression test 추가 (가상 모듈 path + cache-hit 왕복 후 다음 alloc 이 panic 없이 동작)
- `src/bundler/linker.zig` / `src/bundler/tree_shaker.zig` / `src/bundler/phase.zig`: 시그니처 / unwrap 정리

## Test plan

- [x] `zig build test` 통과 (alias_table 왕복 + 신규 parse_arena 왕복 regression 테스트 포함)
- [x] `tests/integration/tests/fixtures/rn-example-app` 에서 `devMode: true` watch + App.tsx 변경 → REBUILD callback 정상 발화
- [x] 동일 fixture 에서 `devMode: false` (production) watch + App.tsx 변경 → panic 없이 `onRebuild({success: true})`. 이게 이전엔 `0xAAA…A2` segfault 로 죽던 시나리오
- [ ] CI

PR #2695 (가상 모듈 mtime 우회) 는 이 PR 머지 시 불필요해짐 — close 예정.

Closes #2694