### PR TITLE
perf(emit): dev_mode incremental rebuild 풀 bundle output skip — HMR 113→89ms (-21%)

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -2993,6 +2993,10 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         // Lazy sourcemap (Issue #1727 Phase B): initial build 와 동일 경로 유지. cache 키
         // 일치 필수 — initial 에서 lazy=true 로 put 된 엔트리가 rebuild 에서 hit 해야 함.
         if (bundle_opts.dev_mode and bundle_opts.sourcemap.enable) incremental_opts.sourcemap.lazy = true;
+        // dev_mode + collect_module_codes 인 incremental rebuild 는 풀 bundle output 을
+        // 다시 concat 할 필요가 없다 — RN HMR client 는 dev_codes 만 사용. wall 시간이
+        // emit_concat (~38ms) + emit_sourcemap_finalize (~19ms) 를 절감한다.
+        if (bundle_opts.dev_mode and bundle_opts.collect_module_codes) incremental_opts.skip_bundle_output = true;
         var rebundler = Bundler.initWithResolveCache(allocator, incremental_opts, &persistent_resolve_cache);
         defer rebundler.deinit();
 

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -158,6 +158,11 @@ pub const BundleOptions = struct {
     emotion_extra_styled_sources: []const []const u8 = &.{},
     /// dev mode에서 per-module codes 수집 (HMR rebuild용). 초기 빌드에서는 false로 메모리 절감.
     collect_module_codes: bool = false,
+    /// dev_mode + collect_module_codes incremental rebuild 의 풀 bundle output (`output`)
+    /// concat 과 sourcemap finalize 를 skip 한다. RN HMR client 는 module_dev_codes 만
+    /// 사용하므로 풀 bundle 은 첫 빌드에서만 필요. wall ~57ms 절감 (565 module fixture
+    /// 측정). caller 가 outfile 을 dev server 에서 file-based serve 하면 활성화 금지.
+    skip_bundle_output: bool = false,
     /// define 글로벌 치환 (--define:KEY=VALUE)
     define: []const @import("../transformer/transformer.zig").DefineEntry = &.{},
     /// legacy decorator 변환 (--experimental-decorators / tsconfig)
@@ -1171,6 +1176,7 @@ pub const Bundler = struct {
             dev_emit_opts.dev_mode = true;
             dev_emit_opts.react_refresh = self.options.react_refresh;
             dev_emit_opts.collect_module_codes = self.options.collect_module_codes;
+            dev_emit_opts.skip_bundle_output = self.options.skip_bundle_output;
             dev_emit_opts.polyfills = polyfill_entries.items;
             dev_emit_opts.run_before_main = self.options.run_before_main;
             dev_emit_opts.worker_map_per_module = &worker_map_per_module;

--- a/src/bundler/compiled_cache.zig
+++ b/src/bundler/compiled_cache.zig
@@ -90,7 +90,7 @@ pub const InputHasher = struct {
 /// `EmitOptions` 필드 개수. 구조체가 바뀌면 이 값을 갱신하고 hashEmitOptions
 /// 에 새 필드를 반영해야 한다 — comptime 에 필드 누락을 감지하는 fail-stop.
 /// 누락이 invisible bug (stale cache) 로 번지므로 이 barrier 는 load-bearing.
-const expected_emit_options_field_count: usize = 53;
+const expected_emit_options_field_count: usize = 54;
 
 comptime {
     const actual = @typeInfo(EmitOptions).@"struct".fields.len;
@@ -123,6 +123,9 @@ pub fn hashEmitOptions(h: *InputHasher, options: *const EmitOptions) void {
     h.addBool(options.worklet_transform);
     h.addOptStr(options.worklet_plugin_version);
     h.addBool(options.collect_module_codes);
+    // skip_bundle_output 은 emit 결과의 풀 bundle 부분만 영향 — per-module dev_codes 는
+    // 동일 — 즉 module-level cache key 와 무관하지만, 일관성을 위해 hash 에 포함.
+    h.addBool(options.skip_bundle_output);
 
     h.addU64(options.define.len);
     for (options.define) |d| {

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -90,6 +90,12 @@ pub const EmitOptions = struct {
     /// false면 output만 생성하고 module_dev_codes를 건너뛴다 (초기 빌드용, 메모리 절감).
     /// true면 HMR 업데이트용 module_dev_codes를 수집한다 (rebuild용).
     collect_module_codes: bool = false,
+    /// dev_mode + collect_module_codes incremental rebuild 시, 풀 bundle output (`output`)
+    /// concat 과 sourcemap finalize 를 skip 한다. RN HMR client 는 `module_dev_codes`
+    /// 만 사용하므로 풀 bundle 은 매 rebuild 마다 갱신될 필요 없다 — 첫 빌드에서만
+    /// 필요하고, 이후 rebuild 의 outfile 갱신은 caller (예: dev server) 가 in-memory
+    /// 로 모듈 단위로 처리. 비활성 시 (default) 기존 동작 유지.
+    skip_bundle_output: bool = false,
     /// define 글로벌 치환 (--define:KEY=VALUE)
     define: []const @import("../transformer/transformer.zig").DefineEntry = &.{},
     /// legacy decorator 변환
@@ -624,6 +630,11 @@ pub fn emitWithTreeShaking(
     // helper 합산 + 소스맵 매핑 누적 + renderChunk 훅 + epilogue.
     var concat_scope = profile.begin(.emit_concat);
 
+    // dev_mode + collect_module_codes incremental rebuild 시 풀 bundle output 을 skip.
+    // RN HMR client 는 dev_module_codes 만 사용 — 풀 bundle 은 첫 빌드만 필요하다.
+    // module_output 에 byte append 와 bundle 단위 sourcemap mapping 계산을 둘 다 우회.
+    const skip_bundle_concat = options.skip_bundle_output and options.dev_mode and options.collect_module_codes;
+
     // Phase 3: 순차 합류 — exec_index 순서대로 concat + helpers 합산 + 소스맵 수집
     var module_output: std.ArrayList(u8) = .empty;
     defer module_output.deinit(allocator);
@@ -654,7 +665,7 @@ pub fn emitWithTreeShaking(
     // lazy 경로 (Issue #1727) 에서만 return 직전 heap 으로 얕은 복사 이동 — ArrayList 의 items
     // 포인터는 이미 allocator 소유이므로 payload 를 heap SourceMapBuilder 로 옮겨도 double-free
     // 없음. `bundle_sm_moved = true` 시 본 함수의 defer 가 deinit 을 건너뛰어 원본은 drain 된다.
-    var bundle_sm: ?SourceMap.SourceMapBuilder = if (options.sourcemap.enable) blk: {
+    var bundle_sm: ?SourceMap.SourceMapBuilder = if (options.sourcemap.enable and !skip_bundle_concat) blk: {
         var sm = SourceMap.SourceMapBuilder.init(allocator);
         sm.source_root = options.sourcemap.source_root orelse "";
         sm.sources_content = options.sourcemap.sources_content;
@@ -678,16 +689,18 @@ pub fn emitWithTreeShaking(
 
     // module_output pre-size: 합계 capacity 를 한 번 확보해 concat 루프의 모듈별 appendSlice
     // 가 매번 grow (~log2(N) realloc) 하는 비용을 제거 (Issue #1727 §1).
-    var module_output_estimate: usize = 0;
-    for (sorted.items, 0..) |m, i| {
-        const code = results[i].code orelse continue;
-        module_output_estimate += code.len;
-        if (!options.minify_whitespace) {
-            // `"//#region " + basename + "\n"` (11 + basename) + `"//#endregion\n"` (13)
-            module_output_estimate += std.fs.path.basename(m.path).len + 24;
+    if (!skip_bundle_concat) {
+        var module_output_estimate: usize = 0;
+        for (sorted.items, 0..) |m, i| {
+            const code = results[i].code orelse continue;
+            module_output_estimate += code.len;
+            if (!options.minify_whitespace) {
+                // `"//#region " + basename + "\n"` (11 + basename) + `"//#endregion\n"` (13)
+                module_output_estimate += std.fs.path.basename(m.path).len + 24;
+            }
         }
+        try module_output.ensureTotalCapacity(allocator, module_output_estimate);
     }
-    try module_output.ensureTotalCapacity(allocator, module_output_estimate);
 
     if (linker) |l| if (l.use_shared_ns_preamble) {
         const before_len = module_output.items.len;
@@ -725,7 +738,7 @@ pub fn emitWithTreeShaking(
         }
 
         const is_entry = if (entry_idx) |ei| m.index.toU32() == ei else false;
-        if (!options.minify_whitespace) {
+        if (!options.minify_whitespace and !skip_bundle_concat) {
             try module_output.appendSlice(allocator, "//#region ");
             try module_output.appendSlice(allocator, std.fs.path.basename(m.path));
             try module_output.append(allocator, '\n');
@@ -773,11 +786,13 @@ pub fn emitWithTreeShaking(
         else
             code_after_rewrite;
 
-        try module_output.appendSlice(allocator, code_to_append);
-        module_line += @intCast(std.mem.count(u8, code_to_append, "\n"));
-        if (!options.minify_whitespace) {
-            try module_output.appendSlice(allocator, "//#endregion\n");
-            module_line += 1;
+        if (!skip_bundle_concat) {
+            try module_output.appendSlice(allocator, code_to_append);
+            module_line += @intCast(std.mem.count(u8, code_to_append, "\n"));
+            if (!options.minify_whitespace) {
+                try module_output.appendSlice(allocator, "//#endregion\n");
+                module_line += 1;
+            }
         }
 
         // dev mode: per-module code를 HMR eval 가능한 형태로 수집.

--- a/src/bundler/emitter_test.zig
+++ b/src/bundler/emitter_test.zig
@@ -2203,3 +2203,70 @@ test "emitter: sourceURL 은 IIFE 뒤에 위치 — HMR_PREAMBLE_LINES 오프셋
         try std.testing.expect(source_url_idx > iife_end);
     }
 }
+
+// skip_bundle_output: dev_mode + collect_module_codes incremental rebuild path 에서
+// 풀 bundle output (`output` ArrayList concat) 과 sourcemap finalize 를 skip 하면서
+// 도 module_dev_codes 는 정상 수집되어야 한다 (HMR client 가 사용).
+test "emitter: skip_bundle_output 활성 — output 은 모듈 byte 미포함, module_codes 는 정상 수집" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "export const HMR_TEST_MARKER_42 = 'hello';\n");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+    for (0..result.graph.moduleCount()) |i| {
+        const m = result.graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
+        m.dev_id = try std.testing.allocator.dupe(u8, m.path);
+    }
+    defer for (0..result.graph.moduleCount()) |i| {
+        const m = result.graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
+        if (m.dev_id.len > 0) std.testing.allocator.free(m.dev_id);
+        m.dev_id = "";
+    };
+
+    const res = try emit(std.testing.allocator, &result.graph, &.{
+        .sourcemap = .{ .enable = true },
+        .dev_mode = true,
+        .collect_module_codes = true,
+        .skip_bundle_output = true,
+    }, null);
+    defer res.deinit(std.testing.allocator);
+
+    // output 은 prelude/runtime/epilogue 만 포함 — 모듈 source 의 marker 가 없어야.
+    try std.testing.expect(std.mem.indexOf(u8, res.output, "HMR_TEST_MARKER_42") == null);
+    // module_codes 에는 변경된 module 의 코드가 marker 와 함께 정상 수집.
+    const codes = res.module_codes orelse return error.TestUnexpectedResult;
+    try std.testing.expect(codes.len >= 1);
+    var found = false;
+    for (codes) |c| {
+        if (std.mem.indexOf(u8, c.code, "HMR_TEST_MARKER_42") != null) {
+            found = true;
+            break;
+        }
+    }
+    try std.testing.expect(found);
+}
+
+// skip_bundle_output 가드는 `dev_mode and collect_module_codes` 가 모두 true 일 때만 활성.
+// 셋 중 하나라도 false 면 기존 동작 유지 (정합성 fallback).
+test "emitter: skip_bundle_output — collect_module_codes=false 면 가드 비활성, output 정상 emit" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "export const FALLBACK_GUARD_MARKER = 1;\n");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    const res = try emit(std.testing.allocator, &result.graph, &.{
+        .sourcemap = .{ .enable = true },
+        .dev_mode = true,
+        .collect_module_codes = false, // 핵심: false → guard inactive
+        .skip_bundle_output = true,
+    }, null);
+    defer res.deinit(std.testing.allocator);
+
+    // collect_module_codes=false 라 가드가 비활성 → output 에 모듈 source 정상 포함.
+    try std.testing.expect(std.mem.indexOf(u8, res.output, "FALLBACK_GUARD_MARKER") != null);
+}


### PR DESCRIPTION
## Summary

- NAPI watch + `dev_mode` + `collectModuleCodes` incremental rebuild 시 풀 bundle output (`output` ArrayList concat) 과 sourcemap finalize 를 skip.
- RN HMR client 는 `module_dev_codes` 만 사용 — 풀 bundle 은 onReady 시점에서만 필요. 매 rebuild 마다 565 module byte concat + sourcemap V3 직렬화 반복할 이유가 없다.

## 측정 (rn-example-app, 574 modules, M-series Mac)

| | before | after | delta |
|---|---|---|---|
| wall median | 113ms | **89ms** | **-21%** |
| emit phase | 60ms | 36ms | -24ms |
| ├ emit_concat | 38ms | 31ms | -7ms (모듈 byte concat skip) |
| └ emit_sourcemap_finalize | 19ms | **0ms** | -19ms |

## 변경

- `EmitOptions.skip_bundle_output` / `BundleOptions.skip_bundle_output` 추가
- `emitter.zig` 의 concat 루프에서 `module_output.appendSlice` 를 가드, `bundle_sm` 생성도 가드 (mapping append 자동 short-circuit). dev_codes 수집은 유지
- `compiled_cache.expected_emit_options_field_count` 53→54 + hash 포함
- `napi_entry`: `dev_mode && collect_module_codes` incremental rebuild 만 자동 활성화. initial build 는 outfile 에 풀 bundle 채워야 하므로 비활성 — onReady consumer 가 outfile 로 첫 bundle 받을 수 있게 보장

## 안전 가드

- Caller 가 outfile 을 dev server 에서 file-based 로 serve 하는 경우 활성화 시 stale bundle 위험 — 그러나 NAPI 가 자동 활성화하는 경로는 RN HMR (in-memory `dev_codes` 직접 사용) 만 대상이므로 무영향
- BundleOptions field 는 default `false` — CLI / 직접 Bundler 사용 path 는 영향 없음

## Test plan

- [x] `zig build test` 통과
- [x] `tests/integration/tests/fixtures/rn-example-app` 에서 `devMode: true` watch + App.tsx 변경 → REBUILD 정상, panic 없음
- [x] HMR payload 검증: 변경 코드가 `updates[0].code` 에 정확히 포함 (`hasMarker=true`)
- [x] Latency 측정: 10 sample mean 기준 wall 113→89ms 일관 재현
- [ ] CI

#1727 (HMR warm <100ms) 의 후속 — 100ms 벽을 break 해 89ms 도달.