### PR TITLE
fix(react-native): avoid default Babel transform pass

### DIFF
--- a/examples/react-native-bare/App.tsx
+++ b/examples/react-native-bare/App.tsx
@@ -40,11 +40,8 @@ import Animated, {
   Extrapolation,
 } from 'react-native-reanimated';
 import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
-// ~/  alias test (babel-plugin-root-import: ~/ → ./src)
+import Svg, { Polyline, type SvgProps } from 'react-native-svg';
 import { getGreeting, getVersion } from '~/utils/greeting';
-
-// SVG test (react-native-svg-transformer)
-import CheckIcon from '~/assets/check.svg';
 
 // ES5 다운레벨 스트레스 테스트 — 번들 출력 검증용. 런타임엔 호출 안 해도 됨.
 import { es5DownlevelCases } from './src/es5-downlevel-cases';
@@ -63,6 +60,26 @@ interface TestResult {
   status: TestStatus;
   message: string;
   duration?: number;
+}
+
+function CheckIcon({
+  stroke = 'currentColor',
+  strokeWidth = 2,
+  strokeLinecap = 'round',
+  strokeLinejoin = 'round',
+  ...svgProps
+}: SvgProps) {
+  return (
+    <Svg width={24} height={24} viewBox="0 0 24 24" fill="none" {...svgProps}>
+      <Polyline
+        points="20 6 9 17 4 12"
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+        strokeLinecap={strokeLinecap}
+        strokeLinejoin={strokeLinejoin}
+      />
+    </Svg>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -295,8 +312,8 @@ function AppContent({ isDarkMode }: { isDarkMode: boolean }) {
     });
     console.log('Array test:', [1, 'two', { three: 3 }, [4, 5]]);
 
-    // babel-plugin-root-import (~/ alias) + lodash tree-shaking test
-    console.log('Root import test:', getGreeting('world'));
+    // native import + lodash path import test
+    console.log('Lodash import test:', getGreeting('world'));
     console.log('Version:', getVersion());
 
     setConsoleTest({
@@ -446,11 +463,11 @@ function AppContent({ isDarkMode }: { isDarkMode: boolean }) {
           dimColor={dimColor}
         />
 
-        {/* Babel Plugin Tests */}
+        {/* Native Transform Tests */}
         <View style={[styles.card, { backgroundColor: cardBg }]}>
-          <Text style={[styles.cardTitle, { color: textColor }]}>Babel Plugins</Text>
+          <Text style={[styles.cardTitle, { color: textColor }]}>Native Transforms</Text>
           <Text style={[styles.cardDesc, { color: dimColor }]}>
-            root-import, lodash, SVG, decorators
+            SVG component, lodash path import, worklets
           </Text>
           <View style={{ marginTop: 8, gap: 4 }}>
             <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
@@ -462,7 +479,7 @@ function AppContent({ isDarkMode }: { isDarkMode: boolean }) {
               </Text>
             </View>
             <Text style={{ color: textColor, fontSize: 13 }}>
-              ~/ alias: {getGreeting('dev')}
+              greeting: {getGreeting('dev')}
             </Text>
             <Text style={{ color: textColor, fontSize: 13 }}>
               version: {getVersion()}

--- a/examples/react-native-bare/App.tsx
+++ b/examples/react-native-bare/App.tsx
@@ -40,7 +40,7 @@ import Animated, {
   Extrapolation,
 } from 'react-native-reanimated';
 import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
-import Svg, { Polyline, type SvgProps } from 'react-native-svg';
+import CheckIcon from '~/assets/check.svg';
 import { getGreeting, getVersion } from '~/utils/greeting';
 
 // ES5 다운레벨 스트레스 테스트 — 번들 출력 검증용. 런타임엔 호출 안 해도 됨.
@@ -60,26 +60,6 @@ interface TestResult {
   status: TestStatus;
   message: string;
   duration?: number;
-}
-
-function CheckIcon({
-  stroke = 'currentColor',
-  strokeWidth = 2,
-  strokeLinecap = 'round',
-  strokeLinejoin = 'round',
-  ...svgProps
-}: SvgProps) {
-  return (
-    <Svg width={24} height={24} viewBox="0 0 24 24" fill="none" {...svgProps}>
-      <Polyline
-        points="20 6 9 17 4 12"
-        stroke={stroke}
-        strokeWidth={strokeWidth}
-        strokeLinecap={strokeLinecap}
-        strokeLinejoin={strokeLinejoin}
-      />
-    </Svg>
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -391,8 +371,8 @@ function AppContent({ isDarkMode }: { isDarkMode: boolean }) {
       {/* Test cards */}
       <View style={styles.section}>
         <TestCard
-          title="GET Request"
-          desc="jsonplaceholder /posts/1"
+          title='GET Request'
+          desc='jsonplaceholder /posts/1'
           result={fetchGet}
           onRun={runFetchGet}
           cardBg={cardBg}
@@ -400,8 +380,8 @@ function AppContent({ isDarkMode }: { isDarkMode: boolean }) {
           dimColor={dimColor}
         />
         <TestCard
-          title="POST Request"
-          desc="jsonplaceholder /posts"
+          title='POST Request'
+          desc='jsonplaceholder /posts'
           result={fetchPost}
           onRun={runFetchPost}
           cardBg={cardBg}
@@ -409,8 +389,8 @@ function AppContent({ isDarkMode }: { isDarkMode: boolean }) {
           dimColor={dimColor}
         />
         <TestCard
-          title="Error Handling"
-          desc="httpstat.us/404"
+          title='Error Handling'
+          desc='httpstat.us/404'
           result={fetchError}
           onRun={runFetchError}
           cardBg={cardBg}
@@ -418,8 +398,8 @@ function AppContent({ isDarkMode }: { isDarkMode: boolean }) {
           dimColor={dimColor}
         />
         <TestCard
-          title="WebSocket Echo"
-          desc="echo.websocket.org"
+          title='WebSocket Echo'
+          desc='echo.websocket.org'
           result={wsTest}
           onRun={runWsTest}
           cardBg={cardBg}
@@ -427,8 +407,8 @@ function AppContent({ isDarkMode }: { isDarkMode: boolean }) {
           dimColor={dimColor}
         />
         <TestCard
-          title="Abort Timeout"
-          desc="3s timeout on 10s delay"
+          title='Abort Timeout'
+          desc='3s timeout on 10s delay'
           result={timeoutTest}
           onRun={runTimeoutTest}
           cardBg={cardBg}
@@ -436,8 +416,8 @@ function AppContent({ isDarkMode }: { isDarkMode: boolean }) {
           dimColor={dimColor}
         />
         <TestCard
-          title="Parallel Fetch"
-          desc="5 concurrent GET requests"
+          title='Parallel Fetch'
+          desc='5 concurrent GET requests'
           result={multiTest}
           onRun={runMultiTest}
           cardBg={cardBg}
@@ -445,8 +425,8 @@ function AppContent({ isDarkMode }: { isDarkMode: boolean }) {
           dimColor={dimColor}
         />
         <TestCard
-          title="Error / SourceMap"
-          desc="Throw error — check Red Screen + stack trace"
+          title='Error / SourceMap'
+          desc='Throw error — check Red Screen + stack trace'
           result={errorTest}
           onRun={runErrorTest}
           cardBg={cardBg}
@@ -454,8 +434,8 @@ function AppContent({ isDarkMode }: { isDarkMode: boolean }) {
           dimColor={dimColor}
         />
         <TestCard
-          title="Console Levels"
-          desc="log, info, warn, error, debug — check terminal"
+          title='Console Levels'
+          desc='log, info, warn, error, debug — check terminal'
           result={consoleTest}
           onRun={runConsoleTest}
           cardBg={cardBg}
@@ -472,18 +452,14 @@ function AppContent({ isDarkMode }: { isDarkMode: boolean }) {
           <View style={{ marginTop: 8, gap: 4 }}>
             <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
               <View style={{ backgroundColor: '#E8F5E9', borderRadius: 8, padding: 8 }}>
-                <CheckIcon width={32} height={32} stroke="#4CAF50" strokeWidth={3} />
+                <CheckIcon width={32} height={32} stroke='#4CAF50' strokeWidth={3} />
               </View>
               <Text style={{ color: textColor, fontSize: 14, fontWeight: '600' }}>
                 SVG component loaded
               </Text>
             </View>
-            <Text style={{ color: textColor, fontSize: 13 }}>
-              greeting: {getGreeting('dev')}
-            </Text>
-            <Text style={{ color: textColor, fontSize: 13 }}>
-              version: {getVersion()}
-            </Text>
+            <Text style={{ color: textColor, fontSize: 13 }}>greeting: {getGreeting('dev')}</Text>
+            <Text style={{ color: textColor, fontSize: 13 }}>version: {getVersion()}</Text>
           </View>
         </View>
       </View>
@@ -787,10 +763,7 @@ function PinchRotateDemo({
   const composed = Gesture.Simultaneous(pinch, rotate);
 
   const boxStyle = useAnimatedStyle(() => ({
-    transform: [
-      { scale: scale.value },
-      { rotateZ: `${(angle.value * 180) / Math.PI}deg` },
-    ],
+    transform: [{ scale: scale.value }, { rotateZ: `${(angle.value * 180) / Math.PI}deg` }],
   }));
 
   const reset = () => {
@@ -1022,12 +995,7 @@ function SharedMorphDemo({
         </TouchableOpacity>
       </View>
       <View style={{ alignItems: 'center', paddingVertical: 20 }}>
-        <Animated.View
-          style={[
-            { justifyContent: 'center', alignItems: 'center' },
-            morphStyle,
-          ]}
-        >
+        <Animated.View style={[{ justifyContent: 'center', alignItems: 'center' }, morphStyle]}>
           <Animated.Text style={[{ color: '#fff', fontWeight: '700' }, labelStyle]}>
             expanded
           </Animated.Text>
@@ -1137,7 +1105,7 @@ function TestCard({
           disabled={result.status === 'running'}
         >
           {result.status === 'running' ? (
-            <ActivityIndicator size="small" color="#fff" />
+            <ActivityIndicator size='small' color='#fff' />
           ) : (
             <Text style={styles.runBtnText}>Run</Text>
           )}

--- a/examples/react-native-bare/babel.config.js
+++ b/examples/react-native-bare/babel.config.js
@@ -1,20 +1,3 @@
 module.exports = {
   presets: ['module:@react-native/babel-preset'],
-  plugins: [
-    [
-      'babel-plugin-root-import',
-      {
-        rootPathSuffix: './src',
-        rootPathPrefix: '~/',
-        functions: ['jest.mock'],
-      },
-    ],
-    ['@babel/plugin-proposal-optional-chaining'],
-    '@babel/plugin-transform-flow-strip-types',
-    ['@babel/plugin-proposal-decorators', { version: 'legacy' }],
-    ['@babel/plugin-transform-class-properties', { loose: true }],
-    ['@babel/plugin-transform-private-methods', { loose: true }],
-    ['lodash'],
-    ['react-native-worklets/plugin'],
-  ],
 };

--- a/examples/react-native-bare/jest.config.js
+++ b/examples/react-native-bare/jest.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   preset: 'react-native',
+  moduleNameMapper: {
+    '^~/(.*)$': '<rootDir>/src/$1',
+  },
 };

--- a/examples/react-native-bare/metro.config.js
+++ b/examples/react-native-bare/metro.config.js
@@ -14,7 +14,12 @@ const defaultConfig = getDefaultConfig(__dirname);
  */
 const config = {
   watchFolders: [monorepoRoot],
+  transformer: {
+    babelTransformerPath: require.resolve('react-native-svg-transformer/react-native'),
+  },
   resolver: {
+    assetExts: defaultConfig.resolver.assetExts.filter((ext) => ext !== 'svg'),
+    sourceExts: [...defaultConfig.resolver.sourceExts, 'svg'],
     nodeModulesPaths: [
       path.resolve(__dirname, 'node_modules'),
       path.resolve(monorepoRoot, 'node_modules'),

--- a/examples/react-native-bare/metro.config.js
+++ b/examples/react-native-bare/metro.config.js
@@ -14,12 +14,7 @@ const defaultConfig = getDefaultConfig(__dirname);
  */
 const config = {
   watchFolders: [monorepoRoot],
-  transformer: {
-    babelTransformerPath: require.resolve('react-native-svg-transformer/react-native'),
-  },
   resolver: {
-    assetExts: defaultConfig.resolver.assetExts.filter((ext) => ext !== 'svg'),
-    sourceExts: [...defaultConfig.resolver.sourceExts, 'svg'],
     nodeModulesPaths: [
       path.resolve(__dirname, 'node_modules'),
       path.resolve(monorepoRoot, 'node_modules'),

--- a/examples/react-native-bare/src/utils/greeting.ts
+++ b/examples/react-native-bare/src/utils/greeting.ts
@@ -1,11 +1,10 @@
-import _ from 'lodash';
+import capitalize from 'lodash/capitalize';
 
 /**
- * Test module for babel-plugin-root-import (~/utils/greeting)
- * and babel-plugin-lodash (tree-shaking)
+ * Test module for direct lodash path import without Babel.
  */
 export function getGreeting(name: string): string {
-  return _.capitalize(`hello ${name} from bungae`);
+  return capitalize(`hello ${name} from bungae`);
 }
 
 export function getVersion(): string {

--- a/examples/react-native-bare/tsconfig.json
+++ b/examples/react-native-bare/tsconfig.json
@@ -4,6 +4,10 @@
     "types": ["jest", "node"],
     "lib": ["ESNext", "DOM"],
     "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["src/*"]
+    },
     "esModuleInterop": true,
     "skipLibCheck": true
   },

--- a/examples/react-native-bare/zntc.config.ts
+++ b/examples/react-native-bare/zntc.config.ts
@@ -14,7 +14,7 @@ export default {
   minify: false,
   outDir: join(__dirname, ".zntc"),
   resolver: {
-    sourceExts: [".tsx", ".ts", ".jsx", ".js", ".mjs", ".cjs", ".json", ".svg"],
+    sourceExts: [".tsx", ".ts", ".jsx", ".js", ".mjs", ".cjs", ".json"],
     assetExts: [
       ".bmp",
       ".gif",
@@ -22,6 +22,7 @@ export default {
       ".jpeg",
       ".png",
       ".webp",
+      ".svg",
       ".avif",
       ".ico",
       ".icns",
@@ -34,8 +35,9 @@ export default {
   transformer: {
     minifier: "terser",
     inlineRequires: false,
-    babelTransformerPath: "react-native-svg-transformer/react-native",
-    babel: {},
+  },
+  alias: {
+    "~": join(__dirname, "src"),
   },
   serializer: {
     polyfills: [],

--- a/examples/react-native-bare/zntc.config.ts
+++ b/examples/react-native-bare/zntc.config.ts
@@ -1,52 +1,51 @@
 // ZNTC dev server + bundler config — React Native 0.85 bare.
 // `zntc dev --platform=react-native` 가 본 파일을 자동 로드.
 
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 export default {
   root: __dirname,
-  entry: "index.js",
+  entry: 'index.js',
   dev: true,
   minify: false,
-  outDir: join(__dirname, ".zntc"),
+  outDir: join(__dirname, '.zntc'),
   resolver: {
-    sourceExts: [".tsx", ".ts", ".jsx", ".js", ".mjs", ".cjs", ".json"],
+    sourceExts: ['.tsx', '.ts', '.jsx', '.js', '.mjs', '.cjs', '.json', '.svg'],
     assetExts: [
-      ".bmp",
-      ".gif",
-      ".jpg",
-      ".jpeg",
-      ".png",
-      ".webp",
-      ".svg",
-      ".avif",
-      ".ico",
-      ".icns",
-      ".icxl",
+      '.bmp',
+      '.gif',
+      '.jpg',
+      '.jpeg',
+      '.png',
+      '.webp',
+      '.avif',
+      '.ico',
+      '.icns',
+      '.icxl',
     ],
-    platforms: ["ios", "android", "native"],
+    platforms: ['ios', 'android', 'native'],
     preferNativePlatform: true,
-    nodeModulesPaths: [join(__dirname, "../../node_modules")],
+    nodeModulesPaths: [join(__dirname, '../../node_modules')],
   },
   transformer: {
-    minifier: "terser",
+    minifier: 'terser',
     inlineRequires: false,
   },
   alias: {
-    "~": join(__dirname, "src"),
+    '~': join(__dirname, 'src'),
   },
   serializer: {
     polyfills: [],
     prelude: [],
-    bundleType: "plain",
+    bundleType: 'plain',
   },
   server: {
     port: 8081,
-    host: "localhost",
+    host: 'localhost',
     useGlobalHotkey: true,
     forwardClientLogs: false,
     verifyConnections: false,

--- a/packages/core/bin/rn-dev-input.mjs
+++ b/packages/core/bin/rn-dev-input.mjs
@@ -67,6 +67,21 @@ export function buildRnBundleExtra(config, opts = {}) {
   };
 }
 
+export function buildRnBundleOverride(config, override) {
+  const cfg = config ?? {};
+  const out = {};
+  if (cfg.alias && typeof cfg.alias === 'object') {
+    out.alias = cfg.alias;
+  }
+  if (cfg.moduleSpecifierMap && typeof cfg.moduleSpecifierMap === 'object') {
+    out.moduleSpecifierMap = cfg.moduleSpecifierMap;
+  }
+  if (override && typeof override === 'object') {
+    Object.assign(out, override);
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
 /**
  * 번개 BungaeConfig 의 `root` / `entry` / `dev` / `minify` / `server.*` /
  * `resolver.*` / `transformer.*` / `serializer.*` / `symbolicator.*` /
@@ -116,6 +131,7 @@ export function buildRnDevServerInput(opts, config) {
         cfg.minify ||
         false,
       extra: buildRnBundleExtra(cfg, opts),
+      override: buildRnBundleOverride(cfg),
     },
     port: opts.port ?? server.port ?? 8081,
     host: opts.host ?? server.host ?? 'localhost',

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -16,7 +16,11 @@ import { fileURLToPath } from 'node:url';
 
 import { applyFlagAction, KNOWN_FLAGS, matchFlagFromRegistry } from './cli-flags.mjs';
 import { copyRnAssets } from './rn-asset-copy.mjs';
-import { buildRnBundleExtra, buildRnDevServerInput } from './rn-dev-input.mjs';
+import {
+  buildRnBundleExtra,
+  buildRnBundleOverride,
+  buildRnDevServerInput,
+} from './rn-dev-input.mjs';
 
 function isMissingBuiltCore(error) {
   if (!error || error.code !== 'ERR_MODULE_NOT_FOUND') return false;
@@ -719,7 +723,10 @@ async function runRnBundle(opts, config) {
     minify:
       opts.minify || opts.minifyWhitespace || opts.minifyIdentifiers || opts.minifySyntax || false,
     extra: buildRnBundleExtra(cfg, opts),
-    override: outfile && !callerWrite ? { outfile, write: true } : undefined,
+    override: buildRnBundleOverride(
+      cfg,
+      outfile && !callerWrite ? { outfile, write: true } : undefined,
+    ),
   });
 
   // caller-side write — bundle / sourcemap path 분리 + URL override 적용.

--- a/packages/core/bin/zntc.test.ts
+++ b/packages/core/bin/zntc.test.ts
@@ -5129,6 +5129,19 @@ describe('buildRnDevServerInput — config + opts 추출 (#2605)', () => {
     expect(input?.bundle.extra?.watchFolders).toEqual(['../shared', '../tokens']);
   });
 
+  test('config.alias / moduleSpecifierMap → bundle.override 매핑', async () => {
+    const { buildRnDevServerInput } = await import('./rn-dev-input.mjs');
+    const input = buildRnDevServerInput(
+      { entryPoints: ['i.js'] },
+      {
+        alias: { '~': '/abs/src' },
+        moduleSpecifierMap: { lodash: 'lodash/{name}' },
+      },
+    );
+    expect(input?.bundle.override?.alias).toEqual({ '~': '/abs/src' });
+    expect(input?.bundle.override?.moduleSpecifierMap).toEqual({ lodash: 'lodash/{name}' });
+  });
+
   test('config.transformer.babelTransformerPath 매핑', async () => {
     const { buildRnDevServerInput } = await import('./rn-dev-input.mjs');
     const input = buildRnDevServerInput(

--- a/packages/react-native/src/plugins/asset.test.ts
+++ b/packages/react-native/src/plugins/asset.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 import { ZNTC_HMR_CLIENT_CODE } from '../runtime-loader.ts';
-import { createAssetPlugin } from './asset.ts';
+import { createAssetPlugin, createSvgComponentModule } from './asset.ts';
 import type { PluginConfig } from './types.ts';
 
 interface OnLoadHandler {
@@ -59,6 +62,48 @@ describe('createAssetPlugin', () => {
   test('babelTransformerPath 미지정 — HMRClient.js handler 만 등록 (custom transformer 없음)', () => {
     const handlers = captureHandlers(baseConfig);
     expect(handlers.length).toBe(1);
+  });
+
+  test('내장 SVG component transformer — sourceExts 에 .svg 지정 시 등록', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-rn-svg-'));
+    try {
+      const svgPath = join(dir, 'check-icon.svg');
+      writeFileSync(svgPath, '<svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg>');
+      const handlers = captureHandlers({
+        ...baseConfig,
+        sourceExts: ['ts', 'tsx', 'js', 'jsx', 'svg'],
+      });
+      expect(handlers.length).toBe(2);
+      const svgHandler = handlers[1]!;
+      expect(svgHandler.filter.test(svgPath)).toBe(true);
+      const result = await svgHandler.handler({ path: svgPath });
+      expect(result?.contents).toContain(`import { SvgXml } from 'react-native-svg';`);
+      expect(result?.contents).toContain('function SvgCheckIcon(props)');
+      expect(result?.contents).toContain('React.createElement(SvgXml');
+      expect(result?.contents).toContain('Object.assign({ xml }, props)');
+      expect(result?.contents).toContain('export default SvgCheckIcon');
+      expect(result?.contents).toContain(
+        JSON.stringify('<svg viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg>'),
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('내장 SVG component transformer — 사용자 babelTransformerPath 가 있으면 등록하지 않음', () => {
+    const handlers = captureHandlers({
+      ...baseConfig,
+      sourceExts: ['.ts', '.tsx', '.js', '.jsx', '.svg'],
+      babelTransformerPath: 'react-native-svg-transformer',
+    });
+    expect(handlers.length).toBe(2);
+    expect(handlers[1]!.filter.test('/abs/icon.svg')).toBe(true);
+  });
+
+  test('createSvgComponentModule — JS identifier 로 안전한 component name 생성', () => {
+    const code = createSvgComponentModule('<svg/>', '/tmp/24-check.icon.svg');
+    expect(code).toContain('function Svg24CheckIcon(props)');
+    expect(code).toContain('Svg24CheckIcon.displayName = "Svg24CheckIcon"');
   });
 
   test('babelTransformerPath 지정 + customExts 0 — HMRClient.js handler 만', () => {

--- a/packages/react-native/src/plugins/asset.ts
+++ b/packages/react-native/src/plugins/asset.ts
@@ -5,12 +5,18 @@
 // 책임 아님.
 
 import { readFileSync } from 'node:fs';
+import { basename, extname } from 'node:path';
 
 import type { ZntcPlugin } from '@zntc/core';
 
 import { HMR_CLIENT_SUFFIX, ZNTC_HMR_CLIENT_CODE } from '../runtime-loader.ts';
 import { escapeRegex } from './escape-regex.ts';
-import { type BabelInstance, getErrorMessage, requireFromCli } from './internal.ts';
+import {
+  type BabelInstance,
+  getErrorMessage,
+  normalizeExt,
+  requireFromCli,
+} from './internal.ts';
 import type { PluginConfig } from './types.ts';
 
 interface MetroTransformerResult {
@@ -24,6 +30,36 @@ interface MetroTransformer {
     filename: string;
     options: { platform: 'ios' | 'android'; dev: boolean };
   }): Promise<MetroTransformerResult> | MetroTransformerResult;
+}
+
+// SVGR/react-native-svg-transformer 와 동일하게 `Svg{Pascal}` 형태 — 사용자가
+// 두 transformer 사이를 옮길 때 컴포넌트 이름 변하지 않도록.
+function svgComponentName(filePath: string): string {
+  const pascal = basename(filePath, extname(filePath))
+    .split(/[^A-Za-z0-9_$]+/)
+    .filter(Boolean)
+    .map((part) => part[0]!.toUpperCase() + part.slice(1))
+    .join('');
+  return pascal ? `Svg${pascal}` : 'SvgComponent';
+}
+
+export function createSvgComponentModule(svg: string, filePath: string): string {
+  const componentName = svgComponentName(filePath);
+  return [
+    `import * as React from 'react';`,
+    `import { SvgXml } from 'react-native-svg';`,
+    ``,
+    `const xml = ${JSON.stringify(svg)};`,
+    ``,
+    `function ${componentName}(props) {`,
+    `  return React.createElement(SvgXml, Object.assign({ xml }, props));`,
+    `}`,
+    ``,
+    `${componentName}.displayName = ${JSON.stringify(componentName)};`,
+    ``,
+    `export default ${componentName};`,
+    ``,
+  ].join('\n');
 }
 
 /**
@@ -46,6 +82,15 @@ export function createAssetPlugin(config: PluginConfig): ZntcPlugin {
         ),
       }));
 
+      const hasSvgSource = config.sourceExts.some(
+        (e) => normalizeExt(e).toLowerCase() === '.svg',
+      );
+      if (!config.babelTransformerPath && hasSvgSource) {
+        build.onLoad({ filter: /\.svg$/i }, (args) => ({
+          contents: createSvgComponentModule(readFileSync(args.path, 'utf8'), args.path),
+        }));
+      }
+
       if (config.babelTransformerPath) {
         let customTransformer: MetroTransformer | null = null;
         let babel: BabelInstance | null = null;
@@ -54,8 +99,8 @@ export function createAssetPlugin(config: PluginConfig): ZntcPlugin {
         // 사용자 transformer 적용 대상 — sourceExts 중 ts/tsx/js/jsx/mjs/cjs/json
         // 외 (RN-specific 확장자, 예: .svg). 표준 JS/TS 는 ZNTC 가 처리하므로 제외.
         const customExts = config.sourceExts
-          .filter((e) => !/^\.(tsx?|jsx?|mjs|cjs|json)$/.test(e))
-          .map((e) => e.replace(/^\./, ''))
+          .map((e) => normalizeExt(e).slice(1))
+          .filter((e) => !/^(tsx?|jsx?|mjs|cjs|json)$/.test(e))
           .join('|');
 
         if (customExts) {

--- a/packages/react-native/src/plugins/asset.ts
+++ b/packages/react-native/src/plugins/asset.ts
@@ -11,12 +11,7 @@ import type { ZntcPlugin } from '@zntc/core';
 
 import { HMR_CLIENT_SUFFIX, ZNTC_HMR_CLIENT_CODE } from '../runtime-loader.ts';
 import { escapeRegex } from './escape-regex.ts';
-import {
-  type BabelInstance,
-  getErrorMessage,
-  normalizeExt,
-  requireFromCli,
-} from './internal.ts';
+import { type BabelInstance, getErrorMessage, normalizeExt, requireFromCli } from './internal.ts';
 import type { PluginConfig } from './types.ts';
 
 interface MetroTransformerResult {
@@ -82,9 +77,7 @@ export function createAssetPlugin(config: PluginConfig): ZntcPlugin {
         ),
       }));
 
-      const hasSvgSource = config.sourceExts.some(
-        (e) => normalizeExt(e).toLowerCase() === '.svg',
-      );
+      const hasSvgSource = config.sourceExts.some((e) => normalizeExt(e).toLowerCase() === '.svg');
       if (!config.babelTransformerPath && hasSvgSource) {
         build.onLoad({ filter: /\.svg$/i }, (args) => ({
           contents: createSvgComponentModule(readFileSync(args.path, 'utf8'), args.path),

--- a/packages/react-native/src/plugins/babel.ts
+++ b/packages/react-native/src/plugins/babel.ts
@@ -1,8 +1,9 @@
 // Babel 패스: 사용자 babel.config.js 의 custom plugin (Reanimated / NativeWind /
 // 사용자 worklet) 만 — ZNTC 가 native 처리하는 plugin (TS strip / RN preset /
 // JSX / class fields / worklets / flow / arrow / block-scoping 등) 은 zero-cost
-// pass. Babel/lazy-load — 첫 transform 호출 시점에 require, custom plugin 0 면
-// plugin 자체 등록 skip (createBabelPlugin 의 detectCustomPlugins false 분기).
+// pass. caller (preset.ts) 가 detectCustomPlugins 게이트로 등록 여부 결정 —
+// custom plugin 0 면 plugin 자체 미등록. Babel/lazy-load 는 첫 transform 호출
+// 시점에 require (`createBabelTransformer` 의 `ensureBabel`).
 
 import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
@@ -14,6 +15,7 @@ import {
   type BabelInstance,
   type BabelTransformOptions,
   getErrorMessage,
+  normalizeExt,
   requireFromCli,
 } from './internal.ts';
 import type { InlineBabelConfig, PluginConfig } from './types.ts';
@@ -267,18 +269,16 @@ export function createBabelTransformer(
 
 /**
  * Babel transform plugin — 사용자 babel.config.js 의 custom plugin (Reanimated
- * / NativeWind / 사용자 worklet) 을 source file 마다 적용. detectCustomPlugins
- * false 면 plugin 자체 등록 skip (NAPI build 의 startup latency 0).
+ * / NativeWind / 사용자 worklet) 을 source file 마다 적용. caller (preset.ts)
+ * 가 `detectCustomPlugins` 으로 게이트하므로 setup 시점엔 custom plugin 보장.
  */
 export function createBabelPlugin(config: PluginConfig): ZntcPlugin {
   return {
     name: 'zntc:react-native:babel-transform',
     setup(build) {
-      if (!detectCustomPlugins(config.projectRoot, config.inlineBabel)) return;
-
       const transformer = createBabelTransformer(config.projectRoot, config.inlineBabel);
 
-      const extPatterns = config.sourceExts.map((e) => e.replace(/^\./, '')).join('|');
+      const extPatterns = config.sourceExts.map((e) => normalizeExt(e).slice(1)).join('|');
       const sourcePattern = new RegExp(`\\.(${extPatterns})$`);
 
       build.onTransform({ filter: sourcePattern }, (args) => {

--- a/packages/react-native/src/plugins/internal.ts
+++ b/packages/react-native/src/plugins/internal.ts
@@ -38,3 +38,8 @@ export function getErrorMessage(err: unknown, max = 100): string {
   if (typeof e?.message === 'string') return e.message.slice(0, max);
   return String(err).slice(0, max);
 }
+
+/** `"ext"` / `".ext"` → `".ext"`. sourceExts/assetExts 정규화 공용. */
+export function normalizeExt(ext: string): string {
+  return ext.startsWith('.') ? ext : `.${ext}`;
+}

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -39,7 +39,7 @@ describe('buildRnBundleOptions — 기본 RN preset 필드', () => {
     expect(opts.platform).toBe('react-native');
   });
 
-  test('RN-specific 자동 활성 필드 (target/flow/jsxInJs/configurableExports/strictExecutionOrder/workletTransform)', () => {
+  test('RN-specific 자동 활성 필드 (target/flow/jsxInJs/configurableExports/strictExecutionOrder/workletTransform/codegenTransform)', () => {
     const opts = buildRnBundleOptions(baseInput());
     expect(opts.target).toBe('es5');
     expect(opts.flow).toBe(true);
@@ -47,6 +47,7 @@ describe('buildRnBundleOptions — 기본 RN preset 필드', () => {
     expect(opts.configurableExports).toBe(true);
     expect(opts.strictExecutionOrder).toBe(true);
     expect(opts.workletTransform).toBe(true);
+    expect(opts.codegenTransform).toBe(true);
   });
 
   test('emitDiskSourcemap — dev 시 false, prod 시 true', () => {
@@ -307,20 +308,30 @@ describe('buildRnBundleOptions — dev mode 분기 (jsx / devMode / reactRefresh
   });
 });
 
-describe('buildRnBundleOptions — plugins (asset/codegen/babel/require-context/[+metro-resolve])', () => {
-  test('기본 4 plugin (asset/codegen/babel/require-context)', () => {
+describe('buildRnBundleOptions — plugins (asset/optional-babel/require-context/[+metro-resolve])', () => {
+  test('기본 2 plugin (asset/require-context)', () => {
     const opts = buildRnBundleOptions(baseInput());
-    expect(opts.plugins?.length).toBe(4);
+    expect(opts.plugins?.length).toBe(2);
     const names = opts.plugins?.map((p) => p.name);
-    expect(names).toEqual([
+    expect(names).toEqual(['zntc:react-native:runtime', 'zntc:react-native:require-context']);
+  });
+
+  test('native 외 inline babel plugin 지정 시 babel plugin 추가', () => {
+    const opts = buildRnBundleOptions(
+      baseInput({
+        extra: {
+          babel: { plugins: ['nativewind/babel'] },
+        },
+      }),
+    );
+    expect(opts.plugins?.map((p) => p.name)).toEqual([
       'zntc:react-native:runtime',
-      'zntc:react-native:codegen-view-config',
       'zntc:react-native:babel-transform',
       'zntc:react-native:require-context',
     ]);
   });
 
-  test('extra.metroResolveRequest 지정 시 5 plugin (metro-resolve-request 추가)', () => {
+  test('extra.metroResolveRequest 지정 시 3 plugin (metro-resolve-request 추가)', () => {
     const opts = buildRnBundleOptions(
       baseInput({
         extra: {
@@ -328,8 +339,8 @@ describe('buildRnBundleOptions — plugins (asset/codegen/babel/require-context/
         },
       }),
     );
-    expect(opts.plugins?.length).toBe(5);
-    expect(opts.plugins?.[4]?.name).toBe('zntc:react-native:metro-resolve-request');
+    expect(opts.plugins?.length).toBe(3);
+    expect(opts.plugins?.[2]?.name).toBe('zntc:react-native:metro-resolve-request');
   });
 
   test('extra.additionalPlugins → plugins 끝에 append', () => {
@@ -341,8 +352,8 @@ describe('buildRnBundleOptions — plugins (asset/codegen/babel/require-context/
         },
       }),
     );
-    expect(opts.plugins?.length).toBe(5);
-    expect(opts.plugins?.[4]).toBe(userPlugin);
+    expect(opts.plugins?.length).toBe(3);
+    expect(opts.plugins?.[2]).toBe(userPlugin);
   });
 });
 

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -30,8 +30,7 @@ import {
 
 import type { CustomResolver, MetroPlatform } from './metro-resolver-types.ts';
 import { createAssetPlugin } from './plugins/asset.ts';
-import { createBabelPlugin } from './plugins/babel.ts';
-import { createCodegenPlugin } from './plugins/codegen.ts';
+import { createBabelPlugin, detectCustomPlugins } from './plugins/babel.ts';
 import { requireFromCli } from './plugins/internal.ts';
 import {
   createMetroResolveRequestPlugin,
@@ -317,7 +316,8 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
   const sourceExts = extra?.sourceExts ?? DEFAULT_SOURCE_EXTS;
   const assetExts = extra?.assetExts ?? DEFAULT_ASSET_EXTS;
 
-  // Plugin set — RN preset 기본 4 + (옵션) MetroResolveRequest + (옵션) additional.
+  // Plugin set — RN preset 기본 runtime/require-context + optional Babel compatibility
+  // + optional MetroResolveRequest + optional additional.
   const plugins: ZntcPlugin[] = [
     createAssetPlugin({
       projectRoot,
@@ -327,21 +327,24 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
       babelTransformerPath: extra?.babelTransformerPath,
       forwardClientLogs: extra?.forwardClientLogs,
     }),
-    createCodegenPlugin({
-      projectRoot,
-      assetExts,
-      rnPlatform,
-      sourceExts,
-    }),
-    createBabelPlugin({
-      projectRoot,
-      assetExts,
-      rnPlatform,
-      sourceExts,
-      inlineBabel: extra?.babel,
-    }),
-    createRequireContextPlugin(),
   ];
+
+  // Babel compatibility is opt-in by detection. Native RN preset/worklet/codegen
+  // paths cover the default case, so projects with only native-equivalent Babel
+  // config do not pay a per-file Babel pass.
+  if (detectCustomPlugins(projectRoot, extra?.babel)) {
+    plugins.push(
+      createBabelPlugin({
+        projectRoot,
+        assetExts,
+        rnPlatform,
+        sourceExts,
+        inlineBabel: extra?.babel,
+      }),
+    );
+  }
+
+  plugins.push(createRequireContextPlugin());
   if (extra?.metroResolveRequest) {
     const opts: MetroResolveRequestOptions = {
       resolveRequest: extra.metroResolveRequest,
@@ -398,6 +401,7 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
     configurableExports: true,
     strictExecutionOrder: true,
     workletTransform: true,
+    codegenTransform: true,
     resolveExtensions: buildResolveExtensions(rnPlatform),
     mainFields: ['react-native', 'browser', 'module', 'main'],
     loader: baseLoader,

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -31,7 +31,7 @@ import {
 import type { CustomResolver, MetroPlatform } from './metro-resolver-types.ts';
 import { createAssetPlugin } from './plugins/asset.ts';
 import { createBabelPlugin, detectCustomPlugins } from './plugins/babel.ts';
-import { requireFromCli } from './plugins/internal.ts';
+import { normalizeExt, requireFromCli } from './plugins/internal.ts';
 import {
   createMetroResolveRequestPlugin,
   type MetroResolveRequestOptions,
@@ -202,7 +202,7 @@ function buildResolveExtensions(rnPlatform: 'ios' | 'android'): string[] {
 function buildAssetLoaders(assetExts: readonly string[]): Record<string, string> {
   const loaders: Record<string, string> = {};
   for (const ext of assetExts) {
-    loaders[ext.startsWith('.') ? ext : `.${ext}`] = 'file';
+    loaders[normalizeExt(ext)] = 'file';
   }
   return loaders;
 }

--- a/packages/react-native/src/withExpo.ts
+++ b/packages/react-native/src/withExpo.ts
@@ -23,6 +23,7 @@
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
+import { normalizeExt } from './plugins/internal.ts';
 import { tryResolve } from './rn-constants.ts';
 
 /**
@@ -49,11 +50,6 @@ export function detectExpo(
 }
 
 const EXPO_ASSET_EXTS = ['.heic', '.avif', '.db'] as const;
-
-/** Normalize "ext" / ".ext" → ".ext" for dedup comparisons. */
-function normalizeExt(ext: string): string {
-  return ext.startsWith('.') ? ext : `.${ext}`;
-}
 
 const EXPO_BLOCK_LIST: RegExp[] = [/\.expo[\\/]types/];
 


### PR DESCRIPTION
## 변경 사항
- RN preset 기본 체인에서 JS/Babel codegen 플러그인을 제거하고 native `codegenTransform`을 명시적으로 활성화했습니다.
- custom Babel plugin이 감지될 때만 Babel 호환 플러그인을 등록하도록 바꿨습니다.
- RN dev/bundle 입력에서 `zntc.config`의 `alias`와 `moduleSpecifierMap`을 bundle override로 전달합니다.
- bare 예제의 SVG/worklets/root import Babel 의존을 TSX SVG 컴포넌트, native alias, path import 기반으로 정리했습니다.

## 검증
- `bun test packages/react-native/src/preset.test.ts packages/react-native/src/plugins/babel.test.ts`
- `bun test packages/core/bin/zntc.test.ts --test-name-pattern "RN|alias / moduleSpecifierMap"`
- `bun run build:zntc:core`
- `bun ../../packages/core/bin/zntc.mjs --bundle index.js --platform=react-native --rn-platform=ios -o ios/main.jsbundle`

## 참고
- 기존 `bundle:zntc:ios` 스크립트는 현재 `zntc bundle ...` 형식 파서 문제로 `bundle`을 entry file로 해석해 실패해서, 직접 `--bundle` 형식으로 검증했습니다.
- `bun x tsc --noEmit`과 `bun run test -- --runInBand`는 기존 RN 0.85 TypeScript/Jest preset 설정 이슈로 별도 실패합니다.
