### PR TITLE
restore: PR #2696/#2697 변경 재적용 — init overlay merge 시 의도치 않게 revert 됨

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -2993,6 +2993,10 @@ fn watchWorkerThread(async_data: *WatchAsyncData) void {
         // Lazy sourcemap (Issue #1727 Phase B): initial build 와 동일 경로 유지. cache 키
         // 일치 필수 — initial 에서 lazy=true 로 put 된 엔트리가 rebuild 에서 hit 해야 함.
         if (bundle_opts.dev_mode and bundle_opts.sourcemap.enable) incremental_opts.sourcemap.lazy = true;
+        // dev_mode + collect_module_codes 인 incremental rebuild 는 풀 bundle output 을
+        // 다시 concat 할 필요가 없다 — RN HMR client 는 dev_codes 만 사용. wall 시간이
+        // emit_concat (~38ms) + emit_sourcemap_finalize (~19ms) 를 절감한다.
+        if (bundle_opts.dev_mode and bundle_opts.collect_module_codes) incremental_opts.skip_bundle_output = true;
         var rebundler = Bundler.initWithResolveCache(allocator, incremental_opts, &persistent_resolve_cache);
         defer rebundler.deinit();
 

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -158,6 +158,11 @@ pub const BundleOptions = struct {
     emotion_extra_styled_sources: []const []const u8 = &.{},
     /// dev mode에서 per-module codes 수집 (HMR rebuild용). 초기 빌드에서는 false로 메모리 절감.
     collect_module_codes: bool = false,
+    /// dev_mode + collect_module_codes incremental rebuild 의 풀 bundle output (`output`)
+    /// concat 과 sourcemap finalize 를 skip 한다. RN HMR client 는 module_dev_codes 만
+    /// 사용하므로 풀 bundle 은 첫 빌드에서만 필요. wall ~57ms 절감 (565 module fixture
+    /// 측정). caller 가 outfile 을 dev server 에서 file-based serve 하면 활성화 금지.
+    skip_bundle_output: bool = false,
     /// define 글로벌 치환 (--define:KEY=VALUE)
     define: []const @import("../transformer/transformer.zig").DefineEntry = &.{},
     /// legacy decorator 변환 (--experimental-decorators / tsconfig)
@@ -1171,6 +1176,7 @@ pub const Bundler = struct {
             dev_emit_opts.dev_mode = true;
             dev_emit_opts.react_refresh = self.options.react_refresh;
             dev_emit_opts.collect_module_codes = self.options.collect_module_codes;
+            dev_emit_opts.skip_bundle_output = self.options.skip_bundle_output;
             dev_emit_opts.polyfills = polyfill_entries.items;
             dev_emit_opts.run_before_main = self.options.run_before_main;
             dev_emit_opts.worker_map_per_module = &worker_map_per_module;

--- a/src/bundler/compiled_cache.zig
+++ b/src/bundler/compiled_cache.zig
@@ -90,7 +90,7 @@ pub const InputHasher = struct {
 /// `EmitOptions` 필드 개수. 구조체가 바뀌면 이 값을 갱신하고 hashEmitOptions
 /// 에 새 필드를 반영해야 한다 — comptime 에 필드 누락을 감지하는 fail-stop.
 /// 누락이 invisible bug (stale cache) 로 번지므로 이 barrier 는 load-bearing.
-const expected_emit_options_field_count: usize = 53;
+const expected_emit_options_field_count: usize = 54;
 
 comptime {
     const actual = @typeInfo(EmitOptions).@"struct".fields.len;
@@ -123,6 +123,9 @@ pub fn hashEmitOptions(h: *InputHasher, options: *const EmitOptions) void {
     h.addBool(options.worklet_transform);
     h.addOptStr(options.worklet_plugin_version);
     h.addBool(options.collect_module_codes);
+    // skip_bundle_output 은 emit 결과의 풀 bundle 부분만 영향 — per-module dev_codes 는
+    // 동일 — 즉 module-level cache key 와 무관하지만, 일관성을 위해 hash 에 포함.
+    h.addBool(options.skip_bundle_output);
 
     h.addU64(options.define.len);
     for (options.define) |d| {

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -90,6 +90,12 @@ pub const EmitOptions = struct {
     /// false면 output만 생성하고 module_dev_codes를 건너뛴다 (초기 빌드용, 메모리 절감).
     /// true면 HMR 업데이트용 module_dev_codes를 수집한다 (rebuild용).
     collect_module_codes: bool = false,
+    /// dev_mode + collect_module_codes incremental rebuild 시, 풀 bundle output (`output`)
+    /// concat 과 sourcemap finalize 를 skip 한다. RN HMR client 는 `module_dev_codes`
+    /// 만 사용하므로 풀 bundle 은 매 rebuild 마다 갱신될 필요 없다 — 첫 빌드에서만
+    /// 필요하고, 이후 rebuild 의 outfile 갱신은 caller (예: dev server) 가 in-memory
+    /// 로 모듈 단위로 처리. 비활성 시 (default) 기존 동작 유지.
+    skip_bundle_output: bool = false,
     /// define 글로벌 치환 (--define:KEY=VALUE)
     define: []const @import("../transformer/transformer.zig").DefineEntry = &.{},
     /// legacy decorator 변환
@@ -624,6 +630,11 @@ pub fn emitWithTreeShaking(
     // helper 합산 + 소스맵 매핑 누적 + renderChunk 훅 + epilogue.
     var concat_scope = profile.begin(.emit_concat);
 
+    // dev_mode + collect_module_codes incremental rebuild 시 풀 bundle output 을 skip.
+    // RN HMR client 는 dev_module_codes 만 사용 — 풀 bundle 은 첫 빌드만 필요하다.
+    // module_output 에 byte append 와 bundle 단위 sourcemap mapping 계산을 둘 다 우회.
+    const skip_bundle_concat = options.skip_bundle_output and options.dev_mode and options.collect_module_codes;
+
     // Phase 3: 순차 합류 — exec_index 순서대로 concat + helpers 합산 + 소스맵 수집
     var module_output: std.ArrayList(u8) = .empty;
     defer module_output.deinit(allocator);
@@ -654,7 +665,7 @@ pub fn emitWithTreeShaking(
     // lazy 경로 (Issue #1727) 에서만 return 직전 heap 으로 얕은 복사 이동 — ArrayList 의 items
     // 포인터는 이미 allocator 소유이므로 payload 를 heap SourceMapBuilder 로 옮겨도 double-free
     // 없음. `bundle_sm_moved = true` 시 본 함수의 defer 가 deinit 을 건너뛰어 원본은 drain 된다.
-    var bundle_sm: ?SourceMap.SourceMapBuilder = if (options.sourcemap.enable) blk: {
+    var bundle_sm: ?SourceMap.SourceMapBuilder = if (options.sourcemap.enable and !skip_bundle_concat) blk: {
         var sm = SourceMap.SourceMapBuilder.init(allocator);
         sm.source_root = options.sourcemap.source_root orelse "";
         sm.sources_content = options.sourcemap.sources_content;
@@ -678,16 +689,18 @@ pub fn emitWithTreeShaking(
 
     // module_output pre-size: 합계 capacity 를 한 번 확보해 concat 루프의 모듈별 appendSlice
     // 가 매번 grow (~log2(N) realloc) 하는 비용을 제거 (Issue #1727 §1).
-    var module_output_estimate: usize = 0;
-    for (sorted.items, 0..) |m, i| {
-        const code = results[i].code orelse continue;
-        module_output_estimate += code.len;
-        if (!options.minify_whitespace) {
-            // `"//#region " + basename + "\n"` (11 + basename) + `"//#endregion\n"` (13)
-            module_output_estimate += std.fs.path.basename(m.path).len + 24;
+    if (!skip_bundle_concat) {
+        var module_output_estimate: usize = 0;
+        for (sorted.items, 0..) |m, i| {
+            const code = results[i].code orelse continue;
+            module_output_estimate += code.len;
+            if (!options.minify_whitespace) {
+                // `"//#region " + basename + "\n"` (11 + basename) + `"//#endregion\n"` (13)
+                module_output_estimate += std.fs.path.basename(m.path).len + 24;
+            }
         }
+        try module_output.ensureTotalCapacity(allocator, module_output_estimate);
     }
-    try module_output.ensureTotalCapacity(allocator, module_output_estimate);
 
     if (linker) |l| if (l.use_shared_ns_preamble) {
         const before_len = module_output.items.len;
@@ -725,7 +738,7 @@ pub fn emitWithTreeShaking(
         }
 
         const is_entry = if (entry_idx) |ei| m.index.toU32() == ei else false;
-        if (!options.minify_whitespace) {
+        if (!options.minify_whitespace and !skip_bundle_concat) {
             try module_output.appendSlice(allocator, "//#region ");
             try module_output.appendSlice(allocator, std.fs.path.basename(m.path));
             try module_output.append(allocator, '\n');
@@ -773,11 +786,13 @@ pub fn emitWithTreeShaking(
         else
             code_after_rewrite;
 
-        try module_output.appendSlice(allocator, code_to_append);
-        module_line += @intCast(std.mem.count(u8, code_to_append, "\n"));
-        if (!options.minify_whitespace) {
-            try module_output.appendSlice(allocator, "//#endregion\n");
-            module_line += 1;
+        if (!skip_bundle_concat) {
+            try module_output.appendSlice(allocator, code_to_append);
+            module_line += @intCast(std.mem.count(u8, code_to_append, "\n"));
+            if (!options.minify_whitespace) {
+                try module_output.appendSlice(allocator, "//#endregion\n");
+                module_line += 1;
+            }
         }
 
         // dev mode: per-module code를 HMR eval 가능한 형태로 수집.

--- a/src/bundler/emitter_test.zig
+++ b/src/bundler/emitter_test.zig
@@ -2203,3 +2203,70 @@ test "emitter: sourceURL 은 IIFE 뒤에 위치 — HMR_PREAMBLE_LINES 오프셋
         try std.testing.expect(source_url_idx > iife_end);
     }
 }
+
+// skip_bundle_output: dev_mode + collect_module_codes incremental rebuild path 에서
+// 풀 bundle output (`output` ArrayList concat) 과 sourcemap finalize 를 skip 하면서
+// 도 module_dev_codes 는 정상 수집되어야 한다 (HMR client 가 사용).
+test "emitter: skip_bundle_output 활성 — output 은 모듈 byte 미포함, module_codes 는 정상 수집" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "export const HMR_TEST_MARKER_42 = 'hello';\n");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+    for (0..result.graph.moduleCount()) |i| {
+        const m = result.graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
+        m.dev_id = try std.testing.allocator.dupe(u8, m.path);
+    }
+    defer for (0..result.graph.moduleCount()) |i| {
+        const m = result.graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
+        if (m.dev_id.len > 0) std.testing.allocator.free(m.dev_id);
+        m.dev_id = "";
+    };
+
+    const res = try emit(std.testing.allocator, &result.graph, &.{
+        .sourcemap = .{ .enable = true },
+        .dev_mode = true,
+        .collect_module_codes = true,
+        .skip_bundle_output = true,
+    }, null);
+    defer res.deinit(std.testing.allocator);
+
+    // output 은 prelude/runtime/epilogue 만 포함 — 모듈 source 의 marker 가 없어야.
+    try std.testing.expect(std.mem.indexOf(u8, res.output, "HMR_TEST_MARKER_42") == null);
+    // module_codes 에는 변경된 module 의 코드가 marker 와 함께 정상 수집.
+    const codes = res.module_codes orelse return error.TestUnexpectedResult;
+    try std.testing.expect(codes.len >= 1);
+    var found = false;
+    for (codes) |c| {
+        if (std.mem.indexOf(u8, c.code, "HMR_TEST_MARKER_42") != null) {
+            found = true;
+            break;
+        }
+    }
+    try std.testing.expect(found);
+}
+
+// skip_bundle_output 가드는 `dev_mode and collect_module_codes` 가 모두 true 일 때만 활성.
+// 셋 중 하나라도 false 면 기존 동작 유지 (정합성 fallback).
+test "emitter: skip_bundle_output — collect_module_codes=false 면 가드 비활성, output 정상 emit" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "export const FALLBACK_GUARD_MARKER = 1;\n");
+
+    var result = try buildGraph(std.testing.allocator, &tmp, "index.ts");
+    defer result.graph.deinit();
+    defer result.cache.deinit();
+
+    const res = try emit(std.testing.allocator, &result.graph, &.{
+        .sourcemap = .{ .enable = true },
+        .dev_mode = true,
+        .collect_module_codes = false, // 핵심: false → guard inactive
+        .skip_bundle_output = true,
+    }, null);
+    defer res.deinit(std.testing.allocator);
+
+    // collect_module_codes=false 라 가드가 비활성 → output 에 모듈 source 정상 포함.
+    try std.testing.expect(std.mem.indexOf(u8, res.output, "FALLBACK_GUARD_MARKER") != null);
+}

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1874,11 +1874,14 @@ pub const ModuleGraph = struct {
         if (plugin_runner) |runner| {
             if (self.shouldRunLoad(module.path)) {
                 // 임시 allocator로 load 결과만 확인 (성공 시 arena를 생성)
-                var tmp_arena = std.heap.ArenaAllocator.init(self.allocator);
+                const tmp_arena = module_mod.createParseArena(self.allocator) orelse {
+                    module.state = .ready;
+                    return;
+                };
                 const load_result = runner.runLoad(module.path, tmp_arena.allocator()) catch |err| switch (err) {
                     error.PluginFailed => null,
                     error.OutOfMemory => {
-                        tmp_arena.deinit();
+                        module_mod.destroyParseArena(self.allocator, tmp_arena);
                         module.state = .ready;
                         return;
                     },
@@ -1916,7 +1919,7 @@ pub const ModuleGraph = struct {
                     // module_type 분기를 건너뛰고 JS 파싱 경로로 직접 이동
                     // (아래 "모듈별 Arena" 블록은 parse_arena가 이미 설정되어 있으므로 건너뜀)
                 } else {
-                    tmp_arena.deinit();
+                    module_mod.destroyParseArena(self.allocator, tmp_arena);
                 }
             }
         }
@@ -1940,7 +1943,10 @@ pub const ModuleGraph = struct {
         // `export default <json_value>;` 형태의 AST를 생성하여
         // semantic → import_scanner → binding_scanner를 공유한다.
         if (module.module_type == .json) {
-            module.parse_arena = std.heap.ArenaAllocator.init(self.allocator);
+            module.parse_arena = module_mod.createParseArena(self.allocator) orelse {
+                module.state = .ready;
+                return;
+            };
             const arena_alloc = module.parse_arena.?.allocator();
             module.source = self.readModuleSourceWithMtime(module, arena_alloc, 10 * 1024 * 1024, .parse) orelse return;
 
@@ -2054,7 +2060,10 @@ pub const ModuleGraph = struct {
         // 모듈별 Arena: Scanner/Parser/AST 메모리를 소유 (D061)
         // 플러그인 load 훅에서 이미 설정된 경우 건너뜀
         if (module.parse_arena == null) {
-            module.parse_arena = std.heap.ArenaAllocator.init(self.allocator);
+            module.parse_arena = module_mod.createParseArena(self.allocator) orelse {
+                module.state = .ready;
+                return;
+            };
         }
         const arena_alloc = module.parse_arena.?.allocator();
 
@@ -3518,7 +3527,7 @@ pub const ModuleGraph = struct {
             const needs_require = m.wrap_kind == .cjs and m.require_symbol == null;
             if (!needs_init and !needs_exports and !needs_require) continue;
             const sem_ptr = if (m.semantic) |*s| s else continue;
-            const arena = if (m.parse_arena) |*a| a.allocator() else continue;
+            const arena = if (m.parse_arena) |a| a.allocator() else continue;
 
             if (needs_init) {
                 const init_base = types.makeInitVarName(arena, m.path) catch continue;
@@ -3724,7 +3733,10 @@ pub const ModuleGraph = struct {
             return;
         }
 
-        module.parse_arena = std.heap.ArenaAllocator.init(self.allocator);
+        module.parse_arena = module_mod.createParseArena(self.allocator) orelse {
+            module.state = .ready;
+            return;
+        };
         const arena_alloc = module.parse_arena.?.allocator();
 
         // 파일 읽기
@@ -3814,7 +3826,10 @@ pub const ModuleGraph = struct {
     }
 
     fn parseAssetModule(self: *ModuleGraph, module: *Module) void {
-        module.parse_arena = std.heap.ArenaAllocator.init(self.allocator);
+        module.parse_arena = module_mod.createParseArena(self.allocator) orelse {
+            module.state = .ready;
+            return;
+        };
         const arena_alloc = module.parse_arena.?.allocator();
 
         switch (module.loader) {
@@ -4474,7 +4489,7 @@ fn expandRequireContextRecords(self: *ModuleGraph, mod_idx: usize) void {
     // require.context 는 parse 산출물이라 arena 가 항상 존재. 없으면 (disabled/asset 등)
     // expand 자체가 의미 없고, graph allocator fallback 은 module.deinit 에서 free 누락 →
     // leak. 안전하게 early return.
-    const arena = if (module.parse_arena) |*a| a else return;
+    const arena = if (module.parse_arena) |a| a else return;
     const arena_alloc = arena.allocator();
     var expansion = std.ArrayList(types.ImportRecord).empty;
 

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1933,7 +1933,7 @@ pub const Linker = struct {
             const ast = if (importer.ast) |*a| a else continue;
             // 결과 슬라이스는 module.parse_arena가 소유 — 모듈 수명 동안 유효하고
             // deinit 시 자동 해제. linker.allocator를 쓰면 누수 위험.
-            const arena = if (importer.parse_arena) |*pa| pa.allocator() else continue;
+            const arena = if (importer.parse_arena) |pa| pa.allocator() else continue;
 
             if (sem.scope_maps.len == 0) continue;
 

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -102,6 +102,20 @@ pub const TransformCache = struct {
     symbol_ids: []const ?u32,
 };
 
+/// `Module.parse_arena` 용 ArenaAllocator 를 heap 에 생성. 실패 시 null.
+/// 정리는 `destroyParseArena` 로.
+pub fn createParseArena(allocator: std.mem.Allocator) ?*std.heap.ArenaAllocator {
+    const ptr = allocator.create(std.heap.ArenaAllocator) catch return null;
+    ptr.* = std.heap.ArenaAllocator.init(allocator);
+    return ptr;
+}
+
+/// `createParseArena` 의 짝. arena 데이터 free 후 ptr 자체 free.
+pub fn destroyParseArena(allocator: std.mem.Allocator, arena: *std.heap.ArenaAllocator) void {
+    arena.deinit();
+    allocator.destroy(arena);
+}
+
 pub const Module = struct {
     index: ModuleIndex,
     /// 절대 파일 경로. graph의 path_to_module 키와 동일한 메모리를 참조 (빌림).
@@ -143,7 +157,13 @@ pub const Module = struct {
     /// 모든 export 가 사용 가능해야.
     is_context_dep: bool = false,
     /// 모듈별 Arena — Scanner/Parser/AST/Semantic 메모리를 소유. graph.deinit에서 해제.
-    parse_arena: ?std.heap.ArenaAllocator,
+    ///
+    /// 포인터로 보관 — graph ↔ store 사이의 transfer 가 Module struct copy 로 일어나는데,
+    /// `?ArenaAllocator` (value) 면 두 위치가 같은 buffer_list 를 가리키고 그 후 nullify
+    /// 패턴으로 ownership 을 표현해도 어느 한쪽이 dangling 노드를 통해 다음 alloc 에서
+    /// panic 한다 (#2694). ptr 으로 두면 struct copy 가 ptr 만 복사 — 두 위치가 같은
+    /// 객체 참조하고 nullify 한 쪽이 ownership 박탈을 명확히 표현한다.
+    parse_arena: ?*std.heap.ArenaAllocator,
     /// semantic analyzer 결과. parse_arena가 소유. linker에서 사용.
     semantic: ?ModuleSemanticData,
     /// Semantic Analyzer에서 사전 구축한 StmtInfo. parse_arena가 소유.
@@ -512,7 +532,7 @@ pub const Module = struct {
         }
         // parse_arena가 Scanner/Parser/AST/source 메모리를 전부 소유.
         // ast.deinit()는 불필요 — arena.deinit()이 일괄 해제.
-        if (self.parse_arena) |*arena| arena.deinit();
+        if (self.parse_arena) |arena| destroyParseArena(allocator, arena);
     }
 
     /// Lazy 초기화. graph allocator로 합성 심볼 테이블을 만든다.

--- a/src/bundler/module_store.zig
+++ b/src/bundler/module_store.zig
@@ -5,7 +5,8 @@
 //! Module.parse_arena가 데이터를 소유하므로, arena 소유권 이전으로 캐시를 구현.
 
 const std = @import("std");
-const Module = @import("module.zig").Module;
+const Module_mod = @import("module.zig");
+const Module = Module_mod.Module;
 const types = @import("types.zig");
 
 pub const PersistentModuleStore = struct {
@@ -49,7 +50,7 @@ pub const PersistentModuleStore = struct {
             }
         }
         // parse_arena / alias_table 가 아직 store 에 있으면 해제.
-        if (cached.module.parse_arena) |*arena| arena.deinit();
+        if (cached.module.parse_arena) |arena| Module_mod.destroyParseArena(self.allocator, arena);
         if (cached.module.alias_table) |*t| t.deinit();
         // dependencies/importers/dynamic_imports/dynamic_importers ArrayList 해제
         cached.module.dependencies.deinit(self.allocator);
@@ -111,14 +112,14 @@ pub const PersistentModuleStore = struct {
                 .module = cached_module,
                 .import_specifiers = specs,
             }) catch {
-                if (cached_module.parse_arena) |*a| a.deinit();
+                if (cached_module.parse_arena) |a| Module_mod.destroyParseArena(self.allocator, a);
                 if (cached_module.alias_table) |*t| t.deinit();
                 for (specs) |s| self.allocator.free(s);
                 self.allocator.free(specs);
             };
         } else {
             const key = self.allocator.dupe(u8, path) catch {
-                if (cached_module.parse_arena) |*a| a.deinit();
+                if (cached_module.parse_arena) |a| Module_mod.destroyParseArena(self.allocator, a);
                 if (cached_module.alias_table) |*t| t.deinit();
                 for (specs) |s| self.allocator.free(s);
                 self.allocator.free(specs);
@@ -131,7 +132,7 @@ pub const PersistentModuleStore = struct {
                 .import_specifiers = specs,
             }) catch {
                 self.allocator.free(key);
-                if (cached_module.parse_arena) |*a| a.deinit();
+                if (cached_module.parse_arena) |a| Module_mod.destroyParseArena(self.allocator, a);
                 if (cached_module.alias_table) |*t| t.deinit();
                 for (specs) |s| self.allocator.free(s);
                 self.allocator.free(specs);
@@ -228,4 +229,46 @@ test "PersistentModuleStore: alias_table ownership 왕복 (rebuild 2회)" {
     const cached2 = store.getIfFresh("/virtual/mod.ts", 2) orelse return error.CacheMiss;
     try testing.expect(cached2.module.alias_table != null);
     try testing.expectEqual(@as(u32, 3), cached2.module.alias_table.?.count());
+}
+
+// Regression #2694: 가상 모듈 (mtime=0) 이 cache-hit 으로 store ↔ graph 왕복할 때
+// 다음 rebuild 의 첫 alloc 이 panic 하지 않아야 한다. 과거에는 `parse_arena` 가
+// `?ArenaAllocator` (value) 라 putModule/getIfFresh 의 struct copy 가 buffer_list 의
+// first BufNode 를 두 위치에서 공유해 한쪽 deinit 이후 다른 쪽이 dangling 포인터로
+// alloc 시 `start index 16 is larger than end index 0` panic.
+test "PersistentModuleStore: parse_arena ownership 왕복 후 alloc 정상 (#2694)" {
+    const testing = std.testing;
+    const allocator = testing.allocator;
+
+    var store = PersistentModuleStore.init(allocator);
+    defer store.deinit();
+
+    var module = Module.init(@enumFromInt(0), "\x00zntc:runtime/extends");
+    module.parse_arena = Module_mod.createParseArena(allocator) orelse return error.OutOfMemory;
+    // 첫 빌드에서 arena 에 alloc — buffer_list 에 BufNode 등록.
+    _ = try module.parse_arena.?.allocator().alloc(u8, 256);
+
+    store.putModule("\x00zntc:runtime/extends", &module, 1);
+    try testing.expect(module.parse_arena == null);
+    module.deinit(allocator);
+
+    // build 2: cache-hit. graph 가 ownership 환수.
+    const cached = store.getIfFresh("\x00zntc:runtime/extends", 1) orelse return error.CacheMiss;
+    var mod2 = Module.init(@enumFromInt(0), "\x00zntc:runtime/extends");
+    const saved_deps = mod2.dependencies;
+    const saved_importers = mod2.importers;
+    mod2 = cached.module;
+    mod2.dependencies = saved_deps;
+    mod2.importers = saved_importers;
+    cached.module.parse_arena = null;
+    cached.module.alias_table = null;
+
+    // 두 번째 빌드 emit 단계의 fold pass 가 ast.allocator (= parse_arena) 로 새 노드
+    // 푸시하는 시나리오. 과거에는 buffer_list 의 first 가 dangling 이라 panic.
+    try testing.expect(mod2.parse_arena != null);
+    const buf2 = try mod2.parse_arena.?.allocator().alloc(u8, 512);
+    try testing.expectEqual(@as(usize, 512), buf2.len);
+
+    store.putModule("\x00zntc:runtime/extends", &mod2, 2);
+    mod2.deinit(allocator);
 }

--- a/src/bundler/phase.zig
+++ b/src/bundler/phase.zig
@@ -83,7 +83,7 @@ pub const ParseAccessor = struct {
         if (self.graph.moduleAtMut(idx)) |m| m.semantic = semantic;
     }
 
-    pub inline fn setParseArena(self: ParseAccessor, idx: ModuleIndex, arena: ?std.heap.ArenaAllocator) void {
+    pub inline fn setParseArena(self: ParseAccessor, idx: ModuleIndex, arena: ?*std.heap.ArenaAllocator) void {
         if (self.graph.moduleAtMut(idx)) |m| m.parse_arena = arena;
     }
 

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -437,7 +437,7 @@ pub const TreeShaker = struct {
     fn foldNumericExportSeeds(_: *TreeShaker, m: *Module, ast: *Ast) !bool {
         const minify_mod = @import("../transformer/minify.zig");
         const sem = if (m.semantic) |*sem| sem else return false;
-        const arena_alloc = if (m.parse_arena) |*arena| arena.allocator() else return false;
+        const arena_alloc = if (m.parse_arena) |arena| arena.allocator() else return false;
         var has_exported_number = false;
 
         for (ast.nodes.items) |node| {


### PR DESCRIPTION
## Summary

\`2800c24e feat(init): add React Native CLI overlay initializer\` 머지 시 init overlay 추가 외에 PR #2696 + #2697 의 변경이 같이 revert 된 것을 발견. 동일 commit 으로 cherry-pick 재적용.

## 영향 (revert 상태에서 발생)

- **#2694 회귀**: \`Module.parse_arena: ?ArenaAllocator\` 가 value type 으로 되돌려져 graph ↔ store 왕복 시 dangling BufNode panic 재발현 (production-mode + watch + \`extends\` virtual module).
- **#2697 회귀**: \`skip_bundle_output\` 가드 + emit_concat/sourcemap_finalize skip 로직이 사라져 HMR rebuild 89→113ms (+27%) 후퇴.
- **regression test 67줄 삭제**: \`emitter_test.zig\` 의 \`skip_bundle_output\` 검증 + fallback 가드 테스트 두 개 사라짐.

## 변경

세 commit 을 \`d67edcbc\`, \`1085615a\`, \`f0e3421e\` 순서로 cherry-pick:
- fix(module): parse_arena heap ptr 전환 — store 왕복 dangling BufNode panic 근본수정 (#2694)
- perf(emit): dev_mode incremental rebuild 의 풀 bundle output skip — HMR wall 113→89ms (-21%)
- test(emit): skip_bundle_output 검증 — output 모듈 미포함 + module_codes 수집 + fallback 가드

\`init\` overlay 자체와 충돌 없이 cherry-pick 적용됐고 \`zig build napi -Dnapi-optimize=ReleaseSafe\` / \`zig build test\` 통과.

## 추정 원인

\`feat(init)\` PR 의 base 가 #2696/#2697 가 머지되기 전 main 이었고 머지 시 자동 충돌 해결 또는 stale base merge 로 변경이 누락된 것으로 보임. 향후 같은 incident 방지를 위해 머지 전 base 를 최신 main 으로 rebase 권장.

## Test plan

- [x] \`zig build napi -Dnapi-optimize=ReleaseSafe\` 통과
- [x] \`zig build test\` 통과 (\`PersistentModuleStore: parse_arena ownership 왕복 후 alloc 정상 (#2694)\` + \`emitter: skip_bundle_output 활성\` + fallback 가드 신규)
- [x] \`tests/integration/tests/fixtures/rn-example-app\` watch + dev mode REBUILD 정상, panic 0
- [ ] CI

Closes #2694 (재발) / #2697 후속.