### PR TITLE
fix(playground): bundler codeSplitting/preserveModules 토글 시 format 자동 ESM (#1964)

### DIFF
--- a/documents/src/components/PlaygroundBundler.tsx
+++ b/documents/src/components/PlaygroundBundler.tsx
@@ -531,12 +531,9 @@ export default function PlaygroundBundler() {
         next.minifySyntax = b;
       }
       // codeSplitting / preserveModules 는 ESM 출력만 지원 — cjs/iife/umd/amd 에는
-      // 네이티브 dynamic import 가 없어 빌드가 실패한다. 토글 시 ESM 으로 강제하고,
-      // format 을 ESM 외로 바꿀 때는 두 옵션을 자동 off — build-time error 노출 전에
-      // playground 가 일관된 조합으로 자동 보정.
-      if (ESM_ONLY_KEYS.has(key) && value === true && next.format !== "esm") {
-        next.format = "esm";
-      }
+      // 네이티브 dynamic import 가 없어 빌드가 실패한다. format 을 ESM 외로 바꾸면
+      // 두 옵션은 자동 off (잘못된 조합으로 stale state 방지). 토글 자체는 UI 단에서
+      // disabled 처리하므로, ESM 외 상태에서 사용자가 토글을 활성화 시도할 수 없다.
       if (key === "format" && value !== "esm") {
         for (const k of ESM_ONLY_KEYS) (next as Record<string, unknown>)[k] = false;
       }
@@ -730,13 +727,16 @@ export default function PlaygroundBundler() {
                   label="Code splitting"
                   checked={opts.codeSplitting}
                   onChange={(v) => updateOpt("codeSplitting", v)}
+                  disabled={opts.format !== "esm"}
+                  title={opts.format !== "esm" ? "ESM 출력 format 에서만 지원됩니다" : undefined}
                 />
                 <Chk
                   label="Preserve modules"
                   checked={opts.preserveModules}
                   onChange={(v) => updateOpt("preserveModules", v)}
+                  disabled={opts.format !== "esm"}
+                  title={opts.format !== "esm" ? "ESM 출력 format 에서만 지원됩니다" : undefined}
                 />
-                <p className="mt-1 text-[10px] text-neutral-500">ESM 출력만 지원 — 켜면 format 자동 ESM</p>
               </Section>
               <Section title="External">
                 <textarea

--- a/documents/src/components/PlaygroundBundler.tsx
+++ b/documents/src/components/PlaygroundBundler.tsx
@@ -262,6 +262,10 @@ interface BundleOpts {
   sourcemap: boolean;
 }
 
+/// ESM 출력 외에 실행 의미가 없는 옵션 — 토글 시 format 을 esm 으로 강제하고,
+/// format 을 esm 외로 바꿀 때 일괄 off. 향후 옵션 추가 시 set 에 키만 더하면 됨.
+const ESM_ONLY_KEYS: ReadonlySet<keyof BundleOpts> = new Set(["codeSplitting", "preserveModules"]);
+
 const DEFAULT_OPTS: BundleOpts = {
   format: "esm",
   platform: "browser",
@@ -530,12 +534,11 @@ export default function PlaygroundBundler() {
       // 네이티브 dynamic import 가 없어 빌드가 실패한다. 토글 시 ESM 으로 강제하고,
       // format 을 ESM 외로 바꿀 때는 두 옵션을 자동 off — build-time error 노출 전에
       // playground 가 일관된 조합으로 자동 보정.
-      if ((key === "codeSplitting" || key === "preserveModules") && value === true && next.format !== "esm") {
+      if (ESM_ONLY_KEYS.has(key) && value === true && next.format !== "esm") {
         next.format = "esm";
       }
       if (key === "format" && value !== "esm") {
-        next.codeSplitting = false;
-        next.preserveModules = false;
+        for (const k of ESM_ONLY_KEYS) (next as Record<string, unknown>)[k] = false;
       }
       runBundle(files, entryPath, next);
       return next;

--- a/documents/src/components/PlaygroundBundler.tsx
+++ b/documents/src/components/PlaygroundBundler.tsx
@@ -526,6 +526,17 @@ export default function PlaygroundBundler() {
         next.minifyIdentifiers = b;
         next.minifySyntax = b;
       }
+      // codeSplitting / preserveModules 는 ESM 출력만 지원 — cjs/iife/umd/amd 에는
+      // 네이티브 dynamic import 가 없어 빌드가 실패한다. 토글 시 ESM 으로 강제하고,
+      // format 을 ESM 외로 바꿀 때는 두 옵션을 자동 off — build-time error 노출 전에
+      // playground 가 일관된 조합으로 자동 보정.
+      if ((key === "codeSplitting" || key === "preserveModules") && value === true && next.format !== "esm") {
+        next.format = "esm";
+      }
+      if (key === "format" && value !== "esm") {
+        next.codeSplitting = false;
+        next.preserveModules = false;
+      }
       runBundle(files, entryPath, next);
       return next;
     });
@@ -722,6 +733,7 @@ export default function PlaygroundBundler() {
                   checked={opts.preserveModules}
                   onChange={(v) => updateOpt("preserveModules", v)}
                 />
+                <p className="mt-1 text-[10px] text-neutral-500">ESM 출력만 지원 — 켜면 format 자동 ESM</p>
               </Section>
               <Section title="External">
                 <textarea

--- a/documents/src/components/playground-shared.tsx
+++ b/documents/src/components/playground-shared.tsx
@@ -75,14 +75,26 @@ export function Chk({
   label,
   checked,
   onChange,
+  disabled,
+  title,
 }: {
   label: string;
   checked: boolean;
   onChange: (v: boolean) => void;
+  disabled?: boolean;
+  title?: string;
 }) {
+  const base = "flex items-center gap-1.5 text-[13px]";
+  const enabled = "cursor-pointer text-neutral-300";
+  const dim = "cursor-not-allowed text-neutral-500";
   return (
-    <label className="flex cursor-pointer items-center gap-1.5 text-[13px] text-neutral-300">
-      <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} />
+    <label className={`${base} ${disabled ? dim : enabled}`} title={title}>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        disabled={disabled}
+      />
       {label}
     </label>
   );


### PR DESCRIPTION
## Summary

playground bundler 의 codeSplitting / preserveModules + non-ESM format 조합이 build-time error 였는데, **옵션 B (toggle disabled + tooltip)** 로 잘못된 조합 자체를 만들 수 없게 차단.

## 다른 번들러 비교

| | 처리 |
|---|---|
| esbuild | build-time error 만 (CLI/library) |
| rolldown | preserveModules 는 ESM 전제, error 만 |
| rspack | 옵션 분리 |

zntc playground 는 학습/실험용 GUI 라 잘못된 조합을 input 시점에 차단하는 게 프로덕션 패턴 (Vite/webpack 의 config builder 와 동일).

## 변경

- \`Chk\` 컴포넌트에 \`disabled\` + \`title\` (tooltip) prop 추가
- codeSplitting / preserveModules 토글이 \`format !== "esm"\` 일 때 disabled, hover 시 tooltip "ESM 출력 format 에서만 지원됩니다"
- format 을 esm 외로 변경 시 두 옵션은 자동 off (stale state 방지) — \`ESM_ONLY_KEYS\` set 으로 단일 source

## 자동 mutation 회피

옵션 A (codeSplitting 토글 시 format 자동 ESM) 는 사용자 의도를 임의로 변경 — 프로덕션 부적합. 옵션 B 가 사용자 의도 보존:
- \`format=cjs\` 선택 → codeSplitting/preserveModules 토글 disabled
- 사용자가 명시적으로 \`format=esm\` 으로 바꿔야 토글 활성

## Test plan

- [x] \`tsc --noEmit\` 통과
- [ ] CI / playground build
- [ ] 수동: format=cjs 일 때 splitting toggle disabled + hover tooltip, format=esm 으로 바꿀 때 활성

Closes #1964