### PR TITLE
perf(import-scanner): call expression callee tag dispatch

### DIFF
--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -117,10 +117,7 @@ pub fn extractImportsWithCjsDetectionAndDefines(
                 }
             },
             .call_expression => {
-                const e = node.data.extra;
-                if (!ast.hasExtra(e, 0)) continue;
-
-                const callee_idx = ast.readExtraNode(e, 0);
+                const callee_idx = ast.readExtraNode(node.data.extra, 0);
                 if (callee_idx.isNone() or @intFromEnum(callee_idx) >= ast.nodes.items.len) continue;
                 const callee = ast.getNode(callee_idx);
 

--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -117,19 +117,32 @@ pub fn extractImportsWithCjsDetectionAndDefines(
                 }
             },
             .call_expression => {
-                // Order: require.context (specific, callee=member) → require (callee=ident) → glob (callee=meta).
-                // 더 specific 한 패턴 먼저 시도해야 일반 require 가 require.context 를 가리지 않는다.
-                if (tryExtractRequireContextWithDefines(ast, node, defines)) |record| {
-                    has_cjs_require = true;
-                    try records.append(allocator, record);
-                } else if (tryExtractRequire(ast, node)) |record| {
-                    has_cjs_require = true;
-                    try records.append(allocator, record);
-                } else if (tryExtractGlob(ast, node)) |record| {
-                    try records.append(allocator, record);
-                } else if (classifyObjectDefinePropertyExports(ast, node)) |kind| {
-                    has_exports_dot = true;
-                    if (kind == .esmodule_marker) has_esmodule_marker = true;
+                const e = node.data.extra;
+                if (!ast.hasExtra(e, 0)) continue;
+
+                const callee_idx = ast.readExtraNode(e, 0);
+                if (callee_idx.isNone() or @intFromEnum(callee_idx) >= ast.nodes.items.len) continue;
+                const callee = ast.getNode(callee_idx);
+
+                switch (callee.tag) {
+                    .identifier_reference => {
+                        if (tryExtractRequire(ast, node)) |record| {
+                            has_cjs_require = true;
+                            try records.append(allocator, record);
+                        }
+                    },
+                    .static_member_expression => {
+                        if (tryExtractRequireContextWithDefines(ast, node, defines)) |record| {
+                            has_cjs_require = true;
+                            try records.append(allocator, record);
+                        } else if (tryExtractGlob(ast, node)) |record| {
+                            try records.append(allocator, record);
+                        } else if (classifyObjectDefinePropertyExports(ast, node)) |kind| {
+                            has_exports_dot = true;
+                            if (kind == .esmodule_marker) has_esmodule_marker = true;
+                        }
+                    },
+                    else => {},
                 }
             },
             .new_expression => {


### PR DESCRIPTION
## 요약
- `extractImportsWithCjsDetectionAndDefines`의 `call_expression` 처리를 callee tag 기반 분기로 변경했습니다.
- `identifier_reference`는 `require(...)`만 검사하고, `static_member_expression`은 `require.context(...)` / `import.meta.glob(...)` / `Object.defineProperty(...)`만 검사합니다.
- `#1769`의 (1) perf cleanup만 처리합니다. (2) `regexp_literal` layout 분리는 그대로 남겨둡니다.

## 검증
- `zig fmt --check src/bundler/import_scanner.zig`
- `zig build test --summary all`
- `zig build -Doptimize=ReleaseFast --summary all`
- push 전 훅: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`

Refs #1769