### PR TITLE
fix(plugin): 플러그인 실패를 diagnostic으로 노출

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -33,6 +33,45 @@ afterAll(() => {
   close();
 });
 
+function diagText(diag: unknown): string {
+  if (diag && typeof diag === 'object') {
+    const d = diag as { text?: unknown; message?: unknown };
+    if (typeof d.text === 'string') return d.text;
+    if (typeof d.message === 'string') return d.message;
+  }
+  return String(diag);
+}
+
+function expectPluginDiagnostic(
+  result: { errors: unknown[] },
+  expected: {
+    plugin: string;
+    hook: string;
+    message: string;
+    fileIncludes?: string;
+    textIncludes?: string;
+  },
+) {
+  const diag = result.errors.find((entry) => {
+    const d = entry as { code?: string };
+    const text = diagText(entry);
+    return (
+      d.code === 'plugin_error' &&
+      text.includes(expected.plugin) &&
+      text.includes(expected.hook) &&
+      text.includes(expected.message)
+    );
+  }) as ({ location?: { file?: string }; code?: string } & Record<string, unknown>) | undefined;
+
+  expect(diag, `missing plugin_error diagnostic in ${JSON.stringify(result.errors)}`).toBeDefined();
+  if (expected.fileIncludes) {
+    expect(diag?.location?.file ?? '').toContain(expected.fileIncludes);
+  }
+  if (expected.textIncludes) {
+    expect(diagText(diag)).toContain(expected.textIncludes);
+  }
+}
+
 describe('@zntc/core', () => {
   test('기본 standalone transpile은 JS로 파싱해 TypeScript syntax를 거부', () => {
     expect(() => transpile('const x: number = 1;')).toThrow('ParseError');
@@ -1035,23 +1074,51 @@ describe('@zntc/core build + plugins', () => {
     ).toThrow('plugins are only supported with build()');
   });
 
-  test('플러그인 콜백이 throw해도 빌드가 중단되지 않음', async () => {
+  test('plugin_error: onLoad sync throw가 diagnostic으로 노출됨', async () => {
     const throwPlugin: ZntcPlugin = {
       name: 'throw-plugin',
       setup(build) {
-        build.onLoad({ filter: /never-match-anything/ }, () => {
+        build.onResolve({ filter: /\.boom$/ }, (args) => ({ path: resolve(dir, args.path) }));
+        build.onLoad({ filter: /\.boom$/ }, () => {
           throw new Error('plugin error!');
         });
       },
     };
+    writeFileSync(join(dir, 'entry-load-error.ts'), 'import "./style.boom";');
 
-    // filter가 매치하지 않으므로 throw에 도달하지 않음 — 정상 완료
     const result = await build({
-      entryPoints: [join(dir, 'entry.ts')],
+      entryPoints: [join(dir, 'entry-load-error.ts')],
       plugins: [throwPlugin],
     });
-    // css import가 resolve 안 되므로 에러, 하지만 빌드 자체는 크래시하지 않음
-    expect(result.outputFiles.length).toBeGreaterThan(0);
+    expectPluginDiagnostic(result, {
+      plugin: 'throw-plugin',
+      hook: 'load',
+      message: 'plugin error!',
+      fileIncludes: 'style.boom',
+    });
+  });
+
+  test('plugin_error: onTransform async reject가 diagnostic으로 노출됨', async () => {
+    const rejectPlugin: ZntcPlugin = {
+      name: 'reject-transform',
+      setup(build) {
+        build.onTransform({ filter: /transform-reject\.ts$/ }, async () => {
+          throw new Error('async transform rejected');
+        });
+      },
+    };
+    writeFileSync(join(dir, 'transform-reject.ts'), 'console.log("transform");');
+
+    const result = await build({
+      entryPoints: [join(dir, 'transform-reject.ts')],
+      plugins: [rejectPlugin],
+    });
+    expectPluginDiagnostic(result, {
+      plugin: 'reject-transform',
+      hook: 'transform',
+      message: 'async transform rejected',
+      fileIncludes: 'transform-reject.ts',
+    });
   });
 
   test('lifecycle hooks (#2156): buildStart → buildEnd → closeBundle 순서 + 1회씩', async () => {
@@ -1091,7 +1158,6 @@ describe('@zntc/core build + plugins', () => {
         const boom = () => {
           throw new Error('intentional');
         };
-        build.onBuildStart(boom);
         build.onBuildEnd(boom);
         build.onCloseBundle(boom);
       },
@@ -1109,8 +1175,54 @@ describe('@zntc/core build + plugins', () => {
       entryPoints: [join(dir, 'lifecycle-entry.ts')],
       plugins: [throwingPlugin, trackingPlugin],
     });
-    expect(result.errors.length).toBe(0);
+    expectPluginDiagnostic(result, {
+      plugin: 'thrower',
+      hook: 'buildEnd',
+      message: 'intentional',
+    });
+    expectPluginDiagnostic(result, {
+      plugin: 'thrower',
+      hook: 'closeBundle',
+      message: 'intentional',
+    });
     expect(events).toEqual(['start', 'end', 'close']);
+  });
+
+  test('plugin_error: buildEnd/closeBundle 실패는 기존 build error를 덮지 않고 secondary diagnostic으로 기록', async () => {
+    const events: string[] = [];
+    writeFileSync(join(dir, 'entry-unresolved.ts'), 'import "missing-package-1902";');
+    const lifecyclePlugin: ZntcPlugin = {
+      name: 'lifecycle-failures',
+      setup(build) {
+        build.onBuildEnd(() => {
+          events.push('buildEnd');
+          throw new Error('buildEnd cleanup failed');
+        });
+        build.onCloseBundle(() => {
+          events.push('closeBundle');
+          throw new Error('closeBundle cleanup failed');
+        });
+      },
+    };
+
+    const result = await build({
+      entryPoints: [join(dir, 'entry-unresolved.ts')],
+      plugins: [lifecyclePlugin],
+    });
+    expect(result.errors.some((diag) => diagText(diag).includes('Cannot resolve module'))).toBe(
+      true,
+    );
+    expectPluginDiagnostic(result, {
+      plugin: 'lifecycle-failures',
+      hook: 'buildEnd',
+      message: 'buildEnd cleanup failed',
+    });
+    expectPluginDiagnostic(result, {
+      plugin: 'lifecycle-failures',
+      hook: 'closeBundle',
+      message: 'closeBundle cleanup failed',
+    });
+    expect(events).toEqual(['buildEnd', 'closeBundle']);
   });
 
   test('lifecycle hooks (#2156): vitePlugin 어댑터가 buildStart/buildEnd/closeBundle 을 forward', async () => {
@@ -1374,7 +1486,7 @@ describe('@zntc/core edge cases', () => {
 // ─── 추가 커버리지 테스트 ───
 
 describe('@zntc/core 플러그인 심화', () => {
-  test('플러그인 콜백이 매치 후 throw — 에러로 전파', async () => {
+  test('plugin_error: thrown string과 hook 이름을 보존', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'zntc-plugin-throw-'));
     writeFileSync(join(dir, 'index.ts'), 'import "./data.json";');
 
@@ -1385,18 +1497,21 @@ describe('@zntc/core 플러그인 심화', () => {
           path: resolve(dir, args.path),
         }));
         build.onLoad({ filter: /\.json$/ }, () => {
-          throw new Error('intentional plugin error');
+          throw 'plain string failure';
         });
       },
     };
 
-    // 플러그인이 throw하면 load 결과가 null → 번들러가 파일 읽기로 폴백
-    // .json 파일이 없으므로 에러 발생
     const result = await build({
       entryPoints: [join(dir, 'index.ts')],
       plugins: [throwPlugin],
     });
-    expect(result.errors.length).toBeGreaterThan(0);
+    expectPluginDiagnostic(result, {
+      plugin: 'throw-on-load',
+      hook: 'load',
+      message: 'plain string failure',
+      fileIncludes: 'data.json',
+    });
     rmSync(dir, { recursive: true, force: true });
   });
 
@@ -2621,6 +2736,89 @@ describe('vitePlugin 어댑터', () => {
     expect(result.errors.length).toBe(0);
     // importer는 entry.ts의 절대 경로여야 함
     expect(receivedImporter).toContain('entry.ts');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('plugin_error: vitePlugin.resolveId sync throw가 diagnostic으로 노출됨', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-vite-resolve-error-'));
+    writeFileSync(join(dir, 'entry.ts'), 'import "virtual:boom";');
+
+    const result = await build({
+      entryPoints: [join(dir, 'entry.ts')],
+      plugins: [
+        vitePlugin({
+          name: 'vite-resolve-fail',
+          resolveId(source) {
+            if (source === 'virtual:boom') throw new Error('resolve exploded');
+          },
+        }),
+      ],
+    });
+    expectPluginDiagnostic(result, {
+      plugin: 'vite-resolve-fail',
+      hook: 'resolveId',
+      message: 'resolve exploded',
+      fileIncludes: 'entry.ts',
+    });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('plugin_error: vitePlugin.load의 this.error가 RollupError-like location을 보존', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-vite-this-error-'));
+    const virtualId = join(dir, 'virtual.ts');
+    writeFileSync(join(dir, 'entry.ts'), 'import "./virtual";');
+
+    const result = await build({
+      entryPoints: [join(dir, 'entry.ts')],
+      plugins: [
+        vitePlugin({
+          name: 'vite-this-error',
+          resolveId(source) {
+            if (source === './virtual') return virtualId;
+          },
+          load(id) {
+            if (id === virtualId) {
+              this.error({
+                message: 'rollup context failed',
+                id,
+                loc: { file: id, line: 7, column: 3 },
+              });
+            }
+          },
+        } as RollupPlugin),
+      ],
+    });
+    expectPluginDiagnostic(result, {
+      plugin: 'vite-this-error',
+      hook: 'load',
+      message: 'rollup context failed',
+      fileIncludes: 'virtual.ts',
+      textIncludes: '7:3',
+    });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('plugin_error: vitePlugin.transform async reject가 diagnostic으로 노출됨', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-vite-transform-error-'));
+    writeFileSync(join(dir, 'entry.ts'), 'console.log("vite transform");');
+
+    const result = await build({
+      entryPoints: [join(dir, 'entry.ts')],
+      plugins: [
+        vitePlugin({
+          name: 'vite-transform-fail',
+          async transform() {
+            throw new Error('vite transform rejected');
+          },
+        }),
+      ],
+    });
+    expectPluginDiagnostic(result, {
+      plugin: 'vite-transform-fail',
+      hook: 'transform',
+      message: 'vite transform rejected',
+      fileIncludes: 'entry.ts',
+    });
     rmSync(dir, { recursive: true, force: true });
   });
 

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -54,7 +54,8 @@ interface OutputFile {
 
 interface Diagnostic {
   text: string;
-  location?: { file: string };
+  code?: string;
+  location?: { file: string; line?: number; column?: number };
 }
 
 interface NativeBuildResult {
@@ -1002,6 +1003,15 @@ export interface ZntcPlugin {
 
 /** 플러그인 훅 반환값: 동기/비동기 모두 허용. null/undefined로 패스스루. */
 type HookResult<T> = T | null | undefined | Promise<T | null | undefined>;
+type PluginFailureResult = {
+  __zntcPluginFailure: true;
+  pluginName: string;
+  hookName: string;
+  message: string;
+  file?: string;
+  line?: number;
+  column?: number;
+};
 
 export interface PluginBuild {
   onResolve(
@@ -1172,17 +1182,103 @@ export interface AppDevPrepareResult {
  * filter 없는 lifecycle/generate hook 의 callback 들을 sequential 로 실행하고 swallow.
  * Rollup 명세 — 한 plugin 의 실패가 다른 plugin 을 차단하지 않는다.
  */
+function normalizePluginFailure(
+  pluginName: string,
+  hookName: string,
+  thrown: unknown,
+  fallbackFile?: string | null,
+): PluginFailureResult {
+  let message = 'Plugin hook failed';
+  let file = fallbackFile ?? undefined;
+  let line: number | undefined;
+  let column: number | undefined;
+
+  if (typeof thrown === 'string') {
+    message = thrown;
+  } else if (thrown && typeof thrown === 'object') {
+    const err = thrown as {
+      message?: unknown;
+      text?: unknown;
+      id?: unknown;
+      file?: unknown;
+      fileName?: unknown;
+      line?: unknown;
+      lineNumber?: unknown;
+      column?: unknown;
+      columnNumber?: unknown;
+      loc?: { file?: unknown; line?: unknown; column?: unknown };
+    };
+    if (typeof err.message === 'string') message = err.message;
+    else if (typeof err.text === 'string') message = err.text;
+    else message = String(thrown);
+
+    const loc = err.loc;
+    const fileCandidate = loc?.file ?? err.id ?? err.file ?? err.fileName;
+    if (typeof fileCandidate === 'string' && fileCandidate.length > 0) file = fileCandidate;
+
+    const lineCandidate = loc?.line ?? err.line ?? err.lineNumber;
+    const columnCandidate = loc?.column ?? err.column ?? err.columnNumber;
+    if (typeof lineCandidate === 'number' && Number.isFinite(lineCandidate)) line = lineCandidate;
+    if (typeof columnCandidate === 'number' && Number.isFinite(columnCandidate)) {
+      column = columnCandidate;
+    }
+  } else if (thrown != null) {
+    message = String(thrown);
+  }
+
+  return {
+    __zntcPluginFailure: true,
+    pluginName,
+    hookName,
+    message,
+    ...(file ? { file } : {}),
+    ...(line !== undefined ? { line } : {}),
+    ...(column !== undefined ? { column } : {}),
+  };
+}
+
+function pluginFailureText(failure: PluginFailureResult): string {
+  const location =
+    failure.file && failure.line !== undefined
+      ? ` (${failure.file}:${failure.line}:${failure.column ?? 0})`
+      : failure.file
+        ? ` (${failure.file})`
+        : '';
+  return `Plugin "${failure.pluginName}" failed in ${failure.hookName}: ${failure.message}${location}`;
+}
+
+function pluginFailureToDiagnostic(failure: PluginFailureResult): Diagnostic {
+  return {
+    code: 'plugin_error',
+    text: pluginFailureText(failure),
+    ...(failure.file
+      ? { location: { file: failure.file, line: failure.line, column: failure.column } }
+      : {}),
+  };
+}
+
+function isPluginFailureResult(value: unknown): value is PluginFailureResult {
+  return Boolean(
+    value &&
+    typeof value === 'object' &&
+    (value as { __zntcPluginFailure?: unknown }).__zntcPluginFailure === true,
+  );
+}
+
 async function runFireAndForget<T>(
-  callbacks: Array<(arg: T) => void | Promise<void>>,
+  callbacks: Array<{ pluginName: string; callback: (arg: T) => void | Promise<void> }>,
+  hookName: string,
   arg: T,
-): Promise<void> {
-  for (const cb of callbacks) {
+): Promise<PluginFailureResult | null> {
+  let firstFailure: PluginFailureResult | null = null;
+  for (const { pluginName, callback } of callbacks) {
     try {
-      await cb(arg);
-    } catch {
-      // pass
+      await callback(arg);
+    } catch (err) {
+      firstFailure ??= normalizePluginFailure(pluginName, hookName, err);
     }
   }
+  return firstFailure;
 }
 
 /**
@@ -1190,7 +1286,14 @@ async function runFireAndForget<T>(
  * dispatcher(hookName, arg1, arg2) → result | null
  */
 function createPluginDispatcher(plugins: ZntcPlugin[]) {
-  type HookEntry = { filter: RegExp; callback: (...args: any[]) => any };
+  type HookEntry = { pluginName: string; filter: RegExp; callback: (...args: any[]) => any };
+  type PluginDispatcher = ((
+    hookName: string,
+    arg1: unknown,
+    arg2: string | null,
+  ) => Promise<unknown>) & {
+    takeLifecycleFailures(): PluginFailureResult[];
+  };
   const hooks: Record<string, HookEntry[]> = {
     resolveId: [],
     load: [],
@@ -1198,43 +1301,52 @@ function createPluginDispatcher(plugins: ZntcPlugin[]) {
     renderChunk: [],
     resolveContext: [],
   };
-  const generateBundleCallbacks: Array<(outputs: OutputFile[]) => void | Promise<void>> = [];
-  const buildStartCallbacks: Array<() => void | Promise<void>> = [];
-  const buildEndCallbacks: Array<(error?: Error) => void | Promise<void>> = [];
-  const closeBundleCallbacks: Array<() => void | Promise<void>> = [];
+  const generateBundleCallbacks: Array<{
+    pluginName: string;
+    callback: (outputs: OutputFile[]) => void | Promise<void>;
+  }> = [];
+  const buildStartCallbacks: Array<{ pluginName: string; callback: () => void | Promise<void> }> =
+    [];
+  const buildEndCallbacks: Array<{
+    pluginName: string;
+    callback: (error?: Error) => void | Promise<void>;
+  }> = [];
+  const closeBundleCallbacks: Array<{ pluginName: string; callback: () => void | Promise<void> }> =
+    [];
   const astFunctionHooks: HookEntry[] = [];
+  const lifecycleFailures: PluginFailureResult[] = [];
 
   for (const plugin of plugins) {
     const build: PluginBuild = {
       onResolve(opts, cb) {
-        hooks.resolveId.push({ filter: opts.filter, callback: cb });
+        hooks.resolveId.push({ pluginName: plugin.name, filter: opts.filter, callback: cb });
       },
       onLoad(opts, cb) {
-        hooks.load.push({ filter: opts.filter, callback: cb });
+        hooks.load.push({ pluginName: plugin.name, filter: opts.filter, callback: cb });
       },
       onTransform(opts, cb) {
-        hooks.transform.push({ filter: opts.filter, callback: cb });
+        hooks.transform.push({ pluginName: plugin.name, filter: opts.filter, callback: cb });
       },
       onRenderChunk(opts, cb) {
-        hooks.renderChunk.push({ filter: opts.filter, callback: cb });
+        hooks.renderChunk.push({ pluginName: plugin.name, filter: opts.filter, callback: cb });
       },
       onGenerateBundle(cb) {
-        generateBundleCallbacks.push(cb);
+        generateBundleCallbacks.push({ pluginName: plugin.name, callback: cb });
       },
       onBuildStart(cb) {
-        buildStartCallbacks.push(cb);
+        buildStartCallbacks.push({ pluginName: plugin.name, callback: cb });
       },
       onBuildEnd(cb) {
-        buildEndCallbacks.push(cb);
+        buildEndCallbacks.push({ pluginName: plugin.name, callback: cb });
       },
       onCloseBundle(cb) {
-        closeBundleCallbacks.push(cb);
+        closeBundleCallbacks.push({ pluginName: plugin.name, callback: cb });
       },
       onAstFunction(opts, cb) {
-        astFunctionHooks.push({ filter: opts.filter, callback: cb });
+        astFunctionHooks.push({ pluginName: plugin.name, filter: opts.filter, callback: cb });
       },
       onResolveContext(opts, cb) {
-        hooks.resolveContext.push({ filter: opts.filter, callback: cb });
+        hooks.resolveContext.push({ pluginName: plugin.name, filter: opts.filter, callback: cb });
       },
     };
     plugin.setup(build);
@@ -1247,7 +1359,11 @@ function createPluginDispatcher(plugins: ZntcPlugin[]) {
     renderChunk: (arg1, arg2) => [arg2 ?? '', { code: arg1, chunk: arg2 }],
   };
 
-  return async function dispatcher(hookName: string, arg1: unknown, arg2: string | null) {
+  const dispatcher = async function dispatcher(
+    hookName: string,
+    arg1: unknown,
+    arg2: string | null,
+  ) {
     // astFunction: arg1이 JSON 직렬화된 FunctionInfo
     if (hookName === 'astFunction') {
       if (astFunctionHooks.length === 0) return null;
@@ -1258,8 +1374,8 @@ function createPluginDispatcher(plugins: ZntcPlugin[]) {
             try {
               const result = await h.callback(info);
               if (result != null) return result;
-            } catch {
-              // 에러 시 해당 플러그인 건너뛰기
+            } catch (err) {
+              return normalizePluginFailure(h.pluginName, 'astFunction', err, info.sourcePath);
             }
           }
         }
@@ -1287,8 +1403,8 @@ function createPluginDispatcher(plugins: ZntcPlugin[]) {
             try {
               const result = await h.callback(args);
               if (result != null) return result;
-            } catch {
-              // 에러 시 다음 plugin 시도
+            } catch (err) {
+              return normalizePluginFailure(h.pluginName, 'resolveContext', err, args.importer);
             }
           }
         }
@@ -1301,23 +1417,27 @@ function createPluginDispatcher(plugins: ZntcPlugin[]) {
     // filter 없이 모든 callback 순차 호출 (Rollup sequential 명세). 한 plugin 실패가
     // 다른 plugin 차단 안 되도록 try/catch swallow.
     if (hookName === 'generateBundle') {
-      await runFireAndForget(generateBundleCallbacks, arg1 as OutputFile[]);
-      return null;
+      return await runFireAndForget(
+        generateBundleCallbacks,
+        'generateBundle',
+        arg1 as OutputFile[],
+      );
     }
     if (hookName === 'buildStart') {
-      await runFireAndForget(buildStartCallbacks, undefined);
-      return null;
+      return await runFireAndForget(buildStartCallbacks, 'buildStart', undefined);
     }
     if (hookName === 'buildEnd') {
       // native 측이 fatal diagnostic message 를 string 으로 forward — 빈 문자열은 정상 build.
       const msg = arg1 as string;
       const err = msg && msg.length > 0 ? new Error(msg) : undefined;
-      await runFireAndForget(buildEndCallbacks, err);
-      return null;
+      const failure = await runFireAndForget(buildEndCallbacks, 'buildEnd', err);
+      if (failure) lifecycleFailures.push(failure);
+      return failure;
     }
     if (hookName === 'closeBundle') {
-      await runFireAndForget(closeBundleCallbacks, undefined);
-      return null;
+      const failure = await runFireAndForget(closeBundleCallbacks, 'closeBundle', undefined);
+      if (failure) lifecycleFailures.push(failure);
+      return failure;
     }
 
     const hookList = hooks[hookName];
@@ -1342,8 +1462,8 @@ function createPluginDispatcher(plugins: ZntcPlugin[]) {
                 changed = true;
               }
             }
-          } catch {
-            // 에러 시 해당 플러그인 건너뛰고 다음으로
+          } catch (err) {
+            return normalizePluginFailure(h.pluginName, hookName, err, arg2);
           }
         }
       }
@@ -1359,13 +1479,16 @@ function createPluginDispatcher(plugins: ZntcPlugin[]) {
         try {
           const result = await h.callback(cbArgs);
           if (result != null) return result;
-        } catch {
-          return null;
+        } catch (err) {
+          const fallbackFile = hookName === 'resolveId' ? arg2 : filterTarget;
+          return normalizePluginFailure(h.pluginName, hookName, err, fallbackFile);
         }
       }
     }
     return null;
-  };
+  } as PluginDispatcher;
+  dispatcher.takeLifecycleFailures = () => lifecycleFailures.splice(0);
+  return dispatcher;
 }
 
 /**
@@ -1677,11 +1800,24 @@ export async function build(options: BuildOptions): Promise<BuildResult> {
   // 결정 직후라 disk write *전* 이므로 closeBundle 자리 부적합.
   try {
     const result: BuildResult = await native.build(napiOptions);
+    if (dispatcher) {
+      for (const failure of dispatcher.takeLifecycleFailures()) {
+        result.errors.push(pluginFailureToDiagnostic(failure));
+      }
+    }
 
     postProcessCssOutputs(result, options);
     writeOutputFiles(result, options);
 
-    if (dispatcher) await dispatcher('closeBundle', undefined, null);
+    if (dispatcher) {
+      const closeResult = await dispatcher('closeBundle', undefined, null);
+      const failures = dispatcher.takeLifecycleFailures();
+      if (failures.length > 0) {
+        for (const failure of failures) result.errors.push(pluginFailureToDiagnostic(failure));
+      } else if (isPluginFailureResult(closeResult)) {
+        result.errors.push(pluginFailureToDiagnostic(closeResult));
+      }
+    }
     return result;
   } finally {
     cleanup();
@@ -1904,42 +2040,59 @@ export function benchmark(options: BenchmarkOptions): BenchmarkResult {
 
 type MaybePromise<T> = T | Promise<T>;
 
+export interface RollupPluginContext {
+  error(error: unknown): never;
+}
+
 export interface RollupPlugin {
   name: string;
   resolveId?(
+    this: RollupPluginContext,
     source: string,
     importer?: string | null,
   ): MaybePromise<string | null | undefined | void | { id: string; external?: boolean }>;
   load?(
+    this: RollupPluginContext,
     id: string,
   ): MaybePromise<string | null | undefined | void | { code: string; map?: unknown }>;
   transform?(
+    this: RollupPluginContext,
     code: string,
     id: string,
   ): MaybePromise<string | null | undefined | void | { code: string; map?: unknown }>;
   renderChunk?(
+    this: RollupPluginContext,
     code: string,
     chunk: string,
   ): MaybePromise<string | null | undefined | void | { code: string }>;
-  generateBundle?(outputs: OutputFile[]): MaybePromise<void>;
+  generateBundle?(this: RollupPluginContext, outputs: OutputFile[]): MaybePromise<void>;
   /** Bundle 시작 시 1회. esbuild `onStart` / Rollup `buildStart` 호환 (#2156).
    *  ZNTC 는 인자 없이 호출 (esbuild 스타일) — Rollup plugin 이 `options` 인자를 기대하면
-   *  plugin 자체 closure 로 받아둘 것. `this` context 는 미지원. */
-  buildStart?(): MaybePromise<void>;
+   *  plugin 자체 closure 로 받아둘 것. */
+  buildStart?(this: RollupPluginContext): MaybePromise<void>;
   /** Bundle 종료 시 1회. Rollup `buildEnd` 호환 — error 가 있으면 빌드 실패. */
-  buildEnd?(error?: Error): MaybePromise<void>;
+  buildEnd?(this: RollupPluginContext, error?: Error): MaybePromise<void>;
   /** Output 파일 write 완료 후. Rollup `closeBundle` 호환. */
-  closeBundle?(): MaybePromise<void>;
+  closeBundle?(this: RollupPluginContext): MaybePromise<void>;
+}
+
+function createRollupPluginContext(): RollupPluginContext {
+  return {
+    error(error: unknown): never {
+      throw error;
+    },
+  };
 }
 
 export function vitePlugin(rollupPlugin: RollupPlugin): ZntcPlugin {
   return {
     name: rollupPlugin.name,
     setup(build) {
+      const context = createRollupPluginContext();
       if (rollupPlugin.resolveId) {
         const hook = rollupPlugin.resolveId;
         build.onResolve({ filter: /.*/ }, async (args) => {
-          const result = await hook(args.path, args.importer);
+          const result = await hook.call(context, args.path, args.importer);
           if (result == null) return null;
           if (typeof result === 'string') return { path: result };
           if (typeof result === 'object' && 'id' in result) {
@@ -1952,7 +2105,7 @@ export function vitePlugin(rollupPlugin: RollupPlugin): ZntcPlugin {
       if (rollupPlugin.load) {
         const hook = rollupPlugin.load;
         build.onLoad({ filter: /.*/ }, async (args) => {
-          const result = await hook(args.path);
+          const result = await hook.call(context, args.path);
           if (result == null) return null;
           if (typeof result === 'string') return { contents: result };
           if (typeof result === 'object' && 'code' in result) {
@@ -1965,7 +2118,7 @@ export function vitePlugin(rollupPlugin: RollupPlugin): ZntcPlugin {
       if (rollupPlugin.transform) {
         const hook = rollupPlugin.transform;
         build.onTransform({ filter: /.*/ }, async (args) => {
-          const result = await hook(args.code, args.path);
+          const result = await hook.call(context, args.code, args.path);
           if (result == null) return null;
           if (typeof result === 'string') return { code: result };
           if (typeof result === 'object' && 'code' in result) {
@@ -1978,7 +2131,7 @@ export function vitePlugin(rollupPlugin: RollupPlugin): ZntcPlugin {
       if (rollupPlugin.renderChunk) {
         const hook = rollupPlugin.renderChunk;
         build.onRenderChunk({ filter: /.*/ }, async (args) => {
-          const result = await hook(args.code, args.chunk);
+          const result = await hook.call(context, args.code, args.chunk);
           if (result == null) return null;
           if (typeof result === 'string') return { code: result };
           if (typeof result === 'object' && 'code' in result) {
@@ -1991,28 +2144,28 @@ export function vitePlugin(rollupPlugin: RollupPlugin): ZntcPlugin {
       if (rollupPlugin.generateBundle) {
         const hook = rollupPlugin.generateBundle;
         build.onGenerateBundle(async (outputs) => {
-          await hook(outputs);
+          await hook.call(context, outputs);
         });
       }
 
       if (rollupPlugin.buildStart) {
         const hook = rollupPlugin.buildStart;
         build.onBuildStart(async () => {
-          await hook();
+          await hook.call(context);
         });
       }
 
       if (rollupPlugin.buildEnd) {
         const hook = rollupPlugin.buildEnd;
         build.onBuildEnd(async (err) => {
-          await hook(err);
+          await hook.call(context, err);
         });
       }
 
       if (rollupPlugin.closeBundle) {
         const hook = rollupPlugin.closeBundle;
         build.onCloseBundle(async () => {
-          await hook();
+          await hook.call(context);
         });
       }
     },

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1179,8 +1179,8 @@ export interface AppDevPrepareResult {
 }
 
 /**
- * filter 없는 lifecycle/generate hook 의 callback 들을 sequential 로 실행하고 swallow.
- * Rollup 명세 — 한 plugin 의 실패가 다른 plugin 을 차단하지 않는다.
+ * thrown 값을 PluginFailureResult 로 정규화한다. Error / RollupError-like / 문자열 / 기타를
+ * 한 가지 모양으로 묶어 NAPI 경계 너머로 전달 가능하게 한다 (#1902).
  */
 function normalizePluginFailure(
   pluginName: string,
@@ -1255,14 +1255,6 @@ function pluginFailureToDiagnostic(failure: PluginFailureResult): Diagnostic {
       ? { location: { file: failure.file, line: failure.line, column: failure.column } }
       : {}),
   };
-}
-
-function isPluginFailureResult(value: unknown): value is PluginFailureResult {
-  return Boolean(
-    value &&
-    typeof value === 'object' &&
-    (value as { __zntcPluginFailure?: unknown }).__zntcPluginFailure === true,
-  );
 }
 
 async function runFireAndForget<T>(
@@ -1415,7 +1407,7 @@ function createPluginDispatcher(plugins: ZntcPlugin[]) {
     }
 
     // filter 없이 모든 callback 순차 호출 (Rollup sequential 명세). 한 plugin 실패가
-    // 다른 plugin 차단 안 되도록 try/catch swallow.
+    // 다른 plugin 을 차단하지 않도록 첫 실패만 capture 후 나머지는 계속 실행 (#1902).
     if (hookName === 'generateBundle') {
       return await runFireAndForget(
         generateBundleCallbacks,
@@ -1810,12 +1802,9 @@ export async function build(options: BuildOptions): Promise<BuildResult> {
     writeOutputFiles(result, options);
 
     if (dispatcher) {
-      const closeResult = await dispatcher('closeBundle', undefined, null);
-      const failures = dispatcher.takeLifecycleFailures();
-      if (failures.length > 0) {
-        for (const failure of failures) result.errors.push(pluginFailureToDiagnostic(failure));
-      } else if (isPluginFailureResult(closeResult)) {
-        result.errors.push(pluginFailureToDiagnostic(closeResult));
+      await dispatcher('closeBundle', undefined, null);
+      for (const failure of dispatcher.takeLifecycleFailures()) {
+        result.errors.push(pluginFailureToDiagnostic(failure));
       }
     }
     return result;

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1181,6 +1181,11 @@ fn buildResultToJS(env: c.napi_env, result: *const bundler_mod.BundleResult, log
         _ = c.napi_create_string_utf8(env, d.message.ptr, d.message.len, &js_msg);
         _ = c.napi_set_named_property(env, js_diag, "text", js_msg);
 
+        const code_name = @tagName(d.code);
+        var js_code: c.napi_value = undefined;
+        _ = c.napi_create_string_utf8(env, code_name.ptr, code_name.len, &js_code);
+        _ = c.napi_set_named_property(env, js_diag, "code", js_code);
+
         if (d.file_path.len > 0) {
             var js_loc: c.napi_value = undefined;
             _ = c.napi_create_object(env, &js_loc);
@@ -1278,6 +1283,13 @@ const NapiPlugin = struct {
         /// ParsedLoader.fromString 으로 변환된 결과. null = override 안 함.
         loader_override: ?bundler_mod.types.Loader = null,
         loader_module_type: ?bundler_mod.types.ModuleType = null,
+        is_failure: bool = false,
+        failure_plugin_name: ?[]const u8 = null,
+        failure_hook_name: ?[]const u8 = null,
+        failure_message: ?[]const u8 = null,
+        failure_file: ?[]const u8 = null,
+        failure_line: u32 = 0,
+        failure_column: u32 = 0,
     };
 
     /// Per-call 요청 컨텍스트. 여러 워커 스레드가 동시에 호출해도 안전.
@@ -1302,6 +1314,16 @@ const NapiPlugin = struct {
         }
 
         var resp = PluginResponse{};
+        if (getObjectBool(env, js_result, "__zntcPluginFailure", false)) {
+            resp.is_failure = true;
+            resp.failure_plugin_name = getObjectString(env, js_result, "pluginName", native_alloc);
+            resp.failure_hook_name = getObjectString(env, js_result, "hookName", native_alloc);
+            resp.failure_message = getObjectString(env, js_result, "message", native_alloc);
+            resp.failure_file = getObjectString(env, js_result, "file", native_alloc);
+            resp.failure_line = getObjectUint32(env, js_result, "line", 0);
+            resp.failure_column = getObjectUint32(env, js_result, "column", 0);
+            return resp;
+        }
         if (getObjectString(env, js_result, "path", native_alloc)) |path| {
             resp.resolved_path = path;
         }
@@ -1342,6 +1364,27 @@ const NapiPlugin = struct {
         return resp;
     }
 
+    fn freeFailureFields(resp: PluginResponse) void {
+        if (resp.failure_plugin_name) |s| native_alloc.free(s);
+        if (resp.failure_hook_name) |s| native_alloc.free(s);
+        if (resp.failure_message) |s| native_alloc.free(s);
+        if (resp.failure_file) |s| native_alloc.free(s);
+    }
+
+    fn failWithResponse(self: *NapiPlugin, resp: PluginResponse, alloc: std.mem.Allocator) PluginError {
+        const failure = plugin_mod.PluginFailure.init(
+            alloc,
+            resp.failure_plugin_name orelse self.name,
+            resp.failure_hook_name orelse "plugin",
+            resp.failure_message orelse "Plugin hook failed",
+            resp.failure_file orelse "",
+            resp.failure_line,
+            resp.failure_column,
+        ) catch return error.OutOfMemory;
+        plugin_mod.setLastPluginFailure(failure);
+        return error.PluginFailed;
+    }
+
     /// CallContext에 응답을 기록하고 워커 스레드에 시그널을 보낸다.
     fn signalResponse(ctx: *CallContext, resp: PluginResponse) void {
         ctx.mutex.lock();
@@ -1366,10 +1409,12 @@ const NapiPlugin = struct {
 
     /// Promise의 .catch() 콜백 — reject 시 빈 응답으로 워커 스레드에 전달
     fn promiseCatchCallback(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+        var argc: usize = 1;
+        var argv: [1]c.napi_value = undefined;
         var cb_data: ?*anyopaque = null;
-        _ = c.napi_get_cb_info(env, info, null, null, null, &cb_data);
+        _ = c.napi_get_cb_info(env, info, &argc, &argv, null, &cb_data);
         const ctx: *CallContext = @ptrCast(@alignCast(cb_data.?));
-        signalResponse(ctx, .{});
+        signalResponse(ctx, if (argc > 0) parseJsResult(env, argv[0]) else .{});
         var undef: c.napi_value = undefined;
         _ = c.napi_get_undefined(env, &undef);
         return undef;
@@ -1496,7 +1541,11 @@ const NapiPlugin = struct {
     /// code를 반환하는 훅 공통 구현 (transform, renderChunk, load)
     fn callCodeHook(self: *NapiPlugin, hook: HookType, arg1: []const u8, arg2: ?[]const u8, alloc: std.mem.Allocator) PluginError!?[]const u8 {
         const resp = self.callHook(hook, arg1, arg2) orelse return null;
-        defer if (resp.resolved_path) |p| native_alloc.free(p);
+        defer {
+            if (resp.resolved_path) |p| native_alloc.free(p);
+            freeFailureFields(resp);
+        }
+        if (resp.is_failure) return self.failWithResponse(resp, alloc);
         if (resp.code) |result_code| {
             const result = alloc.dupe(u8, result_code) catch return error.OutOfMemory;
             native_alloc.free(result_code);
@@ -1511,7 +1560,9 @@ const NapiPlugin = struct {
         defer {
             if (resp.resolved_path) |p| native_alloc.free(p);
             if (resp.code) |co| native_alloc.free(co);
+            freeFailureFields(resp);
         }
+        if (resp.is_failure) return self.failWithResponse(resp, alloc);
 
         // disabled: 빈 모듈로 처리. path는 식별용 — resolved_path 또는 specifier 그대로.
         // Metro `{ type: 'empty' }` 매핑, webpack `resolve.fallback: false`와 동등.
@@ -1535,7 +1586,11 @@ const NapiPlugin = struct {
     fn pluginLoad(ctx: ?*anyopaque, path: []const u8, alloc: std.mem.Allocator) PluginError!?plugin_mod.LoadResult {
         const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
         const resp = self.callHook(.load, path, null) orelse return null;
-        defer if (resp.resolved_path) |p| native_alloc.free(p);
+        defer {
+            if (resp.resolved_path) |p| native_alloc.free(p);
+            freeFailureFields(resp);
+        }
+        if (resp.is_failure) return self.failWithResponse(resp, alloc);
         const result_code = resp.code orelse return null;
         const contents = alloc.dupe(u8, result_code) catch {
             native_alloc.free(result_code);
@@ -1562,7 +1617,9 @@ const NapiPlugin = struct {
 
     fn pluginBuildStart(ctx: ?*anyopaque) PluginError!void {
         const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
-        _ = self.callHook(.buildStart, "", null);
+        const resp = self.callHook(.buildStart, "", null) orelse return;
+        defer freeFailureFields(resp);
+        if (resp.is_failure) return error.PluginFailed;
     }
 
     fn pluginBuildEnd(ctx: ?*anyopaque, build_error: ?*const bundler_mod.types.BundlerDiagnostic) PluginError!void {
@@ -1571,12 +1628,16 @@ const NapiPlugin = struct {
         // code/severity/file_path/span/step/suggestion 손실은 follow-up 으로 RollupError 호환
         // 객체 (`{ code, message, file, line }`) 직렬화 검토 (#2156 follow-up).
         const msg = if (build_error) |d| d.message else "";
-        _ = self.callHook(.buildEnd, msg, null);
+        const resp = self.callHook(.buildEnd, msg, null) orelse return;
+        defer freeFailureFields(resp);
+        if (resp.is_failure) return error.PluginFailed;
     }
 
     fn pluginCloseBundle(ctx: ?*anyopaque) PluginError!void {
         const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
-        _ = self.callHook(.closeBundle, "", null);
+        const resp = self.callHook(.closeBundle, "", null) orelse return;
+        defer freeFailureFields(resp);
+        if (resp.is_failure) return error.PluginFailed;
     }
 
     /// JSON string field 인코딩 — `"` `\` 와 control char escape.
@@ -1634,7 +1695,11 @@ const NapiPlugin = struct {
         json_buf.append(native_alloc, '}') catch return null;
 
         const resp = self.callHookFull(.resolveContext, json_buf.items, null, null) orelse return null;
-        defer if (resp.context_matches) |m| native_alloc.free(m);
+        defer {
+            if (resp.context_matches) |m| native_alloc.free(m);
+            freeFailureFields(resp);
+        }
+        if (resp.is_failure) return self.failWithResponse(resp, alloc);
         // inner string 들도 native_alloc 소유 (parseStringArray 가 dupe 함). 함께 free.
         defer if (resp.context_matches) |m| {
             for (m) |s| native_alloc.free(s);
@@ -1699,7 +1764,9 @@ const NapiPlugin = struct {
             }
             if (resp.resolved_path) |p| native_alloc.free(p);
             if (resp.code) |co| native_alloc.free(co);
+            freeFailureFields(resp);
         }
+        if (resp.is_failure) return error.PluginFailed;
 
         if (resp.strip_directive != null) {
             _ = api.stripDirective(func.body_idx) catch return;

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -78,6 +78,7 @@ pub const ModuleGraph = struct {
     requested_exports: std.AutoHashMapUnmanaged(u32, RequestedExports) = .{},
     requested_exports_mutex: std.Thread.Mutex = .{},
     diagnostics: std.ArrayList(BundlerDiagnostic),
+    owned_diagnostic_strings: std.ArrayList([]const u8) = .empty,
     resolve_cache: *ResolveCache,
     source_read_cache: fs.ReadFileCache = .{},
     /// 병렬 워커에서 diagnostics 접근 보호용 mutex
@@ -273,6 +274,8 @@ pub const ModuleGraph = struct {
         while (pi_it.next()) |info| info.side_effects.deinit(self.allocator);
         self.pkg_info_cache.deinit(self.allocator);
         self.source_read_cache.deinit(self.allocator);
+        for (self.owned_diagnostic_strings.items) |s| self.allocator.free(s);
+        self.owned_diagnostic_strings.deinit(self.allocator);
         self.diagnostics.deinit(self.allocator);
         for (self.worker_entries.items) |we| {
             self.allocator.free(we.resolved_path);
@@ -1821,7 +1824,11 @@ pub const ModuleGraph = struct {
                 if (plugin_runner) |runner| {
                     if (self.shouldRunResolveId(record.specifier)) {
                         const resolve_result = runner.runResolveId(record.specifier, module_path, self.allocator) catch |err| switch (err) {
-                            error.PluginFailed => null,
+                            error.PluginFailed => {
+                                self.addPluginFailureDiag(plugin_mod.takeLastPluginFailure(), module_path, record.span, .resolve);
+                                results[rec_i] = .{ .is_error = true, .skipped = !should_link };
+                                continue;
+                            },
                             error.OutOfMemory => {
                                 self.addDiag(.resolve_error, .@"error", module_path, record.span, .resolve, "Out of memory during resolve", record.specifier);
                                 continue;
@@ -1879,7 +1886,12 @@ pub const ModuleGraph = struct {
                     return;
                 };
                 const load_result = runner.runLoad(module.path, tmp_arena.allocator()) catch |err| switch (err) {
-                    error.PluginFailed => null,
+                    error.PluginFailed => {
+                        self.addPluginFailureDiag(plugin_mod.takeLastPluginFailure(), module.path, Span.EMPTY, .resolve);
+                        module_mod.destroyParseArena(self.allocator, tmp_arena);
+                        module.state = .ready;
+                        return;
+                    },
                     error.OutOfMemory => {
                         module_mod.destroyParseArena(self.allocator, tmp_arena);
                         module.state = .ready;
@@ -2083,7 +2095,11 @@ pub const ModuleGraph = struct {
         if (plugin_runner) |runner| {
             if (self.has_transform_plugins) {
                 const transform_result = runner.runTransform(module.source, module.path, arena_alloc) catch |err| switch (err) {
-                    error.PluginFailed => null,
+                    error.PluginFailed => {
+                        self.addPluginFailureDiag(plugin_mod.takeLastPluginFailure(), module.path, Span.EMPTY, .transform);
+                        module.state = .ready;
+                        return;
+                    },
                     error.OutOfMemory => {
                         module.state = .ready;
                         return;
@@ -3158,7 +3174,10 @@ pub const ModuleGraph = struct {
             if (plugin_runner) |runner| {
                 if (self.shouldRunResolveId(record.specifier)) {
                     const resolve_result = runner.runResolveId(record.specifier, module_path, self.allocator) catch |err| switch (err) {
-                        error.PluginFailed => null,
+                        error.PluginFailed => {
+                            self.addPluginFailureDiag(plugin_mod.takeLastPluginFailure(), module_path, record.span, .resolve);
+                            return;
+                        },
                         error.OutOfMemory => return error.OutOfMemory,
                     };
                     // non-null이면 플러그인이 resolve 완료 → 기본 resolver 건너뜀
@@ -3984,6 +4003,45 @@ pub const ModuleGraph = struct {
             .step = step,
             .suggestion = suggestion,
         }) catch {};
+    }
+
+    fn addPluginFailureDiag(
+        self: *ModuleGraph,
+        failure: ?plugin_mod.PluginFailure,
+        fallback_file: []const u8,
+        span: Span,
+        step: BundlerDiagnostic.Step,
+    ) void {
+        const f = failure orelse {
+            self.addDiag(.plugin_error, .@"error", fallback_file, span, step, "Plugin hook failed", null);
+            return;
+        };
+        defer f.deinit();
+
+        const message = f.formatMessage(self.allocator) catch {
+            self.addDiag(.plugin_error, .@"error", fallback_file, span, step, "Plugin hook failed", null);
+            return;
+        };
+        const file_src = if (f.file_path.len > 0) f.file_path else fallback_file;
+        const file_path = self.allocator.dupe(u8, file_src) catch {
+            self.allocator.free(message);
+            self.addDiag(.plugin_error, .@"error", fallback_file, span, step, "Plugin hook failed", null);
+            return;
+        };
+        self.owned_diagnostic_strings.append(self.allocator, message) catch {
+            self.allocator.free(message);
+            self.allocator.free(file_path);
+            self.addDiag(.plugin_error, .@"error", fallback_file, span, step, "Plugin hook failed", null);
+            return;
+        };
+        self.owned_diagnostic_strings.append(self.allocator, file_path) catch {
+            _ = self.owned_diagnostic_strings.pop();
+            self.allocator.free(message);
+            self.allocator.free(file_path);
+            self.addDiag(.plugin_error, .@"error", fallback_file, span, step, "Plugin hook failed", null);
+            return;
+        };
+        self.addDiag(.plugin_error, .@"error", file_path, span, step, message, null);
     }
 };
 

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -4012,35 +4012,34 @@ pub const ModuleGraph = struct {
         span: Span,
         step: BundlerDiagnostic.Step,
     ) void {
-        const f = failure orelse {
+        if (failure) |f| {
+            defer f.deinit();
+            self.tryAddPluginFailureDiag(f, fallback_file, span, step) catch {
+                self.addDiag(.plugin_error, .@"error", fallback_file, span, step, "Plugin hook failed", null);
+            };
+        } else {
             self.addDiag(.plugin_error, .@"error", fallback_file, span, step, "Plugin hook failed", null);
-            return;
-        };
-        defer f.deinit();
+        }
+    }
 
-        const message = f.formatMessage(self.allocator) catch {
-            self.addDiag(.plugin_error, .@"error", fallback_file, span, step, "Plugin hook failed", null);
-            return;
-        };
+    fn tryAddPluginFailureDiag(
+        self: *ModuleGraph,
+        f: plugin_mod.PluginFailure,
+        fallback_file: []const u8,
+        span: Span,
+        step: BundlerDiagnostic.Step,
+    ) !void {
+        const message = try f.formatMessage(self.allocator);
+        errdefer self.allocator.free(message);
+
         const file_src = if (f.file_path.len > 0) f.file_path else fallback_file;
-        const file_path = self.allocator.dupe(u8, file_src) catch {
-            self.allocator.free(message);
-            self.addDiag(.plugin_error, .@"error", fallback_file, span, step, "Plugin hook failed", null);
-            return;
-        };
-        self.owned_diagnostic_strings.append(self.allocator, message) catch {
-            self.allocator.free(message);
-            self.allocator.free(file_path);
-            self.addDiag(.plugin_error, .@"error", fallback_file, span, step, "Plugin hook failed", null);
-            return;
-        };
-        self.owned_diagnostic_strings.append(self.allocator, file_path) catch {
-            _ = self.owned_diagnostic_strings.pop();
-            self.allocator.free(message);
-            self.allocator.free(file_path);
-            self.addDiag(.plugin_error, .@"error", fallback_file, span, step, "Plugin hook failed", null);
-            return;
-        };
+        const file_path = try self.allocator.dupe(u8, file_src);
+        errdefer self.allocator.free(file_path);
+
+        try self.owned_diagnostic_strings.ensureUnusedCapacity(self.allocator, 2);
+        self.owned_diagnostic_strings.appendAssumeCapacity(message);
+        self.owned_diagnostic_strings.appendAssumeCapacity(file_path);
+
         self.addDiag(.plugin_error, .@"error", file_path, span, step, message, null);
     }
 };

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -35,6 +35,85 @@ pub const PluginError = error{
     OutOfMemory,
 };
 
+pub const PluginFailure = struct {
+    allocator: std.mem.Allocator,
+    plugin_name: []const u8,
+    hook_name: []const u8,
+    message: []const u8,
+    file_path: []const u8,
+    line: u32 = 0,
+    column: u32 = 0,
+
+    pub fn init(
+        allocator: std.mem.Allocator,
+        plugin_name: []const u8,
+        hook_name: []const u8,
+        message: []const u8,
+        file_path: []const u8,
+        line: u32,
+        column: u32,
+    ) !PluginFailure {
+        const plugin_name_copy = try allocator.dupe(u8, plugin_name);
+        errdefer allocator.free(plugin_name_copy);
+        const hook_name_copy = try allocator.dupe(u8, hook_name);
+        errdefer allocator.free(hook_name_copy);
+        const message_copy = try allocator.dupe(u8, message);
+        errdefer allocator.free(message_copy);
+        const file_path_copy = try allocator.dupe(u8, file_path);
+        return .{
+            .allocator = allocator,
+            .plugin_name = plugin_name_copy,
+            .hook_name = hook_name_copy,
+            .message = message_copy,
+            .file_path = file_path_copy,
+            .line = line,
+            .column = column,
+        };
+    }
+
+    pub fn deinit(self: PluginFailure) void {
+        self.allocator.free(self.plugin_name);
+        self.allocator.free(self.hook_name);
+        self.allocator.free(self.message);
+        self.allocator.free(self.file_path);
+    }
+
+    pub fn formatMessage(self: PluginFailure, allocator: std.mem.Allocator) ![]const u8 {
+        if (self.file_path.len > 0 and self.line > 0) {
+            return std.fmt.allocPrint(
+                allocator,
+                "Plugin \"{s}\" failed in {s}: {s} ({s}:{d}:{d})",
+                .{ self.plugin_name, self.hook_name, self.message, self.file_path, self.line, self.column },
+            );
+        }
+        if (self.file_path.len > 0) {
+            return std.fmt.allocPrint(
+                allocator,
+                "Plugin \"{s}\" failed in {s}: {s} ({s})",
+                .{ self.plugin_name, self.hook_name, self.message, self.file_path },
+            );
+        }
+        return std.fmt.allocPrint(
+            allocator,
+            "Plugin \"{s}\" failed in {s}: {s}",
+            .{ self.plugin_name, self.hook_name, self.message },
+        );
+    }
+};
+
+threadlocal var last_plugin_failure: ?PluginFailure = null;
+
+pub fn setLastPluginFailure(failure: PluginFailure) void {
+    if (last_plugin_failure) |old| old.deinit();
+    last_plugin_failure = failure;
+}
+
+pub fn takeLastPluginFailure() ?PluginFailure {
+    const failure = last_plugin_failure;
+    last_plugin_failure = null;
+    return failure;
+}
+
 /// Plugin resolveId 응답의 통합 모델 (#1885).
 ///
 /// origin 별 type-safe 분기 — esbuild 의 string namespace 보다 컴파일 타임 안전.

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -686,6 +686,8 @@ pub const BundlerDiagnostic = struct {
         require_context_invalid,
         /// require.context 매칭 핸들러 미구현 (host plugin resolveContext hook 없음). #1579 / #1771
         require_context_no_handler,
+        /// JS/native plugin hook throw/reject 실패. #1902
+        plugin_error,
         /// `output.exports = "default"` 모드 + named export 섞임. Rollup 도 동일 케이스 throw. #2159
         output_exports_conflict,
     };


### PR DESCRIPTION
## 요약
- #1902 순차 작업 중 PR 1: plugin failure diagnostics입니다.
- JS plugin hook throw/reject를 더 이상 null/pass-through로 삼키지 않고 `plugin_error` diagnostic으로 정규화합니다.
- PR 2(transform sourcemap chain)는 이 PR 머지 후 진행합니다.

## 먼저 추가한 실패 테스트
- `onLoad` sync throw -> `plugin_error`
- `onTransform` async reject -> `plugin_error`
- thrown string의 plugin/hook/message 보존
- `vitePlugin.resolveId` sync throw -> `plugin_error`
- `vitePlugin.load`의 `this.error()`가 RollupError-like location 보존
- `vitePlugin.transform` async reject -> `plugin_error`
- `buildEnd`/`closeBundle` 실패는 기존 build error를 덮지 않고 secondary diagnostic으로 기록

## 구현 요약
- JS dispatcher가 hook별 plugin name을 보존하고 throw/reject를 failure payload로 정규화합니다.
- NAPI bridge가 failure payload를 native plugin failure로 전달하고 `BuildResult.errors[].code = "plugin_error"`를 노출합니다.
- graph가 `resolveId`/`load`/`transform` failure payload를 fatal diagnostic으로 복사합니다.
- `vitePlugin()`에 Rollup-style `this.error()` context를 추가했습니다.
- lifecycle cleanup 실패는 `build()` 결과에 secondary diagnostic으로 병합합니다.

## 검증
- `zig build napi`
- `zig build test --summary all`
- `bun test packages/core/index.test.ts --test-name-pattern plugin_error`
- `bun test packages/core/index.test.ts`
- `bun run --cwd packages/core build:js`
- `bun run fmt:check`
- `zig fmt --check src packages/core/src/napi_entry.zig`
- `git diff --check`
- `bun run lint` (기존 warning 21개, error 0)
- push hook 통과

Refs #1902
