### PR TITLE
fix(sourcemap): 플러그인 transform map을 최종 sourcemap에 합성

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -7,6 +7,7 @@ import {
   watch,
   close,
   vitePlugin,
+  type OutputFile,
   type ZntcPlugin,
   type RollupPlugin,
 } from './index';
@@ -70,6 +71,141 @@ function expectPluginDiagnostic(
   if (expected.textIncludes) {
     expect(diagText(diag)).toContain(expected.textIncludes);
   }
+}
+
+const SOURCE_MAP_VLQ_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+function encodeSourceMapVlq(value: number): string {
+  let vlq = value < 0 ? (-value << 1) | 1 : value << 1;
+  let out = '';
+  do {
+    let digit = vlq & 31;
+    vlq >>>= 5;
+    if (vlq > 0) digit |= 32;
+    out += SOURCE_MAP_VLQ_CHARS[digit];
+  } while (vlq > 0);
+  return out;
+}
+
+function lineOffsetMappings(generatedStart: number, originalStart: number, lineCount: number) {
+  const lines = Array.from({ length: generatedStart + lineCount }, () => '');
+  let prevSource = 0;
+  let prevOriginalLine = 0;
+  let prevOriginalColumn = 0;
+  for (let i = 0; i < lineCount; i++) {
+    const originalLine = originalStart + i;
+    lines[generatedStart + i] =
+      encodeSourceMapVlq(0) +
+      encodeSourceMapVlq(0 - prevSource) +
+      encodeSourceMapVlq(originalLine - prevOriginalLine) +
+      encodeSourceMapVlq(0 - prevOriginalColumn);
+    prevSource = 0;
+    prevOriginalLine = originalLine;
+    prevOriginalColumn = 0;
+  }
+  return lines.join(';');
+}
+
+function decodeSourceMapVlq(segment: string): number[] {
+  const out: number[] = [];
+  let value = 0;
+  let shift = 0;
+  for (const ch of segment) {
+    const digit = SOURCE_MAP_VLQ_CHARS.indexOf(ch);
+    if (digit < 0) throw new Error(`bad vlq char ${ch}`);
+    value |= (digit & 31) << shift;
+    shift += 5;
+    if ((digit & 32) === 0) {
+      const signed = value & 1 ? -(value >> 1) : value >> 1;
+      out.push(signed);
+      value = 0;
+      shift = 0;
+    }
+  }
+  return out;
+}
+
+interface DecodedSourceMapSegment {
+  genCol: number;
+  sourceIndex: number;
+  srcLine: number;
+  srcCol: number;
+}
+
+function decodeSourceMapMappings(mappings: string): DecodedSourceMapSegment[][] {
+  const lines: DecodedSourceMapSegment[][] = [];
+  let prevSource = 0;
+  let prevSourceLine = 0;
+  let prevSourceColumn = 0;
+  for (const line of mappings.split(';')) {
+    const segments: DecodedSourceMapSegment[] = [];
+    let prevGeneratedColumn = 0;
+    for (const rawSegment of line.split(',')) {
+      if (!rawSegment) continue;
+      const fields = decodeSourceMapVlq(rawSegment);
+      prevGeneratedColumn += fields[0] ?? 0;
+      if (fields.length >= 4) {
+        prevSource += fields[1];
+        prevSourceLine += fields[2];
+        prevSourceColumn += fields[3];
+        segments.push({
+          genCol: prevGeneratedColumn,
+          sourceIndex: prevSource,
+          srcLine: prevSourceLine,
+          srcCol: prevSourceColumn,
+        });
+      }
+    }
+    lines.push(segments);
+  }
+  return lines;
+}
+
+function lookupSourceMapSegment(
+  decoded: DecodedSourceMapSegment[][],
+  line: number,
+  column: number,
+) {
+  let found: DecodedSourceMapSegment | null = null;
+  for (const segment of decoded[line] ?? []) {
+    if (segment.genCol > column) break;
+    found = segment;
+  }
+  return found;
+}
+
+function findTextPosition(text: string, needle: string) {
+  const index = text.indexOf(needle);
+  expect(index).toBeGreaterThanOrEqual(0);
+  const prefix = text.slice(0, index);
+  const lines = prefix.split('\n');
+  return { line: lines.length - 1, column: lines.at(-1)!.length };
+}
+
+function parseBundleMap(result: { outputFiles: OutputFile[] }) {
+  const jsFile =
+    result.outputFiles.find((file) => file.path.endsWith('.js')) ?? result.outputFiles[0];
+  const mapFile = result.outputFiles.find((file) => file.path.endsWith('.map'));
+  expect(mapFile).toBeDefined();
+  return { code: jsFile.text, map: JSON.parse(mapFile!.text) };
+}
+
+function expectMarkerMappedToSourceLine(
+  result: { outputFiles: OutputFile[] },
+  marker: string,
+  expectedSource: string,
+  expectedLine: number,
+) {
+  const { code, map } = parseBundleMap(result);
+  const generated = findTextPosition(code, marker);
+  const segment = lookupSourceMapSegment(
+    decodeSourceMapMappings(map.mappings ?? ''),
+    generated.line,
+    generated.column,
+  );
+  expect(segment).not.toBeNull();
+  expect(map.sources[segment!.sourceIndex]).toContain(expectedSource);
+  expect(segment!.srcLine).toBe(expectedLine);
 }
 
 describe('@zntc/core', () => {
@@ -2822,25 +2958,327 @@ describe('vitePlugin 어댑터', () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  test('vitePlugin: transform이 { code, map } 반환 시 map 무시', async () => {
+  test('vitePlugin: transform이 { code, map } 반환 시 최종 sourcemap에 반영', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'zntc-vite-map-'));
-    writeFileSync(join(dir, 'index.ts'), 'const x = 1;');
+    const source = 'const VITE_MAP_MARKER = 1;\nconsole.log(VITE_MAP_MARKER);\n';
+    writeFileSync(join(dir, 'index.ts'), source);
 
     const plugin: RollupPlugin = {
       name: 'with-map',
       transform(code) {
-        return { code: code.replace('1', '42'), map: { version: 3, mappings: '' } };
+        return {
+          code: 'const __viteHeader = 0;\n' + code,
+          map: {
+            version: 3,
+            sources: ['index.ts'],
+            sourcesContent: [source],
+            mappings: lineOffsetMappings(1, 0, source.split('\n').length - 1),
+          },
+        };
       },
     };
 
     const result = await build({
       entryPoints: [join(dir, 'index.ts')],
+      sourcemap: true,
       plugins: [vitePlugin(plugin)],
     });
     expect(result.errors.length).toBe(0);
-    expect(result.outputFiles[0].text).toContain('42');
+    expectMarkerMappedToSourceLine(result, 'VITE_MAP_MARKER', 'index.ts', 0);
     rmSync(dir, { recursive: true, force: true });
   });
+});
+
+describe('@zntc/core plugin transform sourcemap chain', () => {
+  test('onLoad map을 최종 sourcemap에 합성', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-plugin-map-load-'));
+    writeFileSync(join(dir, 'entry.ts'), 'import "./virtual";\n');
+    const virtualPath = join(dir, 'virtual.ts');
+    const source = 'const LOAD_MAP_MARKER = 1;\nconsole.log(LOAD_MAP_MARKER);\n';
+
+    const plugin: ZntcPlugin = {
+      name: 'load-map',
+      setup(build) {
+        build.onResolve({ filter: /^\.\/virtual$/ }, () => ({ path: virtualPath }));
+        build.onLoad({ filter: /virtual\.ts$/ }, () => ({
+          contents: 'const __loadHeader = 0;\n' + source,
+          map: {
+            version: 3,
+            sources: ['virtual-original.ts'],
+            sourcesContent: [source],
+            mappings: lineOffsetMappings(1, 0, source.split('\n').length - 1),
+          },
+        }));
+      },
+    };
+
+    const result = await build({
+      entryPoints: [join(dir, 'entry.ts')],
+      sourcemap: true,
+      plugins: [plugin],
+    });
+    expect(result.errors.length).toBe(0);
+    expectMarkerMappedToSourceLine(result, 'LOAD_MAP_MARKER', 'virtual-original.ts', 0);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('단일 onTransform map을 최종 sourcemap에 합성', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-plugin-map-single-'));
+    const source = 'const SINGLE_MAP_MARKER = 1;\nconsole.log(SINGLE_MAP_MARKER);\n';
+    writeFileSync(join(dir, 'entry.ts'), source);
+
+    const plugin: ZntcPlugin = {
+      name: 'single-map',
+      setup(build) {
+        build.onTransform({ filter: /entry\.ts$/ }, (args) => ({
+          code: 'const __singleHeader = 0;\n' + args.code,
+          map: {
+            version: 3,
+            sources: ['entry.ts'],
+            sourcesContent: [source],
+            mappings: lineOffsetMappings(1, 0, source.split('\n').length - 1),
+          },
+        }));
+      },
+    };
+
+    const result = await build({
+      entryPoints: [join(dir, 'entry.ts')],
+      sourcemap: true,
+      plugins: [plugin],
+    });
+    expect(result.errors.length).toBe(0);
+    expectMarkerMappedToSourceLine(result, 'SINGLE_MAP_MARKER', 'entry.ts', 0);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('onTransform map만 반환해도 최종 sourcemap에 합성', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-plugin-map-only-'));
+    const source = 'const MAP_ONLY_MARKER = 1;\nconsole.log(MAP_ONLY_MARKER);\n';
+    const original = '\n\n\n\n\n' + source;
+    writeFileSync(join(dir, 'entry.ts'), source);
+
+    const plugin: ZntcPlugin = {
+      name: 'map-only',
+      setup(build) {
+        build.onTransform({ filter: /entry\.ts$/ }, (args) => ({
+          code: args.code,
+          map: {
+            version: 3,
+            sources: ['original.ts'],
+            sourcesContent: [original],
+            mappings: lineOffsetMappings(0, 5, source.split('\n').length - 1),
+          },
+        }));
+      },
+    };
+
+    const result = await build({
+      entryPoints: [join(dir, 'entry.ts')],
+      sourcemap: true,
+      plugins: [plugin],
+    });
+    expect(result.errors.length).toBe(0);
+    expectMarkerMappedToSourceLine(result, 'MAP_ONLY_MARKER', 'original.ts', 5);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('2단 onTransform map chain을 원본 위치까지 역추적', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-plugin-map-chain-'));
+    const source = 'const CHAIN_MAP_MARKER = 1;\nconsole.log(CHAIN_MAP_MARKER);\n';
+    writeFileSync(join(dir, 'entry.ts'), source);
+    const stage1 = 'const __stageOne = 1;\n' + source;
+
+    const stage1Plugin: ZntcPlugin = {
+      name: 'stage-one-map',
+      setup(build) {
+        build.onTransform({ filter: /entry\.ts$/ }, () => ({
+          code: stage1,
+          map: {
+            version: 3,
+            sources: ['entry.ts'],
+            sourcesContent: [source],
+            mappings: lineOffsetMappings(1, 0, source.split('\n').length - 1),
+          },
+        }));
+      },
+    };
+    const stage2Plugin: ZntcPlugin = {
+      name: 'stage-two-map',
+      setup(build) {
+        build.onTransform({ filter: /entry\.ts$/ }, (args) => ({
+          code: 'const __stageTwo = 2;\n' + args.code,
+          map: {
+            version: 3,
+            sources: ['stage1.js'],
+            sourcesContent: [stage1],
+            mappings: lineOffsetMappings(1, 0, stage1.split('\n').length - 1),
+          },
+        }));
+      },
+    };
+
+    const result = await build({
+      entryPoints: [join(dir, 'entry.ts')],
+      sourcemap: true,
+      plugins: [stage1Plugin, stage2Plugin],
+    });
+    expect(result.errors.length).toBe(0);
+    expectMarkerMappedToSourceLine(result, 'CHAIN_MAP_MARKER', 'entry.ts', 0);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('map: null은 sourcemap 합성을 건너뛰고 빌드를 실패시키지 않음', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-plugin-map-null-'));
+    writeFileSync(join(dir, 'entry.ts'), 'const NULL_MAP_MARKER = 1;\n');
+
+    const plugin: ZntcPlugin = {
+      name: 'null-map',
+      setup(build) {
+        build.onTransform({ filter: /entry\.ts$/ }, (args) => ({
+          code: args.code.replace('1', '2'),
+          map: null,
+        }));
+      },
+    };
+
+    const result = await build({
+      entryPoints: [join(dir, 'entry.ts')],
+      sourcemap: true,
+      plugins: [plugin],
+    });
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain('NULL_MAP_MARKER');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('invalid transform map은 plugin_error diagnostic으로 실패', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-plugin-map-invalid-'));
+    writeFileSync(join(dir, 'entry.ts'), 'const INVALID_MAP_MARKER = 1;\n');
+
+    const plugin: ZntcPlugin = {
+      name: 'invalid-map',
+      setup(build) {
+        build.onTransform({ filter: /entry\.ts$/ }, (args) => ({
+          code: args.code,
+          map: '{ invalid sourcemap json',
+        }));
+      },
+    };
+
+    const result = await build({
+      entryPoints: [join(dir, 'entry.ts')],
+      sourcemap: true,
+      plugins: [plugin],
+    });
+    expectPluginDiagnostic(result, {
+      plugin: 'invalid-map',
+      hook: 'transform',
+      message: 'Invalid sourcemap',
+      fileIncludes: 'entry.ts',
+    });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('index map sections 입력의 section offset을 반영', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-plugin-map-sections-'));
+    const source = 'const SECTION_MAP_MARKER = 1;\nconsole.log(SECTION_MAP_MARKER);\n';
+    writeFileSync(join(dir, 'entry.ts'), source);
+
+    const plugin: ZntcPlugin = {
+      name: 'sections-map',
+      setup(build) {
+        build.onTransform({ filter: /entry\.ts$/ }, (args) => ({
+          code: 'const __sectionHeader = 0;\n' + args.code,
+          map: {
+            version: 3,
+            sections: [
+              {
+                offset: { line: 1, column: 0 },
+                map: {
+                  version: 3,
+                  sources: ['entry.ts'],
+                  sourcesContent: [source],
+                  mappings: lineOffsetMappings(0, 0, source.split('\n').length - 1),
+                },
+              },
+            ],
+          },
+        }));
+      },
+    };
+
+    const result = await build({
+      entryPoints: [join(dir, 'entry.ts')],
+      sourcemap: true,
+      plugins: [plugin],
+    });
+    expect(result.errors.length).toBe(0);
+    expectMarkerMappedToSourceLine(result, 'SECTION_MAP_MARKER', 'entry.ts', 0);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('plugin transform map은 eager/lazy sourcemap JSON에서 동일하게 반영', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-plugin-map-lazy-'));
+    const source = 'const LAZY_MAP_MARKER = 1;\nconsole.log(LAZY_MAP_MARKER);\n';
+    writeFileSync(join(dir, 'entry.ts'), source);
+
+    const plugin: ZntcPlugin = {
+      name: 'lazy-map',
+      setup(build) {
+        build.onTransform({ filter: /entry\.ts$/ }, (args) => ({
+          code: 'const __lazyHeader = 0;\n' + args.code,
+          map: {
+            version: 3,
+            sources: ['entry.ts'],
+            sourcesContent: [source],
+            mappings: lineOffsetMappings(1, 0, source.split('\n').length - 1),
+          },
+        }));
+      },
+    };
+
+    const eager = await build({
+      entryPoints: [join(dir, 'entry.ts')],
+      outfile: join(dir, 'bundle.js'),
+      sourcemap: true,
+      devMode: true,
+      plugins: [plugin],
+    });
+    expect(eager.errors.length).toBe(0);
+    const eagerMap = parseBundleMap(eager).map;
+    expectMarkerMappedToSourceLine(eager, 'LAZY_MAP_MARKER', 'entry.ts', 0);
+
+    const { promise: readyP, resolve: readyDone } = Promise.withResolvers<void>();
+    const handle = watch({
+      entryPoints: [join(dir, 'entry.ts')],
+      outfile: join(dir, 'bundle.js'),
+      sourcemap: true,
+      devMode: true,
+      emitDiskSourcemap: false,
+      plugins: [plugin],
+      onReady() {
+        readyDone();
+      },
+    });
+    await readyP;
+    const lazyMap = JSON.parse(handle.getBundleSourceMap()!);
+    expect(lazyMap.sources).toEqual(eagerMap.sources);
+    expect(lazyMap.mappings).toEqual(eagerMap.mappings);
+    expectMarkerMappedToSourceLine(
+      {
+        outputFiles: [
+          { path: join(dir, 'bundle.js'), text: readFileSync(join(dir, 'bundle.js'), 'utf-8') },
+          { path: join(dir, 'bundle.js.map'), text: JSON.stringify(lazyMap) },
+        ],
+      },
+      'LAZY_MAP_MARKER',
+      'entry.ts',
+      0,
+    );
+    handle.stop();
+    rmSync(dir, { recursive: true, force: true });
+  }, 10000);
 });
 
 // ─── 옵션 조합 심화 테스트 ───

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1270,18 +1270,11 @@ function serializePluginSourceMap(map: unknown): string | null {
   if (typeof map !== 'object') {
     throw new Error(`Invalid sourcemap: expected object, string, null, or undefined`);
   }
-  let json: string;
   try {
-    json = JSON.stringify(map);
+    return JSON.stringify(map);
   } catch (err) {
     throw new Error(`Invalid sourcemap: ${err instanceof Error ? err.message : String(err)}`);
   }
-  try {
-    JSON.parse(json);
-  } catch (err) {
-    throw new Error(`Invalid sourcemap: ${err instanceof Error ? err.message : String(err)}`);
-  }
-  return json;
 }
 
 async function runFireAndForget<T>(

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1030,11 +1030,11 @@ export interface PluginBuild {
     options: { filter: RegExp },
     callback: (args: {
       path: string;
-    }) => HookResult<{ contents: string | Uint8Array; loader?: string }>,
+    }) => HookResult<{ contents: string | Uint8Array; loader?: string; map?: unknown }>,
   ): void;
   onTransform(
     options: { filter: RegExp },
-    callback: (args: { code: string; path: string }) => HookResult<{ code: string }>,
+    callback: (args: { code: string; path: string }) => HookResult<{ code: string; map?: unknown }>,
   ): void;
   onRenderChunk(
     options: { filter: RegExp },
@@ -1257,6 +1257,33 @@ function pluginFailureToDiagnostic(failure: PluginFailureResult): Diagnostic {
   };
 }
 
+function serializePluginSourceMap(map: unknown): string | null {
+  if (map == null) return null;
+  if (typeof map === 'string') {
+    try {
+      JSON.parse(map);
+    } catch (err) {
+      throw new Error(`Invalid sourcemap: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    return map;
+  }
+  if (typeof map !== 'object') {
+    throw new Error(`Invalid sourcemap: expected object, string, null, or undefined`);
+  }
+  let json: string;
+  try {
+    json = JSON.stringify(map);
+  } catch (err) {
+    throw new Error(`Invalid sourcemap: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  try {
+    JSON.parse(json);
+  } catch (err) {
+    throw new Error(`Invalid sourcemap: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  return json;
+}
+
 async function runFireAndForget<T>(
   callbacks: Array<{ pluginName: string; callback: (arg: T) => void | Promise<void> }>,
   hookName: string,
@@ -1439,6 +1466,7 @@ function createPluginDispatcher(plugins: ZntcPlugin[]) {
     if (hookName === 'transform' || hookName === 'renderChunk') {
       let currentCode = arg1 as string;
       let changed = false;
+      const sourceMaps: string[] = [];
       for (const h of hookList) {
         if (h.filter.test(arg2 ?? '')) {
           try {
@@ -1453,13 +1481,19 @@ function createPluginDispatcher(plugins: ZntcPlugin[]) {
                 currentCode = newCode;
                 changed = true;
               }
+              if (hookName === 'transform' && typeof result === 'object' && 'map' in result) {
+                const map = serializePluginSourceMap(result.map);
+                if (map != null) sourceMaps.push(map);
+              }
             }
           } catch (err) {
             return normalizePluginFailure(h.pluginName, hookName, err, arg2);
           }
         }
       }
-      return changed ? { code: currentCode } : null;
+      return changed
+        ? { code: currentCode, ...(sourceMaps.length > 0 ? { maps: sourceMaps } : {}) }
+        : null;
     }
 
     // resolveId/load: 첫 번째 매칭 반환 (first 모드)
@@ -1470,7 +1504,13 @@ function createPluginDispatcher(plugins: ZntcPlugin[]) {
       if (h.filter.test(filterTarget)) {
         try {
           const result = await h.callback(cbArgs);
-          if (result != null) return result;
+          if (result != null) {
+            if (hookName === 'load' && typeof result === 'object' && 'map' in result) {
+              const map = serializePluginSourceMap(result.map);
+              return { ...result, ...(map != null ? { map } : { map: undefined }) };
+            }
+            return result;
+          }
         } catch (err) {
           const fallbackFile = hookName === 'resolveId' ? arg2 : filterTarget;
           return normalizePluginFailure(h.pluginName, hookName, err, fallbackFile);
@@ -2098,7 +2138,7 @@ export function vitePlugin(rollupPlugin: RollupPlugin): ZntcPlugin {
           if (result == null) return null;
           if (typeof result === 'string') return { contents: result };
           if (typeof result === 'object' && 'code' in result) {
-            return { contents: result.code };
+            return { contents: result.code, map: result.map };
           }
           return null;
         });
@@ -2111,7 +2151,7 @@ export function vitePlugin(rollupPlugin: RollupPlugin): ZntcPlugin {
           if (result == null) return null;
           if (typeof result === 'string') return { code: result };
           if (typeof result === 'object' && 'code' in result) {
-            return { code: result.code };
+            return { code: result.code, map: result.map };
           }
           return null;
         });

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1284,7 +1284,7 @@ const NapiPlugin = struct {
         loader_override: ?bundler_mod.types.Loader = null,
         loader_module_type: ?bundler_mod.types.ModuleType = null,
         /// onLoad/onTransform callback 의 source map JSON chain. JS dispatcher 가 object map 을
-        /// JSON string 으로 정규화해서 전달한다 (#1902 PR 2).
+        /// JSON string 으로 정규화해서 전달한다 (#1902).
         source_maps: ?[]const []const u8 = null,
         is_failure: bool = false,
         failure_plugin_name: ?[]const u8 = null,
@@ -1377,30 +1377,39 @@ const NapiPlugin = struct {
         return resp;
     }
 
-    fn freeFailureFields(resp: PluginResponse) void {
+    /// `parseJsResult` 가 native_alloc 으로 dupe 한 모든 conditional field 를 일괄 해제.
+    /// hook 별로 채워지는 field 가 다르지만 미사용 field 는 null 이라 free 가 no-op.
+    /// 개별 hook 에서 필드별 defer 를 늘어놓을 때 빠뜨리기 쉬운 leak 를 한 곳에서 막는다.
+    fn freeResponseFields(resp: PluginResponse) void {
+        if (resp.resolved_path) |s| native_alloc.free(s);
+        if (resp.code) |s| native_alloc.free(s);
+        if (resp.strip_directive) |s| native_alloc.free(s);
+        if (resp.trailing_code) |tc| {
+            for (tc) |s| native_alloc.free(s);
+            native_alloc.free(tc);
+        }
+        if (resp.context_matches) |m| {
+            for (m) |s| native_alloc.free(s);
+            native_alloc.free(m);
+        }
+        if (resp.source_maps) |maps| {
+            for (maps) |m| native_alloc.free(m);
+            native_alloc.free(maps);
+        }
         if (resp.failure_plugin_name) |s| native_alloc.free(s);
         if (resp.failure_hook_name) |s| native_alloc.free(s);
         if (resp.failure_message) |s| native_alloc.free(s);
         if (resp.failure_file) |s| native_alloc.free(s);
     }
 
-    fn freeSourceMaps(resp: PluginResponse) void {
-        if (resp.source_maps) |maps| {
-            for (maps) |m| native_alloc.free(m);
-            native_alloc.free(maps);
-        }
-    }
-
     fn setResponseSourceMaps(resp: PluginResponse, alloc: std.mem.Allocator) PluginError!void {
         const maps = resp.source_maps orelse return;
         if (maps.len == 0) return;
+        // alloc 은 caller 의 parse_arena — 개별 free 불가 (CLAUDE.md memory ownership).
+        // 부분 실패 시 arena.deinit() 이 일괄 해제하므로 errdefer 없이 OOM 만 전달한다.
         const copied = alloc.alloc([]const u8, maps.len) catch return error.OutOfMemory;
-        errdefer alloc.free(copied);
-        var filled: usize = 0;
-        errdefer for (copied[0..filled]) |m| alloc.free(m);
         for (maps, 0..) |map_json, i| {
             copied[i] = alloc.dupe(u8, map_json) catch return error.OutOfMemory;
-            filled = i + 1;
         }
         plugin_mod.setLastTransformSourceMaps(copied);
     }
@@ -1575,17 +1584,11 @@ const NapiPlugin = struct {
     /// code를 반환하는 훅 공통 구현 (transform, renderChunk, load)
     fn callCodeHook(self: *NapiPlugin, hook: HookType, arg1: []const u8, arg2: ?[]const u8, alloc: std.mem.Allocator) PluginError!?[]const u8 {
         const resp = self.callHook(hook, arg1, arg2) orelse return null;
-        defer {
-            if (resp.resolved_path) |p| native_alloc.free(p);
-            freeSourceMaps(resp);
-            freeFailureFields(resp);
-        }
+        defer freeResponseFields(resp);
         if (resp.is_failure) return self.failWithResponse(resp, alloc);
         if (resp.code) |result_code| {
             const result = alloc.dupe(u8, result_code) catch return error.OutOfMemory;
-            errdefer alloc.free(result);
             try setResponseSourceMaps(resp, alloc);
-            native_alloc.free(result_code);
             return result;
         }
         return null;
@@ -1594,12 +1597,7 @@ const NapiPlugin = struct {
     fn pluginResolveId(ctx: ?*anyopaque, specifier: []const u8, importer: ?[]const u8, alloc: std.mem.Allocator) PluginError!?plugin_mod.ResolvedModule {
         const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
         const resp = self.callHook(.resolveId, specifier, importer) orelse return null;
-        defer {
-            if (resp.resolved_path) |p| native_alloc.free(p);
-            if (resp.code) |co| native_alloc.free(co);
-            freeSourceMaps(resp);
-            freeFailureFields(resp);
-        }
+        defer freeResponseFields(resp);
         if (resp.is_failure) return self.failWithResponse(resp, alloc);
 
         // disabled: 빈 모듈로 처리. path는 식별용 — resolved_path 또는 specifier 그대로.
@@ -1624,20 +1622,11 @@ const NapiPlugin = struct {
     fn pluginLoad(ctx: ?*anyopaque, path: []const u8, alloc: std.mem.Allocator) PluginError!?plugin_mod.LoadResult {
         const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
         const resp = self.callHook(.load, path, null) orelse return null;
-        defer {
-            if (resp.resolved_path) |p| native_alloc.free(p);
-            freeSourceMaps(resp);
-            freeFailureFields(resp);
-        }
+        defer freeResponseFields(resp);
         if (resp.is_failure) return self.failWithResponse(resp, alloc);
         const result_code = resp.code orelse return null;
-        const contents = alloc.dupe(u8, result_code) catch {
-            native_alloc.free(result_code);
-            return error.OutOfMemory;
-        };
-        errdefer alloc.free(contents);
+        const contents = alloc.dupe(u8, result_code) catch return error.OutOfMemory;
         try setResponseSourceMaps(resp, alloc);
-        native_alloc.free(result_code);
         return .{ .contents = contents, .loader = resp.loader_override, .module_type = resp.loader_module_type };
     }
 
@@ -1654,18 +1643,14 @@ const NapiPlugin = struct {
     fn pluginGenerateBundle(ctx: ?*anyopaque, output_files: []const bundler_mod.emitter.OutputFile) void {
         const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
         if (self.callHookFull(.generateBundle, "", null, output_files)) |resp| {
-            freeSourceMaps(resp);
-            freeFailureFields(resp);
+            freeResponseFields(resp);
         }
     }
 
     fn pluginBuildStart(ctx: ?*anyopaque) PluginError!void {
         const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
         const resp = self.callHook(.buildStart, "", null) orelse return;
-        defer {
-            freeSourceMaps(resp);
-            freeFailureFields(resp);
-        }
+        defer freeResponseFields(resp);
         if (resp.is_failure) return error.PluginFailed;
     }
 
@@ -1676,20 +1661,14 @@ const NapiPlugin = struct {
         // 객체 (`{ code, message, file, line }`) 직렬화 검토 (#2156 follow-up).
         const msg = if (build_error) |d| d.message else "";
         const resp = self.callHook(.buildEnd, msg, null) orelse return;
-        defer {
-            freeSourceMaps(resp);
-            freeFailureFields(resp);
-        }
+        defer freeResponseFields(resp);
         if (resp.is_failure) return error.PluginFailed;
     }
 
     fn pluginCloseBundle(ctx: ?*anyopaque) PluginError!void {
         const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
         const resp = self.callHook(.closeBundle, "", null) orelse return;
-        defer {
-            freeSourceMaps(resp);
-            freeFailureFields(resp);
-        }
+        defer freeResponseFields(resp);
         if (resp.is_failure) return error.PluginFailed;
     }
 
@@ -1748,16 +1727,8 @@ const NapiPlugin = struct {
         json_buf.append(native_alloc, '}') catch return null;
 
         const resp = self.callHookFull(.resolveContext, json_buf.items, null, null) orelse return null;
-        defer {
-            if (resp.context_matches) |m| native_alloc.free(m);
-            freeSourceMaps(resp);
-            freeFailureFields(resp);
-        }
+        defer freeResponseFields(resp);
         if (resp.is_failure) return self.failWithResponse(resp, alloc);
-        // inner string 들도 native_alloc 소유 (parseStringArray 가 dupe 함). 함께 free.
-        defer if (resp.context_matches) |m| {
-            for (m) |s| native_alloc.free(s);
-        };
 
         const matches = resp.context_matches orelse return null;
 
@@ -1810,17 +1781,7 @@ const NapiPlugin = struct {
 
         // JS 호출
         const resp = self.callHook(.astFunction, json, null) orelse return;
-        defer {
-            if (resp.strip_directive) |sd| native_alloc.free(sd);
-            if (resp.trailing_code) |tc| {
-                for (tc) |s| native_alloc.free(s);
-                native_alloc.free(tc);
-            }
-            if (resp.resolved_path) |p| native_alloc.free(p);
-            if (resp.code) |co| native_alloc.free(co);
-            freeSourceMaps(resp);
-            freeFailureFields(resp);
-        }
+        defer freeResponseFields(resp);
         if (resp.is_failure) return error.PluginFailed;
 
         if (resp.strip_directive != null) {

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1283,6 +1283,9 @@ const NapiPlugin = struct {
         /// ParsedLoader.fromString 으로 변환된 결과. null = override 안 함.
         loader_override: ?bundler_mod.types.Loader = null,
         loader_module_type: ?bundler_mod.types.ModuleType = null,
+        /// onLoad/onTransform callback 의 source map JSON chain. JS dispatcher 가 object map 을
+        /// JSON string 으로 정규화해서 전달한다 (#1902 PR 2).
+        source_maps: ?[]const []const u8 = null,
         is_failure: bool = false,
         failure_plugin_name: ?[]const u8 = null,
         failure_hook_name: ?[]const u8 = null,
@@ -1339,6 +1342,16 @@ const NapiPlugin = struct {
                 resp.code = code;
             }
         }
+        if (getObjectString(env, js_result, "map", native_alloc)) |map_json| {
+            const maps = native_alloc.alloc([]const u8, 1) catch {
+                native_alloc.free(map_json);
+                return resp;
+            };
+            maps[0] = map_json;
+            resp.source_maps = maps;
+        } else if (getNamedProperty(env, js_result, "maps")) |maps_val| {
+            resp.source_maps = parseStringArray(env, maps_val, native_alloc);
+        }
         // AST plugin 응답 파싱
         if (getObjectString(env, js_result, "stripDirective", native_alloc)) |sd| {
             resp.strip_directive = sd;
@@ -1369,6 +1382,27 @@ const NapiPlugin = struct {
         if (resp.failure_hook_name) |s| native_alloc.free(s);
         if (resp.failure_message) |s| native_alloc.free(s);
         if (resp.failure_file) |s| native_alloc.free(s);
+    }
+
+    fn freeSourceMaps(resp: PluginResponse) void {
+        if (resp.source_maps) |maps| {
+            for (maps) |m| native_alloc.free(m);
+            native_alloc.free(maps);
+        }
+    }
+
+    fn setResponseSourceMaps(resp: PluginResponse, alloc: std.mem.Allocator) PluginError!void {
+        const maps = resp.source_maps orelse return;
+        if (maps.len == 0) return;
+        const copied = alloc.alloc([]const u8, maps.len) catch return error.OutOfMemory;
+        errdefer alloc.free(copied);
+        var filled: usize = 0;
+        errdefer for (copied[0..filled]) |m| alloc.free(m);
+        for (maps, 0..) |map_json, i| {
+            copied[i] = alloc.dupe(u8, map_json) catch return error.OutOfMemory;
+            filled = i + 1;
+        }
+        plugin_mod.setLastTransformSourceMaps(copied);
     }
 
     fn failWithResponse(self: *NapiPlugin, resp: PluginResponse, alloc: std.mem.Allocator) PluginError {
@@ -1543,11 +1577,14 @@ const NapiPlugin = struct {
         const resp = self.callHook(hook, arg1, arg2) orelse return null;
         defer {
             if (resp.resolved_path) |p| native_alloc.free(p);
+            freeSourceMaps(resp);
             freeFailureFields(resp);
         }
         if (resp.is_failure) return self.failWithResponse(resp, alloc);
         if (resp.code) |result_code| {
             const result = alloc.dupe(u8, result_code) catch return error.OutOfMemory;
+            errdefer alloc.free(result);
+            try setResponseSourceMaps(resp, alloc);
             native_alloc.free(result_code);
             return result;
         }
@@ -1560,6 +1597,7 @@ const NapiPlugin = struct {
         defer {
             if (resp.resolved_path) |p| native_alloc.free(p);
             if (resp.code) |co| native_alloc.free(co);
+            freeSourceMaps(resp);
             freeFailureFields(resp);
         }
         if (resp.is_failure) return self.failWithResponse(resp, alloc);
@@ -1588,6 +1626,7 @@ const NapiPlugin = struct {
         const resp = self.callHook(.load, path, null) orelse return null;
         defer {
             if (resp.resolved_path) |p| native_alloc.free(p);
+            freeSourceMaps(resp);
             freeFailureFields(resp);
         }
         if (resp.is_failure) return self.failWithResponse(resp, alloc);
@@ -1596,6 +1635,8 @@ const NapiPlugin = struct {
             native_alloc.free(result_code);
             return error.OutOfMemory;
         };
+        errdefer alloc.free(contents);
+        try setResponseSourceMaps(resp, alloc);
         native_alloc.free(result_code);
         return .{ .contents = contents, .loader = resp.loader_override, .module_type = resp.loader_module_type };
     }
@@ -1612,13 +1653,19 @@ const NapiPlugin = struct {
 
     fn pluginGenerateBundle(ctx: ?*anyopaque, output_files: []const bundler_mod.emitter.OutputFile) void {
         const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
-        _ = self.callHookFull(.generateBundle, "", null, output_files);
+        if (self.callHookFull(.generateBundle, "", null, output_files)) |resp| {
+            freeSourceMaps(resp);
+            freeFailureFields(resp);
+        }
     }
 
     fn pluginBuildStart(ctx: ?*anyopaque) PluginError!void {
         const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
         const resp = self.callHook(.buildStart, "", null) orelse return;
-        defer freeFailureFields(resp);
+        defer {
+            freeSourceMaps(resp);
+            freeFailureFields(resp);
+        }
         if (resp.is_failure) return error.PluginFailed;
     }
 
@@ -1629,14 +1676,20 @@ const NapiPlugin = struct {
         // 객체 (`{ code, message, file, line }`) 직렬화 검토 (#2156 follow-up).
         const msg = if (build_error) |d| d.message else "";
         const resp = self.callHook(.buildEnd, msg, null) orelse return;
-        defer freeFailureFields(resp);
+        defer {
+            freeSourceMaps(resp);
+            freeFailureFields(resp);
+        }
         if (resp.is_failure) return error.PluginFailed;
     }
 
     fn pluginCloseBundle(ctx: ?*anyopaque) PluginError!void {
         const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
         const resp = self.callHook(.closeBundle, "", null) orelse return;
-        defer freeFailureFields(resp);
+        defer {
+            freeSourceMaps(resp);
+            freeFailureFields(resp);
+        }
         if (resp.is_failure) return error.PluginFailed;
     }
 
@@ -1697,6 +1750,7 @@ const NapiPlugin = struct {
         const resp = self.callHookFull(.resolveContext, json_buf.items, null, null) orelse return null;
         defer {
             if (resp.context_matches) |m| native_alloc.free(m);
+            freeSourceMaps(resp);
             freeFailureFields(resp);
         }
         if (resp.is_failure) return self.failWithResponse(resp, alloc);
@@ -1764,6 +1818,7 @@ const NapiPlugin = struct {
             }
             if (resp.resolved_path) |p| native_alloc.free(p);
             if (resp.code) |co| native_alloc.free(co);
+            freeSourceMaps(resp);
             freeFailureFields(resp);
         }
         if (resp.is_failure) return error.PluginFailed;

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -763,6 +763,7 @@ pub fn emitWithTreeShaking(
                     region_lines,
                     @intCast(std.mem.count(u8, code, "\n")),
                     endregion_lines,
+                    m.plugin_source_maps,
                 );
                 // function map: source 추가 순서와 동기화
                 if (options.sourcemap.function_map) {
@@ -850,6 +851,7 @@ pub fn emitWithTreeShaking(
                         0, // HMR preamble path 는 region marker 없음
                         @intCast(std.mem.count(u8, code, "\n")),
                         0, // endregion 도 없음
+                        m.plugin_source_maps,
                     );
                     if (options.sourcemap.lazy) {
                         module_sm_builder = try mod_sm.moveToHeap(allocator);

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -419,6 +419,7 @@ pub fn emitChunks(
                     region_lines,
                     stripped_lines,
                     endregion_lines,
+                    m.plugin_source_maps,
                 );
             };
 

--- a/src/bundler/emitter/dev.zig
+++ b/src/bundler/emitter/dev.zig
@@ -5,6 +5,7 @@
 const std = @import("std");
 const Module = @import("../module.zig").Module;
 const SourceMap = @import("../../codegen/sourcemap.zig");
+const source_map_trace = @import("../../codegen/source_map_trace.zig");
 
 /// 모듈의 소스맵 매핑을 번들 레벨 SourceMapBuilder에 추가한다.
 /// sourcesContent 등록 + preamble/wrapper 오프셋 반영 + module 영역 안의
@@ -47,12 +48,31 @@ pub fn addModuleMappings(
     total_code_lines: u32,
     /// module wrapper 후 boilerplate line 수 (e.g. //#endregion, default 0)
     post_lines: u32,
+    /// plugin load/transform 이 반환한 Source Map V3 JSON chain. 비어 있으면 identity.
+    plugin_source_maps: []const []const u8,
 ) !void {
+    if (maps.len == 0) return;
+    if (plugin_source_maps.len > 0) {
+        return addTracedModuleMappings(
+            sm,
+            module_id,
+            source,
+            maps,
+            base_line,
+            preamble_lines,
+            sources_content,
+            indent_offset,
+            pre_lines,
+            total_code_lines,
+            post_lines,
+            plugin_source_maps,
+        );
+    }
+
     const source_idx = try sm.addSource(module_id);
     if (sources_content and source.len > 0) {
         try sm.addSourceContent(source);
     }
-    if (maps.len == 0) return;
 
     // maps 가 generated_line 순 정렬 가정 — codegen / esm_wrap merge 가 보장.
     // 첫/마지막 mapping 의 original_line 으로 boilerplate 영역 (region marker,
@@ -137,6 +157,178 @@ pub fn addModuleMappings(
     }
 }
 
+const ResolvedTrace = struct {
+    source_name: []const u8,
+    source_content: ?[]const u8,
+    original_line: u32,
+    original_column: u32,
+};
+
+fn resolveTrace(
+    parsed_maps: []const source_map_trace.ParsedMap,
+    module_id: []const u8,
+    fallback_source: []const u8,
+    mapping: SourceMap.Mapping,
+) ResolvedTrace {
+    if (source_map_trace.trace(parsed_maps, mapping.original_line, mapping.original_column)) |hit| {
+        return .{
+            .source_name = hit.source,
+            .source_content = hit.source_content,
+            .original_line = hit.line,
+            .original_column = hit.column,
+        };
+    }
+    return .{
+        .source_name = module_id,
+        .source_content = fallback_source,
+        .original_line = mapping.original_line,
+        .original_column = mapping.original_column,
+    };
+}
+
+fn ensureTraceSource(
+    sm: *SourceMap.SourceMapBuilder,
+    cache: *std.StringHashMap(u32),
+    source_name: []const u8,
+    source_content: ?[]const u8,
+    include_content: bool,
+) !u32 {
+    if (cache.get(source_name)) |idx| return idx;
+    const idx = try sm.addSource(source_name);
+    if (include_content) {
+        try sm.addSourceContent(source_content orelse "");
+    }
+    try cache.put(source_name, idx);
+    return idx;
+}
+
+fn addTracedModuleMappings(
+    sm: *SourceMap.SourceMapBuilder,
+    module_id: []const u8,
+    source: []const u8,
+    maps: []const SourceMap.Mapping,
+    base_line: u32,
+    preamble_lines: u32,
+    sources_content: bool,
+    indent_offset: bool,
+    pre_lines: u32,
+    total_code_lines: u32,
+    post_lines: u32,
+    plugin_source_maps: []const []const u8,
+) !void {
+    var parsed_maps: std.ArrayList(source_map_trace.ParsedMap) = .empty;
+    defer {
+        for (parsed_maps.items) |*parsed| parsed.deinit();
+        parsed_maps.deinit(sm.allocator);
+    }
+    for (plugin_source_maps) |source_map_json| {
+        try parsed_maps.append(sm.allocator, try source_map_trace.parse(sm.allocator, source_map_json));
+    }
+
+    var source_cache = std.StringHashMap(u32).init(sm.allocator);
+    defer source_cache.deinit();
+
+    const first_trace = resolveTrace(parsed_maps.items, module_id, source, maps[0]);
+    const first_source_idx = try ensureTraceSource(
+        sm,
+        &source_cache,
+        first_trace.source_name,
+        first_trace.source_content,
+        sources_content,
+    );
+
+    var i: u32 = 0;
+    while (i < pre_lines) : (i += 1) {
+        try sm.addMapping(.{
+            .generated_line = base_line + i,
+            .generated_column = 0,
+            .source_index = first_source_idx,
+            .original_line = first_trace.original_line,
+            .original_column = 0,
+        });
+    }
+
+    var prev_source_idx: u32 = first_source_idx;
+    var prev_orig: u32 = first_trace.original_line;
+    var last_source_idx: u32 = first_source_idx;
+    var last_orig: u32 = first_trace.original_line;
+    var maps_idx: usize = 0;
+    var line: u32 = 0;
+    while (line < total_code_lines) : (line += 1) {
+        var line_had_mapping = false;
+        while (maps_idx < maps.len and maps[maps_idx].generated_line == line) : (maps_idx += 1) {
+            const m = maps[maps_idx];
+            const traced = resolveTrace(parsed_maps.items, module_id, source, m);
+            const traced_source_idx = try ensureTraceSource(
+                sm,
+                &source_cache,
+                traced.source_name,
+                traced.source_content,
+                sources_content,
+            );
+            try sm.addMapping(.{
+                .generated_line = base_line + pre_lines + preamble_lines + m.generated_line,
+                .generated_column = if (indent_offset and m.generated_line != 0)
+                    m.generated_column + 1
+                else
+                    m.generated_column,
+                .source_index = traced_source_idx,
+                .original_line = traced.original_line,
+                .original_column = traced.original_column,
+            });
+            prev_source_idx = traced_source_idx;
+            prev_orig = traced.original_line;
+            last_source_idx = traced_source_idx;
+            last_orig = traced.original_line;
+            line_had_mapping = true;
+        }
+        if (!line_had_mapping) {
+            try sm.addMapping(.{
+                .generated_line = base_line + pre_lines + preamble_lines + line,
+                .generated_column = 0,
+                .source_index = prev_source_idx,
+                .original_line = prev_orig,
+                .original_column = 0,
+            });
+        }
+    }
+
+    while (maps_idx < maps.len) : (maps_idx += 1) {
+        const m = maps[maps_idx];
+        const traced = resolveTrace(parsed_maps.items, module_id, source, m);
+        const traced_source_idx = try ensureTraceSource(
+            sm,
+            &source_cache,
+            traced.source_name,
+            traced.source_content,
+            sources_content,
+        );
+        try sm.addMapping(.{
+            .generated_line = base_line + pre_lines + preamble_lines + m.generated_line,
+            .generated_column = if (indent_offset and m.generated_line != 0)
+                m.generated_column + 1
+            else
+                m.generated_column,
+            .source_index = traced_source_idx,
+            .original_line = traced.original_line,
+            .original_column = traced.original_column,
+        });
+        last_source_idx = traced_source_idx;
+        last_orig = traced.original_line;
+    }
+
+    i = 0;
+    while (i < post_lines) : (i += 1) {
+        try sm.addMapping(.{
+            .generated_line = base_line + pre_lines + preamble_lines + total_code_lines + i,
+            .generated_column = 0,
+            .source_index = last_source_idx,
+            .original_line = last_orig,
+            .original_column = 0,
+        });
+    }
+}
+
 /// 모듈 경로를 dev bundle용 ID로 변환.
 /// root_dir이 있으면 상대 경로, 없으면 절대 경로 그대로 사용.
 pub fn makeModuleId(path: []const u8, root_dir: ?[]const u8) []const u8 {
@@ -190,6 +382,7 @@ test "addModuleMappings: codegen body 의 내부 빈 줄 (gap) 도 직전 orig �
         0, // pre_lines
         6, // total_code_lines
         0, // post_lines
+        &.{},
     );
 
     // generated_line 100~105 (base + 0~5) 모두 mapping 존재해야 함.
@@ -228,6 +421,7 @@ test "addModuleMappings: 첫 매핑 이전의 wrap header 줄들도 first_orig �
         0,
         4, // total_code_lines (wrap header 2 + body 2)
         0,
+        &.{},
     );
 
     var has_line = std.AutoHashMap(u32, u32).init(testing.allocator);
@@ -262,6 +456,7 @@ test "addModuleMappings: tail (마지막 mapping 이후 wrap closing brace) 영�
         0,
         4, // total_code_lines
         0,
+        &.{},
     );
 
     var has_line = std.AutoHashMap(u32, u32).init(testing.allocator);
@@ -300,6 +495,7 @@ test "addModuleMappings: pre/post (region/endregion marker) + 내부 gap 동시 
         1, // pre_lines (region marker)
         3, // total_code_lines (body)
         1, // post_lines (endregion marker)
+        &.{},
     );
 
     var has_line = std.AutoHashMap(u32, u32).init(testing.allocator);
@@ -335,8 +531,9 @@ test "addModuleMappings: maps 가 비어있으면 아무 mapping 도 추가 안 
         1,
         5,
         1,
+        &.{},
     );
 
-    // source 는 등록되지만 mapping 은 0 개.
+    // empty mapping 입력은 source 등록도 하지 않고 빠져나간다.
     try testing.expectEqual(@as(usize, 0), sm.mappings.items.len);
 }

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -51,6 +51,7 @@ const Span = @import("../lexer/token.zig").Span;
 const pkg_json = @import("package_json.zig");
 const mime = @import("../server/mime.zig");
 const plugin_mod = @import("plugin.zig");
+const source_map_trace = @import("../codegen/source_map_trace.zig");
 const MpscChannel = @import("mpsc_channel.zig").MpscChannel;
 const transformer_mod = @import("../transformer/transformer.zig");
 const Transformer = transformer_mod.Transformer;
@@ -1900,6 +1901,7 @@ pub const ModuleGraph = struct {
                 };
                 if (load_result) |plugin_result| {
                     plugin_load_applied = true;
+                    const load_source_maps = plugin_mod.takeLastTransformSourceMaps() orelse &.{};
                     // 플러그인이 내용을 반환. (#2157) `loader` 가 명시되면 raw bytes 를 그 loader 의
                     // 값 표현식으로 변환 (parseAssetModule 와 동일한 assetSourceFromBytes 헬퍼).
                     // asset 변환 성공 시 parseAssetModule 와 동일하게 ast 없이 종료 → emitter 의
@@ -1908,6 +1910,15 @@ pub const ModuleGraph = struct {
                     // import binding 이 깨진다.
                     module.parse_arena = tmp_arena;
                     const arena_alloc = tmp_arena.allocator();
+                    if (load_source_maps.len > 0) {
+                        if (!self.validatePluginSourceMaps(load_source_maps, module.path, Span.EMPTY, .transform, "load")) {
+                            module_mod.destroyParseArena(self.allocator, tmp_arena);
+                            module.parse_arena = null;
+                            module.state = .ready;
+                            return;
+                        }
+                        module.plugin_source_maps = load_source_maps;
+                    }
                     if (plugin_result.loader) |loader_override| {
                         module.loader = loader_override;
                         module.module_type = plugin_result.module_type orelse
@@ -2106,6 +2117,23 @@ pub const ModuleGraph = struct {
                     },
                 };
                 if (transform_result) |result| {
+                    if (plugin_mod.takeLastTransformSourceMaps()) |maps| {
+                        if (!self.validatePluginSourceMaps(maps, module.path, Span.EMPTY, .transform, "transform")) {
+                            module.state = .ready;
+                            return;
+                        }
+                        if (module.plugin_source_maps.len > 0) {
+                            module.plugin_source_maps = std.mem.concat(arena_alloc, []const u8, &.{
+                                module.plugin_source_maps,
+                                maps,
+                            }) catch {
+                                module.state = .ready;
+                                return;
+                            };
+                        } else {
+                            module.plugin_source_maps = maps;
+                        }
+                    }
                     module.source = result;
                     plugin_transform_applied = true;
                 }
@@ -4020,6 +4048,33 @@ pub const ModuleGraph = struct {
         } else {
             self.addDiag(.plugin_error, .@"error", fallback_file, span, step, "Plugin hook failed", null);
         }
+    }
+
+    fn validatePluginSourceMaps(
+        self: *ModuleGraph,
+        source_maps: []const []const u8,
+        fallback_file: []const u8,
+        span: Span,
+        step: BundlerDiagnostic.Step,
+        hook_name: []const u8,
+    ) bool {
+        for (source_maps) |source_map_json| {
+            var parsed = source_map_trace.parse(self.allocator, source_map_json) catch {
+                const failure = plugin_mod.PluginFailure.init(
+                    self.allocator,
+                    "zntc:source-map",
+                    hook_name,
+                    "Invalid sourcemap returned by plugin",
+                    fallback_file,
+                    0,
+                    0,
+                ) catch null;
+                self.addPluginFailureDiag(failure, fallback_file, span, step);
+                return false;
+            };
+            parsed.deinit();
+        }
+        return true;
     }
 
     fn tryAddPluginFailureDiag(

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -124,6 +124,9 @@ pub const Module = struct {
     dev_id: []const u8 = "",
     /// 소스 코드. parse_arena에서 할당 (Module.arena가 소유).
     source: []const u8,
+    /// JS plugin load/transform 이 반환한 Source Map V3 JSON chain.
+    /// 순서는 transform 실행 순서이며 parse_arena 가 backing 을 소유한다.
+    plugin_source_maps: []const []const u8 = &.{},
     /// 파싱된 AST. nodes/extra_data/string_table 의 backing 은 `parse_arena` 가 소유.
     ///
     /// ### Ownership 규약 (D1 디버그 인프라 — RFC #1672)

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -102,6 +102,7 @@ pub const PluginFailure = struct {
 };
 
 threadlocal var last_plugin_failure: ?PluginFailure = null;
+threadlocal var last_transform_source_maps: ?[]const []const u8 = null;
 
 pub fn setLastPluginFailure(failure: PluginFailure) void {
     if (last_plugin_failure) |old| old.deinit();
@@ -112,6 +113,16 @@ pub fn takeLastPluginFailure() ?PluginFailure {
     const failure = last_plugin_failure;
     last_plugin_failure = null;
     return failure;
+}
+
+pub fn setLastTransformSourceMaps(source_maps: []const []const u8) void {
+    last_transform_source_maps = source_maps;
+}
+
+pub fn takeLastTransformSourceMaps() ?[]const []const u8 {
+    const source_maps = last_transform_source_maps;
+    last_transform_source_maps = null;
+    return source_maps;
 }
 
 /// Plugin resolveId 응답의 통합 모델 (#1885).
@@ -343,6 +354,7 @@ pub const PluginRunner = struct {
         path: []const u8,
         allocator: std.mem.Allocator,
     ) PluginError!?LoadResult {
+        last_transform_source_maps = null;
         for (self.plugins) |p| {
             if (p.load) |hook| {
                 if (try hook(p.context, path, allocator)) |result| {
@@ -362,16 +374,26 @@ pub const PluginRunner = struct {
         id: []const u8,
         allocator: std.mem.Allocator,
     ) PluginError!?[]const u8 {
+        last_transform_source_maps = null;
+        var source_maps: std.ArrayList([]const u8) = .empty;
+        defer source_maps.deinit(allocator);
+
         var current: ?[]const u8 = null;
         for (self.plugins) |p| {
             if (p.transform) |hook| {
                 const input = current orelse code;
                 if (try hook(p.context, input, id, allocator)) |result| {
+                    if (takeLastTransformSourceMaps()) |maps| {
+                        try source_maps.appendSlice(allocator, maps);
+                    }
                     // 이전 체이닝 결과가 있으면 해제 (원본 code는 caller 소유이므로 건드리지 않음)
                     if (current) |prev| allocator.free(prev);
                     current = result;
                 }
             }
+        }
+        if (source_maps.items.len > 0) {
+            setLastTransformSourceMaps(try source_maps.toOwnedSlice(allocator));
         }
         return current;
     }

--- a/src/codegen/source_map_trace.zig
+++ b/src/codegen/source_map_trace.zig
@@ -6,24 +6,15 @@
 //! plugin chain in reverse order before being inserted into the bundle map.
 
 const std = @import("std");
+const sourcemap = @import("sourcemap.zig");
 
 pub const ParseError = error{
     InvalidSourceMap,
     OutOfMemory,
 };
 
-pub const TraceMapping = struct {
-    generated_line: u32,
-    generated_column: u32,
-    source_index: u32,
-    original_line: u32,
-    original_column: u32,
-
-    fn lessThan(_: void, a: TraceMapping, b: TraceMapping) bool {
-        if (a.generated_line != b.generated_line) return a.generated_line < b.generated_line;
-        return a.generated_column < b.generated_column;
-    }
-};
+/// 빌드된 sourcemap 의 단일 segment — codegen `SourceMap.Mapping` 과 layout 동일.
+pub const TraceMapping = sourcemap.Mapping;
 
 pub const TraceResult = struct {
     source: []const u8,

--- a/src/codegen/source_map_trace.zig
+++ b/src/codegen/source_map_trace.zig
@@ -1,0 +1,412 @@
+//! Source Map V3 decoder and trace helper for plugin transform maps.
+//!
+//! The bundler codegen map points from final emitted module code back to the
+//! post-plugin module source. Plugin maps point from each transform output back
+//! to the previous input, so final output positions are traced through the
+//! plugin chain in reverse order before being inserted into the bundle map.
+
+const std = @import("std");
+
+pub const ParseError = error{
+    InvalidSourceMap,
+    OutOfMemory,
+};
+
+pub const TraceMapping = struct {
+    generated_line: u32,
+    generated_column: u32,
+    source_index: u32,
+    original_line: u32,
+    original_column: u32,
+
+    fn lessThan(_: void, a: TraceMapping, b: TraceMapping) bool {
+        if (a.generated_line != b.generated_line) return a.generated_line < b.generated_line;
+        return a.generated_column < b.generated_column;
+    }
+};
+
+pub const TraceResult = struct {
+    source: []const u8,
+    source_content: ?[]const u8,
+    line: u32,
+    column: u32,
+};
+
+pub const ParsedMap = struct {
+    allocator: std.mem.Allocator,
+    sources: []const []const u8,
+    sources_content: []const ?[]const u8,
+    mappings: []const TraceMapping,
+    line_starts: []const usize,
+
+    pub fn deinit(self: *ParsedMap) void {
+        for (self.sources) |s| self.allocator.free(s);
+        self.allocator.free(self.sources);
+        for (self.sources_content) |maybe_content| {
+            if (maybe_content) |content| self.allocator.free(content);
+        }
+        self.allocator.free(self.sources_content);
+        self.allocator.free(self.mappings);
+        self.allocator.free(self.line_starts);
+    }
+
+    pub fn lookup(self: *const ParsedMap, line: u32, column: u32) ?TraceResult {
+        const line_usize: usize = @intCast(line);
+        if (line_usize + 1 >= self.line_starts.len) return null;
+        const start = self.line_starts[line_usize];
+        const end = self.line_starts[line_usize + 1];
+        var found: ?TraceMapping = null;
+        for (self.mappings[start..end]) |mapping| {
+            if (mapping.generated_column > column) break;
+            found = mapping;
+        }
+        const mapping = found orelse return null;
+        const src_idx: usize = @intCast(mapping.source_index);
+        if (src_idx >= self.sources.len) return null;
+        const content = if (src_idx < self.sources_content.len) self.sources_content[src_idx] else null;
+        return .{
+            .source = self.sources[src_idx],
+            .source_content = content,
+            .line = mapping.original_line,
+            .column = mapping.original_column,
+        };
+    }
+};
+
+const BuildState = struct {
+    allocator: std.mem.Allocator,
+    sources: std.ArrayList([]const u8) = .empty,
+    sources_content: std.ArrayList(?[]const u8) = .empty,
+    mappings: std.ArrayList(TraceMapping) = .empty,
+
+    fn deinit(self: *BuildState) void {
+        for (self.sources.items) |s| self.allocator.free(s);
+        for (self.sources_content.items) |maybe_content| {
+            if (maybe_content) |content| self.allocator.free(content);
+        }
+        self.sources.deinit(self.allocator);
+        self.sources_content.deinit(self.allocator);
+        self.mappings.deinit(self.allocator);
+    }
+
+    fn addSource(
+        self: *BuildState,
+        source_root: []const u8,
+        source: []const u8,
+        content: ?[]const u8,
+    ) ParseError!u32 {
+        const source_name = try joinSourceRoot(self.allocator, source_root, source);
+        errdefer self.allocator.free(source_name);
+        const content_copy = if (content) |c| try self.allocator.dupe(u8, c) else null;
+        errdefer if (content_copy) |c| self.allocator.free(c);
+
+        const idx: u32 = @intCast(self.sources.items.len);
+        try self.sources.append(self.allocator, source_name);
+        try self.sources_content.append(self.allocator, content_copy);
+        return idx;
+    }
+};
+
+pub fn parse(allocator: std.mem.Allocator, json_text: []const u8) ParseError!ParsedMap {
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, json_text, .{}) catch
+        return error.InvalidSourceMap;
+    defer parsed.deinit();
+
+    var state = BuildState{ .allocator = allocator };
+    errdefer state.deinit();
+
+    try parseValueInto(&state, parsed.value, 0, 0);
+    return finishParsedMap(allocator, &state);
+}
+
+pub fn trace(maps: []const ParsedMap, line: u32, column: u32) ?TraceResult {
+    var current_line = line;
+    var current_column = column;
+    var result: ?TraceResult = null;
+    var i = maps.len;
+    while (i > 0) {
+        i -= 1;
+        const next = maps[i].lookup(current_line, current_column) orelse return null;
+        result = next;
+        current_line = next.line;
+        current_column = next.column;
+    }
+    return result;
+}
+
+fn finishParsedMap(allocator: std.mem.Allocator, state: *BuildState) ParseError!ParsedMap {
+    if (state.mappings.items.len > 1) {
+        std.mem.sort(TraceMapping, state.mappings.items, {}, TraceMapping.lessThan);
+    }
+
+    var max_line: u32 = 0;
+    for (state.mappings.items) |mapping| {
+        if (mapping.generated_line > max_line) max_line = mapping.generated_line;
+    }
+
+    const sources = try state.sources.toOwnedSlice(allocator);
+    errdefer freeSources(allocator, sources);
+    const sources_content = try state.sources_content.toOwnedSlice(allocator);
+    errdefer freeSourceContents(allocator, sources_content);
+    const mappings = try state.mappings.toOwnedSlice(allocator);
+    errdefer allocator.free(mappings);
+
+    const line_count: usize = if (mappings.len == 0) 1 else @as(usize, @intCast(max_line)) + 2;
+    const line_starts = try allocator.alloc(usize, line_count);
+    errdefer allocator.free(line_starts);
+    var cursor: usize = 0;
+    var line: usize = 0;
+    while (line + 1 < line_count) : (line += 1) {
+        line_starts[line] = cursor;
+        while (cursor < mappings.len and mappings[cursor].generated_line == line) {
+            cursor += 1;
+        }
+    }
+    line_starts[line_count - 1] = mappings.len;
+
+    return .{
+        .allocator = allocator,
+        .sources = sources,
+        .sources_content = sources_content,
+        .mappings = mappings,
+        .line_starts = line_starts,
+    };
+}
+
+fn freeSources(allocator: std.mem.Allocator, sources: []const []const u8) void {
+    for (sources) |s| allocator.free(s);
+    allocator.free(sources);
+}
+
+fn freeSourceContents(allocator: std.mem.Allocator, sources_content: []const ?[]const u8) void {
+    for (sources_content) |maybe_content| {
+        if (maybe_content) |content| allocator.free(content);
+    }
+    allocator.free(sources_content);
+}
+
+fn parseValueInto(
+    state: *BuildState,
+    value: std.json.Value,
+    base_line: u32,
+    base_column: u32,
+) ParseError!void {
+    const obj = switch (value) {
+        .object => |o| o,
+        else => return error.InvalidSourceMap,
+    };
+    const version_value = obj.get("version") orelse return error.InvalidSourceMap;
+    if (jsonU32(version_value) orelse 0 != 3) return error.InvalidSourceMap;
+
+    if (obj.get("sections")) |sections_value| {
+        const sections = switch (sections_value) {
+            .array => |a| a,
+            else => return error.InvalidSourceMap,
+        };
+        for (sections.items) |section_value| {
+            const section = switch (section_value) {
+                .object => |o| o,
+                else => return error.InvalidSourceMap,
+            };
+            const offset = switch (section.get("offset") orelse return error.InvalidSourceMap) {
+                .object => |o| o,
+                else => return error.InvalidSourceMap,
+            };
+            const section_line = jsonU32(offset.get("line") orelse return error.InvalidSourceMap) orelse
+                return error.InvalidSourceMap;
+            const section_column = jsonU32(offset.get("column") orelse return error.InvalidSourceMap) orelse
+                return error.InvalidSourceMap;
+            const child_map = section.get("map") orelse return error.InvalidSourceMap;
+            const child_base_line = base_line + section_line;
+            const child_base_column = if (section_line == 0)
+                base_column + section_column
+            else
+                section_column;
+            try parseValueInto(state, child_map, child_base_line, child_base_column);
+        }
+        return;
+    }
+
+    const sources_value = obj.get("sources") orelse return error.InvalidSourceMap;
+    const sources = switch (sources_value) {
+        .array => |a| a,
+        else => return error.InvalidSourceMap,
+    };
+    const source_root = if (obj.get("sourceRoot")) |sr| switch (sr) {
+        .string => |s| s,
+        else => "",
+    } else "";
+
+    const sources_content_array = if (obj.get("sourcesContent")) |sc| switch (sc) {
+        .array => |a| a,
+        else => null,
+    } else null;
+
+    const source_base: u32 = @intCast(state.sources.items.len);
+    for (sources.items, 0..) |source_value, i| {
+        const source_name = switch (source_value) {
+            .string => |s| s,
+            else => return error.InvalidSourceMap,
+        };
+        const content: ?[]const u8 = if (sources_content_array) |arr| blk: {
+            if (i >= arr.items.len) break :blk null;
+            break :blk switch (arr.items[i]) {
+                .string => |s| s,
+                .null => null,
+                else => null,
+            };
+        } else null;
+        _ = try state.addSource(source_root, source_name, content);
+    }
+
+    const mappings_value = obj.get("mappings") orelse return error.InvalidSourceMap;
+    const mappings = switch (mappings_value) {
+        .string => |s| s,
+        else => return error.InvalidSourceMap,
+    };
+    try decodeMappingsInto(state, mappings, source_base, @intCast(sources.items.len), base_line, base_column);
+}
+
+fn decodeMappingsInto(
+    state: *BuildState,
+    mappings: []const u8,
+    source_base: u32,
+    source_count: u32,
+    base_line: u32,
+    base_column: u32,
+) ParseError!void {
+    var generated_line: u32 = 0;
+    var previous_source: i32 = 0;
+    var previous_original_line: i32 = 0;
+    var previous_original_column: i32 = 0;
+
+    var line_it = std.mem.splitScalar(u8, mappings, ';');
+    while (line_it.next()) |line_text| : (generated_line += 1) {
+        var previous_generated_column: i32 = 0;
+        var segment_it = std.mem.splitScalar(u8, line_text, ',');
+        while (segment_it.next()) |segment| {
+            if (segment.len == 0) continue;
+            var fields_buf: [5]i32 = undefined;
+            const fields = try decodeVlqSegment(segment, &fields_buf);
+            if (!(fields.len == 1 or fields.len == 4 or fields.len == 5)) {
+                return error.InvalidSourceMap;
+            }
+            previous_generated_column += fields[0];
+            if (previous_generated_column < 0) return error.InvalidSourceMap;
+            if (fields.len == 1) continue;
+
+            previous_source += fields[1];
+            previous_original_line += fields[2];
+            previous_original_column += fields[3];
+            if (previous_source < 0 or
+                previous_original_line < 0 or
+                previous_original_column < 0)
+            {
+                return error.InvalidSourceMap;
+            }
+            const source_index: u32 = @intCast(previous_source);
+            if (source_index >= source_count) return error.InvalidSourceMap;
+
+            try state.mappings.append(state.allocator, .{
+                .generated_line = base_line + generated_line,
+                .generated_column = if (generated_line == 0)
+                    base_column + @as(u32, @intCast(previous_generated_column))
+                else
+                    @intCast(previous_generated_column),
+                .source_index = source_base + source_index,
+                .original_line = @intCast(previous_original_line),
+                .original_column = @intCast(previous_original_column),
+            });
+        }
+    }
+}
+
+fn decodeVlqSegment(segment: []const u8, out: *[5]i32) ParseError![]const i32 {
+    var count: usize = 0;
+    var value: i64 = 0;
+    var shift: u6 = 0;
+    for (segment) |ch| {
+        const digit = decodeBase64(ch) orelse return error.InvalidSourceMap;
+        const continuation = (digit & 32) != 0;
+        if (shift > 30) return error.InvalidSourceMap;
+        value |= @as(i64, @intCast(digit & 31)) << shift;
+        if (!continuation) {
+            if (count >= out.len) return error.InvalidSourceMap;
+            const negative = (value & 1) != 0;
+            const decoded = value >> 1;
+            if (decoded > std.math.maxInt(i32)) return error.InvalidSourceMap;
+            const signed = if (negative) -decoded else decoded;
+            out[count] = @intCast(signed);
+            count += 1;
+            value = 0;
+            shift = 0;
+        } else {
+            if (shift == 30) return error.InvalidSourceMap;
+            shift += 5;
+        }
+    }
+    if (shift != 0 or count == 0) return error.InvalidSourceMap;
+    return out[0..count];
+}
+
+fn decodeBase64(ch: u8) ?u6 {
+    return switch (ch) {
+        'A'...'Z' => @intCast(ch - 'A'),
+        'a'...'z' => @intCast(ch - 'a' + 26),
+        '0'...'9' => @intCast(ch - '0' + 52),
+        '+' => 62,
+        '/' => 63,
+        else => null,
+    };
+}
+
+fn jsonU32(value: std.json.Value) ?u32 {
+    return switch (value) {
+        .integer => |i| if (i >= 0 and i <= std.math.maxInt(u32)) @intCast(i) else null,
+        .float => |f| if (f >= 0 and f <= @as(f64, @floatFromInt(std.math.maxInt(u32))) and @floor(f) == f)
+            @intFromFloat(f)
+        else
+            null,
+        else => null,
+    };
+}
+
+fn joinSourceRoot(allocator: std.mem.Allocator, source_root: []const u8, source: []const u8) ParseError![]const u8 {
+    if (source_root.len == 0) return allocator.dupe(u8, source);
+    if (source.len == 0) return allocator.dupe(u8, source_root);
+    if (source[0] == '/' or std.mem.endsWith(u8, source_root, "/")) {
+        return std.mem.concat(allocator, u8, &.{ source_root, source });
+    }
+    return std.mem.concat(allocator, u8, &.{ source_root, "/", source });
+}
+
+test "source map trace: simple mapping lookup" {
+    var map = try parse(
+        std.testing.allocator,
+        "{\"version\":3,\"sources\":[\"input.ts\"],\"sourcesContent\":[\"const x = 1;\"],\"mappings\":\";AAAA;AACA\"}",
+    );
+    defer map.deinit();
+
+    const hit = map.lookup(1, 0) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings("input.ts", hit.source);
+    try std.testing.expectEqual(@as(u32, 0), hit.line);
+}
+
+test "source map trace: sections offset" {
+    var map = try parse(
+        std.testing.allocator,
+        "{\"version\":3,\"sections\":[{\"offset\":{\"line\":2,\"column\":0},\"map\":{\"version\":3,\"sources\":[\"input.ts\"],\"mappings\":\"AAAA\"}}]}",
+    );
+    defer map.deinit();
+
+    const hit = map.lookup(2, 0) orelse return error.TestUnexpectedResult;
+    try std.testing.expectEqualStrings("input.ts", hit.source);
+    try std.testing.expectEqual(@as(u32, 0), hit.line);
+}
+
+test "source map trace: invalid segment shape is rejected" {
+    try std.testing.expectError(
+        error.InvalidSourceMap,
+        parse(std.testing.allocator, "{\"version\":3,\"sources\":[\"input.ts\"],\"mappings\":\"AA\"}"),
+    );
+}


### PR DESCRIPTION
## 개요

#1902 순차 계획 중 PR 2입니다. PR 1(plugin failure diagnostics)이 머지된 뒤 시작했고, 이 PR이 머지되기 전까지 PR 3(`buildSync()` sync JS plugin support)은 시작하지 않습니다.

## 먼저 추가한 실패 테스트

- 기존 `vitePlugin: transform이 { code, map } 반환 시 map 무시` 기대값을 최종 sourcemap 반영 기대값으로 변경
- `onLoad` map이 최종 sourcemap에 합성되는 케이스
- 단일 `onTransform` map 합성
- code 변경 없이 map만 반환하는 `onTransform` map 합성
- 2단 `onTransform` map chain 원본 위치 역추적
- `map: null`은 합성 없이 정상 빌드
- invalid transform map은 `plugin_error` diagnostic으로 실패
- index map `sections` 입력의 section offset 반영
- eager/lazy sourcemap JSON의 sources/mappings 동등성 및 원본 위치 반영

## 구현 요약

- JS plugin/vitePlugin dispatcher가 `load`/`transform` 반환의 `map`을 JSON string으로 정규화해 NAPI로 전달합니다.
- NAPI bridge와 native plugin runner가 load/transform sourcemap chain을 module에 보존합니다.
- Source Map V3 decoder/trace helper를 추가해 일반 map과 index map `sections` 입력을 flat mapping으로 파싱하고 역추적합니다.
- emitter가 최종 bundle/HMR sourcemap에 module mapping을 넣기 전 plugin sourcemap chain으로 원본 위치를 추적합니다.
- malformed sourcemap은 fatal `plugin_error` diagnostic으로 노출되도록 검증 경로를 추가했습니다.

## 검증

- `zig build test --summary all`
- `zig build napi`
- `bun run --cwd packages/core build:js`
- `bun test packages/core/index.test.ts`
- `bun test packages/core/index.test.ts --test-name-pattern "plugin transform sourcemap chain|transform이 \\{ code, map \\}"`
- `zig build -Doptimize=ReleaseFast`
- `(cd tests/integration && bun test --timeout 10000 tests/sourcemap.test.ts tests/sourcemap-footer.test.ts tests/round4-sourcemap.test.ts tests/round5-sourcemap.test.ts)`
- `bun run fmt:check`
- `zig fmt --check src/codegen/source_map_trace.zig src/bundler/emitter/dev.zig src/bundler/emitter.zig src/bundler/emitter/chunks.zig src/bundler/graph.zig src/bundler/module.zig src/bundler/plugin.zig packages/core/src/napi_entry.zig`
- `git diff --check`
- `bun run lint` (기존 warning 21개, error 0)
- `git push -u origin fix/transform-sourcemap-chain-1902` pre-push hook 통과

Refs #1902