### PR TITLE
feat(rn): dev-server 터미널 UI bungae 정합 + 콘솔 로그 v 토글

### DIFF
--- a/packages/init/src/react-native.ts
+++ b/packages/init/src/react-native.ts
@@ -159,7 +159,7 @@ export default {
     port: 8081,
     host: "localhost",
     useGlobalHotkey: true,
-    forwardClientLogs: false,
+    forwardClientLogs: true,
   },
 };
 `;

--- a/packages/react-native/runtime/zntc-hmr-client.js
+++ b/packages/react-native/runtime/zntc-hmr-client.js
@@ -139,32 +139,40 @@ var HMRClient = {
             }
             break;
           case 'hmr:update':
-            console.log(
-              '[ZNTC HMR] update received, modules:',
-              msg.modules ? msg.modules.length : 0,
-            );
-            console.log('[ZNTC HMR] __zntc_apply_update:', typeof __zntc_apply_update);
-            console.log(
-              '[ZNTC HMR] global.__zntc_apply_update:',
-              typeof global.__zntc_apply_update,
-            );
+            // hmr-client debug — __ZNTC_HMR_DEBUG__ true 시에만 update 도착/주입
+            // 진행 로그 출력. default false — forwardClientLogs 로 터미널 forwarding
+            // 시 사용자 앱 console.log 가 시스템 노이즈에 묻히지 않게.
+            var hmrDebug = typeof __ZNTC_HMR_DEBUG__ !== 'undefined' ? __ZNTC_HMR_DEBUG__ : false;
+            if (hmrDebug) {
+              console.log(
+                '[ZNTC HMR] update received, modules:',
+                msg.modules ? msg.modules.length : 0,
+              );
+            }
             var applyFn =
               typeof __zntc_apply_update === 'function'
                 ? __zntc_apply_update
                 : global.__zntc_apply_update;
             if (typeof applyFn === 'function' && msg.modules && msg.modules.length > 0) {
-              console.log(
-                '[ZNTC HMR] calling __zntc_apply_update with',
-                msg.modules.length,
-                'modules',
-              );
+              if (hmrDebug) {
+                console.log(
+                  '[ZNTC HMR] applying',
+                  msg.modules.length,
+                  typeof __zntc_apply_update === 'function'
+                    ? 'modules (local)'
+                    : 'modules (global)',
+                );
+              }
               try {
                 applyFn(msg.modules);
-                console.log('[ZNTC HMR] __zntc_apply_update completed successfully');
+                if (hmrDebug) console.log('[ZNTC HMR] apply OK');
               } catch (e) {
+                // 항상 출력 — apply 실패는 silent 면 안 됨. 사용자 진단 정보.
                 console.error('[ZNTC HMR] __zntc_apply_update threw:', e);
               }
-            } else {
+            } else if (hmrDebug || (msg.modules && msg.modules.length > 0)) {
+              // modules 가 있는데 applyFn 없으면 항상 warn (런타임 주입 누락 진단).
+              // modules 비었고 debug off 면 silent (normal idle).
               console.warn('[ZNTC HMR] __zntc_apply_update not available or no modules');
             }
             break;

--- a/packages/react-native/src/dev-server/hmr-bridge.ts
+++ b/packages/react-native/src/dev-server/hmr-bridge.ts
@@ -28,6 +28,11 @@ export interface HmrBridge {
   readonly path: string;
   /** http upgrade chain 안에서 호출 — channel.accept + initial greeting. */
   acceptUpgrade(req: IncomingMessage, socket: Socket): void;
+  /**
+   * RN runtime console.log forwarding 출력 표시 toggle. 새 상태 반환. server-side
+   * mute 라 클라이언트는 계속 보냄 — 트래픽 절약하려면 forwardClientLogs OFF 로 build.
+   */
+  toggleLogs(): boolean;
 }
 
 function annotateUpdates(
@@ -83,10 +88,10 @@ function buildOnRebuild(adapter: MetroHmrAdapter, opts: { silent?: boolean } = {
 }
 
 /**
- * RN client 가 보내는 메시지 처리 — `register-entrypoints` ACK + `log` forwarding
- * (RN runtime 의 console.log → dev server 터미널).
+ * RN client 메시지 처리 — `register-entrypoints` ACK + `log` forwarding (RN runtime
+ * 의 console.log → dev server 터미널). `getLogsEnabled` false 시 출력 skip.
  */
-function buildIncomingHandler(adapter: MetroHmrAdapter) {
+function buildIncomingHandler(adapter: MetroHmrAdapter, getLogsEnabled: () => boolean) {
   return (text: string, socket: import('node:net').Socket): void => {
     let msg: { type?: string; level?: string; data?: unknown } | null = null;
     try {
@@ -102,6 +107,7 @@ function buildIncomingHandler(adapter: MetroHmrAdapter) {
       return;
     }
     if (msg.type === 'log') {
+      if (!getLogsEnabled()) return;
       const level = typeof msg.level === 'string' ? msg.level : 'log';
       const data = Array.isArray(msg.data) ? msg.data : [msg.data];
       const formatted = data
@@ -133,7 +139,8 @@ function buildAckFrame(): Buffer {
 export function createHmrBridge(options: HmrBridgeOptions): HmrBridge {
   const adapter = createMetroHmrAdapter();
   const onRebuild = buildOnRebuild(adapter, { silent: options.silent });
-  adapter.channel.onIncoming(buildIncomingHandler(adapter));
+  let logsEnabled = true;
+  adapter.channel.onIncoming(buildIncomingHandler(adapter, () => logsEnabled));
 
   return {
     adapter,
@@ -142,6 +149,10 @@ export function createHmrBridge(options: HmrBridgeOptions): HmrBridge {
     acceptUpgrade(req, socket) {
       adapter.channel.accept(req, socket);
       adapter.sendInitialGreeting();
+    },
+    toggleLogs() {
+      logsEnabled = !logsEnabled;
+      return logsEnabled;
     },
   };
 }

--- a/packages/react-native/src/dev-server/logger.test.ts
+++ b/packages/react-native/src/dev-server/logger.test.ts
@@ -100,15 +100,16 @@ describe('printZntcRnBanner', () => {
   test('version 지정 시 banner 에 포함', () => {
     printZntcRnBanner('0.1.0');
     const out = (logSpy.mock.calls[0] as unknown[])[0] as string;
-    expect(out).toContain('@zntc/react-native');
+    // ZNTC ASCII 로고 (Z 글리프 첫 줄) + 슬로건 + version.
+    expect(out).toContain('███████╗███╗');
+    expect(out).toContain('Lightning Fast React Native Bundler');
     expect(out).toContain('v0.1.0');
-    expect(out).toContain('Metro-compatible RN dev server');
   });
 
   test('version 없음 → version 영역 비움', () => {
     printZntcRnBanner();
     const out = (logSpy.mock.calls[0] as unknown[])[0] as string;
-    expect(out).toContain('@zntc/react-native');
+    expect(out).toContain('███████╗███╗');
     expect(out).not.toMatch(/v\d/);
   });
 

--- a/packages/react-native/src/dev-server/logger.ts
+++ b/packages/react-native/src/dev-server/logger.ts
@@ -64,7 +64,7 @@ export function logBundle(
   console.log(`${badge} ${colors.dim}[${platform}]${colors.reset} ${subject}${tail}`);
 }
 
-const BANNER_WIDTH = 53;
+const BANNER_WIDTH = 59;
 
 function bannerLine(content: string): string {
   // ANSI escape 제거 후 visible length 측정.
@@ -73,20 +73,43 @@ function bannerLine(content: string): string {
   const padding = Math.max(0, BANNER_WIDTH - visibleLen);
   const left = Math.floor(padding / 2);
   const right = padding - left;
-  return `${colors.cyan}║${colors.reset}${' '.repeat(left)}${content}${' '.repeat(right)}${colors.cyan}║${colors.reset}`;
+  return `${colors.cyan}    ║${colors.reset}${' '.repeat(left)}${content}${' '.repeat(right)}${colors.cyan}║${colors.reset}`;
 }
 
-/** ZNTC RN dev server 시작 banner. */
+const ZNTC_ASCII = [
+  '███████╗███╗   ██╗████████╗ ██████╗',
+  '╚══███╔╝████╗  ██║╚══██╔══╝██╔════╝',
+  '  ███╔╝ ██╔██╗ ██║   ██║   ██║     ',
+  ' ███╔╝  ██║╚██╗██║   ██║   ██║     ',
+  '███████╗██║ ╚████║   ██║   ╚██████╗',
+  '╚══════╝╚═╝  ╚═══╝   ╚═╝    ╚═════╝',
+] as const;
+
+const ZNTC_GRADIENT = [
+  colors.yellow,
+  colors.yellow,
+  colors.blue,
+  colors.blue,
+  colors.magenta,
+  colors.magenta,
+] as const;
+
+/** ZNTC RN dev server 시작 banner — 6줄 ASCII 로고 + 그라디언트 + 박스. */
 export function printZntcRnBanner(version?: string): void {
-  const versionText = version ? ` v${version}` : '';
+  const versionText = version ? `v${version}` : '';
+  const logoLines = ZNTC_ASCII.map((line, i) =>
+    bannerLine(`${colors.bold}${ZNTC_GRADIENT[i]}${line}${colors.reset}`),
+  );
   const lines = [
     '',
-    `${colors.cyan}╔${'═'.repeat(BANNER_WIDTH)}╗${colors.reset}`,
+    `${colors.cyan}    ╔${'═'.repeat(BANNER_WIDTH)}╗${colors.reset}`,
     bannerLine(''),
-    bannerLine(`${colors.bold}${colors.cyan}@zntc/react-native${colors.reset}${versionText}`),
-    bannerLine(`${colors.gray}Metro-compatible RN dev server${colors.reset}`),
+    ...logoLines,
     bannerLine(''),
-    `${colors.cyan}╚${'═'.repeat(BANNER_WIDTH)}╝${colors.reset}`,
+    bannerLine(`${colors.cyan}Lightning Fast React Native Bundler${colors.reset}`),
+    bannerLine(`${colors.gray}${versionText}${colors.reset}`),
+    bannerLine(''),
+    `${colors.cyan}    ╚${'═'.repeat(BANNER_WIDTH)}╝${colors.reset}`,
     '',
   ];
   console.log(lines.join('\n'));

--- a/packages/react-native/src/dev-server/serve.ts
+++ b/packages/react-native/src/dev-server/serve.ts
@@ -4,7 +4,7 @@
 
 import { createDevHttpServer, type DevHttpServerHandle } from './http-server.ts';
 import { createHmrBridge, type HmrBridge } from './hmr-bridge.ts';
-import { logBundle, logInfo, printZntcRnBanner } from './logger.ts';
+import { logBundle, logError, logInfo, printZntcRnBanner } from './logger.ts';
 import { loadCliServerApi } from './middleware/cli-server-api.ts';
 import { loadDevMiddleware } from './middleware/dev-middleware.ts';
 import type { RnDevServerOptions } from './options.ts';
@@ -13,7 +13,7 @@ import {
   type PlatformStateRegistry,
   waitForBuild,
 } from './platform-state.ts';
-import { setupTerminalActions } from './terminal-actions.ts';
+import { printDefaultShortcuts, setupTerminalActions } from './terminal-actions.ts';
 import type { Broadcast } from './types.ts';
 
 export interface RnDevServerHandle {
@@ -54,6 +54,11 @@ export interface ServeRnExtras {
   version?: string;
   /** banner / startup log 출력 안 함 (test 환경 등). default false. */
   silent?: boolean;
+  /**
+   * SIGINT/SIGTERM listener 등록 + shutdown 메시지. CLI 사용 시 default true,
+   * embed 사용 시 caller 가 직접 lifecycle 관리하면 false. default true.
+   */
+  installSignalHandlers?: boolean;
 }
 
 export async function serveRn(
@@ -120,8 +125,16 @@ export async function serveRn(
       onReload: () => broadcast('reload'),
       onDevMenu: () => broadcast('devMenu'),
       onOpenDevTools: () => {
-        // dev-middleware 가 /open-debugger POST 를 처리. 미설치 시 silent skip.
-        fetch(`${httpHandle.url}/open-debugger`, { method: 'POST' }).catch(() => {});
+        // 5s timeout — dev-middleware 미설치/hang 시 무한 대기 회피.
+        fetch(`${httpHandle.url}/open-debugger`, {
+          method: 'POST',
+          signal: AbortSignal.timeout(5000),
+        }).catch((err) => {
+          logError(
+            `Failed to open DevTools: ${(err as Error).message ?? err}. ` +
+              `'@react-native/dev-middleware' peer dependency 설치 확인.`,
+          );
+        });
       },
       onClearCache: () => {
         for (const state of platforms.platforms.values()) {
@@ -130,14 +143,43 @@ export async function serveRn(
           state.sourceMapCache = null;
         }
       },
+      onToggleLogs: () => hmrBridge?.toggleLogs() ?? true,
     },
     { enabled: options.terminalActions },
   );
-  if (!extras.silent && options.terminalActions) {
-    logInfo('Press ? to show keyboard shortcuts (r/d/j/i/a/c)');
-  }
   if (!extras.silent) {
     logInfo(`Dev server listening on ${httpHandle.url} (platform=${options.bundle.rnPlatform})`);
+    if (options.terminalActions) printDefaultShortcuts();
+  }
+
+  // shuttingDown — SIGINT 두 번/SIGINT+SIGTERM 동시 도착 재진입 차단. handle.stop()
+  // 에서 listener 제거해 다중 serveRn() 호출 시 핸들러 누적 방지.
+  let signalCleanup: (() => void) | null = null;
+  if (extras.installSignalHandlers !== false) {
+    let shuttingDown = false;
+    const handleSignal = (signal: NodeJS.Signals): void => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      if (!extras.silent) logInfo(`${signal} received, shutting down...`);
+      void (async () => {
+        try {
+          terminalCleanup();
+          await httpHandle.stop();
+          await platforms.stopAll();
+        } catch (err) {
+          logError(`Shutdown error: ${(err as Error).message ?? err}`);
+          process.exit(1);
+        }
+        if (!extras.silent) logInfo('Server stopped');
+        process.exit(0);
+      })();
+    };
+    process.on('SIGINT', handleSignal);
+    process.on('SIGTERM', handleSignal);
+    signalCleanup = () => {
+      process.off('SIGINT', handleSignal);
+      process.off('SIGTERM', handleSignal);
+    };
   }
 
   return {
@@ -146,6 +188,7 @@ export async function serveRn(
     hmrBridge,
     platforms,
     async stop() {
+      signalCleanup?.();
       terminalCleanup();
       await httpHandle.stop();
       await platforms.stopAll();

--- a/packages/react-native/src/dev-server/terminal-actions.test.ts
+++ b/packages/react-native/src/dev-server/terminal-actions.test.ts
@@ -34,12 +34,16 @@ function makeCallbacks(): TerminalActionsCallbacks & {
   devMenuCount: number;
   devToolsCount: number;
   clearCount: number;
+  toggleCount: number;
+  logsEnabled: boolean;
 } {
   const cb = {
     reloadCount: 0,
     devMenuCount: 0,
     devToolsCount: 0,
     clearCount: 0,
+    toggleCount: 0,
+    logsEnabled: true,
     onReload() {
       cb.reloadCount++;
     },
@@ -51,6 +55,11 @@ function makeCallbacks(): TerminalActionsCallbacks & {
     },
     onClearCache() {
       cb.clearCount++;
+    },
+    onToggleLogs() {
+      cb.toggleCount++;
+      cb.logsEnabled = !cb.logsEnabled;
+      return cb.logsEnabled;
     },
   };
   return cb;
@@ -178,6 +187,20 @@ describe('setupTerminalActions — keypress 라우팅', () => {
     stdin.emitKey('j');
     stdin.emitKey('c');
     expect([cb.devMenuCount, cb.devToolsCount, cb.clearCount]).toEqual([1, 1, 1]);
+    cleanup();
+  });
+
+  test('v → onToggleLogs (한 번 누름 → ON→OFF)', () => {
+    const cb = makeCallbacks();
+    const stdin = makeStdin();
+    const cleanup = setupTerminalActions(cb, { enabled: true, stdin });
+    expect(cb.logsEnabled).toBe(true);
+    stdin.emitKey('v');
+    expect(cb.toggleCount).toBe(1);
+    expect(cb.logsEnabled).toBe(false);
+    stdin.emitKey('v');
+    expect(cb.toggleCount).toBe(2);
+    expect(cb.logsEnabled).toBe(true);
     cleanup();
   });
 

--- a/packages/react-native/src/dev-server/terminal-actions.ts
+++ b/packages/react-native/src/dev-server/terminal-actions.ts
@@ -5,6 +5,8 @@ import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { colors, logInfo, logWarn } from './logger.ts';
+
 export interface TerminalActionsCallbacks {
   /** `r` — RN runtime reload broadcast. */
   onReload(): void;
@@ -14,6 +16,11 @@ export interface TerminalActionsCallbacks {
   onOpenDevTools(): void;
   /** `c` — clear cache (per-platform state.bundle null 처리 등). */
   onClearCache(): void;
+  /**
+   * `v` — RN runtime 의 console.log forwarding mute/unmute. 새 상태 반환 (true=ON,
+   * false=OFF) — INFO 피드백 메시지에 사용.
+   */
+  onToggleLogs(): boolean;
 }
 
 export interface TerminalActionsOptions {
@@ -21,23 +28,36 @@ export interface TerminalActionsOptions {
   enabled: boolean;
   /** TTY 가 아니면 listener 등록 skip — CI / pipe 환경 호환. */
   stdin?: NodeJS.ReadStream;
-  /** 단축키 list 출력 callback (`?`). 미지정 시 console.log default. */
+  /** 단축키 list 출력 callback (`?`). 미지정 시 INFO badge default. */
   printShortcuts?(): void;
 }
 
-const DEFAULT_SHORTCUTS_HELP = [
-  'Available shortcuts:',
-  '  r - Reload    d - Dev Menu    j - DevTools',
-  '  i - iOS Sim   a - Android     c - Clear cache',
-];
-
-function defaultPrintShortcuts(): void {
-  for (const line of DEFAULT_SHORTCUTS_HELP) console.log(line);
+/** `?` 응답 — INFO badge + 5칸 들여쓰기 + 앞뒤 빈 줄. */
+export function printDefaultShortcuts(): void {
+  console.log('');
+  logInfo('Available shortcuts:');
+  console.log(
+    `     ${colors.bold}r${colors.reset} - Reload    ${colors.bold}d${colors.reset} - Dev Menu    ${colors.bold}j${colors.reset} - DevTools`,
+  );
+  console.log(
+    `     ${colors.bold}i${colors.reset} - iOS Sim   ${colors.bold}a${colors.reset} - Android     ${colors.bold}c${colors.reset} - Clear cache`,
+  );
+  console.log(
+    `     ${colors.bold}v${colors.reset} - Toggle console logs           ${colors.bold}?${colors.reset} - Show this help`,
+  );
+  console.log('');
 }
 
-function openIOSSimulator(): boolean {
-  if (process.platform !== 'darwin') return false;
-  if (!existsSync('/usr/bin/xcrun')) return false;
+function openIOSSimulator(): void {
+  if (process.platform !== 'darwin') {
+    logWarn('iOS Simulator is only available on macOS');
+    return;
+  }
+  if (!existsSync('/usr/bin/xcrun')) {
+    logWarn('xcrun not found. Install Xcode Command Line Tools.');
+    return;
+  }
+  logInfo('Opening iOS Simulator...');
   const child = spawn('open', ['-a', 'Simulator'], {
     detached: true,
     stdio: ['ignore', 'ignore', 'ignore'],
@@ -46,18 +66,23 @@ function openIOSSimulator(): boolean {
     /* spawn ENOENT/EACCES — silent skip */
   });
   child.unref();
-  return true;
 }
 
 // Defense-in-depth: emulator `-list-avds` 는 신뢰할만한 출력이지만 path injection
 // 회피용으로 valid AVD name pattern 만 허용.
 const AVD_NAME_RE = /^[a-zA-Z0-9._-]+$/;
 
-function openAndroidEmulator(): boolean {
+function openAndroidEmulator(): void {
   const androidHome = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT;
-  if (!androidHome) return false;
+  if (!androidHome) {
+    logWarn('ANDROID_HOME or ANDROID_SDK_ROOT not set');
+    return;
+  }
   const emulatorPath = join(androidHome, 'emulator', 'emulator');
-  if (!existsSync(emulatorPath)) return false;
+  if (!existsSync(emulatorPath)) {
+    logWarn('Android emulator not found. Check your Android SDK installation.');
+    return;
+  }
 
   const list = spawn(emulatorPath, ['-list-avds'], { stdio: ['ignore', 'pipe', 'ignore'] });
   list.on('error', () => {
@@ -69,9 +94,16 @@ function openAndroidEmulator(): boolean {
   });
   list.on('close', () => {
     const first = buf.split('\n').find((line) => line.trim().length > 0);
-    if (!first) return;
+    if (!first) {
+      logWarn('No Android AVDs found. Create an AVD first.');
+      return;
+    }
     const avdName = first.trim();
-    if (!AVD_NAME_RE.test(avdName)) return;
+    if (!AVD_NAME_RE.test(avdName)) {
+      logWarn('Invalid AVD name');
+      return;
+    }
+    logInfo(`Opening Android Emulator: ${avdName}`);
     const child = spawn(emulatorPath, ['@' + avdName], {
       detached: true,
       stdio: ['ignore', 'ignore', 'ignore'],
@@ -81,7 +113,6 @@ function openAndroidEmulator(): boolean {
     });
     child.unref();
   });
-  return true;
 }
 
 /**
@@ -129,7 +160,7 @@ export function setupTerminalActions(
   stdin.resume();
   stdin.setEncoding('utf8');
 
-  const printShortcuts = options.printShortcuts ?? defaultPrintShortcuts;
+  const printShortcuts = options.printShortcuts ?? printDefaultShortcuts;
 
   // Bun runtime 의 stdin 은 setEncoding('utf8') 호출해도 'data' event 가 Buffer 로
   // emit 될 수 있다 (Node 와 다른 동작). bungae graph-bundler/terminal-actions.ts
@@ -166,12 +197,15 @@ export function setupTerminalActions(
     }
     switch (key.toLowerCase()) {
       case 'r':
+        logInfo('Reloading app...');
         callbacks.onReload();
         break;
       case 'd':
+        logInfo('Opening Dev Menu...');
         callbacks.onDevMenu();
         break;
       case 'j':
+        logInfo('Opening DevTools...');
         callbacks.onOpenDevTools();
         break;
       case 'i':
@@ -182,7 +216,13 @@ export function setupTerminalActions(
         break;
       case 'c':
         callbacks.onClearCache();
+        logInfo('Cache cleared');
         break;
+      case 'v': {
+        const enabled = callbacks.onToggleLogs();
+        logInfo(`Console logs: ${enabled ? 'ON' : 'OFF'}`);
+        break;
+      }
       case '?':
         printShortcuts();
         break;


### PR DESCRIPTION
## Summary

원본 (`bungae`) 의 RN dev server 터미널을 zts 로 옮길 때 다섯 가지 UI 요소가 누락돼 있어 사용자가 "Metro/번개와 다르게 보인다" 고 보고. 이번 PR 에서 모두 정합 + 콘솔 로그 핫키 토글 신규.

## UI 정합 (원본 동등)

- **ZNTC ASCII 배너** — 미니멀 텍스트 → 6줄 로고 + 그라디언트(yellow/blue/magenta) + 박스 폭 59 통일
- **시작 시 단축키 표 즉시 출력** — `Press ?` 한 줄 → 4줄 표 (r·d·j / i·a·c / v·?) + INFO 헤더
- **핫키 액션 피드백** — 침묵 → 매 핫키마다 INFO 출력 (`Reloading app...`, `Cache cleared` 등)
- **shortcuts help 포맷** — plain text 2칸 → INFO badge + 5칸 들여쓰기 + 앞뒤 빈 줄
- **SIGINT/SIGTERM 핸들러** — `${signal} received, shutting down...` → graceful stop → `Server stopped`. `handle.stop()` 에서 listener 제거 idempotent

## 신규 — 콘솔 로그 `v` 토글

- `terminal-actions.ts`: `onToggleLogs()` callback 추가, 새 상태 `Console logs: ON|OFF` 출력
- `hmr-bridge.ts`: `toggleLogs()` 메서드 — server-side mute (수신은 계속, 출력만 skip)
- `init/react-native.ts`: `forwardClientLogs` default `false` → `true` (v 토글이 동작하려면 client 가 보내야 함, 원본 동작과 일치)

## 추가 정리

- `zntc-hmr-client.js`: `hmr:update` 마다 매번 5줄씩 찍던 verbose console.log 를 `__ZNTC_HMR_DEBUG__` flag 로 gate. apply 실패 진단 로그는 항상 유지 (forwardClientLogs ON 시 사용자 앱 로그가 시스템 노이즈에 묻히지 않게)
- `serve.ts`: `j` (DevTools) fetch 에 `AbortSignal.timeout(5000)` — dev-middleware 미설치/hang 시 무한 대기 회피. 실패 시 `logError` 로 원인 출력

## zts 만의 강점은 유지

- `(platform=ios)` 표기 (멀티 플랫폼 빌드)
- rebuild 이벤트 detail (`Graph changed` / `HMR update` / `Rebuilt` 풍부 정보)
- `[zntc:rn-dev]` stderr 진단 prefix (silent failure 가시화)

## Test plan

- [x] `bun test src/dev-server/terminal-actions.test.ts src/dev-server/logger.test.ts` — 36 pass / 0 fail (`v` 토글 신규 테스트 1건 포함)
- [x] `bun run lint` — 우리 변경분 0 warnings
- [x] `bun run fmt` 통과
- [ ] RN bare/expo example 에서 dev server 띄워 배너·단축키 표·핫키 피드백·v 토글·Ctrl+C 시 shutdown 메시지 시각 확인

## Notes

- `hmr-bridge.test.ts` / `serve.test.ts` 의 `Cannot find module '@zntc/server'` 에러는 main baseline 에서도 동일 — monorepo workspace 빌드 인프라 이슈 (PR 변경분 무관)
- `installSignalHandlers: false` 옵션 추가 — embed 사용 시 caller 가 직접 lifecycle 관리하면 비활성

🤖 Generated with [Claude Code](https://claude.com/claude-code)