### PR TITLE
fix(buildSync): sync JS 플러그인 지원

### DIFF
--- a/packages/core/index.test.ts
+++ b/packages/core/index.test.ts
@@ -1201,13 +1201,98 @@ describe('@zntc/core build + plugins', () => {
     rmSync(entryDir, { recursive: true, force: true });
   });
 
-  test('buildSync에서 plugins 사용 시 에러', () => {
-    expect(() =>
-      buildSync({
-        entryPoints: [join(dir, 'entry.ts')],
-        plugins: [{ name: 'test', setup() {} }],
-      }),
-    ).toThrow('plugins are only supported with build()');
+  test('buildSync: onResolve/onLoad/onTransform sync plugin 동작', () => {
+    const syncDir = mkdtempSync(join(tmpdir(), 'zntc-buildsync-plugin-'));
+    writeFileSync(
+      join(syncDir, 'entry.ts'),
+      'import msg from "virtual:message";\nconsole.log(msg);',
+    );
+    const virtualPath = join(syncDir, 'virtual-message.ts');
+
+    const plugin: ZntcPlugin = {
+      name: 'sync-plugin',
+      setup(build) {
+        build.onResolve({ filter: /^virtual:message$/ }, () => ({ path: virtualPath }));
+        build.onLoad({ filter: /virtual-message\.ts$/ }, () => ({
+          contents: 'export default "SYNC_LOAD";',
+        }));
+        build.onTransform({ filter: /virtual-message\.ts$/ }, (args) => ({
+          code: args.code.replace('SYNC_LOAD', 'SYNC_TRANSFORM'),
+        }));
+      },
+    };
+
+    const result = buildSync({
+      entryPoints: [join(syncDir, 'entry.ts')],
+      plugins: [plugin],
+    });
+
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain('SYNC_TRANSFORM');
+    rmSync(syncDir, { recursive: true, force: true });
+  });
+
+  test('buildSync: vitePlugin sync hooks 동작', () => {
+    const syncDir = mkdtempSync(join(tmpdir(), 'zntc-buildsync-vite-plugin-'));
+    writeFileSync(
+      join(syncDir, 'entry.ts'),
+      'import { msg } from "virtual:vite";\nconsole.log(msg);',
+    );
+    const virtualPath = join(syncDir, 'virtual-vite.ts');
+
+    const result = buildSync({
+      entryPoints: [join(syncDir, 'entry.ts')],
+      plugins: [
+        vitePlugin({
+          name: 'vite-sync-plugin',
+          resolveId(id) {
+            if (id === 'virtual:vite') return virtualPath;
+            return null;
+          },
+          load(id) {
+            if (id === virtualPath) return 'export const msg = "VITE_LOAD";';
+            return null;
+          },
+          transform(code, id) {
+            if (id === virtualPath) return { code: code.replace('VITE_LOAD', 'VITE_TRANSFORM') };
+            return null;
+          },
+        }),
+      ],
+    });
+
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain('VITE_TRANSFORM');
+    rmSync(syncDir, { recursive: true, force: true });
+  });
+
+  test('buildSync: Promise 반환 plugin hook은 plugin_error로 실패하고 async build 안내를 포함', () => {
+    const syncDir = mkdtempSync(join(tmpdir(), 'zntc-buildsync-async-plugin-'));
+    writeFileSync(join(syncDir, 'entry.ts'), 'import "./async-module";');
+    writeFileSync(join(syncDir, 'async-module.ts'), 'console.log("original");');
+
+    const plugin: ZntcPlugin = {
+      name: 'async-in-sync-plugin',
+      setup(build) {
+        build.onLoad({ filter: /async-module\.ts$/ }, () =>
+          Promise.resolve({ contents: 'console.log("async");' }),
+        );
+      },
+    };
+
+    const result = buildSync({
+      entryPoints: [join(syncDir, 'entry.ts')],
+      plugins: [plugin],
+    });
+
+    expectPluginDiagnostic(result, {
+      plugin: 'async-in-sync-plugin',
+      hook: 'load',
+      message: 'buildSync() does not support async plugin hooks',
+      fileIncludes: 'async-module.ts',
+    });
+    expect(diagText(result.errors[0])).toContain('use build() instead');
+    rmSync(syncDir, { recursive: true, force: true });
   });
 
   test('plugin_error: onLoad sync throw가 diagnostic으로 노출됨', async () => {
@@ -2345,17 +2430,18 @@ describe('@zntc/core define/alias', () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  test('alias array: buildSync 에서 throw (host RegExp 위임 plugin 필요)', () => {
+  test('alias array: buildSync 에서 sync dispatcher로 동작', () => {
     const dir = mkdtempSync(join(tmpdir(), 'zntc-alias-array-sync-'));
-    writeFileSync(join(dir, 'index.ts'), 'console.log("hi");');
+    writeFileSync(join(dir, 'index.ts'), 'import { msg } from "@/aliased";\nconsole.log(msg);');
+    writeFileSync(join(dir, 'aliased.ts'), 'export const msg = "ALIAS_ARRAY_SYNC";');
 
-    expect(() =>
-      buildSync({
-        entryPoints: [join(dir, 'index.ts')],
-        alias: [{ find: /^@\//, replacement: dir + '/' }],
-      }),
-    ).toThrow(/array-form alias.*async build/);
+    const result = buildSync({
+      entryPoints: [join(dir, 'index.ts')],
+      alias: [{ find: /^@\/(.*)$/, replacement: join(dir, '$1.ts') }],
+    });
 
+    expect(result.errors.length).toBe(0);
+    expect(result.outputFiles[0].text).toContain('ALIAS_ARRAY_SYNC');
     rmSync(dir, { recursive: true, force: true });
   });
 

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -597,7 +597,7 @@ interface BuildOptionsCommon {
    *
    * 일반 해석 **전에 무조건** 치환됨 — 설치된 실제 패키지가 있어도 무시.
    * Optional shim 용도로는 `fallback`을 쓸 것 (실패 시에만 적용).
-   * Array 형태는 build() 만 지원 (host RegExp 위임 — buildSync 미지원). */
+   * Array 형태는 sync hook만 쓰는 buildSync()에서도 지원. */
   alias?: Record<string, string> | Array<{ find: string | RegExp; replacement: string }>;
   /** Fallback resolution — 일반 해석이 **실패했을 때만** 적용됨 (webpack `resolve.fallback` / Metro `resolver.extraNodeModules` 호환).
    * 값이 문자열이면 해당 specifier로 재해석, `false`면 빈 모듈로 대체.
@@ -1293,83 +1293,185 @@ async function runFireAndForget<T>(
   return firstFailure;
 }
 
-/**
- * plugins 배열을 처리하여 단일 dispatcher 함수를 생성한다.
- * dispatcher(hookName, arg1, arg2) → result | null
- */
-function createPluginDispatcher(plugins: ZntcPlugin[]) {
-  type HookEntry = { pluginName: string; filter: RegExp; callback: (...args: any[]) => any };
-  type PluginDispatcher = ((
-    hookName: string,
-    arg1: unknown,
-    arg2: string | null,
-  ) => Promise<unknown>) & {
-    takeLifecycleFailures(): PluginFailureResult[];
-  };
-  const hooks: Record<string, HookEntry[]> = {
-    resolveId: [],
-    load: [],
-    transform: [],
-    renderChunk: [],
-    resolveContext: [],
-  };
-  const generateBundleCallbacks: Array<{
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    value != null &&
+    (typeof value === 'object' || typeof value === 'function') &&
+    typeof (value as { then?: unknown }).then === 'function'
+  );
+}
+
+function silenceUnsupportedSyncPromise(value: PromiseLike<unknown>): void {
+  Promise.resolve(value).catch(() => {});
+}
+
+function syncPluginPromiseFailure(
+  pluginName: string,
+  hookName: string,
+  file?: string | null,
+): PluginFailureResult {
+  return normalizePluginFailure(
+    pluginName,
+    hookName,
+    new Error(
+      'buildSync() does not support async plugin hooks. Return a synchronous value or use build() instead.',
+    ),
+    file,
+  );
+}
+
+function mapMaybePromise<T, U>(value: T | PromiseLike<T>, mapper: (value: T) => U): U | Promise<U> {
+  if (isPromiseLike(value)) return Promise.resolve(value).then(mapper);
+  return mapper(value);
+}
+
+function runFireAndForgetSync<T>(
+  callbacks: Array<{ pluginName: string; callback: (arg: T) => void | Promise<void> }>,
+  hookName: string,
+  arg: T,
+): PluginFailureResult | null {
+  let firstFailure: PluginFailureResult | null = null;
+  for (const { pluginName, callback } of callbacks) {
+    try {
+      const result = callback(arg);
+      if (isPromiseLike(result)) {
+        silenceUnsupportedSyncPromise(result);
+        firstFailure ??= syncPluginPromiseFailure(pluginName, hookName);
+      }
+    } catch (err) {
+      firstFailure ??= normalizePluginFailure(pluginName, hookName, err);
+    }
+  }
+  return firstFailure;
+}
+
+type HookEntry = { pluginName: string; filter: RegExp; callback: (...args: any[]) => any };
+type PluginDispatcherLifecycle = {
+  takeLifecycleFailures(): PluginFailureResult[];
+};
+type PluginDispatcher = ((
+  hookName: string,
+  arg1: unknown,
+  arg2: string | null,
+) => Promise<unknown>) &
+  PluginDispatcherLifecycle;
+type SyncPluginDispatcher = ((hookName: string, arg1: unknown, arg2: string | null) => unknown) &
+  PluginDispatcherLifecycle;
+
+type PluginRegistry = {
+  hooks: Record<string, HookEntry[]>;
+  generateBundleCallbacks: Array<{
     pluginName: string;
     callback: (outputs: OutputFile[]) => void | Promise<void>;
-  }> = [];
-  const buildStartCallbacks: Array<{ pluginName: string; callback: () => void | Promise<void> }> =
-    [];
-  const buildEndCallbacks: Array<{
+  }>;
+  buildStartCallbacks: Array<{ pluginName: string; callback: () => void | Promise<void> }>;
+  buildEndCallbacks: Array<{
     pluginName: string;
     callback: (error?: Error) => void | Promise<void>;
-  }> = [];
-  const closeBundleCallbacks: Array<{ pluginName: string; callback: () => void | Promise<void> }> =
-    [];
-  const astFunctionHooks: HookEntry[] = [];
-  const lifecycleFailures: PluginFailureResult[] = [];
+  }>;
+  closeBundleCallbacks: Array<{ pluginName: string; callback: () => void | Promise<void> }>;
+  astFunctionHooks: HookEntry[];
+  lifecycleFailures: PluginFailureResult[];
+};
+
+function collectPluginRegistry(plugins: ZntcPlugin[]): PluginRegistry {
+  const registry: PluginRegistry = {
+    hooks: {
+      resolveId: [],
+      load: [],
+      transform: [],
+      renderChunk: [],
+      resolveContext: [],
+    },
+    generateBundleCallbacks: [],
+    buildStartCallbacks: [],
+    buildEndCallbacks: [],
+    closeBundleCallbacks: [],
+    astFunctionHooks: [],
+    lifecycleFailures: [],
+  };
 
   for (const plugin of plugins) {
     const build: PluginBuild = {
       onResolve(opts, cb) {
-        hooks.resolveId.push({ pluginName: plugin.name, filter: opts.filter, callback: cb });
+        registry.hooks.resolveId.push({
+          pluginName: plugin.name,
+          filter: opts.filter,
+          callback: cb,
+        });
       },
       onLoad(opts, cb) {
-        hooks.load.push({ pluginName: plugin.name, filter: opts.filter, callback: cb });
+        registry.hooks.load.push({ pluginName: plugin.name, filter: opts.filter, callback: cb });
       },
       onTransform(opts, cb) {
-        hooks.transform.push({ pluginName: plugin.name, filter: opts.filter, callback: cb });
+        registry.hooks.transform.push({
+          pluginName: plugin.name,
+          filter: opts.filter,
+          callback: cb,
+        });
       },
       onRenderChunk(opts, cb) {
-        hooks.renderChunk.push({ pluginName: plugin.name, filter: opts.filter, callback: cb });
+        registry.hooks.renderChunk.push({
+          pluginName: plugin.name,
+          filter: opts.filter,
+          callback: cb,
+        });
       },
       onGenerateBundle(cb) {
-        generateBundleCallbacks.push({ pluginName: plugin.name, callback: cb });
+        registry.generateBundleCallbacks.push({ pluginName: plugin.name, callback: cb });
       },
       onBuildStart(cb) {
-        buildStartCallbacks.push({ pluginName: plugin.name, callback: cb });
+        registry.buildStartCallbacks.push({ pluginName: plugin.name, callback: cb });
       },
       onBuildEnd(cb) {
-        buildEndCallbacks.push({ pluginName: plugin.name, callback: cb });
+        registry.buildEndCallbacks.push({ pluginName: plugin.name, callback: cb });
       },
       onCloseBundle(cb) {
-        closeBundleCallbacks.push({ pluginName: plugin.name, callback: cb });
+        registry.closeBundleCallbacks.push({ pluginName: plugin.name, callback: cb });
       },
       onAstFunction(opts, cb) {
-        astFunctionHooks.push({ pluginName: plugin.name, filter: opts.filter, callback: cb });
+        registry.astFunctionHooks.push({
+          pluginName: plugin.name,
+          filter: opts.filter,
+          callback: cb,
+        });
       },
       onResolveContext(opts, cb) {
-        hooks.resolveContext.push({ pluginName: plugin.name, filter: opts.filter, callback: cb });
+        registry.hooks.resolveContext.push({
+          pluginName: plugin.name,
+          filter: opts.filter,
+          callback: cb,
+        });
       },
     };
     plugin.setup(build);
   }
 
-  // hookName → { filter 대상, 콜백 인자 } 매핑
-  const argBuilders: Record<string, (arg1: string, arg2: string | null) => [string, unknown]> = {
+  return registry;
+}
+
+// hookName → { filter 대상, 콜백 인자 } 매핑
+const pluginArgBuilders: Record<string, (arg1: string, arg2: string | null) => [string, unknown]> =
+  {
     resolveId: (arg1, arg2) => [arg1, { path: arg1, importer: arg2 }],
     load: (arg1, _) => [arg1, { path: arg1 }],
     renderChunk: (arg1, arg2) => [arg2 ?? '', { code: arg1, chunk: arg2 }],
   };
+
+/**
+ * plugins 배열을 처리하여 단일 dispatcher 함수를 생성한다.
+ * dispatcher(hookName, arg1, arg2) → result | null
+ */
+function createPluginDispatcher(plugins: ZntcPlugin[]) {
+  const {
+    hooks,
+    generateBundleCallbacks,
+    buildStartCallbacks,
+    buildEndCallbacks,
+    closeBundleCallbacks,
+    astFunctionHooks,
+    lifecycleFailures,
+  } = collectPluginRegistry(plugins);
 
   const dispatcher = async function dispatcher(
     hookName: string,
@@ -1490,7 +1592,7 @@ function createPluginDispatcher(plugins: ZntcPlugin[]) {
     }
 
     // resolveId/load: 첫 번째 매칭 반환 (first 모드)
-    const buildArgs = argBuilders[hookName];
+    const buildArgs = pluginArgBuilders[hookName];
     if (!buildArgs) return null;
     const [filterTarget, cbArgs] = buildArgs(arg1 as string, arg2);
     for (const h of hookList) {
@@ -1512,6 +1614,166 @@ function createPluginDispatcher(plugins: ZntcPlugin[]) {
     }
     return null;
   } as PluginDispatcher;
+  dispatcher.takeLifecycleFailures = () => lifecycleFailures.splice(0);
+  return dispatcher;
+}
+
+/**
+ * buildSync() 전용 dispatcher. Sync hook은 기존 build()와 같은 contract로 실행하되,
+ * Promise/thenable 반환은 즉시 plugin_error payload로 바꾼다.
+ */
+function createSyncPluginDispatcher(plugins: ZntcPlugin[]) {
+  const {
+    hooks,
+    generateBundleCallbacks,
+    buildStartCallbacks,
+    buildEndCallbacks,
+    closeBundleCallbacks,
+    astFunctionHooks,
+    lifecycleFailures,
+  } = collectPluginRegistry(plugins);
+
+  const dispatcher = function dispatcher(hookName: string, arg1: unknown, arg2: string | null) {
+    if (hookName === 'astFunction') {
+      if (astFunctionHooks.length === 0) return null;
+      try {
+        const info = JSON.parse(arg1 as string) as AstFunctionInfo;
+        for (const h of astFunctionHooks) {
+          if (h.filter.test(info.sourcePath)) {
+            try {
+              const result = h.callback(info);
+              if (isPromiseLike(result)) {
+                silenceUnsupportedSyncPromise(result);
+                return syncPluginPromiseFailure(h.pluginName, 'astFunction', info.sourcePath);
+              }
+              if (result != null) return result;
+            } catch (err) {
+              return normalizePluginFailure(h.pluginName, 'astFunction', err, info.sourcePath);
+            }
+          }
+        }
+      } catch {
+        // JSON 파싱 실패
+      }
+      return null;
+    }
+
+    if (hookName === 'resolveContext') {
+      if (hooks.resolveContext.length === 0) return null;
+      try {
+        const args = JSON.parse(arg1 as string) as {
+          dir: string;
+          recursive: boolean;
+          filter?: string;
+          flags?: string;
+          importer: string;
+        };
+        for (const h of hooks.resolveContext) {
+          if (h.filter.test(args.dir)) {
+            try {
+              const result = h.callback(args);
+              if (isPromiseLike(result)) {
+                silenceUnsupportedSyncPromise(result);
+                return syncPluginPromiseFailure(h.pluginName, 'resolveContext', args.importer);
+              }
+              if (result != null) return result;
+            } catch (err) {
+              return normalizePluginFailure(h.pluginName, 'resolveContext', err, args.importer);
+            }
+          }
+        }
+      } catch {
+        // JSON 파싱 실패
+      }
+      return null;
+    }
+
+    if (hookName === 'generateBundle') {
+      return runFireAndForgetSync(generateBundleCallbacks, 'generateBundle', arg1 as OutputFile[]);
+    }
+    if (hookName === 'buildStart') {
+      return runFireAndForgetSync(buildStartCallbacks, 'buildStart', undefined);
+    }
+    if (hookName === 'buildEnd') {
+      const msg = arg1 as string;
+      const err = msg && msg.length > 0 ? new Error(msg) : undefined;
+      const failure = runFireAndForgetSync(buildEndCallbacks, 'buildEnd', err);
+      if (failure) lifecycleFailures.push(failure);
+      return failure;
+    }
+    if (hookName === 'closeBundle') {
+      const failure = runFireAndForgetSync(closeBundleCallbacks, 'closeBundle', undefined);
+      if (failure) lifecycleFailures.push(failure);
+      return failure;
+    }
+
+    const hookList = hooks[hookName];
+    if (!hookList) return null;
+
+    if (hookName === 'transform' || hookName === 'renderChunk') {
+      let currentCode = arg1 as string;
+      let changed = false;
+      const sourceMaps: string[] = [];
+      for (const h of hookList) {
+        if (h.filter.test(arg2 ?? '')) {
+          try {
+            const cbArgs =
+              hookName === 'transform'
+                ? { code: currentCode, path: arg2 }
+                : { code: currentCode, chunk: arg2 };
+            const result = h.callback(cbArgs);
+            if (isPromiseLike(result)) {
+              silenceUnsupportedSyncPromise(result);
+              return syncPluginPromiseFailure(h.pluginName, hookName, arg2);
+            }
+            if (result != null) {
+              const newCode = typeof result === 'string' ? result : result.code;
+              if (newCode != null) {
+                currentCode = newCode;
+                changed = true;
+              }
+              if (hookName === 'transform' && typeof result === 'object' && 'map' in result) {
+                const map = serializePluginSourceMap(result.map);
+                if (map != null) sourceMaps.push(map);
+              }
+            }
+          } catch (err) {
+            return normalizePluginFailure(h.pluginName, hookName, err, arg2);
+          }
+        }
+      }
+      return changed
+        ? { code: currentCode, ...(sourceMaps.length > 0 ? { maps: sourceMaps } : {}) }
+        : null;
+    }
+
+    const buildArgs = pluginArgBuilders[hookName];
+    if (!buildArgs) return null;
+    const [filterTarget, cbArgs] = buildArgs(arg1 as string, arg2);
+    for (const h of hookList) {
+      if (h.filter.test(filterTarget)) {
+        try {
+          const result = h.callback(cbArgs);
+          if (isPromiseLike(result)) {
+            silenceUnsupportedSyncPromise(result);
+            const fallbackFile = hookName === 'resolveId' ? arg2 : filterTarget;
+            return syncPluginPromiseFailure(h.pluginName, hookName, fallbackFile);
+          }
+          if (result != null) {
+            if (hookName === 'load' && typeof result === 'object' && 'map' in result) {
+              const map = serializePluginSourceMap(result.map);
+              return { ...result, ...(map != null ? { map } : { map: undefined }) };
+            }
+            return result;
+          }
+        } catch (err) {
+          const fallbackFile = hookName === 'resolveId' ? arg2 : filterTarget;
+          return normalizePluginFailure(h.pluginName, hookName, err, fallbackFile);
+        }
+      }
+    }
+    return null;
+  } as SyncPluginDispatcher;
   dispatcher.takeLifecycleFailures = () => lifecycleFailures.splice(0);
   return dispatcher;
 }
@@ -1556,11 +1818,16 @@ function arrayAliasToPlugin(
 
 // Array 형태 alias (#2153) 는 onResolve plugin 으로 변환해 user plugins 앞에 prepend —
 // 다른 plugin 보다 먼저 매칭돼 alias 치환이 우선 적용된다 (Vite 동작).
-function resolveDispatcher(options: BuildOptions) {
+function resolveDispatcher(options: BuildOptions, mode: 'sync'): SyncPluginDispatcher | null;
+function resolveDispatcher(options: BuildOptions, mode?: 'async'): PluginDispatcher | null;
+function resolveDispatcher(options: BuildOptions, mode: 'async' | 'sync' = 'async') {
   const arrayAlias = Array.isArray(options.alias) ? options.alias : null;
   const userPlugins = options.plugins ?? [];
   const allPlugins = arrayAlias ? [arrayAliasToPlugin(arrayAlias), ...userPlugins] : userPlugins;
-  return allPlugins.length ? createPluginDispatcher(allPlugins) : null;
+  if (allPlugins.length === 0) return null;
+  return mode === 'sync'
+    ? createSyncPluginDispatcher(allPlugins)
+    : createPluginDispatcher(allPlugins);
 }
 
 function isBrowserLikeBuildPlatform(platform: BuildOptions['platform'] | undefined): boolean {
@@ -1601,7 +1868,7 @@ function prepareNapiOptions(options: BuildOptions): {
   delete napiOptions.outdir;
   delete napiOptions.plugins;
   delete napiOptions.allowOverwrite;
-  // Array 형태 alias 는 plugin 으로 위임 (build() 에서 처리). NAPI 로 전달하면 Zig 가
+  // Array 형태 alias 는 plugin 으로 위임. NAPI 로 전달하면 Zig 가
   // Record 형태만 받으므로 type mismatch — 명시 삭제.
   if (Array.isArray(napiOptions.alias)) delete napiOptions.alias;
   // manualChunks 는 `_manualChunks` 전용 슬롯으로 재전달 (plugin dispatcher 패턴).
@@ -1804,7 +2071,7 @@ function writeOutputFiles(result: BuildResult, options: BuildOptions): void {
 
 /**
  * 번들링을 비동기적으로 실행한다. 이벤트 루프를 블로킹하지 않음.
- * JS 플러그인은 이 함수에서만 지원됨.
+ * JS 플러그인의 Promise/async hook 은 이 함수에서 지원됨.
  *
  * Plugin lifecycle 호출 순서: buildStart → (NAPI build) → buildEnd → write → closeBundle.
  * `buildEnd` 는 NAPI 실패 시에도 호출되며 error 인자가 전달된다 (Rollup 동일).
@@ -1848,29 +2115,31 @@ export async function build(options: BuildOptions): Promise<BuildResult> {
 
 /**
  * 번들링을 동기적으로 실행한다.
- * 주의: JS 플러그인은 build() (async) / watch()에서만 지원됨.
+ * JS 플러그인은 sync hook만 지원한다. Promise/async hook은 plugin_error로 실패한다.
  */
 export function buildSync(options: BuildOptions): BuildResult {
   if (!native) throw new Error('@zntc/core: not initialized. Call init() first.');
   if (!options.entryPoints?.length) throw new Error('@zntc/core: entryPoints is required');
   validateTsConfigRaw(options.tsconfigRaw);
-  if (options.plugins?.length) {
-    throw new Error(
-      '@zntc/core: plugins are only supported with build() (async). Use build() instead of buildSync().',
-    );
-  }
-  // Array 형태 alias 는 host RegExp 위임이 plugin hook 기반이라 buildSync 미지원.
-  if (Array.isArray(options.alias)) {
-    throw new Error(
-      '@zntc/core: array-form alias (with RegExp / Vite-style) requires async build(). Use Record<string, string> form for buildSync, or call build() instead.',
-    );
-  }
 
   const { napiOptions, cleanup } = prepareNapiOptions(options);
+  const dispatcher = resolveDispatcher(options, 'sync');
+  if (dispatcher) napiOptions._pluginDispatcherSync = dispatcher;
   try {
     const result: BuildResult = native.buildSync(napiOptions);
+    if (dispatcher) {
+      for (const failure of dispatcher.takeLifecycleFailures()) {
+        result.errors.push(pluginFailureToDiagnostic(failure));
+      }
+    }
     postProcessCssOutputs(result, options);
     writeOutputFiles(result, options);
+    if (dispatcher) {
+      dispatcher('closeBundle', undefined, null);
+      for (const failure of dispatcher.takeLifecycleFailures()) {
+        result.errors.push(pluginFailureToDiagnostic(failure));
+      }
+    }
     return result;
   } finally {
     cleanup();
@@ -2113,82 +2382,82 @@ export function vitePlugin(rollupPlugin: RollupPlugin): ZntcPlugin {
       const context = createRollupPluginContext();
       if (rollupPlugin.resolveId) {
         const hook = rollupPlugin.resolveId;
-        build.onResolve({ filter: /.*/ }, async (args) => {
-          const result = await hook.call(context, args.path, args.importer);
-          if (result == null) return null;
-          if (typeof result === 'string') return { path: result };
-          if (typeof result === 'object' && 'id' in result) {
-            return { path: result.id, external: result.external };
-          }
-          return null;
+        build.onResolve({ filter: /.*/ }, (args) => {
+          const result = hook.call(context, args.path, args.importer);
+          return mapMaybePromise(result, (result) => {
+            if (result == null) return null;
+            if (typeof result === 'string') return { path: result };
+            if (typeof result === 'object' && 'id' in result) {
+              return { path: result.id, external: result.external };
+            }
+            return null;
+          });
         });
       }
 
       if (rollupPlugin.load) {
         const hook = rollupPlugin.load;
-        build.onLoad({ filter: /.*/ }, async (args) => {
-          const result = await hook.call(context, args.path);
-          if (result == null) return null;
-          if (typeof result === 'string') return { contents: result };
-          if (typeof result === 'object' && 'code' in result) {
-            return { contents: result.code, map: result.map };
-          }
-          return null;
+        build.onLoad({ filter: /.*/ }, (args) => {
+          const result = hook.call(context, args.path);
+          return mapMaybePromise(result, (result) => {
+            if (result == null) return null;
+            if (typeof result === 'string') return { contents: result };
+            if (typeof result === 'object' && 'code' in result) {
+              return { contents: result.code, map: result.map };
+            }
+            return null;
+          });
         });
       }
 
       if (rollupPlugin.transform) {
         const hook = rollupPlugin.transform;
-        build.onTransform({ filter: /.*/ }, async (args) => {
-          const result = await hook.call(context, args.code, args.path);
-          if (result == null) return null;
-          if (typeof result === 'string') return { code: result };
-          if (typeof result === 'object' && 'code' in result) {
-            return { code: result.code, map: result.map };
-          }
-          return null;
+        build.onTransform({ filter: /.*/ }, (args) => {
+          const result = hook.call(context, args.code, args.path);
+          return mapMaybePromise(result, (result) => {
+            if (result == null) return null;
+            if (typeof result === 'string') return { code: result };
+            if (typeof result === 'object' && 'code' in result) {
+              return { code: result.code, map: result.map };
+            }
+            return null;
+          });
         });
       }
 
       if (rollupPlugin.renderChunk) {
         const hook = rollupPlugin.renderChunk;
-        build.onRenderChunk({ filter: /.*/ }, async (args) => {
-          const result = await hook.call(context, args.code, args.chunk);
-          if (result == null) return null;
-          if (typeof result === 'string') return { code: result };
-          if (typeof result === 'object' && 'code' in result) {
-            return { code: result.code };
-          }
-          return null;
+        build.onRenderChunk({ filter: /.*/ }, (args) => {
+          const result = hook.call(context, args.code, args.chunk);
+          return mapMaybePromise(result, (result) => {
+            if (result == null) return null;
+            if (typeof result === 'string') return { code: result };
+            if (typeof result === 'object' && 'code' in result) {
+              return { code: result.code };
+            }
+            return null;
+          });
         });
       }
 
       if (rollupPlugin.generateBundle) {
         const hook = rollupPlugin.generateBundle;
-        build.onGenerateBundle(async (outputs) => {
-          await hook.call(context, outputs);
-        });
+        build.onGenerateBundle((outputs) => hook.call(context, outputs));
       }
 
       if (rollupPlugin.buildStart) {
         const hook = rollupPlugin.buildStart;
-        build.onBuildStart(async () => {
-          await hook.call(context);
-        });
+        build.onBuildStart(() => hook.call(context));
       }
 
       if (rollupPlugin.buildEnd) {
         const hook = rollupPlugin.buildEnd;
-        build.onBuildEnd(async (err) => {
-          await hook.call(context, err);
-        });
+        build.onBuildEnd((err) => hook.call(context, err));
       }
 
       if (rollupPlugin.closeBundle) {
         const hook = rollupPlugin.closeBundle;
-        build.onCloseBundle(async () => {
-          await hook.call(context);
-        });
+        build.onCloseBundle(() => hook.call(context));
       }
     },
   };

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1492,19 +1492,9 @@ const NapiPlugin = struct {
         const ctx: *CallContext = @ptrCast(@alignCast(data.?));
 
         // JS dispatcher 호출: dispatcher(hookName, arg1, arg2)
+        // HookType tag 이름이 dispatcher 가 기대하는 string 과 동일.
+        const hook_name: []const u8 = @tagName(ctx.hook);
         var hook_str: c.napi_value = undefined;
-        const hook_name: []const u8 = switch (ctx.hook) {
-            .resolveId => "resolveId",
-            .load => "load",
-            .transform => "transform",
-            .renderChunk => "renderChunk",
-            .generateBundle => "generateBundle",
-            .astFunction => "astFunction",
-            .resolveContext => "resolveContext",
-            .buildStart => "buildStart",
-            .buildEnd => "buildEnd",
-            .closeBundle => "closeBundle",
-        };
         _ = c.napi_create_string_utf8(env, hook_name.ptr, hook_name.len, &hook_str);
 
         var js_arg1: c.napi_value = undefined;
@@ -1862,21 +1852,6 @@ const NapiSyncPlugin = struct {
         }
     }
 
-    fn hookName(hook: NapiPlugin.HookType) []const u8 {
-        return switch (hook) {
-            .resolveId => "resolveId",
-            .load => "load",
-            .transform => "transform",
-            .renderChunk => "renderChunk",
-            .generateBundle => "generateBundle",
-            .astFunction => "astFunction",
-            .resolveContext => "resolveContext",
-            .buildStart => "buildStart",
-            .buildEnd => "buildEnd",
-            .closeBundle => "closeBundle",
-        };
-    }
-
     fn callHookFull(
         self: *NapiSyncPlugin,
         hook: NapiPlugin.HookType,
@@ -1889,7 +1864,7 @@ const NapiSyncPlugin = struct {
             return null;
         }
 
-        const hook_name = hookName(hook);
+        const hook_name = @tagName(hook);
         var hook_str: c.napi_value = undefined;
         _ = c.napi_create_string_utf8(self.env, hook_name.ptr, hook_name.len, &hook_str);
 

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -849,10 +849,33 @@ fn napiBuildSync(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.nap
         owned_string_arrays.deinit(native_alloc);
     }
 
-    const bundle_opts = parseBuildOptions(env, argv[0], &owned_strings, &owned_string_arrays) orelse {
+    var bundle_opts = parseBuildOptions(env, argv[0], &owned_strings, &owned_string_arrays) orelse {
         return throwError(env, "invalid build options (entryPoints required)");
     };
     defer freeOptionsTypedSlices(&bundle_opts);
+
+    var sync_plugin: ?*NapiSyncPlugin = null;
+    defer if (sync_plugin) |sp| sp.deinit();
+    var sync_plugin_storage: [1]Plugin = undefined;
+    if (getNamedProperty(env, argv[0], "_pluginDispatcherSync")) |dispatcher_fn| {
+        const sp = native_alloc.create(NapiSyncPlugin) catch return throwError(env, "OutOfMemory");
+        sp.* = .{
+            .name = native_alloc.dupe(u8, "js-plugin") catch {
+                native_alloc.destroy(sp);
+                return throwError(env, "OutOfMemory");
+            },
+            .env = env,
+            .callback_ref = undefined,
+        };
+        if (c.napi_create_reference(env, dispatcher_fn, 1, &sp.callback_ref) != c.napi_ok) {
+            native_alloc.free(sp.name);
+            native_alloc.destroy(sp);
+            return throwError(env, "failed to create plugin reference");
+        }
+        sync_plugin = sp;
+        sync_plugin_storage[0] = sp.toPlugin();
+        bundle_opts.plugins = sync_plugin_storage[0..1];
+    }
 
     var bundler = Bundler.init(native_alloc, bundle_opts);
     var result = bundler.bundle() catch |err| {
@@ -1802,6 +1825,306 @@ const NapiPlugin = struct {
 
     fn deinit(self: *NapiPlugin) void {
         _ = c.napi_release_threadsafe_function(self.tsfn, c.napi_tsfn_release);
+        native_alloc.free(self.name);
+        native_alloc.destroy(self);
+    }
+};
+
+// ─── NapiSyncPlugin: buildSync() sync-only JS plugin bridge ───
+// buildSync() 은 NAPI main thread 를 블로킹하므로 TSFN으로 main thread 에 재진입할 수 없다.
+// sync dispatcher 를 직접 호출하고 Promise/thenable 은 plugin_error 로 즉시 실패시킨다.
+
+const NapiSyncPlugin = struct {
+    name: []const u8,
+    env: c.napi_env,
+    callback_ref: c.napi_ref,
+
+    fn makeFailure(
+        plugin_name: []const u8,
+        hook_name: []const u8,
+        message: []const u8,
+        file_path: ?[]const u8,
+    ) NapiPlugin.PluginResponse {
+        return .{
+            .is_failure = true,
+            .failure_plugin_name = native_alloc.dupe(u8, plugin_name) catch null,
+            .failure_hook_name = native_alloc.dupe(u8, hook_name) catch null,
+            .failure_message = native_alloc.dupe(u8, message) catch null,
+            .failure_file = if (file_path) |fp| native_alloc.dupe(u8, fp) catch null else null,
+        };
+    }
+
+    fn clearPendingException(env: c.napi_env) void {
+        var pending: bool = false;
+        if (c.napi_is_exception_pending(env, &pending) == c.napi_ok and pending) {
+            var exception: c.napi_value = undefined;
+            _ = c.napi_get_and_clear_last_exception(env, &exception);
+        }
+    }
+
+    fn hookName(hook: NapiPlugin.HookType) []const u8 {
+        return switch (hook) {
+            .resolveId => "resolveId",
+            .load => "load",
+            .transform => "transform",
+            .renderChunk => "renderChunk",
+            .generateBundle => "generateBundle",
+            .astFunction => "astFunction",
+            .resolveContext => "resolveContext",
+            .buildStart => "buildStart",
+            .buildEnd => "buildEnd",
+            .closeBundle => "closeBundle",
+        };
+    }
+
+    fn callHookFull(
+        self: *NapiSyncPlugin,
+        hook: NapiPlugin.HookType,
+        arg1: []const u8,
+        arg2: ?[]const u8,
+        files: ?[]const bundler_mod.emitter.OutputFile,
+    ) ?NapiPlugin.PluginResponse {
+        var js_callback: c.napi_value = undefined;
+        if (c.napi_get_reference_value(self.env, self.callback_ref, &js_callback) != c.napi_ok) {
+            return null;
+        }
+
+        const hook_name = hookName(hook);
+        var hook_str: c.napi_value = undefined;
+        _ = c.napi_create_string_utf8(self.env, hook_name.ptr, hook_name.len, &hook_str);
+
+        var js_arg1: c.napi_value = undefined;
+        if (files) |output_files| {
+            _ = c.napi_create_array_with_length(self.env, output_files.len, &js_arg1);
+            for (output_files, 0..) |file, i| {
+                var js_file: c.napi_value = undefined;
+                _ = c.napi_create_object(self.env, &js_file);
+                var js_path: c.napi_value = undefined;
+                _ = c.napi_create_string_utf8(self.env, file.path.ptr, file.path.len, &js_path);
+                _ = c.napi_set_named_property(self.env, js_file, "path", js_path);
+                var js_text: c.napi_value = undefined;
+                _ = c.napi_create_string_utf8(self.env, file.contents.ptr, file.contents.len, &js_text);
+                _ = c.napi_set_named_property(self.env, js_file, "text", js_text);
+                _ = c.napi_set_element(self.env, js_arg1, @intCast(i), js_file);
+            }
+        } else {
+            _ = c.napi_create_string_utf8(self.env, arg1.ptr, arg1.len, &js_arg1);
+        }
+
+        var js_arg2: c.napi_value = undefined;
+        if (arg2) |a2| {
+            _ = c.napi_create_string_utf8(self.env, a2.ptr, a2.len, &js_arg2);
+        } else {
+            _ = c.napi_get_null(self.env, &js_arg2);
+        }
+
+        var js_result: c.napi_value = undefined;
+        const args = [_]c.napi_value{ hook_str, js_arg1, js_arg2 };
+        var js_undefined: c.napi_value = undefined;
+        _ = c.napi_get_undefined(self.env, &js_undefined);
+        if (c.napi_call_function(self.env, js_undefined, js_callback, 3, &args, &js_result) != c.napi_ok) {
+            clearPendingException(self.env);
+            return makeFailure(self.name, hook_name, "Plugin hook failed", arg2);
+        }
+
+        var is_promise: bool = false;
+        _ = c.napi_is_promise(self.env, js_result, &is_promise);
+        if (is_promise) {
+            return makeFailure(
+                self.name,
+                hook_name,
+                "buildSync() does not support async plugin hooks. Return a synchronous value or use build() instead.",
+                arg2,
+            );
+        }
+
+        return NapiPlugin.parseJsResult(self.env, js_result);
+    }
+
+    fn callHook(self: *NapiSyncPlugin, hook: NapiPlugin.HookType, arg1: []const u8, arg2: ?[]const u8) ?NapiPlugin.PluginResponse {
+        return self.callHookFull(hook, arg1, arg2, null);
+    }
+
+    fn failWithResponse(self: *NapiSyncPlugin, resp: NapiPlugin.PluginResponse, alloc: std.mem.Allocator) PluginError {
+        const failure = plugin_mod.PluginFailure.init(
+            alloc,
+            resp.failure_plugin_name orelse self.name,
+            resp.failure_hook_name orelse "plugin",
+            resp.failure_message orelse "Plugin hook failed",
+            resp.failure_file orelse "",
+            resp.failure_line,
+            resp.failure_column,
+        ) catch return error.OutOfMemory;
+        plugin_mod.setLastPluginFailure(failure);
+        return error.PluginFailed;
+    }
+
+    fn callCodeHook(self: *NapiSyncPlugin, hook: NapiPlugin.HookType, arg1: []const u8, arg2: ?[]const u8, alloc: std.mem.Allocator) PluginError!?[]const u8 {
+        const resp = self.callHook(hook, arg1, arg2) orelse return null;
+        defer NapiPlugin.freeResponseFields(resp);
+        if (resp.is_failure) return self.failWithResponse(resp, alloc);
+        if (resp.code) |result_code| {
+            const result = alloc.dupe(u8, result_code) catch return error.OutOfMemory;
+            try NapiPlugin.setResponseSourceMaps(resp, alloc);
+            return result;
+        }
+        return null;
+    }
+
+    fn pluginResolveId(ctx: ?*anyopaque, specifier: []const u8, importer: ?[]const u8, alloc: std.mem.Allocator) PluginError!?plugin_mod.ResolvedModule {
+        const self: *NapiSyncPlugin = @ptrCast(@alignCast(ctx.?));
+        const resp = self.callHook(.resolveId, specifier, importer) orelse return null;
+        defer NapiPlugin.freeResponseFields(resp);
+        if (resp.is_failure) return self.failWithResponse(resp, alloc);
+
+        if (resp.is_disabled) {
+            const id_path = resp.resolved_path orelse specifier;
+            return .{ .disabled = .{
+                .path = alloc.dupe(u8, id_path) catch return error.OutOfMemory,
+                .module_type = .js,
+            } };
+        }
+
+        if (resp.resolved_path) |path| {
+            return .{ .file = .{
+                .path = alloc.dupe(u8, path) catch return error.OutOfMemory,
+                .module_type = .js,
+            } };
+        }
+        return null;
+    }
+
+    fn pluginLoad(ctx: ?*anyopaque, path: []const u8, alloc: std.mem.Allocator) PluginError!?plugin_mod.LoadResult {
+        const self: *NapiSyncPlugin = @ptrCast(@alignCast(ctx.?));
+        const resp = self.callHook(.load, path, null) orelse return null;
+        defer NapiPlugin.freeResponseFields(resp);
+        if (resp.is_failure) return self.failWithResponse(resp, alloc);
+        const result_code = resp.code orelse return null;
+        const contents = alloc.dupe(u8, result_code) catch return error.OutOfMemory;
+        try NapiPlugin.setResponseSourceMaps(resp, alloc);
+        return .{ .contents = contents, .loader = resp.loader_override, .module_type = resp.loader_module_type };
+    }
+
+    fn pluginTransform(ctx: ?*anyopaque, code: []const u8, id: []const u8, alloc: std.mem.Allocator) PluginError!?[]const u8 {
+        const self: *NapiSyncPlugin = @ptrCast(@alignCast(ctx.?));
+        return self.callCodeHook(.transform, code, id, alloc);
+    }
+
+    fn pluginRenderChunk(ctx: ?*anyopaque, code: []const u8, chunk_name: []const u8, alloc: std.mem.Allocator) PluginError!?[]const u8 {
+        const self: *NapiSyncPlugin = @ptrCast(@alignCast(ctx.?));
+        return self.callCodeHook(.renderChunk, code, chunk_name, alloc);
+    }
+
+    fn pluginGenerateBundle(ctx: ?*anyopaque, output_files: []const bundler_mod.emitter.OutputFile) void {
+        const self: *NapiSyncPlugin = @ptrCast(@alignCast(ctx.?));
+        if (self.callHookFull(.generateBundle, "", null, output_files)) |resp| {
+            NapiPlugin.freeResponseFields(resp);
+        }
+    }
+
+    fn pluginBuildStart(ctx: ?*anyopaque) PluginError!void {
+        const self: *NapiSyncPlugin = @ptrCast(@alignCast(ctx.?));
+        const resp = self.callHook(.buildStart, "", null) orelse return;
+        defer NapiPlugin.freeResponseFields(resp);
+        if (resp.is_failure) return self.failWithResponse(resp, native_alloc);
+    }
+
+    fn pluginBuildEnd(ctx: ?*anyopaque, build_error: ?*const bundler_mod.types.BundlerDiagnostic) PluginError!void {
+        const self: *NapiSyncPlugin = @ptrCast(@alignCast(ctx.?));
+        const msg = if (build_error) |d| d.message else "";
+        const resp = self.callHook(.buildEnd, msg, null) orelse return;
+        defer NapiPlugin.freeResponseFields(resp);
+        if (resp.is_failure) return self.failWithResponse(resp, native_alloc);
+    }
+
+    fn pluginResolveContext(
+        ctx: ?*anyopaque,
+        dir: []const u8,
+        recursive: bool,
+        filter_pattern: ?[]const u8,
+        filter_flags: ?[]const u8,
+        importer: []const u8,
+        alloc: std.mem.Allocator,
+    ) PluginError!?[]const []const u8 {
+        const self: *NapiSyncPlugin = @ptrCast(@alignCast(ctx.?));
+
+        var json_buf: std.ArrayList(u8) = .empty;
+        defer json_buf.deinit(native_alloc);
+        json_buf.append(native_alloc, '{') catch return null;
+        json_buf.appendSlice(native_alloc, "\"dir\":") catch return null;
+        NapiPlugin.appendJsonString(&json_buf, native_alloc, dir) catch return null;
+        json_buf.appendSlice(native_alloc, ",\"recursive\":") catch return null;
+        json_buf.appendSlice(native_alloc, if (recursive) "true" else "false") catch return null;
+        if (filter_pattern) |fp| {
+            json_buf.appendSlice(native_alloc, ",\"filter\":") catch return null;
+            NapiPlugin.appendJsonString(&json_buf, native_alloc, fp) catch return null;
+        }
+        if (filter_flags) |ff| {
+            json_buf.appendSlice(native_alloc, ",\"flags\":") catch return null;
+            NapiPlugin.appendJsonString(&json_buf, native_alloc, ff) catch return null;
+        }
+        json_buf.appendSlice(native_alloc, ",\"importer\":") catch return null;
+        NapiPlugin.appendJsonString(&json_buf, native_alloc, importer) catch return null;
+        json_buf.append(native_alloc, '}') catch return null;
+
+        const resp = self.callHookFull(.resolveContext, json_buf.items, null, null) orelse return null;
+        defer NapiPlugin.freeResponseFields(resp);
+        if (resp.is_failure) return self.failWithResponse(resp, alloc);
+
+        const matches = resp.context_matches orelse return null;
+        const out = alloc.alloc([]const u8, matches.len) catch return null;
+        for (matches, 0..) |s, i| {
+            out[i] = alloc.dupe(u8, s) catch {
+                for (out[0..i]) |prev| alloc.free(prev);
+                alloc.free(out);
+                return null;
+            };
+        }
+        return out;
+    }
+
+    fn pluginAstFunction(ctx: ?*anyopaque, api: *NapiPlugin.AstTransformCtx, func: NapiPlugin.FunctionInfo) PluginError!void {
+        const self: *NapiSyncPlugin = @ptrCast(@alignCast(ctx.?));
+
+        const json = serializeFunctionInfo(api, func) catch return;
+        defer native_alloc.free(json);
+
+        const resp = self.callHook(.astFunction, json, null) orelse return;
+        defer NapiPlugin.freeResponseFields(resp);
+        if (resp.is_failure) return self.failWithResponse(resp, native_alloc);
+
+        if (resp.strip_directive != null) {
+            _ = api.stripDirective(func.body_idx) catch return;
+        }
+        if (resp.trailing_code) |codes| {
+            for (codes) |code_str| {
+                const stmts = api.parseAndInjectStatements(code_str) catch continue;
+                for (stmts) |stmt| {
+                    api.addTrailingStatement(stmt) catch continue;
+                }
+            }
+        }
+    }
+
+    fn toPlugin(self: *NapiSyncPlugin) Plugin {
+        return .{
+            .name = self.name,
+            .context = @ptrCast(self),
+            .resolveId = pluginResolveId,
+            .load = pluginLoad,
+            .transform = pluginTransform,
+            .renderChunk = pluginRenderChunk,
+            .generateBundle = pluginGenerateBundle,
+            .onFunction = pluginAstFunction,
+            .resolveContext = pluginResolveContext,
+            .buildStart = pluginBuildStart,
+            .buildEnd = pluginBuildEnd,
+            .closeBundle = null,
+        };
+    }
+
+    fn deinit(self: *NapiSyncPlugin) void {
+        _ = c.napi_delete_reference(self.env, self.callback_ref);
         native_alloc.free(self.name);
         native_alloc.destroy(self);
     }


### PR DESCRIPTION
## 먼저 추가한 실패 테스트
- `buildSync()`에서 `onResolve` / `onLoad` / `onTransform` sync 플러그인이 동작해야 함
- `buildSync()`에서 `vitePlugin()`의 sync `resolveId` / `load` / `transform` hook이 동작해야 함
- `buildSync()`에서 Promise 반환 hook은 `plugin_error`로 실패하고 `build()` 사용 안내를 포함해야 함
- array-form alias가 `buildSync()`에서도 sync dispatcher를 통해 동작해야 함

## 구현 요약
- `buildSync()`의 JS plugin / array-form alias 금지 guard를 제거하고 sync-only dispatcher를 추가했습니다.
- sync dispatcher는 기존 async dispatcher 등록 로직을 공유하되 Promise/thenable 반환을 즉시 `plugin_error` payload로 정규화합니다.
- NAPI `buildSync()` 경로에 main thread 직접 호출형 `NapiSyncPlugin` bridge를 추가해 TSFN 없이 sync JS hook을 실행합니다.
- `vitePlugin()` wrapper가 sync hook 결과는 Promise로 감싸지 않도록 변경해 `buildSync()`에서도 Rollup-style sync hook을 그대로 사용할 수 있게 했습니다.
- async/sync dispatcher overload를 분리해 declaration build에서 watch의 async dispatcher 반환 타입이 보존되도록 했습니다.

## 검증
- `bun test packages/core/index.test.ts --test-name-pattern "buildSync: onResolve|buildSync: vitePlugin|Promise 반환 plugin hook|alias array: buildSync"`
- `bun test packages/core/index.test.ts`
- `zig build test --summary all`
- `zig build napi`
- `bun run --cwd packages/core build:js`
- `bun run --cwd packages/core build:dts`
- `cd packages/core && bun run build:js && bun run build:dts`
- `bun run fmt:check`
- `zig fmt --check packages/core/src/napi_entry.zig`
- `git diff --check`
- `bun run lint` (기존 warning 21개, error 0)
- `git push` pre-push hook (`zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`)

Refs #1902
