### PR TITLE
refactor(plugin): TLS 채널을 HookContext out-param 으로 대체

### DIFF
--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -1425,7 +1425,7 @@ const NapiPlugin = struct {
         if (resp.failure_file) |s| native_alloc.free(s);
     }
 
-    fn setResponseSourceMaps(resp: PluginResponse, alloc: std.mem.Allocator) PluginError!void {
+    fn setResponseSourceMaps(resp: PluginResponse, alloc: std.mem.Allocator, hook_ctx: *plugin_mod.HookContext) PluginError!void {
         const maps = resp.source_maps orelse return;
         if (maps.len == 0) return;
         // alloc 은 caller 의 parse_arena — 개별 free 불가 (CLAUDE.md memory ownership).
@@ -1434,10 +1434,10 @@ const NapiPlugin = struct {
         for (maps, 0..) |map_json, i| {
             copied[i] = alloc.dupe(u8, map_json) catch return error.OutOfMemory;
         }
-        plugin_mod.setLastTransformSourceMaps(copied);
+        hook_ctx.source_maps = copied;
     }
 
-    fn failWithResponse(self: *NapiPlugin, resp: PluginResponse, alloc: std.mem.Allocator) PluginError {
+    fn failWithResponse(self: *NapiPlugin, resp: PluginResponse, alloc: std.mem.Allocator, hook_ctx: *plugin_mod.HookContext) PluginError {
         const failure = plugin_mod.PluginFailure.init(
             alloc,
             resp.failure_plugin_name orelse self.name,
@@ -1447,7 +1447,7 @@ const NapiPlugin = struct {
             resp.failure_line,
             resp.failure_column,
         ) catch return error.OutOfMemory;
-        plugin_mod.setLastPluginFailure(failure);
+        hook_ctx.failure = failure;
         return error.PluginFailed;
     }
 
@@ -1595,23 +1595,23 @@ const NapiPlugin = struct {
     // ─── Plugin 인터페이스 구현 ───
 
     /// code를 반환하는 훅 공통 구현 (transform, renderChunk, load)
-    fn callCodeHook(self: *NapiPlugin, hook: HookType, arg1: []const u8, arg2: ?[]const u8, alloc: std.mem.Allocator) PluginError!?[]const u8 {
+    fn callCodeHook(self: *NapiPlugin, hook: HookType, arg1: []const u8, arg2: ?[]const u8, alloc: std.mem.Allocator, hook_ctx: *plugin_mod.HookContext) PluginError!?[]const u8 {
         const resp = self.callHook(hook, arg1, arg2) orelse return null;
         defer freeResponseFields(resp);
-        if (resp.is_failure) return self.failWithResponse(resp, alloc);
+        if (resp.is_failure) return self.failWithResponse(resp, alloc, hook_ctx);
         if (resp.code) |result_code| {
             const result = alloc.dupe(u8, result_code) catch return error.OutOfMemory;
-            try setResponseSourceMaps(resp, alloc);
+            try setResponseSourceMaps(resp, alloc, hook_ctx);
             return result;
         }
         return null;
     }
 
-    fn pluginResolveId(ctx: ?*anyopaque, specifier: []const u8, importer: ?[]const u8, alloc: std.mem.Allocator) PluginError!?plugin_mod.ResolvedModule {
+    fn pluginResolveId(ctx: ?*anyopaque, specifier: []const u8, importer: ?[]const u8, alloc: std.mem.Allocator, hook_ctx: *plugin_mod.HookContext) PluginError!?plugin_mod.ResolvedModule {
         const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
         const resp = self.callHook(.resolveId, specifier, importer) orelse return null;
         defer freeResponseFields(resp);
-        if (resp.is_failure) return self.failWithResponse(resp, alloc);
+        if (resp.is_failure) return self.failWithResponse(resp, alloc, hook_ctx);
 
         // disabled: 빈 모듈로 처리. path는 식별용 — resolved_path 또는 specifier 그대로.
         // Metro `{ type: 'empty' }` 매핑, webpack `resolve.fallback: false`와 동등.
@@ -1632,25 +1632,25 @@ const NapiPlugin = struct {
         return null;
     }
 
-    fn pluginLoad(ctx: ?*anyopaque, path: []const u8, alloc: std.mem.Allocator) PluginError!?plugin_mod.LoadResult {
+    fn pluginLoad(ctx: ?*anyopaque, path: []const u8, alloc: std.mem.Allocator, hook_ctx: *plugin_mod.HookContext) PluginError!?plugin_mod.LoadResult {
         const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
         const resp = self.callHook(.load, path, null) orelse return null;
         defer freeResponseFields(resp);
-        if (resp.is_failure) return self.failWithResponse(resp, alloc);
+        if (resp.is_failure) return self.failWithResponse(resp, alloc, hook_ctx);
         const result_code = resp.code orelse return null;
         const contents = alloc.dupe(u8, result_code) catch return error.OutOfMemory;
-        try setResponseSourceMaps(resp, alloc);
+        try setResponseSourceMaps(resp, alloc, hook_ctx);
         return .{ .contents = contents, .loader = resp.loader_override, .module_type = resp.loader_module_type };
     }
 
-    fn pluginTransform(ctx: ?*anyopaque, code: []const u8, id: []const u8, alloc: std.mem.Allocator) PluginError!?[]const u8 {
+    fn pluginTransform(ctx: ?*anyopaque, code: []const u8, id: []const u8, alloc: std.mem.Allocator, hook_ctx: *plugin_mod.HookContext) PluginError!?[]const u8 {
         const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
-        return self.callCodeHook(.transform, code, id, alloc);
+        return self.callCodeHook(.transform, code, id, alloc, hook_ctx);
     }
 
-    fn pluginRenderChunk(ctx: ?*anyopaque, code: []const u8, chunk_name: []const u8, alloc: std.mem.Allocator) PluginError!?[]const u8 {
+    fn pluginRenderChunk(ctx: ?*anyopaque, code: []const u8, chunk_name: []const u8, alloc: std.mem.Allocator, hook_ctx: *plugin_mod.HookContext) PluginError!?[]const u8 {
         const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
-        return self.callCodeHook(.renderChunk, code, chunk_name, alloc);
+        return self.callCodeHook(.renderChunk, code, chunk_name, alloc, hook_ctx);
     }
 
     fn pluginGenerateBundle(ctx: ?*anyopaque, output_files: []const bundler_mod.emitter.OutputFile) void {
@@ -1660,14 +1660,14 @@ const NapiPlugin = struct {
         }
     }
 
-    fn pluginBuildStart(ctx: ?*anyopaque) PluginError!void {
+    fn pluginBuildStart(ctx: ?*anyopaque, hook_ctx: *plugin_mod.HookContext) PluginError!void {
         const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
         const resp = self.callHook(.buildStart, "", null) orelse return;
         defer freeResponseFields(resp);
-        if (resp.is_failure) return error.PluginFailed;
+        if (resp.is_failure) return self.failWithResponse(resp, native_alloc, hook_ctx);
     }
 
-    fn pluginBuildEnd(ctx: ?*anyopaque, build_error: ?*const bundler_mod.types.BundlerDiagnostic) PluginError!void {
+    fn pluginBuildEnd(ctx: ?*anyopaque, build_error: ?*const bundler_mod.types.BundlerDiagnostic, hook_ctx: *plugin_mod.HookContext) PluginError!void {
         const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
         // Phase 1 minimal forward — message string 만 JS Error 로 wrap.
         // code/severity/file_path/span/step/suggestion 손실은 follow-up 으로 RollupError 호환
@@ -1675,14 +1675,14 @@ const NapiPlugin = struct {
         const msg = if (build_error) |d| d.message else "";
         const resp = self.callHook(.buildEnd, msg, null) orelse return;
         defer freeResponseFields(resp);
-        if (resp.is_failure) return error.PluginFailed;
+        if (resp.is_failure) return self.failWithResponse(resp, native_alloc, hook_ctx);
     }
 
-    fn pluginCloseBundle(ctx: ?*anyopaque) PluginError!void {
+    fn pluginCloseBundle(ctx: ?*anyopaque, hook_ctx: *plugin_mod.HookContext) PluginError!void {
         const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
         const resp = self.callHook(.closeBundle, "", null) orelse return;
         defer freeResponseFields(resp);
-        if (resp.is_failure) return error.PluginFailed;
+        if (resp.is_failure) return self.failWithResponse(resp, native_alloc, hook_ctx);
     }
 
     /// JSON string field 인코딩 — `"` `\` 와 control char escape.
@@ -1716,6 +1716,7 @@ const NapiPlugin = struct {
         filter_flags: ?[]const u8,
         importer: []const u8,
         alloc: std.mem.Allocator,
+        hook_ctx: *plugin_mod.HookContext,
     ) PluginError!?[]const []const u8 {
         const self: *NapiPlugin = @ptrCast(@alignCast(ctx.?));
 
@@ -1741,7 +1742,7 @@ const NapiPlugin = struct {
 
         const resp = self.callHookFull(.resolveContext, json_buf.items, null, null) orelse return null;
         defer freeResponseFields(resp);
-        if (resp.is_failure) return self.failWithResponse(resp, alloc);
+        if (resp.is_failure) return self.failWithResponse(resp, alloc, hook_ctx);
 
         const matches = resp.context_matches orelse return null;
 
@@ -1920,7 +1921,7 @@ const NapiSyncPlugin = struct {
         return self.callHookFull(hook, arg1, arg2, null);
     }
 
-    fn failWithResponse(self: *NapiSyncPlugin, resp: NapiPlugin.PluginResponse, alloc: std.mem.Allocator) PluginError {
+    fn failWithResponse(self: *NapiSyncPlugin, resp: NapiPlugin.PluginResponse, alloc: std.mem.Allocator, hook_ctx: *plugin_mod.HookContext) PluginError {
         const failure = plugin_mod.PluginFailure.init(
             alloc,
             resp.failure_plugin_name orelse self.name,
@@ -1930,27 +1931,27 @@ const NapiSyncPlugin = struct {
             resp.failure_line,
             resp.failure_column,
         ) catch return error.OutOfMemory;
-        plugin_mod.setLastPluginFailure(failure);
+        hook_ctx.failure = failure;
         return error.PluginFailed;
     }
 
-    fn callCodeHook(self: *NapiSyncPlugin, hook: NapiPlugin.HookType, arg1: []const u8, arg2: ?[]const u8, alloc: std.mem.Allocator) PluginError!?[]const u8 {
+    fn callCodeHook(self: *NapiSyncPlugin, hook: NapiPlugin.HookType, arg1: []const u8, arg2: ?[]const u8, alloc: std.mem.Allocator, hook_ctx: *plugin_mod.HookContext) PluginError!?[]const u8 {
         const resp = self.callHook(hook, arg1, arg2) orelse return null;
         defer NapiPlugin.freeResponseFields(resp);
-        if (resp.is_failure) return self.failWithResponse(resp, alloc);
+        if (resp.is_failure) return self.failWithResponse(resp, alloc, hook_ctx);
         if (resp.code) |result_code| {
             const result = alloc.dupe(u8, result_code) catch return error.OutOfMemory;
-            try NapiPlugin.setResponseSourceMaps(resp, alloc);
+            try NapiPlugin.setResponseSourceMaps(resp, alloc, hook_ctx);
             return result;
         }
         return null;
     }
 
-    fn pluginResolveId(ctx: ?*anyopaque, specifier: []const u8, importer: ?[]const u8, alloc: std.mem.Allocator) PluginError!?plugin_mod.ResolvedModule {
+    fn pluginResolveId(ctx: ?*anyopaque, specifier: []const u8, importer: ?[]const u8, alloc: std.mem.Allocator, hook_ctx: *plugin_mod.HookContext) PluginError!?plugin_mod.ResolvedModule {
         const self: *NapiSyncPlugin = @ptrCast(@alignCast(ctx.?));
         const resp = self.callHook(.resolveId, specifier, importer) orelse return null;
         defer NapiPlugin.freeResponseFields(resp);
-        if (resp.is_failure) return self.failWithResponse(resp, alloc);
+        if (resp.is_failure) return self.failWithResponse(resp, alloc, hook_ctx);
 
         if (resp.is_disabled) {
             const id_path = resp.resolved_path orelse specifier;
@@ -1969,25 +1970,25 @@ const NapiSyncPlugin = struct {
         return null;
     }
 
-    fn pluginLoad(ctx: ?*anyopaque, path: []const u8, alloc: std.mem.Allocator) PluginError!?plugin_mod.LoadResult {
+    fn pluginLoad(ctx: ?*anyopaque, path: []const u8, alloc: std.mem.Allocator, hook_ctx: *plugin_mod.HookContext) PluginError!?plugin_mod.LoadResult {
         const self: *NapiSyncPlugin = @ptrCast(@alignCast(ctx.?));
         const resp = self.callHook(.load, path, null) orelse return null;
         defer NapiPlugin.freeResponseFields(resp);
-        if (resp.is_failure) return self.failWithResponse(resp, alloc);
+        if (resp.is_failure) return self.failWithResponse(resp, alloc, hook_ctx);
         const result_code = resp.code orelse return null;
         const contents = alloc.dupe(u8, result_code) catch return error.OutOfMemory;
-        try NapiPlugin.setResponseSourceMaps(resp, alloc);
+        try NapiPlugin.setResponseSourceMaps(resp, alloc, hook_ctx);
         return .{ .contents = contents, .loader = resp.loader_override, .module_type = resp.loader_module_type };
     }
 
-    fn pluginTransform(ctx: ?*anyopaque, code: []const u8, id: []const u8, alloc: std.mem.Allocator) PluginError!?[]const u8 {
+    fn pluginTransform(ctx: ?*anyopaque, code: []const u8, id: []const u8, alloc: std.mem.Allocator, hook_ctx: *plugin_mod.HookContext) PluginError!?[]const u8 {
         const self: *NapiSyncPlugin = @ptrCast(@alignCast(ctx.?));
-        return self.callCodeHook(.transform, code, id, alloc);
+        return self.callCodeHook(.transform, code, id, alloc, hook_ctx);
     }
 
-    fn pluginRenderChunk(ctx: ?*anyopaque, code: []const u8, chunk_name: []const u8, alloc: std.mem.Allocator) PluginError!?[]const u8 {
+    fn pluginRenderChunk(ctx: ?*anyopaque, code: []const u8, chunk_name: []const u8, alloc: std.mem.Allocator, hook_ctx: *plugin_mod.HookContext) PluginError!?[]const u8 {
         const self: *NapiSyncPlugin = @ptrCast(@alignCast(ctx.?));
-        return self.callCodeHook(.renderChunk, code, chunk_name, alloc);
+        return self.callCodeHook(.renderChunk, code, chunk_name, alloc, hook_ctx);
     }
 
     fn pluginGenerateBundle(ctx: ?*anyopaque, output_files: []const bundler_mod.emitter.OutputFile) void {
@@ -1997,19 +1998,19 @@ const NapiSyncPlugin = struct {
         }
     }
 
-    fn pluginBuildStart(ctx: ?*anyopaque) PluginError!void {
+    fn pluginBuildStart(ctx: ?*anyopaque, hook_ctx: *plugin_mod.HookContext) PluginError!void {
         const self: *NapiSyncPlugin = @ptrCast(@alignCast(ctx.?));
         const resp = self.callHook(.buildStart, "", null) orelse return;
         defer NapiPlugin.freeResponseFields(resp);
-        if (resp.is_failure) return self.failWithResponse(resp, native_alloc);
+        if (resp.is_failure) return self.failWithResponse(resp, native_alloc, hook_ctx);
     }
 
-    fn pluginBuildEnd(ctx: ?*anyopaque, build_error: ?*const bundler_mod.types.BundlerDiagnostic) PluginError!void {
+    fn pluginBuildEnd(ctx: ?*anyopaque, build_error: ?*const bundler_mod.types.BundlerDiagnostic, hook_ctx: *plugin_mod.HookContext) PluginError!void {
         const self: *NapiSyncPlugin = @ptrCast(@alignCast(ctx.?));
         const msg = if (build_error) |d| d.message else "";
         const resp = self.callHook(.buildEnd, msg, null) orelse return;
         defer NapiPlugin.freeResponseFields(resp);
-        if (resp.is_failure) return self.failWithResponse(resp, native_alloc);
+        if (resp.is_failure) return self.failWithResponse(resp, native_alloc, hook_ctx);
     }
 
     fn pluginResolveContext(
@@ -2020,6 +2021,7 @@ const NapiSyncPlugin = struct {
         filter_flags: ?[]const u8,
         importer: []const u8,
         alloc: std.mem.Allocator,
+        hook_ctx: *plugin_mod.HookContext,
     ) PluginError!?[]const []const u8 {
         const self: *NapiSyncPlugin = @ptrCast(@alignCast(ctx.?));
 
@@ -2044,7 +2046,7 @@ const NapiSyncPlugin = struct {
 
         const resp = self.callHookFull(.resolveContext, json_buf.items, null, null) orelse return null;
         defer NapiPlugin.freeResponseFields(resp);
-        if (resp.is_failure) return self.failWithResponse(resp, alloc);
+        if (resp.is_failure) return self.failWithResponse(resp, alloc, hook_ctx);
 
         const matches = resp.context_matches orelse return null;
         const out = alloc.alloc([]const u8, matches.len) catch return null;
@@ -2066,7 +2068,13 @@ const NapiSyncPlugin = struct {
 
         const resp = self.callHook(.astFunction, json, null) orelse return;
         defer NapiPlugin.freeResponseFields(resp);
-        if (resp.is_failure) return self.failWithResponse(resp, native_alloc);
+        // onFunction 은 transformer 가 PluginFailed 를 swallow 하므로 metadata 미사용 — local ctx
+        // 로 받아 deinit.
+        if (resp.is_failure) {
+            var local_ctx: plugin_mod.HookContext = .{};
+            defer local_ctx.deinit();
+            return self.failWithResponse(resp, native_alloc, &local_ctx);
+        }
 
         if (resp.strip_directive != null) {
             _ = api.stripDirective(func.body_idx) catch return;

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -765,7 +765,9 @@ pub const Bundler = struct {
             lifecycle_runner.runBuildEnd(null);
             lifecycle_runner.runCloseBundle();
         }
-        try lifecycle_runner.runBuildStart();
+        var build_start_ctx: plugin_mod.HookContext = .{};
+        defer build_start_ctx.deinit();
+        try lifecycle_runner.runBuildStart(&build_start_ctx);
 
         // 타이머는 항상 동작 (watch 관측성용 — HMR phaseDurations 에 노출).
         // 추가로 `profile` 모듈 activation 시 같은 구간에 .graph/.link/.shake/.emit scope 가 기록된다.

--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -954,6 +954,7 @@ fn rcMatchAB(
     _: ?[]const u8,
     _: []const u8,
     allocator: std.mem.Allocator,
+    _: *plugin_mod.HookContext,
 ) PluginError!?[]const []const u8 {
     // Plugin contract: outer + inner 모두 allocator 소유 (graph 가 free).
     const result = try allocator.alloc([]const u8, 2);
@@ -971,6 +972,7 @@ fn rcScanDir(
     _: ?[]const u8,
     importer: []const u8,
     allocator: std.mem.Allocator,
+    _: *plugin_mod.HookContext,
 ) PluginError!?[]const []const u8 {
     const importer_dir = std.fs.path.dirname(importer) orelse return null;
     const abs_dir = std.fs.path.resolve(allocator, &.{ importer_dir, dir }) catch return null;
@@ -1001,6 +1003,7 @@ fn rcRecursiveScan(
     _: ?[]const u8,
     importer: []const u8,
     allocator: std.mem.Allocator,
+    _: *plugin_mod.HookContext,
 ) PluginError!?[]const []const u8 {
     const importer_dir = std.fs.path.dirname(importer) orelse return null;
     const abs_dir = std.fs.path.resolve(allocator, &.{ importer_dir, dir }) catch return null;
@@ -1031,6 +1034,7 @@ fn rcMatchEmpty(
     _: ?[]const u8,
     _: []const u8,
     allocator: std.mem.Allocator,
+    _: *plugin_mod.HookContext,
 ) PluginError!?[]const []const u8 {
     return try allocator.alloc([]const u8, 0);
 }
@@ -1044,6 +1048,7 @@ fn rcMatchSpecialChars(
     _: ?[]const u8,
     _: []const u8,
     allocator: std.mem.Allocator,
+    _: *plugin_mod.HookContext,
 ) PluginError!?[]const []const u8 {
     const result = try allocator.alloc([]const u8, 1);
     result[0] = try allocator.dupe(u8, "./weird\"name\\x.tsx");
@@ -1058,6 +1063,7 @@ fn rcMatchNoDotSlash(
     _: ?[]const u8,
     _: []const u8,
     allocator: std.mem.Allocator,
+    _: *plugin_mod.HookContext,
 ) PluginError!?[]const []const u8 {
     // dot-slash prefix 없는 경로도 emitJoinedPath 가 정규화하는지 확인.
     const result = try allocator.alloc([]const u8, 1);
@@ -1211,6 +1217,7 @@ fn rcDispatchByCallCount(
     _: ?[]const u8,
     _: []const u8,
     allocator: std.mem.Allocator,
+    _: *plugin_mod.HookContext,
 ) PluginError!?[]const []const u8 {
     const S = struct {
         var count: u32 = 0;

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -898,7 +898,9 @@ pub fn emitWithTreeShaking(
     // Plugin: renderChunk 훅 — 단일 파일 모드에서도 적용
     if (options.plugins.len > 0) {
         const runner = plugin_mod.PluginRunner.init(options.plugins);
-        const rc_result = runner.runRenderChunk(output.items, "bundle", allocator) catch |err| switch (err) {
+        var hook_ctx: plugin_mod.HookContext = .{};
+        defer hook_ctx.deinit();
+        const rc_result = runner.runRenderChunk(output.items, "bundle", allocator, &hook_ctx) catch |err| switch (err) {
             error.PluginFailed => null,
             error.OutOfMemory => return error.OutOfMemory,
         };

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -529,7 +529,9 @@ pub fn emitChunks(
             const runner = plugin_mod.PluginRunner.init(options.plugins);
             var rc_stem_buf: [128]u8 = undefined;
             const rc_chunk_name = chunkPlaceholderStem(chunk, &rc_stem_buf, options);
-            const chunk_rc_result = runner.runRenderChunk(chunk_output.items, rc_chunk_name, allocator) catch |err| switch (err) {
+            var hook_ctx: plugin_mod.HookContext = .{};
+            defer hook_ctx.deinit();
+            const chunk_rc_result = runner.runRenderChunk(chunk_output.items, rc_chunk_name, allocator, &hook_ctx) catch |err| switch (err) {
                 error.PluginFailed => null,
                 error.OutOfMemory => return error.OutOfMemory,
             };

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -1824,9 +1824,10 @@ pub const ModuleGraph = struct {
 
                 if (plugin_runner) |runner| {
                     if (self.shouldRunResolveId(record.specifier)) {
-                        const resolve_result = runner.runResolveId(record.specifier, module_path, self.allocator) catch |err| switch (err) {
+                        var hook_ctx: plugin_mod.HookContext = .{};
+                        const resolve_result = runner.runResolveId(record.specifier, module_path, self.allocator, &hook_ctx) catch |err| switch (err) {
                             error.PluginFailed => {
-                                self.addPluginFailureDiag(plugin_mod.takeLastPluginFailure(), module_path, record.span, .resolve);
+                                self.addPluginFailureDiag(hook_ctx.failure, module_path, record.span, .resolve);
                                 results[rec_i] = .{ .is_error = true, .skipped = !should_link };
                                 continue;
                             },
@@ -1886,9 +1887,10 @@ pub const ModuleGraph = struct {
                     module.state = .ready;
                     return;
                 };
-                const load_result = runner.runLoad(module.path, tmp_arena.allocator()) catch |err| switch (err) {
+                var hook_ctx: plugin_mod.HookContext = .{};
+                const load_result = runner.runLoad(module.path, tmp_arena.allocator(), &hook_ctx) catch |err| switch (err) {
                     error.PluginFailed => {
-                        self.addPluginFailureDiag(plugin_mod.takeLastPluginFailure(), module.path, Span.EMPTY, .resolve);
+                        self.addPluginFailureDiag(hook_ctx.failure, module.path, Span.EMPTY, .resolve);
                         module_mod.destroyParseArena(self.allocator, tmp_arena);
                         module.state = .ready;
                         return;
@@ -1901,7 +1903,7 @@ pub const ModuleGraph = struct {
                 };
                 if (load_result) |plugin_result| {
                     plugin_load_applied = true;
-                    const load_source_maps = plugin_mod.takeLastTransformSourceMaps() orelse &.{};
+                    const load_source_maps = hook_ctx.source_maps orelse &.{};
                     // 플러그인이 내용을 반환. (#2157) `loader` 가 명시되면 raw bytes 를 그 loader 의
                     // 값 표현식으로 변환 (parseAssetModule 와 동일한 assetSourceFromBytes 헬퍼).
                     // asset 변환 성공 시 parseAssetModule 와 동일하게 ast 없이 종료 → emitter 의
@@ -2105,9 +2107,10 @@ pub const ModuleGraph = struct {
         var plugin_transform_applied = false;
         if (plugin_runner) |runner| {
             if (self.has_transform_plugins) {
-                const transform_result = runner.runTransform(module.source, module.path, arena_alloc) catch |err| switch (err) {
+                var hook_ctx: plugin_mod.HookContext = .{};
+                const transform_result = runner.runTransform(module.source, module.path, arena_alloc, &hook_ctx) catch |err| switch (err) {
                     error.PluginFailed => {
-                        self.addPluginFailureDiag(plugin_mod.takeLastPluginFailure(), module.path, Span.EMPTY, .transform);
+                        self.addPluginFailureDiag(hook_ctx.failure, module.path, Span.EMPTY, .transform);
                         module.state = .ready;
                         return;
                     },
@@ -2117,7 +2120,7 @@ pub const ModuleGraph = struct {
                     },
                 };
                 if (transform_result) |result| {
-                    if (plugin_mod.takeLastTransformSourceMaps()) |maps| {
+                    if (hook_ctx.source_maps) |maps| {
                         if (!self.validatePluginSourceMaps(maps, module.path, Span.EMPTY, .transform, "transform")) {
                             module.state = .ready;
                             return;
@@ -3201,9 +3204,10 @@ pub const ModuleGraph = struct {
             // Plugin: resolveId 훅 — 기본 resolver 전에 플러그인에게 경로 해석 기회를 줌
             if (plugin_runner) |runner| {
                 if (self.shouldRunResolveId(record.specifier)) {
-                    const resolve_result = runner.runResolveId(record.specifier, module_path, self.allocator) catch |err| switch (err) {
+                    var hook_ctx: plugin_mod.HookContext = .{};
+                    const resolve_result = runner.runResolveId(record.specifier, module_path, self.allocator, &hook_ctx) catch |err| switch (err) {
                         error.PluginFailed => {
-                            self.addPluginFailureDiag(plugin_mod.takeLastPluginFailure(), module_path, record.span, .resolve);
+                            self.addPluginFailureDiag(hook_ctx.failure, module_path, record.span, .resolve);
                             return;
                         },
                         error.OutOfMemory => return error.OutOfMemory,
@@ -4618,6 +4622,8 @@ fn expandRequireContextRecords(self: *ModuleGraph, mod_idx: usize) void {
 
         // Plugin 호출
         if (plugin_runner) |runner| {
+            var hook_ctx: plugin_mod.HookContext = .{};
+            defer hook_ctx.deinit();
             const matches = runner.runResolveContext(
                 record.specifier,
                 record.context_recursive,
@@ -4625,6 +4631,7 @@ fn expandRequireContextRecords(self: *ModuleGraph, mod_idx: usize) void {
                 record.context_filter_flags,
                 module_path,
                 self.allocator,
+                &hook_ctx,
             ) catch null;
             if (matches) |m| {
                 record.context_matches = m;

--- a/src/bundler/graph_test.zig
+++ b/src/bundler/graph_test.zig
@@ -882,6 +882,7 @@ fn countedResolveHook(
     specifier: []const u8,
     _: ?[]const u8,
     allocator: std.mem.Allocator,
+    _: *plugin_mod.HookContext,
 ) plugin_mod.PluginError!?plugin_mod.ResolvedModule {
     const counter: *ResolveCounter = @ptrCast(@alignCast(ctx.?));
     counter.count += 1;

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -101,29 +101,28 @@ pub const PluginFailure = struct {
     }
 };
 
-threadlocal var last_plugin_failure: ?PluginFailure = null;
-threadlocal var last_transform_source_maps: ?[]const []const u8 = null;
+/// fallible plugin hook 의 out-param. 호출자가 stack 에 만들어 hook 으로 전달하면
+/// hook 이 실패 metadata 와 (load/transform 의 경우) source map chain 을 채운다.
+/// 이전에는 threadlocal 두 개로 같은 데이터를 흘렸지만 thread-safety/생명주기/계약
+/// 추적 모두 명시 out-param 이 깔끔.
+pub const HookContext = struct {
+    /// hook 이 `error.PluginFailed` 를 반환할 때 metadata 가 들어간다.
+    /// 성공 path 에서는 null. caller 가 consume (addPluginFailureDiag) 또는
+    /// `deinit()` 으로 해제 책임.
+    failure: ?PluginFailure = null,
+    /// `load` / `transform` 이 반환한 source map JSON chain.
+    /// 다른 hook 은 사용 안 함. caller 가 free 책임.
+    source_maps: ?[]const []const u8 = null,
 
-pub fn setLastPluginFailure(failure: PluginFailure) void {
-    if (last_plugin_failure) |old| old.deinit();
-    last_plugin_failure = failure;
-}
-
-pub fn takeLastPluginFailure() ?PluginFailure {
-    const failure = last_plugin_failure;
-    last_plugin_failure = null;
-    return failure;
-}
-
-pub fn setLastTransformSourceMaps(source_maps: []const []const u8) void {
-    last_transform_source_maps = source_maps;
-}
-
-pub fn takeLastTransformSourceMaps() ?[]const []const u8 {
-    const source_maps = last_transform_source_maps;
-    last_transform_source_maps = null;
-    return source_maps;
-}
+    /// 사용 안 하는 failure metadata 를 일괄 정리. 이미 consume 된 경우 no-op.
+    /// swallow 경로 (lifecycle hook, fallback null path 등) 에서 `defer ctx.deinit()` 으로 사용.
+    pub fn deinit(self: *HookContext) void {
+        if (self.failure) |f| {
+            f.deinit();
+            self.failure = null;
+        }
+    }
+};
 
 /// Plugin resolveId 응답의 통합 모델 (#1885).
 ///
@@ -173,6 +172,7 @@ pub const ResolveContextFn = ?*const fn (
     filter_flags: ?[]const u8,
     importer: []const u8,
     allocator: std.mem.Allocator,
+    hook_ctx: *HookContext,
 ) PluginError!?[]const []const u8;
 
 /// Rollup 호환 플러그인 인터페이스. 각 훅은 optional 함수 포인터 — null이면 해당 훅을 구현하지 않음.
@@ -184,37 +184,40 @@ pub const Plugin = struct {
 
     /// 모듈 경로 해석 커스텀 (alias, virtual module).
     /// non-null 반환 시 기본 resolver를 건너뜀.
-    resolveId: ?*const fn (ctx: ?*anyopaque, specifier: []const u8, importer: ?[]const u8, allocator: std.mem.Allocator) PluginError!?ResolvedModule = null,
+    /// 실패 시 `hook_ctx.failure` 채우고 `error.PluginFailed`.
+    resolveId: ?*const fn (ctx: ?*anyopaque, specifier: []const u8, importer: ?[]const u8, allocator: std.mem.Allocator, hook_ctx: *HookContext) PluginError!?ResolvedModule = null,
 
     /// 모듈 내용 로딩 (virtual module, 커스텀 로더).
     /// non-null 반환 시 파일 시스템 읽기를 건너뜀.
     /// `LoadResult.loader` 를 non-null 로 반환하면 graph 가 module loader 를 그 값으로 override
     /// (확장자 기반 추론 무시) — esbuild `onLoad` callback 의 `loader: 'text' | 'binary' | ...`
     /// 와 동일 의미. (#2157)
-    load: ?*const fn (ctx: ?*anyopaque, path: []const u8, allocator: std.mem.Allocator) PluginError!?LoadResult = null,
+    /// `hook_ctx.source_maps` 를 채워 source map chain 전달 가능 (#1902).
+    load: ?*const fn (ctx: ?*anyopaque, path: []const u8, allocator: std.mem.Allocator, hook_ctx: *HookContext) PluginError!?LoadResult = null,
 
     /// 코드 변환 (codegen 직후, CJS 래핑 전).
     /// non-null 반환 시 원본 코드를 반환값으로 교체.
-    transform: ?*const fn (ctx: ?*anyopaque, code: []const u8, id: []const u8, allocator: std.mem.Allocator) PluginError!?[]const u8 = null,
+    /// `hook_ctx.source_maps` 를 채워 source map chain 전달 가능 (#1902).
+    transform: ?*const fn (ctx: ?*anyopaque, code: []const u8, id: []const u8, allocator: std.mem.Allocator, hook_ctx: *HookContext) PluginError!?[]const u8 = null,
 
     /// 청크 코드 후처리 (청크 완성 후, footer 전).
     /// non-null 반환 시 청크 코드를 반환값으로 교체.
-    renderChunk: ?*const fn (ctx: ?*anyopaque, code: []const u8, chunk_name: []const u8, allocator: std.mem.Allocator) PluginError!?[]const u8 = null,
+    renderChunk: ?*const fn (ctx: ?*anyopaque, code: []const u8, chunk_name: []const u8, allocator: std.mem.Allocator, hook_ctx: *HookContext) PluginError!?[]const u8 = null,
 
     /// 번들 생성 완료 알림. 모든 플러그인에 호출됨.
     generateBundle: ?*const fn (ctx: ?*anyopaque, output_files: []const OutputFile) void = null,
 
     /// bundle 시작 시 1회 호출. esbuild `onStart`, Rollup/Vite/rolldown `buildStart` 동일.
     /// 옵션 인자는 Zig 측에서 안 넘김 — JS 어댑터가 자체 context 로 forward.
-    buildStart: ?*const fn (ctx: ?*anyopaque) PluginError!void = null,
+    buildStart: ?*const fn (ctx: ?*anyopaque, hook_ctx: *HookContext) PluginError!void = null,
 
     /// bundle 종료 시 1회 호출. 성공/실패 모두 dispatch. 실패 시 fatal diagnostic 첫 항목 전달.
     /// esbuild `onEnd`, Rollup/Vite/rolldown `buildEnd` 동일.
-    buildEnd: ?*const fn (ctx: ?*anyopaque, build_error: ?*const types.BundlerDiagnostic) PluginError!void = null,
+    buildEnd: ?*const fn (ctx: ?*anyopaque, build_error: ?*const types.BundlerDiagnostic, hook_ctx: *HookContext) PluginError!void = null,
 
     /// write 완료 후 1회 호출. watch 모드면 매 rebuild 마다 재호출.
     /// Rollup/Vite/rolldown `closeBundle` 동일. esbuild 는 `onDispose` 라 명명 다름.
-    closeBundle: ?*const fn (ctx: ?*anyopaque) PluginError!void = null,
+    closeBundle: ?*const fn (ctx: ?*anyopaque, hook_ctx: *HookContext) PluginError!void = null,
 
     /// `require.context(dir, recursive, filter)` 매칭 결과 주입 (#1579 Phase 2).
     /// ZNTC 자체 regex executor 가 없어서 (#1771) host runtime 의 RegExp 에 위임.
@@ -310,15 +313,17 @@ pub const PluginRunner = struct {
 
     /// resolveId: first 모드 — 첫 번째 non-null 반환값 사용.
     /// 모든 플러그인이 null을 반환하면 null (기본 resolver 사용).
+    /// 실패 시 hook 이 `hook_ctx.failure` 를 채우고 `error.PluginFailed`.
     pub fn runResolveId(
         self: *const PluginRunner,
         specifier: []const u8,
         importer: ?[]const u8,
         allocator: std.mem.Allocator,
+        hook_ctx: *HookContext,
     ) PluginError!?ResolvedModule {
         for (self.plugins) |p| {
             if (p.resolveId) |hook| {
-                if (try hook(p.context, specifier, importer, allocator)) |result| {
+                if (try hook(p.context, specifier, importer, allocator, hook_ctx)) |result| {
                     return result;
                 }
             }
@@ -336,10 +341,11 @@ pub const PluginRunner = struct {
         filter_flags: ?[]const u8,
         importer: []const u8,
         allocator: std.mem.Allocator,
+        hook_ctx: *HookContext,
     ) PluginError!?[]const []const u8 {
         for (self.plugins) |p| {
             if (p.resolveContext) |hook| {
-                if (try hook(p.context, dir, recursive, filter_pattern, filter_flags, importer, allocator)) |result| {
+                if (try hook(p.context, dir, recursive, filter_pattern, filter_flags, importer, allocator, hook_ctx)) |result| {
                     return result;
                 }
             }
@@ -349,15 +355,16 @@ pub const PluginRunner = struct {
 
     /// load: first 모드 — 첫 번째 non-null 반환값 사용.
     /// 모든 플러그인이 null을 반환하면 null (파일 시스템에서 읽기).
+    /// 성공 시 `hook_ctx.source_maps` 에 plugin 이 채운 source map chain 이 들어 있다.
     pub fn runLoad(
         self: *const PluginRunner,
         path: []const u8,
         allocator: std.mem.Allocator,
+        hook_ctx: *HookContext,
     ) PluginError!?LoadResult {
-        last_transform_source_maps = null;
         for (self.plugins) |p| {
             if (p.load) |hook| {
-                if (try hook(p.context, path, allocator)) |result| {
+                if (try hook(p.context, path, allocator, hook_ctx)) |result| {
                     return result;
                 }
             }
@@ -368,13 +375,14 @@ pub const PluginRunner = struct {
     /// transform: 순차 체이닝 — 이전 플러그인 출력이 다음 플러그인 입력.
     /// 체이닝 중간 결과는 free. 최종 결과는 allocator 소유.
     /// 아무 플러그인도 변환하지 않으면 null 반환.
+    /// 체인 안에서 각 plugin 이 채운 source maps 를 모아 `hook_ctx.source_maps` 에 합친다.
     pub fn runTransform(
         self: *const PluginRunner,
         code: []const u8,
         id: []const u8,
         allocator: std.mem.Allocator,
+        hook_ctx: *HookContext,
     ) PluginError!?[]const u8 {
-        last_transform_source_maps = null;
         var source_maps: std.ArrayList([]const u8) = .empty;
         defer source_maps.deinit(allocator);
 
@@ -382,18 +390,26 @@ pub const PluginRunner = struct {
         for (self.plugins) |p| {
             if (p.transform) |hook| {
                 const input = current orelse code;
-                if (try hook(p.context, input, id, allocator)) |result| {
-                    if (takeLastTransformSourceMaps()) |maps| {
+                // 각 plugin 별 fresh inner_ctx — source_maps 는 chain 에서 누적, failure 는
+                // 첫 실패 시 outer 로 옮긴다. plugin hook 이 failure 를 read 하는 contract 는
+                // 없으므로 hook_ctx.failure 시드 불필요.
+                var inner_ctx: HookContext = .{};
+                const result = hook(p.context, input, id, allocator, &inner_ctx) catch |err| {
+                    hook_ctx.failure = inner_ctx.failure;
+                    return err;
+                };
+                if (result) |r| {
+                    if (inner_ctx.source_maps) |maps| {
                         try source_maps.appendSlice(allocator, maps);
                     }
                     // 이전 체이닝 결과가 있으면 해제 (원본 code는 caller 소유이므로 건드리지 않음)
                     if (current) |prev| allocator.free(prev);
-                    current = result;
+                    current = r;
                 }
             }
         }
         if (source_maps.items.len > 0) {
-            setLastTransformSourceMaps(try source_maps.toOwnedSlice(allocator));
+            hook_ctx.source_maps = try source_maps.toOwnedSlice(allocator);
         }
         return current;
     }
@@ -405,12 +421,13 @@ pub const PluginRunner = struct {
         code: []const u8,
         chunk_name: []const u8,
         allocator: std.mem.Allocator,
+        hook_ctx: *HookContext,
     ) PluginError!?[]const u8 {
         var current: ?[]const u8 = null;
         for (self.plugins) |p| {
             if (p.renderChunk) |hook| {
                 const input = current orelse code;
-                if (try hook(p.context, input, chunk_name, allocator)) |result| {
+                if (try hook(p.context, input, chunk_name, allocator, hook_ctx)) |result| {
                     if (current) |prev| allocator.free(prev);
                     current = result;
                 }
@@ -433,9 +450,9 @@ pub const PluginRunner = struct {
 
     /// buildStart: 모든 플러그인 실행. 한 plugin 이 실패하면 즉시 stop + 에러 전파.
     /// bundle 시작 직후 1회만 호출.
-    pub fn runBuildStart(self: *const PluginRunner) PluginError!void {
+    pub fn runBuildStart(self: *const PluginRunner, hook_ctx: *HookContext) PluginError!void {
         for (self.plugins) |p| {
-            if (p.buildStart) |hook| try hook(p.context);
+            if (p.buildStart) |hook| try hook(p.context, hook_ctx);
         }
     }
 
@@ -447,7 +464,9 @@ pub const PluginRunner = struct {
     ) void {
         for (self.plugins) |p| {
             if (p.buildEnd) |hook| {
-                hook(p.context, build_error) catch {};
+                var hook_ctx: HookContext = .{};
+                defer hook_ctx.deinit();
+                hook(p.context, build_error, &hook_ctx) catch {};
             }
         }
     }
@@ -457,7 +476,9 @@ pub const PluginRunner = struct {
     pub fn runCloseBundle(self: *const PluginRunner) void {
         for (self.plugins) |p| {
             if (p.closeBundle) |hook| {
-                hook(p.context) catch {};
+                var hook_ctx: HookContext = .{};
+                defer hook_ctx.deinit();
+                hook(p.context, &hook_ctx) catch {};
             }
         }
     }

--- a/src/bundler/plugin_test.zig
+++ b/src/bundler/plugin_test.zig
@@ -22,17 +22,18 @@ const absPath = test_helpers.absPath;
 test "PluginRunner: empty plugins is no-op" {
     const runner = PluginRunner.init(&.{});
     try std.testing.expect(runner.isEmpty());
+    var hook_ctx: plugin_mod.HookContext = .{};
 
-    const resolve_result = try runner.runResolveId("foo", null, std.testing.allocator);
+    const resolve_result = try runner.runResolveId("foo", null, std.testing.allocator, &hook_ctx);
     try std.testing.expect(resolve_result == null);
 
-    const load_result = try runner.runLoad("foo.ts", std.testing.allocator);
+    const load_result = try runner.runLoad("foo.ts", std.testing.allocator, &hook_ctx);
     try std.testing.expect(load_result == null);
 
-    const transform_result = try runner.runTransform("code", "id", std.testing.allocator);
+    const transform_result = try runner.runTransform("code", "id", std.testing.allocator, &hook_ctx);
     try std.testing.expect(transform_result == null);
 
-    const render_result = try runner.runRenderChunk("code", "chunk", std.testing.allocator);
+    const render_result = try runner.runRenderChunk("code", "chunk", std.testing.allocator, &hook_ctx);
     try std.testing.expect(render_result == null);
 
     runner.runGenerateBundle(&.{});
@@ -40,7 +41,7 @@ test "PluginRunner: empty plugins is no-op" {
 
 // --- resolveId 훅 테스트 ---
 
-fn testResolveIdHook(_: ?*anyopaque, specifier: []const u8, _: ?[]const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?plugin_mod.ResolvedModule {
+fn testResolveIdHook(_: ?*anyopaque, specifier: []const u8, _: ?[]const u8, allocator: std.mem.Allocator, _: *plugin_mod.HookContext) plugin_mod.PluginError!?plugin_mod.ResolvedModule {
     if (std.mem.eql(u8, specifier, "virtual:config")) {
         return .{ .file = .{
             .path = try allocator.dupe(u8, "/virtual/config.js"),
@@ -55,9 +56,10 @@ test "PluginRunner: resolveId first mode" {
         .{ .name = "test-resolve", .resolveId = testResolveIdHook },
     };
     const runner = PluginRunner.init(&plugins);
+    var hook_ctx: plugin_mod.HookContext = .{};
 
     // 매칭되는 specifier → non-null
-    const result = try runner.runResolveId("virtual:config", null, std.testing.allocator);
+    const result = try runner.runResolveId("virtual:config", null, std.testing.allocator, &hook_ctx);
     try std.testing.expect(result != null);
     const path = switch (result.?) {
         .file => |f| f.path,
@@ -67,13 +69,13 @@ test "PluginRunner: resolveId first mode" {
     std.testing.allocator.free(path);
 
     // 매칭 안 되는 specifier → null (기본 resolver 사용)
-    const result2 = try runner.runResolveId("./normal", null, std.testing.allocator);
+    const result2 = try runner.runResolveId("./normal", null, std.testing.allocator, &hook_ctx);
     try std.testing.expect(result2 == null);
 }
 
 // --- load 훅 테스트 ---
 
-fn testLoadHook(_: ?*anyopaque, path: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?plugin_mod.LoadResult {
+fn testLoadHook(_: ?*anyopaque, path: []const u8, allocator: std.mem.Allocator, _: *plugin_mod.HookContext) plugin_mod.PluginError!?plugin_mod.LoadResult {
     if (std.mem.endsWith(u8, path, ".custom")) {
         const contents = try allocator.dupe(u8, "export default 'custom-loaded';");
         return .{ .contents = contents };
@@ -86,24 +88,25 @@ test "PluginRunner: load first mode" {
         .{ .name = "test-load", .load = testLoadHook },
     };
     const runner = PluginRunner.init(&plugins);
+    var hook_ctx: plugin_mod.HookContext = .{};
 
-    const result = try runner.runLoad("module.custom", std.testing.allocator);
+    const result = try runner.runLoad("module.custom", std.testing.allocator, &hook_ctx);
     try std.testing.expect(result != null);
     try std.testing.expectEqualStrings("export default 'custom-loaded';", result.?.contents);
     std.testing.allocator.free(result.?.contents);
 
     // 매칭 안 되는 확장자 → null (파일 시스템에서 읽기)
-    const result2 = try runner.runLoad("module.ts", std.testing.allocator);
+    const result2 = try runner.runLoad("module.ts", std.testing.allocator, &hook_ctx);
     try std.testing.expect(result2 == null);
 }
 
 // --- transform 훅 테스트 (체이닝) ---
 
-fn testTransformHookA(_: ?*anyopaque, code: []const u8, _: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
+fn testTransformHookA(_: ?*anyopaque, code: []const u8, _: []const u8, allocator: std.mem.Allocator, _: *plugin_mod.HookContext) plugin_mod.PluginError!?[]const u8 {
     return std.mem.concat(allocator, u8, &.{ "/* A */", code }) catch return error.OutOfMemory;
 }
 
-fn testTransformHookB(_: ?*anyopaque, code: []const u8, _: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
+fn testTransformHookB(_: ?*anyopaque, code: []const u8, _: []const u8, allocator: std.mem.Allocator, _: *plugin_mod.HookContext) plugin_mod.PluginError!?[]const u8 {
     return std.mem.concat(allocator, u8, &.{ "/* B */", code }) catch return error.OutOfMemory;
 }
 
@@ -114,7 +117,8 @@ test "PluginRunner: transform chaining" {
     };
     const runner = PluginRunner.init(&plugins);
 
-    const result = try runner.runTransform("original", "test.js", std.testing.allocator);
+    var hook_ctx: plugin_mod.HookContext = .{};
+    const result = try runner.runTransform("original", "test.js", std.testing.allocator, &hook_ctx);
     try std.testing.expect(result != null);
     // B가 A의 결과를 받으므로: "/* B *//* A */original"
     try std.testing.expectEqualStrings("/* B *//* A */original", result.?);
@@ -123,7 +127,7 @@ test "PluginRunner: transform chaining" {
 
 // --- renderChunk 훅 테스트 ---
 
-fn testRenderChunkHook(_: ?*anyopaque, code: []const u8, _: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
+fn testRenderChunkHook(_: ?*anyopaque, code: []const u8, _: []const u8, allocator: std.mem.Allocator, _: *plugin_mod.HookContext) plugin_mod.PluginError!?[]const u8 {
     return std.mem.concat(allocator, u8, &.{ "/* rendered */\n", code }) catch return error.OutOfMemory;
 }
 
@@ -133,7 +137,8 @@ test "PluginRunner: renderChunk chaining" {
     };
     const runner = PluginRunner.init(&plugins);
 
-    const result = try runner.runRenderChunk("chunk code", "main", std.testing.allocator);
+    var hook_ctx: plugin_mod.HookContext = .{};
+    const result = try runner.runRenderChunk("chunk code", "main", std.testing.allocator, &hook_ctx);
     try std.testing.expect(result != null);
     try std.testing.expect(std.mem.startsWith(u8, result.?, "/* rendered */\n"));
     std.testing.allocator.free(result.?);
@@ -164,7 +169,7 @@ test "PluginRunner: generateBundle all executed" {
 
 // --- transform 훅 통합 테스트 ---
 
-fn integrationTransformHook(_: ?*anyopaque, code: []const u8, _: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
+fn integrationTransformHook(_: ?*anyopaque, code: []const u8, _: []const u8, allocator: std.mem.Allocator, _: *plugin_mod.HookContext) plugin_mod.PluginError!?[]const u8 {
     // 파싱 전에 호출되므로 실행 가능한 문을 삽입 (주석은 파서가 제거)
     return std.mem.concat(allocator, u8, &.{ "var __PLUGIN_TRANSFORM__ = true;\n", code }) catch return error.OutOfMemory;
 }
@@ -195,7 +200,7 @@ test "Plugin integration: transform hook modifies output" {
     try std.testing.expect(!result.hasErrors());
 }
 
-fn transformAddsImportHook(_: ?*anyopaque, code: []const u8, id: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
+fn transformAddsImportHook(_: ?*anyopaque, code: []const u8, id: []const u8, allocator: std.mem.Allocator, _: *plugin_mod.HookContext) plugin_mod.PluginError!?[]const u8 {
     if (!std.mem.endsWith(u8, id, "index.ts")) return null;
     return std.mem.concat(allocator, u8, &.{ "import './side';\n", code }) catch return error.OutOfMemory;
 }
@@ -227,7 +232,7 @@ test "Plugin integration: transform-added imports are scanned from final source 
     try std.testing.expect(std.mem.indexOf(u8, result.output, "entry-2038") != null);
 }
 
-fn transformAddsPurePackageImportHook(_: ?*anyopaque, _: []const u8, id: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
+fn transformAddsPurePackageImportHook(_: ?*anyopaque, _: []const u8, id: []const u8, allocator: std.mem.Allocator, _: *plugin_mod.HookContext) plugin_mod.PluginError!?[]const u8 {
     if (!std.mem.endsWith(u8, id, "index.ts")) return null;
     return allocator.dupe(u8,
         \\import { used } from "pure-lib-2038";
@@ -274,7 +279,7 @@ test "Plugin integration: transform-added package import feeds tree-shaking (#20
 
 var compiled_cache_transform_marker: []const u8 = "A";
 
-fn cacheSensitiveTransformHook(_: ?*anyopaque, _: []const u8, id: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
+fn cacheSensitiveTransformHook(_: ?*anyopaque, _: []const u8, id: []const u8, allocator: std.mem.Allocator, _: *plugin_mod.HookContext) plugin_mod.PluginError!?[]const u8 {
     if (!std.mem.endsWith(u8, id, "index.ts")) return null;
     return std.fmt.allocPrint(
         allocator,
@@ -353,7 +358,7 @@ test "Plugin integration: transform output invalidates compiled cache (#2038)" {
 
 var compiled_cache_load_marker: []const u8 = "A";
 
-fn cacheSensitiveLoadHook(_: ?*anyopaque, path: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?plugin_mod.LoadResult {
+fn cacheSensitiveLoadHook(_: ?*anyopaque, path: []const u8, allocator: std.mem.Allocator, _: *plugin_mod.HookContext) plugin_mod.PluginError!?plugin_mod.LoadResult {
     if (!std.mem.endsWith(u8, path, "index.ts")) return null;
     const contents = std.fmt.allocPrint(
         allocator,
@@ -475,11 +480,11 @@ test "Plugin integration: no plugins preserves existing behavior" {
 
 // --- 다중 플러그인 체이닝 통합 테스트 ---
 
-fn chainTransformA(_: ?*anyopaque, code: []const u8, _: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
+fn chainTransformA(_: ?*anyopaque, code: []const u8, _: []const u8, allocator: std.mem.Allocator, _: *plugin_mod.HookContext) plugin_mod.PluginError!?[]const u8 {
     return std.mem.concat(allocator, u8, &.{ "var CHAIN_A = true;\n", code }) catch return error.OutOfMemory;
 }
 
-fn chainTransformB(_: ?*anyopaque, code: []const u8, _: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
+fn chainTransformB(_: ?*anyopaque, code: []const u8, _: []const u8, allocator: std.mem.Allocator, _: *plugin_mod.HookContext) plugin_mod.PluginError!?[]const u8 {
     return std.mem.concat(allocator, u8, &.{ "var CHAIN_B = true;\n", code }) catch return error.OutOfMemory;
 }
 
@@ -513,7 +518,7 @@ test "Plugin integration: multiple plugins chain transforms" {
 
 // --- resolveId가 null 반환 시 기본 resolver fall through ---
 
-fn nullResolveHook(_: ?*anyopaque, _: []const u8, _: ?[]const u8, _: std.mem.Allocator) plugin_mod.PluginError!?plugin_mod.ResolvedModule {
+fn nullResolveHook(_: ?*anyopaque, _: []const u8, _: ?[]const u8, _: std.mem.Allocator, _: *plugin_mod.HookContext) plugin_mod.PluginError!?plugin_mod.ResolvedModule {
     return null;
 }
 
@@ -546,7 +551,7 @@ test "Plugin integration: resolveId null falls through to default resolver" {
 
 // --- load 훅이 null 반환 시 파일 시스템 폴백 ---
 
-fn nullLoadHook(_: ?*anyopaque, _: []const u8, _: std.mem.Allocator) plugin_mod.PluginError!?plugin_mod.LoadResult {
+fn nullLoadHook(_: ?*anyopaque, _: []const u8, _: std.mem.Allocator, _: *plugin_mod.HookContext) plugin_mod.PluginError!?plugin_mod.LoadResult {
     return null;
 }
 
@@ -580,7 +585,7 @@ test "Plugin integration: load null falls through to filesystem" {
 var transform_all_call_count: usize = 0;
 var transform_all_user_file_seen: bool = false;
 
-fn countingTransformHook(_: ?*anyopaque, code: []const u8, id: []const u8, allocator: std.mem.Allocator) plugin_mod.PluginError!?[]const u8 {
+fn countingTransformHook(_: ?*anyopaque, code: []const u8, id: []const u8, allocator: std.mem.Allocator, _: *plugin_mod.HookContext) plugin_mod.PluginError!?[]const u8 {
     transform_all_call_count += 1;
     if (std.mem.indexOf(u8, id, "node_modules") == null) {
         transform_all_user_file_seen = true;
@@ -710,18 +715,18 @@ const LifecycleLog = struct {
     }
 };
 
-fn lifecycleBuildStart(_: ?*anyopaque) plugin_mod.PluginError!void {
+fn lifecycleBuildStart(_: ?*anyopaque, _: *plugin_mod.HookContext) plugin_mod.PluginError!void {
     LifecycleLog.build_start_count += 1;
     if (LifecycleLog.build_start_should_fail) return error.PluginFailed;
 }
 
-fn lifecycleBuildEnd(_: ?*anyopaque, build_error: ?*const types.BundlerDiagnostic) plugin_mod.PluginError!void {
+fn lifecycleBuildEnd(_: ?*anyopaque, build_error: ?*const types.BundlerDiagnostic, _: *plugin_mod.HookContext) plugin_mod.PluginError!void {
     LifecycleLog.build_end_count += 1;
     LifecycleLog.build_end_error_was_null = build_error == null;
     if (build_error) |d| LifecycleLog.build_end_error_code = d.code;
 }
 
-fn lifecycleCloseBundle(_: ?*anyopaque) plugin_mod.PluginError!void {
+fn lifecycleCloseBundle(_: ?*anyopaque, _: *plugin_mod.HookContext) plugin_mod.PluginError!void {
     LifecycleLog.close_bundle_count += 1;
 }
 
@@ -732,7 +737,8 @@ test "PluginRunner: buildStart 모든 plugin 순차 실행" {
         .{ .name = "p2", .buildStart = lifecycleBuildStart },
     };
     const runner = PluginRunner.init(&plugins);
-    try runner.runBuildStart();
+    var hook_ctx: plugin_mod.HookContext = .{};
+    try runner.runBuildStart(&hook_ctx);
     try std.testing.expectEqual(@as(u32, 2), LifecycleLog.build_start_count);
 }
 
@@ -744,7 +750,9 @@ test "PluginRunner: buildStart 한 plugin 실패 시 즉시 stop + 에러 전파
         .{ .name = "never", .buildStart = lifecycleBuildStart },
     };
     const runner = PluginRunner.init(&plugins);
-    try std.testing.expectError(error.PluginFailed, runner.runBuildStart());
+    var hook_ctx: plugin_mod.HookContext = .{};
+    defer hook_ctx.deinit();
+    try std.testing.expectError(error.PluginFailed, runner.runBuildStart(&hook_ctx));
     try std.testing.expectEqual(@as(u32, 1), LifecycleLog.build_start_count); // 두 번째 plugin 미호출
 }
 
@@ -768,11 +776,11 @@ test "PluginRunner: buildEnd error 인자 전달" {
     try std.testing.expectEqual(types.BundlerDiagnostic.ErrorCode.unresolved_import, LifecycleLog.build_end_error_code.?);
 }
 
-fn lifecycleAlwaysFails(_: ?*anyopaque, _: ?*const types.BundlerDiagnostic) plugin_mod.PluginError!void {
+fn lifecycleAlwaysFails(_: ?*anyopaque, _: ?*const types.BundlerDiagnostic, _: *plugin_mod.HookContext) plugin_mod.PluginError!void {
     return error.PluginFailed;
 }
 
-fn lifecycleCloseBundleAlwaysFails(_: ?*anyopaque) plugin_mod.PluginError!void {
+fn lifecycleCloseBundleAlwaysFails(_: ?*anyopaque, _: *plugin_mod.HookContext) plugin_mod.PluginError!void {
     return error.PluginFailed;
 }
 

--- a/src/bundler/require_context_resolve_test.zig
+++ b/src/bundler/require_context_resolve_test.zig
@@ -61,6 +61,7 @@ fn captureCallback(
     filter_flags: ?[]const u8,
     importer: []const u8,
     allocator: std.mem.Allocator,
+    _: *plugin_mod.HookContext,
 ) PluginError!?[]const []const u8 {
     RecordedCall.call_count += 1;
     RecordedCall.dir_len = @min(dir.len, RecordedCall.dir_buf.len);
@@ -82,6 +83,7 @@ fn matchingCallback(
     _: ?[]const u8,
     _: []const u8,
     allocator: std.mem.Allocator,
+    _: *plugin_mod.HookContext,
 ) PluginError!?[]const []const u8 {
     // contract: outer slice + inner string 모두 allocator 소유 (graph 가 free)
     const result = try allocator.alloc([]const u8, 3);
@@ -99,6 +101,7 @@ fn nullCallback(
     _: ?[]const u8,
     _: []const u8,
     _: std.mem.Allocator,
+    _: *plugin_mod.HookContext,
 ) PluginError!?[]const []const u8 {
     return null;
 }
@@ -111,6 +114,7 @@ fn errorCallback(
     _: ?[]const u8,
     _: []const u8,
     _: std.mem.Allocator,
+    _: *plugin_mod.HookContext,
 ) PluginError!?[]const []const u8 {
     return error.PluginFailed;
 }
@@ -123,14 +127,16 @@ fn freeMatches(alloc: std.mem.Allocator, matches: []const []const u8) void {
 
 test "runResolveContext: empty plugins → null" {
     const runner = PluginRunner.init(&.{});
-    const result = try runner.runResolveContext("./pages", true, null, null, "/tmp/foo.ts", std.testing.allocator);
+    var hook_ctx: plugin_mod.HookContext = .{};
+    const result = try runner.runResolveContext("./pages", true, null, null, "/tmp/foo.ts", std.testing.allocator, &hook_ctx);
     try std.testing.expect(result == null);
 }
 
 test "runResolveContext: plugin without hook → null" {
     const plugins = [_]Plugin{.{ .name = "noop" }};
     const runner = PluginRunner.init(&plugins);
-    const result = try runner.runResolveContext("./pages", true, null, null, "/tmp/foo.ts", std.testing.allocator);
+    var hook_ctx: plugin_mod.HookContext = .{};
+    const result = try runner.runResolveContext("./pages", true, null, null, "/tmp/foo.ts", std.testing.allocator, &hook_ctx);
     try std.testing.expect(result == null);
 }
 
@@ -138,7 +144,8 @@ test "runResolveContext: hook called with all args propagated" {
     RecordedCall.reset();
     const plugins = [_]Plugin{.{ .name = "capture", .resolveContext = captureCallback }};
     const runner = PluginRunner.init(&plugins);
-    const result = try runner.runResolveContext("./app", true, "\\.tsx?$", "i", "/proj/index.ts", std.testing.allocator);
+    var hook_ctx: plugin_mod.HookContext = .{};
+    const result = try runner.runResolveContext("./app", true, "\\.tsx?$", "i", "/proj/index.ts", std.testing.allocator, &hook_ctx);
     try std.testing.expect(result != null);
     defer freeMatches(std.testing.allocator, result.?);
 
@@ -157,7 +164,8 @@ test "runResolveContext: first non-null wins (multiple plugins)" {
         .{ .name = "should-not-call", .resolveContext = matchingCallback },
     };
     const runner = PluginRunner.init(&plugins);
-    const result = try runner.runResolveContext("./pages", true, null, null, "/proj/index.ts", std.testing.allocator);
+    var hook_ctx: plugin_mod.HookContext = .{};
+    const result = try runner.runResolveContext("./pages", true, null, null, "/proj/index.ts", std.testing.allocator, &hook_ctx);
     try std.testing.expect(result != null);
     defer freeMatches(std.testing.allocator, result.?);
     try std.testing.expectEqual(@as(usize, 3), result.?.len);
@@ -169,7 +177,8 @@ test "runResolveContext: all plugins null → null" {
         .{ .name = "null2", .resolveContext = nullCallback },
     };
     const runner = PluginRunner.init(&plugins);
-    const result = try runner.runResolveContext("./pages", true, null, null, "/proj/index.ts", std.testing.allocator);
+    var hook_ctx: plugin_mod.HookContext = .{};
+    const result = try runner.runResolveContext("./pages", true, null, null, "/proj/index.ts", std.testing.allocator, &hook_ctx);
     try std.testing.expect(result == null);
 }
 
@@ -177,7 +186,8 @@ test "runResolveContext: plugin returns empty slice (matched 0 files) — valid"
     RecordedCall.reset();
     const plugins = [_]Plugin{.{ .name = "empty", .resolveContext = captureCallback }};
     const runner = PluginRunner.init(&plugins);
-    const result = try runner.runResolveContext("./empty-dir", true, null, null, "/proj/index.ts", std.testing.allocator);
+    var hook_ctx: plugin_mod.HookContext = .{};
+    const result = try runner.runResolveContext("./empty-dir", true, null, null, "/proj/index.ts", std.testing.allocator, &hook_ctx);
     try std.testing.expect(result != null);
     defer freeMatches(std.testing.allocator, result.?);
     try std.testing.expectEqual(@as(usize, 0), result.?.len);
@@ -186,9 +196,10 @@ test "runResolveContext: plugin returns empty slice (matched 0 files) — valid"
 test "runResolveContext: plugin error propagated" {
     const plugins = [_]Plugin{.{ .name = "err", .resolveContext = errorCallback }};
     const runner = PluginRunner.init(&plugins);
+    var hook_ctx: plugin_mod.HookContext = .{};
     try std.testing.expectError(
         error.PluginFailed,
-        runner.runResolveContext("./pages", true, null, null, "/proj/index.ts", std.testing.allocator),
+        runner.runResolveContext("./pages", true, null, null, "/proj/index.ts", std.testing.allocator, &hook_ctx),
     );
 }
 

--- a/src/runtime_helper_modules.zig
+++ b/src/runtime_helper_modules.zig
@@ -384,6 +384,7 @@ fn resolveIdHook(
     specifier: []const u8,
     _: ?[]const u8,
     _: std.mem.Allocator,
+    _: *plugin_mod.HookContext,
 ) plugin_mod.PluginError!?plugin_mod.ResolvedModule {
     if (!isVirtualId(specifier)) return null;
     const short = specifier[ID_PREFIX.len..];
@@ -395,6 +396,7 @@ fn loadHook(
     ctx: ?*anyopaque,
     path: []const u8,
     allocator: std.mem.Allocator,
+    _: *plugin_mod.HookContext,
 ) plugin_mod.PluginError!?plugin_mod.LoadResult {
     if (!isVirtualId(path)) return null;
     const short = path[ID_PREFIX.len..];
@@ -608,21 +610,24 @@ test "smoke: 모든 MODULES 의 helper 가 source 에 export 됨" {
 test "loadHook: virtual ID → source 반환" {
     const allocator = std.testing.allocator;
     const opts = SourceOptions{};
-    const result = (try loadHook(@ptrCast(@constCast(&opts)), "\x00zntc:runtime/generator", allocator)).?;
+    var hook_ctx: plugin_mod.HookContext = .{};
+    const result = (try loadHook(@ptrCast(@constCast(&opts)), "\x00zntc:runtime/generator", allocator, &hook_ctx)).?;
     defer allocator.free(result.contents);
     try std.testing.expect(std.mem.indexOf(u8, result.contents, "__generator") != null);
 }
 
 test "loadHook: 비 virtual ID 는 null" {
     const allocator = std.testing.allocator;
-    const result = try loadHook(null, "/some/path.ts", allocator);
+    var hook_ctx: plugin_mod.HookContext = .{};
+    const result = try loadHook(null, "/some/path.ts", allocator, &hook_ctx);
     try std.testing.expect(result == null);
 }
 
 test "loadHook: 미등록 short 는 null" {
     const allocator = std.testing.allocator;
     const opts = SourceOptions{};
-    const result = try loadHook(@ptrCast(@constCast(&opts)), "\x00zntc:runtime/no-such-helper", allocator);
+    var hook_ctx: plugin_mod.HookContext = .{};
+    const result = try loadHook(@ptrCast(@constCast(&opts)), "\x00zntc:runtime/no-such-helper", allocator, &hook_ctx);
     try std.testing.expect(result == null);
 }
 
@@ -630,21 +635,23 @@ test "loadHook: ctx 의 minify 옵션이 source 에 반영 (alias export)" {
     // ctx 캐스트 회귀 방지 — ctx 가 무시되면 default_opts 사용해서 alias 가 없을 것.
     const allocator = std.testing.allocator;
     const opts = SourceOptions{ .minify = true };
-    const result = (try loadHook(@ptrCast(@constCast(&opts)), "\x00zntc:runtime/generator", allocator)).?;
+    var hook_ctx: plugin_mod.HookContext = .{};
+    const result = (try loadHook(@ptrCast(@constCast(&opts)), "\x00zntc:runtime/generator", allocator, &hook_ctx)).?;
     defer allocator.free(result.contents);
     try std.testing.expect(std.mem.indexOf(u8, result.contents, "$gn as __generator") != null);
 }
 
 test "resolveIdHook: virtual specifier 만 가로챔" {
     const allocator = std.testing.allocator;
-    const r1 = try resolveIdHook(null, "\x00zntc:runtime/generator", null, allocator);
+    var hook_ctx: plugin_mod.HookContext = .{};
+    const r1 = try resolveIdHook(null, "\x00zntc:runtime/generator", null, allocator, &hook_ctx);
     try std.testing.expect(r1 != null);
     try std.testing.expect(r1.? == .virtual);
 
-    const r2 = try resolveIdHook(null, "./local.ts", null, allocator);
+    const r2 = try resolveIdHook(null, "./local.ts", null, allocator, &hook_ctx);
     try std.testing.expect(r2 == null);
 
-    const r3 = try resolveIdHook(null, "\x00zntc:runtime/no-such-helper", null, allocator);
+    const r3 = try resolveIdHook(null, "\x00zntc:runtime/no-such-helper", null, allocator, &hook_ctx);
     try std.testing.expect(r3 == null);
 }
 
@@ -655,10 +662,11 @@ test "makePlugin: hook 호출이 ctx 통해 동작" {
     const p = makePlugin(&opts);
     try std.testing.expectEqualStrings("zntc:runtime-helpers", p.name);
 
-    const resolved = (try p.resolveId.?(p.context, "\x00zntc:runtime/generator", null, allocator)).?;
+    var hook_ctx: plugin_mod.HookContext = .{};
+    const resolved = (try p.resolveId.?(p.context, "\x00zntc:runtime/generator", null, allocator, &hook_ctx)).?;
     try std.testing.expect(resolved == .virtual);
 
-    const loaded = (try p.load.?(p.context, "\x00zntc:runtime/generator", allocator)).?;
+    const loaded = (try p.load.?(p.context, "\x00zntc:runtime/generator", allocator, &hook_ctx)).?;
     defer allocator.free(loaded.contents);
     try std.testing.expect(std.mem.indexOf(u8, loaded.contents, "__generator") != null);
 }

--- a/src/transformer/plugins/rn_codegen/snapshot_test.zig
+++ b/src/transformer/plugins/rn_codegen/snapshot_test.zig
@@ -22,6 +22,7 @@
 
 const std = @import("std");
 const codegen_plugin = @import("../rn_codegen_plugin.zig");
+const plugin_mod = @import("../../../bundler/plugin.zig");
 
 const SNAPSHOTS_ROOT = "tests/codegen-snapshots";
 
@@ -426,7 +427,8 @@ fn compareCase(suite: []const u8, fixture_name: []const u8, golden_name: []const
     defer alloc.free(golden);
 
     const plugin = codegen_plugin.plugin();
-    const zntc_out = (try plugin.transform.?(plugin.context, fixture, fixture_name, alloc)) orelse {
+    var hook_ctx: plugin_mod.HookContext = .{};
+    const zntc_out = (try plugin.transform.?(plugin.context, fixture, fixture_name, alloc, &hook_ctx)) orelse {
         std.debug.print("[{s}] ZNTC plugin returned null — fixture not transformed\n", .{fixture_name});
         return error.TestUnexpectedNull;
     };

--- a/src/transformer/plugins/rn_codegen_plugin.zig
+++ b/src/transformer/plugins/rn_codegen_plugin.zig
@@ -65,6 +65,7 @@ fn onTransform(
     code: []const u8,
     id: []const u8,
     alloc: std.mem.Allocator,
+    _: *@import("../../bundler/plugin.zig").HookContext,
 ) PluginError!?[]const u8 {
     _ = ctx;
 

--- a/src/transformer/plugins/rn_codegen_plugin_test.zig
+++ b/src/transformer/plugins/rn_codegen_plugin_test.zig
@@ -4,10 +4,12 @@
 
 const std = @import("std");
 const codegen_plugin = @import("rn_codegen_plugin.zig");
+const plugin_mod = @import("../../bundler/plugin.zig");
 
 fn callTransform(alloc: std.mem.Allocator, code: []const u8, id: []const u8) !?[]const u8 {
     const plugin = codegen_plugin.plugin();
-    return plugin.transform.?(plugin.context, code, id, alloc);
+    var hook_ctx: plugin_mod.HookContext = .{};
+    return plugin.transform.?(plugin.context, code, id, alloc, &hook_ctx);
 }
 
 fn expectContains(haystack: []const u8, needle: []const u8) !void {


### PR DESCRIPTION
## 개요

#1902 시리즈 머지 후 follow-up 정리 5개 중 **A (foundation)**.

`src/bundler/plugin.zig` 의 두 threadlocal 채널 — `last_plugin_failure`, `last_transform_source_maps` — 을 명시적 `*HookContext` out-param 으로 대체합니다. fallible plugin hook 의 시그니처가 hook_ctx 를 받도록 확장되고, NAPI bridge 와 graph caller 가 stack 에 만든 context 를 직접 읽고 씁니다.

## 동기

기존 패턴은 hook 이 `setLastPluginFailure(...)` 로 TLS 에 쓰고 graph 가 매 호출 직후 `takeLastPluginFailure()` 로 가져오는 형태:

- worker thread hop 시 TLS 가 다른 thread 에 잡혀 metadata 누락 가능
- 매 callsite 에서 take 호출 보일러플레이트
- 잊고 take 안 하면 다음 호출에서 stale 한 failure 가 따라옴
- 두 채널 (`last_plugin_failure`, `last_transform_source_maps`) 짝맞춰 관리

`HookContext` out-param 은 lifetime 이 stack frame 안으로 한정되고 contract 가 시그니처에 명시됩니다.

## 변경

- `plugin.zig`: `HookContext { failure, source_maps }` 타입 + `deinit()` 헬퍼 추가, threadlocal 두 개 + setter/getter 4개 제거, `PluginRunner` 메서드들 `*HookContext` 받도록 확장.
- `napi_entry.zig`: `NapiPlugin` / `NapiSyncPlugin` 의 `failWithResponse` / `setResponseSourceMaps` 가 TLS 대신 out-param 에 쓰고, 모든 hook 구현이 `*HookContext` 를 받아 위로 전달.
- `graph.zig` (4 sites) / `bundler.zig` / `emitter.zig` / `emitter/chunks.zig`: 호출 사이트마다 `var hook_ctx: HookContext = .{}` + `defer hook_ctx.deinit()` (또는 consume via `addPluginFailureDiag`).
- builtin plugins (`runtime_helper_modules`, `rn_codegen_plugin`) 시그니처 확장.
- 테스트 hook (~30개) signature update.

## /simplify pass 적용

3-에이전트 리뷰 후 채택:
- `runTransform` 의 `inner_ctx.failure = hook_ctx.failure` 시드 제거 — plugin 이 failure 를 read 하는 contract 없음, vestigial.
- `HookContext.deinit()` 헬퍼 추출 — 6+ swallow 사이트의 `defer if (hook_ctx.failure) |f| f.deinit();` 보일러플레이트 정리. `graph.zig:4625` 의 `catch blk:` 도 `defer + catch null` 로 단순화.

## 검증

- `zig build napi`
- `zig build test --summary all` 4721 pass
- `bun test packages/core/index.test.ts` 417 pass
- `bun run --cwd packages/core build:js`
- `bun run fmt:check`
- `zig fmt --check src packages/core/src/napi_entry.zig`
- `git diff --check`
- `bun run lint` (기존 warning 21개, error 0)
- pre-push hook (zig fmt + zig build test + oxlint + oxfmt) 통과

## Test plan

- [x] `zig build test` — bundler/plugin/graph/transformer 전부 PASS
- [x] `bun test packages/core` — JS dispatcher 통합 회귀 PASS
- [x] sourcemap chain (#1902 PR 2) 회귀: integration sourcemap 4 파일 PASS
- [x] buildSync sync plugin (#1902 PR 3) 회귀: 4 신규 테스트 PASS

## Follow-up (A 완료 후 순서)

- B+D: dispatcher async/sync 통합 + buildEnd/closeBundle single channel
- C: NapiPlugin/NapiSyncPlugin per-hook adapter dedup
- E: dev.zig addModuleMappings traced/untraced 통합 + struct args
- F: dispatcher map/maps key 통일

Refs #1902