### PR TITLE
Fix RN HMR loading toast

### DIFF
--- a/packages/react-native/runtime/zntc-hmr-client.js
+++ b/packages/react-native/runtime/zntc-hmr-client.js
@@ -5,18 +5,99 @@
  */
 'use strict';
 
-// Metro HMRClient 와 동일한 'Refreshing...' 배너 동작을 위해 NativeModules.DevLoadingView 접근.
-// RN global 이 채워지기 전/환경 부재 상황 (web, 테스트) 에선 조용히 no-op.
-function getDevLoadingView() {
+var REFRESH_TEXT_COLOR = -1; // #ffffff
+var REFRESH_BACKGROUND_COLOR = -14318360; // #2584e8
+
+function getRoot() {
+  return (
+    (typeof global !== 'undefined' && global) ||
+    (typeof globalThis !== 'undefined' && globalThis) ||
+    (typeof window !== 'undefined' && window) ||
+    null
+  );
+}
+
+function getDirectNativeDevLoadingView() {
   try {
-    var nm =
-      (typeof global !== 'undefined' && global.NativeModules) ||
-      (typeof window !== 'undefined' && window.NativeModules) ||
-      null;
-    return nm && nm.DevLoadingView ? nm.DevLoadingView : null;
+    var root = getRoot();
+    if (root) {
+      if (root.nativeModuleProxy && root.nativeModuleProxy.DevLoadingView) {
+        return root.nativeModuleProxy.DevLoadingView;
+      }
+      if (typeof root.__turboModuleProxy === 'function') {
+        var turboModule = root.__turboModuleProxy('DevLoadingView');
+        if (turboModule) return turboModule;
+      }
+      if (root.NativeModules && root.NativeModules.DevLoadingView) {
+        return root.NativeModules.DevLoadingView;
+      }
+    }
   } catch (_e) {
-    return null;
+    // fallback 으로 내려간다.
   }
+
+  try {
+    if (typeof require === 'function') {
+      var nativeModules = require('../BatchedBridge/NativeModules');
+      nativeModules = nativeModules && (nativeModules.default || nativeModules);
+      if (nativeModules && nativeModules.DevLoadingView) {
+        return nativeModules.DevLoadingView;
+      }
+    }
+  } catch (_e) {
+    // fallback 으로 내려간다.
+  }
+
+  try {
+    if (typeof require === 'function') {
+      var rn = require('react-native');
+      var rnNativeModules = rn && rn.NativeModules;
+      if (rnNativeModules && rnNativeModules.DevLoadingView) {
+        return rnNativeModules.DevLoadingView;
+      }
+    }
+  } catch (_e) {
+    // fallback 으로 내려간다.
+  }
+
+  return null;
+}
+
+function wrapNativeDevLoadingView(nativeDevLoadingView) {
+  return {
+    showMessage: function (message, _type, options) {
+      nativeDevLoadingView.showMessage(
+        message,
+        REFRESH_TEXT_COLOR,
+        REFRESH_BACKGROUND_COLOR,
+        !!(options && options.dismissButton),
+      );
+    },
+    hide: function () {
+      nativeDevLoadingView.hide();
+    },
+  };
+}
+
+// Metro HMRClient 는 RN DevLoadingView wrapper 를 require 한다. zntc 번들에서는
+// wrapper 내부 NativeDevLoadingView 값이 초기화 시점에 null 로 굳을 수 있어,
+// 호출 시점 native module 재조회 경로를 먼저 사용한다.
+function getDevLoadingView() {
+  var nativeDevLoadingView = getDirectNativeDevLoadingView();
+  if (nativeDevLoadingView && typeof nativeDevLoadingView.showMessage === 'function') {
+    return wrapNativeDevLoadingView(nativeDevLoadingView);
+  }
+
+  try {
+    if (typeof require === 'function') {
+      var mod = require('./DevLoadingView');
+      return mod && (mod.default || mod) ? mod.default || mod : null;
+    }
+  } catch (_e) {
+    // RN module resolution 실패 시 fallback 으로 내려간다.
+  }
+
+  return null;
 }
 
 var HMRClient = {
@@ -25,6 +106,28 @@ var HMRClient = {
   _originalConsole: null,
   // Metro 처럼 중첩 update 를 카운트 — 마지막 update-done 에서만 배너 hide.
   _pendingUpdates: 0,
+
+  _showRefreshing: function () {
+    var dlvStart = getDevLoadingView();
+    if (dlvStart && typeof dlvStart.showMessage === 'function') {
+      try {
+        dlvStart.showMessage('Refreshing...', 'refresh');
+      } catch (_e) {
+        // DevLoadingView 호출 실패는 HMR 동작과 무관 — 무시
+      }
+    }
+  },
+
+  _hideRefreshing: function () {
+    var dlvDone = getDevLoadingView();
+    if (dlvDone && typeof dlvDone.hide === 'function') {
+      try {
+        dlvDone.hide();
+      } catch (_e) {
+        // 무시
+      }
+    }
+  },
 
   enable: function () {
     this._enabled = true;
@@ -128,14 +231,7 @@ var HMRClient = {
             // 실제 코드 변경이 아니므로 "Refreshing..." 배너 노출 skip.
             // Metro HMRClient 동일 동작 (isInitialUpdate flag 검사).
             if (self._enabled && !msg.isInitialUpdate) {
-              var dlvStart = getDevLoadingView();
-              if (dlvStart && typeof dlvStart.showMessage === 'function') {
-                try {
-                  dlvStart.showMessage('Refreshing...', 'refresh');
-                } catch (_e) {
-                  // DevLoadingView 호출 실패는 HMR 동작과 무관 — 무시
-                }
-              }
+              self._showRefreshing();
             }
             break;
           case 'hmr:update':
@@ -179,14 +275,7 @@ var HMRClient = {
           case 'hmr:update-done':
             if (self._pendingUpdates > 0) self._pendingUpdates--;
             if (self._pendingUpdates === 0) {
-              var dlvDone = getDevLoadingView();
-              if (dlvDone && typeof dlvDone.hide === 'function') {
-                try {
-                  dlvDone.hide();
-                } catch (_e) {
-                  // 무시
-                }
-              }
+              self._hideRefreshing();
             }
             break;
           case 'hmr:reload':

--- a/packages/react-native/runtime/zntc-hmr-client.js
+++ b/packages/react-native/runtime/zntc-hmr-client.js
@@ -79,9 +79,8 @@ function wrapNativeDevLoadingView(nativeDevLoadingView) {
   };
 }
 
-// Metro HMRClient 는 RN DevLoadingView wrapper 를 require 한다. zntc 번들에서는
 // wrapper 내부 NativeDevLoadingView 값이 초기화 시점에 null 로 굳을 수 있어,
-// 호출 시점 native module 재조회 경로를 먼저 사용한다.
+// 호출 시점 native module 재조회 경로를 먼저 시도한 뒤 require 로 폴백.
 function getDevLoadingView() {
   var nativeDevLoadingView = getDirectNativeDevLoadingView();
   if (nativeDevLoadingView && typeof nativeDevLoadingView.showMessage === 'function') {
@@ -104,29 +103,30 @@ var HMRClient = {
   _socket: null,
   _enabled: true,
   _originalConsole: null,
-  // Metro 처럼 중첩 update 를 카운트 — 마지막 update-done 에서만 배너 hide.
+  // 중첩 update 카운트 — 마지막 update-done 에서만 배너 hide.
   _pendingUpdates: 0,
+  // lazy cache — 첫 호출 때 1회 lookup (native module 가 setup 시점엔 아직 미로드).
+  // socket.onclose 에서 invalidate — reconnect 시 module 상태 재조회.
+  _devLoadingView: null,
 
-  _showRefreshing: function () {
-    var dlvStart = getDevLoadingView();
-    if (dlvStart && typeof dlvStart.showMessage === 'function') {
+  _safeCallDlv: function (method, args) {
+    if (this._devLoadingView == null) this._devLoadingView = getDevLoadingView();
+    var dlv = this._devLoadingView;
+    if (dlv && typeof dlv[method] === 'function') {
       try {
-        dlvStart.showMessage('Refreshing...', 'refresh');
+        dlv[method].apply(dlv, args);
       } catch (_e) {
         // DevLoadingView 호출 실패는 HMR 동작과 무관 — 무시
       }
     }
   },
 
+  _showRefreshing: function () {
+    this._safeCallDlv('showMessage', ['Refreshing...', 'refresh']);
+  },
+
   _hideRefreshing: function () {
-    var dlvDone = getDevLoadingView();
-    if (dlvDone && typeof dlvDone.hide === 'function') {
-      try {
-        dlvDone.hide();
-      } catch (_e) {
-        // 무시
-      }
-    }
+    this._safeCallDlv('hide', []);
   },
 
   enable: function () {
@@ -227,9 +227,8 @@ var HMRClient = {
         switch (msg.type) {
           case 'hmr:update-start':
             self._pendingUpdates++;
-            // Initial update sequence (서버가 connect 시 전송해 로딩바 dismiss 용) 는
-            // 실제 코드 변경이 아니므로 "Refreshing..." 배너 노출 skip.
-            // Metro HMRClient 동일 동작 (isInitialUpdate flag 검사).
+            // initial sequence (connect 시 로딩바 dismiss 용) 는 실제 코드 변경이
+            // 아니므로 "Refreshing..." 배너 노출 skip.
             if (self._enabled && !msg.isInitialUpdate) {
               self._showRefreshing();
             }
@@ -318,6 +317,22 @@ var HMRClient = {
     };
 
     socket.onclose = function () {
+      // console intercept 복원 — reconnect 시 stale closure / 중복 wrap 방지.
+      if (self._originalConsole) {
+        for (var level in self._originalConsole) {
+          if (Object.prototype.hasOwnProperty.call(self._originalConsole, level)) {
+            console[level] = self._originalConsole[level];
+          }
+        }
+        self._originalConsole = null;
+      }
+      // 중첩 update 도중 socket drop 시 stuck banner 방지.
+      if (self._pendingUpdates > 0) {
+        self._pendingUpdates = 0;
+        self._hideRefreshing();
+      }
+      // DevLoadingView cache 무효화 — reconnect 시 module 상태 변경 가능.
+      self._devLoadingView = null;
       self._socket = null;
     };
   },

--- a/packages/react-native/src/dev-server/hmr-bridge.test.ts
+++ b/packages/react-native/src/dev-server/hmr-bridge.test.ts
@@ -16,6 +16,8 @@ function fakeState(platform: 'ios' | 'android' = 'ios'): PlatformState {
       getHmrSourceMap: () => null,
     } as unknown as WatchHandle,
     bundle: null,
+    bundleStale: false,
+    refreshBundle: async () => {},
     sourceMapCache: null,
     buildError: null,
     fileCount: 1,

--- a/packages/react-native/src/dev-server/platform-state.test.ts
+++ b/packages/react-native/src/dev-server/platform-state.test.ts
@@ -279,10 +279,7 @@ describe('createPlatformState — onReady/onRebuild 콜백 (Finding #7)', () => 
 
       writeFileSync(join(dir, 'src/util.ts'), 'export const value = "graph-second";\n');
       await new Promise((r) => setTimeout(r, 100));
-      writeFileSync(
-        entryPath,
-        'import { value } from "./util";\nconsole.log(value);\n',
-      );
+      writeFileSync(entryPath, 'import { value } from "./util";\nconsole.log(value);\n');
 
       const { state, event } = await rebuildP;
       expect(event.success).toBe(true);

--- a/packages/react-native/src/dev-server/platform-state.test.ts
+++ b/packages/react-native/src/dev-server/platform-state.test.ts
@@ -39,6 +39,8 @@ function fakeState(overrides: Partial<PlatformState> = {}): PlatformState {
     outputPath: '/tmp/x/bundle.js',
     handle,
     bundle: null,
+    bundleStale: false,
+    refreshBundle: async () => {},
     sourceMapCache: null,
     buildError: null,
     fileCount: 1,
@@ -60,6 +62,8 @@ describe('getCachedSourceMap', () => {
       outputPath: '/tmp/b.js',
       handle,
       bundle: null,
+      bundleStale: false,
+      refreshBundle: async () => {},
       sourceMapCache: null,
       buildError: null,
       fileCount: 1,
@@ -84,6 +88,8 @@ describe('getCachedSourceMap', () => {
       outputPath: '/tmp/b.js',
       handle,
       bundle: null,
+      bundleStale: false,
+      refreshBundle: async () => {},
       sourceMapCache: null,
       buildError: null,
       fileCount: 1,
@@ -108,6 +114,8 @@ describe('getCachedSourceMap', () => {
       outputPath: '/tmp/b.js',
       handle,
       bundle: null,
+      bundleStale: false,
+      refreshBundle: async () => {},
       sourceMapCache: '{"v":3}',
       buildError: null,
       fileCount: 1,
@@ -213,6 +221,79 @@ describe('createPlatformStateRegistry — 캐싱', () => {
 });
 
 describe('createPlatformState — onReady/onRebuild 콜백 (Finding #7)', () => {
+  test('dev HMR rebuild 는 풀 bundle state 를 stale 로 표시하고 필요 시 재생성', async () => {
+    const opts = buildRnDevServerOptions({
+      bundle: { entry: entryPath, projectRoot: dir, rnPlatform: 'ios', dev: true },
+    });
+    const { promise: rebuildP, resolve: rebuildDone } = Promise.withResolvers<{
+      state: PlatformState;
+      event: { updates?: Array<{ id: string; code: string }>; graphChanged?: boolean };
+    }>();
+    const registry = createPlatformStateRegistry(opts, {
+      onRebuild(state, event) {
+        if (event.updates && event.updates.length > 0) {
+          rebuildDone({ state, event });
+        }
+      },
+    });
+    try {
+      const ios = registry.getOrCreate('ios');
+      await waitForBuild(ios);
+      const initial = ios.bundle;
+      expect(initial).toContain('hi');
+
+      await new Promise((r) => setTimeout(r, 100));
+      writeFileSync(entryPath, 'console.log("second");\n');
+
+      const { state, event } = await rebuildP;
+      expect(event.graphChanged).toBeFalsy();
+      expect(state.bundleStale).toBe(true);
+      expect(state.bundle).toBe(initial);
+
+      await state.refreshBundle();
+      expect(state.bundleStale).toBe(false);
+      expect(state.bundle).toContain('second');
+    } finally {
+      await registry.stopAll();
+    }
+  }, 10000);
+
+  test('dev graphChanged 는 reload callback 전 풀 bundle 을 갱신', async () => {
+    const opts = buildRnDevServerOptions({
+      bundle: { entry: entryPath, projectRoot: dir, rnPlatform: 'ios', dev: true },
+    });
+    const { promise: rebuildP, resolve: rebuildDone } = Promise.withResolvers<{
+      state: PlatformState;
+      event: { success: boolean; graphChanged?: boolean };
+    }>();
+    const registry = createPlatformStateRegistry(opts, {
+      onRebuild(state, event) {
+        if (event.graphChanged || !event.success) {
+          rebuildDone({ state, event });
+        }
+      },
+    });
+    try {
+      const ios = registry.getOrCreate('ios');
+      await waitForBuild(ios);
+
+      writeFileSync(join(dir, 'src/util.ts'), 'export const value = "graph-second";\n');
+      await new Promise((r) => setTimeout(r, 100));
+      writeFileSync(
+        entryPath,
+        'import { value } from "./util";\nconsole.log(value);\n',
+      );
+
+      const { state, event } = await rebuildP;
+      expect(event.success).toBe(true);
+      expect(event.graphChanged).toBe(true);
+      expect(state.bundleStale).toBe(false);
+      expect(state.bundle).toContain('graph-second');
+    } finally {
+      await registry.stopAll();
+    }
+  }, 10000);
+
   test('stopAll 시 watch handle 의 stop 이 throw 해도 silent', async () => {
     // platform-state.ts 의 stopAll try/catch 분기 검증. handle.stop 이 throw 하면
     // 다른 platform 의 cleanup 이 영향 받지 않아야 함.

--- a/packages/react-native/src/dev-server/platform-state.ts
+++ b/packages/react-native/src/dev-server/platform-state.ts
@@ -8,7 +8,7 @@ import { join } from 'node:path';
 
 import type { WatchHandle, WatchReadyEvent, WatchRebuildEvent } from '@zntc/core';
 
-import { watchRn } from '../preset.ts';
+import { bundleRn, watchRn } from '../preset.ts';
 import type { RnDevServerOptions } from './options.ts';
 import { postProcessSourceMap } from './sourcemap.ts';
 
@@ -20,6 +20,8 @@ export interface PlatformState {
   readonly outputPath: string;
   handle: WatchHandle;
   bundle: string | null;
+  bundleStale: boolean;
+  refreshBundle: () => Promise<void>;
   /** rebuild 마다 invalidate. 같은 build 안에서 여러 sourcemap 요청 시 재사용. */
   sourceMapCache: string | null;
   buildError: string | null;
@@ -46,6 +48,12 @@ export interface PlatformStateCallbacks {
   onRebuild?: (state: PlatformState, event: WatchRebuildEvent) => void;
 }
 
+function getBundleText(result: Awaited<ReturnType<typeof bundleRn>>): string {
+  const jsFile = result.outputFiles.find((file) => file.path.endsWith('.js')) ?? result.outputFiles[0];
+  if (!jsFile) throw new Error('Build produced no output');
+  return jsFile.text.replace(SOURCE_MAPPING_URL_RE, '');
+}
+
 /**
  * platform 별 watch + state 생성. 첫 build 는 비동기 — caller 가
  * `waitForBuild(state)` 로 대기. RN runtime 이 ios+android 동시 요청 시
@@ -61,6 +69,7 @@ export function createPlatformState(
 
   // bundle 의 RnBundleInput 의 rnPlatform 만 override — 다른 필드 그대로 유지.
   const platformBundle = { ...options.bundle, rnPlatform: platform };
+  let refreshPromise: Promise<void> | null = null;
 
   const state: PlatformState = {
     platform,
@@ -71,11 +80,33 @@ export function createPlatformState(
     // 만들지 않으므로 초기 undefined window 누수 없음.
     handle: undefined as unknown as WatchHandle,
     bundle: null,
+    bundleStale: false,
+    refreshBundle: () => refreshPlatformBundle(),
     sourceMapCache: null,
     buildError: null,
     fileCount: 1,
     lastRebuildTime: Date.now(),
   };
+
+  function refreshPlatformBundle(): Promise<void> {
+    if (!state.bundleStale && state.bundle !== null) return Promise.resolve();
+    if (refreshPromise) return refreshPromise;
+    refreshPromise = bundleRn(platformBundle)
+      .then((result) => {
+        state.bundle = getBundleText(result);
+        state.buildError = null;
+        state.bundleStale = false;
+      })
+      .catch((err) => {
+        state.bundle = null;
+        state.buildError = err instanceof Error ? err.message : String(err);
+        state.bundleStale = false;
+      })
+      .finally(() => {
+        refreshPromise = null;
+      });
+    return refreshPromise;
+  }
 
   if (process.env.ZNTC_DEBUG_TERMINAL === '1') {
     process.stderr.write(
@@ -89,6 +120,7 @@ export function createPlatformState(
       if (event.files) state.fileCount = event.files;
       if (existsSync(outputPath)) {
         state.bundle = readFileSync(outputPath, 'utf-8').replace(SOURCE_MAPPING_URL_RE, '');
+        state.bundleStale = false;
       } else {
         state.buildError = 'Build produced no output';
       }
@@ -104,8 +136,30 @@ export function createPlatformState(
       state.buildError = null;
       // rebuild 마다 cache invalidate — 다음 요청 시 lazy getter 가 swap fetch.
       state.sourceMapCache = null;
+      if (platformBundle.dev) {
+        if (event.graphChanged) {
+          state.bundleStale = true;
+          return state.refreshBundle().then(() => {
+            if (state.buildError) {
+              callbacks?.onRebuild?.(state, {
+                ...event,
+                success: false,
+                error: state.buildError,
+              });
+              return;
+            }
+            callbacks?.onRebuild?.(state, event);
+          });
+        }
+        if (event.updates && event.updates.length > 0) {
+          state.bundleStale = true;
+        }
+        callbacks?.onRebuild?.(state, event);
+        return;
+      }
       if (existsSync(outputPath)) {
         state.bundle = readFileSync(outputPath, 'utf-8').replace(SOURCE_MAPPING_URL_RE, '');
+        state.bundleStale = false;
       }
       callbacks?.onRebuild?.(state, event);
     },

--- a/packages/react-native/src/dev-server/platform-state.ts
+++ b/packages/react-native/src/dev-server/platform-state.ts
@@ -49,7 +49,8 @@ export interface PlatformStateCallbacks {
 }
 
 function getBundleText(result: Awaited<ReturnType<typeof bundleRn>>): string {
-  const jsFile = result.outputFiles.find((file) => file.path.endsWith('.js')) ?? result.outputFiles[0];
+  const jsFile =
+    result.outputFiles.find((file) => file.path.endsWith('.js')) ?? result.outputFiles[0];
   if (!jsFile) throw new Error('Build produced no output');
   return jsFile.text.replace(SOURCE_MAPPING_URL_RE, '');
 }

--- a/packages/react-native/src/dev-server/routes/bundle.test.ts
+++ b/packages/react-native/src/dev-server/routes/bundle.test.ts
@@ -66,6 +66,8 @@ function makeState(overrides: Partial<PlatformState> = {}): PlatformState {
     outputPath: '/tmp/b.js',
     handle: fakeHandle(),
     bundle: null,
+    bundleStale: false,
+    refreshBundle: async () => {},
     sourceMapCache: null,
     buildError: null,
     fileCount: 1,
@@ -162,6 +164,33 @@ describe('handleBundleRequest', () => {
     expect(body).toContain('console.log(1);');
     expect(body).toContain('//# sourceMappingURL=http://x:8081/index.map?platform=ios&dev=true');
     expect(body).toContain('//# sourceURL=');
+  });
+
+  test('stale bundle 이면 refreshBundle 후 응답', async () => {
+    let refreshed = 0;
+    const state = makeState({
+      bundle: 'old;',
+      bundleStale: true,
+      refreshBundle: async () => {
+        refreshed++;
+        state.bundle = 'new;';
+        state.bundleStale = false;
+      },
+    });
+    const registry = fixedRegistry(state);
+    const res = makeRes();
+    await handleBundleRequest(
+      makeReq('x:8081') as never,
+      res as unknown as ServerResponse,
+      new URL('http://x:8081/index.bundle?platform=ios&dev=true'),
+      registry,
+      'ios',
+      '/proj',
+      8081,
+    );
+    expect(refreshed).toBe(1);
+    expect(res.statusCode).toBe(200);
+    expect(res.chunks.join('')).toContain('new;');
   });
 
   test('multipart/mixed accept → progress + bundle chunks', async () => {

--- a/packages/react-native/src/dev-server/routes/bundle.ts
+++ b/packages/react-native/src/dev-server/routes/bundle.ts
@@ -46,6 +46,9 @@ export async function handleBundleRequest(
   if (state.bundle === null && state.buildError === null) {
     await waitForBuild(state);
   }
+  if (state.bundleStale && state.buildError === null) {
+    await state.refreshBundle();
+  }
 
   if (state.buildError) {
     sendText(

--- a/packages/react-native/src/dev-server/routes/symbolicate.test.ts
+++ b/packages/react-native/src/dev-server/routes/symbolicate.test.ts
@@ -42,6 +42,8 @@ function makeState(bundleMap: string | null = null): PlatformState {
       getHmrSourceMap: () => null,
     } as unknown as WatchHandle,
     bundle: null,
+    bundleStale: false,
+    refreshBundle: async () => {},
     sourceMapCache: null,
     buildError: null,
     fileCount: 1,

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -476,7 +476,7 @@ export async function bundleRn(input: RnBundleInput): Promise<BuildResult> {
 export interface RnWatchInput extends RnBundleInput {
   outfile: string;
   onReady?: (event: WatchReadyEvent) => void;
-  onRebuild?: (event: WatchRebuildEvent) => void;
+  onRebuild?: (event: WatchRebuildEvent) => void | Promise<void>;
 }
 
 /**

--- a/packages/react-native/src/runtime/zntc-hmr-client.test.mjs
+++ b/packages/react-native/src/runtime/zntc-hmr-client.test.mjs
@@ -20,6 +20,7 @@ function loadHmrClient(globalEnv) {
     var location = arguments[6];
     var window = arguments[7];
     var __ZNTC_FORWARD_CLIENT_LOGS__ = arguments[8];
+    var require = arguments[9];
     ${HMR_CLIENT_SOURCE}
     return module.exports;
   `;
@@ -34,6 +35,7 @@ function loadHmrClient(globalEnv) {
     globalEnv.location,
     globalEnv.window,
     globalEnv.forwardClientLogs,
+    globalEnv.require,
   );
 }
 
@@ -66,16 +68,18 @@ MockWebSocket.instances = [];
 let HMRClient;
 let mockGlobal;
 let mockConsole;
+let mockDevLoadingView;
 // wrap 전 console.X 의 mock 보존 — onopen 에서 console.X 가 wrappedFn 으로
 // 교체되므로 toHaveBeenCalledWith 검증 시 wrap 전 ref 사용 필요.
 let originalConsole;
 
 beforeEach(() => {
   MockWebSocket.reset();
+  mockDevLoadingView = {
+    showMessage: mock(() => {}),
+    hide: mock(() => {}),
+  };
   mockGlobal = {
-    NativeModules: {
-      DevLoadingView: { showMessage: mock(() => {}), hide: mock(() => {}) },
-    },
     WebSocket: MockWebSocket,
     __zntc_apply_update: mock(() => {}),
     __zntc_reload: mock(() => {}),
@@ -97,6 +101,10 @@ beforeEach(() => {
     location: { reload: mock(() => {}) },
     window: undefined,
     forwardClientLogs: true,
+    require: (specifier) => {
+      if (specifier === './DevLoadingView') return { default: mockDevLoadingView };
+      throw new Error(`Unexpected require: ${specifier}`);
+    },
   });
 });
 
@@ -176,6 +184,45 @@ describe('onopen — hmr:connected + console wrap', () => {
     expect(log.data).toEqual(['hello']);
   });
 
+  test('nativeModuleProxy.DevLoadingView 가 있으면 호출 시점 native module 을 직접 사용', () => {
+    const nativeDevLoadingView = {
+      showMessage: mock(() => {}),
+      hide: mock(() => {}),
+    };
+    HMRClient = loadHmrClient({
+      global: {
+        ...mockGlobal,
+        nativeModuleProxy: { DevLoadingView: nativeDevLoadingView },
+      },
+      WebSocket: MockWebSocket,
+      console: mockConsole,
+      __zntc_apply_update: mockGlobal.__zntc_apply_update,
+      __zntc_reload: mockGlobal.__zntc_reload,
+      location: { reload: mock(() => {}) },
+      window: undefined,
+      forwardClientLogs: true,
+      require: (specifier) => {
+        if (specifier === './DevLoadingView') return { default: mockDevLoadingView };
+        throw new Error(`Unexpected require: ${specifier}`);
+      },
+    });
+    HMRClient.setup('ios', '/abs/idx.js', 'localhost', 8081, true, 'http');
+    const ws = MockWebSocket.instances[0];
+    ws.onopen();
+
+    ws.onmessage({ data: JSON.stringify({ type: 'hmr:update-start' }) });
+    ws.onmessage({ data: JSON.stringify({ type: 'hmr:update-done' }) });
+
+    expect(nativeDevLoadingView.showMessage).toHaveBeenCalledWith(
+      'Refreshing...',
+      -1,
+      -14318360,
+      false,
+    );
+    expect(nativeDevLoadingView.hide).toHaveBeenCalled();
+    expect(mockDevLoadingView.showMessage).not.toHaveBeenCalled();
+  });
+
   test('forwardClientLogs=false — console wrap 하지 않음', () => {
     HMRClient = loadHmrClient({
       global: mockGlobal,
@@ -186,6 +233,10 @@ describe('onopen — hmr:connected + console wrap', () => {
       location: { reload: mock(() => {}) },
       window: undefined,
       forwardClientLogs: false,
+      require: (specifier) => {
+        if (specifier === './DevLoadingView') return { default: mockDevLoadingView };
+        throw new Error(`Unexpected require: ${specifier}`);
+      },
     });
     HMRClient.setup('ios', '/abs/idx.js', 'localhost', 8081, true, 'http');
     const ws = MockWebSocket.instances[0];
@@ -228,13 +279,13 @@ describe('onmessage — Metro 메시지 분기', () => {
   test('hmr:update-start (isInitial=true) — DevLoadingView.showMessage 호출 안 함', () => {
     const ws = setupConnected();
     ws.onmessage({ data: JSON.stringify({ type: 'hmr:update-start', isInitialUpdate: true }) });
-    expect(mockGlobal.NativeModules.DevLoadingView.showMessage).not.toHaveBeenCalled();
+    expect(mockDevLoadingView.showMessage).not.toHaveBeenCalled();
   });
 
   test("hmr:update-start (incremental) — DevLoadingView.showMessage('Refreshing...', 'refresh')", () => {
     const ws = setupConnected();
     ws.onmessage({ data: JSON.stringify({ type: 'hmr:update-start' }) });
-    expect(mockGlobal.NativeModules.DevLoadingView.showMessage).toHaveBeenCalledWith(
+    expect(mockDevLoadingView.showMessage).toHaveBeenCalledWith(
       'Refreshing...',
       'refresh',
     );
@@ -257,7 +308,7 @@ describe('onmessage — Metro 메시지 분기', () => {
     const ws = setupConnected();
     ws.onmessage({ data: JSON.stringify({ type: 'hmr:update-start' }) });
     ws.onmessage({ data: JSON.stringify({ type: 'hmr:update-done' }) });
-    expect(mockGlobal.NativeModules.DevLoadingView.hide).toHaveBeenCalled();
+    expect(mockDevLoadingView.hide).toHaveBeenCalled();
   });
 
   test('hmr:update-done 중첩 — 마지막 update-done 에서만 hide', () => {
@@ -265,15 +316,38 @@ describe('onmessage — Metro 메시지 분기', () => {
     ws.onmessage({ data: JSON.stringify({ type: 'hmr:update-start' }) });
     ws.onmessage({ data: JSON.stringify({ type: 'hmr:update-start' }) });
     ws.onmessage({ data: JSON.stringify({ type: 'hmr:update-done' }) });
-    expect(mockGlobal.NativeModules.DevLoadingView.hide).not.toHaveBeenCalled();
+    expect(mockDevLoadingView.hide).not.toHaveBeenCalled();
     ws.onmessage({ data: JSON.stringify({ type: 'hmr:update-done' }) });
-    expect(mockGlobal.NativeModules.DevLoadingView.hide).toHaveBeenCalledTimes(1);
+    expect(mockDevLoadingView.hide).toHaveBeenCalledTimes(1);
   });
 
   test('hmr:reload — __zntc_reload 호출', () => {
     const ws = setupConnected();
     ws.onmessage({ data: JSON.stringify({ type: 'hmr:reload' }) });
     expect(mockGlobal.__zntc_reload).toHaveBeenCalled();
+  });
+
+  test('hmr:reload — __zntc_reload 없으면 location.reload fallback', () => {
+    const reload = mock(() => {});
+    HMRClient = loadHmrClient({
+      global: mockGlobal,
+      WebSocket: MockWebSocket,
+      console: mockConsole,
+      __zntc_apply_update: mockGlobal.__zntc_apply_update,
+      __zntc_reload: undefined,
+      location: { reload },
+      window: undefined,
+      forwardClientLogs: true,
+      require: (specifier) => {
+        if (specifier === './DevLoadingView') return { default: mockDevLoadingView };
+        throw new Error(`Unexpected require: ${specifier}`);
+      },
+    });
+    const ws = setupConnected();
+
+    ws.onmessage({ data: JSON.stringify({ type: 'hmr:reload' }) });
+
+    expect(reload).toHaveBeenCalled();
   });
 
   test('hmr:error — console.error (backward-compat: body 없음)', () => {
@@ -342,7 +416,7 @@ describe('onmessage — Metro 메시지 분기', () => {
     const ws = setupConnected();
     HMRClient.disable();
     ws.onmessage({ data: JSON.stringify({ type: 'hmr:update-start' }) });
-    expect(mockGlobal.NativeModules.DevLoadingView.showMessage).not.toHaveBeenCalled();
+    expect(mockDevLoadingView.showMessage).not.toHaveBeenCalled();
     ws.onmessage({ data: JSON.stringify({ type: 'hmr:error', message: 'x' }) });
     expect(originalConsole.error).toHaveBeenCalledWith('[ZNTC HMR]', 'x');
   });

--- a/packages/react-native/src/runtime/zntc-hmr-client.test.mjs
+++ b/packages/react-native/src/runtime/zntc-hmr-client.test.mjs
@@ -285,10 +285,7 @@ describe('onmessage — Metro 메시지 분기', () => {
   test("hmr:update-start (incremental) — DevLoadingView.showMessage('Refreshing...', 'refresh')", () => {
     const ws = setupConnected();
     ws.onmessage({ data: JSON.stringify({ type: 'hmr:update-start' }) });
-    expect(mockDevLoadingView.showMessage).toHaveBeenCalledWith(
-      'Refreshing...',
-      'refresh',
-    );
+    expect(mockDevLoadingView.showMessage).toHaveBeenCalledWith('Refreshing...', 'refresh');
   });
 
   test('hmr:update — __zntc_apply_update 호출 with modules', () => {


### PR DESCRIPTION
## Summary
- Resolve React Native HMR loading toast not appearing under ZNTC by resolving the native DevLoadingView at call time.
- Keep Metro-compatible DevLoadingView wrapper fallback while preferring direct native handles when available.
- Avoid regenerating/reading the full RN dev bundle on every HMR update; refresh the full bundle lazily when it is requested or before graph-change reloads.

## Tests
- `bun test src/runtime/zntc-hmr-client.test.mjs`
- `bun test --timeout 10000`
- `zig build test --summary none`
- `bun run build`