### PR TITLE
refactor(emitter): addModuleMappings traced/identity 통합 + struct args

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -751,20 +751,20 @@ pub fn emitWithTreeShaking(
             if (results[i].mappings) |maps| {
                 const region_lines: u32 = if (options.minify_whitespace) 0 else 1;
                 const endregion_lines: u32 = if (options.minify_whitespace) 0 else 1;
-                try addModuleMappings(
-                    sm,
-                    sourcemapSourcePath(m.path, options),
-                    m.source,
-                    maps,
-                    module_line - region_lines,
-                    results[i].preamble_lines,
-                    options.sourcemap.sources_content,
-                    false,
-                    region_lines,
-                    @intCast(std.mem.count(u8, code, "\n")),
-                    endregion_lines,
-                    m.plugin_source_maps,
-                );
+                try addModuleMappings(.{
+                    .sm = sm,
+                    .module_id = sourcemapSourcePath(m.path, options),
+                    .source = m.source,
+                    .maps = maps,
+                    .base_line = module_line - region_lines,
+                    .preamble_lines = results[i].preamble_lines,
+                    .sources_content = options.sourcemap.sources_content,
+                    .indent_offset = false,
+                    .pre_lines = region_lines,
+                    .total_code_lines = @intCast(std.mem.count(u8, code, "\n")),
+                    .post_lines = endregion_lines,
+                    .plugin_source_maps = m.plugin_source_maps,
+                });
                 // function map: source 추가 순서와 동기화
                 if (options.sourcemap.function_map) {
                     try per_source_fn_maps.append(allocator, results[i].fn_map_json);
@@ -839,20 +839,20 @@ pub fn emitWithTreeShaking(
                     var mod_sm_moved = false;
                     defer if (!mod_sm_moved) mod_sm.deinit();
                     mod_sm.sources_content = options.sourcemap.sources_content;
-                    try addModuleMappings(
-                        &mod_sm,
-                        sourcemapSourcePath(m.path, options),
-                        m.source,
-                        maps,
-                        HMR_PREAMBLE_LINES,
-                        results[i].preamble_lines,
-                        options.sourcemap.sources_content,
-                        false,
-                        0, // HMR preamble path 는 region marker 없음
-                        @intCast(std.mem.count(u8, code, "\n")),
-                        0, // endregion 도 없음
-                        m.plugin_source_maps,
-                    );
+                    try addModuleMappings(.{
+                        .sm = &mod_sm,
+                        .module_id = sourcemapSourcePath(m.path, options),
+                        .source = m.source,
+                        .maps = maps,
+                        .base_line = HMR_PREAMBLE_LINES,
+                        .preamble_lines = results[i].preamble_lines,
+                        .sources_content = options.sourcemap.sources_content,
+                        .indent_offset = false,
+                        .pre_lines = 0, // HMR preamble path 는 region marker 없음
+                        .total_code_lines = @intCast(std.mem.count(u8, code, "\n")),
+                        .post_lines = 0, // endregion 도 없음
+                        .plugin_source_maps = m.plugin_source_maps,
+                    });
                     if (options.sourcemap.lazy) {
                         module_sm_builder = try mod_sm.moveToHeap(allocator);
                         mod_sm_moved = true;

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -407,20 +407,20 @@ pub fn emitChunks(
             if (chunk_sm) |*sm| if (module_mappings) |maps| {
                 const region_lines: u32 = if (options.minify_whitespace) 0 else 1;
                 const endregion_lines: u32 = if (options.minify_whitespace) 0 else 1;
-                try parent.addModuleMappings(
-                    sm,
-                    parent.sourcemapSourcePath(m.path, options),
-                    m.source,
-                    maps,
-                    module_line.? - region_lines,
-                    module_preamble_lines,
-                    options.sourcemap.sources_content,
-                    false,
-                    region_lines,
-                    stripped_lines,
-                    endregion_lines,
-                    m.plugin_source_maps,
-                );
+                try parent.addModuleMappings(.{
+                    .sm = sm,
+                    .module_id = parent.sourcemapSourcePath(m.path, options),
+                    .source = m.source,
+                    .maps = maps,
+                    .base_line = module_line.? - region_lines,
+                    .preamble_lines = module_preamble_lines,
+                    .sources_content = options.sourcemap.sources_content,
+                    .indent_offset = false,
+                    .pre_lines = region_lines,
+                    .total_code_lines = stripped_lines,
+                    .post_lines = endregion_lines,
+                    .plugin_source_maps = m.plugin_source_maps,
+                });
             };
 
             try chunk_output.appendSlice(allocator, stripped);

--- a/src/bundler/emitter/dev.zig
+++ b/src/bundler/emitter/dev.zig
@@ -7,6 +7,28 @@ const Module = @import("../module.zig").Module;
 const SourceMap = @import("../../codegen/sourcemap.zig");
 const source_map_trace = @import("../../codegen/source_map_trace.zig");
 
+/// `addModuleMappings` 입력. caller 가 named field 로 채워 호출 site 가 self-documenting.
+/// `plugin_source_maps` 가 비어 있으면 identity 매핑, 아니면 plugin source map chain 을 trace.
+pub const ModuleMappingArgs = struct {
+    sm: *SourceMap.SourceMapBuilder,
+    module_id: []const u8,
+    source: []const u8,
+    maps: []const SourceMap.Mapping,
+    base_line: u32,
+    preamble_lines: u32,
+    sources_content: bool,
+    /// dev 모드에서 tab 들여쓰기 보정이 필요하면 true
+    indent_offset: bool,
+    /// module wrapper 전 boilerplate line 수 (e.g. //#region, default 0)
+    pre_lines: u32,
+    /// wrap 적용 후 code 의 전체 \n 갯수
+    total_code_lines: u32,
+    /// module wrapper 후 boilerplate line 수 (e.g. //#endregion, default 0)
+    post_lines: u32,
+    /// plugin load/transform 이 반환한 Source Map V3 JSON chain. 비어 있으면 identity.
+    plugin_source_maps: []const []const u8 = &.{},
+};
+
 /// 모듈의 소스맵 매핑을 번들 레벨 SourceMapBuilder에 추가한다.
 /// sourcesContent 등록 + preamble/wrapper 오프셋 반영 + module 영역 안의
 /// 매핑 누락 line (region/endregion marker, wrapper closing brace, 그리고
@@ -32,61 +54,29 @@ const source_map_trace = @import("../../codegen/source_map_trace.zig");
 /// **호출자 invariant**: `maps` 는 `generated_line` 오름차순으로 정렬되어 있어야
 /// 한다. codegen / esm_wrap merge 둘 다 이 보장을 만족 (#2651 perf — 보장이
 /// 깨지면 builder 의 `is_sorted=false` 가 플립되어 bundle 전역 sort 비용 발생).
-pub fn addModuleMappings(
-    sm: *SourceMap.SourceMapBuilder,
-    module_id: []const u8,
-    source: []const u8,
-    maps: []const SourceMap.Mapping,
-    base_line: u32,
-    preamble_lines: u32,
-    sources_content: bool,
-    /// dev 모드에서 tab 들여쓰기 보정이 필요하면 true
-    indent_offset: bool,
-    /// module wrapper 전 boilerplate line 수 (e.g. //#region, default 0)
-    pre_lines: u32,
-    /// wrap 적용 후 code 의 전체 \\n 갯수
-    total_code_lines: u32,
-    /// module wrapper 후 boilerplate line 수 (e.g. //#endregion, default 0)
-    post_lines: u32,
-    /// plugin load/transform 이 반환한 Source Map V3 JSON chain. 비어 있으면 identity.
-    plugin_source_maps: []const []const u8,
-) !void {
-    if (maps.len == 0) return;
-    if (plugin_source_maps.len > 0) {
-        return addTracedModuleMappings(
-            sm,
-            module_id,
-            source,
-            maps,
-            base_line,
-            preamble_lines,
-            sources_content,
-            indent_offset,
-            pre_lines,
-            total_code_lines,
-            post_lines,
-            plugin_source_maps,
-        );
-    }
+pub fn addModuleMappings(args: ModuleMappingArgs) !void {
+    if (args.maps.len == 0) return;
 
-    const source_idx = try sm.addSource(module_id);
-    if (sources_content and source.len > 0) {
-        try sm.addSourceContent(source);
-    }
+    var resolver = try MappingResolver.init(
+        args.sm,
+        args.module_id,
+        args.source,
+        args.plugin_source_maps,
+        args.sources_content,
+    );
+    defer resolver.deinit();
 
-    // maps 가 generated_line 순 정렬 가정 — codegen / esm_wrap merge 가 보장.
-    // 첫/마지막 mapping 의 original_line 으로 boilerplate 영역 (region marker,
-    // wrap header, wrap closing brace, endregion marker) 을 채움.
-    const first_orig_line = maps[0].original_line;
+    // 첫 mapping 으로 초기 source/orig 를 정해 pre_lines / 매핑 없는 line / post_lines 채움.
+    const first = try resolver.resolve(args.maps[0]);
 
     // pre_lines (region marker) — module 의 first source line 으로 매핑.
     var i: u32 = 0;
-    while (i < pre_lines) : (i += 1) {
-        try sm.addMapping(.{
-            .generated_line = base_line + i,
+    while (i < args.pre_lines) : (i += 1) {
+        try args.sm.addMapping(.{
+            .generated_line = args.base_line + i,
             .generated_column = 0,
-            .source_index = source_idx,
-            .original_line = first_orig_line,
+            .source_index = first.source_idx,
+            .original_line = first.line,
             .original_column = 0,
         });
     }
@@ -94,34 +84,21 @@ pub fn addModuleMappings(
     // body 영역 single-pass: maps 의 mapping 을 정렬 순서로 emit + 매핑 없는
     // 줄은 직전 줄의 orig 로 채움. generated_line 단조 증가 보장 → builder 의
     // is_sorted 유지 (#2651 perf — 별도 sort pass 회피).
-    var prev_orig: u32 = first_orig_line;
-    var last_orig: u32 = first_orig_line;
+    var last = first;
     var maps_idx: usize = 0;
     var line: u32 = 0;
-    while (line < total_code_lines) : (line += 1) {
+    while (line < args.total_code_lines) : (line += 1) {
         var line_had_mapping = false;
-        while (maps_idx < maps.len and maps[maps_idx].generated_line == line) : (maps_idx += 1) {
-            const m = maps[maps_idx];
-            try sm.addMapping(.{
-                .generated_line = base_line + pre_lines + preamble_lines + m.generated_line,
-                .generated_column = if (indent_offset and m.generated_line != 0)
-                    m.generated_column + 1
-                else
-                    m.generated_column,
-                .source_index = source_idx,
-                .original_line = m.original_line,
-                .original_column = m.original_column,
-            });
-            prev_orig = m.original_line;
-            last_orig = m.original_line;
+        while (maps_idx < args.maps.len and args.maps[maps_idx].generated_line == line) : (maps_idx += 1) {
+            last = try emitResolvedMapping(args, &resolver, args.maps[maps_idx]);
             line_had_mapping = true;
         }
         if (!line_had_mapping) {
-            try sm.addMapping(.{
-                .generated_line = base_line + pre_lines + preamble_lines + line,
+            try args.sm.addMapping(.{
+                .generated_line = args.base_line + args.pre_lines + args.preamble_lines + line,
                 .generated_column = 0,
-                .source_index = source_idx,
-                .original_line = prev_orig,
+                .source_index = last.source_idx,
+                .original_line = last.line,
                 .original_column = 0,
             });
         }
@@ -129,205 +106,147 @@ pub fn addModuleMappings(
 
     // total_code_lines 초과 mapping (안전망 — caller 가 잘못된 total 을 넘기면
     // 발생). 정렬 invariant 유지를 위해 post_lines 전에 emit.
-    while (maps_idx < maps.len) : (maps_idx += 1) {
-        const m = maps[maps_idx];
-        try sm.addMapping(.{
-            .generated_line = base_line + pre_lines + preamble_lines + m.generated_line,
-            .generated_column = if (indent_offset and m.generated_line != 0)
-                m.generated_column + 1
-            else
-                m.generated_column,
-            .source_index = source_idx,
-            .original_line = m.original_line,
-            .original_column = m.original_column,
-        });
-        last_orig = m.original_line;
+    while (maps_idx < args.maps.len) : (maps_idx += 1) {
+        last = try emitResolvedMapping(args, &resolver, args.maps[maps_idx]);
     }
 
     // post_lines (endregion marker) — last source line 으로 매핑.
     i = 0;
-    while (i < post_lines) : (i += 1) {
-        try sm.addMapping(.{
-            .generated_line = base_line + pre_lines + preamble_lines + total_code_lines + i,
+    while (i < args.post_lines) : (i += 1) {
+        try args.sm.addMapping(.{
+            .generated_line = args.base_line + args.pre_lines + args.preamble_lines + args.total_code_lines + i,
             .generated_column = 0,
-            .source_index = source_idx,
-            .original_line = last_orig,
+            .source_index = last.source_idx,
+            .original_line = last.line,
             .original_column = 0,
         });
     }
 }
 
-const ResolvedTrace = struct {
-    source_name: []const u8,
-    source_content: ?[]const u8,
-    original_line: u32,
-    original_column: u32,
+/// codegen mapping 한 개를 resolve → addMapping 로 emit. body 와 tail loop 에서 공유.
+inline fn emitResolvedMapping(
+    args: ModuleMappingArgs,
+    resolver: *MappingResolver,
+    m: SourceMap.Mapping,
+) !ResolvedMapping {
+    const r = try resolver.resolve(m);
+    try args.sm.addMapping(.{
+        .generated_line = args.base_line + args.pre_lines + args.preamble_lines + m.generated_line,
+        .generated_column = if (args.indent_offset and m.generated_line != 0)
+            m.generated_column + 1
+        else
+            m.generated_column,
+        .source_index = r.source_idx,
+        .original_line = r.line,
+        .original_column = r.column,
+    });
+    return r;
+}
+
+/// `addModuleMappings` 가 매 mapping 마다 source_idx + 원본 line/column 을 결정할 때 쓰는
+/// resolver. plugin source map 이 없으면 identity (mapping 의 값 그대로), 있으면
+/// chain 을 타고 trace.
+const ResolvedMapping = struct {
+    source_idx: u32,
+    line: u32,
+    column: u32,
 };
 
-fn resolveTrace(
-    parsed_maps: []const source_map_trace.ParsedMap,
+const MappingResolver = union(enum) {
+    identity: u32,
+    traced: TraceResolver,
+
+    fn init(
+        sm: *SourceMap.SourceMapBuilder,
+        module_id: []const u8,
+        source: []const u8,
+        plugin_source_maps: []const []const u8,
+        sources_content: bool,
+    ) !MappingResolver {
+        if (plugin_source_maps.len == 0) {
+            const idx = try sm.addSource(module_id);
+            if (sources_content and source.len > 0) {
+                try sm.addSourceContent(source);
+            }
+            return .{ .identity = idx };
+        }
+        return .{ .traced = try TraceResolver.init(sm, module_id, source, plugin_source_maps, sources_content) };
+    }
+
+    fn deinit(self: *MappingResolver) void {
+        switch (self.*) {
+            .identity => {},
+            .traced => |*tr| tr.deinit(),
+        }
+    }
+
+    fn resolve(self: *MappingResolver, m: SourceMap.Mapping) !ResolvedMapping {
+        switch (self.*) {
+            .identity => |idx| return .{ .source_idx = idx, .line = m.original_line, .column = m.original_column },
+            .traced => |*tr| return tr.resolve(m),
+        }
+    }
+};
+
+const TraceResolver = struct {
+    sm: *SourceMap.SourceMapBuilder,
     module_id: []const u8,
     fallback_source: []const u8,
-    mapping: SourceMap.Mapping,
-) ResolvedTrace {
-    if (source_map_trace.trace(parsed_maps, mapping.original_line, mapping.original_column)) |hit| {
+    parsed_maps: std.ArrayList(source_map_trace.ParsedMap),
+    source_cache: std.StringHashMap(u32),
+    sources_content: bool,
+
+    fn init(
+        sm: *SourceMap.SourceMapBuilder,
+        module_id: []const u8,
+        source: []const u8,
+        plugin_source_maps: []const []const u8,
+        sources_content: bool,
+    ) !TraceResolver {
+        var parsed_maps: std.ArrayList(source_map_trace.ParsedMap) = .empty;
+        errdefer {
+            for (parsed_maps.items) |*parsed| parsed.deinit();
+            parsed_maps.deinit(sm.allocator);
+        }
+        for (plugin_source_maps) |source_map_json| {
+            try parsed_maps.append(sm.allocator, try source_map_trace.parse(sm.allocator, source_map_json));
+        }
         return .{
-            .source_name = hit.source,
-            .source_content = hit.source_content,
-            .original_line = hit.line,
-            .original_column = hit.column,
+            .sm = sm,
+            .module_id = module_id,
+            .fallback_source = source,
+            .parsed_maps = parsed_maps,
+            .source_cache = std.StringHashMap(u32).init(sm.allocator),
+            .sources_content = sources_content,
         };
     }
-    return .{
-        .source_name = module_id,
-        .source_content = fallback_source,
-        .original_line = mapping.original_line,
-        .original_column = mapping.original_column,
-    };
-}
 
-fn ensureTraceSource(
-    sm: *SourceMap.SourceMapBuilder,
-    cache: *std.StringHashMap(u32),
-    source_name: []const u8,
-    source_content: ?[]const u8,
-    include_content: bool,
-) !u32 {
-    if (cache.get(source_name)) |idx| return idx;
-    const idx = try sm.addSource(source_name);
-    if (include_content) {
-        try sm.addSourceContent(source_content orelse "");
-    }
-    try cache.put(source_name, idx);
-    return idx;
-}
-
-fn addTracedModuleMappings(
-    sm: *SourceMap.SourceMapBuilder,
-    module_id: []const u8,
-    source: []const u8,
-    maps: []const SourceMap.Mapping,
-    base_line: u32,
-    preamble_lines: u32,
-    sources_content: bool,
-    indent_offset: bool,
-    pre_lines: u32,
-    total_code_lines: u32,
-    post_lines: u32,
-    plugin_source_maps: []const []const u8,
-) !void {
-    var parsed_maps: std.ArrayList(source_map_trace.ParsedMap) = .empty;
-    defer {
-        for (parsed_maps.items) |*parsed| parsed.deinit();
-        parsed_maps.deinit(sm.allocator);
-    }
-    for (plugin_source_maps) |source_map_json| {
-        try parsed_maps.append(sm.allocator, try source_map_trace.parse(sm.allocator, source_map_json));
+    fn deinit(self: *TraceResolver) void {
+        for (self.parsed_maps.items) |*parsed| parsed.deinit();
+        self.parsed_maps.deinit(self.sm.allocator);
+        self.source_cache.deinit();
     }
 
-    var source_cache = std.StringHashMap(u32).init(sm.allocator);
-    defer source_cache.deinit();
-
-    const first_trace = resolveTrace(parsed_maps.items, module_id, source, maps[0]);
-    const first_source_idx = try ensureTraceSource(
-        sm,
-        &source_cache,
-        first_trace.source_name,
-        first_trace.source_content,
-        sources_content,
-    );
-
-    var i: u32 = 0;
-    while (i < pre_lines) : (i += 1) {
-        try sm.addMapping(.{
-            .generated_line = base_line + i,
-            .generated_column = 0,
-            .source_index = first_source_idx,
-            .original_line = first_trace.original_line,
-            .original_column = 0,
-        });
-    }
-
-    var prev_source_idx: u32 = first_source_idx;
-    var prev_orig: u32 = first_trace.original_line;
-    var last_source_idx: u32 = first_source_idx;
-    var last_orig: u32 = first_trace.original_line;
-    var maps_idx: usize = 0;
-    var line: u32 = 0;
-    while (line < total_code_lines) : (line += 1) {
-        var line_had_mapping = false;
-        while (maps_idx < maps.len and maps[maps_idx].generated_line == line) : (maps_idx += 1) {
-            const m = maps[maps_idx];
-            const traced = resolveTrace(parsed_maps.items, module_id, source, m);
-            const traced_source_idx = try ensureTraceSource(
-                sm,
-                &source_cache,
-                traced.source_name,
-                traced.source_content,
-                sources_content,
-            );
-            try sm.addMapping(.{
-                .generated_line = base_line + pre_lines + preamble_lines + m.generated_line,
-                .generated_column = if (indent_offset and m.generated_line != 0)
-                    m.generated_column + 1
-                else
-                    m.generated_column,
-                .source_index = traced_source_idx,
-                .original_line = traced.original_line,
-                .original_column = traced.original_column,
-            });
-            prev_source_idx = traced_source_idx;
-            prev_orig = traced.original_line;
-            last_source_idx = traced_source_idx;
-            last_orig = traced.original_line;
-            line_had_mapping = true;
+    fn resolve(self: *TraceResolver, m: SourceMap.Mapping) !ResolvedMapping {
+        if (source_map_trace.trace(self.parsed_maps.items, m.original_line, m.original_column)) |hit| {
+            const idx = try self.ensureSource(hit.source, hit.source_content);
+            return .{ .source_idx = idx, .line = hit.line, .column = hit.column };
         }
-        if (!line_had_mapping) {
-            try sm.addMapping(.{
-                .generated_line = base_line + pre_lines + preamble_lines + line,
-                .generated_column = 0,
-                .source_index = prev_source_idx,
-                .original_line = prev_orig,
-                .original_column = 0,
-            });
+        const idx = try self.ensureSource(self.module_id, self.fallback_source);
+        return .{ .source_idx = idx, .line = m.original_line, .column = m.original_column };
+    }
+
+    /// `source_name` 첫 등장 시 `sm.addSource` + (옵션) sourcesContent 등록 + cache. 이후엔 cache hit.
+    fn ensureSource(self: *TraceResolver, source_name: []const u8, source_content: ?[]const u8) !u32 {
+        if (self.source_cache.get(source_name)) |idx| return idx;
+        const idx = try self.sm.addSource(source_name);
+        if (self.sources_content) {
+            try self.sm.addSourceContent(source_content orelse "");
         }
+        try self.source_cache.put(source_name, idx);
+        return idx;
     }
-
-    while (maps_idx < maps.len) : (maps_idx += 1) {
-        const m = maps[maps_idx];
-        const traced = resolveTrace(parsed_maps.items, module_id, source, m);
-        const traced_source_idx = try ensureTraceSource(
-            sm,
-            &source_cache,
-            traced.source_name,
-            traced.source_content,
-            sources_content,
-        );
-        try sm.addMapping(.{
-            .generated_line = base_line + pre_lines + preamble_lines + m.generated_line,
-            .generated_column = if (indent_offset and m.generated_line != 0)
-                m.generated_column + 1
-            else
-                m.generated_column,
-            .source_index = traced_source_idx,
-            .original_line = traced.original_line,
-            .original_column = traced.original_column,
-        });
-        last_source_idx = traced_source_idx;
-        last_orig = traced.original_line;
-    }
-
-    i = 0;
-    while (i < post_lines) : (i += 1) {
-        try sm.addMapping(.{
-            .generated_line = base_line + pre_lines + preamble_lines + total_code_lines + i,
-            .generated_column = 0,
-            .source_index = last_source_idx,
-            .original_line = last_orig,
-            .original_column = 0,
-        });
-    }
-}
+};
 
 /// 모듈 경로를 dev bundle용 ID로 변환.
 /// root_dir이 있으면 상대 경로, 없으면 절대 경로 그대로 사용.
@@ -370,20 +289,19 @@ test "addModuleMappings: codegen body 의 내부 빈 줄 (gap) 도 직전 orig �
         .{ .generated_line = 5, .generated_column = 0, .original_line = 15, .original_column = 0 },
     };
 
-    try addModuleMappings(
-        &sm,
-        "src/foo.ts",
-        "// dummy source",
-        &maps,
-        100, // base_line
-        0, // preamble_lines
-        false, // sources_content
-        false, // indent_offset
-        0, // pre_lines
-        6, // total_code_lines
-        0, // post_lines
-        &.{},
-    );
+    try addModuleMappings(.{
+        .sm = &sm,
+        .module_id = "src/foo.ts",
+        .source = "// dummy source",
+        .maps = &maps,
+        .base_line = 100,
+        .preamble_lines = 0,
+        .sources_content = false,
+        .indent_offset = false,
+        .pre_lines = 0,
+        .total_code_lines = 6,
+        .post_lines = 0,
+    });
 
     // generated_line 100~105 (base + 0~5) 모두 mapping 존재해야 함.
     var has_line = std.AutoHashMap(u32, u32).init(testing.allocator);
@@ -409,20 +327,19 @@ test "addModuleMappings: 첫 매핑 이전의 wrap header 줄들도 first_orig �
         .{ .generated_line = 3, .generated_column = 0, .original_line = 6, .original_column = 0 },
     };
 
-    try addModuleMappings(
-        &sm,
-        "src/foo.ts",
-        "",
-        &maps,
-        0,
-        0,
-        false,
-        false,
-        0,
-        4, // total_code_lines (wrap header 2 + body 2)
-        0,
-        &.{},
-    );
+    try addModuleMappings(.{
+        .sm = &sm,
+        .module_id = "src/foo.ts",
+        .source = "",
+        .maps = &maps,
+        .base_line = 0,
+        .preamble_lines = 0,
+        .sources_content = false,
+        .indent_offset = false,
+        .pre_lines = 0,
+        .total_code_lines = 4, // wrap header 2 + body 2
+        .post_lines = 0,
+    });
 
     var has_line = std.AutoHashMap(u32, u32).init(testing.allocator);
     defer has_line.deinit();
@@ -444,20 +361,19 @@ test "addModuleMappings: tail (마지막 mapping 이후 wrap closing brace) 영�
         .{ .generated_line = 0, .generated_column = 0, .original_line = 7, .original_column = 0 },
     };
 
-    try addModuleMappings(
-        &sm,
-        "src/foo.ts",
-        "",
-        &maps,
-        0,
-        0,
-        false,
-        false,
-        0,
-        4, // total_code_lines
-        0,
-        &.{},
-    );
+    try addModuleMappings(.{
+        .sm = &sm,
+        .module_id = "src/foo.ts",
+        .source = "",
+        .maps = &maps,
+        .base_line = 0,
+        .preamble_lines = 0,
+        .sources_content = false,
+        .indent_offset = false,
+        .pre_lines = 0,
+        .total_code_lines = 4,
+        .post_lines = 0,
+    });
 
     var has_line = std.AutoHashMap(u32, u32).init(testing.allocator);
     defer has_line.deinit();
@@ -483,20 +399,19 @@ test "addModuleMappings: pre/post (region/endregion marker) + 내부 gap 동시 
         .{ .generated_line = 2, .generated_column = 0, .original_line = 22, .original_column = 0 },
     };
 
-    try addModuleMappings(
-        &sm,
-        "src/foo.ts",
-        "",
-        &maps,
-        0, // base_line
-        0, // preamble_lines
-        false,
-        false,
-        1, // pre_lines (region marker)
-        3, // total_code_lines (body)
-        1, // post_lines (endregion marker)
-        &.{},
-    );
+    try addModuleMappings(.{
+        .sm = &sm,
+        .module_id = "src/foo.ts",
+        .source = "",
+        .maps = &maps,
+        .base_line = 0,
+        .preamble_lines = 0,
+        .sources_content = false,
+        .indent_offset = false,
+        .pre_lines = 1, // region marker
+        .total_code_lines = 3, // body
+        .post_lines = 1, // endregion marker
+    });
 
     var has_line = std.AutoHashMap(u32, u32).init(testing.allocator);
     defer has_line.deinit();
@@ -519,20 +434,19 @@ test "addModuleMappings: maps 가 비어있으면 아무 mapping 도 추가 안 
     var sm = SourceMap.SourceMapBuilder.init(testing.allocator);
     defer sm.deinit();
 
-    try addModuleMappings(
-        &sm,
-        "src/foo.ts",
-        "",
-        &.{}, // empty maps
-        0,
-        0,
-        false,
-        false,
-        1,
-        5,
-        1,
-        &.{},
-    );
+    try addModuleMappings(.{
+        .sm = &sm,
+        .module_id = "src/foo.ts",
+        .source = "",
+        .maps = &.{}, // empty maps
+        .base_line = 0,
+        .preamble_lines = 0,
+        .sources_content = false,
+        .indent_offset = false,
+        .pre_lines = 1,
+        .total_code_lines = 5,
+        .post_lines = 1,
+    });
 
     // empty mapping 입력은 source 등록도 하지 않고 빠져나간다.
     try testing.expectEqual(@as(usize, 0), sm.mappings.items.len);


### PR DESCRIPTION
## 개요

#1902 시리즈 머지 후 follow-up 5개 중 **E** (PR A, B+D, C 머지 후 진행).

`src/bundler/emitter/dev.zig` 의 두 함수가 pre_lines / body / tail / post_lines 골격이 byte-near-identical 했고 mapping 별 `(source_idx, line, column)` 결정 방식만 달랐던 것을 단일 함수 + `MappingResolver` union 으로 통합. 동시에 12 positional 인자를 `ModuleMappingArgs` struct 로 정리.

## 동기

PR 2 (#1902 sourcemap chain) 머지 직후 /simplify 리뷰가 가장 큰 follow-up 으로 지목한 부분:
- `addModuleMappings` (~120줄, identity 경로) 와 `addTracedModuleMappings` (~125줄, traced 경로) 가 거의 동일.
- 한쪽 fix 가 다른 쪽으로 전파 안 되는 drift 위험. `prev_orig` / `last_orig` 같은 임시 변수 이름까지 두 번 손으로 mirror 해야 했던 부분.
- 12 positional 인자 — 호출 사이트마다 `// pre_lines` / `// total_code_lines` 같은 trailing comment 로 가독성 보완.

## 변경

`src/bundler/emitter/dev.zig`
- `MappingResolver` union (`identity: u32` / `traced: TraceResolver`) 추가. `init` / `deinit` / `resolve` 로 매 mapping 마다 `(source_idx, line, column)` 결정.
- `addModuleMappings(args: ModuleMappingArgs)` 단일 함수로 통합 (이전 두 함수 합산 ~245줄 → ~150줄).
- `addTracedModuleMappings` 삭제.

`ModuleMappingArgs` struct: 12 fields. `plugin_source_maps: []const []const u8 = &.{}` 기본값으로 identity 케이스를 자연스럽게 표현.

호출 사이트 8개 모두 named field 로 업데이트:
- `dev.zig` 5 tests
- `emitter.zig` 2 sites (single-file output, dev mode HMR per-module sourcemap)
- `chunks.zig` 1 site (chunk emit)

## /simplify pass 적용

3-에이전트 리뷰 후 채택:
- **body+tail emit 블록 중복** → `emitResolvedMapping(args, resolver, m)` inline helper. body single-pass 와 tail overflow 가 동일한 `addMapping(.{...})` + `indent_offset` ternary 를 공유.
- **`ResolvedTrace` + free-fn `ensureTraceSource` 인라이닝** → `TraceResolver.ensureSource` 메서드로 흡수. 둘 다 소비처가 한 곳 (`TraceResolver.resolve`) 뿐이라 외부 노출이 cruft.
- doc-comment 의 stale "12개 positional 인자" 표현 정리.

## 변경 통계

3 files changed, 269 insertions / 355 deletions (-86 net).
- `src/bundler/emitter/dev.zig` 가 핵심 (~245줄 두 함수 → ~190줄 한 함수 + resolver).
- `emitter.zig` / `chunks.zig` 는 callsite struct literal 전환만.

## 검증

- `zig build napi`
- `zig build test --summary all` — 4721 pass
- `bun test packages/core/index.test.ts` — 417 pass
- `(cd tests/integration && bun test sourcemap.test.ts sourcemap-footer.test.ts round4-sourcemap.test.ts round5-sourcemap.test.ts)` — 48 pass (sourcemap chain 회귀)
- `bun run fmt:check` / `zig fmt --check src`
- pre-push hook (zig fmt + zig build test + oxlint + oxfmt) 통과

## Test plan

- [x] dev.zig 단위 테스트 5개 (pre/post fill, gap fill, tail overflow, empty maps) 모두 PASS
- [x] sourcemap chain integration: plugin transform map 합성 회귀 (#1902 PR 2) PASS
- [x] dev mode HMR per-module sourcemap (`emitter.zig:842` 경로) — bundler integration test PASS

## Follow-up

- F: dispatcher map/maps key 통일 (마지막 남은 항목)

Refs #1902