### PR TITLE
fix(semantic): exclude computed constructor keys

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1885,6 +1885,7 @@ pub fn main() !void {
         try stdout.print("Running Test262: {s}\n", .{walk_path});
         const summary = try runner.runDirectory(allocator, walk_path, false);
         try summary.print(stdout);
+        if (summary.failed > 0) std.process.exit(1);
         return;
     }
 

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1516,6 +1516,25 @@ pub const Ast = struct {
             else => null,
         };
     }
+
+    /// object/method/class key 노드에서 non-computed 정적 이름만 추출한다.
+    /// `staticKeyName` 은 codegen/contextual-name 용도로 computed literal 도 해석하지만,
+    /// class constructor / object `__proto__` early error 의 PropName 규칙에서는
+    /// ComputedPropertyName 이 empty 로 취급되어야 한다.
+    pub fn directStaticKeyName(
+        self: *const Ast,
+        alloc: std.mem.Allocator,
+        key_idx: NodeIndex,
+    ) std.mem.Allocator.Error!?[]u8 {
+        if (key_idx.isNone() or @intFromEnum(key_idx) >= self.nodes.items.len) return null;
+        const n = self.getNode(key_idx);
+        return switch (n.tag) {
+            .identifier_reference, .binding_identifier, .private_identifier => try alloc.dupe(u8, self.getText(n.data.string_ref)),
+            .numeric_literal => try alloc.dupe(u8, self.getText(n.span)),
+            .string_literal => try decodeStringLiteralKey(self, alloc, key_idx),
+            else => null,
+        };
+    }
 };
 
 fn decodeStringLiteralKey(

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1527,13 +1527,8 @@ pub const Ast = struct {
         key_idx: NodeIndex,
     ) std.mem.Allocator.Error!?[]u8 {
         if (key_idx.isNone() or @intFromEnum(key_idx) >= self.nodes.items.len) return null;
-        const n = self.getNode(key_idx);
-        return switch (n.tag) {
-            .identifier_reference, .binding_identifier, .private_identifier => try alloc.dupe(u8, self.getText(n.data.string_ref)),
-            .numeric_literal => try alloc.dupe(u8, self.getText(n.span)),
-            .string_literal => try decodeStringLiteralKey(self, alloc, key_idx),
-            else => null,
-        };
+        if (self.getNode(key_idx).tag == .computed_property_key) return null;
+        return self.staticKeyName(alloc, key_idx);
     }
 };
 

--- a/src/semantic/checker.zig
+++ b/src/semantic/checker.zig
@@ -106,19 +106,6 @@ pub fn checkDuplicateConstructors(
 // 공통 헬퍼
 // ====================================================================
 
-/// key 노드의 이름이 target과 일치하는지 확인한다.
-/// identifier 계열 / string_literal (escape 디코드) / numeric / computed-literal 모두 처리.
-fn matchKeyName(
-    allocator: std.mem.Allocator,
-    ast: *const Ast,
-    key_idx: NodeIndex,
-    target: []const u8,
-) std.mem.Allocator.Error!bool {
-    const name = (try ast.staticKeyName(allocator, key_idx)) orelse return false;
-    defer allocator.free(name);
-    return std.mem.eql(u8, name, target);
-}
-
 /// key 노드의 non-computed 이름이 target과 일치하는지 확인한다.
 fn matchDirectKeyName(
     allocator: std.mem.Allocator,

--- a/src/semantic/checker.zig
+++ b/src/semantic/checker.zig
@@ -81,8 +81,10 @@ pub fn checkDuplicateConstructors(
         // getter/setter/async/generator는 이미 파서에서 에러 처리
         if ((flags & (METHOD_FLAG_GETTER | METHOD_FLAG_SETTER | METHOD_FLAG_ASYNC | METHOD_FLAG_GENERATOR)) != 0) continue;
 
-        // key가 "constructor" 문자열인지 확인
-        if (!try matchKeyName(allocator, ast, key_idx, "constructor")) continue;
+        // key가 non-computed "constructor" 문자열인지 확인.
+        // ComputedPropertyName 은 PropName empty 이므로 ['constructor']() 는
+        // 실제 constructor가 아니라 일반 prototype method 이다.
+        if (!try matchDirectKeyName(allocator, ast, key_idx, "constructor")) continue;
 
         // TypeScript constructor overloads: body가 없는 시그니처는 허용.
         // body(extra[2])가 .none이면 overload 시그니처이므로 스킵.
@@ -113,6 +115,18 @@ fn matchKeyName(
     target: []const u8,
 ) std.mem.Allocator.Error!bool {
     const name = (try ast.staticKeyName(allocator, key_idx)) orelse return false;
+    defer allocator.free(name);
+    return std.mem.eql(u8, name, target);
+}
+
+/// key 노드의 non-computed 이름이 target과 일치하는지 확인한다.
+fn matchDirectKeyName(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    key_idx: NodeIndex,
+    target: []const u8,
+) std.mem.Allocator.Error!bool {
+    const name = (try ast.directStaticKeyName(allocator, key_idx)) orelse return false;
     defer allocator.free(name);
     return std.mem.eql(u8, name, target);
 }

--- a/src/semantic/checker.zig
+++ b/src/semantic/checker.zig
@@ -270,9 +270,11 @@ pub fn checkObjectDuplicateProto(
         // shorthand는 right가 none이고 flags가 0인 경우.
         if (node.data.binary.right.isNone() and node.data.binary.flags == 0) continue;
 
-        // key가 "__proto__" 인지 확인
+        // key가 non-computed "__proto__" 인지 확인.
+        // ComputedPropertyName 의 PropName 은 empty 이므로 ['__proto__'] 는
+        // Annex B duplicate __proto__ early error 대상이 아니다.
         const key_idx = node.data.binary.left;
-        if (!try matchKeyName(allocator, ast, key_idx, "__proto__")) continue;
+        if (!try matchDirectKeyName(allocator, ast, key_idx, "__proto__")) continue;
 
         if (first_proto_span) |_| {
             try addErrorCode(errors, allocator, node.span, try std.fmt.allocPrint(allocator, "Property name __proto__ appears more than once in object literal", .{}), .proto_duplicate);

--- a/src/semantic/checker_test.zig
+++ b/src/semantic/checker_test.zig
@@ -187,6 +187,27 @@ test "checker: single __proto__ is valid" {
     try std.testing.expect(errs.items.len == 0);
 }
 
+test "checker: computed __proto__ does not count as duplicate proto initializer" {
+    var scanner = try Scanner.init(std.testing.allocator, "var o = { __proto__: null, ['__proto__']: null, ['__proto__']: 1 };");
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    var errs: std.ArrayList(Diagnostic) = .empty;
+    defer errs.deinit(std.testing.allocator);
+
+    const ast = &parser.ast;
+    for (ast.nodes.items) |node| {
+        if (node.tag == .object_expression) {
+            try checkObjectDuplicateProto(ast, node.data.list, &errs, std.testing.allocator);
+            break;
+        }
+    }
+
+    try std.testing.expect(errs.items.len == 0);
+}
+
 test "checker: duplicate arrow params is error" {
     var scanner = try Scanner.init(std.testing.allocator, "var f = (x, x) => x;");
     defer scanner.deinit();

--- a/src/semantic/checker_test.zig
+++ b/src/semantic/checker_test.zig
@@ -61,6 +61,48 @@ test "checker: single constructor is valid" {
     try std.testing.expect(errs.items.len == 0);
 }
 
+test "checker: computed constructor method is not a class constructor" {
+    var scanner = try Scanner.init(std.testing.allocator, "class C { constructor() {} ['constructor']() {} }");
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    var errs: std.ArrayList(Diagnostic) = .empty;
+    defer errs.deinit(std.testing.allocator);
+
+    const ast = &parser.ast;
+    for (ast.nodes.items) |node| {
+        if (node.tag == .class_body) {
+            try checkDuplicateConstructors(ast, node.data.list, &errs, std.testing.allocator);
+            break;
+        }
+    }
+
+    try std.testing.expect(errs.items.len == 0);
+}
+
+test "checker: string literal constructor counts as class constructor" {
+    var scanner = try Scanner.init(std.testing.allocator, "class C { 'constructor'() {} constructor() {} }");
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    var errs: std.ArrayList(Diagnostic) = .empty;
+    defer deinitErrors(&errs, std.testing.allocator);
+
+    const ast = &parser.ast;
+    for (ast.nodes.items) |node| {
+        if (node.tag == .class_body) {
+            try checkDuplicateConstructors(ast, node.data.list, &errs, std.testing.allocator);
+            break;
+        }
+    }
+
+    try std.testing.expect(errs.items.len > 0);
+}
+
 test "checker: static/instance private name conflict is error" {
     var scanner = try Scanner.init(std.testing.allocator, "class C { set #f(v) {} static get #f() {} }");
     defer scanner.deinit();

--- a/src/test262/main.zig
+++ b/src/test262/main.zig
@@ -35,6 +35,7 @@ pub fn main() !void {
 
     if (args.len > 1) {
         // 특정 카테고리 실행
+        var had_failures = false;
         for (args[1..]) |cat_name| {
             const cat_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ abs_path, cat_name });
             defer allocator.free(cat_path);
@@ -42,10 +43,13 @@ pub fn main() !void {
             try stdout.print("\n=== {s} ===\n", .{cat_name});
             const summary = runner.runDirectory(allocator, cat_path, true) catch |err| {
                 try stdout.print("Error: {}\n", .{err});
+                had_failures = true;
                 continue;
             };
             try summary.print(stdout);
+            if (summary.failed > 0) had_failures = true;
         }
+        if (had_failures) std.process.exit(1);
     } else {
         // 전체 카테고리별 실행
         try stdout.print("Running Test262 parser tests...\n", .{});
@@ -83,5 +87,6 @@ pub fn main() !void {
         try stdout.print("{s:<30} {d:>6} {d:>6} {d:>6} {d:>6} {d:>7.1}%\n", .{
             "TOTAL", total.total, total.passed, total.failed, total.skipped, total.passRate(),
         });
+        if (total.failed > 0) std.process.exit(1);
     }
 }

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -54,9 +54,16 @@ pub fn buildStaticPrivateFieldDescriptor(self: anytype, var_name: []const u8, in
 /// ComputedPropertyName `['constructor']` 는 일반 prototype method 이다.
 pub fn isConstructorKey(self: anytype, key_idx: NodeIndex) bool {
     if (key_idx.isNone()) return false;
-    const name = (self.ast.directStaticKeyName(self.allocator, key_idx) catch return false) orelse return false;
-    defer self.allocator.free(name);
-    return std.mem.eql(u8, name, "constructor");
+    const key = self.ast.getNode(key_idx);
+    return switch (key.tag) {
+        .identifier_reference, .binding_identifier => std.mem.eql(u8, self.ast.getText(key.data.string_ref), "constructor"),
+        .string_literal => blk: {
+            const name = (self.ast.directStaticKeyName(self.allocator, key_idx) catch break :blk false) orelse break :blk false;
+            defer self.allocator.free(name);
+            break :blk std.mem.eql(u8, name, "constructor");
+        },
+        else => false,
+    };
 }
 
 /// 인덱스로부터 임시 변수명 생성: _a, _b, _c, ..., _a2, _b2, ...

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -49,14 +49,14 @@ pub fn buildStaticPrivateFieldDescriptor(self: anytype, var_name: []const u8, in
     return makeVarDeclaration(self, &.{declarator}, .@"var", span);
 }
 
-/// class member의 key가 `constructor` 이름인지 판별.
-/// identifier_reference/binding_identifier만 허용 (string literal key 등은 constructor로 취급 안 함).
+/// class member의 key가 non-computed `constructor` 이름인지 판별.
+/// IdentifierName/StringLiteral constructor는 실제 class constructor지만,
+/// ComputedPropertyName `['constructor']` 는 일반 prototype method 이다.
 pub fn isConstructorKey(self: anytype, key_idx: NodeIndex) bool {
     if (key_idx.isNone()) return false;
-    const key = self.ast.getNode(key_idx);
-    if (key.tag != .identifier_reference and key.tag != .binding_identifier) return false;
-    const text = self.ast.getText(key.data.string_ref);
-    return std.mem.eql(u8, text, "constructor");
+    const name = (self.ast.directStaticKeyName(self.allocator, key_idx) catch return false) orelse return false;
+    defer self.allocator.free(name);
+    return std.mem.eql(u8, name, "constructor");
 }
 
 /// 인덱스로부터 임시 변수명 생성: _a, _b, _c, ..., _a2, _b2, ...

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -4553,11 +4553,8 @@ pub const Transformer = struct {
         self.needs_arguments_var = false;
         self.super_call_this_alias = false;
 
-        const is_ctor = (flags & ast_mod.MethodFlags.is_static) == 0 and blk: {
-            const key_node = self.ast.getNode(self.readNodeIdx(e, 0));
-            if (key_node.tag != .identifier_reference) break :blk false;
-            break :blk std.mem.eql(u8, self.ast.getText(key_node.span), "constructor");
-        };
+        const is_ctor = (flags & ast_mod.MethodFlags.is_static) == 0 and
+            es_helpers.isConstructorKey(self, self.readNodeIdx(e, ast_mod.MethodExtra.key));
 
         // ES2015 new.target: method → constructor 또는 void 0
         const saved_new_target_ctx = self.new_target_ctx;

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -358,6 +358,21 @@ test "useDefineForClassFields=false: with existing constructor" {
     try std.testing.expectEqual(@as(u32, 1), r.statementCount());
 }
 
+test "ES2015 class: string literal constructor lowers as constructor" {
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        "class A { 'constructor'() { return {}; } }",
+        .{ .unsupported = TransformOptions.compat.fromESTarget(.es5) },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer r.allocator.free(code);
+
+    try std.testing.expect(std.mem.indexOf(u8, code, "function A()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "return {};") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "Object.defineProperty(A.prototype, \"constructor\"") == null);
+}
+
 test "useDefineForClassFields=false: with super class" {
     var r = try parseAndTransformWithOptions(
         std.testing.allocator,


### PR DESCRIPTION
## 요약
- class constructor duplicate early error에서 computed key를 제외했습니다.
- non-computed string literal `"constructor"`는 실제 constructor로 downlevel되도록 class key 판정을 정리했습니다.

## 검증
- `zig build test`
- `zig build -Doptimize=ReleaseFast test262-run -- computed-property-names`
- `zig build run -- --test262 tests/test262/test/staging/sm/class/`
- string/computed constructor ES5 output을 Node로 실행해 sanity check