### PR TITLE
fix(semantic): ignore computed duplicate proto keys

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1885,6 +1885,7 @@ pub fn main() !void {
         try stdout.print("Running Test262: {s}\n", .{walk_path});
         const summary = try runner.runDirectory(allocator, walk_path, false);
         try summary.print(stdout);
+        if (summary.failed > 0) std.process.exit(1);
         return;
     }
 

--- a/src/semantic/checker.zig
+++ b/src/semantic/checker.zig
@@ -106,19 +106,6 @@ pub fn checkDuplicateConstructors(
 // 공통 헬퍼
 // ====================================================================
 
-/// key 노드의 이름이 target과 일치하는지 확인한다.
-/// identifier 계열 / string_literal (escape 디코드) / numeric / computed-literal 모두 처리.
-fn matchKeyName(
-    allocator: std.mem.Allocator,
-    ast: *const Ast,
-    key_idx: NodeIndex,
-    target: []const u8,
-) std.mem.Allocator.Error!bool {
-    const name = (try ast.staticKeyName(allocator, key_idx)) orelse return false;
-    defer allocator.free(name);
-    return std.mem.eql(u8, name, target);
-}
-
 /// key 노드의 non-computed 이름이 target과 일치하는지 확인한다.
 fn matchDirectKeyName(
     allocator: std.mem.Allocator,

--- a/src/semantic/checker.zig
+++ b/src/semantic/checker.zig
@@ -270,9 +270,11 @@ pub fn checkObjectDuplicateProto(
         // shorthand는 right가 none이고 flags가 0인 경우.
         if (node.data.binary.right.isNone() and node.data.binary.flags == 0) continue;
 
-        // key가 "__proto__" 인지 확인
+        // key가 non-computed "__proto__" 인지 확인.
+        // ComputedPropertyName 의 PropName 은 empty 이므로 ['__proto__'] 는
+        // Annex B duplicate __proto__ early error 대상이 아니다.
         const key_idx = node.data.binary.left;
-        if (!try matchKeyName(allocator, ast, key_idx, "__proto__")) continue;
+        if (!try matchDirectKeyName(allocator, ast, key_idx, "__proto__")) continue;
 
         if (first_proto_span) |_| {
             try addErrorCode(errors, allocator, node.span, try std.fmt.allocPrint(allocator, "Property name __proto__ appears more than once in object literal", .{}), .proto_duplicate);

--- a/src/semantic/checker_test.zig
+++ b/src/semantic/checker_test.zig
@@ -187,6 +187,27 @@ test "checker: single __proto__ is valid" {
     try std.testing.expect(errs.items.len == 0);
 }
 
+test "checker: computed __proto__ does not count as duplicate proto initializer" {
+    var scanner = try Scanner.init(std.testing.allocator, "var o = { __proto__: null, ['__proto__']: null, ['__proto__']: 1 };");
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    _ = try parser.parse();
+
+    var errs: std.ArrayList(Diagnostic) = .empty;
+    defer errs.deinit(std.testing.allocator);
+
+    const ast = &parser.ast;
+    for (ast.nodes.items) |node| {
+        if (node.tag == .object_expression) {
+            try checkObjectDuplicateProto(ast, node.data.list, &errs, std.testing.allocator);
+            break;
+        }
+    }
+
+    try std.testing.expect(errs.items.len == 0);
+}
+
 test "checker: duplicate arrow params is error" {
     var scanner = try Scanner.init(std.testing.allocator, "var f = (x, x) => x;");
     defer scanner.deinit();

--- a/src/test262/main.zig
+++ b/src/test262/main.zig
@@ -35,6 +35,7 @@ pub fn main() !void {
 
     if (args.len > 1) {
         // 특정 카테고리 실행
+        var had_failures = false;
         for (args[1..]) |cat_name| {
             const cat_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ abs_path, cat_name });
             defer allocator.free(cat_path);
@@ -42,10 +43,13 @@ pub fn main() !void {
             try stdout.print("\n=== {s} ===\n", .{cat_name});
             const summary = runner.runDirectory(allocator, cat_path, true) catch |err| {
                 try stdout.print("Error: {}\n", .{err});
+                had_failures = true;
                 continue;
             };
             try summary.print(stdout);
+            if (summary.failed > 0) had_failures = true;
         }
+        if (had_failures) std.process.exit(1);
     } else {
         // 전체 카테고리별 실행
         try stdout.print("Running Test262 parser tests...\n", .{});
@@ -83,5 +87,6 @@ pub fn main() !void {
         try stdout.print("{s:<30} {d:>6} {d:>6} {d:>6} {d:>6} {d:>7.1}%\n", .{
             "TOTAL", total.total, total.passed, total.failed, total.skipped, total.passRate(),
         });
+        if (total.failed > 0) std.process.exit(1);
     }
 }


### PR DESCRIPTION
## 요약
- object literal duplicate `__proto__` early error에서 computed key를 제외했습니다.
- computed `[`__proto__`]`가 일반 own property로 허용되는 Test262 케이스를 회귀 테스트로 고정했습니다.

## 검증
- `zig build test`
- `zig build -Doptimize=ReleaseFast test262-run -- expressions`
- `./zig-out/bin/zntc tests/test262/test/language/expressions/object/__proto__-duplicate-computed.js`
- `./zig-out/bin/zntc tests/test262/test/language/expressions/object/__proto__-permitted-dup.js`