### PR TITLE
ci(test262): fail when conformance cases fail

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1885,6 +1885,7 @@ pub fn main() !void {
         try stdout.print("Running Test262: {s}\n", .{walk_path});
         const summary = try runner.runDirectory(allocator, walk_path, false);
         try summary.print(stdout);
+        if (summary.failed > 0) std.process.exit(1);
         return;
     }
 

--- a/src/test262/main.zig
+++ b/src/test262/main.zig
@@ -35,6 +35,7 @@ pub fn main() !void {
 
     if (args.len > 1) {
         // 특정 카테고리 실행
+        var had_failures = false;
         for (args[1..]) |cat_name| {
             const cat_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ abs_path, cat_name });
             defer allocator.free(cat_path);
@@ -42,10 +43,13 @@ pub fn main() !void {
             try stdout.print("\n=== {s} ===\n", .{cat_name});
             const summary = runner.runDirectory(allocator, cat_path, true) catch |err| {
                 try stdout.print("Error: {}\n", .{err});
+                had_failures = true;
                 continue;
             };
             try summary.print(stdout);
+            if (summary.failed > 0) had_failures = true;
         }
+        if (had_failures) std.process.exit(1);
     } else {
         // 전체 카테고리별 실행
         try stdout.print("Running Test262 parser tests...\n", .{});
@@ -83,5 +87,6 @@ pub fn main() !void {
         try stdout.print("{s:<30} {d:>6} {d:>6} {d:>6} {d:>6} {d:>7.1}%\n", .{
             "TOTAL", total.total, total.passed, total.failed, total.skipped, total.passRate(),
         });
+        if (total.failed > 0) std.process.exit(1);
     }
 }


### PR DESCRIPTION
## 요약
- `zntc --test262` 실행 결과에 실패 케이스가 있으면 exit 1로 종료하도록 했습니다.
- `zig build test262-run`도 카테고리/전체 실행 모두 실패 케이스 또는 카테고리 실행 오류를 non-zero exit로 승격합니다.

## 검증
- 임시 negative fixture로 실패 1건 발생 시 `zig build run -- --test262 <dir>`가 exit 1인지 확인
- `zig build test`
- `zig build run -- --test262 tests/test262/test/language/` → 23,384/23,384
- `zig build -Doptimize=ReleaseFast test262-run` → 23,384/23,384
- `./zig-out/bin/zntc --test262 tests/test262` → 50,504/50,504
- `zig fmt --check src/`