### PR TITLE
fix(semantic): predeclare nested-block function with correct kind

### DIFF
--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -3446,7 +3446,7 @@ pub const SemanticAnalyzer = struct {
             .function_declaration => {
                 const extra_start = node.data.extra;
                 const extras = self.ast.extra_data.items;
-                if (extra_start >= extras.len) return;
+                if (extra_start + ast_mod.FunctionExtra.flags >= extras.len) return;
                 const name_idx: NodeIndex = @enumFromInt(extras[extra_start]);
                 if (!name_idx.isNone() and @intFromEnum(name_idx) < self.ast.nodes.items.len) {
                     const name_node = self.ast.getNode(name_idx);
@@ -3455,7 +3455,11 @@ pub const SemanticAnalyzer = struct {
                     if (self.findSymbolInScope(var_scope, name_text)) |existing| {
                         if (existing.kind.isBlockScoped()) return;
                     }
-                    try self.declareSymbolWithNode(name_node.span, .function_decl, name_node.span, null);
+                    // generator / async / async-generator 는 block-scoped function-like 이므로
+                    // 1st pass 부터 정확한 SymbolKind 로 등록해야 후속 같은-이름 function-like
+                    // declaration 의 redecl early error (Block LexicallyDeclaredNames duplicate)
+                    // 가 detect 된다.
+                    try self.declareSymbolWithNode(name_node.span, functionSymbolKind(extras[extra_start + ast_mod.FunctionExtra.flags]), name_node.span, null);
                 }
             },
             // 재귀 대상: block/if/for/while/switch/try/labeled 등

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -898,21 +898,30 @@ const AnalyzeResult = struct {
     }
 };
 
-fn analyzeModule(source: []const u8) !AnalyzeResult {
+const AnalyzeOpts = struct { module: bool = true, ts: bool = true };
+
+fn analyzeWith(source: []const u8, opts: AnalyzeOpts) !AnalyzeResult {
     var scanner = try Scanner.init(std.testing.allocator, source);
     errdefer scanner.deinit();
-    scanner.is_module = true;
+    scanner.is_module = opts.module;
     var parser = Parser.init(std.testing.allocator, &scanner);
     errdefer parser.deinit();
-    parser.source_mode = .ts;
-    parser.is_module = true;
+    if (opts.ts) parser.source_mode = .ts;
+    parser.is_module = opts.module;
     _ = try parser.parse();
-
     var ana = SemanticAnalyzer.init(std.testing.allocator, &parser.ast);
-    ana.is_module = true;
+    ana.is_module = opts.module;
     errdefer ana.deinit();
     try ana.analyze();
     return .{ .scanner = scanner, .parser = parser, .analyzer = ana };
+}
+
+fn analyzeModule(source: []const u8) !AnalyzeResult {
+    return analyzeWith(source, .{});
+}
+
+fn analyzeScript(source: []const u8) !AnalyzeResult {
+    return analyzeWith(source, .{ .module = false, .ts = false });
 }
 
 fn analyzeNoErrors(source: []const u8) !void {
@@ -922,13 +931,23 @@ fn analyzeNoErrors(source: []const u8) !void {
     try std.testing.expectEqual(@as(usize, 0), r.analyzer.errors.items.len);
 }
 
-fn analyzeHasError(source: []const u8, needle: []const u8) !void {
-    var r = try analyzeModule(source);
-    defer r.deinit();
+fn expectAnalyzeError(r: *AnalyzeResult, needle: []const u8) !void {
     for (r.analyzer.errors.items) |err| {
         if (std.mem.indexOf(u8, err.message, needle) != null) return;
     }
     return error.TestUnexpectedResult;
+}
+
+fn analyzeHasError(source: []const u8, needle: []const u8) !void {
+    var r = try analyzeModule(source);
+    defer r.deinit();
+    try expectAnalyzeError(&r, needle);
+}
+
+fn analyzeScriptHasError(source: []const u8, needle: []const u8) !void {
+    var r = try analyzeScript(source);
+    defer r.deinit();
+    try expectAnalyzeError(&r, needle);
 }
 
 test "Enum: re-export via export specifier" {
@@ -1807,6 +1826,21 @@ test "Redecl: block generator vs function declaration" {
 
 test "Redecl: block class vs function declaration" {
     try analyzeHasError("{ class f {} function f() {} }", "already been declared");
+}
+
+// sloppy (script) 모드에서도 test262 block-scope 같은-이름 function-like redecl
+// 케이스가 검출되어야 한다. predeclareVarDeclsRecursive 가 generator/async 를
+// `.function_decl` 로 잘못 등록하던 회귀 (#2714) 방어용.
+test "Redecl(script): block generator vs function declaration" {
+    try analyzeScriptHasError("{ function* f() {} function f() {} }", "already been declared");
+}
+
+test "Redecl(script): block async generator vs function declaration" {
+    try analyzeScriptHasError("{ async function* f() {} function f() {} }", "already been declared");
+}
+
+test "Redecl(script): block async function vs function declaration" {
+    try analyzeScriptHasError("{ async function f() {} function f() {} }", "already been declared");
 }
 
 test "Redecl: nested block var vs outer function" {


### PR DESCRIPTION
## 요약

`predeclareVarDeclsRecursive` 가 nested-block FunctionDeclaration 을 항상 `.function_decl` 로 등록하고 있어, generator / async / async-generator 가 var_scope 에 들어가도 `block_scoped` 비트가 떨어졌습니다. 그 결과 sloppy(script) 모드에서 같은 이름의 후속 function declaration 이 `LexicallyDeclaredNames` 중복 early error 를 검출하지 못해 #2714 머지 후 test262 `block-scope/redeclaration` 의 다음 케이스가 회귀했습니다:

- `generator-name-redeclaration-attempt-with-function.js`
- `async-generator-name-redeclaration-attempt-with-function.js`
- `async-function-name-redeclaration-attempt-with-function.js`

## 수정

1st pass 부터 `functionSymbolKind(flags)` 로 정확한 SymbolKind 를 등록합니다. generator/async 는 `declFlags().block_scoped = true` 라서, 이후 같은 이름의 function declaration 이 `declareSymbolWithNode` 의 alias path 에 도달했을 때 `canRedeclare` 가 정상적으로 redecl 을 잡습니다.

회귀 방어를 위해 sloppy(script) 모드에서 같은 케이스를 검증하는 `analyzeScript` helper + 3 테스트를 추가했고, simplify 검토 반영해서 `analyzeWith(opts)` 로 `analyzeModule`/`analyzeScript` 의 boilerplate 중복을 제거했으며 매직 리터럴 `3` 도 `ast_mod.FunctionExtra.flags` 상수로 교체했습니다.

## 검증

- `zig build test` ✓
- `zig build test262-run`
  - block-scope: 142/145 → **145/145**
  - 전체 main: 45 fail → **1 fail** (남은 1개 `module-code/top-level-await/await-expr-regexp.js` 는 #2714 와 무관한 await 뒤 regexp parser 케이스 — 별도 이슈)

Closes regression introduced by #2714 merge.