### PR TITLE
debug(test262): trace await-expr-regexp.js OS discrepancy

### DIFF
--- a/src/test262/runner.zig
+++ b/src/test262/runner.zig
@@ -181,6 +181,14 @@ pub fn runTest(allocator: mem.Allocator, source: []const u8, meta: TestMetadata,
     var parser = Parser.init(arena_alloc, &scanner);
 
     // module 모드 설정 — module은 항상 strict mode (D054)
+    // [DEBUG #2719] OS 차이 추적: await-expr-regexp.js 케이스만 디버그 출력
+    const is_target_case = mem.indexOf(u8, source, "await / x.y / g") != null;
+    if (is_target_case) {
+        const stderr = std.fs.File.stderr().deprecatedWriter();
+        stderr.print("[DBG-OS] await-expr-regexp meta: is_module={} is_negative={} is_only_strict={} is_no_strict={}\n", .{
+            meta.is_module, meta.is_negative_parse, meta.is_only_strict, meta.is_no_strict,
+        }) catch {};
+    }
     if (meta.is_module) {
         parser.is_module = true;
         scanner.is_module = true;
@@ -214,6 +222,22 @@ pub fn runTest(allocator: mem.Allocator, source: []const u8, meta: TestMetadata,
 
     // 렉서 에러 + 파서 에러 + semantic 에러 모두 체크
     const had_error = scanner.token.kind == .syntax_error or parser.errors.items.len > 0 or semantic_error_count > 0;
+
+    // [DEBUG #2719] OS 차이 추적
+    if (is_target_case) {
+        const stderr = std.fs.File.stderr().deprecatedWriter();
+        stderr.print("[DBG-OS] await-expr-regexp had_error={} scanner.token.kind={s} parser.errors={d} semantic={d}\n", .{
+            had_error,
+            @tagName(scanner.token.kind),
+            parser.errors.items.len,
+            semantic_error_count,
+        }) catch {};
+        if (parser.errors.items.len > 0) {
+            for (parser.errors.items, 0..) |err, i| {
+                stderr.print("[DBG-OS]   err[{d}]@{d}: {s}\n", .{ i, err.span.start, err.message }) catch {};
+            }
+        }
+    }
 
     const result: TestResult = if (meta.is_negative_parse)
         (if (had_error) .pass else .fail)

--- a/src/test262/runner.zig
+++ b/src/test262/runner.zig
@@ -184,8 +184,8 @@ pub fn runTest(allocator: mem.Allocator, source: []const u8, meta: TestMetadata,
     // [DEBUG #2719] OS 차이 추적: await-expr-regexp.js 케이스만 디버그 출력
     const is_target_case = mem.indexOf(u8, source, "await / x.y / g") != null;
     if (is_target_case) {
-        const stderr = std.fs.File.stderr().deprecatedWriter();
-        stderr.print("[DBG-OS] await-expr-regexp meta: is_module={} is_negative={} is_only_strict={} is_no_strict={}\n", .{
+        const stdout = std.fs.File.stdout().deprecatedWriter();
+        stdout.print("[DBG-OS] await-expr-regexp meta: is_module={} is_negative={} is_only_strict={} is_no_strict={}\n", .{
             meta.is_module, meta.is_negative_parse, meta.is_only_strict, meta.is_no_strict,
         }) catch {};
     }
@@ -225,8 +225,8 @@ pub fn runTest(allocator: mem.Allocator, source: []const u8, meta: TestMetadata,
 
     // [DEBUG #2719] OS 차이 추적
     if (is_target_case) {
-        const stderr = std.fs.File.stderr().deprecatedWriter();
-        stderr.print("[DBG-OS] await-expr-regexp had_error={} scanner.token.kind={s} parser.errors={d} semantic={d}\n", .{
+        const stdout = std.fs.File.stdout().deprecatedWriter();
+        stdout.print("[DBG-OS] await-expr-regexp had_error={} scanner.token.kind={s} parser.errors={d} semantic={d}\n", .{
             had_error,
             @tagName(scanner.token.kind),
             parser.errors.items.len,
@@ -234,7 +234,7 @@ pub fn runTest(allocator: mem.Allocator, source: []const u8, meta: TestMetadata,
         }) catch {};
         if (parser.errors.items.len > 0) {
             for (parser.errors.items, 0..) |err, i| {
-                stderr.print("[DBG-OS]   err[{d}]@{d}: {s}\n", .{ i, err.span.start, err.message }) catch {};
+                stdout.print("[DBG-OS]   err[{d}]@{d}: {s}\n", .{ i, err.span.start, err.message }) catch {};
             }
         }
     }

--- a/src/test262/runner.zig
+++ b/src/test262/runner.zig
@@ -181,13 +181,21 @@ pub fn runTest(allocator: mem.Allocator, source: []const u8, meta: TestMetadata,
     var parser = Parser.init(arena_alloc, &scanner);
 
     // module 모드 설정 — module은 항상 strict mode (D054)
-    // [DEBUG #2719] OS 차이 추적: await-expr-regexp.js 케이스만 디버그 출력
-    const is_target_case = mem.indexOf(u8, source, "await / x.y / g") != null;
+    // [DEBUG #2719] OS 차이 추적: top-level-await regex 케이스 (다양한 패턴으로 매칭)
+    const is_target_case =
+        mem.indexOf(u8, source, "RegularExpressionLiteral following an AwaitExpression") != null;
     if (is_target_case) {
         const stdout = std.fs.File.stdout().deprecatedWriter();
-        stdout.print("[DBG-OS] await-expr-regexp meta: is_module={} is_negative={} is_only_strict={} is_no_strict={}\n", .{
+        const tail_start: usize = if (source.len > 80) source.len - 80 else 0;
+        stdout.print("[DBG-OS] target case detected len={d}\n", .{source.len}) catch {};
+        stdout.print("[DBG-OS] meta: is_module={} is_negative={} is_only_strict={} is_no_strict={}\n", .{
             meta.is_module, meta.is_negative_parse, meta.is_only_strict, meta.is_no_strict,
         }) catch {};
+        stdout.print("[DBG-OS] source tail bytes: ", .{}) catch {};
+        for (source[tail_start..]) |b| {
+            if (b >= 0x20 and b < 0x7f) stdout.print("{c}", .{b}) catch {} else stdout.print("\\x{x:0>2}", .{b}) catch {};
+        }
+        stdout.print("\n", .{}) catch {};
     }
     if (meta.is_module) {
         parser.is_module = true;


### PR DESCRIPTION
## 목적

#2719 머지 후 main CI 가 0 fail 인데 macOS 로컬에서는 `module-code/top-level-await/await-expr-regexp.js` 1 fail. 같은 commit, 같은 submodule pin (md5 일치), 같은 build/run 명령에서 OS 별 결과가 다른 이유를 추적합니다.

**머지 대상 아님** — CI 한 번 돌고 결과 확인 후 close.

## 추가한 stderr debug 출력

target case (`await / x.y / g` 포함) 만 출력:
- metadata 파싱 결과 (`is_module`, `is_negative_parse`, `is_only_strict`, `is_no_strict`)
- 최종 `had_error`, `scanner.token.kind`, `parser.errors.len`, `semantic_error_count`
- parser error 의 첫 메시지 (있으면)

## 가설

1. CI fixture 가 다른 내용 (가능성 낮음 — md5 일치 확인됨)
2. CI runner 의 walk 에서 누락 (가능성 낮음 — total 23384 동일)
3. metadata parse 결과 OS 별 차이 (`flags: [module, async]` 인식 실패?)
4. lexer/parser 의 어딘가 platform-conditional 동작

CI 의 stderr 출력으로 1~3 즉시 배제 가능. 4 일 경우 후속 trace.

## 로컬 결과 (macOS arm64, zig 0.15.2)

```
[DBG-OS] await-expr-regexp meta: is_module=true is_negative=false is_only_strict=false is_no_strict=false
[DBG-OS] await-expr-regexp had_error=true scanner.token.kind=eof parser.errors=1 semantic=0
[DBG-OS]   err[0]@1092: ;
Failed: 1
```

CI Linux 의 출력과 비교 예정.

⚠️ **DO NOT MERGE.**