### PR TITLE
refactor(core): NAPI 공통 헬퍼 분리

### DIFF
--- a/packages/core/src/napi/common.zig
+++ b/packages/core/src/napi/common.zig
@@ -1,0 +1,276 @@
+//! Shared NAPI helpers for the `@zntc/core` native entry.
+
+const std = @import("std");
+
+pub const c = @cImport({
+    @cDefine("NAPI_VERSION", "8");
+    @cInclude("node_api.h");
+});
+
+pub const NullableStringPair = struct { []const u8, ?[]const u8 };
+
+pub fn throwError(env: c.napi_env, msg: [*:0]const u8) c.napi_value {
+    _ = c.napi_throw_error(env, null, msg);
+    return null;
+}
+
+/// JS object 의 native pointer (napi_wrap 결과) 를 안전하게 추출.
+/// `napi_unwrap` 실패 / null pointer 시 null — caller 가 throw / fallback 결정.
+pub inline fn unwrapNapi(comptime T: type, env: c.napi_env, value: c.napi_value) ?*T {
+    var ptr: ?*anyopaque = null;
+    if (c.napi_unwrap(env, value, &ptr) != c.napi_ok) return null;
+    const p = ptr orelse return null;
+    return @ptrCast(@alignCast(p));
+}
+
+/// JS string 인자를 Zig 슬라이스로 추출. 빈 문자열이면 null 반환.
+pub fn getStringArg(env: c.napi_env, value: c.napi_value, alloc: std.mem.Allocator) ?[]const u8 {
+    var len: usize = 0;
+    if (c.napi_get_value_string_utf8(env, value, null, 0, &len) != c.napi_ok) return null;
+    if (len == 0) return null;
+    const buf = alloc.alloc(u8, len + 1) catch return null;
+    var actual: usize = 0;
+    if (c.napi_get_value_string_utf8(env, value, buf.ptr, len + 1, &actual) != c.napi_ok) {
+        alloc.free(buf);
+        return null;
+    }
+    return buf[0..actual];
+}
+
+pub fn getNamedProperty(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8) ?c.napi_value {
+    var val: c.napi_value = undefined;
+    if (c.napi_get_named_property(env, obj, key, &val) != c.napi_ok) return null;
+    // undefined/null 체크
+    var val_type: c.napi_valuetype = undefined;
+    _ = c.napi_typeof(env, val, &val_type);
+    if (val_type == c.napi_undefined or val_type == c.napi_null) return null;
+    return val;
+}
+
+pub fn getObjectBool(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, default_val: bool) bool {
+    const val = getNamedProperty(env, obj, key) orelse return default_val;
+    var result: bool = default_val;
+    _ = c.napi_get_value_bool(env, val, &result);
+    return result;
+}
+
+/// bool 필드의 tri-state 조회 — 키가 없으면 null, 있으면 실제 값.
+/// tsconfig 머지 시 "JS 가 명시적으로 false" 와 "JS 가 생략" 을 구분하기 위해 사용.
+pub fn getObjectBoolOptional(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8) ?bool {
+    const val = getNamedProperty(env, obj, key) orelse return null;
+    var result: bool = false;
+    if (c.napi_get_value_bool(env, val, &result) != c.napi_ok) return null;
+    return result;
+}
+
+pub fn getObjectUint32(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, default_val: u32) u32 {
+    const val = getNamedProperty(env, obj, key) orelse return default_val;
+    var result: u32 = default_val;
+    _ = c.napi_get_value_uint32(env, val, &result);
+    return result;
+}
+
+pub fn getObjectString(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, alloc: std.mem.Allocator) ?[]const u8 {
+    const val = getNamedProperty(env, obj, key) orelse return null;
+    return getStringArg(env, val, alloc);
+}
+
+/// plugin onLoad 의 `contents` 가 string 일 수도 있고 Uint8Array/Buffer 일 수도 있음.
+/// 후자는 binary-safe (PNG/JPG 등 raw bytes 가 utf-8 invalid 일 수 있음). (#2157 follow-up)
+/// - string: utf-8 디코드된 byte slice 그대로 (빈 string 도 valid — `loader: 'empty'` 등)
+/// - Node.js Buffer: napi_is_buffer 로 먼저 확인 (V8 Uint8Array subclass 지만 공식 API 분리)
+/// - Uint8Array typed array: byteLength 만큼 raw bytes 복사
+/// - 그 외 type 또는 missing: null
+pub fn getObjectBytes(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, alloc: std.mem.Allocator) ?[]const u8 {
+    const val = getNamedProperty(env, obj, key) orelse return null;
+    var ty: c.napi_valuetype = undefined;
+    if (c.napi_typeof(env, val, &ty) != c.napi_ok) return null;
+    if (ty == c.napi_string) {
+        var len: usize = 0;
+        if (c.napi_get_value_string_utf8(env, val, null, 0, &len) != c.napi_ok) return null;
+        if (len == 0) {
+            return alloc.alloc(u8, 0) catch null;
+        }
+        const buf = alloc.alloc(u8, len + 1) catch return null;
+        var actual: usize = 0;
+        if (c.napi_get_value_string_utf8(env, val, buf.ptr, len + 1, &actual) != c.napi_ok) {
+            alloc.free(buf);
+            return null;
+        }
+        return buf[0..actual];
+    }
+    // Node.js Buffer: napi_is_buffer 가 권위 있음. 일부 런타임에서 napi_is_typedarray 가
+    // false 일 가능성 있어 별도 처리.
+    var is_buffer: bool = false;
+    if (c.napi_is_buffer(env, val, &is_buffer) == c.napi_ok and is_buffer) {
+        var byte_len: usize = 0;
+        var data_ptr: ?*anyopaque = null;
+        if (c.napi_get_buffer_info(env, val, &data_ptr, &byte_len) != c.napi_ok) return null;
+        return copyBytesOrEmpty(alloc, data_ptr, byte_len);
+    }
+    // Uint8Array / Uint8ClampedArray: raw bytes 복사. 다른 typed array (Int8Array/Float32Array 등)
+    // 는 silent reject — plugin 작성 실수 시 contents missing 으로 표면화.
+    var is_typed: bool = false;
+    if (c.napi_is_typedarray(env, val, &is_typed) != c.napi_ok or !is_typed) return null;
+    var ta_type: c.napi_typedarray_type = undefined;
+    var byte_len: usize = 0;
+    var data_ptr: ?*anyopaque = null;
+    if (c.napi_get_typedarray_info(env, val, &ta_type, &byte_len, &data_ptr, null, null) != c.napi_ok) return null;
+    if (ta_type != c.napi_uint8_array and ta_type != c.napi_uint8_clamped_array) return null;
+    return copyBytesOrEmpty(alloc, data_ptr, byte_len);
+}
+
+fn copyBytesOrEmpty(alloc: std.mem.Allocator, data_ptr: ?*anyopaque, byte_len: usize) ?[]const u8 {
+    if (byte_len == 0) {
+        return alloc.alloc(u8, 0) catch null;
+    }
+    const src_ptr: [*]const u8 = @ptrCast(data_ptr orelse return null);
+    const out = alloc.alloc(u8, byte_len) catch return null;
+    @memcpy(out, src_ptr[0..byte_len]);
+    return out;
+}
+
+pub fn getObjectStringArray(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, alloc: std.mem.Allocator) ?[]const []const u8 {
+    const val = getNamedProperty(env, obj, key) orelse return null;
+    return parseStringArray(env, val, alloc);
+}
+
+/// JS 배열 값을 문자열 슬라이스로 변환. (key 없이 직접 배열 값을 받는 버전)
+/// 빈 배열은 명시적으로 빈 slice 반환 (caller 가 "0개" 와 "invalid" 를 구분 가능).
+pub fn parseStringArray(env: c.napi_env, val: c.napi_value, alloc: std.mem.Allocator) ?[]const []const u8 {
+    var is_array: bool = false;
+    _ = c.napi_is_array(env, val, &is_array);
+    if (!is_array) return null;
+    var len: u32 = 0;
+    _ = c.napi_get_array_length(env, val, &len);
+    if (len == 0) return alloc.alloc([]const u8, 0) catch return null;
+    const result = alloc.alloc([]const u8, len) catch return null;
+    var count: u32 = 0;
+    for (0..len) |i| {
+        var elem: c.napi_value = undefined;
+        if (c.napi_get_element(env, val, @intCast(i), &elem) != c.napi_ok) continue;
+        if (getStringArg(env, elem, alloc)) |s| {
+            result[count] = s;
+            count += 1;
+        }
+    }
+    if (count == 0) {
+        alloc.free(result);
+        return null;
+    }
+    return result[0..count];
+}
+
+/// JS 객체의 키-값 쌍을 [2][]const u8 배열로 추출. { "key": "value", ... }
+pub fn getObjectKeyValuePairs(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, alloc: std.mem.Allocator) ?[][2][]const u8 {
+    const val = getNamedProperty(env, obj, key) orelse return null;
+
+    // 프로퍼티 이름 목록 가져오기
+    var prop_names: c.napi_value = undefined;
+    if (c.napi_get_property_names(env, val, &prop_names) != c.napi_ok) return null;
+    var len: u32 = 0;
+    _ = c.napi_get_array_length(env, prop_names, &len);
+    if (len == 0) return null;
+
+    const result = alloc.alloc([2][]const u8, len) catch return null;
+    var count: u32 = 0;
+    for (0..len) |i| {
+        var prop_key: c.napi_value = undefined;
+        if (c.napi_get_element(env, prop_names, @intCast(i), &prop_key) != c.napi_ok) continue;
+        const k = getStringArg(env, prop_key, alloc) orelse continue;
+
+        // napi_get_property로 키에 대한 값 가져오기 (null-terminated 불필요)
+        var prop_val: c.napi_value = undefined;
+        if (c.napi_get_property(env, val, prop_key, &prop_val) != c.napi_ok) {
+            alloc.free(k);
+            continue;
+        }
+
+        const v = getStringArg(env, prop_val, alloc) orelse {
+            alloc.free(k);
+            continue;
+        };
+
+        result[count] = .{ k, v };
+        count += 1;
+    }
+    if (count == 0) {
+        alloc.free(result);
+        return null;
+    }
+    return result[0..count];
+}
+
+/// fallback 옵션용 — 값이 boolean false이면 null 저장, 문자열이면 그대로. 그 외엔 스킵.
+pub fn getObjectKeyValuePairsWithNullable(
+    env: c.napi_env,
+    obj: c.napi_value,
+    key: [*:0]const u8,
+    alloc: std.mem.Allocator,
+) ?[]NullableStringPair {
+    const val = getNamedProperty(env, obj, key) orelse return null;
+
+    var prop_names: c.napi_value = undefined;
+    if (c.napi_get_property_names(env, val, &prop_names) != c.napi_ok) return null;
+    var len: u32 = 0;
+    _ = c.napi_get_array_length(env, prop_names, &len);
+    if (len == 0) return null;
+
+    const result = alloc.alloc(NullableStringPair, len) catch return null;
+    var count: u32 = 0;
+    for (0..len) |i| {
+        var prop_key: c.napi_value = undefined;
+        if (c.napi_get_element(env, prop_names, @intCast(i), &prop_key) != c.napi_ok) continue;
+        const k = getStringArg(env, prop_key, alloc) orelse continue;
+
+        var prop_val: c.napi_value = undefined;
+        if (c.napi_get_property(env, val, prop_key, &prop_val) != c.napi_ok) {
+            alloc.free(k);
+            continue;
+        }
+        var val_type: c.napi_valuetype = undefined;
+        _ = c.napi_typeof(env, prop_val, &val_type);
+
+        if (val_type == c.napi_boolean) {
+            var b: bool = false;
+            _ = c.napi_get_value_bool(env, prop_val, &b);
+            // false만 의미 있음 (빈 모듈). true는 "기본값"으로 해석 — 스킵.
+            if (b) {
+                alloc.free(k);
+                continue;
+            }
+            result[count] = .{ k, null };
+            count += 1;
+        } else {
+            const v = getStringArg(env, prop_val, alloc) orelse {
+                alloc.free(k);
+                continue;
+            };
+            result[count] = .{ k, v };
+            count += 1;
+        }
+    }
+    if (count == 0) {
+        alloc.free(result);
+        return null;
+    }
+    return result[0..count];
+}
+
+pub fn setDoubleProp(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, value: f64) void {
+    var v: c.napi_value = undefined;
+    _ = c.napi_create_double(env, value, &v);
+    _ = c.napi_set_named_property(env, obj, key, v);
+}
+
+pub fn setUint32Prop(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, value: u32) void {
+    var v: c.napi_value = undefined;
+    _ = c.napi_create_uint32(env, value, &v);
+    _ = c.napi_set_named_property(env, obj, key, v);
+}
+
+pub fn setStringProp(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, value: []const u8) void {
+    var v: c.napi_value = undefined;
+    _ = c.napi_create_string_utf8(env, value.ptr, value.len, &v);
+    _ = c.napi_set_named_property(env, obj, key, v);
+}

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -63,42 +63,29 @@ const EmitFormat = bundler_mod.emitter.EmitOptions.Format;
 const SourceMap = zntc_lib.codegen.sourcemap;
 const types_mod = zntc_lib.bundler.types;
 const transformer_mod = zntc_lib.transformer.transformer;
-const c = @cImport({
-    @cDefine("NAPI_VERSION", "8");
-    @cInclude("node_api.h");
-});
+const common = @import("napi/common.zig");
+const c = common.c;
 
 const native_alloc = std.heap.c_allocator;
 
 // ─── NAPI 헬퍼 ───
 
-fn throwError(env: c.napi_env, msg: [*:0]const u8) c.napi_value {
-    _ = c.napi_throw_error(env, null, msg);
-    return null;
-}
-
-/// JS object 의 native pointer (napi_wrap 결과) 를 안전하게 추출.
-/// `napi_unwrap` 실패 / null pointer 시 null — caller 가 throw / fallback 결정.
-inline fn unwrapNapi(comptime T: type, env: c.napi_env, value: c.napi_value) ?*T {
-    var ptr: ?*anyopaque = null;
-    if (c.napi_unwrap(env, value, &ptr) != c.napi_ok) return null;
-    const p = ptr orelse return null;
-    return @ptrCast(@alignCast(p));
-}
-
-/// JS string 인자를 Zig 슬라이스로 추출. 빈 문자열이면 null 반환.
-fn getStringArg(env: c.napi_env, value: c.napi_value, alloc: std.mem.Allocator) ?[]const u8 {
-    var len: usize = 0;
-    if (c.napi_get_value_string_utf8(env, value, null, 0, &len) != c.napi_ok) return null;
-    if (len == 0) return null;
-    const buf = alloc.alloc(u8, len + 1) catch return null;
-    var actual: usize = 0;
-    if (c.napi_get_value_string_utf8(env, value, buf.ptr, len + 1, &actual) != c.napi_ok) {
-        alloc.free(buf);
-        return null;
-    }
-    return buf[0..actual];
-}
+const throwError = common.throwError;
+const unwrapNapi = common.unwrapNapi;
+const getStringArg = common.getStringArg;
+const getNamedProperty = common.getNamedProperty;
+const getObjectBool = common.getObjectBool;
+const getObjectBoolOptional = common.getObjectBoolOptional;
+const getObjectUint32 = common.getObjectUint32;
+const getObjectString = common.getObjectString;
+const getObjectBytes = common.getObjectBytes;
+const getObjectStringArray = common.getObjectStringArray;
+const parseStringArray = common.parseStringArray;
+const getObjectKeyValuePairs = common.getObjectKeyValuePairs;
+const getObjectKeyValuePairsWithNullable = common.getObjectKeyValuePairsWithNullable;
+const setDoubleProp = common.setDoubleProp;
+const setUint32Prop = common.setUint32Prop;
+const setStringProp = common.setStringProp;
 
 // ─── TsconfigCache (#2367) ───
 
@@ -405,46 +392,6 @@ fn napiProfileReport(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c
     return js_report;
 }
 
-// ─── 객체 프로퍼티 헬퍼 ───
-
-fn getNamedProperty(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8) ?c.napi_value {
-    var val: c.napi_value = undefined;
-    if (c.napi_get_named_property(env, obj, key, &val) != c.napi_ok) return null;
-    // undefined/null 체크
-    var val_type: c.napi_valuetype = undefined;
-    _ = c.napi_typeof(env, val, &val_type);
-    if (val_type == c.napi_undefined or val_type == c.napi_null) return null;
-    return val;
-}
-
-fn getObjectBool(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, default_val: bool) bool {
-    const val = getNamedProperty(env, obj, key) orelse return default_val;
-    var result: bool = default_val;
-    _ = c.napi_get_value_bool(env, val, &result);
-    return result;
-}
-
-/// bool 필드의 tri-state 조회 — 키가 없으면 null, 있으면 실제 값.
-/// tsconfig 머지 시 "JS 가 명시적으로 false" 와 "JS 가 생략" 을 구분하기 위해 사용.
-fn getObjectBoolOptional(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8) ?bool {
-    const val = getNamedProperty(env, obj, key) orelse return null;
-    var result: bool = false;
-    if (c.napi_get_value_bool(env, val, &result) != c.napi_ok) return null;
-    return result;
-}
-
-fn getObjectUint32(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, default_val: u32) u32 {
-    const val = getNamedProperty(env, obj, key) orelse return default_val;
-    var result: u32 = default_val;
-    _ = c.napi_get_value_uint32(env, val, &result);
-    return result;
-}
-
-fn getObjectString(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, alloc: std.mem.Allocator) ?[]const u8 {
-    const val = getNamedProperty(env, obj, key) orelse return null;
-    return getStringArg(env, val, alloc);
-}
-
 /// `emotionAutoLabel` 옵션을 enum 값으로 파싱. JS 측에서 string ("never"/"always"/
 /// "dev-only") 또는 boolean (legacy: false=never, true=always) 으로 보낼 수 있음.
 /// 누락 시 기본 `.always`.
@@ -467,66 +414,6 @@ fn getAutoLabelMode(env: c.napi_env, obj: c.napi_value, alloc: std.mem.Allocator
         },
         else => return .always,
     }
-}
-
-/// plugin onLoad 의 `contents` 가 string 일 수도 있고 Uint8Array/Buffer 일 수도 있음.
-/// 후자는 binary-safe (PNG/JPG 등 raw bytes 가 utf-8 invalid 일 수 있음). (#2157 follow-up)
-/// - string: utf-8 디코드된 byte slice 그대로 (빈 string 도 valid — `loader: 'empty'` 등)
-/// - Node.js Buffer: napi_is_buffer 로 먼저 확인 (V8 Uint8Array subclass 지만 공식 API 분리)
-/// - Uint8Array typed array: byteLength 만큼 raw bytes 복사
-/// - 그 외 type 또는 missing: null
-fn getObjectBytes(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, alloc: std.mem.Allocator) ?[]const u8 {
-    const val = getNamedProperty(env, obj, key) orelse return null;
-    var ty: c.napi_valuetype = undefined;
-    if (c.napi_typeof(env, val, &ty) != c.napi_ok) return null;
-    if (ty == c.napi_string) {
-        var len: usize = 0;
-        if (c.napi_get_value_string_utf8(env, val, null, 0, &len) != c.napi_ok) return null;
-        if (len == 0) {
-            return alloc.alloc(u8, 0) catch null;
-        }
-        const buf = alloc.alloc(u8, len + 1) catch return null;
-        var actual: usize = 0;
-        if (c.napi_get_value_string_utf8(env, val, buf.ptr, len + 1, &actual) != c.napi_ok) {
-            alloc.free(buf);
-            return null;
-        }
-        return buf[0..actual];
-    }
-    // Node.js Buffer: napi_is_buffer 가 권위 있음. 일부 런타임에서 napi_is_typedarray 가
-    // false 일 가능성 있어 별도 처리.
-    var is_buffer: bool = false;
-    if (c.napi_is_buffer(env, val, &is_buffer) == c.napi_ok and is_buffer) {
-        var byte_len: usize = 0;
-        var data_ptr: ?*anyopaque = null;
-        if (c.napi_get_buffer_info(env, val, &data_ptr, &byte_len) != c.napi_ok) return null;
-        return copyBytesOrEmpty(alloc, data_ptr, byte_len);
-    }
-    // Uint8Array / Uint8ClampedArray: raw bytes 복사. 다른 typed array (Int8Array/Float32Array 등)
-    // 는 silent reject — plugin 작성 실수 시 contents missing 으로 표면화.
-    var is_typed: bool = false;
-    if (c.napi_is_typedarray(env, val, &is_typed) != c.napi_ok or !is_typed) return null;
-    var ta_type: c.napi_typedarray_type = undefined;
-    var byte_len: usize = 0;
-    var data_ptr: ?*anyopaque = null;
-    if (c.napi_get_typedarray_info(env, val, &ta_type, &byte_len, &data_ptr, null, null) != c.napi_ok) return null;
-    if (ta_type != c.napi_uint8_array and ta_type != c.napi_uint8_clamped_array) return null;
-    return copyBytesOrEmpty(alloc, data_ptr, byte_len);
-}
-
-fn copyBytesOrEmpty(alloc: std.mem.Allocator, data_ptr: ?*anyopaque, byte_len: usize) ?[]const u8 {
-    if (byte_len == 0) {
-        return alloc.alloc(u8, 0) catch null;
-    }
-    const src_ptr: [*]const u8 = @ptrCast(data_ptr orelse return null);
-    const out = alloc.alloc(u8, byte_len) catch return null;
-    @memcpy(out, src_ptr[0..byte_len]);
-    return out;
-}
-
-fn getObjectStringArray(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, alloc: std.mem.Allocator) ?[]const []const u8 {
-    const val = getNamedProperty(env, obj, key) orelse return null;
-    return parseStringArray(env, val, alloc);
 }
 
 /// `sourcemapMode` 옵션 (#2152) — `"linked"` / `"external"` / `"inline"` 한정.
@@ -572,124 +459,6 @@ fn parseOutputExports(env: c.napi_env, obj: c.napi_value) bundler_mod.OutputExpo
     var len: usize = 0;
     if (c.napi_get_value_string_utf8(env, val, &buf, buf.len, &len) != c.napi_ok) return .auto;
     return bundler_mod.OutputExports.fromString(buf[0..len]) orelse .auto;
-}
-
-/// JS 배열 값을 문자열 슬라이스로 변환. (key 없이 직접 배열 값을 받는 버전)
-/// 빈 배열은 명시적으로 빈 slice 반환 (caller 가 "0개" 와 "invalid" 를 구분 가능).
-fn parseStringArray(env: c.napi_env, val: c.napi_value, alloc: std.mem.Allocator) ?[]const []const u8 {
-    var is_array: bool = false;
-    _ = c.napi_is_array(env, val, &is_array);
-    if (!is_array) return null;
-    var len: u32 = 0;
-    _ = c.napi_get_array_length(env, val, &len);
-    if (len == 0) return alloc.alloc([]const u8, 0) catch return null;
-    const result = alloc.alloc([]const u8, len) catch return null;
-    var count: u32 = 0;
-    for (0..len) |i| {
-        var elem: c.napi_value = undefined;
-        if (c.napi_get_element(env, val, @intCast(i), &elem) != c.napi_ok) continue;
-        if (getStringArg(env, elem, alloc)) |s| {
-            result[count] = s;
-            count += 1;
-        }
-    }
-    if (count == 0) {
-        alloc.free(result);
-        return null;
-    }
-    return result[0..count];
-}
-
-/// JS 객체의 키-값 쌍을 [2][]const u8 배열로 추출. { "key": "value", ... }
-fn getObjectKeyValuePairs(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, alloc: std.mem.Allocator) ?[][2][]const u8 {
-    const val = getNamedProperty(env, obj, key) orelse return null;
-
-    // 프로퍼티 이름 목록 가져오기
-    var prop_names: c.napi_value = undefined;
-    if (c.napi_get_property_names(env, val, &prop_names) != c.napi_ok) return null;
-    var len: u32 = 0;
-    _ = c.napi_get_array_length(env, prop_names, &len);
-    if (len == 0) return null;
-
-    const result = alloc.alloc([2][]const u8, len) catch return null;
-    var count: u32 = 0;
-    for (0..len) |i| {
-        var prop_key: c.napi_value = undefined;
-        if (c.napi_get_element(env, prop_names, @intCast(i), &prop_key) != c.napi_ok) continue;
-        const k = getStringArg(env, prop_key, alloc) orelse continue;
-
-        // napi_get_property로 키에 대한 값 가져오기 (null-terminated 불필요)
-        var prop_val: c.napi_value = undefined;
-        if (c.napi_get_property(env, val, prop_key, &prop_val) != c.napi_ok) {
-            alloc.free(k);
-            continue;
-        }
-
-        const v = getStringArg(env, prop_val, alloc) orelse {
-            alloc.free(k);
-            continue;
-        };
-
-        result[count] = .{ k, v };
-        count += 1;
-    }
-    if (count == 0) {
-        alloc.free(result);
-        return null;
-    }
-    return result[0..count];
-}
-
-/// fallback 옵션용 — 값이 boolean false이면 null 저장, 문자열이면 그대로. 그 외엔 스킵.
-fn getObjectKeyValuePairsWithNullable(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, alloc: std.mem.Allocator) ?[]struct { []const u8, ?[]const u8 } {
-    const val = getNamedProperty(env, obj, key) orelse return null;
-
-    var prop_names: c.napi_value = undefined;
-    if (c.napi_get_property_names(env, val, &prop_names) != c.napi_ok) return null;
-    var len: u32 = 0;
-    _ = c.napi_get_array_length(env, prop_names, &len);
-    if (len == 0) return null;
-
-    const Pair = struct { []const u8, ?[]const u8 };
-    const result = alloc.alloc(Pair, len) catch return null;
-    var count: u32 = 0;
-    for (0..len) |i| {
-        var prop_key: c.napi_value = undefined;
-        if (c.napi_get_element(env, prop_names, @intCast(i), &prop_key) != c.napi_ok) continue;
-        const k = getStringArg(env, prop_key, alloc) orelse continue;
-
-        var prop_val: c.napi_value = undefined;
-        if (c.napi_get_property(env, val, prop_key, &prop_val) != c.napi_ok) {
-            alloc.free(k);
-            continue;
-        }
-        var val_type: c.napi_valuetype = undefined;
-        _ = c.napi_typeof(env, prop_val, &val_type);
-
-        if (val_type == c.napi_boolean) {
-            var b: bool = false;
-            _ = c.napi_get_value_bool(env, prop_val, &b);
-            // false만 의미 있음 (빈 모듈). true는 "기본값"으로 해석 — 스킵.
-            if (b) {
-                alloc.free(k);
-                continue;
-            }
-            result[count] = .{ k, null };
-            count += 1;
-        } else {
-            const v = getStringArg(env, prop_val, alloc) orelse {
-                alloc.free(k);
-                continue;
-            };
-            result[count] = .{ k, v };
-            count += 1;
-        }
-    }
-    if (count == 0) {
-        alloc.free(result);
-        return null;
-    }
-    return result[0..count];
 }
 
 fn resolveEntryPoint(alloc: std.mem.Allocator, path: []const u8) ?[]const u8 {
@@ -4551,22 +4320,4 @@ fn napiBenchmark(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.nap
     }
 
     return js_result;
-}
-
-fn setDoubleProp(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, value: f64) void {
-    var v: c.napi_value = undefined;
-    _ = c.napi_create_double(env, value, &v);
-    _ = c.napi_set_named_property(env, obj, key, v);
-}
-
-fn setUint32Prop(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, value: u32) void {
-    var v: c.napi_value = undefined;
-    _ = c.napi_create_uint32(env, value, &v);
-    _ = c.napi_set_named_property(env, obj, key, v);
-}
-
-fn setStringProp(env: c.napi_env, obj: c.napi_value, key: [*:0]const u8, value: []const u8) void {
-    var v: c.napi_value = undefined;
-    _ = c.napi_create_string_utf8(env, value.ptr, value.len, &v);
-    _ = c.napi_set_named_property(env, obj, key, v);
 }


### PR DESCRIPTION
## 요약
- `packages/core/src/napi/common.zig`를 추가해 NAPI 공통 helper를 분리했습니다.
- `napi_entry.zig`는 `common.c`를 공유해 `node_api.h` 타입 정의를 한 곳에서만 가져오도록 유지했습니다.
- 옵션 파싱/build/watch/plugin 로직은 옮기지 않고, 첫 production 분리 PR 범위를 순수 NAPI helper로 제한했습니다.

## 검증
- `zig build napi`
- `bun test ./packages/core/test/core/plugin-onload-loader/binary-contents.ts --timeout 30000`
- `bun test ./packages/core/test/core/build-options-exposure/custom-loaders.ts --timeout 30000`
- `bun test ./packages/core/test/core/bundle-options-exposure.ts --timeout 30000`
- `bun test ./packages/core/test/core/vite-plugin/hook-return-values/resolve-load.ts --timeout 30000`
- `zig build test`
- `zig fmt --check packages/core/src/napi_entry.zig packages/core/src/napi/common.zig`
- `git diff --check`
- push pre-push hook: `zig fmt --check src/...`, `zig build test`, `oxlint`(기존 경고 23개 / error 0), `oxfmt --check`