### PR TITLE
refactor(core): 그래프 에셋 헬퍼 분리

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -17,7 +17,6 @@
 //!   - references/bun/src/bundler/LinkerContext.zig
 
 const std = @import("std");
-const wyhash = @import("../util/wyhash.zig");
 const types = @import("types.zig");
 const ModuleIndex = types.ModuleIndex;
 const ModuleType = types.ModuleType;
@@ -68,6 +67,15 @@ pub const ModulePhase = phase_mod.ModulePhase;
 pub const ParseAccessor = phase_mod.ParseAccessor;
 pub const ResolveAccessor = phase_mod.ResolveAccessor;
 pub const LinkAccessor = phase_mod.LinkAccessor;
+const graph_assets = @import("graph/assets.zig");
+const escapeJsString = graph_assets.escapeJsString;
+const base64Encode = graph_assets.base64Encode;
+const contentHash = graph_assets.contentHash;
+const applyAssetNamingPattern = graph_assets.applyAssetNamingPattern;
+const emitAssetRegistryCall = graph_assets.emitAssetRegistryCall;
+const ScaleCollection = graph_assets.ScaleCollection;
+const collectScaleVariants = graph_assets.collectScaleVariants;
+const computeAssetDir = graph_assets.computeAssetDir;
 
 pub const ModuleGraph = struct {
     allocator: std.mem.Allocator,
@@ -4104,109 +4112,8 @@ pub const ModuleGraph = struct {
 };
 
 // ============================================================
-// Asset 로더 유틸리티
+// Graph path utilities
 // ============================================================
-
-/// JS 문자열 리터럴용 이스케이프. \ " \n \r \0 \u2028 \u2029 를 처리한다.
-fn escapeJsString(allocator: std.mem.Allocator, input: []const u8) ![]const u8 {
-    // fast path: 이스케이프가 필요한 문자가 없으면 복사만
-    var needs_escape = false;
-    for (input) |c| {
-        switch (c) {
-            '\\', '"', '\n', '\r', 0 => {
-                needs_escape = true;
-                break;
-            },
-            0xe2 => {
-                needs_escape = true; // UTF-8 U+2028/U+2029 시작 바이트
-                break;
-            },
-            else => {},
-        }
-    }
-    if (!needs_escape) return try allocator.dupe(u8, input);
-
-    var buf: std.ArrayList(u8) = .empty;
-    try buf.ensureTotalCapacity(allocator, input.len);
-    var i: usize = 0;
-    while (i < input.len) {
-        const c = input[i];
-        switch (c) {
-            '\\' => try buf.appendSlice(allocator, "\\\\"),
-            '"' => try buf.appendSlice(allocator, "\\\""),
-            '\n' => try buf.appendSlice(allocator, "\\n"),
-            '\r' => try buf.appendSlice(allocator, "\\r"),
-            0 => try buf.appendSlice(allocator, "\\0"),
-            0xe2 => {
-                // U+2028 (LS) = E2 80 A8, U+2029 (PS) = E2 80 A9
-                if (i + 2 < input.len and input[i + 1] == 0x80) {
-                    if (input[i + 2] == 0xa8) {
-                        try buf.appendSlice(allocator, "\\u2028");
-                        i += 3;
-                        continue;
-                    } else if (input[i + 2] == 0xa9) {
-                        try buf.appendSlice(allocator, "\\u2029");
-                        i += 3;
-                        continue;
-                    }
-                }
-                try buf.append(allocator, c);
-            },
-            else => try buf.append(allocator, c),
-        }
-        i += 1;
-    }
-    return buf.toOwnedSlice(allocator);
-}
-
-/// 바이트 배열을 standard base64로 인코딩한다.
-fn base64Encode(allocator: std.mem.Allocator, data: []const u8) ![]const u8 {
-    const encoder = std.base64.standard.Encoder;
-    const encoded_len = encoder.calcSize(data.len);
-    const buf = try allocator.alloc(u8, encoded_len);
-    _ = encoder.encode(buf, data);
-    return buf;
-}
-
-const contentHash = wyhash.hashHex8;
-
-/// asset naming 패턴 적용: [name] [hash] 치환 + 확장자 추가.
-fn applyAssetNamingPattern(
-    allocator: std.mem.Allocator,
-    pattern: []const u8,
-    name: []const u8,
-    hash: *const [8]u8,
-    ext: []const u8,
-    dir: []const u8,
-) ![]const u8 {
-    var buf: std.ArrayList(u8) = .empty;
-    var i: usize = 0;
-    while (i < pattern.len) {
-        if (std.mem.startsWith(u8, pattern[i..], "[name]")) {
-            try buf.appendSlice(allocator, name);
-            i += "[name]".len;
-        } else if (std.mem.startsWith(u8, pattern[i..], "[hash]")) {
-            try buf.appendSlice(allocator, hash);
-            i += "[hash]".len;
-        } else if (std.mem.startsWith(u8, pattern[i..], "[dir]")) {
-            // Windows 경로 구분자(\)를 URL 구분자(/)로 정규화
-            for (dir) |c| {
-                try buf.append(allocator, if (c == '\\') '/' else c);
-            }
-            i += "[dir]".len;
-        } else if (std.mem.startsWith(u8, pattern[i..], "[ext]")) {
-            // [ext]는 dot 없이 (예: "png")
-            if (ext.len > 1) try buf.appendSlice(allocator, ext[1..]);
-            i += "[ext]".len;
-        } else {
-            try buf.append(allocator, pattern[i]);
-            i += 1;
-        }
-    }
-    // 확장자 추가
-    try buf.appendSlice(allocator, ext);
-    return buf.toOwnedSlice(allocator);
-}
 
 /// 디렉토리에서 위로 올라가며 첫 `package.json` 위치를 찾는다.
 /// Metro/RN CLI의 projectRoot 자동 감지와 동일 — 모노레포의 packages/app/처럼
@@ -4226,157 +4133,6 @@ fn findProjectRoot(alloc: std.mem.Allocator, start_dir: []const u8) ![]const u8 
         dir = parent;
     }
     return start_dir;
-}
-
-/// Metro AssetRegistry.registerAsset() 호출식을 생성.
-/// RN 런타임은 이 객체의 키를 정확히 요구하므로 shape를 Metro 1:1로 맞춘다.
-fn emitAssetRegistryCall(
-    alloc: std.mem.Allocator,
-    registry_path: []const u8,
-    abs_path: []const u8,
-    bytes: []const u8,
-    hash: *const [8]u8,
-    ext: []const u8,
-    name_without_ext: []const u8,
-    url: []const u8,
-    scales: []const u32,
-    project_root: []const u8,
-) ![]const u8 {
-    const asset_meta = @import("asset_meta.zig");
-    const dims = asset_meta.extractDimensions(bytes);
-    const width = if (dims) |d| d.width else 0;
-    const height = if (dims) |d| d.height else 0;
-    const asset_type = asset_meta.AssetType.fromExtension(ext);
-    const type_name = asset_type.typeName(ext);
-
-    // Metro 호환: httpServerLocation = `/assets/` + projectRoot 기준 상대 경로의 dirname.
-    // RN 런타임이 `<dev-server>:<port><httpServerLocation>/<name>.<hash>.<type>` 형태로
-    // URL을 만들기 때문에 `.`만 있으면 dev server가 파일을 찾지 못한다 (#1428).
-    const http_loc_raw = blk: {
-        if (project_root.len == 0) break :blk std.fs.path.dirname(url) orelse ".";
-        const rel = std.fs.path.relative(alloc, project_root, abs_path) catch break :blk ".";
-        defer alloc.free(rel);
-        const rel_dir = std.fs.path.dirname(rel) orelse ".";
-        break :blk std.fmt.allocPrint(alloc, "/assets/{s}", .{rel_dir}) catch ".";
-    };
-    const fs_dir_raw = std.fs.path.dirname(abs_path) orelse ".";
-
-    // 사용자 경로/식별자에 따옴표·역슬래시·개행이 포함되면 JSON 파싱이 깨지므로 escape 필수.
-    // RN/Metro에서 파일명에 특수문자 있을 가능성은 낮지만 안전하게 처리.
-    const http_loc = try escapeJsString(alloc, http_loc_raw);
-    const fs_dir = try escapeJsString(alloc, fs_dir_raw);
-    const name_esc = try escapeJsString(alloc, name_without_ext);
-    const registry_esc = try escapeJsString(alloc, registry_path);
-
-    // Metro 호환: asset hash는 raw bytes의 MD5 32자 hex (Metro `Assets.js`의 hashFiles 결과).
-    // RN 런타임/빌드 시스템이 캐시 키, 디스크 자산명 등에서 32자를 가정하므로
-    // 8byte wyhash hex로는 충돌 확률 + Metro 호환성 모두 부족 (#1428).
-    // 인자의 hash(`*const [8]u8`)는 기존 caller 호환을 위해 남겨두지만 미사용.
-    _ = hash;
-    var md5_digest: [16]u8 = undefined;
-    std.crypto.hash.Md5.hash(bytes, &md5_digest, .{});
-    var hash_hex: [32]u8 = undefined;
-    const hex_chars = "0123456789abcdef";
-    for (md5_digest, 0..) |b, i| {
-        hash_hex[i * 2] = hex_chars[b >> 4];
-        hash_hex[i * 2 + 1] = hex_chars[b & 0x0F];
-    }
-
-    // scales 배열 직렬화. 일반적으로 [1,2,3] 정도라 스택 버퍼로 충분.
-    var scales_stack_buf: [128]u8 = undefined;
-    var scales_stream = std.io.fixedBufferStream(&scales_stack_buf);
-    const sw = scales_stream.writer();
-    sw.writeByte('[') catch return error.OutOfMemory;
-    for (scales, 0..) |s, i| {
-        if (i > 0) sw.writeAll(", ") catch return error.OutOfMemory;
-        std.fmt.format(sw, "{d}", .{s}) catch return error.OutOfMemory;
-    }
-    sw.writeByte(']') catch return error.OutOfMemory;
-    const scales_str = scales_stream.getWritten();
-
-    return try std.fmt.allocPrint(alloc,
-        \\module.exports = require("{s}").registerAsset({{
-        \\  "__packager_asset": true,
-        \\  "httpServerLocation": "{s}",
-        \\  "width": {d},
-        \\  "height": {d},
-        \\  "scales": {s},
-        \\  "hash": "{s}",
-        \\  "name": "{s}",
-        \\  "type": "{s}",
-        \\  "fileSystemLocation": "{s}"
-        \\}})
-    , .{ registry_esc, http_loc, width, height, scales_str, &hash_hex, name_esc, type_name, fs_dir });
-}
-
-const ScaleCollection = struct {
-    scales: []const u32,
-    variants: []const Module.ScaleVariant,
-};
-
-/// `name.ext`의 sibling을 스캔해 `name@2x.ext`, `name@3x.ext` 등을 수집.
-/// Metro는 base(1x)가 반드시 존재해야 하며 variant만 있으면 매칭 안 함 — 같은 규칙.
-fn collectScaleVariants(
-    alloc: std.mem.Allocator,
-    abs_path: []const u8,
-    name_without_ext: []const u8,
-    ext: []const u8,
-    asset_names: []const u8,
-    dir_pattern: []const u8,
-) !ScaleCollection {
-    const fs_dir = std.fs.path.dirname(abs_path) orelse return ScaleCollection{ .scales = &.{1}, .variants = &.{} };
-
-    var scale_list: std.ArrayList(u32) = .empty;
-    defer scale_list.deinit(alloc);
-    try scale_list.append(alloc, 1); // base
-
-    var variants: std.ArrayList(Module.ScaleVariant) = .empty;
-    defer variants.deinit(alloc);
-
-    // @2x부터 @4x까지 검사 (RN 실전 최대치). @1x 명시는 base와 중복이므로 무시.
-    // stat으로 존재 여부 먼저 확인 — 없으면 readFileAlloc의 큰 alloc + read 시도 회피.
-    var scale: u32 = 2;
-    while (scale <= 4) : (scale += 1) {
-        const variant_name = try std.fmt.allocPrint(alloc, "{s}@{d}x{s}", .{ name_without_ext, scale, ext });
-        defer alloc.free(variant_name);
-        const variant_path = try std.fs.path.join(alloc, &.{ fs_dir, variant_name });
-        defer alloc.free(variant_path);
-
-        fs.access(variant_path) catch continue;
-        const loaded = fs.readFile(alloc, variant_path, 100 * 1024 * 1024) catch continue;
-        const hash = contentHash(loaded.contents);
-        const variant_basename = try std.fmt.allocPrint(alloc, "{s}@{d}x", .{ name_without_ext, scale });
-        defer alloc.free(variant_basename);
-        const output_name = try applyAssetNamingPattern(alloc, asset_names, variant_basename, &hash, ext, dir_pattern);
-
-        try scale_list.append(alloc, scale);
-        try variants.append(alloc, .{
-            .scale = scale,
-            .output_name = output_name,
-            .raw_content = loaded.contents,
-        });
-    }
-
-    return ScaleCollection{
-        .scales = try scale_list.toOwnedSlice(alloc),
-        .variants = try variants.toOwnedSlice(alloc),
-    };
-}
-
-/// asset 파일의 entry_dir 기준 상대 디렉토리 경로를 계산한다.
-/// 예: entry_dir="/app/src", module="/app/src/images/icons/logo.png" → "images/icons"
-/// entry_dir 밖이면 빈 문자열 반환.
-fn computeAssetDir(module_path: []const u8, entry_dir: []const u8) []const u8 {
-    if (entry_dir.len == 0) return "";
-    const module_dir = std.fs.path.dirname(module_path) orelse return "";
-    // entry_dir이 module_dir의 prefix인지 확인
-    if (module_dir.len <= entry_dir.len) return "";
-    if (!std.mem.startsWith(u8, module_dir, entry_dir)) return "";
-    // 구분자 건너뛰기
-    var start = entry_dir.len;
-    if (start < module_dir.len and module_dir[start] == std.fs.path.sep) start += 1;
-    if (start >= module_dir.len) return "";
-    return module_dir[start..];
 }
 
 const JsxRuntime = @import("../codegen/codegen.zig").JsxRuntime;

--- a/src/bundler/graph/assets.zig
+++ b/src/bundler/graph/assets.zig
@@ -1,0 +1,258 @@
+//! Asset loader helpers for ModuleGraph.
+
+const std = @import("std");
+const wyhash = @import("../../util/wyhash.zig");
+const fs = @import("../fs.zig");
+const Module = @import("../module.zig").Module;
+const asset_meta = @import("../asset_meta.zig");
+
+/// JS 문자열 리터럴용 이스케이프. \ " \n \r \0 \u2028 \u2029 를 처리한다.
+pub fn escapeJsString(allocator: std.mem.Allocator, input: []const u8) ![]const u8 {
+    // fast path: 이스케이프가 필요한 문자가 없으면 복사만
+    var needs_escape = false;
+    for (input) |c| {
+        switch (c) {
+            '\\', '"', '\n', '\r', 0 => {
+                needs_escape = true;
+                break;
+            },
+            0xe2 => {
+                needs_escape = true; // UTF-8 U+2028/U+2029 시작 바이트
+                break;
+            },
+            else => {},
+        }
+    }
+    if (!needs_escape) return try allocator.dupe(u8, input);
+
+    var buf: std.ArrayList(u8) = .empty;
+    try buf.ensureTotalCapacity(allocator, input.len);
+    var i: usize = 0;
+    while (i < input.len) {
+        const c = input[i];
+        switch (c) {
+            '\\' => try buf.appendSlice(allocator, "\\\\"),
+            '"' => try buf.appendSlice(allocator, "\\\""),
+            '\n' => try buf.appendSlice(allocator, "\\n"),
+            '\r' => try buf.appendSlice(allocator, "\\r"),
+            0 => try buf.appendSlice(allocator, "\\0"),
+            0xe2 => {
+                // U+2028 (LS) = E2 80 A8, U+2029 (PS) = E2 80 A9
+                if (i + 2 < input.len and input[i + 1] == 0x80) {
+                    if (input[i + 2] == 0xa8) {
+                        try buf.appendSlice(allocator, "\\u2028");
+                        i += 3;
+                        continue;
+                    } else if (input[i + 2] == 0xa9) {
+                        try buf.appendSlice(allocator, "\\u2029");
+                        i += 3;
+                        continue;
+                    }
+                }
+                try buf.append(allocator, c);
+            },
+            else => try buf.append(allocator, c),
+        }
+        i += 1;
+    }
+    return buf.toOwnedSlice(allocator);
+}
+
+/// 바이트 배열을 standard base64로 인코딩한다.
+pub fn base64Encode(allocator: std.mem.Allocator, data: []const u8) ![]const u8 {
+    const encoder = std.base64.standard.Encoder;
+    const encoded_len = encoder.calcSize(data.len);
+    const buf = try allocator.alloc(u8, encoded_len);
+    _ = encoder.encode(buf, data);
+    return buf;
+}
+
+pub const contentHash = wyhash.hashHex8;
+
+/// asset naming 패턴 적용: [name] [hash] 치환 + 확장자 추가.
+pub fn applyAssetNamingPattern(
+    allocator: std.mem.Allocator,
+    pattern: []const u8,
+    name: []const u8,
+    hash: *const [8]u8,
+    ext: []const u8,
+    dir: []const u8,
+) ![]const u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    var i: usize = 0;
+    while (i < pattern.len) {
+        if (std.mem.startsWith(u8, pattern[i..], "[name]")) {
+            try buf.appendSlice(allocator, name);
+            i += "[name]".len;
+        } else if (std.mem.startsWith(u8, pattern[i..], "[hash]")) {
+            try buf.appendSlice(allocator, hash);
+            i += "[hash]".len;
+        } else if (std.mem.startsWith(u8, pattern[i..], "[dir]")) {
+            // Windows 경로 구분자(\)를 URL 구분자(/)로 정규화
+            for (dir) |c| {
+                try buf.append(allocator, if (c == '\\') '/' else c);
+            }
+            i += "[dir]".len;
+        } else if (std.mem.startsWith(u8, pattern[i..], "[ext]")) {
+            // [ext]는 dot 없이 (예: "png")
+            if (ext.len > 1) try buf.appendSlice(allocator, ext[1..]);
+            i += "[ext]".len;
+        } else {
+            try buf.append(allocator, pattern[i]);
+            i += 1;
+        }
+    }
+    // 확장자 추가
+    try buf.appendSlice(allocator, ext);
+    return buf.toOwnedSlice(allocator);
+}
+
+/// Metro AssetRegistry.registerAsset() 호출식을 생성.
+/// RN 런타임은 이 객체의 키를 정확히 요구하므로 shape를 Metro 1:1로 맞춘다.
+pub fn emitAssetRegistryCall(
+    alloc: std.mem.Allocator,
+    registry_path: []const u8,
+    abs_path: []const u8,
+    bytes: []const u8,
+    hash: *const [8]u8,
+    ext: []const u8,
+    name_without_ext: []const u8,
+    url: []const u8,
+    scales: []const u32,
+    project_root: []const u8,
+) ![]const u8 {
+    const dims = asset_meta.extractDimensions(bytes);
+    const width = if (dims) |d| d.width else 0;
+    const height = if (dims) |d| d.height else 0;
+    const asset_type = asset_meta.AssetType.fromExtension(ext);
+    const type_name = asset_type.typeName(ext);
+
+    // Metro 호환: httpServerLocation = `/assets/` + projectRoot 기준 상대 경로의 dirname.
+    // RN 런타임이 `<dev-server>:<port><httpServerLocation>/<name>.<hash>.<type>` 형태로
+    // URL을 만들기 때문에 `.`만 있으면 dev server가 파일을 찾지 못한다 (#1428).
+    const http_loc_raw = blk: {
+        if (project_root.len == 0) break :blk std.fs.path.dirname(url) orelse ".";
+        const rel = std.fs.path.relative(alloc, project_root, abs_path) catch break :blk ".";
+        defer alloc.free(rel);
+        const rel_dir = std.fs.path.dirname(rel) orelse ".";
+        break :blk std.fmt.allocPrint(alloc, "/assets/{s}", .{rel_dir}) catch ".";
+    };
+    const fs_dir_raw = std.fs.path.dirname(abs_path) orelse ".";
+
+    // 사용자 경로/식별자에 따옴표·역슬래시·개행이 포함되면 JSON 파싱이 깨지므로 escape 필수.
+    // RN/Metro에서 파일명에 특수문자 있을 가능성은 낮지만 안전하게 처리.
+    const http_loc = try escapeJsString(alloc, http_loc_raw);
+    const fs_dir = try escapeJsString(alloc, fs_dir_raw);
+    const name_esc = try escapeJsString(alloc, name_without_ext);
+    const registry_esc = try escapeJsString(alloc, registry_path);
+
+    // Metro 호환: asset hash는 raw bytes의 MD5 32자 hex (Metro `Assets.js`의 hashFiles 결과).
+    // RN 런타임/빌드 시스템이 캐시 키, 디스크 자산명 등에서 32자를 가정하므로
+    // 8byte wyhash hex로는 충돌 확률 + Metro 호환성 모두 부족 (#1428).
+    // 인자의 hash(`*const [8]u8`)는 기존 caller 호환을 위해 남겨두지만 미사용.
+    _ = hash;
+    var md5_digest: [16]u8 = undefined;
+    std.crypto.hash.Md5.hash(bytes, &md5_digest, .{});
+    var hash_hex: [32]u8 = undefined;
+    const hex_chars = "0123456789abcdef";
+    for (md5_digest, 0..) |b, i| {
+        hash_hex[i * 2] = hex_chars[b >> 4];
+        hash_hex[i * 2 + 1] = hex_chars[b & 0x0F];
+    }
+
+    // scales 배열 직렬화. 일반적으로 [1,2,3] 정도라 스택 버퍼로 충분.
+    var scales_stack_buf: [128]u8 = undefined;
+    var scales_stream = std.io.fixedBufferStream(&scales_stack_buf);
+    const sw = scales_stream.writer();
+    sw.writeByte('[') catch return error.OutOfMemory;
+    for (scales, 0..) |s, i| {
+        if (i > 0) sw.writeAll(", ") catch return error.OutOfMemory;
+        std.fmt.format(sw, "{d}", .{s}) catch return error.OutOfMemory;
+    }
+    sw.writeByte(']') catch return error.OutOfMemory;
+    const scales_str = scales_stream.getWritten();
+
+    return try std.fmt.allocPrint(alloc,
+        \\module.exports = require("{s}").registerAsset({{
+        \\  "__packager_asset": true,
+        \\  "httpServerLocation": "{s}",
+        \\  "width": {d},
+        \\  "height": {d},
+        \\  "scales": {s},
+        \\  "hash": "{s}",
+        \\  "name": "{s}",
+        \\  "type": "{s}",
+        \\  "fileSystemLocation": "{s}"
+        \\}})
+    , .{ registry_esc, http_loc, width, height, scales_str, &hash_hex, name_esc, type_name, fs_dir });
+}
+
+pub const ScaleCollection = struct {
+    scales: []const u32,
+    variants: []const Module.ScaleVariant,
+};
+
+/// `name.ext`의 sibling을 스캔해 `name@2x.ext`, `name@3x.ext` 등을 수집.
+/// Metro는 base(1x)가 반드시 존재해야 하며 variant만 있으면 매칭 안 함 — 같은 규칙.
+pub fn collectScaleVariants(
+    alloc: std.mem.Allocator,
+    abs_path: []const u8,
+    name_without_ext: []const u8,
+    ext: []const u8,
+    asset_names: []const u8,
+    dir_pattern: []const u8,
+) !ScaleCollection {
+    const fs_dir = std.fs.path.dirname(abs_path) orelse return ScaleCollection{ .scales = &.{1}, .variants = &.{} };
+
+    var scale_list: std.ArrayList(u32) = .empty;
+    defer scale_list.deinit(alloc);
+    try scale_list.append(alloc, 1); // base
+
+    var variants: std.ArrayList(Module.ScaleVariant) = .empty;
+    defer variants.deinit(alloc);
+
+    // @2x부터 @4x까지 검사 (RN 실전 최대치). @1x 명시는 base와 중복이므로 무시.
+    // stat으로 존재 여부 먼저 확인 — 없으면 readFileAlloc의 큰 alloc + read 시도 회피.
+    var scale: u32 = 2;
+    while (scale <= 4) : (scale += 1) {
+        const variant_name = try std.fmt.allocPrint(alloc, "{s}@{d}x{s}", .{ name_without_ext, scale, ext });
+        defer alloc.free(variant_name);
+        const variant_path = try std.fs.path.join(alloc, &.{ fs_dir, variant_name });
+        defer alloc.free(variant_path);
+
+        fs.access(variant_path) catch continue;
+        const loaded = fs.readFile(alloc, variant_path, 100 * 1024 * 1024) catch continue;
+        const hash = contentHash(loaded.contents);
+        const variant_basename = try std.fmt.allocPrint(alloc, "{s}@{d}x", .{ name_without_ext, scale });
+        defer alloc.free(variant_basename);
+        const output_name = try applyAssetNamingPattern(alloc, asset_names, variant_basename, &hash, ext, dir_pattern);
+
+        try scale_list.append(alloc, scale);
+        try variants.append(alloc, .{
+            .scale = scale,
+            .output_name = output_name,
+            .raw_content = loaded.contents,
+        });
+    }
+
+    return ScaleCollection{
+        .scales = try scale_list.toOwnedSlice(alloc),
+        .variants = try variants.toOwnedSlice(alloc),
+    };
+}
+
+/// asset 파일의 entry_dir 기준 상대 디렉토리 경로를 계산한다.
+/// 예: entry_dir="/app/src", module="/app/src/images/icons/logo.png" → "images/icons"
+/// entry_dir 밖이면 빈 문자열 반환.
+pub fn computeAssetDir(module_path: []const u8, entry_dir: []const u8) []const u8 {
+    if (entry_dir.len == 0) return "";
+    const module_dir = std.fs.path.dirname(module_path) orelse return "";
+    // entry_dir이 module_dir의 prefix인지 확인
+    if (module_dir.len <= entry_dir.len) return "";
+    if (!std.mem.startsWith(u8, module_dir, entry_dir)) return "";
+    // 구분자 건너뛰기
+    var start = entry_dir.len;
+    if (start < module_dir.len and module_dir[start] == std.fs.path.sep) start += 1;
+    if (start >= module_dir.len) return "";
+    return module_dir[start..];
+}


### PR DESCRIPTION
## 요약
- `src/bundler/graph/assets.zig`를 추가해 asset loader helper를 `graph.zig`에서 분리했습니다.
- `graph.zig`는 child module을 import하고 기존 call site는 alias로 유지했습니다.
- 재점검 결과 `findProjectRoot`는 build/buildIncremental 초기화와 테스트에 걸친 graph-level path util이라 이번 PR 범위에 포함하지 않았습니다.

## 검증
- `zig build test`
- `zig build napi`
- `zig fmt --check src/bundler/graph.zig src/bundler/graph/assets.zig`
- `git diff --check`
- `bun test ./packages/core/test/core/build-options-exposure/resource-loaders.ts --timeout 30000`
- `bun test ./packages/core/test/core/plugin-onload-loader/standard-loaders.ts --timeout 30000`
- `bun test ./packages/core/test/core/plugin-onload-loader/binary-contents.ts --timeout 30000`
- pre-push hook 통과 (`zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`)