### PR TITLE
refactor(core): 그래프 synthetic import 헬퍼 분리

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -76,6 +76,10 @@ const emitAssetRegistryCall = graph_assets.emitAssetRegistryCall;
 const ScaleCollection = graph_assets.ScaleCollection;
 const collectScaleVariants = graph_assets.collectScaleVariants;
 const computeAssetDir = graph_assets.computeAssetDir;
+const graph_synthetic_imports = @import("graph/synthetic_imports.zig");
+const injectJsxRuntimeImports = graph_synthetic_imports.injectJsxRuntimeImports;
+const injectFlowEnumRuntimeImport = graph_synthetic_imports.injectFlowEnumRuntimeImport;
+const createJsxImportBindings = graph_synthetic_imports.createJsxImportBindings;
 
 pub const ModuleGraph = struct {
     allocator: std.mem.Allocator,
@@ -4133,98 +4137,6 @@ fn findProjectRoot(alloc: std.mem.Allocator, start_dir: []const u8) ![]const u8 
         dir = parent;
     }
     return start_dir;
-}
-
-const JsxRuntime = @import("../codegen/codegen.zig").JsxRuntime;
-const ImportBinding = binding_scanner_mod.ImportBinding;
-
-/// JSX automatic import를 synthetic하게 추가한다.
-/// 기존 import_records 배열 끝에 각 specifier 를 static_import record 로 append.
-/// 한 번의 alloc + memcpy 로 처리해 중간 버퍼 낭비를 피한다.
-fn injectJsxRuntimeImports(
-    specifiers: []const []const u8,
-    arena_alloc: std.mem.Allocator,
-    existing_records: []ImportRecord,
-) ![]ImportRecord {
-    const new_records = try arena_alloc.alloc(ImportRecord, existing_records.len + specifiers.len);
-    @memcpy(new_records[0..existing_records.len], existing_records);
-    for (specifiers, 0..) |specifier, i| {
-        new_records[existing_records.len + i] = .{
-            .specifier = specifier,
-            .kind = .static_import,
-            .span = Span.EMPTY,
-        };
-    }
-    return new_records;
-}
-
-fn injectFlowEnumRuntimeImport(
-    arena_alloc: std.mem.Allocator,
-    existing_records: []ImportRecord,
-) ![]ImportRecord {
-    const specifier = runtime_helpers.FLOW_ENUMS_RUNTIME_SPECIFIER;
-    for (existing_records) |record| {
-        if (std.mem.eql(u8, record.specifier, specifier)) return existing_records;
-    }
-
-    const new_records = try arena_alloc.alloc(ImportRecord, existing_records.len + 1);
-    @memcpy(new_records[0..existing_records.len], existing_records);
-    new_records[existing_records.len] = .{
-        .specifier = specifier,
-        .kind = .require,
-        .span = Span.EMPTY,
-    };
-    return new_records;
-}
-
-/// JSX automatic import 의 synthetic bindings. `react_record_index` 가 있으면
-/// key-after-spread fallback 용 `_createElement` 도 포함.
-fn createJsxImportBindings(
-    jsx_runtime: JsxRuntime,
-    arena_alloc: std.mem.Allocator,
-    existing_bindings: []ImportBinding,
-    jsx_record_index: u32,
-    react_record_index: ?u32,
-) ![]ImportBinding {
-    const is_dev = jsx_runtime == .automatic_dev;
-
-    const Entry = struct { local: []const u8, imported: []const u8, record: u32 };
-    var buf: [4]Entry = undefined;
-    var len: usize = 0;
-    if (is_dev) {
-        buf[len] = .{ .local = "_jsxDEV", .imported = "jsxDEV", .record = jsx_record_index };
-        len += 1;
-        buf[len] = .{ .local = "_Fragment", .imported = "Fragment", .record = jsx_record_index };
-        len += 1;
-    } else {
-        buf[len] = .{ .local = "_jsx", .imported = "jsx", .record = jsx_record_index };
-        len += 1;
-        buf[len] = .{ .local = "_jsxs", .imported = "jsxs", .record = jsx_record_index };
-        len += 1;
-        buf[len] = .{ .local = "_Fragment", .imported = "Fragment", .record = jsx_record_index };
-        len += 1;
-    }
-    if (react_record_index) |rr| {
-        buf[len] = .{ .local = "_createElement", .imported = "createElement", .record = rr };
-        len += 1;
-    }
-
-    const entries = buf[0..len];
-    const new_bindings = try arena_alloc.alloc(ImportBinding, existing_bindings.len + entries.len);
-    @memcpy(new_bindings[0..existing_bindings.len], existing_bindings);
-    for (entries, 0..) |e, i| {
-        // 각 synthetic binding에 고유 sentinel span 부여.
-        // Span.EMPTY(0,0)를 공유하면 linker의 spanKey 기반 HashMap에서 덮어쓰기 발생.
-        const sentinel_start: u32 = ImportBinding.SYNTHETIC_SPAN_BASE + @as(u32, @intCast(i));
-        new_bindings[existing_bindings.len + i] = .{
-            .kind = .named,
-            .local_name = e.local,
-            .imported_name = e.imported,
-            .local_span = .{ .start = sentinel_start, .end = sentinel_start },
-            .import_record_index = e.record,
-        };
-    }
-    return new_bindings;
 }
 
 /// 스캔 결과와 파일 확장자로 모듈의 export 방식을 결정한다.

--- a/src/bundler/graph/synthetic_imports.zig
+++ b/src/bundler/graph/synthetic_imports.zig
@@ -1,0 +1,99 @@
+//! Synthetic import helpers for ModuleGraph.
+
+const std = @import("std");
+const types = @import("../types.zig");
+const ImportRecord = types.ImportRecord;
+const Span = @import("../../lexer/token.zig").Span;
+const runtime_helpers = @import("../runtime_helpers.zig");
+const JsxRuntime = @import("../../codegen/codegen.zig").JsxRuntime;
+const binding_scanner = @import("../binding_scanner.zig");
+const ImportBinding = binding_scanner.ImportBinding;
+
+/// JSX automatic import를 synthetic하게 추가한다.
+/// 기존 import_records 배열 끝에 각 specifier 를 static_import record 로 append.
+/// 한 번의 alloc + memcpy 로 처리해 중간 버퍼 낭비를 피한다.
+pub fn injectJsxRuntimeImports(
+    specifiers: []const []const u8,
+    arena_alloc: std.mem.Allocator,
+    existing_records: []ImportRecord,
+) ![]ImportRecord {
+    const new_records = try arena_alloc.alloc(ImportRecord, existing_records.len + specifiers.len);
+    @memcpy(new_records[0..existing_records.len], existing_records);
+    for (specifiers, 0..) |specifier, i| {
+        new_records[existing_records.len + i] = .{
+            .specifier = specifier,
+            .kind = .static_import,
+            .span = Span.EMPTY,
+        };
+    }
+    return new_records;
+}
+
+pub fn injectFlowEnumRuntimeImport(
+    arena_alloc: std.mem.Allocator,
+    existing_records: []ImportRecord,
+) ![]ImportRecord {
+    const specifier = runtime_helpers.FLOW_ENUMS_RUNTIME_SPECIFIER;
+    for (existing_records) |record| {
+        if (std.mem.eql(u8, record.specifier, specifier)) return existing_records;
+    }
+
+    const new_records = try arena_alloc.alloc(ImportRecord, existing_records.len + 1);
+    @memcpy(new_records[0..existing_records.len], existing_records);
+    new_records[existing_records.len] = .{
+        .specifier = specifier,
+        .kind = .require,
+        .span = Span.EMPTY,
+    };
+    return new_records;
+}
+
+/// JSX automatic import 의 synthetic bindings. `react_record_index` 가 있으면
+/// key-after-spread fallback 용 `_createElement` 도 포함.
+pub fn createJsxImportBindings(
+    jsx_runtime: JsxRuntime,
+    arena_alloc: std.mem.Allocator,
+    existing_bindings: []ImportBinding,
+    jsx_record_index: u32,
+    react_record_index: ?u32,
+) ![]ImportBinding {
+    const is_dev = jsx_runtime == .automatic_dev;
+
+    const Entry = struct { local: []const u8, imported: []const u8, record: u32 };
+    var buf: [4]Entry = undefined;
+    var len: usize = 0;
+    if (is_dev) {
+        buf[len] = .{ .local = "_jsxDEV", .imported = "jsxDEV", .record = jsx_record_index };
+        len += 1;
+        buf[len] = .{ .local = "_Fragment", .imported = "Fragment", .record = jsx_record_index };
+        len += 1;
+    } else {
+        buf[len] = .{ .local = "_jsx", .imported = "jsx", .record = jsx_record_index };
+        len += 1;
+        buf[len] = .{ .local = "_jsxs", .imported = "jsxs", .record = jsx_record_index };
+        len += 1;
+        buf[len] = .{ .local = "_Fragment", .imported = "Fragment", .record = jsx_record_index };
+        len += 1;
+    }
+    if (react_record_index) |rr| {
+        buf[len] = .{ .local = "_createElement", .imported = "createElement", .record = rr };
+        len += 1;
+    }
+
+    const entries = buf[0..len];
+    const new_bindings = try arena_alloc.alloc(ImportBinding, existing_bindings.len + entries.len);
+    @memcpy(new_bindings[0..existing_bindings.len], existing_bindings);
+    for (entries, 0..) |e, i| {
+        // 각 synthetic binding에 고유 sentinel span 부여.
+        // Span.EMPTY(0,0)를 공유하면 linker의 spanKey 기반 HashMap에서 덮어쓰기 발생.
+        const sentinel_start: u32 = ImportBinding.SYNTHETIC_SPAN_BASE + @as(u32, @intCast(i));
+        new_bindings[existing_bindings.len + i] = .{
+            .kind = .named,
+            .local_name = e.local,
+            .imported_name = e.imported,
+            .local_span = .{ .start = sentinel_start, .end = sentinel_start },
+            .import_record_index = e.record,
+        };
+    }
+    return new_bindings;
+}


### PR DESCRIPTION
## 요약
- `src/bundler/graph/synthetic_imports.zig`를 추가해 JSX/Flow synthetic import helper를 `graph.zig`에서 분리했습니다.
- `graph.zig`는 child module import와 함수 alias만 유지해 기존 call site 흐름을 보존했습니다.
- `ModuleGraph`와 plugin diagnostic을 직접 쓰는 glob/context expansion은 이번 PR 범위에서 제외했습니다.

## 검증
- `zig build test`
- `zig build napi`
- `zig fmt --check src/bundler/graph.zig src/bundler/graph/synthetic_imports.zig`
- `git diff --check`
- `bun test ./packages/core/test/core/build-option-combinations/feature-flags.ts --timeout 30000`
- `bun test ./packages/core/test/core/edge-combinations/react.ts --timeout 30000`
- `bun test ./packages/core/test/core/react-refresh.ts --timeout 30000`
- `bun test ./packages/core/test/cli/formats/react.ts --timeout 30000`
- pre-push hook 통과 (`zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`)