### PR TITLE
refactor(core): 그래프 glob 헬퍼 분리

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -82,6 +82,8 @@ const injectFlowEnumRuntimeImport = graph_synthetic_imports.injectFlowEnumRuntim
 const createJsxImportBindings = graph_synthetic_imports.createJsxImportBindings;
 const graph_project_root = @import("graph/project_root.zig");
 const findProjectRoot = graph_project_root.findProjectRoot;
+const graph_glob = @import("graph/glob.zig");
+const expandGlobRecords = graph_glob.expandGlobRecords;
 
 pub const ModuleGraph = struct {
     allocator: std.mem.Allocator,
@@ -4148,77 +4150,6 @@ pub fn determineExportsKind(
     if (std.mem.eql(u8, ext, ".mjs") or std.mem.eql(u8, ext, ".mts")) return .esm;
 
     return .none;
-}
-
-/// import.meta.glob 패턴을 파일 시스템에서 확장한다.
-/// 패턴: "./dir/*.ext" — prefix(./dir/) + *와 suffix(.ext)로 분리하여 디렉토리 탐색.
-/// 상대 경로 배열을 반환한다 (예: ["./pages/Home.tsx", "./pages/About.tsx"]).
-fn expandGlob(allocator: std.mem.Allocator, source_dir: []const u8, pattern: []const u8) ![]const []const u8 {
-    // 패턴에서 * 위치 찾기
-    const star_pos = std.mem.indexOf(u8, pattern, "*") orelse return &.{};
-    const prefix = pattern[0..star_pos]; // "./pages/"
-    const suffix = pattern[star_pos + 1 ..]; // ".tsx"
-
-    // prefix에서 디렉토리 경로 추출
-    const glob_dir_rel = if (prefix.len > 0 and prefix[prefix.len - 1] == '/')
-        prefix[0 .. prefix.len - 1]
-    else if (std.fs.path.dirname(prefix)) |d| d else ".";
-
-    // 절대 경로로 변환
-    const glob_dir_abs = try std.fs.path.resolve(allocator, &.{ source_dir, glob_dir_rel });
-    defer allocator.free(glob_dir_abs);
-
-    // 디렉토리 항목 수집
-    const entries = fs.listDir(allocator, glob_dir_abs) catch return &.{};
-    defer {
-        for (entries) |e| allocator.free(e.name);
-        allocator.free(entries);
-    }
-
-    var results: std.ArrayList([]const u8) = .empty;
-    errdefer {
-        for (results.items) |r| allocator.free(r);
-        results.deinit(allocator);
-    }
-
-    // prefix에서 디렉토리 이후 부분 (파일명 prefix)
-    const file_prefix = if (prefix.len > 0 and prefix[prefix.len - 1] == '/')
-        ""
-    else
-        std.fs.path.basename(prefix);
-
-    for (entries) |entry| {
-        if (entry.kind != .file and entry.kind != .symlink) continue;
-        const name = entry.name;
-
-        // prefix 매칭
-        if (file_prefix.len > 0 and !std.mem.startsWith(u8, name, file_prefix)) continue;
-        // suffix 매칭 (확장자)
-        if (suffix.len > 0 and !std.mem.endsWith(u8, name, suffix)) continue;
-
-        // 상대 경로 생성: "./dir/filename.ext"
-        const rel_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ glob_dir_rel, name });
-        try results.append(allocator, rel_path);
-    }
-
-    // 결정적 순서를 위해 정렬
-    std.mem.sortUnstable([]const u8, results.items, {}, struct {
-        fn cmp(_: void, a: []const u8, b: []const u8) bool {
-            return std.mem.lessThan(u8, a, b);
-        }
-    }.cmp);
-
-    return try results.toOwnedSlice(allocator);
-}
-
-/// import_records 배열에서 glob 레코드를 찾아 expandGlob으로 파일 매칭을 수행한다.
-/// scanWorker와 resolveModuleImports 양쪽에서 호출되는 공통 헬퍼.
-fn expandGlobRecords(allocator: std.mem.Allocator, records: []types.ImportRecord, source_dir: []const u8) void {
-    for (records) |*record| {
-        if (record.kind == .glob) {
-            record.glob_matches = expandGlob(allocator, source_dir, record.specifier) catch &.{};
-        }
-    }
 }
 
 /// require.context(...) 레코드의 매칭 파일 목록을 host plugin (resolveContext) 으로 채운다.

--- a/src/bundler/graph/glob.zig
+++ b/src/bundler/graph/glob.zig
@@ -1,0 +1,120 @@
+//! import.meta.glob expansion helpers for ModuleGraph.
+
+const std = @import("std");
+const fs = @import("../fs.zig");
+const types = @import("../types.zig");
+const Span = @import("../../lexer/token.zig").Span;
+
+/// import.meta.glob 패턴을 파일 시스템에서 확장한다.
+/// 패턴: "./dir/*.ext" — prefix(./dir/) + *와 suffix(.ext)로 분리하여 디렉토리 탐색.
+/// 상대 경로 배열을 반환한다 (예: ["./pages/Home.tsx", "./pages/About.tsx"]).
+fn expandGlob(allocator: std.mem.Allocator, source_dir: []const u8, pattern: []const u8) ![]const []const u8 {
+    const star_pos = std.mem.indexOf(u8, pattern, "*") orelse return &.{};
+    const prefix = pattern[0..star_pos];
+    const suffix = pattern[star_pos + 1 ..];
+
+    const glob_dir_rel = if (prefix.len > 0 and prefix[prefix.len - 1] == '/')
+        prefix[0 .. prefix.len - 1]
+    else if (std.fs.path.dirname(prefix)) |d| d else ".";
+
+    const glob_dir_abs = try std.fs.path.resolve(allocator, &.{ source_dir, glob_dir_rel });
+    defer allocator.free(glob_dir_abs);
+
+    const entries = fs.listDir(allocator, glob_dir_abs) catch return &.{};
+    defer {
+        for (entries) |e| allocator.free(e.name);
+        allocator.free(entries);
+    }
+
+    var results: std.ArrayList([]const u8) = .empty;
+    errdefer {
+        for (results.items) |r| allocator.free(r);
+        results.deinit(allocator);
+    }
+
+    const file_prefix = if (prefix.len > 0 and prefix[prefix.len - 1] == '/')
+        ""
+    else
+        std.fs.path.basename(prefix);
+
+    for (entries) |entry| {
+        if (entry.kind != .file and entry.kind != .symlink) continue;
+        const name = entry.name;
+        if (file_prefix.len > 0 and !std.mem.startsWith(u8, name, file_prefix)) continue;
+        if (suffix.len > 0 and !std.mem.endsWith(u8, name, suffix)) continue;
+
+        const rel_path = try std.fmt.allocPrint(allocator, "{s}/{s}", .{ glob_dir_rel, name });
+        try results.append(allocator, rel_path);
+    }
+
+    std.mem.sortUnstable([]const u8, results.items, {}, struct {
+        fn cmp(_: void, a: []const u8, b: []const u8) bool {
+            return std.mem.lessThan(u8, a, b);
+        }
+    }.cmp);
+
+    return try results.toOwnedSlice(allocator);
+}
+
+/// import_records 배열에서 glob 레코드를 찾아 expandGlob으로 파일 매칭을 수행한다.
+/// scanWorker와 resolveModuleImports 양쪽에서 호출되는 공통 헬퍼.
+pub fn expandGlobRecords(allocator: std.mem.Allocator, records: []types.ImportRecord, source_dir: []const u8) void {
+    for (records) |*record| {
+        if (record.kind == .glob) {
+            record.glob_matches = expandGlob(allocator, source_dir, record.specifier) catch &.{};
+        }
+    }
+}
+
+const test_helpers = @import("../test_helpers.zig");
+const writeFile = test_helpers.writeFile;
+const absPath = test_helpers.absPath;
+
+fn freeGlobMatches(allocator: std.mem.Allocator, matches: []const []const u8) void {
+    for (matches) |match| allocator.free(match);
+    allocator.free(matches);
+}
+
+test "expandGlob: 파일명 prefix와 suffix를 적용하고 결과를 정렬한다" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "src/pages/PageB.tsx", "");
+    try writeFile(tmp.dir, "src/pages/PageA.tsx", "");
+    try writeFile(tmp.dir, "src/pages/Other.tsx", "");
+    try writeFile(tmp.dir, "src/pages/PageC.css", "");
+
+    const source_dir = try absPath(&tmp, "src");
+    defer std.testing.allocator.free(source_dir);
+
+    const matches = try expandGlob(std.testing.allocator, source_dir, "./pages/Page*.tsx");
+    defer freeGlobMatches(std.testing.allocator, matches);
+
+    try std.testing.expectEqual(@as(usize, 2), matches.len);
+    try std.testing.expectEqualStrings("./pages/PageA.tsx", matches[0]);
+    try std.testing.expectEqualStrings("./pages/PageB.tsx", matches[1]);
+}
+
+test "expandGlobRecords: glob 레코드에만 매칭 결과를 채운다" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "app/mods/a.ts", "");
+    try writeFile(tmp.dir, "app/mods/b.ts", "");
+
+    const source_dir = try absPath(&tmp, "app");
+    defer std.testing.allocator.free(source_dir);
+
+    var records = [_]types.ImportRecord{
+        .{ .specifier = "./mods/*.ts", .kind = .glob, .span = Span.EMPTY },
+        .{ .specifier = "./side-effect", .kind = .side_effect, .span = Span.EMPTY },
+    };
+
+    expandGlobRecords(std.testing.allocator, &records, source_dir);
+    defer if (records[0].glob_matches) |matches| freeGlobMatches(std.testing.allocator, matches);
+
+    try std.testing.expect(records[0].glob_matches != null);
+    const matches = records[0].glob_matches.?;
+    try std.testing.expectEqual(@as(usize, 2), matches.len);
+    try std.testing.expectEqualStrings("./mods/a.ts", matches[0]);
+    try std.testing.expectEqualStrings("./mods/b.ts", matches[1]);
+    try std.testing.expect(records[1].glob_matches == null);
+}

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -120,6 +120,7 @@ test {
     _ = @import("statement_shaker_test.zig");
     _ = @import("graph_test.zig");
     _ = @import("graph/project_root.zig");
+    _ = @import("graph/glob.zig");
     _ = @import("resolver_test.zig");
     _ = @import("package_json_test.zig");
     _ = @import("binding_scanner_test.zig");


### PR DESCRIPTION
## 요약
- import.meta.glob 확장 로직을 src/bundler/graph/glob.zig로 분리했습니다.
- graph.zig는 기존 호출 지점에서 새 헬퍼를 import해서 사용하도록 유지했습니다.
- 분리된 glob 헬퍼가 test 빌드에서 직접 발견되도록 bundler test aggregator에 추가하고, prefix/suffix/정렬 및 glob record 적용 단위 테스트를 추가했습니다.

## 검증
- zig test src/root.zig --test-filter expandGlob
- zig test src/root.zig --test-filter "import.meta.glob"
- zig build test
- zig build napi
- zig build -Doptimize=ReleaseFast
- bun test ./packages/core/test/core/import-meta-glob/basic.ts --timeout 30000
- bun test ./packages/core/test/core/import-meta-glob/output-formats.ts --timeout 30000
- bun test ./packages/core/test/core/import-meta-glob/string-literal.ts --timeout 30000
- bun test ./packages/core/test/cli/import-meta-glob/basic-options.ts --timeout 30000
- bun test ./packages/core/test/cli/import-meta-glob/vite-patterns.ts --timeout 30000
- git diff --check
- pre-push hook 통과 (zig fmt, zig build test, oxlint 경고 23개/에러 0개, oxfmt)