### PR TITLE
feat(monorepo): adopt source exports condition + vite-plugin publish-ready

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -238,6 +238,9 @@
       "dependencies": {
         "@zntc/core": "workspace:*",
       },
+      "devDependencies": {
+        "@types/node": "^25.5.2",
+      },
       "peerDependencies": {
         "vite": ">=5.0.0",
       },
@@ -873,7 +876,7 @@
 
     "@expo/json-file": ["@expo/json-file@10.0.14", "", { "dependencies": { "@babel/code-frame": "^7.20.0", "json5": "^2.2.3" } }, "sha512-yWwBFywFv+SxkJp/pIzzA416JVYflNUh7pqQzgaA6nXDqRyK7KfrqVzk8PdUfDnqbBcaZZxpzNssfQZzp5KHrA=="],
 
-    "@expo/local-build-cache-provider": ["@expo/local-build-cache-provider@55.0.12", "", { "dependencies": { "@expo/config": "~55.0.16", "chalk": "^4.1.2" } }, "sha512-Wqhe7ajt6lyIEQvqDC1zm0MQ1RqQLlM9awCepY9pz+tm9rvhuxGPZNTCddWeD8k4kolinBlDbLDFnNi06XgaDWQ=="],
+    "@expo/local-build-cache-provider": ["@expo/local-build-cache-provider@55.0.12", "", { "dependencies": { "@expo/config": "~55.0.16", "chalk": "^4.1.2" } }, ""],
 
     "@expo/log-box": ["@expo/log-box@55.0.12", "", { "dependencies": { "@expo/dom-webview": "^55.0.6", "anser": "^1.4.9", "stacktrace-parser": "^0.1.10" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-f9ARS8J60cq3LLNdIqmUjYwyerBzVS5Ecp7KjIf3GOIPjW0571rkcwLz4/U18l/1DeSkSzIkYsNl2TC9oTdWaQ=="],
 
@@ -2587,7 +2590,7 @@
 
     "esast-util-from-js": ["esast-util-from-js@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "acorn": "^8.0.0", "esast-util-from-estree": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw=="],
 
-    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVzntcLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, ""],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -2753,7 +2756,7 @@
 
     "fb-watchman": ["fb-watchman@2.0.2", "", { "dependencies": { "bser": "2.1.1" } }, "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA=="],
 
-    "fbjs": ["fbjs@3.0.5", "", { "dependencies": { "cross-fetch": "^3.1.5", "fbjs-css-vars": "^1.0.0", "loose-envify": "^1.0.0", "object-assign": "^4.1.0", "promise": "^7.1.1", "setimmediate": "^1.0.5", "ua-parser-js": "^1.0.35" } }, "sha512-zntcSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg=="],
+    "fbjs": ["fbjs@3.0.5", "", { "dependencies": { "cross-fetch": "^3.1.5", "fbjs-css-vars": "^1.0.0", "loose-envify": "^1.0.0", "object-assign": "^4.1.0", "promise": "^7.1.1", "setimmediate": "^1.0.5", "ua-parser-js": "^1.0.35" } }, ""],
 
     "fbjs-css-vars": ["fbjs-css-vars@1.0.2", "", {}, "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="],
 
@@ -3257,7 +3260,7 @@
 
     "klona": ["klona@2.0.6", "", {}, "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA=="],
 
-    "ky": ["ky@1.14.3", "", {}, "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozntc9qQCfk7bIw=="],
+    "ky": ["ky@1.14.3", "", {}, ""],
 
     "kysely": ["kysely@0.27.6", "", {}, "sha512-FIyV/64EkKhJmjgC0g2hygpBv5RNWVPyNCqSAD7eTCv6eFWNIi4PN1UvdSJGicN/o35bnevgis4Y0UDC0qi8jQ=="],
 
@@ -3399,7 +3402,7 @@
 
     "mdast-util-mdx-expression": ["mdast-util-mdx-expression@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ=="],
 
-    "mdast-util-mdx-jsx": ["mdast-util-mdx-jsx@3.2.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "parse-entities": "^4.0.0", "stringify-entities": "^4.0.0", "unist-util-stringify-position": "^4.0.0", "vfile-message": "^4.0.0" } }, "sha512-lj/z8v0r6ZntcN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q=="],
+    "mdast-util-mdx-jsx": ["mdast-util-mdx-jsx@3.2.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "parse-entities": "^4.0.0", "stringify-entities": "^4.0.0", "unist-util-stringify-position": "^4.0.0", "vfile-message": "^4.0.0" } }, ""],
 
     "mdast-util-mdxjs-esm": ["mdast-util-mdxjs-esm@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg=="],
 
@@ -4137,7 +4140,7 @@
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
-    "sshpk": ["sshpk@1.18.0", "", { "dependencies": { "asn1": "~0.2.3", "assert-plus": "^1.0.0", "bcrypt-pbkdf": "^1.0.0", "dashdash": "^1.12.0", "ecc-jsbn": "~0.1.1", "getpass": "^0.1.1", "jsbn": "~0.1.0", "safer-buffer": "^2.0.2", "tweetnacl": "~0.14.0" }, "bin": { "sshpk-conv": "bin/sshpk-conv", "sshpk-sign": "bin/sshpk-sign", "sshpk-verify": "bin/sshpk-verify" } }, "sha512-2p2KJZNTCqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ=="],
+    "sshpk": ["sshpk@1.18.0", "", { "dependencies": { "asn1": "~0.2.3", "assert-plus": "^1.0.0", "bcrypt-pbkdf": "^1.0.0", "dashdash": "^1.12.0", "ecc-jsbn": "~0.1.1", "getpass": "^0.1.1", "jsbn": "~0.1.0", "safer-buffer": "^2.0.2", "tweetnacl": "~0.14.0" }, "bin": { "sshpk-conv": "bin/sshpk-conv", "sshpk-sign": "bin/sshpk-sign", "sshpk-verify": "bin/sshpk-verify" } }, ""],
 
     "stable-hash": ["stable-hash@0.0.5", "", {}, "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA=="],
 
@@ -4185,7 +4188,7 @@
 
     "string.prototype.trim": ["string.prototype.trim@1.2.10", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "define-data-property": "^1.1.4", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-object-atoms": "^1.0.0", "has-property-descriptors": "^1.0.2" } }, "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA=="],
 
-    "string.prototype.trimend": ["string.prototype.trimend@1.0.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZntcNque2FN2PoUhfZXYLNWwEr4dLQ=="],
+    "string.prototype.trimend": ["string.prototype.trimend@1.0.9", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, ""],
 
     "string.prototype.trimleft": ["string.prototype.trimleft@2.1.3", "", { "dependencies": { "call-bind": "^1.0.0", "define-properties": "^1.1.3", "string.prototype.trimstart": "^1.0.3" } }, "sha512-699Ibssmj/awVzvdNk4g83/Iu8U9vDohzmA/ly2BrQWGhamuY4Tlvs5XKmKliDt3ky6SKbE1bzPhASKCFlx9Sg=="],
 
@@ -4563,13 +4566,13 @@
 
     "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
 
-    "zod": ["zod@4.4.1", "", {}, "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q=="],
-
-    "zrender": ["zrender@6.0.0", "", { "dependencies": { "tslib": "2.3.0" } }, "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg=="],
-
     "zntc-example-react-native-bare": ["zntc-example-react-native-bare@workspace:examples/react-native-bare"],
 
     "zntc-example-react-native-expo": ["zntc-example-react-native-expo@workspace:examples/react-native-expo"],
+
+    "zod": ["zod@4.4.1", "", {}, "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q=="],
+
+    "zrender": ["zrender@6.0.0", "", { "dependencies": { "tslib": "2.3.0" } }, "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg=="],
 
     "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
 
@@ -5385,8 +5388,6 @@
 
     "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
-    "zrender/tslib": ["tslib@2.3.0", "", {}, "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="],
-
     "zntc-example-react-native-bare/@react-native/babel-plugin-codegen": ["@react-native/babel-plugin-codegen@0.85.1", "", { "dependencies": { "@babel/traverse": "^7.29.0", "@react-native/codegen": "0.85.1" } }, "sha512-Klex4kTsRxoswZmo7EBXobvpg+HO6h7xeGo87CLXSKPq3qHlJ8ilpgtmzYCTK+Qr/0Mk3cz2zv3bA9VTXR+NDA=="],
 
     "zntc-example-react-native-bare/@react-native/babel-preset": ["@react-native/babel-preset@0.85.1", "", { "dependencies": { "@babel/core": "^7.25.2", "@babel/plugin-proposal-export-default-from": "^7.24.7", "@babel/plugin-syntax-dynamic-import": "^7.8.3", "@babel/plugin-syntax-export-default-from": "^7.24.7", "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3", "@babel/plugin-syntax-optional-chaining": "^7.8.3", "@babel/plugin-transform-async-generator-functions": "^7.25.4", "@babel/plugin-transform-async-to-generator": "^7.24.7", "@babel/plugin-transform-block-scoping": "^7.25.0", "@babel/plugin-transform-class-properties": "^7.25.4", "@babel/plugin-transform-classes": "^7.25.4", "@babel/plugin-transform-destructuring": "^7.24.8", "@babel/plugin-transform-flow-strip-types": "^7.25.2", "@babel/plugin-transform-for-of": "^7.24.7", "@babel/plugin-transform-modules-commonjs": "^7.24.8", "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7", "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7", "@babel/plugin-transform-optional-catch-binding": "^7.24.7", "@babel/plugin-transform-optional-chaining": "^7.24.8", "@babel/plugin-transform-private-methods": "^7.24.7", "@babel/plugin-transform-private-property-in-object": "^7.24.7", "@babel/plugin-transform-react-display-name": "^7.24.7", "@babel/plugin-transform-react-jsx": "^7.25.2", "@babel/plugin-transform-react-jsx-self": "^7.24.7", "@babel/plugin-transform-react-jsx-source": "^7.24.7", "@babel/plugin-transform-regenerator": "^7.24.7", "@babel/plugin-transform-runtime": "^7.24.7", "@babel/plugin-transform-typescript": "^7.25.2", "@babel/plugin-transform-unicode-regex": "^7.24.7", "@react-native/babel-plugin-codegen": "0.85.1", "babel-plugin-syntax-hermes-parser": "0.33.3", "babel-plugin-transform-flow-enums": "^0.0.2", "react-refresh": "^0.14.0" } }, "sha512-Mplsn13fCxQElOfWg6wIuXJP+tyO980etTQ1gQFTt5Zstj3rs33GzTLMNlo6EnT8PQghO3GxIrg/2im5GwodnA=="],
@@ -5408,6 +5409,8 @@
     "zntc-example-react-native-expo/react-native-safe-area-context": ["react-native-safe-area-context@5.6.2", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg=="],
 
     "zntc-example-react-native-expo/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "zrender/tslib": ["tslib@2.3.0", "", {}, "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="],
 
     "@astrojs/react/vite/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
@@ -5717,7 +5720,7 @@
 
     "astro/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
 
-    "astro/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZntcpjFbiuW5/dOj7H4Yw=="],
+    "astro/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, ""],
 
     "astro/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
 
@@ -6157,7 +6160,7 @@
 
     "@astrojs/react/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
 
-    "@astrojs/react/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZntcpjFbiuW5/dOj7H4Yw=="],
+    "@astrojs/react/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, ""],
 
     "@astrojs/react/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
 
@@ -6381,7 +6384,7 @@
 
     "documents/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
 
-    "documents/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZntcpjFbiuW5/dOj7H4Yw=="],
+    "documents/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, ""],
 
     "documents/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -71,7 +71,7 @@ CLI > config > `--tsconfig-raw` > tsconfig file > defaults. 같은 옵션이 여
 | `metafile`                                   |            `--metafile`            |               ✅               |            ❌             | esbuild 호환                                                       |
 | `resolveExtensions`                          |      `--resolve-extensions=`       |               ✅               |          (간접)           | tsconfig 의 paths 와 별개                                          |
 | `mainFields`                                 |          `--main-fields=`          |               ✅               |            ❌             | package.json field 우선순위                                        |
-| `conditions`                                 |          `--conditions=`           |               ✅               |            ❌             | package exports 사용자 조건. monorepo internal src 직접 inline 은 §Monorepo (`source` condition) 참조 |
+| `conditions`                                 |          `--conditions=`           |               ✅               |            ❌             | package exports 사용자 조건. monorepo internal src 직접 inline 은 [Monorepo](#monorepo--source-exports-condition) 참조 |
 | `nodePaths`                                  |          `--node-paths=`           |               ✅               |            ❌             | bare specifier 추가 탐색 경로                                      |
 | `profile` / `profileLevel` / `profileFormat` |            `--profile*`            |               ✅               |            ❌             | 디버그/성능 측정                                                   |
 | `ignoreAnnotations`                          |       `--ignore-annotations`       |               ✅               |            ❌             | pure/sideEffects annotation 무시                                   |
@@ -326,6 +326,8 @@ consumer 의 빌드 명령에 `--conditions=source` 추가:
 → ZNTC 가 `import '@zntc/server'` 만나면 `./src/index.ts` 직접 따라가서 inline. server 의 dist 가 stale 이거나 없어도 무관.
 
 외부 npm 사용자에겐 `source` condition 이 켜지지 않으니 그대로 dist 사용 — monorepo 내부에서만 전환된다.
+
+> 최상위 `"source": "./src/index.ts"` 필드는 ZNTC bundler 가 직접 읽지 않는다 (`exports.source` 만 사용). parcel / microbundle 등 외부 도구 호환을 위해 함께 두는 관행.
 
 ### resolver 우선순위
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -71,7 +71,7 @@ CLI > config > `--tsconfig-raw` > tsconfig file > defaults. 같은 옵션이 여
 | `metafile`                                   |            `--metafile`            |               ✅               |            ❌             | esbuild 호환                                                       |
 | `resolveExtensions`                          |      `--resolve-extensions=`       |               ✅               |          (간접)           | tsconfig 의 paths 와 별개                                          |
 | `mainFields`                                 |          `--main-fields=`          |               ✅               |            ❌             | package.json field 우선순위                                        |
-| `conditions`                                 |          `--conditions=`           |               ✅               |            ❌             | package exports 사용자 조건                                        |
+| `conditions`                                 |          `--conditions=`           |               ✅               |            ❌             | package exports 사용자 조건. monorepo internal src 직접 inline 은 §Monorepo (`source` condition) 참조 |
 | `nodePaths`                                  |          `--node-paths=`           |               ✅               |            ❌             | bare specifier 추가 탐색 경로                                      |
 | `profile` / `profileLevel` / `profileFormat` |            `--profile*`            |               ✅               |            ❌             | 디버그/성능 측정                                                   |
 | `ignoreAnnotations`                          |       `--ignore-annotations`       |               ✅               |            ❌             | pure/sideEffects annotation 무시                                   |
@@ -290,6 +290,68 @@ Array 형태는 host runtime 의 RegExp 매칭에 위임하므로 sync 경로(`b
 | `fallback` | resolve **실패 시**| exact only   | ✅ — 실패 시에만  | ✅ (`=false`)             |
 
 자동 polyfill 한 줄 매핑 (`node-polyfill-webpack-plugin` 류) 은 ZNTC 가 제공하지 않는다 — esbuild 정책과 동일하게 사용자가 명시 매핑하거나 plugin 으로 처리.
+
+## Monorepo — `source` exports condition
+
+monorepo 안에서 internal package 끼리 import 할 때, 기본 동작은 **package.json `main` / `exports.import` 따라 dist 를 inline bundle**. 즉 의존 package 의 `dist/` 를 먼저 빌드해야 하고, dist 가 stale 이면 옛 코드가 박혀버린다 (build order + stale 위험).
+
+ZNTC 는 producer 의 src 를 직접 inline 하기 위해 **`source` exports condition** 을 지원한다 (parcel / microbundle / preconstruct 와 동일 패턴).
+
+### 설정
+
+producer package 가 자기 src 위치를 선언:
+
+```jsonc
+// packages/server/package.json
+{
+  "source": "./src/index.ts",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  }
+}
+```
+
+consumer 의 빌드 명령에 `--conditions=source` 추가:
+
+```jsonc
+// packages/web/package.json
+"build:bundle": "node ../core/bin/zntc.mjs --bundle src/index.ts --outfile dist/index.js --conditions=source --external @zntc/core ..."
+```
+
+→ ZNTC 가 `import '@zntc/server'` 만나면 `./src/index.ts` 직접 따라가서 inline. server 의 dist 가 stale 이거나 없어도 무관.
+
+외부 npm 사용자에겐 `source` condition 이 켜지지 않으니 그대로 dist 사용 — monorepo 내부에서만 전환된다.
+
+### resolver 우선순위
+
+```
+1. alias (--alias / build({ alias })) — 명시 override, 항상 우선
+2. tsconfig paths
+3. package.json exports (--conditions=source 면 source 먼저 매치)
+4. exports.import / main (default)
+```
+
+esbuild / Vite / Rollup 과 동일 순서. `alias` 는 fork / vendor escape hatch 로만 권장.
+
+### IDE / TS 체커는 여전히 dist 를 본다
+
+bundler 가 src 를 inline 해도 TS `tsc` 와 IDE 는 producer 의 `dist/*.d.ts` 를 따라간다. server src 만 고치고 dist rebuild 를 안 한 상태에서 web/RN 빌드는 새 코드를 inline 하지만, IDE/TS 체커는 옛 타입을 표시한다. 이를 해소하려면 TypeScript Project References (`composite: true` + `references`) 로 cross-package 타입 체크를 묶는 별도 작업이 필요하다 (이번 변경 scope 외).
+
+### 다른 번들러 비교
+
+| 번들러   | 방식                          | 빌드 순서 필요? | stale 위험      |
+| -------- | ----------------------------- | --------------- | --------------- |
+| esbuild  | dist (또는 monorepo 미사용)   | yes             | 있음            |
+| swc/oxc  | turbo + dist                  | yes             | turbo cache 완화|
+| Rollup   | `@rollup/plugin-alias` → src  | no              | 없음            |
+| Vite     | `resolve.alias` → src         | no              | 없음            |
+| Parcel   | `source` exports condition    | no              | 없음            |
+| **ZNTC** | `source` exports condition    | **no**          | **없음**        |
 
 ## 다른 번들러와의 차이
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,6 +6,7 @@
   "bin": {
     "zntc": "./bin/zntc.mjs"
   },
+  "source": "./index.ts",
   "files": [
     "dist/",
     "bin/",
@@ -16,6 +17,7 @@
   "types": "dist/core/index.d.ts",
   "exports": {
     ".": {
+      "source": "./index.ts",
       "import": "./dist/index.js",
       "types": "./dist/core/index.d.ts"
     }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,23 +1,12 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022"],
-    "types": ["node"],
-    "declaration": true,
     "declarationDir": "dist",
     "outDir": "dist",
-    "emitDeclarationOnly": true,
-    "allowImportingTsExtensions": true,
-    "rewriteRelativeImportExtensions": true,
     // index.ts 가 ../shared/index 를 import 하므로 source root 가 packages/ 까지
     // 확장된다. TS 6 의 TS5011 (inferred rootDir 거부) 회피 + 기존 emit layout
     // (`dist/core/index.d.ts` + `dist/shared/*.d.ts`, package.json `types` 와 일치) 보존.
-    "rootDir": "..",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true
+    "rootDir": ".."
   },
   "include": ["index.ts"]
 }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -19,7 +19,7 @@
     "./runtime/zntc-hmr-client.js": "./runtime/zntc-hmr-client.js"
   },
   "scripts": {
-    "build:bundle": "node ../core/bin/zntc.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --external @zntc/core --external @babel/core --external @react-native/babel-plugin-codegen --external @react-native/babel-preset --external metro-resolver --external react-native --external @react-native/js-polyfills",
+    "build:bundle": "node ../core/bin/zntc.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --conditions=source --external @zntc/core --external @babel/core --external @react-native/babel-plugin-codegen --external @react-native/babel-preset --external metro-resolver --external react-native --external @react-native/js-polyfills",
     "build:dts": "bun x tsc --emitDeclarationOnly",
     "build": "bun run build:bundle && bun run build:dts",
     "test": "bun test --timeout 10000"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "ZNTC internal server layer — HMR protocol, WS frame, watcher, TLS",
   "license": "MIT",
+  "source": "./src/index.ts",
   "files": [
     "dist/",
     "README.md"
@@ -13,12 +14,13 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }
   },
   "scripts": {
-    "build:bundle": "node ../core/bin/zntc.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --external @zntc/core",
+    "build:bundle": "node ../core/bin/zntc.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --conditions=source --external @zntc/core",
     "build:dts": "bun x tsc --emitDeclarationOnly",
     "build": "bun run build:bundle && bun run build:dts",
     "test": "bun test --timeout 10000"

--- a/packages/vite-plugin-zntc/package.json
+++ b/packages/vite-plugin-zntc/package.json
@@ -3,16 +3,31 @@
   "version": "0.1.0",
   "description": "Use ZNTC as the TypeScript/JSX transformer in Vite (replaces esbuild)",
   "license": "MIT",
+  "source": "./src/index.ts",
+  "files": [
+    "dist/",
+    "README.md"
+  ],
   "type": "module",
-  "main": "src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./src/index.ts",
-      "types": "./src/index.ts"
+      "source": "./src/index.ts",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
+  },
+  "scripts": {
+    "build:bundle": "node ../core/bin/zntc.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --conditions=source --external @zntc/core --external vite",
+    "build:dts": "bun x tsc --emitDeclarationOnly",
+    "build": "bun run build:bundle && bun run build:dts"
   },
   "dependencies": {
     "@zntc/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.2"
   },
   "peerDependencies": {
     "vite": ">=5.0.0"

--- a/packages/vite-plugin-zntc/src/index.ts
+++ b/packages/vite-plugin-zntc/src/index.ts
@@ -14,8 +14,8 @@
  */
 
 import type { Plugin } from 'vite';
-import { TsconfigCache, init, transpile } from '../../core/index';
-import type { TranspileOptions } from '../../core/index';
+import { TsconfigCache, init, transpile } from '@zntc/core';
+import type { TranspileOptions } from '@zntc/core';
 
 export interface ZntcPluginOptions {
   /**

--- a/packages/vite-plugin-zntc/tsconfig.json
+++ b/packages/vite-plugin-zntc/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../core/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declarationDir": "dist"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/vite-plugin-zntc/tsconfig.json
+++ b/packages/vite-plugin-zntc/tsconfig.json
@@ -5,5 +5,6 @@
     "outDir": "dist",
     "declarationDir": "dist"
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -17,7 +17,7 @@
     }
   },
   "scripts": {
-    "build:bundle": "node ../core/bin/zntc.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --external @zntc/core --external postcss --external postcss-load-config --external sass",
+    "build:bundle": "node ../core/bin/zntc.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --conditions=source --external @zntc/core --external postcss --external postcss-load-config --external sass",
     "build:dts": "bun x tsc --emitDeclarationOnly",
     "build": "bun run build:bundle && bun run build:dts",
     "test": "bun test --timeout 10000"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary

- monorepo 안에서 internal package 끼리 import 시, dist 대신 src 를 직접 inline bundle 하도록 **`source` exports condition** 도입 (parcel/microbundle 패턴). `--conditions=source` flag 한 개로 build order 의존 + dist stale 위험 제거
- **`vite-plugin-zntc` 를 publish-ready 로 정리**. 기존엔 `main: src/index.ts` 로 raw TypeScript 를 npm 에 publish 하려는 상태였고 (Node 22 미만에서 즉사), `files` 필드 부재로 publish tarball 도 비위생. dist 빌드 + `files` whitelist + `@zntc/core` workspace import 정상화
- **`tsconfig.base.json` 신설** + `packages/core/tsconfig.json` 이 extends. 공통 컴파일러 옵션 (target/strict/lib/skipLibCheck 등) 한 곳 모음. `paths` 는 rootDir / project references 작업과 함께 별도 PR

## 변경 파일

| 파일 | 변경 |
|---|---|
| `packages/{core,server,vite-plugin-zntc}/package.json` | `source` 필드 + `exports.source` condition |
| `packages/{web,react-native,server,vite-plugin-zntc}/package.json` | `build:bundle` 에 `--conditions=source` |
| `packages/vite-plugin-zntc/package.json` | publish-ready (`files`, `dist/*` paths, `build:bundle` + `build:dts`, `@types/node` devDep) |
| `packages/vite-plugin-zntc/src/index.ts` | `'../../core/index'` raw relative → `'@zntc/core'` workspace import |
| `packages/vite-plugin-zntc/tsconfig.json` (신설) | `extends "../core/tsconfig.json"` |
| `tsconfig.base.json` (신설) | 공통 컴파일러 옵션 |
| `packages/core/tsconfig.json` | base 를 extends, 자기 고유 옵션만 |
| `docs/CONFIG.md` | §Monorepo 섹션 신설 |

## 동작 검증

```
$ bun run --cwd packages/server build      # ✅
$ bun run --cwd packages/web build         # ✅
$ bun run --cwd packages/react-native build # ✅
$ bun run --cwd packages/vite-plugin-zntc build  # ✅
```

server 심볼이 web/RN dist 에 inline 되었는지 grep:
- `web/dist/index.js` → `HmrChannel|APP_DEV_HMR_CLIENT_PATH|HMR_RN_MSG` 6회
- `react-native/dist/index.js` → 11회
- 두 dist 모두 `import ... from '@zntc/server'` 0건 (외부 의존 아님)

## Test plan

- [x] `bun run --cwd packages/{server,web,react-native,vite-plugin-zntc} build` 모두 통과
- [x] web/RN dist 에 server 코드 inline 확인 (grep)
- [x] web/RN dist 에 `@zntc/server` import 0건 확인
- [x] vite-plugin-zntc type-check 통과 (`bun x tsc -p packages/vite-plugin-zntc/tsconfig.json --noEmit`)
- [x] `bun run fmt` 통과
- [ ] 통합 테스트: `bun run test:integration`
- [ ] (별도 follow-up) `paths` 추가 — TypeScript Project References (`composite: true` + `references`) 도입 시 함께

## 후속 작업 (이번 PR 의 scope 외)

- `paths` 도입: `rootDir` 재정리 + Project References — IDE / `tsc` 가 src 직접 보도록
- core/server 의 stale dist 사고 방지: CI 에 internal package 빌드 스크립트가 `--conditions=source` 포함하는지 확인하는 lint 한 줄
- `packages/{web,react-native}` 의 `@zntc/server` dependencies → devDependencies 로 이동 (private package 가 published deps 에 박혀있는 문제 — npm install 시 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)