### PR TITLE
fix(monorepo): move @zntc/server to devDependencies in web/RN

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -206,12 +206,12 @@
       "dependencies": {
         "@react-native-community/cli-server-api": "^15.0.0",
         "@zntc/core": "workspace:*",
-        "@zntc/server": "workspace:*",
         "jsc-safe-url": "^0.2.4",
         "source-map": "^0.7.4",
       },
       "devDependencies": {
         "@types/node": "^25.5.2",
+        "@zntc/server": "workspace:*",
       },
       "optionalDependencies": {
         "@babel/core": "^7.26.0",
@@ -254,10 +254,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@zntc/core": "workspace:*",
-        "@zntc/server": "workspace:*",
       },
       "devDependencies": {
         "@types/node": "^25.5.2",
+        "@zntc/server": "workspace:*",
       },
       "optionalDependencies": {
         "postcss": "^8.5.8",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -27,12 +27,12 @@
   "dependencies": {
     "@react-native-community/cli-server-api": "^15.0.0",
     "@zntc/core": "workspace:*",
-    "@zntc/server": "workspace:*",
     "jsc-safe-url": "^0.2.4",
     "source-map": "^0.7.4"
   },
   "devDependencies": {
-    "@types/node": "^25.5.2"
+    "@types/node": "^25.5.2",
+    "@zntc/server": "workspace:*"
   },
   "optionalDependencies": {
     "@babel/core": "^7.26.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -23,11 +23,11 @@
     "test": "bun test --timeout 10000"
   },
   "dependencies": {
-    "@zntc/core": "workspace:*",
-    "@zntc/server": "workspace:*"
+    "@zntc/core": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "^25.5.2"
+    "@types/node": "^25.5.2",
+    "@zntc/server": "workspace:*"
   },
   "optionalDependencies": {
     "postcss": "^8.5.8",


### PR DESCRIPTION
## Summary

- `@zntc/server` 는 `private: true` 패키지이며 npm registry 에 publish 되지 않는다. 그런데 `@zntc/web` / `@zntc/react-native` 의 `dependencies` 에 `workspace:*` 로 박혀있어, publish 후 사용자가 `npm i @zntc/web` 시 npm 이 `@zntc/server@0.1.0` 을 fetch 하려다 **404 NOT FOUND** 로 install 실패
- PR #2791 에서 `--conditions=source` 도입으로 server 의 src 가 web/RN dist 에 자동 inline 되므로 runtime 에 server 패키지가 필요 없음 → `dependencies` 에서 제거 가능. 빌드/타입 의존만 남기기 위해 `devDependencies` 로 이동

## 변경 파일

| 파일 | 변경 |
|---|---|
| `packages/web/package.json` | `dependencies."@zntc/server"` → `devDependencies."@zntc/server"` |
| `packages/react-native/package.json` | 동일 |
| `bun.lock` | bun install 에 따른 자동 업데이트 |

## Test plan

- [x] `bun install` 통과 (workspace 안 동작 변화 없음)
- [x] `bun run --cwd packages/web build` 통과 (server src 가 여전히 inline)
- [x] `bun run --cwd packages/react-native build` 통과
- [x] `bun pm pack` 으로 publish tarball 생성 → 추출한 `package.json` 검증:
  - web: `dependencies = { "@zntc/core": "0.1.0" }` (server 빠짐), `devDependencies."@zntc/server": "0.1.0"`
  - RN: `dependencies = @zntc/core + RN/source-map deps` (server 빠짐), `devDependencies."@zntc/server": "0.1.0"`
- [ ] 통합 테스트: `bun run test:integration`

## 후속 작업 (별도 PR)

- `@zntc/wasm` 의 dts emit 누락 — types 가 dist/index.d.ts 를 가리키지만 build script 가 dts 를 emit 안 함
- CI lint: internal package 빌드 스크립트가 `--conditions=source` 포함하는지 검증
- TS Project References (paths 도입) — IDE / tsc 가 src 직접 보도록

🤖 Generated with [Claude Code](https://claude.com/claude-code)