### PR TITLE
fix(transformer): preserve block-scoped for-of captures

### DIFF
--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2078,10 +2078,10 @@ pub const Transformer = struct {
 
             if (lexical_names.items.len > 0) {
                 const orig_body_idx = node.data.ternary.c;
+                // 원본 AST 에서 capture 검사 — visitNode 가 closure 경계를 변환하기 전 시점.
                 const has_capture = BlockScoping.hasCapturedClosure(self, orig_body_idx, lexical_names.items);
 
                 var flow = BlockScoping.FlowResult{};
-                flow.labels = .empty;
                 defer flow.labels.deinit(self.allocator);
                 if (has_capture) {
                     BlockScoping.analyzeControlFlow(self, orig_body_idx, &flow, 0, 0);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2071,6 +2071,59 @@ pub const Transformer = struct {
     /// `a`(left) 방문 시 in_for_in_of_header 플래그를 켜서, block_scoping 다운레벨로
     /// let/const → var 변환 시 불필요한 `= void 0` init 주입을 막는다 (#1386).
     fn visitForInOfTernary(self: *Transformer, node: Node) Error!NodeIndex {
+        if (self.options.unsupported.block_scoping) {
+            const BlockScoping = es2015_block_scoping.ES2015BlockScoping(Transformer);
+            var lexical_names = try BlockScoping.collectLexicalVarNames(self, node.data.ternary.a);
+            defer lexical_names.deinit(self.allocator);
+
+            if (lexical_names.items.len > 0) {
+                const orig_body_idx = node.data.ternary.c;
+                const has_capture = BlockScoping.hasCapturedClosure(self, orig_body_idx, lexical_names.items);
+
+                var flow = BlockScoping.FlowResult{};
+                flow.labels = .empty;
+                defer flow.labels.deinit(self.allocator);
+                if (has_capture) {
+                    BlockScoping.analyzeControlFlow(self, orig_body_idx, &flow, 0, 0);
+                }
+
+                const saved = self.in_for_in_of_header;
+                self.in_for_in_of_header = true;
+                const new_a = try self.visitNode(node.data.ternary.a);
+                self.in_for_in_of_header = saved;
+                const new_b = try self.visitNode(node.data.ternary.b);
+                const new_c = try self.visitNode(orig_body_idx);
+
+                if (has_capture) {
+                    const result = try BlockScoping.buildLoopClosureWithFlow(
+                        self,
+                        new_c,
+                        lexical_names.items,
+                        &flow,
+                        null,
+                        node.span,
+                    );
+                    const loop_node = try self.ast.addNode(.{
+                        .tag = node.tag,
+                        .span = node.span,
+                        .data = .{ .ternary = .{ .a = new_a, .b = new_b, .c = result.call_and_check } },
+                    });
+                    const stmts = try self.ast.addNodeList(&.{ result.loop_fn, loop_node });
+                    return self.ast.addNode(.{
+                        .tag = .block_statement,
+                        .span = node.span,
+                        .data = .{ .list = stmts },
+                    });
+                }
+
+                return self.ast.addNode(.{
+                    .tag = node.tag,
+                    .span = node.span,
+                    .data = .{ .ternary = .{ .a = new_a, .b = new_b, .c = new_c } },
+                });
+            }
+        }
+
         const saved = self.in_for_in_of_header;
         self.in_for_in_of_header = true;
         const new_a = try self.visitNode(node.data.ternary.a);

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1345,6 +1345,48 @@ test "#1797 negative: for-of down-level 꺼져있으면 변환 자체 비활성"
     try std.testing.expect(std.mem.indexOf(u8, code, "for (let k of") != null);
 }
 
+test "#1797 native for-of + block scoping: let 캡처 시 _loop 함수로 추출" {
+    // RN preset은 for-of 문법은 유지하지만 block_scoping으로 let/const를 var로 낮춘다.
+    // 이때 getter/closure가 loop binding을 캡처하면 native for-of 경로에서도 fresh binding
+    // 의미를 보존해야 한다.
+    const source =
+        \\for (let key of keys) {
+        \\  arr.push(() => from[key]);
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = false, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "for (var key of") != null);
+    const push_pos = std.mem.indexOf(u8, code, "arr.push") orelse unreachable;
+    const loop_pos = std.mem.indexOf(u8, code, "_loop") orelse unreachable;
+    try std.testing.expect(push_pos > loop_pos);
+}
+
+test "#1797 native for-of + block scoping: closure 없으면 _loop 변환 안 함" {
+    const source =
+        \\for (let key of keys) {
+        \\  total += key;
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = false, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") == null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "for (var key of") != null);
+}
+
 test "#1797 bungae __copyProps pattern: getter 가 iteration-local key 캡처" {
     // @radix-ui/react-slot 이 esbuild 로 빌드한 `__copyProps` 의 정확한 패턴.
     // RN Hermes 에서 `React$250 = '19.2.0'` crash 를 재현한 입력.

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1387,6 +1387,175 @@ test "#1797 native for-of + block scoping: closure 없으면 _loop 변환 안 �
     try std.testing.expect(std.mem.indexOf(u8, code, "for (var key of") != null);
 }
 
+test "#1797 native for-of + block scoping: const 도 capture 시 _loop 변환" {
+    const source =
+        \\for (const key of keys) {
+        \\  arr.push(() => from[key]);
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = false, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "for (var key of") != null);
+}
+
+test "#1797 native for-in + block scoping: let capture → _loop 변환" {
+    const source =
+        \\for (let key in obj) {
+        \\  arr.push(() => obj[key]);
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = false, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "for (var key in") != null);
+}
+
+test "#1797 native for-of + block scoping: object destructuring 모든 binding 이 params" {
+    const source =
+        \\for (let { a, b } of pairs) {
+        \\  arr.push(() => a + b);
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = false, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    // 두 binding 모두 _loop param 으로 전달돼야 함
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop(a, b)") != null);
+}
+
+test "#1797 native for-of + block scoping: nested loops — 외부/내부 모두 wrap" {
+    const source =
+        \\for (let x of xs) {
+        \\  for (let y of ys) {
+        \\    handlers.push(() => x + y);
+        \\  }
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = false, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // 내부 루프는 y 만 capture (x 는 외부 scope, 내부 _loop 안 들어가도 외부 _loop 으로 fresh)
+    // 외부 루프는 x 를 transitive 하게 capture (내부 closure 가 x 사용)
+    var count: usize = 0;
+    var pos: usize = 0;
+    while (std.mem.indexOfPos(u8, code, pos, "_loop")) |found| {
+        count += 1;
+        pos = found + 5;
+    }
+    try std.testing.expect(count >= 2); // 외부 _loop fn + 내부 _loop fn 최소 2회 등장
+    try std.testing.expect(std.mem.indexOf(u8, code, "for (var x of") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "for (var y of") != null);
+}
+
+test "#1797 native for-of + block scoping: continue → return; 으로 변환" {
+    const source =
+        \\for (let key of keys) {
+        \\  if (skip(key)) continue;
+        \\  arr.push(() => from[key]);
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = false, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    // continue 가 return; 으로 변환되어야 — 안 그러면 SyntaxError ("Illegal continue: no surrounding iteration")
+    try std.testing.expect(std.mem.indexOf(u8, code, "continue;") == null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "return;") != null);
+}
+
+test "#1797 native for-of + block scoping: break → outer 종료 ret 체인" {
+    const source =
+        \\for (let key of keys) {
+        \\  if (done(key)) break;
+        \\  arr.push(() => from[key]);
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = false, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    // break 검사용 _ret 변수가 호출부에 있어야 함
+    try std.testing.expect(std.mem.indexOf(u8, code, "_ret") != null);
+}
+
+test "#1797 native for-of + block scoping: return value 보존" {
+    const source =
+        \\function findValue(keys) {
+        \\  for (let key of keys) {
+        \\    if (matches(key)) return () => from[key];
+        \\  }
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = false, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    // return value 캡처용 { v: ... } 객체가 있어야 함
+    try std.testing.expect(std.mem.indexOf(u8, code, "v:") != null);
+}
+
+test "#1797 native for-of + block scoping: labeled break OUTER" {
+    const source =
+        \\OUTER: for (let key of keys) {
+        \\  for (let v of values) {
+        \\    if (skip(v)) break OUTER;
+        \\    arr.push(() => from[key]);
+        \\  }
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = false, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    // labeled break 가 처리되면 _ret 체인 + label 보존
+    try std.testing.expect(std.mem.indexOf(u8, code, "_ret") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "OUTER") != null);
+}
+
 test "#1797 bungae __copyProps pattern: getter 가 iteration-local key 캡처" {
     // @radix-ui/react-slot 이 esbuild 로 빌드한 `__copyProps` 의 정확한 패턴.
     // RN Hermes 에서 `React$250 = '19.2.0'` crash 를 재현한 입력.


### PR DESCRIPTION
## 작업 내용
- `block_scoping` 다운레벨이 켜진 상태에서 native `for-in` / `for-of` / `for-await-of` 루프의 `let`/`const` 바인딩을 closure가 캡처하면 `_loop(...)` 함수로 감싸 반복별 바인딩 의미를 보존하도록 수정했습니다.
- native `for-of + block_scoping` 조합에서 closure capture가 있는 경우와 없는 경우를 각각 회귀 테스트로 추가했습니다.

## 배경
RN 프리셋은 Hermes 호환을 위해 `let`/`const`를 `var`로 낮춥니다. 그런데 `for (let key of keys)`의 `key`는 반복마다 새 바인딩이어야 합니다. 이를 단순히 `for (var key of keys)`로 바꾸면 루프 안의 getter나 callback이 모두 같은 `key`를 공유해서 마지막 값만 보게 됩니다.

이번 문제에서는 이 때문에 `@radix-ui/react-slot`의 helper getter가 `React.forwardRef` 대신 마지막 export인 `React.version` 값을 읽게 되었고, Expo Router 초기화 전에 `React.forwardRef is not a function (it is '19.2.0')` 예외가 발생했습니다.

## Zig 초보자용 설명
`visitForInOfTernary`는 `for-in` / `for-of` / `for-await-of`처럼 `a, b, c` 세 자식으로 구성된 루프 노드를 방문하는 경로입니다. 이번 변경은 왼쪽 선언부에서 lexical 바인딩 이름을 모으고, 본문 내부 함수가 그 이름을 캡처하는 경우에만 기존 `ES2015BlockScoping.buildLoopClosureWithFlow` 헬퍼를 재사용합니다. 그래서 필요할 때만 `_loop(key)` 형태를 만들고, 캡처가 없는 루프는 기존 출력 경로를 유지합니다.

## 테스트
- `zig build test`