### PR TITLE
fix(wasm): emit dts + extend tsconfig.base + fix latent type errors

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -248,6 +248,9 @@
     "packages/wasm": {
       "name": "@zntc/wasm",
       "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^25.5.2",
+      },
     },
     "packages/web": {
       "name": "@zntc/web",

--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -11,7 +11,7 @@
  */
 
 export type { Target, Platform, TranspileOptions, TranspileResult } from '../shared/index';
-import type { TranspileOptions, TranspileResult } from '../shared/index';
+import type { Target, TranspileOptions, TranspileResult } from '../shared/index';
 import { buildOptionsJson, targetToUnsupported } from '../shared/index';
 
 // ─── WASM Instance ───
@@ -218,7 +218,7 @@ export function initSync(input: WebAssembly.Module | BufferSource): void {
     input instanceof WebAssembly.Module
       ? input
       : new WebAssembly.Module(
-          input instanceof ArrayBuffer ? input : (input as ArrayBufferView).buffer,
+          input instanceof ArrayBuffer ? input : ((input as ArrayBufferView).buffer as ArrayBuffer),
         );
 
   const instance = new WebAssembly.Instance(mod, imports);

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -10,11 +10,11 @@
   ],
   "type": "module",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/wasm/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/wasm/index.d.ts"
     },
     "./zntc.wasm": "./zntc.wasm",
     "./zntc-bundler.wasm": "./zntc-bundler.wasm"
@@ -22,7 +22,11 @@
   "scripts": {
     "build:wasm": "cd ../.. && zig build wasm && zig build wasm-bundler",
     "build:js": "bun build index.ts --outdir dist --format esm --target browser",
-    "build": "bun run build:wasm && cp ../../zig-out/bin/zntc.wasm . && cp ../../zig-out/bin/zntc-bundler.wasm . && bun run build:js",
+    "build:dts": "bun x tsc --emitDeclarationOnly",
+    "build": "bun run build:wasm && cp ../../zig-out/bin/zntc.wasm . && cp ../../zig-out/bin/zntc-bundler.wasm . && bun run build:js && bun run build:dts",
     "test": "bun test --timeout 10000"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.2"
   }
 }

--- a/packages/wasm/tsconfig.json
+++ b/packages/wasm/tsconfig.json
@@ -1,14 +1,12 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "declaration": true,
+    "lib": ["ES2022", "WebWorker"],
     "declarationDir": "dist",
     "outDir": "dist",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true
+    // index.ts 가 ../shared/index 를 import 하므로 source root 가 packages/ 까지
+    // 확장된다. emit layout 은 dist/wasm/index.d.ts + dist/shared/*.d.ts.
+    "rootDir": ".."
   },
   "include": ["index.ts"]
 }


### PR DESCRIPTION
## Summary

- `@zntc/wasm` 의 build script 가 dts 를 emit 안 해서 publish 시 사용자가 type 파일 (`package.json` `types: dist/index.d.ts`) 을 받지 못하는 상태였음. PR #2791 에 명시한 follow-up 항목
- dts script 추가하면서 그동안 노출 안 됐던 latent type errors 3건도 함께 수정
- `tsconfig.base.json` extends 로 옵션 중복 제거 (22 줄 → 11 줄)

## 변경 파일

| 파일 | 변경 |
|---|---|
| `packages/wasm/package.json` | `build:dts` script + build chain. `types` 경로 `dist/wasm/index.d.ts` (rootDir=\"..\" emit layout, core 와 동일). `@types/node` devDep |
| `packages/wasm/tsconfig.json` | `tsconfig.base.json` extends. wasm 고유 옵션만 남김 (`lib: [\"ES2022\", \"WebWorker\"]`, `rootDir: \"..\"`, `outDir`/`declarationDir`) |
| `packages/wasm/index.ts` | `Target` type-import 추가 (line 479 사용처). `ArrayBufferView.buffer` 를 `ArrayBuffer` 로 cast (TS 5.7+ stricter `ArrayBufferLike` typing 우회) |

### tsconfig 결정 노트

- `lib: WebWorker` vs `DOM`: `fetch` / `Request` / `Response` / `URL` / `TextEncoder` / `TextDecoder` / `WebAssembly` 모두 양쪽 lib 에 있음. WebWorker 가 isomorphic 에 더 정확 — `window` / `document` 같은 browser-only 글로벌을 ambient 로 안 끌어옴
- `types: [\"node\"]` 는 base 에서 상속. `resolveWasmSource` 의 dynamic `import('fs'/'path'/'url')` 때문에 필요

## Test plan

- [x] `bun run --cwd packages/wasm build:js && build:dts` 통과 (type errors 0)
- [x] dist 구조 확인:
  - `dist/index.js` (bun build, browser target)
  - `dist/wasm/index.d.ts` (tsc dts)
  - `dist/shared/compat-engines.d.ts`, `dist/shared/index.d.ts` (transitive shared)
- [x] `bun pm pack` tarball 안 dts 파일 포함 확인
- [x] `bun run fmt:check` + `bun run lint` 통과
- [ ] 통합 테스트

## 후속 작업

- PR #2791 follow-up 잔여:
  - CI lint: internal package 빌드 스크립트가 `--conditions=source` 포함 검증 / publish smoke test
  - TS Project References (paths 도입) — IDE / tsc 가 src 직접 보도록
- 별도 nice-to-have:
  - wasm `ArrayBuffer` cast 를 type guard + SharedArrayBuffer 거부 throw 로 정확화
  - wasm `build` chain 의 `build:js` + `build:dts` parallel 화

🤖 Generated with [Claude Code](https://claude.com/claude-code)