### PR TITLE
fix(transformer): propagate async marker to _loop closure (capture + body await)

### DIFF
--- a/src/transformer/es2015_block_scoping.zig
+++ b/src/transformer/es2015_block_scoping.zig
@@ -42,6 +42,15 @@ pub inline fn lowerKind(_: VariableDeclarationKind) VariableDeclarationKind {
     return .@"var";
 }
 
+/// closure 경계 — 안의 capture / await / yield 등은 우리 책임이 아니라 해당 함수 책임.
+/// hasCapturedClosure / hasAwaitExpression 양쪽이 동일 set 사용 → 단일 정의로 drift 차단.
+inline fn isFunctionBoundary(tag: Tag) bool {
+    return tag == .function_expression or
+        tag == .function_declaration or
+        tag == .arrow_function_expression or
+        tag == .function;
+}
+
 pub fn ES2015BlockScoping(comptime Transformer: type) type {
     return struct {
         const Self = @This();
@@ -117,10 +126,7 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
                 const node = self.ast.getNode(entry.idx);
 
                 // 클로저 경계: fn_depth 증가
-                const fn_depth = if (node.tag == .function_expression or
-                    node.tag == .function_declaration or
-                    node.tag == .arrow_function_expression or
-                    node.tag == .function)
+                const fn_depth = if (isFunctionBoundary(node.tag))
                     entry.fn_depth + 1
                 else
                     entry.fn_depth;
@@ -139,6 +145,41 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
                 collectChildIndices(self, node, &children) catch return true;
                 for (children.items) |child_idx| {
                     stack.append(self.allocator, .{ .idx = child_idx, .fn_depth = fn_depth }) catch return true;
+                }
+            }
+            return false;
+        }
+
+        /// loop body 직속 (closure 경계 안 넘는) `await` expression 이 있는지 검사.
+        /// 있으면 합성된 `_loop` 함수도 async 로 emit + 호출부 `await _loop(x)` wrap
+        /// 필요 — `_loop` 가 새 function scope 라 enclosing async-ness 가 끊기기 때문.
+        ///
+        /// 명시적 스택 사용 — stack overflow 불가능. closure (function/arrow) 안의
+        /// `await` 는 그 closure 의 async-ness 가 결정하므로 무시한다.
+        pub fn hasAwaitExpression(self: *Transformer, body_idx: NodeIndex) bool {
+            if (body_idx.isNone()) return false;
+            const max_node = self.parser_node_count;
+
+            const ScanEntry = struct { idx: NodeIndex, in_closure: bool };
+            var stack: std.ArrayList(ScanEntry) = .empty;
+            defer stack.deinit(self.allocator);
+            stack.append(self.allocator, .{ .idx = body_idx, .in_closure = false }) catch return false;
+
+            while (stack.items.len > 0) {
+                const entry = stack.pop() orelse break;
+                if (entry.idx.isNone()) continue;
+                if (@intFromEnum(entry.idx) >= max_node) continue;
+                const node = self.ast.getNode(entry.idx);
+
+                const in_closure = entry.in_closure or isFunctionBoundary(node.tag);
+
+                if (!in_closure and node.tag == .await_expression) return true;
+
+                var children: std.ArrayList(NodeIndex) = .empty;
+                defer children.deinit(self.allocator);
+                collectChildIndices(self, node, &children) catch return true;
+                for (children.items) |child_idx| {
+                    stack.append(self.allocator, .{ .idx = child_idx, .in_closure = in_closure }) catch return true;
                 }
             }
             return false;
@@ -196,6 +237,7 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
             flow: *const FlowResult,
             local_label: ?[]const u8,
             span: Span,
+            is_async: bool,
         ) Transformer.Error!struct { loop_fn: NodeIndex, call_and_check: NodeIndex } {
             // --- _loop 함수명 생성 ---
             const loop_prefix = "_loop";
@@ -249,9 +291,10 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
 
             const none = @intFromEnum(NodeIndex.none);
             const params_node = try self.ast.addFormalParameters(params, span);
+            const func_flags: u32 = if (is_async) ast_mod.FunctionFlags.is_async else 0;
             const func_extra = try self.ast.addExtras(&.{
                 none,                           @intFromEnum(params_node),
-                @intFromEnum(transformed_body), 0,
+                @intFromEnum(transformed_body), func_flags,
                 none,
             });
             const func_expr = try self.ast.addNode(.{
@@ -283,15 +326,22 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
                 .data = .{ .extra = call_extra },
             });
 
-            // --- 제어 흐름 후처리: var _ret = _loop(i); if (...) ... ---
+            // is_async — `_loop(...)` 가 Promise 반환. 호출부도 `await _loop(...)` 로
+            // wrap 해야 iteration 순서 보존 + needsRetVar 시 _ret 가 resolved value.
+            const call_expr: NodeIndex = if (is_async)
+                try es_helpers.makeAwaitExpression(self, loop_call, span)
+            else
+                loop_call;
+
+            // --- 제어 흐름 후처리: var _ret = await _loop(i); if (...) ... ---
             var final_stmt: NodeIndex = undefined;
             if (needs_ret_var) {
-                final_stmt = try buildControlFlowCheck(self, loop_call, flow, local_label, span);
+                final_stmt = try buildControlFlowCheck(self, call_expr, flow, local_label, span);
             } else {
                 final_stmt = try self.ast.addNode(.{
                     .tag = .expression_statement,
                     .span = span,
-                    .data = .{ .unary = .{ .operand = loop_call, .flags = 0 } },
+                    .data = .{ .unary = .{ .operand = call_expr, .flags = 0 } },
                 });
             }
 

--- a/src/transformer/es2015_for_of.zig
+++ b/src/transformer/es2015_for_of.zig
@@ -185,8 +185,8 @@ pub fn ES2015ForOf(comptime Transformer: type) type {
                 defer lexical_names.deinit(self.allocator);
 
                 if (lexical_names.items.len > 0 and BlockScoping.hasCapturedClosure(self, body, lexical_names.items)) {
+                    const is_async = BlockScoping.hasAwaitExpression(self, body);
                     var flow = BlockScoping.FlowResult{};
-                    flow.labels = .empty;
                     defer flow.labels.deinit(self.allocator);
                     BlockScoping.analyzeControlFlow(self, body, &flow, 0, 0);
                     const local_label = if (label_name_idx.isNone())
@@ -201,6 +201,7 @@ pub fn ES2015ForOf(comptime Transformer: type) type {
                         &flow,
                         local_label,
                         span,
+                        is_async,
                     );
                     loop_fn_decl = result.loop_fn;
                     body_after_closure = result.call_and_check;

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -2080,6 +2080,10 @@ pub const Transformer = struct {
                 const orig_body_idx = node.data.ternary.c;
                 // 원본 AST 에서 capture 검사 — visitNode 가 closure 경계를 변환하기 전 시점.
                 const has_capture = BlockScoping.hasCapturedClosure(self, orig_body_idx, lexical_names.items);
+                // body 에 await 가 있으면 _loop 도 async 여야 (호출부도 await wrap).
+                // for-await-of 자체는 enclosing async function 보장이지만 body 에 await
+                // 가 없으면 sync _loop 으로 충분.
+                const is_async = if (has_capture) BlockScoping.hasAwaitExpression(self, orig_body_idx) else false;
 
                 var flow = BlockScoping.FlowResult{};
                 defer flow.labels.deinit(self.allocator);
@@ -2102,6 +2106,7 @@ pub const Transformer = struct {
                         &flow,
                         null,
                         node.span,
+                        is_async,
                     );
                     const loop_node = try self.ast.addNode(.{
                         .tag = node.tag,
@@ -3912,10 +3917,10 @@ pub const Transformer = struct {
                 // 원본 body에서 캡처/제어흐름 분석 (new AST에서는 extra 레이아웃이 변경됨)
                 const orig_body_idx = self.readNodeIdx(e, 3);
                 const has_capture = BlockScoping.hasCapturedClosure(self, orig_body_idx, lexical_names.items);
+                const is_async = if (has_capture) BlockScoping.hasAwaitExpression(self, orig_body_idx) else false;
 
                 // 제어 흐름 분석도 원본에서 수행
                 var flow = BlockScoping.FlowResult{};
-                flow.labels = .empty;
                 defer flow.labels.deinit(self.allocator);
                 if (has_capture) {
                     BlockScoping.analyzeControlFlow(self, orig_body_idx, &flow, 0, 0);
@@ -3934,6 +3939,7 @@ pub const Transformer = struct {
                         &flow,
                         null,
                         node.span,
+                        is_async,
                     );
 
                     // var _loop = function(...) { ... };

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1556,6 +1556,141 @@ test "#1797 native for-of + block scoping: labeled break OUTER" {
     try std.testing.expect(std.mem.indexOf(u8, code, "OUTER") != null);
 }
 
+// ─── async marker propagation: body 에 await 가 있으면 _loop 도 async + 호출부 await wrap ───
+
+test "#1797 native for-of + block scoping: body await + capture → async _loop + await call" {
+    const source =
+        \\async function f(items) {
+        \\  for (let key of items) {
+        \\    handlers.push(() => from[key]);
+        \\    await use(key);
+        \\  }
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = false, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    // _loop 가 async 로 emit
+    try std.testing.expect(std.mem.indexOf(u8, code, "async function") != null);
+    // 호출부도 await 로 wrap — 안 하면 iteration 순서 깨지고, needsRetVar 시 Promise 객체 검사
+    try std.testing.expect(std.mem.indexOf(u8, code, "await _loop") != null);
+}
+
+test "#1797 native for-of + block scoping: body 에 await 없으면 sync _loop" {
+    const source =
+        \\async function f(items) {
+        \\  for (let key of items) {
+        \\    handlers.push(() => from[key]);
+        \\  }
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = false, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "await _loop") == null);
+}
+
+test "#1797 native for-of + block scoping: closure 안 await 는 무시 (그 closure 책임)" {
+    const source =
+        \\async function f(items) {
+        \\  for (let key of items) {
+        \\    handlers.push(async () => await use(key));
+        \\  }
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = false, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    // body 의 직접 await 가 아닌 inner closure 의 await — _loop 는 sync 여야 함
+    try std.testing.expect(std.mem.indexOf(u8, code, "await _loop") == null);
+}
+
+test "#1797 native for-await-of + block scoping: capture + body await → async _loop" {
+    const source =
+        \\async function f(stream) {
+        \\  for await (let chunk of stream) {
+        \\    parts.push(() => chunk);
+        \\    await consume(chunk);
+        \\  }
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = false, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "async function") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "await _loop") != null);
+    // for-await-of 는 그대로 보존
+    try std.testing.expect(std.mem.indexOf(u8, code, "for await (var chunk of") != null);
+}
+
+test "#1797 classic for-loop + block scoping: body await + capture → async _loop" {
+    const source =
+        \\async function f(n) {
+        \\  for (let i = 0; i < n; i++) {
+        \\    fns.push(() => i);
+        \\    await tick(i);
+        \\  }
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "async function") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "await _loop") != null);
+}
+
+test "#1797 ES5 down-level for-of + block scoping: body await → async _loop" {
+    const source =
+        \\async function f(items) {
+        \\  for (let key of items) {
+        \\    handlers.push(() => from[key]);
+        \\    await use(key);
+        \\  }
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = true, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "async function") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "await _loop") != null);
+}
+
 test "#1797 bungae __copyProps pattern: getter 가 iteration-local key 캡처" {
     // @radix-ui/react-slot 이 esbuild 로 빌드한 `__copyProps` 의 정확한 패턴.
     // RN Hermes 에서 `React$250 = '19.2.0'` crash 를 재현한 입력.


### PR DESCRIPTION
## Summary

PR #2793 의 follow-up. body 에 **closure capture + await** 가 함께 있을 때, 기존 코드가 합성한 `_loop` 함수가 일반 (sync) function 으로 emit 되어 enclosing async-ness 가 끊기는 문제.

```js
// 입력
async function f(items) {
  for (let key of items) {
    handlers.push(() => from[key]);   // capture → _loop wrap
    await use(key);                    // ← _loop 안으로 들어가면 SyntaxError
  }
}

// PR 전 (broken)
async function f(items) {
  var _loop = function (key) {            // ← sync function
    handlers.push(function () { return from[key]; });
    await use(key);                        // SyntaxError
  };
  for (var key of items) { _loop(key); }
}

// PR 후
async function f(items) {
  var _loop = async function (key) {       // ← async marker 전파
    handlers.push(function () { return from[key]; });
    await use(key);
  };
  for (var key of items) { await _loop(key); }   // ← 호출부도 await wrap
}
```

## 변경 파일

| 파일 | 변경 |
|---|---|
| `src/transformer/es2015_block_scoping.zig` | `hasAwaitExpression(body_idx)` 추가 (`hasCapturedClosure` 와 동일 명시 stack 패턴, closure 경계 가드). `buildLoopClosureWithFlow` 에 `is_async: bool` 인자 → `FunctionFlags.is_async` 비트 set + 호출부 `await_expression` wrap (`es_helpers.makeAwaitExpression` 재사용). closure-boundary tag set 을 `inline fn isFunctionBoundary` 로 통합 (drift 차단) |
| `src/transformer/transformer.zig` | `visitForInOfTernary` (native for-in/of/await-of) + `visitForStatement` (classic for) 두 곳에서 `hasAwaitExpression` 호출 + `is_async` 인자 전달 |
| `src/transformer/es2015_for_of.zig` | ES5 down-level for-of path 동일 처리 |

부수: `flow.labels = .empty;` redundant 제거 (default 와 동일).

## 회귀 테스트 (6건)

| 케이스 | expectation |
|---|---|
| native for-of + body await + capture | `async function` + `await _loop` |
| body await 없음 | sync `_loop`, no `await _loop` |
| inner closure 의 await | sync `_loop` (해당 closure 책임) |
| for-await-of + body await + capture | async + `for await (var ...)` 보존 |
| classic for-loop + body await + capture | async + `await _loop` |
| ES5 down-level for-of (`for_of: true`) + body await | async + `await _loop` |

## Test plan

- [x] `zig build test` → EXIT=0
- [x] `zig build test -Doptimize=ReleaseFast` → EXIT=0 (debug-only 회귀 회피)
- [x] `bun run fmt:check` clean
- [ ] 통합 테스트

## 후속 작업

- 동일 패턴 (`hasCapturedClosure` / `hasAwaitExpression` iterative DFS) 을 generic `forEachInsideClosureBoundary(self, body, ctx, visit_fn)` 로 묶기 — closure-boundary set 은 이미 `isFunctionBoundary` 로 단일화. drift 위험 적음
- `es2015_generator.zig:1431` 의 `containsYield` 가 recursive 패턴 — deep AST 시 stack overflow. 같은 명시 stack 패턴으로 마이그레이션 권장 (별도 PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)