### PR TITLE
ci: publish smoke test — tarball / deps / files / paths 검증

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,6 +273,61 @@ jobs:
           }
           EOF
 
+  publish-smoke:
+    name: Publish Smoke Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache Bun packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock', 'tests/benchmark/bun.lock', 'tests/integration/fixtures/emotion-v10/bun.lock', 'package.json', 'tests/integration/package.json', 'tests/benchmark/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install
+
+      # publish-smoke 의 검증 대상은 tarball 의 layout / exports / files / deps —
+      # NAPI binary (.node) 와 wasm 바이너리 자체 동작은 별도 job 책임. JS dist 만
+      # 있으면 검증 충분 (smoke test 는 파일 존재 + package.json 만 본다).
+      - name: Build NAPI module + wasm (binary 산출 — JS wrapper 가 require)
+        run: zig build napi && zig build wasm && zig build wasm-bundler
+
+      - name: Build all publishable packages
+        run: |
+          cp zig-out/lib/zntc.node packages/core/zntc.node
+          bun run --cwd packages/core build:js
+          bun run --cwd packages/core build:dts
+          cp zig-out/bin/zntc.wasm packages/wasm/
+          cp zig-out/bin/zntc-bundler.wasm packages/wasm/
+          bun run --cwd packages/wasm build:js
+          bun run --cwd packages/wasm build:dts
+          bun run --cwd packages/server build
+          bun run --cwd packages/web build
+          bun run --cwd packages/react-native build
+          bun run --cwd packages/vite-plugin-zntc build
+          bun run --cwd packages/init build
+
+      - name: Run publish smoke test
+        run: bun scripts/publish-smoke-test.ts
+
   wasm:
     name: WASM Build & Test
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "bun run test:integration",
     "test:integration": "bun test --cwd tests/integration",
     "test:runtime-polyfills:coverage": "bun run scripts/check-runtime-polyfill-coverage.mjs",
+    "test:publish-smoke": "bun scripts/publish-smoke-test.ts",
     "test:e2e": "bun run --cwd tests/e2e test",
     "test:all": "bun run test:integration && bun run test:e2e",
     "build:zntc": "zig build -Doptimize=ReleaseFast",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,10 @@
   "source": "./index.ts",
   "files": [
     "dist/",
-    "bin/",
+    "bin/cli-flags.mjs",
+    "bin/rn-asset-copy.mjs",
+    "bin/rn-dev-input.mjs",
+    "bin/zntc.mjs",
     "zntc.node"
   ],
   "type": "module",

--- a/scripts/publish-smoke-test.ts
+++ b/scripts/publish-smoke-test.ts
@@ -1,0 +1,278 @@
+/**
+ * Publish smoke test — 각 publishable workspace package 마다 publish tarball 을
+ * 만들고 검증한다. publish 후 사용자 install 시 발생할 사고를 사전 차단:
+ *
+ * - workspace:* 가 concrete semver 로 변환됐는지
+ * - private package (@zntc/server) 가 published dependencies 에 새지 않았는지
+ * - 자기 자신을 dependencies 에 박아 install loop 유발하지 않는지
+ * - peerDependencies 와 peerDependenciesMeta 가 일관 (선언만 하고 meta 누락)
+ * - package.json 의 `main` / `types` / `bin` / `exports[*]` 가 가리키는 파일이
+ *   실제로 tarball 안에 존재하는지
+ * - `files` 화이트리스트로 sensitive 파일 (.env, *.test.*, node_modules 등) 누수 없음
+ *
+ * TARGETS 는 root package.json 의 `workspaces` 에서 자동 검출 — drift 차단.
+ *
+ * 사용:
+ *   bun scripts/publish-smoke-test.ts
+ *
+ * 사전 조건: 각 패키지가 빌드된 상태 (`dist/`). CI 에서는 publish-smoke job 이
+ * build step 선행.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { mkdir, readFile, readdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+const PRIVATE_PACKAGES = new Set(['@zntc/server']);
+
+// `source` condition 은 monorepo internal-only — published tarball 에 src 가
+// 들어가지 않는 게 정상 (외부 사용자는 dist 만 사용). parcel/microbundle 패턴.
+const IGNORED_CONDITIONS = new Set(['source']);
+
+// publish tarball 에 절대 들어가서는 안 되는 파일 패턴.
+// `.gitkeep` 은 빈 디렉토리 보존용이라 무해 — 명시 화이트리스트로 제외.
+const SUSPECT_PATTERNS: RegExp[] = [
+  /(^|\/)\.env$/,
+  /(^|\/)\.env\./,
+  /\.test\./,
+  /\.spec\./,
+  /\.tsbuildinfo$/,
+  /(^|\/)\.git\//,
+  /(^|\/)\.gitignore$/,
+  /(^|\/)\.gitattributes$/,
+  /(^|\/)\.DS_Store$/,
+  /\.log$/,
+  /(^|\/)node_modules\//,
+];
+
+interface Failure {
+  pkg: string;
+  msg: string;
+}
+
+const failures: Failure[] = [];
+
+function fail(pkg: string, msg: string) {
+  failures.push({ pkg, msg });
+  console.error(`  ❌ ${msg}`);
+}
+
+function ok(msg: string) {
+  console.log(`  ✓ ${msg}`);
+}
+
+async function listFilesRecursive(root: string): Promise<string[]> {
+  const out: string[] = [];
+  async function walk(dir: string, prefix: string) {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const e of entries) {
+      const full = join(dir, e.name);
+      const rel = prefix ? `${prefix}/${e.name}` : e.name;
+      if (e.isDirectory()) await walk(full, rel);
+      else out.push(rel);
+    }
+  }
+  await walk(root, '');
+  return out;
+}
+
+function normalizePath(p: string): string {
+  return p.startsWith('./') ? p.slice(2) : p;
+}
+
+function collectExportsPaths(exportsField: unknown, out: Set<string>) {
+  if (typeof exportsField === 'string') {
+    out.add(normalizePath(exportsField));
+    return;
+  }
+  if (exportsField && typeof exportsField === 'object') {
+    for (const [key, v] of Object.entries(exportsField as Record<string, unknown>)) {
+      if (IGNORED_CONDITIONS.has(key)) continue;
+      collectExportsPaths(v, out);
+    }
+  }
+}
+
+function collectBinPaths(binField: unknown, out: Set<string>) {
+  if (typeof binField === 'string') {
+    out.add(normalizePath(binField));
+    return;
+  }
+  if (binField && typeof binField === 'object') {
+    for (const v of Object.values(binField as Record<string, unknown>)) {
+      if (typeof v === 'string') out.add(normalizePath(v));
+    }
+  }
+}
+
+async function smokeOne(pkgDir: string, tmpRoot: string): Promise<void> {
+  const absPkg = resolve(repoRoot, pkgDir);
+  const sourcePkgJson = JSON.parse(await readFile(join(absPkg, 'package.json'), 'utf8'));
+  const pkgName = sourcePkgJson.name as string;
+  console.log(`\n=== ${pkgName} (${pkgDir}) ===`);
+
+  // bun pm pack --quiet 는 stdout 에 tarball 파일명만 출력 — fragile name 추론 회피.
+  const packDest = join(tmpRoot, encodeURIComponent(pkgName));
+  await mkdir(packDest, { recursive: true });
+  const packResult = spawnSync('bun', ['pm', 'pack', '--quiet', '--destination', packDest], {
+    cwd: absPkg,
+    encoding: 'utf8',
+  });
+  if (packResult.status !== 0) {
+    fail(pkgName, `bun pm pack 실패: ${packResult.stderr || packResult.stdout}`);
+    return;
+  }
+  // bun pm pack --quiet 는 절대 경로 또는 파일명을 stdout 에 출력 (버전마다 다름).
+  const stdoutLine = packResult.stdout.trim().split(/\s+/).pop();
+  if (!stdoutLine) {
+    fail(pkgName, `bun pm pack stdout 에서 tarball 이름 못 찾음`);
+    return;
+  }
+  const tarball = isAbsolute(stdoutLine) ? stdoutLine : join(packDest, basename(stdoutLine));
+  if (!existsSync(tarball)) {
+    fail(pkgName, `tarball 을 못 찾음: ${tarball}`);
+    return;
+  }
+
+  const extractDir = join(packDest, 'extract');
+  await mkdir(extractDir, { recursive: true });
+  const tarResult = spawnSync('tar', ['-xzf', tarball, '-C', extractDir], { encoding: 'utf8' });
+  if (tarResult.status !== 0) {
+    fail(pkgName, `tar 추출 실패: ${tarResult.stderr}`);
+    return;
+  }
+
+  const pkgRoot = join(extractDir, 'package');
+  const tarballPkgJson = JSON.parse(await readFile(join(pkgRoot, 'package.json'), 'utf8'));
+  const tarballFiles = await listFilesRecursive(pkgRoot);
+  const fileSet = new Set(tarballFiles);
+
+  // 1) workspace:* 잔존 없음
+  const checkDeps = (deps: Record<string, string> | undefined, label: string) => {
+    if (!deps) return;
+    for (const [name, version] of Object.entries(deps)) {
+      if (version.startsWith('workspace:')) {
+        fail(pkgName, `${label}["${name}"] = "${version}" — workspace: prefix 잔존 (publish 변환 실패)`);
+      }
+    }
+  };
+  checkDeps(tarballPkgJson.dependencies, 'dependencies');
+  checkDeps(tarballPkgJson.peerDependencies, 'peerDependencies');
+  checkDeps(tarballPkgJson.optionalDependencies, 'optionalDependencies');
+
+  // 2) private package 가 dependencies 에 누수되지 않음
+  if (tarballPkgJson.dependencies) {
+    for (const dep of Object.keys(tarballPkgJson.dependencies)) {
+      if (PRIVATE_PACKAGES.has(dep)) {
+        fail(pkgName, `dependencies."${dep}" 가 private — npm install 시 404`);
+      }
+      // 3) self-reference (install loop)
+      if (dep === pkgName) {
+        fail(pkgName, `dependencies."${dep}" 가 자기 자신 — npm install 시 무한 loop`);
+      }
+    }
+  }
+
+  // 4) peerDependencies / peerDependenciesMeta 일관
+  const peerDeps = tarballPkgJson.peerDependencies as Record<string, string> | undefined;
+  const peerMeta = tarballPkgJson.peerDependenciesMeta as Record<string, unknown> | undefined;
+  if (peerMeta) {
+    for (const metaKey of Object.keys(peerMeta)) {
+      if (!peerDeps || !(metaKey in peerDeps)) {
+        fail(pkgName, `peerDependenciesMeta."${metaKey}" 가 peerDependencies 에 없음`);
+      }
+    }
+  }
+
+  // 5) main / types / bin / exports paths 가 tarball 안에 존재
+  const checkPath = (rel: string, label: string) => {
+    if (!fileSet.has(rel)) fail(pkgName, `${label} = "${rel}" — tarball 에 없음`);
+  };
+  if (tarballPkgJson.main) checkPath(normalizePath(tarballPkgJson.main), 'main');
+  if (tarballPkgJson.types) checkPath(normalizePath(tarballPkgJson.types), 'types');
+
+  if (tarballPkgJson.bin) {
+    const binPaths = new Set<string>();
+    collectBinPaths(tarballPkgJson.bin, binPaths);
+    for (const p of binPaths) checkPath(p, `bin "${p}"`);
+  }
+
+  if (tarballPkgJson.exports) {
+    const paths = new Set<string>();
+    collectExportsPaths(tarballPkgJson.exports, paths);
+    for (const p of paths) checkPath(p, `exports "${p}"`);
+    if (paths.size > 0) ok(`exports paths ${paths.size}개 모두 존재`);
+  }
+
+  // 6) sensitive 파일 누수 검사
+  for (const f of tarballFiles) {
+    for (const p of SUSPECT_PATTERNS) {
+      if (p.test(f)) {
+        fail(pkgName, `의심 파일 누수: ${f} (files 화이트리스트 점검 필요)`);
+      }
+    }
+  }
+  ok(`tarball 파일 ${tarballFiles.length}개`);
+}
+
+async function detectTargets(): Promise<string[]> {
+  // root package.json 의 workspaces 에서 packages/* 만 추출. examples/tests/documents
+  // 같은 비-publish 워크스페이스 제외.
+  const root = JSON.parse(await readFile(join(repoRoot, 'package.json'), 'utf8'));
+  const ws = root.workspaces as string[] | undefined;
+  if (!ws) throw new Error('root package.json 에 workspaces 필드 없음');
+  return ws
+    .map((w) => w.replace(/^\.\//, ''))
+    .filter((w) => w.startsWith('packages/'));
+}
+
+async function main() {
+  const targets = await detectTargets();
+  console.log(`Detected ${targets.length} workspace packages:`, targets.join(', '));
+
+  const tmpRoot = mkdtempSync(join(tmpdir(), 'zntc-publish-smoke-'));
+  try {
+    for (const t of targets) {
+      const pkgJsonPath = resolve(repoRoot, t, 'package.json');
+      if (!existsSync(pkgJsonPath)) {
+        console.warn(`skip: ${t} (package.json 없음)`);
+        continue;
+      }
+      const pkg = JSON.parse(await readFile(pkgJsonPath, 'utf8'));
+      if (pkg.private) {
+        console.log(`\nskip: ${pkg.name} (private)`);
+        continue;
+      }
+      const distDir = resolve(repoRoot, t, 'dist');
+      if (!existsSync(distDir)) {
+        console.log(`\n=== ${pkg.name} (${t}) ===`);
+        fail(pkg.name, `dist/ 없음 — 빌드 선행 필요 (bun run --cwd ${t} build)`);
+        continue;
+      }
+      try {
+        await smokeOne(t, tmpRoot);
+      } catch (e) {
+        fail(pkg.name, `예외: ${(e as Error).message}`);
+      }
+    }
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+
+  console.log('\n────────────────');
+  if (failures.length === 0) {
+    console.log(`✓ 모든 검사 통과`);
+    return;
+  }
+  console.error(`❌ ${failures.length}건 실패:`);
+  for (const f of failures) console.error(`  - ${f.pkg}: ${f.msg}`);
+  process.exit(1);
+}
+
+await main();


### PR DESCRIPTION
## Summary

PR #2791 follow-up. publish 후 사용자 install 시 발생할 사고를 publish **전**에 자동 차단하기 위한 smoke test 도입. CI publish-smoke job + scripts/publish-smoke-test.ts.

## 검증 항목

각 publishable workspace package (`packages/*`, `private: true` 제외) 마다 `bun pm pack` → tarball 추출 → 검증:

| 항목 | 차단하는 사고 |
|---|---|
| `workspace:*` 잔존 검사 | 변환 실패 시 사용자 install 깨짐 |
| private package leak (`@zntc/server`) | npm install 시 404 (PR #2792 회귀 방지) |
| self-reference (`pkg.dependencies."<self>"`) | npm install 무한 loop |
| `peerDependencies` ↔ `peerDependenciesMeta` 일관 | meta 만 있고 deps 누락 |
| `main` / `types` / `bin` / `exports[*]` 파일 존재 | publish 후 ENOENT |
| 의심 파일 누수 검사 | `.env`, `*.test.*`, `*.spec.*`, `.tsbuildinfo`, `.git/`, `.DS_Store`, `*.log`, `node_modules/` |

`source` exports condition 은 monorepo internal-only (parcel 패턴) — published tarball 에 src 가 없는 게 정상이므로 검사에서 ignore.

TARGETS 는 root `package.json` 의 `workspaces` 에서 `packages/*` 자동 검출 → 새 패키지 추가 시 잊을 위험 0.

## 발견·수정한 실제 누수

`packages/core/package.json`: `files` 의 `bin/` glob 이 다음 3개의 test 파일을 publish tarball 에 노출하고 있었음:
- `bin/zntc.test.ts`
- `bin/rn-asset-copy.test.ts`
- `bin/zntc-cli-schema-sync.test.ts`

→ `files` 를 명시 list (cli-flags.mjs / zntc.mjs / rn-asset-copy.mjs / rn-dev-input.mjs) 로 변경. glob 은 향후 추가될 파일 silent inclusion 위험.

## 변경 파일

| 파일 | 변경 |
|---|---|
| `scripts/publish-smoke-test.ts` (신설) | 190줄, 자동 검증 스크립트 |
| `.github/workflows/ci.yml` | `publish-smoke` job 추가 (binary + 모든 publishable package build → 스크립트 실행) |
| `package.json` | `test:publish-smoke` 편의 script |
| `packages/core/package.json` | `files` 의 `bin/` → 명시 list |

## Test plan

- [x] `bun run test:publish-smoke` (local) — 6개 publishable packages 모두 통과
- [x] core 의 bin test 파일 누수 fix 확인 (재실행)
- [x] CI workflow 문법 검증
- [ ] CI 첫 run 확인

## 후속 작업

- 별도 PR: `napi-package-smoke` 와 `publish-smoke` 의 binary build step 중복 — `.github/actions/build-zntc-binaries/action.yml` composite action 추출
- 별도 PR: `publint` / `manypkg` 도입 (이번 smoke 와 보완 관계 — manypkg 가 더 일반적, smoke 는 zntc 특화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)