### PR TITLE
feat(ts-references): phase 1 — composite + tsc -b on server/core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ Thumbs.db
 .vscode/
 .idea/
 
+# TypeScript Project References — composite 빌드의 incremental cache
+*.tsbuildinfo
+
 # Documents (starlight-typedoc 자동 생성)
 documents/src/content/docs/reference/api/
 documents/dist/

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "build:napi": "cd ../.. && zig build napi",
     "build:js": "bun build index.ts --outdir dist --format esm --target node",
-    "build:dts": "bun x tsc --emitDeclarationOnly",
+    "build:dts": "bun x tsc -b",
     "build": "bun run build:napi && cp ../../zig-out/lib/zntc.node . && bun run build:js && bun run build:dts",
     "postinstall": "[ -f ../../zig-out/lib/zntc.node ] && cp ../../zig-out/lib/zntc.node . || true",
     "pretest": "bun run --cwd ../server build && bun run --cwd ../web build && bun run --cwd ../react-native build",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -6,7 +6,13 @@
     // index.ts 가 ../shared/index 를 import 하므로 source root 가 packages/ 까지
     // 확장된다. TS 6 의 TS5011 (inferred rootDir 거부) 회피 + 기존 emit layout
     // (`dist/core/index.d.ts` + `dist/shared/*.d.ts`, package.json `types` 와 일치) 보존.
-    "rootDir": ".."
+    "rootDir": "..",
+    // composite: TS Project Reference 의 referenced project 노출. consumer 가
+    // references 로 명시하면 `tsc -b` 가 토폴로지 빌드 + incremental
+    // .tsbuildinfo. emitDeclarationOnly 와 호환.
+    "composite": true,
+    "tsBuildInfoFile": ".tsbuildinfo"
   },
-  "include": ["index.ts"]
+  "include": ["index.ts", "src/**/*", "../shared/**/*"],
+  "exclude": ["src/**/*.test.ts", "../shared/**/*.test.ts"]
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build:bundle": "node ../core/bin/zntc.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --conditions=source --external @zntc/core",
-    "build:dts": "bun x tsc --emitDeclarationOnly",
+    "build:dts": "bun x tsc -b",
     "build": "bun run build:bundle && bun run build:dts",
     "test": "bun test --timeout 10000"
   },

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -3,7 +3,13 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "declarationDir": "dist"
+    "declarationDir": "dist",
+    // composite: 이 패키지를 TS Project Reference 의 referenced project 로
+    // 노출. consumer 의 tsconfig 가 references 배열로 명시하면 tsc -b 가
+    // 토폴로지 빌드 + incremental .tsbuildinfo. emitDeclarationOnly 와 호환 —
+    // tsc 는 .d.ts 만 생성, .js 는 zntc/bun build 가 emit.
+    "composite": true,
+    "tsBuildInfoFile": ".tsbuildinfo"
   },
   "include": ["src/**/*"],
   "exclude": ["src/**/*.test.ts"]


### PR DESCRIPTION
## Summary

TS Project References 도입 epic 의 첫 단계. server / core 의 tsconfig 에 `composite: true` + `tsBuildInfoFile` 추가 + `build:dts` 를 `tsc -b` 로 전환. **이 단계에서는 consumer (web/RN/vite-plugin) 의 references 는 미추가** — 영향 범위를 server/core 자체의 incremental build 만으로 한정해 안전 검증.

## 이득

- 두 번째 build 부터 `.tsbuildinfo` cache 활용 → no-change 빌드 ~40ms
- 다음 PR (Phase 2) 에서 consumer 가 `references` 추가하면 `tsc -b consumer` 한 번으로 의존하는 server/core 도 토폴로지 자동 incremental 빌드

## 변경

| 파일 | 변경 |
|---|---|
| `packages/server/tsconfig.json` | `composite: true`, `tsBuildInfoFile: \".tsbuildinfo\"` |
| `packages/core/tsconfig.json` | 동일 + `include` 확장 (`src/**/*`, `../shared/**/*`) — composite 가 모든 reachable file 명시 요구 (TS6307) |
| `packages/{server,core}/package.json` | `build:dts` → `bun x tsc -b` |
| `.gitignore` | `*.tsbuildinfo` (incremental cache 는 commit 안 함) |

`tsBuildInfoFile` 위치: 패키지 root 의 hidden `.tsbuildinfo`. dist/ 안에 두면 publish 누수 위험 — `files` 화이트리스트가 `dist/` 만 포함하니 root 에 두면 자동 제외.

## Test plan

- [x] `bun run build:publishable` — 6 publishable package 모두 통과
- [x] `bun run test:publish-smoke` — 6 패키지 통과 (`.tsbuildinfo` 누수 없음)
- [x] `bun run test:publint` — 7 패키지 통과
- [x] `zig build test` EXIT=0
- [x] `bun run fmt:check` clean

## 후속 PR (Phase 2 / Phase 3)

- **Phase 2**: consumer (web/RN/vite-plugin) tsconfig 에 `references: [{path: \"../core\"}, {path: \"../server\"}]` + `composite: true` + `build:dts` 를 `tsc -b` 로
- **Phase 3**: root `tsconfig.solution.json` — IDE 가 단일 entry 로 모든 패키지 인식

🤖 Generated with [Claude Code](https://claude.com/claude-code)