### PR TITLE
feat(ts-references): phase 2 — wire web/RN/vite-plugin → core/server

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build:bundle": "node ../core/bin/zntc.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --conditions=source --external @zntc/core --external @babel/core --external @react-native/babel-plugin-codegen --external @react-native/babel-preset --external metro-resolver --external react-native --external @react-native/js-polyfills",
-    "build:dts": "bun x tsc --emitDeclarationOnly",
+    "build:dts": "bun x tsc -b",
     "build": "bun run build:bundle && bun run build:dts",
     "test": "bun test --timeout 10000"
   },

--- a/packages/react-native/tsconfig.json
+++ b/packages/react-native/tsconfig.json
@@ -3,8 +3,10 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "declarationDir": "dist"
+    "declarationDir": "dist",
+    "tsBuildInfoFile": ".tsbuildinfo"
   },
+  "references": [{ "path": "../core" }, { "path": "../server" }],
   "include": ["src/**/*"],
   "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/vite-plugin-zntc/package.json
+++ b/packages/vite-plugin-zntc/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build:bundle": "node ../core/bin/zntc.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --conditions=source --external @zntc/core --external vite",
-    "build:dts": "bun x tsc --emitDeclarationOnly",
+    "build:dts": "bun x tsc -b",
     "build": "bun run build:bundle && bun run build:dts"
   },
   "dependencies": {

--- a/packages/vite-plugin-zntc/tsconfig.json
+++ b/packages/vite-plugin-zntc/tsconfig.json
@@ -3,8 +3,10 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "declarationDir": "dist"
+    "declarationDir": "dist",
+    "tsBuildInfoFile": ".tsbuildinfo"
   },
+  "references": [{ "path": "../core" }],
   "include": ["src/**/*"],
   "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build:bundle": "node ../core/bin/zntc.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --conditions=source --external @zntc/core --external postcss --external postcss-load-config --external sass",
-    "build:dts": "bun x tsc --emitDeclarationOnly",
+    "build:dts": "bun x tsc -b",
     "build": "bun run build:bundle && bun run build:dts",
     "test": "bun test --timeout 10000"
   },

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -3,8 +3,13 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "declarationDir": "dist"
+    "declarationDir": "dist",
+    // composite 는 core 에서 상속. tsBuildInfoFile 은 extends 가 base path
+    // 기준 resolve 라 명시 override 필수 — 안 그러면 packages/core/.tsbuildinfo
+    // 와 충돌.
+    "tsBuildInfoFile": ".tsbuildinfo"
   },
+  "references": [{ "path": "../core" }, { "path": "../server" }],
   "include": ["src/**/*"],
   "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

PR #2805 (Phase 1) follow-up. consumer (web/react-native/vite-plugin-zntc) tsconfig 에 `references` 추가 + `build:dts` 를 `tsc -b` 로 전환. `composite: true` 는 core 에서 extends 로 상속.

이제 consumer 에서 `tsc -b` 한 번 호출 → referenced project (core/server) 가 자동 토폴로지 incremental 빌드 + consumer 빌드. **server 의 `.d.ts` 가 stale 이어도 `tsc -b` 가 알아서 갱신** (build order drift 차단).

## 변경

| 파일 | references | tsBuildInfoFile |
|---|---|---|
| `packages/web/tsconfig.json` | `[core, server]` | `.tsbuildinfo` (override) |
| `packages/react-native/tsconfig.json` | `[core, server]` | `.tsbuildinfo` |
| `packages/vite-plugin-zntc/tsconfig.json` | `[core]` | `.tsbuildinfo` |
| `packages/{web,react-native,vite-plugin-zntc}/package.json` | — | `build:dts` → `tsc -b` |

`tsBuildInfoFile` 명시 override 이유: extends 시 base path 가 base 위치 기준 resolve. 안 하면 모든 consumer 가 `packages/core/.tsbuildinfo` 를 공유 → cache 충돌 + race.

## Test plan

- [x] 6 publishable build 모두 통과
- [x] 두 번째 build (no-change) ~50ms — incremental cache 활용
- [x] `bun run test:publish-smoke` / `test:publint` 모두 통과
- [x] `zig build test` EXIT=0
- [x] `bun run fmt:check` clean

## 후속 PR (Phase 3)

- root `tsconfig.solution.json` — IDE 가 단일 entry 로 전체 monorepo 인식
- root npm script: `tsc -b` 한 번으로 모든 dts 빌드

🤖 Generated with [Claude Code](https://claude.com/claude-code)