### PR TITLE
feat(ts-references): phase 3 — solution-style root tsconfig + tsc -b scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "test:publish-smoke": "bun scripts/publish-smoke-test.ts",
     "test:publint": "bun scripts/publint-all.ts",
     "build:publishable": "bun run --cwd packages/server build && bun run --cwd packages/web build && bun run --cwd packages/react-native build && bun run --cwd packages/vite-plugin-zntc build && bun run --cwd packages/init build",
+    "build:dts:all": "bun x tsc -b",
+    "type-check": "bun x tsc -b --dry",
     "test:e2e": "bun run --cwd tests/e2e test",
     "test:all": "bun run test:integration && bun run test:e2e",
     "build:zntc": "zig build -Doptimize=ReleaseFast",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+// Solution-style root tsconfig — 자기 type-check 안 하고 (`files: []`)
+// referenced project 들만 노출. IDE 가 이 파일을 자동 발견해 모든 패키지를
+// 단일 program 으로 인식 (cross-package go-to-def, no-symlink-required type
+// resolution). `tsc -b` 를 root 에서 호출하면 전체 monorepo dts 가 토폴로지
+// incremental 빌드.
+//
+// composite 가 활성화된 패키지만 references 에 등록. init / wasm 는 향후
+// composite 전환 시 추가 (별도 PR).
+{
+  "files": [],
+  "references": [
+    { "path": "./packages/core" },
+    { "path": "./packages/server" },
+    { "path": "./packages/web" },
+    { "path": "./packages/react-native" },
+    { "path": "./packages/vite-plugin-zntc" }
+  ]
+}


### PR DESCRIPTION
## Summary

PR #2806 (Phase 2) follow-up. monorepo 전체를 단일 TS program 으로 묶는 root `tsconfig.json` (solution-style) + 편의 npm script.

## 추가

| 파일 | 내용 |
|---|---|
| `/tsconfig.json` (신설) | `files: []` + `references: [core, server, web, react-native, vite-plugin-zntc]` (composite 활성 패키지만) |
| root npm scripts | `build:dts:all` = `tsc -b`, `type-check` = `tsc -b --dry` |

## 이득

- **IDE (VSCode 등) 가 root tsconfig 자동 발견** → 모든 패키지 단일 program 인식 → cross-package go-to-definition / type 추론 정확
- **전체 빌드**: cold ~615ms / no-change ~45ms (incremental cache)
- 새 패키지 composite 전환 시 `references` 한 줄만 추가하면 통합

## Test plan

- [x] `bun run build:dts:all` — 5 패키지 모두 통과
- [x] `bun run type-check` (`--dry`) — 모두 \"up to date\" 보고
- [x] `bun run fmt:check` clean

## 후속

- 별도 PR: `init` / `wasm` composite 전환 후 references 에 추가
- 별도 PR: IDE 별 권장 설정 docs (선택)

🤖 Generated with [Claude Code](https://claude.com/claude-code)