### PR TITLE
feat(ts-references): wire init + wasm into solution

### DIFF
--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "build:js": "bun build src/index.ts src/cli.ts --outdir dist --format esm --target node",
-    "build:dts": "bun x tsc --emitDeclarationOnly",
+    "build:dts": "bun x tsc -b",
     "build": "bun run build:js && bun run build:dts",
     "test": "bun test --timeout 10000"
   },

--- a/packages/init/tsconfig.json
+++ b/packages/init/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "declarationDir": "dist"
+    "declarationDir": "dist",
+    "tsBuildInfoFile": ".tsbuildinfo"
   },
   "include": ["src/**/*"],
   "exclude": ["src/**/*.test.ts"]

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "build:wasm": "cd ../.. && zig build wasm && zig build wasm-bundler",
     "build:js": "bun build index.ts --outdir dist --format esm --target browser",
-    "build:dts": "bun x tsc --emitDeclarationOnly",
+    "build:dts": "bun x tsc -b",
     "build": "bun run build:wasm && cp ../../zig-out/bin/zntc.wasm . && cp ../../zig-out/bin/zntc-bundler.wasm . && bun run build:js && bun run build:dts",
     "test": "bun test --timeout 10000"
   },

--- a/packages/wasm/tsconfig.json
+++ b/packages/wasm/tsconfig.json
@@ -6,7 +6,12 @@
     "outDir": "dist",
     // index.ts 가 ../shared/index 를 import 하므로 source root 가 packages/ 까지
     // 확장된다. emit layout 은 dist/wasm/index.d.ts + dist/shared/*.d.ts.
-    "rootDir": ".."
+    "rootDir": "..",
+    // composite: TS Project Reference 의 referenced project 노출. tsconfig.base.json
+    // 에는 없으므로 명시 추가. include 가 reachable file 모두 명시 (TS6307 회피).
+    "composite": true,
+    "tsBuildInfoFile": ".tsbuildinfo"
   },
-  "include": ["index.ts"]
+  "include": ["index.ts", "../shared/**/*"],
+  "exclude": ["../shared/**/*.test.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,7 @@
 // resolution). `tsc -b` 를 root 에서 호출하면 전체 monorepo dts 가 토폴로지
 // incremental 빌드.
 //
-// composite 가 활성화된 패키지만 references 에 등록. init / wasm 는 향후
-// composite 전환 시 추가 (별도 PR).
+// composite 가 활성화된 패키지만 references 에 등록.
 {
   "files": [],
   "references": [
@@ -13,6 +12,8 @@
     { "path": "./packages/server" },
     { "path": "./packages/web" },
     { "path": "./packages/react-native" },
-    { "path": "./packages/vite-plugin-zntc" }
+    { "path": "./packages/vite-plugin-zntc" },
+    { "path": "./packages/init" },
+    { "path": "./packages/wasm" }
   ]
 }


### PR DESCRIPTION
## Summary

PR #2807 follow-up — TS Project References 마무리. `init` / `wasm` 도 composite + solution-style references 에 등록.

## 변경

| 파일 | 변경 |
|---|---|
| `packages/init/tsconfig.json` | `tsBuildInfoFile` override (composite 는 core 에서 상속) |
| `packages/wasm/tsconfig.json` | composite + tsBuildInfoFile 추가 (base 에는 composite 없음). `include` 확장 (`../shared/**/*` — TS6307 회피) |
| `packages/{init,wasm}/package.json` | `build:dts` → `bun x tsc -b` |
| `tsconfig.json` (root solution) | `references` 에 `init` + `wasm` 추가 |

이제 **7 publishable package 전부 단일 program**. `tsc -b` 한 번으로 전체 토폴로지 빌드.

## Test plan

- [x] 전체 cold build: ~676ms (5 → 7 패키지)
- [x] 2nd build (no-change): ~56ms (incremental cache)
- [x] `bun run test:publish-smoke` — 6 publishable 모두 통과
- [x] `bun run test:publint` — 7 모두 통과
- [x] `bun run fmt:check` clean

이제 IDE 가 root `tsconfig.json` 한 곳만 보면 모든 패키지 type-check + cross-package go-to-definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)