### PR TITLE
ci: add sherif (workspace metadata 일관성) + fix vite-plugin peer 누락

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,6 +309,9 @@ jobs:
       - name: Run publint (npm 표준 모범 사례 errors)
         run: bun run test:publint
 
+      - name: Run sherif (workspace metadata 일관성 — license/types/packageManager 등)
+        run: bun run test:sherif
+
   wasm:
     name: WASM Build & Test
     runs-on: ubuntu-latest

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "react-dom": "^19.2.5",
         "rxjs": "^7.8.2",
         "sass": "^1.99.0",
+        "sherif": "1.11.1",
         "styled-components": "^6.4.0",
         "tailwindcss": "^4.2.2",
         "typescript": "^6.0.3",
@@ -241,6 +242,7 @@
       },
       "devDependencies": {
         "@types/node": "^25.5.2",
+        "vite": "^8.0.8",
       },
       "peerDependencies": {
         "vite": ">=5.0.0",
@@ -4095,6 +4097,24 @@
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
+
+    "sherif": ["sherif@1.11.1", "", { "optionalDependencies": { "sherif-darwin-arm64": "1.11.1", "sherif-darwin-x64": "1.11.1", "sherif-linux-arm64": "1.11.1", "sherif-linux-arm64-musl": "1.11.1", "sherif-linux-x64": "1.11.1", "sherif-linux-x64-musl": "1.11.1", "sherif-windows-arm64": "1.11.1", "sherif-windows-x64": "1.11.1" }, "bin": { "sherif": "index.js" } }, "sha512-HBFce8NGaPuWPg5NXb6+aI7hJQFjTilhtbrgo+Y/BvtGlkuJAzLnkmC8nyD+p3v7oIAq4KQeA8qySKGga28xZg=="],
+
+    "sherif-darwin-arm64": ["sherif-darwin-arm64@1.11.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-VoMrUv5QY6hQ2rByNa3AAhr/KGQsCb6pvAUNKa1iCh1jvnY836hQr6zNBw9hYCDkVv6t9sITFGJljwdTCQD4xw=="],
+
+    "sherif-darwin-x64": ["sherif-darwin-x64@1.11.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-7j3yOCBkvVbltVT3lXoiazGfG2nb36FteYT5VZPEBSf8sTn1pPTScukAQ1Fdl+MphadGyici7XlRbDrtZ/wnvA=="],
+
+    "sherif-linux-arm64": ["sherif-linux-arm64@1.11.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-vCZFS7RxhZ/8g9bdj3UPNVPTcZiKiWigW+FIlVQEUKEKfG0MfSOMBJqEWPVVUniyJa3rdIxtmZKSdWkG0e1x3w=="],
+
+    "sherif-linux-arm64-musl": ["sherif-linux-arm64-musl@1.11.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-DCf87RFqBh8ZrYgu3y+fv0x4kFn/np84m2jAEgygznwozH/VCfrXbHFVdhxW7762JCYkXbHO9dUj/ff5fkvkvw=="],
+
+    "sherif-linux-x64": ["sherif-linux-x64@1.11.1", "", { "os": "linux", "cpu": "x64" }, "sha512-9t+p1X3SyhU75BrJNHBbj9i/aQxHC/sF+Mdkf17V5AlokCznFgYKQUXq5EVmcmRDDhDl69RMzCTLD95EBqUSYA=="],
+
+    "sherif-linux-x64-musl": ["sherif-linux-x64-musl@1.11.1", "", { "os": "linux", "cpu": "x64" }, "sha512-f8xitqXdHObUFPZo4QVbz3o30Y4+gHA3B5ZobsOWocnSfJBaUGutBzJsUsjG6w2tccSRn6+mugiMUGKIbIPZmQ=="],
+
+    "sherif-windows-arm64": ["sherif-windows-arm64@1.11.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-Dnffgcyz9zLq/8UTY2REchJzRJWcWAuMWo5Vl5O17IZGkhl71dwa7/Vi2wC3EQd8WAVK/O82yArOYggWA0dj5w=="],
+
+    "sherif-windows-x64": ["sherif-windows-x64@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-xjfYUL/IQ65DwHkRsWIxiZWtglKtL5/E3UHpnLwOui3jqW1V2K88SMct415dnlBQiL3U9VEIVUo1i+KmToOBgQ=="],
 
     "shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "zntc",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "bun@1.3.11",
   "workspaces": [
     "./packages/core",
     "./packages/init",
@@ -24,6 +25,7 @@
     "test:runtime-polyfills:coverage": "bun run scripts/check-runtime-polyfill-coverage.mjs",
     "test:publish-smoke": "bun scripts/publish-smoke-test.ts",
     "test:publint": "bun scripts/publint-all.ts",
+    "test:sherif": "bunx sherif --ignore-rule multiple-dependency-versions --ignore-rule unsync-similar-dependencies",
     "build:publishable": "bun run --cwd packages/server build && bun run --cwd packages/web build && bun run --cwd packages/react-native build && bun run --cwd packages/vite-plugin-zntc build && bun run --cwd packages/init build",
     "build:dts:all": "bun x tsc -b",
     "type-check": "bun x tsc -b --dry",
@@ -60,6 +62,7 @@
     "react-dom": "^19.2.5",
     "rxjs": "^7.8.2",
     "sass": "^1.99.0",
+    "sherif": "1.11.1",
     "styled-components": "^6.4.0",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.3",

--- a/packages/vite-plugin-zntc/package.json
+++ b/packages/vite-plugin-zntc/package.json
@@ -27,7 +27,8 @@
     "@zntc/core": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "^25.5.2"
+    "@types/node": "^25.5.2",
+    "vite": "^8.0.8"
   },
   "peerDependencies": {
     "vite": ">=5.0.0"


### PR DESCRIPTION
## Summary

publish 인프라 강화 follow-up. workspace metadata 일관성 lint 도구 도입 검토 후 sherif 채택.

manypkg 도 시도했으나 internal-mismatch (workspace 사이의 dep version 통일) 강제가 너무 엄격 — examples/benchmark 가 의도적으로 다양한 RN/React/SWC 버전 시험. sherif 는 rule 단위 ignore 가능 + 더 가벼움.

## 활성 검사

- `packageManager` field 누락
- `private` 일관성
- `license` / npm name 누락
- `types-in-dependencies` (devDeps 어야 할 게 deps 에)
- `packages-without-package-json`
- `package-without-license`
- `empty-dependencies`
- 기타 sherif default rule 중 `multiple-dependency-versions` / `unsync-similar-dependencies` 둘만 비활성

## 발견된 fix

| 항목 | 변경 |
|---|---|
| `vite-plugin-zntc` | `vite` peer 가 dev 에 미선언 → `^8.0.8` 추가 (workspace 빌드 시 vite type 사용하니 dev 필수) |
| root `package.json` | `packageManager: \"bun@1.3.11\"` (corepack 표준 권장) |

## 추가

- root devDeps: `sherif 1.11.1`
- root npm script: `test:sherif`
- CI `publish-smoke` job 에 sherif step

## Test plan

- [x] `bun run test:sherif` → No issues found
- [x] `bun run fmt:check` clean

## 후속 (이번 세션 follow-up 작업 list)

- publish-smoke install + import 단계 추가 (실제 npm install 시나리오 검증)
- IDE 권장 설정 docs (TS Project References + tsgo)
- core dist 크기 audit (composite emit 가 transitive .d.ts 까지 포함)
- async edge case 추가 회귀 테스트
- anyMatchInsideClosure 일반화 (containsYield/Return 통합)

🤖 Generated with [Claude Code](https://claude.com/claude-code)