### PR TITLE
fix(bundler): RN ES5 runtime helper rename 오류 수정

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -706,7 +706,10 @@ pub const Linker = struct {
                         if (rec.resolved.isNone()) break :blk !rec.is_lazy_resolved;
                         const target_idx = @intFromEnum(rec.resolved);
                         if (target_idx >= self.graph.moduleCount()) break :blk m.wrap_kind == .esm;
-                        const target_wrap = self.getModule(target_idx).?.wrap_kind;
+                        const target_module = self.getModule(target_idx).?;
+                        const helper_modules = @import("../runtime_helper_modules.zig");
+                        if (helper_modules.isVirtualId(target_module.path)) break :blk false;
+                        const target_wrap = target_module.wrap_kind;
                         if (m.wrap_kind == .esm) {
                             // CJS named import는 `require_xxx().prop` 직접 참조로
                             // 치환하므로 별도 top-level var를 만들지 않는다.


### PR DESCRIPTION
## 요약
- runtime helper virtual module import를 top-level deconflict 후보에서 제외
- RN ExampleApp 번들에서 `__extends` 선언은 원본명인데 호출부만 `__extends$1`로 바뀌던 ReferenceError 수정

## 원인
- `6e44d991` (`fix(bundler): post-transform analysis refresh`, 2026-04-27 01:49:45 +0900) 이후 post-transform import binding 분석이 helper import까지 실제 top-level var 생성 import처럼 수집했습니다.
- 그 결과 RN `__esm` wrap 모듈에서 helper 호출부가 rename되었지만 helper virtual module 선언/초기화 경로와 어긋났습니다.

## 검증
- `zig build`
- `zig build test`
- `zig build napi`
- `git diff --check`
- `cd tests/integration && bun test tests/es5-rn.test.ts -t "ExampleApp" --timeout 600000`
- pre-push hook (`zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`)
