### PR TITLE
ci(publish): add prepublishOnly + pre-release-check + PUBLISH.md

### DIFF
--- a/docs/PUBLISH.md
+++ b/docs/PUBLISH.md
@@ -1,0 +1,73 @@
+# Publishing
+
+ZNTC monorepo 의 publish 절차 + 자동 검증 chain.
+
+## 검증 인프라
+
+publish 안전을 위한 5 layer (CI publish-smoke job 에서도 모두 실행):
+
+| Layer | 명령 | 검증 항목 |
+|---|---|---|
+| **Build** | `bun run build:publishable` | 모든 publishable 패키지 dist 생성 |
+| **publish-smoke** | `bun run test:publish-smoke` | tarball layout / files / metadata / private dep leak / sensitive 파일 누수 |
+| **publint** | `bun run test:publint` | npm 표준 모범 사례 (exports order / file extension 정합성 등) |
+| **sherif** | `bun run test:sherif` | workspace metadata 일관성 (license / packageManager / types-in-deps) |
+| **publish-install** | `bun run test:publish-install` | 실제 `npm install <tarball>` + dynamic ESM import |
+
+## 단일 명령: pre-release-check
+
+publish 직전 위 5 layer 를 한 번에:
+
+```bash
+bun run pre-release-check
+```
+
+통과해야 publish 시도 권장.
+
+## 자동 안전망: prepublishOnly
+
+각 publishable 패키지의 `package.json` 에 `prepublishOnly` 가 등록되어 있어, 실수로 검증 안 한 채 `npm publish` / `bun publish` 호출해도 npm/bun 이 자동으로:
+
+```jsonc
+"prepublishOnly": "bun run build && bunx publint --strict --level error ."
+```
+
+→ build + publint 가 통과해야 실제 publish 진행. 실패 시 publish 중단.
+
+이 hook 은 **publish 명령을 명시 호출했을 때만** 실행 — `bun install` / `bun run dev` 등에는 영향 0.
+
+## 권장 publish 절차
+
+ZNTC 는 monorepo 라 패키지 간 dependency 가 있어 순서가 중요:
+
+```bash
+# 1. 모든 검증
+bun run pre-release-check
+
+# 2. core 부터 (다른 패키지의 dependency)
+cd packages/core
+bun publish      # prepublishOnly 가 자동 build + publint 한 번 더 검증
+
+# 3. server 는 private 이라 publish 안 됨 (skip)
+
+# 4. core 를 의존하는 패키지 — 순서 무관
+cd ../web && bun publish
+cd ../react-native && bun publish
+cd ../vite-plugin-zntc && bun publish
+cd ../wasm && bun publish
+cd ../init && bun publish
+```
+
+**주의**: 첫 publish 전 npm registry 의 패키지명 가용성 확인 (`npm view @zntc/core` 가 `404` 면 OK).
+
+## 후속 release 자동화
+
+`changesets` (https://github.com/changesets/changesets) 도입 시 version bump + changelog + sequential publish 가 한 번에. 현재는 manual 절차.
+
+## 관련 PR
+
+- publish-smoke (#2798), composite action (#2799)
+- publint + types-first (#2801), publint --strict + .cjs (#2802)
+- sherif + vite-plugin peer fix (#2810)
+- publish-install (#2811)
+- prepublishOnly + pre-release-check (이번 PR)

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:publint": "bun scripts/publint-all.ts",
     "test:sherif": "bunx sherif --ignore-rule multiple-dependency-versions --ignore-rule unsync-similar-dependencies",
     "build:publishable": "bun run --cwd packages/server build && bun run --cwd packages/web build && bun run --cwd packages/react-native build && bun run --cwd packages/vite-plugin-zntc build && bun run --cwd packages/init build",
+    "pre-release-check": "bun run build:publishable && bun run test:publish-smoke && bun run test:publint && bun run test:sherif && bun run test:publish-install",
     "build:dts:all": "bun x tsc -b",
     "type-check": "bun x tsc -b --dry",
     "test:e2e": "bun run --cwd tests/e2e test",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,8 @@
     "build": "bun run build:napi && cp ../../zig-out/lib/zntc.node . && bun run build:js && bun run build:dts",
     "postinstall": "[ -f ../../zig-out/lib/zntc.node ] && cp ../../zig-out/lib/zntc.node . || true",
     "pretest": "bun run --cwd ../server build && bun run --cwd ../web build && bun run --cwd ../react-native build",
-    "test": "bun test --timeout 10000"
+    "test": "bun test --timeout 10000",
+    "prepublishOnly": "bun run build && bunx publint --strict --level error ."
   },
   "devDependencies": {
     "@types/node": "^25.5.2"

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -24,7 +24,8 @@
     "build:js": "bun build src/index.ts src/cli.ts --outdir dist --format esm --target node",
     "build:dts": "bun x tsc -b",
     "build": "bun run build:js && bun run build:dts",
-    "test": "bun test --timeout 10000"
+    "test": "bun test --timeout 10000",
+    "prepublishOnly": "bun run build && bunx publint --strict --level error ."
   },
   "devDependencies": {
     "@types/node": "^25.5.2"

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -22,7 +22,8 @@
     "build:bundle": "node ../core/bin/zntc.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --conditions=source --external @zntc/core --external @babel/core --external @react-native/babel-plugin-codegen --external @react-native/babel-preset --external metro-resolver --external react-native --external @react-native/js-polyfills",
     "build:dts": "bun x tsc -b",
     "build": "bun run build:bundle && bun run build:dts",
-    "test": "bun test --timeout 10000"
+    "test": "bun test --timeout 10000",
+    "prepublishOnly": "bun run build && bunx publint --strict --level error ."
   },
   "dependencies": {
     "@react-native-community/cli-server-api": "^15.0.0",

--- a/packages/vite-plugin-zntc/package.json
+++ b/packages/vite-plugin-zntc/package.json
@@ -21,7 +21,8 @@
   "scripts": {
     "build:bundle": "node ../core/bin/zntc.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --conditions=source --external @zntc/core --external vite",
     "build:dts": "bun x tsc -b",
-    "build": "bun run build:bundle && bun run build:dts"
+    "build": "bun run build:bundle && bun run build:dts",
+    "prepublishOnly": "bun run build && bunx publint --strict --level error ."
   },
   "dependencies": {
     "@zntc/core": "workspace:*"

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -24,7 +24,8 @@
     "build:js": "bun build index.ts --outdir dist --format esm --target browser",
     "build:dts": "bun x tsc -b",
     "build": "bun run build:wasm && cp ../../zig-out/bin/zntc.wasm . && cp ../../zig-out/bin/zntc-bundler.wasm . && bun run build:js && bun run build:dts",
-    "test": "bun test --timeout 10000"
+    "test": "bun test --timeout 10000",
+    "prepublishOnly": "bun run build && bunx publint --strict --level error ."
   },
   "devDependencies": {
     "@types/node": "^25.5.2"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -20,7 +20,8 @@
     "build:bundle": "node ../core/bin/zntc.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --conditions=source --external @zntc/core --external postcss --external postcss-load-config --external sass",
     "build:dts": "bun x tsc -b",
     "build": "bun run build:bundle && bun run build:dts",
-    "test": "bun test --timeout 10000"
+    "test": "bun test --timeout 10000",
+    "prepublishOnly": "bun run build && bunx publint --strict --level error ."
   },
   "dependencies": {
     "@zntc/core": "workspace:*"


### PR DESCRIPTION
## Summary

publish 자동 안전망 + 절차 문서화. **publish 자체를 자동 실행하는 게 아님** — 사용자가 publish 하려는 순간 검증을 강제하는 hook + 통합 검증 명령 + docs.

## 추가

| 파일 | 변경 |
|---|---|
| 6 publishable `package.json` (core/web/RN/vite-plugin/wasm/init) | `prepublishOnly: \"bun run build && bunx publint --strict --level error .\"` — `npm publish` / `bun publish` 시 자동 build + publint 검증 |
| root `package.json` | `pre-release-check`: `build:publishable + test:publish-smoke + test:publint + test:sherif + test:publish-install` 5 layer 한 번에 |
| `docs/PUBLISH.md` (신설) | 검증 인프라 / pre-release-check / prepublishOnly / 권장 publish 절차 / changesets 등 |

server 는 `private: true` 라 prepublishOnly 미추가 (publish 자체가 안 됨).

## 안전성 보증

- **prepublishOnly 는 `publish` 명령에만 발동** — `install` / `build` / `dev` 등 일반 작업에 영향 0
- publish 시기는 여전히 사용자 결정 — hook 은 publish *전* 검증 강제만
- pre-release-check 도 명시 호출 (`bun run pre-release-check`) — 자동 실행 X

## Test plan

- [x] `bun run pre-release-check` — 6 publishable + sherif + publint + publish-install 모두 통과
- [x] `bun run --cwd packages/init prepublishOnly` 직접 호출 — build + publint 통과 (실제 publish 명령 없이 hook 만 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)