### PR TITLE
refactor: transformer namespace 헬퍼 분리

### DIFF
--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -61,6 +61,7 @@ const emotion_mod = @import("transformer/emotion.zig");
 const tagged_template_mod = @import("transformer/tagged_template.zig");
 const flow_mod = @import("transformer/flow.zig");
 const define_mod = @import("transformer/define.zig");
+const namespace_mod = @import("transformer/namespace.zig");
 pub const ast_plugin_mod = @import("ast_plugin.zig");
 pub const AstTransformCtx = ast_plugin_mod.AstTransformCtx;
 pub const FunctionInfo = ast_plugin_mod.FunctionInfo;
@@ -2430,73 +2431,9 @@ pub const Transformer = struct {
     // ================================================================
     // TS namespace 변환
     // ================================================================
-
-    /// ts_module_declaration: binary = { left=name, right=body_or_inner, flags }
-    /// flags=1: ambient module declaration (`declare module "*.css" { ... }`) → strip.
-    /// flags=0: 일반 namespace → 새 AST에 복사. codegen에서 IIFE로 출력.
-    /// import x = require('y') → const x = require('y')
-    /// import x = Namespace.Member → const x = Namespace.Member
-    fn visitImportEqualsDeclaration(self: *Transformer, node: Node) Error!NodeIndex {
-        const name_idx = node.data.binary.left;
-        const value_idx = node.data.binary.right;
-        const new_name = try self.visitNode(name_idx);
-        const new_value = try self.visitNode(value_idx);
-        // variable_declarator: extra = [name, type_ann(none), init]
-        const decl_extra = try self.ast.addExtras(&.{
-            @intFromEnum(new_name),
-            @intFromEnum(NodeIndex.none), // type_ann (stripped)
-            @intFromEnum(new_value),
-        });
-        const declarator = try self.ast.addNode(.{
-            .tag = .variable_declarator,
-            .span = node.span,
-            .data = .{ .extra = decl_extra },
-        });
-        const scratch_top = self.scratch.items.len;
-        try self.scratch.append(self.allocator, declarator);
-        const list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
-        self.scratch.shrinkRetainingCapacity(scratch_top);
-        // variable_declaration: extra = [kind_flags, list.start, list.len]
-        // kind = .const
-        const var_extra = try self.ast.addExtras(&.{ @intFromEnum(VariableDeclarationKind.@"const"), list.start, list.len });
-        return try self.ast.addNode(.{
-            .tag = .variable_declaration,
-            .span = node.span,
-            .data = .{ .extra = var_extra },
-        });
-    }
-
-    /// `export = expr;` → `module.exports = expr;` ExpressionStatement.
-    /// ESM output context 에서는 런타임에서 `module is not defined` 으로 실패하지만
-    /// (tsc TS1203 동등), rewrite 는 무조건 — #1961 의 helper-import 패턴과 동일하게
-    /// 정책 (warn/strip/error) 은 호출자/codegen 이 결정.
-    fn visitExportAssignment(self: *Transformer, node: Node) Error!NodeIndex {
-        const new_expr = try self.visitNode(node.data.unary.operand);
-        if (new_expr.isNone()) return .none;
-
-        const module_id = try es_helpers.makeIdentifierRef(self, "module");
-        const exports_id = try es_helpers.makeIdentifierRef(self, "exports");
-        const member = try es_helpers.makeStaticMember(self, module_id, exports_id, node.span);
-        return es_helpers.makeAssignStmt(self, member, new_expr, node.span, 0);
-    }
-
-    fn visitNamespaceDeclaration(self: *Transformer, node: Node) Error!NodeIndex {
-        // declare module "*.css" { ... } 같은 ambient module은 런타임 코드 없음 → strip
-        if (node.data.binary.flags == 1) return .none;
-        const new_name = try self.visitNode(node.data.binary.left);
-        const new_body = try self.visitNode(node.data.binary.right);
-        // 타입만 있어 전부 스트리핑됐거나, 빈 블록인 namespace → strip
-        if (new_body.isNone()) return .none;
-        const body_node = self.ast.getNode(new_body);
-        if ((body_node.tag == .block_statement or body_node.tag == .ts_module_block) and body_node.data.list.len == 0) {
-            return .none;
-        }
-        return self.ast.addNode(.{
-            .tag = .ts_module_declaration,
-            .span = node.span,
-            .data = .{ .binary = .{ .left = new_name, .right = new_body, .flags = 0 } },
-        });
-    }
+    pub const visitImportEqualsDeclaration = namespace_mod.visitImportEqualsDeclaration;
+    pub const visitExportAssignment = namespace_mod.visitExportAssignment;
+    pub const visitNamespaceDeclaration = namespace_mod.visitNamespaceDeclaration;
 
     // ================================================================
     // 헬퍼

--- a/src/transformer/transformer/namespace.zig
+++ b/src/transformer/transformer/namespace.zig
@@ -1,0 +1,77 @@
+//! TypeScript namespace and module-assignment helpers for Transformer.
+
+const ast_mod = @import("../../parser/ast.zig");
+const Node = ast_mod.Node;
+const NodeIndex = ast_mod.NodeIndex;
+const VariableDeclarationKind = ast_mod.VariableDeclarationKind;
+const es_helpers = @import("../es_helpers.zig");
+const transformer_mod = @import("../transformer.zig");
+const Transformer = transformer_mod.Transformer;
+const Error = Transformer.Error;
+
+/// import x = require('y') -> const x = require('y')
+/// import x = Namespace.Member -> const x = Namespace.Member
+pub fn visitImportEqualsDeclaration(self: *Transformer, node: Node) Error!NodeIndex {
+    const name_idx = node.data.binary.left;
+    const value_idx = node.data.binary.right;
+    const new_name = try self.visitNode(name_idx);
+    const new_value = try self.visitNode(value_idx);
+
+    const decl_extra = try self.ast.addExtras(&.{
+        @intFromEnum(new_name),
+        @intFromEnum(NodeIndex.none),
+        @intFromEnum(new_value),
+    });
+    const declarator = try self.ast.addNode(.{
+        .tag = .variable_declarator,
+        .span = node.span,
+        .data = .{ .extra = decl_extra },
+    });
+
+    const scratch_top = self.scratch.items.len;
+    defer self.scratch.shrinkRetainingCapacity(scratch_top);
+
+    try self.scratch.append(self.allocator, declarator);
+    const list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+    const var_extra = try self.ast.addExtras(&.{ @intFromEnum(VariableDeclarationKind.@"const"), list.start, list.len });
+    return self.ast.addNode(.{
+        .tag = .variable_declaration,
+        .span = node.span,
+        .data = .{ .extra = var_extra },
+    });
+}
+
+/// `export = expr;` -> `module.exports = expr;`
+/// ESM output context can still fail at runtime with `module is not defined`
+/// (tsc TS1203 equivalent); policy is handled outside this syntax rewrite.
+pub fn visitExportAssignment(self: *Transformer, node: Node) Error!NodeIndex {
+    const new_expr = try self.visitNode(node.data.unary.operand);
+    if (new_expr.isNone()) return .none;
+
+    const module_id = try es_helpers.makeIdentifierRef(self, "module");
+    const exports_id = try es_helpers.makeIdentifierRef(self, "exports");
+    const member = try es_helpers.makeStaticMember(self, module_id, exports_id, node.span);
+    return es_helpers.makeAssignStmt(self, member, new_expr, node.span, 0);
+}
+
+/// ts_module_declaration: binary = { left=name, right=body_or_inner, flags }
+/// flags=1: ambient module declaration (`declare module "*.css" { ... }`) -> strip.
+/// flags=0: namespace with runtime output; codegen emits the IIFE.
+pub fn visitNamespaceDeclaration(self: *Transformer, node: Node) Error!NodeIndex {
+    if (node.data.binary.flags == 1) return .none;
+
+    const new_name = try self.visitNode(node.data.binary.left);
+    const new_body = try self.visitNode(node.data.binary.right);
+    if (new_body.isNone()) return .none;
+
+    const body_node = self.ast.getNode(new_body);
+    if ((body_node.tag == .block_statement or body_node.tag == .ts_module_block) and body_node.data.list.len == 0) {
+        return .none;
+    }
+
+    return self.ast.addNode(.{
+        .tag = .ts_module_declaration,
+        .span = node.span,
+        .data = .{ .binary = .{ .left = new_name, .right = new_body, .flags = 0 } },
+    });
+}


### PR DESCRIPTION
## 요약
- `src/transformer/transformer.zig`의 TS namespace/import-equals/export-assignment 변환을 `transformer/namespace.zig`로 분리
- 기존 `flow.zig`, `import_export.zig`처럼 `pub fn` helper + `pub const` re-export 패턴 유지
- `transformer.zig`: 4029줄 → 3966줄, 신규 `namespace.zig`: 77줄

## 진행 중 판단 변경
- 함수/메서드 visitor는 `this/arguments`, `new.target`, parameter property, plugin dispatch, temp-var hoist 상태가 얽혀 있어 이번 PR 범위로는 과하다고 판단했습니다.
- 그래서 독립성이 높은 TS namespace 계열 변환만 먼저 분리했습니다.

## 검증
- `zig fmt src/transformer/transformer.zig src/transformer/transformer/namespace.zig`
- `zig build test`
- `zig build napi`
- `git diff --check`
- pre-push hook (`zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`)
