### PR TITLE
feat(ts): enable isolatedDeclarations on tsconfig.base.json

### DIFF
--- a/docs/IDE.md
+++ b/docs/IDE.md
@@ -63,6 +63,22 @@ VSCode 의 `typescript.tsserver.experimental.useTsgo: true` 옵션은 Go 로 재
 
 incremental cache (`<pkg>/.tsbuildinfo`) 가 활성화되어 있어 두 번째 호출부터 ~50ms.
 
+## Contributor 주의: `isolatedDeclarations`
+
+PR #2819 부터 `tsconfig.base.json` 에 `isolatedDeclarations: true` 활성화. **새로 추가하는 export 는 명시 타입 필수**:
+
+```ts
+// ❌ 빌드 깨짐 (TS9008/TS9010/TS9017)
+export function helper() { return 42; }
+export const opts = { foo: 'bar' };
+
+// ✅ 명시 타입
+export function helper(): number { return 42; }
+export const opts: { foo: string } = { foo: 'bar' };
+```
+
+이유: `isolatedDeclarations` 가 켜지면 외부 transformer (oxc/swc/bun) 가 TS inference 없이 dts 단독 emit 가능 → emit 가속 + future migration 옵션. 단 export 의 모든 타입을 source 가 직접 명시해야 함.
+
 ## 관련 PR
 
 - TS Project References Phase 1 (#2805): server/core composite

--- a/packages/core/src/runtime-polyfills.ts
+++ b/packages/core/src/runtime-polyfills.ts
@@ -110,7 +110,7 @@ export const __runtimePolyfillTestHooks = {
 
 /** @internal — Zig 매핑 테이블과의 sync 검증용. 외부 사용자는 사용 금지. */
 export const __runtimePolyfillTestInternals = {
-  get featureModules(): typeof RUNTIME_POLYFILL_FEATURE_MODULES {
+  get featureModules(): Readonly<typeof RUNTIME_POLYFILL_FEATURE_MODULES> {
     return RUNTIME_POLYFILL_FEATURE_MODULES;
   },
 };

--- a/packages/core/src/runtime-polyfills.ts
+++ b/packages/core/src/runtime-polyfills.ts
@@ -96,12 +96,12 @@ function getRuntimeRequire(): RuntimeRequire {
 
 /** @internal */
 export const __runtimePolyfillTestHooks = {
-  reset() {
+  reset(): void {
     coreJsCompatCache = undefined;
     coreJsVersionCache = undefined;
     runtimeRequireOverride = null;
   },
-  setRuntimeRequire(runtimeRequire: RuntimeRequire | null) {
+  setRuntimeRequire(runtimeRequire: RuntimeRequire | null): void {
     coreJsCompatCache = undefined;
     coreJsVersionCache = undefined;
     runtimeRequireOverride = runtimeRequire;
@@ -110,7 +110,7 @@ export const __runtimePolyfillTestHooks = {
 
 /** @internal — Zig 매핑 테이블과의 sync 검증용. 외부 사용자는 사용 금지. */
 export const __runtimePolyfillTestInternals = {
-  get featureModules() {
+  get featureModules(): typeof RUNTIME_POLYFILL_FEATURE_MODULES {
     return RUNTIME_POLYFILL_FEATURE_MODULES;
   },
 };

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -98,7 +98,7 @@ export function defineWorkspace<T extends WorkspaceInput>(input: T): T {
  * workspace 파일 자동 탐색 우선순위. `CONFIG_EXT_PRIORITY` 와 동일 정책 — 동일 디렉토리에
  * 다중 확장자 존재 시 첫 매치를 반환한다 (`.ts` > `.mts` > `.cts` > `.mjs` > `.js` > `.cjs` > `.json`).
  */
-export const WORKSPACE_EXT_PRIORITY = CONFIG_EXT_PRIORITY_LOCAL;
+export const WORKSPACE_EXT_PRIORITY: typeof CONFIG_EXT_PRIORITY_LOCAL = CONFIG_EXT_PRIORITY_LOCAL;
 
 /**
  * `cwd` 에서 `zntc.workspace.{ext}` 를 자동 탐색.

--- a/packages/react-native/src/dev-server/middleware/dev-middleware.ts
+++ b/packages/react-native/src/dev-server/middleware/dev-middleware.ts
@@ -93,7 +93,7 @@ export async function loadDevMiddleware(
   }
 }
 
-export const DEV_MIDDLEWARE_PATH_PREFIXES = [
+export const DEV_MIDDLEWARE_PATH_PREFIXES: string[] = [
   '/json',
   '/open-debugger',
   '/debugger-frontend',

--- a/packages/react-native/src/plugins/babel.ts
+++ b/packages/react-native/src/plugins/babel.ts
@@ -34,7 +34,7 @@ type BabelEntry = string | [string, Record<string, unknown>?, string?];
  * 되면 ZNTC 가 이미 처리). 사용자 babel.config.js 의 plugin 중 *이 list 외* 만
  * Babel 로 forward.
  */
-export const ZNTC_NATIVE_PLUGIN_PATTERNS = [
+export const ZNTC_NATIVE_PLUGIN_PATTERNS: string[] = [
   'optional-chaining',
   'nullish-coalescing',
   'class-properties',

--- a/packages/react-native/src/plugins/internal.ts
+++ b/packages/react-native/src/plugins/internal.ts
@@ -5,7 +5,7 @@
 import { createRequire } from 'node:module';
 
 /** ZNTC CLI 의 createRequire — fallback / require 의 모든 plugin 공용. */
-export const requireFromCli = createRequire(import.meta.url);
+export const requireFromCli: NodeRequire = createRequire(import.meta.url);
 
 /** Babel @babel/core 의 transformSync 표면. babel.ts / codegen.ts 가 lazy load 후 사용. */
 export interface BabelInstance {

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -139,7 +139,7 @@ export interface RnBundleInput {
 const DEFAULT_SOURCE_EXTS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.json'];
 // Metro 호환 + RN 흔한 폰트/이미지 — bungae DEFAULT_RESOLVER.assetExts 와 동일.
 // caller 가 `extra.assetExts` 로 override 하면 이 list 무시.
-export const DEFAULT_ASSET_EXTS = [
+export const DEFAULT_ASSET_EXTS: string[] = [
   // 이미지
   '.bmp',
   '.gif',

--- a/packages/server/src/protocol.ts
+++ b/packages/server/src/protocol.ts
@@ -3,13 +3,13 @@
 // `hmr:update-start` / `hmr:update` / `hmr:update-done` / `hmr:reload` / `hmr:error` /
 // `log` 그대로 (RN 런타임의 HMRClient 가 소비). web 의 HMR_MSG 와 직교 (#2540).
 
-export const HMR_MSG = Object.freeze({
+export const HMR_MSG = {
   Connected: 'connected',
   CssUpdate: 'css-update',
   ClearError: 'clear-error',
   Error: 'error',
   FullReload: 'full-reload',
-} as const);
+} as const;
 
 export type HmrMessageType = (typeof HMR_MSG)[keyof typeof HMR_MSG];
 
@@ -80,14 +80,14 @@ export function normalizeHmrErrors(errors: readonly unknown[] | unknown): HmrErr
 // 의 onmessage 분기 키. revisionId 기반 delta 는 caller (번개 server) 가 관리,
 // adapter 는 메시지 union 만 통과.
 
-export const HMR_RN_MSG = Object.freeze({
+export const HMR_RN_MSG = {
   UpdateStart: 'hmr:update-start',
   Update: 'hmr:update',
   UpdateDone: 'hmr:update-done',
   Reload: 'hmr:reload',
   Error: 'hmr:error',
   Log: 'log',
-} as const);
+} as const;
 
 export type HmrRnMessageType = (typeof HMR_RN_MSG)[keyof typeof HMR_RN_MSG];
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,6 +11,7 @@
     "rewriteRelativeImportExtensions": true,
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "isolatedDeclarations": true
   }
 }


### PR DESCRIPTION
## Summary

TypeScript 5.5+ 의 `isolatedDeclarations` 활성화. composite 와 호환 — 명시 타입 강제로 emit 가속 + 외부 transformer (oxc/swc/bun) 가 dts 단독 emit 가능 (TS inference 안 거치고).

## 변경

`tsconfig.base.json` 에 `isolatedDeclarations: true` 추가 후 발견된 source error 10건 fix:

### packages/core

- `src/runtime-polyfills.ts`: 2 method (reset/setRuntimeRequire) return type `void` 명시 + `featureModules` getter return type 명시
- `src/workspace.ts`:101: `WORKSPACE_EXT_PRIORITY` 명시 type

### packages/server

- `src/protocol.ts`: `HMR_MSG` / `HMR_RN_MSG` 의 `Object.freeze({...} as const)` → `as const` 만 (TypeScript level immutability 충분, runtime freeze 제거 — consumer 가 mutate 안 함)

### packages/react-native

- `src/dev-server/middleware/dev-middleware.ts`:96 `DEV_MIDDLEWARE_PATH_PREFIXES`
- `src/plugins/babel.ts`:37 `ZNTC_NATIVE_PLUGIN_PATTERNS`
- `src/preset.ts`:142 `DEFAULT_ASSET_EXTS`
  → array literal 명시 type (`string[]`). readonly 도 시도했으나 caller 가 mutable `string[]` 받아서 호환 X (callsite 변경 별도 작업)
- `src/plugins/internal.ts`:8 `requireFromCli: NodeRequire` 명시

## Test plan

- [x] `bun run build:dts:all` — cold ~676ms / no-change ~66ms (이전과 비슷)
- [x] `bun run pre-release-check` — 6 layer 모두 통과
- [x] `bun run fmt:check` clean

## 이득 (점진적)

- emit 정확성 강제 — export API 의 return type drift 차단
- 향후 dts bundler (api-extractor 등) / 외부 transformer 도입 시 즉시 호환

🤖 Generated with [Claude Code](https://claude.com/claude-code)