### PR TITLE
refactor: transformer filter 헬퍼 분리

### DIFF
--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -62,6 +62,8 @@ const tagged_template_mod = @import("transformer/tagged_template.zig");
 const flow_mod = @import("transformer/flow.zig");
 const define_mod = @import("transformer/define.zig");
 const namespace_mod = @import("transformer/namespace.zig");
+const drop_mod = @import("transformer/drop.zig");
+const type_only_mod = @import("transformer/type_only.zig");
 pub const ast_plugin_mod = @import("ast_plugin.zig");
 pub const AstTransformCtx = ast_plugin_mod.AstTransformCtx;
 pub const FunctionInfo = ast_plugin_mod.FunctionInfo;
@@ -955,19 +957,7 @@ pub const Transformer = struct {
         // --------------------------------------------------------
         // 2단계: --drop 처리
         // --------------------------------------------------------
-        if (self.options.drop_debugger and node.tag == .debugger_statement) {
-            return .none;
-        }
-        if (self.options.drop_console and node.tag == .expression_statement) {
-            if (self.isConsoleCall(node)) return .none;
-        }
-        if (self.options.drop_labels.len > 0 and node.tag == .labeled_statement) {
-            const label_node = self.ast.getNode(node.data.binary.left);
-            const label_name = self.ast.getText(label_node.span);
-            for (self.options.drop_labels) |drop| {
-                if (std.mem.eql(u8, label_name, drop)) return .none;
-            }
-        }
+        if (self.shouldDropNode(node)) return .none;
 
         // --------------------------------------------------------
         // 3단계: define 글로벌 치환
@@ -2360,36 +2350,8 @@ pub const Transformer = struct {
     // --drop 헬퍼
     // ================================================================
 
-    /// expression_statement가 console.* 호출인지 판별.
-    /// console.log(...), console.warn(...), console.error(...) 등.
-    fn isConsoleCall(self: *const Transformer, node: Node) bool {
-        // expression_statement → unary.operand가 call_expression이어야 함
-        const expr_idx = node.data.unary.operand;
-        if (expr_idx.isNone()) return false;
-        const expr = self.ast.getNode(expr_idx);
-        if (expr.tag != .call_expression) return false;
-
-        // call_expression: extra = [callee, args_start, args_len, flags]
-        const ce = expr.data.extra;
-        if (ce >= self.ast.extra_data.items.len) return false;
-        const callee_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[ce]);
-        if (callee_idx.isNone()) return false;
-        const callee = self.ast.getNode(callee_idx);
-
-        // callee가 static_member_expression (console.log)이어야 함
-        if (callee.tag != .static_member_expression) return false;
-
-        // left가 identifier "console" — extra = [object, property, flags]
-        const me = callee.data.extra;
-        if (me >= self.ast.extra_data.items.len) return false;
-        const obj_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me]);
-        if (obj_idx.isNone()) return false;
-        const obj = self.ast.getNode(obj_idx);
-        if (obj.tag != .identifier_reference) return false;
-
-        const obj_text = self.ast.getText(obj.data.string_ref);
-        return std.mem.eql(u8, obj_text, "console");
-    }
+    pub const shouldDropNode = drop_mod.shouldDropNode;
+    pub const isConsoleCall = drop_mod.isConsoleCall;
 
     // ================================================================
     // define 글로벌 치환
@@ -3766,117 +3728,7 @@ pub const Transformer = struct {
     // Comptime 헬퍼 — TS 타입 전용 노드 판별 (D042)
     // ================================================================
 
-    /// TS 타입 전용 노드인지 판별한다 (comptime 평가).
-    ///
-    /// 이 함수는 컴파일 타임에 평가되므로 런타임 비용이 0이다.
-    /// tag의 정수 값 범위로 판별하지 않고 명시적으로 나열한다.
-    /// 이유: enum 값 순서가 바뀌어도 안전하게 동작하도록.
-    pub fn isTypeOnlyNode(tag: Tag) bool {
-        return switch (tag) {
-            // TS 타입 키워드 (14개)
-            .ts_any_keyword,
-            .ts_string_keyword,
-            .ts_boolean_keyword,
-            .ts_number_keyword,
-            .ts_never_keyword,
-            .ts_unknown_keyword,
-            .ts_null_keyword,
-            .ts_undefined_keyword,
-            .ts_void_keyword,
-            .ts_symbol_keyword,
-            .ts_object_keyword,
-            .ts_bigint_keyword,
-            .ts_this_type,
-            .ts_intrinsic_keyword,
-            // TS 타입 구문 (23개)
-            .ts_type_reference,
-            .ts_qualified_name,
-            .ts_array_type,
-            .ts_tuple_type,
-            .ts_named_tuple_member,
-            .ts_union_type,
-            .ts_intersection_type,
-            .ts_conditional_type,
-            .ts_type_operator,
-            .ts_optional_type,
-            .ts_rest_type,
-            .ts_indexed_access_type,
-            .ts_type_literal,
-            .ts_function_type,
-            .ts_constructor_type,
-            .ts_mapped_type,
-            .ts_template_literal_type,
-            .ts_infer_type,
-            .ts_parenthesized_type,
-            .ts_import_type,
-            .ts_type_query,
-            .ts_literal_type,
-            .ts_type_predicate,
-            // TS/Flow 선언 (통째로 삭제) — isTypeOnlyDeclaration() 대상 포함
-            .ts_type_alias_declaration,
-            .ts_interface_declaration,
-            .ts_interface_body,
-            .ts_property_signature,
-            .ts_method_signature,
-            .ts_call_signature,
-            .ts_construct_signature,
-            .ts_index_signature,
-            .ts_getter_signature,
-            .ts_setter_signature,
-            // TS 타입 파라미터/this/implements
-            .ts_type_parameter,
-            .ts_type_parameter_declaration,
-            .ts_type_parameter_instantiation,
-            .ts_this_parameter,
-            .ts_class_implements,
-            // namespace는 런타임 코드 생성 → visitNode에서 별도 처리
-            // ts_namespace_export_declaration은 타입 전용 (export as namespace X)
-            .ts_namespace_export_declaration,
-            // TS import/export 특수 형태
-            // ts_import_equals_declaration / ts_export_assignment 는 런타임 코드 생성
-            // — visitNode 에서 별도 처리.
-            .ts_external_module_reference,
-            // enum은 타입 전용이 아님 — 런타임 코드 생성이 필요
-            // visitNode의 switch에서 별도 처리
-            // Flow 타입 (flow.zig에서 생성)
-            .flow_any_keyword,
-            .flow_string_keyword,
-            .flow_boolean_keyword,
-            .flow_number_keyword,
-            .flow_never_keyword,
-            .flow_null_keyword,
-            .flow_void_keyword,
-            .flow_symbol_keyword,
-            .flow_bigint_keyword,
-            .flow_this_type,
-            .flow_mixed_keyword,
-            .flow_empty_keyword,
-            .flow_type_reference,
-            .flow_qualified_name,
-            .flow_array_type,
-            .flow_tuple_type,
-            .flow_union_type,
-            .flow_intersection_type,
-            .flow_function_type,
-            .flow_parenthesized_type,
-            .flow_literal_type,
-            .flow_type_query,
-            .flow_nullable_type,
-            .flow_type_parameter,
-            .flow_type_parameter_declaration,
-            .flow_type_parameter_instantiation,
-            .flow_this_parameter,
-            .flow_type_alias_declaration,
-            .flow_opaque_type,
-            .flow_interface_declaration,
-            .flow_object_type,
-            .flow_exact_object_type,
-            .flow_property_signature,
-            .flow_object_spread_property,
-            => true,
-            else => false,
-        };
-    }
+    pub const isTypeOnlyNode = type_only_mod.isTypeOnlyNode;
 
     // ================================================================
     // React Fast Refresh — transformer/refresh.zig로 위임

--- a/src/transformer/transformer/drop.zig
+++ b/src/transformer/transformer/drop.zig
@@ -1,0 +1,55 @@
+//! Drop-option filters for Transformer.
+
+const std = @import("std");
+const ast_mod = @import("../../parser/ast.zig");
+const Node = ast_mod.Node;
+const NodeIndex = ast_mod.NodeIndex;
+const transformer_mod = @import("../transformer.zig");
+const Transformer = transformer_mod.Transformer;
+
+pub fn shouldDropNode(self: *const Transformer, node: Node) bool {
+    if (self.options.drop_debugger and node.tag == .debugger_statement) return true;
+    if (self.options.drop_console and node.tag == .expression_statement and isConsoleCall(self, node)) return true;
+    if (self.options.drop_labels.len > 0 and node.tag == .labeled_statement) return hasDroppedLabel(self, node);
+    return false;
+}
+
+/// expression_statement가 console.* 호출인지 판별.
+/// console.log(...), console.warn(...), console.error(...) 등.
+pub fn isConsoleCall(self: *const Transformer, node: Node) bool {
+    // expression_statement -> unary.operand가 call_expression이어야 함
+    const expr_idx = node.data.unary.operand;
+    if (expr_idx.isNone()) return false;
+    const expr = self.ast.getNode(expr_idx);
+    if (expr.tag != .call_expression) return false;
+
+    // call_expression: extra = [callee, args_start, args_len, flags]
+    const ce = expr.data.extra;
+    if (ce >= self.ast.extra_data.items.len) return false;
+    const callee_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[ce]);
+    if (callee_idx.isNone()) return false;
+    const callee = self.ast.getNode(callee_idx);
+
+    // callee가 static_member_expression (console.log)이어야 함
+    if (callee.tag != .static_member_expression) return false;
+
+    // left가 identifier "console" - extra = [object, property, flags]
+    const me = callee.data.extra;
+    if (me >= self.ast.extra_data.items.len) return false;
+    const obj_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me]);
+    if (obj_idx.isNone()) return false;
+    const obj = self.ast.getNode(obj_idx);
+    if (obj.tag != .identifier_reference) return false;
+
+    const obj_text = self.ast.getText(obj.data.string_ref);
+    return std.mem.eql(u8, obj_text, "console");
+}
+
+fn hasDroppedLabel(self: *const Transformer, node: Node) bool {
+    const label_node = self.ast.getNode(node.data.binary.left);
+    const label_name = self.ast.getText(label_node.span);
+    for (self.options.drop_labels) |drop| {
+        if (std.mem.eql(u8, label_name, drop)) return true;
+    }
+    return false;
+}

--- a/src/transformer/transformer/type_only.zig
+++ b/src/transformer/transformer/type_only.zig
@@ -1,0 +1,114 @@
+//! Type-only syntax classification for Transformer.
+
+const Tag = @import("../../parser/ast.zig").Node.Tag;
+
+/// TS/Flow 타입 전용 노드인지 판별한다.
+///
+/// tag의 정수 값 범위로 판별하지 않고 명시적으로 나열한다.
+/// 이유: enum 값 순서가 바뀌어도 안전하게 동작하도록.
+pub fn isTypeOnlyNode(tag: Tag) bool {
+    return switch (tag) {
+        // TS 타입 키워드 (14개)
+        .ts_any_keyword,
+        .ts_string_keyword,
+        .ts_boolean_keyword,
+        .ts_number_keyword,
+        .ts_never_keyword,
+        .ts_unknown_keyword,
+        .ts_null_keyword,
+        .ts_undefined_keyword,
+        .ts_void_keyword,
+        .ts_symbol_keyword,
+        .ts_object_keyword,
+        .ts_bigint_keyword,
+        .ts_this_type,
+        .ts_intrinsic_keyword,
+        // TS 타입 구문 (23개)
+        .ts_type_reference,
+        .ts_qualified_name,
+        .ts_array_type,
+        .ts_tuple_type,
+        .ts_named_tuple_member,
+        .ts_union_type,
+        .ts_intersection_type,
+        .ts_conditional_type,
+        .ts_type_operator,
+        .ts_optional_type,
+        .ts_rest_type,
+        .ts_indexed_access_type,
+        .ts_type_literal,
+        .ts_function_type,
+        .ts_constructor_type,
+        .ts_mapped_type,
+        .ts_template_literal_type,
+        .ts_infer_type,
+        .ts_parenthesized_type,
+        .ts_import_type,
+        .ts_type_query,
+        .ts_literal_type,
+        .ts_type_predicate,
+        // TS/Flow 선언 (통째로 삭제) - isTypeOnlyDeclaration() 대상 포함
+        .ts_type_alias_declaration,
+        .ts_interface_declaration,
+        .ts_interface_body,
+        .ts_property_signature,
+        .ts_method_signature,
+        .ts_call_signature,
+        .ts_construct_signature,
+        .ts_index_signature,
+        .ts_getter_signature,
+        .ts_setter_signature,
+        // TS 타입 파라미터/this/implements
+        .ts_type_parameter,
+        .ts_type_parameter_declaration,
+        .ts_type_parameter_instantiation,
+        .ts_this_parameter,
+        .ts_class_implements,
+        // namespace는 런타임 코드 생성 -> visitNode에서 별도 처리
+        // ts_namespace_export_declaration은 타입 전용 (export as namespace X)
+        .ts_namespace_export_declaration,
+        // TS import/export 특수 형태
+        // ts_import_equals_declaration / ts_export_assignment 는 런타임 코드 생성
+        // - visitNode 에서 별도 처리.
+        .ts_external_module_reference,
+        // enum은 타입 전용이 아님 - 런타임 코드 생성이 필요
+        // visitNode의 switch에서 별도 처리
+        // Flow 타입 (flow.zig에서 생성)
+        .flow_any_keyword,
+        .flow_string_keyword,
+        .flow_boolean_keyword,
+        .flow_number_keyword,
+        .flow_never_keyword,
+        .flow_null_keyword,
+        .flow_void_keyword,
+        .flow_symbol_keyword,
+        .flow_bigint_keyword,
+        .flow_this_type,
+        .flow_mixed_keyword,
+        .flow_empty_keyword,
+        .flow_type_reference,
+        .flow_qualified_name,
+        .flow_array_type,
+        .flow_tuple_type,
+        .flow_union_type,
+        .flow_intersection_type,
+        .flow_function_type,
+        .flow_parenthesized_type,
+        .flow_literal_type,
+        .flow_type_query,
+        .flow_nullable_type,
+        .flow_type_parameter,
+        .flow_type_parameter_declaration,
+        .flow_type_parameter_instantiation,
+        .flow_this_parameter,
+        .flow_type_alias_declaration,
+        .flow_opaque_type,
+        .flow_interface_declaration,
+        .flow_object_type,
+        .flow_exact_object_type,
+        .flow_property_signature,
+        .flow_object_spread_property,
+        => true,
+        else => false,
+    };
+}


### PR DESCRIPTION
## 요약
- transformer의 `--drop` 처리 조건을 `transformer/drop.zig`로 분리했습니다.
- TS/Flow 타입 전용 노드 판별을 `transformer/type_only.zig`로 분리했습니다.
- `visitNodeInner` 초입은 순수 필터 호출만 남겨, 실제 visitor 본문과 상태 추적 로직은 그대로 유지했습니다.

## 범위 조정
- 함수/메서드 visitor는 `this`, `arguments`, `new.target`, parameter property, plugin dispatch, temp-var hoisting이 함께 얽혀 있어 이번 PR에서는 분리하지 않았습니다.
- 대신 독립적인 boolean 필터 계층만 먼저 잘라서 transformer 본문을 3818라인까지 줄였습니다.

## 검증
- `zig fmt src/transformer/transformer.zig src/transformer/transformer/drop.zig src/transformer/transformer/type_only.zig`
- `zig build`
- `zig build test`
- `zig build napi`
- `git diff --check`
- pre-push hook: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`