### PR TITLE
refactor: napi tsconfig cache 헬퍼 분리

### DIFF
--- a/packages/core/src/napi/tsconfig_cache.zig
+++ b/packages/core/src/napi/tsconfig_cache.zig
@@ -1,0 +1,88 @@
+//! TsconfigCache NAPI handle helpers.
+
+const std = @import("std");
+const zntc_lib = @import("zntc_lib");
+const common = @import("common.zig");
+const c = common.c;
+
+const TsconfigCache = zntc_lib.tsconfig_cache.TsconfigCache;
+const native_alloc = std.heap.c_allocator;
+const throwError = common.throwError;
+const unwrapNapi = common.unwrapNapi;
+
+/// `napi_wrap` finalizer — JS handle GC 시 native cache deinit.
+fn tsconfigCacheFinalize(_: c.napi_env, finalize_data: ?*anyopaque, _: ?*anyopaque) callconv(.c) void {
+    if (finalize_data) |data| {
+        const cache: *TsconfigCache = @ptrCast(@alignCast(data));
+        cache.deinit();
+    }
+}
+
+/// `cache.clear()` — 모든 entry 와 내부 string 메모리 회수.
+fn napiTsconfigCacheClear(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+    var argc: usize = 0;
+    var this: c.napi_value = undefined;
+    if (c.napi_get_cb_info(env, info, &argc, null, &this, null) != c.napi_ok) {
+        return throwError(env, "failed to get this");
+    }
+    const cache = unwrapNapi(TsconfigCache, env, this) orelse return throwError(env, "TsconfigCache: unwrap failed");
+    cache.clear();
+    var js_undef: c.napi_value = undefined;
+    _ = c.napi_get_undefined(env, &js_undef);
+    return js_undef;
+}
+
+/// `cache.size()` — 현재 캐시된 entry 수 (number).
+fn napiTsconfigCacheSize(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+    var argc: usize = 0;
+    var this: c.napi_value = undefined;
+    if (c.napi_get_cb_info(env, info, &argc, null, &this, null) != c.napi_ok) {
+        return throwError(env, "failed to get this");
+    }
+    const cache = unwrapNapi(TsconfigCache, env, this) orelse return throwError(env, "TsconfigCache: unwrap failed");
+    var js_n: c.napi_value = undefined;
+    _ = c.napi_create_uint32(env, @intCast(cache.size()), &js_n);
+    return js_n;
+}
+
+/// `createTsconfigCache()` → handle 객체 ({ clear, size }).
+/// JS 측 `class TsconfigCache` 가 본 handle 을 wrapping 해서 사용. NAPI 가 finalizer 로
+/// GC 시 자동 cleanup — 사용자가 명시 dispose 안 해도 메모리 안전.
+pub fn napiCreateTsconfigCache(env: c.napi_env, _: c.napi_callback_info) callconv(.c) c.napi_value {
+    const cache = TsconfigCache.init(native_alloc) catch {
+        return throwError(env, "TsconfigCache: OOM");
+    };
+
+    var js_handle: c.napi_value = undefined;
+    if (c.napi_create_object(env, &js_handle) != c.napi_ok) {
+        cache.deinit();
+        return throwError(env, "failed to create handle object");
+    }
+
+    if (c.napi_wrap(env, js_handle, @ptrCast(cache), tsconfigCacheFinalize, null, null) != c.napi_ok) {
+        cache.deinit();
+        return throwError(env, "failed to wrap TsconfigCache");
+    }
+
+    var clear_fn: c.napi_value = undefined;
+    _ = c.napi_create_function(env, "clear", "clear".len, napiTsconfigCacheClear, null, &clear_fn);
+    _ = c.napi_set_named_property(env, js_handle, "clear", clear_fn);
+
+    var size_fn: c.napi_value = undefined;
+    _ = c.napi_create_function(env, "size", "size".len, napiTsconfigCacheSize, null, &size_fn);
+    _ = c.napi_set_named_property(env, js_handle, "size", size_fn);
+
+    return js_handle;
+}
+
+/// 옵셔널 인자 (transpile 4번째) 가 TsconfigCache handle 이면 internal pointer 반환.
+/// undefined / null / wrap 실패 시 null. caller 가 null-check 으로 fallback (직접 walk).
+///
+/// **Lifetime**: 반환 pointer 는 _현재 sync NAPI 호출_ 동안만 유효. JS handle 이 caller
+/// stack 에 잡혀있어 GC finalizer 가 실행되지 않음을 전제. 호출 종료 후 보관 금지.
+pub fn unwrapTsconfigCache(env: c.napi_env, value: c.napi_value) ?*TsconfigCache {
+    var value_type: c.napi_valuetype = undefined;
+    if (c.napi_typeof(env, value, &value_type) != c.napi_ok) return null;
+    if (value_type != c.napi_object) return null;
+    return unwrapNapi(TsconfigCache, env, value);
+}

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -16,7 +16,6 @@ const zntc_lib = @import("zntc_lib");
 pub const panic = zntc_lib.crash_handler.panic;
 const transpile_mod = zntc_lib.transpile;
 const Scanner = zntc_lib.lexer.Scanner;
-const TsconfigCache = zntc_lib.tsconfig_cache.TsconfigCache;
 const rich_diagnostic = zntc_lib.rich_diagnostic;
 const diagnostic_renderer = zntc_lib.diagnostic_renderer;
 const napi_render_opts: diagnostic_renderer.RenderOptions = .{ .color = false, .unicode = true };
@@ -29,6 +28,7 @@ const BundleOptions = bundler_mod.BundleOptions;
 const transformer_mod = zntc_lib.transformer.transformer;
 const common = @import("napi/common.zig");
 const options_mod = @import("napi/options.zig");
+const tsconfig_cache_mod = @import("napi/tsconfig_cache.zig");
 const c = common.c;
 
 const native_alloc = std.heap.c_allocator;
@@ -36,7 +36,6 @@ const native_alloc = std.heap.c_allocator;
 // ─── NAPI 헬퍼 ───
 
 const throwError = common.throwError;
-const unwrapNapi = common.unwrapNapi;
 const getStringArg = common.getStringArg;
 const getNamedProperty = common.getNamedProperty;
 const getObjectBool = common.getObjectBool;
@@ -54,85 +53,6 @@ const getAutoLabelMode = options_mod.getAutoLabelMode;
 const parseLogFilterOptions = options_mod.parseLogFilterOptions;
 const parseBuildOptions = options_mod.parseBuildOptions;
 const freeOptionsTypedSlices = options_mod.freeOptionsTypedSlices;
-
-// ─── TsconfigCache (#2367) ───
-
-/// `napi_wrap` finalizer — JS handle GC 시 native cache deinit.
-fn tsconfigCacheFinalize(_: c.napi_env, finalize_data: ?*anyopaque, _: ?*anyopaque) callconv(.c) void {
-    if (finalize_data) |data| {
-        const cache: *TsconfigCache = @ptrCast(@alignCast(data));
-        cache.deinit();
-    }
-}
-
-/// `cache.clear()` — 모든 entry 와 내부 string 메모리 회수.
-fn napiTsconfigCacheClear(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
-    var argc: usize = 0;
-    var this: c.napi_value = undefined;
-    if (c.napi_get_cb_info(env, info, &argc, null, &this, null) != c.napi_ok) {
-        return throwError(env, "failed to get this");
-    }
-    const cache = unwrapNapi(TsconfigCache, env, this) orelse return throwError(env, "TsconfigCache: unwrap failed");
-    cache.clear();
-    var js_undef: c.napi_value = undefined;
-    _ = c.napi_get_undefined(env, &js_undef);
-    return js_undef;
-}
-
-/// `cache.size()` — 현재 캐시된 entry 수 (number).
-fn napiTsconfigCacheSize(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
-    var argc: usize = 0;
-    var this: c.napi_value = undefined;
-    if (c.napi_get_cb_info(env, info, &argc, null, &this, null) != c.napi_ok) {
-        return throwError(env, "failed to get this");
-    }
-    const cache = unwrapNapi(TsconfigCache, env, this) orelse return throwError(env, "TsconfigCache: unwrap failed");
-    var js_n: c.napi_value = undefined;
-    _ = c.napi_create_uint32(env, @intCast(cache.size()), &js_n);
-    return js_n;
-}
-
-/// `createTsconfigCache()` → handle 객체 ({ clear, size }).
-/// JS 측 `class TsconfigCache` 가 본 handle 을 wrapping 해서 사용. NAPI 가 finalizer 로
-/// GC 시 자동 cleanup — 사용자가 명시 dispose 안 해도 메모리 안전.
-fn napiCreateTsconfigCache(env: c.napi_env, _: c.napi_callback_info) callconv(.c) c.napi_value {
-    const cache = TsconfigCache.init(native_alloc) catch {
-        return throwError(env, "TsconfigCache: OOM");
-    };
-
-    var js_handle: c.napi_value = undefined;
-    if (c.napi_create_object(env, &js_handle) != c.napi_ok) {
-        cache.deinit();
-        return throwError(env, "failed to create handle object");
-    }
-
-    if (c.napi_wrap(env, js_handle, @ptrCast(cache), tsconfigCacheFinalize, null, null) != c.napi_ok) {
-        cache.deinit();
-        return throwError(env, "failed to wrap TsconfigCache");
-    }
-
-    var clear_fn: c.napi_value = undefined;
-    _ = c.napi_create_function(env, "clear", "clear".len, napiTsconfigCacheClear, null, &clear_fn);
-    _ = c.napi_set_named_property(env, js_handle, "clear", clear_fn);
-
-    var size_fn: c.napi_value = undefined;
-    _ = c.napi_create_function(env, "size", "size".len, napiTsconfigCacheSize, null, &size_fn);
-    _ = c.napi_set_named_property(env, js_handle, "size", size_fn);
-
-    return js_handle;
-}
-
-/// 옵셔널 인자 (transpile 4번째) 가 TsconfigCache handle 이면 internal pointer 반환.
-/// undefined / null / wrap 실패 시 null. caller 가 null-check 으로 fallback (직접 walk).
-///
-/// **Lifetime**: 반환 pointer 는 _현재 sync NAPI 호출_ 동안만 유효. JS handle 이 caller
-/// stack 에 잡혀있어 GC finalizer 가 실행되지 않음을 전제. 호출 종료 후 보관 금지.
-fn unwrapTsconfigCache(env: c.napi_env, value: c.napi_value) ?*TsconfigCache {
-    var value_type: c.napi_valuetype = undefined;
-    if (c.napi_typeof(env, value, &value_type) != c.napi_ok) return null;
-    if (value_type != c.napi_object) return null;
-    return unwrapNapi(TsconfigCache, env, value);
-}
 
 // ─── transpile 함수 ───
 
@@ -183,7 +103,7 @@ fn napiTranspile(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.nap
     // cache 만 스킵 — 결과는 여전히 정확.
     const has_raw = std.mem.indexOf(u8, opts_json, "\"tsconfigRaw\"") != null;
     if (argc > 3 and options.tsconfig_path == null and !has_raw) {
-        if (unwrapTsconfigCache(env, argv[3])) |cache| {
+        if (tsconfig_cache_mod.unwrapTsconfigCache(env, argv[3])) |cache| {
             if (cache.findTsconfigPath(filename)) |path| {
                 options.tsconfig_path = path;
             }
@@ -1058,7 +978,7 @@ export fn napi_register_module_v1(env: c.napi_env, exports: c.napi_value) c.napi
 
     // TsconfigCache (#2367)
     var ctc_fn: c.napi_value = undefined;
-    _ = c.napi_create_function(env, "createTsconfigCache", "createTsconfigCache".len, napiCreateTsconfigCache, null, &ctc_fn);
+    _ = c.napi_create_function(env, "createTsconfigCache", "createTsconfigCache".len, tsconfig_cache_mod.napiCreateTsconfigCache, null, &ctc_fn);
     _ = c.napi_set_named_property(env, exports, "createTsconfigCache", ctc_fn);
 
     var build_sync_fn: c.napi_value = undefined;


### PR DESCRIPTION
## 요약
- `napi_entry.zig`에 있던 TsconfigCache NAPI handle 콜백을 `packages/core/src/napi/tsconfig_cache.zig`로 분리했습니다.
- entry 파일에는 `transpile`의 cache unwrap 호출과 `createTsconfigCache` 등록만 남겼습니다.
- 진행 중 점검 결과, `codegen` namespace 분리는 내부 출력 메서드 공개 범위를 넓혀야 해서 이번 PR에서는 보류하고 더 보수적인 NAPI 분리로 범위를 조정했습니다.

## Zig 관례 점검
- 새 파일은 기존 `napi/common.zig`, `napi/options.zig`, `napi/watch.zig`와 같은 기능별 NAPI helper 모듈 형태로 두었습니다.
- C callback 시그니처와 finalizer/unwrap lifetime 정책은 기존 구현 그대로 유지했습니다.

## 검증
- `zig fmt packages/core/src/napi_entry.zig packages/core/src/napi/tsconfig_cache.zig`
- `zig build`
- `zig build test`
- `zig build napi`
- `bun test --cwd tests/integration tests/tsconfig-cache.test.ts --timeout 10000`
- `node --test packages/core/napi.test.mjs`
- `git diff --check`
- pre-push hook: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`