### PR TITLE
fix(transformer): isFunctionBoundary 에 method_definition 추가

### DIFF
--- a/src/transformer/es2015_block_scoping.zig
+++ b/src/transformer/es2015_block_scoping.zig
@@ -44,11 +44,16 @@ pub inline fn lowerKind(_: VariableDeclarationKind) VariableDeclarationKind {
 
 /// closure 경계 — 안의 capture / await / yield 등은 우리 책임이 아니라 해당 함수 책임.
 /// hasCapturedClosure / hasAwaitExpression 양쪽이 동일 set 사용 → 단일 정의로 drift 차단.
+///
+/// `method_definition` 도 포함 — class/object literal 의 method body 는 자체 함수 scope.
+/// 누락 시 `for (let i ...) { class C { m() { return i; } } }` 같은 패턴에서 m() 안의
+/// `i` 를 capture 가 아닌 직접 reference 로 오인 → per-iteration fresh binding 변환 누락.
 inline fn isFunctionBoundary(tag: Tag) bool {
     return tag == .function_expression or
         tag == .function_declaration or
         tag == .arrow_function_expression or
-        tag == .function;
+        tag == .function or
+        tag == .method_definition;
 }
 
 pub fn ES2015BlockScoping(comptime Transformer: type) type {

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1602,6 +1602,55 @@ test "#1797 native for-of + block scoping: body 에 await 없으면 sync _loop" 
     try std.testing.expect(std.mem.indexOf(u8, code, "await _loop") == null);
 }
 
+test "#1797 native for-of + block scoping: class method capture → _loop 변환" {
+    // method_definition 도 closure boundary. body 안의 lexical reference 는
+    // capture 로 인식되어야 — per-iteration fresh binding 보존.
+    const source =
+        \\for (let i = 0; i < n; i++) {
+        \\  class C {
+        \\    m() { return i; }
+        \\  }
+        \\  arr.push(C);
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    // class method m() 안의 i 가 capture 로 인식되어 _loop wrap
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+}
+
+test "#1797 native for-of + block scoping: class method 안 await → sync _loop (method 책임)" {
+    // class method 도 closure boundary — 안의 await 는 method 의 async-ness
+    // 책임. enclosing for-of 의 _loop 는 sync 여야 함.
+    const source =
+        \\function f(items) {
+        \\  for (let key of items) {
+        \\    class C {
+        \\      async m() { await use(key); }
+        \\    }
+        \\    arr.push(C);
+        \\  }
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .for_of = false, .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+    try std.testing.expect(std.mem.indexOf(u8, code, "_loop") != null);
+    // class method 안의 await — _loop 는 sync 여야
+    try std.testing.expect(std.mem.indexOf(u8, code, "await _loop") == null);
+}
+
 test "#1797 native for-of + block scoping: closure 안 await 는 무시 (그 closure 책임)" {
     const source =
         \\async function f(items) {


### PR DESCRIPTION
## Summary

PR #2796 / #2800 의 cumulative review (이전 세션에서 생략한 simplify 결과) 에서 발견된 must 회귀.

`isFunctionBoundary` 의 closure boundary tag set 에 **`method_definition` 누락**. 영향:

```js
for (let i = 0; i < n; i++) {
  class C { m() { return i; } }   // m() 안의 i 가 capture 인데 helper 가 누락
  arr.push(C);
}
```

- `hasCapturedClosure` 가 method body 안의 lexical reference 를 `in_closure=false` 로 분류 → "capture 아님" 으로 false-negative
- 결과: per-iteration fresh binding 변환 누락 → 모든 method 인스턴스가 마지막 값 공유 (PR #2793 의 원래 버그 패턴 재발)

## 수정

`packages/.../es2015_block_scoping.zig` 의 `isFunctionBoundary` 에 `.method_definition` 추가. helper 가 `hasCapturedClosure` / `hasAwaitExpression` 양쪽에서 사용되므로 한 줄 fix 로 둘 다 정정.

## 회귀 테스트 2건

| 시나리오 | expectation |
|---|---|
| class method 안 capture (`for (let i ...) class C { m() { return i; } }`) | `_loop` wrap |
| class method 안 await (`for (let key ...) class C { async m() { await use(key); } }`) | sync `_loop` (method 책임, enclosing 영향 X) |

## Test plan

- [x] `zig build test` EXIT=0
- [x] `zig build test -Doptimize=ReleaseFast` EXIT=0
- [x] 기존 16+ for-of/async 회귀 테스트 모두 통과 + 2 new 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)