### PR TITLE
refactor: napi benchmark 콜백 분리

### DIFF
--- a/packages/core/src/napi/benchmark.zig
+++ b/packages/core/src/napi/benchmark.zig
@@ -1,0 +1,125 @@
+//! Benchmark NAPI callback.
+
+const std = @import("std");
+const zntc_lib = @import("zntc_lib");
+const common = @import("common.zig");
+const c = common.c;
+
+const transpile_mod = zntc_lib.transpile;
+const profile_mod = zntc_lib.profile;
+const bench_mod = zntc_lib.bench;
+
+const native_alloc = std.heap.c_allocator;
+const throwError = common.throwError;
+const getObjectString = common.getObjectString;
+const getObjectStringArray = common.getObjectStringArray;
+const getObjectUint32 = common.getObjectUint32;
+const setDoubleProp = common.setDoubleProp;
+
+// ─── benchmark 함수 (CLI `zntc bench` 의 NAPI 대응) ───
+
+/// benchmark(optionsObj) → { phases: { <name>: { mean_ms, median_ms, p95_ms, p99_ms, min_ms, max_ms, stddev_ms, samples } } }
+///
+/// optionsObj:
+/// - source: string (source code, 또는)
+/// - file: string (파일 경로)
+/// - filename: string (source 와 함께, 확장자 감지용)
+/// - phases: string[] (측정할 category 목록, required)
+/// - iterations: number (default 100)
+/// - warmup: number (default 10)
+pub fn napiBenchmark(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
+    var argc: usize = 1;
+    var argv: [1]c.napi_value = undefined;
+    if (c.napi_get_cb_info(env, info, &argc, &argv, null, null) != c.napi_ok) {
+        return throwError(env, "failed to get arguments");
+    }
+    if (argc < 1) return throwError(env, "benchmark requires an options object");
+
+    const opts_obj = argv[0];
+
+    // source or file
+    var arena = std.heap.ArenaAllocator.init(native_alloc);
+    defer arena.deinit();
+    const arena_alloc = arena.allocator();
+
+    const filename = getObjectString(env, opts_obj, "filename", arena_alloc) orelse
+        arena_alloc.dupe(u8, "input.js") catch return throwError(env, "OutOfMemory");
+
+    const source_owned: []const u8 = blk: {
+        if (getObjectString(env, opts_obj, "source", arena_alloc)) |s| break :blk s;
+        if (getObjectString(env, opts_obj, "file", arena_alloc)) |path| {
+            const loaded = std.fs.cwd().readFileAlloc(arena_alloc, path, 100 * 1024 * 1024) catch {
+                return throwError(env, "benchmark: cannot read file");
+            };
+            break :blk loaded;
+        }
+        return throwError(env, "benchmark requires 'source' or 'file' option");
+    };
+
+    // phases
+    const phase_names = getObjectStringArray(env, opts_obj, "phases", arena_alloc) orelse
+        return throwError(env, "benchmark requires 'phases' (string array)");
+    if (phase_names.len == 0) return throwError(env, "benchmark: 'phases' must be non-empty");
+
+    var phase_cats: std.ArrayList(profile_mod.Category) = .empty;
+    defer phase_cats.deinit(arena_alloc);
+    for (phase_names) |name| {
+        const cat = profile_mod.Category.fromString(name) orelse {
+            return throwError(env, "benchmark: unknown phase name");
+        };
+        phase_cats.append(arena_alloc, cat) catch return throwError(env, "OutOfMemory");
+    }
+
+    const iterations = getObjectUint32(env, opts_obj, "iterations", 100);
+    const warmup = getObjectUint32(env, opts_obj, "warmup", 10);
+    if (iterations == 0) return throwError(env, "benchmark: 'iterations' must be >= 1");
+
+    // Benchmark 실행
+    const Ctx = struct {
+        source: []const u8,
+        filename: []const u8,
+        fn run(a: std.mem.Allocator, raw_ctx: ?*anyopaque) anyerror!void {
+            const self: *@This() = @ptrCast(@alignCast(raw_ctx.?));
+            var r = transpile_mod.transpileWithCallback(a, self.source, self.filename, .{}, null) catch return;
+            r.deinit(a);
+        }
+    };
+    var ctx: Ctx = .{ .source = source_owned, .filename = filename };
+    var samples = bench_mod.runBenchmark(arena_alloc, phase_cats.items, iterations, warmup, Ctx.run, &ctx) catch {
+        return throwError(env, "benchmark: runner failed");
+    };
+    defer samples.deinit(arena_alloc);
+
+    // 결과 객체 구성: { phases: { <name>: PhaseStats-flat } }
+    var js_result: c.napi_value = undefined;
+    if (c.napi_create_object(env, &js_result) != c.napi_ok) return throwError(env, "failed to create result");
+
+    var js_phases: c.napi_value = undefined;
+    _ = c.napi_create_object(env, &js_phases);
+    _ = c.napi_set_named_property(env, js_result, "phases", js_phases);
+
+    for (phase_names, 0..) |name, i| {
+        const stats = bench_mod.PhaseStats.fromSamples(samples.per_phase[i].items);
+        var js_stats: c.napi_value = undefined;
+        _ = c.napi_create_object(env, &js_stats);
+        setDoubleProp(env, js_stats, "mean_ms", stats.meanMs());
+        setDoubleProp(env, js_stats, "median_ms", stats.medianMs());
+        setDoubleProp(env, js_stats, "p95_ms", stats.p95Ms());
+        setDoubleProp(env, js_stats, "p99_ms", stats.p99Ms());
+        setDoubleProp(env, js_stats, "min_ms", stats.minMs());
+        setDoubleProp(env, js_stats, "max_ms", stats.maxMs());
+        setDoubleProp(env, js_stats, "stddev_ms", stats.stddevMs());
+
+        var js_samples: c.napi_value = undefined;
+        _ = c.napi_create_uint32(env, @intCast(stats.samples), &js_samples);
+        _ = c.napi_set_named_property(env, js_stats, "samples", js_samples);
+
+        var key_buf: [128]u8 = undefined;
+        if (name.len >= key_buf.len) continue;
+        @memcpy(key_buf[0..name.len], name);
+        key_buf[name.len] = 0;
+        _ = c.napi_set_named_property(env, js_phases, @ptrCast(&key_buf), js_stats);
+    }
+
+    return js_result;
+}

--- a/packages/core/src/napi_entry.zig
+++ b/packages/core/src/napi_entry.zig
@@ -22,13 +22,13 @@ const napi_render_opts: diagnostic_renderer.RenderOptions = .{ .color = false, .
 const bundler_mod = zntc_lib.bundler;
 const Bundler = bundler_mod.Bundler;
 const profile_mod = zntc_lib.profile;
-const bench_mod = zntc_lib.bench;
 
 const BundleOptions = bundler_mod.BundleOptions;
 const transformer_mod = zntc_lib.transformer.transformer;
 const common = @import("napi/common.zig");
 const options_mod = @import("napi/options.zig");
 const tsconfig_cache_mod = @import("napi/tsconfig_cache.zig");
+const benchmark_mod = @import("napi/benchmark.zig");
 const c = common.c;
 
 const native_alloc = std.heap.c_allocator;
@@ -44,7 +44,6 @@ const getObjectString = common.getObjectString;
 const getObjectStringArray = common.getObjectStringArray;
 const parseStringArray = common.parseStringArray;
 const getObjectKeyValuePairs = common.getObjectKeyValuePairs;
-const setDoubleProp = common.setDoubleProp;
 const setUint32Prop = common.setUint32Prop;
 const setStringProp = common.setStringProp;
 
@@ -1002,116 +1001,8 @@ export fn napi_register_module_v1(env: c.napi_env, exports: c.napi_value) c.napi
     _ = c.napi_set_named_property(env, exports, "watch", watch_fn);
 
     var bench_fn: c.napi_value = undefined;
-    _ = c.napi_create_function(env, "benchmark", "benchmark".len, napiBenchmark, null, &bench_fn);
+    _ = c.napi_create_function(env, "benchmark", "benchmark".len, benchmark_mod.napiBenchmark, null, &bench_fn);
     _ = c.napi_set_named_property(env, exports, "benchmark", bench_fn);
 
     return exports;
-}
-
-// ─── benchmark 함수 (CLI `zntc bench` 의 NAPI 대응) ───
-
-/// benchmark(optionsObj) → { phases: { <name>: { mean_ms, median_ms, p95_ms, p99_ms, min_ms, max_ms, stddev_ms, samples } } }
-///
-/// optionsObj:
-/// - source: string (source code, 또는)
-/// - file: string (파일 경로)
-/// - filename: string (source 와 함께, 확장자 감지용)
-/// - phases: string[] (측정할 category 목록, required)
-/// - iterations: number (default 100)
-/// - warmup: number (default 10)
-fn napiBenchmark(env: c.napi_env, info: c.napi_callback_info) callconv(.c) c.napi_value {
-    var argc: usize = 1;
-    var argv: [1]c.napi_value = undefined;
-    if (c.napi_get_cb_info(env, info, &argc, &argv, null, null) != c.napi_ok) {
-        return throwError(env, "failed to get arguments");
-    }
-    if (argc < 1) return throwError(env, "benchmark requires an options object");
-
-    const opts_obj = argv[0];
-
-    // source or file
-    var arena = std.heap.ArenaAllocator.init(native_alloc);
-    defer arena.deinit();
-    const arena_alloc = arena.allocator();
-
-    const filename = getObjectString(env, opts_obj, "filename", arena_alloc) orelse
-        arena_alloc.dupe(u8, "input.js") catch return throwError(env, "OutOfMemory");
-
-    const source_owned: []const u8 = blk: {
-        if (getObjectString(env, opts_obj, "source", arena_alloc)) |s| break :blk s;
-        if (getObjectString(env, opts_obj, "file", arena_alloc)) |path| {
-            const loaded = std.fs.cwd().readFileAlloc(arena_alloc, path, 100 * 1024 * 1024) catch {
-                return throwError(env, "benchmark: cannot read file");
-            };
-            break :blk loaded;
-        }
-        return throwError(env, "benchmark requires 'source' or 'file' option");
-    };
-
-    // phases
-    const phase_names = getObjectStringArray(env, opts_obj, "phases", arena_alloc) orelse
-        return throwError(env, "benchmark requires 'phases' (string array)");
-    if (phase_names.len == 0) return throwError(env, "benchmark: 'phases' must be non-empty");
-
-    var phase_cats: std.ArrayList(profile_mod.Category) = .empty;
-    defer phase_cats.deinit(arena_alloc);
-    for (phase_names) |name| {
-        const cat = profile_mod.Category.fromString(name) orelse {
-            return throwError(env, "benchmark: unknown phase name");
-        };
-        phase_cats.append(arena_alloc, cat) catch return throwError(env, "OutOfMemory");
-    }
-
-    const iterations = getObjectUint32(env, opts_obj, "iterations", 100);
-    const warmup = getObjectUint32(env, opts_obj, "warmup", 10);
-    if (iterations == 0) return throwError(env, "benchmark: 'iterations' must be >= 1");
-
-    // Benchmark 실행
-    const Ctx = struct {
-        source: []const u8,
-        filename: []const u8,
-        fn run(a: std.mem.Allocator, raw_ctx: ?*anyopaque) anyerror!void {
-            const self: *@This() = @ptrCast(@alignCast(raw_ctx.?));
-            var r = transpile_mod.transpileWithCallback(a, self.source, self.filename, .{}, null) catch return;
-            r.deinit(a);
-        }
-    };
-    var ctx: Ctx = .{ .source = source_owned, .filename = filename };
-    var samples = bench_mod.runBenchmark(arena_alloc, phase_cats.items, iterations, warmup, Ctx.run, &ctx) catch {
-        return throwError(env, "benchmark: runner failed");
-    };
-    defer samples.deinit(arena_alloc);
-
-    // 결과 객체 구성: { phases: { <name>: PhaseStats-flat } }
-    var js_result: c.napi_value = undefined;
-    if (c.napi_create_object(env, &js_result) != c.napi_ok) return throwError(env, "failed to create result");
-
-    var js_phases: c.napi_value = undefined;
-    _ = c.napi_create_object(env, &js_phases);
-    _ = c.napi_set_named_property(env, js_result, "phases", js_phases);
-
-    for (phase_names, 0..) |name, i| {
-        const stats = bench_mod.PhaseStats.fromSamples(samples.per_phase[i].items);
-        var js_stats: c.napi_value = undefined;
-        _ = c.napi_create_object(env, &js_stats);
-        setDoubleProp(env, js_stats, "mean_ms", stats.meanMs());
-        setDoubleProp(env, js_stats, "median_ms", stats.medianMs());
-        setDoubleProp(env, js_stats, "p95_ms", stats.p95Ms());
-        setDoubleProp(env, js_stats, "p99_ms", stats.p99Ms());
-        setDoubleProp(env, js_stats, "min_ms", stats.minMs());
-        setDoubleProp(env, js_stats, "max_ms", stats.maxMs());
-        setDoubleProp(env, js_stats, "stddev_ms", stats.stddevMs());
-
-        var js_samples: c.napi_value = undefined;
-        _ = c.napi_create_uint32(env, @intCast(stats.samples), &js_samples);
-        _ = c.napi_set_named_property(env, js_stats, "samples", js_samples);
-
-        var key_buf: [128]u8 = undefined;
-        if (name.len >= key_buf.len) continue;
-        @memcpy(key_buf[0..name.len], name);
-        key_buf[name.len] = 0;
-        _ = c.napi_set_named_property(env, js_phases, @ptrCast(&key_buf), js_stats);
-    }
-
-    return js_result;
 }


### PR DESCRIPTION
## 요약
- `napi_entry.zig`의 `benchmark()` NAPI callback을 `packages/core/src/napi/benchmark.zig`로 분리했습니다.
- entry 파일은 `benchmark` export 등록만 담당하고, option 파싱/phase 매핑/결과 객체 생성은 benchmark 모듈로 이동했습니다.
- 이전 검토에서 `codegen` namespace 분리는 내부 출력 API 공개 범위를 넓혀야 해서 보류했고, NAPI의 독립 callback부터 작은 PR로 이어갑니다.

## Zig 관례 점검
- 기존 `napi/common.zig`, `napi/options.zig`, `napi/watch.zig`, `napi/tsconfig_cache.zig`처럼 기능별 NAPI helper 파일로 분리했습니다.
- NAPI callback 시그니처와 JS API 이름은 그대로 유지했습니다.

## 검증
- `zig fmt packages/core/src/napi_entry.zig packages/core/src/napi/benchmark.zig`
- `zig build`
- `zig build test`
- `zig build napi`
- `bun test --cwd tests/integration tests/bench.test.ts --timeout 10000`
- `node --test packages/core/napi.test.mjs`
- `git diff --check`
- pre-push hook: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`