### PR TITLE
fix(monorepo): cumulative review fixes — build:publishable / server refs / IDE docs

### DIFF
--- a/docs/IDE.md
+++ b/docs/IDE.md
@@ -4,7 +4,7 @@ ZNTC monorepo 를 IDE 에서 효과적으로 다루기 위한 권장 설정.
 
 ## TypeScript Project References (root `tsconfig.json`)
 
-PR #2805 ~ #2808 에서 도입. 7 publishable workspace package 를 단일 TS program 으로 묶음:
+PR #2805 ~ #2808 에서 도입. 7 workspace package (publishable 6 + private `@zntc/server`) 를 단일 TS program 으로 묶음:
 
 - `packages/{core,server,web,react-native,vite-plugin-zntc,init,wasm}/tsconfig.json` 가 `composite: true`
 - root `/tsconfig.json` (solution-style) 이 모두 `references` 로 묶음

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:publint": "bun scripts/publint-all.ts",
     "test:sherif": "bunx sherif --ignore-rule multiple-dependency-versions --ignore-rule unsync-similar-dependencies",
     "test:publishable-deps": "bun scripts/publishable-deps-check.ts",
-    "build:publishable": "bun run --cwd packages/server build && bun run --cwd packages/web build && bun run --cwd packages/react-native build && bun run --cwd packages/vite-plugin-zntc build && bun run --cwd packages/init build",
+    "build:publishable": "bun run --cwd packages/core build && bun run --cwd packages/wasm build && bun run --cwd packages/web build && bun run --cwd packages/react-native build && bun run --cwd packages/vite-plugin-zntc build && bun run --cwd packages/init build",
     "pre-release-check": "bun run build:publishable && bun run test:publish-smoke && bun run test:publint && bun run test:sherif && bun run test:publishable-deps && bun run test:publish-install",
     "release": "bun scripts/release.ts",
     "release:dry-run": "bun scripts/release.ts",

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -11,6 +11,7 @@
     "composite": true,
     "tsBuildInfoFile": ".tsbuildinfo"
   },
+  "references": [{ "path": "../core" }],
   "include": ["src/**/*"],
   "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

PR #2791 ~ #2819 의 **cumulative simplify review** 에서 발견된 must/should 3건을 한 PR 에.

## 변경

### 1. build:publishable 가 publishable 과 불일치 (must)

**기존**: server/web/RN/vite-plugin/init (5개) — **core/wasm 누락** + server (private) 포함
**수정**: core/wasm/web/RN/vite-plugin/init (6개) — 실제 publishable 과 일치

server 는 redundant (web/RN 이 source condition 으로 src 직접 inline). core/wasm 누락은 진짜 위험 — pre-release-check 가 stale dist 위에서 검증할 가능성.

### 2. server tsconfig references 누락 (should)

server 가 @zntc/core typed import 하지만 references 자체가 없음. tsc -b 가 server build 시 core dts 변경 놓칠 수 있음. 다른 consumer 모두 명시 references — server 만 asymmetric.

### 3. docs/IDE.md \"7 publishable\" 표현 정정 (should)

7 packages 중 server 는 private. \"publishable 6 + private @zntc/server\" 로 정확히 표기.

## Test plan

- [x] bun run build:dts:all EXIT=0
- [x] bun run pre-release-check 모두 통과
- [x] bun run fmt:check clean

## 후속 PR

- scripts 공통 helper 추출 (workspace 검출 / tarball pack 중복)

🤖 Generated with [Claude Code](https://claude.com/claude-code)