### PR TITLE
refactor(scripts): extract scripts/lib/workspace.ts helper (4 script dedup)

### DIFF
--- a/scripts/lib/workspace.ts
+++ b/scripts/lib/workspace.ts
@@ -1,0 +1,72 @@
+/**
+ * 4 publish 관련 script (publish-smoke / publish-install / publint-all /
+ * publishable-deps-check) 의 공통 helper. workspace 검출 + tarball pack 의
+ * drift 차단.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const repoRoot: string = resolve(__dirname, '..', '..');
+
+export interface PackageInfo {
+  /** workspace 상대 path (예: "packages/core") */
+  dir: string;
+  /** 절대 path */
+  absDir: string;
+  /** package.json name */
+  name: string;
+  /** package.json 전체 */
+  pkg: any;
+  /** private: true 인지 */
+  isPrivate: boolean;
+  /** dist/ 디렉토리 존재 여부 */
+  hasDist: boolean;
+}
+
+/**
+ * root package.json 의 workspaces 에서 packages/* 만 추출 + package.json 파싱.
+ * examples / tests / documents 같은 비-publish workspace 는 제외.
+ */
+export async function detectWorkspacePackages(): Promise<PackageInfo[]> {
+  const root = JSON.parse(await readFile(join(repoRoot, 'package.json'), 'utf8'));
+  const ws = (root.workspaces as string[] | undefined) ?? [];
+  const out: PackageInfo[] = [];
+  for (const raw of ws) {
+    const dir = raw.replace(/^\.\//, '');
+    if (!dir.startsWith('packages/')) continue;
+    const absDir = resolve(repoRoot, dir);
+    const pkgJsonPath = join(absDir, 'package.json');
+    if (!existsSync(pkgJsonPath)) continue;
+    const pkg = JSON.parse(await readFile(pkgJsonPath, 'utf8'));
+    out.push({
+      dir,
+      absDir,
+      name: pkg.name as string,
+      pkg,
+      isPrivate: pkg.private === true,
+      hasDist: existsSync(join(absDir, 'dist')),
+    });
+  }
+  return out;
+}
+
+/**
+ * `bun pm pack --quiet --destination <dest>` 호출 + tarball 절대 경로 반환.
+ * stdout 의 절대/상대 path 모두 normalize.
+ */
+export function packTarball(pkgDir: string, destDir: string): string | null {
+  const res = spawnSync('bun', ['pm', 'pack', '--quiet', '--destination', destDir], {
+    cwd: pkgDir,
+    encoding: 'utf8',
+  });
+  if (res.status !== 0) return null;
+  const line = res.stdout.trim().split(/\s+/).pop();
+  if (!line) return null;
+  const tarball = isAbsolute(line) ? line : join(destDir, basename(line));
+  return existsSync(tarball) ? tarball : null;
+}

--- a/scripts/publint-all.ts
+++ b/scripts/publint-all.ts
@@ -13,38 +13,27 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
-import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const repoRoot = resolve(__dirname, '..');
+import { detectWorkspacePackages, repoRoot } from './lib/workspace.ts';
 
 async function main() {
-  const root = JSON.parse(await readFile(join(repoRoot, 'package.json'), 'utf8'));
-  const ws = (root.workspaces as string[] | undefined) ?? [];
-  const targets = ws.map((w) => w.replace(/^\.\//, '')).filter((w) => w.startsWith('packages/'));
+  const targets = await detectWorkspacePackages();
 
   let failed = 0;
   for (const t of targets) {
-    const pkgJsonPath = resolve(repoRoot, t, 'package.json');
-    if (!existsSync(pkgJsonPath)) continue;
-    const pkg = JSON.parse(await readFile(pkgJsonPath, 'utf8'));
-    if (pkg.private) {
-      console.log(`\nskip: ${pkg.name} (private)`);
+    if (t.isPrivate) {
+      console.log(`\nskip: ${t.name} (private)`);
       continue;
     }
-    if (!existsSync(resolve(repoRoot, t, 'dist'))) {
-      console.log(`\n=== ${pkg.name} ===`);
-      console.error(`  ❌ dist/ 없음 — 빌드 선행 필요 (bun run --cwd ${t} build)`);
+    if (!t.hasDist) {
+      console.log(`\n=== ${t.name} ===`);
+      console.error(`  ❌ dist/ 없음 — 빌드 선행 필요 (bun run --cwd ${t.dir} build)`);
       failed += 1;
       continue;
     }
-    console.log(`\n=== ${pkg.name} (${t}) ===`);
+    console.log(`\n=== ${t.name} (${t.dir}) ===`);
     // --strict: warning 도 error 로 승격. RN runtime 의 .js (ESM 모드 + CJS 코드)
     // case 는 .cjs 로 rename 처리됨 (#2802). 새 warning 발생 시 case 별 audit.
-    const res = spawnSync('bunx', ['publint', '--strict', '--level', 'error', t], {
+    const res = spawnSync('bunx', ['publint', '--strict', '--level', 'error', t.dir], {
       cwd: repoRoot,
       encoding: 'utf8',
       stdio: 'inherit',

--- a/scripts/publish-install-test.ts
+++ b/scripts/publish-install-test.ts
@@ -23,14 +23,11 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const repoRoot = resolve(__dirname, '..');
+import { join } from 'node:path';
+import { detectWorkspacePackages, packTarball } from './lib/workspace.ts';
 
 interface Failure {
   pkg: string;
@@ -53,18 +50,6 @@ interface TargetInfo {
   workspaceDeps: string[];
 }
 
-async function packTarball(pkgDir: string, destDir: string): Promise<string | null> {
-  const res = spawnSync('bun', ['pm', 'pack', '--quiet', '--destination', destDir], {
-    cwd: pkgDir,
-    encoding: 'utf8',
-  });
-  if (res.status !== 0) return null;
-  const line = res.stdout.trim().split(/\s+/).pop();
-  if (!line) return null;
-  const tarball = isAbsolute(line) ? line : join(destDir, basename(line));
-  return existsSync(tarball) ? tarball : null;
-}
-
 function collectWorkspaceDeps(pkg: any, allNames: Set<string>): string[] {
   const result: string[] = [];
   const collectFrom = (deps: Record<string, string> | undefined) => {
@@ -81,43 +66,37 @@ function collectWorkspaceDeps(pkg: any, allNames: Set<string>): string[] {
 }
 
 async function detectTargets(tmpRoot: string): Promise<TargetInfo[]> {
-  const root = JSON.parse(await readFile(join(repoRoot, 'package.json'), 'utf8'));
-  const ws = (root.workspaces as string[] | undefined) ?? [];
-  const wsPaths = ws.map((w) => w.replace(/^\.\//, '')).filter((w) => w.startsWith('packages/'));
+  const all = await detectWorkspacePackages();
 
-  // 1차 pass: name + private 수집
+  // publishable 만 + dist 존재 검증
   const targets: TargetInfo[] = [];
   const allNames = new Set<string>();
-  const pkgInfos = new Map<string, any>();
-  for (const t of wsPaths) {
-    const pkgJsonPath = resolve(repoRoot, t, 'package.json');
-    if (!existsSync(pkgJsonPath)) continue;
-    const pkg = JSON.parse(await readFile(pkgJsonPath, 'utf8'));
-    if (pkg.private) {
-      console.log(`skip: ${pkg.name} (private)`);
+  const pkgInfos: { dir: string; pkg: any }[] = [];
+  for (const t of all) {
+    if (t.isPrivate) {
+      console.log(`skip: ${t.name} (private)`);
       continue;
     }
-    if (!existsSync(resolve(repoRoot, t, 'dist'))) {
-      console.log(`\n=== ${pkg.name} (${t}) ===`);
-      fail(pkg.name, `dist/ 없음 — 빌드 선행 필요 (bun run --cwd ${t} build)`);
+    if (!t.hasDist) {
+      console.log(`\n=== ${t.name} (${t.dir}) ===`);
+      fail(t.name, `dist/ 없음 — 빌드 선행 필요 (bun run --cwd ${t.dir} build)`);
       continue;
     }
-    allNames.add(pkg.name);
-    pkgInfos.set(t, pkg);
+    allNames.add(t.name);
+    pkgInfos.push({ dir: t.absDir, pkg: t.pkg });
   }
 
-  // 2차 pass: tarball 생성 + workspaceDeps 해결
+  // tarball 생성 + workspaceDeps 해결
   const tarballDir = join(tmpRoot, 'tarballs');
   await mkdir(tarballDir, { recursive: true });
-  for (const [t, pkg] of pkgInfos) {
-    const absPkg = resolve(repoRoot, t);
-    const tarball = await packTarball(absPkg, tarballDir);
+  for (const { dir, pkg } of pkgInfos) {
+    const tarball = packTarball(dir, tarballDir);
     if (!tarball) {
       fail(pkg.name, `bun pm pack 실패`);
       continue;
     }
     targets.push({
-      dir: t,
+      dir,
       name: pkg.name,
       tarballPath: tarball,
       workspaceDeps: collectWorkspaceDeps(pkg, allNames),

--- a/scripts/publish-smoke-test.ts
+++ b/scripts/publish-smoke-test.ts
@@ -20,14 +20,11 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { mkdir, readFile, readdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const repoRoot = resolve(__dirname, '..');
+import { join } from 'node:path';
+import { detectWorkspacePackages, packTarball, type PackageInfo } from './lib/workspace.ts';
 
 const PRIVATE_PACKAGES = new Set(['@zntc/server']);
 
@@ -111,32 +108,15 @@ function collectBinPaths(binField: unknown, out: Set<string>) {
   }
 }
 
-async function smokeOne(pkgDir: string, tmpRoot: string): Promise<void> {
-  const absPkg = resolve(repoRoot, pkgDir);
-  const sourcePkgJson = JSON.parse(await readFile(join(absPkg, 'package.json'), 'utf8'));
-  const pkgName = sourcePkgJson.name as string;
-  console.log(`\n=== ${pkgName} (${pkgDir}) ===`);
+async function smokeOne(target: PackageInfo, tmpRoot: string): Promise<void> {
+  const pkgName = target.name;
+  console.log(`\n=== ${pkgName} (${target.dir}) ===`);
 
-  // bun pm pack --quiet 는 stdout 에 tarball 파일명만 출력 — fragile name 추론 회피.
   const packDest = join(tmpRoot, encodeURIComponent(pkgName));
   await mkdir(packDest, { recursive: true });
-  const packResult = spawnSync('bun', ['pm', 'pack', '--quiet', '--destination', packDest], {
-    cwd: absPkg,
-    encoding: 'utf8',
-  });
-  if (packResult.status !== 0) {
-    fail(pkgName, `bun pm pack 실패: ${packResult.stderr || packResult.stdout}`);
-    return;
-  }
-  // bun pm pack --quiet 는 절대 경로 또는 파일명을 stdout 에 출력 (버전마다 다름).
-  const stdoutLine = packResult.stdout.trim().split(/\s+/).pop();
-  if (!stdoutLine) {
-    fail(pkgName, `bun pm pack stdout 에서 tarball 이름 못 찾음`);
-    return;
-  }
-  const tarball = isAbsolute(stdoutLine) ? stdoutLine : join(packDest, basename(stdoutLine));
-  if (!existsSync(tarball)) {
-    fail(pkgName, `tarball 을 못 찾음: ${tarball}`);
+  const tarball = packTarball(target.absDir, packDest);
+  if (!tarball) {
+    fail(pkgName, `bun pm pack 실패 또는 tarball 못 찾음`);
     return;
   }
 
@@ -221,44 +201,26 @@ async function smokeOne(pkgDir: string, tmpRoot: string): Promise<void> {
   ok(`tarball 파일 ${tarballFiles.length}개`);
 }
 
-async function detectTargets(): Promise<string[]> {
-  // root package.json 의 workspaces 에서 packages/* 만 추출. examples/tests/documents
-  // 같은 비-publish 워크스페이스 제외.
-  const root = JSON.parse(await readFile(join(repoRoot, 'package.json'), 'utf8'));
-  const ws = root.workspaces as string[] | undefined;
-  if (!ws) throw new Error('root package.json 에 workspaces 필드 없음');
-  return ws
-    .map((w) => w.replace(/^\.\//, ''))
-    .filter((w) => w.startsWith('packages/'));
-}
-
 async function main() {
-  const targets = await detectTargets();
-  console.log(`Detected ${targets.length} workspace packages:`, targets.join(', '));
+  const targets = await detectWorkspacePackages();
+  console.log(`Detected ${targets.length} workspace packages:`, targets.map((t) => t.dir).join(', '));
 
   const tmpRoot = mkdtempSync(join(tmpdir(), 'zntc-publish-smoke-'));
   try {
     for (const t of targets) {
-      const pkgJsonPath = resolve(repoRoot, t, 'package.json');
-      if (!existsSync(pkgJsonPath)) {
-        console.warn(`skip: ${t} (package.json 없음)`);
+      if (t.isPrivate) {
+        console.log(`\nskip: ${t.name} (private)`);
         continue;
       }
-      const pkg = JSON.parse(await readFile(pkgJsonPath, 'utf8'));
-      if (pkg.private) {
-        console.log(`\nskip: ${pkg.name} (private)`);
-        continue;
-      }
-      const distDir = resolve(repoRoot, t, 'dist');
-      if (!existsSync(distDir)) {
-        console.log(`\n=== ${pkg.name} (${t}) ===`);
-        fail(pkg.name, `dist/ 없음 — 빌드 선행 필요 (bun run --cwd ${t} build)`);
+      if (!t.hasDist) {
+        console.log(`\n=== ${t.name} (${t.dir}) ===`);
+        fail(t.name, `dist/ 없음 — 빌드 선행 필요 (bun run --cwd ${t.dir} build)`);
         continue;
       }
       try {
         await smokeOne(t, tmpRoot);
       } catch (e) {
-        fail(pkg.name, `예외: ${(e as Error).message}`);
+        fail(t.name, `예외: ${(e as Error).message}`);
       }
     }
   } finally {

--- a/scripts/publishable-deps-check.ts
+++ b/scripts/publishable-deps-check.ts
@@ -16,13 +16,7 @@
  *   bun scripts/publishable-deps-check.ts
  */
 
-import { existsSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
-import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const repoRoot = resolve(__dirname, '..');
+import { detectWorkspacePackages } from './lib/workspace.ts';
 
 interface DepUsage {
   pkg: string;
@@ -42,19 +36,12 @@ function record(deps: Record<string, string> | undefined, pkg: string, field: st
 }
 
 async function main() {
-  const root = JSON.parse(await readFile(join(repoRoot, 'package.json'), 'utf8'));
-  const ws = (root.workspaces as string[] | undefined) ?? [];
-  const targets = ws
-    .map((w) => w.replace(/^\.\//, ''))
-    .filter((w) => w.startsWith('packages/'));
+  const targets = await detectWorkspacePackages();
 
   for (const t of targets) {
-    const pkgJsonPath = resolve(repoRoot, t, 'package.json');
-    if (!existsSync(pkgJsonPath)) continue;
-    const pkg = JSON.parse(await readFile(pkgJsonPath, 'utf8'));
-    record(pkg.dependencies, pkg.name, 'dependencies');
-    record(pkg.peerDependencies, pkg.name, 'peerDependencies');
-    record(pkg.optionalDependencies, pkg.name, 'optionalDependencies');
+    record(t.pkg.dependencies, t.name, 'dependencies');
+    record(t.pkg.peerDependencies, t.name, 'peerDependencies');
+    record(t.pkg.optionalDependencies, t.name, 'optionalDependencies');
   }
 
   const conflicts: string[] = [];


### PR DESCRIPTION
## Summary

PR #2791~#2819 의 cumulative review (이전 세션 simplify 생략 cleanup) 의 should — **4 publish 관련 script 가 workspace 검출 + tarball pack 로직을 동일하게 inline**. drift 위험.

## 추가

### `scripts/lib/workspace.ts` (신설)

- `detectWorkspacePackages()` — root.workspaces 에서 packages/* + private + hasDist 까지 한 번에 normalize
- `packTarball(pkgDir, dest)` — `bun pm pack --quiet` stdout 의 절대/상대 path normalize. 단일 fragile 지점

### 각 script 의 변경 (line count)

| script | before → after |
|---|---|
| publint-all.ts | 65 → 51 |
| publish-smoke-test.ts | 280 → 219 |
| publish-install-test.ts | 219 → 197 |
| publishable-deps-check.ts | 80 → 67 |
| **합계** | **-83 line** |

## Test plan

- [x] `bun run pre-release-check` — 6 layer 모두 통과 (4 refactored script 포함)
- [x] `bun run fmt:check` clean

## drift 차단 효과

새 script 추가 시 helper 사용 → workspace 패턴 / tarball pack 형식 변경 시 한 곳만 update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)