### PR TITLE
refactor: graph plugin과 state 타입 분리

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -85,6 +85,8 @@ const graph_glob = @import("graph/glob.zig");
 const expandGlobRecords = graph_glob.expandGlobRecords;
 const graph_package_side_effects = @import("graph/package_side_effects.zig");
 const graph_parse_helpers = @import("graph/parse_helpers.zig");
+const graph_plugins = @import("graph/plugins.zig");
+const graph_state = @import("graph/state.zig");
 
 pub const ModuleGraph = struct {
     pub const matchSideEffectsPatterns = graph_package_side_effects.matchPatterns;
@@ -248,28 +250,9 @@ pub const ModuleGraph = struct {
     /// transform 은 user plugin 또는 builtin RN codegen 이 활성이면 실행 — 둘을 합친 게이트.
     has_transform_plugins: bool = false,
 
-    pub const PkgInfo = struct {
-        is_module: bool,
-        side_effects: pkg_json.PackageJson.SideEffects,
-    };
-
-    pub const WorkerEntry = struct {
-        /// resolve된 worker 파일 절대 경로
-        resolved_path: []const u8,
-        /// worker를 참조하는 모듈 인덱스
-        source_module: ModuleIndex,
-        /// 해당 모듈의 import_records 내 인덱스
-        record_index: u32,
-    };
-
-    const RequestedExports = struct {
-        all: bool = false,
-        names: std.StringHashMapUnmanaged(void) = .{},
-
-        fn deinit(self: *RequestedExports, allocator: std.mem.Allocator) void {
-            self.names.deinit(allocator);
-        }
-    };
+    pub const PkgInfo = graph_state.PkgInfo;
+    pub const WorkerEntry = graph_state.WorkerEntry;
+    const RequestedExports = graph_state.RequestedExports;
 
     pub fn init(allocator: std.mem.Allocator, resolve_cache: *ResolveCache) ModuleGraph {
         return .{
@@ -313,64 +296,10 @@ pub const ModuleGraph = struct {
         self.runtime_polyfill_roots.deinit(self.allocator);
     }
 
-    /// `plugins_with_helpers` lazy 초기화 — `self.plugins` 앞에 ZNTC builtin plugin 들 (runtime
-    /// helper, RN codegen 등) 을 prepend 한 slice 를 graph allocator 로 만든다 (#1961, #2348).
-    /// 빌드 옵션 (minify_whitespace 등) 은 이미 graph 에 set 됐다는 전제. `helper_plugin_opts`
-    /// 도 같이 hydrate. 단일 thread 진입점 (`build` 등) 에서만 호출.
-    fn ensureBuiltinPlugins(self: *ModuleGraph) void {
-        if (self.plugins_with_helpers != null) return;
-        self.has_user_resolve_id_plugins = false;
-        self.has_user_load_plugins = false;
-        self.has_transform_plugins = self.codegen_transform;
-        for (self.plugins) |p| {
-            if (p.resolveId != null) self.has_user_resolve_id_plugins = true;
-            if (p.load != null) self.has_user_load_plugins = true;
-            if (p.transform != null) self.has_transform_plugins = true;
-        }
-
-        // SourceOptions 는 빌드 옵션 기반으로 1회 결정.
-        const u = self.transform_options_base.unsupported;
-        self.helper_plugin_opts = .{
-            .minify = self.transform_options_base.minify_whitespace,
-            .es5 = u.async_await or u.arrow,
-            // configurable_exports 는 RN 같은 환경 — 현재 graph 에 직접 필드 없으므로 false.
-            // 후속 PR 에서 BundleOptions.configurable_exports 또는 platform=react-native 기반 결정.
-            .configurable_exports = false,
-        };
-        const helper = runtime_helper_modules.makePlugin(&self.helper_plugin_opts);
-
-        var builtin_count: usize = 1; // helper 항상 포함
-        if (self.codegen_transform) builtin_count += 1;
-
-        const merged = self.allocator.alloc(plugin_mod.Plugin, self.plugins.len + builtin_count) catch return;
-        var i: usize = 0;
-        merged[i] = helper;
-        i += 1;
-        if (self.codegen_transform) {
-            const codegen_plugin = @import("../transformer/plugins/rn_codegen_plugin.zig");
-            merged[i] = codegen_plugin.plugin();
-            i += 1;
-        }
-        @memcpy(merged[i..], self.plugins);
-        self.plugins_with_helpers = merged;
-    }
-
-    /// 모든 PluginRunner 호출 site 가 사용하는 통합 진입점. `ensureBuiltinPlugins` 가
-    /// `plugins_with_helpers` 를 하이드레이트한 후 그걸로 runner 만든다. fallback 으로
-    /// `self.plugins` 사용 (alloc 실패 시).
-    fn pluginRunnerWithBuiltins(self: *ModuleGraph) ?plugin_mod.PluginRunner {
-        const list = self.plugins_with_helpers orelse self.plugins;
-        if (list.len == 0) return null;
-        return plugin_mod.PluginRunner.init(list);
-    }
-
-    fn shouldRunResolveId(self: *const ModuleGraph, specifier: []const u8) bool {
-        return self.has_user_resolve_id_plugins or runtime_helper_modules.isVirtualId(specifier);
-    }
-
-    fn shouldRunLoad(self: *const ModuleGraph, path: []const u8) bool {
-        return self.has_user_load_plugins or runtime_helper_modules.isVirtualId(path);
-    }
+    const ensureBuiltinPlugins = graph_plugins.ensureBuiltinPlugins;
+    const pluginRunnerWithBuiltins = graph_plugins.pluginRunnerWithBuiltins;
+    const shouldRunResolveId = graph_plugins.shouldRunResolveId;
+    const shouldRunLoad = graph_plugins.shouldRunLoad;
 
     // ============================================================
     // Module accessor API (#1779 PR #1a + PR #3)
@@ -447,8 +376,8 @@ pub const ModuleGraph = struct {
     /// shelf pointer 배열도 고정 크기라 append 가 절대 pointer 무효화 안 함 (#1779).
     /// `std.SegmentedList` 는 `dynamic_segments` (ArrayListUnmanaged) 가 grow 시 realloc →
     /// worker 가 shelf pointer 읽는 중이면 stale (CI Stress test 에서 재현된 race).
-    pub const ModuleList = @import("module_list.zig").StableSegmentedList(Module);
-    pub const ModulesIterator = ModuleList.ConstIterator;
+    pub const ModuleList = graph_state.ModuleList;
+    pub const ModulesIterator = graph_state.ModulesIterator;
 
     /// 확장자에 대한 로더를 결정한다.
     /// --loader 오버라이드가 있으면 우선 사용, 없으면 확장자 기본값.

--- a/src/bundler/graph/plugins.zig
+++ b/src/bundler/graph/plugins.zig
@@ -1,0 +1,54 @@
+const plugin_mod = @import("../plugin.zig");
+const runtime_helper_modules = @import("../../runtime_helper_modules.zig");
+
+/// `plugins_with_helpers` lazy init: prepend ZNTC builtin plugins such as runtime
+/// helper modules and RN codegen before user plugins.
+pub fn ensureBuiltinPlugins(self: anytype) void {
+    if (self.plugins_with_helpers != null) return;
+    self.has_user_resolve_id_plugins = false;
+    self.has_user_load_plugins = false;
+    self.has_transform_plugins = self.codegen_transform;
+    for (self.plugins) |p| {
+        if (p.resolveId != null) self.has_user_resolve_id_plugins = true;
+        if (p.load != null) self.has_user_load_plugins = true;
+        if (p.transform != null) self.has_transform_plugins = true;
+    }
+
+    const u = self.transform_options_base.unsupported;
+    self.helper_plugin_opts = .{
+        .minify = self.transform_options_base.minify_whitespace,
+        .es5 = u.async_await or u.arrow,
+        // React Native-like configurable exports are not graph-level yet.
+        .configurable_exports = false,
+    };
+    const helper = runtime_helper_modules.makePlugin(&self.helper_plugin_opts);
+
+    var builtin_count: usize = 1;
+    if (self.codegen_transform) builtin_count += 1;
+
+    const merged = self.allocator.alloc(plugin_mod.Plugin, self.plugins.len + builtin_count) catch return;
+    var i: usize = 0;
+    merged[i] = helper;
+    i += 1;
+    if (self.codegen_transform) {
+        const codegen_plugin = @import("../../transformer/plugins/rn_codegen_plugin.zig");
+        merged[i] = codegen_plugin.plugin();
+        i += 1;
+    }
+    @memcpy(merged[i..], self.plugins);
+    self.plugins_with_helpers = merged;
+}
+
+pub fn pluginRunnerWithBuiltins(self: anytype) ?plugin_mod.PluginRunner {
+    const list = self.plugins_with_helpers orelse self.plugins;
+    if (list.len == 0) return null;
+    return plugin_mod.PluginRunner.init(list);
+}
+
+pub fn shouldRunResolveId(self: anytype, specifier: []const u8) bool {
+    return self.has_user_resolve_id_plugins or runtime_helper_modules.isVirtualId(specifier);
+}
+
+pub fn shouldRunLoad(self: anytype, path: []const u8) bool {
+    return self.has_user_load_plugins or runtime_helper_modules.isVirtualId(path);
+}

--- a/src/bundler/graph/state.zig
+++ b/src/bundler/graph/state.zig
@@ -1,0 +1,30 @@
+const std = @import("std");
+const types = @import("../types.zig");
+const module_mod = @import("../module.zig");
+const pkg_json = @import("../package_json.zig");
+
+pub const PkgInfo = struct {
+    is_module: bool,
+    side_effects: pkg_json.PackageJson.SideEffects,
+};
+
+pub const WorkerEntry = struct {
+    /// Resolved absolute worker file path.
+    resolved_path: []const u8,
+    /// Module index that references the worker.
+    source_module: types.ModuleIndex,
+    /// Import record index inside the source module.
+    record_index: u32,
+};
+
+pub const RequestedExports = struct {
+    all: bool = false,
+    names: std.StringHashMapUnmanaged(void) = .{},
+
+    pub fn deinit(self: *RequestedExports, allocator: std.mem.Allocator) void {
+        self.names.deinit(allocator);
+    }
+};
+
+pub const ModuleList = @import("../module_list.zig").StableSegmentedList(module_mod.Module);
+pub const ModulesIterator = ModuleList.ConstIterator;

--- a/src/transformer/state.zig
+++ b/src/transformer/state.zig
@@ -1,0 +1,65 @@
+const Span = @import("../lexer/token.zig").Span;
+const NodeIndex = @import("../parser/ast.zig").NodeIndex;
+const es_helpers = @import("es_helpers.zig");
+
+pub const AstOwnership = enum { owned, borrowed };
+
+pub const BlockRenameEntry = struct {
+    old_name: []const u8,
+    new_name: []const u8,
+};
+
+pub const GeneratorLabelEntry = struct {
+    name: []const u8,
+    break_label: u32,
+    continue_label: ?u32,
+};
+
+pub const NewTargetCtx = union(enum) {
+    none,
+    constructor, // class constructor: new.target -> this.constructor
+    method, // class method: new.target -> void 0
+    function_named: Span, // function Fn: new.target -> this instanceof Fn ? this.constructor : void 0
+};
+
+pub const ConstEnumValue = union(enum) {
+    number: f64, // ECMAScript Number: decimals and large integers
+    /// Raw string without quotes. The AST printer adds quotes.
+    string: []const u8,
+};
+
+pub const ConstEnumMember = struct {
+    name: []const u8,
+    value: ConstEnumValue,
+};
+
+pub const ConstEnumDecl = struct {
+    name: []const u8,
+    members: []const ConstEnumMember,
+    /// enum binding symbol id. Used for shadowing checks; member access is inlined
+    /// only when identifier_reference points at the same binding. null falls back
+    /// to name matching when symbol info is unavailable.
+    symbol_id: ?u32,
+};
+
+/// `class_name` distinguishes instance vs static private fields.
+/// null -> instance WeakMap, non-null -> static descriptor + class brand check.
+pub const PrivateFieldMapping = struct {
+    original_name: []const u8, // "#x"
+    var_name: []const u8, // "_x"
+    class_name: ?[]const u8 = null,
+};
+
+/// `class_name` distinguishes instance vs static private methods.
+/// null -> instance WeakSet, non-null -> static descriptor + class brand check.
+pub const PrivateMethodMapping = struct {
+    original_name: []const u8, // "#method"
+    weakset_name: []const u8, // "_method"
+    func_name: []const u8, // "_method_fn" / "_method_get" / "_method_set"
+    member_idx: NodeIndex = NodeIndex.none,
+    // Standalone function_declaration span. Keeps leading comments anchored before
+    // `function _fn()` instead of after the function header (#1516).
+    member_span: Span = .{ .start = 0, .end = 0 },
+    kind: es_helpers.PrivateMethodKind = .method,
+    class_name: ?[]const u8 = null,
+};

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -65,6 +65,7 @@ const drop_mod = @import("transformer/drop.zig");
 const type_only_mod = @import("transformer/type_only.zig");
 const options_mod = @import("options.zig");
 const runtime_helper_bits = @import("runtime_helper_bits.zig");
+const state_mod = @import("state.zig");
 pub const ast_plugin_mod = @import("ast_plugin.zig");
 pub const AstTransformCtx = ast_plugin_mod.AstTransformCtx;
 pub const FunctionInfo = ast_plugin_mod.FunctionInfo;
@@ -260,65 +261,14 @@ pub const Transformer = struct {
     /// const 바인딩만 추적 (let/var 는 재할당 가능).
     regex_var_map: std.AutoHashMapUnmanaged(u32, []const u8) = .empty,
 
-    pub const BlockRenameEntry = struct {
-        old_name: []const u8,
-        new_name: []const u8,
-    };
-
-    pub const GeneratorLabelEntry = struct {
-        name: []const u8,
-        break_label: u32,
-        continue_label: ?u32,
-    };
-
-    pub const NewTargetCtx = union(enum) {
-        none,
-        constructor, // class constructor: new.target → this.constructor
-        method, // class method: new.target → void 0
-        function_named: Span, // function Fn: new.target → this instanceof Fn ? this.constructor : void 0
-    };
-
-    pub const ConstEnumValue = union(enum) {
-        number: f64, // ECMAScript Number — 소수/큰 정수 모두 표현 가능
-        /// quote 미포함 raw 문자열. AST 출력 시 quote 추가.
-        string: []const u8,
-    };
-
-    pub const ConstEnumMember = struct {
-        name: []const u8,
-        value: ConstEnumValue,
-    };
-
-    pub const ConstEnumDecl = struct {
-        name: []const u8,
-        members: []const ConstEnumMember,
-        /// enum binding 의 symbol_id. shadowing 검사 — identifier_reference 의 symbol_id 가
-        /// 일치할 때만 인라인 (같은 스코프의 다른 변수 잘못 변환 방지). null이면 symbol 정보 없음 → 이름으로만 매칭.
-        symbol_id: ?u32,
-    };
-
-    /// `class_name` 으로 instance/static 을 구분 — null 이면 instance (WeakMap 기반),
-    /// non-null 이면 static (descriptor 객체 + class brand check).
-    pub const PrivateFieldMapping = struct {
-        original_name: []const u8, // "#x"
-        var_name: []const u8, // "_x"
-        class_name: ?[]const u8 = null, // null → instance, non-null → static (brand check 클래스명)
-    };
-
-    /// `class_name` 으로 instance/static 을 구분 — null 이면 instance (WeakSet 기반),
-    /// non-null 이면 static (descriptor 객체 + class brand check).
-    pub const PrivateMethodMapping = struct {
-        original_name: []const u8, // "#method" (원본 소스 텍스트)
-        weakset_name: []const u8, // "_method" (WeakSet 변수명 — 같은 name 의 getter/setter 공유)
-        func_name: []const u8, // kind 에 따라 "_method_fn" / "_method_get" / "_method_set"
-        member_idx: NodeIndex = NodeIndex.none, // method_definition 노드 (ES2015 경로에서 사용)
-        // standalone function_declaration 의 span 으로 사용 — leading comment 가
-        // `function _fn()` 뒤가 아니라 함수 앞에서 flush 되도록 (#1516).
-        member_span: Span = .{ .start = 0, .end = 0 },
-        /// method / getter / setter (#1523).
-        kind: @import("es_helpers.zig").PrivateMethodKind = .method,
-        class_name: ?[]const u8 = null, // null → instance, non-null → static
-    };
+    pub const BlockRenameEntry = state_mod.BlockRenameEntry;
+    pub const GeneratorLabelEntry = state_mod.GeneratorLabelEntry;
+    pub const NewTargetCtx = state_mod.NewTargetCtx;
+    pub const ConstEnumValue = state_mod.ConstEnumValue;
+    pub const ConstEnumMember = state_mod.ConstEnumMember;
+    pub const ConstEnumDecl = state_mod.ConstEnumDecl;
+    pub const PrivateFieldMapping = state_mod.PrivateFieldMapping;
+    pub const PrivateMethodMapping = state_mod.PrivateMethodMapping;
 
     // RefreshRegistration / RefreshSignature 타입 정의는 plugin_state.zig로 이사.
     // 외부 모듈 (refresh.zig 등)에서 `Transformer.RefreshRegistration`로 접근 가능하도록 alias 제공.
@@ -369,7 +319,7 @@ pub const Transformer = struct {
         return finishInit(allocator, @constCast(ast), opts, .borrowed);
     }
 
-    const AstOwnership = enum { owned, borrowed };
+    const AstOwnership = state_mod.AstOwnership;
 
     fn finishInit(
         allocator: std.mem.Allocator,


### PR DESCRIPTION
## 요약
- `ModuleGraph`의 builtin plugin/PluginRunner 게이트를 `src/bundler/graph/plugins.zig`로 분리했습니다.
- `ModuleGraph` 상태 타입(`PkgInfo`, `WorkerEntry`, `RequestedExports`, module list alias)을 `src/bundler/graph/state.zig`로 분리했습니다.
- `Transformer` 상태 타입(`AstOwnership`, block rename/generator/new.target/const enum/private mapping 타입)을 `src/transformer/state.zig`로 분리했습니다.
- 기존 `ModuleGraph.X`, `Transformer.X` 타입 접근은 alias로 유지했습니다.

## 분리 기준
- 단순 줄 수 감소보다 기능 단위 가독성을 우선했습니다.
- runtime polyfill 전체는 내부 graph mutation 함수까지 같이 노출해야 해서 이번 PR에서는 제외했습니다. 대신 private graph mutation을 건드리지 않는 plugin/builtin runner 경계를 먼저 분리했습니다.
- state 타입은 구현 로직과 별개로 여러 helper 모듈에서 공유되는 public 타입이라 별도 파일 경계가 자연스럽습니다.

## 라인 수
- `src/bundler/graph.zig`: 4,225 -> 4,154
- `src/transformer/transformer.zig`: 3,462 -> 3,412
- 신규 `src/bundler/graph/plugins.zig`: 54
- 신규 `src/bundler/graph/state.zig`: 30
- 신규 `src/transformer/state.zig`: 65

## 검증
- `zig build test`
- `zig build`
- `zig build napi`
- `bun test --cwd tests/integration tests/downlevel.test.ts tests/runtime-helper-virtual-module.test.ts --timeout 10000`
- `node --test packages/core/napi.test.mjs`
- `git diff --check`
- pre-push: `zig fmt --check src/...`, `zig build test`, `oxlint`(기존 경고 23개, 에러 0), `oxfmt --check`