### PR TITLE
docs: update ZNTC expansion wording

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# ZNTC - Zig Native Transpiler Compiler
+# ZNTC - Zig Native Transpiler & Compiler
 
 Zig로 작성하는 JS/TS/Flow 트랜스파일러 + 번들러 (SWC/oxc 수준 목표).
 C NAPI 바인딩으로 Node.js/Bun에서 in-process 사용, Vite/Rollup 플러그인 어댑터 지원.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ZNTC - Zig Native Transpiler Compiler
+# ZNTC - Zig Native Transpiler & Compiler
 
-JavaScript / TypeScript / Flow 를 네이티브 속도로 처리하는 Zig Native Transpiler Compiler.
+JavaScript / TypeScript / Flow 를 네이티브 속도로 처리하는 Zig Native Transpiler & Compiler.
 트랜스파일과 번들링 파이프라인을 함께 제공합니다.
 
 > **Status**: Phase 1–6 전반 완료 (렉서/파서/세만틱/트랜스포머/코드젠/번들러/Dev 서버/HMR).

--- a/documents/astro.config.mjs
+++ b/documents/astro.config.mjs
@@ -13,7 +13,7 @@ export default defineConfig({
   integrations: [
     starlight({
       title: "ZNTC",
-      description: "Zig Native Transpiler Compiler",
+      description: "Zig Native Transpiler & Compiler",
       expressiveCode: {
         themes: ["github-dark", "github-light"],
         styleOverrides: {

--- a/documents/src/content/docs/en/guides/introduction.md
+++ b/documents/src/content/docs/en/guides/introduction.md
@@ -5,7 +5,7 @@ description: Learn what ZNTC is and why it was built.
 
 ## What is ZNTC?
 
-ZNTC stands for **Zig Native Transpiler Compiler**. It is a native-speed transpile and bundling toolchain for JavaScript, TypeScript, and Flow, aiming for production-level quality on par with SWC and oxc.
+ZNTC stands for **Zig Native Transpiler & Compiler**. It is a native-speed transpile and bundling toolchain for JavaScript, TypeScript, and Flow, aiming for production-level quality on par with SWC and oxc.
 
 ## Key Features
 

--- a/documents/src/content/docs/en/index.mdx
+++ b/documents/src/content/docs/en/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: ZNTC
-description: Zig Native Transpiler Compiler for JavaScript and TypeScript
+description: "Zig Native Transpiler & Compiler for JavaScript and TypeScript"
 template: splash
 head:
   - tag: style
@@ -27,7 +27,7 @@ import CtaCard from "../../../components/landing/CtaCard.astro";
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 <Hero
-  eyebrow="Zig Native Transpiler Compiler"
+  eyebrow="Zig Native Transpiler & Compiler"
   title={`Fast, lightweight\nTypeScript toolchain`}
   subtitle="A transpiler + bundler written in Zig. JavaScript · TypeScript · JSX · Flow at native speed, with a Vite/Rollup-compatible plugin system."
   actions={[

--- a/documents/src/content/docs/guides/introduction.md
+++ b/documents/src/content/docs/guides/introduction.md
@@ -5,7 +5,7 @@ description: ZNTC가 무엇인지, 왜 만들었는지 알아봅니다.
 
 ## ZNTC란?
 
-ZNTC는 **Zig Native Transpiler Compiler**의 약자로, JavaScript/TypeScript/Flow를 네이티브 속도로 처리하는 트랜스파일 및 번들링 툴체인입니다. SWC, oxc 수준의 프로덕션 레벨 품질을 목표로 합니다.
+ZNTC는 **Zig Native Transpiler & Compiler**의 약자로, JavaScript/TypeScript/Flow를 네이티브 속도로 처리하는 트랜스파일 및 번들링 툴체인입니다. SWC, oxc 수준의 프로덕션 레벨 품질을 목표로 합니다.
 
 ## 주요 기능
 

--- a/documents/src/content/docs/index.mdx
+++ b/documents/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: ZNTC
-description: JavaScript/TypeScript를 위한 Zig Native Transpiler Compiler
+description: "JavaScript/TypeScript를 위한 Zig Native Transpiler & Compiler"
 template: splash
 head:
   - tag: style
@@ -27,7 +27,7 @@ import CtaCard from "../../components/landing/CtaCard.astro";
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 <Hero
-  eyebrow="Zig Native Transpiler Compiler"
+  eyebrow="Zig Native Transpiler & Compiler"
   title={`빠르고 가벼운\nTypeScript 트랜스파일러`}
   subtitle="Zig 로 작성한 트랜스파일러 + 번들러. JavaScript · TypeScript · JSX · Flow 를 네이티브 속도로 처리하고, Vite/Rollup 호환 플러그인 시스템을 제공합니다."
   actions={[

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
 # @zntc/core
 
-ZNTC (Zig Native Transpiler Compiler) 의 코어 — Zig 로 작성된 JS/TS/Flow 트랜스파일러 + 번들러의 Node.js NAPI 바인딩 + JS API + CLI.
+ZNTC (Zig Native Transpiler & Compiler) 의 코어 — Zig 로 작성된 JS/TS/Flow 트랜스파일러 + 번들러의 Node.js NAPI 바인딩 + JS API + CLI.
 
 SWC / oxc 와 동급 성능을 목표로, in-process 호출 (NAPI) + Vite/Rollup 어댑터 / 단독 CLI 모두 제공.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zntc/core",
   "version": "0.1.0",
-  "description": "ZNTC native transpiler compiler binding",
+  "description": "ZNTC native transpiler & compiler binding",
   "license": "MIT",
   "bin": {
     "zntc": "./bin/zntc.mjs"

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zntc/wasm",
   "version": "0.1.0",
-  "description": "ZNTC native transpiler compiler — WASM build",
+  "description": "ZNTC native transpiler & compiler — WASM build",
   "license": "MIT",
   "files": [
     "dist/",

--- a/src/main.zig
+++ b/src/main.zig
@@ -3011,7 +3011,7 @@ fn collectWatchRootMtimes(
 
 fn printUsage(writer: anytype) !void {
     try writer.print(
-        \\zntc v0.1.0 - Zig Native Transpiler Compiler
+        \\zntc v0.1.0 - Zig Native Transpiler & Compiler
         \\
         \\Usage:
         \\  zntc <file.ts>                    Transpile to stdout

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,4 +1,4 @@
-//! ZNTC — Zig Native Transpiler Compiler
+//! ZNTC — Zig Native Transpiler & Compiler
 //!
 //! 라이브러리 엔트리포인트. 모든 공개 모듈을 여기서 re-export한다.
 


### PR DESCRIPTION
## 요약
- ZNTC 풀네임 표기를 `Zig Native Transpiler Compiler`에서 `Zig Native Transpiler & Compiler`로 정리
- README, CLAUDE, CLI help, docs 사이트 메타/본문, package description, package README 표기 동기화

## 확인
- `rg -n "Navite|Zig Native Transpiler Compiler|native transpiler compiler|Transpiler Compiler" --glob '!tests/test262/**' --glob '!bun.lock' --glob '!node_modules/**'`
- `git diff --check`

## 테스트
- 문구 변경만 포함되어 별도 빌드/런타임 테스트는 실행하지 않음
