### PR TITLE
refactor: graph transform prepass 분리

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -41,8 +41,6 @@ const Parser = @import("../parser/parser.zig").Parser;
 const SemanticAnalyzer = @import("../semantic/analyzer.zig").SemanticAnalyzer;
 const profile = @import("../profile.zig");
 const semantic_symbol = @import("../semantic/symbol.zig");
-const ModuleSemanticData = @import("module.zig").ModuleSemanticData;
-const AliasTable = @import("module.zig").AliasTable;
 const stmt_info_mod = @import("stmt_info.zig");
 const purity = @import("purity.zig");
 const Span = @import("../lexer/token.zig").Span;
@@ -54,8 +52,6 @@ const transformer_mod = @import("../transformer/transformer.zig");
 const Transformer = transformer_mod.Transformer;
 const TransformOptions = transformer_mod.TransformOptions;
 const TransformCache = @import("module.zig").TransformCache;
-const builtin_plugins = @import("../transformer/plugins/builtin.zig");
-const Ast = @import("../parser/ast.zig").Ast;
 const NodeIndex = @import("../parser/ast.zig").NodeIndex;
 const module_parser = @import("../parser/module.zig");
 const runtime_helper_modules = @import("../runtime_helper_modules.zig");
@@ -74,6 +70,7 @@ const collectScaleVariants = graph_assets.collectScaleVariants;
 const computeAssetDir = graph_assets.computeAssetDir;
 const assetSourceFromBytes = graph_assets.sourceFromBytes;
 const moduleReadsSourceForAsset = graph_assets.loaderReadsSource;
+const graph_transform_prepass = @import("graph/transform_prepass.zig");
 const graph_synthetic_imports = @import("graph/synthetic_imports.zig");
 const injectJsxRuntimeImports = graph_synthetic_imports.injectJsxRuntimeImports;
 const injectFlowEnumRuntimeImport = graph_synthetic_imports.injectFlowEnumRuntimeImport;
@@ -89,6 +86,8 @@ const graph_requested_exports = @import("graph/requested_exports.zig");
 const graph_runtime_polyfills = @import("graph/runtime_polyfills.zig");
 const graph_state = @import("graph/state.zig");
 
+pub const determineExportsKind = graph_parse_helpers.determineExportsKind;
+
 pub const ModuleGraph = struct {
     pub const matchSideEffectsPatterns = graph_package_side_effects.matchPatterns;
     const configureParserForModule = graph_parse_helpers.configureParserForModule;
@@ -103,6 +102,10 @@ pub const ModuleGraph = struct {
     const shouldLinkResolvedRecordForModule = graph_requested_exports.shouldLinkResolvedRecordForModule;
     const hasDeferredRequestedImports = graph_requested_exports.hasDeferredRequestedImports;
     const requestDependencyExports = graph_requested_exports.requestDependencyExports;
+    const shouldRunTransformerPrePass = graph_transform_prepass.shouldRun;
+    const runTransformerPrePass = graph_transform_prepass.run;
+    pub const resyncModuleMetadataAfterConstMaterialization = graph_transform_prepass.resyncAfterConstMaterialization;
+    pub const resyncModuleMetadataAfterAstMutation = graph_transform_prepass.resyncAfterAstMutation;
 
     allocator: std.mem.Allocator,
     /// Module storage. SegmentedList 는 append 시에도 기존 포인터를 무효화하지
@@ -2217,451 +2220,6 @@ pub const ModuleGraph = struct {
         module.state = .parsed;
     }
 
-    /// 보수적 graph pre-pass 게이트.
-    ///
-    /// graph 단계 pre-pass 는 helper/runtime import 를 link 전에 발견해야 하는 모듈에만
-    /// 필요하다. 단순 ESM/TS-strip 모듈은 parser scan + semantic 결과를 그대로 쓰고,
-    /// emit 단계의 legacy transformer/codegen 경로가 최종 출력 변환을 수행한다.
-    fn shouldRunTransformerPrePass(
-        self: *const ModuleGraph,
-        module: *const Module,
-        plugin_transform_applied: bool,
-    ) bool {
-        {
-            var gate_scope = profile.begin(.graph_discover_pm_prepass_decision_module_gate);
-            defer gate_scope.end();
-            if (!module.module_type.isJavaScriptLike()) return false;
-            if (plugin_transform_applied) return true;
-
-            // Check cheap single-byte flags before the heavier option predicate.
-            if (self.minify_identifiers) return true;
-            if (self.react_refresh or self.styled_components or self.emotion or self.worklet_transform) {
-                return true;
-            }
-        }
-
-        const ast = &module.ast.?;
-        {
-            var ast_flags_scope = profile.begin(.graph_discover_pm_prepass_decision_ast_flags);
-            defer ast_flags_scope.end();
-            if (ast.has_jsx or ast.has_decorator or ast.has_ts_namespace_or_enum or
-                ast.has_ts_import_equals or ast.has_ts_export_equals)
-            {
-                return true;
-            }
-        }
-
-        {
-            var options_scope = profile.begin(.graph_discover_pm_prepass_decision_options);
-            defer options_scope.end();
-            return self.transform_options_base.requiresGraphPrePass(ast);
-        }
-    }
-
-    /// transformer pre-pass — graph 단계에서 1회 실행.
-    /// 결과: `module.ast` 를 transformer 결과 AST 로 교체, `module.transform_cache` set,
-    /// final AST 기준 분석 데이터 refresh.
-    /// 실패 시 error diagnostic 을 남기고 모듈 파싱을 중단한다. stale semantic/binding
-    /// 데이터로 tree-shaker/linker 가 진행하는 silent bug 를 막기 위한 정책 (#1913).
-    fn runTransformerPrePass(self: *ModuleGraph, module: *Module, arena_alloc: std.mem.Allocator) void {
-        if (module.ast == null) return;
-        const ast_ptr = &(module.ast.?);
-
-        // emitter 와 동일한 옵션 결정 휴리스틱 — 결과 분기 시 cache mismatch.
-        const is_user_code = std.mem.indexOf(u8, module.path, "/node_modules/") == null;
-        // worklet 변환은 react-native/@react-native 코어 제외, 나머지 node_modules 포함.
-        const exclude_worklet = self.worklet_transform and
-            (std.mem.indexOf(u8, module.path, "/node_modules/react-native/") != null or
-                std.mem.indexOf(u8, module.path, "/node_modules/@react-native/") != null);
-        const merged_plugins = builtin_plugins.collect(.{
-            .worklet = self.worklet_transform and !exclude_worklet,
-        }, self.plugins, arena_alloc) catch return;
-
-        const parser_node_count: u32 = @intCast(ast_ptr.nodes.items.len);
-
-        var opts = self.transform_options_base;
-        opts.react_refresh = self.react_refresh and is_user_code;
-        opts.styled_components = self.styled_components and is_user_code;
-        opts.styled_components_ssr = self.styled_components_ssr;
-        opts.styled_components_minify = self.styled_components_minify;
-        opts.styled_components_file_name = self.styled_components_file_name;
-        opts.styled_components_pure = self.styled_components_pure;
-        opts.styled_components_namespace = self.styled_components_namespace;
-        opts.styled_components_meaningless_file_names = self.styled_components_meaningless_file_names;
-        opts.styled_components_top_level_import_paths = self.styled_components_top_level_import_paths;
-        opts.styled_components_css_prop = self.styled_components_css_prop;
-        opts.emotion = self.emotion and is_user_code;
-        opts.emotion_auto_label = self.emotion_auto_label;
-        opts.emotion_source_map = self.emotion_source_map;
-        opts.emotion_label_format = self.emotion_label_format;
-        opts.emotion_extra_css_sources = self.emotion_extra_css_sources;
-        opts.emotion_extra_styled_sources = self.emotion_extra_styled_sources;
-        opts.plugins = merged_plugins;
-        opts.jsx_transform = ast_ptr.has_jsx;
-        opts.jsx_filename = module.path;
-        // #1961 PR 1h 후 splitting / single-bundle 양쪽에서 helper module virtual import
-        // 모델 활성. mangler 가 helper module top-level 식별자를 reserved 처리
-        // (linker.zig 의 candidates collect 에서 isVirtualId 분기) — cross-module binding
-        // 안전. dev mode 모듈도 동일.
-        opts.emit_runtime_helper_imports = true;
-
-        var transformer = Transformer.init(arena_alloc, ast_ptr, opts) catch return;
-
-        if (module.semantic) |sem| {
-            transformer.initSymbolIds(sem.symbol_ids) catch return;
-            transformer.symbols = sem.symbols.items;
-            transformer.references = sem.references;
-        }
-        transformer.line_offsets = module.line_offsets;
-
-        const root = transformer.transform() catch return;
-        if (self.ignore_annotations) {
-            purity.clearPureCallFlags(transformer.ast);
-        } else {
-            purity.markUserPureCalls(transformer.ast, self.pure);
-        }
-        if (self.transform_options_base.minify_syntax) {
-            const minify_mod = @import("../transformer/minify.zig");
-            const ctx: minify_mod.MinifyCtx = if (module.semantic != null)
-                minify_mod.MinifyCtx.fromSemantic(&module.semantic.?, transformer.symbol_ids.items, true)
-            else
-                .empty;
-            minify_mod.minify(transformer.ast, ctx, arena_alloc, root);
-        }
-
-        // transformer 가 새 ast (clone) 에 transform 결과를 보유. module.ast 를 그 새 ast 로
-        // swap. arena_alloc 가 owner 라 backing 은 안전. emit 단계 transformer 가 module.ast
-        // 를 clone 시 transformed_root 까지 복사되어 cache hit 분기 즉시 return.
-        module.ast = transformer.ast.*;
-
-        const owned_symbol_ids = transformer.symbol_ids.toOwnedSlice(arena_alloc) catch &[_]?u32{};
-        module.transform_cache = .{
-            .runtime_helpers = transformer.runtime_helpers,
-            .symbol_ids = owned_symbol_ids,
-        };
-
-        _ = parser_node_count;
-
-        self.resyncModuleMetadataAfterAstMutation(module, arena_alloc) catch {
-            self.addDiag(
-                .parse_error,
-                .@"error",
-                module.path,
-                Span.EMPTY,
-                .parse,
-                "Post-transform analysis refresh failed",
-                "The transformed AST could not be re-analyzed safely.",
-            );
-            module.state = .ready;
-            return;
-        };
-    }
-
-    /// AST mutation 이후 module 의 graph-facing metadata 를 같은 AST 기준으로 재동기화한다.
-    ///
-    /// 이 함수는 단순 semantic refresh 가 아니다. transformed/minified AST 를 기준으로
-    /// semantic symbol table, StmtInfo, import/require records, import/export bindings,
-    /// namespace access, exported_names, ESM/CJS classification, synthetic JSX imports,
-    /// alias table 을 다시 맞춘다.
-    ///
-    /// 호출 후 invariant:
-    /// - `module.ast`, `module.semantic`, `module.prebuilt_stmt_info`,
-    ///   `module.import_records`, `module.import_bindings`, `module.export_bindings`,
-    ///   `module.exported_names`, `module.alias_table` 은 모두 같은 AST snapshot 기준이다.
-    /// - runtime helper virtual module 내부의 helper 이름은 unresolved global 에 남지 않는다.
-    ///
-    /// 이 중앙 resync 경로를 우회해서 record/binding 만 수동 보정하면 linker, tree-shaker,
-    /// chunking 이 서로 다른 AST/semantic 상태를 보게 되므로 여기서만 metadata 재구축
-    /// 정책을 확장해야 한다 (#1913).
-    fn preserveCanonicalNamesAfterSemanticResync(
-        source: []const u8,
-        old_sem: ModuleSemanticData,
-        new_sem: *ModuleSemanticData,
-    ) void {
-        const module_scope: ?*const std.StringHashMap(usize) = if (new_sem.scope_maps.len > 0) &new_sem.scope_maps[0] else null;
-        for (old_sem.symbols.items) |old_sym| {
-            if (old_sym.canonical_name.len == 0) continue;
-
-            if (old_sym.synthetic_kind == null) {
-                const name = old_sym.nameText(source);
-                const new_idx = if (module_scope) |scope| scope.get(name) else null;
-                if (new_idx) |idx| {
-                    if (idx < new_sem.symbols.items.len) {
-                        const new_sym = &new_sem.symbols.items[idx];
-                        if (new_sym.synthetic_kind == null) {
-                            new_sym.canonical_name = old_sym.canonical_name;
-                        }
-                    }
-                }
-                continue;
-            }
-
-            for (new_sem.symbols.items) |*new_sym| {
-                if (new_sym.synthetic_kind != old_sym.synthetic_kind) continue;
-                if (!std.mem.eql(u8, new_sym.synthetic_name, old_sym.synthetic_name)) continue;
-                new_sym.canonical_name = old_sym.canonical_name;
-                break;
-            }
-        }
-    }
-
-    fn refreshSemanticAndStmtInfoAfterAstMutation(
-        self: *ModuleGraph,
-        module: *Module,
-        arena_alloc: std.mem.Allocator,
-    ) !void {
-        const ast = &(module.ast orelse return);
-        const previous_semantic = module.semantic;
-
-        var analyzer = SemanticAnalyzer.init(arena_alloc, ast);
-        {
-            var semantic_scope = profile.begin(.graph_resync_semantic);
-            defer semantic_scope.end();
-
-            analyzer.is_strict_mode = true;
-            analyzer.is_module = true;
-            analyzer.is_ts = module.module_type.isTypeScript();
-            analyzer.is_flow = self.flow or isFlowPath(module.path);
-            analyzer.enable_stmt_info = true;
-            try analyzer.analyze();
-
-            module.semantic = .{
-                .symbols = analyzer.symbols,
-                .scopes = analyzer.scopes.items,
-                .scope_maps = analyzer.scope_maps.items,
-                .exported_names = analyzer.exported_names,
-                .symbol_ids = analyzer.symbol_ids.items,
-                .unresolved_references = analyzer.unresolved_references,
-                .references = analyzer.references.items,
-                .numeric_const_texts = analyzer.numeric_const_texts,
-            };
-            if (!self.minify_identifiers) {
-                if (previous_semantic) |old_sem| {
-                    preserveCanonicalNamesAfterSemanticResync(module.source, old_sem, &module.semantic.?);
-                }
-            }
-            suppressRuntimeHelperInternalUnresolved(module);
-            module.uses_top_level_await = analyzer.has_top_level_await;
-            if (module.transform_cache) |*cache| {
-                cache.symbol_ids = analyzer.symbol_ids.items;
-            }
-        }
-
-        if (self.ignore_annotations) {
-            purity.clearPureCallFlags(ast);
-        } else {
-            purity.markUserPureCalls(ast, self.pure);
-        }
-
-        {
-            var stmt_info_scope = profile.begin(.graph_resync_stmt_info);
-            defer stmt_info_scope.end();
-
-            module.prebuilt_stmt_info = null;
-            if (analyzer.stmt_info_count > 0) {
-                module.prebuilt_stmt_info = try stmt_info_mod.buildFromSemantic(
-                    arena_alloc,
-                    ast,
-                    analyzer.symbols.items,
-                    analyzer.references.items,
-                    if (module.semantic) |*s| &s.unresolved_references else null,
-                    false,
-                );
-            }
-        }
-    }
-
-    fn refreshStableBindingRefsAfterSemanticResync(
-        self: *ModuleGraph,
-        module: *Module,
-        arena_alloc: std.mem.Allocator,
-        cat: profile.Category,
-    ) !void {
-        var binding_refs_scope = profile.begin(cat);
-        defer binding_refs_scope.end();
-
-        const sem = if (module.semantic) |*s| s else return;
-        const scope0: ?std.StringHashMap(usize) =
-            if (sem.scope_maps.len > 0) sem.scope_maps[0] else null;
-        for (module.import_bindings) |*ib| {
-            if (ib.isSynthetic()) continue;
-            ib.local_symbol = bundler_symbol.SymbolRef.invalid;
-            if (scope0) |module_scope| {
-                if (module_scope.get(ib.local_name)) |sym_idx| {
-                    ib.local_symbol = bundler_symbol.SymbolRef.makeSemantic(module.index, sym_idx);
-                }
-            }
-        }
-
-        if (module.alias_table) |*table| table.deinit();
-        module.alias_table = AliasTable.init(self.allocator);
-        try binding_scanner_mod.populateSyntheticSymbols(
-            &module.alias_table.?,
-            module.index,
-            module.export_bindings,
-            &sem.symbols,
-            arena_alloc,
-            scope0,
-        );
-    }
-
-    /// Numeric const materialization replaces identifier reads and may let minify fold
-    /// expressions, but it does not add/remove import or export declarations. Keep the
-    /// expensive syntax-level scanners intact for general transforms and use this path
-    /// only when the caller owns that invariant.
-    pub fn resyncModuleMetadataAfterConstMaterialization(
-        self: *ModuleGraph,
-        module: *Module,
-        arena_alloc: std.mem.Allocator,
-    ) !void {
-        var resync_scope = profile.begin(.graph_resync);
-        defer resync_scope.end();
-        var const_scope = profile.begin(.graph_resync_const);
-        defer const_scope.end();
-
-        _ = &(module.ast orelse return);
-        try self.refreshSemanticAndStmtInfoAfterAstMutation(module, arena_alloc);
-        try self.refreshStableBindingRefsAfterSemanticResync(module, arena_alloc, .graph_resync_binding_refs);
-    }
-
-    pub fn resyncModuleMetadataAfterAstMutation(
-        self: *ModuleGraph,
-        module: *Module,
-        arena_alloc: std.mem.Allocator,
-    ) !void {
-        var resync_scope = profile.begin(.graph_resync);
-        defer resync_scope.end();
-
-        const ast = &(module.ast orelse return);
-        const previous_import_records = module.import_records;
-        const previous_import_bindings = module.import_bindings;
-
-        try self.refreshSemanticAndStmtInfoAfterAstMutation(module, arena_alloc);
-
-        var scan_result: import_scanner.ScanResult = undefined;
-        {
-            var import_scan_scope = profile.begin(.graph_resync_import_scan);
-            defer import_scan_scope.end();
-
-            scan_result = try import_scanner.extractImportsWithCjsDetectionAndDefines(arena_alloc, ast, self.defines);
-            module.import_records = try mergeImportRecords(arena_alloc, previous_import_records, scan_result.records);
-            // specifier dupe — arena 로 owned 화 (#raw-require UAF 회피).
-            for (module.import_records) |*r| {
-                if (arena_alloc.dupe(u8, r.specifier)) |owned| r.specifier = owned else |_| {}
-            }
-            try import_scanner.markPostScanFlags(arena_alloc, ast, module.import_records);
-        }
-
-        {
-            var import_bindings_scope = profile.begin(.graph_resync_import_bindings);
-            defer import_bindings_scope.end();
-
-            const transformed_import_bindings = try binding_scanner_mod.extractImportBindings(arena_alloc, ast, module.import_records);
-            module.import_bindings = try mergeImportBindings(arena_alloc, previous_import_bindings, transformed_import_bindings);
-            try binding_scanner_mod.collectNamespaceAccesses(arena_alloc, ast, module.import_bindings);
-        }
-
-        {
-            var export_bindings_scope = profile.begin(.graph_resync_export_bindings);
-            defer export_bindings_scope.end();
-
-            module.export_bindings = try binding_scanner_mod.extractExportBindings(
-                arena_alloc,
-                ast,
-                module.import_records,
-                module.import_bindings,
-            );
-            module.exported_names = projectExportedNames(arena_alloc, module.export_bindings);
-        }
-
-        const has_refreshed_cjs = scan_result.has_cjs_require or
-            scan_result.has_module_exports or
-            scan_result.has_exports_dot;
-        const has_refreshed_esm = if (module.exports_kind == .commonjs and has_refreshed_cjs)
-            false
-        else
-            scan_result.has_esm_syntax;
-
-        const refreshed_scan_result = import_scanner.ScanResult{
-            .records = module.import_records,
-            .has_esm_syntax = has_refreshed_esm,
-            .has_cjs_require = scan_result.has_cjs_require,
-            .has_module_exports = scan_result.has_module_exports,
-            .has_exports_dot = scan_result.has_exports_dot,
-            .has_esmodule_marker = scan_result.has_esmodule_marker,
-        };
-
-        {
-            var classify_scope = profile.begin(.graph_resync_classify);
-            defer classify_scope.end();
-
-            try self.injectJsxSyntheticImportsForModule(module, arena_alloc, ast);
-
-            // 기존 exports_kind 가 ESM 인데 post-transform scan 이 `.none` 으로 떨어지는 경우
-            // (예: TS interface-only 파일의 `export {};` 를 transformer 가 drop) ESM 분류를 유지한다.
-            // `.none` 으로 강등하면 Pass 2 markEsmCjsHybrid 가 node_modules + def_format unknown
-            // 모듈을 implicit CJS 로 승격시켜, `export *` chain 의 빈 source 가 CJS wrapper 로
-            // wrap 되고 `resolveOrCjsFallback` 이 잘못된 모듈을 named import 의 source 로 반환한다
-            // (kysely/cheerio 회귀 #2052/#2051).
-            const refreshed_kind = determineExportsKind(refreshed_scan_result, module.path);
-            const previous_kind = module.exports_kind;
-            const preserve_esm = refreshed_kind == .none and previous_kind.isEsm();
-            module.exports_kind = if (preserve_esm) previous_kind else refreshed_kind;
-            module.wrap_kind = if (module.exports_kind == .commonjs) .cjs else .none;
-            module.has_cjs_export_signal = refreshed_scan_result.has_module_exports or refreshed_scan_result.has_exports_dot;
-            module.can_skip_cjs_default_interop = Module.computeCanSkipCjsDefaultInterop(
-                module.wrap_kind == .cjs,
-                refreshed_scan_result.has_module_exports,
-                refreshed_scan_result.has_exports_dot,
-                refreshed_scan_result.has_esmodule_marker,
-            );
-        }
-
-        try self.refreshStableBindingRefsAfterSemanticResync(module, arena_alloc, .graph_resync_alias);
-    }
-
-    fn injectJsxSyntheticImportsForModule(
-        self: *ModuleGraph,
-        module: *Module,
-        arena_alloc: std.mem.Allocator,
-        ast: *const Ast,
-    ) !void {
-        if (self.jsx_runtime == .classic or !ast.has_jsx) return;
-        if (self.jsx_specifier_cache == null) {
-            const is_dev = self.jsx_runtime == .automatic_dev;
-            self.jsx_specifier_cache = try std.fmt.allocPrint(
-                self.allocator,
-                "{s}/{s}",
-                .{ self.jsx_import_source, if (is_dev) "jsx-dev-runtime" else "jsx-runtime" },
-            );
-        }
-        const specifier = self.jsx_specifier_cache orelse return;
-        for (module.import_records) |rec| {
-            if (rec.kind == .static_import and std.mem.eql(u8, rec.specifier, specifier)) return;
-        }
-        const base_record_count: u32 = @intCast(module.import_records.len);
-        var specs_buf: [2][]const u8 = undefined;
-        specs_buf[0] = specifier;
-        var n: usize = 1;
-        const react_injected = ast.has_jsx_key_after_spread;
-        if (react_injected) {
-            specs_buf[n] = self.jsx_import_source;
-            n += 1;
-        }
-        module.import_records = try injectJsxRuntimeImports(
-            specs_buf[0..n],
-            arena_alloc,
-            module.import_records,
-        );
-        module.import_bindings = try createJsxImportBindings(
-            self.jsx_runtime,
-            arena_alloc,
-            module.import_bindings,
-            base_record_count,
-            if (react_injected) base_record_count + 1 else null,
-        );
-    }
-
     const findPackageDirPath = resolve_cache_mod.findPackageDirPath;
 
     /// `pkg_info_cache` 통합 lookup. pkg_dir_path 별 1회만 parsePackageJson,
@@ -3499,7 +3057,7 @@ pub const ModuleGraph = struct {
         return loaded.loaded.contents;
     }
 
-    fn addDiag(
+    pub fn addDiag(
         self: *ModuleGraph,
         code: BundlerDiagnostic.ErrorCode,
         severity: BundlerDiagnostic.Severity,
@@ -3587,39 +3145,6 @@ pub const ModuleGraph = struct {
         self.addDiag(.plugin_error, .@"error", file_path, span, step, message, null);
     }
 };
-
-// ============================================================
-// Graph path utilities
-// ============================================================
-
-/// 스캔 결과와 파일 확장자로 모듈의 export 방식을 결정한다.
-/// 우선순위: 1) ESM+CJS 혼용 → esm_with_dynamic_fallback
-///          2) ESM만 → esm
-///          3) CJS 신호 → commonjs
-///          4) 확장자 (.cjs/.mjs 등) → commonjs/esm
-///          5) 판별 불가 → none
-pub fn determineExportsKind(
-    scan: import_scanner.ScanResult,
-    path: []const u8,
-) types.ExportsKind {
-    const has_cjs = scan.has_cjs_require or scan.has_module_exports or scan.has_exports_dot;
-
-    // ESM + CJS 혼용
-    if (scan.has_esm_syntax and has_cjs) return .esm_with_dynamic_fallback;
-
-    // ESM만
-    if (scan.has_esm_syntax) return .esm;
-
-    // CJS 신호
-    if (has_cjs) return .commonjs;
-
-    // 확장자로 판별
-    const ext = std.fs.path.extension(path);
-    if (std.mem.eql(u8, ext, ".cjs") or std.mem.eql(u8, ext, ".cts")) return .commonjs;
-    if (std.mem.eql(u8, ext, ".mjs") or std.mem.eql(u8, ext, ".mts")) return .esm;
-
-    return .none;
-}
 
 /// require.context(...) 레코드의 매칭 파일 목록을 host plugin (resolveContext) 으로 채운다.
 /// (#1579 Phase 2). ZNTC 자체 regex executor 가 없어서 host runtime 의 RegExp 위임 (#1771).

--- a/src/bundler/graph/parse_helpers.zig
+++ b/src/bundler/graph/parse_helpers.zig
@@ -6,6 +6,7 @@ const Module = @import("../module.zig").Module;
 const ModuleType = types.ModuleType;
 const Parser = @import("../../parser/parser.zig").Parser;
 const ImportRecord = types.ImportRecord;
+const import_scanner = @import("../import_scanner.zig");
 const binding_scanner = @import("../binding_scanner.zig");
 const runtime_helper_modules = @import("../../runtime_helper_modules.zig");
 
@@ -109,4 +110,33 @@ pub fn projectExportedNames(allocator: std.mem.Allocator, bindings: []const bind
     const out = allocator.alloc([]const u8, bindings.len) catch return &.{};
     for (bindings, 0..) |b, i| out[i] = b.exported_name;
     return out;
+}
+
+/// 스캔 결과와 파일 확장자로 모듈의 export 방식을 결정한다.
+/// 우선순위: 1) ESM+CJS 혼용 → esm_with_dynamic_fallback
+///          2) ESM만 → esm
+///          3) CJS 신호 → commonjs
+///          4) 확장자 (.cjs/.mjs 등) → commonjs/esm
+///          5) 판별 불가 → none
+pub fn determineExportsKind(
+    scan: import_scanner.ScanResult,
+    path: []const u8,
+) types.ExportsKind {
+    const has_cjs = scan.has_cjs_require or scan.has_module_exports or scan.has_exports_dot;
+
+    // ESM + CJS 혼용
+    if (scan.has_esm_syntax and has_cjs) return .esm_with_dynamic_fallback;
+
+    // ESM만
+    if (scan.has_esm_syntax) return .esm;
+
+    // CJS 신호
+    if (has_cjs) return .commonjs;
+
+    // 확장자로 판별
+    const ext = std.fs.path.extension(path);
+    if (std.mem.eql(u8, ext, ".cjs") or std.mem.eql(u8, ext, ".cts")) return .commonjs;
+    if (std.mem.eql(u8, ext, ".mjs") or std.mem.eql(u8, ext, ".mts")) return .esm;
+
+    return .none;
 }

--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -1,0 +1,473 @@
+//! ModuleGraph transformer pre-pass and post-transform metadata resync helpers.
+
+const std = @import("std");
+const Module = @import("../module.zig").Module;
+const ModuleSemanticData = @import("../module.zig").ModuleSemanticData;
+const AliasTable = @import("../module.zig").AliasTable;
+const binding_scanner_mod = @import("../binding_scanner.zig");
+const bundler_symbol = @import("../symbol.zig");
+const import_scanner = @import("../import_scanner.zig");
+const stmt_info_mod = @import("../stmt_info.zig");
+const purity = @import("../purity.zig");
+const profile = @import("../../profile.zig");
+const SemanticAnalyzer = @import("../../semantic/analyzer.zig").SemanticAnalyzer;
+const Transformer = @import("../../transformer/transformer.zig").Transformer;
+const builtin_plugins = @import("../../transformer/plugins/builtin.zig");
+const Span = @import("../../lexer/token.zig").Span;
+const Ast = @import("../../parser/ast.zig").Ast;
+const parse_helpers = @import("parse_helpers.zig");
+const graph_synthetic_imports = @import("synthetic_imports.zig");
+
+const isFlowPath = parse_helpers.isFlowPath;
+const suppressRuntimeHelperInternalUnresolved = parse_helpers.suppressRuntimeHelperInternalUnresolved;
+const mergeImportRecords = parse_helpers.mergeImportRecords;
+const mergeImportBindings = parse_helpers.mergeImportBindings;
+const projectExportedNames = parse_helpers.projectExportedNames;
+const determineExportsKind = parse_helpers.determineExportsKind;
+const injectJsxRuntimeImports = graph_synthetic_imports.injectJsxRuntimeImports;
+const createJsxImportBindings = graph_synthetic_imports.createJsxImportBindings;
+
+/// 보수적 graph pre-pass 게이트.
+///
+/// graph 단계 pre-pass 는 helper/runtime import 를 link 전에 발견해야 하는 모듈에만
+/// 필요하다. 단순 ESM/TS-strip 모듈은 parser scan + semantic 결과를 그대로 쓰고,
+/// emit 단계의 legacy transformer/codegen 경로가 최종 출력 변환을 수행한다.
+pub fn shouldRun(
+    self: anytype,
+    module: *const Module,
+    plugin_transform_applied: bool,
+) bool {
+    {
+        var gate_scope = profile.begin(.graph_discover_pm_prepass_decision_module_gate);
+        defer gate_scope.end();
+        if (!module.module_type.isJavaScriptLike()) return false;
+        if (plugin_transform_applied) return true;
+
+        // Check cheap single-byte flags before the heavier option predicate.
+        if (self.minify_identifiers) return true;
+        if (self.react_refresh or self.styled_components or self.emotion or self.worklet_transform) {
+            return true;
+        }
+    }
+
+    const ast = &module.ast.?;
+    {
+        var ast_flags_scope = profile.begin(.graph_discover_pm_prepass_decision_ast_flags);
+        defer ast_flags_scope.end();
+        if (ast.has_jsx or ast.has_decorator or ast.has_ts_namespace_or_enum or
+            ast.has_ts_import_equals or ast.has_ts_export_equals)
+        {
+            return true;
+        }
+    }
+
+    {
+        var options_scope = profile.begin(.graph_discover_pm_prepass_decision_options);
+        defer options_scope.end();
+        return self.transform_options_base.requiresGraphPrePass(ast);
+    }
+}
+
+/// transformer pre-pass — graph 단계에서 1회 실행.
+/// 결과: `module.ast` 를 transformer 결과 AST 로 교체, `module.transform_cache` set,
+/// final AST 기준 분석 데이터 refresh.
+/// 실패 시 error diagnostic 을 남기고 모듈 파싱을 중단한다. stale semantic/binding
+/// 데이터로 tree-shaker/linker 가 진행하는 silent bug 를 막기 위한 정책 (#1913).
+pub fn run(self: anytype, module: *Module, arena_alloc: std.mem.Allocator) void {
+    if (module.ast == null) return;
+    const ast_ptr = &(module.ast.?);
+
+    // emitter 와 동일한 옵션 결정 휴리스틱 — 결과 분기 시 cache mismatch.
+    const is_user_code = std.mem.indexOf(u8, module.path, "/node_modules/") == null;
+    // worklet 변환은 react-native/@react-native 코어 제외, 나머지 node_modules 포함.
+    const exclude_worklet = self.worklet_transform and
+        (std.mem.indexOf(u8, module.path, "/node_modules/react-native/") != null or
+            std.mem.indexOf(u8, module.path, "/node_modules/@react-native/") != null);
+    const merged_plugins = builtin_plugins.collect(.{
+        .worklet = self.worklet_transform and !exclude_worklet,
+    }, self.plugins, arena_alloc) catch return;
+
+    const parser_node_count: u32 = @intCast(ast_ptr.nodes.items.len);
+
+    var opts = self.transform_options_base;
+    opts.react_refresh = self.react_refresh and is_user_code;
+    opts.styled_components = self.styled_components and is_user_code;
+    opts.styled_components_ssr = self.styled_components_ssr;
+    opts.styled_components_minify = self.styled_components_minify;
+    opts.styled_components_file_name = self.styled_components_file_name;
+    opts.styled_components_pure = self.styled_components_pure;
+    opts.styled_components_namespace = self.styled_components_namespace;
+    opts.styled_components_meaningless_file_names = self.styled_components_meaningless_file_names;
+    opts.styled_components_top_level_import_paths = self.styled_components_top_level_import_paths;
+    opts.styled_components_css_prop = self.styled_components_css_prop;
+    opts.emotion = self.emotion and is_user_code;
+    opts.emotion_auto_label = self.emotion_auto_label;
+    opts.emotion_source_map = self.emotion_source_map;
+    opts.emotion_label_format = self.emotion_label_format;
+    opts.emotion_extra_css_sources = self.emotion_extra_css_sources;
+    opts.emotion_extra_styled_sources = self.emotion_extra_styled_sources;
+    opts.plugins = merged_plugins;
+    opts.jsx_transform = ast_ptr.has_jsx;
+    opts.jsx_filename = module.path;
+    // #1961 PR 1h 후 splitting / single-bundle 양쪽에서 helper module virtual import
+    // 모델 활성. mangler 가 helper module top-level 식별자를 reserved 처리
+    // (linker.zig 의 candidates collect 에서 isVirtualId 분기) — cross-module binding
+    // 안전. dev mode 모듈도 동일.
+    opts.emit_runtime_helper_imports = true;
+
+    var transformer = Transformer.init(arena_alloc, ast_ptr, opts) catch return;
+
+    if (module.semantic) |sem| {
+        transformer.initSymbolIds(sem.symbol_ids) catch return;
+        transformer.symbols = sem.symbols.items;
+        transformer.references = sem.references;
+    }
+    transformer.line_offsets = module.line_offsets;
+
+    const root = transformer.transform() catch return;
+    if (self.ignore_annotations) {
+        purity.clearPureCallFlags(transformer.ast);
+    } else {
+        purity.markUserPureCalls(transformer.ast, self.pure);
+    }
+    if (self.transform_options_base.minify_syntax) {
+        const minify_mod = @import("../../transformer/minify.zig");
+        const ctx: minify_mod.MinifyCtx = if (module.semantic != null)
+            minify_mod.MinifyCtx.fromSemantic(&module.semantic.?, transformer.symbol_ids.items, true)
+        else
+            .empty;
+        minify_mod.minify(transformer.ast, ctx, arena_alloc, root);
+    }
+
+    // transformer 가 새 ast (clone) 에 transform 결과를 보유. module.ast 를 그 새 ast 로
+    // swap. arena_alloc 가 owner 라 backing 은 안전. emit 단계 transformer 가 module.ast
+    // 를 clone 시 transformed_root 까지 복사되어 cache hit 분기 즉시 return.
+    module.ast = transformer.ast.*;
+
+    const owned_symbol_ids = transformer.symbol_ids.toOwnedSlice(arena_alloc) catch &[_]?u32{};
+    module.transform_cache = .{
+        .runtime_helpers = transformer.runtime_helpers,
+        .symbol_ids = owned_symbol_ids,
+    };
+
+    _ = parser_node_count;
+
+    resyncAfterAstMutation(self, module, arena_alloc) catch {
+        self.addDiag(
+            .parse_error,
+            .@"error",
+            module.path,
+            Span.EMPTY,
+            .parse,
+            "Post-transform analysis refresh failed",
+            "The transformed AST could not be re-analyzed safely.",
+        );
+        module.state = .ready;
+        return;
+    };
+}
+
+/// AST mutation 이후 module 의 graph-facing metadata 를 같은 AST 기준으로 재동기화한다.
+///
+/// 이 함수는 단순 semantic refresh 가 아니다. transformed/minified AST 를 기준으로
+/// semantic symbol table, StmtInfo, import/require records, import/export bindings,
+/// namespace access, exported_names, ESM/CJS classification, synthetic JSX imports,
+/// alias table 을 다시 맞춘다.
+///
+/// 호출 후 invariant:
+/// - `module.ast`, `module.semantic`, `module.prebuilt_stmt_info`,
+///   `module.import_records`, `module.import_bindings`, `module.export_bindings`,
+///   `module.exported_names`, `module.alias_table` 은 모두 같은 AST snapshot 기준이다.
+/// - runtime helper virtual module 내부의 helper 이름은 unresolved global 에 남지 않는다.
+///
+/// 이 중앙 resync 경로를 우회해서 record/binding 만 수동 보정하면 linker, tree-shaker,
+/// chunking 이 서로 다른 AST/semantic 상태를 보게 되므로 여기서만 metadata 재구축
+/// 정책을 확장해야 한다 (#1913).
+fn preserveCanonicalNamesAfterSemanticResync(
+    source: []const u8,
+    old_sem: ModuleSemanticData,
+    new_sem: *ModuleSemanticData,
+) void {
+    const module_scope: ?*const std.StringHashMap(usize) = if (new_sem.scope_maps.len > 0) &new_sem.scope_maps[0] else null;
+    for (old_sem.symbols.items) |old_sym| {
+        if (old_sym.canonical_name.len == 0) continue;
+
+        if (old_sym.synthetic_kind == null) {
+            const name = old_sym.nameText(source);
+            const new_idx = if (module_scope) |scope| scope.get(name) else null;
+            if (new_idx) |idx| {
+                if (idx < new_sem.symbols.items.len) {
+                    const new_sym = &new_sem.symbols.items[idx];
+                    if (new_sym.synthetic_kind == null) {
+                        new_sym.canonical_name = old_sym.canonical_name;
+                    }
+                }
+            }
+            continue;
+        }
+
+        for (new_sem.symbols.items) |*new_sym| {
+            if (new_sym.synthetic_kind != old_sym.synthetic_kind) continue;
+            if (!std.mem.eql(u8, new_sym.synthetic_name, old_sym.synthetic_name)) continue;
+            new_sym.canonical_name = old_sym.canonical_name;
+            break;
+        }
+    }
+}
+
+fn refreshSemanticAndStmtInfoAfterAstMutation(
+    self: anytype,
+    module: *Module,
+    arena_alloc: std.mem.Allocator,
+) !void {
+    const ast = &(module.ast orelse return);
+    const previous_semantic = module.semantic;
+
+    var analyzer = SemanticAnalyzer.init(arena_alloc, ast);
+    {
+        var semantic_scope = profile.begin(.graph_resync_semantic);
+        defer semantic_scope.end();
+
+        analyzer.is_strict_mode = true;
+        analyzer.is_module = true;
+        analyzer.is_ts = module.module_type.isTypeScript();
+        analyzer.is_flow = self.flow or isFlowPath(module.path);
+        analyzer.enable_stmt_info = true;
+        try analyzer.analyze();
+
+        module.semantic = .{
+            .symbols = analyzer.symbols,
+            .scopes = analyzer.scopes.items,
+            .scope_maps = analyzer.scope_maps.items,
+            .exported_names = analyzer.exported_names,
+            .symbol_ids = analyzer.symbol_ids.items,
+            .unresolved_references = analyzer.unresolved_references,
+            .references = analyzer.references.items,
+            .numeric_const_texts = analyzer.numeric_const_texts,
+        };
+        if (!self.minify_identifiers) {
+            if (previous_semantic) |old_sem| {
+                preserveCanonicalNamesAfterSemanticResync(module.source, old_sem, &module.semantic.?);
+            }
+        }
+        suppressRuntimeHelperInternalUnresolved(module);
+        module.uses_top_level_await = analyzer.has_top_level_await;
+        if (module.transform_cache) |*cache| {
+            cache.symbol_ids = analyzer.symbol_ids.items;
+        }
+    }
+
+    if (self.ignore_annotations) {
+        purity.clearPureCallFlags(ast);
+    } else {
+        purity.markUserPureCalls(ast, self.pure);
+    }
+
+    {
+        var stmt_info_scope = profile.begin(.graph_resync_stmt_info);
+        defer stmt_info_scope.end();
+
+        module.prebuilt_stmt_info = null;
+        if (analyzer.stmt_info_count > 0) {
+            module.prebuilt_stmt_info = try stmt_info_mod.buildFromSemantic(
+                arena_alloc,
+                ast,
+                analyzer.symbols.items,
+                analyzer.references.items,
+                if (module.semantic) |*s| &s.unresolved_references else null,
+                false,
+            );
+        }
+    }
+}
+
+fn refreshStableBindingRefsAfterSemanticResync(
+    self: anytype,
+    module: *Module,
+    arena_alloc: std.mem.Allocator,
+    cat: profile.Category,
+) !void {
+    var binding_refs_scope = profile.begin(cat);
+    defer binding_refs_scope.end();
+
+    const sem = if (module.semantic) |*s| s else return;
+    const scope0: ?std.StringHashMap(usize) =
+        if (sem.scope_maps.len > 0) sem.scope_maps[0] else null;
+    for (module.import_bindings) |*ib| {
+        if (ib.isSynthetic()) continue;
+        ib.local_symbol = bundler_symbol.SymbolRef.invalid;
+        if (scope0) |module_scope| {
+            if (module_scope.get(ib.local_name)) |sym_idx| {
+                ib.local_symbol = bundler_symbol.SymbolRef.makeSemantic(module.index, sym_idx);
+            }
+        }
+    }
+
+    if (module.alias_table) |*table| table.deinit();
+    module.alias_table = AliasTable.init(self.allocator);
+    try binding_scanner_mod.populateSyntheticSymbols(
+        &module.alias_table.?,
+        module.index,
+        module.export_bindings,
+        &sem.symbols,
+        arena_alloc,
+        scope0,
+    );
+}
+
+/// Numeric const materialization replaces identifier reads and may let minify fold
+/// expressions, but it does not add/remove import or export declarations. Keep the
+/// expensive syntax-level scanners intact for general transforms and use this path
+/// only when the caller owns that invariant.
+pub fn resyncAfterConstMaterialization(
+    self: anytype,
+    module: *Module,
+    arena_alloc: std.mem.Allocator,
+) !void {
+    var resync_scope = profile.begin(.graph_resync);
+    defer resync_scope.end();
+    var const_scope = profile.begin(.graph_resync_const);
+    defer const_scope.end();
+
+    _ = &(module.ast orelse return);
+    try refreshSemanticAndStmtInfoAfterAstMutation(self, module, arena_alloc);
+    try refreshStableBindingRefsAfterSemanticResync(self, module, arena_alloc, .graph_resync_binding_refs);
+}
+
+pub fn resyncAfterAstMutation(
+    self: anytype,
+    module: *Module,
+    arena_alloc: std.mem.Allocator,
+) !void {
+    var resync_scope = profile.begin(.graph_resync);
+    defer resync_scope.end();
+
+    const ast = &(module.ast orelse return);
+    const previous_import_records = module.import_records;
+    const previous_import_bindings = module.import_bindings;
+
+    try refreshSemanticAndStmtInfoAfterAstMutation(self, module, arena_alloc);
+
+    var scan_result: import_scanner.ScanResult = undefined;
+    {
+        var import_scan_scope = profile.begin(.graph_resync_import_scan);
+        defer import_scan_scope.end();
+
+        scan_result = try import_scanner.extractImportsWithCjsDetectionAndDefines(arena_alloc, ast, self.defines);
+        module.import_records = try mergeImportRecords(arena_alloc, previous_import_records, scan_result.records);
+        // specifier dupe — arena 로 owned 화 (#raw-require UAF 회피).
+        for (module.import_records) |*r| {
+            if (arena_alloc.dupe(u8, r.specifier)) |owned| r.specifier = owned else |_| {}
+        }
+        try import_scanner.markPostScanFlags(arena_alloc, ast, module.import_records);
+    }
+
+    {
+        var import_bindings_scope = profile.begin(.graph_resync_import_bindings);
+        defer import_bindings_scope.end();
+
+        const transformed_import_bindings = try binding_scanner_mod.extractImportBindings(arena_alloc, ast, module.import_records);
+        module.import_bindings = try mergeImportBindings(arena_alloc, previous_import_bindings, transformed_import_bindings);
+        try binding_scanner_mod.collectNamespaceAccesses(arena_alloc, ast, module.import_bindings);
+    }
+
+    {
+        var export_bindings_scope = profile.begin(.graph_resync_export_bindings);
+        defer export_bindings_scope.end();
+
+        module.export_bindings = try binding_scanner_mod.extractExportBindings(
+            arena_alloc,
+            ast,
+            module.import_records,
+            module.import_bindings,
+        );
+        module.exported_names = projectExportedNames(arena_alloc, module.export_bindings);
+    }
+
+    const has_refreshed_cjs = scan_result.has_cjs_require or
+        scan_result.has_module_exports or
+        scan_result.has_exports_dot;
+    const has_refreshed_esm = if (module.exports_kind == .commonjs and has_refreshed_cjs)
+        false
+    else
+        scan_result.has_esm_syntax;
+
+    const refreshed_scan_result = import_scanner.ScanResult{
+        .records = module.import_records,
+        .has_esm_syntax = has_refreshed_esm,
+        .has_cjs_require = scan_result.has_cjs_require,
+        .has_module_exports = scan_result.has_module_exports,
+        .has_exports_dot = scan_result.has_exports_dot,
+        .has_esmodule_marker = scan_result.has_esmodule_marker,
+    };
+
+    {
+        var classify_scope = profile.begin(.graph_resync_classify);
+        defer classify_scope.end();
+
+        try injectJsxSyntheticImportsForModule(self, module, arena_alloc, ast);
+
+        // 기존 exports_kind 가 ESM 인데 post-transform scan 이 `.none` 으로 떨어지는 경우
+        // (예: TS interface-only 파일의 `export {};` 를 transformer 가 drop) ESM 분류를 유지한다.
+        // `.none` 으로 강등하면 Pass 2 markEsmCjsHybrid 가 node_modules + def_format unknown
+        // 모듈을 implicit CJS 로 승격시켜, `export *` chain 의 빈 source 가 CJS wrapper 로
+        // wrap 되고 `resolveOrCjsFallback` 이 잘못된 모듈을 named import 의 source 로 반환한다
+        // (kysely/cheerio 회귀 #2052/#2051).
+        const refreshed_kind = determineExportsKind(refreshed_scan_result, module.path);
+        const previous_kind = module.exports_kind;
+        const preserve_esm = refreshed_kind == .none and previous_kind.isEsm();
+        module.exports_kind = if (preserve_esm) previous_kind else refreshed_kind;
+        module.wrap_kind = if (module.exports_kind == .commonjs) .cjs else .none;
+        module.has_cjs_export_signal = refreshed_scan_result.has_module_exports or refreshed_scan_result.has_exports_dot;
+        module.can_skip_cjs_default_interop = Module.computeCanSkipCjsDefaultInterop(
+            module.wrap_kind == .cjs,
+            refreshed_scan_result.has_module_exports,
+            refreshed_scan_result.has_exports_dot,
+            refreshed_scan_result.has_esmodule_marker,
+        );
+    }
+
+    try refreshStableBindingRefsAfterSemanticResync(self, module, arena_alloc, .graph_resync_alias);
+}
+
+fn injectJsxSyntheticImportsForModule(
+    self: anytype,
+    module: *Module,
+    arena_alloc: std.mem.Allocator,
+    ast: *const Ast,
+) !void {
+    if (self.jsx_runtime == .classic or !ast.has_jsx) return;
+    if (self.jsx_specifier_cache == null) {
+        const is_dev = self.jsx_runtime == .automatic_dev;
+        self.jsx_specifier_cache = try std.fmt.allocPrint(
+            self.allocator,
+            "{s}/{s}",
+            .{ self.jsx_import_source, if (is_dev) "jsx-dev-runtime" else "jsx-runtime" },
+        );
+    }
+    const specifier = self.jsx_specifier_cache orelse return;
+    for (module.import_records) |rec| {
+        if (rec.kind == .static_import and std.mem.eql(u8, rec.specifier, specifier)) return;
+    }
+    const base_record_count: u32 = @intCast(module.import_records.len);
+    var specs_buf: [2][]const u8 = undefined;
+    specs_buf[0] = specifier;
+    var n: usize = 1;
+    const react_injected = ast.has_jsx_key_after_spread;
+    if (react_injected) {
+        specs_buf[n] = self.jsx_import_source;
+        n += 1;
+    }
+    module.import_records = try injectJsxRuntimeImports(
+        specs_buf[0..n],
+        arena_alloc,
+        module.import_records,
+    );
+    module.import_bindings = try createJsxImportBindings(
+        self.jsx_runtime,
+        arena_alloc,
+        module.import_bindings,
+        base_record_count,
+        if (react_injected) base_record_count + 1 else null,
+    );
+}


### PR DESCRIPTION
## 요약
- `src/bundler/graph/transform_prepass.zig`를 추가해 transformer pre-pass와 post-transform metadata resync 로직을 `graph.zig`에서 분리했습니다.
- `graph.zig`는 parse/build 흐름을 유지하고, AST mutation 이후 semantic/import/export/alias 재동기화 책임은 helper 모듈로 옮겼습니다.
- 진행 중 점검 결과 `determineExportsKind`는 graph 본체보다 scan 결과 분류 helper에 가까워서 `graph/parse_helpers.zig`로 같이 이동하고 top-level re-export를 유지했습니다.

## 라인 수
- `src/bundler/graph.zig`: 3422줄
- `src/bundler/graph/transform_prepass.zig`: 473줄
- `src/bundler/graph/parse_helpers.zig`: 142줄
- `src/transformer/transformer.zig`: 3412줄
- `src/codegen/codegen.zig`: 2811줄
- `packages/core/src/napi_entry.zig`: 951줄

## 검증
- `zig build test`
- `zig build`
- `zig build napi`
- `bun test --cwd tests/integration tests/downlevel.test.ts tests/runtime-helper-virtual-module.test.ts --timeout 10000`
- `node --test packages/core/napi.test.mjs`
- `git diff --check`
- pre-push: 통과 (기존 oxlint 경고 23개, 오류 0개)