### PR TITLE
fix(parser): `.js`/`.jsx` 도 ESM 으로 파싱 (esbuild/swc/rollup 정렬)

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -294,7 +294,9 @@ pub const Parser = struct {
     /// oxc 방식 Unambiguous 모드:
     /// - .mts/.mjs → 확정적 Module (is_module=true)
     /// - .ts/.tsx → Unambiguous (is_module=true 낙관적 파싱 + 에러 지연)
-    /// - .js/.jsx/.cts/.cjs → Script (is_module=false)
+    /// - .js/.jsx → Unambiguous (is_module=true 낙관적 파싱 — esbuild/swc/rollup 와
+    ///                            동일하게 ESM 코드도 받음. 순수 script 코드도 호환)
+    /// - .cts/.cjs → Script (is_module=false, Node CommonJS 컨벤션)
     /// CLI용: .ts/.tsx는 Unambiguous 모드 (import/export 유무로 module/script 파싱 후 확정)
     pub fn configureFromExtension(self: *Parser, ext: []const u8) void {
         self.applyExtension(ext, true);
@@ -324,7 +326,12 @@ pub const Parser = struct {
         if (std.mem.eql(u8, ext, ".mts") or std.mem.eql(u8, ext, ".mjs")) {
             self.is_module = true;
             self.scanner.is_module = true;
-        } else if (std.mem.eql(u8, ext, ".ts") or std.mem.eql(u8, ext, ".tsx")) {
+        } else if (std.mem.eql(u8, ext, ".ts") or std.mem.eql(u8, ext, ".tsx") or
+            std.mem.eql(u8, ext, ".js") or std.mem.eql(u8, ext, ".jsx"))
+        {
+            // Unambiguous: 낙관적 module 파싱 + 에러 지연. import/export 가 없으면
+            // script 코드도 그대로 받음 — esbuild/swc/rollup 와 동일 정책.
+            // .cjs / .cts 는 위 분기를 안 타고 script 모드 유지 (Node CommonJS 컨벤션).
             self.is_module = true;
             self.scanner.is_module = true;
             self.is_unambiguous = ts_unambiguous;

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -326,15 +326,20 @@ pub const Parser = struct {
         if (std.mem.eql(u8, ext, ".mts") or std.mem.eql(u8, ext, ".mjs")) {
             self.is_module = true;
             self.scanner.is_module = true;
-        } else if (std.mem.eql(u8, ext, ".ts") or std.mem.eql(u8, ext, ".tsx") or
-            std.mem.eql(u8, ext, ".js") or std.mem.eql(u8, ext, ".jsx"))
-        {
-            // Unambiguous: 낙관적 module 파싱 + 에러 지연. import/export 가 없으면
-            // script 코드도 그대로 받음 — esbuild/swc/rollup 와 동일 정책.
-            // .cjs / .cts 는 위 분기를 안 타고 script 모드 유지 (Node CommonJS 컨벤션).
+        } else if (std.mem.eql(u8, ext, ".ts") or std.mem.eql(u8, ext, ".tsx")) {
             self.is_module = true;
             self.scanner.is_module = true;
             self.is_unambiguous = ts_unambiguous;
+        } else if (ts_unambiguous and
+            (std.mem.eql(u8, ext, ".js") or std.mem.eql(u8, ext, ".jsx")))
+        {
+            // CLI/transpile 모드 전용. 번들러 (ts_unambiguous=false) 는 `graph.zig`
+            // 의 `def_format` 분류 (package.json#type 인식 포함) 로 module/script
+            // 를 결정 — 거기서 unambiguous 도 같이 set 한다. 여기서 비-bundler
+            // 경로만 esbuild/swc/rollup 와 동일하게 `.js` 를 낙관적 module 로 받음.
+            self.is_module = true;
+            self.scanner.is_module = true;
+            self.is_unambiguous = true;
         }
         if (std.mem.eql(u8, ext, ".ts") or std.mem.eql(u8, ext, ".tsx") or
             std.mem.eql(u8, ext, ".mts") or std.mem.eql(u8, ext, ".cts"))

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -2712,6 +2712,54 @@ test "declare module: export inside ambient module body" {
     , ".ts");
 }
 
+// ============================================================
+// `.js`/`.jsx` 가 ESM (import/export) 을 받도록 — esbuild/swc/rollup 와 정렬.
+// date-fns 4.x 같은 ESM-only `.js` 패키지 통과 회귀 보호.
+// ============================================================
+
+test ".js: top-level export const → module 로 파싱" {
+    try expectNoParseErrorWithExt(
+        \\export const x = 1;
+    , ".js");
+}
+
+test ".js: top-level import → module 로 파싱" {
+    try expectNoParseErrorWithExt(
+        \\import { format } from "date-fns";
+        \\console.log(format);
+    , ".js");
+}
+
+test ".js: export function 도 module 로 파싱" {
+    try expectNoParseErrorWithExt(
+        \\export function add(a, b) { return a + b; }
+    , ".js");
+}
+
+test ".js: 순수 script (module.exports) 도 그대로 동작" {
+    try expectNoParseErrorWithExt(
+        \\module.exports = { x: 1 };
+    , ".js");
+}
+
+test ".jsx: top-level export default JSX 도 module 로 파싱" {
+    try expectNoParseErrorWithExt(
+        \\export default function App() { return null; }
+    , ".jsx");
+}
+
+test ".cjs: ESM export 는 여전히 거부 (Node CJS 컨벤션 유지)" {
+    try expectParseErrorWithExt(
+        \\export const x = 1;
+    , ".cjs", .{ .message_contains = "module code" });
+}
+
+test ".cts: ESM export 도 거부 (TS CommonJS 컨벤션 유지)" {
+    try expectParseErrorWithExt(
+        \\export const x: number = 1;
+    , ".cts", .{ .message_contains = "module code" });
+}
+
 test "declare module: multiple statements in ambient body" {
     try expectNoParseErrorWithExt(
         \\declare module "*.svg" { const src: string; export default src; }

--- a/src/transformer/plugins/rn_codegen_plugin.zig
+++ b/src/transformer/plugins/rn_codegen_plugin.zig
@@ -83,11 +83,9 @@ fn onTransform(
     defer parser.deinit();
     parser.configureFromExtension(std.fs.path.extension(id));
     if (std.mem.endsWith(u8, id, ".js")) {
+        // RN spec 파일은 Flow + import/export 사용. `configureFromExtension(".js")`
+        // 가 이미 module 모드를 set 하므로 (esbuild/swc/rollup 정렬) Flow 만 toggle.
         parser.is_flow = true;
-        // RN spec 파일은 import/export 사용 — Flow `.js` 도 모듈 모드 필요. configureFromExtension
-        // 이 .js 를 Script 로 두므로 명시적 module 모드 토글.
-        parser.is_module = true;
-        parser.scanner.is_module = true;
     }
 
     const program = parser.parse() catch return null;


### PR DESCRIPTION
## 요약
- `.js`/`.jsx` 에서 `import`/`export` 사용 시 `ZNTC0300/0305` ParseError 던지는 문제 수정. ESM `.js` 패키지 (date-fns 4.x 등) 가 통과하도록 함.
- esbuild / swc / rollup / Babel 7+ / Node `"type":"module"` 모두 `.js` 를 module 로 받는데 ZNTC 만 옛 tsc (pre-allowJs) 식 script-only 였음.

## 원인
`src/parser/parser.zig` 의 `applyExtension()` 이 `.mts`/`.mjs`/`.ts`/`.tsx` 만 `is_module=true` 로 set 하고, `.js`/`.jsx` 는 script 모드로 두었음. parser 가 top-level `import`/`export` 만나면 module-only 에러 (`ZNTC0300`/`ZNTC0305`) 즉시 발생.

## 수정
`applyExtension()` 의 `.js`/`.jsx` 분기를 `ts_unambiguous=true` (CLI/transpile 경로) 일 때만 `is_module=true, is_unambiguous=true` 로 set. 번들러 경로 (`ts_unambiguous=false`) 는 기존 `graph.zig:1898` 의 `def_format` 분류 (package.json#type 인식 포함) 가 처리.

`.cjs`/`.cts` 는 그대로 script 모드 유지 (Node CommonJS 컨벤션).

### 발견 경로
`@zntc/rspack-loader` (#2840) 작업 중 date-fns 4.x (ESM `.js` 252 파일) 통과 시 ParseError 250/252 → 추적해서 잡음. 그동안 발견 안 된 이유:
- ZNTC 메인 use-case 가 `.ts` 위주 (자기 번들링/CLI/통합 테스트)
- `vite-plugin-zntc` 는 Vite 가 `.js` 를 자체 esbuild 로 처리해 ZNTC 까지 도달 안 함
- Test262 는 각 케이스가 `[Module]`/`[Script]` annotation 으로 mode 명시 → extension-based 로직 우회

## 검증

- [x] **Zig parser 테스트** 7건 추가 (`.js`/`.jsx` ESM × 5 + `.cjs`/`.cts` ESM 거부 × 2)
- [x] **date-fns 4.x** 252/252 통과 (이전 2/252)
- [x] **packages/core** 881 pass / 0 fail / 2 skip
- [x] **기존 zig 테스트** 회귀 0건 (`zig build test` exit 0)
- [x] **#1258 `with`** 회귀 테스트 — bundler 의 `def_format` 분류 보존으로 그대로 동작

## 변경

- `src/parser/parser.zig` — `applyExtension()` 의 `.js`/`.jsx` CLI 분기 추가
- `src/parser/parser_test.zig` — 회귀 테스트 7건

🤖 Generated with [Claude Code](https://claude.com/claude-code)