### PR TITLE
refactor: graph package context 헬퍼 분리

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -44,7 +44,6 @@ const semantic_symbol = @import("../semantic/symbol.zig");
 const stmt_info_mod = @import("stmt_info.zig");
 const purity = @import("purity.zig");
 const Span = @import("../lexer/token.zig").Span;
-const pkg_json = @import("package_json.zig");
 const plugin_mod = @import("plugin.zig");
 const MpscChannel = @import("mpsc_channel.zig").MpscChannel;
 const transformer_mod = @import("../transformer/transformer.zig");
@@ -72,6 +71,8 @@ const graph_project_root = @import("graph/project_root.zig");
 const findProjectRoot = graph_project_root.findProjectRoot;
 const graph_glob = @import("graph/glob.zig");
 const expandGlobRecords = graph_glob.expandGlobRecords;
+const graph_require_context = @import("graph/require_context.zig");
+const expandRequireContextRecords = graph_require_context.expandRecords;
 const graph_package_side_effects = @import("graph/package_side_effects.zig");
 const graph_parse_helpers = @import("graph/parse_helpers.zig");
 const graph_plugins = @import("graph/plugins.zig");
@@ -99,6 +100,10 @@ pub const ModuleGraph = struct {
     const runTransformerPrePass = graph_transform_prepass.run;
     pub const resyncModuleMetadataAfterConstMaterialization = graph_transform_prepass.resyncAfterConstMaterialization;
     pub const resyncModuleMetadataAfterAstMutation = graph_transform_prepass.resyncAfterAstMutation;
+    const graph_package_info = @import("graph/package_info.zig");
+    pub const lookupPkgInfo = graph_package_info.lookupPkgInfo;
+    const applySideEffectsFromPackageJson = graph_package_info.applySideEffectsFromPackageJson;
+    const isPackageTypeModule = graph_package_info.isPackageTypeModule;
 
     allocator: std.mem.Allocator,
     /// Module storage. SegmentedList 는 append 시에도 기존 포인터를 무효화하지
@@ -2213,53 +2218,6 @@ pub const ModuleGraph = struct {
         module.state = .parsed;
     }
 
-    const findPackageDirPath = resolve_cache_mod.findPackageDirPath;
-
-    /// `pkg_info_cache` 통합 lookup. pkg_dir_path 별 1회만 parsePackageJson,
-    /// 이후 호출은 cache hit. is_module 과 side_effects 모두 반환 (#1744).
-    ///
-    /// Fast path (lock→get→unlock) → Slow path (lock 밖 parse) →
-    /// double-check put (race 시 내 값 폐기). patterns 메모리 소유권은
-    /// 캐시가 보유하며 Linker deinit 에서 일괄 해제.
-    pub fn lookupPkgInfo(self: *ModuleGraph, pkg_dir_path: []const u8) PkgInfo {
-        self.pkg_info_cache_mutex.lock();
-        const cached = self.pkg_info_cache.get(pkg_dir_path);
-        self.pkg_info_cache_mutex.unlock();
-        if (cached) |c| return c;
-
-        var info: PkgInfo = .{ .is_module = false, .side_effects = .unknown };
-        if (pkg_json.parsePackageJson(self.allocator, pkg_dir_path)) |parsed_val| {
-            var parsed = parsed_val;
-            info.is_module = parsed.pkg.isModule();
-            info.side_effects = parsed.pkg.side_effects;
-            // 소유권을 info 로 이전 — parsed.deinit() 에서 이중 free 방지.
-            parsed.pkg.side_effects = .unknown;
-            parsed.deinit();
-        } else |_| {}
-
-        self.pkg_info_cache_mutex.lock();
-        defer self.pkg_info_cache_mutex.unlock();
-        // Race: 다른 스레드가 먼저 put 했으면 내 info.side_effects 폐기.
-        if (self.pkg_info_cache.get(pkg_dir_path)) |raced| {
-            info.side_effects.deinit(self.allocator);
-            return raced;
-        }
-        self.pkg_info_cache.put(self.allocator, pkg_dir_path, info) catch {
-            // alloc 실패 시 누수 방지
-            info.side_effects.deinit(self.allocator);
-            return .{ .is_module = info.is_module, .side_effects = .unknown };
-        };
-        return info;
-    }
-
-    /// node_modules 패키지의 package.json sideEffects 필드를 module.side_effects에 반영.
-    fn applySideEffectsFromPackageJson(self: *ModuleGraph, module: *Module) void {
-        if (self.ignore_annotations) return;
-        const pkg_dir_path = findPackageDirPath(module.path) orelse return;
-        const info = self.lookupPkgInfo(pkg_dir_path);
-        graph_package_side_effects.applyCached(module, pkg_dir_path, info.side_effects);
-    }
-
     /// Phase 1: 모듈의 import들을 resolve하고 의존성 모듈을 등록한다.
     /// modules 배열이 커질 수 있으므로, 포인터가 아닌 인덱스로만 접근.
     fn resolveModuleImports(self: *ModuleGraph, idx: ModuleIndex) !void {
@@ -2500,15 +2458,6 @@ pub const ModuleGraph = struct {
     const registerWrapperSymbols = graph_finalize.registerWrapperSymbols;
     const propagateTopLevelAwait = graph_finalize.propagateTopLevelAwait;
 
-    /// 모듈 경로에서 가장 가까운 package.json의 "type" 필드가 "module"인지 확인.
-    /// `lookupPkgInfo` 로 캐시 경유 — 같은 pkg 의 side_effects 조회와 pkg.json parse 공유.
-    fn isPackageTypeModule(self: *ModuleGraph, module_path: []const u8) bool {
-        var scope = profile.begin(.graph_discover_pm_is_pkg_type);
-        defer scope.end();
-        const pkg_dir_path = findPackageDirPath(module_path) orelse return false;
-        return self.lookupPkgInfo(pkg_dir_path).is_module;
-    }
-
     // Loader/source helpers — graph/loaders.zig로 위임
     const graph_loaders = @import("graph/loaders.zig");
     const parseCssModule = graph_loaders.parseCssModule;
@@ -2521,134 +2470,6 @@ pub const ModuleGraph = struct {
     const addPluginFailureDiag = graph_diagnostics.addPluginFailureDiag;
     const validatePluginSourceMaps = graph_diagnostics.validatePluginSourceMaps;
 };
-
-/// require.context(...) 레코드의 매칭 파일 목록을 host plugin (resolveContext) 으로 채운다.
-/// (#1579 Phase 2). ZNTC 자체 regex executor 가 없어서 host runtime 의 RegExp 위임 (#1771).
-///
-/// 처리 순서:
-///   1. invalid record (`context_invalid_reason != null`) → require_context_invalid error.
-///   2. plugin runner 호출 (first non-null wins) → 결과를 record.context_matches 에 저장.
-///   3. plugin 미구현 → require_context_no_handler warning (record.context_matches 는 null 유지).
-///
-/// `self`: ModuleGraph (addDiag, plugins 접근용)
-/// `module_path`: 현재 모듈 경로 (importer)
-/// `records`: 모듈의 import_records (in-place 수정)
-fn expandRequireContextRecords(self: *ModuleGraph, mod_idx: usize) void {
-    const module = self.modules.at(mod_idx);
-
-    // scanWorker + resolveModuleImports 양쪽에서 호출됨. 이미 expand 됐으면 즉시 리턴
-    // (has_any 루프보다 먼저 체크 — 재진입 시 records 전체 순회 회피).
-    if (module.context_expansion_deps.len > 0) return;
-
-    const records = module.import_records;
-    var has_any = false;
-    for (records) |r| {
-        if (r.kind == .require_context) {
-            has_any = true;
-            break;
-        }
-    }
-    if (!has_any) return;
-
-    const module_path = module.path;
-    const plugin_runner: ?plugin_mod.PluginRunner = self.pluginRunnerWithBuiltins();
-
-    // require.context 는 parse 산출물이라 arena 가 항상 존재. 없으면 (disabled/asset 등)
-    // expand 자체가 의미 없고, graph allocator fallback 은 module.deinit 에서 free 누락 →
-    // leak. 안전하게 early return.
-    const arena = if (module.parse_arena) |a| a else return;
-    const arena_alloc = arena.allocator();
-    var expansion = std.ArrayList(types.ImportRecord).empty;
-
-    for (records) |*record| {
-        if (record.kind != .require_context) continue;
-        if (record.context_matches != null) continue;
-
-        // Invalid 인자 → diagnostic (Phase 1 의 reason 텍스트 그대로 사용). empty slice 로 마킹.
-        if (record.context_invalid_reason) |reason| {
-            self.addDiag(.require_context_invalid, .@"error", module_path, record.span, .resolve, reason, null);
-            record.context_matches = &.{};
-            continue;
-        }
-
-        // Plugin 호출
-        if (plugin_runner) |runner| {
-            var hook_ctx: plugin_mod.HookContext = .{};
-            defer hook_ctx.deinit();
-            const matches = runner.runResolveContext(
-                record.specifier,
-                record.context_recursive,
-                record.context_filter,
-                record.context_filter_flags,
-                module_path,
-                self.allocator,
-                &hook_ctx,
-            ) catch null;
-            if (matches) |m| {
-                record.context_matches = m;
-                // 매치별 abs path resolve 결과를 record.context_resolved_paths 에 1:1 저장.
-                // codegen 이 webpackContext IIFE 의 module wrapper 호출 (`__zntc_modules[<abs>]`) 에 사용.
-                // null 슬롯 = resolve 실패 — codegen 이 throw stub 으로 emit.
-                const source_dir = std.fs.path.dirname(module_path) orelse ".";
-                const resolved_paths_opt: ?[]?[]const u8 = arena_alloc.alloc(?[]const u8, m.len) catch null;
-                for (m, 0..) |match_path, i| {
-                    const joined = joinContextPath(arena_alloc, record.specifier, match_path) orelse {
-                        if (resolved_paths_opt) |paths| paths[i] = null;
-                        continue;
-                    };
-                    if (resolved_paths_opt) |paths| {
-                        // default null — file variant 만 dupe 성공 시 덮어씀.
-                        paths[i] = null;
-                        if (self.resolve_cache.resolveThreadSafe(source_dir, joined, .require) catch null) |res| switch (res) {
-                            // resolve_cache 가 self.allocator 로 path 할당 → arena 로 dupe 후 free.
-                            .file => |f| {
-                                paths[i] = arena_alloc.dupe(u8, f.path) catch null;
-                                self.allocator.free(f.path);
-                            },
-                            .disabled => |d| self.allocator.free(d.path),
-                            .virtual, .dataurl, .external, .custom => {},
-                        };
-                    }
-                    // graph dep 등록은 applyContextDepResults 에서 (cache hit 라 빠름).
-                    expansion.append(arena_alloc, .{
-                        .specifier = joined,
-                        .kind = .require,
-                        .span = record.span,
-                    }) catch {};
-                }
-                if (resolved_paths_opt) |paths| record.context_resolved_paths = paths;
-                continue;
-            }
-        }
-
-        // Plugin 미구현 → warning. empty slice 로 마킹 (Phase 3 codegen 이 빈 stub 으로 emit).
-        self.addDiag(
-            .require_context_no_handler,
-            .warning,
-            module_path,
-            record.span,
-            .resolve,
-            "require.context requires a host plugin to match files (ZNTC regex executor not yet implemented — see #1771)",
-            null,
-        );
-        record.context_matches = &.{};
-    }
-
-    module.context_expansion_deps = expansion.toOwnedSlice(arena_alloc) catch &.{};
-}
-
-/// record.specifier (e.g. "./app" 또는 "../foo") 와 match_path (e.g. "./a.tsx") 를 결합.
-/// codegen 의 emitJoinedPath 와 동일 로직 — dir trailing `/`, match `./` prefix 정규화.
-/// 결과는 모듈 resolver 가 일반 require 처럼 처리할 수 있는 specifier.
-fn joinContextPath(alloc: std.mem.Allocator, dir: []const u8, match: []const u8) ?[]u8 {
-    const dir_clean = if (dir.len > 0 and dir[dir.len - 1] == '/') dir[0 .. dir.len - 1] else dir;
-    const match_clean = if (match.len >= 2 and match[0] == '.' and match[1] == '/') match[2..] else match;
-    const out = alloc.alloc(u8, dir_clean.len + 1 + match_clean.len) catch return null;
-    @memcpy(out[0..dir_clean.len], dir_clean);
-    out[dir_clean.len] = '/';
-    @memcpy(out[dir_clean.len + 1 ..], match_clean);
-    return out;
-}
 
 const test_helpers = @import("test_helpers.zig");
 const writeFile = test_helpers.writeFile;

--- a/src/bundler/graph/package_info.zig
+++ b/src/bundler/graph/package_info.zig
@@ -1,0 +1,65 @@
+//! Package metadata cache helpers for ModuleGraph.
+
+const Module = @import("../module.zig").Module;
+const pkg_json = @import("../package_json.zig");
+const resolve_cache_mod = @import("../resolve_cache.zig");
+const profile = @import("../../profile.zig");
+const graph_package_side_effects = @import("package_side_effects.zig");
+const graph_mod = @import("../graph.zig");
+const ModuleGraph = graph_mod.ModuleGraph;
+const PkgInfo = ModuleGraph.PkgInfo;
+const findPackageDirPath = resolve_cache_mod.findPackageDirPath;
+
+/// `pkg_info_cache` 통합 lookup. pkg_dir_path 별 1회만 parsePackageJson,
+/// 이후 호출은 cache hit. is_module 과 side_effects 모두 반환 (#1744).
+///
+/// Fast path (lock→get→unlock) → Slow path (lock 밖 parse) →
+/// double-check put (race 시 내 값 폐기). patterns 메모리 소유권은
+/// 캐시가 보유하며 Linker deinit 에서 일괄 해제.
+pub fn lookupPkgInfo(self: *ModuleGraph, pkg_dir_path: []const u8) PkgInfo {
+    self.pkg_info_cache_mutex.lock();
+    const cached = self.pkg_info_cache.get(pkg_dir_path);
+    self.pkg_info_cache_mutex.unlock();
+    if (cached) |c| return c;
+
+    var info: PkgInfo = .{ .is_module = false, .side_effects = .unknown };
+    if (pkg_json.parsePackageJson(self.allocator, pkg_dir_path)) |parsed_val| {
+        var parsed = parsed_val;
+        info.is_module = parsed.pkg.isModule();
+        info.side_effects = parsed.pkg.side_effects;
+        // 소유권을 info 로 이전 — parsed.deinit() 에서 이중 free 방지.
+        parsed.pkg.side_effects = .unknown;
+        parsed.deinit();
+    } else |_| {}
+
+    self.pkg_info_cache_mutex.lock();
+    defer self.pkg_info_cache_mutex.unlock();
+    // Race: 다른 스레드가 먼저 put 했으면 내 info.side_effects 폐기.
+    if (self.pkg_info_cache.get(pkg_dir_path)) |raced| {
+        info.side_effects.deinit(self.allocator);
+        return raced;
+    }
+    self.pkg_info_cache.put(self.allocator, pkg_dir_path, info) catch {
+        // alloc 실패 시 누수 방지
+        info.side_effects.deinit(self.allocator);
+        return .{ .is_module = info.is_module, .side_effects = .unknown };
+    };
+    return info;
+}
+
+/// node_modules 패키지의 package.json sideEffects 필드를 module.side_effects에 반영.
+pub fn applySideEffectsFromPackageJson(self: *ModuleGraph, module: *Module) void {
+    if (self.ignore_annotations) return;
+    const pkg_dir_path = findPackageDirPath(module.path) orelse return;
+    const info = self.lookupPkgInfo(pkg_dir_path);
+    graph_package_side_effects.applyCached(module, pkg_dir_path, info.side_effects);
+}
+
+/// 모듈 경로에서 가장 가까운 package.json의 "type" 필드가 "module"인지 확인.
+/// `lookupPkgInfo` 로 캐시 경유 — 같은 pkg 의 side_effects 조회와 pkg.json parse 공유.
+pub fn isPackageTypeModule(self: *ModuleGraph, module_path: []const u8) bool {
+    var scope = profile.begin(.graph_discover_pm_is_pkg_type);
+    defer scope.end();
+    const pkg_dir_path = findPackageDirPath(module_path) orelse return false;
+    return self.lookupPkgInfo(pkg_dir_path).is_module;
+}

--- a/src/bundler/graph/require_context.zig
+++ b/src/bundler/graph/require_context.zig
@@ -1,0 +1,136 @@
+//! require.context expansion helpers for ModuleGraph.
+
+const std = @import("std");
+const types = @import("../types.zig");
+const plugin_mod = @import("../plugin.zig");
+const graph_plugins = @import("plugins.zig");
+const graph_mod = @import("../graph.zig");
+const ModuleGraph = graph_mod.ModuleGraph;
+
+/// require.context(...) 레코드의 매칭 파일 목록을 host plugin (resolveContext) 으로 채운다.
+/// (#1579 Phase 2). ZNTC 자체 regex executor 가 없어서 host runtime 의 RegExp 위임 (#1771).
+///
+/// 처리 순서:
+///   1. invalid record (`context_invalid_reason != null`) → require_context_invalid error.
+///   2. plugin runner 호출 (first non-null wins) → 결과를 record.context_matches 에 저장.
+///   3. plugin 미구현 → require_context_no_handler warning (record.context_matches 는 null 유지).
+///
+/// `self`: ModuleGraph (addDiag, plugins 접근용)
+/// `module_path`: 현재 모듈 경로 (importer)
+/// `records`: 모듈의 import_records (in-place 수정)
+pub fn expandRecords(self: *ModuleGraph, mod_idx: usize) void {
+    const module = self.modules.at(mod_idx);
+
+    // scanWorker + resolveModuleImports 양쪽에서 호출됨. 이미 expand 됐으면 즉시 리턴
+    // (has_any 루프보다 먼저 체크 — 재진입 시 records 전체 순회 회피).
+    if (module.context_expansion_deps.len > 0) return;
+
+    const records = module.import_records;
+    var has_any = false;
+    for (records) |r| {
+        if (r.kind == .require_context) {
+            has_any = true;
+            break;
+        }
+    }
+    if (!has_any) return;
+
+    const module_path = module.path;
+    const plugin_runner: ?plugin_mod.PluginRunner = graph_plugins.pluginRunnerWithBuiltins(self);
+
+    // require.context 는 parse 산출물이라 arena 가 항상 존재. 없으면 (disabled/asset 등)
+    // expand 자체가 의미 없고, graph allocator fallback 은 module.deinit 에서 free 누락 →
+    // leak. 안전하게 early return.
+    const arena = if (module.parse_arena) |a| a else return;
+    const arena_alloc = arena.allocator();
+    var expansion = std.ArrayList(types.ImportRecord).empty;
+
+    for (records) |*record| {
+        if (record.kind != .require_context) continue;
+        if (record.context_matches != null) continue;
+
+        // Invalid 인자 → diagnostic (Phase 1 의 reason 텍스트 그대로 사용). empty slice 로 마킹.
+        if (record.context_invalid_reason) |reason| {
+            self.addDiag(.require_context_invalid, .@"error", module_path, record.span, .resolve, reason, null);
+            record.context_matches = &.{};
+            continue;
+        }
+
+        // Plugin 호출
+        if (plugin_runner) |runner| {
+            var hook_ctx: plugin_mod.HookContext = .{};
+            defer hook_ctx.deinit();
+            const matches = runner.runResolveContext(
+                record.specifier,
+                record.context_recursive,
+                record.context_filter,
+                record.context_filter_flags,
+                module_path,
+                self.allocator,
+                &hook_ctx,
+            ) catch null;
+            if (matches) |m| {
+                record.context_matches = m;
+                // 매치별 abs path resolve 결과를 record.context_resolved_paths 에 1:1 저장.
+                // codegen 이 webpackContext IIFE 의 module wrapper 호출 (`__zntc_modules[<abs>]`) 에 사용.
+                // null 슬롯 = resolve 실패 — codegen 이 throw stub 으로 emit.
+                const source_dir = std.fs.path.dirname(module_path) orelse ".";
+                const resolved_paths_opt: ?[]?[]const u8 = arena_alloc.alloc(?[]const u8, m.len) catch null;
+                for (m, 0..) |match_path, i| {
+                    const joined = joinContextPath(arena_alloc, record.specifier, match_path) orelse {
+                        if (resolved_paths_opt) |paths| paths[i] = null;
+                        continue;
+                    };
+                    if (resolved_paths_opt) |paths| {
+                        // default null — file variant 만 dupe 성공 시 덮어씀.
+                        paths[i] = null;
+                        if (self.resolve_cache.resolveThreadSafe(source_dir, joined, .require) catch null) |res| switch (res) {
+                            // resolve_cache 가 self.allocator 로 path 할당 → arena 로 dupe 후 free.
+                            .file => |f| {
+                                paths[i] = arena_alloc.dupe(u8, f.path) catch null;
+                                self.allocator.free(f.path);
+                            },
+                            .disabled => |d| self.allocator.free(d.path),
+                            .virtual, .dataurl, .external, .custom => {},
+                        };
+                    }
+                    // graph dep 등록은 applyContextDepResults 에서 (cache hit 라 빠름).
+                    expansion.append(arena_alloc, .{
+                        .specifier = joined,
+                        .kind = .require,
+                        .span = record.span,
+                    }) catch {};
+                }
+                if (resolved_paths_opt) |paths| record.context_resolved_paths = paths;
+                continue;
+            }
+        }
+
+        // Plugin 미구현 → warning. empty slice 로 마킹 (Phase 3 codegen 이 빈 stub 으로 emit).
+        self.addDiag(
+            .require_context_no_handler,
+            .warning,
+            module_path,
+            record.span,
+            .resolve,
+            "require.context requires a host plugin to match files (ZNTC regex executor not yet implemented — see #1771)",
+            null,
+        );
+        record.context_matches = &.{};
+    }
+
+    module.context_expansion_deps = expansion.toOwnedSlice(arena_alloc) catch &.{};
+}
+
+/// record.specifier (e.g. "./app" 또는 "../foo") 와 match_path (e.g. "./a.tsx") 를 결합.
+/// codegen 의 emitJoinedPath 와 동일 로직 — dir trailing `/`, match `./` prefix 정규화.
+/// 결과는 모듈 resolver 가 일반 require 처럼 처리할 수 있는 specifier.
+fn joinContextPath(alloc: std.mem.Allocator, dir: []const u8, match: []const u8) ?[]u8 {
+    const dir_clean = if (dir.len > 0 and dir[dir.len - 1] == '/') dir[0 .. dir.len - 1] else dir;
+    const match_clean = if (match.len >= 2 and match[0] == '.' and match[1] == '/') match[2..] else match;
+    const out = alloc.alloc(u8, dir_clean.len + 1 + match_clean.len) catch return null;
+    @memcpy(out[0..dir_clean.len], dir_clean);
+    out[dir_clean.len] = '/';
+    @memcpy(out[dir_clean.len + 1 ..], match_clean);
+    return out;
+}


### PR DESCRIPTION
## 요약
- `graph.zig`의 package.json metadata/cache 헬퍼를 `graph/package_info.zig`로 분리했습니다.
- `require.context` 확장 로직과 path join 헬퍼를 `graph/require_context.zig`로 분리했습니다.
- 기존 `ModuleGraph.lookupPkgInfo` 공개 API와 내부 호출 형태는 alias로 유지했습니다.
- `graph.zig`는 2798줄에서 2619줄로 줄었습니다.

## 검증
- `zig build test`
- `zig build`
- `zig build napi`
- `bun test --cwd tests/integration tests/downlevel.test.ts tests/runtime-helper-virtual-module.test.ts --timeout 10000`
- `node --test packages/core/napi.test.mjs`
- `git diff --check`
- pre-push hook (`zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`)
