### PR TITLE
refactor: graph parser metadata 헬퍼 분리

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -20,7 +20,6 @@ const std = @import("std");
 const types = @import("types.zig");
 const ModuleIndex = types.ModuleIndex;
 const ModuleType = types.ModuleType;
-const ImportKind = types.ImportKind;
 const ImportRecord = types.ImportRecord;
 const BundlerDiagnostic = types.BundlerDiagnostic;
 const module_mod = @import("module.zig");
@@ -32,7 +31,6 @@ const resolve_cache_mod = @import("resolve_cache.zig");
 const ResolveCache = resolve_cache_mod.ResolveCache;
 const resolver_mod = @import("resolver.zig");
 const import_scanner = @import("import_scanner.zig");
-const binding_scanner_mod = @import("binding_scanner.zig");
 const bundler_symbol = @import("symbol.zig");
 const fs = @import("fs.zig");
 const Scanner = @import("../lexer/scanner.zig").Scanner;
@@ -61,10 +59,6 @@ pub const LinkAccessor = phase_mod.LinkAccessor;
 const graph_assets = @import("graph/assets.zig");
 const moduleReadsSourceForAsset = graph_assets.loaderReadsSource;
 const graph_transform_prepass = @import("graph/transform_prepass.zig");
-const graph_synthetic_imports = @import("graph/synthetic_imports.zig");
-const injectJsxRuntimeImports = graph_synthetic_imports.injectJsxRuntimeImports;
-const injectFlowEnumRuntimeImport = graph_synthetic_imports.injectFlowEnumRuntimeImport;
-const createJsxImportBindings = graph_synthetic_imports.createJsxImportBindings;
 const graph_project_root = @import("graph/project_root.zig");
 const findProjectRoot = graph_project_root.findProjectRoot;
 const graph_glob = @import("graph/glob.zig");
@@ -77,6 +71,7 @@ const graph_plugins = @import("graph/plugins.zig");
 const graph_requested_exports = @import("graph/requested_exports.zig");
 const graph_runtime_polyfills = @import("graph/runtime_polyfills.zig");
 const graph_state = @import("graph/state.zig");
+const graph_parser_metadata = @import("graph/parser_metadata.zig");
 
 pub const determineExportsKind = graph_parse_helpers.determineExportsKind;
 
@@ -87,7 +82,6 @@ pub const ModuleGraph = struct {
     const mergeImportBindings = graph_parse_helpers.mergeImportBindings;
     const mergeImportRecords = graph_parse_helpers.mergeImportRecords;
     const moduleTypeForLoader = graph_parse_helpers.moduleTypeForLoader;
-    const projectExportedNames = graph_parse_helpers.projectExportedNames;
     const suppressRuntimeHelperInternalUnresolved = graph_parse_helpers.suppressRuntimeHelperInternalUnresolved;
     const requestAllExports = graph_requested_exports.requestAll;
     const requestNamedExport = graph_requested_exports.requestNamed;
@@ -306,6 +300,7 @@ pub const ModuleGraph = struct {
     const shouldRunResolveId = graph_plugins.shouldRunResolveId;
     const runPluginLoadForModule = graph_plugins.runLoadForModule;
     const runPluginTransformForModule = graph_plugins.runTransformForModule;
+    const materializeParserMetadata = graph_parser_metadata.materialize;
 
     // ============================================================
     // Module accessor API (#1779 PR #1a + PR #3)
@@ -1765,187 +1760,7 @@ pub const ModuleGraph = struct {
         module.ast = parser.ast;
         module.line_offsets = scanner.line_offsets.items;
 
-        // import/export 추출: inline scan 결과를 bundler 타입으로 변환
-        {
-            // Parser scan records → bundler ImportRecord
-            {
-                var records_scope = profile.begin(.graph_discover_pm_post_records);
-                defer records_scope.end();
-
-                const scan_records = parser.scan_import_records.items;
-                const records = arena_alloc.alloc(ImportRecord, scan_records.len) catch {
-                    module.state = .ready;
-                    return;
-                };
-                for (scan_records, 0..) |sr, i| {
-                    const ik: ImportKind = @enumFromInt(@intFromEnum(sr.kind));
-                    const ctx_mode: types.RequireContextMode = @enumFromInt(@intFromEnum(sr.context_mode));
-                    records[i] = .{
-                        .specifier = sr.specifier,
-                        .kind = ik,
-                        .span = sr.span,
-                        .url_span = sr.url_span,
-                        .glob_eager = sr.glob_eager,
-                        .glob_import_name = sr.glob_import_name,
-                        .context_recursive = sr.context_recursive,
-                        .context_filter = sr.context_filter,
-                        .context_filter_flags = sr.context_filter_flags,
-                        .context_mode = ctx_mode,
-                        .context_invalid_reason = sr.context_invalid_reason,
-                    };
-                }
-                module.import_records = records;
-
-                // Parser scan import bindings → bundler ImportBinding
-                const scan_ibindings = parser.scan_import_bindings.items;
-                if (arena_alloc.alloc(binding_scanner_mod.ImportBinding, scan_ibindings.len)) |ibindings| {
-                    for (scan_ibindings, 0..) |sb, i| {
-                        const ib_kind: binding_scanner_mod.ImportBinding.Kind = @enumFromInt(@intFromEnum(sb.kind));
-                        ibindings[i] = .{
-                            .kind = ib_kind,
-                            .local_name = sb.local_name,
-                            .imported_name = sb.imported_name,
-                            .local_span = sb.local_span,
-                            .import_record_index = sb.import_record_index,
-                        };
-                    }
-                    module.import_bindings = ibindings;
-                } else |_| {}
-
-                // Parser scan export bindings → bundler ExportBinding
-                const scan_ebindings = parser.scan_export_bindings.items;
-                if (arena_alloc.alloc(binding_scanner_mod.ExportBinding, scan_ebindings.len)) |ebindings| {
-                    for (scan_ebindings, 0..) |sb, i| {
-                        const eb_kind: binding_scanner_mod.ExportBinding.Kind = @enumFromInt(@intFromEnum(sb.kind));
-                        ebindings[i] = .{
-                            .exported_name = sb.exported_name,
-                            .local_name = sb.local_name,
-                            .local_span = sb.local_span,
-                            .kind = eb_kind,
-                            .import_record_index = sb.import_record_index,
-                        };
-                    }
-                    module.export_bindings = ebindings;
-                    module.exported_names = projectExportedNames(arena_alloc, ebindings);
-                } else |_| {}
-            }
-
-            // OOM 시 silent skip 하면 optional require 가 hard error 로 회귀하므로 module 을
-            // ready 로 끝내고 graph 진행 중단 (1108줄 extractImports 와 동일 패턴).
-            {
-                var optional_scope = profile.begin(.graph_discover_pm_post_optional_requires);
-                defer optional_scope.end();
-                import_scanner.markPostScanFlags(arena_alloc, &(module.ast.?), module.import_records) catch {
-                    module.state = .ready;
-                    return;
-                };
-            }
-
-            if (parser.ast.has_flow_enum_declaration) {
-                module.import_records = injectFlowEnumRuntimeImport(
-                    arena_alloc,
-                    module.import_records,
-                ) catch module.import_records;
-            }
-
-            // namespace access 수집은 별도 AST walk 필요
-            {
-                var namespace_scope = profile.begin(.graph_discover_pm_post_namespace_access);
-                defer namespace_scope.end();
-                binding_scanner_mod.collectNamespaceAccesses(arena_alloc, &parser.ast, module.import_bindings) catch {};
-            }
-
-            // Phase 1-3b (#1328): 합성 심볼 테이블 초기화 + re_export_alias 등록
-            // + semantic 공간에 synthetic_default 등록.
-            {
-                var synthetic_scope = profile.begin(.graph_discover_pm_post_synthetic_symbols);
-                defer synthetic_scope.end();
-                module.ensureAliasTable(self.allocator);
-                if (module.semantic) |*sem| {
-                    const scope0: ?std.StringHashMap(usize) =
-                        if (sem.scope_maps.len > 0) sem.scope_maps[0] else null;
-                    binding_scanner_mod.populateSyntheticSymbols(
-                        &module.alias_table.?,
-                        module.index,
-                        module.export_bindings,
-                        &sem.symbols,
-                        arena_alloc,
-                        scope0,
-                    ) catch {};
-                }
-            }
-
-            // CJS/ESM 감지 — inline scan 결과로 ScanResult 생성
-            const scan_result = import_scanner.ScanResult{
-                .records = module.import_records,
-                .has_esm_syntax = parser.scan_result.has_esm_syntax or parser.has_module_syntax,
-                .has_cjs_require = parser.scan_result.has_cjs_require,
-                .has_module_exports = parser.scan_result.has_module_exports,
-                .has_exports_dot = parser.scan_result.has_exports_dot,
-                .has_esmodule_marker = parser.scan_result.has_esmodule_marker,
-            };
-
-            // JSX automatic synthetic imports. `react` 는 key-after-spread 일 때만 주입 —
-            // 모든 JSX 모듈에 일괄 주입하면 `createElement` 문자열이 노출되어
-            // `createElement 미노출` 회귀 테스트를 깬다.
-            var jsx_injected = false;
-            var react_injected = false;
-            var jsx_inject_base: u32 = 0;
-            {
-                var jsx_scope = profile.begin(.graph_discover_pm_post_jsx_imports);
-                defer jsx_scope.end();
-                if (self.jsx_runtime != .classic and parser.ast.has_jsx) {
-                    if (self.jsx_specifier_cache == null) {
-                        const is_dev = self.jsx_runtime == .automatic_dev;
-                        self.jsx_specifier_cache = std.fmt.allocPrint(
-                            self.allocator,
-                            "{s}/{s}",
-                            .{ self.jsx_import_source, if (is_dev) "jsx-dev-runtime" else "jsx-runtime" },
-                        ) catch null;
-                    }
-                    if (self.jsx_specifier_cache) |specifier| {
-                        var specs_buf: [2][]const u8 = undefined;
-                        specs_buf[0] = specifier;
-                        var n: usize = 1;
-                        if (parser.ast.has_jsx_key_after_spread) {
-                            specs_buf[n] = self.jsx_import_source;
-                            n += 1;
-                        }
-                        jsx_inject_base = @intCast(module.import_records.len);
-                        module.import_records = injectJsxRuntimeImports(
-                            specs_buf[0..n],
-                            arena_alloc,
-                            module.import_records,
-                        ) catch module.import_records;
-                        jsx_injected = (module.import_records.len > jsx_inject_base);
-                        react_injected = (n == 2) and jsx_injected;
-                    }
-                }
-            }
-
-            module.exports_kind = determineExportsKind(scan_result, module.path);
-            module.wrap_kind = if (module.exports_kind == .commonjs) .cjs else .none;
-            module.has_cjs_export_signal = scan_result.has_module_exports or scan_result.has_exports_dot;
-            module.can_skip_cjs_default_interop = Module.computeCanSkipCjsDefaultInterop(
-                module.wrap_kind == .cjs,
-                scan_result.has_module_exports,
-                scan_result.has_exports_dot,
-                scan_result.has_esmodule_marker,
-            );
-
-            // JSX synthetic import bindings 추가
-            if (jsx_injected) {
-                const jsx_record_idx: u32 = jsx_inject_base;
-                const react_record_idx: ?u32 = if (react_injected) jsx_record_idx + 1 else null;
-                module.import_bindings = createJsxImportBindings(
-                    self.jsx_runtime,
-                    arena_alloc,
-                    module.import_bindings,
-                    jsx_record_idx,
-                    react_record_idx,
-                ) catch module.import_bindings;
-            }
-        }
+        if (!self.materializeParserMetadata(module, &parser, arena_alloc)) return;
 
         // #1961/#1913: transformer pre-pass. helper module 을 graph 의 1급 모듈로
         // 분배하려면 helper import 가 link 단계 전에 import_records 에 등록되어야 한다.

--- a/src/bundler/graph/parser_metadata.zig
+++ b/src/bundler/graph/parser_metadata.zig
@@ -1,0 +1,203 @@
+//! Parser scan result materialization helpers for ModuleGraph.
+
+const std = @import("std");
+const types = @import("../types.zig");
+const Module = @import("../module.zig").Module;
+const Parser = @import("../../parser/parser.zig").Parser;
+const profile = @import("../../profile.zig");
+const import_scanner = @import("../import_scanner.zig");
+const binding_scanner = @import("../binding_scanner.zig");
+const graph_parse_helpers = @import("parse_helpers.zig");
+const graph_synthetic_imports = @import("synthetic_imports.zig");
+const ImportKind = types.ImportKind;
+const ImportRecord = types.ImportRecord;
+
+const determineExportsKind = graph_parse_helpers.determineExportsKind;
+const projectExportedNames = graph_parse_helpers.projectExportedNames;
+const injectJsxRuntimeImports = graph_synthetic_imports.injectJsxRuntimeImports;
+const injectFlowEnumRuntimeImport = graph_synthetic_imports.injectFlowEnumRuntimeImport;
+const createJsxImportBindings = graph_synthetic_imports.createJsxImportBindings;
+
+pub fn materialize(
+    self: anytype,
+    module: *Module,
+    parser: *Parser,
+    arena_alloc: std.mem.Allocator,
+) bool {
+    // Parser scan records -> bundler ImportRecord.
+    {
+        var records_scope = profile.begin(.graph_discover_pm_post_records);
+        defer records_scope.end();
+
+        const scan_records = parser.scan_import_records.items;
+        const records = arena_alloc.alloc(ImportRecord, scan_records.len) catch {
+            module.state = .ready;
+            return false;
+        };
+        for (scan_records, 0..) |sr, i| {
+            const ik: ImportKind = @enumFromInt(@intFromEnum(sr.kind));
+            const ctx_mode: types.RequireContextMode = @enumFromInt(@intFromEnum(sr.context_mode));
+            records[i] = .{
+                .specifier = sr.specifier,
+                .kind = ik,
+                .span = sr.span,
+                .url_span = sr.url_span,
+                .glob_eager = sr.glob_eager,
+                .glob_import_name = sr.glob_import_name,
+                .context_recursive = sr.context_recursive,
+                .context_filter = sr.context_filter,
+                .context_filter_flags = sr.context_filter_flags,
+                .context_mode = ctx_mode,
+                .context_invalid_reason = sr.context_invalid_reason,
+            };
+        }
+        module.import_records = records;
+
+        // Parser scan import bindings -> bundler ImportBinding.
+        const scan_ibindings = parser.scan_import_bindings.items;
+        if (arena_alloc.alloc(binding_scanner.ImportBinding, scan_ibindings.len)) |ibindings| {
+            for (scan_ibindings, 0..) |sb, i| {
+                const ib_kind: binding_scanner.ImportBinding.Kind = @enumFromInt(@intFromEnum(sb.kind));
+                ibindings[i] = .{
+                    .kind = ib_kind,
+                    .local_name = sb.local_name,
+                    .imported_name = sb.imported_name,
+                    .local_span = sb.local_span,
+                    .import_record_index = sb.import_record_index,
+                };
+            }
+            module.import_bindings = ibindings;
+        } else |_| {}
+
+        // Parser scan export bindings -> bundler ExportBinding.
+        const scan_ebindings = parser.scan_export_bindings.items;
+        if (arena_alloc.alloc(binding_scanner.ExportBinding, scan_ebindings.len)) |ebindings| {
+            for (scan_ebindings, 0..) |sb, i| {
+                const eb_kind: binding_scanner.ExportBinding.Kind = @enumFromInt(@intFromEnum(sb.kind));
+                ebindings[i] = .{
+                    .exported_name = sb.exported_name,
+                    .local_name = sb.local_name,
+                    .local_span = sb.local_span,
+                    .kind = eb_kind,
+                    .import_record_index = sb.import_record_index,
+                };
+            }
+            module.export_bindings = ebindings;
+            module.exported_names = projectExportedNames(arena_alloc, ebindings);
+        } else |_| {}
+    }
+
+    // OOM 시 silent skip 하면 optional require 가 hard error 로 회귀하므로 module 을
+    // ready 로 끝내고 graph 진행 중단 (1108줄 extractImports 와 동일 패턴).
+    {
+        var optional_scope = profile.begin(.graph_discover_pm_post_optional_requires);
+        defer optional_scope.end();
+        import_scanner.markPostScanFlags(arena_alloc, &(module.ast.?), module.import_records) catch {
+            module.state = .ready;
+            return false;
+        };
+    }
+
+    if (parser.ast.has_flow_enum_declaration) {
+        module.import_records = injectFlowEnumRuntimeImport(
+            arena_alloc,
+            module.import_records,
+        ) catch module.import_records;
+    }
+
+    // namespace access 수집은 별도 AST walk 필요
+    {
+        var namespace_scope = profile.begin(.graph_discover_pm_post_namespace_access);
+        defer namespace_scope.end();
+        binding_scanner.collectNamespaceAccesses(arena_alloc, &parser.ast, module.import_bindings) catch {};
+    }
+
+    // Phase 1-3b (#1328): 합성 심볼 테이블 초기화 + re_export_alias 등록
+    // + semantic 공간에 synthetic_default 등록.
+    {
+        var synthetic_scope = profile.begin(.graph_discover_pm_post_synthetic_symbols);
+        defer synthetic_scope.end();
+        module.ensureAliasTable(self.allocator);
+        if (module.semantic) |*sem| {
+            const scope0: ?std.StringHashMap(usize) =
+                if (sem.scope_maps.len > 0) sem.scope_maps[0] else null;
+            binding_scanner.populateSyntheticSymbols(
+                &module.alias_table.?,
+                module.index,
+                module.export_bindings,
+                &sem.symbols,
+                arena_alloc,
+                scope0,
+            ) catch {};
+        }
+    }
+
+    const scan_result = import_scanner.ScanResult{
+        .records = module.import_records,
+        .has_esm_syntax = parser.scan_result.has_esm_syntax or parser.has_module_syntax,
+        .has_cjs_require = parser.scan_result.has_cjs_require,
+        .has_module_exports = parser.scan_result.has_module_exports,
+        .has_exports_dot = parser.scan_result.has_exports_dot,
+        .has_esmodule_marker = parser.scan_result.has_esmodule_marker,
+    };
+
+    var jsx_injected = false;
+    var react_injected = false;
+    var jsx_inject_base: u32 = 0;
+    // `react` 는 key-after-spread 때만 주입한다. 모든 JSX 모듈에 넣으면
+    // `createElement 미노출` 회귀 테스트가 깨진다.
+    {
+        var jsx_scope = profile.begin(.graph_discover_pm_post_jsx_imports);
+        defer jsx_scope.end();
+        if (self.jsx_runtime != .classic and parser.ast.has_jsx) {
+            if (self.jsx_specifier_cache == null) {
+                const is_dev = self.jsx_runtime == .automatic_dev;
+                self.jsx_specifier_cache = std.fmt.allocPrint(
+                    self.allocator,
+                    "{s}/{s}",
+                    .{ self.jsx_import_source, if (is_dev) "jsx-dev-runtime" else "jsx-runtime" },
+                ) catch null;
+            }
+            if (self.jsx_specifier_cache) |specifier| {
+                var specs_buf: [2][]const u8 = undefined;
+                specs_buf[0] = specifier;
+                var n: usize = 1;
+                if (parser.ast.has_jsx_key_after_spread) {
+                    specs_buf[n] = self.jsx_import_source;
+                    n += 1;
+                }
+                jsx_inject_base = @intCast(module.import_records.len);
+                module.import_records = injectJsxRuntimeImports(
+                    specs_buf[0..n],
+                    arena_alloc,
+                    module.import_records,
+                ) catch module.import_records;
+                jsx_injected = (module.import_records.len > jsx_inject_base);
+                react_injected = (n == 2) and jsx_injected;
+            }
+        }
+    }
+
+    module.exports_kind = determineExportsKind(scan_result, module.path);
+    module.wrap_kind = if (module.exports_kind == .commonjs) .cjs else .none;
+    module.has_cjs_export_signal = scan_result.has_module_exports or scan_result.has_exports_dot;
+    module.can_skip_cjs_default_interop = Module.computeCanSkipCjsDefaultInterop(
+        module.wrap_kind == .cjs,
+        scan_result.has_module_exports,
+        scan_result.has_exports_dot,
+        scan_result.has_esmodule_marker,
+    );
+
+    if (jsx_injected) {
+        const jsx_record_idx: u32 = jsx_inject_base;
+        const react_record_idx: ?u32 = if (react_injected) jsx_record_idx + 1 else null;
+        module.import_bindings = createJsxImportBindings(
+            self.jsx_runtime,
+            arena_alloc,
+            module.import_bindings,
+            jsx_record_idx,
+            react_record_idx,
+        ) catch module.import_bindings;
+    }
+    return true;
+}


### PR DESCRIPTION
## 요약
- `parseModule`의 parser scan 결과/import-export metadata materialization 블록을 `src/bundler/graph/parser_metadata.zig`로 분리했습니다.
- `graph.zig`는 parser AST/line offset 세팅 후 metadata helper에 위임하도록 정리했습니다.
- import record, binding projection, synthetic import, JSX runtime metadata 처리 흐름은 기존 동작 그대로 유지했습니다.

## 검증
- `zig fmt --check src/bundler/graph.zig src/bundler/graph/parser_metadata.zig`
- `git diff --check`
- `zig build test`
- `zig build`
- `zig build napi`
- `node --test packages/core/napi.test.mjs`
- pre-push: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`

## 참고
- `bun test --cwd tests/integration --timeout 10000`은 `watch-stress` 1건에서 RSS slope 기준으로 실패했습니다.
- 같은 `watch-stress` 단독 테스트가 현재 `main`에서도 재현됩니다. branch: slope 8.45KB/rebuild, growth 1456KB / main: slope 8.40KB/rebuild, growth 1440KB 입니다.