### PR TITLE
fix(bundler): `.cjs` 를 script mode 로 정렬 + `.cts` 는 module 일관 유지

### DIFF
--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -1973,3 +1973,66 @@ test "ESM ns-access: opaque path (bare ref after member access) doesn't leak" {
     // 실제 검증은 GPA debug allocator 의 leak 검출에 위임 —
     // leak 발생 시 `zig build test` 가 테스트 실패 처리.
 }
+
+// ============================================================
+// `.cjs` / `.cts` 는 Node CommonJS 컨벤션상 ESM 구문 (`import`/`export`) 거부.
+// 이전엔 graph/parser_setup.zig 가 모든 모듈을 is_module=true 로 promote 해서
+// `.cjs` 도 `export const x = 1` 을 받아들여 Node 와 호환 안 됐음.
+// ============================================================
+
+test "CJS convention: `.cjs` 가 top-level `export const` 를 거부" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.cjs",
+        \\export const x = 1;
+    );
+
+    const entry = try absPath(&tmp, "entry.cjs");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.hasErrors());
+}
+
+test "CJS convention: `.cjs` 의 `module.exports` + `with` 모두 정상 (script mode)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.cjs",
+        \\function run(obj) {
+        \\  var x = 1;
+        \\  with (obj) { console.log(x); }
+        \\}
+        \\module.exports = { run };
+    );
+
+    const entry = try absPath(&tmp, "entry.cjs");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+}
+
+test "CJS convention: `.cts` 는 ESM 구문 허용 (TS 가 module.exports 로 transpile — tsc 정책)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "import { x } from './lib.cts';\nconsole.log(x);");
+    try writeFile(tmp.dir, "lib.cts", "export const x: number = 42;");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+}

--- a/src/bundler/graph/parser_setup.zig
+++ b/src/bundler/graph/parser_setup.zig
@@ -64,14 +64,27 @@ pub fn init(
     else
         .unknown;
 
-    // .js/.jsx: package.json "type" 또는 Unambiguous 모드로 module/script 결정
-    // .mjs/.mts/.ts/.tsx: 이미 확정 module, 변경 없음
-    if (!parser.is_module) {
-        parser.is_module = true;
-        scanner.is_module = true;
-        if (module.def_format == .unknown) {
+    // def_format 기반 module/script 결정:
+    //   .esm_mjs / .esm_mts / .esm_package_json → 확정 module
+    //   .cjs → script (Node CommonJS — `import`/`export` 거부, top-level await 거부).
+    //   .cts → module 유지 (TypeScript CJS — ESM 구문을 TS 가 module.exports 로 transpile.
+    //          tsc 와 동일한 정책. configureForBundlerKind 가 이미 is_module=true 로 set).
+    //   .unknown → Unambiguous (낙관적 module + 에러 지연 → 파싱 후 resolveModuleKind 가 확정)
+    // .mjs/.mts/.ts/.tsx 는 configureForBundler 단계에서 이미 is_module=true.
+    switch (module.def_format) {
+        .cjs => {
+            parser.is_module = false;
+            scanner.is_module = false;
+        },
+        .unknown => if (!parser.is_module) {
+            parser.is_module = true;
+            scanner.is_module = true;
             parser.is_unambiguous = true;
-        }
+        },
+        else => if (!parser.is_module) {
+            parser.is_module = true;
+            scanner.is_module = true;
+        },
     }
     // Inline scanning: 파서가 AST를 구축하면서 import/export 레코드를 동시 수집
     parser.enable_scan = true;

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -293,10 +293,11 @@ pub const Parser = struct {
     ///
     /// oxc 방식 Unambiguous 모드:
     /// - .mts/.mjs → 확정적 Module (is_module=true)
-    /// - .ts/.tsx → Unambiguous (is_module=true 낙관적 파싱 + 에러 지연)
+    /// - .ts/.tsx/.cts → Unambiguous (is_module=true 낙관적 파싱 + 에러 지연).
+    ///                    .cts 는 TS CommonJS 인데 tsc 정책상 ESM 구문 허용 → module.exports 로 transpile.
     /// - .js/.jsx → Unambiguous (is_module=true 낙관적 파싱 — esbuild/swc/rollup 와
     ///                            동일하게 ESM 코드도 받음. 순수 script 코드도 호환)
-    /// - .cts/.cjs → Script (is_module=false, Node CommonJS 컨벤션)
+    /// - .cjs → Script (is_module=false, Node CommonJS — `import`/`export`/top-level-await 거부)
     /// CLI용: .ts/.tsx는 Unambiguous 모드 (import/export 유무로 module/script 파싱 후 확정)
     pub fn configureFromExtension(self: *Parser, ext: []const u8) void {
         self.applyExtension(ext, true);
@@ -326,7 +327,11 @@ pub const Parser = struct {
         if (std.mem.eql(u8, ext, ".mts") or std.mem.eql(u8, ext, ".mjs")) {
             self.is_module = true;
             self.scanner.is_module = true;
-        } else if (std.mem.eql(u8, ext, ".ts") or std.mem.eql(u8, ext, ".tsx")) {
+        } else if (std.mem.eql(u8, ext, ".ts") or std.mem.eql(u8, ext, ".tsx") or
+            std.mem.eql(u8, ext, ".cts"))
+        {
+            // .cts 는 Node 입장에선 CJS 지만 tsc 가 ESM 구문을 받아 module.exports 로
+            // transpile. parser 레벨에선 module 로 파싱.
             self.is_module = true;
             self.scanner.is_module = true;
             self.is_unambiguous = ts_unambiguous;

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -2754,10 +2754,10 @@ test ".cjs: ESM export 는 여전히 거부 (Node CJS 컨벤션 유지)" {
     , ".cjs", .{ .message_contains = "module code" });
 }
 
-test ".cts: ESM export 도 거부 (TS CommonJS 컨벤션 유지)" {
-    try expectParseErrorWithExt(
+test ".cts: ESM 구문 허용 — TS 가 module.exports 로 transpile (tsc 정책)" {
+    try expectNoParseErrorWithExt(
         \\export const x: number = 1;
-    , ".cts", .{ .message_contains = "module code" });
+    , ".cts");
 }
 
 test "declare module: multiple statements in ambient body" {


### PR DESCRIPTION
## 요약
- 번들러가 `.cjs` 도 무조건 `is_module=true` 로 promote 하던 문제 수정. Node CommonJS 컨벤션상 `.cjs` 는 `import`/`export`/top-level-await 거부.
- `.cts` 는 module 모드 일관 유지 — tsc 정책상 ESM 구문 허용 (transpile 시 `module.exports` 로 변환).
- PR #2853 머지 직후 발견된 후속 quirk.

## 원인
`src/bundler/graph/parser_setup.zig` 의 `if (!parser.is_module) { parser.is_module = true; ... }` 가 `def_format` 무관하게 모든 모듈을 module 로 promote. `.cjs` (Node CommonJS) 도 ESM 받아들여 Node 와 호환 안 됐음.

## 수정
1. **`parser_setup.zig`** — 무조건 promote → `def_format` switch:
   - `.cjs` → script (Node CommonJS — `configureForBundlerKind` 가 set 한 is_module=true 도 revert)
   - `.cts` → module 유지 (tsc 정책)
   - `.esm_*` → module 유지
   - `.unknown` → 낙관적 module + unambiguous (기존)

2. **`parser.zig` `applyExtension()`** — `.cts` 를 TS module 분기에 추가. CLI/transpile 도 bundler 와 동일하게 ESM 허용 (이전엔 CLI 만 거부 — 비대칭).

## 검증

- [x] **새 zig 테스트 3건** (`.cjs` reject ESM / `.cjs` allow `with`+`module.exports` / `.cts` accept ESM)
- [x] **`zig build test`** — 4766 pass / 0 fail
- [x] **#1258 `with`** 회귀 테스트 — script mode 보존으로 정상
- [x] **`Extension: import .cts file via .cjs`** — TS CJS module 동작 보존
- [x] **`packages/core`** 881 pass / 0 fail
- [x] **`packages/react-native`** 470 pass / 0 fail
- [x] **`packages/web`** 141 pass / 0 fail
- [x] **`tests/integration`** — pre-existing flaky 3건 외 회귀 0건
- [x] **3-agent /simplify** — 검토 통과

## 사용자 영향

| 입력 | 이전 | 이후 |
|---|---|---|
| `.cjs` + `import { x } from 'y'` | accept (Node-incompat) | **reject** (Node CJS) |
| `.cjs` + `module.exports = x` | accept | accept |
| `.cjs` + `with (...) {}` | reject (strict) | **accept** (script) |
| `.cts` + `export const x` (CLI) | reject (비대칭) | **accept** (tsc parity) |
| `.cts` + `export const x` (bundler) | accept | accept |

🤖 Generated with [Claude Code](https://claude.com/claude-code)