### PR TITLE
fix(server): HMR_MSG / HMR_RN_MSG runtime freeze

### DIFF
--- a/packages/server/src/protocol.ts
+++ b/packages/server/src/protocol.ts
@@ -3,13 +3,19 @@
 // `hmr:update-start` / `hmr:update` / `hmr:update-done` / `hmr:reload` / `hmr:error` /
 // `log` 그대로 (RN 런타임의 HMRClient 가 소비). web 의 HMR_MSG 와 직교 (#2540).
 
-export const HMR_MSG = {
+export const HMR_MSG: Readonly<{
+  Connected: 'connected';
+  CssUpdate: 'css-update';
+  ClearError: 'clear-error';
+  Error: 'error';
+  FullReload: 'full-reload';
+}> = Object.freeze({
   Connected: 'connected',
   CssUpdate: 'css-update',
   ClearError: 'clear-error',
   Error: 'error',
   FullReload: 'full-reload',
-} as const;
+} as const);
 
 export type HmrMessageType = (typeof HMR_MSG)[keyof typeof HMR_MSG];
 
@@ -80,14 +86,21 @@ export function normalizeHmrErrors(errors: readonly unknown[] | unknown): HmrErr
 // 의 onmessage 분기 키. revisionId 기반 delta 는 caller (번개 server) 가 관리,
 // adapter 는 메시지 union 만 통과.
 
-export const HMR_RN_MSG = {
+export const HMR_RN_MSG: Readonly<{
+  UpdateStart: 'hmr:update-start';
+  Update: 'hmr:update';
+  UpdateDone: 'hmr:update-done';
+  Reload: 'hmr:reload';
+  Error: 'hmr:error';
+  Log: 'log';
+}> = Object.freeze({
   UpdateStart: 'hmr:update-start',
   Update: 'hmr:update',
   UpdateDone: 'hmr:update-done',
   Reload: 'hmr:reload',
   Error: 'hmr:error',
   Log: 'log',
-} as const;
+} as const);
 
 export type HmrRnMessageType = (typeof HMR_RN_MSG)[keyof typeof HMR_RN_MSG];
 


### PR DESCRIPTION
## 요약
`packages/server/src/protocol.ts` 의 `HMR_MSG` / `HMR_RN_MSG` enum 이 `as const` 만 적용돼있어 type level 만 readonly. runtime 에선 mutation 가능 → `Object.isFrozen` 테스트 (#2540) 가 main 에서 false 반환.

## 수정
`Object.freeze({...} as const)` 로 감싸 runtime mutation 방지. isolatedDeclarations 제약상 `typeof` 자기참조 안 되므로 명시 `Readonly<{ key: literal; ... }>` annotation.

## 검증
- `bun test --cwd packages/server`: 83 pass / 0 fail (이전 81/2)
- `bun x tsc -b`: 0 errors
- `bun run fmt:check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)