### PR TITLE
fix(bundler): runtime helper canonical_name 보존 (es5-rn `__extends$1 is not defined`)

### DIFF
--- a/src/bundler/bundler_test/default_deconflict.zig
+++ b/src/bundler/bundler_test/default_deconflict.zig
@@ -8,6 +8,7 @@ const CompiledOutputCache = @import("../compiled_cache.zig").CompiledOutputCache
 const test_helpers = @import("../test_helpers.zig");
 const writeFile = test_helpers.writeFile;
 const absPath = test_helpers.absPath;
+const compat_mod = @import("../../transformer/compat.zig");
 
 // ============================================================
 // Default export advanced patterns (Rollup/Rolldown 참고)
@@ -1033,4 +1034,76 @@ test "Default: named `export default function` has no `_default` (#1598)" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "_default") == null);
     // 실행 결과 보존
     try std.testing.expect(std.mem.indexOf(u8, result.output, "Hello") != null);
+}
+
+// ============================================================
+// Runtime helper canonical name 안정성 — `__extends`, `__classCallCheck`
+// 등 ZNTC runtime helper module symbol 은 multi-consumer 환경에서도 단일
+// canonical name 을 유지해야 함. resolveNestedShadowConflicts 가 consumer
+// 별로 helper 의 canonical_name 을 `$1`, `$2`... 로 덮어쓰면 마지막 rename 만
+// declaration 으로 emit 되고 나머지는 `__extends$N is not defined` 런타임 에러
+// (RN ExampleApp 회귀, es5-rn 통합 테스트).
+// ============================================================
+
+test "Runtime helper: 다수의 class extends consumer 가 있어도 __extends 단일 canonical 유지" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // class extends → ES5 lower 시 IIFE 내부에 `function __()` 등 helper-name 과
+    // 충돌 가능한 nested binding 이 생긴다. resolveNestedShadowConflicts 가 매
+    // consumer 마다 helper 의 canonical_name 을 `$1`, `$2` ... 로 덮어쓰면 마지막
+    // rename 만 declaration 으로 emit 되고 나머지 consumer 의 `__extends$N(...)`
+    // 호출은 ReferenceError (RN ExampleApp 회귀, es5-rn 통합 테스트).
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { A } from './a';
+        \\import { B } from './b';
+        \\import { C } from './c';
+        \\import { D } from './d';
+        \\import { E } from './e';
+        \\console.log(A, B, C, D, E);
+    );
+    try writeFile(tmp.dir, "a.ts",
+        \\export class A extends Object {}
+    );
+    try writeFile(tmp.dir, "b.ts",
+        \\export class B extends Array {}
+    );
+    try writeFile(tmp.dir, "c.ts",
+        \\export class C extends Map {}
+    );
+    try writeFile(tmp.dir, "d.ts",
+        \\export class D extends Set {}
+    );
+    try writeFile(tmp.dir, "e.ts",
+        \\export class E extends WeakMap {}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        // es5 target → class extends 가 `__extends(...)` 호출로 lower → runtime helper
+        // import 가 매 consumer 모듈에 synthetic 으로 등록되어 회귀 재현.
+        .unsupported = compat_mod.fromESTarget(.es5),
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+
+    // `__extends$N` (N = 정수) suffix 형태 호출이 있으면 회귀.
+    // helper 의 canonical_name 은 `__extends` (또는 단일 일관 이름) 여야 함.
+    var i: usize = 0;
+    while (std.mem.indexOfPos(u8, result.output, i, "__extends$")) |pos| {
+        const after = pos + "__extends$".len;
+        if (after < result.output.len and std.ascii.isDigit(result.output[after])) {
+            std.debug.print(
+                "Found unresolved __extends${c} at byte {d} — runtime helper canonical_name leak\n",
+                .{ result.output[after], pos },
+            );
+            return error.TestUnexpectedResult;
+        }
+        i = pos + 1;
+    }
 }

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -895,7 +895,12 @@ pub const Linker = struct {
 
     /// import binding의 canonical name이 importer 모듈의 중첩 스코프에 같은 이름이
     /// 있으면, target module의 이름을 한 단계 더 rename하여 shadowing 충돌 방지.
+    /// 단 ZNTC runtime helper module 은 cross-module 공유 symbol 이라 consumer 별로
+    /// rename 하면 매 호출이 canonical_name 을 덮어써 최종 하나만 유효, 나머지
+    /// `__extends$1`, `$2` ... 호출은 ReferenceError (미선언). helper module 은 rename
+    /// 대상에서 제외 — 충돌은 consumer 측 nested binding 을 mangling 단계가 처리한다.
     fn resolveNestedShadowConflicts(self: *Linker, name_to_owners: *const NameToOwnersMap) !void {
+        const helper_modules = @import("../runtime_helper_modules.zig");
         for (0..self.graph.moduleCount()) |mod_i| {
             const m = self.getModule(@intCast(mod_i)) orelse continue;
             for (m.import_bindings) |ib| {
@@ -909,6 +914,8 @@ pub const Linker = struct {
                 {
                     // target module의 canonical name을 한 단계 더 rename
                     const cmod: u32 = @intCast(@intFromEnum(resolved.canonical.module_index));
+                    const target_module = self.getModule(cmod) orelse continue;
+                    if (helper_modules.isVirtualId(target_module.path)) continue;
                     const export_local = self.getExportLocalName(cmod, resolved.canonical.export_name) orelse resolved.canonical.export_name;
 
                     // 새 이름: target_name$N (기존 이름 충돌 없는 것)


### PR DESCRIPTION
## 요약
- 번들러가 `__extends`, `__classCallCheck` 등 ZNTC runtime helper 의 canonical_name 을 매 consumer 마다 `$1`, `$2`... 로 덮어써, 마지막 rename 만 declaration 으로 emit 되고 나머지 호출은 `ReferenceError: __extends$N is not defined` 가 되던 회귀 수정.
- `tests/integration/tests/es5-rn.test.ts` 의 `bundle (no target)` / `bundle --target=es5` 가 RN ExampleApp 번들 실행 시 `FATAL: __extends$1 is not defined` 로 실패하던 원인.

## 원인
`src/bundler/linker.zig` 의 `resolveNestedShadowConflicts`:
- consumer 의 nested binding (예: ES5-lower 시 class IIFE 내부 `function __()`) 이 helper canonical_name 과 같으면 shadow 충돌로 판단
- helper module 의 symbol canonical_name 을 `findAvailableCandidate` 로 `$N` rename
- 매 consumer 마다 새 candidate 생성 → 매번 다른 suffix 가 helper symbol 에 덮어씌워짐
- 최종 helper declaration 은 마지막 rename 의 이름. 그 외 consumer 의 `__extends$N` 호출은 binding 없음

## 수정
`resolveNestedShadowConflicts` 에서 target 이 ZNTC runtime helper virtual module (`\x00zntc:runtime/<name>`) 이면 rename 자체를 skip. helper 는 cross-module 공유 symbol 이라 단일 canonical name 유지. consumer 측 nested binding 의 shadow 는 mangling 단계가 처리.

`collectModuleNames` (#966c567e) / `collectUnifiedInput` 의 helper-skip 패턴과 정합:
- 셋 다 `helper_modules.isVirtualId(target_module.path)` 가드
- helper module 은 cross-module 공유 symbol 이므로 per-consumer rename 금지 — 일관 적용

## 회귀 테스트
`src/bundler/bundler_test/default_deconflict.zig` 에 추가:
- 5개 class extends consumer (Object/Array/Map/Set/WeakMap) + es5 target
- bundle 출력에 `__extends$<digit>` 형태가 있으면 실패 (RN ExampleApp 회귀 minimal repro)

## 검증
- [x] `zig build test`: **4767 pass / 0 fail** (회귀 테스트 +1)
- [x] `tests/integration es5-rn`: **30 pass / 0 fail** (이전 28/2)
- [x] `packages/core`: 881/0
- [x] `packages/react-native`: 470/0
- [x] `packages/web`: 141/0
- [x] `packages/server`: 83/0
- [x] `bun run fmt:check`: clean
- [x] /simplify 3-agent 검토 — 이슈 없음

## 알려진 별개 이슈 (이번 PR 범위 밖)
사용자가 `const __extends = ...` 같은 helper 이름을 top-level 로 직접 선언하는 shadow 케이스. transformer 의 helper reference 가 symbol-bound 가 아니라 name-based 라 user binding 에 의해 shadow 됨. esbuild/swc/rollup 표준은 symbol-bound reference. transformer/AST/semantic 변경 필요한 구조적 fix 라 다음 PR 로 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)