### PR TITLE
refactor: graph cycle 헬퍼 분리

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -72,6 +72,7 @@ const graph_state = @import("graph/state.zig");
 const graph_parser_metadata = @import("graph/parser_metadata.zig");
 const graph_import_usage = @import("graph/import_usage.zig");
 const graph_accessors = @import("graph/accessors.zig");
+const graph_cycles = @import("graph/cycles.zig");
 
 pub const determineExportsKind = graph_parse_helpers.determineExportsKind;
 
@@ -95,6 +96,8 @@ pub const ModuleGraph = struct {
     pub const findModuleByPath = graph_accessors.findModuleByPath;
     pub const moduleAtMut = graph_accessors.moduleAtMut;
     pub const modulesIterator = graph_accessors.modulesIterator;
+    const dfs = graph_cycles.dfs;
+    const markCyclesViaDynamic = graph_cycles.markViaDynamic;
     const shouldRunTransformerPrePass = graph_transform_prepass.shouldRun;
     const runTransformerPrePass = graph_transform_prepass.run;
     pub const resyncModuleMetadataAfterConstMaterialization = graph_transform_prepass.resyncAfterConstMaterialization;
@@ -1743,164 +1746,6 @@ pub const ModuleGraph = struct {
 
         // require.context context_expansion_deps 도 resolve + addDep.
         try self.applyContextDepResults(mod_idx);
-    }
-
-    /// Phase 2: 반복 DFS 후위 순서 순회. exec_index 부여 + 순환 감지 (D065, D076).
-    /// 재귀 대신 명시적 스택 사용 — 깊은 모듈 체인에서도 스택 오버플로 없음.
-    fn dfs(self: *ModuleGraph, start_idx: ModuleIndex, visited: *std.DynamicBitSet, in_stack: *std.DynamicBitSet) !void {
-        const DfsEntry = struct {
-            idx: u32,
-            post: bool, // true = 후처리 (exec_index 부여), false = 전처리 (의존성 push)
-        };
-
-        var stack: std.ArrayList(DfsEntry) = .empty;
-        defer stack.deinit(self.allocator);
-
-        const start = @intFromEnum(start_idx);
-        if (start >= self.modules.count()) return;
-        if (visited.isSet(start)) return;
-
-        try stack.append(self.allocator, .{ .idx = start, .post = false });
-
-        while (stack.items.len > 0) {
-            const entry = stack.pop() orelse break;
-
-            if (entry.post) {
-                // 후처리: exec_index 부여 + in_stack 해제
-                in_stack.unset(entry.idx);
-                visited.set(entry.idx);
-                self.modules.at(entry.idx).exec_index = self.exec_counter;
-                self.exec_counter += 1;
-                continue;
-            }
-
-            if (visited.isSet(entry.idx)) continue;
-
-            // 순환 감지 (D065)
-            if (in_stack.isSet(entry.idx)) {
-                self.cycle_counter += 1;
-                const entry_mod = self.modules.at(entry.idx);
-                entry_mod.cycle_group = self.cycle_counter;
-                // cycle 의 *모든 멤버* 에 같은 cycle_group 부여 (#2198).
-                // stack 거꾸로 따라가며 back-edge target (entry.idx) 까지 marking →
-                // cycle 안 모듈의 const/let 을 emit 시 var 로 강등 (esbuild 호환,
-                // ESM live binding 으로 TDZ 회피). post=true 가 path 상 노드 표식.
-                {
-                    var k = stack.items.len;
-                    while (k > 0) {
-                        k -= 1;
-                        const e = stack.items[k];
-                        if (!e.post) continue;
-                        self.modules.at(e.idx).cycle_group = self.cycle_counter;
-                        if (e.idx == entry.idx) break;
-                    }
-                }
-                self.addDiag(
-                    .circular_dependency,
-                    .warning,
-                    entry_mod.path,
-                    Span.EMPTY,
-                    .link,
-                    "Circular dependency detected",
-                    null,
-                );
-                continue;
-            }
-
-            in_stack.set(entry.idx);
-
-            // 후처리를 먼저 push (LIFO이므로 나중에 실행)
-            try stack.append(self.allocator, .{ .idx = entry.idx, .post = true });
-
-            // 의존성을 역순으로 push (원래 순서대로 방문하기 위해).
-            // dynamic_imports 는 *exec_index/TLA 전파 분석용 dfs* 에선 따라가지
-            // 않는다 (lazy 라 평가 순서/TLA 전파에 무관). cycle marking 은 별도
-            // pass `markCyclesViaDynamic` 에서 dynamic edge 도 같이 본다 (#2211).
-            const deps = self.modules.at(entry.idx).dependencies.items;
-            var j: usize = deps.len;
-            while (j > 0) {
-                j -= 1;
-                const dep = @intFromEnum(deps[j]);
-                if (dep < self.modules.count() and !visited.isSet(dep)) {
-                    try stack.append(self.allocator, .{ .idx = dep, .post = false });
-                }
-            }
-        }
-    }
-
-    /// dynamic edge 도 따라가는 별도 cycle marking pass (#2211).
-    /// 기본 dfs 는 `dependencies` 만 follow 해서 exec_index/TLA 전파 분석 정확성을
-    /// 유지. 그러나 dynamic target 이 다른 모듈과 *static cycle* 이면 cycle 멤버
-    /// marking 이 필요 — `dependencies + dynamic_imports` 양쪽 따라가는 별도 dfs 로
-    /// cycle_group 만 부여한다 (exec_index 는 건드리지 않음).
-    fn markCyclesViaDynamic(self: *ModuleGraph, entry_indices: []const ModuleIndex) !void {
-        const count = self.modules.count();
-        if (count == 0) return;
-
-        var visited = try std.DynamicBitSet.initEmpty(self.allocator, count);
-        defer visited.deinit();
-        var in_stack = try std.DynamicBitSet.initEmpty(self.allocator, count);
-        defer in_stack.deinit();
-
-        const DfsEntry = struct { idx: u32, post: bool };
-        var stack: std.ArrayList(DfsEntry) = .empty;
-        defer stack.deinit(self.allocator);
-
-        for (entry_indices) |entry_idx| {
-            const start = @intFromEnum(entry_idx);
-            if (start >= count) continue;
-            if (visited.isSet(start)) continue;
-            try stack.append(self.allocator, .{ .idx = start, .post = false });
-
-            while (stack.items.len > 0) {
-                const entry = stack.pop() orelse break;
-
-                if (entry.post) {
-                    in_stack.unset(entry.idx);
-                    visited.set(entry.idx);
-                    continue;
-                }
-
-                if (visited.isSet(entry.idx)) continue;
-
-                if (in_stack.isSet(entry.idx)) {
-                    // back-edge — cycle 의 모든 stack 멤버에 같은 cycle_group 부여.
-                    // 기존 (정적 dfs) 가 부여한 cycle_group 이 있으면 그 위에 덮어쓰지
-                    // 않고 새로 dynamic-only cycle 만 카운터 증가.
-                    self.cycle_counter += 1;
-                    var k = stack.items.len;
-                    while (k > 0) {
-                        k -= 1;
-                        const e = stack.items[k];
-                        if (!e.post) continue;
-                        if (self.modules.at(e.idx).cycle_group == 0) {
-                            self.modules.at(e.idx).cycle_group = self.cycle_counter;
-                        }
-                        if (e.idx == entry.idx) break;
-                    }
-                    if (self.modules.at(entry.idx).cycle_group == 0) {
-                        self.modules.at(entry.idx).cycle_group = self.cycle_counter;
-                    }
-                    continue;
-                }
-
-                in_stack.set(entry.idx);
-                try stack.append(self.allocator, .{ .idx = entry.idx, .post = true });
-
-                const cur_mod = self.modules.at(entry.idx);
-                const dep_groups = [_][]const ModuleIndex{ cur_mod.dependencies.items, cur_mod.dynamic_imports.items };
-                for (dep_groups) |group| {
-                    var j: usize = group.len;
-                    while (j > 0) {
-                        j -= 1;
-                        const dep = @intFromEnum(group[j]);
-                        if (dep < count and !visited.isSet(dep)) {
-                            try stack.append(self.allocator, .{ .idx = dep, .post = false });
-                        }
-                    }
-                }
-            }
-        }
     }
 
     // ============================================================

--- a/src/bundler/graph/cycles.zig
+++ b/src/bundler/graph/cycles.zig
@@ -1,0 +1,146 @@
+//! Cycle detection and execution-order DFS helpers for ModuleGraph.
+
+const std = @import("std");
+const ModuleIndex = @import("../types.zig").ModuleIndex;
+const Span = @import("../../lexer/token.zig").Span;
+
+/// Phase 2: 반복 DFS 후위 순서 순회. exec_index 부여 + 순환 감지 (D065, D076).
+/// 재귀 대신 명시적 스택 사용 — 깊은 모듈 체인에서도 스택 오버플로 없음.
+pub fn dfs(self: anytype, start_idx: ModuleIndex, visited: *std.DynamicBitSet, in_stack: *std.DynamicBitSet) !void {
+    const DfsEntry = struct {
+        idx: u32,
+        post: bool, // true = 후처리 (exec_index 부여), false = 전처리 (의존성 push)
+    };
+
+    var stack: std.ArrayList(DfsEntry) = .empty;
+    defer stack.deinit(self.allocator);
+
+    const start = @intFromEnum(start_idx);
+    if (start >= self.modules.count()) return;
+    if (visited.isSet(start)) return;
+
+    try stack.append(self.allocator, .{ .idx = start, .post = false });
+
+    while (stack.items.len > 0) {
+        const entry = stack.pop() orelse break;
+
+        if (entry.post) {
+            in_stack.unset(entry.idx);
+            visited.set(entry.idx);
+            self.modules.at(entry.idx).exec_index = self.exec_counter;
+            self.exec_counter += 1;
+            continue;
+        }
+
+        if (visited.isSet(entry.idx)) continue;
+
+        if (in_stack.isSet(entry.idx)) {
+            self.cycle_counter += 1;
+            const entry_mod = self.modules.at(entry.idx);
+            entry_mod.cycle_group = self.cycle_counter;
+            var k = stack.items.len;
+            while (k > 0) {
+                k -= 1;
+                const e = stack.items[k];
+                if (!e.post) continue;
+                self.modules.at(e.idx).cycle_group = self.cycle_counter;
+                if (e.idx == entry.idx) break;
+            }
+            self.addDiag(
+                .circular_dependency,
+                .warning,
+                entry_mod.path,
+                Span.EMPTY,
+                .link,
+                "Circular dependency detected",
+                null,
+            );
+            continue;
+        }
+
+        in_stack.set(entry.idx);
+        try stack.append(self.allocator, .{ .idx = entry.idx, .post = true });
+
+        const deps = self.modules.at(entry.idx).dependencies.items;
+        var j: usize = deps.len;
+        while (j > 0) {
+            j -= 1;
+            const dep = @intFromEnum(deps[j]);
+            if (dep < self.modules.count() and !visited.isSet(dep)) {
+                try stack.append(self.allocator, .{ .idx = dep, .post = false });
+            }
+        }
+    }
+}
+
+/// dynamic edge 도 따라가는 별도 cycle marking pass (#2211).
+/// 기본 dfs 는 `dependencies` 만 follow 해서 exec_index/TLA 전파 분석 정확성을
+/// 유지. 그러나 dynamic target 이 다른 모듈과 *static cycle* 이면 cycle 멤버
+/// marking 이 필요 — `dependencies + dynamic_imports` 양쪽 따라가는 별도 dfs 로
+/// cycle_group 만 부여한다 (exec_index 는 건드리지 않음).
+pub fn markViaDynamic(self: anytype, entry_indices: []const ModuleIndex) !void {
+    const count = self.modules.count();
+    if (count == 0) return;
+
+    var visited = try std.DynamicBitSet.initEmpty(self.allocator, count);
+    defer visited.deinit();
+    var in_stack = try std.DynamicBitSet.initEmpty(self.allocator, count);
+    defer in_stack.deinit();
+
+    const DfsEntry = struct { idx: u32, post: bool };
+    var stack: std.ArrayList(DfsEntry) = .empty;
+    defer stack.deinit(self.allocator);
+
+    for (entry_indices) |entry_idx| {
+        const start = @intFromEnum(entry_idx);
+        if (start >= count) continue;
+        if (visited.isSet(start)) continue;
+        try stack.append(self.allocator, .{ .idx = start, .post = false });
+
+        while (stack.items.len > 0) {
+            const entry = stack.pop() orelse break;
+
+            if (entry.post) {
+                in_stack.unset(entry.idx);
+                visited.set(entry.idx);
+                continue;
+            }
+
+            if (visited.isSet(entry.idx)) continue;
+
+            if (in_stack.isSet(entry.idx)) {
+                self.cycle_counter += 1;
+                var k = stack.items.len;
+                while (k > 0) {
+                    k -= 1;
+                    const e = stack.items[k];
+                    if (!e.post) continue;
+                    if (self.modules.at(e.idx).cycle_group == 0) {
+                        self.modules.at(e.idx).cycle_group = self.cycle_counter;
+                    }
+                    if (e.idx == entry.idx) break;
+                }
+                if (self.modules.at(entry.idx).cycle_group == 0) {
+                    self.modules.at(entry.idx).cycle_group = self.cycle_counter;
+                }
+                continue;
+            }
+
+            in_stack.set(entry.idx);
+            try stack.append(self.allocator, .{ .idx = entry.idx, .post = true });
+
+            const cur_mod = self.modules.at(entry.idx);
+            const dep_groups = [_][]const ModuleIndex{ cur_mod.dependencies.items, cur_mod.dynamic_imports.items };
+            for (dep_groups) |group| {
+                var j: usize = group.len;
+                while (j > 0) {
+                    j -= 1;
+                    const dep = @intFromEnum(group[j]);
+                    if (dep < count and !visited.isSet(dep)) {
+                        try stack.append(self.allocator, .{ .idx = dep, .post = false });
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 요약
- `ModuleGraph`의 DFS 실행 순서 부여와 cycle marking helper를 `src/bundler/graph/cycles.zig`로 분리했습니다.
- 기존 `self.dfs`, `self.markCyclesViaDynamic` 호출 이름은 alias로 유지했습니다.
- 그래프 build/finalize 흐름은 변경하지 않고 cycle helper 구현만 이동했습니다.

## 검증
- `zig fmt --check src/bundler/graph.zig src/bundler/graph/cycles.zig`
- `git diff --check`
- `zig build test`
- `bun test --cwd tests/integration tests/bundle-smoke.test.ts --timeout 10000` (149 pass)
- `bun test --cwd tests/integration tests/bundle-circular-cycle.test.ts tests/bundle-dynamic-import.test.ts --timeout 10000` (19 pass)
- `zig build`
- `zig build napi`
- `node --test packages/core/napi.test.mjs` (18 pass)
- pre-push hook 통과

## 참고
- pre-push의 oxlint 경고 23개는 기존 JS/TS 파일 경고이며 이번 변경 파일과 무관합니다.
