### PR TITLE
refactor: graph discovery scan 분리

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -74,8 +74,8 @@ pub const ModuleGraph = struct {
     const suppressRuntimeHelperInternalUnresolved = graph_parse_helpers.suppressRuntimeHelperInternalUnresolved;
     const requestAllExports = graph_requested_exports.requestAll;
     const requestNamedExport = graph_requested_exports.requestNamed;
-    const shouldLinkResolvedRecordForModule = graph_requested_exports.shouldLinkResolvedRecordForModule;
-    const hasDeferredRequestedImports = graph_requested_exports.hasDeferredRequestedImports;
+    pub const shouldLinkResolvedRecordForModule = graph_requested_exports.shouldLinkResolvedRecordForModule;
+    pub const hasDeferredRequestedImports = graph_requested_exports.hasDeferredRequestedImports;
     const requestDependencyExports = graph_requested_exports.requestDependencyExports;
     const isImportAllBindingsUnused = graph_import_usage.isImportAllBindingsUnused;
     const validModuleSlot = graph_accessors.validModuleSlot;
@@ -92,7 +92,7 @@ pub const ModuleGraph = struct {
     pub const resyncModuleMetadataAfterAstMutation = graph_transform_prepass.resyncAfterAstMutation;
     const graph_package_info = @import("graph/package_info.zig");
     pub const lookupPkgInfo = graph_package_info.lookupPkgInfo;
-    const applySideEffectsFromPackageJson = graph_package_info.applySideEffectsFromPackageJson;
+    pub const applySideEffectsFromPackageJson = graph_package_info.applySideEffectsFromPackageJson;
     const isPackageTypeModule = graph_package_info.isPackageTypeModule;
 
     allocator: std.mem.Allocator,
@@ -295,7 +295,7 @@ pub const ModuleGraph = struct {
 
     const ensureBuiltinPlugins = graph_plugins.ensureBuiltinPlugins;
     pub const pluginRunnerWithBuiltins = graph_plugins.pluginRunnerWithBuiltins;
-    const shouldRunResolveId = graph_plugins.shouldRunResolveId;
+    pub const shouldRunResolveId = graph_plugins.shouldRunResolveId;
     pub const runPluginLoadForModule = graph_plugins.runLoadForModule;
     pub const runPluginTransformForModule = graph_plugins.runTransformForModule;
     pub const materializeParserMetadata = graph_parser_metadata.materialize;
@@ -587,7 +587,7 @@ pub const ModuleGraph = struct {
         try self.linkDependency(from, to);
     }
 
-    fn discardResolvedModule(self: *ModuleGraph, resolved: plugin_mod.ResolvedModule) void {
+    pub fn discardResolvedModule(self: *ModuleGraph, resolved: plugin_mod.ResolvedModule) void {
         switch (resolved) {
             .file => |f| self.allocator.free(f.path),
             .disabled => |d| self.allocator.free(d.path),
@@ -595,7 +595,7 @@ pub const ModuleGraph = struct {
         }
     }
 
-    fn markRecordLazyResolved(self: *ModuleGraph, mod_idx: usize, rec_i: usize) void {
+    pub fn markRecordLazyResolved(self: *ModuleGraph, mod_idx: usize, rec_i: usize) void {
         if (mod_idx >= self.modules.count()) return;
         const m = self.modules.at(mod_idx);
         if (rec_i >= m.import_records.len) return;
@@ -1044,7 +1044,7 @@ pub const ModuleGraph = struct {
     /// context_expansion_deps 를 resolve 하고 graph 에 module + dependency 로 등록 (#1579 Phase 4).
     /// scanModules receiver / resolveModuleImports 양쪽 경로에서 호출. SegmentedList 로
     /// append 해도 기존 *Module 포인터는 유효 (#1779 INVARIANTS.md).
-    fn applyContextDepResults(self: *ModuleGraph, mod_idx: usize) !void {
+    pub fn applyContextDepResults(self: *ModuleGraph, mod_idx: usize) !void {
         const mod_index = ModuleIndex.fromUsize(mod_idx);
         const mod_ptr = self.modules.at(mod_idx);
         const context_deps = mod_ptr.context_expansion_deps;
@@ -1112,7 +1112,7 @@ pub const ModuleGraph = struct {
         }
     }
 
-    fn applyResolveResult(
+    pub fn applyResolveResult(
         self: *ModuleGraph,
         mod_idx: usize,
         rec_i: usize,
@@ -1273,172 +1273,22 @@ pub const ModuleGraph = struct {
         }
     }
 
-    /// resolve 결과를 저장하는 구조체. scanWorker가 기록, 메인 스레드가 적용.
-    const ResolveOutput = struct {
-        resolved: ?plugin_mod.ResolvedModule = null,
-        is_error: bool = false,
-        skipped: bool = false,
-    };
-
-    /// 이벤트 큐 기반 스캔 결과. 워커가 채널로 전송, 메인이 수신.
-    const ScanResult = struct {
-        module_idx: ModuleIndex,
-        resolve_outputs: []ResolveOutput,
-    };
-
-    /// Event-queue scan worker: parse and resolve, then send the result to the channel.
-    /// It does not mutate graph topology, so the main thread remains the sole writer.
-    fn scanWorker(self: *ModuleGraph, idx: ModuleIndex, channel: *MpscChannel(ScanResult)) void {
-        channel.send(self.scanModule(idx));
-    }
-
-    fn scanModuleRangeSequential(self: *ModuleGraph, start: usize, end: usize) !usize {
-        var i = start;
-        while (i < end) : (i += 1) {
-            const m = self.modules.at(i);
-            if (m.state == .ready) continue;
-            const result = self.scanModule(.fromUsize(i));
-            try self.applyScanResult(result);
-        }
-        return end;
-    }
-
-    fn applyScanResult(self: *ModuleGraph, result: ScanResult) !void {
-        var apply_scope = profile.begin(.graph_discover_apply);
-        defer apply_scope.end();
-        defer if (result.resolve_outputs.len > 0) self.allocator.free(result.resolve_outputs);
-
-        const mod_idx = @intFromEnum(result.module_idx);
-        const mod_ptr = self.modules.at(mod_idx);
-        self.applySideEffectsFromPackageJson(mod_ptr);
-        mod_ptr.state = .ready;
-
-        const records = mod_ptr.import_records;
-        const resolves = result.resolve_outputs;
-
-        // SegmentedList (#1779 PR #3) appends do not invalidate existing pointers,
-        // so *Module pointers held by inflight workers remain valid. The old
-        // ArrayList-era drain/realloc path is no longer needed.
-        for (records, 0..) |record, rec_i| {
-            if (rec_i < resolves.len) {
-                if (resolves[rec_i].skipped and !resolves[rec_i].is_error) {
-                    self.markRecordLazyResolved(mod_idx, rec_i);
-                    if (resolves[rec_i].resolved) |resolved| self.discardResolvedModule(resolved);
-                    continue;
-                }
-                try self.applyResolveResult(mod_idx, rec_i, record, resolves[rec_i].resolved, resolves[rec_i].is_error);
-            }
-        }
-        if (self.hasDeferredRequestedImports(mod_idx)) {
-            try self.resolveModuleImports(result.module_idx);
-        }
-        // Register require.context matches as graph dependencies (#1579 Phase 4).
-        try self.applyContextDepResults(mod_idx);
-    }
-
-    fn scanModule(self: *ModuleGraph, idx: ModuleIndex) ScanResult {
-        var scope = profile.begin(.graph_discover_scan_worker);
-        defer scope.end();
-
-        {
-            var parse_scope = profile.begin(.graph_discover_scan_worker_parse);
-            defer parse_scope.end();
-            self.parseModule(idx);
-        }
-
-        const mod_idx = @intFromEnum(idx);
-        if (mod_idx >= self.modules.count()) {
-            return .{ .module_idx = idx, .resolve_outputs = &.{} };
-        }
-
-        const mod_ptr = self.modules.at(mod_idx);
-        self.applySideEffectsFromPackageJson(mod_ptr);
-        if (mod_ptr.import_records.len == 0) {
-            return .{ .module_idx = idx, .resolve_outputs = &.{} };
-        }
-
-        const module_path = mod_ptr.path;
-        const source_dir = std.fs.path.dirname(module_path) orelse ".";
-
-        const plugin_runner: ?plugin_mod.PluginRunner = self.pluginRunnerWithBuiltins();
-
-        // import.meta.glob: 워커에서 glob 확장 수행
-        expandGlobRecords(self.allocator, mod_ptr.import_records, source_dir);
-        // require.context: plugin 으로 matches 주입 + context_expansion_deps 로 수집 (#1579 Phase 4).
-        // import_records 는 건드리지 않으므로 len 변화 없음.
-        expandRequireContextRecords(self, mod_idx);
-
-        const records = mod_ptr.import_records;
-        var results = self.allocator.alloc(ResolveOutput, records.len) catch {
-            self.addDiag(.resolve_error, .@"error", module_path, Span.EMPTY, .resolve, "Out of memory allocating resolve results", null);
-            return .{ .module_idx = idx, .resolve_outputs = &.{} };
-        };
-        for (results) |*r| r.* = .{};
-
-        {
-            var resolve_scope = profile.begin(.graph_discover_scan_worker_resolve);
-            defer resolve_scope.end();
-
-            for (records, 0..) |record, rec_i| {
-                if (record.kind == .glob or record.kind == .require_context) {
-                    results[rec_i].skipped = true;
-                    continue;
-                }
-                if (record.resolved != .none or record.is_external) {
-                    results[rec_i].skipped = true;
-                    continue;
-                }
-                const should_link = self.shouldLinkResolvedRecordForModule(mod_idx, rec_i, record);
-
-                if (plugin_runner) |runner| {
-                    if (self.shouldRunResolveId(record.specifier)) {
-                        var hook_ctx: plugin_mod.HookContext = .{};
-                        const resolve_result = runner.runResolveId(record.specifier, module_path, self.allocator, &hook_ctx) catch |err| switch (err) {
-                            error.PluginFailed => {
-                                self.addPluginFailureDiag(hook_ctx.failure, module_path, record.span, .resolve);
-                                results[rec_i] = .{ .is_error = true, .skipped = !should_link };
-                                continue;
-                            },
-                            error.OutOfMemory => {
-                                self.addDiag(.resolve_error, .@"error", module_path, record.span, .resolve, "Out of memory during resolve", record.specifier);
-                                continue;
-                            },
-                        };
-                        if (resolve_result) |plugin_result| {
-                            results[rec_i] = .{ .resolved = plugin_result, .is_error = false, .skipped = !should_link };
-                            continue;
-                        }
-                    }
-                }
-
-                const resolved = self.resolve_cache.resolveThreadSafe(
-                    source_dir,
-                    record.specifier,
-                    record.kind,
-                ) catch |err| switch (err) {
-                    error.ModuleNotFound => {
-                        results[rec_i] = .{ .is_error = true, .skipped = !should_link };
-                        continue;
-                    },
-                    error.OutOfMemory => {
-                        self.addDiag(.resolve_error, .@"error", module_path, record.span, .resolve, "Out of memory during resolve", record.specifier);
-                        continue;
-                    },
-                };
-                results[rec_i] = .{ .resolved = resolved, .skipped = !should_link };
-            }
-        }
-
-        return .{ .module_idx = idx, .resolve_outputs = results };
-    }
+    // Discovery scan workers — graph/discovery_scan.zig로 위임
+    const graph_discovery_scan = @import("graph/discovery_scan.zig");
+    const ResolveOutput = graph_discovery_scan.ResolveOutput;
+    const ScanResult = graph_discovery_scan.ScanResult;
+    const scanWorker = graph_discovery_scan.scanWorker;
+    const scanModuleRangeSequential = graph_discovery_scan.scanModuleRangeSequential;
+    pub const applyScanResult = graph_discovery_scan.applyScanResult;
+    pub const scanModule = graph_discovery_scan.scanModule;
 
     // Module parsing pipeline — graph/parse_module.zig로 위임
     const graph_parse_module = @import("graph/parse_module.zig");
-    const parseModule = graph_parse_module.parseModule;
+    pub const parseModule = graph_parse_module.parseModule;
 
     /// Phase 1: 모듈의 import들을 resolve하고 의존성 모듈을 등록한다.
     /// modules 배열이 커질 수 있으므로, 포인터가 아닌 인덱스로만 접근.
-    fn resolveModuleImports(self: *ModuleGraph, idx: ModuleIndex) !void {
+    pub fn resolveModuleImports(self: *ModuleGraph, idx: ModuleIndex) !void {
         const mod_idx = @intFromEnum(idx);
         if (mod_idx >= self.modules.count()) return;
 
@@ -1531,7 +1381,7 @@ pub const ModuleGraph = struct {
     // Diagnostics helpers — graph/diagnostics.zig로 위임
     const graph_diagnostics = @import("graph/diagnostics.zig");
     pub const addDiag = graph_diagnostics.addDiag;
-    const addPluginFailureDiag = graph_diagnostics.addPluginFailureDiag;
+    pub const addPluginFailureDiag = graph_diagnostics.addPluginFailureDiag;
     const validatePluginSourceMaps = graph_diagnostics.validatePluginSourceMaps;
 };
 

--- a/src/bundler/graph/discovery_scan.zig
+++ b/src/bundler/graph/discovery_scan.zig
@@ -1,0 +1,174 @@
+//! Event-queue discovery scan workers for ModuleGraph.
+
+const std = @import("std");
+const types = @import("../types.zig");
+const ModuleIndex = types.ModuleIndex;
+const plugin_mod = @import("../plugin.zig");
+const MpscChannel = @import("../mpsc_channel.zig").MpscChannel;
+const profile = @import("../../profile.zig");
+const Span = @import("../../lexer/token.zig").Span;
+const graph_mod = @import("../graph.zig");
+const ModuleGraph = graph_mod.ModuleGraph;
+const graph_glob = @import("glob.zig");
+const expandGlobRecords = graph_glob.expandGlobRecords;
+const graph_require_context = @import("require_context.zig");
+const expandRequireContextRecords = graph_require_context.expandRecords;
+
+/// resolve 결과를 저장하는 구조체. scanWorker가 기록, 메인 스레드가 적용.
+pub const ResolveOutput = struct {
+    resolved: ?plugin_mod.ResolvedModule = null,
+    is_error: bool = false,
+    skipped: bool = false,
+};
+
+/// 이벤트 큐 기반 스캔 결과. 워커가 채널로 전송, 메인이 수신.
+pub const ScanResult = struct {
+    module_idx: ModuleIndex,
+    resolve_outputs: []ResolveOutput,
+};
+
+/// Event-queue scan worker: parse and resolve, then send the result to the channel.
+/// It does not mutate graph topology, so the main thread remains the sole writer.
+pub fn scanWorker(self: *ModuleGraph, idx: ModuleIndex, channel: *MpscChannel(ScanResult)) void {
+    channel.send(self.scanModule(idx));
+}
+
+pub fn scanModuleRangeSequential(self: *ModuleGraph, start: usize, end: usize) !usize {
+    var i = start;
+    while (i < end) : (i += 1) {
+        const m = self.modules.at(i);
+        if (m.state == .ready) continue;
+        const result = self.scanModule(.fromUsize(i));
+        try self.applyScanResult(result);
+    }
+    return end;
+}
+
+pub fn applyScanResult(self: *ModuleGraph, result: ScanResult) !void {
+    var apply_scope = profile.begin(.graph_discover_apply);
+    defer apply_scope.end();
+    defer if (result.resolve_outputs.len > 0) self.allocator.free(result.resolve_outputs);
+
+    const mod_idx = @intFromEnum(result.module_idx);
+    const mod_ptr = self.modules.at(mod_idx);
+    self.applySideEffectsFromPackageJson(mod_ptr);
+    mod_ptr.state = .ready;
+
+    const records = mod_ptr.import_records;
+    const resolves = result.resolve_outputs;
+
+    // SegmentedList (#1779 PR #3) appends do not invalidate existing pointers,
+    // so *Module pointers held by inflight workers remain valid. The old
+    // ArrayList-era drain/realloc path is no longer needed.
+    for (records, 0..) |record, rec_i| {
+        if (rec_i < resolves.len) {
+            if (resolves[rec_i].skipped and !resolves[rec_i].is_error) {
+                self.markRecordLazyResolved(mod_idx, rec_i);
+                if (resolves[rec_i].resolved) |resolved| self.discardResolvedModule(resolved);
+                continue;
+            }
+            try self.applyResolveResult(mod_idx, rec_i, record, resolves[rec_i].resolved, resolves[rec_i].is_error);
+        }
+    }
+    if (self.hasDeferredRequestedImports(mod_idx)) {
+        try self.resolveModuleImports(result.module_idx);
+    }
+    // Register require.context matches as graph dependencies (#1579 Phase 4).
+    try self.applyContextDepResults(mod_idx);
+}
+
+pub fn scanModule(self: *ModuleGraph, idx: ModuleIndex) ScanResult {
+    var scope = profile.begin(.graph_discover_scan_worker);
+    defer scope.end();
+
+    {
+        var parse_scope = profile.begin(.graph_discover_scan_worker_parse);
+        defer parse_scope.end();
+        self.parseModule(idx);
+    }
+
+    const mod_idx = @intFromEnum(idx);
+    if (mod_idx >= self.modules.count()) {
+        return .{ .module_idx = idx, .resolve_outputs = &.{} };
+    }
+
+    const mod_ptr = self.modules.at(mod_idx);
+    self.applySideEffectsFromPackageJson(mod_ptr);
+    if (mod_ptr.import_records.len == 0) {
+        return .{ .module_idx = idx, .resolve_outputs = &.{} };
+    }
+
+    const module_path = mod_ptr.path;
+    const source_dir = std.fs.path.dirname(module_path) orelse ".";
+
+    const plugin_runner: ?plugin_mod.PluginRunner = self.pluginRunnerWithBuiltins();
+
+    // import.meta.glob: 워커에서 glob 확장 수행
+    expandGlobRecords(self.allocator, mod_ptr.import_records, source_dir);
+    // require.context: plugin 으로 matches 주입 + context_expansion_deps 로 수집 (#1579 Phase 4).
+    // import_records 는 건드리지 않으므로 len 변화 없음.
+    expandRequireContextRecords(self, mod_idx);
+
+    const records = mod_ptr.import_records;
+    var results = self.allocator.alloc(ResolveOutput, records.len) catch {
+        self.addDiag(.resolve_error, .@"error", module_path, Span.EMPTY, .resolve, "Out of memory allocating resolve results", null);
+        return .{ .module_idx = idx, .resolve_outputs = &.{} };
+    };
+    for (results) |*r| r.* = .{};
+
+    {
+        var resolve_scope = profile.begin(.graph_discover_scan_worker_resolve);
+        defer resolve_scope.end();
+
+        for (records, 0..) |record, rec_i| {
+            if (record.kind == .glob or record.kind == .require_context) {
+                results[rec_i].skipped = true;
+                continue;
+            }
+            if (record.resolved != .none or record.is_external) {
+                results[rec_i].skipped = true;
+                continue;
+            }
+            const should_link = self.shouldLinkResolvedRecordForModule(mod_idx, rec_i, record);
+
+            if (plugin_runner) |runner| {
+                if (self.shouldRunResolveId(record.specifier)) {
+                    var hook_ctx: plugin_mod.HookContext = .{};
+                    const resolve_result = runner.runResolveId(record.specifier, module_path, self.allocator, &hook_ctx) catch |err| switch (err) {
+                        error.PluginFailed => {
+                            self.addPluginFailureDiag(hook_ctx.failure, module_path, record.span, .resolve);
+                            results[rec_i] = .{ .is_error = true, .skipped = !should_link };
+                            continue;
+                        },
+                        error.OutOfMemory => {
+                            self.addDiag(.resolve_error, .@"error", module_path, record.span, .resolve, "Out of memory during resolve", record.specifier);
+                            continue;
+                        },
+                    };
+                    if (resolve_result) |plugin_result| {
+                        results[rec_i] = .{ .resolved = plugin_result, .is_error = false, .skipped = !should_link };
+                        continue;
+                    }
+                }
+            }
+
+            const resolved = self.resolve_cache.resolveThreadSafe(
+                source_dir,
+                record.specifier,
+                record.kind,
+            ) catch |err| switch (err) {
+                error.ModuleNotFound => {
+                    results[rec_i] = .{ .is_error = true, .skipped = !should_link };
+                    continue;
+                },
+                error.OutOfMemory => {
+                    self.addDiag(.resolve_error, .@"error", module_path, record.span, .resolve, "Out of memory during resolve", record.specifier);
+                    continue;
+                },
+            };
+            results[rec_i] = .{ .resolved = resolved, .skipped = !should_link };
+        }
+    }
+
+    return .{ .module_idx = idx, .resolve_outputs = results };
+}


### PR DESCRIPTION
## 요약
- `graph.zig`에 있던 event queue 기반 discovery scan 워커/적용 로직을 `src/bundler/graph/discovery_scan.zig`로 분리했습니다.
- `graph.zig`는 orchestration과 공유 헬퍼를 유지하고, 새 모듈에서 필요한 helper alias/function만 `pub const`/`pub fn`으로 열었습니다.
- 동작 로직은 바꾸지 않고 파일 경계만 나눴습니다.

## Zig 초보자용 설명
- Zig에서는 `@import("graph/discovery_scan.zig")`로 같은 패키지 안의 다른 파일을 가져올 수 있습니다.
- 다른 파일에서 접근해야 하는 심볼만 `pub const` 또는 `pub fn`으로 공개했습니다.
- 이동한 scan 본문은 기존 코드와 동일하고, 들여쓰기 제거와 `pub` 공개 전환만 들어갔습니다.

## 검증
- `zig fmt --check src/bundler/graph.zig src/bundler/graph/discovery_scan.zig`
- `git diff --check`
- `zig build test`
- `bun test --cwd tests/integration tests/downlevel.test.ts tests/bundle-smoke.test.ts --timeout 10000` (402 pass)
- `zig build`
- `zig build napi`
- `node --test packages/core/napi.test.mjs`
- `bun run lint` (기존 oxlint warning 23개, error 0개)
- `bun run fmt:check`
- `zig build -Doptimize=ReleaseFast`
- `zig build test262`
- pre-push hook 통과

## 추가 확인
- 이동한 discovery scan block은 기존 `HEAD` 본문과 비교했고, unindent 및 `pub` 공개 전환을 제외하면 동일함을 확인했습니다.
