### PR TITLE
fix(main): mtime_map upsert leak in watch loop (#2868)

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -2464,11 +2464,7 @@ pub fn main() !void {
             try mtime_map.put(entry_dupe, entry_mtime);
 
             if (result.module_paths) |paths| {
-                for (paths) |p| {
-                    const duped = allocator.dupe(u8, p) catch continue;
-                    const mt = getFileMtime(p) catch continue;
-                    mtime_map.put(duped, mt) catch continue;
-                }
+                for (paths) |p| upsertMtimePath(allocator, &mtime_map, p);
             }
 
             // --watch-folder: 번들 그래프 밖 루트를 재귀 스캔해 감시 대상에 추가
@@ -2665,17 +2661,9 @@ pub fn main() !void {
                     while (kit.next()) |k| allocator.free(k.*);
                     mtime_map.clearRetainingCapacity();
 
-                    // 엔트리 재추가
-                    const re_entry = allocator.dupe(u8, abs_entry) catch continue;
-                    const re_mtime = getFileMtime(abs_entry) catch 0;
-                    mtime_map.put(re_entry, re_mtime) catch continue;
-
+                    upsertMtimePath(allocator, &mtime_map, abs_entry);
                     if (rebuild_result.module_paths) |paths| {
-                        for (paths) |p| {
-                            const duped = allocator.dupe(u8, p) catch continue;
-                            const mt = getFileMtime(p) catch continue;
-                            mtime_map.put(duped, mt) catch continue;
-                        }
+                        for (paths) |p| upsertMtimePath(allocator, &mtime_map, p);
                     }
                 }
             }
@@ -2930,6 +2918,23 @@ fn writeJsonString(writer: anytype, s: []const u8) !void {
 fn getFileMtime(path: []const u8) !i128 {
     const stat = try std.fs.cwd().statFile(path);
     return stat.mtime;
+}
+
+/// path → mtime upsert. 키 충돌 시 std.HashMap.put 이 기존 키 유지 +
+/// 값만 갱신하는 동작 때문에 무조건 dupe 후 put 하면 두 번째 dupe 가 leak.
+/// getPtr 로 존재 확인 후 새 entry 일 때만 dupe.
+fn upsertMtimePath(
+    allocator: std.mem.Allocator,
+    map: *std.StringHashMap(i128),
+    path: []const u8,
+) void {
+    const mt = getFileMtime(path) catch return;
+    if (map.getPtr(path)) |existing| {
+        existing.* = mt;
+        return;
+    }
+    const duped = allocator.dupe(u8, path) catch return;
+    map.put(duped, mt) catch allocator.free(duped);
 }
 
 /// 디렉토리를 순회하며 .ts/.tsx 파일의 mtime을 수집한다.


### PR DESCRIPTION
## Summary

watch loop 의 `mtime_map` 재구축 시 동일 path 가 충돌하면서 매 rebuild 마다 dupe 1건이 누수되던 문제 fix.

- `mtime_map.put(duped, mt)` 가 키 충돌 (eql) 시 `std.HashMap.put` 은 기존 키 유지 + 값만 갱신 → 두 번째 dupe 가 leak
- `abs_entry` 와 `module_paths` 에 동일 path (entry.ts) 가 양쪽 등장 → rebuild 마다 1건씩 누적

`upsertMtimePath` 헬퍼로 두 호출부 단순화: `getPtr` 로 존재 확인 후 새 entry 일 때만 dupe.

## 진단 과정

debug 빌드는 GPA + leak detection 자동 활성. `ZNTC_WATCH_MAX_REBUILDS` 환경변수 임시 추가해서 10 rebuild 후 정상 종료 → GPA leak report 11건 확인 (첫 빌드 1건 + 매 rebuild 1건). 진단 코드는 commit 에서 제거.

## 측정

`tests/integration/tests/watch-stress.test.ts` (150 rebuild, ReleaseFast):

| | slope | growth | last RSS |
|---|---|---|---|
| before | 8.40 KB/rebuild | 1440 KB | 8880 KB |
| after | **0.15 KB/rebuild** | **48 KB** | 4192 KB (15회 후 고정) |

slope 98% 감소, baseline RSS 도 절반 — leak 메모리가 mimalloc 페이지 단위로 reserve 되어 RSS 증가폭이 leak 자체보다 컸던 것으로 추정.

## Test plan

- [x] watch-stress.test.ts: slope=0.15 << 임계 2.0, growth=48 KB << 임계 2048 KB
- [x] debug 빌드 GPA leak detection: 0 leaks (이전 11건)
- [x] 진단 코드 완전 제거 (`grep LEAK_DIAG`/`diag_` clean)

Closes #2868

🤖 Generated with [Claude Code](https://claude.com/claude-code)