### PR TITLE
fix(rspack-loader): split exports types for import/require

### DIFF
--- a/packages/rspack-loader/package.json
+++ b/packages/rspack-loader/package.json
@@ -9,19 +9,25 @@
     "README.md"
   ],
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "source": "./src/index.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "scripts": {
     "build:bundle": "node ../core/bin/zntc.mjs --bundle src/index.ts --outfile dist/index.js --format=esm --target=node --conditions=source --external @zntc/core && node ../core/bin/zntc.mjs --bundle src/index.ts --outfile dist/index.cjs --format=cjs --target=node --conditions=source --external @zntc/core",
-    "build:dts": "bun x tsc -b",
+    "build:dts": "bun x tsc -b && cp dist/index.d.ts dist/index.d.cts",
     "build": "bun run build:bundle && bun run build:dts",
     "test": "bun test",
     "prepublishOnly": "bun run build && bunx publint --strict --level error ."


### PR DESCRIPTION
## Summary

\`bun scripts/publint-all.ts\` (CI 의 \`test:publint\`) 가 \`@zntc/rspack-loader\` 한 곳에서 error 로 깨지던 문제 fix.

\`\`\`
Errors:
1. pkg.exports[\".\"].types types is interpreted as ESM when resolving with the \"require\" condition. This causes the types to only work when dynamically importing the package, even though the package exports CJS. Consider splitting out two \"types\" conditions for \"import\" and \"require\", and use the .cts extension, e.g. pkg.exports[\".\"].require.types: \"./dist/index.d.cts\"
\`\`\`

## 원인

\`@zntc/rspack-loader\` 는 dual ESM+CJS 패키지 (rspack/webpack 양쪽 호환). 그러나 \`exports[\".\"].types\` 가 단일 \`./dist/index.d.ts\` 였고, 패키지가 \`\"type\": \"module\"\` 이라 require condition 으로 resolve 할 때 type 이 ESM 으로 해석돼 깨짐.

다른 publishable 패키지들 (core / web / wasm / react-native / vite-plugin-zntc / init) 은 ESM-only (\`require\` condition 없음) 라 publint 통과. rspack-loader 만 dual.

## Fix

publint 권장 패턴으로 전환:

\`\`\`json
\"exports\": {
  \".\": {
    \"source\": \"./src/index.ts\",
    \"import\": {
      \"types\": \"./dist/index.d.ts\",
      \"default\": \"./dist/index.js\"
    },
    \"require\": {
      \"types\": \"./dist/index.d.cts\",
      \"default\": \"./dist/index.cjs\"
    }
  }
}
\`\`\`

- \`build:dts\` 에 \`cp dist/index.d.ts dist/index.d.cts\` 추가 — declare 만 있는 type 정의라 .d.ts 와 .d.cts 내용 동일
- legacy \`main\` 을 \`.cjs\` 로 옮기고 \`module\` 필드 추가 (node10 + 구 번들러 호환)

## Test plan

- [x] \`bun scripts/publint-all.ts\` 전체 통과 (이전: rspack-loader 1건 error)
- [x] \`bun run build\` clean build 시 dist/ 에 4개 산출물 (index.js / index.cjs / index.d.ts / index.d.cts) 모두 생성

🤖 Generated with [Claude Code](https://claude.com/claude-code)