### PR TITLE
refactor: codegen dispatch와 transformer lifecycle 분리

### DIFF
--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -12,20 +12,13 @@
 const std = @import("std");
 const ast_mod = @import("../parser/ast.zig");
 const Node = ast_mod.Node;
-const Tag = Node.Tag;
 const NodeIndex = ast_mod.NodeIndex;
-const NodeList = ast_mod.NodeList;
 const Ast = ast_mod.Ast;
-const Span = @import("../lexer/token.zig").Span;
-const Kind = @import("../lexer/token.zig").Kind;
 const Comment = @import("../lexer/scanner.zig").Comment;
 const rt = @import("../bundler/runtime_helpers.zig");
 const options_mod = @import("options.zig");
-const module_emit = @import("modules.zig");
-const type_runtime_emit = @import("type_runtime.zig");
 const writer_emit = @import("writer.zig");
 const debug_metadata = @import("debug_metadata.zig");
-const expression_emit = @import("expressions.zig");
 
 pub const ModuleFormat = options_mod.ModuleFormat;
 pub const Platform = options_mod.Platform;
@@ -37,21 +30,9 @@ pub const CodegenOptions = options_mod.CodegenOptions;
 pub const KeepNameEntry = options_mod.KeepNameEntry;
 
 const SourceMapBuilder = @import("sourcemap.zig").SourceMapBuilder;
-const Mapping = @import("sourcemap.zig").Mapping;
 const FunctionMapBuilder = @import("function_map.zig").FunctionMapBuilder;
-const RangeMapping = @import("function_map.zig").RangeMapping;
 
 pub const Codegen = struct {
-    const emitImport = module_emit.emitImport;
-    const emitExportNamed = module_emit.emitExportNamed;
-    const emitExportSpecifier = module_emit.emitExportSpecifier;
-    const emitExportDefault = module_emit.emitExportDefault;
-    const emitExportAll = module_emit.emitExportAll;
-
-    const emitEnumIIFE = type_runtime_emit.emitEnumIIFE;
-    const emitFlowEnum = type_runtime_emit.emitFlowEnum;
-    const emitNamespaceIIFE = type_runtime_emit.emitNamespaceIIFE;
-
     ast: *const Ast,
     allocator: std.mem.Allocator,
     buf: std.ArrayList(u8),
@@ -292,320 +273,16 @@ pub const Codegen = struct {
     // Statement/comment emission — codegen/statements.zig로 위임
     // ================================================================
     const statement_emit = @import("statements.zig");
-    const emitComments = statement_emit.emitComments;
     const isSkipped = statement_emit.isSkipped;
     pub const evalBooleanCondition = statement_emit.evalBooleanCondition;
-    const emitProgram = statement_emit.emitProgram;
-    const emitBlock = statement_emit.emitBlock;
-    const emitBracedList = statement_emit.emitBracedList;
-    const emitExpressionStatement = statement_emit.emitExpressionStatement;
-    const emitReturn = statement_emit.emitReturn;
-    const emitThrow = statement_emit.emitThrow;
-    const emitIf = statement_emit.emitIf;
-    const emitWhile = statement_emit.emitWhile;
-    const emitDoWhile = statement_emit.emitDoWhile;
-    const emitFor = statement_emit.emitFor;
-    const emitForAwaitOf = statement_emit.emitForAwaitOf;
-    const emitForInOf = statement_emit.emitForInOf;
-    const emitSwitch = statement_emit.emitSwitch;
-    const emitSwitchCase = statement_emit.emitSwitchCase;
-    const emitSimpleStmt = statement_emit.emitSimpleStmt;
-    const emitTry = statement_emit.emitTry;
-    const emitCatch = statement_emit.emitCatch;
-    const emitLabeled = statement_emit.emitLabeled;
-    const emitWith = statement_emit.emitWith;
 
     // ================================================================
     // 노드 출력
     // ================================================================
 
     pub const Error = std.mem.Allocator.Error;
-
-    pub fn emitNode(self: *Codegen, idx: NodeIndex) Error!void {
-        if (idx.isNone()) return;
-
-        // 번들 모드: skip_nodes에 있으면 출력하지 않음 (import/export 제거)
-        if (self.isSkipped(idx)) return;
-
-        const node = self.ast.getNode(idx);
-
-        // 이 노드 이전에 위치한 주석들을 출력.
-        // STRING_TABLE_BIT가 설정된 span은 합성 노드(string_table 참조)이므로
-        // 원본 소스 위치가 아님 → 주석 위치 비교를 건너뛴다.
-        if (node.span.start != node.span.end and node.span.start & Ast.STRING_TABLE_BIT == 0) {
-            try self.emitComments(node.span.start);
-        }
-
-        // 소스맵 매핑: 유의미한 노드 출력 시 원본 위치 기록.
-        // 컨테이너 노드(program, block, function_body)는 자식의 매핑을 오염시키므로 제외.
-        if (self.sm_builder != null and node.span.start != node.span.end) {
-            switch (node.tag) {
-                .program,
-                .block_statement,
-                .function_body,
-                .class_body,
-                .static_block,
-                .switch_statement,
-                .try_statement,
-                => {},
-                else => try self.addSourceMapping(node.span),
-            }
-        }
-
-        switch (node.tag) {
-            .program => try self.emitProgram(node),
-            .block_statement => try self.emitBlock(node),
-            .empty_statement => try self.writeByte(';'),
-            .expression_statement => try self.emitExpressionStatement(node),
-            .variable_declaration => try self.emitVariableDeclaration(node),
-            .variable_declarator => try self.emitVariableDeclarator(node),
-            .return_statement => try self.emitReturn(node),
-            .throw_statement => try self.emitThrow(node),
-            .if_statement => try self.emitIf(node),
-            .while_statement => try self.emitWhile(node),
-            .do_while_statement => try self.emitDoWhile(node),
-            .for_statement => try self.emitFor(node),
-            .for_in_statement => try self.emitForInOf(node, "in"),
-            .for_of_statement => try self.emitForInOf(node, "of"),
-            .for_await_of_statement => try self.emitForAwaitOf(node),
-            .switch_statement => try self.emitSwitch(node),
-            .switch_case => try self.emitSwitchCase(node),
-            .break_statement => try self.emitSimpleStmt(node, "break"),
-            .continue_statement => try self.emitSimpleStmt(node, "continue"),
-            .debugger_statement => try self.write("debugger;"),
-            .try_statement => try self.emitTry(node),
-            .catch_clause => try self.emitCatch(node),
-            .labeled_statement => try self.emitLabeled(node),
-            .with_statement => try self.emitWith(node),
-            .directive => {
-                // span 은 문자열 리터럴 범위 (따옴표 포함). quote_style 정규화를 적용해
-                // `'use server'` → `"use server"` 같은 변환이 일반 string_literal 과 동일하게
-                // 일어나도록 writeStringLiteral 사용. 항상 `;` 를 붙여 ASI 의존을 피한다.
-                try self.writeStringLiteral(node.span);
-                try self.writeByte(';');
-            },
-            .hashbang => {
-                if (!self.options.strip_hashbang) try self.writeNodeSpan(node);
-            },
-
-            // Literals
-            .boolean_literal => {
-                // Peephole: true → !0, false → !1 (minify_syntax 활성화 시).
-                // #1552: 각 리터럴당 2-3 byte 절감. 출현 빈도 높아 총 크기 영향 있음.
-                // span의 첫 byte는 `t` 또는 `f`로 고정(렉서 불변식) — 한 byte 검사로 판별.
-                if (self.options.minify_syntax) {
-                    const text = self.ast.getText(node.span);
-                    try self.write(if (text.len > 0 and text[0] == 't') "!0" else "!1");
-                } else {
-                    try self.writeNodeSpan(node);
-                }
-            },
-            .null_literal,
-            .numeric_literal,
-            .bigint_literal,
-            .regexp_literal,
-            => try self.writeNodeSpan(node),
-
-            .string_literal => try self.writeStringLiteral(node.span),
-
-            // Identifiers — 번들 모드에서 symbol_id 기반 리네임 적용
-            .identifier_reference,
-            .private_identifier,
-            .binding_identifier,
-            .assignment_target_identifier,
-            => {
-                // Peephole: global `undefined` → `(void 0)` (minify_syntax 활성화 시).
-                // 9 bytes → 8 bytes, 1 byte 절감. parens는 member/call/new 등 모든 parent
-                // context에서 안전하게 해석되도록 유지 — `undefined.x`/`undefined()` 같은
-                // 경로를 간단한 치환으로 깨지 않기 위함 (`void 0.x`는 `void (0.x)`로 오파싱).
-                // global binding일 때만 치환 (shadow rebind 드물지만 보호).
-                if (self.options.minify_syntax and node.tag == .identifier_reference) {
-                    const text = self.ast.getText(node.span);
-                    if (std.mem.eql(u8, text, "undefined")) {
-                        const is_global = if (self.options.linking_metadata) |meta|
-                            self.resolveSymbolId(idx, meta) == null
-                        else
-                            true;
-                        if (is_global) {
-                            try self.write("(void 0)");
-                            return;
-                        }
-                    }
-                }
-
-                if (self.options.linking_metadata) |meta| {
-                    const sym_id = self.resolveSymbolId(idx, meta);
-                    if (sym_id) |sid| {
-                        // 상수 인라인: import symbol이 상수이면 리터럴로 대체
-                        if (node.tag == .identifier_reference) {
-                            if (meta.const_values.get(sid)) |cv| {
-                                try self.writeConstValue(cv);
-                                return;
-                            }
-                        }
-                        // namespace 변수 참조: ns를 값으로 사용 → 변수명으로 치환
-                        if (meta.ns_inline_objects.get(sid)) |entry| {
-                            try self.write(entry.var_name);
-                            return;
-                        }
-                        if (meta.renames.get(sid)) |new_name| {
-                            try self.write(new_name);
-                            return;
-                        }
-                    }
-                }
-                // namespace IIFE 내부: export된 변수의 "참조"를 ns.name으로 치환.
-                // identifier_reference(값 참조)와 assignment_target_identifier(대입 대상) 모두 치환.
-                // binding_identifier(선언 위치)는 치환하지 않음 — 선언은 emitNamespaceVarDirectAssign에서 처리.
-                if (self.ns_prefix) |prefix| {
-                    if (node.tag == .identifier_reference or node.tag == .assignment_target_identifier) {
-                        const name = self.ast.getText(node.data.string_ref);
-                        if (self.ns_exports) |exports| {
-                            if (exports.contains(name)) {
-                                try self.write(prefix);
-                                try self.writeByte('.');
-                                try self.write(name);
-                                return;
-                            }
-                        }
-                    }
-                }
-                try self.writeSpan(node.data.string_ref);
-            },
-
-            .this_expression => try self.write("this"),
-            .super_expression => try self.write("super"),
-
-            // Expressions
-            .unary_expression => try self.emitUnary(node),
-            .update_expression => try self.emitUpdate(node),
-            .binary_expression, .logical_expression => try self.emitBinary(node),
-            .assignment_expression => try self.emitAssignment(node),
-            .conditional_expression => try self.emitConditional(node),
-            .sequence_expression => try self.emitSequence(node),
-            .parenthesized_expression => try self.emitParen(node),
-            .spread_element => try self.emitSpread(node),
-            .await_expression => try self.emitAwait(node),
-            .yield_expression => try self.emitYield(node),
-            .array_expression => try self.emitArray(node),
-            .object_expression => try self.emitObject(node),
-            .object_property => try self.emitObjectProperty(node),
-            .computed_property_key => try self.emitComputedKey(node),
-            .static_member_expression => try self.emitStaticMember(node),
-            .computed_member_expression => try self.emitComputedMember(node),
-            .private_field_expression => try self.emitStaticMember(node),
-            .call_expression => try self.emitCall(node),
-            .new_expression => try self.emitNew(node),
-            .template_literal => try self.emitTemplateLiteral(node),
-            .template_element => try self.writeNodeSpan(node),
-            .tagged_template_expression => try self.emitTaggedTemplate(node),
-            .import_expression => try self.emitImportExpr(node),
-            .meta_property => try self.emitMetaProperty(node),
-            .chain_expression => try self.emitNode(node.data.unary.operand),
-
-            // Functions / Classes
-            .function_declaration, .function_expression, .function => try self.emitFunction(node),
-            .arrow_function_expression => try self.emitArrow(node),
-            .class_declaration, .class_expression => try self.emitClass(node),
-            .class_body => try self.emitClassBody(node),
-            .method_definition => try self.emitMethodDef(node),
-            .property_definition => try self.emitPropertyDef(node),
-            .static_block => try self.emitStaticBlock(node),
-            .decorator => try self.emitDecorator(node),
-            .accessor_property => try self.emitAccessorProp(node),
-
-            // Patterns
-            .array_pattern, .array_assignment_target => try self.emitArray(node),
-            .object_pattern, .object_assignment_target => try self.emitObject(node),
-            .assignment_pattern => try self.emitAssignmentPattern(node),
-            .binding_property => try self.emitBindingProperty(node),
-            .rest_element, .binding_rest_element, .assignment_target_rest => try self.emitRest(node),
-            .assignment_target_with_default => try self.emitAssignmentPattern(node),
-            .assignment_target_property_identifier,
-            .assignment_target_property_property,
-            => try self.emitBindingProperty(node),
-            .elision => {},
-
-            // Import/Export
-            .import_declaration => try self.emitImport(node),
-            .import_specifier,
-            .import_default_specifier,
-            .import_namespace_specifier,
-            .import_attribute,
-            => try self.writeNodeSpan(node),
-            .export_named_declaration => try self.emitExportNamed(node),
-            .export_default_declaration => try self.emitExportDefault(node),
-            .export_all_declaration => try self.emitExportAll(node),
-            .export_specifier => try self.emitExportSpecifier(node),
-
-            // Formal parameters
-            .formal_parameters, .function_body => try self.emitList(node, self.listSep()),
-
-            .formal_parameter => try self.emitFormalParam(node),
-
-            // Flow match expression — transformer에서 if-else IIFE로 변환됨
-            // 변환되지 않은 경우 (non-bundle 등) span 텍스트 그대로 출력
-            .flow_match_expression => try self.writeNodeSpan(node),
-
-            // JSX: Transformer의 jsx_lowering이 call_expression으로 변환 완료.
-            // codegen은 JSX AST 노드를 만나지 않아야 함.
-            .jsx_element,
-            .jsx_fragment,
-            .jsx_expression_container,
-            .jsx_text,
-            .jsx_spread_attribute,
-            .jsx_spread_child,
-            => unreachable,
-
-            // TS enum/namespace → IIFE 출력
-            .ts_enum_declaration => try self.emitEnumIIFE(node),
-            .ts_module_declaration => try self.emitNamespaceIIFE(node),
-            // Flow enum (#2401) → `const Name = Object.freeze({...})` 출력. members 의
-            // init expression 이 없으면 base_type 에 따라 default value (string/number/...).
-            .flow_enum_declaration => try self.emitFlowEnum(node),
-
-            // TS/Flow expression 노드: operand만 출력 (type 부분 스트리핑).
-            // pre-visit body를 codegen할 때 (e.g. worklet __initData.code) TS/Flow 노드가 남아있을 수 있음.
-            .ts_as_expression,
-            .ts_satisfies_expression,
-            .ts_non_null_expression,
-            .ts_type_assertion,
-            .ts_instantiation_expression,
-            .flow_as_expression,
-            .flow_type_cast_expression,
-            => try self.emitNode(node.data.unary.operand),
-
-            // TS 타입 전용 노드: 출력 안 함
-            .ts_type_alias_declaration,
-            .ts_interface_declaration,
-            .ts_import_equals_declaration,
-            => {},
-
-            // 그 외 — 소스 텍스트 그대로 출력
-            else => try self.writeNodeSpan(node),
-        }
-    }
-
-    // ================================================================
-    // Expression 출력
-    // ================================================================
-
-    const emitUnary = expression_emit.emitUnary;
-    const emitUpdate = expression_emit.emitUpdate;
-    const emitBinary = expression_emit.emitBinary;
-    const emitAssignment = expression_emit.emitAssignment;
-    const emitConditional = expression_emit.emitConditional;
-    const emitSequence = expression_emit.emitSequence;
-    const emitParen = expression_emit.emitParen;
-    const emitSpread = expression_emit.emitSpread;
-    const emitAwait = expression_emit.emitAwait;
-    const emitYield = expression_emit.emitYield;
-    const emitArray = expression_emit.emitArray;
-    const emitObject = expression_emit.emitObject;
-    const emitObjectProperty = expression_emit.emitObjectProperty;
-    const emitComputedKey = expression_emit.emitComputedKey;
-    const emitStaticMember = expression_emit.emitStaticMember;
-    const emitComputedMember = expression_emit.emitComputedMember;
+    const node_dispatch_emit = @import("node_dispatch.zig");
+    pub const emitNode = node_dispatch_emit.emitNode;
 
     /// identifier 노드의 symbol_id를 해결.
     /// symbol_ids[node_i]에서 직접 조회 (트랜스포머의 propagateSymbolId로 전파된 값).
@@ -641,42 +318,11 @@ pub const Codegen = struct {
     // Call/new/import.meta/require emission — codegen/calls.zig로 위임
     // ================================================================
     const call_emit = @import("calls.zig");
-    const emitCall = call_emit.emitCall;
-    const emitNew = call_emit.emitNew;
-    const emitMetaProperty = call_emit.emitMetaProperty;
-    const emitImportExpr = call_emit.emitImportExpr;
     pub const resolveImportMetaProp = call_emit.resolveImportMetaProp;
     pub const writeImportMetaUrl = call_emit.writeImportMetaUrl;
     pub const resolveRequireRewriteSpecifier = call_emit.resolveRequireRewriteSpecifier;
     pub const emitRewriteValue = call_emit.emitRewriteValue;
     pub const emitRequireRewriteOrCall = call_emit.emitRequireRewriteOrCall;
-
-    // ================================================================
-    // Template / Function / Class emission — codegen/function_class.zig로 위임
-    // ================================================================
-    const function_class_emit = @import("function_class.zig");
-    const emitTemplateLiteral = function_class_emit.emitTemplateLiteral;
-    const emitTaggedTemplate = function_class_emit.emitTaggedTemplate;
-    const emitFunction = function_class_emit.emitFunction;
-    const emitArrow = function_class_emit.emitArrow;
-    const emitClass = function_class_emit.emitClass;
-    const emitClassBody = function_class_emit.emitClassBody;
-    const emitStaticBlock = function_class_emit.emitStaticBlock;
-    const emitMethodDef = function_class_emit.emitMethodDef;
-    const emitPropertyDef = function_class_emit.emitPropertyDef;
-    const emitDecorator = function_class_emit.emitDecorator;
-    const emitAccessorProp = function_class_emit.emitAccessorProp;
-
-    // ================================================================
-    // Pattern/declaration emission — codegen/bindings.zig로 위임
-    // ================================================================
-    const binding_emit = @import("bindings.zig");
-    const emitAssignmentPattern = binding_emit.emitAssignmentPattern;
-    const emitBindingProperty = binding_emit.emitBindingProperty;
-    const emitRest = binding_emit.emitRest;
-    const emitVariableDeclaration = binding_emit.emitVariableDeclaration;
-    const emitVariableDeclarator = binding_emit.emitVariableDeclarator;
-    const emitFormalParam = binding_emit.emitFormalParam;
 
     // JSX 출력 함수 제거: Transformer의 jsx_lowering이 JSX → call_expression 변환을 담당.
     // emitJSXElement, emitJSXFragment, emitJSXTagName, emitJSXAttrsClassic,

--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -1,0 +1,280 @@
+//! Main AST node dispatch for Codegen.
+
+const std = @import("std");
+const ast_mod = @import("../parser/ast.zig");
+const Ast = ast_mod.Ast;
+const NodeIndex = ast_mod.NodeIndex;
+const statement_emit = @import("statements.zig");
+const module_emit = @import("modules.zig");
+const type_runtime_emit = @import("type_runtime.zig");
+const expression_emit = @import("expressions.zig");
+const call_emit = @import("calls.zig");
+const function_class_emit = @import("function_class.zig");
+const binding_emit = @import("bindings.zig");
+
+const Error = std.mem.Allocator.Error;
+
+pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
+    if (idx.isNone()) return;
+
+    // 번들 모드: skip_nodes에 있으면 출력하지 않음 (import/export 제거)
+    if (statement_emit.isSkipped(self, idx)) return;
+
+    const node = self.ast.getNode(idx);
+
+    // 이 노드 이전에 위치한 주석들을 출력.
+    // STRING_TABLE_BIT가 설정된 span은 합성 노드(string_table 참조)이므로
+    // 원본 소스 위치가 아님 → 주석 위치 비교를 건너뛴다.
+    if (node.span.start != node.span.end and node.span.start & Ast.STRING_TABLE_BIT == 0) {
+        try statement_emit.emitComments(self, node.span.start);
+    }
+
+    // 소스맵 매핑: 유의미한 노드 출력 시 원본 위치 기록.
+    // 컨테이너 노드(program, block, function_body)는 자식의 매핑을 오염시키므로 제외.
+    if (self.sm_builder != null and node.span.start != node.span.end) {
+        switch (node.tag) {
+            .program,
+            .block_statement,
+            .function_body,
+            .class_body,
+            .static_block,
+            .switch_statement,
+            .try_statement,
+            => {},
+            else => try self.addSourceMapping(node.span),
+        }
+    }
+
+    switch (node.tag) {
+        .program => try statement_emit.emitProgram(self, node),
+        .block_statement => try statement_emit.emitBlock(self, node),
+        .empty_statement => try self.writeByte(';'),
+        .expression_statement => try statement_emit.emitExpressionStatement(self, node),
+        .variable_declaration => try binding_emit.emitVariableDeclaration(self, node),
+        .variable_declarator => try binding_emit.emitVariableDeclarator(self, node),
+        .return_statement => try statement_emit.emitReturn(self, node),
+        .throw_statement => try statement_emit.emitThrow(self, node),
+        .if_statement => try statement_emit.emitIf(self, node),
+        .while_statement => try statement_emit.emitWhile(self, node),
+        .do_while_statement => try statement_emit.emitDoWhile(self, node),
+        .for_statement => try statement_emit.emitFor(self, node),
+        .for_in_statement => try statement_emit.emitForInOf(self, node, "in"),
+        .for_of_statement => try statement_emit.emitForInOf(self, node, "of"),
+        .for_await_of_statement => try statement_emit.emitForAwaitOf(self, node),
+        .switch_statement => try statement_emit.emitSwitch(self, node),
+        .switch_case => try statement_emit.emitSwitchCase(self, node),
+        .break_statement => try statement_emit.emitSimpleStmt(self, node, "break"),
+        .continue_statement => try statement_emit.emitSimpleStmt(self, node, "continue"),
+        .debugger_statement => try self.write("debugger;"),
+        .try_statement => try statement_emit.emitTry(self, node),
+        .catch_clause => try statement_emit.emitCatch(self, node),
+        .labeled_statement => try statement_emit.emitLabeled(self, node),
+        .with_statement => try statement_emit.emitWith(self, node),
+        .directive => {
+            // span 은 문자열 리터럴 범위 (따옴표 포함). quote_style 정규화를 적용해
+            // `'use server'` → `"use server"` 같은 변환이 일반 string_literal 과 동일하게
+            // 일어나도록 writeStringLiteral 사용. 항상 `;` 를 붙여 ASI 의존을 피한다.
+            try self.writeStringLiteral(node.span);
+            try self.writeByte(';');
+        },
+        .hashbang => {
+            if (!self.options.strip_hashbang) try self.writeNodeSpan(node);
+        },
+
+        // Literals
+        .boolean_literal => {
+            // Peephole: true → !0, false → !1 (minify_syntax 활성화 시).
+            // #1552: 각 리터럴당 2-3 byte 절감. 출현 빈도 높아 총 크기 영향 있음.
+            // span의 첫 byte는 `t` 또는 `f`로 고정(렉서 불변식) — 한 byte 검사로 판별.
+            if (self.options.minify_syntax) {
+                const text = self.ast.getText(node.span);
+                try self.write(if (text.len > 0 and text[0] == 't') "!0" else "!1");
+            } else {
+                try self.writeNodeSpan(node);
+            }
+        },
+        .null_literal,
+        .numeric_literal,
+        .bigint_literal,
+        .regexp_literal,
+        => try self.writeNodeSpan(node),
+
+        .string_literal => try self.writeStringLiteral(node.span),
+
+        // Identifiers — 번들 모드에서 symbol_id 기반 리네임 적용
+        .identifier_reference,
+        .private_identifier,
+        .binding_identifier,
+        .assignment_target_identifier,
+        => {
+            // Peephole: global `undefined` → `(void 0)` (minify_syntax 활성화 시).
+            // 9 bytes → 8 bytes, 1 byte 절감. parens는 member/call/new 등 모든 parent
+            // context에서 안전하게 해석되도록 유지 — `undefined.x`/`undefined()` 같은
+            // 경로를 간단한 치환으로 깨지 않기 위함 (`void 0.x`는 `void (0.x)`로 오파싱).
+            // global binding일 때만 치환 (shadow rebind 드물지만 보호).
+            if (self.options.minify_syntax and node.tag == .identifier_reference) {
+                const text = self.ast.getText(node.span);
+                if (std.mem.eql(u8, text, "undefined")) {
+                    const is_global = if (self.options.linking_metadata) |meta|
+                        self.resolveSymbolId(idx, meta) == null
+                    else
+                        true;
+                    if (is_global) {
+                        try self.write("(void 0)");
+                        return;
+                    }
+                }
+            }
+
+            if (self.options.linking_metadata) |meta| {
+                const sym_id = self.resolveSymbolId(idx, meta);
+                if (sym_id) |sid| {
+                    // 상수 인라인: import symbol이 상수이면 리터럴로 대체
+                    if (node.tag == .identifier_reference) {
+                        if (meta.const_values.get(sid)) |cv| {
+                            try self.writeConstValue(cv);
+                            return;
+                        }
+                    }
+                    // namespace 변수 참조: ns를 값으로 사용 → 변수명으로 치환
+                    if (meta.ns_inline_objects.get(sid)) |entry| {
+                        try self.write(entry.var_name);
+                        return;
+                    }
+                    if (meta.renames.get(sid)) |new_name| {
+                        try self.write(new_name);
+                        return;
+                    }
+                }
+            }
+            // namespace IIFE 내부: export된 변수의 "참조"를 ns.name으로 치환.
+            // identifier_reference(값 참조)와 assignment_target_identifier(대입 대상) 모두 치환.
+            // binding_identifier(선언 위치)는 치환하지 않음 — 선언은 emitNamespaceVarDirectAssign에서 처리.
+            if (self.ns_prefix) |prefix| {
+                if (node.tag == .identifier_reference or node.tag == .assignment_target_identifier) {
+                    const name = self.ast.getText(node.data.string_ref);
+                    if (self.ns_exports) |exports| {
+                        if (exports.contains(name)) {
+                            try self.write(prefix);
+                            try self.writeByte('.');
+                            try self.write(name);
+                            return;
+                        }
+                    }
+                }
+            }
+            try self.writeSpan(node.data.string_ref);
+        },
+
+        .this_expression => try self.write("this"),
+        .super_expression => try self.write("super"),
+
+        // Expressions
+        .unary_expression => try expression_emit.emitUnary(self, node),
+        .update_expression => try expression_emit.emitUpdate(self, node),
+        .binary_expression, .logical_expression => try expression_emit.emitBinary(self, node),
+        .assignment_expression => try expression_emit.emitAssignment(self, node),
+        .conditional_expression => try expression_emit.emitConditional(self, node),
+        .sequence_expression => try expression_emit.emitSequence(self, node),
+        .parenthesized_expression => try expression_emit.emitParen(self, node),
+        .spread_element => try expression_emit.emitSpread(self, node),
+        .await_expression => try expression_emit.emitAwait(self, node),
+        .yield_expression => try expression_emit.emitYield(self, node),
+        .array_expression => try expression_emit.emitArray(self, node),
+        .object_expression => try expression_emit.emitObject(self, node),
+        .object_property => try expression_emit.emitObjectProperty(self, node),
+        .computed_property_key => try expression_emit.emitComputedKey(self, node),
+        .static_member_expression => try expression_emit.emitStaticMember(self, node),
+        .computed_member_expression => try expression_emit.emitComputedMember(self, node),
+        .private_field_expression => try expression_emit.emitStaticMember(self, node),
+        .call_expression => try call_emit.emitCall(self, node),
+        .new_expression => try call_emit.emitNew(self, node),
+        .template_literal => try function_class_emit.emitTemplateLiteral(self, node),
+        .template_element => try self.writeNodeSpan(node),
+        .tagged_template_expression => try function_class_emit.emitTaggedTemplate(self, node),
+        .import_expression => try call_emit.emitImportExpr(self, node),
+        .meta_property => try call_emit.emitMetaProperty(self, node),
+        .chain_expression => try self.emitNode(node.data.unary.operand),
+
+        // Functions / Classes
+        .function_declaration, .function_expression, .function => try function_class_emit.emitFunction(self, node),
+        .arrow_function_expression => try function_class_emit.emitArrow(self, node),
+        .class_declaration, .class_expression => try function_class_emit.emitClass(self, node),
+        .class_body => try function_class_emit.emitClassBody(self, node),
+        .method_definition => try function_class_emit.emitMethodDef(self, node),
+        .property_definition => try function_class_emit.emitPropertyDef(self, node),
+        .static_block => try function_class_emit.emitStaticBlock(self, node),
+        .decorator => try function_class_emit.emitDecorator(self, node),
+        .accessor_property => try function_class_emit.emitAccessorProp(self, node),
+
+        // Patterns
+        .array_pattern, .array_assignment_target => try expression_emit.emitArray(self, node),
+        .object_pattern, .object_assignment_target => try expression_emit.emitObject(self, node),
+        .assignment_pattern => try binding_emit.emitAssignmentPattern(self, node),
+        .binding_property => try binding_emit.emitBindingProperty(self, node),
+        .rest_element, .binding_rest_element, .assignment_target_rest => try binding_emit.emitRest(self, node),
+        .assignment_target_with_default => try binding_emit.emitAssignmentPattern(self, node),
+        .assignment_target_property_identifier,
+        .assignment_target_property_property,
+        => try binding_emit.emitBindingProperty(self, node),
+        .elision => {},
+
+        // Import/Export
+        .import_declaration => try module_emit.emitImport(self, node),
+        .import_specifier,
+        .import_default_specifier,
+        .import_namespace_specifier,
+        .import_attribute,
+        => try self.writeNodeSpan(node),
+        .export_named_declaration => try module_emit.emitExportNamed(self, node),
+        .export_default_declaration => try module_emit.emitExportDefault(self, node),
+        .export_all_declaration => try module_emit.emitExportAll(self, node),
+        .export_specifier => try module_emit.emitExportSpecifier(self, node),
+
+        // Formal parameters
+        .formal_parameters, .function_body => try self.emitList(node, self.listSep()),
+
+        .formal_parameter => try binding_emit.emitFormalParam(self, node),
+
+        // Flow match expression — transformer에서 if-else IIFE로 변환됨
+        // 변환되지 않은 경우 (non-bundle 등) span 텍스트 그대로 출력
+        .flow_match_expression => try self.writeNodeSpan(node),
+
+        // JSX: Transformer의 jsx_lowering이 call_expression으로 변환 완료.
+        // codegen은 JSX AST 노드를 만나지 않아야 함.
+        .jsx_element,
+        .jsx_fragment,
+        .jsx_expression_container,
+        .jsx_text,
+        .jsx_spread_attribute,
+        .jsx_spread_child,
+        => unreachable,
+
+        // TS enum/namespace → IIFE 출력
+        .ts_enum_declaration => try type_runtime_emit.emitEnumIIFE(self, node),
+        .ts_module_declaration => try type_runtime_emit.emitNamespaceIIFE(self, node),
+        // Flow enum (#2401) → `const Name = Object.freeze({...})` 출력. members 의
+        // init expression 이 없으면 base_type 에 따라 default value (string/number/...).
+        .flow_enum_declaration => try type_runtime_emit.emitFlowEnum(self, node),
+
+        // TS/Flow expression 노드: operand만 출력 (type 부분 스트리핑).
+        // pre-visit body를 codegen할 때 (e.g. worklet __initData.code) TS/Flow 노드가 남아있을 수 있음.
+        .ts_as_expression,
+        .ts_satisfies_expression,
+        .ts_non_null_expression,
+        .ts_type_assertion,
+        .ts_instantiation_expression,
+        .flow_as_expression,
+        .flow_type_cast_expression,
+        => try self.emitNode(node.data.unary.operand),
+
+        // TS 타입 전용 노드: 출력 안 함
+        .ts_type_alias_declaration,
+        .ts_interface_declaration,
+        .ts_import_equals_declaration,
+        => {},
+
+        // 그 외 — 소스 텍스트 그대로 출력
+        else => try self.writeNodeSpan(node),
+    }
+}

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -245,14 +245,13 @@ pub const Transformer = struct {
     pub const ConstEnumDecl = state_mod.ConstEnumDecl;
     pub const PrivateFieldMapping = state_mod.PrivateFieldMapping;
     pub const PrivateMethodMapping = state_mod.PrivateMethodMapping;
+    pub const AstOwnership = state_mod.AstOwnership;
 
     // RefreshRegistration / RefreshSignature 타입 정의는 plugin_state.zig로 이사.
     // 외부 모듈 (refresh.zig 등)에서 `Transformer.RefreshRegistration`로 접근 가능하도록 alias 제공.
     pub const RefreshRegistration = plugin_state.RefreshRegistration;
     pub const RefreshSignature = plugin_state.RefreshSignature;
 
-    /// 파서 AST 를 transformer 가 별도 cell 에 복제 후 transform — 원본 보존 모드.
-    /// 일반적인 single-shot transpile / emit 단계의 first-time transform 진입점.
     /// super 참조가 Parent.prototype.* / Parent.* 호출 형태로 lowering 되어야 하는지 판정.
     /// - `unsupported.class`: ES2015 미만 타겟이라 class 자체가 lowering 됨
     /// - `current_super_is_static`: target 이 class 를 지원해도 static field init/static block 은
@@ -269,127 +268,15 @@ pub const Transformer = struct {
         return (self.options.unsupported.class or self.options.unsupported.class_private_field) and self.current_private_fields.len > 0;
     }
 
-    pub fn init(allocator: std.mem.Allocator, source_ast: *const Ast, options: TransformOptions) Error!Transformer {
-        var opts = options;
-        if (opts.experimental_decorators) opts.use_define_for_class_fields = false;
-
-        const ast_ptr = try allocator.create(Ast);
-        errdefer allocator.destroy(ast_ptr);
-        ast_ptr.* = try Ast.cloneForTransformer(source_ast, allocator);
-        // D1 (RFC #1672): parser/transformer 영역 경계 스냅샷.
-        ast_ptr.transform_boundary = @intCast(ast_ptr.nodes.items.len);
-
-        return finishInit(allocator, ast_ptr, opts, .owned);
-    }
-
-    /// 이미 transform 된 ast 를 borrow — `cloneForTransformer` skip (#1961 PR 1d).
-    /// graph parse 단계의 transformer pre-pass 가 in-place 로 transform 한 ast 를
-    /// emit 단계 transformer 가 그대로 사용. transform() 은 `ast.transformed_root`
-    /// cache hit 분기로 즉시 cached root 반환 → 수백 KB AST 의 전량 memcpy 회피.
-    /// `ast` 는 caller 가 owner — transformer.deinit 은 ast 를 건드리지 않는다.
-    /// `*const Ast` 받음 — transform() cache hit 분기는 ast mutation 없음. 단, ast 필드는
-    /// `*Ast` 라 내부적으로 `@constCast` (caller 가 mut 의도면 별도 borrow 함수 미래에).
-    pub fn initBorrow(allocator: std.mem.Allocator, ast: *const Ast, options: TransformOptions) Error!Transformer {
-        var opts = options;
-        if (opts.experimental_decorators) opts.use_define_for_class_fields = false;
-        return finishInit(allocator, @constCast(ast), opts, .borrowed);
-    }
-
-    const AstOwnership = state_mod.AstOwnership;
-
-    fn finishInit(
-        allocator: std.mem.Allocator,
-        ast_ptr: *Ast,
-        opts: TransformOptions,
-        ownership: AstOwnership,
-    ) Error!Transformer {
-        const parser_count: u32 = switch (ownership) {
-            .owned => @intCast(ast_ptr.nodes.items.len),
-            .borrowed => ast_ptr.transform_boundary orelse @intCast(ast_ptr.nodes.items.len),
-        };
-        var self: Transformer = .{
-            .ast = ast_ptr,
-            .parser_node_count = parser_count,
-            .options = opts,
-            .allocator = allocator,
-            .scratch = .empty,
-            .pending_nodes = .empty,
-            .ast_ownership = ownership,
-        };
-        if (opts.unsupported.arrow) self.runtime_es5_compat = true;
-        return self;
-    }
-
-    pub fn deinit(self: *Transformer) void {
-        // borrow 모드는 외부 owner (보통 module.parse_arena) 가 ast 를 free.
-        if (self.ast_ownership == .owned) {
-            self.ast.deinit();
-            self.allocator.destroy(self.ast);
-        }
-        self.deinitExceptAst();
-    }
-
-    /// AST를 제외한 모든 리소스를 해제한다.
-    /// 테스트에서 AST를 별도로 관리할 때 사용. `.ast` 는 `*Ast` 이므로 호출자가
-    /// `ast.deinit()` + `allocator.destroy(ast)` 둘 다 책임.
-    pub fn deinitExceptAst(self: *Transformer) void {
-        self.scratch.deinit(self.allocator);
-        self.pending_nodes.deinit(self.allocator);
-        self.symbol_ids.deinit(self.allocator);
-        self.helper_ref_nodes.deinit(self.allocator);
-        self.plugins.refresh.registrations.deinit(self.allocator);
-        for (self.plugins.refresh.signatures.items) |s| self.allocator.free(s.signature);
-        self.plugins.refresh.signatures.deinit(self.allocator);
-        self.plugins.emotion.scope_stack.deinit(self.allocator);
-        if (self.plugins.emotion.newline_offsets) |*list| list.deinit(self.allocator);
-        self.plugins.styled_components.css_prop_pending_decls.deinit(self.allocator);
-        // collision 발생 시 mangled name 은 heap-owned. owned flag 로 free 판정 (Zig 의
-        // string-literal pooling 이 implementation-defined 이라 ptr 비교 fragile).
-        const sc = &self.plugins.styled_components;
-        if (sc.css_prop_inject_name_owned) self.allocator.free(sc.css_prop_inject_name);
-        self.trailing_nodes.deinit(self.allocator);
-        self.generator_label_stack.deinit(self.allocator);
-        self.generator_temp_var_spans.deinit(self.allocator);
-        self.tagged_template_fns.deinit(self.allocator);
-        for (self.block_rename_stack.items) |entry| self.allocator.free(entry.new_name);
-        self.block_rename_stack.deinit(self.allocator);
-        self.scope_var_names.deinit(self.allocator);
-        for (self.const_enums.items) |decl| {
-            self.allocator.free(decl.name);
-            for (decl.members) |m| {
-                self.allocator.free(m.name);
-                if (m.value == .string) self.allocator.free(m.value.string);
-            }
-            self.allocator.free(decl.members);
-        }
-        self.const_enums.deinit(self.allocator);
-        {
-            var it = self.regex_var_map.iterator();
-            while (it.next()) |entry| self.allocator.free(entry.value_ptr.*);
-            self.regex_var_map.deinit(self.allocator);
-        }
-    }
-
-    /// semantic analyzer의 symbol_ids를 통합 배열로 복사한다.
-    /// 파서 노드 영역(0..parser_node_count-1)에 symbol_id를 채운다.
-    pub fn initSymbolIds(self: *Transformer, analyzer_symbol_ids: []const ?u32) Error!void {
-        try self.symbol_ids.appendSlice(self.allocator, analyzer_symbol_ids);
-    }
-
-    /// #2869 helper marker 등록. caller 는 새로 만든 NodeIndex 를 넘긴다.
-    pub fn markRuntimeHelperRef(self: *Transformer, idx: NodeIndex) Error!void {
-        try self.helper_ref_nodes.append(self.allocator, @intFromEnum(idx));
-    }
-
-    /// #2869 marker 를 caller 소유 sorted slice 로 transfer. resync analyzer 가
-    /// binary search 로 사용. `alloc` 은 cache lifetime (parse_arena) 의 allocator.
-    pub fn ownedHelperRefNodes(self: *Transformer, alloc: std.mem.Allocator) Error![]u32 {
-        const items = self.helper_ref_nodes.items;
-        if (items.len == 0) return &.{};
-        const out = try alloc.dupe(u32, items);
-        std.mem.sort(u32, out, {}, std.sort.asc(u32));
-        return out;
-    }
+    // Construction/teardown — transformer/lifecycle.zig로 위임
+    const lifecycle_mod = @import("transformer/lifecycle.zig");
+    pub const init = lifecycle_mod.init;
+    pub const initBorrow = lifecycle_mod.initBorrow;
+    pub const deinit = lifecycle_mod.deinit;
+    pub const deinitExceptAst = lifecycle_mod.deinitExceptAst;
+    pub const initSymbolIds = lifecycle_mod.initSymbolIds;
+    pub const markRuntimeHelperRef = lifecycle_mod.markRuntimeHelperRef;
+    pub const ownedHelperRefNodes = lifecycle_mod.ownedHelperRefNodes;
 
     // ================================================================
     // 공개 API

--- a/src/transformer/transformer/lifecycle.zig
+++ b/src/transformer/transformer/lifecycle.zig
@@ -1,0 +1,131 @@
+//! Transformer construction and teardown helpers.
+
+const std = @import("std");
+const ast_mod = @import("../../parser/ast.zig");
+const Ast = ast_mod.Ast;
+const state_mod = @import("../state.zig");
+const transformer_mod = @import("../transformer.zig");
+const Transformer = transformer_mod.Transformer;
+const TransformOptions = transformer_mod.TransformOptions;
+const Error = Transformer.Error;
+const AstOwnership = state_mod.AstOwnership;
+
+pub fn init(allocator: std.mem.Allocator, source_ast: *const Ast, options: TransformOptions) Error!Transformer {
+    var opts = options;
+    if (opts.experimental_decorators) opts.use_define_for_class_fields = false;
+
+    const ast_ptr = try allocator.create(Ast);
+    errdefer allocator.destroy(ast_ptr);
+    ast_ptr.* = try Ast.cloneForTransformer(source_ast, allocator);
+    // D1 (RFC #1672): parser/transformer 영역 경계 스냅샷.
+    ast_ptr.transform_boundary = @intCast(ast_ptr.nodes.items.len);
+
+    return finishInit(allocator, ast_ptr, opts, .owned);
+}
+
+/// 이미 transform 된 ast 를 borrow — `cloneForTransformer` skip (#1961 PR 1d).
+/// graph parse 단계의 transformer pre-pass 가 in-place 로 transform 한 ast 를
+/// emit 단계 transformer 가 그대로 사용. transform() 은 `ast.transformed_root`
+/// cache hit 분기로 즉시 cached root 반환 → 수백 KB AST 의 전량 memcpy 회피.
+/// `ast` 는 caller 가 owner — transformer.deinit 은 ast 를 건드리지 않는다.
+/// `*const Ast` 받음 — transform() cache hit 분기는 ast mutation 없음. 단, ast 필드는
+/// `*Ast` 라 내부적으로 `@constCast` (caller 가 mut 의도면 별도 borrow 함수 미래에).
+pub fn initBorrow(allocator: std.mem.Allocator, ast: *const Ast, options: TransformOptions) Error!Transformer {
+    var opts = options;
+    if (opts.experimental_decorators) opts.use_define_for_class_fields = false;
+    return finishInit(allocator, @constCast(ast), opts, .borrowed);
+}
+
+fn finishInit(
+    allocator: std.mem.Allocator,
+    ast_ptr: *Ast,
+    opts: TransformOptions,
+    ownership: AstOwnership,
+) Error!Transformer {
+    const parser_count: u32 = switch (ownership) {
+        .owned => @intCast(ast_ptr.nodes.items.len),
+        .borrowed => ast_ptr.transform_boundary orelse @intCast(ast_ptr.nodes.items.len),
+    };
+    var self: Transformer = .{
+        .ast = ast_ptr,
+        .parser_node_count = parser_count,
+        .options = opts,
+        .allocator = allocator,
+        .scratch = .empty,
+        .pending_nodes = .empty,
+        .ast_ownership = ownership,
+    };
+    if (opts.unsupported.arrow) self.runtime_es5_compat = true;
+    return self;
+}
+
+pub fn deinit(self: *Transformer) void {
+    // borrow 모드는 외부 owner (보통 module.parse_arena) 가 ast 를 free.
+    if (self.ast_ownership == .owned) {
+        self.ast.deinit();
+        self.allocator.destroy(self.ast);
+    }
+    self.deinitExceptAst();
+}
+
+/// AST를 제외한 모든 리소스를 해제한다.
+/// 테스트에서 AST를 별도로 관리할 때 사용. `.ast` 는 `*Ast` 이므로 호출자가
+/// `ast.deinit()` + `allocator.destroy(ast)` 둘 다 책임.
+pub fn deinitExceptAst(self: *Transformer) void {
+    self.scratch.deinit(self.allocator);
+    self.pending_nodes.deinit(self.allocator);
+    self.symbol_ids.deinit(self.allocator);
+    self.helper_ref_nodes.deinit(self.allocator);
+    self.plugins.refresh.registrations.deinit(self.allocator);
+    for (self.plugins.refresh.signatures.items) |s| self.allocator.free(s.signature);
+    self.plugins.refresh.signatures.deinit(self.allocator);
+    self.plugins.emotion.scope_stack.deinit(self.allocator);
+    if (self.plugins.emotion.newline_offsets) |*list| list.deinit(self.allocator);
+    self.plugins.styled_components.css_prop_pending_decls.deinit(self.allocator);
+    // collision 발생 시 mangled name 은 heap-owned. owned flag 로 free 판정 (Zig 의
+    // string-literal pooling 이 implementation-defined 이라 ptr 비교 fragile).
+    const sc = &self.plugins.styled_components;
+    if (sc.css_prop_inject_name_owned) self.allocator.free(sc.css_prop_inject_name);
+    self.trailing_nodes.deinit(self.allocator);
+    self.generator_label_stack.deinit(self.allocator);
+    self.generator_temp_var_spans.deinit(self.allocator);
+    self.tagged_template_fns.deinit(self.allocator);
+    for (self.block_rename_stack.items) |entry| self.allocator.free(entry.new_name);
+    self.block_rename_stack.deinit(self.allocator);
+    self.scope_var_names.deinit(self.allocator);
+    for (self.const_enums.items) |decl| {
+        self.allocator.free(decl.name);
+        for (decl.members) |m| {
+            self.allocator.free(m.name);
+            if (m.value == .string) self.allocator.free(m.value.string);
+        }
+        self.allocator.free(decl.members);
+    }
+    self.const_enums.deinit(self.allocator);
+    {
+        var it = self.regex_var_map.iterator();
+        while (it.next()) |entry| self.allocator.free(entry.value_ptr.*);
+        self.regex_var_map.deinit(self.allocator);
+    }
+}
+
+/// semantic analyzer의 symbol_ids를 통합 배열로 복사한다.
+/// 파서 노드 영역(0..parser_node_count-1)에 symbol_id를 채운다.
+pub fn initSymbolIds(self: *Transformer, analyzer_symbol_ids: []const ?u32) Error!void {
+    try self.symbol_ids.appendSlice(self.allocator, analyzer_symbol_ids);
+}
+
+/// #2869 helper marker 등록. caller 는 새로 만든 NodeIndex 를 넘긴다.
+pub fn markRuntimeHelperRef(self: *Transformer, idx: ast_mod.NodeIndex) Error!void {
+    try self.helper_ref_nodes.append(self.allocator, @intFromEnum(idx));
+}
+
+/// #2869 marker 를 caller 소유 sorted slice 로 transfer. resync analyzer 가
+/// binary search 로 사용. `alloc` 은 cache lifetime (parse_arena) 의 allocator.
+pub fn ownedHelperRefNodes(self: *Transformer, alloc: std.mem.Allocator) Error![]u32 {
+    const items = self.helper_ref_nodes.items;
+    if (items.len == 0) return &.{};
+    const out = try alloc.dupe(u32, items);
+    std.mem.sort(u32, out, {}, std.sort.asc(u32));
+    return out;
+}


### PR DESCRIPTION
## 요약
- `Codegen.emitNode`의 큰 AST node dispatch switch를 `src/codegen/node_dispatch.zig`로 분리했습니다.
- `Transformer.init/initBorrow/deinit`과 helper marker lifecycle 함수를 `src/transformer/transformer/lifecycle.zig`로 분리했습니다.
- 기존 호출 이름은 `pub const ... = module.fn` alias로 유지해서 동작 변경 없이 파일 책임만 나눴습니다.

## Zig 초심자 설명
- Zig struct 안에서 `pub const emitNode = node_dispatch_emit.emitNode;`처럼 외부 파일 함수를 alias로 노출하면 기존 `self.emitNode(...)` 호출은 그대로 유지됩니다.
- `node_dispatch.zig`는 `statements.zig`, `expressions.zig`, `bindings.zig` 등 실제 emitter 모듈을 직접 import해서 dispatch만 담당합니다.
- `lifecycle.zig`는 AST clone/borrow와 resource 해제만 담당하고, `Transformer` 본문은 상태 필드와 visitor alias 중심으로 남겼습니다.

## 줄 수 변화
- `src/codegen/codegen.zig`: 720줄 → 366줄
- `src/codegen/node_dispatch.zig`: 280줄 신규
- `src/transformer/transformer.zig`: 695줄 → 582줄
- `src/transformer/transformer/lifecycle.zig`: 131줄 신규

## 검증
- `zig fmt src/codegen/codegen.zig src/codegen/node_dispatch.zig src/transformer/transformer.zig src/transformer/transformer/lifecycle.zig`
- `zig fmt --check src/codegen/codegen.zig src/codegen/node_dispatch.zig src/transformer/transformer.zig src/transformer/transformer/lifecycle.zig`
- `git diff --check`
- `git diff --cached --check`
- `zig build test`
- `zig build`
- `zig build napi`
- `node --test packages/core/napi.test.mjs` (18 pass)
- `bun test --cwd tests/integration tests/downlevel.test.ts tests/bundle-smoke.test.ts --timeout 10000` (402 pass)
- `bun scripts/napi-bundler-bug-check.ts` (Total fails 0)
- `cd packages/core && bun run test bin/zntc.test.ts` (260 pass, 2 skip)
- `cd packages/core && bun test index.test.ts` (417 pass)
- `zig build -Doptimize=ReleaseFast`
- `zig build test262`
- `bun run lint` (기존 warning 23개, error 0)
- `bun run fmt:check`
- `git push` pre-push hook 통과
