### PR TITLE
refactor: graph lifecycle과 registry 분리

### DIFF
--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -56,8 +56,6 @@ pub const ModuleGraph = struct {
     const isFlowPath = graph_parse_helpers.isFlowPath;
     const mergeImportBindings = graph_parse_helpers.mergeImportBindings;
     const mergeImportRecords = graph_parse_helpers.mergeImportRecords;
-    const moduleTypeForLoader = graph_parse_helpers.moduleTypeForLoader;
-    const suppressRuntimeHelperInternalUnresolved = graph_parse_helpers.suppressRuntimeHelperInternalUnresolved;
     const requestAllExports = graph_requested_exports.requestAll;
     const requestNamedExport = graph_requested_exports.requestNamed;
     pub const shouldLinkResolvedRecordForModule = graph_requested_exports.shouldLinkResolvedRecordForModule;
@@ -232,47 +230,10 @@ pub const ModuleGraph = struct {
     pub const WorkerEntry = graph_state.WorkerEntry;
     const RequestedExports = graph_state.RequestedExports;
 
-    pub fn init(allocator: std.mem.Allocator, resolve_cache: *ResolveCache) ModuleGraph {
-        return .{
-            .allocator = allocator,
-            // modules 는 default (.{}) 로 빈 SegmentedList.
-            .path_to_module = std.StringHashMap(ModuleIndex).init(allocator),
-            .diagnostics = .empty,
-            .resolve_cache = resolve_cache,
-        };
-    }
-
-    pub fn deinit(self: *ModuleGraph) void {
-        var mod_it = self.modules.iterator(0);
-        while (mod_it.next()) |m| {
-            // import_records, import_bindings, export_bindings는 parse_arena 소유.
-            // parse_arena.deinit()이 일괄 해제하므로 명시적 free 불필요.
-            m.deinit(self.allocator); // parse_arena.deinit() + dependencies/importers 해제
-        }
-        self.modules.deinit(self.allocator);
-        var key_it = self.path_to_module.keyIterator();
-        while (key_it.next()) |key| {
-            self.allocator.free(key.*);
-        }
-        self.path_to_module.deinit();
-        var req_it = self.requested_exports.valueIterator();
-        while (req_it.next()) |req| req.deinit(self.allocator);
-        self.requested_exports.deinit(self.allocator);
-        var pi_it = self.pkg_info_cache.valueIterator();
-        while (pi_it.next()) |info| info.side_effects.deinit(self.allocator);
-        self.pkg_info_cache.deinit(self.allocator);
-        self.source_read_cache.deinit(self.allocator);
-        for (self.owned_diagnostic_strings.items) |s| self.allocator.free(s);
-        self.owned_diagnostic_strings.deinit(self.allocator);
-        self.diagnostics.deinit(self.allocator);
-        for (self.worker_entries.items) |we| {
-            self.allocator.free(we.resolved_path);
-        }
-        self.worker_entries.deinit(self.allocator);
-        if (self.jsx_specifier_cache) |s| self.allocator.free(s);
-        if (self.plugins_with_helpers) |p| self.allocator.free(p);
-        self.runtime_polyfill_roots.deinit(self.allocator);
-    }
+    // Construction/teardown — graph/lifecycle.zig로 위임
+    const graph_lifecycle = @import("graph/lifecycle.zig");
+    pub const init = graph_lifecycle.init;
+    pub const deinit = graph_lifecycle.deinit;
 
     const ensureBuiltinPlugins = graph_plugins.ensureBuiltinPlugins;
     pub const pluginRunnerWithBuiltins = graph_plugins.pluginRunnerWithBuiltins;
@@ -317,131 +278,23 @@ pub const ModuleGraph = struct {
     pub const ModuleList = graph_state.ModuleList;
     pub const ModulesIterator = graph_state.ModulesIterator;
 
-    /// 확장자에 대한 로더를 결정한다.
-    /// --loader 오버라이드가 있으면 우선 사용, 없으면 확장자 기본값.
-    fn resolveLoader(self: *const ModuleGraph, ext: []const u8) types.ParsedLoader {
-        for (self.loader_overrides) |override| {
-            if (std.mem.eql(u8, override.ext, ext)) {
-                return .{ .loader = override.loader, .module_type = override.module_type };
-            }
-        }
-        return types.ParsedLoader.fromExtension(ext);
-    }
+    // Module registry/link helpers — graph/module_registry.zig로 위임
+    const graph_module_registry = @import("graph/module_registry.zig");
+    pub const discardResolvedModule = graph_module_registry.discardResolvedModule;
+    pub const markRecordLazyResolved = graph_module_registry.markRecordLazyResolved;
+    pub const addModule = graph_module_registry.addModule;
+    pub const addDisabledModule = graph_module_registry.addDisabledModule;
+    pub const addExternalModule = graph_module_registry.addExternalModule;
+    pub const linkDependency = graph_module_registry.linkDependency;
+    pub const linkDynamicImport = graph_module_registry.linkDynamicImport;
 
     // Build/incremental orchestration — graph/build_flow.zig로 위임
     const graph_build_flow = @import("graph/build_flow.zig");
     pub const build = graph_build_flow.build;
 
-    pub fn discardResolvedModule(self: *ModuleGraph, resolved: plugin_mod.ResolvedModule) void {
-        switch (resolved) {
-            .file => |f| self.allocator.free(f.path),
-            .disabled => |d| self.allocator.free(d.path),
-            .virtual, .dataurl, .external, .custom => {},
-        }
-    }
-
-    pub fn markRecordLazyResolved(self: *ModuleGraph, mod_idx: usize, rec_i: usize) void {
-        if (mod_idx >= self.modules.count()) return;
-        const m = self.modules.at(mod_idx);
-        if (rec_i >= m.import_records.len) return;
-        m.import_records[rec_i].is_lazy_resolved = true;
-    }
-
     pub const IncrementalBuildResult = graph_build_flow.IncrementalBuildResult;
     pub const buildIncremental = graph_build_flow.buildIncremental;
     pub const getMtime = graph_build_flow.getMtime;
-
-    /// 모듈을 그래프에 추가하고 파싱한다.
-    /// 이미 존재하면 기존 인덱스를 반환.
-    pub fn addModule(self: *ModuleGraph, abs_path: []const u8) !ModuleIndex {
-        // 중복 체크
-        if (self.path_to_module.get(abs_path)) |existing| {
-            return existing;
-        }
-
-        // 새 모듈 슬롯 할당
-        const index: ModuleIndex = @enumFromInt(@as(u32, @intCast(self.modules.count())));
-        const path_owned = try self.allocator.dupe(u8, abs_path);
-
-        var module = Module.init(index, path_owned);
-        const ext = std.fs.path.extension(abs_path);
-        module.module_type = ModuleType.fromExtension(ext);
-        // 로더 결정: --loader 오버라이드 → 확장자 기본값
-        const parsed_loader = self.resolveLoader(ext);
-        module.loader = parsed_loader.loader;
-        module.module_type = parsed_loader.module_type orelse moduleTypeForLoader(module.module_type, module.loader);
-        try self.modules.append(self.allocator, module);
-        try self.path_to_module.put(path_owned, index);
-
-        // 파싱은 build()의 배치 루프에서 수행
-        return index;
-    }
-
-    /// platform=browser에서 Node 빌트인 모듈을 빈 CJS 모듈로 등록 (esbuild "(disabled)" 방식).
-    /// AST 없이 wrap_kind=.cjs, is_disabled=true로 설정.
-    /// DFS가 이 모듈을 방문하여 exec_index를 부여하고, emitter가 빈 __commonJS wrapper를 출력.
-    pub fn addDisabledModule(self: *ModuleGraph, specifier: []const u8) !ModuleIndex {
-        // 가상 경로: "(disabled):specifier" (esbuild 형식).
-        // specifier 기준으로 중복 체크 — 여러 모듈이 같은 빌트인을 require해도 하나만 생성.
-        const disabled_path = try std.mem.concat(self.allocator, u8, &.{ "(disabled):", specifier });
-
-        // 중복 체크
-        if (self.path_to_module.get(disabled_path)) |existing| {
-            self.allocator.free(disabled_path);
-            return existing;
-        }
-
-        const index: ModuleIndex = @enumFromInt(@as(u32, @intCast(self.modules.count())));
-        var module = Module.init(index, disabled_path);
-        module.module_type = .js;
-        module.exports_kind = .commonjs;
-        module.wrap_kind = .cjs;
-        module.is_disabled = true;
-        module.side_effects = false;
-        module.state = .ready;
-        try self.modules.append(self.allocator, module);
-        try self.path_to_module.put(disabled_path, index);
-
-        return index;
-    }
-
-    /// `external` 패턴 매칭된 specifier 를 phantom Module 로 graph 에 등록.
-    /// 같은 specifier 의 여러 import 는 한 Module 을 공유 — Rollup `getModuleInfo("react")`
-    /// 동일 식별자 의미. AST/source 없음, chunk/emit/tree-shake 에선 별도 가드로 제외.
-    pub fn addExternalModule(self: *ModuleGraph, specifier: []const u8) !ModuleIndex {
-        if (self.path_to_module.get(specifier)) |existing| return existing;
-
-        const index: ModuleIndex = @enumFromInt(@as(u32, @intCast(self.modules.count())));
-        const path_owned = try self.allocator.dupe(u8, specifier);
-        var module = Module.init(index, path_owned);
-        module.is_external = true;
-        module.module_type = .js;
-        module.exports_kind = .esm;
-        module.side_effects = true;
-        module.state = .ready;
-        try self.modules.append(self.allocator, module);
-        try self.path_to_module.put(path_owned, index);
-        return index;
-    }
-
-    /// 양방향 의존성 등록. from → to (dependencies) + to → from (importers) 를 동시에 append.
-    /// graph 가 양방향 관계 책임을 캡슐화. storage 가 SegmentedList 로 바뀌어도 caller 영향 없음.
-    pub fn linkDependency(self: *ModuleGraph, from: ModuleIndex, to: ModuleIndex) !void {
-        if (to.isNone()) return;
-        const from_mod = self.moduleAtMut(from) orelse return;
-        const to_mod = self.moduleAtMut(to) orelse return;
-        try from_mod.dependencies.append(self.allocator, to);
-        try to_mod.importers.append(self.allocator, from);
-    }
-
-    /// 양방향 dynamic import 등록. `linkDependency` 의 dynamic 버전.
-    pub fn linkDynamicImport(self: *ModuleGraph, from: ModuleIndex, to: ModuleIndex) !void {
-        if (to.isNone()) return;
-        const from_mod = self.moduleAtMut(from) orelse return;
-        const to_mod = self.moduleAtMut(to) orelse return;
-        try from_mod.dynamic_imports.append(self.allocator, to);
-        try to_mod.dynamic_importers.append(self.allocator, from);
-    }
 
     // Import resolution and resolved dependency application — graph/resolve_imports.zig로 위임
     const graph_resolve_imports = @import("graph/resolve_imports.zig");

--- a/src/bundler/graph/lifecycle.zig
+++ b/src/bundler/graph/lifecycle.zig
@@ -1,0 +1,51 @@
+//! ModuleGraph construction and teardown helpers.
+
+const std = @import("std");
+const graph_mod = @import("../graph.zig");
+const ModuleGraph = graph_mod.ModuleGraph;
+const types = @import("../types.zig");
+const ModuleIndex = types.ModuleIndex;
+const resolve_cache_mod = @import("../resolve_cache.zig");
+const ResolveCache = resolve_cache_mod.ResolveCache;
+
+pub fn init(allocator: std.mem.Allocator, resolve_cache: *ResolveCache) ModuleGraph {
+    return .{
+        .allocator = allocator,
+        // modules 는 default (.{}) 로 빈 SegmentedList.
+        .path_to_module = std.StringHashMap(ModuleIndex).init(allocator),
+        .diagnostics = .empty,
+        .resolve_cache = resolve_cache,
+    };
+}
+
+pub fn deinit(self: *ModuleGraph) void {
+    var mod_it = self.modules.iterator(0);
+    while (mod_it.next()) |m| {
+        // import_records, import_bindings, export_bindings는 parse_arena 소유.
+        // parse_arena.deinit()이 일괄 해제하므로 명시적 free 불필요.
+        m.deinit(self.allocator); // parse_arena.deinit() + dependencies/importers 해제
+    }
+    self.modules.deinit(self.allocator);
+    var key_it = self.path_to_module.keyIterator();
+    while (key_it.next()) |key| {
+        self.allocator.free(key.*);
+    }
+    self.path_to_module.deinit();
+    var req_it = self.requested_exports.valueIterator();
+    while (req_it.next()) |req| req.deinit(self.allocator);
+    self.requested_exports.deinit(self.allocator);
+    var pi_it = self.pkg_info_cache.valueIterator();
+    while (pi_it.next()) |info| info.side_effects.deinit(self.allocator);
+    self.pkg_info_cache.deinit(self.allocator);
+    self.source_read_cache.deinit(self.allocator);
+    for (self.owned_diagnostic_strings.items) |s| self.allocator.free(s);
+    self.owned_diagnostic_strings.deinit(self.allocator);
+    self.diagnostics.deinit(self.allocator);
+    for (self.worker_entries.items) |we| {
+        self.allocator.free(we.resolved_path);
+    }
+    self.worker_entries.deinit(self.allocator);
+    if (self.jsx_specifier_cache) |s| self.allocator.free(s);
+    if (self.plugins_with_helpers) |p| self.allocator.free(p);
+    self.runtime_polyfill_roots.deinit(self.allocator);
+}

--- a/src/bundler/graph/module_registry.zig
+++ b/src/bundler/graph/module_registry.zig
@@ -1,0 +1,131 @@
+//! Module registration and dependency-link helpers for ModuleGraph.
+
+const std = @import("std");
+const graph_mod = @import("../graph.zig");
+const ModuleGraph = graph_mod.ModuleGraph;
+const types = @import("../types.zig");
+const ModuleIndex = types.ModuleIndex;
+const ModuleType = types.ModuleType;
+const module_mod = @import("../module.zig");
+const Module = module_mod.Module;
+const plugin_mod = @import("../plugin.zig");
+const graph_parse_helpers = @import("parse_helpers.zig");
+const moduleTypeForLoader = graph_parse_helpers.moduleTypeForLoader;
+
+/// 확장자에 대한 로더를 결정한다.
+/// --loader 오버라이드가 있으면 우선 사용, 없으면 확장자 기본값.
+pub fn resolveLoader(self: *const ModuleGraph, ext: []const u8) types.ParsedLoader {
+    for (self.loader_overrides) |override| {
+        if (std.mem.eql(u8, override.ext, ext)) {
+            return .{ .loader = override.loader, .module_type = override.module_type };
+        }
+    }
+    return types.ParsedLoader.fromExtension(ext);
+}
+
+pub fn discardResolvedModule(self: *ModuleGraph, resolved: plugin_mod.ResolvedModule) void {
+    switch (resolved) {
+        .file => |f| self.allocator.free(f.path),
+        .disabled => |d| self.allocator.free(d.path),
+        .virtual, .dataurl, .external, .custom => {},
+    }
+}
+
+pub fn markRecordLazyResolved(self: *ModuleGraph, mod_idx: usize, rec_i: usize) void {
+    if (mod_idx >= self.modules.count()) return;
+    const m = self.modules.at(mod_idx);
+    if (rec_i >= m.import_records.len) return;
+    m.import_records[rec_i].is_lazy_resolved = true;
+}
+
+/// 모듈을 그래프에 추가하고 파싱한다.
+/// 이미 존재하면 기존 인덱스를 반환.
+pub fn addModule(self: *ModuleGraph, abs_path: []const u8) !ModuleIndex {
+    // 중복 체크
+    if (self.path_to_module.get(abs_path)) |existing| {
+        return existing;
+    }
+
+    // 새 모듈 슬롯 할당
+    const index: ModuleIndex = @enumFromInt(@as(u32, @intCast(self.modules.count())));
+    const path_owned = try self.allocator.dupe(u8, abs_path);
+
+    var module = Module.init(index, path_owned);
+    const ext = std.fs.path.extension(abs_path);
+    module.module_type = ModuleType.fromExtension(ext);
+    // 로더 결정: --loader 오버라이드 → 확장자 기본값
+    const parsed_loader = resolveLoader(self, ext);
+    module.loader = parsed_loader.loader;
+    module.module_type = parsed_loader.module_type orelse moduleTypeForLoader(module.module_type, module.loader);
+    try self.modules.append(self.allocator, module);
+    try self.path_to_module.put(path_owned, index);
+
+    // 파싱은 build()의 배치 루프에서 수행
+    return index;
+}
+
+/// platform=browser에서 Node 빌트인 모듈을 빈 CJS 모듈로 등록 (esbuild "(disabled)" 방식).
+/// AST 없이 wrap_kind=.cjs, is_disabled=true로 설정.
+/// DFS가 이 모듈을 방문하여 exec_index를 부여하고, emitter가 빈 __commonJS wrapper를 출력.
+pub fn addDisabledModule(self: *ModuleGraph, specifier: []const u8) !ModuleIndex {
+    // 가상 경로: "(disabled):specifier" (esbuild 형식).
+    // specifier 기준으로 중복 체크 — 여러 모듈이 같은 빌트인을 require해도 하나만 생성.
+    const disabled_path = try std.mem.concat(self.allocator, u8, &.{ "(disabled):", specifier });
+
+    // 중복 체크
+    if (self.path_to_module.get(disabled_path)) |existing| {
+        self.allocator.free(disabled_path);
+        return existing;
+    }
+
+    const index: ModuleIndex = @enumFromInt(@as(u32, @intCast(self.modules.count())));
+    var module = Module.init(index, disabled_path);
+    module.module_type = .js;
+    module.exports_kind = .commonjs;
+    module.wrap_kind = .cjs;
+    module.is_disabled = true;
+    module.side_effects = false;
+    module.state = .ready;
+    try self.modules.append(self.allocator, module);
+    try self.path_to_module.put(disabled_path, index);
+
+    return index;
+}
+
+/// `external` 패턴 매칭된 specifier 를 phantom Module 로 graph 에 등록.
+/// 같은 specifier 의 여러 import 는 한 Module 을 공유 — Rollup `getModuleInfo("react")`
+/// 동일 식별자 의미. AST/source 없음, chunk/emit/tree-shake 에선 별도 가드로 제외.
+pub fn addExternalModule(self: *ModuleGraph, specifier: []const u8) !ModuleIndex {
+    if (self.path_to_module.get(specifier)) |existing| return existing;
+
+    const index: ModuleIndex = @enumFromInt(@as(u32, @intCast(self.modules.count())));
+    const path_owned = try self.allocator.dupe(u8, specifier);
+    var module = Module.init(index, path_owned);
+    module.is_external = true;
+    module.module_type = .js;
+    module.exports_kind = .esm;
+    module.side_effects = true;
+    module.state = .ready;
+    try self.modules.append(self.allocator, module);
+    try self.path_to_module.put(path_owned, index);
+    return index;
+}
+
+/// 양방향 의존성 등록. from → to (dependencies) + to → from (importers) 를 동시에 append.
+/// graph 가 양방향 관계 책임을 캡슐화. storage 가 SegmentedList 로 바뀌어도 caller 영향 없음.
+pub fn linkDependency(self: *ModuleGraph, from: ModuleIndex, to: ModuleIndex) !void {
+    if (to.isNone()) return;
+    const from_mod = self.moduleAtMut(from) orelse return;
+    const to_mod = self.moduleAtMut(to) orelse return;
+    try from_mod.dependencies.append(self.allocator, to);
+    try to_mod.importers.append(self.allocator, from);
+}
+
+/// 양방향 dynamic import 등록. `linkDependency` 의 dynamic 버전.
+pub fn linkDynamicImport(self: *ModuleGraph, from: ModuleIndex, to: ModuleIndex) !void {
+    if (to.isNone()) return;
+    const from_mod = self.moduleAtMut(from) orelse return;
+    const to_mod = self.moduleAtMut(to) orelse return;
+    try from_mod.dynamic_imports.append(self.allocator, to);
+    try to_mod.dynamic_importers.append(self.allocator, from);
+}


### PR DESCRIPTION
## 요약
- `ModuleGraph.init/deinit`을 `src/bundler/graph/lifecycle.zig`로 분리했습니다.
- 모듈 등록/disabled/external module 등록, dependency link helper를 `src/bundler/graph/module_registry.zig`로 분리했습니다.
- 처음에는 lifecycle만 분리하려고 했지만, 실제 코드를 다시 읽어보니 registry/link 책임까지 같이 나누는 편이 더 자연스러워 경계를 조정했습니다.
- 기존 `ModuleGraph.addModule(...)`, `graph.linkDependency(...)` 호출은 `pub const ... = module.fn` alias로 유지해서 동작 변경 없이 책임만 나눴습니다.

## Zig 초심자 설명
- Zig에서는 파일 단위 모듈을 `@import("graph/module_registry.zig")`로 가져오고, struct 안에서 `pub const addModule = graph_module_registry.addModule;`처럼 alias할 수 있습니다.
- 이렇게 하면 구현은 별도 파일에 있어도 기존 method-call 문법인 `graph.addModule(...)` / `graph.linkDependency(...)`가 그대로 동작합니다.
- 분리된 파일은 free function 형태로 `*ModuleGraph`를 첫 인자로 받아 상태를 수정하므로, 기존 구조체 ownership과 allocator 사용 방식은 그대로 유지됩니다.

## 줄 수 변화
- `src/bundler/graph.zig`: 638줄 -> 491줄
- `src/bundler/graph/lifecycle.zig`: 51줄 신규
- `src/bundler/graph/module_registry.zig`: 131줄 신규

## 검증
- `zig fmt src/bundler/graph.zig src/bundler/graph/lifecycle.zig src/bundler/graph/module_registry.zig`
- `zig fmt --check src/bundler/graph.zig src/bundler/graph/lifecycle.zig src/bundler/graph/module_registry.zig`
- `git diff --check`
- `zig build test`
- `zig build`
- `zig build napi`
- `bun test --cwd tests/integration tests/downlevel.test.ts tests/bundle-smoke.test.ts --timeout 10000`
- `node --test packages/core/napi.test.mjs`
- `cd packages/core && bun test index.test.ts`
- `bun scripts/napi-bundler-bug-check.ts`
- `cd packages/core && bun run test bin/zntc.test.ts`
- `zig build -Doptimize=ReleaseFast`
- `bun run lint` (기존 warning 23개, error 0개)
- `bun run fmt:check`
- `zig build test262`
- pre-push hook: `zig fmt --check src/...`, `zig build test`, `oxlint`, `oxfmt --check`
