### PR TITLE
fix(react-native): forwardClientLogs deep-clone leak (#2885)

### DIFF
--- a/packages/react-native/runtime/zntc-hmr-client.cjs
+++ b/packages/react-native/runtime/zntc-hmr-client.cjs
@@ -177,39 +177,41 @@ var HMRClient = {
         typeof __ZNTC_FORWARD_CLIENT_LOGS__ !== 'undefined' ? __ZNTC_FORWARD_CLIENT_LOGS__ : false;
       if (forwardClientLogs === true && self._originalConsole == null) {
         self._originalConsole = {};
-        // Intercept console methods to forward logs to dev server terminal.
+        // RN dev mode 는 idle 에도 LogBox/Animated/bridge 가 console 을 frame 단위로
+        // 호출. wrap 안에서 큰 객체를 deep-clone 하면 RN Fiber/props graph 가 매 frame
+        // 복제돼 GC 가 못 따라가고 RAM 이 grow (#2885). single-pass stringify +
+        // circular replacer + bufferedAmount 가드로 fix.
         var levels = ['log', 'info', 'warn', 'error', 'debug'];
+        // server 가 burst 를 못 따라가면 native send buffer 에 누적 — 1MB 초과 시 drop.
+        // dev 메시지 forwarding 은 best-effort.
+        var BUFFER_LIMIT = 1024 * 1024;
         for (var i = 0; i < levels.length; i++) {
           (function (level) {
             var original = console[level];
             if (typeof original === 'function') {
               self._originalConsole[level] = original;
               console[level] = function () {
-                // Call original first
                 original.apply(console, arguments);
-                // Forward to server
-                if (socket.readyState === 1) {
-                  try {
-                    var args = [];
-                    for (var j = 0; j < arguments.length; j++) {
-                      var arg = arguments[j];
-                      // Serialize safely — avoid circular references
-                      if (arg instanceof Error) {
-                        args.push(arg.message);
-                      } else if (typeof arg === 'object' && arg !== null) {
-                        try {
-                          args.push(JSON.parse(JSON.stringify(arg)));
-                        } catch (_e) {
-                          args.push(String(arg));
-                        }
-                      } else {
-                        args.push(arg);
-                      }
-                    }
-                    socket.send(JSON.stringify({ type: 'log', level: level, data: args }));
-                  } catch (_e) {
-                    // ignore serialization errors
+                if (socket.readyState !== 1) return;
+                if (socket.bufferedAmount > BUFFER_LIMIT) return;
+                var argsLen = arguments.length;
+                var args = new Array(argsLen);
+                for (var j = 0; j < argsLen; j++) args[j] = arguments[j];
+                // seen / replacer 를 호출별 local 로 — toString 등으로 인한 reentrancy
+                // (console.log 가 다른 console.log 를 trigger) 에도 안전.
+                var seen = [];
+                var replacer = function (_key, value) {
+                  if (value instanceof Error) return value.message;
+                  if (typeof value === 'object' && value !== null) {
+                    if (seen.indexOf(value) !== -1) return '[Circular]';
+                    seen.push(value);
                   }
+                  return value;
+                };
+                try {
+                  socket.send(JSON.stringify({ type: 'log', level: level, data: args }, replacer));
+                } catch (_e) {
+                  // serialization 실패 — drop
                 }
               };
             }

--- a/packages/react-native/src/runtime/zntc-hmr-client.test.mjs
+++ b/packages/react-native/src/runtime/zntc-hmr-client.test.mjs
@@ -255,7 +255,7 @@ describe('onopen — hmr:connected + console wrap', () => {
     expect(log.data).toEqual(['boom']);
   });
 
-  test('circular reference 객체 fallback (String 변환)', () => {
+  test('circular reference — replacer 가 [Circular] 로 대체 (#2885)', () => {
     HMRClient.setup('ios', '/abs/idx.js', 'localhost', 8081, true, 'http');
     const ws = MockWebSocket.instances[0];
     ws.onopen();
@@ -263,8 +263,60 @@ describe('onopen — hmr:connected + console wrap', () => {
     obj.self = obj;
     mockConsole.log(obj);
     const log = JSON.parse(ws.sent[1]);
-    expect(typeof log.data[0]).toBe('string');
-    expect(log.data[0]).toContain('[object');
+    expect(typeof log.data[0]).toBe('object');
+    expect(log.data[0].a).toBe(1);
+    expect(log.data[0].self).toBe('[Circular]');
+  });
+
+  test('source 에 JSON.parse(JSON.stringify 패턴 없음 (#2885 deep-clone 회귀 가드)', () => {
+    expect(HMR_CLIENT_SOURCE).not.toContain('JSON.parse(JSON.stringify');
+  });
+
+  test('wrap 함수가 JSON.parse 호출 안 함 (deep-clone 부재 직접 검증) (#2885)', () => {
+    HMRClient.setup('ios', '/abs/idx.js', 'localhost', 8081, true, 'http');
+    const ws = MockWebSocket.instances[0];
+    ws.onopen();
+    const originalParse = JSON.parse;
+    let parseCalls = 0;
+    JSON.parse = function () {
+      parseCalls++;
+      return originalParse.apply(JSON, arguments);
+    };
+    try {
+      mockConsole.log({ a: 1, b: { c: 2 } });
+    } finally {
+      JSON.parse = originalParse;
+    }
+    expect(parseCalls).toBe(0);
+  });
+
+  test('bufferedAmount 1MB 초과 시 send drop (#2885 burst 누적 가드)', () => {
+    HMRClient.setup('ios', '/abs/idx.js', 'localhost', 8081, true, 'http');
+    const ws = MockWebSocket.instances[0];
+    ws.onopen();
+    const sentBefore = ws.sent.length;
+    ws.bufferedAmount = 2 * 1024 * 1024;
+    mockConsole.log('this should be dropped');
+    expect(ws.sent.length).toBe(sentBefore);
+    ws.bufferedAmount = 0;
+    mockConsole.log('this should pass');
+    expect(ws.sent.length).toBe(sentBefore + 1);
+  });
+
+  test('readyState !== OPEN 시 send drop (#2885 stale connection 가드)', () => {
+    HMRClient.setup('ios', '/abs/idx.js', 'localhost', 8081, true, 'http');
+    const ws = MockWebSocket.instances[0];
+    ws.onopen();
+    const sentBefore = ws.sent.length;
+    ws.readyState = 0; // CONNECTING
+    mockConsole.log('not yet open');
+    expect(ws.sent.length).toBe(sentBefore);
+    ws.readyState = 2; // CLOSING
+    mockConsole.log('closing');
+    expect(ws.sent.length).toBe(sentBefore);
+    ws.readyState = 3; // CLOSED
+    mockConsole.log('closed');
+    expect(ws.sent.length).toBe(sentBefore);
   });
 });
 


### PR DESCRIPTION
## 증상

RN \`--dev\` 모드로 앱을 켜놓고 **사용자 활동/rebuild 없는 idle 상태에서도 RAM 이 지속적으로 증가**. \`forwardClientLogs: false\` 로 끄면 누수 사라짐. Metro 로 같은 앱은 누수 없음.

## Root cause

\`zntc-hmr-client\` 가 \`forwardClientLogs=true\` 일 때 5개 console method (log/info/warn/error/debug) 를 wrap 한다. 매 호출마다:

\`\`\`js
args.push(JSON.parse(JSON.stringify(arg)));  // ← deep-clone
...
socket.send(JSON.stringify({ type: 'log', level, data: args }));  // ← 또 stringify
\`\`\`

RN dev mode 는 idle 상태에도 LogBox/Animated/bridge 가 console 을 frame 단위로 호출하므로 **RN Fiber/props graph 가 매 frame 통째로 복제** → GC 가 따라가지 못해 RAM 이 grow. 사용자 console 출력이 안 보여도 RN system console 이 wrap function 을 trigger.

## Fix

Metro 패턴에 맞춰 deep-clone 제거 + 가드:

- **single-pass \`JSON.stringify\` + circular replacer** — deep-clone 없이 한 번만 직렬화. circular ref 는 \`[Circular]\` 로 치환
- **\`bufferedAmount > 1MB\` 시 send drop** — server burst 못 따라갈 때 native send queue 누적 가드
- **\`readyState !== OPEN\` 시 send drop** — stale connection (server down 후 close 못 받은 케이스) 가드
- \`seen\` array / replacer 를 호출별 local 로 — \`toString\` 등 reentrancy 안전

## 측정

- Metro 비교: 같은 RN 앱 idle 시 RAM 증가 없음 (사용자 검증)
- zntc 기존: idle 상태 RAM 지속 증가
- zntc fix 후: 사용자 환경에서 검증 필요 (단위 테스트로 deep-clone 부재 + 가드 동작 확인됨)

## 회귀 가드 5개 추가

\`packages/react-native/src/runtime/zntc-hmr-client.test.mjs\`:

1. source 에 \`JSON.parse(JSON.stringify\` 패턴 없음
2. wrap 함수가 \`JSON.parse\` 호출 안 함 (직접 spy 로 측정)
3. circular ref 가 \`[Circular]\` 로 치환된 object 로 send
4. \`bufferedAmount > 1MB\` 시 send drop
5. \`readyState !== OPEN\` 시 send drop

## Test plan

- [x] \`bun test src/runtime/zntc-hmr-client.test.mjs\` — 38/38 통과 (기존 33 + 신규 5)
- [x] \`bun test\` (전체 react-native 패키지) — 474/474 통과 (회귀 없음)
- [ ] 실제 RN 앱 idle 시 RAM 추이 검증 (사용자 환경)

Closes #2885

🤖 Generated with [Claude Code](https://claude.com/claude-code)