### PR TITLE
refactor: tree shaker CJS pattern helper 분리

### DIFF
--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -29,7 +29,6 @@ const Ast = ast_mod.Ast;
 const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const ast_walk = @import("../parser/ast_walk.zig");
-const Kind = @import("../lexer/token.zig").Kind;
 const Span = @import("../lexer/token.zig").Span;
 const purity = @import("purity.zig");
 const stmt_info_mod = @import("stmt_info.zig");
@@ -37,6 +36,7 @@ const StmtInfos = stmt_info_mod.ModuleStmtInfos;
 const constant_facts = @import("constant_facts.zig");
 const ConstValue = @import("../semantic/symbol.zig").ConstValue;
 const runtime_helper_modules = @import("../runtime_helper_modules.zig");
+const cjs_patterns = @import("tree_shaker/cjs_patterns.zig");
 const profile = @import("../profile.zig");
 
 /// `used_exports`의 all-exports-used sentinel. 모듈의 전체 export가 사용됨을 표시.
@@ -1552,7 +1552,7 @@ pub const TreeShaker = struct {
                             if (!self.isExportUsed(item.mod, ALL_EXPORTS_SENTINEL) and
                                 !self.isExportUsed(@intCast(target_mod_idx), ALL_EXPORTS_SENTINEL) and
                                 self.hasAnyUsedExportDirect(@intCast(target_mod_idx)) and
-                                moduleExportsRequireProxyMatches(o, infos, @intCast(item.stmt), rec.resolved))
+                                cjs_patterns.moduleExportsRequireProxyMatches(o, infos, @intCast(item.stmt), rec.resolved))
                             {
                                 const target_infos = module_stmt_infos[target_mod_idx] orelse {
                                     try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
@@ -2019,13 +2019,13 @@ pub const TreeShaker = struct {
 
         var buffer_names: std.StringHashMapUnmanaged(void) = .{};
         defer buffer_names.deinit(self.allocator);
-        collectNodeBufferModuleObjectNames(self.allocator, ast, &buffer_names) catch return false;
+        cjs_patterns.collectNodeBufferModuleObjectNames(self.allocator, ast, &buffer_names) catch return false;
         if (buffer_names.count() == 0) return false;
 
         for (infos.stmts, 0..) |stmt, si| {
             const stmt_ni: usize = stmt.node_idx;
             if (stmt_ni >= ast.nodes.items.len) continue;
-            if (!isModuleExportsAssignedNodeBufferObject(ast, ast.nodes.items[stmt_ni], &buffer_names)) continue;
+            if (!cjs_patterns.isModuleExportsAssignedNodeBufferObject(ast, ast.nodes.items[stmt_ni], &buffer_names)) continue;
             if (reachable_stmts[mod_idx] == null) {
                 reachable_stmts[mod_idx] = try std.DynamicBitSet.initEmpty(self.allocator, infos.stmts.len);
             }
@@ -2050,7 +2050,7 @@ pub const TreeShaker = struct {
         for (infos.stmts, 0..) |stmt, si| {
             const stmt_ni: usize = stmt.node_idx;
             if (stmt_ni >= ast.nodes.items.len) continue;
-            const target = moduleExportsRequireTargetAt(m, ast, @enumFromInt(stmt_ni)) orelse continue;
+            const target = cjs_patterns.moduleExportsRequireTargetAt(m, ast, @enumFromInt(stmt_ni)) orelse continue;
             const target_idx: u32 = @intFromEnum(target);
             if (target_idx == mod_idx) continue;
 
@@ -2299,7 +2299,7 @@ pub const TreeShaker = struct {
         for (target_infos.stmts) |stmt| {
             const stmt_ni = stmt.node_idx;
             if (stmt_ni >= ast.nodes.items.len) continue;
-            const target = moduleExportsRequireTargetAt(m, ast, @enumFromInt(stmt_ni)) orelse continue;
+            const target = cjs_patterns.moduleExportsRequireTargetAt(m, ast, @enumFromInt(stmt_ni)) orelse continue;
             const target_idx: u32 = @intFromEnum(target);
             if (target_idx == mod_idx) continue;
             if (self.isExportUsed(target_idx, ALL_EXPORTS_SENTINEL)) continue;
@@ -2677,7 +2677,7 @@ pub const TreeShaker = struct {
             const m = self.moduleAtMut(@intCast(i)) orelse continue;
             if (m.wrap_kind != .cjs) continue;
             const ast = &(m.ast orelse continue);
-            if (!foldNodeBufferCapabilityIfs(self.allocator, ast)) continue;
+            if (!cjs_patterns.foldNodeBufferCapabilityIfs(self.allocator, ast)) continue;
             self.markAstMutatedAndResync(m);
         }
     }
@@ -2753,459 +2753,4 @@ pub const TreeShaker = struct {
 fn containsU32(slice: []const u32, target: u32) bool {
     for (slice) |v| if (v == target) return true;
     return false;
-}
-
-fn foldNodeBufferCapabilityIfs(allocator: std.mem.Allocator, ast: *Ast) bool {
-    var buffer_names: std.StringHashMapUnmanaged(void) = .{};
-    defer buffer_names.deinit(allocator);
-    collectNodeBufferModuleObjectNames(allocator, ast, &buffer_names) catch return false;
-    if (buffer_names.count() == 0) return false;
-
-    var buffer_ctor_names: std.StringHashMapUnmanaged(void) = .{};
-    defer buffer_ctor_names.deinit(allocator);
-    collectNodeBufferCtorNames(allocator, ast, &buffer_names, &buffer_ctor_names) catch return false;
-    if (buffer_ctor_names.count() == 0) return false;
-
-    var dead_fallback_names: std.StringHashMapUnmanaged(void) = .{};
-    defer dead_fallback_names.deinit(allocator);
-
-    var changed = false;
-    for (ast.nodes.items, 0..) |node, i| {
-        if (node.tag != .if_statement) continue;
-        var caps: BufferCapabilitySet = .{};
-        if (!collectNodeBufferCapabilityCondition(ast, node.data.ternary.a, &buffer_ctor_names, &caps)) continue;
-        if (!caps.hasAll()) continue;
-        collectDeadAlternateCjsExportIdentifiers(allocator, ast, node.data.ternary.c, &dead_fallback_names) catch {};
-        const kept = singleBlockStatement(ast, node.data.ternary.b) orelse node.data.ternary.b;
-        const kept_ni = @intFromEnum(kept);
-        if (kept_ni >= ast.nodes.items.len) continue;
-        ast.nodes.items[i] = ast.nodes.items[kept_ni];
-        changed = true;
-    }
-    if (changed and dead_fallback_names.count() > 0) {
-        removeDeadFallbackSetupStatements(ast, &dead_fallback_names, &buffer_ctor_names);
-    }
-    return changed;
-}
-
-const BufferCapabilitySet = struct {
-    from: bool = false,
-    alloc: bool = false,
-    alloc_unsafe: bool = false,
-    alloc_unsafe_slow: bool = false,
-
-    fn add(self: *BufferCapabilitySet, name: []const u8) bool {
-        if (std.mem.eql(u8, name, "from")) {
-            self.from = true;
-            return true;
-        }
-        if (std.mem.eql(u8, name, "alloc")) {
-            self.alloc = true;
-            return true;
-        }
-        if (std.mem.eql(u8, name, "allocUnsafe")) {
-            self.alloc_unsafe = true;
-            return true;
-        }
-        if (std.mem.eql(u8, name, "allocUnsafeSlow")) {
-            self.alloc_unsafe_slow = true;
-            return true;
-        }
-        return false;
-    }
-
-    fn hasAll(self: BufferCapabilitySet) bool {
-        return self.from and self.alloc and self.alloc_unsafe and self.alloc_unsafe_slow;
-    }
-};
-
-fn collectNodeBufferCapabilityCondition(
-    ast: *const Ast,
-    idx: NodeIndex,
-    ctor_names: *const std.StringHashMapUnmanaged(void),
-    caps: *BufferCapabilitySet,
-) bool {
-    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return false;
-    const node = ast.nodes.items[@intFromEnum(idx)];
-    switch (node.tag) {
-        .parenthesized_expression => return collectNodeBufferCapabilityCondition(ast, node.data.unary.operand, ctor_names, caps),
-        .logical_expression => {
-            if (@as(Kind, @enumFromInt(node.data.binary.flags)) != .amp2) return false;
-            return collectNodeBufferCapabilityCondition(ast, node.data.binary.left, ctor_names, caps) and
-                collectNodeBufferCapabilityCondition(ast, node.data.binary.right, ctor_names, caps);
-        },
-        .static_member_expression => {
-            const parts = staticMemberParts(ast, idx) orelse return false;
-            const obj = ast.nodes.items[@intFromEnum(parts.object)];
-            if (obj.tag != .identifier_reference) return false;
-            if (!ctor_names.contains(ast.getText(obj.span))) return false;
-            const prop = ast.nodes.items[@intFromEnum(parts.property)];
-            if (prop.tag != .identifier_reference and prop.tag != .private_identifier) return false;
-            return caps.add(ast.getText(prop.span));
-        },
-        else => return false,
-    }
-}
-
-fn singleBlockStatement(ast: *const Ast, idx: NodeIndex) ?NodeIndex {
-    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return null;
-    const node = ast.nodes.items[@intFromEnum(idx)];
-    if (node.tag != .block_statement) return null;
-    const list = node.data.list;
-    if (list.len != 1) return null;
-    if (list.start >= ast.extra_data.items.len) return null;
-    return @enumFromInt(ast.extra_data.items[list.start]);
-}
-
-fn collectDeadAlternateCjsExportIdentifiers(
-    allocator: std.mem.Allocator,
-    ast: *const Ast,
-    idx: NodeIndex,
-    out: *std.StringHashMapUnmanaged(void),
-) std.mem.Allocator.Error!void {
-    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return;
-    const node = ast.nodes.items[@intFromEnum(idx)];
-    if (node.tag == .block_statement) {
-        const list = node.data.list;
-        if (list.start + list.len > ast.extra_data.items.len) return;
-        for (ast.extra_data.items[list.start .. list.start + list.len]) |raw| {
-            try collectDeadAlternateCjsExportIdentifiers(allocator, ast, @enumFromInt(raw), out);
-        }
-        return;
-    }
-    if (node.tag != .expression_statement) return;
-    const expr_idx = node.data.unary.operand;
-    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return;
-    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
-    if (expr.tag != .assignment_expression) return;
-    if (!isCjsNamedExportLhs(ast, expr.data.binary.left)) return;
-    const rhs_idx = expr.data.binary.right;
-    if (rhs_idx.isNone() or @intFromEnum(rhs_idx) >= ast.nodes.items.len) return;
-    const rhs = ast.nodes.items[@intFromEnum(rhs_idx)];
-    if (rhs.tag != .identifier_reference) return;
-    try out.put(allocator, ast.getText(rhs.span), {});
-}
-
-fn removeDeadFallbackSetupStatements(
-    ast: *Ast,
-    dead_names: *const std.StringHashMapUnmanaged(void),
-    buffer_ctor_names: *const std.StringHashMapUnmanaged(void),
-) void {
-    const root = programNode(ast) orelse return;
-    const list = root.data.list;
-    if (list.start + list.len > ast.extra_data.items.len) return;
-    for (ast.extra_data.items[list.start .. list.start + list.len]) |raw_stmt| {
-        const stmt_idx: NodeIndex = @enumFromInt(raw_stmt);
-        if (stmt_idx.isNone() or @intFromEnum(stmt_idx) >= ast.nodes.items.len) continue;
-        const stmt = ast.nodes.items[@intFromEnum(stmt_idx)];
-        if (!isDeadFallbackSetupStatement(ast, stmt, dead_names, buffer_ctor_names)) continue;
-        ast.nodes.items[@intFromEnum(stmt_idx)] = .{
-            .tag = .empty_statement,
-            .span = stmt.span,
-            .data = .{ .none = 0 },
-        };
-    }
-}
-
-fn isDeadFallbackSetupStatement(
-    ast: *const Ast,
-    stmt: Node,
-    dead_names: *const std.StringHashMapUnmanaged(void),
-    buffer_ctor_names: *const std.StringHashMapUnmanaged(void),
-) bool {
-    if (stmt.tag != .expression_statement) return false;
-    const expr_idx = stmt.data.unary.operand;
-    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return false;
-    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
-    if (expr.tag == .assignment_expression) {
-        const root = staticMemberRootIdentifier(ast, expr.data.binary.left) orelse return false;
-        return dead_names.contains(root);
-    }
-    if (expr.tag == .call_expression) {
-        return isDeadFallbackCopyCall(ast, expr, dead_names, buffer_ctor_names);
-    }
-    return false;
-}
-
-fn isDeadFallbackCopyCall(
-    ast: *const Ast,
-    call: Node,
-    dead_names: *const std.StringHashMapUnmanaged(void),
-    buffer_ctor_names: *const std.StringHashMapUnmanaged(void),
-) bool {
-    const e = call.data.extra;
-    if (!ast.hasExtra(e, 2)) return false;
-    const args_start = ast.readExtra(e, 1);
-    const args_len = ast.readExtra(e, 2);
-    if (args_len != 2 or args_start + args_len > ast.extra_data.items.len) return false;
-    const first_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start]);
-    const second_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start + 1]);
-    if (first_idx.isNone() or second_idx.isNone()) return false;
-    if (@intFromEnum(first_idx) >= ast.nodes.items.len or @intFromEnum(second_idx) >= ast.nodes.items.len) return false;
-    const first = ast.nodes.items[@intFromEnum(first_idx)];
-    const second = ast.nodes.items[@intFromEnum(second_idx)];
-    if (first.tag != .identifier_reference or second.tag != .identifier_reference) return false;
-    return buffer_ctor_names.contains(ast.getText(first.span)) and dead_names.contains(ast.getText(second.span));
-}
-
-fn staticMemberRootIdentifier(ast: *const Ast, idx: NodeIndex) ?[]const u8 {
-    var current = idx;
-    while (true) {
-        const parts = staticMemberParts(ast, current) orelse return null;
-        const obj = ast.nodes.items[@intFromEnum(parts.object)];
-        if (obj.tag == .identifier_reference) return ast.getText(obj.span);
-        current = parts.object;
-    }
-}
-
-fn collectNodeBufferModuleObjectNames(
-    allocator: std.mem.Allocator,
-    ast: *const Ast,
-    out: *std.StringHashMapUnmanaged(void),
-) std.mem.Allocator.Error!void {
-    const root = programNode(ast) orelse return;
-    const list = root.data.list;
-    if (list.start + list.len > ast.extra_data.items.len) return;
-    for (ast.extra_data.items[list.start .. list.start + list.len]) |raw_stmt| {
-        const stmt_idx: NodeIndex = @enumFromInt(raw_stmt);
-        try collectVarNamesMatchingInit(allocator, ast, stmt_idx, out, isRequireBufferCall);
-    }
-}
-
-fn collectNodeBufferCtorNames(
-    allocator: std.mem.Allocator,
-    ast: *const Ast,
-    buffer_names: *const std.StringHashMapUnmanaged(void),
-    out: *std.StringHashMapUnmanaged(void),
-) std.mem.Allocator.Error!void {
-    const root = programNode(ast) orelse return;
-    const list = root.data.list;
-    if (list.start + list.len > ast.extra_data.items.len) return;
-    for (ast.extra_data.items[list.start .. list.start + list.len]) |raw_stmt| {
-        const stmt_idx: NodeIndex = @enumFromInt(raw_stmt);
-        if (stmt_idx.isNone() or @intFromEnum(stmt_idx) >= ast.nodes.items.len) continue;
-        const stmt = ast.nodes.items[@intFromEnum(stmt_idx)];
-        if (stmt.tag != .variable_declaration) continue;
-        const e = stmt.data.extra;
-        if (!ast.hasExtra(e, 2)) continue;
-        const start = ast.readExtra(e, 1);
-        const len = ast.readExtra(e, 2);
-        if (start + len > ast.extra_data.items.len) continue;
-        for (ast.extra_data.items[start .. start + len]) |raw_decl| {
-            const decl_idx: NodeIndex = @enumFromInt(raw_decl);
-            if (decl_idx.isNone() or @intFromEnum(decl_idx) >= ast.nodes.items.len) continue;
-            const decl = ast.nodes.items[@intFromEnum(decl_idx)];
-            if (decl.tag != .variable_declarator) continue;
-            const de = decl.data.extra;
-            if (!ast.hasExtra(de, 2)) continue;
-            const name_idx: NodeIndex = @enumFromInt(ast.readExtra(de, 0));
-            const init_idx: NodeIndex = @enumFromInt(ast.readExtra(de, 2));
-            if (name_idx.isNone() or @intFromEnum(name_idx) >= ast.nodes.items.len) continue;
-            if (!isNodeBufferCtorRead(ast, init_idx, buffer_names)) continue;
-            const name = ast.nodes.items[@intFromEnum(name_idx)];
-            if (name.tag == .identifier_reference or name.tag == .binding_identifier or name.tag == .assignment_target_identifier) {
-                try out.put(allocator, ast.getText(name.span), {});
-            }
-        }
-    }
-}
-
-fn collectVarNamesMatchingInit(
-    allocator: std.mem.Allocator,
-    ast: *const Ast,
-    stmt_idx: NodeIndex,
-    out: *std.StringHashMapUnmanaged(void),
-    comptime predicate: fn (*const Ast, NodeIndex) bool,
-) std.mem.Allocator.Error!void {
-    if (stmt_idx.isNone() or @intFromEnum(stmt_idx) >= ast.nodes.items.len) return;
-    const stmt = ast.nodes.items[@intFromEnum(stmt_idx)];
-    if (stmt.tag != .variable_declaration) return;
-    const e = stmt.data.extra;
-    if (!ast.hasExtra(e, 2)) return;
-    const start = ast.readExtra(e, 1);
-    const len = ast.readExtra(e, 2);
-    if (start + len > ast.extra_data.items.len) return;
-    for (ast.extra_data.items[start .. start + len]) |raw_decl| {
-        const decl_idx: NodeIndex = @enumFromInt(raw_decl);
-        if (decl_idx.isNone() or @intFromEnum(decl_idx) >= ast.nodes.items.len) continue;
-        const decl = ast.nodes.items[@intFromEnum(decl_idx)];
-        if (decl.tag != .variable_declarator) continue;
-        const de = decl.data.extra;
-        if (!ast.hasExtra(de, 2)) continue;
-        const name_idx: NodeIndex = @enumFromInt(ast.readExtra(de, 0));
-        const init_idx: NodeIndex = @enumFromInt(ast.readExtra(de, 2));
-        if (!predicate(ast, init_idx)) continue;
-        if (name_idx.isNone() or @intFromEnum(name_idx) >= ast.nodes.items.len) continue;
-        const name = ast.nodes.items[@intFromEnum(name_idx)];
-        if (name.tag == .identifier_reference or name.tag == .binding_identifier or name.tag == .assignment_target_identifier) {
-            try out.put(allocator, ast.getText(name.span), {});
-        }
-    }
-}
-
-fn programNode(ast: *const Ast) ?Node {
-    if (ast.nodes.items.len == 0) return null;
-    const root = ast.nodes.items[ast.nodes.items.len - 1];
-    if (root.tag != .program) return null;
-    return root;
-}
-
-fn isRequireBufferCall(ast: *const Ast, idx: NodeIndex) bool {
-    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return false;
-    const node = ast.nodes.items[@intFromEnum(idx)];
-    if (node.tag != .call_expression) return false;
-    const e = node.data.extra;
-    if (!ast.hasExtra(e, 2)) return false;
-    const callee_idx: NodeIndex = @enumFromInt(ast.readExtra(e, 0));
-    if (callee_idx.isNone() or @intFromEnum(callee_idx) >= ast.nodes.items.len) return false;
-    const callee = ast.nodes.items[@intFromEnum(callee_idx)];
-    if (callee.tag != .identifier_reference or !std.mem.eql(u8, ast.getText(callee.span), "require")) return false;
-    const args_start = ast.readExtra(e, 1);
-    const args_len = ast.readExtra(e, 2);
-    if (args_len != 1 or args_start >= ast.extra_data.items.len) return false;
-    const arg_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start]);
-    if (arg_idx.isNone() or @intFromEnum(arg_idx) >= ast.nodes.items.len) return false;
-    const arg = ast.nodes.items[@intFromEnum(arg_idx)];
-    if (arg.tag != .string_literal) return false;
-    const spec = ast_mod.Ast.stripStringQuotes(ast.getText(arg.span));
-    return std.mem.eql(u8, spec, "buffer") or std.mem.eql(u8, spec, "node:buffer");
-}
-
-fn isNodeBufferCtorRead(
-    ast: *const Ast,
-    idx: NodeIndex,
-    buffer_names: *const std.StringHashMapUnmanaged(void),
-) bool {
-    const parts = staticMemberParts(ast, idx) orelse return false;
-    const obj = ast.nodes.items[@intFromEnum(parts.object)];
-    const prop = ast.nodes.items[@intFromEnum(parts.property)];
-    if (obj.tag != .identifier_reference) return false;
-    if (prop.tag != .identifier_reference and prop.tag != .private_identifier) return false;
-    return buffer_names.contains(ast.getText(obj.span)) and std.mem.eql(u8, ast.getText(prop.span), "Buffer");
-}
-
-fn isModuleExportsAssignedNodeBufferObject(
-    ast: *const Ast,
-    stmt: Node,
-    buffer_names: *const std.StringHashMapUnmanaged(void),
-) bool {
-    if (stmt.tag != .expression_statement) return false;
-    const expr_idx = stmt.data.unary.operand;
-    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return false;
-    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
-    if (expr.tag != .assignment_expression) return false;
-    if (!isModuleExportsLhs(ast, expr.data.binary.left)) return false;
-    const rhs_idx = expr.data.binary.right;
-    if (rhs_idx.isNone() or @intFromEnum(rhs_idx) >= ast.nodes.items.len) return false;
-    const rhs = ast.nodes.items[@intFromEnum(rhs_idx)];
-    return rhs.tag == .identifier_reference and buffer_names.contains(ast.getText(rhs.span));
-}
-
-fn isModuleExportsLhs(ast: *const Ast, idx: NodeIndex) bool {
-    const parts = staticMemberParts(ast, idx) orelse return false;
-    const obj = ast.nodes.items[@intFromEnum(parts.object)];
-    const prop = ast.nodes.items[@intFromEnum(parts.property)];
-    return obj.tag == .identifier_reference and
-        prop.tag == .identifier_reference and
-        std.mem.eql(u8, ast.getText(obj.span), "module") and
-        std.mem.eql(u8, ast.getText(prop.span), "exports");
-}
-
-fn isCjsNamedExportLhs(ast: *const Ast, idx: NodeIndex) bool {
-    const outer = staticMemberParts(ast, idx) orelse return false;
-    const prop = ast.nodes.items[@intFromEnum(outer.property)];
-    if (prop.tag != .identifier_reference and prop.tag != .private_identifier) return false;
-    const obj = ast.nodes.items[@intFromEnum(outer.object)];
-    if (obj.tag == .identifier_reference and std.mem.eql(u8, ast.getText(obj.span), "exports")) {
-        return true;
-    }
-    if (obj.tag != .static_member_expression) return false;
-    const inner = staticMemberParts(ast, outer.object) orelse return false;
-    const inner_obj = ast.nodes.items[@intFromEnum(inner.object)];
-    const inner_prop = ast.nodes.items[@intFromEnum(inner.property)];
-    return inner_obj.tag == .identifier_reference and
-        inner_prop.tag == .identifier_reference and
-        std.mem.eql(u8, ast.getText(inner_obj.span), "module") and
-        std.mem.eql(u8, ast.getText(inner_prop.span), "exports");
-}
-
-fn moduleExportsRequireSpanAt(ast: *const Ast, idx: NodeIndex) ?@import("../lexer/token.zig").Span {
-    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return null;
-    const stmt = ast.nodes.items[@intFromEnum(idx)];
-    if (stmt.tag == .block_statement) {
-        const inner = singleBlockStatement(ast, idx) orelse return null;
-        return moduleExportsRequireSpanAt(ast, inner);
-    }
-    if (stmt.tag == .if_statement) {
-        const t = stmt.data.ternary;
-        if (moduleExportsRequireSpanAt(ast, t.b)) |span| return span;
-        if (!t.c.isNone()) return moduleExportsRequireSpanAt(ast, t.c);
-        return null;
-    }
-    if (stmt.tag != .expression_statement) return null;
-    const expr_idx = stmt.data.unary.operand;
-    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return null;
-    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
-    if (expr.tag != .assignment_expression) return null;
-    const op: Kind = @enumFromInt(expr.data.binary.flags);
-    if (op != .eq) return null;
-    if (!isModuleExportsLhs(ast, expr.data.binary.left)) return null;
-
-    const rhs_idx = expr.data.binary.right;
-    if (rhs_idx.isNone() or @intFromEnum(rhs_idx) >= ast.nodes.items.len) return null;
-    const rhs = ast.nodes.items[@intFromEnum(rhs_idx)];
-    if (rhs.tag != .call_expression) return null;
-    const e = rhs.data.extra;
-    if (!ast.hasExtra(e, 2)) return null;
-
-    const callee_idx = ast.readExtraNode(e, 0);
-    if (callee_idx.isNone() or @intFromEnum(callee_idx) >= ast.nodes.items.len) return null;
-    const callee = ast.nodes.items[@intFromEnum(callee_idx)];
-    if (callee.tag != .identifier_reference or !std.mem.eql(u8, ast.getText(callee.span), "require")) return null;
-
-    const args_start = ast.readExtra(e, 1);
-    const args_len = ast.readExtra(e, 2);
-    if (args_len != 1 or args_start >= ast.extra_data.items.len) return null;
-    const arg_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start]);
-    if (arg_idx.isNone() or @intFromEnum(arg_idx) >= ast.nodes.items.len) return null;
-    const arg = ast.nodes.items[@intFromEnum(arg_idx)];
-    if (arg.tag != .string_literal) return null;
-    return arg.span;
-}
-
-fn moduleExportsRequireTargetAt(m: *const Module, ast: *const Ast, idx: NodeIndex) ?ModuleIndex {
-    const span = moduleExportsRequireSpanAt(ast, idx) orelse return null;
-    for (m.import_records) |rec| {
-        if (rec.kind != .require) continue;
-        if (rec.resolved.isNone()) continue;
-        if (rec.span.start == span.start and rec.span.end == span.end) return rec.resolved;
-    }
-    return null;
-}
-
-fn moduleExportsRequireProxyMatches(
-    m: *const Module,
-    infos: StmtInfos,
-    stmt_idx: u32,
-    target: ModuleIndex,
-) bool {
-    if (stmt_idx >= infos.stmts.len) return false;
-    const ast = &(m.ast orelse return false);
-    const stmt_ni = infos.stmts[stmt_idx].node_idx;
-    if (stmt_ni >= ast.nodes.items.len) return false;
-    const proxy_target = moduleExportsRequireTargetAt(m, ast, @enumFromInt(stmt_ni)) orelse return false;
-    return @intFromEnum(proxy_target) == @intFromEnum(target);
-}
-
-fn staticMemberParts(ast: *const Ast, idx: NodeIndex) ?struct { object: NodeIndex, property: NodeIndex } {
-    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return null;
-    const node = ast.nodes.items[@intFromEnum(idx)];
-    if (node.tag != .static_member_expression) return null;
-    const e = node.data.extra;
-    if (!ast.hasExtra(e, 1)) return null;
-    const obj_idx: NodeIndex = @enumFromInt(ast.readExtra(e, 0));
-    const prop_idx: NodeIndex = @enumFromInt(ast.readExtra(e, 1));
-    if (obj_idx.isNone() or prop_idx.isNone()) return null;
-    if (@intFromEnum(obj_idx) >= ast.nodes.items.len or @intFromEnum(prop_idx) >= ast.nodes.items.len) return null;
-    return .{ .object = obj_idx, .property = prop_idx };
 }

--- a/src/bundler/tree_shaker/cjs_patterns.zig
+++ b/src/bundler/tree_shaker/cjs_patterns.zig
@@ -1,0 +1,468 @@
+//! CJS AST pattern helpers used by tree shaking.
+
+const std = @import("std");
+const types = @import("../types.zig");
+const ModuleIndex = types.ModuleIndex;
+const Module = @import("../module.zig").Module;
+const StmtInfos = @import("../stmt_info.zig").ModuleStmtInfos;
+const ast_mod = @import("../../parser/ast.zig");
+const Ast = ast_mod.Ast;
+const Node = ast_mod.Node;
+const NodeIndex = ast_mod.NodeIndex;
+const Kind = @import("../../lexer/token.zig").Kind;
+const Span = @import("../../lexer/token.zig").Span;
+
+pub fn foldNodeBufferCapabilityIfs(allocator: std.mem.Allocator, ast: *Ast) bool {
+    var buffer_names: std.StringHashMapUnmanaged(void) = .{};
+    defer buffer_names.deinit(allocator);
+    collectNodeBufferModuleObjectNames(allocator, ast, &buffer_names) catch return false;
+    if (buffer_names.count() == 0) return false;
+
+    var buffer_ctor_names: std.StringHashMapUnmanaged(void) = .{};
+    defer buffer_ctor_names.deinit(allocator);
+    collectNodeBufferCtorNames(allocator, ast, &buffer_names, &buffer_ctor_names) catch return false;
+    if (buffer_ctor_names.count() == 0) return false;
+
+    var dead_fallback_names: std.StringHashMapUnmanaged(void) = .{};
+    defer dead_fallback_names.deinit(allocator);
+
+    var changed = false;
+    for (ast.nodes.items, 0..) |node, i| {
+        if (node.tag != .if_statement) continue;
+        var caps: BufferCapabilitySet = .{};
+        if (!collectNodeBufferCapabilityCondition(ast, node.data.ternary.a, &buffer_ctor_names, &caps)) continue;
+        if (!caps.hasAll()) continue;
+        collectDeadAlternateCjsExportIdentifiers(allocator, ast, node.data.ternary.c, &dead_fallback_names) catch {};
+        const kept = singleBlockStatement(ast, node.data.ternary.b) orelse node.data.ternary.b;
+        const kept_ni = @intFromEnum(kept);
+        if (kept_ni >= ast.nodes.items.len) continue;
+        ast.nodes.items[i] = ast.nodes.items[kept_ni];
+        changed = true;
+    }
+    if (changed and dead_fallback_names.count() > 0) {
+        removeDeadFallbackSetupStatements(ast, &dead_fallback_names, &buffer_ctor_names);
+    }
+    return changed;
+}
+
+const BufferCapabilitySet = struct {
+    from: bool = false,
+    alloc: bool = false,
+    alloc_unsafe: bool = false,
+    alloc_unsafe_slow: bool = false,
+
+    fn add(self: *BufferCapabilitySet, name: []const u8) bool {
+        if (std.mem.eql(u8, name, "from")) {
+            self.from = true;
+            return true;
+        }
+        if (std.mem.eql(u8, name, "alloc")) {
+            self.alloc = true;
+            return true;
+        }
+        if (std.mem.eql(u8, name, "allocUnsafe")) {
+            self.alloc_unsafe = true;
+            return true;
+        }
+        if (std.mem.eql(u8, name, "allocUnsafeSlow")) {
+            self.alloc_unsafe_slow = true;
+            return true;
+        }
+        return false;
+    }
+
+    fn hasAll(self: BufferCapabilitySet) bool {
+        return self.from and self.alloc and self.alloc_unsafe and self.alloc_unsafe_slow;
+    }
+};
+
+fn collectNodeBufferCapabilityCondition(
+    ast: *const Ast,
+    idx: NodeIndex,
+    ctor_names: *const std.StringHashMapUnmanaged(void),
+    caps: *BufferCapabilitySet,
+) bool {
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return false;
+    const node = ast.nodes.items[@intFromEnum(idx)];
+    switch (node.tag) {
+        .parenthesized_expression => return collectNodeBufferCapabilityCondition(ast, node.data.unary.operand, ctor_names, caps),
+        .logical_expression => {
+            if (@as(Kind, @enumFromInt(node.data.binary.flags)) != .amp2) return false;
+            return collectNodeBufferCapabilityCondition(ast, node.data.binary.left, ctor_names, caps) and
+                collectNodeBufferCapabilityCondition(ast, node.data.binary.right, ctor_names, caps);
+        },
+        .static_member_expression => {
+            const parts = staticMemberParts(ast, idx) orelse return false;
+            const obj = ast.nodes.items[@intFromEnum(parts.object)];
+            if (obj.tag != .identifier_reference) return false;
+            if (!ctor_names.contains(ast.getText(obj.span))) return false;
+            const prop = ast.nodes.items[@intFromEnum(parts.property)];
+            if (prop.tag != .identifier_reference and prop.tag != .private_identifier) return false;
+            return caps.add(ast.getText(prop.span));
+        },
+        else => return false,
+    }
+}
+
+fn singleBlockStatement(ast: *const Ast, idx: NodeIndex) ?NodeIndex {
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return null;
+    const node = ast.nodes.items[@intFromEnum(idx)];
+    if (node.tag != .block_statement) return null;
+    const list = node.data.list;
+    if (list.len != 1) return null;
+    if (list.start >= ast.extra_data.items.len) return null;
+    return @enumFromInt(ast.extra_data.items[list.start]);
+}
+
+fn collectDeadAlternateCjsExportIdentifiers(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    idx: NodeIndex,
+    out: *std.StringHashMapUnmanaged(void),
+) std.mem.Allocator.Error!void {
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return;
+    const node = ast.nodes.items[@intFromEnum(idx)];
+    if (node.tag == .block_statement) {
+        const list = node.data.list;
+        if (list.start + list.len > ast.extra_data.items.len) return;
+        for (ast.extra_data.items[list.start .. list.start + list.len]) |raw| {
+            try collectDeadAlternateCjsExportIdentifiers(allocator, ast, @enumFromInt(raw), out);
+        }
+        return;
+    }
+    if (node.tag != .expression_statement) return;
+    const expr_idx = node.data.unary.operand;
+    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return;
+    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
+    if (expr.tag != .assignment_expression) return;
+    if (!isCjsNamedExportLhs(ast, expr.data.binary.left)) return;
+    const rhs_idx = expr.data.binary.right;
+    if (rhs_idx.isNone() or @intFromEnum(rhs_idx) >= ast.nodes.items.len) return;
+    const rhs = ast.nodes.items[@intFromEnum(rhs_idx)];
+    if (rhs.tag != .identifier_reference) return;
+    try out.put(allocator, ast.getText(rhs.span), {});
+}
+
+fn removeDeadFallbackSetupStatements(
+    ast: *Ast,
+    dead_names: *const std.StringHashMapUnmanaged(void),
+    buffer_ctor_names: *const std.StringHashMapUnmanaged(void),
+) void {
+    const root = programNode(ast) orelse return;
+    const list = root.data.list;
+    if (list.start + list.len > ast.extra_data.items.len) return;
+    for (ast.extra_data.items[list.start .. list.start + list.len]) |raw_stmt| {
+        const stmt_idx: NodeIndex = @enumFromInt(raw_stmt);
+        if (stmt_idx.isNone() or @intFromEnum(stmt_idx) >= ast.nodes.items.len) continue;
+        const stmt = ast.nodes.items[@intFromEnum(stmt_idx)];
+        if (!isDeadFallbackSetupStatement(ast, stmt, dead_names, buffer_ctor_names)) continue;
+        ast.nodes.items[@intFromEnum(stmt_idx)] = .{
+            .tag = .empty_statement,
+            .span = stmt.span,
+            .data = .{ .none = 0 },
+        };
+    }
+}
+
+fn isDeadFallbackSetupStatement(
+    ast: *const Ast,
+    stmt: Node,
+    dead_names: *const std.StringHashMapUnmanaged(void),
+    buffer_ctor_names: *const std.StringHashMapUnmanaged(void),
+) bool {
+    if (stmt.tag != .expression_statement) return false;
+    const expr_idx = stmt.data.unary.operand;
+    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return false;
+    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
+    if (expr.tag == .assignment_expression) {
+        const root = staticMemberRootIdentifier(ast, expr.data.binary.left) orelse return false;
+        return dead_names.contains(root);
+    }
+    if (expr.tag == .call_expression) {
+        return isDeadFallbackCopyCall(ast, expr, dead_names, buffer_ctor_names);
+    }
+    return false;
+}
+
+fn isDeadFallbackCopyCall(
+    ast: *const Ast,
+    call: Node,
+    dead_names: *const std.StringHashMapUnmanaged(void),
+    buffer_ctor_names: *const std.StringHashMapUnmanaged(void),
+) bool {
+    const e = call.data.extra;
+    if (!ast.hasExtra(e, 2)) return false;
+    const args_start = ast.readExtra(e, 1);
+    const args_len = ast.readExtra(e, 2);
+    if (args_len != 2 or args_start + args_len > ast.extra_data.items.len) return false;
+    const first_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start]);
+    const second_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start + 1]);
+    if (first_idx.isNone() or second_idx.isNone()) return false;
+    if (@intFromEnum(first_idx) >= ast.nodes.items.len or @intFromEnum(second_idx) >= ast.nodes.items.len) return false;
+    const first = ast.nodes.items[@intFromEnum(first_idx)];
+    const second = ast.nodes.items[@intFromEnum(second_idx)];
+    if (first.tag != .identifier_reference or second.tag != .identifier_reference) return false;
+    return buffer_ctor_names.contains(ast.getText(first.span)) and dead_names.contains(ast.getText(second.span));
+}
+
+fn staticMemberRootIdentifier(ast: *const Ast, idx: NodeIndex) ?[]const u8 {
+    var current = idx;
+    while (true) {
+        const parts = staticMemberParts(ast, current) orelse return null;
+        const obj = ast.nodes.items[@intFromEnum(parts.object)];
+        if (obj.tag == .identifier_reference) return ast.getText(obj.span);
+        current = parts.object;
+    }
+}
+
+pub fn collectNodeBufferModuleObjectNames(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    out: *std.StringHashMapUnmanaged(void),
+) std.mem.Allocator.Error!void {
+    const root = programNode(ast) orelse return;
+    const list = root.data.list;
+    if (list.start + list.len > ast.extra_data.items.len) return;
+    for (ast.extra_data.items[list.start .. list.start + list.len]) |raw_stmt| {
+        const stmt_idx: NodeIndex = @enumFromInt(raw_stmt);
+        try collectVarNamesMatchingInit(allocator, ast, stmt_idx, out, isRequireBufferCall);
+    }
+}
+
+fn collectNodeBufferCtorNames(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    buffer_names: *const std.StringHashMapUnmanaged(void),
+    out: *std.StringHashMapUnmanaged(void),
+) std.mem.Allocator.Error!void {
+    const root = programNode(ast) orelse return;
+    const list = root.data.list;
+    if (list.start + list.len > ast.extra_data.items.len) return;
+    for (ast.extra_data.items[list.start .. list.start + list.len]) |raw_stmt| {
+        const stmt_idx: NodeIndex = @enumFromInt(raw_stmt);
+        if (stmt_idx.isNone() or @intFromEnum(stmt_idx) >= ast.nodes.items.len) continue;
+        const stmt = ast.nodes.items[@intFromEnum(stmt_idx)];
+        if (stmt.tag != .variable_declaration) continue;
+        const e = stmt.data.extra;
+        if (!ast.hasExtra(e, 2)) continue;
+        const start = ast.readExtra(e, 1);
+        const len = ast.readExtra(e, 2);
+        if (start + len > ast.extra_data.items.len) continue;
+        for (ast.extra_data.items[start .. start + len]) |raw_decl| {
+            const decl_idx: NodeIndex = @enumFromInt(raw_decl);
+            if (decl_idx.isNone() or @intFromEnum(decl_idx) >= ast.nodes.items.len) continue;
+            const decl = ast.nodes.items[@intFromEnum(decl_idx)];
+            if (decl.tag != .variable_declarator) continue;
+            const de = decl.data.extra;
+            if (!ast.hasExtra(de, 2)) continue;
+            const name_idx: NodeIndex = @enumFromInt(ast.readExtra(de, 0));
+            const init_idx: NodeIndex = @enumFromInt(ast.readExtra(de, 2));
+            if (name_idx.isNone() or @intFromEnum(name_idx) >= ast.nodes.items.len) continue;
+            if (!isNodeBufferCtorRead(ast, init_idx, buffer_names)) continue;
+            const name = ast.nodes.items[@intFromEnum(name_idx)];
+            if (name.tag == .identifier_reference or name.tag == .binding_identifier or name.tag == .assignment_target_identifier) {
+                try out.put(allocator, ast.getText(name.span), {});
+            }
+        }
+    }
+}
+
+fn collectVarNamesMatchingInit(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    stmt_idx: NodeIndex,
+    out: *std.StringHashMapUnmanaged(void),
+    comptime predicate: fn (*const Ast, NodeIndex) bool,
+) std.mem.Allocator.Error!void {
+    if (stmt_idx.isNone() or @intFromEnum(stmt_idx) >= ast.nodes.items.len) return;
+    const stmt = ast.nodes.items[@intFromEnum(stmt_idx)];
+    if (stmt.tag != .variable_declaration) return;
+    const e = stmt.data.extra;
+    if (!ast.hasExtra(e, 2)) return;
+    const start = ast.readExtra(e, 1);
+    const len = ast.readExtra(e, 2);
+    if (start + len > ast.extra_data.items.len) return;
+    for (ast.extra_data.items[start .. start + len]) |raw_decl| {
+        const decl_idx: NodeIndex = @enumFromInt(raw_decl);
+        if (decl_idx.isNone() or @intFromEnum(decl_idx) >= ast.nodes.items.len) continue;
+        const decl = ast.nodes.items[@intFromEnum(decl_idx)];
+        if (decl.tag != .variable_declarator) continue;
+        const de = decl.data.extra;
+        if (!ast.hasExtra(de, 2)) continue;
+        const name_idx: NodeIndex = @enumFromInt(ast.readExtra(de, 0));
+        const init_idx: NodeIndex = @enumFromInt(ast.readExtra(de, 2));
+        if (!predicate(ast, init_idx)) continue;
+        if (name_idx.isNone() or @intFromEnum(name_idx) >= ast.nodes.items.len) continue;
+        const name = ast.nodes.items[@intFromEnum(name_idx)];
+        if (name.tag == .identifier_reference or name.tag == .binding_identifier or name.tag == .assignment_target_identifier) {
+            try out.put(allocator, ast.getText(name.span), {});
+        }
+    }
+}
+
+fn programNode(ast: *const Ast) ?Node {
+    if (ast.nodes.items.len == 0) return null;
+    const root = ast.nodes.items[ast.nodes.items.len - 1];
+    if (root.tag != .program) return null;
+    return root;
+}
+
+fn isRequireBufferCall(ast: *const Ast, idx: NodeIndex) bool {
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return false;
+    const node = ast.nodes.items[@intFromEnum(idx)];
+    if (node.tag != .call_expression) return false;
+    const e = node.data.extra;
+    if (!ast.hasExtra(e, 2)) return false;
+    const callee_idx: NodeIndex = @enumFromInt(ast.readExtra(e, 0));
+    if (callee_idx.isNone() or @intFromEnum(callee_idx) >= ast.nodes.items.len) return false;
+    const callee = ast.nodes.items[@intFromEnum(callee_idx)];
+    if (callee.tag != .identifier_reference or !std.mem.eql(u8, ast.getText(callee.span), "require")) return false;
+    const args_start = ast.readExtra(e, 1);
+    const args_len = ast.readExtra(e, 2);
+    if (args_len != 1 or args_start >= ast.extra_data.items.len) return false;
+    const arg_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start]);
+    if (arg_idx.isNone() or @intFromEnum(arg_idx) >= ast.nodes.items.len) return false;
+    const arg = ast.nodes.items[@intFromEnum(arg_idx)];
+    if (arg.tag != .string_literal) return false;
+    const spec = ast_mod.Ast.stripStringQuotes(ast.getText(arg.span));
+    return std.mem.eql(u8, spec, "buffer") or std.mem.eql(u8, spec, "node:buffer");
+}
+
+fn isNodeBufferCtorRead(
+    ast: *const Ast,
+    idx: NodeIndex,
+    buffer_names: *const std.StringHashMapUnmanaged(void),
+) bool {
+    const parts = staticMemberParts(ast, idx) orelse return false;
+    const obj = ast.nodes.items[@intFromEnum(parts.object)];
+    const prop = ast.nodes.items[@intFromEnum(parts.property)];
+    if (obj.tag != .identifier_reference) return false;
+    if (prop.tag != .identifier_reference and prop.tag != .private_identifier) return false;
+    return buffer_names.contains(ast.getText(obj.span)) and std.mem.eql(u8, ast.getText(prop.span), "Buffer");
+}
+
+pub fn isModuleExportsAssignedNodeBufferObject(
+    ast: *const Ast,
+    stmt: Node,
+    buffer_names: *const std.StringHashMapUnmanaged(void),
+) bool {
+    if (stmt.tag != .expression_statement) return false;
+    const expr_idx = stmt.data.unary.operand;
+    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return false;
+    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
+    if (expr.tag != .assignment_expression) return false;
+    if (!isModuleExportsLhs(ast, expr.data.binary.left)) return false;
+    const rhs_idx = expr.data.binary.right;
+    if (rhs_idx.isNone() or @intFromEnum(rhs_idx) >= ast.nodes.items.len) return false;
+    const rhs = ast.nodes.items[@intFromEnum(rhs_idx)];
+    return rhs.tag == .identifier_reference and buffer_names.contains(ast.getText(rhs.span));
+}
+
+fn isModuleExportsLhs(ast: *const Ast, idx: NodeIndex) bool {
+    const parts = staticMemberParts(ast, idx) orelse return false;
+    const obj = ast.nodes.items[@intFromEnum(parts.object)];
+    const prop = ast.nodes.items[@intFromEnum(parts.property)];
+    return obj.tag == .identifier_reference and
+        prop.tag == .identifier_reference and
+        std.mem.eql(u8, ast.getText(obj.span), "module") and
+        std.mem.eql(u8, ast.getText(prop.span), "exports");
+}
+
+fn isCjsNamedExportLhs(ast: *const Ast, idx: NodeIndex) bool {
+    const outer = staticMemberParts(ast, idx) orelse return false;
+    const prop = ast.nodes.items[@intFromEnum(outer.property)];
+    if (prop.tag != .identifier_reference and prop.tag != .private_identifier) return false;
+    const obj = ast.nodes.items[@intFromEnum(outer.object)];
+    if (obj.tag == .identifier_reference and std.mem.eql(u8, ast.getText(obj.span), "exports")) {
+        return true;
+    }
+    if (obj.tag != .static_member_expression) return false;
+    const inner = staticMemberParts(ast, outer.object) orelse return false;
+    const inner_obj = ast.nodes.items[@intFromEnum(inner.object)];
+    const inner_prop = ast.nodes.items[@intFromEnum(inner.property)];
+    return inner_obj.tag == .identifier_reference and
+        inner_prop.tag == .identifier_reference and
+        std.mem.eql(u8, ast.getText(inner_obj.span), "module") and
+        std.mem.eql(u8, ast.getText(inner_prop.span), "exports");
+}
+
+fn moduleExportsRequireSpanAt(ast: *const Ast, idx: NodeIndex) ?Span {
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return null;
+    const stmt = ast.nodes.items[@intFromEnum(idx)];
+    if (stmt.tag == .block_statement) {
+        const inner = singleBlockStatement(ast, idx) orelse return null;
+        return moduleExportsRequireSpanAt(ast, inner);
+    }
+    if (stmt.tag == .if_statement) {
+        const t = stmt.data.ternary;
+        if (moduleExportsRequireSpanAt(ast, t.b)) |span| return span;
+        if (!t.c.isNone()) return moduleExportsRequireSpanAt(ast, t.c);
+        return null;
+    }
+    if (stmt.tag != .expression_statement) return null;
+    const expr_idx = stmt.data.unary.operand;
+    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return null;
+    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
+    if (expr.tag != .assignment_expression) return null;
+    const op: Kind = @enumFromInt(expr.data.binary.flags);
+    if (op != .eq) return null;
+    if (!isModuleExportsLhs(ast, expr.data.binary.left)) return null;
+
+    const rhs_idx = expr.data.binary.right;
+    if (rhs_idx.isNone() or @intFromEnum(rhs_idx) >= ast.nodes.items.len) return null;
+    const rhs = ast.nodes.items[@intFromEnum(rhs_idx)];
+    if (rhs.tag != .call_expression) return null;
+    const e = rhs.data.extra;
+    if (!ast.hasExtra(e, 2)) return null;
+
+    const callee_idx = ast.readExtraNode(e, 0);
+    if (callee_idx.isNone() or @intFromEnum(callee_idx) >= ast.nodes.items.len) return null;
+    const callee = ast.nodes.items[@intFromEnum(callee_idx)];
+    if (callee.tag != .identifier_reference or !std.mem.eql(u8, ast.getText(callee.span), "require")) return null;
+
+    const args_start = ast.readExtra(e, 1);
+    const args_len = ast.readExtra(e, 2);
+    if (args_len != 1 or args_start >= ast.extra_data.items.len) return null;
+    const arg_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start]);
+    if (arg_idx.isNone() or @intFromEnum(arg_idx) >= ast.nodes.items.len) return null;
+    const arg = ast.nodes.items[@intFromEnum(arg_idx)];
+    if (arg.tag != .string_literal) return null;
+    return arg.span;
+}
+
+pub fn moduleExportsRequireTargetAt(m: *const Module, ast: *const Ast, idx: NodeIndex) ?ModuleIndex {
+    const span = moduleExportsRequireSpanAt(ast, idx) orelse return null;
+    for (m.import_records) |rec| {
+        if (rec.kind != .require) continue;
+        if (rec.resolved.isNone()) continue;
+        if (rec.span.start == span.start and rec.span.end == span.end) return rec.resolved;
+    }
+    return null;
+}
+
+pub fn moduleExportsRequireProxyMatches(
+    m: *const Module,
+    infos: StmtInfos,
+    stmt_idx: u32,
+    target: ModuleIndex,
+) bool {
+    if (stmt_idx >= infos.stmts.len) return false;
+    const ast = &(m.ast orelse return false);
+    const stmt_ni = infos.stmts[stmt_idx].node_idx;
+    if (stmt_ni >= ast.nodes.items.len) return false;
+    const proxy_target = moduleExportsRequireTargetAt(m, ast, @enumFromInt(stmt_ni)) orelse return false;
+    return @intFromEnum(proxy_target) == @intFromEnum(target);
+}
+
+fn staticMemberParts(ast: *const Ast, idx: NodeIndex) ?struct { object: NodeIndex, property: NodeIndex } {
+    if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return null;
+    const node = ast.nodes.items[@intFromEnum(idx)];
+    if (node.tag != .static_member_expression) return null;
+    const e = node.data.extra;
+    if (!ast.hasExtra(e, 1)) return null;
+    const obj_idx: NodeIndex = @enumFromInt(ast.readExtra(e, 0));
+    const prop_idx: NodeIndex = @enumFromInt(ast.readExtra(e, 1));
+    if (obj_idx.isNone() or prop_idx.isNone()) return null;
+    if (@intFromEnum(obj_idx) >= ast.nodes.items.len or @intFromEnum(prop_idx) >= ast.nodes.items.len) return null;
+    return .{ .object = obj_idx, .property = prop_idx };
+}


### PR DESCRIPTION
## 요약
- `tree_shaker.zig` 끝에 있던 CJS AST 패턴 매칭 helper를 `src/bundler/tree_shaker/cjs_patterns.zig`로 분리했습니다.
- Node Buffer capability branch folding, `module.exports = require(...)` proxy 판별, CJS named export LHS 판별을 한 모듈에 모았습니다.
- 처음에는 Node Buffer 전용 분리를 생각했지만, 실제 코드를 다시 읽어보니 require proxy helper와 `staticMemberParts`를 공유하고 있어 `cjs_patterns` 경계가 더 자연스럽다고 판단했습니다.
- `tree_shaker.zig`는 3211줄에서 2757줄로 줄었습니다.

## 검증
- `zig fmt --check src/bundler/tree_shaker.zig src/bundler/tree_shaker/cjs_patterns.zig`
- `git diff --check`
- `zig build test`
- `bun test --cwd tests/integration tests/tree-shake-precision.test.ts --timeout 10000`
- `zig build`
- `zig build napi`
- `bun run fmt:check`
- `bun run lint` (기존 warning 23개, error 0개)
- `zig build -Doptimize=ReleaseFast`
- `zig build test262`
- `.git/hooks/pre-push`