### PR TITLE
refactor: standalone CLI modes 분리

### DIFF
--- a/src/cli/standalone.zig
+++ b/src/cli/standalone.zig
@@ -1,0 +1,108 @@
+//! CLI modes that bypass the normal transpile/bundle pipeline.
+
+const std = @import("std");
+const lib = @import("zntc_lib");
+
+const Scanner = lib.lexer.Scanner;
+const runner = lib.test262.runner;
+
+pub fn runTest262(allocator: std.mem.Allocator, dir_path: ?[]const u8) !void {
+    const stdout = std.fs.File.stdout().deprecatedWriter();
+    const stderr = std.fs.File.stderr().deprecatedWriter();
+    const raw_dir = dir_path orelse {
+        try stderr.print("zntc: --test262 requires a directory path\n", .{});
+        std.process.exit(1);
+    };
+    const abs_path = try std.fs.cwd().realpathAlloc(allocator, raw_dir);
+    defer allocator.free(abs_path);
+
+    // test262 repo root 자동 감지: `test/` 와 `tools/` 가 둘 다 있으면 conformance `test/` 만 측정.
+    // tools/lint·generation 의 self-fixture (의도적으로 invalid 한 frontmatter 를 갖는 .js)
+    // 가 함께 walk 되어 fake fail 로 카운트되는 것을 막는다.
+    const test_sub = try std.fs.path.join(allocator, &.{ abs_path, "test" });
+    defer allocator.free(test_sub);
+    const tools_sub = try std.fs.path.join(allocator, &.{ abs_path, "tools" });
+    defer allocator.free(tools_sub);
+    const is_repo_root = blk: {
+        std.fs.accessAbsolute(test_sub, .{}) catch break :blk false;
+        std.fs.accessAbsolute(tools_sub, .{}) catch break :blk false;
+        break :blk true;
+    };
+
+    const walk_path = if (is_repo_root) test_sub else abs_path;
+    if (is_repo_root) {
+        try stdout.print("Detected test262 repo root — restricting walk to '{s}'\n", .{walk_path});
+    }
+    try stdout.print("Running Test262: {s}\n", .{walk_path});
+    const summary = try runner.runDirectory(allocator, walk_path, false);
+    try summary.print(stdout);
+    if (summary.failed > 0) std.process.exit(1);
+}
+
+pub fn runTokenize(allocator: std.mem.Allocator, input_file: ?[]const u8) !void {
+    const stdout = std.fs.File.stdout().deprecatedWriter();
+    const stderr = std.fs.File.stderr().deprecatedWriter();
+    const file_path = input_file orelse {
+        try stderr.print("zntc: --tokenize requires a file path\n", .{});
+        std.process.exit(1);
+    };
+    const source = try std.fs.cwd().readFileAlloc(allocator, file_path, 10 * 1024 * 1024);
+    defer allocator.free(source);
+
+    var scanner = try Scanner.init(allocator, source);
+    defer scanner.deinit();
+
+    while (true) {
+        try scanner.next();
+        const lc = scanner.getLineColumn(scanner.token.span.start);
+        try stdout.print("{d}:{d}\t{s}\t\"{s}\"\n", .{
+            lc.line + 1,
+            lc.column + 1,
+            scanner.token.kind.symbol(),
+            scanner.tokenText(),
+        });
+        if (scanner.token.kind == .eof) break;
+    }
+}
+
+pub const ServeOptions = struct {
+    is_bundle: bool,
+    input_file: ?[]const u8,
+    port: u16,
+    host: []const u8,
+    open: bool,
+    proxy: []const lib.server.DevServer.ProxyRule,
+};
+
+pub fn runServe(allocator: std.mem.Allocator, opts: ServeOptions) !void {
+    const stderr = std.fs.File.stderr().deprecatedWriter();
+
+    // --serve --bundle entry.ts → entry의 디렉토리를 root로 사용
+    const serve_dir: []const u8 = if (opts.is_bundle and opts.input_file != null) blk: {
+        break :blk std.fs.path.dirname(opts.input_file.?) orelse ".";
+    } else opts.input_file orelse ".";
+
+    const entry: ?[]const u8 = if (opts.is_bundle) blk: {
+        break :blk opts.input_file orelse {
+            try stderr.print("zntc: --serve --bundle requires an entry file path\n", .{});
+            std.process.exit(1);
+        };
+    } else null;
+
+    var dev_server = lib.server.DevServer.init(allocator, .{
+        .root_dir = serve_dir,
+        .port = opts.port,
+        .host = opts.host,
+        .open = opts.open,
+        .entry_point = entry,
+        .proxy = opts.proxy,
+    }) catch |err| {
+        try stderr.print("zntc: failed to start dev server: {}\n", .{err});
+        std.process.exit(1);
+    };
+    defer dev_server.deinit();
+    dev_server.start() catch |err| {
+        try stderr.print("zntc: dev server failed: {}\n", .{err});
+        std.process.exit(1);
+    };
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -7,12 +7,12 @@ const SemanticAnalyzer = lib.semantic.SemanticAnalyzer;
 const Transformer = lib.transformer.Transformer;
 const Codegen = lib.codegen.Codegen;
 const TsConfig = lib.config.TsConfig;
-const runner = lib.test262.runner;
 const Bundler = lib.bundler.Bundler;
 const BundleOptions = lib.bundler.BundleOptions;
 const emitter = lib.bundler.emitter;
 const app_command = @import("cli/app.zig");
 const bench_command = @import("cli/bench.zig");
+const standalone_modes = @import("cli/standalone.zig");
 /// Bun 스타일 crash report: panic 발생 시 배너 + 이슈 URL 출력 후 기본 경로로 abort.
 /// root 선언이라야 컴파일러가 safety panic을 여기로 보낸다.
 pub const panic = lib.crash_handler.panic;
@@ -1327,94 +1327,24 @@ pub fn main() !void {
 
     // --test262
     if (opts.is_test262) {
-        const dir_path = opts.test262_dir orelse {
-            try stderr.print("zntc: --test262 requires a directory path\n", .{});
-            std.process.exit(1);
-        };
-        const abs_path = try std.fs.cwd().realpathAlloc(allocator, dir_path);
-        defer allocator.free(abs_path);
-
-        // test262 repo root 자동 감지: `test/` 와 `tools/` 가 둘 다 있으면 conformance `test/` 만 측정.
-        // tools/lint·generation 의 self-fixture (의도적으로 invalid 한 frontmatter 를 갖는 .js)
-        // 가 함께 walk 되어 fake fail 로 카운트되는 것을 막는다.
-        const test_sub = try std.fs.path.join(allocator, &.{ abs_path, "test" });
-        defer allocator.free(test_sub);
-        const tools_sub = try std.fs.path.join(allocator, &.{ abs_path, "tools" });
-        defer allocator.free(tools_sub);
-        const is_repo_root = blk: {
-            std.fs.accessAbsolute(test_sub, .{}) catch break :blk false;
-            std.fs.accessAbsolute(tools_sub, .{}) catch break :blk false;
-            break :blk true;
-        };
-
-        const walk_path = if (is_repo_root) test_sub else abs_path;
-        if (is_repo_root) {
-            try stdout.print("Detected test262 repo root — restricting walk to '{s}'\n", .{walk_path});
-        }
-        try stdout.print("Running Test262: {s}\n", .{walk_path});
-        const summary = try runner.runDirectory(allocator, walk_path, false);
-        try summary.print(stdout);
-        if (summary.failed > 0) std.process.exit(1);
-        return;
+        return standalone_modes.runTest262(allocator, opts.test262_dir);
     }
 
     // --tokenize
     if (opts.is_tokenize) {
-        const file_path = opts.input_file orelse {
-            try stderr.print("zntc: --tokenize requires a file path\n", .{});
-            std.process.exit(1);
-        };
-        const source = try std.fs.cwd().readFileAlloc(allocator, file_path, 10 * 1024 * 1024);
-        defer allocator.free(source);
-
-        var scanner = try Scanner.init(allocator, source);
-        defer scanner.deinit();
-
-        while (true) {
-            try scanner.next();
-            const lc = scanner.getLineColumn(scanner.token.span.start);
-            try stdout.print("{d}:{d}\t{s}\t\"{s}\"\n", .{
-                lc.line + 1,
-                lc.column + 1,
-                scanner.token.kind.symbol(),
-                scanner.tokenText(),
-            });
-            if (scanner.token.kind == .eof) break;
-        }
-        return;
+        return standalone_modes.runTokenize(allocator, opts.input_file);
     }
 
     // --serve (정적 서버 또는 --bundle과 조합하여 번들 서빙)
     if (opts.is_serve) {
-        // --serve --bundle entry.ts → entry의 디렉토리를 root로 사용
-        const serve_dir: []const u8 = if (opts.is_bundle and opts.input_file != null) blk: {
-            break :blk std.fs.path.dirname(opts.input_file.?) orelse ".";
-        } else opts.input_file orelse ".";
-
-        const entry: ?[]const u8 = if (opts.is_bundle) blk: {
-            break :blk opts.input_file orelse {
-                try stderr.print("zntc: --serve --bundle requires an entry file path\n", .{});
-                std.process.exit(1);
-            };
-        } else null;
-
-        var dev_server = lib.server.DevServer.init(allocator, .{
-            .root_dir = serve_dir,
+        return standalone_modes.runServe(allocator, .{
+            .is_bundle = opts.is_bundle,
+            .input_file = opts.input_file,
             .port = opts.serve_port,
             .host = opts.serve_host,
             .open = opts.serve_open,
-            .entry_point = entry,
             .proxy = opts.proxy_list.items,
-        }) catch |err| {
-            try stderr.print("zntc: failed to start dev server: {}\n", .{err});
-            std.process.exit(1);
-        };
-        defer dev_server.deinit();
-        dev_server.start() catch |err| {
-            try stderr.print("zntc: dev server failed: {}\n", .{err});
-            std.process.exit(1);
-        };
-        return;
+        });
     }
 
     // tsconfig 로드 + 머지 — 번들/트랜스파일 양쪽에서 사용.


### PR DESCRIPTION
## 변경 사항
- `--test262`, `--tokenize`, `--serve` early-exit 실행 경로를 `src/cli/standalone.zig`로 분리했습니다.
- `main.zig`는 옵션 파싱 후 필요한 값만 넘기는 dispatch 역할만 유지했습니다.
- `main.zig` 라인 수를 2618줄에서 2548줄로 줄였습니다.

## 검증
- `zig fmt --check src/main.zig src/cli/standalone.zig`
- `git diff --check`
- `zig build test`
- `zig build`
- `bun test ./packages/core/test/cli/bootstrap.ts`
- `bun test ./packages/core/test/cli/transpile/diagnostics.ts`
- `bun test ./packages/core/test/cli/app-builder/dev-server.ts` (6 pass, 1 skip)
- `bun run fmt:check`
- `bun run lint` (기존 warning 23개, error 0)
- `zig build napi`
- `zig build -Doptimize=ReleaseFast`
- `zig build test262`
- `.git/hooks/pre-push`