### PR TITLE
refactor: emitter format wrapper 분리

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -54,6 +54,7 @@ const external_imports = @import("emitter/external_imports.zig");
 const line_wrap = @import("emitter/line_wrap.zig");
 const dead_store = @import("emitter/dead_store.zig");
 const entry_exports = @import("emitter/entry_exports.zig");
+const format_wrapper = @import("emitter/format_wrapper.zig");
 const purity = @import("purity.zig");
 
 pub const EmitOptions = struct {
@@ -2275,126 +2276,5 @@ fn addIdentityMappings(sm: *SourceMap.SourceMapBuilder, source_idx: u32, gen_sta
 }
 
 // --- 포맷별 래핑 (prologue/epilogue) ---
-
-/// 포맷별 prologue를 output에 추가한다.
-fn emitFormatPrologue(
-    output: *std.ArrayList(u8),
-    allocator: std.mem.Allocator,
-    format: types.Format,
-    global_name: ?[]const u8,
-    factory_fn: []const u8,
-    external_specifiers: []const []const u8,
-    ext_param_names: []const []const u8,
-) !void {
-    switch (format) {
-        .iife => {
-            if (global_name) |gn| {
-                if (std.mem.indexOfScalar(u8, gn, '.') != null) {
-                    try output.appendSlice(allocator, "/* [ZNTC WARNING] Dotted globalName (\"");
-                    try output.appendSlice(allocator, gn);
-                    try output.appendSlice(allocator, "\") is not yet supported. Use a simple name. */\n");
-                    try output.appendSlice(allocator, factory_fn);
-                } else {
-                    try output.appendSlice(allocator, "var ");
-                    try output.appendSlice(allocator, gn);
-                    try output.appendSlice(allocator, " = ");
-                    try output.appendSlice(allocator, factory_fn);
-                }
-            } else {
-                try output.appendSlice(allocator, factory_fn);
-            }
-        },
-        .umd => {
-            try output.appendSlice(allocator, "(function(root, factory) {\n");
-            try output.appendSlice(allocator, "  if (typeof define === \"function\" && define.amd) define([");
-            try writeDepArray(output, allocator, external_specifiers);
-            try output.appendSlice(allocator, "], factory);\n");
-            try output.appendSlice(allocator, "  else if (typeof module === \"object\" && module.exports) module.exports = factory(");
-            try writeCjsRequireList(output, allocator, external_specifiers);
-            try output.appendSlice(allocator, ");\n");
-            if (global_name) |gn| {
-                try output.appendSlice(allocator, "  else root.");
-                try output.appendSlice(allocator, gn);
-                try output.appendSlice(allocator, " = factory(");
-            } else {
-                try output.appendSlice(allocator, "  else factory(");
-            }
-            try writeGlobalsList(output, allocator, ext_param_names);
-            try output.appendSlice(allocator, ");\n");
-            try output.appendSlice(allocator, "})(typeof self !== \"undefined\" ? self : this, function(");
-            try writeParamList(output, allocator, ext_param_names);
-            try output.appendSlice(allocator, ") {\n");
-        },
-        .amd => {
-            try output.appendSlice(allocator, "define([");
-            try writeDepArray(output, allocator, external_specifiers);
-            try output.appendSlice(allocator, "], function(");
-            try writeParamList(output, allocator, ext_param_names);
-            try output.appendSlice(allocator, ") {\n");
-        },
-        .cjs => try output.appendSlice(allocator, "\"use strict\";\n"),
-        .esm => {},
-    }
-}
-
-// UMD/AMD prologue 헬퍼: 반복되는 리스트 출력을 공유.
-
-fn writeDepArray(output: *std.ArrayList(u8), allocator: std.mem.Allocator, specifiers: []const []const u8) !void {
-    for (specifiers, 0..) |spec, i| {
-        if (i > 0) try output.appendSlice(allocator, ", ");
-        try output.append(allocator, '"');
-        try output.appendSlice(allocator, spec);
-        try output.append(allocator, '"');
-    }
-}
-
-fn writeCjsRequireList(output: *std.ArrayList(u8), allocator: std.mem.Allocator, specifiers: []const []const u8) !void {
-    for (specifiers, 0..) |spec, i| {
-        if (i > 0) try output.appendSlice(allocator, ", ");
-        try output.appendSlice(allocator, "require(\"");
-        try output.appendSlice(allocator, spec);
-        try output.appendSlice(allocator, "\")");
-    }
-}
-
-fn writeGlobalsList(output: *std.ArrayList(u8), allocator: std.mem.Allocator, names: []const []const u8) !void {
-    for (names, 0..) |name, i| {
-        if (i > 0) try output.appendSlice(allocator, ", ");
-        try output.appendSlice(allocator, "root.");
-        try output.appendSlice(allocator, name);
-    }
-}
-
-fn writeParamList(output: *std.ArrayList(u8), allocator: std.mem.Allocator, names: []const []const u8) !void {
-    for (names, 0..) |name, i| {
-        if (i > 0) try output.appendSlice(allocator, ", ");
-        try output.appendSlice(allocator, name);
-    }
-}
-
-/// 포맷별 epilogue를 output에 추가한다.
-/// `iife_globals_args` 는 IIFE + external globals 매핑이 있을 때만 non-empty —
-/// `})(React, ReactDom);` 형태로 factory 호출 인자를 부착한다 (#1824).
-fn emitFormatEpilogue(
-    output: *std.ArrayList(u8),
-    allocator: std.mem.Allocator,
-    format: types.Format,
-    iife_globals_args: []const []const u8,
-) !void {
-    switch (format) {
-        .iife => {
-            if (iife_globals_args.len > 0) {
-                try output.appendSlice(allocator, "})(");
-                for (iife_globals_args, 0..) |arg, i| {
-                    if (i > 0) try output.appendSlice(allocator, ", ");
-                    try output.appendSlice(allocator, arg);
-                }
-                try output.appendSlice(allocator, ");\n");
-            } else {
-                try output.appendSlice(allocator, "})();\n");
-            }
-        },
-        .umd, .amd => try output.appendSlice(allocator, "});\n"),
-        .cjs, .esm => {},
-    }
-}
+const emitFormatPrologue = format_wrapper.emitFormatPrologue;
+const emitFormatEpilogue = format_wrapper.emitFormatEpilogue;

--- a/src/bundler/emitter/format_wrapper.zig
+++ b/src/bundler/emitter/format_wrapper.zig
@@ -1,0 +1,127 @@
+//! Output format prologue/epilogue writers.
+
+const std = @import("std");
+const types = @import("../types.zig");
+
+/// 포맷별 prologue를 output에 추가한다.
+pub fn emitFormatPrologue(
+    output: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+    format: types.Format,
+    global_name: ?[]const u8,
+    factory_fn: []const u8,
+    external_specifiers: []const []const u8,
+    ext_param_names: []const []const u8,
+) !void {
+    switch (format) {
+        .iife => {
+            if (global_name) |gn| {
+                if (std.mem.indexOfScalar(u8, gn, '.') != null) {
+                    try output.appendSlice(allocator, "/* [ZNTC WARNING] Dotted globalName (\"");
+                    try output.appendSlice(allocator, gn);
+                    try output.appendSlice(allocator, "\") is not yet supported. Use a simple name. */\n");
+                    try output.appendSlice(allocator, factory_fn);
+                } else {
+                    try output.appendSlice(allocator, "var ");
+                    try output.appendSlice(allocator, gn);
+                    try output.appendSlice(allocator, " = ");
+                    try output.appendSlice(allocator, factory_fn);
+                }
+            } else {
+                try output.appendSlice(allocator, factory_fn);
+            }
+        },
+        .umd => {
+            try output.appendSlice(allocator, "(function(root, factory) {\n");
+            try output.appendSlice(allocator, "  if (typeof define === \"function\" && define.amd) define([");
+            try writeDepArray(output, allocator, external_specifiers);
+            try output.appendSlice(allocator, "], factory);\n");
+            try output.appendSlice(allocator, "  else if (typeof module === \"object\" && module.exports) module.exports = factory(");
+            try writeCjsRequireList(output, allocator, external_specifiers);
+            try output.appendSlice(allocator, ");\n");
+            if (global_name) |gn| {
+                try output.appendSlice(allocator, "  else root.");
+                try output.appendSlice(allocator, gn);
+                try output.appendSlice(allocator, " = factory(");
+            } else {
+                try output.appendSlice(allocator, "  else factory(");
+            }
+            try writeGlobalsList(output, allocator, ext_param_names);
+            try output.appendSlice(allocator, ");\n");
+            try output.appendSlice(allocator, "})(typeof self !== \"undefined\" ? self : this, function(");
+            try writeParamList(output, allocator, ext_param_names);
+            try output.appendSlice(allocator, ") {\n");
+        },
+        .amd => {
+            try output.appendSlice(allocator, "define([");
+            try writeDepArray(output, allocator, external_specifiers);
+            try output.appendSlice(allocator, "], function(");
+            try writeParamList(output, allocator, ext_param_names);
+            try output.appendSlice(allocator, ") {\n");
+        },
+        .cjs => try output.appendSlice(allocator, "\"use strict\";\n"),
+        .esm => {},
+    }
+}
+
+// UMD/AMD prologue 헬퍼: 반복되는 리스트 출력을 공유.
+
+fn writeDepArray(output: *std.ArrayList(u8), allocator: std.mem.Allocator, specifiers: []const []const u8) !void {
+    for (specifiers, 0..) |spec, i| {
+        if (i > 0) try output.appendSlice(allocator, ", ");
+        try output.append(allocator, '"');
+        try output.appendSlice(allocator, spec);
+        try output.append(allocator, '"');
+    }
+}
+
+fn writeCjsRequireList(output: *std.ArrayList(u8), allocator: std.mem.Allocator, specifiers: []const []const u8) !void {
+    for (specifiers, 0..) |spec, i| {
+        if (i > 0) try output.appendSlice(allocator, ", ");
+        try output.appendSlice(allocator, "require(\"");
+        try output.appendSlice(allocator, spec);
+        try output.appendSlice(allocator, "\")");
+    }
+}
+
+fn writeGlobalsList(output: *std.ArrayList(u8), allocator: std.mem.Allocator, names: []const []const u8) !void {
+    for (names, 0..) |name, i| {
+        if (i > 0) try output.appendSlice(allocator, ", ");
+        try output.appendSlice(allocator, "root.");
+        try output.appendSlice(allocator, name);
+    }
+}
+
+fn writeParamList(output: *std.ArrayList(u8), allocator: std.mem.Allocator, names: []const []const u8) !void {
+    for (names, 0..) |name, i| {
+        if (i > 0) try output.appendSlice(allocator, ", ");
+        try output.appendSlice(allocator, name);
+    }
+}
+
+/// 포맷별 epilogue를 output에 추가한다.
+/// `iife_globals_args` 는 IIFE + external globals 매핑이 있을 때만 non-empty —
+/// `})(React, ReactDom);` 형태로 factory 호출 인자를 부착한다 (#1824).
+pub fn emitFormatEpilogue(
+    output: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+    format: types.Format,
+    iife_globals_args: []const []const u8,
+) !void {
+    switch (format) {
+        .iife => {
+            if (iife_globals_args.len > 0) {
+                try output.appendSlice(allocator, "})(");
+                for (iife_globals_args, 0..) |arg, i| {
+                    if (i > 0) try output.appendSlice(allocator, ", ");
+                    try output.appendSlice(allocator, arg);
+                }
+                try output.appendSlice(allocator, ");\n");
+            } else {
+                try output.appendSlice(allocator, "})();\n");
+            }
+        },
+        .umd, .amd => try output.appendSlice(allocator, "});\n"),
+        .cjs, .esm => {},
+    }
+}


### PR DESCRIPTION
## 요약
- 포맷별 prologue/epilogue 출력 헬퍼를 `src/bundler/emitter/format_wrapper.zig`로 분리했습니다.
- IIFE/UMD/AMD/CJS/ESM 래핑 문자열 출력 로직과 내부 리스트 writer를 함께 옮겼습니다.
- `emitter.zig`는 2400줄에서 2280줄로 줄었습니다.

## 검증
- `zig fmt --check src/bundler/emitter.zig src/bundler/emitter/format_wrapper.zig`
- `git diff --check`
- `zig build test`
- `zig build`
- `bun test --cwd tests/integration tests/bundle-smoke.test.ts tests/tree-shake-precision.test.ts --timeout 10000`
- `bun test --cwd tests/integration tests/esm-function-hoist.test.ts tests/esm-enum-hoisting.test.ts --timeout 10000`
- `bun run fmt:check`
- `bun run lint` (기존 warning 23개, error 0개)
- `zig build napi`
- `zig build -Doptimize=ReleaseFast`
- `zig build test262`
- `.git/hooks/pre-push`