### PR TITLE
refactor: parser expression type argument 헬퍼 분리

### DIFF
--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -25,86 +25,7 @@ const flow = @import("flow.zig");
 const scan_results_mod = @import("scan_results.zig");
 const import_scanner = @import("../bundler/import_scanner.zig");
 const profile = @import("../profile.zig");
-
-/// TypeScript의 canFollowTypeArgumentsInExpression 대응 (esbuild tsCanFollowTypeArgumentsInExpression).
-/// `f<Type>` 다음에 올 수 있는 토큰인지 판별한다.
-/// esbuild 3단계 로직:
-/// 1. 호출/템플릿 토큰 → true (확실히 type args)
-/// 2. `<`, `>`, `+`, `-` (및 `>`로 시작하는 복합 토큰) → false (확실히 비교)
-/// 3. newline_before || isBinaryOperator || !isStartOfExpression → true
-fn canFollowTypeArgumentsInExpression(self: *const Parser) bool {
-    const kind = self.current();
-    return switch (kind) {
-        // 호출, 멤버 접근, tagged template — 확실히 type args 뒤에 올 수 있음
-        .l_paren, .dot, .question_dot => true,
-        .no_substitution_template, .template_head => true,
-
-        // `<` 뒤에 또 `<`는 의미 없고, `>`는 re-scan된 `>>`와 모호하므로 불허.
-        // `+`, `-`는 이 컨텍스트에서 단항 연산자이므로 불허.
-        // `>`로 시작하는 복합 토큰(>=, >>, >>>, >>=, >>>=)도 불허 (esbuild 동일).
-        .l_angle,
-        .r_angle,
-        .plus,
-        .minus,
-        .gt_eq,
-        .shift_right,
-        .shift_right_eq,
-        .shift_right3,
-        .shift_right3_eq,
-        => false,
-
-        // 그 외: newline || binary operator || not start of expression → true
-        else => self.scanner.token.has_newline_before or
-            tsIsBinaryOperator(self, kind) or
-            !tsIsStartOfExpression(self, kind),
-    };
-}
-
-/// TypeScript 컴파일러의 isBinaryOperator 대응.
-/// 현재 토큰이 이항 연산자인지 판별한다.
-fn tsIsBinaryOperator(self: *const Parser, kind: Kind) bool {
-    if (kind == .kw_in) return self.ctx.allow_in;
-    if (getBinaryPrecedence(kind) > 0) return true;
-    if (kind == .identifier) {
-        const text = self.tokenText();
-        return std.mem.eql(u8, text, "as") or std.mem.eql(u8, text, "satisfies");
-    }
-    return false;
-}
-
-/// TypeScript 컴파일러의 isStartOfExpression 대응.
-/// 현재 토큰이 expression의 시작이 될 수 있는지 판별한다.
-fn tsIsStartOfExpression(self: *const Parser, kind: Kind) bool {
-    if (tsIsStartOfLeftHandSideExpression(kind)) return true;
-    return switch (kind) {
-        .plus, .minus, .tilde, .bang => true,
-        .kw_delete, .kw_typeof, .kw_void => true,
-        .plus2, .minus2 => true,
-        .l_angle => true,
-        .private_identifier => true,
-        .at => true,
-        .kw_await, .kw_yield => true,
-        else => tsIsBinaryOperator(self, kind),
-    };
-}
-
-/// TypeScript 컴파일러의 isStartOfLeftHandSideExpression 대응.
-fn tsIsStartOfLeftHandSideExpression(kind: Kind) bool {
-    return switch (kind) {
-        .kw_this, .kw_super => true,
-        .kw_null, .kw_true, .kw_false => true,
-        .string_literal,
-        .no_substitution_template,
-        .template_head,
-        => true,
-        .l_paren, .l_bracket, .l_curly => true,
-        .kw_function, .kw_class, .kw_new => true,
-        .slash, .slash_eq => true, // regex
-        .identifier => true,
-        .kw_import => true,
-        else => kind.isNumericLiteral(), // decimal, float, hex, bigint 등
-    };
-}
+const type_args = @import("expression/type_args.zig");
 
 /// 콤마 연산자(sequence expression)를 포함한 최상위 표현식 파싱.
 /// ECMAScript: Expression = AssignmentExpression (',' AssignmentExpression)*
@@ -611,7 +532,7 @@ fn parseBinaryExpression(self: *Parser, min_prec: u8) ParseError2!NodeIndex {
         // ECMAScript 13.7.4: for 초기화절에서 `in`은 for-in 키워드이지 연산자가 아니다.
         if (self.current() == .kw_in and !self.ctx.allow_in) break;
 
-        const prec = getBinaryPrecedence(self.current());
+        const prec = type_args.getBinaryPrecedence(self.current());
         if (prec == 0 or prec <= min_prec) break;
 
         // ECMAScript 12.6: unary expression ** exponentiation → SyntaxError
@@ -1070,7 +991,7 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
                 // TS generic type arguments: foo<Type>() or foo<<T>() => T>()
                 // Speculative parse: try parsing <Type>, check if followed by ( or `
                 // If not, restore state and let binary expression handle < as comparison.
-                if (!trySkipTypeArgsSpeculative(self, true, canFollowTypeArgumentsInExpression)) break;
+                if (!trySkipTypeArgsSpeculative(self, true, type_args.canFollowTypeArgumentsInExpression)) break;
             },
             .bang => {
                 // TS non-null assertion: expr!
@@ -1169,7 +1090,7 @@ fn parseNewCallee(self: *Parser) ParseError2!NodeIndex {
         const span = self.currentSpan();
         try self.advance(); // skip 'new'
         const callee = try parseNewCallee(self);
-        _ = trySkipTypeArgsSpeculative(self, true, canFollowTypeArgumentsInExpression);
+        _ = trySkipTypeArgsSpeculative(self, true, type_args.canFollowTypeArgumentsInExpression);
         if (self.current() == .l_paren) {
             try self.advance();
             const arg_list = try parseArgumentList(self);
@@ -1360,7 +1281,7 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
             const callee = try parseNewCallee(self);
 
             // TS/Flow: new X<T>() — type argument를 speculatively 파싱하여 skip
-            _ = trySkipTypeArgsSpeculative(self, true, canFollowTypeArgumentsInExpression);
+            _ = trySkipTypeArgsSpeculative(self, true, type_args.canFollowTypeArgumentsInExpression);
 
             // 인자: (args) — 있으면 소비, 없으면 인자 없는 new (new Foo)
             if (self.current() == .l_paren) {
@@ -1965,28 +1886,6 @@ pub fn parsePropertyKey(self: *Parser) ParseError2!NodeIndex {
             return try self.ast.addNode(.{ .tag = .invalid, .span = span, .data = .{ .none = 0 } });
         },
     }
-}
-
-// ================================================================
-// 연산자 우선순위
-// ================================================================
-
-fn getBinaryPrecedence(kind: Kind) u8 {
-    return switch (kind) {
-        .pipe2 => 1, // ||
-        .question2 => 1, // ??
-        .amp2 => 2, // &&
-        .pipe => 3, // |
-        .caret => 4, // ^
-        .amp => 5, // &
-        .eq2, .neq, .eq3, .neq2 => 6, // == != === !==
-        .l_angle, .r_angle, .lt_eq, .gt_eq, .kw_instanceof, .kw_in => 7, // < > <= >= instanceof in
-        .shift_left, .shift_right, .shift_right3 => 8, // << >> >>>
-        .plus, .minus => 9, // + -
-        .star, .slash, .percent => 10, // * / %
-        .star2 => 11, // ** (우결합)
-        else => 0, // 이항 연산자 아님
-    };
 }
 
 /// TS type assertion: <T>expr → expr (타입 스트리핑)

--- a/src/parser/expression/type_args.zig
+++ b/src/parser/expression/type_args.zig
@@ -1,0 +1,105 @@
+//! TypeScript expression type-argument disambiguation helpers.
+
+const std = @import("std");
+const token_mod = @import("../../lexer/token.zig");
+const Kind = token_mod.Kind;
+const Parser = @import("../parser.zig").Parser;
+
+/// TypeScript의 canFollowTypeArgumentsInExpression 대응 (esbuild tsCanFollowTypeArgumentsInExpression).
+/// `f<Type>` 다음에 올 수 있는 토큰인지 판별한다.
+/// esbuild 3단계 로직:
+/// 1. 호출/템플릿 토큰 -> true (확실히 type args)
+/// 2. `<`, `>`, `+`, `-` (및 `>`로 시작하는 복합 토큰) -> false (확실히 비교)
+/// 3. newline_before || isBinaryOperator || !isStartOfExpression -> true
+pub fn canFollowTypeArgumentsInExpression(self: *const Parser) bool {
+    const kind = self.current();
+    return switch (kind) {
+        // 호출, 멤버 접근, tagged template - 확실히 type args 뒤에 올 수 있음
+        .l_paren, .dot, .question_dot => true,
+        .no_substitution_template, .template_head => true,
+
+        // `<` 뒤에 또 `<`는 의미 없고, `>`는 re-scan된 `>>`와 모호하므로 불허.
+        // `+`, `-`는 이 컨텍스트에서 단항 연산자이므로 불허.
+        // `>`로 시작하는 복합 토큰(>=, >>, >>>, >>=, >>>=)도 불허 (esbuild 동일).
+        .l_angle,
+        .r_angle,
+        .plus,
+        .minus,
+        .gt_eq,
+        .shift_right,
+        .shift_right_eq,
+        .shift_right3,
+        .shift_right3_eq,
+        => false,
+
+        // 그 외: newline || binary operator || not start of expression -> true
+        else => self.scanner.token.has_newline_before or
+            tsIsBinaryOperator(self, kind) or
+            !tsIsStartOfExpression(self, kind),
+    };
+}
+
+/// TypeScript 컴파일러의 isBinaryOperator 대응.
+/// 현재 토큰이 이항 연산자인지 판별한다.
+fn tsIsBinaryOperator(self: *const Parser, kind: Kind) bool {
+    if (kind == .kw_in) return self.ctx.allow_in;
+    if (getBinaryPrecedence(kind) > 0) return true;
+    if (kind == .identifier) {
+        const text = self.tokenText();
+        return std.mem.eql(u8, text, "as") or std.mem.eql(u8, text, "satisfies");
+    }
+    return false;
+}
+
+/// TypeScript 컴파일러의 isStartOfExpression 대응.
+/// 현재 토큰이 expression의 시작이 될 수 있는지 판별한다.
+fn tsIsStartOfExpression(self: *const Parser, kind: Kind) bool {
+    if (tsIsStartOfLeftHandSideExpression(kind)) return true;
+    return switch (kind) {
+        .plus, .minus, .tilde, .bang => true,
+        .kw_delete, .kw_typeof, .kw_void => true,
+        .plus2, .minus2 => true,
+        .l_angle => true,
+        .private_identifier => true,
+        .at => true,
+        .kw_await, .kw_yield => true,
+        else => tsIsBinaryOperator(self, kind),
+    };
+}
+
+/// TypeScript 컴파일러의 isStartOfLeftHandSideExpression 대응.
+fn tsIsStartOfLeftHandSideExpression(kind: Kind) bool {
+    return switch (kind) {
+        .kw_this, .kw_super => true,
+        .kw_null, .kw_true, .kw_false => true,
+        .string_literal,
+        .no_substitution_template,
+        .template_head,
+        => true,
+        .l_paren, .l_bracket, .l_curly => true,
+        .kw_function, .kw_class, .kw_new => true,
+        .slash, .slash_eq => true, // regex
+        .identifier => true,
+        .kw_import => true,
+        else => kind.isNumericLiteral(), // decimal, float, hex, bigint 등
+    };
+}
+
+/// Binary expression precedence used by the expression parser.
+pub fn getBinaryPrecedence(kind: Kind) u8 {
+    return switch (kind) {
+        .pipe2 => 1, // ||
+        .question2 => 1, // ??
+        .amp2 => 2, // &&
+        .pipe => 3, // |
+        .caret => 4, // ^
+        .amp => 5, // &
+        .eq2, .neq, .eq3, .neq2 => 6, // == != === !==
+        .l_angle, .r_angle, .lt_eq, .gt_eq, .kw_instanceof, .kw_in => 7, // < > <= >= instanceof in
+        .shift_left, .shift_right, .shift_right3 => 8, // << >> >>>
+        .plus, .minus => 9, // + -
+        .star, .slash, .percent => 10, // * / %
+        .star2 => 11, // ** (우결합)
+        else => 0, // 이항 연산자 아님
+    };
+}


### PR DESCRIPTION
## 요약
- `parser/expression.zig`의 TypeScript type argument follow 판정 헬퍼를 `parser/expression/type_args.zig`로 분리했습니다.
- binary precedence 판정도 같은 모듈로 옮겨 type argument disambiguation과 expression binary parser가 같은 기준을 공유하게 했습니다.
- TSX generic arrow 파싱처럼 Parser 상태 결합이 큰 영역은 이번 PR에서 제외했습니다.

## 검증
- `zig fmt --check src/parser/expression.zig src/parser/expression/type_args.zig`
- `git diff --check`
- `zig build test`
- `zig build`
- `zig build napi`
- `bun test ./packages/core/test/cli/transpile.ts`
- `bun test ./packages/core/test/core/api/jsx.ts`
- `bun test ./packages/core/test/core/plugin-onload-loader/parser-modes.ts`
- `bun test ./packages/core/test/core/edge-cases/transpile.ts`
- `bun run fmt:check`
- `bun run lint` (기존 warning 23개, error 0개)
- `zig build -Doptimize=ReleaseFast`
- `zig build test262`
- `zig build wasm`
- `.git/hooks/pre-push`

참고: 여러 독립 core 테스트 파일을 한 `bun test` 프로세스에 섞어 실행하면 공용 `afterAll(close)` 순서 때문에 `@zntc/core: not initialized`가 발생할 수 있어, 관련 파일은 각각 단독 프로세스로 재실행해 통과를 확인했습니다.