### PR TITLE
refactor: regexp 문자 헬퍼 분리

### DIFF
--- a/src/regexp/char_helpers.zig
+++ b/src/regexp/char_helpers.zig
@@ -1,0 +1,73 @@
+//! Character helpers shared by the regular-expression parser.
+
+const std = @import("std");
+
+pub fn isHexDigit(c: u8) bool {
+    return std.ascii.isHex(c);
+}
+
+pub fn isSyntaxChar(c: u8) bool {
+    return switch (c) {
+        '^', '$', '\\', '.', '*', '+', '?', '(', ')', '[', ']', '{', '}', '|', '/' => true,
+        else => false,
+    };
+}
+
+pub fn isModifierChar(c: u8) bool {
+    return c == 'i' or c == 'm' or c == 's';
+}
+
+/// modifier 문자를 비트로 변환한다 (i=1, m=2, s=4).
+pub fn modifierBit(c: u8) u8 {
+    return switch (c) {
+        'i' => 1,
+        'm' => 2,
+        's' => 4,
+        else => 0,
+    };
+}
+
+/// v-flag: character class 내에서 리터럴로 사용할 수 없는 문법 문자.
+pub fn isClassSetSyntaxChar(c: u8) bool {
+    return switch (c) {
+        '(', ')', '[', ']', '{', '}', '/', '-', '\\', '|' => true,
+        else => false,
+    };
+}
+
+/// v-flag: 예약된 이중 구두점 (&&, !!, ## 등).
+/// 두 문자가 같고 예약 목록에 있으면 true.
+pub fn isClassSetReservedDoublePunct(c1: u8, c2: u8) bool {
+    return c1 == c2 and switch (c1) {
+        '&', '!', '#', '$', '%', '*', '+', ',', '.', ':', ';', '<', '=', '>', '?', '@', '^', '`', '~' => true,
+        else => false,
+    };
+}
+
+/// 16진수 문자를 값으로 변환한다.
+pub fn hexDigitValue(c: u8) u32 {
+    return switch (c) {
+        '0'...'9' => c - '0',
+        'a'...'f' => c - 'a' + 10,
+        'A'...'F' => c - 'A' + 10,
+        else => 0,
+    };
+}
+
+/// 소스의 [start, end) 범위를 16진수로 해석하여 값을 반환한다.
+pub fn computeHexValue(source: []const u8, start: u32, end: u32) u32 {
+    var val: u32 = 0;
+    for (source[start..end]) |c| {
+        val = val *| 16 +| hexDigitValue(c);
+    }
+    return val;
+}
+
+/// 소스의 [start, end) 범위를 8진수로 해석하여 값을 반환한다.
+pub fn computeOctalValue(source: []const u8, start: u32, end: u32) u32 {
+    var val: u32 = 0;
+    for (source[start..end]) |c| {
+        val = val *| 8 +| (c - '0');
+    }
+    return val;
+}

--- a/src/regexp/parser.zig
+++ b/src/regexp/parser.zig
@@ -13,6 +13,7 @@
 //! 참고: references/oxc/crates/oxc_regular_expression/src/parser
 
 const std = @import("std");
+const char_helpers = @import("char_helpers.zig");
 const flags_mod = @import("flags.zig");
 const Flags = flags_mod.Flags;
 
@@ -21,7 +22,6 @@ pub const ast = @import("ast.zig");
 
 /// 유니코드 프로퍼티 검증 테이블.
 pub const unicode_property = @import("unicode_property.zig");
-
 /// 렉서의 유니코드 식별자 판별 + UTF-8 디코딩.
 const unicode = @import("../lexer/unicode.zig");
 
@@ -745,7 +745,7 @@ pub fn PatternParser(comptime emit_ast: bool) type {
                         while (!self.isEnd() and self.peek() >= '0' and self.peek() <= '7') {
                             self.advance();
                         }
-                        const val = computeOctalValue(self.source, octal_start, self.pos);
+                        const val = char_helpers.computeOctalValue(self.source, octal_start, self.pos);
                         self.setClassValue(val);
                         if (emit_ast) {
                             self.last_node = self.addNode(.character, .{
@@ -781,7 +781,7 @@ pub fn PatternParser(comptime emit_ast: bool) type {
                             }, .{ 'x', @intFromEnum(ast.CharacterKind.identifier), 0 });
                         }
                     } else {
-                        const val = computeHexValue(self.source, hex_start, self.pos);
+                        const val = char_helpers.computeHexValue(self.source, hex_start, self.pos);
                         self.setClassValue(val);
                         if (emit_ast) {
                             self.last_node = self.addNode(.character, .{
@@ -801,7 +801,7 @@ pub fn PatternParser(comptime emit_ast: bool) type {
                             self.setError("invalid unicode escape in regular expression");
                             return false;
                         }
-                        const val = computeHexValue(self.source, hex_start, self.pos - 1);
+                        const val = char_helpers.computeHexValue(self.source, hex_start, self.pos - 1);
                         // \u{...} codepoint 범위 검증: U+0000 ~ U+10FFFF
                         if (val > 0x10FFFF) {
                             self.setError("unicode codepoint must not be greater than 0x10FFFF");
@@ -829,7 +829,7 @@ pub fn PatternParser(comptime emit_ast: bool) type {
                                 }, .{ 'u', @intFromEnum(ast.CharacterKind.identifier), 0 });
                             }
                         } else {
-                            const val = computeHexValue(self.source, hex_start, self.pos);
+                            const val = char_helpers.computeHexValue(self.source, hex_start, self.pos);
                             self.setClassValue(val);
                             if (emit_ast) {
                                 self.last_node = self.addNode(.character, .{
@@ -1007,7 +1007,7 @@ pub fn PatternParser(comptime emit_ast: bool) type {
                 else => {
                     if (self.flags.hasUnicodeMode()) {
                         // SyntaxCharacter + '-' (ClassEscape: \- → dash in character class)
-                        if (isSyntaxChar(c) or c == '-') {
+                        if (char_helpers.isSyntaxChar(c) or c == '-') {
                             self.advance();
                             self.setClassValue(c);
                             if (emit_ast) {
@@ -1315,8 +1315,8 @@ pub fn PatternParser(comptime emit_ast: bool) type {
             var enabling: u8 = 0;
 
             // positive modifiers
-            while (!self.isEnd() and isModifierChar(self.peek())) {
-                const bit = modifierBit(self.peek());
+            while (!self.isEnd() and char_helpers.isModifierChar(self.peek())) {
+                const bit = char_helpers.modifierBit(self.peek());
                 if (seen & bit != 0) {
                     self.setError("duplicate modifier in group");
                     return null;
@@ -1330,8 +1330,8 @@ pub fn PatternParser(comptime emit_ast: bool) type {
             var disabling: u8 = 0;
             if (!self.isEnd() and self.peek() == '-') {
                 self.advance();
-                while (!self.isEnd() and isModifierChar(self.peek())) {
-                    const bit = modifierBit(self.peek());
+                while (!self.isEnd() and char_helpers.isModifierChar(self.peek())) {
+                    const bit = char_helpers.modifierBit(self.peek());
                     if (seen & bit != 0) {
                         self.setError("modifier already set in group");
                         return null;
@@ -1684,7 +1684,7 @@ pub fn PatternParser(comptime emit_ast: bool) type {
             while (i < count) : (i += 1) {
                 if (self.isEnd()) return false;
                 const hc = self.peek();
-                if (!isHexDigit(hc)) return false;
+                if (!char_helpers.isHexDigit(hc)) return false;
                 self.advance();
             }
             return true;
@@ -1693,7 +1693,7 @@ pub fn PatternParser(comptime emit_ast: bool) type {
         fn eatHexDigitsUntil(self: *Self, terminator: u8) bool {
             var count: u32 = 0;
             while (!self.isEnd() and self.peek() != terminator) {
-                if (!isHexDigit(self.peek())) return false;
+                if (!char_helpers.isHexDigit(self.peek())) return false;
                 self.advance();
                 count += 1;
             }
@@ -1906,11 +1906,11 @@ pub fn PatternParser(comptime emit_ast: bool) type {
             }
 
             // v-flag 문법 문자는 리터럴로 사용 불가
-            if (isClassSetSyntaxChar(ch)) return false;
+            if (char_helpers.isClassSetSyntaxChar(ch)) return false;
 
             // 예약된 이중 구두점 방지 (&&, !!, ## 등)
             if (self.pos + 1 < self.source.len) {
-                if (isClassSetReservedDoublePunct(ch, self.source[self.pos + 1])) return false;
+                if (char_helpers.isClassSetReservedDoublePunct(ch, self.source[self.pos + 1])) return false;
             }
 
             self.advance();
@@ -1996,78 +1996,4 @@ pub fn PatternParser(comptime emit_ast: bool) type {
             }
         }
     };
-}
-
-// ================================================================
-// 모듈 스코프 헬퍼 함수
-// ================================================================
-
-fn isHexDigit(c: u8) bool {
-    return std.ascii.isHex(c);
-}
-
-fn isSyntaxChar(c: u8) bool {
-    return switch (c) {
-        '^', '$', '\\', '.', '*', '+', '?', '(', ')', '[', ']', '{', '}', '|', '/' => true,
-        else => false,
-    };
-}
-
-fn isModifierChar(c: u8) bool {
-    return c == 'i' or c == 'm' or c == 's';
-}
-
-/// modifier 문자를 비트로 변환한다 (i=1, m=2, s=4).
-fn modifierBit(c: u8) u8 {
-    return switch (c) {
-        'i' => 1,
-        'm' => 2,
-        's' => 4,
-        else => 0,
-    };
-}
-
-/// v-flag: character class 내에서 리터럴로 사용할 수 없는 문법 문자.
-fn isClassSetSyntaxChar(c: u8) bool {
-    return switch (c) {
-        '(', ')', '[', ']', '{', '}', '/', '-', '\\', '|' => true,
-        else => false,
-    };
-}
-
-/// v-flag: 예약된 이중 구두점 (&&, !!, ## 등).
-/// 두 문자가 같고 예약 목록에 있으면 true.
-fn isClassSetReservedDoublePunct(c1: u8, c2: u8) bool {
-    return c1 == c2 and switch (c1) {
-        '&', '!', '#', '$', '%', '*', '+', ',', '.', ':', ';', '<', '=', '>', '?', '@', '^', '`', '~' => true,
-        else => false,
-    };
-}
-
-/// 16진수 문자를 값으로 변환한다.
-fn hexDigitValue(c: u8) u32 {
-    return switch (c) {
-        '0'...'9' => c - '0',
-        'a'...'f' => c - 'a' + 10,
-        'A'...'F' => c - 'A' + 10,
-        else => 0,
-    };
-}
-
-/// 소스의 [start, end) 범위를 16진수로 해석하여 값을 반환한다.
-fn computeHexValue(source: []const u8, start: u32, end: u32) u32 {
-    var val: u32 = 0;
-    for (source[start..end]) |c| {
-        val = val *| 16 +| hexDigitValue(c);
-    }
-    return val;
-}
-
-/// 소스의 [start, end) 범위를 8진수로 해석하여 값을 반환한다.
-fn computeOctalValue(source: []const u8, start: u32, end: u32) u32 {
-    var val: u32 = 0;
-    for (source[start..end]) |c| {
-        val = val *| 8 +| (c - '0');
-    }
-    return val;
 }


### PR DESCRIPTION
## 요약
- `regexp/parser.zig` 하단의 문자 판정/숫자 변환 helper를 `src/regexp/char_helpers.zig`로 분리했습니다.
- regexp 파서 본체는 기존 동작을 유지하고 helper 호출만 새 모듈 경유로 바꿨습니다.
- `src/regexp/parser.zig` 라인 수를 2073줄에서 1999줄로 줄였습니다.

## 검증
- `git diff --check`
- `zig build test`
- `zig build`
- `zig build napi`
- `bun test ./tests/integration/tests/bundle-smoke.test.ts`
- `bun test ./packages/react-native/src/plugins/escape-regex.test.ts`
- `bun run fmt:check`
- `bun run lint` (기존 warning 23개, error 0개)
- `zig build -Doptimize=ReleaseFast`
- `zig build test262`
- `zig build wasm`
- `.git/hooks/pre-push`