### PR TITLE
feat(es5): Hermes named capture group regex 다운레벨 (#1063)

### DIFF
--- a/packages/core/test/cli/bundle/syntax-targets.ts
+++ b/packages/core/test/cli/bundle/syntax-targets.ts
@@ -1,4 +1,5 @@
 import './syntax-targets/decorators';
 import './syntax-targets/jsx-in-js';
+import './syntax-targets/named-capture-regex';
 import './syntax-targets/target-and-browserslist';
 import './syntax-targets/verbatim-module-syntax';

--- a/packages/core/test/cli/bundle/syntax-targets/named-capture-regex.ts
+++ b/packages/core/test/cli/bundle/syntax-targets/named-capture-regex.ts
@@ -2,6 +2,7 @@ import {
   describe,
   test,
   expect,
+  execSync,
   mkdtempSync,
   writeFileSync,
   rmSync,
@@ -99,5 +100,55 @@ describe('CLI: bundle syntax and targets > named capture regex (#1063)', () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+// __wrapRegExp helper runtime semantic — Babel `_wrapRegExp` 와 동일 코드라 동등 동작 보장.
+// transpile + Node 로 실제 실행해서 결과 검증. 회귀 발생 시 이 case 들이 fail.
+// reference: babel/packages/babel-runtime/test/unittests/wrapRegExp.test.js
+describe('CLI: named capture regex (#1063) > runtime semantic (Babel parity)', () => {
+  function buildAndRun(entrySource: string): string {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-cli-wrapregex-rt-'));
+    try {
+      writeFileSync(join(dir, 'entry.ts'), entrySource);
+      const out = join(dir, 'out.js');
+      const { exitCode } = runCli(['--bundle', join(dir, 'entry.ts'), '-o', out, '--target=es5']);
+      expect(exitCode).toBe(0);
+      return execSync(`node ${out}`, { encoding: 'utf8' }).trim();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  test('$<UNKNOWN> — 등록 안 된 group 은 empty 로 substitute', () => {
+    const result = buildAndRun(
+      'const re = /(?<group>foo)/;\n' + 'console.log("foobar".replace(re, "$<UNKNOWN>"));',
+    );
+    // foo 가 매칭, $<UNKNOWN> 은 empty → "foo" 가 "" 로 대체
+    expect(result).toBe('bar');
+  });
+
+  test('$<__proto__> — prototype pollution 방어 (groups map 이 Object.create(null))', () => {
+    const result = buildAndRun(
+      'const re = /(?<group>foo)/;\n' + 'console.log("foobar".replace(re, "$<__proto__>"));',
+    );
+    // __proto__ 는 groups 에 등록 안 됨 → empty substitute → "foo" 제거 → "bar"
+    expect(result).toBe('bar');
+  });
+
+  test('$<hasOwnProperty> — reserved name 도 일반 group 처럼 처리', () => {
+    const result = buildAndRun(
+      'const re = /(?<group>foo)/;\n' + 'console.log("foobar".replace(re, "$<hasOwnProperty>"));',
+    );
+    // hasOwnProperty 도 groups 에 없음 → empty → "bar"
+    expect(result).toBe('bar');
+  });
+
+  test('$<_$> — 특수 문자 group name 정상 substitute', () => {
+    const result = buildAndRun(
+      'const re = /(?<_$>foo)/;\n' + 'console.log("foobar".replace(re, "$<_$>$<_$>"));',
+    );
+    // _$ 가 등록된 group → 두 번 치환 → "foofoobar"
+    expect(result).toBe('foofoobar');
   });
 });

--- a/packages/core/test/cli/bundle/syntax-targets/named-capture-regex.ts
+++ b/packages/core/test/cli/bundle/syntax-targets/named-capture-regex.ts
@@ -1,0 +1,103 @@
+import {
+  describe,
+  test,
+  expect,
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  tmpdir,
+  join,
+  runCli,
+} from '../../helpers';
+
+// #1063: Hermes / ES5 target 에서 named capture group `(?<NAME>...)` 다운레벨.
+// regex pattern strip + `__wrapRegExp` 로 wrap → `match.groups.NAME` /
+// `replace(re, "$<NAME>")` semantic 보존.
+describe('CLI: bundle syntax and targets > named capture regex (#1063)', () => {
+  test('--target=es5 → 패턴 strip + __wrapRegExp wrap + helper inject', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-cli-named-cap-'));
+    try {
+      writeFileSync(
+        join(dir, 'entry.ts'),
+        'const re = /(?<year>\\d{4})/; const m = re.exec("2026"); console.log(m?.groups?.year);',
+      );
+      const { stdout, exitCode } = runCli(['--bundle', join(dir, 'entry.ts'), '--target=es5']);
+      expect(exitCode).toBe(0);
+      // pattern 자체엔 named group 안 남음
+      expect(stdout).not.toContain('(?<year>');
+      // wrap helper 호출이 들어감
+      expect(stdout).toContain('__wrapRegExp');
+      // helper 정의도 inject (RegExp 상속 클래스)
+      expect(stdout).toContain('BabelRegExp');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('--target=es5 + --minify → short helper name ($wR) 일관 사용', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-cli-named-cap-min-'));
+    try {
+      writeFileSync(
+        join(dir, 'entry.ts'),
+        'const re = /(?<word>\\w+)/; console.log(re.exec("hi")?.groups?.word);',
+      );
+      const { stdout, exitCode } = runCli([
+        '--bundle',
+        join(dir, 'entry.ts'),
+        '--target=es5',
+        '--minify',
+      ]);
+      expect(exitCode).toBe(0);
+      // minify 시 short name $wR 사용 — base name __wrapRegExp 는 안 보여야 (inject + 사용처 모두 short)
+      expect(stdout).toContain('$wR');
+      expect(stdout).not.toContain('__wrapRegExp');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('named group 없으면 wrap 호출 없음 (불필요 helper inject 회피)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-cli-named-cap-none-'));
+    try {
+      writeFileSync(join(dir, 'entry.ts'), 'const re = /(\\d+)/; console.log(re.test("123"));');
+      const { stdout, exitCode } = runCli(['--bundle', join(dir, 'entry.ts'), '--target=es5']);
+      expect(exitCode).toBe(0);
+      expect(stdout).not.toContain('__wrapRegExp');
+      expect(stdout).not.toContain('BabelRegExp');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('lookbehind (?<=...) 만 있으면 wrap 안 함 (named capture 아님)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-cli-lookbehind-'));
+    try {
+      writeFileSync(
+        join(dir, 'entry.ts'),
+        'const re = /(?<=foo)bar/; console.log(re.test("foobar"));',
+      );
+      const { stdout, exitCode } = runCli(['--bundle', join(dir, 'entry.ts'), '--target=es5']);
+      expect(exitCode).toBe(0);
+      expect(stdout).not.toContain('__wrapRegExp');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('--target=es2018 (named capture 지원) → strip 안 함', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-cli-es2018-'));
+    try {
+      writeFileSync(
+        join(dir, 'entry.ts'),
+        'const re = /(?<year>\\d{4})/; console.log(re.exec("2026")?.groups?.year);',
+      );
+      const { stdout, exitCode } = runCli(['--bundle', join(dir, 'entry.ts'), '--target=es2018']);
+      expect(exitCode).toBe(0);
+      // ES2018 은 named capture 네이티브 지원 — 변환 없음
+      expect(stdout).toContain('(?<year>');
+      expect(stdout).not.toContain('__wrapRegExp');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -558,6 +558,70 @@ pub const GENERATOR_RUNTIME =
 ;
 pub const GENERATOR_RUNTIME_MIN = "var " ++ NAMES.GENERATOR_MIN ++ "=function(){var __iterProto={};__iterProto[Symbol.iterator]=function(){return this};var __genProto=Object.create(__iterProto);return function(thisArg,body,genFn){var _={label:0,sent:function(){if(t[0]&1)throw t[1];return t[1]},trys:[],ops:[]},f,y,t,g;if(genFn){if(!genFn.__proto_set){Object.setPrototypeOf(genFn.prototype,__genProto);genFn.__proto_set=true}g=Object.create(genFn.prototype)}else{g={};g[Symbol.iterator]=function(){return this}}g.next=verb(0);g[\"throw\"]=verb(1);g[\"return\"]=verb(2);return g;function verb(n){return function(v){return step([n,v])}}function step(op){if(f)throw new TypeError(\"Generator is already executing.\");while(g&&(g=0,op[0]&&(_=0)),_)try{if(f=1,y&&(t=op[0]&2?y[\"return\"]:op[0]?y[\"throw\"]||((t=y[\"return\"])&&t.call(y),0):y.next)&&!(t=t.call(y,op[1])).done)return t;if(y=0,t)op=[op[0]&2,t.value];switch(op[0]){case 0:case 1:t=op;break;case 4:_.label++;return{value:op[1],done:false};case 5:_.label++;y=op[1];op=[0];continue;case 7:op=_.ops.pop();_.trys.pop();continue;default:if(!(t=_.trys,t=t.length>0&&t[t.length-1])&&(op[0]===6||op[0]===2)){_=0;continue}if(op[0]===3&&(!t||(op[1]>t[0]&&op[1]<t[3]))){_.label=op[1];break}if(op[0]===6&&_.label<t[1]){_.label=t[1];t=op;break}if(t&&_.label<t[2]){_.label=t[2];_.ops.push(op);break}if(t[2])_.ops.pop();_.trys.pop();continue}op=body.call(thisArg,_)}catch(e){op=[6,e];y=0}finally{f=t=0}if(op[0]&5)throw op[1];return{value:op[0]?op[1]:void 0,done:true}}}}();";
 
+/// __wrapRegExp: named capture group 다운레벨 (#1063). Hermes/ES5 등 named capture 미지원
+/// 환경에서 strip 후에도 `re.exec(s).groups.NAME` / `s.replace(re, "$<NAME>")` 가 동작하도록
+/// RegExp 를 wrap 한다. Babel `_wrapRegExp` 와 동일 패턴 (RegExp 상속 + exec/Symbol.replace
+/// override + WeakMap 으로 groups map 보유).
+pub const WRAP_REGEXP_RUNTIME =
+    \\var __wrapRegExp = function() {
+    \\  __wrapRegExp = function(re, groups) { return new BabelRegExp(re, undefined, groups); };
+    \\  var _super = RegExp.prototype;
+    \\  var _groups = new WeakMap();
+    \\  function BabelRegExp(re, flags, groups) {
+    \\    var _this = new RegExp(re, flags);
+    \\    _groups.set(_this, groups || _groups.get(re));
+    \\    return Object.setPrototypeOf(_this, BabelRegExp.prototype);
+    \\  }
+    \\  Object.setPrototypeOf(BabelRegExp.prototype, RegExp.prototype);
+    \\  BabelRegExp.prototype.exec = function(str) {
+    \\    var result = _super.exec.call(this, str);
+    \\    if (result) {
+    \\      result.groups = buildGroups(result, this);
+    \\      var indices = result.indices;
+    \\      if (indices) indices.groups = buildGroups(indices, this);
+    \\    }
+    \\    return result;
+    \\  };
+    \\  BabelRegExp.prototype[Symbol.replace] = function(str, substitution) {
+    \\    if (typeof substitution === "string") {
+    \\      var groups = _groups.get(this);
+    \\      return _super[Symbol.replace].call(this, str, substitution.replace(/\$<([^>]+)(>|$)/g, function(match, name, end) {
+    \\        if (end === "") return match;
+    \\        var group = groups[name];
+    \\        return Array.isArray(group) ? "$" + group.join("$") : typeof group === "number" ? "$" + group : "";
+    \\      }));
+    \\    } else if (typeof substitution === "function") {
+    \\      var _this = this;
+    \\      return _super[Symbol.replace].call(this, str, function() {
+    \\        var args = arguments;
+    \\        if (typeof args[args.length - 1] !== "object") {
+    \\          args = [].slice.call(args);
+    \\          args.push(buildGroups(args, _this));
+    \\        }
+    \\        return substitution.apply(this, args);
+    \\      });
+    \\    }
+    \\    return _super[Symbol.replace].call(this, str, substitution);
+    \\  };
+    \\  function buildGroups(result, re) {
+    \\    var g = _groups.get(re);
+    \\    return Object.keys(g).reduce(function(groups, name) {
+    \\      var i = g[name];
+    \\      if (typeof i === "number") groups[name] = result[i];
+    \\      else {
+    \\        var k = 0;
+    \\        while (result[i[k]] === undefined && k + 1 < i.length) k++;
+    \\        groups[name] = result[i[k]];
+    \\      }
+    \\      return groups;
+    \\    }, Object.create(null));
+    \\  }
+    \\  return __wrapRegExp.apply(this, arguments);
+    \\};
+    \\
+;
+pub const WRAP_REGEXP_RUNTIME_MIN = "var " ++ NAMES.WRAP_REGEXP_MIN ++ "=function(){" ++ NAMES.WRAP_REGEXP_MIN ++ "=function(re,groups){return new BabelRegExp(re,undefined,groups)};var _super=RegExp.prototype;var _groups=new WeakMap();function BabelRegExp(re,flags,groups){var _this=new RegExp(re,flags);_groups.set(_this,groups||_groups.get(re));return Object.setPrototypeOf(_this,BabelRegExp.prototype)}Object.setPrototypeOf(BabelRegExp.prototype,RegExp.prototype);BabelRegExp.prototype.exec=function(str){var result=_super.exec.call(this,str);if(result){result.groups=buildGroups(result,this);var indices=result.indices;if(indices)indices.groups=buildGroups(indices,this)}return result};BabelRegExp.prototype[Symbol.replace]=function(str,substitution){if(typeof substitution===\"string\"){var groups=_groups.get(this);return _super[Symbol.replace].call(this,str,substitution.replace(/\\$<([^>]+)(>|$)/g,function(match,name,end){if(end===\"\")return match;var group=groups[name];return Array.isArray(group)?\"$\"+group.join(\"$\"):typeof group===\"number\"?\"$\"+group:\"\"}))}else if(typeof substitution===\"function\"){var _this=this;return _super[Symbol.replace].call(this,str,function(){var args=arguments;if(typeof args[args.length-1]!==\"object\"){args=[].slice.call(args);args.push(buildGroups(args,_this))}return substitution.apply(this,args)})}return _super[Symbol.replace].call(this,str,substitution)};function buildGroups(result,re){var g=_groups.get(re);return Object.keys(g).reduce(function(groups,name){var i=g[name];if(typeof i===\"number\")groups[name]=result[i];else{var k=0;while(result[i[k]]===undefined&&k+1<i.length)k++;groups[name]=result[i[k]]}return groups},Object.create(null))}return " ++ NAMES.WRAP_REGEXP_MIN ++ ".apply(this,arguments)};";
+
 /// __await: async generator 안 await 표현의 wrapper. (#1911)
 /// `await x` 는 async generator body 안에서 `yield __await(x)` 로 변환되며,
 /// `__asyncGenerator` 의 step() 가 `r.value instanceof __await` 으로 인식해 Promise resolve.
@@ -1219,6 +1283,9 @@ pub fn appendRuntimeHelpers(buf: *std.ArrayList(u8), allocator: std.mem.Allocato
     }
     if (helpers.to_binary) {
         try buf.appendSlice(allocator, if (minify) TO_BINARY_RUNTIME_MIN else TO_BINARY_RUNTIME);
+    }
+    if (helpers.wrap_regex) {
+        try buf.appendSlice(allocator, if (minify) WRAP_REGEXP_RUNTIME_MIN else WRAP_REGEXP_RUNTIME);
     }
     if (helpers.keep_names) {
         try buf.appendSlice(allocator, if (minify) KEEP_NAMES_RUNTIME_MIN else KEEP_NAMES_RUNTIME);

--- a/src/runtime_helper_modules.zig
+++ b/src/runtime_helper_modules.zig
@@ -307,7 +307,7 @@ const MODULES = [_]HelperModule{
         },
     },
 
-    // RegExp named capture group downlevel (#1063) — Hermes/ES5 호환.
+    // RegExp named capture group downlevel — Hermes/ES5 호환.
     .{
         .short = "wrap-regex",
         .helpers = &.{"__wrapRegExp"},

--- a/src/runtime_helper_modules.zig
+++ b/src/runtime_helper_modules.zig
@@ -306,6 +306,13 @@ const MODULES = [_]HelperModule{
             .es5_min = rt.USING_RUNTIME_ES5_MIN,
         },
     },
+
+    // RegExp named capture group downlevel (#1063) — Hermes/ES5 호환.
+    .{
+        .short = "wrap-regex",
+        .helpers = &.{"__wrapRegExp"},
+        .body = .{ .plain = rt.WRAP_REGEXP_RUNTIME, .min = rt.WRAP_REGEXP_RUNTIME_MIN },
+    },
 };
 
 // ============================================================

--- a/src/runtime_helper_names.zig
+++ b/src/runtime_helper_names.zig
@@ -70,6 +70,8 @@ pub const NAMES = struct {
     // ES2025 explicit resource management
     pub const USING_MIN = "$us"; // __using
     pub const CALL_DISPOSE_MIN = "$cD"; // __callDispose
+    // RegExp downlevel
+    pub const WRAP_REGEXP_MIN = "$wR"; // __wrapRegExp (named capture downlevel)
 };
 
 /// 모든 runtime helper 의 `(base_name, short_name)` 단일 소스 테이블.
@@ -127,6 +129,7 @@ pub const PAIRS = [_]struct { base: []const u8, short: []const u8 }{
     .{ .base = "__propKey", .short = NAMES.PROP_KEY_MIN },
     .{ .base = "__using", .short = NAMES.USING_MIN },
     .{ .base = "__callDispose", .short = NAMES.CALL_DISPOSE_MIN },
+    .{ .base = "__wrapRegExp", .short = NAMES.WRAP_REGEXP_MIN },
 };
 
 /// PAIRS 로부터 base_name → short_name comptime 해시맵.

--- a/src/transformer/options.zig
+++ b/src/transformer/options.zig
@@ -293,6 +293,12 @@ pub const TransformOptions = struct {
                     if (u.using and ast.variableDeclarationKind(node).isUsing()) return true;
                 },
                 .await_expression => if (u.top_level_await) return true,
+                // regex 다운레벨 (named capture, dotall, sticky, unicode brace escape).
+                // named capture 는 wrap 변환에 helper module import 필요 — prepass 거쳐야
+                // graph 가 helper module 을 등록 (#1063).
+                .regexp_literal => {
+                    if (u.regex_dotall or u.regex_named_groups or u.regex_sticky or u.unicode_brace_escape) return true;
+                },
                 else => {},
             }
         }

--- a/src/transformer/options.zig
+++ b/src/transformer/options.zig
@@ -295,7 +295,7 @@ pub const TransformOptions = struct {
                 .await_expression => if (u.top_level_await) return true,
                 // regex 다운레벨 (named capture, dotall, sticky, unicode brace escape).
                 // named capture 는 wrap 변환에 helper module import 필요 — prepass 거쳐야
-                // graph 가 helper module 을 등록 (#1063).
+                // graph 가 helper module 을 등록.
                 .regexp_literal => {
                     if (u.regex_dotall or u.regex_named_groups or u.regex_sticky or u.unicode_brace_escape) return true;
                 },

--- a/src/transformer/regex_lower.zig
+++ b/src/transformer/regex_lower.zig
@@ -26,7 +26,8 @@ pub const Result = struct {
     text: ?[]const u8,
     /// named capture group 이 있고 `regex_named_groups` strip 이 적용된 경우의
     /// (name → positional index) 매핑. 호출자가 `__wrapRegExp(re, {...})` 로 감싸는 데
-    /// 사용 (#1063). free 책임은 호출자.
+    /// 사용. free 책임은 호출자. `name` 슬라이스는 호출자가 lower 에 전달한 raw
+    /// 텍스트의 lifetime 에 의존 — owner 가 살아있는 동안만 유효.
     named_groups: ?[]const NamedGroupMapping = null,
 };
 
@@ -58,7 +59,7 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
     if (!need_dotall and !need_named and !need_sticky and !need_unicode) return .{ .text = null };
 
     // named capture mapping 추출 (strip 전에 — strip 후엔 named group 이 사라져 인덱스 추적 불가).
-    // 호출자가 `__wrapRegExp(re, {...})` 합성에 사용 (#1063).
+    // 호출자가 `__wrapRegExp(re, {...})` 합성에 사용.
     var named_groups: ?[]const NamedGroupMapping = null;
     errdefer if (named_groups) |ng| allocator.free(ng);
     if (need_named) {

--- a/src/transformer/regex_lower.zig
+++ b/src/transformer/regex_lower.zig
@@ -24,6 +24,10 @@ pub const Options = struct {
 pub const Result = struct {
     /// 최종 regex literal 텍스트 (`/pattern/flags` 전체). 변환이 없으면 null.
     text: ?[]const u8,
+    /// named capture group 이 있고 `regex_named_groups` strip 이 적용된 경우의
+    /// (name → positional index) 매핑. 호출자가 `__wrapRegExp(re, {...})` 로 감싸는 데
+    /// 사용 (#1063). free 책임은 호출자.
+    named_groups: ?[]const NamedGroupMapping = null,
 };
 
 /// regex literal 원본 텍스트(`/pattern/flags`)를 받아 변환이 필요하면 새 슬라이스를 반환.
@@ -53,6 +57,15 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
 
     if (!need_dotall and !need_named and !need_sticky and !need_unicode) return .{ .text = null };
 
+    // named capture mapping 추출 (strip 전에 — strip 후엔 named group 이 사라져 인덱스 추적 불가).
+    // 호출자가 `__wrapRegExp(re, {...})` 합성에 사용 (#1063).
+    var named_groups: ?[]const NamedGroupMapping = null;
+    errdefer if (named_groups) |ng| allocator.free(ng);
+    if (need_named) {
+        const map = try extractNamedGroupMap(allocator, pattern);
+        if (map.len > 0) named_groups = map else allocator.free(map);
+    }
+
     // /pattern/flags 를 단일 버퍼로 조립. dotAll/unicode 치환을 고려해 +8 여유.
     var out: std.ArrayList(u8) = .empty;
     errdefer out.deinit(allocator);
@@ -70,7 +83,7 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
         if (need_unicode and c == 'u') continue;
         try out.append(allocator, c);
     }
-    return .{ .text = try out.toOwnedSlice(allocator) };
+    return .{ .text = try out.toOwnedSlice(allocator), .named_groups = named_groups };
 }
 
 const PatternOpts = struct {
@@ -348,6 +361,7 @@ const testing = std.testing;
 
 fn runLower(raw: []const u8, unsupported: compat.UnsupportedFeatures) !?[]const u8 {
     const r = try lower(testing.allocator, raw, .{ .unsupported = unsupported });
+    if (r.named_groups) |ng| testing.allocator.free(ng);
     return r.text;
 }
 
@@ -384,6 +398,33 @@ test "regex: named capture 여러 개" {
     const out = (try runLower("/(?<y>\\d{4})-(?<m>\\d{2})/", .{ .regex_named_groups = true })).?;
     defer testing.allocator.free(out);
     try testing.expectEqualStrings("/(\\d{4})-(\\d{2})/", out);
+}
+
+test "regex: named capture mapping 반환 (#1063 wrapRegExp 입력)" {
+    const r = try lower(testing.allocator, "/(?<y>\\d{4})-(?<m>\\d{2})/", .{ .unsupported = .{ .regex_named_groups = true } });
+    defer if (r.text) |t| testing.allocator.free(t);
+    defer if (r.named_groups) |ng| testing.allocator.free(ng);
+    try testing.expect(r.named_groups != null);
+    const ng = r.named_groups.?;
+    try testing.expectEqual(@as(usize, 2), ng.len);
+    try testing.expectEqualStrings("y", ng[0].name);
+    try testing.expectEqual(@as(u32, 1), ng[0].index);
+    try testing.expectEqualStrings("m", ng[1].name);
+    try testing.expectEqual(@as(u32, 2), ng[1].index);
+}
+
+test "regex: named group 없을 때 mapping null (#1063)" {
+    const r = try lower(testing.allocator, "/(\\d+)/", .{ .unsupported = .{ .regex_named_groups = true } });
+    defer if (r.text) |t| testing.allocator.free(t);
+    defer if (r.named_groups) |ng| testing.allocator.free(ng);
+    try testing.expect(r.named_groups == null);
+}
+
+test "regex: lookbehind 만 있을 때 mapping null (#1063)" {
+    const r = try lower(testing.allocator, "/(?<=a)b/", .{ .unsupported = .{ .regex_named_groups = true } });
+    defer if (r.text) |t| testing.allocator.free(t);
+    defer if (r.named_groups) |ng| testing.allocator.free(ng);
+    try testing.expect(r.named_groups == null);
 }
 
 test "regex: lookbehind (?<=...) 은 유지" {

--- a/src/transformer/runtime_helper_bits.zig
+++ b/src/transformer/runtime_helper_bits.zig
@@ -58,7 +58,10 @@ pub const RuntimeHelpers = packed struct(u32) {
     /// transpile-only 모드에서도 헬퍼 정의가 출력에 inline 되도록 transformer 가
     /// 호출 emit 시 함께 set 한다.
     legacy_decorator: bool = false,
-    _padding: u6 = 0,
+    /// __wrapRegExp: named capture group downlevel (Hermes/ES5 등) 에서 RegExp
+    /// 결과의 `.groups.NAME` 접근을 살리는 wrapper (#1063).
+    wrap_regex: bool = false,
+    _padding: u5 = 0,
 
     /// 어떤 helper flag 라도 set 됐는지 - emitter 의 prepend 분기에서 빈 helper 시
     /// no-op 결정에 사용.

--- a/src/transformer/runtime_helper_imports.zig
+++ b/src/transformer/runtime_helper_imports.zig
@@ -62,6 +62,7 @@ const HelperBit = enum {
     await_helper,
     tdz,
     read,
+    wrap_regex,
 };
 
 const BitDef = struct {
@@ -109,6 +110,7 @@ const BIT_DEFS = [_]BitDef{
     .{ .bit = .await_helper, .bases = &.{"__await"} },
     .{ .bit = .tdz, .bases = &.{"__tdz"} },
     .{ .bit = .read, .bases = &.{"__read"} },
+    .{ .bit = .wrap_regex, .bases = &.{"__wrapRegExp"} },
 };
 
 comptime {

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -717,12 +717,18 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
 
                 // {name1: 1, name2: 2, ...} object literal 합성. property key 는 quoted
                 // string literal (`"name"`) — reserved word/하이픈 등 고려 않게 일관 처리.
+                // identifier 는 실무상 짧으므로 256 byte 스택 버퍼로 heap alloc 회피.
                 const props_top = self.scratch.items.len;
                 defer self.scratch.shrinkRetainingCapacity(props_top);
                 for (ng) |entry| {
-                    const key_quoted = try std.fmt.allocPrint(self.allocator, "\"{s}\"", .{entry.name});
-                    defer self.allocator.free(key_quoted);
-                    const key_span = try self.ast.addString(key_quoted);
+                    var stack_buf: [256]u8 = undefined;
+                    const need_heap = entry.name.len + 2 > stack_buf.len;
+                    const quoted = if (need_heap)
+                        try std.fmt.allocPrint(self.allocator, "\"{s}\"", .{entry.name})
+                    else
+                        std.fmt.bufPrint(&stack_buf, "\"{s}\"", .{entry.name}) catch unreachable;
+                    defer if (need_heap) self.allocator.free(quoted);
+                    const key_span = try self.ast.addString(quoted);
                     const key_node = try self.ast.addNode(.{
                         .tag = .string_literal,
                         .span = key_span,

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -697,14 +697,57 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
             }
             const raw = self.ast.getText(node.span);
             const result = try regex_lower.lower(self.allocator, raw, .{ .unsupported = u });
+            defer if (result.named_groups) |ng| self.allocator.free(ng);
             const new_text = result.text orelse break :blk self.copyNodeDirect(idx);
             defer self.allocator.free(new_text);
+
             const new_span = try self.ast.addString(new_text);
-            break :blk try self.ast.addNode(.{
+            const new_regex = try self.ast.addNode(.{
                 .tag = .regexp_literal,
                 .span = new_span,
                 .data = .{ .string_ref = new_span },
             });
+
+            // named capture group 이 있고 strip 됐으면 `__wrapRegExp(/.../, {n:1,...})` 로 wrap
+            // — exec().groups.NAME / replace(re, "$<NAME>") semantic 보존 (#1063). graph 가
+            // helper module (`runtime_helper_modules.zig` 의 wrap-regex) 을 import 해서
+            // chunk 분배까지 자동 처리.
+            if (result.named_groups) |ng| {
+                self.runtime_helpers.wrap_regex = true;
+
+                // {name1: 1, name2: 2, ...} object literal 합성. property key 는 quoted
+                // string literal (`"name"`) — reserved word/하이픈 등 고려 않게 일관 처리.
+                const props_top = self.scratch.items.len;
+                defer self.scratch.shrinkRetainingCapacity(props_top);
+                for (ng) |entry| {
+                    const key_quoted = try std.fmt.allocPrint(self.allocator, "\"{s}\"", .{entry.name});
+                    defer self.allocator.free(key_quoted);
+                    const key_span = try self.ast.addString(key_quoted);
+                    const key_node = try self.ast.addNode(.{
+                        .tag = .string_literal,
+                        .span = key_span,
+                        .data = .{ .string_ref = key_span },
+                    });
+                    const val_node = try es_helpers.makeNumericLiteral(self, entry.index);
+                    const prop_node = try self.ast.addNode(.{
+                        .tag = .object_property,
+                        .span = node.span,
+                        .data = .{ .binary = .{ .left = key_node, .right = val_node, .flags = 0 } },
+                    });
+                    try self.scratch.append(self.allocator, prop_node);
+                }
+                const props_list = try self.ast.addNodeList(self.scratch.items[props_top..]);
+                const groups_obj = try self.ast.addNode(.{
+                    .tag = .object_expression,
+                    .span = node.span,
+                    .data = .{ .list = props_list },
+                });
+
+                const wrap_ref = try es_helpers.makeRuntimeHelperRef(self, "__wrapRegExp");
+                break :blk try es_helpers.makeCallExpr(self, wrap_ref, &.{ new_regex, groups_obj }, node.span);
+            }
+
+            break :blk new_regex;
         },
         .identifier_reference => {
             // ES2015 arrow arguments 캡처: arrow body 안의 arguments → _arguments

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -709,9 +709,9 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
             });
 
             // named capture group 이 있고 strip 됐으면 `__wrapRegExp(/.../, {n:1,...})` 로 wrap
-            // — exec().groups.NAME / replace(re, "$<NAME>") semantic 보존 (#1063). graph 가
-            // helper module (`runtime_helper_modules.zig` 의 wrap-regex) 을 import 해서
-            // chunk 분배까지 자동 처리.
+            // — exec().groups.NAME / replace(re, "$<NAME>") semantic 보존. graph 가 helper
+            // module (`runtime_helper_modules.zig` 의 wrap-regex) 을 import 해서 chunk
+            // 분배까지 자동 처리.
             if (result.named_groups) |ng| {
                 self.runtime_helpers.wrap_regex = true;
 


### PR DESCRIPTION
## Summary

regex pattern strip 만 하던 기존 동작 (`(?<name>X)` → `(X)`) 에 더해 RegExp literal 자체를 \`__wrapRegExp(re, {name: idx})\` 로 wrap. \`exec\` 결과의 \`.groups.NAME\` / \`String.prototype.replace\` 의 \`\$<NAME>\` semantic 보존.

Babel \`_wrapRegExp\` 패턴 차용 — RegExp 상속 + exec/Symbol.replace override + WeakMap 으로 groups map 보유. 사용처 (alias / destructuring) 추적 불필요, 모든 케이스 cover.

## 다운레벨 비교

| 도구 | named capture 다운레벨 |
|---|---|
| Babel | ✅ \`@babel/plugin-transform-named-capturing-groups-regex\` |
| swc | ✅ target 별 자동 |
| esbuild | ❌ 의도적 |
| TypeScript | ❌ |
| **zntc (이 PR 전)** | ❌ — Hermes target 깨짐 |
| **zntc (이 PR 후)** | ✅ |

## 구현 (5 phase)

- **Phase A**: \`RuntimeHelpers.wrap_regex\` flag (\`runtime_helper_bits.zig\`)
- **Phase B**: \`WRAP_REGEXP_RUNTIME\` / \`WRAP_REGEXP_RUNTIME_MIN\` helper (\`runtime_helpers.zig\`) + name 등록 (\`runtime_helper_names.zig\`)
- **Phase C**: \`node_dispatch.zig\` regexp_literal 분기 — strip 후 named groups 있으면 \`call_expression\` (\`__wrapRegExp(/.../, {n:1})\`) 으로 AST 변환
- **Phase D**:
  - \`runtime_helper_modules.zig\` 의 MODULES 에 \`wrap-regex\` 등록 (graph 1급 모듈)
  - \`runtime_helper_imports.zig\` 의 HelperBit / BIT_DEFS entry 추가 (prepass 가 named import 자동 emit)
  - \`appendRuntimeHelpers\` 분기 (transpile path)
  - \`options.zig\` 의 \`unsupportedGraphPrePassFeatureUsed\` 에 \`regexp_literal\` 분기 추가 — regex 다운레벨 옵션 set 시 prepass 활성화 (helper module 등록 필요)
- **Phase E**: 단위 + integration 테스트

## 검증

직접 실행 (Node) 으로 3 케이스 동작 확인:
\`\`\`ts
const m = /(?<word>\\w+)/.exec(\"hello\");
m?.groups?.word;                                      // → \"hello\"
\"John Smith\".replace(/(?<f>\\w+) (?<l>\\w+)/, \"\$<l>, \$<f>\");  // → \"Smith, John\"
/(?<a>\\d+)/.test(\"abc123\");                          // → true
\`\`\`

## 회귀 가드

- **regex_lower 단위 테스트** 3개 추가:
  - \`mapping 반환 (#1063 wrapRegExp 입력)\`
  - \`named group 없을 때 mapping null\`
  - \`lookbehind 만 있을 때 mapping null\`
- **CLI integration 테스트** 5개 추가 (\`named-capture-regex.ts\`):
  - \`--target=es5\` (no minify) → wrap call + helper inject + BabelRegExp
  - \`--target=es5 + --minify\` → short helper name (\`\$wR\`) 일관 사용
  - named group 없으면 wrap 호출 없음 (불필요 helper inject 회피)
  - lookbehind \`(?<=...)\` 만 있으면 wrap 안 함
  - \`--target=es2018\` (named capture 지원) → strip 안 함

## Test plan

- [x] \`zig build test\` — 0 fail
- [x] \`bun test\` (core 패키지) — 886 pass / 0 fail (+5 신규)
- [x] CLI 직접 실행 (Node) 으로 3 케이스 semantic 검증
- [x] zig binary + NAPI binary 양쪽 검증

Closes #1063

🤖 Generated with [Claude Code](https://claude.com/claude-code)