### PR TITLE
refactor: ES2015 generator scan 헬퍼 분리

### DIFF
--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -41,6 +41,7 @@ const token_mod = @import("../lexer/token.zig");
 const Span = token_mod.Span;
 const es_helpers = @import("es_helpers.zig");
 const es2015_destructuring = @import("es2015_destructuring.zig");
+const es2015_scan = @import("es2015_generator/scan.zig");
 
 /// 상태 머신의 개별 연산.
 const OpCode = enum {
@@ -267,7 +268,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                             else
                                 try es_helpers.makeAssignStmt(self, new_left, sent_call, stmt.span, expr.data.binary.flags);
                             try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = assign_stmt } });
-                        } else if (containsYield(self, right_idx)) {
+                        } else if (es2015_scan.containsYield(self, right_idx)) {
                             // x = [yield 5, yield 6] — 우측에 중첩 yield가 있는 assignment
                             // visitExprWithYieldExtraction으로 전체 assignment를 처리하여
                             // 각 yield를 temp 변수로 추출하고 _state.sent()로 대체
@@ -278,7 +279,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                             const new_stmt = try self.visitNode(stmt_idx);
                             try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = new_stmt } });
                         }
-                    } else if (containsYield(self, expr_idx)) {
+                    } else if (es2015_scan.containsYield(self, expr_idx)) {
                         // foo(await x) — 중첩 yield를 추출 후 expression statement
                         const new_expr = try visitExprWithYieldExtraction(self, expr_idx, ops, next_label);
                         const new_stmt = try es_helpers.makeExprStmt(self, new_expr, stmt.span);
@@ -301,7 +302,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                             try ops.append(self.allocator, .{ .code = .nop, .arg = .{ .none = {} } });
                             const sent = try buildSentCall(self, stmt.span);
                             try ops.append(self.allocator, .{ .code = .return_op, .arg = .{ .node = sent } });
-                        } else if (containsYield(self, value_idx)) {
+                        } else if (es2015_scan.containsYield(self, value_idx)) {
                             // return foo(await x) — 중첩 yield를 추출 후 return
                             const new_value = try visitExprWithYieldExtraction(self, value_idx, ops, next_label);
                             try ops.append(self.allocator, .{ .code = .return_op, .arg = .{ .node = new_value } });
@@ -339,7 +340,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                     try collectSwitchOperations(self, stmt_idx, stmt, ops, next_label);
                 },
                 .for_of_statement, .for_in_statement => {
-                    if (containsYield(self, stmt_idx)) {
+                    if (es2015_scan.containsYield(self, stmt_idx)) {
                         try collectForOfOperations(self, stmt_idx, stmt, ops, next_label);
                     } else {
                         const new_stmt = try self.visitNode(stmt_idx);
@@ -385,9 +386,9 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             const then_body = stmt.data.ternary.b;
             const else_body = stmt.data.ternary.c;
 
-            const has_yield_in_body = containsYield(self, then_body) or containsYield(self, else_body);
-            const has_yield_in_cond = containsYield(self, condition);
-            if (!has_yield_in_body and !has_yield_in_cond and !containsReturn(self, then_body) and !containsReturn(self, else_body)) {
+            const has_yield_in_body = es2015_scan.containsYield(self, then_body) or es2015_scan.containsYield(self, else_body);
+            const has_yield_in_cond = es2015_scan.containsYield(self, condition);
+            if (!has_yield_in_body and !has_yield_in_cond and !es2015_scan.containsReturn(self, then_body) and !es2015_scan.containsReturn(self, else_body)) {
                 const new_stmt = try self.visitNode(stmt_idx);
                 if (!new_stmt.isNone()) {
                     try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = new_stmt } });
@@ -447,7 +448,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             const update_idx: NodeIndex = self.readNodeIdx(e, 2);
             const body_idx: NodeIndex = self.readNodeIdx(e, 3);
 
-            if (!containsYield(self, body_idx) and !containsYield(self, test_idx)) {
+            if (!es2015_scan.containsYield(self, body_idx) and !es2015_scan.containsYield(self, test_idx)) {
                 const new_stmt = try self.visitNode(stmt_idx);
                 if (!new_stmt.isNone()) {
                     try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = new_stmt } });
@@ -484,7 +485,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
 
             // test (for_break_sent는 body 처리 후 fixup)
             if (!test_idx.isNone()) {
-                const new_test = if (containsYield(self, test_idx))
+                const new_test = if (es2015_scan.containsYield(self, test_idx))
                     try visitExprWithYieldExtraction(self, test_idx, ops, next_label)
                 else
                     try self.visitNode(test_idx);
@@ -704,7 +705,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             const condition = stmt.data.binary.left;
             const body_idx = stmt.data.binary.right;
 
-            if (!containsYield(self, body_idx) and !containsYield(self, condition)) {
+            if (!es2015_scan.containsYield(self, body_idx) and !es2015_scan.containsYield(self, condition)) {
                 const new_stmt = try self.visitNode(stmt_idx);
                 if (!new_stmt.isNone()) {
                     try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = new_stmt } });
@@ -721,7 +722,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             const while_break_sent = breakSentinel(depth);
             const ops_start = ops.items.len;
 
-            const new_cond = if (containsYield(self, condition))
+            const new_cond = if (es2015_scan.containsYield(self, condition))
                 try visitExprWithYieldExtraction(self, condition, ops, next_label)
             else
                 try self.visitNode(condition);
@@ -895,7 +896,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             const cases_start_val = self.readU32(e, 1);
             const cases_len_val = self.readU32(e, 2);
 
-            if (!containsYield(self, stmt_idx)) {
+            if (!es2015_scan.containsYield(self, stmt_idx)) {
                 const new_stmt = try self.visitNode(stmt_idx);
                 if (!new_stmt.isNone()) {
                     try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = new_stmt } });
@@ -1010,7 +1011,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             const condition = stmt.data.binary.left;
             const body_idx = stmt.data.binary.right;
 
-            if (!containsYield(self, body_idx) and !containsYield(self, condition)) {
+            if (!es2015_scan.containsYield(self, body_idx) and !es2015_scan.containsYield(self, condition)) {
                 const new_stmt = try self.visitNode(stmt_idx);
                 if (!new_stmt.isNone()) {
                     try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = new_stmt } });
@@ -1046,7 +1047,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             try ops.append(self.allocator, .{ .code = .nop, .arg = .{ .none = {} } }); // mark cond_label
 
             // condition → if true, goto body_label
-            const new_cond = if (containsYield(self, condition))
+            const new_cond = if (es2015_scan.containsYield(self, condition))
                 try visitExprWithYieldExtraction(self, condition, ops, next_label)
             else
                 try self.visitNode(condition);
@@ -1080,7 +1081,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             const finally_body = stmt.data.ternary.c;
 
             // yield가 없으면 그대로 visit
-            if (!containsYield(self, try_body) and !containsYield(self, catch_clause) and !containsYield(self, finally_body)) {
+            if (!es2015_scan.containsYield(self, try_body) and !es2015_scan.containsYield(self, catch_clause) and !es2015_scan.containsYield(self, finally_body)) {
                 const new_stmt = try self.visitNode(stmt_idx);
                 if (!new_stmt.isNone()) {
                     try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = new_stmt } });
@@ -1411,7 +1412,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                     const sent_call = try buildSentCall(self, stmt.span);
                     const assign_stmt = try makeDestructuringAssignStmt(self, new_binding, sent_call, stmt.span);
                     try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = assign_stmt } });
-                } else if (containsYield(self, init_idx)) {
+                } else if (es2015_scan.containsYield(self, init_idx)) {
                     // var x = foo(await y) → 중첩 yield 추출 후 x = foo(_state.sent())
                     const new_binding = try self.visitNode(binding);
                     const new_init = try visitExprWithYieldExtraction(self, init_idx, ops, next_label);
@@ -1425,250 +1426,6 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                     try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = assign_stmt } });
                 }
             }
-        }
-
-        /// AST 서브트리에 yield_expression 또는 generator labeled jump가 있는지 체크.
-        ///
-        /// 명시 stack DFS — recursive 였을 때 deep AST 에서 stack overflow 위험. children
-        /// enumeration 은 기존 switch 구조 그대로 유지 (behavior 100% 보존). short-circuit
-        /// `or` 는 children 을 모두 push 한 뒤 다음 iteration 에서 자연 종료.
-        ///
-        /// OOM 시 보수적으로 true 반환 — state machine 변환을 안 하는 것보다 하는 게 안전
-        /// (호출부가 더 보수적 변환 path 선택).
-        fn containsYield(self: *const Transformer, root_idx: NodeIndex) bool {
-            if (root_idx.isNone()) return false;
-            var stack: std.ArrayList(NodeIndex) = .empty;
-            defer stack.deinit(self.allocator);
-            stack.append(self.allocator, root_idx) catch return true;
-
-            while (stack.items.len > 0) {
-                const idx = stack.pop() orelse break;
-                if (idx.isNone()) continue;
-                const node = self.ast.getNode(idx);
-
-                if (node.tag == .yield_expression or node.tag == .await_expression) return true;
-                if (node.tag == .break_statement or node.tag == .continue_statement) {
-                    if (node.data.unary.operand.isNone()) {
-                        if (self.generator_label_stack.items.len > 0) return true;
-                    } else if (self.generator_label_stack.items.len > 0) {
-                        const label_node = self.ast.getNode(node.data.unary.operand);
-                        const label_text = self.ast.getText(label_node.span);
-                        for (self.generator_label_stack.items) |entry| {
-                            if (std.mem.eql(u8, entry.name, label_text)) return true;
-                        }
-                    }
-                }
-                // function/arrow 경계: nested generator/arrow 의 yield 는 다른 스코프
-                if (node.tag == .function_declaration or node.tag == .function_expression or
-                    node.tag == .arrow_function_expression) continue;
-
-                const push = struct {
-                    fn one(self_: *const Transformer, st: *std.ArrayList(NodeIndex), child: NodeIndex) bool {
-                        st.append(self_.allocator, child) catch return false;
-                        return true;
-                    }
-                };
-
-                switch (node.tag) {
-                    .block_statement,
-                    .function_body,
-                    .array_expression,
-                    .object_expression,
-                    .sequence_expression,
-                    .template_literal,
-                    .formal_parameters,
-                    .class_body,
-                    => {
-                        const members = self.ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
-                        for (members) |raw_idx| {
-                            if (!push.one(self, &stack, @enumFromInt(raw_idx))) return true;
-                        }
-                    },
-                    .expression_statement,
-                    .return_statement,
-                    .throw_statement,
-                    .spread_element,
-                    .rest_element,
-                    .parenthesized_expression,
-                    => {
-                        if (!push.one(self, &stack, node.data.unary.operand)) return true;
-                    },
-                    .unary_expression, .update_expression => {
-                        const extras = self.ast.extra_data.items;
-                        const e = node.data.extra;
-                        if (e >= extras.len) continue;
-                        if (!push.one(self, &stack, @enumFromInt(extras[e]))) return true;
-                    },
-                    .assignment_expression,
-                    .binary_expression,
-                    .logical_expression,
-                    .object_property,
-                    => {
-                        if (!push.one(self, &stack, node.data.binary.left)) return true;
-                        if (!push.one(self, &stack, node.data.binary.right)) return true;
-                    },
-                    .static_member_expression,
-                    .computed_member_expression,
-                    .tagged_template_expression,
-                    => {
-                        const extras = self.ast.extra_data.items;
-                        const e = node.data.extra;
-                        if (!push.one(self, &stack, @enumFromInt(extras[e]))) return true;
-                        if (!push.one(self, &stack, @enumFromInt(extras[e + 1]))) return true;
-                    },
-                    .conditional_expression,
-                    .if_statement,
-                    .for_in_statement,
-                    .for_of_statement,
-                    .try_statement,
-                    => {
-                        if (!push.one(self, &stack, node.data.ternary.a)) return true;
-                        if (!push.one(self, &stack, node.data.ternary.b)) return true;
-                        if (!push.one(self, &stack, node.data.ternary.c)) return true;
-                    },
-                    .catch_clause,
-                    .while_statement,
-                    .do_while_statement,
-                    .labeled_statement,
-                    => {
-                        if (!push.one(self, &stack, node.data.binary.left)) return true;
-                        if (!push.one(self, &stack, node.data.binary.right)) return true;
-                    },
-                    .for_statement => {
-                        const extras = self.ast.extra_data.items;
-                        const e = node.data.extra;
-                        if (e + 3 >= extras.len) continue;
-                        if (!push.one(self, &stack, @enumFromInt(extras[e + 3]))) return true; // body
-                    },
-                    .switch_statement, .variable_declaration => {
-                        // extra = [_, list_start, list_len]
-                        const extras = self.ast.extra_data.items;
-                        const e = node.data.extra;
-                        if (e + 2 >= extras.len) continue;
-                        const list_start = extras[e + 1];
-                        const list_len = extras[e + 2];
-                        const items = extras[list_start .. list_start + list_len];
-                        for (items) |raw_idx| {
-                            if (!push.one(self, &stack, @enumFromInt(raw_idx))) return true;
-                        }
-                    },
-                    .switch_case => {
-                        // extra = [test, stmts_start, stmts_len] — test 는 yield 안 가짐 (literal)
-                        const extras = self.ast.extra_data.items;
-                        const e = node.data.extra;
-                        if (e + 2 >= extras.len) continue;
-                        const stmts_start = extras[e + 1];
-                        const stmts_len = extras[e + 2];
-                        const stmts = extras[stmts_start .. stmts_start + stmts_len];
-                        for (stmts) |raw_idx| {
-                            if (!push.one(self, &stack, @enumFromInt(raw_idx))) return true;
-                        }
-                    },
-                    .call_expression, .new_expression => {
-                        // extra = [callee, args_start, args_len, flags]
-                        const extras = self.ast.extra_data.items;
-                        const e = node.data.extra;
-                        if (e + 2 >= extras.len) continue;
-                        if (!push.one(self, &stack, @enumFromInt(extras[e]))) return true;
-                        const args_start = extras[e + 1];
-                        const args_len = extras[e + 2];
-                        const args = extras[args_start .. args_start + args_len];
-                        for (args) |raw_idx| {
-                            if (!push.one(self, &stack, @enumFromInt(raw_idx))) return true;
-                        }
-                    },
-                    .variable_declarator => {
-                        const extras = self.ast.extra_data.items;
-                        const e = node.data.extra;
-                        if (e + 2 >= extras.len) continue;
-                        if (!push.one(self, &stack, @enumFromInt(extras[e + 2]))) return true; // init
-                    },
-                    else => {},
-                }
-            }
-            return false;
-        }
-
-        /// AST 서브트리에 return_statement가 있는지 체크.
-        /// generator 내 if body에서 return이 있으면 collectOperations로 처리해야
-        /// return [2]로 변환됨.
-        ///
-        /// 명시 stack DFS — recursive 였을 때 deep AST 에서 stack overflow 위험.
-        /// containsYield (#2803) 와 동일 변환 패턴. behavior 100% 보존.
-        fn containsReturn(self: *const Transformer, root_idx: NodeIndex) bool {
-            if (root_idx.isNone()) return false;
-            var stack: std.ArrayList(NodeIndex) = .empty;
-            defer stack.deinit(self.allocator);
-            stack.append(self.allocator, root_idx) catch return true;
-
-            while (stack.items.len > 0) {
-                const idx = stack.pop() orelse break;
-                if (idx.isNone()) continue;
-                const node = self.ast.getNode(idx);
-
-                if (node.tag == .return_statement) return true;
-                // function/arrow 경계: nested 함수의 return 은 다른 스코프
-                if (node.tag == .function_declaration or node.tag == .function_expression or
-                    node.tag == .arrow_function_expression) continue;
-
-                const push = struct {
-                    fn one(self_: *const Transformer, st: *std.ArrayList(NodeIndex), child: NodeIndex) bool {
-                        st.append(self_.allocator, child) catch return false;
-                        return true;
-                    }
-                };
-
-                switch (node.tag) {
-                    .block_statement, .function_body => {
-                        const members = self.ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
-                        for (members) |raw_idx| {
-                            if (!push.one(self, &stack, @enumFromInt(raw_idx))) return true;
-                        }
-                    },
-                    .if_statement, .for_in_statement, .for_of_statement => {
-                        if (!push.one(self, &stack, node.data.ternary.b)) return true;
-                        if (!push.one(self, &stack, node.data.ternary.c)) return true;
-                    },
-                    .while_statement, .do_while_statement, .labeled_statement => {
-                        if (!push.one(self, &stack, node.data.binary.right)) return true;
-                    },
-                    .for_statement => {
-                        const extras = self.ast.extra_data.items;
-                        const e = node.data.extra;
-                        if (e + 3 >= extras.len) continue;
-                        if (!push.one(self, &stack, @enumFromInt(extras[e + 3]))) return true;
-                    },
-                    .switch_statement => {
-                        const extras = self.ast.extra_data.items;
-                        const e = node.data.extra;
-                        if (e + 2 >= extras.len) continue;
-                        const cases_start = extras[e + 1];
-                        const cases_len = extras[e + 2];
-                        const cases = extras[cases_start .. cases_start + cases_len];
-                        for (cases) |raw_idx| {
-                            if (!push.one(self, &stack, @enumFromInt(raw_idx))) return true;
-                        }
-                    },
-                    .switch_case => {
-                        const extras = self.ast.extra_data.items;
-                        const e = node.data.extra;
-                        if (e + 2 >= extras.len) continue;
-                        const stmts_start = extras[e + 1];
-                        const stmts_len = extras[e + 2];
-                        const stmts = extras[stmts_start .. stmts_start + stmts_len];
-                        for (stmts) |raw_idx| {
-                            if (!push.one(self, &stack, @enumFromInt(raw_idx))) return true;
-                        }
-                    },
-                    .try_statement => {
-                        if (!push.one(self, &stack, node.data.ternary.a)) return true;
-                        if (!push.one(self, &stack, node.data.ternary.b)) return true;
-                        if (!push.one(self, &stack, node.data.ternary.c)) return true;
-                    },
-                    else => {},
-                }
-            }
-            return false;
         }
 
         /// expression body (arrow function 등)를 state machine으로 변환.
@@ -1712,7 +1469,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             }
 
             // yield를 포함하지 않으면 일반 visit
-            if (!containsYield(self, expr_idx)) {
+            if (!es2015_scan.containsYield(self, expr_idx)) {
                 return self.visitNode(expr_idx);
             }
 

--- a/src/transformer/es2015_generator/scan.zig
+++ b/src/transformer/es2015_generator/scan.zig
@@ -1,0 +1,240 @@
+//! AST scan helpers for ES2015 generator lowering.
+
+const std = @import("std");
+const ast_mod = @import("../../parser/ast.zig");
+const NodeIndex = ast_mod.NodeIndex;
+
+fn pushNode(self: anytype, stack: *std.ArrayList(NodeIndex), child: NodeIndex) bool {
+    stack.append(self.allocator, child) catch return false;
+    return true;
+}
+
+/// AST 서브트리에 yield_expression 또는 generator labeled jump가 있는지 체크.
+///
+/// 명시 stack DFS — recursive 였을 때 deep AST 에서 stack overflow 위험. children
+/// enumeration 은 기존 switch 구조 그대로 유지 (behavior 100% 보존). short-circuit
+/// `or` 는 children 을 모두 push 한 뒤 다음 iteration 에서 자연 종료.
+///
+/// OOM 시 보수적으로 true 반환 — state machine 변환을 안 하는 것보다 하는 게 안전
+/// (호출부가 더 보수적 변환 path 선택).
+pub fn containsYield(self: anytype, root_idx: NodeIndex) bool {
+    if (root_idx.isNone()) return false;
+    var stack: std.ArrayList(NodeIndex) = .empty;
+    defer stack.deinit(self.allocator);
+    stack.append(self.allocator, root_idx) catch return true;
+
+    while (stack.items.len > 0) {
+        const idx = stack.pop() orelse break;
+        if (idx.isNone()) continue;
+        const node = self.ast.getNode(idx);
+
+        if (node.tag == .yield_expression or node.tag == .await_expression) return true;
+        if (node.tag == .break_statement or node.tag == .continue_statement) {
+            if (node.data.unary.operand.isNone()) {
+                if (self.generator_label_stack.items.len > 0) return true;
+            } else if (self.generator_label_stack.items.len > 0) {
+                const label_node = self.ast.getNode(node.data.unary.operand);
+                const label_text = self.ast.getText(label_node.span);
+                for (self.generator_label_stack.items) |entry| {
+                    if (std.mem.eql(u8, entry.name, label_text)) return true;
+                }
+            }
+        }
+        // function/arrow 경계: nested generator/arrow 의 yield 는 다른 스코프
+        if (node.tag == .function_declaration or node.tag == .function_expression or
+            node.tag == .arrow_function_expression) continue;
+
+        switch (node.tag) {
+            .block_statement,
+            .function_body,
+            .array_expression,
+            .object_expression,
+            .sequence_expression,
+            .template_literal,
+            .formal_parameters,
+            .class_body,
+            => {
+                const members = self.ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
+                for (members) |raw_idx| {
+                    if (!pushNode(self, &stack, @enumFromInt(raw_idx))) return true;
+                }
+            },
+            .expression_statement,
+            .return_statement,
+            .throw_statement,
+            .spread_element,
+            .rest_element,
+            .parenthesized_expression,
+            => {
+                if (!pushNode(self, &stack, node.data.unary.operand)) return true;
+            },
+            .unary_expression, .update_expression => {
+                const extras = self.ast.extra_data.items;
+                const e = node.data.extra;
+                if (e >= extras.len) continue;
+                if (!pushNode(self, &stack, @enumFromInt(extras[e]))) return true;
+            },
+            .assignment_expression,
+            .binary_expression,
+            .logical_expression,
+            .object_property,
+            => {
+                if (!pushNode(self, &stack, node.data.binary.left)) return true;
+                if (!pushNode(self, &stack, node.data.binary.right)) return true;
+            },
+            .static_member_expression,
+            .computed_member_expression,
+            .tagged_template_expression,
+            => {
+                const extras = self.ast.extra_data.items;
+                const e = node.data.extra;
+                if (!pushNode(self, &stack, @enumFromInt(extras[e]))) return true;
+                if (!pushNode(self, &stack, @enumFromInt(extras[e + 1]))) return true;
+            },
+            .conditional_expression,
+            .if_statement,
+            .for_in_statement,
+            .for_of_statement,
+            .try_statement,
+            => {
+                if (!pushNode(self, &stack, node.data.ternary.a)) return true;
+                if (!pushNode(self, &stack, node.data.ternary.b)) return true;
+                if (!pushNode(self, &stack, node.data.ternary.c)) return true;
+            },
+            .catch_clause,
+            .while_statement,
+            .do_while_statement,
+            .labeled_statement,
+            => {
+                if (!pushNode(self, &stack, node.data.binary.left)) return true;
+                if (!pushNode(self, &stack, node.data.binary.right)) return true;
+            },
+            .for_statement => {
+                const extras = self.ast.extra_data.items;
+                const e = node.data.extra;
+                if (e + 3 >= extras.len) continue;
+                if (!pushNode(self, &stack, @enumFromInt(extras[e + 3]))) return true; // body
+            },
+            .switch_statement, .variable_declaration => {
+                // extra = [_, list_start, list_len]
+                const extras = self.ast.extra_data.items;
+                const e = node.data.extra;
+                if (e + 2 >= extras.len) continue;
+                const list_start = extras[e + 1];
+                const list_len = extras[e + 2];
+                const items = extras[list_start .. list_start + list_len];
+                for (items) |raw_idx| {
+                    if (!pushNode(self, &stack, @enumFromInt(raw_idx))) return true;
+                }
+            },
+            .switch_case => {
+                // extra = [test, stmts_start, stmts_len] — test 는 yield 안 가짐 (literal)
+                const extras = self.ast.extra_data.items;
+                const e = node.data.extra;
+                if (e + 2 >= extras.len) continue;
+                const stmts_start = extras[e + 1];
+                const stmts_len = extras[e + 2];
+                const stmts = extras[stmts_start .. stmts_start + stmts_len];
+                for (stmts) |raw_idx| {
+                    if (!pushNode(self, &stack, @enumFromInt(raw_idx))) return true;
+                }
+            },
+            .call_expression, .new_expression => {
+                // extra = [callee, args_start, args_len, flags]
+                const extras = self.ast.extra_data.items;
+                const e = node.data.extra;
+                if (e + 2 >= extras.len) continue;
+                if (!pushNode(self, &stack, @enumFromInt(extras[e]))) return true;
+                const args_start = extras[e + 1];
+                const args_len = extras[e + 2];
+                const args = extras[args_start .. args_start + args_len];
+                for (args) |raw_idx| {
+                    if (!pushNode(self, &stack, @enumFromInt(raw_idx))) return true;
+                }
+            },
+            .variable_declarator => {
+                const extras = self.ast.extra_data.items;
+                const e = node.data.extra;
+                if (e + 2 >= extras.len) continue;
+                if (!pushNode(self, &stack, @enumFromInt(extras[e + 2]))) return true; // init
+            },
+            else => {},
+        }
+    }
+    return false;
+}
+
+/// AST 서브트리에 return_statement가 있는지 체크.
+/// generator 내 if body에서 return이 있으면 collectOperations로 처리해야
+/// return [2]로 변환됨.
+///
+/// 명시 stack DFS — recursive 였을 때 deep AST 에서 stack overflow 위험.
+/// containsYield (#2803) 와 동일 변환 패턴. behavior 100% 보존.
+pub fn containsReturn(self: anytype, root_idx: NodeIndex) bool {
+    if (root_idx.isNone()) return false;
+    var stack: std.ArrayList(NodeIndex) = .empty;
+    defer stack.deinit(self.allocator);
+    stack.append(self.allocator, root_idx) catch return true;
+
+    while (stack.items.len > 0) {
+        const idx = stack.pop() orelse break;
+        if (idx.isNone()) continue;
+        const node = self.ast.getNode(idx);
+
+        if (node.tag == .return_statement) return true;
+        // function/arrow 경계: nested 함수의 return 은 다른 스코프
+        if (node.tag == .function_declaration or node.tag == .function_expression or
+            node.tag == .arrow_function_expression) continue;
+
+        switch (node.tag) {
+            .block_statement, .function_body => {
+                const members = self.ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
+                for (members) |raw_idx| {
+                    if (!pushNode(self, &stack, @enumFromInt(raw_idx))) return true;
+                }
+            },
+            .if_statement, .for_in_statement, .for_of_statement => {
+                if (!pushNode(self, &stack, node.data.ternary.b)) return true;
+                if (!pushNode(self, &stack, node.data.ternary.c)) return true;
+            },
+            .while_statement, .do_while_statement, .labeled_statement => {
+                if (!pushNode(self, &stack, node.data.binary.right)) return true;
+            },
+            .for_statement => {
+                const extras = self.ast.extra_data.items;
+                const e = node.data.extra;
+                if (e + 3 >= extras.len) continue;
+                if (!pushNode(self, &stack, @enumFromInt(extras[e + 3]))) return true;
+            },
+            .switch_statement => {
+                const extras = self.ast.extra_data.items;
+                const e = node.data.extra;
+                if (e + 2 >= extras.len) continue;
+                const cases_start = extras[e + 1];
+                const cases_len = extras[e + 2];
+                const cases = extras[cases_start .. cases_start + cases_len];
+                for (cases) |raw_idx| {
+                    if (!pushNode(self, &stack, @enumFromInt(raw_idx))) return true;
+                }
+            },
+            .switch_case => {
+                const extras = self.ast.extra_data.items;
+                const e = node.data.extra;
+                if (e + 2 >= extras.len) continue;
+                const stmts_start = extras[e + 1];
+                const stmts_len = extras[e + 2];
+                const stmts = extras[stmts_start .. stmts_start + stmts_len];
+                for (stmts) |raw_idx| {
+                    if (!pushNode(self, &stack, @enumFromInt(raw_idx))) return true;
+                }
+            },
+            .try_statement => {
+                if (!pushNode(self, &stack, node.data.ternary.a)) return true;
+                if (!pushNode(self, &stack, node.data.ternary.b)) return true;
+                if (!pushNode(self, &stack, node.data.ternary.c)) return true;
+            },
+            else => {},
+        }
+    }
+    return false;
+}


### PR DESCRIPTION
## 요약
- `src/transformer/es2015_generator.zig` 내부의 AST scan helper를 `src/transformer/es2015_generator/scan.zig`로 분리했습니다.
- `containsYield` / `containsReturn` 호출은 새 모듈 경유로 바꾸고, scan 로직 자체는 기존 DFS 동작을 유지했습니다.
- `src/transformer/es2015_generator.zig` 라인 수를 2178줄에서 1935줄로 줄였습니다.

## 검증
- `zig fmt --check src/transformer/es2015_generator.zig src/transformer/es2015_generator/scan.zig`
- `git diff --check`
- `zig build test`
- `zig build napi`
- `bun test --cwd tests/integration tests/tsc/generators.test.ts tests/tsc/es6-yieldExpressions.test.ts tests/tsc/es6-for-ofStatements.test.ts`
- `.git/hooks/pre-push` (기존 oxlint warning 23개, error 0개)