### PR TITLE
ci: bun install --frozen-lockfile 일괄 + emotion-v10 fixture install

### DIFF
--- a/.github/actions/setup-zntc/action.yml
+++ b/.github/actions/setup-zntc/action.yml
@@ -94,5 +94,5 @@ runs:
 
     - name: Install dependencies
       if: ${{ inputs.install == 'true' }}
-      run: bun install
+      run: bun install --frozen-lockfile
       shell: bash

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -51,7 +51,7 @@ jobs:
         run: zig build -Doptimize=ReleaseFast
 
       - name: Install benchmark dependencies
-        run: bun install --cwd tests/benchmark
+        run: bun install --cwd tests/benchmark --frozen-lockfile
 
       - name: Build NAPI module (Windows, MinGW ABI)
         if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
           node-version: 24
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build NAPI module (Windows, MinGW ABI)
         if: runner.os == 'Windows'
@@ -230,7 +230,7 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build NAPI module
         shell: bash
@@ -347,7 +347,7 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build WASM (transpile)
         run: zig build wasm

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
         run: zig build wasm wasm-bundler
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       # documents/package.json 의 prebuild 가 zig-out/bin/zntc.wasm + zntc-bundler.wasm 을
       # public/ 으로 복사 — playground (transpile) + playground/bundler 둘 다 동작.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Lint (oxlint)
         run: bun run lint
@@ -136,7 +136,11 @@ jobs:
           artifact-name: zntc-build-ubuntu-latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
+
+      # emotion-v10 fixture 는 root workspace 미포함 — 격리 install 필요.
+      - name: Install emotion v10 fixture deps
+        run: cd tests/integration/fixtures/emotion-v10 && bun install --frozen-lockfile
 
       - name: Run integration tests
         run: bun run test:integration
@@ -153,7 +157,11 @@ jobs:
           artifact-name: zntc-build-macos-latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
+
+      # emotion-v10 fixture 는 root workspace 미포함 — 격리 install 필요.
+      - name: Install emotion v10 fixture deps
+        run: cd tests/integration/fixtures/emotion-v10 && bun install --frozen-lockfile
 
       - name: Run integration tests
         run: bun run test:integration
@@ -170,7 +178,7 @@ jobs:
           artifact-name: zntc-build-macos-latest
 
       - name: Install RN example app dependencies
-        run: cd tests/integration/tests/fixtures/rn-example-app && bun install
+        run: cd tests/integration/tests/fixtures/rn-example-app && bun install --frozen-lockfile
 
       - name: Install hermes-engine-cli (runtime)
         run: npm install -g hermes-engine-cli
@@ -191,7 +199,7 @@ jobs:
           napi: "false"
 
       - name: Install compat-table
-        run: cd tests/integration && bun install
+        run: cd tests/integration && bun install --frozen-lockfile
 
       - name: Extract compat-table tests
         run: cd tests/integration && node tests/compat-table-extract.cjs > tests/fixtures/compat-table-tests.json
@@ -221,7 +229,7 @@ jobs:
           artifact-name: zntc-build-ubuntu-latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       # E2E test fixture 가 spawn 한 `zntc build` (app 모드) 가 `@zntc/web` 을
       # lazy import. ZNTC artifact 는 core build:js 까지만 — web/server 와 core
@@ -252,7 +260,7 @@ jobs:
           napi: "false"
 
       - name: Install smoke dependencies
-        run: cd tests/benchmark && bun install
+        run: cd tests/benchmark && bun install --frozen-lockfile
 
       - name: Run smoke tests
         run: bun run tests/benchmark/smoke.ts 2>&1 | tee smoke-output.txt


### PR DESCRIPTION
## Summary
- CI 의 `bun install` 호출 15곳에 `--frozen-lockfile` 일괄 적용 — lockfile drift 가 머지된 채 통과되는 사고 방지
- `integration-ubuntu` / `integration-macos` job 에 emotion v10 fixture install step 추가 — `tests/integration/tests/emotion-v10.test.ts` 13개 테스트가 fixture 미설치로 항상 skip 되던 문제 해결

## 배경
emotion v10 (`@emotion/core`) 은 v11 (`@emotion/react`) 과 같은 트리에 공존이 어려워 `tests/integration/fixtures/emotion-v10/` 에 격리 fixture 로 분리되어 있음. root workspace 에 등록되지 않아 `bun install` 만으론 설치되지 않으며, `hasEmotionV10Fixture()` 가드 (`tests/integration/tests/helpers.ts:192`) 가 fixture 부재 시 13개 테스트를 skip 함. 그동안 CI 에선 fixture install 단계가 누락되어 항상 skip 처리되고 있었음 — cache key 에는 이미 `tests/integration/fixtures/emotion-v10/bun.lock` 가 포함되어 있어 install step 만 추가하면 됨.

## 변경 파일
- `.github/workflows/integration.yml` — 9곳 frozen 화 + 신규 fixture install step 2개 (ubuntu / macos)
- `.github/workflows/ci.yml` — 3곳 frozen 화
- `.github/workflows/benchmark.yml`, `docs.yml` — 각 1곳 frozen 화
- `.github/actions/setup-zntc/action.yml` — composite action 내 install step frozen 화

## Test plan
- [ ] CI green — 특히 `Integration Tests (ubuntu-latest)` / `(macos-latest)` 에서 emotion-v10 13개 테스트가 skip 이 아니라 pass 로 잡히는지 로그 확인
- [ ] 어떤 install step 도 `--frozen-lockfile` 위반 (lockfile drift) 으로 깨지지 않는지 확인 — 깨지면 lockfile 정리 필요

## 후속 (별도 PR 권장)
- `setup-zntc/action.yml` 와 `use-zntc-artifact/action.yml` 의 cache `hashFiles(...)` 6-arg 가 동일하게 손-복제되어 drift 위험 → 캐시 단독 composite (`.github/actions/bun-cache/action.yml`) 로 분리
- fixture 가 3개 이상 누적되면 fixture install 도 composite 화

🤖 Generated with [Claude Code](https://claude.com/claude-code)