### PR TITLE
ci(release): release.yml 매트릭스 NAPI 빌드 + npm publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,79 @@ on:
     tags:
       - 'v*'
 
+# permissions:
+#   contents: write   — github-release job (CLI binary tarball 업로드)
+#   id-token: write   — publish-npm job (npm OIDC trusted publishing 준비)
+# 첫 publish 는 NPM_TOKEN 으로. trusted publisher 등록 + NPM_TOKEN 삭제 후엔
+# OIDC 만으로 동작 (--provenance 자동 부착).
 permissions:
   contents: write
+  id-token: write
 
 jobs:
-  build:
-    name: Build ${{ matrix.target }}
+  # ─── NAPI 바이너리 매트릭스 빌드 ───
+  # PLATFORMS in scripts/lib/platforms.ts 와 sync (YAML 정적 한계). 5 platform
+  # 각각 native runner 에서 zig build napi → zntc.node artifact.
+  build-napi:
+    name: Build NAPI (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - platform: linux-x64-gnu
+            runner: ubuntu-latest
+            zig_target: x86_64-linux-gnu
+          - platform: linux-arm64-gnu
+            runner: ubuntu-24.04-arm
+            zig_target: aarch64-linux-gnu
+          - platform: darwin-x64
+            runner: macos-15-intel
+            zig_target: x86_64-macos
+          - platform: darwin-arm64
+            runner: macos-latest
+            zig_target: aarch64-macos
+          - platform: win32-x64-msvc
+            runner: windows-latest
+            zig_target: x86_64-windows-msvc
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - name: Build NAPI (ReleaseFast)
+        shell: bash
+        run: zig build napi -Doptimize=ReleaseFast -Dtarget=${{ matrix.zig_target }}
+
+      - name: Locate zntc.node
+        id: locate
+        shell: bash
+        run: |
+          if [ -f "zig-out/lib/zntc.node" ]; then
+            echo "path=zig-out/lib/zntc.node" >> "$GITHUB_OUTPUT"
+          elif [ -f "zig-out/bin/zntc.node" ]; then
+            echo "path=zig-out/bin/zntc.node" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::zntc.node not found after zig build napi"
+            exit 1
+          fi
+
+      - name: Upload zntc.node artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zntc-node-${{ matrix.platform }}
+          if-no-files-found: error
+          retention-days: 1
+          path: ${{ steps.locate.outputs.path }}
+
+  # ─── CLI 바이너리 매트릭스 (GitHub Release tarball) ───
+  build-cli:
+    name: Build CLI (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -19,10 +86,10 @@ jobs:
             os: ubuntu-latest
             artifact: zntc-x86_64-linux
           - target: aarch64-linux
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
             artifact: zntc-aarch64-linux
           - target: x86_64-macos
-            os: macos-latest
+            os: macos-15-intel
             artifact: zntc-x86_64-macos
           - target: aarch64-macos
             os: macos-latest
@@ -32,46 +99,125 @@ jobs:
             artifact: zntc-x86_64-windows
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+      - uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
 
-      - name: Build (ReleaseFast)
+      - name: Build CLI (ReleaseFast)
         run: zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.target }}
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
+          if-no-files-found: error
+          retention-days: 1
           path: zig-out/bin/
 
-  release:
-    name: Create Release
-    needs: build
+  # ─── npm publish (5 sub-package + main + 나머지) ───
+  publish-npm:
+    name: Publish to npm
+    needs: build-napi
     runs-on: ubuntu-latest
 
     steps:
-      - name: Download all artifacts
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.2
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+
+      - uses: ./.github/actions/bun-cache
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Download all NAPI artifacts
         uses: actions/download-artifact@v4
         with:
+          path: napi-artifacts/
+          pattern: zntc-node-*
+
+      # build-napi 매트릭스의 artifact 디렉토리 자체를 glob — platform 이름 hardcoded
+      # 제거 (PLATFORMS 가 늘면 release.yml 매트릭스만 추가하면 자동 픽업).
+      - name: Distribute zntc.node into platform sub-packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          for dir in napi-artifacts/zntc-node-*/; do
+            platform="${dir#napi-artifacts/zntc-node-}"
+            platform="${platform%/}"
+            src="${dir}zntc.node"
+            dst="packages/core-${platform}/zntc.node"
+            if [ ! -f "$src" ]; then
+              echo "::error::missing artifact: $src"
+              exit 1
+            fi
+            if [ ! -d "packages/core-${platform}" ]; then
+              echo "::error::sub-package directory missing: packages/core-${platform}"
+              exit 1
+            fi
+            cp "$src" "$dst"
+            size=$(stat -c%s "$dst" 2>/dev/null || stat -f%z "$dst")
+            echo "✓ ${dst} (${size} bytes)"
+          done
+
+      # dist-tag 자동 감지: v0.1.0 → latest, v0.1.0-rc.1 → rc, v0.1.0-beta.1 → beta
+      - name: Determine npm dist-tag
+        id: tag
+        shell: bash
+        run: |
+          REF="${{ github.ref_name }}"
+          VERSION="${REF#v}"
+          if [[ "$VERSION" == *-* ]]; then
+            PREID="${VERSION#*-}"
+            DIST_TAG="${PREID%%.*}"
+          else
+            DIST_TAG="latest"
+          fi
+          echo "dist-tag=${DIST_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Will publish with --tag ${DIST_TAG}"
+
+      - name: Publish via release.ts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: bun scripts/release.ts --publish --yes --tag "${{ steps.tag.outputs.dist-tag }}"
+
+  # ─── GitHub Release (CLI binary tarball) ───
+  github-release:
+    name: Create GitHub Release
+    needs: [build-cli, publish-npm]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
           path: artifacts/
+          pattern: zntc-*-*
 
       - name: Create tarballs
         run: |
           cd artifacts
-          for dir in */; do
+          for dir in zntc-*/; do
             name="${dir%/}"
             tar -czf "${name}.tar.gz" -C "$dir" .
           done
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: artifacts/*.tar.gz
+          files: artifacts/zntc-*.tar.gz

--- a/packages/core-darwin-arm64/package.json
+++ b/packages/core-darwin-arm64/package.json
@@ -13,5 +13,8 @@
   "cpu": [
     "arm64"
   ],
-  "main": "zntc.node"
+  "main": "zntc.node",
+  "scripts": {
+    "prepublishOnly": "node ../../scripts/check-platform-binary.mjs"
+  }
 }

--- a/packages/core-darwin-x64/package.json
+++ b/packages/core-darwin-x64/package.json
@@ -13,5 +13,8 @@
   "cpu": [
     "x64"
   ],
-  "main": "zntc.node"
+  "main": "zntc.node",
+  "scripts": {
+    "prepublishOnly": "node ../../scripts/check-platform-binary.mjs"
+  }
 }

--- a/packages/core-linux-arm64-gnu/package.json
+++ b/packages/core-linux-arm64-gnu/package.json
@@ -16,5 +16,8 @@
   "libc": [
     "glibc"
   ],
-  "main": "zntc.node"
+  "main": "zntc.node",
+  "scripts": {
+    "prepublishOnly": "node ../../scripts/check-platform-binary.mjs"
+  }
 }

--- a/packages/core-linux-x64-gnu/package.json
+++ b/packages/core-linux-x64-gnu/package.json
@@ -16,5 +16,8 @@
   "libc": [
     "glibc"
   ],
-  "main": "zntc.node"
+  "main": "zntc.node",
+  "scripts": {
+    "prepublishOnly": "node ../../scripts/check-platform-binary.mjs"
+  }
 }

--- a/packages/core-win32-x64-msvc/package.json
+++ b/packages/core-win32-x64-msvc/package.json
@@ -13,5 +13,8 @@
   "cpu": [
     "x64"
   ],
-  "main": "zntc.node"
+  "main": "zntc.node",
+  "scripts": {
+    "prepublishOnly": "node ../../scripts/check-platform-binary.mjs"
+  }
 }

--- a/scripts/check-platform-binary.mjs
+++ b/scripts/check-platform-binary.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+// 5개 sub-package 의 prepublishOnly hook + scripts/release.ts:verifySubPackageBinary 가
+// 공통 사용 — 빈 placeholder zntc.node 의 npm publish 차단.
+//
+// 사용:
+//   node check-platform-binary.mjs [path]   # default: ./zntc.node
+import { existsSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const target = resolve(process.cwd(), process.argv[2] ?? 'zntc.node');
+const MIN_SIZE = 1000;
+
+if (!existsSync(target)) {
+  throw new Error(
+    `${target} 누락 — release.yml 매트릭스 빌드가 platform binary 를 sub-package 에 분배해야 합니다.`,
+  );
+}
+const size = statSync(target).size;
+if (size < MIN_SIZE) {
+  throw new Error(`${target} 너무 작음 (${size} bytes < ${MIN_SIZE}) — placeholder 의심`);
+}

--- a/scripts/lib/platforms.ts
+++ b/scripts/lib/platforms.ts
@@ -1,0 +1,76 @@
+/**
+ * NAPI publish 의 platform 매트릭스 단일 source.
+ *
+ * 새 platform 추가 시 (예: musl, riscv, android):
+ *   1. 여기에 entry 추가
+ *   2. `packages/core-{name}/` skeleton 생성 (package.json + README)
+ *   3. `packages/core/index.ts:getPlatformPackage()` 매핑 추가
+ *   4. `.github/workflows/release.yml` 매트릭스에 추가 (이 파일과 sync — YAML 정적 한계)
+ *   5. `.github/workflows/ci.yml:napi-package-smoke` 매트릭스도 sync
+ *
+ * win32 정책: napi-rs/swc/oxc 컨벤션 따름 — MSVC 만 publish, mingw/gnu 안 함
+ * (GHA windows-latest = MSVC node 라 install 매칭 자체가 의미 없음).
+ */
+
+export interface PlatformTarget {
+  /** sub-package suffix (e.g. "linux-x64-gnu"). `@zntc/core-${name}` 가 npm 이름. */
+  name: string;
+  /** npm `os` 필드 — install 매칭. */
+  npmOs: 'linux' | 'darwin' | 'win32';
+  /** npm `cpu` 필드. */
+  npmCpu: 'x64' | 'arm64';
+  /** npm `libc` 필드 (linux 만). */
+  npmLibc?: 'glibc' | 'musl';
+  /** `zig build napi -Dtarget=<zigTarget>` */
+  zigTarget: string;
+  /** GitHub Actions runner — release.yml/ci.yml 매트릭스에서도 동일 사용. */
+  ghaRunner: string;
+}
+
+export const PLATFORMS: PlatformTarget[] = [
+  {
+    name: 'linux-x64-gnu',
+    npmOs: 'linux',
+    npmCpu: 'x64',
+    npmLibc: 'glibc',
+    zigTarget: 'x86_64-linux-gnu',
+    ghaRunner: 'ubuntu-latest',
+  },
+  {
+    name: 'linux-arm64-gnu',
+    npmOs: 'linux',
+    npmCpu: 'arm64',
+    npmLibc: 'glibc',
+    zigTarget: 'aarch64-linux-gnu',
+    ghaRunner: 'ubuntu-24.04-arm',
+  },
+  {
+    name: 'darwin-x64',
+    npmOs: 'darwin',
+    npmCpu: 'x64',
+    zigTarget: 'x86_64-macos',
+    ghaRunner: 'macos-15-intel',
+  },
+  {
+    name: 'darwin-arm64',
+    npmOs: 'darwin',
+    npmCpu: 'arm64',
+    zigTarget: 'aarch64-macos',
+    ghaRunner: 'macos-latest',
+  },
+  {
+    name: 'win32-x64-msvc',
+    npmOs: 'win32',
+    npmCpu: 'x64',
+    zigTarget: 'x86_64-windows-msvc',
+    ghaRunner: 'windows-latest',
+  },
+];
+
+export function subPackageName(platform: PlatformTarget): string {
+  return `@zntc/core-${platform.name}`;
+}
+
+export function subPackageDir(platform: PlatformTarget): string {
+  return `packages/core-${platform.name}`;
+}

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -3,26 +3,29 @@
  *
  * 안전 기본값:
  * - default 는 dry-run (실제 publish 안 함)
- * - 실제 publish 는 `--publish` flag 명시 + stdin 'yes' confirm 모두 필요
+ * - 실제 publish 는 `--publish` flag 명시 + stdin 'yes' confirm 모두 필요 (CI 는 --yes 로 우회)
  * - pre-release-check 통과 강제
  * - npm registry 에 이미 같은 version 이 publish 됐으면 그 패키지 skip (idempotent)
+ * - sub-package (`@zntc/core-{platform}`) 의 zntc.node 누락/빈 파일 검증 — 빈 binary publish 차단
  *
  * 사용:
- *   bun scripts/release.ts                 # dry-run, 변경 없음
- *   bun scripts/release.ts --publish       # confirm 후 실제 publish (--access public)
+ *   bun scripts/release.ts                       # dry-run, 변경 없음
+ *   bun scripts/release.ts --publish             # confirm 후 실제 publish (--access public)
+ *   bun scripts/release.ts --publish --yes       # confirm prompt 우회 (CI/release.yml 자동화)
  *   bun scripts/release.ts --publish --tag next  # dist-tag 'next' 로
  *
- * publish 순서: core → server (skip, private) → web / react-native /
- * vite-plugin-zntc / wasm / init (core 만 의존하므로 순서 무관)
+ * publish 순서: platform sub-package 5개 (no deps, main 의 optionalDependencies)
+ *   → core → server (skip, private) → web / react-native / vite-plugin-zntc / wasm / init
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, statSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { createInterface } from 'node:readline/promises';
 import { dirname, join, resolve } from 'node:path';
 import { stdin, stdout } from 'node:process';
 import { fileURLToPath } from 'node:url';
+import { PLATFORMS, subPackageDir } from './lib/platforms.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
@@ -31,10 +34,15 @@ interface ReleaseTarget {
   dir: string;
   name: string;
   version: string;
+  isPlatformSubPackage: boolean;
 }
 
-// publishable 토폴로지: core 먼저, 그 다음 core 만 의존하는 패키지들
+// publishable 토폴로지:
+//   1) platform sub-package 5개 — main 의 optionalDependencies 가 reference 하므로 먼저 publish
+//   2) core — sub-package 들에 optionalDependency
+//   3) core 만 의존하는 패키지들
 const PUBLISH_ORDER = [
+  ...PLATFORMS.map(subPackageDir),
   'packages/core',
   'packages/web',
   'packages/react-native',
@@ -42,6 +50,22 @@ const PUBLISH_ORDER = [
   'packages/wasm',
   'packages/init',
 ];
+
+const PLATFORM_SUB_DIRS = new Set(PLATFORMS.map(subPackageDir));
+
+// sub-package 디렉토리 안 zntc.node 가 정상 binary 인지 확인 — 빈 placeholder
+// publish 차단. release.yml 매트릭스 빌드가 실제 binary 로 채워야 통과.
+// sub-package 의 prepublishOnly hook (`scripts/check-platform-binary.mjs`) 와
+// 같은 검증 — defense-in-depth.
+function verifySubPackageBinary(dir: string, name: string): void {
+  const res = spawnSync('node', [resolve(__dirname, 'check-platform-binary.mjs'), 'zntc.node'], {
+    cwd: resolve(repoRoot, dir),
+    encoding: 'utf8',
+  });
+  if (res.status !== 0) {
+    throw new Error(`${name}: ${res.stderr.trim() || 'binary 검증 실패'}`);
+  }
+}
 
 async function loadTargets(): Promise<ReleaseTarget[]> {
   const targets: ReleaseTarget[] = [];
@@ -56,7 +80,12 @@ async function loadTargets(): Promise<ReleaseTarget[]> {
       console.log(`skip: ${pkg.name} (private)`);
       continue;
     }
-    targets.push({ dir, name: pkg.name, version: pkg.version });
+    targets.push({
+      dir,
+      name: pkg.name,
+      version: pkg.version,
+      isPlatformSubPackage: PLATFORM_SUB_DIRS.has(dir),
+    });
   }
   return targets;
 }
@@ -82,12 +111,14 @@ async function confirm(prompt: string): Promise<boolean> {
 async function main() {
   const args = process.argv.slice(2);
   const isPublish = args.includes('--publish');
+  const isYes = args.includes('--yes');
   const tagIdx = args.indexOf('--tag');
   const tag = tagIdx >= 0 ? args[tagIdx + 1] : undefined;
 
   console.log('=== ZNTC release ===');
   console.log(`mode: ${isPublish ? 'PUBLISH (실제 publish)' : 'dry-run (변경 없음)'}`);
   if (tag) console.log(`tag: ${tag}`);
+  if (isYes) console.log('confirm: --yes (prompt 우회)');
   console.log();
 
   // 1. pre-release-check 먼저 실행
@@ -97,8 +128,7 @@ async function main() {
     stdio: 'inherit',
   });
   if (checkRes.status !== 0) {
-    console.error('\n❌ pre-release-check 실패 — release 중단');
-    process.exit(1);
+    throw new Error('pre-release-check 실패 — release 중단');
   }
   console.log('\n✓ pre-release-check 통과\n');
 
@@ -139,7 +169,13 @@ async function main() {
   console.log('실제 publish 대상:');
   for (const t of toPublish) console.log(`  - ${t.name}@${t.version}`);
   console.log();
-  const ok = await confirm("확인하시려면 'yes' 입력 (그 외 입력 시 중단): ");
+
+  // sub-package binary 무결성 검증 — 빈 placeholder publish 차단.
+  for (const t of toPublish) {
+    if (t.isPlatformSubPackage) verifySubPackageBinary(t.dir, t.name);
+  }
+
+  const ok = isYes || await confirm("확인하시려면 'yes' 입력 (그 외 입력 시 중단): ");
   if (!ok) {
     console.log('취소됨.');
     return;
@@ -155,12 +191,15 @@ async function main() {
       stdio: 'inherit',
     });
     if (res.status !== 0) {
-      console.error(`\n❌ ${t.name} publish 실패 — 중단 (이전 패키지는 publish 됨)`);
-      process.exit(1);
+      throw new Error(`${t.name} publish 실패 — 중단 (이전 패키지는 publish 됨)`);
     }
   }
 
   console.log('\n=== 모두 publish 완료 ===');
 }
 
-await main();
+await main().catch((e: unknown) => {
+  const msg = e instanceof Error ? e.message : String(e);
+  console.error(`\n❌ ${msg}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
첫 npm publish 의 release blocker 해결의 **PR 2/3** — tag push (`v*`) 시 5 platform NAPI binary 매트릭스 빌드 → sub-package 분배 → npm publish 자동화. dist-tag 자동 감지 (semver prerelease) + OIDC trusted publishing 준비. PR #2935 의 sub-package 모델을 실제로 publish 가능한 흐름으로 연결.

## 변경 요약
- **`scripts/lib/platforms.ts`** (신규): 5 platform manifest 단일 source — npm os/cpu/libc + zig target + GHA runner. release.ts 가 import → PUBLISH_ORDER 동적 생성
- **`scripts/check-platform-binary.mjs`** (신규): zntc.node 존재/크기(>1KB) 검증 — 5 sub-package prepublishOnly + release.ts 가 공통 사용 (defense-in-depth)
- **`scripts/release.ts`**:
  - PUBLISH_ORDER 에 sub-package 5개 추가 (main 보다 먼저 — optionalDeps 매칭 보장)
  - `--yes` flag (CI 자동화 confirm 우회)
  - `process.exit(1)` → `throw` + `main().catch` (stack trace 보존, error 톤 통일)
- **5 sub-package `package.json`**: `prepublishOnly: node ../../scripts/check-platform-binary.mjs` (npm publish lifecycle hook)
- **`release.yml`** 완전 재작성:
  | Job | Needs | 역할 |
  |---|---|---|
  | `build-napi` | - | 5 platform NAPI binary 매트릭스 (각자 native runner) → artifact |
  | `build-cli` | - | 5 platform CLI binary 매트릭스 → artifact |
  | `publish-npm` | build-napi | artifact 다운로드 → sub-package 분배 (glob) → dist-tag 자동 감지 → bun scripts/release.ts |
  | `github-release` | build-cli + publish-npm | CLI tarball + Release notes |

## dist-tag 자동 감지
| Git tag | npm dist-tag | 사용자 install |
|---|---|---|
| `v0.1.0` | `latest` | `npm i @zntc/core` |
| `v0.1.0-rc.1` | `rc` | `npm i @zntc/core@rc` |
| `v0.1.0-beta.1` | `beta` | `npm i @zntc/core@beta` |
| `v0.2.0-next.20260510` | `next` | `npm i @zntc/core@next` |

→ stable 사용자가 `npm install` 했을 때 prerelease 받지 않음 (`latest` 만).

## Manual publish 차단 (3중 defense)
1. `prepublishOnly` hook (sub-package package.json) — npm publish lifecycle 단계에서 zntc.node 검증, 빈 placeholder 시 throw
2. `verifySubPackageBinary()` (release.ts) — release script 단계에서 사전 검증
3. `--yes` flag 명시 + tag push trigger — CI 외 manual 실행 시 confirm prompt 가 stdin EOF 로 'no' 처리되어 publish 안 됨

## OIDC Trusted Publishing 준비 (첫 publish 후 전환)
release.yml 에 `permissions: id-token: write` 미리 두었음. 첫 v0.1.0 publish 후:
1. 각 npm 패키지 페이지 → Settings → Trusted Publishers → GitHub Actions 등록 (`ohah/zntc` + `release.yml`)
2. GitHub Secret 의 `NPM_TOKEN` 삭제
3. release.yml publish 호출에 `--provenance` flag 추가
4. 다음 release 부터 OIDC + sigstore provenance 자동 부착 (NPM_TOKEN 자체 불필요 → leak 위험 0)

## Test plan
- [ ] release.yml 자체 syntax 검증 (act 또는 GitHub UI 의 Validation)
- [ ] dry-run: `bun scripts/release.ts` 가 11개 publishable 패키지 모두 잡는지 (sub-package 5 + main + 5)
- [ ] sub-package prepublishOnly hook: 빈 zntc.node 차단 동작 확인 (이미 dev 검증 ✓)
- [ ] **첫 release 시점 (PR 3)** v0.1.0 tag push → 5 platform binary 빌드 → publish 흐름 end-to-end 검증

## 후속 (PR 3 / 별도)
- **PR 3**: 첫 dry-run 시뮬레이션 + npm `@zntc` org 권한 검증 + CHANGELOG 작성
- **별도 cleanup**: packages/core 의 build script 분리 (release-time 의 zig build napi 중복 — 3-5분 낭비, 결과물 미사용)
- **별도 cleanup**: packages/core/index.ts:getPlatformPackage() → platforms.ts import 통합
- **별도**: test:publish-smoke 에 sub-package cover 추가 (현재 main 만 검사)

## simplify 리뷰 반영
3 agent 종합:
- 🟢 **Reuse Q3**: release.yml `Distribute` step glob 으로 변경 → platform 이름 hardcoded 제거 ✓ 즉시 반영
- 🟢 **Quality #1·2**: 5 sub-package prepublishOnly inline JS → 공유 mjs 추출 ✓ 즉시 반영
- 🟢 **Quality #3**: `process.exit(1)` 분산 → `throw` + main catch 통일 ✓ 즉시 반영
- 🟡 **Efficiency critical**: publish-npm 의 build:publishable 안 zig build napi 중복 → packages/core build script 분리 필요. 영향 범위 (dev workflow / prepublishOnly 등) 커서 follow-up
- 🟡 **Reuse Q2**: core/index.ts → platforms.ts import 통합 (packaging 영향 검토 필요) → follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)