### PR TITLE
fix(core): @zntc/core dual ESM/CJS exports + rspack-loader publish 등록

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,8 +235,8 @@ jobs:
         run: cd packages/core && bun run build:js && bun run build:dts
 
       - name: Copy .node into platform sub-package
-        run: |
-          node -e "const fs=require('node:fs'); const from=['zig-out/lib/zntc.node','zig-out/bin/zntc.node'].find(fs.existsSync); if(!from) throw new Error('zntc.node build artifact not found'); fs.copyFileSync(from, 'packages/core-${{ matrix.platform }}/zntc.node');"
+        shell: bash
+        run: cp zig-out/lib/zntc.node packages/core-${{ matrix.platform }}/zntc.node
 
       # 사용자 시나리오: npm install @zntc/core → main + 환경 매칭 sub-package 1개 install.
       # 두 tarball 같이 install 해서 loader 가 sub-package require.resolve 로 binary 찾는 흐름 검증.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,9 +123,7 @@ jobs:
     needs: build-napi
     runs-on: ubuntu-latest
     env:
-      # main `@zntc/core` 의 prepublishOnly build 가 ZNTC self-host 호출 — runner 와
-      # 일치하는 NAPI artifact 가 packages/core/zntc.node 에 있어야 동작. runs-on
-      # 변경 시 여기 값도 함께 갱신.
+      # `runs-on` 과 매칭 — 변경 시 함께 갱신. 사용처: "Place zntc.node in main package".
       MAIN_BUILD_NAPI_PLATFORM: linux-x64-gnu
 
     steps:
@@ -195,7 +193,8 @@ jobs:
             exit 1
           fi
           cp "$src" packages/core/zntc.node
-          echo "✓ packages/core/zntc.node placed for prepublishOnly build"
+          size=$(stat -c%s packages/core/zntc.node 2>/dev/null || stat -f%z packages/core/zntc.node)
+          echo "✓ packages/core/zntc.node (${size} bytes) — prepublishOnly build"
 
       # dist-tag 자동 감지: v0.1.0 → latest, v0.1.0-rc.1 → rc, v0.1.0-beta.1 → beta
       - name: Determine npm dist-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,11 @@ jobs:
     name: Publish to npm
     needs: build-napi
     runs-on: ubuntu-latest
+    env:
+      # main `@zntc/core` 의 prepublishOnly build 가 ZNTC self-host 호출 — runner 와
+      # 일치하는 NAPI artifact 가 packages/core/zntc.node 에 있어야 동작. runs-on
+      # 변경 시 여기 값도 함께 갱신.
+      MAIN_BUILD_NAPI_PLATFORM: linux-x64-gnu
 
     steps:
       - uses: actions/checkout@v4
@@ -175,6 +180,22 @@ jobs:
             size=$(stat -c%s "$dst" 2>/dev/null || stat -f%z "$dst")
             echo "✓ ${dst} (${size} bytes)"
           done
+
+      # main `@zntc/core` publish 의 prepublishOnly 가 build:js:cjs 단계에서
+      # ZNTC self-host (`node bin/zntc.mjs --bundle ...`) 호출 — packages/core/zntc.node
+      # 가 runner 환경에 있어야 동작. publish 산출물 자체에는 안 들어감 (main
+      # 패키지의 `files` 필드에 zntc.node 미포함, sub-package 만 ship).
+      - name: Place zntc.node in main package (build-time only)
+        shell: bash
+        run: |
+          set -euo pipefail
+          src="napi-artifacts/zntc-node-${MAIN_BUILD_NAPI_PLATFORM}/zntc.node"
+          if [ ! -f "$src" ]; then
+            echo "::error::missing artifact for main package build: $src"
+            exit 1
+          fi
+          cp "$src" packages/core/zntc.node
+          echo "✓ packages/core/zntc.node placed for prepublishOnly build"
 
       # dist-tag 자동 감지: v0.1.0 → latest, v0.1.0-rc.1 → rc, v0.1.0-beta.1 → beta
       - name: Determine npm dist-tag

--- a/build.zig
+++ b/build.zig
@@ -277,6 +277,10 @@ pub fn build(b: *std.Build) void {
 
         const napi_install = b.addInstallArtifact(napi_lib, .{
             .dest_sub_path = "zntc.node",
+            // windows 가 dll 을 `bin/` 에 두는 zig default 를 override — 모든 OS
+            // 에서 `zig-out/lib/zntc.node` 로 통일. 컨슈머 (CI cp / findAddon())
+            // 가 단일 경로만 보면 됨.
+            .dest_dir = .{ .override = .lib },
         });
         const napi_step = b.step("napi", "Build NAPI native module (.node)");
         napi_step.dependOn(&napi_install.step);

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -165,8 +165,11 @@ function findAddon(): string {
   // 2. platform sub-package (npm install — production)
   if (platformPkg) {
     try {
-      const require = createRequire(import.meta.url);
-      return require.resolve(platformPkg);
+      // CJS 빌드에서 ZNTC 가 import.meta.url → `require("url").pathToFileURL(__filename).href`
+      // 로 inline 치환하므로, 같은 const 안에서 `require` 식별자 shadowing → TDZ
+      // 회피용 rename. 동작은 동일.
+      const nodeRequire = createRequire(import.meta.url);
+      return nodeRequire.resolve(platformPkg);
     } catch {
       /* fall through */
     }
@@ -251,8 +254,9 @@ import type { UserConfigInput } from './src/config-loader.ts';
 export function init(addonPath?: string): void {
   if (native) return;
   const path = addonPath ?? findAddon();
-  const require = createRequire(import.meta.url);
-  native = require(path) as NativeModule;
+  // require shadowing 회피 — findAddon() 참고.
+  const nodeRequire = createRequire(import.meta.url);
+  native = nodeRequire(path) as NativeModule;
 }
 
 /**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,19 +15,27 @@
     "bin/zntc.mjs"
   ],
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
   "types": "dist/core/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/core/index.d.ts",
       "source": "./index.ts",
-      "import": "./dist/index.js"
+      "import": {
+        "types": "./dist/core/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/core/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     }
   },
   "scripts": {
     "build:napi": "cd ../.. && zig build napi",
-    "build:js": "bun build index.ts --outdir dist --format esm --target node",
-    "build:dts": "bun x tsc -b",
+    "build:js:esm": "bun build index.ts --outdir dist --format esm --target node",
+    "build:js:cjs": "node bin/zntc.mjs --bundle index.ts --outfile dist/index.cjs --format=cjs --platform=node --packages=external",
+    "build:js": "bun run build:js:esm && bun run build:js:cjs",
+    "build:dts": "bun x tsc -b && cp dist/core/index.d.ts dist/core/index.d.cts",
     "build": "bun run build:js && bun run build:dts",
     "build:local": "bun run build:napi && cp ../../zig-out/lib/zntc.node . && bun run build:js && bun run build:dts",
     "postinstall": "[ -f ../../zig-out/lib/zntc.node ] && cp ../../zig-out/lib/zntc.node . || true",

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -47,6 +47,7 @@ const PUBLISH_ORDER = [
   'packages/web',
   'packages/react-native',
   'packages/vite-plugin-zntc',
+  'packages/rspack-loader',
   'packages/wasm',
   'packages/init',
 ];


### PR DESCRIPTION
## 배경

`@zntc/rspack-loader` 가 외부 사용자 환경 (NPM install, 모노레포 밖) 에서
즉시 깨지는 상태였습니다.

```
ERR_PACKAGE_PATH_NOT_EXPORTED: No \"exports\" main defined in
.../node_modules/@zntc/core/package.json
```

원인: rspack/webpack 은 loader 를 **CJS 컨텍스트** 로 require 하는데
`@zntc/core` 의 `exports` 가 `import` 조건만 노출. `@zntc/rspack-loader/dist/index.cjs`
가 `require('@zntc/core')` 호출 시 conditional resolution 실패.

워크스페이스 내부에서는 `source` 조건이 우선되어 가려진 채 #2934 (rspack-loader 추가)
가 머지된 상태로, 다음 release 가 그대로 publish 되면 외부에서 깨지는 상태로 배포됨.

## 변경

### (1) `packages/core/package.json` — dual ESM/CJS exports

- `exports[\".\"]` 에 `require` 조건 추가
- `build:js:cjs` 신설 — ZNTC self-host (`node bin/zntc.mjs --bundle`) 로 CJS 빌드
- `build:dts` 가 `index.d.cts` 도 함께 emit (require 조건의 types)

> ⚠️ `bun build --format=cjs` 는 사용 불가. bun 이 `import.meta.url` 을
> 빌드 시점에 evaluate 해 산출물에 빌드 머신 절대 경로
> (`file:///Users/.../packages/core/...`) 를 하드코딩 — privacy 누출 +
> 런타임에 zntc.node 경로 추론 실패. ZNTC self-host 는
> `import.meta.url` 을 `require(\"url\").pathToFileURL(__filename).href`
> 로 inline 치환해 런타임에 평가되는 안전한 형태로 산출.

### (2) `packages/core/index.ts` — require 식별자 shadowing 회피

`findAddon()` / `init()` 의 `const require = createRequire(...)` 를
`const nodeRequire = createRequire(...)` 로 rename.

ZNTC 가 `import.meta.url` → `require(\"url\").pathToFileURL(__filename).href`
로 변환할 때, 같은 const 선언 우측에 native CJS `require` 가 들어오면서
새 const `require` 와 shadowing → **TDZ 에러** (\"Cannot access 'require'
before initialization\"). rename 하나로 회피, ESM 동작은 동일.

(ZNTC bundler 자체의 식별자 충돌 검사 누락은 별개 이슈. 후속 처리.)

### (3) `scripts/release.ts` — rspack-loader publish 토폴로지 등록

`PUBLISH_ORDER` 에 `packages/rspack-loader` 추가. 누락되어 있어 release
스크립트가 신규 패키지를 publish 하지 않던 상태.

### (4) `.github/workflows/release.yml` — main 패키지 빌드용 zntc.node 배치

`prepublishOnly` 의 `build:js:cjs` 가 ZNTC self-host 를 호출하므로
runner 환경에 `packages/core/zntc.node` 가 필요. NAPI artifact (이미
build-napi 매트릭스가 만든) 를 main 패키지에도 cp.

- publish tarball 에는 들어가지 않음 (`@zntc/core` 의 `files` 필드에
  zntc.node 미포함, sub-package 만 ship)
- runner 와 매칭되는 platform 은 `MAIN_BUILD_NAPI_PLATFORM` env 로 추출
  → runner 변경 시 한 곳만 갱신

## 검증

- `bunx publint --strict --level error` — @zntc/core, @zntc/rspack-loader 모두 \"All good!\"
- `bun pm pack` → 외부 임시 디렉토리에서 `npm install` + rspack 빌드 e2e
  - 결과: loader 가 TS 정상 트랜스파일, 번들에 `interface` 제거된 JS 출력
  - `ERR_PACKAGE_PATH_NOT_EXPORTED` 해소
- `bun test --cwd packages/core index.test.ts` — 417 pass / 0 fail
  (`require` → `nodeRequire` rename 회귀 없음)

## 후속

- 본 PR 머지 후 별도 PR 로 `TranspileOptions` 에 `reactRefresh` 노출 작업.
  rspack-loader 가 SWC builtin 의 `jsc.transform.react.refresh: true` 와
  동등하게 React Fast Refresh 변환을 적용할 수 있도록.
- ZNTC bundler 의 `import.meta.url` → CJS 변환에서 `require` 식별자 충돌
  검사 누락은 별개 이슈로 분리 (현재는 source-level rename 으로 우회).

## Test plan

- [x] `bun run build` (packages/core) — dual ESM/CJS 산출
- [x] `bunx publint --strict --level error` (core, rspack-loader)
- [x] `bun pm pack` 후 외부 디렉토리 install + rspack build e2e
- [x] `bun test --cwd packages/core index.test.ts`
- [ ] CI: publish-smoke 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)