### PR TITLE
feat(refresh): $RefreshSig$ (hook signature) opt-in — reactRefreshHookSignatures

### DIFF
--- a/packages/core/test/core/react-refresh/transpile.ts
+++ b/packages/core/test/core/react-refresh/transpile.ts
@@ -50,4 +50,54 @@ describe('React Refresh: transpile() single-file path', () => {
     );
     expect(code).not.toContain('$RefreshReg$');
   });
+
+  describe('reactRefreshHookSignatures opt-in', () => {
+    const src = `function MyComp() {
+  const [s, setS] = useState(0);
+  useEffect(() => {}, []);
+  return null;
+}
+export default MyComp;`;
+
+    test('opt-in 시 _s() / var _s = $RefreshSig$() / _s(Comp, "sig") 모두 emit', () => {
+      const code = transpileReactRefreshCode(src, {
+        filename: 'MyComp.tsx',
+        reactRefresh: true,
+        reactRefreshHookSignatures: true,
+      });
+      expect(code).toContain('var _s = $RefreshSig$()');
+      expect(code).toContain('_s(MyComp,');
+      expect(code).toContain('useState{[s, setS](0)}');
+      expect(code).toContain('$RefreshReg$(_c, "MyComp")');
+      // body 시작에 _s() 호출
+      expect(code).toMatch(/function MyComp\(\) \{[\s\n]*_s\(\);/);
+    });
+
+    test('reactRefresh 만 활성 (Metro default) 이면 $RefreshSig$ 미emit', () => {
+      const code = transpileReactRefreshCode(src, {
+        filename: 'MyComp.tsx',
+        reactRefresh: true,
+      });
+      expect(code).not.toContain('$RefreshSig$');
+      expect(code).toContain('$RefreshReg$(_c, "MyComp")');
+    });
+
+    test('hook 사용 없는 컴포넌트는 signature 자체 미생성 (registration 만)', () => {
+      const code = transpileReactRefreshCode(
+        `function NoHooks() { return null; }\nexport default NoHooks;`,
+        { filename: 'NoHooks.tsx', reactRefresh: true, reactRefreshHookSignatures: true },
+      );
+      expect(code).not.toContain('$RefreshSig$');
+      expect(code).toContain('$RefreshReg$(_c, "NoHooks")');
+    });
+
+    test('reactRefresh 비활성 + hook signatures 만 활성은 둘 다 미emit (registration 의존)', () => {
+      const code = transpileReactRefreshCode(src, {
+        filename: 'MyComp.tsx',
+        reactRefreshHookSignatures: true,
+      });
+      expect(code).not.toContain('$RefreshSig$');
+      expect(code).not.toContain('$RefreshReg$');
+    });
+  });
 });

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -49,14 +49,26 @@ export interface TranspileOptions {
   /** JS 파일에서도 JSX 허용 */
   jsxInJs?: boolean;
   /**
-   * React Fast Refresh transform — 컴포넌트에 `$RefreshReg$(_c, "Name")` 등록 +
-   * Hook 사용 함수에 `_s = $RefreshSig$()` 시그니처 호출 emit. SWC builtin 의
-   * `jsc.transform.react.refresh: true` / babel-plugin-react-refresh 와 동등.
-   * loader (rspack-loader, webpack/vite plugin) 가 single-file transpile 경로에서
-   * 활성화 시 사용. HMR runtime ($RefreshReg$/$RefreshSig$ 정의) 은 컨슈머 측
-   * `react-refresh/runtime` 또는 dev server 가 prelude 로 주입한다고 가정.
+   * React Fast Refresh transform — 컴포넌트에 `$RefreshReg$(_c, "Name")` 등록.
+   * SWC builtin 의 `jsc.transform.react.refresh: true` / babel-plugin-react-refresh
+   * 의 component registration 과 동등. loader (rspack-loader, webpack/vite plugin)
+   * 가 single-file transpile 경로에서 활성화 시 사용.
+   *
+   * Default 동작은 Metro 호환 (registration 만, hook signature 없음).
+   * babel/SWC 동등의 hook signature emit 은 `reactRefreshHookSignatures: true`
+   * opt-in. HMR runtime ($RefreshReg$/$RefreshSig$ 정의) 은 컨슈머 측 책임.
    */
   reactRefresh?: boolean;
+  /**
+   * `reactRefresh: true` 위에 hook signature emit (`var _s = $RefreshSig$();` +
+   * `_s(Component, "sig")`) 을 추가. babel-plugin-react-refresh 와 동등.
+   * default false — Metro 정책 (signature 없음) 보존.
+   *
+   * 활성화 시 transformer 가 함수 본문 안 hook 호출을 스캔해 signature 문자열
+   * 빌드 → component 등록 직후 `_s(Comp, "sig")` 호출 emit. RN HMR 은 default
+   * (false) 그대로라 영향 없음.
+   */
+  reactRefreshHookSignatures?: boolean;
   /** console.* 호출 제거 */
   dropConsole?: boolean;
   /** debugger 문 제거 */
@@ -227,6 +239,7 @@ export function buildOptionsJson(
   if (opts.flow) payload.flow = true;
   if (opts.jsxInJs) payload.jsxInJs = true;
   if (opts.reactRefresh) payload.reactRefresh = true;
+  if (opts.reactRefreshHookSignatures) payload.reactRefreshHookSignatures = true;
   if (opts.jsx !== undefined) {
     // CLI vocab → Zig enum tag (kebab-case → snake_case): automatic-dev → automatic_dev.
     // 그 외 (`react-jsx` 등 tsconfig vocab, typo) 도 그대로 forward — NAPI / `optionsFromJson`

--- a/src/transformer/options.zig
+++ b/src/transformer/options.zig
@@ -69,8 +69,12 @@ pub const TransformOptions = struct {
     drop_labels: []const []const u8 = &.{},
     /// define 글로벌 치환 (D020). 예: process.env.NODE_ENV → "production"
     define: []const DefineEntry = &.{},
-    /// React Fast Refresh 활성화. 컴포넌트에 $RefreshReg$/$RefreshSig$ 주입.
+    /// React Fast Refresh 활성화. 컴포넌트에 $RefreshReg$ 주입.
     react_refresh: bool = false,
+    /// `react_refresh` 위에 hook signature ($RefreshSig$) emit 까지 활성화.
+    /// default false — Metro 정책 (registration only) 보존. opt-in 시 babel-plugin-
+    /// react-refresh 동등 (component body 에 `_s()` + 모듈 끝 `_s(Comp, "sig")`).
+    react_refresh_hook_signatures: bool = false,
     /// styled-components 1st-party transform 활성화 (compiler.styledComponents).
     /// 활성 시 `const X = styled.div\`...\`` 같은 선언에 displayName 자동 부여.
     /// componentId / SSR / CSS minify 등 추가 변환은 후속 PR.

--- a/src/transformer/transformer/declarations.zig
+++ b/src/transformer/transformer/declarations.zig
@@ -284,8 +284,19 @@ pub fn visitFunction(self: *Transformer, node: Node) Error!NodeIndex {
     self.needs_arguments_var = saved_needs_args;
     self.super_call_this_alias = saved_super_alias;
 
-    // $RefreshSig$ (hook signature) 스캔은 제거 — transform 후 stale AST 인덱스로 OOM 유발.
-    // Metro도 직접 스캔하지 않고 Babel/SWC에 위임. $RefreshReg$만 유지.
+    // React Fast Refresh — hook signature opt-in. default off 면 visitFunction
+    // hot path 영향 0 (옵션 read + early-return). opt-in 시 babel-plugin-react-refresh
+    // 동등 emit. `findHookCallsInNodeDepth` 가 depth=50 + node tag whitelist +
+    // bounds check 로 stale 인덱스 방어.
+    if (self.options.react_refresh and self.options.react_refresh_hook_signatures) {
+        const fn_name_for_sig: ?[]const u8 = blk: {
+            if (new_name.isNone()) break :blk null;
+            const name_node = self.ast.getNode(new_name);
+            if (name_node.tag != .binding_identifier and name_node.tag != .identifier_reference) break :blk null;
+            break :blk self.ast.getText(name_node.data.string_ref);
+        };
+        try self.maybeRegisterRefreshSignature(fn_name_for_sig, old_body_idx, &new_body);
+    }
 
     const none = @intFromEnum(NodeIndex.none);
     const new_params_node = try self.ast.addFormalParameters(pp.new_params, params_span);

--- a/src/transformer/transformer/refresh.zig
+++ b/src/transformer/transformer/refresh.zig
@@ -124,7 +124,17 @@ pub fn appendRefreshRegistrations(self: *Transformer, root: NodeIndex) Error!Nod
     const var_decl = try self.buildRefreshVarDeclaration();
     try self.scratch.append(self.allocator, var_decl);
 
-    // $RefreshSig$ 스캔 제거 — Metro 방식. hook signature 없이 $RefreshReg$만 주입.
+    // $RefreshSig$ — opt-in (`react_refresh_hook_signatures`) 시에만 emit. default
+    // 는 Metro 정책 (registration only) 으로 RN HMR 영향 없음.
+    if (self.options.react_refresh_hook_signatures and self.plugins.refresh.signatures.items.len > 0) {
+        const refresh_sig_span = try self.ast.addString("$RefreshSig$");
+        for (self.plugins.refresh.signatures.items) |sig| {
+            const sig_decl = try self.buildRefreshSigDeclaration(sig, refresh_sig_span);
+            try self.scratch.append(self.allocator, sig_decl);
+            const sig_call = try self.buildRefreshSigCall(sig);
+            try self.scratch.append(self.allocator, sig_call);
+        }
+    }
 
     // $RefreshReg$(_c, "ComponentName"); 호출들
     const refresh_reg_span = try self.ast.addString("$RefreshReg$");
@@ -504,6 +514,8 @@ pub fn makeSigHandle(self: *Transformer) Error!Span {
 }
 
 /// Hook 시그니처가 있는 컴포넌트를 등록하고, body에 _s() 호출을 삽입한다.
+/// `react_refresh` + `react_refresh_hook_signatures` 둘 다 활성일 때만 동작.
+/// 후자가 default false 라 기본 빌드 (RN 포함) 는 영향 없음.
 pub fn maybeRegisterRefreshSignature(
     self: *Transformer,
     func_name: ?[]const u8,
@@ -511,6 +523,7 @@ pub fn maybeRegisterRefreshSignature(
     new_body: *NodeIndex,
 ) Error!void {
     if (!self.options.react_refresh) return;
+    if (!self.options.react_refresh_hook_signatures) return;
     const name = func_name orelse return;
     if (!isComponentName(name)) return;
 

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -456,7 +456,8 @@ fn optionsRequireTransformSemantic(options: TranspileOptions) bool {
         !options.use_define_for_class_fields or
         options.experimental_decorators or
         options.emit_decorator_metadata or
-        options.react_refresh;
+        options.react_refresh or
+        options.react_refresh_hook_signatures;
 }
 
 fn buildTransformPlan(
@@ -1005,6 +1006,7 @@ fn transpileWithCallbackInternal(
         // #1621: standalone transpile 경로도 minify 시 runtime helper 축약 이름 사용.
         .minify_whitespace = options.minify_whitespace,
         .react_refresh = options.react_refresh,
+        .react_refresh_hook_signatures = options.react_refresh_hook_signatures,
     });
     // transformer.ast 도 arena owned (cloneForTransformer 결과). parser.ast 와 동일 이유.
     defer transformer.ast.dumpStringInternStatsIfEnabled();

--- a/src/transpile/options.zig
+++ b/src/transpile/options.zig
@@ -51,9 +51,13 @@ pub const TranspileOptions = struct {
     tsconfig_path: ?[]const u8 = null,
     drop_console: bool = false,
     drop_debugger: bool = false,
-    /// React Fast Refresh transform — `$RefreshReg$` / `$RefreshSig$` emit.
+    /// React Fast Refresh transform — `$RefreshReg$` (component registration) emit.
     /// loader 등 single-file transpile 경로용 surface (bundler 의 build option 과 별개).
     react_refresh: bool = false,
+    /// `react_refresh` 위에 `$RefreshSig$` (hook signature) emit 까지 활성화.
+    /// default false — Metro 정책 (signature 없음) 보존, RN build 무영향. opt-in 시
+    /// babel-plugin-react-refresh 동등 (component body 시작에 _s() 삽입 + 모듈 끝 _s(Comp, "sig")).
+    react_refresh_hook_signatures: bool = false,
 
     // --- 코드 생성 ---
     module_format: codegen.ModuleFormat = .esm,
@@ -102,6 +106,7 @@ pub const ConfigOptionsDto = struct {
     flow: ?bool = null,
     jsxInJs: ?bool = null,
     reactRefresh: ?bool = null,
+    reactRefreshHookSignatures: ?bool = null,
     jsx: ?codegen.JsxRuntime = null,
     jsxFactory: ?[]const u8 = null,
     jsxFragment: ?[]const u8 = null,
@@ -207,6 +212,9 @@ pub fn applyTranspileSharedFields(
     // CliOptions 미보유 — bundler 는 BuildOptionsCommon 으로 별도 surface 사용.
     if (dto.reactRefresh) |v| if (@hasField(@TypeOf(target.*), "react_refresh")) {
         target.react_refresh = v;
+    };
+    if (dto.reactRefreshHookSignatures) |v| if (@hasField(@TypeOf(target.*), "react_refresh_hook_signatures")) {
+        target.react_refresh_hook_signatures = v;
     };
     if (dto.jsx) |v| target.jsx_runtime = v;
     if (dto.jsxFactory) |s| if (s.len > 0) {


### PR DESCRIPTION
## 배경

ZNTC 의 React Fast Refresh 는 의도적 Metro 정책 — component registration
(\`\$RefreshReg\$\`) 만 emit, hook signature (\`\$RefreshSig\$\`) 미emit. 이전 시도
는 transform 후 stale AST 인덱스로 OOM 유발 (\`declarations.zig:287-288\` 의
historical 코멘트 참조).

이후 \`findHookCallsInNodeDepth\` 가 depth=50 + node tag whitelist + bounds
check 로 robust 화되어 재활성 가능. 다만 RN HMR 등 기존 동작에 회귀를 유발할
위험을 우려해 **opt-in 옵션** (\`reactRefreshHookSignatures: boolean\`) 으로
도입. babel-plugin-react-refresh / SWC builtin 의 \`refresh.skipEnvCheck\`
시나리오와 동등.

## 핵심 보장 — RN HMR 무영향

| 보장 | 근거 |
|---|---|
| (1) 모든 surface default false | shared (optional → undefined → false), zig (\`bool = false\` x2) |
| (2) build/bundler 경로에 surface 노출 0 | \`BuildOptionsCommon\` / NAPI build options 에 추가 안 함 — RN/build 사용자가 활성화할 채널 자체 없음 |
| (3) bundler 가 transformer 옵션 set 안 함 | \`src/bundler/\` 어디에도 \`.react_refresh_hook_signatures = \` 없음 → bundler 의 transformer 는 default \`false\` 그대로 |

코드 변경:
- \`declarations.zig::visitFunction\` 새 블록 → \`if (react_refresh and react_refresh_hook_signatures)\` 가드 안 → default off 시 진입 0 (옵션 read + early return)
- \`refresh.zig::appendRefreshRegistrations\` signature emit loop → 옵션 가드
- \`refresh.zig::maybeRegisterRefreshSignature\` → 첫 줄 early return

## 변경

### (1) \`packages/shared/index.ts\`

- \`TranspileOptions.reactRefreshHookSignatures?: boolean\` 추가
- \`buildOptionsJson\` 직렬화
- \`reactRefresh\` JSDoc 도 갱신 (Metro default + opt-in 안내)

### (2) \`src/transpile/options.zig\`

- \`TranspileOptions.react_refresh_hook_signatures: bool = false\`
- \`ConfigOptionsDto.reactRefreshHookSignatures: ?bool = null\`
- \`applyTranspileSharedFields\` 매핑 (CliOptions 미보유 \`@hasField\` 가드)

### (3) \`src/transformer/options.zig\`

- \`TransformOptions.react_refresh_hook_signatures: bool = false\`

### (4) \`src/transpile.zig\`

- \`Transformer.init\` 에 옵션 전달
- \`optionsRequireTransformSemantic\` 분기 추가 (plan 일관성)

### (5) \`src/transformer/transformer/refresh.zig\`

- \`maybeRegisterRefreshSignature\` 에 옵션 가드 추가 (두 옵션 모두 활성일 때만)
- \`appendRefreshRegistrations\` 에 signature emit (옵션 + signatures.len > 0 가드):
  \`var _s = \$RefreshSig\$()\` declaration + \`_s(Comp, "sig")\` call

### (6) \`src/transformer/transformer/declarations.zig\`

- \`visitFunction\` post-visit 에 \`maybeRegisterRefreshSignature\` 호출
- 옵션 가드를 visitor 측에 두어 default off 시 fn name 추출 자체 skip (hot path 0 cost)

## 활성 시 emit (babel-plugin-react-refresh 동등)

\`\`\`tsx
// 입력
function MyComp() {
  const [s, setS] = useState(0);
  useEffect(() => {}, []);
  return <div>{s}</div>;
}
\`\`\`

\`\`\`js
// 출력 (reactRefresh + reactRefreshHookSignatures 둘 다 true)
import { jsx as _jsx } from \"react/jsx-runtime\";
function MyComp() {
  _s();                                              // body 시작
  const [s, setS] = useState(0);
  useEffect(() => {}, []);
  return _jsx(\"div\", { children: s });
}
var _c, _s = \$RefreshSig\$();
_s(MyComp, \"useState{[s, setS](0)}\\nuseEffect{(() => {})}\");
\$RefreshReg\$(_c, \"MyComp\");
\`\`\`

## 사용 예

### rspack-loader

\`\`\`js
{
  loader: '@zntc/rspack-loader',
  options: {
    transpileOptions: {
      jsx: 'automatic',
      reactRefresh: true,
      reactRefreshHookSignatures: true,
    },
  },
}
\`\`\`

### vite plugin (\`@zntc/vite-plugin-zntc\`)

\`\`\`js
import { zntc } from '@zntc/vite-plugin-zntc';

export default {
  plugins: [
    zntc({
      transpileOptions: {
        jsx: 'automatic',
        reactRefresh: true,
        reactRefreshHookSignatures: true,
      },
    }),
  ],
};
\`\`\`

vite plugin 의 \`transform\` hook 이 \`transpileOptions\` 를 그대로 spread 하므로
plugin 자체 변경 없이 자동 동작. 즉석 검증으로 \`var _s = \$RefreshSig\$()\` +
\`_s(MyComp, ...)\` + \`\$RefreshReg\$(_c, \"MyComp\")\` emit 확인.

## 검증

- \`bun test --cwd packages/core index.test.ts\` — **427 pass / 0 fail** (회귀 없음)
- vite plugin / rspack-loader 모두 옵션 forward 동작 확인 (즉석 transpile)
- bundler / RN preset 어디에도 옵션 set 안 함 — grep 으로 확인:
  - \`src/bundler/\` 에 \`react_refresh_hook_signatures\` 매칭 0
  - \`BuildOptionsCommon\` / NAPI build options.zig 에 매칭 0
- default off 시 출력 hash 동일 (회귀 테스트 통과)

## Test plan

- [x] opt-in 시 \`_s()\` body 시작 + \`var _s = \$RefreshSig\$()\` + \`_s(Comp, \"sig\")\` 모두 emit
- [x] Metro default (signature 비활성) 시 기존 출력 그대로
- [x] hook 사용 없는 컴포넌트는 signature 자체 미생성 (registration 만)
- [x] \`reactRefreshHookSignatures\` 만 활성 (\`reactRefresh\` 비활성) → 둘 다 미emit (의존)
- [x] vite plugin / rspack-loader 사용 시 옵션 forward
- [ ] CI: NAPI Build & Test + Publish Smoke + RN smoke (Hermes Validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)