### PR TITLE
feat(ci): win32-ia32 smoke 추가 (Node 22 LTS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,10 +208,16 @@ jobs:
           - platform: win32-arm64-msvc
             os: windows-11-arm
             zig_target: native
-          # win32-ia32-msvc 는 smoke 매트릭스에서 제외 — Node.js v24 가 win-x86
-          # 빌드를 폐지 (https://nodejs.org/dist/v24.0.0/SHASUMS256.txt). build
-          # 검증은 release.yml 의 build-napi/build-cli 에서 zig cross-build +
-          # check-platform-binary 사이즈 체크로 커버.
+          # win32-ia32-msvc: Node.js v24 가 win-x86 빌드를 폐지했으므로 v22 LTS
+          # (마지막 win-x86 공식 빌드 유지) 로 native require 검증. host dogfood
+          # 도 32-bit Node 가 dlopen 해야 하므로 host_zig_target 으로 32-bit
+          # binary 강제. release.yml 의 publish 는 9 platform 그대로.
+          - platform: win32-ia32-msvc
+            os: windows-latest
+            zig_target: x86-windows-msvc
+            host_zig_target: x86-windows-msvc
+            node_version: '22'
+            node_arch: x86
 
     steps:
       - name: Checkout
@@ -232,7 +238,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: ${{ matrix.node_version || '24' }}
+          architecture: ${{ matrix.node_arch || '' }}
 
       - uses: ./.github/actions/bun-cache
         with:
@@ -245,17 +252,26 @@ jobs:
       # node 가 packages/core/zntc.node 를 dlopen 함. host 와 ABI 가 다른 cross
       # binary (musl 등) 는 못 읽으므로 host native 를 먼저 빌드해 두고, cross
       # 매트릭스만 그 후 target binary 로 zig-out 을 덮어 sub-package 에 복사.
+      # host_zig_target 명시 entry (ia32 등) 는 host node arch 에 맞춘 cross
+      # build 로 dogfood 가능하게 — windows-latest(64-bit) 에서 32-bit Node 가
+      # 64-bit binary dlopen 못 함.
       - name: Build host NAPI (dogfood)
         shell: bash
         run: |
-          zig build napi
+          if [ -n "${{ matrix.host_zig_target }}" ]; then
+            zig build napi -Dtarget=${{ matrix.host_zig_target }}
+          else
+            zig build napi
+          fi
           cp zig-out/lib/zntc.node packages/core/zntc.node
 
       - name: Build JS wrapper + dts
         run: cd packages/core && bun run build:js && bun run build:dts
 
+      # host_zig_target == zig_target 인 경우 (ia32) host build 가 이미 sub-package
+      # 용 binary 라 cross step 중복. zig cache 가 hit 해도 step 자체 overhead 회피.
       - name: Build platform NAPI (cross)
-        if: matrix.zig_target != 'native'
+        if: matrix.zig_target != 'native' && matrix.zig_target != matrix.host_zig_target
         shell: bash
         run: zig build napi -Dtarget=${{ matrix.zig_target }}
 


### PR DESCRIPTION
## Summary

PR #2942 에서 Node v24 가 win-x86 빌드를 폐지해 ia32 smoke 를 매트릭스에서 드롭했었습니다. **Node v22 LTS 는 win-x86 공식 빌드 (`node-v22.22.2-win-x86.zip`) 를 유지**하므로 v22 로 ia32 smoke 한 entry 를 부활합니다.

## 변경

**`.github/workflows/ci.yml` `napi-package-smoke` 매트릭스** — entry 1 추가, step 2 분기:

```yaml
- platform: win32-ia32-msvc
  os: windows-latest
  zig_target: x86-windows-msvc
  host_zig_target: x86-windows-msvc
  node_version: '22'
  node_arch: x86
```

**필드 의미**
- `node_version: '22'` — Node 24 win-x86 부재 회피
- `node_arch: x86` — `setup-node` 가 32-bit Node 22 설치
- `host_zig_target: x86-windows-msvc` — dogfood `build:js:cjs` 가 32-bit Node 에서 도므로 host NAPI 도 32-bit 이어야 dlopen 가능 (windows-latest 자체는 64-bit OS)

**step 분기**
- `setup-node`: `node-version: \${{ matrix.node_version || '24' }}`, `architecture: \${{ matrix.node_arch || '' }}`
- "Build host NAPI (dogfood)": `matrix.host_zig_target` 명시 시 cross-build, 아니면 native
- "Build platform NAPI (cross)": `host_zig_target == zig_target` 이면 skip (ia32 의 동일 binary 중복 빌드 회피)

다른 8 매트릭스 entry 는 영향 없음 (default Node 24, host = native build).

## Test plan

- [ ] `napi-package-smoke (win32-ia32-msvc)` green — 32-bit Node 22 가 ia32 sub-package require + transpile + tokenize 통과
- [ ] 다른 8 platform smoke 회귀 없음 (default Node 24 / native host build 그대로)
- [ ] `Build host NAPI (dogfood)` step 의 `matrix.host_zig_target` 분기가 `''` 일 때 native 로 정상 fallback

## 후속

- 향후 Node 26 등이 다시 win-x86 추가하면 `node_version` 필드만 갱신해 통합 가능
- musl/win-arm 도 같은 매트릭스 패턴 (별도 node_version) 으로 확장 가능 — 현재는 default 24 로 충분

🤖 Generated with [Claude Code](https://claude.com/claude-code)