### PR TITLE
fix(bundler): wrapper-barrel detection in isLazyBarrelCandidate

### DIFF
--- a/src/bundler/graph/requested_exports.zig
+++ b/src/bundler/graph/requested_exports.zig
@@ -40,11 +40,28 @@ pub fn requestNamed(self: anytype, idx: ModuleIndex, name: []const u8) !bool {
 
 pub fn isLazyBarrelCandidate(self: anytype, m: *const Module) bool {
     if (self.dev_mode or self.preserve_modules) return false;
-    return m.side_effects_user_defined and
+    if (!(m.side_effects_user_defined and
         !m.side_effects and
         m.exports_kind.isEsm() and
         m.import_records.len > 0 and
-        m.export_bindings.len > 0;
+        m.export_bindings.len > 0)) return false;
+
+    // Wrapper-barrel pattern: `import x from './w'; export default x;` 같이 imported
+    // binding 을 default 로 re-export 하는 경우 body 가 그 binding 을 mutate 할
+    // 가능성이 높다 (lodash-es lodash.default.js: `import lodash from './wrapperLodash.js';
+    // lodash.uniq = uniq; ... export default lodash;`). lazy 처리하면 body 의 mutation
+    // 들이 reference 하는 35 개 import 가 graph 에 등록되지 않아 runtime 에서
+    // `_mixin is not defined` 같은 ReferenceError 가 발생. 이 패턴이 있으면 lazy
+    // 비활성화 — 모든 import 가 link 되어 정상 BFS 추적 가능하도록.
+    for (m.export_bindings) |eb| {
+        if (eb.kind == .re_export and
+            std.mem.eql(u8, eb.exported_name, "default") and
+            std.mem.eql(u8, eb.local_name, "default"))
+        {
+            return false;
+        }
+    }
+    return true;
 }
 
 pub fn localNeedsAllRecords(m: *const Module, req: *const RequestedExports) bool {


### PR DESCRIPTION
## Summary

- `isLazyBarrelCandidate` 의 정확성 개선 — `import x; export default x;` wrapper-barrel pattern 모듈은 lazy 처리에서 제외
- lodash-es 의 `lodash.default.js` 처럼 imported binding 을 default 로 re-export 하면서 body 에서 mutate 하는 패턴의 graph-level 정확성 회복

## 배경

`lazy_barrel_candidate` 룰은 `sideEffects: false` ESM 모듈의 import_records 를 "requested 가 일치하는 것만 link" 하는 정밀 트리쉐이킹 hint. `export default {a:1}` 같은 순수 barrel 에서는 정확하지만, 다음 wrapper-barrel pattern 에서 부정확:

```js
// lodash.default.js (lodash-es)
import lodash from './wrapperLodash.js';
import _mixin from './mixin.js';
// ... 35 more imports
lodash.uniq = uniq;          // body mutation
lodash.keys = keys;
// ... ~300 mutations
export default lodash;       // imported binding 을 default 로 re-export
```

이 모듈은 body 가 imported binding 을 mutate. lazy 처리하면 body 의 mutation 이 reference 하는 imports (mixin, baseFunctions 등 35 개) 가 graph 에 등록되지 않아 후속 단계에서 `_mixin is not defined` 같은 ReferenceError 가능.

## 수정

`isLazyBarrelCandidate` 가 다음 조건을 만족하는 export binding 을 가진 모듈을 wrapper-barrel 로 인식하고 `false` 를 반환:

- `kind == .re_export`
- `exported_name == "default"`
- `local_name == "default"`

이는 `import { default } from ...` 후 `export default <id>` 결과로 `binding_scanner.zig:386-391` 가 만들어내는 정확한 형태. 검출 조건이 매우 specific 이라 일반 sideEffects:false ESM 모듈 (named exports only, function default, object literal default) 은 영향 없음.

## 영향 범위

- ✅ tslib pattern (`export default {...}`) unused default object DCE 보존 — `eb.kind=.local`이라 wrapper 룰 fire 안함
- ✅ valibot/cookie 같은 sideEffects:false subset DCE 보존 (named exports 만)
- ✅ export-star unrelated source DCE 보존 (`re_export_star` 는 wrapper 룰 미해당)
- ✅ lodash-es lodash.default.js 의 35 imports 가 graph 에 등록 — `mixin.js`, `baseFunctions.js` 등이 module graph 에 들어감

## 별도 작업 (이번 PR 에서는 다루지 않음)

`import _ from 'lodash-es'; _.uniq()` 같은 default-only 사용은 여전히 `lodash.uniq is not a function` — tree_shaker 의 seeding 정책이 sideEffects:false 모듈의 body mutation 을 시드하지 않기 때문. 별도 PR 에서 wrapper-barrel 모듈만 시드하도록 좁혀진 게이트 + 회귀 가드 필요. 시도했으나 export-star unrelated source DCE 회귀를 일으켜 분리.

## Test plan

- [x] `zig build test` — 4773 unit tests 통과
- [x] 통합 테스트 회귀 없음: bundle-smoke, tree-shake-precision, manual-chunks-smoke, lodash-es-default-import (PR #2945) — 175/175 통과
- [x] export-star unrelated source DCE 회귀 가드 (`TreeShaking: export star named import drops unrelated source declared sideEffects:false`) 통과
- [x] tslib pattern (`export default {...}`) unused default object DCE 보존

🤖 Generated with [Claude Code](https://claude.com/claude-code)