### PR TITLE
fix(integ-tests): direct spawn zntc — sh -c wrapper leak 회피

### DIFF
--- a/tests/integration/tests/helpers.ts
+++ b/tests/integration/tests/helpers.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'bun';
 import { mkdtemp, rm, writeFile, mkdir, symlink, stat } from 'node:fs/promises';
-import { readFileSync, statSync } from 'node:fs';
+import { readFileSync, statSync, openSync, closeSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, relative, resolve } from 'node:path';
 
@@ -288,35 +288,50 @@ export async function runNode(file: string): Promise<{ stdout: string; stderr: s
 
 // ─── watch-json 테스트 공용 헬퍼 ───
 
-/// `zntc --watch-json ...`을 shell 경유로 spawn하고 stdout을 jsonOutPath로 리다이렉트.
+/// `zntc --watch-json ...`을 직접 spawn하고 stdout을 jsonOutPath로 리다이렉트.
 /// bun test가 child process stdout pipe를 제대로 처리 못 해서 파일 리다이렉트 방식 사용.
+/// `sh -c` 래퍼는 사용하지 않는다 — `proc.kill()` 이 sh 만 죽이고 자식 zntc 는
+/// 좀비로 남는 leak (#2945 후속) 회피. fd 를 open 해서 stdio 로 직접 넘긴다.
 export function spawnWatchJson(
   args: string[],
   jsonOutPath: string,
 ): import('node:child_process').ChildProcess {
   const { spawn: spawnChild } = require('node:child_process');
-  const quoted = args.map((a) => `"${a}"`).join(' ');
-  return spawnChild('sh', ['-c', `"${ZNTC_BIN}" ${quoted} > "${jsonOutPath}" 2>/dev/null`]);
+  const fd = openSync(jsonOutPath, 'w');
+  try {
+    return spawnChild(ZNTC_BIN, args, { stdio: ['ignore', fd, 'ignore'] });
+  } finally {
+    // child 가 fd duplicate 를 들고 있으므로 부모는 즉시 닫아도 안전.
+    closeSync(fd);
+  }
 }
 
 /// watch 프로세스를 kill하고 종료를 기다림. 2초 후 SIGKILL fallback — 좀비 방지.
+/// Bun 의 child_process 호환층에서 `proc.kill()` 이 자식 PID 에 시그널을 정확히
+/// 전달하지 않는 경우가 관찰되어, `process.kill(proc.pid, signal)` 로 명시적
+/// 송신한다 (orphan 좀비 방지).
 export function killAndWait(proc: import('node:child_process').ChildProcess): Promise<void> {
   return new Promise<void>((resolve) => {
     if (proc.exitCode !== null) {
       resolve();
       return;
     }
-    const timeout = setTimeout(() => {
+    const pid = proc.pid;
+    const sendSignal = (signal: NodeJS.Signals) => {
+      if (pid === undefined) return;
       try {
-        proc.kill('SIGKILL');
+        process.kill(pid, signal);
       } catch {}
+    };
+    const timeout = setTimeout(() => {
+      sendSignal('SIGKILL');
       resolve();
     }, 2000);
     proc.on('exit', () => {
       clearTimeout(timeout);
       resolve();
     });
-    proc.kill();
+    sendSignal('SIGTERM');
   });
 }
 

--- a/tests/integration/tests/watch-stress.test.ts
+++ b/tests/integration/tests/watch-stress.test.ts
@@ -32,22 +32,6 @@ async function sampleRSS(pid: number): Promise<number> {
   return rss;
 }
 
-/** shell 부모 PID의 자식(zntc) 찾기. Linux/macOS 공용. */
-async function findZntcChildPid(parentPid: number): Promise<number> {
-  const proc = Bun.spawn({
-    cmd: ['pgrep', '-P', String(parentPid), 'zntc'],
-    stdout: 'pipe',
-    stderr: 'pipe',
-  });
-  const stdout = await new Response(proc.stdout).text();
-  await proc.exited;
-  const pid = Number.parseInt(stdout.trim().split('\n')[0], 10);
-  if (Number.isNaN(pid)) {
-    throw new Error(`failed to find zntc child of pid ${parentPid}`);
-  }
-  return pid;
-}
-
 /** samples = [{x,y}...] 에서 최소제곱법 기울기(y per x). */
 function linearSlope(samples: Array<{ x: number; y: number }>): number {
   const n = samples.length;
@@ -87,7 +71,8 @@ describe('watch 메모리 스트레스 (시뮬레이션)', () => {
       try {
         await waitForNdjsonLines(jsonOut, 1, tail, { timeoutMs: 15000 });
 
-        const zntcPid = await findZntcChildPid(proc.pid!);
+        // spawnWatchJson 가 zntc 를 직접 spawn 하므로 proc.pid 가 곧 zntc PID.
+        const zntcPid = proc.pid!;
         const samples: Array<{ x: number; y: number }> = [];
         samples.push({ x: 0, y: await sampleRSS(zntcPid) });
 


### PR DESCRIPTION
## Summary

- watch-json 통합 테스트의 `spawnWatchJson` 헬퍼가 `sh -c "...zntc... > out 2>/dev/null"` 형태로 spawn → `proc.kill()` 시 부모 sh 만 죽고 자식 zntc 가 init 으로 reparent → leak (테스트당 1 좀비 + 1 tmpdir 영구 잔존)
- `zntc` 직접 spawn + stdout 만 file fd 로 redirect, `process.kill(pid, signal)` 명시 송신으로 전환

## 변경

**`tests/integration/tests/helpers.ts`**

- `spawnWatchJson`: `sh -c` 래퍼 제거. `openSync(jsonOutPath, 'w')` → `spawn(ZNTC_BIN, args, { stdio: ['ignore', fd, 'ignore'] })` → `closeSync(fd)`. child 가 fd dup 을 들고 있으므로 부모 즉시 close 안전.
- `killAndWait`: `proc.kill(...)` (Bun 호환층 자식 PID 송신 미흡 관찰됨) → `process.kill(proc.pid, signal)` 로 명시 송신. SIGTERM → 2초 후 SIGKILL fallback 동작은 그대로.

**`tests/integration/tests/watch-stress.test.ts`**

- `findZntcChildPid` 제거 — `sh` 자식 탐색용이었으나 이제 `proc.pid` 가 곧 zntc PID. `pgrep -P` 외부 프로세스 spawn 1회 절감.

## Test plan

- [x] `bun test tests/watch-json.test.ts tests/watch-stress.test.ts`: 7/7 pass
- [x] 실행 후 `pgrep -f 'zntc.*watch-json'` = 0, `zntc-integration-*` tmpdir = 0 (이전 7개 leak)
- [x] Bun runtime + Node runtime 둘 다 spawn → kill → leak 0 검증 (fd dup 시점이 둘 다 spawn 동기 반환 전이라 동일 동작)
- [x] 통합 테스트 풀런 3710 pass / 0 fail / 2 todo 회귀 없음
- [x] `/simplify` 통과 — 재사용/품질/효율 3 리뷰어 모두 clean