### PR TITLE
chore(simplify): isLazyBarrelCandidate negation guard 평탄화

### DIFF
--- a/src/bundler/graph/requested_exports.zig
+++ b/src/bundler/graph/requested_exports.zig
@@ -40,11 +40,11 @@ pub fn requestNamed(self: anytype, idx: ModuleIndex, name: []const u8) !bool {
 
 pub fn isLazyBarrelCandidate(self: anytype, m: *const Module) bool {
     if (self.dev_mode or self.preserve_modules) return false;
-    if (!(m.side_effects_user_defined and
-        !m.side_effects and
-        m.exports_kind.isEsm() and
-        m.import_records.len > 0 and
-        m.export_bindings.len > 0)) return false;
+    if (!m.side_effects_user_defined or
+        m.side_effects or
+        !m.exports_kind.isEsm() or
+        m.import_records.len == 0 or
+        m.export_bindings.len == 0) return false;
 
     // Wrapper-barrel pattern: `import x from './w'; export default x;` 같이 imported
     // binding 을 default 로 re-export 하는 경우 body 가 그 binding 을 mutate 할


### PR DESCRIPTION
## Summary

PR #2946 의 follow-up `/simplify` — code review 에서 식별된 가독성 개선.

`if (!(A and B and C and D and E)) return false;` 형태의 5단계 negation 중첩을 De Morgan 으로 풀어 `if (!A or B' or !C or D' or E') return false;` 형태의 평탄한 early-return guard 로 변경. 기능 변화 없음.

## Test plan

- [x] `zig build` — 빌드 통과
- [x] `zig build test` — 4773 unit tests 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)