### PR TITLE
fix(bundler): tree_shake wrapper-barrel module body seeding

### DIFF
--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -36,6 +36,7 @@ const const_materialize = @import("tree_shaker/const_materialize.zig");
 const import_records = @import("tree_shaker/import_records.zig");
 const module_effects = @import("tree_shaker/module_effects.zig");
 const re_export_namespace = @import("tree_shaker/re_export_namespace.zig");
+const graph_requested_exports = @import("graph/requested_exports.zig");
 const profile = @import("../profile.zig");
 
 /// `used_exports`의 all-exports-used sentinel. 모듈의 전체 export가 사용됨을 표시.
@@ -786,6 +787,22 @@ pub const TreeShaker = struct {
                         try self.enqueue(@intCast(i), @intCast(si), reachable_stmts, &queue);
                     }
                 } else if (m.side_effects) {
+                    for (infos.stmts, 0..) |stmt, si| {
+                        if (stmt.has_side_effects) {
+                            try self.enqueue(@intCast(i), @intCast(si), reachable_stmts, &queue);
+                        }
+                    }
+                } else if (m.side_effects_user_defined and
+                    !m.side_effects and
+                    !graph_requested_exports.isLazyBarrelCandidate(self.graph, m))
+                {
+                    // user 가 명시적으로 sideEffects:false 선언 + graph 가 wrapper-barrel
+                    // pattern (`import x; export default x;` + body mutate) 으로 식별한
+                    // 모듈만 body 시드. 일반 lazy barrel (named exports / object literal
+                    // default 등) 은 isLazyBarrelCandidate 가 true 라 이 분기에 안 들어와
+                    // 기존 lazy seed 유지. node_modules 밖에서 sideEffects:false 가
+                    // 적용 안 된 모듈 (user_def=false) 도 영향 없음. lodash-es
+                    // lodash.default.js 의 `lodash.uniq = uniq;` 같은 mutation 시드.
                     for (infos.stmts, 0..) |stmt, si| {
                         if (stmt.has_side_effects) {
                             try self.enqueue(@intCast(i), @intCast(si), reachable_stmts, &queue);
@@ -1713,6 +1730,20 @@ pub const TreeShaker = struct {
                 if (!self.included.isSet(src)) {
                     self.included.set(src);
                     changed = true;
+                }
+                // wrapper-barrel intermediate 보존: src 모듈이 user-declared
+                // sideEffects:false + wrapper-barrel pattern 인 경우, prune phase 에서
+                // hasAnyUsedExport=false 로 unset 되지 않도록 default 를 used 마킹.
+                // graph 의 isLazyBarrelCandidate wrapper-barrel detection 과 대응.
+                // lodash-es lodash.js → lodash.default.js → wrapperLodash.js chain 의
+                // intermediate 보존.
+                if (eb.kind == .re_export and
+                    std.mem.eql(u8, eb.exported_name, "default") and
+                    std.mem.eql(u8, eb.local_name, "default") and
+                    src_module.side_effects_user_defined and
+                    !src_module.side_effects)
+                {
+                    try self.markExportUsed(@intCast(src), "default");
                 }
                 if (src_module.wrap_kind == .cjs and eb.kind == .re_export_star) {
                     try self.markAllExportsUsed(@intCast(src));

--- a/tests/integration/tests/lodash-es-default-import.test.ts
+++ b/tests/integration/tests/lodash-es-default-import.test.ts
@@ -124,10 +124,12 @@ describe('export default <imported_id>: dangling _default reference 회귀 가�
   });
 
   test.skipIf(!hasPackage('lodash-es'))(
-    'lodash-es: 종합 import 패턴 — dangling _default 가 발생하지 않는다',
+    'lodash-es: 종합 import 패턴 + default 객체 method 호출이 정상 작동',
     async () => {
-      // lodash-es 는 위 합성 fixture 와 동일한 default re-export chain 을 가진다
-      // (lodash.js → lodash.default.js → wrapperLodash.js). 실제 패키지로 회귀 검증.
+      // lodash-es 의 default re-export chain (lodash.js → lodash.default.js
+      // → wrapperLodash.js) 에서 lodash.default.js 의 body mutation
+      // (`lodash.uniq = uniq;`) 이 보존되어 `_.uniq()` 같은 method 호출이
+      // 작동해야 한다.
       const fixture = await createFixture({
         'package.json': '{"type":"module"}',
         'entry.ts': `
@@ -136,15 +138,15 @@ describe('export default <imported_id>: dangling _default reference 회귀 가�
           import * as L from 'lodash-es';
           import uniqDirect from 'lodash-es/uniq.js';
 
-          // 직접 사용되는 named/namespace/subpath 함수는 정상 동작 검증.
-          // \`_\` (default) 는 lodash.default.js 의 mutation 까지 살리는 별도 작업
-          // (graph-level lazy import resolution) 이 필요해 typeof 만 확인.
           const out = {
             named_uniq: uniq([1, 1, 2, 2, 3]),
             named_chunk: chunk([1, 2, 3, 4, 5], 2),
             namespace_zip: L.zip(['a', 'b'], [1, 2]),
             subpath: uniqDirect([7, 7, 8]),
-            default_typeof: typeof _,
+            default_uniq: _.uniq([3, 3, 1, 1, 2, 2]),
+            default_keys: _.keys({ x: 1, y: 2 }),
+            default_camelCase: _.camelCase('foo bar baz'),
+            default_max: _.max([1, 9, 3]),
           };
           console.log(JSON.stringify(out));
         `,
@@ -175,8 +177,10 @@ describe('export default <imported_id>: dangling _default reference 회귀 가�
         ['b', 2],
       ]);
       expect(parsed.subpath).toEqual([7, 8]);
-      // _ 가 function 형태로 import 되어야 (실제 method 호출은 별도 PR 에서 수정).
-      expect(parsed.default_typeof).toBe('function');
+      expect(parsed.default_uniq).toEqual([3, 1, 2]);
+      expect(parsed.default_keys).toEqual(['x', 'y']);
+      expect(parsed.default_camelCase).toBe('fooBarBaz');
+      expect(parsed.default_max).toBe(9);
 
       expectNoDanglingDefaultRefs(readFileSync(outFile, 'utf8'));
     },


### PR DESCRIPTION
## Summary

- `import _ from 'lodash-es'; _.uniq()` 같은 default-only 사용에서 `lodash.uniq is not a function` 으로 깨지던 회귀 수정
- PR #2946 의 graph wrapper-barrel detection 후속 — tree_shake 가 wrapper-barrel module body 의 mutation 도 보존
- 회귀 테스트 강화 (typeof 검증 → 실제 method 호출 결과 검증)

## 배경

lodash-es `lodash.default.js`:

```js
import lodash from './wrapperLodash.js';
import uniq from './uniq.js';
// ... 35 more imports
lodash.uniq = uniq;          // body mutation
lodash.keys = keys;
// ... ~300 mutations
export default lodash;
```

PR #2946 으로 graph 가 이 wrapper-barrel pattern 을 식별해 모든 imports 를 link 했지만, tree_shake 의 seeding 정책이 sideEffects:false 모듈을 통째로 skip 해 body 의 mutation stmt 가 시드 안 됨 → BFS 가 reach 못 함 → emit 누락 → runtime `lodash.uniq is not a function`.

## 수정 (`src/bundler/tree_shaker.zig`)

1. **Seeding 분기에 wrapper-barrel 케이스 추가**:

```zig
} else if (m.side_effects_user_defined and
    !m.side_effects and
    !graph_requested_exports.isLazyBarrelCandidate(self.graph, m))
{
    // user-declared sideEffects:false + wrapper-barrel pattern → body 의
    // has_side_effects=true stmt seed (mutation 들이 BFS 로 도달 가능하게).
    ...
}
```

2. **`includeReExportSources` 의 narrow propagation**:

```zig
if (eb.kind == .re_export and
    eb.exported_name == "default" and eb.local_name == "default" and
    src_module.side_effects_user_defined and !src_module.side_effects)
{
    // wrapper-barrel intermediate (lodash.default.js) 가 prune 으로 unset 되지
    // 않도록 default 를 used 마킹.
    try self.markExportUsed(@intCast(src), "default");
}
```

두 변경 모두 `user_def=true + side_effects=false` 게이트 — `node_modules` 밖의 fixture 모듈 (sideEffects 적용 안 됨, user_def=false) 이 잘못 fire 되는 회귀 방지.

## Root cause analysis (회귀 추적)

이전 시도에서 `else if (!isLazyBarrelCandidate(...))` 만으로는 fixture 의 unused-marker 회귀 발생. `findPackageDirPath` 가 `node_modules/<pkg>` 만 찾아 fixture root 의 `package.json` 을 못 찾고 모듈들의 `side_effects_user_defined=false` 로 남음. `isLazyBarrelCandidate` 첫 검사에서 fail → false 반환 → `!isLazyBarrelCandidate=true` → 잘못된 시드.

`user_def=true` 게이트 추가로 fixture 영향 회피.

## 회귀 테스트 강화

`tests/integration/tests/lodash-es-default-import.test.ts` 의 lodash-es 케이스가 이전엔 `default_typeof === 'function'` 까지만 검증. 이번 PR 로 가능해진 method 호출 결과까지 검증:

- `_.uniq([3,3,1,1,2,2])` → `[3,1,2]`
- `_.keys({x:1,y:2})` → `['x','y']`
- `_.camelCase('foo bar baz')` → `'fooBarBaz'`
- `_.max([1,9,3])` → `9`

## Test plan

- [x] `zig build test` — rn_codegen 25 baseline fail 외 회귀 없음
- [x] `export-star unrelated source DCE` 회귀 가드 통과 (`TreeShaking: export star named import drops unrelated source declared sideEffects:false`)
- [x] tslib pattern (`export default {...}`) unused default object DCE 보존
- [x] valibot/cookie 같은 sideEffects:false subset DCE 보존 — wrapper-barrel 아닌 일반 모듈은 영향 없음
- [x] lodash-es 회귀 테스트 4/4 통과 (default method 호출 정상 작동)
- [x] bundle-smoke / manual-chunks-smoke / sourcemap / swc-compare 통합 테스트 회귀 없음 (zod 1 fail 은 baseline pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)