### PR TITLE
refactor(bundler): wrapper-barrel detection helper + Module cache

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -112,6 +112,15 @@ pub const ExportBinding = struct {
         }
     };
 
+    /// `export { default } from './m'` 같이 default → default 직진 named re-export
+    /// 인지. wrapper-barrel pattern (lodash-es lodash.js → lodash.default.js) detection
+    /// 의 한 부분. `default as X` 같이 alias 가 들어가는 케이스는 false.
+    pub fn isDefaultDirectReExport(self: ExportBinding) bool {
+        return self.kind == .re_export and
+            std.mem.eql(u8, self.exported_name, "default") and
+            std.mem.eql(u8, self.local_name, "default");
+    }
+
     /// 이 export 때문에 현재 모듈에 `_default` 합성 변수가 생기는지 확인.
     /// #1338 Phase 4e-2d-a: synthetic_default는 항상 semantic 공간에 등록됨.
     pub fn hasSyntheticDefault(

--- a/src/bundler/graph/json_module.zig
+++ b/src/bundler/graph/json_module.zig
@@ -86,6 +86,7 @@ pub fn parse(self: *ModuleGraph, module: *Module) void {
     binding_scanner_mod.collectNamespaceAccesses(arena_alloc, &(module.ast.?), module.import_bindings) catch {};
     module.export_bindings = binding_scanner_mod.extractExportBindings(arena_alloc, &(module.ast.?), scan_result.records, module.import_bindings) catch &.{};
     module.exported_names = projectExportedNames(arena_alloc, module.export_bindings);
+    module.is_wrapper_barrel = @import("requested_exports.zig").computeIsWrapperBarrel(module);
 
     // Phase 1 (#1328): 합성 심볼 테이블 초기화 + export default 등록.
     module.ensureAliasTable(self.allocator);

--- a/src/bundler/graph/parser_metadata.zig
+++ b/src/bundler/graph/parser_metadata.zig
@@ -84,6 +84,8 @@ pub fn materialize(
             }
             module.export_bindings = ebindings;
             module.exported_names = projectExportedNames(arena_alloc, ebindings);
+            // wrapper-barrel detection 캐시 (export_bindings 가 final 인 시점에 한 번 계산).
+            module.is_wrapper_barrel = @import("requested_exports.zig").computeIsWrapperBarrel(module);
         } else |_| {}
     }
 

--- a/src/bundler/graph/requested_exports.zig
+++ b/src/bundler/graph/requested_exports.zig
@@ -55,16 +55,17 @@ pub fn isLazyBarrelCandidate(self: anytype, m: *const Module) bool {
 /// `lodash.uniq = uniq;` 같은 ~300 개 mutation) lazy 처리하면 mutation reference imports
 /// 가 누락되어 runtime ReferenceError 발생. graph 의 `shouldLinkResolvedRecordForModule`
 /// 와 tree_shaker 의 시드 게이트 양쪽이 이 함수를 사용해 wrapper-barrel 만 정확히
-/// 처리하도록 한다.
+/// 처리하도록 한다. `Module.is_wrapper_barrel` 캐시를 사용해 hot path 중복 계산 회피.
 pub fn isWrapperBarrel(self: anytype, m: *const Module) bool {
     if (!isLazyBarrelCandidate(self, m)) return false;
+    return m.is_wrapper_barrel;
+}
+
+/// `Module.is_wrapper_barrel` 캐시 채우는 1 회용 컴퓨터. graph build 의 `applySideEffects`
+/// 직후, parse 가 끝나 export_bindings 가 final 인 시점에 호출.
+pub fn computeIsWrapperBarrel(m: *const Module) bool {
     for (m.export_bindings) |eb| {
-        if (eb.kind == .re_export and
-            std.mem.eql(u8, eb.exported_name, "default") and
-            std.mem.eql(u8, eb.local_name, "default"))
-        {
-            return true;
-        }
+        if (eb.isDefaultDirectReExport()) return true;
     }
     return false;
 }

--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -391,6 +391,7 @@ pub fn resyncAfterAstMutation(
             module.import_bindings,
         );
         module.exported_names = projectExportedNames(arena_alloc, module.export_bindings);
+        module.is_wrapper_barrel = @import("requested_exports.zig").computeIsWrapperBarrel(module);
     }
 
     const has_refreshed_cjs = scan_result.has_cjs_require or

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -237,6 +237,11 @@ pub const Module = struct {
     /// true면 tree-shaker의 auto-purity 분석이 이 값을 덮어쓸 수 없다.
     /// Rolldown `DeterminedSideEffects::UserDefined` 포팅.
     side_effects_user_defined: bool = false,
+    /// `import x; export default x;` body mutation pattern (lodash-es lodash.default.js).
+    /// `requested_exports.computeIsWrapperBarrel` 가 export_bindings 순회로 한 번 결정해
+    /// 캐시. graph link 결정 (`shouldLinkResolvedRecordForModule`) + tree_shaker 시드 게이트
+    /// + tree_shaker default→default re-export propagation 세 hot-path 호출처가 공유.
+    is_wrapper_barrel: bool = false,
     /// platform=browser에서 Node 빌트인 모듈을 빈 CJS로 대체 (esbuild "(disabled)" 방식).
     /// AST가 없고, emitter가 빈 __commonJS wrapper를 출력한다.
     is_disabled: bool = false,

--- a/src/bundler/phase.zig
+++ b/src/bundler/phase.zig
@@ -92,7 +92,10 @@ pub const ParseAccessor = struct {
     }
 
     pub inline fn setExportBindings(self: ParseAccessor, idx: ModuleIndex, bindings: []ExportBinding) void {
-        if (self.graph.moduleAtMut(idx)) |m| m.export_bindings = bindings;
+        if (self.graph.moduleAtMut(idx)) |m| {
+            m.export_bindings = bindings;
+            m.is_wrapper_barrel = @import("graph/requested_exports.zig").computeIsWrapperBarrel(m);
+        }
     }
 
     pub inline fn setLineOffsets(self: ParseAccessor, idx: ModuleIndex, offsets: []const u32) void {

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -1731,9 +1731,7 @@ pub const TreeShaker = struct {
                 // 되지 않도록 default 를 used 마킹. lodash-es lodash.js → lodash.default.js
                 // → wrapperLodash.js chain 보존. `default as X` alias 는 line 1716 gate 에서
                 // X 가 used 가 아니면 propagation 자체 차단되므로 narrow check 로 충분.
-                if (eb.kind == .re_export and
-                    std.mem.eql(u8, eb.exported_name, "default") and
-                    std.mem.eql(u8, eb.local_name, "default") and
+                if (eb.isDefaultDirectReExport() and
                     graph_requested_exports.isWrapperBarrel(self.graph, src_module))
                 {
                     try self.markExportUsed(@intCast(src), "default");


### PR DESCRIPTION
## Summary

PR #2951 의 follow-up — `/simplify` 가 식별한 두 잠재 개선 적용.

## 변경

### 1. `ExportBinding.isDefaultDirectReExport()` helper

`eb.kind == .re_export and eb.exported_name == "default" and eb.local_name == "default"` 4-condition chain 을 method 로 추출. `requested_exports.zig` 와 `tree_shaker.zig` 두 호출처가 helper 사용 → 의도 명확화.

### 2. `Module.is_wrapper_barrel` cache field

`isWrapperBarrel(self.graph, m)` 가 hot path 에서 호출됨:
- `shouldLinkResolvedRecordForModule` (graph build, 모든 import_record 마다)
- tree_shaker 시드 게이트 (모든 included module 마다)
- tree_shaker `markExportUsed` propagation (re-export binding 마다)

매 호출마다 export_bindings 순회 = O(K). N×M×K = lodash-es 규모 9000+ 호출 × ~3 binding = 27000+ 비교. cache field 로 한 번 계산 → 후속 O(1).

`computeIsWrapperBarrel(m)` 가 export_bindings 추출 직후 한 번 호출되도록 4 곳에 hook 추가:
- `graph/parser_metadata.zig:88` (parallel scan path)
- `graph/transform_prepass.zig:394` (resync path)
- `graph/json_module.zig:90` (json module)
- `phase.zig:setExportBindings` (phase API)

`isWrapperBarrel` 은 cache 만 read.

## Test plan

- [x] `zig build test` — rn_codegen 25 baseline fail 외 회귀 없음
- [x] export-star unrelated source DCE 회귀 가드 통과
- [x] lodash-es 회귀 테스트 4/4 통과 (default method 호출 정상)
- [x] bundle-smoke / manual-chunks-smoke / tree-shake-precision 통합 테스트 회귀 없음 (zod 1 fail 은 baseline pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)