### PR TITLE
fix(bundler): linker namespace import collision detection

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -426,9 +426,12 @@ pub const Linker = struct {
                 // import binding이 top-level 변수를 생성하는 경우에만 충돌 대상에 포함:
                 // - CJS preamble: var X = require_xxx().X
                 // - __esm 호이스팅: var X; (래퍼 밖으로 호이스팅)
+                // - namespace import 의 inline ns_var (`var z = external_ns;`) 는
+                //   wrap_kind 에 무관하게 emit 되므로 collision detection 대상.
                 const generates_top_level_var = blk: {
                     for (m.import_bindings) |ib| {
                         if (!std.mem.eql(u8, ib.local_name, sym_name)) continue;
+                        if (ib.kind == .namespace) break :blk true;
                         if (ib.import_record_index >= m.import_records.len) break :blk false;
                         const rec = m.import_records[ib.import_record_index];
                         if (rec.resolved.isNone()) break :blk !rec.is_lazy_resolved;

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -379,6 +379,25 @@ describe('번들 스모크 테스트', () => {
     expect(result.runOutput).toBe('ok');
   });
 
+  test('namespace import 와 다른 모듈의 동명 module-local var 충돌 방지', async () => {
+    // 두 모듈이 같은 이름 `z` 를 가지지만 한 쪽은 namespace import (`import * as z`),
+    // 다른 쪽은 module-local const. linker collectModuleNames 가 namespace import 의
+    // ns_var (`var z = ...`) 도 collision detection 에 등록해야 한다.
+    // zod entry 의 `import { z }` + 내부 from-json-schema.js 의 `const z = {...}` 패턴
+    // (browser-smoke.test.ts 의 `Identifier 'z' has already been declared` 회귀 가드).
+    const result = await bundleAndRun({
+      'index.ts': `import { z } from "./pkg"; import other from "./collision"; console.log(typeof z.foo, other.local);`,
+      'pkg.ts': `import * as z from "./target"; export { z }; export default z;`,
+      'target.ts': `export function foo() { return "ok"; }`,
+      'collision.ts': `const z = { local: true }; export default z;`,
+    });
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runStderr).not.toMatch(/Identifier .* has already been declared/);
+    expect(result.runOutput).toBe('function true');
+  });
+
   test('namespace 변수명 progressive 충돌 방지 (z_ns export 존재 시 z_ns2)', async () => {
     const result = await bundleAndRun({
       'index.ts': `import * as z from "./lib"; console.log(z.foo(), z.z_ns, Object.keys(z).sort().join(","));`,


### PR DESCRIPTION
## Summary

CI 의 `tests/e2e/tests/browser-smoke.test.ts:644 (zod)` 가 `Identifier 'z' has already been declared` SyntaxError 로 fail 하던 회귀 수정. `collectModuleNames` 가 namespace import 의 inline ns_var 를 collision detection 대상에 누락한 게 원인.

## 증상

```
file:///.../bundle.js:8882
var z = external_ns;
    ^
SyntaxError: Identifier 'z' has already been declared
```

zod/index.js 의 `import * as z from "./external.js"` 가 inline namespace var 로 emit (`var z = external_ns;`) 되고, 같은 패키지 내부의 `from-json-schema.js` 가 `const z = {..._schemas, ..._checks, iso: _iso};` 로 module-local var 를 정의. ESM scope-hoisted 번들에서 둘이 같은 top-level scope 에 들어가 충돌.

## 근본 원인

`src/bundler/linker.zig:429-455` 의 `collectModuleNames` 가 import binding 의 collision detection 대상 여부를 결정할 때 `generates_top_level_var` 검사:

| 케이스 | generates_top_level_var |
|--------|-------------------------|
| CJS preamble (`var X = require_xxx().X`) | ✓ |
| `__esm` 호이스팅 | ✓ |
| namespace import (`var z = external_ns`) | ✗ **누락** |

namespace import 의 inline ns_var 도 wrap_kind 와 무관하게 항상 emit 되므로 collision detection 대상에 포함되어야 한다.

## 수정

`for (m.import_bindings) |ib| { if (!eql(ib.local_name, sym_name)) continue;` 직후에 `if (ib.kind == .namespace) break :blk true;` 한 줄 추가. namespace import binding 매치 시 즉시 collision 대상으로 등록.

## 회귀 가드

`tests/integration/tests/bundle-smoke.test.ts` 에 zod 패턴 reproducer 추가:

```ts
'pkg.ts': `import * as z from "./target"; export { z }; export default z;`,
'collision.ts': `const z = { local: true }; export default z;`,
```

baseline 에서 `SyntaxError: Identifier 'z' has already been declared` 로 fail, 이번 fix 후 통과 확인. e2e `tests/e2e/tests/browser-smoke.test.ts:644 (zod)` 도 동일 패턴이라 같이 해결.

## Test plan

- [x] `zig build test` — rn_codegen 25 baseline fail 외 회귀 없음
- [x] zod fixture (`import { z } from 'zod'`) 정상 실행 (`typeof z.string === 'function'`)
- [x] 합성 fixture 회귀 가드 통과
- [x] 기존 namespace import 테스트들 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)