### PR TITLE
fix(bundler/emitter): minify ESM external import 식별자↔키워드 토큰 경계 공백 누락

### DIFF
--- a/src/bundler/emitter/external_imports.zig
+++ b/src/bundler/emitter/external_imports.zig
@@ -186,8 +186,12 @@ fn emitOneImport(
     const list_sep: []const u8 = if (minify_whitespace) "," else ", ";
     const brace_open: []const u8 = if (minify_whitespace) "{" else "{ ";
     const brace_close: []const u8 = if (minify_whitespace) "}" else " }";
-    const from_open: []const u8 = if (minify_whitespace) "from\"" else " from \"";
     const eol: []const u8 = if (minify_whitespace) "" else "\n";
+
+    // ESM token boundary 규칙 (#2955):
+    //   - `import D from "x"` 의 D 는 식별자라서 keyword 와 인접하면 공백 필수.
+    //   - `import{x}from"y"` 는 `{` / `}` 가 토큰 경계라 minify 시 공백 생략 가능.
+    //   - `import * as N from "x"` 의 N 도 식별자라 from 앞 공백 필수.
 
     const has_default_or_named = group.default_local != null or group.named.items.len > 0;
     const has_any = has_default_or_named or group.namespace_local != null;
@@ -205,12 +209,15 @@ fn emitOneImport(
     // (1) default + named — 한 줄. rolldown 의 `create_import_declaration` 동일.
     //     ESM spec 상 `import D, { x } from "spec"` 합법. namespace 는 같이 못 묶음.
     if (has_default_or_named) {
-        try output.appendSlice(allocator, if (minify_whitespace) "import" else "import ");
+        const import_kw: []const u8 = if (minify_whitespace and group.default_local == null) "import" else "import ";
+        try output.appendSlice(allocator, import_kw);
+
         var has_pre = false;
         if (group.default_local) |d| {
             try output.appendSlice(allocator, d);
             has_pre = true;
         }
+        var ends_with_brace = false;
         if (group.named.items.len > 0) {
             if (has_pre) try output.appendSlice(allocator, list_sep);
             try output.appendSlice(allocator, brace_open);
@@ -225,8 +232,14 @@ fn emitOneImport(
                 }
             }
             try output.appendSlice(allocator, brace_close);
+            ends_with_brace = true;
         }
-        try output.appendSlice(allocator, from_open);
+        const from_kw: []const u8 = blk: {
+            if (!minify_whitespace) break :blk " from \"";
+            if (ends_with_brace) break :blk "from\"";
+            break :blk " from\"";
+        };
+        try output.appendSlice(allocator, from_kw);
         try output.appendSlice(allocator, spec);
         try output.appendSlice(allocator, "\";");
         try output.appendSlice(allocator, eol);
@@ -237,7 +250,7 @@ fn emitOneImport(
     if (group.namespace_local) |n| {
         try output.appendSlice(allocator, if (minify_whitespace) "import*as " else "import * as ");
         try output.appendSlice(allocator, n);
-        try output.appendSlice(allocator, from_open);
+        try output.appendSlice(allocator, if (minify_whitespace) " from\"" else " from \"");
         try output.appendSlice(allocator, spec);
         try output.appendSlice(allocator, "\";");
         try output.appendSlice(allocator, eol);

--- a/src/bundler/emitter/external_imports.zig
+++ b/src/bundler/emitter/external_imports.zig
@@ -267,3 +267,97 @@ fn emitOneImport(
         try output.appendSlice(allocator, eol);
     }
 }
+
+// ============================================================
+// Tests
+// ============================================================
+
+const testing = std.testing;
+
+fn runEmit(group: *const SpecifierGroup, spec: []const u8, minify: bool) ![]u8 {
+    var output: std.ArrayList(u8) = .empty;
+    errdefer output.deinit(testing.allocator);
+    try emitOneImport(&output, testing.allocator, spec, group, minify);
+    return output.toOwnedSlice(testing.allocator);
+}
+
+test "emitOneImport: default-only minify — 식별자↔keyword 토큰 경계 공백 (#2955)" {
+    var group: SpecifierGroup = .{ .default_local = "process$1" };
+    defer group.deinit(testing.allocator);
+
+    const out = try runEmit(&group, "node:process", true);
+    defer testing.allocator.free(out);
+
+    // `importprocess$1from"…"` 가 아니라 양쪽에 공백.
+    try testing.expectEqualStrings("import process$1 from\"node:process\";", out);
+}
+
+test "emitOneImport: default + named minify — brace 직후 from 공백 생략 (minify 효과)" {
+    var group: SpecifierGroup = .{ .default_local = "D" };
+    defer group.deinit(testing.allocator);
+    try group.named.append(testing.allocator, .{ .imported = "x", .local = "x" });
+
+    const out = try runEmit(&group, "spec", true);
+    defer testing.allocator.free(out);
+
+    // `}` 가 토큰 경계라 from 앞 공백 생략 가능 — 단 import↔D 사이는 공백 필수.
+    try testing.expectEqualStrings("import D,{x}from\"spec\";", out);
+}
+
+test "emitOneImport: named-only minify — 양쪽 brace 가 경계라 공백 모두 생략" {
+    var group: SpecifierGroup = .{};
+    defer group.deinit(testing.allocator);
+    try group.named.append(testing.allocator, .{ .imported = "createRequire", .local = "createRequire" });
+
+    const out = try runEmit(&group, "node:module", true);
+    defer testing.allocator.free(out);
+
+    try testing.expectEqualStrings("import{createRequire}from\"node:module\";", out);
+}
+
+test "emitOneImport: namespace minify — 식별자 직후 from 공백 필수 (#2955)" {
+    var group: SpecifierGroup = .{ .namespace_local = "ns" };
+    defer group.deinit(testing.allocator);
+
+    const out = try runEmit(&group, "spec", true);
+    defer testing.allocator.free(out);
+
+    // `*as N` 의 N 은 식별자라 from 앞 공백 필수. `nsfrom"…"` 형태 회귀 방지.
+    try testing.expectEqualStrings("import*as ns from\"spec\";", out);
+}
+
+test "emitOneImport: side-effect minify — `\"` 가 토큰 경계라 공백 불필요" {
+    var group: SpecifierGroup = .{ .side_effect_only = true };
+    defer group.deinit(testing.allocator);
+
+    const out = try runEmit(&group, "polyfill", true);
+    defer testing.allocator.free(out);
+
+    try testing.expectEqualStrings("import\"polyfill\";", out);
+}
+
+test "emitOneImport: non-minify default + named — 보수적 공백 + newline" {
+    var group: SpecifierGroup = .{ .default_local = "D" };
+    defer group.deinit(testing.allocator);
+    try group.named.append(testing.allocator, .{ .imported = "x", .local = "y" });
+
+    const out = try runEmit(&group, "spec", false);
+    defer testing.allocator.free(out);
+
+    try testing.expectEqualStrings("import D, { x as y } from \"spec\";\n", out);
+}
+
+test "emitOneImport: rename 없는 named 두 개 — list_sep 적용" {
+    var group: SpecifierGroup = .{};
+    defer group.deinit(testing.allocator);
+    try group.named.append(testing.allocator, .{ .imported = "a", .local = "a" });
+    try group.named.append(testing.allocator, .{ .imported = "b", .local = "b" });
+
+    const min = try runEmit(&group, "x", true);
+    defer testing.allocator.free(min);
+    try testing.expectEqualStrings("import{a,b}from\"x\";", min);
+
+    const pretty = try runEmit(&group, "x", false);
+    defer testing.allocator.free(pretty);
+    try testing.expectEqualStrings("import { a, b } from \"x\";\n", pretty);
+}


### PR DESCRIPTION
## Summary
- minify 모드 ESM external import emit 시 식별자가 keyword 와 인접한 케이스에서 공백을 항상 생략 → SyntaxError
- 영향: `import D from "x"`, `import * as N from "x"` 처럼 default / namespace 식별자가 들어가는 모든 external import

## Root cause
`src/bundler/emitter/external_imports.zig` 가 minify 시 `from"…"` 하나로 emit. token boundary 무시:
```js
// 기존 minify 출력 (chalk 사례)
importprocess$1from"node:process";
//     ^^^^^^^^^^         ^^^^
//     식별자가 keyword 와 합쳐짐 → SyntaxError
```

`{` / `}` 는 punctuator 라 키워드와 인접해도 안전하지만 식별자는 공백이 필수.

## Fix
`from_open` 단일 상수를 제거하고 두 사이트에서 token-boundary-aware 분기:
- **default + named**: `import_kw` 가 default 존재 시 `"import "` 로, `from_kw` 는 `ends_with_brace` 로 분기 (brace 직후만 공백 생략)
- **namespace**: 식별자 직후라 `" from\""` 로 항상 공백

named-only 케이스 (`import{x}from"y"`) 는 그대로 유지 (minify 효과 최대 보존).

## 회귀 검증

`bun run tests/benchmark/smoke.ts --deep --minify-all`:

| | 이전 | 이후 |
|---|---|---|
| chalk | ❌ build OK / run SyntaxError | ✅ build OK / run MATCH (4-way 일치) |
| 다른 fixture | (다른 13개 별도 이슈) | 회귀 0 — 모두 동일 |

생성된 출력 확인:
```js
import process$1 from"node:process";import os from"node:os";import tty from"node:tty";...
```

## Test plan
- [ ] `bun run tests/benchmark/smoke.ts --deep --minify-all --filter=chalk` → MATCH
- [ ] `bun run tests/benchmark/smoke.ts --deep --filter=chalk` → MATCH (non-minify 회귀 없음)
- [ ] minify 없는 빌드: `import process$1 from "node:process";` 형태 그대로 유지
- [ ] named-only minify: `import{createRequire}from"node:module"` 형태 그대로 유지 (공백 추가 안 됨 — minify 손실 0)

Closes #2955

🤖 Generated with [Claude Code](https://claude.com/claude-code)