### PR TITLE
fix(mangler): cross-module Phase A 이름이 nested binding 과 충돌하는 shadow 차단

### DIFF
--- a/src/codegen/mangler.zig
+++ b/src/codegen/mangler.zig
@@ -136,10 +136,18 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
         };
     }
 
-    // 선언 scope 자체를 alive로 표시
+    // 선언 scope 자체 + 모든 후손 scope 를 alive 로 표시 (#2956 shadowing 방지).
+    //
+    // outer binding 은 모든 후손 scope 에서 reference 가능 (closure). 후손 scope 의
+    // declaration 이 ancestor 와 같은 slot 을 받으면 mangle 후 자기참조가 됨:
+    //   function e(t,n) { ... }
+    //   function p(n,t) { const e = e(n); ... }   // const e 가 outer e 를 shadow → ReferenceError
+    // declaration scope 의 subtree 전체를 alive 로 표시하면 이 binding 과 후손
+    // declaration 이 graph coloring 에서 다른 slot 을 받게 됨. sibling 은 declaration
+    // scope 가 같아 이미 충돌 (intersect) 처리되므로 영향 없음.
     for (symbols, 0..) |sym, i| {
         if (!sym.scope_id.isNone() and sym.scope_id.toIndex() < scope_count) {
-            symbol_liveness[i].set(sym.scope_id.toIndex());
+            markScopeSubtree(&symbol_liveness[i], children, sym.scope_id.toIndex());
         }
     }
 
@@ -403,6 +411,23 @@ fn markAncestorPath(
     }
 }
 
+/// scope_root 와 그 모든 후손 scope 를 liveness 에 set (#2956 shadowing 방지).
+/// children list 를 따라 재귀 DFS. scope tree depth 는 보통 < 100 으로 stack 안전.
+fn markScopeSubtree(
+    liveness: *std.DynamicBitSet,
+    children: ChildrenList,
+    scope_root: u32,
+) void {
+    liveness.set(scope_root);
+    if (scope_root + 1 >= children.offsets.len) return;
+    const start = children.offsets[scope_root];
+    const end = children.offsets[scope_root + 1];
+    var ci = start;
+    while (ci < end) : (ci += 1) {
+        markScopeSubtree(liveness, children, children.list[ci]);
+    }
+}
+
 /// 두 BitSet이 교집합을 가지는지 검사 (하나라도 겹치면 true).
 /// std.DynamicBitSet에는 non-destructive 교집합 검사가 없으므로 직접 구현.
 fn bitsetIntersects(a: std.DynamicBitSet, b: std.DynamicBitSet) bool {
@@ -640,4 +665,54 @@ test "mangle: string_table 기반 생성 심볼도 rename 결과에 포함" {
     defer result.deinit();
 
     try std.testing.expectEqualStrings("e", result.renames.get(0).?);
+}
+
+test "markScopeSubtree: declaration scope + 모든 후손 set, sibling/ancestor 는 제외 (#2956)" {
+    const allocator = std.testing.allocator;
+
+    // scope tree:
+    //   0 (root)
+    //     ├─ 1
+    //     │   └─ 3
+    //     └─ 2
+    const scopes = [_]Scope{
+        .{ .parent = .none, .kind = .global, .is_strict = false, .symbol_count = 0 },
+        .{ .parent = @enumFromInt(0), .kind = .function, .is_strict = false, .symbol_count = 0 },
+        .{ .parent = @enumFromInt(0), .kind = .function, .is_strict = false, .symbol_count = 0 },
+        .{ .parent = @enumFromInt(1), .kind = .block, .is_strict = false, .symbol_count = 0 },
+    };
+
+    const children = try buildChildrenList(allocator, &scopes);
+    defer allocator.free(children.offsets);
+    defer allocator.free(children.list);
+
+    var liveness = try std.DynamicBitSet.initEmpty(allocator, scopes.len);
+    defer liveness.deinit();
+
+    // scope 1 의 subtree (1, 3) 만 set 되어야 한다.
+    markScopeSubtree(&liveness, children, 1);
+    try std.testing.expect(liveness.isSet(1));
+    try std.testing.expect(liveness.isSet(3));
+    try std.testing.expect(!liveness.isSet(0)); // ancestor 는 제외
+    try std.testing.expect(!liveness.isSet(2)); // sibling 은 제외
+}
+
+test "markScopeSubtree: leaf scope 은 자기 자신만 set" {
+    const allocator = std.testing.allocator;
+
+    const scopes = [_]Scope{
+        .{ .parent = .none, .kind = .global, .is_strict = false, .symbol_count = 0 },
+        .{ .parent = @enumFromInt(0), .kind = .function, .is_strict = false, .symbol_count = 0 },
+    };
+
+    const children = try buildChildrenList(allocator, &scopes);
+    defer allocator.free(children.offsets);
+    defer allocator.free(children.list);
+
+    var liveness = try std.DynamicBitSet.initEmpty(allocator, scopes.len);
+    defer liveness.deinit();
+
+    markScopeSubtree(&liveness, children, 1);
+    try std.testing.expect(liveness.isSet(1));
+    try std.testing.expect(!liveness.isSet(0));
 }

--- a/src/codegen/unified_mangler.zig
+++ b/src/codegen/unified_mangler.zig
@@ -145,20 +145,13 @@ pub fn mangleAll(
     errdefer allocator.free(phase_b_stats);
 
     for (input.modules, 0..) |m, i| {
-        // Phase B 는 per-module 독립 counter. external_reserved 는 해당 모듈
-        // scope 심볼의 Phase A mangled 이름만 포함 (outer shadow 방지 + 전역
-        // pool 공유의 over-reserving 회피).
-        var module_reserved: std.StringHashMap(void) = .init(allocator);
-        defer module_reserved.deinit();
-        if (m.scope_maps.len > 0) {
-            var sit = m.scope_maps[0].iterator();
-            while (sit.next()) |entry| {
-                const sid: u32 = @intCast(entry.value_ptr.*);
-                const key: ModuleSymKey = .{ .module_index = @intCast(i), .symbol_id = sid };
-                if (renames.get(key)) |mangled| try module_reserved.put(mangled, {});
-            }
-        }
-
+        // Phase B 는 per-module 독립 counter 지만 external_reserved 로 전역
+        // `reserved` 를 그대로 전달한다 (#2956). 다른 모듈의 Phase A mangled
+        // 이름이 이 모듈의 nested binding 과 충돌하면 cross-module shadow 가
+        // 발생 (date-fns: outer constructDateFrom='t' 와 다른 모듈 addDays 의
+        // inner const _date='t' 가 자기참조 ReferenceError). 자기 모듈의
+        // top-scope binding 은 Phase A 에서 이미 reserved 에 등록되어 있으므로
+        // 별도 module_reserved 를 만들지 않아도 된다.
         var nested = try mangler.mangle(allocator, .{
             .scopes = m.scopes,
             .symbols = m.symbols,
@@ -166,7 +159,7 @@ pub fn mangleAll(
             .references = m.references,
             .source = m.source,
             .skip_symbols = m.module_scope_symbols,
-            .external_reserved = &module_reserved,
+            .external_reserved = &reserved,
         });
         defer nested.deinit();
         phase_b_stats[i] = nested.stats;


### PR DESCRIPTION
## Summary
- #2956 root cause: Phase B 가 자기 모듈 module-top binding 만 reserved 에 등록 → 다른 모듈의 Phase A mangled 이름이 이 모듈의 nested binding 과 같은 short name 받음
- 결과: outer constructDateFrom='t' 와 다른 모듈 addDays 의 inner const _date='t' 가 자기참조 ReferenceError

## Root cause
\`unified_mangler.zig\` Phase B 의 nested mangler 호출:
```zig
// before
.external_reserved = &module_reserved,  // 자기 모듈 binding 만 — 다른 모듈은 미인식
```
다른 모듈의 Phase A 이름은 전역 \`reserved\` 에 들어가지만 nested mangler 입력에는 module-local set 만 전달돼서 cross-module shadow 발생.

## Fix
1. **\`unified_mangler.zig\`**: Phase B nested mangler 의 \`external_reserved\` 를 전역 \`reserved\` 로 직접 전달. 자기 모듈 binding 은 Phase A 에서 이미 reserved 에 들어가 있어 추가 손실 없음.

2. **\`mangler.zig\`**: declaration scope 의 subtree 전체를 liveness 에 표시 (\`markScopeSubtree\`). single-module 안에서 outer binding 과 inner declaration 이 우연히 같은 slot 받아 shadow 되는 케이스를 graph coloring 에서 차단. sibling 은 declaration scope 가 같아 이미 처리되므로 minify 효과 손실 없음.

3. **단위 테스트 2개** (\`mangler.zig\`):
   - \`markScopeSubtree\` 가 declaration scope + 자손만 set, sibling/ancestor 는 제외
   - leaf scope 케이스

## 회귀 검증

| | 이전 | 이후 |
|---|---|---|
| effect | ❌ build OK / run RangeError | ✅ build OK / run MATCH |
| date-fns | ❌ ReferenceError | ⚠️ mangler 자체 정상, 별개 minify 버그로 fail (#2964) |
| three | ❌ ReferenceError | ⚠️ mangler 자체 정상, 별개 sibling collision 으로 fail (#2965) |
| 다른 28개 fixture | — | 회귀 0 |

## 후속
- #2964 — date-fns 의 arrow function object body unwrap 버그 (별개 minify codegen 이슈)
- #2965 — three 의 top-level class ↔ nested const collision 버그 (별개 mangler edge case)

이 두 이슈가 fix 되면 #2956 의 마지막 두 라이브러리도 통과.

## Test plan
- [ ] \`bun run tests/benchmark/smoke.ts --deep --minify-all --filter=effect\` → MATCH
- [ ] \`bun run tests/benchmark/smoke.ts --deep --minify-all --filter=date-fns\` → 새 에러 (#2964)
- [ ] \`bun run tests/benchmark/smoke.ts --deep --minify-all --filter=three\` → 새 에러 (#2965)
- [ ] 다른 fixture 회귀 0
- [ ] \`zig build test -Dtest-filter=markScopeSubtree\` 통과

Refs #2956 (effect 부분 close, #2964 #2965 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)