### PR TITLE
fix(codegen): template literal 의 list.start=0 가 raw span 분기로 잘못 진입 (#2957)

### DIFF
--- a/src/codegen/function_class.zig
+++ b/src/codegen/function_class.zig
@@ -26,9 +26,14 @@ fn collectKeepNameEntry(self: anytype, name_idx: NodeIndex) void {
 /// template literal을 child node 단위로 emit.
 /// rename/mangling이 적용되려면 expression을 개별 emitNode로 처리해야 한다.
 pub fn emitTemplateLiteral(self: anytype, node: Node) !void {
-    // substitution 없는 단순 template은 data.none=0 (list가 아님).
-    // extern union이므로 list.start로 읽으면 none 값과 동일 — 0이면 raw span.
-    if (node.data.none == 0) {
+    // raw-span shorthand (#2957): emotion / styled_components 의 transformer 가
+    // `.data = .{ .list = .{ .start = 0, .len = 0 } }` 로 만든 template literal.
+    // 이 경우만 raw span path 로 출력. parser-created template literal 은 list.start
+    // 가 우연히 0 이어도 list.len > 0 이라 이 분기를 피한다 (이전엔 `data.none == 0`
+    // 으로 검사해 list.start = 0 인 정상 template literal 의 expression 이 mangle
+    // 되지 않고 source span 그대로 출력 — `${code}` 같은 매개변수 reference 가
+    // 깨지는 회귀).
+    if (node.data.list.len == 0) {
         try self.writeNodeSpan(node);
         return;
     }


### PR DESCRIPTION
## Summary
- **Root cause**: \`emitTemplateLiteral\` 의 \`if (node.data.none == 0)\` 검사가 extern union 의 첫 4 바이트(=list.start) 만 보고 raw span path 진입
- parser-created template literal 의 list.start 가 우연히 0 (extra_data 의 첫 list) 이면 잘못 raw span path 로 빠짐 → expression 안의 식별자가 mangle 안 됨
- Redux toolkit \`function i(t){return \`Minified Redux error #\${code};...\`}\` 처럼 매개변수 \`code\`→\`t\` mangle 후에도 template literal 안의 \`\${code}\` 그대로 남아 ReferenceError

## Fix
\`list.len == 0\` 으로 검사 변경 — emotion/styled_components transformer 가 만든 raw-span shorthand (\`.data = .{ .list = .{ .start = 0, .len = 0 } }\`) 만 raw span path 로 빠지고, parser-created template literal 은 항상 list 순회 path 진입.

## 회귀 검증

### Single-module reproducer
```ts
function formatProdErrorMessage(code: number) {
  return \`error #\${code}; ...?code=\${code}\`;
}
console.log(formatProdErrorMessage(2));
```

| | 이전 | 이후 |
|---|---|---|
| 출력 | \`function e(t){return \`error #\${code};...?code=\${code}\`}\` | \`function e(t){return \`error #\${t};...?code=\${t}\`}\` |
| node 실행 | ❌ ReferenceError: code is not defined | ✅ \`error #2; ...?code=2\` |

### 30 fixture deep+minify-all 회귀
- toolkit 은 별개 \`else }\` SyntaxError (#2967) 로 여전히 fail — template literal 자체는 정상 mangle 됨 확인
- 다른 fixture stdout MATCH 회귀 0

## 후속
- #2967 — production define 으로 dead 처리된 else block 의 빈 brace 가 SyntaxError (별개 DCE 버그). 이 fix 후 toolkit 도 통과 예상.

## Test plan
- [ ] \`/tmp/repro-2957.ts\` 빌드 후 mangle 결과 확인
- [ ] \`bun run tests/benchmark/smoke.ts --deep --minify-all --filter=toolkit\` → 새 에러 (#2967), template literal 자체는 정상
- [ ] emotion/styled_components 빌드 회귀 없음 (raw-span shorthand 케이스 유지)

Closes #2957

🤖 Generated with [Claude Code](https://claude.com/claude-code)