### PR TITLE
fix(codegen): static member property 슬롯에서 peephole identifier 치환 차단

### DIFF
--- a/src/codegen/expressions.zig
+++ b/src/codegen/expressions.zig
@@ -311,7 +311,11 @@ pub fn emitStaticMember(self: anytype, node: Node) !void {
     } else {
         try self.writeByte('.');
     }
-    try self.emitNode(property);
+    // property name 슬롯은 reserved word 도 valid identifier 로 취급되므로
+    // peephole 치환 (예: `undefined` → `(void 0)`) 이 적용되면 안 된다 (#2964).
+    // 예: `obj.undefined` 가 `obj.(void 0)` 로 깨지면 SyntaxError. raw span 으로 출력.
+    const prop_node = self.ast.getNode(property);
+    try self.writeNodeSpan(prop_node);
 }
 
 pub fn emitComputedMember(self: anytype, node: Node) !void {


### PR DESCRIPTION
## Summary
- \`obj.undefined\` 처럼 reserved word 가 property name 으로 사용된 경우 minify peephole 이 \`obj.(void 0)\` 으로 치환해 SyntaxError
- property 위치는 raw span 으로 출력하도록 \`emitStaticMember\` 수정

## Reproducer
\`\`\`ts
const i = { undefined: "U", string: "S" };
const g = (x: any) => {
  switch (typeof x) {
    case "undefined": return i.undefined;
    case "string": return i.string;
  }
};
\`\`\`

| | 이전 | 이후 |
|---|---|---|
| zntc | \`return i.(void 0)\` | \`return i.undefined\` |
| 실행 | ❌ Unexpected token '(' | ✅ OK |

## 후속
zod 자체는 별개의 mangler shadow 충돌 (\`Identifier 'z' has already been declared\`) 으로 여전히 fail. 별도 issue 로 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)