### PR TITLE
fix(mangler): 1-char top-level binding 도 reserved 등록 (#2965, #2958)

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -777,7 +777,15 @@ pub const Linker = struct {
 
                         if (blocks) continue;
                         if (exported.contains(sym_name)) continue;
-                        if (sym_name.len <= 1) continue;
+                        if (sym_name.len <= 1) {
+                            // candidate skip 한 1-char binding 도 reserved 에 등록 (#2965).
+                            // entry deepEntry 의 \`const e = ...\` 같은 짧은 식별자는
+                            // mangle 안 되고 source 그대로 emit 되므로 internal binding 의
+                            // mangle 결과로 동일 이름 부여 시 충돌 — three 의 \`class e\` ↔
+                            // entry \`const e = new Euler(...)\` 가 그 케이스.
+                            try reserved.put(sym_name, {});
+                            continue;
+                        }
                         if (std.mem.eql(u8, sym_name, "default")) continue;
                         if (std.mem.eql(u8, sym_name, "arguments")) continue;
 
@@ -789,7 +797,12 @@ pub const Linker = struct {
                         if (sym.synthetic_kind == .default_export) continue;
 
                         const key = if (sym.canonical_name.len > 0) sym.canonical_name else sym_name;
-                        if (key.len <= 1) continue;
+                        if (key.len <= 1) {
+                            // canonical_name 이 sym_name 과 다른 1-char 케이스도 reserve
+                            // (위 sym_name 분기와 대칭 — #2965).
+                            try reserved.put(key, {});
+                            continue;
+                        }
                         if (exported.contains(key)) continue;
 
                         try candidates.append(self.allocator, .{


### PR DESCRIPTION
## Summary
- **Root cause**: \`collectUnifiedInput\` 의 candidate filter 가 1-char binding 을 mangle 후보에서 제외하면서 reserved 에 등록도 안 함 → source 그대로 emit 되는 1-char 이름이 internal binding 의 mangle 결과로 동일 short name 부여 시 충돌
- three: \`const e = new Euler(...)\` + internal \`class e {...}\` → SyntaxError
- jotai: 같은 패턴 (\`const a = atom(0)\` 등)

## Fix
candidate filter 두 사이트에서 \`continue\` 직전에 \`reserved.put(name, {})\` 추가:
- line 780: \`sym_name.len <= 1\` 분기 (raw declared name)
- line 800: \`canonical_name\` 적용 후 \`key.len <= 1\` 분기 (canonical 1-char shadowing 대응)

## /simplify
- Agent 1+2 모두 line 800 sibling site 의 같은 fix 필요 발견 → mirror 적용
- Agent 1: helper module synthetic / synthetic default loop 는 ≥2 chars 라 영향 없음 (skip)
- Comment 는 WHY-only, 적정 길이 (proportionate)

## 회귀 검증

| | 이전 | 이후 |
|---|---|---|
| zntc OK | 33/39 | **35/39** |
| three | ❌ \`Identifier 'e' has already been declared\` | ✅ MATCH |
| jotai | ❌ | ✅ MATCH (같은 root cause) |
| zod / svelte | ✅ (이전 fix) | ✅ 회귀 0 |
| 다른 fixture | — | 회귀 0 |

zntc-only fail: 6 → 4 (axios, express, yargs, d3 만 남음).

Closes #2965, Closes #2958

🤖 Generated with [Claude Code](https://claude.com/claude-code)