### PR TITLE
fix(codegen): new callee paren stripping 이 비-MemberExpression 결합을 깨는 회귀 (#2960)

### DIFF
--- a/src/codegen/calls.zig
+++ b/src/codegen/calls.zig
@@ -289,6 +289,22 @@ fn newCalleeNeedsParens(self: anytype, idx: NodeIndex) bool {
             .static_member_expression, .computed_member_expression, .private_field_expression => {
                 cur = self.ast.readExtraNode(n.data.extra, 0);
             },
+            // `new MemberExpression` callee 슬롯이 아닌 expression: paren 을 벗기면 결합이 깨진다.
+            // `new (a||b)()` → `new a||b()` 가 `(new a)||b()` 로 결합 (#2960).
+            // function/class expression 은 PrimaryExpression 이라 callee 슬롯에 직접 가능 (#1586).
+            .logical_expression,
+            .binary_expression,
+            .conditional_expression,
+            .assignment_expression,
+            .sequence_expression,
+            .arrow_function_expression,
+            .new_expression,
+            .yield_expression,
+            .await_expression,
+            .import_expression,
+            .unary_expression,
+            .update_expression,
+            => return true,
             else => return false,
         }
     }


### PR DESCRIPTION
## Summary
\`emitNew\` 의 minify_syntax paren-stripping loop 가 \`new (X || Y)()\` 처럼 callee 가 logical/binary/conditional 등인 케이스에서 paren 을 벗겨 결합이 깨짐.

axios follow-redirects \`new (baseClass || Error)()\` → minify 후 \`new hy || Error()\` = \`(new hy) || Error()\` → \`hy\` undefined → TypeError.

## Fix
\`newCalleeNeedsParens\` switch 에 ECMAScript 12.3 MemberExpression 이 아닌 expression tag 12개 추가:
- logical/binary/conditional/assignment/sequence
- arrow_function/new/yield/await/import
- unary/update

\`function_expression\`/\`class_expression\` 은 PrimaryExpression 이라 callee 슬롯에 직접 가능 (#1586 test 가 명시 검증).

## /simplify 적용
- Agent 2 권장 4개 중 \`new_expression\` + \`import_expression\` 만 추가 (function/class 는 PrimaryExpression 이라 제외 — #1586 test 가 검증)
- 주석 4줄 → 3줄 trim

## 회귀 검증

| | 이전 | 이후 |
|---|---|---|
| zntc OK | 35/39 | **37/39** |
| axios | ❌ TypeError | ✅ MATCH |
| d3 | ❌ | ✅ MATCH (같은 root cause) |
| #1586 \`new (class X{})()\` test | ✅ | ✅ 유지 |
| 다른 28개 fixture | — | 회귀 0 |

zntc-only fail: 4 → 2 (express, yargs 만).

Closes #2960

🤖 Generated with [Claude Code](https://claude.com/claude-code)