### PR TITLE
fix(binder): 함수 매개변수 + 같은 이름 var 를 동일 binding 으로 처리 (#2976)

### DIFF
--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -595,6 +595,19 @@ pub const SemanticAnalyzer = struct {
                     try self.addRedeclarationError(decl_span, name_text, existing.declaration_span);
                     return;
                 }
+                // JS spec: 매개변수 + 같은 이름 var 는 동일 binding (var hoisting). 새 symbol
+                // 만들면 mangler 가 두 binding 으로 처리해 \`function f(fn){var fn=...}\` 의
+                // 매개변수가 reference 와 다르게 mangle 됨 (#2976 express \`Router.use(fn)\`).
+                if (kind == .variable_var and (existing.kind == .parameter or existing.kind == .variable_var)) {
+                    if (self.findSymbolIndexInScope(target_scope, name_text)) |existing_sym_idx| {
+                        if (node_idx) |ni| {
+                            if (ni < self.symbol_ids.items.len) {
+                                self.symbol_ids.items[ni] = @intCast(existing_sym_idx);
+                            }
+                        }
+                        return;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
\`function f(fn) { var fn = ... }\` 의 매개변수 + 같은 이름 var 가 binder 에서 두 별개 symbol 로 처리되어, mangle 후 매개변수 declaration site 만 raw 로 남고 reference 는 다른 short name 으로 link → runtime fail.

express \`Router.use(fn) { for(...) var fn = callbacks[i]; }\` 가 \`TypeError: Router.use() requires a middleware function\` 의 root cause.

## Fix
\`declareSymbolWithNode\` 에서 \`canRedeclare\` 통과 후, 새 \`variable_var\` 가 existing parameter 또는 variable_var 와 같은 이름이면 새 symbol 만들지 않고 \`findSymbolIndexInScope\` 로 existing 의 sym_idx 를 lookup, declaration node 의 \`symbol_ids[ni]\` 에 attach.

## Reproducer
\`\`\`ts
function f(fn: any) {
  if (typeof fn !== 'function') throw new TypeError('not function');
  for (let i = 0; i < 1; i++) {
    var fn = (() => 42) as any;  // var hoisting + parameter = same binding
  }
  return fn();
}
console.log(f(() => 99));
\`\`\`

| | 이전 | 이후 |
|---|---|---|
| zntc minify | \`function f(fn){if(typeof e!==...)throw;...var e=(...);return e()}\` | \`function f(e){if(typeof e!==...)throw;...var e=(...);return e()}\` |
| node 실행 | ❌ TypeError | ✅ \`42\` |

## /simplify 적용
- \`findSymbolIndexInScope\` helper 사용 → redundant scope_maps lookup 제거
- bound check 2개 제거 (helper 가 이미 안전성 보장)
- comment 4줄 → 3줄

## 회귀 검증

| | 이전 | 이후 |
|---|---|---|
| zntc OK | 37/39 | **38/39** |
| express | ❌ TypeError | ✅ MATCH |
| 다른 28개 fixture | — | 회귀 0 |

zntc-only fail: 2 → 1 (yargs 만 남음 — #2977 private class field polyfill).

Closes #2976

🤖 Generated with [Claude Code](https://claude.com/claude-code)