### PR TITLE
fix(codegen): destructuring shorthand 의 implicit RHS rename 시 longhand expand (#2977)

### DIFF
--- a/src/codegen/bindings.zig
+++ b/src/codegen/bindings.zig
@@ -4,6 +4,7 @@ const ast_mod = @import("../parser/ast.zig");
 const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const writer = @import("writer.zig");
+const expressions = @import("expressions.zig");
 
 const writeNewline = writer.writeNewline;
 const writeSpace = writer.writeSpace;
@@ -27,8 +28,18 @@ pub fn emitBindingProperty(self: anytype, node: Node) !void {
     } else {
         try self.writeSpan(key_node.span);
     }
-    // shorthand: right가 none이면 {key} 형태 — 콜론 생략
-    if (!node.data.binary.right.isNone()) {
+    // shorthand (right=none): \`{key}\` — 기본은 콜론 생략. 단 implicit RHS 식별자가
+    // mangle 됐으면 \`key:mangled\` longhand 로 expand (#2977 yargs). \`let {x}=obj\` 와
+    // \`({x}=obj)\` (binding_property / assignment_target_property_identifier) 양쪽에 적용.
+    // expressions.zig 의 emitObjectProperty 와 동일한 분기.
+    if (node.data.binary.right.isNone()) {
+        if (expressions.identifierHasRename(self, node.data.binary.left)) {
+            try self.writeByte(':');
+            try self.emitNode(node.data.binary.left);
+        }
+        return;
+    }
+    {
         // shorthand_with_default: { x = val } → x:x=val
         // cover grammar에서 assignment_target_property_identifier로 변환된 경우,
         // right가 default value이고 key가 binding name이다.

--- a/src/codegen/expressions.zig
+++ b/src/codegen/expressions.zig
@@ -205,7 +205,7 @@ pub fn emitObjectProperty(self: anytype, node: Node) !void {
     }
 }
 
-fn identifierHasRename(self: anytype, idx: NodeIndex) bool {
+pub fn identifierHasRename(self: anytype, idx: NodeIndex) bool {
     if (idx.isNone()) return false;
     const key_node = self.ast.getNode(idx);
     if (self.options.linking_metadata) |meta| {


### PR DESCRIPTION
## Summary
\`let configObjects; ({configObjects} = frozen);\` destructuring assignment 의 shorthand \`{configObjects}\` 가 outer scope binding 을 reference 하는데, \`emitBindingProperty\` 가 key 를 raw span 으로 출력하고 rename 적용 안 함 → mangle 후 unbound ReferenceError.

yargs \`unfreeze\` method 의 destructuring 패턴 (TypeScript downlevel 결과) 이 정확한 케이스.

## Fix
\`emitObjectProperty\` (expressions.zig) 의 같은 패턴을 \`emitBindingProperty\` (bindings.zig) 에 추가:
- shorthand 분기에서 \`identifierHasRename\` 으로 RHS 가 mangle 됐는지 검사
- 발견 시 \`key:mangled\` longhand 로 expand
- \`let {x}=obj\` (binding_property) + \`({x}=obj)\` (assignment_target_property_identifier) 양쪽 적용

\`identifierHasRename\` 은 cross-module 호출을 위해 pub 으로 변경.

## /simplify 적용
- 새 early-return 후 dead \`if (!isNone())\` block 을 plain block 으로 flatten
- comment broaden — \`let {x}=obj\` 케이스도 명시

## Reproducer
\`\`\`ts
function test(frozen: any) {
  let configObjects: any[];
  ({ configObjects } = frozen);
  return configObjects;
}
\`\`\`

| | 이전 | 이후 |
|---|---|---|
| zntc minify | \`let t;({configObjects}=n);return t\` ← raw \`configObjects\` | \`let t;({configObjects:t}=n);return t\` |
| 실행 | ❌ undefined | ✅ \`[1,2,3]\` |

## 회귀 검증

| | 이전 | 이후 |
|---|---|---|
| zntc OK | 38/39 | **39/39** |
| yargs | ❌ ReferenceError | ✅ MATCH |
| 다른 28개 fixture | — | 회귀 0 |

\`smoke.ts --deep --minify-all\` 모든 fixture 통과 (lodash-es@chrome80 의 stdout DIFF 는 mangle 함수명 cosmetic 차이만 — 동작 동일).

Closes #2977

🤖 Generated with [Claude Code](https://claude.com/claude-code)