### PR TITLE
fix(codegen): static member property sourcemap mapping 누락 회귀

### DIFF
--- a/src/codegen/expressions.zig
+++ b/src/codegen/expressions.zig
@@ -311,10 +311,12 @@ pub fn emitStaticMember(self: anytype, node: Node) !void {
     } else {
         try self.writeByte('.');
     }
-    // property name 슬롯은 reserved word 도 valid identifier 로 취급되므로
-    // peephole 치환 (예: `undefined` → `(void 0)`) 이 적용되면 안 된다 (#2964).
-    // 예: `obj.undefined` 가 `obj.(void 0)` 로 깨지면 SyntaxError. raw span 으로 출력.
+    // property name 슬롯은 reserved word 도 valid identifier 로 취급되므로 peephole
+    // 치환 (예: `undefined` → `(void 0)`) 이 적용되면 안 된다 — `obj.undefined` 가
+    // `obj.(void 0)` 로 깨지면 SyntaxError. emitNode 우회 시 sourcemap mapping 이
+    // 같이 빠지므로 명시 발행 후 raw span 출력.
     const prop_node = self.ast.getNode(property);
+    try self.addSourceMapping(prop_node.span);
     try self.writeNodeSpan(prop_node);
 }
 


### PR DESCRIPTION
## Summary

\`06e1cff8 fix(codegen): static member property 슬롯에서 peephole identifier 치환 차단\` 이 \`emitNode(property)\` → \`writeNodeSpan(prop_node)\` 으로 바꾸면서, \`emitNode\` dispatch 가 자동으로 호출하던 \`addSourceMapping(node.span)\` 이 함께 사라짐.

property identifier (\`MARKER_INST.MARKER_METHOD\`, \`MARKER_COLOR.MARKER_RED\`) 의 source map mapping 이 발행되지 않아 lookup 시 잘못된 column 으로 폴백 → \`Round 5 sourcemap mapping > 06-class-method.ts / 12-enum.ts\` column tolerance (≤5) 초과 (received 12, 13).

## Root cause

\`node_dispatch.emitNode\` 는 dispatch 시점에 다음을 함께 처리:

\`\`\`zig
if (self.sm_builder != null and node.span.start != node.span.end) {
    switch (node.tag) {
        .program, .block_statement, ... => {},
        else => try self.addSourceMapping(node.span),
    }
}
\`\`\`

\`identifier_reference\` 는 제외 목록에 없어 매핑이 발행됨. 그러나 \`writeNodeSpan\` 은 raw bytes 만 쓰므로 매핑 누락.

## Fix

\`writeNodeSpan\` 직전에 \`addSourceMapping(prop_node.span)\` 명시 호출로 dispatch path 와 동일 매핑 복원. peephole 차단 (\`obj.undefined\` → \`(void 0)\` 방지) 은 그대로 유지.

\`\`\`diff
+    // emitNode 우회 시 sourcemap mapping 이 같이 빠지므로 명시 발행 후 raw span 출력.
     const prop_node = self.ast.getNode(property);
+    try self.addSourceMapping(prop_node.span);
     try self.writeNodeSpan(prop_node);
\`\`\`

## 회귀 검증

- [x] \`round5-sourcemap.test.ts\` — 17/17 통과 (회귀 케이스 06/12 포함)
- [x] \`sourcemap.test.ts\` / \`sourcemap-footer.test.ts\` / \`round4-sourcemap\` — 48/48 통과
- [x] TSC 스냅샷 — 1029/1029 통과
- [x] \`i.undefined\` 패턴 single-module reproducer — \`(void 0)\` 치환 안 됨, \`U\` 정상 출력
- [x] \`zig build test\` 통과

## 다른 \`writeNodeSpan\` 직접 호출 검토

별개 누락 의심 없음:
- \`emitStaticBlock\`, \`emitMetaProperty\` — dispatch 가 노드 시작 매핑을 이미 발행
- \`emitTemplateLiteral\` raw-span shorthand — emotion/styled transformer 합성 노드, source 위치 의미 없음
- \`emitTemplateLiteral\` template_element 자식 — text 부분, 식별자 매핑 대상 아님
- \`modules.zig\` import/export specifier — 인접 라인에서 이미 \`addSourceMapping(spec_node.span)\` 호출 중

## Test plan

- [ ] CI 적색 회생 (round5-sourcemap 2 fail 사라짐)
- [ ] 다른 sourcemap 회귀 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)