### PR TITLE
refactor(codegen): sourcemap mapping 을 oxc-style 명시 발행으로 통일

### DIFF
--- a/src/codegen/bindings.zig
+++ b/src/codegen/bindings.zig
@@ -14,12 +14,14 @@ const writeSpace = writer.writeSpace;
 // ================================================================
 
 pub fn emitAssignmentPattern(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     try self.emitNode(node.data.binary.left);
     try self.writeByte('=');
     try self.emitNode(node.data.binary.right);
 }
 
 pub fn emitBindingProperty(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     // key는 원본 span 출력 (프로퍼티 이름이므로 rename 적용 안 함).
     // computed property key ([expr])는 내부 표현식에 rename이 필요하므로 emitNode 사용.
     const key_node = self.ast.getNode(node.data.binary.left);
@@ -59,6 +61,7 @@ pub fn emitBindingProperty(self: anytype, node: Node) !void {
 }
 
 pub fn emitRest(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     try self.write("...");
     try self.emitNode(node.data.unary.operand);
 }
@@ -68,6 +71,7 @@ pub fn emitRest(self: anytype, node: Node) !void {
 // ================================================================
 
 pub fn emitVariableDeclaration(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const e = node.data.extra;
     const extras = self.ast.extra_data.items[e .. e + 3];
     const kind = self.ast.variableDeclarationKind(node);
@@ -138,6 +142,7 @@ pub fn emitVariableDeclaration(self: anytype, node: Node) !void {
 }
 
 pub fn emitVariableDeclarator(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const e = node.data.extra;
     const extras = self.ast.extra_data.items[e .. e + 3];
     const name: NodeIndex = @enumFromInt(extras[0]);
@@ -166,6 +171,7 @@ pub fn emitVariableDeclarator(self: anytype, node: Node) !void {
 }
 
 pub fn emitFormalParam(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const e = node.data.extra;
     // extra = [pattern, type_ann, default, flags, deco_start, deco_len]
     const extras = self.ast.extra_data.items[e .. e + 6];

--- a/src/codegen/calls.zig
+++ b/src/codegen/calls.zig
@@ -12,6 +12,7 @@ const IMPORT_META_URL_NODE = "require(\"url\").pathToFileURL(__filename).href";
 const IMPORT_META_NODE_OBJECT = "{url:" ++ IMPORT_META_URL_NODE ++ ",dirname:__dirname,filename:__filename}";
 
 pub fn emitCall(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const e = node.data.extra;
     if (!self.ast.hasExtra(e, 3)) return;
     const callee = self.ast.readExtraNode(e, 0);
@@ -369,6 +370,7 @@ fn tryEmitWorkerURL(self: anytype, callee: ast_mod.NodeIndex, args_start: u32, a
 }
 
 pub fn emitNew(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const e = node.data.extra;
     if (!self.ast.hasExtra(e, 3)) return;
     var callee = self.ast.readExtraNode(e, 0);
@@ -420,6 +422,7 @@ pub fn resolveImportMetaProp(self: anytype, object: NodeIndex, property: NodeInd
 }
 
 pub fn emitMetaProperty(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const text = self.ast.getText(node.span);
     if (std.mem.eql(u8, text, "import.meta")) {
         if (self.options.module_format == .cjs or self.options.replace_import_meta) {
@@ -435,6 +438,7 @@ pub fn emitMetaProperty(self: anytype, node: Node) !void {
 }
 
 pub fn emitImportExpr(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     try self.write("import(");
     try self.emitNode(node.data.binary.left);
     if (!node.data.binary.right.isNone()) {

--- a/src/codegen/debug_metadata.zig
+++ b/src/codegen/debug_metadata.zig
@@ -32,7 +32,10 @@ pub fn generateSourceMapWithFunctionMap(self: anytype, output_file: []const u8) 
 
 pub fn addSourceMapping(self: anytype, span: Span) !void {
     if (self.sm_builder) |*sm| {
-        if (span.start & Ast.STRING_TABLE_BIT != 0 or (span.start == 0 and span.end == 0)) return;
+        // 합성 노드 (string_table 참조) 와 zero-width span 은 발행 안 함 (zero span 도 포함).
+        // 호출자가 emitter 첫 줄에서 부담 없이 호출하도록 가드 일원화.
+        if (span.start & Ast.STRING_TABLE_BIT != 0) return;
+        if (span.start == span.end) return;
         const lc = getOriginalLineColumn(self, span.start);
         try sm.addMapping(.{
             .generated_line = self.gen_line,

--- a/src/codegen/expressions.zig
+++ b/src/codegen/expressions.zig
@@ -7,6 +7,7 @@ const NodeIndex = ast_mod.NodeIndex;
 const Kind = @import("../lexer/token.zig").Kind;
 
 pub fn emitUnary(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const e = node.data.extra;
     const extras = self.ast.extra_data.items;
     if (e + 1 >= extras.len) return;
@@ -24,6 +25,7 @@ pub fn emitUnary(self: anytype, node: Node) !void {
 }
 
 pub fn emitUpdate(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const e = node.data.extra;
     const extras = self.ast.extra_data.items;
     if (e + 1 >= extras.len) return;
@@ -37,6 +39,7 @@ pub fn emitUpdate(self: anytype, node: Node) !void {
 }
 
 pub fn emitBinary(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const op: Kind = @enumFromInt(node.data.binary.flags);
     if (self.options.linking_metadata != null and node.tag == .logical_expression) {
         if (self.evalBooleanCondition(node.data.binary.left)) |left_val| {
@@ -66,6 +69,7 @@ pub fn emitBinary(self: anytype, node: Node) !void {
 }
 
 pub fn emitAssignment(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     try self.emitNode(node.data.binary.left);
     try self.writeSpace();
     if (node.data.binary.flags != 0) {
@@ -92,6 +96,7 @@ pub fn emitAssignment(self: anytype, node: Node) !void {
 }
 
 pub fn emitConditional(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const t = node.data.ternary;
     if (self.options.linking_metadata != null) {
         if (self.evalBooleanCondition(t.a)) |cond| {
@@ -111,26 +116,31 @@ pub fn emitConditional(self: anytype, node: Node) !void {
 }
 
 pub fn emitSequence(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     try self.emitList(node, ",");
 }
 
 pub fn emitParen(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     try self.writeByte('(');
     try self.emitNode(node.data.unary.operand);
     try self.writeByte(')');
 }
 
 pub fn emitSpread(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     try self.write("...");
     try self.emitNode(node.data.unary.operand);
 }
 
 pub fn emitAwait(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     try self.write("await ");
     try self.emitNode(node.data.unary.operand);
 }
 
 pub fn emitYield(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     try self.write("yield");
     if (node.data.unary.flags & 1 != 0) try self.writeByte('*');
     if (!node.data.unary.operand.isNone()) {
@@ -140,12 +150,14 @@ pub fn emitYield(self: anytype, node: Node) !void {
 }
 
 pub fn emitArray(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     try self.writeByte('[');
     try self.emitList(node, self.listSep());
     try self.writeByte(']');
 }
 
 pub fn emitObject(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const list = node.data.list;
     if (list.len == 0) {
         try self.write("{}");
@@ -163,6 +175,7 @@ pub fn emitObject(self: anytype, node: Node) !void {
 }
 
 pub fn emitObjectProperty(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const key = node.data.binary.left;
     const value = node.data.binary.right;
     if (key.isNone()) return;
@@ -235,12 +248,14 @@ fn identifierHasConstValue(self: anytype, idx: NodeIndex) bool {
 }
 
 pub fn emitComputedKey(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     try self.writeByte('[');
     try self.emitNode(node.data.unary.operand);
     try self.writeByte(']');
 }
 
 pub fn emitStaticMember(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const e = node.data.extra;
     if (!self.ast.hasExtra(e, 2)) return;
     const object = self.ast.readExtraNode(e, 0);
@@ -321,6 +336,7 @@ pub fn emitStaticMember(self: anytype, node: Node) !void {
 }
 
 pub fn emitComputedMember(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const e = node.data.extra;
     if (!self.ast.hasExtra(e, 2)) return;
     const object = self.ast.readExtraNode(e, 0);

--- a/src/codegen/function_class.zig
+++ b/src/codegen/function_class.zig
@@ -26,6 +26,7 @@ fn collectKeepNameEntry(self: anytype, name_idx: NodeIndex) void {
 /// template literal을 child node 단위로 emit.
 /// rename/mangling이 적용되려면 expression을 개별 emitNode로 처리해야 한다.
 pub fn emitTemplateLiteral(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     // raw-span shorthand (#2957): emotion / styled_components 의 transformer 가
     // `.data = .{ .list = .{ .start = 0, .len = 0 } }` 로 만든 template literal.
     // 이 경우만 raw span path 로 출력. parser-created template literal 은 list.start
@@ -50,6 +51,7 @@ pub fn emitTemplateLiteral(self: anytype, node: Node) !void {
 }
 
 pub fn emitTaggedTemplate(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const e = node.data.extra;
     const extras = self.ast.extra_data.items;
     if (e + 1 >= extras.len) return;
@@ -67,6 +69,7 @@ pub fn emitTaggedTemplate(self: anytype, node: Node) !void {
 }
 
 pub fn emitFunction(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const e = node.data.extra;
     // function_expression은 ret_type 없이 4 slots, function_declaration/function은 5 slots.
     // 공통 [name(0), params(1), body(2), flags(3)]만 읽는다.
@@ -131,6 +134,7 @@ pub fn emitFunction(self: anytype, node: Node) !void {
 
 /// arrow_function_expression: extra = [params, body, flags]
 pub fn emitArrow(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const e = node.data.extra;
     const extras = self.ast.extra_data.items;
     if (e + 2 >= extras.len) return;
@@ -206,6 +210,7 @@ fn expressionStartsWithBraceDepth(self: anytype, node_idx: ast_mod.NodeIndex, de
 
 /// class: extra = [name, super, body, type_params, impl_start, impl_len, deco_start, deco_len]
 pub fn emitClass(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const e = node.data.extra;
     const name: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
     const super_class: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 1]);
@@ -310,6 +315,7 @@ pub fn emitStaticBlock(self: anytype, node: Node) !void {
 }
 
 pub fn emitMethodDef(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const e = node.data.extra;
     const extras = self.ast.extra_data.items[e .. e + 6];
     const key: NodeIndex = @enumFromInt(extras[ast_mod.MethodExtra.key]);
@@ -350,6 +356,7 @@ pub fn emitMethodDef(self: anytype, node: Node) !void {
 }
 
 pub fn emitPropertyDef(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const e = node.data.extra;
     const extras = self.ast.extra_data.items[e .. e + 5];
     const key: NodeIndex = @enumFromInt(extras[ast_mod.PropertyExtra.key]);
@@ -383,6 +390,7 @@ pub fn emitPropertyDef(self: anytype, node: Node) !void {
 }
 
 pub fn emitDecorator(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     try self.writeByte('@');
     try self.emitNode(node.data.unary.operand);
 }
@@ -400,6 +408,7 @@ fn emitMemberDecorators(self: anytype, deco_start: u32, deco_len: u32) !void {
 }
 
 pub fn emitAccessorProp(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const e = node.data.extra;
     const extras = self.ast.extra_data.items[e .. e + 5];
     const key: NodeIndex = @enumFromInt(extras[ast_mod.PropertyExtra.key]);

--- a/src/codegen/modules.zig
+++ b/src/codegen/modules.zig
@@ -9,6 +9,7 @@ const rt = @import("../bundler/runtime_helpers.zig");
 const linker_mod = @import("../bundler/linker.zig");
 
 pub fn emitImport(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const x = module_parser.readImportDeclExtras(self.ast, node.data.extra);
 
     if (self.options.module_format == .cjs) {
@@ -292,6 +293,7 @@ pub fn emitImportSpecifierRename(self: anytype, spec_node: Node, sep: []const u8
 }
 
 pub fn emitExportNamed(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const x = module_parser.readExportNamedExtras(self.ast, node.data.extra);
 
     if (self.options.module_format == .cjs) {
@@ -452,6 +454,7 @@ pub fn emitCJSExportBinding(self: anytype, decl_idx: NodeIndex) !void {
 }
 
 pub fn emitExportDefault(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     if (self.options.module_format == .cjs) {
         if (self.options.skip_cjs_exports) {
             // __esm 모듈: export는 __export()가 처리.
@@ -581,6 +584,7 @@ pub fn emitDefaultVarAssignment(self: anytype, name: []const u8, inner: NodeInde
 }
 
 pub fn emitExportAll(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const x = module_parser.readExportAllExtras(self.ast, node.data.extra);
     if (self.options.module_format == .cjs) {
         // export * from './bar' → Object.assign(exports,require('./bar'));

--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -29,26 +29,17 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
         try statement_emit.emitComments(self, node.span.start);
     }
 
-    // 소스맵 매핑: 유의미한 노드 출력 시 원본 위치 기록.
-    // 컨테이너 노드(program, block, function_body)는 자식의 매핑을 오염시키므로 제외.
-    if (self.sm_builder != null and node.span.start != node.span.end) {
-        switch (node.tag) {
-            .program,
-            .block_statement,
-            .function_body,
-            .class_body,
-            .static_block,
-            .switch_statement,
-            .try_statement,
-            => {},
-            else => try self.addSourceMapping(node.span),
-        }
-    }
+    // 소스맵 매핑은 각 emitter / inline case 가 명시 발행 (oxc/esbuild 패턴).
+    // 컨테이너 노드 (program, block_statement, function_body, class_body, static_block,
+    // switch_statement, try_statement) 는 자식이 매핑하므로 자체 발행 안 함.
 
     switch (node.tag) {
         .program => try statement_emit.emitProgram(self, node),
         .block_statement => try statement_emit.emitBlock(self, node),
-        .empty_statement => try self.writeByte(';'),
+        .empty_statement => {
+            try self.addSourceMapping(node.span);
+            try self.writeByte(';');
+        },
         .expression_statement => try statement_emit.emitExpressionStatement(self, node),
         .variable_declaration => try binding_emit.emitVariableDeclaration(self, node),
         .variable_declarator => try binding_emit.emitVariableDeclarator(self, node),
@@ -65,12 +56,16 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
         .switch_case => try statement_emit.emitSwitchCase(self, node),
         .break_statement => try statement_emit.emitSimpleStmt(self, node, "break"),
         .continue_statement => try statement_emit.emitSimpleStmt(self, node, "continue"),
-        .debugger_statement => try self.write("debugger;"),
+        .debugger_statement => {
+            try self.addSourceMapping(node.span);
+            try self.write("debugger;");
+        },
         .try_statement => try statement_emit.emitTry(self, node),
         .catch_clause => try statement_emit.emitCatch(self, node),
         .labeled_statement => try statement_emit.emitLabeled(self, node),
         .with_statement => try statement_emit.emitWith(self, node),
         .directive => {
+            try self.addSourceMapping(node.span);
             // span 은 문자열 리터럴 범위 (따옴표 포함). quote_style 정규화를 적용해
             // `'use server'` → `"use server"` 같은 변환이 일반 string_literal 과 동일하게
             // 일어나도록 writeStringLiteral 사용. 항상 `;` 를 붙여 ASI 의존을 피한다.
@@ -78,11 +73,15 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
             try self.writeByte(';');
         },
         .hashbang => {
-            if (!self.options.strip_hashbang) try self.writeNodeSpan(node);
+            if (!self.options.strip_hashbang) {
+                try self.addSourceMapping(node.span);
+                try self.writeNodeSpan(node);
+            }
         },
 
         // Literals
         .boolean_literal => {
+            try self.addSourceMapping(node.span);
             // Peephole: true → !0, false → !1 (minify_syntax 활성화 시).
             // #1552: 각 리터럴당 2-3 byte 절감. 출현 빈도 높아 총 크기 영향 있음.
             // span의 첫 byte는 `t` 또는 `f`로 고정(렉서 불변식) — 한 byte 검사로 판별.
@@ -97,9 +96,15 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
         .numeric_literal,
         .bigint_literal,
         .regexp_literal,
-        => try self.writeNodeSpan(node),
+        => {
+            try self.addSourceMapping(node.span);
+            try self.writeNodeSpan(node);
+        },
 
-        .string_literal => try self.writeStringLiteral(node.span),
+        .string_literal => {
+            try self.addSourceMapping(node.span);
+            try self.writeStringLiteral(node.span);
+        },
 
         // Identifiers — 번들 모드에서 symbol_id 기반 리네임 적용
         .identifier_reference,
@@ -107,6 +112,7 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
         .binding_identifier,
         .assignment_target_identifier,
         => {
+            try self.addSourceMapping(node.span);
             // Peephole: global `undefined` → `(void 0)` (minify_syntax 활성화 시).
             // 9 bytes → 8 bytes, 1 byte 절감. parens는 member/call/new 등 모든 parent
             // context에서 안전하게 해석되도록 유지 — `undefined.x`/`undefined()` 같은
@@ -166,8 +172,14 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
             try self.writeSpan(node.data.string_ref);
         },
 
-        .this_expression => try self.write("this"),
-        .super_expression => try self.write("super"),
+        .this_expression => {
+            try self.addSourceMapping(node.span);
+            try self.write("this");
+        },
+        .super_expression => {
+            try self.addSourceMapping(node.span);
+            try self.write("super");
+        },
 
         // Expressions
         .unary_expression => try expression_emit.emitUnary(self, node),
@@ -190,10 +202,14 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
         .call_expression => try call_emit.emitCall(self, node),
         .new_expression => try call_emit.emitNew(self, node),
         .template_literal => try function_class_emit.emitTemplateLiteral(self, node),
-        .template_element => try self.writeNodeSpan(node),
+        .template_element => {
+            try self.addSourceMapping(node.span);
+            try self.writeNodeSpan(node);
+        },
         .tagged_template_expression => try function_class_emit.emitTaggedTemplate(self, node),
         .import_expression => try call_emit.emitImportExpr(self, node),
         .meta_property => try call_emit.emitMetaProperty(self, node),
+        // chain_expression / TS·Flow type-cast: transparent wrapper — operand 가 자기 매핑 발행.
         .chain_expression => try self.emitNode(node.data.unary.operand),
 
         // Functions / Classes
@@ -225,7 +241,10 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
         .import_default_specifier,
         .import_namespace_specifier,
         .import_attribute,
-        => try self.writeNodeSpan(node),
+        => {
+            try self.addSourceMapping(node.span);
+            try self.writeNodeSpan(node);
+        },
         .export_named_declaration => try module_emit.emitExportNamed(self, node),
         .export_default_declaration => try module_emit.emitExportDefault(self, node),
         .export_all_declaration => try module_emit.emitExportAll(self, node),
@@ -238,7 +257,10 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
 
         // Flow match expression — transformer에서 if-else IIFE로 변환됨
         // 변환되지 않은 경우 (non-bundle 등) span 텍스트 그대로 출력
-        .flow_match_expression => try self.writeNodeSpan(node),
+        .flow_match_expression => {
+            try self.addSourceMapping(node.span);
+            try self.writeNodeSpan(node);
+        },
 
         // JSX: Transformer의 jsx_lowering이 call_expression으로 변환 완료.
         // codegen은 JSX AST 노드를 만나지 않아야 함.
@@ -275,6 +297,9 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
         => {},
 
         // 그 외 — 소스 텍스트 그대로 출력
-        else => try self.writeNodeSpan(node),
+        else => {
+            try self.addSourceMapping(node.span);
+            try self.writeNodeSpan(node);
+        },
     }
 }

--- a/src/codegen/sourcemap.zig
+++ b/src/codegen/sourcemap.zig
@@ -300,12 +300,26 @@ pub const SourceMapBuilder = struct {
         try self.source_contents.append(self.allocator, copy);
     }
 
-    /// 매핑 추가.
+    /// 매핑 추가. emitter 가 outer wrapper 진입 시 발행한 mapping 과 첫 자식 emitter
+    /// 가 발행한 mapping 이 동일 (gen,src) 위치에 박히는 패턴이 잦아 (예: expression
+    /// statement → operand expression 의 첫 토큰), 직전 mapping 과 모든 좌표가 같으면
+    /// 중복 push 를 생략한다. 출력 VLQ size 와 mappings 배열 메모리 절감.
     pub fn addMapping(self: *SourceMapBuilder, mapping: Mapping) !void {
-        if (self.is_sorted and self.mappings.items.len > 0) {
-            const out_of_order = mapping.generated_line < self.last_gen_line or
-                (mapping.generated_line == self.last_gen_line and mapping.generated_column < self.last_gen_col);
-            if (out_of_order) self.is_sorted = false;
+        if (self.mappings.items.len > 0) {
+            const last = self.mappings.items[self.mappings.items.len - 1];
+            if (last.generated_line == mapping.generated_line and
+                last.generated_column == mapping.generated_column and
+                last.source_index == mapping.source_index and
+                last.original_line == mapping.original_line and
+                last.original_column == mapping.original_column)
+            {
+                return;
+            }
+            if (self.is_sorted) {
+                const out_of_order = mapping.generated_line < self.last_gen_line or
+                    (mapping.generated_line == self.last_gen_line and mapping.generated_column < self.last_gen_col);
+                if (out_of_order) self.is_sorted = false;
+            }
         }
         self.last_gen_line = mapping.generated_line;
         self.last_gen_col = mapping.generated_column;

--- a/src/codegen/statements.zig
+++ b/src/codegen/statements.zig
@@ -109,11 +109,13 @@ pub fn emitBracedList(self: anytype, node: Node) !void {
 }
 
 pub fn emitExpressionStatement(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     try self.emitNode(node.data.unary.operand);
     try self.writeByte(';');
 }
 
 pub fn emitReturn(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     try self.write("return");
     if (!node.data.unary.operand.isNone()) {
         try self.writeByte(' ');
@@ -123,12 +125,14 @@ pub fn emitReturn(self: anytype, node: Node) !void {
 }
 
 pub fn emitThrow(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     try self.write("throw ");
     try self.emitNode(node.data.unary.operand);
     try self.writeByte(';');
 }
 
 pub fn emitIf(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const t = node.data.ternary;
     // 상수 조건 DCE: if (false) → else만 출력, if (true) → then만 출력
     if (evalBooleanCondition(self, t.a)) |known| {
@@ -323,6 +327,7 @@ fn stripQuotes(s: []const u8) []const u8 {
 }
 
 pub fn emitWhile(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     if (self.options.minify_whitespace) try self.write("while(") else try self.write("while (");
     try self.emitNode(node.data.binary.left);
     try self.writeByte(')');
@@ -330,6 +335,7 @@ pub fn emitWhile(self: anytype, node: Node) !void {
 }
 
 pub fn emitDoWhile(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     try self.write("do");
     // block body는 emitBracedList가 { 앞 공백 관리, non-block은 공백 필수 (dox++ 방지)
     if (node.data.binary.right.isNone() or self.ast.getNode(node.data.binary.right).tag != .block_statement) {
@@ -342,6 +348,7 @@ pub fn emitDoWhile(self: anytype, node: Node) !void {
 }
 
 pub fn emitFor(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const e = node.data.extra;
     const extras = self.ast.extra_data.items[e .. e + 4];
     if (self.options.minify_whitespace) try self.write("for(") else try self.write("for (");
@@ -360,6 +367,7 @@ pub fn emitFor(self: anytype, node: Node) !void {
 }
 
 pub fn emitForAwaitOf(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const t = node.data.ternary;
     // for-in/of 와 동일한 var initializer hoist/skip 처리.
     // ES2015 block-scoping 다운레벨이 `const/let x` → `var x = void 0` 로 바꾼
@@ -383,6 +391,7 @@ pub fn emitForAwaitOf(self: anytype, node: Node) !void {
 }
 
 pub fn emitForInOf(self: anytype, node: Node, keyword: []const u8) !void {
+    try self.addSourceMapping(node.span);
     const t = node.data.ternary;
 
     // for-in var initializer hoisting (esbuild 호환):
@@ -493,6 +502,7 @@ pub fn emitSwitch(self: anytype, node: Node) !void {
 }
 
 pub fn emitSwitchCase(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     // 파서 구조: extra = [test_expr, stmts_start, stmts_len]
     // test_expr가 none이면 default:
     const e = node.data.extra;
@@ -522,6 +532,7 @@ pub fn emitSwitchCase(self: anytype, node: Node) !void {
 }
 
 pub fn emitSimpleStmt(self: anytype, node: Node, keyword: []const u8) !void {
+    try self.addSourceMapping(node.span);
     try self.write(keyword);
     // label이 있으면 출력
     if (!node.data.unary.operand.isNone()) {
@@ -549,6 +560,7 @@ pub fn emitTry(self: anytype, node: Node) !void {
 }
 
 pub fn emitCatch(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     try self.write("catch");
     if (!node.data.binary.left.isNone()) {
         if (self.options.minify_whitespace) try self.writeByte('(') else try self.write(" (");
@@ -559,12 +571,14 @@ pub fn emitCatch(self: anytype, node: Node) !void {
 }
 
 pub fn emitLabeled(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     try self.emitNode(node.data.binary.left);
     try self.writeByte(':');
     try self.emitNode(node.data.binary.right);
 }
 
 pub fn emitWith(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     try self.write("with(");
     try self.emitNode(node.data.binary.left);
     try self.writeByte(')');

--- a/src/codegen/type_runtime.zig
+++ b/src/codegen/type_runtime.zig
@@ -11,6 +11,7 @@ const rt = @import("../bundler/runtime_helpers.zig");
 /// enum Color { Red, Green = 5, Blue } →
 /// var Color;((Color) => {Color[Color["Red"]=0]="Red";Color[Color["Green"]=5]="Green";Color[Color["Blue"]=6]="Blue";})(Color || (Color = {}));
 pub fn emitEnumIIFE(self: anytype, node: Node) !void {
+    try self.addSourceMapping(node.span);
     const e = node.data.extra;
     const name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
     const members_start = self.ast.extra_data.items[e + 1];
@@ -224,6 +225,7 @@ const EnumMemberValue = union(enum) {
 ///   - Symbol body: 각 member 의 init 으로 \`Symbol('name')\` 자동 emit
 ///   - number/boolean body + defaulted: ZNTC 가 default value (auto-increment / false) 채움
 pub fn emitFlowEnum(self: anytype, node: Node) std.mem.Allocator.Error!void {
+    try self.addSourceMapping(node.span);
     const e = node.data.extra;
     const name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
     const members_start = self.ast.extra_data.items[e + 1];
@@ -317,6 +319,7 @@ pub fn emitNamespaceIIFE(self: anytype, node: Node) !void {
 
 /// parent_ns: 부모 namespace 이름 (중첩 시 foo.bar 경로 생성용)
 fn emitNamespaceIIFEInner(self: anytype, node: Node, parent_ns: ?[]const u8) !void {
+    try self.addSourceMapping(node.span);
     const name_idx = node.data.binary.left;
     const body_idx = node.data.binary.right;
 


### PR DESCRIPTION
## Summary

\`node_dispatch.emitNode\` 가 dispatch 진입 시 자동으로 \`addSourceMapping\` 을 발행하던 디자인을 제거하고, 모든 emitter 함수 / dispatch inline case 가 명시적으로 발행하도록 통일. esbuild / oxc / swc 의 codegen 패턴.

Closes #2983

## Why

자동 발행 디자인은 우회 호출 (\`writeNodeSpan\` 직접 호출, peephole skip path 등) 시 매핑이 누락되는 회귀 잠복지였음. \`#2982\` 회귀 (static member property 매핑 누락) 가 정확히 그 패턴 — \`emitStaticMember\` 가 \`emitNode(property)\` → \`writeNodeSpan(prop_node)\` 으로 바꾸면서 dispatch 자동 발행이 함께 빠짐. 이런 우회 패턴은 codegen 진화하면서 (peephole 차단, mangle skip 등) 계속 늘어남.

## 다른 번들러 비교

| 번들러 | 패턴 |
|---|---|
| esbuild | 명시 발행 (\`p.addSourceMapping(loc)\` in printer.go) |
| oxc | 명시 발행 (\`Gen\` trait 각 구현체) |
| swc | 명시 발행 (\`srcmap\` push) |
| **zts (이전)** | **자동 발행 (dispatch)** |
| **zts (이번 PR)** | **명시 발행** |

## 변경 범위

총 10 파일 / +130, -32 줄.

### 자동 발행 제거
\`src/codegen/node_dispatch.zig\` 의 \`if (self.sm_builder != null and node.span.start != node.span.end) switch (tag) { container 7개 => {}, else => addSourceMapping(node.span) }\` 제거.

### emitter 명시 발행 추가 (27 함수)
- statements (14): emitExpressionStatement / emitReturn / emitThrow / emitIf / emitWhile / emitDoWhile / emitFor / emitForAwaitOf / emitForInOf / emitSwitchCase / emitSimpleStmt / emitCatch / emitLabeled / emitWith
- expressions (16): emitUnary / emitUpdate / emitBinary / emitAssignment / emitConditional / emitSequence / emitParen / emitSpread / emitAwait / emitYield / emitArray / emitObject / emitObjectProperty / emitComputedKey / emitStaticMember / emitComputedMember
- function_class (9): emitTemplateLiteral / emitTaggedTemplate / emitFunction / emitArrow / emitClass / emitMethodDef / emitPropertyDef / emitDecorator / emitAccessorProp
- bindings (6): emitAssignmentPattern / emitBindingProperty / emitRest / emitVariableDeclaration / emitVariableDeclarator / emitFormalParam
- calls (4): emitCall / emitNew / emitMetaProperty / emitImportExpr
- modules (4): emitImport / emitExportNamed / emitExportDefault / emitExportAll
- type_runtime (3): emitEnumIIFE / emitFlowEnum / emitNamespaceIIFEInner

컨테이너 (program / block_statement / function_body / class_body / static_block / switch_statement / try_statement) 는 자식이 매핑하므로 제외.

### dispatch inline case 명시 발행 (11 case)
empty_statement / debugger_statement / directive / hashbang / boolean_literal / null/numeric/bigint/regexp_literal / string_literal / identifier 블록 / this / super / template_element / import specifier 4종 / flow_match_expression / else fallback. \`chain_expression\` 은 transparent wrapper 라 operand 위임.

## 안전 가드

\`debug_metadata.addSourceMapping\`: \`span.start == span.end\` 가드 추가. emitter 가 합성 노드 / 빈 span 으로 호출해도 안전. 호출자 부담 0.

\`SourceMapBuilder.addMapping\`: 직전 매핑과 모든 좌표 (gen, src) 동일 시 중복 push skip. wrapper + 첫 자식이 같은 위치 가리키는 패턴 (\`expression_statement\` → operand 등) 의 이중 발행이 자동 dedup → mappings 배열 / VLQ size 감소.

## /simplify 검토 반영

3-agent 검토 결과:
- ✅ Tier 1 중복 발행 박멸: \`addMapping\` 의 dedup 가드 (Agent 3 제안)
- ✅ \`chain_expression\` 매핑 제거 — transparent wrapper (Agent 2 F1)
- ✅ \`directive\` case 매핑 위치를 주석 위로 이동 (Agent 2 F4)
- ✅ \`addSourceMapping\` 가드 주석 단순화 (Agent 2 F6)
- 보류: inline helper 3종 (cosmetic, 별도 cleanup PR 가치)

## 검증

- [x] \`zig build test\` 통과
- [x] sourcemap 통합 테스트 4 파일 / 48 tests 통과 (sourcemap, round4/5-sourcemap, sourcemap-footer)
- [x] 통합 테스트 전체 (109 files): 3710 pass / 1 baseline fail (manualChunks zod — main 동일)
- [ ] CI 회귀 0

## 후속 (별도 PR)

- Phase 2: leaf token 매핑 추가 (\`emitFunction\` name / \`emitClass\` name / \`emitMethodDef\` key) — minify debugger jump 정확도 ↑
- CI audit script: emitter 함수마다 \`addSourceMapping\` 호출 정적 검사 (\`#1803\` 패턴 재활용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)