### PR TITLE
feat(docs): bundler-deep-dive + flow-support 가이드 페이지 추가

### DIFF
--- a/documents/astro.config.mjs
+++ b/documents/astro.config.mjs
@@ -86,12 +86,18 @@ export default defineConfig({
             { label: "개요", slug: "guides/bundling", translations: { en: "Overview" } },
             { label: "트리쉐이킹", slug: "guides/tree-shaking", translations: { en: "Tree-shaking" } },
             { label: "manualChunks", slug: "guides/manual-chunks", translations: { en: "manualChunks" } },
+            {
+              label: "구조와 동작 원리",
+              slug: "guides/bundler-deep-dive",
+              translations: { en: "Architecture & Internals" },
+            },
           ],
         },
         {
           label: "React Native",
           items: [
             { label: "개요", slug: "guides/react-native", translations: { en: "Overview" } },
+            { label: "Flow 지원", slug: "guides/flow-support", translations: { en: "Flow Support" } },
           ],
         },
         {

--- a/documents/src/content/docs/en/guides/bundler-deep-dive.md
+++ b/documents/src/content/docs/en/guides/bundler-deep-dive.md
@@ -1,0 +1,314 @@
+---
+title: Bundler Architecture & How It Works
+description: The six stages of the ZNTC bundler pipeline plus the runtime behavior worth knowing — module resolution, execution order, scope hoisting, CJS/ESM interop, code splitting.
+---
+
+This guide explains what the ZNTC bundler does between input and output, and which stage is responsible for behaviors you might encounter in your code.
+
+For CLI options see [Bundling](/zntc/en/guides/bundling/); for tree-shaking specifics see [Tree-shaking](/zntc/en/guides/tree-shaking/). This page sits on top of those and answers "why does it work this way?"
+
+## The six stages
+
+```
+Entry Points
+  → Resolver        (specifier → absolute file path)
+  → Module Graph    (parallel BFS parse + DFS execution order)
+  → Linker          (scope hoisting, name conflict resolution)
+  → Tree-shaker     (drop unused exports/statements)
+  → Chunker         (split dynamic imports into chunks)
+  → Emitter         (per-module transform + codegen)
+  → Output (bundle.js + chunks + .map)
+```
+
+Each stage has a **single direction of dependency** — the resolver knows nothing about the graph, the linker knows nothing about the resolver. The output of one becomes the input of the next, and almost every observable behavior in your code is decided by exactly one of these stages.
+
+| Stage | Input | Output | What you might notice |
+|---|---|---|---|
+| Resolver | import path | absolute file path | "Module not found" errors, alias/fallback behavior |
+| Graph | entry points | modules + dependencies + execution order | circular reference warnings, ESM side-effect order |
+| Linker | modules + symbols | global symbol table | variables renamed to `Foo$1` |
+| Tree-shaker | linked graph | reachability marks | "why is this code still in my bundle?" |
+| Chunker | marked graph | chunk list | `chunks/abc.js`, runtime loader |
+| Emitter | chunks | JS + sourcemap | final output, line/column mapping |
+
+## 1. Module resolution
+
+Decides which file a specifier like `import './foo'` refers to. Filesystem only — no parser/AST involved.
+
+### Resolution priority
+
+1. **alias** — `defineConfig({ alias: { ... } })` or `--alias:foo=bar` is applied **before** any other resolution. Always.
+2. **tsconfig paths** — `compilerOptions.paths` from `tsconfig.json`.
+3. **package.json `exports`** — conditional matching. Use `--conditions` to enable arbitrary conditions.
+4. **`main-fields` order** — defaults to `module → main` (browser target prepends `browser`, RN target prepends `react-native`).
+5. **Auto-extensions** — tried in `--resolve-extensions` order (`.tsx, .ts, .jsx, .js, ...`).
+6. **`fallback`** — applied **only** when everything above fails. Compatible with webpack `resolve.fallback` / Metro `extraNodeModules`.
+
+### Per-platform behavior
+
+| `--platform` | Automatic |
+|---|---|
+| `browser` (default) | Node built-ins (`fs`, `path`, ...) → empty modules, `process.env.NODE_ENV` → `"production"` define |
+| `node` | Node built-ins + `node:` subpaths auto-external |
+| `react-native` | `.native.*` / `.ios.*` / `.android.*` extensions tried automatically, `react-native` prepended to `main-fields`, Flow auto-enabled, Hermes target forced |
+
+### Conditional exports
+
+```jsonc
+{
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
+    }
+  }
+}
+```
+
+- Pass `--conditions=source` to inline monorepo internal packages directly from src without rebuilding `dist`.
+- `--platform=browser` automatically adds the `browser` condition; `--platform=node` adds `node`.
+
+## 2. Module graph and execution order
+
+Starting from the entry points, ZNTC parses dependencies in parallel via BFS. When parsing finishes, it walks the graph in DFS post-order to assign `exec_index`. That index is the order modules are emitted into the final bundle, and the order their ESM side effects run.
+
+### Static ESM imports preserve order
+
+```ts
+// entry.ts
+import './a';   // top-level of `a` runs
+import './b';   // top-level of `b` runs
+```
+
+Even after scope hoisting fuses everything into one file, **`a`'s top-level code runs before `b`'s.** This matches the ESM spec and is what makes side-effect modules (polyfills, CSS injection, …) work correctly.
+
+### Circular references
+
+```ts
+// a.ts
+import { B } from './b';
+export const A = () => B();
+
+// b.ts
+import { A } from './a';
+export const B = () => A();
+```
+
+ZNTC treats cycles as a **warning, not an error**, and packs them into the same chunk. The cycle's entry module runs first, and by the time functions are actually called both sides are initialized (matching Node.js ESM behavior). One caveat: **calling something inside the cycle at top level** can still trip TDZ.
+
+### Dynamic imports
+
+```ts
+const mod = await import('./heavy');
+```
+
+Dynamic imports are tracked as separate dependencies. With `--splitting` they become standalone chunks; without splitting they get inlined into the same bundle.
+
+### Top-level await
+
+```ts
+// data.ts
+export const data = await fetch('/data.json').then(r => r.json());
+```
+
+A module with top-level await **must be evaluated dynamically and cannot be statically hoisted.** Every module that imports it is automatically promoted to async evaluation — be aware that this can propagate further than you expect.
+
+## 3. Scope hoisting (Linker)
+
+Fusing many modules into one file causes name collisions. ZNTC renames automatically.
+
+### Same-name collisions
+
+```ts
+// a.ts
+const value = 1;
+export const A = value;
+
+// b.ts
+const value = 2;
+export const B = value;
+
+// entry.ts
+import { A } from './a';
+import { B } from './b';
+```
+
+Bundle output:
+
+```js
+// a.ts
+const value = 1;
+const A = value;
+// b.ts
+const value$1 = 2;       // automatic suffix
+const B = value$1;
+```
+
+That's why you see `$1`, `$2` suffixes. Original names are preserved in the sourcemap.
+
+### Global protection
+
+User variables that collide with `window`, `document`, `console`, `Math`, etc., are renamed automatically to prevent TDZ or shadowing accidents.
+
+### `default` handling
+
+```ts
+// component.ts
+export default function Component() { ... }
+
+// entry.ts
+import Component from './component';
+```
+
+`default` isn't a usable identifier in the hoisted output, so default exports are renamed to a module-derived identifier (e.g. `component_default`).
+
+### Debugging tips
+
+- Build with `sourcemap: true` — devtools shows the original variable names.
+- `--metafile=meta.json` + the [Metafile analyzer](/zntc/analyze/) visualizes which module went into which chunk and where.
+
+## 4. CJS ↔ ESM Interop
+
+This stage decides what happens when CommonJS imports ESM, or vice versa.
+
+### When `require()` is converted to import
+
+Importing a CJS module from ESM picks one of two modes:
+
+| Importer kind | Mode | Behavior |
+|---|---|---|
+| `.mjs` / `.mts` / `package.json` `"type": "module"` | **Node mode** | `__toESM(require(), 1)` — matches Node.js native behavior |
+| Everything else (`.js` / `.ts` / regular import) | **Babel mode** | `__toESM(require())` — honors `__esModule`, extracts default |
+
+### `default` import vs namespace import
+
+```ts
+// react.ts (CJS, exports.default = ..., module.exports.useState = ...)
+import React from 'react';        // default
+import * as ReactNs from 'react'; // namespace
+```
+
+| Form | Result for a CJS module |
+|---|---|
+| `import X from 'cjs-mod'` | `module.exports.default` if `__esModule` is true, else `module.exports` itself |
+| `import * as X from 'cjs-mod'` | A namespace object wrapping every enumerable property of `module.exports` |
+| `import { x } from 'cjs-mod'` | `module.exports.x` — only when statically provable (see below) |
+
+For CJS named imports to work, ZNTC must **statically prove** the export. Supported patterns:
+
+- `exports.foo = ...`
+- `module.exports = { foo, bar }`
+- `Object.defineProperty(exports, 'foo', { value })` / `{ get }`
+
+Conservatively preserved (not statically provable):
+
+- `exports[k] = ...` (dynamic key)
+- `if (cond) exports.foo = ...` (runtime branch)
+- Dynamic getter side effects
+
+### `export *` and default
+
+```ts
+// re-export.ts
+export * from './source';
+```
+
+Per ESM spec (15.2.3.5) `export *` **does not include default**. To re-export both:
+
+```ts
+export { default } from './source';
+export * from './source';
+```
+
+### Namespace barrel re-export
+
+```ts
+// barrel.ts
+import * as utils from './utils';
+export { utils };
+```
+
+This pattern materializes the namespace object inline — meaning every export of `utils` is treated as used and tree-shaking can no longer prune them. Prefer explicit re-exports when possible:
+
+```ts
+export { foo, bar } from './utils';
+```
+
+## 5. Code splitting (Chunker)
+
+When `--splitting` is on and a dynamic import is encountered, ZNTC partitions the module graph into chunks.
+
+### Split rules
+
+1. **Dynamic import target → its own chunk**
+   ```ts
+   const mod = await import('./pages/about');
+   // → chunks/about-XXXXXX.js
+   ```
+2. **Common modules auto-extracted** — modules shared by multiple entry points get their own chunk (the "vendor chunk" effect).
+3. **Cycles stay in one chunk** — splitting a cycle would break ESM evaluation order, so they're forced together.
+
+### Runtime loader
+
+When chunks are split, ZNTC emits a tiny ESM-based loader as the entry chunk's prelude. No additional runtime dependencies (esbuild/Rolldown style).
+
+### Filename patterns
+
+```bash
+zntc --bundle entry.ts --splitting --outdir dist/ \
+  --entry-names="[name]-[hash]" \
+  --chunk-names="chunks/[name]-[hash]" \
+  --asset-names="assets/[name]-[hash]"
+```
+
+- `[name]` — module basename (e.g. `about`)
+- `[hash]` — content hash (cache busting)
+- `[ext]` — extension
+
+## 6. Emitter
+
+The emitter places module bodies in `exec_index` order per chunk, running each through transformer + codegen.
+
+### Output shape per format
+
+| `--format` | Output |
+|---|---|
+| `esm` (default) | `import` / `export` left intact, top-level code |
+| `cjs` | Converted to `require()` / `module.exports` |
+| `iife` | Wrapped as `(function() { ... })()`, exposed via `--global-name` |
+| `umd` | UMD wrapper (CJS / AMD / global fallback) |
+| `amd` | `define([...], function (...) { ... })` |
+
+### `banner` / `footer` vs `intro` / `outro`
+
+- `banner` / `footer` — **outside** the wrapper (license headers, shebangs)
+- `intro` / `outro` — **inside** the wrapper, before/after bundle code (Rollup `output.intro/outro` compatible)
+
+The distinction matters for IIFE/UMD wrap formats.
+
+### Sourcemaps
+
+- `--sourcemap` — external `.map` file plus URL comment
+- `--sourcemap=inline` — base64 inline data URL
+- `--sourcemap=hidden` — emit map file but omit URL comment (production)
+
+Bundle sourcemaps are computed via direct AST-span mapping (no chaining required). If the input already has a sourcemap, it's chained automatically.
+
+## Debugging — which stage owns this symptom?
+
+| Symptom | Suspect stage | Tool |
+|---|---|---|
+| `Could not resolve '...'` | Resolver | `--log-level=debug`, `inputs` in `--metafile` |
+| Variables renamed unexpectedly | Linker | sourcemap, `output` mapping in `--metafile` |
+| Dead code not removed | Tree-shaker | See limits in [Tree-shaking](/zntc/en/guides/tree-shaking/) |
+| CJS named import doesn't work | Interop | See "statically provable patterns" above |
+| Chunks split too aggressively | Chunker | Disable `--splitting` or use `manualChunks` |
+| Output format isn't what you wanted | Emitter | Check `--format`, `--global-name` |
+
+## Further reading
+
+- [Tree-shaking](/zntc/en/guides/tree-shaking/) — `@__PURE__`, `sideEffects`, type-only elision, statement-level DCE
+- [Bundling](/zntc/en/guides/bundling/) — full CLI option reference
+- Contributor design docs: [`docs/BUNDLER.md`](https://github.com/ohah/zntc/blob/main/docs/BUNDLER.md), [`docs/ARCHITECTURE.md`](https://github.com/ohah/zntc/blob/main/docs/ARCHITECTURE.md)

--- a/documents/src/content/docs/en/guides/flow-support.md
+++ b/documents/src/content/docs/en/guides/flow-support.md
@@ -1,0 +1,243 @@
+---
+title: Flow Support
+description: ZNTC's Flow type stripping — React Native core compatibility, how to enable it, and the supported syntax list.
+---
+
+ZNTC parses and strips Facebook Flow type annotations directly. Because React Native core and many Meta libraries are written in Flow, this is effectively required for RN bundling.
+
+## When to use it
+
+- **React Native bundling** — RN core, `react-native`, and many `react-native-*` packages use Flow. Auto-enabled by `--platform=react-native`.
+- **Meta-ecosystem libraries** — Hermes runs Flow natively, but other runtimes (Node, browsers, V8) need stripping.
+- **Flow-only legacy codebases** — replaces `@babel/preset-flow`.
+
+## How to enable it
+
+Three mechanisms work; precedence is: pragma > extension > CLI/config.
+
+### `// @flow` pragma auto-detection
+
+```ts
+// @flow
+const x: number = 1;
+```
+
+A pragma at the top of the file switches the parser to Flow mode for that file. Mixing TypeScript syntax in the same file is then an error.
+
+### `.js.flow` extension
+
+```ts
+// types.js.flow
+export type User = { id: number; name: string };
+```
+
+The `.js.flow` extension marks a file as Flow type definitions and is parsed in Flow mode automatically (analogous to TypeScript's `.d.ts`).
+
+### CLI / config
+
+```bash
+zntc --bundle entry.js --flow -o bundle.js
+```
+
+```ts
+// zntc.config.ts
+import { defineConfig } from "@zntc/core";
+
+export default defineConfig({
+  flow: true,
+});
+```
+
+`--platform=react-native` turns on `flow: true` automatically.
+
+## Supported syntax
+
+### Basic type annotations
+
+```ts
+// @flow
+const n: number = 1;
+const s: ?string = null;          // nullable
+const m: mixed = anything;
+const arr: number[] = [1, 2, 3];
+const arr2: Array<string> = ['a'];
+
+function add(a: number, b: number): number {
+  return a + b;
+}
+```
+
+Supported: `string`, `number`, `boolean`, `bool`, `mixed`, `empty`, `void`, `null`, `?Type` (nullable), `T[]`, `Array<T>`.
+
+### Generics
+
+```ts
+// @flow
+function identity<T>(x: T): T { return x; }
+function map<T, U>(arr: T[], fn: (x: T) => U): U[] { /* ... */ }
+
+class Box<T> {
+  value: T;
+  constructor(v: T) { this.value = v; }
+}
+```
+
+### Union / Intersection
+
+```ts
+// @flow
+type Result = 'ok' | 'error' | 'pending';
+type WithMeta<T> = T & { meta: Meta };
+```
+
+### Variance
+
+```ts
+// @flow
+type ReadOnly = { +name: string };   // covariant (read-only)
+type WriteOnly = { -name: string };  // contravariant (write-only)
+```
+
+### Type alias / Opaque type
+
+```ts
+// @flow
+type Point = { x: number; y: number };
+
+opaque type UserId = string;                      // string is invisible outside
+opaque type Email: string = string;               // supertype constraint — string-compatible outside
+```
+
+### Interface
+
+```ts
+// @flow
+interface Comparable<T> {
+  compareTo(other: T): number;
+}
+
+interface Sortable extends Comparable<Sortable> {
+  sort(): void;
+}
+```
+
+### Import / Export type
+
+```ts
+// @flow
+import type { User } from './types';
+import typeof UserClass from './User';
+
+export type Result = { ok: boolean };
+export type { User } from './types';
+```
+
+### Declare
+
+```ts
+// @flow
+declare class Logger { log(msg: string): void }
+declare function debug(msg: string): void;
+declare var __DEV__: boolean;
+
+declare module 'some-untyped-lib' {
+  declare module.exports: { foo: () => void };
+}
+
+declare export function exported(): void;
+```
+
+### Type cast
+
+```ts
+// @flow
+const x = (value: string);              // parenthesized cast
+const y = obj as User;                  // as cast
+```
+
+### Exact object type
+
+```ts
+// @flow
+type ExactUser = {| id: number, name: string |};   // additional fields disallowed
+```
+
+### Predicate function
+
+```ts
+// @flow
+function isString(x: mixed): boolean %checks {
+  return typeof x === 'string';
+}
+```
+
+### Comment types
+
+```ts
+// @flow
+const x /*: number */ = 1;            // inline
+/*::
+type Internal = { secret: string };
+*/
+```
+
+Used to add types while keeping JS-compatibility. ZNTC recognizes and strips both forms.
+
+## Unsupported syntax
+
+The following constructs are not used by Metro / RN core, so they're not yet supported. If you need any of them, please open an issue with your use case at [GitHub Issues](https://github.com/ohah/zntc/issues).
+
+| Syntax | Introduced | Status |
+|---|---|---|
+| `component` declaration | Flow 2023 | unsupported |
+| `hook` declaration | Flow 2023 | unsupported |
+| `match` expression | Flow 2024 | unsupported |
+
+## Validation
+
+All `@flow` files in `react-native` 0.74 (410 files) parse and strip cleanly. Regression tests keep this guarantee permanent.
+
+```bash
+# Reproduce locally
+git clone https://github.com/facebook/react-native
+zntc --bundle react-native/Libraries/react-native/index.js --platform=react-native -o /tmp/rn.js
+```
+
+## Using it with React Native
+
+`--platform=react-native` enables several things in addition to Flow.
+
+- Platform-specific extensions tried automatically — `.ios.tsx`, `.ios.ts`, `.ios.jsx`, `.ios.js`, `.native.*`, ...
+- `react-native` prepended to `main-fields`
+- Hermes target (`--target=hermes0.70`) forced
+- `process.env.NODE_ENV` define
+- Metro-compatible block list (`__tests__/`, iOS/Android build folders)
+
+To configure manually:
+
+```ts
+defineConfig({
+  flow: true,
+  platform: "react-native",
+  resolveExtensions: [
+    ".ios.tsx", ".ios.ts", ".ios.jsx", ".ios.js",
+    ".native.tsx", ".native.ts", ".native.jsx", ".native.js",
+    ".tsx", ".ts", ".jsx", ".js",
+  ],
+  mainFields: ["react-native", "browser", "module", "main"],
+});
+```
+
+For full RN integration see the [React Native guide](/zntc/en/guides/react-native/); for porting from a Babel-based RN setup see [Babel Migration](/zntc/en/guides/babel-migration/).
+
+## Mixing with TypeScript
+
+Flow files and TypeScript files in the same project are supported — the mode is decided per file (pragma / extension / `--flow` fallback).
+
+Mixing the two syntaxes within the **same file** is not supported — the TypeScript compiler has the same restriction.
+
+## Further reading
+
+- Contributor design doc: [`docs/FLOW.md`](https://github.com/ohah/zntc/blob/main/docs/FLOW.md) — Flow implementation decisions, Metro source analysis, prioritization of unsupported syntax
+- [React Native guide](/zntc/en/guides/react-native/) — full RN integration flow
+- [Babel migration](/zntc/en/guides/babel-migration/) — porting an existing Babel + Flow setup to ZNTC

--- a/documents/src/content/docs/guides/bundler-deep-dive.md
+++ b/documents/src/content/docs/guides/bundler-deep-dive.md
@@ -1,0 +1,315 @@
+---
+title: 번들러 구조와 동작 원리
+description: ZNTC 번들러 파이프라인 6단계와 사용자가 알면 도움 되는 동작 원리 — 모듈 해석, 실행 순서, 스코프 호이스팅, CJS/ESM interop, 코드 스플리팅.
+---
+
+이 문서는 ZNTC 번들러가 입력에서 출력까지 어떤 단계를 거치는지, 그리고 사용자 코드에서 마주칠 수 있는 동작들이 어디서 결정되는지 설명합니다.
+
+CLI 옵션은 [번들링](/zntc/guides/bundling/) 을, 트리쉐이킹의 자세한 동작은 [트리쉐이킹](/zntc/guides/tree-shaking/) 을 참고하세요. 이 문서는 그 위에서 "왜 이렇게 동작하는가" 에 답합니다.
+
+## 파이프라인 6단계
+
+```
+Entry Points
+  → Resolver        (경로 → 절대 파일 경로)
+  → Module Graph    (BFS 파싱 + DFS 실행 순서)
+  → Linker          (스코프 호이스팅, 이름 충돌 해결)
+  → Tree-shaker     (사용 안 되는 export/문장 제거)
+  → Chunker         (동적 import → 청크 분할)
+  → Emitter         (모듈별 transform + codegen)
+  → Output (bundle.js + chunks + .map)
+```
+
+각 단계는 **단방향 의존** 입니다 — Resolver 는 Graph 를 모르고, Linker 는 Resolver 를 모릅니다. 한 단계의 출력이 다음 단계의 입력이 되고, 사용자 코드의 동작은 거의 항상 이 중 한 단계에서 결정됩니다.
+
+| 단계 | 입력 | 출력 | 사용자가 마주치는 것 |
+|---|---|---|---|
+| Resolver | import 경로 | 절대 파일 경로 | "Module not found" 에러, alias/fallback 동작 |
+| Graph | 진입점 | 모듈 + 의존성 + 실행 순서 | 순환 참조 경고, ESM 사이드이펙트 순서 |
+| Linker | 모듈 + 심볼 | 글로벌 심볼 테이블 | 변수 이름이 `Foo$1` 처럼 바뀌는 현상 |
+| Tree-shaker | 링크된 그래프 | 사용 마킹 | "왜 이 코드가 번들에 남았지?" |
+| Chunker | 마킹된 그래프 | 청크 목록 | `chunks/abc.js`, runtime loader |
+| Emitter | 청크 | JS + sourcemap | 최종 출력, line/column 매핑 |
+
+## 1. 모듈 해석 (Resolver)
+
+`import './foo'` 같은 specifier 가 어떤 파일로 풀리는지 결정합니다. 파서/AST 와 무관, 파일시스템만 사용합니다.
+
+### 해석 우선순위
+
+1. **alias** — `defineConfig({ alias: { ... } })` 또는 `--alias:foo=bar` 가 가장 먼저 적용됩니다. 일반 해석 **이전에 무조건** 치환됩니다.
+2. **tsconfig paths** — `tsconfig.json` 의 `compilerOptions.paths` 매핑.
+3. **package.json `exports`** — 조건부 매칭. `--conditions` 로 임의 조건 활성화.
+4. **`main-fields` 순서** — 기본 `module → main` (browser 타겟은 `browser` prepend, RN 타겟은 `react-native` prepend).
+5. **확장자 자동 추가** — `--resolve-extensions` 순서대로 시도 (`.tsx, .ts, .jsx, .js, ...`).
+6. **`fallback`** — 위 모두 실패한 경우에만 적용. webpack `resolve.fallback` / Metro `extraNodeModules` 호환.
+
+### 플랫폼별 동작
+
+| `--platform` | 자동 동작 |
+|---|---|
+| `browser` (기본) | Node 내장(`fs`, `path`, ...) → 빈 모듈, `process.env.NODE_ENV` → `"production"` define |
+| `node` | Node 내장 + `node:` 서브패스 자동 external |
+| `react-native` | `.native.*` / `.ios.*` / `.android.*` 확장자 자동 시도, `main-fields` 에 `react-native` prepend, Flow 자동 활성화, Hermes 타겟 강제 |
+
+### 조건부 exports
+
+```jsonc
+{
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.js"
+    }
+  }
+}
+```
+
+- `--conditions=source` 를 켜면 모노레포 내부 패키지를 dist 빌드 없이 src 에서 직접 inline 합니다.
+- `--platform=browser` 는 `browser` 조건을, `--platform=node` 는 `node` 조건을 자동으로 추가합니다.
+
+## 2. 모듈 그래프와 실행 순서
+
+진입점부터 의존성을 BFS 로 병렬 파싱하고, 끝나면 DFS 후위 순서로 `exec_index` 를 부여합니다. 이 인덱스가 최종 번들에서 모듈 본문이 배치되는 순서이자 ESM 사이드이펙트 실행 순서입니다.
+
+### ESM 정적 import 순서 보장
+
+```ts
+// entry.ts
+import './a';   // a 의 top-level 실행
+import './b';   // b 의 top-level 실행
+```
+
+스코프 호이스팅으로 모든 모듈이 한 파일에 합쳐져도 **`a` 의 top-level 코드가 `b` 보다 먼저 실행됩니다**. 이는 ESM 스펙 준수이며, 사이드이펙트가 있는 모듈(polyfill, CSS 주입 등)이 정상 동작하는 근거입니다.
+
+### 순환 참조
+
+```ts
+// a.ts
+import { B } from './b';
+export const A = () => B();
+
+// b.ts
+import { A } from './a';
+export const B = () => A();
+```
+
+ZNTC 는 순환 참조를 **에러가 아닌 경고** 로 처리하고 같은 청크에 묶습니다. 사이클의 진입 모듈이 먼저 실행되며, 함수 호출 시점에는 양쪽 모두 초기화되어 있습니다 (런타임 호출 기준). 단, 사이클 안에서 **top-level 에서 즉시 호출** 하는 코드는 TDZ 에러가 날 수 있습니다 — Node.js ESM 동작과 동일.
+
+### 동적 import
+
+```ts
+const mod = await import('./heavy');
+```
+
+동적 import 는 별도 의존성으로 추적됩니다. `--splitting` 이 켜져 있으면 별도 청크로 분리되고, 꺼져 있으면 같은 번들에 inline 됩니다.
+
+### Top-level await
+
+```ts
+// data.ts
+export const data = await fetch('/data.json').then(r => r.json());
+```
+
+Top-level await 가 있는 모듈은 **동적으로 평가되어야 하므로 정적으로 hoist 할 수 없습니다.** 이를 사용하는 모든 모듈은 자동으로 async 평가 모드로 승격됩니다 — 의도하지 않은 모듈에 전파될 수 있으니 주의.
+
+## 3. 스코프 호이스팅 (Linker)
+
+여러 모듈을 한 파일로 합치면 변수 이름이 충돌합니다. ZNTC 는 이를 자동으로 rename 합니다.
+
+### 같은 이름 충돌
+
+```ts
+// a.ts
+const value = 1;
+export const A = value;
+
+// b.ts
+const value = 2;
+export const B = value;
+
+// entry.ts
+import { A } from './a';
+import { B } from './b';
+```
+
+번들 결과:
+
+```js
+// a.ts
+const value = 1;
+const A = value;
+// b.ts
+const value$1 = 2;       // 자동 suffix
+const B = value$1;
+```
+
+`$1`, `$2` 같은 suffix 가 붙는 이유입니다. sourcemap 으로 원본 위치는 그대로 추적됩니다.
+
+### 글로벌 보호
+
+`window`, `document`, `console`, `Math` 같은 글로벌 이름과 충돌하는 사용자 변수는 자동으로 rename 됩니다 (TDZ 또는 shadowing 사고 방지).
+
+### `default` 처리
+
+```ts
+// component.ts
+export default function Component() { ... }
+
+// entry.ts
+import Component from './component';
+```
+
+번들 결과에서 `default` 라는 키워드 이름은 사용 불가하므로, default export 는 모듈명 기반의 식별자(예: `component_default`) 로 rename 되어 호이스트됩니다.
+
+### 디버깅 팁
+
+- `sourcemap: true` 로 빌드하면 브라우저 devtools 에서 원본 변수명 확인 가능.
+- `--metafile=meta.json` + [Metafile 분석](/zntc/analyze/) 으로 어떤 모듈이 어떤 청크/위치에 들어갔는지 시각화.
+
+## 4. CJS ↔ ESM Interop
+
+CommonJS 모듈을 ESM 에서 import 하거나 그 반대일 때 어떻게 동작할지 결정하는 단계입니다.
+
+### `require()` 가 import 로 변환될 때
+
+CJS 모듈을 ESM 컨텍스트에서 import 하면 ZNTC 는 두 가지 모드 중 하나를 적용합니다.
+
+| Importer 종류 | 적용 모드 | 동작 |
+|---|---|---|
+| `.mjs` / `.mts` / `package.json` `"type": "module"` | **Node 모드** | `__toESM(require(), 1)` — Node.js 기본 동작과 동일 |
+| 기타 (`.js` / `.ts` / 일반 import) | **Babel 모드** | `__toESM(require())` — `__esModule` 플래그를 존중, default 추출 |
+
+### `default` import vs namespace import
+
+```ts
+// react.ts (CJS, exports.default = ..., module.exports.useState = ...)
+import React from 'react';        // default import
+import * as ReactNs from 'react'; // namespace import
+```
+
+| 형태 | CJS 모듈 결과 |
+|---|---|
+| `import X from 'cjs-mod'` | `__esModule` 이 true 면 `module.exports.default`, 아니면 `module.exports` 자체 |
+| `import * as X from 'cjs-mod'` | `module.exports` 의 모든 enumerable property 를 wrap 한 namespace 객체 |
+| `import { x } from 'cjs-mod'` | `module.exports.x` (정적 추출 가능한 경우만 — 아래 참고) |
+
+CJS named import 가 동작하려면 ZNTC 가 **정적으로 export 를 증명** 할 수 있어야 합니다. 지원하는 패턴:
+
+- `exports.foo = ...`
+- `module.exports = { foo, bar }`
+- `Object.defineProperty(exports, 'foo', { value })` / `{ get }`
+
+지원 안 되는 패턴 (보수적으로 보존):
+
+- `exports[k] = ...` (dynamic key)
+- `if (cond) exports.foo = ...` (runtime branch)
+- 동적 getter side-effect
+
+### `export *` 와 default
+
+```ts
+// re-export.ts
+export * from './source';
+```
+
+ESM 스펙(15.2.3.5) 에 따라 `export *` 는 **default 를 포함하지 않습니다.** default 도 같이 re-export 하려면:
+
+```ts
+export { default } from './source';
+export * from './source';
+```
+
+### Namespace barrel re-export
+
+```ts
+// barrel.ts
+import * as utils from './utils';
+export { utils };
+```
+
+이 패턴은 namespace 객체를 인라인으로 생성합니다 — 즉, `utils` 의 모든 export 가 사용된 것으로 간주되어 트리쉐이킹이 어려워집니다. 가능하면 명시적 re-export 로 바꾸세요:
+
+```ts
+export { foo, bar } from './utils';
+```
+
+## 5. 코드 스플리팅 (Chunker)
+
+`--splitting` 이 켜진 상태에서 동적 import 를 만나면 ZNTC 는 모듈 그래프를 청크로 나눕니다.
+
+### 청크 분할 규칙
+
+1. **동적 import target → 별도 청크**
+   ```ts
+   const mod = await import('./pages/about');
+   // → chunks/about-XXXXXX.js
+   ```
+2. **공통 모듈 자동 추출** — 여러 진입점이 공유하는 모듈은 별도 청크 (vendor 청크 효과).
+3. **순환 참조는 같은 청크** — 사이클 분리 시 ESM 평가 순서가 깨지므로 강제 묶음.
+
+### 런타임 로더
+
+청크가 분할되면 ZNTC 는 모듈을 동적으로 로드하는 작은 ESM 기반 로더를 entry 청크 prelude 로 emit 합니다. 추가 런타임 의존성은 없습니다 (esbuild/Rolldown 방식).
+
+### 파일명 패턴
+
+```bash
+zntc --bundle entry.ts --splitting --outdir dist/ \
+  --entry-names="[name]-[hash]" \
+  --chunk-names="chunks/[name]-[hash]" \
+  --asset-names="assets/[name]-[hash]"
+```
+
+- `[name]` — 모듈 basename (`about` 등)
+- `[hash]` — 콘텐츠 해시 (캐시 무효화)
+- `[ext]` — 확장자
+
+## 6. 코드 생성 (Emitter)
+
+청크별로 모듈 본문을 `exec_index` 순서로 배치하고, 각 모듈을 transformer + codegen 으로 처리합니다.
+
+### `format` 별 출력 형태
+
+| `--format` | 출력 |
+|---|---|
+| `esm` (기본) | `import` / `export` 문 그대로, 최상위 코드 |
+| `cjs` | `require()` / `module.exports` 로 변환 |
+| `iife` | `(function() { ... })()` 로 wrap, `--global-name` 으로 노출 |
+| `umd` | UMD 래퍼 (CJS / AMD / 글로벌 fallback) |
+| `amd` | `define([...], function (...) { ... })` |
+
+### `banner` / `footer` vs `intro` / `outro`
+
+- `banner` / `footer` — wrapper **밖** (라이선스 헤더, shebang)
+- `intro` / `outro` — wrapper **안** 번들 코드 앞/뒤 (Rollup `output.intro/outro` 호환)
+
+IIFE/UMD 같은 wrap 포맷에서 차이가 명확합니다.
+
+### 소스맵
+
+- `--sourcemap` — external `.map` 파일 + URL 주석
+- `--sourcemap=inline` — base64 inline data URL
+- `--sourcemap=hidden` — 파일 emit 만 하고 URL 주석 생략 (production)
+
+번들 소스맵은 AST span 으로 원본→최종 직접 매핑입니다 (체이닝 불필요). 입력에 이미 sourcemap 이 있으면 자동 체이닝합니다.
+
+## 디버깅 — 어느 단계에서 일어났는지 알기
+
+| 증상 | 의심 단계 | 도구 |
+|---|---|---|
+| `Could not resolve '...'` | Resolver | `--log-level=debug`, `--metafile` 의 `inputs` 확인 |
+| 변수 이름이 이상하게 바뀜 | Linker | sourcemap 확인, `--metafile` 의 `output` 매핑 |
+| 미사용 코드가 안 빠짐 | Tree-shaker | [트리쉐이킹](/zntc/guides/tree-shaking/) 의 한계 섹션 참고 |
+| CJS named import 동작 안 함 | Interop | 위 § "정적으로 증명 가능한 패턴" 참고 |
+| 청크가 너무 잘게 쪼개짐 | Chunker | `--splitting` 끄거나 `manualChunks` 사용 |
+| 출력 포맷이 의도와 다름 | Emitter | `--format`, `--global-name` 확인 |
+
+## 더 읽을거리
+
+- [트리쉐이킹](/zntc/guides/tree-shaking/) — `@__PURE__`, `sideEffects`, type-only elision, statement-level DCE
+- [manualChunks](/zntc/guides/manual-chunks/) — 청크 분할을 수동으로 제어
+- [번들링](/zntc/guides/bundling/) — CLI 옵션 전체
+- 컨트리뷰터용 설계 문서: [`docs/BUNDLER.md`](https://github.com/ohah/zntc/blob/main/docs/BUNDLER.md), [`docs/ARCHITECTURE.md`](https://github.com/ohah/zntc/blob/main/docs/ARCHITECTURE.md)

--- a/documents/src/content/docs/guides/flow-support.md
+++ b/documents/src/content/docs/guides/flow-support.md
@@ -1,0 +1,243 @@
+---
+title: Flow 지원
+description: ZNTC 의 Flow 타입 스트리핑 — React Native 코어 호환, 활성화 방법, 지원 구문 목록.
+---
+
+ZNTC 는 Facebook Flow 타입 어노테이션을 직접 파싱하고 스트리핑합니다. React Native 코어와 다수의 Meta 라이브러리가 Flow 로 작성되어 있어, RN 번들링에서는 사실상 필수 기능입니다.
+
+## 언제 사용하는가
+
+- **React Native 앱 번들링** — RN 코어, `react-native`, `react-native-*` 패키지 다수가 Flow 사용. `--platform=react-native` 시 자동 활성화됩니다.
+- **Meta 생태계 라이브러리** — Hermes 엔진은 Flow 를 네이티브 실행하지만, 다른 환경(Node, 브라우저, V8) 에서는 stripping 이 필요합니다.
+- **Flow 만 쓰는 레거시 코드베이스** — Babel `@babel/preset-flow` 를 ZNTC 로 대체.
+
+## 활성화 방법
+
+세 가지 방식이 모두 동작합니다 (우선순위: pragma > 확장자 > CLI/config).
+
+### `// @flow` pragma 자동 감지
+
+```ts
+// @flow
+const x: number = 1;
+```
+
+파일 상단에 pragma 가 있으면 자동으로 Flow 모드로 파싱됩니다. 이 모드에서는 같은 파일 안에 TypeScript 구문이 섞여 있으면 에러입니다.
+
+### `.js.flow` 확장자
+
+```ts
+// types.js.flow
+export type User = { id: number; name: string };
+```
+
+`.js.flow` 확장자는 Flow 타입 정의 파일로 인식되어 자동으로 Flow 모드로 파싱됩니다 (TypeScript 의 `.d.ts` 와 유사).
+
+### CLI / config
+
+```bash
+zntc --bundle entry.js --flow -o bundle.js
+```
+
+```ts
+// zntc.config.ts
+import { defineConfig } from "@zntc/core";
+
+export default defineConfig({
+  flow: true,
+});
+```
+
+`--platform=react-native` 를 사용하면 `flow: true` 가 자동으로 켜집니다.
+
+## 지원되는 구문
+
+### 기본 타입 어노테이션
+
+```ts
+// @flow
+const n: number = 1;
+const s: ?string = null;          // nullable
+const m: mixed = anything;
+const arr: number[] = [1, 2, 3];
+const arr2: Array<string> = ['a'];
+
+function add(a: number, b: number): number {
+  return a + b;
+}
+```
+
+지원: `string`, `number`, `boolean`, `bool`, `mixed`, `empty`, `void`, `null`, `?Type` (nullable), `T[]`, `Array<T>`.
+
+### 제네릭
+
+```ts
+// @flow
+function identity<T>(x: T): T { return x; }
+function map<T, U>(arr: T[], fn: (x: T) => U): U[] { /* ... */ }
+
+class Box<T> {
+  value: T;
+  constructor(v: T) { this.value = v; }
+}
+```
+
+### Union / Intersection
+
+```ts
+// @flow
+type Result = 'ok' | 'error' | 'pending';
+type WithMeta<T> = T & { meta: Meta };
+```
+
+### Variance
+
+```ts
+// @flow
+type ReadOnly = { +name: string };   // covariant (읽기 전용)
+type WriteOnly = { -name: string };  // contravariant (쓰기 전용)
+```
+
+### Type alias / Opaque type
+
+```ts
+// @flow
+type Point = { x: number; y: number };
+
+opaque type UserId = string;                      // 외부에서는 string 으로 못 봄
+opaque type Email: string = string;               // supertype constraint — 외부에서는 string 호환
+```
+
+### Interface
+
+```ts
+// @flow
+interface Comparable<T> {
+  compareTo(other: T): number;
+}
+
+interface Sortable extends Comparable<Sortable> {
+  sort(): void;
+}
+```
+
+### Import / Export type
+
+```ts
+// @flow
+import type { User } from './types';
+import typeof UserClass from './User';
+
+export type Result = { ok: boolean };
+export type { User } from './types';
+```
+
+### Declare
+
+```ts
+// @flow
+declare class Logger { log(msg: string): void }
+declare function debug(msg: string): void;
+declare var __DEV__: boolean;
+
+declare module 'some-untyped-lib' {
+  declare module.exports: { foo: () => void };
+}
+
+declare export function exported(): void;
+```
+
+### TypeCast
+
+```ts
+// @flow
+const x = (value: string);              // 괄호 캐스트
+const y = obj as User;                  // as 캐스트
+```
+
+### Exact object type
+
+```ts
+// @flow
+type ExactUser = {| id: number, name: string |};   // 추가 필드 금지
+```
+
+### Predicate function
+
+```ts
+// @flow
+function isString(x: mixed): boolean %checks {
+  return typeof x === 'string';
+}
+```
+
+### Comment 타입
+
+```ts
+// @flow
+const x /*: number */ = 1;            // 인라인
+/*::
+type Internal = { secret: string };
+*/
+```
+
+JS 호환성을 유지하면서 타입을 추가할 때 사용. ZNTC 는 두 형태 모두 인식하고 stripping 합니다.
+
+## 미지원 구문
+
+다음 구문은 Metro / RN 코어에서 사용되지 않아 아직 미지원입니다. 필요한 경우 [GitHub 이슈](https://github.com/ohah/zntc/issues) 에 사용 사례와 함께 요청해 주세요.
+
+| 구문 | 도입 | 상태 |
+|---|---|---|
+| `component` 선언 | Flow 2023 | 미지원 |
+| `hook` 선언 | Flow 2023 | 미지원 |
+| `match` 표현식 | Flow 2024 | 미지원 |
+
+## 검증
+
+`react-native` 0.74 의 모든 `@flow` 파일(410 개) 에 대해 파싱 + 스트리핑이 통과합니다. 회귀 테스트로 영구 보존됩니다.
+
+```bash
+# 직접 검증해 보고 싶다면
+git clone https://github.com/facebook/react-native
+zntc --bundle react-native/Libraries/react-native/index.js --platform=react-native -o /tmp/rn.js
+```
+
+## React Native 와 함께 쓰기
+
+`--platform=react-native` 는 Flow 외에도 다음을 자동으로 활성화합니다.
+
+- 플랫폼 확장자 자동 시도 — `.ios.tsx`, `.ios.ts`, `.ios.jsx`, `.ios.js`, `.native.*`, ...
+- `main-fields` 에 `react-native` prepend
+- Hermes 타겟 (`--target=hermes0.70`) 강제
+- `process.env.NODE_ENV` define
+- Metro 호환 block list (`__tests__/`, iOS/Android 빌드 폴더)
+
+수동으로 세부 설정하려면:
+
+```ts
+defineConfig({
+  flow: true,
+  platform: "react-native",
+  resolveExtensions: [
+    ".ios.tsx", ".ios.ts", ".ios.jsx", ".ios.js",
+    ".native.tsx", ".native.ts", ".native.jsx", ".native.js",
+    ".tsx", ".ts", ".jsx", ".js",
+  ],
+  mainFields: ["react-native", "browser", "module", "main"],
+});
+```
+
+자세한 RN 통합은 [React Native 가이드](/zntc/guides/react-native/) 를, Babel 기반 RN 프로젝트에서 옮겨오는 절차는 [Babel 마이그레이션](/zntc/guides/babel-migration/) 을 참고하세요.
+
+## TypeScript 와 섞어 쓰기
+
+같은 프로젝트에 Flow 파일과 TypeScript 파일이 공존하는 것은 지원합니다 — 파일 단위로 모드가 결정됩니다 (pragma / 확장자 / `--flow` 의 fallback 적용).
+
+같은 **파일** 안에 두 문법을 섞는 것은 지원하지 않습니다 — TypeScript 컴파일러도 동일한 제약입니다.
+
+## 더 읽을거리
+
+- 컨트리뷰터용 설계 문서 — [`docs/FLOW.md`](https://github.com/ohah/zntc/blob/main/docs/FLOW.md): Flow 구현 의사결정, Metro 소스 분석, 미지원 구문 우선순위
+- [React Native 가이드](/zntc/guides/react-native/) — RN 프로젝트 통합 전체 흐름
+- [Babel 마이그레이션](/zntc/guides/babel-migration/) — 기존 Babel + Flow 설정에서 ZNTC 로 옮기기


### PR DESCRIPTION
## Summary

- **`guides/bundler-deep-dive`** (신규, 한/영) — 번들러 6단계 파이프라인 (resolver → graph → linker → tree-shaker → chunker → emitter) 과 사용자 코드에서 마주칠 수 있는 동작 (실행 순서, 변수 rename, CJS↔ESM interop, 코드 스플리팅) 을 "어느 단계에서 결정되는가" 관점으로 정리
- **`guides/flow-support`** (신규, 한/영) — Flow 활성화 방법 (pragma / `.js.flow` / CLI), 지원 구문 전체 (TIER 1+2), 미지원 구문 (component / hook / match), RN 통합
- **사이드바 수정** — 번들러 그룹에 "구조와 동작 원리", React Native 그룹에 "Flow 지원" 항목 추가

## 작성 원칙

내부 설계 문서 (`docs/BUNDLER.md`, `docs/FLOW.md`, `docs/ARCHITECTURE.md`) 의 디테일을 그대로 옮기지 않고 사용자 관점으로 재구성. PR 번호 / 성능 history / 의사결정 ID / 구현 선택지 비교 같은 구현 비하인드는 의도적으로 제외하고, "지원 기능 + 동작 원리 + 한계" 만 노출. 컨트리뷰터는 각 페이지 끝의 "더 읽을거리" 에서 GitHub 의 기존 설계 문서로 안내.

기존 \`tree-shaking.md\` 와 주제 중복 회피 — 이 PR 의 deep-dive 페이지는 트리쉐이킹은 다루지 않고 순수하게 파이프라인 단계별 사용자 가시 동작 위주.

## 변경 파일

- (신규) \`documents/src/content/docs/guides/bundler-deep-dive.md\`
- (신규) \`documents/src/content/docs/en/guides/bundler-deep-dive.md\`
- (신규) \`documents/src/content/docs/guides/flow-support.md\`
- (신규) \`documents/src/content/docs/en/guides/flow-support.md\`
- (수정) \`documents/astro.config.mjs\` — 사이드바 2개 항목 추가

## Test plan

- [x] \`cd documents && bun run build\` 성공 (474 페이지 빌드 + Pagefind 인덱스)
- [x] \`starlightLinksValidator\` 전체 통과 (모든 내부 링크 유효)
- [x] /simplify 검토 — 한/영 일관성, 사용자 피드백 준수, CLI/config/Flow 구문 사실 정확성 모두 OK
- [ ] 머지 후 https://ohah.github.io/zntc/guides/bundler-deep-dive/ 와 /flow-support/ 페이지 렌더링 확인
- [ ] 영문 페이지 (\`/en/guides/...\`) 동일 확인
- [ ] 사이드바에서 새 항목이 올바른 그룹/순서로 노출되는지 확인

## Notes

영문 \`bundler-deep-dive\` 의 "Further reading" 에서는 \`manual-chunks\` 링크를 일부러 빼두었습니다 — 영문 \`manual-chunks.md\` 가 아직 없어 \`starlightLinksValidator\` 가 막기 때문. 한국어판은 한국어 \`manual-chunks.md\` 가 있어 그대로 유지. 영문 \`manual-chunks\` 가 추가되는 시점에 본문도 같이 보강 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)