### PR TITLE
chore(ci): codegen emitter 의 addSourceMapping 누락 정적 audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,11 @@ jobs:
       - name: Audit AST addNode variants (#1797, #1802)
         run: bun scripts/audit_addnode_variants.ts --strict-cosmetic
 
+      # codegen 모든 emitter 가 첫 줄에 `addSourceMapping(node.span)` 발행하는지
+      # 정적 검사. 새 emitter 추가 시 매핑 누락 회귀 (#2982 패턴) 차단 (#2983).
+      - name: Audit codegen sourcemap mapping (#2983)
+        run: bun scripts/audit-codegen-sourcemap.ts
+
   napi:
     name: NAPI Build & Test
     runs-on: ${{ matrix.os }}

--- a/scripts/audit-codegen-sourcemap.ts
+++ b/scripts/audit-codegen-sourcemap.ts
@@ -1,0 +1,120 @@
+#!/usr/bin/env bun
+/**
+ * codegen sourcemap mapping audit (#2983 후속).
+ *
+ * `node_dispatch.emitNode` 가 dispatch 에서 자식 노드별로 호출하는 모든 emitter
+ * 함수가 첫 줄에서 `try self.addSourceMapping(node.span);` 을 발행하는지
+ * 검사. esbuild / oxc / swc 와 동일한 명시 발행 패턴이 깨지면 새 emitter
+ * 추가 시 매핑 누락 회귀 (#2982 같은 패턴) 가 잠복하므로 CI 에서 정적 차단.
+ *
+ * 검사 규칙:
+ *   - `pub fn emit*(self: anytype, node: Node, ...)` 시그니처 매치
+ *   - 본문 첫 5 non-comment, non-blank 줄 안에 `try self.addSourceMapping(node.span);`
+ *     호출이 있는지 확인
+ *   - SKIP_FUNCS 에 명시된 컨테이너 / 위임 / 자체-위치-매핑 emitter 는 제외
+ *
+ * 누락 시 list 출력 + exit 1.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(SCRIPT_DIR, "..");
+const CODEGEN_DIR = join(ROOT, "src", "codegen");
+
+const TARGET_FILES = [
+	"statements.zig",
+	"expressions.zig",
+	"calls.zig",
+	"function_class.zig",
+	"bindings.zig",
+	"modules.zig",
+	"type_runtime.zig",
+];
+
+/**
+ * 매핑 발행 면제 — 컨테이너 (자식이 매핑) 또는 자체적으로 다른 위치 매핑을
+ * 발행하는 위임형 함수.
+ */
+const SKIP_FUNCS = new Map<string, string>([
+	["emitProgram", "container — children carry mappings"],
+	["emitBlock", "container — children carry mappings"],
+	["emitBracedList", "container helper for block_statement / class_body"],
+	["emitSwitch", "container — switch_case children carry mappings"],
+	["emitTry", "container — block / catch / finally children carry mappings"],
+	["emitClassBody", "container — delegates to emitBracedList"],
+	["emitStaticBlock", "container — body carries mappings"],
+	["emitNamespaceIIFE", "delegates to emitNamespaceIIFEInner"],
+	["emitExportSpecifier", "leaf-token mapping at local_node.span (not outer node.span)"],
+]);
+
+/** `pub fn emit<Name>(self: anytype, node: Node, ...)` 시그니처 매치. */
+const EMITTER_SIGNATURE = /^pub fn (emit\w+)\(self:\s*anytype,\s*node:\s*Node[^)]*\)\s*[^{]*\{/;
+
+const REQUIRED_CALL = "try self.addSourceMapping(node.span);";
+
+interface Finding {
+	file: string;
+	line: number;
+	name: string;
+}
+
+function checkFunctionBody(lines: string[], startIdx: number): boolean {
+	// 본문 첫 5 non-comment, non-blank 줄 검사.
+	let inspected = 0;
+	for (let i = startIdx; i < lines.length && inspected < 5; i++) {
+		const line = lines[i].trim();
+		if (line.length === 0) continue;
+		if (line.startsWith("//")) continue;
+		if (line === "}") return false; // 함수 끝 도달 — 발견 못 함
+		if (line.includes(REQUIRED_CALL)) return true;
+		inspected++;
+	}
+	return false;
+}
+
+function auditFile(absPath: string): Finding[] {
+	const text = readFileSync(absPath, "utf-8");
+	const lines = text.split("\n");
+	const findings: Finding[] = [];
+
+	for (let i = 0; i < lines.length; i++) {
+		const m = lines[i].match(EMITTER_SIGNATURE);
+		if (!m) continue;
+		const name = m[1];
+		if (SKIP_FUNCS.has(name)) continue;
+		if (!checkFunctionBody(lines, i + 1)) {
+			findings.push({
+				file: relative(ROOT, absPath),
+				line: i + 1,
+				name,
+			});
+		}
+	}
+	return findings;
+}
+
+function main(): void {
+	const allFindings: Finding[] = [];
+	for (const file of TARGET_FILES) {
+		const abs = join(CODEGEN_DIR, file);
+		allFindings.push(...auditFile(abs));
+	}
+
+	if (allFindings.length === 0) {
+		console.log(`✓ codegen sourcemap audit: 모든 emitter 가 \`${REQUIRED_CALL}\` 를 첫 줄에 발행 (총 ${TARGET_FILES.length} 파일)`);
+		process.exit(0);
+	}
+
+	console.error("✗ codegen sourcemap audit: 매핑 발행 누락 emitter");
+	for (const f of allFindings) {
+		console.error(`  ${f.file}:${f.line}  pub fn ${f.name}`);
+	}
+	console.error("");
+	console.error(`각 emitter 함수 첫 줄에 \`${REQUIRED_CALL}\` 추가 필요.`);
+	console.error(`컨테이너 / 위임형 emitter 라면 scripts/audit-codegen-sourcemap.ts 의 SKIP_FUNCS 에 사유와 함께 추가.`);
+	process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

\`#2984\` (sourcemap mapping 명시 발행 통일) 의 calling convention 을 CI 로 정착시키는 audit script. \`node_dispatch\` 가 자동 발행을 안 하므로 새 emitter 추가 시 매핑을 첫 줄에 발행하지 않으면 회귀 (\`#2982\` 패턴) 가 잠복 — 이걸 PR 단위에서 정적으로 catch.

Closes #2983

## 검사 규칙

- 대상: \`src/codegen/{statements,expressions,calls,function_class,bindings,modules,type_runtime}.zig\` 의 \`pub fn emit*(self: anytype, node: Node, ...)\` 시그니처
- 통과 조건: 본문 첫 5 non-comment / non-blank 줄 안에 \`try self.addSourceMapping(node.span);\` 호출
- 면제 (SKIP_FUNCS):
  - 컨테이너 (자식이 매핑): \`emitProgram\`, \`emitBlock\`, \`emitBracedList\`, \`emitSwitch\`, \`emitTry\`, \`emitClassBody\`, \`emitStaticBlock\`
  - 위임 (Inner 가 발행): \`emitNamespaceIIFE\`
  - 다른 위치 매핑: \`emitExportSpecifier\` (\`local_node.span\` leaf token)

## 사용

\`\`\`sh
bun scripts/audit-codegen-sourcemap.ts
\`\`\`

통과:
\`\`\`
✓ codegen sourcemap audit: 모든 emitter 가 \`try self.addSourceMapping(node.span);\` 를 첫 줄에 발행 (총 7 파일)
\`\`\`

누락 시:
\`\`\`
✗ codegen sourcemap audit: 매핑 발행 누락 emitter
  src/codegen/expressions.zig:9  pub fn emitUnary

각 emitter 함수 첫 줄에 \`try self.addSourceMapping(node.span);\` 추가 필요.
컨테이너 / 위임형 emitter 라면 scripts/audit-codegen-sourcemap.ts 의 SKIP_FUNCS 에 사유와 함께 추가.
\`\`\`

## CI 통합

\`.github/workflows/ci.yml\` 의 \`lint\` job 에 추가 — \`audit_addnode_variants.ts\` (\`#1797\` 정적 audit) 다음 step.

## 검증

- [x] 현 main 통과 (모든 emitter 매핑 발행 중)
- [x] negative test: \`emitUnary\` 의 매핑 임시 제거 시 audit fail (\`expressions.zig:9 pub fn emitUnary\`) 확인 후 복원

🤖 Generated with [Claude Code](https://claude.com/claude-code)