### PR TITLE
feat(docs): bundling/plugins/config/transpile 가이드 사용자 함정·한계 보강

### DIFF
--- a/documents/src/content/docs/en/guides/bundling.md
+++ b/documents/src/content/docs/en/guides/bundling.md
@@ -169,6 +169,34 @@ zntc --bundle entry.ts -o bundle.js --analyze
 
 Upload `meta.json` to [Metafile Analyze](/zntc/analyze/) to inspect output sizes, input sizes, and the import graph.
 
+### Which metric to look at, and what to do about it
+
+| Metric | What it tells you | Action |
+|---|---|---|
+| **bytesInOutput per chunk** | Chunk size distribution | If one chunk is bloated, try `--splitting` or `manualChunks` |
+| **inputs[].imports** | Which module imports what | Surface unintended deep imports (e.g. all of `lodash`) — switch to named imports |
+| **inputs[].bytes vs bytesInOutput** | Input vs output size ratio | Ratio close to 1 means tree-shaking barely fired — check `sideEffects` / `@__PURE__` |
+| **outputs[].imports** | Inter-chunk dependency graph | Decide preload/prefetch priority |
+| **entry pointer chain** | Hops from entry to first used module | Candidates for shortening initial-load critical path |
+
+## `allowOverwrite`
+
+By default ZNTC refuses output paths that would overwrite an input file. Allow it explicitly when you really intend an in-place transpile.
+
+```bash
+zntc --bundle src/index.ts -o src/index.ts --allow-overwrite
+```
+
+```ts
+defineConfig({
+  entryPoints: ["src/index.ts"],
+  outfile: "src/index.ts",
+  allowOverwrite: true,
+});
+```
+
+Note: with sourcemaps enabled, overwriting in place causes the second build's sourcemap reference to point at the first build's output. Prefer a separate output directory whenever possible.
+
 ## Minify
 
 ```bash
@@ -327,3 +355,67 @@ defineConfig({
 zntc --bundle entry.ts -o bundle.js --watch
 zntc --bundle entry.ts -o bundle.js --watch-json  # NDJSON event output
 ```
+
+## Debugging — limits worth knowing
+
+The cases you most commonly trip over when bundle output isn't what you expect.
+
+### CJS wrapper modules don't tree-shake
+
+```ts
+// my-lib (CJS)
+const featureA = require('./feature-a');
+const featureB = require('./feature-b');
+module.exports = { featureA, featureB };
+```
+
+```ts
+// entry.ts
+import { featureA } from 'my-lib';   // featureB is also bundled
+```
+
+A `require_X()` call counts as a side effect, so the entire CJS wrap module is preserved even when the named import is unused. Either migrate the library to ESM or import the deep path directly:
+
+```ts
+import featureA from 'my-lib/feature-a';  // only what you need
+```
+
+JSON modules are converted to ESM ASTs and *do* tree-shake at the named-export level.
+
+### Variables that shadow globals get auto-renamed
+
+```ts
+const document = createVirtualDocument();
+document.title = "Hi";
+```
+
+In the bundle this becomes `document$1` or similar — automatic protection against TDZ and shadowing accidents. Sourcemaps preserve the original names. Which names are protected depends on the target environment (`browser` / `node` / `react-native`).
+
+### Namespace re-export hurts tree-shaking precision
+
+```ts
+// barrel.ts
+import * as utils from './utils';
+export { utils };
+```
+
+This pattern marks every export of `utils` as used. Prefer explicit re-exports when you can:
+
+```ts
+export { foo, bar } from './utils';
+```
+
+### `--define` values must be JavaScript literals
+
+```bash
+# ✗ Wrong — admin becomes an identifier, producing unintended code
+zntc --bundle entry.ts --define:USERNAME=admin
+
+# ✓ Right — quote it so it becomes a string literal
+zntc --bundle entry.ts --define:USERNAME='"admin"'
+
+# ✓ Numbers / booleans / null are literals as-is
+zntc --bundle entry.ts --define:DEBUG=false --define:MAX=100
+```
+
+Shell quoting gotcha: in bash/zsh you need to wrap the double quotes in single quotes to keep them.

--- a/documents/src/content/docs/en/guides/config-file.md
+++ b/documents/src/content/docs/en/guides/config-file.md
@@ -35,6 +35,86 @@ ZNTC merges options in this order (**later wins**):
 
 You can override config values from the CLI but not the other way around. To temporarily disable the config, rename or delete the file.
 
+## Advanced merge rules
+
+Most options follow simple "higher wins", but a few have asymmetric/special behaviors that bite users.
+
+### Boolean options merge asymmetrically
+
+A boolean flag like `--minify` cannot distinguish between "not passed" and "passed as false". Hence the asymmetry below.
+
+```json
+// zntc.config.json
+{ "minify": true, "sourcesContent": false }
+```
+
+```bash
+zntc --bundle entry.ts            # CLI passes neither --minify nor --sources-content
+# → minify=true            (default=false, so config's true applies)
+# → sourcesContent=false   (default=true, so config's false applies)
+```
+
+Rule: **only config values opposite to the default actually take effect.**
+
+| Default | config=true | config=false |
+|---|---|---|
+| `false` | ✅ applied | (no-op — already false) |
+| `true` | (no-op — already true) | ✅ applied |
+
+For precise control across CLI and config, use the functional config form's `command`/`mode` branching.
+
+```ts
+defineConfig(({ command, mode }) => ({
+  minify: command === 'bundle' && mode === 'production',
+}));
+```
+
+### `plugins` is concat (unlike other arrays)
+
+```ts
+// zntc.config.ts
+defineConfig({ plugins: [a, b] });
+```
+
+```bash
+zntc --bundle --plugin ./c.js --plugin ./d.js entry.ts
+# → plugins = [a, b, c, d]   (config + CLI concat)
+```
+
+Other array options (`external`, `inject`, `drop`, ...) follow "**CLI replaces config when non-empty**", but `plugins` is concatenated. Since order affects hook results (see first-match / chaining policy in the [Plugins guide](/zntc/en/guides/plugins/)), be intentional with registration order.
+
+### `--tsconfig-raw` for inline JSON
+
+You can pass tsconfig contents as a raw JSON string on the CLI — bypassing both `-p path` and auto-discovery.
+
+```bash
+zntc --bundle entry.ts --tsconfig-raw='{"compilerOptions":{"jsx":"preserve"}}'
+```
+
+Useful in CI / Docker where you'd rather not write a tsconfig file just to flip an option. Priority: `--tsconfig-raw` > `-p path` > auto-discovery.
+
+### tsconfig + `zntc.config` + CLI 3-way (e.g. `jsx`)
+
+If the same option is defined in all three, priority resolves "highest wins".
+
+```json
+// tsconfig.json
+{ "compilerOptions": { "jsx": "preserve" } }
+```
+
+```ts
+// zntc.config.ts
+export default defineConfig({ jsx: 'automatic' });
+```
+
+```bash
+zntc --bundle --jsx=transform App.tsx
+# → jsx=transform   (CLI wins)
+# → config's automatic and tsconfig's preserve are both ignored
+```
+
+If only `zntc.config` is present (no CLI flag), `automatic` applies. If even that is missing, tsconfig's `preserve` is the fallback.
+
 ## Editor setup
 
 ### VSCode

--- a/documents/src/content/docs/en/guides/plugins.md
+++ b/documents/src/content/docs/en/guides/plugins.md
@@ -35,7 +35,53 @@ write
 closeBundle
 ```
 
-In `watch()`, the same order runs for the initial build and every rebuild. `onReady` or `onRebuild` runs after `buildEnd`. When multiple plugins implement the same hook, they run in registration order.
+In `watch()`, the same order runs for the initial build and every rebuild. `onReady` or `onRebuild` runs after `buildEnd`.
+
+### Per-hook selection policy with multiple plugins
+
+When two or more plugins register the same hook, the way they combine differs by hook.
+
+| Hook | Policy | Notes |
+|---|---|---|
+| `resolveId` / `onResolve` | **first-match** | First non-null wins. Subsequent plugins aren't called |
+| `load` / `onLoad` | **first-match** | First non-null wins |
+| `transform` / `onTransform` | **chaining** | All called in registration order. Each hook's output is the next hook's input |
+| `renderChunk` | **chaining** | All called in registration order (chunk-code transforms) |
+| `generateBundle` | **all-run, sequential** | All run; return values ignored (observation only) |
+| `buildStart` / `buildEnd` / `closeBundle` | **all-run, sequential** | All run; lifecycle signals |
+
+**When plugin order changes the result:**
+- `resolveId` / `load` — once an earlier plugin matches, later plugins don't get a chance. Place virtual-module/alias handlers before the default resolver.
+- `transform` — chain order matters. If env-substitution → minify is swapped, the result differs.
+
+**Watch-mode lifecycle repetition:**
+
+```text
+Initial build: buildStart → resolveId/load/transform → buildEnd → write → onReady → closeBundle
+On file change: buildStart → ... → buildEnd → onRebuild → closeBundle
+```
+
+`buildStart` / `closeBundle` fire **on every rebuild**. If you need to reuse a long-lived resource (DB/socket), initialize it **outside the build** (at module load) — not in `buildStart`.
+
+**Errors in `buildEnd` / `closeBundle` are swallowed:**
+
+Throwing from these two hooks does not affect the build/rebuild result (post-processing failures must not mask the user's build). To surface failures, use an explicit flag/log:
+
+```typescript
+let lastBuildOk = true;
+const myPlugin = {
+  name: 'after-build',
+  buildEnd(err) {
+    if (err) { lastBuildOk = false; return; }
+    try {
+      runPostProcess();   // failure is swallowed
+    } catch (e) {
+      lastBuildOk = false;
+      console.error('[after-build] failed:', e);
+    }
+  },
+};
+```
 
 ## Config File
 

--- a/documents/src/content/docs/en/guides/transpile.md
+++ b/documents/src/content/docs/en/guides/transpile.md
@@ -143,9 +143,52 @@ zntc --ascii-only app.ts  # Escape non-ASCII to \uXXXX
 zntc --define:DEBUG=false --define:VERSION='"1.0.0"' app.ts
 ```
 
-## Drop
+Values must be **JavaScript literals**. Watch out for missing quotes.
 
 ```bash
-zntc --drop=console app.ts     # Remove console.* calls
-zntc --drop=debugger app.ts    # Remove debugger statements
+# ✗ Wrong — admin becomes an identifier, producing unintended code
+zntc --define:USERNAME=admin app.ts
+
+# ✓ Right — quote it so it becomes a string literal
+zntc --define:USERNAME='"admin"' app.ts
+
+# ✓ Numbers / booleans / null are literals as-is
+zntc --define:DEBUG=false --define:MAX=100 --define:USER=null app.ts
+
+# ✓ Object / array work too if they're valid JSON literals
+zntc --define:ENV='{"mode":"prod"}' app.ts
 ```
+
+Shell quoting gotcha: in bash/zsh you need to wrap the double quotes in single quotes to keep them.
+
+## Drop
+
+Three independent removal options that can be combined.
+
+```bash
+# Remove console.* calls
+zntc --drop=console app.ts
+
+# Remove debugger statements
+zntc --drop=debugger app.ts
+
+# Remove labeled blocks entirely — comma-separated labels
+zntc --drop-labels=DEV,TEST app.ts
+
+# All three at once
+zntc --drop=console --drop=debugger --drop-labels=DEV,TEST app.ts
+```
+
+`--drop-labels` example:
+
+```ts
+// Source
+DEV: {
+  console.log("debug only");
+  attachDevtools();
+}
+
+// --drop-labels=DEV → the whole block disappears in the output
+```
+
+Wrap dev-only debug code in a label and you can strip it all in one switch for production builds.

--- a/documents/src/content/docs/guides/bundling.md
+++ b/documents/src/content/docs/guides/bundling.md
@@ -169,6 +169,34 @@ zntc --bundle entry.ts -o bundle.js --analyze
 
 `meta.json`은 [Metafile 분석](/zntc/analyze/) 페이지에 업로드해 output 크기, input 크기, import graph를 확인할 수 있습니다.
 
+### 어떤 메트릭을 보고 무엇을 결정하나
+
+| 메트릭 | 무엇을 보는가 | 행동 |
+|---|---|---|
+| **bytesInOutput per chunk** | 청크 사이즈 분포 | 한 청크가 비대해지면 `--splitting` 또는 `manualChunks` |
+| **inputs[].imports** | 어떤 모듈이 어디서 import 됐는지 | 의도치 않은 deep import (예: `lodash` 전체) → named import 로 변경 |
+| **inputs[].bytes vs bytesInOutput** | 입력 vs 출력 크기 비율 | 비율이 1 에 가까우면 트리쉐이킹이 거의 없음 — `sideEffects` / `@__PURE__` 검토 |
+| **outputs[].imports** | 청크 간 의존 관계 | preload/prefetch 우선순위 결정 |
+| **entry pointer chain** | entry → 첫 사용 모듈까지 거리 | 초기 로딩 critical path 단축 후보 |
+
+## `allowOverwrite`
+
+기본적으로 입력 파일을 덮어쓰는 출력 경로는 안전을 위해 거부됩니다. `in-place` 트랜스파일이 의도라면 명시 허용하세요.
+
+```bash
+zntc --bundle src/index.ts -o src/index.ts --allow-overwrite
+```
+
+```ts
+defineConfig({
+  entryPoints: ["src/index.ts"],
+  outfile: "src/index.ts",
+  allowOverwrite: true,
+});
+```
+
+소스맵을 켠 채 같은 경로에 덮어쓰면 두 번째 빌드의 sourcemap reference 가 첫 빌드의 출력을 가리키게 되므로 주의 — 가능하면 별도 출력 디렉토리를 권장합니다.
+
 ## Minify
 
 ```bash
@@ -327,3 +355,67 @@ defineConfig({
 zntc --bundle entry.ts -o bundle.js --watch
 zntc --bundle entry.ts -o bundle.js --watch-json  # NDJSON 이벤트 출력
 ```
+
+## 디버깅 — 알아두면 좋은 한계
+
+번들 결과가 의도와 다르게 나올 때 가장 자주 부딪히는 케이스들입니다.
+
+### CJS 래퍼 모듈은 트리쉐이킹되지 않음
+
+```ts
+// my-lib (CJS)
+const featureA = require('./feature-a');
+const featureB = require('./feature-b');
+module.exports = { featureA, featureB };
+```
+
+```ts
+// entry.ts
+import { featureA } from 'my-lib';   // featureB 도 번들에 포함됨
+```
+
+`require_X()` 호출은 사이드이펙트로 간주되므로, 미사용 named import 라도 CJS wrap 모듈 전체가 보존됩니다. 가능하면 라이브러리를 ESM 으로 마이그레이션하거나, 직접 deep import 하세요.
+
+```ts
+import featureA from 'my-lib/feature-a';  // 필요한 것만
+```
+
+JSON 모듈은 ESM AST 로 변환되어 named export 단위 트리쉐이킹이 동작합니다.
+
+### 글로벌과 같은 이름의 변수는 자동 rename
+
+```ts
+const document = createVirtualDocument();
+document.title = "Hi";
+```
+
+번들 결과에서 `document` → `document$1` 처럼 rename 됩니다 — TDZ 또는 shadowing 사고를 피하기 위한 자동 보호. sourcemap 으로 원본 이름은 그대로 추적됩니다. 어떤 이름이 보호 대상인지는 타겟 환경(`browser` / `node` / `react-native`) 에 따라 다릅니다.
+
+### Namespace re-export 는 트리쉐이킹 정밀도가 낮아짐
+
+```ts
+// barrel.ts
+import * as utils from './utils';
+export { utils };
+```
+
+이 패턴은 `utils` 의 모든 export 가 사용된 것으로 간주됩니다. 가능하면 명시적 re-export 로 바꾸세요:
+
+```ts
+export { foo, bar } from './utils';
+```
+
+### `--define` 값은 JavaScript 리터럴이어야 함
+
+```bash
+# ✗ 틀림 — admin 이 식별자로 처리되어 의도와 다른 코드가 생성됨
+zntc --bundle entry.ts --define:USERNAME=admin
+
+# ✓ 맞음 — 큰따옴표를 포함해 문자열 리터럴
+zntc --bundle entry.ts --define:USERNAME='"admin"'
+
+# ✓ 숫자/불리언/null 은 그대로 리터럴
+zntc --bundle entry.ts --define:DEBUG=false --define:MAX=100
+```
+
+쉘 quoting 함정 — bash/zsh 에서 큰따옴표를 보존하려면 작은따옴표로 감싸야 합니다.

--- a/documents/src/content/docs/guides/config-file.md
+++ b/documents/src/content/docs/guides/config-file.md
@@ -35,6 +35,86 @@ ZNTC는 다음 순서로 옵션을 병합합니다 (**뒤가 우선**):
 
 CLI 인자로 `zntc.config.json`의 값을 덮어쓸 수 있지만, 반대는 불가능합니다. config 파일을 일시 비활성화하려면 파일을 이름 변경하거나 삭제하세요.
 
+## 고급 머지 규칙
+
+대부분의 옵션은 단순히 "위가 이긴다" 지만, 몇 가지는 사용자가 자주 함정에 빠지는 비대칭/특수 동작이 있습니다.
+
+### Boolean 옵션의 비대칭 머지
+
+`--minify` 같은 boolean flag 는 CLI 가 "안 줬을 때" 와 "false 로 줬을 때" 를 구분하지 못합니다. 그래서 다음 비대칭이 적용됩니다.
+
+```json
+// zntc.config.json
+{ "minify": true, "sourcesContent": false }
+```
+
+```bash
+zntc --bundle entry.ts            # CLI 에 --minify, --sources-content 둘 다 안 줌
+# → minify=true            (default=false 이므로 config 의 true 적용)
+# → sourcesContent=false   (default=true 이므로 config 의 false 적용)
+```
+
+규칙: **default 와 반대 방향으로 설정된 config 값만 효과를 가집니다.**
+
+| Default | config=true | config=false |
+|---|---|---|
+| `false` | ✅ 적용됨 | (무시 — 이미 false) |
+| `true` | (무시 — 이미 true) | ✅ 적용됨 |
+
+CLI 와 config 모두 정밀하게 제어하고 싶다면 함수형 config 의 `command`/`mode` 분기를 사용하세요.
+
+```ts
+defineConfig(({ command, mode }) => ({
+  minify: command === 'bundle' && mode === 'production',
+}));
+```
+
+### `plugins` 는 concat (다른 배열과 다름)
+
+```ts
+// zntc.config.ts
+defineConfig({ plugins: [a, b] });
+```
+
+```bash
+zntc --bundle --plugin ./c.js --plugin ./d.js entry.ts
+# → plugins = [a, b, c, d]   (config + CLI concat)
+```
+
+다른 배열 옵션 (`external`, `inject`, `drop`, ...) 은 **CLI 가 비어있지 않으면 CLI 만 사용** (덮어쓰기) 인 반면, `plugins` 는 합쳐집니다. 순서가 hook 결과에 영향을 주므로 ([플러그인 가이드](/zntc/guides/plugins/) 의 first-match / chaining 정책 참고) 등록 순서를 의식해서 작성하세요.
+
+### `--tsconfig-raw` JSON 직접 주입
+
+CLI 에서 tsconfig 내용을 JSON 문자열로 직접 전달할 수 있습니다 — 파일 기반 `-p path` 와 자동 탐색을 모두 우회합니다.
+
+```bash
+zntc --bundle entry.ts --tsconfig-raw='{"compilerOptions":{"jsx":"preserve"}}'
+```
+
+CI / Docker 환경에서 tsconfig 파일을 새로 만들지 않고 동적으로 옵션을 주입할 때 유용합니다. 우선순위는 `--tsconfig-raw` > `-p path` > 자동 탐색 순.
+
+### tsconfig + `zntc.config` + CLI 3-way (`jsx` 예시)
+
+같은 옵션이 세 곳에 정의되면 우선순위에 따라 가장 위가 이깁니다.
+
+```json
+// tsconfig.json
+{ "compilerOptions": { "jsx": "preserve" } }
+```
+
+```ts
+// zntc.config.ts
+export default defineConfig({ jsx: 'automatic' });
+```
+
+```bash
+zntc --bundle --jsx=transform App.tsx
+# → jsx=transform   (CLI 우선)
+# → config 의 automatic, tsconfig 의 preserve 둘 다 무시
+```
+
+`zntc.config` 만 있고 CLI 가 없으면 `automatic` 이 적용되고, `zntc.config` 도 없으면 tsconfig 의 `preserve` 가 fallback 됩니다.
+
 ## $schema 에디터 설정
 
 ### VSCode

--- a/documents/src/content/docs/guides/plugins.md
+++ b/documents/src/content/docs/guides/plugins.md
@@ -35,7 +35,53 @@ write
 closeBundle
 ```
 
-`watch()`에서는 같은 순서가 초기 build와 매 rebuild마다 반복되고, `buildEnd` 이후 `onReady` 또는 `onRebuild` callback이 실행됩니다. 여러 플러그인이 같은 hook을 구현하면 등록 순서대로 처리됩니다.
+`watch()`에서는 같은 순서가 초기 build와 매 rebuild마다 반복되고, `buildEnd` 이후 `onReady` 또는 `onRebuild` callback이 실행됩니다.
+
+### 다중 플러그인일 때 hook 별 선택 정책
+
+두 개 이상의 플러그인이 같은 hook 을 등록하면 어떻게 합쳐지는지가 hook 마다 다릅니다.
+
+| Hook | 정책 | 설명 |
+|---|---|---|
+| `resolveId` / `onResolve` | **first-match** | 첫 non-null 반환이 우승. 뒤 플러그인은 호출되지 않음 |
+| `load` / `onLoad` | **first-match** | 첫 non-null 반환이 우승 |
+| `transform` / `onTransform` | **chaining** | 등록 순서대로 모두 호출. 앞 hook 의 출력 → 뒤 hook 의 입력 |
+| `renderChunk` | **chaining** | 등록 순서대로 모두 호출 (chunk code 변환) |
+| `generateBundle` | **all-run, sequential** | 모두 실행 (반환값 무시 — observation only) |
+| `buildStart` / `buildEnd` / `closeBundle` | **all-run, sequential** | 모두 실행. lifecycle 신호 |
+
+**플러그인 순서가 결과에 영향을 주는 경우:**
+- `resolveId` / `load` — 앞에 등록된 플러그인이 매칭되면 뒤 플러그인은 기회 없음. virtual module / alias 처리는 일반 resolver 보다 앞에 두어야 함.
+- `transform` — 변환 chain 의 순서. 예: ENV 치환 → 코드 minify 순서가 뒤바뀌면 결과가 달라짐.
+
+**watch 모드 lifecycle 반복:**
+
+```text
+초기 build:    buildStart → resolveId/load/transform → buildEnd → write → onReady → closeBundle
+파일 변경 시:  buildStart → ... → buildEnd → onRebuild → closeBundle
+```
+
+매 rebuild 마다 `buildStart` / `closeBundle` 이 다시 호출되므로, **연결 재사용 (DB/소켓 등) 이 필요하면 build 외부 (모듈 로드 시점) 에서 한 번만 초기화** 하세요.
+
+**`buildEnd` / `closeBundle` 의 에러 swallow:**
+
+이 두 hook 에서 플러그인이 throw 해도 build/rebuild 결과는 정상 반환됩니다 (후처리 실패가 사용자 빌드를 가리지 않도록). 실패 감지가 필요하면 별도 flag/log 로 노출하세요:
+
+```typescript
+let lastBuildOk = true;
+const myPlugin = {
+  name: 'after-build',
+  buildEnd(err) {
+    if (err) { lastBuildOk = false; return; }
+    try {
+      runPostProcess();   // 실패해도 swallow 됨
+    } catch (e) {
+      lastBuildOk = false;
+      console.error('[after-build] failed:', e);
+    }
+  },
+};
+```
 
 ## NAPI 플러그인
 

--- a/documents/src/content/docs/guides/transpile.md
+++ b/documents/src/content/docs/guides/transpile.md
@@ -143,9 +143,52 @@ zntc --ascii-only app.ts  # non-ASCII → \uXXXX 이스케이프
 zntc --define:DEBUG=false --define:VERSION='"1.0.0"' app.ts
 ```
 
-## Drop
+값은 **JavaScript 리터럴** 이어야 합니다. 큰따옴표 빠뜨리는 함정에 주의.
 
 ```bash
-zntc --drop=console app.ts     # console.* 제거
-zntc --drop=debugger app.ts    # debugger 문 제거
+# ✗ 틀림 — admin 이 식별자로 처리되어 의도와 다른 코드 생성
+zntc --define:USERNAME=admin app.ts
+
+# ✓ 맞음 — 큰따옴표 포함해 문자열 리터럴
+zntc --define:USERNAME='"admin"' app.ts
+
+# ✓ 숫자 / 불리언 / null 은 그대로 리터럴
+zntc --define:DEBUG=false --define:MAX=100 --define:USER=null app.ts
+
+# ✓ 객체 / 배열도 JSON 리터럴이면 OK
+zntc --define:ENV='{"mode":"prod"}' app.ts
 ```
+
+쉘 quoting 함정 — bash/zsh 에서 큰따옴표를 보존하려면 작은따옴표로 감싸야 합니다.
+
+## Drop
+
+세 가지 제거 옵션이 독립적으로 동작 — 동시에 사용 가능합니다.
+
+```bash
+# console.* 호출 제거
+zntc --drop=console app.ts
+
+# debugger 문 제거
+zntc --drop=debugger app.ts
+
+# labeled block 통째로 제거 — 쉼표로 여러 라벨 지정
+zntc --drop-labels=DEV,TEST app.ts
+
+# 셋 다 동시에
+zntc --drop=console --drop=debugger --drop-labels=DEV,TEST app.ts
+```
+
+`--drop-labels` 예시:
+
+```ts
+// 원본
+DEV: {
+  console.log("debug only");
+  attachDevtools();
+}
+
+// --drop-labels=DEV → 위 블록 전체가 출력에서 사라짐
+```
+
+production 빌드 전용 디버그 코드를 라벨로 감싸면 한 번에 제거할 수 있습니다.


### PR DESCRIPTION
## Summary

기존 4개 사용자 가이드에 자주 마주치는 동작/함정 섹션을 추가. 새 페이지 X — 기존 페이지 안에 사용자 관점 보강만.

| 페이지 | 추가 섹션 |
|---|---|
| `bundling.md` | "어떤 메트릭을 보고 무엇을 결정하나" (metafile 5행 표) / "\`allowOverwrite\`" / "디버깅 — 알아두면 좋은 한계" (CJS wrap, 글로벌 충돌, namespace barrel, --define 함정) |
| `plugins.md` | "다중 플러그인일 때 hook 별 선택 정책" (first-match / chaining / all-run 표, watch lifecycle 반복, buildEnd swallow) |
| `config-file.md` | "고급 머지 규칙" (boolean 비대칭, plugins concat, --tsconfig-raw, jsx 3-way 우선순위) |
| `transpile.md` | Define (리터럴 함정 + JSON 객체) / Drop (drop-labels 신규 안내) |

## 작성 원칙

그룹 B PR (#2985) 과 동일 — 사용자 가이드라인에 맞춰 PR 번호 / 성능 history / D 번호 / 구현 선택지 비교는 본문에 넣지 않음. \"지원 기능 + 동작 원리 + 한계\" 만.

## 변경 파일

8 파일 수정, 528 줄 추가, 6 줄 변경. 새 파일 없음, 사이드바 변경 없음.

- \`documents/src/content/docs/guides/{bundling,plugins,config-file,transpile}.md\`
- \`documents/src/content/docs/en/guides/{bundling,plugins,config-file,transpile}.md\`

## Test plan

- [x] \`cd documents && bun run build\` 성공 (470 페이지)
- [x] \`starlightLinksValidator\` 전체 통과
- [x] /simplify 검토 — 한/영 일관성 OK / 사용자 피드백 준수 OK / 사실 정확성 9/10 OK + 1건 fix (define 함정 표현 정확도 개선)
- [ ] 머지 후 https://ohah.github.io/zntc/guides/{bundling,plugins,config-file,transpile}/ 4개 페이지에서 새 섹션 렌더링 확인
- [ ] 영문 페이지도 동일 확인

## Notes

- 그룹 B PR (#2985) 과 독립 — 겹치는 파일 없음. 머지 순서 무관.
- 다음 그룹 (C: hmr-protocol + testing-guide 신규 페이지) 은 별도 PR 로 진행 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)