### PR TITLE
feat(docs): dev-server 가이드에 import.meta.hot HMR API 섹션 추가

### DIFF
--- a/documents/src/content/docs/en/guides/dev-server.md
+++ b/documents/src/content/docs/en/guides/dev-server.md
@@ -30,6 +30,134 @@ curl -X POST http://localhost:12300/mcp \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 ```
 
+## HMR — `import.meta.hot` API
+
+`zntc --serve` pushes only changed modules to the client and re-runs them per module. Your code uses `import.meta.hot` to declare which modules are hot boundaries and what to do when an update arrives.
+
+ZNTC's `import.meta.hot` is **Vite-compatible**. Existing Vite plugins / code mostly carries over.
+
+### Basic usage
+
+```ts
+// src/store.ts
+export const store = createStore();
+
+if (import.meta.hot) {
+  // Mark this module as a hot boundary
+  import.meta.hot.accept((newModule) => {
+    if (newModule) {
+      // newModule.store is the new instance
+      replaceStore(newModule.store);
+    }
+  });
+}
+```
+
+The whole `import.meta.hot` block is removed automatically in **production builds** (only truthy in dev server).
+
+### Accepting dependency changes
+
+```ts
+// Self-update
+import.meta.hot.accept((newSelf) => { ... });
+
+// A specific dep
+import.meta.hot.accept('./logger', (newLogger) => { ... });
+
+// Multiple deps at once
+import.meta.hot.accept(['./a', './b'], ([newA, newB]) => { ... });
+```
+
+### Cleanup — `dispose`
+
+Called right before the module is replaced. Use it to clean up timers / listeners / sockets:
+
+```ts
+const id = setInterval(tick, 1000);
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    clearInterval(id);
+  });
+}
+```
+
+### Carrying state — `hot.data`
+
+Whatever you put on the object that `dispose` receives is readable from the new module via `import.meta.hot.data` — i.e. state handed across module replacements.
+
+```ts
+let count = import.meta.hot?.data.count ?? 0;
+
+if (import.meta.hot) {
+  import.meta.hot.dispose((data) => {
+    data.count = count;        // pass to the next module instance
+  });
+}
+```
+
+### Forcing a full reload — `invalidate`
+
+When you receive an update but can't apply it safely:
+
+```ts
+if (import.meta.hot) {
+  import.meta.hot.accept((newModule) => {
+    if (!canSafelyApply(newModule)) {
+      import.meta.hot.invalidate();   // full page reload
+    }
+  });
+}
+```
+
+In browsers this calls `location.reload()`. In React Native, `DevSettings.reload()`.
+
+### React Fast Refresh
+
+If a `.tsx` / `.jsx` file's exports are **all React components**, ZNTC treats it as a hot boundary automatically — you don't need to write `import.meta.hot.accept` yourself. Component functions, `forwardRef`, `memo`, and `lazy` count as components.
+
+```tsx
+// Auto Fast Refresh — no explicit hot code needed
+export function Button({ children }) {
+  return <button>{children}</button>;
+}
+```
+
+The auto boundary does NOT trigger (and a **full reload** happens) if:
+
+- A component and a non-component value are **exported together** — e.g. `export const config = {...}; export function App() {}`
+- The default export is an anonymous arrow (`export default () => <div />`) — no displayName
+- A component reads module-scoped state for `useState` initial values (state can be lost)
+
+Multiple component updates are batched into a single React refresh cycle with a 50 ms debounce.
+
+### File-change detection — watcher
+
+| OS | Mechanism |
+|---|---|
+| macOS | kqueue |
+| Linux | inotify |
+| Windows | ReadDirectoryChangesW |
+
+In most environments OS events fire instantly. The following environments have unreliable OS events and may drop changes:
+
+- Docker volume mounts (host → container)
+- Network filesystems like NFS / SMB
+- Windows WSL1 (WSL2 is fine)
+
+ZNTC does not currently expose a polling-fallback flag. If changes don't propagate in those environments, force a browser reload manually. Polling fallback is planned for a future release.
+
+### Debugging — when updates don't arrive
+
+| Symptom | Suspect |
+|---|---|
+| Saving the file doesn't refresh the client | watcher (consider polling fallback above) or missing hot boundary (no full reload either) |
+| Full reload happens repeatedly | Mixed exports, or no module along the dep chain calls `accept` |
+| Component state resets every time | React Fast Refresh boundary broke — check for anonymous default export or mixed exports |
+| Two instances coexist after update | Missing `dispose` — clean up timers/listeners |
+
+Subscribe to `/sse/events` to see whether the watcher caught the change (`watch_change` event) and whether the build succeeded (`bundle_build_done`).
+
 ## SSE event stream
 
 ### `GET /sse/events`

--- a/documents/src/content/docs/guides/dev-server.md
+++ b/documents/src/content/docs/guides/dev-server.md
@@ -30,6 +30,134 @@ curl -X POST http://localhost:12300/mcp \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 ```
 
+## HMR — `import.meta.hot` API
+
+`zntc --serve` 로 띄운 dev 서버는 변경된 모듈만 클라이언트로 push 하고, 모듈 단위로 재실행합니다. 사용자 코드는 `import.meta.hot` 으로 어떤 모듈이 hot boundary 인지, 업데이트가 들어왔을 때 무엇을 할지 제어합니다.
+
+ZNTC 의 `import.meta.hot` 는 **Vite 호환** 입니다. 기존 Vite 플러그인 / 코드를 거의 그대로 가져올 수 있습니다.
+
+### 기본 사용법
+
+```ts
+// src/store.ts
+export const store = createStore();
+
+if (import.meta.hot) {
+  // 이 모듈을 hot boundary 로 표시
+  import.meta.hot.accept((newModule) => {
+    if (newModule) {
+      // newModule.store 가 새 인스턴스
+      replaceStore(newModule.store);
+    }
+  });
+}
+```
+
+빌드 산출물에서 `import.meta.hot` 블록 전체는 **production 빌드** 에서 자동으로 제거됩니다 (dev 서버에서만 truthy).
+
+### 의존성 변경 받기
+
+```ts
+// 자기 모듈 변경
+import.meta.hot.accept((newSelf) => { ... });
+
+// 특정 dep 의 변경
+import.meta.hot.accept('./logger', (newLogger) => { ... });
+
+// 여러 dep 한 번에
+import.meta.hot.accept(['./a', './b'], ([newA, newB]) => { ... });
+```
+
+### Cleanup — `dispose`
+
+모듈이 교체되기 직전에 호출됩니다. 타이머/리스너/소켓 정리에 사용:
+
+```ts
+const id = setInterval(tick, 1000);
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    clearInterval(id);
+  });
+}
+```
+
+### 데이터 전달 — `hot.data`
+
+`dispose` 콜백이 받는 객체에 무엇을 담아두면, 새 모듈의 `import.meta.hot.data` 에서 읽을 수 있습니다 — 모듈 교체 사이에 상태 전달.
+
+```ts
+let count = import.meta.hot?.data.count ?? 0;
+
+if (import.meta.hot) {
+  import.meta.hot.dispose((data) => {
+    data.count = count;        // 다음 모듈 인스턴스로 넘김
+  });
+}
+```
+
+### Full reload 강제 — `invalidate`
+
+업데이트를 받았지만 안전하게 처리할 수 없을 때:
+
+```ts
+if (import.meta.hot) {
+  import.meta.hot.accept((newModule) => {
+    if (!canSafelyApply(newModule)) {
+      import.meta.hot.invalidate();   // 페이지 전체 reload
+    }
+  });
+}
+```
+
+브라우저에서는 `location.reload()`, React Native 에서는 `DevSettings.reload()` 가 호출됩니다.
+
+### React Fast Refresh
+
+`.tsx` / `.jsx` 파일이 **모든 export 가 React 컴포넌트** 인 경우 — `import.meta.hot.accept` 를 직접 작성하지 않아도 자동으로 hot boundary 로 처리됩니다. 컴포넌트 함수 / forwardRef / memo / lazy 가 컴포넌트로 인식됩니다.
+
+```tsx
+// Auto Fast Refresh — 명시적 hot 코드 불필요
+export function Button({ children }) {
+  return <button>{children}</button>;
+}
+```
+
+다음 경우는 자동 boundary 가 동작하지 않아 **full reload** 됩니다:
+
+- 컴포넌트와 일반 값을 **함께 export** — 예: `export const config = {...}; export function App() {}`
+- default export 가 anonymous arrow (`export default () => <div />`) — displayName 없음
+- 컴포넌트 안에서 `useState` 의 초기값을 모듈 스코프 변수로 참조하는 경우 (state 손실 가능)
+
+여러 컴포넌트 업데이트는 50ms debounce 로 한 번의 React refresh 사이클에 배칭됩니다.
+
+### 파일 변경 감지 — watcher 동작
+
+| OS | 메커니즘 |
+|---|---|
+| macOS | kqueue |
+| Linux | inotify |
+| Windows | ReadDirectoryChangesW |
+
+대부분 환경에서 OS 이벤트가 즉시 반영됩니다. 다음 환경에서는 OS 이벤트가 불안정해 변경이 누락될 수 있습니다.
+
+- Docker volume mount (호스트 → 컨테이너)
+- NFS / SMB 같은 네트워크 파일시스템
+- Windows WSL1 (WSL2 는 OK)
+
+현재 ZNTC 에는 polling fallback flag 가 없습니다. 위 환경에서 변경이 반영되지 않으면 브라우저 새로고침으로 강제 갱신하세요. polling fallback 은 추후 추가 예정.
+
+### 디버깅 — 업데이트가 안 들어올 때
+
+| 증상 | 의심 |
+|---|---|
+| 파일 저장해도 클라이언트 갱신 없음 | watcher (위 polling fallback 검토) 또는 hot boundary 누락 (full reload 안 함) |
+| Full reload 가 자꾸 일어남 | mixed export, 또는 module dependency chain 의 어떤 모듈도 `accept` 안 함 |
+| Component state 가 매번 초기화됨 | React Fast Refresh boundary 가 깨졌음 — anonymous default export 또는 mixed export 확인 |
+| 업데이트 후 두 인스턴스 공존 | `dispose` 누락 — 타이머/리스너 정리 필요 |
+
+`/sse/events` 를 구독하면 watcher 가 변경을 감지했는지 (`watch_change` 이벤트), 빌드가 성공했는지 (`bundle_build_done`) 직접 확인할 수 있습니다.
+
 ## SSE 이벤트 스트림
 
 ### `GET /sse/events`


### PR DESCRIPTION
## Summary

기존 \`dev-server.md\` (SSE / Control API / MCP 위주) 의 \"빠른 시작\" 바로 뒤에 사용자가 직접 작성하는 HMR 코드 표면을 한 곳에 모은 \`## HMR — import.meta.hot API\` 섹션 신규.

## 추가 서브섹션

- **기본 사용법** — \`accept\` 콜백, production 빌드에서 자동 제거
- **의존성 변경 받기** — 자기 모듈 / 단일 dep / 복수 dep
- **Cleanup — \`dispose\`** — 타이머/리스너 정리
- **데이터 전달 — \`hot.data\`** — 모듈 교체 사이 상태 핸드오프
- **Full reload 강제 — \`invalidate\`** — 브라우저 \`location.reload\`, RN \`DevSettings.reload\`
- **React Fast Refresh** — 자동 boundary 조건 + 깨지는 케이스 (mixed export, anonymous default 등) + 50ms debounce
- **파일 변경 감지 — watcher** — macOS kqueue / Linux inotify / Windows ReadDirectoryChangesW, Docker/NFS/WSL1 한계 (polling fallback 추후)
- **디버깅** — 증상 → 의심 매핑 표

## 작성 원칙

그룹 B (#2985) / 그룹 A (#2987) 와 동일 — 사용자 가이드라인에 맞춰 PR 번호 / D 번호 / Vite 와의 구현 비교 같은 비하인드는 본문에 넣지 않음. \`\"Vite 호환\"\` 호환성 명시만.

## 변경 파일

2 파일 수정, 256 줄 추가. 새 파일/사이드바 변경 없음.

- \`documents/src/content/docs/guides/dev-server.md\` — 한국어
- \`documents/src/content/docs/en/guides/dev-server.md\` — 영문

## Test plan

- [x] \`cd documents && bun run build\` 성공 (470 페이지)
- [x] \`starlightLinksValidator\` 전체 통과
- [x] /simplify 검토 — 한/영 일관성 OK / 사용자 피드백 준수 OK / 사실 정확성 7개 항목 중 1건 fix (\`--watch-poll\` flag 미구현 → 정확한 한계 안내로 수정)
- [ ] 머지 후 https://ohah.github.io/zntc/guides/dev-server/ 에서 새 \"HMR\" 섹션 렌더링 확인
- [ ] 영문 페이지도 동일 확인

## Notes

- 그룹 B (#2985) / 그룹 A (#2987) 와 독립 — 겹치는 파일 없음. 머지 순서 무관.
- 원래 그룹 C 에 포함 예정이던 \`testing-guide\` 신규 페이지는 사용자 관점 가치가 낮아 (컨트리뷰터 향) 작성 보류 — \`docs/TESTING.md\` 에 남겨둠.
- 원래 검토했던 별도 \`hmr-protocol.md\` 신규 페이지 안 대신, 기존 \`dev-server.md\` 확장으로 통합 — 사용자 입장에서 \"HMR\" 과 \"dev server\" 가 같은 페이지에 있는 게 자연스러움.

🤖 Generated with [Claude Code](https://claude.com/claude-code)