### PR TITLE
feat(codegen): sourcemap names 배열 + mapping name_index 발행 (Sentry production debugging)

### DIFF
--- a/src/bundler/compiled_module.zig
+++ b/src/bundler/compiled_module.zig
@@ -16,6 +16,10 @@ pub const CompiledModule = struct {
     helpers: RuntimeHelpers = .{},
     /// codegen 이 생성한 매핑 (bundle SourceMap 빌더에 병합).
     mappings: ?[]const SourceMap.Mapping = null,
+    /// codegen builder 의 names 배열 (mangler rename 발생 시 원본 식별자 이름).
+    /// `mappings[i].name_index` 가 가리키는 module-local 인덱스. bundle 머지 시 chunk
+    /// builder 로 옮길 때 chunk-global 인덱스로 재매핑 (#2987).
+    names: []const []const u8 = &.{},
     /// preamble/래퍼 헤더로 codegen 매핑과 어긋나는 줄 수.
     preamble_lines: u32 = 0,
     /// per-source function map JSON. null = 비활성/함수 없음.
@@ -38,6 +42,8 @@ pub const CompiledModule = struct {
     pub fn deinit(self: CompiledModule, allocator: std.mem.Allocator) void {
         if (self.code) |c| allocator.free(c);
         if (self.mappings) |m| allocator.free(m);
+        for (self.names) |n| allocator.free(n);
+        if (self.names.len > 0) allocator.free(self.names);
         if (self.fn_map_json) |j| allocator.free(j);
         if (self.entry_chain) |c| allocator.free(c);
         for (self.shared_ns_decls) |d| {
@@ -55,6 +61,14 @@ pub const CompiledModule = struct {
         errdefer if (code) |c| allocator.free(c);
         const mappings = if (self.mappings) |m| try allocator.dupe(SourceMap.Mapping, m) else null;
         errdefer if (mappings) |m| allocator.free(m);
+        const names = try allocator.alloc([]const u8, self.names.len);
+        errdefer allocator.free(names);
+        var names_filled: usize = 0;
+        errdefer for (names[0..names_filled]) |n| allocator.free(n);
+        for (self.names, 0..) |n, i| {
+            names[i] = try allocator.dupe(u8, n);
+            names_filled = i + 1;
+        }
         const fn_map = if (self.fn_map_json) |j| try allocator.dupe(u8, j) else null;
         errdefer if (fn_map) |j| allocator.free(j);
         const ec = if (self.entry_chain) |c| try allocator.dupe(u8, c) else null;
@@ -78,6 +92,7 @@ pub const CompiledModule = struct {
             .code = code,
             .helpers = self.helpers,
             .mappings = mappings,
+            .names = names,
             .preamble_lines = self.preamble_lines,
             .fn_map_json = fn_map,
             .entry_chain = ec,

--- a/src/bundler/compiled_module.zig
+++ b/src/bundler/compiled_module.zig
@@ -17,8 +17,8 @@ pub const CompiledModule = struct {
     /// codegen 이 생성한 매핑 (bundle SourceMap 빌더에 병합).
     mappings: ?[]const SourceMap.Mapping = null,
     /// codegen builder 의 names 배열 (mangler rename 발생 시 원본 식별자 이름).
-    /// `mappings[i].name_index` 가 가리키는 module-local 인덱스. bundle 머지 시 chunk
-    /// builder 로 옮길 때 chunk-global 인덱스로 재매핑 (#2987).
+    /// `mappings[i].name_index` 가 가리키는 module-local 인덱스. bundle 머지 시
+    /// chunk builder 로 옮길 때 chunk-global 인덱스로 재매핑.
     names: []const []const u8 = &.{},
     /// preamble/래퍼 헤더로 codegen 매핑과 어긋나는 줄 수.
     preamble_lines: u32 = 0,

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -610,7 +610,7 @@ pub fn emitWithTreeShaking(
             if (hit_mask[i]) continue;
             const is_entry = if (entry_idx) |ei| m.index.toU32() == ei else false;
             const used_names: ?[]const []const u8 = if (used_names_list[i].all_used) null else used_names_list[i].names;
-            results[i].code = emitModule(allocator, m, options, linker, is_entry, used_names, shaker, &results[i].helpers, &results[i].mappings, &results[i].preamble_lines, &results[i].fn_map_json, &results[i].entry_chain, &results[i].shared_ns_decls) catch null;
+            results[i].code = emitModule(allocator, m, options, linker, is_entry, used_names, shaker, &results[i].helpers, &results[i].mappings, &results[i].names, &results[i].preamble_lines, &results[i].fn_map_json, &results[i].entry_chain, &results[i].shared_ns_decls) catch null;
         }
     }
 
@@ -757,6 +757,7 @@ pub fn emitWithTreeShaking(
                     .module_id = sourcemapSourcePath(m.path, options),
                     .source = m.source,
                     .maps = maps,
+                    .module_names = results[i].names,
                     .base_line = module_line - region_lines,
                     .preamble_lines = results[i].preamble_lines,
                     .sources_content = options.sourcemap.sources_content,
@@ -845,6 +846,7 @@ pub fn emitWithTreeShaking(
                         .module_id = sourcemapSourcePath(m.path, options),
                         .source = m.source,
                         .maps = maps,
+                        .module_names = results[i].names,
                         .base_line = HMR_PREAMBLE_LINES,
                         .preamble_lines = results[i].preamble_lines,
                         .sources_content = options.sourcemap.sources_content,
@@ -1241,7 +1243,7 @@ fn emitModuleThread(
     shaker: ?*const TreeShaker,
     result: *CompiledModule,
 ) void {
-    result.code = emitModule(allocator, module, options, linker, is_entry, used_names, shaker, &result.helpers, &result.mappings, &result.preamble_lines, &result.fn_map_json, &result.entry_chain, &result.shared_ns_decls) catch null;
+    result.code = emitModule(allocator, module, options, linker, is_entry, used_names, shaker, &result.helpers, &result.mappings, &result.names, &result.preamble_lines, &result.fn_map_json, &result.entry_chain, &result.shared_ns_decls) catch null;
 }
 
 /// 단일 모듈을 Transformer → Codegen 파이프라인으로 처리.
@@ -1257,6 +1259,7 @@ pub fn emitModule(
     shaker: ?*const TreeShaker,
     helpers_out: ?*RuntimeHelpers,
     mappings_out: ?*?[]const SourceMap.Mapping,
+    names_out: ?*[]const []const u8,
     preamble_lines_out: ?*u32,
     fn_map_json_out: ?*?[]const u8,
     entry_chain_out: ?*?[]const u8,
@@ -1685,6 +1688,24 @@ pub fn emitModule(
         if (cg.sm_builder) |*sm| {
             if (sm.mappings.items.len > 0) {
                 mout.* = try allocator.dupe(SourceMap.Mapping, sm.mappings.items);
+            }
+        }
+    }
+    // sourcemap names 복사: mangler rename 발생한 식별자의 원본 이름. mappings 의
+    // name_index 가 가리키는 module-local 인덱스. bundle merge 시 chunk builder 로
+    // 옮길 때 chunk-global 인덱스로 재매핑 (#2987).
+    if (names_out) |nout| {
+        if (cg.sm_builder) |*sm| {
+            if (sm.names.items.len > 0) {
+                const dst = try allocator.alloc([]const u8, sm.names.items.len);
+                errdefer allocator.free(dst);
+                var filled: usize = 0;
+                errdefer for (dst[0..filled]) |s| allocator.free(s);
+                for (sm.names.items, 0..) |n, i| {
+                    dst[i] = try allocator.dupe(u8, n);
+                    filled = i + 1;
+                }
+                nout.* = dst;
             }
         }
     }

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1606,6 +1606,15 @@ pub fn emitModule(
         if (mappings_out) |mout| {
             mout.* = esm_result.mappings;
         }
+        // ESM-wrapped 모듈도 mangler rename 시 names 전파 — Sentry 가 RN cycle /
+        // scope-hoisted ESM 모듈에서도 원본 식별자 복원 가능하도록.
+        if (names_out) |nout| {
+            nout.* = esm_result.names;
+        } else if (esm_result.names.len > 0) {
+            // out 슬롯 없으면 누수 — 안전하게 free.
+            for (esm_result.names) |n| allocator.free(n);
+            allocator.free(esm_result.names);
+        }
         // entry_error_guard + entry: chain 을 entry_chain_out 으로 전달.
         // 비-entry 또는 비-guard 면 entry_chain == null.
         if (entry_chain_out) |out| {
@@ -1693,7 +1702,7 @@ pub fn emitModule(
     }
     // sourcemap names 복사: mangler rename 발생한 식별자의 원본 이름. mappings 의
     // name_index 가 가리키는 module-local 인덱스. bundle merge 시 chunk builder 로
-    // 옮길 때 chunk-global 인덱스로 재매핑 (#2987).
+    // 옮길 때 chunk-global 인덱스로 재매핑.
     if (names_out) |nout| {
         if (cg.sm_builder) |*sm| {
             if (sm.names.items.len > 0) {

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -352,6 +352,11 @@ pub fn emitChunks(
             const is_entry = if (entry_mod_idx) |ei| mi == ei else false;
             var module_mappings: ?[]const SourceMap.Mapping = null;
             defer if (module_mappings) |maps| allocator.free(maps);
+            var module_names: []const []const u8 = &.{};
+            defer {
+                for (module_names) |n| allocator.free(n);
+                if (module_names.len > 0) allocator.free(module_names);
+            }
             var module_preamble_lines: u32 = 0;
             const raw_code = try emitModule(
                 allocator,
@@ -363,6 +368,7 @@ pub fn emitChunks(
                 null,
                 null,
                 if (chunk_sm != null) &module_mappings else null,
+                if (chunk_sm != null) &module_names else null,
                 if (chunk_sm != null) &module_preamble_lines else null,
                 null,
                 null,
@@ -412,6 +418,7 @@ pub fn emitChunks(
                     .module_id = parent.sourcemapSourcePath(m.path, options),
                     .source = m.source,
                     .maps = maps,
+                    .module_names = module_names,
                     .base_line = module_line.? - region_lines,
                     .preamble_lines = module_preamble_lines,
                     .sources_content = options.sourcemap.sources_content,

--- a/src/bundler/emitter/dev.zig
+++ b/src/bundler/emitter/dev.zig
@@ -14,6 +14,10 @@ pub const ModuleMappingArgs = struct {
     module_id: []const u8,
     source: []const u8,
     maps: []const SourceMap.Mapping,
+    /// codegen builder 의 names 슬라이스. mapping.name_index 가 가리키는 식별자
+    /// 원본 이름들 — chunk builder 로 옮길 때 module-local 인덱스를 chunk-global
+    /// 인덱스로 재매핑 (#2987).
+    module_names: []const []const u8 = &.{},
     base_line: u32,
     preamble_lines: u32,
     sources_content: bool,
@@ -130,6 +134,14 @@ inline fn emitResolvedMapping(
     m: SourceMap.Mapping,
 ) !ResolvedMapping {
     const r = try resolver.resolve(m);
+    // module-local name_index → chunk-global 재매핑. mangler rename 발생 시
+    // codegen 이 module builder 의 names 에 등록한 원본 이름을 chunk builder
+    // 로 옮겨 Sentry / DevTools 가 minified 식별자의 원본을 복원 가능하게.
+    const chunk_name_idx: ?u32 = blk: {
+        const local = m.name_index orelse break :blk null;
+        if (local >= args.module_names.len) break :blk null;
+        break :blk try args.sm.addName(args.module_names[local]);
+    };
     try args.sm.addMapping(.{
         .generated_line = args.base_line + args.pre_lines + args.preamble_lines + m.generated_line,
         .generated_column = if (args.indent_offset and m.generated_line != 0)
@@ -139,6 +151,7 @@ inline fn emitResolvedMapping(
         .source_index = r.source_idx,
         .original_line = r.line,
         .original_column = r.column,
+        .name_index = chunk_name_idx,
     });
     return r;
 }

--- a/src/bundler/emitter/dev.zig
+++ b/src/bundler/emitter/dev.zig
@@ -16,7 +16,7 @@ pub const ModuleMappingArgs = struct {
     maps: []const SourceMap.Mapping,
     /// codegen builder 의 names 슬라이스. mapping.name_index 가 가리키는 식별자
     /// 원본 이름들 — chunk builder 로 옮길 때 module-local 인덱스를 chunk-global
-    /// 인덱스로 재매핑 (#2987).
+    /// 인덱스로 재매핑.
     module_names: []const []const u8 = &.{},
     base_line: u32,
     preamble_lines: u32,
@@ -135,8 +135,8 @@ inline fn emitResolvedMapping(
 ) !ResolvedMapping {
     const r = try resolver.resolve(m);
     // module-local name_index → chunk-global 재매핑. mangler rename 발생 시
-    // codegen 이 module builder 의 names 에 등록한 원본 이름을 chunk builder
-    // 로 옮겨 Sentry / DevTools 가 minified 식별자의 원본을 복원 가능하게.
+    // codegen 이 module builder 의 names 에 등록한 원본 이름을 chunk builder 로
+    // 옮겨 Sentry / DevTools 가 minified 식별자의 원본 복원 가능.
     const chunk_name_idx: ?u32 = blk: {
         const local = m.name_index orelse break :blk null;
         if (local >= args.module_names.len) break :blk null;

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -85,7 +85,7 @@ pub const EsmEmitResult = struct {
     code: []const u8,
     mappings: ?[]const SourceMap.Mapping = null,
     /// codegen builder 의 names 배열 (mangler rename 발생 시 원본 식별자 이름).
-    /// `mappings[i].name_index` 가 가리키는 module-local 인덱스 (#2987).
+    /// `mappings[i].name_index` 가 가리키는 module-local 인덱스.
     names: []const []const u8 = &.{},
     /// `CompiledModule.entry_chain` 참조. emitter 로 전달되는 unroll 버퍼.
     entry_chain: ?[]const u8 = null,
@@ -341,6 +341,7 @@ pub fn emitEsmWrappedModule(
 
     // 3. 호이스팅된 function 선언 (rolldown 방식: canonical 변수 직접 참조)
     var hoist_mappings: ?[]const SourceMap.Mapping = null;
+    var hoist_names: []const []const u8 = &.{};
     var hoist_preamble_lines: u32 = 0;
     if (hoisted_stmts.items.len > 0) {
         var hoist_cg = Codegen.initWithOptions(arena_alloc, esm_ast, .{
@@ -371,6 +372,7 @@ pub fn emitEsmWrappedModule(
             if (sm.mappings.items.len > 0) {
                 hoist_mappings = sm.mappings.items;
             }
+            hoist_names = sm.names.items;
         }
     }
 
@@ -552,6 +554,7 @@ pub fn emitEsmWrappedModule(
     // 5. body codegen (variable_declaration/class → 할당문만)
     // func_code의 sourcemap 매핑을 병합 단계까지 보존 (호이스팅된 함수 정의 매핑, #1315)
     var func_mappings: ?[]const SourceMap.Mapping = null;
+    var func_names: []const []const u8 = &.{};
     var func_preamble_lines: u32 = 0;
     var body_cg = Codegen.initWithOptions(arena_alloc, esm_ast, .{
         .minify_whitespace = options.minify_whitespace,
@@ -604,6 +607,7 @@ pub fn emitEsmWrappedModule(
         func_code = try func_cg.generateStatements(root, body_func_stmts.items);
         if (func_cg.sm_builder) |*sm| {
             if (sm.mappings.items.len > 0) func_mappings = sm.mappings.items;
+            func_names = sm.names.items;
         }
     }
     var body_code = try body_cg.generateStatements(root, body_stmts.items);
@@ -911,13 +915,20 @@ pub fn emitEsmWrappedModule(
     }
 
     // 소스맵 매핑 수집: hoisted + body 매핑을 병합하여 단일 슬라이스로 할당.
+    // hoist/func/body 각 codegen builder 의 names 도 concat — 각 partition 의 mapping
+    // name_index 에 partition offset 을 더해 통합 names 인덱스로 재매핑.
     var mappings: ?[]const SourceMap.Mapping = null;
+    var names_merged: []const []const u8 = &.{};
     {
         const hm = hoist_mappings orelse &[_]SourceMap.Mapping{};
         const fm = func_mappings orelse &[_]SourceMap.Mapping{};
         const bm = if (body_cg.sm_builder) |*sm| sm.mappings.items else &[_]SourceMap.Mapping{};
+        const hn = hoist_names;
+        const fn_names = func_names;
+        const bn = if (body_cg.sm_builder) |*sm| sm.names.items else &[_][]const u8{};
         const all_maps = [_][]const SourceMap.Mapping{ hm, fm, bm };
         const line_offsets = [_]u32{ hoist_preamble_lines, func_preamble_lines, body_preamble_lines };
+        const name_offsets = [_]u32{ 0, @intCast(hn.len), @intCast(hn.len + fn_names.len) };
         const total = hm.len + fm.len + bm.len;
         if (total > 0) {
             // 각 줄의 첫 매핑이 column 0이 아니면, column 0 매핑을 추가.
@@ -936,20 +947,44 @@ pub fn emitEsmWrappedModule(
 
             const buf = try allocator.alloc(SourceMap.Mapping, total + col0_count);
             var wi: usize = 0;
-            for (all_maps, line_offsets) |maps, offset| {
+            for (all_maps, line_offsets, name_offsets) |maps, offset, name_off| {
                 var prev_gl: u32 = std.math.maxInt(u32);
                 for (maps) |m| {
                     const gl = m.generated_line + offset;
                     if (gl != prev_gl and m.generated_column > 0) {
+                        // col0 line anchor — name 없음 (line 단위 fallback 용도).
                         buf[wi] = .{ .generated_line = gl, .generated_column = 0, .source_index = m.source_index, .original_line = m.original_line, .original_column = m.original_column };
                         wi += 1;
                     }
                     prev_gl = gl;
-                    buf[wi] = .{ .generated_line = gl, .generated_column = m.generated_column, .source_index = m.source_index, .original_line = m.original_line, .original_column = m.original_column };
+                    const shifted_name: ?u32 = if (m.name_index) |ni| ni + name_off else null;
+                    buf[wi] = .{ .generated_line = gl, .generated_column = m.generated_column, .source_index = m.source_index, .original_line = m.original_line, .original_column = m.original_column, .name_index = shifted_name };
                     wi += 1;
                 }
             }
             mappings = buf[0..wi];
+        }
+
+        // names concat — hoist + func + body. mapping.name_index 의 partition offset 과 정합.
+        const total_names = hn.len + fn_names.len + bn.len;
+        if (total_names > 0) {
+            const names_buf = try allocator.alloc([]const u8, total_names);
+            errdefer allocator.free(names_buf);
+            var filled: usize = 0;
+            errdefer for (names_buf[0..filled]) |s| allocator.free(s);
+            for (hn) |n| {
+                names_buf[filled] = try allocator.dupe(u8, n);
+                filled += 1;
+            }
+            for (fn_names) |n| {
+                names_buf[filled] = try allocator.dupe(u8, n);
+                filled += 1;
+            }
+            for (bn) |n| {
+                names_buf[filled] = try allocator.dupe(u8, n);
+                filled += 1;
+            }
+            names_merged = names_buf;
         }
     }
 
@@ -963,6 +998,7 @@ pub fn emitEsmWrappedModule(
     return .{
         .code = try allocator.dupe(u8, wrapped.items),
         .mappings = mappings,
+        .names = names_merged,
         .entry_chain = entry_chain_owned,
     };
 }

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -84,6 +84,9 @@ fn reExportAliasCanonicalName(ref: SymbolRef, mod: *const Module) ?[]const u8 {
 pub const EsmEmitResult = struct {
     code: []const u8,
     mappings: ?[]const SourceMap.Mapping = null,
+    /// codegen builder 의 names 배열 (mangler rename 발생 시 원본 식별자 이름).
+    /// `mappings[i].name_index` 가 가리키는 module-local 인덱스 (#2987).
+    names: []const []const u8 = &.{},
     /// `CompiledModule.entry_chain` 참조. emitter 로 전달되는 unroll 버퍼.
     entry_chain: ?[]const u8 = null,
 };

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -242,6 +242,7 @@ pub const Codegen = struct {
     pub const generateSourceMap = debug_metadata.generateSourceMap;
     pub const generateSourceMapWithFunctionMap = debug_metadata.generateSourceMapWithFunctionMap;
     pub const addSourceMapping = debug_metadata.addSourceMapping;
+    pub const addSourceMappingWithName = debug_metadata.addSourceMappingWithName;
     const fnMapEnter = debug_metadata.fnMapEnter;
     const fnMapExit = debug_metadata.fnMapExit;
     pub const isFunctionLike = debug_metadata.isFunctionLike;

--- a/src/codegen/debug_metadata.zig
+++ b/src/codegen/debug_metadata.zig
@@ -47,6 +47,30 @@ pub fn addSourceMapping(self: anytype, span: Span) !void {
     }
 }
 
+/// mangler 가 rename 한 식별자 emit 직전 호출. 원본 이름을 names 배열에 등록하고
+/// mapping 의 name_index 로 참조 — Sentry / DevTools 가 minified `f` → 원본
+/// `calculateTotalPrice` 복원 가능. `original_name` 이 비어있거나 합성 span 이면
+/// 일반 매핑으로 fallback (이름 없이).
+pub fn addSourceMappingWithName(self: anytype, span: Span, original_name: []const u8) !void {
+    if (self.sm_builder) |*sm| {
+        if (span.start & Ast.STRING_TABLE_BIT != 0) return;
+        if (span.start == span.end) return;
+        const lc = getOriginalLineColumn(self, span.start);
+        const name_idx: ?u32 = if (original_name.len > 0)
+            try sm.addName(original_name)
+        else
+            null;
+        try sm.addMapping(.{
+            .generated_line = self.gen_line,
+            .generated_column = self.gen_col,
+            .source_index = 0,
+            .original_line = lc.line,
+            .original_column = lc.column,
+            .name_index = name_idx,
+        });
+    }
+}
+
 fn getOriginalLineColumn(self: anytype, offset: u32) struct { line: u32, column: u32 } {
     const offsets = self.line_offsets;
     if (offsets.len == 0) return .{ .line = 0, .column = offset };

--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -112,7 +112,12 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
         .binding_identifier,
         .assignment_target_identifier,
         => {
-            try self.addSourceMapping(node.span);
+            // mangler / ns_prefix 치환 / inline 치환이 발생하면 원본 이름을 sourcemap
+            // names 배열에 등록해 mapping.name_index 로 참조 — Sentry / DevTools 가
+            // minified `f` 의 원본 `originalName` 을 stack frame variable / hover 에서
+            // 복원. 치환 안 일어나는 일반 경로는 names 발행 X (size 폭증 회피, esbuild
+            // 동일 정책).
+
             // Peephole: global `undefined` → `(void 0)` (minify_syntax 활성화 시).
             // 9 bytes → 8 bytes, 1 byte 절감. parens는 member/call/new 등 모든 parent
             // context에서 안전하게 해석되도록 유지 — `undefined.x`/`undefined()` 같은
@@ -126,6 +131,7 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
                     else
                         true;
                     if (is_global) {
+                        try self.addSourceMapping(node.span);
                         try self.write("(void 0)");
                         return;
                     }
@@ -138,16 +144,23 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
                     // 상수 인라인: import symbol이 상수이면 리터럴로 대체
                     if (node.tag == .identifier_reference) {
                         if (meta.const_values.get(sid)) |cv| {
+                            try self.addSourceMapping(node.span);
                             try self.writeConstValue(cv);
                             return;
                         }
                     }
-                    // namespace 변수 참조: ns를 값으로 사용 → 변수명으로 치환
+                    // namespace 변수 참조: ns를 값으로 사용 → 변수명으로 치환.
+                    // 원본 식별자 이름을 names 에 등록해 디버거가 원형 lookup 가능.
                     if (meta.ns_inline_objects.get(sid)) |entry| {
+                        const original = self.ast.getText(node.data.string_ref);
+                        try self.addSourceMappingWithName(node.span, original);
                         try self.write(entry.var_name);
                         return;
                     }
+                    // mangler rename — 원본 이름 names 등록.
                     if (meta.renames.get(sid)) |new_name| {
+                        const original = self.ast.getText(node.data.string_ref);
+                        try self.addSourceMappingWithName(node.span, original);
                         try self.write(new_name);
                         return;
                     }
@@ -161,6 +174,7 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
                     const name = self.ast.getText(node.data.string_ref);
                     if (self.ns_exports) |exports| {
                         if (exports.contains(name)) {
+                            try self.addSourceMappingWithName(node.span, name);
                             try self.write(prefix);
                             try self.writeByte('.');
                             try self.write(name);
@@ -169,6 +183,7 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
                     }
                 }
             }
+            try self.addSourceMapping(node.span);
             try self.writeSpan(node.data.string_ref);
         },
 

--- a/src/codegen/sourcemap.zig
+++ b/src/codegen/sourcemap.zig
@@ -227,7 +227,7 @@ pub const SourceMapBuilder = struct {
     last_gen_col: u32 = 0,
     /// sourcemap spec `names` 배열. mangler 가 rename 한 식별자의 원본 이름이
     /// 들어가고 mapping.name_index 가 이 배열을 가리킨다. Sentry / DevTools 가
-    /// minified 식별자를 원본 이름으로 표시하는 데 사용 (#2987).
+    /// minified 식별자를 원본 이름으로 표시하는 데 사용.
     names: std.ArrayList([]const u8) = .empty,
     /// names 배열 dedup 용 — 같은 원본 이름 여러 번 등장 시 같은 인덱스 반환.
     /// 키는 builder allocator 로 dupe 된 문자열 (names 배열과 ownership 공유).

--- a/src/codegen/sourcemap.zig
+++ b/src/codegen/sourcemap.zig
@@ -74,6 +74,10 @@ pub const Mapping = struct {
     original_line: u32,
     /// 소스 파일의 열 (0-based)
     original_column: u32,
+    /// names 배열 인덱스 (mangler rename 발생 시 원본 이름). null 이면 5-segment VLQ
+    /// (line/col/source/orig_line/orig_col), non-null 이면 6-segment (+name_index).
+    /// Sentry 같은 도구가 minified 식별자의 원본 이름을 복원하는 데 사용.
+    name_index: ?u32 = null,
 
     pub fn lessThan(_: void, a: Mapping, b: Mapping) bool {
         if (a.generated_line != b.generated_line) return a.generated_line < b.generated_line;
@@ -221,6 +225,13 @@ pub const SourceMapBuilder = struct {
     is_sorted: bool = true,
     last_gen_line: u32 = 0,
     last_gen_col: u32 = 0,
+    /// sourcemap spec `names` 배열. mangler 가 rename 한 식별자의 원본 이름이
+    /// 들어가고 mapping.name_index 가 이 배열을 가리킨다. Sentry / DevTools 가
+    /// minified 식별자를 원본 이름으로 표시하는 데 사용 (#2987).
+    names: std.ArrayList([]const u8) = .empty,
+    /// names 배열 dedup 용 — 같은 원본 이름 여러 번 등장 시 같은 인덱스 반환.
+    /// 키는 builder allocator 로 dupe 된 문자열 (names 배열과 ownership 공유).
+    name_index_map: std.StringHashMapUnmanaged(u32) = .empty,
 
     pub fn init(allocator: std.mem.Allocator) SourceMapBuilder {
         return .{
@@ -235,10 +246,13 @@ pub const SourceMapBuilder = struct {
     pub fn deinit(self: *SourceMapBuilder) void {
         for (self.sources.items) |s| self.allocator.free(s);
         for (self.source_contents.items) |c| self.allocator.free(c);
+        for (self.names.items) |n| self.allocator.free(n);
         self.mappings.deinit(self.allocator);
         self.sources.deinit(self.allocator);
         self.source_contents.deinit(self.allocator);
         self.ignored_sources.deinit(self.allocator);
+        self.names.deinit(self.allocator);
+        self.name_index_map.deinit(self.allocator);
         self.buf.deinit(self.allocator);
     }
 
@@ -300,6 +314,19 @@ pub const SourceMapBuilder = struct {
         try self.source_contents.append(self.allocator, copy);
     }
 
+    /// names 배열에 식별자 추가 — 같은 이름은 첫 인덱스 반환 (dedup). 키는 builder
+    /// allocator 로 dupe 되어 names 배열과 ownership 공유. mangler rename 발생 시
+    /// 원본 이름을 등록해 mapping.name_index 로 참조.
+    pub fn addName(self: *SourceMapBuilder, name: []const u8) !u32 {
+        if (self.name_index_map.get(name)) |idx| return idx;
+        const copy = try self.allocator.dupe(u8, name);
+        errdefer self.allocator.free(copy);
+        const idx: u32 = @intCast(self.names.items.len);
+        try self.names.append(self.allocator, copy);
+        try self.name_index_map.put(self.allocator, copy, idx);
+        return idx;
+    }
+
     /// 매핑 추가. emitter 가 outer wrapper 진입 시 발행한 mapping 과 첫 자식 emitter
     /// 가 발행한 mapping 이 동일 (gen,src) 위치에 박히는 패턴이 잦아 (예: expression
     /// statement → operand expression 의 첫 토큰), 직전 mapping 과 모든 좌표가 같으면
@@ -352,7 +379,16 @@ pub const SourceMapBuilder = struct {
             try self.appendJsonString(src);
         }
 
-        try self.buf.appendSlice(self.allocator, "],\"names\":[],\"mappings\":\"");
+        try self.buf.appendSlice(self.allocator, "],\"names\":[");
+
+        // names 배열 — mangler rename 발생 시 등록된 원본 식별자들. mapping.name_index 가
+        // 이 배열을 가리켜 Sentry 가 minified `f` → 원본 `calculateTotalPrice` 복원.
+        for (self.names.items, 0..) |n, i| {
+            if (i > 0) try self.buf.append(self.allocator, ',');
+            try self.appendJsonString(n);
+        }
+
+        try self.buf.appendSlice(self.allocator, "],\"mappings\":\"");
 
         // mappings 인코딩
         try self.encodeMappings();
@@ -460,6 +496,7 @@ pub const SourceMapBuilder = struct {
         var prev_src_idx: i32 = 0;
         var prev_src_line: i32 = 0;
         var prev_src_col: i32 = 0;
+        var prev_name_idx: i32 = 0;
         var prev_gen_line: u32 = 0;
         var is_first_segment_on_line = true;
 
@@ -478,7 +515,7 @@ pub const SourceMapBuilder = struct {
             }
             is_first_segment_on_line = false;
 
-            // 4개 필드 VLQ 인코딩
+            // 4개 필드 VLQ 인코딩 (name_index 가 있으면 5번째 필드까지)
             // 1. 출력 열 (이전 세그먼트 대비 상대값)
             try encodeVLQ(self.allocator, &self.buf, @as(i32, @intCast(m.generated_column)) - prev_gen_col);
             // 2. 소스 인덱스 (상대값)
@@ -487,6 +524,12 @@ pub const SourceMapBuilder = struct {
             try encodeVLQ(self.allocator, &self.buf, @as(i32, @intCast(m.original_line)) - prev_src_line);
             // 4. 소스 열 (상대값)
             try encodeVLQ(self.allocator, &self.buf, @as(i32, @intCast(m.original_column)) - prev_src_col);
+            // 5. names 인덱스 (옵션) — mangler rename 발생 시만 발행. spec: prev_name_idx 는
+            // mapping 단위가 아니라 file 전체에 걸쳐 누적 (5-segment mapping 끼리만 chain).
+            if (m.name_index) |ni| {
+                try encodeVLQ(self.allocator, &self.buf, @as(i32, @intCast(ni)) - prev_name_idx);
+                prev_name_idx = @intCast(ni);
+            }
 
             prev_gen_col = @intCast(m.generated_column);
             prev_src_idx = @intCast(m.source_index);


### PR DESCRIPTION
## Summary

Sentry / Chrome DevTools 의 production minify 디버깅에서 minified 식별자 (\`f\`, \`t\`) 를 원본 이름 (\`calculateTotalPrice\`, \`items\`) 으로 복원할 수 있도록 sourcemap V3 spec 의 \`names\` 배열과 mapping 의 5th VLQ field (name_index) 를 발행.

이전엔 \`"names":[]\` 빈 배열 + \`Mapping\` struct 에 \`name_index\` 필드 자체 부재 → Sentry 의 stack frame variable 표시 / DevTools 의 식별자 hover 가 동작 안 함. esbuild / oxc / swc 모두 발행 — zts 만 미발행이었음.

## Why

| 기능 | 요건 | 이전 | 이번 PR |
|---|---|---|---|
| Stack trace line/col | line/col 매핑 | ✅ #2984 | ✅ |
| Source context (주변 줄) | sourcesContent | ✅ | ✅ |
| **변수 이름 복원** (\`f is undefined\` → \"원래 \`calculateTotalPrice\`\") | **names + name_index** | ❌ | ✅ |
| DevTools Variable hover | 동일 | ❌ | ✅ |

## 변경 범위

### Core (sourcemap.zig + debug_metadata.zig)

- \`Mapping\` struct: \`name_index: ?u32 = null\` 필드 추가
- \`SourceMapBuilder\`: names ArrayList + intern HashMap, \`addName(name)\` (dedup)
- JSON 출력: \`"names":[]\` → 실 배열 채움
- VLQ encode: name_index 있는 mapping 은 5-segment VLQ (delta encoding)
- \`addSourceMappingWithName(span, original_name)\` helper

### Codegen 분기 (node_dispatch.zig)

identifier 분기 (\`identifier_reference\` / \`binding_identifier\` / \`assignment_target_identifier\` / \`private_identifier\`):
- \`meta.renames.get(sid)\` hit → mangler rename → 원본 이름 names 에 등록
- \`meta.ns_inline_objects.get(sid)\` hit → namespace inline → 원본 이름 등록
- \`ns_prefix\` 치환 → 원본 이름 등록
- 일반 path (치환 없음) → names 발행 X (size 폭증 회피, esbuild 동일 정책)

### Bundle path 전파

\`CompiledModule.names\` + \`EsmEmitResult.names\` 추가. module 별 names 를 \`emitModule\` 가 \`names_out\` 으로 반환. \`addModuleMappings\` 가 module-local name_index → chunk-global 로 재매핑.

## 검증

### Single-module reproducer
\`\`\`ts
function calculatePrice(amount: number): number {
  let result = 0;
  for (let i = 0; i < amount; i++) result = result + i;
  return result;
}
console.log(calculatePrice(10));
\`\`\`

minified output:
\`\`\`js
function e(n){let t=0;for(let i=0;i<n;i++){t=t + i}return t}console.log(e(10));
\`\`\`

sourcemap (이전):
\`\`\`json
"names": []
\`\`\`

sourcemap (이번 PR):
\`\`\`json
"names": ["calculatePrice", "amount", "result"],
"mappings": "...SAASA,EAAeC,..."  // 5-segment VLQ (마지막 A = name_index delta)
\`\`\`

### 회귀
- [x] sourcemap 통합 4 파일 / 48 tests 통과 (sourcemap, round4/5-sourcemap, sourcemap-footer)
- [x] 통합 테스트 전체 (109 files): 3710 pass / 1 baseline fail (manualChunks zod, main 동일)
- [x] \`zig build test\` 통과 (RN codegen fixture FileNotFound 25개는 별개 baseline)
- [x] \`bun scripts/audit-codegen-sourcemap.ts\` 통과

## 후속 (별도 PR)

- 모든 leaf token (\`(\`, \`)\`, \`{\`, \`}\`) 매핑 — 추가 가치 marginal 하므로 보류
- mangler 로 mangled 안 됐지만 `Symbol.canonical_name` 만으로 rename 된 top-level 심볼의 names 발행 — 현재 dispatch path 거치지 않을 가능성 검토 (별도 분석)

🤖 Generated with [Claude Code](https://claude.com/claude-code)