### PR TITLE
fix(bundler): manualChunks 의 vendor 청크 정의 namespace 가 entry preamble 로 누출 (#2990)

### DIFF
--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -63,13 +63,11 @@ pub fn emitChunks(
 
     // splitting / manualChunks 모드에서도 namespace import 의 object literal 을
     // referrer 모듈 self-preamble 이 아닌 정의자 청크 preamble 로 분리해야 entry
-    // 청크에 vendor 코드가 누출되지 않음 (#2990). `use_shared_ns_preamble = true`
-    // 면 metadata.finalizeNamespaceData 가 entry 의 object_literal 을 빈 문자열로
-    // 두고, linker 의 ns_shared_inline_cache 에 정의자 mod_idx + 실 object_literal
-    // 저장 — 청크 emit 시 정의자 모듈이 속한 청크 preamble 에서 inline.
-    if (linker) |l| {
-        @constCast(l).use_shared_ns_preamble = true;
-    }
+    // 청크에 vendor 코드가 누출되지 않음. `use_shared_ns_preamble = true` 면
+    // finalizeNamespaceData 가 referrer 측 object_literal 을 빈 문자열로 두고,
+    // linker 의 ns_shared_inline_cache 에 정의자 mod_idx + 실 object_literal 저장
+    // — 청크 emit 시 정의자 모듈이 속한 청크 preamble 에서 inline.
+    if (linker) |l| @constCast(l).use_shared_ns_preamble = true;
 
     var outputs: std.ArrayList(OutputFile) = .empty;
     errdefer {
@@ -163,11 +161,11 @@ pub fn emitChunks(
             );
         }
 
-        // shared namespace preamble (#2990): 이 청크의 정의자 모듈에 속한 namespace
-        // object literal 만 inline. referrer 청크가 자기 self-preamble 에 inline
-        // 하던 동작 (entry 에 vendor 코드 누출) 을 정의자 청크 preamble 로 옮긴다.
+        // 이 청크의 정의자 모듈에 속한 namespace object literal 만 inline.
+        // referrer 청크가 자기 self-preamble 에 inline 하던 동작 (entry 에 vendor
+        // 코드 누출) 을 정의자 청크 preamble 로 옮긴다.
         if (linker) |l| if (l.use_shared_ns_preamble) {
-            var chunk_targets: std.AutoHashMapUnmanaged(u32, void) = .{};
+            var chunk_targets: std.AutoHashMapUnmanaged(u32, void) = .empty;
             defer chunk_targets.deinit(allocator);
             try chunk_targets.ensureTotalCapacity(allocator, @intCast(chunk.modules.items.len));
             for (chunk.modules.items) |mod_idx| {

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -61,6 +61,16 @@ pub fn emitChunks(
             error.CodeSplittingRequiresESM;
     }
 
+    // splitting / manualChunks 모드에서도 namespace import 의 object literal 을
+    // referrer 모듈 self-preamble 이 아닌 정의자 청크 preamble 로 분리해야 entry
+    // 청크에 vendor 코드가 누출되지 않음 (#2990). `use_shared_ns_preamble = true`
+    // 면 metadata.finalizeNamespaceData 가 entry 의 object_literal 을 빈 문자열로
+    // 두고, linker 의 ns_shared_inline_cache 에 정의자 mod_idx + 실 object_literal
+    // 저장 — 청크 emit 시 정의자 모듈이 속한 청크 preamble 에서 inline.
+    if (linker) |l| {
+        @constCast(l).use_shared_ns_preamble = true;
+    }
+
     var outputs: std.ArrayList(OutputFile) = .empty;
     errdefer {
         for (outputs.items) |o| {
@@ -152,6 +162,19 @@ pub fn emitChunks(
                 options.minify_whitespace,
             );
         }
+
+        // shared namespace preamble (#2990): 이 청크의 정의자 모듈에 속한 namespace
+        // object literal 만 inline. referrer 청크가 자기 self-preamble 에 inline
+        // 하던 동작 (entry 에 vendor 코드 누출) 을 정의자 청크 preamble 로 옮긴다.
+        if (linker) |l| if (l.use_shared_ns_preamble) {
+            var chunk_targets: std.AutoHashMapUnmanaged(u32, void) = .{};
+            defer chunk_targets.deinit(allocator);
+            try chunk_targets.ensureTotalCapacity(allocator, @intCast(chunk.modules.items.len));
+            for (chunk.modules.items) |mod_idx| {
+                chunk_targets.putAssumeCapacity(@intFromEnum(mod_idx), {});
+            }
+            try l.appendSharedNamespacePreambleFiltered(&chunk_output, &chunk_targets);
+        };
 
         var rbm_cross_imports: std.ArrayList(RunBeforeMainCrossImport) = .empty;
         defer {

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1602,6 +1602,7 @@ pub const Linker = struct {
 
     pub const registerNamespaceRewrites = shared_namespace.registerNamespaceRewrites;
     pub const appendSharedNamespacePreamble = shared_namespace.appendSharedNamespacePreamble;
+    pub const appendSharedNamespacePreambleFiltered = shared_namespace.appendSharedNamespacePreambleFiltered;
     pub const restoreSharedNamespaceDecls = shared_namespace.restoreSharedNamespaceDecls;
     pub const collectSharedNamespaceDecls = shared_namespace.collectSharedNamespaceDecls;
 

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -118,6 +118,21 @@ pub fn registerNamespaceRewrites(
             const ns_var = if (ns_target_to_var.get(target)) |cached|
                 cached
             else blk: {
+                // splitting / manualChunks 시 referrer 청크 self-preamble 에 inline
+                // 하면 entry 청크에 vendor 코드 누출 (#2990). use_shared_ns_preamble
+                // 활성 시 정의자 모듈 (`target`) 의 청크 preamble 로 분리 — linker 의
+                // ns_shared_inline_cache 에 등록 후 청크 emit 단계에서 chunk filter.
+                if (self.use_shared_ns_preamble) {
+                    const ns_var_name = try getOrCreateSharedNamespaceVar(self, target, &seen_exports);
+                    try ns_target_to_var.put(target, ns_var_name);
+                    try ns_inline_list.append(self.allocator, .{
+                        .symbol_id = null,
+                        .object_literal = try self.allocator.dupe(u8, ""),
+                        .var_name = try self.allocator.dupe(u8, ns_var_name),
+                        .shared_target_mod_idx = target,
+                    });
+                    break :blk ns_var_name;
+                }
                 const fresh = try makeUniqueNsVarName(self, exp.exported, &seen_exports);
                 try ns_target_to_var.put(target, fresh);
                 const obj_str = try buildInlineObjectStr(self, target, 0);
@@ -208,6 +223,18 @@ fn getOrCreateSharedNamespaceVar(
 }
 
 pub fn appendSharedNamespacePreamble(self: *const Linker, out: *std.ArrayList(u8)) std.mem.Allocator.Error!void {
+    try appendSharedNamespacePreambleFiltered(self, out, null);
+}
+
+/// 특정 청크의 정의자 모듈에 속한 namespace 만 emit. `target_filter` 가 non-null 이면
+/// 그 set 에 속한 target_mod_idx 만 inline (splitting / manualChunks #2990 fix —
+/// referrer 청크가 아닌 정의자 청크의 preamble 에 namespace 가 위치하도록).
+/// null 이면 전 namespace inline (single-file bundle 호환).
+pub fn appendSharedNamespacePreambleFiltered(
+    self: *const Linker,
+    out: *std.ArrayList(u8),
+    target_filter: ?*const std.AutoHashMapUnmanaged(u32, void),
+) std.mem.Allocator.Error!void {
     const sorted_targets = try self.allocator.dupe(u32, self.ns_shared_inline_order.items);
     defer self.allocator.free(sorted_targets);
     const SortCtx = struct {
@@ -223,6 +250,9 @@ pub fn appendSharedNamespacePreamble(self: *const Linker, out: *std.ArrayList(u8
     std.mem.sort(u32, sorted_targets, SortCtx{ .linker = self }, SortCtx.lessThan);
 
     for (sorted_targets) |target_mod_idx| {
+        if (target_filter) |f| {
+            if (!f.contains(target_mod_idx)) continue;
+        }
         const entry = self.ns_shared_inline_cache.get(target_mod_idx) orelse continue;
         try out.appendSlice(self.allocator, "var ");
         try out.appendSlice(self.allocator, entry.var_name);

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -118,19 +118,11 @@ pub fn registerNamespaceRewrites(
             const ns_var = if (ns_target_to_var.get(target)) |cached|
                 cached
             else blk: {
-                // splitting / manualChunks 시 referrer 청크 self-preamble 에 inline
-                // 하면 entry 청크에 vendor 코드 누출 (#2990). use_shared_ns_preamble
-                // 활성 시 정의자 모듈 (`target`) 의 청크 preamble 로 분리 — linker 의
-                // ns_shared_inline_cache 에 등록 후 청크 emit 단계에서 chunk filter.
+                // splitting 시엔 referrer 청크 self-preamble 대신 정의자 청크 preamble 에
+                // namespace 가 위치하도록 shared cache 경유.
                 if (self.use_shared_ns_preamble) {
-                    const ns_var_name = try getOrCreateSharedNamespaceVar(self, target, &seen_exports);
+                    const ns_var_name = try appendSharedNsInlineEntry(self, ns_inline_list, null, target, &seen_exports);
                     try ns_target_to_var.put(target, ns_var_name);
-                    try ns_inline_list.append(self.allocator, .{
-                        .symbol_id = null,
-                        .object_literal = try self.allocator.dupe(u8, ""),
-                        .var_name = try self.allocator.dupe(u8, ns_var_name),
-                        .shared_target_mod_idx = target,
-                    });
                     break :blk ns_var_name;
                 }
                 const fresh = try makeUniqueNsVarName(self, exp.exported, &seen_exports);
@@ -164,13 +156,7 @@ pub fn registerNamespaceRewrites(
     // 후자의 경우 codegen fallback 이 namespace 객체 access 로 emit 할 수 있도록 객체가 필요.
     if (force_inline or has_shadow) {
         if (self.use_shared_ns_preamble) {
-            const ns_var_name = try getOrCreateSharedNamespaceVar(self, target_mod_idx, &seen_exports);
-            try ns_inline_list.append(self.allocator, .{
-                .symbol_id = symbol_id,
-                .object_literal = try self.allocator.dupe(u8, ""),
-                .var_name = try self.allocator.dupe(u8, ns_var_name),
-                .shared_target_mod_idx = target_mod_idx,
-            });
+            _ = try appendSharedNsInlineEntry(self, ns_inline_list, symbol_id, target_mod_idx, &seen_exports);
         } else {
             const obj_str = try buildInlineObjectStr(self, target_mod_idx, 0);
             const ns_var_name = try makeUniqueNsVarName(self, var_name, &seen_exports);
@@ -181,6 +167,27 @@ pub fn registerNamespaceRewrites(
             });
         }
     }
+}
+
+/// shared namespace cache 에 declaration-only entry 추가. `getOrCreateSharedNamespaceVar`
+/// 로 청크-glob 한 var name 발급 + ns_inline_list 에 빈 object_literal 로 등록 (실 literal
+/// 은 ns_shared_inline_cache 가 보유, 청크 emit 단계가 정의자 청크 preamble 로 inline).
+/// 반환값은 var name — caller 가 inner_map 등에 사용.
+fn appendSharedNsInlineEntry(
+    self: *const Linker,
+    ns_inline_list: *std.ArrayList(LinkingMetadata.NsInlineObjects.Entry),
+    symbol_id: ?u32,
+    target_mod_idx: u32,
+    seen_exports: *std.StringHashMap(void),
+) std.mem.Allocator.Error![]const u8 {
+    const ns_var_name = try getOrCreateSharedNamespaceVar(self, target_mod_idx, seen_exports);
+    try ns_inline_list.append(self.allocator, .{
+        .symbol_id = symbol_id,
+        .object_literal = try self.allocator.dupe(u8, ""),
+        .var_name = try self.allocator.dupe(u8, ns_var_name),
+        .shared_target_mod_idx = target_mod_idx,
+    });
+    return ns_var_name;
 }
 
 fn getOrCreateSharedNamespaceVar(
@@ -227,8 +234,8 @@ pub fn appendSharedNamespacePreamble(self: *const Linker, out: *std.ArrayList(u8
 }
 
 /// 특정 청크의 정의자 모듈에 속한 namespace 만 emit. `target_filter` 가 non-null 이면
-/// 그 set 에 속한 target_mod_idx 만 inline (splitting / manualChunks #2990 fix —
-/// referrer 청크가 아닌 정의자 청크의 preamble 에 namespace 가 위치하도록).
+/// 그 set 에 속한 target_mod_idx 만 inline — splitting / manualChunks 시 referrer
+/// 청크가 아닌 정의자 청크의 preamble 에 namespace 가 위치하도록 한다.
 /// null 이면 전 namespace inline (single-file bundle 호환).
 pub fn appendSharedNamespacePreambleFiltered(
     self: *const Linker,


### PR DESCRIPTION
## Summary

splitting / manualChunks 모드에서 namespace import (\`import * as core\`) 의 object literal (\`var core_ns = {...}\`) 가 referrer 모듈 self-preamble 에 inline → vendor 코드가 entry 청크에 ~4KB 누출. 회귀 가드 fail.

Closes #2990

## Root cause

- \`emitter.zig:589\` 의 \`use_shared_ns_preamble = true\` 가 single-file \`emit()\` 만 set. \`emitChunks\` (splitting/manualChunks path) 는 미설정.
- 추가로 \`shared_namespace.registerNamespaceRewrites\` 의 ns_target_mod re-export path (line 117-130) 는 \`use_shared_ns_preamble\` 활성 시도 shared cache 에 등록 안 함 — 미완성 구현.

## Fix

1. \`emitChunks\` 시작 시 \`linker.use_shared_ns_preamble = true\` (single-file path 와 동일)
2. ns_target_mod re-export path 도 shared cache 등록 → referrer self-preamble 에는 빈 object_literal
3. \`appendSharedNamespacePreambleFiltered(out, chunk_target_set)\` 추가 — 청크 modules set 으로 filter
4. \`chunks.zig\` 청크 emit 시 external imports 다음, modules 코드 전에 chunk-filtered preamble 호출

## 검증

### 회귀 가드
\`tests/manual-chunks-smoke.test.ts\` 의 zod 케이스 (\`expect(entry × 10 < vendor)\`):
- 이전: entry × 10 = 536,870 > vendor 495,989 (tolerance 10.8%, ~4KB 초과)
- **이번 PR: 32/32 통과**

### 전체
- 통합 테스트 전체: **3711 pass / 0 fail** (이전 baseline 1 fail 이 이번 fix 대상)
- \`zig build test\` 통과
- sourcemap / round5-sourcemap 등 무관 회귀 0

## 영향

- entry 청크가 \`var core_ns = {...}\` 거대 object literal 을 보유하지 않음 → entry size 감소
- vendor 청크가 자기 정의 namespace 를 자체 preamble 에 inline → 정의자 청크 self-contained
- Sentry / DevTools production debugging 에서 **vendor cache hit rate 개선** — vendor 코드 변경이 entry preamble 에 leak 안 됨
- single-file bundle (\`emit()\` path) 동작 영향 없음 (이미 same flag 활성)

🤖 Generated with [Claude Code](https://claude.com/claude-code)