### PR TITLE
fix(bundler): UMD/AMD globals 매핑 회귀 — IIFE 와 정책 통일

### DIFF
--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -1549,14 +1549,15 @@ test "Bundler: IIFE + --globals maps external to factory arg (#1824)" {
     try std.testing.expect(!result.hasErrors());
     const output = result.output;
 
-    // factory signature: `var MyLib = ((React, ReactDom) => {` (arrow, ES target 기본값)
-    try std.testing.expect(std.mem.indexOf(u8, output, "var MyLib = ((React, ReactDom) => {") != null);
+    // factory signature: `var MyLib = ((React, ReactDOM) => {` (arrow, ES target 기본값).
+    // globals 매핑 이름 (React/ReactDOM) 으로 factory param/caller arg/preamble 모두 일관.
+    try std.testing.expect(std.mem.indexOf(u8, output, "var MyLib = ((React, ReactDOM) => {") != null);
     // factory call args: 매핑된 전역 (`React, ReactDOM`)
     try std.testing.expect(std.mem.endsWith(u8, output, "})(React, ReactDOM);\n"));
     // named import preamble: `var useState = React.useState;`
     try std.testing.expect(std.mem.indexOf(u8, output, "var useState = React.useState") != null);
-    // default import → factory param 직접 사용
-    try std.testing.expect(std.mem.indexOf(u8, output, "ReactDom") != null);
+    // default import → factory param 직접 사용 (ReactDOM)
+    try std.testing.expect(std.mem.indexOf(u8, output, "ReactDOM") != null);
     // body 에 bare require 없음
     try std.testing.expect(std.mem.indexOf(u8, output, "require(\"react\")") == null);
 }
@@ -1595,6 +1596,8 @@ test "Bundler: UMD external dependencies in wrapper" {
         .format = .umd,
         .external = &.{"react"},
         .global_name = "MyApp",
+        // globals 매핑 필수 — PascalCase 자동 추정 fallback 제거됨.
+        .globals = &.{.{ .specifier = "react", .global_name = "React" }},
     });
     defer b.deinit();
 
@@ -1605,11 +1608,11 @@ test "Bundler: UMD external dependencies in wrapper" {
 
     // UMD wrapper에 dependency array 포함
     try std.testing.expect(std.mem.indexOf(u8, output, "define([\"react\"]") != null);
-    // factory 매개변수 포함
+    // factory 매개변수 = globals 매핑 이름
     try std.testing.expect(std.mem.indexOf(u8, output, "function(React)") != null);
     // CJS 경로에 require("react") 포함
     try std.testing.expect(std.mem.indexOf(u8, output, "require(\"react\")") != null);
-    // IIFE 글로벌 경로
+    // IIFE 글로벌 경로 — globals 매핑 이름 사용
     try std.testing.expect(std.mem.indexOf(u8, output, "root.React") != null);
     // body에 bare require("react") 없음 (factory param으로 대체됨)
     try std.testing.expect(std.mem.indexOf(u8, output, "var React = require(\"react\")") == null);
@@ -2091,6 +2094,8 @@ test "Bundler: AMD external dependencies in wrapper" {
         .entry_points = &.{entry},
         .format = .amd,
         .external = &.{"lodash"},
+        // globals 매핑 필수 — PascalCase 자동 추정 fallback 제거됨.
+        .globals = &.{.{ .specifier = "lodash", .global_name = "Lodash" }},
     });
     defer b.deinit();
 
@@ -2101,7 +2106,7 @@ test "Bundler: AMD external dependencies in wrapper" {
 
     // AMD wrapper에 dependency array 포함
     try std.testing.expect(std.mem.indexOf(u8, output, "define([\"lodash\"]") != null);
-    // factory 매개변수 포함
+    // factory 매개변수 = globals 매핑 이름
     try std.testing.expect(std.mem.indexOf(u8, output, "function(Lodash)") != null);
 }
 

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -349,46 +349,34 @@ pub fn emitWithTreeShaking(
     const use_arrow = !options.unsupported.arrow;
 
     // UMD/AMD/IIFE: external specifier 수집 (dependency array + factory params 생성용).
-    // IIFE 는 globals 매핑된 spec 만 수집 — 매핑 안 된 external 은 unresolved 로 취급되어
-    // linker 가 fatal_diagnostics 로 에러 발행 (#1791).
+    // 세 포맷 모두 `options.globals` 매핑된 spec 만 수록 — 매핑 없는 external 은 linker 가
+    // fatal_diagnostics 로 에러 발행 (#1791). PascalCase 자동 추정 fallback 은 사용자 의도
+    // 와 어긋나는 가짜 동작이라 제거.
     var ext_specifiers: std.ArrayList([]const u8) = .empty;
     defer ext_specifiers.deinit(allocator);
-    // IIFE 는 globals 매핑된 spec 에 대응되는 전역 인자를 수집한다. UMD/AMD 는 사용 안 함.
-    var iife_ext_globals: std.ArrayList([]const u8) = .empty;
-    defer iife_ext_globals.deinit(allocator);
-    const collect_externals = options.format == .umd or options.format == .amd or
-        (options.format == .iife and options.globals.len > 0);
+    var ext_globals: std.ArrayList([]const u8) = .empty;
+    defer ext_globals.deinit(allocator);
+    const collect_externals = (options.format == .umd or options.format == .amd or options.format == .iife) and
+        options.globals.len > 0;
     if (collect_externals) {
         var seen = std.StringHashMap(void).init(allocator);
         defer seen.deinit();
         for (sorted.items) |m| {
             for (m.import_records) |rec| {
                 if (!rec.is_external or seen.contains(rec.specifier)) continue;
-                if (options.format == .iife) {
-                    // IIFE: globals 매핑이 있는 spec 만 factory 파라미터에 수록.
-                    // 매핑이 없는 external 은 linker 가 fatal diagnostic 으로 처리.
-                    if (types.GlobalEntry.lookup(options.globals, rec.specifier)) |gname| {
-                        try seen.put(rec.specifier, {});
-                        try ext_specifiers.append(allocator, rec.specifier);
-                        try iife_ext_globals.append(allocator, gname);
-                    }
-                } else {
+                if (types.GlobalEntry.lookup(options.globals, rec.specifier)) |gname| {
                     try seen.put(rec.specifier, {});
                     try ext_specifiers.append(allocator, rec.specifier);
+                    try ext_globals.append(allocator, gname);
                 }
             }
         }
     }
 
-    // specifier → factory 매개변수명 precompute (UMD/AMD/IIFE 공통)
-    var ext_param_names: std.ArrayList([]const u8) = .empty;
-    defer {
-        for (ext_param_names.items) |n| allocator.free(n);
-        ext_param_names.deinit(allocator);
-    }
-    for (ext_specifiers.items) |spec| {
-        try ext_param_names.append(allocator, try types.specifierToParamName(allocator, spec));
-    }
+    // factory 매개변수명 = globals 매핑 이름 그대로 사용. wrapper 의 `root.<name>` /
+    // factory parameter / caller arg 가 모두 같은 이름으로 일관 (rollup `output.globals` 호환).
+    // ext_globals 는 options.globals 슬라이스 참조라 별도 alloc/free 불필요.
+    const ext_param_names: []const []const u8 = ext_globals.items;
 
     // IIFE + externals 가 있으면 factory_fn 을 param 포함 형태로 조립 (#1824).
     // 예: `(function(React, ReactDom) {\n`. 그 외에는 정적 문자열 사용.
@@ -397,7 +385,7 @@ pub fn emitWithTreeShaking(
     else
         (if (use_arrow) "(() => {\n" else "(function() {\n");
     const factory_fn_owned: ?[]const u8 = blk: {
-        if (options.format != .iife or ext_param_names.items.len == 0) break :blk null;
+        if (options.format != .iife or ext_param_names.len == 0) break :blk null;
         const prefix = if (has_tla)
             (if (use_arrow) "(async (" else "(async function(")
         else
@@ -405,7 +393,7 @@ pub fn emitWithTreeShaking(
         var buf: std.ArrayList(u8) = .empty;
         errdefer buf.deinit(allocator);
         try buf.appendSlice(allocator, prefix);
-        for (ext_param_names.items, 0..) |n, i| {
+        for (ext_param_names, 0..) |n, i| {
             if (i > 0) try buf.appendSlice(allocator, ", ");
             try buf.appendSlice(allocator, n);
         }
@@ -424,7 +412,7 @@ pub fn emitWithTreeShaking(
     var prelude_scope = profile.begin(.emit_prelude);
 
     // 포맷별 prologue
-    try emitFormatPrologue(&output, allocator, options.format, options.global_name, factory_fn, ext_specifiers.items, ext_param_names.items);
+    try emitFormatPrologue(&output, allocator, options.format, options.global_name, factory_fn, ext_specifiers.items, ext_param_names);
 
     if (options.intro_js) |intro| {
         try output.appendSlice(allocator, intro);
@@ -934,7 +922,7 @@ pub fn emitWithTreeShaking(
         if (outro.len > 0 and outro[outro.len - 1] != '\n') try output.append(allocator, '\n');
     }
 
-    try emitFormatEpilogue(&output, allocator, options.format, iife_ext_globals.items);
+    try emitFormatEpilogue(&output, allocator, options.format, ext_globals.items);
 
     // legal comments (eof 모드): 모든 모듈의 legal comment를 파일 끝에 모아서 출력
     const lc_mode = resolveDefaultLegalComments(options.legal_comments, options.minify_whitespace);

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -41,16 +41,21 @@ const EXPR_RENAME_MARKER = linker_mod.EXPR_RENAME_MARKER;
 /// synthetic binding (JSX runtime 등) 은 semantic 이 추적하지 않으므로 "사용 중" 간주.
 /// `references` 가 비어있어도 보수적 보존. 호출자가 `verbatim_module_syntax` 를 먼저
 /// 확인해 true 이면 이 경로를 bypass.
-/// #1824: IIFE + `--globals` 매핑된 external 판정. UMD/AMD 와 동일한 factory-param
-/// preamble 경로로 분기하기 위한 공용 predicate. buildMetadataForAst / buildRequireRewrites
-/// 둘 다 동일 조건을 쓴다.
-inline fn isIifeMappedExternal(
+/// #1824: IIFE/UMD/AMD + `--globals` 매핑된 external 판정 + factory-param 이름 반환.
+/// wrapper 포맷 세 종류 모두 같은 preamble 경로로 분기하며, 매핑 이름까지 한 번에 돌려줘
+/// 호출자가 추가 lookup 없이 사용한다 (hot path 중복 스캔 회피). 매핑 없는 external 은
+/// emitter 가 ext_specifiers 에 넣지 않으므로 linker 도 일관되게 별도 경로로 흘려보낸다.
+inline fn mappedExternalParam(
     format: types.Format,
     globals: []const types.GlobalEntry,
     rec: types.ImportRecord,
-) bool {
-    return rec.is_external and format == .iife and
-        types.GlobalEntry.lookup(globals, rec.specifier) != null;
+) ?[]const u8 {
+    if (!rec.is_external) return null;
+    switch (format) {
+        .iife, .umd, .amd => {},
+        else => return null,
+    }
+    return types.GlobalEntry.lookup(globals, rec.specifier);
 }
 
 pub fn isImportBindingTypeOnly(sem: *const @import("../module.zig").ModuleSemanticData, ib: ImportBinding) bool {
@@ -305,13 +310,11 @@ pub fn buildMetadataForAst(
                     // top-level에 이미 `var _jsxDEV, _Fragment;` 선언이 호이스팅됨.
                     // init 함수 본문에서 `var`로 재선언하면 outer scope를 shadow → #1209.
                     const is_synthetic_esm = ib.isSynthetic() and m.wrap_kind == .esm;
-                    const is_iife_mapped = isIifeMappedExternal(self.format, self.iife_globals, rec);
-                    if (rec.is_external and (self.format == .umd or self.format == .amd or is_iife_mapped)) {
-                        // UMD/AMD/IIFE+globals: factory 매개변수에서 직접 참조.
-                        // 파라미터 이름은 UMD/AMD 관행대로 `specifierToParamName` 결과를 사용한다
-                        // (IIFE 도 emitter 쪽 factory 시그니처와 일치하는 이름 — #1824).
-                        const param_name = try types.specifierToParamName(self.allocator, rec.specifier);
-                        defer self.allocator.free(param_name);
+                    const mapped_param = mappedExternalParam(self.format, self.iife_globals, rec);
+                    if (mapped_param) |param_name| {
+                        // IIFE/UMD/AMD + globals 매핑: factory 매개변수에서 직접 참조.
+                        // 파라미터 이름 = globals 매핑 이름. emitter 의 wrapper factory
+                        // 시그니처와 동일하게 유지 (rollup `output.globals` 호환).
                         if (ib.kind == .namespace or ib.importsDefault()) {
                             // import * as React / import React → factory param 직접 사용
                             if (!std.mem.eql(u8, preamble_name, param_name)) {
@@ -821,12 +824,9 @@ pub fn buildRequireRewrites(self: *const Linker, m: *const Module) !std.StringHa
     for (m.import_records) |rec| {
         if (rec.resolved.isNone()) {
             // UMD/AMD/IIFE+globals: external require → factory 매개변수 참조.
-            // require("react") → React (factory params에서 주입, #1824 IIFE 확장)
-            const iife_mapped = isIifeMappedExternal(self.format, self.iife_globals, rec);
-            if (rec.is_external and (self.format == .umd or self.format == .amd or iife_mapped)) {
+            // require("react") → React (factory params에서 주입, #1824 IIFE 확장).
+            if (mappedExternalParam(self.format, self.iife_globals, rec)) |param| {
                 if (!require_rewrites.contains(rec.specifier)) {
-                    const param = try types.specifierToParamName(self.allocator, rec.specifier);
-                    defer self.allocator.free(param);
                     // "(React)" 형태로 저장 — emitRewriteValue가 '('로 시작하면 ()를 붙이지 않음
                     const owned = try std.fmt.allocPrint(self.allocator, "({s})", .{param});
                     try require_rewrites.put(self.allocator, rec.specifier, owned);


### PR DESCRIPTION
## Summary

UMD/AMD 빌드 시 `--globals SPEC=NAME` 매핑이 wrapper / factory param / body reference 어디에도 반영되지 않고 specifier 의 PascalCase 자동 추정 (`mathlib` → `Mathlib`) 으로 emit 되는 회귀 수정. IIFE 만 epilogue caller args 에서 매핑 사용했고, 그 외 경로는 fallback 으로 흘러갔다. 정밀 점검 (`scripts/strict-format-matrix.ts`) 에서 발견.

### 회귀 재현

```bash
zntc --bundle entry.ts --format=umd -o out.umd.js \
  --external mathlib --external decorlib \
  --globals=mathlib=MLib,decorlib=DLib \
  --global-name=Lib
```

전: `root.Lib = factory(root.Mathlib, root.Decorlib)` / `function(Mathlib, Decorlib)` / `var mlib = Mathlib; var decor = Decorlib.decor;`
후: `root.Lib = factory(root.MLib, root.DLib)` / `function(MLib, DLib)` / `var mlib = MLib; var decor = DLib.decor;`

## 원인 / 수정

- `emitter.zig:389-391` 가 `ext_param_names` 를 `specifierToParamName` 으로 생성하면서 `options.globals` lookup 을 건너뜀
- `linker/metadata.zig` 의 `buildMetadataForAst` / `buildRequireRewrites` 도 body reference 를 동일 PascalCase 로 만들어 wrapper 와 일관성 깨짐

새 정책 (IIFE 와 통일, PascalCase fallback 제거):
- 세 wrapper 포맷 (iife/umd/amd) 모두 `options.globals` 매핑된 spec 만 `ext_specifiers` 에 수록
- 매핑 없는 external 은 linker 가 fatal_diagnostic 발행 (`#1791` 와 동일 경로)
- 매핑 이름을 wrapper / factory param / body reference 어디서나 동일하게 사용 (rollup `output.globals` 호환)

## /simplify 반영

`isIifeMappedExternal(bool)` → `mappedExternalParam(?[]const u8)` 으로 변경해 두 호출처에서 lookup 한 번으로 통합 — hot path 중복 스캔 회피. 불필요 `specifierToParamName` alloc/free 제거.

## Test plan

- [x] `zig build test` 통과 (UMD/AMD/IIFE+globals 회귀 가드 3개 fixture 갱신: 명시 `globals` 매핑 추가)
- [x] `ReleaseFast` 직접 빌드 — UMD/IIFE/AMD wrapper, factory param, body reference 모두 매핑 이름으로 일관
- [x] `scripts/strict-format-matrix.ts` shallow/deep 매트릭스 — 30/30 build, 30/30 sourcemap, 28/30 run modes (나머지 2건은 driver 한계)
- [ ] CI: 144/144 smoke 회귀 없음 (auto-merge 시 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)