### PR TITLE
feat(cli): --external:pkg esbuild 호환 alias 추가

### DIFF
--- a/src/cli/options.zig
+++ b/src/cli/options.zig
@@ -648,6 +648,12 @@ pub fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator)
             if (val.len > 0) {
                 try opts.external_list.append(allocator, val);
             }
+        } else if (std.mem.startsWith(u8, arg, "--external:")) {
+            // esbuild 호환: --external:react (콜론 형식)
+            const val = arg["--external:".len..];
+            if (val.len > 0) {
+                try opts.external_list.append(allocator, val);
+            }
         } else if (std.mem.eql(u8, arg, "--globals")) {
             // --globals react=React (다음 인자)
             if (i + 1 < args.len) {


### PR DESCRIPTION
## Summary

CLI 가 rollup 형식 `--external pkg` / `--external=pkg` 만 받았고 esbuild 의 콜론 형식 (`--external:pkg`) 은 \`zntc: unknown option\` 으로 거부됐다. esbuild → ZNTC 마이그레이션 사용자가 동일 인자 그대로 사용 가능하도록 alias 추가.

\`--alias:K=V\` 는 이미 esbuild 형식 지원. \`--globals\` 는 esbuild 에 동치 옵션 없음 (rollup `output.globals` 호환) 이라 변경 없음.

## Test plan

- [x] `--external:mathlib --external:decorlib --globals=mathlib=MLib,decorlib=DLib --format=umd` 조합 정상 빌드 + 매핑 적용
- [x] 기존 `--external pkg` / `--external=pkg` 경로 회귀 없음 (코드는 새 분기만 추가)
- [ ] CI smoke 144/144 (auto-merge 시 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)