### PR TITLE
docs(cli): --help 에 누락된 핵심 옵션 표시 추가

### DIFF
--- a/src/cli/usage.zig
+++ b/src/cli/usage.zig
@@ -20,20 +20,33 @@ pub fn printUsage(writer: anytype) !void {
         \\Options:
         \\  -o, --out-file <path>            Output file path
         \\  --outdir <path>                  Output directory (for directory input)
+        \\  --outbase=<dir>                  Common parent dir for entry points (preserves tree under --outdir)
         \\  --allow-overwrite                Permit output paths to overwrite input files
-        \\  --minify                         Minify output
+        \\  --minify                         Minify output (whitespace + identifiers + syntax)
+        \\  --minify-whitespace              Remove whitespace only
+        \\  --minify-identifiers             Mangle identifiers only
+        \\  --minify-syntax                  Apply AST-level syntax minification only
+        \\  --keep-names                     Preserve `.name` of fn/class under minification (__name helper)
+        \\  --target=<spec>                  ES version or engine matrix (esnext|es2015..|chrome80,safari14,...)
         \\  --format=esm|cjs|iife|umd|amd    Module format (default: esm)
         \\  --drop=console                   Remove console.* calls
         \\  --drop=debugger                  Remove debugger statements
+        \\  --drop-labels=A,B                Remove labeled blocks named A or B
         \\  --pure:CALLEE                    Mark matching call/new expressions as removable when unused
+        \\  --ignore-annotations             Ignore /* @__PURE__ */ and `sideEffects` field
         \\  --define:KEY=VALUE               Replace KEY with VALUE globally
         \\  --sourcemap                      Generate source map (.js.map)
+        \\  --sourcemap=<mode>               external | inline | linked | both | none
         \\  --sourcemap-debug-ids            Add Sentry debugId to JS and source map
         \\  --ascii-only                     Escape non-ASCII to \uXXXX
+        \\  --charset=utf8                   Force UTF-8 output (no \uXXXX escape)
         \\  --quotes=<style>                 String quote style (double|single|preserve)
+        \\  --legal-comments=<mode>          none | inline | eof — license/legal comment placement
         \\  -w, --watch                      Watch for file changes
+        \\  --watch-delay=<ms>               Debounce window for file events (default: 50)
         \\  -p, --project <path>             Path to tsconfig.json file or directory
         \\  --tsconfig-path <path>           Alias of -p/--project (matches NAPI `tsconfigPath`)
+        \\  --tsconfig-raw=<json>            Inline tsconfig JSON (overrides file/auto-discovery)
         \\  --tokenize                       Print tokens instead of transpiling
         \\  --test262 <dir>                  Run Test262 tests
         \\  -h, --help                       Show this help
@@ -56,9 +69,26 @@ pub fn printUsage(writer: anytype) !void {
         \\  --splitting                      Enable code splitting (requires --outdir)
         \\  --preserve-modules               One file per module (library builds, requires --outdir)
         \\  --preserve-modules-root=<dir>    Root directory for output structure
-        \\  --external <pkg>                 Exclude package (repeatable)
-        \\  --globals SPEC=GLOBAL            IIFE external → global mapping (rollup output.globals)
+        \\  --inline-dynamic-imports         Force dynamic import() into the main chunk
+        \\  --external <pkg>                 Exclude package (repeatable, also: --external=pkg, --external:pkg)
+        \\  --packages=external              Treat every bare import as external
+        \\  --globals SPEC=GLOBAL            UMD/AMD/IIFE external → global mapping (rollup output.globals)
         \\  --globals=SPEC=GLOBAL[,...]      Same, comma-separated form
+        \\  --global-name=<name>             IIFE/UMD container global identifier
+        \\  --alias:K=V                      Force-rewrite import specifier K → V (resolve전)
+        \\  --fallback:K=V                   Map K → V only when normal resolve fails (`=false` → empty)
+        \\  --banner:js=<text>               Prepend text to the JS output
+        \\  --footer:js=<text>               Append text to the JS output
+        \\  --inject:KEY=PATH                Auto-import PATH and bind to KEY in every entry
+        \\  --loader:.ext=<type>             Per-extension loader (js|ts|jsx|tsx|json|text|file|dataurl|binary|copy|css|empty)
+        \\  --public-path=<url>              URL prefix for assets/chunks
+        \\  --entry-names=<pattern>          Entry filename pattern (e.g. `[name]-[hash]`)
+        \\  --chunk-names=<pattern>          Chunk filename pattern
+        \\  --asset-names=<pattern>          Asset filename pattern
+        \\  --metafile                       Emit build metadata to stderr
+        \\  --metafile=<path>                Emit build metadata to file (esbuild compat)
+        \\  --analyze                        Print bundle analyzer summary
+        \\  --shim-missing-exports           Stub-export missing named imports (rolldown compat)
         \\  --conditions=<cond,...>          Custom export conditions (e.g. production)
         \\  --platform=browser|node|neutral  Target platform (default: browser)
         \\  --rn-platform=ios|android        RN sub-platform (.ios.*/.android.* extensions)
@@ -68,12 +98,22 @@ pub fn printUsage(writer: anytype) !void {
         \\  --use-define-for-class-fields=false  Move fields to constructor (assign semantics)
         \\  --verbatim-module-syntax          Preserve unused value imports (TS 5.0+)
         \\
+        \\JSX options:
+        \\  --jsx=<mode>                      preserve | transform | automatic | automatic-dev
+        \\  --jsx-dev                         Shortcut for --jsx=automatic-dev
+        \\  --jsx-factory=<name>              Element factory (classic, default: React.createElement)
+        \\  --jsx-fragment=<name>             Fragment factory (classic, default: React.Fragment)
+        \\  --jsx-import-source=<pkg>         Runtime import source (automatic, default: react)
+        \\  --jsx-side-effects                Preserve unused JSX expressions
+        \\
         \\Flow options:
         \\  --flow                            Enable Flow type stripping (auto-detected via @flow pragma)
         \\
         \\Resolve options:
         \\  --resolve-extensions=<exts>       Comma-separated extension order (e.g. .ios.ts,.ts,.js)
         \\  --main-fields=<fields>            Comma-separated package.json field order (e.g. react-native,browser,main)
+        \\  --node-paths=<dirs>               Comma-separated extra bare-specifier search dirs (NODE_PATH-like)
+        \\  --preserve-symlinks               Resolve symlinks to the link path itself
         \\
         \\Profiling (pipeline timing):
         \\  --profile=<CATS>                  Categories to profile. CSV of:


### PR DESCRIPTION
## Summary

CLI 가 실제로 파싱은 하는데 `--help` 출력에 표시되지 않던 옵션 다수 추가. ROADMAP/CONFIG.md 의 약속과 실제 노출 사이 격차 해소.

정밀 점검 (`scripts/strict-format-matrix.ts`) 작성 중 `--global-name=`, `--banner:js=`, `--keep-names`, `--metafile` 등이 \`--help\` 에 없어 옵션 누락으로 오해. 코드 (`cli/options.zig`) 에는 모두 존재 — 단지 usage 텍스트만 outdated.

## 추가 영역

- **Options**: `--outbase`, `--minify-{whitespace,identifiers,syntax}`, `--keep-names`, `--target`, `--drop-labels`, `--ignore-annotations`, `--sourcemap=<mode>`, `--charset`, `--legal-comments`, `--watch-delay`, `--tsconfig-raw`
- **Bundle**: `--inline-dynamic-imports`, `--packages=external`, `--global-name`, `--alias`, `--fallback`, `--banner:js`, `--footer:js`, `--inject`, `--loader`, `--public-path`, `--entry-names`, `--chunk-names`, `--asset-names`, `--metafile`, `--analyze`, `--shim-missing-exports`
- **JSX (신규 섹션)**: `--jsx`, `--jsx-dev`, `--jsx-factory`, `--jsx-fragment`, `--jsx-import-source`, `--jsx-side-effects`
- **Resolve**: `--node-paths`, `--preserve-symlinks`
- `--external` 줄에 콜론/등호 형식 alias 명시 (esbuild 호환)

## Test plan

- [x] 코드 동작 변경 없음 — `usage.zig` 정적 텍스트만 갱신
- [x] `zntc --help` 출력 124 → 164 라인 (40 라인 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)