### PR TITLE
fix(bundler): AMD/UMD external 의 PascalCase fallback 복원 (IIFE 만 매핑 필수)

### DIFF
--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -1596,8 +1596,7 @@ test "Bundler: UMD external dependencies in wrapper" {
         .format = .umd,
         .external = &.{"react"},
         .global_name = "MyApp",
-        // globals 매핑 필수 — PascalCase 자동 추정 fallback 제거됨.
-        .globals = &.{.{ .specifier = "react", .global_name = "React" }},
+        // globals 매핑 미지정 — UMD 는 PascalCase 자동 추정 (rollup/rolldown 관행).
     });
     defer b.deinit();
 
@@ -2094,8 +2093,7 @@ test "Bundler: AMD external dependencies in wrapper" {
         .entry_points = &.{entry},
         .format = .amd,
         .external = &.{"lodash"},
-        // globals 매핑 필수 — PascalCase 자동 추정 fallback 제거됨.
-        .globals = &.{.{ .specifier = "lodash", .global_name = "Lodash" }},
+        // globals 매핑 미지정 — AMD 는 PascalCase 자동 추정 (rollup/rolldown 관행).
     });
     defer b.deinit();
 

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -349,34 +349,43 @@ pub fn emitWithTreeShaking(
     const use_arrow = !options.unsupported.arrow;
 
     // UMD/AMD/IIFE: external specifier 수집 (dependency array + factory params 생성용).
-    // 세 포맷 모두 `options.globals` 매핑된 spec 만 수록 — 매핑 없는 external 은 linker 가
-    // fatal_diagnostics 로 에러 발행 (#1791). PascalCase 자동 추정 fallback 은 사용자 의도
-    // 와 어긋나는 가짜 동작이라 제거.
+    // 정책:
+    //   - IIFE: caller args 가 글로벌 변수 직접 참조라 `options.globals` 매핑 필수.
+    //     매핑 없는 external 은 linker 가 fatal_diagnostics 로 에러 발행 (#1791).
+    //   - UMD/AMD: 모든 external 수록. 매핑 우선, 없으면 specifier 의 PascalCase 자동 추정
+    //     (`react` → `React`) — rollup/rolldown 관행과 일치. wrapper / factory param /
+    //     body reference 가 동일 이름 사용해 일관 유지.
     var ext_specifiers: std.ArrayList([]const u8) = .empty;
     defer ext_specifiers.deinit(allocator);
-    var ext_globals: std.ArrayList([]const u8) = .empty;
-    defer ext_globals.deinit(allocator);
-    const collect_externals = (options.format == .umd or options.format == .amd or options.format == .iife) and
-        options.globals.len > 0;
+    var ext_param_names_buf: std.ArrayList([]const u8) = .empty;
+    defer {
+        for (ext_param_names_buf.items) |n| allocator.free(n);
+        ext_param_names_buf.deinit(allocator);
+    }
+    const requires_globals_mapping = options.format == .iife;
+    const collect_externals = options.format == .umd or options.format == .amd or
+        (options.format == .iife and options.globals.len > 0);
     if (collect_externals) {
         var seen = std.StringHashMap(void).init(allocator);
         defer seen.deinit();
         for (sorted.items) |m| {
             for (m.import_records) |rec| {
                 if (!rec.is_external or seen.contains(rec.specifier)) continue;
-                if (types.GlobalEntry.lookup(options.globals, rec.specifier)) |gname| {
-                    try seen.put(rec.specifier, {});
-                    try ext_specifiers.append(allocator, rec.specifier);
-                    try ext_globals.append(allocator, gname);
-                }
+                const mapped = types.GlobalEntry.lookup(options.globals, rec.specifier);
+                if (requires_globals_mapping and mapped == null) continue;
+                const param = if (mapped) |gname|
+                    try allocator.dupe(u8, gname)
+                else
+                    try types.specifierToParamName(allocator, rec.specifier);
+                errdefer allocator.free(param);
+                try seen.put(rec.specifier, {});
+                try ext_specifiers.append(allocator, rec.specifier);
+                try ext_param_names_buf.append(allocator, param);
             }
         }
     }
 
-    // factory 매개변수명 = globals 매핑 이름 그대로 사용. wrapper 의 `root.<name>` /
-    // factory parameter / caller arg 가 모두 같은 이름으로 일관 (rollup `output.globals` 호환).
-    // ext_globals 는 options.globals 슬라이스 참조라 별도 alloc/free 불필요.
-    const ext_param_names: []const []const u8 = ext_globals.items;
+    const ext_param_names: []const []const u8 = ext_param_names_buf.items;
 
     // IIFE + externals 가 있으면 factory_fn 을 param 포함 형태로 조립 (#1824).
     // 예: `(function(React, ReactDom) {\n`. 그 외에는 정적 문자열 사용.
@@ -922,7 +931,7 @@ pub fn emitWithTreeShaking(
         if (outro.len > 0 and outro[outro.len - 1] != '\n') try output.append(allocator, '\n');
     }
 
-    try emitFormatEpilogue(&output, allocator, options.format, ext_globals.items);
+    try emitFormatEpilogue(&output, allocator, options.format, ext_param_names_buf.items);
 
     // legal comments (eof 모드): 모든 모듈의 legal comment를 파일 끝에 모아서 출력
     const lc_mode = resolveDefaultLegalComments(options.legal_comments, options.minify_whitespace);

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -41,21 +41,32 @@ const EXPR_RENAME_MARKER = linker_mod.EXPR_RENAME_MARKER;
 /// synthetic binding (JSX runtime 등) 은 semantic 이 추적하지 않으므로 "사용 중" 간주.
 /// `references` 가 비어있어도 보수적 보존. 호출자가 `verbatim_module_syntax` 를 먼저
 /// 확인해 true 이면 이 경로를 bypass.
-/// #1824: IIFE/UMD/AMD + `--globals` 매핑된 external 판정 + factory-param 이름 반환.
-/// wrapper 포맷 세 종류 모두 같은 preamble 경로로 분기하며, 매핑 이름까지 한 번에 돌려줘
-/// 호출자가 추가 lookup 없이 사용한다 (hot path 중복 스캔 회피). 매핑 없는 external 은
-/// emitter 가 ext_specifiers 에 넣지 않으므로 linker 도 일관되게 별도 경로로 흘려보낸다.
+/// #1824: IIFE/UMD/AMD wrapper 의 external → factory-param 이름 결정.
+/// 정책:
+///   - IIFE: `--globals` 매핑된 spec 만 반환 (없으면 null → linker 가 fatal #1791).
+///     caller args 가 글로벌 변수 참조라 사용자가 명시 안 하면 어떤 이름인지 알 수 없음.
+///   - UMD/AMD: 매핑 우선, 없으면 specifier 의 PascalCase 자동 추정 (rollup/rolldown 관행).
+///     emitter 가 동일 정책으로 wrapper 의 factory param 을 만들기 때문에 일관 유지.
+/// 반환 slice 는 allocator 소유 — 호출자가 free.
 inline fn mappedExternalParam(
     format: types.Format,
     globals: []const types.GlobalEntry,
     rec: types.ImportRecord,
-) ?[]const u8 {
+    allocator: std.mem.Allocator,
+) std.mem.Allocator.Error!?[]const u8 {
     if (!rec.is_external) return null;
+    const mapped = types.GlobalEntry.lookup(globals, rec.specifier);
     switch (format) {
-        .iife, .umd, .amd => {},
+        .iife => {
+            const gname = mapped orelse return null;
+            return try allocator.dupe(u8, gname);
+        },
+        .umd, .amd => {
+            if (mapped) |gname| return try allocator.dupe(u8, gname);
+            return try types.specifierToParamName(allocator, rec.specifier);
+        },
         else => return null,
     }
-    return types.GlobalEntry.lookup(globals, rec.specifier);
 }
 
 pub fn isImportBindingTypeOnly(sem: *const @import("../module.zig").ModuleSemanticData, ib: ImportBinding) bool {
@@ -310,11 +321,11 @@ pub fn buildMetadataForAst(
                     // top-level에 이미 `var _jsxDEV, _Fragment;` 선언이 호이스팅됨.
                     // init 함수 본문에서 `var`로 재선언하면 outer scope를 shadow → #1209.
                     const is_synthetic_esm = ib.isSynthetic() and m.wrap_kind == .esm;
-                    const mapped_param = mappedExternalParam(self.format, self.iife_globals, rec);
+                    const mapped_param = try mappedExternalParam(self.format, self.iife_globals, rec, self.allocator);
                     if (mapped_param) |param_name| {
-                        // IIFE/UMD/AMD + globals 매핑: factory 매개변수에서 직접 참조.
-                        // 파라미터 이름 = globals 매핑 이름. emitter 의 wrapper factory
-                        // 시그니처와 동일하게 유지 (rollup `output.globals` 호환).
+                        defer self.allocator.free(param_name);
+                        // IIFE/UMD/AMD: factory 매개변수에서 직접 참조. emitter 의 wrapper
+                        // factory 시그니처와 동일 이름 (rollup `output.globals` 호환).
                         if (ib.kind == .namespace or ib.importsDefault()) {
                             // import * as React / import React → factory param 직접 사용
                             if (!std.mem.eql(u8, preamble_name, param_name)) {
@@ -825,7 +836,8 @@ pub fn buildRequireRewrites(self: *const Linker, m: *const Module) !std.StringHa
         if (rec.resolved.isNone()) {
             // UMD/AMD/IIFE+globals: external require → factory 매개변수 참조.
             // require("react") → React (factory params에서 주입, #1824 IIFE 확장).
-            if (mappedExternalParam(self.format, self.iife_globals, rec)) |param| {
+            if (try mappedExternalParam(self.format, self.iife_globals, rec, self.allocator)) |param| {
+                defer self.allocator.free(param);
                 if (!require_rewrites.contains(rec.specifier)) {
                     // "(React)" 형태로 저장 — emitRewriteValue가 '('로 시작하면 ()를 붙이지 않음
                     const owned = try std.fmt.allocPrint(self.allocator, "({s})", .{param});


### PR DESCRIPTION
## Summary

PR #2994 (`fix(bundler): UMD/AMD/IIFE globals 매핑 정책 통일`) 가 AMD/UMD 도 globals 매핑 필수로 바꾸면서 rollup/rolldown 의 관행 (매핑 없으면 PascalCase 자동 추정) 과 어긋났습니다. CI 에서 \`packages/core/test/core/edge-combinations/react.ts\` 의 \"React: AMD + external → define 래핑\" 테스트가 `external: ['react']` 만 지정해도 빌드되리라 기대해서 fail.

Closes #3000

## 다른 번들러 관행

- **esbuild**: UMD/AMD 미지원
- **rollup / rolldown**: `external: ['react']` + `output.globals` 없으면 PascalCase 자동 추정 (`react` → `React`) + warning 출력
- **rspack**: `externals` 명시로 자동 매핑

ZNTC 만 fatal 처리하면 사용자 친화성 떨어짐 + 다른 번들러에서 ZNTC 로 마이그레이션 시 매번 globals 명시 강제 → 핵심 사용 패턴 깨짐.

## 정책 재정리

| 포맷 | 매핑 정책 | 이유 |
|---|---|---|
| **IIFE** | 매핑 필수 (없으면 fatal #1791) | caller args 가 글로벌 변수 참조 — 사용자가 어떤 이름인지 명시 안 하면 알 수 없음 |
| **UMD / AMD** | 매핑 우선 + PascalCase fallback | dependency array (`["react"]`) 는 spec 그대로, factory param 은 임의 이름 가능 — rollup/rolldown 호환 |

PR #2994 의 핵심 fix (wrapper/factory param/body reference 일관성) 은 유지. 단 fallback 허용으로 사용 편의 복원.

## 변경

- **emitter.zig**: `collect_externals` 가 UMD/AMD 는 모든 external 수록, IIFE 는 globals 매핑된 spec 만 수록. `ext_param_names` 는 매핑 우선 + PascalCase fallback (owned slice). wrapper/factory/body 모두 동일 이름 일관 유지.
- **linker/metadata.zig**: `mappedExternalParam` 이 allocator 받아 owned slice 반환. IIFE 는 매핑 없으면 null, UMD/AMD 는 PascalCase fallback. 호출자가 `defer free`.
- **bundler_test/basic.zig**: PR #2994 에서 추가했던 UMD/AMD globals 명시 제거 (rollup/rolldown 관행 따른 사용 패턴 복원).

## Test plan

- [x] `zig build test`: UMD/AMD/IIFE 관련 테스트 통과 (RN codegen snapshot 25개 fail 은 별도 baseline 이슈)
- [x] AMD `--external react` 만으로 `define([\"react\"], function(React) { React.createElement... })` 정상 빌드
- [x] UMD `--external react --global-name=MyApp` 만으로 `root.MyApp = factory(root.React)` + `function(React)` 정상 빌드
- [x] IIFE 매핑 없으면 `unresolved import \"react\" cannot be emitted in IIFE format` fatal 유지
- [x] IIFE `--globals=react=React` 명시 시 정상 빌드
- [ ] CI: `packages/core/test/core/edge-combinations/react.ts` AMD 테스트 통과 (auto-merge 시 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)