### PR TITLE
feat(transformer): react-refresh 에 Vite plugin-react 호환 path filter 추가

### DIFF
--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -70,6 +70,11 @@ pub const Transformer = struct {
     /// 설정
     options: TransformOptions,
 
+    /// `options.react_refresh` + `options.jsx_filename` 의 Vite plugin-react path filter
+    /// (`.[jt]sx?$`/`.mjs$` + `node_modules` 제외) 결합 결과. jsx_filename 이 모듈 단위
+    /// 고정이라 init 시점에 한 번 계산. 함수 노드마다 호출되는 hot path 에서 path 재스캔 회피.
+    refresh_enabled_cached: bool = false,
+
     /// allocator (ArrayList 호출에 필요)
     allocator: std.mem.Allocator,
 
@@ -548,6 +553,7 @@ pub const Transformer = struct {
     const refresh = @import("transformer/refresh.zig");
     pub const isComponentName = refresh.isComponentName;
     pub const getFunctionName = refresh.getFunctionName;
+    pub const refreshEnabled = refresh.refreshEnabled;
     pub const maybeRegisterRefreshComponent = refresh.maybeRegisterRefreshComponent;
     pub const maybeRegisterRefreshComponentByBinding = refresh.maybeRegisterRefreshComponentByBinding;
     pub const makeRefreshHandle = refresh.makeRefreshHandle;

--- a/src/transformer/transformer/declarations.zig
+++ b/src/transformer/transformer/declarations.zig
@@ -288,7 +288,7 @@ pub fn visitFunction(self: *Transformer, node: Node) Error!NodeIndex {
     // hot path 영향 0 (옵션 read + early-return). opt-in 시 babel-plugin-react-refresh
     // 동등 emit. `findHookCallsInNodeDepth` 가 depth=50 + node tag whitelist +
     // bounds check 로 stale 인덱스 방어.
-    if (self.options.react_refresh and self.options.react_refresh_hook_signatures) {
+    if (self.refreshEnabled() and self.options.react_refresh_hook_signatures) {
         const fn_name_for_sig: ?[]const u8 = blk: {
             if (new_name.isNone()) break :blk null;
             const name_node = self.ast.getNode(new_name);

--- a/src/transformer/transformer/driver.zig
+++ b/src/transformer/transformer/driver.zig
@@ -61,8 +61,9 @@ pub fn transform(self: anytype) Error!NodeIndex {
         }
     }
 
-    // React Fast Refresh: 컴포넌트 등록 코드를 프로그램 끝에 추가 ($RefreshReg$만, $RefreshSig$ 제거)
-    if (self.options.react_refresh and self.plugins.refresh.registrations.items.len > 0) {
+    // React Fast Refresh: 컴포넌트 등록 코드를 프로그램 끝에 추가 ($RefreshReg$만, $RefreshSig$ 제거).
+    // refreshEnabled() 가 path filter (Vite plugin-react 호환 — `.[jt]sx?$`/`.mjs$` + node_modules 제외) 까지 검증.
+    if (self.refreshEnabled() and self.plugins.refresh.registrations.items.len > 0) {
         root = try self.appendRefreshRegistrations(root);
     }
 

--- a/src/transformer/transformer/lifecycle.zig
+++ b/src/transformer/transformer/lifecycle.zig
@@ -50,6 +50,7 @@ fn finishInit(
         .ast = ast_ptr,
         .parser_node_count = parser_count,
         .options = opts,
+        .refresh_enabled_cached = @import("refresh.zig").computeRefreshEnabled(opts),
         .allocator = allocator,
         .scratch = .empty,
         .pending_nodes = .empty,

--- a/src/transformer/transformer/refresh.zig
+++ b/src/transformer/transformer/refresh.zig
@@ -28,6 +28,33 @@ pub fn isComponentName(name: []const u8) bool {
     return name[0] >= 'A' and name[0] <= 'Z';
 }
 
+/// Vite core `JS_TYPES_RE` (`/\.(?:j|t)sx?$|\.mjs$/`) 매칭 확장자 — plugin-react 기본 filter.
+const refresh_target_extensions = [_][]const u8{ ".js", ".jsx", ".ts", ".tsx", ".mjs" };
+
+/// 파일 경로가 `@vitejs/plugin-react` 기본 filter 와 호환되는지 — `.[jt]sx?` 또는
+/// `.mjs` 확장자 + `node_modules` 제외. plugin-react 의 default `include`/`exclude` 정확 일치.
+fn isRefreshTargetPath(path: []const u8) bool {
+    if (path.len == 0) return true; // path 정보 없으면 보수적으로 허용 (transpile direct API 등)
+    if (std.mem.indexOf(u8, path, "/node_modules/") != null) return false;
+    const last_dot = std.mem.lastIndexOfScalar(u8, path, '.') orelse return false;
+    const ext = path[last_dot..];
+    for (refresh_target_extensions) |target| {
+        if (std.mem.eql(u8, ext, target)) return true;
+    }
+    return false;
+}
+
+/// `Transformer.refresh_enabled_cached` 의 init 값 계산. `lifecycle.finishInit` 에서 호출.
+pub fn computeRefreshEnabled(opts: @import("../transformer.zig").TransformOptions) bool {
+    if (!opts.react_refresh) return false;
+    return isRefreshTargetPath(opts.jsx_filename);
+}
+
+/// react-refresh transform 활성화 여부 — init 시 계산한 캐시 값 read. hot path 안전.
+pub inline fn refreshEnabled(self: *const Transformer) bool {
+    return self.refresh_enabled_cached;
+}
+
 /// 함수 노드에서 이름 텍스트를 추출한다.
 /// function_declaration의 extra[0]이 binding_identifier.
 /// ast의 extra_data에서 읽음 (visitFunction이 이미 노드를 생성했으므로).
@@ -44,7 +71,7 @@ pub fn getFunctionName(self: *Transformer, func_node: Node) ?[]const u8 {
 /// 변환된 함수 노드가 React 컴포넌트이면 등록 정보를 수집한다.
 /// visitFunction에서 호출.
 pub fn maybeRegisterRefreshComponent(self: *Transformer, new_func_idx: NodeIndex) Error!void {
-    if (!self.options.react_refresh) return;
+    if (!refreshEnabled(self)) return;
     if (self.plugins.refresh.suppress_registration) return;
 
     const func_node = self.ast.getNode(new_func_idx);
@@ -65,7 +92,7 @@ pub fn maybeRegisterRefreshComponentByBinding(
     init_idx: NodeIndex,
     binding_name: []const u8,
 ) Error!void {
-    if (!self.options.react_refresh) return;
+    if (!refreshEnabled(self)) return;
     if (self.plugins.refresh.suppress_registration) return;
     if (init_idx.isNone()) return;
     if (!isComponentName(binding_name)) return;
@@ -347,7 +374,7 @@ pub fn isHookCall(name: []const u8) bool {
 /// ast에서 함수 body 내의 Hook 호출을 스캔하여 시그니처 문자열을 생성한다.
 /// Hook이 없으면 null 반환.
 pub fn scanHookSignature(self: *Transformer, func_body_idx: NodeIndex) Error!?[]const u8 {
-    if (!self.options.react_refresh) return null;
+    if (!refreshEnabled(self)) return null;
     if (func_body_idx.isNone()) return null;
 
     var sig_buf: std.ArrayList(u8) = .empty;
@@ -522,7 +549,7 @@ pub fn maybeRegisterRefreshSignature(
     old_body_idx: NodeIndex,
     new_body: *NodeIndex,
 ) Error!void {
-    if (!self.options.react_refresh) return;
+    if (!refreshEnabled(self)) return;
     if (!self.options.react_refresh_hook_signatures) return;
     const name = func_name orelse return;
     if (!isComponentName(name)) return;


### PR DESCRIPTION
## Summary

`react_refresh` 옵션이 켜지면 모든 모듈 (Vue/Svelte/CSS-in-JS 등 포함) 의 PascalCase 함수에 register 코드가 삽입되던 문제 — `@vitejs/plugin-react` 의 default filter 와 정확히 일치하는 path 조건으로 좁힘.

## 기존 동작

- 데브 모드 (`--dev` / `zntc dev`) → 무조건 활성화
- 파일 확장자 / 경로 무관 → 모든 PascalCase 함수에 `_c = Foo; $RefreshReg$(_c, "Foo")` 삽입
- React Fast Refresh runtime 없으면 noop 이라 무해하나, 출력 비용 증가 + 다른 번들러 관행과 불일치

## 다른 번들러 정책

- **Vite (`@vitejs/plugin-react`)**: `include: /\.[tj]sx?$/, exclude: /\/node_modules\//`
- **Next.js**: `pages/`/`app/` 라우터 디렉토리 + JSX 확장자
- **Rspack/Webpack (`react-refresh-webpack-plugin`)**: 사용자 `test` rule 명시
- **esbuild**: 자체 변환 없음

## 적용 정책 (Vite 호환)

- **Include 확장자**: `.js` / `.jsx` / `.ts` / `.tsx` / `.mjs`
- **Exclude 경로**: `/node_modules/` 포함
- Vite core `JS_TYPES_RE` (`/\.(?:j|t)sx?$|\.mjs$/`) 와 정확 일치

## 변경

- **refresh.zig**: `isRefreshTargetPath` (path filter) + `computeRefreshEnabled` 신규. extension 매칭 lookup table 화.
- **Transformer**: `refresh_enabled_cached: bool` 필드 + `finishInit` 에서 1회 계산. 함수 노드마다 호출되는 hot path 에서 path 재스캔 회피.
- 기존 `options.react_refresh` 게이트 5곳 (refresh.zig / declarations.zig / driver.zig) 을 `self.refreshEnabled()` 로 교체.

## /simplify 반영

- **Reuse**: clean (refresh 전용 정책 — bundler `ModuleType.isJavaScriptLike` 와 의도 다름)
- **Quality**: extension or 체인 → lookup table 로 가독성 보강
- **Efficiency**: hot path 매번 path scan → init 시 cache (`refresh_enabled_cached`)

## Test plan

- [x] `zig build test` 통과 (error 0)
- [x] `--bundle App.tsx --dev` → register 2개 (App + Helper)
- [x] `--bundle node_modules/lib/index.tsx --dev` → register 0개 (skip)
- [x] 프로덕션 빌드 (`--dev` 없음) → register 0개 (기존 유지)
- [ ] CI: smoke + integration 회귀 없음 (auto-merge 시 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)