### PR TITLE
test(transformer): react-refresh Vite path filter 회귀 가드 추가

### DIFF
--- a/src/bundler/bundler_test/splitting_dev.zig
+++ b/src/bundler/bundler_test/splitting_dev.zig
@@ -1501,6 +1501,65 @@ test "Bundler: dev mode refresh registration" {
     try std.testing.expect(std.mem.indexOf(u8, output, "_s(App") == null);
 }
 
+// ----------------------------------------------------------------
+// react-refresh Vite plugin-react 호환 path filter 회귀 가드
+// ----------------------------------------------------------------
+
+test "Bundler: refresh — node_modules entry skipped by Vite-compatible path filter" {
+    // node_modules 안에 있는 모듈은 PascalCase 함수여도 $RefreshReg$ 등록 코드를
+    // 주입하지 않는다 (Vite @vitejs/plugin-react 의 default exclude).
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath("node_modules/lib");
+    try writeFile(tmp.dir, "node_modules/lib/index.tsx",
+        \\export default function LibComp() { return 1; }
+    );
+
+    const entry = try absPath(&tmp, "node_modules/lib/index.tsx");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .react_refresh = true,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+
+    // node_modules 모듈은 register 코드가 들어가지 않아야 한다 — runtime stub
+    // (`g.$RefreshReg$ = function() {}`) 은 별도라 `_c = LibComp;` 패턴으로 검증.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "_c = LibComp") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$RefreshReg$(_c, \"LibComp\"") == null);
+}
+
+test "Bundler: refresh — user-land .tsx still registers (positive control)" {
+    // 위 음성 케이스의 짝 — 동일 fixture 패턴에서 path 만 다른 경우 register 가 들어간다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "Comp.tsx",
+        \\export default function MyComp() { return 1; }
+    );
+
+    const entry = try absPath(&tmp, "Comp.tsx");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .react_refresh = true,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$RefreshReg$(_c, \"MyComp\"") != null);
+}
+
 test "Bundler: dev mode ES5 runtime helpers injected globally" {
     // Phase 2: ES5 타겟 dev mode에서 __classCallCheck 등 헬퍼가 모듈 코드 앞에 주입
     var tmp = std.testing.tmpDir(.{});

--- a/src/transformer/transformer/refresh.zig
+++ b/src/transformer/transformer/refresh.zig
@@ -616,3 +616,70 @@ pub fn insertSigCallAtBodyStart(self: *Transformer, body_idx: NodeIndex, handle_
         .data = .{ .list = new_list },
     });
 }
+
+// ================================================================
+// Tests — path filter (Vite plugin-react 기본 include/exclude 호환)
+// ================================================================
+
+test "isRefreshTargetPath: include extensions" {
+    try std.testing.expect(isRefreshTargetPath("/src/App.tsx"));
+    try std.testing.expect(isRefreshTargetPath("/src/App.ts"));
+    try std.testing.expect(isRefreshTargetPath("/src/App.jsx"));
+    try std.testing.expect(isRefreshTargetPath("/src/App.js"));
+    try std.testing.expect(isRefreshTargetPath("/src/App.mjs"));
+}
+
+test "isRefreshTargetPath: exclude non-JS extensions" {
+    try std.testing.expect(!isRefreshTargetPath("/src/App.css"));
+    try std.testing.expect(!isRefreshTargetPath("/src/App.vue"));
+    try std.testing.expect(!isRefreshTargetPath("/src/App.svelte"));
+    try std.testing.expect(!isRefreshTargetPath("/src/App.zig"));
+    try std.testing.expect(!isRefreshTargetPath("/src/App.json"));
+    try std.testing.expect(!isRefreshTargetPath("/src/App.cjs"));
+    try std.testing.expect(!isRefreshTargetPath("/src/App.cts"));
+    try std.testing.expect(!isRefreshTargetPath("/src/Makefile"));
+}
+
+test "isRefreshTargetPath: exclude /node_modules/ regardless of extension" {
+    try std.testing.expect(!isRefreshTargetPath("/project/node_modules/react/index.tsx"));
+    try std.testing.expect(!isRefreshTargetPath("/project/node_modules/foo/bar/Baz.tsx"));
+    try std.testing.expect(!isRefreshTargetPath("/a/node_modules/.pnpm/x/dist/y.jsx"));
+    // node_modules 가 path 의 일부지만 segment 경계가 아닌 경우 — `/foo_node_modules_bar/`
+    // 같은 fake match 는 거의 안 일어나지만 Vite 동작 (substring 검사) 그대로 유지.
+}
+
+test "isRefreshTargetPath: empty path → conservative allow" {
+    // jsx_filename 이 비어있는 transpile direct API 경로는 보수적으로 허용.
+    try std.testing.expect(isRefreshTargetPath(""));
+}
+
+test "isRefreshTargetPath: no extension" {
+    try std.testing.expect(!isRefreshTargetPath("/src/script"));
+}
+
+test "computeRefreshEnabled: react_refresh=false short-circuits filter" {
+    const TransformOptions = @import("../transformer.zig").TransformOptions;
+    const opts: TransformOptions = .{ .react_refresh = false, .jsx_filename = "/src/App.tsx" };
+    try std.testing.expect(!computeRefreshEnabled(opts));
+}
+
+test "computeRefreshEnabled: react_refresh=true + matching path" {
+    const TransformOptions = @import("../transformer.zig").TransformOptions;
+    const opts: TransformOptions = .{ .react_refresh = true, .jsx_filename = "/src/App.tsx" };
+    try std.testing.expect(computeRefreshEnabled(opts));
+}
+
+test "computeRefreshEnabled: react_refresh=true + non-matching path → false" {
+    const TransformOptions = @import("../transformer.zig").TransformOptions;
+    const opts: TransformOptions = .{ .react_refresh = true, .jsx_filename = "/src/App.css" };
+    try std.testing.expect(!computeRefreshEnabled(opts));
+}
+
+test "computeRefreshEnabled: react_refresh=true + node_modules → false" {
+    const TransformOptions = @import("../transformer.zig").TransformOptions;
+    const opts: TransformOptions = .{
+        .react_refresh = true,
+        .jsx_filename = "/project/node_modules/react/index.tsx",
+    };
+    try std.testing.expect(!computeRefreshEnabled(opts));
+}


### PR DESCRIPTION
## Summary

PR #3003 (`react-refresh 에 Vite plugin-react 호환 path filter`) 의 동작을 보장하는 단위 + 통합 테스트 추가. 직전엔 직접 명령어 호출로만 검증했던 부분을 `zig build test` 회귀 가드로 고정.

## 추가

### refresh.zig 단위 테스트 8건

`isRefreshTargetPath` / `computeRefreshEnabled` 의 pure function 동작 검증:
- 매칭 확장자 5종 통과 (`.js` / `.jsx` / `.ts` / `.tsx` / `.mjs`)
- 비 매칭 확장자 skip (`.css` / `.vue` / `.svelte` / `.zig` / `.json` / `.cjs` / `.cts` / 확장자 없음)
- `/node_modules/` 포함 path 는 확장자 무관 skip
- 빈 path → 보수적 허용 (transpile direct API 경로)
- `react_refresh=false` → filter 호출 전 short-circuit
- `react_refresh=true` + 매칭/비매칭/node_modules 조합

### bundler_test/splitting_dev.zig 통합 테스트 2건

음성/양성 control 짝:
- **`refresh — node_modules entry skipped`**: node_modules 안의 PascalCase 컴포넌트에 `_c = LibComp;` / `$RefreshReg$(_c, "LibComp")` 가 없는지
- **`refresh — user-land .tsx still registers`**: 같은 패턴의 user-land `.tsx` 에는 `$RefreshReg$(_c, "MyComp")` 가 들어가는지

## Test plan

- [x] `zig build test` 통과 (error 0). 추가된 10개 테스트 모두 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)