### PR TITLE
fix(wasm): #3005 Node init() default 호출 시 url.fileURLToPath 누락

### DIFF
--- a/packages/wasm/index.ts
+++ b/packages/wasm/index.ts
@@ -164,11 +164,17 @@ async function resolveWasmSource(
   defaultFile: string,
 ): Promise<BufferSource | WebAssembly.Module | Response> {
   if (input === undefined) {
-    const fs = await import('fs');
-    const path = await import('path');
-    const url = await import('url');
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const url = await import('node:url');
     const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
-    return fs.readFileSync(path.join(__dirname, defaultFile));
+    // dist/index.js 기준으로 .wasm 은 publish layout 상 package root 에 있음.
+    // dist/ 안에 wasm 을 둘 수도 있어 두 위치 모두 시도.
+    const candidates = [path.join(__dirname, defaultFile), path.join(__dirname, '..', defaultFile)];
+    for (const candidate of candidates) {
+      if (fs.existsSync(candidate)) return fs.readFileSync(candidate);
+    }
+    throw new Error(`zntc-wasm: ${defaultFile} not found near ${__dirname}`);
   }
   if (input instanceof WebAssembly.Module) return input;
   if (input instanceof Response) return input;

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build:wasm": "cd ../.. && zig build wasm && zig build wasm-bundler",
-    "build:js": "bun build index.ts --outdir dist --format esm --target browser",
+    "build:js": "bun build index.ts --outdir dist --format esm --target browser --external 'node:*'",
     "build:dts": "bun x tsc -b",
     "build": "bun run build:wasm && cp ../../zig-out/bin/zntc.wasm . && cp ../../zig-out/bin/zntc-bundler.wasm . && bun run build:js && bun run build:dts",
     "test": "bun test --timeout 10000",


### PR DESCRIPTION
Closes #3005

## 증상

\`\`\`js
import { init } from '@zntc/wasm';
await init();
// → TypeError: url.fileURLToPath is not a function
\`\`\`

## 원인 (두 단계)

1. \`resolveWasmSource\` 의 dynamic import 가 \`'url'\` (no \`node:\` prefix) 라 \`bun build --target=browser\` 가 옛 \`url\` polyfill 을 인라인 — 거기에 \`fileURLToPath\` 누락
2. fix 후에도 publish layout 상 \`.wasm\` 은 package root, \`dist/index.js\` 는 dist/ 안 → \`path.join(__dirname, defaultFile)\` 이 \`dist/zntc.wasm\` 을 찾지만 실제로는 \`../zntc.wasm\`

## 수정

- \`packages/wasm/index.ts\` — \`node:fs\` / \`node:path\` / \`node:url\` prefix 명시 + 두 후보 위치 (dist 내부 / 한 단계 위) 모두 시도, 명확한 에러 메시지
- \`packages/wasm/package.json\` — \`build:js\` 에 \`--external 'node:*'\` 추가 → polyfill 인라인 회피 (43KB → 16KB 사이즈 절감)

## 검증

별도 fresh smoke 디렉토리:

\`\`\`bash
mkdir /tmp/smoke && cd /tmp/smoke
echo '{\"name\":\"smoke\",\"type\":\"module\",\"dependencies\":{\"@zntc/wasm\":\"file:.../packages/wasm\"}}' > package.json
bun install
\`\`\`

\`\`\`js
import { init, transpile } from \"@zntc/wasm\";
await init();
const t = transpile(\"const x: number = 1;\\nexport { x };\", { filename: \"x.ts\" });
// ✓ const x = 1; | export { x };
const jsx = transpile(\"export const A = () => <div>hi</div>;\", { filename: \"x.tsx\", jsx: \"automatic\" });
// ✓ import { jsx as _jsx } from \"react/jsx-runtime\";
const downES5 = transpile(\"const f = (x: number) => x ** 2;\", { filename: \"x.ts\", target: \"es5\" });
// ✓ var f = function(x) { return Math.pow(x, 2); };
\`\`\`

## 영향

- 브라우저: 영향 없음 (input 명시 분기 사용 — 본 코드 경로 안 탐).
- Node: \`init()\` default 호출이 정상 통과.
- publish-install-test 보강 follow-up 권장: 각 패키지의 entry function (init/transpile) 도 호출해야 본 회귀 사전 차단 가능.

## Test plan

- [x] \`packages/wasm\` 재빌드 + 별도 smoke dir 에서 init/transpile/JSX/downlevel 통과
- [ ] CI 의 publish-smoke / publint / sherif / publish-install 통과
- [ ] 머지 후 \`bun run release:dry-run\` 재확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)