### PR TITLE
feat(analyze): Treemap + Import graph 시각화 추가

### DIFF
--- a/documents/src/components/MetafileAnalyzer.tsx
+++ b/documents/src/components/MetafileAnalyzer.tsx
@@ -1,4 +1,11 @@
 import { useMemo, useState } from "react";
+import ReactEChartsCore from "echarts-for-react/lib/core";
+import * as echarts from "echarts/core";
+import { TreemapChart, GraphChart } from "echarts/charts";
+import { TooltipComponent, LegendComponent } from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
+
+echarts.use([TreemapChart, GraphChart, TooltipComponent, LegendComponent, CanvasRenderer]);
 
 type ImportRecord = {
   path?: string;
@@ -35,6 +42,10 @@ type RankedModule = {
   path: string;
   bytes: number;
 };
+
+type ViewMode = "summary" | "treemap" | "graph";
+
+const GRAPH_NODE_LIMIT = 250;
 
 const sampleMetafile = JSON.stringify(
   {
@@ -113,6 +124,95 @@ function countImports(inputs: Record<string, InputMeta> | undefined): number {
   return Object.values(inputs ?? {}).reduce((sum, input) => sum + (input.imports?.length ?? 0), 0);
 }
 
+type TreemapNode = {
+  name: string;
+  value?: number;
+  children?: TreemapNode[];
+  path?: string;
+};
+
+function buildTreemap(inputs: Record<string, InputMeta> | undefined): TreemapNode[] {
+  if (!inputs) return [];
+  const root: TreemapNode = { name: "bundle", children: [] };
+  for (const [path, meta] of Object.entries(inputs)) {
+    const segments = path.split("/").filter(Boolean);
+    let cursor = root;
+    for (let i = 0; i < segments.length - 1; i++) {
+      const dir = segments[i];
+      let next = cursor.children?.find((c) => c.name === dir);
+      if (!next) {
+        next = { name: dir, children: [] };
+        cursor.children!.push(next);
+      }
+      cursor = next;
+    }
+    const leaf = segments[segments.length - 1] ?? path;
+    cursor.children!.push({ name: leaf, value: meta.bytes ?? 0, path });
+  }
+  return root.children ?? [];
+}
+
+type GraphNode = {
+  id: string;
+  name: string;
+  value: number;
+  symbolSize: number;
+  category: number;
+};
+
+type GraphLink = {
+  source: string;
+  target: string;
+  lineStyle: { type: "solid" | "dashed" | "dotted"; opacity?: number };
+};
+
+type GraphData = {
+  nodes: GraphNode[];
+  links: GraphLink[];
+  categories: { name: string }[];
+};
+
+function buildGraph(inputs: Record<string, InputMeta> | undefined): GraphData {
+  const nodes: GraphNode[] = [];
+  const seen = new Map<string, GraphNode>();
+  const links: GraphLink[] = [];
+  if (!inputs) return { nodes, links, categories: [{ name: "module" }, { name: "external" }] };
+
+  const allBytes = Object.values(inputs).map((m) => m.bytes ?? 0);
+  const maxBytes = Math.max(1, ...allBytes);
+
+  function ensureNode(id: string, bytes: number, category: number): void {
+    if (seen.has(id)) return;
+    const size = bytes > 0 ? Math.max(8, Math.min(42, 8 + (bytes / maxBytes) * 34)) : 8;
+    const node: GraphNode = {
+      id,
+      name: id.split("/").pop() ?? id,
+      value: bytes,
+      symbolSize: size,
+      category,
+    };
+    seen.set(id, node);
+    nodes.push(node);
+  }
+
+  for (const [path, meta] of Object.entries(inputs)) {
+    ensureNode(path, meta.bytes ?? 0, 0);
+    for (const imp of meta.imports ?? []) {
+      const target = imp.path ?? imp.original;
+      if (!target) continue;
+      const category = imp.external ? 1 : 0;
+      const targetBytes = (!imp.external && inputs[target]?.bytes) || 0;
+      ensureNode(target, targetBytes, category);
+      const kind = imp.kind ?? "import-statement";
+      const type: "solid" | "dashed" | "dotted" =
+        kind === "dynamic-import" ? "dashed" : kind === "require-resolve" ? "dotted" : "solid";
+      links.push({ source: path, target, lineStyle: { type, opacity: 0.55 } });
+    }
+  }
+
+  return { nodes, links, categories: [{ name: "module" }, { name: "external" }] };
+}
+
 function BarRow({
   label,
   bytes,
@@ -153,9 +253,179 @@ function SummaryTile({ label, value, hint }: { label: string; value: string; hin
   );
 }
 
+function ViewToggleButton({
+  active,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={
+        "rounded border px-3 py-1.5 text-[13px] " +
+        (active
+          ? "border-zig-500 bg-zig-500/10 text-zig-300"
+          : "border-surface-700 text-neutral-200 hover:border-zig-500 hover:text-zig-300")
+      }
+    >
+      {label}
+    </button>
+  );
+}
+
+function TreemapView({ inputs }: { inputs: Record<string, InputMeta> | undefined }) {
+  const data = useMemo(() => buildTreemap(inputs), [inputs]);
+  const option = useMemo(
+    () => ({
+      backgroundColor: "transparent",
+      tooltip: {
+        backgroundColor: "rgba(15,15,15,0.95)",
+        borderColor: "#262626",
+        textStyle: { color: "#e5e5e5", fontSize: 12 },
+        formatter: (info: { treePathInfo?: { name: string }[]; value?: number; name?: string }) => {
+          const trail = info.treePathInfo?.map((t) => t.name).join(" / ") ?? info.name ?? "";
+          const bytes = typeof info.value === "number" ? formatBytes(info.value) : "—";
+          return `<div style="font-family:ui-monospace,Menlo,monospace;font-size:11px;">${trail}</div><div style="margin-top:4px;color:#f7a41d;font-weight:600;">${bytes}</div>`;
+        },
+      },
+      series: [
+        {
+          type: "treemap",
+          data,
+          width: "100%",
+          height: "100%",
+          roam: false,
+          nodeClick: "zoomToNode",
+          breadcrumb: {
+            show: true,
+            top: 6,
+            itemStyle: { color: "#1f2937", borderColor: "#374151", textStyle: { color: "#e5e5e5", fontSize: 11 } },
+          },
+          label: { show: true, formatter: "{b}", color: "#fafafa", fontSize: 11 },
+          upperLabel: { show: true, height: 22, color: "#fafafa", fontSize: 11, backgroundColor: "rgba(0,0,0,0.35)" },
+          itemStyle: { borderColor: "#0a0a0a", gapWidth: 2, borderWidth: 1 },
+          levels: [
+            { itemStyle: { borderWidth: 0, gapWidth: 4, borderColorSaturation: 0.6 } },
+            { itemStyle: { borderWidth: 4, gapWidth: 2, borderColorSaturation: 0.6 } },
+            { itemStyle: { borderWidth: 1, gapWidth: 1 }, colorSaturation: [0.35, 0.55] },
+          ],
+        },
+      ],
+    }),
+    [data],
+  );
+
+  if (data.length === 0) {
+    return (
+      <div className="flex h-[520px] items-center justify-center rounded border border-surface-800 bg-surface-900 text-[13px] text-neutral-500">
+        inputs 가 비어 있어 treemap 을 그릴 수 없습니다.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded border border-surface-800 bg-surface-900 p-2">
+      <ReactEChartsCore echarts={echarts} option={option} style={{ height: "600px", width: "100%" }} />
+    </div>
+  );
+}
+
+function GraphView({ inputs }: { inputs: Record<string, InputMeta> | undefined }) {
+  const data = useMemo(() => buildGraph(inputs), [inputs]);
+
+  const option = useMemo(
+    () => ({
+      backgroundColor: "transparent",
+      tooltip: {
+        backgroundColor: "rgba(15,15,15,0.95)",
+        borderColor: "#262626",
+        textStyle: { color: "#e5e5e5", fontSize: 12 },
+        formatter: (info: { dataType?: string; data?: GraphNode | GraphLink }) => {
+          if (info.dataType === "node") {
+            const n = info.data as GraphNode;
+            return `<div style="font-family:ui-monospace,Menlo,monospace;font-size:11px;">${n.id}</div><div style="margin-top:4px;color:#f7a41d;font-weight:600;">${formatBytes(n.value)}</div>`;
+          }
+          if (info.dataType === "edge") {
+            const l = info.data as GraphLink;
+            return `<div style="font-family:ui-monospace,Menlo,monospace;font-size:11px;">${l.source}<br/>↓<br/>${l.target}</div>`;
+          }
+          return "";
+        },
+      },
+      legend: [
+        {
+          data: ["module", "external"],
+          top: 6,
+          right: 12,
+          textStyle: { color: "#e5e5e5", fontSize: 12 },
+        },
+      ],
+      color: ["#f7a41d", "#737373"],
+      series: [
+        {
+          type: "graph",
+          layout: "force",
+          data: data.nodes,
+          links: data.links,
+          categories: data.categories,
+          roam: true,
+          draggable: true,
+          label: {
+            show: true,
+            position: "right",
+            color: "#e5e5e5",
+            fontSize: 11,
+            formatter: (p: { data: GraphNode }) => p.data.name,
+          },
+          force: { repulsion: 90, edgeLength: 70, gravity: 0.08, friction: 0.6 },
+          lineStyle: { color: "source", curveness: 0.05, width: 1 },
+          emphasis: { focus: "adjacency", lineStyle: { width: 2 } },
+        },
+      ],
+    }),
+    [data],
+  );
+
+  if (data.nodes.length === 0) {
+    return (
+      <div className="flex h-[520px] items-center justify-center rounded border border-surface-800 bg-surface-900 text-[13px] text-neutral-500">
+        inputs 가 비어 있어 graph 를 그릴 수 없습니다.
+      </div>
+    );
+  }
+  if (data.nodes.length > GRAPH_NODE_LIMIT) {
+    return (
+      <div className="flex h-[520px] flex-col items-center justify-center gap-2 rounded border border-surface-800 bg-surface-900 px-6 text-center text-[13px] text-neutral-300">
+        <div className="font-semibold text-neutral-100">
+          {nf.format(data.nodes.length)} nodes — force layout 비활성화
+        </div>
+        <div className="max-w-[480px] text-neutral-400">
+          그래프 시각화는 {GRAPH_NODE_LIMIT} 노드까지 안정적입니다. 그 이상은 force simulation 이 brower 를 멈춥니다. Treemap view 또는 path 필터링된 Largest inputs 를 이용하세요.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded border border-surface-800 bg-surface-900 p-2">
+      <ReactEChartsCore echarts={echarts} option={option} style={{ height: "600px", width: "100%" }} />
+      <div className="border-t border-surface-800 px-3 py-2 text-[11px] text-neutral-500">
+        <span className="font-semibold text-neutral-300">solid</span> = static import ·{" "}
+        <span className="font-semibold text-neutral-300">dashed</span> = dynamic-import · 휠로 zoom, 드래그로 pan, 노드 drag 가능
+      </div>
+    </div>
+  );
+}
+
 export function MetafileAnalyzer() {
   const [text, setText] = useState(sampleMetafile);
   const [filter, setFilter] = useState("");
+  const [view, setView] = useState<ViewMode>("summary");
   const parsed = useMemo(() => parseMetafile(text), [text]);
   const meta = parsed.meta;
 
@@ -224,73 +494,98 @@ export function MetafileAnalyzer() {
               <SummaryTile label="Inputs" value={nf.format(inputs.length)} hint={formatBytes(inputTotal)} />
               <SummaryTile label="Outputs" value={nf.format(outputs.length)} hint={formatBytes(outputTotal)} />
               <SummaryTile label="Imports" value={nf.format(importTotal)} hint="resolved graph edges" />
-              <SummaryTile label="Format" value={outputs.some(([, out]) => out.inputs) ? "Detailed" : "Basic"} hint="output attribution" />
+              <SummaryTile
+                label="Format"
+                value={outputs.some(([, out]) => out.inputs) ? "Detailed" : "Basic"}
+                hint="output attribution"
+              />
             </div>
 
-            <section className="rounded border border-surface-800 bg-surface-900">
-              <div className="flex flex-wrap items-center justify-between gap-3 border-b border-surface-800 px-4 py-3">
-                <h2 className="text-[14px] font-semibold text-neutral-100">Outputs</h2>
-                <span className="text-[12px] text-neutral-500">esbuild-compatible `outputs[*].inputs` is used when present</span>
-              </div>
-              <div className="grid gap-3 p-4 xl:grid-cols-2">
-                {outputs.map(([path, output]) => {
-                  const contributions = outputContributions(output);
-                  const maxBytes = contributions[0]?.bytes ?? 0;
-                  return (
-                    <article key={path} className="rounded border border-surface-800 bg-surface-950 p-3">
-                      <div className="flex items-start justify-between gap-3">
-                        <div className="min-w-0">
-                          <h3 className="truncate text-[13px] font-semibold text-neutral-100" title={path}>
-                            {path}
-                          </h3>
-                          {output.entryPoint ? <p className="mt-1 text-[12px] text-neutral-500">entry: {output.entryPoint}</p> : null}
-                        </div>
-                        <div className="shrink-0 font-mono text-[12px] text-neutral-300">{formatBytes(output.bytes ?? 0)}</div>
-                      </div>
-                      <div className="mt-3 flex flex-col gap-2">
-                        {contributions.length > 0 ? (
-                          contributions
-                            .slice(0, 6)
-                            .map((item) => <BarRow key={item.path} label={item.path} bytes={item.bytes} maxBytes={maxBytes} />)
-                        ) : (
-                          <p className="text-[12px] leading-5 text-neutral-500">
-                            이 output에는 input 기여도 정보가 없습니다. 현재 ZNTC metafile의 basic form에서는 output 크기와 graph
-                            input/import 목록을 함께 확인하세요.
-                          </p>
-                        )}
-                      </div>
-                    </article>
-                  );
-                })}
-              </div>
-            </section>
+            <div className="flex flex-wrap items-center gap-2">
+              <ViewToggleButton active={view === "summary"} label="Summary" onClick={() => setView("summary")} />
+              <ViewToggleButton active={view === "treemap"} label="Treemap" onClick={() => setView("treemap")} />
+              <ViewToggleButton active={view === "graph"} label="Import graph" onClick={() => setView("graph")} />
+            </div>
 
-            <section className="rounded border border-surface-800 bg-surface-900">
-              <div className="flex flex-wrap items-center justify-between gap-3 border-b border-surface-800 px-4 py-3">
-                <h2 className="text-[14px] font-semibold text-neutral-100">Largest inputs</h2>
-                <input
-                  value={filter}
-                  placeholder="Filter path"
-                  onChange={(event) => setFilter(event.currentTarget.value)}
-                  className="w-[220px] rounded border border-surface-700 bg-surface-950 px-2 py-1 text-[12px] text-neutral-200 outline-none"
-                />
-              </div>
-              <div className="flex max-h-[420px] flex-col gap-3 overflow-auto p-4">
-                {filteredInputs.slice(0, 80).map((item) => {
-                  const input = meta?.inputs?.[item.path];
-                  const importCount = input?.imports?.length ?? 0;
-                  return (
-                    <BarRow
-                      key={item.path}
-                      label={item.path}
-                      bytes={item.bytes}
-                      maxBytes={maxInputBytes}
-                      sublabel={importCount === 1 ? "1 import" : `${importCount} imports`}
+            {view === "treemap" ? <TreemapView inputs={meta?.inputs} /> : null}
+            {view === "graph" ? <GraphView inputs={meta?.inputs} /> : null}
+
+            {view === "summary" ? (
+              <>
+                <section className="rounded border border-surface-800 bg-surface-900">
+                  <div className="flex flex-wrap items-center justify-between gap-3 border-b border-surface-800 px-4 py-3">
+                    <h2 className="text-[14px] font-semibold text-neutral-100">Outputs</h2>
+                    <span className="text-[12px] text-neutral-500">
+                      esbuild-compatible `outputs[*].inputs` is used when present
+                    </span>
+                  </div>
+                  <div className="grid gap-3 p-4 xl:grid-cols-2">
+                    {outputs.map(([path, output]) => {
+                      const contributions = outputContributions(output);
+                      const maxBytes = contributions[0]?.bytes ?? 0;
+                      return (
+                        <article key={path} className="rounded border border-surface-800 bg-surface-950 p-3">
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0">
+                              <h3 className="truncate text-[13px] font-semibold text-neutral-100" title={path}>
+                                {path}
+                              </h3>
+                              {output.entryPoint ? (
+                                <p className="mt-1 text-[12px] text-neutral-500">entry: {output.entryPoint}</p>
+                              ) : null}
+                            </div>
+                            <div className="shrink-0 font-mono text-[12px] text-neutral-300">
+                              {formatBytes(output.bytes ?? 0)}
+                            </div>
+                          </div>
+                          <div className="mt-3 flex flex-col gap-2">
+                            {contributions.length > 0 ? (
+                              contributions
+                                .slice(0, 6)
+                                .map((item) => (
+                                  <BarRow key={item.path} label={item.path} bytes={item.bytes} maxBytes={maxBytes} />
+                                ))
+                            ) : (
+                              <p className="text-[12px] leading-5 text-neutral-500">
+                                이 output에는 input 기여도 정보가 없습니다. 현재 ZNTC metafile의 basic form에서는 output 크기와 graph
+                                input/import 목록을 함께 확인하세요.
+                              </p>
+                            )}
+                          </div>
+                        </article>
+                      );
+                    })}
+                  </div>
+                </section>
+
+                <section className="rounded border border-surface-800 bg-surface-900">
+                  <div className="flex flex-wrap items-center justify-between gap-3 border-b border-surface-800 px-4 py-3">
+                    <h2 className="text-[14px] font-semibold text-neutral-100">Largest inputs</h2>
+                    <input
+                      value={filter}
+                      placeholder="Filter path"
+                      onChange={(event) => setFilter(event.currentTarget.value)}
+                      className="w-[220px] rounded border border-surface-700 bg-surface-950 px-2 py-1 text-[12px] text-neutral-200 outline-none"
                     />
-                  );
-                })}
-              </div>
-            </section>
+                  </div>
+                  <div className="flex max-h-[420px] flex-col gap-3 overflow-auto p-4">
+                    {filteredInputs.slice(0, 80).map((item) => {
+                      const input = meta?.inputs?.[item.path];
+                      const importCount = input?.imports?.length ?? 0;
+                      return (
+                        <BarRow
+                          key={item.path}
+                          label={item.path}
+                          bytes={item.bytes}
+                          maxBytes={maxInputBytes}
+                          sublabel={importCount === 1 ? "1 import" : `${importCount} imports`}
+                        />
+                      );
+                    })}
+                  </div>
+                </section>
+              </>
+            ) : null}
           </div>
         </section>
       </div>

--- a/documents/src/components/MetafileAnalyzer.tsx
+++ b/documents/src/components/MetafileAnalyzer.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useDeferredValue, useMemo, useState, type ReactNode } from "react";
 import ReactEChartsCore from "echarts-for-react/lib/core";
 import * as echarts from "echarts/core";
 import { TreemapChart, GraphChart } from "echarts/charts";
@@ -7,9 +7,18 @@ import { CanvasRenderer } from "echarts/renderers";
 
 echarts.use([TreemapChart, GraphChart, TooltipComponent, LegendComponent, CanvasRenderer]);
 
+type ImportKind =
+  | "import-statement"
+  | "require-call"
+  | "dynamic-import"
+  | "require-resolve"
+  | "import-rule"
+  | "composes-from"
+  | "url-token";
+
 type ImportRecord = {
   path?: string;
-  kind?: string;
+  kind?: ImportKind | string;
   external?: boolean;
   original?: string;
 };
@@ -46,6 +55,11 @@ type RankedModule = {
 type ViewMode = "summary" | "treemap" | "graph";
 
 const GRAPH_NODE_LIMIT = 250;
+
+const KIND_TO_LINE_STYLE: Record<string, "solid" | "dashed" | "dotted"> = {
+  "dynamic-import": "dashed",
+  "require-resolve": "dotted",
+};
 
 const sampleMetafile = JSON.stringify(
   {
@@ -134,15 +148,21 @@ type TreemapNode = {
 function buildTreemap(inputs: Record<string, InputMeta> | undefined): TreemapNode[] {
   if (!inputs) return [];
   const root: TreemapNode = { name: "bundle", children: [] };
+  const lookups = new Map<TreemapNode, Map<string, TreemapNode>>();
+  lookups.set(root, new Map());
+
   for (const [path, meta] of Object.entries(inputs)) {
     const segments = path.split("/").filter(Boolean);
     let cursor = root;
     for (let i = 0; i < segments.length - 1; i++) {
       const dir = segments[i];
-      let next = cursor.children?.find((c) => c.name === dir);
+      const childMap = lookups.get(cursor)!;
+      let next = childMap.get(dir);
       if (!next) {
         next = { name: dir, children: [] };
         cursor.children!.push(next);
+        childMap.set(dir, next);
+        lookups.set(next, new Map());
       }
       cursor = next;
     }
@@ -163,36 +183,47 @@ type GraphNode = {
 type GraphLink = {
   source: string;
   target: string;
-  lineStyle: { type: "solid" | "dashed" | "dotted"; opacity?: number };
+  kind: ImportKind | string;
 };
 
 type GraphData = {
   nodes: GraphNode[];
   links: GraphLink[];
   categories: { name: string }[];
+  overflow?: number;
 };
 
-function buildGraph(inputs: Record<string, InputMeta> | undefined): GraphData {
-  const nodes: GraphNode[] = [];
-  const seen = new Map<string, GraphNode>();
-  const links: GraphLink[] = [];
-  if (!inputs) return { nodes, links, categories: [{ name: "module" }, { name: "external" }] };
+const GRAPH_CATEGORIES = [{ name: "module" }, { name: "external" }];
 
-  const allBytes = Object.values(inputs).map((m) => m.bytes ?? 0);
-  const maxBytes = Math.max(1, ...allBytes);
+function buildGraph(inputs: Record<string, InputMeta> | undefined): GraphData {
+  if (!inputs) return { nodes: [], links: [], categories: GRAPH_CATEGORIES };
+
+  const inputCount = Object.keys(inputs).length;
+  if (inputCount > GRAPH_NODE_LIMIT) {
+    return { nodes: [], links: [], categories: GRAPH_CATEGORIES, overflow: inputCount };
+  }
+
+  let maxBytes = 1;
+  for (const meta of Object.values(inputs)) {
+    const b = meta.bytes ?? 0;
+    if (b > maxBytes) maxBytes = b;
+  }
+
+  const nodes: GraphNode[] = [];
+  const seen = new Set<string>();
+  const links: GraphLink[] = [];
 
   function ensureNode(id: string, bytes: number, category: number): void {
     if (seen.has(id)) return;
     const size = bytes > 0 ? Math.max(8, Math.min(42, 8 + (bytes / maxBytes) * 34)) : 8;
-    const node: GraphNode = {
+    seen.add(id);
+    nodes.push({
       id,
       name: id.split("/").pop() ?? id,
       value: bytes,
       symbolSize: size,
       category,
-    };
-    seen.set(id, node);
-    nodes.push(node);
+    });
   }
 
   for (const [path, meta] of Object.entries(inputs)) {
@@ -203,14 +234,11 @@ function buildGraph(inputs: Record<string, InputMeta> | undefined): GraphData {
       const category = imp.external ? 1 : 0;
       const targetBytes = (!imp.external && inputs[target]?.bytes) || 0;
       ensureNode(target, targetBytes, category);
-      const kind = imp.kind ?? "import-statement";
-      const type: "solid" | "dashed" | "dotted" =
-        kind === "dynamic-import" ? "dashed" : kind === "require-resolve" ? "dotted" : "solid";
-      links.push({ source: path, target, lineStyle: { type, opacity: 0.55 } });
+      links.push({ source: path, target, kind: imp.kind ?? "import-statement" });
     }
   }
 
-  return { nodes, links, categories: [{ name: "module" }, { name: "external" }] };
+  return { nodes, links, categories: GRAPH_CATEGORIES };
 }
 
 function BarRow({
@@ -278,6 +306,23 @@ function ViewToggleButton({
   );
 }
 
+function ChartFrame({ children, footer }: { children: ReactNode; footer?: ReactNode }) {
+  return (
+    <div className="rounded border border-surface-800 bg-surface-900 p-2">
+      {children}
+      {footer ? <div className="border-t border-surface-800 px-3 py-2 text-[11px] text-neutral-500">{footer}</div> : null}
+    </div>
+  );
+}
+
+function EmptyChartPlaceholder({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex h-[520px] flex-col items-center justify-center gap-2 rounded border border-surface-800 bg-surface-900 px-6 text-center text-[13px] text-neutral-300">
+      {children}
+    </div>
+  );
+}
+
 function TreemapView({ inputs }: { inputs: Record<string, InputMeta> | undefined }) {
   const data = useMemo(() => buildTreemap(inputs), [inputs]);
   const option = useMemo(
@@ -321,37 +366,38 @@ function TreemapView({ inputs }: { inputs: Record<string, InputMeta> | undefined
   );
 
   if (data.length === 0) {
-    return (
-      <div className="flex h-[520px] items-center justify-center rounded border border-surface-800 bg-surface-900 text-[13px] text-neutral-500">
-        inputs 가 비어 있어 treemap 을 그릴 수 없습니다.
-      </div>
-    );
+    return <EmptyChartPlaceholder>inputs 가 비어 있어 treemap 을 그릴 수 없습니다.</EmptyChartPlaceholder>;
   }
 
   return (
-    <div className="rounded border border-surface-800 bg-surface-900 p-2">
+    <ChartFrame>
       <ReactEChartsCore echarts={echarts} option={option} style={{ height: "600px", width: "100%" }} />
-    </div>
+    </ChartFrame>
   );
 }
 
 function GraphView({ inputs }: { inputs: Record<string, InputMeta> | undefined }) {
   const data = useMemo(() => buildGraph(inputs), [inputs]);
 
-  const option = useMemo(
-    () => ({
+  const option = useMemo(() => {
+    const links = data.links.map((l) => ({
+      source: l.source,
+      target: l.target,
+      lineStyle: { type: KIND_TO_LINE_STYLE[l.kind] ?? "solid", opacity: 0.55 },
+    }));
+    return {
       backgroundColor: "transparent",
       tooltip: {
         backgroundColor: "rgba(15,15,15,0.95)",
         borderColor: "#262626",
         textStyle: { color: "#e5e5e5", fontSize: 12 },
-        formatter: (info: { dataType?: string; data?: GraphNode | GraphLink }) => {
+        formatter: (info: { dataType?: string; data?: GraphNode | { source: string; target: string } }) => {
           if (info.dataType === "node") {
             const n = info.data as GraphNode;
             return `<div style="font-family:ui-monospace,Menlo,monospace;font-size:11px;">${n.id}</div><div style="margin-top:4px;color:#f7a41d;font-weight:600;">${formatBytes(n.value)}</div>`;
           }
           if (info.dataType === "edge") {
-            const l = info.data as GraphLink;
+            const l = info.data as { source: string; target: string };
             return `<div style="font-family:ui-monospace,Menlo,monospace;font-size:11px;">${l.source}<br/>↓<br/>${l.target}</div>`;
           }
           return "";
@@ -371,7 +417,7 @@ function GraphView({ inputs }: { inputs: Record<string, InputMeta> | undefined }
           type: "graph",
           layout: "force",
           data: data.nodes,
-          links: data.links,
+          links,
           categories: data.categories,
           roam: true,
           draggable: true,
@@ -387,38 +433,136 @@ function GraphView({ inputs }: { inputs: Record<string, InputMeta> | undefined }
           emphasis: { focus: "adjacency", lineStyle: { width: 2 } },
         },
       ],
-    }),
-    [data],
-  );
+    };
+  }, [data]);
 
-  if (data.nodes.length === 0) {
+  if (data.overflow != null) {
     return (
-      <div className="flex h-[520px] items-center justify-center rounded border border-surface-800 bg-surface-900 text-[13px] text-neutral-500">
-        inputs 가 비어 있어 graph 를 그릴 수 없습니다.
-      </div>
-    );
-  }
-  if (data.nodes.length > GRAPH_NODE_LIMIT) {
-    return (
-      <div className="flex h-[520px] flex-col items-center justify-center gap-2 rounded border border-surface-800 bg-surface-900 px-6 text-center text-[13px] text-neutral-300">
+      <EmptyChartPlaceholder>
         <div className="font-semibold text-neutral-100">
-          {nf.format(data.nodes.length)} nodes — force layout 비활성화
+          {nf.format(data.overflow)} nodes — force layout 비활성화
         </div>
         <div className="max-w-[480px] text-neutral-400">
-          그래프 시각화는 {GRAPH_NODE_LIMIT} 노드까지 안정적입니다. 그 이상은 force simulation 이 brower 를 멈춥니다. Treemap view 또는 path 필터링된 Largest inputs 를 이용하세요.
+          브라우저가 멈출 수 있어 {GRAPH_NODE_LIMIT} 노드까지만 그립니다. Summary 탭의 Largest inputs (path 필터) 또는 Treemap 을
+          이용하세요.
         </div>
-      </div>
+      </EmptyChartPlaceholder>
     );
+  }
+  if (data.nodes.length === 0) {
+    return <EmptyChartPlaceholder>inputs 가 비어 있어 graph 를 그릴 수 없습니다.</EmptyChartPlaceholder>;
   }
 
   return (
-    <div className="rounded border border-surface-800 bg-surface-900 p-2">
+    <ChartFrame
+      footer={
+        <>
+          <span className="font-semibold text-neutral-300">solid</span> = static import ·{" "}
+          <span className="font-semibold text-neutral-300">dashed</span> = dynamic-import · 휠로 zoom, 드래그로 pan, 노드 drag 가능
+        </>
+      }
+    >
       <ReactEChartsCore echarts={echarts} option={option} style={{ height: "600px", width: "100%" }} />
-      <div className="border-t border-surface-800 px-3 py-2 text-[11px] text-neutral-500">
-        <span className="font-semibold text-neutral-300">solid</span> = static import ·{" "}
-        <span className="font-semibold text-neutral-300">dashed</span> = dynamic-import · 휠로 zoom, 드래그로 pan, 노드 drag 가능
-      </div>
-    </div>
+    </ChartFrame>
+  );
+}
+
+function SummaryView({
+  meta,
+  inputs,
+  outputs,
+  filter,
+  onFilterChange,
+  maxInputBytes,
+}: {
+  meta: Metafile | undefined;
+  inputs: RankedModule[];
+  outputs: [string, OutputMeta][];
+  filter: string;
+  onFilterChange: (next: string) => void;
+  maxInputBytes: number;
+}) {
+  const lowerFilter = filter.toLowerCase();
+  const filteredInputs = useMemo(
+    () => (lowerFilter ? inputs.filter((item) => item.path.toLowerCase().includes(lowerFilter)) : inputs),
+    [inputs, lowerFilter],
+  );
+
+  return (
+    <>
+      <section className="rounded border border-surface-800 bg-surface-900">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-surface-800 px-4 py-3">
+          <h2 className="text-[14px] font-semibold text-neutral-100">Outputs</h2>
+          <span className="text-[12px] text-neutral-500">
+            esbuild-compatible `outputs[*].inputs` is used when present
+          </span>
+        </div>
+        <div className="grid gap-3 p-4 xl:grid-cols-2">
+          {outputs.map(([path, output]) => {
+            const contributions = outputContributions(output);
+            const maxBytes = contributions[0]?.bytes ?? 0;
+            return (
+              <article key={path} className="rounded border border-surface-800 bg-surface-950 p-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <h3 className="truncate text-[13px] font-semibold text-neutral-100" title={path}>
+                      {path}
+                    </h3>
+                    {output.entryPoint ? (
+                      <p className="mt-1 text-[12px] text-neutral-500">entry: {output.entryPoint}</p>
+                    ) : null}
+                  </div>
+                  <div className="shrink-0 font-mono text-[12px] text-neutral-300">
+                    {formatBytes(output.bytes ?? 0)}
+                  </div>
+                </div>
+                <div className="mt-3 flex flex-col gap-2">
+                  {contributions.length > 0 ? (
+                    contributions
+                      .slice(0, 6)
+                      .map((item) => (
+                        <BarRow key={item.path} label={item.path} bytes={item.bytes} maxBytes={maxBytes} />
+                      ))
+                  ) : (
+                    <p className="text-[12px] leading-5 text-neutral-500">
+                      이 output에는 input 기여도 정보가 없습니다. 현재 ZNTC metafile의 basic form에서는 output 크기와 graph
+                      input/import 목록을 함께 확인하세요.
+                    </p>
+                  )}
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="rounded border border-surface-800 bg-surface-900">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-surface-800 px-4 py-3">
+          <h2 className="text-[14px] font-semibold text-neutral-100">Largest inputs</h2>
+          <input
+            value={filter}
+            placeholder="Filter path"
+            onChange={(event) => onFilterChange(event.currentTarget.value)}
+            className="w-[220px] rounded border border-surface-700 bg-surface-950 px-2 py-1 text-[12px] text-neutral-200 outline-none"
+          />
+        </div>
+        <div className="flex max-h-[420px] flex-col gap-3 overflow-auto p-4">
+          {filteredInputs.slice(0, 80).map((item) => {
+            const input = meta?.inputs?.[item.path];
+            const importCount = input?.imports?.length ?? 0;
+            return (
+              <BarRow
+                key={item.path}
+                label={item.path}
+                bytes={item.bytes}
+                maxBytes={maxInputBytes}
+                sublabel={importCount === 1 ? "1 import" : `${importCount} imports`}
+              />
+            );
+          })}
+        </div>
+      </section>
+    </>
   );
 }
 
@@ -426,16 +570,16 @@ export function MetafileAnalyzer() {
   const [text, setText] = useState(sampleMetafile);
   const [filter, setFilter] = useState("");
   const [view, setView] = useState<ViewMode>("summary");
-  const parsed = useMemo(() => parseMetafile(text), [text]);
+  const deferredText = useDeferredValue(text);
+  const parsed = useMemo(() => parseMetafile(deferredText), [deferredText]);
   const meta = parsed.meta;
 
   const inputs = useMemo(() => rankInputs(meta?.inputs), [meta?.inputs]);
   const outputs = useMemo(() => Object.entries(meta?.outputs ?? {}), [meta?.outputs]);
-  const inputTotal = inputs.reduce((sum, item) => sum + item.bytes, 0);
-  const outputTotal = outputs.reduce((sum, [, out]) => sum + (out.bytes ?? 0), 0);
-  const importTotal = countImports(meta?.inputs);
+  const inputTotal = useMemo(() => inputs.reduce((sum, item) => sum + item.bytes, 0), [inputs]);
+  const outputTotal = useMemo(() => outputs.reduce((sum, [, out]) => sum + (out.bytes ?? 0), 0), [outputs]);
+  const importTotal = useMemo(() => countImports(meta?.inputs), [meta?.inputs]);
   const maxInputBytes = inputs[0]?.bytes ?? 0;
-  const filteredInputs = inputs.filter((item) => item.path.toLowerCase().includes(filter.toLowerCase()));
 
   async function loadFile(file: File | undefined) {
     if (!file) return;
@@ -507,85 +651,20 @@ export function MetafileAnalyzer() {
               <ViewToggleButton active={view === "graph"} label="Import graph" onClick={() => setView("graph")} />
             </div>
 
-            {view === "treemap" ? <TreemapView inputs={meta?.inputs} /> : null}
-            {view === "graph" ? <GraphView inputs={meta?.inputs} /> : null}
-
             {view === "summary" ? (
-              <>
-                <section className="rounded border border-surface-800 bg-surface-900">
-                  <div className="flex flex-wrap items-center justify-between gap-3 border-b border-surface-800 px-4 py-3">
-                    <h2 className="text-[14px] font-semibold text-neutral-100">Outputs</h2>
-                    <span className="text-[12px] text-neutral-500">
-                      esbuild-compatible `outputs[*].inputs` is used when present
-                    </span>
-                  </div>
-                  <div className="grid gap-3 p-4 xl:grid-cols-2">
-                    {outputs.map(([path, output]) => {
-                      const contributions = outputContributions(output);
-                      const maxBytes = contributions[0]?.bytes ?? 0;
-                      return (
-                        <article key={path} className="rounded border border-surface-800 bg-surface-950 p-3">
-                          <div className="flex items-start justify-between gap-3">
-                            <div className="min-w-0">
-                              <h3 className="truncate text-[13px] font-semibold text-neutral-100" title={path}>
-                                {path}
-                              </h3>
-                              {output.entryPoint ? (
-                                <p className="mt-1 text-[12px] text-neutral-500">entry: {output.entryPoint}</p>
-                              ) : null}
-                            </div>
-                            <div className="shrink-0 font-mono text-[12px] text-neutral-300">
-                              {formatBytes(output.bytes ?? 0)}
-                            </div>
-                          </div>
-                          <div className="mt-3 flex flex-col gap-2">
-                            {contributions.length > 0 ? (
-                              contributions
-                                .slice(0, 6)
-                                .map((item) => (
-                                  <BarRow key={item.path} label={item.path} bytes={item.bytes} maxBytes={maxBytes} />
-                                ))
-                            ) : (
-                              <p className="text-[12px] leading-5 text-neutral-500">
-                                이 output에는 input 기여도 정보가 없습니다. 현재 ZNTC metafile의 basic form에서는 output 크기와 graph
-                                input/import 목록을 함께 확인하세요.
-                              </p>
-                            )}
-                          </div>
-                        </article>
-                      );
-                    })}
-                  </div>
-                </section>
-
-                <section className="rounded border border-surface-800 bg-surface-900">
-                  <div className="flex flex-wrap items-center justify-between gap-3 border-b border-surface-800 px-4 py-3">
-                    <h2 className="text-[14px] font-semibold text-neutral-100">Largest inputs</h2>
-                    <input
-                      value={filter}
-                      placeholder="Filter path"
-                      onChange={(event) => setFilter(event.currentTarget.value)}
-                      className="w-[220px] rounded border border-surface-700 bg-surface-950 px-2 py-1 text-[12px] text-neutral-200 outline-none"
-                    />
-                  </div>
-                  <div className="flex max-h-[420px] flex-col gap-3 overflow-auto p-4">
-                    {filteredInputs.slice(0, 80).map((item) => {
-                      const input = meta?.inputs?.[item.path];
-                      const importCount = input?.imports?.length ?? 0;
-                      return (
-                        <BarRow
-                          key={item.path}
-                          label={item.path}
-                          bytes={item.bytes}
-                          maxBytes={maxInputBytes}
-                          sublabel={importCount === 1 ? "1 import" : `${importCount} imports`}
-                        />
-                      );
-                    })}
-                  </div>
-                </section>
-              </>
-            ) : null}
+              <SummaryView
+                meta={meta}
+                inputs={inputs}
+                outputs={outputs}
+                filter={filter}
+                onFilterChange={setFilter}
+                maxInputBytes={maxInputBytes}
+              />
+            ) : view === "treemap" ? (
+              <TreemapView inputs={meta?.inputs} />
+            ) : (
+              <GraphView inputs={meta?.inputs} />
+            )}
           </div>
         </section>
       </div>


### PR DESCRIPTION
## Summary

`/analyze/` 페이지가 막대 그래프만 표시해 webpack-bundle-analyzer 스타일 시각화가 부재했습니다. ECharts 기반 **Treemap** + **Import graph** 두 가지 view 를 추가하고 Summary/Treemap/Graph 토글로 전환합니다.

### Treemap view

- inputs 의 `path` 를 `/` 로 split 해 hierarchical tree 로 변환 (`buildTreemap`)
- 디렉토리 그룹별로 면적 = bytes 비례, click 으로 drill-down, breadcrumb 으로 위로
- 3-level color depth, 다크 톤 매칭 (`bg-surface-950` 위)

### Import graph view

- nodes = inputs, links = imports (`buildGraph`)
- `dynamic-import` 는 **dashed**, 일반 import 는 solid, `require-resolve` 는 dotted
- `external: true` 는 별도 category (회색) — `module` 카테고리(zig 오렌지) 와 구분
- node size = bytes 정규화 (8~42px), force-directed layout, roam/drag 가능
- **250 nodes 초과 시 graph 자동 비활성** — force simulation 으로 브라우저 멈춤 방지. 안내 메시지로 Treemap 또는 Largest inputs filter 안내.

### Summary view

기존 Outputs / Largest inputs 막대 + filter 그대로 보존.

## Test plan

- [x] `cd documents && bun run build` — 476 페이지 빌드 성공
- [x] `starlight-links-validator` 통과, pagefind 인덱스 OK
- [x] 의존성 추가 없음 — `echarts@^6.0.0` / `echarts-for-react@^3.0.6` 기존 의존성 재사용, `TreemapChart` / `GraphChart` series 만 추가 import
- [ ] 머지 후 https://ohah.github.io/zntc/analyze/ 에서 토글 동작 확인
- [ ] Treemap drill-down + breadcrumb 동작 확인
- [ ] Import graph roam/drag 동작 확인 (sample metafile 로)
- [ ] 큰 metafile (>250 nodes) 로 graph 비활성 메시지 노출 확인

## 비고

- CLAUDE.md "PR 전 /simplify" 규칙 사용자 요청 우선으로 생략. 머지 전 트리거 필요하면 알려주세요.
- 변경 범위 단일 파일 (`documents/src/components/MetafileAnalyzer.tsx`) — 빌드/런타임 안전.

🤖 Generated with [Claude Code](https://claude.com/claude-code)