### PR TITLE
feat(html): index.html 안 EJS 스타일 ZNTC_* 환경변수 토큰 치환

### DIFF
--- a/documents/src/content/docs/en/guides/config-file.md
+++ b/documents/src/content/docs/en/guides/config-file.md
@@ -195,6 +195,35 @@ defineConfig({
 
 For the full option list, see the [Babel migration guide](/zntc/en/guides/babel-migration/).
 
+#### Env tokens inside `index.html` (EJS style)
+
+Place `<%= ZNTC_KEY %>` tokens directly inside `index.html`. They get substituted with `.env` values during both `dev` and `build` — completely independent of the JS-side `import.meta.env.X` mechanism.
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= ZNTC_APP_TITLE %></title>
+    <meta name="version" content="<%= ZNTC_BUILD_VERSION %>" />
+  </head>
+  <body><div id="root"></div></body>
+</html>
+```
+
+```bash
+# .env
+ZNTC_APP_TITLE=My App
+ZNTC_BUILD_VERSION=2026.05
+```
+
+**Spec**:
+
+- Token form: `<%= KEY %>` (whitespace inside delimiters allowed — `<%=KEY%>` / `<%=   KEY   %>` all work).
+- Prefix is restricted to **`ZNTC_`** only. Even if the JS side `envPrefixes` allows `VITE_*`, those keys are not exposed in HTML — prevents secret leakage.
+- Other prefix tokens (`<%= VITE_API_KEY %>`) are **left as-is plus warning** (the raw token is visible on the page, making the mistake easy to spot).
+- Missing keys (`<%= ZNTC_UNDEFINED %>`) are **replaced with an empty string plus warning** (same as Vite / CRA).
+- Expression evaluation (`<%= mode === 'prod' ? '/' : '/dev/' %>`) is **not supported** — key-only.
+
 #### Functional config `ConfigEnv.command`
 
 When using `defineConfig(({ command, mode, env }) => ...)` in `zntc.config.ts`, `command` can take:

--- a/documents/src/content/docs/guides/config-file.md
+++ b/documents/src/content/docs/guides/config-file.md
@@ -198,6 +198,35 @@ defineConfig({
 
 전체 옵션 목록은 [Babel 마이그레이션 가이드](/zntc/guides/babel-migration/)를 참조하세요.
 
+#### `index.html` 안의 환경변수 — EJS 토큰
+
+`index.html` 본문에 `<%= ZNTC_KEY %>` 형태로 토큰을 쓰면, `dev` / `build` 양쪽에서 자동으로 `.env` 의 값으로 치환됩니다. JS 측 `import.meta.env.X` 와는 별개 경로 — HTML 안에서 직접 사용 가능합니다.
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= ZNTC_APP_TITLE %></title>
+    <meta name="version" content="<%= ZNTC_BUILD_VERSION %>" />
+  </head>
+  <body><div id="root"></div></body>
+</html>
+```
+
+```bash
+# .env
+ZNTC_APP_TITLE=My App
+ZNTC_BUILD_VERSION=2026.05
+```
+
+**Spec**:
+
+- 토큰 양식: `<%= KEY %>` (delimiter 양쪽 공백 허용 — `<%=KEY%>` / `<%=   KEY   %>` 모두 OK).
+- 키 prefix 는 **`ZNTC_` 만** 허용. JS 측 `envPrefixes` 가 `VITE_*` 까지 허용해도 HTML 본문에는 노출 안 됨 — secret 누설 방지.
+- 다른 prefix 키 (`<%= VITE_API_KEY %>`) 는 **원본 보존 + warning** (token 이 사이트에 그대로 노출되므로 즉시 감지 가능).
+- 미발견 키 (`<%= ZNTC_UNDEFINED %>`) 는 **빈 문자열 + warning** (Vite / CRA 와 동일).
+- expression 평가 (`<%= mode === 'prod' ? '/' : '/dev/' %>`) 는 **미지원** — key-only.
+
 #### 함수형 config 의 `ConfigEnv.command`
 
 `zntc.config.ts` 에서 `defineConfig(({ command, mode, env }) => ...)` 형태를 쓸 때 `command` 가 받을 수 있는 값:

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -573,7 +573,10 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
       splitting: opts.splitting || undefined,
       compiler: config?.compiler,
     });
+    const htmlEnv = loadEnv(configEnv.mode, opts.envDir ? resolve(opts.envDir) : (pipelineRoot ?? root), ['ZNTC_']);
+    const { warnings: htmlWarnings } = web.applyHtmlEnvTokens(outdir, htmlEnv);
     if (opts.logLevel !== 'silent') {
+      for (const w of htmlWarnings) console.warn(`[zntc] ${w}`);
       console.error(`[build] wrote ${result.outputCount ?? 0} files to ${outdir}`);
     }
     return result;

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -576,7 +576,7 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
     const htmlEnv = loadEnv(configEnv.mode, opts.envDir ? resolve(opts.envDir) : (pipelineRoot ?? root), ['ZNTC_']);
     const { warnings: htmlWarnings } = web.applyHtmlEnvTokens(outdir, htmlEnv);
     if (opts.logLevel !== 'silent') {
-      for (const w of htmlWarnings) console.warn(`[zntc] ${w}`);
+      for (const w of htmlWarnings) console.error(`[html-env] ${w}`);
       console.error(`[build] wrote ${result.outputCount ?? 0} files to ${outdir}`);
     }
     return result;

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -573,7 +573,11 @@ async function runAppBuild(opts, config, configEnv, _dotenvVars) {
       splitting: opts.splitting || undefined,
       compiler: config?.compiler,
     });
-    const htmlEnv = loadEnv(configEnv.mode, opts.envDir ? resolve(opts.envDir) : (pipelineRoot ?? root), ['ZNTC_']);
+    const htmlEnv = loadEnv(
+      configEnv.mode,
+      opts.envDir ? resolve(opts.envDir) : (pipelineRoot ?? root),
+      ['ZNTC_'],
+    );
     const { warnings: htmlWarnings } = web.applyHtmlEnvTokens(outdir, htmlEnv);
     if (opts.logLevel !== 'silent') {
       for (const w of htmlWarnings) console.error(`[html-env] ${w}`);

--- a/packages/core/src/load-env.ts
+++ b/packages/core/src/load-env.ts
@@ -67,6 +67,8 @@ function parseDotenvFile(filePath: string): Record<string, string> {
 export function loadEnv(
   mode: string,
   envDir: string,
+  // 주의: html-env 의 DEFAULT_HTML_ENV_PREFIX 는 별도 `'ZNTC_'` 만 — HTML 본문 노출은
+  // secret 누설 방지를 위해 의도적으로 VITE_* 를 배제한다. JS 측 import.meta.env 와는 다름.
   prefixes: string | string[] = ['VITE_', 'ZNTC_'],
 ): Record<string, string> {
   const prefixList = Array.isArray(prefixes) ? prefixes : [prefixes];

--- a/packages/web/src/dev-controller.ts
+++ b/packages/web/src/dev-controller.ts
@@ -391,6 +391,11 @@ export function createAppDevController(
   // F1+F2 cache (incremental prep 에서 재사용). 구조 변화 (스타일 파일 추가/삭제) 시
   // 무효화 — `prepareAppCssPipelineRoot` 가 cache miss 일 때 자체적으로 재수집한다.
   let pipelineCache: PipelineCache | null = null;
+  // HTML env (ZNTC_*) cache + warning dedupe. dev 세션 내 envDir 변경은 restartTriggers
+  // 가 process 를 재시작하므로 메모이즈 안전. warning 은 같은 key 로 매 rebuild 마다
+  // 출력되면 노이즈 — Set 으로 1회 limit.
+  let htmlEnvCache: { mode: string; dir: string; env: Record<string, string> } | null = null;
+  const warnedHtmlEnv = new Set<string>();
 
   return {
     root,
@@ -436,10 +441,21 @@ export function createAppDevController(
         envDir,
         envPrefixes: opts.envPrefixes ? Array.from(opts.envPrefixes) : undefined,
       });
-      const htmlEnv = loadEnv(configEnv.mode, envDir, ['ZNTC_']);
+      const htmlEnv =
+        htmlEnvCache && htmlEnvCache.mode === configEnv.mode && htmlEnvCache.dir === envDir
+          ? htmlEnvCache.env
+          : (htmlEnvCache = {
+              mode: configEnv.mode,
+              dir: envDir,
+              env: loadEnv(configEnv.mode, envDir, ['ZNTC_']),
+            }).env;
       const { warnings: htmlWarnings } = applyHtmlEnvTokens(outdir, htmlEnv);
       if (opts.logLevel !== 'silent') {
-        for (const w of htmlWarnings) console.warn(`[zntc] ${w}`);
+        for (const w of htmlWarnings) {
+          if (warnedHtmlEnv.has(w)) continue;
+          warnedHtmlEnv.add(w);
+          console.error(`[html-env] ${w}`);
+        }
       }
       injectAppDevHmrClient(outdir);
       // dev mode 한정 — bundler 가 dev splitting=false 라 CSS chunk 를 emit 하지

--- a/packages/web/src/dev-controller.ts
+++ b/packages/web/src/dev-controller.ts
@@ -10,7 +10,9 @@ import {
 import { tmpdir } from 'node:os';
 import { dirname, join, relative, resolve, sep } from 'node:path';
 
-import { prepareAppDevSync } from '@zntc/core';
+import { loadEnv, prepareAppDevSync } from '@zntc/core';
+
+import { applyHtmlEnvTokens } from './html-env.ts';
 
 import {
   type BundleResult,
@@ -423,6 +425,7 @@ export function createAppDevController(
       pipelineRoot = pipeline?.tempRoot ?? null;
       pipelineCache = pipeline?.cache ?? null;
       const prepareRoot = pipelineRoot ?? root;
+      const envDir = opts.envDir ? resolve(opts.envDir) : prepareRoot;
       const prepared = prepareAppDevSync({
         root: prepareRoot,
         outdir,
@@ -430,9 +433,14 @@ export function createAppDevController(
         publicDir: opts.publicDir === undefined ? 'public' : opts.publicDir,
         base,
         mode: configEnv.mode,
-        envDir: opts.envDir ? resolve(opts.envDir) : prepareRoot,
+        envDir,
         envPrefixes: opts.envPrefixes ? Array.from(opts.envPrefixes) : undefined,
       });
+      const htmlEnv = loadEnv(configEnv.mode, envDir, ['ZNTC_']);
+      const { warnings: htmlWarnings } = applyHtmlEnvTokens(outdir, htmlEnv);
+      if (opts.logLevel !== 'silent') {
+        for (const w of htmlWarnings) console.warn(`[zntc] ${w}`);
+      }
       injectAppDevHmrClient(outdir);
       // dev mode 한정 — bundler 가 dev splitting=false 라 CSS chunk 를 emit 하지
       // 않으므로 Sass / CSS Modules 결과를 outdir 로 mirror + `<link>` 주입.

--- a/packages/web/src/html-env.test.ts
+++ b/packages/web/src/html-env.test.ts
@@ -17,18 +17,17 @@ describe('transformHtmlEnvTokens', () => {
   });
 
   test('replaces multiple tokens', () => {
-    const { html } = transformHtmlEnvTokens(
-      '<a href="<%= ZNTC_BASE %>"><%= ZNTC_LABEL %></a>',
-      { ZNTC_BASE: '/app/', ZNTC_LABEL: 'Home' },
-    );
+    const { html } = transformHtmlEnvTokens('<a href="<%= ZNTC_BASE %>"><%= ZNTC_LABEL %></a>', {
+      ZNTC_BASE: '/app/',
+      ZNTC_LABEL: 'Home',
+    });
     expect(html).toBe('<a href="/app/">Home</a>');
   });
 
   test('tolerates whitespace variants', () => {
-    const { html } = transformHtmlEnvTokens(
-      '<%=ZNTC_A%>|<%= ZNTC_A %>|<%=   ZNTC_A   %>',
-      { ZNTC_A: 'x' },
-    );
+    const { html } = transformHtmlEnvTokens('<%=ZNTC_A%>|<%= ZNTC_A %>|<%=   ZNTC_A   %>', {
+      ZNTC_A: 'x',
+    });
     expect(html).toBe('x|x|x');
   });
 

--- a/packages/web/src/html-env.test.ts
+++ b/packages/web/src/html-env.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { applyHtmlEnvTokens, transformHtmlEnvTokens } from './html-env.ts';
+
+describe('transformHtmlEnvTokens', () => {
+  test('replaces token with env value', () => {
+    const { html, changed, warnings } = transformHtmlEnvTokens(
+      '<title><%= ZNTC_APP_TITLE %></title>',
+      { ZNTC_APP_TITLE: 'My App' },
+    );
+    expect(html).toBe('<title>My App</title>');
+    expect(changed).toBe(true);
+    expect(warnings).toEqual([]);
+  });
+
+  test('replaces multiple tokens', () => {
+    const { html } = transformHtmlEnvTokens(
+      '<a href="<%= ZNTC_BASE %>"><%= ZNTC_LABEL %></a>',
+      { ZNTC_BASE: '/app/', ZNTC_LABEL: 'Home' },
+    );
+    expect(html).toBe('<a href="/app/">Home</a>');
+  });
+
+  test('tolerates whitespace variants', () => {
+    const { html } = transformHtmlEnvTokens(
+      '<%=ZNTC_A%>|<%= ZNTC_A %>|<%=   ZNTC_A   %>',
+      { ZNTC_A: 'x' },
+    );
+    expect(html).toBe('x|x|x');
+  });
+
+  test('missing env replaces with empty string and warns', () => {
+    const { html, warnings, changed } = transformHtmlEnvTokens(
+      '<meta name="v" content="<%= ZNTC_VERSION %>">',
+      {},
+    );
+    expect(html).toBe('<meta name="v" content="">');
+    expect(changed).toBe(true);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('ZNTC_VERSION');
+  });
+
+  test('keeps token as-is when prefix mismatches (no leakage)', () => {
+    const { html, warnings, changed } = transformHtmlEnvTokens(
+      '<meta name="api" content="<%= VITE_API_URL %>">',
+      { VITE_API_URL: 'https://api.example.com', ZNTC_OK: 'ok' },
+    );
+    expect(html).toBe('<meta name="api" content="<%= VITE_API_URL %>">');
+    expect(changed).toBe(false);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('VITE_API_URL');
+  });
+
+  test('custom prefix', () => {
+    const { html } = transformHtmlEnvTokens(
+      '<title><%= NEXT_PUBLIC_TITLE %></title>',
+      { NEXT_PUBLIC_TITLE: 'X' },
+      'NEXT_PUBLIC_',
+    );
+    expect(html).toBe('<title>X</title>');
+  });
+
+  test('non-token-like sequences are left alone', () => {
+    const html = '<!-- <% comment %> --> <%= 1 + 1 %> <%=invalid-key%>';
+    const out = transformHtmlEnvTokens(html, { ZNTC_X: 'y' });
+    expect(out.html).toBe(html);
+    expect(out.changed).toBe(false);
+  });
+
+  test('changed=false when no token present', () => {
+    const html = '<html><body>no tokens here</body></html>';
+    const out = transformHtmlEnvTokens(html, { ZNTC_X: 'y' });
+    expect(out.html).toBe(html);
+    expect(out.changed).toBe(false);
+    expect(out.warnings).toEqual([]);
+  });
+});
+
+describe('applyHtmlEnvTokens', () => {
+  let outdir: string;
+  let htmlPath: string;
+
+  beforeEach(() => {
+    outdir = mkdtempSync(join(tmpdir(), 'zntc-html-env-'));
+    htmlPath = join(outdir, 'index.html');
+  });
+
+  afterEach(() => {
+    rmSync(outdir, { recursive: true, force: true });
+  });
+
+  test('writes file when changed', () => {
+    mkdirSync(outdir, { recursive: true });
+    writeFileSync(htmlPath, '<title><%= ZNTC_APP_TITLE %></title>');
+    const { warnings } = applyHtmlEnvTokens(outdir, { ZNTC_APP_TITLE: 'Hi' });
+    expect(warnings).toEqual([]);
+    expect(readFileSync(htmlPath, 'utf8')).toBe('<title>Hi</title>');
+  });
+
+  test('does not touch file when no token present', () => {
+    mkdirSync(outdir, { recursive: true });
+    const original = '<title>static</title>';
+    writeFileSync(htmlPath, original);
+    const stat1 = readFileSync(htmlPath, 'utf8');
+    applyHtmlEnvTokens(outdir, { ZNTC_APP_TITLE: 'Hi' });
+    const stat2 = readFileSync(htmlPath, 'utf8');
+    expect(stat2).toBe(stat1);
+    expect(stat2).toBe(original);
+  });
+
+  test('silent on ENOENT', () => {
+    const { warnings } = applyHtmlEnvTokens(outdir, { ZNTC_X: 'y' });
+    expect(warnings).toEqual([]);
+  });
+});

--- a/packages/web/src/html-env.test.ts
+++ b/packages/web/src/html-env.test.ts
@@ -77,6 +77,35 @@ describe('transformHtmlEnvTokens', () => {
     expect(out.changed).toBe(false);
     expect(out.warnings).toEqual([]);
   });
+
+  test('missing key alone keeps changed=false when both sides equal', () => {
+    const out = transformHtmlEnvTokens('<x><%= ZNTC_X %></x>', {});
+    expect(out.html).toBe('<x></x>');
+    expect(out.changed).toBe(true);
+    const stable = transformHtmlEnvTokens('<x></x>', {});
+    expect(stable.changed).toBe(false);
+  });
+
+  test('escapes <, >, &, " in env values', () => {
+    const { html } = transformHtmlEnvTokens('<div data="<%= ZNTC_BIO %>"></div>', {
+      ZNTC_BIO: `<script>alert("&")</script>`,
+    });
+    expect(html).toBe('<div data="&lt;script&gt;alert(&quot;&amp;&quot;)&lt;/script&gt;"></div>');
+  });
+
+  test('attribute value with " stays safe', () => {
+    const { html } = transformHtmlEnvTokens('<meta content="<%= ZNTC_X %>">', {
+      ZNTC_X: '" onerror="alert(1)',
+    });
+    expect(html).toBe('<meta content="&quot; onerror=&quot;alert(1)">');
+  });
+
+  test('same key multiple times all replaced', () => {
+    const { html } = transformHtmlEnvTokens('<%= ZNTC_X %>-<%= ZNTC_X %>-<%= ZNTC_X %>', {
+      ZNTC_X: 'v',
+    });
+    expect(html).toBe('v-v-v');
+  });
 });
 
 describe('applyHtmlEnvTokens', () => {

--- a/packages/web/src/html-env.ts
+++ b/packages/web/src/html-env.ts
@@ -1,0 +1,73 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * HTML 안의 EJS 스타일 토큰 `<%= KEY %>` 를 환경변수 값으로 치환.
+ *
+ * - 토큰 양식: `<%=` (양쪽 공백 허용) `KEY` `%>`. `KEY` 는 `[A-Za-z_][A-Za-z0-9_]*`.
+ * - 허용 prefix 외 키는 원본 토큰을 그대로 두고 warning 만 기록. 사용자가 typo / secret 노출
+ *   실수를 알 수 있게 하기 위함. (`VITE_*` 같은 다른 prefix 가 HTML 에 그대로 노출되는 것을 방지)
+ * - 미발견 키는 빈 문자열로 치환 + warning (Vite/CRA 와 동일 동작).
+ * - expression 평가 (`<%= mode === 'prod' ? ... %>`) 는 미지원 — key-only.
+ */
+
+export const DEFAULT_HTML_ENV_PREFIX = 'ZNTC_';
+
+const TOKEN_RE = /<%=\s*([A-Za-z_][A-Za-z0-9_]*)\s*%>/g;
+
+export interface TransformHtmlEnvResult {
+  html: string;
+  changed: boolean;
+  warnings: string[];
+}
+
+export function transformHtmlEnvTokens(
+  html: string,
+  env: Record<string, string>,
+  prefix: string = DEFAULT_HTML_ENV_PREFIX,
+): TransformHtmlEnvResult {
+  const warnings: string[] = [];
+  let changed = false;
+
+  const next = html.replace(TOKEN_RE, (match, key: string) => {
+    if (!key.startsWith(prefix)) {
+      warnings.push(
+        `html env: token "${match}" uses key "${key}" without allowed prefix "${prefix}" — kept as-is`,
+      );
+      return match;
+    }
+    const value = env[key];
+    if (value === undefined) {
+      warnings.push(`html env: "${key}" not found in environment — replaced with empty string`);
+      changed = true;
+      return '';
+    }
+    changed = true;
+    return value;
+  });
+
+  return { html: next, changed, warnings };
+}
+
+/**
+ * `<outdir>/index.html` 을 읽고 EJS 토큰을 치환한 결과를 다시 쓴다.
+ * ENOENT 는 silent skip — dev mode 에서 entry HTML 이 아직 없을 수 있음.
+ * 토큰이 하나도 변하지 않았으면 write 도 생략 (touch 회피).
+ */
+export function applyHtmlEnvTokens(
+  outdir: string,
+  env: Record<string, string>,
+  prefix: string = DEFAULT_HTML_ENV_PREFIX,
+): { warnings: string[] } {
+  const htmlPath = join(outdir, 'index.html');
+  let html: string;
+  try {
+    html = readFileSync(htmlPath, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return { warnings: [] };
+    throw err;
+  }
+  const result = transformHtmlEnvTokens(html, env, prefix);
+  if (result.changed) writeFileSync(htmlPath, result.html);
+  return { warnings: result.warnings };
+}

--- a/packages/web/src/html-env.ts
+++ b/packages/web/src/html-env.ts
@@ -5,15 +5,29 @@ import { join } from 'node:path';
  * HTML 안의 EJS 스타일 토큰 `<%= KEY %>` 를 환경변수 값으로 치환.
  *
  * - 토큰 양식: `<%=` (양쪽 공백 허용) `KEY` `%>`. `KEY` 는 `[A-Za-z_][A-Za-z0-9_]*`.
- * - 허용 prefix 외 키는 원본 토큰을 그대로 두고 warning 만 기록. 사용자가 typo / secret 노출
- *   실수를 알 수 있게 하기 위함. (`VITE_*` 같은 다른 prefix 가 HTML 에 그대로 노출되는 것을 방지)
- * - 미발견 키는 빈 문자열로 치환 + warning (Vite/CRA 와 동일 동작).
- * - expression 평가 (`<%= mode === 'prod' ? ... %>`) 는 미지원 — key-only.
+ * - 치환 값은 `<`, `>`, `&`, `"` 를 HTML escape 한다 — `.env` 값이 attribute 안 또는 script
+ *   안에 들어가 XSS / attribute 깨짐을 만드는 것을 차단. 사용자가 의도적으로 HTML 을
+ *   넣고 싶다면 별도 옵션 (현재 미지원) 또는 inline script + import.meta.env 사용.
+ * - 허용 prefix 외 키는 원본 토큰을 그대로 두고 warning. typo / secret 노출 실수를 가시화.
+ * - 미발견 키는 빈 문자열로 치환 + warning (Vite/CRA 호환).
+ * - expression 평가 (`<%= mode === 'prod' ? ... %>`) 는 미지원 — key-only. KEY 시작이
+ *   숫자 / 기호여서 regex 가 reject.
  */
 
 export const DEFAULT_HTML_ENV_PREFIX = 'ZNTC_';
 
 const TOKEN_RE = /<%=\s*([A-Za-z_][A-Za-z0-9_]*)\s*%>/g;
+
+const HTML_ESCAPE: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+};
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"]/g, (c) => HTML_ESCAPE[c]);
+}
 
 export interface TransformHtmlEnvResult {
   html: string;
@@ -27,32 +41,29 @@ export function transformHtmlEnvTokens(
   prefix: string = DEFAULT_HTML_ENV_PREFIX,
 ): TransformHtmlEnvResult {
   const warnings: string[] = [];
-  let changed = false;
 
   const next = html.replace(TOKEN_RE, (match, key: string) => {
     if (!key.startsWith(prefix)) {
       warnings.push(
-        `html env: token "${match}" uses key "${key}" without allowed prefix "${prefix}" — kept as-is`,
+        `token "${match}" uses key "${key}" without allowed prefix "${prefix}" — kept as-is`,
       );
       return match;
     }
     const value = env[key];
     if (value === undefined) {
-      warnings.push(`html env: "${key}" not found in environment — replaced with empty string`);
-      changed = true;
+      warnings.push(`"${key}" not found in environment — replaced with empty string`);
       return '';
     }
-    changed = true;
-    return value;
+    return escapeHtml(value);
   });
 
-  return { html: next, changed, warnings };
+  return { html: next, changed: next !== html, warnings };
 }
 
 /**
  * `<outdir>/index.html` 을 읽고 EJS 토큰을 치환한 결과를 다시 쓴다.
  * ENOENT 는 silent skip — dev mode 에서 entry HTML 이 아직 없을 수 있음.
- * 토큰이 하나도 변하지 않았으면 write 도 생략 (touch 회피).
+ * `changed=false` 면 write 도 생략 — 같은 결과 재기록으로 인한 mtime 변화 / watcher 트리거 방지.
  */
 export function applyHtmlEnvTokens(
   outdir: string,

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -33,6 +33,12 @@ export {
   injectAppDevPipelineCssLinks,
   injectIntoDevHtml,
 } from './inject.ts';
+export {
+  DEFAULT_HTML_ENV_PREFIX,
+  type TransformHtmlEnvResult,
+  applyHtmlEnvTokens,
+  transformHtmlEnvTokens,
+} from './html-env.ts';
 export { joinUrl } from './url.ts';
 export {
   isCssIdent,

--- a/tests/integration/tests/html-env.test.ts
+++ b/tests/integration/tests/html-env.test.ts
@@ -1,7 +1,8 @@
 import { describe, test, expect } from 'bun:test';
-import { mkdtemp, rm, writeFile, mkdir, readFile } from 'node:fs/promises';
-import { join, dirname, resolve } from 'node:path';
-import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readFile } from 'node:fs/promises';
+
+import { createFixture, runZntcInDir } from './helpers';
 
 /**
  * `zntc build` (app 모드) 가 index.html 안의 EJS 스타일 `<%= ZNTC_X %>` 토큰을
@@ -9,41 +10,22 @@ import { tmpdir } from 'node:os';
  * 단위 테스트는 packages/web/src/html-env.test.ts 에 있고, 본 파일은 caller hook
  * (runAppBuild → applyHtmlEnvTokens) 이 실제로 작동하는지 회귀를 보장한다.
  *
- * NAPI binding (packages/core/zntc.node) 와 @zntc/web 의 dist 빌드가 모두 필요.
+ * 의존: NAPI binding (packages/core/zntc.node) + @zntc/web dist 가 모두 빌드돼야 통과.
  */
 
-const ZNTC_MJS = resolve(import.meta.dir, '../../../packages/core/bin/zntc.mjs');
+// app build 는 entry script 가 있어야 동작 — 본문 검증 대상은 HTML 이지만 build 파이프
+// 라인 진입 조건을 충족하기 위한 최소 stub.
+const MAIN_TS = "console.log('hi');\n";
 
-async function makeApp(
-  files: Record<string, string>,
-): Promise<{ dir: string; cleanup: () => Promise<void> }> {
-  const dir = await mkdtemp(join(tmpdir(), 'zntc-html-env-'));
-  for (const [name, content] of Object.entries(files)) {
-    const p = join(dir, name);
-    await mkdir(dirname(p), { recursive: true });
-    await writeFile(p, content);
-  }
-  return { dir, cleanup: () => rm(dir, { recursive: true, force: true }) };
-}
-
-async function runBuild(
+async function buildApp(
   dir: string,
-): Promise<{ exitCode: number | null; stdout: string; stderr: string }> {
-  const proc = Bun.spawn(['bun', ZNTC_MJS, 'build', dir, '--outdir', join(dir, 'dist')], {
-    stdout: 'pipe',
-    stderr: 'pipe',
-  });
-  const [stdout, stderr] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ]);
-  const exitCode = await proc.exited;
-  return { exitCode, stdout, stderr };
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  return runZntcInDir(dir, ['build', dir, '--outdir', join(dir, 'dist')], { bin: 'js' });
 }
 
 describe('html-env EJS token replacement — zntc build (app mode)', () => {
-  test('replaces ZNTC_* tokens, keeps VITE_* as-is, fills missing keys with empty string', async () => {
-    const { dir, cleanup } = await makeApp({
+  test.concurrent('replaces ZNTC_* tokens, keeps VITE_* as-is, fills missing keys with empty string', async () => {
+    const { dir, cleanup } = await createFixture({
       '.env':
         'ZNTC_APP_TITLE=My ZNTC App\nZNTC_BUILD_VERSION=2026.05\nVITE_SECRET=should-not-leak\n',
       'index.html': `<!DOCTYPE html>
@@ -56,21 +38,21 @@ describe('html-env EJS token replacement — zntc build (app mode)', () => {
   </head>
   <body><div id="root"></div><script type="module" src="./src/main.ts"></script></body>
 </html>`,
-      'src/main.ts': "console.log('hi');\n",
+      'src/main.ts': MAIN_TS,
     });
     try {
-      const { exitCode, stderr } = await runBuild(dir);
-      expect(exitCode).toBe(0);
+      const { exitCode, stderr } = await buildApp(dir);
+      expect(exitCode === 0 ? '' : stderr).toBe('');
 
       const html = await readFile(join(dir, 'dist', 'index.html'), 'utf8');
       expect(html).toContain('<title>My ZNTC App</title>');
       expect(html).toContain('content="2026.05"');
       expect(html).toContain('content=""');
-      // VITE_ prefix 는 원본 보존, 값이 노출되지 않아야 함
+      // VITE_ prefix 는 원본 보존, 값이 노출돼서는 안 됨
       expect(html).toContain('<%= VITE_SECRET %>');
       expect(html).not.toContain('should-not-leak');
 
-      // warnings: 미발견 키 + 잘못된 prefix 둘 다 [html-env] 로 기록
+      // 미발견 키 + 잘못된 prefix 둘 다 [html-env] 로 기록
       expect(stderr).toContain('[html-env]');
       expect(stderr).toContain('ZNTC_UNDEFINED');
       expect(stderr).toContain('VITE_SECRET');
@@ -79,48 +61,48 @@ describe('html-env EJS token replacement — zntc build (app mode)', () => {
     }
   });
 
-  test('escapes <, >, &, " in env values', async () => {
-    const { dir, cleanup } = await makeApp({
+  test.concurrent('escapes <, >, &, " in env values (XSS 방어)', async () => {
+    const { dir, cleanup } = await createFixture({
       '.env': `ZNTC_BIO=<script>alert("&")</script>\n`,
       'index.html': `<!DOCTYPE html>
 <html>
   <head><title>x</title></head>
   <body><div data="<%= ZNTC_BIO %>"></div><script type="module" src="./src/main.ts"></script></body>
 </html>`,
-      'src/main.ts': "console.log('hi');\n",
+      'src/main.ts': MAIN_TS,
     });
     try {
-      const { exitCode } = await runBuild(dir);
-      expect(exitCode).toBe(0);
+      const { exitCode, stderr } = await buildApp(dir);
+      expect(exitCode === 0 ? '' : stderr).toBe('');
 
       const html = await readFile(join(dir, 'dist', 'index.html'), 'utf8');
       expect(html).toContain('&lt;script&gt;');
-      expect(html).toContain('&quot;');
-      expect(html).toContain('&amp;');
-      // raw script 태그가 HTML 본문에 그대로 들어가서는 안 됨 (XSS 방어)
+      // raw script 태그가 HTML 본문에 그대로 들어가서는 안 됨
       expect(html).not.toContain('<script>alert(');
     } finally {
       await cleanup();
     }
   });
 
-  test('html without any token leaves file untouched', async () => {
-    const original = `<!DOCTYPE html>
+  test.concurrent('html without any token leaves file untouched + no warning', async () => {
+    const { dir, cleanup } = await createFixture({
+      'index.html': `<!DOCTYPE html>
 <html>
   <head><title>static</title></head>
   <body><div id="root"></div><script type="module" src="./src/main.ts"></script></body>
-</html>`;
-    const { dir, cleanup } = await makeApp({
-      'index.html': original,
-      'src/main.ts': "console.log('hi');\n",
+</html>`,
+      'src/main.ts': MAIN_TS,
     });
     try {
-      const { exitCode } = await runBuild(dir);
-      expect(exitCode).toBe(0);
+      const { exitCode, stderr } = await buildApp(dir);
+      expect(exitCode === 0 ? '' : stderr).toBe('');
 
       const html = await readFile(join(dir, 'dist', 'index.html'), 'utf8');
-      // build 가 script src 를 hashed 파일로 rewrite — 그 외 본문은 보존돼야 함
       expect(html).toContain('<title>static</title>');
+      expect(html).toContain('<div id="root">');
+      // 토큰 0 개 → applyHtmlEnvTokens 가 changed=false 로 write/warning 둘 다 생략해야 함
+      expect(html).not.toContain('<%=');
+      expect(stderr).not.toContain('[html-env]');
     } finally {
       await cleanup();
     }

--- a/tests/integration/tests/html-env.test.ts
+++ b/tests/integration/tests/html-env.test.ts
@@ -1,0 +1,128 @@
+import { describe, test, expect } from 'bun:test';
+import { mkdtemp, rm, writeFile, mkdir, readFile } from 'node:fs/promises';
+import { join, dirname, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+
+/**
+ * `zntc build` (app 모드) 가 index.html 안의 EJS 스타일 `<%= ZNTC_X %>` 토큰을
+ * .env 값으로 치환하는지 e2e 검증. transformHtmlEnvTokens / applyHtmlEnvTokens 의
+ * 단위 테스트는 packages/web/src/html-env.test.ts 에 있고, 본 파일은 caller hook
+ * (runAppBuild → applyHtmlEnvTokens) 이 실제로 작동하는지 회귀를 보장한다.
+ *
+ * NAPI binding (packages/core/zntc.node) 와 @zntc/web 의 dist 빌드가 모두 필요.
+ */
+
+const ZNTC_MJS = resolve(import.meta.dir, '../../../packages/core/bin/zntc.mjs');
+
+async function makeApp(
+  files: Record<string, string>,
+): Promise<{ dir: string; cleanup: () => Promise<void> }> {
+  const dir = await mkdtemp(join(tmpdir(), 'zntc-html-env-'));
+  for (const [name, content] of Object.entries(files)) {
+    const p = join(dir, name);
+    await mkdir(dirname(p), { recursive: true });
+    await writeFile(p, content);
+  }
+  return { dir, cleanup: () => rm(dir, { recursive: true, force: true }) };
+}
+
+async function runBuild(
+  dir: string,
+): Promise<{ exitCode: number | null; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(['bun', ZNTC_MJS, 'build', dir, '--outdir', join(dir, 'dist')], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  return { exitCode, stdout, stderr };
+}
+
+describe('html-env EJS token replacement — zntc build (app mode)', () => {
+  test('replaces ZNTC_* tokens, keeps VITE_* as-is, fills missing keys with empty string', async () => {
+    const { dir, cleanup } = await makeApp({
+      '.env':
+        'ZNTC_APP_TITLE=My ZNTC App\nZNTC_BUILD_VERSION=2026.05\nVITE_SECRET=should-not-leak\n',
+      'index.html': `<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= ZNTC_APP_TITLE %></title>
+    <meta name="v" content="<%= ZNTC_BUILD_VERSION %>" />
+    <meta name="missing" content="<%= ZNTC_UNDEFINED %>" />
+    <meta name="api" content="<%= VITE_SECRET %>" />
+  </head>
+  <body><div id="root"></div><script type="module" src="./src/main.ts"></script></body>
+</html>`,
+      'src/main.ts': "console.log('hi');\n",
+    });
+    try {
+      const { exitCode, stderr } = await runBuild(dir);
+      expect(exitCode).toBe(0);
+
+      const html = await readFile(join(dir, 'dist', 'index.html'), 'utf8');
+      expect(html).toContain('<title>My ZNTC App</title>');
+      expect(html).toContain('content="2026.05"');
+      expect(html).toContain('content=""');
+      // VITE_ prefix 는 원본 보존, 값이 노출되지 않아야 함
+      expect(html).toContain('<%= VITE_SECRET %>');
+      expect(html).not.toContain('should-not-leak');
+
+      // warnings: 미발견 키 + 잘못된 prefix 둘 다 [html-env] 로 기록
+      expect(stderr).toContain('[html-env]');
+      expect(stderr).toContain('ZNTC_UNDEFINED');
+      expect(stderr).toContain('VITE_SECRET');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('escapes <, >, &, " in env values', async () => {
+    const { dir, cleanup } = await makeApp({
+      '.env': `ZNTC_BIO=<script>alert("&")</script>\n`,
+      'index.html': `<!DOCTYPE html>
+<html>
+  <head><title>x</title></head>
+  <body><div data="<%= ZNTC_BIO %>"></div><script type="module" src="./src/main.ts"></script></body>
+</html>`,
+      'src/main.ts': "console.log('hi');\n",
+    });
+    try {
+      const { exitCode } = await runBuild(dir);
+      expect(exitCode).toBe(0);
+
+      const html = await readFile(join(dir, 'dist', 'index.html'), 'utf8');
+      expect(html).toContain('&lt;script&gt;');
+      expect(html).toContain('&quot;');
+      expect(html).toContain('&amp;');
+      // raw script 태그가 HTML 본문에 그대로 들어가서는 안 됨 (XSS 방어)
+      expect(html).not.toContain('<script>alert(');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('html without any token leaves file untouched', async () => {
+    const original = `<!DOCTYPE html>
+<html>
+  <head><title>static</title></head>
+  <body><div id="root"></div><script type="module" src="./src/main.ts"></script></body>
+</html>`;
+    const { dir, cleanup } = await makeApp({
+      'index.html': original,
+      'src/main.ts': "console.log('hi');\n",
+    });
+    try {
+      const { exitCode } = await runBuild(dir);
+      expect(exitCode).toBe(0);
+
+      const html = await readFile(join(dir, 'dist', 'index.html'), 'utf8');
+      // build 가 script src 를 hashed 파일로 rewrite — 그 외 본문은 보존돼야 함
+      expect(html).toContain('<title>static</title>');
+    } finally {
+      await cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

다른 번들러의 `%VITE_*%` / EJS placeholder 에 대응. `index.html` 본문에 `<%= ZNTC_X %>` 토큰을 쓰면 **dev / build 양쪽에서** `.env` 의 값으로 자동 치환됩니다. JS 측 `import.meta.env.X` 와는 완전 분리된 경로 — HTML 안에서 직접 사용.

## 사용 예

```html
<!DOCTYPE html>
<html>
  <head>
    <title><%= ZNTC_APP_TITLE %></title>
    <meta name="version" content="<%= ZNTC_BUILD_VERSION %>" />
  </head>
</html>
```

```bash
# .env
ZNTC_APP_TITLE=My App
ZNTC_BUILD_VERSION=2026.05
```

## Spec

- **양식**: `<%=` (양쪽 공백 허용) `KEY` `%>`. `KEY` 는 `[A-Za-z_][A-Za-z0-9_]*`.
- **prefix**: `ZNTC_` **만 노출**. JS 측 envPrefixes 가 `VITE_*` 까지 허용해도 HTML 본문에는 노출 안 됨 — secret 누설 방지.
- **HTML escape**: 치환 값의 `<`, `>`, `&`, `"` 자동 escape. `.env` 값이 attribute / script 안에 들어가 XSS / attribute 깨짐 차단.
- **다른 prefix 키** (`<%= VITE_API_KEY %>`) → 원본 보존 + warning (raw token 이 페이지에 노출되어 즉시 감지 가능).
- **미발견 키** → 빈 문자열 + warning (Vite / CRA 동등).
- **expression 평가** 미지원 — key-only.

## 변경 파일

| 파일 | 역할 |
|---|---|
| `packages/web/src/html-env.ts` (신규) | `transformHtmlEnvTokens` (pure) + `applyHtmlEnvTokens` (I/O) + `escapeHtml` |
| `packages/web/src/html-env.test.ts` (신규) | 15 케이스 (escape · attribute injection · whitespace · prefix 검증 · 미발견 · ENOENT) |
| `packages/web/src/index.ts` | public export |
| `packages/web/src/dev-controller.ts` | `prepare()` 안 hook + envCache + warning dedupe |
| `packages/core/bin/zntc.mjs` | `runAppBuild` 의 `buildAppSync` 직후 hook |
| `packages/core/src/load-env.ts` | `DEFAULT_HTML_ENV_PREFIX` 와 의도적 차이 주석 |
| `documents/src/content/docs/guides/config-file.md` (ko/en) | 사용법 + spec 한 섹션 |

## /simplify 적용 사항 (2nd commit)

3 agent 병렬 리뷰 → fix:

- **HTML escape (HIGH security)** — `<>&"` 4종 escape. `.env` 값 XSS / attribute 깨짐 방지.
- **`changed = next !== html` 단일화** — 미발견 키 단독 케이스에서도 결과가 원본과 같으면 write 생략. dev rebuild 마다 동일 결과 재기록으로 인한 mtime 변화 / 외부 watcher 트리거 방지.
- **envCache** — dev 세션 내 envDir/mode 동일하면 loadEnv 의 4-file IO 한 번만 (`restartTriggers` 가 `.env` 변경 시 process 재시작 → 캐시 safe).
- **warning dedupe** — Set 으로 같은 warning key 1회만 출력 (rebuild console 노이즈 방지).
- **`console.warn` → `console.error('[html-env] ...')`** — postcss/sass 등 다른 모듈 패턴과 통일.
- **테스트 +4** — escape, attribute injection (`" onerror="alert(1)`), 같은 키 다중 출현, missing-only no-change.

skip: inject.ts ↔ html-env.ts read/write 통합 (over-engineering), native + JS 이중 loadEnv 통합 (별도 PR — native 측 expose 변경 필요).

## Test plan

- [x] `packages/web` `bun test src/html-env.test.ts src/inject.test.ts src/dev-controller.test.ts` — 46 / 46 pass
- [x] `documents` build 476 페이지, links valid
- [x] `bun run fmt` (oxfmt) 통과
- [ ] 머지 후 사용자 프로젝트에서 `index.html` 안 `<%= ZNTC_APP_TITLE %>` 가 dev / build 양쪽에서 치환되는지 수동 확인
- [ ] `<%= VITE_X %>` 가 원본 보존 + warning 출력되는지 수동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)