### PR TITLE
fix(init): zntcBundleScript 에 --minify default 추가

### DIFF
--- a/packages/init/src/react-native.test.ts
+++ b/packages/init/src/react-native.test.ts
@@ -60,6 +60,9 @@ describe('@zntc/init React Native overlay', () => {
       expect(pkg.scripts['bundle:ios']).toContain('zntc --bundle index.js');
       expect(pkg.scripts['bundle:ios']).toContain('--bundle-output ios/main.jsbundle');
       expect(pkg.scripts['bundle:ios']).toContain('--assets-dest ios');
+      // Metro 의 `--dev false` 와 parity — minify 자동 활성 (회귀 가드)
+      expect(pkg.scripts['bundle:ios']).toContain('--minify');
+      expect(pkg.scripts['bundle:android']).toContain('--minify');
       expect(pkg.scripts['bundle:android']).toContain('--assets-dest android/app/src/main/res');
       expect(pkg.scripts['bundle:metro:ios']).toContain('react-native bundle --platform ios');
       expect(readFileSync(join(root, 'zntc.config.ts'), 'utf8')).toBe(createReactNativeConfig());

--- a/packages/init/src/react-native.ts
+++ b/packages/init/src/react-native.ts
@@ -84,7 +84,9 @@ function bundleOut(platform: ReactNativePlatform): string {
 }
 
 function zntcBundleScript(platform: ReactNativePlatform): string {
-  return `zntc --bundle ${DEFAULT_RN_ENTRY} --platform=react-native --rn-platform=${platform} ${bundleOut(platform)}`;
+  // Metro 의 `react-native bundle --dev false` 가 minify 를 자동 활성하는 동작과 parity.
+  // RN 사용자가 `bun run bundle:ios` 했을 때 ~2배 큰 비-minify bundle 받는 사고 차단.
+  return `zntc --bundle ${DEFAULT_RN_ENTRY} --platform=react-native --rn-platform=${platform} --minify ${bundleOut(platform)}`;
 }
 
 function metroBundleScript(platform: ReactNativePlatform): string {


### PR DESCRIPTION
## 발견

\`@zntc/init\` 가 RN 프로젝트에 추가하는 bundle script 가 \`--minify\` 없이 생성됨:

\`\`\`ts
// 이전
function zntcBundleScript(platform) {
  return \`zntc --bundle \${DEFAULT_RN_ENTRY} --platform=react-native --rn-platform=\${platform} \${bundleOut(platform)}\`;
  //   ↑ --minify 없음
}

// 비교 — Metro 는 --dev false 가 minify 자동 활성
function metroBundleScript(platform) {
  return \`react-native bundle --platform \${platform} --dev false ...\`;
}
\`\`\`

→ 사용자가 \`bunx @zntc/init\` 후 \`bun run bundle:ios\` 실행 시 **prod 빌드도 minify 안 된 ~2배 큰 bundle**.

## 검증 (RN fixture)

\`tests/integration/tests/fixtures/rn-example-app\` 에서:

| 빌드 | 사이즈 |
|---|---|
| \`--minify\` ON | **1,007,132 B (~983 KB)** |
| no minify | 2,004,185 B (~1.95 MB) |

→ **정확히 2배 차이.** Metro 사용자의 prod bundle 기대 사이즈와 parity.

## 변경

- \`packages/init/src/react-native.ts\` — \`zntcBundleScript\` 에 \`--minify\` 추가
- \`packages/init/src/react-native.test.ts\` — \`expect(scripts['bundle:ios']).toContain('--minify')\` 회귀 가드 (android 도 동일)

## 영향

- 기존 사용자 (이미 init 한 프로젝트): \`package.json\` 의 script 수동 갱신 필요 X
- 신규 사용자 (publish 후 init 실행): 즉시 minified prod bundle

## Test plan

- [x] \`bun test --cwd packages/init\` (10 pass + 새 assert 2개)
- [x] RN fixture 에서 \`--minify\` 적용 사이즈 검증 (위 표)

## Notes

- 본 PR 은 사용자 dev 워크플로 검증 중 발견 — \`@zntc/init\` 가 publish 직후 사용자 첫인상에 직결.
- publish 전 머지 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)