### PR TITLE
fix(ci): integration job 에 @zntc/web 빌드 step 추가 — app 모드 테스트 회귀 가드

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -134,6 +134,16 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # 통합 테스트 fixture 가 spawn 한 `zntc build` / `zntc dev` (app 모드) 가
+      # `@zntc/web` 과 `@zntc/server` 를 lazy import. ZNTC artifact 는 core
+      # build:js 까지만 — web/server 와 core dts 를 별도 빌드. (#2539 PR #6d 이후
+      # web 의 tsc emit 가 core 의 `prepareAppDevSync` declaration 의존.)
+      - name: Build @zntc/core dts + @zntc/server + @zntc/web (app 모드 의존)
+        run: |
+          bun run --cwd packages/core build:dts
+          bun run --cwd packages/server build
+          bun run --cwd packages/web build
+
       # emotion-v10 fixture 는 root workspace 미포함 — 격리 install 필요.
       - name: Install emotion v10 fixture deps
         run: cd tests/integration/fixtures/emotion-v10 && bun install --frozen-lockfile
@@ -154,6 +164,16 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      # 통합 테스트 fixture 가 spawn 한 `zntc build` / `zntc dev` (app 모드) 가
+      # `@zntc/web` 과 `@zntc/server` 를 lazy import. ZNTC artifact 는 core
+      # build:js 까지만 — web/server 와 core dts 를 별도 빌드. (#2539 PR #6d 이후
+      # web 의 tsc emit 가 core 의 `prepareAppDevSync` declaration 의존.)
+      - name: Build @zntc/core dts + @zntc/server + @zntc/web (app 모드 의존)
+        run: |
+          bun run --cwd packages/core build:dts
+          bun run --cwd packages/server build
+          bun run --cwd packages/web build
 
       # emotion-v10 fixture 는 root workspace 미포함 — 격리 install 필요.
       - name: Install emotion v10 fixture deps


### PR DESCRIPTION
## Summary

- main CI 의 `Integration Tests (macos-latest)` / `(ubuntu-latest)` job 에서 `tests/integration/tests/html-env.test.ts` 3 케이스가 실패 (run: https://github.com/ohah/zntc/actions/runs/25650605250/job/75288712404)
- 실패 메시지: `error: @zntc/web 패키지가 필요합니다 (zntc dev / preview / build app 모드).`
- 원인: 통합 테스트 fixture 가 spawn 한 `zntc build` (app 모드) 가 `@zntc/web` 을 lazy import 하는데, integration job 의 `use-zntc-artifact` 는 core `build:js` 까지만 받음 → `packages/web/dist` 없음 → import 실패. e2e job (line 234-238) 에는 이미 동일 build step 이 있었지만 두 integration job 에는 누락되어 있었음 (PR #2978 머지 시점에 함께 들어가지 못함).
- e2e 와 동일한 build step (`core build:dts` + `server build` + `web build`) 을 `integration-ubuntu` / `integration-macos` 두 job 에 추가. step 코멘트도 "html-env 등" 좁은 표현 대신 "app/dev 모드 fixture 가 lazy import" 본질로 작성해 향후 회귀 시 단서가 stale 되지 않도록.

## 회귀 검증 범위

- `html-env.test.ts` 3 케이스 (replaces ZNTC_* / escapes XSS / no token)
- 동일 메커니즘으로 `@zntc/server` 를 lazy import 하는 dev/serve 통합 테스트 (예: `devserver.test.ts`, `hmr.test.ts`)

## Follow-up (이번 PR 범위 밖)

같은 build step 이 e2e + integration-ubuntu + integration-macos 3 job 에 중복되어 drift 위험. 별도 이슈로 분리 권장:

1. `.github/actions/build-app-mode-deps/action.yml` composite action 으로 추출 (3 곳 호출)
2. 또는 `prepare-zntc-{ubuntu,macos}` artifact 에 `packages/{server,web}/dist/**` 포함시켜 한 번만 빌드 후 download (e2e 중복도 해소, macOS minutes 절감)
3. `core build:dts → (server build:bundle, web build:bundle) 병렬 → tsc -b 한 번` 으로 직렬 빌드 순서 최적화 (~30% 단축 가능, /simplify efficiency 리뷰 결과)

## Test plan

- [ ] CI 에서 `Integration Tests (ubuntu-latest)` 통과 (특히 html-env 3 케이스 pass)
- [ ] CI 에서 `Integration Tests (macos-latest)` 통과
- [ ] e2e job 동작은 변경 없음
- [ ] 다른 통합 테스트 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)