### PR TITLE
fix(bundler): writer-edge 가 함수 body 안 write 까지 over-fire 하던 회귀 (#3012)

### DIFF
--- a/src/bundler/bundler_test/tree_shake.zig
+++ b/src/bundler/bundler_test/tree_shake.zig
@@ -4775,6 +4775,155 @@ test "TreeShaking: post-declaration assignment to top-level var is preserved" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "_self = Box") != null);
 }
 
+test "TreeShaking: function-body writer of mutable let does not pull function in" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { untrack } from './runtime';
+        \\console.log(untrack(() => 1));
+    );
+    try writeFile(tmp.dir, "runtime.ts",
+        \\import { HEAVY_DEP_BODY_TAG } from './heavy';
+        \\export let untracking = false;
+        \\export function untrack(fn) {
+        \\  const prev = untracking;
+        \\  untracking = true;
+        \\  try { return fn(); } finally { untracking = prev; }
+        \\}
+        \\export function update_reaction() {
+        \\  untracking = false;
+        \\  return HEAVY_DEP_BODY_TAG;
+        \\}
+    );
+    try writeFile(tmp.dir, "heavy.ts", "export const HEAVY_DEP_BODY_TAG = 'WRITER_OVERFIRE_HEAVY_MARKER';");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "untrack") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "update_reaction") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "WRITER_OVERFIRE_HEAVY_MARKER") == null);
+}
+
+test "TreeShaking: top-level writer kept, function-body writer dropped on shared let" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { read } from './lib';
+        \\console.log(read());
+    );
+    try writeFile(tmp.dir, "lib.ts",
+        \\import { HEAVY_DEAD_BODY_TAG } from './heavy';
+        \\export let x = 1;
+        \\x = 2;
+        \\export function read() { return x; }
+        \\function dead_fn() { x = 999; return HEAVY_DEAD_BODY_TAG; }
+    );
+    try writeFile(tmp.dir, "heavy.ts", "export const HEAVY_DEAD_BODY_TAG = 'MIXED_WRITER_HEAVY_MARKER';");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "x = 2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "dead_fn") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "MIXED_WRITER_HEAVY_MARKER") == null);
+}
+
+test "TreeShaking: dead function-body writer does not cascade through transitive imports" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { readable } from './store';
+        \\console.log(readable());
+    );
+    try writeFile(tmp.dir, "store.ts",
+        \\import { untrack } from './runtime';
+        \\export function readable() { return untrack(() => 42); }
+    );
+    try writeFile(tmp.dir, "runtime.ts",
+        \\import { effect_helper } from './effects';
+        \\export let untracking = false;
+        \\export function untrack(fn) {
+        \\  const prev = untracking; untracking = true;
+        \\  try { return fn(); } finally { untracking = prev; }
+        \\}
+        \\export function update_effect(e) {
+        \\  untracking = false;
+        \\  return effect_helper(e);
+        \\}
+    );
+    try writeFile(tmp.dir, "effects.ts",
+        \\import { SOURCE_CASCADE_TAG } from './sources';
+        \\export function effect_helper(e) { return SOURCE_CASCADE_TAG + e; }
+    );
+    try writeFile(tmp.dir, "sources.ts", "export const SOURCE_CASCADE_TAG = 'CASCADE_SHOULD_DROP_MARKER';");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "CASCADE_SHOULD_DROP_MARKER") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "effect_helper") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "update_effect") == null);
+}
+
+test "TreeShaking: compound/update writers inside function body are not writer-edged" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { read } from './lib';
+        \\console.log(read());
+    );
+    try writeFile(tmp.dir, "lib.ts",
+        \\import { HEAVY_COMPOUND_TAG } from './heavy';
+        \\export let counter = 0;
+        \\export function read() { return counter; }
+        \\function dead_inc() { counter += 1; counter++; return HEAVY_COMPOUND_TAG; }
+    );
+    try writeFile(tmp.dir, "heavy.ts", "export const HEAVY_COMPOUND_TAG = 'COMPOUND_WRITER_DROP_MARKER';");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "dead_inc") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "COMPOUND_WRITER_DROP_MARKER") == null);
+}
+
 test "TreeShaking: unused direct re-export source preserves eval side effect only" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/graph/json_module.zig
+++ b/src/bundler/graph/json_module.zig
@@ -57,6 +57,7 @@ pub fn parse(self: *ModuleGraph, module: *Module) void {
                 arena_alloc,
                 &(module.ast.?),
                 analyzer.symbols.items,
+                analyzer.scopes.items,
                 analyzer.references.items,
                 if (module.semantic) |*s| &s.unresolved_references else null,
                 false,

--- a/src/bundler/graph/parse_module.zig
+++ b/src/bundler/graph/parse_module.zig
@@ -205,6 +205,7 @@ pub fn parseModule(self: *ModuleGraph, idx: ModuleIndex) void {
                     arena_alloc,
                     &parser.ast,
                     analyzer.symbols.items,
+                    analyzer.scopes.items,
                     analyzer.references.items,
                     if (module.semantic) |*s| &s.unresolved_references else null,
                     false,

--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -282,6 +282,7 @@ fn refreshSemanticAndStmtInfoAfterAstMutation(
                 arena_alloc,
                 ast,
                 analyzer.symbols.items,
+                analyzer.scopes.items,
                 analyzer.references.items,
                 if (module.semantic) |*s| &s.unresolved_references else null,
                 false,

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -15,7 +15,9 @@ const NodeIndex = ast_mod.NodeIndex;
 const Span = @import("../lexer/token.zig").Span;
 const Symbol = @import("../semantic/symbol.zig").Symbol;
 const Reference = @import("../semantic/symbol.zig").Reference;
-const ScopeId = @import("../semantic/scope.zig").ScopeId;
+const scope_mod = @import("../semantic/scope.zig");
+const ScopeId = scope_mod.ScopeId;
+const Scope = scope_mod.Scope;
 const purity = @import("purity.zig");
 
 pub const StmtInfo = struct {
@@ -1105,12 +1107,17 @@ fn buildStmtInfoSlot(
     };
 }
 
+fn scopeIsFunctionOrClassBody(sc: Scope) bool {
+    return sc.kind == .function or sc.kind == .class_body;
+}
+
 /// Semantic Analyzer 의 `references` 배열로부터 ModuleStmtInfos 를 구축한다.
 /// declare/read/write 플래그로 stmt 단위 선언·참조 bucket 을 분배 (analyzer 는 중간 캐시를 유지하지 않음).
 pub fn buildFromSemantic(
     allocator: std.mem.Allocator,
     ast: *const Ast,
     symbols: []const Symbol,
+    scopes: []const Scope,
     references: []const Reference,
     unresolved_globals: ?*const purity.GlobalRefSet,
     collect_cjs_exports: bool,
@@ -1197,7 +1204,11 @@ pub fn buildFromSemantic(
             try declared_buckets[r.stmt_idx].append(allocator, sym_u32);
         } else {
             try referenced_buckets[r.stmt_idx].append(allocator, sym_u32);
-            if (r.flags.write) {
+            // 함수/클래스 body 안의 write 는 함수가 호출될 때만 실행되므로 call graph
+            // (referenced_symbols → declarer 엣지) 가 처리. 여기서 writer 엣지를 만들면
+            // enclosing 함수 declaration 이 false-positive 로 live 가 되어 dead 함수 body 의
+            // transitive import 까지 cascade 보존됨.
+            if (r.flags.write and !scope_mod.anyAncestor(scopes, r.scope_id, scopeIsFunctionOrClassBody)) {
                 try writer_buckets[sym_u32].append(allocator, r.stmt_idx);
             }
         }

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -378,13 +378,11 @@ pub const SemanticAnalyzer = struct {
     }
 
     fn isInsideFunctionScope(self: *const SemanticAnalyzer) bool {
-        var scope_id = self.current_scope;
-        while (!scope_id.isNone()) {
-            const scope = self.scopes.items[scope_id.toIndex()];
-            if (scope.kind == .function) return true;
-            scope_id = scope.parent;
-        }
-        return false;
+        return scope_mod.anyAncestor(self.scopes.items, self.current_scope, struct {
+            fn pred(sc: scope_mod.Scope) bool {
+                return sc.kind == .function;
+            }
+        }.pred);
     }
 
     /// 현재 스코프가 strict mode인지 확인한다.

--- a/src/semantic/scope.zig
+++ b/src/semantic/scope.zig
@@ -83,3 +83,17 @@ pub const Scope = struct {
         return self.subtree_has_direct_eval or self.subtree_has_with;
     }
 };
+
+/// `start` 또는 그 조상 스코프 중 `pred` 를 만족하는 것이 있으면 true.
+/// 잘못된 인덱스를 만나면 false (defensive — analyzer 가 항상 valid 한 chain 보장).
+pub fn anyAncestor(scopes: []const Scope, start: ScopeId, comptime pred: fn (Scope) bool) bool {
+    var sid = start;
+    while (!sid.isNone()) {
+        const idx = sid.toIndex();
+        if (idx >= scopes.len) return false;
+        const sc = scopes[idx];
+        if (pred(sc)) return true;
+        sid = sc.parent;
+    }
+    return false;
+}


### PR DESCRIPTION
Fixes #3012

## Root cause

`f667ce9c` (minimatch TS-emit `var _a; class X {}; _a = X;` 후속 할당 보존 fix) 가 추가한 `sym_to_writer_stmts` 역인덱스가 너무 넓게 동작합니다.

`stmt_info.zig` 의 reference loop 가 *모든* `write` reference 에 대해 그 reference 의 enclosing top-level statement 를 writer 로 등록했는데, **함수/클래스 body 안의 write reference 의 경우 enclosing top-level statement 가 곧 함수 declaration 자체**입니다.

결과적으로 \`let untracking\` 같은 mutable export 가 함수 body 안에서 mutate 될 때마다 그 함수 declaration 이 writer-edge 로 자동 live 가 되어, **호출하는 사람이 없어도** 함수 body 안 모든 reference 가 살아남고 → 그 reference 들의 import 들이 transitive 로 cascade.

svelte `runtime.js` 가 정확히 이 패턴:

\`\`\`js
export let untracking = false;

export function untrack(fn) { ... }            // entry 가 사용
export function update_reaction() {            // 아무도 호출 안 함
  untracking = false;                          // ← writer-edge over-fire
  // body 가 effects.js / sources.js / ... 의 30+ 심볼 참조
}
\`\`\`

\`untrack\` 하나만 import 해도 \`update_reaction\` 의 declaration 이 writer-edge 로 live → body 의 import 들이 cascade → **73KB (esbuild 7.0KB, rolldown 7.2KB, 10.47x ❌)**.

## 다른 번들러는 어떻게?

조사 결과 esbuild / rolldown 둘 다:
- 1 top-level stmt = 1 part 모델
- identifier write 에 reverse edge **없음**
- 함수 body 의 write 는 함수가 실제 호출돼야 실행 → call graph (referenced_symbols → declarer 엣지) 가 자연스럽게 처리

ZNTC 도 같은 모델을 따라야 하지만, minimatch fix 가 \`var _a; _a = X;\` (top-level expression statement) 보존만을 위해 writer-edge 메커니즘을 도입했고 게이트가 부족했습니다.

## 수정

writer-bucket 등록 게이트를 **함수/클래스 body 안 references 만 제외** 로 좁힙니다.

\`\`\`zig
if (r.flags.write and !scope_mod.anyAncestor(scopes, r.scope_id, scopeIsFunctionOrClassBody)) {
    try writer_buckets[sym_u32].append(allocator, r.stmt_idx);
}
\`\`\`

핵심 포인트:
- TS-emit \`_a = X;\` 은 module top-level expression statement → 게이트 통과 ✅
- 함수 body 안 \`untracking = false;\` → 게이트 차단 ✅
- **단순 block / if / for 등 module-init 시 실행되는 블록 스코프 write 는 그대로 유지** — \`block\` / \`switch_block\` / \`catch_clause\` 는 \`.function\` / \`.class_body\` 가 아니므로 \`anyAncestor\` predicate 통과 안 함. reanimated \`if (native) { measure = measureNative; }\` 같은 ESM-export 조건부 할당 패턴 보존 (\`tree_shake.zig\` 의 기존 회귀 테스트).

scope 부모 체인 walk 가 \`analyzer.isInsideFunctionScope\` 와 거의 같아 \`scope.zig\` 에 generic helper \`anyAncestor(scopes, start, pred)\` 로 추출하고 양쪽이 공유합니다.

## Zig 초보자 노트

- \`anyAncestor\` 의 \`pred: fn (Scope) bool\` 는 \`comptime\` 함수 포인터 — Zig 에서는 zero-cost 로 호출자 site 에서 인라인됩니다 (직접 작성한 while 루프와 동일하게 컴파일).
- \`analyzer.zig\` 호출처는 \`struct { fn pred(...) bool { ... } }.pred\` 형태로 nested fn 을 넘김. Zig 에 lambda 가 없어 가장 가까운 idiom입니다.
- \`buildFromSemantic\` 에 \`scopes: []const Scope\` 파라미터를 새로 추가했고, 호출처 3곳 (\`parse_module.zig\`, \`json_module.zig\`, \`transform_prepass.zig\`) 에서 \`analyzer.scopes.items\` 전달.

## 결과

| 메트릭 | Before | After |
|---|---|---|
| svelte deep | 73KB (10.47x ❌) | **3.5KB (0.50x ✅)** |
| svelte-mount | 91KB (0.97x) | 77KB (0.83x ✅) |
| svelte-full | 97KB (0.93x) | 84KB (0.81x ✅) |
| svelte-full-min | 31KB (1.33x ⚠️) | 30KB (1.26x ⚠️) |
| svelte-mount-min | 29KB (1.33x ⚠️) | 27KB (1.25x ⚠️) |
| svelte deep region count | 34 | 7 (rolldown 5) |
| Deep 벤치 평균 ratio | 3.01x | **0.88x** |
| Deep 벤치 \`smaller\` count | 80 | **115** / 143 |

svelte deep 결과물은 esbuild / rolldown 보다도 작습니다. 5/5 svelte 빌드 baseline 런타임 동작 MATCH.

## 회귀 방지

기존 통과:
- TS-emit minimatch (\`var _self; class Box { static spawn() { return new _self(); } }; _self = Box;\`) — \`tree_shake.zig:4746\`
- reanimated 조건부 ESM-export 할당 (\`if (native) { measure = measureNative; }\`) — \`tree_shake.zig:480\`
- tslib self-reassignment — \`tree_shake.zig:516\`

신규 4개 추가 (\`tree_shake.zig\`):
1. **function-body writer of mutable let does not pull function in** — svelte case 직접 reproducer
2. **top-level writer kept, function-body writer dropped on shared let** — 같은 let 에 둘 다 있는 혼합 케이스
3. **dead function-body writer does not cascade through transitive imports** — multi-module cascade 시나리오
4. **compound/update writers inside function body are not writer-edged** — \`x += 1\` / \`x++\` (read+write flag) 경로

TreeShaking 전체 147 tests 통과. 광역 테스트 회귀 0건 (사전 환경 fixture 누락 25건은 변경 무관 — stash 검증).

## Test plan

- [x] \`zig build test -Dtest-filter=\"TreeShaking\"\` 전부 통과 (147/147)
- [x] \`zig build test\` 전체 — 사전 환경 fixture 실패 (react-native codegen 25건) 외 회귀 없음
- [x] \`bun run tests/benchmark/smoke.ts --filter=svelte --deep\` baseline MATCH 5/5
- [x] \`bun run tests/benchmark/smoke.ts --deep\` 광역 — 평균 0.88x, larger 11개 (mobx / lru-cache 등 별개 이슈)

🤖 Generated with [Claude Code](https://claude.com/claude-code)