### PR TITLE
docs(plugins): JS/NAPI plugin 개발 가이드 + Vue/Svelte SFC 한계 + 네이티브 추후 명시

### DIFF
--- a/documents/src/content/docs/en/guides/migration.md
+++ b/documents/src/content/docs/en/guides/migration.md
@@ -255,7 +255,7 @@ To write native-style plugins, use `setup(build) { build.onLoad(...) }`.
 | `import.meta.url`                    | Supported (ESM standard)                                                                                 |
 | `@vitejs/plugin-react`               | `--jsx=automatic` (automatic runtime built-in)                                                           |
 | `@vitejs/plugin-react` Fast Refresh  | Built-in HMR (React Refresh)                                                                             |
-| `@vitejs/plugin-vue`                 | Not supported                                                                                            |
+| `@vitejs/plugin-vue`                 | Not supported ([details + workarounds](/zntc/en/guides/plugin-recipes/#framework-sfc-vue--svelte--currently-unsupported)) |
 | `@vitejs/plugin-legacy`              | Partial via `--target=es5` etc.                                                                          |
 | CSS Modules (`.module.css`)          | Supported in app mode. Provides default exports and valid named exports                                  |
 | CSS `@import`                        | Built-in Lightning CSS or `--loader:.css=text`                                                           |

--- a/documents/src/content/docs/en/guides/plugin-recipes.md
+++ b/documents/src/content/docs/en/guides/plugin-recipes.md
@@ -404,4 +404,4 @@ Building a minimal `App.vue` + `main.ts` produces:
 - **JS APIs of Vue / Svelte themselves**: runtime imports like `createApp` / `ref` from `vue` and stores from `svelte/store` work — only single-file `.vue` / `.svelte` *compilation* is missing.
 - Once the two surfaces above land in native, the plugins should work as-is. The `vitePlugin()` adapter already accepts vite 4+ hook objects and plugin sourcemap objects.
 
-See [Bundler architecture & internals](/zntc/en/guides/bundler-deep-dive/) → Module Resolution for the underlying differences.
+See [Bundler architecture & internals → Module Resolution](/zntc/en/guides/bundler-deep-dive/#1-module-resolution) for the underlying differences.

--- a/documents/src/content/docs/en/guides/plugin-recipes.md
+++ b/documents/src/content/docs/en/guides/plugin-recipes.md
@@ -364,3 +364,44 @@ export const gitHash = ${JSON.stringify(
 import { buildTime, gitHash } from "virtual:build-info";
 console.log(`Built at ${buildTime} (${gitHash})`);
 ```
+
+## Framework SFC (Vue / Svelte) — currently unsupported
+
+Wrapping official vite plugins like `@vitejs/plugin-vue@6.x` / `@sveltejs/vite-plugin-svelte@7.x` with `vitePlugin()` makes **the plugin hooks themselves run, but the build still does not complete**. ZNTC's native resolver/loader does not yet recognise two surfaces that SFC builds rely on:
+
+1. **Virtual module IDs** — plugin-vue returns IDs like `\0plugin-vue:export-helper`.
+2. **Query-parameter sub-imports** — a single `.vue` file is split during SFC compile into sub-imports such as `App.vue?vue&type=script&setup=true&lang.ts` and `App.vue?vue&type=style&index=0&scoped=...&lang.css`. ZNTC has no logic that reads the `lang.X` query and routes to a different parser/loader.
+
+### What happens today
+
+```typescript
+// zntc.config.ts
+import { defineConfig, vitePlugin } from "@zntc/core";
+import vue from "@vitejs/plugin-vue";
+
+export default defineConfig({
+  entryPoints: ["main.ts"],
+  bundler: true,
+  platform: "browser",
+  loader: { ".vue": "js" }, // the .vue entry itself is fine
+  plugins: [vitePlugin(vue())],
+});
+```
+
+Building a minimal `App.vue` + `main.ts` produces:
+
+```
+✓ Plugin hooks invoked (hook object format / sourcemap object both accepted)
+✗ Cannot resolve module App.vue?vue&type=style&index=0&scoped=...&lang.css
+✗ Expression expected — CSS sub-module went through the JS parser
+✗ TypeScript type annotations are not allowed when parsing as JavaScript
+  — ?vue&type=script&setup=true&lang.ts was treated as JS
+```
+
+### Workarounds (today)
+
+- **Pre-compiled Vue / Svelte components**: if SFCs are compiled in a separate step into plain `.js` + `.css` artifacts, ZNTC handles them as ordinary JS libraries (real benchmarks confirm `vue 1MB` and `svelte` ESM APIs bundle correctly).
+- **JS APIs of Vue / Svelte themselves**: runtime imports like `createApp` / `ref` from `vue` and stores from `svelte/store` work — only single-file `.vue` / `.svelte` *compilation* is missing.
+- Once the two surfaces above land in native, the plugins should work as-is. The `vitePlugin()` adapter already accepts vite 4+ hook objects and plugin sourcemap objects.
+
+See [Bundler architecture & internals](/zntc/en/guides/bundler-deep-dive/) → Module Resolution for the underlying differences.

--- a/documents/src/content/docs/en/guides/plugins.md
+++ b/documents/src/content/docs/en/guides/plugins.md
@@ -30,7 +30,7 @@ ZNTC provides a Rollup/Vite-compatible plugin interface. Plugins are written in 
 | Plugin context `this.error()` / `this.warn()` | Supported | `warn` is prefixed with `@zntc/core [name]:` |
 | Plugin context `this.addWatchFile()` | no-op | Callable but not propagated to the native watcher (SFC `<style src="..."/>` external dep may go stale) |
 | Plugin context `this.resolve()` / `this.emitFile()` | ❌ Unsupported | Throws an informative Error — graph mutation surface is missing |
-| **Framework SFC** (`.vue` / `.svelte`) | ❌ Unsupported | Requires recognising virtual module IDs and `?vue&type=style&lang.css` query sub-imports — tracked separately |
+| **Framework SFC** (`.vue` / `.svelte`) | ❌ Unsupported | Requires recognising virtual module IDs and `?vue&type=style&lang.css` query sub-imports — [details + workarounds →](/zntc/en/guides/plugin-recipes/#framework-sfc-vue--svelte--currently-unsupported) |
 | `buildSync()` + JS plugins | Unsupported | use async `build()` / `watch()` |
 
 The native ZNTC worker calls JS hooks through NAPI threadsafe functions when it reaches a module and waits for the response. Keep hook filters narrow, and prefer the built-in `loader` option for simple extension-based handling.
@@ -102,6 +102,8 @@ const myPlugin = {
 
 ZNTC plugins are **written in JavaScript** and called by the native worker through ZNTC's NAPI binding (no separate compile step). Start with the smallest skeleton and add hooks one at a time.
 
+Pick only the hooks you need — for example, a plugin that just needs **transform** (env replacement, banner injection, JSX rewrite) can skip steps 2 and 3.
+
 ### 1. Empty plugin skeleton
 
 ```typescript
@@ -128,7 +130,7 @@ build.onResolve({ filter: /^virtual:settings$/ }, () => ({
 }));
 ```
 
-The `\0` prefix is an esbuild/Rollup convention for "not a real file" — ZNTC's native resolver will not look this ID up on disk.
+The `\0` prefix is an esbuild/Rollup convention for "not a real file". Because a NUL byte cannot appear in any real filesystem path, ZNTC's native resolver never even attempts an fs lookup — virtual IDs cannot accidentally collide with real files.
 
 ### 3. `load` — synthesize module contents
 

--- a/documents/src/content/docs/en/guides/plugins.md
+++ b/documents/src/content/docs/en/guides/plugins.md
@@ -9,13 +9,28 @@ ZNTC provides a Rollup/Vite-compatible plugin interface. Plugins are written in 
 
 ## Compatibility Summary
 
+### Plugin authoring surfaces
+
+| Surface | Status | Note |
+| ------- | ------ | ---- |
+| **JavaScript (NAPI)** — in-process on Node.js / Bun | ✅ Supported | Most common. Use Rollup/Vite/esbuild plugins directly or via the adapter |
+| **Native Zig** plugin (`*.zig`, statically linked) | ❌ Planned | Skip the NAPI overhead and run in-engine — for frontend/transform hot-path acceleration |
+| **WASM** plugin (`*.wasm`, dynamically loaded) | ❌ Planned | Any language + isolation (Rust / AssemblyScript / Go, …) |
+
+### Plugin hook compatibility
+
 | Surface | Status | Use |
 | ------- | ------ | --- |
 | esbuild-style `setup(build)` | Partial | `build.onResolve`, `build.onLoad`, `build.onTransform`, `build.onResolveContext`, `build.onAstFunction` |
 | Rollup/Vite-style `resolveId` / `load` / `transform` | Supported | `vitePlugin()` wrapper or config plugin |
+| **Vite 4+ hook object** `{ filter, handler }` | Supported | `vitePlugin()` extracts `handler` automatically (`filter` is ignored by native) |
+| **Plugin sourcemap object** (`RawSourceMap`) | Supported | wrapper validates V3 and stringifies; invalid maps are dropped with a one-time warning |
 | output hooks `renderChunk` / `generateBundle` | Partial | chunk post-processing and output-list access |
 | lifecycle `buildStart` / `buildEnd` / `closeBundle` | Supported | called for `build()` and for each initial/rebuild cycle in `watch()` |
-| Rollup context `this.resolve()` / `this.emitFile()` | Unsupported | needs a separate graph mutation surface |
+| Plugin context `this.error()` / `this.warn()` | Supported | `warn` is prefixed with `@zntc/core [name]:` |
+| Plugin context `this.addWatchFile()` | no-op | Callable but not propagated to the native watcher (SFC `<style src="..."/>` external dep may go stale) |
+| Plugin context `this.resolve()` / `this.emitFile()` | ❌ Unsupported | Throws an informative Error — graph mutation surface is missing |
+| **Framework SFC** (`.vue` / `.svelte`) | ❌ Unsupported | Requires recognising virtual module IDs and `?vue&type=style&lang.css` query sub-imports — tracked separately |
 | `buildSync()` + JS plugins | Unsupported | use async `build()` / `watch()` |
 
 The native ZNTC worker calls JS hooks through NAPI threadsafe functions when it reaches a module and waits for the response. Keep hook filters narrow, and prefer the built-in `loader` option for simple extension-based handling.
@@ -82,6 +97,84 @@ const myPlugin = {
   },
 };
 ```
+
+## Authoring a plugin from scratch — 5 steps
+
+ZNTC plugins are **written in JavaScript** and called by the native worker through ZNTC's NAPI binding (no separate compile step). Start with the smallest skeleton and add hooks one at a time.
+
+### 1. Empty plugin skeleton
+
+```typescript
+// my-plugin.ts
+import type { ZntcPlugin } from "@zntc/core";
+
+export function myPlugin(): ZntcPlugin {
+  return {
+    name: "my-plugin",
+    setup(build) {
+      // register hooks here
+    },
+  };
+}
+```
+
+The `name` is exposed verbatim in diagnostics (`Plugin "<name>" failed ...`), so pick something users can recognise.
+
+### 2. `resolveId` — virtual modules and aliases
+
+```typescript
+build.onResolve({ filter: /^virtual:settings$/ }, () => ({
+  path: "\0virtual:settings",
+}));
+```
+
+The `\0` prefix is an esbuild/Rollup convention for "not a real file" — ZNTC's native resolver will not look this ID up on disk.
+
+### 3. `load` — synthesize module contents
+
+```typescript
+build.onLoad({ filter: /^\0virtual:settings$/ }, () => ({
+  contents: `export const apiUrl = ${JSON.stringify(process.env.API_URL ?? "")};`,
+  loader: "ts", // or "js" / "json"
+}));
+```
+
+Specifying `loader` tells the native parser which front-end to use immediately.
+
+### 4. `transform` — modify existing module code
+
+```typescript
+build.onTransform({ filter: /\.tsx?$/ }, (args) => {
+  if (!args.code.includes("__BUILD_TIME__")) return null; // no change
+  return {
+    code: args.code.replace(/__BUILD_TIME__/g, JSON.stringify(new Date().toISOString())),
+  };
+});
+```
+
+Return `null` when nothing changed — ZNTC keeps the original (avoids unnecessary sourcemap regeneration).
+
+### 5. Register and use
+
+```typescript
+// zntc.config.ts
+import { defineConfig } from "@zntc/core";
+import { myPlugin } from "./my-plugin";
+
+export default defineConfig({
+  entryPoints: ["src/index.ts"],
+  outdir: "dist",
+  plugins: [myPlugin()],
+});
+```
+
+The same `plugins: [...]` array works when calling the `build()` API directly.
+
+### Tips — debugging
+
+- Use `console.warn` and prefix messages with your plugin name — `[my-plugin] ...`. Calling `this.warn(msg)` does this automatically (`@zntc/core [name]:`).
+- `transform` / `load` run **once per module**, so avoid heavy synchronous work (e.g. sync file system reads) on the hot path.
+- Throw with `this.error(new Error(...))` — ZNTC prints the plugin name and file location alongside the diagnostic.
 
 ## Config File
 

--- a/documents/src/content/docs/guides/migration.md
+++ b/documents/src/content/docs/guides/migration.md
@@ -255,7 +255,7 @@ export default defineConfig({
 | `import.meta.url`                    | 지원 (ESM 표준)                                                                                        |
 | `@vitejs/plugin-react`               | `--jsx=automatic` (자동 런타임 내장)                                                                   |
 | `@vitejs/plugin-react` Fast Refresh  | HMR 내장 (React Refresh)                                                                               |
-| `@vitejs/plugin-vue`                 | 미지원                                                                                                 |
+| `@vitejs/plugin-vue`                 | 미지원 ([자세히 + 대안](/zntc/guides/plugin-recipes/#프레임워크-sfc-vue--svelte--현재-미지원))          |
 | `@vitejs/plugin-legacy`              | `--target=es5` 등으로 일부 대응                                                                        |
 | CSS Modules (`.module.css`)          | 앱 모드에서 지원. default export와 가능한 named export 제공                                            |
 | CSS `@import`                        | Lightning CSS 내장 후처리 또는 `--loader:.css=text`                                                    |

--- a/documents/src/content/docs/guides/plugin-recipes.md
+++ b/documents/src/content/docs/guides/plugin-recipes.md
@@ -404,4 +404,4 @@ minimal `App.vue` + `main.ts` 빌드 결과:
 - **Vue/Svelte 라이브러리 자체의 JS API 사용**: `vue` 의 `createApp`/`ref` 같은 런타임 import 와 `svelte/store` 같은 라이브러리는 정상 동작 — 단지 `.vue` / `.svelte` 파일 자체의 SFC 컴파일이 미지원.
 - 위 두 surface (virtual module + query sub-import) 가 native 에 추가되면 plugin 그대로 동작할 예정. 현재 wrapper(`vitePlugin()`)는 이미 vite 4+ 신형 hook object 와 plugin sourcemap object 를 모두 받을 수 있다.
 
-자세한 내부 동작 차이는 [번들러 구조와 동작 원리](/zntc/guides/bundler-deep-dive/) 의 "모듈 해석 (Resolver)" 섹션 참조.
+자세한 내부 동작 차이는 [번들러 구조와 동작 원리 → 모듈 해석 (Resolver)](/zntc/guides/bundler-deep-dive/#1-모듈-해석-resolver) 섹션 참조.

--- a/documents/src/content/docs/guides/plugin-recipes.md
+++ b/documents/src/content/docs/guides/plugin-recipes.md
@@ -363,3 +363,45 @@ export const gitHash = ${JSON.stringify(
 import { buildTime, gitHash } from "virtual:build-info";
 console.log(`Built at ${buildTime} (${gitHash})`);
 ```
+
+
+## 프레임워크 SFC (Vue / Svelte) — 현재 미지원
+
+`@vitejs/plugin-vue@6.x` / `@sveltejs/vite-plugin-svelte@7.x` 같은 공식 vite plugin 을 `vitePlugin()` 어댑터로 감싸 적용하면 **plugin hook 자체는 호출되지만 빌드는 완전히 통과하지 못한다**. ZNTC native resolver/loader 가 SFC 가 의존하는 다음 두 surface 를 아직 인식하지 않기 때문이다:
+
+1. **Virtual module ID** — vue plugin 이 `\0plugin-vue:export-helper` 같은 가상 ID 를 반환.
+2. **Query parameter sub-import** — 단일 `.vue` 파일이 SFC compile 후 `App.vue?vue&type=script&setup=true&lang.ts`, `App.vue?vue&type=style&index=0&scoped=...&lang.css` 처럼 query 가 붙은 sub-import 로 쪼개짐. ZNTC 는 query 의 `lang.X` 를 보고 parser/loader 를 분기시키는 로직이 없다.
+
+### 현재 시도 시 동작
+
+```typescript
+// zntc.config.ts
+import { defineConfig, vitePlugin } from "@zntc/core";
+import vue from "@vitejs/plugin-vue";
+
+export default defineConfig({
+  entryPoints: ["main.ts"],
+  bundler: true,
+  platform: "browser",
+  loader: { ".vue": "js" }, // .vue 진입 자체는 통과
+  plugins: [vitePlugin(vue())],
+});
+```
+
+minimal `App.vue` + `main.ts` 빌드 결과:
+
+```
+✓ Plugin hook 호출 성공 (hook object format / sourcemap object 지원됨)
+✗ Cannot resolve module App.vue?vue&type=style&index=0&scoped=...&lang.css
+✗ Expression expected — CSS sub-module 을 JS 파서가 처리
+✗ TypeScript type annotations are not allowed when parsing as JavaScript
+  — ?vue&type=script&setup=true&lang.ts 가 JS 로 처리됨
+```
+
+### 대안 (현재 시점)
+
+- **컴파일된 Vue / Svelte 컴포넌트만 사용**: SFC 가 빌드 시점이 아닌 *별도 단계* 에서 미리 컴파일된 `.js` + `.css` 산출물로 바뀌어 있으면 ZNTC 는 일반 JS 라이브러리로 처리 가능 (실제 벤치 결과 `vue 1MB`, `svelte` ESM API 빌드 정상 동작).
+- **Vue/Svelte 라이브러리 자체의 JS API 사용**: `vue` 의 `createApp`/`ref` 같은 런타임 import 와 `svelte/store` 같은 라이브러리는 정상 동작 — 단지 `.vue` / `.svelte` 파일 자체의 SFC 컴파일이 미지원.
+- 위 두 surface (virtual module + query sub-import) 가 native 에 추가되면 plugin 그대로 동작할 예정. 현재 wrapper(`vitePlugin()`)는 이미 vite 4+ 신형 hook object 와 plugin sourcemap object 를 모두 받을 수 있다.
+
+자세한 내부 동작 차이는 [번들러 구조와 동작 원리](/zntc/guides/bundler-deep-dive/) 의 "모듈 해석 (Resolver)" 섹션 참조.

--- a/documents/src/content/docs/guides/plugins.md
+++ b/documents/src/content/docs/guides/plugins.md
@@ -9,13 +9,28 @@ ZNTC 플러그인은 Rollup/Vite 호환 인터페이스로, `@zntc/core`의 NAPI
 
 ## 호환성 요약
 
+### 플러그인 작성 surface
+
+| Surface | 상태 | 비고 |
+| ------- | ---- | --- |
+| **JavaScript (NAPI)** — Node.js / Bun in-process | ✅ 지원 | 가장 일반적. Rollup/Vite/esbuild plugin 그대로 또는 어댑터 경유 |
+| **네이티브 Zig** plugin (`*.zig` → 정적 링크) | ❌ 추후 지원 예정 | NAPI overhead 없이 in-engine 호출 — frontend/transform 핫패스 가속용 |
+| **WASM** plugin (`*.wasm` 동적 로드) | ❌ 추후 지원 예정 | 언어 자유 + 격리 (Rust / AssemblyScript / Go 등) |
+
+### Plugin hook 호환성
+
 | Surface | 상태 | 사용 경로 |
 | ------- | ---- | -------- |
 | esbuild-style `setup(build)` | 부분 지원 | `build.onResolve`, `build.onLoad`, `build.onTransform`, `build.onResolveContext`, `build.onAstFunction` |
 | Rollup/Vite-style `resolveId` / `load` / `transform` | 지원 | `vitePlugin()` wrapper 또는 config plugin |
+| **Vite 4+ hook object** `{ filter, handler }` | 지원 | `vitePlugin()` 가 `handler` 자동 추출 (`filter` 는 native 가 무시) |
+| **Plugin sourcemap object** (`RawSourceMap`) | 지원 | wrapper 가 V3 검증 + stringify. invalid 시 drop + warn |
 | output hook `renderChunk` / `generateBundle` | 부분 지원 | chunk 후처리, output 목록 접근 |
 | lifecycle `buildStart` / `buildEnd` / `closeBundle` | 지원 | `build()`와 `watch()` 초기 build/rebuild마다 호출 |
-| Rollup context `this.resolve()` / `this.emitFile()` | 미지원 | graph mutation이 필요한 별도 surface |
+| Plugin context `this.error()` / `this.warn()` | 지원 | `warn` 은 `@zntc/core [name]:` prefix |
+| Plugin context `this.addWatchFile()` | no-op | 호출 가능하지만 native watcher 에 전파 X (SFC `<style src="..."/>` 외부 dep stale 가능) |
+| Plugin context `this.resolve()` / `this.emitFile()` | ❌ 미지원 | 호출 시 informative Error throw — graph mutation surface 부재 |
+| **프레임워크 SFC** (`.vue` / `.svelte`) | ❌ 미지원 | virtual module ID + `?vue&type=style&lang.css` query sub-import 인식 필요 — 별도 follow-up |
 | `buildSync()` + JS plugin | 미지원 | async `build()` / `watch()` 사용 |
 
 ZNTC native worker는 module을 만날 때 NAPI threadsafe function으로 JS hook을 호출하고 응답을 기다립니다. 따라서 hook filter를 좁게 잡고, 단순 확장자 처리는 `loader` 옵션을 먼저 쓰는 편이 빠릅니다.
@@ -82,6 +97,84 @@ const myPlugin = {
   },
 };
 ```
+
+## 처음부터 만들기 — 5 단계
+
+ZNTC 플러그인은 **JavaScript 로 작성**하고, ZNTC 의 NAPI 바인딩이 native worker 에서 호출합니다 (별도 컴파일 단계 없음). 가장 단순한 형태부터 출발해 hook 을 하나씩 더해가는 방식이 안전합니다.
+
+### 1. 빈 plugin 스켈레톤
+
+```typescript
+// my-plugin.ts
+import type { ZntcPlugin } from "@zntc/core";
+
+export function myPlugin(): ZntcPlugin {
+  return {
+    name: "my-plugin",
+    setup(build) {
+      // 여기에 hook 을 등록
+    },
+  };
+}
+```
+
+`name` 은 진단 메시지(`Plugin "<name>" failed ...`) 에 그대로 노출되므로 사용자가 식별 가능한 형태로 짓습니다.
+
+### 2. `resolveId` — 가상 모듈 / 별칭 처리
+
+```typescript
+build.onResolve({ filter: /^virtual:settings$/ }, () => ({
+  path: "\0virtual:settings",
+}));
+```
+
+`\0` prefix 는 esbuild/Rollup 관례로 "실제 파일이 아닌 가상 ID" 를 의미합니다. ZNTC 의 native resolver 가 해당 ID 를 디스크에서 찾지 않습니다.
+
+### 3. `load` — 모듈 본문 만들기
+
+```typescript
+build.onLoad({ filter: /^\0virtual:settings$/ }, () => ({
+  contents: `export const apiUrl = ${JSON.stringify(process.env.API_URL ?? "")};`,
+  loader: "ts", // 또는 "js" / "json"
+}));
+```
+
+`loader` 를 지정해두면 native 가 어떤 parser 로 파싱할지 즉시 알 수 있습니다.
+
+### 4. `transform` — 기존 모듈 코드 변환
+
+```typescript
+build.onTransform({ filter: /\.tsx?$/ }, (args) => {
+  if (!args.code.includes("__BUILD_TIME__")) return null; // 변경 없음
+  return {
+    code: args.code.replace(/__BUILD_TIME__/g, JSON.stringify(new Date().toISOString())),
+  };
+});
+```
+
+변경이 없으면 `null` 을 반환하세요 — ZNTC 가 원본을 그대로 사용합니다 (불필요한 sourcemap 재생성 회피).
+
+### 5. 등록 + 사용
+
+```typescript
+// zntc.config.ts
+import { defineConfig } from "@zntc/core";
+import { myPlugin } from "./my-plugin";
+
+export default defineConfig({
+  entryPoints: ["src/index.ts"],
+  outdir: "dist",
+  plugins: [myPlugin()],
+});
+```
+
+`build()` API 로 직접 호출 시에도 동일한 `plugins: [...]` 배열을 넘기면 됩니다.
+
+### Tip — 디버깅
+
+- `console.warn` 으로 출력하되, 메시지에 plugin 이름 prefix 를 넣으세요 — `[my-plugin] ...` 처럼. `this.warn(msg)` 를 쓰면 `@zntc/core [name]:` 가 자동으로 붙습니다.
+- transform/load 가 **모듈마다 한 번씩** 호출되므로 hot-path 에서 동기 큰 작업(파일 시스템 동기 읽기 등) 은 피하세요.
+- 에러는 `this.error(new Error(...))` 로 throw 하면 ZNTC 가 plugin 이름 + 파일 위치를 진단에 같이 출력합니다.
 
 ## NAPI 플러그인
 

--- a/documents/src/content/docs/guides/plugins.md
+++ b/documents/src/content/docs/guides/plugins.md
@@ -30,7 +30,7 @@ ZNTC 플러그인은 Rollup/Vite 호환 인터페이스로, `@zntc/core`의 NAPI
 | Plugin context `this.error()` / `this.warn()` | 지원 | `warn` 은 `@zntc/core [name]:` prefix |
 | Plugin context `this.addWatchFile()` | no-op | 호출 가능하지만 native watcher 에 전파 X (SFC `<style src="..."/>` 외부 dep stale 가능) |
 | Plugin context `this.resolve()` / `this.emitFile()` | ❌ 미지원 | 호출 시 informative Error throw — graph mutation surface 부재 |
-| **프레임워크 SFC** (`.vue` / `.svelte`) | ❌ 미지원 | virtual module ID + `?vue&type=style&lang.css` query sub-import 인식 필요 — 별도 follow-up |
+| **프레임워크 SFC** (`.vue` / `.svelte`) | ❌ 미지원 | virtual module ID + `?vue&type=style&lang.css` query sub-import 인식 필요 — [자세히 + 대안 →](/zntc/guides/plugin-recipes/#프레임워크-sfc-vue--svelte--현재-미지원) |
 | `buildSync()` + JS plugin | 미지원 | async `build()` / `watch()` 사용 |
 
 ZNTC native worker는 module을 만날 때 NAPI threadsafe function으로 JS hook을 호출하고 응답을 기다립니다. 따라서 hook filter를 좁게 잡고, 단순 확장자 처리는 `loader` 옵션을 먼저 쓰는 편이 빠릅니다.
@@ -102,6 +102,8 @@ const myPlugin = {
 
 ZNTC 플러그인은 **JavaScript 로 작성**하고, ZNTC 의 NAPI 바인딩이 native worker 에서 호출합니다 (별도 컴파일 단계 없음). 가장 단순한 형태부터 출발해 hook 을 하나씩 더해가는 방식이 안전합니다.
 
+필요한 hook 만 골라 쓰면 됩니다 — 예: ENV 치환 / banner 주입 / JSX 변환처럼 **transform 만 필요한** 플러그인은 2·3 단계를 건너뛰어도 동작합니다.
+
 ### 1. 빈 plugin 스켈레톤
 
 ```typescript
@@ -128,7 +130,7 @@ build.onResolve({ filter: /^virtual:settings$/ }, () => ({
 }));
 ```
 
-`\0` prefix 는 esbuild/Rollup 관례로 "실제 파일이 아닌 가상 ID" 를 의미합니다. ZNTC 의 native resolver 가 해당 ID 를 디스크에서 찾지 않습니다.
+`\0` prefix 는 esbuild/Rollup 관례로 "실제 파일이 아닌 가상 ID" 를 의미합니다. NUL byte 는 어떤 파일 시스템 경로에도 등장할 수 없기에 ZNTC 의 native resolver 가 fs lookup 자체를 시도하지 않습니다 — 가상 ID 가 우연히 진짜 파일과 충돌할 위험이 없습니다.
 
 ### 3. `load` — 모듈 본문 만들기
 


### PR DESCRIPTION
## Summary

PR #3017 (vitePlugin wrapper hook object + sourcemap object 호환) 머지 후, 그 변경을 docs 에 반영하고 사용자가 자주 묻는 두 질문에 정직하게 답하도록 가이드 정비.

1. "어떤 형태로 plugin 을 작성할 수 있나?" — JS/NAPI 만 현재 지원, 네이티브 Zig / WASM 은 **추후**
2. "Vue / Svelte SFC 도 빌드되나?" — 직접 실측해본 결과 + 어디서 막히는지 + 현재 대안

## plugins.md (한/영)

### Authoring surface 표 신설

| Surface | 상태 | 비고 |
|---|---|---|
| **JavaScript (NAPI)** | ✅ 지원 | Rollup/Vite/esbuild plugin 그대로 또는 어댑터 |
| **네이티브 Zig** plugin | ❌ 추후 | NAPI overhead 없이 in-engine |
| **WASM** plugin | ❌ 추후 | 언어 자유 + 격리 |

### Hook 호환성 표 갱신 (PR #3017 반영)

- vite 4+ hook object `{ filter, handler }` — 지원
- Plugin sourcemap object (`RawSourceMap`) — 지원 (V3 검증 + stringify)
- `this.warn()` — 지원 (`@zntc/core [name]:` prefix)
- `this.addWatchFile()` — no-op (SFC `<style src=...>` stale 위험 명시)
- `this.resolve()` / `this.emitFile()` — informative throw
- `.vue` / `.svelte` SFC — ❌ 미지원, follow-up

### "처음부터 만들기 — 5 단계" 신규 섹션

빈 스켈레톤 → resolveId → load → transform → 등록. 디버깅 tip (`this.warn` / hot-path / `this.error`) 포함.

## plugin-recipes.md (한/영)

### Vue / Svelte SFC 한계 섹션

직접 `@vitejs/plugin-vue@6.x` / `@sveltejs/vite-plugin-svelte@7.x` 를 적용해보고 어디서 막히는지 정직하게:

```
✓ plugin hook 자체는 호출됨 (PR #3017 wrapper 효과)
✗ Cannot resolve module App.vue?vue&type=style&...&lang.css
✗ CSS sub-module 이 JS 파서로 처리 (Expression expected)
✗ ?vue&type=script&setup=true&lang.ts 가 JS 로 처리 (TS reject)
```

원인 두 가지(virtual module ID + query sub-import) 명시 + 현재 대안:
- SFC pre-compile 후 `.js` + `.css` 산출물로 빌드
- Vue/Svelte 라이브러리 JS API (`createApp` / `svelte/store`) 는 정상

## Test plan

- [ ] `documents/` 에서 `bun run dev` 후
  - [ ] `/zntc/guides/plugins/` 페이지에 새 호환성 표 2개 + "처음부터 만들기 — 5 단계" 섹션이 보이는지
  - [ ] `/zntc/guides/plugin-recipes/` 페이지 끝에 "프레임워크 SFC (Vue / Svelte) — 현재 미지원" 섹션이 보이는지
- [ ] `/zntc/en/guides/plugins/` + `/zntc/en/guides/plugin-recipes/` 영어 페이지도 동일 검증
- [ ] CI docs build 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)