### PR TITLE
fix(bundler): plugin load loader fallback + types/schema test 회귀 (#3024)

### DIFF
--- a/packages/core/bin/zntc-cli-schema-sync.test.ts
+++ b/packages/core/bin/zntc-cli-schema-sync.test.ts
@@ -407,6 +407,9 @@ describe('CLI flag ↔ BuildOptions / TranspileOptions schema sync', () => {
     // CLI 가 enum→boolean 변환 (`--charset=utf8` → charsetUtf8: true)
     'charsetUtf8',
     'analyze', // CLI 가 boolean flag, BuildOptions 는 boolean — 매칭되지만 alias 처리 누락 가능
+    // React Refresh 관련 opt-in — `reactRefresh` 자체가 config-only (CLI flag 없음).
+    // hook signature emit (babel/SWC 동등) 도 config 에서만 켠다.
+    'reactRefreshHookSignatures',
   ]);
 
   test('CLI flag 가 BuildOptions / TranspileOptions 키와 매칭되거나 cliOnlyFlags 에 등록', () => {

--- a/packages/core/types.test.ts
+++ b/packages/core/types.test.ts
@@ -78,7 +78,16 @@ describe('@zntc/core TypeScript declaration', () => {
   test('exports.types 역시 실제 파일을 가리킴', () => {
     const pkgPath = join(import.meta.dir, 'package.json');
     const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
-    const typesPath = join(import.meta.dir, pkg.exports['.'].types);
-    expect(existsSync(typesPath)).toBe(true);
+    // conditional exports 형식 (`exports['.'].import.types` / `.require.types`) 와 top-level
+    // `exports['.'].types` 양쪽 모두 인식. 각 조건의 `types` 파일이 실제로 존재해야 한다.
+    const exportEntry = pkg.exports['.'];
+    const candidates: string[] = [];
+    if (typeof exportEntry.types === 'string') candidates.push(exportEntry.types);
+    if (typeof exportEntry.import?.types === 'string') candidates.push(exportEntry.import.types);
+    if (typeof exportEntry.require?.types === 'string') candidates.push(exportEntry.require.types);
+    expect(candidates.length).toBeGreaterThan(0);
+    for (const rel of candidates) {
+      expect(existsSync(join(import.meta.dir, rel))).toBe(true);
+    }
   });
 });

--- a/src/bundler/graph/plugins.zig
+++ b/src/bundler/graph/plugins.zig
@@ -141,25 +141,22 @@ pub fn runLoadForModule(self: anytype, module: *Module, runner: ?plugin_mod.Plug
             // 여기서 값 표현식으로 낮출 수 없는 loader는 JS 파이프라인으로 계속 진행한다.
             module.source = plugin_result.contents;
         } else {
-            // plugin 이 loader override 안 했을 때 세 가지 케이스 (#3022):
-            // - 확장자 없는 가상 모듈 (`.none`, e.g. runtime helper `\0zntc:runtime/...`):
-            //   `.javascript` + `.js` 강제 — 기존 동작 유지.
-            // - `.javascript` loader 이지만 module_type 이 `.ts` / `.tsx` (SFC `?...&lang.ts`):
-            //   addModule 에서 결정한 module_type 유지. 여기서 `.js` 로 덮어쓰면 TS
-            //   문법이 JS 파서로 가서 "type annotations are not allowed" syntax error.
-            // - 이외 (`.css` / `.json` 등 명시적 non-JS loader 또는 module_type 도 `.js` 인
-            //   순수 JS): 그대로 둠.
-            switch (module.loader) {
-                .none => {
-                    module.loader = .javascript;
-                    module.module_type = .js;
-                },
-                .javascript => {
-                    if (module.module_type != .ts and module.module_type != .tsx) {
-                        module.module_type = .js;
-                    }
-                },
-                else => {},
+            // plugin contract: load 가 loader 명시 안 하면 contents 는 JS 로 가정.
+            // 기본은 `.javascript` + `.js` 로 강제 (esbuild / rolldown 동일 — #3024 회귀
+            // 해소). 다만 plugin 가상 ID (NUL prefix 또는 query 포함) 의 경우 addModule
+            // 의 `loaderExtensionFor` 가 이미 SFC sub-import 의 `lang.X` query 로
+            // `.css/.ts` 등을 결정해뒀고, 그게 plugin 이 반환한 실제 컨텐츠 확장자다 — 그
+            // 때만 module 의 loader/module_type 을 유지한다 (#3022). `isPluginVirtualId`
+            // 는 같은 파일의 single source of truth.
+            const is_virtual_id = isPluginVirtualId(module.path);
+            const has_explicit_non_js_loader = module.loader != .javascript and module.loader != .none;
+            const is_typescript_module_type = module.module_type == .ts or module.module_type == .tsx;
+            const keep_module_typing = is_virtual_id and
+                (has_explicit_non_js_loader or
+                    (module.loader == .javascript and is_typescript_module_type));
+            if (!keep_module_typing) {
+                module.loader = .javascript;
+                module.module_type = .js;
             }
             module.source = plugin_result.contents;
         }


### PR DESCRIPTION
## Summary

PR #3023 머지 후 main CI 가 3 갈래로 깨졌다 — 모두 한 PR 으로 해소.

## 1. plugin load loader fallback contract 복원 (메인 fix)

`graph/plugins.zig` 의 plugin load 결과 처리 분기가 esbuild/rolldown contract 를 깼음:
- plugin load 가 loader 명시 안 하면 → 기존: `.javascript` + `.js` 강제 (JS 가정)
- PR #3023: `.css` / `.typescript` 등 명시 loader 유지 → 일반 CSS plugin 패턴 깨짐

```ts
// 깨진 케이스
build.onResolve({ filter: /\.css$/ }, ({ path }) => ({ path }));
build.onLoad({ filter: /\.css$/ }, () => ({ contents: 'export default "red"' }));
// → addModule loader=.css → plugin load 반환 (loader 없음) → CSS parser 가 JS code 처리 → fail
```

기본은 `.javascript` + `.js` 강제로 되돌리고, **SFC sub-import 만 예외**: `module.path` 에 `?` 포함된 가상 specifier (vue/svelte 의 `?vue&type=style&lang.css` 또는 `?...&lang.ts`) 만 module.loader / module_type 유지.

## 2. `types.test.ts` 의 conditional exports 인식

`pkg.exports['.'].types` 가 conditional exports 형식 (`exports['.'].import.types` + `.require.types`) 에서는 top-level 에 없어 `undefined` 반환 → `join()` TypeError. test 가 nested types + top-level 양쪽 인식하도록 보강. 각 후보 파일이 build:dts 산출물로 실제 존재하는지 검증.

## 3. `reactRefreshHookSignatures` 를 `buildOptionsOnlyKeys` allowlist 에

`reactRefresh` 자체가 CLI flag 없는 config-only 옵션. hook signature emit (babel/SWC 동등) 도 같은 위치라 schema sync test 의 allowlist 에 추가.

## 검증

- `zig build test`: 통과
- `bun run --cwd packages/core test`: **900 pass / 0 fail** (이전 10 plugin fail + 2 unrelated fail 모두 해소)

## 회귀 영향

PR #3023 의 vue/svelte SFC fix 는 그대로 보존 — `?vue&type=style&lang.css` 같은 SFC sub-import 만 module.loader 유지하는 조건부 분기로 좁힘.

## Test plan

- [ ] CI `Integration & E2E` 통과
- [ ] CI `Test262 Conformance` 통과 (회귀 없음 확인)
- [ ] CI NAPI Build & Test 통과 (이전 10 plugin fail 해소 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)