### PR TITLE
docs(site): 로드맵 + Electron 가이드 페이지 추가

### DIFF
--- a/documents/astro.config.mjs
+++ b/documents/astro.config.mjs
@@ -132,6 +132,7 @@ export default defineConfig({
           translations: { en: "Recipes" },
           items: [
             { label: "Dev Server (SSE/MCP)", slug: "guides/dev-server" },
+            { label: "Electron", slug: "guides/electron" },
           ],
         },
         {
@@ -144,6 +145,7 @@ export default defineConfig({
             { label: "옵션 매트릭스", slug: "reference/options-matrix", translations: { en: "Options Matrix" } },
             { label: "벤치마크", slug: "reference/benchmarks", translations: { en: "Benchmarks" } },
             { label: "Metafile 분석", link: "/analyze/", translations: { en: "Metafile Analyze" } },
+            { label: "로드맵", slug: "roadmap", translations: { en: "Roadmap" } },
             {
               label: "에러 코드",
               translations: { en: "Error Codes" },

--- a/documents/src/content/docs/en/guides/electron.md
+++ b/documents/src/content/docs/en/guides/electron.md
@@ -1,0 +1,113 @@
+---
+title: Electron
+description: Build and develop Electron apps using ZNTC's dev server and CLI alone.
+---
+
+ZNTC ships no Electron-specific integration. Like webpack / rspack, you bundle **main · preload · renderer** as three separate entries with ZNTC and wire them together via npm scripts. The renderer is served by ZNTC's own dev server, so no extra plugin is needed.
+
+## Project layout
+
+```text
+my-electron-app/
+├── src/
+│   ├── main.ts            # Electron main process
+│   ├── preload.ts         # contextBridge preload
+│   └── renderer/
+│       ├── index.html
+│       └── app.tsx
+├── dist/                  # build output
+└── package.json
+```
+
+## main · preload (Node · CJS)
+
+Keep `electron` and Node built-ins external; emit as CommonJS.
+
+```jsonc
+{
+  "scripts": {
+    "build:main": "zntc --bundle src/main.ts --platform=node --format=cjs --packages=external -o dist/main.cjs",
+    "build:preload": "zntc --bundle src/preload.ts --platform=node --format=cjs --packages=external -o dist/preload.cjs"
+  }
+}
+```
+
+- `--packages=external`: keeps every bare import (`electron`, Node built-ins, `electron-store`, …) external; Electron `require`s them at runtime.
+- `--format=cjs`: CJS is the most compatible format for the Electron main process. (Use `--format=esm` if you target Electron 28+ ESM main.)
+
+## renderer (browser · dev server)
+
+The renderer is a plain SPA. Serve it with ZNTC's dev server and have the main process point `BrowserWindow` at it.
+
+```jsonc
+{
+  "scripts": {
+    "dev:renderer": "zntc dev src/renderer",
+    "build:renderer": "zntc build src/renderer"
+  }
+}
+```
+
+```ts
+// src/main.ts
+import { app, BrowserWindow } from "electron";
+import { join } from "node:path";
+
+const isDev = process.env.NODE_ENV === "development";
+
+app.whenReady().then(() => {
+  const win = new BrowserWindow({
+    webPreferences: { preload: join(__dirname, "preload.cjs") },
+  });
+
+  if (isDev) {
+    win.loadURL("http://localhost:12300");
+  } else {
+    win.loadFile(join(__dirname, "renderer/index.html"));
+  }
+});
+```
+
+## Dev / prod scripts
+
+Watch · restart · concurrent execution is wired with standard tooling (`npm-run-all`, `wait-on`, `nodemon`) — the same pattern as webpack/rspack's Electron guides.
+
+```jsonc
+{
+  "scripts": {
+    "dev:renderer": "zntc dev src/renderer",
+    "dev:main": "zntc --bundle src/main.ts --platform=node --format=cjs --packages=external --watch -o dist/main.cjs",
+    "dev:preload": "zntc --bundle src/preload.ts --platform=node --format=cjs --packages=external --watch -o dist/preload.cjs",
+    "dev:electron": "wait-on tcp:12300 && nodemon --watch dist/main.cjs --watch dist/preload.cjs --exec electron dist/main.cjs",
+    "dev": "npm-run-all -p dev:renderer dev:main dev:preload dev:electron",
+
+    "build:main": "zntc --bundle src/main.ts --platform=node --format=cjs --packages=external -o dist/main.cjs",
+    "build:preload": "zntc --bundle src/preload.ts --platform=node --format=cjs --packages=external -o dist/preload.cjs",
+    "build:renderer": "zntc build src/renderer",
+    "build": "npm-run-all build:main build:preload build:renderer",
+
+    "package": "electron-builder"
+  }
+}
+```
+
+Renderer HMR is handled by ZNTC's dev server (see [Dev Server](/zntc/en/guides/dev-server/)). When the main / preload bundles rebuild, `nodemon` restarts the Electron process.
+
+## Packaging
+
+Use `electron-builder` or `electron-forge`'s generic mode as-is — ZNTC's output is plain Node CJS / browser bundles, with no extra transform step required.
+
+```jsonc
+// package.json — electron-builder example
+{
+  "build": {
+    "appId": "com.example.app",
+    "files": ["dist/**/*", "package.json"]
+  }
+}
+```
+
+## Notes
+
+- ZNTC itself does not auto-restart Electron when the main process rebuilds — the `nodemon` script above plays that role.
+- IPC type sync, `autoUpdater`, and other Electron ecosystem tools work independently of ZNTC.

--- a/documents/src/content/docs/en/roadmap.md
+++ b/documents/src/content/docs/en/roadmap.md
@@ -1,0 +1,121 @@
+---
+title: Roadmap
+description: Planned features and current limitations of ZNTC, from a user perspective.
+---
+
+This page covers only features as you encounter them. Internal phases, progress percentages, and implementation details live in the GitHub repository.
+
+## Planned
+
+### Bundler
+
+#### Public WASM AST API
+
+Expose the ZNTC AST as a WASM module so it can be consumed outside Node and the browser. The WASM build that today powers the Playground and Metafile Analyze pages will be stabilized and published as a user-facing API. Depends on AST schema stabilization.
+
+#### External Zig plugins
+
+Zig plugins currently exist only for built-in transforms (worklet, Fast Refresh). User-authored Zig modules will be loadable as plugins, statically linked at build time and called in-process. No JS↔native serialization overhead, but the Zig compiler must be available at build time.
+
+#### Per-chunk CSS splitting
+
+`import './style.css'` auto-emit, `@import` inlining, and Lightning CSS minification already work. Splitting CSS per output chunk during code-splitting is deferred. (`.module.css` class-name hashing / scoping is already built in for app mode — see [Plugin Recipes / CSS Modules](/zntc/en/guides/plugin-recipes/#css-modules).)
+
+#### Refined dead-code elimination (innerGraph)
+
+Straight-line dead stores on local variables are eliminated. Dead-store analysis across `if` / `for` / `try` control flow is in progress.
+
+#### lazyBarrel refinement
+
+Barrel re-exports (`export * from`, `export { X } from`, `import * as X; export { X }`) skip compilation for pure / local / namespace patterns. Wrapper barrels that mutate imported bindings (e.g. lodash-es's `lodash.default.js`) currently disable lazy mode entirely as a conservative fallback. Refining this to apply lazy mode to non-mutating parts only is pending. See [Tree-shaking](/zntc/en/guides/tree-shaking/) for current limits.
+
+#### mangleProps
+
+Cross-module property mangling, esbuild-style. Not implemented yet.
+
+#### Improved module concatenation
+
+Scope-hoisting at the level of rspack / rolldown.
+
+#### Persistent disk cache
+
+Only an in-memory parse cache + resolve cache lives across rebuilds within a watch / serve session. A persistent on-disk cache to speed up cold rebuilds is on the backlog.
+
+#### Module Federation
+
+Microfrontend code / asset sharing, comparable to rspack. Not implemented yet.
+
+#### Lazy compilation
+
+On-demand module compilation for faster dev startup. Not implemented yet.
+
+### Transpiler
+
+#### `.d.ts` emission (isolatedDeclarations)
+
+Currently delegated to `tsc`. Native isolatedDeclarations-based emission is planned.
+
+### Dev server
+
+#### Converging to a single Zig dev server
+
+Two dev servers coexist today:
+
+- **Zig native** (`zntc serve` / `zntc dev`) — standalone, no Node required.
+- **JS** (`zntc dev <root>` app mode) — used to delegate to JS-ecosystem plugins (postcss / sass).
+
+The long-term goal is to vendor BoringSSL, abstract the plugin host, and converge on the Zig server (similar to Bun's model). This sits behind the stability / CSS / ecosystem milestones.
+
+### Ecosystem
+
+#### Plugin examples
+
+Reference plugins for common cases: PostCSS, Tailwind, SVG, YAML.
+
+#### Migration guides
+
+Expand the esbuild → ZNTC and Vite → ZNTC mapping tables. Some material already lives under [Migration](/zntc/en/guides/migration/).
+
+#### Framework integration (Next.js · Remix · SvelteKit · Expo)
+
+Each of these ships its own bundler tightly coupled to the framework, so an adapter ends up being a partial reimplementation of the framework's compiler. This is the last milestone.
+
+- **Expo**: A meta-framework on top of React Native. Plain React Native apps already build via `--platform=react-native`, but integrating with Expo Router's filesystem-routing manifest, the `expo prebuild` step, and the EAS build pipeline requires a dedicated adapter.
+
+#### Vite-compatible mode
+
+Read `vite.config.js` directly for zero-cost migration. Long-term goal.
+
+## Current limitations
+
+### Cannot build Next.js / Remix directly
+
+These frameworks bake the bundler into the framework itself — RSC payload serialization, filesystem-routing manifests, loader/action server-client separation. A general-purpose bundler cannot stand in for them. Plain React / Vue / Svelte SPAs and React Native (Metro-compatible output) are supported.
+
+### `.module.css` auto-transform in core `--bundle` mode
+
+App mode (`zntc dev` / `zntc build`) supports `.module.css` class-name hashing / scoping out of the box — see [Plugin Recipes / CSS Modules](/zntc/en/guides/plugin-recipes/#css-modules). Core `--bundle` mode does not auto-transform `.module.css`; go through the Vite adapter or a user plugin (PostCSS Modules / Lightning CSS Modules) instead.
+
+### Per-chunk CSS splitting
+
+CSS is emitted as a single artifact even when JS is code-split. Per-chunk CSS is deferred.
+
+### Persistent disk cache · Module Federation · Lazy compilation · mangleProps
+
+See the corresponding "Planned" items.
+
+### Control-flow-aware dead stores
+
+Dead assignments inside `if` / `for` / `try` may be preserved. Only straight-line dead stores are eliminated today.
+
+### Wrapper-barrel mutation pattern
+
+When a barrel module mutates an imported binding (some libraries do this — e.g. lodash-es), the lazy-barrel optimization is disabled wholesale for that module. Correctness is preserved, but the bundle can be larger than necessary.
+
+### Large `tsconfig` `paths` (hundreds of entries)
+
+Only the first resolve walks the array linearly; subsequent resolves hit the resolver cache. No measurable impact at normal project sizes.
+
+### Public WASM API
+
+Limited to internal use by the Playground and Metafile Analyze pages. There is no stabilized public API for users to `import` directly yet (see the "Planned" entry above).

--- a/documents/src/content/docs/guides/electron.md
+++ b/documents/src/content/docs/guides/electron.md
@@ -1,0 +1,113 @@
+---
+title: Electron
+description: ZNTC 의 dev server 와 CLI 만으로 Electron 앱을 빌드하고 개발하는 예제입니다.
+---
+
+ZNTC 는 Electron 전용 통합을 제공하지 않습니다. webpack / rspack 과 동일하게 **main · preload · renderer 세 진입점을 각각 ZNTC 로 빌드하고 npm script 로 묶는 방식** 입니다. renderer 는 ZNTC 자체 dev server 를 그대로 사용하므로 별도 플러그인이 필요 없습니다.
+
+## 프로젝트 구조
+
+```text
+my-electron-app/
+├── src/
+│   ├── main.ts            # Electron main process
+│   ├── preload.ts         # contextBridge preload
+│   └── renderer/
+│       ├── index.html
+│       └── app.tsx
+├── dist/                  # 빌드 산출물
+└── package.json
+```
+
+## main · preload (Node · CJS)
+
+`electron` 모듈과 Node 내장 모듈은 external 로 두고, CommonJS 로 emit 합니다.
+
+```jsonc
+{
+  "scripts": {
+    "build:main": "zntc --bundle src/main.ts --platform=node --format=cjs --packages=external -o dist/main.cjs",
+    "build:preload": "zntc --bundle src/preload.ts --platform=node --format=cjs --packages=external -o dist/preload.cjs"
+  }
+}
+```
+
+- `--packages=external`: `electron`, Node builtin, `electron-store` 같은 bare import 를 전부 external 로 유지합니다. 런타임에서 Electron 이 직접 require.
+- `--format=cjs`: Electron main 은 CJS 가 가장 호환성이 높습니다. (Electron 28+ 의 ESM main 을 쓰시려면 `--format=esm`.)
+
+## renderer (browser · dev server)
+
+renderer 는 일반 SPA 와 동일합니다. ZNTC dev server 로 띄우고, main 의 `BrowserWindow` 가 dev 서버 URL 을 로드합니다.
+
+```jsonc
+{
+  "scripts": {
+    "dev:renderer": "zntc dev src/renderer",
+    "build:renderer": "zntc build src/renderer"
+  }
+}
+```
+
+```ts
+// src/main.ts
+import { app, BrowserWindow } from "electron";
+import { join } from "node:path";
+
+const isDev = process.env.NODE_ENV === "development";
+
+app.whenReady().then(() => {
+  const win = new BrowserWindow({
+    webPreferences: { preload: join(__dirname, "preload.cjs") },
+  });
+
+  if (isDev) {
+    win.loadURL("http://localhost:12300");
+  } else {
+    win.loadFile(join(__dirname, "renderer/index.html"));
+  }
+});
+```
+
+## 개발 / 프로덕션 스크립트
+
+watch · 재시작 · 동시 실행은 webpack/rspack 의 Electron 가이드와 동일하게 `npm-run-all`, `wait-on`, `nodemon` 등 표준 도구로 구성합니다.
+
+```jsonc
+{
+  "scripts": {
+    "dev:renderer": "zntc dev src/renderer",
+    "dev:main": "zntc --bundle src/main.ts --platform=node --format=cjs --packages=external --watch -o dist/main.cjs",
+    "dev:preload": "zntc --bundle src/preload.ts --platform=node --format=cjs --packages=external --watch -o dist/preload.cjs",
+    "dev:electron": "wait-on tcp:12300 && nodemon --watch dist/main.cjs --watch dist/preload.cjs --exec electron dist/main.cjs",
+    "dev": "npm-run-all -p dev:renderer dev:main dev:preload dev:electron",
+
+    "build:main": "zntc --bundle src/main.ts --platform=node --format=cjs --packages=external -o dist/main.cjs",
+    "build:preload": "zntc --bundle src/preload.ts --platform=node --format=cjs --packages=external -o dist/preload.cjs",
+    "build:renderer": "zntc build src/renderer",
+    "build": "npm-run-all build:main build:preload build:renderer",
+
+    "package": "electron-builder"
+  }
+}
+```
+
+renderer 의 HMR 은 ZNTC dev server 가 처리합니다 ([Dev Server](/zntc/guides/dev-server/) 참조). main · preload 는 빌드 산출물이 바뀌면 `nodemon` 이 Electron 프로세스를 재시작합니다.
+
+## 패키징
+
+`electron-builder` 또는 `electron-forge` 의 generic 모드를 그대로 사용하시면 됩니다. ZNTC 의 빌드 산출물은 표준 Node CJS / browser 번들이므로 추가 변환이 필요하지 않습니다.
+
+```jsonc
+// package.json — electron-builder 예제
+{
+  "build": {
+    "appId": "com.example.app",
+    "files": ["dist/**/*", "package.json"]
+  }
+}
+```
+
+## 참고
+
+- ZNTC 자체로는 main process 변경 시 Electron 자동 재시작 같은 통합 워크플로우를 제공하지 않습니다. 위 `nodemon` 스크립트가 그 역할입니다.
+- IPC 타입 sync, `autoUpdater` 같은 Electron 생태계 도구는 ZNTC 와 독립적으로 사용 가능합니다.

--- a/documents/src/content/docs/roadmap.md
+++ b/documents/src/content/docs/roadmap.md
@@ -1,0 +1,121 @@
+---
+title: 로드맵
+description: ZNTC 가 다음에 추가할 기능과 현재 지원되지 않는 항목을 정리합니다.
+---
+
+이 페이지는 사용자가 직접 마주치는 기능 단위로만 정리합니다. 내부 단계·진행률·구현 디테일은 GitHub 저장소를 참고하시기 바랍니다.
+
+## 예정 기능
+
+### 번들러
+
+#### WASM 공개 AST API
+
+브라우저 / Node 외부에서 ZNTC 의 AST 를 읽고 변환할 수 있도록 WASM 모듈로 노출합니다. 현재 Playground 와 Metafile Analyze 페이지가 내부적으로 사용하는 WASM 빌드를 사용자 API 로 안정화 후 공개합니다. AST 스키마 안정화가 선행 조건입니다.
+
+#### 외부 Zig 플러그인
+
+지금은 worklet · Fast Refresh 같은 빌트인 트랜스폼만 Zig 함수 포인터 기반 플러그인으로 동작합니다. 사용자가 작성한 Zig 모듈을 빌드 시 정적 링크해 in-process 로 호출하는 경로를 공개 예정입니다. NAPI 플러그인이 갖는 JS↔Native 직렬화 비용이 없는 대신, 빌드 시점에 Zig 컴파일러를 함께 사용해야 합니다.
+
+#### 청크별 CSS 분리
+
+`import './style.css'` 자동 emit, `@import` 인라이닝, Lightning CSS minify 까지는 지원합니다. 코드 스플리팅 시 CSS 도 청크별로 분리해 emit 하는 항목이 후순위로 잡혀 있습니다. (`.module.css` 클래스명 해싱·scope 는 앱 모드에서 이미 빌트인 지원입니다 — [Plugin Recipes 의 CSS Modules](/zntc/guides/plugin-recipes/#css-modules) 참조.)
+
+#### 정밀 dead-code elimination (innerGraph 확장)
+
+순수 local 변수의 straight-line dead store 는 제거합니다. branch / loop / try 같은 control-flow 안의 변수 할당 추적은 진행 중입니다.
+
+#### lazyBarrel 정밀화
+
+barrel re-export (`export * from`, `export { X } from`, `import * as X; export { X }`) 의 컴파일 생략은 순수·local·namespace 패턴에서 동작합니다. wrapper barrel 안에서 imported binding 을 mutate 하는 패턴(예: lodash-es 의 `lodash.default.js`) 은 현재 보수적으로 lazy 를 통째로 비활성화합니다. mutation 영역만 부분 lazy 로 적용하는 정밀화가 남아 있습니다. 현재 동작 한계는 [Tree-shaking](/zntc/guides/tree-shaking/) 참조.
+
+#### mangleProps
+
+cross-module property 난독화입니다. esbuild 와 유사한 기준이며 아직 미구현입니다.
+
+#### Module Concatenation 고도화
+
+rspack / rolldown 수준의 scope hoisting 입니다.
+
+#### Persistent disk cache
+
+현재는 watch / serve 세션 내 in-memory 파싱 캐시 + resolve 캐시만 사용합니다. 디스크 기반 영구 캐시로 cold rebuild 시간을 더 줄이는 항목이 후순위로 잡혀 있습니다.
+
+#### Module Federation
+
+마이크로프론트엔드용 코드 / 리소스 공유입니다. rspack 동등 수준을 목표로 하지만 아직 미구현입니다.
+
+#### Lazy compilation
+
+dev 모드에서 모듈을 온디맨드로 컴파일해 시작 시간을 줄이는 항목입니다. 미구현.
+
+### Transpiler
+
+#### `.d.ts` 생성 (isolatedDeclarations)
+
+지금은 `tsc` 에 위임합니다. 향후 isolatedDeclarations 기반의 emit 을 자체적으로 지원할 예정입니다.
+
+### Dev Server
+
+#### 단일 Zig dev server 로 수렴
+
+현재는 두 dev server 가 공존합니다.
+
+- **Zig 네이티브** (`zntc serve` / `zntc dev`) — Node 미설치 환경에서도 standalone 동작.
+- **JS** (`zntc dev <root>` app 모드) — postcss / sass 같은 JS 생태계 플러그인 위임용.
+
+장기 목표는 BoringSSL 통합 + 플러그인 호스트 추상화를 거쳐 Zig 단일 서버로 수렴하는 것입니다 (Bun 모델 참조). 우선순위는 안정성·CSS·생태계 항목 모두 이후입니다.
+
+### 생태계
+
+#### 플러그인 예제
+
+PostCSS · Tailwind · SVG · YAML 같은 자주 쓰이는 케이스를 레퍼런스 플러그인으로 정리합니다.
+
+#### 마이그레이션 가이드
+
+esbuild → ZNTC, Vite → ZNTC 설정 대응표를 확장합니다. 일부 가이드는 이미 [Migration](/zntc/guides/migration/) 에서 다룹니다.
+
+#### 프레임워크 통합 (Next.js · Remix · SvelteKit · Expo)
+
+각 프레임워크가 번들러를 내장하고 있어, 어댑터는 사실상 해당 프레임워크 compiler 의 부분 재구현을 의미합니다. 가장 마지막 단계로 잡혀 있습니다.
+
+- **Expo**: React Native 위에 얹힌 메타 프레임워크. 일반 React Native 앱은 이미 `--platform=react-native` 로 빌드 가능하지만, Expo Router 의 파일시스템 라우팅 manifest, Expo CLI 의 prebuild, EAS 빌드 파이프라인과의 통합은 별도 어댑터가 필요합니다.
+
+#### Vite 호환 모드
+
+`vite.config.js` 를 직접 읽어 마이그레이션 비용을 제로화하는 장기 목표입니다.
+
+## 현재 한계
+
+### Next.js / Remix 직접 빌드 불가
+
+두 프레임워크는 번들러가 RSC payload 직렬화, 파일시스템 routing manifest, loader/action 서버-클라이언트 분리 등 프레임워크 일부로 고정돼 있어 일반 번들러로 대체할 수 없습니다. 일반 React · Vue · Svelte SPA 와 React Native (Metro 호환 출력) 는 지원합니다.
+
+### core `--bundle` 모드에서 `.module.css` 자동 변환
+
+앱 모드 (`zntc dev` · `zntc build`) 에서는 `.module.css` 의 클래스명 해싱·scope 변환을 빌트인으로 지원합니다 ([Plugin Recipes 의 CSS Modules](/zntc/guides/plugin-recipes/#css-modules) 참조). core `--bundle` 모드에서는 자동 변환을 하지 않으므로 Vite 어댑터 또는 사용자 플러그인 (PostCSS Modules / Lightning CSS Modules) 을 거쳐야 합니다.
+
+### 청크별 CSS 분리
+
+code splitting 시 CSS 는 단일 산출물로 emit 됩니다. 청크별 CSS 분리는 후순위.
+
+### Persistent disk cache · Module Federation · Lazy compilation · mangleProps
+
+위 "예정 기능" 의 미구현 항목들입니다.
+
+### control-flow 기반 일반 dead store
+
+`if` / `for` / `try` 내부에서 다시 덮어쓰여 의미가 없는 변수 할당은 일부 보존됩니다. straight-line dead store 만 제거합니다.
+
+### wrapper barrel mutation 패턴
+
+barrel 모듈이 imported binding 을 mutate 하는 경우 (lodash-es 등 일부 라이브러리) lazy barrel 최적화가 통째로 꺼집니다. 결과의 정확성은 보장되지만 번들 사이즈가 더 클 수 있습니다.
+
+### tsconfig `paths` 매우 많을 때 (수백 개 이상)
+
+첫 resolve 만 선형 스캔이고 이후는 resolve 캐시가 흡수합니다. 일반 프로젝트 규모에서는 실측 영향이 없습니다.
+
+### WASM 공개 API
+
+현재 Playground / Metafile Analyze 내부 사용에 한정합니다. 사용자가 직접 `import` 할 안정화된 공개 API 는 아직 제공하지 않습니다 (위 "예정 기능" 참조).


### PR DESCRIPTION
## Summary

문서 사이트(`documents/`)에 두 페이지를 추가합니다.

### 1. 로드맵 (`/zntc/roadmap/`, `/zntc/en/roadmap/`)

- 사이드바: **레퍼런스** 그룹 끝에 `슬러그: roadmap` 으로 추가.
- 내용: 사용자 관점의 "예정 기능 + 현재 한계" 만 정리. PR 번호 / Phase / D번호 / 내부 파일 경로 / 도구 비교 표 / 성능 history 는 모두 제외 (memory feedback `feedback_pages_user_perspective.md` 준수).
- 예정 기능: **WASM 공개 AST API**, **외부 Zig 플러그인** (사용자 요청), 청크별 CSS 분리, innerGraph 일반화, lazyBarrel 정밀화, mangleProps, Module Concatenation 고도화, 영구 디스크 캐시, Module Federation, Lazy compilation, `.d.ts` (isolatedDeclarations), Bun 모델 dev server 수렴, **프레임워크 통합 (Next.js · Remix · SvelteKit · Expo)** (Expo 사용자 요청), Vite 호환 모드.
- 현재 한계: Next/Remix 직접 빌드 불가, `core --bundle` 의 `.module.css` 자동 변환 (앱 모드는 빌트인 지원 명시), 청크별 CSS 분리, control-flow 일반 dead store, wrapper-barrel mutation pattern, 매우 큰 `tsconfig paths`, 공개 WASM API.

### 2. Electron 가이드 (`/zntc/guides/electron/`, `/zntc/en/guides/electron/`)

- 사이드바: **레시피** 그룹의 "Dev Server (SSE/MCP)" 옆.
- 별도 어댑터 없이 webpack/rspack 의 표준 패턴 그대로 npm script + ZNTC CLI 만으로 Electron 앱을 빌드/개발하는 예제.
- main · preload: `--platform=node --format=cjs --packages=external`. renderer: `zntc dev` (포트 12300) + `BrowserWindow.loadURL`. watch · 재시작은 `npm-run-all`, `wait-on`, `nodemon` 으로 묶음. 패키징은 `electron-builder` / `electron-forge` generic 모드 그대로.

## 검토 결과 (simplify)

세 개 리뷰 에이전트(cross-page reuse / 컨텐츠 규칙 compliance / 사이드바 설정) 모두 통과. 다음 두 가지를 simplify 사이클에서 잡아 정정했습니다.

1. **CSS Modules 모순** — 최초 작성 시 "`.module.css` 미지원" 으로 적었으나 `guides/plugin-recipes.md`, `guides/migration.md`, `guides/comparison.md` 는 "앱 모드 빌트인 지원" 으로 명시. 정정 후 "core `--bundle` 모드 한정 미지원, 앱 모드는 지원" 으로 수정 + cross-link 추가.
2. **lazyBarrel cross-link** — `guides/tree-shaking.md` 의 동일 한계 설명에 cross-link 추가.

CLI 옵션 / 포트 (`12300`) 는 실제 소스 (`src/cli/options.zig`, `packages/core/bin/zntc.mjs`) 와 대조해 확인.

## Test plan

- [x] `bun run build` 통과 (483 페이지, +4)
- [x] starlight-links-validator "All internal links are valid"
- [x] `dist/roadmap/`, `dist/en/roadmap/`, `dist/guides/electron/`, `dist/en/guides/electron/` 모두 생성 확인
- [ ] 배포 후 사이드바에서 "로드맵" / "Electron" 항목이 KO/EN 모두 정상 노출되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)