### PR TITLE
fix(bundler+cli): asset_outputs (CSS bundle) 가 dist 에 write 되도록 — #3022 마무리

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -440,11 +440,24 @@ function writeOutputFiles(outputFiles, outfile, outdir, entryPoints, allowOverwr
   const resolvedEntries = allowOverwrite ? null : new Set(entryPoints.map(safeRealpath));
   if (outfile) {
     const outPath = resolve(outfile);
+    const outDirAbs = dirname(outPath);
     assertCanWriteOutput(outPath, resolvedEntries);
-    mkdirSync(dirname(outPath), { recursive: true });
+    mkdirSync(outDirAbs, { recursive: true });
+    // 첫 entry 는 main bundle/transpile output → outfile. 나머지는 path 로 분기 —
+    // `.map` 으로 끝나면 sourcemap (`outfile.map`), 아니면 asset (CSS bundle / worker
+    // chunk 등) 으로 outfile 의 dirname 안에 basename. 옛 코드가 `[1]` slot 을 무조건
+    // sourcemap 으로 가정해 asset 이 함께 emit 될 때 asset 이 `.map` 자리에 잘못
+    // write 되던 회귀 해소.
     writeFileSync(outPath, outputFiles[0].text);
-    if (outputFiles.length > 1) {
-      writeFileSync(resolve(outfile + '.map'), outputFiles[1].text);
+    for (let i = 1; i < outputFiles.length; i++) {
+      const file = outputFiles[i];
+      if (file.path.endsWith('.map')) {
+        writeFileSync(outPath + '.map', file.text);
+      } else {
+        const assetPath = join(outDirAbs, basename(file.path));
+        assertCanWriteOutput(assetPath, resolvedEntries);
+        writeFileSync(assetPath, file.text);
+      }
     }
   } else if (outdir) {
     const outDirAbs = resolve(outdir);

--- a/packages/core/src/napi/result.zig
+++ b/packages/core/src/napi/result.zig
@@ -86,6 +86,31 @@ pub fn buildResultToJS(env: c.napi_env, result: *const bundler_mod.BundleResult,
             _ = c.napi_set_element(env, js_outputs, 1, js_sm_file);
         }
     }
+
+    // asset_outputs (CSS bundle / worker chunks / file-loader 산출물 등) 도 outputFiles
+    // 배열에 합쳐 JS 의 `writeOutputFiles` 가 dist 에 write 하도록 한다. native 만
+    // 별도 storage 라 path/contents 외 metadata (module_ids/exports/imports) 는 없다.
+    // (#3022 — vue/svelte SFC 의 `?vue&type=style&lang.css` sub-import 의 CSS bundle 이
+    // dist 에 누락되던 회귀 해소.)
+    if (result.asset_outputs) |assets| {
+        var current_len: u32 = 0;
+        _ = c.napi_get_array_length(env, js_outputs, &current_len);
+        for (assets, 0..) |asset, i| {
+            var js_asset: c.napi_value = undefined;
+            _ = c.napi_create_object(env, &js_asset);
+
+            var js_path: c.napi_value = undefined;
+            _ = c.napi_create_string_utf8(env, asset.path.ptr, asset.path.len, &js_path);
+            _ = c.napi_set_named_property(env, js_asset, "path", js_path);
+
+            var js_text: c.napi_value = undefined;
+            _ = c.napi_create_string_utf8(env, asset.contents.ptr, asset.contents.len, &js_text);
+            _ = c.napi_set_named_property(env, js_asset, "text", js_text);
+
+            _ = c.napi_set_element(env, js_outputs, current_len + @as(u32, @intCast(i)), js_asset);
+        }
+    }
+
     _ = c.napi_set_named_property(env, js_result, "outputFiles", js_outputs);
 
     var js_errors: c.napi_value = undefined;


### PR DESCRIPTION
## Summary

이슈 #3022 (vite plugin virtual module + query sub-import 지원) 의 마지막 미해결 검증 항목 해소. vue SFC 의 `<style scoped>` 블록이 `?vue&type=style&lang.css` sub-module 로 transform 되고 `parseCssModule` + `emitCssBundle` 까지 정상 동작했지만 **`dist/` 에 .css 파일이 emit 되지 않던 문제**.

## Root cause

native 의 `BundleResult.asset_outputs` 가 JS 측에 노출 안 됨:

1. `src/bundler/bundler.zig:1463` 가 `final_asset_outputs` (CSS bundle / worker chunks / file-loader asset) 를 `result.asset_outputs` 에 set
2. `packages/core/src/napi/result.zig:buildResultToJS` 가 `result.outputs` (main + sourcemap) 만 직렬화 — `asset_outputs` **무시**
3. JS `writeOutputFiles` 가 outputFiles 만 iterate → asset 모름 → write 안 됨

추가: `bin/zntc.mjs:writeOutputFiles` 가 `outputFiles[1]` 슬롯을 sourcemap 으로 *가정* — asset 함께 emit 시 asset 이 sourcemap 자리에 write (dist 에 `main.js.map` 으로 CSS 가 들어가던 회귀).

## Fix

### `packages/core/src/napi/result.zig`
`buildResultToJS` 가 `result.asset_outputs` 를 같은 `outputFiles` 배열에 append. `{path, text}` shape 동일 — JS 측 변경 없이 자동 인식.

### `packages/core/bin/zntc.mjs`
`writeOutputFiles` 의 outfile 분기:
- 옛: `outputFiles[0]` → outfile, `outputFiles[1]` → outfile + `.map` (index 가정)
- 새: `outputFiles[0]` → outfile, `[1+]` 는 path 로 분기 — `.map` 으로 끝나면 outfile + `.map`, 아니면 `dirname(outfile)/basename(file.path)`

transpile (`outputFiles[0]` = transpile output) / bundle (`outputFiles[0]` = `bundle.js`) 양쪽 동작 그대로 + asset 이 함께 emit 될 때만 path-based 처리.

## 검증

- `zig build test`: 통과
- `bun run --cwd packages/core test`: **900 pass / 0 fail** (transpile `-o` / `--sourcemap` + asset 모두 통과)
- minimal vue SFC fixture (`<template>` + `<script setup lang="ts">` + `<style scoped>`):
  - 이전: `dist/main.js` (195KB) 만, CSS 누락
  - 현재: **`dist/main.js` (195KB) + `dist/main.css` (52B, `.hello { color: tomato; … }`)** 둘 다 emit. exit 0.

## 이슈 #3022 검증 체크리스트

- [x] `zntc build` exit 0
- [x] App 컴포넌트의 render 함수가 `dist/main.js` 에 포함 (`defineComponent` + `setup` + `_export_sfc` + `createApp(_default$2)`)
- [x] 컴파일된 CSS 문자열이 `dist/main.css` 에 포함

Closes #3022

## 관련 PR 체인

vue/svelte SFC 빌드 전 chain:
- #3017 — vitePlugin wrapper hook object + sourcemap object
- #3023 — virtual module + query sub-import (`?vue&type=style&lang.css`)
- #3027 — plugin load loader fallback 회귀 fix
- #3029 — NUL byte import specifier unescape (`\0plugin-vue:...`)
- **이번 PR** — asset_outputs 의 dist write

🤖 Generated with [Claude Code](https://claude.com/claude-code)