### PR TITLE
fix(docs): zntc-init 도움말 시그니처 최신화 (RN 가이드)

### DIFF
--- a/documents/src/content/docs/en/guides/react-native.md
+++ b/documents/src/content/docs/en/guides/react-native.md
@@ -21,8 +21,11 @@ my-rn-app/
 
 The fastest way to add ZNTC to an existing RN CLI project is `@zntc/init`. It patches `package.json` scripts and writes `zntc.config.ts` — it does not generate a new native shell.
 
+`zntc-init` takes a mode as its first argument; for RN it's `react-native` (omitting the mode falls back to `react-native` for backward compatibility). Other modes — `vite`, `rspack`, `web` — are covered by their own guides.
+
 ```bash
-npx @zntc/init
+npx @zntc/init react-native
+npx @zntc/init react-native --platform=android
 npx @zntc/init --help
 ```
 
@@ -37,31 +40,51 @@ What it does:
 Help output:
 
 ```text
-Usage: zntc-init [react-native] [options]
+Usage: zntc-init <mode> [options]
 
-Overlay ZNTC onto an existing React Native CLI project.
+Modes:
+  react-native    Overlay ZNTC onto an existing React Native CLI project
+  vite            Overlay ZNTC onto an existing Vite project (@zntc/vite-plugin)
+  rspack          Overlay ZNTC onto an existing Rspack/Webpack project (@zntc/rspack-loader)
+  web             Scaffold a standalone ZNTC web project (no Vite/Rspack)
 
-Options:
-  --root <dir>               Project root (default: cwd)
-  --platform <ios|android>   Default platform for the start script (default: ios)
-  --zntc-version <range>     Version range for @zntc packages (default: latest)
-  --package-manager <pm>     Install command hint: bun, npm, pnpm, or yarn
-  --no-metro-fallback        Do not add Metro fallback scripts
-  --force                    Overwrite an existing zntc.config.ts
-  --dry-run                  Print planned changes without writing files
-  --help, -h                 Show this help message
+Common options:
+  --root <dir>                Project root (default: cwd)
+  --zntc-version <range>      Version range for @zntc packages (default: latest)
+  --package-manager <pm>      Install command hint: bun, npm, pnpm, or yarn
+  --force                     Overwrite existing files where the mode allows
+  --dry-run                   Print planned changes without writing files
+  --help, -h                  Show this help message
+
+react-native options:
+  --platform <ios|android>    Default platform for the start script (default: ios)
+  --no-metro-fallback         Do not add Metro fallback scripts
+
+rspack options:
+  --bundler <rspack|webpack>  Force bundler choice (default: auto-detect)
+
+web options:
+  --name <pkg-name>           package.json name field (default: directory name)
+  --framework <react|vanilla> Starter template (default: react)
 ```
 
-| Option                                     | Description                                                              |
-| ------------------------------------------ | ------------------------------------------------------------------------ |
-| `--root <dir>`                             | Project root. Defaults to cwd.                                           |
-| `--platform <ios\|android>`                | Default RN platform for the `start` script. Defaults to `ios`.           |
-| `--zntc-version <range>`                   | Version range for `@zntc/core` / `@zntc/react-native`.                   |
-| `--package-manager <bun\|npm\|pnpm\|yarn>` | Install-command hint printed after init.                                 |
-| `--no-metro-fallback`                      | Skip `start:metro` / `bundle:metro:*` fallback scripts.                  |
-| `--force`                                  | Overwrite an existing `zntc.config.ts`.                                  |
-| `--dry-run`                                | Print planned changes without writing files.                             |
-| `--help`, `-h`                             | Show help.                                                               |
+### Common options
+
+| Option                                     | Description                                                  |
+| ------------------------------------------ | ------------------------------------------------------------ |
+| `--root <dir>`                             | Project root. Defaults to cwd.                               |
+| `--zntc-version <range>`                   | Version range for the `@zntc/*` packages (default: `latest`).|
+| `--package-manager <bun\|npm\|pnpm\|yarn>` | Install-command hint printed after init.                     |
+| `--force`                                  | Overwrite existing files where the mode allows.              |
+| `--dry-run`                                | Print planned changes without writing files.                 |
+| `--help`, `-h`                             | Show help.                                                   |
+
+### react-native mode options
+
+| Option                          | Description                                                    |
+| ------------------------------- | -------------------------------------------------------------- |
+| `--platform <ios\|android>`     | Default RN platform for the `start` script. Defaults to `ios`. |
+| `--no-metro-fallback`           | Skip `start:metro` / `bundle:metro:*` fallback scripts.        |
 
 ## Manual setup
 

--- a/documents/src/content/docs/guides/react-native.md
+++ b/documents/src/content/docs/guides/react-native.md
@@ -21,8 +21,11 @@ my-rn-app/
 
 기존 RN CLI 프로젝트에 ZNTC 를 얹는 가장 빠른 방법은 `@zntc/init` 입니다. native shell 을 새로 만들지 않고 `package.json` 의 script 와 `zntc.config.ts` 만 패치합니다.
 
+`zntc-init` 는 모드를 첫 인자로 받으며 RN 은 `react-native` 입니다 (모드를 생략하면 `react-native` 로 동작 — 기존 호환). 다른 모드: `vite`, `rspack`, `web` 은 각 가이드 참조.
+
 ```bash
-npx @zntc/init
+npx @zntc/init react-native
+npx @zntc/init react-native --platform=android
 npx @zntc/init --help
 ```
 
@@ -37,31 +40,51 @@ npx @zntc/init --help
 도움말 출력:
 
 ```text
-Usage: zntc-init [react-native] [options]
+Usage: zntc-init <mode> [options]
 
-Overlay ZNTC onto an existing React Native CLI project.
+Modes:
+  react-native    Overlay ZNTC onto an existing React Native CLI project
+  vite            Overlay ZNTC onto an existing Vite project (@zntc/vite-plugin)
+  rspack          Overlay ZNTC onto an existing Rspack/Webpack project (@zntc/rspack-loader)
+  web             Scaffold a standalone ZNTC web project (no Vite/Rspack)
 
-Options:
-  --root <dir>               Project root (default: cwd)
-  --platform <ios|android>   Default platform for the start script (default: ios)
-  --zntc-version <range>     Version range for @zntc packages (default: latest)
-  --package-manager <pm>     Install command hint: bun, npm, pnpm, or yarn
-  --no-metro-fallback        Do not add Metro fallback scripts
-  --force                    Overwrite an existing zntc.config.ts
-  --dry-run                  Print planned changes without writing files
-  --help, -h                 Show this help message
+Common options:
+  --root <dir>                Project root (default: cwd)
+  --zntc-version <range>      Version range for @zntc packages (default: latest)
+  --package-manager <pm>      Install command hint: bun, npm, pnpm, or yarn
+  --force                     Overwrite existing files where the mode allows
+  --dry-run                   Print planned changes without writing files
+  --help, -h                  Show this help message
+
+react-native options:
+  --platform <ios|android>    Default platform for the start script (default: ios)
+  --no-metro-fallback         Do not add Metro fallback scripts
+
+rspack options:
+  --bundler <rspack|webpack>  Force bundler choice (default: auto-detect)
+
+web options:
+  --name <pkg-name>           package.json name field (default: directory name)
+  --framework <react|vanilla> Starter template (default: react)
 ```
 
-| 옵션                                       | 설명                                                             |
-| ------------------------------------------ | ---------------------------------------------------------------- |
-| `--root <dir>`                             | 프로젝트 루트. 기본값은 현재 디렉터리                            |
-| `--platform <ios\|android>`                | `start` script 의 기본 RN platform. 기본값은 `ios`               |
-| `--zntc-version <range>`                   | 추가할 `@zntc/core` / `@zntc/react-native` 버전 범위             |
-| `--package-manager <bun\|npm\|pnpm\|yarn>` | 초기화 후 출력할 install 명령 힌트                               |
-| `--no-metro-fallback`                      | `start:metro` / `bundle:metro:*` fallback script 를 추가하지 않음 |
-| `--force`                                  | 기존 `zntc.config.ts` 덮어쓰기                                   |
-| `--dry-run`                                | 파일을 쓰지 않고 변경 계획만 출력                                |
-| `--help`, `-h`                             | 도움말 출력                                                      |
+### 공통 옵션
+
+| 옵션                                       | 설명                                                       |
+| ------------------------------------------ | ---------------------------------------------------------- |
+| `--root <dir>`                             | 프로젝트 루트. 기본값은 현재 디렉터리                       |
+| `--zntc-version <range>`                   | 추가할 `@zntc/*` 패키지 버전 범위 (기본값: `latest`)         |
+| `--package-manager <bun\|npm\|pnpm\|yarn>` | 초기화 후 출력할 install 명령 힌트                          |
+| `--force`                                  | 모드가 허용하는 범위에서 기존 파일 덮어쓰기                  |
+| `--dry-run`                                | 파일을 쓰지 않고 변경 계획만 출력                            |
+| `--help`, `-h`                             | 도움말 출력                                                |
+
+### react-native 모드 옵션
+
+| 옵션                          | 설명                                                              |
+| ----------------------------- | ----------------------------------------------------------------- |
+| `--platform <ios\|android>`   | `start` script 의 기본 RN platform. 기본값은 `ios`                |
+| `--no-metro-fallback`         | `start:metro` / `bundle:metro:*` fallback script 를 추가하지 않음 |
 
 ## 수동 적용
 


### PR DESCRIPTION
## Summary

`https://ohah.github.io/zntc/guides/react-native/` 의 `zntc-init` 도움말이 옛 시그니처 (`zntc-init [react-native] [options]`) 로 적혀 있어 실제 CLI 출력 (`zntc-init <mode> [options]`) 과 일치하지 않았습니다. 4b4ef757 `feat(init): vite/rspack overlay + web scaffold 모드 추가` 이후 `@zntc/init` 가 모드 인자를 도입했고 옵션이 Common / mode-specific 으로 분리되었으나 가이드는 이 변경을 따라가지 못한 상태였습니다.

## 정정 내용

### 도움말 텍스트 (`packages/init/src/cli.ts:21-48` 출력과 동기화)

이전 (옛):
```
Usage: zntc-init [react-native] [options]
Overlay ZNTC onto an existing React Native CLI project.
Options:
  --root, --platform, --zntc-version, --package-manager,
  --no-metro-fallback, --force, --dry-run, --help
```

현재 (실제):
```
Usage: zntc-init <mode> [options]
Modes: react-native | vite | rspack | web
Common options + react-native options + rspack options + web options
```

### 호출 예제

- `npx @zntc/init` → `npx @zntc/init react-native` (모드 명시 권장 — 모드 생략 시 RN 으로 fallback 되는 backward-compat 동작은 유지된다는 점도 본문에 명시).
- `--platform=android` 예제 추가.

### 옵션 표

기존 단일 표를 **공통 옵션** (`--root`, `--zntc-version`, `--package-manager`, `--force`, `--dry-run`, `--help`) + **react-native 모드 옵션** (`--platform`, `--no-metro-fallback`) 두 표로 분리. 실제 cli.ts 의 분리 구조 그대로.

KO/EN 동시 정정.

## 범위 밖

- vite / rspack / web 모드의 사용법은 별도 가이드/PR 로 분리. 이 PR 은 RN 페이지의 도움말 동기화만.

## Test plan

- [x] `bun run build` 통과 (485 페이지)
- [x] starlight-links-validator 통과
- [ ] 배포 후 `https://ohah.github.io/zntc/guides/react-native/` 도움말이 실제 `npx @zntc/init --help` 출력과 일치하는지 육안 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)