### PR TITLE
docs(site): zntc-init vite/rspack/web 모드 별도 가이드

### DIFF
--- a/documents/astro.config.mjs
+++ b/documents/astro.config.mjs
@@ -126,6 +126,9 @@ export default defineConfig({
           items: [
             { label: "Dev Server (SSE/MCP)", slug: "guides/dev-server" },
             { label: "Electron", slug: "guides/electron" },
+            { label: "Vite", slug: "guides/vite" },
+            { label: "Rspack / Webpack", slug: "guides/rspack" },
+            { label: "Web (standalone)", slug: "guides/web-starter" },
             { label: "React Native", slug: "guides/react-native" },
             { label: "React Native + Expo", slug: "guides/react-native-expo" },
             { label: "Flow 지원", slug: "guides/flow-support", translations: { en: "Flow Support" } },

--- a/documents/src/content/docs/en/guides/rspack.md
+++ b/documents/src/content/docs/en/guides/rspack.md
@@ -1,0 +1,107 @@
+---
+title: Rspack / Webpack
+description: Replace swc-loader / babel-loader with ZNTC in an Rspack or Webpack project.
+---
+
+ZNTC slots into Rspack / Webpack's `swc-loader` / `babel-loader` position via `@zntc/rspack-loader`. The host bundler's entry / plugins / output / dev server stay unchanged — ZNTC only handles `.ts` / `.tsx` / `.jsx` transformations.
+
+## Project layout
+
+```text
+my-rspack-app/
+├── rspack.config.mjs       # or webpack.config.mjs
+├── src/
+│   ├── index.ts
+│   └── ...
+└── package.json
+```
+
+## Automatic setup (`zntc-init rspack`)
+
+```bash
+# Rspack — auto-detected from package.json's @rspack/* dependencies
+npx @zntc/init rspack
+
+# Webpack — force the bundler choice
+npx @zntc/init rspack --bundler=webpack
+```
+
+What it does:
+
+- Auto-detects the bundler from `@rspack/core` / `@rspack/cli` or `webpack` / `webpack-cli` in `package.json`. If neither is present, you must pass `--bundler`.
+- Adds `@zntc/core` and `@zntc/rspack-loader` to dev dependencies.
+- Writes a default `rspack.config.mjs` (or `webpack.config.mjs`) if missing.
+- If a config already exists, prints manual-patch instructions. Use `--force` to overwrite.
+
+Generated default config (Rspack):
+
+```js
+// rspack.config.mjs
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.(?:tsx?|jsx?)$/,
+        exclude: /node_modules/,
+        loader: "@zntc/rspack-loader",
+        options: {
+          transpileOptions: { target: "es2020", jsx: "automatic" },
+        },
+      },
+    ],
+  },
+};
+```
+
+Webpack uses the same rule shape — only the header comment differs.
+
+## Manual setup
+
+Add this rule to your existing `rspack.config` / `webpack.config`:
+
+```js
+{
+  test: /\.(?:tsx?|jsx?)$/,
+  exclude: /node_modules/,
+  loader: "@zntc/rspack-loader",
+  options: {
+    transpileOptions: { target: "es2020", jsx: "automatic" },
+  },
+},
+```
+
+Remove any existing `swc-loader` / `babel-loader` / `ts-loader` rule — ZNTC's loader takes that slot.
+
+## Commands
+
+Use the regular Rspack / Webpack CLI:
+
+```bash
+# Rspack
+bun rspack build
+bun rspack serve
+
+# Webpack
+bun webpack build
+bun webpack serve
+```
+
+## Options & recipes
+
+Detailed `transpileOptions`, `define`, `tsconfig`, and Flow options live in the [`@zntc/rspack-loader` reference](/zntc/en/guides/rspack-loader/).
+
+Common knobs:
+
+- `target` — `es2015` … `esnext`, or engine targets (`chrome80`, `node18`, …).
+- `jsx` — `automatic` (React 17+) / `classic` / `automatic-dev`.
+- `define` — compile-time replacement, e.g. `process.env.NODE_ENV`.
+- `tsconfigCache` — reuses tsconfig across the same dir tree (on by default).
+
+## Known limitations
+
+- ZNTC's loader runs only at transpile / parse time. Chunk splitting, asset modules, and dev-server behavior are decided by the host bundler — ZNTC's bundler-only options (`manualChunks`, tree-shaking, …) have no effect in this mode.
+- Mixing ZNTC's native bundler (`zntc --bundle`) and Rspack/Webpack in the same project can produce inconsistent output. Pick one build path.
+
+## See also
+
+- [`@zntc/rspack-loader` reference](/zntc/en/guides/rspack-loader/) — full loader options, peer dependencies, `define`-based env injection, Flow usage.

--- a/documents/src/content/docs/en/guides/vite.md
+++ b/documents/src/content/docs/en/guides/vite.md
@@ -1,0 +1,101 @@
+---
+title: Vite
+description: Replace Vite's esbuild transform with ZNTC in an existing Vite project.
+---
+
+ZNTC slots into Vite's esbuild-transform position via `@zntc/vite-plugin`. Vite's dev server, HMR, and plugin ecosystem keep working as-is — ZNTC only handles `.ts` / `.tsx` / `.jsx` transformations.
+
+## Project layout
+
+```text
+my-vite-app/
+├── index.html
+├── vite.config.ts          # registers @zntc/vite-plugin
+├── src/
+│   ├── main.tsx
+│   └── App.tsx
+└── package.json
+```
+
+## Automatic setup (`zntc-init vite`)
+
+The fastest way to add ZNTC to a project that already depends on `vite`. If `vite` isn't installed, use `zntc-init web` for a standalone scaffold ([Web (standalone)](/zntc/en/guides/web-starter/)).
+
+```bash
+npx @zntc/init vite
+```
+
+What it does:
+
+- Adds `@zntc/core` and `@zntc/vite-plugin` to dev dependencies.
+- Writes a default `vite.config.ts` (or `.mts` / `.js` / `.mjs`) if missing.
+- If a config already exists, prints manual-patch instructions. Use `--force` to overwrite.
+
+Generated default config:
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import { zntc } from "@zntc/vite-plugin";
+
+export default defineConfig({
+  plugins: [zntc()],
+  esbuild: false,
+});
+```
+
+## Manual setup
+
+To wire it into an existing `vite.config.ts` yourself:
+
+```ts
+import { defineConfig } from "vite";
+import { zntc } from "@zntc/vite-plugin";
+
+export default defineConfig({
+  plugins: [
+    zntc(), // place near the front (esbuild's old slot)
+    // ...your existing plugins
+  ],
+  esbuild: false, // disable Vite's esbuild transform
+});
+```
+
+`esbuild: false` is required — if Vite still transforms `.ts` / `.tsx` with esbuild, you'll get double-transformed output.
+
+## Commands
+
+Use Vite's regular CLI:
+
+```bash
+bun vite           # dev server (Vite HMR)
+bun vite build     # production build
+bun vite preview   # preview the build output
+```
+
+## Vite vs ZNTC's own dev server
+
+- `bun vite` — Vite dev server + ZNTC transform. You keep Vite's HMR and plugin ecosystem.
+- `zntc dev <root>` — ZNTC's standalone dev server. Vite is not involved; only the ZNTC plugin API is available (see [Dev Server](/zntc/en/guides/dev-server/)).
+
+Pick whichever fits your project. If you already use Vite, sticking with Vite + `@zntc/vite-plugin` is the natural choice.
+
+## How it works
+
+`@zntc/vite-plugin`'s `zntc()` attaches to these Vite hooks:
+
+- `resolveId` / `load` — mirrors your ZNTC plugin's `resolveId` / `load` into Vite.
+- `transform` — converts `.ts` / `.tsx` / `.jsx` / `.mts` / `.cts` / `.flow.js` through ZNTC and returns a sourcemap object (compatible with Vite 4+).
+- `renderChunk` / `generateBundle` — forwards your plugin's lifecycle hooks.
+
+If a `defineConfig({...})` is present, `zntc()` picks up its options automatically.
+
+## Known limitations
+
+- SFC transformations from Vite-specific plugins (e.g. `@vitejs/plugin-vue`) are out of scope for ZNTC. Keep using the SFC plugin; ZNTC only handles the `<script lang="ts">` block.
+- Rollup plugins that call `this.parse()` get partial ESTree adapter coverage — see the Rollup ModuleInfo Phase C entry in the [Roadmap](/zntc/en/roadmap/).
+
+## See also
+
+- [Plugin Recipes](/zntc/en/guides/plugin-recipes/) — PostCSS, Tailwind, SVG, GraphQL recipes that pair with `@zntc/vite-plugin`.
+- [Web (standalone)](/zntc/en/guides/web-starter/) — start fresh without Vite.

--- a/documents/src/content/docs/en/guides/web-starter.md
+++ b/documents/src/content/docs/en/guides/web-starter.md
@@ -1,0 +1,106 @@
+---
+title: Web (standalone)
+description: Start a new web project with ZNTC alone — no Vite or Rspack.
+---
+
+`zntc-init web` scaffolds a new web project that runs on ZNTC alone, into an empty directory. Unlike the Vite / Rspack overlay modes, it generates a full starter template from scratch.
+
+## Command
+
+```bash
+# React starter (default)
+npx @zntc/init web --framework=react
+
+# Vanilla TS starter
+npx @zntc/init web --framework=vanilla
+```
+
+Options:
+
+| Option                          | Description                                                       |
+| ------------------------------- | ----------------------------------------------------------------- |
+| `--name <pkg-name>`             | `package.json`'s `name` field. Defaults to the directory name.    |
+| `--framework <react\|vanilla>`  | Starter template. Defaults to `react`.                            |
+| `--root <dir>`                  | Project root. Defaults to cwd.                                    |
+| `--zntc-version <range>`        | Version range for `@zntc/*` packages. Defaults to `latest`.       |
+| `--force`                       | Overwrite existing files.                                         |
+
+## Generated files
+
+### React template
+
+```text
+my-app/
+├── index.html              # <div id="root"> + <script type="module" src="/src/main.tsx">
+├── package.json            # react@^19, react-dom@^19, @zntc/core, typescript
+├── tsconfig.json           # jsx: react-jsx, strict, isolatedModules, moduleResolution: Bundler
+├── zntc.config.ts          # defineConfig: entryPoints / outdir / platform=browser / target=es2022 / jsx=automatic / sourcemap
+└── src/
+    ├── main.tsx            # createRoot(...).render(<App />)
+    └── App.tsx
+```
+
+Generated `zntc.config.ts`:
+
+```ts
+import { defineConfig } from "@zntc/core";
+
+export default defineConfig({
+  entryPoints: ["src/main.tsx"],
+  outdir: "dist",
+  format: "esm",
+  platform: "browser",
+  target: "es2022",
+  jsx: "automatic",
+  sourcemap: true,
+});
+```
+
+### Vanilla template
+
+```text
+my-app/
+├── index.html              # <div id="app"> + <script type="module" src="/src/main.ts">
+├── package.json            # @zntc/core + typescript only
+├── tsconfig.json           # strict, isolatedModules — no JSX
+├── zntc.config.ts          # entryPoints: ["src/main.ts"]
+└── src/
+    └── main.ts
+```
+
+## Dev commands
+
+The generated `package.json` scripts:
+
+```jsonc
+{
+  "scripts": {
+    "dev": "zntc dev",
+    "build": "zntc build",
+    "preview": "zntc preview"
+  }
+}
+```
+
+```bash
+# use the package manager hint printed by init (bun / npm / pnpm / yarn)
+bun install
+bun run dev          # ZNTC dev server (HMR)
+bun run build        # production bundle into dist/
+bun run preview      # preview dist/
+```
+
+## When to use web mode
+
+| Situation                                              | Recommended mode                                              |
+| ------------------------------------------------------ | ------------------------------------------------------------- |
+| Starting from scratch (no tooling chosen yet)          | **`zntc-init web`** — ZNTC only.                              |
+| Existing Vite project                                  | [`zntc-init vite`](/zntc/en/guides/vite/)                     |
+| Existing Rspack / Webpack project                      | [`zntc-init rspack`](/zntc/en/guides/rspack/)                 |
+| Existing React Native CLI project                      | [`zntc-init react-native`](/zntc/en/guides/react-native/)     |
+
+## See also
+
+- [Dev Server](/zntc/en/guides/dev-server/) — `zntc dev` SSE / MCP / Live Reload behavior.
+- [Config File](/zntc/en/guides/config-file/) — full `zntc.config.ts` options and functional config.
+- [Plugin Recipes](/zntc/en/guides/plugin-recipes/) — CSS / PostCSS / Tailwind / SVG plugin patterns.

--- a/documents/src/content/docs/guides/rspack.md
+++ b/documents/src/content/docs/guides/rspack.md
@@ -1,0 +1,107 @@
+---
+title: Rspack / Webpack
+description: Rspack 또는 Webpack 프로젝트에서 ZNTC 로 swc-loader / babel-loader 를 교체하는 방법입니다.
+---
+
+ZNTC 는 `@zntc/rspack-loader` 로 Rspack / Webpack 의 `swc-loader` / `babel-loader` 자리에 들어갑니다. Rspack / Webpack 의 entry / plugins / output / dev server 는 그대로 두고 `.ts` / `.tsx` / `.jsx` 변환만 ZNTC 가 담당합니다.
+
+## 프로젝트 구조
+
+```text
+my-rspack-app/
+├── rspack.config.mjs       # 또는 webpack.config.mjs
+├── src/
+│   ├── index.ts
+│   └── ...
+└── package.json
+```
+
+## 자동 적용 (`zntc-init rspack`)
+
+```bash
+# Rspack — package.json 의 @rspack/* 의존성 자동 감지
+npx @zntc/init rspack
+
+# Webpack — 명시적으로 강제
+npx @zntc/init rspack --bundler=webpack
+```
+
+수행 작업:
+
+- `package.json` 의 `@rspack/core` / `@rspack/cli` 또는 `webpack` / `webpack-cli` 의존성을 보고 bundler 를 자동 감지합니다 (없으면 `--bundler` 로 강제).
+- `@zntc/core`, `@zntc/rspack-loader` 개발 의존성을 추가합니다.
+- `rspack.config.mjs` (또는 `webpack.config.mjs`) 가 없으면 기본 config 를 생성합니다.
+- 기존 config 가 있으면 manual patch 안내를 출력합니다. `--force` 로 덮어쓰기 가능.
+
+기본 생성 config (Rspack):
+
+```js
+// rspack.config.mjs
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.(?:tsx?|jsx?)$/,
+        exclude: /node_modules/,
+        loader: "@zntc/rspack-loader",
+        options: {
+          transpileOptions: { target: "es2020", jsx: "automatic" },
+        },
+      },
+    ],
+  },
+};
+```
+
+Webpack 도 동일한 rule 형태 — header 주석만 다릅니다.
+
+## 수동 적용
+
+기존 `rspack.config` / `webpack.config` 의 `module.rules` 에 다음 rule 을 추가합니다.
+
+```js
+{
+  test: /\.(?:tsx?|jsx?)$/,
+  exclude: /node_modules/,
+  loader: "@zntc/rspack-loader",
+  options: {
+    transpileOptions: { target: "es2020", jsx: "automatic" },
+  },
+},
+```
+
+기존의 `swc-loader` / `babel-loader` / `ts-loader` rule 은 제거하시면 됩니다 — ZNTC loader 가 그 자리를 차지합니다.
+
+## 명령
+
+기존 Rspack / Webpack CLI 를 그대로 사용합니다.
+
+```bash
+# Rspack
+bun rspack build
+bun rspack serve
+
+# Webpack
+bun webpack build
+bun webpack serve
+```
+
+## 옵션 / 사용 예시
+
+`@zntc/rspack-loader` 의 `transpileOptions`, `define`, `tsconfig`, `flow` 등 자세한 옵션과 예시는 [`@zntc/rspack-loader` reference](/zntc/guides/rspack-loader/) 를 참조하세요.
+
+자주 쓰는 옵션 요약:
+
+- `target` — `es2015` ~ `esnext`, 또는 엔진 타겟 (`chrome80`, `node18` 등).
+- `jsx` — `automatic` (React 17+) / `classic` / `automatic-dev`.
+- `define` — `process.env.NODE_ENV` 같은 컴파일 타임 치환.
+- `tsconfigCache` — 같은 디렉토리 트리에서 tsconfig 재사용 (기본 활성).
+
+## 알려진 한계
+
+- ZNTC loader 는 transpile / parse 시점에만 동작합니다. Rspack / Webpack 의 chunk splitting / asset module / dev server 동작은 호스트 번들러가 결정합니다 — ZNTC 의 번들러 옵션 (`manualChunks`, `tree-shaking` 등) 은 이 모드에서 효과가 없습니다.
+- 동일 프로젝트에서 ZNTC native bundler (`zntc --bundle`) 와 Rspack/Webpack 을 혼용하면 출력이 일치하지 않을 수 있습니다. 한 가지 빌드 경로를 선택해 사용하세요.
+
+## 관련 문서
+
+- [`@zntc/rspack-loader` reference](/zntc/guides/rspack-loader/) — loader 옵션 / peerDependency / `define` 환경변수 치환 / Flow 사용 예시.

--- a/documents/src/content/docs/guides/vite.md
+++ b/documents/src/content/docs/guides/vite.md
@@ -1,0 +1,101 @@
+---
+title: Vite
+description: 기존 Vite 프로젝트에서 ZNTC 로 esbuild transform 을 대체하는 방법입니다.
+---
+
+ZNTC 는 `@zntc/vite-plugin` 으로 Vite 의 esbuild transform 자리에 들어갑니다. Vite 의 dev server / HMR / plugin 생태계는 그대로 사용하시고, `.ts` / `.tsx` / `.jsx` 변환만 ZNTC 가 담당합니다.
+
+## 프로젝트 구조
+
+```text
+my-vite-app/
+├── index.html
+├── vite.config.ts          # @zntc/vite-plugin 등록
+├── src/
+│   ├── main.tsx
+│   └── App.tsx
+└── package.json
+```
+
+## 자동 적용 (`zntc-init vite`)
+
+`vite` 가 dependency 에 있는 기존 프로젝트에 ZNTC 를 얹는 가장 빠른 방법입니다. `vite` 가 없으면 `zntc-init web` 으로 standalone scaffold 를 사용하세요 ([Web (standalone)](/zntc/guides/web-starter/)).
+
+```bash
+npx @zntc/init vite
+```
+
+수행 작업:
+
+- `package.json` 에 `@zntc/core`, `@zntc/vite-plugin` 개발 의존성을 추가합니다.
+- `vite.config.ts` (또는 `.mts` / `.js` / `.mjs`) 가 없으면 기본 config 를 생성합니다.
+- 기존 config 가 있으면 manual patch 안내를 출력합니다. `--force` 로 덮어쓰기 가능.
+
+기본 생성 config:
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import { zntc } from "@zntc/vite-plugin";
+
+export default defineConfig({
+  plugins: [zntc()],
+  esbuild: false,
+});
+```
+
+## 수동 적용
+
+기존 `vite.config.ts` 에 직접 끼우려면 다음 두 곳을 수정합니다.
+
+```ts
+import { defineConfig } from "vite";
+import { zntc } from "@zntc/vite-plugin";
+
+export default defineConfig({
+  plugins: [
+    zntc(), // 기존 plugins 배열 앞쪽 (esbuild 자리)
+    // ...기존 plugins
+  ],
+  esbuild: false, // Vite 의 esbuild transform 비활성
+});
+```
+
+`esbuild: false` 가 필수입니다 — Vite 가 esbuild 로 `.ts`/`.tsx` 를 transform 하면 ZNTC 와 중복 처리되어 출력이 어긋날 수 있습니다.
+
+## 명령
+
+Vite 의 기존 CLI 를 그대로 사용합니다.
+
+```bash
+bun vite           # dev server (Vite HMR)
+bun vite build     # 프로덕션 번들
+bun vite preview   # 빌드 결과 미리보기
+```
+
+## Vite vs ZNTC 자체 dev server
+
+- `bun vite` — Vite dev server + ZNTC transform. Vite 의 HMR / plugin 생태계 그대로 사용.
+- `zntc dev <root>` — ZNTC 자체 dev server. Vite 없이 동작. ZNTC plugin API 만 사용 가능 ([Dev Server](/zntc/guides/dev-server/) 참조).
+
+같은 프로젝트에서 둘 중 적절한 것을 선택해 사용하시면 됩니다. 일반적으로 기존 Vite 생태계를 이미 사용 중이면 Vite + `@zntc/vite-plugin` 조합이 자연스럽습니다.
+
+## 동작 요약
+
+`@zntc/vite-plugin` 의 `zntc()` 는 다음 Vite hook 에 attach 됩니다.
+
+- `resolveId` / `load` — 사용자 ZNTC plugin (`zntc.config.ts`) 의 resolve / load 훅을 Vite 쪽으로 미러링.
+- `transform` — `.ts` / `.tsx` / `.jsx` / `.mts` / `.cts` / `.flow.js` 를 ZNTC 로 변환. source map 객체 반환 (Vite 4+ 호환).
+- `renderChunk` / `generateBundle` — 사용자 plugin 의 lifecycle 훅 전달.
+
+ZNTC `defineConfig({...})` 가 있으면 `zntc()` 가 자동으로 읽어 옵션을 적용합니다.
+
+## 알려진 한계
+
+- 일부 Vite-only plugin (예: `vite:vue`, `@vitejs/plugin-vue`) 의 SFC 변환은 ZNTC 의 책임 밖입니다. SFC 변환 plugin 은 그대로 사용하시고 ZNTC 는 `<script lang="ts">` 안 TypeScript 만 처리합니다.
+- Rollup plugin 의 `this.parse()` ESTree adapter 는 부분 지원 — `info.ast` 같은 ESTree 노드 접근은 [Roadmap](/zntc/roadmap/) 의 Rollup ModuleInfo Phase C 참조.
+
+## 관련 문서
+
+- [Plugin Recipes](/zntc/guides/plugin-recipes/) — Vite plugin 과 함께 쓰는 PostCSS / Tailwind / SVG / GraphQL 등 패턴.
+- [Web (standalone)](/zntc/guides/web-starter/) — Vite 없이 ZNTC 만으로 새 프로젝트 시작.

--- a/documents/src/content/docs/guides/web-starter.md
+++ b/documents/src/content/docs/guides/web-starter.md
@@ -1,0 +1,106 @@
+---
+title: Web (standalone)
+description: Vite / Rspack 없이 ZNTC 만으로 새 웹 프로젝트를 시작하는 방법입니다.
+---
+
+`zntc-init web` 은 기존 도구 없이 ZNTC 만으로 동작하는 새 웹 프로젝트를 빈 디렉토리에 scaffold 합니다. Vite / Rspack 위에 얹는 overlay 모드와 달리 starter 템플릿을 통째로 생성합니다.
+
+## 명령
+
+```bash
+# React 스타터 (기본)
+npx @zntc/init web --framework=react
+
+# Vanilla TS 스타터
+npx @zntc/init web --framework=vanilla
+```
+
+옵션:
+
+| 옵션                       | 설명                                                            |
+| -------------------------- | --------------------------------------------------------------- |
+| `--name <pkg-name>`        | `package.json` 의 `name` 필드. 기본값: 디렉토리 이름.            |
+| `--framework <react\|vanilla>` | 스타터 템플릿. 기본값: `react`.                              |
+| `--root <dir>`             | 프로젝트 루트. 기본값: 현재 디렉터리.                            |
+| `--zntc-version <range>`   | `@zntc/*` 패키지 버전 범위. 기본값: `latest`.                    |
+| `--force`                  | 기존 파일 덮어쓰기.                                              |
+
+## 산출물
+
+### React 템플릿
+
+```text
+my-app/
+├── index.html              # <div id="root"> + <script type="module" src="/src/main.tsx">
+├── package.json            # react@^19, react-dom@^19, @zntc/core, typescript
+├── tsconfig.json           # jsx: react-jsx, strict, isolatedModules, moduleResolution: Bundler
+├── zntc.config.ts          # defineConfig: entryPoints / outdir / platform=browser / target=es2022 / jsx=automatic / sourcemap
+└── src/
+    ├── main.tsx            # createRoot(...).render(<App />)
+    └── App.tsx
+```
+
+생성된 `zntc.config.ts`:
+
+```ts
+import { defineConfig } from "@zntc/core";
+
+export default defineConfig({
+  entryPoints: ["src/main.tsx"],
+  outdir: "dist",
+  format: "esm",
+  platform: "browser",
+  target: "es2022",
+  jsx: "automatic",
+  sourcemap: true,
+});
+```
+
+### Vanilla 템플릿
+
+```text
+my-app/
+├── index.html              # <div id="app"> + <script type="module" src="/src/main.ts">
+├── package.json            # @zntc/core + typescript 만
+├── tsconfig.json           # strict, isolatedModules — JSX 미사용
+├── zntc.config.ts          # entryPoints: ["src/main.ts"]
+└── src/
+    └── main.ts
+```
+
+## 개발 명령
+
+자동 생성된 `package.json` 의 scripts:
+
+```jsonc
+{
+  "scripts": {
+    "dev": "zntc dev",
+    "build": "zntc build",
+    "preview": "zntc preview"
+  }
+}
+```
+
+```bash
+# init 출력 힌트의 패키지 매니저 (bun / npm / pnpm / yarn) 사용
+bun install
+bun run dev          # ZNTC dev server (HMR)
+bun run build        # 프로덕션 번들 dist/
+bun run preview      # dist/ 미리보기
+```
+
+## 언제 web 모드를 쓸까
+
+| 상황                                       | 권장 모드                                                  |
+| ------------------------------------------ | ---------------------------------------------------------- |
+| 새 프로젝트 시작 (도구 선택 없음)          | **`zntc-init web`** — ZNTC 만으로 동작.                     |
+| 기존 Vite 프로젝트가 있음                  | [`zntc-init vite`](/zntc/guides/vite/)                      |
+| 기존 Rspack / Webpack 프로젝트가 있음      | [`zntc-init rspack`](/zntc/guides/rspack/)                  |
+| 기존 React Native CLI 프로젝트가 있음      | [`zntc-init react-native`](/zntc/guides/react-native/)      |
+
+## 관련 문서
+
+- [Dev Server](/zntc/guides/dev-server/) — `zntc dev` 의 SSE / MCP / Live Reload 동작.
+- [Config File](/zntc/guides/config-file/) — `zntc.config.ts` 의 전체 옵션과 함수형 config.
+- [Plugin Recipes](/zntc/guides/plugin-recipes/) — CSS / PostCSS / Tailwind / SVG 같은 자주 쓰는 plugin 패턴.


### PR DESCRIPTION
## Summary

이전 PR #3032 의 후속. RN 가이드의 `zntc-init` 도움말만 동기화하고 vite/rspack/web 모드는 별도 PR 로 분리하기로 했습니다. 세 모드 모두 Electron / RN 가이드와 동일한 형태로 별도 페이지를 추가합니다.

## 페이지

### `guides/vite` (KO/EN)

`zntc-init vite` — 기존 Vite 프로젝트에서 esbuild transform 을 `@zntc/vite-plugin` 으로 교체. 자동 생성 config (`plugins: [zntc()]`, `esbuild: false`), 수동 패치 시 `esbuild: false` 강제 이유, Vite vs ZNTC 자체 dev server 선택 기준, `vitePlugin wrapper` 가 attach 하는 hook 5개 (`resolveId` / `load` / `transform` / `renderChunk` / `generateBundle`) 정리.

### `guides/rspack` (KO/EN)

`zntc-init rspack` — `@rspack/core` / `webpack` 자동 감지 (`--bundler` 강제), `@zntc/rspack-loader` 로 `swc-loader` / `babel-loader` 자리 교체. 기존 [`@zntc/rspack-loader` reference](`guides/rspack-loader.md`) 와 분담 — 이 페이지는 init 워크플로우, 기존 페이지는 loader 옵션 reference.

### `guides/web-starter` (KO/EN)

`zntc-init web` — Vite / Rspack 없이 ZNTC 만으로 새 프로젝트 scaffold. React (`^19`) 와 Vanilla 두 템플릿 별 산출 파일 트리, 자동 생성 `zntc.config.ts` 예제, dev 스크립트, 다른 init 모드와의 선택 기준 표.

## 사이드바 재정렬

"레시피" 그룹 순서:

```
Dev Server (SSE/MCP)
Electron
Vite                  ── 신규
Rspack / Webpack      ── 신규
Web (standalone)      ── 신규
React Native
React Native + Expo
Flow Support
```

`@zntc/init` 4개 모드 (`react-native` / `vite` / `rspack` / `web`) 가 모두 사이드바에서 1:1 로 가이드를 갖게 됩니다.

## 출처

- 도움말 텍스트: `packages/init/src/cli.ts:21-48` 그대로 인용 (이전 PR 과 일관).
- vite 자동 생성 config: `packages/init/src/vite.ts:42-52` (`createViteConfig`).
- rspack/webpack 자동 생성 config: `packages/init/src/rspack.ts:49-70` (`createRspackConfig`).
- web 스타터: `packages/init/src/web.ts:60-126` (`createPackageJson` / `createTsconfig` / `createZntcConfig`) 의 실제 출력.

## Test plan

- [x] `bun run build` 통과 (491 페이지, +6 — KO/EN × 3 신규)
- [x] starlight-links-validator 통과
- [x] `dist/guides/{vite,rspack,web-starter}/` 및 EN 6개 산출물 모두 생성 확인
- [ ] 배포 후 사이드바 "레시피" 그룹이 8개 항목 KO/EN 모두 노출 / 새 페이지의 코드 예제가 init 실제 출력과 일치하는지 육안 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)