### PR TITLE
docs(site): 10/1000/5000 modules 벤치마크 재측정 + bench.ts fixture 개선

### DIFF
--- a/documents/src/content/docs/en/index.mdx
+++ b/documents/src/content/docs/en/index.mdx
@@ -66,30 +66,29 @@ const { code } = await transpile({
     <div class="mt-6 grid gap-4 text-sm sm:grid-cols-3">
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
         <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">small (10 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">2.56 ms</strong></div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">3.20 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1st)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs Bun 5.38 · esbuild 6.16 · rolldown 47.8 · rspack 51.6 · webpack 183 ms
+          vs Bun 6.38 · esbuild 8.45 · rolldown 50.6 · rspack 57.5 · webpack 464 ms
         </div>
       </div>
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
-        <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">medium (50 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">4.0 ms</strong></div>
+        <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">medium (1000 modules)</div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">29.3 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(3rd)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs Bun 6.0 · esbuild 7.0 · rolldown 51.2 · rspack 55.2 · webpack 184 ms
+          vs Bun 19.5 · esbuild 24.4 · rolldown 67.7 · rspack 83.6 · webpack 1865 ms
         </div>
       </div>
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
-        <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">large (200 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">8.12 ms</strong></div>
+        <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">large (5000 modules)</div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">140 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(4th)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs Bun 8.29 · esbuild 10.0 · rolldown 55.3 ms
+          vs Bun 65 · esbuild 86.7 · rolldown 124 · rspack 180 · webpack 19908 ms
         </div>
       </div>
     </div>
 
     <p class="mt-6 text-center text-xs text-[color:var(--sl-color-gray-3)]">
-      2026-05-06 · darwin arm64 · 5-run median ·
-      <a href="/zntc/en/reference/benchmarks/" class="ml-1 text-zig-400 hover:underline">Full benchmarks →</a>
+      2026-05-11 · darwin arm64 · 5-run median · fan-out tree fixture (see <a href="/zntc/en/reference/benchmarks/" class="text-zig-400 hover:underline">full benchmarks →</a>)
     </p>
   </div>
 </Section>

--- a/documents/src/content/docs/index.mdx
+++ b/documents/src/content/docs/index.mdx
@@ -66,30 +66,29 @@ const { code } = await transpile({
     <div class="mt-6 grid gap-4 text-sm sm:grid-cols-3">
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
         <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">small (10 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">2.56 ms</strong></div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">3.20 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1위)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs Bun 5.38 · esbuild 6.16 · rolldown 47.8 · rspack 51.6 · webpack 183 ms
+          vs Bun 6.38 · esbuild 8.45 · rolldown 50.6 · rspack 57.5 · webpack 464 ms
         </div>
       </div>
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
-        <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">medium (50 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">4.0 ms</strong></div>
+        <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">medium (1000 modules)</div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">29.3 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(3위)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs Bun 6.0 · esbuild 7.0 · rolldown 51.2 · rspack 55.2 · webpack 184 ms
+          vs Bun 19.5 · esbuild 24.4 · rolldown 67.7 · rspack 83.6 · webpack 1865 ms
         </div>
       </div>
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
-        <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">large (200 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">8.12 ms</strong></div>
+        <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">large (5000 modules)</div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">140 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(4위)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs Bun 8.29 · esbuild 10.0 · rolldown 55.3 ms
+          vs Bun 65 · esbuild 86.7 · rolldown 124 · rspack 180 · webpack 19908 ms
         </div>
       </div>
     </div>
 
     <p class="mt-6 text-center text-xs text-[color:var(--sl-color-gray-3)]">
-      2026-05-06 · darwin arm64 · 5회 median ·
-      <a href="/zntc/reference/benchmarks/" class="ml-1 text-zig-400 hover:underline">전체 벤치마크 →</a>
+      2026-05-11 · darwin arm64 · 5회 median · fan-out tree fixture (자세히는 <a href="/zntc/reference/benchmarks/" class="text-zig-400 hover:underline">전체 벤치마크 →</a>)
     </p>
   </div>
 </Section>

--- a/documents/src/data/benchmark-data.json
+++ b/documents/src/data/benchmark-data.json
@@ -28,24 +28,26 @@
       { "tool": "SWC", "scale": "large (5K lines)", "medianMs": 56.2, "minMs": 55.9, "maxMs": 56.4, "p95Ms": 56.3 }
     ],
     "bundleCli": [
-      { "tool": "ZNTC", "scale": "small (10 modules)", "medianMs": 2.56, "minMs": 2.4, "maxMs": 2.57, "p95Ms": 2.57 },
-      { "tool": "Bun", "scale": "small (10 modules)", "medianMs": 5.38, "minMs": 5.27, "maxMs": 5.44, "p95Ms": 5.43 },
-      { "tool": "esbuild", "scale": "small (10 modules)", "medianMs": 6.16, "minMs": 6.03, "maxMs": 6.32, "p95Ms": 6.31 },
-      { "tool": "rolldown", "scale": "small (10 modules)", "medianMs": 47.8, "minMs": 47.6, "maxMs": 49.1, "p95Ms": 49.0 },
-      { "tool": "rspack", "scale": "small (10 modules)", "medianMs": 51.6, "minMs": 51.0, "maxMs": 60.1, "p95Ms": 59.7 },
-      { "tool": "webpack", "scale": "small (10 modules)", "medianMs": 183, "minMs": 183, "maxMs": 184, "p95Ms": 184 },
+      { "tool": "ZNTC", "scale": "small (10 modules)", "medianMs": 3.2, "minMs": 2.95, "maxMs": 3.29, "p95Ms": 3.29 },
+      { "tool": "Bun", "scale": "small (10 modules)", "medianMs": 6.38, "minMs": 6.13, "maxMs": 6.62, "p95Ms": 6.58 },
+      { "tool": "esbuild", "scale": "small (10 modules)", "medianMs": 8.45, "minMs": 8.22, "maxMs": 9.5, "p95Ms": 9.33 },
+      { "tool": "rolldown", "scale": "small (10 modules)", "medianMs": 50.6, "minMs": 48.9, "maxMs": 52.3, "p95Ms": 52.3 },
+      { "tool": "rspack", "scale": "small (10 modules)", "medianMs": 57.5, "minMs": 57.3, "maxMs": 59.3, "p95Ms": 59.1 },
+      { "tool": "webpack", "scale": "small (10 modules)", "medianMs": 464, "minMs": 461, "maxMs": 472, "p95Ms": 471 },
 
-      { "tool": "ZNTC", "scale": "medium (50 modules)", "medianMs": 4.0, "minMs": 3.76, "maxMs": 4.05, "p95Ms": 4.04 },
-      { "tool": "Bun", "scale": "medium (50 modules)", "medianMs": 6.0, "minMs": 5.88, "maxMs": 6.18, "p95Ms": 6.15 },
-      { "tool": "esbuild", "scale": "medium (50 modules)", "medianMs": 7.0, "minMs": 6.9, "maxMs": 7.06, "p95Ms": 7.05 },
-      { "tool": "rolldown", "scale": "medium (50 modules)", "medianMs": 51.2, "minMs": 48.4, "maxMs": 52.3, "p95Ms": 52.2 },
-      { "tool": "rspack", "scale": "medium (50 modules)", "medianMs": 55.2, "minMs": 54.5, "maxMs": 55.9, "p95Ms": 55.8 },
-      { "tool": "webpack", "scale": "medium (50 modules)", "medianMs": 184, "minMs": 183, "maxMs": 185, "p95Ms": 184 },
+      { "tool": "ZNTC", "scale": "medium (1000 modules)", "medianMs": 29.3, "minMs": 28.2, "maxMs": 30.5, "p95Ms": 30.3 },
+      { "tool": "Bun", "scale": "medium (1000 modules)", "medianMs": 19.5, "minMs": 18.4, "maxMs": 19.8, "p95Ms": 19.8 },
+      { "tool": "esbuild", "scale": "medium (1000 modules)", "medianMs": 24.4, "minMs": 23.8, "maxMs": 25.0, "p95Ms": 24.9 },
+      { "tool": "rolldown", "scale": "medium (1000 modules)", "medianMs": 67.7, "minMs": 65.5, "maxMs": 70.6, "p95Ms": 70.1 },
+      { "tool": "rspack", "scale": "medium (1000 modules)", "medianMs": 83.6, "minMs": 81.5, "maxMs": 84.9, "p95Ms": 84.8 },
+      { "tool": "webpack", "scale": "medium (1000 modules)", "medianMs": 1865, "minMs": 1747, "maxMs": 1918, "p95Ms": 1917 },
 
-      { "tool": "ZNTC", "scale": "large (200 modules)", "medianMs": 8.12, "minMs": 7.96, "maxMs": 8.22, "p95Ms": 8.22 },
-      { "tool": "Bun", "scale": "large (200 modules)", "medianMs": 8.29, "minMs": 8.17, "maxMs": 8.45, "p95Ms": 8.43 },
-      { "tool": "esbuild", "scale": "large (200 modules)", "medianMs": 10.0, "minMs": 9.97, "maxMs": 10.2, "p95Ms": 10.2 },
-      { "tool": "rolldown", "scale": "large (200 modules)", "medianMs": 55.3, "minMs": 54.4, "maxMs": 56.1, "p95Ms": 56.1 }
+      { "tool": "ZNTC", "scale": "large (5000 modules)", "medianMs": 140, "minMs": 139, "maxMs": 142, "p95Ms": 142 },
+      { "tool": "Bun", "scale": "large (5000 modules)", "medianMs": 65.0, "minMs": 57.6, "maxMs": 71.9, "p95Ms": 71.7 },
+      { "tool": "esbuild", "scale": "large (5000 modules)", "medianMs": 86.7, "minMs": 86.6, "maxMs": 88.1, "p95Ms": 88.0 },
+      { "tool": "rolldown", "scale": "large (5000 modules)", "medianMs": 124, "minMs": 123, "maxMs": 127, "p95Ms": 127 },
+      { "tool": "rspack", "scale": "large (5000 modules)", "medianMs": 180, "minMs": 170, "maxMs": 228, "p95Ms": 219 },
+      { "tool": "webpack", "scale": "large (5000 modules)", "medianMs": 19908, "minMs": 19895, "maxMs": 20255, "p95Ms": 20197 }
     ],
     "napiWasmCli": [
       { "tool": "NAPI (.node)", "scale": "small (100 lines)", "medianMs": 0.335, "minMs": 0.324, "maxMs": 0.369, "p95Ms": 0.368 },

--- a/tests/benchmark/bench.ts
+++ b/tests/benchmark/bench.ts
@@ -7,7 +7,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, existsSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { computeMetricStats, formatMetric, type MetricStats } from './stats';
@@ -52,19 +52,33 @@ function generateHelper(): string {
 function generateProject(dir: string, fileCount: number) {
   mkdirSync(join(dir, 'src'), { recursive: true });
 
-  for (let i = 0; i < fileCount - 1; i++) {
-    writeFileSync(
-      join(dir, 'src', `mod${i}.ts`),
-      `export const val${i} = ${i};\nexport function fn${i}(x: number) { return x + ${i}; }\n`,
-    );
+  // Fan-out tree: mod_i imports mod_{i*5+1} … mod_{i*5+5} (if in range).
+  // entry → mod0 → 자연스럽게 fileCount 모듈 fan-out. 일반 코드 패턴 (parent
+  // imports children) 에 가깝고, 한 파일의 import / statement 개수가 fan-out
+  // (5) 으로 제한돼 webpack/rspack 의 거대 entry 한계를 피함.
+  const fanOut = 5;
+  for (let i = 0; i < fileCount; i++) {
+    const childStart = i * fanOut + 1;
+    const childEnd = Math.min(childStart + fanOut, fileCount);
+    const childIndices: number[] = [];
+    for (let c = childStart; c < childEnd; c++) childIndices.push(c);
+    const importLines = childIndices
+      .map((c) => `import { val${c}, fn${c} } from './mod${c}';`)
+      .join('\n');
+    const sumExpr = childIndices.length
+      ? ' + ' + childIndices.map((c) => `fn${c}(val${c})`).join(' + ')
+      : '';
+    const body =
+      (importLines ? `${importLines}\n` : '') +
+      `export const val${i} = ${i};\n` +
+      `export function fn${i}(x: number): number { return x + ${i}${sumExpr}; }\n`;
+    writeFileSync(join(dir, 'src', `mod${i}.ts`), body);
   }
 
-  const imports = Array.from(
-    { length: fileCount - 1 },
-    (_, i) => `import { val${i}, fn${i} } from './mod${i}';`,
-  ).join('\n');
-  const usage = Array.from({ length: fileCount - 1 }, (_, i) => `fn${i}(val${i})`).join(' + ');
-  writeFileSync(join(dir, 'src', 'index.ts'), `${imports}\nconsole.log(${usage});\n`);
+  writeFileSync(
+    join(dir, 'src', 'index.ts'),
+    `import { val0, fn0 } from './mod0';\nconsole.log(fn0(val0));\n`,
+  );
 
   writeFileSync(
     join(dir, 'tsconfig.json'),
@@ -119,7 +133,7 @@ function runBench(name: string, task: string, scale: string, fn: () => void): Be
 }
 
 function execBin(bin: string, args: string[], cwd?: string) {
-  spawnSync(bin, args, { cwd, stdio: 'pipe', timeout: 120000 });
+  spawnSync(bin, args, { cwd, stdio: 'pipe', timeout: 600000 });
 }
 
 // ============================================================
@@ -203,8 +217,8 @@ function benchBundle(): BenchResult[] {
   const results: BenchResult[] = [];
   const scales = [
     { name: 'small (10 modules)', files: 10 },
-    { name: 'medium (50 modules)', files: 50 },
-    { name: 'large (200 modules)', files: 200 },
+    { name: 'medium (1000 modules)', files: 1000 },
+    { name: 'large (5000 modules)', files: 5000 },
   ];
 
   const esbuildBin = findBin('esbuild');
@@ -212,12 +226,22 @@ function benchBundle(): BenchResult[] {
   const webpackBin = findBin('webpack');
   const rspackBin = findBin('rspack');
 
+  const benchModules = join(__dirname, 'node_modules');
+
   for (const scale of scales) {
     const dir = mkdtempSync(join(tmpdir(), 'zntc-bench-bundle-'));
     generateProject(dir, scale.files);
     const entry = join(dir, 'src', 'index.ts');
     const outDir = join(dir, 'dist');
     mkdirSync(outDir, { recursive: true });
+
+    // webpack / rspack 의 ts-loader · swc-loader resolution 을 위해
+    // fixture 디렉토리에 tests/benchmark/node_modules 를 symlink.
+    try {
+      symlinkSync(benchModules, join(dir, 'node_modules'), 'dir');
+    } catch {
+      // 이미 있으면 무시.
+    }
 
     console.log(`\n--- Bundle: ${scale.name} ---`);
 
@@ -255,43 +279,43 @@ function benchBundle(): BenchResult[] {
       );
     }
 
-    // webpack/rspack은 large 제외 (느려서)
-    if (scale.files <= 50) {
-      if (webpackBin) {
-        const config = join(dir, 'webpack.config.js');
-        writeFileSync(
-          config,
-          `module.exports = {
+    // webpack / rspack — 큰 스케일에서는 시간이 길어지지만 사용자 요청으로
+    // 전 스케일에서 측정. timeout 안에 못 끝나면 FAIL 로 노출.
+    if (webpackBin) {
+      const config = join(dir, 'webpack.config.js');
+      writeFileSync(
+        config,
+        `module.exports = {
   mode: 'production', entry: '${entry}',
   output: { path: '${outDir}', filename: 'webpack.js' },
   resolve: { extensions: ['.ts', '.js'] },
+  resolveLoader: { modules: ['${benchModules}'] },
   module: { rules: [{ test: /\\.ts$/, use: 'ts-loader', exclude: /node_modules/ }] },
 };`,
-        );
-        results.push(
-          runBench('webpack', 'bundle', scale.name, () => {
-            execBin(webpackBin, ['--config', config], dir);
-          }),
-        );
-      }
+      );
+      results.push(
+        runBench('webpack', 'bundle', scale.name, () => {
+          execBin(webpackBin, ['--config', config], dir);
+        }),
+      );
+    }
 
-      if (rspackBin) {
-        const config = join(dir, 'rspack.config.js');
-        writeFileSync(
-          config,
-          `module.exports = {
+    if (rspackBin) {
+      const config = join(dir, 'rspack.config.js');
+      writeFileSync(
+        config,
+        `module.exports = {
   mode: 'production', entry: '${entry}',
   output: { path: '${outDir}', filename: 'rspack.js' },
   resolve: { extensions: ['.ts', '.js'] },
   module: { rules: [{ test: /\\.ts$/, type: 'javascript/auto', use: { loader: 'builtin:swc-loader', options: { jsc: { parser: { syntax: 'typescript' } } } } }] },
 };`,
-        );
-        results.push(
-          runBench('rspack', 'bundle', scale.name, () => {
-            execBin(rspackBin, ['build', '--config', config], dir);
-          }),
-        );
-      }
+      );
+      results.push(
+        runBench('rspack', 'bundle', scale.name, () => {
+          execBin(rspackBin, ['build', '--config', config], dir);
+        }),
+      );
     }
 
     rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

사용자 지적 — `https://ohah.github.io/zntc/` 메인 페이지 large (200 modules) 카드에 webpack / rspack 이 빠져 있었고, 작은 스케일에서는 시작 오버헤드가 dominate 해 도구 간 의미 있는 비교가 어려웠습니다. 스케일을 10/1000/5000 로 확장하고 bench.ts 자체의 시고단 두 가지를 같이 잡아 재측정.

## bench.ts 변경

1. **Scales** — `small(10)/medium(50)/large(200)` → `small(10)/medium(1000)/large(5000)`.
2. **Fixture** — flat fan-out (`fn0(val0)+fn1(val1)+...` 5000-arity binary chain) → fan-out tree (parent 가 5개 자식 import).
   - 이전 fixture 는 5000 modules 시:
     - webpack `JavascriptParser.walkBinaryExpression` 재귀로 **Maximum call stack size exceeded**.
     - ts-loader **TS2563 module body too large for control flow analysis**.
     - rspack swc-loader **segfault (exit 132)**.
   - 새 fan-out tree fixture 는 6개 도구 모두 build 통과 검증.
3. **Loader resolution** — webpack/rspack 의 ts-loader / swc-loader resolution 실패로 인한 silent fail 을 fix. fixture dir 에 `tests/benchmark/node_modules` 를 symlink + webpack `resolveLoader.modules` 명시. 이전 측정값 (webpack 183ms 평탄) 은 실은 build 실패 후 종료 시간.
4. **Timeout** — 120s → 600s (5000 modules webpack ~20s build 안전 마진).
5. **webpack/rspack large 제외 조건 제거** — `scale.files <= 50` 게이트 삭제, 모든 스케일에서 6개 도구 측정.

## 측정 결과 (2026-05-11 · darwin arm64 · ReleaseFast · 5회 median)

| Scale | 1위 | 2위 | 3위 | 4위 | 5위 | 6위 |
|---|---|---|---|---|---|---|
| small (10) | **ZNTC 3.20** | Bun 6.38 | esbuild 8.45 | rolldown 50.6 | rspack 57.5 | webpack 464 |
| medium (1000) | Bun 19.5 | esbuild 24.4 | **ZNTC 29.3** | rolldown 67.7 | rspack 83.6 | webpack 1865 |
| large (5000) | Bun 65 | esbuild 86.7 | rolldown 124 | **ZNTC 140** | rspack 180 | webpack 19908 |

ZNTC 는 시작 오버헤드 (~3ms) 가 작아 작은 빌드 dominant, 큰 스케일에서는 Bun/esbuild 와 경쟁. 사용자가 "정직하게 모두 노출" 결정 → 메인 카드 3개 모두 ZNTC 수치 + 순위 라벨 (1/3/4위) + vs 라인에 6개 도구 모두 표기.

## Root cause 분석 (resolve.realpath bottleneck)

`--profile=resolve --profile-level=detailed` 결과:

| Sub-phase | Self | % | Count | Per-call |
|---|---|---|---|---|
| **resolve.realpath** | **3107 ms** | **38.2%** | 4915 | 0.63 ms |
| resolve.extensions | 1629 ms | 20.0% | 4881 | 0.33 ms |
| resolve.resolver | 1645 ms | 20.2% | 4892 | — |

`src/bundler/resolver.zig:665` 의 `makeResult` 가 모듈마다 `fs.realpath()` syscall 을 호출하는데 **결과 캐시 없음**. 같은 디렉토리의 5000 파일도 5000회 syscall. directory-level realpath 캐시 도입 시 5000 modules 가 **140ms → ~75ms** 로 줄어 Bun (65ms) · esbuild (87ms) 와 동급 예상 — **별도 후속 PR 로 분리**.

## 변경 파일

- `tests/benchmark/bench.ts` — 측정 코드 (사용자 요청으로 같이 포함).
- `documents/src/data/benchmark-data.json` — bundleCli 18 entry 교체.
- `documents/src/content/docs/index.mdx` + `en/index.mdx` — 카드 라벨 (10/1000/5000) · 수치 · vs 라인 · 순위 라벨 · 측정 날짜 (2026-05-06 → 2026-05-11) 동기화.

## Test plan

- [x] `bun run build` 통과 (491 페이지)
- [x] starlight-links-validator 통과
- [x] bench.ts 새 fixture 가 6개 도구 모두 5000 modules build 통과 검증
- [x] profile 모드로 resolve.realpath bottleneck 확인 (root cause)
- [ ] 배포 후 메인 카드의 새 수치 / 1·3·4위 라벨 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)