### PR TITLE
perf(fs): pm.setup.read.close profile scope 분리 + bottleneck 분석

### DIFF
--- a/src/bundler/fs.zig
+++ b/src/bundler/fs.zig
@@ -147,7 +147,11 @@ pub const RealReadFileCache = struct {
             defer scope.end();
             break :blk self.openFile(cache_allocator, path) catch |err| return mapFsError(err);
         };
-        defer file.close();
+        defer {
+            var close_scope = profile.begin(.graph_discover_pm_setup_read_close);
+            defer close_scope.end();
+            file.close();
+        }
 
         const stat = blk: {
             var scope = profile.begin(.graph_discover_pm_setup_read_stat);

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -83,6 +83,7 @@ pub const Category = enum {
     graph_discover_pm_setup_read_open,
     graph_discover_pm_setup_read_stat,
     graph_discover_pm_setup_read_bytes,
+    graph_discover_pm_setup_read_close,
     graph_discover_pm_setup_parser,
     graph_discover_pm_parse,
     graph_discover_pm_semantic,


### PR DESCRIPTION
## Summary

PR #3039 (realpath cache) 후속 분석. fix 이후 ZNTC 5000 modules 가 81.1 ms — Bun (63.6 ms) 과 17.5 ms 차이. 그 정체를 좁히기 위해 `RealReadFileCache.readFileWithStat` 의 `defer file.close()` 를 explicit profile scope 로 분리했습니다. 이번 PR 은 **observability 만 개선** — 측정 결과 단순 fix 가 없음을 documented.

## 측정 (5000 modules · fan-out tree · warm cache · ReleaseFast)

| Sub-phase | Self time | Count | Per-call |
|---|---|---|---|
| `read.with.stat` (outer) | 474 ms | 4832 | — |
| **`read.open`** | **472 ms** | 4931 | **0.096 ms** |
| `read.close` (신규) | 8.6 ms | 4904 | 0.0018 ms |
| `read.stat` | 8.3 ms | 4971 | 0.0017 ms |
| `read.bytes` | 24.6 ms | 4979 | 0.0049 ms |

`close` 가 8.6 ms 만 차지하므로 "close 가 1832 ms 의 정체" 라는 이전 가설은 틀림. 이전 측정의 `read.with.stat self 1832 ms` 는 **cold-disk I/O 노이즈** — warm 재측정에서 474 ms.

## 결론

- ZNTC vs Bun 의 ~17.5 ms 차이의 핵심은 **`openat` syscall 자체 비용** (warm 472 ms profile self → 실측 환산 ~25 ms).
- dir-fd cache + openat 패턴은 `fs.zig:185-205` 의 `RealReadFileCache.openFile` 에 이미 적용. **추가 simple fix 없음** (kernel namei lookup 비용).
- 추가 절감 후보 (모두 위험 / 대형 변경):
  - mmap I/O (작은 파일에서 효과 불확실)
  - parser SIMD 확장 (parse 12 ms 추정 → 6-8 ms)
  - worker pool scaling (CPU core 활용)

## 변경 파일

- `src/profile.zig` — `graph_discover_pm_setup_read_close` enum 추가.
- `src/bundler/fs.zig` — `defer file.close()` 를 explicit profile scope 로 변경. close syscall 비용을 측정 가능하게.

## Test plan

- [x] `zig build -Doptimize=ReleaseFast` 통과
- [x] `zig build test` 유닛 테스트 통과
- [x] 5000-module profile 로 close 비중 확인 (8.6 ms)
- [x] 이전 1832 ms 가 cold-disk 노이즈 였음을 warm 재측정으로 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)