### PR TITLE
perf(fs): fresh build fstat 생략 + dir-fd cache 통일 + webpack 비교 제외

### DIFF
--- a/documents/src/content/docs/en/index.mdx
+++ b/documents/src/content/docs/en/index.mdx
@@ -66,23 +66,23 @@ const { code } = await transpile({
     <div class="mt-6 grid gap-4 text-sm sm:grid-cols-3">
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
         <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">small (10 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">2.98 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1st)</span></div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">3.00 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1st)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs Bun 6.37 · esbuild 8.36 · rolldown 49.3 · rspack 58.7 · webpack 460 ms
+          vs Bun 6.68 · esbuild 8.84 · rolldown 50.5 · rspack 58.8 ms
         </div>
       </div>
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
         <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">medium (1000 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">17.9 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1st)</span></div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">17.5 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1st)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs Bun 19.7 · esbuild 23.9 · rolldown 66.8 · rspack 83.7 · webpack 1765 ms
+          vs Bun 20.2 · esbuild 23.9 · rolldown 67.8 · rspack 84.2 ms
         </div>
       </div>
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
         <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">large (5000 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">81.1 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(2nd)</span></div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">80.7 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(2nd)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs Bun 63.6 · esbuild 86.7 · rolldown 125 · rspack 180 · webpack 19880 ms
+          vs Bun 67.6 · esbuild 86.1 · rolldown 145 · rspack 211 ms
         </div>
       </div>
     </div>

--- a/documents/src/content/docs/index.mdx
+++ b/documents/src/content/docs/index.mdx
@@ -66,23 +66,23 @@ const { code } = await transpile({
     <div class="mt-6 grid gap-4 text-sm sm:grid-cols-3">
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
         <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">small (10 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">2.98 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1위)</span></div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">3.00 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1위)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs Bun 6.37 · esbuild 8.36 · rolldown 49.3 · rspack 58.7 · webpack 460 ms
+          vs Bun 6.68 · esbuild 8.84 · rolldown 50.5 · rspack 58.8 ms
         </div>
       </div>
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
         <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">medium (1000 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">17.9 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1위)</span></div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">17.5 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1위)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs Bun 19.7 · esbuild 23.9 · rolldown 66.8 · rspack 83.7 · webpack 1765 ms
+          vs Bun 20.2 · esbuild 23.9 · rolldown 67.8 · rspack 84.2 ms
         </div>
       </div>
       <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
         <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">large (5000 modules)</div>
-        <div class="font-mono text-lg"><strong class="text-zig-400">81.1 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(2위)</span></div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">80.7 ms</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(2위)</span></div>
         <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
-          vs Bun 63.6 · esbuild 86.7 · rolldown 125 · rspack 180 · webpack 19880 ms
+          vs Bun 67.6 · esbuild 86.1 · rolldown 145 · rspack 211 ms
         </div>
       </div>
     </div>

--- a/documents/src/data/benchmark-data.json
+++ b/documents/src/data/benchmark-data.json
@@ -28,26 +28,23 @@
       { "tool": "SWC", "scale": "large (5K lines)", "medianMs": 56.2, "minMs": 55.9, "maxMs": 56.4, "p95Ms": 56.3 }
     ],
     "bundleCli": [
-      { "tool": "ZNTC", "scale": "small (10 modules)", "medianMs": 2.98, "minMs": 2.6, "maxMs": 4.04, "p95Ms": 3.85 },
-      { "tool": "Bun", "scale": "small (10 modules)", "medianMs": 6.37, "minMs": 6.01, "maxMs": 6.69, "p95Ms": 6.68 },
-      { "tool": "esbuild", "scale": "small (10 modules)", "medianMs": 8.36, "minMs": 8.2, "maxMs": 9.18, "p95Ms": 9.02 },
-      { "tool": "rolldown", "scale": "small (10 modules)", "medianMs": 49.3, "minMs": 48.5, "maxMs": 49.8, "p95Ms": 49.7 },
-      { "tool": "rspack", "scale": "small (10 modules)", "medianMs": 58.7, "minMs": 56.7, "maxMs": 58.8, "p95Ms": 58.8 },
-      { "tool": "webpack", "scale": "small (10 modules)", "medianMs": 460, "minMs": 459, "maxMs": 460, "p95Ms": 460 },
+      { "tool": "ZNTC", "scale": "small (10 modules)", "medianMs": 3.0, "minMs": 2.87, "maxMs": 3.49, "p95Ms": 3.43 },
+      { "tool": "Bun", "scale": "small (10 modules)", "medianMs": 6.68, "minMs": 6.39, "maxMs": 6.92, "p95Ms": 6.88 },
+      { "tool": "esbuild", "scale": "small (10 modules)", "medianMs": 8.84, "minMs": 8.23, "maxMs": 9.0, "p95Ms": 8.99 },
+      { "tool": "rolldown", "scale": "small (10 modules)", "medianMs": 50.5, "minMs": 48.9, "maxMs": 54.0, "p95Ms": 53.4 },
+      { "tool": "rspack", "scale": "small (10 modules)", "medianMs": 58.8, "minMs": 58.4, "maxMs": 58.9, "p95Ms": 58.9 },
 
-      { "tool": "ZNTC", "scale": "medium (1000 modules)", "medianMs": 17.9, "minMs": 17.6, "maxMs": 18.1, "p95Ms": 18.1 },
-      { "tool": "Bun", "scale": "medium (1000 modules)", "medianMs": 19.7, "minMs": 16.4, "maxMs": 21.0, "p95Ms": 20.7 },
-      { "tool": "esbuild", "scale": "medium (1000 modules)", "medianMs": 23.9, "minMs": 23.2, "maxMs": 24.2, "p95Ms": 24.1 },
-      { "tool": "rolldown", "scale": "medium (1000 modules)", "medianMs": 66.8, "minMs": 65.7, "maxMs": 67.8, "p95Ms": 67.6 },
-      { "tool": "rspack", "scale": "medium (1000 modules)", "medianMs": 83.7, "minMs": 82.4, "maxMs": 84.1, "p95Ms": 84.1 },
-      { "tool": "webpack", "scale": "medium (1000 modules)", "medianMs": 1765, "minMs": 1733, "maxMs": 1798, "p95Ms": 1793 },
+      { "tool": "ZNTC", "scale": "medium (1000 modules)", "medianMs": 17.5, "minMs": 17.2, "maxMs": 17.8, "p95Ms": 17.8 },
+      { "tool": "Bun", "scale": "medium (1000 modules)", "medianMs": 20.2, "minMs": 19.9, "maxMs": 21.0, "p95Ms": 20.9 },
+      { "tool": "esbuild", "scale": "medium (1000 modules)", "medianMs": 23.9, "minMs": 23.5, "maxMs": 24.1, "p95Ms": 24.1 },
+      { "tool": "rolldown", "scale": "medium (1000 modules)", "medianMs": 67.8, "minMs": 66.1, "maxMs": 68.8, "p95Ms": 68.7 },
+      { "tool": "rspack", "scale": "medium (1000 modules)", "medianMs": 84.2, "minMs": 84.0, "maxMs": 85.2, "p95Ms": 85.2 },
 
-      { "tool": "ZNTC", "scale": "large (5000 modules)", "medianMs": 81.1, "minMs": 79.7, "maxMs": 82.3, "p95Ms": 82.3 },
-      { "tool": "Bun", "scale": "large (5000 modules)", "medianMs": 63.6, "minMs": 58.7, "maxMs": 64.7, "p95Ms": 64.6 },
-      { "tool": "esbuild", "scale": "large (5000 modules)", "medianMs": 86.7, "minMs": 86.2, "maxMs": 87.7, "p95Ms": 87.7 },
-      { "tool": "rolldown", "scale": "large (5000 modules)", "medianMs": 125, "minMs": 121, "maxMs": 126, "p95Ms": 126 },
-      { "tool": "rspack", "scale": "large (5000 modules)", "medianMs": 180, "minMs": 177, "maxMs": 181, "p95Ms": 181 },
-      { "tool": "webpack", "scale": "large (5000 modules)", "medianMs": 19880, "minMs": 19764, "maxMs": 19969, "p95Ms": 19965 }
+      { "tool": "ZNTC", "scale": "large (5000 modules)", "medianMs": 80.7, "minMs": 78.8, "maxMs": 81.1, "p95Ms": 81.0 },
+      { "tool": "Bun", "scale": "large (5000 modules)", "medianMs": 67.6, "minMs": 63.7, "maxMs": 74.9, "p95Ms": 74.7 },
+      { "tool": "esbuild", "scale": "large (5000 modules)", "medianMs": 86.1, "minMs": 85.6, "maxMs": 86.6, "p95Ms": 86.5 },
+      { "tool": "rolldown", "scale": "large (5000 modules)", "medianMs": 145, "minMs": 143, "maxMs": 148, "p95Ms": 147 },
+      { "tool": "rspack", "scale": "large (5000 modules)", "medianMs": 211, "minMs": 192, "maxMs": 230, "p95Ms": 227 }
     ],
     "napiWasmCli": [
       { "tool": "NAPI (.node)", "scale": "small (100 lines)", "medianMs": 0.335, "minMs": 0.324, "maxMs": 0.369, "p95Ms": 0.368 },

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -833,6 +833,9 @@ pub const Bundler = struct {
         var graph_scope = profile.begin(.graph);
         var graph = ModuleGraph.init(self.allocator, self.getResolveCache());
         graph.dev_mode = self.options.dev_mode;
+        graph.incremental_mode = self.options.module_store != null or
+            self.options.changed_files != null or
+            self.options.compiled_cache != null;
         graph.inline_dynamic_imports = self.options.inline_dynamic_imports;
         // require.context 등 parser inline scan 의 build-time 정적 평가에 사용 (#1579 Phase 2.6)
         graph.defines = self.options.define;

--- a/src/bundler/fs.zig
+++ b/src/bundler/fs.zig
@@ -132,6 +132,43 @@ pub const RealReadFileCache = struct {
         self.dirs.deinit(allocator);
     }
 
+    /// stat 없는 read — fresh build path 에서 mtime 이 caller 없을 때 사용.
+    /// dir-fd cache (`openFile`) 는 그대로 활용해 path lookup 비용 절감.
+    /// 모듈당 syscall: open + read(+) + close (3+). readFileWithStat 대비 fstat
+    /// 1 syscall 절감 — 5000 modules 환경에서 측정 가능한 차이.
+    pub fn readFile(
+        self: *RealReadFileCache,
+        cache_allocator: std.mem.Allocator,
+        content_allocator: std.mem.Allocator,
+        path: []const u8,
+        max_bytes: usize,
+    ) FsError!LoadedModule {
+        const file = blk: {
+            var scope = profile.begin(.graph_discover_pm_setup_read_open);
+            defer scope.end();
+            break :blk self.openFile(cache_allocator, path) catch |err| return mapFsError(err);
+        };
+        defer {
+            var close_scope = profile.begin(.graph_discover_pm_setup_read_close);
+            defer close_scope.end();
+            file.close();
+        }
+
+        const bytes = blk: {
+            var scope = profile.begin(.graph_discover_pm_setup_read_bytes);
+            defer scope.end();
+            // size hint 없이 — readToEndAlloc 가 EOF 까지 dynamic grow. 일반 source
+            // 모듈 (< 8KB) 은 1회 read 안에 들어옴.
+            break :blk file.readToEndAlloc(content_allocator, max_bytes) catch |err| return mapFsError(err);
+        };
+
+        return .{
+            .contents = bytes,
+            .path = path,
+            .namespace = .file,
+        };
+    }
+
     pub fn readFileWithStat(
         self: *RealReadFileCache,
         cache_allocator: std.mem.Allocator,
@@ -212,6 +249,16 @@ pub const RealReadFileCache = struct {
 
 pub const VirtualReadFileCache = struct {
     pub fn deinit(_: *VirtualReadFileCache, _: std.mem.Allocator) void {}
+
+    pub fn readFile(
+        _: *VirtualReadFileCache,
+        _: std.mem.Allocator,
+        content_allocator: std.mem.Allocator,
+        path: []const u8,
+        max_bytes: usize,
+    ) FsError!LoadedModule {
+        return Implementation.init().readFile(content_allocator, path, max_bytes);
+    }
 
     pub fn readFileWithStat(
         _: *VirtualReadFileCache,

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -101,6 +101,12 @@ pub const ModuleGraph = struct {
     exec_counter: u32 = 0,
     cycle_counter: u32 = 0,
 
+    /// Incremental rebuild path 여부. bundler 가 `module_store` / `changed_files`
+    /// / `compiled_cache` 중 하나라도 주입한 경우 true — `readModuleSourceWithMtime`
+    /// 가 fstat 호출로 mtime 을 채워야 cache invalidation 이 동작. fresh build
+    /// (CLI / 첫 빌드 외부) 에서는 false — caller 자체가 없어 fstat 불필요.
+    /// 5000-module 합성 벤치에서 fstat ~5000 회 절감.
+    incremental_mode: bool = false,
     /// dev mode: HMR을 위해 모든 모듈을 강제 래핑 (__esm).
     dev_mode: bool = false,
     /// `output.inlineDynamicImports` 런타임 부분. true 면 dynamic-import target 모듈을

--- a/src/bundler/graph/loaders.zig
+++ b/src/bundler/graph/loaders.zig
@@ -173,8 +173,9 @@ pub fn parseAssetModule(self: *ModuleGraph, module: *Module) void {
     module.state = .ready;
 }
 
-/// fs.readFile + 실패 시 read_error diagnostic 추가 + module.state=ready 마킹.
-/// caller 는 `orelse return` 으로 함수 종료. 5+곳 중복 catch handler 통일.
+/// stat 없는 source read — dir-fd cache 경유 (path lookup 비용 절감) + EOF 까지
+/// dynamic grow read. mtime 이 필요한 caller (incremental rebuild) 가 없을 때만
+/// 사용 — 모듈당 fstat 1 syscall 절감.
 fn readModuleSource(
     self: *ModuleGraph,
     module: *Module,
@@ -185,7 +186,7 @@ fn readModuleSource(
     const loaded = blk: {
         var scope = profile.begin(.graph_discover_pm_setup_read_file);
         defer scope.end();
-        break :blk fs.readFile(alloc, module.path, max_bytes) catch {
+        break :blk self.source_read_cache.readFile(self.allocator, alloc, module.path, max_bytes) catch {
             self.addDiag(.read_error, .@"error", module.path, Span.EMPTY, step, "Cannot read file", null);
             module.state = .ready;
             return null;
@@ -202,6 +203,14 @@ pub fn readModuleSourceWithMtime(
     step: BundlerDiagnostic.Step,
 ) ?[]const u8 {
     if (module.mtime != 0) return readModuleSource(self, module, alloc, max_bytes, step);
+
+    // Fresh build (CLI / 첫 빌드): module_store / compiled_cache / changed_files 모두
+    // null 이므로 mtime 을 read 하는 caller 가 없다 — fstat 호출을 생략해 모듈당
+    // 1 syscall 절감. incremental rebuild 에서는 cache invalidation 이 mtime 에
+    // 의존하므로 stat 유지.
+    if (!self.incremental_mode) {
+        return readModuleSource(self, module, alloc, max_bytes, step);
+    }
 
     const loaded = self.source_read_cache.readFileWithStat(self.allocator, alloc, module.path, max_bytes) catch {
         self.addDiag(.read_error, .@"error", module.path, Span.EMPTY, step, "Cannot read file", null);

--- a/tests/benchmark/bench.ts
+++ b/tests/benchmark/bench.ts
@@ -223,7 +223,6 @@ function benchBundle(): BenchResult[] {
 
   const esbuildBin = findBin('esbuild');
   const rolldownBin = findBin('rolldown');
-  const webpackBin = findBin('webpack');
   const rspackBin = findBin('rspack');
 
   const benchModules = join(__dirname, 'node_modules');
@@ -279,27 +278,10 @@ function benchBundle(): BenchResult[] {
       );
     }
 
-    // webpack / rspack — 큰 스케일에서는 시간이 길어지지만 사용자 요청으로
-    // 전 스케일에서 측정. timeout 안에 못 끝나면 FAIL 로 노출.
-    if (webpackBin) {
-      const config = join(dir, 'webpack.config.js');
-      writeFileSync(
-        config,
-        `module.exports = {
-  mode: 'production', entry: '${entry}',
-  output: { path: '${outDir}', filename: 'webpack.js' },
-  resolve: { extensions: ['.ts', '.js'] },
-  resolveLoader: { modules: ['${benchModules}'] },
-  module: { rules: [{ test: /\\.ts$/, use: 'ts-loader', exclude: /node_modules/ }] },
-};`,
-      );
-      results.push(
-        runBench('webpack', 'bundle', scale.name, () => {
-          execBin(webpackBin, ['--config', config], dir);
-        }),
-      );
-    }
-
+    // rspack — webpack 은 사용자 요청으로 비교표에서 제외 (5000 modules 에서
+    // 19s+ 가 measurement run-time 을 비례적으로 늘려 측정 효율 저하 + 19s 의
+    // 대부분이 ts-loader 의 type-check 비용이라 ZNTC/Bun/esbuild 와 fair 한
+    // 비교가 아님).
     if (rspackBin) {
       const config = join(dir, 'rspack.config.js');
       writeFileSync(


### PR DESCRIPTION
## Summary

PR #3040 의 후속. fresh build path 가 `fs.readFile` (std `readFileAlloc`) 을 통해 dir-fd cache 를 우회하던 것을 발견, cache 메서드로 통일 + mtime caller 가 없는 fresh build 에서 `fstat` 생략. 사용자 요청에 따라 webpack 도 비교표에서 제외.

## 코드 변경

### `RealReadFileCache.readFile` 신규 (fs.zig)

`openFile()` (dir-fd cache) 경유 + stat 없이 `readToEndAlloc`. 모듈당 syscall: `openat + read(+) + close` (3+). `readFileWithStat` 대비 `fstat` 1 syscall 절감. profile points: `read.open` / `read.bytes` / `read.close` 그대로 측정.

### `ModuleGraph.incremental_mode` 필드 + 분기 (graph.zig / bundler.zig / loaders.zig)

`bundler.zig` 에서 `module_store` / `changed_files` / `compiled_cache` 중 하나라도 주입 시 `incremental_mode = true`. `readModuleSourceWithMtime` 가 incremental 아닌 경우 stat 없는 `readModuleSource` 로 분기. fresh build (CLI / 첫 빌드) 는 mtime 을 read 할 caller 가 없으므로 fstat 호출 자체 불필요.

### `readModuleSource` 가 cache 사용 (loaders.zig)

이전: `fs.readFile()` → `std.fs.cwd().readFileAlloc()` (path 마다 전체 lookup, dir-fd cache 우회).
이후: `self.source_read_cache.readFile()` → dir-fd cache 활용.

## 측정 (2026-05-11 · darwin arm64 · ReleaseFast · 5회 median · 5 도구)

| Scale | ZNTC | Bun | esbuild | rolldown | rspack | ZNTC 순위 |
|---|---|---|---|---|---|---|
| small (10) | **3.00** | 6.68 | 8.84 | 50.5 | 58.8 | 1위 (Bun 2.2×) |
| medium (1000) | **17.5** | 20.2 | 23.9 | 67.8 | 84.2 | 1위 (Bun 1.2×) |
| large (5000) | 80.7 | **67.6** | 86.1 | 145 | 211 | 2위 (Bun 1.0×, ZNTC 1.2×) |

이전 PR #3039 대비 ZNTC: small 2.98 → 3.00 / medium 17.9 → 17.5 / large 81.1 → 80.7. 모두 noise 범위 (±2%). fstat 자체가 macOS arm64 page-cache hit 시 sub-ms 라 절대 효과가 작음. 다만 dir-fd cache 통일 + incremental_mode 분기는 정확한 동작 보장에 필요.

## webpack 제외 (사용자 요청)

- `tests/benchmark/bench.ts` — webpack 측정 코드 삭제. ts-loader 의 type-check 가 19s+ 차지해 ZNTC/Bun/esbuild 와 fair 한 비교 아님 + measurement run-time 도 비례 단축.
- `benchmark-data.json` / `index.mdx` (KO/EN) — webpack 항목 / vs 라인 제거.

## Cross-platform 영향

- 3 OS (macOS · Linux · Windows) 모두 Zig `std.fs.File` API 만 사용. 동작 동일.
- **Windows 가 효과 가장 클 가능성** — `GetFileInformationByHandle` 가 NTFS / Windows Defender 의 무거운 path 라 fstat 생략의 절대 절감이 macOS 보다 클 수 있음. 별도 CI 측정 권장.

## 다음 단계 (별도 PR 검토)

- **mmap I/O (POSIX 분기)** — open + mmap + munmap + close 로 read 자체를 page-fault 로 lazy. macOS / Linux 한정. 5000 modules 에서 5-10ms 절감 추정.
- **parser SIMD 확장** — 공백/식별자 외 JSX 토큰 / 문자열 리터럴 / operator scan. 2-4ms 절감 추정.
- **worker pool scaling** — CPU core 활용 — 잠재 효과 큼.

## Test plan

- [x] `zig build -Doptimize=ReleaseFast` 통과
- [x] `zig build test` 유닛 테스트 통과 (incremental_mode 분기 정확 동작 — `compiled_cache populates on FIRST build` 등)
- [x] 5000-module 실측 (80.7 ms, ZNTC 2위)
- [x] `documents bun run build` 통과 (491 페이지, 링크 검증 통과)
- [ ] 배포 후 메인 카드 / Linux/Windows CI 측정 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)