### PR TITLE
feat(core+vite-plugin): jsx: 'preserve' mode + return ASI hazard fix

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -626,7 +626,13 @@ interface BuildOptionsCommon {
    * - `false`: 비활성화 (웹과 동일한 URL 문자열 export)
    * 기본 경로: `"react-native/Libraries/Image/AssetRegistry"` */
   assetRegistry?: string | false;
-  jsx?: 'classic' | 'automatic' | 'automatic-dev';
+  /** JSX runtime mode. `'preserve'` 는 JSX 를 변환 없이 그대로 출력 — TS 어노테이션만
+   * strip. downstream tool (`@vitejs/plugin-react` / `@preact/preset-vite` /
+   * `vite-plugin-solid` 등) 이 JSX 를 처리하도록 위임할 때 사용. tsc 의
+   * `"jsx": "preserve"` 와 동등.
+   * 알려진 제약 — JSX 안의 expression container 내부 TS 어노테이션
+   * (e.g. `<Foo prop={value as Type}>`) 은 strip 되지 않은 채 raw 로 남음. */
+  jsx?: 'classic' | 'automatic' | 'automatic-dev' | 'preserve';
   jsxFactory?: string;
   jsxFragment?: string;
   jsxImportSource?: string;

--- a/packages/core/napi.test.mjs
+++ b/packages/core/napi.test.mjs
@@ -81,6 +81,20 @@ describe('@zntc/core NAPI (Node.js)', () => {
     assert.ok(result.code.includes('preact'));
   });
 
+  it('JSX preserve — JSX 는 raw, TS 는 strip', () => {
+    const src =
+      'export function App({ initial }: { initial: number }) { const x: number = initial; return <div data-x={x}>hi</div>; }';
+    const result = call(src, 'app.tsx', { jsx: 'preserve' });
+    // JSX 가 그대로 출력 (React.createElement / jsx() 변환 없음)
+    assert.ok(result.code.includes('<div'));
+    assert.ok(result.code.includes('</div>'));
+    assert.ok(!result.code.includes('React.createElement'));
+    assert.ok(!result.code.includes('jsx-runtime'));
+    // TS 어노테이션 stripped
+    assert.ok(!result.code.includes(': number'));
+    assert.ok(!result.code.includes(': { initial'));
+  });
+
   it('ES5 다운레벨링', () => {
     const result = call('const x = () => 1;', 'input.ts', { target: 'es5' });
     assert.ok(!result.code.includes('=>'));

--- a/packages/core/src/napi/options.zig
+++ b/packages/core/src/napi/options.zig
@@ -388,18 +388,17 @@ pub fn parseBuildOptions(
 
     // JSX — string→enum 변환만 여기서. 최종 런타임/factory 결정은 tsconfig_merge 에 위임
     // (file/raw tsconfig 의 "jsx"/"jsxFactory" 등을 함께 고려).
-    // 유효 vocab: "automatic" / "automatic-dev" / "classic" (`transpile.zig::optionsFromJson`
-    // 의 enum-strict 동작과 일관). tsconfig vocab ("react" / "react-jsx" / "react-jsxdev") 또는
-    // typo 는 throw — 이전 silent classic fallback 은 사용자 디버깅을 어렵게 했음.
+    // 유효 vocab: "automatic" / "automatic-dev" / "classic" / "preserve"
+    // (`transpile.zig::optionsFromJson` 의 enum-strict 동작과 일관). tsconfig vocab
+    // ("react" / "react-jsx" / "react-jsxdev" / "react-native") 또는 typo 는 throw —
+    // 이전 silent classic fallback 은 사용자 디버깅을 어렵게 했음.
     const jsx_str = ownStr(env, opts_obj, "jsx", owned_strings);
     const jsx_runtime_explicit: ?JsxRuntime = if (jsx_str) |s| blk: {
-        if (std.mem.eql(u8, s, "automatic")) break :blk .automatic;
-        if (std.mem.eql(u8, s, "automatic-dev")) break :blk .automatic_dev;
-        if (std.mem.eql(u8, s, "classic")) break :blk .classic;
+        if (JsxRuntime.fromString(s)) |r| break :blk r;
         // parseBuildOptions 반환 타입이 ?BundleOptions 라 throwError 의 napi_value 결과를 그대로
         // return 못 함 — discard 후 null 반환. caller 의 `orelse return throwError(...)` 가
         // already-pending exception 위에 다시 throw 시도하지만 NAPI spec 상 silent ignore 라 안전.
-        _ = throwError(env, "invalid 'jsx' option (expected automatic / automatic-dev / classic)");
+        _ = throwError(env, "invalid 'jsx' option (expected automatic / automatic-dev / classic / preserve)");
         return null;
     } else null;
     const jsx_factory = ownStr(env, opts_obj, "jsxFactory", owned_strings);

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -38,8 +38,10 @@ export interface TranspileOptions {
   minifySyntax?: boolean;
   /** 전체 축소 (whitespace + identifiers + syntax) */
   minify?: boolean;
-  /** JSX 런타임 */
-  jsx?: 'classic' | 'automatic' | 'automatic-dev';
+  /** JSX 런타임. `'preserve'` 는 JSX 를 변환 없이 그대로 출력 — TypeScript 어노테이션만
+   * strip. downstream tool (e.g. @vitejs/plugin-react, @preact/preset-vite,
+   * vite-plugin-solid) 이 JSX 를 처리하도록 위임할 때 사용. tsc `"jsx": "preserve"` 와 동등. */
+  jsx?: 'classic' | 'automatic' | 'automatic-dev' | 'preserve';
   /** classic 모드 JSX factory (기본: "React.createElement") */
   jsxFactory?: string;
   /** classic 모드 Fragment factory (기본: "React.Fragment") */

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -41,6 +41,32 @@ zntc({
 });
 ```
 
+## Framework plugin 과 함께 쓰기
+
+대부분의 framework plugin (`@vitejs/plugin-react`, `@vitejs/plugin-vue`,
+`@sveltejs/vite-plugin-svelte`, `vite-plugin-solid`) 은 ZNTC 와 충돌 없이 같이
+쓸 수 있습니다. 다만 **babel 기반으로 `.tsx` 를 자체적으로 다시 변환하는 plugin**
+— 대표적으로 `@preact/preset-vite` — 와 함께 쓰면 `.tsx` 가 둘 다 처리되면서
+결과가 깨질 수 있습니다 (component body 의 JSX return 이 비어버림).
+
+이 경우 `jsx: 'preserve'` 옵션을 사용합니다 — ZNTC 는 `.tsx`/`.jsx` 처리를
+건너뛰고 framework plugin 이 JSX + TS 까지 모두 담당합니다. `.ts` 는 그대로
+ZNTC 가 처리.
+
+```ts
+// preact + vite
+import { defineConfig } from 'vite';
+import preact from '@preact/preset-vite';
+import { zntc } from '@zntc/vite-plugin';
+
+export default defineConfig({
+  plugins: [zntc({ transpileOptions: { jsx: 'preserve' } }), preact()],
+});
+```
+
+`jsx: 'preserve'` 는 tsc `"jsx": "preserve"` 와 동등한 의미 — JSX 변환을
+downstream tool 에 위임합니다.
+
 ## peer
 
 - `vite >= 5.0.0` (8.x 권장)

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -41,6 +41,8 @@ export interface ZntcPluginOptions {
 
 const DEFAULT_INCLUDE = /\.(tsx?|jsx)$/;
 const DEFAULT_EXCLUDE = /node_modules/;
+/// jsx: 'preserve' 모드에서 ZNTC 가 위임할 파일 패턴 — JSX 가 있을 수 있는 확장자.
+const JSX_EXT_PATTERN = /\.[jt]sx$/;
 
 export function zntc(options: ZntcPluginOptions = {}): Plugin {
   const include = options.include ?? DEFAULT_INCLUDE;
@@ -79,6 +81,15 @@ export function zntc(options: ZntcPluginOptions = {}): Plugin {
     transform(code, id) {
       if (!include.test(id)) return null;
       if (exclude.test(id)) return null;
+
+      // jsx: 'preserve' 면 JSX 가 포함될 수 있는 .tsx/.jsx 는 ZNTC 가 건너뛰고
+      // downstream framework plugin (`@vitejs/plugin-react`, `@preact/preset-vite`,
+      // `vite-plugin-solid` 등) 이 JSX 와 TS strip 까지 함께 처리하도록 위임한다.
+      // ZNTC core 의 preserve 출력 (raw JSX + TS stripped) 을 babel-based plugin
+      // 이 후처리할 때 sourcemap 이나 parse 측면에서 깨지는 케이스가 있어 안전쪽으로.
+      if (transpileOpts.jsx === 'preserve' && JSX_EXT_PATTERN.test(id)) {
+        return null;
+      }
 
       const result = transpile(code, {
         ...transpileOpts,

--- a/src/cli/options.zig
+++ b/src/cli/options.zig
@@ -527,16 +527,12 @@ pub fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator)
         } else if (std.mem.eql(u8, arg, "--jsx-in-js")) {
             opts.jsx_in_js = true;
         } else if (std.mem.startsWith(u8, arg, "--jsx=")) {
-            // CLI vocab: automatic / automatic-dev / classic. tsconfig vocab ("react-jsx" /
-            // "react-jsxdev") 는 CLI 가 받지 않음 — tsconfig 파싱 (`tsconfig_merge`) 이 처리.
+            // CLI vocab: classic / automatic / automatic-dev / preserve. tsconfig vocab
+            // (`react-jsx` / `react-jsxdev` / `react-native`) 은 CLI 가 받지 않음 —
+            // `tsconfig_merge` 가 처리. unknown 값은 `.classic` 으로 silent fallback
+            // (기존 동작 보존, NAPI 의 strict throw 와 의도적으로 다름).
             const val = arg["--jsx=".len..];
-            if (std.mem.eql(u8, val, "automatic")) {
-                opts.jsx_runtime = .automatic;
-            } else if (std.mem.eql(u8, val, "automatic-dev")) {
-                opts.jsx_runtime = .automatic_dev;
-            } else {
-                opts.jsx_runtime = .classic;
-            }
+            opts.jsx_runtime = lib.codegen.codegen.JsxRuntime.fromString(val) orelse .classic;
         } else if (std.mem.eql(u8, arg, "--jsx-dev")) {
             opts.jsx_runtime = .automatic_dev;
         } else if (std.mem.startsWith(u8, arg, "--jsx-factory=")) {

--- a/src/cli/usage.zig
+++ b/src/cli/usage.zig
@@ -99,7 +99,7 @@ pub fn printUsage(writer: anytype) !void {
         \\  --verbatim-module-syntax          Preserve unused value imports (TS 5.0+)
         \\
         \\JSX options:
-        \\  --jsx=<mode>                      preserve | transform | automatic | automatic-dev
+        \\  --jsx=<mode>                      classic | automatic | automatic-dev | preserve
         \\  --jsx-dev                         Shortcut for --jsx=automatic-dev
         \\  --jsx-factory=<name>              Element factory (classic, default: React.createElement)
         \\  --jsx-fragment=<name>             Fragment factory (classic, default: React.Fragment)

--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -277,15 +277,29 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
             try self.writeNodeSpan(node);
         },
 
-        // JSX: Transformer의 jsx_lowering이 call_expression으로 변환 완료.
-        // codegen은 JSX AST 노드를 만나지 않아야 함.
+        // JSX: 일반적으로 Transformer 의 jsx_lowering 이 call_expression 으로 변환.
+        // jsx_runtime == .preserve 면 JSX 노드가 codegen 까지 도달 — 원본 소스
+        // slice 를 그대로 emit (downstream tool 이 처리하도록 위임).
+        //
+        // 알려진 제약: JSX 자식 (attribute value / expression container) 내부의
+        // TypeScript 어노테이션 (e.g. `<Foo prop={value as Type}>`) 은 strip 되지
+        // 않은 채 raw 로 남는다. preserve 모드의 주 사용처가 vite plugin chain 의
+        // downstream tool 위임이라 그쪽이 TS 까지 함께 처리하는 것으로 가정.
         .jsx_element,
         .jsx_fragment,
-        .jsx_expression_container,
-        .jsx_text,
+        .jsx_opening_element,
+        .jsx_closing_element,
+        .jsx_attribute,
         .jsx_spread_attribute,
         .jsx_spread_child,
-        => unreachable,
+        .jsx_expression_container,
+        .jsx_text,
+        .jsx_namespaced_name,
+        .jsx_member_expression,
+        => {
+            try self.addSourceMapping(node.span);
+            try self.writeNodeSpan(node);
+        },
 
         // TS enum/namespace → IIFE 출력
         .ts_enum_declaration => try type_runtime_emit.emitEnumIIFE(self, node),

--- a/src/codegen/options.zig
+++ b/src/codegen/options.zig
@@ -46,6 +46,24 @@ pub const JsxRuntime = enum {
     automatic,
     /// jsxDEV from "<importSource>/jsx-dev-runtime". source info 포함.
     automatic_dev,
+    /// JSX 를 변환 없이 그대로 출력 (tsc `"jsx": "preserve"` 동등). TypeScript
+    /// 어노테이션만 strip. downstream tool (`@vitejs/plugin-react` /
+    /// `@preact/preset-vite` / `vite-plugin-solid` 등) 이 JSX 처리 담당하도록
+    /// 위임할 때 사용 — vite/rollup plugin chain 안에서 ZNTC 가 먼저 처리해도
+    /// JSX 가 raw 로 남아 후속 plugin 이 정상 변환 가능.
+    preserve,
+
+    /// CLI / NAPI string 입력을 enum 으로 변환. invalid 면 null — caller 가
+    /// strict throw (NAPI) 또는 default fallback (CLI) 정책을 결정.
+    /// tsconfig vocab (`react` / `react-jsx` / `react-jsxdev` / `react-native`)
+    /// 은 받지 않음 — `tsconfig_merge.mapTsConfigJsxToRuntime` 가 처리.
+    pub fn fromString(s: []const u8) ?JsxRuntime {
+        if (std.mem.eql(u8, s, "classic")) return .classic;
+        if (std.mem.eql(u8, s, "automatic")) return .automatic;
+        if (std.mem.eql(u8, s, "automatic-dev")) return .automatic_dev;
+        if (std.mem.eql(u8, s, "preserve")) return .preserve;
+        return null;
+    }
 };
 
 pub const CodegenOptions = struct {

--- a/src/codegen/statements.zig
+++ b/src/codegen/statements.zig
@@ -119,9 +119,35 @@ pub fn emitReturn(self: anytype, node: Node) !void {
     try self.write("return");
     if (!node.data.unary.operand.isNone()) {
         try self.writeByte(' ');
+        // operand 의 leading comments 가 `emitNode` 내부에서 emit 될 때 newline + indent 를
+        // 끼우면 `return` 직후 줄바꿈이 와 JavaScript ASI 가 `return;` 으로 종료해버린다
+        // (`/* @__PURE__ */ jsxs(...)` 같은 leading annotation 이 흔한 케이스). 미리
+        // inline (space-separated) 으로 소비해 ASI hazard 회피.
+        const operand_node = self.ast.getNode(node.data.unary.operand);
+        const has_real_span = operand_node.span.start != operand_node.span.end and
+            (operand_node.span.start & ast_mod.Ast.STRING_TABLE_BIT) == 0;
+        if (has_real_span) {
+            try emitLeadingCommentsInline(self, operand_node.span.start);
+        }
         try self.emitNode(node.data.unary.operand);
     }
     try self.writeByte(';');
+}
+
+/// operand 의 leading comments 를 newline 없이 inline 으로 emit. `return` /
+/// `throw` 등 ASI-sensitive position 에서 호출.
+fn emitLeadingCommentsInline(self: anytype, pos: u32) !void {
+    while (self.next_comment_idx < self.comments.len) {
+        const comment = self.comments[self.next_comment_idx];
+        if (comment.start > pos) break;
+        if (self.options.minify_whitespace and !comment.is_legal) {
+            self.next_comment_idx += 1;
+            continue;
+        }
+        try self.write(self.ast.source[comment.start..comment.end]);
+        try self.writeByte(' ');
+        self.next_comment_idx += 1;
+    }
 }
 
 pub fn emitThrow(self: anytype, node: Node) !void {

--- a/src/transformer/jsx_lowering.zig
+++ b/src/transformer/jsx_lowering.zig
@@ -120,6 +120,8 @@ pub fn JsxLowering(comptime Transformer: type) type {
                 .classic => lowerElementClassic(self, working_node.span, tag_name_idx, attrs_start, attrs_len, children_start, children_len),
                 .automatic => lowerElementAutomatic(self, working_node.span, tag_name_idx, attrs_start, attrs_len, children_start, children_len, false),
                 .automatic_dev => lowerElementAutomatic(self, working_node.span, tag_name_idx, attrs_start, attrs_len, children_start, children_len, true),
+                // preserve 는 dispatch 단에서 visitJSXElement 로 우회되므로 lowering 진입 불가.
+                .preserve => unreachable,
             };
         }
 
@@ -130,6 +132,7 @@ pub fn JsxLowering(comptime Transformer: type) type {
                 .classic => lowerFragmentClassic(self, node.span, list.start, list.len),
                 .automatic => lowerFragmentAutomatic(self, node.span, list.start, list.len, false),
                 .automatic_dev => lowerFragmentAutomatic(self, node.span, list.start, list.len, true),
+                .preserve => unreachable,
             };
         }
 

--- a/src/transformer/options.zig
+++ b/src/transformer/options.zig
@@ -313,4 +313,10 @@ pub const TransformOptions = struct {
         const e = node.data.extra;
         return ast.hasExtra(e, ast_mod.ArrowExtra.flags) and (ast.readExtra(e, ast_mod.ArrowExtra.flags) & flag) != 0;
     }
+
+    /// JSX 노드를 call_expression 으로 lowering 할지 판단.
+    /// preserve 모드는 lowering 을 skip 하고 codegen 이 raw source slice 를 emit 한다.
+    pub fn shouldLowerJsx(self: @This()) bool {
+        return self.jsx_transform and self.jsx_runtime != .preserve;
+    }
 };

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -125,7 +125,10 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
 
         // JSX — fragment는 .list, element/opening_element는 .extra
         .jsx_fragment => {
-            if (self.options.jsx_transform) {
+            // preserve 모드면 lowering skip — visitJSXElement / visitListNode 가 자식만
+            // visit (TS strip 적용) 하고 JSX 노드 자체는 유지. downstream tool 이 JSX 를
+            // 처리할 때 (vite plugin chain 등) 활용.
+            if (self.options.shouldLowerJsx()) {
                 return jsx_lowering_mod.JsxLowering(Transformer).lowerJSXFragment(self, node);
             }
             return self.visitListNode(idx);
@@ -189,7 +192,7 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
             const pushed_emotion_scope = try emotion_mod.maybeEnterClassNamesScope(self, node);
             defer if (pushed_emotion_scope) emotion_mod.exitClassNamesScope(self);
 
-            if (self.options.jsx_transform) {
+            if (self.options.shouldLowerJsx()) {
                 return jsx_lowering_mod.JsxLowering(Transformer).lowerJSXElement(self, node);
             }
             return self.visitJSXElement(node);

--- a/src/tsconfig_merge.zig
+++ b/src/tsconfig_merge.zig
@@ -52,12 +52,14 @@ pub const MergedFlags = struct {
 };
 
 /// tsconfig 의 "jsx" 문자열 값을 ZNTC 의 `JsxRuntime` 으로 매핑.
-/// "preserve" 와 인식 못 하는 값은 null — caller 가 default(`.classic`) 를 적용.
+/// 인식 못 하는 값은 null — caller 가 default(`.classic`) 를 적용.
 fn mapTsConfigJsxToRuntime(tsconfig_jsx: ?[]const u8) ?codegen.JsxRuntime {
     const s = tsconfig_jsx orelse return null;
     if (std.mem.eql(u8, s, "react")) return .classic;
     if (std.mem.eql(u8, s, "react-jsx")) return .automatic;
     if (std.mem.eql(u8, s, "react-jsxdev")) return .automatic_dev;
+    if (std.mem.eql(u8, s, "preserve")) return .preserve;
+    if (std.mem.eql(u8, s, "react-native")) return .preserve;
     return null;
 }
 
@@ -167,13 +169,19 @@ test "merge: explicit jsx runtime wins over tsconfig" {
     try std.testing.expect(merged.jsx_runtime == .classic);
 }
 
-test "merge: preserve / unknown jsx falls back to default classic" {
+test "merge: preserve / react-native jsx → .preserve" {
     var ts = TsConfig{};
 
     ts.jsx = "preserve";
-    try std.testing.expect(merge(&ts, .{}).jsx_runtime == .classic);
+    try std.testing.expect(merge(&ts, .{}).jsx_runtime == .preserve);
 
     ts.jsx = "react-native";
+    try std.testing.expect(merge(&ts, .{}).jsx_runtime == .preserve);
+}
+
+test "merge: unknown jsx falls back to default classic" {
+    var ts = TsConfig{};
+    ts.jsx = "invalid-jsx-mode";
     try std.testing.expect(merge(&ts, .{}).jsx_runtime == .classic);
 }
 


### PR DESCRIPTION
## Summary

`@preact/preset-vite` 의 babel 이 ZNTC vite-plugin 과 같은 `.tsx` 를 둘 다 처리하면서 충돌 → JSX return 누락 (#3056). 해결책으로 tsc `"jsx": "preserve"` 와 동등한 모드를 core 와 vite-plugin 양쪽에 도입.

## ZNTC core

`JsxRuntime` enum 에 `preserve` 추가 — JSX 를 변환 없이 그대로 출력, TS 어노테이션만 strip.

- `JsxRuntime.preserve` enum + tsconfig `"preserve"` / `"react-native"` 매핑
- transformer dispatch 가 preserve 면 `lowerJSXElement` / `lowerJSXFragment` skip → 기존 `visitJSXElement` 경로가 자식만 visit (TS strip 적용) 하고 JSX 노드 유지
- codegen 의 jsx_* node 가 unreachable → `writeNodeSpan` 으로 raw source slice emit (element / fragment / opening / closing / attribute / spread_attribute / spread_child / expression_container / text / namespaced_name / member_expression)
- CLI `--jsx=preserve`, NAPI `jsx: 'preserve'`, JS `TranspileOptions.jsx` 타입 확장

### 알려진 제약

JSX 내부 expression container 의 TS 어노테이션 (e.g. `<Foo prop={value as Type}>`) 은 raw source slice 출력이라 strip 안 됨. 주 사용처가 downstream tool 위임이라 babel/swc 등이 함께 TS 처리하는 가정.

## ZNTC vite-plugin

`jsx: 'preserve'` 명시 시 `.tsx`/`.jsx` 를 ZNTC 가 skip — downstream framework plugin 이 JSX + TS 모두 처리. `.ts` 는 그대로 ZNTC.

core 의 preserve 출력 (raw JSX + TS stripped) 을 babel-based plugin 이 후처리할 때 sourcemap 측면에서 깨지는 케이스 (preact preset) 가 있어 plugin 단에서 안전쪽으로 skip. core 의 preserve 는 standalone 사용 (CLI / direct transpile API) 에서 의미.

README 에 preact 가이드 추가:

```ts
plugins: [zntc({ transpileOptions: { jsx: 'preserve' } }), preact()],
```

## Test plan

- [x] napi.test.mjs 19/19 pass (`jsx: 'preserve'` 케이스 추가)
- [x] core index.test.ts 427/427 pass
- [x] integration/vite-plugin.test.ts 8/8 pass
- [x] zig build test pass (`tsconfig_merge` 의 preserve fallback test 도 새 동작에 맞춰 갱신)
- [x] 수동: preact + vite + `zntc({ transpileOptions: { jsx: 'preserve' } })` 빌드 시 component body JSX 가 preact jsx-runtime 으로 정상 변환, count/doubled/inc 모두 보존
- [x] React / vue / svelte / solid / lit / qwik + vite + zntc 회귀 없음 (#3035 머지 후 통합)

Closes #3056

🤖 Generated with [Claude Code](https://claude.com/claude-code)