### PR TITLE
test(core): drop hand-rolled CLI sidecar list in bootstrap test

### DIFF
--- a/packages/core/test/cli/bootstrap.ts
+++ b/packages/core/test/cli/bootstrap.ts
@@ -6,11 +6,11 @@ import {
   mkdtempSync,
   rmSync,
   mkdirSync,
+  readdirSync,
   tmpdir,
   join,
   resolve,
   BIN_DIR,
-  CLI,
   RUNTIME,
   shellQuote,
   readRedirectedProcessOutput,
@@ -23,10 +23,9 @@ describe('CLI: bootstrap', () => {
     try {
       const binDir = join(dir, 'bin');
       mkdirSync(binDir, { recursive: true });
-      cpSync(CLI, join(binDir, 'zntc.mjs'));
-      cpSync(resolve(BIN_DIR, 'cli-flags.mjs'), join(binDir, 'cli-flags.mjs'));
-      cpSync(resolve(BIN_DIR, 'rn-dev-input.mjs'), join(binDir, 'rn-dev-input.mjs'));
-      cpSync(resolve(BIN_DIR, 'rn-asset-copy.mjs'), join(binDir, 'rn-asset-copy.mjs'));
+      for (const f of readdirSync(BIN_DIR)) {
+        if (f.endsWith('.mjs')) cpSync(resolve(BIN_DIR, f), join(binDir, f));
+      }
 
       const result = readRedirectedProcessOutput(
         [RUNTIME, join(binDir, 'zntc.mjs'), '--help'].map(shellQuote).join(' '),

--- a/packages/core/test/cli/helpers.ts
+++ b/packages/core/test/cli/helpers.ts
@@ -7,6 +7,7 @@ export {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,


### PR DESCRIPTION
## Summary
- `packages/core/test/cli/bootstrap.ts`의 `prints actionable setup error when built JS dist is missing` 테스트가 실패하던 문제 수정.
- 원인: `5f3cffcb` (`chore(release): 0.1.0 publish 준비`)에서 `bin/zntc.mjs`가 새로 `banner.mjs`를 import하도록 추가됐는데, bootstrap 테스트는 임시 디렉토리에 복사할 sidecar 파일 목록을 하드코딩으로 관리하고 있어서 `banner.mjs`만 누락. node가 ESM resolve 단계에서 `ERR_MODULE_NOT_FOUND`로 죽으며, 테스트가 검증하려던 "dist 누락" 에러 경로에 도달하기도 전에 실패함.
- 해결: 하드코딩된 `cpSync` 5줄을 `readdirSync(BIN_DIR)` 기반 glob 한 줄(`.mjs`만 필터)로 교체. 앞으로 sidecar가 추가돼도 테스트 셋업을 같이 고칠 필요가 없어 drift class 자체를 제거.

## Why glob, not just "banner.mjs 한 줄 추가"
한 줄 추가는 같은 버그를 다음 sidecar 추가 시점에 그대로 재발시킴. `bin/*.mjs`가 곧 "런타임에 `zntc.mjs`가 필요로 하는 sidecar 집합"이라는 사실은 이미 패키지 구조에 의해 보장됨(`package.json#files`와도 일치). `+5 -5` 수준의 변경이라 비용도 거의 없음.

## Test plan
- [x] `cd packages/core && bun test bin/zntc.test.ts -t "CLI: bootstrap"` → 2 pass / 0 fail
- [x] `bun x tsc -b --force` (전체 type-check, memory의 `--dry` cache hit 함정 회피) → 깨끗

🤖 Generated with [Claude Code](https://claude.com/claude-code)