### PR TITLE
fix(e2e): port 충돌 해소 — fixed port를 tests/e2e/tests/ports.ts로 중앙화

### DIFF
--- a/tests/e2e/tests/ports.ts
+++ b/tests/e2e/tests/ports.ts
@@ -1,0 +1,26 @@
+/**
+ * 모든 e2e 테스트가 공유하는 단일 port 발급처.
+ *
+ * playwright 는 기본적으로 test 파일 간 parallel 실행이라, 두 파일이 동일 port 로
+ * 서버를 spawn 하면 EADDRINUSE 또는 응답이 섞이며 fail 이 race 로 들쭉날쭉해진다.
+ * fixed port 가 필요한 케이스는 모두 여기서 unique 하게 발급한다.
+ * 동적 port (`listen(0)`) 를 쓰는 케이스는 등록 불필요.
+ */
+export const PORTS = {
+  SMOKE: 3999,
+  SOURCEMAP: 3986,
+  VITE_APP: 3985,
+
+  BUILD_PREVIEW: 3997,
+  DEV: 3998,
+  CSS_MODULE_PREVIEW: 3995,
+  CSS_MODULE_DEV: 3994,
+  SCSS_PREVIEW: 3993,
+  SCSS_DEV: 3992,
+  SASS_HTML_PREVIEW: 3991,
+  SCSS_RECOVERY_DEV: 3990,
+  OVERLAY_DEV: 3989,
+  RUNTIME_OVERLAY_DEV: 3988,
+  REJECTION_OVERLAY_DEV: 3987,
+  NESTED: 3996,
+} as const;

--- a/tests/e2e/tests/smoke.test.ts
+++ b/tests/e2e/tests/smoke.test.ts
@@ -3,9 +3,10 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
+import { PORTS } from './ports';
 
 const ZNTC_BIN = resolve(__dirname, '../../../zig-out/bin/zntc');
-const TEST_PORT = 3999;
+const TEST_PORT = PORTS.SMOKE;
 
 let server: ChildProcess | null = null;
 let fixtureDir: string;

--- a/tests/e2e/tests/sourcemap-e2e.test.ts
+++ b/tests/e2e/tests/sourcemap-e2e.test.ts
@@ -3,9 +3,10 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
+import { PORTS } from './ports';
 
 const ZNTC_BIN = resolve(__dirname, '../../../zig-out/bin/zntc');
-const TEST_PORT = 3997;
+const TEST_PORT = PORTS.SOURCEMAP;
 
 // 10줄 소스 — "console.log(greeting)"은 10번째 줄(0-indexed 9)로 CDP breakpoint 테스트에 사용.
 const APP_TS = `

--- a/tests/e2e/tests/vite-app-e2e.test.ts
+++ b/tests/e2e/tests/vite-app-e2e.test.ts
@@ -3,6 +3,7 @@ import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
+import { PORTS } from './ports';
 
 /**
  * Multi-module Vite 앱을 @zntc/vite-plugin로 빌드 → 브라우저 실행 E2E.
@@ -16,7 +17,7 @@ import { dirname, join, resolve } from 'node:path';
  */
 
 const PROJECT_ROOT = resolve(__dirname, '../../..');
-const TEST_PORT = 3996;
+const TEST_PORT = PORTS.VITE_APP;
 
 const FILES: Record<string, string> = {
   'index.html': `<!doctype html>

--- a/tests/e2e/tests/zntc-app-builder-e2e.test.ts
+++ b/tests/e2e/tests/zntc-app-builder-e2e.test.ts
@@ -3,6 +3,7 @@ import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
+import { PORTS } from './ports';
 
 /**
  * Vite-style app builder (`zntc build` / `zntc dev` / `zntc preview`) 의 브라우저 E2E.
@@ -16,17 +17,17 @@ import { dirname, join, resolve } from 'node:path';
 const ZNTC_BIN = resolve(__dirname, '../../../zig-out/bin/zntc');
 const ZNTC_JS_CLI = resolve(__dirname, '../../../packages/core/bin/zntc.mjs');
 const ZNTC_JS_RUNTIME = 'bun';
-const BUILD_PREVIEW_PORT = 3997;
-const DEV_PORT = 3998;
-const CSS_MODULE_PREVIEW_PORT = 3995;
-const CSS_MODULE_DEV_PORT = 3994;
-const SCSS_PREVIEW_PORT = 3993;
-const SCSS_DEV_PORT = 3992;
-const SASS_HTML_PREVIEW_PORT = 3991;
-const SCSS_RECOVERY_DEV_PORT = 3990;
-const OVERLAY_DEV_PORT = 3989;
-const RUNTIME_OVERLAY_DEV_PORT = 3988;
-const REJECTION_OVERLAY_DEV_PORT = 3987;
+const BUILD_PREVIEW_PORT = PORTS.BUILD_PREVIEW;
+const DEV_PORT = PORTS.DEV;
+const CSS_MODULE_PREVIEW_PORT = PORTS.CSS_MODULE_PREVIEW;
+const CSS_MODULE_DEV_PORT = PORTS.CSS_MODULE_DEV;
+const SCSS_PREVIEW_PORT = PORTS.SCSS_PREVIEW;
+const SCSS_DEV_PORT = PORTS.SCSS_DEV;
+const SASS_HTML_PREVIEW_PORT = PORTS.SASS_HTML_PREVIEW;
+const SCSS_RECOVERY_DEV_PORT = PORTS.SCSS_RECOVERY_DEV;
+const OVERLAY_DEV_PORT = PORTS.OVERLAY_DEV;
+const RUNTIME_OVERLAY_DEV_PORT = PORTS.RUNTIME_OVERLAY_DEV;
+const REJECTION_OVERLAY_DEV_PORT = PORTS.REJECTION_OVERLAY_DEV;
 
 test.describe.configure({ mode: 'parallel' });
 
@@ -317,7 +318,7 @@ test.describe.serial('zntc dev E2E', () => {
 test.describe.serial('zntc build: nested CSS path preservation E2E', () => {
   let nestedDir: string;
   let nestedPreview: ChildProcess | null = null;
-  const NESTED_PORT = 3996;
+  const NESTED_PORT = PORTS.NESTED;
 
   test.beforeAll(async () => {
     nestedDir = await mkdtemp(join(tmpdir(), 'zntc-app-nested-css-e2e-'));


### PR DESCRIPTION
## Summary

- playwright 의 test 파일 간 parallel 실행 환경에서 두 파일이 동일 port 로 서버를 spawn 해 EADDRINUSE / 응답 섞임이 발생하던 race 두 건을 해소.
- 모든 fixed port 를 `tests/e2e/tests/ports.ts` 한 곳에서 unique 하게 발급. `listen(0)` 동적 port 케이스 (browser-smoke, lib-scenario) 는 등록 불필요.

## 충돌 내역

| Port | 파일 1 | 파일 2 |
|---|---|---|
| 3997 | `sourcemap-e2e.test.ts` TEST_PORT | `zntc-app-builder-e2e.test.ts` BUILD_PREVIEW_PORT |
| 3996 | `vite-app-e2e.test.ts` TEST_PORT | `zntc-app-builder-e2e.test.ts` NESTED_PORT |

race 로 실행마다 다른 케이스가 fail 했음 (smoke 에러 오버레이 / import.meta.env production 정적 주입 / nested CSS path / public 자산 / bundle.js.map 등 5종). 수동 재현 결과 zntc build / preview 자체에는 회귀가 없었고 전부 port 충돌로 인한 인프라 이슈.

## 검증

- 변경 후 `bun run test:e2e` — 128 passed / 0 failed / 0 did not run (이전엔 race 로 121~125 passed 변동).
- type-check / lint / fmt:check / pre-release-check 모두 통과.

## Test plan

- [x] e2e 전체 실행
- [x] type-check
- [x] pre-release-check (build:publishable + publint + sherif + publish-install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)