### PR TITLE
fix(linker): JSX runtime helper scope 격리 — 사용자 식별자 충돌 회피 (#3068)

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -52,6 +52,11 @@ pub const ImportBinding = struct {
     /// linker.populateImportSymbols가 채움. invalid = synthetic binding 등
     /// semantic scope에 로컬이 없는 경우.
     local_symbol: symbol_mod.SymbolRef = symbol_mod.SymbolRef.invalid,
+    /// #3068: helper marker (runtime helper / JSX runtime) 가 적용된 binding.
+    /// linker 의 local_symbol lookup 이 일반 `module_scope` 가 아닌 격리된
+    /// `helper_scope_map` 에서 sym_index 를 찾아야 사용자가 같은 이름의 식별자를
+    /// 선언한 경우에도 충돌이 일어나지 않는다.
+    is_helper: bool = false,
 
     pub const Kind = enum {
         default,
@@ -142,10 +147,15 @@ pub const ExportBinding = struct {
 
 /// AST에서 import 바인딩 상세를 추출한다.
 /// import_record_map: import source span → ImportRecord 인덱스 매핑
+/// `helper_ref_nodes` 가 non-null 이면 import_specifier 의 local_node idx 가 그 sorted slice
+/// 에 있을 때 해당 binding 에 `is_helper=true` 를 set 한다. linker 가 이 binding 의 local_symbol
+/// 을 일반 module_scope 가 아닌 격리된 helper_scope_map 에서 찾도록 보장 — 사용자가 같은
+/// 식별자를 선언해도 충돌 회피 (#3068).
 pub fn extractImportBindings(
     allocator: std.mem.Allocator,
     ast: *const Ast,
     import_records: []const types.ImportRecord,
+    helper_ref_nodes: ?[]const u32,
 ) ![]ImportBinding {
     var bindings: std.ArrayList(ImportBinding) = .empty;
     errdefer bindings.deinit(allocator);
@@ -219,11 +229,21 @@ pub fn extractImportBindings(
                     const imported_node = ast.getNode(imported_idx);
                     const imported_name = ast.getText(imported_node.span);
 
-                    const local_node = if (!local_idx.isNone() and @intFromEnum(local_idx) != @intFromEnum(imported_idx))
-                        ast.getNode(local_idx)
+                    const local_node_idx = if (!local_idx.isNone() and @intFromEnum(local_idx) != @intFromEnum(imported_idx))
+                        local_idx
                     else
-                        imported_node;
+                        imported_idx;
+                    const local_node = ast.getNode(local_node_idx);
                     const local_name = ast.getText(local_node.span);
+
+                    const is_helper = if (helper_ref_nodes) |refs|
+                        std.sort.binarySearch(u32, refs, @intFromEnum(local_node_idx), struct {
+                            fn cmp(needle: u32, item: u32) std.math.Order {
+                                return std.math.order(needle, item);
+                            }
+                        }.cmp) != null
+                    else
+                        false;
 
                     try bindings.append(allocator, .{
                         .kind = .named,
@@ -231,6 +251,7 @@ pub fn extractImportBindings(
                         .imported_name = imported_name,
                         .local_span = local_node.span,
                         .import_record_index = rec_idx,
+                        .is_helper = is_helper,
                     });
                 },
                 else => {},

--- a/src/bundler/binding_scanner_test.zig
+++ b/src/bundler/binding_scanner_test.zig
@@ -33,7 +33,7 @@ fn parseAndExtractBindings(allocator: std.mem.Allocator, source: []const u8) !st
 
     const records = try import_scanner.extractImports(allocator, &parser.ast);
 
-    const import_bindings = try extractImportBindings(allocator, &parser.ast, records);
+    const import_bindings = try extractImportBindings(allocator, &parser.ast, records, null);
     const export_bindings = try extractExportBindings(allocator, &parser.ast, records, import_bindings);
 
     return .{

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -1406,13 +1406,14 @@ test "JSX automatic: ESM-wrapped module with CJS jsx-runtime — synthetic bindi
 }
 
 test "JSX automatic-dev: #1209 — _jsxDEV must be assigned per module (HMR safety)" {
-    // #3062 이후 synthetic JSX 우회 (synthetic ImportBinding `_jsxDEV` 등) 가
-    // 제거되고 transformer 가 entry AST 에 정식 import 노드를 추가하는 방식으로
-    // 변경됐다. 이 테스트의 assertion (`_jsxDEV` 식별자 substring, `var _jsxDEV`
-    // shadow 회귀) 은 기존 방식의 구체 emit pattern 가정이라 새 방식에선
-    // 부적용 — entry 의 `_jsxDEV` 호출은 source 의 canonical 식별자로 rename됨.
-    // 동등 동작 검증은 e2e `lib-scenario-e2e.test.ts` 의 `H1_preact_jsx_automatic`
-    // 시나리오가 더 정확히 cover.
+    // #3062 이후 synthetic JSX 우회 제거 + transformer 가 정식 import 노드 추가. 새
+    // 방식에선 `_jsxDEV` 식별자가 source 의 canonical 로 rename 되어 substring
+    // assertion 부적용. brittle substring 보다 더 robust 한 e2e DOM 검증으로 대체:
+    //   - tests/e2e/tests/lib-scenario-e2e.test.ts 의 H1/H4/H5/H6 시나리오가
+    //     preact JSX automatic 의 빌드 → 브라우저 실행 → DOM 검증까지 다룸.
+    //     H4: 사용자 `_jsx` 식별자 충돌 (#3068 helper scope 격리)
+    //     H5: 멀티 모듈 jsx-runtime 공유
+    //     H6: barrel re-export JSX
     return error.SkipZigTest;
 }
 
@@ -1449,9 +1450,9 @@ test "JSX automatic-dev: #1209 — browser platform also affected" {
 }
 
 test "JSX automatic: multiple modules sharing same jsx-runtime" {
-    // #3062: synthetic JSX 우회 제거 후 entry 의 `_jsx` 식별자는 source 의 canonical
-    // 식별자 (rename 적용 후) 로 emit 되므로 `_jsx(` substring assertion 이 부적용.
-    // 동등 동작 검증은 e2e `lib-scenario-e2e.test.ts` 의 `H1_preact_jsx_automatic`.
+    // #3062 이후 substring assertion 부적용. e2e 대체:
+    //   tests/e2e/tests/lib-scenario-e2e.test.ts 의 H5_preact_jsx_multi_module
+    //   (CompA / CompB / entry 가 동시에 JSX 사용 + 브라우저 DOM 검증).
     return error.SkipZigTest;
 }
 
@@ -1540,15 +1541,17 @@ test "JSX automatic: mixed JSX and non-JSX modules" {
 }
 
 test "JSX automatic: re-export of JSX component" {
-    // #3062: `_jsx` substring assertion 이 새 emit 방식과 부적용. 동등 동작 검증은
-    // e2e `lib-scenario-e2e.test.ts` 의 `H1_preact_jsx_automatic`.
+    // #3062 이후 substring assertion 부적용. e2e 대체:
+    //   tests/e2e/tests/lib-scenario-e2e.test.ts 의 H6_preact_jsx_re_export
+    //   (barrel 파일 통과 후 Button 컴포넌트 → 브라우저 DOM 검증).
     return error.SkipZigTest;
 }
 
 test "JSX automatic: ESM-wrapped hoisted function can access _jsxDEV (scope test)" {
-    // #3062: `_jsxDEV` 식별자 substring 및 outer scope 선언 assertion 이 새 emit
-    // 방식과 부적용. 동등 동작 검증은 e2e `lib-scenario-e2e.test.ts` 의
-    // `H1_preact_jsx_automatic`.
+    // #3062 이후 substring assertion 부적용. e2e 대체:
+    //   tests/e2e/tests/lib-scenario-e2e.test.ts 의 H1/H4/H5/H6 가 preact JSX
+    //   automatic 의 빌드/렌더 정상성을 브라우저 동작까지 검증. 별도 ESM-wrapped
+    //   require 소비 fixture 가 필요하면 후속 시나리오로 추가 가능.
     return error.SkipZigTest;
 }
 

--- a/src/bundler/graph/json_module.zig
+++ b/src/bundler/graph/json_module.zig
@@ -83,7 +83,7 @@ pub fn parse(self: *ModuleGraph, module: *Module) void {
         module.state = .ready;
         return;
     };
-    module.import_bindings = binding_scanner_mod.extractImportBindings(arena_alloc, &(module.ast.?), scan_result.records) catch &.{};
+    module.import_bindings = binding_scanner_mod.extractImportBindings(arena_alloc, &(module.ast.?), scan_result.records, null) catch &.{};
     binding_scanner_mod.collectNamespaceAccesses(arena_alloc, &(module.ast.?), module.import_bindings) catch {};
     module.export_bindings = binding_scanner_mod.extractExportBindings(arena_alloc, &(module.ast.?), scan_result.records, module.import_bindings) catch &.{};
     module.exported_names = projectExportedNames(arena_alloc, module.export_bindings);

--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -249,6 +249,7 @@ fn refreshSemanticAndStmtInfoAfterAstMutation(
             .unresolved_references = analyzer.unresolved_references,
             .references = analyzer.references.items,
             .numeric_const_texts = analyzer.numeric_const_texts,
+            .helper_scope_map = analyzer.helper_scope_map,
         };
         if (!self.minify_identifiers) {
             if (previous_semantic) |old_sem| {
@@ -372,7 +373,8 @@ pub fn resyncAfterAstMutation(
         var import_bindings_scope = profile.begin(.graph_resync_import_bindings);
         defer import_bindings_scope.end();
 
-        const transformed_import_bindings = try binding_scanner_mod.extractImportBindings(arena_alloc, ast, module.import_records);
+        const helper_refs: ?[]const u32 = if (module.transform_cache) |cache| cache.helper_ref_nodes else null;
+        const transformed_import_bindings = try binding_scanner_mod.extractImportBindings(arena_alloc, ast, module.import_records, helper_refs);
         module.import_bindings = try mergeImportBindings(arena_alloc, previous_import_bindings, transformed_import_bindings);
         try binding_scanner_mod.collectNamespaceAccesses(arena_alloc, ast, module.import_bindings);
     }

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1434,7 +1434,16 @@ pub const Linker = struct {
                 // current-side: scope_maps[0]에서 로컬 심볼 조회
                 if (module_scope_opt) |module_scope| {
                     if (!ib.isSynthetic()) {
-                        if (module_scope.get(ib.local_name)) |sym_idx| {
+                        // #3068: helper binding 은 user 가 같은 이름을 선언했어도 격리된
+                        // helper_scope_map 에서 lookup. 일반 module_scope.get 가 user 의
+                        // sym_idx 를 반환하면 JSX call 이 user binding 으로 잘못 묶인다.
+                        const sym_lookup = if (ib.is_helper) blk: {
+                            if (importer.semantic) |*sem| {
+                                if (sem.helper_scope_map.get(ib.local_name)) |sym_idx| break :blk @as(?usize, sym_idx);
+                            }
+                            break :blk @as(?usize, null);
+                        } else module_scope.get(ib.local_name);
+                        if (sym_lookup) |sym_idx| {
                             ib.local_symbol = bundler_symbol.SymbolRef.makeSemantic(mod_idx, sym_idx);
                         }
                     }

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -74,6 +74,11 @@ pub const ModuleSemanticData = struct {
     /// Symbol 에 16B slice 를 박지 않으려고 분리 — 보통 numeric const 는 전체 심볼의 극소수.
     /// parse_arena 가 backing — value slice 는 source 또는 string_table 참조.
     numeric_const_texts: std.AutoHashMapUnmanaged(u32, []const u8) = .{},
+    /// #3068: helper marker (runtime helper / JSX runtime) 가 적용된 import_specifier 의
+    /// local 식별자 binding 을 격리 보관. linker 의 `populateImportSymbols` 가
+    /// `ImportBinding.is_helper=true` 인 binding 의 local_symbol 을 이 맵에서 찾도록 해
+    /// 사용자가 같은 이름의 식별자를 선언해도 충돌이 일어나지 않게 한다.
+    helper_scope_map: std.StringHashMapUnmanaged(usize) = .{},
 
     /// 심볼 id에 해당하는 이름을 반환. `Symbol.nameText` 래퍼.
     pub fn symbolName(self: *const ModuleSemanticData, id: u32, source: []const u8) []const u8 {

--- a/src/transformer/jsx_lowering.zig
+++ b/src/transformer/jsx_lowering.zig
@@ -175,6 +175,16 @@ pub fn JsxLowering(comptime Transformer: type) type {
         // ================================================================
 
         /// Classic: React.createElement(tag, props, ...children)
+        /// JSX runtime helper 식별자 (`_jsx`, `_jsxs`, `_jsxDEV`, `_Fragment`,
+        /// `_createElement`) 참조 노드를 만든다. `#2869` helper marker 도 함께 등록해
+        /// resync 분석기가 이 ref 를 user scope 가 아닌 helper_scope_map 으로 binding
+        /// 시킨다 — 사용자가 같은 이름의 식별자를 선언해도 충돌 회피 (#3068).
+        fn makeJsxRuntimeRef(self: *Transformer, name: []const u8) Transformer.Error!NodeIndex {
+            const idx = try helpers.makeIdentifierRef(self, name);
+            try self.markRuntimeHelperRef(idx);
+            return idx;
+        }
+
         fn lowerElementClassic(
             self: *Transformer,
             span: Span,
@@ -264,13 +274,13 @@ pub fn JsxLowering(comptime Transformer: type) type {
             // callee 선택
             const callee = if (is_dev) blk: {
                 self.jsx_import_info.used_jsxDEV = true;
-                break :blk try helpers.makeIdentifierRef(self, "_jsxDEV");
+                break :blk try makeJsxRuntimeRef(self, "_jsxDEV");
             } else if (is_static) blk: {
                 self.jsx_import_info.used_jsxs = true;
-                break :blk try helpers.makeIdentifierRef(self, "_jsxs");
+                break :blk try makeJsxRuntimeRef(self, "_jsxs");
             } else blk: {
                 self.jsx_import_info.used_jsx = true;
-                break :blk try helpers.makeIdentifierRef(self, "_jsx");
+                break :blk try makeJsxRuntimeRef(self, "_jsx");
             };
 
             // 1st arg: tag name
@@ -340,16 +350,16 @@ pub fn JsxLowering(comptime Transformer: type) type {
 
             const callee = if (is_dev) blk: {
                 self.jsx_import_info.used_jsxDEV = true;
-                break :blk try helpers.makeIdentifierRef(self, "_jsxDEV");
+                break :blk try makeJsxRuntimeRef(self, "_jsxDEV");
             } else if (is_static) blk: {
                 self.jsx_import_info.used_jsxs = true;
-                break :blk try helpers.makeIdentifierRef(self, "_jsxs");
+                break :blk try makeJsxRuntimeRef(self, "_jsxs");
             } else blk: {
                 self.jsx_import_info.used_jsx = true;
-                break :blk try helpers.makeIdentifierRef(self, "_jsx");
+                break :blk try makeJsxRuntimeRef(self, "_jsx");
             };
 
-            const fragment_ref = try helpers.makeIdentifierRef(self, "_Fragment");
+            const fragment_ref = try makeJsxRuntimeRef(self, "_Fragment");
 
             // props: {children: ...} or {}
             const props_arg = try buildAutomaticProps(self, 0, 0, children_start, children_len, null, effective_children, span, .none);
@@ -400,7 +410,7 @@ pub fn JsxLowering(comptime Transformer: type) type {
             children_len: u32,
         ) Transformer.Error!NodeIndex {
             self.jsx_import_info.used_createElement = true;
-            const callee = try helpers.makeIdentifierRef(self, "_createElement");
+            const callee = try makeJsxRuntimeRef(self, "_createElement");
             const tag_arg = try lowerTagName(self, tag_name_idx);
 
             // classic-style props (key 포함)

--- a/src/transformer/jsx_runtime_imports.zig
+++ b/src/transformer/jsx_runtime_imports.zig
@@ -11,10 +11,10 @@
 //! 일반 import 처럼 detect → 다운스트림에 synthetic 분기 없이 처리된다.
 //! `runtime_helper_imports.zig` 가 사용하는 패턴과 의도적으로 동일 구조.
 //!
-//! 참고 — runtime helper 의 `markRuntimeHelperRef` (#2869, helper_scope_map 격리) 는
-//! 본 모듈에서 호출하지 않는다. JSX local 이름은 `_jsx`/`_jsxs`/`_Fragment` 등
-//! single-underscore 라 관례상 internal 이지만 helper 의 `__extends` (double underscore)
-//! 와 달리 사용자 코드 충돌 위험이 있어, 추가 격리 정책은 별도 PR 에서 검증한다.
+//! `#2869` helper marker (helper_scope_map 격리) 도 함께 적용 (#3068). 사용자가
+//! `const _jsx = ...` 같이 같은 이름을 선언했을 때 resync 의 binding_scanner 가
+//! user scope 와 helper scope 를 분리 → JSX call 이 사용자 binding 을 잘못 가리키는
+//! 충돌을 회피. `jsx_lowering` 의 ref 생성도 같은 marker 를 거친다.
 
 const std = @import("std");
 const ast_mod = @import("../parser/ast.zig");
@@ -114,6 +114,7 @@ fn emitImportDeclaration(
             .span = local_text,
             .data = .{ .string_ref = local_text },
         });
+        try self.markRuntimeHelperRef(local_node);
 
         const spec = try self.ast.addNode(.{
             .tag = .import_specifier,

--- a/tests/e2e/tests/lib-scenario-e2e.test.ts
+++ b/tests/e2e/tests/lib-scenario-e2e.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 import { spawnSync } from 'node:child_process';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { join, resolve, dirname } from 'node:path';
 import { serve, closeServer } from './serve';
 
 /**
@@ -25,6 +25,8 @@ type Scenario = {
   packages: string[];
   entry: string;
   entryFile?: string;
+  /** entry 외 추가 fixture 파일. `mkdir -p` + writeFile 처리. */
+  files?: Record<string, string>;
   expect: Record<string, string>;
   extraArgs?: string[];
 };
@@ -357,6 +359,39 @@ BBPromise.resolve('bb-ok').then((v: string) => {
     },
   },
   {
+    // 회귀 테스트 — #3068 helper scope 격리: 사용자가 `_jsx` 식별자를 의도적으로
+    // 선언한 경우에도 JSX runtime call 이 사용자 binding 으로 잘못 묶이지 않아야 한다.
+    // 사용자 함수 `_jsx` (`user-jsx-...` 반환) 와 JSX call 결과 (`<p>JSX-ok</p>`) 가
+    // 모두 자기 의도대로 동작하는지 검증.
+    name: 'H4_preact_jsx_user_id_collision',
+    category: 'H_jsx_ts',
+    packages: ['preact'],
+    entryFile: 'index.tsx',
+    extraArgs: ['--jsx=automatic', '--jsx-import-source=preact'],
+    entry: `import { render } from 'preact';
+
+const _jsx = (msg: string) => \`user-jsx-\${msg}\`;
+const userOut = _jsx('hi');
+
+function App() {
+  return <p data-testid="jsx">JSX-ok</p>;
+}
+
+const mount = document.createElement('div');
+document.body.appendChild(mount);
+render(<App />, mount);
+
+const userP = document.createElement('p');
+userP.setAttribute('data-testid', 'user');
+userP.textContent = userOut;
+document.body.appendChild(userP);
+`,
+    expect: {
+      jsx: 'JSX-ok',
+      user: 'user-jsx-hi',
+    },
+  },
+  {
     // 회귀 테스트 — #3062 (`--jsx=automatic --jsx-import-source=preact`):
     // transformer 가 JSX runtime import 를 정식 AST 노드로 추가하지 않고 parser_metadata
     // 가 synthetic ImportRecord/Binding 만 inject 하던 우회 경로 때문에, ESM
@@ -396,6 +431,63 @@ createApp({
 `,
     expect: {
       vue: 'vue-ok',
+    },
+  },
+  {
+    // 회귀 테스트 — 여러 모듈이 같은 jsx-runtime 을 import 할 때 각 모듈이 독립적으로
+    // 정상 emit. 기존 zig test "JSX automatic: multiple modules sharing same jsx-runtime"
+    // 의 e2e 대체.
+    name: 'H5_preact_jsx_multi_module',
+    category: 'H_jsx_ts',
+    packages: ['preact'],
+    entryFile: 'index.tsx',
+    extraArgs: ['--jsx=automatic', '--jsx-import-source=preact'],
+    files: {
+      'CompA.tsx': `export function CompA() { return <span data-testid="a">A</span>; }\n`,
+      'CompB.tsx': `export function CompB() { return <span data-testid="b">B</span>; }\n`,
+    },
+    entry: `import { render } from 'preact';
+import { CompA } from './CompA';
+import { CompB } from './CompB';
+
+function App() {
+  return <div><CompA /><CompB /></div>;
+}
+
+const mount = document.createElement('div');
+document.body.appendChild(mount);
+render(<App />, mount);
+`,
+    expect: {
+      a: 'A',
+      b: 'B',
+    },
+  },
+  {
+    // 회귀 테스트 — JSX 컴포넌트 re-export (barrel 파일) 통과 후 정상 emit. 기존 zig
+    // test "JSX automatic: re-export of JSX component" 의 e2e 대체.
+    name: 'H6_preact_jsx_re_export',
+    category: 'H_jsx_ts',
+    packages: ['preact'],
+    entryFile: 'index.tsx',
+    extraArgs: ['--jsx=automatic', '--jsx-import-source=preact'],
+    files: {
+      'Button.tsx': `export function Button() { return <button data-testid="btn">Click</button>; }\n`,
+      'barrel.ts': `export { Button } from './Button';\n`,
+    },
+    entry: `import { render } from 'preact';
+import { Button } from './barrel';
+
+function App() {
+  return <div><Button /></div>;
+}
+
+const mount = document.createElement('div');
+document.body.appendChild(mount);
+render(<App />, mount);
+`,
+    expect: {
+      btn: 'Click',
     },
   },
   {
@@ -457,6 +549,14 @@ for (const s of SCENARIOS) {
 
     const entryFile = s.entryFile ?? 'index.ts';
     await writeFile(join(caseDir, entryFile), s.entry);
+    if (s.files) {
+      for (const [relPath, content] of Object.entries(s.files)) {
+        const filePath = join(caseDir, relPath);
+        const dir = dirname(filePath);
+        if (dir !== caseDir) await mkdir(dir, { recursive: true });
+        await writeFile(filePath, content);
+      }
+    }
     const outFile = join(caseDir, 'bundle.js');
     const build = spawnSync(
       ZNTC_BIN,


### PR DESCRIPTION
## Summary

#3067 후속. transformer 가 JSX runtime import 를 정식 AST 노드로 추가하는 새 경로 완성 후, 사용자가 `const _jsx = ...` 처럼 같은 이름을 의도적으로 선언했을 때 JSX call 이 사용자 binding 으로 잘못 묶이는 회귀를 fix.

## 검증한 회귀

```tsx
import { render } from 'preact';
const _jsx = (msg) => `user-jsx-${msg}`;
console.log(_jsx('hello'));
function App() { return <p>JSX-ok</p>; }
render(<App />, mount);
```

| 단계 | 결과 |
|---|---|
| **fix 전** | `function App() { return u$1("p", ...); }` ← JSX call 이 사용자 함수 호출 |
| **fix 후** | 사용자 `_jsx` 그대로, JSX call 은 source 의 canonical `u$1` (별개 식별자) |

## Root cause

기존 helper marker (#2869) 메커니즘이 semantic analyzer 단계에서 helper symbol 을 `helper_scope_map` 에 격리해도, 다음 두 경로가 사용자 binding 과 분리되지 않았다:
1. `binding_scanner` 가 만드는 `ImportBinding` 에 helper marker 정보 없음
2. linker `populateImportSymbols` 가 module_scope 만 lookup → user 가 점유하면 helper binding 의 `local_symbol` 이 사용자 sym_idx 로 잘못 set

## 변경

| 영역 | 변경 |
|---|---|
| `ImportBinding.is_helper` 필드 추가 | binding_scanner.zig |
| `extractImportBindings` 가 `helper_ref_nodes` 받아 매칭 → `is_helper` set | binding_scanner.zig |
| 호출처 갱신 (json_module / transform_prepass) | cache.helper_ref_nodes 전달 |
| `ModuleSemanticData.helper_scope_map` 노출 | module.zig |
| transform_prepass 의 semantic refresh 가 `analyzer.helper_scope_map` 전달 | transform_prepass.zig |
| linker `populateImportSymbols` 가 `is_helper` 면 `helper_scope_map` lookup | linker.zig |
| `jsx_lowering` 의 ref 생성 8곳을 `makeJsxRuntimeRef` 헬퍼로 묶고 marker 등록 | jsx_lowering.zig |
| `jsx_runtime_imports` 의 import_specifier local_node 에 marker | jsx_runtime_imports.zig |

## 회귀 테스트 (e2e)

`tests/e2e/tests/lib-scenario-e2e.test.ts` 에 시나리오 3개 추가 (substring assertion 보다 DOM 검증이 robust):
- **H4_preact_jsx_user_id_collision**: 사용자 `_jsx` 식별자 + JSX 사용 동시. 사용자 함수와 JSX call 이 각자 의도대로 동작
- **H5_preact_jsx_multi_module**: CompA / CompB / entry 가 동시에 JSX 사용 — 여러 모듈이 jsx-runtime 공유 시 각 모듈이 독립 정상 emit
- **H6_preact_jsx_re_export**: barrel 파일 통과 후 JSX 컴포넌트 정상 동작

기존 4개 skip 한 `bundler_test/plugin_misc.zig` 의 NOTE 도 새 e2e 시나리오 link 로 강화 — substring assertion 이 brittle 하니 e2e 가 더 정확한 회귀 cover.

## 검증

- 빌드: ReleaseFast OK
- zig test: 통과 (skip 4 + 동등 동작은 e2e 가 cover)
- e2e lib-scenario: **13/13 통과** (H1/H4/H5/H6 모두 포함)
- integration: **3714 pass / 0 fail**

## 후속

- 나머지 synthetic (Flow enum / esm_wrap default 등) 도 같은 helper scope 통합 패턴으로 마이그레이션 → `isSynthetic` 분기 7곳 점진 제거. 별도 epic.

## Test plan

- [x] `bun run build:zntc` (ReleaseFast)
- [x] `zig build test`
- [x] e2e lib-scenario (H4 회귀 테스트 포함)
- [x] integration 전체
- [x] 충돌 fixture 수동 검증 (사용자 _jsx + JSX 동시)

Closes #3068

🤖 Generated with [Claude Code](https://claude.com/claude-code)