### PR TITLE
docs(pages): HTTPS dev server / Web Worker 사용자 가이드 추가 (KO/EN)

### DIFF
--- a/documents/src/content/docs/en/guides/bundling.md
+++ b/documents/src/content/docs/en/guides/bundling.md
@@ -130,6 +130,42 @@ zntc --bundle entry.ts --loader:.png=file --loader:.svg=dataurl
 
 Supported loaders: `js`, `ts`, `json`, `text`, `css`, `file`, `dataurl`, `binary`, `copy`, `empty`
 
+## Web Worker
+
+ZNTC auto-detects the `new Worker(new URL("./worker.ts", import.meta.url))` pattern and emits the worker entry as a **standalone IIFE bundle**. No additional build configuration or entry option is needed.
+
+```ts
+// src/main.ts
+const worker = new Worker(new URL("./worker.ts", import.meta.url));
+worker.postMessage({ task: "compute", n: 1000 });
+worker.onmessage = (e) => console.log(e.data);
+
+// src/worker.ts
+self.onmessage = (e) => {
+  const { task, n } = e.data;
+  if (task === "compute") {
+    let sum = 0;
+    for (let i = 0; i < n; i++) sum += i;
+    self.postMessage({ sum });
+  }
+};
+```
+
+`SharedWorker` is auto-detected with the same pattern (`new SharedWorker(new URL(...))`).
+
+### Output
+
+The worker entry is emitted as a **separate chunk** (not an import dependency of the main bundle). Its filename follows the `--chunk-names` pattern, and the `new Worker(new URL(...))` call site in the main bundle is automatically rewritten to point at the built worker URL. The worker chunk's module format is always IIFE (or CJS when bundling for a Node CJS target).
+
+### Limitations
+
+- Only the **exact static pattern** `new Worker(new URL(...))` / `new SharedWorker(new URL(...))` is auto-detected. These forms are not picked up:
+  - URL stored in a variable: `const url = new URL(...); new Worker(url);`
+  - Dynamic path: `new Worker(new URL(\`./${name}.ts\`, import.meta.url))`
+  - Aliased constructor: `const W = Worker; new W(new URL(...))`
+- The second-argument options object (e.g. `{ type: "module" }`) is ignored — workers are always bundled as IIFE. If you need an ESM module worker, build it as a separate entry and pass the URL manually.
+- `ServiceWorker` is not auto-detected. Build it as a separate entry and pass the resulting URL manually.
+
 ## Filename Patterns
 
 ```bash

--- a/documents/src/content/docs/en/guides/dev-server.md
+++ b/documents/src/content/docs/en/guides/dev-server.md
@@ -371,6 +371,31 @@ export default defineConfig({
 | `strictPort` | `boolean` | `false` | If `true`, exit on port conflict instead of falling back to the next port. |
 | `open` | `boolean` | `false` | Open the served URL in the browser after startup. CLI `--open` overrides. |
 
+## HTTPS — `--certfile` / `--keyfile`
+
+Pass PEM-encoded cert / key files and the dev server listens on `https://localhost:12300`. HMR WebSockets are automatically upgraded to `wss://`.
+
+```bash
+zntc dev . --certfile ./certs/dev.pem --keyfile ./certs/dev-key.pem
+```
+
+### Generating a self-signed cert
+
+For local development, [`mkcert`](https://github.com/FiloSottile/mkcert) is the easiest option — it sets up a local CA in your system trust store, so browsers don't show security warnings.
+
+```bash
+mkcert -install
+mkcert localhost 127.0.0.1
+# → localhost+1.pem (cert) / localhost+1-key.pem (key)
+
+zntc dev . --certfile ./localhost+1.pem --keyfile ./localhost+1-key.pem
+```
+
+### Limitations
+
+- TLS is only supported on the Node / Bun JS dev server (`zntc dev <root>`). `zntc serve` running as a standalone server does not support TLS — if you need a binary without Node installed, terminate TLS at an external reverse proxy (nginx / Caddy) in front of the dev server.
+- Browser trust for self-signed certs depends on the OS / browser. Without `mkcert -install`, you may need workarounds like Chrome flags or `--ignore-certificate-errors`.
+
 ## Lazy sourcemap — `emitDiskSourcemap` + `WatchHandle`
 
 When you host a dev server directly on top of `@zntc/core`'s `watch()` handle, this moves the `.map` disk-write cost out of HMR latency.

--- a/documents/src/content/docs/guides/bundling.md
+++ b/documents/src/content/docs/guides/bundling.md
@@ -130,6 +130,42 @@ zntc --bundle entry.ts --loader:.png=file --loader:.svg=dataurl
 
 지원 로더: `js`, `ts`, `json`, `text`, `css`, `file`, `dataurl`, `binary`, `copy`, `empty`
 
+## Web Worker
+
+`new Worker(new URL("./worker.ts", import.meta.url))` 패턴을 자동 감지해 워커 엔트리를 **별도 IIFE 번들** 로 분리합니다. 사용자가 빌드 설정이나 entry 옵션을 추가할 필요가 없습니다.
+
+```ts
+// src/main.ts
+const worker = new Worker(new URL("./worker.ts", import.meta.url));
+worker.postMessage({ task: "compute", n: 1000 });
+worker.onmessage = (e) => console.log(e.data);
+
+// src/worker.ts
+self.onmessage = (e) => {
+  const { task, n } = e.data;
+  if (task === "compute") {
+    let sum = 0;
+    for (let i = 0; i < n; i++) sum += i;
+    self.postMessage({ sum });
+  }
+};
+```
+
+`SharedWorker` 도 동일한 패턴 (`new SharedWorker(new URL(...))`) 으로 자동 감지됩니다.
+
+### 출력
+
+워커 엔트리는 메인 번들의 import dependency 가 아닌 **별도 chunk** 로 생성됩니다. 파일명은 `--chunk-names` 패턴을 따르며, 메인 번들의 `new Worker(new URL(...))` 호출부는 빌드된 워커 파일 URL 로 자동 치환됩니다. 워커 chunk 의 모듈 포맷은 항상 IIFE 입니다 (Node CJS 타겟 빌드에서는 CJS).
+
+### 한계
+
+- `new Worker(new URL(...))` / `new SharedWorker(new URL(...))` 의 **정확한 정적 패턴** 만 자동 감지합니다. 다음 형태는 미감지:
+  - 변수에 담긴 URL: `const url = new URL(...); new Worker(url);`
+  - 동적 경로: `new Worker(new URL(\`./${name}.ts\`, import.meta.url))`
+  - 별도 별칭 변수: `const W = Worker; new W(new URL(...))`
+- 두 번째 인수 옵션 객체 (`{ type: "module" }` 등) 는 무시되고 항상 IIFE 로 번들됩니다. ESM module worker 가 필요하면 별도 entry 로 빌드하고 URL 을 직접 지정하세요.
+- `ServiceWorker` 는 자동 감지하지 않습니다. 별도 entry 로 빌드한 뒤 사용자가 직접 URL 을 지정하세요.
+
 ## 파일명 패턴
 
 ```bash

--- a/documents/src/content/docs/guides/dev-server.md
+++ b/documents/src/content/docs/guides/dev-server.md
@@ -371,6 +371,31 @@ export default defineConfig({
 | `strictPort` | `boolean` | `false` | `true` 면 포트 점유 시 다음 포트로 fallback 하지 않고 종료. |
 | `open` | `boolean` | `false` | 시작 후 served URL 을 브라우저에서 자동 열기. CLI `--open` 가 override. |
 
+## HTTPS — `--certfile` / `--keyfile`
+
+PEM 형식 cert / key 파일을 지정하면 dev server 가 `https://localhost:12300` 으로 listen 합니다. HMR WebSocket 도 자동으로 `wss://` 로 업그레이드됩니다.
+
+```bash
+zntc dev . --certfile ./certs/dev.pem --keyfile ./certs/dev-key.pem
+```
+
+### Self-signed cert 만들기
+
+로컬 개발용으로 [`mkcert`](https://github.com/FiloSottile/mkcert) 같은 도구가 가장 편합니다 — 로컬 CA 를 시스템 trust store 에 자동 등록해 줘서 브라우저 보안 경고 없이 사용할 수 있습니다.
+
+```bash
+mkcert -install
+mkcert localhost 127.0.0.1
+# → localhost+1.pem (cert) / localhost+1-key.pem (key) 생성
+
+zntc dev . --certfile ./localhost+1.pem --keyfile ./localhost+1-key.pem
+```
+
+### 한계
+
+- TLS 는 Node / Bun 런타임의 JS dev server (`zntc dev <root>`) 에서만 지원합니다. `zntc serve` 로 띄우는 standalone 서버는 TLS 미지원 — Node 미설치 환경이 필요하면 dev server 앞에 별도 reverse proxy (nginx / Caddy) 로 TLS termination 을 위임하세요.
+- self-signed cert 의 브라우저 신뢰는 OS / 브라우저별로 다릅니다. `mkcert -install` 미사용 시 Chrome flags 또는 `--ignore-certificate-errors` 같은 우회가 필요할 수 있습니다.
+
 ## Lazy sourcemap — `emitDiskSourcemap` + `WatchHandle`
 
 `@zntc/core` 의 `watch()` 핸들로 dev server 를 직접 호스팅할 때 — `.map` 디스크 쓰기 비용을 HMR latency 밖으로 빼냅니다.


### PR DESCRIPTION
## Summary

ROADMAP 상 ✅ 완료된 두 기능이 사용자 페이지에 0 mentions 였던 격차를 채움.

### 1. HTTPS dev server (`--certfile` / `--keyfile`)

`documents/src/content/docs/guides/dev-server.md` (+ EN) — `## Proxy` / `## server config` 다음, `## Lazy sourcemap` 직전에 새 섹션.

내용:
- PEM cert / key 사용법 + HMR WebSocket 자동 `wss://` 업그레이드
- `mkcert` 로 self-signed cert 생성 절차
- 한계: Node/Bun JS dev server 전용. `zntc serve` (Zig 네이티브) 는 TLS 미지원 → 외부 reverse proxy 권장. self-signed cert 브라우저 신뢰는 OS/브라우저별.

### 2. Web Worker 자동 감지

`documents/src/content/docs/guides/bundling.md` (+ EN) — `## Loader` 와 `## 파일명 패턴` 사이에 새 섹션.

내용:
- `new Worker(new URL(...))` / `new SharedWorker(new URL(...))` 정확한 정적 패턴 자동 감지
- 별도 chunk (IIFE; Node CJS 타겟에서는 CJS) 로 emit, 메인 번들 호출부 자동 URL rewrite
- 한계 (사실 검증 후 정확화):
  - 두 번째 인수 옵션 객체 (`{ type: \"module\" }` 등) 는 **무시** — 항상 IIFE 로 번들 (실제 구현 검증으로 정정)
  - `ServiceWorker` 미감지, `SharedWorker` 는 감지됨 (실제 구현 검증으로 정정)
  - 변수 / 동적 경로 / 별칭 constructor 미감지

## Test plan
- [x] `bun run build` (documents/) — 509 페이지 빌드 성공, internal link 검증 통과
- [x] HTTPS 동작 (`zntc.mjs:1575,1617-1622,1657-1662` cert/key 핸들링, `dev_server.zig:86` wss 분기) fact-check
- [x] Web Worker 자동 감지 (`import_scanner.zig:907`, `parser/expression/scan.zig:164` Worker/SharedWorker, `bundler.zig:652-654` workerFormat IIFE/CJS) fact-check
- [x] Memory rule 준수: PR 번호 / 성능 history / D-ID / 구현 비교 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)