### PR TITLE
docs(bundler): extractImportBindings 의 helper_ref_nodes sortedness invariant 명시

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -147,10 +147,14 @@ pub const ExportBinding = struct {
 
 /// AST에서 import 바인딩 상세를 추출한다.
 /// import_record_map: import source span → ImportRecord 인덱스 매핑
-/// `helper_ref_nodes` 가 non-null 이면 import_specifier 의 local_node idx 가 그 sorted slice
-/// 에 있을 때 해당 binding 에 `is_helper=true` 를 set 한다. linker 가 이 binding 의 local_symbol
+/// `helper_ref_nodes` 가 non-null 이면 import_specifier 의 local_node idx 가 그 slice 에
+/// 있을 때 해당 binding 에 `is_helper=true` 를 set 한다. linker 가 이 binding 의 local_symbol
 /// 을 일반 module_scope 가 아닌 격리된 helper_scope_map 에서 찾도록 보장 — 사용자가 같은
 /// 식별자를 선언해도 충돌 회피 (#3068).
+///
+/// `helper_ref_nodes` 는 ascending sorted 여야 한다 (binary search 전제). transformer 의
+/// `markRuntimeHelperRef` 가 새 NodeIndex 만 단조 증가로 append → `ownedHelperRefNodes` 가
+/// 그 invariant 를 보존하며 sort 한다 (analyzer.zig 의 `isHelperRefNode` 도 동일 가정).
 pub fn extractImportBindings(
     allocator: std.mem.Allocator,
     ast: *const Ast,


### PR DESCRIPTION
## Summary

#3068 (#3071) simplify follow-up. `extractImportBindings` 의 `helper_ref_nodes` 파라미터가 binary search 의 전제로 ascending sorted 여야 한다는 invariant 를 doc 에 명시.

`markRuntimeHelperRef` 가 단조 증가 NodeIndex 만 append → `ownedHelperRefNodes` 가 그 invariant 보존하며 sort. analyzer.zig 의 `isHelperRefNode` 도 동일 가정.

doc 변경뿐 — 빌드/동작 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)