### PR TITLE
test(e2e): JSX automatic callee 분기 회귀 테스트 — static children / fragment

### DIFF
--- a/tests/e2e/tests/lib-scenario-e2e.test.ts
+++ b/tests/e2e/tests/lib-scenario-e2e.test.ts
@@ -418,6 +418,65 @@ render(<App />, mount);
     },
   },
   {
+    // 회귀 테스트 — JSX element 의 static children 여러 개 → `_jsxs` 사용 경로.
+    // automatic transform 의 callee 분기 (`_jsx` vs `_jsxs`) 가 helper marker 와
+    // 함께 정상 동작하는지 검증.
+    name: 'H7_preact_jsx_static_children',
+    category: 'H_jsx_ts',
+    packages: ['preact'],
+    entryFile: 'index.tsx',
+    extraArgs: ['--jsx=automatic', '--jsx-import-source=preact'],
+    entry: `import { render } from 'preact';
+
+function App() {
+  return (
+    <div>
+      <span data-testid="c1">one</span>
+      <span data-testid="c2">two</span>
+      <span data-testid="c3">three</span>
+    </div>
+  );
+}
+
+const mount = document.createElement('div');
+document.body.appendChild(mount);
+render(<App />, mount);
+`,
+    expect: {
+      c1: 'one',
+      c2: 'two',
+      c3: 'three',
+    },
+  },
+  {
+    // 회귀 테스트 — JSX fragment (`<>...</>`) + static children → `_jsxs(_Fragment, ...)`.
+    // _Fragment helper ref 도 marker 를 거치는지 검증.
+    name: 'H8_preact_jsx_fragment_static',
+    category: 'H_jsx_ts',
+    packages: ['preact'],
+    entryFile: 'index.tsx',
+    extraArgs: ['--jsx=automatic', '--jsx-import-source=preact'],
+    entry: `import { render } from 'preact';
+
+function App() {
+  return (
+    <>
+      <span data-testid="f1">alpha</span>
+      <span data-testid="f2">beta</span>
+    </>
+  );
+}
+
+const mount = document.createElement('div');
+document.body.appendChild(mount);
+render(<App />, mount);
+`,
+    expect: {
+      f1: 'alpha',
+      f2: 'beta',
+    },
+  },
+  {
     name: 'H2_vue_h_render',
     category: 'H_jsx_ts',
     packages: ['vue'],


### PR DESCRIPTION
## Summary

#3068 follow-up. JSX automatic transform 의 callee 분기 (`_jsx` vs `_jsxs`) 가 helper marker 와 함께 정상 동작하는지 브라우저 DOM 검증으로 cover.

- **H7_preact_jsx_static_children**: `<div>` 안 span 3개 → `_jsxs(_jsx, ...)` 경로
- **H8_preact_jsx_fragment_static**: `<>...</>` 안 span 2개 → `_jsxs(_Fragment, ...)` 경로

기존 `bundler_test/plugin_misc.zig` 의 substring assertion ("JSX automatic: fragment syntax uses _Fragment" 등) 의 e2e 보강.

dev/HMR JSX 시나리오는 별도 issue 로 분리 — dev server 인프라 + 새 fixture/port 가 필요하고, build 모드 JSX 8개 (H1~H8) 로 transformer 의 JSX 코드는 이미 충분히 cover (dev 모드도 같은 transformer prepass).

## 검증

lib-scenario **15/15 통과** + type-check OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)