### PR TITLE
refactor(bundler): dead mergeImportBindings synthetic-only loop 제거

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -64,8 +64,11 @@ pub const ImportBinding = struct {
         namespace,
     };
 
-    /// Synthetic binding (JSX runtime 등, graph.zig에서 sentinel span으로 주입)
-    /// 감지. 실제 AST import에는 없고 linker/emitter가 인공 생성한 바인딩.
+    /// Synthetic binding (JSX runtime 등 — graph 가 인공 생성하던 sentinel-span 바인딩).
+    /// #3067 (JSX synthetic 우회 제거) 이후 이 sentinel 을 set 하는 생성처가 없어
+    /// `isSynthetic()` 는 항상 false. 잔여 분기 (linker / emitter / metadata 의 7곳)
+    /// 제거는 후속 — `metadata.zig` 의 `is_synthetic_esm` / `is_synthetic` 변수가
+    /// emit 분기 여러 곳에서 쓰여 점진적 검증 필요.
     pub const SYNTHETIC_SPAN_BASE: u32 = 0xFFFF_0000;
 
     pub fn isSynthetic(self: ImportBinding) bool {

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -54,7 +54,6 @@ pub const ModuleGraph = struct {
     pub const matchSideEffectsPatterns = graph_package_side_effects.matchPatterns;
     const configureParserForModule = graph_parse_helpers.configureParserForModule;
     const isFlowPath = graph_parse_helpers.isFlowPath;
-    const mergeImportBindings = graph_parse_helpers.mergeImportBindings;
     const mergeImportRecords = graph_parse_helpers.mergeImportRecords;
     const requestAllExports = graph_requested_exports.requestAll;
     const requestNamedExport = graph_requested_exports.requestNamed;

--- a/src/bundler/graph/parse_helpers.zig
+++ b/src/bundler/graph/parse_helpers.zig
@@ -66,42 +66,6 @@ fn hasImportRecord(records: []const ImportRecord, needle: ImportRecord) bool {
     return false;
 }
 
-/// post-transform AST 의 binding 을 source of truth 로 삼고, `previous` 에서 transformer
-/// 가 직접 추가한 synthetic binding (JSX runtime 등 - span sentinel 로 식별) 만 보존한다.
-/// 단순 append 로 합치면 Phase D 가 elide 한 import specifier 에 대응하는 stale binding
-/// 이 살아남아 linker preamble 이 `var err = require_xxx().err` 같은 죽은 코드를 emit
-/// 하거나 `non-synthetic import binding 'err' has no semantic local symbol` panic 을 낸다.
-pub fn mergeImportBindings(
-    arena_alloc: std.mem.Allocator,
-    previous: []const binding_scanner.ImportBinding,
-    transformed: []const binding_scanner.ImportBinding,
-) ![]binding_scanner.ImportBinding {
-    var bindings: std.ArrayList(binding_scanner.ImportBinding) = .empty;
-    errdefer bindings.deinit(arena_alloc);
-    try bindings.appendSlice(arena_alloc, transformed);
-    for (previous) |binding| {
-        if (!binding.isSynthetic()) continue;
-        if (hasImportBinding(bindings.items, binding)) continue;
-        try bindings.append(arena_alloc, binding);
-    }
-    return bindings.toOwnedSlice(arena_alloc);
-}
-
-fn hasImportBinding(bindings: []const binding_scanner.ImportBinding, needle: binding_scanner.ImportBinding) bool {
-    for (bindings) |binding| {
-        if (binding.kind == needle.kind and
-            binding.import_record_index == needle.import_record_index and
-            binding.local_span.start == needle.local_span.start and
-            binding.local_span.end == needle.local_span.end and
-            std.mem.eql(u8, binding.local_name, needle.local_name) and
-            std.mem.eql(u8, binding.imported_name, needle.imported_name))
-        {
-            return true;
-        }
-    }
-    return false;
-}
-
 /// `ExportBinding[]` -> `[]const []const u8` 평탄 이름 슬라이스 (#1883).
 /// `ModuleInfo` 가 binding_scanner internal struct 를 노출 안 하도록 사전 투영.
 /// 실패 시 빈 슬라이스 - caller 가 fallback 가능하게.

--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -19,7 +19,6 @@ const parse_helpers = @import("parse_helpers.zig");
 const isFlowPath = parse_helpers.isFlowPath;
 const suppressRuntimeHelperInternalUnresolved = parse_helpers.suppressRuntimeHelperInternalUnresolved;
 const mergeImportRecords = parse_helpers.mergeImportRecords;
-const mergeImportBindings = parse_helpers.mergeImportBindings;
 const projectExportedNames = parse_helpers.projectExportedNames;
 const determineExportsKind = parse_helpers.determineExportsKind;
 
@@ -351,7 +350,6 @@ pub fn resyncAfterAstMutation(
 
     const ast = &(module.ast orelse return);
     const previous_import_records = module.import_records;
-    const previous_import_bindings = module.import_bindings;
 
     try refreshSemanticAndStmtInfoAfterAstMutation(self, module, arena_alloc);
 
@@ -373,9 +371,11 @@ pub fn resyncAfterAstMutation(
         var import_bindings_scope = profile.begin(.graph_resync_import_bindings);
         defer import_bindings_scope.end();
 
+        // #3067 이후 transformer 가 직접 추가하던 synthetic ImportBinding (JSX runtime
+        // 등) 이 정식 import 노드로 대체됐다 — post-transform AST 에서 일반 binding 으로
+        // 추출되므로 previous 에서 따로 보존할 synthetic binding 이 없다.
         const helper_refs: ?[]const u32 = if (module.transform_cache) |cache| cache.helper_ref_nodes else null;
-        const transformed_import_bindings = try binding_scanner_mod.extractImportBindings(arena_alloc, ast, module.import_records, helper_refs);
-        module.import_bindings = try mergeImportBindings(arena_alloc, previous_import_bindings, transformed_import_bindings);
+        module.import_bindings = try binding_scanner_mod.extractImportBindings(arena_alloc, ast, module.import_records, helper_refs);
         try binding_scanner_mod.collectNamespaceAccesses(arena_alloc, ast, module.import_bindings);
     }
 


### PR DESCRIPTION
## Summary

#3068 follow-up. `mergeImportBindings` 는 post-transform binding 에 previous 의 synthetic ImportBinding (JSX runtime 등 — sentinel span) 만 보존하던 함수. #3067 에서 transformer 가 JSX runtime import 를 정식 AST 노드로 대체하면서 synthetic ImportBinding 을 만드는 생성처가 사라져 이 loop 가 항상 no-op. caller 는 `extractImportBindings` 결과를 직접 할당하면 충분.

## 변경

- `parse_helpers.zig`: `mergeImportBindings` / `hasImportBinding` 제거 (-36 라인)
- `transform_prepass.zig`: caller 직접 할당 + `previous_import_bindings` / alias 제거
- `graph.zig`: 무용 `mergeImportBindings` alias 제거
- `binding_scanner.zig`: `SYNTHETIC_SPAN_BASE` / `isSynthetic` 정의는 유지 — 잔여 분기 (linker / emitter / metadata 의 7곳, 모두 dead) 제거는 후속. `metadata.zig` 의 `is_synthetic_esm` / `is_synthetic` 변수가 emit 분기 여러 곳에서 쓰여 점진 검증 필요.

순 변경: +9 / -43.

## 검증

- `zig build test` 통과
- e2e lib-scenario **15/15 통과**
- ReleaseFast 빌드 OK

## 후속

잔여 `isSynthetic` 7곳 분기 + 정의 제거는 별도 PR — `metadata.zig` 의 `is_synthetic_esm` / `is_synthetic` 변수가 IIFE / ESM-wrap / CJS interop 의 emit 분기에서 쓰여 각각 검증 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)