### PR TITLE
refactor(bundler): isSynthetic() → is_helper 로 명확화 (안전 케이스 2곳)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1110,7 +1110,9 @@ fn shouldSkipLazyBarrelEmit(
 
     for (module.import_bindings) |binding| {
         if (binding.kind == .namespace) return false;
-        if (binding.isSynthetic()) return false;
+        // helper marker binding (JSX runtime / runtime helper import) 이 있으면 단순
+        // re-export barrel 이 아니다 — elide 대상에서 제외.
+        if (binding.is_helper) return false;
     }
 
     for (module.export_bindings) |binding| {

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -428,14 +428,14 @@ pub const Module = struct {
     }
 
     /// ImportBinding의 현재 모듈 로컬 이름.
-    /// 일반 import 는 semantic ref 에서 이름을 가져와야 한다. synthetic import
-    /// binding(JSX runtime 등)은 semantic scope 에 실제 로컬 선언이 없으므로 scanner 가
-    /// 저장한 `local_name` 이 canonical source of truth 다.
+    /// 일반 import 는 semantic ref 에서 이름을 가져온다. helper marker binding (JSX
+    /// runtime / runtime helper) 은 user 가 같은 이름을 점유했을 때 semantic scope 에
+    /// 로컬이 없을 수 있으므로 scanner 가 저장한 `local_name` 이 fallback.
     pub fn importBindingLocalName(self: *const Module, ib: ImportBinding) []const u8 {
         if (self.refName(ib.local_symbol)) |name| return name;
-        if (ib.isSynthetic()) return ib.local_name;
+        if (ib.is_helper) return ib.local_name;
         std.debug.panic(
-            "non-synthetic import binding '{s}' in module '{s}' has no semantic local symbol",
+            "non-helper import binding '{s}' in module '{s}' has no semantic local symbol",
             .{ ib.local_name, self.path },
         );
     }
@@ -561,7 +561,7 @@ pub const Module = struct {
     }
 };
 
-test "Module.importBindingLocalName allows synthetic binding local_name" {
+test "Module.importBindingLocalName allows helper binding local_name fallback" {
     var module = Module.init(@enumFromInt(0), "synthetic.tsx");
     defer module.deinit(std.testing.allocator);
 
@@ -569,11 +569,9 @@ test "Module.importBindingLocalName allows synthetic binding local_name" {
         .kind = .named,
         .local_name = "_jsx",
         .imported_name = "jsx",
-        .local_span = .{
-            .start = ImportBinding.SYNTHETIC_SPAN_BASE,
-            .end = ImportBinding.SYNTHETIC_SPAN_BASE + 1,
-        },
+        .local_span = Span.EMPTY,
         .import_record_index = 0,
+        .is_helper = true,
     };
 
     try std.testing.expectEqualStrings("_jsx", module.importBindingLocalName(ib));


### PR DESCRIPTION
## Summary

#3068 follow-up. `isSynthetic()` 는 #3067 (JSX synthetic 우회 제거) 이후 항상 false. 그 중 의미가 `is_helper` 로 정확히 치환되는 2곳을 명확화.

- **`module.importBindingLocalName`**: semantic ref 없는 binding 의 fallback — 이제 helper marker binding (JSX runtime / runtime helper, user 가 같은 이름 점유 시 semantic 로컬 없음) 만 해당. `is_helper` 가 정확.
- **`emitter` 의 re-export barrel elide 판정**: helper marker binding 이 있으면 단순 barrel 아님. `is_helper` 로 직접 표현.

## 검증

- `zig build test` 통과
- e2e lib-scenario **15/15 통과**
- ReleaseFast 빌드 OK

## 후속

나머지 `isSynthetic` 5곳 (linker 2곳 / esm_wrap / external_imports / metadata 의 IIFE·ESM-wrap·CJS interop emit 분기) + `isSynthetic` 정의 제거 + Flow enum runtime synthetic 마이그레이션은 별도 epic — `metadata.zig` 의 `is_synthetic_esm` / `is_synthetic` 변수가 emit 분기 여러 곳에서 쓰여 점진 검증 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)