### PR TITLE
refactor(bundler): esm_wrap helper binding hoist + linker isSynthetic 정리 (#3078)

### DIFF
--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -287,12 +287,12 @@ pub fn emitEsmWrappedModule(
         }
     }
 
-    // synthetic JSX import binding: top-level에 var 선언이 필요.
-    // preamble은 __esm init 블록 안에 삽입되므로, var _jsxDEV = ... 형태면
-    // 호이스팅된 함수에서 접근 불가. var _jsxDEV;를 top-level에 선언하고
-    // init 안에서 _jsxDEV = ... (할당만)으로 처리해야 함.
+    // helper marker import binding (JSX runtime / runtime helper): top-level 에
+    // var 선언이 필요. preamble 은 __esm init 블록 안에 삽입되므로, `var _jsxDEV = ...`
+    // 형태면 호이스팅된 함수에서 접근 불가 (#1209). `var _jsxDEV;` 를 top-level 에
+    // 선언하고 init 안에서 `_jsxDEV = ...` (할당만) 으로 처리.
     for (module.import_bindings) |ib| {
-        if (ib.isSynthetic()) {
+        if (ib.is_helper) {
             try hoisted_var_names.append(allocator, try arena_alloc.dupe(u8, module.importBindingLocalName(ib)));
         }
     }

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1431,21 +1431,19 @@ pub const Linker = struct {
             const mod_idx: bundler_symbol.ModuleIndex = @enumFromInt(i);
 
             for (importer.import_bindings) |*ib| {
-                // current-side: scope_maps[0]에서 로컬 심볼 조회
+                // current-side: scope_maps[0]에서 로컬 심볼 조회.
+                // #3068: helper binding 은 user 가 같은 이름을 선언했어도 격리된
+                // helper_scope_map 에서 lookup. 일반 module_scope.get 가 user 의 sym_idx 를
+                // 반환하면 JSX call 이 user binding 으로 잘못 묶인다.
                 if (module_scope_opt) |module_scope| {
-                    if (!ib.isSynthetic()) {
-                        // #3068: helper binding 은 user 가 같은 이름을 선언했어도 격리된
-                        // helper_scope_map 에서 lookup. 일반 module_scope.get 가 user 의
-                        // sym_idx 를 반환하면 JSX call 이 user binding 으로 잘못 묶인다.
-                        const sym_lookup = if (ib.is_helper) blk: {
-                            if (importer.semantic) |*sem| {
-                                if (sem.helper_scope_map.get(ib.local_name)) |sym_idx| break :blk @as(?usize, sym_idx);
-                            }
-                            break :blk @as(?usize, null);
-                        } else module_scope.get(ib.local_name);
-                        if (sym_lookup) |sym_idx| {
-                            ib.local_symbol = bundler_symbol.SymbolRef.makeSemantic(mod_idx, sym_idx);
+                    const sym_lookup = if (ib.is_helper) blk: {
+                        if (importer.semantic) |*sem| {
+                            if (sem.helper_scope_map.get(ib.local_name)) |sym_idx| break :blk @as(?usize, sym_idx);
                         }
+                        break :blk @as(?usize, null);
+                    } else module_scope.get(ib.local_name);
+                    if (sym_lookup) |sym_idx| {
+                        ib.local_symbol = bundler_symbol.SymbolRef.makeSemantic(mod_idx, sym_idx);
                     }
                 }
 

--- a/tests/e2e/tests/lib-scenario-e2e.test.ts
+++ b/tests/e2e/tests/lib-scenario-e2e.test.ts
@@ -477,6 +477,28 @@ render(<App />, mount);
     },
   },
   {
+    // 회귀 테스트 — #1209: JSX 컴포넌트를 require() 로 소비하면 그 모듈이 ESM-wrapped
+    // (__esm init 함수) 로 강제된다. helper marker binding (`_jsx` 등) 이 top-level 로
+    // hoist 되지 않으면 init 함수 안의 `var _jsx = ...` 가 호이스팅된 컴포넌트 함수에서
+    // 접근 불가 → `_jsx is not a function`. esm_wrap 의 hoist loop 가 is_helper binding
+    // 을 처리하는지 검증.
+    name: 'H9_preact_jsx_esm_wrapped',
+    category: 'H_jsx_ts',
+    packages: ['preact'],
+    entryFile: 'index.ts',
+    extraArgs: ['--jsx=automatic', '--jsx-import-source=preact'],
+    files: {
+      // .tsx 모듈을 require() 로 소비 → ESM-wrap 강제
+      'Comp.tsx': `import { render } from 'preact';\nexport function mountComp() {\n  const m = document.createElement('div');\n  document.body.appendChild(m);\n  render(<p data-testid="esm">esm-wrapped-ok</p>, m);\n}\n`,
+    },
+    entry: `const { mountComp } = require('./Comp.tsx');
+mountComp();
+`,
+    expect: {
+      esm: 'esm-wrapped-ok',
+    },
+  },
+  {
     name: 'H2_vue_h_render',
     category: 'H_jsx_ts',
     packages: ['vue'],


### PR DESCRIPTION
## Summary

#3068 follow-up. `isSynthetic()` 가 #3067 이후 항상 false 라 두 곳을 의미가 정확한 형태로 정리.

- **`esm_wrap.zig`**: ESM-wrapped 모듈에서 helper binding (`_jsx` 등) 을 top-level 로 hoist 하던 `if (ib.isSynthetic())` loop → `if (ib.is_helper)`. 기존엔 synthetic binding 만 hoist 했으나 #3067 이후 helper binding 이 일반 import binding 으로 처리되므로, ESM-wrapped (`require()` 소비) 모듈의 helper alias `var _jsx = ...` 가 init 함수 안에만 있으면 호이스팅된 컴포넌트 함수에서 접근 불가 (#1209 회귀). is_helper binding 을 hoist 해야 함.
- **`linker.zig`**: `populateImportSymbols` 의 `if (!ib.isSynthetic())` 조건 제거 — 항상 true 였고, helper binding 은 이미 `is_helper` 분기로 helper_scope_map lookup.

## 회귀 테스트

`tests/e2e/tests/lib-scenario-e2e.test.ts` 에 **H9_preact_jsx_esm_wrapped** 추가: JSX 컴포넌트를 `require('./Comp.tsx')` 로 소비 → 그 모듈이 ESM-wrap 강제 → helper binding 의 top-level hoist 가 동작하는지 브라우저 DOM 검증.

## 검증

- `zig build test` 통과
- e2e lib-scenario **16/16 통과** (H9 ESM-wrapped JSX 포함)
- integration **3714 pass / 0 fail**
- ReleaseFast 빌드 OK

## 후속 (#3078 에 남음)

`linker.zig:453` (`!ib.isSynthetic()` 조건), `external_imports.zig:79`, `metadata.zig` 의 `is_synthetic_esm` / `is_synthetic` 변수 (IIFE·ESM-wrap·CJS interop emit 분기) + `isSynthetic` 정의 제거 + Flow enum 마이그레이션.

🤖 Generated with [Claude Code](https://claude.com/claude-code)