### PR TITLE
feat(cli): 문서에만 있던 7개 플래그를 실제 CLI 에 연결 + --mangle-report 문서 제거

### DIFF
--- a/documents/src/content/docs/en/reference/cli.md
+++ b/documents/src/content/docs/en/reference/cli.md
@@ -126,7 +126,6 @@ Options:
 | `--keep-names`                      | Preserve function/class `.name`                                            |
 | `--charset=utf8`                    | Preserve non-ASCII verbatim (parser only accepts `utf8`)                   |
 | `--ascii-only`                      | Non-ASCII → `\uXXXX` (asymmetric — `--charset=ascii` is not accepted)      |
-| `--mangle-report=<path>`            | Emit original-to-mangled identifier map JSON (with `--minify-identifiers`) |
 | `--quotes=double\|single\|preserve` | String quote style                                                         |
 | `--line-limit=<n>`                  | Wrap long output lines at safe token boundaries (`0` disables wrapping)    |
 

--- a/documents/src/content/docs/reference/cli.md
+++ b/documents/src/content/docs/reference/cli.md
@@ -124,7 +124,6 @@ Options:
 | `--keep-names`                      | 함수/클래스 `.name` 보존                                       |
 | `--charset=utf8`                    | non-ASCII 문자를 그대로 유지 (parser 는 `utf8` 만 받음)        |
 | `--ascii-only`                      | non-ASCII → `\uXXXX` (반대 방향 — `--charset=ascii` 는 미지원) |
-| `--mangle-report=<path>`            | minify-identifiers 적용 시 원본↔축약 매핑 JSON 출력            |
 | `--quotes=double\|single\|preserve` | 문자열 따옴표 스타일                                           |
 | `--line-limit=<n>`                  | 안전한 토큰 경계에서 긴 출력 라인 줄바꿈 (`0`은 무제한)        |
 

--- a/packages/core/bin/cli-flags.mjs
+++ b/packages/core/bin/cli-flags.mjs
@@ -85,6 +85,8 @@ export const FLAG_REGISTRY = [
   { kind: 'bool', flag: '--allow-overwrite', target: 'allowOverwrite' },
   { kind: 'bool', flag: '--jsx-side-effects', target: 'jsxSideEffects' },
   { kind: 'bool', flag: '--ignore-annotations', target: 'ignoreAnnotations' },
+  // dev 모드 — HMR 런타임 주입 등 dev 동작 활성화. NAPI BuildOptions.devMode 와 동일.
+  { kind: 'bool', flag: '--dev', target: 'devMode' },
 
   // ─── kind=string — string scalar (`--key=value` 단방향) ───
   { kind: 'string', flag: '--format', target: 'format', forms: ['equal'] },
@@ -175,6 +177,18 @@ export const FLAG_REGISTRY = [
   { kind: 'array', flag: '--drop', target: 'drop', forms: ['equal'] },
   { kind: 'array', flag: '--plugin', target: 'pluginPaths', forms: ['pair'] },
   { kind: 'array', flag: '--runtime-target', target: 'runtimeTargetQueries' },
+  // scope hoisting 시 예약할 전역 식별자 (반복 가능). NAPI BuildOptions.globalIdentifiers.
+  { kind: 'array', flag: '--global-identifier', target: 'globalIdentifiers', forms: ['equal'] },
+  // 번들 시작 시 즉시 실행할 폴리필 경로 / 엔트리 모듈 직전 실행 모듈 (반복 가능, 경로 abs 변환).
+  { kind: 'array', flag: '--polyfill', target: 'polyfills', forms: ['equal'] },
+  { kind: 'array', flag: '--run-before-main', target: 'runBeforeMain', forms: ['equal'] },
+  // 번들 그래프 밖 디렉토리를 감시 루트에 추가 (반복 가능, abs 변환). NAPI BuildOptions.watchFolders.
+  // 주의: RN-CLI 호환 csv flag `--watchFolders` (target=rnWatchFolders, 위 csv 섹션) 와 별개 —
+  // 이쪽은 zntc 네이티브 watcher, 저쪽은 Metro graph-bundler 경로.
+  { kind: 'array', flag: '--watch-folder', target: 'watchFolders', forms: ['equal'] },
+  // watchFolders 스캔 시 포함/제외 glob (반복 가능, 루트 기준 상대 경로 — abs 변환 안 함).
+  { kind: 'array', flag: '--watch-include', target: 'watchInclude', forms: ['equal'] },
+  { kind: 'array', flag: '--watch-exclude', target: 'watchExclude', forms: ['equal'] },
 
   // ─── kind=csv — `,` 분리 → array ───
   { kind: 'csv', flag: '--drop-labels', target: 'dropLabels', forms: ['equal'] },
@@ -185,6 +199,7 @@ export const FLAG_REGISTRY = [
   { kind: 'csv', flag: '--node-paths', target: 'nodePaths', forms: ['equal'] },
   { kind: 'csv', flag: '--profile', target: 'profile', forms: ['equal'] },
   // RN CLI 호환 (#2605 audit P0) — Metro 의 camelCase flag.
+  // 주의: zntc 네이티브 watcher 용 kebab flag `--watch-folder` (target=watchFolders, 위 array 섹션) 와 별개.
   { kind: 'csv', flag: '--watchFolders', target: 'rnWatchFolders' },
   { kind: 'csv', flag: '--sourceExts', target: 'rnSourceExts' },
 

--- a/packages/core/bin/zntc-cli-schema-sync.test.ts
+++ b/packages/core/bin/zntc-cli-schema-sync.test.ts
@@ -378,6 +378,12 @@ describe('CLI flag ↔ BuildOptions / TranspileOptions schema sync', () => {
     // out-extension — esbuild 식 namespace (`--out-extension:.js=`). BuildOptions 의
     // `outExtension: string` (단일) 와 1:N. zntc.mjs 가 `.js` 만 받아 단일 string 으로 변환.
     '--out-extension:.js=',
+    // --dev — CLI shorthand, BuildOptions 는 `devMode: boolean`.
+    '--dev',
+    // 단수 flag 이름 ↔ 복수 BuildOptions 키 (단순 키 매칭으론 추적 안 됨).
+    '--global-identifier=', // → globalIdentifiers
+    '--polyfill=', // → polyfills
+    '--watch-folder=', // → watchFolders (RN-CLI `--watchFolders` csv 와 별개)
   ]);
 
   // BuildOptions/TranspileOptions 에 있고 CLI 에 없는 키 (의도적). 함수형/고급 옵션.

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -247,6 +247,7 @@ function parseArgs(argv) {
     jsxFactory: undefined,
     jsxFragment: undefined,
     jsxImportSource: undefined,
+    devMode: false,
     flow: false,
     experimentalDecorators: false,
     useDefineForClassFields: true,
@@ -1255,6 +1256,17 @@ async function runBundle(opts, config) {
     jsxFragment: opts.jsxFragment,
     jsxImportSource: opts.jsxImportSource,
     inject: opts.inject.map((p) => resolve(p)),
+    devMode: opts.devMode,
+    globalIdentifiers: opts.globalIdentifiers,
+    // --polyfill / --run-before-main / --watch-folder 는 경로 → abs 변환 (--inject 와 동일).
+    // --watch-include / --watch-exclude 는 루트 기준 glob 이므로 변환 안 함.
+    polyfills: opts.polyfills?.length ? opts.polyfills.map((p) => resolve(p)) : undefined,
+    runBeforeMain: opts.runBeforeMain?.length
+      ? opts.runBeforeMain.map((p) => resolve(p))
+      : undefined,
+    watchFolders: opts.watchFolders?.length ? opts.watchFolders.map((p) => resolve(p)) : undefined,
+    watchInclude: opts.watchInclude?.length ? opts.watchInclude : undefined,
+    watchExclude: opts.watchExclude?.length ? opts.watchExclude : undefined,
     jobs: opts.jobs,
     outbase: opts.outbase,
     plugins: plugins.length > 0 ? plugins : undefined,

--- a/packages/core/test/cli/args/basic.ts
+++ b/packages/core/test/cli/args/basic.ts
@@ -56,4 +56,37 @@ describe('CLI: arg parsing > basic flags', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  test('--dev', () => {
+    const dir = createCliInput();
+    try {
+      const { exitCode } = runCli(['--bundle', join(dir, 'input.ts'), '--dev']);
+      expect(exitCode).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('--global-identifier / --polyfill / --run-before-main / --watch-folder / --watch-include / --watch-exclude (반복 가능)', () => {
+    const dir = createCliInput();
+    writeFileSync(join(dir, 'poly.ts'), 'globalThis.__POLY__ = 1;');
+    writeFileSync(join(dir, 'pre.ts'), 'globalThis.__PRE__ = 1;');
+    try {
+      const { exitCode, stderr } = runCli([
+        '--bundle',
+        join(dir, 'input.ts'),
+        '--global-identifier=__FOO',
+        '--global-identifier=__BAR',
+        `--polyfill=${join(dir, 'poly.ts')}`,
+        `--run-before-main=${join(dir, 'pre.ts')}`,
+        `--watch-folder=${dir}`,
+        '--watch-include=**/*.ts',
+        '--watch-exclude=**/*.test.ts',
+      ]);
+      expect(exitCode).toBe(0);
+      expect(stderr).not.toContain('unknown CLI flag');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary

`documents/.../reference/cli.md` 가 문서화하던 7개 플래그가 실제로는 CLI 에 없고 NAPI BuildOptions 옵션으로만 존재해, 사용자가 문서대로 입력하면 `unknown CLI flag` 에러가 나던 문제 수정. 코드를 문서에 맞춤.

| 추가된 CLI flag | NAPI BuildOptions 키 | kind |
|---|---|---|
| `--dev` | `devMode` | bool |
| `--global-identifier=<name>` | `globalIdentifiers` | array (`forms:['equal']`) |
| `--polyfill=<path>` | `polyfills` | array, abs 변환 |
| `--run-before-main=<path>` | `runBeforeMain` | array, abs 변환 |
| `--watch-folder=<dir>` | `watchFolders` | array, abs 변환 |
| `--watch-include=<glob>` | `watchInclude` | array (glob — 변환 안 함) |
| `--watch-exclude=<glob>` | `watchExclude` | array (glob — 변환 안 함) |

`--watch-folder` 는 RN-CLI 호환 csv flag `--watchFolders` (target=`rnWatchFolders`, Metro graph-bundler 경로) 와 **별개** — zntc 네이티브 watcher 용. 양쪽에 cross-ref 코멘트 추가.

## 변경 파일
- `packages/core/bin/cli-flags.mjs`: `FLAG_REGISTRY` 에 7 entry
- `packages/core/bin/zntc.mjs`: `runBundle()` `buildOpts` 에 7 필드 forward (`array` kind 는 미지정 시 `undefined` 라 `?.length` 가드). path-bearing 은 `--inject` 와 동일하게 `resolve()`. opts defaults 에 `devMode: false` 추가 (다른 bool 들과 일관)
- `packages/core/bin/zntc-cli-schema-sync.test.ts`: 단수 flag ↔ 복수 BuildOptions 키 mismatch 4개를 `cliOnlyFlags` allowlist 에 등록 (`NAPI_INTERNAL_ONLY_KEYS` 는 typo-suggest 와 공유라 안 건드림)
- `packages/core/test/cli/args/basic.ts`: `--dev` + 반복형 6개 스모크 테스트 2개
- `documents/.../reference/cli.md` (KO/EN): `--mangle-report=<path>` 행 제거 — NAPI/zntc.mjs 어디에도 mangle report 구현이 없는 fiction

> 참고: stale 브랜치 `feat/cli-missing-flags` (`zts.*` 파일명, rename 이전) 가 비슷한 목적으로 머지 안 된 채 남아 있음 — 이 PR 이 대체.

## Test plan
- [x] `bun test bin/zntc-cli-schema-sync.test.ts` — 11 pass
- [x] `bun test bin/zntc.test.ts -t "basic flags"` — 6 pass (기존 4 + 새 2)
- [x] `bun test src/typo-suggest.test.ts` — 23 pass
- [x] `bun x tsc -b --force` — clean
- [x] `bun run lint` — 0 errors
- [x] `bun run fmt` — applied
- [x] `bun run build` (documents/) — 509 페이지, link 검증 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)