### PR TITLE
refactor(bundler): external_imports 의 isSynthetic → is_helper (#3078)

### DIFF
--- a/src/bundler/emitter/external_imports.zig
+++ b/src/bundler/emitter/external_imports.zig
@@ -76,7 +76,10 @@ pub fn emitChunkExternalImports(
             const rec = m.import_records[ib.import_record_index];
             if (!rec.is_external) continue;
             if (rec.kind != .static_import and rec.kind != .re_export) continue;
-            if (!ib.isSynthetic() and !ib.local_symbol.isValid()) continue;
+            // helper binding (JSX runtime / runtime helper) 은 user 가 같은 이름 점유
+            // 시 semantic 로컬이 없을 수 있다 — local_name 은 importBindingLocalName 의
+            // is_helper fallback 으로 얻으므로 local_symbol 없어도 통과시킨다.
+            if (!ib.is_helper and !ib.local_symbol.isValid()) continue;
 
             // verbatim_module_syntax=true 면 모두 보존, 아니면 type-only 는 drop.
             if (!verbatim) {


### PR DESCRIPTION
## Summary

#3068 follow-up. `isSynthetic()` 가 #3067 이후 항상 false. external import binding emit 분기의 `if (!ib.isSynthetic() and !ib.local_symbol.isValid()) continue;` 를 `if (!ib.is_helper and !ib.local_symbol.isValid()) continue;` 로 변경 — helper binding (JSX runtime / runtime helper) 은 user 가 같은 이름 점유 시 semantic 로컬이 없을 수 있고, local_name 은 `importBindingLocalName` 의 is_helper fallback (#3079) 으로 얻으므로 local_symbol 없어도 통과시킨다.

## 검증

- `zig build test` 통과
- e2e **144/144 통과** (lib-scenario 16/16 포함)
- ReleaseFast 빌드 OK

## 후속 (#3078)

`linker.zig:453` (react/jsx-runtime CJS interop preamble 과 상호작용), `metadata.zig` 의 `is_synthetic_esm` / `is_synthetic` 변수 (IIFE·ESM-wrap·CJS interop emit 분기), `isSynthetic` 정의 제거, Flow enum runtime synthetic 마이그레이션.

🤖 Generated with [Claude Code](https://claude.com/claude-code)