### PR TITLE
docs(pages): reference/cli.md RN bundle 표 --source-map-url 중복 제거

### DIFF
--- a/documents/src/content/docs/reference/cli.md
+++ b/documents/src/content/docs/reference/cli.md
@@ -130,7 +130,7 @@ Options:
 | `--max-workers=<n>` | 병렬 워커 수 — `--jobs` alias |
 | `--rn-project-root=<dir>` | RN preset projectRoot (기본 cwd, monorepo root 지정 시) |
 | `--watchFolders=<a,b>` / `--sourceExts=<a,b>` | Metro camelCase 형 — RN preset 으로 전달 (`--watch-folder` 와 별개) |
-| `--unstable-transform-profile=<name>` / `--source-map-url=<url>` / `--sourcemap-sources-root=<dir>` / `--sourcemap-use-absolute-path` / `--no-interactive` | Metro 호환 옵션 |
+| `--unstable-transform-profile=<name>` / `--sourcemap-sources-root=<dir>` / `--sourcemap-use-absolute-path` / `--no-interactive` | Metro 호환 옵션 |
 | `--transform-option=<k=v>` / `--resolver-option=<k=v>` | Metro transformer/resolver 옵션 (반복 가능) — **현재 무시** (Metro graph-bundler 전용) |
 
 전체 표 + 동작 설명: [React Native 가이드](/zntc/guides/react-native/#metro--react-native-bundle-호환-옵션)


### PR DESCRIPTION
## Summary

PR #3081 에서 `reference/cli.md` 의 RN bundle (Metro) 호환 표를 추가할 때 `--source-map-url=<url>` 이 별도 행 + "Metro 호환 옵션" 묶음 행 양쪽에 중복으로 들어갔음. 묶음 행에서 제거 (별도 행은 유지). EN 은 이미 한 번만 있어 변경 없음.

`/simplify` 후속 정정.

## Test plan
- [x] `bun run build` (documents/) — 509 페이지, link 검증 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)