### PR TITLE
refactor(bundler): ImportBinding.isSynthetic 완전 제거 — is_helper 로 대체 (#3078)

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -64,17 +64,6 @@ pub const ImportBinding = struct {
         namespace,
     };
 
-    /// Synthetic binding (JSX runtime 등 — graph 가 인공 생성하던 sentinel-span 바인딩).
-    /// #3067 (JSX synthetic 우회 제거) 이후 이 sentinel 을 set 하는 생성처가 없어
-    /// `isSynthetic()` 는 항상 false. 잔여 분기 (linker / emitter / metadata 의 7곳)
-    /// 제거는 후속 — `metadata.zig` 의 `is_synthetic_esm` / `is_synthetic` 변수가
-    /// emit 분기 여러 곳에서 쓰여 점진적 검증 필요.
-    pub const SYNTHETIC_SPAN_BASE: u32 = 0xFFFF_0000;
-
-    pub fn isSynthetic(self: ImportBinding) bool {
-        return self.local_span.start >= SYNTHETIC_SPAN_BASE;
-    }
-
     /// `import x from './m'` (kind=.default) 또는 `import { default as X }`
     /// (kind=.named, imported_name="default") 어느 쪽이든 source의 default를
     /// import하는 케이스 통칭.

--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -300,12 +300,15 @@ fn refreshStableBindingRefsAfterSemanticResync(
     const scope0: ?std.StringHashMap(usize) =
         if (sem.scope_maps.len > 0) sem.scope_maps[0] else null;
     for (module.import_bindings) |*ib| {
-        if (ib.isSynthetic()) continue;
         ib.local_symbol = bundler_symbol.SymbolRef.invalid;
-        if (scope0) |module_scope| {
-            if (module_scope.get(ib.local_name)) |sym_idx| {
-                ib.local_symbol = bundler_symbol.SymbolRef.makeSemantic(module.index, sym_idx);
-            }
+        // #3068: helper binding 은 user 가 같은 이름 점유 시에도 격리된 helper_scope_map
+        // 에서 lookup — 일반 module_scope.get 면 user sym 을 잘못 가리킨다 (linker
+        // populateImportSymbols 와 동일 정책).
+        const sym_lookup: ?usize = if (ib.is_helper)
+            sem.helper_scope_map.get(ib.local_name)
+        else if (scope0) |module_scope| module_scope.get(ib.local_name) else null;
+        if (sym_lookup) |sym_idx| {
+            ib.local_symbol = bundler_symbol.SymbolRef.makeSemantic(module.index, sym_idx);
         }
     }
 

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -448,9 +448,10 @@ pub const Linker = struct {
                         if (helper_modules.isVirtualId(target_module.path)) break :blk false;
                         const target_wrap = target_module.wrap_kind;
                         if (m.wrap_kind == .esm) {
-                            // CJS named import는 `require_xxx().prop` 직접 참조로
-                            // 치환하므로 별도 top-level var를 만들지 않는다.
-                            if (target_wrap == .cjs and ib.kind == .named and !ib.isSynthetic()) break :blk false;
+                            // CJS named import는 `require_xxx().prop` 직접 참조로 치환하므로
+                            // 별도 top-level var를 만들지 않는다. helper binding (JSX runtime
+                            // 등) 은 call site 가 식별자 (`_jsx(...)`) 라 var 할당이 필요.
+                            if (target_wrap == .cjs and ib.kind == .named and !ib.is_helper) break :blk false;
                             // __esm: scope-hoisted 타겟의 import는 skip되어 var 미생성
                             break :blk target_wrap != .none;
                         } else {

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -70,7 +70,8 @@ inline fn mappedExternalParam(
 }
 
 pub fn isImportBindingTypeOnly(sem: *const @import("../module.zig").ModuleSemanticData, ib: ImportBinding) bool {
-    if (ib.isSynthetic()) return false;
+    // helper binding (JSX runtime / runtime helper) 은 런타임 호출이라 type-only 가 아니다.
+    if (ib.is_helper) return false;
     // named 한정 — default / namespace 는 JSX pragma 등 implicit value use 위험이
     // 큼 (#1793 revert 원인). transformer 와 동일 제한.
     if (ib.kind != .named) return false;
@@ -315,12 +316,12 @@ pub fn buildMetadataForAst(
             if (rec.resolved.isNone()) {
                 if (rec.is_lazy_resolved) continue;
                 if (rec.kind == .static_import or rec.kind == .side_effect or rec.kind == .re_export) {
-                    if (!ib.isSynthetic() and !ib.local_symbol.isValid()) continue;
+                    if (!ib.is_helper and !ib.local_symbol.isValid()) continue;
                     const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse m.importBindingLocalName(ib);
-                    // synthetic binding(JSX runtime 등) + ESM-wrapped 모듈 조합에서는
-                    // top-level에 이미 `var _jsxDEV, _Fragment;` 선언이 호이스팅됨.
-                    // init 함수 본문에서 `var`로 재선언하면 outer scope를 shadow → #1209.
-                    const is_synthetic_esm = ib.isSynthetic() and m.wrap_kind == .esm;
+                    // helper binding (JSX runtime 등) + ESM-wrapped 모듈 조합에서는 top-level
+                    // 에 이미 `var _jsxDEV, _Fragment;` 선언이 호이스팅됨 (esm_wrap). init 함수
+                    // 본문에서 `var` 로 재선언하면 outer scope 를 shadow → #1209.
+                    const is_helper_esm = ib.is_helper and m.wrap_kind == .esm;
                     const mapped_param = try mappedExternalParam(self.format, self.iife_globals, rec, self.allocator);
                     if (mapped_param) |param_name| {
                         defer self.allocator.free(param_name);
@@ -345,7 +346,7 @@ pub fn buildMetadataForAst(
                             try preamble.write(ib.imported_name);
                             try preamble.write(";\n");
                         }
-                    } else if (self.format == .iife and !ib.isSynthetic()) {
+                    } else if (self.format == .iife and !ib.is_helper) {
                         // #1791 IIFE: 매핑 안 된 unresolved external 은 의미 자체가 성립 안 함
                         // (factory 스코프에 require 없음, top-level import 도 불가).
                         // #1824: --globals 로 매핑된 external 은 위 `is_iife_mapped` 브랜치에서 처리됨.
@@ -370,17 +371,17 @@ pub fn buildMetadataForAst(
                                 .suggestion = null,
                             });
                         }
-                    } else if (self.format == .esm and rec.is_external and !is_synthetic_esm) {
+                    } else if (self.format == .esm and rec.is_external and !is_helper_esm) {
                         // #1962 ESM external: chunk top 의 ESM `import` 구문이 binding 을
                         // 제공하므로 모듈 preamble 에 require() 를 두지 않는다.
                         // - emitter 의 `external_imports.emitChunkExternalImports` 가 dedup 후 emit.
                         // - codegen 은 import_declaration 노드를 skip (skip_imports=true).
                         // - canonical rename 은 emitter 측에서 동일 ImportBinding 을 보고 적용.
-                        // synthetic_esm (JSX runtime 합성 binding + ESM-wrapped 모듈) 은 init
-                        // 함수 본문에서 var 할당이 필요해 require() 경로를 유지한다.
+                        // helper binding + ESM-wrapped 모듈은 init 함수 본문에서 var 할당이
+                        // 필요해 require() 경로를 유지한다 (#1209).
                     } else {
-                        // CJS / ESM-wrapped + synthetic / 그 외: require() preamble 생성.
-                        if (is_synthetic_esm) {
+                        // CJS / ESM-wrapped + helper / 그 외: require() preamble 생성.
+                        if (is_helper_esm) {
                             try preamble.writeUnresolvedRequireAssignOnly(preamble_name, rec.specifier, ib.imported_name, ib.kind == .namespace);
                         } else {
                             try preamble.writeUnresolvedRequire(preamble_name, rec.specifier, ib.imported_name, ib.kind == .namespace);
@@ -401,9 +402,9 @@ pub fn buildMetadataForAst(
             // named import는 `require_xxx().name` 직접 참조로 치환해 top-level
             // binding을 만들지 않는다. default/namespace는 interop 값 자체가 필요하므로
             // outer var를 선언하고 init preamble에서 할당한다.
-            const is_synthetic = ib.isSynthetic();
+            const is_helper_binding = ib.is_helper;
             const canonical_m_opt = self.getModule(canonical_mod);
-            if (!is_synthetic and m.wrap_kind == .esm and canonical_m_opt != null and
+            if (!is_helper_binding and m.wrap_kind == .esm and canonical_m_opt != null and
                 (canonical_m_opt.?.wrap_kind == .cjs or canonical_mod == module_index))
             {
                 if (canonical_m_opt.?.wrap_kind == .cjs) {
@@ -447,8 +448,8 @@ pub fn buildMetadataForAst(
                 const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse m.importBindingLocalName(ib);
                 const req_var = try getOrCreateRequireVar(self, &cjs_var_cache, @intCast(canonical_mod));
                 const interop_mode: types.Interop = if (m.def_format.isEsm()) .node else .babel;
-                // ESM-wrapped + synthetic binding: top-level에 이미 var 선언됨 → 할당만
-                if (is_synthetic and m.wrap_kind == .esm) {
+                // ESM-wrapped + helper binding: top-level 에 이미 var 선언됨 (esm_wrap) → 할당만
+                if (is_helper_binding and m.wrap_kind == .esm) {
                     if (ib.importsDefault() and m.canUseDirectCjsDefaultImport(canonical_m_opt.?)) {
                         try preamble.writeCjsDirectDefault(preamble_name, req_var, true);
                     } else {


### PR DESCRIPTION
## Summary

#3068 follow-up 마무리. #3067 (JSX synthetic 우회 제거) 이후 synthetic ImportBinding 을 만드는 생성처가 사라져 `isSynthetic()` 가 항상 false. 모든 호출처를 의미가 정확한 `is_helper` 로 치환하고 `isSynthetic()` / `SYNTHETIC_SPAN_BASE` 정의를 제거.

## 변경

- **`binding_scanner.zig`**: `SYNTHETIC_SPAN_BASE` / `isSynthetic()` 정의 제거
- **`linker/metadata.zig`**: `isImportBindingTypeOnly` short-circuit, `is_synthetic_esm` → `is_helper_esm`, IIFE diagnostics 가드, `is_synthetic` → `is_helper_binding`, ESM-wrapped + helper binding 의 require() assign-only preamble — 모두 `is_helper` 로. emit 분기 (IIFE / ESM-wrap / CJS interop) 동작 동등 (synthetic binding 케이스를 helper binding 케이스가 대체).
- **`linker.zig`**: `populateImportSymbols` 의 binding lookup 게이트, ESM-wrapped 모듈의 CJS named import top-level var 판정 — `is_helper` 로.
- **`transform_prepass.zig`**: `refreshStableBindingRefsAfterSemanticResync` 의 binding refs 재조회 loop 를 helper-aware 로 (helper binding 은 `helper_scope_map` lookup — linker `populateImportSymbols` 와 동일 정책).

## 검증

- `zig build test` 통과
- e2e **144/144 통과** (lib-scenario 16/16 — H1~H9 preact JSX 시나리오 포함)
- integration **3714 pass / 0 fail**
- ReleaseFast 빌드 OK

## 후속 (#3078)

Flow enum runtime synthetic (`injectFlowEnumRuntimeImport`, ImportRecord 만 inject) 의 transformer-정식-노드 마이그레이션 + IIFE format / dev-HMR JSX e2e 시나리오.

이 PR 로 **`ImportBinding` 의 synthetic 우회 메커니즘이 완전히 제거**됩니다 — JSX runtime 은 transformer 가 정식 AST import 노드 생성 (#3067), helper scope 격리 (#3071), 잔여 분기 정리 (#3076/#3077/#3079/#3082/이 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)