### PR TITLE
test(e2e): IIFE format + JSX automatic 회귀 시나리오 추가 (#3078)

### DIFF
--- a/tests/e2e/tests/lib-scenario-e2e.test.ts
+++ b/tests/e2e/tests/lib-scenario-e2e.test.ts
@@ -572,6 +572,29 @@ render(<App />, mount);
     },
   },
   {
+    // 회귀 테스트 — IIFE format + JSX automatic. IIFE 는 ESM `import` 가 불가하므로
+    // transformer 가 추가한 jsx-runtime import 노드가 chunk top 의 `import` 가 아니라
+    // 번들 안에 inline 합쳐져야 한다 (preact/jsx-runtime 모듈이 IIFE wrapper 내부).
+    name: 'H10_preact_jsx_iife',
+    category: 'H_jsx_ts',
+    packages: ['preact'],
+    entryFile: 'index.tsx',
+    extraArgs: ['--format=iife', '--jsx=automatic', '--jsx-import-source=preact'],
+    entry: `import { render } from 'preact';
+
+function App() {
+  return <p data-testid="iife">iife-jsx-ok</p>;
+}
+
+const mount = document.createElement('div');
+document.body.appendChild(mount);
+render(<App />, mount);
+`,
+    expect: {
+      iife: 'iife-jsx-ok',
+    },
+  },
+  {
     name: 'H3_ts_legacy_decorator',
     category: 'H_jsx_ts',
     packages: [],


### PR DESCRIPTION
## Summary

#3078 follow-up. IIFE format 은 ESM `import` 가 불가하므로 transformer 가 추가한 jsx-runtime import 노드가 chunk top 의 `import` 가 아니라 번들 안에 inline 으로 합쳐져야 한다 (preact/jsx-runtime 모듈이 IIFE wrapper 내부). 그 emit 경로가 정상 동작하는지 브라우저 DOM 검증.

- **H10_preact_jsx_iife**: `--format=iife --jsx=automatic --jsx-import-source=preact`

## 검증

- e2e lib-scenario **17/17 통과**
- type-check OK

## 후속 (#3078)

dev/HMR JSX 시나리오 (dev server 인프라 + 새 fixture/port 필요) — 이번 PR 범위 밖.

이 PR 로 lib-scenario 의 JSX automatic cover 가 H1~H10 (10 시나리오): preact JSX automatic / 사용자 식별자 충돌 / multi-module / re-export / static children / fragment / ESM-wrapped / IIFE format 까지 확장됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)