### PR TITLE
docs(pages): 3차 점검 정정 — watcher 백엔드 / RN 무시 플래그 / worker chunk / loader 목록

### DIFF
--- a/documents/src/content/docs/en/guides/bundling.md
+++ b/documents/src/content/docs/en/guides/bundling.md
@@ -128,7 +128,7 @@ defineConfig({
 zntc --bundle entry.ts --loader:.png=file --loader:.svg=dataurl
 ```
 
-Supported loaders: `js`, `ts`, `json`, `text`, `css`, `file`, `dataurl`, `binary`, `copy`, `empty`
+Supported loaders: `js`, `jsx`, `ts`, `tsx`, `json`, `css`, `text`, `file`, `dataurl`, `base64`, `binary`, `copy`, `empty`
 
 ## Web Worker
 
@@ -155,7 +155,7 @@ self.onmessage = (e) => {
 
 ### Output
 
-The worker entry is emitted as a **separate chunk** (not an import dependency of the main bundle). Its filename follows the `--chunk-names` pattern, and the `new Worker(new URL(...))` call site in the main bundle is automatically rewritten to point at the built worker URL. The worker chunk's module format is always IIFE (or CJS when bundling for a Node CJS target).
+The worker entry is emitted as a **separate chunk** (not an import dependency of the main bundle). Its filename uses the fixed form `<source-stem>-<crc32-hex>.js` (the `--chunk-names` pattern does not apply here), and the `new Worker(new URL(...))` call site in the main bundle is automatically rewritten to point at the built worker URL. The worker chunk's module format is always IIFE (or CJS when bundling for a Node CJS target).
 
 ### Limitations
 

--- a/documents/src/content/docs/en/guides/dev-server.md
+++ b/documents/src/content/docs/en/guides/dev-server.md
@@ -137,15 +137,15 @@ Multiple component updates are batched into a single React refresh cycle with a 
 |---|---|
 | macOS | kqueue |
 | Linux | inotify |
-| Windows | ReadDirectoryChangesW |
+| Windows / other | mtime polling fallback |
 
-In most environments OS events fire instantly. The following environments have unreliable OS events and may drop changes:
+macOS / Linux deliver OS events instantly. Windows and other platforms fall back to mtime polling, and in the following environments change detection may be slow or miss changes:
 
 - Docker volume mounts (host → container)
 - Network filesystems like NFS / SMB
 - Windows WSL1 (WSL2 is fine)
 
-ZNTC does not currently expose a polling-fallback flag. If changes don't propagate in those environments, force a browser reload manually. Polling fallback is planned for a future release.
+There is no user flag to tune the polling interval yet. If changes don't propagate in those environments, force a browser reload manually.
 
 ### Debugging — when updates don't arrive
 

--- a/documents/src/content/docs/en/guides/react-native.md
+++ b/documents/src/content/docs/en/guides/react-native.md
@@ -181,11 +181,11 @@ react-native → browser → module → main
 | `--sourcemap-sources-root <dir>` | Source map `sourceRoot` (same meaning as `--source-root`) |
 | `--sourcemap-use-absolute-path` | Use absolute paths for sources in the source map |
 | `--assets-dest <dir>` | Destination for copied assets (images/fonts) — in production (not `--dev`) builds the asset loader copies there (iOS 1x/2x/3x, Android `res/`) |
-| `--asset-catalog-dest <dir>` | Destination for the iOS asset catalog (`.xcassets`) |
+| `--asset-catalog-dest <dir>` | iOS asset catalog destination — **currently ignored** (accepted but no-op, stderr warning) |
 | `--bundle-encoding <utf8\|utf16le\|ascii>` | Bundle file encoding (default `utf-8`) |
 | `--reset-cache` | Invalidate the cache on startup |
 | `--max-workers <n>` | Parallel worker count — alias of `--jobs` |
-| `--unstable-transform-profile <name>` | Hermes transform profile (`hermes-stable`, etc.) |
+| `--unstable-transform-profile <name>` | Hermes transform profile — **currently ignored** (accepted but no-op, stderr warning) |
 | `--no-interactive` | Disable terminal interactive actions (Metro UI compat) |
 | `--watchFolders <a,b>` | Extra watch roots (Metro's camelCase form, comma-separated) — forwarded to the RN preset's watchFolders. Distinct from the native watcher's `--watch-folder` |
 | `--sourceExts <a,b>` | Extra source extensions (Metro's camelCase form, comma-separated) |

--- a/documents/src/content/docs/en/reference/cli.md
+++ b/documents/src/content/docs/en/reference/cli.md
@@ -126,14 +126,13 @@ Options:
 | `--sourcemap-output=<path>` | Source map output path (implies sourcemap when set) |
 | `--source-map-url=<url>` | Value for `//# sourceMappingURL` |
 | `--assets-dest=<dir>` | Asset copy destination in production builds (iOS 1x/2x/3x, Android `res/`) |
-| `--asset-catalog-dest=<dir>` | Destination for the iOS asset catalog (`.xcassets`) |
 | `--bundle-encoding=<utf8\|utf16le\|ascii>` | Bundle file encoding (default `utf-8`) |
 | `--reset-cache` | Invalidate the cache on startup |
 | `--max-workers=<n>` | Parallel worker count — alias of `--jobs` |
 | `--rn-project-root=<dir>` | RN preset projectRoot (defaults to cwd; set for monorepo roots) |
 | `--watchFolders=<a,b>` / `--sourceExts=<a,b>` | Metro camelCase forms — forwarded to the RN preset (distinct from `--watch-folder`) |
-| `--unstable-transform-profile=<name>` / `--sourcemap-sources-root=<dir>` / `--sourcemap-use-absolute-path` / `--no-interactive` | Metro compat options |
-| `--transform-option=<k=v>` / `--resolver-option=<k=v>` | Metro transformer/resolver options (repeatable) — **currently ignored** (Metro graph-bundler only) |
+| `--sourcemap-sources-root=<dir>` / `--sourcemap-use-absolute-path` / `--no-interactive` | Metro compat options |
+| `--asset-catalog-dest=<dir>` / `--unstable-transform-profile=<name>` / `--transform-option=<k=v>` / `--resolver-option=<k=v>` | Accepted but **currently ignored** (Metro graph-bundler only) |
 
 Full table + behavior: [React Native guide](/zntc/en/guides/react-native/#metro--react-native-bundle-compatibility-flags)
 

--- a/documents/src/content/docs/guides/bundling.md
+++ b/documents/src/content/docs/guides/bundling.md
@@ -128,7 +128,7 @@ defineConfig({
 zntc --bundle entry.ts --loader:.png=file --loader:.svg=dataurl
 ```
 
-지원 로더: `js`, `ts`, `json`, `text`, `css`, `file`, `dataurl`, `binary`, `copy`, `empty`
+지원 로더: `js`, `jsx`, `ts`, `tsx`, `json`, `css`, `text`, `file`, `dataurl`, `base64`, `binary`, `copy`, `empty`
 
 ## Web Worker
 
@@ -155,7 +155,7 @@ self.onmessage = (e) => {
 
 ### 출력
 
-워커 엔트리는 메인 번들의 import dependency 가 아닌 **별도 chunk** 로 생성됩니다. 파일명은 `--chunk-names` 패턴을 따르며, 메인 번들의 `new Worker(new URL(...))` 호출부는 빌드된 워커 파일 URL 로 자동 치환됩니다. 워커 chunk 의 모듈 포맷은 항상 IIFE 입니다 (Node CJS 타겟 빌드에서는 CJS).
+워커 엔트리는 메인 번들의 import dependency 가 아닌 **별도 chunk** 로 생성됩니다. 파일명은 `<원본파일명>-<crc32 hex>.js` 고정 형식이며 (`--chunk-names` 패턴 미적용), 메인 번들의 `new Worker(new URL(...))` 호출부는 빌드된 워커 파일 URL 로 자동 치환됩니다. 워커 chunk 의 모듈 포맷은 항상 IIFE 입니다 (Node CJS 타겟 빌드에서는 CJS).
 
 ### 한계
 

--- a/documents/src/content/docs/guides/dev-server.md
+++ b/documents/src/content/docs/guides/dev-server.md
@@ -137,15 +137,15 @@ export function Button({ children }) {
 |---|---|
 | macOS | kqueue |
 | Linux | inotify |
-| Windows | ReadDirectoryChangesW |
+| Windows / 기타 | mtime 폴링 폴백 |
 
-대부분 환경에서 OS 이벤트가 즉시 반영됩니다. 다음 환경에서는 OS 이벤트가 불안정해 변경이 누락될 수 있습니다.
+macOS / Linux 는 OS 이벤트가 즉시 반영됩니다. Windows 및 그 외 환경은 mtime 폴링으로 폴백하며, 다음 환경에서는 변경 감지가 느리거나 누락될 수 있습니다.
 
 - Docker volume mount (호스트 → 컨테이너)
 - NFS / SMB 같은 네트워크 파일시스템
 - Windows WSL1 (WSL2 는 OK)
 
-현재 ZNTC 에는 polling fallback flag 가 없습니다. 위 환경에서 변경이 반영되지 않으면 브라우저 새로고침으로 강제 갱신하세요. polling fallback 은 추후 추가 예정.
+폴링 간격을 조정하는 사용자 flag 는 아직 없습니다. 위 환경에서 변경이 반영되지 않으면 브라우저 새로고침으로 강제 갱신하세요.
 
 ### 디버깅 — 업데이트가 안 들어올 때
 

--- a/documents/src/content/docs/guides/react-native.md
+++ b/documents/src/content/docs/guides/react-native.md
@@ -181,11 +181,11 @@ react-native → browser → module → main
 | `--sourcemap-sources-root <dir>` | 소스맵의 `sourceRoot` (`--source-root` 와 동일 의미) |
 | `--sourcemap-use-absolute-path` | 소스맵 내 source 경로를 절대 경로로 |
 | `--assets-dest <dir>` | 이미지/폰트 등 asset 복사 대상 — production (`--dev` 아님) 빌드에서 asset 로더가 해당 디렉토리로 복사 (iOS 는 1x/2x/3x, Android 는 `res/`) |
-| `--asset-catalog-dest <dir>` | iOS asset catalog (`.xcassets`) 생성 대상 |
+| `--asset-catalog-dest <dir>` | iOS asset catalog 대상 — **현재 무시** (받기만 하고 동작 없음, stderr 경고) |
 | `--bundle-encoding <utf8\|utf16le\|ascii>` | 번들 파일 인코딩 (기본 `utf-8`) |
 | `--reset-cache` | 시작 시 캐시 무효화 |
 | `--max-workers <n>` | 병렬 워커 수 — `--jobs` 의 alias |
-| `--unstable-transform-profile <name>` | Hermes transform profile (`hermes-stable` 등) |
+| `--unstable-transform-profile <name>` | Hermes transform profile — **현재 무시** (받기만 하고 동작 없음, stderr 경고) |
 | `--no-interactive` | 터미널 인터랙티브 액션 비활성 (Metro UI 호환) |
 | `--watchFolders <a,b>` | 감시 루트 추가 (Metro 의 camelCase 형, comma 구분) — RN preset 의 watchFolders 로 전달. zntc 네이티브 watcher 의 `--watch-folder` 와 별개 |
 | `--sourceExts <a,b>` | 추가 소스 확장자 (Metro 의 camelCase 형, comma 구분) |

--- a/documents/src/content/docs/reference/cli.md
+++ b/documents/src/content/docs/reference/cli.md
@@ -124,14 +124,13 @@ Options:
 | `--sourcemap-output=<path>` | 소스맵 출력 경로 (지정 시 sourcemap 자동 활성) |
 | `--source-map-url=<url>` | `//# sourceMappingURL` 값 |
 | `--assets-dest=<dir>` | production 빌드의 asset 복사 대상 (iOS 1x/2x/3x, Android `res/`) |
-| `--asset-catalog-dest=<dir>` | iOS asset catalog (`.xcassets`) 생성 대상 |
 | `--bundle-encoding=<utf8\|utf16le\|ascii>` | 번들 파일 인코딩 (기본 `utf-8`) |
 | `--reset-cache` | 시작 시 캐시 무효화 |
 | `--max-workers=<n>` | 병렬 워커 수 — `--jobs` alias |
 | `--rn-project-root=<dir>` | RN preset projectRoot (기본 cwd, monorepo root 지정 시) |
 | `--watchFolders=<a,b>` / `--sourceExts=<a,b>` | Metro camelCase 형 — RN preset 으로 전달 (`--watch-folder` 와 별개) |
-| `--unstable-transform-profile=<name>` / `--sourcemap-sources-root=<dir>` / `--sourcemap-use-absolute-path` / `--no-interactive` | Metro 호환 옵션 |
-| `--transform-option=<k=v>` / `--resolver-option=<k=v>` | Metro transformer/resolver 옵션 (반복 가능) — **현재 무시** (Metro graph-bundler 전용) |
+| `--sourcemap-sources-root=<dir>` / `--sourcemap-use-absolute-path` / `--no-interactive` | Metro 호환 옵션 |
+| `--asset-catalog-dest=<dir>` / `--unstable-transform-profile=<name>` / `--transform-option=<k=v>` / `--resolver-option=<k=v>` | 받기만 하고 **현재 무시** (Metro graph-bundler 전용) |
 
 전체 표 + 동작 설명: [React Native 가이드](/zntc/guides/react-native/#metro--react-native-bundle-호환-옵션)
 


### PR DESCRIPTION
## Summary

코드 재검증(3차 점검) 결과 발견한 부정확 항목 5건 정정:

| 위치 | 잘못된 내용 | 실제 코드 |
|---|---|---|
| `dev-server.md` watcher 표 | `Windows \| ReadDirectoryChangesW` | `file_watcher.zig` 는 kqueue(macOS)/inotify(Linux) 만 네이티브, 나머지(Windows 포함)는 mtime 폴링 폴백 → `Windows / 기타 \| mtime 폴링 폴백`. "polling fallback 추후 추가 예정" 문구도 정정 (auto 폴링은 이미 있음) |
| `react-native.md` + `reference/cli.md` Metro 표 | `--asset-catalog-dest` / `--unstable-transform-profile` 가 동작하는 것처럼 표기 | `warnRnBundleUnsupported` 의 ignored set — 받기만 하고 동작 없음 (stderr 경고). `--transform-option`/`--resolver-option` 처럼 "현재 무시"로 표기 |
| `bundling.md` Web Worker | 워커 chunk 파일명이 `--chunk-names` 패턴을 따름 | `bundler.zig` 는 `<원본파일명>-<crc32 hex>.js` 고정, `--chunk-names` 미적용 |
| `bundling.md` `## Loader` 목록 | `base64` / `jsx` / `tsx` 누락 | `napi.mdx` 와 동일하게 `js, jsx, ts, tsx, json, css, text, file, dataurl, base64, binary, copy, empty` |

> 별도 트래킹: `KNOWN_CONFIG_KEYS` (`packages/core/src/typo-suggest.ts`) 가 `polyfills`/`runBeforeMain`/`globalIdentifiers`/`watchInclude`/`watchExclude`/`fallback`/`blockList`/`assetRegistry`/`devMode`/`reactRefresh` 등을 누락 — `zntc.config.*` 에 이 키를 쓰면 typo-warning 이 뜸 (동작은 함). 코드 gap 이라 이 PR 범위 밖.

## Test plan
- [x] `bun run build` (documents/) — 509 페이지, link 검증 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)