### PR TITLE
fix(transformer): classic JSX factory 가 named import 일 때 elision 되지 않게

### DIFF
--- a/src/transformer/options.zig
+++ b/src/transformer/options.zig
@@ -319,4 +319,22 @@ pub const TransformOptions = struct {
     pub fn shouldLowerJsx(self: @This()) bool {
         return self.jsx_transform and self.jsx_runtime != .preserve;
     }
+
+    /// classic JSX lowering 이 참조하는 factory 의 head identifier
+    /// (`React.createElement` → `React`, `h` → `h`). 이 식별자는 source 에 직접
+    /// 쓰이지 않으므로 import elision 이 별도로 살아있는 것으로 취급해야 한다 (#3063).
+    pub fn jsxClassicFactoryHead(self: @This()) []const u8 {
+        return jsxHeadIdent(self.jsx_factory);
+    }
+
+    /// classic JSX `<>...</>` lowering 이 참조하는 fragment 의 head identifier.
+    pub fn jsxClassicFragmentHead(self: @This()) []const u8 {
+        return jsxHeadIdent(self.jsx_fragment);
+    }
 };
+
+/// 점-구분 pragma 의 head segment. `jsx_lowering.makeFactoryCallee` 가 동일하게
+/// `factory[0..첫 '.']` 를 root-scope binding 으로 attach 하므로 둘이 일치해야 한다.
+fn jsxHeadIdent(spec: []const u8) []const u8 {
+    return std.mem.sliceTo(spec, '.');
+}

--- a/src/transformer/transformer/import_export.zig
+++ b/src/transformer/transformer/import_export.zig
@@ -304,10 +304,20 @@ fn isImportSpecifierUnused(self: *const Transformer, spec_idx: NodeIndex, spec_n
     if (spec_node.tag != .import_specifier) return false;
     const local_idx = spec_node.data.binary.right;
     const sym_node_idx: u32 = if (!local_idx.isNone()) @intFromEnum(local_idx) else @intFromEnum(spec_idx);
+    const local_node = if (!local_idx.isNone()) self.ast.getNode(local_idx) else spec_node;
+    const local_name = self.ast.getText(local_node.span);
+
+    // classic JSX lowering 은 source 에 없던 factory/fragment identifier 참조를 만든다 —
+    // elision 이 보는 reference / binding_lite 스캔에는 안 잡히므로, head identifier 가
+    // 일치하면 value-use 로 간주해 keep. automatic 모드의 jsx-runtime import 는
+    // transformer 가 직접 주입하므로 (user import 아님) 이 경로와 무관 (#3063).
+    if (self.ast.has_jsx and self.options.shouldLowerJsx() and self.options.jsx_runtime == .classic) {
+        if (std.mem.eql(u8, local_name, self.options.jsxClassicFactoryHead()) or
+            std.mem.eql(u8, local_name, self.options.jsxClassicFragmentHead()))
+            return false;
+    }
 
     if (self.binding_lite) |binding_lite| {
-        const local_node = if (!local_idx.isNone()) self.ast.getNode(local_idx) else spec_node;
-        const local_name = self.ast.getText(local_node.span);
         if (binding_lite.namedImportValueUse(local_name)) |used_as_value| return !used_as_value;
         return false;
     }

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -2340,6 +2340,58 @@ test "#1791 type-only elision: positive + negative cases" {
 }
 
 // ============================================================
+// #3063: classic JSX factory(named import) 가 elision 되지 않아야 한다
+//
+// classic JSX lowering 은 `<App/>` 를 `h(App, null)` 로 바꾸지만, elision 이 보는
+// reference/binding_lite 스캔은 lowering 전 AST 를 본다 — factory `h` 가 import 의
+// 유일한 사용처면 specifier 가 잘못 제거되어 `h(...)` 가 ReferenceError 가 됐다.
+// ============================================================
+
+test "#3063 classic JSX factory named import 보존 / non-JSX 는 그대로 elide" {
+    // factory(h) 가 유일 사용처 — 보존되어야 함.
+    {
+        var result = try transpile_mod.transpile(
+            std.testing.allocator,
+            \\import { h } from "preact";
+            \\export const App = () => <p>x</p>;
+        ,
+            "input.jsx",
+            .{ .jsx_runtime = .classic, .jsx_factory = "h", .jsx_fragment = "Fragment" },
+        );
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expect(std.mem.indexOf(u8, result.code, "\"preact\"") != null);
+        try std.testing.expect(std.mem.indexOf(u8, result.code, "h(\"p\"") != null);
+    }
+    // fragment(Fragment) 도 보존 — `<>...</>` lowering 이 참조.
+    {
+        var result = try transpile_mod.transpile(
+            std.testing.allocator,
+            \\import { h, Fragment } from "preact";
+            \\export const App = () => <><p>a</p><p>b</p></>;
+        ,
+            "input.jsx",
+            .{ .jsx_runtime = .classic, .jsx_factory = "h", .jsx_fragment = "Fragment" },
+        );
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expect(std.mem.indexOf(u8, result.code, "\"preact\"") != null);
+        try std.testing.expect(std.mem.indexOf(u8, result.code, "h(Fragment") != null);
+    }
+    // JSX 없는 파일 — 같은 이름이어도 정상 elide (over-keep 회귀 방지).
+    {
+        var result = try transpile_mod.transpile(
+            std.testing.allocator,
+            \\import { h } from "preact";
+            \\export const x = 1;
+        ,
+            "input.ts",
+            .{ .jsx_runtime = .classic, .jsx_factory = "h", .jsx_fragment = "Fragment" },
+        );
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expect(std.mem.indexOf(u8, result.code, "import") == null);
+    }
+}
+
+// ============================================================
 // --define 치환 (#1552)
 // ============================================================
 

--- a/tests/e2e/tests/lib-scenario-e2e.test.ts
+++ b/tests/e2e/tests/lib-scenario-e2e.test.ts
@@ -595,6 +595,35 @@ render(<App />, mount);
     },
   },
   {
+    // 회귀 테스트 — #3063: classic `--jsx-factory=h` 가 import 의 유일 사용처일 때
+    // import elision 이 lowering 전 AST 만 보고 `h`/`Fragment` specifier 를 제거 →
+    // `h(...)` ReferenceError. fix 이후 factory/fragment head ident 를 value-use 로 취급.
+    name: 'H11_preact_jsx_classic_named_factory',
+    category: 'H_jsx_ts',
+    packages: ['preact'],
+    entryFile: 'index.tsx',
+    extraArgs: ['--jsx=classic', '--jsx-factory=h', '--jsx-fragment=Fragment'],
+    entry: `import { h, Fragment, render } from 'preact';
+
+function App() {
+  return (
+    <>
+      <p data-testid="classic">classic-jsx-ok</p>
+      <span data-testid="classic2">classic-frag-ok</span>
+    </>
+  );
+}
+
+const mount = document.createElement('div');
+document.body.appendChild(mount);
+render(<App />, mount);
+`,
+    expect: {
+      classic: 'classic-jsx-ok',
+      classic2: 'classic-frag-ok',
+    },
+  },
+  {
     name: 'H3_ts_legacy_decorator',
     category: 'H_jsx_ts',
     packages: [],


### PR DESCRIPTION
## 무엇을 / 왜 (#3063)

`zntc --bundle --jsx=classic --jsx-factory=h` + `import { h, render } from 'preact'` 조합에서, factory `h` 가 `h` import 의 **유일한 사용처**이면 transformer 의 unused-import elision (`isImportSpecifierUnused`) 이 `h` specifier 를 잘못 제거했습니다.

원인: elision 이 참조하는 reference / `binding_lite` 스캔은 **JSX lowering 전 AST** 를 봅니다. classic lowering 은 `<App/>` → `h(App, null)` 로 바꿔서 factory 식별자를 *나중에* 만들기 때문에, lowering 전 시점엔 `h` 가 "미사용" 으로 보입니다. 결과:
- `import { h } from './h.js'` → `h.js` 의 `export function h` 가 tree-shake 로 통째 제거 → entry 의 `h(...)` 가 댕글링 (`ReferenceError: h is not defined`)
- (다른 이유로 export 가 살아남는 경우) entry 의 `h(...)` 가 source 모듈의 renamed export 를 따라가지 못함 (preact: `createElement` 가 minify 되어 `k` → entry 는 `h(...)` 그대로 emit)

이슈에 적힌 workaround (`--jsx-factory=createElement` + `import { createElement }`) 도 같은 이유로 동작하지 않았습니다.

> automatic 모드는 jsx-runtime import 를 transformer 가 직접 주입(`import { jsx as _jsx } from "react/jsx-runtime"`)하므로 user import 가 아니라 이 경로와 무관 — **classic 모드 전용 회귀**입니다 (#3062 와 영역은 같지만 코드 경로가 분리됨).

## 변경

- **`src/transformer/options.zig`** — `TransformOptions.jsxClassicFactoryHead()` / `jsxClassicFragmentHead()`: pragma 의 head identifier (`React.createElement` → `React`, `h` → `h`, `Preact.h` → `Preact`). classic lowering 이 참조하는 binding 의 single source. (`jsx_lowering.makeFactoryCallee` 가 동일하게 head segment 를 root-scope binding 으로 attach 하므로 둘이 일치해야 함 — 헬퍼에 명시.)
- **`src/transformer/transformer/import_export.zig`** — `isImportSpecifierUnused`: `has_jsx and shouldLowerJsx() and jsx_runtime == .classic` 인 모듈에서 import specifier 의 local name 이 factory/fragment head 와 일치하면 value-use 로 간주해 elision 에서 제외. (`local_node`/`local_name` 계산을 `binding_lite` 분기 밖으로 hoist.)
- **유닛 테스트** (`transformer_test.zig` #3063): ① factory(`h`) 가 유일 사용처 → 보존, ② fragment(`Fragment`, `<>...</>`) 도 보존, ③ JSX 없는 파일은 같은 이름이어도 정상 elide (over-keep 회귀 방지).
- **e2e** (`lib-scenario-e2e.test.ts` H11): preact `--jsx=classic --jsx-factory=h --jsx-fragment=Fragment` (named import) 이 브라우저에서 element + fragment 둘 다 렌더.

## Zig 초보자용 메모

- `import { h }` 의 `h` 같은 named import 는 transformer 에게 "값으로 쓰였나?" 를 reference 목록으로 판단합니다. JSX `<App/>` 는 source 에서 `h` 를 *글자 그대로* 참조하지 않으므로(`h(App, null)` 은 변환 *후* 생기는 노드) 그 카운트에 안 잡혀, 사용 중인데도 "미사용" 으로 오판해 제거됐던 것입니다. 이 PR 은 "classic 모드 + 이 모듈에 JSX 있음" 이면 factory/fragment 이름은 무조건 살아있는 것으로 취급하게 합니다.
- `std.mem.sliceTo(s, '.')` 은 첫 `.` 까지의 슬라이스(없으면 전체)를 반환 — 새 메모리 할당 없이 `s` 내부를 가리킵니다.

## 테스트

- `zig build test` ✅ (#3063 유닛 테스트 포함)
- `bun run type-check` / `lint` / `fmt` / `zig fmt --check src/` ✅
- `cd tests/e2e && bunx playwright test tests/lib-scenario-e2e.test.ts` ✅ (H11 포함 18 passed)
- `cd tests/integration && bun test` — 기존 baseline 실패(`watch-stress` RSS, RN hermesc 3건)만 남음. 본 변경은 RN 경로 미접근, clean main 에서도 동일 실패 확인.
- 수동: 최소 재현(`export function h(...){}` + JSX) → fix 이후 `function h` 보존 + `h(...)` 정상; preact `--jsx-factory=h` → entry 가 `k(App, null)` (preact createElement 의 renamed export 로 정상 resolve).

Closes #3063

🤖 Generated with [Claude Code](https://claude.com/claude-code)