### PR TITLE
feat(transformer): per-file JSX pragma 주석 지원 (@jsx / @jsxFrag / @jsxRuntime / @jsxImportSource)

### DIFF
--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -104,6 +104,9 @@ pub fn run(self: anytype, module: *Module, arena_alloc: std.mem.Allocator) void 
     opts.plugins = merged_plugins;
     opts.jsx_transform = ast_ptr.has_jsx;
     opts.jsx_filename = module.path;
+    // per-file JSX pragma (D026): `@jsxRuntime` / `@jsx` / `@jsxFrag` / `@jsxImportSource`
+    // 가 tsconfig/CLI 보다 우선. lowering 전에 module 의 effective JSX 설정을 확정.
+    opts = opts.withModuleJsxPragmas(ast_ptr);
     // #1961 PR 1h 후 splitting / single-bundle 양쪽에서 helper module virtual import
     // 모델 활성. mangler 가 helper module top-level 식별자를 reserved 처리
     // (linker.zig 의 candidates collect 에서 isVirtualId 분기) — cross-module binding

--- a/src/lexer/scanner.zig
+++ b/src/lexer/scanner.zig
@@ -86,8 +86,8 @@ pub const Scanner = struct {
     prev_token_kind: Kind = .eof,
 
     /// JSX pragma (D026): 파일 상단 주석에서 감지.
-    /// `@jsx h` → jsx_pragma = "h"
-    jsx_pragma: ?[]const u8 = null,
+    /// `@jsx h` → jsx_factory_pragma = "h"
+    jsx_factory_pragma: ?[]const u8 = null,
     /// `@jsxFrag Fragment` → jsx_frag_pragma = "Fragment"
     jsx_frag_pragma: ?[]const u8 = null,
     /// `@jsxRuntime automatic` → jsx_runtime_pragma = "automatic"
@@ -1129,7 +1129,7 @@ pub const Scanner = struct {
                 !std.mem.startsWith(u8, val, "Runtime") and
                 !std.mem.startsWith(u8, val, "ImportSource"))
             {
-                self.jsx_pragma = val;
+                self.jsx_factory_pragma = val;
             }
         }
     }

--- a/src/lexer/scanner_test.zig
+++ b/src/lexer/scanner_test.zig
@@ -1155,7 +1155,7 @@ test "Scanner: @jsx pragma in single-line comment" {
 
     try scanner.next(); // const (comment is skipped)
     try std.testing.expectEqual(Kind.kw_const, scanner.token.kind);
-    try std.testing.expectEqualStrings("h", scanner.jsx_pragma.?);
+    try std.testing.expectEqualStrings("h", scanner.jsx_factory_pragma.?);
 }
 
 test "Scanner: @jsx pragma in multi-line comment" {
@@ -1164,7 +1164,7 @@ test "Scanner: @jsx pragma in multi-line comment" {
     defer scanner.deinit();
 
     try scanner.next();
-    try std.testing.expectEqualStrings("h", scanner.jsx_pragma.?);
+    try std.testing.expectEqualStrings("h", scanner.jsx_factory_pragma.?);
 }
 
 test "Scanner: @jsxFrag pragma" {
@@ -1202,7 +1202,7 @@ test "Scanner: multiple pragmas in one file" {
     // 전체 스캔
     try drainTokensToEof(&scanner);
 
-    try std.testing.expectEqualStrings("h", scanner.jsx_pragma.?);
+    try std.testing.expectEqualStrings("h", scanner.jsx_factory_pragma.?);
     try std.testing.expectEqualStrings("Fragment", scanner.jsx_frag_pragma.?);
 }
 
@@ -1212,7 +1212,7 @@ test "Scanner: no pragma in normal comment" {
     defer scanner.deinit();
 
     try scanner.next();
-    try std.testing.expect(scanner.jsx_pragma == null);
+    try std.testing.expect(scanner.jsx_factory_pragma == null);
     try std.testing.expect(scanner.jsx_frag_pragma == null);
 }
 

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -916,6 +916,15 @@ pub const Ast = struct {
     /// require 주입 여부를 O(1) 로 결정 (linear AST walk 회피).
     has_flow_enum_declaration: bool = false,
 
+    /// per-file JSX pragma 주석 (D026). lexer 가 주석에서 감지해 채운다. transform
+    /// 단계에서 `TransformOptions.withModuleJsxPragmas` 가 module 단위로
+    /// jsx_runtime/factory/fragment/import_source 를 override (file pragma > tsconfig/CLI,
+    /// esbuild/TS 동일). 모두 source 슬라이스 — Ast.source 가 backing.
+    jsx_pragma_factory: ?[]const u8 = null, // `@jsx h`
+    jsx_pragma_fragment: ?[]const u8 = null, // `@jsxFrag Fragment`
+    jsx_pragma_runtime: ?[]const u8 = null, // `@jsxRuntime automatic`
+    jsx_pragma_import_source: ?[]const u8 = null, // `@jsxImportSource preact`
+
     /// D1 (RFC #1672) 디버그 인프라. Transformer.init 시점의 `nodes.items.len` snapshot.
     /// null = 미변환. boundary 이상의 노드는 transformer 가 append 한 것.
     /// D1a 부터 clone 경로 (Transformer.init → cloneForTransformer) 에서 활성.
@@ -1032,6 +1041,10 @@ pub const Ast = struct {
             .has_ts_import_equals = source_ast.has_ts_import_equals,
             .has_ts_export_equals = source_ast.has_ts_export_equals,
             .has_flow_enum_declaration = source_ast.has_flow_enum_declaration,
+            .jsx_pragma_factory = source_ast.jsx_pragma_factory,
+            .jsx_pragma_fragment = source_ast.jsx_pragma_fragment,
+            .jsx_pragma_runtime = source_ast.jsx_pragma_runtime,
+            .jsx_pragma_import_source = source_ast.jsx_pragma_import_source,
             .allocator = allocator,
             // #1961: source_ast 가 이미 transform 된 상태면 transformed_root + boundary 도
             // 복사. 그렇지 않으면 emit 단계 transformer 가 graph pre-pass 결과를 무시하고

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -74,6 +74,13 @@ pub fn parse(self: *Parser) !NodeIndex {
     // Unambiguous 모드 해결: import/export 유무로 module/script 확정 (oxc 방식)
     try self.resolveModuleKind();
 
+    // per-file JSX pragma (D026) — scanner 가 주석 스캔 중 누적한 값을 AST 로 carry.
+    // 파일 어디의 주석이든 (esbuild 와 동일) 마지막 값이 적용된다.
+    self.ast.jsx_pragma_factory = self.scanner.jsx_factory_pragma;
+    self.ast.jsx_pragma_fragment = self.scanner.jsx_frag_pragma;
+    self.ast.jsx_pragma_runtime = self.scanner.jsx_runtime_pragma;
+    self.ast.jsx_pragma_import_source = self.scanner.jsx_import_source_pragma;
+
     const list = try self.ast.addNodeList(stmts.items);
     return try self.ast.addNode(.{
         .tag = .program,

--- a/src/transformer/options.zig
+++ b/src/transformer/options.zig
@@ -331,6 +331,23 @@ pub const TransformOptions = struct {
     pub fn jsxClassicFragmentHead(self: @This()) []const u8 {
         return jsxHeadIdent(self.jsx_fragment);
     }
+
+    /// per-file JSX pragma 주석 (D026) 을 적용한 module-local 옵션 사본.
+    /// `@jsxRuntime` → runtime, `@jsx` → factory, `@jsxFrag` → fragment,
+    /// `@jsxImportSource` → import source. 우선순위는 file pragma > tsconfig/CLI
+    /// (esbuild / TypeScript 동일). pragma 가 없는 항목은 그대로 둔다. transform 의
+    /// 모든 진입점 (graph pre-pass, transpile) 이 이 함수 하나를 거쳐 module 의
+    /// effective JSX 설정을 확정한다.
+    pub fn withModuleJsxPragmas(self: @This(), ast: *const Ast) @This() {
+        var out = self;
+        if (ast.jsx_pragma_runtime) |s| {
+            if (codegen_options.JsxRuntime.fromString(s)) |rt| out.jsx_runtime = rt;
+        }
+        if (ast.jsx_pragma_factory) |s| out.jsx_factory = s;
+        if (ast.jsx_pragma_fragment) |s| out.jsx_fragment = s;
+        if (ast.jsx_pragma_import_source) |s| out.jsx_import_source = s;
+        return out;
+    }
 };
 
 /// 점-구분 pragma 의 head segment. `jsx_lowering.makeFactoryCallee` 가 동일하게

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -2392,6 +2392,81 @@ test "#3063 classic JSX factory named import 보존 / non-JSX 는 그대로 elid
 }
 
 // ============================================================
+// D026: per-file JSX pragma 주석 — `@jsx` / `@jsxFrag` / `@jsxRuntime` / `@jsxImportSource`
+//
+// lexer 가 주석에서 감지(scanner.jsx_*_pragma) → AST 로 carry → transform 단계에서
+// `TransformOptions.withModuleJsxPragmas` 가 module 단위로 jsx 설정 override.
+// 우선순위: file pragma > tsconfig/CLI (esbuild/TypeScript 동일).
+// ============================================================
+
+test "D026 per-file JSX pragma override" {
+    // `@jsx` / `@jsxFrag` → classic factory/fragment override (default `React.createElement` 무시).
+    {
+        var result = try transpile_mod.transpile(
+            std.testing.allocator,
+            \\/** @jsx h */
+            \\/** @jsxFrag Fragment */
+            \\import { h, Fragment } from "preact";
+            \\export const App = () => <><p>a</p></>;
+        ,
+            "input.jsx",
+            .{},
+        );
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expect(std.mem.indexOf(u8, result.code, "h(Fragment") != null);
+        try std.testing.expect(std.mem.indexOf(u8, result.code, "React.createElement") == null);
+        // #3063 elision 연동 — pragma 가 effective factory/fragment 를 정하므로 specifier 도 보존.
+        try std.testing.expect(std.mem.indexOf(u8, result.code, "\"preact\"") != null);
+    }
+    // single-line `// @jsx h` 도 동일.
+    {
+        var result = try transpile_mod.transpile(
+            std.testing.allocator,
+            \\// @jsx h
+            \\import { h } from "preact";
+            \\export const App = () => <div>c</div>;
+        ,
+            "input.jsx",
+            .{},
+        );
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expect(std.mem.indexOf(u8, result.code, "h(\"div\"") != null);
+    }
+    // `@jsxImportSource` → automatic import source override.
+    {
+        var result = try transpile_mod.transpile(
+            std.testing.allocator,
+            \\/** @jsxImportSource preact */
+            \\export const App = () => <p>x</p>;
+        ,
+            "input.jsx",
+            .{ .jsx_runtime = .automatic },
+        );
+        defer result.deinit(std.testing.allocator);
+        // `"preact/jsx-runtime"` 가 `react/jsx-runtime` 을 substring 으로 포함하므로
+        // 음성 단언은 `from "react/jsx-runtime"` 처럼 quote 까지 포함해 검사.
+        try std.testing.expect(std.mem.indexOf(u8, result.code, "\"preact/jsx-runtime\"") != null);
+        try std.testing.expect(std.mem.indexOf(u8, result.code, "from \"react/jsx-runtime\"") == null);
+    }
+    // `@jsxRuntime classic` → automatic 기본 프로젝트를 classic 으로 전환.
+    {
+        var result = try transpile_mod.transpile(
+            std.testing.allocator,
+            \\/** @jsxRuntime classic */
+            \\/** @jsx h */
+            \\import { h } from "preact";
+            \\export const App = () => <div>d</div>;
+        ,
+            "input.jsx",
+            .{ .jsx_runtime = .automatic },
+        );
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expect(std.mem.indexOf(u8, result.code, "h(\"div\"") != null);
+        try std.testing.expect(std.mem.indexOf(u8, result.code, "jsx-runtime") == null);
+    }
+}
+
+// ============================================================
 // --define 치환 (#1552)
 // ============================================================
 

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -17,6 +17,7 @@ const Ast = ast_mod.Ast;
 const ast_walk = @import("parser/ast_walk.zig");
 const SemanticAnalyzer = @import("semantic/mod.zig").SemanticAnalyzer;
 const Transformer = @import("transformer/transformer.zig").Transformer;
+const TransformOptions = @import("transformer/transformer.zig").TransformOptions;
 const BindingLite = @import("transformer/transformer.zig").BindingLite;
 const Codegen = @import("codegen/codegen.zig").Codegen;
 const SourceMap = @import("codegen/sourcemap.zig");
@@ -987,7 +988,7 @@ fn transpileWithCallbackInternal(
     }
 
     // 4. 변환
-    var transformer = try Transformer.init(arena_alloc, &parser.ast, .{
+    const transform_opts: TransformOptions = .{
         .drop_console = options.drop_console,
         .drop_debugger = options.drop_debugger,
         .define = options.define,
@@ -1007,7 +1008,9 @@ fn transpileWithCallbackInternal(
         .minify_whitespace = options.minify_whitespace,
         .react_refresh = options.react_refresh,
         .react_refresh_hook_signatures = options.react_refresh_hook_signatures,
-    });
+    };
+    // per-file JSX pragma (D026): tsconfig/CLI 보다 우선 — graph pre-pass 와 동일 경로.
+    var transformer = try Transformer.init(arena_alloc, &parser.ast, transform_opts.withModuleJsxPragmas(&parser.ast));
     // transformer.ast 도 arena owned (cloneForTransformer 결과). parser.ast 와 동일 이유.
     defer transformer.ast.dumpStringInternStatsIfEnabled();
     if (analyzer_storage) |*analyzer| {
@@ -1082,10 +1085,12 @@ fn transpileWithCallbackInternal(
     }
     const raw_output = cg.generate(root) catch return error.CodegenError;
 
-    // 6.5. JSX import prepend (transformer가 JSX lowering 수행한 경우)
+    // 6.5. JSX import prepend (transformer가 JSX lowering 수행한 경우).
+    // transformer.options 는 per-file pragma (#D026) 가 적용된 effective 설정 — 원본
+    // `options.jsx_*` 가 아니라 이쪽을 써야 `@jsxImportSource` / `@jsxRuntime` 가 반영된다.
     const jsx_import_str: ?[]const u8 = if (transformer.jsx_import_info.hasImports()) blk: {
-        const is_dev = options.jsx_runtime == .automatic_dev;
-        break :blk transformer.jsx_import_info.buildImportString(arena_alloc, options.jsx_import_source, is_dev);
+        const is_dev = transformer.options.jsx_runtime == .automatic_dev;
+        break :blk transformer.jsx_import_info.buildImportString(arena_alloc, transformer.options.jsx_import_source, is_dev);
     } else null;
     const jsx_output = prependImportLine(arena_alloc, jsx_import_str, raw_output);
 

--- a/tests/e2e/tests/lib-scenario-e2e.test.ts
+++ b/tests/e2e/tests/lib-scenario-e2e.test.ts
@@ -624,6 +624,30 @@ render(<App />, mount);
     },
   },
   {
+    // D026 per-file JSX pragma: 프로젝트 기본 `--jsx=automatic` (import source = react,
+    // 미설치) 인데 파일이 `/** @jsxImportSource preact */` 로 override → preact/jsx-runtime
+    // 사용. pragma 가 안 먹히면 빌드 시 `react/jsx-runtime` resolve 실패로 fail.
+    name: 'H12_jsx_pragma_import_source',
+    category: 'H_jsx_ts',
+    packages: ['preact'],
+    entryFile: 'index.tsx',
+    extraArgs: ['--jsx=automatic'],
+    entry: `/** @jsxImportSource preact */
+import { render } from 'preact';
+
+function App() {
+  return <p data-testid="pragma">jsx-pragma-ok</p>;
+}
+
+const mount = document.createElement('div');
+document.body.appendChild(mount);
+render(<App />, mount);
+`,
+    expect: {
+      pragma: 'jsx-pragma-ok',
+    },
+  },
+  {
     name: 'H3_ts_legacy_decorator',
     category: 'H_jsx_ts',
     packages: [],


### PR DESCRIPTION
## 무엇을 / 왜

lexer 는 이미 파일 주석에서 JSX pragma — `/** @jsx h */`, `/** @jsxFrag Fragment */`, `/** @jsxRuntime automatic */`, `/** @jsxImportSource preact */` (single-line `// @jsx h` 도) — 를 감지해 `Scanner` 필드에 담고 있었습니다 (decision **D026**). 그런데 그 값을 **읽는 코드가 어디에도 없어** 완전히 무시되고 있었습니다 (`grep -rn jsx_pragma src/` → `scanner.zig` 한 곳뿐, dead).

esbuild · TypeScript · Babel 은 모두 이 pragma 를 honor 합니다. "프로젝트는 React 인데 이 파일 하나만 preact / `@emotion/react`" 같은 mixed 코드베이스, 또는 tsconfig/CLI 를 안 건드리고 파일 단위로 JSX 런타임을 바꾸고 싶을 때 흔히 씁니다. config-level (`--jsx-import-source`, tsconfig `jsxImportSource`) 은 이미 동작하지만 per-file 은 비어 있었습니다.

## wiring (single source of truth)

1. **`Scanner` → `Ast`** — `parse()` 끝에서 `scanner.jsx_factory_pragma` 등을 `Ast.jsx_pragma_{factory,fragment,runtime,import_source}` 로 carry. 파일 어디의 주석이든 마지막 값이 적용 (esbuild 동일). `Ast.source` 가 backing 슬라이스 — `cloneForTransformer` 도 carry.
2. **`TransformOptions.withModuleJsxPragmas(ast)`** — `@jsxRuntime` → `jsx_runtime` (`JsxRuntime.fromString`), `@jsx` → `jsx_factory`, `@jsxFrag` → `jsx_fragment`, `@jsxImportSource` → `jsx_import_source`. **우선순위: file pragma > tsconfig/CLI** (esbuild/TS 동일). transform 의 두 진입점 — `transform_prepass.zig` (bundler), `transpile.zig` (CLI/NAPI) — 이 이 함수 하나를 거쳐 module 의 effective JSX 설정을 확정.
3. **`transpile.zig` 의 JSX import prepend** — `transformer.options.*` (pragma 적용 후) 를 읽도록 수정. 이전엔 원본 `options.jsx_import_source`/`jsx_runtime` 라 `@jsxImportSource` / `@jsxRuntime` 가 prepend 되는 import line 에 반영 안 됐음.
4. **#3063 elision fix 와 자동 연동** — `@jsx h` 가 `options.jsx_factory` 를 `"h"` 로 정하므로, `import { h, Fragment } from 'preact'` 가 unused-import elision 에 안 걸려 보존됨 (추가 작업 없음 — `jsxClassicFactoryHead()` 가 pragma-aware 한 `options.jsx_factory` 를 봄).
5. **scanner 필드명** `jsx_pragma` → `jsx_factory_pragma` (`jsx_frag_pragma` / `jsx_runtime_pragma` / `jsx_import_source_pragma` 와 대칭).

## 동작 예시

```tsx
/** @jsxImportSource preact */          // 프로젝트가 jsx: react-jsx 여도 이 파일만 preact
import { render } from 'preact';
export const App = () => <p>x</p>;
// → import { jsx as _jsx } from "preact/jsx-runtime"; ... _jsx("p", { children: "x" })

/** @jsx h */ /** @jsxFrag Fragment */  // 이 파일만 classic + preact pragma
import { h, Fragment } from 'preact';
export const App = () => <><p>a</p></>;
// → h(Fragment, null, h("p", null, "a"))   (h/Fragment import 보존)

/** @jsxRuntime classic */ /** @jsx h */  // automatic 기본 프로젝트를 이 파일만 classic 으로
```

## 한계 (의도된 동작)

`@jsx` / `@jsxFrag` 가 effective runtime 이 automatic 일 때는 무시됩니다 (factory 는 classic 에서만 쓰임). esbuild 는 이 조합을 에러로 처리하나, TypeScript 처럼 관대하게 허용 — 더 엄격하게 가려면 `withModuleJsxPragmas` 에 diagnostics 채널을 연결해야 해서 별도 작업으로 둡니다. `@jsxRuntime` 으로 명시적으로 전환하는 게 권장 패턴.

## Zig 초보자용 메모

- `withModuleJsxPragmas` 는 `TransformOptions` 값을 복사해 일부 필드만 덮은 사본을 반환 (`var out = self; if (...) out.x = ...; return out;`) — Zig 의 struct 는 값 타입이라 한 번 복사하는 비용은 무시 가능하고, caller (`opts = opts.withModuleJsxPragmas(ast);`) 입장에선 in-place 수정처럼 보임.
- `Ast.jsx_pragma_*` 는 `?[]const u8` 슬라이스로, scanner 가 주석 텍스트(`ast.source` 안)에서 잘라낸 것 — 새 메모리 할당 없음. `ast.source` 가 AST 보다 오래 살므로 dangling 없음.

D026 (docs/DECISIONS.md) 의 미완성 부분을 완성.

🤖 Generated with [Claude Code](https://claude.com/claude-code)