### PR TITLE
docs: per-file JSX pragma 주석 문서화 (@jsx / @jsxFrag / @jsxRuntime / @jsxImportSource)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -140,9 +140,10 @@
 - **결정**: 렉서에서 지원
 - **이유**: 트리쉐이킹의 핵심. esbuild/Bun/oxc 전부 렉서에서 이 주석을 토큰에 달아줌. 함수 호출이 부작용 없음을 표시하는 사실상 표준
 
-### D026: JSX pragma 주석 감지
-- **결정**: 렉서에서 지원
-- **이유**: `/** @jsx h */`, `/** @jsxRuntime automatic */` 등 파일 상단 주석에서 JSX 설정 오버라이드. esbuild/Bun/SWC 전부 지원. 렉서가 파일 시작 주석에서 추출
+### D026: JSX pragma 주석 감지 — 구현 완료
+- **결정**: 지원 (lexer 감지 + transform 단계 module override)
+- **이유**: `/** @jsx h */` / `/** @jsxFrag Fragment */` / `/** @jsxRuntime automatic */` / `/** @jsxImportSource preact */` (single-line `// @jsx h` 포함) 파일 주석에서 JSX 설정 per-file override. esbuild/Bun/SWC/TS/Babel 전부 지원
+- **구현**: lexer(`Scanner`) 가 주석 스캔 중 감지 → `Ast.jsx_pragma_*` 로 carry → `TransformOptions.withModuleJsxPragmas(ast)` 가 module 단위로 `jsx_runtime`/`jsx_factory`/`jsx_fragment`/`jsx_import_source` override. 우선순위 file pragma > tsconfig/CLI. `@jsx`/`@jsxFrag` 는 effective runtime 이 classic 일 때만 효과 (automatic 에선 무시 — esbuild 는 error 이나 TS 처럼 관대)
 
 ### D027: AMD / SystemJS 모듈 출력
 - **결정**: 미지원

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -98,6 +98,26 @@ zntc --bundle src/index.ts --drop-labels=DEV,TEST
 zntc --bundle src/index.ts --pure:React.createElement --pure:PropTypes.*
 ```
 
+### JSX pragma 주석 (per-file override)
+
+파일 주석으로 그 파일만의 JSX 설정을 지정할 수 있다 (esbuild/TS/Babel 동일).
+**우선순위: file pragma > tsconfig / CLI 옵션 > 기본값.**
+
+- `/** @jsx h */` — classic factory (= `--jsx-factory`)
+- `/** @jsxFrag Fragment */` — classic fragment (= `--jsx-fragment`)
+- `/** @jsxRuntime automatic|classic */` — JSX 런타임 모드 (= `--jsx`)
+- `/** @jsxImportSource preact */` — automatic import source (= `--jsx-import-source`)
+
+`//` 한 줄 주석(`// @jsx h`)도 인식한다. `@jsx` / `@jsxFrag` 는 effective 런타임이
+classic 일 때만 효과가 있다 (automatic 모드는 factory 를 안 쓰므로 무시). 프로젝트는
+React(`jsx: react-jsx`)인데 특정 파일만 preact / `@emotion/react` 로 쓰고 싶을 때:
+
+```tsx
+/** @jsxImportSource preact */
+import { render } from "preact";
+export const App = () => <p>preact only here</p>;
+```
+
 ### 플러그인은 `@zntc/core` JS API로 (npm 배포 CLI)
 
 JS 플러그인을 쓰려면 npm 배포 CLI(`packages/core/bin/zntc.mjs`)를 사용. 내부적으로

--- a/documents/src/content/docs/en/reference/cli.md
+++ b/documents/src/content/docs/en/reference/cli.md
@@ -193,6 +193,21 @@ Full table + behavior: [React Native guide](/zntc/en/guides/react-native/#metro-
 | `--jsx-in-js`                             | Allow JSX parsing in `.js` files                  |
 | `--jsx-side-effects`                      | Preserve unused JSX expressions as side-effectful |
 
+### Per-file pragma comments
+
+Per-file comments override that file's JSX settings (same as esbuild/TypeScript/Babel).
+**Precedence: file pragma > tsconfig / CLI options > defaults.** `//` line comments work too.
+
+- `/** @jsx h */` — classic factory (= `--jsx-factory`)
+- `/** @jsxFrag Fragment */` — classic fragment (= `--jsx-fragment`)
+- `/** @jsxRuntime automatic|classic */` — runtime mode (= `--jsx`)
+- `/** @jsxImportSource preact */` — automatic import source (= `--jsx-import-source`)
+
+`@jsx` / `@jsxFrag` only take effect when the effective runtime is classic (the automatic
+runtime doesn't use a factory). E.g. a project on React (`jsx: react-jsx`) can have one file
+use preact by adding just `/** @jsxImportSource preact */` — that file alone uses
+`preact/jsx-runtime`.
+
 ## TypeScript
 
 | Option                                         | Description                                                                  |

--- a/documents/src/content/docs/reference/cli.md
+++ b/documents/src/content/docs/reference/cli.md
@@ -190,6 +190,20 @@ Options:
 | `--jsx-in-js`                             | `.js` 파일에서도 JSX 파싱 허용                                     |
 | `--jsx-side-effects`                      | 사용되지 않은 JSX expression을 side-effect가 있는 것으로 보고 보존 |
 
+### Per-file pragma 주석
+
+파일 주석으로 그 파일만의 JSX 설정을 override 합니다 (esbuild/TypeScript/Babel 동일).
+**우선순위: file pragma > tsconfig / CLI 옵션 > 기본값.** `//` 한 줄 주석도 인식.
+
+- `/** @jsx h */` — classic factory (= `--jsx-factory`)
+- `/** @jsxFrag Fragment */` — classic fragment (= `--jsx-fragment`)
+- `/** @jsxRuntime automatic|classic */` — 런타임 모드 (= `--jsx`)
+- `/** @jsxImportSource preact */` — automatic import source (= `--jsx-import-source`)
+
+`@jsx` / `@jsxFrag` 는 effective 런타임이 classic 일 때만 효과가 있습니다 (automatic 모드는
+factory 미사용). 예: 프로젝트는 React(`jsx: react-jsx`)지만 한 파일만 preact —
+`/** @jsxImportSource preact */` 한 줄로 그 파일만 `preact/jsx-runtime` 을 씁니다.
+
 ## TypeScript
 
 | 옵션                                           | 설명                                                                     |


### PR DESCRIPTION
PR #3090 (D026 per-file JSX pragma 지원) 의 문서화.

- `docs/DECISIONS.md` — D026 "구현 완료" 로 갱신 (lexer 감지 + transform 단계 module override, 우선순위, classic-only 한계)
- `docs/USAGE.md` — `### JSX pragma 주석 (per-file override)` 섹션 추가 (4개 pragma + 우선순위 + preact/emotion 예시)
- `documents/src/content/docs/reference/cli.md` (KO/EN) — JSX 섹션에 `### Per-file pragma 주석/comments` 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)