### PR TITLE
feat(transformer): @jsx / @jsxFrag pragma 가 automatic runtime 에서 무시될 때 warning

### DIFF
--- a/src/bundler/bundler_test/jsx.zig
+++ b/src/bundler/bundler_test/jsx.zig
@@ -752,3 +752,31 @@ test "Stress: MVC 7-module framework" {
         try std.testing.expect(std.mem.indexOf(u8, result.output, needle) != null);
     }
 }
+
+test "JSX: @jsx pragma + automatic runtime → warning diagnostic (D026)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // 프로젝트는 automatic 인데 파일에 classic factory pragma — factory 가 무시됨.
+    try writeFile(tmp.dir, "app.tsx",
+        \\/** @jsx h */
+        \\export const App = () => <p>x</p>;
+        \\console.log(App);
+    );
+
+    const entry = try absPath(&tmp, "app.tsx");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .jsx_runtime = .automatic });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    // (react/jsx-runtime 미설치라 resolve error 도 같이 나지만) jsx_pragma_ignored warning 은 와야 함.
+    var has_pragma_warning = false;
+    for (result.getDiagnostics()) |d| {
+        if (d.code == .jsx_pragma_ignored and d.severity == .warning) {
+            has_pragma_warning = true;
+            break;
+        }
+    }
+    try std.testing.expect(has_pragma_warning);
+}

--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -12,6 +12,7 @@ const purity = @import("../purity.zig");
 const profile = @import("../../profile.zig");
 const SemanticAnalyzer = @import("../../semantic/analyzer.zig").SemanticAnalyzer;
 const Transformer = @import("../../transformer/transformer.zig").Transformer;
+const TransformOptions = @import("../../transformer/transformer.zig").TransformOptions;
 const builtin_plugins = @import("../../transformer/plugins/builtin.zig");
 const Span = @import("../../lexer/token.zig").Span;
 const parse_helpers = @import("parse_helpers.zig");
@@ -107,6 +108,9 @@ pub fn run(self: anytype, module: *Module, arena_alloc: std.mem.Allocator) void 
     // per-file JSX pragma (D026): `@jsxRuntime` / `@jsx` / `@jsxFrag` / `@jsxImportSource`
     // 가 tsconfig/CLI 보다 우선. lowering 전에 module 의 effective JSX 설정을 확정.
     opts = opts.withModuleJsxPragmas(ast_ptr);
+    if (opts.jsxClassicPragmaIgnoredUnderAutomatic(ast_ptr)) {
+        self.addDiag(.jsx_pragma_ignored, .warning, module.path, Span.EMPTY, .parse, TransformOptions.jsx_pragma_ignored_msg, null);
+    }
     // #1961 PR 1h 후 splitting / single-bundle 양쪽에서 helper module virtual import
     // 모델 활성. mangler 가 helper module top-level 식별자를 reserved 처리
     // (linker.zig 의 candidates collect 에서 isVirtualId 분기) — cross-module binding

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -690,6 +690,9 @@ pub const BundlerDiagnostic = struct {
         plugin_error,
         /// `output.exports = "default"` 모드 + named export 섞임. Rollup 도 동일 케이스 throw. #2159
         output_exports_conflict,
+        /// `@jsx` / `@jsxFrag` pragma 가 있는데 effective JSX runtime 이 automatic — classic
+        /// factory 가 무시됨 (D026). warning severity.
+        jsx_pragma_ignored,
     };
 
     pub const Severity = enum {

--- a/src/transformer/options.zig
+++ b/src/transformer/options.zig
@@ -348,6 +348,20 @@ pub const TransformOptions = struct {
         if (ast.jsx_pragma_import_source) |s| out.jsx_import_source = s;
         return out;
     }
+
+    /// `@jsx` / `@jsxFrag` pragma 가 있는데 (pragma·tsconfig·CLI 머지 후) effective
+    /// runtime 이 automatic 이면 classic factory 가 무시된다 — caller 가 warning 을 띄운다.
+    pub fn jsxClassicPragmaIgnoredUnderAutomatic(self: @This(), ast: *const Ast) bool {
+        if (!ast.has_jsx) return false;
+        if (self.jsx_runtime != .automatic and self.jsx_runtime != .automatic_dev) return false;
+        return ast.jsx_pragma_factory != null or ast.jsx_pragma_fragment != null;
+    }
+
+    /// `jsxClassicPragmaIgnoredUnderAutomatic` 가 true 일 때 caller 가 띄우는 메시지.
+    /// graph pre-pass(structured diagnostic) 와 transpile(`std.log.warn`) 양쪽이 공유.
+    pub const jsx_pragma_ignored_msg =
+        "@jsx / @jsxFrag pragma ignored — the effective JSX runtime is automatic; " ++
+        "add /** @jsxRuntime classic */ to use a custom factory, or remove the pragma";
 };
 
 /// 점-구분 pragma 의 head segment. `jsx_lowering.makeFactoryCallee` 가 동일하게

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -2464,6 +2464,21 @@ test "D026 per-file JSX pragma override" {
         try std.testing.expect(std.mem.indexOf(u8, result.code, "h(\"div\"") != null);
         try std.testing.expect(std.mem.indexOf(u8, result.code, "jsx-runtime") == null);
     }
+    // `@jsx h` 만 + effective runtime automatic → factory 무시 (automatic transform 그대로).
+    // (warning 도 함께 emit 되지만 std.log.warn 은 여기서 단언 불가 — 동작만 검증.)
+    {
+        var result = try transpile_mod.transpile(
+            std.testing.allocator,
+            \\/** @jsx h */
+            \\export const App = () => <p>x</p>;
+        ,
+            "input.jsx",
+            .{ .jsx_runtime = .automatic },
+        );
+        defer result.deinit(std.testing.allocator);
+        try std.testing.expect(std.mem.indexOf(u8, result.code, "jsx-runtime") != null);
+        try std.testing.expect(std.mem.indexOf(u8, result.code, "h(\"p\"") == null);
+    }
 }
 
 // ============================================================

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -1010,7 +1010,11 @@ fn transpileWithCallbackInternal(
         .react_refresh_hook_signatures = options.react_refresh_hook_signatures,
     };
     // per-file JSX pragma (D026): tsconfig/CLI 보다 우선 — graph pre-pass 와 동일 경로.
-    var transformer = try Transformer.init(arena_alloc, &parser.ast, transform_opts.withModuleJsxPragmas(&parser.ast));
+    const effective_opts = transform_opts.withModuleJsxPragmas(&parser.ast);
+    if (effective_opts.jsxClassicPragmaIgnoredUnderAutomatic(&parser.ast)) {
+        std.log.warn("zntc: {s}: {s}", .{ file_path, TransformOptions.jsx_pragma_ignored_msg });
+    }
+    var transformer = try Transformer.init(arena_alloc, &parser.ast, effective_opts);
     // transformer.ast 도 arena owned (cloneForTransformer 결과). parser.ast 와 동일 이유.
     defer transformer.ast.dumpStringInternStatsIfEnabled();
     if (analyzer_storage) |*analyzer| {


### PR DESCRIPTION
## 무엇을 / 왜

D026 (PR #3090) 로 per-file JSX pragma 를 지원하게 됐는데 — `/** @jsx h */` / `/** @jsxFrag Fragment */` 는 **classic** factory/fragment 를 지정합니다. 그런데 effective JSX runtime 이 `automatic` / `automatic-dev` 면 (automatic 모드는 `React.createElement` 같은 factory 를 안 쓰고 `jsx-runtime` 에서 import 한 `_jsx`/`_jsxs` 를 씀) 이 pragma 가 **조용히 무시**됩니다. 사용자가 `@jsx h` 를 적어두고 "왜 안 먹히지?" 하고 헷갈릴 수 있어서 warning 으로 알려줍니다.

레퍼런스 비교 (`references/oxc`, `references/swc`):
- **esbuild**: 이 조합을 **error** 로 처리
- **oxc / rolldown**: **warning** (`OxcDiagnostic::warn("pragma and pragmaFrag cannot be set when runtime is automatic")`)
- **TypeScript / Babel / SWC**: silent (무시)

`feedback_oxc_reference` (구현 방법 여러 개면 oxc 방식) 에 따라 **warning** 채택 — esbuild 의 hard error 는 "factory 무시되지만 빌드는 됨"인 경우도 깨서 과하고, 완전 silent 는 footgun.

## 변경

- **`src/transformer/options.zig`** — `TransformOptions.jsxClassicPragmaIgnoredUnderAutomatic(ast)`: `@jsx`/`@jsxFrag` pragma 가 있고 (pragma·tsconfig·CLI 머지 후) effective runtime 이 automatic 계열이면 true. `jsx_pragma_ignored_msg` 상수도 같이 둬서 두 경로가 동일 문구 공유.
- **`src/bundler/graph/transform_prepass.zig`** (번들러 — `zntc --bundle`, `zntc build/dev`): `withModuleJsxPragmas` 직후 conflict 면 `addDiag(.jsx_pragma_ignored, .warning, ...)`. `BundlerDiagnostic.ErrorCode.jsx_pragma_ignored` 추가.
- **`src/transpile.zig`** (CLI/NAPI — `zntc file.tsx`): `std.log.warn(...)`. transpile 경로는 transform-time diagnostics 채널이 없어 (`Diagnostic` 타입에 severity 없음) `react-refresh not found` warning 과 동일하게 `std.log.warn` 사용.
- **동작**: warning 만 추가하고 transform 결과는 그대로 — automatic 으로 lowering, factory 무시. `/** @jsxRuntime classic */` 을 함께 쓰면 classic 으로 전환되어 warning 안 뜸. `preserve` 모드는 JSX 자체를 변환 안 하므로 (oxc 와 동일하게) 대상 아님.

```tsx
/** @jsx h */                             // 프로젝트가 jsx: react-jsx (automatic) 인데...
export const App = () => <p>x</p>;
// → warning: @jsx / @jsxFrag pragma ignored — the effective JSX runtime is automatic;
//            add /** @jsxRuntime classic */ to use a custom factory, or remove the pragma
// → 출력은 그대로 automatic: _jsx("p", { children: "x" })
```

## 테스트

- bundler (`bundler_test/jsx.zig`): `.jsx_runtime = .automatic` + `@jsx h` 픽스처 → `result.getDiagnostics()` 에 `.jsx_pragma_ignored` `.warning` 들어옴.
- transpile (`transformer_test.zig` D026 케이스 추가): `@jsx h` + `.jsx_runtime = .automatic` → 출력이 automatic transform (`jsx-runtime` import, `h(...)` 호출 없음) — factory 무시 동작 검증. (warning 자체는 `std.log.warn` 이라 단언 불가 — 동작만.)
- `zig build test` / type-check / lint / fmt / `zig fmt --check src/` ✅
- 수동: transpile/bundle 양쪽에서 warning 출력 확인, `@jsxRuntime classic` 동반 시 미출력 확인.

D026 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)