### PR TITLE
fix(bundler,test): dev 빌드 에러 후 overlay 가 잘못 사라지는 버그 + watch-stress warmup false positive

### DIFF
--- a/src/bundler/incremental.zig
+++ b/src/bundler/incremental.zig
@@ -174,6 +174,13 @@ pub const IncrementalBundler = struct {
                 return .fatal;
             };
             result.deinit(self.allocator);
+            // 빌드 에러 후엔 다음 rebuild 를 full rebuild 로 강제. 그렇지 않으면 broken
+            // module 이 persistent_store 에 캐시된 채 남아, 같은 broken 파일에 대한
+            // 다음 incremental rebuild 가 cache hit → `result.hasErrors()` false → `.success`
+            // (changed_modules=0) 로 잘못 보고하고, dev server 가 overlay 를 clear 해버린다.
+            // 파일이 고쳐지면 full rebuild 가 에러 없이 끝나며 doBuild 의 `if (is_first)`
+            // 분기에서 flag 가 자동 해제된다.
+            self.needs_full_rebuild = true;
             return .{ .build_error = err_json };
         }
 

--- a/tests/integration/tests/watch-stress.test.ts
+++ b/tests/integration/tests/watch-stress.test.ts
@@ -53,6 +53,8 @@ describe('watch 메모리 스트레스 (시뮬레이션)', () => {
     async () => {
       const ITERATIONS = 150;
       const SAMPLE_EVERY = 15;
+      // 첫 ~40% 의 rebuild 는 cache warmup 구간 — slope 측정에서 제외 (아래 주석 참조).
+      const WARMUP_FRACTION = 0.4;
       // 임계: 실측 0.05 KB/rebuild 대비 넉넉하되 누수는 탐지 가능한 범위.
       // 실제 누수 발생 시 수십 KB/회 수준이 통상.
       const SLOPE_THRESHOLD_KB = 2;
@@ -89,11 +91,16 @@ describe('watch 메모리 스트레스 (시뮬레이션)', () => {
         const first = samples[0].y;
         const last = samples[samples.length - 1].y;
         const max = Math.max(...samples.map((s) => s.y));
-        const slope = linearSlope(samples);
+        // warmup 구간 동안 resolve/compiled cache·module store·intern table 가 차오르며
+        // RSS 가 한 번 ramp 후 평탄해진다 (bounded). 전체 샘플에 linear fit 하면 이 ramp 가
+        // slope 를 부풀려 false positive. 누수 판정은 warmup 이후 steady-state 구간의 slope 로
+        // — 실제 누수면 평탄화되지 않고 steady-state 에서도 기울기가 남는다.
+        const steadyState = samples.slice(Math.floor(samples.length * WARMUP_FRACTION));
+        const slope = linearSlope(steadyState.length >= 2 ? steadyState : samples);
         const totalGrowth = max - first;
 
         const trace = samples.map((s) => `${s.x}:${s.y}KB`).join(', ');
-        const summary = `iters=${ITERATIONS} first=${first}KB last=${last}KB max=${max}KB slope=${slope.toFixed(2)}KB/rebuild growth=${totalGrowth}KB`;
+        const summary = `iters=${ITERATIONS} first=${first}KB last=${last}KB max=${max}KB steadySlope=${slope.toFixed(2)}KB/rebuild growth=${totalGrowth}KB`;
 
         // 실패 시 디버깅 편의. 성공 시에도 CI 로그에 궤적 한 줄 남겨 트렌드 모니터링.
         console.log(`[watch-stress] ${summary}`);


### PR DESCRIPTION
배포 전 남아있던 e2e 1 fail + integration 1 fail (둘 다 baseline) 수정.

## 1. `incremental.zig` — `zntc --serve --bundle` 에서 빌드 에러 오버레이가 즉시 사라짐

**증상**: dev server 에 띄운 파일에 구문 에러를 넣으면 `#zntc-error-overlay` 가 떠야 하는데 곧바로 사라진다. e2e `smoke.test.ts › Dev Server E2E › 빌드 에러 시 에러 오버레이가 표시된다` 가 macOS 에서 일관되게 fail (Linux CI 에선 이미 `test.skip` — "inotify timing").

**원인** (디버그로 확인): `fs.writeFile` 한 번이 fsevents/inotify 에서 종종 2개의 change 이벤트로 쪼개진다.
- 1번째 이벤트 → `IncrementalBundler.rebuild()` → `.build_error` → dev server 가 `{"type":"error",...}` WS broadcast → 오버레이 표시 ✓
- `.build_error` 경로는 broken module 을 `persistent_store` 에 캐시된 채 남김
- 2번째 이벤트 → `rebuild()` → 같은 broken 파일 cache hit → `result.hasErrors()` **false** → `.success` (changed_modules=0) 로 잘못 보고 → dev server 가 `{"type":"clear-error"}` broadcast → **오버레이 제거** ✗

WS 트레이스로 확인: `{"type":"connected"}` → `{"type":"error",...}` → `{"type":"clear-error"}` (← 버그).

**fix**: `.build_error` 반환 시 `self.needs_full_rebuild = true`. broken 파일은 다음 rebuild 부터 full re-parse → 매번 `.build_error` 재보고 (`clear-error` 안 나감). 파일을 고치면 full rebuild 가 에러 없이 끝나며 `doBuild` 의 `if (is_first) needs_full_rebuild = false` 분기에서 flag 자동 해제 → incremental 복귀. full rebuild 는 "파일이 깨진" 예외 상태에서만 발생하므로 성능 영향 무시 가능 (esbuild 도 incremental rebuild 가 에러 후 full rebuild 로 폴백).

수정 후 WS 트레이스: `{"type":"connected"}` → `{"type":"error",...}` → `{"type":"error",...}` (2번째 이벤트도 에러, clear 없음). 오버레이 정상 표시.

## 2. `watch-stress.test.ts` — warmup ramp 가 slope false positive

**증상**: 150회 rebuild 동안 RSS 샘플링 → linear fit slope `>= 2KB/rebuild` 면 누수로 판정. 그런데 실제로는 첫 ~60회 동안 resolve/compiled cache·module store·intern table 가 차오르며 RSS 가 ~768KB ramp 후 평탄해진다 (bounded — 실제 누수 아님). 전체 샘플에 fit 하면 이 warmup ramp 가 slope 를 ~3.7 로 부풀려 fail (`totalGrowth` 는 < 2MB 로 통과).

```
trace: 0:7376KB, 15:7760KB, 30:7952KB, 45:8112KB, 60:8128KB, 75:8032KB, 90:8144KB, 105:8160KB, 120:8144KB, 135:8160KB, 150:8144KB
                └──────────── warmup ramp ────────────┘└──────────── plateau ────────────┘
```

**fix**: slope 를 warmup 이후 (첫 `WARMUP_FRACTION`=40% 제외) steady-state 구간에서만 측정. 실제 누수면 평탄화되지 않으므로 steady-state slope 에 그대로 잡힌다 (수정 후 실측 0.72KB/rebuild << 2KB threshold). `totalGrowth` (max - first ≤ 2MB) 체크는 그대로 — 계단식 leak 도 계속 탐지.

## 테스트

- e2e `smoke.test.ts`: 9/9 pass (이전 1 fail → 0)
- `tests/integration/tests/watch-stress.test.ts`: 1/1 pass (steadySlope=0.72KB/rebuild)
- e2e `zntc-app-builder-e2e.test.ts`: 21/21 pass (incremental.zig 변경이 dev 경로 회귀 없는지 확인)
- `zig build test` / type-check / lint / fmt / `zig fmt --check src/` ✅

남은 baseline fail 3건 (RN hermesc 구문 검증)은 별도 — `zntc --bundle --platform=react-native` 가 출력에 uninitialized `0xaa` 바이트를 섞어 hermesc 가 "Invalid UTF-8 lead byte 0xaa" 로 거부하는 별개의 버그 (wrapped module 의 top-level var hoist emit 경로 추정). 후속 이슈에서.

🤖 Generated with [Claude Code](https://claude.com/claude-code)