### PR TITLE
perf(codegen): minify 시 binary +/- 연산자 공백 제거 (#3097)

### DIFF
--- a/src/codegen/codegen_test/basic.zig
+++ b/src/codegen/codegen_test/basic.zig
@@ -94,7 +94,7 @@ test "Codegen: TS export = class expression → module.exports = class" {
 test "Codegen: TS export = function expression → module.exports = function" {
     var r = try e2e(std.testing.allocator, "export = function add(a: number, b: number) { return a + b; };");
     defer r.deinit();
-    try std.testing.expectEqualStrings("module.exports=function add(a,b){return a + b;};", r.output);
+    try std.testing.expectEqualStrings("module.exports=function add(a,b){return a+b;};", r.output);
 }
 
 test "Codegen: TS export = require().default cherry-pick" {
@@ -288,4 +288,76 @@ test "Codegen: 원본 소스의 !0/!1은 minify_syntax와 무관하게 유지" {
     defer r.deinit();
     try std.testing.expect(std.mem.indexOf(u8, r.output, "!0") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "!1") != null);
+}
+
+// ============================================================
+// #3097: binary `+` / `-` 연산자 공백 — minify_whitespace 시 tight
+//   `a + b` → `a+b`, 단 `+`/`-` 다음에 `+`/`-`/`++`/`--` 로 시작하는 RHS 가
+//   오면 `++`/`--` 로 토큰이 잘못 합쳐지므로 한 칸만 삽입.
+// ============================================================
+
+test "Codegen #3097: minify 시 binary +/- tight" {
+    var r = try e2e(std.testing.allocator, "var z = a + b - c;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var z=a+b-c;", r.output);
+}
+
+test "Codegen #3097: minify 시 * / 는 기존대로 tight (anti-regression)" {
+    var r = try e2e(std.testing.allocator, "var z = a * b / c;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var z=a*b/c;", r.output);
+}
+
+test "Codegen #3097: + 다음 unary + 는 한 칸 (a+ +b)" {
+    var r = try e2e(std.testing.allocator, "var z = a + +b;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var z=a+ +b;", r.output);
+}
+
+test "Codegen #3097: - 다음 unary - 는 한 칸 (a- -b)" {
+    var r = try e2e(std.testing.allocator, "var z = a - -b;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var z=a- -b;", r.output);
+}
+
+test "Codegen #3097: + 다음 unary - 는 공백 불필요 (a+-b)" {
+    var r = try e2e(std.testing.allocator, "var z = a + -b;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var z=a+-b;", r.output);
+}
+
+test "Codegen #3097: - 다음 unary + 는 공백 불필요 (a-+b)" {
+    var r = try e2e(std.testing.allocator, "var z = a - +b;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var z=a-+b;", r.output);
+}
+
+test "Codegen #3097: + 다음 prefix ++ 는 한 칸 (a+ ++b)" {
+    var r = try e2e(std.testing.allocator, "var z = a + ++b;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var z=a+ ++b;", r.output);
+}
+
+test "Codegen #3097: - 다음 prefix -- 는 한 칸 (a- --b)" {
+    var r = try e2e(std.testing.allocator, "var z = a - --b;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var z=a- --b;", r.output);
+}
+
+test "Codegen #3097: postfix ++ 좌측은 공백 불필요 (a+++b == (a++)+b)" {
+    var r = try e2e(std.testing.allocator, "var z = a++ + b;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var z=a+++b;", r.output);
+}
+
+test "Codegen #3097: 더 높은 우선순위 RHS 의 leftmost 가 unary - (a- -b*c)" {
+    var r = try e2e(std.testing.allocator, "var z = a - -b * c;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var z=a- -b*c;", r.output);
+}
+
+test "Codegen #3097: non-minify 는 ` + ` 공백 유지 (anti-regression)" {
+    var r = try e2eWithOptions(std.testing.allocator, "var z = a + b;", .{});
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var z = a + b;\n", r.output);
 }

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -832,25 +832,25 @@ test "ES2015: no-substitution template" {
 test "ES2015: template with substitution" {
     var r = try e2eTarget(std.testing.allocator, "var x=`a${b}c`;", .es5);
     defer r.deinit();
-    try std.testing.expectEqualStrings("var x=\"a\" + b + \"c\";", r.output);
+    try std.testing.expectEqualStrings("var x=\"a\"+b+\"c\";", r.output);
 }
 
 test "ES2015: template empty head" {
     var r = try e2eTarget(std.testing.allocator, "var x=`${a}`;", .es5);
     defer r.deinit();
-    try std.testing.expectEqualStrings("var x=\"\" + a;", r.output);
+    try std.testing.expectEqualStrings("var x=\"\"+a;", r.output);
 }
 
 test "ES2015: template multiple substitutions" {
     var r = try e2eTarget(std.testing.allocator, "var x=`${a}${b}`;", .es5);
     defer r.deinit();
-    try std.testing.expectEqualStrings("var x=\"\" + a + b;", r.output);
+    try std.testing.expectEqualStrings("var x=\"\"+a+b;", r.output);
 }
 
 test "ES2015: template with text between substitutions" {
     var r = try e2eTarget(std.testing.allocator, "var x=`a${b}c${d}e`;", .es5);
     defer r.deinit();
-    try std.testing.expectEqualStrings("var x=\"a\" + b + \"c\" + d + \"e\";", r.output);
+    try std.testing.expectEqualStrings("var x=\"a\"+b+\"c\"+d+\"e\";", r.output);
 }
 
 test "ES2015: empty template" {
@@ -1099,13 +1099,13 @@ test "ES2015: arrow expression body" {
 test "ES2015: arrow with param" {
     var r = try e2eTarget(std.testing.allocator, "var f=x=>x+1;", .es5);
     defer r.deinit();
-    try std.testing.expectEqualStrings("var f=function(x){return x + 1;};", r.output);
+    try std.testing.expectEqualStrings("var f=function(x){return x+1;};", r.output);
 }
 
 test "ES2015: arrow with parens param" {
     var r = try e2eTarget(std.testing.allocator, "var f=(x)=>x+1;", .es5);
     defer r.deinit();
-    try std.testing.expectEqualStrings("var f=function(x){return x + 1;};", r.output);
+    try std.testing.expectEqualStrings("var f=function(x){return x+1;};", r.output);
 }
 
 test "ES2015: arrow block body" {
@@ -1117,7 +1117,7 @@ test "ES2015: arrow block body" {
 test "ES2015: arrow multiple params" {
     var r = try e2eTarget(std.testing.allocator, "var f=(a,b)=>a+b;", .es5);
     defer r.deinit();
-    try std.testing.expectEqualStrings("var f=function(a,b){return a + b;};", r.output);
+    try std.testing.expectEqualStrings("var f=function(a,b){return a+b;};", r.output);
 }
 
 test "ES2015: arrow no transform on esnext" {
@@ -1173,7 +1173,7 @@ test "ES2015: arrow simple params — no unnecessary lowering" {
     var r = try e2eTarget(std.testing.allocator, "var f=(a,b)=>a+b;", .es5);
     defer r.deinit();
     // 단순 파라미터는 그대로 유지 (destructuring lowering 불필요)
-    try std.testing.expectEqualStrings("var f=function(a,b){return a + b;};", r.output);
+    try std.testing.expectEqualStrings("var f=function(a,b){return a+b;};", r.output);
 }
 
 test "ES2015: class method destructuring params lowered" {
@@ -2468,7 +2468,7 @@ test "ES2015: template with actual newline" {
 test "ES2015: template with newline and substitution" {
     var r = try e2eTarget(std.testing.allocator, "var s=`a\n${b}\nc`;", .es5);
     defer r.deinit();
-    try std.testing.expectEqualStrings("var s=\"a\\n\" + b + \"\\nc\";", r.output);
+    try std.testing.expectEqualStrings("var s=\"a\\n\"+b+\"\\nc\";", r.output);
 }
 
 test "ES2015: template with carriage return" {

--- a/src/codegen/codegen_test/features.zig
+++ b/src/codegen/codegen_test/features.zig
@@ -126,7 +126,7 @@ test "Codegen: arrow single param" {
 test "Codegen: arrow block body" {
     var r = try e2e(std.testing.allocator, "const f = (a, b) => { return a + b; };");
     defer r.deinit();
-    try std.testing.expectEqualStrings("const f=(a,b)=>{return a + b;};", r.output);
+    try std.testing.expectEqualStrings("const f=(a,b)=>{return a+b;};", r.output);
 }
 
 test "Codegen: arrow rest param" {
@@ -641,7 +641,7 @@ test "Codegen: namespace export reference substitution" {
 test "Codegen: namespace export reference — multiple exports" {
     var r = try e2e(std.testing.allocator, "namespace ns { export let a = 1, b = 2; console.log(a + b); }");
     defer r.deinit();
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "console.log(ns.a + ns.b)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "console.log(ns.a+ns.b)") != null);
 }
 
 test "Codegen: namespace export reference — function" {

--- a/src/codegen/expressions.zig
+++ b/src/codegen/expressions.zig
@@ -54,18 +54,81 @@ pub fn emitBinary(self: anytype, node: Node) !void {
         }
     }
     try self.emitNode(node.data.binary.left);
-    if (op == .kw_in or op == .kw_instanceof or op == .plus or op == .minus) {
+    if (op == .kw_in or op == .kw_instanceof) {
+        // 영문 키워드 연산자는 양옆 공백 필수 (`a in b` ≠ `ainb`) — minify 와 무관.
+        try self.writeByte(' ');
+        try self.write(op.symbol());
         try self.writeByte(' ');
     } else {
+        const sym = op.symbol();
+        // `+`/`-` 도 minify 시엔 tight (`a+b`). 단 RHS 가 unary `+`/`-` 또는 prefix
+        // `++`/`--` 로 시작하면 `++`/`--` 로 토큰이 잘못 합쳐지므로(`a+ +b` → `a++b`)
+        // 그 경우에만 한 칸 삽입. 좌측은 합쳐질 일 없음 — postfix `a++` + `+b` 는
+        // `a+++b` 로 다시 lex 해도 `(a++)+b` 라 의미 동일.
         try self.writeSpace();
-    }
-    try self.write(op.symbol());
-    if (op == .kw_in or op == .kw_instanceof or op == .plus or op == .minus) {
-        try self.writeByte(' ');
-    } else {
-        try self.writeSpace();
+        try self.write(sym);
+        if (self.options.minify_whitespace and (op == .plus or op == .minus) and
+            rhsLeadingSignChar(self, node.data.binary.right) == sym[0])
+        {
+            try self.writeByte(' ');
+        } else {
+            try self.writeSpace();
+        }
     }
     try self.emitNode(node.data.binary.right);
+}
+
+/// unary_expression / update_expression 의 extra = [operand, flags]. flags 의 low byte 가
+/// 연산자 Kind. extra 범위 밖이면 null.
+fn unaryOpKind(self: anytype, extra_base: u32) ?Kind {
+    const extras = self.ast.extra_data.items;
+    if (extra_base + 1 >= extras.len) return null;
+    return @enumFromInt(@as(u8, @truncate(extras[extra_base + 1])));
+}
+
+/// binary `+`/`-` 의 RHS 가 출력 시 `+` 또는 `-` 로 시작하는지 — 시작하면 그 문자 반환,
+/// 아니면 null. minify 시 `++`/`--` 토큰 오결합 방지용. unary `+`/`-`, prefix `++`/`--`,
+/// 그리고 (상수 폴딩으로 생긴) 음수 numeric/bigint literal 만 해당. 더 높은 우선순위
+/// 이항식은 codegen 이 paren 없이 출력하므로 leftmost leaf 로 내려가 검사한다.
+fn rhsLeadingSignChar(self: anytype, idx: NodeIndex) ?u8 {
+    var cur = idx;
+    var depth: u8 = 0;
+    while (depth < 32) : (depth += 1) {
+        const n = self.ast.getNode(cur);
+        switch (n.tag) {
+            .unary_expression => return switch (unaryOpKind(self, n.data.extra) orelse return null) {
+                .plus => '+',
+                .minus => '-',
+                else => null, // !x, ~x, typeof/void/delete x → 다른 글자로 시작
+            },
+            .update_expression => {
+                const extras = self.ast.extra_data.items;
+                const e = n.data.extra;
+                if (e + 1 >= extras.len) return null;
+                if ((extras[e + 1] & ast_mod.UnaryFlags.postfix) != 0) {
+                    cur = @enumFromInt(extras[e]); // `x++` → operand 의 첫 글자로 시작 → 내려감
+                    continue;
+                }
+                return switch (@as(Kind, @enumFromInt(@as(u8, @truncate(extras[e + 1]))))) {
+                    .plus2 => '+',
+                    .minus2 => '-',
+                    else => null,
+                };
+            },
+            .numeric_literal, .bigint_literal => {
+                const text = self.ast.getText(n.span);
+                return if (text.len > 0 and text[0] == '-') '-' else null;
+            },
+            // 같은/낮은 우선순위 RHS 는 paren 으로 감싸져 `(` 로 시작 → 안전(null).
+            // 더 높은 우선순위(`a + b*c` 의 `b*c`)면 leftmost leaf 로 내려가 검사.
+            .binary_expression, .logical_expression => {
+                cur = n.data.binary.left;
+                continue;
+            },
+            else => return null,
+        }
+    }
+    return null;
 }
 
 pub fn emitAssignment(self: anytype, node: Node) !void {


### PR DESCRIPTION
## 무엇을

`--minify`(`minify_whitespace`) 출력에서 binary `+` / `-` 연산자 좌우 공백을 제거 — `a + b` → `a+b`. esbuild/SWC(rspack) 와 동일. Closes #3097.

기존엔 `*` `/` `%` `&&` 등은 tight 였는데 `+`/`-` 만 무조건 ` + ` 로 나왔다.

## 토큰 오결합 처리

`+`/`-` 다음 글자가 또 `+`/`-`(unary plus/minus) 또는 `++`/`--`(prefix update) 면 `++`/`--` 로 토큰이 잘못 합쳐진다:

| 의미 | 잘못된 출력 | 올바른 출력 |
|---|---|---|
| `a + (+b)` | `a++b` (= `(a++) b` → SyntaxError) | `a+ +b` |
| `a - (-b)` | `a--b` (= `(a--) b`) | `a- -b` |
| `a + (++b)` | `a+++b` (= `(a++)+b`) | `a+ ++b` |
| `a - (--b)` | `a---b` (= `(a--)-b`) | `a- --b` |

그래서 그 경우에만 한 칸 삽입한다. 부호가 다르면(`a + -b` → `a+-b`) `+-` 는 토큰이 안 합쳐지니 공백 불필요.

좌측은 신경 안 써도 됨 — postfix `a++` 뒤에 `+ b` 가 와서 `a+++b` 가 돼도 max-munch 로 `(a++) + b` 라 의미가 같다.

`a in b` / `a instanceof b` 의 공백은 (`ainb` 가 되면 안 되므로) 그대로 유지.

## 구현 (Zig 초보자용)

- `src/codegen/expressions.zig` `emitBinary` 의 `+`/`-` 분기를 분리. `op.symbol()` 을 `const sym` 으로 한 번만 꺼내 쓴다.
- 새 헬퍼 `rhsLeadingSignChar(self, idx) ?u8` — RHS 노드를 받아 그 출력이 `+`/`-` 로 시작하면 그 글자, 아니면 `null`. `unary_expression`(plus/minus), prefix `update_expression`(`++`/`--`), 그리고 상수 폴딩으로 생길 수 있는 음수 numeric/bigint literal 만 해당. 같은/낮은 우선순위 RHS 는 codegen 이 `(...)` 로 감싸 출력하므로 `(` 로 시작 → 안전. 더 높은 우선순위(`a + b*c` 의 `b*c`)면 leftmost leaf(`b`)까지 내려가 검사한다. 깊이 32 캡 (`function_class.zig` 등 다른 walker 와 동일 관습).
- `unaryOpKind` 작은 헬퍼로 `extra_data` 레이아웃(`[operand, flags]`, flags low byte = op Kind) decode 를 한 군데로.

## 테스트

- TDD — `src/codegen/codegen_test/basic.zig` 에 `#3097` 11개 추가: tight `+/-`, `*//` anti-regression, `+/-` × unary `+/-` 4조합, prefix `++`/`--`, postfix `a+++b == (a++)+b`, 더 높은 우선순위 RHS 의 leftmost(`a- -b*c`), non-minify 시 ` + ` 유지 anti-regression.
- 회귀: 기존 `expectEqualStrings` 가 buggy 한 ` + ` 출력을 박아둔 곳들(`basic.zig`, `features.zig`, `es_downlevel.zig` 의 template/arrow downlevel 테스트) 을 tight 로 갱신.
- `zig build test` 전체 통과. smoke (svelte / vue / react-dom / express / axios) 모두 baseline 과 출력 일치 (`MATCH`).

## 효과

#3097 본문대로 작지만 누적되는 항목. svelte-mount-min 한 파일 −26 B (svelte 런타임은 `+` 사용이 적음), 문자열 concat 많은 번들에선 비례해서 더 큼.

🤖 Generated with [Claude Code](https://claude.com/claude-code)