### PR TITLE
perf(codegen): minify_syntax 시 const → let 다운그레이드 (#3098)

### DIFF
--- a/src/codegen/bindings.zig
+++ b/src/codegen/bindings.zig
@@ -129,7 +129,10 @@ pub fn emitVariableDeclaration(self: anytype, node: Node) !void {
     const keyword = if (demote_to_var) "var " else switch (kind) {
         .@"var" => "var ",
         .let => "let ",
-        .@"const" => "const ",
+        // #3098: syntax minify 시 const → let. 런타임 의미 동일 (차이는 컴파일타임
+        // 재할당 에러뿐) → 올바른 프로그램엔 영향 없음. `using`/`await using` 은
+        // disposal 의미가 달라 제외.
+        .@"const" => if (self.options.minify_syntax) "let " else "const ",
         .using => "using ",
         .await_using => "await using ",
     };

--- a/src/codegen/codegen_test/basic.zig
+++ b/src/codegen/codegen_test/basic.zig
@@ -361,3 +361,40 @@ test "Codegen #3097: non-minify 는 ` + ` 공백 유지 (anti-regression)" {
     defer r.deinit();
     try std.testing.expectEqualStrings("var z = a + b;\n", r.output);
 }
+
+// ============================================================
+// #3098: const → let 다운그레이드 — minify_syntax 시 함수/블록 스코프 const 도
+//   3자 `let` 으로. `using` / `await using` 은 disposal 의미가 달라 그대로.
+// ============================================================
+
+test "Codegen #3098: minify_syntax 시 const → let" {
+    var r = try e2eWithOptions(std.testing.allocator, "{ const x = 1; }", .{ .minify_syntax = true });
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "let x = 1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "const") == null);
+}
+
+test "Codegen #3098: minify_syntax off → const 유지 (anti-regression)" {
+    var r = try e2eWithOptions(std.testing.allocator, "{ const x = 1; }", .{});
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "const x = 1") != null);
+}
+
+test "Codegen #3098: let / var 는 그대로 (anti-regression)" {
+    var r = try e2eWithOptions(std.testing.allocator, "{ let a = 1; var b = 2; }", .{ .minify_syntax = true });
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "let a = 1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var b = 2") != null);
+}
+
+test "Codegen #3098: for-of const → let" {
+    var r = try e2eWithOptions(std.testing.allocator, "for (const x of arr) console.log(x);", .{ .minify_syntax = true });
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "for (let x of arr)") != null);
+}
+
+test "Codegen #3098: using 은 const 로 안 바뀜 (그대로 using)" {
+    var r = try e2eWithOptions(std.testing.allocator, "{ using x = getResource(); }", .{ .minify_syntax = true });
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "using x = getResource()") != null);
+}

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -449,13 +449,14 @@ test "minify: comma operator mixed keeps non-literal" {
 // ================================================================
 
 test "minify_syntax: undefined → (void 0)" {
-    try expectMinifySyntax("const x = undefined;", "const x = (void 0);");
+    // #3098: minify_syntax 는 const → let 도 적용 → 출력은 `let`.
+    try expectMinifySyntax("const x = undefined;", "let x = (void 0);");
 }
 
 test "minify_syntax: undefined 비교" {
     try expectMinifySyntax(
         "const x = a === undefined;",
-        "const x = a === (void 0);",
+        "let x = a === (void 0);",
     );
 }
 
@@ -464,7 +465,7 @@ test "minify_syntax: undefined.x 치환 시 parens로 안전 유지" {
     // `(void 0)` 형태 유지로 member access가 정확히 `(void 0).x`가 된다.
     try expectMinifySyntax(
         "const x = undefined.foo;",
-        "const x = (void 0).foo;",
+        "let x = (void 0).foo;",
     );
 }
 


### PR DESCRIPTION
## 무엇을

`--minify` / `--minify-syntax` 출력에서 함수·블록 스코프 `const`(5자) 를 `let`(3자) 로 출력. Closes #3098.

`const` → `let` 은 **런타임 의미가 완전히 동일**합니다 — 유일한 차이는 "재할당 시 컴파일타임 에러"이고, 올바른(=const 를 재할당하지 않는) 프로그램에는 아무 영향이 없습니다. esbuild `--minify-syntax` / SWC 도 동일하게 합니다.

기존엔 top-level `const` 만 `downgradeToVar`(`#1630`)로 `var` 가 됐고, 함수·블록 안 `const` 는 그대로 5자였습니다. svelte-mount-min 한 파일에서 `const` 94회 → 0회.

## 안전성 (Zig 초보자용)

- `using` / `await using` 은 **제외** — disposal(`Symbol.dispose`) 의미가 `const`/`let` 과 다릅니다. `VariableDeclarationKind` switch 에서 `.using` / `.await_using` arm 은 건드리지 않습니다.
- cycle 모듈 top-level 의 `const`/`let` → `var` 강등(`demote_to_var`, 정의 전 참조 시 TDZ throw 대신 `undefined` fallback)은 switch 보다 앞에서 검사하므로 그대로 우선합니다.
- `for (const x of arr)` → `for (let x of arr)` — for-of/for-in 헤드는 `let`/`const` 둘 다 매 iteration 새 binding 이라 동일. 안전.
- codegen(파이프라인 마지막 단계)에서 하므로 이후 패스가 `const` 의 불변성에 의존할 일이 없음 — 가장 안전한 위치.

## 구현

- `src/codegen/bindings.zig` `emitVariableDeclaration` 의 키워드 선택: `.@"const" => if (self.options.minify_syntax) "let " else "const "`. 한 줄.
- bundle 모드 top-level 은 이미 `downgradeToVar` 로 `var` 가 되므로, 이 변경이 실제로 작용하는 건 nested block / for-of 헤드 / 단일 파일 transpile 의 `const` 입니다.

## 테스트

- TDD — `src/codegen/codegen_test/basic.zig` 에 `#3098` 5개: `const`→`let`, minify_syntax off 시 `const` 유지, `let`/`var` 불변, for-of `const`→`let`, `using` 불변.
- 회귀: `src/transformer/minify_test.zig` 의 `minify_syntax: undefined → (void 0)` 류 3개가 `const x = ...` 를 박아둬서 `let x = ...` 로 갱신.
- `zig build test` 전체 통과. smoke (svelte / vue / react / react-dom / three / preact) 모두 baseline 출력 일치 (`MATCH`). svelte-mount-min −188 B, svelte-full-min −218 B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)