### PR TITLE
perf(codegen): single-param arrow 괄호 제거 + bundle entry export brace 공백 (#3096)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1796,7 +1796,7 @@ pub fn emitModule(
     const final_exports = if (final_export_entries) |entries| blk: {
         if (options.format.isWrappedFormat()) {
             if (options.format != .iife or options.global_name != null) {
-                final_exports_buf = try emitWrappedEntryExports(allocator, entries);
+                final_exports_buf = try emitWrappedEntryExports(allocator, entries, options.minify_whitespace);
                 break :blk final_exports_buf;
             }
             // 래핑 포맷 (globalName 없음, IIFE): export는 syntax error이므로 제거
@@ -1815,7 +1815,7 @@ pub fn emitModule(
             };
             break :blk final_exports_buf;
         }
-        final_exports_buf = try emitEsmEntryExports(allocator, entries);
+        final_exports_buf = try emitEsmEntryExports(allocator, entries, options.minify_whitespace);
         break :blk final_exports_buf;
     } else raw_final_exports;
 

--- a/src/bundler/emitter/entry_exports.zig
+++ b/src/bundler/emitter/entry_exports.zig
@@ -37,26 +37,29 @@ pub fn emitOutputExportsConflictDiag(
 }
 
 /// Entry export struct를 ESM `export { ... }` 구문으로 출력.
+/// #3096: minify_whitespace 시 brace 안 공백 / 항목 사이 공백 / 후행 newline 제거
+/// (`export{a,b as c};`). chunks.zig 의 chunk export emit 과 동일 관습.
 pub fn emitEsmEntryExports(
     allocator: std.mem.Allocator,
     entries: []const FinalExportEntry,
+    minify_whitespace: bool,
 ) ![]const u8 {
     if (entries.len == 0) return try allocator.dupe(u8, "");
 
     var out: std.ArrayListUnmanaged(u8) = .empty;
     errdefer out.deinit(allocator);
 
-    try out.appendSlice(allocator, "export {");
+    try out.appendSlice(allocator, if (minify_whitespace) "export{" else "export {");
     for (entries, 0..) |e, i| {
         if (i > 0) try out.appendSlice(allocator, ",");
-        try out.append(allocator, ' ');
+        if (!minify_whitespace) try out.append(allocator, ' ');
         try out.appendSlice(allocator, e.local);
         if (!std.mem.eql(u8, e.local, e.exported)) {
             try out.appendSlice(allocator, " as ");
             try out.appendSlice(allocator, e.exported);
         }
     }
-    try out.appendSlice(allocator, " };\n");
+    try out.appendSlice(allocator, if (minify_whitespace) "};" else " };\n");
     return try out.toOwnedSlice(allocator);
 }
 
@@ -64,25 +67,26 @@ pub fn emitEsmEntryExports(
 pub fn emitWrappedEntryExports(
     allocator: std.mem.Allocator,
     entries: []const FinalExportEntry,
+    minify_whitespace: bool,
 ) ![]const u8 {
     if (entries.len == 0) return try allocator.dupe(u8, "");
 
     var out: std.ArrayListUnmanaged(u8) = .empty;
     errdefer out.deinit(allocator);
 
-    try out.appendSlice(allocator, "return {");
+    try out.appendSlice(allocator, if (minify_whitespace) "return{" else "return {");
     for (entries, 0..) |e, i| {
         if (i > 0) try out.appendSlice(allocator, ",");
-        try out.append(allocator, ' ');
+        if (!minify_whitespace) try out.append(allocator, ' ');
         if (!e.isDefault() and std.mem.eql(u8, e.local, e.exported)) {
             try out.appendSlice(allocator, e.local);
         } else {
             try out.appendSlice(allocator, e.exported);
-            try out.appendSlice(allocator, ": ");
+            try out.appendSlice(allocator, if (minify_whitespace) ":" else ": ");
             try out.appendSlice(allocator, e.local);
         }
     }
-    try out.appendSlice(allocator, " };\n");
+    try out.appendSlice(allocator, if (minify_whitespace) "};" else " };\n");
     return try out.toOwnedSlice(allocator);
 }
 
@@ -223,9 +227,19 @@ test "emitEsmEntryExports: emits export statement from typed entries" {
         FinalExportEntry{ .local = "b$1", .exported = "b" },
         FinalExportEntry{ .local = "x", .exported = "default" },
     };
-    const out = try emitEsmEntryExports(std.testing.allocator, entries);
+    const out = try emitEsmEntryExports(std.testing.allocator, entries, false);
     defer std.testing.allocator.free(out);
     try std.testing.expectEqualStrings("export { a, b$1 as b, x as default };\n", out);
+}
+
+test "emitEsmEntryExports: minify 시 공백/newline 제거 (#3096)" {
+    const entries = &.{
+        FinalExportEntry{ .local = "a", .exported = "a" },
+        FinalExportEntry{ .local = "b$1", .exported = "b" },
+    };
+    const out = try emitEsmEntryExports(std.testing.allocator, entries, true);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("export{a,b$1 as b};", out);
 }
 
 test "emitWrappedEntryExports: emits object return from typed entries" {
@@ -234,7 +248,17 @@ test "emitWrappedEntryExports: emits object return from typed entries" {
         FinalExportEntry{ .local = "b$1", .exported = "b" },
         FinalExportEntry{ .local = "x", .exported = "default" },
     };
-    const out = try emitWrappedEntryExports(std.testing.allocator, entries);
+    const out = try emitWrappedEntryExports(std.testing.allocator, entries, false);
     defer std.testing.allocator.free(out);
     try std.testing.expectEqualStrings("return { a, b: b$1, default: x };\n", out);
+}
+
+test "emitWrappedEntryExports: minify 시 공백/newline 제거 (#3096)" {
+    const entries = &.{
+        FinalExportEntry{ .local = "a", .exported = "a" },
+        FinalExportEntry{ .local = "b$1", .exported = "b" },
+    };
+    const out = try emitWrappedEntryExports(std.testing.allocator, entries, true);
+    defer std.testing.allocator.free(out);
+    try std.testing.expectEqualStrings("return{a,b:b$1};", out);
 }

--- a/src/codegen/codegen_test/basic.zig
+++ b/src/codegen/codegen_test/basic.zig
@@ -398,3 +398,64 @@ test "Codegen #3098: using 은 const 로 안 바뀜 (그대로 using)" {
     defer r.deinit();
     try std.testing.expect(std.mem.indexOf(u8, r.output, "using x = getResource()") != null);
 }
+
+// ============================================================
+// #3096: single-param arrow 의 불필요한 괄호 제거 — minify_whitespace 시
+//   `(x) => ...` → `x => ...`. 단일 plain identifier 파라미터일 때만
+//   (default / rest / destructuring / 0개 / 2개+ 는 괄호 유지).
+// ============================================================
+
+test "Codegen #3096: minify 시 single-param arrow 괄호 제거" {
+    var r = try e2e(std.testing.allocator, "var f = (x) => x;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var f=x=>x;", r.output);
+}
+
+test "Codegen #3096: 이미 괄호 없는 single-param 은 그대로 (anti-regression)" {
+    var r = try e2e(std.testing.allocator, "var f = x => x + 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var f=x=>x+1;", r.output);
+}
+
+test "Codegen #3096: 0개 파라미터는 () 유지" {
+    var r = try e2e(std.testing.allocator, "var f = () => 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var f=()=>1;", r.output);
+}
+
+test "Codegen #3096: 2개 이상 파라미터는 () 유지" {
+    var r = try e2e(std.testing.allocator, "var f = (a, b) => a;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var f=(a,b)=>a;", r.output);
+}
+
+test "Codegen #3096: rest 파라미터는 () 유지" {
+    var r = try e2e(std.testing.allocator, "var f = (...args) => args;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var f=(...args)=>args;", r.output);
+}
+
+test "Codegen #3096: default 파라미터는 () 유지" {
+    var r = try e2e(std.testing.allocator, "var f = (x = 1) => x;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var f=(x=1)=>x;", r.output);
+}
+
+test "Codegen #3096: destructuring 파라미터는 () 유지" {
+    var r = try e2e(std.testing.allocator, "var f = ({ x }) => x;");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "f=({") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "})=>x") != null);
+}
+
+test "Codegen #3096: async single-param 은 괄호 제거하되 async 공백 유지" {
+    var r = try e2e(std.testing.allocator, "var f = async (x) => x;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var f=async x=>x;", r.output);
+}
+
+test "Codegen #3096: non-minify 는 (x) 유지 (anti-regression)" {
+    var r = try e2eWithOptions(std.testing.allocator, "var f = (x) => x;", .{});
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var f = (x) => x;\n", r.output);
+}

--- a/src/codegen/codegen_test/features.zig
+++ b/src/codegen/codegen_test/features.zig
@@ -117,10 +117,10 @@ test "Codegen: arrow no params" {
 }
 
 test "Codegen: arrow single param" {
-    // esbuild 호환: 단일 파라미터도 항상 괄호로 감싸기
+    // #3096: minify 시 단일 plain identifier 파라미터는 괄호 생략 (esbuild/SWC 동일)
     var r = try e2e(std.testing.allocator, "const f = x => x;");
     defer r.deinit();
-    try std.testing.expectEqualStrings("const f=(x)=>x;", r.output);
+    try std.testing.expectEqualStrings("const f=x=>x;", r.output);
 }
 
 test "Codegen: arrow block body" {

--- a/src/codegen/function_class.zig
+++ b/src/codegen/function_class.zig
@@ -156,12 +156,15 @@ pub fn emitArrow(self: anytype, node: Node) !void {
     if (flags & ast_mod.ArrowFlags.is_async != 0) try self.write("async ");
 
     // params 출력 — #1283 이후 항상 formal_parameters 노드. 괄호는 codegen이 부착.
-    if (!params.isNone()) {
+    // #3096: minify 시 단일 plain identifier 파라미터는 괄호 생략 (`x => ...`).
+    if (params.isNone()) {
+        try self.write("()");
+    } else if (self.options.minify_whitespace and arrowParamsOmittable(self, params)) {
+        try self.emitNode(params);
+    } else {
         try self.writeByte('(');
         try self.emitNode(params);
         try self.writeByte(')');
-    } else {
-        try self.write("()");
     }
     try self.writeSpace();
     try self.write("=>");
@@ -177,6 +180,30 @@ pub fn emitArrow(self: anytype, node: Node) !void {
     if (needs_paren) try self.writeByte('(');
     try self.emitNode(body);
     if (needs_paren) try self.writeByte(')');
+}
+
+/// 파라미터 노드가 단순 식별자 1개(이름만 출력) 인지 — `binding_identifier` 또는
+/// 파서 cover-grammar 변환 산물인 `assignment_target_identifier`. destructuring / rest /
+/// default 패턴은 여기 해당 안 함.
+fn isPlainIdentifierParam(tag: ast_mod.Node.Tag) bool {
+    return tag == .binding_identifier or tag == .assignment_target_identifier;
+}
+
+/// arrow 파라미터를 괄호 없이 출력해도 되는지 — 정확히 1개의 plain identifier 파라미터
+/// (default / rest / destructuring 없음)일 때만. `emitFormalParam` / 식별자 emit 이 그
+/// 경우 이름만 출력하므로 `x => ...` 가 valid arrow 가 된다.
+fn arrowParamsOmittable(self: anytype, params_idx: NodeIndex) bool {
+    const pnode = self.ast.getNode(params_idx);
+    if (pnode.tag != .formal_parameters) return false;
+    const list = pnode.data.list;
+    if (list.len != 1 or list.start >= self.ast.extra_data.items.len) return false;
+    const elem = self.ast.getNode(@enumFromInt(self.ast.extra_data.items[list.start]));
+    if (isPlainIdentifierParam(elem.tag)) return true;
+    if (elem.tag != .formal_parameter) return false;
+    const FP = ast_mod.FormalParameterExtra;
+    if (!self.ast.hasExtra(elem.data.extra, FP.default)) return false;
+    if (!self.ast.readExtraNode(elem.data.extra, FP.default).isNone()) return false; // (x = 1) => — 괄호 필수
+    return isPlainIdentifierParam(self.ast.getNode(self.ast.readExtraNode(elem.data.extra, FP.pattern)).tag);
 }
 
 fn expressionStartsWithBrace(self: anytype, node_idx: ast_mod.NodeIndex) bool {


### PR DESCRIPTION
## 무엇을

`--minify`(minify_whitespace) 출력에서:

1. **단일 plain identifier 파라미터 arrow 의 괄호 생략** — `(x) => x` → `x => x`, `async (x) => x` → `async x => x`. `default`(`(x=1)=>`) / rest(`(...a)=>`) / destructuring(`({x})=>`) / 0개(`()=>`) / 2개+ 파라미터는 괄호 유지. esbuild/SWC 동일.
2. **bundle 모드 entry export brace 공백 제거** — `export { a, b as c };\n` → `export{a,b as c};`, wrapped(IIFE/UMD) factory 반환값 `return { a, b: x };\n` → `return{a,b:x};`. 코드-스플릿 청크 export(`chunks.zig`)는 이미 이렇게 하고 있어 동일 관습으로 맞춤.

`import { x } from "..."` 와 단일 파일 transpile 의 `export { x }`(codegen `emitExportNamed`)는 이미 tight 라 변경 없음.

Closes #3096.

## 구현 (Zig 초보자용)

- `src/codegen/function_class.zig` `emitArrow` — params 출력 시 `arrowParamsOmittable(self, params)` 가 true 면 `(` `)` 없이 `emitNode(params)` 만. 헬퍼는 `formal_parameters` 노드의 list 가 정확히 1개이고 그 element 가 plain identifier(`binding_identifier` 또는 파서 cover-grammar 변환 산물 `assignment_target_identifier`)이거나, `formal_parameter` wrapper 안의 pattern 이 그것이고 default 가 없을 때만 true. `FormalParameterExtra` 상수로 extra 슬롯 접근.
- `src/bundler/emitter/entry_exports.zig` — `emitEsmEntryExports` / `emitWrappedEntryExports` 에 `minify_whitespace: bool` 인자 추가, brace 안 공백·항목 사이 공백·후행 newline 을 조건부로. 호출부(`emitter.zig`)에서 `options.minify_whitespace` 전달.

## 테스트

- TDD — `src/codegen/codegen_test/basic.zig` 에 `#3096` 9개: 괄호 제거 / 괄호 없는 single-param 그대로 / 0개·2개+·rest·default·destructuring 는 괄호 유지 / async / non-minify 시 `(x)` 유지.
- `src/bundler/emitter/entry_exports.zig` 에 minify 케이스 unit test 2개 추가, 기존 2개는 새 인자(`false`) 반영.
- 회귀: `src/codegen/codegen_test/features.zig` 의 "arrow single param" 이 `const f=(x)=>x;` 를 박아둬서 `const f=x=>x;` 로 갱신.
- `zig build test` 전체 통과. smoke (svelte / vue / react / react-dom / preact / solid-js) 모두 baseline 출력 일치 (`MATCH`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)