### PR TITLE
fix(semantic,bundler): synthetic 이름이 string_table 슬라이스로 dangling — RN 번들에 0xaa garbage

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -195,7 +195,7 @@ pub fn extractImportBindings(
             const spec_node = ast.getNode(spec);
             switch (spec_node.tag) {
                 .import_default_specifier => {
-                    const name = ast.getText(spec_node.span);
+                    const name = try ast.getTextStable(allocator, spec_node.span);
                     try bindings.append(allocator, .{
                         .kind = .default,
                         .local_name = name,
@@ -205,7 +205,7 @@ pub fn extractImportBindings(
                     });
                 },
                 .import_namespace_specifier => {
-                    const name = ast.getText(spec_node.span);
+                    const name = try ast.getTextStable(allocator, spec_node.span);
                     try bindings.append(allocator, .{
                         .kind = .namespace,
                         .local_name = name,
@@ -223,14 +223,14 @@ pub fn extractImportBindings(
                     if (imported_idx.isNone()) continue;
 
                     const imported_node = ast.getNode(imported_idx);
-                    const imported_name = ast.getText(imported_node.span);
+                    const imported_name = try ast.getTextStable(allocator, imported_node.span);
 
                     const local_node_idx = if (!local_idx.isNone() and @intFromEnum(local_idx) != @intFromEnum(imported_idx))
                         local_idx
                     else
                         imported_idx;
                     const local_node = ast.getNode(local_node_idx);
-                    const local_name = ast.getText(local_node.span);
+                    const local_name = try ast.getTextStable(allocator, local_node.span);
 
                     const is_helper = if (helper_ref_nodes) |refs|
                         std.sort.binarySearch(u32, refs, @intFromEnum(local_node_idx), struct {

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1493,6 +1493,17 @@ pub const Ast = struct {
         return self.source[span.start..span.end];
     }
 
+    /// `getText` 와 같지만, span 이 `string_table` 을 가리키면 (transformer 가 `addString`
+    /// 으로 만든 synthetic 이름 — runtime helper / JSX runtime import 등) `allocator` 로
+    /// owned 복사를 반환한다. `string_table` 은 후속 transform/link 단계에서 reallocate/free
+    /// 될 수 있어, raw 슬라이스를 parse 이후까지 들고 가면 dangling → 출력에 `0xaa` 등
+    /// garbage 가 섞인다 (#3100). source span 은 `source` 가 안 움직이므로 그대로 반환.
+    pub fn getTextStable(self: *const Ast, allocator: std.mem.Allocator, span: Span) ![]const u8 {
+        const text = self.getText(span);
+        if (span.start & STRING_TABLE_BIT != 0) return allocator.dupe(u8, text);
+        return text;
+    }
+
     /// object_property 노드에서 value 위치 노드를 반환한다.
     /// shorthand `{ x }` 는 right 가 none → key (left) 가 곧 value.
     /// 그 외 explicit `{ k: v }` 는 right 가 value.

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -554,7 +554,10 @@ pub const SemanticAnalyzer = struct {
     }
 
     fn declareSymbolWithNode(self: *SemanticAnalyzer, name_span: Span, kind: SymbolKind, decl_span: Span, node_idx: ?u32) AllocError!void {
-        const name_text = self.ast.getText(name_span);
+        const is_synthetic_name = name_span.start & ast_mod.Ast.STRING_TABLE_BIT != 0;
+        // transformer 가 `addString` 으로 만든 이름(string_table span)은 owned 복사 — symbol
+        // `synthetic_name` / scope_map 키로 raw 슬라이스를 들고 가면 dangling (#3100).
+        const name_text = try self.ast.getTextStable(self.allocator, name_span);
 
         // function-like 선언의 스코핑 규칙:
         // - var scope(global/function/module) 안에서 직접 선언: var scope에 등록 (호이스팅)
@@ -659,7 +662,7 @@ pub const SemanticAnalyzer = struct {
             .decl_flags = decl_flags,
             .declaration_span = decl_span,
             .origin_scope = self.current_scope,
-            .synthetic_name = if (name_span.start & ast_mod.Ast.STRING_TABLE_BIT != 0) name_text else "",
+            .synthetic_name = if (is_synthetic_name) name_text else "",
         });
 
         // symbol_ids에 선언 노드 기록
@@ -3062,7 +3065,11 @@ pub const SemanticAnalyzer = struct {
         decl_span: Span,
         node_idx: u32,
     ) AllocError!void {
-        const name_text = self.ast.getText(name_span);
+        // helper import 의 이름은 transformer 가 `addString` 으로 만든 string_table span
+        // — owned 복사를 써야 symbol synthetic_name + helper_scope_map/scope_map 키가
+        // dangling 되지 않는다 (#3100).
+        const is_synthetic_name = name_span.start & ast_mod.Ast.STRING_TABLE_BIT != 0;
+        const name_text = try self.ast.getTextStable(self.allocator, name_span);
         const target_scope = self.findVarScope();
 
         const sym_index = self.symbols.items.len;
@@ -3073,7 +3080,7 @@ pub const SemanticAnalyzer = struct {
             .decl_flags = SymbolKind.import_binding.declFlags(),
             .declaration_span = decl_span,
             .origin_scope = self.current_scope,
-            .synthetic_name = if (name_span.start & ast_mod.Ast.STRING_TABLE_BIT != 0) name_text else "",
+            .synthetic_name = if (is_synthetic_name) name_text else "",
         });
 
         if (node_idx < self.symbol_ids.items.len) {


### PR DESCRIPTION
## 증상 (#3100)

`zntc --bundle --platform=react-native` 출력에 uninitialized `0xaa` 바이트가 섞여 `hermesc` 가 거부:

```
out.js:337:238: error: Invalid UTF-8 lead byte 0xaa
var Systrace$1, deepFreezeAndThrowOnMutationInDev$1, ..., DEBUG_INFO_LIMIT, MessageQueue, ████████████████;
```

`tests/integration` 의 RN hermesc 검증 3건 (`hermes-runtime.test.ts` 의 hermesc 검증 + `es5-rn.test.ts` 의 hbc/Node 실행 검증 2건) baseline fail.

## 근본 원인 (디버그로 확정)

`SemanticAnalyzer` 가 symbol 의 `synthetic_name` (그리고 `scope_maps[var_scope]` / `helper_scope_map` 의 **키**) 를 AST `string_table.items` ArrayList 로의 **raw 슬라이스**로 저장했다.

`string_table` 은 parse 이후 transform/link 단계에서 reallocate/free 될 수 있다 (특히 linker 의 mangler 가 `Systrace$1` 같은 deconflict 이름을 추가하면서). 그러면 그 raw 슬라이스는 dangling → emit 시점에 freed/poisoned 메모리 (`0xaa` = Zig debug-undefined fill) 를 읽는다.

이 경로 (`addString` → `STRING_TABLE_BIT` set 된 span) 를 타는 건 **transformer 가 주입하는 이름** — ES5 downlevel 시 class 가 있으면 주입하는 `import { __classCallCheck } from " zntc:runtime/class-call-check"` 같은 runtime-helper import. RN core 의 `MessageQueue.js` (`class MessageQueue`) + `--platform=react-native` (ES5 downlevel) 에서 발현했다.

디버그: `MessageQueue.js` 의 hoisted-var 리스트 마지막 항목이 `local_span = 0x80000005..0x80000015` (string_table 바이트 [5..21]), prepass 시점엔 `"__classCallCheck"` 였다가 emit 시점엔 `0xaa×16`. → `string_table` 버퍼가 그 사이에 reallocate/free 됨.

## 수정

- **`Ast.getTextStable(allocator, span)`** (`src/parser/ast.zig`) — `getText` 와 같지만 span 이 string_table 을 가리키면 `allocator` 로 owned 복사 반환. source span 은 `source` 가 재할당 안 되므로 그대로 반환.
- **`analyzer.zig`** `declareSymbolWithNode` / `declareHelperImportSpec` — synthetic 이름을 `getTextStable` 로 owned 화. `synthetic_name` + scope_map / helper_scope_map 키가 이제 module parse arena 소유 (= `module.semantic` 와 같은 수명) → dangling 없음. (`Symbol` doc 의 "`synthetic_name` ... ArrayList 수명과 일치" 보장을 실제로 만족.)
- **`binding_scanner.zig`** `extractImportBindings` — `ImportBinding.local_name` / `imported_name` 도 동일하게 `getTextStable`. `importBindingLocalName` 의 `is_helper` fallback 경로 (`refName` 이 null 인 user-collision 케이스) 방어.

source-span 이름 (사용자가 직접 쓴 식별자) 은 복사하지 않음 — `source` 버퍼는 절대 재할당되지 않으므로 raw 슬라이스 안전. 복사는 transformer-injected 이름 (모듈당 한 줌) 에만 — 무시 가능한 비용.

## Zig 초보자용 메모

- `[]const u8` 은 "포인터 + 길이" 슬라이스 — 어떤 버퍼를 *가리킬* 뿐 소유하지 않는다. 그 버퍼가 `ArrayList` 인데 grow 하면 새 버퍼를 alloc 하고 복사한 뒤 옛 버퍼를 free — 그러면 옛 버퍼를 가리키던 슬라이스는 dangling. debug 빌드는 free 된 메모리를 `0xaa` 로 채워서(poison) 버그를 눈에 띄게 한다.
- `allocator.dupe(u8, slice)` 는 그 내용을 `allocator` 가 소유하는 새 메모리에 복사한 슬라이스를 반환 — module parse arena 처럼 충분히 오래 사는 allocator 로 복사하면 dangling 회피.

## 테스트

- `tests/integration`: **3714 pass / 0 fail** (이전 3710/4 — 본 PR 이 RN hermesc 3건 fix, #3099 가 watch-stress 1건 fix)
- e2e: **150 pass / 0 fail**
- `zig build test` ✅ (4800+ tests, 0 leaks), type-check / lint / fmt / `zig fmt --check src/` ✅
- 수동: `zntc --bundle <rn-app> --platform=react-native --rn-platform=ios --flow` → `hermesc -emit-binary` 0 errors 확인

Closes #3100

🤖 Generated with [Claude Code](https://claude.com/claude-code)