### PR TITLE
perf(codegen): minify 시 single-statement block 의 불필요한 `{}` 제거 (#3094)

### DIFF
--- a/src/codegen/codegen_test/basic.zig
+++ b/src/codegen/codegen_test/basic.zig
@@ -459,3 +459,106 @@ test "Codegen #3096: non-minify 는 (x) 유지 (anti-regression)" {
     defer r.deinit();
     try std.testing.expectEqualStrings("var f = (x) => x;\n", r.output);
 }
+
+// ============================================================
+// #3094: single-statement block 의 불필요한 `{}` 제거 — minify_whitespace 시
+//   `if(x){f()}` → `if(x)f()`. 본문이 출력되는 statement 1개뿐이고 그게
+//   expression/return/throw/break/continue/debugger/var 일 때만 (let/const/class/
+//   function 선언 · if/for/while 류 · 빈 block · 2개+ 는 `{}` 유지).
+// ============================================================
+
+test "Codegen #3094: if 본문 단일 statement → {} 제거" {
+    var r = try e2e(std.testing.allocator, "if (a) { f(); }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("if(a)f();", r.output);
+}
+
+test "Codegen #3094: if/else 양쪽 단일 statement → {} 제거" {
+    var r = try e2e(std.testing.allocator, "if (a) { f(); } else { g(); }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("if(a)f();else g();", r.output);
+}
+
+test "Codegen #3094: if/else return → return c;else return d;" {
+    var r = try e2e(std.testing.allocator, "function h(){ if (a) { return 1; } else { return 2; } }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){if(a)return 1;else return 2;}", r.output);
+}
+
+test "Codegen #3094: var 선언은 본문으로 valid → {} 제거" {
+    var r = try e2e(std.testing.allocator, "if (a) { var x = 1; }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("if(a)var x=1;", r.output);
+}
+
+test "Codegen #3094: let 선언은 {} 유지 (lexical decl)" {
+    var r = try e2e(std.testing.allocator, "if (a) { let x = 1; }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("if(a){let x=1;}", r.output);
+}
+
+test "Codegen #3094: class 선언은 {} 유지" {
+    var r = try e2e(std.testing.allocator, "if (a) { class C {} }");
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "if(a){class C") != null);
+}
+
+test "Codegen #3094: for 본문 단일 statement → {} 제거" {
+    var r = try e2e(std.testing.allocator, "for (;;) { f(); }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("for(;;)f();", r.output);
+}
+
+test "Codegen #3094: for-of 본문 → {} 제거" {
+    var r = try e2e(std.testing.allocator, "for (const x of arr) { g(x); }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("for(const x of arr)g(x);", r.output);
+}
+
+test "Codegen #3094: while 본문 → {} 제거" {
+    var r = try e2e(std.testing.allocator, "while (c) { f(); }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("while(c)f();", r.output);
+}
+
+test "Codegen #3094: 2개 이상 statement 는 {} 유지" {
+    var r = try e2e(std.testing.allocator, "if (a) { f(); g(); }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("if(a){f();g();}", r.output);
+}
+
+test "Codegen #3094: 본문이 if statement 면 {} 유지 (dangling-else 회피, 보수적)" {
+    var r = try e2e(std.testing.allocator, "if (a) { if (b) c(); } else d();");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("if(a){if(b)c();}else d();", r.output);
+}
+
+test "Codegen #3094: 빈 block 은 {} 유지" {
+    var r = try e2e(std.testing.allocator, "if (a) {}");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("if(a){}", r.output);
+}
+
+test "Codegen #3094: throw 본문 → {} 제거" {
+    var r = try e2e(std.testing.allocator, "if (a) { throw e; }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("if(a)throw e;", r.output);
+}
+
+test "Codegen #3094: 중첩 — for 안 if 안 expr" {
+    var r = try e2e(std.testing.allocator, "for (const x of arr) { if (x) { use(x); } }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("for(const x of arr){if(x)use(x);}", r.output);
+}
+
+test "Codegen #3094: non-minify 는 {} 유지 (anti-regression)" {
+    var r = try e2eWithOptions(std.testing.allocator, "if (a) { f(); }", .{});
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "{") != null);
+}
+
+test "Codegen #3094: break/continue 본문 → {} 제거" {
+    var r = try e2e(std.testing.allocator, "for (;;) { if (a) { break; } else { continue; } }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("for(;;){if(a)break;else continue;}", r.output);
+}

--- a/src/codegen/statements.zig
+++ b/src/codegen/statements.zig
@@ -79,6 +79,63 @@ pub fn emitBlock(self: anytype, node: Node) !void {
     try emitBracedList(self, node);
 }
 
+/// `if`/`else`/`for`/`while`/`for-in`/`for-of` 의 본문을 emit. minify 시 본문이
+/// "벗겨도 안전한" statement 하나뿐인 block 이면 `{}` 를 제거하고 그 statement 만 출력
+/// (`if(x){f()}` → `if(x)f()`). 그 외에는 본문 노드를 그대로 emit.
+pub fn emitStatementBody(self: anytype, body_idx: NodeIndex) !void {
+    if (unwrappedStatementBody(self, body_idx)) |inner| {
+        try self.emitNode(inner);
+        return;
+    }
+    try self.emitNode(body_idx);
+}
+
+/// `body_idx` 가 minify 시 `{}` 를 벗길 수 있는 block 이면 그 안의 단일 statement idx,
+/// 아니면 null. `else` 키워드 spacing 결정에도 쓰여 별도 함수로 둔다.
+fn unwrappedStatementBody(self: anytype, body_idx: NodeIndex) ?NodeIndex {
+    if (!self.options.minify_whitespace or body_idx.isNone()) return null;
+    const body = self.ast.getNode(body_idx);
+    if (body.tag != .block_statement) return null;
+    return singleUnwrappableStmt(self, body);
+}
+
+/// block 에서 "출력되는" statement 가 정확히 1개이고, 그게 `{}` 없이 단독으로 와도
+/// 안전한 종류면 그 statement 의 idx 를 반환. 아니면 null.
+///
+/// **안전 조건**: lexical declaration(`let`/`const`/`class`/`function` 선언) 은 `if`/`for`
+/// 본문으로 올 수 없으므로 거부. `if`/`for`/`while` 류는 뒤따르는 `else` 를 잘못 흡수
+/// (dangling else)하거나 ASI 가 미묘해 보수적으로 거부. `var` 선언은 본문으로 valid 하고
+/// hoisting 의미도 동일하므로 허용. `return`/`throw`/`break`/`continue`/`debugger`/
+/// expression statement 는 `else` 흡수 불가 + lexical decl 아님 → 안전.
+fn singleUnwrappableStmt(self: anytype, block: Node) ?NodeIndex {
+    const list = block.data.list;
+    const indices = self.ast.extra_data.items[list.start .. list.start + list.len];
+    var only: ?NodeIndex = null;
+    for (indices) |raw| {
+        const idx: NodeIndex = @enumFromInt(raw);
+        if (isElidedStmt(self, idx)) continue;
+        if (only != null) return null; // 출력되는 statement 가 2개+ → 못 벗김
+        only = idx;
+    }
+    const stmt_idx = only orelse return null; // 빈 block — `{}` 그대로 (보수적)
+    const s = self.ast.getNode(stmt_idx);
+    switch (s.tag) {
+        .expression_statement,
+        .return_statement,
+        .throw_statement,
+        .break_statement,
+        .continue_statement,
+        .debugger_statement,
+        => return stmt_idx,
+        // `var` 는 본문으로 valid + hoisting 동일 → 허용. 단 `esm_var_assign_only`
+        // (wrapped ESM body) 에선 top-level `var` 키워드가 codegen 에서 제거되는데,
+        // hoist scan 은 block 안 `var` 를 안 잡으므로 벗기면 미선언 할당 → 거부.
+        .variable_declaration => return if (!self.options.esm_var_assign_only and
+            self.ast.variableDeclarationKind(s) == .@"var") stmt_idx else null,
+        else => return null,
+    }
+}
+
 /// { item1 item2 ... } — 블록과 클래스 바디 공통.
 /// `{` 앞 공백: 마지막 바이트가 공백/줄바꿈이 아니면 자동 추가 (이중 공백 방지).
 pub fn emitBracedList(self: anytype, node: Node) !void {
@@ -190,23 +247,22 @@ fn emitIfVerbatim(self: anytype, t: anytype) !void {
     if (self.options.minify_whitespace) try self.write("if(") else try self.write("if (");
     try self.emitNode(t.a);
     try self.writeByte(')');
-    try self.emitNode(t.b);
+    try emitStatementBody(self, t.b);
     if (!t.c.isNone()) {
         // else 분기가 DCE 결과 비어 있으면 else 키워드 자체를 생략 (#2967).
         // 변환 전 transformer 가 dead `if` 본문을 `empty_statement` 로 바꿨거나
         // 빈 block 으로 만들면 minify 시 statement 가 사라져 `else }` SyntaxError.
         if (isElidedAlternate(self, t.c)) return;
         if (self.options.minify_whitespace) {
-            const next_node = self.ast.getNode(t.c);
-            if (next_node.tag == .block_statement) {
-                try self.write("else");
-            } else {
-                try self.write("else ");
-            }
+            // else 분기가 `{...}` 로 출력되면 `else{`, 아니면(bare statement 또는
+            // #3094 로 `{}` 가 벗겨지는 block) 키워드 뒤 공백 필수.
+            const emits_braces = self.ast.getNode(t.c).tag == .block_statement and
+                unwrappedStatementBody(self, t.c) == null;
+            try self.write(if (emits_braces) "else" else "else ");
         } else {
             try self.write(" else ");
         }
-        try self.emitNode(t.c);
+        try emitStatementBody(self, t.c);
     }
 }
 
@@ -364,7 +420,7 @@ pub fn emitWhile(self: anytype, node: Node) !void {
     if (self.options.minify_whitespace) try self.write("while(") else try self.write("while (");
     try self.emitNode(node.data.binary.left);
     try self.writeByte(')');
-    try self.emitNode(node.data.binary.right);
+    try emitStatementBody(self, node.data.binary.right);
 }
 
 pub fn emitDoWhile(self: anytype, node: Node) !void {
@@ -396,7 +452,7 @@ pub fn emitFor(self: anytype, node: Node) !void {
     if (self.options.minify_whitespace) try self.writeByte(';') else try self.write("; ");
     try self.emitNode(@enumFromInt(extras[2]));
     try self.writeByte(')');
-    try self.emitNode(@enumFromInt(extras[3]));
+    try emitStatementBody(self, @enumFromInt(extras[3]));
 }
 
 pub fn emitForAwaitOf(self: anytype, node: Node) !void {
@@ -420,7 +476,7 @@ pub fn emitForAwaitOf(self: anytype, node: Node) !void {
     try self.write(" of ");
     try self.emitNode(t.b);
     try self.writeByte(')');
-    try self.emitNode(t.c);
+    try emitStatementBody(self, t.c);
 }
 
 pub fn emitForInOf(self: anytype, node: Node, keyword: []const u8) !void {
@@ -449,7 +505,7 @@ pub fn emitForInOf(self: anytype, node: Node, keyword: []const u8) !void {
     try self.writeByte(' ');
     try self.emitNode(t.b);
     try self.writeByte(')');
-    try self.emitNode(t.c);
+    try emitStatementBody(self, t.c);
 }
 
 /// for-in var initializer가 있으면 `name = init;`를 hoisting 출력.


### PR DESCRIPTION
## 무엇을

`--minify`(minify_whitespace) 출력에서 `if`/`else`/`for`/`while`/`for-in`/`for-of`/`for-await` 의 본문이 "출력되는 statement 1개뿐인 block" 이면 `{}` 를 벗긴다:

- `if(x){f()}` → `if(x)f()`
- `if(a){return 1}else{return 2}` → `if(a)return 1;else return 2`
- `for(;;){f()}` → `for(;;)f()`, `while(c){f()}` → `while(c)f()`

esbuild/SWC 동일. Closes #3094.

## 안전 조건 (보수적, Zig 초보자용)

`{}` 를 벗기는 건 본문의 단일 statement 가 다음일 때만:
**expression statement / `return` / `throw` / `break` / `continue` / `debugger` / `var` 선언**

거부하는 경우:
- **lexical declaration** (`let`/`const`/`class`/`function` 선언) — `if(a)let x=1;` 은 syntax error (block 필요) → `{}` 유지
- **`if`/`for`/`while` 류** — `if(a){if(b)c()}else d()` 에서 안쪽 `{}` 를 벗기면 `else` 가 안쪽 `if` 에 잘못 binding (dangling else). 보수적으로 거부 → `if(a){if(b)c();}else d();`. ASI 가 미묘한 경우도 회피.
- **`var` + `esm_var_assign_only`** — wrapped ESM body 에서 top-level `var` 는 codegen 이 키워드를 제거(`x=1;`)하는데, hoist scan 이 block 안 `var` 까지 안 잡으므로 그 경우만 `var` 도 거부 (미선언 할당 방지). 일반 `var` 는 허용 (본문으로 valid + hoisting 의미 동일).
- **빈 block** / **2개+ statement** → `{}` 유지

`else` 키워드 spacing: else 분기가 `{...}` 로 출력되면 `else{`, bare statement 거나 `{}` 가 벗겨지는 block 이면 `else ` (`elsereturn` 방지).

`do-while` / `with` / labeled statement / `if(true)`-DCE-분기 는 이번 범위 밖 (각각 미묘한 grammar/ASI 가 있어 보수적으로 후순위).

## 구현

`src/codegen/statements.zig`:
- `emitStatementBody(self, body_idx)` — 본문 emit. `unwrappedStatementBody` 가 벗길 수 있다고 하면 안쪽 statement 만 emit, 아니면 그대로.
- `unwrappedStatementBody` / `singleUnwrappableStmt` — 위 안전 조건 판정.
- `emitIfVerbatim` / `emitWhile` / `emitFor` / `emitForAwaitOf` / `emitForInOf` 의 본문 emit 을 `emitStatementBody` 경유로 변경. `emitIfVerbatim` 은 `else` 키워드 spacing 도 조정.

## 테스트

- TDD — `src/codegen/codegen_test/basic.zig` 에 `#3094` 16개: if 본문 / if-else 양쪽 / function 안 if-else-return / `var`(벗김) vs `let`·`class`(유지) / for·for-of·while / 2개+(유지) / 본문이 if(유지, dangling-else) / 빈 block(유지) / throw / break·continue / 중첩 / non-minify 시 `{}` 유지.
- `zig build test` 전체 통과. smoke (svelte / vue / react-dom / three / axios / express) 모두 baseline 출력 일치 (`MATCH`). tricky 케이스(if-else-return, dangling-else, for/while 본문, 빈 block) node 실행으로 원본과 동일 출력 확인. svelte-mount-min −215 B, svelte-full-min −235 B (ratio 1.25x → 1.23x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)