### PR TITLE
perf(codegen): minify_syntax 시 if-else-return → return ternary (#3095)

### DIFF
--- a/src/codegen/codegen_test/basic.zig
+++ b/src/codegen/codegen_test/basic.zig
@@ -562,3 +562,77 @@ test "Codegen #3094: break/continue 본문 → {} 제거" {
     defer r.deinit();
     try std.testing.expectEqualStrings("for(;;){if(a)break;else continue;}", r.output);
 }
+
+// ============================================================
+// #3095: if/return 평탄화 — minify_syntax 시 `if(c){return A}else{return B}` →
+//   `return c?A:B;`. c 가 paren 없이 ?: test 자리에 올 수 있고 A/B 가 sequence
+//   (comma) 가 아닐 때만. else-if 체인은 미지원 (else 분기가 다시 변환됨).
+// ============================================================
+
+fn e2eMinAll(allocator: std.mem.Allocator, source: []const u8) !helpers.TestResult {
+    return e2eWithOptions(allocator, source, .{ .minify_whitespace = true, .minify_syntax = true });
+}
+
+test "Codegen #3095: if/else return block → return c?A:B" {
+    var r = try e2eMinAll(std.testing.allocator, "function h(){ if (c) { return 1; } else { return 2; } }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){return c?1:2}", r.output);
+}
+
+test "Codegen #3095: bare return 양쪽도 → return c?A:B" {
+    var r = try e2eMinAll(std.testing.allocator, "function h(){ if (c) return a; else return b; }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){return c?a:b}", r.output);
+}
+
+test "Codegen #3095: member / logical cond 안전" {
+    var r = try e2eMinAll(std.testing.allocator, "function h(){ if (x.y && z) return a; else return b; }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){return x.y&&z?a:b}", r.output);
+}
+
+test "Codegen #3095: assignment cond 는 변환 안 함 (paren 필요)" {
+    var r = try e2eMinAll(std.testing.allocator, "function h(){ if (a = b) return x; else return y; }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){if(a=b)return x;else return y}", r.output);
+}
+
+test "Codegen #3095: 한쪽이 return 아니면 변환 안 함" {
+    var r = try e2eMinAll(std.testing.allocator, "function h(){ if (c) { return 1; } else { f(); } }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){if(c)return 1;else f()}", r.output);
+}
+
+test "Codegen #3095: return 인자 없으면 변환 안 함" {
+    var r = try e2eMinAll(std.testing.allocator, "function h(){ if (c) { return; } else { return 2; } }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){if(c)return;else return 2}", r.output);
+}
+
+test "Codegen #3095: else 없으면 변환 안 함" {
+    var r = try e2eMinAll(std.testing.allocator, "function h(){ if (c) { return 1; } g(); }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){if(c)return 1;g()}", r.output);
+}
+
+test "Codegen #3095: 중첩 — else 분기의 if도 변환 (체인 부분 적용)" {
+    var r = try e2eMinAll(std.testing.allocator, "function h(){ if (a) return 1; else if (b) return 2; else return 3; }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){if(a)return 1;else return b?2:3}", r.output);
+}
+
+test "Codegen #3095: cond 앞 leading comment 가 있어도 return ASI 안 됨 (minify_syntax only)" {
+    // legal comment 는 minify_whitespace 없으면 보존되며 newline 을 끼움 → emitNode 로
+    // 그대로 emit 하면 `return /*!c*/\n c?1:2` 가 되어 ASI 로 `return;` — emitNoLineTerminatorOperand 로 방지.
+    var r = try e2eWithOptions(std.testing.allocator, "function h(){ if (/*! note */ c) return 1; else return 2; }", .{ .minify_syntax = true });
+    defer r.deinit();
+    // `return` 과 cond 사이에 newline 이 없어야 함 (ASI 방지)
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "return\n") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "?") != null);
+}
+
+test "Codegen #3095: minify_syntax off → 변환 안 함 (anti-regression)" {
+    var r = try e2eWithOptions(std.testing.allocator, "function h(){ if (c) { return 1; } else { return 2; } }", .{ .minify_whitespace = true });
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){if(c)return 1;else return 2;}", r.output);
+}

--- a/src/codegen/statements.zig
+++ b/src/codegen/statements.zig
@@ -107,17 +107,23 @@ fn unwrappedStatementBody(self: anytype, body_idx: NodeIndex) ?NodeIndex {
 /// (dangling else)하거나 ASI 가 미묘해 보수적으로 거부. `var` 선언은 본문으로 valid 하고
 /// hoisting 의미도 동일하므로 허용. `return`/`throw`/`break`/`continue`/`debugger`/
 /// expression statement 는 `else` 흡수 불가 + lexical decl 아님 → 안전.
-fn singleUnwrappableStmt(self: anytype, block: Node) ?NodeIndex {
+/// block 의 element 중 출력되는(= elided 아닌) statement 가 정확히 1개면 그 idx, 아니면 null
+/// (0개 또는 2개+ → null).
+fn singleNonElidedStmt(self: anytype, block: Node) ?NodeIndex {
     const list = block.data.list;
     const indices = self.ast.extra_data.items[list.start .. list.start + list.len];
     var only: ?NodeIndex = null;
     for (indices) |raw| {
         const idx: NodeIndex = @enumFromInt(raw);
         if (isElidedStmt(self, idx)) continue;
-        if (only != null) return null; // 출력되는 statement 가 2개+ → 못 벗김
+        if (only != null) return null;
         only = idx;
     }
-    const stmt_idx = only orelse return null; // 빈 block — `{}` 그대로 (보수적)
+    return only;
+}
+
+fn singleUnwrappableStmt(self: anytype, block: Node) ?NodeIndex {
+    const stmt_idx = singleNonElidedStmt(self, block) orelse return null; // 빈/2개+ block → `{}` 그대로
     const s = self.ast.getNode(stmt_idx);
     switch (s.tag) {
         .expression_statement,
@@ -243,7 +249,79 @@ pub fn emitIf(self: anytype, node: Node) !void {
     try emitIfVerbatim(self, t);
 }
 
+/// #3095: `cond` 가 paren 없이 `?:` test(= ShortCircuitExpression 또는 그보다 tight)
+/// 자리에 올 수 있는 노드 tag 인지 — 보수적 whitelist. assignment / sequence / yield /
+/// arrow / conditional 등은 `?:` 보다 느슨해 paren 이 필요하므로 거부 (transform skip).
+fn isSafeTernaryTest(tag: ast_mod.Node.Tag) bool {
+    return switch (tag) {
+        .identifier_reference,
+        .this_expression,
+        .static_member_expression,
+        .computed_member_expression,
+        .private_field_expression,
+        .call_expression,
+        .new_expression,
+        .numeric_literal,
+        .string_literal,
+        .boolean_literal,
+        .null_literal,
+        .bigint_literal,
+        .regexp_literal,
+        .template_literal,
+        .tagged_template_expression,
+        .parenthesized_expression,
+        .unary_expression,
+        .update_expression,
+        .await_expression,
+        .binary_expression,
+        .logical_expression,
+        => true,
+        else => false,
+    };
+}
+
+/// `idx` 가 `return <expr>;` 이거나 그것 하나만 담은 block 이면 그 expr 의 idx, 아니면 null.
+/// `return;` (인자 없음) 은 null.
+fn singleReturnArg(self: anytype, idx_in: NodeIndex) ?NodeIndex {
+    var idx = idx_in;
+    if (idx.isNone()) return null;
+    var n = self.ast.getNode(idx);
+    if (n.tag == .block_statement) {
+        idx = singleNonElidedStmt(self, n) orelse return null;
+        n = self.ast.getNode(idx);
+    }
+    if (n.tag != .return_statement or n.data.unary.operand.isNone()) return null;
+    return n.data.unary.operand;
+}
+
+/// `if(c){return A}else{return B}` → `return c?A:B;` 출력 시도. minify_syntax 전용.
+/// `c` 가 paren 없이 `?:` test 자리에 올 수 있고 A/B 가 sequence(comma) 가 아닐 때만.
+/// 출력했으면 true. (else-if 체인은 미지원 — else 분기 자체가 다시 emitIf 를 타며 변환됨.)
+fn tryEmitIfReturnTernary(self: anytype, t: anytype) !bool {
+    if (!self.options.minify_syntax or t.c.isNone()) return false;
+    const a_arg = singleReturnArg(self, t.b) orelse return false;
+    const b_arg = singleReturnArg(self, t.c) orelse return false;
+    if (!isSafeTernaryTest(self.ast.getNode(t.a).tag)) return false;
+    if (self.ast.getNode(a_arg).tag == .sequence_expression) return false;
+    if (self.ast.getNode(b_arg).tag == .sequence_expression) return false;
+    try self.write("return ");
+    // `return` 직후 cond — leading comment 가 newline 을 끼우면 ASI 로 `return;` 됨.
+    // `emitReturn` 과 동일하게 NoLineTerminator 처리.
+    try emitNoLineTerminatorOperand(self, t.a);
+    try writeSpace(self);
+    try self.writeByte('?');
+    try writeSpace(self);
+    try self.emitNode(a_arg);
+    try writeSpace(self);
+    try self.writeByte(':');
+    try writeSpace(self);
+    try self.emitNode(b_arg);
+    try self.writeByte(';');
+    return true;
+}
+
 fn emitIfVerbatim(self: anytype, t: anytype) !void {
+    if (try tryEmitIfReturnTernary(self, t)) return;
     if (self.options.minify_whitespace) try self.write("if(") else try self.write("if (");
     try self.emitNode(t.a);
     try self.writeByte(')');


### PR DESCRIPTION
## 무엇을

`--minify` / `--minify-syntax` 출력에서 `if(c){return A}else{return B}` → `return c?A:B;`. esbuild/SWC 동일. Closes #3095 의 핵심 케이스.

```js
// 입력
function classify(n){ if(n>0){return "pos";} else {return "neg";} }
// 출력
function classify(n){return n>0?"pos":"neg"}
```

bare return (`if(c)return a;else return b;`) 와 block 으로 감싼 경우 둘 다. else-if 체인(`else if(...)`)은 직접 재귀하진 않지만, else 분기 자체가 다시 `emitIf` 를 타므로 **안쪽부터 부분 적용**됨 — `if(a)return 1;else if(b)return 2;else return 3;` → `if(a)return 1;else return b?2:3`.

## 안전 조건 (보수적, Zig 초보자용)

- **`c` (조건)** 는 paren 없이 `?:` test 자리에 와도 안전한 노드 tag 일 때만 변환 — identifier/member/call/new/literal/template/unary/update/await/binary/logical/paren 등 (`?:` 보다 tight 한 것들). `a=b`(assignment), `a,b`(sequence), `yield x`, `x=>y`(arrow), `x?y:z`(conditional) 등은 paren 이 필요한데 codegen 이 자동 paren 을 안 넣으므로 그 경우엔 변환을 건너뛰고 `if` 를 그대로 둠. (whitelist 방식 — 못 보는 케이스가 있어도 절대 틀리진 않음.)
- **A / B (return 값)** 는 sequence expression(comma)이면 거부 — `?:` arm 은 AssignmentExpression 이라 comma 는 paren 필요. assignment/arrow/yield/conditional 은 arm 에 그대로 와도 OK 라 허용.
- 양쪽 본문은 **단일 `return <expr>`** 이어야 함 — `return;`(인자 없음)이나 다른 statement 가 섞여 있으면 거부.
- **`return` 직후 cond emit 은 `emitNoLineTerminatorOperand` 경유** — cond 앞에 leading comment 가 있으면 `emitNode` 가 newline 을 끼워 `return\n c?...` → ASI 로 `return;` 이 되는 회귀를 막음 (`minify_syntax` 만 켜서 legal comment `/*! ... */` 가 보존될 때 발생). `emitReturn`/`emitThrow` 와 동일 처리.

## 구현

`src/codegen/statements.zig`:
- `tryEmitIfReturnTernary(self, t)` — `emitIfVerbatim` 맨 앞에서 호출, 패턴 매치하면 `return c?A:B;` emit 후 true 반환 (이후 verbatim/`{}` 제거/`else` spacing 로직 전부 bypass).
- `isSafeTernaryTest(tag)` — 조건 whitelist. `singleReturnArg(self, idx)` — `return <expr>;` 또는 그것 하나만 담은 block 에서 expr 추출.
- `singleNonElidedStmt(self, block)` — block 의 단일 non-elided statement 추출 헬퍼로 분리, `#3094` 의 `singleUnwrappableStmt` 와 공유 (중복 제거).

## 테스트

- TDD — `src/codegen/codegen_test/basic.zig` 에 `#3095` 10개: if/else return block / bare return / member·logical cond / assignment cond(변환 안 함) / 한쪽이 return 아님(안 함) / `return;`(안 함) / else 없음(안 함) / else-if 체인(부분 적용) / cond 앞 comment + minify_syntax (ASI 회귀 방지) / minify_syntax off(안 함).
- `zig build test` 전체 통과. smoke (svelte / vue / react-dom / three / axios) 모두 baseline 출력 일치 (`MATCH`). 수기 케이스(classify/pick/nested/assignment-cond/non-return) node 실행으로 원본과 동일 출력 확인. svelte 런타임은 이 패턴이 적어 size 변화는 미미하지만 일반 helper 함수 많은 코드에 효과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)