### PR TITLE
fix(bundler): minify 시 entry export 후행 newline 유지 — line-limit + sourcemap 회귀 (#3096 후속)

### DIFF
--- a/src/bundler/emitter/entry_exports.zig
+++ b/src/bundler/emitter/entry_exports.zig
@@ -37,8 +37,9 @@ pub fn emitOutputExportsConflictDiag(
 }
 
 /// Entry export struct를 ESM `export { ... }` 구문으로 출력.
-/// #3096: minify_whitespace 시 brace 안 공백 / 항목 사이 공백 / 후행 newline 제거
-/// (`export{a,b as c};`). chunks.zig 의 chunk export emit 과 동일 관습.
+/// #3096: minify_whitespace 시 brace 안 공백 / 항목 사이 공백 제거 (`export{a,b as c};`).
+/// 후행 `\n` 은 유지 — bundle 끝의 `//# sourceMappingURL=` 주석이 같은 줄로 붙어
+/// `--line-limit` 초과하던 회귀(#3096 후속) 방지.
 pub fn emitEsmEntryExports(
     allocator: std.mem.Allocator,
     entries: []const FinalExportEntry,
@@ -59,7 +60,7 @@ pub fn emitEsmEntryExports(
             try out.appendSlice(allocator, e.exported);
         }
     }
-    try out.appendSlice(allocator, if (minify_whitespace) "};" else " };\n");
+    try out.appendSlice(allocator, if (minify_whitespace) "};\n" else " };\n");
     return try out.toOwnedSlice(allocator);
 }
 
@@ -86,7 +87,7 @@ pub fn emitWrappedEntryExports(
             try out.appendSlice(allocator, e.local);
         }
     }
-    try out.appendSlice(allocator, if (minify_whitespace) "};" else " };\n");
+    try out.appendSlice(allocator, if (minify_whitespace) "};\n" else " };\n");
     return try out.toOwnedSlice(allocator);
 }
 
@@ -239,7 +240,7 @@ test "emitEsmEntryExports: minify 시 공백/newline 제거 (#3096)" {
     };
     const out = try emitEsmEntryExports(std.testing.allocator, entries, true);
     defer std.testing.allocator.free(out);
-    try std.testing.expectEqualStrings("export{a,b$1 as b};", out);
+    try std.testing.expectEqualStrings("export{a,b$1 as b};\n", out);
 }
 
 test "emitWrappedEntryExports: emits object return from typed entries" {
@@ -260,5 +261,5 @@ test "emitWrappedEntryExports: minify 시 공백/newline 제거 (#3096)" {
     };
     const out = try emitWrappedEntryExports(std.testing.allocator, entries, true);
     defer std.testing.allocator.free(out);
-    try std.testing.expectEqualStrings("return{a,b:b$1};", out);
+    try std.testing.expectEqualStrings("return{a,b:b$1};\n", out);
 }


### PR DESCRIPTION
## 무엇을

#3096 ([PR #3103](https://github.com/ohah/zntc/pull/3103))에서 `emitEsmEntryExports` / `emitWrappedEntryExports` 가 `minify_whitespace` 시 brace 안 공백뿐 아니라 **후행 `\n` 까지** 제거했더니, bundle 맨 끝의 `//# sourceMappingURL=` 주석이 `export{...};` 와 **같은 줄로 붙어** 버립니다. `--line-limit` 과 함께 쓰면 그 줄이 한도를 초과:

```
console.log(values.length);export{      (34, OK)
values};//# sourceMappingURL=out.js.map (42, > --line-limit=40 ❌)
```

→ `tests/integration/tests/batch-e-cli.test.ts` 의 `--line-limit: JS CLI sourcemap mappings remain decodable after wrapping` 실패.

## 수정

후행 `\n` 은 1바이트뿐이고 esbuild 의 minified 출력도 끝에 `\n` 을 둡니다 — **유지**하되 brace 안 공백 / 항목 사이 공백만 제거 (`export{a,b};\n` / `return{a:b};\n`). 그러면 `//# sourceMappingURL=` 주석이 다시 자기 줄에 옴.

`src/bundler/emitter/entry_exports.zig`: `if (minify_whitespace) "};" else " };\n"` → `if (minify_whitespace) "};\n" else " };\n"` (2곳) + 관련 unit test 2개 expectation 갱신.

## 검증

- `zig build napi` 후 `bun test tests/integration/tests/batch-e-cli.test.ts` — 20/20 pass (이전 1 fail).
- `zig build test` 전체 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)