### PR TITLE
perf(codegen): minify_syntax 시 if → 논리/삼항 식 변환 (#3107)

### DIFF
--- a/src/codegen/codegen_test/basic.zig
+++ b/src/codegen/codegen_test/basic.zig
@@ -636,3 +636,87 @@ test "Codegen #3095: minify_syntax off → 변환 안 함 (anti-regression)" {
     defer r.deinit();
     try std.testing.expectEqualStrings("function h(){if(c)return 1;else return 2;}", r.output);
 }
+
+// ============================================================
+// #3107: if → 논리/삼항 식 변환 — minify_syntax 시
+//   `if(c){a()}else{b()}` → `c?a():b();`, `if(c){a()}` → `c&&a();`.
+//   양쪽 본문이 단일 expression statement 이고 paren-safety 충족 시만.
+// ============================================================
+
+test "Codegen #3107: if/else expr → c?a():b()" {
+    var r = try e2eMinAll(std.testing.allocator, "if (c) { a(); } else { b(); }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("c?a():b();", r.output);
+}
+
+test "Codegen #3107: bare expr 양쪽도 → c?a():b()" {
+    var r = try e2eMinAll(std.testing.allocator, "if (c) a(); else b();");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("c?a():b();", r.output);
+}
+
+test "Codegen #3107: 양쪽 assignment → c?x=1:x=2" {
+    var r = try e2eMinAll(std.testing.allocator, "if (c) x = 1; else x = 2;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("c?x=1:x=2;", r.output);
+}
+
+test "Codegen #3107: else 없음 → c&&a()" {
+    var r = try e2eMinAll(std.testing.allocator, "if (c) { a(); }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("c&&a();", r.output);
+}
+
+test "Codegen #3107: bare 본문 else 없음 → c&&a()" {
+    var r = try e2eMinAll(std.testing.allocator, "if (x.y) a();");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("x.y&&a();", r.output);
+}
+
+test "Codegen #3107: logical cond 은 ?: test 로는 안전 (x.y&&z?a():b())" {
+    var r = try e2eMinAll(std.testing.allocator, "if (x.y && z) a(); else b();");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("x.y&&z?a():b();", r.output);
+}
+
+test "Codegen #3107: logical cond + else 없음 은 && 변환 안 함 (paren 필요)" {
+    var r = try e2eMinAll(std.testing.allocator, "if (a || b) f();");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("if(a||b)f();", r.output);
+}
+
+test "Codegen #3107: 본문이 assignment + else 없음 은 && 변환 안 함" {
+    var r = try e2eMinAll(std.testing.allocator, "if (c) x = 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("if(c)x=1;", r.output);
+}
+
+test "Codegen #3107: 본문이 logical expr + else 없음 은 && 변환 안 함" {
+    var r = try e2eMinAll(std.testing.allocator, "if (c) a || b;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("if(c)a||b;", r.output);
+}
+
+test "Codegen #3107: 2개 statement 면 변환 안 함" {
+    var r = try e2eMinAll(std.testing.allocator, "if (c) { a(); b(); } else { x(); }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("if(c){a();b()}else x();", r.output);
+}
+
+test "Codegen #3107: else-if 체인 — 안쪽부터 부분 적용" {
+    var r = try e2eMinAll(std.testing.allocator, "if (p) a(); else if (q) b(); else f();");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("if(p)a();else q?b():f();", r.output);
+}
+
+test "Codegen #3107: 한쪽이 expr 아니면(return) 변환 안 함" {
+    var r = try e2eMinAll(std.testing.allocator, "function h(){ if (c) { a(); } else { return 1; } }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){if(c)a();else return 1}", r.output);
+}
+
+test "Codegen #3107: minify_syntax off → 변환 안 함 (anti-regression)" {
+    var r = try e2eWithOptions(std.testing.allocator, "if (c) a(); else b();", .{ .minify_whitespace = true });
+    defer r.deinit();
+    try std.testing.expectEqualStrings("if(c)a();else b();", r.output);
+}

--- a/src/codegen/statements.zig
+++ b/src/codegen/statements.zig
@@ -320,8 +320,65 @@ fn tryEmitIfReturnTernary(self: anytype, t: anytype) !bool {
     return true;
 }
 
+/// `idx` 가 `<expr>;` (expression statement) 이거나 그것 하나만 담은 block 이면 그 expr 의 idx,
+/// 아니면 null.
+fn singleExprStmt(self: anytype, idx_in: NodeIndex) ?NodeIndex {
+    var idx = idx_in;
+    if (idx.isNone()) return null;
+    var n = self.ast.getNode(idx);
+    if (n.tag == .block_statement) {
+        idx = singleNonElidedStmt(self, n) orelse return null;
+        n = self.ast.getNode(idx);
+    }
+    if (n.tag != .expression_statement) return null;
+    return n.data.unary.operand;
+}
+
+/// `&&` 의 좌/우 피연산자로 paren 없이 올 수 있는 노드 tag 인지 — `?:` test whitelist 에서
+/// `logical_expression` 만 추가로 제외 (`||`/`??` 가 `&&` 보다 느슨해 `(a||b)&&c` paren 필요;
+/// `a&&b` 는 valid 지만 op 검사 회피 위해 통째로 제외 — 보수적).
+fn isSafeAndOperand(tag: ast_mod.Node.Tag) bool {
+    return isSafeTernaryTest(tag) and tag != .logical_expression;
+}
+
+/// `if(c){a()}else{b()}` → `c?a():b();`, `if(c){a()}` (else 없음/elided) → `c&&a();`.
+/// minify_syntax 전용. 양쪽 본문이 단일 expression statement 이고 paren-safety 충족 시만.
+fn tryEmitIfExprStatement(self: anytype, t: anytype) !bool {
+    if (!self.options.minify_syntax) return false;
+    const then_expr = singleExprStmt(self, t.b) orelse return false;
+    const has_else = !t.c.isNone() and !isElidedAlternate(self, t.c);
+    if (!has_else) {
+        // `if(c)a();` → `c&&a();` — c 와 a() 둘 다 `&&` 피연산자로 paren 없이 와야 함.
+        if (!isSafeAndOperand(self.ast.getNode(t.a).tag)) return false;
+        if (!isSafeAndOperand(self.ast.getNode(then_expr).tag)) return false;
+        try self.emitNode(t.a);
+        try writeSpace(self);
+        try self.write("&&");
+        try writeSpace(self);
+        try self.emitNode(then_expr);
+        try self.writeByte(';');
+        return true;
+    }
+    const else_expr = singleExprStmt(self, t.c) orelse return false;
+    if (!isSafeTernaryTest(self.ast.getNode(t.a).tag)) return false;
+    if (self.ast.getNode(then_expr).tag == .sequence_expression) return false;
+    if (self.ast.getNode(else_expr).tag == .sequence_expression) return false;
+    try self.emitNode(t.a);
+    try writeSpace(self);
+    try self.writeByte('?');
+    try writeSpace(self);
+    try self.emitNode(then_expr);
+    try writeSpace(self);
+    try self.writeByte(':');
+    try writeSpace(self);
+    try self.emitNode(else_expr);
+    try self.writeByte(';');
+    return true;
+}
+
 fn emitIfVerbatim(self: anytype, t: anytype) !void {
     if (try tryEmitIfReturnTernary(self, t)) return;
+    if (try tryEmitIfExprStatement(self, t)) return;
     if (self.options.minify_whitespace) try self.write("if(") else try self.write("if (");
     try self.emitNode(t.a);
     try self.writeByte(')');


### PR DESCRIPTION
## 무엇을

`--minify` / `--minify-syntax` 출력에서 본문이 expression statement 인 `if` 를 식으로 평탄화:

| 입력 | 출력 |
|---|---|
| `if(c){a()}else{b()}` / `if(c)a();else b();` | `c?a():b();` |
| `if(c)x=1;else x=2;` | `c?x=1:x=2;` |
| `if(c){a()}` / `if(c)a();` (else 없음) | `c&&a();` |
| `if(x.y)a();` | `x.y&&a();` |
| `if(p)a();else if(q)b();else f();` | `if(p)a();else q?b():f();` (안쪽부터 부분 적용) |

esbuild/SWC 동일. Closes #3107 의 핵심 케이스 (`if(c)a()`→`c&&a()`, `if(c)a();else b()`→`c?a():b()`, `if(c)x=1;else x=2`→`c?x=1:x=2`).

## 안전 조건 (보수적, Zig 초보자용)

- **`?:` 케이스** (`if/else` 둘 다 expr stmt): `c` 가 paren 없이 `?:` test(=ShortCircuitExpression 또는 더 tight) 자리에 올 수 있는 노드일 때만 (`isSafeTernaryTest` whitelist — assignment/sequence/yield/arrow/conditional 은 제외). arm(then/else expr)은 `sequence_expression`(comma)이면 거부 — `?:` arm 은 AssignmentExpression 이라 assignment/conditional/arrow 는 그대로 OK, comma 만 paren 필요.
- **`&&` 케이스** (else 없음): `c` 와 body expr **둘 다** `&&` 피연산자로 paren 없이 와야 함 — `isSafeAndOperand` = `isSafeTernaryTest` 에서 `logical_expression` 추가 제외 (`(a||b)&&c` 는 paren 필요; `a&&b` 는 valid 지만 op 검사 회피 위해 통째로 제외). body 가 `assignment`/`conditional`/`logical`/`sequence` 면 거부 (`c&&x=1` → `(c&&x)=1` parse error 등).
- 결과를 expression statement 위치에 출력하지만 whitelist 가 `{`/`function`/`class`/`array` literal 을 모두 제외하므로 statement-start 오파싱 위험 없음 (`object_expression` 등은 `isSafeTernaryTest` 에 없음).
- `return`-branch 케이스(#3095 `tryEmitIfReturnTernary`)와 mutually exclusive — `singleExprStmt` 는 `return_statement` 에 null 반환.

## 구현

`src/codegen/statements.zig`:
- `tryEmitIfExprStatement(self, t)` — `emitIfVerbatim` 에서 `tryEmitIfReturnTernary` 다음에 호출.
- `singleExprStmt(self, idx)` — `<expr>;` 또는 그것 하나만 담은 block 에서 expr 추출 (`singleReturnArg`/`singleNonElidedStmt` 패턴 재사용).
- `isSafeAndOperand(tag)` — `&&` 피연산자 whitelist.

## 테스트

- TDD — `src/codegen/codegen_test/basic.zig` 에 `#3107` 13개: if/else expr / bare 양쪽 / assignment arm / `&&` (no else) / member cond `&&` / logical cond 은 `?:` 로는 OK 지만 `&&` 로는 거부 / assignment body·logical body `&&` 거부 / 2개 statement 거부 / else-if 체인 부분 / return-mixed 거부 / minify_syntax off.
- `zig build test` 전체 통과. smoke (svelte/vue/react-dom/three/axios) 모두 baseline 출력 일치 (`MATCH`). 수기 케이스 node 실행으로 원본과 동일 출력 확인. **svelte-mount-min 27,165 → 26,965 B (−200), svelte-full-min 29,741 → 29,509 B (−232)** — svelte 런타임에 `if(c)f()` 가드 패턴이 많아 `&&` 변환 효과가 큼.

🤖 Generated with [Claude Code](https://claude.com/claude-code)