### PR TITLE
perf(codegen): if-else-return ternary 의 else-if 체인 완전 변환 (#3109)

### DIFF
--- a/src/codegen/codegen_test/basic.zig
+++ b/src/codegen/codegen_test/basic.zig
@@ -615,10 +615,28 @@ test "Codegen #3095: else 없으면 변환 안 함" {
     try std.testing.expectEqualStrings("function h(){if(c)return 1;g()}", r.output);
 }
 
-test "Codegen #3095: 중첩 — else 분기의 if도 변환 (체인 부분 적용)" {
+test "Codegen #3109: else-if return 체인 전체를 ternary 로 (right-assoc)" {
     var r = try e2eMinAll(std.testing.allocator, "function h(){ if (a) return 1; else if (b) return 2; else return 3; }");
     defer r.deinit();
-    try std.testing.expectEqualStrings("function h(){if(a)return 1;else return b?2:3}", r.output);
+    try std.testing.expectEqualStrings("function h(){return a?1:b?2:3}", r.output);
+}
+
+test "Codegen #3109: return arg 가 conditional 이어도 paren 불필요" {
+    var r = try e2eMinAll(std.testing.allocator, "function h(){ if (a) return x ? y : z; else return 1; }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){return a?x?y:z:1}", r.output);
+}
+
+test "Codegen #3109: 체인 중간 cond 가 unsafe(assignment) 면 전체 변환 안 함" {
+    var r = try e2eMinAll(std.testing.allocator, "function h(){ if (a) return 1; else if (c = d) return 2; else return 3; }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){if(a)return 1;else if(c=d)return 2;else return 3}", r.output);
+}
+
+test "Codegen #3109: 체인 마지막 else 가 return 아니면 전체 변환 안 함" {
+    var r = try e2eMinAll(std.testing.allocator, "function h(){ if (a) return 1; else if (b) return 2; else f(); }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){if(a)return 1;else if(b)return 2;else f()}", r.output);
 }
 
 test "Codegen #3095: cond 앞 leading comment 가 있어도 return ASI 안 됨 (minify_syntax only)" {

--- a/src/codegen/statements.zig
+++ b/src/codegen/statements.zig
@@ -294,28 +294,44 @@ fn singleReturnArg(self: anytype, idx_in: NodeIndex) ?NodeIndex {
     return n.data.unary.operand;
 }
 
-/// `if(c){return A}else{return B}` → `return c?A:B;` 출력 시도. minify_syntax 전용.
-/// `c` 가 paren 없이 `?:` test 자리에 올 수 있고 A/B 가 sequence(comma) 가 아닐 때만.
-/// 출력했으면 true. (else-if 체인은 미지원 — else 분기 자체가 다시 emitIf 를 타며 변환됨.)
-fn tryEmitIfReturnTernary(self: anytype, t: anytype) !bool {
-    if (!self.options.minify_syntax or t.c.isNone()) return false;
-    const a_arg = singleReturnArg(self, t.b) orelse return false;
-    const b_arg = singleReturnArg(self, t.c) orelse return false;
+/// `if(c){return A}else{...}` 체인 전체가 `return c?A:...` 로 평탄화 가능한지 (pure check).
+/// then/else 가 모두 `return <expr>` 이거나 else 가 다시 같은 형태의 if 이고, 모든 cond 가
+/// `?:` test 자리에 paren 없이 올 수 있으며, 모든 return arg 가 sequence(comma) 가 아닐 때.
+fn canEmitIfReturnChain(self: anytype, t: anytype, depth: u8) bool {
+    if (depth >= 32 or t.c.isNone()) return false;
     if (!isSafeTernaryTest(self.ast.getNode(t.a).tag)) return false;
+    const a_arg = singleReturnArg(self, t.b) orelse return false;
     if (self.ast.getNode(a_arg).tag == .sequence_expression) return false;
-    if (self.ast.getNode(b_arg).tag == .sequence_expression) return false;
-    try self.write("return ");
-    // `return` 직후 cond — leading comment 가 newline 을 끼우면 ASI 로 `return;` 됨.
-    // `emitReturn` 과 동일하게 NoLineTerminator 처리.
-    try emitNoLineTerminatorOperand(self, t.a);
+    if (singleReturnArg(self, t.c)) |b_arg| {
+        return self.ast.getNode(b_arg).tag != .sequence_expression;
+    }
+    const else_node = self.ast.getNode(t.c);
+    return else_node.tag == .if_statement and canEmitIfReturnChain(self, else_node.data.ternary, depth + 1);
+}
+
+/// `canEmitIfReturnChain` 가 통과한 if 체인을 `cond?A:<rest>` 식으로 emit.
+/// `is_first` 면 cond 를 `emitNoLineTerminatorOperand` 로 (`return` 직후 ASI 회피).
+/// `?:` 는 right-assoc 이라 `a?1:b?2:3` 가 `a?1:(b?2:3)` 로 정확히 파싱됨 — paren 불필요.
+fn emitIfReturnChainTail(self: anytype, t: anytype, is_first: bool) !void {
+    if (is_first) try emitNoLineTerminatorOperand(self, t.a) else try self.emitNode(t.a);
     try writeSpace(self);
     try self.writeByte('?');
     try writeSpace(self);
-    try self.emitNode(a_arg);
+    try self.emitNode(singleReturnArg(self, t.b).?);
     try writeSpace(self);
     try self.writeByte(':');
     try writeSpace(self);
-    try self.emitNode(b_arg);
+    if (singleReturnArg(self, t.c)) |b_arg| {
+        try self.emitNode(b_arg);
+    } else {
+        try emitIfReturnChainTail(self, self.ast.getNode(t.c).data.ternary, false);
+    }
+}
+
+fn tryEmitIfReturnTernary(self: anytype, t: anytype) !bool {
+    if (!self.options.minify_syntax or !canEmitIfReturnChain(self, t, 0)) return false;
+    try self.write("return ");
+    try emitIfReturnChainTail(self, t, true);
     try self.writeByte(';');
     return true;
 }


### PR DESCRIPTION
## 무엇을

#3095 ([PR #3106](https://github.com/ohah/zntc/pull/3106))의 `if(c){return A}else{return B}` → `return c?A:B;` 가 else-if 체인을 직접 재귀하도록 확장:

```js
// 입력
function classify(n){ if(n<0) return "neg"; else if(n===0) return "zero"; else if(n<10) return "small"; else return "big"; }
// #3095 (부분)
function classify(n){if(n<0)return "neg";else return n===0?"zero":n<10?"small":"big"}
// #3109 (전체)
function classify(n){return n<0?"neg":n===0?"zero":n<10?"small":"big"}
```

esbuild/SWC 동일. Closes #3109.

## 안전 조건 (Zig 초보자용)

- `?:` 는 **right-associative** — `a?1:b?2:3` 가 `a?1:(b?2:3)` 로 정확히 파싱됨. 그래서 체인을 flat 하게 paren 없이 emit 하는 게 맞음.
- `canEmitIfReturnChain` 으로 **체인 전체가 변환 가능한지 먼저 검사**(pure, emit 없음): 모든 cond 가 `?:` test 자리에 paren 없이 올 수 있고(`isSafeTernaryTest`), 모든 return arg 가 `sequence_expression`(comma)이 아니고, 각 else 가 `return <expr>` 이거나 같은 형태의 if 일 때만. 통과해야 `emitIfReturnChainTail` 로 emit (emit 도중 abort 불가하므로 pre-check 필수).
- **중간 cond 가 unsafe**(assignment `c=d` 등)거나 **체인 끝 else 가 return 이 아니면** 전체 변환을 포기하고 verbatim — `else if(...)` 를 `?:` alternate 자리에 둘 수 없으므로 중간에서 멈출 수 없음.
- 첫 cond(`return` 직후)만 `emitNoLineTerminatorOperand` (leading comment 가 newline 끼우면 ASI 로 `return;` 되는 회귀 방지, #3095 와 동일). 나머지 cond 는 `:` 뒤라 ASI 무관.

## 테스트

- TDD — `src/codegen/codegen_test/basic.zig`: else-if return 체인 전체 → nested ternary / 체인 중간 cond 가 assignment 면 전체 변환 안 함 / 체인 끝 else 가 return 아니면 안 함 / return arg 가 conditional 이어도 paren 불필요 (`return a?x?y:z:1`). #3095 의 "체인 부분 적용" 테스트는 #3109 의 "전체 변환" 으로 갱신.
- `zig build test` 전체 통과. smoke (svelte / vue / react-dom / three) 모두 baseline 출력 일치 (`MATCH`). 수기 케이스(4-level chain, assignment mid-chain) node 실행으로 원본과 동일 출력 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)