### PR TITLE
perf(codegen): #3094 후속 — do-while 본문 / if(true)·if(false) DCE 분기 의 single-statement `{}` 제거 (#3111)

### DIFF
--- a/src/codegen/codegen_test/basic.zig
+++ b/src/codegen/codegen_test/basic.zig
@@ -738,3 +738,50 @@ test "Codegen #3107: minify_syntax off → 변환 안 함 (anti-regression)" {
     defer r.deinit();
     try std.testing.expectEqualStrings("if(c)a();else b();", r.output);
 }
+
+// ============================================================
+// #3111: do-while 본문 / if(true)·if(false) DCE 분기 의 single-statement {} 제거
+//   (#3094 후속 — emitStatementBody 인프라 재사용).
+// ============================================================
+
+test "Codegen #3111: do-while 본문 단일 statement → {} 제거" {
+    var r = try e2e(std.testing.allocator, "do { f(); } while (c);");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("do f();while(c);", r.output);
+}
+
+test "Codegen #3111: do-while 2개 statement 면 {} 유지" {
+    var r = try e2e(std.testing.allocator, "do { f(); g(); } while (c);");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("do{f();g();}while(c);", r.output);
+}
+
+test "Codegen #3111: do-while let 본문은 {} 유지" {
+    var r = try e2e(std.testing.allocator, "do { let x = 1; } while (c);");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("do{let x=1;}while(c);", r.output);
+}
+
+test "Codegen #3111: if(true) DCE 분기 {} 제거" {
+    var r = try e2e(std.testing.allocator, "if (true) { f(); }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("f();", r.output);
+}
+
+test "Codegen #3111: if(false)/else DCE 분기 {} 제거" {
+    var r = try e2e(std.testing.allocator, "if (false) { bad(); } else { g(); }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("g();", r.output);
+}
+
+test "Codegen #3111: if(true) DCE 분기 let 은 {} 유지" {
+    var r = try e2e(std.testing.allocator, "if (true) { let x = 1; }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("{let x=1;}", r.output);
+}
+
+test "Codegen #3111: non-minify 는 do {} 유지 (anti-regression)" {
+    var r = try e2eWithOptions(std.testing.allocator, "do { f(); } while (c);", .{});
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "{") != null);
+}

--- a/src/codegen/statements.zig
+++ b/src/codegen/statements.zig
@@ -79,9 +79,10 @@ pub fn emitBlock(self: anytype, node: Node) !void {
     try emitBracedList(self, node);
 }
 
-/// `if`/`else`/`for`/`while`/`for-in`/`for-of` 의 본문을 emit. minify 시 본문이
-/// "벗겨도 안전한" statement 하나뿐인 block 이면 `{}` 를 제거하고 그 statement 만 출력
-/// (`if(x){f()}` → `if(x)f()`). 그 외에는 본문 노드를 그대로 emit.
+/// 제어흐름 본문(`if`/`else`/`for`/`while`/`for-in`/`for-of`/`do-while`) 또는 standalone
+/// statement 자리(상수-조건 DCE 로 남은 분기)의 노드를 emit. minify 시 그 자리가 "벗겨도
+/// 안전한" statement 하나뿐인 block 이면 `{}` 를 제거하고 그 statement 만 출력
+/// (`if(x){f()}` → `if(x)f()`). 그 외에는 노드를 그대로 emit.
 pub fn emitStatementBody(self: anytype, body_idx: NodeIndex) !void {
     if (unwrappedStatementBody(self, body_idx)) |inner| {
         try self.emitNode(inner);
@@ -236,13 +237,13 @@ pub fn emitIf(self: anytype, node: Node) !void {
             // if (false) { ... } else { alt } → alt만 출력
             if (!t.c.isNone()) {
                 if (isFunctionDeclarationNode(self, t.c)) return emitIfVerbatim(self, t);
-                try self.emitNode(t.c);
+                try emitStatementBody(self, t.c);
             }
             return;
         } else {
             // if (true) { ... } → then만 출력
             if (isFunctionDeclarationNode(self, t.b)) return emitIfVerbatim(self, t);
-            try self.emitNode(t.b);
+            try emitStatementBody(self, t.b);
             return;
         }
     }
@@ -577,11 +578,13 @@ pub fn emitWhile(self: anytype, node: Node) !void {
 pub fn emitDoWhile(self: anytype, node: Node) !void {
     try self.addSourceMapping(node.span);
     try self.write("do");
-    // block body는 emitBracedList가 { 앞 공백 관리, non-block은 공백 필수 (dox++ 방지)
-    if (node.data.binary.right.isNone() or self.ast.getNode(node.data.binary.right).tag != .block_statement) {
-        try self.writeByte(' ');
-    }
-    try self.emitNode(node.data.binary.right);
+    const body = node.data.binary.right;
+    // block body 면 emitBracedList 가 `{` 앞 공백을 관리. non-block(또는 #3094 로 `{}` 가
+    // 벗겨질 block)은 키워드 뒤 공백 필수 (`dox++` 방지).
+    const body_is_braces = !body.isNone() and self.ast.getNode(body).tag == .block_statement and
+        unwrappedStatementBody(self, body) == null;
+    if (!body_is_braces) try self.writeByte(' ');
+    try emitStatementBody(self, body);
     if (self.options.minify_whitespace) try self.write("while(") else try self.write(" while (");
     try self.emitNode(node.data.binary.left);
     try self.write(");");


### PR DESCRIPTION
## 무엇을

#3094 ([PR #3105](https://github.com/ohah/zntc/pull/3105))가 보수적으로 제외했던 두 케이스를 `emitStatementBody` 인프라 재사용으로 처리:

1. **`do-while` 본문** — `do{f()}while(c)` → `do f();while(c)` (본문이 단일 안전 statement 인 block 일 때만; `do` 뒤 공백은 본문이 bare statement 거나 벗겨질 block 이면 필수 — `dox++`/`doreturn` 방지).
2. **`if(true){A}` / `if(false){A}else{B}` 의 상수-조건 DCE 분기** — `emitIf` 가 남는 분기를 `emitNode` → `emitStatementBody` 경유로. standalone 위치라 `{f()}` ≡ `f();` (블록이 scope 를 안 만듦, `let`/`const`/`class`/`function` 선언은 `singleUnwrappableStmt` 가 거부해서 `{}` 유지).

Closes #3111.

## 알려진 한계 (PR 본문에 명시)

`--minify` 에선 `src/transformer/minify.zig` 의 `foldIf` 가 codegen 전에 `if(true){A}` 를 standalone `{A}` block 으로 DCE 해버리므로, 위 `emitIf` codegen 경로는 `minify_syntax` 없이 `minify_whitespace` 만 켰을 때만 작용합니다. `--minify` 에서 그 standalone `{f()}` 를 `f();` 로 만들려면 `foldIf` 가 DCE 시 single-statement block 을 벗기거나, statement-list 의 useless block 을 flatten 해야 함 — 별도 follow-up.

## 안전성 (Zig 초보자용)

- `do <bare stmt>; while(c)` 는 valid — `do` 의 본문은 정확히 statement 1개, parser 가 greedily 확장 안 함. `do x++;while(c);` 는 `do` + `x++;` + `while(c);` 로 명확히 lex.
- standalone `{f()}` 벗기기: 블록에 expression statement / `return` / `throw` / `break` / `continue` / `debugger` / `var` 만 있으면 scope 를 안 만들어 `f();` 와 동일. `var` 는 함수 스코프라 블록과 무관. `let`/`const`/`class`/`function` 선언은 거부 (벗기면 enclosing scope 로 누출). `esm_var_assign_only` 에선 `var` 도 거부 (#3094 와 동일).

## 테스트

- TDD — `src/codegen/codegen_test/basic.zig` 에 `#3111` 7개: do-while 단일 → `{}` 제거 / do-while 2개 → 유지 / do-while `let` → 유지 / `if(true)` DCE → `f();` / `if(false)/else` DCE → `g();` / `if(true)` DCE `let` → `{let x=1;}` 유지 / non-minify 시 `do{}` 유지.
- `zig build test` 전체 통과. smoke (svelte / vue / react-dom / three / axios) 모두 baseline 출력 일치 (`MATCH`). 수기 케이스(do-while 1개/2개, if(true)/if(false) DCE) node 실행으로 원본과 동일 출력 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)