### PR TITLE
fix(react-native): preserve RuntimeKind in RN bundles

### DIFF
--- a/packages/core/bin/rn-dev-input.mjs
+++ b/packages/core/bin/rn-dev-input.mjs
@@ -110,6 +110,7 @@ export function buildRnDevServerInput(opts, config) {
   // shortcut 의 enable gate. CLI flag 우선 — 명시 시 config override.
   const terminalActions =
     opts.noInteractive === true || server.useGlobalHotkey === false ? false : undefined;
+  const dev = opts.devMode !== undefined ? Boolean(opts.devMode) : cfg.dev !== false;
 
   return {
     bundle: {
@@ -117,7 +118,7 @@ export function buildRnDevServerInput(opts, config) {
       projectRoot,
       rnPlatform,
       // dev server 는 default __DEV__=true / sourcemap=true (bundle 의 default false 와 의도적 비대칭).
-      dev: opts.devMode !== false && cfg.dev !== false,
+      dev,
       // dev server 는 항상 sourcemap=true — RN LogBox / DevTools 의 source link
       // 동작에 필수. zntc.mjs 의 `opts.sourcemap` default 가 false 라 `!== false`
       // 비교는 무용 (사용자 명시 disable 구분 불가). dev server 컨텍스트에선

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -247,7 +247,7 @@ function parseArgs(argv) {
     jsxFactory: undefined,
     jsxFragment: undefined,
     jsxImportSource: undefined,
-    devMode: false,
+    devMode: undefined,
     flow: false,
     experimentalDecorators: false,
     useDefineForClassFields: true,

--- a/packages/core/test/cli/react-native-dev-input/bundle-options/runtime-config.ts
+++ b/packages/core/test/cli/react-native-dev-input/bundle-options/runtime-config.ts
@@ -20,13 +20,19 @@ describe('buildRnDevServerInput — runtime bundle option config 추출 (#2605)'
     expect(input?.bundle.extra?.babelTransformerPath).toBe('react-native-svg-transformer');
   });
 
-  test('config.dev=false → bundle.dev=false (CLI override 가능)', async () => {
+  test('dev 우선순위: CLI devMode > config.dev > default true', async () => {
     const buildRnDevServerInput = await loadBuildRnDevServerInput();
-    const a = buildRnDevServerInput({ entryPoints: ['i.js'] }, { dev: false });
-    expect(a?.bundle.dev).toBe(false);
+    const defaultInput = buildRnDevServerInput({ entryPoints: ['i.js'] }, {});
+    expect(defaultInput?.bundle.dev).toBe(true);
 
-    const b = buildRnDevServerInput({ entryPoints: ['i.js'], devMode: false }, { dev: true });
-    expect(b?.bundle.dev).toBe(false);
+    const configOff = buildRnDevServerInput({ entryPoints: ['i.js'] }, { dev: false });
+    expect(configOff?.bundle.dev).toBe(false);
+
+    const cliOff = buildRnDevServerInput({ entryPoints: ['i.js'], devMode: false }, { dev: true });
+    expect(cliOff?.bundle.dev).toBe(false);
+
+    const cliOn = buildRnDevServerInput({ entryPoints: ['i.js'], devMode: true }, { dev: false });
+    expect(cliOn?.bundle.dev).toBe(true);
   });
 
   test('config.minify → bundle.minify', async () => {

--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -529,6 +529,18 @@ fn extractDeclExportNames(allocator: std.mem.Allocator, ast: *const Ast, decl: N
                 .span = name_node.span,
             });
         },
+        .ts_enum_declaration => {
+            // extra = [name, members_start, members_len, flags]
+            const e = decl.data.extra;
+            if (e >= ast.extra_data.items.len) return names.toOwnedSlice(allocator);
+            const name_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e]);
+            if (name_idx.isNone()) return names.toOwnedSlice(allocator);
+            const name_node = ast.getNode(name_idx);
+            try names.append(allocator, .{
+                .name = ast.getText(name_node.span),
+                .span = name_node.span,
+            });
+        },
         else => {},
     }
 

--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -507,30 +507,9 @@ fn extractDeclExportNames(allocator: std.mem.Allocator, ast: *const Ast, decl: N
                 }
             }
         },
-        .function_declaration => {
-            const e = decl.data.extra;
-            if (e >= ast.extra_data.items.len) return names.toOwnedSlice(allocator);
-            const name_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e]);
-            if (name_idx.isNone()) return names.toOwnedSlice(allocator);
-            const name_node = ast.getNode(name_idx);
-            try names.append(allocator, .{
-                .name = ast.getText(name_node.span),
-                .span = name_node.span,
-            });
-        },
-        .class_declaration => {
-            const e = decl.data.extra;
-            if (e >= ast.extra_data.items.len) return names.toOwnedSlice(allocator);
-            const name_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e]);
-            if (name_idx.isNone()) return names.toOwnedSlice(allocator);
-            const name_node = ast.getNode(name_idx);
-            try names.append(allocator, .{
-                .name = ast.getText(name_node.span),
-                .span = name_node.span,
-            });
-        },
-        .ts_enum_declaration => {
-            // extra = [name, members_start, members_len, flags]
+        // 모두 extra[0] 이 이름 노드 (function: [name, ...], class: [name, ...],
+        // enum: [name, members_start, members_len, flags]).
+        .function_declaration, .class_declaration, .ts_enum_declaration => {
             const e = decl.data.extra;
             if (e >= ast.extra_data.items.len) return names.toOwnedSlice(allocator);
             const name_idx: NodeIndex = @enumFromInt(ast.extra_data.items[e]);

--- a/src/bundler/binding_scanner_test.zig
+++ b/src/bundler/binding_scanner_test.zig
@@ -188,6 +188,20 @@ test "export binding: export function" {
     try std.testing.expectEqualStrings("greet", r.export_bindings[0].exported_name);
 }
 
+test "export binding: export enum" {
+    const alloc = std.testing.allocator;
+    var r = try parseAndExtractBindings(alloc, "export enum RuntimeKind { ReactNative = 1, UI = 2 }");
+    defer r.arena.deinit();
+    defer alloc.free(r.import_bindings);
+    defer alloc.free(r.export_bindings);
+    defer alloc.free(r.import_records);
+
+    try std.testing.expectEqual(@as(usize, 1), r.export_bindings.len);
+    try std.testing.expectEqualStrings("RuntimeKind", r.export_bindings[0].exported_name);
+    try std.testing.expectEqualStrings("RuntimeKind", r.export_bindings[0].local_name);
+    try std.testing.expectEqual(ExportBinding.Kind.local, r.export_bindings[0].kind);
+}
+
 test "export binding: multi-declarator (export const x=1, y=2)" {
     const alloc = std.testing.allocator;
     var r = try parseAndExtractBindings(alloc, "export const x = 1, y = 2;");

--- a/src/bundler/tree_shaker_test.zig
+++ b/src/bundler/tree_shaker_test.zig
@@ -1637,6 +1637,21 @@ test "typescript: enum import used directly" {
     try std.testing.expect(r.shaker.isIncluded(r.findModule("enums.ts").?));
 }
 
+test "typescript: exported enum in sideEffects false module stays reachable" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "import { UIRuntimeId } from './use'; console.log(UIRuntimeId);");
+    try writeFile(tmp.dir, "use.ts", "import { RuntimeKind } from './runtimeKind'; export const UIRuntimeId = RuntimeKind.UI;");
+    try writeFile(tmp.dir, "runtimeKind.ts", "export enum RuntimeKind { ReactNative = 1, UI = 2, Worker = 3 }");
+
+    var r = try buildAndShakeWithOpts(std.testing.allocator, &tmp, "entry.ts", &.{ "use.ts", "runtimeKind.ts" });
+    defer r.deinit();
+
+    const runtime_mod = r.findModule("runtimeKind.ts").?;
+    try std.testing.expect(r.shaker.isIncluded(runtime_mod));
+    try std.testing.expect(r.shaker.isExportUsed(runtime_mod, "RuntimeKind"));
+}
+
 test "typescript: abstract class import" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -3325,27 +3325,7 @@ pub const SemanticAnalyzer = struct {
                     }
                 }
             },
-            .function_declaration => {
-                const extras = self.ast.extra_data.items;
-                if (node.data.extra >= extras.len) return;
-                const name_idx: NodeIndex = @enumFromInt(extras[node.data.extra]);
-                if (!name_idx.isNone() and @intFromEnum(name_idx) < self.ast.nodes.items.len) {
-                    const name_node = self.ast.getNode(name_idx);
-                    const name = self.ast.getText(name_node.span);
-                    try self.registerExportedName(name, name_node.span);
-                }
-            },
-            .class_declaration => {
-                const extras = self.ast.extra_data.items;
-                if (node.data.extra >= extras.len) return;
-                const name_idx: NodeIndex = @enumFromInt(extras[node.data.extra]);
-                if (!name_idx.isNone() and @intFromEnum(name_idx) < self.ast.nodes.items.len) {
-                    const name_node = self.ast.getNode(name_idx);
-                    const name = self.ast.getText(name_node.span);
-                    try self.registerExportedName(name, name_node.span);
-                }
-            },
-            .ts_enum_declaration => {
+            .function_declaration, .class_declaration, .ts_enum_declaration => {
                 const extras = self.ast.extra_data.items;
                 if (node.data.extra >= extras.len) return;
                 const name_idx: NodeIndex = @enumFromInt(extras[node.data.extra]);
@@ -3395,17 +3375,7 @@ pub const SemanticAnalyzer = struct {
                     }
                 }
             },
-            .function_declaration, .class_declaration => {
-                const extras = self.ast.extra_data.items;
-                if (node.data.extra >= extras.len) return;
-                const name_idx: NodeIndex = @enumFromInt(extras[node.data.extra]);
-                if (!name_idx.isNone() and @intFromEnum(name_idx) < self.ast.nodes.items.len) {
-                    const name_node = self.ast.getNode(name_idx);
-                    const name = self.ast.getText(name_node.span);
-                    self.markSymbolExported(name, false);
-                }
-            },
-            .ts_enum_declaration => {
+            .function_declaration, .class_declaration, .ts_enum_declaration => {
                 const extras = self.ast.extra_data.items;
                 if (node.data.extra >= extras.len) return;
                 const name_idx: NodeIndex = @enumFromInt(extras[node.data.extra]);

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -3345,6 +3345,16 @@ pub const SemanticAnalyzer = struct {
                     try self.registerExportedName(name, name_node.span);
                 }
             },
+            .ts_enum_declaration => {
+                const extras = self.ast.extra_data.items;
+                if (node.data.extra >= extras.len) return;
+                const name_idx: NodeIndex = @enumFromInt(extras[node.data.extra]);
+                if (!name_idx.isNone() and @intFromEnum(name_idx) < self.ast.nodes.items.len) {
+                    const name_node = self.ast.getNode(name_idx);
+                    const name = self.ast.getText(name_node.span);
+                    try self.registerExportedName(name, name_node.span);
+                }
+            },
             else => {},
         }
     }
@@ -3363,7 +3373,7 @@ pub const SemanticAnalyzer = struct {
     /// visitNode 로 심볼 생성이 완료된 후 호출되어야 한다.
     ///
     /// Note: `collectExportedDeclNames` 와 동일한 AST 구조 (variable_declaration /
-    /// function_declaration / class_declaration) 를 순회한다. 지원 대상이 바뀌면
+    /// function_declaration / class_declaration / ts_enum_declaration) 를 순회한다. 지원 대상이 바뀌면
     /// 두 함수를 함께 갱신할 것 — 한쪽만 놓치면 이름은 exported 로 기록되는데
     /// 심볼 플래그가 안 세팅되거나 반대의 불일치가 발생한다.
     fn markExportedDeclSymbols(self: *SemanticAnalyzer, node: Node) void {
@@ -3386,6 +3396,16 @@ pub const SemanticAnalyzer = struct {
                 }
             },
             .function_declaration, .class_declaration => {
+                const extras = self.ast.extra_data.items;
+                if (node.data.extra >= extras.len) return;
+                const name_idx: NodeIndex = @enumFromInt(extras[node.data.extra]);
+                if (!name_idx.isNone() and @intFromEnum(name_idx) < self.ast.nodes.items.len) {
+                    const name_node = self.ast.getNode(name_idx);
+                    const name = self.ast.getText(name_node.span);
+                    self.markSymbolExported(name, false);
+                }
+            },
+            .ts_enum_declaration => {
                 const extras = self.ast.extra_data.items;
                 if (node.data.extra >= extras.len) return;
                 const name_idx: NodeIndex = @enumFromInt(extras[node.data.extra]);

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -962,6 +962,21 @@ test "Enum: export enum declaration" {
     try analyzeNoErrors("export enum Color { Red, Green }");
 }
 
+test "Enum: export enum declaration marks exported symbol" {
+    var r = try analyzeModule("export enum Color { Red, Green }");
+    defer r.deinit();
+
+    try std.testing.expect(r.analyzer.exported_names.contains("Color"));
+
+    var found = false;
+    for (r.analyzer.symbols.items) |sym| {
+        if (!std.mem.eql(u8, sym.nameText(r.parser.ast.source), "Color")) continue;
+        found = true;
+        try std.testing.expect(sym.decl_flags.is_exported);
+    }
+    try std.testing.expect(found);
+}
+
 test "Enum: default export" {
     try analyzeNoErrors("enum Status { Active }\nexport default Status;");
 }


### PR DESCRIPTION
## 요약
- RN dev server가 CLI 미지정 상태에서도 `dev=true`로 번들하도록 `devMode` 기본값과 config 우선순위를 수정했습니다.
- `export enum` 선언을 export binding/semantic exported symbol로 추적해 `sideEffects:false` 패키지의 RuntimeKind enum이 DCE에서 빠지지 않게 했습니다.
- RN RuntimeKind 회귀를 binding scanner, semantic analyzer, tree-shaker 테스트로 고정했습니다.

## /simplify 검토
- fallback 방식 대신 `export enum`을 export graph에 올리는 루트 원인 수정으로 정리했습니다.
- 미추적 예제 산출물과 local native artifact는 커밋에서 제외했습니다.

## 테스트
- `zig build test -Dtest-filter="export enum"`
- `zig build test -Dtest-filter="exported enum in sideEffects false"`
- `bun test ./packages/core/test/cli/react-native-dev-input/bundle-options/runtime-config.ts`
- `bun test ./packages/core/test/cli/args/basic.ts`
- bare RN prod/dev 번들에서 `RuntimeKind` enum IIFE 포함 확인
