### PR TITLE
perf(codegen): minify_syntax 시 if-return + 후속 return → return c?A:B (#3110)

### DIFF
--- a/src/codegen/codegen_test/basic.zig
+++ b/src/codegen/codegen_test/basic.zig
@@ -785,3 +785,68 @@ test "Codegen #3111: non-minify 는 do {} 유지 (anti-regression)" {
     defer r.deinit();
     try std.testing.expect(std.mem.indexOf(u8, r.output, "{") != null);
 }
+
+// ============================================================
+// #3110: list-level — `if(c)return A;` 바로 다음 형제가 `return B;` 면 `return c?A:B;`.
+//   (early-return inversion 등 나머지 list-level 평탄화는 후속.)
+// ============================================================
+
+test "Codegen #3110: if-return + 다음 return → return c?A:B" {
+    var r = try e2eMinAll(std.testing.allocator, "function h(){ if (c) return a; return b; }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){return c?a:b}", r.output);
+}
+
+test "Codegen #3110: block then-branch도 → return c?A:B" {
+    var r = try e2eMinAll(std.testing.allocator, "function h(){ if (c) { return a; } return b; }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){return c?a:b}", r.output);
+}
+
+test "Codegen #3110: member cond" {
+    var r = try e2eMinAll(std.testing.allocator, "function h(){ if (x.y) return 1; return 2; }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){return x.y?1:2}", r.output);
+}
+
+test "Codegen #3110: assignment cond 는 변환 안 함" {
+    var r = try e2eMinAll(std.testing.allocator, "function h(){ if (c = d) return a; return b; }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){if(c=d)return a;return b}", r.output);
+}
+
+test "Codegen #3110: then-branch 2개 statement 면 변환 안 함" {
+    var r = try e2eMinAll(std.testing.allocator, "function h(){ if (c) { return a; x(); } return b; }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){if(c){return a;x()}return b}", r.output);
+}
+
+test "Codegen #3110: if 에 else 가 있으면 list-level 변환 안 함" {
+    var r = try e2eMinAll(std.testing.allocator, "function h(){ if (c) return a; else d(); return b; }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){if(c)return a;else d();return b}", r.output);
+}
+
+test "Codegen #3110: return; (인자 없음) 은 변환 안 함" {
+    var r = try e2eMinAll(std.testing.allocator, "function h(){ if (c) return; return b; }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){if(c)return;return b}", r.output);
+}
+
+test "Codegen #3110: 다음 형제가 return 아니면 변환 안 함" {
+    var r = try e2eMinAll(std.testing.allocator, "function h(){ if (c) return a; f(); }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){if(c)return a;f()}", r.output);
+}
+
+test "Codegen #3110: return 뒤 dead code 는 그대로 (별도 DCE)" {
+    var r = try e2eMinAll(std.testing.allocator, "function h(){ if (c) return a; return b; x(); }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){return c?a:b;x()}", r.output);
+}
+
+test "Codegen #3110: minify_syntax off → 변환 안 함 (anti-regression)" {
+    var r = try e2eWithOptions(std.testing.allocator, "function h(){ if (c) return a; return b; }", .{ .minify_whitespace = true });
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function h(){if(c)return a;return b;}", r.output);
+}

--- a/src/codegen/statements.zig
+++ b/src/codegen/statements.zig
@@ -157,11 +157,19 @@ pub fn emitBracedList(self: anytype, node: Node) !void {
     const indices = self.ast.extra_data.items[list.start .. list.start + list.len];
     if (indices.len > 0) {
         self.indent_level += 1;
-        for (indices) |raw_idx| {
-            const idx: NodeIndex = @enumFromInt(raw_idx);
+        var i: usize = 0;
+        while (i < indices.len) : (i += 1) {
+            const idx: NodeIndex = @enumFromInt(indices[i]);
             if (isElidedStmt(self, idx)) continue;
             try writeNewline(self);
             try writeIndent(self);
+            // #3110: `if(c)return A;` 바로 다음 형제가 `return B;` 면 `return c?A:B;` 로 합침.
+            if (self.options.minify_syntax) {
+                if (try tryEmitReturnFallthrough(self, indices, i)) |consumed_j| {
+                    i = consumed_j; // loop 의 `: (i += 1)` 가 소비된 `return B;` 슬롯을 지나감
+                    continue;
+                }
+            }
             try self.emitNode(idx);
         }
         self.indent_level -= 1;
@@ -335,6 +343,40 @@ fn tryEmitIfReturnTernary(self: anytype, t: anytype) !bool {
     try emitIfReturnChainTail(self, t, true);
     try self.writeByte(';');
     return true;
+}
+
+/// statement list 의 `indices[i]` 가 `if(c)return A;` (else 없음/elided) 이고 바로 다음
+/// 출력 statement 가 `return B;` 면 `return c?A:B;` 를 emit 하고 소비한 `return B;` 의
+/// list 인덱스를 반환. 아니면 null. minify_syntax 전용 (emitBracedList 에서만 호출).
+/// `c` 가 paren 없이 `?:` test 자리에 올 수 있고, A/B 가 sequence(comma) / void 가 아닐 때만.
+fn tryEmitReturnFallthrough(self: anytype, indices: []const u32, i: usize) !?usize {
+    const if_node = self.ast.getNode(@enumFromInt(indices[i]));
+    if (if_node.tag != .if_statement) return null;
+    const t = if_node.data.ternary;
+    if (!t.c.isNone() and !isElidedAlternate(self, t.c)) return null; // else 가 있으면 #3095 가 처리
+    if (evalBooleanCondition(self, t.a) != null) return null; // 상수 조건은 DCE 가 처리 (더 작음)
+    if (!isSafeTernaryTest(self.ast.getNode(t.a).tag)) return null;
+    const a_arg = singleReturnArg(self, t.b) orelse return null;
+    if (self.ast.getNode(a_arg).tag == .sequence_expression) return null;
+    var j = i + 1;
+    while (j < indices.len and isElidedStmt(self, @enumFromInt(indices[j]))) : (j += 1) {}
+    if (j >= indices.len) return null;
+    const next = self.ast.getNode(@enumFromInt(indices[j]));
+    if (next.tag != .return_statement or next.data.unary.operand.isNone()) return null;
+    const b_arg = next.data.unary.operand;
+    if (self.ast.getNode(b_arg).tag == .sequence_expression) return null;
+    try self.write("return ");
+    try emitNoLineTerminatorOperand(self, t.a); // `return` 직후 cond — leading comment ASI 회피
+    try writeSpace(self);
+    try self.writeByte('?');
+    try writeSpace(self);
+    try self.emitNode(a_arg);
+    try writeSpace(self);
+    try self.writeByte(':');
+    try writeSpace(self);
+    try self.emitNode(b_arg);
+    try self.writeByte(';');
+    return j;
 }
 
 /// `idx` 가 `<expr>;` (expression statement) 이거나 그것 하나만 담은 block 이면 그 expr 의 idx,


### PR DESCRIPTION
## 무엇을

statement list 에서 `if(c)return A;` 바로 다음 형제가 `return B;` 면 `return c?A:B;` 로 합침:

```js
// 입력
function clamp(v,lo,hi){ if(v<lo) return lo; if(v>hi) return hi; return v; }
// 출력 (마지막 쌍부터 적용)
function clamp(v,s,l){if(v<s)return s;return v>l?l:v}
// 입력
function pick(c,a,b){ if(c) return a; return b; }
// 출력
function pick(c,a,b){return c?a:b}
```

esbuild/SWC 의 `mangleStmts` 류 statement-level 변환의 일부. Closes #3110 의 then-return fall-through 케이스. (cross-sibling 체인 `if(c1)return a1;if(c2)return a2;return b;` → `return c1?a1:c2?a2:b;` 및 early-return inversion `if(!c)return;rest` → `if(c){rest}` 는 후속.)

## 구현

`emitBracedList` 의 item loop 을 `for` → index 기반 `while` 로 바꿔, 합쳐진 `return B;` 슬롯을 건너뛸 수 있게 함. `tryEmitReturnFallthrough(self, indices, i) → ?usize` (소비한 형제 인덱스 반환):
- if 에 (비-elided) `else` 가 있으면 skip — `if(c)return A;else d();return B;` 는 `return c?A:B` 와 동치가 아님 (else 가 `d()` 실행). `#3095` 가 `if(c){return A}else{return B}` 를 처리.
- **상수 조건은 skip** — DCE 가 처리 (더 작음). (`--minify` 에선 `foldIf` 가 codegen 전에 DCE 하므로 사실상 도달 안 하지만 방어적으로.)
- cond 가 `?:` test 자리에 paren 없이 올 수 있고(`isSafeTernaryTest`), A/B 가 `sequence_expression`(comma) / void 가 아닐 때만.
- `return` 직후 cond 는 `emitNoLineTerminatorOperand` (leading comment 가 newline 끼우면 ASI 로 `return;` 되는 회귀 방지, `#3095` 와 동일).

## 안전성 (Zig 초보자용)

- `if(c)return A; return B;` ≡ `return c?A:B;` — `c` 한 번 평가, 그다음 A 또는 B, 그다음 return. then-branch 가 정확히 `return A;`(또는 `{return A;}` — non-elided statement 1개) 일 때만 (`singleReturnArg`/`singleNonElidedStmt`). `{x();return A;}` 처럼 2개면 변환 안 함.
- `if(c)return A;else{}` (빈 else) → `isElidedAlternate` true → no-else 취급 → 변환 OK (빈 else 는 no-op).
- `?:` arm 은 AssignmentExpression — `sequence`(comma)만 paren 필요라 그것만 거부. assignment/conditional/object literal 등은 그대로 OK. `return (a,b);` (paren 으로 감싼 sequence) 는 `parenthesized_expression` 라 통과 + parens 보존.
- class body / `emitProgram`(module top-level) 은 영향 없음 (전자는 item 이 `if_statement` 가 아님, 후자는 `return` 자체가 invalid).
- `return B;` 뒤에 dead code 가 있으면 그대로 둠 (원래도 dead — 별도 DCE 영역).

## 테스트

- TDD — `src/codegen/codegen_test/basic.zig` 에 `#3110` 10개: if-return + return / block then-branch / member cond / assignment cond(안 함) / 2-stmt then-branch(안 함) / else 있음(안 함) / `return;`(안 함) / 다음 형제가 return 아님(안 함) / return 뒤 dead code 유지 / minify_syntax off(안 함).
- `zig build test` 전체 통과. smoke (svelte / vue / react-dom / three / axios) 모두 baseline 출력 일치 (`MATCH`). 수기 케이스(clamp, pick, assignment-cond, dead-code) node 실행으로 원본과 동일 출력 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)