### PR TITLE
perf(minify): single-use identifier-alias inline — const x = foo → use(foo) (#3112)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1360,10 +1360,13 @@ pub fn emitModule(
     // dev 에서 아무 minify 안 하는 것과 동일한 trade-off.
     if (!options.dev_mode) {
         const minify_mod = @import("../transformer/minify.zig");
-        const ctx: minify_mod.MinifyCtx = if (module.semantic != null)
+        var ctx: minify_mod.MinifyCtx = if (module.semantic != null)
             minify_mod.MinifyCtx.fromSemantic(&module.semantic.?, transformer.symbol_ids.items, options.minify_syntax)
         else
             .empty;
+        // codegen/mangler 도 `transformer.symbol_ids` 를 읽으므로(override_syms → md.symbol_ids)
+        // alias inline 의 symbol_id 갱신이 전파됨. 동일 backing 의 mutable view.
+        ctx.symbol_ids_mut = transformer.symbol_ids.items;
         minify_mod.minify(transformer.ast, ctx, arena_alloc, root);
     }
 

--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -41,6 +41,11 @@ const unused_expr = @import("minify/unused_expr.zig");
 pub const MinifyCtx = struct {
     symbols: []const symbol_mod.Symbol,
     symbol_ids: []const ?u32,
+    /// `symbol_ids` 의 mutable view (동일 backing). single-use **identifier-alias** inline
+    /// 이 read 위치 노드의 symbol_id 를 init 식별자(`S`)의 것으로 갱신하는 데 필요 —
+    /// codegen/mangler 의 rename 조회가 symbol_id 기준이라(둘 다 `transformer.symbol_ids` 를
+    /// 읽음 = 단일 진실의 원천). null 이면 alias inline 자체를 skip (constant inline 무관).
+    symbol_ids_mut: ?[]?u32 = null,
     scopes: []const scope_mod.Scope,
     unresolved_globals: ?*const purity.GlobalRefSet,
     /// per-reference 배열. #1666 single-use inline 이 declaration ↔ read adjacency
@@ -718,7 +723,28 @@ fn tryInlineDecl(ast: *Ast, ctx: MinifyCtx, counts: []const u32, first_loc: []co
 
     const init_idx: NodeIndex = @enumFromInt(init_raw);
     if (init_idx.isNone()) return;
-    if (!isConstantExpr(ast, init_idx)) return;
+    const init_ni = @intFromEnum(init_idx);
+    if (init_ni >= ast.nodes.items.len) return;
+    const init_node = ast.nodes.items[init_ni];
+
+    // inline 대상 두 종류: ① 식별자 의존 없는 constant expr (mutable state 무관 → 위치 자유),
+    // ② **immutable binding 의 alias** — `const x = foo;` 에서 `foo` 가 재할당 없는 심볼
+    //   (const / import / param / function·class 선언명; write_count == 0). ②는 read 가 `x`
+    //   선언과 **같은 scope** 에 있을 때만 (아래 scope 검사) — 다른 scope 로 ref 를 옮기면
+    //   `foo` 의 이름이 그 scope 의 다른 binding 에 의해 shadow 될 수 있고, mangler 는
+    //   "outer 심볼 ref 가 그 이름을 shadow 하는 inner scope 안에 나타나는" 상황을 가정 안 함
+    //   (특히 1글자 이름은 skip 되어 원본 유지) → collision. 같은 scope 면 `foo` resolve 가
+    //   선언 위치와 동일하므로 그런 상황이 생기지 않음.
+    var alias_sym: ?u32 = null;
+    if (!isConstantExpr(ast, init_idx)) {
+        if (ctx.symbol_ids_mut == null) return; // alias inline 은 mutable symbol_ids 필요
+        if (init_node.tag != .identifier_reference) return;
+        if (init_ni >= ctx.symbol_ids.len) return;
+        const s = ctx.symbol_ids[init_ni] orelse return; // unresolved global → 불변성 확인 불가
+        if (s >= ctx.symbols.len or s == sym_id) return; // self-ref(`const x = x;`) 방어
+        if (ctx.symbols[s].write_count != 0) return; // 어딘가 재할당 → 불변 아님
+        alias_sym = s;
+    }
     if (!purity.isExprPure(ast, init_idx, ctx.unresolved_globals)) return;
 
     // 실측 identifier_reference 수 확인 — ref_deltas 를 감안한 ref_count 와 정확히 1 일치.
@@ -726,6 +752,20 @@ fn tryInlineDecl(ast: *Ast, ctx: MinifyCtx, counts: []const u32, first_loc: []co
     if (counts[sym_id] != 1) return;
     const read_ni = first_loc[sym_id];
     if (read_ni == std.math.maxInt(u32) or read_ni >= ast.nodes.items.len) return;
+
+    // alias inline: read 위치가 `x` 선언과 같은 scope 여야 안전 (위 주석). read 의 scope 는
+    // pre-minify `references` 에서 `node_index == read_ni` 인 항목으로 조회 — transformer 가
+    // 노드를 copy 했으면 매칭 실패(orphan) → 안전 보수적 skip.
+    if (alias_sym != null) {
+        var read_scope_ok = false;
+        for (ctx.references) |r| {
+            if (@intFromEnum(r.node_index) != read_ni) continue;
+            if (@intFromEnum(r.symbol_id) != sym_id) continue;
+            read_scope_ok = @intFromEnum(r.scope_id) == @intFromEnum(sym.scope_id);
+            break;
+        }
+        if (!read_scope_ok) return;
+    }
     // Forward-reference 검증 (#2195). read 가 declaration 이전이면 TDZ throw 대상이라
     // inline 금지 — `let x = 1; console.log(x)` 와 `console.log(x); let x = 1;` 의 의미가
     // 다름 (전자는 1, 후자는 ReferenceError). 이전엔 top-level 만 검증해 block-scoped
@@ -736,10 +776,6 @@ fn tryInlineDecl(ast: *Ast, ctx: MinifyCtx, counts: []const u32, first_loc: []co
     // 안전 우선 (semantic-preserving).
     if (sourceSpanStart(ast.nodes.items[read_ni]) <= sourceSpanStart(node)) return;
 
-    const init_ni = @intFromEnum(init_idx);
-    if (init_ni >= ast.nodes.items.len) return;
-    const init_node = ast.nodes.items[init_ni];
-
     // in-place swap: read 위치의 identifier_reference 를 init 의 tag/data 로 덮어쓴다.
     // init 의 자식은 extra_data 공유 → codegen 은 read_ni 에서 init 전체를 출력.
     // span 은 init 의 것을 사용 (source map 에서 inlined 값의 위치 유지).
@@ -748,6 +784,14 @@ fn tryInlineDecl(ast: *Ast, ctx: MinifyCtx, counts: []const u32, first_loc: []co
         .span = init_node.span,
         .data = init_node.data,
     };
+    // alias inline: codegen/mangler 의 rename 조회가 symbol_id 기준이므로 read 위치의
+    // symbol_id 를 `S` 로 갱신. ref count 는 불변 — init 의 `S`-ref 가 read 위치로 "이동"
+    // 하고, decl 제거로 orphan 되는 init 노드가 `reference_count(S)` 를 balance.
+    if (alias_sym) |s| {
+        if (ctx.symbol_ids_mut) |sids| {
+            if (read_ni < sids.len) sids[read_ni] = s;
+        }
+    }
 
     replaceNode(ast, decl_stmt_idx, .{
         .tag = .empty_statement,

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -761,8 +761,10 @@ fn expectMinifyDead(body: []const u8, expected: []const u8) !void {
     const ctx: minify_mod.MinifyCtx = .{
         .symbols = analyzer.symbols.items,
         .symbol_ids = transformer.symbol_ids.items,
+        .symbol_ids_mut = transformer.symbol_ids.items, // alias inline (#3112)
         .scopes = analyzer.scopes.items,
         .unresolved_globals = null,
+        .references = analyzer.references.items,
     };
     minify_mod.minify(transformer.ast, ctx, a, root);
     minify_mod.mergeDecls(transformer.ast, null);
@@ -822,12 +824,37 @@ test "dead store: read 1회 + literal init — Phase 2 inline" {
     );
 }
 
-test "dead store: read 1회 + 비-constant init — 보존 (inline 조건 미충족)" {
-    // Phase 2+3 inline 은 init 이 constant-expression 일 때만 동작. 식별자 의존이
-    // 있는 init (예: 파라미터) 은 inline 제외 → 원래 dead-store "read>=1 보존" 경로.
+test "single-use inline #3112: immutable binding 의 alias (같은 scope read) 는 inline" {
+    // `let x = n` 에서 `n` 은 재할당 없는 파라미터(write_count == 0) → `x` 는 불변 alias.
+    // `return x` 가 `let x` 와 같은 scope → read 위치를 `n` 으로 치환 + symbol_id 갱신, decl 제거.
     try expectMinifyDead(
         "function f(n) { let x = n; return x; } f(1);",
-        "function run() {\n\tfunction f(n) {\n\t\tlet x = n;\n\t\treturn x;\n\t}\n\tf(1);\n}\nrun();",
+        "function run() {\n\tfunction f(n) {\n\t\t;\n\t\treturn n;\n\t}\n\tf(1);\n}\nrun();",
+    );
+}
+
+test "single-use inline #3112: alias read 가 nested scope 면 보존 (shadow collision 회피)" {
+    // `q` 의 read(`return q + p`)가 `const q` 와 다른 scope(inner block) → ref 를 옮기면
+    // inner `let p` 가 outer `p` 를 shadow 하는 자리에 ref 가 가 mangler 가 처리 못함 → skip.
+    try expectMinifyDead(
+        "function f(p) { const q = p; { let p = compute(); use(p); return q + p; } } f(1);",
+        "function run() {\n\tfunction f(p) {\n\t\tconst q = p;\n\t\t{\n\t\t\tlet p = compute();\n\t\t\tuse(p);\n\t\t\treturn q + p;\n\t\t}\n\t}\n\tf(1);\n}\nrun();",
+    );
+}
+
+test "single-use inline #3112: 재할당되는 binding 의 alias 는 보존 (immutable 아님)" {
+    try expectMinifyDead(
+        "function f(n) { let x = n; n = 9; return x; } f(1);",
+        "function run() {\n\tfunction f(n) {\n\t\tlet x = n;\n\t\tn = 9;\n\t\treturn x;\n\t}\n\tf(1);\n}\nrun();",
+    );
+}
+
+test "single-use inline #3112: const 의 alias (같은 scope) 도 inline" {
+    // `const c = obj(); const a = c; return [a, c];` — `a` 는 `c`(const, write_count 0) alias,
+    // `return [a, c]` 가 `const a` 와 같은 scope → inline → `c` 가 2회 사용이라 더 안 함.
+    try expectMinifyDead(
+        "function f(){ const c = obj(); const a = c; return [a, c]; } f();",
+        "function run() {\n\tfunction f() {\n\t\tconst c = obj();\n\t\t;\n\t\treturn [c, c];\n\t}\n\tf();\n}\nrun();",
     );
 }
 

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -1037,6 +1037,9 @@ fn transpileWithCallbackInternal(
         const ctx: minify_mod.MinifyCtx = .{
             .symbols = analyzer.symbols.items,
             .symbol_ids = transformer.symbol_ids.items,
+            // 동일 backing 의 mutable view — codegen/mangler 도 `transformer.symbol_ids` 를
+            // 읽으므로(mangle_metadata.symbol_ids) alias inline 의 symbol_id 갱신이 전파됨.
+            .symbol_ids_mut = transformer.symbol_ids.items,
             .scopes = analyzer.scopes.items,
             .unresolved_globals = null,
             .references = analyzer.references.items,


### PR DESCRIPTION
## 무엇을

minify 의 single-use inline 을 **identifier-alias** 까지 확장:

```js
// 입력
function f(p){ const q = p; return q + g(p); }
import { readFileSync as rfs } from "node:fs";
function h(){ const r = rfs; return typeof r; }
// 출력
function f(p){ return p + g(p); }
function h(){ return typeof rfs; }
```

조건: `foo` 가 **재할당 없는 심볼**(`write_count == 0` — const / import / param / function·class 선언명)이고, `x` 의 **유일한 read** 가 `const x = foo` 선언과 **같은 scope** 에 있을 때만. Closes #3112.

기존 `inlineSingleUse`/`tryInlineDecl` 은 init 이 constant literal/array/object 일 때만 inline 했습니다. esbuild `substituteSingleUseSymbolInExpr` 류.

## 2차 root cause 처리 (이전 PoC 가 wrong output 냈던 이유)

`const x = foo` 의 read 를 **다른 scope** 로 옮기면 그 scope 에 `foo` 와 같은 이름의 binding(`let foo` 등)이 있을 때 `foo` 가 그쪽으로 lexical resolve 됩니다. mangler 는 "어떤 심볼 `S` 의 ref 가 `S` 의 이름을 shadow 하는 inner scope 안에 나타나는" 상황을 가정하지 않습니다 — valid 한 소스 AST 에선 절대 안 생기는 상황이라(inner binding 이 무조건 이김), mangler 의 이 가정은 건전합니다. 특히 1글자 이름은 `shouldSkip` 으로 원본 유지 → param `p` 와 inner `let p` 둘 다 `p` → 옮긴 ref 가 `return p+p` 로 collision.

→ **fix**: alias inline 이 그런 AST 를 만들지 않게 — read 가 `x` 선언과 **같은 scope** 일 때만 적용. 같은 scope 면 `foo` 가 선언 위치와 동일하게 resolve 됨(다른 binding 이 있었으면 `const x = foo` 가 그걸 resolve 했을 것 — 모순). invariant 를 깨지 않는 게 transform 의 책임이지 mangler 를 cross-scope-shadow 까지 처리하게 만드는 게 아님 (delicate component 에 광범위 영향, 마진 이득). read scope 는 pre-minify `references` 의 `node_index == read_ni` 항목으로 조회 — transformer 가 copy 한 노드면 orphan 매칭 실패 → 보수적 skip.

## 구현 (Zig 초보자용)

- `MinifyCtx.symbol_ids_mut: ?[]?u32` — `symbol_ids` 의 mutable view(동일 backing). alias inline 시 read 노드의 symbol_id 를 `S` 로 갱신해야 codegen/mangler 의 rename 조회(둘 다 `transformer.symbol_ids` 를 읽음 = 단일 진실의 원천)가 맞음. `transpile.zig`/`emitter.zig` 에서 `transformer.symbol_ids.items` 전달.
- `tryInlineDecl`: `!isConstantExpr(init)` 일 때 — init 이 `identifier_reference` → `S = symbol_ids[init_ni]` (unresolved global 이면 null → skip), `S != x`, `write_count(S) == 0` → `alias_sym = S`. read scope 검사 통과 시 read 노드를 `foo` 로 overwrite + `symbol_ids_mut[read_ni] = S`, decl 제거. ref count 불변 (orphan 된 init ref 가 transferred read ref 를 balance).
- mangler 는 minify **전에** 돌아서(linker.computeMangling / transpile mangle 이 minify 보다 먼저) renames 를 pre-minify AST 로 계산 — same-scope 조건이면 `S` 가 이미 `x` scope 에서 alive(`const x = foo` init ref 가 거기 있었음)이라 mangled name 이 read 위치에서 valid.

## 테스트

- TDD — `src/transformer/minify_test.zig` 에 `#3112` 4개: param alias (같은 scope) → inline / read 가 nested scope → 보존(shadow collision 회피) / 재할당되는 binding alias → 보존 / const alias (같은 scope) → inline + 그 const 가 2회 사용되면 더 안 함. (기존 "비-constant init 보존" 테스트는 이 동작 변경 반영해 갱신.)
- `zig build test` 전체 통과. smoke (svelte / vue / react / react-dom / three / preact / solid-js / axios / express) 모두 baseline 출력 일치 (`MATCH`). 수기 케이스(param alias, import alias, shadowing → 보존, const-alias chain, 재할당 → 보존, nested-read → 보존) node 실행으로 원본과 동일 출력 확인.
- size: 이 fixture 들에선 작음 (vue −15 B, svelte 변화 없음 — alias 의 read 가 대부분 nested scope 라 보수적 gate 에 걸림). identifier alias 가 많은 일반 앱 코드에선 비례 증가. `symbol_ids_mut` 인프라 + alias-inline 패턴은 향후 ref 를 옮기는 minify 변형의 토대.

🤖 Generated with [Claude Code](https://claude.com/claude-code)