### PR TITLE
refactor(resolver): DirEntryCache — readdir outside the lock, pointer-stable entries

### DIFF
--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -80,11 +80,20 @@ fn matchTsPathEntry(entry: @import("../config.zig").TsConfig.PathEntry, specifie
 /// 디렉토리 엔트리 캐시 (esbuild 방식).
 /// 디렉토리를 처음 접근할 때 readdir()로 파일 목록을 통째로 읽어 캐시.
 /// 이후 같은 디렉토리의 파일 존재 확인은 syscall 없이 메모리 조회.
-/// 멀티스레드 resolve에서 공유되므로 mutex로 보호.
+///
+/// 멀티스레드 resolve 에서 공유된다. 두 가지 contention 회피:
+///   1. **읽기는 `RwLock` 의 shared lock** — 캐시 hit 가 압도적으로 많고(워밍업 후
+///      readdir 거의 없음) 서로 막지 않게.
+///   2. **readdir + EntrySet 빌드는 lock 을 안 쥔 채** 수행하고, 다 만든 뒤 짧게
+///      exclusive lock 을 잡아 삽입. 예전엔 첫 스레드가 느린 readdir syscall 을
+///      global mutex 를 쥔 채로 돌려서 나머지 worker 를 전부 막았다.
+///
+/// `EntrySet` 은 heap 에 두고 map 에는 `*EntrySet` 만 저장 — `getOrLoad` 가 돌려준
+/// 포인터가 이후 다른 스레드의 삽입(map rehash)에도 dangling 되지 않게 한다.
 pub const DirEntryCache = struct {
-    /// 디렉토리 절대 경로 → 엔트리 집합. null이면 디렉토리가 존재하지 않음.
-    cache: std.StringHashMap(?EntrySet),
-    mutex: std.Thread.Mutex = .{},
+    /// 디렉토리 절대 경로 → 엔트리 집합. null이면 디렉토리가 존재하지 않음 (negative 캐시).
+    cache: std.StringHashMap(?*EntrySet),
+    rwlock: std.Thread.RwLock = .{},
     allocator: std.mem.Allocator,
 
     const EntrySet = struct {
@@ -94,7 +103,7 @@ pub const DirEntryCache = struct {
 
     pub fn init(allocator: std.mem.Allocator) DirEntryCache {
         return .{
-            .cache = std.StringHashMap(?EntrySet).init(allocator),
+            .cache = std.StringHashMap(?*EntrySet).init(allocator),
             .allocator = allocator,
         };
     }
@@ -102,17 +111,20 @@ pub const DirEntryCache = struct {
     pub fn deinit(self: *DirEntryCache) void {
         var it = self.cache.iterator();
         while (it.next()) |entry| {
-            if (entry.value_ptr.*) |*set| {
-                var fit = set.files.keyIterator();
-                while (fit.next()) |k| self.allocator.free(k.*);
-                set.files.deinit();
-                var dit = set.dirs.keyIterator();
-                while (dit.next()) |k| self.allocator.free(k.*);
-                set.dirs.deinit();
-            }
+            if (entry.value_ptr.*) |set| self.destroyEntrySet(set);
             self.allocator.free(entry.key_ptr.*);
         }
         self.cache.deinit();
+    }
+
+    fn destroyEntrySet(self: *DirEntryCache, set: *EntrySet) void {
+        var fit = set.files.keyIterator();
+        while (fit.next()) |k| self.allocator.free(k.*);
+        set.files.deinit();
+        var dit = set.dirs.keyIterator();
+        while (dit.next()) |k| self.allocator.free(k.*);
+        set.dirs.deinit();
+        self.allocator.destroy(set);
     }
 
     /// 디렉토리 내 파일 존재 확인. 캐시 미스 시 readdir() 후 캐시.
@@ -137,63 +149,66 @@ pub const DirEntryCache = struct {
     }
 
     fn getOrLoad(self: *DirEntryCache, dir_path: []const u8) ?*const EntrySet {
-        self.mutex.lock();
-        defer self.mutex.unlock();
-
-        if (self.cache.get(dir_path)) |maybe_set| {
-            if (maybe_set) |*set| return set;
-            return null; // 디렉토리 없음 (캐시된 negative)
+        // 1. fast path — shared lock 으로 조회.
+        {
+            self.rwlock.lockShared();
+            defer self.rwlock.unlockShared();
+            if (self.cache.get(dir_path)) |maybe_set| return maybe_set;
         }
 
-        // 캐시 미스 → readdir
-        const entries = fs.listDir(self.allocator, dir_path) catch {
-            // 디렉토리 없음 → negative 캐시
-            const key = self.allocator.dupe(u8, dir_path) catch return null;
-            self.cache.put(key, null) catch {
-                self.allocator.free(key);
-                return null;
-            };
+        // 2. 캐시 미스 — lock 없이 readdir + EntrySet 빌드.
+        const built: ?*EntrySet = self.buildEntrySet(dir_path);
+
+        // 3. exclusive lock 으로 삽입. 그 사이 다른 스레드가 먼저 넣었을 수 있다.
+        self.rwlock.lock();
+        defer self.rwlock.unlock();
+        if (self.cache.get(dir_path)) |existing| {
+            if (built) |b| self.destroyEntrySet(b);
+            return existing;
+        }
+        const key = self.allocator.dupe(u8, dir_path) catch {
+            if (built) |b| self.destroyEntrySet(b);
             return null;
         };
-        // entries 의 name 은 cache 에 소유권 이전되거나 free 됨 — slice 자체만 free.
+        self.cache.put(key, built) catch {
+            self.allocator.free(key);
+            if (built) |b| self.destroyEntrySet(b);
+            return null;
+        };
+        return built;
+    }
+
+    /// readdir() 후 heap 에 `EntrySet` 을 만들어 반환. 디렉토리가 없거나 OOM 이면 null
+    /// (호출자는 negative 로 캐시) — 기존 동작과 동일.
+    fn buildEntrySet(self: *DirEntryCache, dir_path: []const u8) ?*EntrySet {
+        const entries = fs.listDir(self.allocator, dir_path) catch return null;
+        // entries 의 name 은 hashmap 으로 소유권 이전되거나 free 됨 — slice 자체만 free.
         defer self.allocator.free(entries);
 
-        var files = std.StringHashMap(void).init(self.allocator);
-        var dirs = std.StringHashMap(void).init(self.allocator);
+        const set = self.allocator.create(EntrySet) catch {
+            for (entries) |entry| self.allocator.free(entry.name);
+            return null;
+        };
+        set.* = .{
+            .files = std.StringHashMap(void).init(self.allocator),
+            .dirs = std.StringHashMap(void).init(self.allocator),
+        };
 
         for (entries) |entry| {
             switch (entry.kind) {
-                .file => files.put(entry.name, {}) catch {
-                    self.allocator.free(entry.name);
-                },
-                .directory => dirs.put(entry.name, {}) catch {
-                    self.allocator.free(entry.name);
-                },
+                .file => set.files.put(entry.name, {}) catch self.allocator.free(entry.name),
+                .directory => set.dirs.put(entry.name, {}) catch self.allocator.free(entry.name),
                 .symlink => {
                     // symlink는 대상이 파일인지 디렉토리인지 readdir만으로 알 수 없으므로 양쪽에 등록.
                     // Linux의 bun install이 node_modules에 symlink 디렉토리를 만들기 때문에 필수.
-                    files.put(entry.name, {}) catch {};
+                    set.files.put(entry.name, {}) catch {};
                     const name2 = self.allocator.dupe(u8, entry.name) catch continue;
-                    dirs.put(name2, {}) catch {
-                        self.allocator.free(name2);
-                    };
+                    set.dirs.put(name2, {}) catch self.allocator.free(name2);
                 },
                 else => self.allocator.free(entry.name),
             }
         }
-
-        const key = self.allocator.dupe(u8, dir_path) catch return null;
-        const set = EntrySet{ .files = files, .dirs = dirs };
-        self.cache.put(key, set) catch {
-            self.allocator.free(key);
-            return null;
-        };
-
-        // cache.get은 포인터 안정적 (StringHashMap 내부 포인터)
-        if (self.cache.getPtr(key)) |ptr| {
-            if (ptr.*) |*s| return s;
-        }
-        return null;
+        return set;
     }
 };
 

--- a/src/bundler/resolver_test.zig
+++ b/src/bundler/resolver_test.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const resolver_mod = @import("resolver.zig");
 const Resolver = resolver_mod.Resolver;
+const DirEntryCache = resolver_mod.DirEntryCache;
 const AliasEntry = resolver_mod.AliasEntry;
 const ModuleType = @import("types.zig").ModuleType;
 const isRelativeOrAbsolute = resolver_mod.isRelativeOrAbsolute;
@@ -492,4 +493,73 @@ test "resolve.alias — multiple entries first match wins" {
     const result = try Resolver.applyAlias(std.testing.allocator, aliases, "react");
     defer std.testing.allocator.free(result.?);
     try std.testing.expectEqualStrings("preact/compat", result.?);
+}
+
+// ============================================================
+// DirEntryCache
+// ============================================================
+
+test "DirEntryCache: hasFile / hasDir / negative 캐시" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try createFile(tmp.dir, "a.ts");
+    try createFile(tmp.dir, "sub/b.ts");
+
+    const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dir_path);
+    const sub_path = try std.fs.path.join(std.testing.allocator, &.{ dir_path, "sub" });
+    defer std.testing.allocator.free(sub_path);
+    const missing_path = try std.fs.path.join(std.testing.allocator, &.{ dir_path, "nope" });
+    defer std.testing.allocator.free(missing_path);
+
+    var cache = DirEntryCache.init(std.testing.allocator);
+    defer cache.deinit();
+
+    // 첫 조회 → readdir, 두 번째 → 캐시 hit. 결과는 동일해야 한다.
+    try std.testing.expect(cache.hasFile(dir_path, "a.ts"));
+    try std.testing.expect(cache.hasFile(dir_path, "a.ts"));
+    try std.testing.expect(!cache.hasFile(dir_path, "missing.ts"));
+    try std.testing.expect(cache.hasDir(dir_path, "sub"));
+    try std.testing.expect(!cache.hasDir(dir_path, "a.ts")); // 파일은 dir 아님
+    try std.testing.expect(cache.hasFile(sub_path, "b.ts"));
+
+    // 존재하지 않는 디렉토리 → negative 캐시 (반복 조회해도 일관)
+    try std.testing.expect(!cache.hasFile(missing_path, "x.ts"));
+    try std.testing.expect(!cache.hasFile(missing_path, "x.ts"));
+    try std.testing.expect(!cache.dirExists(missing_path));
+    try std.testing.expect(cache.dirExists(sub_path));
+}
+
+test "DirEntryCache: 동시 조회 — 같은 디렉토리에 여러 스레드" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    inline for (.{ "f0.ts", "f1.ts", "f2.ts", "f3.ts" }) |name| try createFile(tmp.dir, name);
+    // 디렉토리도 여러 개 — cache 가 readdir 미스를 lock 밖에서 처리하는 경로를 동시에 친다.
+    inline for (.{ "d0", "d1", "d2", "d3" }) |name| try tmp.dir.makePath(name);
+
+    const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dir_path);
+
+    var cache = DirEntryCache.init(std.testing.allocator);
+    defer cache.deinit();
+
+    const Worker = struct {
+        fn run(c: *DirEntryCache, base: []const u8) void {
+            var i: usize = 0;
+            while (i < 200) : (i += 1) {
+                _ = c.hasFile(base, "f1.ts");
+                _ = c.hasFile(base, "missing.ts");
+                _ = c.hasDir(base, "d2");
+            }
+        }
+    };
+
+    var threads: [4]std.Thread = undefined;
+    for (&threads) |*t| t.* = try std.Thread.spawn(.{}, Worker.run, .{ &cache, dir_path });
+    for (threads) |t| t.join();
+
+    // 경합 후에도 정답은 그대로.
+    try std.testing.expect(cache.hasFile(dir_path, "f1.ts"));
+    try std.testing.expect(!cache.hasFile(dir_path, "missing.ts"));
+    try std.testing.expect(cache.hasDir(dir_path, "d2"));
 }


### PR DESCRIPTION
## 문제

`DirEntryCache.getOrLoad` 가 global `std.Thread.Mutex` 를 쥔 채로 — `readdir` syscall + `files`/`dirs` 두 개의 `StringHashMap` 빌드 + 모든 entry name `dup` — 까지 전부 처리합니다. 멀티스레드 resolve(번들러 discover phase)에서 첫 스레드가 어떤 디렉토리를 처음 만지면 그 readdir 가 끝날 때까지 나머지 worker 가 전부 이 한 mutex 앞에서 블록됩니다. node_modules 디렉토리 수백 개 → 수백 번의 직렬화된 readdir.

추가로, `getOrLoad` 가 `defer self.mutex.unlock()` 이후 `*const EntrySet`(map 내부 값 포인터)를 caller 에게 돌려주는데, 그 포인터를 쓰기 전에 다른 스레드의 `cache.put` 이 `StringHashMap` 을 rehash 하면 내부 storage 가 재배치되어 포인터가 dangling 됩니다. 워밍업 중(읽기/삽입 동시) 터질 수 있는 latent heisenbug.

## 변경

- **`EntrySet` 을 heap 에 두고** map 에는 `?*EntrySet` 만 저장 — `getOrLoad` 가 돌려준 포인터가 이후 다른 스레드의 삽입(rehash)에도 안정. (`null` = negative 캐시 = 디렉토리 없음.)
- **`getOrLoad` 2단계**: ① shared lock 으로 조회 → ② 미스면 **lock 없이** `readdir` + `EntrySet` 빌드 → ③ exclusive lock 으로 **짧게** 삽입 (그 사이 다른 스레드가 먼저 넣었으면 내가 만든 건 폐기). 느린 syscall 이 critical section 밖으로 빠짐.
- `std.Thread.Mutex` → `std.Thread.RwLock` — 캐시 hit 가 압도적으로 많으니(워밍업 후 readdir 거의 없음) reader 끼리는 안 막게.
- **`DirEntryCache` 직접 테스트 추가** — 기존엔 커버리지 0 이었음 (`resolver_test.zig` 의 `Resolver` 는 `dir_cache == null` 이라 `fs.statFile` 폴백 경로만 탔다). hasFile/hasDir/negative 캐시 동작 + 4-thread 동시 조회 smoke.

## 솔직한 perf 노트

react-native-bare 번들(FS warm)에서 **wall time 변화 없음** — 그래프 discover phase 의 병렬 scaling 한계는 `DirEntryCache` lock 경합이 아니라 직렬 `graph.resync` / `finalize` tail 쪽이었습니다(별도 분석 중). 이 PR 은 (a) 위 dangling-pointer 버그 제거, (b) cold FS / CI / 대형 그래프(수천 모듈)에서의 readdir-under-lock 경합 제거 — 정정·견고화 성격입니다. "이 벤치를 N% 빠르게" 는 아닙니다.

## Zig 초보자용 설명

- `std.Thread.RwLock` = 읽기/쓰기 락. `lockShared()`/`unlockShared()` 는 여러 스레드가 **동시에** 들 수 있고(읽기 전용), `lock()`/`unlock()` 은 한 명만(쓰기). 캐시처럼 "읽기 99% / 쓰기 1%" 워크로드에 적합.
- `allocator.create(T)` / `allocator.destroy(ptr)` = 단일 값 `T` 를 heap 에 할당/해제. 여기선 `EntrySet` 을 heap 에 둬서, 그걸 가리키는 포인터가 바깥 hashmap 이 어떻게 커지든 그대로 유효하게 만듦 (hashmap **값**의 주소는 rehash 때 바뀔 수 있지만 그 안에 넣은 **포인터가 가리키는 대상**은 안 바뀜).
- double-checked 삽입: `lock 없이 비싼 작업 → lock 잡고 "그새 누가 넣었나?" 재확인 → 없으면 내 것 삽입, 있으면 폐기`. 비싼 작업(readdir)을 락 밖으로 빼면서도 중복 삽입을 막는 흔한 패턴.

## 테스트
- `zig build test` ✅ 전체
- `tests/integration`: `bundle-smoke` 150/150, `resolve-fallback` / `pnpm-bundle` / `bundle-circular-cycle` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)