### PR TITLE
perf(bundler): skip transformer pre-pass for plain node_modules modules

### DIFF
--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -41,8 +41,18 @@ pub fn shouldRun(
 
         // Check cheap single-byte flags before the heavier option predicate.
         if (self.minify_identifiers) return true;
-        if (self.react_refresh or self.styled_components or self.emotion or self.worklet_transform) {
-            return true;
+        // react_refresh / styled-components / emotion 은 emitter·`run` 과 마찬가지로 user
+        // code 에만 적용된다 (`/node_modules/` 밖). node_modules 의 plain ESM/ES5 dep 까지
+        // pre-pass 를 돌리던 게 가장 큰 낭비였다 — 그 모듈들은 helper import 도 안 만든다.
+        const is_user_code = std.mem.indexOf(u8, module.path, "/node_modules/") == null;
+        if (is_user_code and (self.react_refresh or self.styled_components or self.emotion)) return true;
+        // worklet 변환은 react-native / @react-native 코어를 제외한 모든 모듈 대상 (`run` 의
+        // exclude_worklet 과 동일). 워크릿 디렉티브가 없으면 plugin 은 no-op 이지만, 변환이
+        // helper 를 주입할 수 있으니 게이트는 보수적으로 유지.
+        if (self.worklet_transform) {
+            const is_rn_core = std.mem.indexOf(u8, module.path, "/node_modules/react-native/") != null or
+                std.mem.indexOf(u8, module.path, "/node_modules/@react-native/") != null;
+            if (!is_rn_core) return true;
         }
     }
 


### PR DESCRIPTION
## 문제

`transform_prepass.shouldRun` (graph 단계 pre-pass 게이트) 는 `react_refresh || styled_components || emotion || worklet_transform` 중 하나라도 전역으로 켜져 있으면 **모든 JS 모듈**에 pre-pass 를 실행했습니다. RN 빌드는 `react_refresh` 가 기본 on 이라 → node_modules 의 plain ESM/ES5 dep 수백 개도 전부 pre-pass 대상.

그런데 `transform_prepass.run` 은 이 변환들을 `is_user_code` (`module.path` 에 `/node_modules/` 없음) 일 때만 적용합니다 (`opts.react_refresh = self.react_refresh and is_user_code;` 등). 즉 node_modules dep 에 대해 pre-pass 는 transformer 를 통째 한 번 돌리고 → 그 결과 AST 로 semantic/import/binding/StmtInfo 를 다시 만들고 → 결국 아무것도 안 바뀜. pre-pass 의 유일한 존재 이유는 "transformer 가 주입하는 runtime helper import 를 link 전에 graph 에 등록" 인데, plain dep 은 helper import 를 안 만들기 때문에 통째로 헛수고였습니다.

## 변경

`shouldRun` 의 Gate 1 을 `run` 의 휴리스틱과 일치시킴:
- `react_refresh / styled_components / emotion` → **user code 일 때만** 게이트 통과 (`run` 과 동일).
- `worklet_transform` → **react-native / @react-native 코어를 제외한 모듈** 일 때만 (`run` 의 `exclude_worklet` 과 동일). 워크릿 디렉티브가 없으면 plugin 은 no-op 이지만, 변환이 helper 를 주입할 수 있어 게이트는 보수적으로 유지.
- node_modules plain dep 은 이제 Gate 2 (`ast.has_jsx / has_decorator / has_ts_namespace_or_enum / ...`) 와 Gate 3 (`requiresGraphPrePass` — define 참조, `--minify-syntax`, downlevel feature 등) 만 통과하면 pre-pass.

## 측정 (react-native-bare 번들)

- pre-pass 실행 횟수: **935 → 665** (~29% 감소).
- discover phase aggregate CPU: ~1s 절감.
- **wall time: 변화 없음** (~1.53s). pre-pass 는 병렬 discover phase 안에 있고, 측정해보면 이 빌드의 wall 임계경로는 discover 가 아니라 emit + 직렬 구간입니다. 그래서 이건 "모듈 수 많은 빌드 / 코어 적은 머신 / 메모리 압박" 측면의 개선이지 이 벤치의 headline 단축은 아닙니다 — 솔직히 적어둡니다.
- 한계: `worklet_transform` 이 켜진 프로젝트(reanimated)에서는 RN 코어 외 모든 모듈이 여전히 게이트를 통과합니다 (워크릿 디렉티브 유무를 parser 플래그 없이 싸게 알 수 없어서). 그쪽 추가 최적화는 후속.

## 테스트
- `zig build test` ✅ 전체
- `tests/integration`: `bundle-smoke` 150/150, `es5-rn` 30/30

🤖 Generated with [Claude Code](https://claude.com/claude-code)