### PR TITLE
chore(profile): break down `metadata` phase into sub-phases

### DIFF
--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -204,7 +204,11 @@ pub fn buildMetadataForAst(
     // 래핑 모듈: import를 skip하지 않음 (emitImportCJS가 처리).
     // scope hoisted 타겟 import만 import_bindings 루프에서 개별 skip.
     const skip_imports = !m.wrap_kind.isWrapped();
-    var skip_nodes = try buildSkipNodes(self.allocator, ast, skip_imports);
+    var skip_nodes = blk: {
+        var sn_scope = profile.begin(.metadata_skip_nodes);
+        defer sn_scope.end();
+        break :blk try buildSkipNodes(self.allocator, ast, skip_imports);
+    };
     errdefer skip_nodes.deinit();
 
     var renames = std.AutoHashMap(u32, []const u8).init(self.allocator);
@@ -294,6 +298,8 @@ pub fn buildMetadataForAst(
     // collectExportsRecursive DFS 를 한 번만 수행하도록 공유 (#1734).
 
     if (sem.scope_maps.len > 0) {
+        var ib_scope = profile.begin(.metadata_import_bindings);
+        defer ib_scope.end();
         const module_scope = sem.scope_maps[0];
 
         // export된 local name을 미리 수집 — namespace import가 re-export되는지 O(1) 확인용
@@ -713,7 +719,11 @@ pub fn buildMetadataForAst(
         // nested rename 을 `Linker.unified_result` 에서 조회. Phase A (module
         // scope) 은 위 self-rename 루프에서 canonical_name 경유로 이미 처리됨.
         // metadata 가 dupe 하여 소유 — unified_result 가 deinit 되어도 안전.
-        mergeUnifiedPhaseB(self, module_index, &renames, &owned_nested_renames) catch {};
+        {
+            var mb_scope = profile.begin(.metadata_merge_phase_b);
+            defer mb_scope.end();
+            mergeUnifiedPhaseB(self, module_index, &renames, &owned_nested_renames) catch {};
+        }
     }
 
     // Side-effect-only import has no ImportBinding, so scope-hoisted modules that
@@ -774,12 +784,16 @@ pub fn buildMetadataForAst(
     }
 
     // 3. 엔트리 포인트 final exports
-    const final_export_entries = try self.buildFinalExports(
-        is_entry,
-        module_index,
-        m.export_bindings,
-        &owned_nested_renames,
-    );
+    const final_export_entries = blk: {
+        var fe_scope = profile.begin(.metadata_final_exports);
+        defer fe_scope.end();
+        break :blk try self.buildFinalExports(
+            is_entry,
+            module_index,
+            m.export_bindings,
+            &owned_nested_renames,
+        );
+    };
 
     // 크로스-모듈 상수 인라인: import binding의 canonical export가 상수이면 매핑
     const const_values = try self.buildCrossModuleConstValues(self.getModule(module_index).?, sem);
@@ -787,14 +801,22 @@ pub fn buildMetadataForAst(
     // ns_member_rewrites / ns_inline_objects 소유권 이동 + namespace preamble 생성.
     // finalizeNamespaceData가 리스트를 소비(deinit)하므로, 이후 에러 시
     // errdefer가 이미 해제된 리스트에 접근하지 않도록 마지막에 호출한다.
-    const ns_result = try finalizeNamespaceData(self.allocator, &ns_rewrite_list, &ns_inline_list, cjs_import_preamble);
+    const ns_result = blk: {
+        var ns_scope = profile.begin(.metadata_finalize_ns);
+        defer ns_scope.end();
+        break :blk try finalizeNamespaceData(self.allocator, &ns_rewrite_list, &ns_inline_list, cjs_import_preamble);
+    };
     const ns_rewrites = ns_result.rewrites;
     const ns_inlines = ns_result.inlines;
     const combined_preamble = ns_result.combined_preamble;
 
     // ESM+CJS 혼합 모듈(esm_with_dynamic_fallback)이 scope hoisting될 때
     // 내부 require() 호출도 require_xxx()로 치환해야 함.
-    const require_rewrites = try self.buildRequireRewrites(&m);
+    const require_rewrites = blk: {
+        var rr_scope = profile.begin(.metadata_require_rewrites);
+        defer rr_scope.end();
+        break :blk try self.buildRequireRewrites(&m);
+    };
 
     // ns_var_list → dev_ns_vars: backing slice 소유권 이전 (복사 없음)
     const dev_ns_vars: ?[]const []const u8 = if (ns_var_list.items.len > 0)

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -191,7 +191,13 @@ pub const Category = enum {
     shake_numeric_postpass_minify_skip,
     shake_mirror,
     metadata,
+    metadata_skip_nodes,
+    metadata_import_bindings,
     metadata_register_ns_rewrites,
+    metadata_merge_phase_b,
+    metadata_finalize_ns,
+    metadata_require_rewrites,
+    metadata_final_exports,
 
     // ── Transform ──
     transform,


### PR DESCRIPTION
## 배경

`metadata` 단계(`buildMetadataForAst` — linker metadata, emit 시 모듈당 호출)는 `--profile` 에서 ~2.8s aggregate(react-native-bare 기준)인데 sub-category 가 `metadata.register.ns.rewrites` 하나뿐이라 어디서 시간이 가는지 보이지 않았습니다. (이 세션에서 "측정부터 하자" 의 일환.)

## 변경

`buildMetadataForAst` 의 주요 단계를 sub-phase 로 쪼갰습니다:
- `metadata.skip.nodes` — `buildSkipNodes` (전체 AST walk → skip 비트셋)
- `metadata.import.bindings` — `m.import_bindings` 루프 (canonical rename + CJS/ESM preamble 생성) + 자체 top-level rename 루프
- `metadata.merge.phase.b` — `mergeUnifiedPhaseB` (linker 전역 `unified_result.renames` 조회)
- `metadata.finalize.ns` — `finalizeNamespaceData`
- `metadata.require.rewrites` — `buildRequireRewrites`
- `metadata.final.exports` — `buildFinalExports`

전부 `try` 식을 `blk: { var s = profile.begin(...); defer s.end(); break :blk try ...; }` 형태로 감싸서 에러 전파 시에도 scope 가 정확히 닫히게 했고(코드 인덴트 변경 없음), `import.bindings` 는 `if (sem.scope_maps.len > 0)` 블록 최상단에 `var s = begin(); defer s.end();` 만 추가 (블록 defer 는 어떤 경로로 블록을 빠져나가도 실행).

## 이 측정으로 드러난 것 (참고)

react-native-bare 번들 `--profile=all --profile-level=detailed --profile-format=tree`:
- `metadata` 2.86s agg = `import.bindings` **1.67s** + `require.rewrites` **0.66s** + `skip.nodes` 0.32s + `register.ns.rewrites` 0.13s + 나머지 ≈ 0.
- `require.rewrites` 가 모듈당 ~0.73ms — CJS target 이 없는 모듈에서도 도는 거면 거의 헛수고. 후속 최적화 후보.
- `import.bindings` 모듈당 ~1.85ms — import 가 적은 모듈도 비용이 있음. 조사 필요.

(전체 wall breakdown 은 PR 코멘트가 아니라 이슈/논의에서 — 요지: wall 1.55s ≈ discover ~660ms + emit ~470ms + shake 148ms + link 117ms. discover·emit 둘 다 worker-bound 라 aggregate 작업을 줄여야 wall 이 줄어듦.)

## Zig 메모

`begin/end` 는 `--profile` 비활성 시 zero-cost (`begin` 이 `enabled()` false 면 빈 Scope 반환, `end` 도 no-op). `--profile=metadata` 지정 시 prefix 매칭(`metadata_*`)으로 sub-phase 가 자동 활성되고 tree 포맷에서 nested 로 표시됨.

## 테스트
- `zig build test` ✅ 전체
- `tests/integration`: `profile-flags` 12/12, `bundle-smoke` 150/150

🤖 Generated with [Claude Code](https://claude.com/claude-code)