### PR TITLE
fix(react-native): handle RN Hermes downlevel edge cases

### DIFF
--- a/packages/react-native/src/plugins/babel.ts
+++ b/packages/react-native/src/plugins/babel.ts
@@ -109,8 +109,7 @@ function hasNonNative(plugins: unknown[]): boolean {
 
 function parserPluginsFor(filename: string): string[] {
   const ext = extname(filename);
-  if (ext === '.ts') return ['typescript', 'jsx'];
-  if (ext === '.tsx') return ['typescript', 'jsx'];
+  if (ext === '.ts' || ext === '.tsx') return ['typescript', 'jsx'];
   if (ext === '.js' || ext === '.jsx' || ext === '.mjs' || ext === '.cjs') {
     return ['jsx', 'flow'];
   }

--- a/packages/react-native/src/plugins/babel.ts
+++ b/packages/react-native/src/plugins/babel.ts
@@ -7,7 +7,7 @@
 
 import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { join } from 'node:path';
+import { extname, join } from 'node:path';
 
 import type { ZntcPlugin } from '@zntc/core';
 
@@ -105,6 +105,16 @@ function hasNonNative(plugins: unknown[]): boolean {
     // negative.
     return typeof name === 'string' && name !== '' && !isZntcNativePlugin(name);
   });
+}
+
+function parserPluginsFor(filename: string): string[] {
+  const ext = extname(filename);
+  if (ext === '.ts') return ['typescript', 'jsx'];
+  if (ext === '.tsx') return ['typescript', 'jsx'];
+  if (ext === '.js' || ext === '.jsx' || ext === '.mjs' || ext === '.cjs') {
+    return ['jsx', 'flow'];
+  }
+  return ['jsx'];
 }
 
 /**
@@ -214,10 +224,9 @@ export function createBabelTransformer(
       }
     }
 
-    // ZNTC 가 항상 추가하는 preset (TS strip) + 사용자 inline preset.
-    const customPresets: unknown[] = [
-      ['@babel/preset-typescript', { isTSX: true, allExtensions: true }],
-    ];
+    // TS/Flow strip 은 ZNTC native transform 이 처리하므로 Babel 에 preset-typescript 를
+    // 강제 주입하지 않는다. 여기서는 사용자가 명시한 non-native preset 만 forward 한다.
+    const customPresets: unknown[] = [];
     if (inline?.presets) {
       for (const preset of inline.presets) {
         const name = entryName(preset);
@@ -252,6 +261,7 @@ export function createBabelTransformer(
       const result = babel!.transformSync(code, {
         ...babelOptions,
         filename,
+        parserOpts: { plugins: parserPluginsFor(filename) },
       });
       if (result?.code && result.code !== code) {
         process.stderr.write(

--- a/packages/react-native/src/plugins/types.ts
+++ b/packages/react-native/src/plugins/types.ts
@@ -23,7 +23,7 @@ export interface PluginConfig {
   /**
    * Inline babel preset / plugin (zntc.config.ts 의 `transformer.babel`). 사용자
    * babel.config.js 의 plugins 와 concat 되며 양쪽 모두 ZNTC native filter 통과
-   * 후 babel pass 에 등록.
+   * 후 babel pass 에 등록. TS/Flow strip 은 ZNTC native transform 이 처리한다.
    */
   inlineBabel?: InlineBabelConfig;
 }

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -102,8 +102,8 @@ export interface RnBundleInput {
      * strip / RN preset / Reanimated 등) 은 자동 제외 — 충돌 회피.
      *
      * 사용자 babel.config.js 의 plugins 와 concat 되며 양쪽 모두 ZNTC native filter
-     * 통과 후 babel pass 에 forward. presets 는 zntc 가 추가하는 `preset-typescript`
-     * 외에 추가됨.
+     * 통과 후 babel pass 에 forward. TS/Flow strip 은 ZNTC native transform 이 처리하므로
+     * presets 는 사용자가 명시한 non-native 항목만 forward 됨.
      */
     babel?: InlineBabelConfig;
     /**

--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -494,17 +494,8 @@ fn extractDeclExportNames(allocator: std.mem.Allocator, ast: *const Ast, decl: N
                 const name_idx: NodeIndex = @enumFromInt(ast.extra_data.items[de]);
                 if (name_idx.isNone()) continue;
                 if (@intFromEnum(name_idx) >= ast.nodes.items.len) continue;
-                const name_node = ast.getNode(name_idx);
 
-                // destructuring: export const { X, Y } = obj
-                if (name_node.tag == .object_pattern) {
-                    try extractObjectPatternNames(&names, allocator, ast, name_node);
-                } else {
-                    try names.append(allocator, .{
-                        .name = ast.getText(name_node.span),
-                        .span = name_node.span,
-                    });
-                }
+                try extractBindingPatternNames(&names, allocator, ast, name_idx);
             }
         },
         // 모두 extra[0] 이 이름 노드 (function: [name, ...], class: [name, ...],
@@ -526,36 +517,23 @@ fn extractDeclExportNames(allocator: std.mem.Allocator, ast: *const Ast, decl: N
     return names.toOwnedSlice(allocator);
 }
 
-/// object_pattern의 각 프로퍼티 이름을 추출한다.
-/// `{ Command, Option }` → ["Command", "Option"]
-fn extractObjectPatternNames(
+/// declaration binding pattern의 BoundNames를 export 이름으로 추출한다.
+/// `export const [a, b] = ...` → ["a", "b"]
+/// `export const { key: local } = ...` → ["local"]
+fn extractBindingPatternNames(
     names: *std.ArrayList(NameInfo),
     allocator: std.mem.Allocator,
     ast: *const Ast,
-    pattern: Node,
+    pattern_idx: NodeIndex,
 ) !void {
-    const list = pattern.data.list;
-    if (list.len == 0) return;
-    if (list.start + list.len > ast.extra_data.items.len) return;
-    const indices = ast.extra_data.items[list.start .. list.start + list.len];
-    for (indices) |raw_idx| {
-        const prop_idx: NodeIndex = @enumFromInt(raw_idx);
-        if (prop_idx.isNone() or @intFromEnum(prop_idx) >= ast.nodes.items.len) continue;
-        const prop = ast.getNode(prop_idx);
-        switch (prop.tag) {
-            .binding_property => {
-                // binary: left=key, right=value
-                // shorthand { X } → left == right (같은 노드), exported_name = "X"
-                // rename { X: Y } → left=key "X", right=value "Y", exported_name = key
-                const key = ast.getNode(prop.data.binary.left);
-                const exported_name = ast.getText(key.span);
-                try names.append(allocator, .{
-                    .name = exported_name,
-                    .span = key.span,
-                });
-            },
-            else => {},
-        }
+    var w = try ast_walk.bindingIdentifiers(allocator, ast, pattern_idx, .{});
+    defer w.deinit();
+    while (try w.next()) |name_idx| {
+        const name_node = ast.getNode(name_idx);
+        try names.append(allocator, .{
+            .name = ast.getText(name_node.span),
+            .span = name_node.span,
+        });
     }
 }
 

--- a/src/bundler/bundler_test/default_deconflict.zig
+++ b/src/bundler/bundler_test/default_deconflict.zig
@@ -42,6 +42,46 @@ test "Default: export default class" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "new MyClass") != null);
 }
 
+test "Default: RN anonymous export default class lowers with synthetic binding" {
+    // react-native-root-siblings 의 `export default class extends Component` 처럼
+    // 클래스명이 없는 default class 패턴. RN/Hermes preset 은 class 를 ES5 로 낮추므로
+    // outer var declarator 에도 `_Class` binding 이 실제로 존재해야 한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\import StaticContainer from './StaticContainer';
+        \\const inst = new StaticContainer();
+        \\console.log(inst.value());
+    );
+    try writeFile(tmp.dir, "Component.js",
+        \\export class Component {}
+    );
+    try writeFile(tmp.dir, "StaticContainer.js",
+        \\import { Component } from './Component';
+        \\export default class extends Component {
+        \\  extendsCheck() { return Component !== undefined; }
+        \\  value() { return 'static-container'; }
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "function _Class") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "return _Class") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "static-container") != null);
+}
+
 test "Default: export default arrow function" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -159,6 +199,38 @@ test "Default: export { X as default } where X is default-import (#1321 edge)" {
 
     try std.testing.expect(!result.hasErrors());
     try std.testing.expect(std.mem.indexOf(u8, result.output, "\"REAL\"") != null);
+}
+
+test "Default: default-import barrel getter uses local binding for wrapped CJS" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { listenToKeyboardEvents } from './index';
+        \\console.log(listenToKeyboardEvents());
+    );
+    try writeFile(tmp.dir, "index.ts",
+        \\import listenToKeyboardEvents from './hoc.cjs';
+        \\export { listenToKeyboardEvents };
+    );
+    try writeFile(tmp.dir, "hoc.cjs",
+        \\module.exports = function listen() { return 'ok'; };
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .dev_mode = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "return default") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "=> listenToKeyboardEvents") != null);
 }
 
 test "Default: mixed default + named imports re-exported from single source (#1321 edge)" {

--- a/src/bundler/bundler_test/patterns.zig
+++ b/src/bundler/bundler_test/patterns.zig
@@ -700,6 +700,35 @@ test "Mixed: destructuring in import and export" {
     try std.testing.expect(!result.hasErrors());
 }
 
+test "Mixed: array destructuring export emits each bound name" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { getInstallerPackageName, getInstallerPackageNameSync } from './device';
+        \\console.log(getInstallerPackageName, getInstallerPackageNameSync);
+    );
+    try writeFile(tmp.dir, "device.ts",
+        \\const fns = [() => 'async', () => 'sync'];
+        \\export const [
+        \\  getInstallerPackageName,
+        \\  getInstallerPackageNameSync,
+        \\] = fns;
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .platform = .react_native });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"[\n") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "getInstallerPackageName") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "getInstallerPackageNameSync") != null);
+}
+
 test "Mixed: generator function across modules" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -518,7 +518,9 @@ pub fn emitEsmWrappedModule(
                             const local_name = module.exportBindingLocalName(eb);
                             for (module.import_bindings) |ib| {
                                 if (ib.import_record_index != rec_idx) continue;
-                                if (std.mem.eql(u8, ib.imported_name, local_name)) break :re_export;
+                                if (std.mem.eql(u8, ib.imported_name, local_name)) {
+                                    break :blk l.getCanonicalByRef(ib.local_symbol) orelse module.importBindingLocalName(ib);
+                                }
                             }
 
                             const getter_val = try makeStarGetterValue(allocator, l, src_mod, si, local_name);

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -1009,6 +1009,38 @@ test "ES2015: object async method → state machine wrapped in function" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "async a(") == null);
 }
 
+test "Hermes: async object method lowers even when object extensions are supported" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        "new ReadableStream({async pull(controller){const {done,value}=await iterator.next();return value;},cancel(reason){return iterator.return(reason);}});",
+        .{ .unsupported = TransformOptions.compat.fromHermesPreset() },
+        .{ .minify_whitespace = true },
+        ".js",
+    );
+    defer r.deinit();
+
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "pull:function") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__async") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "async pull") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "yield iterator.next") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "cancel(reason)") != null);
+}
+
+test "Hermes: async arrow expression body extracts nested await" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        "const encodeText=async (str)=>new Uint8Array(await new Request(str).arrayBuffer());",
+        .{ .unsupported = TransformOptions.compat.fromHermesPreset() },
+        .{ .minify_whitespace = true },
+        ".js",
+    );
+    defer r.deinit();
+
+    try expectAsyncStateMachine(r.output);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "yield new Request") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "new Uint8Array(_") != null);
+}
+
 test "ES2015: object generator method → state machine wrapped in function" {
     var r = try e2eTarget(std.testing.allocator, "var o={*g(){yield 1;}};", .es5);
     defer r.deinit();
@@ -2397,6 +2429,30 @@ test "ES2018: for-await-of with break — lowered (#1381)" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, ".return") != null);
 }
 
+test "ES2018: for-await-of inside try participates in async state machine" {
+    var r = try e2eTarget(std.testing.allocator, "async function f(iter){try{for await(const v of iter){await g(v);}}finally{cleanup();}}", .es5);
+    defer r.deinit();
+    try expectAsyncStateMachine(r.output);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "for await") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "await ") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__asyncValues") != null);
+}
+
+test "ES5: throw sequence with nested await extracts before throw" {
+    var r = try e2eTarget(std.testing.allocator, "async function f(err){throw this.once('error',function(){}),await finished(this.destroy(err)),err;}", .es5);
+    defer r.deinit();
+    try expectAsyncStateMachine(r.output);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "throw this.once") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "throw err") != null);
+}
+
+test "ES5: await inside TS assertion participates in async state machine" {
+    var r = try e2eTarget(std.testing.allocator, "async function f(permission){const status=(await NativeModule.check(permission)) as PermissionStatus;return status;}", .es5);
+    defer r.deinit();
+    try expectAsyncStateMachine(r.output);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "status=((yield") == null);
+}
+
 test "ES2018: for-await-of preserved at esnext" {
     var r = try e2eTarget(std.testing.allocator, "async function f(iter){for await(const v of iter)g(v);}", .esnext);
     defer r.deinit();
@@ -3051,4 +3107,41 @@ test "ES5: for-await-of hoists loop var to function top (#1901)" {
         std.mem.indexOf(u8, r.output, ",v=") != null or
         std.mem.indexOf(u8, r.output, ",v,") != null;
     try std.testing.expect(has_v_decl);
+}
+
+test "ES5: async for-in body extracts await into state machine" {
+    var r = try e2eES5Async(std.testing.allocator,
+        \\async function validateAll(fields) {
+        \\  for (const name in fields) {
+        \\    const field = fields[name];
+        \\    const fieldError = await validateField(field);
+        \\    if (fieldError) break;
+        \\  }
+        \\  return true;
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.keys") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "(yield validateField") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "validateField(field)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_state.sent()") != null);
+}
+
+test "ES5: async switch case block extracts await" {
+    var r = try e2eES5Async(std.testing.allocator,
+        \\async function requestCamera(result) {
+        \\  switch (result) {
+        \\    case "denied": {
+        \\      const permission = await requestCameraPermission();
+        \\      return permission === "granted";
+        \\    }
+        \\    default:
+        \\      return false;
+        \\  }
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "(yield requestCameraPermission") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "requestCameraPermission()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_state.sent()") != null);
 }

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -20,6 +20,7 @@ const Parser = @import("parser.zig").Parser;
 const ParseError2 = @import("parser.zig").ParseError2;
 const binding_mod = @import("binding.zig");
 const scan_results_mod = @import("scan_results.zig");
+const ast_walk = @import("ast_walk.zig");
 const import_scanner = @import("../bundler/import_scanner.zig");
 const import_specifier_unescape = @import("import_specifier.zig");
 const profile = @import("../profile.zig");
@@ -1279,17 +1280,8 @@ fn collectDeclExportBindings(self: *Parser, decl_idx: NodeIndex) void {
                 if (@intFromEnum(name_idx) >= self.ast.nodes.items.len) continue;
                 const name_node = self.ast.getNode(name_idx);
 
-                if (name_node.tag == .object_pattern) {
-                    collectObjectPatternExportBindings(self, name_node);
-                } else {
-                    const name = self.ast.source[name_node.span.start..name_node.span.end];
-                    self.scan_export_bindings.append(self.allocator, .{
-                        .exported_name = name,
-                        .local_name = name,
-                        .local_span = name_node.span,
-                        .kind = .local,
-                    }) catch {};
-                }
+                _ = name_node;
+                collectPatternExportBindings(self, name_idx);
             }
         },
         .function_declaration, .class_declaration => {
@@ -1310,26 +1302,19 @@ fn collectDeclExportBindings(self: *Parser, decl_idx: NodeIndex) void {
     }
 }
 
-/// object_pattern에서 export binding name을 추출한다.
-fn collectObjectPatternExportBindings(self: *Parser, pattern: Node) void {
-    const list = pattern.data.list;
-    if (list.len == 0) return;
-    if (list.start + list.len > self.ast.extra_data.items.len) return;
-    const indices = self.ast.extra_data.items[list.start .. list.start + list.len];
-    for (indices) |raw_idx| {
-        const prop_idx: NodeIndex = @enumFromInt(raw_idx);
-        if (prop_idx.isNone() or @intFromEnum(prop_idx) >= self.ast.nodes.items.len) continue;
-        const prop = self.ast.getNode(prop_idx);
-        if (prop.tag == .binding_property) {
-            const key = self.ast.getNode(prop.data.binary.left);
-            const name = self.ast.source[key.span.start..key.span.end];
-            self.scan_export_bindings.append(self.allocator, .{
-                .exported_name = name,
-                .local_name = name,
-                .local_span = key.span,
-                .kind = .local,
-            }) catch {};
-        }
+/// declaration binding pattern의 BoundNames를 export binding으로 수집한다.
+fn collectPatternExportBindings(self: *Parser, pattern_idx: NodeIndex) void {
+    var w = ast_walk.bindingIdentifiers(self.allocator, &self.ast, pattern_idx, .{}) catch return;
+    defer w.deinit();
+    while (w.next() catch null) |name_idx| {
+        const name_node = self.ast.getNode(name_idx);
+        const name = self.ast.getText(name_node.span);
+        self.scan_export_bindings.append(self.allocator, .{
+            .exported_name = name,
+            .local_name = name,
+            .local_span = name_node.span,
+            .kind = .local,
+        }) catch {};
     }
 }
 

--- a/src/transformer/compat.zig
+++ b/src/transformer/compat.zig
@@ -198,6 +198,14 @@ pub const UnsupportedFeatures = packed struct(u32) {
         return self.class or self.class_private_field or self.class_private_method;
     }
 
+    /// object literal method shorthand 를 `key: function` 형태로 낮춰야 하는 타겟인지.
+    /// object_extensions 미지원이면 전부 변환 대상이고, Hermes/RN 처럼 shorthand 자체는
+    /// 지원하지만 async/generator method 만 낮춰야 하는 경우도 포함. node 단위 정밀 판정 전에
+    /// 멤버 순회를 건너뛰기 위한 cheap gate.
+    pub fn needsObjectMethodDownlevel(self: UnsupportedFeatures) bool {
+        return self.object_extensions or self.async_await or self.generator;
+    }
+
     /// `for await (... of ...)` 는 ES2018 문법. 전용 feature 비트가 없어서, ES2018 비트
     /// (object_spread / regex_dotall / regex_named_groups) 중 하나라도 unsupported 면
     /// "타겟이 ES2018 미만" 으로 간주. async_await (ES2017) 도 같이 OR — ES2017 미지원 타겟은

--- a/src/transformer/es2015_class.zig
+++ b/src/transformer/es2015_class.zig
@@ -68,12 +68,16 @@ pub fn ES2015Class(comptime Transformer: type) type {
             const super_idx: NodeIndex = self.readNodeIdx(e, ast_mod.ClassExtra.super);
             const body_idx: NodeIndex = self.readNodeIdx(e, ast_mod.ClassExtra.body);
 
-            // 클래스 이름 추출
-            const new_name = try self.visitNode(name_idx);
+            // 클래스 이름 추출. `export default class {}` 는 class_declaration 이지만
+            // 이름이 없으므로, ES5 lowering 의 outer `var` 선언에도 실제 binding 이 필요하다.
+            var new_name = try self.visitNode(name_idx);
             const name_span = if (!new_name.isNone())
                 self.ast.getNode(new_name).data.string_ref
-            else
-                try self.ast.addString("_Class");
+            else blk: {
+                const synthetic = try self.ast.addString("_Class");
+                new_name = try es_helpers.makeBindingIdentifier(self, synthetic);
+                break :blk synthetic;
+            };
 
             // super class 처리
             const has_super = !super_idx.isNone();

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -314,9 +314,48 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                         try ops.append(self.allocator, .{ .code = .return_op, .arg = .{ .node = NodeIndex.none } });
                     }
                 },
+                .throw_statement => {
+                    const value_idx = stmt.data.unary.operand;
+                    if (!value_idx.isNone()) {
+                        const value_node = self.ast.getNode(value_idx);
+                        if (value_node.tag == .yield_expression or value_node.tag == .await_expression) {
+                            // throw await x → yield x; throw _state.sent()
+                            const inner_value = value_node.data.unary.operand;
+                            const new_inner = try visitExprWithYieldExtraction(self, inner_value, ops, next_label);
+                            try ops.append(self.allocator, .{ .code = yieldOpCodeFor(value_node), .arg = .{ .node = new_inner } });
+                            next_label.* += 1;
+                            try ops.append(self.allocator, .{ .code = .nop, .arg = .{ .none = {} } });
+                            const sent = try buildSentCall(self, stmt.span);
+                            const throw_stmt = try self.ast.addNode(.{
+                                .tag = .throw_statement,
+                                .span = stmt.span,
+                                .data = .{ .unary = .{ .operand = sent, .flags = 0 } },
+                            });
+                            try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = throw_stmt } });
+                        } else if (es2015_scan.containsYield(self, value_idx)) {
+                            // throw (a(), await b(), err) → extract await before the throw.
+                            const new_value = try visitExprWithYieldExtraction(self, value_idx, ops, next_label);
+                            const throw_stmt = try self.ast.addNode(.{
+                                .tag = .throw_statement,
+                                .span = stmt.span,
+                                .data = .{ .unary = .{ .operand = new_value, .flags = 0 } },
+                            });
+                            try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = throw_stmt } });
+                        } else {
+                            const new_stmt = try self.visitNode(stmt_idx);
+                            try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = new_stmt } });
+                        }
+                    } else {
+                        const new_stmt = try self.visitNode(stmt_idx);
+                        try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = new_stmt } });
+                    }
+                },
                 .variable_declaration => {
                     // 모든 var는 호이스팅됨. init를 assignment로 변환.
                     try collectVarDeclWithYield(self, stmt, ops, next_label);
+                },
+                .block_statement, .function_body => {
+                    try collectBodyOperations(self, stmt_idx, ops, next_label);
                 },
                 .if_statement => {
                     try collectIfOperations(self, stmt_idx, stmt, ops, next_label);
@@ -537,31 +576,30 @@ pub fn ES2015Generator(comptime Transformer: type) type {
         /// for-of/for-in 문의 연산 수집.
         /// for (const x of arr) { yield ... }
         /// → for (var _i = 0, _arr = arr; _i < _arr.length; _i++) { var x = _arr[_i]; yield ... }
-        /// 배열 기반 변환 후 collectForOperations와 동일한 yield 추출.
+        /// for-in은 Object.keys(obj) snapshot을 순회하는 동일한 배열 기반 루프로 낮춘다.
         fn collectForOfOperations(self: *Transformer, stmt_idx: NodeIndex, stmt: Node, ops: *std.ArrayList(Operation), next_label: *u32) Transformer.Error!void {
+            _ = stmt_idx;
             const span = stmt.span;
             const left = stmt.data.ternary.a; // loop variable
             const right = stmt.data.ternary.b; // iterable
             const body_idx = stmt.data.ternary.c; // body
 
-            // for-in: yield를 포함한 state machine 변환은 미지원.
-            // for-in은 iterable protocol이 아닌 object key 열거이므로 배열 변환 불가.
-            // yield는 방문되지만 state machine 추출 없이 그대로 출력됨.
-            if (stmt.tag == .for_in_statement) {
-                const new_stmt = try self.visitNode(stmt_idx);
-                if (!new_stmt.isNone()) {
-                    try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = new_stmt } });
-                }
-                return;
-            }
-
-            // for-of → for 변환: _i (index), _arr (array)
+            // for-of/for-in → for 변환: _i (index), _arr (array or key snapshot)
             const idx_span = try es_helpers.makeTempVarSpan(self);
             const arr_span = try es_helpers.makeTempVarSpan(self);
             // 임시 변수를 호이스팅 리스트에 등록 (buildGeneratorBody에서 var 선언 생성)
             try self.generator_temp_var_spans.append(self.allocator, idx_span);
             try self.generator_temp_var_spans.append(self.allocator, arr_span);
-            const new_right = try self.visitNode(right);
+            const new_right = if (es2015_scan.containsYield(self, right))
+                try visitExprWithYieldExtraction(self, right, ops, next_label)
+            else
+                try self.visitNode(right);
+            const iterable_value = if (stmt.tag == .for_in_statement) blk: {
+                const object_ref = try es_helpers.makeIdentifierRef(self, "Object");
+                const keys_ref = try es_helpers.makeIdentifierRef(self, "keys");
+                const keys_member = try es_helpers.makeStaticMember(self, object_ref, keys_ref, span);
+                break :blk try es_helpers.makeCallExpr(self, keys_member, &.{new_right}, span);
+            } else new_right;
 
             // init: _i = 0, _arr = iterable (assignment)
             // __generator 콜백은 매 호출마다 새 실행 컨텍스트이므로
@@ -581,7 +619,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             const arr_assign = try self.ast.addNode(.{
                 .tag = .assignment_expression,
                 .span = span,
-                .data = .{ .binary = .{ .left = arr_ref_init, .right = new_right, .flags = 0 } },
+                .data = .{ .binary = .{ .left = arr_ref_init, .right = iterable_value, .flags = 0 } },
             });
             const arr_stmt = try es_helpers.makeExprStmt(self, arr_assign, span);
             try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = arr_stmt } });
@@ -1479,6 +1517,19 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 return es_helpers.makeParenExpr(self, inner, node.span);
             }
 
+            // TS/Flow type wrappers are runtime-transparent. Look through them so
+            // `(await x) as T` does not become raw `(yield x)` after type stripping.
+            if (node.tag == .ts_as_expression or
+                node.tag == .ts_satisfies_expression or
+                node.tag == .ts_non_null_expression or
+                node.tag == .ts_type_assertion or
+                node.tag == .ts_instantiation_expression or
+                node.tag == .flow_as_expression or
+                node.tag == .flow_type_cast_expression)
+            {
+                return visitExprWithYieldExtraction(self, node.data.unary.operand, ops, next_label);
+            }
+
             // logical/binary expression: 양쪽 재귀
             if (node.tag == .logical_expression or node.tag == .binary_expression) {
                 const new_left = try visitExprWithYieldExtraction(self, node.data.binary.left, ops, next_label);
@@ -1500,6 +1551,33 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                     .span = node.span,
                     .data = .{ .ternary = .{ .a = new_a, .b = new_b, .c = new_c } },
                 });
+            }
+
+            // sequence expression: a(), await b(), c()
+            // 앞쪽 expression은 순서 보존을 위해 statement operation으로 먼저 방출하고,
+            // 마지막 expression만 원래 expression 자리의 값으로 반환한다.
+            if (node.tag == .sequence_expression) {
+                const list_start = node.data.list.start;
+                const list_len = node.data.list.len;
+                if (list_len == 0) return self.visitNode(expr_idx);
+
+                var i_seq: u32 = 0;
+                while (i_seq < list_len) : (i_seq += 1) {
+                    const elem_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[list_start + i_seq]);
+                    const is_last = i_seq + 1 == list_len;
+                    const new_elem = if (es2015_scan.containsYield(self, elem_idx))
+                        try visitExprWithYieldExtraction(self, elem_idx, ops, next_label)
+                    else
+                        try self.visitNode(elem_idx);
+
+                    if (is_last) return new_elem;
+                    if (!new_elem.isNone()) {
+                        const elem_node = self.ast.getNode(elem_idx);
+                        const stmt = try es_helpers.makeExprStmt(self, new_elem, elem_node.span);
+                        try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = stmt } });
+                    }
+                }
+                return .none;
             }
 
             // unary/update expression: extra = [operand, operator_and_flags]
@@ -1640,28 +1718,49 @@ pub fn ES2015Generator(comptime Transformer: type) type {
         }
 
         fn buildExpressionBodyStateMachine(self: *Transformer, body_idx: NodeIndex, body: Node, span: Span) Transformer.Error!StateMachineResult {
-            // expression body는 최대 3개 연산 (yield + nop + return)
-            var ops_buf: [3]Operation = undefined;
-            var ops_len: usize = 0;
+            var ops: std.ArrayList(Operation) = .empty;
+            defer ops.deinit(self.allocator);
+            var next_label: u32 = 1;
 
             if (body.tag == .await_expression or body.tag == .yield_expression) {
                 // return await/yield x → yield x + return _state.sent()
                 const inner_value = body.data.unary.operand;
-                const new_inner = if (!inner_value.isNone()) try self.visitNode(inner_value) else NodeIndex.none;
-                ops_buf[0] = .{ .code = yieldOpCodeFor(body), .arg = .{ .node = new_inner } };
-                ops_buf[1] = .{ .code = .nop, .arg = .{ .none = {} } };
+                const new_inner = if (!inner_value.isNone())
+                    try visitExprWithYieldExtraction(self, inner_value, &ops, &next_label)
+                else
+                    NodeIndex.none;
+                try ops.append(self.allocator, .{ .code = yieldOpCodeFor(body), .arg = .{ .node = new_inner } });
+                next_label += 1;
+                try ops.append(self.allocator, .{ .code = .nop, .arg = .{ .none = {} } });
                 const sent = try buildSentCall(self, span);
-                ops_buf[2] = .{ .code = .return_op, .arg = .{ .node = sent } };
-                ops_len = 3;
+                try ops.append(self.allocator, .{ .code = .return_op, .arg = .{ .node = sent } });
+            } else if (es2015_scan.containsYield(self, body_idx)) {
+                // async arrow expression body: `async x => f(await x)` 는 implicit return 이므로,
+                // block body 의 `return f(await x)` 와 동일하게 nested await를 먼저 추출한다.
+                const new_value = try visitExprWithYieldExtraction(self, body_idx, &ops, &next_label);
+                try ops.append(self.allocator, .{ .code = .return_op, .arg = .{ .node = new_value } });
             } else {
                 // 일반 expression: return expr
                 const new_value = try self.visitNode(body_idx);
-                ops_buf[0] = .{ .code = .return_op, .arg = .{ .node = new_value } };
-                ops_len = 1;
+                try ops.append(self.allocator, .{ .code = .return_op, .arg = .{ .node = new_value } });
             }
 
-            const switch_node = try buildSwitchFromOps(self, ops_buf[0..ops_len], span);
-            return .{ .body = switch_node, .var_decl = .none };
+            const switch_node = try buildSwitchFromOps(self, ops.items, span);
+
+            var var_decl_node: NodeIndex = .none;
+            if (self.generator_temp_var_spans.items.len > 0) {
+                const scratch_top = self.scratch.items.len;
+                defer self.scratch.shrinkRetainingCapacity(scratch_top);
+                for (self.generator_temp_var_spans.items) |temp_span| {
+                    const binding = try es_helpers.makeBindingIdentifier(self, temp_span);
+                    const declarator = try es_helpers.makeDeclarator(self, binding, .none, span);
+                    try self.scratch.append(self.allocator, declarator);
+                }
+                self.generator_temp_var_spans.clearRetainingCapacity();
+                var_decl_node = try es_helpers.makeVarDeclaration(self, self.scratch.items[scratch_top..], .@"var", span);
+            }
+
+            return .{ .body = switch_node, .var_decl = var_decl_node };
         }
 
         /// 연산 리스트를 switch case로 변환.

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -199,30 +199,49 @@ pub fn ES2015Generator(comptime Transformer: type) type {
 
             // Phase 2: 연산을 switch case로 변환
             const switch_node = try buildSwitchFromOps(self, ops.items, span);
-
-            // var 선언을 __generator 콜백 밖으로 분리하여 함수 스코프에 배치.
-            // 콜백 안에 두면 매 호출마다 var가 재선언되어 상태가 리셋됨.
-            var var_decl_node: NodeIndex = .none;
-            const has_temp_vars = self.generator_temp_var_spans.items.len > 0;
-            if (hoisted_vars.items.len > 0 or has_temp_vars) {
-                const scratch_top2 = self.scratch.items.len;
-                defer self.scratch.shrinkRetainingCapacity(scratch_top2);
-
-                for (hoisted_vars.items) |binding| {
-                    const declarator = try es_helpers.makeDeclarator(self, binding, .none, span);
-                    try self.scratch.append(self.allocator, declarator);
-                }
-                // for-of 변환에서 생성한 임시 변수도 호이스팅
-                for (self.generator_temp_var_spans.items) |temp_span| {
-                    const binding = try es_helpers.makeBindingIdentifier(self, temp_span);
-                    const declarator = try es_helpers.makeDeclarator(self, binding, .none, span);
-                    try self.scratch.append(self.allocator, declarator);
-                }
-                self.generator_temp_var_spans.clearRetainingCapacity();
-                var_decl_node = try es_helpers.makeVarDeclaration(self, self.scratch.items[scratch_top2..], .@"var", span);
-            }
-
+            const var_decl_node = try buildHoistedVarDecl(self, hoisted_vars.items, span);
             return .{ .body = switch_node, .var_decl = var_decl_node };
+        }
+
+        /// generator body 의 hoisted `var` 선언과 for-of/await 변환에서 생성한 임시 변수를
+        /// 하나의 `var` 선언으로 합쳐 반환. __generator 콜백 밖(함수 스코프)에 배치해야 한다 —
+        /// 콜백 안에 두면 매 호출마다 재선언되어 상태가 리셋된다. 합칠 변수가 없으면 `.none`.
+        fn buildHoistedVarDecl(self: *Transformer, hoisted_vars: []const NodeIndex, span: Span) Transformer.Error!NodeIndex {
+            if (hoisted_vars.len == 0 and self.generator_temp_var_spans.items.len == 0) return .none;
+            const scratch_top = self.scratch.items.len;
+            defer self.scratch.shrinkRetainingCapacity(scratch_top);
+            for (hoisted_vars) |binding| {
+                const declarator = try es_helpers.makeDeclarator(self, binding, .none, span);
+                try self.scratch.append(self.allocator, declarator);
+            }
+            for (self.generator_temp_var_spans.items) |temp_span| {
+                const binding = try es_helpers.makeBindingIdentifier(self, temp_span);
+                const declarator = try es_helpers.makeDeclarator(self, binding, .none, span);
+                try self.scratch.append(self.allocator, declarator);
+            }
+            self.generator_temp_var_spans.clearRetainingCapacity();
+            return es_helpers.makeVarDeclaration(self, self.scratch.items[scratch_top..], .@"var", span);
+        }
+
+        /// `return`/`throw` 의 피연산자 식을 yield 추출과 함께 처리한 뒤, 그 자리에 들어갈
+        /// 최종 식 노드를 반환한다.
+        ///  - `await x` / `yield x` 자체: yield 연산 + nop 을 ops 에 방출하고 `_state.sent()` 반환.
+        ///  - 중첩 yield (`f(await x)` 등): yield 들을 추출한 뒤 남은 식 반환.
+        ///  - yield 없음: 그냥 visitNode 결과 반환.
+        fn lowerYieldingOperand(self: *Transformer, value_idx: NodeIndex, span: Span, ops: *std.ArrayList(Operation), next_label: *u32) Transformer.Error!NodeIndex {
+            const value_node = self.ast.getNode(value_idx);
+            if (value_node.tag == .yield_expression or value_node.tag == .await_expression) {
+                const inner_value = value_node.data.unary.operand;
+                const new_inner = try visitExprWithYieldExtraction(self, inner_value, ops, next_label);
+                try ops.append(self.allocator, .{ .code = yieldOpCodeFor(value_node), .arg = .{ .node = new_inner } });
+                next_label.* += 1;
+                try ops.append(self.allocator, .{ .code = .nop, .arg = .{ .none = {} } });
+                return buildSentCall(self, span);
+            }
+            if (es2015_scan.containsYield(self, value_idx)) {
+                return visitExprWithYieldExtraction(self, value_idx, ops, next_label);
+            }
+            return self.visitNode(value_idx);
         }
 
         /// AST 문을 순회하며 연산을 수집.
@@ -291,63 +310,25 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 },
                 .return_statement => {
                     const value_idx = stmt.data.unary.operand;
-                    if (!value_idx.isNone()) {
-                        const value_node = self.ast.getNode(value_idx);
-                        if (value_node.tag == .yield_expression or value_node.tag == .await_expression) {
-                            // return yield/await x → yield x + return _state.sent()
-                            const inner_value = value_node.data.unary.operand;
-                            const new_inner = try visitExprWithYieldExtraction(self, inner_value, ops, next_label);
-                            try ops.append(self.allocator, .{ .code = yieldOpCodeFor(value_node), .arg = .{ .node = new_inner } });
-                            next_label.* += 1;
-                            try ops.append(self.allocator, .{ .code = .nop, .arg = .{ .none = {} } });
-                            const sent = try buildSentCall(self, stmt.span);
-                            try ops.append(self.allocator, .{ .code = .return_op, .arg = .{ .node = sent } });
-                        } else if (es2015_scan.containsYield(self, value_idx)) {
-                            // return foo(await x) — 중첩 yield를 추출 후 return
-                            const new_value = try visitExprWithYieldExtraction(self, value_idx, ops, next_label);
-                            try ops.append(self.allocator, .{ .code = .return_op, .arg = .{ .node = new_value } });
-                        } else {
-                            const new_value = try self.visitNode(value_idx);
-                            try ops.append(self.allocator, .{ .code = .return_op, .arg = .{ .node = new_value } });
-                        }
-                    } else {
-                        try ops.append(self.allocator, .{ .code = .return_op, .arg = .{ .node = NodeIndex.none } });
-                    }
+                    const new_value = if (value_idx.isNone())
+                        NodeIndex.none
+                    else
+                        try lowerYieldingOperand(self, value_idx, stmt.span, ops, next_label);
+                    try ops.append(self.allocator, .{ .code = .return_op, .arg = .{ .node = new_value } });
                 },
                 .throw_statement => {
                     const value_idx = stmt.data.unary.operand;
-                    if (!value_idx.isNone()) {
-                        const value_node = self.ast.getNode(value_idx);
-                        if (value_node.tag == .yield_expression or value_node.tag == .await_expression) {
-                            // throw await x → yield x; throw _state.sent()
-                            const inner_value = value_node.data.unary.operand;
-                            const new_inner = try visitExprWithYieldExtraction(self, inner_value, ops, next_label);
-                            try ops.append(self.allocator, .{ .code = yieldOpCodeFor(value_node), .arg = .{ .node = new_inner } });
-                            next_label.* += 1;
-                            try ops.append(self.allocator, .{ .code = .nop, .arg = .{ .none = {} } });
-                            const sent = try buildSentCall(self, stmt.span);
-                            const throw_stmt = try self.ast.addNode(.{
-                                .tag = .throw_statement,
-                                .span = stmt.span,
-                                .data = .{ .unary = .{ .operand = sent, .flags = 0 } },
-                            });
-                            try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = throw_stmt } });
-                        } else if (es2015_scan.containsYield(self, value_idx)) {
-                            // throw (a(), await b(), err) → extract await before the throw.
-                            const new_value = try visitExprWithYieldExtraction(self, value_idx, ops, next_label);
-                            const throw_stmt = try self.ast.addNode(.{
-                                .tag = .throw_statement,
-                                .span = stmt.span,
-                                .data = .{ .unary = .{ .operand = new_value, .flags = 0 } },
-                            });
-                            try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = throw_stmt } });
-                        } else {
-                            const new_stmt = try self.visitNode(stmt_idx);
-                            try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = new_stmt } });
-                        }
-                    } else {
+                    if (value_idx.isNone() or !es2015_scan.containsYield(self, value_idx)) {
                         const new_stmt = try self.visitNode(stmt_idx);
                         try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = new_stmt } });
+                    } else {
+                        const new_value = try lowerYieldingOperand(self, value_idx, stmt.span, ops, next_label);
+                        const throw_stmt = try self.ast.addNode(.{
+                            .tag = .throw_statement,
+                            .span = stmt.span,
+                            .data = .{ .unary = .{ .operand = new_value, .flags = 0 } },
+                        });
+                        try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = throw_stmt } });
                     }
                 },
                 .variable_declaration => {
@@ -380,7 +361,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 },
                 .for_of_statement, .for_in_statement => {
                     if (es2015_scan.containsYield(self, stmt_idx)) {
-                        try collectForOfOperations(self, stmt_idx, stmt, ops, next_label);
+                        try collectForOfOperations(self, stmt, ops, next_label);
                     } else {
                         const new_stmt = try self.visitNode(stmt_idx);
                         if (!new_stmt.isNone()) {
@@ -577,8 +558,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
         /// for (const x of arr) { yield ... }
         /// → for (var _i = 0, _arr = arr; _i < _arr.length; _i++) { var x = _arr[_i]; yield ... }
         /// for-in은 Object.keys(obj) snapshot을 순회하는 동일한 배열 기반 루프로 낮춘다.
-        fn collectForOfOperations(self: *Transformer, stmt_idx: NodeIndex, stmt: Node, ops: *std.ArrayList(Operation), next_label: *u32) Transformer.Error!void {
-            _ = stmt_idx;
+        fn collectForOfOperations(self: *Transformer, stmt: Node, ops: *std.ArrayList(Operation), next_label: *u32) Transformer.Error!void {
             const span = stmt.span;
             const left = stmt.data.ternary.a; // loop variable
             const right = stmt.data.ternary.b; // iterable
@@ -1517,8 +1497,8 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 return es_helpers.makeParenExpr(self, inner, node.span);
             }
 
-            // TS/Flow type wrappers are runtime-transparent. Look through them so
-            // `(await x) as T` does not become raw `(yield x)` after type stripping.
+            // TS/Flow 타입 wrapper 는 런타임상 noop 이므로 통과한다. 그러지 않으면 타입 스트립
+            // 이후 `(await x) as T` 가 추출되지 못한 raw `(yield x)` 로 남는다.
             if (node.tag == .ts_as_expression or
                 node.tag == .ts_satisfies_expression or
                 node.tag == .ts_non_null_expression or
@@ -1746,20 +1726,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             }
 
             const switch_node = try buildSwitchFromOps(self, ops.items, span);
-
-            var var_decl_node: NodeIndex = .none;
-            if (self.generator_temp_var_spans.items.len > 0) {
-                const scratch_top = self.scratch.items.len;
-                defer self.scratch.shrinkRetainingCapacity(scratch_top);
-                for (self.generator_temp_var_spans.items) |temp_span| {
-                    const binding = try es_helpers.makeBindingIdentifier(self, temp_span);
-                    const declarator = try es_helpers.makeDeclarator(self, binding, .none, span);
-                    try self.scratch.append(self.allocator, declarator);
-                }
-                self.generator_temp_var_spans.clearRetainingCapacity();
-                var_decl_node = try es_helpers.makeVarDeclaration(self, self.scratch.items[scratch_top..], .@"var", span);
-            }
-
+            const var_decl_node = try buildHoistedVarDecl(self, &.{}, span);
             return .{ .body = switch_node, .var_decl = var_decl_node };
         }
 

--- a/src/transformer/es2015_generator/scan.zig
+++ b/src/transformer/es2015_generator/scan.zig
@@ -29,6 +29,7 @@ pub fn containsYield(self: anytype, root_idx: NodeIndex) bool {
         const node = self.ast.getNode(idx);
 
         if (node.tag == .yield_expression or node.tag == .await_expression) return true;
+        if (node.tag == .for_await_of_statement and self.options.unsupported.needsForAwaitOfDownlevel()) return true;
         if (node.tag == .break_statement or node.tag == .continue_statement) {
             if (node.data.unary.operand.isNone()) {
                 if (self.generator_label_stack.items.len > 0) return true;
@@ -65,6 +66,13 @@ pub fn containsYield(self: anytype, root_idx: NodeIndex) bool {
             .spread_element,
             .rest_element,
             .parenthesized_expression,
+            .ts_as_expression,
+            .ts_satisfies_expression,
+            .ts_non_null_expression,
+            .ts_type_assertion,
+            .ts_instantiation_expression,
+            .flow_as_expression,
+            .flow_type_cast_expression,
             => {
                 if (!pushNode(self, &stack, node.data.unary.operand)) return true;
             },
@@ -95,6 +103,7 @@ pub fn containsYield(self: anytype, root_idx: NodeIndex) bool {
             .if_statement,
             .for_in_statement,
             .for_of_statement,
+            .for_await_of_statement,
             .try_statement,
             => {
                 if (!pushNode(self, &stack, node.data.ternary.a)) return true;
@@ -193,7 +202,7 @@ pub fn containsReturn(self: anytype, root_idx: NodeIndex) bool {
                     if (!pushNode(self, &stack, @enumFromInt(raw_idx))) return true;
                 }
             },
-            .if_statement, .for_in_statement, .for_of_statement => {
+            .if_statement, .for_in_statement, .for_of_statement, .for_await_of_statement => {
                 if (!pushNode(self, &stack, node.data.ternary.b)) return true;
                 if (!pushNode(self, &stack, node.data.ternary.c)) return true;
             },

--- a/src/transformer/es2015_object_methods.zig
+++ b/src/transformer/es2015_object_methods.zig
@@ -42,22 +42,8 @@ pub fn ES2015ObjectMethods(comptime Transformer: type) type {
                 (self.options.unsupported.generator and (flags & ast_mod.MethodFlags.is_generator) != 0);
         }
 
-        /// object_expression 멤버 중 method_definition이 있는지 확인.
-        /// getter/setter(flags 0x02/0x04)는 ES5도 지원하므로 제외.
-        pub fn hasObjectMethod(self: *const Transformer, node: Node) bool {
-            const members = self.ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
-            for (members) |raw_idx| {
-                const m = self.ast.getNode(@enumFromInt(raw_idx));
-                if (m.tag != .method_definition) continue;
-                const flags = self.ast.extra_data.items[m.data.extra + ast_mod.MethodExtra.flags];
-                if (!isPlainObjectMethod(flags)) continue;
-                return true;
-            }
-            return false;
-        }
-
         /// 현재 타겟에서 method_definition → object_property + function_expression
-        /// 변환이 필요한 멤버가 있는지 확인.
+        /// 변환이 필요한 멤버(getter/setter 및 보존 가능한 일반 method 제외)가 있는지 확인.
         pub fn needsObjectMethodLowering(self: *const Transformer, node: Node) bool {
             const members = self.ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
             for (members) |raw_idx| {

--- a/src/transformer/es2015_object_methods.zig
+++ b/src/transformer/es2015_object_methods.zig
@@ -1,6 +1,8 @@
 //! ES2015 다운레벨링: object literal method shorthand
 //!
 //! --target < es2015 (object_extensions unsupported) 일 때 활성화.
+//! 또한 Hermes/RN 처럼 method shorthand 자체는 지원하지만 async/generator 를
+//! 다운레벨링해야 하는 타겟에서는 해당 method만 function expression으로 바꾼다.
 //! { m() {} } → { m: function() {} }
 //! { async a() {} } → { a: function() {} }  (body는 async lowering)
 //! { *g() {} } → { g: function*() {} }      (이후 generator lowering)
@@ -28,7 +30,19 @@ const NodeList = ast_mod.NodeList;
 
 pub fn ES2015ObjectMethods(comptime Transformer: type) type {
     return struct {
-        /// object_expression 멤버 중 변환 대상 method_definition이 있는지 확인.
+        fn isPlainObjectMethod(flags: u32) bool {
+            return (flags & ast_mod.MethodFlags.is_getter) == 0 and
+                (flags & ast_mod.MethodFlags.is_setter) == 0;
+        }
+
+        fn methodNeedsFunctionLowering(self: *const Transformer, flags: u32) bool {
+            if (!isPlainObjectMethod(flags)) return false;
+            return self.options.unsupported.object_extensions or
+                (self.options.unsupported.async_await and (flags & ast_mod.MethodFlags.is_async) != 0) or
+                (self.options.unsupported.generator and (flags & ast_mod.MethodFlags.is_generator) != 0);
+        }
+
+        /// object_expression 멤버 중 method_definition이 있는지 확인.
         /// getter/setter(flags 0x02/0x04)는 ES5도 지원하므로 제외.
         pub fn hasObjectMethod(self: *const Transformer, node: Node) bool {
             const members = self.ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
@@ -36,9 +50,21 @@ pub fn ES2015ObjectMethods(comptime Transformer: type) type {
                 const m = self.ast.getNode(@enumFromInt(raw_idx));
                 if (m.tag != .method_definition) continue;
                 const flags = self.ast.extra_data.items[m.data.extra + ast_mod.MethodExtra.flags];
-                // getter / setter 는 ES5 지원 → 변환 제외
-                if ((flags & ast_mod.MethodFlags.is_getter) != 0 or (flags & ast_mod.MethodFlags.is_setter) != 0) continue;
+                if (!isPlainObjectMethod(flags)) continue;
                 return true;
+            }
+            return false;
+        }
+
+        /// 현재 타겟에서 method_definition → object_property + function_expression
+        /// 변환이 필요한 멤버가 있는지 확인.
+        pub fn needsObjectMethodLowering(self: *const Transformer, node: Node) bool {
+            const members = self.ast.extra_data.items[node.data.list.start .. node.data.list.start + node.data.list.len];
+            for (members) |raw_idx| {
+                const m = self.ast.getNode(@enumFromInt(raw_idx));
+                if (m.tag != .method_definition) continue;
+                const flags = self.ast.extra_data.items[m.data.extra + ast_mod.MethodExtra.flags];
+                if (methodNeedsFunctionLowering(self, flags)) return true;
             }
             return false;
         }
@@ -74,8 +100,8 @@ pub fn ES2015ObjectMethods(comptime Transformer: type) type {
                 const body_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[me + ast_mod.MethodExtra.body]);
                 const flags: u32 = self.ast.extra_data.items[me + ast_mod.MethodExtra.flags];
 
-                // getter/setter는 원본 그대로 방문 (ES5 지원)
-                if ((flags & ast_mod.MethodFlags.is_getter) != 0 or (flags & ast_mod.MethodFlags.is_setter) != 0) {
+                // getter/setter 또는 현재 타겟에서 보존 가능한 일반 method는 원본 그대로 방문.
+                if (!methodNeedsFunctionLowering(self, flags)) {
                     const new_m = try self.visitNode(m_idx);
                     if (!new_m.isNone()) try self.scratch.append(self.allocator, new_m);
                     continue;

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -166,15 +166,15 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
             // method shorthand → { key: function() {} } 를 먼저 처리.
             // function_expression 내부 async/generator lowering까지 visitNode 경로로 수행한 뒤,
             // computed key가 남아 있으면 아래 ES2015Computed가 후속 처리한다.
-            if (self.options.unsupported.object_extensions) {
-                if (es2015_object_methods.ES2015ObjectMethods(Transformer).hasObjectMethod(self, node)) {
-                    const lowered = try es2015_object_methods.ES2015ObjectMethods(Transformer).lowerObjectMethods(self, node);
-                    const lowered_node = self.ast.getNode(lowered);
+            if (es2015_object_methods.ES2015ObjectMethods(Transformer).needsObjectMethodLowering(self, node)) {
+                const lowered = try es2015_object_methods.ES2015ObjectMethods(Transformer).lowerObjectMethods(self, node);
+                const lowered_node = self.ast.getNode(lowered);
+                if (self.options.unsupported.object_extensions) {
                     if (es2015_computed.ES2015Computed(Transformer).hasComputedProperty(self, lowered_node)) {
                         return es2015_computed.ES2015Computed(Transformer).lowerComputedProperties(self, lowered_node);
                     }
-                    return lowered;
                 }
+                return lowered;
             }
             if (self.options.unsupported.object_extensions) {
                 if (es2015_computed.ES2015Computed(Transformer).hasComputedProperty(self, node)) {

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -166,7 +166,9 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
             // method shorthand → { key: function() {} } 를 먼저 처리.
             // function_expression 내부 async/generator lowering까지 visitNode 경로로 수행한 뒤,
             // computed key가 남아 있으면 아래 ES2015Computed가 후속 처리한다.
-            if (es2015_object_methods.ES2015ObjectMethods(Transformer).needsObjectMethodLowering(self, node)) {
+            if (self.options.unsupported.needsObjectMethodDownlevel() and
+                es2015_object_methods.ES2015ObjectMethods(Transformer).needsObjectMethodLowering(self, node))
+            {
                 const lowered = try es2015_object_methods.ES2015ObjectMethods(Transformer).lowerObjectMethods(self, node);
                 const lowered_node = self.ast.getNode(lowered);
                 if (self.options.unsupported.object_extensions) {


### PR DESCRIPTION
## 요약
- RN/Hermes 타겟에서 anonymous default class, async object method, async expression body, for-in/for-await-of, throw sequence, TS/Flow wrapper 내부 await downlevel 케이스를 보강했습니다.
- export destructuring BoundNames 수집과 wrapped CJS default re-export getter의 local binding 참조를 보정했습니다.
- RN Babel fallback에서 preset-typescript 강제 주입을 제거하고 파일 확장자별 parser plugin을 지정했습니다.

## 테스트
- `zig build test`
- `bun run lint` (기존 `tests/benchmark/smoke.ts` no-useless-escape 경고 4건만 출력)

## Simplify
- 생성 산출물(PNG, ios, zts.node, zts-out.js)은 PR에서 제외했습니다.
- 변경 범위는 RN downlevel/export binding 회귀와 관련 테스트로만 제한했습니다.