### PR TITLE
chore(profile): break down `resolve.resolver` into pkg.json / exports

### DIFF
--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -558,7 +558,11 @@ pub const Resolver = struct {
     /// 디렉토리 내 package.json에서 module/main 필드를 읽어 resolve 시도.
     /// fp-ts 등에서 사용하는 서브패스 package.json 패턴 지원.
     fn tryDirectoryPackageJson(self: *Resolver, dir_path: []const u8) ResolveError!?ResolveResult {
-        var parsed = pkg_json.parsePackageJson(self.allocator, dir_path) catch return null;
+        var parsed = blk: {
+            var pj_scope = profile.begin(.resolve_resolver_pkg_json);
+            defer pj_scope.end();
+            break :blk pkg_json.parsePackageJson(self.allocator, dir_path) catch return null;
+        };
         defer parsed.deinit();
 
         return self.resolveByMainFields(&parsed, dir_path);
@@ -654,12 +658,14 @@ pub const Resolver = struct {
     /// 우선순위: exports → module → main → index 파일
     fn resolvePackage(self: *Resolver, pkg_dir_path: []const u8, subpath: []const u8) ResolveError!?ResolveResult {
         // package.json 파싱 시도
-        var parsed = pkg_json.parsePackageJson(self.allocator, pkg_dir_path) catch |err| switch (err) {
-            error.FileNotFound => {
+        var parsed = blk: {
+            var pj_scope = profile.begin(.resolve_resolver_pkg_json);
+            defer pj_scope.end();
+            break :blk pkg_json.parsePackageJson(self.allocator, pkg_dir_path) catch |err| switch (err) {
                 // package.json 없으면 index 파일 탐색
-                return self.tryDirectoryIndex(pkg_dir_path);
-            },
-            else => return null,
+                error.FileNotFound => return self.tryDirectoryIndex(pkg_dir_path),
+                else => return null,
+            };
         };
         defer parsed.deinit();
 
@@ -675,7 +681,12 @@ pub const Resolver = struct {
         const exports_subpath = allocated_subpath orelse subpath;
 
         if (pkg.exports) |exports| {
-            if (pkg_json.resolveExports(self.allocator, exports, exports_subpath, self.conditions)) |exports_result| {
+            const exports_match = blk: {
+                var ex_scope = profile.begin(.resolve_resolver_exports);
+                defer ex_scope.end();
+                break :blk pkg_json.resolveExports(self.allocator, exports, exports_subpath, self.conditions);
+            };
+            if (exports_match) |exports_result| {
                 defer if (exports_result.allocated) self.allocator.free(exports_result.path);
                 const abs_path = std.fs.path.resolve(self.allocator, &.{ pkg_dir_path, exports_result.path }) catch
                     return error.OutOfMemory;

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -61,6 +61,8 @@ pub const Category = enum {
     resolve_cache_lookup,
     resolve_browser_override,
     resolve_resolver,
+    resolve_resolver_pkg_json,
+    resolve_resolver_exports,
     resolve_cache_store,
     resolve_path,
     resolve_file_exists,


### PR DESCRIPTION
## 배경

`resolve.resolver` (실제 resolve 알고리즘 — `Resolver.resolve()`, 병렬 discover 에서 모듈당 호출)는 `--profile` 에서 ~3.4s aggregate(react-native-bare 기준)인데 내부 breakdown 이 없어서 "package.json 파싱이 얼마인지 / exports-field 매칭이 얼마인지"가 안 보였습니다. ("측정부터 하자" 의 연속 — #3125 의 `metadata.*` 와 같은 맥락.)

## 변경

`resolvePackage` / `tryDirectoryPackageJson` 의 호출을 sub-phase 로 감쌈:
- `resolve.resolver.pkg.json` — `pkg_json.parsePackageJson` (path.join + readFile + `std.json.parseFromSlice` + alloc)
- `resolve.resolver.exports` — `pkg_json.resolveExports` (conditions 매칭)

`blk: { var s = profile.begin(...); defer s.end(); break :blk EXPR; }` 패턴 (#3125 / `metadata.zig` / `parse_module.zig` 와 동일 — `try`/optional 식을 인덴트 변경 없이 timing). `--profile` 비활성 시 zero-cost (`begin` early return).

## 이 측정으로 드러난 것

react-native-bare 번들 `--profile=resolve --profile-level=detailed`:
- `resolve.resolver.pkg.json` = **699ms / 346회 = 모듈당 ~2ms** ← `parsePackageJson` 이 **캐시 안 됨**. `DirEntryCache`(readdir)·`RealpathCache`(realpath) 는 있는데 package.json 캐시는 없어서, 같은 `react/package.json` 을 importer 디렉토리마다 다시 read+parse. → `PackageJsonCache` (DirEntryCache 와 같은 thread-safe-build-outside-lock 패턴) 추가하면 ~700ms aggregate 의 절반 이상 절감 가능. **후속 PR 후보.**
- `resolve.resolver.exports` = **3.86ms / 108회** ← exports 매칭은 무시 가능.
- `resolve.resolver` self (모든 children 제외) ≈ **510ms** ← node_modules walk-up 루프 (`dirExists` 체크들 + `splitBareSpecifier` + condition 셋업 + alias/fallback).

전체 `resolve` ~5.8s = `resolver` 3.4s (pkg.json 0.7 + path 0.6 + extensions 0.94 + dir.index 0.45 + file.exists 0.24 + realpath 0.15 + walk 0.51) + `cache.lookup/store` ~1.1s (cache_mutex 경합) + 기타.

## 테스트
- `zig build test` ✅ 전체
- `tests/integration`: `profile-flags` 12/12, `bundle-smoke` 150/150, `resolve-fallback` + `pnpm-bundle` ✅
- `/simplify`: reuse / quality / efficiency 리뷰 — 이슈 없음 (패턴이 기존과 동일, `defer` scope-close 가 `catch ... return` 경로에서도 정상, 트리 리포터 중복 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)