### PR TITLE
fix(profile): WASM 빌드에서 64-bit atomic counter 컴파일 실패 수정

### DIFF
--- a/src/profile.zig
+++ b/src/profile.zig
@@ -29,6 +29,31 @@
 //! 자세한 내용은 `docs/design/profile-infrastructure.md`.
 
 const std = @import("std");
+const builtin = @import("builtin");
+
+/// counters(`totals_ns` 등)를 atomic 으로 갱신할지 여부 (comptime).
+///
+/// native multi-thread 빌드는 worker pool 에서 phase 가 동시에 끝나므로 atomic add 가
+/// 필요하다(lost update 방지). 두 경우만 예외로 plain `+=`:
+/// - `single_threaded` 빌드(transpile-only `zig build wasm`) — race 자체가 없음.
+/// - WASM — Zig 0.15.2 는 64-bit atomic RMW(`@atomicRmw(u64, …)`)를 지원하지 않는다
+///   (atomics feature 가 있는 `wasm-bundler` 타깃도 "expected 32-bit integer type or
+///   smaller" 로 컴파일 실패). wasm-bundler 가 multi-thread 라도 profile 카운터의 가끔
+///   발생하는 lost update 는 허용한다 — 번들 정확성과 무관한 진단용 수치이고, thread-aware
+///   한 핵심 수정(nesting 스택 threadlocal 화)은 이 flag 와 무관하게 항상 적용된다.
+const atomic_counters = !builtin.single_threaded and !builtin.cpu.arch.isWasm();
+
+inline fn atomicAdd(comptime T: type, slot: *T, delta: T) void {
+    if (atomic_counters) {
+        _ = @atomicRmw(T, slot, .Add, delta, .monotonic);
+    } else {
+        slot.* += delta;
+    }
+}
+
+inline fn atomicGet(comptime T: type, slot: *const T) T {
+    return if (atomic_counters) @atomicLoad(T, slot, .monotonic) else slot.*;
+}
 
 // ============================================================================
 // Category & Level
@@ -569,22 +594,22 @@ fn recordTiming(cat: Category, ns: u64, self_ns: u64) void {
     const idx = @intFromEnum(cat);
     // 여러 worker thread 가 동시에 기록할 수 있으므로 atomic add (lost update 방지).
     // 측정 구간(`t.read()`) 밖이라 contention 시간이 sample 에 섞이지 않는다.
-    _ = @atomicRmw(u64, &totals_ns[idx], .Add, ns, .monotonic);
-    _ = @atomicRmw(u64, &self_totals_ns[idx], .Add, self_ns, .monotonic);
-    _ = @atomicRmw(u32, &counts[idx], .Add, 1, .monotonic);
+    atomicAdd(u64, &totals_ns[idx], ns);
+    atomicAdd(u64, &self_totals_ns[idx], self_ns);
+    atomicAdd(u32, &counts[idx], 1);
 }
 
 /// 수집된 원시 데이터 조회 (테스트 + 외부 리포터용). 모든 스레드 합산값.
 pub fn totalNs(cat: Category) u64 {
-    return @atomicLoad(u64, &totals_ns[@intFromEnum(cat)], .monotonic);
+    return atomicGet(u64, &totals_ns[@intFromEnum(cat)]);
 }
 
 pub fn selfNs(cat: Category) u64 {
-    return @atomicLoad(u64, &self_totals_ns[@intFromEnum(cat)], .monotonic);
+    return atomicGet(u64, &self_totals_ns[@intFromEnum(cat)]);
 }
 
 pub fn count(cat: Category) u32 {
-    return @atomicLoad(u32, &counts[@intFromEnum(cat)], .monotonic);
+    return atomicGet(u32, &counts[@intFromEnum(cat)]);
 }
 
 // ============================================================================
@@ -603,7 +628,7 @@ pub fn report(writer: anytype, format: Format) !void {
 
 fn totalAllNs() u64 {
     var sum: u64 = 0;
-    for (&self_totals_ns) |*ns| sum += @atomicLoad(u64, ns, .monotonic);
+    for (&self_totals_ns) |*ns| sum += atomicGet(u64, ns);
     return sum;
 }
 


### PR DESCRIPTION
## 문제

`12b917a2 fix(profile): make timer aggregation thread-safe` 가 `recordTiming` 의 카운터 증분을 `@atomicRmw(u64, …)` 로 바꿨는데, **Zig 0.15.2 의 wasm32 백엔드는 64-bit atomic RMW 를 지원하지 않습니다.** 그래서 CI 의 WASM 빌드가 깨졌습니다:

```
src/profile.zig:572:20: error: expected 32-bit integer type or smaller; found 64-bit integer type
    _ = @atomicRmw(u64, &totals_ns[idx], .Add, ns, .monotonic);
```

- `zig build wasm` (wasm32-wasi, `-mcpu baseline` → atomics feature 없음): 실패
- `zig build wasm-bundler` (wasm32-wasi + `atomics`/`bulk_memory` features): **이것도** 실패 — Zig 0.15.2 에서는 atomics feature 가 있어도 64-bit atomic RMW 는 막혀 있음

## 수정

- comptime flag `atomic_counters = !builtin.single_threaded and !builtin.cpu.arch.isWasm()` 도입
- `atomicAdd` / `atomicGet` 헬퍼로 atomic ↔ plain 분기를 한 곳에 일원화 (`recordTiming` / `totalNs` / `selfNs` / `count` / `totalAllNs`)
- WASM 에서는 plain `+=`:
  - transpile-only(`zig build wasm`)는 single-thread 라 애초에 race 없음
  - `wasm-bundler` 는 multi-thread 지만 profile 카운터의 가끔 발생하는 lost update 는 허용 — 번들 결과 정확성과 무관한 진단용 수치이고, 원래 `12b917a2` 의 핵심 수정(nesting 스택 `threadlocal` 화)은 이 flag 와 무관하게 그대로 적용됨
- native multi-thread 빌드는 종전대로 atomic add

## 검증

- `zig build` / `zig build wasm` / `zig build wasm-bundler` 모두 통과
- `zig build test` (profile 28개 유닛 테스트 포함) 통과

> Zig 초보자용 메모: `@atomicRmw` 는 "read-modify-write 를 한 번에" 하는 빌트인이라 여러 스레드가 동시에 `+=` 해도 값이 유실되지 않습니다. comptime 분기(`if (atomic_counters)`)는 빌드 타임에 한 쪽만 남으므로 런타임 비용이 없습니다. `inline fn` 이라 호출 오버헤드도 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)