### PR TITLE
perf(resolver): cache parsed package.json per directory

### DIFF
--- a/src/bundler/package_json.zig
+++ b/src/bundler/package_json.zig
@@ -104,6 +104,107 @@ pub const ParsedPackageJson = struct {
     }
 };
 
+/// 디렉토리당 1회만 package.json 을 read+parse 하는 thread-safe 캐시.
+/// `parsePackageJson` 자체는 캐시가 없어서 (cf. `DirEntryCache`/`RealpathCache` 는 있음)
+/// 같은 `node_modules/<pkg>/package.json` 을 importer 디렉토리마다 다시 읽었다 — 대형
+/// RN 그래프에서 `resolve.resolver.pkg.json` ~0.7s aggregate.
+///
+/// `DirEntryCache` 와 동일 패턴: shared lock 으로 조회, 미스면 lock 밖에서 parse,
+/// 다 만든 뒤 짧게 exclusive lock 으로 삽입 (그 사이 다른 스레드가 먼저 넣었으면 폐기).
+/// 반환 포인터는 캐시 소유 — 호출자가 `deinit` 하면 안 된다 (deinit 전까지 유효).
+/// `PackageJsonCache.getOrParse` 의 에러 — `parsePackageJson` 의 deterministic 에러
+/// (FileNotFound/IoError/JsonParseError)는 캐시되고, OutOfMemory 는 transient 라 전파.
+pub const PkgJsonCacheError = error{ FileNotFound, IoError, JsonParseError, OutOfMemory };
+
+pub const PackageJsonCache = struct {
+    cache: std.StringHashMap(Entry),
+    rwlock: std.Thread.RwLock = .{},
+    allocator: std.mem.Allocator,
+
+    const Entry = union(enum) {
+        ok: *ParsedPackageJson,
+        file_not_found,
+        io_error,
+        parse_error,
+
+        fn result(self: Entry) PkgJsonCacheError!*ParsedPackageJson {
+            return switch (self) {
+                .ok => |p| p,
+                .file_not_found => error.FileNotFound,
+                .io_error => error.IoError,
+                .parse_error => error.JsonParseError,
+            };
+        }
+    };
+
+    pub fn init(allocator: std.mem.Allocator) PackageJsonCache {
+        return .{ .cache = std.StringHashMap(Entry).init(allocator), .allocator = allocator };
+    }
+
+    fn freeBuilt(self: *PackageJsonCache, built: ?*ParsedPackageJson) void {
+        if (built) |p| {
+            p.deinit();
+            self.allocator.destroy(p);
+        }
+    }
+
+    pub fn deinit(self: *PackageJsonCache) void {
+        var it = self.cache.iterator();
+        while (it.next()) |entry| {
+            if (entry.value_ptr.* == .ok) self.freeBuilt(entry.value_ptr.ok);
+            self.allocator.free(entry.key_ptr.*);
+        }
+        self.cache.deinit();
+    }
+
+    pub fn getOrParse(self: *PackageJsonCache, pkg_dir_path: []const u8) PkgJsonCacheError!*ParsedPackageJson {
+        // 1. fast path — shared lock 으로 조회.
+        {
+            self.rwlock.lockShared();
+            defer self.rwlock.unlockShared();
+            if (self.cache.get(pkg_dir_path)) |entry| return entry.result();
+        }
+
+        // 2. 캐시 미스 — lock 없이 parse. (errdefer 는 안 쓴다 — `result()` 가 음수 entry 일 때
+        //  error 를 반환하므로 errdefer 가 "성공적으로 캐시한 key" 까지 free 해버려 double-free.)
+        var built: ?*ParsedPackageJson = null;
+        const new_entry: Entry = blk: {
+            const parsed = parsePackageJson(self.allocator, pkg_dir_path) catch |err| switch (err) {
+                error.FileNotFound => break :blk .file_not_found,
+                error.IoError => break :blk .io_error,
+                error.JsonParseError => break :blk .parse_error,
+                error.OutOfMemory => return error.OutOfMemory, // transient — 캐시 안 함
+            };
+            const p = self.allocator.create(ParsedPackageJson) catch {
+                var pp = parsed;
+                pp.deinit();
+                return error.OutOfMemory;
+            };
+            p.* = parsed;
+            built = p;
+            break :blk .{ .ok = p };
+        };
+
+        // 3. exclusive lock 으로 삽입. 그 사이 다른 스레드가 먼저 넣었을 수 있다.
+        self.rwlock.lock();
+        defer self.rwlock.unlock();
+        if (self.cache.get(pkg_dir_path)) |existing| {
+            self.freeBuilt(built);
+            return existing.result();
+        }
+        const key = self.allocator.dupe(u8, pkg_dir_path) catch {
+            self.freeBuilt(built);
+            return error.OutOfMemory;
+        };
+        self.cache.put(key, new_entry) catch {
+            self.allocator.free(key);
+            self.freeBuilt(built);
+            return error.OutOfMemory;
+        };
+        return new_entry.result();
+    }
+};
+
 /// `pkg_dir_path` 디렉토리의 package.json 을 읽고 파싱한다. path 기반 시그니처로
 /// fs.zig 추상화 통과 — std.fs.Dir 핸들 의존 제거 (#1921, #1885 Phase 1 완성).
 pub fn parsePackageJson(allocator: std.mem.Allocator, pkg_dir_path: []const u8) !ParsedPackageJson {
@@ -338,9 +439,3 @@ fn parseSideEffects(obj: std.json.ObjectMap, allocator: std.mem.Allocator) Packa
         else => return .unknown,
     }
 }
-
-pub const Error = error{
-    FileNotFound,
-    JsonParseError,
-    OutOfMemory,
-};

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -57,6 +57,8 @@ pub const ResolveCache = struct {
     /// 디렉토리 엔트리 캐시 — readdir() 결과를 메모리에 보관하여 stat() syscall 대폭 감소.
     dir_cache: resolver_mod.DirEntryCache,
     realpath_cache: resolver_mod.RealpathCache,
+    /// package.json 파싱 캐시 — 디렉토리당 1회 read+parse (importer 디렉토리마다 재파싱 방지).
+    pkg_json_cache: pkg_json.PackageJsonCache,
 
     /// 패키지 디렉토리별 browser 필드 override 캐시 (disabled + string remap).
     /// pkg_dir_path → BrowserOverrides (null 이면 browser 필드 없음).
@@ -232,6 +234,7 @@ pub const ResolveCache = struct {
             .packages_external = options.packages_external,
             .dir_cache = resolver_mod.DirEntryCache.init(allocator),
             .realpath_cache = resolver_mod.RealpathCache.init(allocator),
+            .pkg_json_cache = pkg_json.PackageJsonCache.init(allocator),
             .browser_overrides_cache = std.StringHashMap(?BrowserOverrides).init(allocator),
             .conditions_import = cond_import,
             .conditions_require = cond_require,
@@ -243,6 +246,7 @@ pub const ResolveCache = struct {
     pub fn deinit(self: *ResolveCache) void {
         self.dir_cache.deinit();
         self.realpath_cache.deinit();
+        self.pkg_json_cache.deinit();
 
         // 캐시된 경로 문자열 해제
         var it = self.cache.iterator();
@@ -401,6 +405,7 @@ pub const ResolveCache = struct {
         local_resolver.conditions = self.conditionsFor(kind);
         local_resolver.dir_cache = &self.dir_cache;
         local_resolver.realpath_cache = &self.realpath_cache;
+        local_resolver.pkg_json_cache = &self.pkg_json_cache;
         if (!thread_safe) {
             // 단일 스레드: self.resolver의 conditions를 직접 교체 후 복원
             self.resolver.conditions = local_resolver.conditions;
@@ -640,11 +645,8 @@ pub const ResolveCache = struct {
     /// package.json 의 browser 필드를 4 축 (path/module × disabled/remap) 으로 수집.
     /// 키 prefix 로 분류: "./foo" → path-key, 나머지는 bare module key (#1530).
     fn buildBrowserOverrides(self: *ResolveCache, pkg_dir_path: []const u8) ?BrowserOverrides {
-        // self.allocator 통과 — page_allocator 가 wasm32 multi-threaded 미지원 (#1885 Phase 2).
-        // parsed.deinit() 이 같은 allocator 로 free 하므로 leak 없음.
-        var parsed = pkg_json.parsePackageJson(self.allocator, pkg_dir_path) catch return null;
-        defer parsed.deinit();
-
+        // pkg_json_cache 가 소유 — 여기서 deinit 하지 않는다 (디렉토리당 1회 parse 재사용).
+        const parsed = self.pkg_json_cache.getOrParse(pkg_dir_path) catch return null;
         const browser_map = parsed.pkg.browser_map orelse return null;
         const browser_obj = browser_map.object;
 

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -324,6 +324,9 @@ pub const Resolver = struct {
     /// Directory-level realpath 캐시. null 이면 매번 fs.realpath() 호출 (테스트용).
     /// 같은 디렉토리의 N 개 파일 → 1 realpath syscall. 대형 그래프에서 큰 비중.
     realpath_cache: ?*RealpathCache = null,
+    /// package.json 파싱 캐시. null 이면 매번 read+parse (테스트용).
+    /// 같은 `node_modules/<pkg>/package.json` 을 importer 디렉토리마다 다시 읽지 않게.
+    pkg_json_cache: ?*pkg_json.PackageJsonCache = null,
     /// NODE_PATH 추가 탐색 경로 (--node-paths). 상위 디렉토리 탐색 실패 시 폴백.
     node_paths: []const []const u8 = &.{},
 
@@ -555,17 +558,37 @@ pub const Resolver = struct {
         return null;
     }
 
+    /// package.json 을 캐시(있으면) 또는 직접 read+parse 한다.
+    /// 캐시 hit/miss 면 borrowed 포인터 (deinit 금지) + `owned_out` 는 null 그대로.
+    /// 캐시 없으면 (테스트 경로) `owned_out` 에 by-value 결과를 두고 그 포인터를 반환 — 호출자가
+    /// `owned_out` 의 lifetime/deinit 을 관리. 어느 쪽이든 반환은 `*ParsedPackageJson`.
+    fn getPackageJson(
+        self: *Resolver,
+        dir_path: []const u8,
+        owned_out: *?pkg_json.ParsedPackageJson,
+    ) pkg_json.PkgJsonCacheError!*pkg_json.ParsedPackageJson {
+        var pj_scope = profile.begin(.resolve_resolver_pkg_json);
+        defer pj_scope.end();
+        if (self.pkg_json_cache) |cache| {
+            owned_out.* = null;
+            return cache.getOrParse(dir_path);
+        }
+        owned_out.* = pkg_json.parsePackageJson(self.allocator, dir_path) catch |err| switch (err) {
+            error.FileNotFound => return error.FileNotFound,
+            error.IoError => return error.IoError,
+            error.JsonParseError => return error.JsonParseError,
+            error.OutOfMemory => return error.OutOfMemory,
+        };
+        return &owned_out.*.?;
+    }
+
     /// 디렉토리 내 package.json에서 module/main 필드를 읽어 resolve 시도.
     /// fp-ts 등에서 사용하는 서브패스 package.json 패턴 지원.
     fn tryDirectoryPackageJson(self: *Resolver, dir_path: []const u8) ResolveError!?ResolveResult {
-        var parsed = blk: {
-            var pj_scope = profile.begin(.resolve_resolver_pkg_json);
-            defer pj_scope.end();
-            break :blk pkg_json.parsePackageJson(self.allocator, dir_path) catch return null;
-        };
-        defer parsed.deinit();
-
-        return self.resolveByMainFields(&parsed, dir_path);
+        var pj_owned: ?pkg_json.ParsedPackageJson = null;
+        defer if (pj_owned) |*o| o.deinit();
+        const parsed = self.getPackageJson(dir_path, &pj_owned) catch return null;
+        return self.resolveByMainFields(parsed, dir_path);
     }
 
     /// package.json의 main_fields 또는 기본 순서(module → main)로 엔트리포인트를 찾는다.
@@ -657,17 +680,14 @@ pub const Resolver = struct {
     /// 패키지 디렉토리에서 엔트리포인트를 해석한다.
     /// 우선순위: exports → module → main → index 파일
     fn resolvePackage(self: *Resolver, pkg_dir_path: []const u8, subpath: []const u8) ResolveError!?ResolveResult {
-        // package.json 파싱 시도
-        var parsed = blk: {
-            var pj_scope = profile.begin(.resolve_resolver_pkg_json);
-            defer pj_scope.end();
-            break :blk pkg_json.parsePackageJson(self.allocator, pkg_dir_path) catch |err| switch (err) {
-                // package.json 없으면 index 파일 탐색
-                error.FileNotFound => return self.tryDirectoryIndex(pkg_dir_path),
-                else => return null,
-            };
+        // package.json 파싱 시도 (캐시 통과)
+        var pj_owned: ?pkg_json.ParsedPackageJson = null;
+        defer if (pj_owned) |*o| o.deinit();
+        const parsed = self.getPackageJson(pkg_dir_path, &pj_owned) catch |err| switch (err) {
+            // package.json 없으면 index 파일 탐색
+            error.FileNotFound => return self.tryDirectoryIndex(pkg_dir_path),
+            else => return null,
         };
-        defer parsed.deinit();
 
         const pkg = &parsed.pkg;
 
@@ -718,7 +738,7 @@ pub const Resolver = struct {
             return null;
         }
 
-        if (try self.resolveByMainFields(&parsed, pkg_dir_path)) |result| return result;
+        if (try self.resolveByMainFields(parsed, pkg_dir_path)) |result| return result;
 
         // 4. index 파일 폴백
         return self.tryDirectoryIndex(pkg_dir_path);


### PR DESCRIPTION
## 문제

`pkg_json.parsePackageJson` 은 캐시가 없습니다 (`DirEntryCache`(readdir)·`RealpathCache`(realpath) 는 있는데). 그래서 같은 `node_modules/<pkg>/package.json` 을 importer 디렉토리마다 다시 `readFile` + `std.json.parseFromSlice` + alloc 했습니다. react-native-bare 번들 측정(#3127 의 `resolve.resolver.pkg.json` 계측): **~0.7s aggregate / 346회** (≈ 디렉토리당 2.5배 중복 파싱).

## 변경

- **`PackageJsonCache`** (`package_json.zig`) — `DirEntryCache` 와 동일 패턴:
  - shared lock(`RwLock`)으로 조회 → 미스면 **lock 없이** parse → 다 만든 뒤 짧게 exclusive lock 으로 삽입(그 사이 다른 스레드가 먼저 넣었으면 내 것 폐기).
  - `*ParsedPackageJson` 을 heap 에 두고 map 에 포인터 저장 — 캐시 소유, 호출자는 `deinit` 하면 안 됨 (cache `deinit` 전까지 유효).
  - `FileNotFound`/`IoError`/`JsonParseError` 는 캐시(deterministic), `OutOfMemory` 는 transient 라 캐시 안 하고 전파.
- **`ResolveCache`** 가 소유 (`dir_cache`/`realpath_cache` 와 나란히 init/deinit), `resolveInner` 가 per-thread resolver 에 `&self.pkg_json_cache` 연결. `buildBrowserOverrides` 도 캐시 통과.
- **`Resolver`** 에 `pkg_json_cache: ?*PackageJsonCache` (null = 테스트용 bare `Resolver.init`, 직접 parse). `getPackageJson` 헬퍼가 borrowed(캐시 hit/miss)/owned(no-cache, out-param 으로 호출자가 lifetime 관리) 둘 다 처리해서 호출처 변경 최소화.
- 부수: 미사용 dead `pub const Error` (package_json.zig, `PkgJsonCacheError` 와 near-dup) 제거.

## 효과

react-native-bare `--profile=resolve --profile-level=detailed`:
- `resolve.resolver.pkg.json`: **699ms → 138ms** (~5x, 디렉토리당 1회로 dedup)
- `resolve` aggregate: **5.8s → 5.4s**
- wall: 1.55s → ~1.48-1.5s (병렬 phase 라 wall 임팩트는 작음 — aggregate 가 핵심)
- **출력 불변** — resolve 결과가 동일하고 파싱만 dedup 함.

## Zig 메모

- `std.json.Parsed(T)` 는 `{ arena: *ArenaAllocator, value: T }` — by-value 복사가 안전 (포인터 복사). `p.* = parsed` 후 죽은 로컬 `parsed` 는 안 건드리고 `p` 만 살아있음 → `deinit` 한 번만.
- borrowed-vs-owned: 캐시 있으면 캐시 소유 포인터를 빌려주고, 없으면 호출자 스택의 `?ParsedPackageJson` out-param 에 두고 그 포인터 반환 + 호출자가 `defer ... deinit`.
- 음수 entry 캐시(`.file_not_found` 등) 시 `getOrParse` 가 error 를 *반환*하므로 — `errdefer self.allocator.free(key)` 를 쓰면 "방금 캐시에 넣은 key" 가 errdefer 로 free 되어 `deinit` 때 double-free. 그래서 `errdefer` 대신 각 실패 경로에서 명시적 cleanup. (이전 리뷰 라운드에서 실제로 이 double-free 가 터졌고 그렇게 고침.)

## 테스트
- `zig build test` ✅ 전체 (4898 tests)
- `tests/integration`: `bundle-smoke` 150 + `resolve-fallback` + `pnpm-bundle` + `es5-rn` 30 + `bundle-circular-cycle` = 199/199
- `/simplify`: reuse + correctness/quality 2-agent 리뷰 — must-fix 없음. nice-to-have 2건(dead `Error` 제거, `freeBuilt` 헬퍼) 반영. 모든 ownership 경로(parse-error / OOM-on-create / race-lost / dupe-OOM / put-OOM / success / 워커 arena) sound 확인.

후속 후보: `resolveSubpathImports`(`#imports`)도 캐시 통과시키기 (소규모, 효과 적음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)