### PR TITLE
perf(resolver): probe candidate extensions via dir cache, not full-path allocs

### DIFF
--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -495,14 +495,20 @@ pub const Resolver = struct {
         defer scope.end();
 
         const extensions = if (self.custom_extensions.len > 0) self.custom_extensions else default_extensions;
+        // dir_cache 멤버십 체크는 (dir, name) 으로 한다 — 후보마다 full path 를 alloc 하지 않고
+        // basename 만 stack 버퍼에서 조립해 확인, hit 일 때만 full path 를 1회 alloc.
+        const dir = std.fs.path.dirname(base) orelse return null;
+        const stem = std.fs.path.basename(base);
+        var name_buf: [std.fs.max_name_bytes]u8 = undefined;
         for (extensions) |ext| {
-            const path = std.mem.concat(self.allocator, u8, &.{ base, ext }) catch
-                return error.OutOfMemory;
-            defer self.allocator.free(path);
+            if (stem.len + ext.len > name_buf.len) continue; // NAME_MAX 초과 — 실존 불가
+            @memcpy(name_buf[0..stem.len], stem);
+            @memcpy(name_buf[stem.len..][0..ext.len], ext);
+            if (!self.fileExistsIn(dir, name_buf[0 .. stem.len + ext.len])) continue;
 
-            if (self.fileExists(path)) {
-                return self.makeResult(path);
-            }
+            const path = std.mem.concat(self.allocator, u8, &.{ base, ext }) catch return error.OutOfMemory;
+            defer self.allocator.free(path);
+            return self.makeResult(path);
         }
         return null;
     }
@@ -546,14 +552,20 @@ pub const Resolver = struct {
         if (try self.tryDirectoryPackageJson(path)) |result| return result;
 
         const extensions = if (self.custom_extensions.len > 0) self.custom_extensions else default_extensions;
+        // `index<ext>` 후보는 짧으니 stack 버퍼에서 조립 → dir_cache 멤버십만 확인,
+        // hit 일 때만 full path 를 1회 alloc (cf. tryExtensions).
+        const idx_prefix = "index";
+        var name_buf: [std.fs.max_name_bytes]u8 = undefined;
+        @memcpy(name_buf[0..idx_prefix.len], idx_prefix);
         for (extensions) |ext| {
-            const index_name = std.mem.concat(self.allocator, u8, &.{ "index", ext }) catch
-                return error.OutOfMemory;
-            defer self.allocator.free(index_name);
+            if (idx_prefix.len + ext.len > name_buf.len) continue;
+            @memcpy(name_buf[idx_prefix.len..][0..ext.len], ext);
+            const index_name = name_buf[0 .. idx_prefix.len + ext.len];
+            if (!self.fileExistsIn(path, index_name)) continue;
             const index_path = std.fs.path.resolve(self.allocator, &.{ path, index_name }) catch
                 return error.OutOfMemory;
             defer self.allocator.free(index_path);
-            if (self.fileExists(index_path)) return self.makeResult(index_path);
+            return self.makeResult(index_path);
         }
         return null;
     }
@@ -808,17 +820,25 @@ pub const Resolver = struct {
     }
 
     fn fileExists(self: *const Resolver, path: []const u8) bool {
+        const dir_path = std.fs.path.dirname(path) orelse return false;
+        const file_name = std.fs.path.basename(path);
+        return self.fileExistsIn(dir_path, file_name);
+    }
+
+    /// `dir_path` 안에 `file_name` 이 있는지. 후보 확장자 탐색 등에서 full path 를 매번
+    /// alloc 했다가 `fileExists` 가 다시 dirname/basename 으로 쪼개던 낭비를 피한다 — caller 가
+    /// dir + name 을 직접 넘긴다. (DirEntryCache 자체가 dir 단위 readdir 캐시라 이게 자연스럽다.)
+    fn fileExistsIn(self: *const Resolver, dir_path: []const u8, file_name: []const u8) bool {
         var scope = profile.begin(.resolve_file_exists);
         defer scope.end();
-
+        if (file_name.len == 0) return false;
         if (self.dir_cache) |cache| {
-            const dir_path = std.fs.path.dirname(path) orelse return false;
-            const file_name = std.fs.path.basename(path);
-            if (file_name.len == 0) return false;
             // constCast: getOrLoad 내부에서 캐시 write를 위해 mutex 사용
             return @constCast(cache).hasFile(dir_path, file_name);
         }
-        const stat = fs.statFile(path) catch return false;
+        var buf: [std.fs.max_path_bytes]u8 = undefined;
+        const joined = std.fmt.bufPrint(&buf, "{s}{c}{s}", .{ dir_path, std.fs.path.sep, file_name }) catch return false;
+        const stat = fs.statFile(joined) catch return false;
         return stat.kind == .file;
     }
 


### PR DESCRIPTION
## 문제

`tryExtensions` / `tryDirectoryIndex` 는 후보 확장자마다 (default 9개, RN preset 은 `.ios.js`/`.native.tsx`/... 포함 15~25개) full path 를 새로 alloc 했습니다:
- `tryExtensions`: `std.mem.concat(allocator, &.{base, ext})` → `fileExists(fullpath)` → free
- `tryDirectoryIndex`: `concat("index", ext)` + `path.resolve(dir, index_name)` → `fileExists` → free

그런데 `fileExists` 는 받은 full path 를 곧바로 `dirname`/`basename` 으로 쪼개 `dir_cache.hasFile(dir, name)` 를 호출합니다 (`DirEntryCache` 가 dir 단위 readdir 캐시라). 즉 **모듈당 ~20번의 full-path alloc 이 멤버십 체크 한 번 하려고 만들어졌다가 버려졌습니다.** react-native-bare 번들에서 `resolve.extensions` ~1.1s + `resolve.directory.index` ~0.65s aggregate.

## 변경

- **`fileExistsIn(dir, name)` 헬퍼** — `dir_cache.hasFile(dir, name)` 직접 호출 (full path 안 만듦). `fileExists(path)` 는 `fileExistsIn(dirname(path), basename(path))` 로 위임. `profile.begin(.resolve_file_exists)` 도 여기로 이동 (sample 수 불변 — 1:1 치환).
- **`tryExtensions`**: `base` 를 `dir = dirname(base)` + `stem = basename(base)` 으로 1회 분리 → 후보마다 `stem ++ ext` 를 stack 버퍼(`[std.fs.max_name_bytes]u8`)에서 조립해 `fileExistsIn(dir, ...)` 으로 확인 → **hit 일 때만** `concat(base, ext)` 1회 alloc 해서 `makeResult`.
- **`tryDirectoryIndex`**: 동일 — `"index" ++ ext` stack 버퍼 → hit 일 때만 `path.resolve(path, index_name)`.
- NAME_MAX 초과 후보는 `continue` (그런 파일명은 실존 불가).

동작 불변: `base` 는 항상 `std.fs.path.resolve(...)` 결과(정규화된 절대경로, trailing sep 없음)이므로 `dirname(base ++ ext) == dirname(base)` 이고 `basename(base ++ ext) == basename(base) ++ ext`. `base` 가 dirname 없는 경우(`"/"` 뿐)는 old 코드도 모든 후보에 대해 false 였으니 `return null` early 와 등가.

## 효과 (react-native-bare)

- `resolve.extensions`: 1.1s → **0.29s self** (~3.5x)
- `resolve.directory.index`: 0.65s → **0.04s self** (~16x)
- `resolve` aggregate: 4.4s → **2.4s** (~2s 절감)
- **wall: 1.5s → 1.30s (~13%)** — 이 세션에서 처음으로 wall 이 의미있게 줄었습니다. full-path alloc 제거가 worker 16스레드의 allocator 경합까지 줄여서 (병렬 phase 의 aggregate-/-N 추정보다) 더 큼.
- 출력 불변 (resolve 결과 동일 — 멤버십을 다르게 확인할 뿐, 최종 경로는 그대로).

## 테스트
- `zig build test` ✅ 전체
- `tests/integration`: `bundle-smoke` 150 + `resolve-fallback` + `pnpm-bundle` + `bundle-circular-cycle` + `es5-rn` 30 = 199/199
- `/simplify`: correctness 리뷰 — 동작 등가성(`base`/`path` edge case 전부), stack 버퍼 bound(`@memcpy` off-by-one 없음, NAME_MAX guard), no-cache fallback(`bufPrint` 재구성), alloc-failure 경로 모두 sound. 이슈 없음.

(곁다리: `tryTsExtensionMapping` 도 같은 패턴이지만 `resolve.ts.extension.map` ≈ 0ms 라 안 건드림 — `.js`→`.ts` 매핑은 rare.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)