### PR TITLE
fix(bundler): use getEnvVarOwned for ZNTC_MODULE_STATS (Windows build)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1058,7 +1058,11 @@ pub const Bundler = struct {
         graph_scope.end();
 
         // PoC: ZNTC_MODULE_STATS=1 → 모듈 분류 히스토그램 (plain-dep 고속 경로 견적용).
-        if (std.posix.getenv("ZNTC_MODULE_STATS") != null) dumpModuleStats(&graph);
+        // `std.posix.getenv` 은 Windows 미지원 — `getEnvVarOwned` 로 cross-platform 체크.
+        if (std.process.getEnvVarOwned(self.allocator, "ZNTC_MODULE_STATS") catch null) |v| {
+            self.allocator.free(v);
+            dumpModuleStats(&graph);
+        }
 
         // 2. 링킹 (scope hoisting)
         // code_splitting=true일 때는 글로벌 computeRenames를 건너뛴다.


### PR DESCRIPTION
## 문제

#3133 (`ZNTC_MODULE_STATS` PoC 히스토그램) 이 `std.posix.getenv("ZNTC_MODULE_STATS")` 를 사용했는데, `std.posix.getenv` 는 Windows 미지원입니다 (`environment strings are in WTF-16 format`). → CI 의 `Benchmark (windows-latest)` ReleaseFast 빌드가 컴파일 에러로 실패:

```
error: std.posix.getenv is unavailable for Windows because environment strings are in WTF-16 format.
See std.process.getEnvVarOwned for a cross-platform API ...
```

## 수정

`bundler.zig` 의 체크를 `std.process.getEnvVarOwned(self.allocator, "ZNTC_MODULE_STATS") catch null` 로 교체 — cross-platform (`profile.zig` 의 `initFromEnv` 가 `ZNTC_PROFILE`/`ZNTC_PROFILE_LEVEL` 에 쓰는 것과 동일 패턴). 반환된 값은 즉시 `free` — 존재 여부만 확인하면 되므로.

```zig
if (std.process.getEnvVarOwned(self.allocator, "ZNTC_MODULE_STATS") catch null) |v| {
    self.allocator.free(v);
    dumpModuleStats(&graph);
}
```

(참고: macOS Benchmark 레그의 "unterminated profile JSON output" 실패는 #3132 의 Benchmark 가 macOS/ubuntu/windows 전부 성공한 걸로 봐서 일회성 flaky 였음 — 별도 이슈 아님.)

## 테스트
- `zig build test` ✅ 전체
- `ZNTC_MODULE_STATS=1` 으로 히스토그램 출력 확인, env 없으면 no-op 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)