### PR TITLE
fix(bundler): `export *` source 는 namespace 전체를 요청 (deferred record raw require 잔존 수정)

### DIFF
--- a/src/bundler/graph/requested_exports.zig
+++ b/src/bundler/graph/requested_exports.zig
@@ -174,8 +174,13 @@ pub fn requestedExportsForReExportRecord(
                     }
                 },
                 .re_export_star => {
+                    // `export * from "./X"` 는 어느 source 가 이 이름을 제공하는지 정적으로
+                    // 알 수 없다 — 후보 source 마다 namespace 전체를 요청해야 한다. 그러지
+                    // 않으면 X 가 이 이름을 안 가졌을 때 X 의 import record 가 deferred 인
+                    // 채로 (wrapped barrel 의 `init_*` 로 도달 가능해) 번들에 남아 raw
+                    // `require()` 가 출력된다 (#3136).
                     if (!nameHasDirectNonStarExport(importer, requested_name)) {
-                        changed = (try requestNamed(self, dep_idx, requested_name)) or changed;
+                        changed = (try requestAll(self, dep_idx)) or changed;
                     }
                 },
                 .local => {},


### PR DESCRIPTION
이슈 #3136 의 부분 수정 (3건 중 2건 결정적 제거).

## 원인

`export * from "./X"` 는 어떤 source 가 특정 re-export 이름을 제공하는지 정적으로 알 수 없습니다. 그래서 그 barrel 을 통해 이름이 요청되면:
- LINK 단계: `reExportRecordMatchesRequest` 가 "이 이름이 X 의 direct export 가 아니니 X 에 있을 수도 있다" → `export * from "./X"` record 를 link → X 가 그래프에 추가됨
- PROPAGATE 단계: 그런데 X 로는 그 이름 하나만 `requestNamed` 함

X 가 정작 그 이름을 export 하지 않으면 → `shouldLinkResolvedRecordForModule(X, …)` 가 false → X 의 **자기 import record 들이 lazy-deferred** 됨. 그런데 X 는 wrapped barrel 의 `init_*()` 로 도달 가능해서 tree-shaking 에서 안 잘리고 emit 됨 → record 가 `.none` 인 채 emit 되어 raw `require("…")` 출력 → 런타임 크래시.

## 수정

`requestedExportsForReExportRecord` 의 `.re_export_star` 분기에서 `requestNamed(dep, name)` 대신 `requestAll(dep)` 로 전파합니다. `export *` source 는 namespace 전체가 importer 의 namespace 에 합쳐지므로, importer 가 쓰이면 source 의 export 도 전부 "요청됨" 으로 보는 게 맞는 over-approximation 입니다.

```zig
.re_export_star => {
    if (!nameHasDirectNonStarExport(importer, requested_name)) {
        changed = (try requestAll(self, dep_idx)) or changed;  // was: requestNamed(..., requested_name)
    }
},
```

> Zig 초보자 메모: `requestAll` / `requestNamed` 은 같은 파일의 함수로, 모듈의 "어떤 export 가 필요한지" 집합(`requested_exports`)에 표시를 남깁니다. `requestAll` 은 그 모듈의 전부, `requestNamed` 은 특정 이름 하나. lazy-barrel 최적화는 이 집합을 보고 "필요한 import 만" resolve 합니다.

## 영향 범위

- **named re-export barrel (`export { x } from './x'`)** — lodash-es / date-fns / @mui 등 — 영향 없음 (`.re_export` 분기는 그대로 `requestNamed`). speculation 이 없는 패턴이라 안 건드림.
- **`export *` chain** 만 더 eager 하게 resolve. reanimated 처럼 `export *` 가 깊은 라이브러리에서 leaf 모듈 몇 개가 누락되던 게 사라짐.
- smoke benchmark 출력 크기 변동 없음 (오히려 한 패키지가 "smaller" 로 넘어감 — `Smaller: 116 → 117`).

## 검증

- `zig build test` ✅
- `tests/integration` ✅ (3711 pass / 3 fail — `main` 에서도 깨지는 선행 `html-env`, 무관). `tests/es5-rn` `Raw require() calls remaining: 0`, fixture 변동 없음.
- `tests/benchmark` smoke ✅ (전부 OK + MATCH, 크기 회귀 없음)
- `examples/react-native-bare`: residual raw `require()` **0~3 → 0~1**. 남은 1건 (`react-native-worklets` 의 `memory/serializableMappingCache` import)은 다른 경로(scan 타이밍 race)라 #3136 에서 계속 추적.

🤖 Generated with [Claude Code](https://claude.com/claude-code)