### PR TITLE
fix(bundler): 순수 re-export barrel 만 import 를 lazy-defer (deferred record raw require 잔존 완전 해결)

### DIFF
--- a/src/bundler/graph/requested_exports.zig
+++ b/src/bundler/graph/requested_exports.zig
@@ -38,21 +38,30 @@ pub fn requestNamed(self: anytype, idx: ModuleIndex, name: []const u8) !bool {
     return true;
 }
 
-/// 이 모듈이 user-declared `sideEffects:false` ESM barrel 인지 — `requested_exports` 에
-/// 일치하는 것만 link 하는 정밀 트리쉐이킹 hint 의 적용 대상.
+/// 이 모듈이 user-declared `sideEffects:false` 인 *순수 re-export barrel* 인지 —
+/// `requested_exports` 에 일치하는 record 만 link 하는 정밀 트리쉐이킹 hint 의 적용 대상.
+///
+/// 순수 barrel 이 아니라 (a) `export class`/`export const x = …` 같은 local 선언이나
+/// (b) pre-pass 가 주입한 runtime helper (`__extends` 등) 가 있는 모듈은 `init_<mod>()`
+/// 가 그 body 를 실행하면서 자신의 import 를 (helper virtual import 포함) 참조하므로,
+/// import record 를 lazy 로 미루면 `export *` chain 으로 번들에 끌려 들어왔을 때 resolve
+/// 가 안 돼 emit 에 raw `require("…")` 가 남아 런타임 크래시한다.
 pub fn isLazyBarrelCandidate(self: anytype, m: *const Module) bool {
     if (self.dev_mode or self.preserve_modules) return false;
-    // pre-pass 가 runtime helper (`__extends`/`__classCallCheck` …) 를 주입한 모듈은
-    // 순수 re-export barrel 이 아니라 downlevel 된 실제 코드다. 이런 모듈의 import
-    // record (helper virtual import 포함) 를 lazy 로 미루면 `export *` chain 으로 번들에
-    // 끌려 들어왔을 때 resolve 가 안 돼 emit 에 raw `require("\x00zntc:runtime/…")` 가
-    // 남아 런타임 크래시.
     if (m.transform_cache) |tc| if (tc.runtime_helpers.hasAny()) return false;
+    if (moduleHasLocalExport(m)) return false;
     return m.side_effects_user_defined and
         !m.side_effects and
         m.exports_kind.isEsm() and
         m.import_records.len > 0 and
         m.export_bindings.len > 0;
+}
+
+fn moduleHasLocalExport(m: *const Module) bool {
+    for (m.export_bindings) |eb| {
+        if (eb.kind == .local) return true;
+    }
+    return false;
 }
 
 /// Wrapper-barrel pattern: `import x from './w'; export default x;` 같이 imported
@@ -72,17 +81,6 @@ pub fn isWrapperBarrel(self: anytype, m: *const Module) bool {
 pub fn computeIsWrapperBarrel(m: *const Module) bool {
     for (m.export_bindings) |eb| {
         if (eb.isDefaultDirectReExport()) return true;
-    }
-    return false;
-}
-
-pub fn localNeedsAllRecords(m: *const Module, req: *const RequestedExports) bool {
-    if (req.all) return true;
-    var it = req.names.keyIterator();
-    while (it.next()) |name| {
-        for (m.export_bindings) |eb| {
-            if (eb.kind == .local and std.mem.eql(u8, eb.exported_name, name.*)) return true;
-        }
     }
     return false;
 }
@@ -111,7 +109,6 @@ pub fn shouldLinkResolvedRecordForModule(self: anytype, mod_idx: usize, rec_i: u
     defer self.requested_exports_mutex.unlock();
     const req = self.requested_exports.get(key) orelse return true;
     if (req.all) return true;
-    if (localNeedsAllRecords(m, &req)) return true;
     return reExportRecordMatchesRequest(m, rec_i, &req);
 }
 


### PR DESCRIPTION
이슈 #3136 의 최종 수정. `examples/react-native-bare` 의 미변환 `require()` 가 12회 연속 빌드에서 **0** 으로 안정화됩니다.

## 원인 (root cause)

`isLazyBarrelCandidate` 가 `sideEffects:false` 인 ESM + import + export 모듈을 전부 "barrel" 로 보고 import record 를 lazy 하게 미뤘습니다. 그런데 `.local` export (`export class …`, `export const x = importedThing`, `export function …`) 가 있는 모듈은 순수 re-export barrel 이 아니라 **body 가 있는 실제 코드**입니다 — `init_<mod>()` 가 그 body 를 실행하면서 그 모듈의 *모든* import 를 참조합니다 (특정 re-export 가 가리키는 record 하나만이 아니라).

기존 `localNeedsAllRecords` 는 *요청된* 이름이 `.local` export 와 일치할 때만 "전 record link" 했습니다. 그래서 모듈이 `export *` chain 으로 끌려 들어왔는데 (요청된 이름은 그 모듈의 `.local` 이 아니라 *re-export* 이름이면) → `.local` 일치 없음 → 다른 import record 들이 deferred 인 채로 남고 → 그 모듈은 wrapped (`__esm`) 이라 `init_*` 으로 도달 가능해 emit 됨 → `.none` record 가 raw `require("…")` 로 출력 → 런타임 크래시.

예: `react-native-worklets/src/deprecated.ts`
```ts
import { makeShareable, ... } from './memory/serializable';
import { serializableMappingCache } from './memory/serializableMappingCache';
export { makeShareable, ... };                                 // re-export (imported binding)
export const shareableMappingCache = serializableMappingCache; // .local, import 참조
export function callMicrotasks() { 'worklet'; }                // .local
```
`worklets/index.ts` 가 `export { makeShareable, ... } from './deprecated'` 로 `makeShareable` 만 요청 → `deprecated.ts` 는 `makeShareable` 을 제공하니 link 됨 → 하지만 `serializableMappingCache` import 는 그 `makeShareable` re-export 의 source 가 아니라 → deferred → `init_deprecated()` 가 `var shareableMappingCache = serializableMappingCache_imported` 를 실행하는데 → raw `require("./memory/serializableMappingCache")`.

## 수정

`.local` export binding 이 하나라도 있는 모듈은 `isLazyBarrelCandidate` 에서 제외 (graph 의 link gate 와 tree_shaker 의 seed gate 양쪽이 동일하게 "lazy 아님" 으로 봄). 순수 re-export barrel (`export { x } from './x'`, `export * from './x'` 만 있는 모듈)만 lazy 처리 대상으로 남습니다.

```zig
pub fn isLazyBarrelCandidate(self: anytype, m: *const Module) bool {
    if (self.dev_mode or self.preserve_modules) return false;
    if (m.transform_cache) |tc| if (tc.runtime_helpers.hasAny()) return false;
    if (moduleHasLocalExport(m)) return false;   // ← 추가
    return m.side_effects_user_defined and !m.side_effects and
        m.exports_kind.isEsm() and m.import_records.len > 0 and m.export_bindings.len > 0;
}
fn moduleHasLocalExport(m: *const Module) bool {
    for (m.export_bindings) |eb| if (eb.kind == .local) return true;
    return false;
}
```

이 변경은 #3135 의 `runtime_helpers.hasAny()` 제외를 흔한 경우 포함(downlevel 된 `export class` 는 `.local` 이므로)하지만, helper 코드가 export 가 아닌 statement 에 있을 수도 있어 두 체크 모두 유지합니다. `localNeedsAllRecords` 는 이제 도달 불가(이 게이트를 통과한 모듈엔 `.local` 이 없음) — 제거했습니다.

> Zig 초보자 메모: `eb.kind == .local` 은 export binding 종류 enum 입니다 — `.local` 은 "이 모듈에서 선언된 것을 export" (`export const x`), `.re_export` 는 "다른 모듈 것을 다시 export" (`export { x } from './y'`), `.re_export_star` 는 `export * from './y'`. lazy barrel 최적화는 re-export 만 있는 모듈에 안전합니다.

## 영향 범위

- **순수 re-export barrel** (lodash-es/index.js, @mui/material/index.js, date-fns/index.js 등 — `.local` export 없음) → 그대로 lazy. 요청 안 된 re-export 는 계속 미뤄지고 그 leaf 모듈은 그래프에 안 들어옴. 최적화 보존. lodash-es 같이 `export default <local-fn>` 인 leaf 모듈은 이미 `localNeedsAllRecords` 가 link-all 하던 경우라 동작 동일.
- `.local` + re-export 를 섞은 모듈만 더 eager 하게 — 그 모듈의 import 가 전부 resolve 됨 (어차피 `init_*` 가 다 쓰므로 정확). 드물게 `export const VERSION = "1.0"; export { a } from './a'; ...` 형태 barrel 은 `./a`, `./b`, … 까지 link 될 수 있으나 tree-shaking 이 미사용 코드를 제거하므로 번들 크기 변동 없음.

## 검증

- `examples/react-native-bare`: 미변환 `require()` **0~1 → 0** (12회 연속 빌드 동일, size 3541352 고정)
- `zig build test` ✅
- `tests/integration` ✅ (3711 pass / 3 fail — `main` 에서도 깨지는 선행 `html-env`, 무관). `tests/es5-rn` `Raw require() calls remaining: 0`, fixture 변동 없음.
- `tests/benchmark` smoke ✅ — ZNTC 빌드 전부 OK, 크기 회귀 없음 (`Smaller 116 → 117`). 유일한 runtime MISMATCH (`nanoid@node16`)는 `main` 에서도 동일한 선행 이슈.

이걸로 #3136 closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)