### PR TITLE
chore(bundler): /simplify 후속 — lazy-barrel gate 정리 (no behavior change)

### DIFF
--- a/src/bundler/graph/requested_exports.zig
+++ b/src/bundler/graph/requested_exports.zig
@@ -48,13 +48,13 @@ pub fn requestNamed(self: anytype, idx: ModuleIndex, name: []const u8) !bool {
 /// 가 안 돼 emit 에 raw `require("…")` 가 남아 런타임 크래시한다.
 pub fn isLazyBarrelCandidate(self: anytype, m: *const Module) bool {
     if (self.dev_mode or self.preserve_modules) return false;
-    if (m.transform_cache) |tc| if (tc.runtime_helpers.hasAny()) return false;
-    if (moduleHasLocalExport(m)) return false;
-    return m.side_effects_user_defined and
+    if (!(m.side_effects_user_defined and
         !m.side_effects and
         m.exports_kind.isEsm() and
         m.import_records.len > 0 and
-        m.export_bindings.len > 0;
+        m.export_bindings.len > 0)) return false;
+    if (m.transform_cache) |tc| if (tc.runtime_helpers.hasAny()) return false;
+    return !moduleHasLocalExport(m);
 }
 
 fn moduleHasLocalExport(m: *const Module) bool {
@@ -165,19 +165,21 @@ pub fn requestedExportsForReExportRecord(
                         changed = (try requestNamed(self, dep_idx, eb.local_name)) or changed;
                     }
                 },
+                // namespace / star re-export 는 dep 전체를 요청한다 — 한 번 `.all` 이 되면
+                // 이후 requested_name 들의 작업은 전부 no-op 이므로 즉시 반환.
                 .re_export_namespace => {
                     if (std.mem.eql(u8, eb.exported_name, requested_name)) {
-                        changed = (try requestAll(self, dep_idx)) or changed;
+                        return (try requestAll(self, dep_idx)) or changed;
                     }
                 },
                 .re_export_star => {
                     // `export * from "./X"` 는 어느 source 가 이 이름을 제공하는지 정적으로
-                    // 알 수 없다 — 후보 source 마다 namespace 전체를 요청해야 한다. 그러지
+                    // 알 수 없다 — 후보 source 의 namespace 전체를 요청해야 한다. 그러지
                     // 않으면 X 가 이 이름을 안 가졌을 때 X 의 import record 가 deferred 인
                     // 채로 (wrapped barrel 의 `init_*` 로 도달 가능해) 번들에 남아 raw
                     // `require()` 가 출력된다 (#3136).
                     if (!nameHasDirectNonStarExport(importer, requested_name)) {
-                        changed = (try requestAll(self, dep_idx)) or changed;
+                        return (try requestAll(self, dep_idx)) or changed;
                     }
                 },
                 .local => {},


### PR DESCRIPTION
`/simplify` 3-agent 리뷰에서 나온 minor 개선 2건. **동작 변화 없음** (리팩터만).

1. **`isLazyBarrelCandidate`**: 싸구려 boolean/length gate (`side_effects_user_defined`, `!side_effects`, `exports_kind.isEsm()`, `import_records.len > 0`, `export_bindings.len > 0`)를 먼저 검사 → `moduleHasLocalExport` 의 `export_bindings` 순회는 실제 `sideEffects:false` ESM barrel 후보에서만 돈다. (대부분 모듈은 첫 gate 에서 바로 false.)
2. **`requestedExportsForReExportRecord`**: `re_export_star` / `re_export_namespace` 가 `requestAll(dep)` 를 한 번 호출하면 dep 은 `.all` 이 되고, 그 뒤 requested_name 들의 작업(`requestNamed`/`requestAll`)은 전부 no-op (매번 mutex 만 잡음) → 즉시 반환.

리뷰에서 거론됐지만 **안 한 것**: `moduleHasLocalExport` 를 `Module.has_local_export` 로 캐싱(`is_wrapper_barrel` 처럼) — efficiency 리뷰가 "early-terminating loop, 단일 호출처, 전체 비용 sub-ms" 로 판단해 field + 4개 대입처 추가할 가치 없음으로 스킵.

## 검증
- `examples/react-native-bare` 미변환 `require()`: 6회 빌드 모두 0, size 3541352 고정 (변화 없음)
- `zig build test` ✅ / `tests/integration` 3711 pass / 3 fail(선행 `html-env`, 무관) / `tests/es5-rn` `Raw require() calls remaining: 0`, fixture 변동 없음
- `tests/benchmark` smoke ✅ — ZNTC 빌드 전부 OK, 크기·MATCH 전부 직전과 동일

🤖 Generated with [Claude Code](https://claude.com/claude-code)