### PR TITLE
perf(bundler): has_local_export 를 Module 캐시로 (is_wrapper_barrel 패턴)

### DIFF
--- a/src/bundler/graph/json_module.zig
+++ b/src/bundler/graph/json_module.zig
@@ -87,7 +87,7 @@ pub fn parse(self: *ModuleGraph, module: *Module) void {
     binding_scanner_mod.collectNamespaceAccesses(arena_alloc, &(module.ast.?), module.import_bindings) catch {};
     module.export_bindings = binding_scanner_mod.extractExportBindings(arena_alloc, &(module.ast.?), scan_result.records, module.import_bindings) catch &.{};
     module.exported_names = projectExportedNames(arena_alloc, module.export_bindings);
-    module.is_wrapper_barrel = @import("requested_exports.zig").computeIsWrapperBarrel(module);
+    @import("requested_exports.zig").computeBarrelFlags(module);
 
     // Phase 1 (#1328): 합성 심볼 테이블 초기화 + export default 등록.
     module.ensureAliasTable(self.allocator);

--- a/src/bundler/graph/parser_metadata.zig
+++ b/src/bundler/graph/parser_metadata.zig
@@ -82,8 +82,8 @@ pub fn materialize(
             }
             module.export_bindings = ebindings;
             module.exported_names = projectExportedNames(arena_alloc, ebindings);
-            // wrapper-barrel detection 캐시 (export_bindings 가 final 인 시점에 한 번 계산).
-            module.is_wrapper_barrel = @import("requested_exports.zig").computeIsWrapperBarrel(module);
+            // barrel 분류 캐시 (export_bindings 가 final 인 시점에 한 번 계산).
+            @import("requested_exports.zig").computeBarrelFlags(module);
         } else |_| {}
     }
 

--- a/src/bundler/graph/requested_exports.zig
+++ b/src/bundler/graph/requested_exports.zig
@@ -54,14 +54,7 @@ pub fn isLazyBarrelCandidate(self: anytype, m: *const Module) bool {
         m.import_records.len > 0 and
         m.export_bindings.len > 0)) return false;
     if (m.transform_cache) |tc| if (tc.runtime_helpers.hasAny()) return false;
-    return !moduleHasLocalExport(m);
-}
-
-fn moduleHasLocalExport(m: *const Module) bool {
-    for (m.export_bindings) |eb| {
-        if (eb.kind == .local) return true;
-    }
-    return false;
+    return !m.has_local_export;
 }
 
 /// Wrapper-barrel pattern: `import x from './w'; export default x;` 같이 imported
@@ -76,13 +69,18 @@ pub fn isWrapperBarrel(self: anytype, m: *const Module) bool {
     return m.is_wrapper_barrel;
 }
 
-/// `Module.is_wrapper_barrel` 캐시 채우는 1 회용 컴퓨터. graph build 의 `applySideEffects`
-/// 직후, parse 가 끝나 export_bindings 가 final 인 시점에 호출.
-pub fn computeIsWrapperBarrel(m: *const Module) bool {
+/// `Module.is_wrapper_barrel` / `has_local_export` 캐시를 한 번의 export_bindings 순회로
+/// 채운다. graph build 의 `applySideEffects` 직후, parse 가 끝나 export_bindings 가 final
+/// 인 시점에 호출.
+pub fn computeBarrelFlags(m: *Module) void {
+    var is_wrapper = false;
+    var has_local = false;
     for (m.export_bindings) |eb| {
-        if (eb.isDefaultDirectReExport()) return true;
+        if (eb.isDefaultDirectReExport()) is_wrapper = true;
+        if (eb.kind == .local) has_local = true;
     }
-    return false;
+    m.is_wrapper_barrel = is_wrapper;
+    m.has_local_export = has_local;
 }
 
 pub fn nameHasDirectNonStarExport(m: *const Module, name: []const u8) bool {

--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -410,7 +410,7 @@ pub fn resyncAfterAstMutation(
             module.import_bindings,
         );
         module.exported_names = projectExportedNames(arena_alloc, module.export_bindings);
-        module.is_wrapper_barrel = @import("requested_exports.zig").computeIsWrapperBarrel(module);
+        @import("requested_exports.zig").computeBarrelFlags(module);
     }
 
     const has_refreshed_cjs = scan_result.has_cjs_require or

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -243,10 +243,14 @@ pub const Module = struct {
     /// Rolldown `DeterminedSideEffects::UserDefined` 포팅.
     side_effects_user_defined: bool = false,
     /// `import x; export default x;` body mutation pattern (lodash-es lodash.default.js).
-    /// `requested_exports.computeIsWrapperBarrel` 가 export_bindings 순회로 한 번 결정해
+    /// `requested_exports.computeBarrelFlags` 가 export_bindings 순회로 한 번 결정해
     /// 캐시. graph link 결정 (`shouldLinkResolvedRecordForModule`) + tree_shaker 시드 게이트
     /// + tree_shaker default→default re-export propagation 세 hot-path 호출처가 공유.
     is_wrapper_barrel: bool = false,
+    /// `.local` export binding (`export class`/`export const x = …`/`export function`) 보유 —
+    /// 순수 re-export barrel 이 아니므로 `isLazyBarrelCandidate` 에서 제외 (body 가 import 참조).
+    /// `is_wrapper_barrel` 과 같은 패스에서 채워지는 hot-path 캐시.
+    has_local_export: bool = false,
     /// platform=browser에서 Node 빌트인 모듈을 빈 CJS로 대체 (esbuild "(disabled)" 방식).
     /// AST가 없고, emitter가 빈 __commonJS wrapper를 출력한다.
     is_disabled: bool = false,

--- a/src/bundler/phase.zig
+++ b/src/bundler/phase.zig
@@ -94,7 +94,7 @@ pub const ParseAccessor = struct {
     pub inline fn setExportBindings(self: ParseAccessor, idx: ModuleIndex, bindings: []ExportBinding) void {
         if (self.graph.moduleAtMut(idx)) |m| {
             m.export_bindings = bindings;
-            m.is_wrapper_barrel = @import("graph/requested_exports.zig").computeIsWrapperBarrel(m);
+            @import("graph/requested_exports.zig").computeBarrelFlags(m);
         }
     }
 


### PR DESCRIPTION
`/simplify` reuse 리뷰 후속. **동작 변화 없음.**

`isLazyBarrelCandidate` 는 parallel scan / resolve / tree-shaker hot path 에서 import record 마다 호출되는데, 직전 PR (#3138) 에서 추가한 inline `moduleHasLocalExport` 가 매번 `export_bindings` 를 순회했습니다. 이 결과를 `Module.has_local_export` 캐시 필드로 승격 — 이미 `is_wrapper_barrel` 을 계산하는 그 *한 번의 순회* 안에서 같이 채웁니다.

- `computeIsWrapperBarrel(m: *const Module) bool` → `computeBarrelFlags(m: *Module) void` (두 flag 동시 set)
- 호출처 4곳 (`phase.zig` / `parser_metadata.zig` / `transform_prepass.zig` / `json_module.zig`) 동일하게 `computeBarrelFlags(m)` 로 교체
- `isLazyBarrelCandidate` 마지막 줄: `return !moduleHasLocalExport(m);` → `return !m.has_local_export;`
- `Module.has_local_export: bool` 필드 추가 (`is_wrapper_barrel` 옆, 동일 캐시 패턴 — incremental rebuild 의 module-store 캐시에도 자동 포함)

`is_wrapper_barrel` 과 같은 이유 (graph link gate + tree_shaker seed gate 등 hot path 공유) 로 캐싱하는 게 이 파일의 기존 관례입니다.

## 검증
- `examples/react-native-bare` 미변환 `require()`: 6회 빌드 모두 0, size 3541352 고정 (변화 없음)
- `zig build test` ✅ / `tests/integration` 3711 pass / 3 fail(선행 `html-env`, 무관) / `tests/es5-rn` `Raw require() calls remaining: 0`
- `tests/benchmark` smoke ✅ — ZNTC 빌드 전부 OK, 크기·MATCH 직전과 동일

🤖 Generated with [Claude Code](https://claude.com/claude-code)