### PR TITLE
fix(react-native): zntc 번들 디버깅 이슈 정리

### DIFF
--- a/packages/core/bin/rn-dev-input.mjs
+++ b/packages/core/bin/rn-dev-input.mjs
@@ -68,7 +68,20 @@ export function buildRnBundleExtra(config, opts = {}) {
   };
 }
 
-export function buildRnBundleOverride(config, override) {
+function assignRnBuildOptionOverrides(out, config, opts = {}) {
+  const cfg = config ?? {};
+  if (opts.experimentalDecorators === true || cfg.experimentalDecorators === true) {
+    out.experimentalDecorators = true;
+  }
+  if (opts.emitDecoratorMetadata === true || cfg.emitDecoratorMetadata === true) {
+    out.emitDecoratorMetadata = true;
+  }
+  if (opts.useDefineForClassFields === false || cfg.useDefineForClassFields === false) {
+    out.useDefineForClassFields = false;
+  }
+}
+
+export function buildRnBundleOverride(config, opts = {}, override) {
   const cfg = config ?? {};
   const out = {};
   if (cfg.alias && typeof cfg.alias === 'object') {
@@ -77,6 +90,7 @@ export function buildRnBundleOverride(config, override) {
   if (cfg.moduleSpecifierMap && typeof cfg.moduleSpecifierMap === 'object') {
     out.moduleSpecifierMap = cfg.moduleSpecifierMap;
   }
+  assignRnBuildOptionOverrides(out, cfg, opts);
   if (override && typeof override === 'object') {
     Object.assign(out, override);
   }
@@ -133,7 +147,7 @@ export function buildRnDevServerInput(opts, config) {
         cfg.minify ||
         false,
       extra: buildRnBundleExtra(cfg, opts),
-      override: buildRnBundleOverride(cfg),
+      override: buildRnBundleOverride(cfg, opts),
     },
     port: opts.port ?? server.port ?? 8081,
     host: opts.host ?? server.host ?? 'localhost',

--- a/packages/core/bin/rn-dev-input.mjs
+++ b/packages/core/bin/rn-dev-input.mjs
@@ -50,6 +50,7 @@ export function buildRnBundleExtra(config, opts = {}) {
   const server = cfg.server ?? {};
   return {
     watchFolders: opts.rnWatchFolders ?? cfg.watchFolders ?? undefined,
+    nodeModulesPaths: resolver.nodeModulesPaths ?? undefined,
     sourceExts: opts.rnSourceExts ?? resolver.sourceExts ?? undefined,
     assetExts: resolver.assetExts ?? undefined,
     blockList: resolver.blockList ?? undefined,

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -770,6 +770,7 @@ async function runRnBundle(opts, config) {
     extra: buildRnBundleExtra(cfg, opts),
     override: buildRnBundleOverride(
       cfg,
+      opts,
       outfile && !callerWrite ? { outfile, write: true } : undefined,
     ),
   });

--- a/packages/core/test/cli/react-native-dev-input/bundle-options/resolver.ts
+++ b/packages/core/test/cli/react-native-dev-input/bundle-options/resolver.ts
@@ -17,6 +17,7 @@ describe('buildRnDevServerInput — resolver bundle option config 추출 (#2605)
       },
     );
     expect(input?.nodeModulesPaths).toEqual(['../../node_modules']);
+    expect(input?.bundle.extra?.nodeModulesPaths).toEqual(['../../node_modules']);
     expect(input?.bundle.extra?.blockList).toEqual([/.web.tsx?$/]);
     expect(input?.bundle.extra?.fallback).toEqual({ foo: '/x' });
     expect(input?.bundle.extra?.sourceExts).toEqual(['.ts']);

--- a/packages/core/test/cli/react-native-dev-input/bundle-options/runtime-config.ts
+++ b/packages/core/test/cli/react-native-dev-input/bundle-options/runtime-config.ts
@@ -41,6 +41,27 @@ describe('buildRnDevServerInput — runtime bundle option config 추출 (#2605)'
     expect(input?.bundle.minify).toBe(true);
   });
 
+  test('decorator BuildOptions → bundle.override', async () => {
+    const buildRnDevServerInput = await loadBuildRnDevServerInput();
+    const configInput = buildRnDevServerInput(
+      { entryPoints: ['i.js'] },
+      { experimentalDecorators: true, emitDecoratorMetadata: true },
+    );
+    expect(configInput?.bundle.override?.experimentalDecorators).toBe(true);
+    expect(configInput?.bundle.override?.emitDecoratorMetadata).toBe(true);
+
+    const cliInput = buildRnDevServerInput(
+      {
+        entryPoints: ['i.js'],
+        experimentalDecorators: true,
+        useDefineForClassFields: false,
+      },
+      {},
+    );
+    expect(cliInput?.bundle.override?.experimentalDecorators).toBe(true);
+    expect(cliInput?.bundle.override?.useDefineForClassFields).toBe(false);
+  });
+
   test('config.root → projectRoot (resolve 적용)', async () => {
     const buildRnDevServerInput = await loadBuildRnDevServerInput();
     const input = buildRnDevServerInput({ entryPoints: ['i.js'] }, { root: '/abs/path' });

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -113,6 +113,43 @@ describe('buildRnBundleOptions — define / banner / footer / polyfills', () => 
     // Hermes 가 spec global lazy registration trigger.
     expect(opts.banner).not.toContain('globalThis.__ZNTC_RN_BUNDLER__');
     expect(opts.banner).not.toContain('__BUNGAE_');
+    // Metro prelude 는 `global` 을 var 로 재선언하지 않는다. RN/Hermes 의 native global
+    // binding 을 가리지 않도록 zntc prelude 도 fallback assignment 만 둔다.
+    expect(opts.banner).not.toContain('var global=');
+  });
+
+  test('banner — Metro 처럼 native global 을 먼저 선택하고 hasOwnProperty 를 보강', () => {
+    const opts = buildRnBundleOptions(baseInput({ dev: true }));
+    expect(opts.banner).toContain(
+      "__ZNTC_RN_GLOBAL__=(function(g,t,w,s){return g&&(typeof g==='object'||typeof g==='function')?g:",
+    );
+    expect(opts.banner).toContain("Object.defineProperty(__ZNTC_RN_GLOBAL__,'hasOwnProperty'");
+
+    const nativeGlobal = Object.create(null) as Record<string, unknown>;
+    const specGlobal = Object.create(null) as Record<string, unknown>;
+    const selectRnGlobal = new Function(
+      'nativeGlobal',
+      'specGlobal',
+      `var global=nativeGlobal;var globalThis=specGlobal;${opts.banner};return __ZNTC_RN_GLOBAL__;`,
+    ) as (
+      nativeGlobal: Record<string, unknown>,
+      specGlobal: Record<string, unknown>,
+    ) => Record<string, unknown>;
+
+    const selected = selectRnGlobal(nativeGlobal, specGlobal) as Record<string, unknown> & {
+      window?: { hasOwnProperty?: (key: string) => boolean };
+    };
+    selected.window = selected;
+
+    expect(selected).toBe(nativeGlobal);
+    expect(typeof selected.hasOwnProperty).toBe('function');
+    expect(() => selected.window!.hasOwnProperty!('__REACT_DEVTOOLS_GLOBAL_HOOK__')).not.toThrow();
+
+    const selectFallbackGlobal = new Function(
+      'specGlobal',
+      `var global=null;var globalThis=specGlobal;${opts.banner};return __ZNTC_RN_GLOBAL__;`,
+    ) as (specGlobal: Record<string, unknown>) => Record<string, unknown>;
+    expect(selectFallbackGlobal(specGlobal)).toBe(specGlobal);
   });
 
   test('bannerExtras — RN prelude 끝에 append', () => {
@@ -128,6 +165,7 @@ describe('buildRnBundleOptions — define / banner / footer / polyfills', () => 
     // top-level globalThis assignment 회피 — IIFE 안에서 set
     expect(opts.footer).toContain('__ZNTC_RN_BUNDLER__');
     expect(opts.footer).toMatch(/\(function\(g\)\{g\.__ZNTC_RN_BUNDLER__/);
+    expect(opts.footer).toContain("typeof global!=='undefined'?global:void 0");
     expect(opts.footer).toContain('DevLoadingView.hide');
   });
 

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -60,9 +60,9 @@ describe('buildRnBundleOptions — 기본 RN preset 필드', () => {
     expect(opts.globalIdentifiers).toEqual([...RN_GLOBAL_IDENTIFIERS]);
   });
 
-  test('mainFields — react-native / browser / module / main', () => {
+  test('mainFields — Metro RN default 와 동일하게 react-native / browser / main', () => {
     const opts = buildRnBundleOptions(baseInput());
-    expect(opts.mainFields).toEqual(['react-native', 'browser', 'module', 'main']);
+    expect(opts.mainFields).toEqual(['react-native', 'browser', 'main']);
   });
 });
 

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -365,6 +365,13 @@ describe('buildRnBundleOptions — extra (watchFolders / blockList / fallback)',
     expect(opts.watchFolders).toEqual([join(dir, 'shared'), '/abs/other']);
   });
 
+  test('nodeModulesPaths — Metro resolver 경로를 core nodePaths 로 정규화', () => {
+    const opts = buildRnBundleOptions(
+      baseInput({ extra: { nodeModulesPaths: ['./node_modules', '/abs/monorepo/node_modules'] } }),
+    );
+    expect(opts.nodePaths).toEqual([join(dir, 'node_modules'), '/abs/monorepo/node_modules']);
+  });
+
   test('blockList — 빈 배열은 미설정', () => {
     const opts = buildRnBundleOptions(baseInput({ extra: { blockList: [] } }));
     expect(opts.blockList).toBeUndefined();

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -221,6 +221,9 @@ const PRELUDE_RESERVED = new Set([
   'process',
 ]);
 
+const RN_GLOBAL_EXPR =
+  "(function(g,t,w,s){return g&&(typeof g==='object'||typeof g==='function')?g:t&&(typeof t==='object'||typeof t==='function')?t:w&&(typeof w==='object'||typeof w==='function')?w:s;})(typeof global!=='undefined'?global:void 0,typeof globalThis!=='undefined'?globalThis:void 0,typeof window!=='undefined'?window:void 0,this)";
+
 function formatExtraVars(extraVars: Record<string, unknown>): string {
   const out: string[] = [];
   for (const [key, value] of Object.entries(extraVars)) {
@@ -238,11 +241,16 @@ function buildPrelude(input: RnBundleInput): string {
   // `Object.defineProperty(globalThis, ...)` 시도 → throw → 부팅 실패. Metro bundle 도 모든
   // globalThis assignment 를 module factory 안 (nested scope) 에 두는 패턴이라 trigger 회피.
   // 추가 식별자가 필요하면 `__ZNTC_RN_BUNDLER__` 처럼 footer 의 IIFE 안에서 세팅.
+  //
+  // RN 런타임 소스의 `global` 식별자는 Metro 에서 `metro-runtime/src/polyfills/require.js`
+  // 가 module factory 에 넘기는 native global 과 동등해야 한다. 따라서 zntc 치환 대상인
+  // `__ZNTC_RN_GLOBAL__` 도 `globalThis` 보다 native `global` 을 먼저 선택한다.
   const lines = [
     `var __BUNDLE_START_TIME__=this.nativePerformanceNow?nativePerformanceNow():Date.now();`,
     `var __DEV__=${dev};`,
-    `var __ZNTC_RN_GLOBAL__=typeof globalThis!=='undefined'?globalThis:typeof global!=='undefined'?global:typeof window!=='undefined'?window:this;`,
-    `if(typeof global==='undefined')var global=__ZNTC_RN_GLOBAL__;`,
+    `var __ZNTC_RN_GLOBAL__=${RN_GLOBAL_EXPR};`,
+    `if(typeof global==='undefined')global=__ZNTC_RN_GLOBAL__;`,
+    `if(typeof __ZNTC_RN_GLOBAL__.hasOwnProperty!=='function')try{Object.defineProperty(__ZNTC_RN_GLOBAL__,'hasOwnProperty',{value:Object.prototype.hasOwnProperty,configurable:true,writable:true});}catch(_e){try{__ZNTC_RN_GLOBAL__.hasOwnProperty=Object.prototype.hasOwnProperty;}catch(_e2){}}`,
     `var process=__ZNTC_RN_GLOBAL__.process||{};process.env=process.env||{};process.env.NODE_ENV=process.env.NODE_ENV||"${dev ? 'development' : 'production'}";`,
   ];
   if (extra?.extraVars && Object.keys(extra.extraVars).length > 0) {
@@ -260,7 +268,7 @@ function buildPrelude(input: RnBundleInput): string {
 function buildFooter(dev: boolean): string {
   const parts: string[] = [
     // __ZNTC_RN_BUNDLER__ flag — IIFE 안에서 set 해야 안전
-    `(function(g){g.__ZNTC_RN_BUNDLER__=true;})(typeof globalThis!=='undefined'?globalThis:typeof global!=='undefined'?global:typeof window!=='undefined'?window:this);`,
+    `(function(g){g.__ZNTC_RN_BUNDLER__=true;})(${RN_GLOBAL_EXPR});`,
   ];
   if (dev) {
     parts.push(`setTimeout(function(){try{NativeModules.DevLoadingView.hide()}catch(e){}},0);`);

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -68,6 +68,8 @@ export interface RnBundleInput {
   /** Metro 호환 추가 옵션 (caller 의 ResolvedConfig 에서 추출). */
   extra?: {
     watchFolders?: string[];
+    /** Metro `resolver.nodeModulesPaths` 호환. bare import 추가 탐색 경로. */
+    nodeModulesPaths?: string[];
     blockList?: (RegExp | string)[];
     fallback?: Record<string, string | false>;
     /** RN 외 사용자 plugin (asset/babel/codegen/require-context/metro-resolve-request 외 추가). */
@@ -433,6 +435,9 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
 
   if (extra?.watchFolders && extra.watchFolders.length > 0) {
     preset.watchFolders = extra.watchFolders.map((p) => resolve(projectRoot, p));
+  }
+  if (extra?.nodeModulesPaths && extra.nodeModulesPaths.length > 0) {
+    preset.nodePaths = extra.nodeModulesPaths.map((p) => resolve(projectRoot, p));
   }
   if (extra?.blockList && extra.blockList.length > 0) {
     preset.blockList = extra.blockList;

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -3,7 +3,7 @@
 //
 // 자동 활성 필드 (RN platform 시): target=es5, flow=true, jsxInJs=true,
 // configurableExports=true, strictExecutionOrder=true, workletTransform=true,
-// resolveExtensions (ios/android prefix), mainFields (RN/browser/module/main),
+// resolveExtensions (ios/android prefix), mainFields (RN/browser/main),
 // banner (RN prelude), define (__DEV__/process.env), polyfills/runBeforeMain/
 // globalIdentifiers (resolveRnPolyfills + InitializeCore + RN_GLOBAL_IDENTIFIERS),
 // loader (asset 확장자), plugins (asset/codegen/babel/require-context/[metro-resolve-request]).
@@ -405,7 +405,7 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
     workletTransform: true,
     codegenTransform: true,
     resolveExtensions: buildResolveExtensions(rnPlatform),
-    mainFields: ['react-native', 'browser', 'module', 'main'],
+    mainFields: ['react-native', 'browser', 'main'],
     loader: baseLoader,
     alias: {},
     define,

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1071,7 +1071,9 @@ pub const Bundler = struct {
         var link_scope = profile.begin(.link);
         var linker: ?Linker = if (self.options.scope_hoist or self.options.dev_mode) blk: {
             var l = Linker.initWithGlobalIdentifiers(self.allocator, &graph, self.options.format, self.options.global_identifiers);
-            l.shim_missing_exports = self.options.shim_missing_exports;
+            // Metro+Babel은 named import를 CommonJS property access로 낮추므로, export가
+            // 실제로 없어도 런타임 값은 ReferenceError가 아니라 undefined가 된다.
+            l.shim_missing_exports = self.options.shim_missing_exports or self.options.platform == .react_native;
             l.dev_mode = self.options.dev_mode;
             l.entry_error_guard = self.options.entry_error_guard;
             l.inline_requires = self.options.platform == .react_native;

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -790,6 +790,7 @@ pub const Bundler = struct {
         var worker_linker = Linker.init(arena_alloc, &worker_graph, format);
         // #1621: worker 청크도 minify 시 preamble 축약 이름 사용.
         worker_linker.minify_whitespace = self.options.minify_whitespace;
+        worker_linker.inline_requires = self.options.platform == .react_native;
         try worker_linker.link();
         try worker_linker.finalize(.{
             .compute_renames = true,
@@ -1073,6 +1074,7 @@ pub const Bundler = struct {
             l.shim_missing_exports = self.options.shim_missing_exports;
             l.dev_mode = self.options.dev_mode;
             l.entry_error_guard = self.options.entry_error_guard;
+            l.inline_requires = self.options.platform == .react_native;
             // #1621: preamble/metadata 가 __toESM/__toCommonJS 를 축약 이름으로 emit.
             l.minify_whitespace = self.options.minify_whitespace;
             // #1791 Phase D: value-ref 0 binding elision 정책을 transformer 와 동기화.

--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -256,6 +256,41 @@ test "Bundler: try-block 안의 unresolved require 는 warning 만 + stub 으로
     try std.testing.expect(std.mem.indexOf(u8, result.output, "42") != null);
 }
 
+test "Bundler: try-block 안의 unresolved require 는 실행 시 MODULE_NOT_FOUND 를 던진다" {
+    // Node/Metro 의미: try 안의 optional peer require 는 resolve 실패를 catch 로 넘긴다.
+    // 빈 모듈을 반환하면 destructuring default 가 undefined 로 떨어져 catch 가 실행되지 않는다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\let fallback;
+        \\try {
+        \\  const { default: EventSource } = require("missing-optional-peer");
+        \\  fallback = EventSource.prototype;
+        \\} catch (e) {
+        \\  fallback = "mock";
+        \\}
+        \\module.exports = fallback;
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .node,
+        .format = .cjs,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "missing-optional-peer") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "MODULE_NOT_FOUND") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "Cannot find module") != null);
+}
+
 test "Bundler: try-block 바깥의 unresolved require 는 여전히 hard error (회귀 가드)" {
     // optional 마킹이 너무 광범위해 일반 require 의 hard error 를 잃지 않도록.
     var tmp = std.testing.tmpDir(.{});

--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -664,6 +664,38 @@ test "CJS: esm_with_dynamic_fallback module required — wrapped in __esm (bundl
     try std.testing.expect(std.mem.indexOf(u8, result.output, "init_hybrid") != null);
 }
 
+test "CJS: React Native mixed import plus module.exports uses Metro CJS wrapper" {
+    // Metro+Babel은 RN .js 파일의 import를 require로 낮춘 뒤 CJS module wrapper에서
+    // 실행한다. import + module.exports 혼용 파일을 __esm으로 감싸면 module이 없어져
+    // @payhereinc/react-native-code-push/AlertAdapter.js 패턴이 부팅 중 실패한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "import adapter from './AlertAdapter.js';\nconsole.log(adapter.Alert);");
+    try writeFile(tmp.dir, "AlertAdapter.js",
+        \\import React, { Platform } from './rn.js';
+        \\let { Alert } = React;
+        \\if (Platform.OS === 'android') Alert = {};
+        \\module.exports = { Alert };
+    );
+    try writeFile(tmp.dir, "rn.js",
+        \\export const Platform = { OS: 'ios' };
+        \\export default { Alert: 'alert', Platform };
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .platform = .react_native });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"AlertAdapter.js\"(exports, module)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var require_AlertAdapter = __commonJS") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var init_AlertAdapter = __esm") == null);
+}
+
 test "CJS: ESM import inside __commonJS wrapper rewritten to require_xxx()" {
     // ESM 모듈이 require()로 소비되어 __commonJS 래핑될 때,
     // 내부 import 문이 require("specifier")로 변환되는데,

--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -727,6 +727,36 @@ test "CJS: React Native mixed import plus module.exports uses Metro CJS wrapper"
     try std.testing.expect(std.mem.indexOf(u8, result.output, "var init_AlertAdapter = __esm") == null);
 }
 
+test "CJS: React Native missing named import is shimmed to undefined" {
+    // Metro/Babel은 `require("./lib").missing` property access로 남겨 undefined를 반환한다.
+    // RN 플랫폼에서 zntc가 strict ESM missing export처럼 free identifier를 만들면 런타임 ReferenceError가 난다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\import { missing } from './lib';
+        \\class SDK {
+        \\  static missing = missing;
+        \\}
+        \\console.log(SDK.missing);
+    );
+    try writeFile(tmp.dir, "lib.js", "export const existing = 42;");
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "void 0") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "static missing = missing") == null);
+}
+
 test "CJS: ESM import inside __commonJS wrapper rewritten to require_xxx()" {
     // ESM 모듈이 require()로 소비되어 __commonJS 래핑될 때,
     // 내부 import 문이 require("specifier")로 변환되는데,

--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -1765,6 +1765,36 @@ test "ESM re-export: named re-export from CJS binds via require getter (#1425)" 
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require_registry().getAssetByID") != null);
 }
 
+test "ESM namespace import: CJS named re-export member binds via require getter" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "registry.js",
+        \\exports.setTag = function setTag(value) { globalThis.tag = value; };
+    );
+    try writeFile(tmp.dir, "facade.js",
+        \\export { setTag } from './registry.js';
+    );
+    try writeFile(tmp.dir, "entry.js",
+        \\import * as facade from './facade.js';
+        \\facade.setTag('ok');
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require_registry().setTag(\"ok\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\nsetTag(\"ok\")") == null);
+}
+
 test "ESM re-export: named re-export from ESM binds via exports getter (#1425)" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -572,6 +572,37 @@ test "CJS: default import keeps __toESM when defineProperty __esModule marker ex
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM(require_lib()).default") != null);
 }
 
+test "CJS: React Native type module default import uses Babel interop" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath("node_modules/pkg");
+    try writeFile(tmp.dir, "entry.cjs", "require('pkg');\n");
+    try writeFile(tmp.dir, "node_modules/pkg/package.json",
+        \\{"type":"module","react-native":"./widget.tsx","main":"./fallback.cjs"}
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/widget.tsx", "import styled from './styled.cjs';\nexport const value = styled('View');\n");
+    try writeFile(tmp.dir, "node_modules/pkg/styled.cjs",
+        \\Object.defineProperty(exports, "__esModule", { value: true });
+        \\exports.default = function styled(component) { return component; };
+        \\exports.styled = exports.default;
+    );
+
+    const entry = try absPath(&tmp, "entry.cjs");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM(require_pkg_styled()).default") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__toESM(require_pkg_styled(), 1).default") == null);
+}
+
 test "CJS: multiple ESM modules importing same CJS module" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/bundler_test/lowering_rename_leak.zig
+++ b/src/bundler/bundler_test/lowering_rename_leak.zig
@@ -101,6 +101,38 @@ test "rename leak: for-of body 의 template literal compound assign 도 일관 r
     try testing.expect(std.mem.indexOf(u8, body, "t += ") == null);
 }
 
+test "rename leak: object shorthand 는 block-rename 된 value 로 확장됨" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "lib.js",
+        \\let routes = "module-level";
+        \\export function derive(cond, state, props) {
+        \\  if (cond) {
+        \\    let routes = state.routes;
+        \\    let previousRoutes = state.previousRoutes;
+        \\    let descriptors = props.descriptors;
+        \\    let previousDescriptors = state.previousDescriptors;
+        \\    return { routes, previousRoutes, descriptors, previousDescriptors };
+        \\  }
+        \\  let routes = props.routes;
+        \\  return { routes };
+        \\}
+        \\export function getModuleRoutes() { return routes; }
+    );
+    try writeFile(tmp.dir, "entry.js",
+        \\import { derive, getModuleRoutes } from './lib.js';
+        \\derive(true, { routes: ['a'], previousRoutes: [], previousDescriptors: {} }, { routes: ['b'], descriptors: {} });
+        \\getModuleRoutes();
+    );
+
+    var r = try bundleEntry(testing.allocator, &tmp, "entry.js");
+    defer r.deinit();
+    const code = r.code();
+
+    try testing.expect(std.mem.indexOf(u8, code, "routes: routes$") != null);
+    try testing.expect(std.mem.indexOf(u8, code, "return { routes, previousRoutes") == null);
+}
+
 // 충돌 없는 단일 let 은 rename 없이 유지 (over-fix 방지).
 test "rename leak: 충돌 없는 let 은 suffix 없이 그대로" {
     var tmp = testing.tmpDir(.{});

--- a/src/bundler/bundler_test/patterns.zig
+++ b/src/bundler/bundler_test/patterns.zig
@@ -692,12 +692,15 @@ test "Mixed: destructuring in import and export" {
     const entry = try absPath(&tmp, "entry.ts");
     defer std.testing.allocator.free(entry);
 
-    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry}, .platform = .react_native });
     defer b.deinit();
     const result = try b.bundle();
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var {x:x,y:y}=point;") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var point, x, y;") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "({ x:x, y:y } = point);") != null);
 }
 
 test "Mixed: array destructuring export emits each bound name" {

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -3447,14 +3447,11 @@ test "react_native inlineRequires: TS parameter property default visits ESM valu
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // class lowering 으로 default 가 `if (color === void 0)` 형태로 풀릴 수
-    // 있어 prefix 위치가 다양하다. lazy guard wrap 자체가 들어갔는지 (TOKENS
-    // 가 guarded lambda 안에서 .primary 로 접근) 만 잠근다. 또한 bare
-    // `TOKENS.primary` 가 어디에도 남지 않아야 한다.
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "(TOKENS.primary") == null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, " TOKENS.primary") == null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "=TOKENS.primary") == null);
 
+    // lazy guard 안의 `TOKENS).primary` 가 등장하면 raw `TOKENS.primary`
+    // 는 어디에도 남지 않아야 한다 — class lowering 으로 default 가
+    // `if (color === void 0)` 형태로 풀릴 수 있어 prefix 는 다양하니
+    // raw bare 부재 한 가지로 잠근다.
     const lazy_marker = try std.fmt.allocPrint(
         std.testing.allocator,
         "{s}__zntc_modules[\"{s}\"].fn()}}), TOKENS).primary",
@@ -3462,6 +3459,10 @@ test "react_native inlineRequires: TS parameter property default visits ESM valu
     );
     defer std.testing.allocator.free(lazy_marker);
     try std.testing.expect(std.mem.indexOf(u8, result.output, lazy_marker) != null);
+
+    // raw `TOKENS.primary` 가 lazy_marker 외부에 남지 않았는지 — marker 안의
+    // `TOKENS).primary` 는 닫는 `)` 가 끼어 있어 substring 매칭 안 됨.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "TOKENS.primary") == null);
 }
 
 test "react_native inlineRequires: for-of binding default visits ESM value import" {

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -2964,3 +2964,91 @@ test "entry_error_guard #21: silent_console_error_patterns 다중 패턴 — 모
     // 배열 loop 으로 검사 (단일 regex .test 가 아니라 IGNORE.length loop).
     try std.testing.expect(std.mem.indexOf(u8, result.output, "for (var i = 0; i < IGNORE.length") != null);
 }
+
+test "react_native inlineRequires: defer function-only ESM imports across selector cycles" {
+    // Payhere mobile-seller 축소 재현:
+    // seller selector 가 함수 안에서만 seller module state 를 읽는데, 그 import 를
+    // eager init 하면 sellerModule -> sagas -> local -> sellerSelectors 순환이 먼저 열려
+    // local 의 top-level createSelector 가 아직 할당 전인 getMode 를 받는다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.js",
+        \\import { getMode, readInitial } from './sellerSelectors';
+        \\globalThis.__zntcInlineRequiresResult = [getMode(), readInitial()];
+    );
+    try writeFile(tmp.dir, "reselect.js",
+        \\export function createSelector(inputs, result) {
+        \\  if (inputs.some((fn) => typeof fn !== 'function')) {
+        \\    throw new Error('bad selector');
+        \\  }
+        \\  return function selector() {
+        \\    return result(...inputs.map((fn) => fn()));
+        \\  };
+        \\}
+    );
+    try writeFile(tmp.dir, "local.js",
+        \\import { createSelector } from './reselect';
+        \\import { getMode } from './sellerSelectors';
+        \\export const storage = () => true;
+        \\export const select = createSelector(
+        \\  [getMode, storage],
+        \\  (mode, visible) => mode && visible,
+        \\);
+    );
+    try writeFile(tmp.dir, "sellerSelectors/index.js",
+        \\export * from './seller';
+    );
+    try writeFile(tmp.dir, "sellerSelectors/seller.js",
+        \\import { sellerInitialState } from '../sellerModule';
+        \\export const getMode = () => true;
+        \\export function readInitial() {
+        \\  return sellerInitialState.ready ? 'READY_MARKER' : 'EMPTY_MARKER';
+        \\}
+    );
+    try writeFile(tmp.dir, "sellerModule/index.js",
+        \\export { sellerInitialState } from './module';
+        \\export { watchers } from './sagas';
+    );
+    try writeFile(tmp.dir, "sellerModule/module.js",
+        \\export const sellerInitialState = { ready: true };
+    );
+    try writeFile(tmp.dir, "sellerModule/sagas.js",
+        \\import { select } from '../local';
+        \\export const watchers = [select];
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .tree_shaking = false,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "sellerInitialState.ready") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "sellerInitialState).ready") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "READY_MARKER") != null);
+
+    var dev_b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .tree_shaking = false,
+        .dev_mode = true,
+    });
+    defer dev_b.deinit();
+    const dev_result = try dev_b.bundle();
+    defer dev_result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!dev_result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, dev_result.output, "__zntc_modules[") != null);
+    try std.testing.expect(std.mem.indexOf(u8, dev_result.output, "sellerInitialState.ready") == null);
+    try std.testing.expect(std.mem.indexOf(u8, dev_result.output, "sellerInitialState).ready") != null);
+}

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -3267,3 +3267,252 @@ test "react_native inlineRequires: object parameter default visits ESM value imp
     defer std.testing.allocator.free(lazy_tokens_value);
     try std.testing.expect(std.mem.indexOf(u8, result.output, lazy_tokens_value) != null);
 }
+
+test "react_native inlineRequires: simple parameter default visits ESM value import" {
+    // `function f(a = X.y)` — assignment_pattern at the formal parameter level.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.js",
+        \\import { format } from './fmt';
+        \\globalThis.__zntcParamDefaultResult = format();
+    );
+    try writeFile(tmp.dir, "tokens.js",
+        \\export const TOKENS = { primary: 'primary-default' };
+    );
+    try writeFile(tmp.dir, "fmt.js",
+        \\import { TOKENS } from './tokens';
+        \\export function format(color = TOKENS.primary) { return color; }
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+    const tokens = try absPath(&tmp, "tokens.js");
+    defer std.testing.allocator.free(tokens);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .tree_shaking = false,
+        .dev_mode = true,
+        .entry_error_guard = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "color=TOKENS.primary") == null);
+
+    const lazy = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "color=({s}__zntc_modules[\"{s}\"].fn()}}), TOKENS).primary",
+        .{ rt.GUARD_LAMBDA_OPEN, tokens },
+    );
+    defer std.testing.allocator.free(lazy);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, lazy) != null);
+}
+
+test "react_native inlineRequires: array pattern default visits ESM value import" {
+    // `function f([a = X.y])` — array_pattern element default.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.js",
+        \\import { pick } from './pick';
+        \\globalThis.__zntcParamDefaultResult = pick([]);
+    );
+    try writeFile(tmp.dir, "tokens.js",
+        \\export const TOKENS = { primary: 'arr-default' };
+    );
+    try writeFile(tmp.dir, "pick.js",
+        \\import { TOKENS } from './tokens';
+        \\export function pick([first = TOKENS.primary] = []) { return first; }
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+    const tokens = try absPath(&tmp, "tokens.js");
+    defer std.testing.allocator.free(tokens);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .tree_shaking = false,
+        .dev_mode = true,
+        .entry_error_guard = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // bare `=TOKENS.primary` 가 남으면 lazy 치환 누락.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "=TOKENS.primary") == null);
+
+    // lazy expression 일부가 등장해야 한다 — array element default 위치.
+    const lazy_marker = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "{s}__zntc_modules[\"{s}\"].fn()}}), TOKENS).primary",
+        .{ rt.GUARD_LAMBDA_OPEN, tokens },
+    );
+    defer std.testing.allocator.free(lazy_marker);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, lazy_marker) != null);
+}
+
+test "react_native inlineRequires: nested destructuring default visits ESM value import" {
+    // `function f({ a: { b = X.y } = {} })` — nested object inside object default.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.js",
+        \\import { render } from './render';
+        \\globalThis.__zntcParamDefaultResult = render({});
+    );
+    try writeFile(tmp.dir, "tokens.js",
+        \\export const TOKENS = { primary: 'nested-default' };
+    );
+    try writeFile(tmp.dir, "render.js",
+        \\import { TOKENS } from './tokens';
+        \\export function render({ style: { color = TOKENS.primary } = {} } = {}) { return color; }
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+    const tokens = try absPath(&tmp, "tokens.js");
+    defer std.testing.allocator.free(tokens);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .tree_shaking = false,
+        .dev_mode = true,
+        .entry_error_guard = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "color=TOKENS.primary") == null);
+
+    const lazy = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "color=({s}__zntc_modules[\"{s}\"].fn()}}), TOKENS).primary",
+        .{ rt.GUARD_LAMBDA_OPEN, tokens },
+    );
+    defer std.testing.allocator.free(lazy);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, lazy) != null);
+}
+
+test "react_native inlineRequires: TS parameter property default visits ESM value import" {
+    // `class C { constructor(public a = X.y) {} }` — TS access modifier 가
+    // `formal_parameter` wrap 을 만드는 분기. 240bba46 의 formal_parameter
+    // extra layout 분기를 정확히 잠근다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { Theme } from './theme';
+        \\(globalThis as any).__zntcParamDefaultResult = new Theme();
+    );
+    try writeFile(tmp.dir, "tokens.ts",
+        \\export const TOKENS = { primary: 'ts-param-prop-default' };
+    );
+    try writeFile(tmp.dir, "theme.ts",
+        \\import { TOKENS } from './tokens';
+        \\export class Theme {
+        \\  constructor(public color: string = TOKENS.primary) {}
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    const tokens = try absPath(&tmp, "tokens.ts");
+    defer std.testing.allocator.free(tokens);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .tree_shaking = false,
+        .dev_mode = true,
+        .entry_error_guard = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    // class lowering 으로 default 가 `if (color === void 0)` 형태로 풀릴 수
+    // 있어 prefix 위치가 다양하다. lazy guard wrap 자체가 들어갔는지 (TOKENS
+    // 가 guarded lambda 안에서 .primary 로 접근) 만 잠근다. 또한 bare
+    // `TOKENS.primary` 가 어디에도 남지 않아야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "(TOKENS.primary") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, " TOKENS.primary") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "=TOKENS.primary") == null);
+
+    const lazy_marker = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "{s}__zntc_modules[\"{s}\"].fn()}}), TOKENS).primary",
+        .{ rt.GUARD_LAMBDA_OPEN, tokens },
+    );
+    defer std.testing.allocator.free(lazy_marker);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, lazy_marker) != null);
+}
+
+test "react_native inlineRequires: for-of binding default visits ESM value import" {
+    // `for (const { a = X.y } of arr)` — `registerBinding` 경로의 default
+    // visit.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.js",
+        \\import { run } from './run';
+        \\globalThis.__zntcParamDefaultResult = run([{}, {}]);
+    );
+    try writeFile(tmp.dir, "tokens.js",
+        \\export const TOKENS = { primary: 'for-of-default' };
+    );
+    try writeFile(tmp.dir, "run.js",
+        \\import { TOKENS } from './tokens';
+        \\export function run(items) {
+        \\  const out = [];
+        \\  for (const { color = TOKENS.primary } of items) {
+        \\    out.push(color);
+        \\  }
+        \\  return out;
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+    const tokens = try absPath(&tmp, "tokens.js");
+    defer std.testing.allocator.free(tokens);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .tree_shaking = false,
+        .dev_mode = true,
+        .entry_error_guard = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "color=TOKENS.primary") == null);
+
+    const lazy_marker = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "{s}__zntc_modules[\"{s}\"].fn()}}), TOKENS).primary",
+        .{ rt.GUARD_LAMBDA_OPEN, tokens },
+    );
+    defer std.testing.allocator.free(lazy_marker);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, lazy_marker) != null);
+}

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -2362,7 +2362,7 @@ fn buildRnGuardedWithSilentPatterns(allocator: std.mem.Allocator, entry: []const
     });
 }
 
-test "entry_error_guard #1: 옵션 활성 시 prologue 에 helper + inGuard pattern 보존" {
+test "entry_error_guard #1: 옵션 활성 시 prologue 에 Metro guard helper emit" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.js", "export const x = 1;\n");
@@ -2375,9 +2375,12 @@ test "entry_error_guard #1: 옵션 활성 시 prologue 에 helper + inGuard patt
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // helper 정의 + ZNTC policy: 각 호출 별 독립 try/catch + console.warn 로 LogBox 보고.
+    // helper 정의 + Metro guardedLoadModule semantics:
+    // outer guard + ErrorUtils.reportFatalError, ErrorUtils 없으면 fallback rethrow.
     try std.testing.expect(std.mem.indexOf(u8, result.output, "function __zntc_guarded") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "console.warn") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__zntc_in_guard") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__zntc_guard_global.ErrorUtils.reportFatalError") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "return fn();") != null);
 }
 
 test "entry_error_guard #2: 옵션 비활성 시 helper / wrap 모두 없음 (회귀 방지)" {
@@ -2563,11 +2566,9 @@ test "entry_error_guard #9: mixed CJS + ESM dependencies — 모두 wrap" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__zntc_guarded(") != null);
 }
 
-test "entry_error_guard #10: 각 호출 별 독립 try/catch (ZNTC policy)" {
-    // Metro 의 inGuard pattern 은 iOS 26.4+ native fatal handler 와 조합으로 부팅 정지
-    // 이슈 발생. ZNTC 는 각 호출을 독립 try/catch 로 wrap 해 한 layer throw 가 다음
-    // layer 영향 없도록 함 — 각 outer (rbm, winter, metro-runtime, entry chain, entry)
-    // 가 별도 catch 로 swallow + console.error 로 보고.
+test "entry_error_guard #10: Metro inGuard + ErrorUtils fallback rethrow semantics" {
+    // Metro 는 ErrorUtils 가 있을 때만 outermost 호출을 catch/report 한다.
+    // ErrorUtils 미정의 구간은 unguarded 로 실행해야 InitializeCore 실패를 숨기지 않는다.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.js", "export const v = 1;\n");
@@ -2580,8 +2581,10 @@ test "entry_error_guard #10: 각 호출 별 독립 try/catch (ZNTC policy)" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // 각 호출 별 독립 try/catch — inGuard short-circuit 없이 매 호출이 outer
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "console.warn") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "if (!__zntc_in_guard && __zntc_guard_global && __zntc_guard_global.ErrorUtils)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__zntc_in_guard = true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__zntc_in_guard = false") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "return fn();") != null);
 }
 
 test "entry_error_guard #11: entry 안의 var/function 정의 + chain 혼재" {
@@ -2655,11 +2658,12 @@ test "entry_error_guard #13: minify_whitespace — minified helper 형태 정상
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // minified 형태도 helper 정의 + console.warn swallow 보존
+    // minified 형태도 helper 정의 + Metro ErrorUtils guard 보존
     try std.testing.expect(std.mem.indexOf(u8, result.output, "function $zg") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "$zg(") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__zntc_guarded") == null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "console.warn") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$zgG.ErrorUtils.reportFatalError") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "return fn()") != null);
 }
 
 test "entry_error_guard #14: 비-entry 모듈의 chain 도 wrap (preamble + side-effect)" {
@@ -2797,9 +2801,9 @@ test "entry_error_guard #17b: silent_console_error_patterns 비어있으면 sett
     try std.testing.expect(std.mem.indexOf(u8, result.output, "function __zntc_guarded") != null);
 }
 
-test "entry_error_guard #18: __ZNTC_DEBUG_GUARD toggle — 기본 silent, toggle on 시 console.warn" {
-    // `__zntc_guarded` 의 catch block 은 기본 silent. 디버그 시 globalThis.__ZNTC_DEBUG_GUARD
-    // 를 truthy 로 set 하면 console.warn 으로 출력 — escape hatch.
+test "entry_error_guard #18: silent swallow/debug toggle 제거 — Metro ErrorUtils 보고만 사용" {
+    // `__zntc_guarded` 는 Metro 와 동일하게 ErrorUtils 가 있으면 reportFatalError,
+    // 없으면 rethrow. 별도 debug toggle 로 예외를 삼키지 않는다.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.js", "export const x = 1;\n");
@@ -2812,13 +2816,10 @@ test "entry_error_guard #18: __ZNTC_DEBUG_GUARD toggle — 기본 silent, toggle
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // toggle gate — silent 기본 + 명시적 enable.
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "__ZNTC_DEBUG_GUARD") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "console.warn(\"[zntc:guard] caught:\"") != null);
-    // bare console.warn (toggle 무시) 또는 console.error 호출이 catch block 에 없어야 함.
-    // simple substring: "[zntc:guard]" 는 toggle gate 안에서만 나와야 함 — 한 번만 등장.
-    const tag_count = std.mem.count(u8, result.output, "[zntc:guard]");
-    try std.testing.expectEqual(@as(usize, 1), tag_count);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__ZNTC_DEBUG_GUARD") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "[zntc:guard]") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "console.warn") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__zntc_guard_global.ErrorUtils.reportFatalError") != null);
 }
 
 test "entry_error_guard #19: dev_mode + entry_chain — __zntc_modules[\"...\"].fn() 도 wrap" {

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -2334,9 +2334,10 @@ test "JSX automatic: _createElement injected for .js source (expo-router useScre
 // 검증 invariant:
 // 1. helper 가 prologue 에 1번만 emit (중복 방지)
 // 2. helper 의 inGuard pattern 보존 (Metro 동등) — nested 호출은 throw propagate
-// 3. entry chain unroll — entry init body 의 module init 호출이 entry trigger 위치에
-//    separate top-level statement 로 emit 되어 각각 별 outer try/catch
-// 4. 비-entry 모듈의 chain 호출은 그대로 (factory body 안)
+// 3. runBeforeMain unroll — runBeforeMainModule은 entry trigger 앞의 separate
+//    top-level statement 로 emit
+// 4. entry dependency chain 과 비-entry 모듈 chain 호출은 factory body 안에 남아
+//    nested throw propagation 보존
 // 5. ErrorUtils 정의 환경 / 미정의 환경 fallback 정확
 // 6. side-effect / re-export / CJS / mixed / TLA edge case 모두 안전
 // 7. minify 출력에서도 동일 의미
@@ -2448,9 +2449,10 @@ test "entry_error_guard #4: 단순 entry — chain unroll 없이 entry trigger �
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__zntc_guarded(") != null);
 }
 
-test "entry_error_guard #5: 다중 chain entry — 각 import 의 init 호출이 separate outer wrap" {
-    // Option B 핵심: entry init body 의 chain 이 entry trigger 위치에 unroll 되어
-    // 각 모듈 init 호출이 별 top-level `__zntc_guarded(...)` statement 가 됨.
+test "entry_error_guard #5: 다중 chain entry — import init 은 entry guard 안에 유지" {
+    // Metro는 entry `__r(entry)` 하나만 outer guard로 감싸고, entry import chain은
+    // factory 내부 nested require로 실행한다. dependency throw가 entry 평가를 중단해야
+    // 하므로 import init을 top-level 개별 guard로 풀면 안 된다.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "a.js", "globalThis.__guardA = 1; export const a = globalThis.__guardA;\n");
@@ -2471,10 +2473,58 @@ test "entry_error_guard #5: 다중 chain entry — 각 import 의 init 호출이
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // 호출 site count 가 chain 수에 비례 — entry 3 imports + entry 자체 trigger
-    const guarded_calls = std.mem.count(u8, result.output, "__zntc_guarded(");
-    // 최소 4 (3 chain + 1 entry trigger). 실제로 더 많을 수 있음 (esm_wrap 의 다른 path)
-    try std.testing.expect(guarded_calls >= 4);
+    const marker = "//#endregion\n";
+    const top_start = (std.mem.lastIndexOf(u8, result.output, marker) orelse 0) + marker.len;
+    const top_level = result.output[top_start..];
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, top_level, "__zntc_guarded("));
+    try std.testing.expect(std.mem.indexOf(u8, top_level, "init_entry") != null);
+    try std.testing.expect(std.mem.indexOf(u8, top_level, "init_a") == null);
+    try std.testing.expect(std.mem.indexOf(u8, top_level, "init_b") == null);
+    try std.testing.expect(std.mem.indexOf(u8, top_level, "init_c") == null);
+}
+
+test "entry_error_guard #5b: runBeforeMain 만 entry 앞에 분리하고 entry import 는 중첩 유지" {
+    // 재현 최소 케이스: runBeforeMain이 ErrorUtils를 설치한 뒤 entry dependency가 throw.
+    // Metro에서는 entry outer guard가 그 throw를 report하고 entry factory를 중단하므로
+    // 뒤 import/entry body가 실행되지 않는다. zntc가 entry import를 top-level 개별 guard로
+    // unroll하면 throw가 swallow되어 뒤 import가 계속 실행된다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "setup.js", "globalThis.ErrorUtils = { reportFatalError(e) { globalThis.reported = e.message; } };\n");
+    try writeFile(tmp.dir, "boom.js", "throw new Error('boom');\n");
+    try writeFile(tmp.dir, "after.js", "globalThis.afterRan = true;\n");
+    try writeFile(tmp.dir, "entry.js",
+        \\import './boom.js';
+        \\import './after.js';
+        \\globalThis.entryRan = true;
+    );
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+    const setup = try absPath(&tmp, "setup.js");
+    defer std.testing.allocator.free(setup);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .entry_error_guard = true,
+        .run_before_main = &.{setup},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const marker = "//#endregion\n";
+    const top_start = (std.mem.lastIndexOf(u8, result.output, marker) orelse 0) + marker.len;
+    const top_level = result.output[top_start..];
+    try std.testing.expect(std.mem.indexOf(u8, top_level, "init_setup") != null);
+    try std.testing.expect(std.mem.indexOf(u8, top_level, "init_entry") != null);
+    try std.testing.expect(std.mem.indexOf(u8, top_level, "init_boom") == null);
+    try std.testing.expect(std.mem.indexOf(u8, top_level, "init_after") == null);
+
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__zntc_guarded(function(){return init_boom();});") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__zntc_guarded(function(){return init_after();});") != null);
 }
 
 test "entry_error_guard #6: side-effect import — wrap 적용 + 평가 시점 보존" {
@@ -2694,9 +2744,10 @@ test "entry_error_guard #14: 비-entry 모듈의 chain 도 wrap (preamble + side
     try std.testing.expect(guarded_calls >= 2);
 }
 
-test "entry_error_guard #15: entry chain unroll — entry init body 안 chain 라인이 entry trigger 위치로 이동" {
-    // Option B 핵심 검증: entry 모듈의 init body 안에 chain init 호출이 *없어야* 하고,
-    // 대신 entry trigger 위치 (bundle 끝) 에 separate top-level 로 emit 되어야 함.
+test "entry_error_guard #15: entry import chain 은 entry init body 안에 남김" {
+    // Metro 동등성 검증: entry 모듈의 init body 안에 import init 호출이 남아야 한다.
+    // bundle 끝 entry trigger 영역에는 entry 자체 호출만 있어야 dependency throw가
+    // 같은 outer guard 아래에서 전파된다.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "dep.js", "export const d = 1;\n");
@@ -2713,12 +2764,10 @@ test "entry_error_guard #15: entry chain unroll — entry init body 안 chain �
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // bundle 의 마지막 부분 (entry trigger 영역) 에 chain unroll 결과 — separate
-    // top-level `__zntc_guarded(...);` statement 가 여러 개 존재해야 함.
-    // 정확한 패턴 검증은 구현 후 strict assertion 으로 강화.
-    const tail_start = if (result.output.len > 2000) result.output.len - 2000 else 0;
-    const tail = result.output[tail_start..];
-    try std.testing.expect(std.mem.indexOf(u8, tail, "__zntc_guarded(") != null);
+    const marker = "//#endregion\n";
+    const top_start = (std.mem.lastIndexOf(u8, result.output, marker) orelse 0) + marker.len;
+    const top_level = result.output[top_start..];
+    try std.testing.expect(std.mem.indexOf(u8, top_level, "init_dep") == null);
 }
 
 test "entry_error_guard #16: GUARD_LAMBDA 매크로 형식 — esm_wrap / metadata 두 사이트 일관" {
@@ -2822,9 +2871,9 @@ test "entry_error_guard #18: silent swallow/debug toggle 제거 — Metro ErrorU
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__zntc_guard_global.ErrorUtils.reportFatalError") != null);
 }
 
-test "entry_error_guard #19: dev_mode + entry_chain — __zntc_modules[\"...\"].fn() 도 wrap" {
-    // dev_mode 에서는 init 호출이 `__zntc_modules["id"].fn()` 형식. entry_chain unroll
-    // 시 이것도 `__zntc_guarded(function(){return __zntc_modules["id"].fn();})` 로 wrap 되어야 함.
+test "entry_error_guard #19: dev_mode + entry import chain — __zntc_modules[\"...\"].fn() 도 중첩 wrap" {
+    // dev_mode 에서는 init 호출이 `__zntc_modules["id"].fn()` 형식이다. entry import
+    // chain도 entry factory 내부에 남기되 동일한 guard lambda 형식을 유지해야 한다.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "dep.js", "export const d = 1;\n");
@@ -2847,9 +2896,14 @@ test "entry_error_guard #19: dev_mode + entry_chain — __zntc_modules[\"...\"].
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // dev_mode 형식 + wrap 둘 다 존재.
+    // dev_mode 형식 + nested wrap 둘 다 존재.
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__zntc_modules[") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__zntc_guarded(function(){return __zntc_modules[") != null);
+    const marker = "//#endregion\n";
+    const top_start = (std.mem.lastIndexOf(u8, result.output, marker) orelse 0) + marker.len;
+    const top_level = result.output[top_start..];
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, top_level, "__zntc_guarded("));
+    try std.testing.expect(std.mem.indexOf(u8, top_level, "dep.js") == null);
 }
 
 test "entry_error_guard #20: silent_console_error_patterns 정확도 — 실제 expo 메시지 형식과 매치" {

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -3132,6 +3132,94 @@ test "react_native inlineRequires: defer top-level ESM value imports to use site
     try std.testing.expect(std.mem.indexOf(u8, result.output, ".fn();});\n,") == null);
 }
 
+test "react_native inlineRequires: keeps default ESM imports eager for provider side effects" {
+    // Metro inlineRequires 는 `import Foo from './foo'` 를 named import 처럼
+    // `require(...).Foo` 위치로 미루지 않는다. RNFirebase Firestore 는 default
+    // import 된 모듈의 top-level provider 호출로 DocumentReference 내부 slot 을
+    // 채우므로 default import 를 lazy 처리하면 `new null.prototype` 계열 런타임
+    // 오류가 난다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.js",
+        \\import { makeDoc } from './firestore-index';
+        \\globalThis.__zntcFirestoreDocResult = makeDoc();
+    );
+    try writeFile(tmp.dir, "firestore-index.js",
+        \\import FirestoreQuery from './FirestoreQuery';
+        \\import FirestoreDocumentReference from './FirestoreDocumentReference';
+        \\export function makeQuery() {
+        \\  return new FirestoreQuery();
+        \\}
+        \\export function makeDoc() {
+        \\  return new FirestoreDocumentReference().get();
+        \\}
+    );
+    try writeFile(tmp.dir, "FirestoreQuery.js",
+        \\import FirestoreDocumentSnapshot from './FirestoreDocumentSnapshot';
+        \\export default class FirestoreQuery {
+        \\  snapshot() {
+        \\    return new FirestoreDocumentSnapshot().name;
+        \\  }
+        \\}
+    );
+    try writeFile(tmp.dir, "FirestoreDocumentSnapshot.js",
+        \\import { provideDocumentSnapshotClass } from './FirestoreDocumentReference';
+        \\export default class FirestoreDocumentSnapshot {
+        \\  constructor() {
+        \\    this.name = 'snapshot-ready';
+        \\  }
+        \\}
+        \\provideDocumentSnapshotClass(FirestoreDocumentSnapshot);
+    );
+    try writeFile(tmp.dir, "FirestoreDocumentReference.js",
+        \\let FirestoreDocumentSnapshot = null;
+        \\export function provideDocumentSnapshotClass(cls) {
+        \\  FirestoreDocumentSnapshot = cls;
+        \\}
+        \\export default class FirestoreDocumentReference {
+        \\  get() {
+        \\    return new FirestoreDocumentSnapshot().name;
+        \\  }
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+    const query = try absPath(&tmp, "FirestoreQuery.js");
+    defer std.testing.allocator.free(query);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .tree_shaking = false,
+        .dev_mode = true,
+        .entry_error_guard = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+
+    const eager_query_init = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "__zntc_guarded(function(){{return __zntc_modules[\"{s}\"].fn();}});",
+        .{query},
+    );
+    defer std.testing.allocator.free(eager_query_init);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, eager_query_init) != null);
+
+    const lazy_query_value = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "(__zntc_guarded(function(){{return __zntc_modules[\"{s}\"].fn()}}), FirestoreQuery)",
+        .{query},
+    );
+    defer std.testing.allocator.free(lazy_query_value);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, lazy_query_value) == null);
+}
+
 test "react_native inlineRequires: object parameter default visits ESM value import" {
     // `{ backgroundColor = COLOR_TOKENS.bgPrimary }` 는 binding pattern 이지만
     // default initializer 는 값 표현식이다. Metro/Babel 은 이 import 를 값 참조로

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -2792,13 +2792,16 @@ test "entry_error_guard #16: GUARD_LAMBDA 매크로 형식 — esm_wrap / metada
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // 모든 wrap 호출은 정확히 `__zntc_guarded(function(){return ` 으로 시작 + `;});` 으로 종료.
-    // 다른 형식 (예: `__zntc_guarded(()=>` 또는 `__zntc_guarded(function(){X();})` 등) 검출.
+    // 모든 wrap 호출은 정확히 `__zntc_guarded(function(){return ` 으로 시작한다.
+    // statement guard 는 `;});`, expression guard 는 `}),` 로 닫힌다.
+    // expression guard 에 statement terminator 가 섞이면 `(...;});, value)` 문법 오류가 된다.
     const open_count = std.mem.count(u8, result.output, "__zntc_guarded(function(){return ");
-    const close_count = std.mem.count(u8, result.output, ";});");
+    const statement_close_count = std.mem.count(u8, result.output, ";});");
+    const expression_close_count = std.mem.count(u8, result.output, "}),");
     try std.testing.expect(open_count >= 2);
     // close 는 wrap 외 다른 곳 (ESM closure 등) 에서도 나올 수 있어 >= 만 검증.
-    try std.testing.expect(close_count >= open_count);
+    try std.testing.expect(statement_close_count + expression_close_count >= open_count);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, ".fn();});\n,") == null);
 }
 
 test "entry_error_guard #17: silent_console_error_patterns 주입 시 setter intercept emit" {

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -2876,9 +2876,10 @@ test "entry_error_guard #19: dev_mode + entry import chain — __zntc_modules[\"
     // chain도 entry factory 내부에 남기되 동일한 guard lambda 형식을 유지해야 한다.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    try writeFile(tmp.dir, "dep.js", "export const d = 1;\n");
+    try writeFile(tmp.dir, "dep.js", "export const d = getD();\nfunction getD() { return 1; }\n");
     try writeFile(tmp.dir, "entry.js",
         \\import { d } from './dep.js';
+        \\globalThis.__zntcGuardDevValue = d;
         \\export const r = d;
     );
     const entry = try absPath(&tmp, "entry.js");
@@ -2904,6 +2905,7 @@ test "entry_error_guard #19: dev_mode + entry import chain — __zntc_modules[\"
     const top_level = result.output[top_start..];
     try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, top_level, "__zntc_guarded("));
     try std.testing.expect(std.mem.indexOf(u8, top_level, "dep.js") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, ".fn();});\n,") == null);
 }
 
 test "entry_error_guard #20: silent_console_error_patterns 정확도 — 실제 expo 메시지 형식과 매치" {
@@ -3042,6 +3044,7 @@ test "react_native inlineRequires: defer function-only ESM imports across select
         .format = .iife,
         .tree_shaking = false,
         .dev_mode = true,
+        .entry_error_guard = true,
     });
     defer dev_b.deinit();
     const dev_result = try dev_b.bundle();
@@ -3051,4 +3054,76 @@ test "react_native inlineRequires: defer function-only ESM imports across select
     try std.testing.expect(std.mem.indexOf(u8, dev_result.output, "__zntc_modules[") != null);
     try std.testing.expect(std.mem.indexOf(u8, dev_result.output, "sellerInitialState.ready") == null);
     try std.testing.expect(std.mem.indexOf(u8, dev_result.output, "sellerInitialState).ready") != null);
+}
+
+test "react_native inlineRequires: defer top-level ESM value imports to use site" {
+    // Metro inlineRequires 는 named import 의 require() 를 모듈 선두로 올리지 않고
+    // 실제 값 참조 지점에 둔다. Payhere mobile-seller 의 selector/navigator cycle 에서
+    // zntc 가 import init 을 먼저 실행하면 Metro 보다 이른 시점에 순환 모듈이 열려
+    // reselect input selector 가 undefined 로 평가된다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.js",
+        \\import { select } from './local';
+        \\globalThis.__zntcTopLevelInlineRequiresResult = select();
+    );
+    try writeFile(tmp.dir, "reselect.js",
+        \\export function createSelector(inputs, result) {
+        \\  if (inputs.some((fn) => typeof fn !== 'function')) {
+        \\    throw new Error('bad selector');
+        \\  }
+        \\  return function selector() {
+        \\    return result(...inputs.map((fn) => fn()));
+        \\  };
+        \\}
+    );
+    try writeFile(tmp.dir, "local.js",
+        \\import { createSelector } from './reselect';
+        \\import { getRemoteValue } from './remote';
+        \\export const getLocalValue = () => 'local';
+        \\export const select = createSelector([getRemoteValue], (value) => value);
+    );
+    try writeFile(tmp.dir, "remote.js",
+        \\import { createSelector } from './reselect';
+        \\import { getLocalValue } from './local';
+        \\export const getRemoteBase = () => 'remote';
+        \\export const getRemoteValue = createSelector([getLocalValue], (value) => value);
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+    const remote = try absPath(&tmp, "remote.js");
+    defer std.testing.allocator.free(remote);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .tree_shaking = false,
+        .dev_mode = true,
+        .entry_error_guard = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+
+    const eager_remote_init = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "__zntc_guarded(function(){{return __zntc_modules[\"{s}\"].fn();}});",
+        .{remote},
+    );
+    defer std.testing.allocator.free(eager_remote_init);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, eager_remote_init) == null);
+
+    const lazy_remote_value = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "(__zntc_guarded(function(){{return __zntc_modules[\"{s}\"].fn()}}),",
+        .{remote},
+    );
+    defer std.testing.allocator.free(lazy_remote_value);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, lazy_remote_value) != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, ".fn();});\n,") == null);
 }

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -4,6 +4,7 @@ const types = @import("../types.zig");
 const emitter = @import("../emitter.zig");
 const ResolveCache = @import("../resolve_cache.zig").ResolveCache;
 const ModuleGraph = @import("../graph.zig").ModuleGraph;
+const rt = @import("../runtime_helpers.zig");
 const test_helpers = @import("../test_helpers.zig");
 const writeFile = test_helpers.writeFile;
 const absPath = test_helpers.absPath;
@@ -3126,4 +3127,52 @@ test "react_native inlineRequires: defer top-level ESM value imports to use site
     defer std.testing.allocator.free(lazy_remote_value);
     try std.testing.expect(std.mem.indexOf(u8, result.output, lazy_remote_value) != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, ".fn();});\n,") == null);
+}
+
+test "react_native inlineRequires: object parameter default visits ESM value import" {
+    // `{ backgroundColor = COLOR_TOKENS.bgPrimary }` 는 binding pattern 이지만
+    // default initializer 는 값 표현식이다. Metro/Babel 은 이 import 를 값 참조로
+    // 남기므로 zntc 도 lazy ESM import 치환을 적용해야 한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.js",
+        \\import { TabTemplate } from './template';
+        \\globalThis.__zntcParamDefaultResult = TabTemplate({});
+    );
+    try writeFile(tmp.dir, "tokens.js",
+        \\export const COLOR_TOKENS = { bgPrimary: 'primary-bg' };
+    );
+    try writeFile(tmp.dir, "template.js",
+        \\import { COLOR_TOKENS } from './tokens';
+        \\export const TabTemplate = ({ backgroundColor = COLOR_TOKENS.bgPrimary }) => backgroundColor;
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+    const tokens = try absPath(&tmp, "tokens.js");
+    defer std.testing.allocator.free(tokens);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .tree_shaking = false,
+        .dev_mode = true,
+        .entry_error_guard = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "backgroundColor=COLOR_TOKENS.bgPrimary") == null);
+
+    const lazy_tokens_value = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "backgroundColor=({s}__zntc_modules[\"{s}\"].fn()}}), COLOR_TOKENS).bgPrimary",
+        .{ rt.GUARD_LAMBDA_OPEN, tokens },
+    );
+    defer std.testing.allocator.free(lazy_tokens_value);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, lazy_tokens_value) != null);
 }

--- a/src/bundler/bundler_test/resolution.zig
+++ b/src/bundler/bundler_test/resolution.zig
@@ -173,6 +173,51 @@ test "PackageJson: react-native platform follows Metro main field order" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "\"from-main\"") == null);
 }
 
+test "PackageJson: react-native package exports without RN/default falls back to main fields" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "import { value } from 'rnpkg';\nconsole.log(value);");
+    try writeFile(tmp.dir, "node_modules/rnpkg/package.json",
+        \\{
+        \\  "name": "rnpkg",
+        \\  "react-native": "./rn.js",
+        \\  "main": "./main.js",
+        \\  "exports": {
+        \\    ".": {
+        \\      "import": {
+        \\        "types": "./dist/index.d.ts",
+        \\        "default": "./dist/index.js"
+        \\      },
+        \\      "require": {
+        \\        "types": "./dist/index.d.cts",
+        \\        "default": "./dist/index.cjs"
+        \\      }
+        \\    }
+        \\  }
+        \\}
+    );
+    try writeFile(tmp.dir, "node_modules/rnpkg/rn.js", "export const value = 'from-react-native';");
+    try writeFile(tmp.dir, "node_modules/rnpkg/main.js", "export const value = 'from-main';");
+    try writeFile(tmp.dir, "node_modules/rnpkg/dist/index.js", "export const value = 'from-import-default';");
+    try writeFile(tmp.dir, "node_modules/rnpkg/dist/index.cjs", "module.exports = { value: 'from-require-default' };");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"from-react-native\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"from-import-default\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"from-require-default\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"from-main\"") == null);
+}
+
 test "PackageJson: no package.json index.js fallback" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/bundler_test/resolution.zig
+++ b/src/bundler/bundler_test/resolution.zig
@@ -173,7 +173,11 @@ test "PackageJson: react-native platform follows Metro main field order" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "\"from-main\"") == null);
 }
 
-test "PackageJson: react-native package exports without RN/default falls back to main fields" {
+test "PackageJson: react-native package exports without RN condition matches import" {
+    // Metro `unstable_conditionNames: ["react-native"]` + ESM importer 에서
+    // `import` / `default` 를 자동 추가하므로, `react-native` 조건이 없어도
+    // exports 의 `import` 분기가 우선 매칭된다. main field 의 `react-native`
+    // 보다 exports 가 우선.
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.ts", "import { value } from 'rnpkg';\nconsole.log(value);");
@@ -212,10 +216,47 @@ test "PackageJson: react-native package exports without RN/default falls back to
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"from-react-native\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"from-import-default\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"from-import-default\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"from-react-native\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "\"from-require-default\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "\"from-main\"") == null);
+}
+
+test "PackageJson: react-native package exports with RN condition wins over import" {
+    // 패키지가 `react-native` 조건을 명시했으면 `import` / `default` 보다 우선.
+    // Metro 의 conditionNames Set 에서 `react-native` 가 unstable_conditionNames 로
+    // 먼저 들어가고, exports 의 키 매칭은 정의 순서를 따른다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts", "import { value } from 'rnpkg2';\nconsole.log(value);");
+    try writeFile(tmp.dir, "node_modules/rnpkg2/package.json",
+        \\{
+        \\  "name": "rnpkg2",
+        \\  "exports": {
+        \\    ".": {
+        \\      "react-native": "./dist/index.native.js",
+        \\      "import": "./dist/index.js",
+        \\      "default": "./dist/index.js"
+        \\    }
+        \\  }
+        \\}
+    );
+    try writeFile(tmp.dir, "node_modules/rnpkg2/dist/index.native.js", "export const value = 'from-rn-export';");
+    try writeFile(tmp.dir, "node_modules/rnpkg2/dist/index.js", "export const value = 'from-import-export';");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"from-rn-export\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "\"from-import-export\"") == null);
 }
 
 test "PackageJson: no package.json index.js fallback" {

--- a/src/bundler/bundler_test/runtime_helper_shadow.zig
+++ b/src/bundler/bundler_test/runtime_helper_shadow.zig
@@ -178,3 +178,52 @@ test "Runtime helper shadow: helper 호출이 user binding 의 rename 결과를 
     try std.testing.expect(!result.hasErrors());
     try std.testing.expect(std.mem.indexOf(u8, result.output, "\"shadow-ati\"") != null);
 }
+
+test "Runtime helper shadow: private field set helper avoids UMD global helper overwrite" {
+    // RN/Metro 환경에서 tslib UMD는 helper를 module.exports와 global 양쪽에 export한다.
+    // Metro+Babel의 class private helper는 모듈 래퍼 내부 local이라 global write에
+    // 덮이지 않는다. ZNTC도 transformer helper call site가 global helper 이름
+    // `__classPrivateFieldSet` 자체에 묶이면 tslib의 TS signature helper에 덮여
+    // `state.has is not a function`으로 죽는다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.ts",
+        \\import './tslib-umd.js';
+        \\import { Box } from './box';
+        \\export const value = new Box().set(1);
+    );
+    try writeFile(tmp.dir, "box.ts",
+        \\export class Box {
+        \\  #value = 0;
+        \\  set(next: number) {
+        \\    return this.#value = next;
+        \\  }
+        \\}
+    );
+    try writeFile(tmp.dir, "tslib-umd.js",
+        \\const root = typeof globalThis === 'object' ? globalThis : global;
+        \\root.__classPrivateFieldSet = function(receiver, state, value) {
+        \\  if (!state.has(receiver)) throw new TypeError('tslib private field helper');
+        \\  state.set(receiver, value);
+        \\  return value;
+        \\};
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .unsupported = compat_mod.fromESTarget(.es5),
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "root.__classPrivateFieldSet") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__zntcClassPrivateFieldSet(_value, this, next)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__classPrivateFieldSet(_value, this, next)") == null);
+}

--- a/src/bundler/compiled_module.zig
+++ b/src/bundler/compiled_module.zig
@@ -24,9 +24,9 @@ pub const CompiledModule = struct {
     preamble_lines: u32 = 0,
     /// per-source function map JSON. null = 비활성/함수 없음.
     fn_map_json: ?[]const u8 = null,
-    /// `entry_error_guard` 활성 + entry 모듈에서 factory body 와 분리해 emitter 가
-    /// 별 top-level statement 로 unroll. 각 chain 이 독립 `__zntc_guarded(...)` 가 되어
-    /// 한 layer throw 가 다른 layer 부팅을 막지 않음 (Metro `__r(N)` per-path 와 동등).
+    /// `entry_error_guard` 활성 + entry 모듈의 runBeforeMain 호출을 factory body 와
+    /// 분리해 emitter 가 별 top-level statement 로 unroll. entry dependency chain은
+    /// Metro처럼 entry factory 내부 nested require로 남겨 throw 전파를 보존한다.
     entry_chain: ?[]const u8 = null,
     /// 이 module code 가 참조하는 shared namespace object 선언 목록.
     /// compiled output cache hit 시 linker 의 bundle preamble registry 를 복원하는 데 사용.

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -911,8 +911,10 @@ pub fn emitWithTreeShaking(
         }
     }
 
-    // 래핑된 엔트리 자동 호출. Metro `getAppendScripts` 와 동등 — `runBeforeMainModule`
-    // + entry 각 path 마다 separate `__r(N);` (= 독립 outer `__zntc_guarded(...)`) 로 emit.
+    // 래핑된 엔트리 자동 호출. Metro `getAppendScripts` 와 동등하게
+    // runBeforeMainModule은 entry 앞의 별도 `__r(N);`로 실행하고, entry 자체는 한 번만
+    // outer `__zntc_guarded(...)`로 호출한다. entry dependency chain은 entry factory
+    // 내부 nested require로 남아야 throw가 entry 평가를 중단한다.
     if (entry_idx) |ei| {
         for (sorted.items, 0..) |em, ei_idx| {
             if (em.index.toU32() == ei and em.wrap_kind.isWrapped()) {

--- a/src/bundler/emitter/cjs_wrap.zig
+++ b/src/bundler/emitter/cjs_wrap.zig
@@ -6,7 +6,8 @@
 
 const std = @import("std");
 const rt = @import("../runtime_helpers.zig");
-const Module = @import("../module.zig").Module;
+const module_mod = @import("../module.zig");
+const Module = module_mod.Module;
 const EmitOptions = @import("../emitter.zig").EmitOptions;
 
 /// Disabled 모듈: platform=browser에서 Node 빌트인 모듈을 빈 __commonJS wrapper로 출력.
@@ -16,6 +17,24 @@ pub fn emitDisabledModule(allocator: std.mem.Allocator, module: *const Module, m
     defer allocator.free(var_name);
 
     var buf: std.ArrayList(u8) = .empty;
+    if (module.disabled_throw_on_require) {
+        const specifier = optionalMissingSpecifier(module);
+        if (minify) {
+            try buf.appendSlice(allocator, "var ");
+            try buf.appendSlice(allocator, var_name);
+            try buf.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "({\"(optional-missing)\"(exports,module){");
+            try appendOptionalMissingThrow(allocator, &buf, specifier, true);
+            try buf.appendSlice(allocator, "}});");
+        } else {
+            try buf.appendSlice(allocator, "var ");
+            try buf.appendSlice(allocator, var_name);
+            try buf.appendSlice(allocator, " = __commonJS({\n\t\"(optional-missing)\"(exports, module) {\n\t\t");
+            try appendOptionalMissingThrow(allocator, &buf, specifier, false);
+            try buf.appendSlice(allocator, "\t}\n});\n");
+        }
+        return try buf.toOwnedSlice(allocator);
+    }
+
     if (minify) {
         try buf.appendSlice(allocator, "var ");
         try buf.appendSlice(allocator, var_name);
@@ -27,6 +46,55 @@ pub fn emitDisabledModule(allocator: std.mem.Allocator, module: *const Module, m
         try buf.appendSlice(allocator, " = __commonJS({\n\t\"(disabled)\"(exports, module) {\n\t}\n});\n");
     }
     return try buf.toOwnedSlice(allocator);
+}
+
+fn optionalMissingSpecifier(module: *const Module) []const u8 {
+    if (std.mem.startsWith(u8, module.path, module_mod.OPTIONAL_MISSING_MODULE_PREFIX)) {
+        return module.path[module_mod.OPTIONAL_MISSING_MODULE_PREFIX.len..];
+    }
+    return module.path;
+}
+
+fn appendOptionalMissingThrow(
+    allocator: std.mem.Allocator,
+    buf: *std.ArrayList(u8),
+    specifier: []const u8,
+    minify: bool,
+) !void {
+    if (minify) {
+        try buf.appendSlice(allocator, "var e=new Error(\"Cannot find module \\\"\"+");
+        try appendJsStringLiteral(allocator, buf, specifier);
+        try buf.appendSlice(allocator, "+\"\\\"\");e.code=\"MODULE_NOT_FOUND\";throw e;");
+        return;
+    }
+
+    try buf.appendSlice(allocator, "var e = new Error(\"Cannot find module \\\"\" + ");
+    try appendJsStringLiteral(allocator, buf, specifier);
+    try buf.appendSlice(allocator, " + \"\\\"\");\n\t\te.code = \"MODULE_NOT_FOUND\";\n\t\tthrow e;\n");
+}
+
+fn appendJsStringLiteral(allocator: std.mem.Allocator, buf: *std.ArrayList(u8), value: []const u8) !void {
+    const hex = "0123456789abcdef";
+    try buf.append(allocator, '"');
+    for (value) |c| {
+        switch (c) {
+            '\\' => try buf.appendSlice(allocator, "\\\\"),
+            '"' => try buf.appendSlice(allocator, "\\\""),
+            '\n' => try buf.appendSlice(allocator, "\\n"),
+            '\r' => try buf.appendSlice(allocator, "\\r"),
+            '\t' => try buf.appendSlice(allocator, "\\t"),
+            else => {
+                if (c < 0x20) {
+                    try buf.appendSlice(allocator, "\\u00");
+                    try buf.append(allocator, hex[c >> 4]);
+                    try buf.append(allocator, hex[c & 0x0f]);
+                } else {
+                    try buf.append(allocator, c);
+                }
+            },
+        }
+    }
+    try buf.append(allocator, '"');
 }
 
 /// Asset 모듈(file/copy 로더)을 CJS wrap 패턴으로 출력. source엔 값 표현식이 저장됨.

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -11,6 +11,7 @@ const ModuleGraph = @import("../graph.zig").ModuleGraph;
 const ast_mod = @import("../../parser/ast.zig");
 const Ast = ast_mod.Ast;
 const NodeIndex = ast_mod.NodeIndex;
+const ast_walk = @import("../../parser/ast_walk.zig");
 const Transformer = @import("../../transformer/transformer.zig").Transformer;
 const RuntimeHelpers = @import("../../transformer/runtime_helper_bits.zig").RuntimeHelpers;
 const Codegen = @import("../../codegen/codegen.zig").Codegen;
@@ -244,6 +245,16 @@ pub fn emitEsmWrappedModule(
                         const raw_name = try arena_alloc.dupe(u8, esm_ast.getText(name_node.data.string_ref));
                         const resolved = try arena_alloc.dupe(u8, resolveNodeName(metadata, @intFromEnum(name_raw), raw_name));
                         try hoisted_var_names.append(allocator, resolved);
+                    } else {
+                        var it = try ast_walk.bindingIdentifiers(allocator, esm_ast, name_raw, .{});
+                        defer it.deinit();
+                        while (try it.next()) |bind_idx| {
+                            const bind_node = esm_ast.nodes.items[@intFromEnum(bind_idx)];
+                            if (bind_node.tag != .binding_identifier) continue;
+                            const raw_name = try arena_alloc.dupe(u8, esm_ast.getText(bind_node.data.string_ref));
+                            const resolved = try arena_alloc.dupe(u8, resolveNodeName(metadata, @intFromEnum(bind_idx), raw_name));
+                            try hoisted_var_names.append(allocator, resolved);
+                        }
                     }
                 }
                 // body에 넣어서 할당문으로 변환

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -59,6 +59,11 @@ fn isSyntheticDefault(ref: SymbolRef, mod: *const Module) bool {
     };
 }
 
+inline fn cjsInteropMode(options: *const EmitOptions, importer: *const Module) types.Interop {
+    if (options.platform == .react_native) return .babel;
+    return if (importer.def_format.isEsm()) .node else .babel;
+}
+
 /// re_export_alias에 linker가 주입한 canonical_name을 반환. null이면
 /// alias 심볼이 아니거나 linker가 resolve하지 못한 경우.
 /// re-export 의 source 모듈을 resolve. resolved + non-self-cycle 인 정상 record 만 반환,
@@ -712,7 +717,7 @@ pub fn emitEsmWrappedModule(
                         } else {
                             const rv = try source_mod.allocRequireName(allocator);
                             defer allocator.free(rv);
-                            const interop_mode: types.Interop = if (module.def_format.isEsm()) .node else .babel;
+                            const interop_mode = cjsInteropMode(options, module);
                             // #1621: minify 시 __toESM → $tE 축약.
                             const to_esm_name: []const u8 = if (options.minify_whitespace) rt.NAMES.TOESM_MIN else "__toESM";
                             try reexport_buf.appendSlice(allocator, to_esm_name);

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -801,13 +801,12 @@ pub fn emitEsmWrappedModule(
 
     const is_async = module.uses_top_level_await;
 
-    // Option B (entry chain unroll): entry+entry_error_guard 활성 시 factory body 의
-    // chain init 호출 (rbm + preamble + star_init) 을 별 buffer 로 capture 후
-    // EsmEmitResult.entry_chain 으로 export. emitter 가 entry trigger 위치에서
-    // separate top-level statement 로 unroll emit → 각 chain 호출이 별 outer
-    // `__zntc_guarded(...)` (Metro `__r(N)` 와 동등). nested 호출은 inGuard 로
-    // wrap 효과 없이 throw propagate (Metro 100% 동등 mechanism).
-    const unroll_entry_chain = module.is_entry_point and options.entry_error_guard;
+    // entry+entry_error_guard 활성 시 runBeforeMain만 entry trigger 위치로 분리한다.
+    // Metro는 runBeforeMainModule을 entry `__r(entry)`와 별도 top-level `__r(...)`로
+    // 실행하지만, entry dependency chain은 entry factory 안의 nested require로 남긴다.
+    // dependency를 top-level 개별 guard로 풀면 ErrorUtils 설치 후 throw가 swallow되어
+    // entry 평가가 계속 진행된다.
+    const unroll_run_before_main = module.is_entry_point and options.entry_error_guard;
     var entry_chain_buf: std.ArrayList(u8) = .empty;
     errdefer entry_chain_buf.deinit(allocator);
 
@@ -835,15 +834,15 @@ pub fn emitEsmWrappedModule(
             try wrapped.appendSlice(allocator, " \"+id)};");
             try wrapped.appendSlice(allocator, "__zntc_g.$RefreshSig$=function(){var rt=__zntc_g.__ReactRefresh||__zntc_resolveRefresh();if(rt)return rt.createSignatureFunctionForTransform();return function(t){return t}};");
         }
-        try writeChainPiece(&entry_chain_buf, &wrapped, allocator, rbm_code.items, unroll_entry_chain, false);
+        try writeChainPiece(&entry_chain_buf, &wrapped, allocator, rbm_code.items, unroll_run_before_main, false);
         if (func_code.len > 0) {
             func_preamble_lines = @intCast(std.mem.count(u8, wrapped.items, "\n"));
             try wrapped.appendSlice(allocator, func_code);
         }
         if (preamble_code) |p| {
-            try writeChainPiece(&entry_chain_buf, &wrapped, allocator, p, unroll_entry_chain, false);
+            try writeChainPiece(&entry_chain_buf, &wrapped, allocator, p, false, false);
         }
-        try writeChainPiece(&entry_chain_buf, &wrapped, allocator, star_init_buf.items, unroll_entry_chain, false);
+        try writeChainPiece(&entry_chain_buf, &wrapped, allocator, star_init_buf.items, false, false);
         try wrapped.appendSlice(allocator, body_code);
         if (reexport_buf.items.len > 0) try wrapped.appendSlice(allocator, reexport_buf.items);
         if (has_refresh) {
@@ -881,7 +880,7 @@ pub fn emitEsmWrappedModule(
             try wrapped.appendSlice(allocator, "\t\treturn function(t) { return t; };\n");
             try wrapped.appendSlice(allocator, "\t};\n");
         }
-        try writeChainPiece(&entry_chain_buf, &wrapped, allocator, rbm_code.items, unroll_entry_chain, true);
+        try writeChainPiece(&entry_chain_buf, &wrapped, allocator, rbm_code.items, unroll_run_before_main, true);
         // func_code를 preamble 앞에 배치: 순환 참조에서 preamble이 의존 모듈을 init할 때
         // 이 모듈의 함수가 이미 할당된 상태여야 한다. (#1092)
         if (func_code.len > 0) {
@@ -890,9 +889,9 @@ pub fn emitEsmWrappedModule(
             try appendIndented(&wrapped, allocator, func_code);
         }
         if (preamble_code) |p| {
-            try writeChainPiece(&entry_chain_buf, &wrapped, allocator, p, unroll_entry_chain, true);
+            try writeChainPiece(&entry_chain_buf, &wrapped, allocator, p, false, true);
         }
-        try writeChainPiece(&entry_chain_buf, &wrapped, allocator, star_init_buf.items, unroll_entry_chain, true);
+        try writeChainPiece(&entry_chain_buf, &wrapped, allocator, star_init_buf.items, false, true);
         body_preamble_lines = @intCast(std.mem.count(u8, wrapped.items, "\n"));
         if (body_code.len > 0) {
             try wrapped.append(allocator, '\t');
@@ -995,8 +994,9 @@ pub fn emitEsmWrappedModule(
         }
     }
 
-    // entry_chain: unroll 모드에서 caller (emitter.zig) 에 전달. 빈 buffer 면 null.
-    const entry_chain_owned: ?[]const u8 = if (unroll_entry_chain and entry_chain_buf.items.len > 0)
+    // entry_chain: runBeforeMain unroll 모드에서 caller (emitter.zig) 에 전달.
+    // 빈 buffer 면 null.
+    const entry_chain_owned: ?[]const u8 = if (unroll_run_before_main and entry_chain_buf.items.len > 0)
         try allocator.dupe(u8, entry_chain_buf.items)
     else
         null;

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -287,6 +287,7 @@ pub const ModuleGraph = struct {
     pub const markRecordLazyResolved = graph_module_registry.markRecordLazyResolved;
     pub const addModule = graph_module_registry.addModule;
     pub const addDisabledModule = graph_module_registry.addDisabledModule;
+    pub const addOptionalMissingModule = graph_module_registry.addOptionalMissingModule;
     pub const addExternalModule = graph_module_registry.addExternalModule;
     pub const linkDependency = graph_module_registry.linkDependency;
     pub const linkDynamicImport = graph_module_registry.linkDynamicImport;

--- a/src/bundler/graph/finalize.zig
+++ b/src/bundler/graph/finalize.zig
@@ -31,6 +31,9 @@ pub fn promoteExportsKinds(self: *ModuleGraph) void {
                 if (target.module_type == .json) {
                     target.exports_kind = .commonjs;
                     target.wrap_kind = .cjs;
+                } else if (shouldUseMetroCjsForMixedModule(self, target)) {
+                    target.exports_kind = .commonjs;
+                    target.wrap_kind = .cjs;
                 } else if (target.exports_kind.isEsm()) {
                     target.wrap_kind = .esm;
                 } else {
@@ -98,6 +101,11 @@ pub fn promoteExportsKinds(self: *ModuleGraph) void {
         var it = self.modules.iterator(0);
         while (it.next()) |m| {
             if (m.wrap_kind != .none) continue;
+            if (shouldUseMetroCjsForMixedModule(self, m)) {
+                m.exports_kind = .commonjs;
+                m.wrap_kind = .cjs;
+                continue;
+            }
             if (!m.exports_kind.isEsm()) continue;
             // RN production: side-effect free + non-cyclic + no TLA + no re_export 모듈은
             // scope-hoist 유지. re_export 가 있는 barrel 은 wrap 필수 (#1340/#1193 —
@@ -127,6 +135,12 @@ pub fn promoteExportsKinds(self: *ModuleGraph) void {
             m.wrap_kind = .esm;
         }
     }
+}
+
+fn shouldUseMetroCjsForMixedModule(self: *ModuleGraph, module: *const Module) bool {
+    return self.resolve_cache.platform == .react_native and
+        module.exports_kind == .esm_with_dynamic_fallback and
+        module.has_cjs_export_signal;
 }
 
 pub fn promoteRunBeforeMainModules(self: *ModuleGraph) void {

--- a/src/bundler/graph/module_registry.zig
+++ b/src/bundler/graph/module_registry.zig
@@ -96,7 +96,23 @@ pub fn addModule(self: *ModuleGraph, abs_path: []const u8) !ModuleIndex {
 pub fn addDisabledModule(self: *ModuleGraph, specifier: []const u8) !ModuleIndex {
     // 가상 경로: "(disabled):specifier" (esbuild 형식).
     // specifier 기준으로 중복 체크 — 여러 모듈이 같은 빌트인을 require해도 하나만 생성.
-    const disabled_path = try std.mem.concat(self.allocator, u8, &.{ "(disabled):", specifier });
+    return addDisabledModuleWithMode(self, module_mod.DISABLED_MODULE_PREFIX, specifier, false);
+}
+
+/// try/catch 안의 unresolved optional dependency 를 등록한다.
+/// 빈 모듈을 반환하면 destructuring/default access 가 catch 로 넘어가지 않으므로,
+/// require 되는 순간 Node/Metro처럼 MODULE_NOT_FOUND 를 던지는 CJS wrapper 를 출력한다.
+pub fn addOptionalMissingModule(self: *ModuleGraph, specifier: []const u8) !ModuleIndex {
+    return addDisabledModuleWithMode(self, module_mod.OPTIONAL_MISSING_MODULE_PREFIX, specifier, true);
+}
+
+fn addDisabledModuleWithMode(
+    self: *ModuleGraph,
+    prefix: []const u8,
+    specifier: []const u8,
+    throw_on_require: bool,
+) !ModuleIndex {
+    const disabled_path = try std.mem.concat(self.allocator, u8, &.{ prefix, specifier });
 
     // 중복 체크
     if (self.path_to_module.get(disabled_path)) |existing| {
@@ -110,6 +126,7 @@ pub fn addDisabledModule(self: *ModuleGraph, specifier: []const u8) !ModuleIndex
     module.exports_kind = .commonjs;
     module.wrap_kind = .cjs;
     module.is_disabled = true;
+    module.disabled_throw_on_require = throw_on_require;
     module.side_effects = false;
     module.state = .ready;
     try self.modules.append(self.allocator, module);

--- a/src/bundler/graph/resolve_imports.zig
+++ b/src/bundler/graph/resolve_imports.zig
@@ -50,6 +50,10 @@ pub fn replayCachedResolvedDeps(self: *ModuleGraph, mod_idx: usize) !void {
                 const dep_idx = try self.addDisabledModule(dep.path);
                 try replayLinkResolvedDep(self, mod_index, mod_idx, dep, dep_idx);
             },
+            .optional_missing => {
+                const dep_idx = try self.addOptionalMissingModule(dep.path);
+                try replayLinkResolvedDep(self, mod_index, mod_idx, dep, dep_idx);
+            },
             .external => {
                 const ext_idx = try self.addExternalModule(dep.path);
                 if (dep.record_index) |rec_idx| {
@@ -205,11 +209,11 @@ pub fn applyResolveResult(
         // runtime 에 catch 되는 의도된 케이스를 build hard-fail 시키지 않는다.
         if (record.is_optional) {
             self.addDiag(.unresolved_import, .warning, self.modules.at(mod_idx).path, record.span, .resolve, "Optional dependency not resolved (will throw at runtime if reached)", record.specifier);
-            const dep_idx = try self.addDisabledModule(record.specifier);
+            const dep_idx = try self.addOptionalMissingModule(record.specifier);
             try appendResolvedDep(self, mod_idx, .{
                 .record_index = @intCast(rec_i),
                 .kind = record.kind,
-                .target = .disabled,
+                .target = .optional_missing,
                 .path = record.specifier,
             });
             try recordResolvedDep(self, mod_index, mod_idx, rec_i, dep_idx, record.kind);

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1627,6 +1627,16 @@ pub const Linker = struct {
         return name;
     }
 
+    fn cjsNamespaceExportAccess(self: *const Linker, ref: SymbolRef) std.mem.Allocator.Error!?[]const u8 {
+        const target = self.graph.getModule(ref.module_index) orelse return null;
+        if (target.wrap_kind != .cjs) return null;
+        if (std.mem.eql(u8, ref.export_name, "default")) return null;
+
+        const req_var = try target.allocRequireName(self.allocator);
+        defer self.allocator.free(req_var);
+        return try std.fmt.allocPrint(self.allocator, "{s}().{s}", .{ req_var, ref.export_name });
+    }
+
     /// `import_records[idx].resolved` 가 valid 면 모듈 인덱스 반환, 아니면 null.
     /// `collectExportsRecursive` 의 3개 분기에서 공유.
     inline fn resolvedRecordModule(records: anytype, rec_idx_opt: ?u32) ?u32 {
@@ -1676,6 +1686,7 @@ pub const Linker = struct {
             // 가 access site 마다 객체 literal 을 inline emit (#1928). 대신 source mod_idx
             // 만 기록하고 ns_var 등록은 호출 site 가 일임.
             var ns_target_mod: ?u32 = null;
+            var owns_actual_local = false;
             const actual_local = if (eb.kind == .re_export_namespace) blk: {
                 ns_target_mod = resolvedRecordModule(m.import_records, eb.import_record_index);
                 break :blk eb_local;
@@ -1693,7 +1704,13 @@ pub const Linker = struct {
                             }
                         }
                     }
-                    if (ns_target_mod == null) break :blk self.resolveToLocalName(canonical);
+                    if (ns_target_mod == null) {
+                        if (try self.cjsNamespaceExportAccess(canonical)) |expr| {
+                            owns_actual_local = true;
+                            break :blk expr;
+                        }
+                        break :blk self.resolveToLocalName(canonical);
+                    }
                     break :blk eb_local;
                 }
                 break :blk eb_local;
@@ -1703,12 +1720,15 @@ pub const Linker = struct {
                 break :blk eb_local;
             };
 
-            const safe_local = self.safeIdentifierName(actual_local, @intCast(mod_i));
+            const safe_local = if (owns_actual_local)
+                actual_local
+            else
+                self.safeIdentifierName(actual_local, @intCast(mod_i));
 
             try exports.append(self.allocator, .{
                 .exported = eb.exported_name,
                 .local = safe_local,
-                .owned = false,
+                .owned = owns_actual_local,
                 .ns_target_mod = ns_target_mod,
             });
         }

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -153,6 +153,10 @@ pub const Linker = struct {
     /// init_xxx() 대신 동적 lookup을 사용하여 new Function()에서도 접근 가능.
     dev_mode: bool = false,
 
+    /// Metro inlineRequires 호환 경로. RN에서는 함수 내부에서만 읽히는 import의
+    /// module init을 top-level preamble에서 미루고, 참조 지점에서 lazy init한다.
+    inline_requires: bool = false,
+
     /// `EmitOptions.entry_error_guard` propagate. preamble 의 module init 호출을
     /// `__zntc_guarded(fn)` 으로 wrap 하여 outermost 에서 `ErrorUtils.reportFatalError`
     /// 로 swallow. helper 자체는 emitter prologue 에 주입.

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -92,6 +92,53 @@ pub fn isImportBindingTypeOnly(sem: *const @import("../module.zig").ModuleSemant
     return true;
 }
 
+fn hasFunctionAncestor(sem: *const @import("../module.zig").ModuleSemanticData, scope_id: @import("../../semantic/scope.zig").ScopeId) bool {
+    var sid = scope_id;
+    while (!sid.isNone()) {
+        const idx = sid.toIndex();
+        if (idx >= sem.scopes.len) return false;
+        const scope = sem.scopes[idx];
+        if (scope.kind == .function) return true;
+        sid = scope.parent;
+    }
+    return false;
+}
+
+fn isFunctionOnlyValueImport(sem: *const @import("../module.zig").ModuleSemanticData, ib: ImportBinding) bool {
+    if (ib.is_helper) return false;
+    if (ib.kind == .namespace) return false;
+    const sym_idx = ib.local_symbol.semanticIndex() orelse return false;
+    if (sym_idx >= sem.symbols.items.len) return false;
+
+    var saw_value_use = false;
+    for (sem.references) |r| {
+        if (@intFromEnum(r.symbol_id) != sym_idx) continue;
+        if (!r.isValueUse()) continue;
+        saw_value_use = true;
+        if (!hasFunctionAncestor(sem, r.scope_id)) return false;
+    }
+    return saw_value_use;
+}
+
+fn allocLazyEsmImportExpr(self: *const Linker, target_mod: *const Module, target_name: []const u8) ![]const u8 {
+    const sep = if (self.minify_whitespace) "," else ", ";
+    if (self.dev_mode) {
+        return try std.fmt.allocPrint(
+            self.allocator,
+            "(__zntc_modules[\"{s}\"].fn(){s}{s})",
+            .{ target_mod.dev_id, sep, target_name },
+        );
+    }
+
+    const init_name = try target_mod.allocInitName(self.allocator);
+    defer self.allocator.free(init_name);
+    return try std.fmt.allocPrint(
+        self.allocator,
+        "({s}(){s}{s})",
+        .{ init_name, sep, target_name },
+    );
+}
+
 pub fn buildSkipNodes(allocator: std.mem.Allocator, ast: *const Ast, skip_imports: bool) !std.DynamicBitSet {
     const node_count = ast.nodes.items.len;
     var skip_nodes = try std.DynamicBitSet.initEmpty(allocator, node_count);
@@ -480,15 +527,25 @@ pub fn buildMetadataForAst(
             // 호이스팅된 함수는 top-level에 있으므로 rename으로 참조 가능.
             // init 호출은 모듈당 1회만 (중복 방지는 esm_init_set으로).
             // `entry_error_guard` 활성 시 wrap. TLA 는 await 가 lambda 안에 못 들어가서 제외.
+            var lazy_esm_import = false;
             if (canonical_m_opt != null and canonical_m_opt.?.wrap_kind == .esm) {
                 // CJS path 와 동일하게 tree-shake 결과 반영 (#2398). `sideEffects: false`
                 // 인 .esm wrap 모듈이 unused 로 drop 되면 `init_xxx is not defined` 가
                 // 나므로 preamble 도 함께 생략. `tree_shaker_active=false` 인 단위 테스트
                 // 환경에서는 is_included bit 가 신뢰 불가라 가드 미적용 (line 408 동일 정책).
                 if (self.tree_shaker_active and !canonical_m_opt.?.is_included) continue;
-                if (!esm_init_set.contains(@intCast(canonical_mod))) {
+                const target_mod = canonical_m_opt.?;
+                lazy_esm_import = self.inline_requires and
+                    m.wrap_kind == .esm and
+                    rec.kind == .static_import and
+                    canonical_mod != module_index and
+                    !is_helper_binding and
+                    ib.kind != .namespace and
+                    !target_mod.uses_top_level_await and
+                    !exported_locals.contains(m.importBindingLocalName(ib)) and
+                    isFunctionOnlyValueImport(&sem, ib);
+                if (!lazy_esm_import and !esm_init_set.contains(@intCast(canonical_mod))) {
                     try esm_init_set.put(@intCast(canonical_mod), {});
-                    const target_mod = canonical_m_opt.?;
                     const is_tla = target_mod.uses_top_level_await;
                     const guard = target_mod.shouldGuard(self.entry_error_guard);
                     if (is_tla) try preamble.write("await ");
@@ -642,13 +699,25 @@ pub fn buildMetadataForAst(
             // 채워졌으면 rename 스킵 (#2429).
             if (!isReservedName(target_name) and target_name.len > 0 and isValidIdentStartByte(target_name[0])) {
                 if (ib.local_symbol.semanticIndex()) |sym_idx| {
-                    try putOwnedRename(self, &renames, &owned_nested_renames, sym_idx, target_name);
+                    const rename_value = if (lazy_esm_import)
+                        try allocLazyEsmImportExpr(self, canonical_m_opt.?, target_name)
+                    else
+                        target_name;
+                    if (lazy_esm_import) {
+                        var rename_owned_by_list = false;
+                        errdefer if (!rename_owned_by_list) self.allocator.free(rename_value);
+                        try owned_nested_renames.append(self.allocator, rename_value);
+                        rename_owned_by_list = true;
+                        try renames.put(sym_idx, rename_value);
+                    } else {
+                        try putOwnedRename(self, &renames, &owned_nested_renames, sym_idx, rename_value);
+                    }
                     // __esm → __esm live binding: __export getter override 등록 +
                     // 자체 rename 루프에서 덮어쓰기 방지
                     if (m.wrap_kind == .esm and canonical_m_opt != null and
                         canonical_m_opt.?.wrap_kind == .esm)
                     {
-                        try export_getter_overrides.put(self.allocator, m.importBindingLocalName(ib), target_name);
+                        try export_getter_overrides.put(self.allocator, m.importBindingLocalName(ib), rename_value);
                     }
                 }
             }

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -29,6 +29,11 @@ const NamePair = PreambleWriter.NamePair;
 const NS_VAR_PREFIX = linker_mod.NS_VAR_PREFIX;
 const EXPR_RENAME_MARKER = linker_mod.EXPR_RENAME_MARKER;
 
+inline fn cjsInteropMode(self: *const Linker, importer: *const Module) types.Interop {
+    if (self.graph.resolve_cache.platform == .react_native) return .babel;
+    return if (importer.def_format.isEsm()) .node else .babel;
+}
+
 /// #1791 Phase D: import binding 의 local 이 value 로 참조된 적이 있는지 조회.
 /// analyzer 가 각 Reference 에 `type_context` / `value_as_type` flag 를 기록하므로,
 /// symbol 의 Reference 들 중 **순수 value read** 가 하나라도 있으면 false. 하나도 없으면
@@ -423,7 +428,7 @@ pub fn buildMetadataForAst(
                             try renames.put(sym_idx, direct_access);
                         }
                     } else {
-                        const interop_mode: types.Interop = if (m.def_format.isEsm()) .node else .babel;
+                        const interop_mode = cjsInteropMode(self, &m);
                         const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse m.importBindingLocalName(ib);
                         const hoisted_name = try self.allocator.dupe(u8, preamble_name);
                         errdefer self.allocator.free(hoisted_name);
@@ -453,7 +458,7 @@ pub fn buildMetadataForAst(
                 if (self.tree_shaker_active and !canonical_m_opt.?.is_included) continue;
                 const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse m.importBindingLocalName(ib);
                 const req_var = try getOrCreateRequireVar(self, &cjs_var_cache, @intCast(canonical_mod));
-                const interop_mode: types.Interop = if (m.def_format.isEsm()) .node else .babel;
+                const interop_mode = cjsInteropMode(self, &m);
                 // ESM-wrapped + helper binding: top-level 에 이미 var 선언됨 (esm_wrap) → 할당만
                 if (is_helper_binding and m.wrap_kind == .esm) {
                     if (ib.importsDefault() and m.canUseDirectCjsDefaultImport(canonical_m_opt.?)) {
@@ -553,7 +558,7 @@ pub fn buildMetadataForAst(
                 if (cjs_mod_opt != null and cjs_mod_opt.?.wrap_kind == .cjs) {
                     const preamble_name = self.getCanonicalByRef(ib.local_symbol) orelse m.importBindingLocalName(ib);
                     const req_var = try getOrCreateRequireVar(self, &cjs_var_cache, cjs_mod);
-                    const interop_mode2: types.Interop = if (m.def_format.isEsm()) .node else .babel;
+                    const interop_mode2 = cjsInteropMode(self, &m);
                     const effective_name = rb.canonical.export_name;
                     if (std.mem.eql(u8, effective_name, "default") and m.canUseDirectCjsDefaultImport(cjs_mod_opt.?)) {
                         try preamble.writeCjsDirectDefault(preamble_name, req_var, false);

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -92,46 +92,30 @@ pub fn isImportBindingTypeOnly(sem: *const @import("../module.zig").ModuleSemant
     return true;
 }
 
-fn hasFunctionAncestor(sem: *const @import("../module.zig").ModuleSemanticData, scope_id: @import("../../semantic/scope.zig").ScopeId) bool {
-    var sid = scope_id;
-    while (!sid.isNone()) {
-        const idx = sid.toIndex();
-        if (idx >= sem.scopes.len) return false;
-        const scope = sem.scopes[idx];
-        if (scope.kind == .function) return true;
-        sid = scope.parent;
-    }
-    return false;
-}
-
-fn isFunctionOnlyValueImport(sem: *const @import("../module.zig").ModuleSemanticData, ib: ImportBinding) bool {
-    if (ib.is_helper) return false;
-    if (ib.kind == .namespace) return false;
-    const sym_idx = ib.local_symbol.semanticIndex() orelse return false;
-    if (sym_idx >= sem.symbols.items.len) return false;
-
-    var saw_value_use = false;
-    for (sem.references) |r| {
-        if (@intFromEnum(r.symbol_id) != sym_idx) continue;
-        if (!r.isValueUse()) continue;
-        saw_value_use = true;
-        if (!hasFunctionAncestor(sem, r.scope_id)) return false;
-    }
-    return saw_value_use;
-}
-
 fn allocLazyEsmImportExpr(self: *const Linker, target_mod: *const Module, target_name: []const u8) ![]const u8 {
     const sep = if (self.minify_whitespace) "," else ", ";
+    const guard_close_expr = "})";
+    const guard = target_mod.shouldGuard(self.entry_error_guard);
     if (self.dev_mode) {
-        return try std.fmt.allocPrint(
-            self.allocator,
-            "(__zntc_modules[\"{s}\"].fn(){s}{s})",
-            .{ target_mod.dev_id, sep, target_name },
-        );
+        if (guard) {
+            return try std.fmt.allocPrint(
+                self.allocator,
+                "({s}__zntc_modules[\"{s}\"].fn(){s}{s}{s})",
+                .{ if (self.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN, target_mod.dev_id, guard_close_expr, sep, target_name },
+            );
+        }
+        return try std.fmt.allocPrint(self.allocator, "(__zntc_modules[\"{s}\"].fn(){s}{s})", .{ target_mod.dev_id, sep, target_name });
     }
 
     const init_name = try target_mod.allocInitName(self.allocator);
     defer self.allocator.free(init_name);
+    if (guard) {
+        return try std.fmt.allocPrint(
+            self.allocator,
+            "({s}{s}(){s}{s}{s})",
+            .{ if (self.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN, init_name, guard_close_expr, sep, target_name },
+        );
+    }
     return try std.fmt.allocPrint(
         self.allocator,
         "({s}(){s}{s})",
@@ -535,6 +519,11 @@ pub fn buildMetadataForAst(
                 // 환경에서는 is_included bit 가 신뢰 불가라 가드 미적용 (line 408 동일 정책).
                 if (self.tree_shaker_active and !canonical_m_opt.?.is_included) continue;
                 const target_mod = canonical_m_opt.?;
+                // Metro inlineRequires 호환: RN 에서는 static import 의 module init 을
+                // 모듈 선두 preamble 로 당기지 않고 실제 값 참조 지점에 둔다.
+                // 기존 function-only 한정은 함수 body cycle 만 해결했지만, Metro 는
+                // top-level initializer 안의 named import 도 `require(...).name` 위치에서
+                // 평가하므로 selector/navigator cycle 에서 초기화 순서 차이가 생겼다.
                 lazy_esm_import = self.inline_requires and
                     m.wrap_kind == .esm and
                     rec.kind == .static_import and
@@ -542,8 +531,7 @@ pub fn buildMetadataForAst(
                     !is_helper_binding and
                     ib.kind != .namespace and
                     !target_mod.uses_top_level_await and
-                    !exported_locals.contains(m.importBindingLocalName(ib)) and
-                    isFunctionOnlyValueImport(&sem, ib);
+                    !exported_locals.contains(m.importBindingLocalName(ib));
                 if (!lazy_esm_import and !esm_init_set.contains(@intCast(canonical_mod))) {
                     try esm_init_set.put(@intCast(canonical_mod), {});
                     const is_tla = target_mod.uses_top_level_await;

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -519,17 +519,18 @@ pub fn buildMetadataForAst(
                 // 환경에서는 is_included bit 가 신뢰 불가라 가드 미적용 (line 408 동일 정책).
                 if (self.tree_shaker_active and !canonical_m_opt.?.is_included) continue;
                 const target_mod = canonical_m_opt.?;
-                // Metro inlineRequires 호환: RN 에서는 static import 의 module init 을
-                // 모듈 선두 preamble 로 당기지 않고 실제 값 참조 지점에 둔다.
-                // 기존 function-only 한정은 함수 body cycle 만 해결했지만, Metro 는
-                // top-level initializer 안의 named import 도 `require(...).name` 위치에서
-                // 평가하므로 selector/navigator cycle 에서 초기화 순서 차이가 생겼다.
+                // Metro inlineRequires 호환: RN 은 named import 만 `require(...).name`
+                // 위치로 미루고 default/namespace import 는 eager require 로 유지한다.
+                // default import 된 모듈은 top-level provider 등록 같은 부작용을 가질
+                // 수 있으므로 lazy 처리하면 RNFirebase Firestore 처럼 초기화 순서가
+                // Metro 와 달라진다.
                 lazy_esm_import = self.inline_requires and
                     m.wrap_kind == .esm and
                     rec.kind == .static_import and
                     canonical_mod != module_index and
                     !is_helper_binding and
-                    ib.kind != .namespace and
+                    ib.kind == .named and
+                    !ib.importsDefault() and
                     !target_mod.uses_top_level_await and
                     !exported_locals.contains(m.importBindingLocalName(ib));
                 if (!lazy_esm_import and !esm_init_set.contains(@intCast(canonical_mod))) {

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -141,11 +141,9 @@ pub fn registerNamespaceRewrites(
             try inner_map.put(exp.exported, ns_var);
             continue;
         }
-        const local = if (exp.owned)
-            try self.allocator.dupe(u8, exp.local)
-        else
-            exp.local;
-        try inner_map.put(exp.exported, local);
+        // exp.local 은 owned=true 면 ns_export_cache 가, 아니면 target module 이 소유한다.
+        // metadata map 은 값 포인터만 빌린다.
+        try inner_map.put(exp.exported, exp.local);
     }
     try ns_rewrite_list.append(self.allocator, .{
         .symbol_id = symbol_id,

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -28,6 +28,9 @@ const symbol_mod = @import("symbol.zig");
 pub const AliasTable = symbol_mod.AliasTable;
 const RuntimeHelpers = @import("../transformer/runtime_helper_bits.zig").RuntimeHelpers;
 
+pub const DISABLED_MODULE_PREFIX = "(disabled):";
+pub const OPTIONAL_MISSING_MODULE_PREFIX = "(optional-missing):";
+
 /// 증분 빌드용 path 기반 resolve cache.
 ///
 /// `ImportRecord.resolved` 는 빌드마다 새로 배정되는 ModuleIndex라 다음 rebuild에서
@@ -44,6 +47,7 @@ pub const CachedResolvedDep = struct {
     pub const Target = enum {
         file,
         disabled,
+        optional_missing,
         external,
         worker,
         virtual,
@@ -250,6 +254,9 @@ pub const Module = struct {
     /// platform=browser에서 Node 빌트인 모듈을 빈 CJS로 대체 (esbuild "(disabled)" 방식).
     /// AST가 없고, emitter가 빈 __commonJS wrapper를 출력한다.
     is_disabled: bool = false,
+    /// try/catch 안의 optional unresolved dependency. Graph 상으론 disabled 모듈처럼 AST가
+    /// 없지만, require 되는 순간 Node/Metro처럼 MODULE_NOT_FOUND 를 던져 catch 로 넘어가야 한다.
+    disabled_throw_on_require: bool = false,
     /// `external` 패턴 매칭으로 번들에 포함되지 않는 모듈. graph 에는 phantom 으로 등록되어
     /// `meta.getModuleInfo` / `info.importedIds` 등 graph traversal API 의 1급 노드로 보이지만
     /// chunk 배정 / emit / tree-shake 에선 제외. AST 없음, source 없음, path = original specifier.

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -143,16 +143,23 @@ pub const ResolveCache = struct {
                 .node => &.{ c.require, c.node, c.default },
                 .browser => &.{ c.require, c.browser, c.default },
                 .neutral => &.{ c.require, c.default },
-                .react_native => &.{ c.react_native, c.default },
+                // Metro: `unstable_conditionNames: ["react-native"]` + 리졸버가
+                // importer 시점에 `require` / `default` 를 자동 추가
+                // (`references/metro/packages/metro-resolver/src/utils/matchSubpathFromExportsLike.js`).
+                // ESM 패키지가 react-native 조건 없이 require/default 만 노출해도
+                // Metro 는 `require` 매칭으로 정상 해석함 → `require` 를 살려야 한다.
+                .react_native => &.{ c.react_native, c.require, c.default },
             },
             else => switch (platform) {
                 .node => &.{ c.node, c.import, c.module, c.default },
                 .browser => &.{ c.browser, c.import, c.module, c.default },
                 .neutral => &.{ c.import, c.module, c.default },
-                // Metro RN defaults assert only "react-native"; the resolver adds
-                // "default" for package exports. "import"/"require"/"browser" are
-                // not native RN defaults, and would bypass Metro's main-field fallback.
-                .react_native => &.{ c.react_native, c.default },
+                // Metro: `unstable_conditionNames: ["react-native"]` + 리졸버가
+                // ESM importer 에서 `import` / `default` 를 자동 추가.
+                // ESM-only 패키지가 react-native 조건 없이 `import`/`default` 만
+                // 노출하는 경우에도 Metro 는 `./dist/index.js` 같은 import 분기를
+                // 정상 해석한다. `module` 은 RN 표준 main field 가 아니므로 미포함.
+                .react_native => &.{ c.react_native, c.import, c.default },
             },
         };
     }

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -143,13 +143,16 @@ pub const ResolveCache = struct {
                 .node => &.{ c.require, c.node, c.default },
                 .browser => &.{ c.require, c.browser, c.default },
                 .neutral => &.{ c.require, c.default },
-                .react_native => &.{ c.require, c.react_native, c.browser, c.default },
+                .react_native => &.{ c.react_native, c.default },
             },
             else => switch (platform) {
                 .node => &.{ c.node, c.import, c.module, c.default },
                 .browser => &.{ c.browser, c.import, c.module, c.default },
                 .neutral => &.{ c.import, c.module, c.default },
-                .react_native => &.{ c.react_native, c.browser, c.import, c.module, c.default },
+                // Metro RN defaults assert only "react-native"; the resolver adds
+                // "default" for package exports. "import"/"require"/"browser" are
+                // not native RN defaults, and would bypass Metro's main-field fallback.
+                .react_native => &.{ c.react_native, c.default },
             },
         };
     }

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -81,7 +81,8 @@ pub const ResolveCache = struct {
     };
 
     fn cacheShardFor(self: *ResolveCache, cache_key: []const u8) *CacheShard {
-        return &self.cache_shards[std.hash_map.hashString(cache_key) % num_resolve_cache_shards];
+        const shard_index: usize = @intCast(std.hash_map.hashString(cache_key) % num_resolve_cache_shards);
+        return &self.cache_shards[shard_index];
     }
 
     /// browser 필드 override — 4 축 분리 (path-key / module-key) × (disabled / remap).

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -855,6 +855,7 @@ pub const Resolver = struct {
 pub fn isRelativeOrAbsolute(specifier: []const u8) bool {
     if (specifier.len == 0) return false;
     if (specifier[0] == '/') return true;
+    if (specifier.len == 1 and specifier[0] == '.') return true;
     // "./" — 현재 디렉토리 상대
     if (specifier.len >= 2 and specifier[0] == '.' and specifier[1] == '/') return true;
     // "../" — 상위 디렉토리 상대. ".." 뒤에 / 또는 끝이어야 함 ("..foo"는 bare specifier)

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -883,6 +883,12 @@ pub fn splitBareSpecifier(specifier: []const u8) BareSpecifierSplit {
         if (std.mem.indexOfScalar(u8, specifier, '/')) |first_slash| {
             // 두 번째 / 를 찾으면 그 뒤가 서브패스
             if (std.mem.indexOfScalarPos(u8, specifier, first_slash + 1, '/')) |second_slash| {
+                if (second_slash == specifier.len - 1) {
+                    return .{
+                        .pkg_name = specifier[0..second_slash],
+                        .subpath = ".",
+                    };
+                }
                 return .{
                     .pkg_name = specifier[0..second_slash],
                     .subpath = specifier[second_slash..],
@@ -894,6 +900,12 @@ pub fn splitBareSpecifier(specifier: []const u8) BareSpecifierSplit {
 
     // 일반 패키지: name/subpath
     if (std.mem.indexOfScalar(u8, specifier, '/')) |slash| {
+        if (slash == specifier.len - 1) {
+            return .{
+                .pkg_name = specifier[0..slash],
+                .subpath = ".",
+            };
+        }
         return .{
             .pkg_name = specifier[0..slash],
             .subpath = specifier[slash..],

--- a/src/bundler/resolver_test.zig
+++ b/src/bundler/resolver_test.zig
@@ -279,6 +279,23 @@ test "resolve: bare specifier with index fallback" {
     try std.testing.expect(pathEndsWith(result.path, "simple/index.js"));
 }
 
+test "resolve: trailing slash bare specifier uses package root" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "node_modules/buffer/package.json", "{\"main\":\"index.js\"}");
+    try createFile(tmp.dir, "node_modules/buffer/index.js");
+
+    const dir_path = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(dir_path);
+
+    var resolver = Resolver.init(std.testing.allocator);
+    const result = try resolver.resolve(dir_path, "buffer/");
+    defer std.testing.allocator.free(result.path);
+
+    try std.testing.expect(pathEndsWith(result.path, "buffer/index.js"));
+    try std.testing.expectEqual(ModuleType.js, result.module_type);
+}
+
 test "resolve: bare specifier walk up directories" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -318,6 +335,10 @@ test "splitBareSpecifier" {
     try std.testing.expectEqualStrings("react", s2.pkg_name);
     try std.testing.expectEqualStrings("/jsx-runtime", s2.subpath);
 
+    const s2_trailing = splitBareSpecifier("buffer/");
+    try std.testing.expectEqualStrings("buffer", s2_trailing.pkg_name);
+    try std.testing.expectEqualStrings(".", s2_trailing.subpath);
+
     const s3 = splitBareSpecifier("@mui/material");
     try std.testing.expectEqualStrings("@mui/material", s3.pkg_name);
     try std.testing.expectEqualStrings(".", s3.subpath);
@@ -325,6 +346,10 @@ test "splitBareSpecifier" {
     const s4 = splitBareSpecifier("@mui/material/Button");
     try std.testing.expectEqualStrings("@mui/material", s4.pkg_name);
     try std.testing.expectEqualStrings("/Button", s4.subpath);
+
+    const s4_trailing = splitBareSpecifier("@mui/material/");
+    try std.testing.expectEqualStrings("@mui/material", s4_trailing.pkg_name);
+    try std.testing.expectEqualStrings(".", s4_trailing.subpath);
 }
 
 test "resolve: json module type" {

--- a/src/bundler/resolver_test.zig
+++ b/src/bundler/resolver_test.zig
@@ -168,6 +168,22 @@ test "resolve: directory index (./dir → ./dir/index.ts)" {
     try std.testing.expect(pathEndsWith(result.path, "components/index.ts"));
 }
 
+test "resolve: current directory dot specifier resolves index" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try createFile(tmp.dir, "feature/index.js");
+    try createFile(tmp.dir, "feature/component.js");
+
+    const feature_path = try tmp.dir.realpathAlloc(std.testing.allocator, "feature");
+    defer std.testing.allocator.free(feature_path);
+
+    var resolver = Resolver.init(std.testing.allocator);
+    const result = try resolver.resolve(feature_path, ".");
+    defer std.testing.allocator.free(result.path);
+
+    try std.testing.expect(pathEndsWith(result.path, "feature/index.js"));
+}
+
 test "resolve: directory index (.tsx)" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/resolver_test.zig
+++ b/src/bundler/resolver_test.zig
@@ -296,6 +296,24 @@ test "resolve: trailing slash bare specifier uses package root" {
     try std.testing.expectEqual(ModuleType.js, result.module_type);
 }
 
+test "resolve: trailing slash bare specifier walks up to workspace root node_modules" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "node_modules/buffer/package.json", "{\"main\":\"index.js\"}");
+    try createFile(tmp.dir, "node_modules/buffer/index.js");
+    try createFile(tmp.dir, "packages/app/src/entry.ts");
+
+    const source_path = try tmp.dir.realpathAlloc(std.testing.allocator, "packages/app/src");
+    defer std.testing.allocator.free(source_path);
+
+    var resolver = Resolver.init(std.testing.allocator);
+    const result = try resolver.resolve(source_path, "buffer/");
+    defer std.testing.allocator.free(result.path);
+
+    try std.testing.expect(pathEndsWith(result.path, "buffer/index.js"));
+    try std.testing.expectEqual(ModuleType.js, result.module_type);
+}
+
 test "resolve: bare specifier walk up directories" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -808,7 +808,7 @@ pub const STATIC_PRIVATE_FIELD_RUNTIME_MIN =
 /// `wm.set(obj, value)` 는 WeakMap을 반환하므로 expression 값이 값 자체가 되도록 helper 사용.
 /// 통합 spec: `this.#x = v` expression value === v, `this.#x += 5` === new value.
 pub const PRIVATE_FIELD_SET_RUNTIME =
-    \\var __classPrivateFieldSet = function(wm, obj, value) {
+    \\var __zntcClassPrivateFieldSet = function(wm, obj, value) {
     \\  wm.set(obj, value);
     \\  return value;
     \\};

--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -1007,17 +1007,18 @@ pub const REFRESH_STUB =
 
 /// `entry_error_guard` 활성 시 prologue 에 주입. `__zntc_guarded(fn)` helper —
 /// 각 module init 호출 site (entry trigger / linker preamble / re-export / side-effect
-/// init) 가 통과. throw 를 silent swallow 해서 부팅 진행. Metro 의 `metro-runtime/src/
-/// polyfills/require.js:178` `guardedLoadModule` 와 등가 mechanism — Metro 도 module
-/// 평가는 eager 이지만 top-level `__r(N)` 호출이 try/catch wrap 되어 있어 throw 가
-/// LogBox 로 흘러가고 RN runtime 자체는 살아있음. ZNTC 는 자체 module 시스템
-/// (`__esm`/`__commonJS`) 사용해 metro require.js 를 안 써서 이 invariant 가 빠져있었음.
+/// init) 가 통과. Metro 의 `metro-runtime/src/polyfills/require.js` `guardedLoadModule`
+/// 과 같은 의미를 유지한다:
 ///
-/// Metro 의 `inGuard` flag (nested 호출 무력화) 는 채택하지 않음 — 그건 native
-/// `ErrorUtils.reportFatalError` → `RN$handleException` 와 짝인데, iOS native immutable
-/// global 이 trigger 한 상황 (관측: iPad iOS 26.4 + Expo SDK 55) 에서는 그 handler 가
-/// "runtime not ready" 로 부팅 정지시킴. ZNTC 는 silent swallow + 디버그 toggle:
-/// `globalThis.__ZNTC_DEBUG_GUARD = true`.
+/// - outermost 호출이고 `global.ErrorUtils` 가 있으면 try/catch 후
+///   `ErrorUtils.reportFatalError(e)` 로 전달한다.
+/// - 이미 guard 안이거나 `ErrorUtils` 가 없으면 unguarded 로 실행해 예외를 그대로
+///   다시 던진다.
+///
+/// RN 초기화 중 `InitializeCore` 이전 예외를 silent swallow 하면 `setUpXHR` /
+/// `setUpBatchedBridge` 가 건너뛰어 `AbortController`, `HMRClient`, `RCTDeviceEventEmitter`
+/// 가 등록되지 않고, 후속 `AppRegistry.registerComponent` 미호출처럼 보이는 2차 오류로
+/// 번진다. 따라서 Metro 와 동일하게 ErrorUtils 미설치 구간에서는 반드시 throw 를 보존한다.
 ///
 /// 별도 `console.error` setter intercept (`emitConsoleErrorIntercept`) 는 RN preset 자동
 /// 활성 안 함 — `silent_console_error_patterns` 옵션이 비어있으면 emit X. trigger 가
@@ -1025,20 +1026,30 @@ pub const REFRESH_STUB =
 /// immutable 충돌처럼 specific 환경에서만 발생하므로, consumer (bungae 등) 가 환경 감지
 /// 후 패턴 주입. vanilla RN CLI 빌드는 dead code 0.
 pub const GUARDED_RUNTIME =
+    \\var __zntc_in_guard = false;
+    \\var __zntc_guard_global = typeof global !== "undefined" ? global :
+    \\  typeof globalThis !== "undefined" ? globalThis :
+    \\  typeof self !== "undefined" ? self :
+    \\  typeof window !== "undefined" ? window : void 0;
     \\function __zntc_guarded(fn) {
-    \\  try { return fn(); }
-    \\  catch (e) {
-    \\    if (typeof globalThis !== "undefined" && globalThis.__ZNTC_DEBUG_GUARD &&
-    \\        typeof console !== "undefined" && console.warn) {
-    \\      console.warn("[zntc:guard] caught:", e);
+    \\  if (!__zntc_in_guard && __zntc_guard_global && __zntc_guard_global.ErrorUtils) {
+    \\    __zntc_in_guard = true;
+    \\    var returnValue;
+    \\    try {
+    \\      returnValue = fn();
+    \\    } catch (e) {
+    \\      __zntc_guard_global.ErrorUtils.reportFatalError(e);
     \\    }
+    \\    __zntc_in_guard = false;
+    \\    return returnValue;
     \\  }
+    \\  return fn();
     \\}
     \\
 ;
 
 pub const GUARDED_RUNTIME_MIN =
-    "function $zg(fn){try{return fn()}catch(e){if(typeof globalThis!==\"undefined\"&&globalThis.__ZNTC_DEBUG_GUARD&&typeof console!==\"undefined\"&&console.warn)console.warn(\"[zntc:guard] caught:\",e)}}\n";
+    "var $zi=false,$zgG=typeof global!==\"undefined\"?global:typeof globalThis!==\"undefined\"?globalThis:typeof self!==\"undefined\"?self:typeof window!==\"undefined\"?window:void 0;function $zg(fn){if(!$zi&&$zgG&&$zgG.ErrorUtils){$zi=true;var r;try{r=fn()}catch(e){$zgG.ErrorUtils.reportFatalError(e)}$zi=false;return r}return fn()}\n";
 
 /// `silent_console_error_patterns` 가 비어있지 않을 때 prologue 에 주입.
 /// `Object.defineProperty(console, "error", { set })` setter intercept — RN

--- a/src/codegen/bindings.zig
+++ b/src/codegen/bindings.zig
@@ -78,45 +78,34 @@ pub fn emitVariableDeclaration(self: anytype, node: Node) !void {
     const list_start = extras[1];
     const list_len = extras[2];
 
-    // __esm 호이스팅: top-level 단순 변수 선언만 키워드 제거 (할당문으로 변환).
+    // __esm 호이스팅: top-level 변수 선언은 래퍼 밖 `var`에 대응하는 할당문으로 변환.
     // indent_level == 0: factory body의 top-level에서만 적용.
     // 함수 안의 const/let/var는 그대로 유지해야 함.
-    // destructuring 패턴이 있으면 normal 경로 (키워드 필요).
     if (self.options.esm_var_assign_only and self.indent_level == 0 and !self.in_for_init) {
         const declarators = self.ast.extra_data.items[list_start .. list_start + list_len];
-        // destructuring 여부 확인: 하나라도 binding_identifier가 아니면 normal 경로
-        var has_destructuring = false;
+        var has_output = false;
         for (declarators) |raw_decl_idx| {
             const decl_node = self.ast.nodes.items[raw_decl_idx];
             const dextras2 = self.ast.extra_data.items[decl_node.data.extra .. decl_node.data.extra + 3];
             const n_idx: NodeIndex = @enumFromInt(dextras2[0]);
-            if (!n_idx.isNone() and self.ast.nodes.items[@intFromEnum(n_idx)].tag != .binding_identifier) {
-                has_destructuring = true;
-                break;
-            }
+            const init_idx: NodeIndex = @enumFromInt(dextras2[2]);
+            if (init_idx.isNone()) continue;
+
+            if (n_idx.isNone()) continue;
+            if (has_output) try writeNewline(self);
+            const name_node = self.ast.nodes.items[@intFromEnum(n_idx)];
+            const needs_paren = name_node.tag == .object_pattern;
+            if (needs_paren) try self.writeByte('(');
+            try self.emitNode(n_idx);
+            try writeSpace(self);
+            try self.writeByte('=');
+            try writeSpace(self);
+            try self.emitNode(init_idx);
+            if (needs_paren) try self.writeByte(')');
+            try self.writeByte(';');
+            has_output = true;
         }
-        if (!has_destructuring) {
-            var has_output = false;
-            for (declarators) |raw_decl_idx| {
-                const decl_node = self.ast.nodes.items[raw_decl_idx];
-                const de = decl_node.data.extra;
-                const dextras = self.ast.extra_data.items[de .. de + 3];
-                const name_idx: NodeIndex = @enumFromInt(dextras[0]);
-                const init_idx: NodeIndex = @enumFromInt(dextras[2]);
-                if (!init_idx.isNone()) {
-                    if (has_output) try writeNewline(self);
-                    try self.emitNode(name_idx);
-                    try writeSpace(self);
-                    try self.writeByte('=');
-                    try writeSpace(self);
-                    try self.emitNode(init_idx);
-                    try self.writeByte(';');
-                    has_output = true;
-                }
-            }
-            return;
-        }
-        // destructuring → fall through to normal path (var 키워드 유지)
+        return;
     }
 
     // #2198: cycle 모듈의 top-level let/const 는 var 로 강등 — 정의 전 참조 시

--- a/src/codegen/codegen_test/decorator.zig
+++ b/src/codegen/codegen_test/decorator.zig
@@ -556,6 +556,22 @@ test "stage3: accessor decorator → kind accessor + backing field" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "_x_initializers") != null);
 }
 
+test "stage3: private accessor decorator strips # from backing storage name" {
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec
+        \\  accessor #x = 1;
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"accessor\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "private: true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "#_x_accessor_storage") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "#_#x_accessor_storage") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "get #x()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "set #x(") != null);
+}
+
 // --- No decorator → passthrough ---
 
 test "stage3: no decorator → class preserved as-is" {

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -285,6 +285,16 @@ test "ES5: async function with multiple awaits" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "_state.sent()") != null);
 }
 
+test "ES5: async try/catch return lowers to generator return op" {
+    var r = try e2eTarget(std.testing.allocator, "async function foo(x) { try { if (x) return 1; } catch (e) { return 2; } }", .es5);
+    defer r.deinit();
+    try expectAsyncStateMachine(r.output);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "return [2,1]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "return [2,2]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "return 1;") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "return 2;") == null);
+}
+
 test "ES5: async arrow block body → state machine" {
     var r = try e2eTarget(std.testing.allocator, "var f = async () => { await x; };", .es5);
     defer r.deinit();

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -2072,7 +2072,7 @@ test "ES2015: class private field set" {
     // #1488: wm.set 은 WeakMap을 반환하므로 expression 값이 value가 되도록 helper 경유.
     var r = try e2eTarget(std.testing.allocator, "class F{#x=0;s(v){this.#x=v;}}", .es5);
     defer r.deinit();
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "__classPrivateFieldSet(_x,this,v)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__zntcClassPrivateFieldSet(_x,this,v)") != null);
 }
 
 // --- class static private field ---

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -1919,6 +1919,18 @@ test "ES2015: derived constructor super 중복 호출은 할당 전 검사" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__assertThisUninitialized(_this,_this=") == null);
 }
 
+test "ES2015: derived constructor arrow this capture waits for super" {
+    var r = try e2eTarget(
+        std.testing.allocator,
+        "class B{}class C extends B{constructor(emitter){super();emitter.addListener('evt',event=>{this.seen=event.value;});}}",
+        .es5,
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__assertThisUninitialized(_this),_this=__callSuper") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function(event){_this.seen=event.value;}") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var _this=this") == null);
+}
+
 test "ES2015: derived constructor arrow super uses lexical NewTarget" {
     // arrow 안의 super() 도 outer 의 _newTarget 변수를 closure 로 캡쳐 → lexical NewTarget 보존.
     var r = try e2eTarget(std.testing.allocator, "class B{constructor(arg){this.x=arg;}}class C extends B{constructor(){var callSuper=()=>super('foo');callSuper();}}", .es5);

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -2097,6 +2097,26 @@ test "ES2015: class private field set" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__zntcClassPrivateFieldSet(_x,this,v)") != null);
 }
 
+test "ES2015: private field helper avoids constructor reference collision" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\function make(max) {
+        \\  var _y = function(n) { return Array; };
+        \\  class Cache {
+        \\    #y;
+        \\    constructor() {
+        \\      this.#y = 1;
+        \\      this.arr = new (max ? _y(max) : Array)(max);
+        \\    }
+        \\  }
+        \\  return new Cache().arr.length;
+        \\}
+    , .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var _y2=new WeakMap") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "new (max?_y(max):Array)(max)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var _y=new WeakMap") == null);
+}
+
 // --- class static private field ---
 
 test "ES2022: static private field descriptor object" {

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -295,6 +295,47 @@ test "ES5: async try/catch return lowers to generator return op" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "return 2;") == null);
 }
 
+test "ES5: async control-flow return after await lowers to generator return op" {
+    const cases = [_]struct {
+        src: []const u8,
+        expected: []const []const u8,
+        forbidden: []const []const u8,
+    }{
+        .{
+            .src = "async function f(x) { await a(); switch (x) { case 1: return true; default: return false; } }",
+            .expected = &.{ "return [2,true]", "return [2,false]" },
+            .forbidden = &.{ "return true;", "return false;" },
+        },
+        .{
+            .src = "async function f(xs) { await a(); for (var i = 0; i < xs.length; i++) { if (xs[i]) return 1; } return 0; }",
+            .expected = &.{ "return [2,1]", "return [2,0]" },
+            .forbidden = &.{"return 1;"},
+        },
+        .{
+            .src = "async function f(x) { await a(); while (x) { return 1; } return 0; }",
+            .expected = &.{ "return [2,1]", "return [2,0]" },
+            .forbidden = &.{"return 1;"},
+        },
+        .{
+            .src = "async function f(xs) { await a(); for (var x of xs) { return x; } return null; }",
+            .expected = &.{ "return [2,x]", "return [2,null]" },
+            .forbidden = &.{"return x;"},
+        },
+    };
+
+    for (cases) |c| {
+        var r = try e2eTarget(std.testing.allocator, c.src, .es5);
+        defer r.deinit();
+        try expectAsyncStateMachine(r.output);
+        for (c.expected) |needle| {
+            try std.testing.expect(std.mem.indexOf(u8, r.output, needle) != null);
+        }
+        for (c.forbidden) |needle| {
+            try std.testing.expect(std.mem.indexOf(u8, r.output, needle) == null);
+        }
+    }
+}
+
 test "ES5: async arrow block body → state machine" {
     var r = try e2eTarget(std.testing.allocator, "var f = async () => { await x; };", .es5);
     defer r.deinit();

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -2364,6 +2364,13 @@ test "ES2015: class constructor with super and field" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__assertThisInitialized(_this).z=2") != null);
 }
 
+test "ES2015: parameter property with default uses bare binding for assignment" {
+    var r = try e2eTarget(std.testing.allocator, "class B{}class D extends B{constructor(public config: Config = {}){super();}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "_this.config=config") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "config:Config") == null);
+}
+
 // --- generator edge cases ---
 
 test "ES2015: generator with while yield" {

--- a/src/codegen/codegen_test/private_jsx_advanced.zig
+++ b/src/codegen/codegen_test/private_jsx_advanced.zig
@@ -1022,7 +1022,7 @@ test "#1275: private method + field 혼합 (RN PerformanceObserver 케이스)" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "_nativeHandle.set(this,null)") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__classPrivateMethodInit(this,_createObserver)") != null);
     // this.#callback = callback 은 assignment_expression → expression value 반환 helper 경유 (#1488).
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "__classPrivateFieldSet(_callback,this,callback)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__zntcClassPrivateFieldSet(_callback,this,callback)") != null);
 }
 
 test "#1275: private method만 있고 원본 constructor 없을 때 새 constructor 1개 생성" {

--- a/src/codegen/mangler_test.zig
+++ b/src/codegen/mangler_test.zig
@@ -83,7 +83,11 @@ test "nextBase54Name: skips all runtime helper short names" {
 test "helperName: base_name → short mapping for every PAIR" {
     const rt = @import("../runtime_helper_names.zig");
     inline for (rt.PAIRS) |p| {
-        try std.testing.expectEqualStrings(p.base, rt.helperName(p.base, false));
+        const plain = if (std.mem.eql(u8, p.base, "__classPrivateFieldSet"))
+            rt.NAMES.PRIVATE_FIELD_SET_LOCAL
+        else
+            p.base;
+        try std.testing.expectEqualStrings(plain, rt.helperName(p.base, false));
         try std.testing.expectEqualStrings(p.short, rt.helperName(p.base, true));
     }
     // 알 수 없는 이름 → 원본 반환 (fallback 안전성)

--- a/src/parser/declaration.zig
+++ b/src/parser/declaration.zig
@@ -621,7 +621,9 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
         // get/set 뒤 다음 토큰이 accessor 대상이 될 수 있는지 판별.
         // class body에서 get\nx()는 accessor (줄바꿈 있어도). 단, get\n*x()는 ASI.
         // TypeScript PR#60225: newline은 * 앞에서만 ASI 유발
+        // `get<T>()` / `set<T>()`는 TS generic method 이름이지 accessor가 아니다.
         const is_accessor_target = next_tok.kind != .l_paren and
+            next_tok.kind != .l_angle and
             next_tok.kind != .semicolon and next_tok.kind != .eq and
             next_tok.kind != .r_curly and next_tok.kind != .eof;
         const newline_blocks = next_tok.has_newline_before and

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -1156,6 +1156,28 @@ fn parseNewCallee(self: *Parser) ParseError2!NodeIndex {
     return expr;
 }
 
+fn isFlowMatchExpressionStart(self: *Parser) ParseError2!bool {
+    const saved = self.saveState();
+    defer self.restoreState(saved);
+
+    try self.scanner.next(); // skip 'match'
+    if (self.current() != .l_paren) return false;
+
+    var paren_depth: u32 = 1;
+    while (paren_depth > 0) {
+        try self.scanner.next();
+        switch (self.current()) {
+            .eof => return false,
+            .l_paren => paren_depth += 1,
+            .r_paren => paren_depth -= 1,
+            else => {},
+        }
+    }
+
+    try self.scanner.next();
+    return self.current() == .l_curly;
+}
+
 fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
     const span = self.currentSpan();
 
@@ -1168,8 +1190,7 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
     {
         // Flow match expression: match (expr) { Pattern => expr, ... }
         if (self.is_flow and self.isContextual("match")) {
-            const next_kind = try self.peekNextKind();
-            if (next_kind == .l_paren) {
+            if (try isFlowMatchExpressionStart(self)) {
                 return try flow.parseMatchExpression(self);
             }
         }

--- a/src/parser/expression/generic_arrow.zig
+++ b/src/parser/expression/generic_arrow.zig
@@ -94,10 +94,12 @@ pub fn tryParseGenericArrow(self: *Parser, is_async: bool) ParseError2!?NodeInde
 
     // 선택적 리턴 타입: <T>(): R => body
     // Flow: return type에서 `=>` 를 function type arrow로 해석하지 않도록 플래그 설정
-    const saved_flow_flag = self.flow_in_return_type;
-    self.flow_in_return_type = true;
-    defer self.flow_in_return_type = saved_flow_flag;
-    _ = try self.tryParseReturnType();
+    {
+        const saved_flow_flag = self.flow_in_return_type;
+        self.flow_in_return_type = true;
+        defer self.flow_in_return_type = saved_flow_flag;
+        _ = try self.tryParseReturnType();
+    }
 
     // => 가 와야 arrow function
     if (self.current() != .arrow or self.scanner.token.has_newline_before) {

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1818,10 +1818,12 @@ pub const Parser = struct {
 
         // return type annotation: ): Type =>
         // Flow: shorthand 함수 타입 금지 — (): any => {} 에서 =>는 arrow body
-        const saved_flow_flag = self.flow_in_return_type;
-        self.flow_in_return_type = true;
-        defer self.flow_in_return_type = saved_flow_flag;
-        _ = try self.tryParseReturnType();
+        {
+            const saved_flow_flag = self.flow_in_return_type;
+            self.flow_in_return_type = true;
+            defer self.flow_in_return_type = saved_flow_flag;
+            _ = try self.tryParseReturnType();
+        }
 
         // => 확인
         if (self.current() != .arrow or self.scanner.token.has_newline_before) {

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -3224,6 +3224,19 @@ test "Flow: typed arrow with return type" {
     , .{ .jsx = true });
 }
 
+test "Flow: typed arrow restores return type context before body" {
+    try expectNoParseErrorFlow(
+        \\const f = (x: number) => {
+        \\  const cb = (resolve: A => B) => resolve;
+        \\};
+    );
+    try expectNoParseErrorFlow(
+        \\const g = <T>(x: T) => {
+        \\  const cb = (resolve: A => B) => resolve;
+        \\};
+    );
+}
+
 test "Flow: shorthand function type as method return" {
     try expectNoParseErrorFlow(
         \\class C {

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -1005,6 +1005,12 @@ test "Parser: TS type predicate in function type literal" {
     }
 }
 
+test "Parser: TS function type property signature in .ts mode" {
+    try expectNoParseErrorWithExt(
+        \\type X = { create: (target: string) => string; };
+    , ".ts");
+}
+
 test "Parser: TS object type literal" {
     var scanner = try Scanner.init(std.testing.allocator, "const obj: { x: number; y: string } = { x: 1, y: 'a' };");
     defer scanner.deinit();

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -1218,6 +1218,25 @@ test "Parser: TS parameter property" {
     try std.testing.expect(parser.errors.items.len == 0);
 }
 
+test "Parser: TS generic class method named get/set" {
+    var scanner = try Scanner.init(std.testing.allocator,
+        \\class QueryCache {
+        \\  get<T>(queryHash: string): Query<T> | undefined {
+        \\    return this.queries.get(queryHash) as Query<T> | undefined
+        \\  }
+        \\  set<T>(queryHash: string, value: Query<T>): void {
+        \\    this.queries.set(queryHash, value)
+        \\  }
+        \\}
+    );
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+
+    _ = try parser.parse();
+    try std.testing.expect(parser.errors.items.len == 0);
+}
+
 test "Parser: decorator on class" {
     var scanner = try Scanner.init(std.testing.allocator, "@Component class Foo { }");
     defer scanner.deinit();

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -3151,6 +3151,18 @@ test "Flow: match expression" {
     );
 }
 
+test "Flow: match call expression is not match syntax" {
+    try expectNoParseErrorFlow("const out = (match(value, callback = /x/));");
+    try expectNoParseErrorFlow(
+        \\function f(value, callback) {
+        \\  switch (match(value, callback = /(::plac\w+|:read-\w+)/)) {
+        \\    case ':read-only':
+        \\      break;
+        \\  }
+        \\}
+    );
+}
+
 test "Flow: import typeof specifier" {
     try expectNoParseErrorFlow("import {typeof VirtualizedList as VirtualizedListT} from './VirtualizedList';");
 }

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -1283,13 +1283,21 @@ fn tryParseFunctionTypeWithBacktracking(self: *Parser, start: u32) ParseError2!?
 /// identifier/this 다음에 : 또는 ? 가 오면 함수 타입 파라미터
 fn isFunctionTypeParam(self: *Parser) bool {
     // identifier/this 다음에 : 또는 ? → 확정 함수 파라미터
-    if (self.current() == .identifier or self.current() == .kw_this) {
+    if (isFunctionTypeParamName(self.current())) {
         const next = self.peekNextKind() catch return false;
         return next == .colon or next == .question;
     }
     // destructuring 패턴: [...] 또는 {...} → 함수 파라미터
     if (self.current() == .l_bracket or self.current() == .l_curly) return true;
     return false;
+}
+
+fn isFunctionTypeParamName(kind: @import("../lexer/token.zig").Kind) bool {
+    return kind == .identifier or
+        kind == .escaped_keyword or
+        kind == .escaped_strict_reserved or
+        kind == .kw_this or
+        (kind.isKeyword() and !kind.isReservedKeyword());
 }
 
 /// 함수 타입 파라미터 리스트를 파싱하여 함수 타입 노드 생성

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -34,25 +34,43 @@ const builtin = @import("builtin");
 /// counters(`totals_ns` 등)를 atomic 으로 갱신할지 여부 (comptime).
 ///
 /// native multi-thread 빌드는 worker pool 에서 phase 가 동시에 끝나므로 atomic add 가
-/// 필요하다(lost update 방지). 두 경우만 예외로 plain `+=`:
+/// 필요하다(lost update 방지). 단, 타깃이 해당 counter 폭의 atomic 을 지원하지 않으면 mutex
+/// fallback 을 쓴다:
 /// - `single_threaded` 빌드(transpile-only `zig build wasm`) — race 자체가 없음.
 /// - WASM — Zig 0.15.2 는 64-bit atomic RMW(`@atomicRmw(u64, …)`)를 지원하지 않는다
 ///   (atomics feature 가 있는 `wasm-bundler` 타깃도 "expected 32-bit integer type or
-///   smaller" 로 컴파일 실패). wasm-bundler 가 multi-thread 라도 profile 카운터의 가끔
-///   발생하는 lost update 는 허용한다 — 번들 정확성과 무관한 진단용 수치이고, thread-aware
-///   한 핵심 수정(nesting 스택 threadlocal 화)은 이 flag 와 무관하게 항상 적용된다.
-const atomic_counters = !builtin.single_threaded and !builtin.cpu.arch.isWasm();
+///   smaller" 로 컴파일 실패). wasm-bundler 가 multi-thread 면 프로파일 카운터만 mutex 로
+///   느려질 수 있고, 번들 결과와는 무관하다.
+/// - 32-bit native targets — `u64` timing counters 는 atomic 불가지만 `u32` counts 는
+///   계속 atomic 가능하다.
+inline fn useAtomicCounter(comptime T: type) bool {
+    return !builtin.single_threaded and
+        !builtin.cpu.arch.isWasm() and
+        @bitSizeOf(T) <= @bitSizeOf(usize);
+}
+
+var counter_mutex: std.Thread.Mutex = .{};
 
 inline fn atomicAdd(comptime T: type, slot: *T, delta: T) void {
-    if (atomic_counters) {
+    if (useAtomicCounter(T)) {
         _ = @atomicRmw(T, slot, .Add, delta, .monotonic);
+    } else if (!builtin.single_threaded) {
+        counter_mutex.lock();
+        defer counter_mutex.unlock();
+        slot.* += delta;
     } else {
         slot.* += delta;
     }
 }
 
 inline fn atomicGet(comptime T: type, slot: *const T) T {
-    return if (atomic_counters) @atomicLoad(T, slot, .monotonic) else slot.*;
+    if (useAtomicCounter(T)) return @atomicLoad(T, slot, .monotonic);
+    if (!builtin.single_threaded) {
+        counter_mutex.lock();
+        defer counter_mutex.unlock();
+        return slot.*;
+    }
+    return slot.*;
 }
 
 // ============================================================================

--- a/src/runtime_helper_names.zig
+++ b/src/runtime_helper_names.zig
@@ -54,6 +54,7 @@ pub const NAMES = struct {
     pub const PRIVATE_METHOD_INIT_MIN = "$pI"; // __classPrivateMethodInit
     pub const PRIVATE_METHOD_GET_MIN = "$pG"; // __classPrivateMethodGet
     pub const PRIVATE_FIELD_SET_MIN = "$pF"; // __classPrivateFieldSet
+    pub const PRIVATE_FIELD_SET_LOCAL = "__zntcClassPrivateFieldSet";
     pub const STATIC_PRIVATE_ACCESS_MIN = "$sA"; // __classCheckPrivateStaticAccess
     pub const STATIC_PRIVATE_DESC_MIN = "$sD"; // __classCheckPrivateStaticFieldDescriptor
     pub const STATIC_PRIVATE_GET_MIN = "$sG"; // __classStaticPrivateFieldSpecGet
@@ -146,11 +147,16 @@ pub const ALL_SHORT_NAMES: [PAIRS.len][]const u8 = blk: {
     break :blk names;
 };
 
-/// transformer 가 AST identifier 로 emit 하는 runtime helper 이름을 minify 플래그에
+/// transformer 가 AST identifier 로 emit 하는 runtime helper local 이름을 minify 플래그에
 /// 따라 축약/원본으로 선택한다. non-helper identifier (Math, writable 등) 에는
 /// 호출하지 않는다 — `PAIRS` 에 등록된 이름만 처리. 매핑에 없으면 원본 반환
 /// (mangler_test 가 drift 를 빌드 타임에 잡음).
 pub fn helperName(base_name: []const u8, minify: bool) []const u8 {
-    if (!minify) return base_name;
+    if (!minify) {
+        // tslib UMD가 RN global에 같은 helper 이름을 export한다. ZNTC private-field
+        // helper는 시그니처가 달라 실제 local/call 이름만 내부 전용 이름으로 둔다.
+        if (std.mem.eql(u8, base_name, "__classPrivateFieldSet")) return NAMES.PRIVATE_FIELD_SET_LOCAL;
+        return base_name;
+    }
     return helper_map.get(base_name) orelse base_name;
 }

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -1021,8 +1021,12 @@ pub const SemanticAnalyzer = struct {
                 }
                 return;
             },
-            .binding_property, .assignment_target_property_identifier, .assignment_target_property_property => {
+            .binding_property, .assignment_target_property_property => {
                 try self.recheckPredeclaredVar(bnode.data.binary.right);
+                return;
+            },
+            .assignment_target_property_identifier => {
+                try self.recheckPredeclaredVar(bnode.data.binary.left);
                 return;
             },
             .assignment_pattern, .assignment_target_with_default => {
@@ -1067,8 +1071,11 @@ pub const SemanticAnalyzer = struct {
                     self.setSymbolIdForPredeclaredBinding(op);
                 }
             },
-            .binding_property, .assignment_target_property_identifier, .assignment_target_property_property => {
+            .binding_property, .assignment_target_property_property => {
                 self.setSymbolIdForPredeclaredBinding(node.data.binary.right);
+            },
+            .assignment_target_property_identifier => {
+                self.setSymbolIdForPredeclaredBinding(node.data.binary.left);
             },
             .assignment_pattern, .assignment_target_with_default => {
                 self.setSymbolIdForPredeclaredBinding(node.data.binary.left);
@@ -2019,8 +2026,11 @@ pub const SemanticAnalyzer = struct {
                     try self.predeclareBindingNames(op, kind);
                 }
             },
-            .binding_property, .assignment_target_property_identifier, .assignment_target_property_property => {
+            .binding_property, .assignment_target_property_property => {
                 try self.predeclareBindingNames(node.data.binary.right, kind);
+            },
+            .assignment_target_property_identifier => {
+                try self.predeclareBindingNames(node.data.binary.left, kind);
             },
             .assignment_pattern, .assignment_target_with_default => {
                 // default value(right)는 순회하지 않고, 바인딩 이름(left)만 추출
@@ -2049,8 +2059,13 @@ pub const SemanticAnalyzer = struct {
                     try self.visitBindingPatternExpressions(op);
                 }
             },
-            .binding_property, .assignment_target_property_identifier, .assignment_target_property_property => {
+            .binding_property, .assignment_target_property_property => {
                 try self.visitBindingPatternExpressions(node.data.binary.right);
+            },
+            .assignment_target_property_identifier => {
+                if (!node.data.binary.right.isNone()) {
+                    try self.visitNode(node.data.binary.right);
+                }
             },
             .assignment_pattern, .assignment_target_with_default => {
                 // default value(right)를 순회
@@ -2216,7 +2231,9 @@ pub const SemanticAnalyzer = struct {
                 }
                 return false;
             },
-            .assignment_target_with_default => return self.isLexicalPredeclared(node.data.binary.left),
+            .binding_property, .assignment_target_property_property => return self.isLexicalPredeclared(node.data.binary.right),
+            .assignment_target_property_identifier => return self.isLexicalPredeclared(node.data.binary.left),
+            .assignment_pattern, .assignment_target_with_default => return self.isLexicalPredeclared(node.data.binary.left),
             .rest_element, .spread_element => return self.isLexicalPredeclared(node.data.unary.operand),
             else => return false,
         }
@@ -2246,7 +2263,9 @@ pub const SemanticAnalyzer = struct {
                     }
                 }
             },
-            .assignment_target_with_default => try self.predeclareLexicalBinding(n.data.binary.left, sym_kind, decl_span),
+            .binding_property, .assignment_target_property_property => try self.predeclareLexicalBinding(n.data.binary.right, sym_kind, decl_span),
+            .assignment_target_property_identifier => try self.predeclareLexicalBinding(n.data.binary.left, sym_kind, decl_span),
+            .assignment_pattern, .assignment_target_with_default => try self.predeclareLexicalBinding(n.data.binary.left, sym_kind, decl_span),
             else => {},
         }
     }
@@ -2452,6 +2471,16 @@ pub const SemanticAnalyzer = struct {
                     try self.declareArrowParams(@enumFromInt(raw_idx));
                 }
             },
+            .formal_parameter => {
+                const e = node.data.extra;
+                if (!self.ast.hasExtra(e, 2)) return;
+                const pattern: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+                const default_value: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 2]);
+                try self.declareArrowParams(pattern);
+                if (!default_value.isNone()) {
+                    try self.visitNode(default_value);
+                }
+            },
             .parenthesized_expression => {
                 try self.declareArrowParams(node.data.unary.operand);
             },
@@ -2510,8 +2539,11 @@ pub const SemanticAnalyzer = struct {
             .assignment_target_property_identifier => {
                 // shorthand property: { x } 또는 { x = default }
                 // left = key(바인딩), right = default value 또는 none
-                // 항상 left(key)에서 바인딩을 추출한다. right는 default value.
+                // 항상 left(key)에서 바인딩을 추출하고, default value 는 값 표현식으로 방문한다.
                 try self.declareBindingPattern(node.data.binary.left);
+                if (!node.data.binary.right.isNone()) {
+                    try self.visitNode(node.data.binary.right);
+                }
             },
             .assignment_target_property_property => {
                 // long-form property: { key: value }
@@ -2519,8 +2551,11 @@ pub const SemanticAnalyzer = struct {
                 try self.declareBindingPattern(node.data.binary.right);
             },
             .assignment_pattern, .assignment_expression, .assignment_target_with_default => {
-                // 기본값: left가 바인딩
+                // 기본값: left가 바인딩, right는 값 표현식이다.
                 try self.declareBindingPattern(node.data.binary.left);
+                if (!node.data.binary.right.isNone()) {
+                    try self.visitNode(node.data.binary.right);
+                }
             },
             .spread_element, .rest_element, .assignment_target_rest => {
                 try self.declareBindingPattern(node.data.unary.operand);
@@ -3476,6 +3511,16 @@ pub const SemanticAnalyzer = struct {
         if (idx.isNone()) return;
         const node = self.ast.getNode(idx);
         switch (node.tag) {
+            .formal_parameter => {
+                const e = node.data.extra;
+                if (!self.ast.hasExtra(e, 2)) return;
+                const pattern: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
+                const default_value: NodeIndex = @enumFromInt(self.ast.extra_data.items[e + 2]);
+                try self.registerBinding(pattern, kind);
+                if (!default_value.isNone()) {
+                    try self.visitNode(default_value);
+                }
+            },
             .binding_identifier, .assignment_target_identifier => {
                 try self.declareSymbolWithNode(node.span, kind, node.span, @intFromEnum(idx));
             },
@@ -3489,11 +3534,17 @@ pub const SemanticAnalyzer = struct {
                 }
             },
             .binding_property,
-            .assignment_target_property_identifier,
             .assignment_target_property_property,
             => {
                 // binary: { left = key, right = value }
                 try self.registerBinding(node.data.binary.right, kind);
+            },
+            .assignment_target_property_identifier => {
+                // `{ x }` / `{ x = imported.value }`: left가 바인딩, right는 default 표현식.
+                try self.registerBinding(node.data.binary.left, kind);
+                if (!node.data.binary.right.isNone()) {
+                    try self.visitNode(node.data.binary.right);
+                }
             },
             .assignment_pattern, .assignment_target_with_default => {
                 // binary: { left = binding, right = default_value }

--- a/src/transformer/es2015_class/constructors.zig
+++ b/src/transformer/es2015_class/constructors.zig
@@ -69,7 +69,7 @@ pub fn Constructors(comptime Transformer: type) type {
             }
             defer self.new_target_ctx = saved_new_target_ctx;
 
-            var new_body = try visitMethodBody(self, body_idx, span);
+            var new_body = try visitMethodBodyWithCtxImpl(self, body_idx, span, null, is_derived);
 
             const lowered_params = if (param_lowering) |lr| lr.new_params else pp.new_params;
             const param_stmts = if (param_lowering) |lr| lr.body_stmts.items else &[_]NodeIndex{};
@@ -170,6 +170,20 @@ pub fn Constructors(comptime Transformer: type) type {
 
         /// visitMethodBody + new.target 컨텍스트 지정
         pub fn visitMethodBodyWithCtx(self: *Transformer, body_idx: NodeIndex, span: Span, nt_ctx: ?Transformer.NewTargetCtx) Transformer.Error!NodeIndex {
+            return visitMethodBodyWithCtxImpl(self, body_idx, span, nt_ctx, false);
+        }
+
+        /// visitMethodBodyWithCtx의 내부 구현.
+        /// derived constructor는 postProcessDerivedConstructorBody가 `var _this;` 선언과
+        /// super() 결과 대입을 맡는다. 여기서 arrow 캡처용 `var _this = this;`를 넣으면
+        /// super() 전 this 접근이 되어 Babel helper가 "Super constructor may only be called once"를 던진다.
+        fn visitMethodBodyWithCtxImpl(
+            self: *Transformer,
+            body_idx: NodeIndex,
+            span: Span,
+            nt_ctx: ?Transformer.NewTargetCtx,
+            derived_constructor_this_alias: bool,
+        ) Transformer.Error!NodeIndex {
             // arrow this state save/restore (일반 함수는 자체 this 바인딩)
             const saved_arrow_depth = self.arrow_this_depth;
             const saved_needs_this = self.needs_this_var;
@@ -192,7 +206,7 @@ pub fn Constructors(comptime Transformer: type) type {
                 var capture_stmts: [2]NodeIndex = undefined;
                 var capture_count: usize = 0;
 
-                if (self.needs_this_var) {
+                if (self.needs_this_var and !derived_constructor_this_alias) {
                     const this_init = try self.ast.addNode(.{
                         .tag = .this_expression,
                         .span = span,

--- a/src/transformer/es2015_class/members.zig
+++ b/src/transformer/es2015_class/members.zig
@@ -237,6 +237,8 @@ pub fn Members(comptime Transformer: type) type {
                 .static_private_fields = .empty,
                 .private_methods = .empty,
             };
+            var private_names = try es_helpers.PrivateNameAllocator.init(self.allocator, self.ast);
+            defer private_names.deinit();
 
             // 분류 phase — visitNode 호출 없이 metadata 만 모은다. instance field init / accessor backing 의
             // 실제 statement build 는 caller 가 setupPrivateFieldMappings 로 매핑을 set 한 뒤
@@ -274,7 +276,7 @@ pub fn Members(comptime Transformer: type) type {
                         if (key_node.tag == .private_identifier) {
                             const orig_name = self.ast.getText(key_node.span); // "#bar"
 
-                            const names = try es_helpers.makePrivateMethodNames(self.allocator, orig_name, pm_kind);
+                            const names = try private_names.makePrivateMethodNames(orig_name, pm_kind);
 
                             try cm.private_methods.append(self.allocator, .{
                                 .member_idx = @enumFromInt(raw_idx),
@@ -322,7 +324,7 @@ pub fn Members(comptime Transformer: type) type {
                         const orig_name_owned = try self.allocator.dupe(u8, self.ast.getText(key_node.span));
                         try cm.synthesized_private_names.append(self.allocator, orig_name_owned);
                         const field_info = PrivateFieldInfo{
-                            .name = try es_helpers.makePrivateVarName(self.allocator, orig_name_owned),
+                            .name = try private_names.makePrivateVarName(orig_name_owned),
                             .original_name = orig_name_owned,
                             .init = init_val,
                         };
@@ -365,7 +367,7 @@ pub fn Members(comptime Transformer: type) type {
                         }
                     }
                 } else if (member.tag == .accessor_property) {
-                    try classifyAccessorProperty(self, &cm, member, span);
+                    try classifyAccessorProperty(self, &cm, &private_names, member, span);
                 } else {
                     std.debug.panic("classifyMembers: unexpected member tag {s}", .{@tagName(member.tag)});
                 }
@@ -379,6 +381,7 @@ pub fn Members(comptime Transformer: type) type {
         fn classifyAccessorProperty(
             self: *Transformer,
             cm: *ClassifiedMembers,
+            private_names: *es_helpers.PrivateNameAllocator,
             member: Node,
             span: Span,
         ) Transformer.Error!void {
@@ -390,10 +393,10 @@ pub fn Members(comptime Transformer: type) type {
 
             const key_node = self.ast.getNode(key_idx);
             if (key_node.tag == .private_identifier) {
-                return classifyPrivateAccessorProperty(self, cm, key_node, init_idx, is_static, member.span, span);
+                return classifyPrivateAccessorProperty(self, cm, private_names, key_node, init_idx, is_static, member.span, span);
             }
             if (key_node.tag == .computed_property_key) {
-                return classifyComputedAccessorProperty(self, cm, key_idx, init_idx, is_static, member.span, span);
+                return classifyComputedAccessorProperty(self, cm, private_names, key_idx, init_idx, is_static, member.span, span);
             }
 
             const raw_key = self.ast.getText(key_node.span);
@@ -404,7 +407,7 @@ pub fn Members(comptime Transformer: type) type {
             const storage_span = try self.ast.addString(storage_name_owned);
 
             const pfi = PrivateFieldInfo{
-                .name = try es_helpers.makePrivateVarName(self.allocator, storage_name_owned),
+                .name = try private_names.makePrivateVarName(storage_name_owned),
                 .original_name = storage_name_owned,
                 .init = init_idx,
             };
@@ -441,6 +444,7 @@ pub fn Members(comptime Transformer: type) type {
         fn classifyPrivateAccessorProperty(
             self: *Transformer,
             cm: *ClassifiedMembers,
+            private_names: *es_helpers.PrivateNameAllocator,
             key_node: Node,
             init_idx: NodeIndex,
             is_static: bool,
@@ -453,7 +457,7 @@ pub fn Members(comptime Transformer: type) type {
                 // static private accessor 는 class-singleton — 별도 backing / synthesis 없이 그대로
                 // static private field 로 등록하면 `this.#x` / `this.#x = v` 가 __classStaticPrivateFieldSpec(Get|Set) 로 lowering.
                 const pfi = PrivateFieldInfo{
-                    .name = try es_helpers.makePrivateVarName(self.allocator, orig_name),
+                    .name = try private_names.makePrivateVarName(orig_name),
                     .original_name = orig_name,
                     .init = init_idx,
                 };
@@ -467,7 +471,7 @@ pub fn Members(comptime Transformer: type) type {
             const storage_span = try self.ast.addString(storage_name_owned);
 
             const pfi = PrivateFieldInfo{
-                .name = try es_helpers.makePrivateVarName(self.allocator, storage_name_owned),
+                .name = try private_names.makePrivateVarName(storage_name_owned),
                 .original_name = storage_name_owned,
                 .init = init_idx,
             };
@@ -492,7 +496,7 @@ pub fn Members(comptime Transformer: type) type {
             const setter_target = try makePrivateFieldAccess(self, storage_span, span);
             const setter_idx = try self.buildSetterMethod(priv_key_set, setter_target, false, span);
 
-            const get_names = try es_helpers.makePrivateMethodNames(self.allocator, orig_name, .getter);
+            const get_names = try private_names.makePrivateMethodNames(orig_name, .getter);
             try cm.private_methods.append(self.allocator, .{
                 .member_idx = getter_idx,
                 .original_name = orig_name,
@@ -502,7 +506,7 @@ pub fn Members(comptime Transformer: type) type {
                 .kind = .getter,
             });
 
-            const set_names = try es_helpers.makePrivateMethodNames(self.allocator, orig_name, .setter);
+            const set_names = try private_names.makePrivateMethodNames(orig_name, .setter);
             try cm.private_methods.append(self.allocator, .{
                 .member_idx = setter_idx,
                 .original_name = orig_name,
@@ -519,6 +523,7 @@ pub fn Members(comptime Transformer: type) type {
         fn classifyComputedAccessorProperty(
             self: *Transformer,
             cm: *ClassifiedMembers,
+            private_names: *es_helpers.PrivateNameAllocator,
             key_idx: NodeIndex,
             init_idx: NodeIndex,
             is_static: bool,
@@ -532,7 +537,7 @@ pub fn Members(comptime Transformer: type) type {
             const storage_span = try self.ast.addString(storage_name_owned);
 
             const pfi = PrivateFieldInfo{
-                .name = try es_helpers.makePrivateVarName(self.allocator, storage_name_owned),
+                .name = try private_names.makePrivateVarName(storage_name_owned),
                 .original_name = storage_name_owned,
                 .init = init_idx,
             };
@@ -548,7 +553,9 @@ pub fn Members(comptime Transformer: type) type {
             // 이 변수를 computed_property_key 로 참조. emitAccessors 는 computed 분기로 Object.defineProperty(proto, _acc_key_N, ...).
             const key_node = self.ast.getNode(key_idx);
             const inner_expr = key_node.data.unary.operand;
-            const mem_var_name = try std.fmt.allocPrint(self.allocator, "_acc_key_{d}", .{seq});
+            const mem_var_base = try std.fmt.allocPrint(self.allocator, "_acc_key_{d}", .{seq});
+            defer self.allocator.free(mem_var_base);
+            const mem_var_name = try private_names.makeUniqueName(mem_var_base);
             try cm.synthesized_private_names.append(self.allocator, mem_var_name); // allocator 소유 보관용 재사용
             const mem_var_span = try self.ast.addString(mem_var_name);
             const visited_inner = try self.visitNode(inner_expr);

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -360,7 +360,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                     try collectSwitchOperations(self, stmt_idx, stmt, ops, next_label);
                 },
                 .for_of_statement, .for_in_statement => {
-                    if (es2015_scan.containsYield(self, stmt_idx)) {
+                    if (es2015_scan.containsYield(self, stmt_idx) or es2015_scan.containsReturn(self, stmt_idx)) {
                         try collectForOfOperations(self, stmt, ops, next_label);
                     } else {
                         const new_stmt = try self.visitNode(stmt_idx);
@@ -468,7 +468,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             const update_idx: NodeIndex = self.readNodeIdx(e, 2);
             const body_idx: NodeIndex = self.readNodeIdx(e, 3);
 
-            if (!es2015_scan.containsYield(self, body_idx) and !es2015_scan.containsYield(self, test_idx)) {
+            if (!es2015_scan.containsYield(self, body_idx) and !es2015_scan.containsYield(self, test_idx) and !es2015_scan.containsReturn(self, body_idx)) {
                 const new_stmt = try self.visitNode(stmt_idx);
                 if (!new_stmt.isNone()) {
                     try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = new_stmt } });
@@ -723,7 +723,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             const condition = stmt.data.binary.left;
             const body_idx = stmt.data.binary.right;
 
-            if (!es2015_scan.containsYield(self, body_idx) and !es2015_scan.containsYield(self, condition)) {
+            if (!es2015_scan.containsYield(self, body_idx) and !es2015_scan.containsYield(self, condition) and !es2015_scan.containsReturn(self, body_idx)) {
                 const new_stmt = try self.visitNode(stmt_idx);
                 if (!new_stmt.isNone()) {
                     try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = new_stmt } });
@@ -914,7 +914,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             const cases_start_val = self.readU32(e, 1);
             const cases_len_val = self.readU32(e, 2);
 
-            if (!es2015_scan.containsYield(self, stmt_idx)) {
+            if (!es2015_scan.containsYield(self, stmt_idx) and !es2015_scan.containsReturn(self, stmt_idx)) {
                 const new_stmt = try self.visitNode(stmt_idx);
                 if (!new_stmt.isNone()) {
                     try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = new_stmt } });
@@ -1029,7 +1029,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             const condition = stmt.data.binary.left;
             const body_idx = stmt.data.binary.right;
 
-            if (!es2015_scan.containsYield(self, body_idx) and !es2015_scan.containsYield(self, condition)) {
+            if (!es2015_scan.containsYield(self, body_idx) and !es2015_scan.containsYield(self, condition) and !es2015_scan.containsReturn(self, body_idx)) {
                 const new_stmt = try self.visitNode(stmt_idx);
                 if (!new_stmt.isNone()) {
                     try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = new_stmt } });

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -1098,8 +1098,17 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             const catch_clause = stmt.data.ternary.b;
             const finally_body = stmt.data.ternary.c;
 
-            // yield가 없으면 그대로 visit
-            if (!es2015_scan.containsYield(self, try_body) and !es2015_scan.containsYield(self, catch_clause) and !es2015_scan.containsYield(self, finally_body)) {
+            const has_yield = es2015_scan.containsYield(self, try_body) or
+                es2015_scan.containsYield(self, catch_clause) or
+                es2015_scan.containsYield(self, finally_body);
+            const has_return = es2015_scan.containsReturn(self, try_body) or
+                es2015_scan.containsReturn(self, catch_clause) or
+                es2015_scan.containsReturn(self, finally_body);
+
+            // yield/await 없이도 return은 __generator callback 안에서 raw return으로
+            // 남으면 안 된다. __generator body는 [op, value] instruction을 반환해야
+            // 하므로 try/catch/finally 안 return도 state-machine op로 수집한다.
+            if (!has_yield and !has_return) {
                 const new_stmt = try self.visitNode(stmt_idx);
                 if (!new_stmt.isNone()) {
                     try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = new_stmt } });

--- a/src/transformer/es2015_generator/scan.zig
+++ b/src/transformer/es2015_generator/scan.zig
@@ -242,6 +242,9 @@ pub fn containsReturn(self: anytype, root_idx: NodeIndex) bool {
                 if (!pushNode(self, &stack, node.data.ternary.b)) return true;
                 if (!pushNode(self, &stack, node.data.ternary.c)) return true;
             },
+            .catch_clause => {
+                if (!pushNode(self, &stack, node.data.binary.right)) return true;
+            },
             else => {},
         }
     }

--- a/src/transformer/es2022.zig
+++ b/src/transformer/es2022.zig
@@ -306,6 +306,9 @@ pub fn ES2022(comptime Transformer: type) type {
             var field_init_idx: std.ArrayList(NodeIndex) = .empty;
             defer field_init_idx.deinit(self.allocator);
 
+            var private_names = try es_helpers.PrivateNameAllocator.init(self.allocator, self.ast);
+            defer private_names.deinit();
+
             {
                 const body_members = self.ast.extra_data.items[body_start .. body_start + body_len];
                 for (body_members) |raw_idx| {
@@ -324,7 +327,7 @@ pub fn ES2022(comptime Transformer: type) type {
 
                         const orig_name = self.ast.getText(key_node.span);
                         const pm_kind = es_helpers.privateMethodKindFromFlags(flags);
-                        const names = try es_helpers.makePrivateMethodNames(self.allocator, orig_name, pm_kind);
+                        const names = try private_names.makePrivateMethodNames(orig_name, pm_kind);
                         try method_mappings.append(self.allocator, .{
                             .original_name = orig_name,
                             .weakset_name = names.ws_name,
@@ -348,7 +351,7 @@ pub fn ES2022(comptime Transformer: type) type {
 
                         const init_val: NodeIndex = self.readNodeIdx(pe, ast_mod.PropertyExtra.init);
                         const orig_name = self.ast.getText(key_node.span);
-                        const var_name = try es_helpers.makePrivateVarName(self.allocator, orig_name);
+                        const var_name = try private_names.makePrivateVarName(orig_name);
 
                         try field_mappings.append(self.allocator, .{
                             .original_name = orig_name,

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -1041,6 +1041,138 @@ pub const PrivateMethodNames = struct {
     fn_name: []const u8,
 };
 
+/// Private field/method downlevel artifacts (`#x` -> `_x`) are emitted as
+/// ordinary `var`/`function` bindings in the surrounding transform scope. They
+/// must therefore avoid user bindings/references and artifacts emitted by
+/// earlier class transforms. Babel's scope.generateUidIdentifier follows the
+/// same invariant; without it, a class `#y` can shadow an existing `_y`
+/// function used inside the constructor.
+pub const PrivateNameAllocator = struct {
+    allocator: std.mem.Allocator,
+    reserved: std.StringHashMap(void),
+    method_weaksets: std.StringHashMap([]const u8),
+
+    pub fn init(allocator: std.mem.Allocator, ast: *const ast_mod.Ast) !PrivateNameAllocator {
+        var self = PrivateNameAllocator{
+            .allocator = allocator,
+            .reserved = std.StringHashMap(void).init(allocator),
+            .method_weaksets = std.StringHashMap([]const u8).init(allocator),
+        };
+        errdefer self.deinit();
+
+        // Fixed captures emitted by class/arrow lowering. Reserving them here
+        // keeps private helpers out of later transformer-generated bindings.
+        try self.reserveExisting("_this");
+        try self.reserveExisting("_arguments");
+
+        try self.collectExistingIdentifierNames(ast);
+        return self;
+    }
+
+    pub fn deinit(self: *PrivateNameAllocator) void {
+        var keys = self.reserved.keyIterator();
+        while (keys.next()) |key| {
+            self.allocator.free(key.*);
+        }
+        self.reserved.deinit();
+        self.method_weaksets.deinit();
+    }
+
+    fn collectExistingIdentifierNames(self: *PrivateNameAllocator, ast: *const ast_mod.Ast) !void {
+        for (ast.nodes.items) |node| {
+            switch (node.tag) {
+                .identifier_reference,
+                .binding_identifier,
+                .assignment_target_identifier,
+                => try self.reserveExisting(ast.getText(node.data.string_ref)),
+                else => {},
+            }
+        }
+    }
+
+    fn reserveExisting(self: *PrivateNameAllocator, name: []const u8) !void {
+        if (self.reserved.contains(name)) return;
+        const owned = try self.allocator.dupe(u8, name);
+        errdefer self.allocator.free(owned);
+        try self.reserved.put(owned, {});
+    }
+
+    fn reserveGenerated(self: *PrivateNameAllocator, name: []const u8) !void {
+        try self.reserveExisting(name);
+    }
+
+    pub fn makeUniqueName(self: *PrivateNameAllocator, base: []const u8) ![]u8 {
+        var candidate = try self.allocator.dupe(u8, base);
+        if (!self.reserved.contains(candidate)) {
+            self.reserveGenerated(candidate) catch |err| {
+                self.allocator.free(candidate);
+                return err;
+            };
+            return candidate;
+        }
+        self.allocator.free(candidate);
+
+        var suffix: usize = 2;
+        while (true) : (suffix += 1) {
+            candidate = try std.fmt.allocPrint(self.allocator, "{s}{d}", .{ base, suffix });
+            if (!self.reserved.contains(candidate)) {
+                self.reserveGenerated(candidate) catch |err| {
+                    self.allocator.free(candidate);
+                    return err;
+                };
+                return candidate;
+            }
+            self.allocator.free(candidate);
+        }
+    }
+
+    /// "#bar" -> "_bar", with collision avoidance (`_bar2`, `_bar3`, ...).
+    pub fn makePrivateVarName(self: *PrivateNameAllocator, orig_name: []const u8) ![]u8 {
+        const bare = orig_name[1..]; // strip '#'
+        var suffix: usize = 0;
+        while (true) : (suffix += 1) {
+            const candidate = if (suffix == 0)
+                try std.fmt.allocPrint(self.allocator, "_{s}", .{bare})
+            else
+                try std.fmt.allocPrint(self.allocator, "_{s}{d}", .{ bare, suffix + 1 });
+
+            if (!self.reserved.contains(candidate)) {
+                self.reserveGenerated(candidate) catch |err| {
+                    self.allocator.free(candidate);
+                    return err;
+                };
+                return candidate;
+            }
+            self.allocator.free(candidate);
+        }
+    }
+
+    /// kind 별 suffix: method -> "_fn", getter -> "_get", setter -> "_set" (#1523).
+    /// Getter/setter pairs share the same WeakSet text but receive separately
+    /// owned slices because ClassifiedMembers deinit frees each mapping entry.
+    pub fn makePrivateMethodNames(self: *PrivateNameAllocator, orig_name: []const u8, kind: PrivateMethodKind) !PrivateMethodNames {
+        const weakset_name = if (self.method_weaksets.get(orig_name)) |existing|
+            try self.allocator.dupe(u8, existing)
+        else blk: {
+            const generated = try self.makePrivateVarName(orig_name);
+            errdefer self.allocator.free(generated);
+            try self.method_weaksets.put(orig_name, generated);
+            break :blk generated;
+        };
+        errdefer self.allocator.free(weakset_name);
+
+        const suffix: []const u8 = switch (kind) {
+            .method => "_fn",
+            .getter => "_get",
+            .setter => "_set",
+        };
+        const fn_base = try std.fmt.allocPrint(self.allocator, "{s}{s}", .{ weakset_name, suffix });
+        defer self.allocator.free(fn_base);
+        const fn_name = try self.makeUniqueName(fn_base);
+        return .{ .ws_name = weakset_name, .fn_name = fn_name };
+    }
+};
+
 /// "#bar" → "_bar" (allocator 소유). private field WeakMap/descriptor 변수명으로 사용.
 pub fn makePrivateVarName(allocator: std.mem.Allocator, orig_name: []const u8) ![]u8 {
     const bare = orig_name[1..]; // # 제거

--- a/src/transformer/transformer/declarations.zig
+++ b/src/transformer/transformer/declarations.zig
@@ -356,10 +356,12 @@ pub fn visitParamsCollectProperties(self: *Transformer, vp: NodeList) Error!Para
         const param_node = self.ast.getNode(param_idx);
         // formal_parameter: extra = [pattern, type_ann, default, flags, deco_start, deco_len]
         // flags != 0 → parameter property (public/private/protected/readonly/override)
-        if (param_node.tag == .formal_parameter and self.ast.extra_data.items[param_node.data.extra + 3] != 0) {
-            const inner = try self.visitNode(@enumFromInt(self.ast.extra_data.items[param_node.data.extra]));
+        if (param_node.tag == .formal_parameter and self.ast.extra_data.items[param_node.data.extra + ast_mod.FormalParameterExtra.flags] != 0) {
+            const inner = try self.visitNode(@enumFromInt(self.ast.extra_data.items[param_node.data.extra + ast_mod.FormalParameterExtra.pattern]));
             try self.scratch.append(self.allocator, inner);
-            try result.prop_names.append(self.allocator, inner);
+            if (parameterPropertyBindingName(self, inner)) |binding| {
+                try result.prop_names.append(self.allocator, binding);
+            }
         } else {
             const new_param = try self.visitNode(@enumFromInt(raw_idx));
             if (!new_param.isNone()) {
@@ -370,6 +372,17 @@ pub fn visitParamsCollectProperties(self: *Transformer, vp: NodeList) Error!Para
 
     result.new_params = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
     return result;
+}
+
+fn parameterPropertyBindingName(self: *Transformer, idx: NodeIndex) ?NodeIndex {
+    if (idx.isNone()) return null;
+    const node = self.ast.getNode(idx);
+    return switch (node.tag) {
+        .binding_identifier => idx,
+        .assignment_pattern => parameterPropertyBindingName(self, node.data.binary.left),
+        .formal_parameter => parameterPropertyBindingName(self, self.readNodeIdx(node.data.extra, ast_mod.FormalParameterExtra.pattern)),
+        else => null,
+    };
 }
 
 /// `this.x = x;` 형태의 expression_statement 노드들을 만들어 반환한다.

--- a/src/transformer/transformer/lists.zig
+++ b/src/transformer/transformer/lists.zig
@@ -61,7 +61,11 @@ fn visitBlockWithScoping(self: *Transformer, node: Node) Error!NodeIndex {
 
     // 블록 퇴장: rename 맵 + scope_var_names 모두 복원
     if (renames_added > 0) {
-        self.block_rename_stack.shrinkRetainingCapacity(self.block_rename_stack.items.len - renames_added);
+        const saved_rename_len = self.block_rename_stack.items.len - renames_added;
+        for (self.block_rename_stack.items[saved_rename_len..]) |entry| {
+            self.allocator.free(entry.new_name);
+        }
+        self.block_rename_stack.shrinkRetainingCapacity(saved_rename_len);
     }
     self.scope_var_names.shrinkRetainingCapacity(saved_scope_len);
 

--- a/src/transformer/transformer/members.zig
+++ b/src/transformer/transformer/members.zig
@@ -11,6 +11,42 @@ const transformer_mod = @import("../transformer.zig");
 const Transformer = transformer_mod.Transformer;
 const Error = Transformer.Error;
 
+fn expandBlockRenamedShorthand(self: *Transformer, node: Node) Error!?NodeIndex {
+    if (!self.options.unsupported.block_scoping) return null;
+    if (!node.data.binary.right.isNone()) return null;
+
+    const key_idx = node.data.binary.left;
+    if (key_idx.isNone()) return null;
+    const key_node = self.ast.getNode(key_idx);
+    if (key_node.tag != .identifier_reference) return null;
+
+    const name = self.ast.getText(key_node.data.string_ref);
+    const new_name = self.lookupBlockRename(name) orelse return null;
+
+    // Object shorthand 의 key 는 property 이름이라 원본을 보존해야 하지만,
+    // 암시된 value 참조는 block-scoping lowering 이 만든 renamed binding 을 읽어야 한다.
+    const new_key = try self.copyNodeDirect(key_idx);
+    self.propagateSymbolId(key_idx, new_key);
+
+    const value_span = try self.ast.addString(new_name);
+    const new_value = try self.ast.addNode(.{
+        .tag = .identifier_reference,
+        .span = value_span,
+        .data = .{ .string_ref = value_span },
+    });
+    self.propagateSymbolId(key_idx, new_value);
+
+    return try self.ast.addNode(.{
+        .tag = .object_property,
+        .span = node.span,
+        .data = .{ .binary = .{
+            .left = new_key,
+            .right = new_value,
+            .flags = node.data.binary.flags,
+        } },
+    });
+}
+
 // method_definition: extra = [key(0), params(1), body(2), flags(3), deco_start(4), deco_len(5)]
 // constructor의 parameter property (public x: number) 변환도 처리.
 // abstract 메서드는 런타임에 존재하면 안 되므로 완전히 제거.
@@ -209,6 +245,7 @@ pub fn visitObjectProperty(self: *Transformer, node: Node) Error!NodeIndex {
     if (self.options.unsupported.object_extensions and node.data.binary.right.isNone()) {
         return es2015_shorthand.ES2015Shorthand(Transformer).expandShorthand(self, node);
     }
+    if (try expandBlockRenamedShorthand(self, node)) |expanded| return expanded;
     // non-computed key(identifier, string, numeric)는 property 이름이므로
     // block scoping rename 등 변수 치환을 적용하면 안 됨. copyNodeDirect 사용.
     // symbol_id는 항상 전파: shorthand({ x })에서 codegen이 rename을

--- a/src/transformer/transformer/node_helpers.zig
+++ b/src/transformer/transformer/node_helpers.zig
@@ -217,9 +217,12 @@ pub fn visitMemberExpression(self: anytype, node: Node) Error!NodeIndex {
     const right_idx = self.readNodeIdx(e, 1);
     const flags = self.readU32(e, 2);
     const new_left = try self.visitNode(left_idx);
-    // computed_member: right는 임의 expression. static_member/private_field: right는 식별자 리프.
-    // visitNode가 리프를 copyNodeDirect로 처리하므로 동일하게 visitNode 호출.
-    const new_right = try self.visitNode(right_idx);
+    // computed member의 property만 expression이다. dot/private member의 property는
+    // lexical reference가 아니라 property key라 block-scoping rename 대상이 아니다.
+    const new_right = if (node.tag == .computed_member_expression)
+        try self.visitNode(right_idx)
+    else
+        right_idx;
     const new_extra = try self.ast.addExtras(&.{ @intFromEnum(new_left), @intFromEnum(new_right), flags });
     return self.ast.addNode(.{ .tag = node.tag, .span = node.span, .data = .{ .extra = new_extra } });
 }

--- a/src/transformer/transformer/stage3_decorator_transform.zig
+++ b/src/transformer/transformer/stage3_decorator_transform.zig
@@ -279,6 +279,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                 const key_idx = self.readNodeIdx(me, ast_mod.PropertyExtra.key);
                 const new_key = try self.visitNode(key_idx);
                 const new_init = try self.visitNode(self.readNodeIdx(me, ast_mod.PropertyExtra.init));
+                const is_private_accessor = self.ast.getNode(key_idx).tag == .private_identifier;
 
                 if (deco_len > 0) {
                     const name_node_idx = try self.memberKeyToStringLiteral(new_key);
@@ -289,13 +290,12 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     if (is_static) has_static_decorators = true else has_instance_decorators = true;
 
                     const names = try self.buildFieldInitNames(name_node_idx);
-                    const clean_name = names.clean_name;
 
                     try member_infos.append(self.allocator, .{
                         .kind = "accessor",
                         .name = name_node_idx,
                         .is_static = is_static,
-                        .is_private = false,
+                        .is_private = is_private_accessor,
                         .decorators = decos,
                         .initializers_name = names.init_name,
                         .extra_initializers_name = names.extra_name,
@@ -303,7 +303,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     });
 
                     // accessor → private backing field + getter + setter
-                    const storage_name = try std.fmt.allocPrint(self.allocator, "#_{s}_accessor_storage", .{clean_name});
+                    const storage_name = try std.fmt.allocPrint(self.allocator, "#_{s}_accessor_storage", .{var_n});
                     defer self.allocator.free(storage_name);
                     const storage_span = try self.ast.addString(storage_name);
                     const storage_key = try self.ast.addNode(.{
@@ -353,7 +353,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     // 우연히 동작하던 것을 안정화).
                     {
                         const return_expr = try makeThisPrivateField(self, storage_span);
-                        const getter_key = try self.ast.addNode(.{
+                        const getter_key = if (is_private_accessor) new_key else try self.ast.addNode(.{
                             .tag = .identifier_reference,
                             .span = self.ast.getNode(new_key).data.string_ref,
                             .data = .{ .string_ref = self.ast.getNode(new_key).data.string_ref },
@@ -364,7 +364,7 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
 
                     // set x(value) { this.#_x_accessor_storage = value; }
                     {
-                        const setter_key = try self.ast.addNode(.{
+                        const setter_key = if (is_private_accessor) new_key else try self.ast.addNode(.{
                             .tag = .identifier_reference,
                             .span = self.ast.getNode(new_key).data.string_ref,
                             .data = .{ .string_ref = self.ast.getNode(new_key).data.string_ref },

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1345,6 +1345,33 @@ test "#1797 negative: for-of down-level 꺼져있으면 변환 자체 비활성"
     try std.testing.expect(std.mem.indexOf(u8, code, "for (let k of") != null);
 }
 
+test "block scoping: dot member property names are not lexical references" {
+    // AxiosHeaders.accessor 패턴 축소. inner const `prototype` 은 rename 되어도
+    // `this.prototype` 의 property key 는 Metro/Babel 처럼 그대로 유지해야 한다.
+    const source =
+        \\class Outer {}
+        \\let prototype = Outer.prototype;
+        \\class Headers {
+        \\  static accessor() {
+        \\    const prototype = this.prototype;
+        \\    return prototype;
+        \\  }
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+
+    try std.testing.expect(std.mem.indexOf(u8, code, "this.prototype$") == null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "this.prototype") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "prototype$") != null);
+}
+
 test "#1797 native for-of + block scoping: let 캡처 시 _loop 함수로 추출" {
     // RN preset은 for-of 문법은 유지하지만 block_scoping으로 let/const를 var로 낮춘다.
     // 이때 getter/closure가 loop binding을 캡처하면 native for-of 경로에서도 fresh binding

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1372,6 +1372,114 @@ test "block scoping: dot member property names are not lexical references" {
     try std.testing.expect(std.mem.indexOf(u8, code, "prototype$") != null);
 }
 
+test "block scoping: optional chain property names are not lexical references" {
+    // `?.foo` 는 같은 `static_member_expression` tag 의 flag bit 라 dot fix 와
+    // 같은 경로. inner `prototype` 이 rename 되어도 property key 는 유지.
+    const source =
+        \\let prototype = null;
+        \\function read(o) {
+        \\  const prototype = 1;
+        \\  return o?.prototype ?? prototype;
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+
+    try std.testing.expect(std.mem.indexOf(u8, code, "o?.prototype$") == null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "o?.prototype") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "prototype$") != null);
+}
+
+test "block scoping: super member property names are not lexical references" {
+    // `super.foo` 도 `static_member_expression` 이고 left 가 super_expression.
+    // outer `value` 와 method body 의 inner `value` 가 shadow 될 때 inner
+    // 가 rename 되어도 `super.value` 의 property key 는 유지되어야 한다.
+    const source =
+        \\let value = "outer";
+        \\class Base {
+        \\  get value() { return "base"; }
+        \\}
+        \\class Derived extends Base {
+        \\  read() {
+        \\    const value = "inner";
+        \\    return super.value + value;
+        \\  }
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+
+    // 핵심: super 의 property key 는 rename 되면 안 됨.
+    try std.testing.expect(std.mem.indexOf(u8, code, "super.value$") == null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "super.value") != null);
+}
+
+test "block scoping: computed member key is renamed (negative)" {
+    // computed_member_expression 의 right 는 lexical reference 이므로 inner
+    // rename 이 그대로 적용되어야 한다. 위 dot/private/super fix 의 negative
+    // 가드.
+    const source =
+        \\let key = "a";
+        \\function pick(o) {
+        \\  const key = "b";
+        \\  return o[key];
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+
+    // outer `key` 와 inner `key` 가 모두 같은 이름이면 안 됨 — 둘 중 하나가
+    // rename 되어야 한다. 어느 방향이든 inner 접근은 renamed binding 으로 가야.
+    try std.testing.expect(std.mem.indexOf(u8, code, "o[key$") != null or
+        std.mem.indexOf(u8, code, "o[key_") != null);
+}
+
+test "block scoping: private field property names are not lexical references" {
+    // `obj.#foo` 는 `private_field_expression` 이고 right 는 `#`-prefixed
+    // private_identifier 라 block_rename 키 (`foo`) 와 사실상 매칭되지
+    // 않는다. 그래도 명시적으로 잠가둠.
+    const source =
+        \\let value = "outer";
+        \\class C {
+        \\  #value = 1;
+        \\  read() {
+        \\    const value = 2;
+        \\    return this.#value + value;
+        \\  }
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{ .block_scoping = true } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+
+    // private field name 은 `#value` 그대로 유지되어야 함 (다운레벨 가도 WeakMap
+    // hoist name 으로 들어가야지 block rename 으로 바뀌면 안 됨).
+    try std.testing.expect(std.mem.indexOf(u8, code, "#value$") == null);
+}
+
 test "#1797 native for-of + block scoping: let 캡처 시 _loop 함수로 추출" {
     // RN preset은 for-of 문법은 유지하지만 block_scoping으로 let/const를 var로 낮춘다.
     // 이때 getter/closure가 loop binding을 캡처하면 native for-of 경로에서도 fresh binding

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1421,9 +1421,11 @@ test "block scoping: super member property names are not lexical references" {
     const code = try generateCode(&r);
     defer std.testing.allocator.free(code);
 
-    // 핵심: super 의 property key 는 rename 되면 안 됨.
+    // 핵심: super 의 property key 는 rename 되면 안 됨. inner binding 자체는
+    // rename 되어야 — shadowing 이 실제로 트리거됐는지 함께 잠금.
     try std.testing.expect(std.mem.indexOf(u8, code, "super.value$") == null);
     try std.testing.expect(std.mem.indexOf(u8, code, "super.value") != null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "value$") != null);
 }
 
 test "block scoping: computed member key is renamed (negative)" {
@@ -1446,10 +1448,9 @@ test "block scoping: computed member key is renamed (negative)" {
     const code = try generateCode(&r);
     defer std.testing.allocator.free(code);
 
-    // outer `key` 와 inner `key` 가 모두 같은 이름이면 안 됨 — 둘 중 하나가
-    // rename 되어야 한다. 어느 방향이든 inner 접근은 renamed binding 으로 가야.
-    try std.testing.expect(std.mem.indexOf(u8, code, "o[key$") != null or
-        std.mem.indexOf(u8, code, "o[key_") != null);
+    // rename 형식은 `{base}${n}` (lists.zig:238) — 항상 `$` suffix.
+    // computed access 의 key 가 inner shadow 로 rename 되어야 함.
+    try std.testing.expect(std.mem.indexOf(u8, code, "o[key$") != null);
 }
 
 test "block scoping: private field property names are not lexical references" {
@@ -1477,6 +1478,7 @@ test "block scoping: private field property names are not lexical references" {
 
     // private field name 은 `#value` 그대로 유지되어야 함 (다운레벨 가도 WeakMap
     // hoist name 으로 들어가야지 block rename 으로 바뀌면 안 됨).
+    try std.testing.expect(std.mem.indexOf(u8, code, "#value") != null);
     try std.testing.expect(std.mem.indexOf(u8, code, "#value$") == null);
 }
 

--- a/tests/integration/tests/tsc/__snapshots__/classes.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/classes.test.ts.snap
@@ -9807,6 +9807,146 @@ class C2 extends C1 {
 "
 `;
 
+exports[`TSC: classes autoAccessorExperimentalDecorators 1`] = `
+"var __esDecorate = function(ctor, descriptorIn, decorators, contextIn, initializers, extraInitializers) {
+  function accept(f) { if (f !== void 0 && typeof f !== "function") throw new TypeError("Function expected"); return f; }
+  var kind = contextIn.kind, key = kind === "getter" ? "get" : kind === "setter" ? "set" : "value";
+  var target = !descriptorIn && ctor ? contextIn["static"] ? ctor : ctor.prototype : null;
+  var descriptor = descriptorIn || (target ? Object.getOwnPropertyDescriptor(target, contextIn.name) : {});
+  var _, done = false;
+  for (var i = decorators.length - 1; i >= 0; i--) {
+    var context = {};
+    for (var p in contextIn) context[p] = p === "access" ? {} : contextIn[p];
+    for (var p in contextIn.access) context.access[p] = contextIn.access[p];
+    context.addInitializer = function(f) { if (done) throw new TypeError("Cannot add initializers after decoration has completed"); extraInitializers.push(accept(f || null)); };
+    var result = (0, decorators[i])(kind === "accessor" ? { get: descriptor.get, set: descriptor.set } : descriptor[key], context);
+    if (kind === "accessor") {
+      if (result === void 0) continue;
+      if (result === null || typeof result !== "object") throw new TypeError("Object expected");
+      if (_ = accept(result.get)) descriptor.get = _;
+      if (_ = accept(result.set)) descriptor.set = _;
+      if (_ = accept(result.init)) initializers.unshift(_);
+    } else if (_ = accept(result)) {
+      if (kind === "field") initializers.unshift(_);
+      else descriptor[key] = _;
+    }
+  }
+  if (target) Object.defineProperty(target, contextIn.name, descriptor);
+  done = true;
+};
+var __runInitializers = function(thisArg, initializers, value) {
+  var useValue = arguments.length > 2;
+  for (var i = 0; i < initializers.length; i++) {
+    value = useValue ? initializers[i].call(thisArg, value) : initializers[i].call(thisArg);
+  }
+  return useValue ? value : void 0;
+};
+var __setFunctionName = function(f, name, prefix) {
+  if (typeof name === "symbol") name = name.description ? "[".concat(name.description, "]") : "";
+  return Object.defineProperty(f, "name", { configurable: true, value: prefix ? "".concat(prefix, " ", name) : name });
+};
+var __propKey = function(x) {
+  return typeof x === "symbol" ? x : "".concat(x);
+};
+let C1 = (() => {
+	let _classThis;
+	let _instanceExtraInitializers = [];
+	let _staticExtraInitializers = [];
+	let _a_decorators;
+	let _a_initializers = [];
+	let _a_extraInitializers = [];
+	let _b_decorators;
+	let _b_initializers = [];
+	let _b_extraInitializers = [];
+	var C1 = class {
+		static {
+			_classThis = this;
+		}
+		static {
+			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+			_a_decorators = [dec];
+			_b_decorators = [dec];
+			__esDecorate(this, null, _b_decorators, { kind: "accessor", name: "b", static: true, private: false, access: { has: (obj) => "b" in obj, get: (obj) => obj.b, set: function(obj,value) {
+				obj.b = value;
+			} }, metadata: _metadata }, _b_initializers, _b_extraInitializers);
+			__esDecorate(this, null, _a_decorators, { kind: "accessor", name: "a", static: false, private: false, access: { has: (obj) => "a" in obj, get: (obj) => obj.a, set: function(obj,value) {
+				obj.a = value;
+			} }, metadata: _metadata }, _a_initializers, _a_extraInitializers);
+			if (_metadata) {
+				Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+			}
+		}
+		#_a_accessor_storage = __runInitializers(this, _instanceExtraInitializers);
+		get a() {
+			return this.#_a_accessor_storage;
+		}
+		set a(value) {
+			this.#_a_accessor_storage = value;
+		}
+		static #_b_accessor_storage;
+		static get b() {
+			return this.#_b_accessor_storage;
+		}
+		static set b(value) {
+			this.#_b_accessor_storage = value;
+		}
+		constructor() {
+			__runInitializers(this, _a_extraInitializers);
+		}
+	};
+	return C1 = _classThis;
+})();
+let C2 = (() => {
+	let _classThis;
+	let _instanceExtraInitializers = [];
+	let _staticExtraInitializers = [];
+	let _a_decorators;
+	let _a_initializers = [];
+	let _a_extraInitializers = [];
+	let _b_decorators;
+	let _b_initializers = [];
+	let _b_extraInitializers = [];
+	var C2 = class {
+		static {
+			_classThis = this;
+		}
+		static {
+			const _metadata = typeof Symbol === "function" && Symbol.metadata ? Object.create(null) : void 0;
+			_a_decorators = [dec];
+			_b_decorators = [dec];
+			__esDecorate(this, null, _b_decorators, { kind: "accessor", name: "#b", static: true, private: true, access: { has: (obj) => #b in obj, get: (obj) => obj.#b, set: function(obj,value) {
+				obj.#b = value;
+			} }, metadata: _metadata }, _b_initializers, _b_extraInitializers);
+			__esDecorate(this, null, _a_decorators, { kind: "accessor", name: "#a", static: false, private: true, access: { has: (obj) => #a in obj, get: (obj) => obj.#a, set: function(obj,value) {
+				obj.#a = value;
+			} }, metadata: _metadata }, _a_initializers, _a_extraInitializers);
+			if (_metadata) {
+				Object.defineProperty(_classThis, Symbol.metadata, { enumerable: true, configurable: true, writable: true, value: _metadata });
+			}
+		}
+		#_a_accessor_storage = __runInitializers(this, _instanceExtraInitializers);
+		get #a() {
+			return this.#_a_accessor_storage;
+		}
+		set #a(value) {
+			this.#_a_accessor_storage = value;
+		}
+		static #_b_accessor_storage;
+		static get #b() {
+			return this.#_b_accessor_storage;
+		}
+		static set #b(value) {
+			this.#_b_accessor_storage = value;
+		}
+		constructor() {
+			__runInitializers(this, _a_extraInitializers);
+		}
+	};
+	return C2 = _classThis;
+})();
+"
+`;
+
 exports[`TSC: classes autoAccessorNoUseDefineForClassFields 1`] = `
 "// https://github.com/microsoft/TypeScript/issues/51528
 class C1 {

--- a/tests/integration/tests/tsc/__snapshots__/classes.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/classes.test.ts.snap
@@ -2179,7 +2179,7 @@ class D {
 }
 class E {
 	constructor(x=this) {
-		this.x = this = x=this;
+		this.x = x;
 	}
 }
 class F extends C {
@@ -2212,14 +2212,14 @@ class E {
 exports[`TSC: classes constructorImplementationWithDefaultValues2 1`] = `
 "class C {
 	constructor(x=1) {
-		this.x: string = 1 = x=1;
+		this.x = x;
 		// error
 		var y = x;
 	}
 }
 class D {
 	constructor(x=1,y=x) {
-		this.y: U = x = y=x;
+		this.y = y;
 		// error
 		var z = x;
 	}
@@ -3145,7 +3145,7 @@ class DerivedInIf extends Object {
 class DerivedInBlockWithProperties extends Object {
 	prop = 1;
 	constructor(paramProp=2) {
-		this.paramProp = 2 = paramProp=2;
+		this.paramProp = paramProp;
 		{
 			super();
 		}
@@ -3154,7 +3154,7 @@ class DerivedInBlockWithProperties extends Object {
 class DerivedInConditionalWithProperties extends Object {
 	prop = 1;
 	constructor(paramProp=2) {
-		this.paramProp = 2 = paramProp=2;
+		this.paramProp = paramProp;
 		if (Math.random()) {
 			super(1);
 		} else {

--- a/tests/integration/tests/tsc/__snapshots__/es6-destructuring.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-destructuring.test.ts.snap
@@ -1246,17 +1246,14 @@ exports[`TSC: es6/destructuring destructuringParameterProperties1 1`] = `
 "// @module: commonjs
 class C1 {
 	constructor([x, y, z]) {
-		this.[x, y, z] = [x, y, z];
 	}
 }
 class C2 {
 	constructor([x, y, z]) {
-		this.[x, y, z] = [x, y, z];
 	}
 }
 class C3 {
 	constructor({ x:x, y:y, z:z }) {
-		this.{ x, y, z } = { x:x, y:y, z:z };
 	}
 }
 var c1 = new C1([]);
@@ -1275,7 +1272,6 @@ exports[`TSC: es6/destructuring destructuringParameterProperties2 1`] = `
 class C1 {
 	constructor(k,[a, b, c]) {
 		this.k = k;
-		this.[a, b, c] = [a, b, c];
 		if ((b === undefined && c === undefined) || (this.b === undefined && this.c === undefined)) {
 			this.a = a || k;
 		}
@@ -1304,7 +1300,6 @@ exports[`TSC: es6/destructuring destructuringParameterProperties3 1`] = `
 class C1 {
 	constructor(k,[a, b, c]) {
 		this.k = k;
-		this.[a, b, c] = [a, b, c];
 		if ((b === undefined && c === undefined) || (this.b === undefined && this.c === undefined)) {
 			this.a = a || k;
 		}
@@ -1335,7 +1330,6 @@ exports[`TSC: es6/destructuring destructuringParameterProperties4 1`] = `
 class C1 {
 	constructor(k,[a, b, c]) {
 		this.k = k;
-		this.[a, b, c] = [a, b, c];
 		if ((b === undefined && c === undefined) || (this.b === undefined && this.c === undefined)) {
 			this.a = a || k;
 		}
@@ -1362,7 +1356,6 @@ exports[`TSC: es6/destructuring destructuringParameterProperties5 1`] = `
 "// @module: commonjs
 class C1 {
 	constructor([{ x1:x1, x2:x2, x3:x3 }, y, z]) {
-		this.[{ x1, x2, x3 }, y, z] = [{ x1:x1, x2:x2, x3:x3 }, y, z];
 		var foo = x1 || x2 || x3 || y || z;
 		var bar = this.x1 || this.x2 || this.x3 || this.y || this.z;
 	}

--- a/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
@@ -14936,68 +14936,60 @@ class x96 {
 }
 class x97 {
 	constructor(parm=() => [d1, d2]) {
-		this.parm: () => Base[] = () => [d1, d2] = parm=() => [d1, d2];
+		this.parm = parm;
 	}
 }
 class x98 {
 	constructor(parm=function() {
 		return [d1, d2];
 	}) {
-		this.parm: () => Base[] = function() { return [d1, d2] } = parm=function() {
-			return [d1, d2];
-		};
+		this.parm = parm;
 	}
 }
 class x99 {
 	constructor(parm=function named() {
 		return [d1, d2];
 	}) {
-		this.parm: () => Base[] = function named() { return [d1, d2] } = parm=function named() {
-			return [d1, d2];
-		};
+		this.parm = parm;
 	}
 }
 class x100 {
 	constructor(parm=() => [d1, d2]) {
-		this.parm: { (): Base[]; } = () => [d1, d2] = parm=() => [d1, d2];
+		this.parm = parm;
 	}
 }
 class x101 {
 	constructor(parm=function() {
 		return [d1, d2];
 	}) {
-		this.parm: { (): Base[]; } = function() { return [d1, d2] } = parm=function() {
-			return [d1, d2];
-		};
+		this.parm = parm;
 	}
 }
 class x102 {
 	constructor(parm=function named() {
 		return [d1, d2];
 	}) {
-		this.parm: { (): Base[]; } = function named() { return [d1, d2] } = parm=function named() {
-			return [d1, d2];
-		};
+		this.parm = parm;
 	}
 }
 class x103 {
 	constructor(parm=[d1, d2]) {
-		this.parm: Base[] = [d1, d2] = parm=[d1, d2];
+		this.parm = parm;
 	}
 }
 class x104 {
 	constructor(parm=[d1, d2]) {
-		this.parm: Array<Base> = [d1, d2] = parm=[d1, d2];
+		this.parm = parm;
 	}
 }
 class x105 {
 	constructor(parm=[d1, d2]) {
-		this.parm: { [n: number]: Base; } = [d1, d2] = parm=[d1, d2];
+		this.parm = parm;
 	}
 }
 class x106 {
 	constructor(parm={ n: [d1, d2] }) {
-		this.parm: {n: Base[]; }  = { n: [d1, d2] } = parm={ n: [d1, d2] };
+		this.parm = parm;
 	}
 }
 class x107 {
@@ -15005,85 +14997,72 @@ class x107 {
 		var n;
 		return null;
 	}) {
-		this.parm: (s: Base[]) => any = n => { var n: Base[]; return null; } = parm=(n) => {
-			var n;
-			return null;
-		};
+		this.parm = parm;
 	}
 }
 class x108 {
 	constructor(parm={ func: (n) => {
 		return [d1, d2];
 	} }) {
-		this.parm: Genric<Base> = { func: n => { return [d1, d2]; } } = parm={ func: (n) => {
-			return [d1, d2];
-		} };
+		this.parm = parm;
 	}
 }
 class x109 {
 	constructor(parm=() => [d1, d2]) {
-		this.parm: () => Base[] = () => [d1, d2] = parm=() => [d1, d2];
+		this.parm = parm;
 	}
 }
 class x110 {
 	constructor(parm=function() {
 		return [d1, d2];
 	}) {
-		this.parm: () => Base[] = function() { return [d1, d2] } = parm=function() {
-			return [d1, d2];
-		};
+		this.parm = parm;
 	}
 }
 class x111 {
 	constructor(parm=function named() {
 		return [d1, d2];
 	}) {
-		this.parm: () => Base[] = function named() { return [d1, d2] } = parm=function named() {
-			return [d1, d2];
-		};
+		this.parm = parm;
 	}
 }
 class x112 {
 	constructor(parm=() => [d1, d2]) {
-		this.parm: { (): Base[]; } = () => [d1, d2] = parm=() => [d1, d2];
+		this.parm = parm;
 	}
 }
 class x113 {
 	constructor(parm=function() {
 		return [d1, d2];
 	}) {
-		this.parm: { (): Base[]; } = function() { return [d1, d2] } = parm=function() {
-			return [d1, d2];
-		};
+		this.parm = parm;
 	}
 }
 class x114 {
 	constructor(parm=function named() {
 		return [d1, d2];
 	}) {
-		this.parm: { (): Base[]; } = function named() { return [d1, d2] } = parm=function named() {
-			return [d1, d2];
-		};
+		this.parm = parm;
 	}
 }
 class x115 {
 	constructor(parm=[d1, d2]) {
-		this.parm: Base[] = [d1, d2] = parm=[d1, d2];
+		this.parm = parm;
 	}
 }
 class x116 {
 	constructor(parm=[d1, d2]) {
-		this.parm: Array<Base> = [d1, d2] = parm=[d1, d2];
+		this.parm = parm;
 	}
 }
 class x117 {
 	constructor(parm=[d1, d2]) {
-		this.parm: { [n: number]: Base; } = [d1, d2] = parm=[d1, d2];
+		this.parm = parm;
 	}
 }
 class x118 {
 	constructor(parm={ n: [d1, d2] }) {
-		this.parm: {n: Base[]; }  = { n: [d1, d2] } = parm={ n: [d1, d2] };
+		this.parm = parm;
 	}
 }
 class x119 {
@@ -15091,19 +15070,14 @@ class x119 {
 		var n;
 		return null;
 	}) {
-		this.parm: (s: Base[]) => any = n => { var n: Base[]; return null; } = parm=(n) => {
-			var n;
-			return null;
-		};
+		this.parm = parm;
 	}
 }
 class x120 {
 	constructor(parm={ func: (n) => {
 		return [d1, d2];
 	} }) {
-		this.parm: Genric<Base> = { func: n => { return [d1, d2]; } } = parm={ func: (n) => {
-			return [d1, d2];
-		} };
+		this.parm = parm;
 	}
 }
 function x121(parm=() => [d1, d2]) {

--- a/tests/integration/tests/tsc/classes.test.ts
+++ b/tests/integration/tests/tsc/classes.test.ts
@@ -11187,7 +11187,9 @@ declare class C3 {
     );
   });
   test('autoAccessorExperimentalDecorators', async () => {
-    await expectError(
+    // TSC rejects this by checking the decorator function signature for auto-accessors.
+    // zntc does not type-check, so the syntax-level transform should still pass.
+    await expectPass(
       `
 declare var dec: (target: any, key: PropertyKey, desc: PropertyDescriptor) => void;
 

--- a/tests/integration/tests/tsc/decorator.test.ts
+++ b/tests/integration/tests/tsc/decorator.test.ts
@@ -858,7 +858,9 @@ class C {
     });
 
     test('decoratorOnClass8 - wrong decorator signature on class', async () => {
-      await expectError(`
+      // TSC rejects this via decorator signature type-checking. zntc only parses
+      // and transforms here, matching decoratorOnClass3 above.
+      await expectPass(`
 declare function dec(): (target: Function, paramIndex: number) => void;
 
 @dec()


### PR DESCRIPTION
## 요약

RN 앱을 zntc로 번들링할 때 Metro/Babel 경로와 다르게 실패하는 문제를 `main` 기준에서 재현하고, 작은 케이스부터 커밋 단위로 루트 원인을 수정합니다.

## 최근 추가 커밋

- `1641a9db test(tsc): update parameter property snapshots`
  - 앞선 parameter property default/destructuring 정상화 뒤 CI integration snapshot이 예전 invalid emit 기대값을 보고 실패하던 문제를 갱신했습니다.
  - 컴파일러 출력은 이미 정상 형태였고, snapshot 기대값만 `this.x = x`, `this.y = y`, `this.paramProp = paramProp`, destructuring parameter property no-op 형태로 맞췄습니다.
  - 전체 integration을 다시 실행해 기존 9개 TSC snapshot 실패가 모두 통과하는 것을 확인했습니다.
- `d61f861a fix(transformer): lower returns in async control flow`
  - ES5 async state machine에서 `await` 이후 `switch`/loop 내부 동기 `return`이 raw JS `return true;`/`return false;`로 남아 `__generator` 런타임이 무한 동기 루프에 빠지던 문제를 수정했습니다.
  - `switch`, `for`, `while`, `do-while`, `for-of` fast path가 `containsYield`만 보던 것을 `containsReturn`까지 보게 해, `return`을 `[2, value]` generator instruction으로 수집합니다.
  - SWC는 generator pass의 `ReturnStmt`를 `create_inline_return`/`emit_return` 경로로 변환해 instruction 배열을 쓰는 것을 `references/swc`에서 확인했습니다. OXC는 async-to-generator 단계에서 generator function으로 넘기며 raw async `return`을 helper wrapper 밖 completion으로 두지 않습니다.
  - 최소 재현 테스트로 `await` 이후 `switch`/loop 내부 early return이 raw return으로 남지 않는지 고정했습니다.
  - 앱 dev server 재실행 후 기존 500ms delay 지점에서 멈추지 않고 이후 액션/네트워크 흐름까지 계속 진행되는 것을 확인했습니다.
- `44400a9c fix(transformer): avoid private helper name collisions`
  - private field/method downlevel helper가 기존 `_y` 같은 사용자 식별자와 같은 hoist scope에서 충돌하던 문제를 수정했습니다.
  - ES2015 class lowering와 ES2022 private member lowering 모두 `PrivateNameAllocator`를 사용해 기존 identifier/reference 및 이전 생성 helper 이름을 피합니다.
  - OXC의 `generate_uid_in_current_hoist_scope`와 SWC의 fresh mark/SyntaxContext 방식처럼, private helper가 일반 바인딩으로 emit될 때 충돌하지 않는 이름을 갖도록 맞췄습니다.
  - 최소 재현 테스트로 기존 `_y` 함수가 constructor에서 계속 호출되고 private WeakMap은 `_y2`로 분리되는지 고정했습니다.
- `70d733a0 fix(linker): bind cjs re-export namespace members`
  - `CJS module -> ESM facade re-export -> import * as ns` 체인에서 `ns.member()`가 bare `member()` 호출로 잘못 치환되던 문제를 수정했습니다.
  - CJS canonical export는 ESM local binding처럼 직접 식별자로 참조할 수 없으므로, namespace member rewrite 값을 `require_x().member` getter 접근으로 기록하게 했습니다.
  - 앱 dev bundle에서 bare 호출이 사라지고 CJS require getter 호출로 바뀐 것을 확인했습니다.
- `190cddeb fix(parser): parse generic get and set methods`
  - TypeScript class member `get<T>(...)` / `set<T>(...)`를 accessor로 오인해 class method 파싱이 깨지던 문제를 수정했습니다.
  - SWC는 `get`/`set` 다음 `<`를 accessor-as-ident 경로로 다루고, OXC는 `get`/`set` contextual modifier의 follower에서 `<`를 제외한 뒤 일반 method declaration의 type parameter로 처리하는 것을 `references/`에서 확인했습니다.
  - 앱 bundle에서 누락되던 `node_modules/.pnpm/@tanstack+query-core@5.67.1/node_modules/@tanstack/query-core/src/queryCache.ts` 단독 변환이 통과하는 것을 확인했습니다.
- `733959e8 fix(rn): forward decorator build options`
  - RN dev/bundle 경로가 `experimentalDecorators`, `emitDecoratorMetadata`, `useDefineForClassFields` 같은 BuildOptions를 preset override로 전달하지 않아, config에서 legacy decorator를 켜도 dev bundle에는 Stage 3 decorator가 남던 문제를 수정했습니다.
  - Metro+Babel 경로에서는 앱 Babel config의 legacy decorator 설정이 적용되지만, zntc RN dev server 경로에서는 해당 옵션이 RN preset으로 넘어가지 않아 `descriptor.value` 런타임 오류로 이어졌습니다.
  - 최소 재현 테스트로 RN dev input에서 config/CLI decorator 옵션이 `bundle.override`에 실리는지 고정했습니다.
  - zntc RN dev bundle에서 SDK decorator 구간이 `__esDecorate`가 아니라 `__decorateClass`로 바뀐 것을 확인했습니다.
- `2542c205 fix(transformer): lower parameter property defaults`
  - `constructor(public config: Config = {})` 같은 TypeScript parameter property를 ES5 class로 낮출 때, `this.config = config` 할당의 property/value 이름에 default pattern과 type annotation이 섞여 invalid JS가 생성되던 문제를 수정했습니다.
  - 최소 재현 테스트로 `public config: Config = {}`가 bare binding을 사용해 할당되는지 고정했습니다.
  - zntc RN dev server bundle에서 기존 invalid 라인이 `_this.config = config;`로 바뀐 것을 확인했습니다.
- `91632157 fix(resolve): match Metro RN export conditions`
  - RN package exports 조건을 Metro 기본 동작에 맞춰 `react-native` + `default`만 assert하도록 수정했습니다.
  - `import`/`require`/`browser` 조건을 RN native 기본 조건처럼 취급하면 Metro가 main field fallback으로 가는 패키지를 zntc가 다른 엔트리로 해석하는 문제가 있었습니다.
  - Metro 0.81 앱 설정과 Metro 0.85 예제 설정 모두 `unstable_conditionNames: ["react-native"]`이고 resolver가 `default`를 추가하는 동작을 확인했습니다.
- `205d4e4e fix(transformer): lower async try returns`
  - ES5 async state machine에서 `try/catch/finally` 내부의 동기 `return`이 raw JS `return`으로 남던 문제를 수정했습니다.
  - `__generator` callback은 `[op, value]` instruction을 반환해야 하므로, `yield/await`가 없더라도 try 계열 블록 안의 `return`은 state-machine op로 수집해야 합니다.
  - 앱 dev server 재실행 후 기존 로그인 흐름에서 사용자 정보 응답과 백업 기기 데이터 흐름까지 진행되는 것을 확인했습니다.
- 이전 커밋들
  - CI Integration TSC 실패 2건 최소 재현 및 수정
  - trailing slash bare package import resolver 수정
  - RN resolver의 Metro `nodeModulesPaths`, `mainFields` 동작 정렬
  - RN `entry_error_guard` 등록/throw 전달 순서 수정
  - mixed ESM/CJS, CJS default interop, private-field helper shadow, exported destructuring live binding 수정
  - selector cycle, derived constructor arrow `this` capture, optional missing require fallback, missing named import shim 수정
  - block-renamed object shorthand value 누락 수정
  - RN inlineRequires ESM named value import 사용 지점 지연 초기화 수정
  - destructured parameter default import reference 누락 수정
  - RN prelude global 선택 순서를 Metro 방식에 맞춤

## 진행 현황

- [x] `origin/main` 기준으로 브랜치 동기화
- [x] 재현 앱의 `babel.config.js`를 임시 비활성화해 zntc 본체 문제로 분리
- [x] RN dev server를 zntc로 실행해 simulator 콘솔/RedBox에서 런타임 오류를 순차 확인
- [x] 앱 런타임의 `Cannot read property 'prototype' of null` 초기화 순서 문제 수정
- [x] async try/catch return state-machine 루트 원인 수정
- [x] RN package exports 조건을 Metro 기본 동작에 맞춤
- [x] TypeScript parameter property 기본값 downlevel 루트 원인 수정
- [x] RN dev/bundle decorator BuildOptions 전달 누락 수정
- [x] TypeScript generic `get<T>`/`set<T>` class method parser 루트 원인 수정
- [x] CJS re-export namespace member rewrite 루트 원인 수정
- [x] private helper 이름 충돌 루트 원인 수정
- [x] async control-flow return state-machine 루트 원인 수정
- [x] PR 본문/댓글에서 앱 로컬 루트 경로와 특정 앱명 제거
- [ ] 최신 head CI 완료 상태 확인
- [ ] 다음 앱 런타임 오류 최소 재현 및 수정

## 이번 라운드 테스트

- `bun run test:integration`
- `zig build test -Dtest-filter="async control-flow return after await"`
- `zig build test -Dtest-filter="async state-machine edge cases"`
- `zig build napi`
- `zig build wasm`
- `zig build wasm-bundler`
- zntc RN dev server 실행 후 simulator reload: 기존 500ms delay 이후 흐름이 멈추지 않고 계속 진행되는 것 확인

## CI

- 최신 head CI는 새 푸시 직후라 아직 running/queued입니다.
- WASM 경로는 이번 head에서 `zig build wasm`을 로컬 통과시켰습니다. 성능은 NAPI보다 느릴 수 있으나 기능 경로 자체는 유지됩니다.

## 참고

재현 명령은 대상 RN 앱 경로에서 실행합니다. 각 문제는 계속 별도 커밋으로 추가하고 본문을 갱신합니다.


