### PR TITLE
refactor(bundler): module stats 를 ZNTC_DEBUG 카테고리로 통합 (ZNTC_MODULE_STATS env 제거)

### DIFF
--- a/docs/DEBUG.md
+++ b/docs/DEBUG.md
@@ -47,12 +47,18 @@ await build({
 
 현재 정의된 카테고리:
 
-| 이름             | 출력 내용                                                | 추가된 PR         |
-| ---------------- | -------------------------------------------------------- | ----------------- |
-| `compiled_cache` | HMR/watch 의 compiled output cache hit/miss 집계         | RFC #1672 B2      |
-| `ast_mutation`   | `Ast.addNode` 추적 (idx, tag, total, transform_boundary) | RFC #1672 D1 prep |
+| 이름                | 출력 내용                                                                                            |
+| ------------------- | ---------------------------------------------------------------------------------------------------- |
+| `compiled_cache`    | HMR/watch 의 compiled output cache hit/miss 집계                                                     |
+| `transform_plan`    | standalone transpile fast-path 라우팅 (`.none`/`.bindings`/`.full`) + `SemanticPlanReason` hit-rate   |
+| `ast_mutation`      | `Ast.addNode`/`addString`/`addNodeList` 추적 (idx, tag, total, transform_boundary)                   |
+| `string_intern`     | `Ast.addString` intern map hit/miss 통계 (모듈별)                                                    |
+| `runtime_polyfills` | core-js 사용 감지 + graph prelude 결정                                                               |
+| `module_stats`      | 빌드 끝에 모듈 분류 히스토그램 (출처·wrap 종류·변환 feature·semantic 보유) — 아래 §`module_stats` 참고 |
 
 추가 시: `src/debug_log.zig` 의 `Category` enum 에 이름만 추가 → 사용처에서 `debug_log.print(.new_category, ...)` 호출 → 이 표 업데이트.
+
+> `--profile`(§2)은 phase 별 **타이밍**, `ZNTC_DEBUG`는 **구조/상태 진단**. `module_stats` 는 빌드의 *모양*(어떤 모듈이 얼마나 들어왔나)을 보여주는 거라 후자에 속한다 — 타이밍은 안 잰다. 둘을 같이 보면 "metadata 가 3.2s 인데(`--profile`) 그게 plain dep 864개를 처리하느라(`module_stats`)" 식으로 읽힌다.
 
 ## 출력 형식
 
@@ -84,6 +90,31 @@ append 하는 흐름을 추적하는 데 사용. `transform_boundary` 는 parser
 - `Ast.transformed_root: ?NodeIndex` — `transform()` 종료 시 root 기록. D1a 부터 활성. 이중 호출 (재진입) 은 `transform()` 진입 시 null 검증으로 탐지.
 - `Ast.assertInvariants()` — Debug 빌드 전용 invariant 검증. boundary 범위 + transformed_root 유효성.
 - `Module.ast` 의 ownership 주석 — parse_arena 소유 규약 명시
+
+### `module_stats` 활용 (빌드 작업 분포 파악)
+
+`ZNTC_DEBUG=module_stats` 로 빌드하면 그래프에 들어온 모듈을 출처·wrap 종류·변환 feature·semantic 보유 여부로 분류한 멀티라인 블록을 빌드 끝에 stderr 로 출력한다 (`src/bundler/bundler.zig` 의 `dumpModuleStats`). 다른 카테고리와 달리 `[cat] key=val` 한 줄이 아니라 헤더 한 줄 + 들여쓴 본문.
+
+```
+[module_stats] module stats
+  total=954  node_modules=938 (98%)  has_semantic=954  prepass_ran(transform_cache)=681
+  wrap_kind: none=173 cjs=92 esm=689
+  features: jsx=61 decorator=0 ts(ns|enum|import=|export=)=14
+  plain(no jsx/deco/ts) in node_modules: none=165 cjs=90 esm=609  | of which has_semantic=864
+  module_type: ts=378 js=534 json=3 tsx=39
+```
+
+| 필드 | 의미 |
+| --- | --- |
+| `node_modules=N (P%)` | 그래프 모듈 중 `/node_modules/` 경로 비율 |
+| `has_semantic=N` | semantic(scopes/symbols/refs) 데이터를 들고 있는 모듈 수 — linker 가 요구하므로 보통 전부 |
+| `prepass_ran(transform_cache)=N` | transformer pre-pass 가 돈 모듈 수 (`module.transform_cache != null`) |
+| `wrap_kind: none/cjs/esm` | scope-hoist(`none`) vs `__commonJS` vs `__esm` wrap |
+| `features: jsx/decorator/ts(...)` | 무거운 변환이 실제로 필요한 모듈 수 |
+| `plain(...) in node_modules` | "평범한"(jsx/deco/ts 없는) dep 을 wrap 종류별로 — `of which has_semantic` 이 곧 "모듈당 작업을 줄일 여지가 있는 후보 규모" |
+| `module_type: ...` | 확장자/타입별 카운트 |
+
+항목 추가 시 `dumpModuleStats` 와 이 표를 함께 갱신.
 
 ## 코드 사용법
 

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -491,9 +491,9 @@ fn copyDiagnostics(
     }
 }
 
-/// PoC (`ZNTC_MODULE_STATS=1`): "plain-dep 고속 경로" 견적용 모듈 분류 히스토그램.
+/// `ZNTC_DEBUG=module_stats` 진단: 모듈 분류 히스토그램 (docs/DEBUG.md §1).
 /// node_modules dep 중 JSX/decorator/TS-feature 없는 모듈이 얼마나 되고 그 중 semantic 데이터를
-/// 들고 있는지 = 모듈당 작업(semantic/metadata)을 통째로 스킵할 수 있는 후보 규모.
+/// 들고 있는지 = 모듈당 작업(semantic/metadata)이 어디 쏠려있는지 파악용.
 fn dumpModuleStats(graph: *ModuleGraph) void {
     var total: usize = 0;
     var nm: usize = 0; // node_modules
@@ -549,19 +549,21 @@ fn dumpModuleStats(graph: *ModuleGraph) void {
         e.value_ptr.* += 1;
     }
 
+    const debug_log = @import("../debug_log.zig");
     const pct = @as(f64, @floatFromInt(nm)) * 100.0 / @as(f64, @floatFromInt(@max(total, 1)));
-    std.debug.print(
-        "\n=== ZNTC module stats ===\n" ++
-            "total={d}  node_modules={d} ({d:.0}%)  has_semantic={d}  prepass_ran(transform_cache)={d}\n" ++
-            "wrap_kind: none={d} cjs={d} esm={d}\n" ++
-            "features: jsx={d} decorator={d} ts(ns|enum|import=|export=)={d}\n" ++
-            "plain(no jsx/deco/ts) in node_modules: none={d} cjs={d} esm={d}  | of which has_semantic={d}\n",
+    debug_log.print(
+        .module_stats,
+        "module stats\n" ++
+            "  total={d}  node_modules={d} ({d:.0}%)  has_semantic={d}  prepass_ran(transform_cache)={d}\n" ++
+            "  wrap_kind: none={d} cjs={d} esm={d}\n" ++
+            "  features: jsx={d} decorator={d} ts(ns|enum|import=|export=)={d}\n" ++
+            "  plain(no jsx/deco/ts) in node_modules: none={d} cjs={d} esm={d}  | of which has_semantic={d}\n" ++
+            "  module_type:",
         .{ total, nm, pct, has_sem, prepass_ran, w_none, w_cjs, w_esm, jsx, deco, ts_feat, plain_none_nm, plain_cjs_nm, plain_esm_nm, plain_nm_has_sem },
     );
     var hit = type_hist.iterator();
-    std.debug.print("module_type:", .{});
     while (hit.next()) |e| std.debug.print(" {s}={d}", .{ e.key_ptr.*, e.value_ptr.* });
-    std.debug.print("\n\n", .{});
+    std.debug.print("\n", .{});
 }
 
 pub const Bundler = struct {
@@ -1057,12 +1059,8 @@ pub const Bundler = struct {
         }
         graph_scope.end();
 
-        // PoC: ZNTC_MODULE_STATS=1 → 모듈 분류 히스토그램 (plain-dep 고속 경로 견적용).
-        // `std.posix.getenv` 은 Windows 미지원 — `getEnvVarOwned` 로 cross-platform 체크.
-        if (std.process.getEnvVarOwned(self.allocator, "ZNTC_MODULE_STATS") catch null) |v| {
-            self.allocator.free(v);
-            dumpModuleStats(&graph);
-        }
+        // ZNTC_DEBUG=module_stats → 모듈 분류 히스토그램 (docs/DEBUG.md §1).
+        if (@import("../debug_log.zig").enabled(.module_stats)) dumpModuleStats(&graph);
 
         // 2. 링킹 (scope hoisting)
         // code_splitting=true일 때는 글로벌 computeRenames를 건너뛴다.

--- a/src/debug_log.zig
+++ b/src/debug_log.zig
@@ -40,6 +40,10 @@ pub const Category = enum {
     string_intern,
     /// Runtime core-js usage detection and graph prelude decisions.
     runtime_polyfills,
+    /// 빌드 끝에 모듈 분류 히스토그램 출력 — 출처(node_modules/유저) · wrap 종류 ·
+    /// 변환 feature(jsx/decorator/ts) · semantic 보유 여부. 빌드 작업이 어디 쏠려있는지
+    /// 파악용. 다른 카테고리와 달리 멀티라인 블록을 출력한다 (`bundler.dumpModuleStats`).
+    module_stats,
 
     /// 카테고리 이름으로 enum 조회 (공백 제거 + 대소문자 무시).
     pub fn fromString(s: []const u8) ?Category {


### PR DESCRIPTION
`#3142` 의 "결정 필요" 중 하나 — module-classification 히스토그램을 어디 둘지.

## 결론: `ZNTC_DEBUG=module_stats` (debug-log 인프라)

- `--profile` (`ZNTC_PROFILE`) = phase 별 **타이밍**. 데이터 모델이 "duration" 인데 module stats 엔 duration 이 없음.
- `ZNTC_DEBUG` = **구조/상태 진단** (`[category] ...` stderr, NAPI `debug:[...]` 연동). module stats 는 빌드의 *모양*(어떤 모듈이 얼마나/어떤 종류로 들어왔나) 스냅샷 → 여기 속함.
- 둘은 보완 관계: `--profile` "metadata 3.2s" + `module_stats` "plain dep 864개" → "metadata 가 plain dep 처리에 쏠림" 으로 읽힘.

기존엔 bespoke `ZNTC_MODULE_STATS=1` env + `std.debug.print` 였음 (`432e1bcc` PoC). 이제:

- `debug_log.Category` 에 `module_stats` 추가 (`ZNTC_DEBUG=module_stats` / NAPI `debug: ['module_stats']`)
- `Bundler.bundle()` 이 `debug_log.enabled(.module_stats)` 로 게이트
- `dumpModuleStats` 가 `debug_log.print(.module_stats, …)` 로 출력 — 헤더 한 줄에 `[module_stats]` prefix, 본문 들여쓰기 (멀티라인이라 다른 카테고리의 `[cat] key=val` 한 줄과 다름)
- `docs/DEBUG.md`: 카테고리 표 정비(stale 했던 `transform_plan`/`string_intern`/`runtime_polyfills` 도 추가) + `module_stats` 활용 섹션(필드 표) + profile vs debug 구분 메모
- 옛 `ZNTC_MODULE_STATS` env 는 더 이상 안 읽음

## 출력 예 (`examples/react-native-bare`)

```
[module_stats] module stats
  total=954  node_modules=938 (98%)  has_semantic=954  prepass_ran(transform_cache)=681
  wrap_kind: none=173 cjs=92 esm=689
  features: jsx=61 decorator=0 ts(ns|enum|import=|export=)=14
  plain(no jsx/deco/ts) in node_modules: none=165 cjs=90 esm=609  | of which has_semantic=864
  module_type: ts=378 js=534 json=3 tsx=39
```

## 검증
- `zig build` ✅ / `zig build test` ✅ (debug_log.zig 테스트 포함)
- `ZNTC_DEBUG=module_stats` 동작 확인 / 옛 `ZNTC_MODULE_STATS=1` 은 inert
- 빌드 동작 변화 없음 (gating·출력 경로만 교체)

`#3142` 의 `ZNTC_MODULE_STATS` 항목 close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)