### PR TITLE
fix(transformer): preserve shorthand key in object_extensions lowering

### DIFF
--- a/src/transformer/es2015_shorthand.zig
+++ b/src/transformer/es2015_shorthand.zig
@@ -22,20 +22,24 @@ pub fn ES2015Shorthand(comptime Transformer: type) type {
         /// shorthand property를 full form으로 확장한다.
         /// { x } → { x: x }
         ///
-        /// key(identifier_reference)를 복제해서 value로 설정.
+        /// key 는 property name 이라 block_rename 대상이 아니므로 원본
+        /// identifier 를 그대로 복제한다. value 는 변수 참조라 visitNode 로
+        /// 변환해 block_scoping / scope hoist rename 을 적용 받아야 한다.
         pub fn expandShorthand(self: *Transformer, node: Node) Transformer.Error!NodeIndex {
-            const new_key = try self.visitNode(node.data.binary.left);
+            const left_idx = node.data.binary.left;
+            const original_left = self.ast.getNode(left_idx);
 
-            // key를 복제하여 value로 사용
-            const key_node = self.ast.getNode(new_key);
-            const new_value = try self.ast.addNode(.{
+            // key: 원본 이름 그대로. property name 이라 rename 대상 아님.
+            const new_key = try self.ast.addNode(.{
                 .tag = .identifier_reference,
-                .span = key_node.span,
-                .data = .{ .string_ref = key_node.data.string_ref },
+                .span = original_left.span,
+                .data = .{ .string_ref = original_left.data.string_ref },
             });
-            // scope hoisting rename이 value에도 적용되도록 symbol_id 복사.
-            // key는 프로퍼티 이름이므로 rename 불필요하나, value는 변수 참조이므로 필요.
-            self.copySymbolId(new_key, new_value);
+            // scope hoisting 등 다른 후속 transform 이 symbol 을 따라가도록 복사.
+            self.copySymbolId(left_idx, new_key);
+
+            // value: visitNode 가 block_rename / scope hoist 를 적용.
+            const new_value = try self.visitNode(left_idx);
 
             return self.ast.addNode(.{
                 .tag = .object_property,

--- a/src/transformer/transformer_test.zig
+++ b/src/transformer/transformer_test.zig
@@ -1482,6 +1482,42 @@ test "block scoping: private field property names are not lexical references" {
     try std.testing.expect(std.mem.indexOf(u8, code, "#value$") == null);
 }
 
+test "block scoping + object_extensions: shorthand key kept as property name" {
+    // `{ routes }` shorthand 의 key 는 property name 이라 block_rename 대상이
+    // 아니다. inner `routes` 가 outer `routes` 와 shadow 돼 `routes$N` 으로
+    // rename 되더라도 emit 결과는 `{ routes: routes$N }` 이어야 함.
+    // object_extensions + block_scoping 콤보에서 expandShorthand 가 key 도
+    // visitNode 로 rename 하던 누락을 가드한다.
+    const source =
+        \\let routes = "outer";
+        \\function f() {
+        \\  const routes = "inner";
+        \\  return { routes };
+        \\}
+    ;
+    var r = try parseAndTransformWithOptions(
+        std.testing.allocator,
+        source,
+        .{ .unsupported = .{
+            .block_scoping = true,
+            .object_extensions = true,
+        } },
+    );
+    defer r.deinit();
+    const code = try generateCode(&r);
+    defer std.testing.allocator.free(code);
+
+    // shadowing 으로 inner binding 이 rename 되어야 한다 (전제 확인).
+    try std.testing.expect(std.mem.indexOf(u8, code, "routes$") != null);
+    // key 는 원래 이름 (`routes`), value 는 rename 된 식별자.
+    // codegen 이 minified 또는 expanded 어느 쪽으로 emit 해도 잠근다.
+    try std.testing.expect(std.mem.indexOf(u8, code, "routes:routes$") != null or
+        std.mem.indexOf(u8, code, "routes: routes$") != null);
+    // 버그 형태 — key 자체가 rename 된 출력은 안 나와야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, code, "routes$1:") == null);
+    try std.testing.expect(std.mem.indexOf(u8, code, "routes$1 :") == null);
+}
+
 test "#1797 native for-of + block scoping: let 캡처 시 _loop 함수로 추출" {
     // RN preset은 for-of 문법은 유지하지만 block_scoping으로 let/const를 var로 낮춘다.
     // 이때 getter/closure가 loop binding을 캡처하면 native for-of 경로에서도 fresh binding


### PR DESCRIPTION
## 요약

PR #3141 follow-up #1/11. `939ec175` 가 `block_scoping = true` 에서 shorthand
value 의 implicit reference 가 rename 결과를 무시하던 문제를 고쳤지만, 같은
파일이 `object_extensions = true` 도 같이 켜고 있으면 `expandShorthand` 가
먼저 발동해 **key 까지** `visitNode` 로 변환 → `{ routes$1: routes$1 }` 같은
잘못된 출력이 만들어지는 케이스가 남아 있었다.

## 원인

`src/transformer/es2015_shorthand.zig` 의 `expandShorthand` 가 shorthand 의
binary.left (식별자) 를 `visitNode` 로 처리해 `new_key` 로 사용했다. 이때
block_rename / scope hoist rename 이 key 에도 적용되어 property name 이
바뀌어 버린다. ES2015 spec 상 shorthand 의 left 는 property name 의미와
value reference 의미를 동시에 가지지만, full form 으로 풀면 property name
은 원본을 유지해야 한다.

## 수정

- key: 원본 identifier 를 직접 복제 (`ast.addNode`), `copySymbolId` 로
  후속 transform 이 따라가도록 symbol 만 이어준다.
- value: `visitNode(left_idx)` 로 변환 — block_scoping / scope hoist rename
  적용 받음.

## 회귀 가드

`block_scoping = true` + `object_extensions = true` 콤보에서 inner shadow
가 발생할 때 `{ routes: routes\$N }` 형태가 emit 되는지 잠그는 unit test
(`block scoping + object_extensions: shorthand key kept as property name`)
를 추가. minified/expanded 양쪽 emit format 호환.

## 테스트

- `zig build test -Dtest-filter="shorthand"` — 44/44 통과
- `zig build test -Dtest-filter="block scoping"` — 47/47 통과
- 전체 `zig build test` — 4942/4946 통과 (4 skipped, 0 failed)