### PR TITLE
fix(transformer): isolate stage3 accessor backing storage names

### DIFF
--- a/src/codegen/codegen_test/decorator.zig
+++ b/src/codegen/codegen_test/decorator.zig
@@ -572,6 +572,29 @@ test "stage3: private accessor decorator strips # from backing storage name" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "set #x(") != null);
 }
 
+test "stage3: accessor + private accessor sharing base name get unique backing storage" {
+    // 같은 base name (`x`) 의 public + private accessor 가 한 class 에 동거할
+    // 때 backing storage 이름이 충돌하면 안 된다. `extractCleanVarName` 이
+    // 둘 다 "x" 를 반환하므로 단일 `allocPrint` 라면 같은 `#_x_accessor_storage`
+    // 가 두 개 생성됨. PrivateNameAllocator 가 충돌 회피.
+    var r = try e2eStage3Decorator(std.testing.allocator,
+        \\class Foo {
+        \\  @dec accessor x = 1;
+        \\  @dec accessor #x = 2;
+        \\}
+    );
+    defer r.deinit();
+    // 첫 번째 storage 는 `#_x_accessor_storage`, 두 번째는 suffix 변형.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "#_x_accessor_storage") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "#_x_accessor_storage2") != null);
+    // public accessor 의 get x() / set x()
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "get x()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "set x(") != null);
+    // private accessor 의 get #x() / set #x()
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "get #x()") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "set #x(") != null);
+}
+
 // --- No decorator → passthrough ---
 
 test "stage3: no decorator → class preserved as-is" {

--- a/src/transformer/transformer/stage3_decorator_transform.zig
+++ b/src/transformer/transformer/stage3_decorator_transform.zig
@@ -32,6 +32,12 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
     // 런타임 헬퍼 사용 표시
     self.runtime_helpers.es_decorator = true;
 
+    // accessor backing storage 이름 충돌 회피용 — 같은 base name 의 public/
+    // private accessor 가 한 class 에 동거하거나, 사용자 코드가 동일 이름의
+    // identifier 를 이미 사용 중이면 PrivateNameAllocator 가 suffix 로 회피.
+    var private_name_allocator = try es_helpers.PrivateNameAllocator.init(self.allocator, self.ast);
+    defer private_name_allocator.deinit();
+
     // 클래스 이름, super, body, decorator 추출
     const name_idx = self.readNodeIdx(e, ast_mod.ClassExtra.name);
     const super_idx = self.readNodeIdx(e, ast_mod.ClassExtra.super);
@@ -302,8 +308,14 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                         .deco_var_name = deco_vname,
                     });
 
-                    // accessor → private backing field + getter + setter
-                    const storage_name = try std.fmt.allocPrint(self.allocator, "#_{s}_accessor_storage", .{var_n});
+                    // accessor → private backing field + getter + setter.
+                    // PrivateNameAllocator 가 `_x_accessor_storage` → 이미 사용
+                    // 중이면 `_x_accessor_storage2` 처럼 회피.
+                    const storage_base = try std.fmt.allocPrint(self.allocator, "_{s}_accessor_storage", .{var_n});
+                    defer self.allocator.free(storage_base);
+                    const storage_local = try private_name_allocator.makeUniqueName(storage_base);
+                    defer self.allocator.free(storage_local);
+                    const storage_name = try std.fmt.allocPrint(self.allocator, "#{s}", .{storage_local});
                     defer self.allocator.free(storage_name);
                     const storage_span = try self.ast.addString(storage_name);
                     const storage_key = try self.ast.addNode(.{


### PR DESCRIPTION
## 요약

PR #3141 follow-up #2/11. \`51e75600\` 이 도입한 stage3 auto-accessor backing
storage 이름 \`#_{name}_accessor_storage\` 가 \`std.fmt.allocPrint\` 직접
조립이라, \`44400a9c\` 가 도입한 \`PrivateNameAllocator\` 의 충돌 회피를
거치지 않았다.

## 원인

다음 조합에서 충돌:
- 같은 class 안 \`@dec accessor x\` + \`@dec accessor #x\` — 둘 다
  \`extractCleanVarName\` 결과가 \"x\" 라 같은 \`#_x_accessor_storage\` 생성
- 사용자 코드가 동일 이름의 private identifier 를 이미 사용 중인 경우

## 수정

- \`transformStage3Decorators\` 진입 시 \`PrivateNameAllocator\` 인스턴스 init
  (\`self.allocator\`, \`self.ast\` 전체 스캔)
- accessor backing storage 마다 \`makeUniqueName(\"_x_accessor_storage\")\` 로
  unique local name 얻은 뒤 \`#\` prefix 만 다시 붙여 최종 \`storage_name\` 사용
- 함수 종료 시 deinit

## 회귀 가드

\`stage3: accessor + private accessor sharing base name get unique
backing storage\` — 같은 base name \"x\" 의 public + private accessor 가
한 class 에서 각각 \`#_x_accessor_storage\` / \`#_x_accessor_storage2\` 로
분리되어 emit 되고, getter/setter 도 정상 생성됨을 확인.

## 테스트

- \`zig build test -Dtest-filter=\"stage3:\"\` — 60/60 통과
- 전체 \`zig build test\` — 4945/4949 통과 (4 skipped, 0 failed)