### PR TITLE
refactor(core): options object for buildRnBundleOverride

### DIFF
--- a/packages/core/bin/rn-dev-input.mjs
+++ b/packages/core/bin/rn-dev-input.mjs
@@ -81,7 +81,25 @@ function assignRnBuildOptionOverrides(out, config, opts = {}) {
   }
 }
 
-export function buildRnBundleOverride(config, opts = {}, override) {
+/**
+ * Internal helper — RN dev/bundle 경로의 `bundle.override` 객체를 구성한다.
+ * `@zntc/core` package.json `exports` 에 노출되지 않는 CLI bin 전용. 외부에서
+ * deep import 로 호출하지 말 것.
+ *
+ * @param {object} input
+ * @param {object} [input.config]   사용자 `zntc.config.{ts,js,json}` 의 root 객체.
+ *   `alias` / `moduleSpecifierMap` 같은 dict 타입은 RN preset 으로 forwarding.
+ *   `experimentalDecorators` 등은 BuildOptions override 로 forward.
+ * @param {object} [input.opts]     CLI flag 가 우선 적용된 RuntimeOptions
+ *   (`experimentalDecorators`/`emitDecoratorMetadata`/`useDefineForClassFields`).
+ *   config 와 OR 로 합산.
+ * @param {object} [input.override] 호출자(zntc.mjs) 가 build 결과 후 caller-side
+ *   write 를 처리할 때 강제로 덮어 씌우고 싶은 BuildOptions (예: `outfile`,
+ *   `write`). 마지막에 `Object.assign` 으로 머지.
+ * @returns {object | undefined} 빈 object 면 `undefined` 반환 — caller 의 spread/
+ *   merge 로직이 noop 으로 처리되도록.
+ */
+export function buildRnBundleOverride({ config, opts = {}, override } = {}) {
   const cfg = config ?? {};
   const out = {};
   if (cfg.alias && typeof cfg.alias === 'object') {
@@ -147,7 +165,7 @@ export function buildRnDevServerInput(opts, config) {
         cfg.minify ||
         false,
       extra: buildRnBundleExtra(cfg, opts),
-      override: buildRnBundleOverride(cfg, opts),
+      override: buildRnBundleOverride({ config: cfg, opts }),
     },
     port: opts.port ?? server.port ?? 8081,
     host: opts.host ?? server.host ?? 'localhost',

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -768,11 +768,11 @@ async function runRnBundle(opts, config) {
     minify:
       opts.minify || opts.minifyWhitespace || opts.minifyIdentifiers || opts.minifySyntax || false,
     extra: buildRnBundleExtra(cfg, opts),
-    override: buildRnBundleOverride(
-      cfg,
+    override: buildRnBundleOverride({
+      config: cfg,
       opts,
-      outfile && !callerWrite ? { outfile, write: true } : undefined,
-    ),
+      override: outfile && !callerWrite ? { outfile, write: true } : undefined,
+    }),
   });
 
   // caller-side write — bundle / sourcemap path 분리 + URL override 적용.

--- a/packages/core/test/cli/react-native-dev-input/bundle-options.ts
+++ b/packages/core/test/cli/react-native-dev-input/bundle-options.ts
@@ -1,3 +1,4 @@
+import './bundle-options/build-override';
 import './bundle-options/resolver';
 import './bundle-options/runtime-config';
 import './bundle-options/serializer';

--- a/packages/core/test/cli/react-native-dev-input/bundle-options/build-override.ts
+++ b/packages/core/test/cli/react-native-dev-input/bundle-options/build-override.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from '../../helpers';
+import { loadBuildRnBundleOverride } from '../helpers';
+
+describe('buildRnBundleOverride — options object 시그니처', () => {
+  test('빈 인자 — undefined 반환', async () => {
+    const buildRnBundleOverride = await loadBuildRnBundleOverride();
+    expect(buildRnBundleOverride()).toBeUndefined();
+    expect(buildRnBundleOverride({})).toBeUndefined();
+    expect(buildRnBundleOverride({ config: {} })).toBeUndefined();
+  });
+
+  test('config.alias → out.alias', async () => {
+    const buildRnBundleOverride = await loadBuildRnBundleOverride();
+    const out = buildRnBundleOverride({
+      config: { alias: { '~': '/abs/src' } },
+    });
+    expect(out?.alias).toEqual({ '~': '/abs/src' });
+  });
+
+  test('config.moduleSpecifierMap → out.moduleSpecifierMap', async () => {
+    const buildRnBundleOverride = await loadBuildRnBundleOverride();
+    const out = buildRnBundleOverride({
+      config: { moduleSpecifierMap: { lodash: 'lodash/{name}' } },
+    });
+    expect(out?.moduleSpecifierMap).toEqual({ lodash: 'lodash/{name}' });
+  });
+
+  test('opts.experimentalDecorators → out.experimentalDecorators', async () => {
+    const buildRnBundleOverride = await loadBuildRnBundleOverride();
+    const out = buildRnBundleOverride({
+      config: {},
+      opts: { experimentalDecorators: true },
+    });
+    expect(out?.experimentalDecorators).toBe(true);
+  });
+
+  test('config.experimentalDecorators (opts 미지정) → out.experimentalDecorators', async () => {
+    const buildRnBundleOverride = await loadBuildRnBundleOverride();
+    const out = buildRnBundleOverride({
+      config: { experimentalDecorators: true },
+    });
+    expect(out?.experimentalDecorators).toBe(true);
+  });
+
+  test('CLI opts 우선 — opts.useDefineForClassFields=false 가 config.true 덮음', async () => {
+    const buildRnBundleOverride = await loadBuildRnBundleOverride();
+    const out = buildRnBundleOverride({
+      config: { useDefineForClassFields: true },
+      opts: { useDefineForClassFields: false },
+    });
+    expect(out?.useDefineForClassFields).toBe(false);
+  });
+
+  test('override 인자 — 가장 마지막 Object.assign 으로 덮어쓰기', async () => {
+    const buildRnBundleOverride = await loadBuildRnBundleOverride();
+    const out = buildRnBundleOverride({
+      config: { experimentalDecorators: true },
+      override: { outfile: '/out/bundle.js', write: true },
+    });
+    expect(out?.experimentalDecorators).toBe(true);
+    expect(out?.outfile).toBe('/out/bundle.js');
+    expect(out?.write).toBe(true);
+  });
+
+  test('override 가 config 의 값을 덮음', async () => {
+    const buildRnBundleOverride = await loadBuildRnBundleOverride();
+    const out = buildRnBundleOverride({
+      config: { alias: { '~': '/abs/src' } },
+      override: { alias: { '~': '/override/src' } },
+    });
+    expect(out?.alias).toEqual({ '~': '/override/src' });
+  });
+});

--- a/packages/core/test/cli/react-native-dev-input/helpers.ts
+++ b/packages/core/test/cli/react-native-dev-input/helpers.ts
@@ -3,6 +3,11 @@ export async function loadBuildRnDevServerInput() {
   return buildRnDevServerInput;
 }
 
+export async function loadBuildRnBundleOverride() {
+  const { buildRnBundleOverride } = await import('../../../bin/rn-dev-input.mjs');
+  return buildRnBundleOverride;
+}
+
 export function captureStderr<T>(callback: () => T): { result: T; output: string } {
   const original = process.stderr.write.bind(process.stderr);
   const writes: string[] = [];


### PR DESCRIPTION
## 요약

PR #3141 follow-up #6/11. \`733959e8\` 가 \`buildRnBundleOverride\` 의 두 번째
positional 인자로 \`opts\` 를 추가하면서 \`(config, opts, override)\` 순서가
됐다. external user 가 \`(config, override)\` 형태로 호출하면 \`override\` 가
\`opts\` 로 잘못 흡수될 위험.

internal CLI helper (\`@zntc/core\` package.json \`exports\` 미노출) 이지만,
명시성 + 다음 인자 추가 시 같은 회귀 방지를 위해 options object 시그니처로
정리.

## 변경

- \`buildRnBundleOverride(config, opts, override)\` → \`buildRnBundleOverride
  ({ config, opts, override })\`
- JSDoc 추가 — internal helper 명시, 각 필드 의미와 사용처 설명
- 호출처 2 갱신 (rn-dev-input / zntc.mjs)

## 회귀 가드

\`test/cli/react-native-dev-input/bundle-options/build-override.ts\` —
8개 direct unit test. config.alias / moduleSpecifierMap / experimentalDecorators
forwarding, opts vs config 우선순위, override 의 최종 \`Object.assign\` 머지.

## 테스트

- \`bun test ./test/cli/react-native-dev-input.ts\` — 41/41 통과