### PR TITLE
chore(bundler): remove dead Module.interop helper

### DIFF
--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -469,13 +469,6 @@ pub const Module = struct {
         return symbol_mod.SymbolRef.invalid;
     }
 
-    /// CJS importee에 대한 interop 모드 결정 (Rolldown 방식).
-    /// importer(self)가 ESM 정의 형식이면 Node 모드, 아니면 Babel 모드.
-    pub fn interop(self: *const Module, importee: *const Module) ?types.Interop {
-        if (importee.exports_kind != .commonjs) return null;
-        return if (self.def_format.isEsm()) .node else .babel;
-    }
-
     pub fn canUseDirectCjsDefaultImport(self: *const Module, importee: *const Module) bool {
         return importee.wrap_kind == .cjs and
             importee.can_skip_cjs_default_interop and


### PR DESCRIPTION
## 요약

PR #3141 follow-up #7/11. \`Module.interop()\` 가 호출처 0건. PR #3141 의
\`7eb23629\` 가 \`cjsInteropMode\` 로 같은 의미를 platform-aware 하게 대체.

## 변경

\`src/bundler/module.zig\` 의 \`Module.interop\` 함수 + doc-comment 제거 (7줄).

## 회귀 가드

- 전체 \`zig build test\` 4940 + 4 skipped 통과 — dead code 제거 후 build
  가 깨지지 않음 자체가 caller 부재의 직접 증명
- \`7eb23629\` 가 도입한 \`Runtime helper shadow: private field set helper
  avoids UMD global helper overwrite\` 등 기존 회귀 가드 그대로 통과