### PR TITLE
docs(bundler): document mixed CJS branch order invariant in finalize

### DIFF
--- a/src/bundler/graph/finalize.zig
+++ b/src/bundler/graph/finalize.zig
@@ -32,6 +32,11 @@ pub fn promoteExportsKinds(self: *ModuleGraph) void {
                     target.exports_kind = .commonjs;
                     target.wrap_kind = .cjs;
                 } else if (shouldUseMetroCjsForMixedModule(self, target)) {
+                    // 분기 순서 invariant: mixed (`.esm_with_dynamic_fallback` +
+                    // CJS export signal) 분기는 반드시 `.isEsm()` 분기보다 위에
+                    // 있어야 한다 (#3141 2dfb2620). `esm_with_dynamic_fallback` 도
+                    // `isEsm()==true` 라 순서가 뒤집히면 mixed 가 강제로 ESM 으로
+                    // 처리되어 `module.exports =` 가 wrapper 안에서 ReferenceError.
                     target.exports_kind = .commonjs;
                     target.wrap_kind = .cjs;
                 } else if (target.exports_kind.isEsm()) {
@@ -101,6 +106,8 @@ pub fn promoteExportsKinds(self: *ModuleGraph) void {
         var it = self.modules.iterator(0);
         while (it.next()) |m| {
             if (m.wrap_kind != .none) continue;
+            // 분기 순서 invariant: Pass 1 과 동일 — mixed 분기는 반드시 `.isEsm()`
+            // 분기보다 위. Pass 3 의 wrap-all 로 흘러올 때도 같은 함정.
             if (shouldUseMetroCjsForMixedModule(self, m)) {
                 m.exports_kind = .commonjs;
                 m.wrap_kind = .cjs;


### PR DESCRIPTION
## 요약

PR #3141 follow-up #8/11. \`2dfb2620\` 가 추가한 \`shouldUseMetroCjsForMixed
Module\` 분기가 \`.isEsm()\` 분기 위에 있어야 동작하는 fragility — 순서가
뒤집히면 \`esm_with_dynamic_fallback\` (= isEsm()==true) 가 ESM 으로 잘못
처리되어 \`module.exports =\` 가 wrapper 안에서 ReferenceError.

## 변경

Pass 1 (line 31-46) 과 Pass 3 (line 100+) 둘 다 같은 함정 — 양쪽에 invariant
명시 주석 추가 (7 라인 코멘트).

## 회귀 가드

이미 \`bundler_test/cjs_esm.zig\` 의 mixed CJS wrap test 가 분기 순서가
뒤집히면 실패하도록 잠금 — 주석만 추가하는 본 PR 은 별도 unit test 불필요.
전체 \`zig build test\` 4940 + 4 skipped 통과.