### PR TITLE
fix(transformer): zntc RN 런타임 회귀 수정

### DIFF
--- a/packages/core/bin/rn-dev-input.mjs
+++ b/packages/core/bin/rn-dev-input.mjs
@@ -64,7 +64,7 @@ export function buildRnBundleExtra(config, opts = {}) {
     inlineSourceMap: serializer.inlineSourceMap ?? undefined,
     sourceRoot: cfg.sourcemapSourcesRoot ?? undefined,
     silentConsoleErrorPatterns: server.silentConsoleErrorPatterns ?? undefined,
-    forwardClientLogs: server.forwardClientLogs === true,
+    forwardClientLogs: server.forwardClientLogs !== false,
   };
 }
 

--- a/packages/core/test/cli/react-native-dev-input/server.ts
+++ b/packages/core/test/cli/react-native-dev-input/server.ts
@@ -100,4 +100,19 @@ describe('buildRnDevServerInput — server config 추출 (#2605)', () => {
     expect(input?.bundle.extra?.forwardClientLogs).toBe(true);
     expect(input?.hmr).toBe(false);
   });
+
+  test('config.server.forwardClientLogs 기본값은 Metro 와 같이 true', async () => {
+    const buildRnDevServerInput = await loadBuildRnDevServerInput();
+    const input = buildRnDevServerInput({ entryPoints: ['i.js'] }, {});
+    expect(input?.bundle.extra?.forwardClientLogs).toBe(true);
+  });
+
+  test('config.server.forwardClientLogs=false → dev server input false', async () => {
+    const buildRnDevServerInput = await loadBuildRnDevServerInput();
+    const input = buildRnDevServerInput(
+      { entryPoints: ['i.js'] },
+      { server: { forwardClientLogs: false } },
+    );
+    expect(input?.bundle.extra?.forwardClientLogs).toBe(false);
+  });
 });

--- a/packages/react-native/runtime/zntc-hmr-client.cjs
+++ b/packages/react-native/runtime/zntc-hmr-client.cjs
@@ -7,6 +7,9 @@
 
 var REFRESH_TEXT_COLOR = -1; // #ffffff
 var REFRESH_BACKGROUND_COLOR = -14318360; // #2584e8
+var BUFFER_LIMIT = 1024 * 1024;
+var prettyFormat = require('pretty-format');
+var prettyFormatImpl = prettyFormat && (prettyFormat.default || prettyFormat);
 
 function getRoot() {
   return (
@@ -99,10 +102,21 @@ function getDevLoadingView() {
   return null;
 }
 
+function formatLogItem(item) {
+  if (typeof item === 'string') return item;
+  return prettyFormatImpl.format(item, {
+    escapeString: true,
+    highlight: true,
+    maxDepth: 3,
+    min: true,
+    plugins: [prettyFormatImpl.plugins.ReactElement],
+  });
+}
+
 var HMRClient = {
   _socket: null,
   _enabled: true,
-  _originalConsole: null,
+  _pendingLogs: [],
   // 중첩 update 카운트 — 마지막 update-done 에서만 배너 hide.
   _pendingUpdates: 0,
   // lazy cache — 첫 호출 때 1회 lookup (native module 가 setup 시점엔 아직 미로드).
@@ -141,12 +155,36 @@ var HMRClient = {
     // No-op: ZNTC bundler does not require bundle registration
   },
 
+  _sendLog: function (level, data) {
+    var socket = this._socket;
+    if (!socket || socket.readyState !== 1 || socket.bufferedAmount > BUFFER_LIMIT) {
+      return false;
+    }
+    try {
+      var formatted = Array.prototype.map.call(data || [], function (item) {
+        return formatLogItem(item);
+      });
+      socket.send(JSON.stringify({ type: 'log', level: level, data: formatted }));
+      return true;
+    } catch {
+      return false;
+    }
+  },
+
+  _flushPendingLogs: function () {
+    var pending = this._pendingLogs;
+    this._pendingLogs = [];
+    for (var i = 0; i < pending.length; i++) {
+      this._sendLog(pending[i][0], pending[i][1]);
+    }
+  },
+
   log: function (level, data) {
-    if (this._socket && this._socket.readyState === 1) {
-      try {
-        this._socket.send(JSON.stringify({ type: 'log', level: level, data: data }));
-      } catch {
-        // ignore
+    if (this._sendLog(level, data)) return;
+    if (!this._socket) {
+      this._pendingLogs.push([level, data]);
+      if (this._pendingLogs.length > 100) {
+        this._pendingLogs.shift();
       }
     }
   },
@@ -172,52 +210,7 @@ var HMRClient = {
           platform: platform,
         }),
       );
-
-      var forwardClientLogs =
-        typeof __ZNTC_FORWARD_CLIENT_LOGS__ !== 'undefined' ? __ZNTC_FORWARD_CLIENT_LOGS__ : false;
-      if (forwardClientLogs === true && self._originalConsole == null) {
-        self._originalConsole = {};
-        // RN dev mode 는 idle 에도 LogBox/Animated/bridge 가 console 을 frame 단위로
-        // 호출. wrap 안에서 큰 객체를 deep-clone 하면 RN Fiber/props graph 가 매 frame
-        // 복제돼 GC 가 못 따라가고 RAM 이 grow (#2885). single-pass stringify +
-        // circular replacer + bufferedAmount 가드로 fix.
-        var levels = ['log', 'info', 'warn', 'error', 'debug'];
-        // server 가 burst 를 못 따라가면 native send buffer 에 누적 — 1MB 초과 시 drop.
-        // dev 메시지 forwarding 은 best-effort.
-        var BUFFER_LIMIT = 1024 * 1024;
-        for (var i = 0; i < levels.length; i++) {
-          (function (level) {
-            var original = console[level];
-            if (typeof original === 'function') {
-              self._originalConsole[level] = original;
-              console[level] = function () {
-                original.apply(console, arguments);
-                if (socket.readyState !== 1) return;
-                if (socket.bufferedAmount > BUFFER_LIMIT) return;
-                var argsLen = arguments.length;
-                var args = Array.from({ length: argsLen });
-                for (var j = 0; j < argsLen; j++) args[j] = arguments[j];
-                // seen / replacer 를 호출별 local 로 — toString 등으로 인한 reentrancy
-                // (console.log 가 다른 console.log 를 trigger) 에도 안전.
-                var seen = [];
-                var replacer = function (_key, value) {
-                  if (value instanceof Error) return value.message;
-                  if (typeof value === 'object' && value !== null) {
-                    if (seen.indexOf(value) !== -1) return '[Circular]';
-                    seen.push(value);
-                  }
-                  return value;
-                };
-                try {
-                  socket.send(JSON.stringify({ type: 'log', level: level, data: args }, replacer));
-                } catch {
-                  // serialization 실패 — drop
-                }
-              };
-            }
-          })(levels[i]);
-        }
-      }
+      self._flushPendingLogs();
     };
 
     socket.onmessage = function (event) {
@@ -237,8 +230,7 @@ var HMRClient = {
             break;
           case 'hmr:update':
             // hmr-client debug — __ZNTC_HMR_DEBUG__ true 시에만 update 도착/주입
-            // 진행 로그 출력. default false — forwardClientLogs 로 터미널 forwarding
-            // 시 사용자 앱 console.log 가 시스템 노이즈에 묻히지 않게.
+            // 진행 로그 출력. 터미널 forwarding 여부와 별개로 기본 비활성화.
             var hmrDebug = typeof __ZNTC_HMR_DEBUG__ !== 'undefined' ? __ZNTC_HMR_DEBUG__ : false;
             if (hmrDebug) {
               console.log(
@@ -319,15 +311,6 @@ var HMRClient = {
     };
 
     socket.onclose = function () {
-      // console intercept 복원 — reconnect 시 stale closure / 중복 wrap 방지.
-      if (self._originalConsole) {
-        for (var level in self._originalConsole) {
-          if (Object.prototype.hasOwnProperty.call(self._originalConsole, level)) {
-            console[level] = self._originalConsole[level];
-          }
-        }
-        self._originalConsole = null;
-      }
       // 중첩 update 도중 socket drop 시 stuck banner 방지.
       if (self._pendingUpdates > 0) {
         self._pendingUpdates = 0;

--- a/packages/react-native/src/dev-server/hmr-bridge.test.ts
+++ b/packages/react-native/src/dev-server/hmr-bridge.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, test } from 'bun:test';
+import { Buffer } from 'node:buffer';
+import { EventEmitter } from 'node:events';
+import type { IncomingMessage } from 'node:http';
+import type { Socket } from 'node:net';
 
 import type { WatchHandle, WatchRebuildEvent } from '@zntc/core';
 
@@ -51,6 +55,35 @@ function rebuild(overrides: Partial<WatchRebuildEvent> = {}): WatchRebuildEvent 
     graphChanged: false,
     ...overrides,
   } as WatchRebuildEvent;
+}
+
+class MockSocket extends EventEmitter {
+  written: Buffer[] = [];
+  destroyed = false;
+  write(chunk: Buffer | string): boolean {
+    this.written.push(typeof chunk === 'string' ? Buffer.from(chunk) : Buffer.from(chunk));
+    return true;
+  }
+  destroy(): void {
+    this.destroyed = true;
+  }
+}
+
+function fakeUpgradeRequest(): IncomingMessage {
+  return {
+    headers: { 'sec-websocket-key': 'dGhlIHNhbXBsZSBub25jZQ==' },
+  } as unknown as IncomingMessage;
+}
+
+function clientTextFrame(text: string): Buffer {
+  const payload = Buffer.from(text);
+  const mask = Buffer.from([1, 2, 3, 4]);
+  const header = Buffer.from([0x81, 0x80 | payload.length]);
+  const masked = Buffer.allocUnsafe(payload.length);
+  for (let i = 0; i < payload.length; i++) {
+    masked[i] = payload[i]! ^ mask[i % 4]!;
+  }
+  return Buffer.concat([header, mask, masked]);
 }
 
 describe('createHmrBridge — onRebuild', () => {
@@ -154,5 +187,71 @@ describe('createHmrBridge — acceptUpgrade', () => {
   test('path readonly 노출', () => {
     const bridge = createHmrBridge({ path: '/__zntc_hot__' });
     expect(bridge.path).toBe('/__zntc_hot__');
+  });
+});
+
+describe('createHmrBridge — client log forwarding', () => {
+  test('forwardClientLogs 기본값 true — Metro 처럼 incoming log 를 터미널에 출력', () => {
+    const bridge = createHmrBridge({ path: '/hot' });
+    const socket = new MockSocket();
+    const original = console.log;
+    const calls: unknown[][] = [];
+    console.log = (...args: unknown[]) => {
+      calls.push(args);
+    };
+    try {
+      bridge.acceptUpgrade(fakeUpgradeRequest(), socket as unknown as Socket);
+      socket.emit(
+        'data',
+        clientTextFrame(JSON.stringify({ type: 'log', level: 'error', data: ['boom'] })),
+      );
+    } finally {
+      console.log = original;
+    }
+    expect(calls).toHaveLength(1);
+    expect(String(calls[0]![0])).toContain('ERROR');
+    expect(String(calls[0]![0])).toContain('boom');
+  });
+
+  test('forwardClientLogs=false — incoming log 를 터미널에 출력하지 않음', () => {
+    const bridge = createHmrBridge({ path: '/hot', forwardClientLogs: false });
+    const socket = new MockSocket();
+    const original = console.log;
+    const calls: unknown[][] = [];
+    console.log = (...args: unknown[]) => {
+      calls.push(args);
+    };
+    try {
+      bridge.acceptUpgrade(fakeUpgradeRequest(), socket as unknown as Socket);
+      socket.emit(
+        'data',
+        clientTextFrame(JSON.stringify({ type: 'log', level: 'error', data: ['boom'] })),
+      );
+    } finally {
+      console.log = original;
+    }
+    expect(calls).toEqual([]);
+  });
+
+  test('forwardClientLogs=true — incoming log 를 터미널에 출력', () => {
+    const bridge = createHmrBridge({ path: '/hot', forwardClientLogs: true });
+    const socket = new MockSocket();
+    const original = console.log;
+    const calls: unknown[][] = [];
+    console.log = (...args: unknown[]) => {
+      calls.push(args);
+    };
+    try {
+      bridge.acceptUpgrade(fakeUpgradeRequest(), socket as unknown as Socket);
+      socket.emit(
+        'data',
+        clientTextFrame(JSON.stringify({ type: 'log', level: 'error', data: ['boom'] })),
+      );
+    } finally {
+      console.log = original;
+    }
+    expect(calls).toHaveLength(1);
+    expect(String(calls[0]![0])).toContain('ERROR');
+    expect(String(calls[0]![0])).toContain('boom');
   });
 });

--- a/packages/react-native/src/dev-server/hmr-bridge.ts
+++ b/packages/react-native/src/dev-server/hmr-bridge.ts
@@ -20,6 +20,8 @@ export interface HmrBridgeOptions {
   readonly path: string;
   /** rebuild log 출력 비활성 (test 환경). default false. */
   readonly silent?: boolean;
+  /** Metro `server.forwardClientLogs` 호환. default true. */
+  readonly forwardClientLogs?: boolean;
 }
 
 export interface HmrBridge {
@@ -28,10 +30,7 @@ export interface HmrBridge {
   readonly path: string;
   /** http upgrade chain 안에서 호출 — channel.accept + initial greeting. */
   acceptUpgrade(req: IncomingMessage, socket: Socket): void;
-  /**
-   * RN runtime console.log forwarding 출력 표시 toggle. 새 상태 반환. server-side
-   * mute 라 클라이언트는 계속 보냄 — 트래픽 절약하려면 forwardClientLogs OFF 로 build.
-   */
+  /** RN runtime console.log forwarding 출력 표시 toggle. 새 상태 반환. */
   toggleLogs(): boolean;
 }
 
@@ -139,7 +138,7 @@ function buildAckFrame(): Buffer {
 export function createHmrBridge(options: HmrBridgeOptions): HmrBridge {
   const adapter = createMetroHmrAdapter();
   const onRebuild = buildOnRebuild(adapter, { silent: options.silent });
-  let logsEnabled = true;
+  let logsEnabled = options.forwardClientLogs !== false;
   adapter.channel.onIncoming(buildIncomingHandler(adapter, () => logsEnabled));
 
   return {

--- a/packages/react-native/src/dev-server/serve.ts
+++ b/packages/react-native/src/dev-server/serve.ts
@@ -89,7 +89,11 @@ export async function serveRn(
 
   // hmrBridge 먼저 생성 — registry callback 으로 onRebuild 전달.
   const hmrBridge = options.hmr
-    ? createHmrBridge({ path: HMR_PATH, silent: extras.silent })
+    ? createHmrBridge({
+        path: HMR_PATH,
+        silent: extras.silent,
+        forwardClientLogs: options.bundle.extra?.forwardClientLogs,
+      })
     : undefined;
   const platforms = createPlatformStateRegistry(options, hmrBridge?.callbacks);
 

--- a/packages/react-native/src/plugins/asset.test.ts
+++ b/packages/react-native/src/plugins/asset.test.ts
@@ -48,14 +48,14 @@ describe('createAssetPlugin', () => {
 
     const result = hmrHandler.handler({ path: '/abs/Libraries/Utilities/HMRClient.js' });
     expect(result).toEqual({
-      contents: ZNTC_HMR_CLIENT_CODE.replace(/__ZNTC_FORWARD_CLIENT_LOGS__/g, 'false'),
+      contents: ZNTC_HMR_CLIENT_CODE,
     });
   });
 
-  test('forwardClientLogs=true — HMR runtime flag true 로 치환', () => {
-    const handlers = captureHandlers({ ...baseConfig, forwardClientLogs: true });
+  test('HMR runtime source 는 client console wrap flag 를 주입하지 않음', () => {
+    const handlers = captureHandlers(baseConfig);
     const result = handlers[0]!.handler({ path: '/abs/Libraries/Utilities/HMRClient.js' });
-    expect(result?.contents).toContain('typeof true');
+    expect(result?.contents).toBe(ZNTC_HMR_CLIENT_CODE);
     expect(result?.contents).not.toContain('__ZNTC_FORWARD_CLIENT_LOGS__');
   });
 

--- a/packages/react-native/src/plugins/asset.ts
+++ b/packages/react-native/src/plugins/asset.ts
@@ -71,10 +71,7 @@ export function createAssetPlugin(config: PluginConfig): ZntcPlugin {
       // HMRClient.js path 매칭 — onLoad 응답으로 ZNTC_HMR_CLIENT_CODE 그대로.
       const hmrClientPattern = new RegExp(`${escapeRegex(HMR_CLIENT_SUFFIX)}$`);
       build.onLoad({ filter: hmrClientPattern }, () => ({
-        contents: ZNTC_HMR_CLIENT_CODE.replace(
-          /__ZNTC_FORWARD_CLIENT_LOGS__/g,
-          config.forwardClientLogs === true ? 'true' : 'false',
-        ),
+        contents: ZNTC_HMR_CLIENT_CODE,
       }));
 
       const hasSvgSource = config.sourceExts.some((e) => normalizeExt(e).toLowerCase() === '.svg');

--- a/packages/react-native/src/plugins/types.ts
+++ b/packages/react-native/src/plugins/types.ts
@@ -18,8 +18,6 @@ export interface PluginConfig {
   sourceExts: string[];
   /** Metro 호환 custom file transformer path (예: react-native-svg-transformer). */
   babelTransformerPath?: string;
-  /** RN runtime console.* forwarding to dev-server terminal. */
-  forwardClientLogs?: boolean;
   /**
    * Inline babel preset / plugin (zntc.config.ts 의 `transformer.babel`). 사용자
    * babel.config.js 의 plugins 와 concat 되며 양쪽 모두 ZNTC native filter 통과

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -420,6 +420,16 @@ describe('buildRnBundleOptions — extra (watchFolders / blockList / fallback)',
     expect(opts.disableHierarchicalLookup).toBeUndefined();
   });
 
+  test('preserveSymlinks — Metro처럼 pnpm logical path 기준으로 bare import 해석', () => {
+    const opts = buildRnBundleOptions(baseInput({}));
+    expect(opts.preserveSymlinks).toBe(true);
+  });
+
+  test('preserveSymlinks — 사용자 override 는 마지막에 적용', () => {
+    const opts = buildRnBundleOptions(baseInput({ override: { preserveSymlinks: false } }));
+    expect(opts.preserveSymlinks).toBe(false);
+  });
+
   test('blockList — 빈 배열은 미설정', () => {
     const opts = buildRnBundleOptions(baseInput({ extra: { blockList: [] } }));
     expect(opts.blockList).toBeUndefined();

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -132,9 +132,8 @@ export interface RnBundleInput {
      */
     silentConsoleErrorPatterns?: string[];
     /**
-     * Metro `server.forwardClientLogs` 호환. true면 RN runtime console.* 를 dev
-     * server 터미널로 forwarding. 기본 false — RN 내부/devtool 로그 직렬화가 앱
-     * 메모리를 계속 늘리는 시나리오를 피한다.
+     * Metro `server.forwardClientLogs` 호환. RN core 의 HMRClient.log 경유 로그를
+     * dev server 터미널로 forwarding. 기본 true.
      */
     forwardClientLogs?: boolean;
   };
@@ -341,7 +340,6 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
       rnPlatform,
       sourceExts,
       babelTransformerPath: extra?.babelTransformerPath,
-      forwardClientLogs: extra?.forwardClientLogs,
     }),
   ];
 

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -420,6 +420,10 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
     mainFields: ['react-native', 'browser', 'main'],
     loader: baseLoader,
     alias: {},
+    // Metro resolves dependencies from the logical node_modules symlink path.
+    // With pnpm, realpathing a package before resolving its bare imports exposes
+    // the package's peer farm and can pull a second React copy into RN bundles.
+    preserveSymlinks: true,
     define,
     banner: buildPrelude(input),
     globalIdentifiers: [...RN_GLOBAL_IDENTIFIERS],

--- a/packages/react-native/src/runtime/zntc-hmr-client.test.mjs
+++ b/packages/react-native/src/runtime/zntc-hmr-client.test.mjs
@@ -69,8 +69,7 @@ let HMRClient;
 let mockGlobal;
 let mockConsole;
 let mockDevLoadingView;
-// wrap 전 console.X 의 mock 보존 — onopen 에서 console.X 가 wrappedFn 으로
-// 교체되므로 toHaveBeenCalledWith 검증 시 wrap 전 ref 사용 필요.
+let mockPrettyFormat;
 let originalConsole;
 
 beforeEach(() => {
@@ -91,6 +90,10 @@ beforeEach(() => {
     error: mock(() => {}),
     debug: mock(() => {}),
   };
+  mockPrettyFormat = {
+    format: mock((item) => `formatted:${item && item.message ? item.message : String(item)}`),
+    plugins: { ReactElement: {} },
+  };
   originalConsole = { ...mockConsole };
   HMRClient = loadHmrClient({
     global: mockGlobal,
@@ -102,6 +105,7 @@ beforeEach(() => {
     window: undefined,
     forwardClientLogs: true,
     require: (specifier) => {
+      if (specifier === 'pretty-format') return mockPrettyFormat;
       if (specifier === './DevLoadingView') return { default: mockDevLoadingView };
       throw new Error(`Unexpected require: ${specifier}`);
     },
@@ -159,7 +163,7 @@ describe('setup()', () => {
   });
 });
 
-describe('onopen — hmr:connected + console wrap', () => {
+describe('onopen — hmr:connected + Metro log path', () => {
   test("'hmr:connected' 메시지 송출 + bundleEntry/platform 포함", () => {
     HMRClient.setup('ios', '/abs/idx.js', 'localhost', 8081, true, 'http');
     const ws = MockWebSocket.instances[0];
@@ -168,15 +172,15 @@ describe('onopen — hmr:connected + console wrap', () => {
     expect(msg).toEqual({ type: 'hmr:connected', bundleEntry: '/abs/idx.js', platform: 'ios' });
   });
 
-  test('console method wrap — original 호출 + socket.send forward', () => {
+  test('setup 은 console 을 직접 wrap 하지 않고 HMRClient.log 만 forward', () => {
     HMRClient.setup('ios', '/abs/idx.js', 'localhost', 8081, true, 'http');
     const ws = MockWebSocket.instances[0];
     ws.onopen();
-    // wrap 후 mockConsole.log 자체가 wrappedFn — 호출은 wrap 된 함수로.
     mockConsole.log('hello');
-    // wrap 안에서 original (originalConsole.log) 호출 검증.
     expect(originalConsole.log).toHaveBeenCalledWith('hello');
-    // socket.send forward — 'hmr:connected' + 'log' 메시지
+    expect(ws.sent.length).toBe(1);
+
+    HMRClient.log('log', ['hello']);
     expect(ws.sent.length).toBe(2);
     const log = JSON.parse(ws.sent[1]);
     expect(log.type).toBe('log');
@@ -202,6 +206,7 @@ describe('onopen — hmr:connected + console wrap', () => {
       window: undefined,
       forwardClientLogs: true,
       require: (specifier) => {
+        if (specifier === 'pretty-format') return mockPrettyFormat;
         if (specifier === './DevLoadingView') return { default: mockDevLoadingView };
         throw new Error(`Unexpected require: ${specifier}`);
       },
@@ -223,7 +228,7 @@ describe('onopen — hmr:connected + console wrap', () => {
     expect(mockDevLoadingView.showMessage).not.toHaveBeenCalled();
   });
 
-  test('forwardClientLogs=false — console wrap 하지 않음', () => {
+  test('forwardClientLogs=false 여도 client console wrap 은 설치하지 않음', () => {
     HMRClient = loadHmrClient({
       global: mockGlobal,
       WebSocket: MockWebSocket,
@@ -234,6 +239,7 @@ describe('onopen — hmr:connected + console wrap', () => {
       window: undefined,
       forwardClientLogs: false,
       require: (specifier) => {
+        if (specifier === 'pretty-format') return mockPrettyFormat;
         if (specifier === './DevLoadingView') return { default: mockDevLoadingView };
         throw new Error(`Unexpected require: ${specifier}`);
       },
@@ -246,26 +252,50 @@ describe('onopen — hmr:connected + console wrap', () => {
     expect(ws.sent.length).toBe(1);
   });
 
-  test('Error object 는 message 만 send', () => {
+  test('non-string log item 은 Metro 처럼 pretty-format 으로 format', () => {
     HMRClient.setup('ios', '/abs/idx.js', 'localhost', 8081, true, 'http');
     const ws = MockWebSocket.instances[0];
     ws.onopen();
-    mockConsole.error(new Error('boom'));
+    HMRClient.log('error', [new Error('boom')]);
     const log = JSON.parse(ws.sent[1]);
-    expect(log.data).toEqual(['boom']);
+    expect(mockPrettyFormat.format).toHaveBeenCalledWith(expect.any(Error), {
+      escapeString: true,
+      highlight: true,
+      maxDepth: 3,
+      min: true,
+      plugins: [mockPrettyFormat.plugins.ReactElement],
+    });
+    expect(log.data).toEqual(['formatted:boom']);
   });
 
-  test('circular reference — replacer 가 [Circular] 로 대체 (#2885)', () => {
+  test('pretty-format 실패 시 Metro 처럼 log frame 을 보내지 않음', () => {
+    HMRClient = loadHmrClient({
+      global: mockGlobal,
+      WebSocket: MockWebSocket,
+      console: mockConsole,
+      __zntc_apply_update: mockGlobal.__zntc_apply_update,
+      __zntc_reload: mockGlobal.__zntc_reload,
+      location: { reload: mock(() => {}) },
+      window: undefined,
+      forwardClientLogs: true,
+      require: (specifier) => {
+        if (specifier === 'pretty-format') {
+          return {
+            format: mock(() => {
+              throw new Error('format failed');
+            }),
+            plugins: { ReactElement: {} },
+          };
+        }
+        if (specifier === './DevLoadingView') return { default: mockDevLoadingView };
+        throw new Error(`Unexpected require: ${specifier}`);
+      },
+    });
     HMRClient.setup('ios', '/abs/idx.js', 'localhost', 8081, true, 'http');
     const ws = MockWebSocket.instances[0];
     ws.onopen();
-    const obj = { a: 1 };
-    obj.self = obj;
-    mockConsole.log(obj);
-    const log = JSON.parse(ws.sent[1]);
-    expect(typeof log.data[0]).toBe('object');
-    expect(log.data[0].a).toBe(1);
-    expect(log.data[0].self).toBe('[Circular]');
+    expect(() => HMRClient.log('log', [{ a: 1 }])).not.toThrow();
+    expect(ws.sent).toHaveLength(1);
   });
 
   test('source 에 JSON.parse(JSON.stringify 패턴 없음 (#2885 deep-clone 회귀 가드)', () => {
@@ -283,7 +313,7 @@ describe('onopen — hmr:connected + console wrap', () => {
       return originalParse.apply(JSON, arguments);
     };
     try {
-      mockConsole.log({ a: 1, b: { c: 2 } });
+      HMRClient.log('log', [{ a: 1, b: { c: 2 } }]);
     } finally {
       JSON.parse = originalParse;
     }
@@ -296,10 +326,10 @@ describe('onopen — hmr:connected + console wrap', () => {
     ws.onopen();
     const sentBefore = ws.sent.length;
     ws.bufferedAmount = 2 * 1024 * 1024;
-    mockConsole.log('this should be dropped');
+    HMRClient.log('log', ['this should be dropped']);
     expect(ws.sent.length).toBe(sentBefore);
     ws.bufferedAmount = 0;
-    mockConsole.log('this should pass');
+    HMRClient.log('log', ['this should pass']);
     expect(ws.sent.length).toBe(sentBefore + 1);
   });
 
@@ -309,13 +339,13 @@ describe('onopen — hmr:connected + console wrap', () => {
     ws.onopen();
     const sentBefore = ws.sent.length;
     ws.readyState = 0; // CONNECTING
-    mockConsole.log('not yet open');
+    HMRClient.log('log', ['not yet open']);
     expect(ws.sent.length).toBe(sentBefore);
     ws.readyState = 2; // CLOSING
-    mockConsole.log('closing');
+    HMRClient.log('log', ['closing']);
     expect(ws.sent.length).toBe(sentBefore);
     ws.readyState = 3; // CLOSED
-    mockConsole.log('closed');
+    HMRClient.log('log', ['closed']);
     expect(ws.sent.length).toBe(sentBefore);
   });
 });
@@ -388,6 +418,7 @@ describe('onmessage — Metro 메시지 분기', () => {
       window: undefined,
       forwardClientLogs: true,
       require: (specifier) => {
+        if (specifier === 'pretty-format') return mockPrettyFormat;
         if (specifier === './DevLoadingView') return { default: mockDevLoadingView };
         throw new Error(`Unexpected require: ${specifier}`);
       },

--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -35,6 +35,29 @@ test "CJS: single CJS module wrapped with __commonJS" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "module.exports") != null);
 }
 
+test "CJS: Object.defineProperty(module, exports) wrapped with __commonJS" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "const lib = require('./lib.js');\nconsole.log(lib.value);");
+    try writeFile(tmp.dir, "lib.js",
+        \\function getExports() { return { value: 123 }; }
+        \\Object.defineProperty(module, "exports", { enumerable: true, get: getExports });
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{ .entry_points = &.{entry} });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var require_lib = __commonJS") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "Object.defineProperty(module, \"exports\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var init_lib = __esm") == null);
+}
+
 test "CJS: ESM imports default from CJS" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -3441,6 +3441,73 @@ test "react_native inlineRequires: named re-export preserves package entry side 
     try std.testing.expect(std.mem.indexOf(u8, result.output, chained_lazy_init) != null);
 }
 
+test "react_native inlineRequires: namespace member rewrite initializes source modules" {
+    // Sentry.init / modalSelectors.getFoo 축소 재현:
+    // `import * as ns` 뒤의 `ns.member` 직접 치환도 namespace object getter와 동일하게
+    // package entry와 canonical export source를 init해야 binding이 undefined로 남지 않는다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("sentry");
+    try writeFile(tmp.dir, "entry.js",
+        \\import * as Sentry from './sentry';
+        \\import * as selectors from './selectors';
+        \\globalThis.__zntcSelector = selectors.getVisible;
+        \\globalThis.__zntcPromise = Promise.resolve().then(() => Sentry.init());
+    );
+    try writeFile(tmp.dir, "sentry/index.js",
+        \\globalThis.__zntcSentryEntry = true;
+        \\export { init } from './sdk';
+    );
+    try writeFile(tmp.dir, "sentry/sdk.js",
+        \\export function init() {
+        \\  return globalThis.__zntcSentryEntry;
+        \\}
+    );
+    try writeFile(tmp.dir, "selectors.js",
+        \\export const getVisible = (state) => state.visible;
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+    const package_entry = try absPath(&tmp, "sentry/index.js");
+    defer std.testing.allocator.free(package_entry);
+    const sdk = try absPath(&tmp, "sentry/sdk.js");
+    defer std.testing.allocator.free(sdk);
+    const selectors = try absPath(&tmp, "selectors.js");
+    defer std.testing.allocator.free(selectors);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .tree_shaking = false,
+        .dev_mode = true,
+        .entry_error_guard = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+
+    const sentry_member_init = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "(__zntc_guarded(function(){{return __zntc_modules[\"{s}\"].fn()}}), __zntc_guarded(function(){{return __zntc_modules[\"{s}\"].fn()}}), init)()",
+        .{ package_entry, sdk },
+    );
+    defer std.testing.allocator.free(sentry_member_init);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, sentry_member_init) != null);
+
+    const selector_member_init = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "(__zntc_guarded(function(){{return __zntc_modules[\"{s}\"].fn()}}), getVisible)",
+        .{selectors},
+    );
+    defer std.testing.allocator.free(selector_member_init);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, selector_member_init) != null);
+}
+
 test "react_native inlineRequires: namespace import from export-star barrel initializes source getters" {
     // react-native-animatable 축소 재현:
     // `import * as defs from './definitions'`를 값으로 넘기면 namespace object가

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -2189,6 +2189,42 @@ test "RN preset: #1302 for-of destructuring + const→var는 void 0 init 추가 
     try std.testing.expect(std.mem.indexOf(u8, result.output, "} = void 0;") == null);
 }
 
+test "RN preset: for-of loop closure preserves method this" {
+    // 루프 body 를 _loop 함수로 추출하더라도 원래 메서드의 `this` 의미를 보존해야 한다.
+    // RN DebuggingOverlayRegistry 의 private method call 이 이 경로에서 깨졌다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\const callbacks = [];
+        \\class Registry {
+        \\  #find(instance) { return instance; }
+        \\  draw(updates) {
+        \\    const out = [];
+        \\    for (const { id, instance, color } of updates) {
+        \\      const parent = this.#find(instance);
+        \\      callbacks.push(function() { return id + color; });
+        \\      out.push(parent);
+        \\    }
+        \\    return out;
+        \\  }
+        \\}
+        \\console.log(new Registry().draw([{ id: 1, instance: 2, color: 3 }]), callbacks[0]());
+    );
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "_loop.call(this") != null);
+}
+
 test "RN preset: #1299 let/const → var 다운레벨 (Hermes block scoping)" {
     // `for (let q = 0, ...)` 같은 패턴이 object literal 평가를 깨뜨려 후속 prop 누락.
     // arrow → function 변환만으로 회피되지 않음. Rolldown도 block-scoping 변환.

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -1915,6 +1915,70 @@ test "Self-require: RN 플랫폼 파일 패턴 (조건부 self-require)" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./widget\")") == null);
 }
 
+test "react_native preserve_symlinks: CJS-wrapped package ESM imports resolve from real pnpm package" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("apps/app/node_modules/@scope");
+    try tmp.dir.makePath("apps/app/node_modules/react-native");
+    try tmp.dir.makePath("node_modules/react-native");
+    try writeFile(tmp.dir, "apps/app/node_modules/react-native/package.json", "{\"main\":\"index.js\"}");
+    try writeFile(tmp.dir, "apps/app/node_modules/react-native/index.js", "exports.NativeModules = { CodePush: {} };");
+    try writeFile(tmp.dir, "node_modules/react-native/package.json", "{\"main\":\"index.js\"}");
+    try writeFile(tmp.dir, "node_modules/react-native/index.js", "exports.NativeModules = { CodePush: {} };");
+
+    try tmp.dir.makePath("node_modules/.pnpm/pkg@1/node_modules/@scope/pkg");
+    try tmp.dir.makePath("node_modules/.pnpm/pkg@1/node_modules/code-push/script");
+    try tmp.dir.makePath("node_modules/.pnpm/pkg@1/node_modules/hoist-non-react-statics");
+    try writeFile(tmp.dir, "node_modules/.pnpm/pkg@1/node_modules/@scope/pkg/package.json", "{\"main\":\"CodePush.js\"}");
+    try writeFile(tmp.dir, "node_modules/.pnpm/pkg@1/node_modules/@scope/pkg/CodePush.js",
+        \\import { AcquisitionManager as Sdk } from "code-push/script/acquisition-sdk";
+        \\import hoistStatics from "hoist-non-react-statics";
+        \\let NativeCodePush = require("react-native").NativeModules.CodePush;
+        \\module.exports = { Sdk, hoistStatics, NativeCodePush };
+    );
+    try writeFile(tmp.dir, "node_modules/.pnpm/pkg@1/node_modules/code-push/package.json", "{\"main\":\"script/acquisition-sdk.js\"}");
+    try writeFile(tmp.dir, "node_modules/.pnpm/pkg@1/node_modules/code-push/script/acquisition-sdk.js", "exports.AcquisitionManager = function AcquisitionManager() {};");
+    try writeFile(tmp.dir, "node_modules/.pnpm/pkg@1/node_modules/hoist-non-react-statics/package.json", "{\"main\":\"index.js\"}");
+    try writeFile(tmp.dir, "node_modules/.pnpm/pkg@1/node_modules/hoist-non-react-statics/index.js", "module.exports = function hoist() {};");
+
+    tmp.dir.symLink(
+        "../../../../node_modules/.pnpm/pkg@1/node_modules/@scope/pkg",
+        "apps/app/node_modules/@scope/pkg",
+        .{ .is_directory = true },
+    ) catch |err| switch (err) {
+        error.AccessDenied, error.PermissionDenied => return error.SkipZigTest,
+        else => return err,
+    };
+
+    try writeFile(tmp.dir, "apps/app/index.js",
+        \\const CodePush = require("@scope/pkg");
+        \\console.log(CodePush);
+    );
+
+    const entry = try absPath(&tmp, "apps/app/index.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .tree_shaking = false,
+        .dev_mode = true,
+        .preserve_symlinks = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"code-push/script/acquisition-sdk\")") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"hoist-non-react-statics\")") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "NativeCodePush = require(\"react-native\")") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require_code_push") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require_hoist_non_react_statics") != null);
+}
+
 test "shimMissingExports: missing export에 shim 변수 생성" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -3256,6 +3320,180 @@ test "react_native inlineRequires: defer top-level ESM value imports to use site
     defer std.testing.allocator.free(lazy_remote_value);
     try std.testing.expect(std.mem.indexOf(u8, result.output, lazy_remote_value) != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, ".fn();});\n,") == null);
+}
+
+test "react_native inlineRequires: named re-export initializes canonical source at use site" {
+    // `import { createStackNavigator } from '@react-navigation/stack'` 형태의
+    // named re-export는 barrel 모듈이 아니라 실제 default export source를 실행해야
+    // canonical binding이 undefined로 남지 않는다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.js",
+        \\import { createStackNavigator } from './stack';
+        \\globalThis.__zntcStackNavigator = createStackNavigator().ready;
+    );
+    try tmp.dir.makePath("stack");
+    try writeFile(tmp.dir, "stack/index.js",
+        \\export { default as createStackNavigator } from './createStackNavigator';
+    );
+    try writeFile(tmp.dir, "stack/createStackNavigator.js",
+        \\export default function createStackNavigator() {
+        \\  return { ready: 'stack-ready' };
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+    const barrel = try absPath(&tmp, "stack/index.js");
+    defer std.testing.allocator.free(barrel);
+    const source = try absPath(&tmp, "stack/createStackNavigator.js");
+    defer std.testing.allocator.free(source);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .tree_shaking = false,
+        .dev_mode = true,
+        .entry_error_guard = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+
+    const chained_lazy_init = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "(__zntc_guarded(function(){{return __zntc_modules[\"{s}\"].fn()}}), __zntc_guarded(function(){{return __zntc_modules[\"{s}\"].fn()}}), createStackNavigator)",
+        .{ barrel, source },
+    );
+    defer std.testing.allocator.free(chained_lazy_init);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, chained_lazy_init) != null);
+}
+
+test "react_native inlineRequires: named re-export preserves package entry side effects" {
+    // RNFirebase perf 축소 재현:
+    // package entry가 namespace side effect를 등록하고 named modular API를 re-export한다.
+    // canonical source만 init하면 getPerformance 함수는 있어도 getApp().perf가 없다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("perf");
+    try writeFile(tmp.dir, "entry.js",
+        \\import { getPerformance } from './perf';
+        \\globalThis.__zntcPerfResult = getPerformance().dataCollectionEnabled;
+    );
+    try writeFile(tmp.dir, "app.js",
+        \\export function getApp() {
+        \\  return globalThis.__zntcFirebaseApp;
+        \\}
+    );
+    try writeFile(tmp.dir, "perf/index.js",
+        \\import { registerPerf } from './registerPerf';
+        \\registerPerf();
+        \\export * from './modular';
+    );
+    try writeFile(tmp.dir, "perf/registerPerf.js",
+        \\export function registerPerf() {
+        \\  globalThis.__zntcFirebaseApp = {
+        \\    perf() {
+        \\      return { dataCollectionEnabled: 'perf-ready' };
+        \\    },
+        \\  };
+        \\}
+    );
+    try writeFile(tmp.dir, "perf/modular.js",
+        \\import { getApp } from '../app';
+        \\export function getPerformance() {
+        \\  return getApp().perf();
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+    const package_entry = try absPath(&tmp, "perf/index.js");
+    defer std.testing.allocator.free(package_entry);
+    const modular = try absPath(&tmp, "perf/modular.js");
+    defer std.testing.allocator.free(modular);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .tree_shaking = false,
+        .dev_mode = true,
+        .entry_error_guard = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+
+    const chained_lazy_init = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "(__zntc_guarded(function(){{return __zntc_modules[\"{s}\"].fn()}}), __zntc_guarded(function(){{return __zntc_modules[\"{s}\"].fn()}}), getPerformance)",
+        .{ package_entry, modular },
+    );
+    defer std.testing.allocator.free(chained_lazy_init);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, chained_lazy_init) != null);
+}
+
+test "react_native inlineRequires: namespace import from export-star barrel initializes source getters" {
+    // react-native-animatable 축소 재현:
+    // `import * as defs from './definitions'`를 값으로 넘기면 namespace object가
+    // 만들어진다. barrel의 `export *` source를 getter에서 init하지 않으면
+    // Object.keys(defs) 이후 defs[name] 값이 undefined로 남는다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("definitions");
+    try writeFile(tmp.dir, "entry.js",
+        \\import * as ANIMATION_DEFINITIONS from './definitions';
+        \\globalThis.__zntcAnimations = Object.keys(ANIMATION_DEFINITIONS)
+        \\  .map((name) => ANIMATION_DEFINITIONS[name].label)
+        \\  .join(',');
+    );
+    try writeFile(tmp.dir, "definitions/index.js",
+        \\export * from './fading';
+        \\export * from './bouncing';
+    );
+    try writeFile(tmp.dir, "definitions/fading.js",
+        \\export const fadeIn = { label: 'fadeIn' };
+    );
+    try writeFile(tmp.dir, "definitions/bouncing.js",
+        \\export const bounceIn = { label: 'bounceIn' };
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+    const fading = try absPath(&tmp, "definitions/fading.js");
+    defer std.testing.allocator.free(fading);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .tree_shaking = false,
+        .dev_mode = true,
+        .entry_error_guard = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+
+    const getter_with_source_init = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "get fadeIn() {{ return (__zntc_guarded(function(){{return __zntc_modules[\"{s}\"].fn()}}), fadeIn); }}",
+        .{fading},
+    );
+    defer std.testing.allocator.free(getter_with_source_init);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, getter_with_source_init) != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "get fadeIn() { return fadeIn; }") == null);
 }
 
 test "react_native inlineRequires: keeps default ESM imports eager for provider side effects" {

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -3036,6 +3036,67 @@ test "entry_error_guard #21: silent_console_error_patterns 다중 패턴 — 모
     try std.testing.expect(std.mem.indexOf(u8, result.output, "for (var i = 0; i < IGNORE.length") != null);
 }
 
+test "react_native re-export getters defer ESM source initialization" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.js",
+        \\import { capture } from './browser-index';
+        \\globalThis.__zntcReExportLazyResult = capture();
+    );
+    try writeFile(tmp.dir, "browser-index.js",
+        \\export { capture } from './core';
+        \\export { feedbackAsyncIntegration } from './feedbackAsync';
+    );
+    try writeFile(tmp.dir, "core.js",
+        \\export function capture() { return 'captured'; }
+    );
+    try writeFile(tmp.dir, "feedbackAsync.js",
+        \\import { buildFeedbackIntegration } from './feedback';
+        \\export const feedbackAsyncIntegration = buildFeedbackIntegration();
+    );
+    try writeFile(tmp.dir, "feedback.js",
+        \\const DOCUMENT = globalThis.WINDOW.document;
+        \\export function buildFeedbackIntegration() { return DOCUMENT; }
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+    const feedback_async = try absPath(&tmp, "feedbackAsync.js");
+    defer std.testing.allocator.free(feedback_async);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .dev_mode = true,
+        .entry_error_guard = true,
+        .tree_shaking = false,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+
+    const eager_init = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "{s}__zntc_modules[\"{s}\"].fn();}});\n",
+        .{ rt.GUARD_LAMBDA_OPEN, feedback_async },
+    );
+    defer std.testing.allocator.free(eager_init);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, eager_init) == null);
+
+    const lazy_getter = try std.fmt.allocPrint(
+        std.testing.allocator,
+        "({s}__zntc_modules[\"{s}\"].fn()}}), exports_",
+        .{ rt.GUARD_LAMBDA_OPEN, feedback_async },
+    );
+    defer std.testing.allocator.free(lazy_getter);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, lazy_getter) != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "feedbackAsyncIntegration") != null);
+}
+
 test "react_native inlineRequires: defer function-only ESM imports across selector cycles" {
     // Payhere mobile-seller 축소 재현:
     // seller selector 가 함수 안에서만 seller module state 를 읽는데, 그 import 를

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -451,7 +451,7 @@ pub fn emitEsmWrappedModule(
                         if (std.mem.eql(u8, name, "default")) continue;
                         if (direct_exports.contains(name)) continue;
 
-                        const getter_val = try makeStarGetterValue(allocator, l, src_mod, src_i, name);
+                        const getter_val = try makeStarGetterValue(allocator, l, src_mod, src_i, name, options);
                         try star_owned.append(allocator, getter_val);
                         try star_entries.append(allocator, .{
                             .name = name,
@@ -463,7 +463,7 @@ pub fn emitEsmWrappedModule(
                     // export * as ns from './dep' → namespace re-export
                     // getter는 소스 모듈의 exports 객체 자체를 참조
                     const getter_val = switch (src_mod.wrap_kind) {
-                        .esm, .none => try src_mod.allocExportsName(allocator),
+                        .esm, .none => try makeNamespaceGetterValue(allocator, src_mod, options),
                         .cjs => blk: {
                             const rv = try src_mod.allocRequireName(allocator);
                             defer allocator.free(rv);
@@ -539,7 +539,7 @@ pub fn emitEsmWrappedModule(
                                 }
                             }
 
-                            const getter_val = try makeStarGetterValue(allocator, l, src_mod, si, local_name);
+                            const getter_val = try makeStarGetterValue(allocator, l, src_mod, si, local_name, options);
                             try star_owned.append(allocator, getter_val);
                             break :blk getter_val;
                         }
@@ -773,6 +773,7 @@ pub fn emitEsmWrappedModule(
             // tree_shaker_active 게이트 (metadata.zig:408,438 동일 정책).
             if (l.tree_shaker_active and !src_mod_ptr.is_included) continue;
             re_export_inited.put(src_i, {}) catch {};
+            if (shouldLazyReExportInit(options, src_mod_ptr)) continue;
 
             try appendWrappedInitCall(&star_init_buf, allocator, src_mod_ptr, options);
         }
@@ -1151,6 +1152,63 @@ fn collectStarExportNames(
     }
 }
 
+fn shouldLazyReExportInit(options: *const EmitOptions, src_mod: *const Module) bool {
+    return options.platform == .react_native and
+        src_mod.wrap_kind != .none and
+        !(src_mod.wrap_kind == .esm and src_mod.uses_top_level_await);
+}
+
+fn makeLazyEsmGetterValue(
+    allocator: std.mem.Allocator,
+    src_mod: *const Module,
+    target: []const u8,
+    options: *const EmitOptions,
+) ![]const u8 {
+    if (!shouldLazyReExportInit(options, src_mod) or src_mod.wrap_kind != .esm) {
+        return try allocator.dupe(u8, target);
+    }
+
+    const init_call = if (options.dev_mode) blk: {
+        break :blk try std.fmt.allocPrint(allocator, "__zntc_modules[\"{s}\"].fn()", .{src_mod.dev_id});
+    } else blk: {
+        const iv = try src_mod.allocInitName(allocator);
+        defer allocator.free(iv);
+        break :blk try std.fmt.allocPrint(allocator, "{s}()", .{iv});
+    };
+    defer allocator.free(init_call);
+
+    const init_expr = if (src_mod.shouldGuard(options.entry_error_guard)) blk: {
+        const guard_name: []const u8 = if (options.minify_whitespace) rt.GUARD_FN_NAME_MIN else rt.GUARD_FN_NAME;
+        break :blk try std.fmt.allocPrint(allocator, "{s}(function(){{return {s}}})", .{ guard_name, init_call });
+    } else try allocator.dupe(u8, init_call);
+    defer allocator.free(init_expr);
+
+    return try std.fmt.allocPrint(allocator, "({s}, {s})", .{ init_expr, target });
+}
+
+fn makeEsmExportGetterValue(
+    allocator: std.mem.Allocator,
+    src_mod: *const Module,
+    name: []const u8,
+    options: *const EmitOptions,
+) ![]const u8 {
+    const ev = try src_mod.allocExportsName(allocator);
+    defer allocator.free(ev);
+    const target = try std.fmt.allocPrint(allocator, "{s}.{s}", .{ ev, name });
+    defer allocator.free(target);
+    return makeLazyEsmGetterValue(allocator, src_mod, target, options);
+}
+
+fn makeNamespaceGetterValue(
+    allocator: std.mem.Allocator,
+    src_mod: *const Module,
+    options: *const EmitOptions,
+) ![]const u8 {
+    const ev = try src_mod.allocExportsName(allocator);
+    defer allocator.free(ev);
+    return makeLazyEsmGetterValue(allocator, src_mod, ev, options);
+}
+
 /// star re-export의 getter 값을 소스 모듈 wrap_kind에 따라 생성한다.
 /// - .none (scope-hoisted): canonical 로컬 변수 이름 (linker rename 반영)
 /// - .esm: "exports_source.name" (exports 객체 프로퍼티 접근)
@@ -1161,6 +1219,7 @@ fn makeStarGetterValue(
     src_mod: *const Module,
     src_i: u32,
     name: []const u8,
+    options: *const EmitOptions,
 ) ![]const u8 {
     switch (src_mod.wrap_kind) {
         .none => {
@@ -1199,9 +1258,7 @@ fn makeStarGetterValue(
             return try allocator.dupe(u8, name);
         },
         .esm => {
-            const ev = try src_mod.allocExportsName(allocator);
-            defer allocator.free(ev);
-            return try std.fmt.allocPrint(allocator, "{s}.{s}", .{ ev, name });
+            return makeEsmExportGetterValue(allocator, src_mod, name, options);
         },
         .cjs => {
             const rv = try src_mod.allocRequireName(allocator);

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -286,6 +286,7 @@ pub const ModuleGraph = struct {
     pub const discardResolvedModule = graph_module_registry.discardResolvedModule;
     pub const markRecordLazyResolved = graph_module_registry.markRecordLazyResolved;
     pub const addModule = graph_module_registry.addModule;
+    pub const addModuleWithResolveDir = graph_module_registry.addModuleWithResolveDir;
     pub const addDisabledModule = graph_module_registry.addDisabledModule;
     pub const addOptionalMissingModule = graph_module_registry.addOptionalMissingModule;
     pub const addExternalModule = graph_module_registry.addExternalModule;

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -432,6 +432,7 @@ pub fn buildIncremental(
                 try cache_hit_modules.put(@intCast(i), {});
                 // parse_arena 소유권 이전: store → graph.
                 cached.module.parse_arena = null;
+                cached.module.resolve_dir = null;
                 cached.module.import_records = &.{};
                 cached.module.resolved_deps = .empty;
                 // alias_table 도 동일 패턴: 얕은 복사로 인해 backing 이

--- a/src/bundler/graph/discovery_scan.zig
+++ b/src/bundler/graph/discovery_scan.zig
@@ -99,7 +99,7 @@ pub fn scanModule(self: *ModuleGraph, idx: ModuleIndex) ScanResult {
     }
 
     const module_path = mod_ptr.path;
-    const source_dir = std.fs.path.dirname(module_path) orelse ".";
+    const source_dir = mod_ptr.sourceDir();
 
     const plugin_runner: ?plugin_mod.PluginRunner = self.pluginRunnerWithBuiltins();
 

--- a/src/bundler/graph/module_registry.zig
+++ b/src/bundler/graph/module_registry.zig
@@ -51,7 +51,10 @@ fn loaderExtensionFor(abs_path: []const u8) []const u8 {
 
 pub fn discardResolvedModule(self: *ModuleGraph, resolved: plugin_mod.ResolvedModule) void {
     switch (resolved) {
-        .file => |f| self.allocator.free(f.path),
+        .file => |f| {
+            self.allocator.free(f.path);
+            if (f.resolve_dir) |dir| self.allocator.free(dir);
+        },
         .disabled => |d| self.allocator.free(d.path),
         .virtual, .dataurl, .external, .custom => {},
     }
@@ -67,16 +70,31 @@ pub fn markRecordLazyResolved(self: *ModuleGraph, mod_idx: usize, rec_i: usize) 
 /// 모듈을 그래프에 추가하고 파싱한다.
 /// 이미 존재하면 기존 인덱스를 반환.
 pub fn addModule(self: *ModuleGraph, abs_path: []const u8) !ModuleIndex {
+    return self.addModuleWithResolveDir(abs_path, null);
+}
+
+pub fn addModuleWithResolveDir(self: *ModuleGraph, abs_path: []const u8, resolve_dir: ?[]const u8) !ModuleIndex {
     // 중복 체크
     if (self.path_to_module.get(abs_path)) |existing| {
+        if (resolve_dir) |dir| {
+            const existing_module = self.modules.at(@intFromEnum(existing));
+            if (existing_module.resolve_dir == null) {
+                existing_module.resolve_dir = try self.allocator.dupe(u8, dir);
+            }
+        }
         return existing;
     }
 
     // 새 모듈 슬롯 할당
     const index: ModuleIndex = @enumFromInt(@as(u32, @intCast(self.modules.count())));
+    var ownership_transferred = false;
     const path_owned = try self.allocator.dupe(u8, abs_path);
+    errdefer if (!ownership_transferred) self.allocator.free(path_owned);
+    const resolve_dir_owned = if (resolve_dir) |dir| try self.allocator.dupe(u8, dir) else null;
+    errdefer if (!ownership_transferred) if (resolve_dir_owned) |dir| self.allocator.free(dir);
 
     var module = Module.init(index, path_owned);
+    module.resolve_dir = resolve_dir_owned;
     const ext_for_loader = loaderExtensionFor(abs_path);
     module.module_type = ModuleType.fromExtension(ext_for_loader);
     // 로더 결정: --loader 오버라이드 → 확장자 기본값
@@ -84,6 +102,7 @@ pub fn addModule(self: *ModuleGraph, abs_path: []const u8) !ModuleIndex {
     module.loader = parsed_loader.loader;
     module.module_type = parsed_loader.module_type orelse moduleTypeForLoader(module.module_type, module.loader);
     try self.modules.append(self.allocator, module);
+    ownership_transferred = true;
     try self.path_to_module.put(path_owned, index);
 
     // 신규 모듈 path 의 dir 를 source_read_cache 에 pre-warm — readModuleSource 단계의

--- a/src/bundler/graph/require_context.zig
+++ b/src/bundler/graph/require_context.zig
@@ -74,7 +74,7 @@ pub fn expandRecords(self: *ModuleGraph, mod_idx: usize) void {
                 // 매치별 abs path resolve 결과를 record.context_resolved_paths 에 1:1 저장.
                 // codegen 이 webpackContext IIFE 의 module wrapper 호출 (`__zntc_modules[<abs>]`) 에 사용.
                 // null 슬롯 = resolve 실패 — codegen 이 throw stub 으로 emit.
-                const source_dir = std.fs.path.dirname(module_path) orelse ".";
+                const source_dir = module.sourceDir();
                 const resolved_paths_opt: ?[]?[]const u8 = arena_alloc.alloc(?[]const u8, m.len) catch null;
                 for (m, 0..) |match_path, i| {
                     const joined = joinContextPath(arena_alloc, record.specifier, match_path) orelse {
@@ -89,6 +89,7 @@ pub fn expandRecords(self: *ModuleGraph, mod_idx: usize) void {
                             .file => |f| {
                                 paths[i] = arena_alloc.dupe(u8, f.path) catch null;
                                 self.allocator.free(f.path);
+                                if (f.resolve_dir) |dir| self.allocator.free(dir);
                             },
                             .disabled => |d| self.allocator.free(d.path),
                             .virtual, .dataurl, .external, .custom => {},

--- a/src/bundler/graph/resolve_imports.zig
+++ b/src/bundler/graph/resolve_imports.zig
@@ -23,9 +23,12 @@ fn appendResolvedDep(
     const mod_ptr = self.modules.at(mod_idx);
     const path_owned = try self.allocator.dupe(u8, dep.path);
     errdefer self.allocator.free(path_owned);
+    const resolve_dir_owned = if (dep.resolve_dir) |dir| try self.allocator.dupe(u8, dir) else null;
+    errdefer if (resolve_dir_owned) |dir| self.allocator.free(dir);
 
     var owned_dep = dep;
     owned_dep.path = path_owned;
+    owned_dep.resolve_dir = resolve_dir_owned;
     try mod_ptr.resolved_deps.append(self.allocator, owned_dep);
 }
 
@@ -37,7 +40,7 @@ pub fn replayCachedResolvedDeps(self: *ModuleGraph, mod_idx: usize) !void {
     for (mod_ptr.resolved_deps.items) |dep| {
         switch (dep.target) {
             .file, .virtual => {
-                const dep_idx = try self.addModule(dep.path);
+                const dep_idx = try self.addModuleWithResolveDir(dep.path, dep.resolve_dir);
                 if (dep.target_is_module_field or mod_ptr.is_module_field) {
                     self.modules.at(@intFromEnum(dep_idx)).is_module_field = true;
                 }
@@ -116,7 +119,7 @@ pub fn applyContextDepResults(self: *ModuleGraph, mod_idx: usize) !void {
     if (context_deps.len == 0) return;
 
     const module_path = mod_ptr.path;
-    const source_dir = std.fs.path.dirname(module_path) orelse ".";
+    const source_dir = mod_ptr.sourceDir();
     for (context_deps) |dep| {
         const resolved = self.resolve_cache.resolveThreadSafe(source_dir, dep.specifier, dep.kind) catch |err| switch (err) {
             error.ModuleNotFound => {
@@ -135,8 +138,11 @@ pub fn applyContextDepResults(self: *ModuleGraph, mod_idx: usize) !void {
         };
         if (resolved) |m| switch (m) {
             .file => |f| {
-                defer self.allocator.free(f.path);
-                const dep_idx = try self.addModule(f.path);
+                defer {
+                    self.allocator.free(f.path);
+                    if (f.resolve_dir) |dir| self.allocator.free(dir);
+                }
+                const dep_idx = try self.addModuleWithResolveDir(f.path, f.resolve_dir);
                 _ = try graph_requested_exports.requestAll(self, dep_idx);
                 // tree-shaker 가 static import 없이도 이 모듈을 보존하도록 마킹.
                 self.modules.at(@intFromEnum(dep_idx)).is_context_dep = true;
@@ -144,6 +150,7 @@ pub fn applyContextDepResults(self: *ModuleGraph, mod_idx: usize) !void {
                     .kind = dep.kind,
                     .target = .file,
                     .path = f.path,
+                    .resolve_dir = f.resolve_dir,
                     .target_is_module_field = f.is_module_field,
                     .is_context_dep = true,
                 });
@@ -249,7 +256,10 @@ pub fn applyResolveResult(
         // virtual/dataurl/external/custom 은 PR 5 plugin layer 도입 시 처리.
         switch (m) {
             .file => |f| {
-                defer self.allocator.free(f.path);
+                defer {
+                    self.allocator.free(f.path);
+                    if (f.resolve_dir) |dir| self.allocator.free(dir);
+                }
 
                 // Worker: 메인 그래프에 모듈로 추가하지 않고 경로만 수집
                 if (record.kind == .worker) {
@@ -264,12 +274,13 @@ pub fn applyResolveResult(
                         .kind = record.kind,
                         .target = .worker,
                         .path = f.path,
+                        .resolve_dir = f.resolve_dir,
                         .target_is_module_field = f.is_module_field,
                     });
                     return;
                 }
 
-                const dep_idx = try self.addModule(f.path);
+                const dep_idx = try self.addModuleWithResolveDir(f.path, f.resolve_dir);
                 if (f.is_module_field or self.modules.at(mod_idx).is_module_field) {
                     self.modules.at(@intFromEnum(dep_idx)).is_module_field = true;
                 }
@@ -279,6 +290,7 @@ pub fn applyResolveResult(
                     .kind = record.kind,
                     .target = .file,
                     .path = f.path,
+                    .resolve_dir = f.resolve_dir,
                     .target_is_module_field = f.is_module_field,
                 });
                 try recordResolvedDep(self, mod_index, mod_idx, rec_i, dep_idx, record.kind);
@@ -356,7 +368,7 @@ pub fn resolveModuleImports(self: *ModuleGraph, idx: ModuleIndex) !void {
 
     const mod_ptr = self.modules.at(mod_idx);
     const module_path = mod_ptr.path;
-    const source_dir = std.fs.path.dirname(module_path) orelse ".";
+    const source_dir = mod_ptr.sourceDir();
 
     // Plugin: resolveId 훅용 runner를 루프 밖에서 한 번만 생성
     const plugin_runner: ?plugin_mod.PluginRunner = self.pluginRunnerWithBuiltins();

--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -15,6 +15,7 @@
 //!   - module.exports = ...              → CJS 신호 (has_module_exports)
 //!   - exports.x = ...                   → CJS 신호 (has_exports_dot)
 //!   - Object.defineProperty(exports, ...) → CJS 신호 (has_exports_dot)
+//!   - Object.defineProperty(module, "exports", ...) → CJS 신호 (has_module_exports)
 //!
 //! AST extra_data 레이아웃:
 //!   - import_declaration:         [specs_start, specs_len, source_node]
@@ -136,8 +137,14 @@ pub fn extractImportsWithCjsDetectionAndDefines(
                         } else if (tryExtractGlob(ast, node)) |record| {
                             try records.append(allocator, record);
                         } else if (classifyObjectDefinePropertyExports(ast, node)) |kind| {
-                            has_exports_dot = true;
-                            if (kind == .esmodule_marker) has_esmodule_marker = true;
+                            switch (kind) {
+                                .module_exports => has_module_exports = true,
+                                .exports_member => has_exports_dot = true,
+                                .esmodule_marker => {
+                                    has_exports_dot = true;
+                                    has_esmodule_marker = true;
+                                },
+                            }
                         }
                     },
                     else => {},
@@ -740,23 +747,13 @@ fn tryExtractRequire(ast: *const Ast, node: Node) ?ImportRecord {
     };
 }
 
-/// `Object.defineProperty(exports, ...)` / `Object.defineProperty(module.exports, ...)`.
+/// `Object.defineProperty(exports, ...)` / `Object.defineProperty(module.exports, ...)`
+/// / `Object.defineProperty(module, "exports", ...)`.
 /// Babel/TS CJS output often declares `__esModule` this way; after transformer pre-pass
 /// rewrites `require()` calls, this may be the remaining CJS signal.
-const DefinePropertyExportsKind = enum { other, esmodule_marker };
+const DefinePropertyExportsKind = enum { exports_member, module_exports, esmodule_marker };
 
 fn classifyObjectDefinePropertyExports(ast: *const Ast, node: Node) ?DefinePropertyExportsKind {
-    const args_start = getObjectDefinePropertyExportsTarget(ast, node) orelse return null;
-    if (ast.hasExtra(args_start, 2)) {
-        const prop_idx = ast.readExtraNode(args_start, 1);
-        if (getStringLiteralText(ast, prop_idx)) |prop| {
-            if (std.mem.eql(u8, prop, ES_MODULE_MARKER)) return .esmodule_marker;
-        }
-    }
-    return .other;
-}
-
-fn getObjectDefinePropertyExportsTarget(ast: *const Ast, node: Node) ?u32 {
     const e = node.data.extra;
     if (!ast.hasExtra(e, 2)) return null;
 
@@ -775,16 +772,36 @@ fn getObjectDefinePropertyExportsTarget(ast: *const Ast, node: Node) ?u32 {
     if (target_idx.isNone() or @intFromEnum(target_idx) >= ast.nodes.items.len) return null;
     const target = ast.getNode(target_idx);
     if (target.tag == .identifier_reference and std.mem.eql(u8, ast.getText(target.span), "exports")) {
-        return args_start;
+        if (isDefinePropertyEsModuleMarker(ast, args_start)) return .esmodule_marker;
+        return .exports_member;
+    }
+    if (target.tag == .identifier_reference and std.mem.eql(u8, ast.getText(target.span), "module")) {
+        if (isDefinePropertyModuleExports(ast, args_start)) return .module_exports;
+        return null;
     }
 
     const target_parts = getStaticMemberParts(ast, target_idx) orelse return null;
     if (std.mem.eql(u8, target_parts.object, "module") and
         std.mem.eql(u8, target_parts.property, "exports"))
     {
-        return args_start;
+        if (isDefinePropertyEsModuleMarker(ast, args_start)) return .esmodule_marker;
+        return .exports_member;
     }
     return null;
+}
+
+fn isDefinePropertyEsModuleMarker(ast: *const Ast, args_start: u32) bool {
+    if (!ast.hasExtra(args_start, 2)) return false;
+    const prop_idx = ast.readExtraNode(args_start, 1);
+    const prop = getStringLiteralText(ast, prop_idx) orelse return false;
+    return std.mem.eql(u8, prop, ES_MODULE_MARKER);
+}
+
+fn isDefinePropertyModuleExports(ast: *const Ast, args_start: u32) bool {
+    if (!ast.hasExtra(args_start, 2)) return false;
+    const prop_idx = ast.readExtraNode(args_start, 1);
+    const prop = getStringLiteralText(ast, prop_idx) orelse return false;
+    return std.mem.eql(u8, prop, "exports");
 }
 
 const MemberParts = struct { object: []const u8, property: []const u8 };

--- a/src/bundler/import_scanner_test.zig
+++ b/src/bundler/import_scanner_test.zig
@@ -799,6 +799,18 @@ test "CJS: Object.defineProperty(module.exports) detected" {
     try std.testing.expect(!result.has_esm_syntax);
 }
 
+test "CJS: Object.defineProperty(module, 'exports') detected" {
+    const alloc = std.testing.allocator;
+    const result = try parseAndExtractFull(
+        alloc,
+        "Object.defineProperty(module, 'exports', { enumerable: true, get: getExports });",
+    );
+    defer alloc.free(result.records);
+
+    try std.testing.expect(result.has_module_exports);
+    try std.testing.expect(!result.has_esm_syntax);
+}
+
 test "CJS: ESM syntax flag set" {
     const alloc = std.testing.allocator;
     // is_module=false에서도 ESM 구문 감지 테스트를 위해 parseAndExtract 사용

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -249,6 +249,9 @@ pub const Linker = struct {
         /// buildInlineObjectStr에서 할당된 문자열인 경우 true.
         /// exports ArrayList 해제 시 owned=true인 local만 free.
         owned: bool = false,
+        /// `import * as ns from './barrel'` 값 사용 시 namespace getter가 실제
+        /// export source 모듈을 lazy init하기 위한 모듈 인덱스.
+        init_mod: ?u32 = null,
         /// re_export_namespace (`export * as Foo from './src'`) / `import * as X; export {X}`
         /// 패턴에서 source 모듈 인덱스. registerNamespaceRewrites 가 이 정보로
         /// hoisted ns_var (예: `Foo_ns`) 를 한 번 declare 하고 inner_map 매핑을
@@ -1687,11 +1690,16 @@ pub const Linker = struct {
             // 만 기록하고 ns_var 등록은 호출 site 가 일임.
             var ns_target_mod: ?u32 = null;
             var owns_actual_local = false;
+            var init_mod: ?u32 = if (m.wrap_kind == .esm) mod_i else null;
             const actual_local = if (eb.kind == .re_export_namespace) blk: {
                 ns_target_mod = resolvedRecordModule(m.import_records, eb.import_record_index);
                 break :blk eb_local;
             } else if (eb.kind == .re_export) blk: {
                 if (self.resolveExportChain(module_idx, eb.exported_name, 0)) |canonical| {
+                    init_mod = if (self.graph.getModule(canonical.module_index)) |cmod|
+                        if (cmod.wrap_kind == .esm) @intFromEnum(canonical.module_index) else null
+                    else
+                        null;
                     if (self.graph.getModule(canonical.module_index)) |cmod| {
                         for (cmod.export_bindings) |ceb| {
                             if (ceb.kind.isReExportAll() and
@@ -1707,6 +1715,7 @@ pub const Linker = struct {
                     if (ns_target_mod == null) {
                         if (try self.cjsNamespaceExportAccess(canonical)) |expr| {
                             owns_actual_local = true;
+                            init_mod = null;
                             break :blk expr;
                         }
                         break :blk self.resolveToLocalName(canonical);
@@ -1729,6 +1738,7 @@ pub const Linker = struct {
                 .exported = eb.exported_name,
                 .local = safe_local,
                 .owned = owns_actual_local,
+                .init_mod = init_mod,
                 .ns_target_mod = ns_target_mod,
             });
         }

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -93,19 +93,18 @@ pub fn isImportBindingTypeOnly(sem: *const @import("../module.zig").ModuleSemant
     return true;
 }
 
-fn allocLazyEsmImportExpr(self: *const Linker, target_mod: *const Module, target_name: []const u8) ![]const u8 {
-    const sep = if (self.minify_whitespace) "," else ", ";
+fn allocEsmInitExpr(self: *const Linker, target_mod: *const Module) ![]const u8 {
     const guard_close_expr = "})";
     const guard = target_mod.shouldGuard(self.entry_error_guard);
     if (self.dev_mode) {
         if (guard) {
             return try std.fmt.allocPrint(
                 self.allocator,
-                "({s}__zntc_modules[\"{s}\"].fn(){s}{s}{s})",
-                .{ if (self.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN, target_mod.dev_id, guard_close_expr, sep, target_name },
+                "{s}__zntc_modules[\"{s}\"].fn(){s}",
+                .{ if (self.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN, target_mod.dev_id, guard_close_expr },
             );
         }
-        return try std.fmt.allocPrint(self.allocator, "(__zntc_modules[\"{s}\"].fn(){s}{s})", .{ target_mod.dev_id, sep, target_name });
+        return try std.fmt.allocPrint(self.allocator, "__zntc_modules[\"{s}\"].fn()", .{target_mod.dev_id});
     }
 
     const init_name = try target_mod.allocInitName(self.allocator);
@@ -113,15 +112,42 @@ fn allocLazyEsmImportExpr(self: *const Linker, target_mod: *const Module, target
     if (guard) {
         return try std.fmt.allocPrint(
             self.allocator,
-            "({s}{s}(){s}{s}{s})",
-            .{ if (self.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN, init_name, guard_close_expr, sep, target_name },
+            "{s}{s}(){s}",
+            .{ if (self.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN, init_name, guard_close_expr },
         );
     }
-    return try std.fmt.allocPrint(
-        self.allocator,
-        "({s}(){s}{s})",
-        .{ init_name, sep, target_name },
-    );
+    return try std.fmt.allocPrint(self.allocator, "{s}()", .{init_name});
+}
+
+fn allocLazyEsmImportExpr(self: *const Linker, import_mod: *const Module, value_mod: *const Module, target_name: []const u8) ![]const u8 {
+    const sep = if (self.minify_whitespace) "," else ", ";
+    const import_init = try allocEsmInitExpr(self, import_mod);
+    defer self.allocator.free(import_init);
+    if (import_mod.index == value_mod.index) {
+        return try std.fmt.allocPrint(self.allocator, "({s}{s}{s})", .{ import_init, sep, target_name });
+    }
+
+    const value_init = try allocEsmInitExpr(self, value_mod);
+    defer self.allocator.free(value_init);
+    return try std.fmt.allocPrint(self.allocator, "({s}{s}{s}{s}{s})", .{ import_init, sep, value_init, sep, target_name });
+}
+
+fn appendEsmInitCall(self: *const Linker, preamble: anytype, target_mod: *const Module) !void {
+    const is_tla = target_mod.uses_top_level_await;
+    const guard = target_mod.shouldGuard(self.entry_error_guard);
+    if (is_tla) try preamble.write("await ");
+    if (guard) try preamble.write(if (self.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN);
+    if (self.dev_mode) {
+        try preamble.write("__zntc_modules[\"");
+        try preamble.write(target_mod.dev_id);
+        try preamble.write("\"].fn()");
+    } else {
+        const init_name = try target_mod.allocInitName(self.allocator);
+        defer self.allocator.free(init_name);
+        try preamble.write(init_name);
+        try preamble.write("()");
+    }
+    try preamble.write(if (guard) rt.GUARD_LAMBDA_CLOSE else rt.INIT_CALL_END);
 }
 
 pub fn buildSkipNodes(allocator: std.mem.Allocator, ast: *const Ast, skip_imports: bool) !std.DynamicBitSet {
@@ -514,11 +540,15 @@ pub fn buildMetadataForAst(
                 continue;
             }
 
+            // resolveImports()에서 이미 해결한 바인딩을 조회하거나, 직접 해결
+            const resolved = self.getResolvedBinding(module_index, ib.local_span);
+
             // __esm 래핑 모듈에서 import: init_xxx() 호출을 preamble에 추가.
             // 호이스팅된 함수는 top-level에 있으므로 rename으로 참조 가능.
             // init 호출은 모듈당 1회만 (중복 방지는 esm_init_set으로).
             // `entry_error_guard` 활성 시 wrap. TLA 는 await 가 lambda 안에 못 들어가서 제외.
             var lazy_esm_import = false;
+            var lazy_esm_import_mod: ?*const Module = null;
             if (canonical_m_opt != null and canonical_m_opt.?.wrap_kind == .esm) {
                 // CJS path 와 동일하게 tree-shake 결과 반영 (#2398). `sideEffects: false`
                 // 인 .esm wrap 모듈이 unused 로 drop 되면 `init_xxx is not defined` 가
@@ -537,6 +567,21 @@ pub fn buildMetadataForAst(
                 // 있지 않다. 그래서 보수적으로 default 만 eager 유지: top-level
                 // provider 등록을 하는 모듈 (예: RNFirebase Firestore) 의 부작용이
                 // lazy 화로 누락되어 Metro 와 다른 초기화 순서가 되는 것을 차단.
+                var value_init_mod = target_mod;
+                var value_init_mod_idx = canonical_mod;
+                if (resolved) |rb| {
+                    const rb_idx = @intFromEnum(rb.canonical.module_index);
+                    if (rb_idx != canonical_mod) {
+                        if (self.graph.getModule(rb.canonical.module_index)) |rb_mod| {
+                            if (rb_mod.wrap_kind == .esm) {
+                                value_init_mod = rb_mod;
+                                value_init_mod_idx = @intCast(rb_idx);
+                            }
+                        }
+                    }
+                }
+                if (self.tree_shaker_active and !value_init_mod.is_included) continue;
+
                 lazy_esm_import = self.inline_requires and
                     m.wrap_kind == .esm and
                     rec.kind == .static_import and
@@ -545,24 +590,18 @@ pub fn buildMetadataForAst(
                     ib.kind == .named and
                     !ib.importsDefault() and
                     !target_mod.uses_top_level_await and
+                    !value_init_mod.uses_top_level_await and
                     !exported_locals.contains(m.importBindingLocalName(ib));
+                if (lazy_esm_import) {
+                    lazy_esm_import_mod = value_init_mod;
+                }
                 if (!lazy_esm_import and !esm_init_set.contains(@intCast(canonical_mod))) {
                     try esm_init_set.put(@intCast(canonical_mod), {});
-                    const is_tla = target_mod.uses_top_level_await;
-                    const guard = target_mod.shouldGuard(self.entry_error_guard);
-                    if (is_tla) try preamble.write("await ");
-                    if (guard) try preamble.write(if (self.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN);
-                    if (self.dev_mode) {
-                        try preamble.write("__zntc_modules[\"");
-                        try preamble.write(target_mod.dev_id);
-                        try preamble.write("\"].fn()");
-                    } else {
-                        const init_name = try target_mod.allocInitName(self.allocator);
-                        defer self.allocator.free(init_name);
-                        try preamble.write(init_name);
-                        try preamble.write("()");
-                    }
-                    try preamble.write(if (guard) rt.GUARD_LAMBDA_CLOSE else rt.INIT_CALL_END);
+                    try appendEsmInitCall(self, &preamble, target_mod);
+                }
+                if (!lazy_esm_import and value_init_mod_idx != canonical_mod and !esm_init_set.contains(@intCast(value_init_mod_idx))) {
+                    try esm_init_set.put(@intCast(value_init_mod_idx), {});
+                    try appendEsmInitCall(self, &preamble, value_init_mod);
                 }
                 // import binding은 아래의 rename 경로로 처리 (continue하지 않음)
             }
@@ -592,9 +631,6 @@ pub fn buildMetadataForAst(
                 );
                 continue;
             }
-
-            // resolveImports()에서 이미 해결한 바인딩을 조회하거나, 직접 해결
-            const resolved = self.getResolvedBinding(module_index, ib.local_span);
 
             // 롤다운 shimMissingExports 호환: 소스 모듈에 해당 export가 없으면
             // strict mode ReferenceError 대신 undefined를 반환하도록 shim 생성.
@@ -702,7 +738,7 @@ pub fn buildMetadataForAst(
             if (!isReservedName(target_name) and target_name.len > 0 and isValidIdentStartByte(target_name[0])) {
                 if (ib.local_symbol.semanticIndex()) |sym_idx| {
                     const rename_value = if (lazy_esm_import)
-                        try allocLazyEsmImportExpr(self, canonical_m_opt.?, target_name)
+                        try allocLazyEsmImportExpr(self, canonical_m_opt.?, lazy_esm_import_mod orelse canonical_m_opt.?, target_name)
                     else
                         target_name;
                     if (lazy_esm_import) {

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -622,6 +622,7 @@ pub fn buildMetadataForAst(
                 try self.registerNamespaceRewrites(
                     &ns_rewrite_list,
                     &ns_inline_list,
+                    &owned_nested_renames,
                     &ns_target_to_var,
                     force_inline,
                     module_index,
@@ -684,6 +685,7 @@ pub fn buildMetadataForAst(
                                             try self.registerNamespaceRewrites(
                                                 &ns_rewrite_list,
                                                 &ns_inline_list,
+                                                &owned_nested_renames,
                                                 &ns_target_to_var,
                                                 true,
                                                 module_index,
@@ -713,6 +715,7 @@ pub fn buildMetadataForAst(
                                 try self.registerNamespaceRewrites(
                                     &ns_rewrite_list,
                                     &ns_inline_list,
+                                    &owned_nested_renames,
                                     &ns_target_to_var,
                                     true,
                                     module_index,

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -547,6 +547,11 @@ fn allocNamespaceGetterValue(self: *const Linker, exp: NsExportPair) std.mem.All
 }
 
 fn allocNamespaceMemberRewriteValue(self: *const Linker, target_mod_idx: u32, exp: NsExportPair) std.mem.Allocator.Error!?[]const u8 {
+    // dev_mode 의 `__zntc_modules[...].fn()` lazy 런타임에서만 init wrap 이 필요하다.
+    // 비-dev 빌드는 namespace import 의 top-level `init_X()` preamble 이 init 을 보장하므로
+    // wrap 이 중복이며 `(init_X(), name)` 형태가 직접 치환을 기대하는 호출지점을 깨뜨린다.
+    if (!self.dev_mode) return null;
+
     const target_init = try allocEsmInitExprForModuleIndex(self, target_mod_idx);
     defer if (target_init) |expr| self.allocator.free(expr);
 

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -42,6 +42,7 @@ pub fn registerNamespaceRewrites(
     self: *const Linker,
     ns_rewrite_list: *std.ArrayList(LinkingMetadata.NsMemberRewrites.Entry),
     ns_inline_list: *std.ArrayList(LinkingMetadata.NsInlineObjects.Entry),
+    owned_rewrite_values: *std.ArrayListUnmanaged([]const u8),
     /// 같은 importer 안에서 여러 namespace import 가 같은 target source 의 inline ns_var
     /// 를 공유하도록 caller 가 owned. `cjs_var_cache` 와 같은 패턴 (`metadata.zig`).
     ns_target_to_var: *std.AutoHashMap(u32, []const u8),
@@ -109,6 +110,8 @@ pub fn registerNamespaceRewrites(
     // hoisted ns_var 를 만들고 inner_map 매핑은 그 변수명으로 둔다 — emitStaticMember
     // 가 access site 마다 객체 literal 을 inline emit 하는 회귀 방지 (#1928).
     var inner_map = std.StringHashMap([]const u8).init(self.allocator);
+    var inner_map_transferred = false;
+    errdefer if (!inner_map_transferred) inner_map.deinit();
     var has_shadow = false;
     for (cached_exports) |exp| {
         if (hasNestedBinding(self, importer_mod_idx, exp.exported)) {
@@ -142,6 +145,16 @@ pub fn registerNamespaceRewrites(
             try inner_map.put(exp.exported, ns_var);
             continue;
         }
+        if (try allocNamespaceMemberRewriteValue(self, target_mod_idx, exp)) |rewrite_value| {
+            var owned_by_list = false;
+            errdefer if (!owned_by_list) self.allocator.free(rewrite_value);
+            // ns_member_rewrites map 은 포인터만 빌리고, 실제 소유권은
+            // LinkingMetadata.owned_rename_values 로 이전해 metadata deinit 에서 해제한다.
+            try owned_rewrite_values.append(self.allocator, rewrite_value);
+            owned_by_list = true;
+            try inner_map.put(exp.exported, rewrite_value);
+            continue;
+        }
         // exp.local 은 owned=true 면 ns_export_cache 가, 아니면 target module 이 소유한다.
         // metadata map 은 값 포인터만 빌린다.
         try inner_map.put(exp.exported, exp.local);
@@ -150,6 +163,7 @@ pub fn registerNamespaceRewrites(
         .symbol_id = symbol_id,
         .map = inner_map,
     });
+    inner_map_transferred = true;
 
     // ns_inline_list 활성화 조건: caller 가 명시 (force_inline) 또는 shadow 충돌 발생.
     // 후자의 경우 codegen fallback 이 namespace 객체 access 로 emit 할 수 있도록 객체가 필요.
@@ -530,6 +544,38 @@ fn allocNamespaceGetterValue(self: *const Linker, exp: NsExportPair) std.mem.All
     defer self.allocator.free(init_expr);
     const sep = if (self.minify_whitespace) "," else ", ";
     return try std.fmt.allocPrint(self.allocator, "({s}{s}{s})", .{ init_expr, sep, exp.local });
+}
+
+fn allocNamespaceMemberRewriteValue(self: *const Linker, target_mod_idx: u32, exp: NsExportPair) std.mem.Allocator.Error!?[]const u8 {
+    const target_init = try allocEsmInitExprForModuleIndex(self, target_mod_idx);
+    defer if (target_init) |expr| self.allocator.free(expr);
+
+    const source_init = if (exp.init_mod) |source_mod_idx|
+        if (source_mod_idx != target_mod_idx)
+            try allocEsmInitExprForModuleIndex(self, source_mod_idx)
+        else
+            null
+    else
+        null;
+    defer if (source_init) |expr| self.allocator.free(expr);
+
+    const sep = if (self.minify_whitespace) "," else ", ";
+    if (target_init) |target_expr| {
+        if (source_init) |source_expr| {
+            return try std.fmt.allocPrint(self.allocator, "({s}{s}{s}{s}{s})", .{ target_expr, sep, source_expr, sep, exp.local });
+        }
+        return try std.fmt.allocPrint(self.allocator, "({s}{s}{s})", .{ target_expr, sep, exp.local });
+    }
+    if (source_init) |source_expr| {
+        return try std.fmt.allocPrint(self.allocator, "({s}{s}{s})", .{ source_expr, sep, exp.local });
+    }
+    return null;
+}
+
+fn allocEsmInitExprForModuleIndex(self: *const Linker, mod_idx: u32) std.mem.Allocator.Error!?[]const u8 {
+    const mod = self.graph.getModule(@enumFromInt(mod_idx)) orelse return null;
+    if (mod.wrap_kind != .esm) return null;
+    return try allocEsmInitExpr(self, mod);
 }
 
 fn allocEsmInitExpr(self: *const Linker, target_mod: *const @import("../module.zig").Module) std.mem.Allocator.Error![]const u8 {

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -11,6 +11,7 @@ const Linker = linker_mod.Linker;
 const LinkingMetadata = linker_mod.LinkingMetadata;
 const ModuleIndex = @import("../types.zig").ModuleIndex;
 const CompiledModule = @import("../compiled_module.zig").CompiledModule;
+const rt = @import("../runtime_helpers.zig");
 const profile = @import("../../profile.zig");
 
 const NsExportPair = Linker.NsExportPair;
@@ -497,7 +498,12 @@ fn buildInlineObjectStr(
                 try buf.appendSlice(self.allocator, exp.exported);
             }
             try buf.appendSlice(self.allocator, "() { return ");
-            try buf.appendSlice(self.allocator, exp.local);
+            if (try allocNamespaceGetterValue(self, exp)) |value| {
+                defer self.allocator.free(value);
+                try buf.appendSlice(self.allocator, value);
+            } else {
+                try buf.appendSlice(self.allocator, exp.local);
+            }
             try buf.appendSlice(self.allocator, "; }");
         }
     }
@@ -513,6 +519,43 @@ fn buildInlineObjectStr(
     }
     try mutable_self.ns_inline_cache.put(self.allocator, target_mod_idx, result);
     return try self.allocator.dupe(u8, result);
+}
+
+fn allocNamespaceGetterValue(self: *const Linker, exp: NsExportPair) std.mem.Allocator.Error!?[]const u8 {
+    const init_mod_idx = exp.init_mod orelse return null;
+    const init_mod = self.graph.getModule(@enumFromInt(init_mod_idx)) orelse return null;
+    if (init_mod.wrap_kind != .esm) return null;
+
+    const init_expr = try allocEsmInitExpr(self, init_mod);
+    defer self.allocator.free(init_expr);
+    const sep = if (self.minify_whitespace) "," else ", ";
+    return try std.fmt.allocPrint(self.allocator, "({s}{s}{s})", .{ init_expr, sep, exp.local });
+}
+
+fn allocEsmInitExpr(self: *const Linker, target_mod: *const @import("../module.zig").Module) std.mem.Allocator.Error![]const u8 {
+    const guard_close_expr = "})";
+    const guard = target_mod.shouldGuard(self.entry_error_guard);
+    if (self.dev_mode) {
+        if (guard) {
+            return try std.fmt.allocPrint(
+                self.allocator,
+                "{s}__zntc_modules[\"{s}\"].fn(){s}",
+                .{ if (self.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN, target_mod.dev_id, guard_close_expr },
+            );
+        }
+        return try std.fmt.allocPrint(self.allocator, "__zntc_modules[\"{s}\"].fn()", .{target_mod.dev_id});
+    }
+
+    const init_name = try target_mod.allocInitName(self.allocator);
+    defer self.allocator.free(init_name);
+    if (guard) {
+        return try std.fmt.allocPrint(
+            self.allocator,
+            "{s}{s}(){s}",
+            .{ if (self.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN, init_name, guard_close_expr },
+        );
+    }
+    return try std.fmt.allocPrint(self.allocator, "{s}()", .{init_name});
 }
 
 /// JS 예약어인 export 이름은 프로퍼티 키에 따옴표 필요.

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -41,6 +41,7 @@ pub const CachedResolvedDep = struct {
     kind: types.ImportKind,
     target: Target,
     path: []const u8,
+    resolve_dir: ?[]const u8 = null,
     target_is_module_field: bool = false,
     is_context_dep: bool = false,
 
@@ -133,6 +134,9 @@ pub const Module = struct {
     index: ModuleIndex,
     /// 절대 파일 경로. graph의 path_to_module 키와 동일한 메모리를 참조 (빌림).
     path: []const u8,
+    /// dependency lookup 시작 디렉토리. preserve_symlinks=true 에서 symlink 를 거친
+    /// logical dirname 을 보존한다. null 이면 dirname(path)를 사용.
+    resolve_dir: ?[]const u8 = null,
     /// dev mode 모듈 ID. bundler에서 한 번 계산 (path의 서브슬라이스, 할당 없음).
     dev_id: []const u8 = "",
     /// 소스 코드. parse_arena에서 할당 (Module.arena가 소유).
@@ -533,12 +537,20 @@ pub const Module = struct {
         return if (self.dev_id.len > 0) self.dev_id else std.fs.path.basename(self.path);
     }
 
+    pub fn sourceDir(self: *const Module) []const u8 {
+        return self.resolve_dir orelse std.fs.path.dirname(self.path) orelse ".";
+    }
+
     pub fn deinit(self: *Module, allocator: std.mem.Allocator) void {
         self.dependencies.deinit(allocator);
         self.importers.deinit(allocator);
         self.dynamic_imports.deinit(allocator);
         self.dynamic_importers.deinit(allocator);
-        for (self.resolved_deps.items) |dep| allocator.free(dep.path);
+        if (self.resolve_dir) |dir| allocator.free(dir);
+        for (self.resolved_deps.items) |dep| {
+            allocator.free(dep.path);
+            if (dep.resolve_dir) |dir| allocator.free(dir);
+        }
         self.resolved_deps.deinit(allocator);
         if (self.alias_table) |*t| t.deinit();
         // require.context: plugin 이 채운 outer slice + 각 inner string free (#1579 Phase 2).

--- a/src/bundler/module_store.zig
+++ b/src/bundler/module_store.zig
@@ -57,7 +57,11 @@ pub const PersistentModuleStore = struct {
         cached.module.importers.deinit(self.allocator);
         cached.module.dynamic_imports.deinit(self.allocator);
         cached.module.dynamic_importers.deinit(self.allocator);
-        for (cached.module.resolved_deps.items) |dep| self.allocator.free(dep.path);
+        if (cached.module.resolve_dir) |dir| self.allocator.free(dir);
+        for (cached.module.resolved_deps.items) |dep| {
+            self.allocator.free(dep.path);
+            if (dep.resolve_dir) |dir| self.allocator.free(dir);
+        }
         cached.module.resolved_deps.deinit(self.allocator);
         // import_specifiers 해제
         for (cached.import_specifiers) |s| self.allocator.free(s);
@@ -101,6 +105,7 @@ pub const PersistentModuleStore = struct {
         // 그 포인터를 통해 setCanonicalName 이 uaf 쓰기를 해 임의의 heap 영역
         // (특히 nested_name_sets HashMap backing 의 Header.capacity) 을 덮어쓴다.
         module.parse_arena = null;
+        module.resolve_dir = null;
         module.alias_table = null;
         module.import_records = &.{};
         module.resolved_deps = .empty;
@@ -113,14 +118,26 @@ pub const PersistentModuleStore = struct {
                 .import_specifiers = specs,
             }) catch {
                 if (cached_module.parse_arena) |a| Module_mod.destroyParseArena(self.allocator, a);
+                if (cached_module.resolve_dir) |dir| self.allocator.free(dir);
                 if (cached_module.alias_table) |*t| t.deinit();
+                for (cached_module.resolved_deps.items) |dep| {
+                    self.allocator.free(dep.path);
+                    if (dep.resolve_dir) |dir| self.allocator.free(dir);
+                }
+                cached_module.resolved_deps.deinit(self.allocator);
                 for (specs) |s| self.allocator.free(s);
                 self.allocator.free(specs);
             };
         } else {
             const key = self.allocator.dupe(u8, path) catch {
                 if (cached_module.parse_arena) |a| Module_mod.destroyParseArena(self.allocator, a);
+                if (cached_module.resolve_dir) |dir| self.allocator.free(dir);
                 if (cached_module.alias_table) |*t| t.deinit();
+                for (cached_module.resolved_deps.items) |dep| {
+                    self.allocator.free(dep.path);
+                    if (dep.resolve_dir) |dir| self.allocator.free(dir);
+                }
+                cached_module.resolved_deps.deinit(self.allocator);
                 for (specs) |s| self.allocator.free(s);
                 self.allocator.free(specs);
                 return;
@@ -133,7 +150,13 @@ pub const PersistentModuleStore = struct {
             }) catch {
                 self.allocator.free(key);
                 if (cached_module.parse_arena) |a| Module_mod.destroyParseArena(self.allocator, a);
+                if (cached_module.resolve_dir) |dir| self.allocator.free(dir);
                 if (cached_module.alias_table) |*t| t.deinit();
+                for (cached_module.resolved_deps.items) |dep| {
+                    self.allocator.free(dep.path);
+                    if (dep.resolve_dir) |dir| self.allocator.free(dir);
+                }
+                cached_module.resolved_deps.deinit(self.allocator);
                 for (specs) |s| self.allocator.free(s);
                 self.allocator.free(specs);
             };

--- a/src/bundler/plugin.zig
+++ b/src/bundler/plugin.zig
@@ -132,6 +132,7 @@ pub const ResolvedModule = union(fs.Namespace) {
     /// fs 또는 plugin 이 제공한 실제 파일. 절대 경로 + module_type + ESM hint.
     file: struct {
         path: []const u8,
+        resolve_dir: ?[]const u8 = null,
         module_type: ModuleType = .unknown,
         is_module_field: bool = false,
     },

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -283,7 +283,7 @@ pub const ResolveCache = struct {
             while (it.next()) |entry| {
                 self.allocator.free(entry.key_ptr.*);
                 switch (entry.value_ptr.*) {
-                    .resolved => |m| self.allocator.free(cachedPath(m)),
+                    .resolved => |m| self.freeCachedResolvedModule(m),
                     .not_found => {},
                 }
             }
@@ -383,6 +383,7 @@ pub const ResolveCache = struct {
                     .resolved => |m| switch (m) {
                         .file => |f| fileResult(
                             self.allocator.dupe(u8, f.path) catch return error.OutOfMemory,
+                            try self.dupeOptional(f.resolve_dir),
                             f.module_type,
                             f.is_module_field,
                         ),
@@ -479,6 +480,7 @@ pub const ResolveCache = struct {
                 .path = cache_path,
                 .module_type = result.module_type,
             } } }) catch {};
+            if (result.resolve_dir) |dir| self.allocator.free(dir);
             return disabledResult(result.path, result.module_type);
         }
 
@@ -495,6 +497,7 @@ pub const ResolveCache = struct {
                         .path = cache_path,
                         .module_type = result.module_type,
                     } } }) catch {};
+                    if (result.resolve_dir) |dir| self.allocator.free(dir);
                     return disabledResult(result.path, result.module_type);
                 },
                 .remap => |rep| {
@@ -506,25 +509,31 @@ pub const ResolveCache = struct {
                             var store_scope = profile.begin(.resolve_cache_store);
                             defer store_scope.end();
                             const cache_path = self.allocator.dupe(u8, result.path) catch return error.OutOfMemory;
+                            const cache_resolve_dir = try self.dupeOptional(result.resolve_dir);
                             self.putCache(cache_key, .{ .resolved = .{ .file = .{
                                 .path = cache_path,
+                                .resolve_dir = cache_resolve_dir,
                                 .module_type = result.module_type,
                             } } }) catch {};
-                            return fileResult(result.path, result.module_type, result.is_module_field);
+                            return fileResult(result.path, result.resolve_dir, result.module_type, result.is_module_field);
                         };
                         defer self.allocator.free(spec_buf);
                         if (thread_safe) cache_shard.mutex.unlock();
                         const maybe_replaced = self.resolver.resolve(pkg_root, spec_buf);
                         if (thread_safe) cache_shard.mutex.lock();
                         if (maybe_replaced) |replaced| {
+                            self.allocator.free(result.path);
+                            if (result.resolve_dir) |dir| self.allocator.free(dir);
                             var store_scope = profile.begin(.resolve_cache_store);
                             defer store_scope.end();
                             const cache_path = self.allocator.dupe(u8, replaced.path) catch return error.OutOfMemory;
+                            const cache_resolve_dir = try self.dupeOptional(replaced.resolve_dir);
                             self.putCache(cache_key, .{ .resolved = .{ .file = .{
                                 .path = cache_path,
+                                .resolve_dir = cache_resolve_dir,
                                 .module_type = replaced.module_type,
                             } } }) catch {};
-                            return fileResult(replaced.path, replaced.module_type, replaced.is_module_field);
+                            return fileResult(replaced.path, replaced.resolve_dir, replaced.module_type, replaced.is_module_field);
                         } else |_| {
                             // fallthrough — replacement 해결 실패 시 원본 사용.
                         }
@@ -538,33 +547,44 @@ pub const ResolveCache = struct {
             var store_scope = profile.begin(.resolve_cache_store);
             defer store_scope.end();
             const cache_path = self.allocator.dupe(u8, result.path) catch return error.OutOfMemory;
+            const cache_resolve_dir = try self.dupeOptional(result.resolve_dir);
             self.putCache(cache_key, .{ .resolved = .{ .file = .{
                 .path = cache_path,
+                .resolve_dir = cache_resolve_dir,
                 .module_type = result.module_type,
             } } }) catch {};
         }
 
-        return fileResult(result.path, result.module_type, result.is_module_field);
+        return fileResult(result.path, result.resolve_dir, result.module_type, result.is_module_field);
     }
 
     /// path 는 caller 가 이미 dupe 한 것을 전달 — caller 가 메모리 owner.
-    fn fileResult(path: []const u8, module_type: ModuleType, is_module_field: bool) ResolvedModule {
-        return .{ .file = .{ .path = path, .module_type = module_type, .is_module_field = is_module_field } };
+    fn fileResult(path: []const u8, resolve_dir: ?[]const u8, module_type: ModuleType, is_module_field: bool) ResolvedModule {
+        return .{ .file = .{
+            .path = path,
+            .resolve_dir = resolve_dir,
+            .module_type = module_type,
+            .is_module_field = is_module_field,
+        } };
     }
 
     fn disabledResult(path: []const u8, module_type: ModuleType) ResolvedModule {
         return .{ .disabled = .{ .path = path, .module_type = module_type } };
     }
 
-    /// CachedResult.resolved (ResolvedModule) 의 path 추출.
-    /// **불변식**: Phase 1 의 cache 는 file/disabled variant 만 저장 (putCache 호출처 검증).
-    /// 다른 variant 도달은 BUG — `else => ""` 는 free no-op safety net.
-    fn cachedPath(m: ResolvedModule) []const u8 {
-        return switch (m) {
-            .file => |f| f.path,
-            .disabled => |d| d.path,
-            else => "",
-        };
+    fn dupeOptional(self: *ResolveCache, value: ?[]const u8) error{OutOfMemory}!?[]const u8 {
+        return if (value) |v| self.allocator.dupe(u8, v) catch return error.OutOfMemory else null;
+    }
+
+    fn freeCachedResolvedModule(self: *ResolveCache, m: ResolvedModule) void {
+        switch (m) {
+            .file => |f| {
+                self.allocator.free(f.path);
+                if (f.resolve_dir) |dir| self.allocator.free(dir);
+            },
+            .disabled => |d| self.allocator.free(d.path),
+            else => {},
+        }
     }
 
     /// 캐시에 엔트리 저장. 기존 키가 있으면 이전 키/값 해제 (Critical #1 수정).
@@ -575,7 +595,7 @@ pub const ResolveCache = struct {
         if (map.fetchRemove(cache_key)) |old| {
             self.allocator.free(old.key);
             switch (old.value) {
-                .resolved => |m| self.allocator.free(cachedPath(m)),
+                .resolved => |m| self.freeCachedResolvedModule(m),
                 .not_found => {},
             }
         }

--- a/src/bundler/resolve_cache_test.zig
+++ b/src/bundler/resolve_cache_test.zig
@@ -235,7 +235,10 @@ test "resolve: profile .resolve 비활성 시 누적 없음" {
 
 fn freeResolvedPath(m: ResolvedModule) void {
     switch (m) {
-        .file => |f| std.testing.allocator.free(f.path),
+        .file => |f| {
+            std.testing.allocator.free(f.path);
+            if (f.resolve_dir) |dir| std.testing.allocator.free(dir);
+        },
         .disabled => |d| std.testing.allocator.free(d.path),
         // Phase 1 cache 는 file/disabled 만 저장 — virtual/dataurl/external/custom variant
         // 가 cache 에서 반환되지 않음. 향후 그 variant 검증 테스트 추가 시 plugin_data

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -37,6 +37,10 @@ pub const ResolveResult = struct {
     /// package.json "module" 필드를 통해 resolve된 파일.
     /// .js 확장자라도 ESM으로 파싱해야 함.
     is_module_field: bool = false,
+    /// preserve_symlinks=true 에서 모듈 identity 는 realpath 로 dedupe 하되,
+    /// 그 모듈의 dependency lookup 은 symlink 를 거친 logical dirname 에서 시작해야 한다.
+    /// null 이면 dirname(path)를 사용.
+    resolve_dir: ?[]const u8 = null,
 };
 
 pub const ResolveError = error{
@@ -296,8 +300,8 @@ pub const Resolver = struct {
     /// ResolveCache.conditionsFor()에서 platform+kind별로 설정.
     /// 기본값은 테스트용 (브라우저 ESM).
     conditions: []const []const u8 = &.{ "import", "module", "browser", "default" },
-    /// symlink를 따라가지 않고 링크 자체 경로로 해석 (--preserve-symlinks).
-    /// true이면 makeResult()에서 realpathAlloc 대신 allocator.dupe 사용.
+    /// symlink를 통해 접근한 package 의 lookup root 를 보존 (--preserve-symlinks).
+    /// module identity 는 항상 realpath 로 canonicalize 해 React 같은 peer singleton 을 dedupe 한다.
     preserve_symlinks: bool = false,
     /// `resolveNodeModules` 의 parent dir walk-up 차단 (Metro `resolver.
     /// disableHierarchicalLookup` 호환). monorepo 에서 dependency hoisting
@@ -425,6 +429,7 @@ pub const Resolver = struct {
             for (self.block_list) |pat| {
                 if (bl.matches(pat, result.path)) {
                     self.allocator.free(result.path);
+                    if (result.resolve_dir) |dir| self.allocator.free(dir);
                     return error.ModuleNotFound;
                 }
             }
@@ -456,6 +461,11 @@ pub const Resolver = struct {
         // bare specifier → node_modules 탐색
         if (!isRelativeOrAbsolute(effective_specifier)) {
             return self.resolveNodeModules(source_dir, effective_specifier) catch |err| {
+                if (err == error.ModuleNotFound and self.preserve_symlinks) {
+                    if (self.resolveNodeModulesFromRealpath(source_dir, effective_specifier)) |r| return r else |fallback_err| {
+                        if (fallback_err != error.ModuleNotFound) return fallback_err;
+                    }
+                }
                 if (err == error.ModuleNotFound and self.fallback.len > 0) {
                     if (try self.applyFallback(source_dir, effective_specifier)) |r| return r;
                 }
@@ -698,6 +708,22 @@ pub const Resolver = struct {
         return error.ModuleNotFound;
     }
 
+    fn resolveNodeModulesFromRealpath(self: *Resolver, source_dir: []const u8, specifier: []const u8) ResolveError!ResolveResult {
+        const real_source_dir = blk: {
+            var realpath_scope = profile.begin(.resolve_realpath);
+            defer realpath_scope.end();
+            if (self.realpath_cache) |cache| {
+                break :blk cache.resolve(source_dir) catch
+                    self.allocator.dupe(u8, source_dir) catch return error.OutOfMemory;
+            }
+            break :blk fs.realpath(self.allocator, source_dir) catch
+                self.allocator.dupe(u8, source_dir) catch return error.OutOfMemory;
+        };
+        defer self.allocator.free(real_source_dir);
+        if (std.mem.eql(u8, real_source_dir, source_dir)) return error.ModuleNotFound;
+        return self.resolveNodeModules(real_source_dir, specifier);
+    }
+
     /// 패키지 디렉토리에서 엔트리포인트를 해석한다.
     /// 우선순위: exports → module → main → index 파일
     fn resolvePackage(self: *Resolver, pkg_dir_path: []const u8, subpath: []const u8) ResolveError!?ResolveResult {
@@ -805,15 +831,12 @@ pub const Resolver = struct {
     }
 
     fn makeResult(self: *Resolver, path: []const u8) ResolveError!?ResolveResult {
-        // preserve_symlinks=true이면 symlink를 따라가지 않고 경로 그대로 사용.
-        // 기본(false)이면 bun(.bun/)과 pnpm(.pnpm/)의 symlink를 realpath로 해석하여
-        // 중첩 node_modules 탐색이 올바른 계층에서 동작하도록 한다.
+        // module identity 는 항상 realpath 로 canonicalize 한다. preserve_symlinks=true 는
+        // canonical path 대신 logical path 를 쓰는 옵션이 아니라, logical resolve root 를
+        // 별도 보존하는 옵션으로 해석한다.
         const resolved = blk: {
             var realpath_scope = profile.begin(.resolve_realpath);
             defer realpath_scope.end();
-            if (self.preserve_symlinks) {
-                break :blk self.allocator.dupe(u8, path) catch return error.OutOfMemory;
-            }
             if (self.realpath_cache) |cache| {
                 break :blk cache.resolve(path) catch
                     self.allocator.dupe(u8, path) catch return error.OutOfMemory;
@@ -821,10 +844,17 @@ pub const Resolver = struct {
             break :blk fs.realpath(self.allocator, path) catch
                 self.allocator.dupe(u8, path) catch return error.OutOfMemory;
         };
+        errdefer self.allocator.free(resolved);
+
+        const resolve_dir = if (self.preserve_symlinks and !std.mem.eql(u8, resolved, path)) blk: {
+            const logical_dir = std.fs.path.dirname(path) orelse ".";
+            break :blk self.allocator.dupe(u8, logical_dir) catch return error.OutOfMemory;
+        } else null;
         const ext = std.fs.path.extension(resolved);
         return .{
             .path = resolved,
             .module_type = ModuleType.fromExtension(ext),
+            .resolve_dir = resolve_dir,
         };
     }
 

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -712,9 +712,15 @@ pub const Resolver = struct {
         const real_source_dir = blk: {
             var realpath_scope = profile.begin(.resolve_realpath);
             defer realpath_scope.end();
-            if (self.realpath_cache) |cache| {
-                break :blk cache.resolve(source_dir) catch
-                    self.allocator.dupe(u8, source_dir) catch return error.OutOfMemory;
+            // preserve_symlinks fallback is specifically for a logical node_modules package
+            // directory that may itself be a symlink (pnpm: app/node_modules/pkg -> .pnpm/...).
+            // Dir-level realpath caching realpaths dirname(source_dir) + basename(source_dir),
+            // which does not follow a symlink in the final path segment. Use full realpath here.
+            if (!self.preserve_symlinks) {
+                if (self.realpath_cache) |cache| {
+                    break :blk cache.resolve(source_dir) catch
+                        self.allocator.dupe(u8, source_dir) catch return error.OutOfMemory;
+                }
             }
             break :blk fs.realpath(self.allocator, source_dir) catch
                 self.allocator.dupe(u8, source_dir) catch return error.OutOfMemory;

--- a/src/bundler/resolver_test.zig
+++ b/src/bundler/resolver_test.zig
@@ -342,6 +342,8 @@ test "resolve: preserve_symlinks keeps pnpm package imports on logical node_modu
     try createFile(tmp.dir, ".pnpm/ui@1_react@18/node_modules/ui/dist/index.js");
     try writeFile(tmp.dir, ".pnpm/ui@1_react@18/node_modules/react/package.json", "{\"main\":\"index.js\"}");
     try createFile(tmp.dir, ".pnpm/ui@1_react@18/node_modules/react/index.js");
+    try writeFile(tmp.dir, ".pnpm/ui@1_react@18/node_modules/code-push/package.json", "{\"main\":\"script/acquisition-sdk.js\"}");
+    try createFile(tmp.dir, ".pnpm/ui@1_react@18/node_modules/code-push/script/acquisition-sdk.js");
 
     tmp.dir.symLink("../.pnpm/ui@1_react@18/node_modules/ui", "node_modules/ui", .{ .is_directory = true }) catch |err| switch (err) {
         error.AccessDenied, error.PermissionDenied => return error.SkipZigTest,
@@ -365,14 +367,21 @@ test "resolve: preserve_symlinks keeps pnpm package imports on logical node_modu
     logical_resolver.preserve_symlinks = true;
     const logical_ui = try logical_resolver.resolve(root, "ui");
     defer std.testing.allocator.free(logical_ui.path);
-    try std.testing.expect(pathEndsWith(logical_ui.path, "node_modules/ui/dist/index.js"));
-    try std.testing.expect(std.mem.indexOf(u8, logical_ui.path, ".pnpm") == null);
+    defer if (logical_ui.resolve_dir) |dir| std.testing.allocator.free(dir);
+    try std.testing.expect(std.mem.indexOf(u8, logical_ui.path, ".pnpm") != null);
+    try std.testing.expect(pathEndsWith(logical_ui.resolve_dir.?, "node_modules/ui/dist"));
 
-    const logical_ui_dir = std.fs.path.dirname(logical_ui.path).?;
+    const logical_ui_dir = logical_ui.resolve_dir.?;
     const root_react = try logical_resolver.resolve(logical_ui_dir, "react");
     defer std.testing.allocator.free(root_react.path);
+    defer if (root_react.resolve_dir) |dir| std.testing.allocator.free(dir);
     try std.testing.expect(pathEndsWith(root_react.path, "node_modules/react/index.js"));
     try std.testing.expect(std.mem.indexOf(u8, root_react.path, ".pnpm/ui@1_react@18/node_modules/react") == null);
+
+    const package_owned_dep = try logical_resolver.resolve(logical_ui_dir, "code-push");
+    defer std.testing.allocator.free(package_owned_dep.path);
+    defer if (package_owned_dep.resolve_dir) |dir| std.testing.allocator.free(dir);
+    try std.testing.expect(std.mem.indexOf(u8, package_owned_dep.path, ".pnpm/ui@1_react@18/node_modules/code-push") != null);
 }
 
 test "resolve: bare specifier walk up directories" {

--- a/src/bundler/resolver_test.zig
+++ b/src/bundler/resolver_test.zig
@@ -330,6 +330,51 @@ test "resolve: trailing slash bare specifier walks up to workspace root node_mod
     try std.testing.expectEqual(ModuleType.js, result.module_type);
 }
 
+test "resolve: preserve_symlinks keeps pnpm package imports on logical node_modules path" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makeDir("node_modules");
+    try writeFile(tmp.dir, "node_modules/react/package.json", "{\"main\":\"index.js\"}");
+    try createFile(tmp.dir, "node_modules/react/index.js");
+
+    try writeFile(tmp.dir, ".pnpm/ui@1_react@18/node_modules/ui/package.json", "{\"main\":\"dist/index.js\"}");
+    try createFile(tmp.dir, ".pnpm/ui@1_react@18/node_modules/ui/dist/index.js");
+    try writeFile(tmp.dir, ".pnpm/ui@1_react@18/node_modules/react/package.json", "{\"main\":\"index.js\"}");
+    try createFile(tmp.dir, ".pnpm/ui@1_react@18/node_modules/react/index.js");
+
+    tmp.dir.symLink("../.pnpm/ui@1_react@18/node_modules/ui", "node_modules/ui", .{ .is_directory = true }) catch |err| switch (err) {
+        error.AccessDenied, error.PermissionDenied => return error.SkipZigTest,
+        else => return err,
+    };
+
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+
+    var realpath_resolver = Resolver.init(std.testing.allocator);
+    const real_ui = try realpath_resolver.resolve(root, "ui");
+    defer std.testing.allocator.free(real_ui.path);
+    try std.testing.expect(std.mem.indexOf(u8, real_ui.path, ".pnpm") != null);
+
+    const real_ui_dir = std.fs.path.dirname(real_ui.path).?;
+    const peer_react = try realpath_resolver.resolve(real_ui_dir, "react");
+    defer std.testing.allocator.free(peer_react.path);
+    try std.testing.expect(std.mem.indexOf(u8, peer_react.path, ".pnpm/ui@1_react@18/node_modules/react") != null);
+
+    var logical_resolver = Resolver.init(std.testing.allocator);
+    logical_resolver.preserve_symlinks = true;
+    const logical_ui = try logical_resolver.resolve(root, "ui");
+    defer std.testing.allocator.free(logical_ui.path);
+    try std.testing.expect(pathEndsWith(logical_ui.path, "node_modules/ui/dist/index.js"));
+    try std.testing.expect(std.mem.indexOf(u8, logical_ui.path, ".pnpm") == null);
+
+    const logical_ui_dir = std.fs.path.dirname(logical_ui.path).?;
+    const root_react = try logical_resolver.resolve(logical_ui_dir, "react");
+    defer std.testing.allocator.free(root_react.path);
+    try std.testing.expect(pathEndsWith(root_react.path, "node_modules/react/index.js"));
+    try std.testing.expect(std.mem.indexOf(u8, root_react.path, ".pnpm/ui@1_react@18/node_modules/react") == null);
+}
+
 test "resolve: bare specifier walk up directories" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/resolver_test.zig
+++ b/src/bundler/resolver_test.zig
@@ -382,6 +382,11 @@ test "resolve: preserve_symlinks keeps pnpm package imports on logical node_modu
     defer std.testing.allocator.free(package_owned_dep.path);
     defer if (package_owned_dep.resolve_dir) |dir| std.testing.allocator.free(dir);
     try std.testing.expect(std.mem.indexOf(u8, package_owned_dep.path, ".pnpm/ui@1_react@18/node_modules/code-push") != null);
+
+    const package_owned_subpath = try logical_resolver.resolve(logical_ui_dir, "code-push/script/acquisition-sdk");
+    defer std.testing.allocator.free(package_owned_subpath.path);
+    defer if (package_owned_subpath.resolve_dir) |dir| std.testing.allocator.free(dir);
+    try std.testing.expect(std.mem.indexOf(u8, package_owned_subpath.path, ".pnpm/ui@1_react@18/node_modules/code-push/script/acquisition-sdk.js") != null);
 }
 
 test "resolve: bare specifier walk up directories" {

--- a/src/codegen/codegen_test/basic.zig
+++ b/src/codegen/codegen_test/basic.zig
@@ -774,6 +774,18 @@ test "Codegen #3111: if(false)/else DCE 분기 {} 제거" {
     try std.testing.expectEqualStrings("g();", r.output);
 }
 
+test "Codegen: string literal DCE decodes unicode escapes" {
+    var r = try e2e(std.testing.allocator, "if (\"Ā\" !== \"\\u0100\") { console.error(\"bad\"); }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("", r.output);
+}
+
+test "Codegen: string literal DCE decodes hex escapes" {
+    var r = try e2e(std.testing.allocator, "if (\"\\x41\" === \"A\") { good(); }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("good();", r.output);
+}
+
 test "Codegen #3111: if(true) DCE 분기 let 은 {} 유지" {
     var r = try e2e(std.testing.allocator, "if (true) { let x = 1; }");
     defer r.deinit();

--- a/src/codegen/statements.zig
+++ b/src/codegen/statements.zig
@@ -5,6 +5,7 @@ const ast_mod = @import("../parser/ast.zig");
 const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const Kind = @import("../lexer/token.zig").Kind;
+const string_escape = @import("../string_escape.zig");
 const writer = @import("writer.zig");
 
 const writeNewline = writer.writeNewline;
@@ -580,13 +581,9 @@ fn evalBooleanConditionDepth(self: anytype, cond_idx: NodeIndex, depth: u8) ?boo
             const left = self.ast.getNode(cond.data.binary.left);
             const right = self.ast.getNode(cond.data.binary.right);
             if (left.tag != .string_literal or right.tag != .string_literal) return null;
-            // string_literal span 은 quote 포함. 다른 quote 문자 (single vs double) 라도
-            // value 가 같으면 같음으로 — quote 제거 비교.
             const lt_raw = self.ast.getText(left.span);
             const rt_raw = self.ast.getText(right.span);
-            const lt = stripQuotes(lt_raw);
-            const rt = stripQuotes(rt_raw);
-            const eq = std.mem.eql(u8, lt, rt);
+            const eq = stringLiteralValuesEqual(self.allocator, lt_raw, rt_raw) orelse return null;
             return switch (op) {
                 .eq2, .eq3 => eq,
                 .neq, .neq2 => !eq,
@@ -597,16 +594,14 @@ fn evalBooleanConditionDepth(self: anytype, cond_idx: NodeIndex, depth: u8) ?boo
     };
 }
 
-/// string literal span (quote 포함) → 내용만. escape 시퀀스는 정확히 같으면 통과,
-/// 다르면 보수적으로 비교 실패 처리해도 무방 (false negative 만 → DCE 효과 약간 감소).
-fn stripQuotes(s: []const u8) []const u8 {
-    if (s.len < 2) return s;
-    const first = s[0];
-    const last = s[s.len - 1];
-    if ((first == '"' or first == '\'' or first == '`') and first == last) {
-        return s[1 .. s.len - 1];
-    }
-    return s;
+/// string_literal span 은 quote 포함이다. Raw body 비교는 `"Ā"` 와 `"\u0100"`을
+/// 다르게 보므로 JS 문자열 값으로 디코드한 뒤 비교한다.
+fn stringLiteralValuesEqual(allocator: std.mem.Allocator, left_raw: []const u8, right_raw: []const u8) ?bool {
+    const left = string_escape.decodeJsStringLiteral(allocator, left_raw) catch return null;
+    defer allocator.free(left);
+    const right = string_escape.decodeJsStringLiteral(allocator, right_raw) catch return null;
+    defer allocator.free(right);
+    return std.mem.eql(u8, left, right);
 }
 
 pub fn emitWhile(self: anytype, node: Node) !void {

--- a/src/transformer/es2015_block_scoping.zig
+++ b/src/transformer/es2015_block_scoping.zig
@@ -185,6 +185,50 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
             }.visit);
         }
 
+        /// loop body 를 `_loop` 함수로 추출할 때 원래 body 의 lexical `this` /
+        /// `super` 의미가 필요한지 검사한다. 일반 function/class/method 는 자체
+        /// `this` 를 가지므로 경계에서 멈추고, arrow function 은 outer `this` 를
+        /// 캡처하므로 계속 탐색한다.
+        pub fn hasLexicalThisReference(self: *Transformer, body_idx: NodeIndex) bool {
+            if (body_idx.isNone()) return false;
+            const max_node = self.parser_node_count;
+
+            var stack: std.ArrayList(NodeIndex) = .empty;
+            defer stack.deinit(self.allocator);
+            stack.append(self.allocator, body_idx) catch return true;
+
+            while (stack.items.len > 0) {
+                const idx = stack.pop() orelse break;
+                if (idx.isNone()) continue;
+                if (@intFromEnum(idx) >= max_node) continue;
+                const node = self.ast.getNode(idx);
+
+                switch (node.tag) {
+                    .this_expression,
+                    .super_expression,
+                    => return true,
+
+                    .function_expression,
+                    .function_declaration,
+                    .function,
+                    .method_definition,
+                    .class_expression,
+                    .class_declaration,
+                    => continue,
+
+                    else => {},
+                }
+
+                var children: std.ArrayList(NodeIndex) = .empty;
+                defer children.deinit(self.allocator);
+                collectChildIndices(self, node, &children) catch return true;
+                for (children.items) |child_idx| {
+                    stack.append(self.allocator, child_idx) catch return true;
+                }
+            }
+            return false;
+        }
+
         /// 노드의 자식 NodeIndex들을 scratch 버퍼에 수집한다.
         /// 공통 `ast_walk.ChildIterator` 로 자식 순회 + `parser_node_count` 가드로
         /// transformer 신규 노드 영역을 걸러낸다 (extra 자식에만 한정).
@@ -238,6 +282,7 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
             local_label: ?[]const u8,
             span: Span,
             is_async: bool,
+            preserve_this: bool,
         ) Transformer.Error!struct { loop_fn: NodeIndex, call_and_check: NodeIndex } {
             // --- _loop 함수명 생성 ---
             const loop_prefix = "_loop";
@@ -312,19 +357,16 @@ pub fn ES2015BlockScoping(comptime Transformer: type) type {
             // --- _loop(i, j, ...) 호출 ---
             const scratch_top2 = self.scratch.items.len;
             defer self.scratch.shrinkRetainingCapacity(scratch_top2);
+            const loop_ref = try es_helpers.makeIdentifierRef(self, loop_name);
+            const call_callee = if (preserve_this) blk: {
+                const call_prop = try es_helpers.makeIdentifierRef(self, "call");
+                try self.scratch.append(self.allocator, try es_helpers.makeThisExpr(self, span));
+                break :blk try es_helpers.makeStaticMember(self, loop_ref, call_prop, span);
+            } else loop_ref;
             for (lexical_names) |name| {
                 try self.scratch.append(self.allocator, try es_helpers.makeIdentifierRef(self, name));
             }
-            const call_args = try self.ast.addNodeList(self.scratch.items[scratch_top2..]);
-            const loop_ref = try es_helpers.makeIdentifierRef(self, loop_name);
-            const call_extra = try self.ast.addExtras(&.{
-                @intFromEnum(loop_ref), call_args.start, call_args.len, 0,
-            });
-            const loop_call = try self.ast.addNode(.{
-                .tag = .call_expression,
-                .span = span,
-                .data = .{ .extra = call_extra },
-            });
+            const loop_call = try es_helpers.makeCallExpr(self, call_callee, self.scratch.items[scratch_top2..], span);
 
             // is_async — `_loop(...)` 가 Promise 반환. 호출부도 `await _loop(...)` 로
             // wrap 해야 iteration 순서 보존 + needsRetVar 시 _ret 가 resolved value.

--- a/src/transformer/es2015_for_of.zig
+++ b/src/transformer/es2015_for_of.zig
@@ -186,6 +186,7 @@ pub fn ES2015ForOf(comptime Transformer: type) type {
 
                 if (lexical_names.items.len > 0 and BlockScoping.hasCapturedClosure(self, body, lexical_names.items)) {
                     const is_async = BlockScoping.hasAwaitExpression(self, body);
+                    const preserve_this = BlockScoping.hasLexicalThisReference(self, body);
                     var flow = BlockScoping.FlowResult{};
                     defer flow.labels.deinit(self.allocator);
                     BlockScoping.analyzeControlFlow(self, body, &flow, 0, 0);
@@ -202,6 +203,7 @@ pub fn ES2015ForOf(comptime Transformer: type) type {
                         local_label,
                         span,
                         is_async,
+                        preserve_this,
                     );
                     loop_fn_decl = result.loop_fn;
                     body_after_closure = result.call_and_check;

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -1462,7 +1462,6 @@ pub fn ES2015Generator(comptime Transformer: type) type {
         /// expression 내부의 yield/await를 별도 yield operation으로 추출하고
         /// 해당 위치를 _state.sent()로 치환한 expression을 반환.
         /// 조건식(if, while, for test) 등에서 yield/await가 중첩된 경우 사용.
-        /// 주의: short-circuit 평가(&&, ||)가 보존되지 않음 — await가 항상 평가됨.
         fn visitExprWithYieldExtraction(self: *Transformer, expr_idx: NodeIndex, ops: *std.ArrayList(Operation), next_label: *u32) Transformer.Error!NodeIndex {
             if (expr_idx.isNone()) return .none;
             const node = self.ast.getNode(expr_idx);
@@ -1521,8 +1520,17 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 return visitExprWithYieldExtraction(self, node.data.unary.operand, ops, next_label);
             }
 
-            // logical/binary expression: 양쪽 재귀
-            if (node.tag == .logical_expression or node.tag == .binary_expression) {
+            // logical expression: short-circuit / nullish lazy branch 보존.
+            if (node.tag == .logical_expression) {
+                const op_kind: token_mod.Kind = @enumFromInt(node.data.binary.flags);
+                switch (op_kind) {
+                    .amp2, .pipe2, .question2 => return lowerLogicalExprWithYieldExtraction(self, node, ops, next_label, op_kind),
+                    else => {},
+                }
+            }
+
+            // binary expression: 양쪽 재귀
+            if (node.tag == .binary_expression) {
                 const new_left = try visitExprWithYieldExtraction(self, node.data.binary.left, ops, next_label);
                 const new_right = try visitExprWithYieldExtraction(self, node.data.binary.right, ops, next_label);
                 return self.ast.addNode(.{
@@ -1534,14 +1542,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
 
             // conditional expression (ternary): a ? b : c
             if (node.tag == .conditional_expression) {
-                const new_a = try visitExprWithYieldExtraction(self, node.data.ternary.a, ops, next_label);
-                const new_b = try visitExprWithYieldExtraction(self, node.data.ternary.b, ops, next_label);
-                const new_c = try visitExprWithYieldExtraction(self, node.data.ternary.c, ops, next_label);
-                return self.ast.addNode(.{
-                    .tag = .conditional_expression,
-                    .span = node.span,
-                    .data = .{ .ternary = .{ .a = new_a, .b = new_b, .c = new_c } },
-                });
+                return lowerConditionalExprWithYieldExtraction(self, node, ops, next_label);
             }
 
             // sequence expression: a(), await b(), c()
@@ -1706,6 +1707,85 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 std.log.warn("visitExprWithYieldExtraction: unhandled tag {}", .{node.tag});
             }
             return self.visitNode(expr_idx);
+        }
+
+        // Expression-internal lazy branches need labels before their final `next_label`
+        // values are allocated. Use reserved sentinel labels, then patch only the ops
+        // emitted by the current expression once the real labels are known.
+        const EXPR_LAZY_BRANCH_END_SENTINEL = LABEL_SENTINEL_BASE - 10_000;
+        const EXPR_LAZY_COND_ELSE_SENTINEL = LABEL_SENTINEL_BASE - 10_001;
+        const EXPR_LAZY_COND_END_SENTINEL = LABEL_SENTINEL_BASE - 10_002;
+
+        fn appendAssignTempStmt(self: *Transformer, ops: *std.ArrayList(Operation), temp_span: Span, value_idx: NodeIndex, span: Span) Transformer.Error!void {
+            const temp_ref = try es_helpers.makeTempVarRef(self, temp_span, temp_span);
+            const assign = try self.ast.addNode(.{
+                .tag = .assignment_expression,
+                .span = span,
+                .data = .{ .binary = .{ .left = temp_ref, .right = value_idx, .flags = 0 } },
+            });
+            const stmt = try es_helpers.makeExprStmt(self, assign, span);
+            try ops.append(self.allocator, .{ .code = .statement, .arg = .{ .node = stmt } });
+        }
+
+        fn lowerLogicalExprWithYieldExtraction(self: *Transformer, node: Node, ops: *std.ArrayList(Operation), next_label: *u32, op_kind: token_mod.Kind) Transformer.Error!NodeIndex {
+            const temp_span = try es_helpers.makeTempVarSpan(self);
+            try self.generator_temp_var_spans.append(self.allocator, temp_span);
+            const ops_start = ops.items.len;
+
+            const left_value = try visitExprWithYieldExtraction(self, node.data.binary.left, ops, next_label);
+            try appendAssignTempStmt(self, ops, temp_span, left_value, node.span);
+
+            const temp_for_cond = try es_helpers.makeTempVarRef(self, temp_span, temp_span);
+            const cond = if (op_kind == .question2)
+                try es_helpers.makeNeqNull(self, temp_for_cond, node.span)
+            else
+                temp_for_cond;
+            const branch_code: OpCode = if (op_kind == .amp2) .break_when_false else .break_when_true;
+            try ops.append(self.allocator, .{
+                .code = branch_code,
+                .arg = .{ .label_and_node = .{ .label = EXPR_LAZY_BRANCH_END_SENTINEL, .node = cond } },
+            });
+
+            const right_value = try visitExprWithYieldExtraction(self, node.data.binary.right, ops, next_label);
+            try appendAssignTempStmt(self, ops, temp_span, right_value, node.span);
+
+            const end_label = next_label.*;
+            next_label.* += 1;
+            try ops.append(self.allocator, .{ .code = .nop, .arg = .{ .none = {} } });
+            fixupSentinel(ops.items[ops_start..], EXPR_LAZY_BRANCH_END_SENTINEL, end_label);
+
+            return es_helpers.makeTempVarRef(self, temp_span, temp_span);
+        }
+
+        fn lowerConditionalExprWithYieldExtraction(self: *Transformer, node: Node, ops: *std.ArrayList(Operation), next_label: *u32) Transformer.Error!NodeIndex {
+            const temp_span = try es_helpers.makeTempVarSpan(self);
+            try self.generator_temp_var_spans.append(self.allocator, temp_span);
+            const ops_start = ops.items.len;
+
+            const cond = try visitExprWithYieldExtraction(self, node.data.ternary.a, ops, next_label);
+            try ops.append(self.allocator, .{
+                .code = .break_when_false,
+                .arg = .{ .label_and_node = .{ .label = EXPR_LAZY_COND_ELSE_SENTINEL, .node = cond } },
+            });
+
+            const then_value = try visitExprWithYieldExtraction(self, node.data.ternary.b, ops, next_label);
+            try appendAssignTempStmt(self, ops, temp_span, then_value, node.span);
+            try ops.append(self.allocator, .{ .code = .break_op, .arg = .{ .label = EXPR_LAZY_COND_END_SENTINEL } });
+
+            const else_label = next_label.*;
+            next_label.* += 1;
+            try ops.append(self.allocator, .{ .code = .nop, .arg = .{ .none = {} } });
+
+            const else_value = try visitExprWithYieldExtraction(self, node.data.ternary.c, ops, next_label);
+            try appendAssignTempStmt(self, ops, temp_span, else_value, node.span);
+
+            const end_label = next_label.*;
+            next_label.* += 1;
+            try ops.append(self.allocator, .{ .code = .nop, .arg = .{ .none = {} } });
+            fixupSentinel(ops.items[ops_start..], EXPR_LAZY_COND_ELSE_SENTINEL, else_label);
+            fixupSentinel(ops.items[ops_start..], EXPR_LAZY_COND_END_SENTINEL, end_label);
+
+            return es_helpers.makeTempVarRef(self, temp_span, temp_span);
         }
 
         fn buildExpressionBodyStateMachine(self: *Transformer, body_idx: NodeIndex, body: Node, span: Span) Transformer.Error!StateMachineResult {

--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -31,6 +31,7 @@ const purity = @import("../bundler/purity.zig");
 const ast_walk = @import("../parser/ast_walk.zig");
 const numeric = @import("minify/numeric.zig");
 const unused_expr = @import("minify/unused_expr.zig");
+const string_escape = @import("../string_escape.zig");
 
 /// Minify pass 컨텍스트. semantic 정보가 있을 때만 dead store 제거가 동작한다.
 /// `symbols` 는 read-only 로 사용한다 — 과거엔 `reference_count` 를 직접 감산했지만,
@@ -272,7 +273,7 @@ fn runOnce(
     while (i < ast.nodes.items.len) : (i += 1) {
         const node = ast.nodes.items[i];
         switch (node.tag) {
-            .binary_expression => foldBinary(ast, i, node, &changed),
+            .binary_expression => foldBinary(ast, scratch, i, node, &changed),
             .logical_expression => foldLogical(ast, i, node, &changed),
             .unary_expression => foldUnary(ast, i, node, &changed),
             .call_expression => foldCall(ast, i, node, &changed),
@@ -942,7 +943,7 @@ pub fn mergeDecls(ast: *Ast, skip_nodes: ?*const std.DynamicBitSet) void {
 // Constant Folding — Binary Expression
 // ================================================================
 
-fn foldBinary(ast: *Ast, node_idx: u32, node: Node, changed: *bool) void {
+fn foldBinary(ast: *Ast, allocator: std.mem.Allocator, node_idx: u32, node: Node, changed: *bool) void {
     const left_ni = @intFromEnum(node.data.binary.left);
     const right_ni = @intFromEnum(node.data.binary.right);
     if (left_ni >= ast.nodes.items.len or right_ni >= ast.nodes.items.len) return;
@@ -959,7 +960,7 @@ fn foldBinary(ast: *Ast, node_idx: u32, node: Node, changed: *bool) void {
             return;
         }
 
-        if (foldStrictEquality(ast, left, right)) |result| {
+        if (foldStrictEquality(ast, allocator, left, right)) |result| {
             const value = if (op == .neq2) !result else result;
             const text = if (value) "true" else "false";
             if (ast.addString(text)) |span| {
@@ -1204,7 +1205,7 @@ fn simplifyBooleanComparison(
     return true;
 }
 
-fn foldStrictEquality(ast: *const Ast, left: Node, right: Node) ?bool {
+fn foldStrictEquality(ast: *const Ast, allocator: std.mem.Allocator, left: Node, right: Node) ?bool {
     // 숫자 === 숫자
     if (left.tag == .numeric_literal and right.tag == .numeric_literal) {
         const a = numeric.parseLiteral(ast, left) orelse return null;
@@ -1222,11 +1223,19 @@ fn foldStrictEquality(ast: *const Ast, left: Node, right: Node) ?bool {
     if (left.tag == .null_literal and right.tag == .null_literal) return true;
     // string === string
     if (left.tag == .string_literal and right.tag == .string_literal) {
-        const a = stripQuotes(ast.getText(left.span));
-        const b = stripQuotes(ast.getText(right.span));
-        return std.mem.eql(u8, a, b);
+        return stringLiteralValuesEqual(allocator, ast.getText(left.span), ast.getText(right.span));
     }
     return null;
+}
+
+/// JS string literal equality must compare decoded string values, not raw literal
+/// bodies. For example `"Ā"` and `"\u0100"` are the same runtime string.
+fn stringLiteralValuesEqual(allocator: std.mem.Allocator, left_raw: []const u8, right_raw: []const u8) ?bool {
+    const left = string_escape.decodeJsStringLiteral(allocator, left_raw) catch return null;
+    defer allocator.free(left);
+    const right = string_escape.decodeJsStringLiteral(allocator, right_raw) catch return null;
+    defer allocator.free(right);
+    return std.mem.eql(u8, left, right);
 }
 
 // ================================================================

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -258,6 +258,14 @@ test "minify: strict equality strings" {
     );
 }
 
+test "minify: strict equality strings decode unicode escapes" {
+    try expectMinify("const x = \"Ā\" !== \"\\u0100\";", "const x = false;");
+}
+
+test "minify: strict equality strings decode hex escapes" {
+    try expectMinify("const x = \"\\x41\" === \"A\";", "const x = true;");
+}
+
 test "minify: strict equality booleans" {
     try expectMinify("const x = true === true;", "const x = true;");
 }

--- a/src/transformer/plugins/rn_codegen/schema_builder.zig
+++ b/src/transformer/plugins/rn_codegen/schema_builder.zig
@@ -632,10 +632,21 @@ fn isFunctionType(ast: *const Ast, type_idx: NodeIndex) bool {
 /// type 이 `DirectEventHandler<T>` / `BubblingEventHandler<T>` 면 해당 BubblingType 반환.
 /// 그 외엔 null.
 fn eventHandlerBubbling(ast: *const Ast, type_idx: NodeIndex) ?schema.BubblingType {
+    return eventHandlerBubblingAt(ast, type_idx, 0);
+}
+
+fn eventHandlerBubblingAt(ast: *const Ast, type_idx: NodeIndex, depth: u8) ?schema.BubblingType {
+    if (depth >= MAX_ALIAS_DEPTH) return null;
     const node = ast.getNode(type_idx);
-    if (node.tag != .ts_type_reference and node.tag != .flow_type_reference) return null;
-    const name = getTypeReferenceName(ast, node) orelse return null;
-    return event_handler_names.get(lastSegment(name));
+    return switch (node.tag) {
+        .ts_type_reference, .flow_type_reference => blk: {
+            const name = getTypeReferenceName(ast, node) orelse return null;
+            break :blk event_handler_names.get(lastSegment(name));
+        },
+        .flow_nullable_type, .ts_parenthesized_type, .flow_parenthesized_type => eventHandlerBubblingAt(ast, node.data.unary.operand, depth + 1),
+        .ts_union_type, .flow_union_type => eventHandlerBubblingFromNullableUnion(ast, node, depth + 1),
+        else => null,
+    };
 }
 
 /// RN codegen 의 명시적 event wrapper — 이름이 bubble vs direct 결정.
@@ -643,6 +654,28 @@ const event_handler_names = std.StaticStringMap(schema.BubblingType).initComptim
     .{ "DirectEventHandler", .direct },
     .{ "BubblingEventHandler", .bubble },
 });
+
+fn eventHandlerBubblingFromNullableUnion(ast: *const Ast, node: Node, depth: u8) ?schema.BubblingType {
+    var found: ?schema.BubblingType = null;
+    var iter = ast.iterateExtraList(node.data.list);
+    while (iter.next()) |elem| {
+        const elem_node = ast.getNode(elem);
+        if (isNullishType(elem_node)) continue;
+        const bubbling = eventHandlerBubblingAt(ast, elem, depth) orelse return null;
+        if (found) |prev| {
+            if (prev != bubbling) return null;
+        }
+        found = bubbling;
+    }
+    return found;
+}
+
+fn isNullishType(node: Node) bool {
+    return switch (node.tag) {
+        .ts_null_keyword, .ts_undefined_keyword, .flow_null_keyword, .flow_void_keyword => true,
+        else => false,
+    };
+}
 
 /// 이벤트 prop 이름 → bubble vs direct 분류.
 /// 일반적 RN 컨벤션: `onCapture` 접미사가 있으면 direct, 그 외는 bubble.

--- a/src/transformer/plugins/rn_codegen/schema_builder_test.zig
+++ b/src/transformer/plugins/rn_codegen/schema_builder_test.zig
@@ -1039,6 +1039,23 @@ test "schema_builder: Flow namespace CT.DirectEventHandler → direct event" {
     try std.testing.expectEqual(schema.BubblingType.direct, shape.events[0].bubbling_type);
 }
 
+test "schema_builder: Flow nullable DirectEventHandler in $ReadOnly → direct event" {
+    var p = try parseAndIndex(std.testing.allocator,
+        \\type Props = $ReadOnly<{
+        \\  onOrientationChange?: ?DirectEventHandler<OrientationChangeEvent>,
+        \\}>;
+    , .flow);
+    defer p.deinit();
+
+    const shape = try buildShape(&p, "Props", "RCTModalHostView");
+    defer freeShape(std.testing.allocator, shape);
+
+    try std.testing.expectEqual(@as(usize, 0), shape.props.len);
+    try std.testing.expectEqual(@as(usize, 1), shape.events.len);
+    try std.testing.expectEqualStrings("onOrientationChange", shape.events[0].name);
+    try std.testing.expectEqual(schema.BubblingType.direct, shape.events[0].bubbling_type);
+}
+
 test "schema_builder: namespaced unknown last segment → mixed fallback (TS)" {
     // Foo.Bar 가 알려진 wrapper/event/reserved/numeric 어디에도 없음 → cross-file
     // 처럼 mixed permissive fallback.

--- a/src/transformer/plugins/rn_codegen/snapshot_test.zig
+++ b/src/transformer/plugins/rn_codegen/snapshot_test.zig
@@ -93,12 +93,15 @@ fn parseKeysFromExpr(
 ) !std.StringArrayHashMapUnmanaged(void) {
     var keys: std.StringArrayHashMapUnmanaged(void) = .{};
     errdefer keys.deinit(alloc);
-    if (body.len < 2) return keys;
+    const trimmed = std.mem.trim(u8, body, " \t\n\r");
+    if (trimmed.len < 2) return keys;
 
-    if (body[0] == '{' and body[body.len - 1] == '}') {
-        try collectKeysIntoSet(alloc, body[1 .. body.len - 1], &keys);
-    } else if (body[0] == '(' and body[body.len - 1] == ')') {
-        try collectFromCallArgs(alloc, body[1 .. body.len - 1], &keys);
+    if (trimmed[0] == '{' and trimmed[trimmed.len - 1] == '}') {
+        try collectKeysIntoSet(alloc, trimmed[1 .. trimmed.len - 1], &keys);
+    } else if (trimmed[0] == '(' and trimmed[trimmed.len - 1] == ')') {
+        try collectFromCallArgs(alloc, trimmed[1 .. trimmed.len - 1], &keys);
+    } else if (isCallLikeExpr(trimmed)) {
+        try collectObjectLiteralsFromExpr(alloc, trimmed, &keys);
     }
     return keys;
 }
@@ -229,6 +232,69 @@ fn maybeFlattenArg(
     try collectKeysIntoSet(alloc, trimmed[1 .. trimmed.len - 1], keys);
 }
 
+fn isCallLikeExpr(expr: []const u8) bool {
+    var i: usize = 0;
+    var in_string: u8 = 0;
+    while (i < expr.len) {
+        const c = expr[i];
+        if (in_string != 0) {
+            if (c == '\' and i + 1 < expr.len) {
+                i += 2;
+                continue;
+            }
+            if (c == in_string) in_string = 0;
+            i += 1;
+            continue;
+        }
+        switch (c) {
+            ''', '"' => {
+                in_string = c;
+                i += 1;
+            },
+            '(' => return true,
+            else => i += 1,
+        }
+    }
+    return false;
+}
+
+fn collectObjectLiteralsFromExpr(
+    alloc: std.mem.Allocator,
+    expr: []const u8,
+    keys: *std.StringArrayHashMapUnmanaged(void),
+) CollectError!void {
+    var i: usize = 0;
+    var in_string: u8 = 0;
+    while (i < expr.len) {
+        const c = expr[i];
+        if (in_string != 0) {
+            if (c == '\' and i + 1 < expr.len) {
+                i += 2;
+                continue;
+            }
+            if (c == in_string) in_string = 0;
+            i += 1;
+            continue;
+        }
+        switch (c) {
+            ''', '"' => {
+                in_string = c;
+                i += 1;
+            },
+            '{' => {
+                const end = skipBalanced(expr, i) orelse expr.len;
+                try collectKeysIntoSet(alloc, expr[i + 1 .. end - 1], keys);
+                i = end;
+            },
+            '[' => {
+                i = skipBalanced(expr, i) orelse expr.len;
+            },
+            '(' => i += 1,
+            else => i += 1,
+        }
+    }
+}
+
 /// `body[start]` 가 여는 괄호 (`{`/`[`/`(`) 일 때, 매칭하는 닫는 괄호 다음 위치 반환.
 /// string literal escape 인식.
 fn skipBalanced(body: []const u8, start: usize) ?usize {
@@ -309,23 +375,31 @@ fn extractSection(body: []const u8, key: []const u8) ?[]const u8 {
                         var v = j + 1;
                         while (v < inner.len and std.ascii.isWhitespace(inner[v])) v += 1;
                         if (v >= inner.len) return null;
-                        // value 가 object literal / array / call 이면 매칭 본체 반환.
-                        // 그 외 (string / ident.member / number) 면 다음 콤마/끝 까지.
-                        if (inner[v] == '{' or inner[v] == '[' or inner[v] == '(') {
-                            const end = skipBalanced(inner, v) orelse return null;
-                            return inner[v..end];
-                        }
                         var k = v;
                         var s: u8 = 0;
-                        while (k < inner.len) : (k += 1) {
+                        while (k < inner.len) {
                             const cc = inner[k];
                             if (s != 0) {
-                                if (cc == '\\' and k + 1 < inner.len) k += 1 else if (cc == s) s = 0;
+                                if (cc == '\' and k + 1 < inner.len) {
+                                    k += 2;
+                                    continue;
+                                }
+                                if (cc == s) s = 0;
+                                k += 1;
                                 continue;
                             }
-                            if (cc == '\'' or cc == '"') s = cc else if (cc == ',') break;
+                            if (cc == ''' or cc == '"') {
+                                s = cc;
+                                k += 1;
+                            } else if (cc == '{' or cc == '[' or cc == '(') {
+                                k = skipBalanced(inner, k) orelse return null;
+                            } else if (cc == ',') {
+                                break;
+                            } else {
+                                k += 1;
+                            }
                         }
-                        return inner[v..k];
+                        return std.mem.trim(u8, inner[v..k], " \t\n\r");
                     }
                 } else {
                     i += 1;

--- a/src/transformer/plugins/rn_codegen/snapshot_test.zig
+++ b/src/transformer/plugins/rn_codegen/snapshot_test.zig
@@ -238,7 +238,7 @@ fn isCallLikeExpr(expr: []const u8) bool {
     while (i < expr.len) {
         const c = expr[i];
         if (in_string != 0) {
-            if (c == '\' and i + 1 < expr.len) {
+            if (c == '\\' and i + 1 < expr.len) {
                 i += 2;
                 continue;
             }
@@ -247,7 +247,7 @@ fn isCallLikeExpr(expr: []const u8) bool {
             continue;
         }
         switch (c) {
-            ''', '"' => {
+            '\'', '"' => {
                 in_string = c;
                 i += 1;
             },
@@ -268,7 +268,7 @@ fn collectObjectLiteralsFromExpr(
     while (i < expr.len) {
         const c = expr[i];
         if (in_string != 0) {
-            if (c == '\' and i + 1 < expr.len) {
+            if (c == '\\' and i + 1 < expr.len) {
                 i += 2;
                 continue;
             }
@@ -277,7 +277,7 @@ fn collectObjectLiteralsFromExpr(
             continue;
         }
         switch (c) {
-            ''', '"' => {
+            '\'', '"' => {
                 in_string = c;
                 i += 1;
             },
@@ -380,7 +380,7 @@ fn extractSection(body: []const u8, key: []const u8) ?[]const u8 {
                         while (k < inner.len) {
                             const cc = inner[k];
                             if (s != 0) {
-                                if (cc == '\' and k + 1 < inner.len) {
+                                if (cc == '\\' and k + 1 < inner.len) {
                                     k += 2;
                                     continue;
                                 }
@@ -388,7 +388,7 @@ fn extractSection(body: []const u8, key: []const u8) ?[]const u8 {
                                 k += 1;
                                 continue;
                             }
-                            if (cc == ''' or cc == '"') {
+                            if (cc == '\'' or cc == '"') {
                                 s = cc;
                                 k += 1;
                             } else if (cc == '{' or cc == '[' or cc == '(') {

--- a/src/transformer/plugins/rn_codegen/view_config_emitter.zig
+++ b/src/transformer/plugins/rn_codegen/view_config_emitter.zig
@@ -12,9 +12,14 @@
 //!   uiViewClassName: 'ComponentName',
 //!   validAttributes: {
 //!     color: { process: require('react-native/Libraries/StyleSheet/processColor').default },
-//!     onSomeEvent: true,
 //!     ...
 //!   },
+//!   // When events exist:
+//!   validAttributes: Object.assign({
+//!     color: { process: require('react-native/Libraries/StyleSheet/processColor').default },
+//!   }, require('react-native/Libraries/NativeComponent/ViewConfigIgnore').ConditionallyIgnoredEventHandlers({
+//!     onSomeEvent: true,
+//!   })),
 //!   bubblingEventTypes: {
 //!     topSomeEvent: { phasedRegistrationNames: { bubbled: 'onSomeEvent', captured: 'onSomeEventCapture' } }
 //!   },
@@ -48,6 +53,8 @@ const REQUIRE_INSETS_DIFFER =
     "{ diff: require('react-native/Libraries/Utilities/differ/insetsDiffer') }";
 const REQUIRE_PROCESS_COLOR_ARRAY =
     "{ process: require('react-native/Libraries/StyleSheet/processColorArray') }";
+const REQUIRE_CONDITIONALLY_IGNORED_EVENT_HANDLERS =
+    "require('react-native/Libraries/NativeComponent/ViewConfigIgnore').ConditionallyIgnoredEventHandlers";
 
 /// ComponentShape 를 view config JS 문자열로 직렬화.
 /// 반환된 슬라이스는 `alloc` 으로 할당 — caller 가 `alloc.free()` 책임.
@@ -127,7 +134,12 @@ fn emitValidAttributes(
     shape: schema.ComponentShape,
     alloc: std.mem.Allocator,
 ) !void {
-    try buf.appendSlice(alloc, "  validAttributes: {\n");
+    const has_events = shape.events.len > 0;
+    if (has_events) {
+        try buf.appendSlice(alloc, "  validAttributes: Object.assign({\n");
+    } else {
+        try buf.appendSlice(alloc, "  validAttributes: {\n");
+    }
     for (shape.props) |prop| {
         try buf.appendSlice(alloc, "    ");
         try emitKey(buf, prop.name, alloc);
@@ -135,13 +147,22 @@ fn emitValidAttributes(
         try emitAttributeValue(buf, prop.type_annotation, alloc);
         try buf.appendSlice(alloc, ",\n");
     }
-    // 모든 이벤트도 validAttributes 에 `true` 로 등록 (Metro 동일).
-    for (shape.events) |event| {
-        try buf.appendSlice(alloc, "    ");
-        try emitKey(buf, event.name, alloc);
-        try buf.appendSlice(alloc, ": true,\n");
+    // RN codegen 0.83 wraps event props with ConditionallyIgnoredEventHandlers.
+    // On iOS this preserves legacy event validAttributes; on Android it returns
+    // undefined to avoid platform-inconsistent event props in validAttributes.
+    if (has_events) {
+        try buf.appendSlice(alloc, "  }, ");
+        try buf.appendSlice(alloc, REQUIRE_CONDITIONALLY_IGNORED_EVENT_HANDLERS);
+        try buf.appendSlice(alloc, "({\n");
+        for (shape.events) |event| {
+            try buf.appendSlice(alloc, "    ");
+            try emitKey(buf, event.name, alloc);
+            try buf.appendSlice(alloc, ": true,\n");
+        }
+        try buf.appendSlice(alloc, "  })),\n");
+    } else {
+        try buf.appendSlice(alloc, "  },\n");
     }
-    try buf.appendSlice(alloc, "  },\n");
 }
 
 /// prop / event 이름이 식별자로 적합하면 그대로, `aria-label` 같은 dash 포함이면 quote.

--- a/src/transformer/plugins/rn_codegen/view_config_emitter_test.zig
+++ b/src/transformer/plugins/rn_codegen/view_config_emitter_test.zig
@@ -89,7 +89,8 @@ test "view_config_emitter: bubble events → bubblingEventTypes with phasedRegis
     const out = try emitter.emit(shape, std.testing.allocator);
     defer std.testing.allocator.free(out);
 
-    // event 도 validAttributes 에 등록 (Metro 동등).
+    // event validAttributes 는 RN 0.83 codegen 과 동일하게 platform wrapper 로 감싼다.
+    try expectContains(out, "ConditionallyIgnoredEventHandlers({");
     try expectContains(out, "onChange: true");
     try expectContains(out, "bubblingEventTypes: {");
     try expectContains(out, "topChange: { phasedRegistrationNames: { bubbled: 'onChange', captured: 'onChangeCapture' } }");
@@ -124,6 +125,9 @@ test "view_config_emitter: mixed bubble + direct events" {
     try expectContains(out, "topChange:");
     try expectContains(out, "directEventTypes: {");
     try expectContains(out, "topScrollCapture:");
+    try expectContains(out, "ConditionallyIgnoredEventHandlers({");
+    try expectContains(out, "onChange: true");
+    try expectContains(out, "onScrollCapture: true");
 }
 
 test "view_config_emitter: dash-containing key gets quoted" {

--- a/src/transformer/plugins/rn_codegen_plugin_test.zig
+++ b/src/transformer/plugins/rn_codegen_plugin_test.zig
@@ -142,6 +142,25 @@ test "codegen_plugin: function-typed prop → event in output" {
     try expectContains(out, "phasedRegistrationNames");
 }
 
+test "codegen_plugin: Flow nullable DirectEventHandler emits directEventTypes" {
+    const code =
+        \\type NativeProps = $ReadOnly<{
+        \\  onOrientationChange?: ?DirectEventHandler<OrientationChangeEvent>,
+        \\}>;
+        \\export default codegenNativeComponent<NativeProps>('ModalHostView', {
+        \\  paperComponentName: 'RCTModalHostView',
+        \\});
+    ;
+    const out_opt = try callTransform(std.testing.allocator, code, "/path/RCTModalHostViewNativeComponent.js");
+    try std.testing.expect(out_opt != null);
+    const out = out_opt.?;
+    defer std.testing.allocator.free(out);
+
+    try expectContains(out, "directEventTypes: {");
+    try expectContains(out, "topOrientationChange:");
+    try expectContains(out, "registrationName: 'onOrientationChange'");
+}
+
 test "codegen_plugin: paperComponentName option → uiViewClassName / nativeComponentName 둘 다 paper 이름" {
     const code =
         \\type NativeProps = { color: string };

--- a/src/transformer/plugins/rn_codegen_plugin_test.zig
+++ b/src/transformer/plugins/rn_codegen_plugin_test.zig
@@ -159,6 +159,8 @@ test "codegen_plugin: Flow nullable DirectEventHandler emits directEventTypes" {
     try expectContains(out, "directEventTypes: {");
     try expectContains(out, "topOrientationChange:");
     try expectContains(out, "registrationName: 'onOrientationChange'");
+    try expectContains(out, "ConditionallyIgnoredEventHandlers({");
+    try expectContains(out, "onOrientationChange: true");
 }
 
 test "codegen_plugin: paperComponentName option → uiViewClassName / nativeComponentName 둘 다 paper 이름" {

--- a/src/transformer/transformer/control_flow.zig
+++ b/src/transformer/transformer/control_flow.zig
@@ -29,6 +29,7 @@ pub fn visitForInOfTernary(self: *Transformer, node: Node) Error!NodeIndex {
             // for-await-of 자체는 enclosing async function 보장이지만 body 에 await
             // 가 없으면 sync _loop 으로 충분.
             const is_async = if (has_capture) BlockScoping.hasAwaitExpression(self, orig_body_idx) else false;
+            const preserve_this = if (has_capture) BlockScoping.hasLexicalThisReference(self, orig_body_idx) else false;
 
             var flow = BlockScoping.FlowResult{};
             defer flow.labels.deinit(self.allocator);
@@ -52,6 +53,7 @@ pub fn visitForInOfTernary(self: *Transformer, node: Node) Error!NodeIndex {
                     null,
                     node.span,
                     is_async,
+                    preserve_this,
                 );
                 const loop_node = try self.ast.addNode(.{
                     .tag = node.tag,
@@ -182,6 +184,7 @@ pub fn visitForStatement(self: *Transformer, node: Node) Error!NodeIndex {
             const orig_body_idx = self.readNodeIdx(e, 3);
             const has_capture = BlockScoping.hasCapturedClosure(self, orig_body_idx, lexical_names.items);
             const is_async = if (has_capture) BlockScoping.hasAwaitExpression(self, orig_body_idx) else false;
+            const preserve_this = if (has_capture) BlockScoping.hasLexicalThisReference(self, orig_body_idx) else false;
 
             // 제어 흐름 분석도 원본에서 수행
             var flow = BlockScoping.FlowResult{};
@@ -204,6 +207,7 @@ pub fn visitForStatement(self: *Transformer, node: Node) Error!NodeIndex {
                     null,
                     node.span,
                     is_async,
+                    preserve_this,
                 );
 
                 // var _loop = function(...) { ... };

--- a/tests/integration/tests/bundle-smoke.test.ts
+++ b/tests/integration/tests/bundle-smoke.test.ts
@@ -1834,6 +1834,18 @@ describe('export type/interface + module.exports → CJS 판별 (#713)', () => {
     expect(result.runOutput).toBe('33');
   });
 
+  test('CJS: Object.defineProperty(module, "exports") → __commonJS 래핑', async () => {
+    const result = await bundleAndRun(
+      {
+        'entry.js': `const lib = require("./lib"); console.log(lib.value);`,
+        'lib.js': `function getExports() { return { value: 123 }; }\nObject.defineProperty(module, "exports", { enumerable: true, get: getExports });`,
+      },
+      'entry.js',
+    );
+    cleanup = result.cleanup;
+    expect(result.runOutput).toBe('123');
+  });
+
   test('TS: export type + export const 혼합 → value export 유지', async () => {
     const result = await bundleAndRun(
       {

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -131,7 +131,12 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
       cleanup = fixture.cleanup;
 
       const outFile = join(fixture.dir, 'out.js');
-      const transpile = await runZntc([join(fixture.dir, 'index.ts'), '-o', outFile, '--target=es5']);
+      const transpile = await runZntc([
+        join(fixture.dir, 'index.ts'),
+        '-o',
+        outFile,
+        '--target=es5',
+      ]);
       expect(transpile.exitCode).toBe(0);
 
       const output = readFileSync(outFile, 'utf8');
@@ -141,7 +146,9 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
       const andGuard = output.indexOf(`if (!(${clientTemp}))`, clientRead);
       const clientEnd = output.indexOf('client.end();');
       const skipOrMatch = output.match(/(_[a-z]+) = true;[\s\S]*?if \(\1\)[\s\S]*?skipOr\(\)/);
-      const skipNullishMatch = output.match(/(_[a-z]+) = "value";[\s\S]*?if \(\1 != null\)[\s\S]*?skipNullish\(\)/);
+      const skipNullishMatch = output.match(
+        /(_[a-z]+) = "value";[\s\S]*?if \(\1 != null\)[\s\S]*?skipNullish\(\)/,
+      );
       const conditionalGuard = output.indexOf('if (!(flag))');
       const thenBranch = output.indexOf('thenBranch()');
       const elseBranch = output.indexOf('elseBranch()');

--- a/tests/integration/tests/downlevel-edge.test.ts
+++ b/tests/integration/tests/downlevel-edge.test.ts
@@ -1,5 +1,7 @@
 import { describe, test, expect, afterEach } from 'bun:test';
-import { bundleAndRun, transpileAndRun } from './helpers';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { bundleAndRun, createFixture, runZntc, transpileAndRun } from './helpers';
 
 describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
   let cleanup: (() => Promise<void>) | undefined;
@@ -115,6 +117,45 @@ describe('ES 다운레벨링 엣지케이스 (복합 조합)', () => {
   });
 
   describe('syntax audit regressions', () => {
+    test('async await extraction preserves lazy logical and conditional branches', async () => {
+      const fixture = await createFixture({
+        'index.ts': `
+          async function run(client: null | { end(): void }, flag: boolean) {
+            client && (client.end(), await delay());
+            true || await skipOr();
+            "value" ?? await skipNullish();
+            return flag ? await thenBranch() : await elseBranch();
+          }
+        `,
+      });
+      cleanup = fixture.cleanup;
+
+      const outFile = join(fixture.dir, 'out.js');
+      const transpile = await runZntc([join(fixture.dir, 'index.ts'), '-o', outFile, '--target=es5']);
+      expect(transpile.exitCode).toBe(0);
+
+      const output = readFileSync(outFile, 'utf8');
+      const clientTemp = output.match(/(_[a-z]+) = client;/)?.[1];
+      expect(clientTemp).toBeDefined();
+      const clientRead = output.indexOf(`${clientTemp} = client;`);
+      const andGuard = output.indexOf(`if (!(${clientTemp}))`, clientRead);
+      const clientEnd = output.indexOf('client.end();');
+      const skipOrMatch = output.match(/(_[a-z]+) = true;[\s\S]*?if \(\1\)[\s\S]*?skipOr\(\)/);
+      const skipNullishMatch = output.match(/(_[a-z]+) = "value";[\s\S]*?if \(\1 != null\)[\s\S]*?skipNullish\(\)/);
+      const conditionalGuard = output.indexOf('if (!(flag))');
+      const thenBranch = output.indexOf('thenBranch()');
+      const elseBranch = output.indexOf('elseBranch()');
+
+      expect(clientRead).toBeGreaterThanOrEqual(0);
+      expect(andGuard).toBeGreaterThan(clientRead);
+      expect(clientEnd).toBeGreaterThan(andGuard);
+      expect(skipOrMatch).not.toBeNull();
+      expect(skipNullishMatch).not.toBeNull();
+      expect(conditionalGuard).toBeGreaterThanOrEqual(0);
+      expect(thenBranch).toBeGreaterThan(conditionalGuard);
+      expect(elseBranch).toBeGreaterThan(thenBranch);
+    });
+
     test('logical nullish assignment reads member value only once', async () => {
       const result = await transpileAndRun(
         `

--- a/tests/integration/tests/es5-rn.test.ts
+++ b/tests/integration/tests/es5-rn.test.ts
@@ -326,13 +326,17 @@ describe('RN 번들: Metro vs ZNTC 모듈 수 비교', () => {
     let violations: string[] = [];
     for (const block of esmBlocks) {
       // __export(exports_xxx, ...) 호출은 정상 — 이건 별도 namespace
-      // exports.x=x 또는 module.exports= 가 있으면 위반
+      // exports.x=x, module.exports=, Object.defineProperty(module, "exports", ...)
+      // 가 있으면 위반
       const lines = block.split('\n');
       for (const line of lines) {
         if (line.match(/\bexports\.\w+\s*=/) && !line.includes('__export')) {
           violations.push(line.trim().substring(0, 80));
         }
         if (line.includes('module.exports=') || line.includes('module.exports =')) {
+          violations.push(line.trim().substring(0, 80));
+        }
+        if (line.match(/Object\.defineProperty\(module\s*,\s*["']exports["']/)) {
           violations.push(line.trim().substring(0, 80));
         }
       }


### PR DESCRIPTION
## 요약
- 문자열 리터럴 동등성 폴딩 전에 escape를 디코딩해 유니코드 escape와 실제 유니코드 문자의 비교 결과가 달라지지 않게 수정했습니다.
- async/generator 다운레벨링에서 `&&`, `||`, `??`, 삼항식 내부의 `await`가 lazy branch를 깨고 먼저 실행되던 문제를 state-machine branch로 보존했습니다.
- RN codegen에서 nullable wrapper로 감싼 `DirectEventHandler`/`BubblingEventHandler`를 이벤트로 분류해 Modal view config의 `topOrientationChange` 등록 누락을 수정했습니다.
- RN codegen view config의 event `validAttributes`를 `ConditionallyIgnoredEventHandlers` wrapper로 emit해 Metro/RN codegen 출력과 맞췄습니다.
- block-scoping 루프 클로저 추출 시 원래 루프 본문의 `this`가 필요하면 `_loop.call(this, ...)`로 호출해 private method 접근의 receiver를 보존했습니다.
- RN dev 로그 forwarding을 Metro 경로와 맞춰, zntc HMR client의 별도 `console.*` 래핑을 제거하고 RN core의 `HMRClient.log` forwarding만 사용하게 했습니다.
- `Object.defineProperty(module, "exports", ...)` 형태의 CJS export 정의를 CJS 신호로 감지해 해당 모듈이 `__esm`으로 잘못 감싸지지 않게 수정했습니다.

## 원인
- 문자열 비교 최적화가 raw literal body만 비교해 같은 문자열을 다른 값으로 판단했습니다.
- async/generator 변환의 yield extraction이 logical/conditional expression 양쪽을 재귀적으로 먼저 낮춰 RHS 또는 선택되지 않은 branch를 guard 전에 실행할 수 있었습니다.
- RN Flow spec의 `?DirectEventHandler<T>`를 schema builder가 nullable wrapper 때문에 일반 prop으로 분류해 `directEventTypes` 생성이 빠졌습니다.
- RN codegen event props를 raw `validAttributes`로 넣어 RN codegen의 platform-specific ignore wrapper와 출력이 달랐습니다. Modal의 `topOrientationChange`는 `directEventTypes`에 있어도 `validAttributes` 구조가 Metro 출력과 달라 Fabric 이벤트 추출 경로에서 차이가 났습니다.
- `for...of`의 per-iteration lexical binding 보존을 위해 루프 body를 `_loop` 함수로 추출한 뒤 호출부가 `_loop(...)`를 사용해 원래 메서드의 `this` 바인딩이 사라졌습니다. private method lowering은 `this`를 receiver로 검사하므로, `_loop` 내부에서 `this.#method()`가 non-instance 접근으로 실패했습니다.
- zntc HMR client가 RN core `setUpDeveloperTools -> HMRClient.log` 경로와 별도로 `console.*`를 한 번 더 감싸며 로그 직렬화/전달 동작이 Metro와 달라졌습니다. 이제 client는 Metro처럼 `pretty-format`을 사용해 `HMRClient.log`에서만 log frame을 만들고, 서버의 `forwardClientLogs` 기본값도 Metro처럼 true로 맞췄습니다.
- import scanner가 `Object.defineProperty(exports, ...)`와 `Object.defineProperty(module.exports, ...)`만 CJS 신호로 보고, `Object.defineProperty(module, "exports", ...)`는 놓쳤습니다. 그 결과 해당 파일이 `module` 인자가 없는 `__esm` wrapper로 분류되어 RN 런타임에서 `Property 'module' doesn't exist`가 발생했습니다.

## 검증
- `zig build test -Dtest-filter="decode"`
- `zig build test -Dtest-filter="async"`
- `bun test tests/integration/tests/downlevel-edge.test.ts -t "async await extraction preserves lazy logical"`
- `zig build test -Dtest-filter="Flow nullable DirectEventHandler"`
- `zig build test -Dtest-filter="view_config_emitter"`
- `zig build test -Dtest-filter="rn_codegen"`
- `zig build test -Dtest-filter="for-of loop closure preserves method this"`
- `zig build test -Dtest-filter="Object.defineProperty(module"`
- `zig build test -Dtest-filter="RN preset"`
- `zig build test -Dtest-filter="block scoping"`
- `zig build test -Dtest-filter="for-of"`
- `zig build test -Dtest-filter="codegen"`
- `bun test packages/react-native/src/runtime/zntc-hmr-client.test.mjs packages/react-native/src/plugins/asset.test.ts packages/react-native/src/dev-server/hmr-bridge.test.ts ./packages/core/test/cli/react-native-dev-input/server.ts`
- `bun run --cwd packages/react-native build:bundle`
- `bun run --cwd packages/react-native build:dts`
- `bun run fmt:check`
- `zig build`
- `zig build napi`
- `zig build napi -Doptimize=ReleaseFast`
- `bundleAndRun` 직접 스모크에서 `Object.defineProperty(module, "exports", ...)` 케이스가 `123`을 출력하는 것 확인
- 앱 개발 서버에서 모달 open 후 fresh 로그 기준 기존 `iconv-lite warning`, MQTT null `.end`, JS compile failure, `topOrientationChange` 오류 문자열 미검출
- 새 번들의 `RCTModalHostView` view config가 `Object.assign(...ConditionallyIgnoredEventHandlers(...))` 형태로 출력되는 것 확인
- 새 번들에서 zntc HMR client의 `_originalConsole`, `__ZNTC_FORWARD_CLIENT_LOGS__`, log item `JSON.stringify` fallback 제거 확인
- 앱 개발 서버 새 번들에서 문제 모듈이 `__commonJS` wrapper로 출력되고, 앱 재시작 후 기존 `Property 'module' doesn't exist` redbox가 사라진 것 확인