### PR TITLE
perf(graph): pre-warm dir-fd cache when registering a new module path

### DIFF
--- a/src/bundler/fs.zig
+++ b/src/bundler/fs.zig
@@ -224,6 +224,21 @@ pub const RealReadFileCache = struct {
         };
     }
 
+    /// 신규 모듈이 그래프에 등록되는 시점에 호출 — 그 모듈을 후속 read 할 때 발생하는
+    /// `openFile` 의 dir-fd cache MISS (`getOrOpenDir` 의 첫 `std.fs.cwd().openDir`)
+    /// 를 미리 처리해 hot path 의 wall 을 줄인다. 결과는 cache 에만 박아둬 caller 는
+    /// fd 를 받지 않는다 — 에러는 모두 swallow (best-effort).
+    ///
+    /// caller 가 fs file path 인지 확신할 수 없는 위치 (`graph.addModule` 처럼 plugin
+    /// virtual / disabled-prefix / specifier 가 섞여 들어오는 곳) 에서도 안전하게
+    /// 호출하도록 path 검증을 둔다 — non-absolute 또는 null-byte 포함 path 는 skip.
+    pub fn preopenDir(self: *RealReadFileCache, allocator: std.mem.Allocator, dir_path: []const u8) void {
+        if (dir_path.len == 0) return;
+        if (!std.fs.path.isAbsolute(dir_path)) return;
+        if (std.mem.indexOfScalar(u8, dir_path, 0) != null) return;
+        _ = self.getOrOpenDir(allocator, dir_path) catch {};
+    }
+
     fn openFile(self: *RealReadFileCache, allocator: std.mem.Allocator, path: []const u8) !std.fs.File {
         const dir_path = std.fs.path.dirname(path) orelse ".";
         const file_name = std.fs.path.basename(path);
@@ -280,6 +295,9 @@ pub const VirtualReadFileCache = struct {
     ) FsError!LoadedModuleWithStat {
         return Implementation.init().readFileWithStat(content_allocator, path, max_bytes);
     }
+
+    /// WASM 빌드 noop — VFS 는 dir-fd cache 가 없으므로 pre-warm 의미 없음.
+    pub fn preopenDir(_: *VirtualReadFileCache, _: std.mem.Allocator, _: []const u8) void {}
 };
 
 /// 호스트 OS 의 std.fs.cwd() 를 wrapping. NAPI / CLI 빌드의 default 구현.

--- a/src/bundler/graph/module_registry.zig
+++ b/src/bundler/graph/module_registry.zig
@@ -86,6 +86,14 @@ pub fn addModule(self: *ModuleGraph, abs_path: []const u8) !ModuleIndex {
     try self.modules.append(self.allocator, module);
     try self.path_to_module.put(path_owned, index);
 
+    // 신규 모듈 path 의 dir 를 source_read_cache 에 pre-warm — readModuleSource 단계의
+    // dir-fd cache MISS (avg 70μs) 를 graph BFS 시점에 미리 처리. virtual path
+    // (disabled / optional missing 등) 는 disabled_path 전용 함수에서 처리되므로
+    // 여기 들어오는 abs_path 는 fs file path. openDir 실패는 preopenDir 가 swallow.
+    if (std.fs.path.dirname(abs_path)) |dir_path| {
+        self.source_read_cache.preopenDir(self.allocator, dir_path);
+    }
+
     // 파싱은 build()의 배치 루프에서 수행
     return index;
 }


### PR DESCRIPTION
## 배경

#3142 의 `graph_io_audit` (PR #3157) 으로 측정한 `RealReadFileCache.openFile` 분포:

| | n | avg_ns |
|---|---:|---:|
| open total | 945 | 36,519 |
| dir_cache HIT | 730 (77%) | 26,536 |
| **dir_cache MISS** | **215 (23%)** | **70,415 (HIT 의 2.65×)** |

MISS 는 첫 모듈이 새 dir 에 도달할 때 발생. `getOrOpenDir` 가 mutex 안에서
`std.fs.cwd().openDir` 호출 — 그 dir 의 다른 모듈들이 cache HIT 받으려면 그
mutex 가 풀린 후여야 함.

## 변경

graph BFS 가 새 모듈 path 를 등록하는 시점 (`graph.addModule`) 에 그 dirname 으로
`fs.RealReadFileCache.preopenDir` 를 호출. 후속 `readModuleSource` 는 cache HIT.

- `fs.RealReadFileCache.preopenDir(allocator, dir_path)` 추가 — `getOrOpenDir`
  결과를 버리고 cache 에만 박음. fd 반환 없음.
- `addModule` 호출 path 가 fs file 이 아닌 경우 (`resolve_imports.zig:304` 의
  plugin virtual / `disabled:` prefix 등) 도 들어올 수 있어서 `preopenDir` 내부에서
  `isAbsolute` + null-byte 검증 후 skip. 모든 에러 swallow (best-effort).
- WASM (`VirtualReadFileCache`) 에는 dir-fd 가 없으므로 noop stub.

## 측정 (`examples/react-native-bare`, 945 모듈, ReleaseFast, `--profile=graph --profile-level=detailed`)

5 runs each:

| 시나리오 | BEFORE open self | AFTER open self | Δ | BEFORE wall | AFTER wall | Δ |
|---|---:|---:|---:|---:|---:|---:|
| **Cold (run 1)** | 328 ms | 253 ms | **-23%** | 66 ms | 58 ms | **-12%** |
| **Warm (median run 2-5)** | 138 ms | 124 ms | -10% | 50 ms | 48 ms | -4% (noise) |

**cold (CI / 첫 빌드) 시나리오에서 wall 12% 절감 명확.** warm (dev/HMR) 은
addModule 시점이 sync 라 BFS scan worker 들의 wall 에 흡수되어 일부만 절감된다.

원래 `graph_io_audit` 분석으로 예상한 절감 (~10ms wall) 과 일치하는 cold 결과.
warm 영향은 미미하지만 regression 없음.

## Test plan

- [x] `zig build test` 전체 통과 — virtual path (`disabled:` prefix / plugin
  namespace 등) 가 `addModule` 에 들어와도 preopen 의 validation 으로 안전
- [x] before/after profile 측정 (위 표) — `examples/react-native-bare` 5 runs
- [x] `--profile=graph` 측정 시 `graph.discover.pm.setup.read.open` aggregate
  self-time 이 cold 23% / warm 10% 감소
- [ ] CI fresh build 시나리오에서 wall 영향 확인 (cold-equivalent)

## 후속

`docs/BACKLOG.md` 등에 cold-build 디스크 캐시 (#3142 §4-D) 가 별도 큰 작업으로
남아있다. 본 PR 은 그 사이 cheap & safe 한 hot path 개선.

🤖 Generated with [Claude Code](https://claude.com/claude-code)