### PR TITLE
fix(parser): accept contextual keywords as Flow function-type param names

### DIFF
--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -584,6 +584,15 @@ fn parseTypeParameter(self: *Parser) ParseError2!NodeIndex {
 // Parenthesized / Function Type
 // ================================================================
 
+/// Flow function-type 의 named-param 이름 자리에 올 수 있는 토큰인지.
+/// `identifier` 와 contextual / strict-reserved keyword (async, from, target,
+/// let, yield 등) 까지 받는다 — type-only context 라 ES reserved (await/with/...)
+/// 만 제외. 호출처는 이 결과로 `(name: T)` named param 인지 `(T)` positional param
+/// 인지 분기하므로 세 호출 사이트가 동일 condition 을 공유해야 한다.
+inline fn canBeFnTypeParamName(kind: @import("../lexer/token.zig").Kind) bool {
+    return kind == .identifier or (kind.isKeyword() and !kind.isReservedKeyword());
+}
+
 /// 괄호 타입 (Type) 또는 함수 타입 (a: Type) => Type (Babel 방식).
 /// 1단계: `()`, `...`, `identifier:` → 확정적 function type
 /// 2단계: 그 외 → grouped type으로 먼저 파싱, `,` 또는 `) =>` 따르면 function type
@@ -604,7 +613,7 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
     // ...rest 또는 identifier: → 확정적 named/rest function param
     const is_definite_fn = blk: {
         if (self.current() == .dot3) break :blk true;
-        if (self.current() == .identifier or (self.current().isKeyword() and !self.current().isReservedKeyword())) {
+        if (canBeFnTypeParamName(self.current())) {
             const next = try self.peekNextKind();
             break :blk (next == .colon or next == .question);
         }
@@ -630,7 +639,7 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
             const loop_guard_pos = self.scanner.token.span.start;
             if (self.current() == .dot3) try self.advance();
             // named param 감지: identifier + (`:` | `?`)
-            if (self.current() == .identifier or (self.current().isKeyword() and !self.current().isReservedKeyword())) {
+            if (canBeFnTypeParamName(self.current())) {
                 const next = try self.peekNextKind();
                 if (next == .colon or next == .question) {
                     const named = try parseFunctionTypeParamList(self);
@@ -722,12 +731,7 @@ fn parseFunctionTypeParamList(self: *Parser) ParseError2!ast_mod.NodeList {
         }
 
         // name: Type 또는 name?: Type — 이름 뒤에 : 또는 ?: 가 오면 named param.
-        // 호출처 `parseParenOrFunctionType` 가 contextual keyword (async/from/of/target/meta/let 등)
-        // 도 named-param 후보로 분류하므로 여기 condition 도 동일하게 받아야 한다 — 더 좁게 받으면
-        // fall-through 후 positional path 가 키워드를 type expression 으로 잘못 파싱해 fail한다.
-        const can_be_param_name = self.current() == .identifier or
-            (self.current().isKeyword() and !self.current().isReservedKeyword());
-        if (can_be_param_name) {
+        if (canBeFnTypeParamName(self.current())) {
             const next = try self.peekNextKind();
             if (next == .colon or next == .question) {
                 const name_span = self.scanner.token.span;

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -721,8 +721,13 @@ fn parseFunctionTypeParamList(self: *Parser) ParseError2!ast_mod.NodeList {
             try self.advance();
         }
 
-        // name: Type 또는 name?: Type — 이름 뒤에 : 또는 ?: 가 오면 named param
-        if (self.current() == .identifier) {
+        // name: Type 또는 name?: Type — 이름 뒤에 : 또는 ?: 가 오면 named param.
+        // 호출처 `parseParenOrFunctionType` 가 contextual keyword (async/from/of/target/meta/let 등)
+        // 도 named-param 후보로 분류하므로 여기 condition 도 동일하게 받아야 한다 — 더 좁게 받으면
+        // fall-through 후 positional path 가 키워드를 type expression 으로 잘못 파싱해 fail한다.
+        const can_be_param_name = self.current() == .identifier or
+            (self.current().isKeyword() and !self.current().isReservedKeyword());
+        if (can_be_param_name) {
             const next = try self.peekNextKind();
             if (next == .colon or next == .question) {
                 const name_span = self.scanner.token.span;

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -3150,16 +3150,18 @@ test "Flow: positional function type params" {
     try expectNoParseErrorFlow("type X = ($ReadOnly<{a: number}>, string) => void;");
 }
 
-test "Flow: contextual keyword as function-type param name" {
-    // 호출처 (parseParenOrFunctionType) 가 named-param 후보로 받는 contextual keyword
-    // 들이 parseFunctionTypeParamList 안에서 fall-through 되던 회귀 가드. react-native
-    // codegen 의 TurboModule spec (`+stat: (target: string, callback: (...) => void) => void;`)
-    // 같은 패턴이 영향 받음.
+test "Flow: contextual keywords as function-type param names" {
+    // react-native-blob-util codegenSpecs (`+stat: (target: string, callback: (...) => void) => void;`)
+    // 같은 RN TurboModule spec 패턴이 fail 하던 회귀 가드.
+    // 1번째 param.
     try expectNoParseErrorFlow("type T = (target: string, b: () => void) => void;");
     try expectNoParseErrorFlow("type T = (meta: string, b: () => void) => void;");
     try expectNoParseErrorFlow("type T = (async: string, b: () => void) => void;");
     try expectNoParseErrorFlow("type T = (from: string, b: () => void) => void;");
     try expectNoParseErrorFlow("type T = (of: string, b: () => void) => void;");
+    // 2번째 이후 param 위치 (parseParenOrFunctionType 의 comma-loop 경로).
+    try expectNoParseErrorFlow("type T = (x: string, target: () => void) => void;");
+    try expectNoParseErrorFlow("type T = (x: string, of: number, target: () => void) => void;");
     // interface method 의 nested function-type param (실제 trigger 케이스).
     try expectNoParseErrorFlow(
         \\interface Spec {

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -3150,6 +3150,26 @@ test "Flow: positional function type params" {
     try expectNoParseErrorFlow("type X = ($ReadOnly<{a: number}>, string) => void;");
 }
 
+test "Flow: contextual keyword as function-type param name" {
+    // 호출처 (parseParenOrFunctionType) 가 named-param 후보로 받는 contextual keyword
+    // 들이 parseFunctionTypeParamList 안에서 fall-through 되던 회귀 가드. react-native
+    // codegen 의 TurboModule spec (`+stat: (target: string, callback: (...) => void) => void;`)
+    // 같은 패턴이 영향 받음.
+    try expectNoParseErrorFlow("type T = (target: string, b: () => void) => void;");
+    try expectNoParseErrorFlow("type T = (meta: string, b: () => void) => void;");
+    try expectNoParseErrorFlow("type T = (async: string, b: () => void) => void;");
+    try expectNoParseErrorFlow("type T = (from: string, b: () => void) => void;");
+    try expectNoParseErrorFlow("type T = (of: string, b: () => void) => void;");
+    // interface method 의 nested function-type param (실제 trigger 케이스).
+    try expectNoParseErrorFlow(
+        \\interface Spec {
+        \\    +stat: (target: string, callback: (value: Array<any>) => void) => void;
+        \\}
+    );
+    // optional param (`name?: Type`) 변형도 함께.
+    try expectNoParseErrorFlow("type T = (target?: string, b?: () => void) => void;");
+}
+
 test "Flow: const type parameter" {
     try expectNoParseErrorFlow("function f<const T: {[string]: true}>(x: T): T { return x; }");
 }


### PR DESCRIPTION
## 배경

`react-native-blob-util` 의 `codegenSpecs/NativeBlobUtils.js` 같은 RN TurboModule
Flow spec 들이 ZNTC 번들 시 parse error 로 실패. 시작은 #3142 측정 중 발견:

```
[error] react-native-blob-util/codegenSpecs/NativeBlobUtils.js: Expression expected
[error] react-native-blob-util/codegenSpecs/NativeBlobUtils.js: :
```

해당 file 의 47 번째 줄:
```js
+stat: (target: string, callback: (value: Array<any>) => void) => void;
```

## Root cause

`src/parser/flow.zig` 의 `parseFunctionTypeParamList` 가 named-param 자리에서
`.identifier` 토큰만 체크했다. 그런데 호출처 `parseParenOrFunctionType` 는 이미
contextual keyword (`target`/`meta`/`async`/`from`/`of`/`let` 등) 를 named-param
후보로 분류해 들여보내므로, parse 함수의 condition mismatch 로 fall-through 발생
→ positional path 가 키워드를 type expression 으로 파싱하려다 fail.

| 위치 | condition | contextual keyword |
|---|---|---|
| `parseParenOrFunctionType` is_definite_fn | `identifier OR (isKeyword AND !isReservedKeyword)` | ✅ 받음 |
| `parseParenOrFunctionType` after-comma | 동일 | ✅ 받음 |
| **`parseFunctionTypeParamList`** | **`.identifier` 만** | ❌ **받지 않음** |

## 변경

`parseFunctionTypeParamList` 의 condition 을 호출처와 동일하게 확장.

## Babel 비교 검증

같은 케이스를 `@babel/parser` (flow plugin) 로 직접 측정해 contextual keyword
처리 범위가 일치함을 확인:

| keyword | ZNTC (fix 후) | Babel | 정답 |
|---|---|---|---|
| target / meta / async / from / of / as | OK | OK | ✅ 일치 |
| await | FAIL | FAIL | ✅ 일치 (ES reserved) |
| **let / yield** | OK | FAIL | ⚠️ ZNTC 가 일관되게 더 관용적 |

`let`/`yield` (strict mode reserved) 는 ZNTC 의 기존 `parseParenOrFunctionType`
정책이 이미 받고 있어 여기서도 일관되게 받음. Babel 과 align 하려면 그쪽까지
함께 좁혀야 하므로 별도 PR 에서 검토 권장.

## Test plan

- [x] `zig build test` 전체 통과
- [x] `zntc react-native-blob-util/codegenSpecs/NativeBlobUtils.js` 정상 transpile
  (이전: 13+ parse error)
- [x] `parser_test.zig` 에 회귀 가드 unit test 추가
  - contextual keyword (`target` / `meta` / `async` / `from` / `of`) × {type alias / interface method / optional param}
- [x] Babel 비교 — `@babel/parser` flow plugin 으로 동일 입력 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)