### PR TITLE
fix(parser): detect typed arrow when first param has default value

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1712,6 +1712,26 @@ pub const Parser = struct {
     // TS Arrow Function Detection
     // ================================================================
 
+    /// `(x = default, y: T) =>` 같은 typed arrow detection 중 default value
+    /// expression 을 통과해 다음 param 의 `:` / `?` 까지 진행한다. paren/bracket/brace
+    /// balanced skip 으로 nested call/object/array literal 도 안전하게 통과. 종료 시
+    /// current 토큰은 `,` 또는 `)` (eof 직전 종료).
+    fn skipDefaultValueToCommaOrRParen(self: *Parser) !void {
+        var depth: u32 = 0;
+        while (self.current() != .eof) {
+            switch (self.current()) {
+                .l_paren, .l_bracket, .l_curly => depth += 1,
+                .r_paren, .r_bracket, .r_curly => {
+                    if (depth == 0) return;
+                    depth -= 1;
+                },
+                .comma => if (depth == 0) return,
+                else => {},
+            }
+            try self.advance();
+        }
+    }
+
     /// TS 모드에서 `(identifier:` 또는 `(identifier?` 패턴으로 typed arrow function 감지.
     /// 현재 토큰이 `(` 일 때 호출. 2-token lookahead로 판단.
     pub fn isTypedArrowFunction(self: *Parser) !bool {
@@ -1752,6 +1772,18 @@ pub const Parser = struct {
             }
             // (a?: Type) — optional parameter
             if (self.current() == .question) return true;
+            // (a = default, ...) — 첫 번째 파라미터에 default value 가 있는 경우.
+            // default expression 을 통과한 뒤 typed arrow 후보 검사를 이어간다.
+            if (self.current() == .eq) {
+                try self.advance(); // skip =
+                try self.skipDefaultValueToCommaOrRParen();
+                if (self.current() == .r_paren) {
+                    try self.advance();
+                    return self.current() == .colon and !self.in_ternary_consequent;
+                }
+                // comma → 아래 typed-param 검사 loop 로 fall-through
+            }
+
             // (a, b: Type) => ... — 첫 번째 파라미터에 타입이 없고 뒤에 타입이 있는 경우.
             // `,` 뒤의 파라미터에서 `identifier :` 패턴을 찾으면 typed arrow로 판별.
             // 예: (background, useForeground: boolean) => {}
@@ -1769,6 +1801,16 @@ pub const Parser = struct {
                         if (self.current() == .r_paren) {
                             try self.advance();
                             return self.current() == .colon and !self.in_ternary_consequent;
+                        }
+                        // default value 가 있는 다음 param — expression 통과 후 계속.
+                        if (self.current() == .eq) {
+                            try self.advance(); // skip =
+                            try self.skipDefaultValueToCommaOrRParen();
+                            if (self.current() == .comma) continue;
+                            if (self.current() == .r_paren) {
+                                try self.advance();
+                                return self.current() == .colon and !self.in_ternary_consequent;
+                            }
                         }
                         // 이 파라미터에도 타입이 없으면 다음 파라미터 확인
                     } else {

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -3213,6 +3213,22 @@ test "Flow: typed arrow in multi-param" {
     try expectNoParseErrorFlow("const f = (a, b, c: string) => c;");
 }
 
+test "TS: typed arrow with default-value parameters" {
+    // @shopify/react-native-skia 의 `vec = (x = 0, y?: number) => ...` 같은 패턴이
+    // `isTypedArrowFunction` detection 에서 fail 하던 회귀 가드.
+    // default 첫 param + optional/plain typed 두 번째.
+    try expectNoParseErrorWithExt("const f = (x = 0, y?: number) => 0;", ".ts");
+    try expectNoParseErrorWithExt("const f = (x = 0, y: number) => 0;", ".ts");
+    // default 두 번째 param + typed 세 번째.
+    try expectNoParseErrorWithExt("const f = (a, b = 1, c: string) => 0;", ".ts");
+    // default expression 의 nested literal 통과 — paren / brace / bracket skip 검증.
+    try expectNoParseErrorWithExt("const f = (x = Math.max(1, 2), y?: number) => 0;", ".ts");
+    try expectNoParseErrorWithExt("const f = (x = { a: 1 }, y: number) => 0;", ".ts");
+    try expectNoParseErrorWithExt("const f = (x = [1, 2, 3], y: number) => 0;", ".ts");
+    // 단일 param + default + return type annotation.
+    try expectNoParseErrorWithExt("const f = (x = 0): number => x;", ".ts");
+}
+
 test "Flow: nullable return type with arrow" {
     // ?(T) return type이 function type이 아닌 nullable paren type으로 해석되어야 함
     try expectNoParseErrorFlow(

--- a/tests/integration/tests/tsc/__snapshots__/es6-defaultParameters.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-defaultParameters.test.ts.snap
@@ -34,7 +34,7 @@ var lambda2 = (x, y="hello") => {
 };
 var lambda3 = (x, y="hello", ...rest) => {
 };
-var lambda4 = (y = "hello", ...rest) => {
+var lambda4 = (y="hello", ...rest) => {
 };
 var x = function(str="hello",...rest) {
 };
@@ -53,7 +53,7 @@ var lambda2 = (x, y="hello") => {
 };
 var lambda3 = (x, y="hello", ...rest) => {
 };
-var lambda4 = (y = "hello", ...rest) => {
+var lambda4 = (y="hello", ...rest) => {
 };
 var x = function(str="hello",...rest) {
 };

--- a/tests/integration/tests/tsc/__snapshots__/es6-functionDeclarations.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-functionDeclarations.test.ts.snap
@@ -26,12 +26,6 @@ exports[`TSC: es6/functionDeclarations FunctionDeclaration2_es6 1`] = `
 "
 `;
 
-exports[`TSC: es6/functionDeclarations FunctionDeclaration3_es6 1`] = `
-"function f(yield=yield) {
-}
-"
-`;
-
 exports[`TSC: es6/functionDeclarations FunctionDeclaration4_es6 1`] = `
 "function yield() {
 }

--- a/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
@@ -6748,6 +6748,1256 @@ f((a) => "");
 "
 `;
 
+exports[`TSC: expressions generatedContextualTyping 1`] = `
+"class Base {
+	p;
+}
+class Derived1 extends Base {
+	m;
+}
+class Derived2 extends Base {
+	n;
+}
+var b = new Base(),d1 = new Derived1(),d2 = new Derived2();
+var x1 = () => [d1, d2];
+var x2 = function() {
+	return [d1, d2];
+};
+var x3 = function named() {
+	return [d1, d2];
+};
+var x4 = () => [d1, d2];
+var x5 = function() {
+	return [d1, d2];
+};
+var x6 = function named() {
+	return [d1, d2];
+};
+var x7 = [d1, d2];
+var x8 = [d1, d2];
+var x9 = [d1, d2];
+var x10 = { n: [d1, d2] };
+var x11 = (n) => {
+	var n;
+	return null;
+};
+var x12 = { func: (n) => {
+	return [d1, d2];
+} };
+class x13 {
+	member = () => [d1, d2];
+}
+class x14 {
+	member = function() {
+		return [d1, d2];
+	};
+}
+class x15 {
+	member = function named() {
+		return [d1, d2];
+	};
+}
+class x16 {
+	member = () => [d1, d2];
+}
+class x17 {
+	member = function() {
+		return [d1, d2];
+	};
+}
+class x18 {
+	member = function named() {
+		return [d1, d2];
+	};
+}
+class x19 {
+	member = [d1, d2];
+}
+class x20 {
+	member = [d1, d2];
+}
+class x21 {
+	member = [d1, d2];
+}
+class x22 {
+	member = { n: [d1, d2] };
+}
+class x23 {
+	member = (n) => {
+		var n;
+		return null;
+	};
+}
+class x24 {
+	member = { func: (n) => {
+		return [d1, d2];
+	} };
+}
+class x25 {
+	member = () => [d1, d2];
+}
+class x26 {
+	member = function() {
+		return [d1, d2];
+	};
+}
+class x27 {
+	member = function named() {
+		return [d1, d2];
+	};
+}
+class x28 {
+	member = () => [d1, d2];
+}
+class x29 {
+	member = function() {
+		return [d1, d2];
+	};
+}
+class x30 {
+	member = function named() {
+		return [d1, d2];
+	};
+}
+class x31 {
+	member = [d1, d2];
+}
+class x32 {
+	member = [d1, d2];
+}
+class x33 {
+	member = [d1, d2];
+}
+class x34 {
+	member = { n: [d1, d2] };
+}
+class x35 {
+	member = (n) => {
+		var n;
+		return null;
+	};
+}
+class x36 {
+	member = { func: (n) => {
+		return [d1, d2];
+	} };
+}
+class x37 {
+	member = () => [d1, d2];
+}
+class x38 {
+	member = function() {
+		return [d1, d2];
+	};
+}
+class x39 {
+	member = function named() {
+		return [d1, d2];
+	};
+}
+class x40 {
+	member = () => [d1, d2];
+}
+class x41 {
+	member = function() {
+		return [d1, d2];
+	};
+}
+class x42 {
+	member = function named() {
+		return [d1, d2];
+	};
+}
+class x43 {
+	member = [d1, d2];
+}
+class x44 {
+	member = [d1, d2];
+}
+class x45 {
+	member = [d1, d2];
+}
+class x46 {
+	member = { n: [d1, d2] };
+}
+class x47 {
+	member = (n) => {
+		var n;
+		return null;
+	};
+}
+class x48 {
+	member = { func: (n) => {
+		return [d1, d2];
+	} };
+}
+class x49 {
+	static member = () => [d1, d2];
+}
+class x50 {
+	static member = function() {
+		return [d1, d2];
+	};
+}
+class x51 {
+	static member = function named() {
+		return [d1, d2];
+	};
+}
+class x52 {
+	static member = () => [d1, d2];
+}
+class x53 {
+	static member = function() {
+		return [d1, d2];
+	};
+}
+class x54 {
+	static member = function named() {
+		return [d1, d2];
+	};
+}
+class x55 {
+	static member = [d1, d2];
+}
+class x56 {
+	static member = [d1, d2];
+}
+class x57 {
+	static member = [d1, d2];
+}
+class x58 {
+	static member = { n: [d1, d2] };
+}
+class x59 {
+	static member = (n) => {
+		var n;
+		return null;
+	};
+}
+class x60 {
+	static member = { func: (n) => {
+		return [d1, d2];
+	} };
+}
+class x61 {
+	static member = () => [d1, d2];
+}
+class x62 {
+	static member = function() {
+		return [d1, d2];
+	};
+}
+class x63 {
+	static member = function named() {
+		return [d1, d2];
+	};
+}
+class x64 {
+	static member = () => [d1, d2];
+}
+class x65 {
+	static member = function() {
+		return [d1, d2];
+	};
+}
+class x66 {
+	static member = function named() {
+		return [d1, d2];
+	};
+}
+class x67 {
+	static member = [d1, d2];
+}
+class x68 {
+	static member = [d1, d2];
+}
+class x69 {
+	static member = [d1, d2];
+}
+class x70 {
+	static member = { n: [d1, d2] };
+}
+class x71 {
+	static member = (n) => {
+		var n;
+		return null;
+	};
+}
+class x72 {
+	static member = { func: (n) => {
+		return [d1, d2];
+	} };
+}
+class x73 {
+	static member = () => [d1, d2];
+}
+class x74 {
+	static member = function() {
+		return [d1, d2];
+	};
+}
+class x75 {
+	static member = function named() {
+		return [d1, d2];
+	};
+}
+class x76 {
+	static member = () => [d1, d2];
+}
+class x77 {
+	static member = function() {
+		return [d1, d2];
+	};
+}
+class x78 {
+	static member = function named() {
+		return [d1, d2];
+	};
+}
+class x79 {
+	static member = [d1, d2];
+}
+class x80 {
+	static member = [d1, d2];
+}
+class x81 {
+	static member = [d1, d2];
+}
+class x82 {
+	static member = { n: [d1, d2] };
+}
+class x83 {
+	static member = (n) => {
+		var n;
+		return null;
+	};
+}
+class x84 {
+	static member = { func: (n) => {
+		return [d1, d2];
+	} };
+}
+class x85 {
+	constructor(parm=() => [d1, d2]) {
+	}
+}
+class x86 {
+	constructor(parm=function() {
+		return [d1, d2];
+	}) {
+	}
+}
+class x87 {
+	constructor(parm=function named() {
+		return [d1, d2];
+	}) {
+	}
+}
+class x88 {
+	constructor(parm=() => [d1, d2]) {
+	}
+}
+class x89 {
+	constructor(parm=function() {
+		return [d1, d2];
+	}) {
+	}
+}
+class x90 {
+	constructor(parm=function named() {
+		return [d1, d2];
+	}) {
+	}
+}
+class x91 {
+	constructor(parm=[d1, d2]) {
+	}
+}
+class x92 {
+	constructor(parm=[d1, d2]) {
+	}
+}
+class x93 {
+	constructor(parm=[d1, d2]) {
+	}
+}
+class x94 {
+	constructor(parm={ n: [d1, d2] }) {
+	}
+}
+class x95 {
+	constructor(parm=(n) => {
+		var n;
+		return null;
+	}) {
+	}
+}
+class x96 {
+	constructor(parm={ func: (n) => {
+		return [d1, d2];
+	} }) {
+	}
+}
+class x97 {
+	constructor(parm=() => [d1, d2]) {
+		this.parm = parm;
+	}
+}
+class x98 {
+	constructor(parm=function() {
+		return [d1, d2];
+	}) {
+		this.parm = parm;
+	}
+}
+class x99 {
+	constructor(parm=function named() {
+		return [d1, d2];
+	}) {
+		this.parm = parm;
+	}
+}
+class x100 {
+	constructor(parm=() => [d1, d2]) {
+		this.parm = parm;
+	}
+}
+class x101 {
+	constructor(parm=function() {
+		return [d1, d2];
+	}) {
+		this.parm = parm;
+	}
+}
+class x102 {
+	constructor(parm=function named() {
+		return [d1, d2];
+	}) {
+		this.parm = parm;
+	}
+}
+class x103 {
+	constructor(parm=[d1, d2]) {
+		this.parm = parm;
+	}
+}
+class x104 {
+	constructor(parm=[d1, d2]) {
+		this.parm = parm;
+	}
+}
+class x105 {
+	constructor(parm=[d1, d2]) {
+		this.parm = parm;
+	}
+}
+class x106 {
+	constructor(parm={ n: [d1, d2] }) {
+		this.parm = parm;
+	}
+}
+class x107 {
+	constructor(parm=(n) => {
+		var n;
+		return null;
+	}) {
+		this.parm = parm;
+	}
+}
+class x108 {
+	constructor(parm={ func: (n) => {
+		return [d1, d2];
+	} }) {
+		this.parm = parm;
+	}
+}
+class x109 {
+	constructor(parm=() => [d1, d2]) {
+		this.parm = parm;
+	}
+}
+class x110 {
+	constructor(parm=function() {
+		return [d1, d2];
+	}) {
+		this.parm = parm;
+	}
+}
+class x111 {
+	constructor(parm=function named() {
+		return [d1, d2];
+	}) {
+		this.parm = parm;
+	}
+}
+class x112 {
+	constructor(parm=() => [d1, d2]) {
+		this.parm = parm;
+	}
+}
+class x113 {
+	constructor(parm=function() {
+		return [d1, d2];
+	}) {
+		this.parm = parm;
+	}
+}
+class x114 {
+	constructor(parm=function named() {
+		return [d1, d2];
+	}) {
+		this.parm = parm;
+	}
+}
+class x115 {
+	constructor(parm=[d1, d2]) {
+		this.parm = parm;
+	}
+}
+class x116 {
+	constructor(parm=[d1, d2]) {
+		this.parm = parm;
+	}
+}
+class x117 {
+	constructor(parm=[d1, d2]) {
+		this.parm = parm;
+	}
+}
+class x118 {
+	constructor(parm={ n: [d1, d2] }) {
+		this.parm = parm;
+	}
+}
+class x119 {
+	constructor(parm=(n) => {
+		var n;
+		return null;
+	}) {
+		this.parm = parm;
+	}
+}
+class x120 {
+	constructor(parm={ func: (n) => {
+		return [d1, d2];
+	} }) {
+		this.parm = parm;
+	}
+}
+function x121(parm=() => [d1, d2]) {
+}
+function x122(parm=function() {
+	return [d1, d2];
+}) {
+}
+function x123(parm=function named() {
+	return [d1, d2];
+}) {
+}
+function x124(parm=() => [d1, d2]) {
+}
+function x125(parm=function() {
+	return [d1, d2];
+}) {
+}
+function x126(parm=function named() {
+	return [d1, d2];
+}) {
+}
+function x127(parm=[d1, d2]) {
+}
+function x128(parm=[d1, d2]) {
+}
+function x129(parm=[d1, d2]) {
+}
+function x130(parm={ n: [d1, d2] }) {
+}
+function x131(parm=(n) => {
+	var n;
+	return null;
+}) {
+}
+function x132(parm={ func: (n) => {
+	return [d1, d2];
+} }) {
+}
+function x133() {
+	return () => [d1, d2];
+}
+function x134() {
+	return function() {
+		return [d1, d2];
+	};
+}
+function x135() {
+	return function named() {
+		return [d1, d2];
+	};
+}
+function x136() {
+	return () => [d1, d2];
+}
+function x137() {
+	return function() {
+		return [d1, d2];
+	};
+}
+function x138() {
+	return function named() {
+		return [d1, d2];
+	};
+}
+function x139() {
+	return [d1, d2];
+}
+function x140() {
+	return [d1, d2];
+}
+function x141() {
+	return [d1, d2];
+}
+function x142() {
+	return { n: [d1, d2] };
+}
+function x143() {
+	return (n) => {
+		var n;
+		return null;
+	};
+}
+function x144() {
+	return { func: (n) => {
+		return [d1, d2];
+	} };
+}
+function x145() {
+	return () => [d1, d2];
+	return () => [d1, d2];
+}
+function x146() {
+	return function() {
+		return [d1, d2];
+	};
+	return function() {
+		return [d1, d2];
+	};
+}
+function x147() {
+	return function named() {
+		return [d1, d2];
+	};
+	return function named() {
+		return [d1, d2];
+	};
+}
+function x148() {
+	return () => [d1, d2];
+	return () => [d1, d2];
+}
+function x149() {
+	return function() {
+		return [d1, d2];
+	};
+	return function() {
+		return [d1, d2];
+	};
+}
+function x150() {
+	return function named() {
+		return [d1, d2];
+	};
+	return function named() {
+		return [d1, d2];
+	};
+}
+function x151() {
+	return [d1, d2];
+	return [d1, d2];
+}
+function x152() {
+	return [d1, d2];
+	return [d1, d2];
+}
+function x153() {
+	return [d1, d2];
+	return [d1, d2];
+}
+function x154() {
+	return { n: [d1, d2] };
+	return { n: [d1, d2] };
+}
+function x155() {
+	return (n) => {
+		var n;
+		return null;
+	};
+	return (n) => {
+		var n;
+		return null;
+	};
+}
+function x156() {
+	return { func: (n) => {
+		return [d1, d2];
+	} };
+	return { func: (n) => {
+		return [d1, d2];
+	} };
+}
+var x157 = () => {
+	return () => [d1, d2];
+};
+var x158 = () => {
+	return function() {
+		return [d1, d2];
+	};
+};
+var x159 = () => {
+	return function named() {
+		return [d1, d2];
+	};
+};
+var x160 = () => {
+	return () => [d1, d2];
+};
+var x161 = () => {
+	return function() {
+		return [d1, d2];
+	};
+};
+var x162 = () => {
+	return function named() {
+		return [d1, d2];
+	};
+};
+var x163 = () => {
+	return [d1, d2];
+};
+var x164 = () => {
+	return [d1, d2];
+};
+var x165 = () => {
+	return [d1, d2];
+};
+var x166 = () => {
+	return { n: [d1, d2] };
+};
+var x167 = () => {
+	return (n) => {
+		var n;
+		return null;
+	};
+};
+var x168 = () => {
+	return { func: (n) => {
+		return [d1, d2];
+	} };
+};
+var x169 = function() {
+	return () => [d1, d2];
+};
+var x170 = function() {
+	return function() {
+		return [d1, d2];
+	};
+};
+var x171 = function() {
+	return function named() {
+		return [d1, d2];
+	};
+};
+var x172 = function() {
+	return () => [d1, d2];
+};
+var x173 = function() {
+	return function() {
+		return [d1, d2];
+	};
+};
+var x174 = function() {
+	return function named() {
+		return [d1, d2];
+	};
+};
+var x175 = function() {
+	return [d1, d2];
+};
+var x176 = function() {
+	return [d1, d2];
+};
+var x177 = function() {
+	return [d1, d2];
+};
+var x178 = function() {
+	return { n: [d1, d2] };
+};
+var x179 = function() {
+	return (n) => {
+		var n;
+		return null;
+	};
+};
+var x180 = function() {
+	return { func: (n) => {
+		return [d1, d2];
+	} };
+};
+var x181;((x181) => {var t = () => [d1, d2];})(x181 || (x181 = {}));
+var x182;((x182) => {var t = function() {
+	return [d1, d2];
+};})(x182 || (x182 = {}));
+var x183;((x183) => {var t = function named() {
+	return [d1, d2];
+};})(x183 || (x183 = {}));
+var x184;((x184) => {var t = () => [d1, d2];})(x184 || (x184 = {}));
+var x185;((x185) => {var t = function() {
+	return [d1, d2];
+};})(x185 || (x185 = {}));
+var x186;((x186) => {var t = function named() {
+	return [d1, d2];
+};})(x186 || (x186 = {}));
+var x187;((x187) => {var t = [d1, d2];})(x187 || (x187 = {}));
+var x188;((x188) => {var t = [d1, d2];})(x188 || (x188 = {}));
+var x189;((x189) => {var t = [d1, d2];})(x189 || (x189 = {}));
+var x190;((x190) => {var t = { n: [d1, d2] };})(x190 || (x190 = {}));
+var x191;((x191) => {var t = (n) => {
+	var n;
+	return null;
+};})(x191 || (x191 = {}));
+var x192;((x192) => {var t = { func: (n) => {
+	return [d1, d2];
+} };})(x192 || (x192 = {}));
+var x193;((x193) => {x193.t=() => [d1, d2];})(x193 || (x193 = {}));
+var x194;((x194) => {x194.t=function() {
+	return [d1, d2];
+};})(x194 || (x194 = {}));
+var x195;((x195) => {x195.t=function named() {
+	return [d1, d2];
+};})(x195 || (x195 = {}));
+var x196;((x196) => {x196.t=() => [d1, d2];})(x196 || (x196 = {}));
+var x197;((x197) => {x197.t=function() {
+	return [d1, d2];
+};})(x197 || (x197 = {}));
+var x198;((x198) => {x198.t=function named() {
+	return [d1, d2];
+};})(x198 || (x198 = {}));
+var x199;((x199) => {x199.t=[d1, d2];})(x199 || (x199 = {}));
+var x200;((x200) => {x200.t=[d1, d2];})(x200 || (x200 = {}));
+var x201;((x201) => {x201.t=[d1, d2];})(x201 || (x201 = {}));
+var x202;((x202) => {x202.t={ n: [d1, d2] };})(x202 || (x202 = {}));
+var x203;((x203) => {x203.t=(n) => {
+	var n;
+	return null;
+};})(x203 || (x203 = {}));
+var x204;((x204) => {x204.t={ func: (n) => {
+	return [d1, d2];
+} };})(x204 || (x204 = {}));
+var x206 = function() {
+	return [d1, d2];
+};
+var x207 = function named() {
+	return [d1, d2];
+};
+var x209 = function() {
+	return [d1, d2];
+};
+var x210 = function named() {
+	return [d1, d2];
+};
+var x211 = [d1, d2];
+var x212 = [d1, d2];
+var x213 = [d1, d2];
+var x214 = { n: [d1, d2] };
+var x216 = { func: (n) => {
+	return [d1, d2];
+} };
+var x217 = undefined || function() {
+	return [d1, d2];
+};
+var x218 = undefined || function named() {
+	return [d1, d2];
+};
+var x219 = undefined || function() {
+	return [d1, d2];
+};
+var x220 = undefined || function named() {
+	return [d1, d2];
+};
+var x221 = undefined || [d1, d2];
+var x222 = undefined || [d1, d2];
+var x223 = undefined || [d1, d2];
+var x224 = undefined || { n: [d1, d2] };
+var x225;
+x225 = () => [d1, d2];
+var x226;
+x226 = function() {
+	return [d1, d2];
+};
+var x227;
+x227 = function named() {
+	return [d1, d2];
+};
+var x228;
+x228 = () => [d1, d2];
+var x229;
+x229 = function() {
+	return [d1, d2];
+};
+var x230;
+x230 = function named() {
+	return [d1, d2];
+};
+var x231;
+x231 = [d1, d2];
+var x232;
+x232 = [d1, d2];
+var x233;
+x233 = [d1, d2];
+var x234;
+x234 = { n: [d1, d2] };
+var x235;
+x235 = (n) => {
+	var n;
+	return null;
+};
+var x236;
+x236 = { func: (n) => {
+	return [d1, d2];
+} };
+var x237 = { n: () => [d1, d2] };
+var x238 = { n: function() {
+	return [d1, d2];
+} };
+var x239 = { n: function named() {
+	return [d1, d2];
+} };
+var x240 = { n: () => [d1, d2] };
+var x241 = { n: function() {
+	return [d1, d2];
+} };
+var x242 = { n: function named() {
+	return [d1, d2];
+} };
+var x243 = { n: [d1, d2] };
+var x244 = { n: [d1, d2] };
+var x245 = { n: [d1, d2] };
+var x246 = { n: { n: [d1, d2] } };
+var x247 = { n: (n) => {
+	var n;
+	return null;
+} };
+var x248 = { n: { func: (n) => {
+	return [d1, d2];
+} } };
+var x252 = [() => [d1, d2]];
+var x253 = [function() {
+	return [d1, d2];
+}];
+var x254 = [function named() {
+	return [d1, d2];
+}];
+var x255 = [[d1, d2]];
+var x256 = [[d1, d2]];
+var x257 = [[d1, d2]];
+var x258 = [{ n: [d1, d2] }];
+var x260 = [{ func: (n) => {
+	return [d1, d2];
+} }];
+var x261 = function() {
+	return [d1, d2];
+} || undefined;
+var x262 = function named() {
+	return [d1, d2];
+} || undefined;
+var x263 = function() {
+	return [d1, d2];
+} || undefined;
+var x264 = function named() {
+	return [d1, d2];
+} || undefined;
+var x265 = [d1, d2] || undefined;
+var x266 = [d1, d2] || undefined;
+var x267 = [d1, d2] || undefined;
+var x268 = { n: [d1, d2] } || undefined;
+var x269 = undefined || function() {
+	return [d1, d2];
+};
+var x270 = undefined || function named() {
+	return [d1, d2];
+};
+var x271 = undefined || function() {
+	return [d1, d2];
+};
+var x272 = undefined || function named() {
+	return [d1, d2];
+};
+var x273 = undefined || [d1, d2];
+var x274 = undefined || [d1, d2];
+var x275 = undefined || [d1, d2];
+var x276 = undefined || { n: [d1, d2] };
+var x277 = function() {
+	return [d1, d2];
+} || function() {
+	return [d1, d2];
+};
+var x278 = function named() {
+	return [d1, d2];
+} || function named() {
+	return [d1, d2];
+};
+var x279 = function() {
+	return [d1, d2];
+} || function() {
+	return [d1, d2];
+};
+var x280 = function named() {
+	return [d1, d2];
+} || function named() {
+	return [d1, d2];
+};
+var x281 = [d1, d2] || [d1, d2];
+var x282 = [d1, d2] || [d1, d2];
+var x283 = [d1, d2] || [d1, d2];
+var x284 = { n: [d1, d2] } || { n: [d1, d2] };
+var x285 = true ? () => [d1, d2] : () => [d1, d2];
+var x286 = true ? function() {
+	return [d1, d2];
+} : function() {
+	return [d1, d2];
+};
+var x287 = true ? function named() {
+	return [d1, d2];
+} : function named() {
+	return [d1, d2];
+};
+var x288 = true ? () => [d1, d2] : () => [d1, d2];
+var x289 = true ? function() {
+	return [d1, d2];
+} : function() {
+	return [d1, d2];
+};
+var x290 = true ? function named() {
+	return [d1, d2];
+} : function named() {
+	return [d1, d2];
+};
+var x291 = true ? [d1, d2] : [d1, d2];
+var x292 = true ? [d1, d2] : [d1, d2];
+var x293 = true ? [d1, d2] : [d1, d2];
+var x294 = true ? { n: [d1, d2] } : { n: [d1, d2] };
+var x295 = true ? (n) => {
+	var n;
+	return null;
+} : (n) => {
+	var n;
+	return null;
+};
+var x296 = true ? { func: (n) => {
+	return [d1, d2];
+} } : { func: (n) => {
+	return [d1, d2];
+} };
+var x297 = true ? undefined : () => [d1, d2];
+var x298 = true ? undefined : function() {
+	return [d1, d2];
+};
+var x299 = true ? undefined : function named() {
+	return [d1, d2];
+};
+var x300 = true ? undefined : () => [d1, d2];
+var x301 = true ? undefined : function() {
+	return [d1, d2];
+};
+var x302 = true ? undefined : function named() {
+	return [d1, d2];
+};
+var x303 = true ? undefined : [d1, d2];
+var x304 = true ? undefined : [d1, d2];
+var x305 = true ? undefined : [d1, d2];
+var x306 = true ? undefined : { n: [d1, d2] };
+var x307 = true ? undefined : (n) => {
+	var n;
+	return null;
+};
+var x308 = true ? undefined : { func: (n) => {
+	return [d1, d2];
+} };
+var x309 = true ? () => [d1, d2] : undefined;
+var x310 = true ? function() {
+	return [d1, d2];
+} : undefined;
+var x311 = true ? function named() {
+	return [d1, d2];
+} : undefined;
+var x312 = true ? () => [d1, d2] : undefined;
+var x313 = true ? function() {
+	return [d1, d2];
+} : undefined;
+var x314 = true ? function named() {
+	return [d1, d2];
+} : undefined;
+var x315 = true ? [d1, d2] : undefined;
+var x316 = true ? [d1, d2] : undefined;
+var x317 = true ? [d1, d2] : undefined;
+var x318 = true ? { n: [d1, d2] } : undefined;
+var x319 = true ? (n) => {
+	var n;
+	return null;
+} : undefined;
+var x320 = true ? { func: (n) => {
+	return [d1, d2];
+} } : undefined;
+function x321(n) {
+}
+;
+x321(() => [d1, d2]);
+function x322(n) {
+}
+;
+x322(function() {
+	return [d1, d2];
+});
+function x323(n) {
+}
+;
+x323(function named() {
+	return [d1, d2];
+});
+function x324(n) {
+}
+;
+x324(() => [d1, d2]);
+function x325(n) {
+}
+;
+x325(function() {
+	return [d1, d2];
+});
+function x326(n) {
+}
+;
+x326(function named() {
+	return [d1, d2];
+});
+function x327(n) {
+}
+;
+x327([d1, d2]);
+function x328(n) {
+}
+;
+x328([d1, d2]);
+function x329(n) {
+}
+;
+x329([d1, d2]);
+function x330(n) {
+}
+;
+x330({ n: [d1, d2] });
+function x331(n) {
+}
+;
+x331((n) => {
+	var n;
+	return null;
+});
+function x332(n) {
+}
+;
+x332({ func: (n) => {
+	return [d1, d2];
+} });
+var x333 = (n) => n;
+x333(() => [d1, d2]);
+var x334 = (n) => n;
+x334(function() {
+	return [d1, d2];
+});
+var x335 = (n) => n;
+x335(function named() {
+	return [d1, d2];
+});
+var x336 = (n) => n;
+x336(() => [d1, d2]);
+var x337 = (n) => n;
+x337(function() {
+	return [d1, d2];
+});
+var x338 = (n) => n;
+x338(function named() {
+	return [d1, d2];
+});
+var x339 = (n) => n;
+x339([d1, d2]);
+var x340 = (n) => n;
+x340([d1, d2]);
+var x341 = (n) => n;
+x341([d1, d2]);
+var x342 = (n) => n;
+x342({ n: [d1, d2] });
+var x343 = (n) => n;
+x343((n) => {
+	var n;
+	return null;
+});
+var x344 = (n) => n;
+x344({ func: (n) => {
+	return [d1, d2];
+} });
+var x345 = function(n) {
+};
+x345(() => [d1, d2]);
+var x346 = function(n) {
+};
+x346(function() {
+	return [d1, d2];
+});
+var x347 = function(n) {
+};
+x347(function named() {
+	return [d1, d2];
+});
+var x348 = function(n) {
+};
+x348(() => [d1, d2]);
+var x349 = function(n) {
+};
+x349(function() {
+	return [d1, d2];
+});
+var x350 = function(n) {
+};
+x350(function named() {
+	return [d1, d2];
+});
+var x351 = function(n) {
+};
+x351([d1, d2]);
+var x352 = function(n) {
+};
+x352([d1, d2]);
+var x353 = function(n) {
+};
+x353([d1, d2]);
+var x354 = function(n) {
+};
+x354({ n: [d1, d2] });
+var x355 = function(n) {
+};
+x355((n) => {
+	var n;
+	return null;
+});
+var x356 = function(n) {
+};
+x356({ func: (n) => {
+	return [d1, d2];
+} });
+"
+`;
+
 exports[`TSC: expressions getSetAccessorContextualTyping 1`] = `
 "// @target: es5, es2015
 // In the body of a get accessor with no return type annotation,
@@ -8257,6 +9507,97 @@ foo((y) => {
 		return 0;
 	};
 });
+"
+`;
+
+exports[`TSC: expressions contextuallyTypedIife 1`] = `
+"// arrow
+((jake) => {
+})("build");
+// function expression
+(function(cats) {
+})("lol");
+// Lots of Irritating Superfluous Parentheses
+(function(x) {
+}("!"));
+((((function(y) {
+}))))("-");
+// multiple arguments
+((a, b, c) => {
+})("foo", 101, false);
+// default parameters
+((m = 10) => m + 1)(12);
+((n = 10) => n + 1)();
+// optional parameters
+((j) => j + 1)(12);
+((k) => k + 1)();
+((l, o) => l + o)(12);
+// o should be any
+// rest parameters
+((...numbers) => numbers.every((n) => n > 0))(5, 6, 7);
+((...mixed) => mixed.every((n) => !!n))(5, "oops", "oh no");
+((...noNumbers) => noNumbers.some((n) => n > 0))();
+((first, ...rest) => first ? [] : rest.map((n) => n > 0))(8, 9, 10);
+// destructuring parameters (with defaults too!)
+(({ q:q }) => q)({ q: 13 });
+(({ p:p=14 }) => p)({ p: 15 });
+(({ r:r=17 }={ r: 18 }) => r)({ r: 19 });
+(({ u:u=22 }={ u: 23 }) => u)();
+// contextually typed parameters.
+let twelve = ((f) => f(12))((i) => i);
+let eleven = ((o) => o.a(11))({ a: function(n) {
+	return n;
+} });
+// missing arguments
+(function(x,undefined) {
+	return x;
+})(42);
+((x, y, z) => 42)();
+"
+`;
+
+exports[`TSC: expressions contextuallyTypedIifeStrict 1`] = `
+"// arrow
+((jake) => {
+})("build");
+// function expression
+(function(cats) {
+})("lol");
+// Lots of Irritating Superfluous Parentheses
+(function(x) {
+}("!"));
+((((function(y) {
+}))))("-");
+// multiple arguments
+((a, b, c) => {
+})("foo", 101, false);
+// default parameters
+((m = 10) => m + 1)(12);
+((n = 10) => n + 1)();
+// optional parameters
+((j) => j + 1)(12);
+((k) => k + 1)();
+((l, o) => l + o)(12);
+// rest parameters
+((...numbers) => numbers.every((n) => n > 0))(5, 6, 7);
+((...mixed) => mixed.every((n) => !!n))(5, "oops", "oh no");
+((...noNumbers) => noNumbers.some((n) => n > 0))();
+((first, ...rest) => first ? [] : rest.map((n) => n > 0))(8, 9, 10);
+// destructuring parameters (with defaults too!)
+(({ q:q }) => q)({ q: 13 });
+(({ p:p=14 }) => p)({ p: 15 });
+(({ r:r=17 }={ r: 18 }) => r)({ r: 19 });
+(({ u:u=22 }={ u: 23 }) => u)();
+// contextually typed parameters.
+let twelve = ((f) => f(12))((i) => i);
+let eleven = ((o) => o.a(11))({ a: function(n) {
+	return n;
+} });
+// missing arguments
+(function(x,undefined) {
+	return x;
+})(42);
+((x, y, z) => 42)();
 "
 `;
 
@@ -11562,6 +12903,7 @@ function foo10(x) {
 	return typeof x === "string" ? x : // string
 	// string
 	((b = x) && // x is number | boolean
+	// x is number | boolean
 	typeof x === "number" && x.toString());
 }
 // x is number
@@ -11571,7 +12913,9 @@ function foo11(x) {
 	return typeof x === "string" ? x : // string
 	// string
 	((b = x) && // x is number | boolean
+	// x is number | boolean
 	typeof x === "number" && (x = 10) && // assignment to x
+	// assignment to x
 	x);
 }
 // x is number
@@ -11580,6 +12924,7 @@ function foo12(x) {
 	var b;
 	return typeof x === "string" ? ((x = 10) && x.toString().length) : // number
 	((b = x) && // x is number | boolean
+	// x is number | boolean
 	typeof x === "number" && x);
 }
 // x is number
@@ -12000,16 +13345,18 @@ function foo11(x) {
 		// number | boolean | string - because below we are changing value of x in if statement
 		return typeof x === "number" ? (// change value of x
 		// change value of x
-		// change value of x
 		x = 10 && x.toString()) : // number | boolean | string
+		// change value of x
+		// number | boolean | string
 		(// do not change value
-		// do not change value
 		// do not change value
 		// do not change value
 		// do not change value
 		y = x && x.toString());
 	}
 }
+// number | boolean | string
+// do not change value
 // number | boolean | string
 function foo12(x) {
 	// Mixing typeguard narrowing in if statement with conditional expression typeguard
@@ -12174,6 +13521,7 @@ function foo7(x) {
 	var z;
 	// Mixing typeguard narrowing
 	return typeof x !== "string" && ((z = x) && // number | boolean
+	// number | boolean
 	(typeof x === "number" ? // change value of x
 	((x = 10) && x.toString()) : // x is number
 	// do not change value
@@ -12229,6 +13577,7 @@ function foo7(x) {
 	var z;
 	// Mixing typeguard narrowing
 	return typeof x === "string" || ((z = x) || // number | boolean
+	// number | boolean
 	(typeof x === "number" ? // change value of x
 	((x = 10) && x.toString()) : // number | boolean | string
 	// do not change value
@@ -14540,1346 +15889,5 @@ C = undefined;
 // Error
 (C) = undefined;
 // Error
-"
-`;
-
-exports[`TSC: expressions generatedContextualTyping 1`] = `
-"class Base {
-	p;
-}
-class Derived1 extends Base {
-	m;
-}
-class Derived2 extends Base {
-	n;
-}
-var b = new Base(),d1 = new Derived1(),d2 = new Derived2();
-var x1 = () => [d1, d2];
-var x2 = function() {
-	return [d1, d2];
-};
-var x3 = function named() {
-	return [d1, d2];
-};
-var x4 = () => [d1, d2];
-var x5 = function() {
-	return [d1, d2];
-};
-var x6 = function named() {
-	return [d1, d2];
-};
-var x7 = [d1, d2];
-var x8 = [d1, d2];
-var x9 = [d1, d2];
-var x10 = { n: [d1, d2] };
-var x11 = (n) => {
-	var n;
-	return null;
-};
-var x12 = { func: (n) => {
-	return [d1, d2];
-} };
-class x13 {
-	member = () => [d1, d2];
-}
-class x14 {
-	member = function() {
-		return [d1, d2];
-	};
-}
-class x15 {
-	member = function named() {
-		return [d1, d2];
-	};
-}
-class x16 {
-	member = () => [d1, d2];
-}
-class x17 {
-	member = function() {
-		return [d1, d2];
-	};
-}
-class x18 {
-	member = function named() {
-		return [d1, d2];
-	};
-}
-class x19 {
-	member = [d1, d2];
-}
-class x20 {
-	member = [d1, d2];
-}
-class x21 {
-	member = [d1, d2];
-}
-class x22 {
-	member = { n: [d1, d2] };
-}
-class x23 {
-	member = (n) => {
-		var n;
-		return null;
-	};
-}
-class x24 {
-	member = { func: (n) => {
-		return [d1, d2];
-	} };
-}
-class x25 {
-	member = () => [d1, d2];
-}
-class x26 {
-	member = function() {
-		return [d1, d2];
-	};
-}
-class x27 {
-	member = function named() {
-		return [d1, d2];
-	};
-}
-class x28 {
-	member = () => [d1, d2];
-}
-class x29 {
-	member = function() {
-		return [d1, d2];
-	};
-}
-class x30 {
-	member = function named() {
-		return [d1, d2];
-	};
-}
-class x31 {
-	member = [d1, d2];
-}
-class x32 {
-	member = [d1, d2];
-}
-class x33 {
-	member = [d1, d2];
-}
-class x34 {
-	member = { n: [d1, d2] };
-}
-class x35 {
-	member = (n) => {
-		var n;
-		return null;
-	};
-}
-class x36 {
-	member = { func: (n) => {
-		return [d1, d2];
-	} };
-}
-class x37 {
-	member = () => [d1, d2];
-}
-class x38 {
-	member = function() {
-		return [d1, d2];
-	};
-}
-class x39 {
-	member = function named() {
-		return [d1, d2];
-	};
-}
-class x40 {
-	member = () => [d1, d2];
-}
-class x41 {
-	member = function() {
-		return [d1, d2];
-	};
-}
-class x42 {
-	member = function named() {
-		return [d1, d2];
-	};
-}
-class x43 {
-	member = [d1, d2];
-}
-class x44 {
-	member = [d1, d2];
-}
-class x45 {
-	member = [d1, d2];
-}
-class x46 {
-	member = { n: [d1, d2] };
-}
-class x47 {
-	member = (n) => {
-		var n;
-		return null;
-	};
-}
-class x48 {
-	member = { func: (n) => {
-		return [d1, d2];
-	} };
-}
-class x49 {
-	static member = () => [d1, d2];
-}
-class x50 {
-	static member = function() {
-		return [d1, d2];
-	};
-}
-class x51 {
-	static member = function named() {
-		return [d1, d2];
-	};
-}
-class x52 {
-	static member = () => [d1, d2];
-}
-class x53 {
-	static member = function() {
-		return [d1, d2];
-	};
-}
-class x54 {
-	static member = function named() {
-		return [d1, d2];
-	};
-}
-class x55 {
-	static member = [d1, d2];
-}
-class x56 {
-	static member = [d1, d2];
-}
-class x57 {
-	static member = [d1, d2];
-}
-class x58 {
-	static member = { n: [d1, d2] };
-}
-class x59 {
-	static member = (n) => {
-		var n;
-		return null;
-	};
-}
-class x60 {
-	static member = { func: (n) => {
-		return [d1, d2];
-	} };
-}
-class x61 {
-	static member = () => [d1, d2];
-}
-class x62 {
-	static member = function() {
-		return [d1, d2];
-	};
-}
-class x63 {
-	static member = function named() {
-		return [d1, d2];
-	};
-}
-class x64 {
-	static member = () => [d1, d2];
-}
-class x65 {
-	static member = function() {
-		return [d1, d2];
-	};
-}
-class x66 {
-	static member = function named() {
-		return [d1, d2];
-	};
-}
-class x67 {
-	static member = [d1, d2];
-}
-class x68 {
-	static member = [d1, d2];
-}
-class x69 {
-	static member = [d1, d2];
-}
-class x70 {
-	static member = { n: [d1, d2] };
-}
-class x71 {
-	static member = (n) => {
-		var n;
-		return null;
-	};
-}
-class x72 {
-	static member = { func: (n) => {
-		return [d1, d2];
-	} };
-}
-class x73 {
-	static member = () => [d1, d2];
-}
-class x74 {
-	static member = function() {
-		return [d1, d2];
-	};
-}
-class x75 {
-	static member = function named() {
-		return [d1, d2];
-	};
-}
-class x76 {
-	static member = () => [d1, d2];
-}
-class x77 {
-	static member = function() {
-		return [d1, d2];
-	};
-}
-class x78 {
-	static member = function named() {
-		return [d1, d2];
-	};
-}
-class x79 {
-	static member = [d1, d2];
-}
-class x80 {
-	static member = [d1, d2];
-}
-class x81 {
-	static member = [d1, d2];
-}
-class x82 {
-	static member = { n: [d1, d2] };
-}
-class x83 {
-	static member = (n) => {
-		var n;
-		return null;
-	};
-}
-class x84 {
-	static member = { func: (n) => {
-		return [d1, d2];
-	} };
-}
-class x85 {
-	constructor(parm=() => [d1, d2]) {
-	}
-}
-class x86 {
-	constructor(parm=function() {
-		return [d1, d2];
-	}) {
-	}
-}
-class x87 {
-	constructor(parm=function named() {
-		return [d1, d2];
-	}) {
-	}
-}
-class x88 {
-	constructor(parm=() => [d1, d2]) {
-	}
-}
-class x89 {
-	constructor(parm=function() {
-		return [d1, d2];
-	}) {
-	}
-}
-class x90 {
-	constructor(parm=function named() {
-		return [d1, d2];
-	}) {
-	}
-}
-class x91 {
-	constructor(parm=[d1, d2]) {
-	}
-}
-class x92 {
-	constructor(parm=[d1, d2]) {
-	}
-}
-class x93 {
-	constructor(parm=[d1, d2]) {
-	}
-}
-class x94 {
-	constructor(parm={ n: [d1, d2] }) {
-	}
-}
-class x95 {
-	constructor(parm=(n) => {
-		var n;
-		return null;
-	}) {
-	}
-}
-class x96 {
-	constructor(parm={ func: (n) => {
-		return [d1, d2];
-	} }) {
-	}
-}
-class x97 {
-	constructor(parm=() => [d1, d2]) {
-		this.parm = parm;
-	}
-}
-class x98 {
-	constructor(parm=function() {
-		return [d1, d2];
-	}) {
-		this.parm = parm;
-	}
-}
-class x99 {
-	constructor(parm=function named() {
-		return [d1, d2];
-	}) {
-		this.parm = parm;
-	}
-}
-class x100 {
-	constructor(parm=() => [d1, d2]) {
-		this.parm = parm;
-	}
-}
-class x101 {
-	constructor(parm=function() {
-		return [d1, d2];
-	}) {
-		this.parm = parm;
-	}
-}
-class x102 {
-	constructor(parm=function named() {
-		return [d1, d2];
-	}) {
-		this.parm = parm;
-	}
-}
-class x103 {
-	constructor(parm=[d1, d2]) {
-		this.parm = parm;
-	}
-}
-class x104 {
-	constructor(parm=[d1, d2]) {
-		this.parm = parm;
-	}
-}
-class x105 {
-	constructor(parm=[d1, d2]) {
-		this.parm = parm;
-	}
-}
-class x106 {
-	constructor(parm={ n: [d1, d2] }) {
-		this.parm = parm;
-	}
-}
-class x107 {
-	constructor(parm=(n) => {
-		var n;
-		return null;
-	}) {
-		this.parm = parm;
-	}
-}
-class x108 {
-	constructor(parm={ func: (n) => {
-		return [d1, d2];
-	} }) {
-		this.parm = parm;
-	}
-}
-class x109 {
-	constructor(parm=() => [d1, d2]) {
-		this.parm = parm;
-	}
-}
-class x110 {
-	constructor(parm=function() {
-		return [d1, d2];
-	}) {
-		this.parm = parm;
-	}
-}
-class x111 {
-	constructor(parm=function named() {
-		return [d1, d2];
-	}) {
-		this.parm = parm;
-	}
-}
-class x112 {
-	constructor(parm=() => [d1, d2]) {
-		this.parm = parm;
-	}
-}
-class x113 {
-	constructor(parm=function() {
-		return [d1, d2];
-	}) {
-		this.parm = parm;
-	}
-}
-class x114 {
-	constructor(parm=function named() {
-		return [d1, d2];
-	}) {
-		this.parm = parm;
-	}
-}
-class x115 {
-	constructor(parm=[d1, d2]) {
-		this.parm = parm;
-	}
-}
-class x116 {
-	constructor(parm=[d1, d2]) {
-		this.parm = parm;
-	}
-}
-class x117 {
-	constructor(parm=[d1, d2]) {
-		this.parm = parm;
-	}
-}
-class x118 {
-	constructor(parm={ n: [d1, d2] }) {
-		this.parm = parm;
-	}
-}
-class x119 {
-	constructor(parm=(n) => {
-		var n;
-		return null;
-	}) {
-		this.parm = parm;
-	}
-}
-class x120 {
-	constructor(parm={ func: (n) => {
-		return [d1, d2];
-	} }) {
-		this.parm = parm;
-	}
-}
-function x121(parm=() => [d1, d2]) {
-}
-function x122(parm=function() {
-	return [d1, d2];
-}) {
-}
-function x123(parm=function named() {
-	return [d1, d2];
-}) {
-}
-function x124(parm=() => [d1, d2]) {
-}
-function x125(parm=function() {
-	return [d1, d2];
-}) {
-}
-function x126(parm=function named() {
-	return [d1, d2];
-}) {
-}
-function x127(parm=[d1, d2]) {
-}
-function x128(parm=[d1, d2]) {
-}
-function x129(parm=[d1, d2]) {
-}
-function x130(parm={ n: [d1, d2] }) {
-}
-function x131(parm=(n) => {
-	var n;
-	return null;
-}) {
-}
-function x132(parm={ func: (n) => {
-	return [d1, d2];
-} }) {
-}
-function x133() {
-	return () => [d1, d2];
-}
-function x134() {
-	return function() {
-		return [d1, d2];
-	};
-}
-function x135() {
-	return function named() {
-		return [d1, d2];
-	};
-}
-function x136() {
-	return () => [d1, d2];
-}
-function x137() {
-	return function() {
-		return [d1, d2];
-	};
-}
-function x138() {
-	return function named() {
-		return [d1, d2];
-	};
-}
-function x139() {
-	return [d1, d2];
-}
-function x140() {
-	return [d1, d2];
-}
-function x141() {
-	return [d1, d2];
-}
-function x142() {
-	return { n: [d1, d2] };
-}
-function x143() {
-	return (n) => {
-		var n;
-		return null;
-	};
-}
-function x144() {
-	return { func: (n) => {
-		return [d1, d2];
-	} };
-}
-function x145() {
-	return () => [d1, d2];
-	return () => [d1, d2];
-}
-function x146() {
-	return function() {
-		return [d1, d2];
-	};
-	return function() {
-		return [d1, d2];
-	};
-}
-function x147() {
-	return function named() {
-		return [d1, d2];
-	};
-	return function named() {
-		return [d1, d2];
-	};
-}
-function x148() {
-	return () => [d1, d2];
-	return () => [d1, d2];
-}
-function x149() {
-	return function() {
-		return [d1, d2];
-	};
-	return function() {
-		return [d1, d2];
-	};
-}
-function x150() {
-	return function named() {
-		return [d1, d2];
-	};
-	return function named() {
-		return [d1, d2];
-	};
-}
-function x151() {
-	return [d1, d2];
-	return [d1, d2];
-}
-function x152() {
-	return [d1, d2];
-	return [d1, d2];
-}
-function x153() {
-	return [d1, d2];
-	return [d1, d2];
-}
-function x154() {
-	return { n: [d1, d2] };
-	return { n: [d1, d2] };
-}
-function x155() {
-	return (n) => {
-		var n;
-		return null;
-	};
-	return (n) => {
-		var n;
-		return null;
-	};
-}
-function x156() {
-	return { func: (n) => {
-		return [d1, d2];
-	} };
-	return { func: (n) => {
-		return [d1, d2];
-	} };
-}
-var x157 = () => {
-	return () => [d1, d2];
-};
-var x158 = () => {
-	return function() {
-		return [d1, d2];
-	};
-};
-var x159 = () => {
-	return function named() {
-		return [d1, d2];
-	};
-};
-var x160 = () => {
-	return () => [d1, d2];
-};
-var x161 = () => {
-	return function() {
-		return [d1, d2];
-	};
-};
-var x162 = () => {
-	return function named() {
-		return [d1, d2];
-	};
-};
-var x163 = () => {
-	return [d1, d2];
-};
-var x164 = () => {
-	return [d1, d2];
-};
-var x165 = () => {
-	return [d1, d2];
-};
-var x166 = () => {
-	return { n: [d1, d2] };
-};
-var x167 = () => {
-	return (n) => {
-		var n;
-		return null;
-	};
-};
-var x168 = () => {
-	return { func: (n) => {
-		return [d1, d2];
-	} };
-};
-var x169 = function() {
-	return () => [d1, d2];
-};
-var x170 = function() {
-	return function() {
-		return [d1, d2];
-	};
-};
-var x171 = function() {
-	return function named() {
-		return [d1, d2];
-	};
-};
-var x172 = function() {
-	return () => [d1, d2];
-};
-var x173 = function() {
-	return function() {
-		return [d1, d2];
-	};
-};
-var x174 = function() {
-	return function named() {
-		return [d1, d2];
-	};
-};
-var x175 = function() {
-	return [d1, d2];
-};
-var x176 = function() {
-	return [d1, d2];
-};
-var x177 = function() {
-	return [d1, d2];
-};
-var x178 = function() {
-	return { n: [d1, d2] };
-};
-var x179 = function() {
-	return (n) => {
-		var n;
-		return null;
-	};
-};
-var x180 = function() {
-	return { func: (n) => {
-		return [d1, d2];
-	} };
-};
-var x181;((x181) => {var t = () => [d1, d2];})(x181 || (x181 = {}));
-var x182;((x182) => {var t = function() {
-	return [d1, d2];
-};})(x182 || (x182 = {}));
-var x183;((x183) => {var t = function named() {
-	return [d1, d2];
-};})(x183 || (x183 = {}));
-var x184;((x184) => {var t = () => [d1, d2];})(x184 || (x184 = {}));
-var x185;((x185) => {var t = function() {
-	return [d1, d2];
-};})(x185 || (x185 = {}));
-var x186;((x186) => {var t = function named() {
-	return [d1, d2];
-};})(x186 || (x186 = {}));
-var x187;((x187) => {var t = [d1, d2];})(x187 || (x187 = {}));
-var x188;((x188) => {var t = [d1, d2];})(x188 || (x188 = {}));
-var x189;((x189) => {var t = [d1, d2];})(x189 || (x189 = {}));
-var x190;((x190) => {var t = { n: [d1, d2] };})(x190 || (x190 = {}));
-var x191;((x191) => {var t = (n) => {
-	var n;
-	return null;
-};})(x191 || (x191 = {}));
-var x192;((x192) => {var t = { func: (n) => {
-	return [d1, d2];
-} };})(x192 || (x192 = {}));
-var x193;((x193) => {x193.t=() => [d1, d2];})(x193 || (x193 = {}));
-var x194;((x194) => {x194.t=function() {
-	return [d1, d2];
-};})(x194 || (x194 = {}));
-var x195;((x195) => {x195.t=function named() {
-	return [d1, d2];
-};})(x195 || (x195 = {}));
-var x196;((x196) => {x196.t=() => [d1, d2];})(x196 || (x196 = {}));
-var x197;((x197) => {x197.t=function() {
-	return [d1, d2];
-};})(x197 || (x197 = {}));
-var x198;((x198) => {x198.t=function named() {
-	return [d1, d2];
-};})(x198 || (x198 = {}));
-var x199;((x199) => {x199.t=[d1, d2];})(x199 || (x199 = {}));
-var x200;((x200) => {x200.t=[d1, d2];})(x200 || (x200 = {}));
-var x201;((x201) => {x201.t=[d1, d2];})(x201 || (x201 = {}));
-var x202;((x202) => {x202.t={ n: [d1, d2] };})(x202 || (x202 = {}));
-var x203;((x203) => {x203.t=(n) => {
-	var n;
-	return null;
-};})(x203 || (x203 = {}));
-var x204;((x204) => {x204.t={ func: (n) => {
-	return [d1, d2];
-} };})(x204 || (x204 = {}));
-var x206 = function() {
-	return [d1, d2];
-};
-var x207 = function named() {
-	return [d1, d2];
-};
-var x209 = function() {
-	return [d1, d2];
-};
-var x210 = function named() {
-	return [d1, d2];
-};
-var x211 = [d1, d2];
-var x212 = [d1, d2];
-var x213 = [d1, d2];
-var x214 = { n: [d1, d2] };
-var x216 = { func: (n) => {
-	return [d1, d2];
-} };
-var x217 = undefined || function() {
-	return [d1, d2];
-};
-var x218 = undefined || function named() {
-	return [d1, d2];
-};
-var x219 = undefined || function() {
-	return [d1, d2];
-};
-var x220 = undefined || function named() {
-	return [d1, d2];
-};
-var x221 = undefined || [d1, d2];
-var x222 = undefined || [d1, d2];
-var x223 = undefined || [d1, d2];
-var x224 = undefined || { n: [d1, d2] };
-var x225;
-x225 = () => [d1, d2];
-var x226;
-x226 = function() {
-	return [d1, d2];
-};
-var x227;
-x227 = function named() {
-	return [d1, d2];
-};
-var x228;
-x228 = () => [d1, d2];
-var x229;
-x229 = function() {
-	return [d1, d2];
-};
-var x230;
-x230 = function named() {
-	return [d1, d2];
-};
-var x231;
-x231 = [d1, d2];
-var x232;
-x232 = [d1, d2];
-var x233;
-x233 = [d1, d2];
-var x234;
-x234 = { n: [d1, d2] };
-var x235;
-x235 = (n) => {
-	var n;
-	return null;
-};
-var x236;
-x236 = { func: (n) => {
-	return [d1, d2];
-} };
-var x237 = { n: () => [d1, d2] };
-var x238 = { n: function() {
-	return [d1, d2];
-} };
-var x239 = { n: function named() {
-	return [d1, d2];
-} };
-var x240 = { n: () => [d1, d2] };
-var x241 = { n: function() {
-	return [d1, d2];
-} };
-var x242 = { n: function named() {
-	return [d1, d2];
-} };
-var x243 = { n: [d1, d2] };
-var x244 = { n: [d1, d2] };
-var x245 = { n: [d1, d2] };
-var x246 = { n: { n: [d1, d2] } };
-var x247 = { n: (n) => {
-	var n;
-	return null;
-} };
-var x248 = { n: { func: (n) => {
-	return [d1, d2];
-} } };
-var x252 = [() => [d1, d2]];
-var x253 = [function() {
-	return [d1, d2];
-}];
-var x254 = [function named() {
-	return [d1, d2];
-}];
-var x255 = [[d1, d2]];
-var x256 = [[d1, d2]];
-var x257 = [[d1, d2]];
-var x258 = [{ n: [d1, d2] }];
-var x260 = [{ func: (n) => {
-	return [d1, d2];
-} }];
-var x261 = function() {
-	return [d1, d2];
-} || undefined;
-var x262 = function named() {
-	return [d1, d2];
-} || undefined;
-var x263 = function() {
-	return [d1, d2];
-} || undefined;
-var x264 = function named() {
-	return [d1, d2];
-} || undefined;
-var x265 = [d1, d2] || undefined;
-var x266 = [d1, d2] || undefined;
-var x267 = [d1, d2] || undefined;
-var x268 = { n: [d1, d2] } || undefined;
-var x269 = undefined || function() {
-	return [d1, d2];
-};
-var x270 = undefined || function named() {
-	return [d1, d2];
-};
-var x271 = undefined || function() {
-	return [d1, d2];
-};
-var x272 = undefined || function named() {
-	return [d1, d2];
-};
-var x273 = undefined || [d1, d2];
-var x274 = undefined || [d1, d2];
-var x275 = undefined || [d1, d2];
-var x276 = undefined || { n: [d1, d2] };
-var x277 = function() {
-	return [d1, d2];
-} || function() {
-	return [d1, d2];
-};
-var x278 = function named() {
-	return [d1, d2];
-} || function named() {
-	return [d1, d2];
-};
-var x279 = function() {
-	return [d1, d2];
-} || function() {
-	return [d1, d2];
-};
-var x280 = function named() {
-	return [d1, d2];
-} || function named() {
-	return [d1, d2];
-};
-var x281 = [d1, d2] || [d1, d2];
-var x282 = [d1, d2] || [d1, d2];
-var x283 = [d1, d2] || [d1, d2];
-var x284 = { n: [d1, d2] } || { n: [d1, d2] };
-var x285 = true ? () => [d1, d2] : () => [d1, d2];
-var x286 = true ? function() {
-	return [d1, d2];
-} : function() {
-	return [d1, d2];
-};
-var x287 = true ? function named() {
-	return [d1, d2];
-} : function named() {
-	return [d1, d2];
-};
-var x288 = true ? () => [d1, d2] : () => [d1, d2];
-var x289 = true ? function() {
-	return [d1, d2];
-} : function() {
-	return [d1, d2];
-};
-var x290 = true ? function named() {
-	return [d1, d2];
-} : function named() {
-	return [d1, d2];
-};
-var x291 = true ? [d1, d2] : [d1, d2];
-var x292 = true ? [d1, d2] : [d1, d2];
-var x293 = true ? [d1, d2] : [d1, d2];
-var x294 = true ? { n: [d1, d2] } : { n: [d1, d2] };
-var x295 = true ? (n) => {
-	var n;
-	return null;
-} : (n) => {
-	var n;
-	return null;
-};
-var x296 = true ? { func: (n) => {
-	return [d1, d2];
-} } : { func: (n) => {
-	return [d1, d2];
-} };
-var x297 = true ? undefined : () => [d1, d2];
-var x298 = true ? undefined : function() {
-	return [d1, d2];
-};
-var x299 = true ? undefined : function named() {
-	return [d1, d2];
-};
-var x300 = true ? undefined : () => [d1, d2];
-var x301 = true ? undefined : function() {
-	return [d1, d2];
-};
-var x302 = true ? undefined : function named() {
-	return [d1, d2];
-};
-var x303 = true ? undefined : [d1, d2];
-var x304 = true ? undefined : [d1, d2];
-var x305 = true ? undefined : [d1, d2];
-var x306 = true ? undefined : { n: [d1, d2] };
-var x307 = true ? undefined : (n) => {
-	var n;
-	return null;
-};
-var x308 = true ? undefined : { func: (n) => {
-	return [d1, d2];
-} };
-var x309 = true ? () => [d1, d2] : undefined;
-var x310 = true ? function() {
-	return [d1, d2];
-} : undefined;
-var x311 = true ? function named() {
-	return [d1, d2];
-} : undefined;
-var x312 = true ? () => [d1, d2] : undefined;
-var x313 = true ? function() {
-	return [d1, d2];
-} : undefined;
-var x314 = true ? function named() {
-	return [d1, d2];
-} : undefined;
-var x315 = true ? [d1, d2] : undefined;
-var x316 = true ? [d1, d2] : undefined;
-var x317 = true ? [d1, d2] : undefined;
-var x318 = true ? { n: [d1, d2] } : undefined;
-var x319 = true ? (n) => {
-	var n;
-	return null;
-} : undefined;
-var x320 = true ? { func: (n) => {
-	return [d1, d2];
-} } : undefined;
-function x321(n) {
-}
-;
-x321(() => [d1, d2]);
-function x322(n) {
-}
-;
-x322(function() {
-	return [d1, d2];
-});
-function x323(n) {
-}
-;
-x323(function named() {
-	return [d1, d2];
-});
-function x324(n) {
-}
-;
-x324(() => [d1, d2]);
-function x325(n) {
-}
-;
-x325(function() {
-	return [d1, d2];
-});
-function x326(n) {
-}
-;
-x326(function named() {
-	return [d1, d2];
-});
-function x327(n) {
-}
-;
-x327([d1, d2]);
-function x328(n) {
-}
-;
-x328([d1, d2]);
-function x329(n) {
-}
-;
-x329([d1, d2]);
-function x330(n) {
-}
-;
-x330({ n: [d1, d2] });
-function x331(n) {
-}
-;
-x331((n) => {
-	var n;
-	return null;
-});
-function x332(n) {
-}
-;
-x332({ func: (n) => {
-	return [d1, d2];
-} });
-var x333 = (n) => n;
-x333(() => [d1, d2]);
-var x334 = (n) => n;
-x334(function() {
-	return [d1, d2];
-});
-var x335 = (n) => n;
-x335(function named() {
-	return [d1, d2];
-});
-var x336 = (n) => n;
-x336(() => [d1, d2]);
-var x337 = (n) => n;
-x337(function() {
-	return [d1, d2];
-});
-var x338 = (n) => n;
-x338(function named() {
-	return [d1, d2];
-});
-var x339 = (n) => n;
-x339([d1, d2]);
-var x340 = (n) => n;
-x340([d1, d2]);
-var x341 = (n) => n;
-x341([d1, d2]);
-var x342 = (n) => n;
-x342({ n: [d1, d2] });
-var x343 = (n) => n;
-x343((n) => {
-	var n;
-	return null;
-});
-var x344 = (n) => n;
-x344({ func: (n) => {
-	return [d1, d2];
-} });
-var x345 = function(n) {
-};
-x345(() => [d1, d2]);
-var x346 = function(n) {
-};
-x346(function() {
-	return [d1, d2];
-});
-var x347 = function(n) {
-};
-x347(function named() {
-	return [d1, d2];
-});
-var x348 = function(n) {
-};
-x348(() => [d1, d2]);
-var x349 = function(n) {
-};
-x349(function() {
-	return [d1, d2];
-});
-var x350 = function(n) {
-};
-x350(function named() {
-	return [d1, d2];
-});
-var x351 = function(n) {
-};
-x351([d1, d2]);
-var x352 = function(n) {
-};
-x352([d1, d2]);
-var x353 = function(n) {
-};
-x353([d1, d2]);
-var x354 = function(n) {
-};
-x354({ n: [d1, d2] });
-var x355 = function(n) {
-};
-x355((n) => {
-	var n;
-	return null;
-});
-var x356 = function(n) {
-};
-x356({ func: (n) => {
-	return [d1, d2];
-} });
-"
-`;
-
-exports[`TSC: expressions contextuallyTypedIife 1`] = `
-"// arrow
-((jake) => {
-})("build");
-// function expression
-(function(cats) {
-})("lol");
-// Lots of Irritating Superfluous Parentheses
-(function(x) {
-}("!"));
-((((function(y) {
-}))))("-");
-// multiple arguments
-((a, b, c) => {
-})("foo", 101, false);
-// default parameters
-((m = 10) => m + 1)(12);
-((n = 10) => n + 1)();
-// optional parameters
-((j) => j + 1)(12);
-((k) => k + 1)();
-((l, o) => l + o)(12);
-// o should be any
-// rest parameters
-((...numbers) => numbers.every((n) => n > 0))(5, 6, 7);
-((...mixed) => mixed.every((n) => !!n))(5, "oops", "oh no");
-((...noNumbers) => noNumbers.some((n) => n > 0))();
-((first, ...rest) => first ? [] : rest.map((n) => n > 0))(8, 9, 10);
-// destructuring parameters (with defaults too!)
-(({ q:q }) => q)({ q: 13 });
-(({ p:p=14 }) => p)({ p: 15 });
-(({ r:r=17 }={ r: 18 }) => r)({ r: 19 });
-(({ u:u=22 }={ u: 23 }) => u)();
-// contextually typed parameters.
-let twelve = ((f) => f(12))((i) => i);
-let eleven = ((o) => o.a(11))({ a: function(n) {
-	return n;
-} });
-// missing arguments
-(function(x,undefined) {
-	return x;
-})(42);
-((x, y, z) => 42)();
-"
-`;
-
-exports[`TSC: expressions contextuallyTypedIifeStrict 1`] = `
-"// arrow
-((jake) => {
-})("build");
-// function expression
-(function(cats) {
-})("lol");
-// Lots of Irritating Superfluous Parentheses
-(function(x) {
-}("!"));
-((((function(y) {
-}))))("-");
-// multiple arguments
-((a, b, c) => {
-})("foo", 101, false);
-// default parameters
-((m = 10) => m + 1)(12);
-((n = 10) => n + 1)();
-// optional parameters
-((j) => j + 1)(12);
-((k) => k + 1)();
-((l, o) => l + o)(12);
-// rest parameters
-((...numbers) => numbers.every((n) => n > 0))(5, 6, 7);
-((...mixed) => mixed.every((n) => !!n))(5, "oops", "oh no");
-((...noNumbers) => noNumbers.some((n) => n > 0))();
-((first, ...rest) => first ? [] : rest.map((n) => n > 0))(8, 9, 10);
-// destructuring parameters (with defaults too!)
-(({ q:q }) => q)({ q: 13 });
-(({ p:p=14 }) => p)({ p: 15 });
-(({ r:r=17 }={ r: 18 }) => r)({ r: 19 });
-(({ u:u=22 }={ u: 23 }) => u)();
-// contextually typed parameters.
-let twelve = ((f) => f(12))((i) => i);
-let eleven = ((o) => o.a(11))({ a: function(n) {
-	return n;
-} });
-// missing arguments
-(function(x,undefined) {
-	return x;
-})(42);
-((x, y, z) => 42)();
 "
 `;


### PR DESCRIPTION
## 배경

`@shopify/react-native-skia` 의 `src/skia/core/Vector.ts` 같은 단순한 TS 파일이
ZNTC 에서 parse error 로 fail. fixture 빌드 중 발견 (#3142 follow-up):

```ts
export const vec = (x = 0, y?: number) => {
  "worklet";
  return Skia.Point(x, y ?? x);
};
```

```
× Expression expected
1 │ export const vec = (x = 0, y?: number) => {
  ·                              ^
```

## Root cause

`src/parser/parser.zig` 의 `isTypedArrowFunction` detection loop 가 첫 param 다음
토큰으로 **`:`, `?`, `)`, `,`** 만 처리. **`=` (default value)** 케이스 누락.

```
(x = 0, y?: number) => 의 흐름:
1. `x` (identifier) → advance ✓
2. `=` ≠ `:` → false
3. `=` ≠ `)` → false
4. `=` ≠ `?` → false
5. `=` ≠ `,` → false
6. return false → typed arrow 아님 판정 → paren expression path 로 fallback
7. 그 path 가 type annotation 처리 못 함 → fail
```

## 변경

`=` 만나면 default expression 을 paren/bracket/brace balanced skip 으로 통과한
뒤 다음 토큰 (`,` / `)`) 기준으로 typed arrow 판정 계속. `skipDefaultValueToCommaOrRParen`
helper 로 첫 param 경로 + comma loop 안 후속 param 경로 모두 통합.

## Babel 비교

| 입력 | Babel TS | ZNTC (fix 후) |
|---|---|---|
| `(x = 0, y?: number) =>` | OK | OK |
| `(x = 0, y: number) =>` | OK | OK |
| `(x = Math.max(1, 2), y?: T) =>` | OK | OK |
| `(x = { a: 1 }, y: T) =>` | OK | OK |
| `(x: number = 0, y?: number) =>` (이전에도 OK) | OK | OK |

Babel 의 cover-grammar reinterpret 접근과 ZNTC 의 detection+speculative-parse 접근
의 동작 동일.

## Test plan

- [x] `zig build test` 전체 통과
- [x] `@shopify/react-native-skia` `Vector.ts` 정상 transpile
- [x] 회귀 가드 unit test 6 case 추가 (`parser_test.zig`)
  - default 첫/두 번째/세 번째 param 위치
  - default expression nested literal (call / object / array) skip 검증
  - 단일 param default + return type annotation
- [x] `@babel/parser` TypeScript plugin 으로 동일 입력 검증

## 영향 범위

RN ecosystem 의 비슷한 패턴 (default + typed/optional 후속 param) 사용 모듈
다수 영향. `#3142` 의 large fixture 빌드에서 발견.

🤖 Generated with [Claude Code](https://claude.com/claude-code)