### PR TITLE
fix(parser): recognize TS interface getter/setter signatures

### DIFF
--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -1011,6 +1011,22 @@ test "Parser: TS function type property signature in .ts mode" {
     , ".ts");
 }
 
+test "Parser: TS interface getter / setter signature" {
+    // `@reduxjs/toolkit` 의 `createSlice.ts` 같은 패턴이 `isContextual("get")` 의
+    // identifier-only check 로 fail 하던 회귀 가드. scanner 가 `get`/`set` 을
+    // `.kw_get`/`.kw_set` 으로 토큰화하므로 token kind 로 비교해야 한다.
+    try expectNoParseErrorWithExt("export interface S { get x(): string; }", ".ts");
+    try expectNoParseErrorWithExt("export interface S { set x(v: string); }", ".ts");
+    try expectNoParseErrorWithExt("export interface S { get x(): string; set x(v: string); }", ".ts");
+    // generic return type 도 처리.
+    try expectNoParseErrorWithExt("export interface S<T> { get items(): Array<T>; }", ".ts");
+    // type literal 안에서도 동일.
+    try expectNoParseErrorWithExt("type X = { get x(): string; set x(v: string); };", ".ts");
+    // static / readonly modifier 와 조합.
+    try expectNoParseErrorWithExt("export interface S { static get x(): string; }", ".ts");
+    try expectNoParseErrorWithExt("export interface S { readonly x: string; }", ".ts");
+}
+
 test "Parser: TS object type literal" {
     var scanner = try Scanner.init(std.testing.allocator, "const obj: { x: number; y: string } = { x: 1, y: 'a' };");
     defer scanner.deinit();

--- a/src/parser/ts/type_members.zig
+++ b/src/parser/ts/type_members.zig
@@ -94,8 +94,9 @@ fn parseTypeMember(self: *Parser) ParseError2!NodeIndex {
     }
 
     // static 수정자 (interface에서 static accessor x 등)
-    // static은 kw_static 토큰이므로 별도 체크 필요
-    if (self.current() == .kw_static or (self.current() == .identifier and self.isContextual("static"))) {
+    // scanner 가 `static` 을 `.kw_static` 토큰으로 production — `isContextual("static")`
+    // 분기는 identifier-only check 로 절대 안 통과 (dead).
+    if (self.current() == .kw_static) {
         const next = try self.peekNextKind();
         if (isFollowedByTypeMemberName(next) or next == .kw_accessor) {
             try self.advance(); // skip 'static'
@@ -122,7 +123,9 @@ fn parseTypeMember(self: *Parser) ParseError2!NodeIndex {
     }
 
     // 4. getter 시그니처: get x(): Type
-    if (self.current() == .identifier and self.isContextual("get")) {
+    // scanner 가 `get` 을 `.kw_get` 토큰으로 production — `isContextual("get")` 은
+    // identifier 만 받아 절대 true 가 안 된다. token kind 로 직접 비교.
+    if (self.current() == .kw_get) {
         const next = try self.peekNextKind();
         if (isFollowedByTypeMemberName(next)) {
             try self.advance(); // skip 'get'
@@ -139,7 +142,7 @@ fn parseTypeMember(self: *Parser) ParseError2!NodeIndex {
     }
 
     // 5. setter 시그니처: set x(v: Type)
-    if (self.current() == .identifier and self.isContextual("set")) {
+    if (self.current() == .kw_set) {
         const next = try self.peekNextKind();
         if (isFollowedByTypeMemberName(next)) {
             try self.advance(); // skip 'set'


### PR DESCRIPTION
## 배경

`@reduxjs/toolkit` 의 `src/createSlice.ts` 가 ZNTC parse 시 fail (fuzz fixture
에서 발견 — #3142 follow-up):

```
× }
   ╭─[createSlice.ts:111:7]
111 │   get selectors(): Id<
    ·       ^^^^^^^^^
```

## Root cause

`src/parser/ts/type_members.zig:125,142` 가 `isContextual("get")` / `isContextual("set")`
로 getter/setter signature 를 감지하려 했지만, scanner 는 `get`/`set` 을 **별도
token kind** (`.kw_get` / `.kw_set`) 로 production.

```zig
pub fn isContextual(self: *const Parser, name: []const u8) bool {
    return self.current() == .identifier and
        std.mem.eql(u8, self.tokenText(), name);
}
```

`isContextual` 의 `current() == .identifier` guard 가 `.kw_get`/`.kw_set` 에서
절대 true 가 안 됨 → getter/setter 분기 자체가 **dead code**. interface 의 모든
getter/setter signature 가 일반 property fallback → return-type `:` 에서 fail.

`isContextual("static")` 도 동일 dead 분기 (scanner = `.kw_static`) — 함께 정리.

## 변경

`.identifier and isContextual(...)` → `.kw_get` / `.kw_set` / `.kw_static` 토큰
직접 비교. comment 도 root cause 명시.

## Babel 비교 검증

`@babel/parser` TypeScript plugin 으로 동일 입력 검증:

| 입력 | Babel | ZNTC (fix 후) |
|---|---|---|
| `interface S { get x(): string; }` | OK | OK |
| `interface S { set x(v: string); }` | OK | OK |
| `interface S { get x(): T; set x(v: T); }` | OK | OK |

## Test plan

- [x] `zig build test` 전체 통과
- [x] `@reduxjs/toolkit/src/createSlice.ts` 정상 transpile
- [x] 회귀 가드 unit test 7 case (`parser_test.zig`):
  - interface getter / setter / 둘 다
  - generic return type
  - type literal 안 getter/setter
  - static modifier + getter
  - readonly modifier + property
- [x] `@babel/parser` TypeScript plugin 으로 동일 결과 확인

## 영향 범위

TS interface / type literal 안의 모든 getter/setter signature. RN ecosystem
의 비슷한 패턴 사용 모듈 다수 (redux toolkit, ...).

🤖 Generated with [Claude Code](https://claude.com/claude-code)