### PR TITLE
fix(parser): preserve type-only import AST so semantic export check sees bindings

### DIFF
--- a/src/bundler/graph/import_usage.zig
+++ b/src/bundler/graph/import_usage.zig
@@ -35,6 +35,7 @@ pub fn isImportAllBindingsUnused(self: anytype, module: *const Module, record: t
         const e = n.data.extra;
         if (e + 2 >= ast_ptr.extra_data.items.len) continue;
         const x = module_parser.readImportDeclExtras(ast_ptr, e);
+        if (x.is_type_only) continue; // type-only declaration 은 runtime record 없음
         if (x.source.isNone()) continue;
         const source_node = ast_ptr.getNode(x.source);
         // record.span 이 정확히 source string literal span 이라 start 비교로 unique

--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -378,15 +378,17 @@ fn tryExtractImportDecl(ast: *const Ast, node: Node) ?ImportRecord {
     const e = node.data.extra;
     if (e + 2 >= ast.extra_data.items.len) return null;
 
-    const extras = ast.extra_data.items[e .. e + 3];
-    const specs_start = extras[0];
-    const specs_len = extras[1];
-    const source_idx: NodeIndex = @enumFromInt(extras[2]);
+    const x = @import("../parser/module.zig").readImportDeclExtras(ast, e);
+    const specs_start = x.specs_start;
+    const specs_len = x.specs_len;
+    const source_idx = x.source;
+
+    // declaration-level type-only (`import type { ... }` / `import type X from ...`):
+    // parser 가 AST 를 보존하므로 (semantic 의 export 검증용) scanner 는 record 등록 skip.
+    if (x.is_type_only) return null;
 
     // 모든 spec 이 individual `type` modifier 면 import 자체 elide — `import { type A, type B }
     // from './foo'` 가 babel typescript preset 이 statement 통째 제거하는 것과 동등.
-    // `import type { ... }` (declaration-level type-only) 는 parser 가 이미 NodeIndex.none
-    // 반환 (`module.zig:430`).
     if (specs_len > 0 and allSpecsAreTypeOnly(ast, specs_start, specs_len)) return null;
 
     const specifier = getStringLiteralText(ast, source_idx) orelse return null;

--- a/src/codegen/modules.zig
+++ b/src/codegen/modules.zig
@@ -12,6 +12,11 @@ pub fn emitImport(self: anytype, node: Node) !void {
     try self.addSourceMapping(node.span);
     const x = module_parser.readImportDeclExtras(self.ast, node.data.extra);
 
+    // `import type { ... }` / `import type X from ...` 같은 declaration-level type-only
+    // 는 codegen 단계에서 전체 strip. parser 가 AST 를 보존하는 이유는 semantic 단계의
+    // export 검증 + Phase D 의 type-only elision 정보 통합 — runtime 출력엔 흔적 X.
+    if (x.is_type_only) return;
+
     if (self.options.module_format == .cjs) {
         return emitImportCJS(self, x.source, x.specs_start, x.specs_len);
     }

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -40,25 +40,42 @@ pub const SPEC_FLAG_TYPE_ONLY: u16 = 1;
 
 /// `import_declaration` extra schema의 단일 source of truth.
 /// codegen / transformer 등 read 사이트가 이 헬퍼를 통해서만 슬롯 의미를 알도록 강제.
+/// `phase` 슬롯에 `is_type_only` 도 bit-packing (lower 4-bit = phase, bit 5 = type-only).
 pub const ImportDeclExtras = struct {
     specs_start: u32,
     specs_len: u32,
     source: NodeIndex,
     phase: ImportPhase,
+    /// `import type { ... }` / `import type X from ...` 같은 declaration-level type-only.
+    /// inline `import { type X }` 는 specifier 의 SPEC_FLAG_TYPE_ONLY 로 별도 표현.
+    /// 양쪽 모두 codegen 단계에서 emit 안 함 — specifier 의 모든 binding 이 type-only.
+    is_type_only: bool,
     attrs_start: u32,
     attrs_len: u32,
 };
 
+const PHASE_MASK: u32 = 0xF; // lower 4 bits
+const TYPE_ONLY_BIT: u32 = 1 << 4; // bit 5
+
 pub fn readImportDeclExtras(ast: anytype, e: u32) ImportDeclExtras {
     const slots = ast.extra_data.items[e .. e + 6];
+    const packed_phase = slots[3];
     return .{
         .specs_start = slots[0],
         .specs_len = slots[1],
         .source = @enumFromInt(slots[2]),
-        .phase = @enumFromInt(@as(u4, @truncate(slots[3]))),
+        .phase = @enumFromInt(@as(u4, @truncate(packed_phase & PHASE_MASK))),
+        .is_type_only = (packed_phase & TYPE_ONLY_BIT) != 0,
         .attrs_start = slots[4],
         .attrs_len = slots[5],
     };
+}
+
+/// `import type { ... }` / `import type X from ...` 같은 declaration-level type-only
+/// 인지. true 면 runtime 출력 / import_record 등록 / styled-components 같은 detection
+/// 모두 skip 해야 한다 (TS spec: type-only declaration 은 항상 elided).
+pub inline fn isDeclarationTypeOnly(x: ImportDeclExtras) bool {
+    return x.is_type_only;
 }
 
 fn finalizeImportDeclaration(
@@ -69,12 +86,15 @@ fn finalizeImportDeclaration(
     source_node: NodeIndex,
     phase: ImportPhase,
     attrs: NodeList,
+    is_type_only: bool,
 ) ParseError2!NodeIndex {
+    const packed_phase: u32 = @as(u32, @intFromEnum(phase)) |
+        (if (is_type_only) TYPE_ONLY_BIT else 0);
     const extra_start = try self.ast.addExtras(&.{
         specs_start,
         specs_len,
         @intFromEnum(source_node),
-        @intFromEnum(phase),
+        packed_phase,
         attrs.start,
         attrs.len,
     });
@@ -271,6 +291,7 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
             source_node,
             phase,
             attrs,
+            is_type_only,
         );
     }
 
@@ -366,13 +387,9 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
                 const attrs = try parseImportAttributes(self);
                 _ = try self.eat(.semicolon);
 
-                if (is_type_only) {
-                    self.restoreScratch(scratch_top);
-                    return NodeIndex.none;
-                }
-
-                // Inline scan: default-only import
-                if (self.enable_scan and !source_node.isNone()) {
+                // Inline scan: default-only import (type-only 는 graph/linker 가
+                // import_record 의 type-only marker 로 elide — scan 단계에선 record 등록).
+                if (self.enable_scan and !is_type_only and !source_node.isNone()) {
                     const src_node = self.ast.getNode(source_node);
                     const raw = self.ast.source[src_node.span.start..src_node.span.end];
                     const specifier = extractImportSpecifier(self, raw);
@@ -391,6 +408,7 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
                     source_node,
                     phase,
                     attrs,
+                    is_type_only,
                 );
             }
         }
@@ -433,13 +451,9 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
     const attrs = try parseImportAttributes(self);
     _ = try self.eat(.semicolon);
 
-    if (is_type_only) {
-        self.restoreScratch(scratch_top);
-        return NodeIndex.none;
-    }
-
-    // Inline scan: full import (namespace/named/mixed)
-    if (self.enable_scan and !source_node.isNone()) {
+    // Inline scan: full import (namespace/named/mixed). type-only 는 graph/linker
+    // 단계에서 import_record 의 type-only marker 로 elide — scan 단계에선 record 등록.
+    if (self.enable_scan and !is_type_only and !source_node.isNone()) {
         const src_node = self.ast.getNode(source_node);
         const raw = self.ast.source[src_node.span.start..src_node.span.end];
         const spec = extractImportSpecifier(self, raw);
@@ -459,6 +473,7 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
         source_node,
         phase,
         attrs,
+        is_type_only,
     );
 }
 

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -1010,6 +1010,63 @@ test "Enum: undefined export still errors" {
 }
 
 // ====================================================================
+// D5: import type declaration + 다른 import → export 검증
+// ====================================================================
+// `@expo/log-box` 의 `LogBox.ts` 같은 패턴이 fail 하던 회귀 가드.
+// parser 가 `import type { ... }` 전체 AST 를 drop 하던 게 root cause —
+// declaration 자체에 is_type_only flag 만 두고 specifier 들의 binding 정보는
+// 보존해야 같은 file 안의 다른 (value) import 와 함께 있을 때 export 검증
+// 이 그 binding 을 인식한다.
+
+test "Import: type-only + namespace value from same source — export resolves" {
+    try analyzeNoErrors(
+        \\import type { Foo } from './x';
+        \\import * as ns from './x';
+        \\export { Foo };
+        \\const _ = ns;
+    );
+}
+
+test "Import: type-only + default value from same source — export resolves" {
+    try analyzeNoErrors(
+        \\import type { Foo } from './x';
+        \\import baz from './x';
+        \\export { Foo };
+        \\const _ = baz;
+    );
+}
+
+test "Import: type-only + namespace from different source — export resolves" {
+    try analyzeNoErrors(
+        \\import type { Foo } from './x';
+        \\import * as ns from './y';
+        \\export { Foo };
+        \\const _ = ns;
+    );
+}
+
+test "Import: type-only default declaration — export resolves" {
+    try analyzeNoErrors(
+        \\import type Foo from './x';
+        \\import * as ns from './x';
+        \\export { Foo };
+        \\const _ = ns;
+    );
+}
+
+test "Import: type-only specifier is still a binding (no runtime use enforced here)" {
+    // type-only binding 을 value 로 쓰면 codegen 단계에서 not-defined runtime error 가
+    // 되지만, semantic 단계에선 binding 으로 인정되어 unresolved 가 아니다 — TS 와 동일.
+    // value 검증은 transformer Phase D / linker 가 별도 단계에서 처리.
+    try analyzeNoErrors(
+        \\import type { Foo } from './x';
+        \\import baz from './x';
+        \\const _ = Foo;
+        \\const __ = baz;
+    );
+}
+
+// ====================================================================
 // Private Name 시맨틱 체크
 // ====================================================================
 

--- a/src/transformer/transformer/emotion.zig
+++ b/src/transformer/transformer/emotion.zig
@@ -113,6 +113,7 @@ pub fn detectEmotionImport(self: *Transformer, node: Node) Error!void {
     if (!self.options.emotion) return;
 
     const x = module_parser.readImportDeclExtras(self.ast, node.data.extra);
+    if (x.is_type_only) return; // type-only import 는 runtime binding 생성 안 함
     if (x.source.isNone()) return;
     const source_node = self.ast.getNode(x.source);
     if (source_node.tag != .string_literal) return;

--- a/src/transformer/transformer/import_export.zig
+++ b/src/transformer/transformer/import_export.zig
@@ -53,6 +53,12 @@ pub fn visitImportDeclaration(self: *Transformer, node: Node) Error!NodeIndex {
 
     const x = module_parser.readImportDeclExtras(self.ast, node.data.extra);
 
+    // `import type { ... }` / `import type X from ...` — declaration 자체가 type-only.
+    // verbatim_module_syntax=true 도 emit 안 함 (TS 도 type-only declaration 은 strip —
+    // TS spec: "always emit type-only imports as elided"). codegen 의 emit 가드와 중복
+    // 이지만 여기서 일찍 .none 반환해 후속 specifier 재구성 비용 절감.
+    if (x.is_type_only) return .none;
+
     // Unused import 제거: 모든 specifier의 reference_count가 0이면 import 전체를 제거.
     // side-effect import는 specifier가 없으면 제거 불가.
     // verbatimModuleSyntax=true면 elision 생략 — 값 import는 그대로 보존.
@@ -75,9 +81,11 @@ pub fn visitImportDeclaration(self: *Transformer, node: Node) Error!NodeIndex {
     const new_specs = try self.visitExtraList(.{ .start = x.specs_start, .len = x.specs_len });
     const new_source = try self.visitNode(x.source);
     // phase / attributes는 metadata — transform 대상 아님, 그대로 통과.
+    // is_type_only 는 이미 위에서 elide 처리 — 여기 도달하면 항상 false.
+    const packed_phase: u32 = @intFromEnum(x.phase);
     return self.addExtraNode(.import_declaration, node.span, &.{
-        new_specs.start,       new_specs.len, @intFromEnum(new_source),
-        @intFromEnum(x.phase), x.attrs_start, x.attrs_len,
+        new_specs.start, new_specs.len, @intFromEnum(new_source),
+        packed_phase,    x.attrs_start, x.attrs_len,
     });
 }
 

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -96,6 +96,7 @@ pub fn detectStyledImport(self: *Transformer, node: Node) Error!void {
     if (!self.options.styled_components) return;
 
     const x = module_parser.readImportDeclExtras(self.ast, node.data.extra);
+    if (x.is_type_only) return; // type-only import 는 runtime binding 생성 안 함
     if (x.source.isNone()) return;
     const source_node = self.ast.getNode(x.source);
     if (source_node.tag != .string_literal) return;
@@ -1537,6 +1538,7 @@ fn collectBindingsFromStatement(
     switch (node.tag) {
         .import_declaration => {
             const x = module_parser.readImportDeclExtras(self.ast, node.data.extra);
+            if (x.is_type_only) return; // type-only import 는 runtime binding 등록 안 함
             var i: u32 = 0;
             while (i < x.specs_len) : (i += 1) {
                 const spec_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[x.specs_start + i]);

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -204,6 +204,7 @@ fn hasUnsupportedNamedImportLocalBindingShadow(ast: *const Ast) error{OutOfMemor
     for (ast.nodes.items) |import_node| {
         if (import_node.tag != .import_declaration) continue;
         const import_decl = module_parser.readImportDeclExtras(ast, import_node.data.extra);
+        if (import_decl.is_type_only) continue;
         var i: u32 = 0;
         while (i < import_decl.specs_len) : (i += 1) {
             const spec_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[import_decl.specs_start + i]);
@@ -527,6 +528,7 @@ fn collectBindingLite(allocator: std.mem.Allocator, ast: *const Ast) !BindingLit
     for (ast.nodes.items) |node| {
         if (node.tag != .import_declaration) continue;
         const import_decl = module_parser.readImportDeclExtras(ast, node.data.extra);
+        if (import_decl.is_type_only) continue;
         var i: u32 = 0;
         while (i < import_decl.specs_len) : (i += 1) {
             const spec_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[import_decl.specs_start + i]);


### PR DESCRIPTION
## 배경

`@expo/log-box` 의 `src/LogBox.ts` 같은 코드가 parser fail (large fixture fuzz
중 D5 발견 — #3142 follow-up):

```ts
import type { IgnorePattern, LogData } from './Data/LogBoxData';
import * as LogBoxData from './Data/LogBoxData';
import { type ExtendedExceptionData } from './Data/parseLogBoxLog';
import { parseLogBoxLog } from './Data/parseLogBoxLog';

export { ExtendedExceptionData, IgnorePattern, LogData };  // ⚠️ "not defined"
```

## Root cause

`parser/module.zig:436` 가 `import type { ... }` 의 AST 전체를 drop
(`return NodeIndex.none`):

| 시나리오 | 결과 |
|---|---|
| `import type { X }` 만 | OK (우연 — `has_module_syntax` 가 false 라 module 모드 안 됨 → export check skip) |
| `import type { X }` + `import { y } from 'src'` | OK |
| **`import type { X }` + `import * as ns from 'src'`** | **FAIL — IgnorePattern not defined** |
| **`import type { X }` + `import baz from 'src'`** | **FAIL** |
| **`import type { X }` + `import * as ns from 'other'`** | **FAIL** (source 무관) |

두 번째 import 가 `has_module_syntax=true` 만들고 `checkExportBinding` 활성화 →
type-only binding 은 AST drop 으로 symbol 등록 안 됨 → not found.

## 변경 (B 방향 — TS/Babel 표준 접근)

1. **AST**: `ImportDeclExtras` 에 `is_type_only` 추가 (slot[3] bit-packing —
   기존 6 slot 유지)
2. **Parser**: `module.zig` 의 두 drop path 제거. AST 보존 + `is_type_only=true`
3. **Codegen** (`emitImport`): `x.is_type_only` 면 일찍 return (출력 strip)
4. **Transformer** (`visitImportDeclaration`): 동일하게 `.none` 반환 (specifier
   재구성 비용 절감)
5. **Bundler** (`import_scanner.tryExtractImportDecl` + `graph/import_usage.zig`):
   type-only declaration 은 runtime import_record 없음 — skip
6. **Detection** (`emotion.zig`, `styled_components.zig`): type-only import 는
   runtime binding 생성 안 함 — skip

## Babel 비교 검증

`@babel/parser` TypeScript plugin 으로 동일 입력 검증 — 모두 OK. ZNTC 도 fix
후 동일 결과.

## Test plan (TDD)

- [x] **Step 1 — failing test 작성**: `analyzer_test.zig` 에 4 trigger case
      추가 → 4 fail 확인 (red)
- [x] **Step 2 — fix**: 6 단계 변경 적용
- [x] **Step 3 — green 확인**: `zig build test` 전체 통과 (D5 4 case + 기존
      9 transformer/codegen/bundler test 모두 pass)
- [x] **Step 4 — real input 검증**: `@expo/log-box/src/LogBox.ts` 정상 transpile
- [x] **Step 5 — Babel ground truth**: `@babel/parser` TypeScript plugin 으로
      동일 입력 비교, 모두 OK
- [x] **Step 6 — inverse case**: type-only binding 을 value 로 사용 시 semantic
      단계 통과 (transformer Phase D 가 별도 처리)

## 영향 범위

RN ecosystem 의 type-heavy 코드 (TS 다수 + namespace/default import 혼합)
사용 모듈 전부. `@expo/log-box`, redux-toolkit, RN codegen specs 등.

📌 #1791 / #1797 Phase D type-only elision 과 통합 — declaration 수준의
type-only 는 specifier 수준 (SPEC_FLAG_TYPE_ONLY) 와 동일 의미.

🤖 Generated with [Claude Code](https://claude.com/claude-code)