### PR TITLE
fix(parser): accept contextual keywords as TS parameter property names

### DIFF
--- a/src/parser/binding.zig
+++ b/src/parser/binding.zig
@@ -50,9 +50,13 @@ pub fn parseBindingPattern(self: *Parser) ParseError2!NodeIndex {
     {
         const modifier_span = self.currentSpan();
         const next = try self.peekNextKind();
-        // modifier 뒤에 식별자가 오면 parameter property
-        // readonly/override는 identifier로 토큰화되므로 next == .identifier에 포함됨
-        if (next == .identifier or next == .l_bracket or next == .l_curly) {
+        // modifier 뒤에 binding name 이 오면 parameter property — contextual keyword
+        // (`kw_source`/`kw_async`/`kw_from`/`kw_of`/`kw_let` 등) 도 받는다. ES reserved
+        // (await/yield/...) 만 제외 (strict mode binding 규칙). destructuring 패턴
+        // (`{...}` / `[...]`) 도 modifier 뒤에 올 수 있다.
+        const next_is_binding_name = next == .identifier or
+            (next.isKeyword() and !next.isReservedKeyword());
+        if (next_is_binding_name or next == .l_bracket or next == .l_curly) {
             var modifier_flags: u32 = if (is_readonly)
                 0x08
             else if (is_override)

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -1234,6 +1234,21 @@ test "Parser: TS parameter property" {
     try std.testing.expect(parser.errors.items.len == 0);
 }
 
+test "Parser: TS parameter property with contextual keyword name" {
+    // `@shopify/react-native-skia` 의 `CanvasKitWebGLBufferImpl.ts` 같은 패턴이
+    // `next == .identifier` 만 체크하던 condition 에서 fail. parameter property
+    // modifier 다음 param name 으로 contextual keyword (source/async/from/of 등)
+    // 가 와도 binding 으로 받아야 한다.
+    try expectNoParseErrorWithExt("class C { constructor(private source: number) {} }", ".ts");
+    try expectNoParseErrorWithExt("class C { constructor(public async: string) {} }", ".ts");
+    try expectNoParseErrorWithExt("class C { constructor(public a: string, private source: number) {} }", ".ts");
+    try expectNoParseErrorWithExt("class C { constructor(readonly defer: number) {} }", ".ts");
+    try expectNoParseErrorWithExt("class C { constructor(public override target: string) {} }", ".ts");
+    // destructuring 패턴 + modifier 도 같은 condition 안 — 기존 동작 회귀 가드.
+    try expectNoParseErrorWithExt("class C { constructor(public { x, y }: Point) {} }", ".ts");
+    try expectNoParseErrorWithExt("class C { constructor(readonly [a, b]: number[]) {} }", ".ts");
+}
+
 test "Parser: TS generic class method named get/set" {
     var scanner = try Scanner.init(std.testing.allocator,
         \\class QueryCache {


### PR DESCRIPTION
## 배경

`@shopify/react-native-skia` 의 `CanvasKitWebGLBufferImpl.ts` 가 ZNTC fail
(D4 fuzz 1500 random sample 에서 발견):

```ts
constructor(public surface: Surface, private source: TextureSource) {
                                            ^^^^^^
                                            "Expression expected"
```

## Root cause

`src/parser/binding.zig:55` 의 parameter property 감지 condition:

```zig
if (next == .identifier or next == .l_bracket or next == .l_curly) {
```

scanner 가 `source` 를 `.kw_source` 로 토큰화 — `.identifier` 아니므로 분기 못
들어가 fall-through. D2 (Flow function-type) / D5 (type-only import) 와 동일
패턴.

## 변경

condition 을 `identifier OR (isKeyword AND !isReservedKeyword) OR l_bracket OR l_curly`
로 확장. contextual keyword (source/async/defer/from/of/let/target/meta 등) 받음.
ES reserved (await/yield 등) 는 strict mode binding 규칙대로 제외.

## Babel 비교 검증

`@babel/parser` TypeScript plugin — 모두 OK:

| 입력 | Babel | ZNTC (fix 후) |
|---|---|---|
| `constructor(private source: T)` | OK | OK |
| `constructor(public async: T)` | OK | OK |
| `constructor(readonly defer: T)` | OK | OK |
| `constructor(public override target: T)` | OK | OK |

## Test plan (TDD)

- [x] **Step 1**: failing test → 1 fail (red)
- [x] **Step 2**: condition 확장 → 0 fail (green)
- [x] **Step 3**: real input (`CanvasKitWebGLBufferImpl.ts`) 정상 transpile
- [x] **Step 4**: Babel ground truth 일치 확인
- [x] **Step 5**: /simplify 3 agent
  - Reuse Agent finding: 같은 condition 이 parser 전반 12+ 사이트 → 별도 리팩터 PR (D7)
  - Quality Agent finding: 변수명 `is_name_token` → `next_is_binding_name`
  - Quality Agent finding: destructuring + modifier 회귀 가드 test 추가
- [x] **Step 6**: 회귀 가드 7 case

## 후속

`Token.Kind.canBeBindingName()` helper 로 promote 하면 parser 전반의 12+
duplicate condition dedup 가능 — 별도 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)