### PR TITLE
refactor(linker): dedupe allocEsmInitExpr into shared_namespace

### DIFF
--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -29,6 +29,7 @@ const isReservedName = Linker.isReservedName;
 const NamePair = PreambleWriter.NamePair;
 const NS_VAR_PREFIX = linker_mod.NS_VAR_PREFIX;
 const EXPR_RENAME_MARKER = linker_mod.EXPR_RENAME_MARKER;
+const allocEsmInitExpr = @import("shared_namespace.zig").allocEsmInitExpr;
 
 inline fn cjsInteropMode(self: *const Linker, importer: *const Module) types.Interop {
     if (self.graph.resolve_cache.platform == .react_native) return .babel;
@@ -91,32 +92,6 @@ pub fn isImportBindingTypeOnly(sem: *const @import("../module.zig").ModuleSemant
         if (r.isValueUse()) return false;
     }
     return true;
-}
-
-fn allocEsmInitExpr(self: *const Linker, target_mod: *const Module) ![]const u8 {
-    const guard_close_expr = "})";
-    const guard = target_mod.shouldGuard(self.entry_error_guard);
-    if (self.dev_mode) {
-        if (guard) {
-            return try std.fmt.allocPrint(
-                self.allocator,
-                "{s}__zntc_modules[\"{s}\"].fn(){s}",
-                .{ if (self.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN, target_mod.dev_id, guard_close_expr },
-            );
-        }
-        return try std.fmt.allocPrint(self.allocator, "__zntc_modules[\"{s}\"].fn()", .{target_mod.dev_id});
-    }
-
-    const init_name = try target_mod.allocInitName(self.allocator);
-    defer self.allocator.free(init_name);
-    if (guard) {
-        return try std.fmt.allocPrint(
-            self.allocator,
-            "{s}{s}(){s}",
-            .{ if (self.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN, init_name, guard_close_expr },
-        );
-    }
-    return try std.fmt.allocPrint(self.allocator, "{s}()", .{init_name});
 }
 
 fn allocLazyEsmImportExpr(self: *const Linker, import_mod: *const Module, value_mod: *const Module, target_name: []const u8) ![]const u8 {

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -11,6 +11,7 @@ const Linker = linker_mod.Linker;
 const LinkingMetadata = linker_mod.LinkingMetadata;
 const ModuleIndex = @import("../types.zig").ModuleIndex;
 const CompiledModule = @import("../compiled_module.zig").CompiledModule;
+const Module = @import("../module.zig").Module;
 const rt = @import("../runtime_helpers.zig");
 const profile = @import("../../profile.zig");
 
@@ -592,7 +593,7 @@ fn allocEsmInitExprForModuleIndex(self: *const Linker, mod_idx: u32) std.mem.All
     return try allocEsmInitExpr(self, mod);
 }
 
-fn allocEsmInitExpr(self: *const Linker, target_mod: *const @import("../module.zig").Module) std.mem.Allocator.Error![]const u8 {
+pub fn allocEsmInitExpr(self: *const Linker, target_mod: *const Module) std.mem.Allocator.Error![]const u8 {
     const guard_close_expr = "})";
     const guard = target_mod.shouldGuard(self.entry_error_guard);
     if (self.dev_mode) {


### PR DESCRIPTION
## 배경

`allocEsmInitExpr` 가 `src/bundler/linker/metadata.zig:96` 과 `src/bundler/linker/shared_namespace.zig:586` 양쪽에 byte-for-byte 동일한 본문으로 정의되어 있었음 (dev_mode/guard 분기, init 식 포맷 모두 일치). \`/simplify\` 리뷰에서 반복적으로 잡힘.

## 변경

- `shared_namespace.zig` 를 canonical 위치로 (이미 동일 family 의 `allocEsmInitExprForModuleIndex` 보유). `pub fn allocEsmInitExpr` 으로 노출.
- `metadata.zig` 는 top imports 블록에 `const allocEsmInitExpr = @import(\"shared_namespace.zig\").allocEsmInitExpr;` re-binding — 코드베이스 다른 곳에서도 쓰는 idiomatic alias 패턴.
- `shared_namespace.zig` 안 inline `*const @import(\"../module.zig\").Module` → top-level `const Module` import 으로 정리.

## 효과

- 동작 변경 없음 (pure dedup).
- 향후 init 식 포맷 변경 시 한 곳만 수정.
- `metadata.zig` 26 lines 감소.

## Test plan

- [x] \`zig build test\` 전체 통과
- [x] 회귀 테스트 동일 결과 (main 대비 통과 set 동일)