### PR TITLE
refactor(parser): promote canBeBindingName helper to Token.Kind, dedup 9 sites

### DIFF
--- a/src/lexer/token.zig
+++ b/src/lexer/token.zig
@@ -373,6 +373,15 @@ pub const Kind = enum(u8) {
         return self.inRange(.kw_true, .kw_null);
     }
 
+    /// binding identifier 자리에 올 수 있는 토큰인지 — `.identifier` 와 contextual /
+    /// strict reserved keyword (async/from/of/let/yield/source/target/meta 등) 까지.
+    /// ES reserved (`await/with/...`) 만 제외. true/false/null literal 도 포함하므로
+    /// strict mode binding (`let true = ...` 같은) 거부가 필요하면 caller 가
+    /// `.isLiteralKeyword()` 도 추가로 검사한다.
+    pub fn canBeBindingName(self: Kind) bool {
+        return self == .identifier or (self.isKeyword() and !self.isReservedKeyword());
+    }
+
     /// 숫자 리터럴인지 (decimal..hex_bigint)
     pub fn isNumericLiteral(self: Kind) bool {
         return self.inRange(.decimal, .hex_bigint);

--- a/src/lexer/token_test.zig
+++ b/src/lexer/token_test.zig
@@ -54,6 +54,35 @@ test "Kind.isLiteralKeyword" {
     try std.testing.expect(!Kind.l_paren.isLiteralKeyword()); // 직후
 }
 
+test "Kind.canBeBindingName covers identifier + contextual/strict-reserved keywords" {
+    // identifier 자체
+    try std.testing.expect(Kind.identifier.canBeBindingName());
+    // contextual keyword (parser 전반의 D1/D2/D5/D6 fix 가 통과시켜야 하는 케이스)
+    try std.testing.expect(Kind.kw_async.canBeBindingName());
+    try std.testing.expect(Kind.kw_from.canBeBindingName());
+    try std.testing.expect(Kind.kw_of.canBeBindingName());
+    try std.testing.expect(Kind.kw_target.canBeBindingName());
+    try std.testing.expect(Kind.kw_meta.canBeBindingName());
+    try std.testing.expect(Kind.kw_source.canBeBindingName());
+    try std.testing.expect(Kind.kw_defer.canBeBindingName());
+    // strict-mode reserved — ES 기본 reserved 가 아니므로 type-only / non-strict 환경에선 받음
+    try std.testing.expect(Kind.kw_let.canBeBindingName());
+    try std.testing.expect(Kind.kw_yield.canBeBindingName());
+    try std.testing.expect(Kind.kw_static.canBeBindingName());
+    // literal keyword — 받음 (caller 가 isLiteralKeyword 로 strict mode 거부 책임)
+    try std.testing.expect(Kind.kw_true.canBeBindingName());
+    try std.testing.expect(Kind.kw_null.canBeBindingName());
+    // ES reserved — 거부 (binding 위치에서 사용 불가)
+    try std.testing.expect(!Kind.kw_await.canBeBindingName());
+    try std.testing.expect(!Kind.kw_with.canBeBindingName());
+    try std.testing.expect(!Kind.kw_class.canBeBindingName());
+    try std.testing.expect(!Kind.kw_function.canBeBindingName());
+    // 그 외 토큰 — 거부
+    try std.testing.expect(!Kind.l_paren.canBeBindingName());
+    try std.testing.expect(!Kind.plus.canBeBindingName());
+    try std.testing.expect(!Kind.escaped_keyword.canBeBindingName());
+}
+
 test "Kind.isNumericLiteral" {
     try std.testing.expect(Kind.decimal.isNumericLiteral());
     try std.testing.expect(Kind.hex.isNumericLiteral());

--- a/src/parser/binding.zig
+++ b/src/parser/binding.zig
@@ -54,9 +54,7 @@ pub fn parseBindingPattern(self: *Parser) ParseError2!NodeIndex {
         // (`kw_source`/`kw_async`/`kw_from`/`kw_of`/`kw_let` 등) 도 받는다. ES reserved
         // (await/yield/...) 만 제외 (strict mode binding 규칙). destructuring 패턴
         // (`{...}` / `[...]`) 도 modifier 뒤에 올 수 있다.
-        const next_is_binding_name = next == .identifier or
-            (next.isKeyword() and !next.isReservedKeyword());
-        if (next_is_binding_name or next == .l_bracket or next == .l_curly) {
+        if (next.canBeBindingName() or next == .l_bracket or next == .l_curly) {
             var modifier_flags: u32 = if (is_readonly)
                 0x08
             else if (is_override)
@@ -132,9 +130,7 @@ fn parseBindingPatternInner(self: *Parser) ParseError2!NodeIndex {
     }
 
     // contextual keyword (get/set/number/string 등)도 binding 위치에서 식별자로 유효
-    if (self.current() == .identifier or
-        (self.current().isKeyword() and !self.current().isReservedKeyword()))
-    {
+    if (self.current().canBeBindingName()) {
         const span = self.currentSpan();
         if (self.current() == .identifier) try self.checkStrictBinding(span);
         try self.checkIdentifierKeywordUse(span);

--- a/src/parser/declaration.zig
+++ b/src/parser/declaration.zig
@@ -203,10 +203,9 @@ fn parseFunctionDeclarationWithFlagsOptionalName(self: *Parser, extra_flags: u32
     const is_generator = (flags & FunctionFlags.is_generator) != 0;
 
     // 이름은 선택적: identifier 또는 contextual keyword(defer, of, set 등)가 있으면 파싱
-    const name = if (self.current() == .identifier or
+    const name = if (self.current().canBeBindingName() or
         self.current() == .kw_yield or self.current() == .kw_await or
-        self.current() == .escaped_keyword or self.current() == .escaped_strict_reserved or
-        (self.current().isKeyword() and !self.current().isReservedKeyword()))
+        self.current() == .escaped_keyword or self.current() == .escaped_strict_reserved)
         try self.parseBindingIdentifier()
     else
         NodeIndex.none;
@@ -289,8 +288,8 @@ pub fn parseFunctionExpressionWithFlags(self: *Parser, extra_flags: u32) ParseEr
     var name = NodeIndex.none;
     // 함수 표현식의 이름: identifier + contextual keyword (get, set, async, from, of 등)
     // ECMAScript에서 reserved keyword만 함수 이름으로 사용 불가
-    if (self.current() == .identifier or self.current() == .kw_yield or self.current() == .kw_await or
-        (self.current().isKeyword() and !self.current().isReservedKeyword()))
+    if (self.current().canBeBindingName() or
+        self.current() == .kw_yield or self.current() == .kw_await)
     {
         name = try self.parseBindingIdentifier();
     }

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -164,7 +164,7 @@ pub fn parseAssignmentExpression(self: *Parser) ParseError2!NodeIndex {
             }
 
             // 형태 1: async x => body (단순 식별자)
-            if (peek.kind == .identifier or (peek.kind.isKeyword() and !peek.kind.isReservedKeyword())) {
+            if (peek.kind.canBeBindingName()) {
                 const saved = self.saveState();
                 try self.advance(); // skip 'async'
                 const id_span = self.currentSpan();
@@ -1184,9 +1184,8 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
     // contextual keyword도 expression 위치에서 식별자로 유효.
     // async는 제외 — async function/arrow에서 특수 처리 (아래 switch에서).
     // literal keyword (true, false, null)는 제외 — 아래 switch에서 boolean_literal/null_literal로 처리.
-    if (self.current() == .identifier or
-        (self.current().isKeyword() and !self.current().isReservedKeyword() and
-            !self.current().isLiteralKeyword() and self.current() != .kw_async))
+    if (self.current().canBeBindingName() and
+        !self.current().isLiteralKeyword() and self.current() != .kw_async)
     {
         // Flow match expression: match (expr) { Pattern => expr, ... }
         if (self.is_flow and self.isContextual("match")) {

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -584,15 +584,6 @@ fn parseTypeParameter(self: *Parser) ParseError2!NodeIndex {
 // Parenthesized / Function Type
 // ================================================================
 
-/// Flow function-type 의 named-param 이름 자리에 올 수 있는 토큰인지.
-/// `identifier` 와 contextual / strict-reserved keyword (async, from, target,
-/// let, yield 등) 까지 받는다 — type-only context 라 ES reserved (await/with/...)
-/// 만 제외. 호출처는 이 결과로 `(name: T)` named param 인지 `(T)` positional param
-/// 인지 분기하므로 세 호출 사이트가 동일 condition 을 공유해야 한다.
-inline fn canBeFnTypeParamName(kind: @import("../lexer/token.zig").Kind) bool {
-    return kind == .identifier or (kind.isKeyword() and !kind.isReservedKeyword());
-}
-
 /// 괄호 타입 (Type) 또는 함수 타입 (a: Type) => Type (Babel 방식).
 /// 1단계: `()`, `...`, `identifier:` → 확정적 function type
 /// 2단계: 그 외 → grouped type으로 먼저 파싱, `,` 또는 `) =>` 따르면 function type
@@ -613,7 +604,7 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
     // ...rest 또는 identifier: → 확정적 named/rest function param
     const is_definite_fn = blk: {
         if (self.current() == .dot3) break :blk true;
-        if (canBeFnTypeParamName(self.current())) {
+        if (self.current().canBeBindingName()) {
             const next = try self.peekNextKind();
             break :blk (next == .colon or next == .question);
         }
@@ -639,7 +630,7 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
             const loop_guard_pos = self.scanner.token.span.start;
             if (self.current() == .dot3) try self.advance();
             // named param 감지: identifier + (`:` | `?`)
-            if (canBeFnTypeParamName(self.current())) {
+            if (self.current().canBeBindingName()) {
                 const next = try self.peekNextKind();
                 if (next == .colon or next == .question) {
                     const named = try parseFunctionTypeParamList(self);
@@ -731,7 +722,7 @@ fn parseFunctionTypeParamList(self: *Parser) ParseError2!ast_mod.NodeList {
         }
 
         // name: Type 또는 name?: Type — 이름 뒤에 : 또는 ?: 가 오면 named param.
-        if (canBeFnTypeParamName(self.current())) {
+        if (self.current().canBeBindingName()) {
             const next = try self.peekNextKind();
             if (next == .colon or next == .question) {
                 const name_span = self.scanner.token.span;

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -322,9 +322,7 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
 
     // TS import-equals: import x = require('y') → const x = require('y')
     // import x = Namespace.Member → const x = Namespace.Member
-    if (self.current() == .identifier or
-        (self.current().isKeyword() and !self.current().isReservedKeyword()))
-    {
+    if (self.current().canBeBindingName()) {
         const next = try self.peekNextKind();
         if (next == .eq) {
             self.ast.has_ts_import_equals = true;
@@ -362,9 +360,7 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
     // default import: import foo from "module"
     // contextual keyword (get/set/number/string/object/type 등)도 import 이름으로 유효
     var has_default = false;
-    if (self.current() == .identifier or
-        (self.current().isKeyword() and !self.current().isReservedKeyword()))
-    {
+    if (self.current().canBeBindingName()) {
         const next = try self.peekNextKind();
         if (next == .comma or next == .kw_from) {
             const spec_span = self.currentSpan();

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -388,17 +388,16 @@ fn isLetDeclarationStart(self: *Parser) ParseError2!bool {
         return false;
     }
     // 줄바꿈 없이 바로 오는 경우: identifier, [, {, escaped_strict_reserved → LexicalDeclaration
-    return next.kind == .identifier or next.kind == .l_bracket or next.kind == .l_curly or
+    return next.kind == .l_bracket or next.kind == .l_curly or
         next.kind == .escaped_strict_reserved or
-        (next.kind.isKeyword() and !next.kind.isReservedKeyword() and !next.kind.isLiteralKeyword());
+        (next.kind.canBeBindingName() and !next.kind.isLiteralKeyword());
 }
 
 /// `using` 뒤에 줄바꿈 없이 identifier가 오면 UsingDeclaration으로 해석한다.
 fn isUsingDeclarationStart(self: *Parser) ParseError2!bool {
     const next = try self.peekNext();
     if (next.has_newline_before) return false;
-    return next.kind == .identifier or
-        (next.kind.isKeyword() and !next.kind.isReservedKeyword() and !next.kind.isLiteralKeyword());
+    return next.kind.canBeBindingName() and !next.kind.isLiteralKeyword();
 }
 
 /// `await` + `using` + identifier (줄바꿈 없이) → AwaitUsingDeclaration
@@ -426,10 +425,10 @@ fn parseAwaitUsingDeclaration(self: *Parser) ParseError2!NodeIndex {
 fn parseExpressionOrLabeledStatement(self: *Parser) ParseError2!NodeIndex {
     // identifier/keyword: statement — labeled statement 판별
     // kw_await/kw_yield도 조건부로 식별자/label 사용 가능 (non-async/non-generator)
-    if (self.current() == .identifier or self.current() == .escaped_keyword or
+    if (self.current() == .escaped_keyword or
         self.current() == .escaped_strict_reserved or
         self.current() == .kw_await or self.current() == .kw_yield or
-        (self.current().isKeyword() and !self.current().isReservedKeyword() and !self.current().isLiteralKeyword()))
+        (self.current().canBeBindingName() and !self.current().isLiteralKeyword()))
     {
         const peek = try self.peekNext();
         if (peek.kind == .colon) {

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -1293,11 +1293,10 @@ fn isFunctionTypeParam(self: *Parser) bool {
 }
 
 fn isFunctionTypeParamName(kind: @import("../lexer/token.zig").Kind) bool {
-    return kind == .identifier or
+    return kind.canBeBindingName() or
         kind == .escaped_keyword or
         kind == .escaped_strict_reserved or
-        kind == .kw_this or
-        (kind.isKeyword() and !kind.isReservedKeyword());
+        kind == .kw_this;
 }
 
 /// 함수 타입 파라미터 리스트를 파싱하여 함수 타입 노드 생성


### PR DESCRIPTION
## 배경

D1/D2/D5/D6 fix 시리즈가 모두 같은 패턴 — `kind == .identifier or (kind.isKeyword() and !kind.isReservedKeyword())` —
의 누락 케이스 (contextual keyword 가 binding identifier 자리에 못 옴) 였다.
같은 condition 이 parser 전반 9 사이트에 inline 으로 duplicate → 매번 새 buggy
variation 도입.

`/simplify` Reuse Agent finding (D6 PR #3165) 의 후속 epic.

## 변경

- `lexer/token.zig`: `Kind.canBeBindingName()` 메서드 추가. docstring 에 strict-mode
  binding (literal keyword 거부) 은 caller 책임 명시.
- `flow.zig`: 이미 같은 의도였던 module-private `canBeFnTypeParamName` 삭제,
  Kind 메서드 호출로 통일.
- 9 site migrate:
  - `binding.zig` (parameter property, binding identifier)
  - `declaration.zig` (function/class name)
  - `expression.zig` (async arrow, identifier expression)
  - `module.zig` (import-equals, default import)
  - `statement.zig` (lexical decl / using decl / labeled statement)
  - `ts.zig` (`isFunctionTypeParamName` 내 부분 reuse)

## 보존된 사이트 (의도적)

| 위치 | 이유 |
|---|---|
| `binding.zig:430` | yield/await + strict-mode + non-strict context 검사 — helper 로 표현 어려운 도메인 조건 |
| `module.zig:234` | `kw_from` 명시 제외 (`import type from ...` 의 type-only 특수 케이스) |

## Test plan

- [x] `zig build test` 전체 통과
- [x] `token_test.zig` 에 `canBeBindingName` 단위 test 추가 — D1/D2/D5/D6 trigger
      keyword + ES reserved + literal keyword + 일반 토큰 cover
- [x] 기존 9 사이트의 기능 동작 회귀 가드 (각 fix 의 unit test 가 그대로 통과)

## 영향

- 향후 새 contextual keyword 가 scanner 에 추가될 때 모든 binding-name 사이트가
  자동으로 따라가게 됨 (D8/D9 같은 fix 시리즈 사전 차단)
- net diff: +59 / -42 (helper 추가 + 9 inline 단축)
- 성능: helper 가 inline-able (단순 `inRange` 조합) — net cost 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)