### PR TITLE
perf(linker): memoize source_init in registerNamespaceRewrites

### DIFF
--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -121,6 +121,18 @@ pub fn registerNamespaceRewrites(
     else
         null;
     defer if (target_init) |expr| self.allocator.free(expr);
+    // barrel re-export (`export { a, b, c } from './x'`) 에서 같은 source_mod_idx 가
+    // export 마다 반복 → 매번 `allocEsmInitExprForModuleIndex` 가 동일한 init 식을 새로
+    // alloc. 호출자가 owned 한 캐시로 1회 alloc + 재사용. null 결과 (source.wrap_kind
+    // != .esm) 도 캐시해 이중 lookup 회피. 같은 패턴: `cjs_var_cache` (metadata.zig).
+    var source_init_cache = std.AutoHashMap(u32, ?[]const u8).init(self.allocator);
+    defer {
+        var it = source_init_cache.valueIterator();
+        while (it.next()) |value_ptr| {
+            if (value_ptr.*) |expr| self.allocator.free(expr);
+        }
+        source_init_cache.deinit();
+    }
     for (cached_exports) |exp| {
         if (hasNestedBinding(self, importer_mod_idx, exp.exported)) {
             has_shadow = true;
@@ -154,7 +166,7 @@ pub fn registerNamespaceRewrites(
             continue;
         }
         if (self.dev_mode) {
-            if (try allocNamespaceMemberRewriteValue(self, target_init, target_mod_idx, exp)) |rewrite_value| {
+            if (try allocNamespaceMemberRewriteValue(self, target_init, target_mod_idx, exp, &source_init_cache)) |rewrite_value| {
                 var owned_by_list = false;
                 errdefer if (!owned_by_list) self.allocator.free(rewrite_value);
                 // ns_member_rewrites map 은 포인터만 빌리고, 실제 소유권은
@@ -559,20 +571,27 @@ fn allocNamespaceGetterValue(self: *const Linker, exp: NsExportPair) std.mem.All
 /// `target_init` 은 호출자가 미리 1회 계산한 target 모듈의 init 식 (예: `init_X()` 또는
 /// `__zntc_modules["..."].fn()`). dev_mode 의 lazy 런타임에서만 호출되며, 비-dev 호출 경로는
 /// caller 에서 차단된다 (top-level `init_X()` preamble 이 init 을 이미 보장).
+///
+/// `source_init_cache` 는 호출자가 owned. 같은 `source_mod_idx` 가 같은
+/// `registerNamespaceRewrites` 호출 안에서 반복되는 barrel re-export 케이스 대비.
 fn allocNamespaceMemberRewriteValue(
     self: *const Linker,
     target_init: ?[]const u8,
     target_mod_idx: u32,
     exp: NsExportPair,
+    source_init_cache: *std.AutoHashMap(u32, ?[]const u8),
 ) std.mem.Allocator.Error!?[]const u8 {
-    const source_init = if (exp.init_mod) |source_mod_idx|
-        if (source_mod_idx != target_mod_idx)
-            try allocEsmInitExprForModuleIndex(self, source_mod_idx)
-        else
-            null
-    else
-        null;
-    defer if (source_init) |expr| self.allocator.free(expr);
+    const source_init: ?[]const u8 = if (exp.init_mod) |source_mod_idx| blk: {
+        if (source_mod_idx == target_mod_idx) break :blk null;
+        const gop = try source_init_cache.getOrPut(source_mod_idx);
+        if (!gop.found_existing) {
+            // alloc 실패 시 entry 의 value_ptr.* 가 undefined 로 남아 defer 가
+            // 잘못 dereference. 미초기화 entry 제거 후 에러 전파.
+            errdefer _ = source_init_cache.remove(source_mod_idx);
+            gop.value_ptr.* = try allocEsmInitExprForModuleIndex(self, source_mod_idx);
+        }
+        break :blk gop.value_ptr.*;
+    } else null;
 
     const sep = if (self.minify_whitespace) "," else ", ";
     if (target_init) |target_expr| {


### PR DESCRIPTION
## 배경

`registerNamespaceRewrites` 안의 per-export 루프가 `allocNamespaceMemberRewriteValue` 를 호출할 때마다 `allocEsmInitExprForModuleIndex(source_mod_idx)` 로 source 모듈의 init 식을 새로 alloc 했다. barrel re-export 패턴 (`export { a, b, c } from './x'`) 에서는 모든 export 의 `init_mod` 가 동일한 `'./x'` 라 같은 init 식이 export 수만큼 반복 alloc 된다.

## 사전 검증

`ZNTC_DEBUG=metadata_audit` 카운터를 임시 추가해 `examples/react-native-large` dev_mode 빌드 측정:

| target | exports | total alloc | distinct | saved | 호출 횟수 |
|--------|---------|-------------|----------|-------|----------|
| 22 | 237 | 229~231 | 12 | 217~219 | 2 |
| 43 | 273 | 268~269 | 13 | 255~256 | 6 |
| 45 | 29 | 27~29 | 1 | 26~28 | 2 |
| 877 | 12 | 12 | 1 | 11 | 3 |

- 누적 총 alloc: **2,166 → 108 (약 95% 감소)**
- 같은 target 이 여러 importer 에서 re-namespace import 될 때마다 반복 발생

## 변경

- `registerNamespaceRewrites` 안에 caller-owned `std.AutoHashMap(u32, ?[]const u8)` source_init 캐시 추가.
- `allocNamespaceMemberRewriteValue` 시그니처에 캐시 포인터 추가.
- `getOrPut` 후 alloc 실패 시 entry 가 미초기화 상태로 남으면 defer 가 잘못 dereference → `errdefer remove` 로 정리.
- null 결과 (source.wrap_kind != .esm) 도 캐시 — 이중 wrap_kind lookup 회피.
- 캐시 패턴은 같은 파일의 형제 `cjs_var_cache` / `ns_target_to_var` 와 동일하게 managed `AutoHashMap` 사용.

## 효과

- dev_mode (HMR / RN inlineRequires) 빌드 hot path 의 namespace 멤버 rewrite alloc ~95% 감소.
- 비-dev 빌드는 캐시 사용 경로 자체가 안 타므로 영향 없음 (`if (self.dev_mode)` 게이트가 caller 에 있음).
- 외부 동작 변경 없음 — 기존 namespace member rewrite 출력은 비트 단위 동일.

## Test plan

- [x] `zig build test` 전체 통과
- [x] `tests/integration` RN dev 픽스처 (bundle-smoke, rn-refresh-prelude, strict-execution-order) 165 tests pass