### PR TITLE
fix(parser): accept TS non-null assertion as assignment target

### DIFF
--- a/src/parser/cover.zig
+++ b/src/parser/cover.zig
@@ -112,6 +112,13 @@ pub fn coverExpressionToAssignmentTarget(self: *Parser, idx: NodeIndex, is_top: 
             return try self.coverExpressionToAssignmentTarget(inner, is_top);
         },
 
+        // 6c) TS non-null assertion — 같은 원리. `x!--`, `a[i]!++`, `x! = 1` 같은
+        // 패턴이 TS 에선 valid (TS spec: `NonNullExpression` 은 assignment target).
+        .ts_non_null_expression => {
+            const inner = node.data.unary.operand;
+            return try self.coverExpressionToAssignmentTarget(inner, is_top);
+        },
+
         // 7) meta_property (import.meta, new.target) — 절대로 assignment target이 될 수 없음.
         //    is_top 여부와 무관하게 항상 에러. else 분기는 is_top=false일 때 에러를 내지 않으므로
         //    destructuring 내부([import.meta] = arr)에서 잘못 통과하는 것을 방지.

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -930,6 +930,23 @@ test "Parser: TS non-null assertion" {
     try std.testing.expect(parser.errors.items.len == 0);
 }
 
+test "Parser: TS non-null assertion as assignment target (postfix ++/-- and =)" {
+    // `@jridgewell/gen-mapping` 의 `set-array.ts` 같은 `indexes[k]!--;` 패턴이
+    // `coverExpressionToAssignmentTarget` 가 `ts_non_null_expression` 을 unwrap
+    // 안 해서 "Invalid assignment target" 으로 fail. ts_as/satisfies 처럼 inner
+    // expression 으로 unwrap 해 valid target 인지 검증.
+    try expectNoParseErrorWithExt("let i = 0; let a: any[] = []; a[i]!--;", ".ts");
+    try expectNoParseErrorWithExt("let i = 0; let a: any[] = []; a[i]!++;", ".ts");
+    try expectNoParseErrorWithExt("let x: any = 1; x!--;", ".ts");
+    try expectNoParseErrorWithExt("let x: any = 1; x!++;", ".ts");
+    // assignment 도 같은 path
+    try expectNoParseErrorWithExt("let x: any = 1; x! = 2;", ".ts");
+    try expectNoParseErrorWithExt("let a: any[] = []; a[0]! = 1;", ".ts");
+    // compound assignment 도 동일 cover path
+    try expectNoParseErrorWithExt("let x: any = 1; x! += 1;", ".ts");
+    try expectNoParseErrorWithExt("let a: any[] = []; a[0]! -= 2;", ".ts");
+}
+
 test "Parser: TS non-null assertion followed by division" {
     // non-null assertion `!` 뒤의 `/`가 regex가 아닌 division으로 파싱되어야 한다
     const cases = [_][]const u8{


### PR DESCRIPTION
## 배경

`@jridgewell/gen-mapping` 의 `set-array.ts:78` 가 ZNTC fail (D4 fuzz 2500 sample
에서 발견):

```ts
indexes[k]!--;
```

```
× Invalid assignment target [ZNTC0517]
```

## Root cause

`parser/cover.zig:coverExpressionToAssignmentTarget` 가 TS wrapper expression
들 중 `ts_as_expression` / `ts_satisfies_expression` 은 inner expression 으로
unwrap 했지만 **`ts_non_null_expression`** 은 빠뜨려 `else` fall-through → invalid
target 처리.

## 변경

case 추가 — 같은 unwrap 패턴 (4 lines):

```zig
.ts_non_null_expression => {
    const inner = node.data.unary.operand;
    return try self.coverExpressionToAssignmentTarget(inner, is_top);
},
```

## Babel 비교 검증

`@babel/parser` TypeScript plugin — 모두 OK: postfix (++/--), simple assignment
(=), compound assignment (+=, -=).

## Test plan

- [x] failing test → red
- [x] fix → green
- [x] 8 회귀 가드 case (postfix + simple + compound × 다양한 lhs)
- [x] real input (`@jridgewell/gen-mapping/src/set-array.ts`) 정상 transpile
- [x] /simplify finding 반영: compound assignment test 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)