### PR TITLE
refactor(linker): share esm init expr body between writer & alloc paths

### DIFF
--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -29,7 +29,9 @@ const isReservedName = Linker.isReservedName;
 const NamePair = PreambleWriter.NamePair;
 const NS_VAR_PREFIX = linker_mod.NS_VAR_PREFIX;
 const EXPR_RENAME_MARKER = linker_mod.EXPR_RENAME_MARKER;
-const allocEsmInitExpr = @import("shared_namespace.zig").allocEsmInitExpr;
+const shared_ns = @import("shared_namespace.zig");
+const allocEsmInitExpr = shared_ns.allocEsmInitExpr;
+const writeEsmInitExprBody = shared_ns.writeEsmInitExprBody;
 
 inline fn cjsInteropMode(self: *const Linker, importer: *const Module) types.Interop {
     if (self.graph.resolve_cache.platform == .react_native) return .babel;
@@ -111,17 +113,7 @@ fn appendEsmInitCall(self: *const Linker, preamble: anytype, target_mod: *const 
     const is_tla = target_mod.uses_top_level_await;
     const guard = target_mod.shouldGuard(self.entry_error_guard);
     if (is_tla) try preamble.write("await ");
-    if (guard) try preamble.write(if (self.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN);
-    if (self.dev_mode) {
-        try preamble.write("__zntc_modules[\"");
-        try preamble.write(target_mod.dev_id);
-        try preamble.write("\"].fn()");
-    } else {
-        const init_name = try target_mod.allocInitName(self.allocator);
-        defer self.allocator.free(init_name);
-        try preamble.write(init_name);
-        try preamble.write("()");
-    }
+    try writeEsmInitExprBody(self, preamble, target_mod, guard);
     try preamble.write(if (guard) rt.GUARD_LAMBDA_CLOSE else rt.INIT_CALL_END);
 }
 

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -613,30 +613,49 @@ fn allocEsmInitExprForModuleIndex(self: *const Linker, mod_idx: u32) std.mem.All
 }
 
 pub fn allocEsmInitExpr(self: *const Linker, target_mod: *const Module) std.mem.Allocator.Error![]const u8 {
-    const guard_close_expr = "})";
     const guard = target_mod.shouldGuard(self.entry_error_guard);
-    if (self.dev_mode) {
-        if (guard) {
-            return try std.fmt.allocPrint(
-                self.allocator,
-                "{s}__zntc_modules[\"{s}\"].fn(){s}",
-                .{ if (self.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN, target_mod.dev_id, guard_close_expr },
-            );
-        }
-        return try std.fmt.allocPrint(self.allocator, "__zntc_modules[\"{s}\"].fn()", .{target_mod.dev_id});
-    }
-
-    const init_name = try target_mod.allocInitName(self.allocator);
-    defer self.allocator.free(init_name);
-    if (guard) {
-        return try std.fmt.allocPrint(
-            self.allocator,
-            "{s}{s}(){s}",
-            .{ if (self.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN, init_name, guard_close_expr },
-        );
-    }
-    return try std.fmt.allocPrint(self.allocator, "{s}()", .{init_name});
+    // 일반 init 식 길이가 30~90B (`__zntc_modules["..."].fn()` + guard wrap).
+    // 96B 로 1회 alloc 하면 grow realloc 없이 toOwnedSlice 시 trim 만 발생.
+    var buf = try std.ArrayList(u8).initCapacity(self.allocator, 96);
+    errdefer buf.deinit(self.allocator);
+    var adapter = ArrayListWriter{ .buf = &buf, .allocator = self.allocator };
+    try writeEsmInitExprBody(self, &adapter, target_mod, guard);
+    if (guard) try buf.appendSlice(self.allocator, "})");
+    return try buf.toOwnedSlice(self.allocator);
 }
+
+/// `appendEsmInitCall` (statement) / `allocEsmInitExpr` (expression) 의 공통 init 식 본문.
+/// await prefix 와 close 토큰 (statement `;});\n`/`;\n` vs expression `})`/없음) 만
+/// caller 가 결정한다. `guard` 는 양쪽 caller 가 close 토큰 결정 시에도 필요해 외부에서 1회 계산.
+pub fn writeEsmInitExprBody(
+    self: *const Linker,
+    writer: anytype,
+    target_mod: *const Module,
+    guard: bool,
+) !void {
+    if (guard) try writer.write(if (self.minify_whitespace) rt.GUARD_LAMBDA_OPEN_MIN else rt.GUARD_LAMBDA_OPEN);
+    if (self.dev_mode) {
+        try writer.write("__zntc_modules[\"");
+        try writer.write(target_mod.dev_id);
+        try writer.write("\"].fn()");
+    } else {
+        const init_name = try target_mod.allocInitName(self.allocator);
+        defer self.allocator.free(init_name);
+        try writer.write(init_name);
+        try writer.write("()");
+    }
+}
+
+/// anytype 슬롯 어댑터 — PreambleWriter 와 동일한 `.write([]const u8) !void` 인터페이스로
+/// ArrayList 에 모은다. PreambleWriter 직접 사용 시 `toOwned` 가 dupe + deinit 라 alloc 1회
+/// 추가 → toOwnedSlice 이전을 쓰기 위해 별도 어댑터.
+const ArrayListWriter = struct {
+    buf: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+    pub inline fn write(self: *ArrayListWriter, s: []const u8) std.mem.Allocator.Error!void {
+        try self.buf.appendSlice(self.allocator, s);
+    }
+};
 
 /// JS 예약어인 export 이름은 프로퍼티 키에 따옴표 필요.
 fn needsPropertyQuoteForExport(name: []const u8) bool {


### PR DESCRIPTION
## 배경

`metadata.zig:appendEsmInitCall` (preamble writer 경로) 와 `shared_namespace.zig:allocEsmInitExpr` (allocated string 경로) 가 동일한 init 식 본문 (\`init_X()\` / \`__zntc_modules[\"...\"].fn()\` + guard lambda wrap) 을 각자 emit 했다. 매 simplify 리뷰마다 일관되게 지적되던 dedupe target.

## 변경

- 공통 본문을 `writeEsmInitExprBody(self, writer, target_mod, guard)` 로 추출. `writer: anytype` duck-typed `.write([]const u8) !void` 로 양쪽 caller 대응.
- `appendEsmInitCall` 은 await prefix + body + statement close (\`;});\\n\` 또는 \`;\\n\`) 만 결정.
- `allocEsmInitExpr` 은 expression close (\`})\` 또는 없음) 만 결정.
- `allocEsmInitExpr` 의 buffer 어댑터 `ArrayListWriter` 추가. PreambleWriter 의 \`toOwned\` 가 dupe + deinit 라 alloc 1회 더 발생 → 별도 어댑터 + \`toOwnedSlice\` 로 ownership 이전.
- 식 길이 30~90B 분포에 맞춰 \`initCapacity(96)\` 로 시작 → grow realloc 제거 (1회 alloc + trim 만).

## 효과

- 동작 변경 없음 (외부 출력 byte-identical).
- 향후 init 식 포맷 변경 시 한 곳만 수정.
- alloc 경로의 realloc 횟수 3-4회 → 1회 + trim.

## Test plan

- [x] \`zig build test\` 전체 통과
- [x] \`tests/integration\` RN dev/smoke 165 tests pass