### PR TITLE
fix(rn-dev): support Rozenite serializer polyfills

### DIFF
--- a/packages/core/bin/rn-dev-input.mjs
+++ b/packages/core/bin/rn-dev-input.mjs
@@ -15,7 +15,7 @@ const UNSUPPORTED_FIELDS = [
   ['transformer', 'minifier'],
   ['serializer', 'bundleType'],
   ['serializer', 'getModulesRunBeforeMainModule'],
-  ['serializer', 'getPolyfills'],
+  ['serializer', 'getRunModuleStatement'],
   ['serializer', 'shouldAddToIgnoreList'],
   // dummy placeholder — bungae 도 declared-but-unused.
   ['server', 'verifyConnections'],
@@ -32,6 +32,39 @@ function warnUnsupported(config) {
       process.stderr.write(`[zntc:rn-dev] config.${section}.${key} (zntc 미지원, ignore)\n`);
     }
   }
+}
+
+function normalizeStringArray(value, label) {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    throw new TypeError(`config.serializer.${label} must be a string array`);
+  }
+  for (const item of value) {
+    if (typeof item !== 'string') {
+      throw new TypeError(`config.serializer.${label} must contain only strings`);
+    }
+  }
+  return value;
+}
+
+function getSerializerPolyfills(serializer, opts = {}) {
+  const polyfills = [];
+
+  const platform = opts.rnPlatform === 'android' ? 'android' : 'ios';
+  if (typeof serializer.getPolyfills === 'function') {
+    const generated = serializer.getPolyfills({ platform });
+    if (generated && typeof generated.then === 'function') {
+      throw new TypeError('async config.serializer.getPolyfills() is not supported');
+    }
+    polyfills.push(...normalizeStringArray(generated, 'getPolyfills() result'));
+  }
+
+  // Metro prepends getPolyfills() and then appends serializer.polyfillModuleNames.
+  polyfills.push(...normalizeStringArray(serializer.polyfillModuleNames, 'polyfillModuleNames'));
+  // ZNTC also keeps the existing serializer.polyfills compatibility field.
+  polyfills.push(...normalizeStringArray(serializer.polyfills, 'polyfills'));
+
+  return polyfills.length > 0 ? polyfills : undefined;
 }
 
 /**
@@ -57,7 +90,7 @@ export function buildRnBundleExtra(config, opts = {}) {
     fallback: resolver.extraNodeModules ?? undefined,
     metroResolveRequest: resolver.resolveRequest ?? undefined,
     babelTransformerPath: transformer.babelTransformerPath ?? undefined,
-    polyfills: serializer.polyfills ?? undefined,
+    polyfills: getSerializerPolyfills(serializer, opts),
     extraVars: serializer.extraVars ?? undefined,
     prelude: serializer.prelude ?? undefined,
     babel: transformer.babel ?? undefined,

--- a/packages/core/test/cli/react-native-dev-input/bundle-options/serializer.ts
+++ b/packages/core/test/cli/react-native-dev-input/bundle-options/serializer.ts
@@ -11,6 +11,38 @@ describe('buildRnDevServerInput — serializer bundle option config 추출 (#260
     expect(input?.bundle.extra?.polyfills).toEqual(['./shims/myPolyfill.js']);
   });
 
+  test('config.serializer.getPolyfills → Metro signature 로 bundle.extra.polyfills 매핑', async () => {
+    const buildRnDevServerInput = await loadBuildRnDevServerInput();
+    const input = buildRnDevServerInput(
+      { entryPoints: ['i.js'], rnPlatform: 'android' },
+      {
+        serializer: {
+          getPolyfills: ({ platform }: { platform: string }) => [`./shims/${platform}.js`],
+        },
+      },
+    );
+    expect(input?.bundle.extra?.polyfills).toEqual(['./shims/android.js']);
+  });
+
+  test('config.serializer.getPolyfills + polyfillModuleNames + polyfills 순서 보존', async () => {
+    const buildRnDevServerInput = await loadBuildRnDevServerInput();
+    const input = buildRnDevServerInput(
+      { entryPoints: ['i.js'] },
+      {
+        serializer: {
+          getPolyfills: () => ['./shims/from-getPolyfills.js'],
+          polyfillModuleNames: ['./shims/from-polyfillModuleNames.js'],
+          polyfills: ['./shims/from-polyfills.js'],
+        },
+      },
+    );
+    expect(input?.bundle.extra?.polyfills).toEqual([
+      './shims/from-getPolyfills.js',
+      './shims/from-polyfillModuleNames.js',
+      './shims/from-polyfills.js',
+    ]);
+  });
+
   test('config.serializer.extraVars → bundle.extra.extraVars 매핑', async () => {
     const buildRnDevServerInput = await loadBuildRnDevServerInput();
     const input = buildRnDevServerInput(

--- a/packages/core/test/cli/react-native-dev-input/warnings.ts
+++ b/packages/core/test/cli/react-native-dev-input/warnings.ts
@@ -9,7 +9,7 @@ describe('buildRnDevServerInput — unsupported field warnings (#2605)', () => {
         { entryPoints: ['i.js'] },
         {
           transformer: { inlineRequires: true, minifier: 'terser' },
-          serializer: { bundleType: 'module' },
+          serializer: { bundleType: 'module', getRunModuleStatement: () => '__r(0);' },
           server: { forwardClientLogs: true, verifyConnections: true },
         },
       );
@@ -18,6 +18,7 @@ describe('buildRnDevServerInput — unsupported field warnings (#2605)', () => {
     expect(output).toContain('transformer.inlineRequires');
     expect(output).toContain('transformer.minifier');
     expect(output).toContain('serializer.bundleType');
+    expect(output).toContain('serializer.getRunModuleStatement');
     expect(output).toContain('server.verifyConnections');
     expect(output).not.toContain('transformer.babel');
     expect(output).not.toContain('serializer.prelude');

--- a/src/codegen/calls.zig
+++ b/src/codegen/calls.zig
@@ -31,7 +31,7 @@ pub fn emitCall(self: anytype, node: Node) !void {
     try self.emitNode(callee);
     if (is_optional) try self.write("?.");
     try self.writeByte('(');
-    try self.emitNodeList(args_start, args_len, self.listSep());
+    try self.emitExpressionNodeList(args_start, args_len, self.listSep());
     try self.writeByte(')');
 }
 
@@ -402,7 +402,7 @@ pub fn emitNew(self: anytype, node: Node) !void {
     try self.emitNode(callee);
     if (needs_parens) try self.writeByte(')');
     try self.writeByte('(');
-    try self.emitNodeList(args_start, args_len, self.listSep());
+    try self.emitExpressionNodeList(args_start, args_len, self.listSep());
     try self.writeByte(')');
 }
 

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -362,6 +362,32 @@ pub const Codegen = struct {
             try self.emitNode(node_idx);
         }
     }
+
+    pub fn emitExpressionList(self: *Codegen, node: Node, sep: []const u8) !void {
+        const list = node.data.list;
+        try self.emitExpressionNodeList(list.start, list.len, sep);
+    }
+
+    pub fn emitExpressionNodeList(self: *Codegen, start: u32, len: u32, sep: []const u8) !void {
+        if (len == 0) return;
+        const indices = self.ast.extra_data.items[start .. start + len];
+        var first = true;
+        for (indices) |raw_idx| {
+            const node_idx: NodeIndex = @enumFromInt(raw_idx);
+            if (node_idx.isNone()) continue;
+            if (self.isSkipped(node_idx)) continue;
+            if (!first) try self.write(sep);
+            first = false;
+            try self.emitExpressionListItem(node_idx);
+        }
+    }
+
+    pub fn emitExpressionListItem(self: *Codegen, node_idx: NodeIndex) !void {
+        const needs_parens = self.ast.getNode(node_idx).tag == .sequence_expression;
+        if (needs_parens) try self.writeByte('(');
+        try self.emitNode(node_idx);
+        if (needs_parens) try self.writeByte(')');
+    }
 };
 
 pub const hasRawPrivateSyntax = @import("../parser/ast_walk.zig").hasRawPrivateSyntax;

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -350,25 +350,21 @@ pub const Codegen = struct {
     }
 
     pub fn emitNodeList(self: *Codegen, start: u32, len: u32, sep: []const u8) !void {
-        if (len == 0) return;
-        const indices = self.ast.extra_data.items[start .. start + len];
-        var first = true;
-        for (indices) |raw_idx| {
-            const node_idx: NodeIndex = @enumFromInt(raw_idx);
-            if (node_idx.isNone()) continue;
-            if (self.isSkipped(node_idx)) continue;
-            if (!first) try self.write(sep);
-            first = false;
-            try self.emitNode(node_idx);
-        }
+        try emitNodeListImpl(self, start, len, sep, false);
     }
 
     pub fn emitExpressionList(self: *Codegen, node: Node, sep: []const u8) !void {
         const list = node.data.list;
-        try self.emitExpressionNodeList(list.start, list.len, sep);
+        try emitNodeListImpl(self, list.start, list.len, sep, true);
     }
 
     pub fn emitExpressionNodeList(self: *Codegen, start: u32, len: u32, sep: []const u8) !void {
+        try emitNodeListImpl(self, start, len, sep, true);
+    }
+
+    // `wrap_sequences` 가 true 이면 a, b 형태의 sequence_expression 항목을 괄호로 감싼다.
+    // call/new arg list, array literal 처럼 콤마가 항목 구분자인 컨텍스트에서만 필요.
+    fn emitNodeListImpl(self: *Codegen, start: u32, len: u32, sep: []const u8, comptime wrap_sequences: bool) !void {
         if (len == 0) return;
         const indices = self.ast.extra_data.items[start .. start + len];
         var first = true;
@@ -378,15 +374,11 @@ pub const Codegen = struct {
             if (self.isSkipped(node_idx)) continue;
             if (!first) try self.write(sep);
             first = false;
-            try self.emitExpressionListItem(node_idx);
+            const wrap = wrap_sequences and self.ast.getNode(node_idx).tag == .sequence_expression;
+            if (wrap) try self.writeByte('(');
+            try self.emitNode(node_idx);
+            if (wrap) try self.writeByte(')');
         }
-    }
-
-    pub fn emitExpressionListItem(self: *Codegen, node_idx: NodeIndex) !void {
-        const needs_parens = self.ast.getNode(node_idx).tag == .sequence_expression;
-        if (needs_parens) try self.writeByte('(');
-        try self.emitNode(node_idx);
-        if (needs_parens) try self.writeByte(')');
     }
 };
 

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -3253,6 +3253,17 @@ test "ES5: async for-in body extracts await into state machine" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "_state.sent()") != null);
 }
 
+test "ES5: async return sequence stays one generator return value" {
+    var r = try e2eES5Async(std.testing.allocator,
+        \\async function setup() {
+        \\  return hook(), { onMessage: 1 };
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "return [2,(hook(),{onMessage:1})]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "return [2,hook(),{onMessage:1}]") == null);
+}
+
 test "ES5: async switch case block extracts await" {
     var r = try e2eES5Async(std.testing.allocator,
         \\async function requestCamera(result) {

--- a/src/codegen/expressions.zig
+++ b/src/codegen/expressions.zig
@@ -215,7 +215,7 @@ pub fn emitYield(self: anytype, node: Node) !void {
 pub fn emitArray(self: anytype, node: Node) !void {
     try self.addSourceMapping(node.span);
     try self.writeByte('[');
-    try self.emitList(node, self.listSep());
+    try self.emitExpressionList(node, self.listSep());
     try self.writeByte(']');
 }
 


### PR DESCRIPTION
## 요약

- Metro `serializer.getPolyfills()`를 RN dev input에서 읽어 `bundle.extra.polyfills`로 전달합니다.
- `serializer.polyfillModuleNames`, 기존 `serializer.polyfills`와 함께 Metro 순서에 맞게 병합합니다.
- 배열 요소와 call/new 인자 같은 expression list에서 top-level sequence expression을 괄호로 감싸도록 codegen을 보정했습니다.
- Rozenite plugin bridge의 async 반환값이 `undefined`로 떨어지던 문제를 회귀 테스트로 막았습니다.

## 배경

Rozenite plugin bridge의 minified CJS에는 `return addEventListener(listener), { send, onMessage, close }` 형태의 sequence expression이 있습니다. zntc의 ES5 async/generator lowering이 이를 `return [2, value]`로 감싸는 과정에서 sequence expression을 배열 요소로 출력할 때 괄호가 빠져 `return [2, addEventListener(...), { ... }]`가 되었고, generator runtime은 두 번째 슬롯만 완료값으로 보아 client 객체 대신 `undefined`가 반환되었습니다.

이번 수정은 generator 전용 특수처리가 아니라, expression list slot에서 sequence expression 의미가 보존되도록 공통 codegen 경로를 보정합니다.

## 검증

- `zig build test -Dtest-filter="async return sequence"`
- `bun test ./packages/core/test/cli/react-native-dev-input/bundle-options/serializer.ts ./packages/core/test/cli/react-native-dev-input/warnings.ts`
- `bun run --cwd packages/core build:napi`
- `bun run --cwd packages/core build:js`
- Payhere mobile-seller dev server에서 `/rozenite/rn_fusebox.html` 200 확인
- Payhere iOS `index.bundle` 200 확인
- 생성 번들에서 Rozenite bridge 반환이 `return [2, (addEventListener(...), { send, onMessage, close })]` 형태로 출력되는 것 확인

## 참고

- 이슈: #3168