### PR TITLE
fix(transpile): auto type-only export elision honors declaration merging

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1208,6 +1208,13 @@ pub const Ast = struct {
         self.nodes.items[@intFromEnum(index)].tag = new_tag;
     }
 
+    /// `binary` shape 노드 (예: `import_specifier` / `export_specifier`) 의 flags
+    /// bitfield 만 갱신. semantic 단계에서 type-only 같은 후속 정보를 marker 로
+    /// 박을 때 사용 (전체 node 교체 회피).
+    pub fn setBinaryFlags(self: *Ast, index: NodeIndex, new_flags: u16) void {
+        self.nodes.items[@intFromEnum(index)].data.binary.flags = new_flags;
+    }
+
     /// 노드 in-place 교체. 주로 transformer 의 cover-grammar / await→yield rewrite 같이
     /// 하위 트리는 보존하면서 같은 인덱스의 tag/data 만 새 형태로 바꿀 때. span 은 caller 가
     /// 보존하든 변경하든 자유 — 일반적으로는 source 위치 유지를 위해 기존 span 유지.

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -3172,6 +3172,11 @@ pub const SemanticAnalyzer = struct {
                 if (spec_idx.isNone() or @intFromEnum(spec_idx) >= self.ast.nodes.items.len) continue;
                 const spec_node = self.ast.getNode(spec_idx);
                 if (spec_node.tag == .export_specifier) {
+                    // markAutoTypeOnlyExportSpecifiers (transpile.zig) 가 이미 type-only 로
+                    // 마킹한 specifier 는 transformer 가 자동 drop 한다. 시맨틱 검증 (binding
+                    // 존재 / value 사용) 전부 skip — 출력에서 사라질 노드라 검증 무의미.
+                    if ((spec_node.data.binary.flags & module_parser.SPEC_FLAG_TYPE_ONLY) != 0) continue;
+
                     // exported name = right (the "as" name, or same as local if no "as")
                     const exported_idx = spec_node.data.binary.right;
                     if (!exported_idx.isNone() and @intFromEnum(exported_idx) < self.ast.nodes.items.len) {

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -555,6 +555,234 @@ fn collectBindingLite(allocator: std.mem.Allocator, ast: *const Ast) !BindingLit
     return lite;
 }
 
+/// Babel `preset-typescript` 의 자동 type-only export elision 을 모든 변환 경로에서
+/// 재현. transformer 의 `.export_specifier` 디스패치가 SPEC_FLAG_TYPE_ONLY 비트를 보고
+/// 자동 drop 하므로, 비트만 일관되게 마킹하면 .none / .bindings / .full 모두 동일 출력.
+///
+/// **호출 시점**: `SemanticAnalyzer.analyze()` 호출 전. .full 경로의 analyzer 가
+/// 마킹된 비트를 보고 specifier 검증을 skip 한다. .none / .bindings 도 동일 비트 기반.
+///
+/// **두 패스**:
+///   pass 1 (top-level statement walk): value binding name (var/let/const/function/class
+///   /enum, import default/namespace/named-value) 과 type-only binding name (type alias,
+///   interface, import-type specifier) 을 각각 set 에 수집. declaration merging
+///   (`const X = 1; type X = ...;`) 처리를 위해 value 가 type 보다 우선.
+///   pass 2 (export_named_declaration scan): source 없는 `export { x }` 의 specifier
+///   중 local 이 value_names 에 없고 type_only_names 에 있는 것만 비트 OR.
+///
+/// 재-export (`export { x } from './y'`) 는 로컬 binding 과 무관 → skip.
+/// `export { 'name' }` string literal local 도 식별자가 아니라 skip.
+fn markAutoTypeOnlyExportSpecifiers(
+    allocator: std.mem.Allocator,
+    ast: *Ast,
+) error{OutOfMemory}!void {
+    // program 의 top-level statements 만 본다. ES module spec: export 는 모듈 scope
+    // binding 만 reference. nested function 의 local var/type alias 는 export 와 무관.
+    var program_idx: ast_mod.NodeIndex = .none;
+    for (ast.nodes.items, 0..) |node, raw_idx| {
+        if (node.tag == .program) {
+            program_idx = @enumFromInt(raw_idx);
+            break;
+        }
+    }
+    if (program_idx.isNone()) return;
+    const prog_node = ast.getNode(program_idx);
+    const stmt_start = prog_node.data.list.start;
+    const stmt_len = prog_node.data.list.len;
+    if (stmt_len == 0) return;
+
+    var value_names: std.StringHashMapUnmanaged(void) = .empty;
+    defer value_names.deinit(allocator);
+    var type_only_names: std.StringHashMapUnmanaged(void) = .empty;
+    defer type_only_names.deinit(allocator);
+
+    // pass 1
+    var i: u32 = 0;
+    while (i < stmt_len) : (i += 1) {
+        const stmt_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[stmt_start + i]);
+        if (stmt_idx.isNone()) continue;
+        if (@intFromEnum(stmt_idx) >= ast.nodes.items.len) continue;
+        try collectAutoTypeOnlyDeclNames(allocator, ast, stmt_idx, &value_names, &type_only_names);
+    }
+
+    if (type_only_names.count() == 0) return;
+
+    // pass 2
+    for (ast.nodes.items) |node| {
+        if (node.tag != .export_named_declaration) continue;
+        const extra_start = node.data.extra;
+        const extras = ast.extra_data.items;
+        if (extra_start + 3 >= extras.len) continue;
+        const specs_start = extras[extra_start + 1];
+        const specs_len = extras[extra_start + 2];
+        const source_idx: ast_mod.NodeIndex = @enumFromInt(extras[extra_start + 3]);
+        if (!source_idx.isNone()) continue;
+        if (specs_len == 0 or specs_start + specs_len > extras.len) continue;
+
+        const spec_indices = extras[specs_start .. specs_start + specs_len];
+        for (spec_indices) |raw_idx| {
+            const spec_idx: ast_mod.NodeIndex = @enumFromInt(raw_idx);
+            if (spec_idx.isNone()) continue;
+            if (@intFromEnum(spec_idx) >= ast.nodes.items.len) continue;
+            const spec_node = ast.getNode(spec_idx);
+            if (spec_node.tag != .export_specifier) continue;
+            if ((spec_node.data.binary.flags & module_parser.SPEC_FLAG_TYPE_ONLY) != 0) continue;
+
+            const local_idx = spec_node.data.binary.left;
+            if (local_idx.isNone()) continue;
+            if (@intFromEnum(local_idx) >= ast.nodes.items.len) continue;
+            const local_node = ast.getNode(local_idx);
+            if (local_node.tag == .string_literal) continue;
+
+            const local_name = ast.getText(local_node.span);
+            // declaration merging: 동명의 value binding 이 있으면 type-only 마킹 skip.
+            // `const X = 1; type X = ...; export { X };` 같은 케이스에서 value 우선.
+            if (value_names.contains(local_name)) continue;
+            if (type_only_names.contains(local_name)) {
+                ast.setBinaryFlags(spec_idx, spec_node.data.binary.flags | module_parser.SPEC_FLAG_TYPE_ONLY);
+            }
+        }
+    }
+}
+
+/// `markAutoTypeOnlyExportSpecifiers` pass 1 의 statement-level 분기. top-level
+/// program statement 한 개를 처리.
+fn collectAutoTypeOnlyDeclNames(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    stmt_idx: ast_mod.NodeIndex,
+    value_names: *std.StringHashMapUnmanaged(void),
+    type_only_names: *std.StringHashMapUnmanaged(void),
+) error{OutOfMemory}!void {
+    const stmt = ast.getNode(stmt_idx);
+    switch (stmt.tag) {
+        // value bindings: function / class / enum / module(namespace) — extras[0] = name
+        .function_declaration,
+        .class_declaration,
+        .ts_enum_declaration,
+        .ts_module_declaration,
+        => try putNameAtExtraSlot(allocator, ast, stmt, 0, value_names),
+
+        // import X = require(...) — runtime value
+        .ts_import_equals_declaration => {
+            // binary: left=name, right=value
+            const left = stmt.data.binary.left;
+            try putNodeIdName(allocator, ast, left, value_names);
+        },
+
+        // variable_declaration: destructuring 포함 모든 binding identifier 추출.
+        // extras = [kind_flags, list_start, list_len]
+        .variable_declaration => {
+            const list_start = ast.extra_data.items[stmt.data.extra + 1];
+            const list_len = ast.extra_data.items[stmt.data.extra + 2];
+            var j: u32 = 0;
+            while (j < list_len) : (j += 1) {
+                const decl_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[list_start + j]);
+                if (decl_idx.isNone()) continue;
+                const decl = ast.getNode(decl_idx);
+                if (decl.tag != .variable_declarator) continue;
+                // variable_declarator extras[0] = binding pattern (또는 simple identifier)
+                const binding_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[decl.data.extra]);
+                try collectBindingIdentifierNames(allocator, ast, binding_idx, value_names);
+            }
+        },
+
+        // type-only declarations
+        .ts_type_alias_declaration,
+        .ts_interface_declaration,
+        => try putNameAtExtraSlot(allocator, ast, stmt, 0, type_only_names),
+
+        // import declaration: type-only spec / inline `type X` 는 type_only_names,
+        // 나머지 (default / namespace / named-value) 는 value_names
+        .import_declaration => {
+            const decl = module_parser.readImportDeclExtras(ast, stmt.data.extra);
+            var j: u32 = 0;
+            while (j < decl.specs_len) : (j += 1) {
+                const spec_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[decl.specs_start + j]);
+                if (spec_idx.isNone()) continue;
+                if (@intFromEnum(spec_idx) >= ast.nodes.items.len) continue;
+                const spec = ast.getNode(spec_idx);
+                const local_idx: ast_mod.NodeIndex = switch (spec.tag) {
+                    // import_specifier: binary { left=imported, right=local }
+                    .import_specifier => spec.data.binary.right,
+                    // import_default_specifier / import_namespace_specifier: extras[0] = local
+                    .import_default_specifier, .import_namespace_specifier => blk: {
+                        if (spec.data.extra >= ast.extra_data.items.len) break :blk .none;
+                        break :blk @enumFromInt(ast.extra_data.items[spec.data.extra]);
+                    },
+                    else => .none,
+                };
+                if (local_idx.isNone()) continue;
+                const is_type_only = decl.is_type_only or
+                    (spec.tag == .import_specifier and (spec.data.binary.flags & module_parser.SPEC_FLAG_TYPE_ONLY) != 0);
+                const bucket = if (is_type_only) type_only_names else value_names;
+                try putNodeIdName(allocator, ast, local_idx, bucket);
+            }
+        },
+
+        // export declaration 안의 nested decl 도 처리 (export const / type / interface / ...).
+        // extras = [decl, specs_start, specs_len, source, ...]
+        .export_named_declaration => {
+            const extra_start = stmt.data.extra;
+            if (extra_start >= ast.extra_data.items.len) return;
+            const decl_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[extra_start]);
+            if (decl_idx.isNone()) return;
+            if (@intFromEnum(decl_idx) >= ast.nodes.items.len) return;
+            // 재귀 분기 — declaration 자체의 binding 만 등록 (specifier 는 pass 2 에서 처리)
+            try collectAutoTypeOnlyDeclNames(allocator, ast, decl_idx, value_names, type_only_names);
+        },
+
+        else => {},
+    }
+}
+
+fn putNameAtExtraSlot(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    node: ast_mod.Node,
+    slot: u32,
+    bucket: *std.StringHashMapUnmanaged(void),
+) error{OutOfMemory}!void {
+    const extra_start = node.data.extra;
+    if (extra_start + slot >= ast.extra_data.items.len) return;
+    const name_idx: ast_mod.NodeIndex = @enumFromInt(ast.extra_data.items[extra_start + slot]);
+    try putNodeIdName(allocator, ast, name_idx, bucket);
+}
+
+fn putNodeIdName(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    name_idx: ast_mod.NodeIndex,
+    bucket: *std.StringHashMapUnmanaged(void),
+) error{OutOfMemory}!void {
+    if (name_idx.isNone()) return;
+    if (@intFromEnum(name_idx) >= ast.nodes.items.len) return;
+    const name_node = ast.getNode(name_idx);
+    const name_text = ast.getText(name_node.span);
+    if (name_text.len == 0) return;
+    try bucket.put(allocator, name_text, {});
+}
+
+/// binding pattern (identifier / array / object pattern) 안의 모든 binding identifier
+/// 텍스트를 bucket 에 모은다. `const { a: b, c = 1, ...rest } = x;` 같은 destructuring
+/// 도 b / c / rest 가 value binding.
+fn collectBindingIdentifierNames(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    idx: ast_mod.NodeIndex,
+    bucket: *std.StringHashMapUnmanaged(void),
+) error{OutOfMemory}!void {
+    if (idx.isNone()) return;
+    if (@intFromEnum(idx) >= ast.nodes.items.len) return;
+    var it = try ast_walk.bindingIdentifiers(ast.allocator, ast, idx, .{ .cover_grammar_assignment = false });
+    defer it.deinit();
+    while (try it.next()) |leaf_idx| {
+        const leaf = ast.getNode(leaf_idx);
+        const name = ast.getText(leaf.span);
+        if (name.len > 0) try bucket.put(allocator, name, {});
+    }
+}
+
 fn markBindingLiteUse(lite: *BindingLite, name: []const u8, shadowed_names: []const []const u8) void {
     if (string_list.contains(shadowed_names, name)) return;
     for (lite.named_imports) |*binding| {
@@ -947,6 +1175,17 @@ fn transpileWithCallbackInternal(
     );
 
     // 2. Semantic analysis
+    // TS 모듈에서 `type X = ...; export { X };` 같은 패턴을 자동 type-only export 로
+    // elision (Babel preset-typescript 동작). analyzer 진입 전 pre-pass 로 SPEC_FLAG_TYPE_ONLY
+    // 비트를 마킹 → transformer 의 `.export_specifier` 디스패치가 자동 drop. .full /
+    // .bindings / .none 모든 경로에서 동일 비트 기반.
+    //
+    // Flow 는 별도 type system 이라 제외 (flow_ 태그 처리는 별도 영역). non-TS 입력은
+    // type alias 자체가 없어 helper 가 early return.
+    if (parser.source_mode == .ts and !parser.is_flow) {
+        try markAutoTypeOnlyExportSpecifiers(arena_alloc, &parser.ast);
+    }
+
     var analyzer_storage: ?SemanticAnalyzer = null;
     var binding_lite_storage: ?BindingLite = null;
     if (transform_plan.semantic == .full) {
@@ -1242,6 +1481,39 @@ fn testTransformPlan(source: []const u8, file_path: []const u8, options: Transpi
     try std.testing.expectEqual(@as(usize, 0), parser.errors.items.len);
 
     return buildTransformPlan(options, &parser, &parser.ast, false);
+}
+
+/// fast 와 full 양쪽 경로의 출력이 expected 와 일치하는지 검증. parity 만으로는
+/// 둘이 *동일하게 잘못된* 출력을 내도 통과해버리므로, expected ground truth (Babel
+/// preset-typescript 출력 기반) 도 함께 확정.
+fn expectTranspileOutput(
+    source: []const u8,
+    expected: []const u8,
+    file_path: []const u8,
+    options: TranspileOptions,
+) !void {
+    var fast = try transpileWithCallbackInternal(
+        std.testing.allocator,
+        source,
+        file_path,
+        options,
+        null,
+        false,
+    );
+    defer fast.deinit(std.testing.allocator);
+
+    var full = try transpileWithCallbackInternal(
+        std.testing.allocator,
+        source,
+        file_path,
+        options,
+        null,
+        true,
+    );
+    defer full.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualStrings(expected, fast.code);
+    try std.testing.expectEqualStrings(expected, full.code);
 }
 
 fn expectFastFullParity(
@@ -1579,6 +1851,31 @@ test "TransformPlan parity: fast TS strip matches full semantic output" {
             \\export const action: () => void = () => {};
             ,
         },
+        // D10 (ajv jtd.ts): `type X = ...; export { X };` — Babel preset-typescript 의
+        // 자동 type-only export elision. full semantic 은 SPEC_FLAG_TYPE_ONLY 마킹으로
+        // specifier 를 제거하므로 fast path 도 동일 출력이어야 한다.
+        .{
+            .name = "auto type-only export elision (type alias)",
+            .source =
+            \\type JTDOptions = { a: number };
+            \\export { JTDOptions };
+            ,
+        },
+        .{
+            .name = "auto type-only export elision (interface)",
+            .source =
+            \\interface IFoo { a: number }
+            \\export { IFoo };
+            ,
+        },
+        .{
+            .name = "auto type-only export elision (mixed type + value)",
+            .source =
+            \\type Bar = number;
+            \\const baz = 1;
+            \\export { Bar, baz };
+            ,
+        },
     };
 
     for (cases) |case| {
@@ -1587,6 +1884,71 @@ test "TransformPlan parity: fast TS strip matches full semantic output" {
             return err;
         };
     }
+}
+
+// D10 declaration merging — type alias 와 동명 value (const / class / function 등) 가
+// 공존하면 value 우선이어야 한다 (Babel preset-typescript 동작). 이전 회귀: 모든
+// 경로에서 export 가 잘못 drop 되어 runtime ReferenceError 가 발생했다. parity 테스트는
+// "fast/full 둘 다 똑같이 잘못된" 케이스도 통과시키므로 expected output 으로 ground
+// truth 확정.
+test "TS auto type-only export: declaration merging preserves value binding" {
+    try expectTranspileOutput(
+        \\const X = 1;
+        \\type X = number;
+        \\export { X };
+        \\
+    ,
+        \\const X = 1;
+        \\export { X };
+        \\
+    ,
+        "input.ts",
+        .{},
+    );
+
+    try expectTranspileOutput(
+        \\class C {}
+        \\type C = string;
+        \\export { C };
+        \\
+    ,
+        \\class C {
+        \\}
+        \\export { C };
+        \\
+    ,
+        "input.ts",
+        .{},
+    );
+
+    try expectTranspileOutput(
+        \\function f() {}
+        \\type f = number;
+        \\export { f };
+        \\
+    ,
+        \\function f() {
+        \\}
+        \\export { f };
+        \\
+    ,
+        "input.ts",
+        .{},
+    );
+
+    // enum 은 value (IIFE 형태로 전개되어도 export 가 유지되어야 함)
+    try expectTranspileOutput(
+        \\enum E { A }
+        \\export { E };
+        \\
+    ,
+        \\var E = /* @__PURE__ */ ((E) => {E[E["A"]=0]="A";return E;})(E || {});
+        \\export { E };
+        \\
+    ,
+        "input.ts",
+        .{},
+    );
 }
 
 test "TransformPlan parity: binding-lite named import elision matches full semantic output" {


### PR DESCRIPTION
## Summary

`type X = ...; export { X };` 패턴의 X 가 type-only 면 자동 elide (Babel `preset-typescript` 동작과 정렬). 핵심: 동명의 value binding 이 있으면 value 우선 — declaration merging 케이스에서 export 가 잘못 drop 되어 runtime `ReferenceError` 가 발생하던 회귀 fix.

## 재현 (fix 전)

```ts
const X = 1;
type X = number;
export { X };
```

ZNTC 출력 (fix 전):
```js
const X = 1;
```
→ `export { X };` 가 통째로 drop. 동명 type alias 의 영향으로 잘못 type-only 마킹.

Babel 출력:
```js
const X = 1;
export { X };
```

## 영향

- ajv `jtd.ts` 의 `type JTDOptions; export { JTDOptions };` 자동 elide (정상 동작) 만 처리하던 D10 의 1차 fix 가 declaration merging / `import type` specifier / switch arm 오염을 함께 회귀시켰음. 이번 PR 이 3종 모두 fix.

## 변경

- 신규 `markAutoTypeOnlyExportSpecifiers` (src/transpile.zig): program top-level 두 패스. pass 1 에서 value 와 type-only binding 이름을 동시에 수집. pass 2 에서 source 없는 export specifier 중 value not-in + type-only in 인 local 만 `SPEC_FLAG_TYPE_ONLY` 비트 OR. transformer 가 비트 기반 자동 drop.
- 호출 시점: `analyze()` 진입 전. `.full` / `.bindings` / `.none` 모든 경로 동일 비트 사용 (fast-path 와 full-semantic 출력 동치성 보장).
- analyzer 의 switch arm 오염 fix: 22 TS 태그 공유 arm 에 들어 있어 `.ts_function_type` 등의 `extras[0]` 을 name 으로 잘못 해석하던 코드 제거. `type_only_decl_names` 필드 / `checkExportBinding` lookup 도 동시 제거 (helper 가 마킹 후 spec 의 비트로 자연 skip).
- `Ast.setBinaryFlags`: binary 노드 flags bitfield in-place mutation helper.

## 다루는 케이스

| 케이스 | Babel | ZNTC (fix 후) |
|---|---|---|
| `type X; export {X}` | `export {};` | `` (empty) — codegen 가 빈 export 통 drop, 별개 이슈 |
| `const X; type X; export {X}` | `const X=1; export {X};` | 동일 ✓ |
| `class C; type C; export {C}` | parse error | `class C{}; export {C};` (TS 합법) ✓ |
| `function f; type f; export {f}` | `function f(){}; export {f};` | 동일 ✓ |
| `enum E; export {E}` | enum IIFE + export | 동일 ✓ |
| `type Bar; const baz; export {Bar,baz}` | `const baz=1; export {baz};` | 동일 ✓ |
| `import type {Foo}; type Bar; export {Foo,Bar}` | `export {};` | 비어있음 (둘 다 type-only) ✓ |

## Test plan

- [x] `zig build test` 전체 통과 (Debug)
- [x] `zig build test -Doptimize=ReleaseFast` 통과
- [x] 9 케이스 Babel 출력 vs ZNTC 출력 1:1 측정
- [x] 회귀 가드: const/class/function/enum + 동명 type alias merging 케이스 expected output 비교 (parity-only 검증 보완 — fast/full 둘 다 잘못된 동일 출력에도 통과시켜 버리던 사각지대 메움)
- [x] /simplify 3 agent 병렬 review 통과 (cross-file / 메모리 ownership / Babel 호환성 — 3가지 critical bug 발견 후 fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)