### PR TITLE
fix(parser): detect typed arrow when params end with trailing comma

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1791,6 +1791,13 @@ pub const Parser = struct {
             if (self.current() == .comma) {
                 while (self.current() == .comma) {
                     try self.advance(); // skip ,
+                    // trailing comma 케이스: `(a, b, c,): T => ...` — 마지막 `,` 다음 곧장
+                    // `)`. 모든 파라미터에 type annotation 이 없어도 return type 으로 typed
+                    // arrow 판별 가능. @reduxjs/toolkit listenerMiddleware.test-d.ts.
+                    if (self.current() == .r_paren) {
+                        try self.advance();
+                        return self.current() == .colon and !self.in_ternary_consequent;
+                    }
                     // rest parameter with type
                     if (self.current() == .dot3) return true;
                     // destructuring with type

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -3277,6 +3277,21 @@ test "TS: typed arrow with default-value parameters" {
     try expectNoParseErrorWithExt("const f = (x = 0): number => x;", ".ts");
 }
 
+test "TS: typed arrow with all untyped params + return type predicate (D11)" {
+    // @reduxjs/toolkit listenerMiddleware.test-d.ts 의 패턴 — 모든 파라미터에 타입
+    // annotation 이 없고 return type 만 type predicate. `isTypedArrowFunction` 의
+    // comma loop 가 trailing comma 후 `)` 를 처리하지 않아 일반 paren expression 으로
+    // 잘못 분기되던 회귀.
+    try expectNoParseErrorWithExt("const f = (a, b, c): a is string => true;", ".ts");
+    // trailing comma 가 핵심 — Babel 도 동일 처리.
+    try expectNoParseErrorWithExt("const f = (a, b, c,): a is string => true;", ".ts");
+    // 일반 return type annotation 도 동일 경로.
+    try expectNoParseErrorWithExt("const f = (a, b, c): number => 0;", ".ts");
+    try expectNoParseErrorWithExt("const f = (a, b, c,): number => 0;", ".ts");
+    // async 도 동일 경로 (expression.zig 의 async-paren 분기가 isTypedArrowFunction 호출).
+    try expectNoParseErrorWithExt("const f = async (a, b, c,): Promise<number> => 0;", ".ts");
+}
+
 test "Flow: nullable return type with arrow" {
     // ?(T) return type이 function type이 아닌 nullable paren type으로 해석되어야 함
     try expectNoParseErrorFlow(


### PR DESCRIPTION
## Summary

`(a, b, c,): T => body` 형태의 typed arrow 가 `isTypedArrowFunction` 의 comma loop 에서 `} else { break; }` 로 빠져 일반 paren expression 으로 잘못 분기되던 회귀 fix. 모든 파라미터에 type annotation 이 없어도 return type annotation 으로 typed arrow 판별 가능 (Babel `preset-typescript` 와 동일).

## 재현 (fix 전)

```ts
foo({
  predicate: (
    action,
    currentState,
    previousState,
  ): action is UnknownAction => {
    return true;
  },
});
```

ZNTC parser error 5+ 발생 (`× } / × ) / × ; / × Expression expected`).

재현 소스: `@reduxjs/toolkit/src/listenerMiddleware/tests/listenerMiddleware.test-d.ts`.

## 원인

`src/parser/parser.zig` `isTypedArrowFunction` 의 comma loop:
1. `,` skip
2. `r_paren` 분기 없음
3. identifier/keyword 가 아니면 `} else { break; }`
4. 결과: trailing comma 다음 `)` 가 break 로 빠져 `return false`

→ 호출자가 paren-expression 으로 분기 → `): T => {` 가 invalid 표현으로 해석.

## 수정

comma 다음 곧장 `)` 면 `:` 검사로 typed arrow 판별 (line 1810 default-value 분기와 동일 패턴). `in_ternary_consequent` 가드 유지.

```zig
while (self.current() == .comma) {
    try self.advance(); // skip ,
    // NEW: trailing comma + r_paren
    if (self.current() == .r_paren) {
        try self.advance();
        return self.current() == .colon and !self.in_ternary_consequent;
    }
    ...
}
```

## 회귀 가드

- type predicate (`a is string`)
- 일반 return type (`number`)
- async paren 진입 (`async (a, b,): Promise<void> => {}`)
- trailing comma 유무 양쪽

## Babel 호환 검증

7 케이스 1:1 측정 (D11 핵심 4종 / nested / ternary / sequence-expression invalid 거부) 모두 Babel 동작과 일치.

## Test plan

- [x] `zig build test` 전체 통과
- [x] `zig build test -Doptimize=ReleaseFast` 통과
- [x] `listenerMiddleware.test-d.ts` 0 errors 로 transpile
- [x] /simplify 3 agent 병렬 review 통과 (cross-file / Babel 호환 / lookahead 안전성)

🤖 Generated with [Claude Code](https://claude.com/claude-code)