### PR TITLE
fix(parser): treat .d.ts files and declare global blocks as ambient

### DIFF
--- a/src/bundler/graph/parser_setup.zig
+++ b/src/bundler/graph/parser_setup.zig
@@ -31,6 +31,7 @@ pub fn init(
     parser.* = Parser.init(arena_alloc, scanner);
     const ext = std.fs.path.extension(module.path);
     configureParserForModule(parser, module, ext);
+    parser.configureAmbientFromPath(module.path);
 
     // Flow 모드: --flow CLI 또는 .js.flow/.jsx.flow 확장자 (pragma는 parse() 내부에서 감지)
     // TS 와 Flow 는 상호 배타 — TS 파일에서는 Flow 무시

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -360,6 +360,19 @@ pub const Parser = struct {
         }
     }
 
+    /// 파일 경로에서 `.d.ts` / `.d.mts` / `.d.cts` 이중 확장자를 감지하여 ambient
+    /// context 를 설정한다. `.d.ts` 의 모든 declaration 은 implicit `declare` — const
+    /// initializer / function body / class field initializer 강제가 적용되지 않는다.
+    /// `std.fs.path.extension()` 은 `.ts` 만 반환하므로 전체 경로 검사 필요.
+    pub fn configureAmbientFromPath(self: *Parser, file_path: []const u8) void {
+        if (std.mem.endsWith(u8, file_path, ".d.ts") or
+            std.mem.endsWith(u8, file_path, ".d.mts") or
+            std.mem.endsWith(u8, file_path, ".d.cts"))
+        {
+            self.ctx.in_ambient = true;
+        }
+    }
+
     /// 파일 경로에서 .js.flow / .jsx.flow 이중 확장자를 감지하여 Flow 모드를 설정한다.
     /// std.fs.path.extension()은 마지막 확장자(.flow)만 반환하므로
     /// 전체 경로를 확인해야 한다.

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -2751,6 +2751,17 @@ fn expectNoParseErrorWithExt(source: []const u8, ext: []const u8) !void {
     try std.testing.expectEqual(@as(usize, 0), parser.errors.items.len);
 }
 
+fn expectNoParseErrorWithPath(source: []const u8, file_path: []const u8) !void {
+    var scanner = try Scanner.init(std.testing.allocator, source);
+    defer scanner.deinit();
+    var parser = Parser.init(std.testing.allocator, &scanner);
+    defer parser.deinit();
+    parser.configureFromExtension(std.fs.path.extension(file_path));
+    parser.configureAmbientFromPath(file_path);
+    _ = try parser.parse();
+    try std.testing.expectEqual(@as(usize, 0), parser.errors.items.len);
+}
+
 fn expectParseErrorWithExt(source: []const u8, ext: []const u8, check: ErrorCheck) !void {
     var scanner = try Scanner.init(std.testing.allocator, source);
     defer scanner.deinit();
@@ -2837,6 +2848,37 @@ test "declare module: multiple statements in ambient body" {
     try expectNoParseErrorWithExt(
         \\declare module "*.svg" { const src: string; export default src; }
     , ".ts");
+}
+
+test "declare global: ambient const without initializer (D12)" {
+    // ethers `crypto-browser.ts` 의 `declare global { const window: Window; }` 패턴.
+    // `parseTsDeclareStatement` 의 global 분기가 `in_ambient` 를 전파하지 않아 자식
+    // const 가 일반 `const X: T;` 로 해석되어 `Const declarations must be
+    // initialized` 가 잘못 발생하던 회귀.
+    try expectNoParseErrorWithExt(
+        \\declare global {
+        \\  const window: Window;
+        \\  const self: WorkerGlobalScope;
+        \\}
+    , ".ts");
+    // 중첩 namespace 안에서도 동일하게 ambient 전파.
+    try expectNoParseErrorWithExt(
+        \\declare global {
+        \\  namespace NodeJS {
+        \\    const process: { env: { NODE_ENV: string } };
+        \\  }
+        \\}
+    , ".ts");
+}
+
+test ".d.ts: ambient const without initializer (D12)" {
+    // nanoid `index.d.ts` 의 `export const urlAlphabet: string;` 패턴. parser entry
+    // 에서 `.d.ts` 경로를 ambient context 로 분류하지 않아 const initializer 강제가
+    // 적용되던 회귀.
+    try expectNoParseErrorWithPath(
+        \\export const urlAlphabet: string;
+        \\export const nanoid: () => string;
+    , "index.d.ts");
 }
 
 test "declare module: export in bundler mode" {

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -294,10 +294,17 @@ fn parseNamespaceBodyInContext(self: *Parser) ParseError2!NodeIndex {
 /// declare var/let/const/function/class/...
 pub fn parseTsDeclareStatement(self: *Parser) ParseError2!NodeIndex {
     try self.advance(); // skip 'declare'
-    // declare global { ... } — 글로벌 augmentation (타입 전용, 완전 제거)
+    // declare global { ... } — 글로벌 augmentation (타입 전용, 완전 제거).
+    // 본체는 ambient — 자식 const/function/class 가 implicit `declare` 처럼 동작
+    // (initializer/body 강제 면제). `declare namespace X { ... }` 와 동일하게
+    // `parseNamespaceBodyInContext` 를 경유해 in_namespace / is_top_level 도 같이
+    // 세팅 — 일반 declare 경로와 컨텍스트 대칭성 유지.
     if (self.current() == .identifier and self.isContextual("global")) {
         try self.advance(); // skip 'global'
-        _ = try parseNamespaceBlock(self);
+        const saved = self.ctx;
+        self.ctx.in_ambient = true;
+        defer self.ctx = saved;
+        _ = try parseNamespaceBodyInContext(self);
         return NodeIndex.none;
     }
     // declare 뒤의 선언은 ambient context — 런타임 코드 없음

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -1135,6 +1135,7 @@ fn transpileWithCallbackInternal(
 
     var parser = Parser.init(arena_alloc, &scanner);
     parser.configureFromExtension(std.fs.path.extension(file_path));
+    parser.configureAmbientFromPath(file_path);
 
     if (parser.source_mode != .ts) {
         if (options.flow) {
@@ -1461,6 +1462,7 @@ fn testTransformPlan(source: []const u8, file_path: []const u8, options: Transpi
     var scanner = try Scanner.init(allocator, source);
     var parser = Parser.init(allocator, &scanner);
     parser.configureFromExtension(std.fs.path.extension(file_path));
+    parser.configureAmbientFromPath(file_path);
     if (parser.source_mode != .ts) {
         if (options.flow) {
             parser.is_flow = true;


### PR DESCRIPTION
## Summary

`.d.ts` 파일 + `declare global { ... }` 블록 본체에서 `Const declarations must be initialized [ZNTC0508]` 가 잘못 발생하던 회귀 fix. 기존엔 top-level `declare const` 만 ambient 로 분류되었고, `.d.ts` 파일과 `declare global` 의 자식 const 가 ambient context 로 진입하지 못해 일반 const 검사가 적용됨.

## 재현 (fix 전)

```ts
// /tmp/x.d.ts
export const urlAlphabet: string;
export const nanoid: () => string;
```

```
× Const declarations must be initialized [ZNTC0508]
```

```ts
declare global {
  const window: Window;
  const self: WorkerGlobalScope;
}
```

```
× Const declarations must be initialized [ZNTC0508]
```

## 수정

- `Parser.configureAmbientFromPath(file_path)` 추가 — `.d.ts` / `.d.mts` / `.d.cts` 경로면 `ctx.in_ambient = true`. `std.fs.path.extension()` 이 `.ts` 만 반환하므로 전체 경로 검사 필요.
- `parseTsDeclareStatement` 의 `declare global` 분기를 `parseNamespaceBodyInContext` 경유로 통합 — `declare namespace X { ... }` 와 동일하게 `in_namespace` / `is_top_level` / `in_ambient` 가 함께 세팅돼 분기 일관성 확보.
- 호출 사이트: `transpile.zig` × 2 + `bundler/graph/parser_setup.zig` × 1.

## 회귀 가드

- `declare global { const window: Window; }` + 중첩 namespace 케이스
- `.d.ts` 파일 entry (`expectNoParseErrorWithPath` helper 신규)
- 기존 `declare namespace NS { const x: T; }` / `declare module "*.svg" { const src: string; }` 회귀 없음

## Fuzz 효과 (실측)

| Library | total | pass | fail | D12 잔존 |
|---|---:|---:|---:|---:|
| nanoid | 5 | **5** | 0 | **0** |
| ethers `src.ts/` | 143 | **143** | 0 | **0** |
| immer | 35 | **31** (이전 21) | 4 | **0** |
| zod | 1095 | **1082** | 13 | **0** |
| type-fest | 245 | **243** | 2 | **0** |
| @tanstack/query-core | 74 | 72 | 2 | **0** |
| @tanstack/react-query | 72 | 70 | 2 | **0** |

D12 카테고리 (`Const declarations must be initialized` / `declare global` ambient) 모든 대상 라이브러리에서 0 건. 잔존 fail 은 D13 (scope-binding), D14 (type predicate), D15 (exponent type literal) — 별개 epic.

## Follow-up (별개 PR)

- `.d.ts` codegen strip: 현재 `in_ambient=true` 는 parser 의 const-init 검사만 면제. codegen 은 ambient declaration 을 그대로 emit → `.d.ts` 입력의 출력이 `export const urlAlphabet;` 같은 invalid JS. Babel/tsc 와 동일한 빈 출력은 별개 영역.
- bundler 가 `.d.ts` 를 entry 로 받을 때 동일 issue.

## Test plan

- [x] `zig build` 통과
- [x] `zig build test` D12 영역 통과 (`declare global` / `.d.ts` ambient 단위 테스트)
- [x] nanoid `index.d.ts` 0 errors
- [x] ethers `crypto-browser.ts` 0 errors
- [x] `declare module "*.svg"` / `declare namespace NS` 기존 통과 케이스 회귀 없음
- [x] /simplify 3 agent 병렬 review 통과 (cross-file / ambient edge case / real-world fuzz)

🤖 Generated with [Claude Code](https://claude.com/claude-code)