### PR TITLE
fix(parser): auto type-only export elision for top-level declare bindings

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -938,6 +938,15 @@ pub const Ast = struct {
     /// 탐지/차단 용도로 확장 예정.
     transformed_root: ?NodeIndex = null,
 
+    /// top-level `declare class/function/var/let/const/enum/namespace/import =` 의
+    /// binding name 사이드테이블. parser 가 declare 노드를 `NodeIndex.none` 으로 strip
+    /// 하면 AST 에 노드가 사라져 transpile.zig 의 markAutoTypeOnlyExportSpecifiers 가
+    /// declare-only name 을 type_only_names 로 인식하지 못함 → `export { X as Y };`
+    /// 의 X 가 declare 만 reference 해도 elision 이 안 됨 (D13).
+    /// 이 set 은 strip 직전에 parseTsDeclareStatement 가 채운다. 키는 ast.source /
+    /// string_table slice — Ast 가 살아있는 동안 유효.
+    declare_only_names: std.StringHashMapUnmanaged(void) = .empty,
+
     /// 메모리 할당자 (Zig 0.15: ArrayList가 더 이상 allocator를 저장하지 않음)
     allocator: std.mem.Allocator,
 
@@ -993,6 +1002,7 @@ pub const Ast = struct {
         self.nodes.deinit(self.allocator);
         self.extra_data.deinit(self.allocator);
         self.string_table.deinit(self.allocator);
+        self.declare_only_names.deinit(self.allocator);
         self.deinitStringInterns();
     }
 

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -315,7 +315,83 @@ pub fn parseTsDeclareStatement(self: *Parser) ParseError2!NodeIndex {
     // namespace 내부의 declare는 이름을 보존해야 함 (export declare const L1)
     // → codegen이 ns.L1 참조 치환에 사용. 본체는 출력하지 않되 이름만 ns_export_map에 등록.
     if (self.in_namespace) return stmt;
+    // top-level declare 는 strip 되어 AST 에 사라지므로, declare 된 binding name 만
+    // `ast.declare_only_names` 에 미리 등록한다. 이후 transpile.zig 의
+    // markAutoTypeOnlyExportSpecifiers 가 이 set 을 type-only 로 분류해
+    // `export { X as Y };` 의 X 가 declare 만 reference 하는 경우를 자동 elide (D13).
+    try registerDeclareBindingNames(self, stmt);
     return NodeIndex.none;
+}
+
+/// declare 된 statement 의 top-level binding name 을 `ast.declare_only_names` 에 등록.
+/// parseTsDeclareStatement 가 strip 직전 호출.
+fn registerDeclareBindingNames(self: *Parser, stmt_idx: NodeIndex) ParseError2!void {
+    if (stmt_idx.isNone()) return;
+    if (@intFromEnum(stmt_idx) >= self.ast.nodes.items.len) return;
+    const stmt = self.ast.getNode(stmt_idx);
+    switch (stmt.tag) {
+        // extras[0] = name node idx
+        .function_declaration,
+        .class_declaration,
+        .ts_enum_declaration,
+        .ts_interface_declaration,
+        .ts_type_alias_declaration,
+        => try putAstDeclareName(self, @enumFromInt(self.ast.extra_data.items[stmt.data.extra])),
+
+        // binary.left = name node idx — ts_module_declaration 은 binary layout
+        // (`declare namespace NS {}`, `declare module "name" {}` 모두 동일).
+        // 후자의 left 는 string_literal 이라 식별자가 아니므로 putAstDeclareName 의
+        // `name_text.len == 0` 가드 외에 string_literal 태그 skip.
+        .ts_module_declaration => {
+            const name_idx = stmt.data.binary.left;
+            if (!name_idx.isNone() and @intFromEnum(name_idx) < self.ast.nodes.items.len) {
+                const name_node = self.ast.getNode(name_idx);
+                if (name_node.tag != .string_literal) {
+                    try putAstDeclareName(self, name_idx);
+                }
+            }
+        },
+
+        // binary.left = name
+        .ts_import_equals_declaration => try putAstDeclareName(self, stmt.data.binary.left),
+
+        // variable_declaration: extras = [kind_flags, list_start, list_len]
+        .variable_declaration => {
+            const list_start = self.ast.extra_data.items[stmt.data.extra + 1];
+            const list_len = self.ast.extra_data.items[stmt.data.extra + 2];
+            var i: u32 = 0;
+            while (i < list_len) : (i += 1) {
+                const decl_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[list_start + i]);
+                if (decl_idx.isNone()) continue;
+                if (@intFromEnum(decl_idx) >= self.ast.nodes.items.len) continue;
+                const decl = self.ast.getNode(decl_idx);
+                if (decl.tag != .variable_declarator) continue;
+                // variable_declarator extras[0] = binding pattern
+                try registerDeclareBindingPatternNames(self, @enumFromInt(self.ast.extra_data.items[decl.data.extra]));
+            }
+        },
+
+        else => {},
+    }
+}
+
+fn registerDeclareBindingPatternNames(self: *Parser, idx: NodeIndex) ParseError2!void {
+    if (idx.isNone()) return;
+    if (@intFromEnum(idx) >= self.ast.nodes.items.len) return;
+    var it = try @import("ast_walk.zig").bindingIdentifiers(self.allocator, &self.ast, idx, .{ .cover_grammar_assignment = false });
+    defer it.deinit();
+    while (try it.next()) |leaf_idx| {
+        try putAstDeclareName(self, leaf_idx);
+    }
+}
+
+fn putAstDeclareName(self: *Parser, name_idx: NodeIndex) ParseError2!void {
+    if (name_idx.isNone()) return;
+    if (@intFromEnum(name_idx) >= self.ast.nodes.items.len) return;
+    const name_node = self.ast.getNode(name_idx);
+    const name_text = self.ast.getText(name_node.span);
+    if (name_text.len == 0) return;
+    try self.ast.declare_only_names.put(self.ast.allocator, name_text, {});
 }
 
 /// abstract class Foo { }

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -605,7 +605,10 @@ fn markAutoTypeOnlyExportSpecifiers(
         try collectAutoTypeOnlyDeclNames(allocator, ast, stmt_idx, &value_names, &type_only_names);
     }
 
-    if (type_only_names.count() == 0) return;
+    // ast.declare_only_names: top-level `declare class/function/var/...` 는 parser 가
+    // strip 해 AST 에 없지만, 이름 자체는 parser 가 사이드테이블에 등록 (D13). value-only
+    // binding 으로 분류되지 않는 type-only binding 으로 취급.
+    if (type_only_names.count() == 0 and ast.declare_only_names.count() == 0) return;
 
     // pass 2
     for (ast.nodes.items) |node| {
@@ -636,9 +639,12 @@ fn markAutoTypeOnlyExportSpecifiers(
 
             const local_name = ast.getText(local_node.span);
             // declaration merging: 동명의 value binding 이 있으면 type-only 마킹 skip.
-            // `const X = 1; type X = ...; export { X };` 같은 케이스에서 value 우선.
+            // `const X = 1; type X = ...; export { X };` 또는
+            // `class A {}; declare class A; export { A };` 양쪽에서 value 우선.
             if (value_names.contains(local_name)) continue;
-            if (type_only_names.contains(local_name)) {
+            if (type_only_names.contains(local_name) or
+                ast.declare_only_names.contains(local_name))
+            {
                 ast.setBinaryFlags(spec_idx, spec_node.data.binary.flags | module_parser.SPEC_FLAG_TYPE_ONLY);
             }
         }
@@ -656,12 +662,22 @@ fn collectAutoTypeOnlyDeclNames(
 ) error{OutOfMemory}!void {
     const stmt = ast.getNode(stmt_idx);
     switch (stmt.tag) {
-        // value bindings: function / class / enum / module(namespace) — extras[0] = name
+        // value bindings: function / class / enum — extras[0] = name
         .function_declaration,
         .class_declaration,
         .ts_enum_declaration,
-        .ts_module_declaration,
         => try putNameAtExtraSlot(allocator, ast, stmt, 0, value_names),
+
+        // ts_module_declaration: binary layout — binary.left = name (namespace) 또는
+        // string_literal (declare module "..."). 후자는 binding 이름이 아니라 skip.
+        .ts_module_declaration => {
+            const name_idx = stmt.data.binary.left;
+            if (name_idx.isNone()) return;
+            if (@intFromEnum(name_idx) >= ast.nodes.items.len) return;
+            const name_node = ast.getNode(name_idx);
+            if (name_node.tag == .string_literal) return;
+            try putNodeIdName(allocator, ast, name_idx, value_names);
+        },
 
         // import X = require(...) — runtime value
         .ts_import_equals_declaration => {
@@ -1946,6 +1962,106 @@ test "TS auto type-only export: declaration merging preserves value binding" {
     ,
         \\var E = /* @__PURE__ */ ((E) => {E[E["A"]=0]="A";return E;})(E || {});
         \\export { E };
+        \\
+    ,
+        "input.ts",
+        .{},
+    );
+}
+
+// D13: top-level `declare class/function/var` 의 name 은 type-only binding.
+// `export { X as Y };` 가 declare 만 reference 하면 specifier 가 자동 elide (Babel
+// preset-typescript 동작). parser 가 top-level declare 를 strip 해 AST 에 사라지므로
+// markAutoTypeOnlyExportSpecifiers 가 별도 sideband (`ast.declare_only_names`) 에서
+// name 을 조회해야 한다.
+test "TS auto type-only export: top-level declare bindings elide rename specifier (D13)" {
+    // export declare class — Babel: `export {};` (ZNTC codegen 은 빈 export 통째 drop)
+    try expectTranspileOutput(
+        \\export declare class Foo {}
+        \\export { Foo as Bar };
+        \\
+    ,
+        \\
+    ,
+        "input.ts",
+        .{},
+    );
+
+    // export declare function (단독 통과는 simple_ts_strip 인데, 다른 케이스도 동등)
+    try expectTranspileOutput(
+        \\export declare function _lte(): number;
+        \\export { _lte as _max };
+        \\
+    ,
+        \\
+    ,
+        "input.ts",
+        .{},
+    );
+
+    // namespace import 가 선행하면 binding-lite path — 동일 결과
+    try expectTranspileOutput(
+        \\import * as foo from "./foo";
+        \\export declare function _lte(): number;
+        \\export { _lte as _max };
+        \\
+    ,
+        \\import * as foo from "./foo";
+        \\
+    ,
+        "input.ts",
+        .{},
+    );
+
+    // non-export declare 도 동일
+    try expectTranspileOutput(
+        \\declare class Foo {}
+        \\export { Foo };
+        \\
+    ,
+        \\
+    ,
+        "input.ts",
+        .{},
+    );
+
+    // declaration merging: value class 와 declare class 가 공존하면 value 우선
+    try expectTranspileOutput(
+        \\class A {}
+        \\declare class B {}
+        \\export { A, B };
+        \\
+    ,
+        \\class A {
+        \\}
+        \\export { A };
+        \\
+    ,
+        "input.ts",
+        .{},
+    );
+
+    // declare namespace — ts_module_declaration 은 binary layout. extras[0] 으로 잘못
+    // 읽으면 OOB panic. binary.left = name idx 가 정답.
+    try expectTranspileOutput(
+        \\declare namespace Foo {}
+        \\export { Foo as Bar };
+        \\
+    ,
+        \\
+    ,
+        "input.ts",
+        .{},
+    );
+
+    // declare module "..." — binary.left 가 string_literal 이라 name 등록 skip.
+    // 자체로 strip, 빈 export 도 strip.
+    try expectTranspileOutput(
+        \\declare module "*.svg" { const src: string; export default src; }
+        \\export const value = 1;
+        \\
+    ,
+        \\export const value = 1;
         \\
     ,
         "input.ts",


### PR DESCRIPTION
## Summary

`export declare class Foo {}; export { Foo as Bar };` 같은 패턴에서 Foo 가 `Export 'Foo' is not defined [ZNTC1201]` 로 잘못 거부되던 회귀 fix. Babel `preset-typescript` 는 모든 `declare X` 자식을 type-only binding 으로 분류해 export specifier 를 자동 elide — ZNTC 도 동일.

## 재현 (fix 전)

```ts
export declare class Foo {}
export { Foo as Bar };
```

```
× Export 'Foo' is not defined [ZNTC1201]
help: Ensure the exported name is declared in module scope before the export statement.
```

또 zod 의 `_v4/core/api.d.ts` 등 `import * as foo from "./foo"; export declare function _lte(): number; export { _lte as _max };` 패턴이 광범위하게 fail. zod fuzz 13건, tanstack 4건, immer 등.

## 원인

parser 가 top-level `declare class/function/var/enum/...` 를 `NodeIndex.none` 으로 strip → AST 에서 사라짐 → `markAutoTypeOnlyExportSpecifiers` (D10/D12 helper) 가 declare-only binding 을 인식 못해 export specifier 의 `SPEC_FLAG_TYPE_ONLY` 마킹이 누락 → semantic analyzer 가 unresolved binding 으로 진단.

## 수정

- `Ast.declare_only_names: StringHashMapUnmanaged(void)` 사이드테이블 추가. parser 가 strip 직전 declare 자식의 binding name 을 등록.
- `parseTsDeclareStatement` 의 top-level (`!in_namespace`) 경로에서 `registerDeclareBindingNames` 호출:
  - function/class/enum/interface/type alias → `extras[0]` = name
  - **`ts_module_declaration`** → `binary.left` = name (binary layout, **extras[0] 아님**). string_literal (`declare module "name"`) 은 skip.
  - `ts_import_equals_declaration` → `binary.left`
  - `variable_declaration` → `ast_walk.bindingIdentifiers` 로 destructuring 포함 모든 식별자
- `markAutoTypeOnlyExportSpecifiers` 의 마킹 조건에 `ast.declare_only_names.contains(name)` 추가. early-return 도 양쪽 set 합 검사. declaration merging (`class A {}; declare class A {}; export { A };`) 시 value 우선은 그대로.
- `collectAutoTypeOnlyDeclNames` 의 `ts_module_declaration` 분기도 동일하게 binary layout 사용. **이전 코드의 `extras[0]` 접근은 OOB panic 의 원인** (Bug A — review agent 발견).

## 회귀 가드

| 케이스 | 출력 |
|---|---|
| `export declare class Foo {}; export { Foo as Bar };` | 빈 |
| `export declare function _lte(): number; export { _lte as _max };` | 빈 |
| `import * as foo from "./foo"; export declare function _lte(): number; export { _lte as _max };` | `import * as foo from "./foo";` |
| `declare class Foo {}; export { Foo };` | 빈 |
| `class A {}; declare class B {}; export { A, B };` | `class A {}\nexport { A };` |
| `declare namespace Foo {}; export { Foo as Bar };` | 빈 (Bug A regression guard) |
| `declare module "*.svg" { ... }; export const value = 1;` | `export const value = 1;` |

## Fuzz 효과 (실측)

| 라이브러리 | before | after | total |
|---|---:|---:|---:|
| zod 4.3.6 | 13 | **0** | 376 |
| zod 4.4.1 | 13 (합산) | **0** | 390 |
| zod 3.25.76 | — | **0** | 329 |
| @tanstack/query-core | 2 | **0** | 74 |
| @tanstack/react-query | 2 | **0** | 67 |
| @reduxjs/toolkit | — | **0** | 169 |
| ethers `src.ts/` | 0 | **0** | 143 |
| immer 11 | 2 | **1** | 18 |
| immer 10 | 2 | **1** | 17 |
| type-fest 4 | 1 | **1** | 166 |
| type-fest 2 | 1 | **1** | 79 |

총 19건 해소. 잔존 4건 = D14 (type predicate `x is T` arrow/function) + D15 (exponent type literal `1e999`).

## Test plan

- [x] `zig build` 통과
- [x] `zig build test` D13 회귀 가드 7종 통과
- [x] 라이브러리 fuzz: zod/tanstack/redux-toolkit/ethers/nanoid 모두 D13 카테고리 0건
- [x] /simplify 3 agent 병렬 review 통과 (cross-file / Babel parity / wide fuzz — Bug A 발견 후 fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)