### PR TITLE
fix(parser): accept contextual keyword as type predicate subject

### DIFF
--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -3319,6 +3319,24 @@ test "TS: typed arrow with default-value parameters" {
     try expectNoParseErrorWithExt("const f = (x = 0): number => x;", ".ts");
 }
 
+test "TS: type predicate subject accepts contextual keyword (D14)" {
+    // immer `src/utils/common.ts` 의 `(target: any): target is Map<...> => ...` 패턴.
+    // `target` 은 ECMAScript contextual keyword (`new.target` 용) 라 `.kw_target` 으로
+    // 토큰화되어 type predicate 의 subject 진입 조건 (`identifier or kw_this`) 에서
+    // 거부되던 회귀. `canBeBindingName()` 으로 일반화.
+    try expectNoParseErrorWithExt("function f(target: any): target is Map<any, any> { return true; }", ".ts");
+    try expectNoParseErrorWithExt("let f = (target: any): target is Map<any, any> => true;", ".ts");
+    // 다른 contextual keyword (async/from/of/get/set/let/source) 도 subject 로 허용
+    try expectNoParseErrorWithExt("function f(async: any): async is Promise<any> { return true; }", ".ts");
+    try expectNoParseErrorWithExt("function f(of: any): of is number { return true; }", ".ts");
+    // asserts 변형도 동일
+    try expectNoParseErrorWithExt("function f(target: any): asserts target is Map<any, any> {}", ".ts");
+    try expectNoParseErrorWithExt("function f(target: any): asserts target {}", ".ts");
+    // 일반 identifier / this 도 기존대로 동작 (regression guard)
+    try expectNoParseErrorWithExt("function f(x: any): x is any[] { return true; }", ".ts");
+    try expectNoParseErrorWithExt("class C { f(): this is C { return true; } }", ".ts");
+}
+
 test "TS: typed arrow with all untyped params + return type predicate (D11)" {
     // @reduxjs/toolkit listenerMiddleware.test-d.ts 의 패턴 — 모든 파라미터에 타입
     // annotation 이 없고 return type 만 type predicate. `isTypedArrowFunction` 의

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -601,9 +601,10 @@ fn parseTypeOrTypePredicate(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
 
     // asserts 프레디케이트: asserts x, asserts x is Type, asserts this is Type
+    // subject 는 contextual keyword (target/async/...) 도 받는다.
     if (self.current() == .identifier and self.isContextual("asserts")) {
         const next = try self.peekNextKind();
-        if (next == .identifier or next == .kw_this) {
+        if (next.canBeBindingName() or next == .kw_this) {
             try self.advance(); // skip 'asserts'
             const param_name = try parsePredicateSubject(self);
             // 선택적 is Type
@@ -621,8 +622,10 @@ fn parseTypeOrTypePredicate(self: *Parser) ParseError2!NodeIndex {
     }
 
     // x is Type 또는 this is Type 판별
-    // saveState/restoreState로 speculative 파싱 — 'is' 확인 후 commit 또는 rollback
-    if (self.current() == .identifier or self.current() == .kw_this) {
+    // saveState/restoreState로 speculative 파싱 — 'is' 확인 후 commit 또는 rollback.
+    // contextual keyword (target/async/let/get/set/of/from/...) 도 binding subject 로
+    // 허용 — D14: `(target: any): target is Map<...>` 패턴 (immer common.ts).
+    if (self.current().canBeBindingName() or self.current() == .kw_this) {
         const next = try self.peekNextKind();
         if (next == .identifier) {
             const saved = self.saveState();
@@ -648,7 +651,8 @@ fn parseTypeOrTypePredicate(self: *Parser) ParseError2!NodeIndex {
     return parseType(self);
 }
 
-/// asserts/is 프레디케이트의 subject 파싱: this 또는 identifier
+/// asserts/is 프레디케이트의 subject 파싱: this 또는 identifier (contextual keyword
+/// 포함 — target/async/let/get/set/of/from/source/... 도 binding 자리에 허용).
 fn parsePredicateSubject(self: *Parser) ParseError2!NodeIndex {
     if (self.current() == .kw_this) {
         const this_span = self.currentSpan();


### PR DESCRIPTION
## Summary

`(target: any): target is Map<any, any> => ...` 패턴이 syntax error 로 거부되던 회귀 fix. `target` 은 ECMAScript contextual keyword (`new.target` 표현식 지원용) 로 lexer 가 `.kw_target` 으로 토큰화하는데, `parseTypeOrTypePredicate` 의 진입 조건이 `identifier or kw_this` 만 허용해 contextual keyword 일체를 거부.

immer `src/utils/common.ts` 의 isMap/isSet/isFunction 등 광범위 영향.

## 재현 (fix 전)

```ts
function isMap(target: any): target is Map<any, any> { return target instanceof Map; }
```

```
× {  (column 37 — `is` 위치)
× ;
× Reserved word cannot be used as shorthand property [ZNTC0611]
× }
```

같은 누락이 asserts 분기 (`asserts target is X`) 에도 존재.

## 수정

D7 에서 promoted 된 `Token.Kind.canBeBindingName()` helper 로 일관 처리:

- `parseTypeOrTypePredicate` 진입 조건: `current() == .identifier or kw_this` → `current().canBeBindingName() or current() == .kw_this`
- asserts 분기의 peek 조건: `next == .identifier or kw_this` → `next.canBeBindingName() or next == .kw_this`

`canBeBindingName()` 는 identifier + 모든 contextual keyword (async/from/of/let/get/set/source/target/accessor/defer/using) + strict-reserved (non-strict) 를 허용. `kw_this` 는 reserved range 라 별도 분기 필수 (`canBeBindingName=false`).

`parsePredicateSubject` 는 토큰 종류 검사 없이 advance + identifier_reference 노드 생성이라 별도 변경 불필요. `getText` 가 source slice 라 contextual keyword 토큰도 무손실 처리.

## 회귀 가드

| 케이스 | 처리 |
|---|---|
| `(target: any): target is Map<...> =>` | ✓ |
| `function f(target: any): target is Map<...>` | ✓ |
| `(async: any): async is Promise<any> =>` | ✓ |
| `function f(of: any): of is number` | ✓ |
| `function f(target: any): asserts target is Map<...>` | ✓ |
| `function f(target: any): asserts target` | ✓ |
| `function f(x: any): x is any[]` (regression — 일반 identifier) | ✓ |
| `class C { f(): this is C {} }` (regression — kw_this 분기) | ✓ |

## Fuzz 효과 (실측)

| 라이브러리 | before | after | total |
|---|---:|---:|---:|
| immer 11.1.4 | 2 | **0** | 18 |
| immer 10.2.0 | 2 | **0** | 17 |
| zod (회귀 가드) | 0 | 0 | 200 |

총 4건 해소. 잔존 D15 (type-fest exponent literal `1e999`) 만 남음.

## Test plan

- [x] `zig build test` D14 회귀 가드 8종 통과
- [x] `zig build test -Doptimize=ReleaseFast` 통과
- [x] immer 11 / 10 fuzz 0 fail
- [x] /simplify 3 agent 병렬 review 통과 (cross-file 안전성 / Babel parity / wide fuzz)

🤖 Generated with [Claude Code](https://claude.com/claude-code)