### PR TITLE
fix(parser): accept all numeric kinds as TS literal type

### DIFF
--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -3319,6 +3319,28 @@ test "TS: typed arrow with default-value parameters" {
     try expectNoParseErrorWithExt("const f = (x = 0): number => x;", ".ts");
 }
 
+test "TS: numeric literal type accepts all numeric kinds (D15)" {
+    // type-fest `numeric.d.ts` 의 `PositiveInfinity = 1e999;` 패턴.
+    // parsePrimaryType 의 numeric 분기에 `.positive_exponential` / `.negative_exponential`
+    // / `.binary` / `.octal` 누락이 root cause. `isNumericLiteral()` 로 일반화.
+    try expectNoParseErrorWithExt("export type T = 1e3;", ".ts");
+    try expectNoParseErrorWithExt("export type T = 1e999;", ".ts");
+    try expectNoParseErrorWithExt("export type T = 1e-10;", ".ts");
+    try expectNoParseErrorWithExt("export type T = 0b101;", ".ts");
+    try expectNoParseErrorWithExt("export type T = 0o77;", ".ts");
+    // 음수 리터럴 — `-1e999`, `-0b101` 등
+    try expectNoParseErrorWithExt("export type T = -1e999;", ".ts");
+    try expectNoParseErrorWithExt("export type T = -1e-10;", ".ts");
+    try expectNoParseErrorWithExt("export type T = -0b101;", ".ts");
+    try expectNoParseErrorWithExt("export type T = -0o77;", ".ts");
+    // 기존 통과 케이스 회귀 가드
+    try expectNoParseErrorWithExt("export type T = 1;", ".ts");
+    try expectNoParseErrorWithExt("export type T = 1.5;", ".ts");
+    try expectNoParseErrorWithExt("export type T = 0xff;", ".ts");
+    try expectNoParseErrorWithExt("export type T = 1n;", ".ts");
+    try expectNoParseErrorWithExt("export type T = -1;", ".ts");
+}
+
 test "TS: type predicate subject accepts contextual keyword (D14)" {
     // immer `src/utils/common.ts` 의 `(target: any): target is Map<...> => ...` 패턴.
     // `target` 은 ECMAScript contextual keyword (`new.target` 용) 라 `.kw_target` 으로

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -967,9 +967,16 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
                 .data = .{ .none = 0 },
             });
         },
+        // 모든 numeric literal kind (decimal/float/binary/octal/hex/exponential/bigint)
+        // 를 type literal 위치에서 받는다. D15: `1e999`, `0b101`, `0o77` 등 누락 케이스
+        // 일괄 커버 — type-fest `numeric.d.ts` 의 `PositiveInfinity = 1e999`.
         .decimal,
         .float,
+        .binary,
+        .octal,
         .hex,
+        .positive_exponential,
+        .negative_exponential,
         .string_literal,
         .decimal_bigint,
         .hex_bigint,
@@ -1032,13 +1039,12 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
         },
         // import("module").Type
         .kw_import => return try parseImportType(self, span.start),
-        // 음수 리터럴 타입: -1, -2n (oxc L406-418)
+        // 음수 리터럴 타입: -1, -2n, -1e10, -0b101 등 (oxc L406-418).
+        // `isNumericLiteral()` 로 일반화 — D15: `-1e999` 등 exponential / binary / octal
+        // 누락 케이스 일괄 커버.
         .minus => {
             try self.advance(); // skip -
-            if (self.current() == .decimal or self.current() == .float or self.current() == .hex or
-                self.current() == .decimal_bigint or self.current() == .hex_bigint or
-                self.current() == .octal_bigint or self.current() == .binary_bigint)
-            {
+            if (self.current().isNumericLiteral()) {
                 try self.advance();
                 return try self.ast.addNode(.{
                     .tag = .ts_literal_type,


### PR DESCRIPTION
## Summary

`export type PositiveInfinity = 1e999;` 같은 numeric type literal 이 `Type expected [ZNTC0912]` 로 거부되던 회귀 fix. type-fest `source/numeric.d.ts` 의 PositiveInfinity/NegativeInfinity 패턴.

## 재현 (fix 전)

```ts
export type PositiveInfinity = 1e999;
export type NegativeInfinity = -1e999;
export type Big = 1e308;
export type Small = 1e3;
```

```
× Type expected [ZNTC0912]
```

## 원인

`parsePrimaryType` 의 type literal 분기가 일부 numeric kind 만 수용:
- positive: `.decimal, .float, .hex, .*_bigint, .string_literal` — `.positive_exponential`, `.negative_exponential`, `.binary`, `.octal` 누락
- unary minus: 위와 동일한 누락

lexer 는 `1e999` 를 `.positive_exponential` 토큰으로 분류 (`isNumericLiteral` range = `.decimal..hex_bigint` 안).

## 수정

- positive 분기에 4 종 numeric kind 추가
- unary minus 분기를 `current().isNumericLiteral()` 로 일반화 (11 종 numeric kind 자동 커버)
- `.string_literal` 은 numeric range 밖이라 positive 분기에 별도 case 유지

## 회귀 가드

13 종 케이스: positive × {decimal, float, hex, exp, binary, octal, bigint} + negative × {exp, binary, octal} + 기존 통과 경로.

## Fuzz 효과 (실측, 1833 파일 / 11 라이브러리)

| 라이브러리 | before | after | total |
|---|---:|---:|---:|
| type-fest 4 | 1 | **0** | 166 |
| type-fest 2 | 1 | **0** | 79 |
| zod 3/4/4.4 | 0 | 0 | 1095 |
| immer 11/10 | 0 | 0 | 35 |
| tanstack q+r | 0 | 0 | 141 |
| ethers `src.ts/` | 0 | 0 | 143 |
| redux-toolkit | 0 | 0 | 169 |
| nanoid | 0 | 0 | 5 |

**총 0 / 1833**. D15 카테고리 0건. 회귀 0.

## Babel parity

7 케이스 (`1e3`, `1e999`, `-1e10`, `0b101`, `0o77`, `-0b101`, `-0xff`) 모두 의미 동등 (type-only elide). Babel 의 `export {};` ESM marker 차이는 codegen 범위 (D10/D12 follow-up 영역).

## Test plan

- [x] `zig build test` D15 회귀 가드 통과
- [x] 11 라이브러리 1833 파일 fuzz fail 0
- [x] Babel parity 7/7 의미 동등
- [x] /simplify 3 agent 병렬 review 통과 (cross-file / wide fuzz)

🤖 Generated with [Claude Code](https://claude.com/claude-code)