### PR TITLE
fix(parser): treat TS files as implicit strict module (5-tool consensus)

### DIFF
--- a/src/codegen/codegen_test/basic.zig
+++ b/src/codegen/codegen_test/basic.zig
@@ -34,9 +34,10 @@ test "Codegen: JS with TS stripped" {
 }
 
 test "Codegen: return statement" {
-    var r = try e2e(std.testing.allocator, "return;");
+    // D16: top-level return 은 module (TS spec) 에서 invalid 라 function 안으로 wrap.
+    var r = try e2e(std.testing.allocator, "function f(){return;}");
     defer r.deinit();
-    try std.testing.expectEqualStrings("return;", r.output);
+    try std.testing.expectEqualStrings("function f(){return;}", r.output);
 }
 
 test "Codegen: enum IIFE" {

--- a/src/codegen/codegen_test/cjs_importmeta.zig
+++ b/src/codegen/codegen_test/cjs_importmeta.zig
@@ -127,9 +127,10 @@ test "Codegen formatted: class with method" {
 }
 
 test "Codegen formatted: spaces indent" {
-    var r = try e2eWithOptions(std.testing.allocator, "if (x) { return 1; }", .{ .indent_char = .space, .indent_width = 2 });
+    // D16: top-level return 은 module (TS spec) 에서 invalid — function 안으로 wrap.
+    var r = try e2eWithOptions(std.testing.allocator, "function f(x){if (x) { return 1; }}", .{ .indent_char = .space, .indent_width = 2 });
     defer r.deinit();
-    try std.testing.expectEqualStrings("if (x) {\n  return 1;\n}\n", r.output);
+    try std.testing.expectEqualStrings("function f(x) {\n  if (x) {\n    return 1;\n  }\n}\n", r.output);
 }
 
 // ================================================================

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -332,9 +332,17 @@ pub const Parser = struct {
         {
             // .cts 는 Node 입장에선 CJS 지만 tsc 가 ESM 구문을 받아 module.exports 로
             // transpile. parser 레벨에선 module 로 파싱.
+            //
+            // D16: TypeScript spec — 모든 TS 모듈은 implicit strict (tsc/babel/swc/oxc/
+            // rolldown 5개 컨센서스). 이전 ZNTC 는 `.ts` 도 unambiguous 로 파싱해 import/
+            // export 없는 파일을 script 로 fallback → strict reserved binding error 가
+            // 폐기되어 `let/yield/private/static` 등이 binding 자리에서 silent accept.
+            // tsc TS1212/TS1100 과 일관되게 항상 module + strict 로 확정 — ts_unambiguous
+            // 인자는 더 이상 TS 분기에서 사용하지 않음 (.js 분기에서만 의미 있음).
             self.is_module = true;
             self.scanner.is_module = true;
-            self.is_unambiguous = ts_unambiguous;
+            self.is_unambiguous = false;
+            self.is_strict_mode = true;
         } else if (ts_unambiguous and
             (std.mem.eql(u8, ext, ".js") or std.mem.eql(u8, ext, ".jsx")))
         {

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -3319,6 +3319,31 @@ test "TS: typed arrow with default-value parameters" {
     try expectNoParseErrorWithExt("const f = (x = 0): number => x;", ".ts");
 }
 
+test "TS: strict-mode reserved word cannot be used as binding (D16)" {
+    // TypeScript spec: 모든 TS 모듈/네임스페이스는 implicit strict mode (tsc TS1212 / TS1100).
+    // 5개 도구 (Babel/tsc/swc/oxc/rolldown) 모두 parse-time reject. ZNTC 도 동일해야.
+    // 이전: `.ts` 파일이 is_unambiguous=true 라 strict reserved error 가 deferred →
+    // import/export 없으면 폐기 → ZNTC accept. 회귀.
+    const cases = [_][]const u8{
+        "let f = (let: any) => true;",
+        "let f = (yield: any) => true;",
+        "let f = (private: any) => true;",
+        "let f = (static: any) => true;",
+        "let f = (interface: any) => true;",
+        "function f(let) { return let; }",
+        "function f(private) {}",
+        "var let = 1;",
+        "let private = 1;",
+        "const static = 1;",
+    };
+    for (cases) |src| {
+        try expectParseErrorWithExt(src, ".ts", .{ .message_contains = "strict mode" });
+    }
+    // eval/arguments 도 strict reserved (tsc TS1100)
+    try expectParseErrorWithExt("let f = (eval: any) => true;", ".ts", .{ .message_contains = "eval" });
+    try expectParseErrorWithExt("let f = (arguments: any) => true;", ".ts", .{ .message_contains = "arguments" });
+}
+
 test "TS: numeric literal type accepts all numeric kinds (D15)" {
     // type-fest `numeric.d.ts` 의 `PositiveInfinity = 1e999;` 패턴.
     // parsePrimaryType 의 numeric 분기에 `.positive_exponential` / `.negative_exponential`


### PR DESCRIPTION
## Summary

`.ts/.tsx/.cts` 파일의 binding 자리에서 strict reserved word (`let`/`yield`/`private`/`static`/`interface`/`eval`/`arguments` 등) 가 silent accept 되던 회귀 fix. TypeScript spec — 모든 TS 모듈/네임스페이스는 implicit strict. **Babel/tsc/swc/oxc-transform/rolldown 5개 도구 모두 parse-time reject**.

## 재현 (fix 전)

```ts
let f = (let: any) => true;      // ZNTC accept — Babel/tsc/swc/oxc/rolldown reject
function f(let) {}               // 동일
var let = 1;                     // 동일
let f = (private: any) => true;  // 동일
```

## 원인 체인

1. ECMAScript 10.2.1 — module = implicit strict. parser 의 `statement.zig:37` 가 module 진입 시 `is_strict_mode = true` 자동 set.
2. `binding.zig:136` 의 `checkIdentifierKeywordUse` 가 strict reserved 거부 시도.
3. 하지만 `.ts/.tsx/.cts` 는 기존엔 `is_unambiguous=true` 로 set 되어 module/script 결정을 parse 완료까지 지연.
4. `addStrictModuleErrorCode` 는 unambiguous 면 deferred → `resolveModuleKind` 에서 `has_module_syntax=false` (import/export 없음) 면 script 로 확정 + deferred errors **폐기**.
5. 결과: `let f = (let: any) => true;` 같은 코드가 parse-time silent accept.

## 수정

`.ts/.tsx/.cts` 분기를 `.mts` 와 동일하게 항상 module 확정 + strict 즉시 적용:
```zig
self.is_module = true;
self.scanner.is_module = true;
self.is_unambiguous = false;
self.is_strict_mode = true;
```

`ts_unambiguous` 인자는 `.js/.jsx` 분기에서만 의미 있음 (esbuild/swc/rollup 호환의 낙관적 module).

## 6-way parity 표

| 케이스 | Babel | tsc | swc | oxc | rolldown | **ZNTC (fix 후)** |
|---|:-:|:-:|:-:|:-:|:-:|:-:|
| `(let: any) =>` | X | X | X | X | X | **X** ZNTC0505 |
| `(yield: any) =>` | X | X | X | X | X | **X** |
| `(private: any) =>` | X | X | X | X | X | **X** ZNTC0505 |
| `(static: any) =>` | X | X | X | X | X | **X** ZNTC0505 |
| `function f(let)` | X | X | X | X | X | **X** ZNTC0505 |
| `var let = 1` | X | X | X | X | X | **X** ZNTC0505 |
| `(eval: any) =>` | X | X | X | X | X | **X** ZNTC0518 |
| `(arguments: any) =>` | X | X | X | X | X | **X** ZNTC0518 |

esbuild 만 outlier (silent rename, `var let` 케이스에서 자체 모순).

## 회귀 가드

- D16 회귀 가드 10 케이스 (parser_test.zig)
- codegen_test 2건 (`basic.zig` "return statement", `cjs_importmeta.zig` "spaces indent") — top-level `return` 이 module 에서 invalid 라 function 안으로 wrap (test 의도 보존)

## Fuzz 효과 (실측)

| 라이브러리 | total | fail |
|---|---:|---:|
| zod 3/4.3/4.4 | 1095 | **0** |
| immer 11/10 | 35 | **0** |
| type-fest 4/2 | 245 | **0** |
| @tanstack/query-core | 74 | **0** |

**합계 1449 / 0**. 회귀 0.

## Follow-up (별개 PR)

- `tests/integration/tests/tsc/helpers.ts:10` 의 `expectPass` silent-skip 분기 — parse 실패한 fixture 도 "통과" 로 처리해 D16 같은 회귀 감지 무력화. 별도 정리 필요.
- `tests/integration/tests/tsc/expressions.test.ts:10375` `arrowFunctionContexts` fixture 의 `with (window) {...}` 블록 — strict 에서 invalid. silent-skip 으로 통과 중이지만 fixture 정합성 회복 필요.

## Test plan

- [x] `zig build test` 통과
- [x] `zig build test -Doptimize=ReleaseFast` 통과
- [x] D16 회귀 가드 10 케이스
- [x] 1449 라이브러리 파일 fuzz fail 0
- [x] 6-way parity (Babel/tsc/swc/oxc/rolldown + ZNTC) 8 케이스 일치
- [x] /simplify 3 agent 병렬 review 통과 (cross-file / internal fixture audit / tools parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)