### PR TITLE
chore(integration): remove tsc expectPass silent-skip, migrate sloppy fixtures

### DIFF
--- a/tests/integration/tests/tsc/__snapshots__/classes.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/classes.test.ts.snap
@@ -11294,3 +11294,5 @@ class Y {
 // should error, incompatible with index signature
 "
 `;
+
+exports[`TSC: classes privateNameInObjectLiteral-3 1`] = `""`;

--- a/tests/integration/tests/tsc/__snapshots__/es6-functionDeclarations.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/es6-functionDeclarations.test.ts.snap
@@ -43,3 +43,5 @@ exports[`TSC: es6/functionDeclarations FunctionDeclaration9_es6 1`] = `
 }
 "
 `;
+
+exports[`TSC: es6/functionDeclarations FunctionDeclaration3_es6 1`] = `""`;

--- a/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
@@ -9320,11 +9320,7 @@ var v3 = f1({ w: (x) => x, r: () => E1.X }, E2.X);
 `;
 
 exports[`TSC: expressions arrowFunctionContexts 1`] = `
-"// Arrow function used in with statement
-with(window) {
-	var p = () => this;
-}
-// Arrow function as argument to super call
+"// Arrow function as argument to super call
 class Base {
 	constructor(n) {
 	}
@@ -9350,10 +9346,7 @@ var E = /* @__PURE__ */ ((E) => {E[E["x"]=() => 4]="x";E[E["y"]=// Error expecte
 // Arrow function as module variable initializer
 var M;((M) => {M.a=(s) => "";var b = (s) => s;})(M || (M = {}));
 // Repeat above for module members that are functions? (necessary to redo all of them?)
-var M2;((M2) => {// Arrow function used in with statement
-with(window) {
-	var p = () => this;
-}// Arrow function as argument to super call
+var M2;((M2) => {// Arrow function as argument to super call
 class Base {
 	constructor(n) {
 	}

--- a/tests/integration/tests/tsc/es6-for-ofStatements.test.ts
+++ b/tests/integration/tests/tsc/es6-for-ofStatements.test.ts
@@ -673,7 +673,8 @@ for (let v of v) {
     );
   });
   test('for-of56', async () => {
-    await expectPass(`for (var let of []) {}`, []);
+    // D16: strict mode reject (was silent-skip 의도) — `var let` reserved
+    await expectError(`for (var let of []) {}`, []);
   });
   test('for-of57', async () => {
     await expectPass(

--- a/tests/integration/tests/tsc/es6-functionDeclarations.test.ts
+++ b/tests/integration/tests/tsc/es6-functionDeclarations.test.ts
@@ -17,7 +17,8 @@ describe('TSC: es6/functionDeclarations', () => {
     );
   });
   test('FunctionDeclaration11_es6', async () => {
-    await expectPass(
+    // D16: strict mode reject (was silent-skip 의도)
+    await expectError(
       `function * yield() {
 }`,
       [],
@@ -37,7 +38,8 @@ describe('TSC: es6/functionDeclarations', () => {
     );
   });
   test('FunctionDeclaration2_es6', async () => {
-    await expectPass(
+    // D16: strict mode reject (was silent-skip 의도)
+    await expectError(
       `function f(yield) {
 }`,
       [],
@@ -51,7 +53,8 @@ describe('TSC: es6/functionDeclarations', () => {
     );
   });
   test('FunctionDeclaration4_es6', async () => {
-    await expectPass(
+    // D16: strict mode reject (was silent-skip 의도)
+    await expectError(
       `function yield() {
 }`,
       [],
@@ -82,7 +85,8 @@ describe('TSC: es6/functionDeclarations', () => {
     );
   });
   test('FunctionDeclaration8_es6', async () => {
-    await expectPass(`var v = { [yield]: foo }`, []);
+    // D16: strict mode reject (was silent-skip 의도)
+    await expectError(`var v = { [yield]: foo }`, []);
   });
   test('FunctionDeclaration9_es6', async () => {
     await expectPass(

--- a/tests/integration/tests/tsc/es6-yieldExpressions.test.ts
+++ b/tests/integration/tests/tsc/es6-yieldExpressions.test.ts
@@ -415,7 +415,8 @@ var f: () => number = () => yield s;`,
     );
   });
   test('generatorTypeCheck38', async () => {
-    await expectPass(
+    // D16: strict mode reject (was silent-skip 의도) — `var yield;`
+    await expectError(
       `var yield;
 function* g() {
     yield 0;
@@ -801,7 +802,8 @@ function* g3(): BadGenerator { }`,
     await expectPass(`function* g3(): void { }`, []);
   });
   test('YieldExpression1_es6', async () => {
-    await expectPass(`yield;`, []);
+    // D16: strict mode reject (was silent-skip 의도)
+    await expectError(`yield;`, []);
   });
   test('YieldExpression10_es6', async () => {
     await expectPass(
@@ -943,7 +945,8 @@ function* test() {
     );
   });
   test('YieldExpression8_es6', async () => {
-    await expectPass(
+    // D16: strict mode reject (was silent-skip 의도) — top-level `yield(foo);`
+    await expectError(
       `yield(foo);
 function* foo() {
   yield(foo);
@@ -979,7 +982,8 @@ function* g() {
     );
   });
   test('YieldStarExpression1_es6', async () => {
-    await expectPass(`yield * [];`, []);
+    // D16: strict mode reject (was silent-skip 의도)
+    await expectError(`yield * [];`, []);
   });
   test('YieldStarExpression2_es6', async () => {
     await expectError(`yield *;`, []);

--- a/tests/integration/tests/tsc/expressions.test.ts
+++ b/tests/integration/tests/tsc/expressions.test.ts
@@ -8835,7 +8835,8 @@ tempTag2 \`\${ x => { x<number, string>(undefined); return x; } }\${ undefined }
     );
   });
   test('letIdentifierInElementAccess01', async () => {
-    await expectPass(
+    // D16: strict mode reject (was silent-skip 의도) — `var let` reserved
+    await expectError(
       `// @target: es2015
 var let: any = {};
 (let[0] = 100);`,
@@ -10373,13 +10374,10 @@ var v3 = f1({ w: x => x, r: () => E1.X }, E2.X);  // Error
     );
   });
   test('arrowFunctionContexts', async () => {
+    // D16: strict mode 은 `with` 금지 — `with(window){...}` 두 블록은 제거하고
+    // 나머지 valid 패턴(super/enum/namespace 등)만 보존 (was silent-skip 의도)
     await expectPass(
       `
-// Arrow function used in with statement
-with (window) {
-    var p = () => this;
-}
-
 // Arrow function as argument to super call
 class Base {
     constructor(n: any) { }
@@ -10416,11 +10414,6 @@ namespace M {
 
 // Repeat above for module members that are functions? (necessary to redo all of them?)
 namespace M2 {
-    // Arrow function used in with statement
-    with (window) {
-        var p = () => this;
-    }
-
     // Arrow function as argument to super call
     class Base {
         constructor(n: any) { }

--- a/tests/integration/tests/tsc/helpers.ts
+++ b/tests/integration/tests/tsc/helpers.ts
@@ -6,11 +6,6 @@ export async function expectPass(code: string, flags: string[] = []) {
   try {
     const result = await runZntc([...flags, `${fixture.dir}/input.ts`]);
 
-    // 파싱 에러로 output 자체가 없는 경우: 아직 미지원 구문이므로 skip
-    if (result.stdout.length === 0 && result.exitCode !== 0) {
-      return;
-    }
-
     // 스냅샷: 출력이 변하면 회귀 감지 (빈 출력도 유효 — 타입 선언만 있는 경우)
     expect(result.stdout).toMatchSnapshot();
   } finally {


### PR DESCRIPTION
## Summary

D16 follow-up — `tests/integration/tests/tsc/helpers.ts:10-12` 의 `expectPass` silent-skip 분기가 sloppy-mode-only fixture 11개를 가리고 있어 회귀 감지 사각지대 형성. ZNTC strict-by-default 정책 (D16) 과 충돌하는 fixture 를 `expectError` 로 마이그레이션.

## 원인

```ts
// helpers.ts (제거 전)
if (result.stdout.length === 0 && result.exitCode !== 0) {
  return;  // 미지원 구문이라 silent return — 회귀 감지 무력화
}
```

D16 fix 후 `.ts` 가 항상 strict module. 이 분기로 가려진 11 fixture 가 모두 strict-mode-invalid sloppy 패턴 — silent 통과 중.

## 영향 11 fixture (sloppy-mode-only)

| 카테고리 | 케이스 수 | 대표 |
|---|---:|---|
| `yield` 식별자 사용 | 8 | `function * yield() {}`, `function f(yield)`, `var yield`, `yield * []`, top-level `yield;` 등 |
| `let` 식별자 사용 | 2 | `var let = 1`, `for (var let of [])` |
| `with (window) {...}` | 1 | `arrowFunctionContexts` 의 두 with 블록 |

## 수정

1. **`helpers.ts`**: silent-skip 분기 제거 (5줄)
2. **11 fixture 의 wrapper**: `expectPass` → `expectError`. tsc 본가 원본 직역 코드는 그대로 보존.
3. **예외 — `arrowFunctionContexts`**: `with(window){...}` 두 블록만 제거하고 다른 valid 패턴 (super/enum/namespace) 은 `expectPass` 유지.

## 측정

- Before / After: **2189 pass / 16 fail / 2205 total** (동일)
- silent-skip 제거로 인한 새 fail 0
- 기존 통과 fixture 회귀 0
- 부수효과: 2 fixture (`privateNameInObjectLiteral-3`, `FunctionDeclaration3_es6`) 가 새 snapshot 으로 자동 등록 — ZNTC 가 정상 emit 한 빈 출력 (silent-skip 가렸던 정상 케이스). 회귀 아님.

## 영향 파일

- `tests/integration/tests/tsc/helpers.ts` (silent-skip 제거)
- `tests/integration/tests/tsc/es6-functionDeclarations.test.ts` (4 케이스)
- `tests/integration/tests/tsc/es6-yieldExpressions.test.ts` (4 케이스)
- `tests/integration/tests/tsc/expressions.test.ts` (2 케이스 + arrowFunctionContexts with 블록 제거)
- `tests/integration/tests/tsc/es6-for-ofStatements.test.ts` (1 케이스)
- `__snapshots__/` 3 파일 (자동 등록 2 + arrowFunctionContexts 갱신)

## Test plan

- [x] `bun test tests/tsc/` 2189 pass / 16 fail (변경 없음)
- [x] `zig build` / `zig build test` 정상
- [x] silent-skip 으로 가려진 11 fixture 모두 `expectError` 로 정상 reject 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)