### PR TITLE
fix(transpile): emit empty output for .d.ts declaration files (D12.5)

### DIFF
--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -1124,6 +1124,16 @@ pub fn transpileWithCallback(
     );
 }
 
+/// `.d.ts` / `.d.mts` / `.d.cts` 는 declaration-only 파일 — 모든 runtime 의미가
+/// 없는 type-only 컨텐츠라 transpile 결과가 빈 출력. parse/transform/codegen 단계
+/// 자체를 skip 하는 게 정확 (tsc/Babel 동작과 일치). D12 의 parser 측 ambient 면제
+/// 와 별개로, output 차원에서도 ambient declaration 을 emit 하지 않도록 한다.
+fn isDeclarationFile(file_path: []const u8) bool {
+    return std.mem.endsWith(u8, file_path, ".d.ts") or
+        std.mem.endsWith(u8, file_path, ".d.mts") or
+        std.mem.endsWith(u8, file_path, ".d.cts");
+}
+
 fn transpileWithCallbackInternal(
     allocator: std.mem.Allocator,
     source: []const u8,
@@ -1132,6 +1142,9 @@ fn transpileWithCallbackInternal(
     on_error: ?ErrorCallback,
     fast_path_disabled: bool,
 ) TranspileError!TranspileResult {
+    // `.d.ts` declaration 파일: 전체 type-only → 빈 출력 (D12.5).
+    if (isDeclarationFile(file_path)) return .{ .code = try allocator.dupe(u8, "") };
+
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
     const arena_alloc = arena.allocator();
@@ -1974,6 +1987,48 @@ test "TS auto type-only export: declaration merging preserves value binding" {
 // preset-typescript 동작). parser 가 top-level declare 를 strip 해 AST 에 사라지므로
 // markAutoTypeOnlyExportSpecifiers 가 별도 sideband (`ast.declare_only_names`) 에서
 // name 을 조회해야 한다.
+test "Transpile: .d.ts declaration file emits empty output (D12.5)" {
+    // tsc/Babel: `.d.ts` 는 declaration-only 파일이라 transpile 결과가 빈 출력.
+    // 이전 ZNTC 는 ambient const initializer 면제만 처리하고 codegen 단계에서
+    // 그대로 emit 해 `export const x;` 같은 invalid JS 가 나옴.
+    try expectTranspileOutput(
+        \\export const urlAlphabet: string;
+        \\export const nanoid: () => string;
+        \\
+    ,
+        "",
+        "index.d.ts",
+        .{},
+    );
+
+    // `.d.mts` / `.d.cts` 동일 처리
+    try expectTranspileOutput(
+        \\export const x: number;
+    ,
+        "",
+        "lib.d.mts",
+        .{},
+    );
+
+    try expectTranspileOutput(
+        \\export const x: number;
+    ,
+        "",
+        "lib.d.cts",
+        .{},
+    );
+
+    // 일반 `.ts` 는 영향 없음 (regression guard)
+    try expectTranspileOutput(
+        \\export const x = 1;
+        \\
+    ,
+        "export const x = 1;\n",
+        "input.ts",
+        .{},
+    );
+}
+
 test "TS auto type-only export: top-level declare bindings elide rename specifier (D13)" {
     // export declare class — Babel: `export {};` (ZNTC codegen 은 빈 export 통째 drop)
     try expectTranspileOutput(


### PR DESCRIPTION
## Summary

D12 follow-up — `.d.ts` / `.d.mts` / `.d.cts` 파일이 transpile 후 invalid JS 를 출력하던 문제. 이전 D12 fix 는 parser 단의 ambient const initializer 면제만 처리 → codegen 은 그대로 emit → `export const urlAlphabet;` 같이 initializer 없는 invalid JS.

## 재현 (fix 전)

```bash
echo 'export const urlAlphabet: string;' > /tmp/x.d.ts
./zig-out/bin/zntc /tmp/x.d.ts
# 출력: export const urlAlphabet;   ← invalid JS
```

tsc/Babel: `.d.ts` 는 declaration-only — transpile 결과가 빈 출력 (또는 ESM marker `export {};`). runtime 의미 없는 type-only 컨텐츠.

## 수정

`transpileWithCallbackInternal` 진입 직후 path 검사로 `.d.ts` / `.d.mts` / `.d.cts` 면 빈 출력 early return. parser/transformer/codegen 단계 전체 skip.

```zig
fn isDeclarationFile(file_path: []const u8) bool {
    return std.mem.endsWith(u8, file_path, ".d.ts") or
        std.mem.endsWith(u8, file_path, ".d.mts") or
        std.mem.endsWith(u8, file_path, ".d.cts");
}
```

## 회귀 가드

- nanoid `index.d.ts` 패턴 (export const : T;) → 빈 출력
- `.d.mts` / `.d.cts` 동일 처리
- 일반 `.ts` 회귀 없음 (`export const x = 1;` 그대로 emit)

## Fuzz 효과

zod 390 / immer 18 / type-fest 166 / @tanstack/query-core 74 — **648 파일 0 fail**. 일반 `.ts` 영향 없음 확인.

## Note

`export {};` ESM marker 차이 (Babel 은 명시적 marker 보존) 는 ZNTC 의 일관된 빈-출력 동작 정책. dual-emit (CJS/ESM) 같은 시나리오에서 marker 가 필요하면 별도 옵션으로 노출 검토.

## Test plan

- [x] `zig build test` D12.5 회귀 가드 4종 통과
- [x] 라이브러리 fuzz 0 fail (648 파일)
- [x] 일반 `.ts` 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)