### PR TITLE
feat(rn): extra.platforms validation sugar for Metro resolver.platforms

### DIFF
--- a/packages/core/bin/rn-dev-input.mjs
+++ b/packages/core/bin/rn-dev-input.mjs
@@ -86,6 +86,7 @@ export function buildRnBundleExtra(config, opts = {}) {
     nodeModulesPaths: resolver.nodeModulesPaths ?? undefined,
     sourceExts: opts.rnSourceExts ?? resolver.sourceExts ?? undefined,
     assetExts: resolver.assetExts ?? undefined,
+    platforms: resolver.platforms ?? undefined,
     blockList: resolver.blockList ?? undefined,
     fallback: resolver.extraNodeModules ?? undefined,
     metroResolveRequest: resolver.resolveRequest ?? undefined,

--- a/packages/core/test/cli/react-native-dev-input/bundle-options/resolver.ts
+++ b/packages/core/test/cli/react-native-dev-input/bundle-options/resolver.ts
@@ -24,6 +24,25 @@ describe('buildRnDevServerInput — resolver bundle option config 추출 (#2605)
     expect(input?.bundle.extra?.assetExts).toEqual(['.png']);
   });
 
+  test('config.resolver.platforms → bundle.extra.platforms 매핑', async () => {
+    const buildRnDevServerInput = await loadBuildRnDevServerInput();
+    const input = buildRnDevServerInput(
+      { entryPoints: ['i.js'] },
+      {
+        resolver: {
+          platforms: ['ios', 'android', 'native', 'web'],
+        },
+      },
+    );
+    expect(input?.bundle.extra?.platforms).toEqual(['ios', 'android', 'native', 'web']);
+  });
+
+  test('config.resolver.platforms 미지정 → bundle.extra.platforms undefined', async () => {
+    const buildRnDevServerInput = await loadBuildRnDevServerInput();
+    const input = buildRnDevServerInput({ entryPoints: ['i.js'] }, { resolver: {} });
+    expect(input?.bundle.extra?.platforms).toBeUndefined();
+  });
+
   test('config.alias / moduleSpecifierMap → bundle.override 매핑', async () => {
     const buildRnDevServerInput = await loadBuildRnDevServerInput();
     const input = buildRnDevServerInput(

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -83,6 +83,36 @@ describe('buildRnBundleOptions — platform 분기 (resolveExtensions)', () => {
   });
 });
 
+describe('buildRnBundleOptions — extra.platforms validation', () => {
+  test('rnPlatform 이 extra.platforms 에 포함되어 있으면 통과', () => {
+    expect(() =>
+      buildRnBundleOptions(
+        baseInput({ rnPlatform: 'ios', extra: { platforms: ['ios', 'android', 'native', 'web'] } }),
+      ),
+    ).not.toThrow();
+  });
+
+  test('rnPlatform 이 extra.platforms 에 없으면 throw', () => {
+    expect(() =>
+      buildRnBundleOptions(
+        baseInput({ rnPlatform: 'ios', extra: { platforms: ['android', 'web'] } }),
+      ),
+    ).toThrow(/does not include the active rnPlatform 'ios'/);
+  });
+
+  test('extra.platforms 미지정이면 통과 (기존 동작 유지)', () => {
+    expect(() => buildRnBundleOptions(baseInput({ rnPlatform: 'ios' }))).not.toThrow();
+  });
+
+  test('extra.platforms 는 resolveExtensions 의 prefix 에 영향 없음 (Metro 동일)', () => {
+    const opts = buildRnBundleOptions(
+      baseInput({ rnPlatform: 'ios', extra: { platforms: ['ios', 'android', 'web'] } }),
+    );
+    expect(opts.resolveExtensions?.[0]).toBe('.ios.ts');
+    expect(opts.resolveExtensions).not.toContain('.web.ts');
+  });
+});
+
 describe('buildRnBundleOptions — define / banner / footer / polyfills', () => {
   test('define — __DEV__ + process.env.NODE_ENV + Expo Router env + EXPO_OS', () => {
     const opts = buildRnBundleOptions(baseInput({ dev: true, rnPlatform: 'android' }));

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -88,6 +88,15 @@ export interface RnBundleInput {
     sourceExts?: string[];
     /** RN assetExts override (default RN preset). */
     assetExts?: string[];
+    /**
+     * Metro `resolver.platforms` 호환. caller 가 인식 가능한 platform 이름 set.
+     * `rnPlatform` 이 이 list 안에 있어야 하며, list 자체는 prefix 확장에는
+     * 영향 없음 (Metro 동작과 동일 — current platform suffix 만 expand). 이
+     * sugar 는 사용자가 자신의 platform list 를 명시했을 때 `rnPlatform`
+     * 누락을 빌드 직전에 잡는 validation 용. 미래의 platform typing 확장
+     * (e.g. `tvos`/`macos`) 의 placeholder.
+     */
+    platforms?: string[];
     /** 사용자 추가 polyfill (preset 의 RN polyfill 와 concat — Metro `serializer.polyfills` 호환). */
     polyfills?: string[];
     /**
@@ -327,6 +336,12 @@ function deepMerge<T extends Record<string, unknown>>(base: T, override: Partial
  */
 export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
   const { entry, projectRoot, rnPlatform, dev, sourcemap, minify, extra } = input;
+
+  if (extra?.platforms && !extra.platforms.includes(rnPlatform)) {
+    throw new Error(
+      `extra.platforms (${JSON.stringify(extra.platforms)}) does not include the active rnPlatform '${rnPlatform}'`,
+    );
+  }
 
   const sourceExts = extra?.sourceExts ?? DEFAULT_SOURCE_EXTS;
   const assetExts = extra?.assetExts ?? DEFAULT_ASSET_EXTS;


### PR DESCRIPTION
## Summary
- `RnBundleInput.extra.platforms?: string[]` typing 추가
- `rnPlatform` 이 `extra.platforms` 에 포함되어 있지 않으면 `buildRnBundleOptions` 가 throw — Metro `resolver.platforms` 호환의 단기 sugar
- prefix 확장에는 영향 없음 (current platform suffix 만 expand — Metro 동일 동작)
- `rn-dev-input.mjs` 가 `config.resolver.platforms` 를 `extra.platforms` 로 forward
- #3149 의 단기 sugar 항목 (`resolver.platforms` deferred 결론에서 단기 추가로 명시된 부분)

## Why
이슈 #3149 에서 `resolver.platforms` 는 sugar 누락 / deferred 로 정리되었으나, 본문 결론에 "`extra.platforms?: string[]` 추가 + `buildResolveExtensions` expand sugar 만 단기 추가" 로 작은 후속이 명시됨. 이 PR 은 그 중 typing + validation 부분.

prefix 확장은 Metro 동작 ("active platform suffix 만 generate") 을 그대로 따라 동작 변경 0 — `extra.platforms` 가 미지정이면 기존 동작 동일, 명시되어 있고 `rnPlatform` 누락 시 build 시점에 throw 로 사용자 실수를 빨리 알림.

미래의 `rnPlatform` 타입 자체 확장 (e.g. `tvos`/`macos`) 의 placeholder 로도 작동.

## Test plan
- [x] `packages/react-native/src/preset.test.ts` — extra.platforms validation 4 케이스 추가 (포함/누락/미지정/prefix 비변경)
- [x] `packages/core/test/cli/react-native-dev-input/bundle-options/resolver.ts` — config.resolver.platforms → extra.platforms forwarding 2 케이스
- [x] `zig build test` 전체 통과
- [x] `bun x tsc -b --force` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)