### PR TITLE
test(tsc): flip readonlyInConstructorParameters to expectPass

### DIFF
--- a/tests/integration/tests/tsc/__snapshots__/classes.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/classes.test.ts.snap
@@ -11296,3 +11296,24 @@ class Y {
 `;
 
 exports[`TSC: classes privateNameInObjectLiteral-3 1`] = `""`;
+
+exports[`TSC: classes readonlyInConstructorParameters 1`] = `
+"class C {
+	constructor(x) {
+		this.x = x;
+	}
+}
+new C(1).x = 2;
+class E {
+	constructor(x) {
+		this.x = x;
+	}
+}
+class F {
+	constructor(x) {
+		this.x = x;
+	}
+}
+new F(1).x;
+"
+`;

--- a/tests/integration/tests/tsc/classes.test.ts
+++ b/tests/integration/tests/tsc/classes.test.ts
@@ -3212,7 +3212,10 @@ class E extends D {
     );
   });
   test('readonlyInConstructorParameters', async () => {
-    await expectError(
+    // tsc 본가는 readonly assignment / modifier order (`readonly public`) 를 type
+    // 단계에서 잡지만 ZNTC 는 type checker 가 아니라 transpile 만 — runtime 정상.
+    // emit 결과가 valid 라 expectPass 로 회귀 감지.
+    await expectPass(
       `class C {
     constructor(readonly x: number) {}
 }


### PR DESCRIPTION
## Summary
- `tests/integration/tests/tsc/classes.test.ts` 의 `readonlyInConstructorParameters` 를 `expectError` → `expectPass` + snapshot 으로 전환
- abacd539 commit message 에 명시된 "2189 pass / 16 fail" known 16 fail 중 하나

## Why
tsc 본가는 다음을 type 단계에서 잡음:
- `new C(1).x = 2` — readonly assignment
- `class E { constructor(readonly public x: number) }` — modifier order (TS1029)

ZNTC 는 type checker 가 아니라 transpile-only. emit 결과 자체는 valid runtime 코드라서 `expectError` 의도가 ZNTC 정책과 충돌. abacd539 가 sloppy-mode-only fixture 를 `expectError` 로 옮긴 것과 정반대 방향 — **type-level error 만 있고 ZNTC 가 그대로 통과시키는 fixture 는 `expectPass` + snapshot** 으로 회귀 감지.

## Test plan
- [x] `bun test tests/tsc/classes.test.ts -t "readonlyInConstructorParameters"` → 1 pass (snapshot 등록)
- [x] `bun test tests/tsc/classes.test.ts` 전체 → 460 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)