### PR TITLE
fix(parser): allow object/class method named get/set/async + generic params

### DIFF
--- a/src/parser/declaration.zig
+++ b/src/parser/declaration.zig
@@ -633,9 +633,12 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
         }
     }
 
-    // async (선택): async [no LineTerminator here] MethodName
-    // 스펙: async와 다음 토큰(*/PropertyName) 사이에 줄바꿈이 없어야 함
+    // async (선택): async [no LineTerminator here] MethodName.
+    // 스펙: async와 다음 토큰(*/PropertyName) 사이에 줄바꿈이 없어야 함.
+    // D17: `async<T>()` 는 'async' 이름의 generic method (async modifier 아님) —
+    // 다음 토큰이 `<` 면 일반 method 로 fallback. object literal 의 동일 fix 와 paired.
     if (self.current() == .kw_async and try self.peekNextKind() != .l_paren and
+        try self.peekNextKind() != .l_angle and
         !(try self.peekNext()).has_newline_before)
     {
         flags |= @intCast(ast_mod.MethodFlags.is_async);

--- a/src/parser/object.zig
+++ b/src/parser/object.zig
@@ -61,10 +61,15 @@ pub fn parseObjectProperty(self: *Parser) ParseError2!NodeIndex {
         });
     }
 
-    // get/set 메서드 shorthand: { get prop() {}, set prop(v) {} }
+    // get/set 메서드 shorthand: { get prop() {}, set prop(v) {} }.
+    // D17: setter/getter 는 generic type parameter 를 받을 수 없으므로 `<` 가 따라오면
+    // 일반 method 로 fallback — `{ set<T>(v: T) {} }` 는 'set' 이라는 이름의 generic
+    // method (Babel/tsc 동작). class member parser 는 동일 분기를 이미 처리.
     if (self.current() == .kw_get or self.current() == .kw_set) {
         const peek = try self.peekNextKind();
-        if (peek != .colon and peek != .l_paren and peek != .comma and peek != .r_curly) {
+        if (peek != .colon and peek != .l_paren and peek != .comma and peek != .r_curly and
+            peek != .l_angle)
+        {
             const method_flags: u16 = if (self.current() == .kw_get) 0x02 else 0x04;
             try self.advance(); // skip get/set
             const key = try self.parsePropertyKey();
@@ -73,12 +78,14 @@ pub fn parseObjectProperty(self: *Parser) ParseError2!NodeIndex {
         }
     }
 
-    // async 메서드 shorthand: { async foo() {} }
+    // async 메서드 shorthand: { async foo() {} }.
     // 주의: { async() {} }는 'async'라는 이름의 일반 메서드 (async 수식어가 아님).
+    // D17: { async<T>() {} } 도 'async' 이름의 generic method.
     if (self.current() == .kw_async) {
         const peek = try self.peekNext();
         if (peek.kind != .colon and peek.kind != .comma and
-            peek.kind != .r_curly and peek.kind != .l_paren and !peek.has_newline_before)
+            peek.kind != .r_curly and peek.kind != .l_paren and peek.kind != .l_angle and
+            !peek.has_newline_before)
         {
             var method_flags: u16 = 0x08; // async
             try self.advance(); // skip 'async'

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -3344,6 +3344,28 @@ test "TS: strict-mode reserved word cannot be used as binding (D16)" {
     try expectParseErrorWithExt("let f = (arguments: any) => true;", ".ts", .{ .message_contains = "arguments" });
 }
 
+test "TS: object literal method shorthand named get/set/async with generics (D17)" {
+    // mobx `src/api/observable.ts` 의 `set<T = any>(...)` 패턴. object literal property
+    // parser 의 get/set/async 분기가 `peek != .l_paren/.colon/.comma/.r_curly` 만 검사 →
+    // 다음 토큰이 `<` 면 accessor 로 lock-in 후 parsePropertyKey 가 `<` 만남 → fail.
+    // setter/getter 는 generic 받을 수 없으므로 (Babel/tsc 동작) `<` 면 일반 method 로
+    // fallback. class member parser 는 동일 disambiguation 이 이미 통과 (regression
+    // 가드 함께).
+    try expectNoParseErrorWithExt("const o = { set<T = any>(x?: T): void {} };", ".ts");
+    try expectNoParseErrorWithExt("const o = { get<T = any>(): T { return null as any; } };", ".ts");
+    try expectNoParseErrorWithExt("const o = { async<T>(): Promise<T> { return null as any; } };", ".ts");
+    // 일반 setter / getter / async 는 그대로 동작 (regression guard)
+    try expectNoParseErrorWithExt("const o = { set foo(v: number) {} };", ".ts");
+    try expectNoParseErrorWithExt("const o = { get foo(): number { return 1; } };", ".ts");
+    try expectNoParseErrorWithExt("const o = { async foo() {} };", ".ts");
+    // setter/getter/async 가 일반 property key 로도 가능 (shorthand)
+    try expectNoParseErrorWithExt("const o = { set: 1, get: 2, async: 3 };", ".ts");
+    // class member 의 동일 패턴 — 이전부터 통과 (회귀 가드)
+    try expectNoParseErrorWithExt("class C { set<T = any>(x?: T): void {} get<T>(): T { return null as any; } }", ".ts");
+    // class 의 async modifier 도 `async<T>()` 면 일반 method (D17 paired fix)
+    try expectNoParseErrorWithExt("class C { async<T>(): Promise<T> { return null as any; } }", ".ts");
+}
+
 test "TS: numeric literal type accepts all numeric kinds (D15)" {
     // type-fest `numeric.d.ts` 의 `PositiveInfinity = 1e999;` 패턴.
     // parsePrimaryType 의 numeric 분기에 `.positive_exponential` / `.negative_exponential`


### PR DESCRIPTION
## Summary

`const obj = { set<T = any>(x?: T): void {} };` 패턴이 `Property key expected [ZNTC0608]` 로 거부되던 회귀 fix. mobx `src/api/observable.ts:235` 의 ObservableSet factory 패턴.

## 재현 (fix 전)

```ts
const obj = { set<T = any>(x?: T): void {} };
// × Property key expected [ZNTC0608]

const obj2 = { get<T>(): T { ... } };  // 동일
const obj3 = { async<T>(): Promise<T> { ... } };  // 동일

class C { async<T>(): Promise<T> { ... } }  // 동일 (paired fix)
```

setter/getter 는 generic 을 받을 수 없으므로 Babel/tsc 는 `<` 이면 일반 method 로 fallback. class member 의 get/set 분기 (declaration.zig:625) 는 이미 처리됨.

## 원인

object literal property parser 의 get/set/async 분기가 peek 검사를 4-tag (`colon/l_paren/comma/r_curly`) 로만 해서 다음 토큰이 `<` 면 accessor/async modifier 로 lock-in 후 `parsePropertyKey` 가 `<` 만남 → fail. class async modifier 분기도 `peek != .l_paren` 만 — 동일 누락 (review agent 가 추가 발견).

## 수정 (2 파일)

- `src/parser/object.zig` `parseObjectProperty`:
  - get/set 분기 peek 검사에 `peek != .l_angle` 추가
  - async 분기 peek 검사에 `peek.kind != .l_angle` 추가
- `src/parser/declaration.zig` `parseClassMember` async modifier 분기에 동일 추가

## 회귀 가드

| 패턴 | 처리 |
|---|---|
| `{ set<T>(){} }`, `{ get<T>(){} }`, `{ async<T>(){} }` | ✓ |
| `{ set foo() {} }`, `{ get foo() {} }`, `{ async foo() {} }` (regression) | ✓ |
| `{ set:1, get:2, async:3 }` (shorthand) | ✓ |
| `class C { set<T>(){}, get<T>(){}, async<T>(){} }` | ✓ (paired) |

## Fuzz 효과

- mobx 6.15.0: **0 / 115** (이전 1 fail)
- zod 4.4.1: 0 / 390 (회귀 0)
- immer 11.1.4: 0 / 18 (회귀 0)

3 agent /simplify review 통과 — class async modifier 의 동일 누락도 paired fix.

## Test plan

- [x] `zig build test` D17 회귀 가드 통과
- [x] `zig build test -Doptimize=ReleaseFast` 통과
- [x] mobx 0 fail (이전 1 → 0)
- [x] zod/immer 회귀 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)