### PR TITLE
docs: React Native 런타임 지원 범위 명확화

### DIFF
--- a/documents/src/content/docs/en/guides/react-native.md
+++ b/documents/src/content/docs/en/guides/react-native.md
@@ -492,4 +492,5 @@ Verification matrix (both use `bun run start:zntc` for the ZNTC dev server):
 ## Compatibility
 
 - RN `>= 0.83` peer-optional. `@zntc/react-native` matches the Hermes / RN-runtime HMRClient interface and Metro's `sourceMappingURL` route conventions.
-- Runs on Bun + Node 22+. Dev-server lifecycle handles SIGINT / SIGTERM with a graceful shutdown.
+- Runs on Node.js 24+. Bun 1.3+ is also supported through its Node-compatible runtime.
+- The dev-server lifecycle uses `process` signal handlers to perform graceful shutdown on SIGINT / SIGTERM.

--- a/documents/src/content/docs/guides/react-native.md
+++ b/documents/src/content/docs/guides/react-native.md
@@ -492,4 +492,5 @@ console.log(`Listening on ${handle.url}`);
 ## 호환성
 
 - RN `>= 0.83` peer optional. `@zntc/react-native` 가 Hermes / RN runtime 의 HMRClient interface 와 sourceMappingURL 라우트 컨벤션 호환.
-- Bun + Node 22+ 에서 동작. dev server lifecycle 은 SIGINT/SIGTERM graceful shutdown 보장.
+- Node.js 24+ 환경에서 동작하며, Bun 1.3+ 에서도 Node-compatible runtime 으로 사용할 수 있습니다.
+- Dev server lifecycle 은 `process` signal handler 기반으로 SIGINT/SIGTERM graceful shutdown 을 처리합니다.


### PR DESCRIPTION
## 요약

- React Native 가이드의 `Bun + Node 22+` 표현을 현재 패키지 엔진과 맞게 수정했습니다.
- Node.js 24+가 기본 지원 환경이고, Bun 1.3+는 Node-compatible runtime으로 사용할 수 있다는 점을 한국어/영문 문서에 반영했습니다.
- Dev server 종료 처리는 Bun 전용이 아니라 `process` signal handler 기반임을 명확히 적었습니다.

## 테스트

- `git diff --check -- documents/src/content/docs/guides/react-native.md documents/src/content/docs/en/guides/react-native.md`
- `rg -n "Bun \\+ Node|Node 22\\+|Node 22" documents/src/content/docs/guides/react-native.md documents/src/content/docs/en/guides/react-native.md documents/src/content/docs/guides/react-native-expo.md documents/src/content/docs/en/guides/react-native-expo.md`
- `bun run --cwd documents build`