### PR TITLE
fix(parser): bail generic-args speculation for literal LHS (parserRealSource2.ts HANG)

### DIFF
--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -416,6 +416,23 @@ pub const Node = struct {
         // 합계: 개수는 컴파일 타임에 Tag 필드 수로 자동 검증
         // ==============================================================
 
+        /// 위 Literals 블록의 7개 태그를 한 군데서 판정 — 새 literal 추가시
+        /// silent bypass 차단. generic-args speculation 등 "literal LHS 면
+        /// callable 불가" 분기에서 쓰인다.
+        pub fn isLiteralTag(tag: Tag) bool {
+            return switch (tag) {
+                .boolean_literal,
+                .null_literal,
+                .numeric_literal,
+                .string_literal,
+                .bigint_literal,
+                .regexp_literal,
+                .template_literal,
+                => true,
+                else => false,
+            };
+        }
+
         /// type-only 선언 태그 판별.
         /// export 문에서 이 태그의 decl은 런타임 코드를 생성하지 않으므로
         /// export_named_declaration으로 래핑하지 않아야 함.

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -991,6 +991,12 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
                 // TS generic type arguments: foo<Type>() or foo<<T>() => T>()
                 // Speculative parse: try parsing <Type>, check if followed by ( or `
                 // If not, restore state and let binary expression handle < as comparison.
+                //
+                // Literal LHS 는 generic-call target 이 될 수 없다 — speculation 은
+                // 무조건 실패하면서 안쪽에 nested `<<` 가 있으면 각 `<<` 마다 재귀
+                // speculation 이 발화해 O(2^N) 폭주 (TSC conformance
+                // `parserRealSource2.ts` 1<<N enum 멤버 20개+ HANG).
+                if (self.ast.getNode(expr).tag.isLiteralTag()) break;
                 if (!trySkipTypeArgsSpeculative(self, true, type_args.canFollowTypeArgumentsInExpression)) break;
             },
             .bang => {

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -4125,3 +4125,34 @@ test "Flow enum: TS mode 에서는 일반 ts_enum_declaration" {
     try std.testing.expectEqual(@as(usize, 1), ts_count);
     try std.testing.expectEqual(@as(usize, 0), flowEnumDeclCount(&r));
 }
+
+// `1 << N` 패턴이 20개 이상 누적되면 generic type-args speculation 이 nested
+// `<<` 마다 재귀 backtrack 해 O(2^N) 으로 폭주 → TSC conformance
+// `parserRealSource2.ts` 무한 루프. 회귀 시 hang 으로 timeout 까지 가지 않고
+// 빠르게 fail 하도록 Timer 로 100ms upper bound 어설션.
+test "TS enum: 30 left-shift initializers 은 O(2^N) speculation 없이 즉시 파싱" {
+    var src: std.ArrayList(u8) = .empty;
+    defer src.deinit(std.testing.allocator);
+    try src.appendSlice(std.testing.allocator, "enum E {\n");
+    var i: usize = 0;
+    while (i < 30) : (i += 1) {
+        var line_buf: [64]u8 = undefined;
+        const line = try std.fmt.bufPrint(&line_buf, "  A{d} = 1 << {d},\n", .{ i, i });
+        try src.appendSlice(std.testing.allocator, line);
+    }
+    try src.appendSlice(std.testing.allocator, "}\n");
+
+    var timer = try std.time.Timer.start();
+    var r = try parseTs(std.testing.allocator, src.items);
+    defer r.deinit();
+    const elapsed_ns = timer.read();
+
+    var enum_count: usize = 0;
+    for (r.parser.ast.nodes.items) |node| {
+        if (node.tag == .ts_enum_declaration) enum_count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 1), enum_count);
+    // 1 << 19 부터 exponential — 정상 경로는 debug 빌드에서도 한자릿수 ms.
+    // 100ms 초과면 speculation 회귀로 본다. CI 노이즈 흡수 위해 여유 마진.
+    try std.testing.expect(elapsed_ns < 100 * std.time.ns_per_ms);
+}

--- a/tests/integration/tests/tsc/__snapshots__/enums.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/enums.test.ts.snap
@@ -56,13 +56,6 @@ var E10 = /* @__PURE__ */ ((E10) => {return E10;})(E10 || {});
 var E11 = /* @__PURE__ */ ((E11) => {E11[E11["A"]=+0]="A";E11[E11["B"]=0]="B";E11[E11["C"]=1]="C";return E11;})(E11 || {});
 var E12 = /* @__PURE__ */ ((E12) => {E12[E12["A"]=1 << 0]="A";E12[E12["B"]=1 << 1]="B";E12[E12["C"]=1 << 2]="C";return E12;})(E12 || {});
 // Examples of numeric enum types with constant and computed members
-// Examples of numeric enum types with constant and computed members
-// Examples of numeric enum types with constant and computed members
-// Examples of numeric enum types with constant and computed members
-// Examples of numeric enum types with constant and computed members
-// Examples of numeric enum types with constant and computed members
-// Examples of numeric enum types with constant and computed members
-// Examples of numeric enum types with constant and computed members
 var E20 = /* @__PURE__ */ ((E20) => {E20[E20["A"]="foo".length]="A";E20[E20["B"]=A + 1]="B";E20[E20["C"]=+"123"]="C";E20[E20["D"]=Math.sin(1)]="D";return E20;})(E20 || {});
 "
 `;
@@ -171,5 +164,10 @@ exports[`TSC: enums enumShadowedInfinityNaN 1`] = `
 	let NaN = {};
 	var En = /* @__PURE__ */ ((En) => {En[En["X"]=NaN]="X";return En;})(En || {});
 }
+"
+`;
+
+exports[`TSC: enums parserRealSource2-style bit-mask enum (30 members) finishes promptly 1`] = `
+"export var E = /* @__PURE__ */ ((E) => {E[E["A0"]=1 << 0]="A0";E[E["A1"]=1 << 1]="A1";E[E["A2"]=1 << 2]="A2";E[E["A3"]=1 << 3]="A3";E[E["A4"]=1 << 4]="A4";E[E["A5"]=1 << 5]="A5";E[E["A6"]=1 << 6]="A6";E[E["A7"]=1 << 7]="A7";E[E["A8"]=1 << 8]="A8";E[E["A9"]=1 << 9]="A9";E[E["A10"]=1 << 10]="A10";E[E["A11"]=1 << 11]="A11";E[E["A12"]=1 << 12]="A12";E[E["A13"]=1 << 13]="A13";E[E["A14"]=1 << 14]="A14";E[E["A15"]=1 << 15]="A15";E[E["A16"]=1 << 16]="A16";E[E["A17"]=1 << 17]="A17";E[E["A18"]=1 << 18]="A18";E[E["A19"]=1 << 19]="A19";E[E["A20"]=1 << 20]="A20";E[E["A21"]=1 << 21]="A21";E[E["A22"]=1 << 22]="A22";E[E["A23"]=1 << 23]="A23";E[E["A24"]=1 << 24]="A24";E[E["A25"]=1 << 25]="A25";E[E["A26"]=1 << 26]="A26";E[E["A27"]=1 << 27]="A27";E[E["A28"]=1 << 28]="A28";E[E["A29"]=1 << 29]="A29";return E;})(E || {});
 "
 `;

--- a/tests/integration/tests/tsc/enums.test.ts
+++ b/tests/integration/tests/tsc/enums.test.ts
@@ -621,4 +621,12 @@ namespace M2 {
       [],
     );
   });
+
+  // 회귀 가드: `1 << N` 누적시 generic-args speculation 의 nested `<<` 재귀
+  // backtrack 이 O(2^N) 으로 폭주해 무한 루프처럼 보였던 케이스. expectPass 가
+  // bun 의 기본 30s default-timeout 안에 끝나야 한다.
+  test('parserRealSource2-style bit-mask enum (30 members) finishes promptly', async () => {
+    const members = Array.from({ length: 30 }, (_, i) => `    A${i} = 1 << ${i},`).join('\n');
+    await expectPass(`export enum E {\n${members}\n}`, []);
+  });
 });


### PR DESCRIPTION
## 요약

PR #3187 TSC conformance audit 가 발견한 P0 HANG (`parserRealSource2.ts`) 픽스. 다른 번들러들도 같은 분기를 쓰지만 architecture 차이로 폭주가 없는 것을 확인하고, TSC 본체의 `canTryReparseTypeArguments` 와 같은 접근으로 ZNTC 에 맞는 root-cause 위치에서 차단.

## 원인 체인

1. `class C { @dec ["x"]() {} }` 같은 패턴이 아니라 — `enum E { A = 1 << 0, B = 1 << 1, ... A19 = 1 << 19, A20 = 1 << 20 }` 처럼 **`literal << N` 가 20개 이상 누적** 시 발화.
2. `expression.zig` postfix-continuation loop 의 `.l_angle | .shift_left` 분기가 generic type-args speculation 을 무조건 시도.
3. 내부 `parseType` 가 다시 `parseTypeArgumentsInExpression` 으로 재진입 → 각 `<<` 토큰마다 nested speculation 발화 → **O(2^N) backtrack 폭주**.
4. `1 << 19` 부터 debug 빌드에서도 1초+, 20+ 멤버는 timeout 안 끝남 → TSC conformance fixture HANG.

## 다른 번들러 비교 (memory feedback_compare_three.md / feedback_oxc_reference.md)

| Parser | 같은 분기? | 시간 (parserRealSource2.ts) | 차이점 |
|---|---|---:|---|
| esbuild | ✅ (`js_parser.go:4725`) | **43ms** | 내부 `skipTypeScriptType` 는 iterative — expression speculation 으로 재진입 안 함 |
| oxc | ✅ (`expression.rs:875`) | **0.3ms** | inner type-parser 가 type-mode (expression-mode 아님) |
| TSC 본체 | ✅ | 빠름 | `canTryReparseTypeArguments` 가드 (literal LHS 차단) |
| **ZNTC (전)** | ✅ | **HANG (timeout)** | inner type-parser 가 expression-mode speculation 으로 재진입 |
| **ZNTC (본 PR)** | ✅ + literal LHS 가드 | **즉시** | TSC 본체와 같은 접근 |

architectural 격리 (inner type-parser 를 type-only mode 로 분리) 는 별도 큰 작업. 본 PR 은 TSC 와 같은 가드만 추가.

## 수정

### `src/parser/ast.zig`
```zig
pub fn isLiteralTag(tag: Tag) bool {
    return switch (tag) {
        .boolean_literal, .null_literal, .numeric_literal,
        .string_literal, .bigint_literal, .regexp_literal,
        .template_literal,
        => true,
        else => false,
    };
}
```
`Tag.isLiteralTag` 를 Literals 블록 옆에 colocate — 새 literal 태그 추가 시 silent bypass 차단 (Tag block 의 7개 그대로 유지).

### `src/parser/expression.zig`
```zig
.l_angle, .shift_left => {
    // Literal LHS 는 generic-call target 이 될 수 없다 — speculation 무용.
    if (self.ast.getNode(expr).tag.isLiteralTag()) break;
    if (!trySkipTypeArgsSpeculative(...)) break;
},
```

## 영향

TSC conformance audit (`scripts/tsc-conformance-audit.ts`):

| | Before | After |
|---|---:|---:|
| **HANG** | **1** | **0** |
| OK_pass | 3556 | 3557 (+1) |
| Match rate | 90.09% | 90.11% |
| Audit 실시간 | 5.7s (timeout-wait) | 1.2s |

## 회귀 가드

**unit** (`src/parser/parser_test.zig`): 30 left-shift enum + `std.time.Timer` 100ms upper bound — 회귀 시 hang 대신 빠른 fail.

**integration** (`tests/integration/tests/tsc/enums.test.ts`): bun 30s default-timeout 안에 끝나야 하는 30-멤버 bit-mask enum case (`parserRealSource2-style ... finishes promptly`).

## 부수 — stale 스냅샷 갱신

`tests/integration/tests/tsc/__snapshots__/enums.test.ts.snap` 의 `enumClassification` 케이스에서 `// Examples of numeric enum types with constant and computed members` 주석이 8회 중복으로 박혀 있었다. 폭주 시 backtracking 부작용으로 같은 주석이 여러 번 emit 됐던 stale 데이터 — 정상 1회로 갱신.

## Test plan

- [x] `zig build` / `zig build test` 정상
- [x] `cd tests/integration && bun test tests/tsc/` 2210/2210 pass (+1 신규 regression)
- [x] `cd tests/integration && bun test tests/bundle-smoke.test.ts` 151/151 pass
- [x] `zig build -Doptimize=ReleaseFast` 정상 + ReleaseFast 빌드도 즉시 종료
- [x] `bun run scripts/tsc-conformance-audit.ts` HANG 0 / match rate 90.11%
- [ ] CI Integration & E2E + ReleaseFast

🤖 Generated with [Claude Code](https://claude.com/claude-code)