### PR TITLE
chore(scripts): audit oracle picks up TSC matrix-baselines

### DIFF
--- a/scripts/tsc-conformance-audit.ts
+++ b/scripts/tsc-conformance-audit.ts
@@ -108,20 +108,36 @@ function isMultiFileFixture(path: string): boolean {
   return MULTIFILE_DIRECTIVE.test(readHead(path, HEAD_READ_BYTES));
 }
 
-function indexBaselines(): Set<string> {
-  const out = new Set<string>();
+/// TSC baseline 들을 basename → 파일 경로 리스트 로 인덱싱.
+/// TSC 는 compiler-option matrix 마다 별도 `<basename>(opt=val,...).errors.txt`
+/// 를 생성한다 (예: `decoratorOnClassMethod3(target=es5).errors.txt`).
+/// 동일 basename 의 모든 variant 를 모아 oracle 이 매트릭스 전체를 합산한다.
+function indexBaselines(): Map<string, string[]> {
+  const out = new Map<string, string[]>();
   const suffix = ".errors.txt";
   for (const f of readdirSync(BASELINE_DIR)) {
-    if (f.endsWith(suffix)) out.add(f.slice(0, -suffix.length));
+    if (!f.endsWith(suffix)) continue;
+    const stem = f.slice(0, -suffix.length);
+    const paren = stem.indexOf("(");
+    const base = paren >= 0 ? stem.slice(0, paren) : stem;
+    let list = out.get(base);
+    if (!list) {
+      list = [];
+      out.set(base, list);
+    }
+    list.push(f);
   }
   return out;
 }
 
-function loadOracle(base: string, baselineIndex: Set<string>): Oracle {
-  if (!baselineIndex.has(base)) return { kind: "accept", codes: [] };
-  const txt = readFileSync(join(BASELINE_DIR, `${base}.errors.txt`), "utf8");
+function loadOracle(base: string, baselineIndex: Map<string, string[]>): Oracle {
+  const files = baselineIndex.get(base);
+  if (!files) return { kind: "accept", codes: [] };
   const codes = new Set<number>();
-  for (const m of txt.matchAll(/error TS(\d+)/g)) codes.add(Number(m[1]));
+  for (const f of files) {
+    const txt = readFileSync(join(BASELINE_DIR, f), "utf8");
+    for (const m of txt.matchAll(/error TS(\d+)/g)) codes.add(Number(m[1]));
+  }
   const sorted = [...codes].sort((a, b) => a - b);
   const hasSyntax = sorted.some((c) => c >= 1000 && c < 2000);
   return { kind: hasSyntax ? "syntax-error" : "accept", codes: sorted };


### PR DESCRIPTION
## 요약

TSC conformance audit (PR #3187) 의 oracle 정확도 결함 발견 — `decoratorOnClassMethod3(target=es5).errors.txt` 같은 **parameterized baseline** 을 못 찾아 124 fixture 가 잘못 false_reject 로 분류됐다. parser 변경 없이 oracle 만 정리.

## 발견 경로

다음 D 후보 분석 중 `Property key expected` 4 케이스가 dec3/Property3/Accessor3/Accessor6 — 모두 `public @dec X` (modifier-then-decorator) 패턴이라 parser bug 처럼 보였다. 그런데:

```bash
$ ls references/typescript/tests/baselines/reference/decoratorOnClassMethod3.errors.txt
ls: ... No such file or directory

$ ls 'references/typescript/tests/baselines/reference/decoratorOnClassMethod3(target=es5).errors.txt'
... (exists, contains TS1436 syntax error)
```

TSC 도 `TS1436: Decorators must precede the name and all keywords of property declarations` 로 거부 — ZNTC 가 옳은 거였고, audit oracle 만 잘못 분류했다.

TSC 는 compiler-option matrix (target=es5/es2015, module=node18/node20/nodenext, alwaysstrict=true/false 등) 조합마다 별도 baseline 을 생성한다. 기존 oracle 은 un-parameterized 형태만 매칭했다.

## 수정

```ts
// before: Set<basename>
function indexBaselines(): Set<string> { ... }

// after: Map<basename, [variant1_file, variant2_file, ...]>
function indexBaselines(): Map<string, string[]> { ... }
```

stem 의 `(opt=val,...)` 접미사를 strip 한 basename 으로 그룹화. `loadOracle` 가 모든 variant 의 error code 를 합산해서 한 variant 라도 TS1xxx 포함이면 reject 기대.

parser-level error (TS1xxx) 는 target/module/strict 매트릭스와 무관하므로 over-approximation 이지만 안전 (모든 variant 가 syntax error 면 어느 매트릭스든 zntc 가 거부해야 한다는 의미).

## 영향 — full audit (4499 single-file fixture)

| | Before | After |
|---|---:|---:|
| OK_pass | 3557 | 3481 (-76) |
| OK_reject | 497 | **621** (+124) |
| false_reject (FR) | 268 | **144** (-124) |
| false_accept (FA) | 177 | 253 (+76) |
| Match rate | 90.11% | **91.18%** |

FR -124 는 잘못 분류됐던 oracle artifact. FA +76 은 이전엔 baseline 없음 (=accept 기대) 였으나 이제 parameterized baseline 발견으로 reject 기대 — type-only 에러가 다수일 가능성 (ZNTC 가 strip 만 하므로 합법적 FA).

## Test plan

- [x] `bun run scripts/tsc-conformance-audit.ts --limit=300` smoke 통과 (match rate 93.67%)
- [x] 전체 audit 4499 → 91.18% match
- [x] `dec3/Property3/Accessor3/Accessor6` 모두 OK_reject 로 reclassify 확인 (parser 변경 없이)

🤖 Generated with [Claude Code](https://claude.com/claude-code)