### PR TITLE
chore(scripts): audit oracle treats syntax-level TS18xxx as reject

### DIFF
--- a/scripts/tsc-conformance-audit.ts
+++ b/scripts/tsc-conformance-audit.ts
@@ -42,6 +42,32 @@ const DIR_RANK_LIMIT = 15;
 const DEFAULT_CONCURRENCY = 16;
 const HEAD_READ_BYTES = 4_096;
 
+/// TSC 의 일부 TS18xxx 진단은 parser-level 거부 (private name 사용 제약,
+/// `#constructor` 예약어 등). TS1xxx 와 동일하게 "syntax error 기대" 로 친다.
+/// 나머지 TS18xxx (type/config 영역) 는 제외.
+/// 출처: references/typescript/src/compiler/diagnosticMessages.json.
+const TS18_SYNTAX_LEVEL_CODES: ReadonlySet<number> = new Set([
+  18006, // Classes may not have a field named 'constructor'
+  18007, // JSX expressions may not use the comma operator
+  18009, // Private identifiers cannot be used as parameters
+  18010, // An accessibility modifier cannot be used with a private identifier
+  18011, // The operand of a 'delete' operator cannot be a private identifier
+  18012, // '#constructor' is a reserved word
+  18016, // Private identifiers are not allowed outside class bodies
+  18019, // modifier cannot be used with a private identifier
+  18024, // An enum member cannot be named with a private identifier
+  18026, // '#!' can only be used at the start of a file
+  18029, // Private identifiers are not allowed in variable declarations
+  18030, // An optional chain cannot contain private identifiers
+  18036, // Class decorators can't be used with static private identifier
+  18037, // 'await' expression cannot be used inside a class static block
+]);
+
+function isSyntaxLevelCode(code: number): boolean {
+  if (code >= 1000 && code < 2000) return true;
+  return TS18_SYNTAX_LEVEL_CODES.has(code);
+}
+
 const OUTCOMES = [
   "OK_pass",
   "OK_reject",
@@ -139,7 +165,7 @@ function loadOracle(base: string, baselineIndex: Map<string, string[]>): Oracle 
     for (const m of txt.matchAll(/error TS(\d+)/g)) codes.add(Number(m[1]));
   }
   const sorted = [...codes].sort((a, b) => a - b);
-  const hasSyntax = sorted.some((c) => c >= 1000 && c < 2000);
+  const hasSyntax = sorted.some(isSyntaxLevelCode);
   return { kind: hasSyntax ? "syntax-error" : "accept", codes: sorted };
 }
 
@@ -321,7 +347,7 @@ async function main() {
       `  ${r.fixture.rel}\n    err: ${r.zntcFirstError}`,
     );
     printSamples("false_accept", results, "MISMATCH_false_accept", (r) => {
-      const codes = r.oracle.codes.filter((c) => c >= 1000 && c < 2000).join(",");
+      const codes = r.oracle.codes.filter(isSyntaxLevelCode).join(",");
       return `  ${r.fixture.rel}  TS:${codes}`;
     });
   }


### PR DESCRIPTION
## 요약

`classes/` 디렉터리 FR=40 클러스터 분석 결과 발견된 두 번째 audit oracle 결함 fix. TSC 의 TS18xxx 진단은 type-level 과 parser-level 이 섞여 있어, parser-level 거부 (`Private identifiers are not allowed in variable declarations` 등) 가 들어간 fixture 가 잘못 false_reject 로 분류됐다.

## 발견 경로

`classes/` FR=40 의 sub-cluster:

| Cluster | 케이스 수 | 원인 |
|---|---:|---|
| `Binding pattern expected` | 3 | `const #foo`, `setFoo(#foo)` 같은 private id 부적절 사용 — TSC: TS18029/18009 (parser-level 거부) |
| `prototype`/`constructor` field 명 | 2 | `class C { static prototype }` — TSC: TS18006 (parser-level 거부) |
| `delete` private | 1 | TSC: TS18011 (parser-level 거부) |
| Private id outside class | 3 | TSC: TS18016 (parser-level 거부) |

이들 모두 ZNTC 가 정상 거부하지만 audit oracle 이 TS1xxx 만 syntax 로 봐서 잘못 false_reject.

(`Private field must be declared in enclosing class` 11 케이스는 별개 — ZNTC/esbuild/oxc 모두 spec 대로 거부, TSC 만 TS2339 type-error 격하. parser 버그 아님 + audit oracle 결함도 아닌 의도된 divergence.)

## 수정

14개 syntax-level TS18xxx 코드 화이트리스트 추가:

```ts
const TS18_SYNTAX_LEVEL_CODES: ReadonlySet<number> = new Set([
  18006, // Classes may not have a field named 'constructor'
  18007, // JSX expressions may not use the comma operator
  18009, // Private identifiers cannot be used as parameters
  18010, // accessibility modifier with private identifier
  18011, // delete + private identifier
  18012, // '#constructor' is a reserved word
  18016, // Private identifiers outside class bodies
  18019, // modifier with private identifier
  18024, // enum member with private identifier
  18026, // '#!' must be at start of file
  18029, // Private identifiers in variable declarations
  18030, // optional chain with private identifiers
  18036, // class decorators with static private identifier
  18037, // 'await' in class static block
]);

function isSyntaxLevelCode(code: number): boolean {
  if (code >= 1000 && code < 2000) return true;
  return TS18_SYNTAX_LEVEL_CODES.has(code);
}
```

oracle 의 hasSyntax 판정 + samples 출력 의 syntax filter 두 군데 모두 이 helper 로 통일.

## 영향 — full audit (4499 single-file fixture)

| | Before (PR #3194) | After |
|---|---:|---:|
| OK_pass | 3481 | 3478 (-3) |
| OK_reject | 621 | **633** (+12) |
| false_reject (FR) | 144 | **132** (-12) |
| false_accept (FA) | 253 | 256 (+3) |
| Match rate | 91.18% | **91.38%** |

| 디렉터리 FR | Before | After |
|---|---:|---:|
| classes | 40 | **29** (-11) |
| parser | 22 | 22 |
| es6 | 65 | 65 |

## 남은 classes/ FR=29 분류

- 11 × `Private field must be declared in enclosing class` — spec-correct (esbuild/oxc 일치)
- 4 × `super outside method/ctor` — strict 검사 차이
- 2 × `Identifier already declared` — TSC 가 declaration merging 으로 허용
- 2 × `prototype/constructor as static field` — spec 검사
- 1 × `Two constructors` — TS overload 허용
- 1 × `OptionalChain in extends` — parser 차이
- 8 × 잡다

진짜 parser 버그 후보는 1-2 개 수준. 의도된 divergence 가 대부분.

## Test plan

- [x] `bun run scripts/tsc-conformance-audit.ts` match rate 91.38% 도달
- [x] classes private-name parser-level 거부 케이스 OK_reject 로 reclassify 확인
- [x] /simplify 3-agent 리뷰 모두 clean (수정 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)