### PR TITLE
chore(scripts): audit oracle treats syntax-equivalent TS2xxx as reject

### DIFF
--- a/scripts/tsc-conformance-audit.ts
+++ b/scripts/tsc-conformance-audit.ts
@@ -63,9 +63,29 @@ const TS18_SYNTAX_LEVEL_CODES: ReadonlySet<number> = new Set([
   18037, // 'await' expression cannot be used inside a class static block
 ]);
 
+/// TSC 의 일부 TS2xxx 진단도 실제로는 ECMAScript spec early-error — TSC 가
+/// type-system 진단으로 격하했을 뿐, 다른 parser (esbuild/oxc) 와 ZNTC 는
+/// parser-level 에서 거부한다. AssignmentTargetType 위반 + super 위치
+/// 규칙 등이 해당.
+const TS2_SYNTAX_LEVEL_CODES: ReadonlySet<number> = new Set([
+  2335, // 'super' can only be referenced in a derived class
+  2337, // Super calls are not permitted outside constructors
+  2357, // Operand of increment/decrement must be a variable or a property access
+  2364, // LHS of an assignment expression must be a variable or a property access
+  2398, // 'constructor' cannot be used as a parameter property name
+  2406, // LHS of a 'for...in' must be a variable or a property access
+  2487, // LHS of a 'for...of' must be a variable or a property access
+  2701, // Target of object rest assignment must be a variable or a property access
+  2777, // Increment/decrement target may not be an optional property access
+  2779, // LHS of an assignment expression may not be an optional property access
+  // 의도적 제외: TS2300 ("Duplicate identifier") 는 JS spec early-error
+  // (`let x; let x;`) 와 TS-only semantic (`type X; type X;`) 양쪽에서 발화 —
+  // dual-purpose 라 syntax 로 일률 분류 불가.
+]);
+
 function isSyntaxLevelCode(code: number): boolean {
   if (code >= 1000 && code < 2000) return true;
-  return TS18_SYNTAX_LEVEL_CODES.has(code);
+  return TS18_SYNTAX_LEVEL_CODES.has(code) || TS2_SYNTAX_LEVEL_CODES.has(code);
 }
 
 const OUTCOMES = [


### PR DESCRIPTION
## 요약

`parser/` 디렉터리 FR=22 분석 결과 — 13개 `Invalid assignment target` cluster 가 모두 audit oracle 결함이었다. TSC 가 TS2xxx (type-level) 로 격하한 ECMAScript spec early errors 를 ZNTC/esbuild/oxc 가 정상 parser-level 에서 거부.

## 발견 경로

`parser/ecmascript5/Statements/parserForStatement8.ts` = `for (this in b) {}`. ZNTC 는 `Invalid assignment target [ZNTC0517]` 로 거부 — esbuild/oxc 도 동일하게 거부.

TSC baseline:
```
parserAssignmentExpression1.ts(1,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
```

ECMAScript spec 13.15.1 (AssignmentExpression Static Semantics) 의 early error:
> It is a Syntax Error if AssignmentTargetType of LeftHandSideExpression is not simple.

TSC 가 TS2364 로 격하했을 뿐 spec 상 syntax. esbuild/oxc/ZNTC 가 일치 — 의도된 spec-conformance.

## 수정

10개 syntax-equivalent TS2xxx 코드 화이트리스트:

```ts
const TS2_SYNTAX_LEVEL_CODES: ReadonlySet<number> = new Set([
  2335, // 'super' can only be referenced in a derived class
  2337, // Super calls are not permitted outside constructors
  2357, // Operand of increment/decrement must be a variable or a property access
  2364, // LHS of an assignment expression must be a variable or a property access
  2398, // 'constructor' cannot be used as a parameter property name
  2406, // LHS of a 'for...in' must be a variable or a property access
  2487, // LHS of a 'for...of' must be a variable or a property access
  2701, // Target of object rest assignment must be a variable or a property access
  2777, // Increment/decrement target may not be an optional property access
  2779, // LHS of an assignment expression may not be an optional property access
  // 의도적 제외: TS2300 ("Duplicate identifier") dual-purpose (JS spec
  // early-error + TS-only semantic).
]);
```

TS18 화이트리스트와 별개 set 유지 — 출처 (TSC 카테고리 구분) 보존.

## 영향 — full audit (4499 single-file fixture)

| | Before (PR #3195) | After |
|---|---:|---:|
| OK_pass | 3478 | 3475 (-3) |
| OK_reject | 633 | **658** (+25) |
| FR | 132 | **107** (-25) |
| FA | 256 | 259 (+3) |
| Match rate | 91.38% | **91.86%** |

| 디렉터리 FR | Before | After |
|---|---:|---:|
| classes | 29 | **25** (-4) |
| parser | 22 | **13** (-9) |
| es6 | 65 | 65 |

## 진짜 parser 버그는?

audit 시작 시 268 FR 였던 게 6 PR 후 **107**. 잔여 클러스터는:
- es6/ FR=65 — 대부분 `arguments` strict-mode 케이스 (PR #3180 의도된 정책)
- async/ FR=29
- classes/ FR=25 — 11개 private-name spec-strict (esbuild/oxc 일치)
- parser/ FR=13 — 잡다

실제 parser 버그 후보는 한자릿수 수준.

ZNTC behavior 변경 없음 — audit oracle 정확도 개선만.

## Test plan

- [x] `bun run scripts/tsc-conformance-audit.ts` match rate 91.86%
- [x] 13개 `Invalid assignment target` parser/ fixture → OK_reject
- [x] /simplify 3-agent 통과 (Agent 2 권고: TS2300 제외 이유 주석 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)