### PR TITLE
chore(scripts): audit oracle adds TS2466/2523/2528 + TS17xxx syntax codes

### DIFF
--- a/scripts/tsc-conformance-audit.ts
+++ b/scripts/tsc-conformance-audit.ts
@@ -74,7 +74,10 @@ const TS2_SYNTAX_LEVEL_CODES: ReadonlySet<number> = new Set([
   2364, // LHS of an assignment expression must be a variable or a property access
   2398, // 'constructor' cannot be used as a parameter property name
   2406, // LHS of a 'for...in' must be a variable or a property access
+  2466, // 'super' cannot be referenced in a computed property name
   2487, // LHS of a 'for...of' must be a variable or a property access
+  2523, // 'yield' expressions cannot be used in a parameter initializer
+  2528, // A module cannot have multiple default exports
   2701, // Target of object rest assignment must be a variable or a property access
   2777, // Increment/decrement target may not be an optional property access
   2779, // LHS of an assignment expression may not be an optional property access
@@ -83,9 +86,32 @@ const TS2_SYNTAX_LEVEL_CODES: ReadonlySet<number> = new Set([
   // dual-purpose 라 syntax 로 일률 분류 불가.
 ]);
 
+/// TSC 의 TS17xxx 진단 중 spec-level syntax 거부. JSX 구조 (closing tag /
+/// duplicate attribute 등), meta-property (`new.target`) 위치, exponentiation
+/// LHS unary/type-assert 제약, TS 타입 postfix/prefix `!`/`?` 위치 등이 해당.
+const TS17_SYNTAX_LEVEL_CODES: ReadonlySet<number> = new Set([
+  17000, // JSX attributes must only be assigned a non-empty 'expression'.
+  17001, // JSX elements cannot have multiple attributes with the same name.
+  17002, // Expected corresponding JSX closing tag for '{0}'.
+  17006, // An unary expression with the '{0}' operator is not allowed in the left-hand side of an exponentiation expression.
+  17007, // A type assertion expression is not allowed in the left-hand side of an exponentiation expression.
+  17008, // JSX element '{0}' has no corresponding closing tag.
+  17012, // '{0}' is not a valid meta-property for keyword '{1}'.
+  17013, // Meta-property '{0}' is only allowed in the body of a function declaration, function expression, or constructor.
+  17014, // JSX fragment has no corresponding closing tag.
+  17015, // Expected corresponding closing tag for JSX fragment.
+  17019, // '{0}' at the end of a type is not valid TypeScript syntax. Did you mean to write '{1}'? (postfix `T!`/`T?` recovery)
+  17020, // '{0}' at the start of a type is not valid TypeScript syntax. Did you mean to write '{1}'? (prefix `?T`/`!T` recovery)
+  17021, // Unicode escape sequence cannot appear here.
+]);
+
 function isSyntaxLevelCode(code: number): boolean {
   if (code >= 1000 && code < 2000) return true;
-  return TS18_SYNTAX_LEVEL_CODES.has(code) || TS2_SYNTAX_LEVEL_CODES.has(code);
+  return (
+    TS2_SYNTAX_LEVEL_CODES.has(code) ||
+    TS17_SYNTAX_LEVEL_CODES.has(code) ||
+    TS18_SYNTAX_LEVEL_CODES.has(code)
+  );
 }
 
 const OUTCOMES = [


### PR DESCRIPTION
## 요약

`es6/` FR=14 (audit 누적 보강 후) 분석 결과 — 6 케이스 `[super.bar()]() {}` (computed property key 에서 super) 가 TSC TS2466 type-system 코드로 분류되지만 spec early-error. ECMAScript spec + esbuild + ZNTC 모두 일치 거부.

추가로 TS17xxx 범위 (JSX 구조, meta-property, exponentiation LHS, TS type postfix recovery) 도 syntax-equivalent 인데 oracle 누락 — 한 번에 묶어 추가.

## 비교 - `[super.bar()]() {}`

| Parser | 결과 |
|---|---|
| TSC | TS2466 (type-error 이지만 emit) |
| esbuild | ❌ "Unexpected super" — parser reject |
| oxc | ✅ accept (관용적) |
| **ZNTC** | ❌ reject — spec + esbuild 일치 |

ECMAScript 14.5.5.2: super 는 computed property name 에서 SyntaxError.

## 수정

```ts
const TS2_SYNTAX_LEVEL_CODES = new Set([
  // 기존: 2335, 2337, 2357, 2364, 2398, 2406, 2487, 2701, 2777, 2779
  2466, // 'super' cannot be referenced in a computed property name (6 cases)
  2523, // 'yield' expressions cannot be used in a parameter initializer (2)
  2528, // A module cannot have multiple default exports (1)
]);

const TS17_SYNTAX_LEVEL_CODES = new Set([
  // JSX 구조
  17000, 17001, 17002, 17008, 17014, 17015,
  // exponentiation LHS unary/type-assert
  17006, 17007,
  // meta-property 위치 (`new.target`)
  17012, 17013,
  // TS 타입 postfix/prefix `!`/`?` recovery
  17019, 17020,
  // Unicode escape 위치
  17021,
]);
```

## 영향 — full audit (4499 single-file fixture)

| | Before (PR #3197) | After |
|---|---:|---:|
| OK_pass | 3475 | 3467 (-8) |
| OK_reject | 658 | **677** (+19) |
| **FR** | **98** | **79** (-19) |
| FA | 259 | 267 (+8) |
| Match rate | 92.06% | **92.31%** |

| 디렉터리 FR | Before | After |
|---|---:|---:|
| **es6** | **14** | **3** (-11) |
| classes | 25 | ? (super-related reclassify) |
| parser | 13 | 13 |
| async | 6 | 6 |

## 진행 추이 (audit 9 PR 누적)

| | 초기 | 현재 |
|---:|---:|---:|
| FR | 268 | **79** (-189, 70.5% 감소) |
| Match rate | 89.75% | **92.31%** |

진짜 parser 버그는 첫 2 PR (#3190, #3192/#3193) 에서 fix 완료. 이후 audit 정확도만 +2.56%p 개선.

## Test plan

- [x] `bun run scripts/tsc-conformance-audit.ts` match rate 92.31%
- [x] es6/ super-in-computed-key 6 케이스 → OK_reject
- [x] /simplify 3-agent 권고 적용 (TSC 원문 comment 정확화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)