### PR TITLE
chore(scripts): audit oracle adds OK_spec_strict outcome

### DIFF
--- a/scripts/tsc-conformance-audit.ts
+++ b/scripts/tsc-conformance-audit.ts
@@ -121,6 +121,7 @@ const OUTCOMES = [
   "MISMATCH_false_accept",
   "HANG",
   "OK_policy_strict", // ZNTC implicit-module-strict 가 의도적으로 거부 — TSC `@strict: false` fixture
+  "OK_spec_strict", // ECMAScript spec early-error — ZNTC + esbuild + oxc 일치 거부, TSC 만 type-error 격하
 ] as const;
 type Outcome = (typeof OUTCOMES)[number];
 
@@ -137,6 +138,20 @@ const STRICT_ERROR_KEYWORDS = [
   "in module code",
   "in non-async function",
   "not allowed in a module",
+];
+
+/// ECMAScript spec early-error 인 ZNTC 거부 메시지. esbuild + oxc 모두 동일하게
+/// 거부하지만 TSC 만 type-system 진단 (TS2300/TS2339/TS2392/TS2500/TS2699 등)
+/// 으로 격하해 emit 한다. ZNTC 가 industry consensus 따라 spec 준수 거부.
+const SPEC_STRICT_ERROR_KEYWORDS = [
+  // 의도적으로 broad — oracle=accept 이라는 사전 조건이 있어, TSC 의
+  // permissive 가 spec early-error (let/const/class/private 중복) 를
+  // type-error 로 격하한 경우만 매치된다 (TS2300).
+  "has already been declared",
+  "must be declared in an enclosing class", // private name scope (TS2339)
+  "may only have one constructor", // multiple ctor implementations (TS2392)
+  "Static class field cannot be named", // prototype as static (TS2699)
+  "Class field cannot be named", // constructor as field (TS18006)
 ];
 
 interface Fixture {
@@ -277,6 +292,11 @@ function classify(oracle: Oracle, run: ZntcRun, fixtureHead: string): Outcome {
     ) {
       return "OK_policy_strict";
     }
+    // ZNTC 가 ECMAScript spec early-error 로 거부 (esbuild/oxc 일치), TSC 만
+    // type-system 진단으로 격하한 경우. fixture directive 무관.
+    if (SPEC_STRICT_ERROR_KEYWORDS.some((kw) => run.firstError.includes(kw))) {
+      return "OK_spec_strict";
+    }
     return "MISMATCH_false_reject";
   }
   return accepted ? "MISMATCH_false_accept" : "OK_reject";
@@ -390,8 +410,9 @@ async function main() {
   for (const r of results) counts[r.outcome]++;
 
   const total = results.length;
-  // OK_policy_strict 도 의도된 동작이므로 match rate 에 포함.
-  const matched = counts.OK_pass + counts.OK_reject + counts.OK_policy_strict;
+  // OK_policy_strict / OK_spec_strict 도 의도된 동작이므로 match rate 에 포함.
+  const matched =
+    counts.OK_pass + counts.OK_reject + counts.OK_policy_strict + counts.OK_spec_strict;
   const okRate = total > 0 ? ((matched / total) * 100).toFixed(2) : "0";
 
   console.log("\n=== TSC Conformance Audit (single-file) ===");
@@ -402,6 +423,7 @@ async function main() {
   console.log(`false_accept (FA): ${counts.MISMATCH_false_accept}  ← syntax laxness 후보 (P1)`);
   console.log(`HANG:              ${counts.HANG}  ← parser 무한 루프 후보 (P0)`);
   console.log(`OK_policy_strict:     ${counts.OK_policy_strict}  ← TS implicit-strict 의도된 divergence (PR #3180)`);
+  console.log(`OK_spec_strict:       ${counts.OK_spec_strict}  ← spec early-error (esbuild/oxc 일치), TSC type-격하`);
   console.log(`Match rate:        ${okRate}%`);
   console.log(`Elapsed:           ${elapsedSec}s  (zntc timeout per fixture: ${ZNTC_TIMEOUT_MS}ms)`);
 


### PR DESCRIPTION
## 요약

`classes/` FR=25 (audit 누적 보강 후) 분석 결과 — **24 케이스 모두 ZNTC + esbuild + oxc 일치 spec early-error**. TSC 만 type-system 진단으로 격하해 emit 한다. PR #3197 의 `OK_policy_strict` 와 같은 패턴 — ZNTC 의 의도된 spec 준수 거부를 새 outcome 으로 분리.

## 발견 패턴

classes/ FR=25 sub-cluster:

| ZNTC code | 패턴 | 케이스 | TSC code |
|---|---|---:|---|
| ZNTC1101 | `Private field '#x' must be declared in an enclosing class` | 17 | TS2339 |
| ZNTC1100 | `Private field '#x' has already been declared` | 2 | TS2300 |
| ZNTC1000 | `Identifier 'C' has already been declared` (`class C; var C;`) | 2 | TS2300 |
| ZNTC1300 | `A class may only have one constructor` | 1 | TS2392 |
| ZNTC0409 | `Static class field cannot be named 'prototype'` | 1 | TS2699 |
| ZNTC0408 | `Class field cannot be named 'constructor'` | 1 | TS18006 |
| (parse error) | `class C extends A?.B {}` | 1 | TS2500 |

esbuild 검증:
- `class C; var C;` → ✅ "The symbol 'C' has already been declared" (esbuild reject)
- `class C { [super.bar()]() {} }` → ✅ "Unexpected super" (esbuild reject — 이미 PR #3198 처리)
- `class B extends A?.B {}` → ✅ "Expected '{' but found '?.'" (esbuild reject)

ZNTC 가 industry consensus 따라 spec 준수.

## 수정

`OK_policy_strict` 와 평행 구조:

```ts
const SPEC_STRICT_ERROR_KEYWORDS = [
  // oracle=accept 사전조건 → TSC permissive 가 spec early-error 를 type-error 로
  // 격하한 경우만 매치된다 (TS2300).
  "has already been declared",
  "must be declared in an enclosing class", // TS2339
  "may only have one constructor",          // TS2392
  "Static class field cannot be named",     // TS2699
  "Class field cannot be named",            // TS18006
];

// classify():
if (SPEC_STRICT_ERROR_KEYWORDS.some((kw) => run.firstError.includes(kw))) {
  return "OK_spec_strict";
}
```

match rate 계산에 `OK_spec_strict` 도 포함.

## 영향 — full audit (4499 single-file fixture)

| | Before (PR #3198) | After |
|---|---:|---:|
| OK_pass | 3467 | 3467 |
| OK_reject | 677 | 677 |
| OK_policy_strict | 9 | 9 |
| **OK_spec_strict** | — | **24** (신규) |
| **FR** | **79** | **55** (-24) |
| FA | 267 | 267 |
| Match rate | 92.31% | **92.84%** |

| 디렉터리 FR | Before | After |
|---|---:|---:|
| **classes** | **25** | **1** (-24) |
| parser | 13 | 13 |
| async | 6 | 6 |
| es6 | 3 | 3 |

잔여 classes/ FR=1 (`classExtendingOptionalChain`) 도 spec-strict 이지만 ZNTC error 메시지가 `× {` 형태로 generic 이라 keyword 매치 불가. 별도 처리 없이 그대로 두는 게 정확.

## 진짜 parser 버그?

audit 누적 10 PR 결과:
- **classes/ 진짜 parser 버그**: 0건 (모두 spec-strict policy)
- **parser/ 진짜 parser 버그**: 0건 (모두 spec-strict)
- **async/ 진짜 parser 버그**: 0건 (모두 PR #3180 policy)
- **es6/ 진짜 parser 버그**: 0건 (spec / policy)

PR #3190, #3192, #3193 에서 fix한 5건 (HANG + decorator computed key) 이 전부.

## Test plan

- [x] `bun run scripts/tsc-conformance-audit.ts` match rate 92.84%
- [x] classes/ FR 25 → 1
- [x] /simplify 3-agent 권고 적용 (generic keyword 의도 주석)

🤖 Generated with [Claude Code](https://claude.com/claude-code)