### PR TITLE
fix(parser): accept TS bare `this` parameter without type annotation

### DIFF
--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1703,20 +1703,24 @@ pub const Parser = struct {
         return ts.tryParseTypeAnnotation(self);
     }
 
-    /// TS `this: Type` 파라미터 스킵. 함수의 첫 번째 파라미터가 `this`이면
-    /// `this` + `: Type` + 선택적 `,`를 소비하고 파라미터 리스트에 추가하지 않는다.
-    /// TS this parameter: `this: Type` → 스킵 (런타임에 불필요).
-    /// `this:` 패턴만 감지 — bare `this`는 일반 파라미터로 처리.
+    /// TS `this` 파라미터 스킵. 함수의 첫 번째 파라미터가 `this` 면
+    /// `this` (+ 선택적 `: Type`) + 선택적 `,` 를 소비하고 파라미터 리스트에
+    /// 추가하지 않는다 — 런타임에 불필요.
+    /// 다음 토큰이 `:` (`this: Type`), `,` (`this, next`), `)` (`this)` 단독 마지막
+    /// 파라미터) 중 하나면 TS this parameter 로 인식. 그 외 (예: `this.x`,
+    /// `this = ...`) 는 일반 expression context 라 fall-through.
+    /// esbuild/oxc 와 일치 — bare `this` (no type annotation) 도 valid TS.
     pub fn trySkipThisParameter(self: *Parser) ParseError2!void {
-        if (self.current() == .kw_this) {
-            const next = try self.peekNextKind();
-            if (next == .colon) {
-                try self.rejectTypeScriptSyntaxInJavaScript("TypeScript this parameters are not allowed when parsing as JavaScript");
-                try self.advance(); // skip 'this'
-                _ = try self.tryParseTypeAnnotation(); // skip ': Type'
-                _ = try self.eat(.comma);
-            }
+        if (self.current() != .kw_this) return;
+        const next = try self.peekNextKind();
+        switch (next) {
+            .colon, .comma, .r_paren => {},
+            else => return,
         }
+        try self.rejectTypeScriptSyntaxInJavaScript("TypeScript this parameters are not allowed when parsing as JavaScript");
+        try self.advance(); // skip 'this'
+        _ = try self.tryParseTypeAnnotation(); // skip ': Type' 있으면
+        _ = try self.eat(.comma);
     }
 
     pub fn tryParseReturnType(self: *Parser) ParseError2!NodeIndex {

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -4164,3 +4164,19 @@ test "TS enum: 30 left-shift initializers 은 O(2^N) speculation 없이 즉시 �
 test "TS: 30 chained `a << N` 식은 architectural speculation guard 로 즉시 파싱" {
     try assertShiftStressParsesUnder100ms("declare const a: number;\n", "const r{d} = a << {d};\n", "");
 }
+
+// TS bare `this` parameter — `function f(this, n)` / `set x(this, n) {}` 는
+// TSC + esbuild + oxc 모두 valid (type 없이도 `this` parameter strip). ZNTC 의
+// 이전 `trySkipThisParameter` 는 `this:` (with colon) 만 인식해 bare `this` 는
+// reserved-word 에러로 거부했었다 (TSC conformance `thisTypeInAccessors.ts`).
+test "TS: bare `this` parameter without type annotation is stripped" {
+    var r = try parseTs(std.testing.allocator,
+        \\const obj = {
+        \\    set x(this, n) { },
+        \\};
+        \\function f(this, n) {}
+    );
+    defer r.deinit();
+    // 에러 없이 파싱 완료 + `this` 파라미터는 list 에서 제외 (런타임 불필요).
+    try std.testing.expectEqual(@as(usize, 0), r.parser.errors.items.len);
+}


### PR DESCRIPTION
## 요약

`types/` FR=7 분석 중 발견한 진짜 parser 버그. TS this parameter 가 type annotation 없이 사용된 경우 (`set x(this, n) {}`, `function f(this, n)`) ZNTC 가 reserved-word 에러로 거부했었다. esbuild + oxc 둘 다 valid TS 로 accept.

## 비교

| Parser | `const obj = { set x(this, n) {} };` |
|---|---|
| TSC | ✅ accept (TS2784 type-warning 만, emit 정상) |
| esbuild | ✅ accept — `this` strip → `set x(n) {}` |
| oxc | ✅ accept (0 errors) |
| **ZNTC (전)** | ❌ "Reserved word cannot be used as identifier [ZNTC0504]" |
| **ZNTC (본 PR)** | ✅ accept — esbuild/oxc 와 일치 |

## 원인

`trySkipThisParameter` 가 `this:` (with colon) 패턴만 인식:

```zig
// Before
if (self.current() == .kw_this) {
    const next = try self.peekNextKind();
    if (next == .colon) {  // ← only :Type case
        // skip this parameter
    }
}
```

`this` 뒤에 `,` 나 `)` 가 오는 bare this parameter 는 fall-through → 다음 단계가 `this` 를 binding identifier 자리에서 만나 reserved-word 에러.

## 수정

다음 토큰이 `:` (`this: Type`), `,` (`this, next`), `)` (`this)` 단독 마지막) 중 하나면 TS this parameter 로 인식:

```zig
pub fn trySkipThisParameter(self: *Parser) ParseError2!void {
    if (self.current() != .kw_this) return;
    const next = try self.peekNextKind();
    switch (next) {
        .colon, .comma, .r_paren => {},
        else => return,  // this.x, this = ... 등 expression context
    }
    try self.rejectTypeScriptSyntaxInJavaScript(...);
    try self.advance();
    _ = try self.tryParseTypeAnnotation(); // optional `: Type`
    _ = try self.eat(.comma);
}
```

## 영향

- `thisTypeInAccessors.ts` (`set x(this, n) {}`) — 통과
- `thisTypeInFunctions.ts` — 통과
- audit FR: 55 → **52** (-3), match rate 92.84% → **92.91%**

## 회귀 가드

`parser_test.zig` 에 unit test 추가 — `set x(this, n)` setter + `function f(this, n)` declaration 두 패턴 parse 성공 검증.

## Test plan

- [x] `zig build` / `zig build test` 정상 (신규 unit test 포함)
- [x] `cd tests/integration && bun test tests/tsc/` 2211/2211 pass
- [x] `bun test tests/bundle-smoke.test.ts` 151/151 pass
- [x] `zig build -Doptimize=ReleaseFast` 정상
- [x] /simplify 3-agent 모두 ship-as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)