### PR TITLE
chore(scripts): audit adds TS2369/TS2462 + Duplicate parameter keyword

### DIFF
--- a/scripts/tsc-conformance-audit.ts
+++ b/scripts/tsc-conformance-audit.ts
@@ -73,7 +73,9 @@ const TS2_SYNTAX_LEVEL_CODES: ReadonlySet<number> = new Set([
   2357, // Operand of increment/decrement must be a variable or a property access
   2364, // LHS of an assignment expression must be a variable or a property access
   2398, // 'constructor' cannot be used as a parameter property name
+  2369, // A parameter property is only allowed in a constructor implementation
   2406, // LHS of a 'for...in' must be a variable or a property access
+  2462, // A rest element must be last in a destructuring pattern
   2466, // 'super' cannot be referenced in a computed property name
   2487, // LHS of a 'for...of' must be a variable or a property access
   2523, // 'yield' expressions cannot be used in a parameter initializer
@@ -138,6 +140,7 @@ const STRICT_ERROR_KEYWORDS = [
   "in module code",
   "in non-async function",
   "not allowed in a module",
+  "Duplicate parameter name", // sloppy script 에서만 허용 — strict 시 SyntaxError
 ];
 
 /// ECMAScript spec early-error 인 ZNTC 거부 메시지. esbuild + oxc 모두 동일하게


### PR DESCRIPTION
## 요약

`types/` FR=4 (PR #3200 이후) 분석 결과 — 모두 audit oracle 누락 케이스. 진짜 parser 버그 0건.

## 발견 케이스

| Fixture | TSC code | ZNTC 거부 | 추가 항목 |
|---|---|---|---|
| `restElementMustBeLast.ts` | TS2462 | `× ]` | TS2462 → TS2_SYNTAX_LEVEL_CODES |
| `objectRestPropertyMustBeLast.ts` | TS2462 | `× }` | TS2462 → TS2_SYNTAX_LEVEL_CODES |
| `constructSignatureWithAccessibilityModifiersOnParameters.ts` | TS2369 | `× )` | TS2369 → TS2_SYNTAX_LEVEL_CODES |
| `constructSignatureWithAccessibilityModifiersOnParameters2.ts` | TS2369 | `× )` | (위와 동일) |
| `callSignaturesWithDuplicateParameters.ts` | TS2300 | `Duplicate parameter name` | STRICT_ERROR_KEYWORDS 에 "Duplicate parameter name" 추가 |

마지막 케이스는 `@strict: false` directive 가 있고 `function foo(x, x) {}` 는 sloppy 에서만 허용되는 패턴 — PR #3180 의 implicit-strict 정책이 거부. OK_policy_strict 분류 대상.

## 영향 — full audit (4499 single-file fixture)

| | Before (PR #3200) | After |
|---|---:|---:|
| OK_pass | 3465 | 3465 |
| OK_reject | 677 | **686** (+9) |
| **FR** | **52** | **43** (-9) |
| FA | 272 | 272 |
| OK_policy_strict | 9 | 9 |
| OK_spec_strict | 24 | 24 |
| Match rate | 92.91% | **93.00%** |

| 디렉터리 FR | Before | After |
|---|---:|---:|
| **types** | **4** | **0** (-4) |
| classes | 1 | 1 |
| parser | 13 | ? |
| async | 6 | 6 |
| es6 | 3 | 3 |

types/ FR 완전 청산. 9 reclassify 중 4 는 types/ 직접, 5 는 TS2369/2462 가 다른 디렉터리 (decorators, externalModules 등) 에서도 추가 매치.

## ZNTC behavior 변경 없음

audit oracle 정확도 개선만.

## Test plan

- [x] `bun run scripts/tsc-conformance-audit.ts` match rate 93.00%
- [x] types/ FR 4 → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)