### PR TITLE
fix(parser): support `using` / `await using` in for-statement header

### DIFF
--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -4180,3 +4180,21 @@ test "TS: bare `this` parameter without type annotation is stripped" {
     // 에러 없이 파싱 완료 + `this` 파라미터는 list 에서 제외 (런타임 불필요).
     try std.testing.expectEqual(@as(usize, 0), r.parser.errors.items.len);
 }
+
+// TC39 Stage 3 Explicit Resource Management — `for (using x = ...; ...; ...)` /
+// `for (using x of ...)` / `for (await using x of ...)`. 이전 parseForStatement
+// 는 var/let/const 만 declaration 분기로 처리, `using` 은 expression 으로 떨어져
+// `× ;` parse error (TSC conformance `usingDeclarationsInFor.ts` 등 9 케이스).
+test "TS: for header allows `using` and `await using` declarations" {
+    var r = try parseTs(std.testing.allocator,
+        \\async function f() {
+        \\    for (using x = null;;) {}
+        \\    for (await using y = null;;) {}
+        \\    for (using x of [null]) {}
+        \\    for (await using y of [null]) {}
+        \\    for await (using z of [null]) {}
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expectEqual(@as(usize, 0), r.parser.errors.items.len);
+}

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -737,8 +737,17 @@ fn parseForStatement(self: *Parser) ParseError2!NodeIndex {
     const is_let_as_identifier = self.current() == .kw_let and !self.is_strict_mode and
         (!try isLetDeclarationStart(self) or try self.peekNextKind() == .kw_of);
 
-    if ((self.current() == .kw_var or self.current() == .kw_let or self.current() == .kw_const) and !is_let_as_identifier) {
-        const init_expr = try parseVariableDeclaration(self);
+    // for ( using x ... ) — TC39 Explicit Resource Management.
+    // `using` 뒤에 줄바꿈 없이 identifier 가 오면 UsingDeclaration.
+    const is_using_decl = self.current() == .kw_using and try isUsingDeclarationStart(self);
+    // for ( await using x ... ) — async variant.
+    const is_await_using_decl = self.current() == .kw_await and try isAwaitUsingDeclarationStart(self);
+
+    if ((self.current() == .kw_var or self.current() == .kw_let or self.current() == .kw_const) and !is_let_as_identifier or is_using_decl or is_await_using_decl) {
+        const init_expr = if (is_await_using_decl)
+            try parseAwaitUsingDeclaration(self)
+        else
+            try parseVariableDeclaration(self);
         self.restoreContext(for_saved);
         self.for_loop_init = saved_for_loop_init;
         // parseVariableDeclaration이 세미콜론을 소비했으면 for(;;)


### PR DESCRIPTION
## 요약

TC39 Stage 3 Explicit Resource Management 의 `for (using x = ...; ...; ...)` / `for (using x of ...)` / `for (await using x of ...)` 패턴이 ZNTC 의 `parseForStatement` 에서 var/let/const 만 declaration 분기로 처리, `using` 은 expression 으로 떨어져 `× ;` parse error.

esbuild + oxc 둘 다 accept (TS 5.2+ 표준 syntax). ZNTC 도 industry consensus 일치하도록 fix.

## 수정

`isUsingDeclarationStart` / `isAwaitUsingDeclarationStart` (이미 statement top-level 에서 쓰던 helper) 를 for-header 분기 조건에 추가:

```zig
const is_using_decl = self.current() == .kw_using and try isUsingDeclarationStart(self);
const is_await_using_decl = self.current() == .kw_await and try isAwaitUsingDeclarationStart(self);

if ((var/let/const and !is_let_as_identifier) or is_using_decl or is_await_using_decl) {
    const init_expr = if (is_await_using_decl) try parseAwaitUsingDeclaration(self)
                      else try parseVariableDeclaration(self);
    // ... 이후 logic 동일
}
```

## 영향

audit FR: 43 → **34** (-9), match rate 93.00% → **93.09%**

reclassified:
- `usingDeclarationsInFor.ts`
- `usingDeclarationsInForOf.1.ts`
- `usingDeclarationsInForAwaitOf.ts`
- `awaitUsingDeclarationsInForOf.{1,2}.ts`
- `awaitUsingDeclarationsInForAwaitOf.{1,2}.ts`
- `awaitUsingDeclarationsInFor.ts`

## 회귀 가드

parser_test.zig 에 5 variant unit test:
- `for (using x = ...; ...; ...)`
- `for (await using y = ...; ...; ...)`
- `for (using x of ...)`
- `for (await using y of ...)`
- `for await (using z of ...)`

## Test plan

- [x] `zig build test` 정상
- [x] `cd tests/integration && bun test tests/tsc/` 2211/2211 pass
- [x] `bun test tests/bundle-smoke.test.ts` 151/151 pass
- [x] audit FR 43 → 34

🤖 Generated with [Claude Code](https://claude.com/claude-code)