### PR TITLE
fix(parser): handle computed key in stage3 accessor decorator transform

### DIFF
--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -4181,6 +4181,22 @@ test "TS: bare `this` parameter without type annotation is stripped" {
     try std.testing.expectEqual(@as(usize, 0), r.parser.errors.items.len);
 }
 
+// Stage 3 auto-accessor with computed key + decorator (`@dec accessor ["x"] = ...`)
+// 가 `data.string_ref` 가정 코드에서 garbage span 으로 합성돼 codegen slice panic
+// (TSC conformance `esDecorators-classDeclaration-fields-staticAccessor.ts`).
+// 동일 NodeIndex 를 getter/setter 양쪽 공유로 fix — PR #3190 와 동일 방향.
+test "TS: decorated auto-accessor with computed key does not crash" {
+    var r = try parseTs(std.testing.allocator,
+        \\declare let dec: any;
+        \\class C {
+        \\    @dec accessor ["x"] = 1;
+        \\    @dec static accessor ["y"] = 2;
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expectEqual(@as(usize, 0), r.parser.errors.items.len);
+}
+
 // TC39 Stage 3 Explicit Resource Management — `for (using x = ...; ...; ...)` /
 // `for (using x of ...)` / `for (await using x of ...)`. 이전 parseForStatement
 // 는 var/let/const 만 declaration 분기로 처리, `using` 은 expression 으로 떨어져

--- a/src/transformer/transformer/stage3_decorator_transform.zig
+++ b/src/transformer/transformer/stage3_decorator_transform.zig
@@ -363,26 +363,23 @@ pub fn transformStage3Decorators(self: *Transformer, node: Node) Error!NodeIndex
                     // .private_field_expression 태그 필수 — .static_member_expression 으로 만들면
                     // transformer.zig:899 private field WeakMap dispatch 를 못 탐 (Stage 3 출력 재방문 경로에서만
                     // 우연히 동작하던 것을 안정화).
+                    //
+                    // 이전: public accessor 일 때 `data.string_ref` 를 가정하고 새
+                    // identifier_reference 노드를 합성. computed key (`accessor ["x"]`)
+                    // 처럼 다른 union variant (`unary.operand`) 를 가진 key 면
+                    // garbage span 으로 합성돼 codegen 단계에서 slice panic 발화.
+                    // 같은 NodeIndex 를 getter/setter 양쪽에서 공유 — codegen 은
+                    // index 만 보고 emit 하므로 안전 (PR #3190 와 동일 방향).
                     {
                         const return_expr = try makeThisPrivateField(self, storage_span);
-                        const getter_key = if (is_private_accessor) new_key else try self.ast.addNode(.{
-                            .tag = .identifier_reference,
-                            .span = self.ast.getNode(new_key).data.string_ref,
-                            .data = .{ .string_ref = self.ast.getNode(new_key).data.string_ref },
-                        });
-                        const getter = try self.buildGetterMethod(getter_key, return_expr, is_static, zero_span);
+                        const getter = try self.buildGetterMethod(new_key, return_expr, is_static, zero_span);
                         try new_members.append(self.allocator, getter);
                     }
 
                     // set x(value) { this.#_x_accessor_storage = value; }
                     {
-                        const setter_key = if (is_private_accessor) new_key else try self.ast.addNode(.{
-                            .tag = .identifier_reference,
-                            .span = self.ast.getNode(new_key).data.string_ref,
-                            .data = .{ .string_ref = self.ast.getNode(new_key).data.string_ref },
-                        });
                         const assign_target = try makeThisPrivateField(self, storage_span);
-                        const setter = try self.buildSetterMethod(setter_key, assign_target, is_static, zero_span);
+                        const setter = try self.buildSetterMethod(new_key, assign_target, is_static, zero_span);
                         try new_members.append(self.allocator, setter);
                     }
                 } else {


### PR DESCRIPTION
## 요약

`@dec accessor ["x"] = 1;` 패턴이 ZNTC stage3 transform 에서 internal slice panic. PR #3190 과 동일 class 의 버그 (computed key + 데코레이터 + `data.string_ref` 가정).

## 원인

`stage3_decorator_transform.zig` 의 accessor 처리 (line 368-383) 가 getter/setter 새 키 노드를 합성:

```zig
const getter_key = if (is_private_accessor) new_key else try self.ast.addNode(.{
    .tag = .identifier_reference,
    .span = self.ast.getNode(new_key).data.string_ref,  // ← bug
    .data = .{ .string_ref = self.ast.getNode(new_key).data.string_ref },
});
```

key 가 `computed_property_key` 면 `data.unary.operand` 라 다른 union variant. garbage Span 으로 합성 → codegen `getText(span)` 에서 slice panic.

## 수정

private accessor 가 이미 하던 것과 같은 방식 — getter/setter 양쪽이 같은 `new_key` NodeIndex 공유:

```zig
const getter = try self.buildGetterMethod(new_key, return_expr, is_static, zero_span);
const setter = try self.buildSetterMethod(new_key, assign_target, is_static, zero_span);
```

codegen 은 NodeIndex 만 보고 emit 하므로 같은 노드를 두 method_definition 에서 참조해도 안전.

## 영향

- `esDecorators-classDeclaration-fields-staticAccessor.ts` — 통과
- `esDecorators-classDeclaration-fields-nonStaticAccessor.ts` — 통과
- audit FR: 34 → 32 (-2), match rate 93.09% → 93.11%

## 회귀 가드

`parser_test.zig` — instance + static accessor 두 케이스 unit test.

## Test plan

- [x] `zig build test` 정상
- [x] `bun test tests/tsc/` 2211/2211 pass
- [x] `bun test tests/bundle-smoke.test.ts` 151/151 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)