### PR TITLE
chore(scripts): audit treats TS2356 as syntax-equivalent

### DIFF
--- a/scripts/tsc-conformance-audit.ts
+++ b/scripts/tsc-conformance-audit.ts
@@ -70,6 +70,7 @@ const TS18_SYNTAX_LEVEL_CODES: ReadonlySet<number> = new Set([
 const TS2_SYNTAX_LEVEL_CODES: ReadonlySet<number> = new Set([
   2335, // 'super' can only be referenced in a derived class
   2337, // Super calls are not permitted outside constructors
+  2356, // Arithmetic operand must be 'any'/'number'/'bigint'/'enum' — TSC type-격하, spec 상 AssignmentTargetType 위반 (`++"x"`, `++[0]`)
   2357, // Operand of increment/decrement must be a variable or a property access
   2364, // LHS of an assignment expression must be a variable or a property access
   2398, // 'constructor' cannot be used as a parameter property name


### PR DESCRIPTION
## 요약

`Invalid assignment target` 잔여 8 케이스 (parser/unaryExpression, expressions/incrementOperator/decrementOperator) 모두 동일 패턴 — TSC 가 TS2356 (type-system) 으로 격하한 spec early-error.

`++"x"`, `++[0]`, `++{a}` 같은 코드는 ECMAScript spec 의 AssignmentTargetType 조건 위반 (not simple). esbuild + oxc + ZNTC 일치 거부.

TS2356 → TS2_SYNTAX_LEVEL_CODES 추가.

## 영향

audit FR: 32 → 24 (-8), match rate 93.11% → 93.18%

## Test plan

- [x] `bun run scripts/tsc-conformance-audit.ts` match rate 93.18%

🤖 Generated with [Claude Code](https://claude.com/claude-code)