### PR TITLE
fix(parser): rescan `/` as regex at start of if/while/for/with body

### DIFF
--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -4181,6 +4181,21 @@ test "TS: bare `this` parameter without type annotation is stripped" {
     try std.testing.expectEqual(@as(usize, 0), r.parser.errors.items.len);
 }
 
+// `if/while/for/with (cond) /regex/.method()` 처럼 control-flow `)` 뒤 statement
+// 가 `/` 로 시작하면 scanner 가 division 으로 잘못 토크나이즈 (TSC conformance
+// `parserRegularExpression5.ts`). statement 시작 `/` 는 항상 regex literal —
+// parser 가 expect(.r_paren) 뒤 rescanAsRegexp 호출.
+test "TS: regex literal at start of if/while/for body is reparsed" {
+    // with (...) /regex/ 도 같은 path 지만 strict 거부로 test 어려움 — if/while/for 만 검증.
+    var r = try parseTs(std.testing.allocator,
+        \\if (a) /b/.test(c);
+        \\while (a) /b/.test(c);
+        \\for (;;) /b/.test(c);
+    );
+    defer r.deinit();
+    try std.testing.expectEqual(@as(usize, 0), r.parser.errors.items.len);
+}
+
 // Stage 3 auto-accessor with computed key + decorator (`@dec accessor ["x"] = ...`)
 // 가 `data.string_ref` 가정 코드에서 garbage span 으로 합성돼 codegen slice panic
 // (TSC conformance `esDecorators-classDeclaration-fields-staticAccessor.ts`).

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -494,6 +494,7 @@ fn parseWithStatement(self: *Parser) ParseError2!NodeIndex {
     try self.expect(.l_paren);
     const obj = try self.parseExpression();
     try self.expect(.r_paren);
+    rescanStatementBodyLeadingSlash(self);
     // with body에서 function declaration은 항상 금지 (Annex B에 with 예외 없음)
     // IsLabelledFunction(Statement) 체크도 필요
     const saved_labelled = self.in_labelled_fn_check;
@@ -639,12 +640,23 @@ fn parseReturnStatement(self: *Parser) ParseError2!NodeIndex {
     });
 }
 
+/// `if/while/for/with (cond) <body>` 에서 body 가 `/regex/.test(...)` 처럼 `/` 로
+/// 시작하면 scanner 는 직전 `)` 때문에 `/` 를 division 으로 잘못 토크나이즈한다.
+/// statement 시작 위치의 `/` 는 항상 regex literal (division 의 LHS 가 없음)
+/// 이므로 강제 rescan. esbuild/oxc 와 일치.
+fn rescanStatementBodyLeadingSlash(self: *Parser) void {
+    if (self.scanner.token.kind == .slash or self.scanner.token.kind == .slash_eq) {
+        self.scanner.rescanAsRegexp();
+    }
+}
+
 fn parseIfStatement(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
     try self.advance(); // skip 'if'
     try self.expect(.l_paren);
     const test_expr = try self.parseExpression();
     try self.expect(.r_paren);
+    rescanStatementBodyLeadingSlash(self);
     const known_scan_condition = self.evalScanCondition(test_expr);
     // ECMAScript 13.6.1: IsLabelledFunction(Statement) → SyntaxError
     const saved_labelled = self.in_labelled_fn_check;
@@ -674,6 +686,7 @@ fn parseWhileStatement(self: *Parser) ParseError2!NodeIndex {
     try self.expect(.l_paren);
     const test_expr = try self.parseExpression();
     try self.expect(.r_paren);
+    rescanStatementBodyLeadingSlash(self);
     const body = try self.parseLoopBody();
 
     return try self.ast.addNode(.{
@@ -863,6 +876,7 @@ fn parseForRest(self: *Parser, start: u32, init_expr: NodeIndex) ParseError2!Nod
         update_expr = try self.parseExpression();
     }
     try self.expect(.r_paren);
+    rescanStatementBodyLeadingSlash(self);
     const body = try self.parseLoopBody();
 
     const extra_start = try self.ast.addExtra(@intFromEnum(init_expr));
@@ -882,6 +896,7 @@ fn parseForIn(self: *Parser, start: u32, left: NodeIndex) ParseError2!NodeIndex 
     try self.advance(); // skip 'in'
     const right = try self.parseExpression();
     try self.expect(.r_paren);
+    rescanStatementBodyLeadingSlash(self);
     const body = try self.parseLoopBody();
 
     return try self.ast.addNode(.{
@@ -896,6 +911,7 @@ fn parseForOf(self: *Parser, start: u32, left: NodeIndex, is_await: bool) ParseE
     try self.advance(); // skip 'of'
     const right = try self.parseAssignmentExpression();
     try self.expect(.r_paren);
+    rescanStatementBodyLeadingSlash(self);
     const body = try self.parseLoopBody();
 
     return try self.ast.addNode(.{


### PR DESCRIPTION
Control-flow paren 뒤 statement leading `/` regex re-lex. FR 21→19.