### PR TITLE
fix(parser): tryReinterpretAsTypedArrow rolls back ParseError without propagating

### DIFF
--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -466,22 +466,36 @@ fn parseConditionalExpression(self: *Parser) ParseError2!NodeIndex {
 fn tryReinterpretAsTypedArrow(self: *Parser, paren_expr: NodeIndex) ParseError2!?NodeIndex {
     const saved = self.saveState();
     const errors_before = self.errors.items.len;
+    const saved_scratch = self.saveScratch();
+    const saved_nodes_len = self.ast.nodes.items.len;
+    const saved_extra_len = self.ast.extra_data.items.len;
 
     // Consume `:` (speculatively — might be return type or ternary separator)
     try self.advance(); // skip :
 
     // Parse the return type. Use disallow_conditional_types to prevent the type
     // parser from consuming `?` that belongs to an outer ternary.
+    // parseType 가 ParseError 를 throw 하면 catch — speculative 이므로 caller
+    // 로 propagate 시키면 안 된다 (예: `a ? (x) : (y => y)` 에서 `(y =>` 가
+    // function type param 파싱 실패).
     const ctx_saved = self.ctx;
     self.ctx.disallow_conditional_types = true;
-    const type_node = try self.parseType();
-    _ = type_node;
+    const type_result = self.parseType();
     self.ctx = ctx_saved;
 
-    // Check for `=>` — if present, this is a typed arrow function
-    if (self.current() != .arrow or self.scanner.token.has_newline_before) {
-        // Not a typed arrow — restore and let the caller treat `:` as ternary separator
+    const rollback_to_caller = type_result == error.OutOfMemory;
+    if (rollback_to_caller) return error.OutOfMemory;
+
+    const arrow_ok = (type_result catch null) != null and
+        self.current() == .arrow and !self.scanner.token.has_newline_before and
+        self.errors.items.len == errors_before;
+
+    if (!arrow_ok) {
+        // Not a typed arrow (or parseType errored) — restore and let the caller treat `:` as ternary separator
         self.rollbackErrors(errors_before);
+        self.ast.nodes.items.len = saved_nodes_len;
+        self.ast.extra_data.items.len = saved_extra_len;
+        self.restoreScratch(saved_scratch);
         self.restoreState(saved);
         return null;
     }

--- a/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
+++ b/tests/integration/tests/tsc/__snapshots__/expressions.test.ts.snap
@@ -15824,3 +15824,116 @@ C = undefined;
 // Error
 "
 `;
+
+exports[`TSC: expressions parenthesizedContexualTyping1 1`] = `
+"function fun(g,x) {
+	return g(x);
+}
+var a = fun((x) => x, 10);
+var b = fun(((x) => x), 10);
+var c = fun((((x) => x)), 10);
+var d = fun(((((x) => x))), 10);
+var e = fun((x) => x, (x) => x, 10);
+var f = fun(((x) => x), ((x) => x), 10);
+var g = fun((((x) => x)), (((x) => x)), 10);
+var h = fun(((((x) => x))), (((x) => x)), 10);
+// Ternaries in parens
+var i = fun((Math.random() < 0.5 ? (x) => x : (x) => undefined), 10);
+var j = fun((Math.random() < 0.5 ? ((x) => x) : ((x) => undefined)), 10);
+var k = fun((Math.random() < 0.5 ? ((x) => x) : ((x) => undefined)), (x) => x, 10);
+var l = fun(((Math.random() < 0.5 ? (((x) => x)) : (((x) => undefined)))), (((x) => x)), 10);
+var lambda1 = (x) => x;
+var lambda2 = ((x) => x);
+var obj1 = { x: (x) => (x,undefined), y: (y) => (y,undefined) };
+var obj2 = ({ x: (x) => (x,undefined), y: (y) => (y,undefined) });
+"
+`;
+
+exports[`TSC: expressions parenthesizedContexualTyping2 1`] = `
+"// These tests ensure that in cases where it may *appear* that a value has a type,
+// they actually are properly being contextually typed. The way we test this is
+// that we invoke contextually typed arguments with type arguments.
+// Since 'any' cannot be invoked with type arguments, we should get errors
+// back if contextual typing is not taking effect.
+function fun(...rest) {
+	return undefined;
+}
+var a = fun((x) => {
+	x(undefined);
+	return x;
+}, 10);
+var b = fun(((x) => {
+	x(undefined);
+	return x;
+}), 10);
+var c = fun((((x) => {
+	x(undefined);
+	return x;
+})), 10);
+var d = fun(((((x) => {
+	x(undefined);
+	return x;
+}))), 10);
+var e = fun((x) => {
+	x(undefined);
+	return x;
+}, (x) => {
+	x(undefined);
+	return x;
+}, 10);
+var f = fun(((x) => {
+	x(undefined);
+	return x;
+}), ((x) => {
+	x(undefined);
+	return x;
+}), 10);
+var g = fun((((x) => {
+	x(undefined);
+	return x;
+})), (((x) => {
+	x(undefined);
+	return x;
+})), 10);
+var h = fun(((((x) => {
+	x(undefined);
+	return x;
+}))), (((x) => {
+	x(undefined);
+	return x;
+})), 10);
+// Ternaries in parens
+var i = fun((Math.random() < 0.5 ? (x) => {
+	x(undefined);
+	return x;
+} : (x) => undefined), 10);
+var j = fun((Math.random() < 0.5 ? ((x) => {
+	x(undefined);
+	return x;
+}) : ((x) => undefined)), 10);
+var k = fun((Math.random() < 0.5 ? ((x) => {
+	x(undefined);
+	return x;
+}) : ((x) => undefined)), (x) => {
+	x(undefined);
+	return x;
+}, 10);
+var l = fun(((Math.random() < 0.5 ? (((x) => {
+	x(undefined);
+	return x;
+})) : (((x) => undefined)))), (((x) => {
+	x(undefined);
+	return x;
+})), 10);
+var lambda1 = (x) => {
+	x(undefined);
+	return x;
+};
+var lambda2 = ((x) => {
+	x(undefined);
+	return x;
+});
+var obj1 = { x: (x) => (x,undefined), y: (y) => (y,undefined) };
+var obj2 = ({ x: (x) => (x,undefined), y: (y) => (y,undefined) });
+"
+`;

--- a/tests/integration/tests/tsc/expressions.test.ts
+++ b/tests/integration/tests/tsc/expressions.test.ts
@@ -8618,7 +8618,7 @@ var b: {};
     );
   });
   test('parenthesizedContexualTyping1', async () => {
-    await expectError(
+    await expectPass(
       `
 function fun<T>(g: (x: T) => T, x: T): T;
 function fun<T>(g: (x: T) => T, h: (y: T) => T, x: T): T;
@@ -8652,7 +8652,7 @@ var obj2: ObjType = ({ x: x => (x, undefined), y: y => (y, undefined) });`,
     );
   });
   test('parenthesizedContexualTyping2', async () => {
-    await expectError(
+    await expectPass(
       `// These tests ensure that in cases where it may *appear* that a value has a type,
 // they actually are properly being contextually typed. The way we test this is
 // that we invoke contextually typed arguments with type arguments.


### PR DESCRIPTION
ternary alternate parenthesized arrow speculative parsing fix. FR 19→17.