### PR TITLE
fix(parser): clear in_decorator inside parenthesized expression

### DIFF
--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -1368,6 +1368,8 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
         .l_paren => {
             // 괄호 표현식 또는 arrow function 파라미터 리스트.
             // 괄호 안에서는 `in` 연산자가 항상 허용된다 (ECMAScript: [+In] 컨텍스트).
+            // `in_decorator` 도 괄호 안에서는 해제 — `@(inst["foo"])` 같은 패턴에서
+            // 안쪽 computed member access 가 다음 멤버 key 와 혼동될 일 없음.
 
             // TS 모드: `(a: Type, b?: Type) => body` — 타입 어노테이션이 있는 arrow function.
             // lookahead로 감지: `(` 뒤에 identifier + `:` 또는 `?` 패턴이면 speculative 파싱.
@@ -1391,7 +1393,10 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
             // `(a, ...b) => {}` 형태의 rest 파라미터를 cover grammar으로 지원.
             // `...`는 일반 expression에서는 나올 수 없으므로 arrow 파라미터로만 해석된다.
             const paren_saved = self.enterAllowInContext(true);
+            const saved_in_decorator = self.ctx.in_decorator;
+            self.ctx.in_decorator = false;
             const expr = try parseExpressionOrRest(self);
+            self.ctx.in_decorator = saved_in_decorator;
             self.restoreContext(paren_saved);
 
             // Flow TypeCast: (expr: Type) — 괄호 안에서 expression 뒤에 `: Type`이 오면

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -4181,6 +4181,21 @@ test "TS: bare `this` parameter without type annotation is stripped" {
     try std.testing.expectEqual(@as(usize, 0), r.parser.errors.items.len);
 }
 
+// `@(inst["foo"]) method() {}` 같은 parenthesized decorator + computed member
+// access 는 `in_decorator` flag 가 안쪽 paren 까지 전파돼 `[` 가 거부되던 버그.
+// (TSC conformance `esDecorators-preservesThis.ts`, `decoratorOnClassMethod12.ts`)
+test "TS: parenthesized decorator allows computed member access inside parens" {
+    var r = try parseTs(std.testing.allocator,
+        \\declare const inst: any;
+        \\class C {
+        \\    @(inst["foo"]) method1() {}
+        \\    @((inst.bar)) method2() {}
+        \\}
+    );
+    defer r.deinit();
+    try std.testing.expectEqual(@as(usize, 0), r.parser.errors.items.len);
+}
+
 // `if/while/for/with (cond) /regex/.method()` 처럼 control-flow `)` 뒤 statement
 // 가 `/` 로 시작하면 scanner 가 division 으로 잘못 토크나이즈 (TSC conformance
 // `parserRegularExpression5.ts`). statement 시작 `/` 는 항상 regex literal —


### PR DESCRIPTION
@(inst["x"]) decorator pattern. FR 17→15.