### PR TITLE
fix(parser): accept contextual keyword as labeled break/continue label

### DIFF
--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -4181,6 +4181,19 @@ test "TS: bare `this` parameter without type annotation is stripped" {
     try std.testing.expectEqual(@as(usize, 0), r.parser.errors.items.len);
 }
 
+// `target: break target;` 같은 labeled break/continue 에서 label 이 contextual
+// keyword (target/from/async/set/get/of/using/accessor 등) 이면 ZNTC 가 label
+// 파싱을 `.identifier` 만 검사해 거부했었다 (TSC conformance `parser_breakTarget1.ts`).
+test "TS: labeled break/continue accepts contextual keyword as label" {
+    var r = try parseTs(std.testing.allocator,
+        \\target: break target;
+        \\from: while (true) continue from;
+        \\of: for (;;) break of;
+    );
+    defer r.deinit();
+    try std.testing.expectEqual(@as(usize, 0), r.parser.errors.items.len);
+}
+
 // `@(inst["foo"]) method() {}` 같은 parenthesized decorator + computed member
 // access 는 `in_decorator` flag 가 안쪽 paren 까지 전파돼 `[` 가 거부되던 버그.
 // (TSC conformance `esDecorators-preservesThis.ts`, `decoratorOnClassMethod12.ts`)

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -927,10 +927,13 @@ fn parseSimpleStatement(self: *Parser, tag: Tag) ParseError2!NodeIndex {
     const start = keyword_span.start;
     try self.advance(); // skip break/continue/debugger
 
-    // break/continue 뒤에 줄바꿈 없이 identifier가 오면 label로 소비
+    // break/continue 뒤에 줄바꿈 없이 identifier-like 토큰이 오면 label 로 소비.
+    // contextual keyword (`target`, `from`, `async`, `set`, `get`, `of`, `using`,
+    // `accessor` 등) 도 label 자리에서는 valid identifier 라서 허용 — TSC conformance
+    // `parser_breakTarget1.ts` (`target: break target;`) 등.
     var label = NodeIndex.none;
     if ((tag == .break_statement or tag == .continue_statement) and
-        self.current() == .identifier and !self.scanner.token.has_newline_before)
+        self.current().canBeBindingName() and !self.scanner.token.has_newline_before)
     {
         label = try self.ast.addNode(.{
             .tag = .identifier_reference,


### PR DESCRIPTION
labeled break/continue contextual keyword label. FR 13→12.