### PR TITLE
fix(rn): copy only registered release assets

### DIFF
--- a/packages/core/bin/rn-asset-copy.mjs
+++ b/packages/core/bin/rn-asset-copy.mjs
@@ -356,11 +356,7 @@ export function copyRegisteredAssetsForAndroid(assets, assetsDest) {
  *
  * @returns 복사된 파일 수.
  */
-export function copyRnAssets({
-  assetsDest,
-  rnPlatform,
-  bundleCode,
-}) {
+export function copyRnAssets({ assetsDest, rnPlatform, bundleCode }) {
   if (!assetsDest) return 0;
   if (typeof bundleCode !== 'string') {
     throw new Error('RN release asset copy requires bundleCode');

--- a/packages/core/bin/rn-asset-copy.mjs
+++ b/packages/core/bin/rn-asset-copy.mjs
@@ -1,15 +1,9 @@
-// RN production bundle 의 asset 복사. Metro saveAssets/getAssetDestPathAndroid
-// 호환 경로를 사용한다.
-//
-// caller (`runRnBundle`) 가 production (dev=false) + `--assets-dest` 명시 시 호출.
-// 동작:
-//   1. bundle 안의 `AssetRegistry.registerAsset({...})` 를 읽어 참조된 asset만 수집.
-//   2. 각 asset 의 scales 기준으로 원본/`@2x`/`@3x` 파일을 복사.
-//   3. iOS — Metro getAssetDestPathIOS 형식으로 복사.
-//   4. Android — Metro getResourceIdentifier + drawable/raw 분기 + keep.xml 생성.
-//   5. projectRoot walk helper 는 단위 테스트와 저수준 호출용으로만 유지.
+// RN production bundle 의 asset 복사. Metro saveAssets/getAssetDestPath{IOS,Android}
+// 호환 경로를 사용한다 — bundle 안 `AssetRegistry.registerAsset({...})` 호출에서
+// 참조된 asset 만 복사하여 release 산출물을 자동 prune. `runRnBundle` 이
+// dev=false + `--assets-dest` 명시 시 호출.
 
-import { copyFileSync, existsSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs';
+import { copyFileSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs';
 import { basename, dirname, extname, join, relative } from 'node:path';
 
 /** scale variant naming — `@2x.png` / `@3x.png` 등. capture group 1 이 scale 숫자. */
@@ -68,24 +62,29 @@ export function parseAssetName(filename) {
 }
 
 /**
- * Metro 의 Android filename convention — `<flatRelPath>_<baseName>.<ext>` 형식.
- * `asset.httpServerLocation` 의 `/assets/` prefix 는 resource identifier 에서 제거된다.
+ * Metro Android resource-identifier sanitize — lowercase, `/` → `_`, non-alnum
+ * 제거, `assets_`/`assetsunstable_path_` prefix 제거. `asset.httpServerLocation`
+ * 이 항상 `/assets/...` 또는 `/assetsunstable_path/...` 로 시작하므로 prefix
+ * 제거가 resource identifier 의 일부.
  */
+function metroSanitizeResourceName(rawPath) {
+  return rawPath
+    .toLowerCase()
+    .replace(/\//g, '_')
+    .replace(/[^a-z0-9_]/g, '')
+    .replace(/^(?:assets|assetsunstable_path)_/, '');
+}
+
+/** Metro 의 Android filename convention — `<flatRelPath>_<baseName>.<ext>` 형식. */
 export function androidAssetFileName(relDir, baseName, ext) {
-  const sanitize = (value) => value.toLowerCase().replace(/[^a-z0-9_]/g, '');
-  const flat = sanitize(relDir.replace(/\//g, '_')).replace(/^(?:assets|assetsunstable_path)_/, '');
-  const prefix = flat ? `${flat}_` : '';
-  return `${prefix}${sanitize(baseName)}${ext.toLowerCase()}`;
+  const sanitized = metroSanitizeResourceName(relDir ? `${relDir}/${baseName}` : baseName);
+  return `${sanitized}${ext.toLowerCase()}`;
 }
 
 export function getAndroidResourceIdentifier(asset) {
   let basePath = asset.httpServerLocation ?? '';
   if (basePath.startsWith('/')) basePath = basePath.slice(1);
-  return `${basePath}/${asset.name}`
-    .toLowerCase()
-    .replace(/\//g, '_')
-    .replace(/([^a-z0-9_])/g, '')
-    .replace(/^(?:assets|assetsunstable_path)_/, '');
+  return metroSanitizeResourceName(`${basePath}/${asset.name}`);
 }
 
 /** Android `keep.xml` body — drawable/raw 자원 보존 list. */
@@ -232,6 +231,17 @@ function sourceFileForScale(asset, scale) {
   return join(asset.fileSystemLocation, `${asset.name}${suffix}.${asset.type}`);
 }
 
+function copyRegisteredAssetFile(src, destPath) {
+  try {
+    copyFileSync(src, destPath);
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      throw new Error(`registered RN asset file not found: ${src}`);
+    }
+    throw err;
+  }
+}
+
 /**
  * iOS production 복사 — `<assetsDest>/<relDir>/<file>` 으로. IOS_SCALES (1/2/3) 외
  * scale 은 제외. 같은 baseName 의 scale variant 들은 모두 같은 destDir 에 원래
@@ -250,22 +260,23 @@ export function copyAssetsForIos(assets, assetsDest) {
 }
 
 export function copyRegisteredAssetsForIos(assets, assetsDest) {
+  const createdDirs = new Set();
   let copied = 0;
   for (const asset of assets) {
     for (const scale of asset.scales) {
       if (!IOS_SCALES.has(scale)) continue;
       const src = sourceFileForScale(asset, scale);
-      if (!existsSync(src)) {
-        throw new Error(`registered RN asset file not found: ${src}`);
-      }
-      const suffix = scale === 1 ? '' : `@${scale}x`;
       const destPath = join(
         assetsDest,
         asset.httpServerLocation.slice(1).replace(/\.\.\//g, '_'),
-        `${asset.name}${suffix}.${asset.type}`,
+        basename(src),
       );
-      mkdirSync(dirname(destPath), { recursive: true });
-      copyFileSync(src, destPath);
+      const targetDir = dirname(destPath);
+      if (!createdDirs.has(targetDir)) {
+        mkdirSync(targetDir, { recursive: true });
+        createdDirs.add(targetDir);
+      }
+      copyRegisteredAssetFile(src, destPath);
       copied++;
     }
   }
@@ -305,6 +316,7 @@ export function copyAssetsForAndroid(assets, assetsDest) {
 
 export function copyRegisteredAssetsForAndroid(assets, assetsDest) {
   const keepRefs = new Set();
+  const createdDirs = new Set();
   let copied = 0;
 
   for (const asset of assets) {
@@ -312,13 +324,15 @@ export function copyRegisteredAssetsForAndroid(assets, assetsDest) {
     const resourceName = getAndroidResourceIdentifier(asset);
     for (const scale of asset.scales) {
       const folder = isDrawable ? getAndroidDrawableFolder(scale) : 'raw';
-      const src = sourceFileForScale(asset, scale);
-      if (!existsSync(src)) {
-        throw new Error(`registered RN asset file not found: ${src}`);
-      }
       const targetDir = join(assetsDest, folder);
-      mkdirSync(targetDir, { recursive: true });
-      copyFileSync(src, join(targetDir, `${resourceName}.${asset.type}`));
+      if (!createdDirs.has(targetDir)) {
+        mkdirSync(targetDir, { recursive: true });
+        createdDirs.add(targetDir);
+      }
+      copyRegisteredAssetFile(
+        sourceFileForScale(asset, scale),
+        join(targetDir, `${resourceName}.${asset.type}`),
+      );
       copied++;
     }
     keepRefs.add(`@${isDrawable ? 'drawable' : 'raw'}/${resourceName}`);
@@ -326,7 +340,10 @@ export function copyRegisteredAssetsForAndroid(assets, assetsDest) {
 
   if (keepRefs.size > 0) {
     const keepDir = join(assetsDest, 'raw');
-    mkdirSync(keepDir, { recursive: true });
+    if (!createdDirs.has(keepDir)) {
+      mkdirSync(keepDir, { recursive: true });
+      createdDirs.add(keepDir);
+    }
     writeFileSync(join(keepDir, 'keep.xml'), buildKeepXml([...keepRefs].sort()));
   }
 

--- a/packages/core/bin/rn-asset-copy.mjs
+++ b/packages/core/bin/rn-asset-copy.mjs
@@ -1,17 +1,16 @@
-// RN production bundle 의 asset 복사. bungae packages/bungae/src/build.ts L100~L260
-// + zntc-bundler/build.ts copyAssets / plugin-core.ts SCALE_REGEX/IOS_SCALES 이식.
+// RN production bundle 의 asset 복사. Metro saveAssets/getAssetDestPathAndroid
+// 호환 경로를 사용한다.
 //
 // caller (`runRnBundle`) 가 production (dev=false) + `--assets-dest` 명시 시 호출.
 // 동작:
-//   1. projectRoot 를 walkDir — assetExts 화이트리스트 매칭 file 수집.
-//   2. file 마다 scale variant 동일 디렉토리에서 추가 수집 (`@2x.png` 등).
-//   3. iOS — IOS_SCALES (1/2/3) 만 통과, `<assetsDest>/<relPath>/<file>` 복사.
-//   4. Android — Metro scaleToDrawable 매핑 (1→mdpi/1.5→hdpi/2→xhdpi/3→xxhdpi/4→xxxhdpi),
-//      `__<flatRel>_<basename>.<ext>` naming + keep.xml 생성.
-//   5. node_modules / .git / dist / build / .next / .turbo / .bun / .DS_Store skip.
+//   1. bundle 안의 `AssetRegistry.registerAsset({...})` 를 읽어 참조된 asset만 수집.
+//   2. 각 asset 의 scales 기준으로 원본/`@2x`/`@3x` 파일을 복사.
+//   3. iOS — Metro getAssetDestPathIOS 형식으로 복사.
+//   4. Android — Metro getResourceIdentifier + drawable/raw 분기 + keep.xml 생성.
+//   5. projectRoot walk helper 는 단위 테스트와 저수준 호출용으로만 유지.
 
-import { copyFileSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs';
-import { basename, extname, join, relative } from 'node:path';
+import { copyFileSync, existsSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs';
+import { basename, dirname, extname, join, relative } from 'node:path';
 
 /** scale variant naming — `@2x.png` / `@3x.png` 등. capture group 1 이 scale 숫자. */
 export const SCALE_REGEX = /@(\d+(?:\.\d+)?)x/;
@@ -40,7 +39,7 @@ const SKIP_DIRS = new Set([
   '.DS_Store',
 ]);
 
-const DRAWABLE_EXT_RE = /\.(png|jpg|jpeg|gif|webp|bmp|avif|ico|icns|icxl)$/i;
+const DRAWABLE_EXT_RE = /\.(gif|jpeg|jpg|png|webp|xml)$/i;
 
 /**
  * Metro 호환 Android drawable folder name. table miss 시 `drawable-{round(160*scale)}dpi`
@@ -70,18 +69,28 @@ export function parseAssetName(filename) {
 
 /**
  * Metro 의 Android filename convention — `<flatRelPath>_<baseName>.<ext>` 형식.
- * relative path 의 `/` 를 `_` 로 치환 + 비-alnum 문자 제거 + `__` prefix
- * (node_modules asset 표식 — Metro 가 그대로 따름).
+ * `asset.httpServerLocation` 의 `/assets/` prefix 는 resource identifier 에서 제거된다.
  */
 export function androidAssetFileName(relDir, baseName, ext) {
-  const flat = relDir.replace(/\//g, '_').replace(/[^a-z0-9_]/gi, '');
-  const prefix = flat ? (flat.startsWith('__') ? flat : `__${flat}`) : '__';
-  return `${prefix}_${baseName}${ext}`;
+  const sanitize = (value) => value.toLowerCase().replace(/[^a-z0-9_]/g, '');
+  const flat = sanitize(relDir.replace(/\//g, '_')).replace(/^(?:assets|assetsunstable_path)_/, '');
+  const prefix = flat ? `${flat}_` : '';
+  return `${prefix}${sanitize(baseName)}${ext.toLowerCase()}`;
 }
 
-/** Android `keep.xml` body — drawable 자원 보존 list. */
+export function getAndroidResourceIdentifier(asset) {
+  let basePath = asset.httpServerLocation ?? '';
+  if (basePath.startsWith('/')) basePath = basePath.slice(1);
+  return `${basePath}/${asset.name}`
+    .toLowerCase()
+    .replace(/\//g, '_')
+    .replace(/([^a-z0-9_])/g, '')
+    .replace(/^(?:assets|assetsunstable_path)_/, '');
+}
+
+/** Android `keep.xml` body — drawable/raw 자원 보존 list. */
 export function buildKeepXml(drawableNames) {
-  const items = drawableNames.map((n) => `@drawable/${n}`).join(',');
+  const items = drawableNames.map((n) => (n.startsWith('@') ? n : `@drawable/${n}`)).join(',');
   return [
     '<?xml version="1.0" encoding="utf-8"?>',
     `<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="${items}" />`,
@@ -94,10 +103,13 @@ export function buildKeepXml(drawableNames) {
  * `[{ filePath, baseName, scale, ext, relDir }]`. relDir 은 projectRoot
  * 기준 상대 경로 (POSIX `/`).
  */
-export function discoverAssets(projectRoot, assetExts) {
-  const exts = new Set(
-    [...assetExts].map((e) => (e.startsWith('.') ? e.toLowerCase() : `.${e.toLowerCase()}`)),
-  );
+export function discoverAssets(projectRoot, assetExts, sourceExts = []) {
+  const normalizeExt = (e) => (e.startsWith('.') ? e.toLowerCase() : `.${e.toLowerCase()}`);
+  const sourceExtSet = new Set([...sourceExts].map(normalizeExt));
+  const exts = new Set([...assetExts].map(normalizeExt));
+  for (const ext of sourceExtSet) {
+    exts.delete(ext);
+  }
   const out = [];
 
   function walk(dir) {
@@ -126,6 +138,100 @@ export function discoverAssets(projectRoot, assetExts) {
   return out;
 }
 
+function findMatchingBrace(source, openIndex) {
+  let depth = 0;
+  let quote = '';
+  let escaped = false;
+
+  for (let i = openIndex; i < source.length; i++) {
+    const ch = source[i];
+
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === '\\') {
+        escaped = true;
+      } else if (ch === quote) {
+        quote = '';
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+
+    if (ch === '{') {
+      depth++;
+      continue;
+    }
+
+    if (ch === '}') {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+
+  return -1;
+}
+
+function isRegisteredAsset(value) {
+  return (
+    value &&
+    value.__packager_asset === true &&
+    typeof value.fileSystemLocation === 'string' &&
+    typeof value.httpServerLocation === 'string' &&
+    typeof value.name === 'string' &&
+    typeof value.type === 'string' &&
+    Array.isArray(value.scales)
+  );
+}
+
+export function extractRegisteredAssets(bundleCode) {
+  if (typeof bundleCode !== 'string' || bundleCode.length === 0) return [];
+
+  const assets = [];
+  let cursor = 0;
+  while (cursor < bundleCode.length) {
+    const callIndex = bundleCode.indexOf('registerAsset(', cursor);
+    if (callIndex === -1) break;
+
+    let argIndex = callIndex + 'registerAsset('.length;
+    while (/\s/.test(bundleCode[argIndex] ?? '')) argIndex++;
+    if (bundleCode[argIndex] !== '{') {
+      cursor = argIndex + 1;
+      continue;
+    }
+
+    const endIndex = findMatchingBrace(bundleCode, argIndex);
+    if (endIndex === -1) break;
+    const objectText = bundleCode.slice(argIndex, endIndex + 1);
+    cursor = endIndex + 1;
+
+    if (!objectText.includes('"__packager_asset"')) continue;
+    try {
+      const asset = JSON.parse(objectText);
+      if (isRegisteredAsset(asset)) {
+        assets.push({
+          ...asset,
+          type: asset.type.toLowerCase(),
+          scales: asset.scales.filter((s) => Number.isFinite(s) && s > 0),
+        });
+      }
+    } catch {
+      // Not a JSON-shaped ZNTC/Metro asset registry call.
+    }
+  }
+
+  return assets;
+}
+
+function sourceFileForScale(asset, scale) {
+  const suffix = scale === 1 ? '' : `@${scale}x`;
+  return join(asset.fileSystemLocation, `${asset.name}${suffix}.${asset.type}`);
+}
+
 /**
  * iOS production 복사 — `<assetsDest>/<relDir>/<file>` 으로. IOS_SCALES (1/2/3) 외
  * scale 은 제외. 같은 baseName 의 scale variant 들은 모두 같은 destDir 에 원래
@@ -143,6 +249,29 @@ export function copyAssetsForIos(assets, assetsDest) {
   return copied;
 }
 
+export function copyRegisteredAssetsForIos(assets, assetsDest) {
+  let copied = 0;
+  for (const asset of assets) {
+    for (const scale of asset.scales) {
+      if (!IOS_SCALES.has(scale)) continue;
+      const src = sourceFileForScale(asset, scale);
+      if (!existsSync(src)) {
+        throw new Error(`registered RN asset file not found: ${src}`);
+      }
+      const suffix = scale === 1 ? '' : `@${scale}x`;
+      const destPath = join(
+        assetsDest,
+        asset.httpServerLocation.slice(1).replace(/\.\.\//g, '_'),
+        `${asset.name}${suffix}.${asset.type}`,
+      );
+      mkdirSync(dirname(destPath), { recursive: true });
+      copyFileSync(src, destPath);
+      copied++;
+    }
+  }
+  return copied;
+}
+
 /**
  * Android production 복사 — Metro scale-to-drawable folder + flattened name +
  * keep.xml. drawable resource name (확장자 제거) 을 keepNames 에 누적.
@@ -151,43 +280,78 @@ export function copyAssetsForIos(assets, assetsDest) {
  */
 export function copyAssetsForAndroid(assets, assetsDest) {
   const baseDir = assetsDest;
-  const keepNames = new Set();
+  const keepRefs = new Set();
   let copied = 0;
   for (const a of assets) {
-    const folder = getAndroidDrawableFolder(a.scale);
+    const isDrawable = DRAWABLE_EXT_RE.test(a.ext);
+    const folder = isDrawable ? getAndroidDrawableFolder(a.scale) : 'raw';
     const targetDir = join(baseDir, folder);
     mkdirSync(targetDir, { recursive: true });
     const fileName = androidAssetFileName(a.relDir, a.baseName, a.ext);
     copyFileSync(a.filePath, join(targetDir, fileName));
     copied++;
-    if (DRAWABLE_EXT_RE.test(fileName)) {
-      keepNames.add(fileName.replace(DRAWABLE_EXT_RE, ''));
-    }
+    const resourceName = fileName.slice(0, fileName.length - extname(fileName).length);
+    keepRefs.add(`@${isDrawable ? 'drawable' : 'raw'}/${resourceName}`);
   }
   // keep.xml — `res/raw/keep.xml` 위치. drawable resources 의 ProGuard/R8 미사용
   // 보장.
-  if (keepNames.size > 0) {
+  if (keepRefs.size > 0) {
     const keepDir = join(baseDir, 'raw');
     mkdirSync(keepDir, { recursive: true });
-    writeFileSync(join(keepDir, 'keep.xml'), buildKeepXml([...keepNames].sort()));
+    writeFileSync(join(keepDir, 'keep.xml'), buildKeepXml([...keepRefs].sort()));
   }
+  return copied;
+}
+
+export function copyRegisteredAssetsForAndroid(assets, assetsDest) {
+  const keepRefs = new Set();
+  let copied = 0;
+
+  for (const asset of assets) {
+    const isDrawable = DRAWABLE_EXT_RE.test(`.${asset.type}`);
+    const resourceName = getAndroidResourceIdentifier(asset);
+    for (const scale of asset.scales) {
+      const folder = isDrawable ? getAndroidDrawableFolder(scale) : 'raw';
+      const src = sourceFileForScale(asset, scale);
+      if (!existsSync(src)) {
+        throw new Error(`registered RN asset file not found: ${src}`);
+      }
+      const targetDir = join(assetsDest, folder);
+      mkdirSync(targetDir, { recursive: true });
+      copyFileSync(src, join(targetDir, `${resourceName}.${asset.type}`));
+      copied++;
+    }
+    keepRefs.add(`@${isDrawable ? 'drawable' : 'raw'}/${resourceName}`);
+  }
+
+  if (keepRefs.size > 0) {
+    const keepDir = join(assetsDest, 'raw');
+    mkdirSync(keepDir, { recursive: true });
+    writeFileSync(join(keepDir, 'keep.xml'), buildKeepXml([...keepRefs].sort()));
+  }
+
   return copied;
 }
 
 /**
  * Production asset 복사 entry — caller (runRnBundle) 에서 dev=false + assetsDest
- * 명시 시 호출. discoverAssets + platform 분기.
+ * 명시 시 호출. Metro처럼 bundle 에 등록된 asset 목록만 복사한다.
  *
  * @returns 복사된 파일 수.
  */
-export function copyRnAssets({ projectRoot, assetsDest, rnPlatform, assetExts }) {
-  // projectRoot 존재 / 디렉토리 검증은 discoverAssets 내부 walk 의 readdirSync
-  // try/catch 가 처리 — 미존재면 빈 array. 별도 guard 불필요.
+export function copyRnAssets({
+  assetsDest,
+  rnPlatform,
+  bundleCode,
+}) {
   if (!assetsDest) return 0;
-  const assets = discoverAssets(projectRoot, assetExts);
-  if (assets.length === 0) return 0;
-  if (rnPlatform === 'android') {
-    return copyAssetsForAndroid(assets, assetsDest);
+  if (typeof bundleCode !== 'string') {
+    throw new Error('RN release asset copy requires bundleCode');
   }
-  return copyAssetsForIos(assets, assetsDest);
+  const registeredAssets = extractRegisteredAssets(bundleCode);
+  if (registeredAssets.length === 0) return 0;
+  if (rnPlatform === 'android') {
+    return copyRegisteredAssetsForAndroid(registeredAssets, assetsDest);
+  }
+  return copyRegisteredAssetsForIos(registeredAssets, assetsDest);
 }

--- a/packages/core/bin/rn-asset-copy.test.ts
+++ b/packages/core/bin/rn-asset-copy.test.ts
@@ -6,9 +6,13 @@ import { join } from 'node:path';
 import {
   androidAssetFileName,
   buildKeepXml,
+  copyAssetsForAndroid,
+  copyAssetsForIos,
   copyRnAssets,
   discoverAssets,
+  extractRegisteredAssets,
   getAndroidDrawableFolder,
+  getAndroidResourceIdentifier,
   IOS_SCALES,
   parseAssetName,
   SCALE_REGEX,
@@ -85,16 +89,50 @@ describe('getAndroidDrawableFolder — Metro scaleToDrawable 매핑', () => {
 });
 
 describe('androidAssetFileName — Metro flat naming', () => {
-  test('빈 relDir — `__<baseName><ext>`', () => {
-    expect(androidAssetFileName('', 'logo', '.png')).toBe('___logo.png');
+  test('빈 relDir — `<baseName><ext>`', () => {
+    expect(androidAssetFileName('', 'logo', '.png')).toBe('logo.png');
   });
 
-  test('단순 디렉토리 — `__<dir>_<baseName><ext>`', () => {
-    expect(androidAssetFileName('src/assets', 'logo', '.png')).toBe('__src_assets_logo.png');
+  test('단순 디렉토리 — `<dir>_<baseName><ext>`', () => {
+    expect(androidAssetFileName('src/assets', 'logo', '.png')).toBe('src_assets_logo.png');
   });
 
   test('비-alnum 문자 제거', () => {
-    expect(androidAssetFileName('src/img-foo', 'icon', '.svg')).toBe('__src_imgfoo_icon.svg');
+    expect(androidAssetFileName('src/img-foo', 'icon', '.svg')).toBe('src_imgfoo_icon.svg');
+  });
+
+  test('Android resource 호환을 위해 대문자를 소문자로 정규화', () => {
+    expect(androidAssetFileName('src/assets/tableOrder', 'imgLayoutB', '.PNG')).toBe(
+      'src_assets_tableorder_imglayoutb.png',
+    );
+  });
+});
+
+describe('Metro registered asset helpers', () => {
+  test('getAndroidResourceIdentifier — Metro resource identifier 와 동일', () => {
+    expect(
+      getAndroidResourceIdentifier({
+        httpServerLocation: '/assets/src/assets/tableOrder',
+        name: 'imgLayoutB',
+      }),
+    ).toBe('src_assets_tableorder_imglayoutb');
+  });
+
+  test('extractRegisteredAssets — bundle 의 AssetRegistry.registerAsset 목록 추출', () => {
+    const asset = {
+      __packager_asset: true,
+      httpServerLocation: '/assets/src/assets',
+      width: 1,
+      height: 1,
+      scales: [1, 2],
+      hash: 'hash',
+      name: 'logo',
+      type: 'png',
+      fileSystemLocation: join(dir, 'src/assets'),
+    };
+    const bundle = `module.exports = Registry.registerAsset(${JSON.stringify(asset)});`;
+
+    expect(extractRegisteredAssets(bundle)).toEqual([asset]);
   });
 });
 
@@ -142,6 +180,16 @@ describe('discoverAssets', () => {
     const result = discoverAssets(dir, ['.png']);
     expect(result.length).toBe(1);
   });
+
+  test('sourceExts 와 겹치는 확장자는 asset copy 에서 제외', () => {
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(join(dir, 'src/icon.svg'), '<svg />');
+    writeFileSync(join(dir, 'src/logo.png'), 'png');
+
+    const result = discoverAssets(dir, ['.svg', '.png'], ['.svg']);
+    const names = result.map((r) => r.filePath.replace(`${dir}/`, '')).sort();
+    expect(names).toEqual(['src/logo.png']);
+  });
 });
 
 describe('copyRnAssets — iOS', () => {
@@ -152,12 +200,7 @@ describe('copyRnAssets — iOS', () => {
     writeFileSync(join(dir, 'src/assets/logo@3x.png'), 'c');
     writeFileSync(join(dir, 'src/assets/logo@4x.png'), 'd'); // skip
 
-    const copied = copyRnAssets({
-      projectRoot: dir,
-      assetsDest: dest,
-      rnPlatform: 'ios',
-      assetExts: ['.png'],
-    });
+    const copied = copyAssetsForIos(discoverAssets(dir, ['.png']), dest);
     expect(copied).toBe(3); // 1x/2x/3x 만, 4x 제외
     expect(existsSync(join(dest, 'src/assets/logo.png'))).toBe(true);
     expect(existsSync(join(dest, 'src/assets/logo@2x.png'))).toBe(true);
@@ -167,7 +210,7 @@ describe('copyRnAssets — iOS', () => {
 
   test('asset 0 — copied 0', () => {
     expect(
-      copyRnAssets({ projectRoot: dir, assetsDest: dest, rnPlatform: 'ios', assetExts: ['.png'] }),
+      copyRnAssets({ assetsDest: dest, rnPlatform: 'ios', bundleCode: '/* no registered asset */' }),
     ).toBe(0);
   });
 });
@@ -179,66 +222,116 @@ describe('copyRnAssets — Android', () => {
     writeFileSync(join(dir, 'src/img/logo@2x.png'), 'b');
     writeFileSync(join(dir, 'src/img/logo@3x.png'), 'c');
 
-    const copied = copyRnAssets({
-      projectRoot: dir,
-      assetsDest: dest,
-      rnPlatform: 'android',
-      assetExts: ['.png'],
-    });
+    const copied = copyAssetsForAndroid(discoverAssets(dir, ['.png']), dest);
     expect(copied).toBe(3);
     // 1x → mdpi, 2x → xhdpi, 3x → xxhdpi (Metro 매핑)
-    expect(existsSync(join(dest, 'drawable-mdpi/__src_img_logo.png'))).toBe(true);
-    expect(existsSync(join(dest, 'drawable-xhdpi/__src_img_logo.png'))).toBe(true);
-    expect(existsSync(join(dest, 'drawable-xxhdpi/__src_img_logo.png'))).toBe(true);
+    expect(existsSync(join(dest, 'drawable-mdpi/src_img_logo.png'))).toBe(true);
+    expect(existsSync(join(dest, 'drawable-xhdpi/src_img_logo.png'))).toBe(true);
+    expect(existsSync(join(dest, 'drawable-xxhdpi/src_img_logo.png'))).toBe(true);
     // keep.xml 생성
     const keepPath = join(dest, 'raw/keep.xml');
     expect(existsSync(keepPath)).toBe(true);
     const xml = readFileSync(keepPath, 'utf-8');
-    expect(xml).toContain('@drawable/__src_img_logo');
+    expect(xml).toContain('@drawable/src_img_logo');
   });
 
   test('Android — 4x scale 도 통과 (iOS 와 다름)', () => {
     mkdirSync(join(dir, 'a'), { recursive: true });
     writeFileSync(join(dir, 'a/icon@4x.png'), 'x');
-    const copied = copyRnAssets({
-      projectRoot: dir,
-      assetsDest: dest,
-      rnPlatform: 'android',
-      assetExts: ['.png'],
-    });
+    const copied = copyAssetsForAndroid(discoverAssets(dir, ['.png']), dest);
     expect(copied).toBe(1);
-    expect(existsSync(join(dest, 'drawable-xxxhdpi/__a_icon.png'))).toBe(true);
+    expect(existsSync(join(dest, 'drawable-xxxhdpi/a_icon.png'))).toBe(true);
   });
 
-  test('Non-image asset — keep.xml 의 drawable list 에서 제외', () => {
+  test('Non-image asset — raw resource 로 복사하고 keep.xml 에 raw ref 포함', () => {
     mkdirSync(join(dir, 'a'), { recursive: true });
     writeFileSync(join(dir, 'a/font.ttf'), 'x');
-    copyRnAssets({
-      projectRoot: dir,
+    copyAssetsForAndroid(discoverAssets(dir, ['.ttf']), dest);
+    expect(existsSync(join(dest, 'raw/a_font.ttf'))).toBe(true);
+    const xml = readFileSync(join(dest, 'raw/keep.xml'), 'utf-8');
+    expect(xml).toContain('@raw/a_font');
+  });
+
+  test('Android raw asset — yml 은 drawable 이 아니라 raw 로 복사', () => {
+    mkdirSync(join(dir, 'pods/Foo.framework.dSYM/Contents/Resources'), { recursive: true });
+    writeFileSync(join(dir, 'pods/Foo.framework.dSYM/Contents/Resources/foo.yml'), 'x');
+    const copied = copyAssetsForAndroid(discoverAssets(dir, ['.yml']), dest);
+
+    expect(copied).toBe(1);
+    expect(
+      existsSync(
+        join(
+          dest,
+          'raw/pods_fooframeworkdsym_contents_resources_foo.yml',
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      existsSync(
+        join(
+          dest,
+          'drawable-mdpi/pods_fooframeworkdsym_contents_resources_foo.yml',
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  test('sourceExts 와 겹치는 svg 는 Android drawable 로 복사하지 않음', () => {
+    mkdirSync(join(dir, 'src/img'), { recursive: true });
+    writeFileSync(join(dir, 'src/img/icon.svg'), '<svg />');
+    writeFileSync(join(dir, 'src/img/logo.png'), 'png');
+
+    const copied = copyAssetsForAndroid(discoverAssets(dir, ['.svg', '.png'], ['.svg']), dest);
+
+    expect(copied).toBe(1);
+    expect(existsSync(join(dest, 'drawable-mdpi/src_img_icon.svg'))).toBe(false);
+    expect(existsSync(join(dest, 'drawable-mdpi/src_img_logo.png'))).toBe(true);
+  });
+
+  test('bundleCode 가 있으면 등록된 asset 만 Metro naming 으로 복사', () => {
+    mkdirSync(join(dir, 'src/assets'), { recursive: true });
+    mkdirSync(join(dir, 'ios/resigned_payload'), { recursive: true });
+    mkdirSync(join(dir, '.github/workflows'), { recursive: true });
+    writeFileSync(join(dir, 'src/assets/logo.png'), 'a');
+    writeFileSync(join(dir, 'src/assets/logo@2x.png'), 'b');
+    writeFileSync(join(dir, 'ios/resigned_payload/AppIcon.png'), 'ios');
+    writeFileSync(join(dir, '.github/workflows/ci.yml'), 'ci');
+
+    const asset = {
+      __packager_asset: true,
+      httpServerLocation: '/assets/src/assets',
+      width: 1,
+      height: 1,
+      scales: [1, 2],
+      hash: 'hash',
+      name: 'logo',
+      type: 'png',
+      fileSystemLocation: join(dir, 'src/assets'),
+    };
+    const copied = copyRnAssets({
       assetsDest: dest,
       rnPlatform: 'android',
-      assetExts: ['.ttf'],
+      bundleCode: `module.exports = Registry.registerAsset(${JSON.stringify(asset)});`,
     });
-    // ttf 는 drawable 자원 아님 → keep.xml 미생성
-    expect(existsSync(join(dest, 'raw/keep.xml'))).toBe(false);
+
+    expect(copied).toBe(2);
+    expect(existsSync(join(dest, 'drawable-mdpi/src_assets_logo.png'))).toBe(true);
+    expect(existsSync(join(dest, 'drawable-xhdpi/src_assets_logo.png'))).toBe(true);
+    expect(existsSync(join(dest, 'drawable-mdpi/ios_resigned_payload_appicon.png'))).toBe(false);
+    expect(existsSync(join(dest, 'raw/github_workflows_ci.yml'))).toBe(false);
   });
 });
 
 describe('copyRnAssets — guards', () => {
   test('assetsDest falsy — 0 반환', () => {
     expect(
-      copyRnAssets({ projectRoot: dir, assetsDest: '', rnPlatform: 'ios', assetExts: ['.png'] }),
+      copyRnAssets({ assetsDest: '', rnPlatform: 'ios', bundleCode: '/* no registered asset */' }),
     ).toBe(0);
   });
 
-  test('projectRoot 미존재 — 0 반환', () => {
+  test('bundleCode 없으면 release asset copy 실패', () => {
     expect(
-      copyRnAssets({
-        projectRoot: '/__nope__',
-        assetsDest: dest,
-        rnPlatform: 'ios',
-        assetExts: ['.png'],
-      }),
-    ).toBe(0);
+      () => copyRnAssets({ assetsDest: dest, rnPlatform: 'ios' } as never),
+    ).toThrow('RN release asset copy requires bundleCode');
   });
 });

--- a/packages/core/bin/rn-asset-copy.test.ts
+++ b/packages/core/bin/rn-asset-copy.test.ts
@@ -210,7 +210,11 @@ describe('copyRnAssets — iOS', () => {
 
   test('asset 0 — copied 0', () => {
     expect(
-      copyRnAssets({ assetsDest: dest, rnPlatform: 'ios', bundleCode: '/* no registered asset */' }),
+      copyRnAssets({
+        assetsDest: dest,
+        rnPlatform: 'ios',
+        bundleCode: '/* no registered asset */',
+      }),
     ).toBe(0);
   });
 });
@@ -258,21 +262,11 @@ describe('copyRnAssets — Android', () => {
     const copied = copyAssetsForAndroid(discoverAssets(dir, ['.yml']), dest);
 
     expect(copied).toBe(1);
+    expect(existsSync(join(dest, 'raw/pods_fooframeworkdsym_contents_resources_foo.yml'))).toBe(
+      true,
+    );
     expect(
-      existsSync(
-        join(
-          dest,
-          'raw/pods_fooframeworkdsym_contents_resources_foo.yml',
-        ),
-      ),
-    ).toBe(true);
-    expect(
-      existsSync(
-        join(
-          dest,
-          'drawable-mdpi/pods_fooframeworkdsym_contents_resources_foo.yml',
-        ),
-      ),
+      existsSync(join(dest, 'drawable-mdpi/pods_fooframeworkdsym_contents_resources_foo.yml')),
     ).toBe(false);
   });
 
@@ -330,8 +324,8 @@ describe('copyRnAssets — guards', () => {
   });
 
   test('bundleCode 없으면 release asset copy 실패', () => {
-    expect(
-      () => copyRnAssets({ assetsDest: dest, rnPlatform: 'ios' } as never),
-    ).toThrow('RN release asset copy requires bundleCode');
+    expect(() => copyRnAssets({ assetsDest: dest, rnPlatform: 'ios' } as never)).toThrow(
+      'RN release asset copy requires bundleCode',
+    );
   });
 });

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -760,6 +760,7 @@ async function runRnBundle(opts, config) {
       typeof opts.sourcemapSourcesRoot === 'string' ||
       opts.sourcemapUseAbsolutePath === true);
 
+  const extra = buildRnBundleExtra(cfg, opts);
   const result = await rn.bundleRn({
     entry,
     projectRoot,
@@ -768,7 +769,7 @@ async function runRnBundle(opts, config) {
     sourcemap: wantsSourcemap,
     minify:
       opts.minify || opts.minifyWhitespace || opts.minifyIdentifiers || opts.minifySyntax || false,
-    extra: buildRnBundleExtra(cfg, opts),
+    extra,
     override: buildRnBundleOverride({
       config: cfg,
       opts,
@@ -802,23 +803,22 @@ async function runRnBundle(opts, config) {
     }
   }
 
-  // production asset 복사 (`--assets-dest`) — dev=false + 명시 시. iOS 는
-  // `<assetsDest>/<relPath>/<file>`, Android 는 Metro scaleToDrawable folder
-  // + flattened naming + keep.xml. 미지정 시 skip (dev server 가 HTTP 서빙).
+  // production asset 복사 (`--assets-dest`) — dev=false + 명시 시. Metro 처럼
+  // bundle 에 등록된 AssetRegistry asset 만 복사한다. 미지정 시 skip (dev server 가 HTTP 서빙).
   if (result.errors.length === 0 && !opts.devMode && opts.assetsDest) {
     const assetsDestAbs = resolve(opts.assetsDest);
     try {
       const copied = copyRnAssets({
-        projectRoot,
         assetsDest: assetsDestAbs,
         rnPlatform,
-        assetExts: rn.DEFAULT_ASSET_EXTS ?? [],
+        bundleCode: result.outputFiles?.[0]?.text,
       });
       if (opts.logLevel !== 'silent') {
         console.error(`[bundle] copied ${copied} asset(s) to ${assetsDestAbs}`);
       }
     } catch (err) {
       process.stderr.write(`[zntc:rn-bundle] asset copy 실패: ${err?.message ?? err}\n`);
+      throw err;
     }
   }
 

--- a/src/bundler/bundler_test/default_deconflict.zig
+++ b/src/bundler/bundler_test/default_deconflict.zig
@@ -270,6 +270,73 @@ test "Default: mixed default + named imports re-exported from single source (#13
     try std.testing.expect(std.mem.indexOf(u8, result.output, "named: () => named") != null);
 }
 
+test "Default: named re-export of default literal emits safe getter" {
+    // uuid/dist/esm-browser 패턴:
+    // `export { default as MAX } from './max.js'` 에서 source default가
+    // literal이면 getter 값 위치에 예약어 `default`를 그대로 쓰면 Hermes가
+    // SyntaxError로 거부한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { MAX } from './index';
+        \\console.log(MAX);
+    );
+    try writeFile(tmp.dir, "index.ts", "export { default as MAX } from './max';");
+    try writeFile(tmp.dir, "max.ts", "export default 'ffffffff-ffff-ffff-ffff-ffffffffffff';");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "return default;") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "MAX") != null);
+}
+
+test "Default: namespace use does not emit dangling default re-export getter" {
+    // uuid/dist/esm-browser 패턴의 namespace 사용:
+    // entry가 `uuid.v4()`만 쓰면 tree-shaker가 다른 default re-export source를
+    // 제외할 수 있다. 이때 barrel의 getter가 빠진 source의 `default`를 그대로
+    // 반환하면 Hermes release parse 단계에서 `return default;`가 된다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\import * as uuid from './index.js';
+        \\console.log(uuid.v4());
+    );
+    try writeFile(tmp.dir, "index.js",
+        \\export { default as MAX } from './max.js';
+        \\export { default as NIL } from './nil.js';
+        \\export { default as v4 } from './v4.js';
+    );
+    try writeFile(tmp.dir, "max.js", "export default 'ffffffff-ffff-ffff-ffff-ffffffffffff';");
+    try writeFile(tmp.dir, "nil.js", "export default '00000000-0000-0000-0000-000000000000';");
+    try writeFile(tmp.dir, "v4.js", "export default function v4() { return 'v4'; }");
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .configurable_exports = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "return default;") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "v4") != null);
+}
+
 test "Default: Platform.js 패턴 — export default X where X is default-import (#1328)" {
     // RN Platform.js 회귀: `import Platform from './Platform.ios'; export default Platform;`
     // binding_scanner가 .re_export로 분류하지만 codegen은 `_default = Platform` emit함.

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -80,6 +80,17 @@ inline fn resolvedReExportSource(l: *const Linker, m: *const Module, eb: ExportB
     return l.graph.getModule(src_idx);
 }
 
+inline fn shouldSkipTreeShakenReExportSource(l: *const Linker, m: *const Module, eb: ExportBinding) bool {
+    if (!l.tree_shaker_active) return false;
+    const rec_idx = eb.import_record_index orelse return false;
+    if (rec_idx >= m.import_records.len) return false;
+    const src_idx = m.import_records[rec_idx].resolved;
+    if (src_idx.isNone()) return true;
+    if (src_idx == m.index) return false;
+    const src_mod = l.graph.getModule(src_idx) orelse return true;
+    return !src_mod.is_included;
+}
+
 fn reExportAliasCanonicalName(ref: SymbolRef, mod: *const Module) ?[]const u8 {
     const id = localAliasId(ref, mod) orelse return null;
     const table = mod.alias_table orelse return null;
@@ -451,7 +462,7 @@ pub fn emitEsmWrappedModule(
                         if (std.mem.eql(u8, name, "default")) continue;
                         if (direct_exports.contains(name)) continue;
 
-                        const getter_val = try makeStarGetterValue(allocator, l, src_mod, src_i, name, options);
+                        const getter_val = (try makeStarGetterValue(allocator, l, src_mod, src_i, name, options)) orelse continue;
                         try star_owned.append(allocator, getter_val);
                         try star_entries.append(allocator, .{
                             .name = name,
@@ -493,16 +504,13 @@ pub fn emitEsmWrappedModule(
             for (module.export_bindings) |eb| {
                 if (eb.kind == .local or eb.kind == .re_export) {
                     // tree-shake 로 제거된 re-export source 의 getter 는 dangling reference (#2398).
-                    // resolved + non-self-cycle 인 source 가 included=false 면 getter emit 생략.
-                    // 비정상 record (resolved=none / self-cycle) 는 일반 경로가 안전 처리하므로 fall-through.
-                    // dev_mode 등 tree-shaker 미동작 환경은 is_included 비트 자체가 신뢰 불가
-                    // (default false) 라 가드 적용 안 함 — metadata.zig:408,438 동일 정책.
-                    if (eb.kind == .re_export) skip: {
+                    // Tree-shaker가 사용되지 않는 re-export source를 그래프에서 제외하면
+                    // import record의 resolved가 none이 될 수 있다. 이 상태에서 getter를
+                    // 만들면 `export { default as X } from`의 local name인 `default`가
+                    // 값 위치에 남아 Hermes release parse에서 `return default;`가 된다.
+                    if (eb.kind == .re_export or eb.import_record_index != null) skip: {
                         const l = linker orelse break :skip;
-                        if (!l.tree_shaker_active) break :skip;
-                        if (resolvedReExportSource(l, module, eb)) |src_mod| {
-                            if (!src_mod.is_included) continue;
-                        }
+                        if (shouldSkipTreeShakenReExportSource(l, module, eb)) continue;
                     }
                     try appendExportGetter(&wrapped, allocator, eb.exported_name, blk: {
                         // Symbol table이 단축 경로의 source of truth.
@@ -513,12 +521,12 @@ pub fn emitEsmWrappedModule(
                         if (isSyntheticDefault(eb.symbol, module)) {
                             break :blk if (metadata) |md| md.default_export_name else "_default";
                         }
-                        // source가 __esm/__commonJS 래핑이면 현재 모듈에 변수가 선언되지
-                        // 않아 getter가 source의 exports를 직접 참조해야 한다 (#1425).
+                        // direct re-export는 현재 모듈에 로컬 변수가 선언되지 않으므로
+                        // source module의 getter/value를 직접 참조해야 한다 (#1425).
                         // barrel alias(`import X from './y'; export { X }`)는 binding_scanner가
                         // .re_export + local_name=ib.imported_name으로 정규화하므로(#1321),
                         // 매칭되는 import binding이 있으면 기존 경로로 폴백.
-                        if (eb.kind == .re_export) re_export: {
+                        if (eb.kind == .re_export or eb.import_record_index != null) re_export: {
                             const l = linker orelse break :re_export;
                             const rec_idx = eb.import_record_index orelse break :re_export;
                             if (rec_idx >= module.import_records.len) break :re_export;
@@ -529,7 +537,6 @@ pub fn emitEsmWrappedModule(
                             if (src_idx == module.index) break :re_export;
                             const si = @intFromEnum(src_idx);
                             const src_mod = l.graph.getModule(src_idx) orelse break :re_export;
-                            if (!src_mod.wrap_kind.isWrapped()) break :re_export;
 
                             const local_name = module.exportBindingLocalName(eb);
                             for (module.import_bindings) |ib| {
@@ -539,7 +546,7 @@ pub fn emitEsmWrappedModule(
                                 }
                             }
 
-                            const getter_val = try makeStarGetterValue(allocator, l, src_mod, si, local_name, options);
+                            const getter_val = (try makeStarGetterValue(allocator, l, src_mod, si, local_name, options)) orelse continue;
                             try star_owned.append(allocator, getter_val);
                             break :blk getter_val;
                         }
@@ -1220,31 +1227,43 @@ fn makeStarGetterValue(
     src_i: u32,
     name: []const u8,
     options: *const EmitOptions,
-) ![]const u8 {
+) !?[]const u8 {
     switch (src_mod.wrap_kind) {
         .none => {
             // scope-hoisted: export의 local_name을 찾아 canonical name으로 변환
             for (src_mod.export_bindings) |src_eb| {
                 if (std.mem.eql(u8, src_eb.exported_name, name)) {
-                    const local = l.getCanonicalForExport(src_eb, src_i);
-                    return try allocator.dupe(u8, local);
+                    if (src_eb.kind == .re_export or src_eb.import_record_index != null) {
+                        if (shouldSkipTreeShakenReExportSource(l, src_mod, src_eb)) return null;
+                        const rec_idx = src_eb.import_record_index orelse return null;
+                        if (rec_idx >= src_mod.import_records.len) return null;
+                        const target_idx = src_mod.import_records[rec_idx].resolved;
+                        if (target_idx.isNone() or target_idx == src_mod.index) return null;
+                        const target_i = @intFromEnum(target_idx);
+                        const target_mod = l.graph.getModule(target_idx) orelse return null;
+                        const target_name = src_mod.exportBindingLocalName(src_eb);
+                        return try makeStarGetterValue(allocator, l, target_mod, target_i, target_name, options);
+                    } else {
+                        const local = l.getCanonicalForExport(src_eb, src_i);
+                        return try allocator.dupe(u8, local);
+                    }
                 }
             }
             // 직접 export에 없으면 소스의 re_export_all 체인을 따라간다.
             // resolveExportChain으로 canonical 이름을 찾는다.
             if (l.resolveExportChain(@enumFromInt(src_i), name, 0)) |resolved| {
                 const canonical_mod_i = resolved.module_index.toU32();
-                const canonical_mod = l.graph.getModule(resolved.module_index) orelse return try allocator.dupe(u8, name);
+                const canonical_mod = l.graph.getModule(resolved.module_index) orelse return null;
                 // canonical 모듈이 래핑되어 있으면 exports_xxx.name 형태
                 if (canonical_mod.wrap_kind == .esm) {
                     const ev = try canonical_mod.allocExportsName(allocator);
                     defer allocator.free(ev);
-                    return try std.fmt.allocPrint(allocator, "{s}.{s}", .{ ev, name });
+                    return try std.fmt.allocPrint(allocator, "{s}.{s}", .{ ev, resolved.export_name });
                 }
                 if (canonical_mod.wrap_kind == .cjs) {
                     const rv = try canonical_mod.allocRequireName(allocator);
                     defer allocator.free(rv);
-                    return try std.fmt.allocPrint(allocator, "{s}().{s}", .{ rv, name });
+                    return try std.fmt.allocPrint(allocator, "{s}().{s}", .{ rv, resolved.export_name });
                 }
                 // .none: canonical 로컬 변수
                 for (canonical_mod.export_bindings) |ceb| {
@@ -1254,11 +1273,11 @@ fn makeStarGetterValue(
                     }
                 }
             }
-            // fallback: 이름 그대로 사용
-            return try allocator.dupe(u8, name);
+            // No source export was available. The caller should omit this getter.
+            return null;
         },
         .esm => {
-            return makeEsmExportGetterValue(allocator, src_mod, name, options);
+            return try makeEsmExportGetterValue(allocator, src_mod, name, options);
         },
         .cjs => {
             const rv = try src_mod.allocRequireName(allocator);

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1068,7 +1068,8 @@ pub const Linker = struct {
         const m = self.getModule(module_index).?;
         const local = m.exportBindingLocalName(eb);
         if (eb.kind == .local) {
-            return self.getCanonicalByRef(eb.symbol) orelse local;
+            const canonical = self.getCanonicalByRef(eb.symbol) orelse local;
+            return self.safeIdentifierName(canonical, module_index);
         }
         return self.getCanonicalName(module_index, local) orelse local;
     }


### PR DESCRIPTION
## 요약
- RN release asset copy가 projectRoot 전체를 훑지 않고 bundle의 `AssetRegistry.registerAsset(...)` 목록만 복사하도록 변경했습니다.
- Android asset 복사는 Metro와 동일하게 drawable/raw 분기, resource identifier, keep.xml 참조를 맞췄습니다.
- tree-shaken re-export source가 사라진 경우 export getter를 생성하지 않도록 보강해 `return default;` 형태의 Hermes release parse 오류를 막았습니다.

## 원인
- dev server는 asset을 HTTP로 서빙하지만 release build는 네이티브 리소스로 복사합니다. 기존 구현은 release asset copy에서 projectRoot 전체를 scan해서 iOS 산출물, CI 파일, sourceExt 처리 대상까지 Android res에 섞일 수 있었습니다.
- Metro release path는 bundle graph에 실제 등록된 asset만 대상으로 삼기 때문에, 동일한 전략으로 맞추는 것이 근본 수정입니다.

## 검증
- `git diff --check`
- `bun test packages/core/bin/rn-asset-copy.test.ts`
- `zig build test -Dtest-filter="Default:"`
- seller Android `assembleStagingRelease` with ZNTC: BUILD SUCCESSFUL (`real 45.69s`, 이후 엄격화 재검증 `real 45.69s`/`45s`대)
- standalone RN release bundle with ZNTC: 673 assets copied, `real 3.60s`
