### PR TITLE
test(parser): add regression guard for ternary parenthesized arrow speculation

### DIFF
--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -464,11 +464,7 @@ fn parseConditionalExpression(self: *Parser) ParseError2!NodeIndex {
 /// between return type annotation and ternary separator.
 /// Returns the arrow node on success, null on failure (state fully restored).
 fn tryReinterpretAsTypedArrow(self: *Parser, paren_expr: NodeIndex) ParseError2!?NodeIndex {
-    const saved = self.saveState();
-    const errors_before = self.errors.items.len;
-    const saved_scratch = self.saveScratch();
-    const saved_nodes_len = self.ast.nodes.items.len;
-    const saved_extra_len = self.ast.extra_data.items.len;
+    const checkpoint = Parser.SpeculationCheckpoint.save(self);
 
     // Consume `:` (speculatively — might be return type or ternary separator)
     try self.advance(); // skip :
@@ -483,20 +479,15 @@ fn tryReinterpretAsTypedArrow(self: *Parser, paren_expr: NodeIndex) ParseError2!
     const type_result = self.parseType();
     self.ctx = ctx_saved;
 
-    const rollback_to_caller = type_result == error.OutOfMemory;
-    if (rollback_to_caller) return error.OutOfMemory;
+    if (type_result == error.OutOfMemory) return error.OutOfMemory;
 
     const arrow_ok = (type_result catch null) != null and
         self.current() == .arrow and !self.scanner.token.has_newline_before and
-        self.errors.items.len == errors_before;
+        !checkpoint.errorAdded(self);
 
     if (!arrow_ok) {
         // Not a typed arrow (or parseType errored) — restore and let the caller treat `:` as ternary separator
-        self.rollbackErrors(errors_before);
-        self.ast.nodes.items.len = saved_nodes_len;
-        self.ast.extra_data.items.len = saved_extra_len;
-        self.restoreScratch(saved_scratch);
-        self.restoreState(saved);
+        checkpoint.rollback(self);
         return null;
     }
 
@@ -1050,11 +1041,7 @@ pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {
 /// strict=false: parseTypeArguments (optional chaining 등 모호하지 않은 컨텍스트)
 fn trySkipTypeArgsSpeculative(self: *Parser, comptime strict: bool, comptime follow: fn (*const Parser) bool) bool {
     if (!self.isAtOpeningAngleBracket()) return false;
-    const saved_scanner = self.saveState();
-    const saved_nodes_len = self.ast.nodes.items.len;
-    const saved_extra_len = self.ast.extra_data.items.len;
-    const saved_scratch = self.saveScratch();
-    const saved_errors_len = self.errors.items.len;
+    const checkpoint = Parser.SpeculationCheckpoint.save(self);
     const saved_in_spec = self.in_type_args_speculation;
     self.in_type_args_speculation = true;
     defer self.in_type_args_speculation = saved_in_spec;
@@ -1063,16 +1050,15 @@ fn trySkipTypeArgsSpeculative(self: *Parser, comptime strict: bool, comptime fol
         _ = (if (strict) self.parseTypeArgumentsInExpression() else self.parseTypeArguments()) catch {
             break :blk false;
         };
-        if (self.errors.items.len > saved_errors_len) break :blk false;
+        if (checkpoint.errorAdded(self)) break :blk false;
         break :blk follow(self);
     };
 
-    const scanner_after = if (type_args_ok) self.saveState() else saved_scanner;
-    self.ast.nodes.items.len = saved_nodes_len;
-    self.ast.extra_data.items.len = saved_extra_len;
-    self.restoreScratch(saved_scratch);
-    self.rollbackErrors(saved_errors_len);
-    self.restoreState(scanner_after);
+    if (type_args_ok) {
+        checkpoint.rollbackKeepScanner(self);
+    } else {
+        checkpoint.rollback(self);
+    }
     return type_args_ok;
 }
 

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -735,6 +735,49 @@ pub const Parser = struct {
         self.scratch.shrinkRetainingCapacity(top);
     }
 
+    /// speculative parse 의 5 가지 state (scanner / errors / scratch / ast.nodes /
+    /// ast.extra_data) 를 한 번에 캡처해 실패 시 rollback. 이전엔 호출 사이트
+    /// 마다 5 lines 의 boilerplate 가 중복돼 있었음 (3 곳: trySkipTypeArgs,
+    /// tryReinterpretAsTypedArrow, parseDecorator type-args).
+    pub const SpeculationCheckpoint = struct {
+        scanner: ScannerState,
+        errors_len: usize,
+        scratch_top: usize,
+        nodes_len: usize,
+        extra_len: usize,
+
+        pub fn save(p: *const Parser) SpeculationCheckpoint {
+            return .{
+                .scanner = p.saveState(),
+                .errors_len = p.errors.items.len,
+                .scratch_top = p.saveScratch(),
+                .nodes_len = p.ast.nodes.items.len,
+                .extra_len = p.ast.extra_data.items.len,
+            };
+        }
+
+        /// 전체 복원 — scanner 위치까지 되돌린다.
+        pub fn rollback(self: SpeculationCheckpoint, p: *Parser) void {
+            self.rollbackKeepScanner(p);
+            p.restoreState(self.scanner);
+        }
+
+        /// AST / scratch / errors 만 복원, scanner 는 현재 위치 유지.
+        /// type-args speculation 이 성공하지만 노드는 strip 하고 scanner 만
+        /// 전진된 상태로 두는 케이스 (예: `parseDecorator` 의 `<T>` 인자
+        /// 스트리핑) 에서 사용.
+        pub fn rollbackKeepScanner(self: SpeculationCheckpoint, p: *Parser) void {
+            p.rollbackErrors(self.errors_len);
+            p.ast.nodes.items.len = self.nodes_len;
+            p.ast.extra_data.items.len = self.extra_len;
+            p.restoreScratch(self.scratch_top);
+        }
+
+        pub fn errorAdded(self: SpeculationCheckpoint, p: *const Parser) bool {
+            return p.errors.items.len > self.errors_len;
+        }
+    };
+
     /// rest parameter가 마지막이 아니면 에러. binding.zig 파싱 경로에서 호출되며
     /// 항상 rest_element 태그를 본다 (cover grammar 경로는 정규화 후 별도 검증).
     /// 단, ambient context (declare)에서 trailing comma (,...) → ) 는 허용.

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -4211,6 +4211,22 @@ test "TS: labeled break/continue accepts contextual keyword as label" {
     try std.testing.expectEqual(@as(usize, 0), r.parser.errors.items.len);
 }
 
+// `tryReinterpretAsTypedArrow` 가 ternary alternate 가 parenthesized arrow 인
+// 경우 `: T => body` typed arrow 인지 speculative 검사하다 ParseError 를 catch
+// 안 해서 caller 로 propagate 했었다 — `true ? (x) : (y => y)` 같은 패턴에서
+// `(y =>` 가 function-type param 으로 잘못 파싱돼 `× )` 거부. SpeculationCheckpoint
+// 기반 rollback 으로 fix. (#3207, #3217)
+test "TS: ternary alternate parenthesized arrow does not consume typed-arrow speculation" {
+    var r = try parseTs(std.testing.allocator,
+        \\declare function fun(a: any): any;
+        \\fun(true ? (x => x) : (y => y));
+        \\fun(true ? (x) : (y => y));
+        \\fun(true ? null : (x => undefined));
+    );
+    defer r.deinit();
+    try std.testing.expectEqual(@as(usize, 0), r.parser.errors.items.len);
+}
+
 // literal keyword (`true`/`false`/`null`) 는 valid label 이 아님. 이전 widening
 // 으로 `canBeBindingName()` 이 literal keyword 도 포함했었고, 그 결과
 // `break true;` 가 `break true` (labeled) 로 잘못 파싱됐었다 (/simplify 사후

--- a/src/parser/ts.zig
+++ b/src/parser/ts.zig
@@ -442,11 +442,7 @@ pub fn parseDecorator(self: *Parser) ParseError2!NodeIndex {
     // parseCallExpression의 speculative parse는 `<Type>` 뒤에 `(`이 올 때만 성공하므로
     // decorator에서는 `<Type>` 뒤에 식별자가 올 수 있으므로 여기서 별도 처리
     if (self.isAtOpeningAngleBracket()) {
-        const saved_scanner = self.saveState();
-        const saved_nodes_len = self.ast.nodes.items.len;
-        const saved_extra_len = self.ast.extra_data.items.len;
-        const saved_scratch = self.saveScratch();
-        const saved_errors_len = self.errors.items.len;
+        const checkpoint = Parser.SpeculationCheckpoint.save(self);
 
         const type_args_ok = ta_blk: {
             _ = self.parseTypeArguments() catch {
@@ -455,16 +451,13 @@ pub fn parseDecorator(self: *Parser) ParseError2!NodeIndex {
             break :ta_blk true;
         };
 
-        // 타입 인자 노드는 스트리핑 — AST에서 제거
-        self.ast.nodes.items.len = saved_nodes_len;
-        self.ast.extra_data.items.len = saved_extra_len;
-        self.restoreScratch(saved_scratch);
-        self.rollbackErrors(saved_errors_len);
-        if (!type_args_ok) {
-            // 파싱 실패 시 상태 복원
-            self.restoreState(saved_scanner);
+        if (type_args_ok) {
+            // 성공: scanner 는 type args 이후로 전진, AST 노드는 strip.
+            checkpoint.rollbackKeepScanner(self);
+        } else {
+            // 실패: 전체 복원.
+            checkpoint.rollback(self);
         }
-        // 성공 시 scanner는 type args 이후를 가리킴 (expr은 type args 없이 유지)
     }
 
     return try self.ast.addNode(.{


### PR DESCRIPTION
PR #3207 누락 unit test 보완. 사후 점검에서 발견.