### PR TITLE
chore(rn-asset): drop legacy projectRoot walk helpers

### DIFF
--- a/packages/core/bin/rn-asset-copy.mjs
+++ b/packages/core/bin/rn-asset-copy.mjs
@@ -3,11 +3,9 @@
 // 참조된 asset 만 복사하여 release 산출물을 자동 prune. `runRnBundle` 이
 // dev=false + `--assets-dest` 명시 시 호출.
 
-import { copyFileSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs';
-import { basename, dirname, extname, join, relative } from 'node:path';
+import { copyFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
 
-/** scale variant naming — `@2x.png` / `@3x.png` 등. capture group 1 이 scale 숫자. */
-export const SCALE_REGEX = /@(\d+(?:\.\d+)?)x/;
 /** iOS 가 native 로 인식하는 scale set. 그 외 (`@4x` 등) 는 production bundle 에서 제외. */
 export const IOS_SCALES = new Set([1, 2, 3]);
 
@@ -21,18 +19,6 @@ const SCALE_TO_DRAWABLE = {
   4: 'xxxhdpi',
 };
 
-const SKIP_DIRS = new Set([
-  'node_modules',
-  '.git',
-  '.bungae',
-  'dist',
-  'build',
-  '.next',
-  '.turbo',
-  '.bun',
-  '.DS_Store',
-]);
-
 const DRAWABLE_EXT_RE = /\.(gif|jpeg|jpg|png|webp|xml)$/i;
 
 /**
@@ -43,22 +29,6 @@ export function getAndroidDrawableFolder(scale) {
   if (SCALE_TO_DRAWABLE[scale]) return `drawable-${SCALE_TO_DRAWABLE[scale]}`;
   if (Number.isFinite(scale) && scale > 0) return `drawable-${Math.round(160 * scale)}dpi`;
   return 'drawable-mdpi';
-}
-
-/**
- * Asset 의 base name (scale variant suffix 제거) 과 scale 추출. `foo@2x.png` →
- * `{ baseName: 'foo', scale: 2 }`, `foo.png` → `{ baseName: 'foo', scale: 1 }`.
- */
-export function parseAssetName(filename) {
-  const ext = extname(filename);
-  const stem = basename(filename, ext);
-  const m = stem.match(SCALE_REGEX);
-  if (!m) return { baseName: stem, scale: 1, ext };
-  return {
-    baseName: stem.replace(SCALE_REGEX, ''),
-    scale: Number.parseFloat(m[1]),
-    ext,
-  };
 }
 
 /**
@@ -75,12 +45,6 @@ function metroSanitizeResourceName(rawPath) {
     .replace(/^(?:assets|assetsunstable_path)_/, '');
 }
 
-/** Metro 의 Android filename convention — `<flatRelPath>_<baseName>.<ext>` 형식. */
-export function androidAssetFileName(relDir, baseName, ext) {
-  const sanitized = metroSanitizeResourceName(relDir ? `${relDir}/${baseName}` : baseName);
-  return `${sanitized}${ext.toLowerCase()}`;
-}
-
 export function getAndroidResourceIdentifier(asset) {
   let basePath = asset.httpServerLocation ?? '';
   if (basePath.startsWith('/')) basePath = basePath.slice(1);
@@ -95,46 +59,6 @@ export function buildKeepXml(drawableNames) {
     `<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="${items}" />`,
     '',
   ].join('\n');
-}
-
-/**
- * project 안의 asset 파일 walk + scale variant 수집. 반환:
- * `[{ filePath, baseName, scale, ext, relDir }]`. relDir 은 projectRoot
- * 기준 상대 경로 (POSIX `/`).
- */
-export function discoverAssets(projectRoot, assetExts, sourceExts = []) {
-  const normalizeExt = (e) => (e.startsWith('.') ? e.toLowerCase() : `.${e.toLowerCase()}`);
-  const sourceExtSet = new Set([...sourceExts].map(normalizeExt));
-  const exts = new Set([...assetExts].map(normalizeExt));
-  for (const ext of sourceExtSet) {
-    exts.delete(ext);
-  }
-  const out = [];
-
-  function walk(dir) {
-    let entries;
-    try {
-      entries = readdirSync(dir, { withFileTypes: true });
-    } catch {
-      return;
-    }
-    for (const entry of entries) {
-      if (SKIP_DIRS.has(entry.name)) continue;
-      const full = join(dir, entry.name);
-      if (entry.isDirectory()) {
-        walk(full);
-        continue;
-      }
-      if (!entry.isFile()) continue;
-      const ext = extname(entry.name).toLowerCase();
-      if (!exts.has(ext)) continue;
-      const parsed = parseAssetName(entry.name);
-      const relDir = relative(projectRoot, dir).replace(/\\/g, '/');
-      out.push({ filePath: full, ...parsed, relDir });
-    }
-  }
-  walk(projectRoot);
-  return out;
 }
 
 function findMatchingBrace(source, openIndex) {
@@ -242,23 +166,6 @@ function copyRegisteredAssetFile(src, destPath) {
   }
 }
 
-/**
- * iOS production 복사 — `<assetsDest>/<relDir>/<file>` 으로. IOS_SCALES (1/2/3) 외
- * scale 은 제외. 같은 baseName 의 scale variant 들은 모두 같은 destDir 에 원래
- * 파일명 그대로.
- */
-export function copyAssetsForIos(assets, assetsDest) {
-  let copied = 0;
-  for (const a of assets) {
-    if (!IOS_SCALES.has(a.scale)) continue;
-    const destDir = a.relDir ? join(assetsDest, a.relDir) : assetsDest;
-    mkdirSync(destDir, { recursive: true });
-    copyFileSync(a.filePath, join(destDir, basename(a.filePath)));
-    copied++;
-  }
-  return copied;
-}
-
 export function copyRegisteredAssetsForIos(assets, assetsDest) {
   const createdDirs = new Set();
   let copied = 0;
@@ -279,37 +186,6 @@ export function copyRegisteredAssetsForIos(assets, assetsDest) {
       copyRegisteredAssetFile(src, destPath);
       copied++;
     }
-  }
-  return copied;
-}
-
-/**
- * Android production 복사 — Metro scale-to-drawable folder + flattened name +
- * keep.xml. drawable resource name (확장자 제거) 을 keepNames 에 누적.
- *
- * `assetsDest` 가 명시되면 그 경로 기준, 미지정 시 `<projectRoot>/android/app/src/main/res`.
- */
-export function copyAssetsForAndroid(assets, assetsDest) {
-  const baseDir = assetsDest;
-  const keepRefs = new Set();
-  let copied = 0;
-  for (const a of assets) {
-    const isDrawable = DRAWABLE_EXT_RE.test(a.ext);
-    const folder = isDrawable ? getAndroidDrawableFolder(a.scale) : 'raw';
-    const targetDir = join(baseDir, folder);
-    mkdirSync(targetDir, { recursive: true });
-    const fileName = androidAssetFileName(a.relDir, a.baseName, a.ext);
-    copyFileSync(a.filePath, join(targetDir, fileName));
-    copied++;
-    const resourceName = fileName.slice(0, fileName.length - extname(fileName).length);
-    keepRefs.add(`@${isDrawable ? 'drawable' : 'raw'}/${resourceName}`);
-  }
-  // keep.xml — `res/raw/keep.xml` 위치. drawable resources 의 ProGuard/R8 미사용
-  // 보장.
-  if (keepRefs.size > 0) {
-    const keepDir = join(baseDir, 'raw');
-    mkdirSync(keepDir, { recursive: true });
-    writeFileSync(join(keepDir, 'keep.xml'), buildKeepXml([...keepRefs].sort()));
   }
   return copied;
 }

--- a/packages/core/bin/rn-asset-copy.test.ts
+++ b/packages/core/bin/rn-asset-copy.test.ts
@@ -4,18 +4,12 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import {
-  androidAssetFileName,
   buildKeepXml,
-  copyAssetsForAndroid,
-  copyAssetsForIos,
   copyRnAssets,
-  discoverAssets,
   extractRegisteredAssets,
   getAndroidDrawableFolder,
   getAndroidResourceIdentifier,
   IOS_SCALES,
-  parseAssetName,
-  SCALE_REGEX,
 } from './rn-asset-copy.mjs';
 
 let dir: string;
@@ -31,38 +25,13 @@ afterEach(() => {
   rmSync(dest, { recursive: true, force: true });
 });
 
-describe('SCALE_REGEX / IOS_SCALES — bungae plugin-core 호환', () => {
-  test('SCALE_REGEX — `@2x` / `@3x` / `@1.5x` 매칭', () => {
-    expect('foo@2x.png'.match(SCALE_REGEX)?.[1]).toBe('2');
-    expect('icon@3x'.match(SCALE_REGEX)?.[1]).toBe('3');
-    expect('img@1.5x.svg'.match(SCALE_REGEX)?.[1]).toBe('1.5');
-  });
-
-  test('SCALE_REGEX — scale 표기 없으면 null', () => {
-    expect('foo.png'.match(SCALE_REGEX)).toBeNull();
-  });
-
-  test('IOS_SCALES — 1/2/3 만 포함', () => {
+describe('IOS_SCALES', () => {
+  test('1/2/3 만 포함', () => {
     expect(IOS_SCALES.has(1)).toBe(true);
     expect(IOS_SCALES.has(2)).toBe(true);
     expect(IOS_SCALES.has(3)).toBe(true);
     expect(IOS_SCALES.has(4)).toBe(false);
     expect(IOS_SCALES.has(0.5)).toBe(false);
-  });
-});
-
-describe('parseAssetName', () => {
-  test('scale 없는 단순 파일', () => {
-    expect(parseAssetName('foo.png')).toEqual({ baseName: 'foo', scale: 1, ext: '.png' });
-  });
-
-  test('scale 있는 파일', () => {
-    expect(parseAssetName('icon@2x.png')).toEqual({ baseName: 'icon', scale: 2, ext: '.png' });
-    expect(parseAssetName('logo@3x.svg')).toEqual({ baseName: 'logo', scale: 3, ext: '.svg' });
-  });
-
-  test('소수점 scale (1.5)', () => {
-    expect(parseAssetName('img@1.5x.png')).toEqual({ baseName: 'img', scale: 1.5, ext: '.png' });
   });
 });
 
@@ -85,26 +54,6 @@ describe('getAndroidDrawableFolder — Metro scaleToDrawable 매핑', () => {
     expect(getAndroidDrawableFolder(0)).toBe('drawable-mdpi');
     expect(getAndroidDrawableFolder(-1)).toBe('drawable-mdpi');
     expect(getAndroidDrawableFolder(Number.NaN)).toBe('drawable-mdpi');
-  });
-});
-
-describe('androidAssetFileName — Metro flat naming', () => {
-  test('빈 relDir — `<baseName><ext>`', () => {
-    expect(androidAssetFileName('', 'logo', '.png')).toBe('logo.png');
-  });
-
-  test('단순 디렉토리 — `<dir>_<baseName><ext>`', () => {
-    expect(androidAssetFileName('src/assets', 'logo', '.png')).toBe('src_assets_logo.png');
-  });
-
-  test('비-alnum 문자 제거', () => {
-    expect(androidAssetFileName('src/img-foo', 'icon', '.svg')).toBe('src_imgfoo_icon.svg');
-  });
-
-  test('Android resource 호환을 위해 대문자를 소문자로 정규화', () => {
-    expect(androidAssetFileName('src/assets/tableOrder', 'imgLayoutB', '.PNG')).toBe(
-      'src_assets_tableorder_imglayoutb.png',
-    );
   });
 });
 
@@ -148,67 +97,39 @@ describe('buildKeepXml', () => {
   });
 });
 
-describe('discoverAssets', () => {
-  test('assetExts 매칭 file 만 수집, node_modules / .git skip', () => {
-    writeFileSync(join(dir, 'logo.png'), 'a');
-    writeFileSync(join(dir, 'data.json'), 'b');
-    mkdirSync(join(dir, 'node_modules'), { recursive: true });
-    writeFileSync(join(dir, 'node_modules/skip.png'), 'c');
-    mkdirSync(join(dir, '.git'), { recursive: true });
-    writeFileSync(join(dir, '.git/skip.png'), 'd');
-    mkdirSync(join(dir, 'src'), { recursive: true });
-    writeFileSync(join(dir, 'src/icon.svg'), 'e');
-
-    const result = discoverAssets(dir, ['.png', '.svg']);
-    const names = result.map((r) => r.filePath.replace(`${dir}/`, '')).sort();
-    expect(names).toEqual(['logo.png', 'src/icon.svg']);
-  });
-
-  test('relDir — projectRoot 기준 POSIX 상대 경로', () => {
-    mkdirSync(join(dir, 'a/b'), { recursive: true });
-    writeFileSync(join(dir, 'a/b/icon.png'), 'x');
-    const result = discoverAssets(dir, ['.png']);
-    expect(result[0]?.relDir).toBe('a/b');
-  });
-
-  test('빈 디렉토리 / 매칭 없음 — 빈 array', () => {
-    expect(discoverAssets(dir, ['.png'])).toEqual([]);
-  });
-
-  test('확장자 case-insensitive', () => {
-    writeFileSync(join(dir, 'LOGO.PNG'), 'x');
-    const result = discoverAssets(dir, ['.png']);
-    expect(result.length).toBe(1);
-  });
-
-  test('sourceExts 와 겹치는 확장자는 asset copy 에서 제외', () => {
-    mkdirSync(join(dir, 'src'), { recursive: true });
-    writeFileSync(join(dir, 'src/icon.svg'), '<svg />');
-    writeFileSync(join(dir, 'src/logo.png'), 'png');
-
-    const result = discoverAssets(dir, ['.svg', '.png'], ['.svg']);
-    const names = result.map((r) => r.filePath.replace(`${dir}/`, '')).sort();
-    expect(names).toEqual(['src/logo.png']);
-  });
-});
-
 describe('copyRnAssets — iOS', () => {
-  test('IOS_SCALES (1/2/3) 만 통과 + relDir 보존', () => {
+  test('등록된 asset 의 IOS_SCALES (1/2/3) variant 만 복사, @4x 제외', () => {
     mkdirSync(join(dir, 'src/assets'), { recursive: true });
     writeFileSync(join(dir, 'src/assets/logo.png'), 'a');
     writeFileSync(join(dir, 'src/assets/logo@2x.png'), 'b');
     writeFileSync(join(dir, 'src/assets/logo@3x.png'), 'c');
-    writeFileSync(join(dir, 'src/assets/logo@4x.png'), 'd'); // skip
 
-    const copied = copyAssetsForIos(discoverAssets(dir, ['.png']), dest);
-    expect(copied).toBe(3); // 1x/2x/3x 만, 4x 제외
-    expect(existsSync(join(dest, 'src/assets/logo.png'))).toBe(true);
-    expect(existsSync(join(dest, 'src/assets/logo@2x.png'))).toBe(true);
-    expect(existsSync(join(dest, 'src/assets/logo@3x.png'))).toBe(true);
-    expect(existsSync(join(dest, 'src/assets/logo@4x.png'))).toBe(false);
+    const asset = {
+      __packager_asset: true,
+      httpServerLocation: '/assets/src/assets',
+      width: 1,
+      height: 1,
+      scales: [1, 2, 3, 4],
+      hash: 'hash',
+      name: 'logo',
+      type: 'png',
+      fileSystemLocation: join(dir, 'src/assets'),
+    };
+    const copied = copyRnAssets({
+      assetsDest: dest,
+      rnPlatform: 'ios',
+      bundleCode: `module.exports = Registry.registerAsset(${JSON.stringify(asset)});`,
+    });
+
+    // Metro getAssetDestPathIOS — httpServerLocation 기반 `<dest>/assets/src/assets/<file>`.
+    expect(copied).toBe(3);
+    expect(existsSync(join(dest, 'assets/src/assets/logo.png'))).toBe(true);
+    expect(existsSync(join(dest, 'assets/src/assets/logo@2x.png'))).toBe(true);
+    expect(existsSync(join(dest, 'assets/src/assets/logo@3x.png'))).toBe(true);
+    expect(existsSync(join(dest, 'assets/src/assets/logo@4x.png'))).toBe(false);
   });
 
-  test('asset 0 — copied 0', () => {
+  test('등록된 asset 없음 — 0 반환', () => {
     expect(
       copyRnAssets({
         assetsDest: dest,
@@ -220,69 +141,7 @@ describe('copyRnAssets — iOS', () => {
 });
 
 describe('copyRnAssets — Android', () => {
-  test('Metro scaleToDrawable folder + flat naming + keep.xml', () => {
-    mkdirSync(join(dir, 'src/img'), { recursive: true });
-    writeFileSync(join(dir, 'src/img/logo.png'), 'a');
-    writeFileSync(join(dir, 'src/img/logo@2x.png'), 'b');
-    writeFileSync(join(dir, 'src/img/logo@3x.png'), 'c');
-
-    const copied = copyAssetsForAndroid(discoverAssets(dir, ['.png']), dest);
-    expect(copied).toBe(3);
-    // 1x → mdpi, 2x → xhdpi, 3x → xxhdpi (Metro 매핑)
-    expect(existsSync(join(dest, 'drawable-mdpi/src_img_logo.png'))).toBe(true);
-    expect(existsSync(join(dest, 'drawable-xhdpi/src_img_logo.png'))).toBe(true);
-    expect(existsSync(join(dest, 'drawable-xxhdpi/src_img_logo.png'))).toBe(true);
-    // keep.xml 생성
-    const keepPath = join(dest, 'raw/keep.xml');
-    expect(existsSync(keepPath)).toBe(true);
-    const xml = readFileSync(keepPath, 'utf-8');
-    expect(xml).toContain('@drawable/src_img_logo');
-  });
-
-  test('Android — 4x scale 도 통과 (iOS 와 다름)', () => {
-    mkdirSync(join(dir, 'a'), { recursive: true });
-    writeFileSync(join(dir, 'a/icon@4x.png'), 'x');
-    const copied = copyAssetsForAndroid(discoverAssets(dir, ['.png']), dest);
-    expect(copied).toBe(1);
-    expect(existsSync(join(dest, 'drawable-xxxhdpi/a_icon.png'))).toBe(true);
-  });
-
-  test('Non-image asset — raw resource 로 복사하고 keep.xml 에 raw ref 포함', () => {
-    mkdirSync(join(dir, 'a'), { recursive: true });
-    writeFileSync(join(dir, 'a/font.ttf'), 'x');
-    copyAssetsForAndroid(discoverAssets(dir, ['.ttf']), dest);
-    expect(existsSync(join(dest, 'raw/a_font.ttf'))).toBe(true);
-    const xml = readFileSync(join(dest, 'raw/keep.xml'), 'utf-8');
-    expect(xml).toContain('@raw/a_font');
-  });
-
-  test('Android raw asset — yml 은 drawable 이 아니라 raw 로 복사', () => {
-    mkdirSync(join(dir, 'pods/Foo.framework.dSYM/Contents/Resources'), { recursive: true });
-    writeFileSync(join(dir, 'pods/Foo.framework.dSYM/Contents/Resources/foo.yml'), 'x');
-    const copied = copyAssetsForAndroid(discoverAssets(dir, ['.yml']), dest);
-
-    expect(copied).toBe(1);
-    expect(existsSync(join(dest, 'raw/pods_fooframeworkdsym_contents_resources_foo.yml'))).toBe(
-      true,
-    );
-    expect(
-      existsSync(join(dest, 'drawable-mdpi/pods_fooframeworkdsym_contents_resources_foo.yml')),
-    ).toBe(false);
-  });
-
-  test('sourceExts 와 겹치는 svg 는 Android drawable 로 복사하지 않음', () => {
-    mkdirSync(join(dir, 'src/img'), { recursive: true });
-    writeFileSync(join(dir, 'src/img/icon.svg'), '<svg />');
-    writeFileSync(join(dir, 'src/img/logo.png'), 'png');
-
-    const copied = copyAssetsForAndroid(discoverAssets(dir, ['.svg', '.png'], ['.svg']), dest);
-
-    expect(copied).toBe(1);
-    expect(existsSync(join(dest, 'drawable-mdpi/src_img_icon.svg'))).toBe(false);
-    expect(existsSync(join(dest, 'drawable-mdpi/src_img_logo.png'))).toBe(true);
-  });
-
-  test('bundleCode 가 있으면 등록된 asset 만 Metro naming 으로 복사', () => {
+  test('등록된 asset 만 Metro scaleToDrawable folder + flat naming + keep.xml 로 복사', () => {
     mkdirSync(join(dir, 'src/assets'), { recursive: true });
     mkdirSync(join(dir, 'ios/resigned_payload'), { recursive: true });
     mkdirSync(join(dir, '.github/workflows'), { recursive: true });
@@ -311,8 +170,38 @@ describe('copyRnAssets — Android', () => {
     expect(copied).toBe(2);
     expect(existsSync(join(dest, 'drawable-mdpi/src_assets_logo.png'))).toBe(true);
     expect(existsSync(join(dest, 'drawable-xhdpi/src_assets_logo.png'))).toBe(true);
+    // 등록되지 않은 file 은 무시 — projectRoot walk path 잔존 회귀 가드.
     expect(existsSync(join(dest, 'drawable-mdpi/ios_resigned_payload_appicon.png'))).toBe(false);
     expect(existsSync(join(dest, 'raw/github_workflows_ci.yml'))).toBe(false);
+
+    const xml = readFileSync(join(dest, 'raw/keep.xml'), 'utf-8');
+    expect(xml).toContain('@drawable/src_assets_logo');
+  });
+
+  test('비-image asset — raw resource 로 복사하고 keep.xml 에 raw ref 포함', () => {
+    mkdirSync(join(dir, 'fonts'), { recursive: true });
+    writeFileSync(join(dir, 'fonts/icomoon.ttf'), 'x');
+
+    const asset = {
+      __packager_asset: true,
+      httpServerLocation: '/assets/fonts',
+      width: 0,
+      height: 0,
+      scales: [1],
+      hash: 'hash',
+      name: 'icomoon',
+      type: 'ttf',
+      fileSystemLocation: join(dir, 'fonts'),
+    };
+    copyRnAssets({
+      assetsDest: dest,
+      rnPlatform: 'android',
+      bundleCode: `Registry.registerAsset(${JSON.stringify(asset)});`,
+    });
+
+    expect(existsSync(join(dest, 'raw/fonts_icomoon.ttf'))).toBe(true);
+    const xml = readFileSync(join(dest, 'raw/keep.xml'), 'utf-8');
+    expect(xml).toContain('@raw/fonts_icomoon');
   });
 });
 


### PR DESCRIPTION
## Summary

#3216 이 production 경로를 `AssetRegistry.registerAsset` 기반 `copyRegisteredAssetsFor{Ios,Android}` 로 전환한 뒤, `runRnBundle` 에서 더 이상 호출되지 않는 legacy projectRoot-walk helpers 가 그대로 export 되어 있던 cleanup PR.

### 제거 대상
- `copyAssetsForIos` / `copyAssetsForAndroid` — legacy walk-based copy.
- `discoverAssets` / 내부 `walkDir` / `SKIP_DIRS` — projectRoot walk + node_modules skip.
- `parseAssetName` / `SCALE_REGEX` — `parseAssetName` 안에서만 사용되던 scale variant 파싱 (registered asset 은 `scales` 배열을 직접 가지므로 불필요).
- `androidAssetFileName` — registered path 는 `getAndroidResourceIdentifier` 만 사용.
- 미사용 import: `readdirSync` / `relative`.

### 회귀 가드
- `copyRnAssets` entry 테스트로 production 경로 회귀 보존.
- 새 iOS 회귀 테스트 추가 — Metro `getAssetDestPathIOS` 형식 (`<dest>/<httpServerLocation>/<file>`) + `IOS_SCALES` (1/2/3) 가드 + `@4x` 제외 확인.
- Android 회귀 테스트에 "등록되지 않은 file 은 무시" assertion 보존 (projectRoot walk path 잔존 회귀 가드).

## Background — Zig 초보자에게

이 PR 은 `.mjs` 만 건드리고 Zig 코드는 변경하지 않습니다. RN production bundle 의 asset 파일을 어디로 복사할지 결정하는 CLI 스크립트입니다.

- `AssetRegistry.registerAsset({...})` — RN 번들러가 `require('./logo.png')` 같은 asset import 를 만나면 bundle 안에 이 호출을 emit. emit 된 object 에는 `httpServerLocation`, `scales`, `name`, `type`, `fileSystemLocation` 같은 metadata 가 포함됨.
- 이전엔 projectRoot 를 walk 해서 `.png` 등을 전부 모은 다음 복사했음 (legacy `copyAssetsForIos/Android`). 그러면 번들에 안 쓰인 asset (예: `.github/workflows/ci.yml`, `ios/resigned_payload/AppIcon.png`) 까지 release 산출물에 들어감.
- #3216 이후엔 bundle 출력에서 `registerAsset(...)` 호출을 직접 파싱해서 참조된 asset 만 복사 — 자동 prune. 이 PR 은 그 전환 이후 남아있던 walk-based 코드를 정리.

## Test plan

- [x] `bun test packages/core/bin/rn-asset-copy.test.ts` 통과 (14 pass / 0 fail)
- [x] `git stash` 상태(legacy 유지)에서 동일하게 packages/core/bin 의 다른 142 fail 이 재현되어 본 PR 변경과 무관함을 확인
- [x] `bun run fmt` / pre-push oxfmt --check 통과
- [x] 다른 패키지가 legacy export 를 import 하지 않는지 grep 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)