### PR TITLE
refactor(esm_wrap): dedupe re-export guard + flatten star getter nesting

### DIFF
--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -80,6 +80,41 @@ inline fn resolvedReExportSource(l: *const Linker, m: *const Module, eb: ExportB
     return l.graph.getModule(src_idx);
 }
 
+/// re-export-like binding 판정. `.re_export` 로 정상 분류된 경우 + barrel alias
+/// (`import X from './y'; export { X }`) 가 binding_scanner 에서 `.local` 로 정규화됐지만
+/// `import_record_index` 가 남아있는 케이스 (#1321) 를 함께 catch. getter emit /
+/// init-call emit / star getter resolution 세 site 에서 일관된 가드.
+inline fn isReExportLike(eb: ExportBinding) bool {
+    return eb.kind == .re_export or eb.import_record_index != null;
+}
+
+/// scope-hoisted re-export 의 target 모듈 + canonical name. tree-shake 로 제거된
+/// source 또는 unresolved record 는 null (caller 가 getter 생략). 데이터만 반환해
+/// `makeStarGetterValue` 의 inferred error set 재귀 cycle 을 회피.
+const ReExportTarget = struct {
+    mod: *const Module,
+    index: u32,
+    name: []const u8,
+};
+
+inline fn resolveReExportTarget(
+    l: *const Linker,
+    src_mod: *const Module,
+    src_eb: ExportBinding,
+) ?ReExportTarget {
+    if (shouldSkipTreeShakenReExportSource(l, src_mod, src_eb)) return null;
+    const rec_idx = src_eb.import_record_index orelse return null;
+    if (rec_idx >= src_mod.import_records.len) return null;
+    const target_idx = src_mod.import_records[rec_idx].resolved;
+    if (target_idx.isNone() or target_idx == src_mod.index) return null;
+    const target_mod = l.graph.getModule(target_idx) orelse return null;
+    return .{
+        .mod = target_mod,
+        .index = @intFromEnum(target_idx),
+        .name = src_mod.exportBindingLocalName(src_eb),
+    };
+}
+
 inline fn shouldSkipTreeShakenReExportSource(l: *const Linker, m: *const Module, eb: ExportBinding) bool {
     if (!l.tree_shaker_active) return false;
     const rec_idx = eb.import_record_index orelse return false;
@@ -508,7 +543,7 @@ pub fn emitEsmWrappedModule(
                     // import record의 resolved가 none이 될 수 있다. 이 상태에서 getter를
                     // 만들면 `export { default as X } from`의 local name인 `default`가
                     // 값 위치에 남아 Hermes release parse에서 `return default;`가 된다.
-                    if (eb.kind == .re_export or eb.import_record_index != null) skip: {
+                    if (isReExportLike(eb)) skip: {
                         const l = linker orelse break :skip;
                         if (shouldSkipTreeShakenReExportSource(l, module, eb)) continue;
                     }
@@ -526,7 +561,7 @@ pub fn emitEsmWrappedModule(
                         // barrel alias(`import X from './y'; export { X }`)는 binding_scanner가
                         // .re_export + local_name=ib.imported_name으로 정규화하므로(#1321),
                         // 매칭되는 import binding이 있으면 기존 경로로 폴백.
-                        if (eb.kind == .re_export or eb.import_record_index != null) re_export: {
+                        if (isReExportLike(eb)) re_export: {
                             const l = linker orelse break :re_export;
                             const rec_idx = eb.import_record_index orelse break :re_export;
                             if (rec_idx >= module.import_records.len) break :re_export;
@@ -1232,22 +1267,13 @@ fn makeStarGetterValue(
         .none => {
             // scope-hoisted: export의 local_name을 찾아 canonical name으로 변환
             for (src_mod.export_bindings) |src_eb| {
-                if (std.mem.eql(u8, src_eb.exported_name, name)) {
-                    if (src_eb.kind == .re_export or src_eb.import_record_index != null) {
-                        if (shouldSkipTreeShakenReExportSource(l, src_mod, src_eb)) return null;
-                        const rec_idx = src_eb.import_record_index orelse return null;
-                        if (rec_idx >= src_mod.import_records.len) return null;
-                        const target_idx = src_mod.import_records[rec_idx].resolved;
-                        if (target_idx.isNone() or target_idx == src_mod.index) return null;
-                        const target_i = @intFromEnum(target_idx);
-                        const target_mod = l.graph.getModule(target_idx) orelse return null;
-                        const target_name = src_mod.exportBindingLocalName(src_eb);
-                        return try makeStarGetterValue(allocator, l, target_mod, target_i, target_name, options);
-                    } else {
-                        const local = l.getCanonicalForExport(src_eb, src_i);
-                        return try allocator.dupe(u8, local);
-                    }
+                if (!std.mem.eql(u8, src_eb.exported_name, name)) continue;
+                if (isReExportLike(src_eb)) {
+                    const target = resolveReExportTarget(l, src_mod, src_eb) orelse return null;
+                    return try makeStarGetterValue(allocator, l, target.mod, target.index, target.name, options);
                 }
+                const local = l.getCanonicalForExport(src_eb, src_i);
+                return try allocator.dupe(u8, local);
             }
             // 직접 export에 없으면 소스의 re_export_all 체인을 따라간다.
             // resolveExportChain으로 canonical 이름을 찾는다.


### PR DESCRIPTION
## Summary

#3216 `/simplify` 에서 보류했던 Zig esm_wrap.zig cleanup. 두 가지 패턴 정리.

### 1. `isReExportLike` helper 추출 (3개 site)

기존: `eb.kind == .re_export or eb.import_record_index != null` 가 세 곳에서 중복.
- L516: getter emit skip 가드 (tree-shake 된 re-export source dangling reference 방어, #2398)
- L534: getter value emit (source module canonical name resolution)
- L1275: `makeStarGetterValue` 안 .none arm

```zig
inline fn isReExportLike(eb: ExportBinding) bool {
    return eb.kind == .re_export or eb.import_record_index != null;
}
```

`.import_record_index != null` 절은 `binding_scanner` 가 barrel alias
(`import X from './y'; export { X }`) 를 `.local` 로 정규화한 케이스 (#1321) 를
함께 catch 하기 위한 것. helper 이름이 그 *의도* 를 드러내고, 세 site 가
lockstep 유지.

### 2. `makeStarGetterValue` `.none` arm 평탄화

기존: `switch(.none) → for → if (kind == .re_export or idx != null) → if/else` 4 levels.

`resolveReExportTarget(l, src_mod, src_eb)` helper 가 데이터만 (target module +
index + name) 반환하고 caller 가 `makeStarGetterValue` 를 재귀 호출하는 형태로
분리. 안쪽 if/else 가 두 줄 early-return 으로 축약.

**구현 노트** — helper 가 directly `makeStarGetterValue` 를 호출하는 형태로
처음 시도했더니 Zig 의 inferred error set 이 두 함수 간 재귀 cycle 을 풀지
못해 `unable to resolve inferred error set` 컴파일 에러 발생. 데이터만
반환하고 caller 가 재귀를 호출하는 형태로 바꿔 회피.

## Background — Zig 초보자에게

- `ExportBinding` 은 `export { foo }` / `export { bar } from './x'` / `export * from './x'` 같은 module export 를 표현하는 구조체.
  - `.kind` 가 `.local` / `.re_export` / `.re_export_star` 같이 분류.
  - `.import_record_index` 는 `from './x'` 의 source module 을 가리키는 record index (없으면 `null`).
- `binding_scanner` 가 `import X from './y'; export { X }` 같은 barrel alias 를 발견하면 `.kind = .local` + `.import_record_index = (./y 의 record)` 로 정규화 (#1321). 그래서 `.kind` 만 보고 re-export 여부를 판단하면 누락이 발생 → OR clause 가 필요.
- `inline fn` 은 Zig 의 inlining 힌트. 작은 가드 helper 에 사용.
- `inferred error set` — `fn ...!T` 처럼 `!` 뒤에 error set 을 명시하지 않으면 컴파일러가 함수 본문에서 발생하는 오류들을 자동 추론. 재귀 호출이 있으면 두 함수의 error set 이 서로를 참조해서 fixed point 를 못 찾는 경우가 있음.

## Test plan

- [x] `zig build` 통과
- [x] `zig build test` 전체 통과
- [x] `zig fmt` 적용
- [x] pre-push oxfmt --check + lint 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)