### PR TITLE
perf(rn-asset): switch release copy to fs/promises + Promise.all

### DIFF
--- a/packages/core/bin/rn-asset-copy.mjs
+++ b/packages/core/bin/rn-asset-copy.mjs
@@ -3,7 +3,7 @@
 // 참조된 asset 만 복사하여 release 산출물을 자동 prune. `runRnBundle` 이
 // dev=false + `--assets-dest` 명시 시 호출.
 
-import { copyFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import { copyFile, mkdir, writeFile } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
 
 /** iOS 가 native 로 인식하는 scale set. 그 외 (`@4x` 등) 는 production bundle 에서 제외. */
@@ -155,9 +155,9 @@ function sourceFileForScale(asset, scale) {
   return join(asset.fileSystemLocation, `${asset.name}${suffix}.${asset.type}`);
 }
 
-function copyRegisteredAssetFile(src, destPath) {
+async function copyRegisteredAssetFile(src, destPath) {
   try {
-    copyFileSync(src, destPath);
+    await copyFile(src, destPath);
   } catch (err) {
     if (err && err.code === 'ENOENT') {
       throw new Error(`registered RN asset file not found: ${src}`);
@@ -166,9 +166,9 @@ function copyRegisteredAssetFile(src, destPath) {
   }
 }
 
-export function copyRegisteredAssetsForIos(assets, assetsDest) {
-  const createdDirs = new Set();
-  let copied = 0;
+export async function copyRegisteredAssetsForIos(assets, assetsDest) {
+  const tasks = [];
+  const dirs = new Set();
   for (const asset of assets) {
     for (const scale of asset.scales) {
       if (!IOS_SCALES.has(scale)) continue;
@@ -178,22 +178,19 @@ export function copyRegisteredAssetsForIos(assets, assetsDest) {
         asset.httpServerLocation.slice(1).replace(/\.\.\//g, '_'),
         basename(src),
       );
-      const targetDir = dirname(destPath);
-      if (!createdDirs.has(targetDir)) {
-        mkdirSync(targetDir, { recursive: true });
-        createdDirs.add(targetDir);
-      }
-      copyRegisteredAssetFile(src, destPath);
-      copied++;
+      dirs.add(dirname(destPath));
+      tasks.push({ src, destPath });
     }
   }
-  return copied;
+  await Promise.all([...dirs].map((d) => mkdir(d, { recursive: true })));
+  await Promise.all(tasks.map(({ src, destPath }) => copyRegisteredAssetFile(src, destPath)));
+  return tasks.length;
 }
 
-export function copyRegisteredAssetsForAndroid(assets, assetsDest) {
+export async function copyRegisteredAssetsForAndroid(assets, assetsDest) {
   const keepRefs = new Set();
-  const createdDirs = new Set();
-  let copied = 0;
+  const dirs = new Set();
+  const tasks = [];
 
   for (const asset of assets) {
     const isDrawable = DRAWABLE_EXT_RE.test(`.${asset.type}`);
@@ -201,29 +198,26 @@ export function copyRegisteredAssetsForAndroid(assets, assetsDest) {
     for (const scale of asset.scales) {
       const folder = isDrawable ? getAndroidDrawableFolder(scale) : 'raw';
       const targetDir = join(assetsDest, folder);
-      if (!createdDirs.has(targetDir)) {
-        mkdirSync(targetDir, { recursive: true });
-        createdDirs.add(targetDir);
-      }
-      copyRegisteredAssetFile(
-        sourceFileForScale(asset, scale),
-        join(targetDir, `${resourceName}.${asset.type}`),
-      );
-      copied++;
+      dirs.add(targetDir);
+      tasks.push({
+        src: sourceFileForScale(asset, scale),
+        destPath: join(targetDir, `${resourceName}.${asset.type}`),
+      });
     }
     keepRefs.add(`@${isDrawable ? 'drawable' : 'raw'}/${resourceName}`);
   }
 
-  if (keepRefs.size > 0) {
-    const keepDir = join(assetsDest, 'raw');
-    if (!createdDirs.has(keepDir)) {
-      mkdirSync(keepDir, { recursive: true });
-      createdDirs.add(keepDir);
-    }
-    writeFileSync(join(keepDir, 'keep.xml'), buildKeepXml([...keepRefs].sort()));
+  const keepDir = keepRefs.size > 0 ? join(assetsDest, 'raw') : null;
+  if (keepDir) dirs.add(keepDir);
+
+  await Promise.all([...dirs].map((d) => mkdir(d, { recursive: true })));
+  await Promise.all(tasks.map(({ src, destPath }) => copyRegisteredAssetFile(src, destPath)));
+
+  if (keepDir) {
+    await writeFile(join(keepDir, 'keep.xml'), buildKeepXml([...keepRefs].sort()));
   }
 
-  return copied;
+  return tasks.length;
 }
 
 /**
@@ -232,7 +226,7 @@ export function copyRegisteredAssetsForAndroid(assets, assetsDest) {
  *
  * @returns 복사된 파일 수.
  */
-export function copyRnAssets({ assetsDest, rnPlatform, bundleCode }) {
+export async function copyRnAssets({ assetsDest, rnPlatform, bundleCode }) {
   if (!assetsDest) return 0;
   if (typeof bundleCode !== 'string') {
     throw new Error('RN release asset copy requires bundleCode');

--- a/packages/core/bin/rn-asset-copy.test.ts
+++ b/packages/core/bin/rn-asset-copy.test.ts
@@ -98,7 +98,7 @@ describe('buildKeepXml', () => {
 });
 
 describe('copyRnAssets — iOS', () => {
-  test('등록된 asset 의 IOS_SCALES (1/2/3) variant 만 복사, @4x 제외', () => {
+  test('등록된 asset 의 IOS_SCALES (1/2/3) variant 만 복사, @4x 제외', async () => {
     mkdirSync(join(dir, 'src/assets'), { recursive: true });
     writeFileSync(join(dir, 'src/assets/logo.png'), 'a');
     writeFileSync(join(dir, 'src/assets/logo@2x.png'), 'b');
@@ -115,7 +115,7 @@ describe('copyRnAssets — iOS', () => {
       type: 'png',
       fileSystemLocation: join(dir, 'src/assets'),
     };
-    const copied = copyRnAssets({
+    const copied = await copyRnAssets({
       assetsDest: dest,
       rnPlatform: 'ios',
       bundleCode: `module.exports = Registry.registerAsset(${JSON.stringify(asset)});`,
@@ -129,9 +129,9 @@ describe('copyRnAssets — iOS', () => {
     expect(existsSync(join(dest, 'assets/src/assets/logo@4x.png'))).toBe(false);
   });
 
-  test('등록된 asset 없음 — 0 반환', () => {
+  test('등록된 asset 없음 — 0 반환', async () => {
     expect(
-      copyRnAssets({
+      await copyRnAssets({
         assetsDest: dest,
         rnPlatform: 'ios',
         bundleCode: '/* no registered asset */',
@@ -141,7 +141,7 @@ describe('copyRnAssets — iOS', () => {
 });
 
 describe('copyRnAssets — Android', () => {
-  test('등록된 asset 만 Metro scaleToDrawable folder + flat naming + keep.xml 로 복사', () => {
+  test('등록된 asset 만 Metro scaleToDrawable folder + flat naming + keep.xml 로 복사', async () => {
     mkdirSync(join(dir, 'src/assets'), { recursive: true });
     mkdirSync(join(dir, 'ios/resigned_payload'), { recursive: true });
     mkdirSync(join(dir, '.github/workflows'), { recursive: true });
@@ -161,7 +161,7 @@ describe('copyRnAssets — Android', () => {
       type: 'png',
       fileSystemLocation: join(dir, 'src/assets'),
     };
-    const copied = copyRnAssets({
+    const copied = await copyRnAssets({
       assetsDest: dest,
       rnPlatform: 'android',
       bundleCode: `module.exports = Registry.registerAsset(${JSON.stringify(asset)});`,
@@ -178,7 +178,7 @@ describe('copyRnAssets — Android', () => {
     expect(xml).toContain('@drawable/src_assets_logo');
   });
 
-  test('비-image asset — raw resource 로 복사하고 keep.xml 에 raw ref 포함', () => {
+  test('비-image asset — raw resource 로 복사하고 keep.xml 에 raw ref 포함', async () => {
     mkdirSync(join(dir, 'fonts'), { recursive: true });
     writeFileSync(join(dir, 'fonts/icomoon.ttf'), 'x');
 
@@ -193,7 +193,7 @@ describe('copyRnAssets — Android', () => {
       type: 'ttf',
       fileSystemLocation: join(dir, 'fonts'),
     };
-    copyRnAssets({
+    await copyRnAssets({
       assetsDest: dest,
       rnPlatform: 'android',
       bundleCode: `Registry.registerAsset(${JSON.stringify(asset)});`,
@@ -206,14 +206,18 @@ describe('copyRnAssets — Android', () => {
 });
 
 describe('copyRnAssets — guards', () => {
-  test('assetsDest falsy — 0 반환', () => {
+  test('assetsDest falsy — 0 반환', async () => {
     expect(
-      copyRnAssets({ assetsDest: '', rnPlatform: 'ios', bundleCode: '/* no registered asset */' }),
+      await copyRnAssets({
+        assetsDest: '',
+        rnPlatform: 'ios',
+        bundleCode: '/* no registered asset */',
+      }),
     ).toBe(0);
   });
 
-  test('bundleCode 없으면 release asset copy 실패', () => {
-    expect(() => copyRnAssets({ assetsDest: dest, rnPlatform: 'ios' } as never)).toThrow(
+  test('bundleCode 없으면 release asset copy 실패', async () => {
+    await expect(copyRnAssets({ assetsDest: dest, rnPlatform: 'ios' } as never)).rejects.toThrow(
       'RN release asset copy requires bundleCode',
     );
   });

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -808,7 +808,7 @@ async function runRnBundle(opts, config) {
   if (result.errors.length === 0 && !opts.devMode && opts.assetsDest) {
     const assetsDestAbs = resolve(opts.assetsDest);
     try {
-      const copied = copyRnAssets({
+      const copied = await copyRnAssets({
         assetsDest: assetsDestAbs,
         rnPlatform,
         bundleCode: result.outputFiles?.[0]?.text,


### PR DESCRIPTION
## Summary

#3216 `/simplify` 에서 보류한 마지막 항목. RN release asset 복사가 `(asset × scale)` 마다 `copyFileSync`/`mkdirSync` 를 event loop 위에서 순차 실행하던 것을 `node:fs/promises` + `Promise.all` 로 병렬화.

### 변경
- `copyFileSync` / `mkdirSync` / `writeFileSync` → `node:fs/promises` async API.
- 모든 copy 작업을 한 번에 `Promise.all` 로 fan-out — 수십~수백 asset × 1~3 scale 이 single-flight 로 끝남.
- unique target dir 을 `Set` 으로 dedupe + `Promise.all(mkdirs)` 한 번 호출 — 기존 `createdDirs` inline check 가 자연스럽게 통합.
- `copyRnAssets` 가 `async` 가 되어 caller (`runRnBundle`) 에 `await` 한 줄 추가. `runRnBundle` 이 이미 `async function` 이라 외부 인터페이스는 영향 없음.

### 테스트
- iOS / Android / 비-image / guards 케이스 모두 `await` 로 변환.
- "bundleCode 없으면 release asset copy 실패" 가드는 sync 함수의 `() => ...).toThrow` 에서 async Promise reject 형태인 `rejects.toThrow` 로.
- 14 pass / 0 fail.

## Background — Zig 초보자에게

- 이 PR 은 `.mjs` / `.ts` 만 건드리고 Zig 코드는 변경하지 않습니다.
- Node.js 의 `node:fs/promises` 는 `node:fs` 의 sync API (`copyFileSync` 등) 와 동일한 시스템 호출을 사용하지만 Promise 를 반환. event loop 가 다른 작업을 처리할 수 있고, `Promise.all` 로 묶으면 libuv 의 thread pool 이 file copy 를 병렬로 처리.
- `runRnBundle` 이 이미 async 라 `await` 추가만으로 전환 가능. Node 의 mkdir 은 `recursive: true` 일 때 race-safe (`EEXIST` 무시) 라 unique dir set 의 동시 호출 안전.

## Test plan

- [x] `bun test packages/core/bin/rn-asset-copy.test.ts` (14 pass / 0 fail)
- [x] `bun run fmt` / pre-push oxfmt --check 통과
- [x] caller `runRnBundle` 가 `async function` 임을 grep 으로 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)