### PR TITLE
refactor(rn-asset): expose AssetRegistry metadata as bundler API

### DIFF
--- a/packages/core/bin/rn-asset-copy.mjs
+++ b/packages/core/bin/rn-asset-copy.mjs
@@ -1,7 +1,7 @@
 // RN production bundle 의 asset 복사. Metro saveAssets/getAssetDestPath{IOS,Android}
-// 호환 경로를 사용한다 — bundle 안 `AssetRegistry.registerAsset({...})` 호출에서
-// 참조된 asset 만 복사하여 release 산출물을 자동 prune. `runRnBundle` 이
-// dev=false + `--assets-dest` 명시 시 호출.
+// 호환 경로를 사용한다 — bundler 가 `--asset-registry` 호출 시 emit 한 asset
+// metadata (result.rnAssetMetadata) 를 직접 받아 release 산출물을 자동 prune.
+// `runRnBundle` 이 dev=false + `--assets-dest` 명시 시 호출.
 
 import { copyFile, mkdir, writeFile } from 'node:fs/promises';
 import { basename, dirname, join } from 'node:path';
@@ -59,95 +59,6 @@ export function buildKeepXml(drawableNames) {
     `<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="${items}" />`,
     '',
   ].join('\n');
-}
-
-function findMatchingBrace(source, openIndex) {
-  let depth = 0;
-  let quote = '';
-  let escaped = false;
-
-  for (let i = openIndex; i < source.length; i++) {
-    const ch = source[i];
-
-    if (quote) {
-      if (escaped) {
-        escaped = false;
-      } else if (ch === '\\') {
-        escaped = true;
-      } else if (ch === quote) {
-        quote = '';
-      }
-      continue;
-    }
-
-    if (ch === '"' || ch === "'") {
-      quote = ch;
-      continue;
-    }
-
-    if (ch === '{') {
-      depth++;
-      continue;
-    }
-
-    if (ch === '}') {
-      depth--;
-      if (depth === 0) return i;
-    }
-  }
-
-  return -1;
-}
-
-function isRegisteredAsset(value) {
-  return (
-    value &&
-    value.__packager_asset === true &&
-    typeof value.fileSystemLocation === 'string' &&
-    typeof value.httpServerLocation === 'string' &&
-    typeof value.name === 'string' &&
-    typeof value.type === 'string' &&
-    Array.isArray(value.scales)
-  );
-}
-
-export function extractRegisteredAssets(bundleCode) {
-  if (typeof bundleCode !== 'string' || bundleCode.length === 0) return [];
-
-  const assets = [];
-  let cursor = 0;
-  while (cursor < bundleCode.length) {
-    const callIndex = bundleCode.indexOf('registerAsset(', cursor);
-    if (callIndex === -1) break;
-
-    let argIndex = callIndex + 'registerAsset('.length;
-    while (/\s/.test(bundleCode[argIndex] ?? '')) argIndex++;
-    if (bundleCode[argIndex] !== '{') {
-      cursor = argIndex + 1;
-      continue;
-    }
-
-    const endIndex = findMatchingBrace(bundleCode, argIndex);
-    if (endIndex === -1) break;
-    const objectText = bundleCode.slice(argIndex, endIndex + 1);
-    cursor = endIndex + 1;
-
-    if (!objectText.includes('"__packager_asset"')) continue;
-    try {
-      const asset = JSON.parse(objectText);
-      if (isRegisteredAsset(asset)) {
-        assets.push({
-          ...asset,
-          type: asset.type.toLowerCase(),
-          scales: asset.scales.filter((s) => Number.isFinite(s) && s > 0),
-        });
-      }
-    } catch {
-      // Not a JSON-shaped ZNTC/Metro asset registry call.
-    }
-  }
-
-  return assets;
 }
 
 function sourceFileForScale(asset, scale) {
@@ -222,19 +133,19 @@ export async function copyRegisteredAssetsForAndroid(assets, assetsDest) {
 
 /**
  * Production asset 복사 entry — caller (runRnBundle) 에서 dev=false + assetsDest
- * 명시 시 호출. Metro처럼 bundle 에 등록된 asset 목록만 복사한다.
+ * 명시 시 호출. Bundler 가 emit 한 `result.rnAssetMetadata` 를 그대로 받아
+ * Metro 호환 경로로 복사.
  *
  * @returns 복사된 파일 수.
  */
-export async function copyRnAssets({ assetsDest, rnPlatform, bundleCode }) {
+export async function copyRnAssets({ assetsDest, rnPlatform, assets }) {
   if (!assetsDest) return 0;
-  if (typeof bundleCode !== 'string') {
-    throw new Error('RN release asset copy requires bundleCode');
+  if (!Array.isArray(assets)) {
+    throw new Error('RN release asset copy requires assets metadata array');
   }
-  const registeredAssets = extractRegisteredAssets(bundleCode);
-  if (registeredAssets.length === 0) return 0;
+  if (assets.length === 0) return 0;
   if (rnPlatform === 'android') {
-    return copyRegisteredAssetsForAndroid(registeredAssets, assetsDest);
+    return copyRegisteredAssetsForAndroid(assets, assetsDest);
   }
-  return copyRegisteredAssetsForIos(registeredAssets, assetsDest);
+  return copyRegisteredAssetsForIos(assets, assetsDest);
 }

--- a/packages/core/bin/rn-asset-copy.test.ts
+++ b/packages/core/bin/rn-asset-copy.test.ts
@@ -6,7 +6,6 @@ import { join } from 'node:path';
 import {
   buildKeepXml,
   copyRnAssets,
-  extractRegisteredAssets,
   getAndroidDrawableFolder,
   getAndroidResourceIdentifier,
   IOS_SCALES,
@@ -66,23 +65,6 @@ describe('Metro registered asset helpers', () => {
       }),
     ).toBe('src_assets_tableorder_imglayoutb');
   });
-
-  test('extractRegisteredAssets — bundle 의 AssetRegistry.registerAsset 목록 추출', () => {
-    const asset = {
-      __packager_asset: true,
-      httpServerLocation: '/assets/src/assets',
-      width: 1,
-      height: 1,
-      scales: [1, 2],
-      hash: 'hash',
-      name: 'logo',
-      type: 'png',
-      fileSystemLocation: join(dir, 'src/assets'),
-    };
-    const bundle = `module.exports = Registry.registerAsset(${JSON.stringify(asset)});`;
-
-    expect(extractRegisteredAssets(bundle)).toEqual([asset]);
-  });
 });
 
 describe('buildKeepXml', () => {
@@ -104,21 +86,21 @@ describe('copyRnAssets — iOS', () => {
     writeFileSync(join(dir, 'src/assets/logo@2x.png'), 'b');
     writeFileSync(join(dir, 'src/assets/logo@3x.png'), 'c');
 
-    const asset = {
-      __packager_asset: true,
-      httpServerLocation: '/assets/src/assets',
-      width: 1,
-      height: 1,
-      scales: [1, 2, 3, 4],
-      hash: 'hash',
-      name: 'logo',
-      type: 'png',
-      fileSystemLocation: join(dir, 'src/assets'),
-    };
     const copied = await copyRnAssets({
       assetsDest: dest,
       rnPlatform: 'ios',
-      bundleCode: `module.exports = Registry.registerAsset(${JSON.stringify(asset)});`,
+      assets: [
+        {
+          httpServerLocation: '/assets/src/assets',
+          width: 1,
+          height: 1,
+          scales: [1, 2, 3, 4],
+          hash: 'hash',
+          name: 'logo',
+          type: 'png',
+          fileSystemLocation: join(dir, 'src/assets'),
+        },
+      ],
     });
 
     // Metro getAssetDestPathIOS — httpServerLocation 기반 `<dest>/assets/src/assets/<file>`.
@@ -134,7 +116,7 @@ describe('copyRnAssets — iOS', () => {
       await copyRnAssets({
         assetsDest: dest,
         rnPlatform: 'ios',
-        bundleCode: '/* no registered asset */',
+        assets: [],
       }),
     ).toBe(0);
   });
@@ -143,36 +125,29 @@ describe('copyRnAssets — iOS', () => {
 describe('copyRnAssets — Android', () => {
   test('등록된 asset 만 Metro scaleToDrawable folder + flat naming + keep.xml 로 복사', async () => {
     mkdirSync(join(dir, 'src/assets'), { recursive: true });
-    mkdirSync(join(dir, 'ios/resigned_payload'), { recursive: true });
-    mkdirSync(join(dir, '.github/workflows'), { recursive: true });
     writeFileSync(join(dir, 'src/assets/logo.png'), 'a');
     writeFileSync(join(dir, 'src/assets/logo@2x.png'), 'b');
-    writeFileSync(join(dir, 'ios/resigned_payload/AppIcon.png'), 'ios');
-    writeFileSync(join(dir, '.github/workflows/ci.yml'), 'ci');
 
-    const asset = {
-      __packager_asset: true,
-      httpServerLocation: '/assets/src/assets',
-      width: 1,
-      height: 1,
-      scales: [1, 2],
-      hash: 'hash',
-      name: 'logo',
-      type: 'png',
-      fileSystemLocation: join(dir, 'src/assets'),
-    };
     const copied = await copyRnAssets({
       assetsDest: dest,
       rnPlatform: 'android',
-      bundleCode: `module.exports = Registry.registerAsset(${JSON.stringify(asset)});`,
+      assets: [
+        {
+          httpServerLocation: '/assets/src/assets',
+          width: 1,
+          height: 1,
+          scales: [1, 2],
+          hash: 'hash',
+          name: 'logo',
+          type: 'png',
+          fileSystemLocation: join(dir, 'src/assets'),
+        },
+      ],
     });
 
     expect(copied).toBe(2);
     expect(existsSync(join(dest, 'drawable-mdpi/src_assets_logo.png'))).toBe(true);
     expect(existsSync(join(dest, 'drawable-xhdpi/src_assets_logo.png'))).toBe(true);
-    // 등록되지 않은 file 은 무시 — projectRoot walk path 잔존 회귀 가드.
-    expect(existsSync(join(dest, 'drawable-mdpi/ios_resigned_payload_appicon.png'))).toBe(false);
-    expect(existsSync(join(dest, 'raw/github_workflows_ci.yml'))).toBe(false);
 
     const xml = readFileSync(join(dest, 'raw/keep.xml'), 'utf-8');
     expect(xml).toContain('@drawable/src_assets_logo');
@@ -182,21 +157,21 @@ describe('copyRnAssets — Android', () => {
     mkdirSync(join(dir, 'fonts'), { recursive: true });
     writeFileSync(join(dir, 'fonts/icomoon.ttf'), 'x');
 
-    const asset = {
-      __packager_asset: true,
-      httpServerLocation: '/assets/fonts',
-      width: 0,
-      height: 0,
-      scales: [1],
-      hash: 'hash',
-      name: 'icomoon',
-      type: 'ttf',
-      fileSystemLocation: join(dir, 'fonts'),
-    };
     await copyRnAssets({
       assetsDest: dest,
       rnPlatform: 'android',
-      bundleCode: `Registry.registerAsset(${JSON.stringify(asset)});`,
+      assets: [
+        {
+          httpServerLocation: '/assets/fonts',
+          width: 0,
+          height: 0,
+          scales: [1],
+          hash: 'hash',
+          name: 'icomoon',
+          type: 'ttf',
+          fileSystemLocation: join(dir, 'fonts'),
+        },
+      ],
     });
 
     expect(existsSync(join(dest, 'raw/fonts_icomoon.ttf'))).toBe(true);
@@ -211,14 +186,14 @@ describe('copyRnAssets — guards', () => {
       await copyRnAssets({
         assetsDest: '',
         rnPlatform: 'ios',
-        bundleCode: '/* no registered asset */',
+        assets: [],
       }),
     ).toBe(0);
   });
 
-  test('bundleCode 없으면 release asset copy 실패', async () => {
+  test('assets 배열 누락 — 실패', async () => {
     await expect(copyRnAssets({ assetsDest: dest, rnPlatform: 'ios' } as never)).rejects.toThrow(
-      'RN release asset copy requires bundleCode',
+      'RN release asset copy requires assets metadata array',
     );
   });
 });

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -811,7 +811,7 @@ async function runRnBundle(opts, config) {
       const copied = await copyRnAssets({
         assetsDest: assetsDestAbs,
         rnPlatform,
-        bundleCode: result.outputFiles?.[0]?.text,
+        assets: result.rnAssetMetadata ?? [],
       });
       if (opts.logLevel !== 'silent') {
         console.error(`[bundle] copied ${copied} asset(s) to ${assetsDestAbs}`);

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -103,6 +103,22 @@ interface Diagnostic {
   location?: { file: string; line?: number; column?: number };
 }
 
+/**
+ * RN AssetRegistry.registerAsset 메타데이터 (Metro 호환 shape).
+ * `--asset-registry` 사용 시 bundler 가 emit 한 asset 마다 1개. `rn-asset-copy`
+ * 가 bundle string 을 파싱하지 않고 직접 받아 release asset 복사에 사용.
+ */
+export interface RnAssetMetadata {
+  httpServerLocation: string;
+  fileSystemLocation: string;
+  name: string;
+  type: string;
+  hash: string;
+  scales: number[];
+  width: number;
+  height: number;
+}
+
 interface NativeBuildResult {
   outputFiles: OutputFile[];
   errors: Diagnostic[];
@@ -110,6 +126,7 @@ interface NativeBuildResult {
   metafile?: string;
   moduleCodes?: Array<{ id: string; code: string }>;
   modulePaths?: string[];
+  rnAssetMetadata?: RnAssetMetadata[];
 }
 
 interface NativeWatchHandle {
@@ -1222,6 +1239,7 @@ export interface BuildResult {
   warnings: Diagnostic[];
   metafile?: string;
   outputCount?: number;
+  rnAssetMetadata?: RnAssetMetadata[];
 }
 
 /**

--- a/packages/core/src/napi/result.zig
+++ b/packages/core/src/napi/result.zig
@@ -205,5 +205,51 @@ pub fn buildResultToJS(env: c.napi_env, result: *const bundler_mod.BundleResult,
         _ = c.napi_set_named_property(env, js_result, "modulePaths", js_paths);
     }
 
+    // RN AssetRegistry.registerAsset metadata (#3216 후속). bundle string 을
+    // hand-rolled 파싱하던 `rn-asset-copy` 의 `extractRegisteredAssets` 가 이 배열을
+    // 직접 받아 release asset 복사에 사용.
+    if (result.rn_asset_metadata) |metas| {
+        var js_metas: c.napi_value = undefined;
+        _ = c.napi_create_array_with_length(env, metas.len, &js_metas);
+        for (metas, 0..) |m, i| {
+            var js_m: c.napi_value = undefined;
+            _ = c.napi_create_object(env, &js_m);
+
+            var js_str: c.napi_value = undefined;
+            _ = c.napi_create_string_utf8(env, m.http_server_location.ptr, m.http_server_location.len, &js_str);
+            _ = c.napi_set_named_property(env, js_m, "httpServerLocation", js_str);
+
+            _ = c.napi_create_string_utf8(env, m.file_system_location.ptr, m.file_system_location.len, &js_str);
+            _ = c.napi_set_named_property(env, js_m, "fileSystemLocation", js_str);
+
+            _ = c.napi_create_string_utf8(env, m.name.ptr, m.name.len, &js_str);
+            _ = c.napi_set_named_property(env, js_m, "name", js_str);
+
+            _ = c.napi_create_string_utf8(env, m.type_name.ptr, m.type_name.len, &js_str);
+            _ = c.napi_set_named_property(env, js_m, "type", js_str);
+
+            _ = c.napi_create_string_utf8(env, m.hash_hex.ptr, m.hash_hex.len, &js_str);
+            _ = c.napi_set_named_property(env, js_m, "hash", js_str);
+
+            var js_num: c.napi_value = undefined;
+            _ = c.napi_create_uint32(env, m.width, &js_num);
+            _ = c.napi_set_named_property(env, js_m, "width", js_num);
+            _ = c.napi_create_uint32(env, m.height, &js_num);
+            _ = c.napi_set_named_property(env, js_m, "height", js_num);
+
+            var js_scales: c.napi_value = undefined;
+            _ = c.napi_create_array_with_length(env, m.scales.len, &js_scales);
+            for (m.scales, 0..) |s, k| {
+                var js_s: c.napi_value = undefined;
+                _ = c.napi_create_uint32(env, s, &js_s);
+                _ = c.napi_set_element(env, js_scales, @intCast(k), js_s);
+            }
+            _ = c.napi_set_named_property(env, js_m, "scales", js_scales);
+
+            _ = c.napi_set_element(env, js_metas, @intCast(i), js_m);
+        }
+        _ = c.napi_set_named_property(env, js_result, "rnAssetMetadata", js_metas);
+    }
+
     return js_result;
 }

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -384,6 +384,10 @@ pub const BundleResult = struct {
     /// asset 파일 출력 (file/copy 로더). allocator 소유.
     /// JS 청크와 별도로 출력 디렉토리에 복사해야 하는 파일들.
     asset_outputs: ?[]OutputFile = null,
+    /// RN AssetRegistry.registerAsset 호출에 emit 된 asset metadata.
+    /// `rn-asset-copy` 가 bundle string 을 hand-rolled 파싱하지 않고 직접 사용.
+    /// allocator 소유 (strings + scales slice).
+    rn_asset_metadata: ?[]@import("graph/assets.zig").RnAssetMetadata = null,
     /// metafile JSON (--metafile). allocator 소유.
     metafile_json: ?[]const u8 = null,
     /// 파이프라인 단계별 타이밍 (ns). 항상 측정 — 워치 모드 관측성용.
@@ -459,6 +463,11 @@ pub const BundleResult = struct {
                 allocator.free(o.contents);
             }
             allocator.free(outs);
+        }
+        if (self.rn_asset_metadata) |metas| {
+            const graph_assets = @import("graph/assets.zig");
+            for (metas) |m| graph_assets.freeRnAssetMetadata(allocator, m);
+            allocator.free(metas);
         }
         if (self.metafile_json) |mf| allocator.free(mf);
     }
@@ -1546,6 +1555,14 @@ pub const Bundler = struct {
         lifecycle_runner.runBuildEnd(first_err);
         lifecycle_runner.runCloseBundle();
 
+        // RN asset metadata ownership 을 graph → BundleResult 로 transfer.
+        // graph.deinit 가 list 만 free 하고 strings 는 BundleResult.deinit 이 회수.
+        const rn_asset_metadata_out: ?[]@import("graph/assets.zig").RnAssetMetadata =
+            if (graph.rn_asset_metadata.items.len > 0)
+                try graph.rn_asset_metadata.toOwnedSlice(self.allocator)
+            else
+                null;
+
         return .{
             .output = output,
             .sourcemap = dev_sourcemap,
@@ -1555,6 +1572,7 @@ pub const Bundler = struct {
             .module_paths = module_paths,
             .module_dev_codes = module_dev_codes,
             .asset_outputs = final_asset_outputs,
+            .rn_asset_metadata = rn_asset_metadata_out,
             .metafile_json = metafile_json,
             .timings = .{
                 .graph_ns = t_graph,

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -157,6 +157,12 @@ pub const ModuleGraph = struct {
     /// Worker 엔트리: new Worker(new URL(...)) 패턴에서 수집된 worker 파일 경로.
     /// 메인 그래프에는 모듈로 추가하지 않고, bundler에서 별도 빌드한다.
     worker_entries: std.ArrayList(WorkerEntry) = .empty,
+    /// RN AssetRegistry.registerAsset 호출에 emit 된 asset metadata 수집.
+    /// loader 가 emit 시점에 push, bundler 가 BundleResult.rn_asset_metadata 로 expose.
+    /// strings 는 graph.allocator 소유 (loader arena 가 free 되어도 안전하도록 dupe).
+    rn_asset_metadata: std.ArrayListUnmanaged(@import("graph/assets.zig").RnAssetMetadata) = .empty,
+    /// rn_asset_metadata 병렬 append 보호 (scanWorker 호출 대응).
+    rn_asset_metadata_mutex: std.Thread.Mutex = .{},
 
     /// `worklet "directive"` plugin 활성 여부 — bundler 가 BundleOptions.worklet_transform 으로 set.
     /// graph 가 직접 사용 (parseModule 의 worklet exclude 휴리스틱).

--- a/src/bundler/graph/assets.zig
+++ b/src/bundler/graph/assets.zig
@@ -156,8 +156,55 @@ pub fn applyAssetNamingPattern(
     return buf.toOwnedSlice(allocator);
 }
 
-/// Metro AssetRegistry.registerAsset() 호출식을 생성.
-/// RN 런타임은 이 객체의 키를 정확히 요구하므로 shape를 Metro 1:1로 맞춘다.
+/// RN bundle 결과로 expose 되는 asset metadata. strings 는 emit 시점에 사용한
+/// allocator (loader 의 module parse_arena) 소유 — caller (graph) 가 long-lived
+/// allocator 로 dupe 해 BundleResult 까지 lifetime 연장.
+pub const RnAssetMetadata = struct {
+    http_server_location: []const u8,
+    file_system_location: []const u8,
+    name: []const u8,
+    type_name: []const u8,
+    hash_hex: []const u8,
+    scales: []const u32,
+    width: u32,
+    height: u32,
+};
+
+pub const EmittedAsset = struct {
+    source: []const u8,
+    metadata: RnAssetMetadata,
+};
+
+/// loader arena 소유 metadata 를 long-lived allocator 로 dupe.
+/// BundleResult lifetime 동안 strings 가 살아남도록 graph allocator 에 owned copy 생성.
+pub fn cloneRnAssetMetadata(
+    allocator: std.mem.Allocator,
+    meta: RnAssetMetadata,
+) !RnAssetMetadata {
+    return .{
+        .http_server_location = try allocator.dupe(u8, meta.http_server_location),
+        .file_system_location = try allocator.dupe(u8, meta.file_system_location),
+        .name = try allocator.dupe(u8, meta.name),
+        .type_name = try allocator.dupe(u8, meta.type_name),
+        .hash_hex = try allocator.dupe(u8, meta.hash_hex),
+        .scales = try allocator.dupe(u32, meta.scales),
+        .width = meta.width,
+        .height = meta.height,
+    };
+}
+
+pub fn freeRnAssetMetadata(allocator: std.mem.Allocator, meta: RnAssetMetadata) void {
+    allocator.free(meta.http_server_location);
+    allocator.free(meta.file_system_location);
+    allocator.free(meta.name);
+    allocator.free(meta.type_name);
+    allocator.free(meta.hash_hex);
+    allocator.free(meta.scales);
+}
+
+/// Metro AssetRegistry.registerAsset() 호출식 + asset metadata 를 생성.
+/// RN 런타임은 호출식 객체의 키를 정확히 요구하므로 shape 를 Metro 1:1 로 맞춘다.
+/// metadata 는 mjs 측 release asset copy 가 string parse 없이 직접 받기 위한 사이드채널.
 pub fn emitAssetRegistryCall(
     alloc: std.mem.Allocator,
     registry_path: []const u8,
@@ -169,7 +216,7 @@ pub fn emitAssetRegistryCall(
     url: []const u8,
     scales: []const u32,
     project_root: []const u8,
-) ![]const u8 {
+) !EmittedAsset {
     const dims = asset_meta.extractDimensions(bytes);
     const width = if (dims) |d| d.width else 0;
     const height = if (dims) |d| d.height else 0;
@@ -202,7 +249,7 @@ pub fn emitAssetRegistryCall(
     _ = hash;
     var md5_digest: [16]u8 = undefined;
     std.crypto.hash.Md5.hash(bytes, &md5_digest, .{});
-    var hash_hex: [32]u8 = undefined;
+    const hash_hex = try alloc.alloc(u8, 32);
     const hex_chars = "0123456789abcdef";
     for (md5_digest, 0..) |b, i| {
         hash_hex[i * 2] = hex_chars[b >> 4];
@@ -221,7 +268,7 @@ pub fn emitAssetRegistryCall(
     sw.writeByte(']') catch return error.OutOfMemory;
     const scales_str = scales_stream.getWritten();
 
-    return try std.fmt.allocPrint(alloc,
+    const source = try std.fmt.allocPrint(alloc,
         \\module.exports = require("{s}").registerAsset({{
         \\  "__packager_asset": true,
         \\  "httpServerLocation": "{s}",
@@ -233,7 +280,21 @@ pub fn emitAssetRegistryCall(
         \\  "type": "{s}",
         \\  "fileSystemLocation": "{s}"
         \\}})
-    , .{ registry_esc, http_loc, width, height, scales_str, &hash_hex, name_esc, type_name, fs_dir });
+    , .{ registry_esc, http_loc, width, height, scales_str, hash_hex, name_esc, type_name, fs_dir });
+
+    return .{
+        .source = source,
+        .metadata = .{
+            .http_server_location = http_loc_raw,
+            .file_system_location = fs_dir_raw,
+            .name = name_without_ext,
+            .type_name = type_name,
+            .hash_hex = hash_hex,
+            .scales = scales,
+            .width = width,
+            .height = height,
+        },
+    };
 }
 
 pub const ScaleCollection = struct {

--- a/src/bundler/graph/lifecycle.zig
+++ b/src/bundler/graph/lifecycle.zig
@@ -45,6 +45,11 @@ pub fn deinit(self: *ModuleGraph) void {
         self.allocator.free(we.resolved_path);
     }
     self.worker_entries.deinit(self.allocator);
+    const graph_assets = @import("assets.zig");
+    for (self.rn_asset_metadata.items) |meta| {
+        graph_assets.freeRnAssetMetadata(self.allocator, meta);
+    }
+    self.rn_asset_metadata.deinit(self.allocator);
     if (self.plugins_with_helpers) |p| self.allocator.free(p);
     self.runtime_polyfill_roots.deinit(self.allocator);
 }

--- a/src/bundler/graph/loaders.zig
+++ b/src/bundler/graph/loaders.zig
@@ -141,10 +141,21 @@ pub fn parseAssetModule(self: *ModuleGraph, module: *Module) void {
                 // loader=.javascript는 호출자의 fall-through 신호.
                 // import_scanner가 source의 require()를 ImportRecord로 추출하고
                 // wrap_kind/exports_kind를 .cjs로 자동 결정한다.
-                module.source = emitAssetRegistryCall(arena_alloc, registry_path, module.path, raw, &hash, ext, name_without_ext, url, scales_result.scales, self.project_root) catch {
+                const emitted = emitAssetRegistryCall(arena_alloc, registry_path, module.path, raw, &hash, ext, name_without_ext, url, scales_result.scales, self.project_root) catch {
                     module.state = .ready;
                     return;
                 };
+                module.source = emitted.source;
+                // metadata 를 graph allocator 로 dupe — BundleResult 가 string parse 없이
+                // rn-asset-copy 에 직접 전달 (#3216 후속). loader arena 가 module 종료 시
+                // 회수되어도 BundleResult lifetime 까지 살아남도록.
+                if (graph_assets.cloneRnAssetMetadata(self.allocator, emitted.metadata)) |owned| {
+                    self.rn_asset_metadata_mutex.lock();
+                    self.rn_asset_metadata.append(self.allocator, owned) catch {
+                        graph_assets.freeRnAssetMetadata(self.allocator, owned);
+                    };
+                    self.rn_asset_metadata_mutex.unlock();
+                } else |_| {}
                 module.module_type = .js;
                 module.loader = .javascript;
                 return;


### PR DESCRIPTION
## Summary

#3216 `/simplify` 의 마지막 보류 항목. `rn-asset-copy` 의 hand-rolled JS 파서 (`findMatchingBrace` + `JSON.parse` 로 bundle string 안 `registerAsset({...})` 추출) 를 bundler 가 emit 시점에 이미 알고 있는 metadata 를 NAPI 로 직접 노출하는 API 로 대체.

기존: bundle output string → mjs hand-rolled parser → `RnAsset[]`
변경: bundler 가 metadata 보관 → NAPI 직렬화 → `result.rnAssetMetadata`

### Zig 측

- `graph/assets.zig`: `RnAssetMetadata` struct + `EmittedAsset { source, metadata }`. `emitAssetRegistryCall` 이 source string 과 함께 raw metadata 반환. `cloneRnAssetMetadata` / `freeRnAssetMetadata` helpers.
- `graph.zig`: `ModuleGraph.rn_asset_metadata: ArrayListUnmanaged` 추가 + 병렬 push 보호 mutex (scanWorker 호출 대응).
- `graph/loaders.zig`: emit 후 graph allocator 로 dupe 해 list 에 append.
- `graph/lifecycle.zig`: list 회수.
- `bundler.zig`: `BundleResult.rn_asset_metadata` 노출. build() 끝에서 graph 의 list 를 `toOwnedSlice` 로 transfer — graph.deinit 가 free 시도하지 않도록 ownership 이전. `BundleResult.deinit` 가 strings + scales slice 회수.

### NAPI bridge

- `packages/core/src/napi/result.zig`: `rn_asset_metadata` 를 JS object 배열 `result.rnAssetMetadata` 로 직렬화. 필드: httpServerLocation / fileSystemLocation / name / type / hash / width / height / scales.

### TS / mjs

- `packages/core/index.ts`: `RnAssetMetadata` interface export. `NativeBuildResult` + `BuildResult` 에 `rnAssetMetadata?` 추가.
- `packages/core/bin/rn-asset-copy.mjs`: `extractRegisteredAssets` / `findMatchingBrace` / `isRegisteredAsset` 전부 제거. `copyRnAssets({ assets })` 가 metadata 배열을 직접 받음.
- `packages/core/bin/zntc.mjs`: `result.rnAssetMetadata` 를 그대로 전달.
- 테스트: bundleCode fixture 모두 제거 → metadata 객체 직접 구성.

## Background — Zig 초보자에게

- `ArrayListUnmanaged` — Zig 의 표준 동적 배열. `Unmanaged` 는 allocator 를 멤버로 저장하지 않고 매 호출시 받는 변종. graph 같이 allocator 가 명확한 컨테이너에 자주 사용.
- ownership transfer — `toOwnedSlice(allocator)` 는 내부 buffer 의 ownership 을 caller 에게 넘기고 list 를 비움. 두 곳에서 같은 메모리를 free 하지 않도록 `BundleResult` 와 `ModuleGraph` 의 lifetime 을 분리하는 표준 패턴.
- mutex — `scanWorker` 가 worker pool 에서 병렬로 loader 를 호출하므로 list append 는 보호 필요. asset 모듈 자체는 흔하지 않아 contention 미미.

## Test plan

- [x] `zig build test` 전체 통과 (asset 관련 회귀 없음)
- [x] `bun test rn-asset-copy.test.ts` 통과 (13 pass / 0 fail) — 새 API shape 회귀
- [x] `bun run fmt` / `zig fmt` 적용
- [x] pre-push lint/fmt 통과
- [x] 로컬 NAPI rebuild (`zig build napi`) 통과 — CI 의 `NAPI Build & Test` job 이 검증

## Follow-up

- 별도 native binary (`packages/core-darwin-arm64/zntc.node`) 는 본 PR scope 밖. CI 의 NAPI Build 가 검증하고 release pipeline 이 platform-specific 패키지에 반영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)