### PR TITLE
refactor(rn-asset): tighten metadata wire-up after simplify follow-up

### DIFF
--- a/packages/core/src/napi/result.zig
+++ b/packages/core/src/napi/result.zig
@@ -205,9 +205,7 @@ pub fn buildResultToJS(env: c.napi_env, result: *const bundler_mod.BundleResult,
         _ = c.napi_set_named_property(env, js_result, "modulePaths", js_paths);
     }
 
-    // RN AssetRegistry.registerAsset metadata (#3216 후속). bundle string 을
-    // hand-rolled 파싱하던 `rn-asset-copy` 의 `extractRegisteredAssets` 가 이 배열을
-    // 직접 받아 release asset 복사에 사용.
+    // mjs `rn-asset-copy` 가 release asset 복사를 위해 이 배열을 직접 소비.
     if (result.rn_asset_metadata) |metas| {
         var js_metas: c.napi_value = undefined;
         _ = c.napi_create_array_with_length(env, metas.len, &js_metas);
@@ -215,27 +213,13 @@ pub fn buildResultToJS(env: c.napi_env, result: *const bundler_mod.BundleResult,
             var js_m: c.napi_value = undefined;
             _ = c.napi_create_object(env, &js_m);
 
-            var js_str: c.napi_value = undefined;
-            _ = c.napi_create_string_utf8(env, m.http_server_location.ptr, m.http_server_location.len, &js_str);
-            _ = c.napi_set_named_property(env, js_m, "httpServerLocation", js_str);
-
-            _ = c.napi_create_string_utf8(env, m.file_system_location.ptr, m.file_system_location.len, &js_str);
-            _ = c.napi_set_named_property(env, js_m, "fileSystemLocation", js_str);
-
-            _ = c.napi_create_string_utf8(env, m.name.ptr, m.name.len, &js_str);
-            _ = c.napi_set_named_property(env, js_m, "name", js_str);
-
-            _ = c.napi_create_string_utf8(env, m.type_name.ptr, m.type_name.len, &js_str);
-            _ = c.napi_set_named_property(env, js_m, "type", js_str);
-
-            _ = c.napi_create_string_utf8(env, m.hash_hex.ptr, m.hash_hex.len, &js_str);
-            _ = c.napi_set_named_property(env, js_m, "hash", js_str);
-
-            var js_num: c.napi_value = undefined;
-            _ = c.napi_create_uint32(env, m.width, &js_num);
-            _ = c.napi_set_named_property(env, js_m, "width", js_num);
-            _ = c.napi_create_uint32(env, m.height, &js_num);
-            _ = c.napi_set_named_property(env, js_m, "height", js_num);
+            common.setStringProp(env, js_m, "httpServerLocation", m.http_server_location);
+            common.setStringProp(env, js_m, "fileSystemLocation", m.file_system_location);
+            common.setStringProp(env, js_m, "name", m.name);
+            common.setStringProp(env, js_m, "type", m.type_name);
+            common.setStringProp(env, js_m, "hash", m.hash_hex);
+            common.setUint32Prop(env, js_m, "width", m.width);
+            common.setUint32Prop(env, js_m, "height", m.height);
 
             var js_scales: c.napi_value = undefined;
             _ = c.napi_create_array_with_length(env, m.scales.len, &js_scales);

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -23,6 +23,8 @@ const Platform = @import("resolve_cache.zig").Platform;
 const emitter = @import("emitter.zig");
 const EmitOptions = emitter.EmitOptions;
 const OutputFile = emitter.OutputFile;
+const graph_assets = @import("graph/assets.zig");
+pub const RnAssetMetadata = graph_assets.RnAssetMetadata;
 const chunk_mod = @import("chunk.zig");
 const linker_mod = @import("linker.zig");
 const Linker = linker_mod.Linker;
@@ -385,9 +387,9 @@ pub const BundleResult = struct {
     /// JS 청크와 별도로 출력 디렉토리에 복사해야 하는 파일들.
     asset_outputs: ?[]OutputFile = null,
     /// RN AssetRegistry.registerAsset 호출에 emit 된 asset metadata.
-    /// `rn-asset-copy` 가 bundle string 을 hand-rolled 파싱하지 않고 직접 사용.
+    /// `rn-asset-copy` 가 bundle string 파싱 없이 직접 사용.
     /// allocator 소유 (strings + scales slice).
-    rn_asset_metadata: ?[]@import("graph/assets.zig").RnAssetMetadata = null,
+    rn_asset_metadata: ?[]RnAssetMetadata = null,
     /// metafile JSON (--metafile). allocator 소유.
     metafile_json: ?[]const u8 = null,
     /// 파이프라인 단계별 타이밍 (ns). 항상 측정 — 워치 모드 관측성용.
@@ -465,7 +467,6 @@ pub const BundleResult = struct {
             allocator.free(outs);
         }
         if (self.rn_asset_metadata) |metas| {
-            const graph_assets = @import("graph/assets.zig");
             for (metas) |m| graph_assets.freeRnAssetMetadata(allocator, m);
             allocator.free(metas);
         }
@@ -1556,8 +1557,8 @@ pub const Bundler = struct {
         lifecycle_runner.runCloseBundle();
 
         // RN asset metadata ownership 을 graph → BundleResult 로 transfer.
-        // graph.deinit 가 list 만 free 하고 strings 는 BundleResult.deinit 이 회수.
-        const rn_asset_metadata_out: ?[]@import("graph/assets.zig").RnAssetMetadata =
+        // graph.deinit 의 free 루프는 toOwnedSlice 후 비어있는 list 를 만남.
+        const rn_asset_metadata_out: ?[]RnAssetMetadata =
             if (graph.rn_asset_metadata.items.len > 0)
                 try graph.rn_asset_metadata.toOwnedSlice(self.allocator)
             else

--- a/src/bundler/graph/assets.zig
+++ b/src/bundler/graph/assets.zig
@@ -177,17 +177,29 @@ pub const EmittedAsset = struct {
 
 /// loader arena 소유 metadata 를 long-lived allocator 로 dupe.
 /// BundleResult lifetime 동안 strings 가 살아남도록 graph allocator 에 owned copy 생성.
+/// 중간 dupe 가 OOM 으로 실패해도 앞서 할당한 strings 가 leak 되지 않도록 errdefer 가드.
 pub fn cloneRnAssetMetadata(
     allocator: std.mem.Allocator,
     meta: RnAssetMetadata,
 ) !RnAssetMetadata {
+    const http_loc = try allocator.dupe(u8, meta.http_server_location);
+    errdefer allocator.free(http_loc);
+    const fs_loc = try allocator.dupe(u8, meta.file_system_location);
+    errdefer allocator.free(fs_loc);
+    const name_owned = try allocator.dupe(u8, meta.name);
+    errdefer allocator.free(name_owned);
+    const type_name_owned = try allocator.dupe(u8, meta.type_name);
+    errdefer allocator.free(type_name_owned);
+    const hash_hex_owned = try allocator.dupe(u8, meta.hash_hex);
+    errdefer allocator.free(hash_hex_owned);
+    const scales_owned = try allocator.dupe(u32, meta.scales);
     return .{
-        .http_server_location = try allocator.dupe(u8, meta.http_server_location),
-        .file_system_location = try allocator.dupe(u8, meta.file_system_location),
-        .name = try allocator.dupe(u8, meta.name),
-        .type_name = try allocator.dupe(u8, meta.type_name),
-        .hash_hex = try allocator.dupe(u8, meta.hash_hex),
-        .scales = try allocator.dupe(u32, meta.scales),
+        .http_server_location = http_loc,
+        .file_system_location = fs_loc,
+        .name = name_owned,
+        .type_name = type_name_owned,
+        .hash_hex = hash_hex_owned,
+        .scales = scales_owned,
         .width = meta.width,
         .height = meta.height,
     };

--- a/src/bundler/graph/loaders.zig
+++ b/src/bundler/graph/loaders.zig
@@ -146,15 +146,15 @@ pub fn parseAssetModule(self: *ModuleGraph, module: *Module) void {
                     return;
                 };
                 module.source = emitted.source;
-                // metadata 를 graph allocator 로 dupe — BundleResult 가 string parse 없이
-                // rn-asset-copy 에 직접 전달 (#3216 후속). loader arena 가 module 종료 시
-                // 회수되어도 BundleResult lifetime 까지 살아남도록.
+                // metadata 는 parse_arena borrow — BundleResult lifetime 까지 살리려면
+                // graph allocator 로 owned copy 가 필요. clone OOM 은 다른 emit 실패와
+                // 동일하게 silent skip — release copy 단계에서 누락이 진단으로 가시화.
                 if (graph_assets.cloneRnAssetMetadata(self.allocator, emitted.metadata)) |owned| {
                     self.rn_asset_metadata_mutex.lock();
+                    defer self.rn_asset_metadata_mutex.unlock();
                     self.rn_asset_metadata.append(self.allocator, owned) catch {
                         graph_assets.freeRnAssetMetadata(self.allocator, owned);
                     };
-                    self.rn_asset_metadata_mutex.unlock();
                 } else |_| {}
                 module.module_type = .js;
                 module.loader = .javascript;


### PR DESCRIPTION
## Summary

#3222 머지 직후 `/simplify` 추가 라운드 결과 4가지 cleanup. 동작 무변경, 안전성/일관성 강화.

### 변경

1. **NAPI bridge — `common` helpers 활용**
   `packages/core/src/napi/result.zig` 의 새 metadata 직렬화가 `setStringProp` / `setUint32Prop` 가 같은 파일에서 이미 import 된 `common.zig` 에 있는 줄 모르고 raw `napi_create_string_utf8` + `napi_set_named_property` 를 14줄 손작성. 7줄로 축소.

2. **`cloneRnAssetMetadata` partial-alloc leak 가드**
   `try allocator.dupe(u8, ...)` 6연속에서 중간 OOM 시 앞서 dupe 한 strings 가 leak. 각 dupe 후 `errdefer allocator.free(...)`.

3. **`loaders.zig` mutex `defer unlock`**
   기존 mutex 사용처 (`graph/diagnostics.zig:20-21`, `graph/package_info.zig:35-36`) 가 `lock(); defer unlock();` 패턴. 새 코드만 inline `unlock()` — 일관성 + `append catch` 안 free 가 향후 mutex 재진입 가능성을 가질 때 lock leak 방어.

4. **`bundler.zig` `RnAssetMetadata` alias**
   필드 타입 + ownership transfer 두 곳에서 `@import("graph/assets.zig").RnAssetMetadata` inline. 상단에 `const graph_assets = @import("graph/assets.zig"); pub const RnAssetMetadata = graph_assets.RnAssetMetadata;` alias 추가 — `OutputFile` 패턴과 일관, deinit 의 inline `@import` 도 제거.

### 보류한 finding

- **strings double-alloc** (parse_arena 에서 emit + graph allocator 로 clone): 해결하려면 `emitAssetRegistryCall` 시그니처가 `(arena_alloc, graph_alloc)` 두 allocator 를 받아야 함. 50 bytes/asset 절감 vs 시그니처 침습 → 별도 PR scope.
- **`type_name` static literal 캐싱**: 4개 known type 은 `'static` literal 이라 dupe 불필요. micro-opt + 복잡도 증가 → 보류.
- **`cloneRnAssetMetadata` comptime field iteration**: 필드 타입이 `[]const u8` / `[]const u32` / scalar 로 섞여 있어 comptime branching 이 explicit 보다 덜 읽힘 → 보류.

### Background — Zig 초보자에게

- `errdefer` 는 `defer` 와 비슷하지만 함수가 error 로 반환할 때만 실행. partial-alloc 패턴의 표준 안전망 — 성공 경로에선 free 되지 않고 caller 에게 ownership 이전.
- `pub const X = @import(...).X` 는 alias re-export. 다른 모듈이 `bundler.RnAssetMetadata` 로 참조 가능 + 같은 모듈 안에서 `@import` path 가 한 곳에만 노출.

## Test plan

- [x] `zig build test` 전체 통과
- [x] `bun test rn-asset-copy.test.ts`: 13 pass / 0 fail
- [x] `bun run fmt` / `zig fmt` / pre-push 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)