### PR TITLE
perf(rn-asset): emit directly into metadata allocator, drop clone step

### DIFF
--- a/src/bundler/graph/assets.zig
+++ b/src/bundler/graph/assets.zig
@@ -156,9 +156,9 @@ pub fn applyAssetNamingPattern(
     return buf.toOwnedSlice(allocator);
 }
 
-/// RN bundle 결과로 expose 되는 asset metadata. strings 는 emit 시점에 사용한
-/// allocator (loader 의 module parse_arena) 소유 — caller (graph) 가 long-lived
-/// allocator 로 dupe 해 BundleResult 까지 lifetime 연장.
+/// RN bundle 결과로 expose 되는 asset metadata. strings + scales 는 emit 시
+/// caller 가 전달한 `metadata_alloc` (BundleResult 까지 살아남는 long-lived
+/// allocator) 직접 소유 — clone 단계 없이 그대로 list 에 push 가능.
 pub const RnAssetMetadata = struct {
     http_server_location: []const u8,
     file_system_location: []const u8,
@@ -175,36 +175,6 @@ pub const EmittedAsset = struct {
     metadata: RnAssetMetadata,
 };
 
-/// loader arena 소유 metadata 를 long-lived allocator 로 dupe.
-/// BundleResult lifetime 동안 strings 가 살아남도록 graph allocator 에 owned copy 생성.
-/// 중간 dupe 가 OOM 으로 실패해도 앞서 할당한 strings 가 leak 되지 않도록 errdefer 가드.
-pub fn cloneRnAssetMetadata(
-    allocator: std.mem.Allocator,
-    meta: RnAssetMetadata,
-) !RnAssetMetadata {
-    const http_loc = try allocator.dupe(u8, meta.http_server_location);
-    errdefer allocator.free(http_loc);
-    const fs_loc = try allocator.dupe(u8, meta.file_system_location);
-    errdefer allocator.free(fs_loc);
-    const name_owned = try allocator.dupe(u8, meta.name);
-    errdefer allocator.free(name_owned);
-    const type_name_owned = try allocator.dupe(u8, meta.type_name);
-    errdefer allocator.free(type_name_owned);
-    const hash_hex_owned = try allocator.dupe(u8, meta.hash_hex);
-    errdefer allocator.free(hash_hex_owned);
-    const scales_owned = try allocator.dupe(u32, meta.scales);
-    return .{
-        .http_server_location = http_loc,
-        .file_system_location = fs_loc,
-        .name = name_owned,
-        .type_name = type_name_owned,
-        .hash_hex = hash_hex_owned,
-        .scales = scales_owned,
-        .width = meta.width,
-        .height = meta.height,
-    };
-}
-
 pub fn freeRnAssetMetadata(allocator: std.mem.Allocator, meta: RnAssetMetadata) void {
     allocator.free(meta.http_server_location);
     allocator.free(meta.file_system_location);
@@ -215,10 +185,12 @@ pub fn freeRnAssetMetadata(allocator: std.mem.Allocator, meta: RnAssetMetadata) 
 }
 
 /// Metro AssetRegistry.registerAsset() 호출식 + asset metadata 를 생성.
-/// RN 런타임은 호출식 객체의 키를 정확히 요구하므로 shape 를 Metro 1:1 로 맞춘다.
-/// metadata 는 mjs 측 release asset copy 가 string parse 없이 직접 받기 위한 사이드채널.
+/// `source_alloc`: emit JS source (module.source) 의 backing — 보통 module parse_arena.
+/// `metadata_alloc`: metadata struct 의 strings + scales backing — BundleResult 까지
+/// 살아남아야 하므로 graph allocator (long-lived). errdefer 가 partial-alloc leak 방지.
 pub fn emitAssetRegistryCall(
-    alloc: std.mem.Allocator,
+    source_alloc: std.mem.Allocator,
+    metadata_alloc: std.mem.Allocator,
     registry_path: []const u8,
     abs_path: []const u8,
     bytes: []const u8,
@@ -233,40 +205,57 @@ pub fn emitAssetRegistryCall(
     const width = if (dims) |d| d.width else 0;
     const height = if (dims) |d| d.height else 0;
     const asset_type = asset_meta.AssetType.fromExtension(ext);
-    const type_name = asset_type.typeName(ext);
+    const type_name_borrow = asset_type.typeName(ext);
 
-    // Metro 호환: httpServerLocation = `/assets/` + projectRoot 기준 상대 경로의 dirname.
+    // Metadata strings 를 metadata_alloc 으로 직접 alloc — 별도 clone 단계 제거.
+    // Metro 호환: httpServerLocation = `/assets/` + projectRoot 기준 dirname.
     // RN 런타임이 `<dev-server>:<port><httpServerLocation>/<name>.<hash>.<type>` 형태로
-    // URL을 만들기 때문에 `.`만 있으면 dev server가 파일을 찾지 못한다 (#1428).
-    const http_loc_raw = blk: {
-        if (project_root.len == 0) break :blk std.fs.path.dirname(url) orelse ".";
-        const rel = std.fs.path.relative(alloc, project_root, abs_path) catch break :blk ".";
-        defer alloc.free(rel);
+    // URL 을 만들기 때문에 `.` 만 있으면 dev server 가 파일을 찾지 못한다 (#1428).
+    const http_loc_owned = blk: {
+        if (project_root.len == 0) {
+            const d = std.fs.path.dirname(url) orelse ".";
+            break :blk try metadata_alloc.dupe(u8, d);
+        }
+        const rel = std.fs.path.relative(metadata_alloc, project_root, abs_path) catch {
+            break :blk try metadata_alloc.dupe(u8, ".");
+        };
+        defer metadata_alloc.free(rel);
         const rel_dir = std.fs.path.dirname(rel) orelse ".";
-        break :blk std.fmt.allocPrint(alloc, "/assets/{s}", .{rel_dir}) catch ".";
+        break :blk try std.fmt.allocPrint(metadata_alloc, "/assets/{s}", .{rel_dir});
     };
-    const fs_dir_raw = std.fs.path.dirname(abs_path) orelse ".";
+    errdefer metadata_alloc.free(http_loc_owned);
 
-    // 사용자 경로/식별자에 따옴표·역슬래시·개행이 포함되면 JSON 파싱이 깨지므로 escape 필수.
-    // RN/Metro에서 파일명에 특수문자 있을 가능성은 낮지만 안전하게 처리.
-    const http_loc = try escapeJsString(alloc, http_loc_raw);
-    const fs_dir = try escapeJsString(alloc, fs_dir_raw);
-    const name_esc = try escapeJsString(alloc, name_without_ext);
-    const registry_esc = try escapeJsString(alloc, registry_path);
+    const fs_dir_owned = try metadata_alloc.dupe(u8, std.fs.path.dirname(abs_path) orelse ".");
+    errdefer metadata_alloc.free(fs_dir_owned);
+    const name_owned = try metadata_alloc.dupe(u8, name_without_ext);
+    errdefer metadata_alloc.free(name_owned);
+    const type_name_owned = try metadata_alloc.dupe(u8, type_name_borrow);
+    errdefer metadata_alloc.free(type_name_owned);
 
-    // Metro 호환: asset hash는 raw bytes의 MD5 32자 hex (Metro `Assets.js`의 hashFiles 결과).
-    // RN 런타임/빌드 시스템이 캐시 키, 디스크 자산명 등에서 32자를 가정하므로
-    // 8byte wyhash hex로는 충돌 확률 + Metro 호환성 모두 부족 (#1428).
-    // 인자의 hash(`*const [8]u8`)는 기존 caller 호환을 위해 남겨두지만 미사용.
+    // Metro 호환: asset hash 는 raw bytes 의 MD5 32 hex (Metro `Assets.js` hashFiles).
+    // RN 런타임/빌드 시스템이 캐시 키, 디스크 자산명 등에서 32 hex 를 가정하므로
+    // 8 byte wyhash 로는 충돌 확률 + Metro 호환성 모두 부족 (#1428).
+    // 인자의 hash(`*const [8]u8`) 는 기존 caller 호환을 위해 남겨두지만 미사용.
     _ = hash;
     var md5_digest: [16]u8 = undefined;
     std.crypto.hash.Md5.hash(bytes, &md5_digest, .{});
-    const hash_hex = try alloc.alloc(u8, 32);
+    const hash_hex_owned = try metadata_alloc.alloc(u8, 32);
+    errdefer metadata_alloc.free(hash_hex_owned);
     const hex_chars = "0123456789abcdef";
     for (md5_digest, 0..) |b, i| {
-        hash_hex[i * 2] = hex_chars[b >> 4];
-        hash_hex[i * 2 + 1] = hex_chars[b & 0x0F];
+        hash_hex_owned[i * 2] = hex_chars[b >> 4];
+        hash_hex_owned[i * 2 + 1] = hex_chars[b & 0x0F];
     }
+
+    const scales_owned = try metadata_alloc.dupe(u32, scales);
+    errdefer metadata_alloc.free(scales_owned);
+
+    // 사용자 경로/식별자에 따옴표·역슬래시·개행이 포함되면 JSON 파싱이 깨지므로 escape 필수.
+    // escape 결과 strings 는 source 생성에만 필요하므로 source_alloc — module 종료 시 회수.
+    const http_loc_esc = try escapeJsString(source_alloc, http_loc_owned);
+    const fs_dir_esc = try escapeJsString(source_alloc, fs_dir_owned);
+    const name_esc = try escapeJsString(source_alloc, name_without_ext);
+    const registry_esc = try escapeJsString(source_alloc, registry_path);
 
     // scales 배열 직렬화. 일반적으로 [1,2,3] 정도라 스택 버퍼로 충분.
     var scales_stack_buf: [128]u8 = undefined;
@@ -280,7 +269,7 @@ pub fn emitAssetRegistryCall(
     sw.writeByte(']') catch return error.OutOfMemory;
     const scales_str = scales_stream.getWritten();
 
-    const source = try std.fmt.allocPrint(alloc,
+    const source = try std.fmt.allocPrint(source_alloc,
         \\module.exports = require("{s}").registerAsset({{
         \\  "__packager_asset": true,
         \\  "httpServerLocation": "{s}",
@@ -292,17 +281,17 @@ pub fn emitAssetRegistryCall(
         \\  "type": "{s}",
         \\  "fileSystemLocation": "{s}"
         \\}})
-    , .{ registry_esc, http_loc, width, height, scales_str, hash_hex, name_esc, type_name, fs_dir });
+    , .{ registry_esc, http_loc_esc, width, height, scales_str, hash_hex_owned, name_esc, type_name_borrow, fs_dir_esc });
 
     return .{
         .source = source,
         .metadata = .{
-            .http_server_location = http_loc_raw,
-            .file_system_location = fs_dir_raw,
-            .name = name_without_ext,
-            .type_name = type_name,
-            .hash_hex = hash_hex,
-            .scales = scales,
+            .http_server_location = http_loc_owned,
+            .file_system_location = fs_dir_owned,
+            .name = name_owned,
+            .type_name = type_name_owned,
+            .hash_hex = hash_hex_owned,
+            .scales = scales_owned,
             .width = width,
             .height = height,
         },

--- a/src/bundler/graph/loaders.zig
+++ b/src/bundler/graph/loaders.zig
@@ -141,21 +141,18 @@ pub fn parseAssetModule(self: *ModuleGraph, module: *Module) void {
                 // loader=.javascript는 호출자의 fall-through 신호.
                 // import_scanner가 source의 require()를 ImportRecord로 추출하고
                 // wrap_kind/exports_kind를 .cjs로 자동 결정한다.
-                const emitted = emitAssetRegistryCall(arena_alloc, registry_path, module.path, raw, &hash, ext, name_without_ext, url, scales_result.scales, self.project_root) catch {
+                // source 는 arena_alloc (module parse_arena), metadata 는 self.allocator
+                // (graph) — emit 가 두 allocator 에 직접 alloc 해 clone 단계 제거.
+                const emitted = emitAssetRegistryCall(arena_alloc, self.allocator, registry_path, module.path, raw, &hash, ext, name_without_ext, url, scales_result.scales, self.project_root) catch {
                     module.state = .ready;
                     return;
                 };
                 module.source = emitted.source;
-                // metadata 는 parse_arena borrow — BundleResult lifetime 까지 살리려면
-                // graph allocator 로 owned copy 가 필요. clone OOM 은 다른 emit 실패와
-                // 동일하게 silent skip — release copy 단계에서 누락이 진단으로 가시화.
-                if (graph_assets.cloneRnAssetMetadata(self.allocator, emitted.metadata)) |owned| {
-                    self.rn_asset_metadata_mutex.lock();
-                    defer self.rn_asset_metadata_mutex.unlock();
-                    self.rn_asset_metadata.append(self.allocator, owned) catch {
-                        graph_assets.freeRnAssetMetadata(self.allocator, owned);
-                    };
-                } else |_| {}
+                self.rn_asset_metadata_mutex.lock();
+                defer self.rn_asset_metadata_mutex.unlock();
+                self.rn_asset_metadata.append(self.allocator, emitted.metadata) catch {
+                    graph_assets.freeRnAssetMetadata(self.allocator, emitted.metadata);
+                };
                 module.module_type = .js;
                 module.loader = .javascript;
                 return;


### PR DESCRIPTION
## Summary

이전 PR (#3223) 의 /simplify 에서 보류했던 두 항목을 한 번에 처리:

1. **strings double-alloc 제거** — emit 시 parse_arena 와 graph allocator 양쪽에 alloc 되던 metadata strings 를 graph allocator 한 곳에만 alloc.
2. **`type_name` dupe** — 위 변경의 자연스러운 결과로 conditional dupe 분기 없이 단일 dupe.

### 변경 핵심

`emitAssetRegistryCall` 시그니처:

```zig
// Before: 단일 allocator — caller (loaders.zig) 가 metadata 를 또 clone.
pub fn emitAssetRegistryCall(alloc, registry_path, abs_path, ...) !EmittedAsset

// After: 두 allocator 분리.
pub fn emitAssetRegistryCall(
    source_alloc: Allocator,    // module.source 의 backing (parse_arena)
    metadata_alloc: Allocator,  // metadata strings + scales (graph allocator)
    registry_path, abs_path, ...
) !EmittedAsset
```

`loaders.zig` 의 caller:
```zig
// Before
const emitted = emitAssetRegistryCall(arena_alloc, ...);
if (graph_assets.cloneRnAssetMetadata(self.allocator, emitted.metadata)) |owned| {
    self.rn_asset_metadata_mutex.lock();
    defer self.rn_asset_metadata_mutex.unlock();
    self.rn_asset_metadata.append(self.allocator, owned) catch {
        graph_assets.freeRnAssetMetadata(self.allocator, owned);
    };
} else |_| {}

// After
const emitted = emitAssetRegistryCall(arena_alloc, self.allocator, ...);
self.rn_asset_metadata_mutex.lock();
defer self.rn_asset_metadata_mutex.unlock();
self.rn_asset_metadata.append(self.allocator, emitted.metadata) catch {
    graph_assets.freeRnAssetMetadata(self.allocator, emitted.metadata);
};
```

### 효과

- `cloneRnAssetMetadata` helper 완전 제거 (caller side clone OOM 분기 동시 제거).
- asset 당 string alloc 횟수: **12 회 → 6 회** (5 strings + 1 scales slice — 각 field 1 회만).
- errdefer 가드가 emit 함수 안에 모여 partial-alloc leak 방어가 한 곳에 정리됨.
- type_name 의 dupe 도 conditional 분기 없이 단일 처리 — 보류 #2 자연 해결.

### 보류 (그대로 유지)

- **comptime field iteration 으로 clone 자동화**: clone 자체가 제거되어 의미 소실.

## Background — Zig 초보자에게

- Zig 의 allocator 는 함수 인자로 명시 전달이 컨벤션. 이전엔 emit 가 단일 `alloc` 만 받아 source 와 metadata 둘 다에 사용. 이번엔 두 allocator 를 받아 lifetime 이 다른 리소스를 분리.
- `source_alloc` 은 module parse_arena — module 의 lifecycle 종료 시 회수.
- `metadata_alloc` 은 graph allocator — BundleResult 로 ownership transfer 후에도 살아남아 mjs caller 가 결과를 소비할 때까지 유효.
- `errdefer` 각 alloc 뒤에 배치 — 중간 alloc 실패 시 앞서 할당된 strings 모두 free.

## Test plan

- [x] `zig build test` 전체 통과
- [x] `bun test rn-asset-copy.test.ts`: 13 pass / 0 fail
- [x] `zig fmt` + pre-push lint/fmt 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)