### PR TITLE
refactor(rn-asset): emit follow-up — borrow escape + arena for temp rel + doc

### DIFF
--- a/src/bundler/graph/assets.zig
+++ b/src/bundler/graph/assets.zig
@@ -11,7 +11,8 @@ const asset_meta = @import("../asset_meta.zig");
 
 /// JS 문자열 리터럴용 이스케이프. \ " \n \r \0 \u2028 \u2029 를 처리한다.
 pub fn escapeJsString(allocator: std.mem.Allocator, input: []const u8) ![]const u8 {
-    // fast path: 이스케이프가 필요한 문자가 없으면 복사만
+    // fast path: 이스케이프가 필요한 문자가 없으면 input 슬라이스 그대로 borrow 반환.
+    // caller 는 결과를 별도 free 하지 말 것 — owned 가 필요하면 명시적 dupe.
     var needs_escape = false;
     for (input) |c| {
         switch (c) {
@@ -26,7 +27,7 @@ pub fn escapeJsString(allocator: std.mem.Allocator, input: []const u8) ![]const 
             else => {},
         }
     }
-    if (!needs_escape) return try allocator.dupe(u8, input);
+    if (!needs_escape) return input;
 
     var buf: std.ArrayList(u8) = .empty;
     try buf.ensureTotalCapacity(allocator, input.len);
@@ -170,6 +171,9 @@ pub const RnAssetMetadata = struct {
     height: u32,
 };
 
+/// `emitAssetRegistryCall` 의 결과. `source` 는 `source_alloc` 소유 (보통 module
+/// parse_arena), `metadata.*` 는 `metadata_alloc` 소유 (long-lived). 두 슬라이스가
+/// 같은 lifetime 아니라는 점에 주의 — 회수 시 각자의 allocator 사용.
 pub const EmittedAsset = struct {
     source: []const u8,
     metadata: RnAssetMetadata,
@@ -185,12 +189,13 @@ pub fn freeRnAssetMetadata(allocator: std.mem.Allocator, meta: RnAssetMetadata) 
 }
 
 /// Metro AssetRegistry.registerAsset() 호출식 + asset metadata 를 생성.
-/// `source_alloc`: emit JS source (module.source) 의 backing — 보통 module parse_arena.
-/// `metadata_alloc`: metadata struct 의 strings + scales backing — BundleResult 까지
-/// 살아남아야 하므로 graph allocator (long-lived). errdefer 가 partial-alloc leak 방지.
+/// 두 allocator 분리 — fs.RealReadFileCache.readFile 의 `(long, short)` 컨벤션 준수:
+/// `metadata_alloc`: metadata strings + scales backing — BundleResult 까지 살아남는 long-lived.
+/// `source_alloc`: emit JS source (module.source) 의 backing — 보통 module parse_arena (short).
+/// errdefer 가 partial-alloc leak 방지.
 pub fn emitAssetRegistryCall(
-    source_alloc: std.mem.Allocator,
     metadata_alloc: std.mem.Allocator,
+    source_alloc: std.mem.Allocator,
     registry_path: []const u8,
     abs_path: []const u8,
     bytes: []const u8,
@@ -205,21 +210,20 @@ pub fn emitAssetRegistryCall(
     const width = if (dims) |d| d.width else 0;
     const height = if (dims) |d| d.height else 0;
     const asset_type = asset_meta.AssetType.fromExtension(ext);
-    const type_name_borrow = asset_type.typeName(ext);
+    const type_name = asset_type.typeName(ext);
 
-    // Metadata strings 를 metadata_alloc 으로 직접 alloc — 별도 clone 단계 제거.
     // Metro 호환: httpServerLocation = `/assets/` + projectRoot 기준 dirname.
     // RN 런타임이 `<dev-server>:<port><httpServerLocation>/<name>.<hash>.<type>` 형태로
     // URL 을 만들기 때문에 `.` 만 있으면 dev server 가 파일을 찾지 못한다 (#1428).
+    // 임시 `rel` 버퍼는 source_alloc (parse_arena) — graph allocator fragmentation 회피.
     const http_loc_owned = blk: {
         if (project_root.len == 0) {
             const d = std.fs.path.dirname(url) orelse ".";
             break :blk try metadata_alloc.dupe(u8, d);
         }
-        const rel = std.fs.path.relative(metadata_alloc, project_root, abs_path) catch {
+        const rel = std.fs.path.relative(source_alloc, project_root, abs_path) catch {
             break :blk try metadata_alloc.dupe(u8, ".");
         };
-        defer metadata_alloc.free(rel);
         const rel_dir = std.fs.path.dirname(rel) orelse ".";
         break :blk try std.fmt.allocPrint(metadata_alloc, "/assets/{s}", .{rel_dir});
     };
@@ -229,7 +233,7 @@ pub fn emitAssetRegistryCall(
     errdefer metadata_alloc.free(fs_dir_owned);
     const name_owned = try metadata_alloc.dupe(u8, name_without_ext);
     errdefer metadata_alloc.free(name_owned);
-    const type_name_owned = try metadata_alloc.dupe(u8, type_name_borrow);
+    const type_name_owned = try metadata_alloc.dupe(u8, type_name);
     errdefer metadata_alloc.free(type_name_owned);
 
     // Metro 호환: asset hash 는 raw bytes 의 MD5 32 hex (Metro `Assets.js` hashFiles).
@@ -251,7 +255,8 @@ pub fn emitAssetRegistryCall(
     errdefer metadata_alloc.free(scales_owned);
 
     // 사용자 경로/식별자에 따옴표·역슬래시·개행이 포함되면 JSON 파싱이 깨지므로 escape 필수.
-    // escape 결과 strings 는 source 생성에만 필요하므로 source_alloc — module 종료 시 회수.
+    // escapeJsString 은 fast path 에서 input slice 를 borrow 반환 — source 임베드용이라
+    // source_alloc lifetime 만 충족하면 됨 (대다수 케이스에 alloc 0).
     const http_loc_esc = try escapeJsString(source_alloc, http_loc_owned);
     const fs_dir_esc = try escapeJsString(source_alloc, fs_dir_owned);
     const name_esc = try escapeJsString(source_alloc, name_without_ext);
@@ -281,7 +286,7 @@ pub fn emitAssetRegistryCall(
         \\  "type": "{s}",
         \\  "fileSystemLocation": "{s}"
         \\}})
-    , .{ registry_esc, http_loc_esc, width, height, scales_str, hash_hex_owned, name_esc, type_name_borrow, fs_dir_esc });
+    , .{ registry_esc, http_loc_esc, width, height, scales_str, hash_hex_owned, name_esc, type_name, fs_dir_esc });
 
     return .{
         .source = source,

--- a/src/bundler/graph/loaders.zig
+++ b/src/bundler/graph/loaders.zig
@@ -141,9 +141,9 @@ pub fn parseAssetModule(self: *ModuleGraph, module: *Module) void {
                 // loader=.javascript는 호출자의 fall-through 신호.
                 // import_scanner가 source의 require()를 ImportRecord로 추출하고
                 // wrap_kind/exports_kind를 .cjs로 자동 결정한다.
-                // source 는 arena_alloc (module parse_arena), metadata 는 self.allocator
-                // (graph) — emit 가 두 allocator 에 직접 alloc 해 clone 단계 제거.
-                const emitted = emitAssetRegistryCall(arena_alloc, self.allocator, registry_path, module.path, raw, &hash, ext, name_without_ext, url, scales_result.scales, self.project_root) catch {
+                // 첫 인자가 metadata_alloc (long-lived, graph), 두번째가 source_alloc
+                // (short-lived, parse_arena) — fs.RealReadFileCache.readFile 컨벤션.
+                const emitted = emitAssetRegistryCall(self.allocator, arena_alloc, registry_path, module.path, raw, &hash, ext, name_without_ext, url, scales_result.scales, self.project_root) catch {
                     module.state = .ready;
                     return;
                 };


### PR DESCRIPTION
## Summary

#3224 머지 후 /simplify 추가 라운드 결과 4가지 cleanup. 동작 무변경.

### 변경

1. **`escapeJsString` fast-path borrow** — needs_escape=false (대다수 케이스) 면 input slice 를 그대로 반환. asset 당 source alloc 4 회 (http_loc/fs_dir/name/registry) 제거. 다른 caller (`sourceFromBytes` text 분기) 도 결과를 즉시 `allocPrint` 에 임베드해 free 하지 않으므로 안전.

2. **`std.fs.path.relative` 의 임시 buffer 를 source_alloc 으로** — graph allocator 의 short-lived churn / fragmentation 회피. parse_arena 가 module 종료 시 일괄 회수.

3. **allocator 인자 순서 통일** — `fs.RealReadFileCache.readFile` 의 `(long, short)` 컨벤션 (`cache_allocator, content_allocator` 순) 과 일치하도록 `emitAssetRegistryCall` 시그니처를 `(metadata_alloc, source_alloc, ...)` 로 재정렬.

4. **`EmittedAsset` ownership doc + 변수명 + narration** —
   - `EmittedAsset` struct 위 doc comment 추가: `source` 는 source_alloc, `metadata.*` 는 metadata_alloc 소유.
   - `type_name_borrow` → `type_name`: codebase 의 `_borrow` suffix 사용 0 회 (`_owned` 는 광범위) — 컨벤션 일탈 해소.
   - 변경 narration 절 (`"별도 clone 단계 제거"`) 제거 — git log 영역.

### 보류 정당

- 6연속 dupe + errdefer 의 ergonomic helper: Zig 관용구, codebase 전반 (`CompiledModule.dupe`, `PluginFailure.init` 등) 에서 동일 패턴.
- 11 args parameter sprawl: call site 1 곳, options struct 화 ROI 낮음.

### Background

- `escapeJsString` 시그니처는 `[]const u8` 반환 그대로 — 호출자가 borrow 인지 owned 인지 신경 안 씀 (어차피 caller 가 free 하지 않음). doc comment 가 fast-path borrow 정책을 명시.
- 모든 caller 가 결과를 `allocPrint` 같은 builder 의 input 으로만 사용 — input slice 가 충분히 살아있으면 borrow 안전.

## Test plan

- [x] `zig build test` 전체 통과
- [x] `bun test rn-asset-copy.test.ts`: 13 pass / 0 fail
- [x] `zig fmt` + pre-push 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)