### PR TITLE
refactor(rn-asset): drop unread width/height/hash from metadata sidechannel

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -104,19 +104,16 @@ interface Diagnostic {
 }
 
 /**
- * RN AssetRegistry.registerAsset 메타데이터 (Metro 호환 shape).
- * `--asset-registry` 사용 시 bundler 가 emit 한 asset 마다 1개. `rn-asset-copy`
- * 가 bundle string 을 파싱하지 않고 직접 받아 release asset 복사에 사용.
+ * RN AssetRegistry.registerAsset 메타데이터 — `rn-asset-copy` 의 release copy
+ * 경로가 실제 읽는 필드만 노출. width/height/hash 는 bundle 안 `registerAsset({...})`
+ * 호출로 RN runtime 에 직접 전달되므로 이 사이드채널에는 중복 보관하지 않는다.
  */
 export interface RnAssetMetadata {
   httpServerLocation: string;
   fileSystemLocation: string;
   name: string;
   type: string;
-  hash: string;
   scales: number[];
-  width: number;
-  height: number;
 }
 
 interface NativeBuildResult {

--- a/packages/core/src/napi/result.zig
+++ b/packages/core/src/napi/result.zig
@@ -217,9 +217,6 @@ pub fn buildResultToJS(env: c.napi_env, result: *const bundler_mod.BundleResult,
             common.setStringProp(env, js_m, "fileSystemLocation", m.file_system_location);
             common.setStringProp(env, js_m, "name", m.name);
             common.setStringProp(env, js_m, "type", m.type_name);
-            common.setStringProp(env, js_m, "hash", m.hash_hex);
-            common.setUint32Prop(env, js_m, "width", m.width);
-            common.setUint32Prop(env, js_m, "height", m.height);
 
             var js_scales: c.napi_value = undefined;
             _ = c.napi_create_array_with_length(env, m.scales.len, &js_scales);

--- a/src/bundler/graph/assets.zig
+++ b/src/bundler/graph/assets.zig
@@ -160,15 +160,17 @@ pub fn applyAssetNamingPattern(
 /// RN bundle 결과로 expose 되는 asset metadata. strings + scales 는 emit 시
 /// caller 가 전달한 `metadata_alloc` (BundleResult 까지 살아남는 long-lived
 /// allocator) 직접 소유 — clone 단계 없이 그대로 list 에 push 가능.
+///
+/// 노출되는 필드는 `rn-asset-copy` 의 release copy 경로가 실제 읽는 것만 (Metro
+/// `getAssetDestPath{IOS,Android}` 입력). width/height/hash 는 source string 안
+/// `registerAsset({...})` 호출로 RN runtime 에 직접 전달되므로 metadata struct 에
+/// 중복 보관할 필요가 없다.
 pub const RnAssetMetadata = struct {
     http_server_location: []const u8,
     file_system_location: []const u8,
     name: []const u8,
     type_name: []const u8,
-    hash_hex: []const u8,
     scales: []const u32,
-    width: u32,
-    height: u32,
 };
 
 /// `emitAssetRegistryCall` 의 결과. `source` 는 `source_alloc` 소유 (보통 module
@@ -184,7 +186,6 @@ pub fn freeRnAssetMetadata(allocator: std.mem.Allocator, meta: RnAssetMetadata) 
     allocator.free(meta.file_system_location);
     allocator.free(meta.name);
     allocator.free(meta.type_name);
-    allocator.free(meta.hash_hex);
     allocator.free(meta.scales);
 }
 
@@ -244,14 +245,15 @@ pub fn emitAssetRegistryCall(
     // Metro 호환: asset hash 는 raw bytes 의 MD5 32 hex (Metro `Assets.js` hashFiles).
     // RN 런타임/빌드 시스템이 캐시 키, 디스크 자산명 등에서 32 hex 를 가정하므로
     // 8 byte wyhash 로는 충돌 확률 + Metro 호환성 모두 부족 (#1428).
+    // hash 는 source string 의 `registerAsset({"hash": "..."})` 안에만 들어가고
+    // metadata struct 는 hash 를 노출하지 않으므로 stack 버퍼만으로 충분.
     var md5_digest: [16]u8 = undefined;
     std.crypto.hash.Md5.hash(input.bytes, &md5_digest, .{});
-    const hash_hex_owned = try metadata_alloc.alloc(u8, 32);
-    errdefer metadata_alloc.free(hash_hex_owned);
+    var hash_hex: [32]u8 = undefined;
     const hex_chars = "0123456789abcdef";
     for (md5_digest, 0..) |b, i| {
-        hash_hex_owned[i * 2] = hex_chars[b >> 4];
-        hash_hex_owned[i * 2 + 1] = hex_chars[b & 0x0F];
+        hash_hex[i * 2] = hex_chars[b >> 4];
+        hash_hex[i * 2 + 1] = hex_chars[b & 0x0F];
     }
 
     const scales_owned = try metadata_alloc.dupe(u32, input.scales);
@@ -289,7 +291,7 @@ pub fn emitAssetRegistryCall(
         \\  "type": "{s}",
         \\  "fileSystemLocation": "{s}"
         \\}})
-    , .{ registry_esc, http_loc_esc, width, height, scales_str, hash_hex_owned, name_esc, type_name, fs_dir_esc });
+    , .{ registry_esc, http_loc_esc, width, height, scales_str, &hash_hex, name_esc, type_name, fs_dir_esc });
 
     return .{
         .source = source,
@@ -298,10 +300,7 @@ pub fn emitAssetRegistryCall(
             .file_system_location = fs_dir_owned,
             .name = name_owned,
             .type_name = type_name_owned,
-            .hash_hex = hash_hex_owned,
             .scales = scales_owned,
-            .width = width,
-            .height = height,
         },
     };
 }


### PR DESCRIPTION
## Summary

`RnAssetMetadata` 의 `width` / `height` / `hash` 가 Zig → NAPI → TS 까지 직렬화되지만 어디서도 read 되지 않는 dead expose 였음. 확인 후 제거.

## 사용처 확인 (grep 전수 조사)

- 외부 caller: **`zntc.mjs:814` 한 곳** — `result.rnAssetMetadata` → `copyRnAssets({ assets })` 로 전달.
- `copyRnAssets` 가 access 하는 필드:

| Field | 사용 | 사용처 |
|---|---|---|
| `httpServerLocation` | ✅ | resource id sanitize + iOS dest path |
| `fileSystemLocation` | ✅ | `sourceFileForScale` |
| `name` | ✅ | source file 명 + resource id |
| `type` | ✅ | drawable 분기 + 확장자 |
| `scales` | ✅ | scale variant loop |
| **`width`** | ❌ | 미사용 |
| **`height`** | ❌ | 미사용 |
| **`hash`** | ❌ | 미사용 |

- 다른 packages/* (`react-native`, `vite-plugin`, `web`, `server`, ...) / tests / examples — `rnAssetMetadata` 접근 **0 건**.

## RN 빌드 동작 영향 없음 — 두 경로 분리

**경로 A — bundle 안 `registerAsset({...})` 호출 (RN runtime 이 읽는 곳)**
`src/bundler/graph/assets.zig` 의 source string emit (`"width": {d}, "height": {d}, ..., "hash": "{s}", ...`) 은 **그대로 유지**. RN runtime 은 이 호출 객체로부터 `Image` intrinsic dimensions 와 캐시 키를 읽음. bundle.js 출력 바이트 동일.

**경로 B — `BundleResult.rn_asset_metadata` (mjs 사이드채널, 본 PR 정리 대상)**
release asset 복사 결정용. width/height/hash 와 무관 (어디로 어떤 파일을 복사할지만 결정).

## 변경

- **Zig** (`src/bundler/graph/assets.zig`):
  - `RnAssetMetadata` 가 5 fields (httpServerLocation / fileSystemLocation / name / type_name / scales) 로 슬림화.
  - emit 안 `hash_hex` 의 `metadata_alloc.alloc(u8, 32)` → stack `[32]u8` 으로 다운그레이드. asset 당 32 bytes graph allocator alloc 절약. source 의 `\"hash\": \"{s}\"` 임베드는 그대로 `&hash_hex` 로 전달.
  - `freeRnAssetMetadata` 에서 `hash_hex` free 제거.
- **NAPI** (`packages/core/src/napi/result.zig`):
  - `setStringProp(\"hash\")` / `setUint32Prop(\"width\"/\"height\")` 호출 3 줄 제거.
- **TS** (`packages/core/index.ts`):
  - `RnAssetMetadata` interface 에서 3 필드 제거 + doc comment 갱신.

## Test plan

- [x] `zig build test` 전체 통과
- [x] `bun test rn-asset-copy.test.ts`: 13 pass / 0 fail
- [x] `bun run fmt` / `zig fmt` / pre-push 통과
- [x] bundle.js 출력 바이트 동일 (source emit 무변경) — RN runtime 영향 없음 검증
- [x] copyRnAssets / keep.xml / dev server 의 사용처 grep — width/height/hash 읽는 코드 0 건

🤖 Generated with [Claude Code](https://claude.com/claude-code)