### PR TITLE
feat(mangle-report): nested stats + ZNTC_DEBUG=mangle_dump 추가

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -24,6 +24,7 @@ const Ast = @import("../parser/ast.zig").Ast;
 const semantic_symbol = @import("../semantic/symbol.zig");
 const bundler_symbol = @import("symbol.zig");
 const profile = @import("../profile.zig");
+const debug_log = @import("../debug_log.zig");
 const CompiledModule = @import("compiled_module.zig").CompiledModule;
 const preamble_writer = @import("linker/preamble_writer.zig");
 const namespace_access = @import("linker/namespace_access.zig");
@@ -932,6 +933,32 @@ pub const Linker = struct {
         if (self.mangle_report) |r| {
             r.top_level = result.phase_a;
             r.top_level_reserved_pool = result.phase_a.reserved_size;
+            for (result.phase_b_modules, 0..) |stats, mi| {
+                const m = self.getModule(@intCast(mi)) orelse continue;
+                try r.recordNested(m.path, stats);
+            }
+        }
+
+        if (debug_log.enabled(.mangle_dump)) {
+            debug_log.print(.mangle_dump, "module\tsymbol_id\torig\tmangled\tref_count\tkind\tmod_included\n", .{});
+            for (collected.top_level_candidates) |cand| {
+                const key: um.ModuleSymKey = .{ .module_index = cand.module_index, .symbol_id = cand.symbol_id };
+                const mangled = result.renames.get(key) orelse cand.name;
+                const cand_mod = self.getModule(cand.module_index) orelse continue;
+                const sem = cand_mod.semantic orelse continue;
+                if (cand.symbol_id >= sem.symbols.items.len) continue;
+                const sym = &sem.symbols.items[cand.symbol_id];
+                const kind_str = if (sym.synthetic_kind) |sk| @tagName(sk) else "user";
+                debug_log.print(.mangle_dump, "{s}\t{d}\t{s}\t{s}\t{d}\t{s}\t{}\n", .{
+                    cand_mod.path,
+                    cand.symbol_id,
+                    cand.name,
+                    mangled,
+                    cand.ref_count,
+                    kind_str,
+                    cand_mod.is_included,
+                });
+            }
         }
 
         self.unified_result = result;

--- a/src/debug_log.zig
+++ b/src/debug_log.zig
@@ -55,6 +55,12 @@ pub const Category = enum {
     /// `graph.discover` 의 fs IO (특히 `pm.setup.read.open`) 분포 — file size ·
     /// open ns · path 길이. parallel batching/precache 여지 식별. issue #3142.
     graph_io_audit,
+    /// Top-level mangle candidate per-row dump
+    /// (`module\tsymbol_id\torig\tmangled\tref_count\tkind\tmod_included`).
+    /// `--mangle-report` 의 집계만으로는 "1글자 이름 발급 vs 실제 출력 잔존" 격차를 식별
+    /// 불가 — 이 dump 를 외부 grep 으로 bundle 과 대조해 어떤 candidate 가 짧은 이름
+    /// 풀을 잠식하는지 확인. mangle 식별자 풀 미소진 진단.
+    mangle_dump,
 
     /// 카테고리 이름으로 enum 조회 (공백 제거 + 대소문자 무시).
     pub fn fromString(s: []const u8) ?Category {


### PR DESCRIPTION
## Summary
- `--mangle-report` 의 `nested` 가 항상 `[]` 였던 결함 수정 — Phase B per-module stats 를 collector 에 append.
- `ZNTC_DEBUG=mangle_dump` 추가 — candidate 별 한 줄씩 stderr 에 dump (탭 구분: `module / symbol_id / orig / mangled / ref_count / kind / mod_included`).

## Why
`--mangle-report` 의 집계만으로는 "Phase A 가 1글자 이름을 54개 발급" 과 "실제 bundle 에 1글자 binding 이 18개만 잔존" 사이 격차를 찾을 수 없었다. dump 를 외부 grep 으로 bundle 과 대조해 어떤 candidate 가 짧은 이름 풀을 잠식하는지 정량화하고, 그에 기반해 root cause fix 를 분리 PR 로 준비 중.

lodash-es 측정 예 (수정 후):
- nested entries: 0 → **641** (모듈 수만큼)
- candidate dump 1203 행 + bundle 대조 → 1글자 54개 중 **18 (33%) 만 잔존** 확인 → 이후 fix 의 baseline

## Test plan
- [x] `zig build` (ReleaseFast) 통과
- [x] `zig build test` 통과
- [x] `ZNTC_DEBUG=mangle_dump zntc --bundle ... --mangle-report=...` 으로 lodash-es smoke — header 1행 + 1203 candidate 행 + nested 641 entries 확인
- [x] disabled 경로 (mangle_report=null + ZNTC_DEBUG 미지정) — 기존 mangle 결과 / bundle size 동일 (lodash-es 21499B 동일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)