### PR TITLE
fix(mangle): tree-shake 후 mangle 로 짧은 이름 풀 잠식 회귀 수정

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1085,6 +1085,10 @@ pub const Bundler = struct {
         // 2. 링킹 (scope hoisting)
         // code_splitting=true일 때는 글로벌 computeRenames를 건너뛴다.
         // 각 청크가 독립된 네임스페이스이므로 emitChunks에서 per-chunk로 처리.
+        // tree-shaking 이 돌면 mangling 은 tree-shake 이후로 미룬다 — dead 모듈의
+        // binding 이 짧은 이름 풀(54자)을 잠식해 candidate-emit 비율이 떨어지는
+        // 회귀 방지. TreeShaker 생성 조건과 동일 predicate.
+        const will_tree_shake = !self.options.dev_mode and self.options.scope_hoist and self.options.tree_shaking;
         var link_scope = profile.begin(.link);
         var linker: ?Linker = if (self.options.scope_hoist or self.options.dev_mode) blk: {
             var l = Linker.initWithGlobalIdentifiers(self.allocator, &graph, self.options.format, self.options.global_identifiers);
@@ -1107,7 +1111,7 @@ pub const Bundler = struct {
             // SymbolRefCounts (tree-shaking companion metric) 까지 한 번에 묶어 emit.
             try l.finalize(.{
                 .compute_renames = !self.options.code_splitting,
-                .compute_mangling = self.options.minify_identifiers,
+                .compute_mangling = self.options.minify_identifiers and !will_tree_shake,
             });
             break :blk l;
         } else null;
@@ -1122,7 +1126,7 @@ pub const Bundler = struct {
         // 2.5. Tree-shaking (scope_hoist + tree_shaking 둘 다 켜져 있을 때)
         // dev_mode에서는 tree-shaking 스킵 (개발 중 모든 코드 필요)
         var shake_scope = profile.begin(.shake);
-        var shaker: ?TreeShaker = if (!self.options.dev_mode and self.options.scope_hoist and self.options.tree_shaking) blk: {
+        var shaker: ?TreeShaker = if (will_tree_shake) blk: {
             var s = blk_init: {
                 var init_scope = profile.begin(.shake_init);
                 defer init_scope.end();
@@ -1133,7 +1137,17 @@ pub const Bundler = struct {
                 defer analyze_scope.end();
                 try s.analyze(self.options.entry_points);
             }
-            if (s.ast_mutated_after_link and !self.options.code_splitting) {
+            // metadata builder + collectUnifiedInput 가 `Module.is_included` 를 신뢰해
+            // tree-shake 된 모듈의 preamble emit + mangle candidate 를 건너뛸 수 있도록
+            // plug. post-shake finalize 보다 먼저 켜 두어야 collectUnifiedInput 가드가
+            // 활성화된다.
+            if (linker) |*l| l.tree_shaker_active = true;
+
+            // ast mutation 이 있었거나 mangle 을 일부러 미뤘던 경우 (will_tree_shake)
+            // tree-shake 결과 (`is_included`) 를 반영해 한 번만 mangle 한다.
+            const need_post_shake_finalize = !self.options.code_splitting and
+                (s.ast_mutated_after_link or will_tree_shake);
+            if (need_post_shake_finalize) {
                 var post_link_scope = profile.begin(.shake_post_link_finalize);
                 defer post_link_scope.end();
                 if (self.options.minify_identifiers) {
@@ -1144,7 +1158,7 @@ pub const Bundler = struct {
                         .clear_first = true,
                         .populate_namespace_accesses = false,
                     });
-                } else {
+                } else if (s.ast_mutated_after_link) {
                     // Tree-shake constant folding only removes/replaces references. Graph
                     // resync preserves existing canonical names, so emit only needs import
                     // and re-export metadata refreshed for the final AST snapshot.
@@ -1153,10 +1167,6 @@ pub const Bundler = struct {
                     l.populateImportSymbols();
                 }
             }
-            // metadata builder 가 `Module.is_included` 비트를 신뢰해 tree-shake 된 target 의
-            // CJS preamble emit 을 건너뛸 수 있도록 plug. analyze() 가 끝난 뒤 mirror 가
-            // 모든 모듈의 `is_included` 비트를 확정해 둔다.
-            if (linker) |*l| l.tree_shaker_active = true;
             break :blk s;
         } else null;
         defer if (shaker) |*s| s.deinit();

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -674,6 +674,20 @@ pub const Linker = struct {
     /// caller 가 `deinit` 해야 함.
     pub fn collectUnifiedInput(self: *const Linker) !UnifiedCollect {
         const um = @import("../codegen/unified_mangler.zig");
+        // helper module / dead module / sem-less module 모두 같은 빈 입력으로
+        // Phase B 를 skip 시킨다.
+        const emptyInput = struct {
+            fn make(source: []const u8, bitset: std.DynamicBitSet) um.ModuleMangleInput {
+                return .{
+                    .scopes = &.{},
+                    .symbols = &.{},
+                    .scope_maps = &.{},
+                    .references = &.{},
+                    .source = source,
+                    .module_scope_symbols = bitset,
+                };
+            }
+        }.make;
 
         const mod_count = self.graph.moduleCount();
         const modules = try self.allocator.alloc(um.ModuleMangleInput, mod_count);
@@ -733,6 +747,14 @@ pub const Linker = struct {
             bitsets[created] = try std.DynamicBitSet.initEmpty(self.allocator, sym_count);
             created += 1;
 
+            // tree-shake 후 dead 로 판정된 모듈은 후보에서 제외 — 짧은 이름 풀이
+            // emit 안 될 binding 으로 잠식되는 회귀 방지. tree_shaker_active=false
+            // 일 땐 is_included 가 default false 라 잘못 skip 되므로 active 일 때만 가드.
+            if (self.tree_shaker_active and !m.is_included) {
+                modules[mi] = emptyInput(m.source, bitsets[mi]);
+                continue;
+            }
+
             // #1961 PR 1h: ZNTC runtime helper virtual module 의 top-level 식별자
             // (`$aS` / `$gn` 등) 는 transformer 가 이미 축약 이름으로 emit 한 결과.
             // mangler 가 추가 rename 하면 cross-module binding 이 깨진다 (main 의
@@ -760,14 +782,7 @@ pub const Linker = struct {
                         }
                     }
                 }
-                modules[mi] = .{
-                    .scopes = &.{},
-                    .symbols = &.{},
-                    .scope_maps = &.{},
-                    .references = &.{},
-                    .source = m.source,
-                    .module_scope_symbols = bitsets[mi],
-                };
+                modules[mi] = emptyInput(m.source, bitsets[mi]);
                 continue;
             }
 
@@ -829,6 +844,10 @@ pub const Linker = struct {
                         switch (sk) {
                             .default_export, .cjs_exports, .cjs_require, .esm_init => {},
                         }
+                        // default_export 는 wrapper 와 달리 cross-module emit 보장이 없다 —
+                        // ref=0 이면 어디서도 import 하지 않아 codegen 이 binding 을 emit
+                        // 하지 않는다. 그런 candidate 는 mangle 풀에서 제외.
+                        if (sk == .default_export and sym.reference_count == 0) continue;
                         const key = if (sym.canonical_name.len > 0) sym.canonical_name else sym.synthetic_name;
                         if (key.len <= 1) continue;
                         if (exported.contains(key)) continue;
@@ -860,14 +879,7 @@ pub const Linker = struct {
                     .module_scope_symbols = bitsets[mi],
                 };
             } else {
-                modules[mi] = .{
-                    .scopes = &.{},
-                    .symbols = &.{},
-                    .scope_maps = &.{},
-                    .references = &.{},
-                    .source = m.source,
-                    .module_scope_symbols = bitsets[mi],
-                };
+                modules[mi] = emptyInput(m.source, bitsets[mi]);
             }
         }
 

--- a/tests/benchmark/mangler-tree-shake.test.ts
+++ b/tests/benchmark/mangler-tree-shake.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '../..');
+const ZNTC_BIN = join(ROOT, 'zig-out/bin/zntc');
+
+interface ManglerStats {
+  slot_count: number;
+  slot_name_length_sum: number;
+  name_counter_final: number;
+  reserved_size: number;
+  renamed_symbol_count: number;
+}
+interface ManglerReport {
+  top_level: ManglerStats;
+  top_level_reserved_pool: number;
+  nested: { module_path: string; stats: ManglerStats }[];
+  bundle_size_bytes: number;
+  totals: ManglerStats;
+}
+
+function bundle(entrySrc: string): ManglerReport {
+  const dir = mkdtempSync(join(tmpdir(), 'zntc-mangle-shake-'));
+  const entry = join(__dirname, `_mangle_shake_entry_${process.pid}.ts`);
+  writeFileSync(entry, entrySrc);
+  try {
+    const out = join(dir, 'out.js');
+    const reportPath = join(dir, 'report.json');
+    const r = spawnSync(
+      ZNTC_BIN,
+      [
+        '--bundle',
+        entry,
+        '-o',
+        out,
+        '--minify',
+        '--platform=node',
+        `--mangle-report=${reportPath}`,
+      ],
+      { encoding: 'utf8', timeout: 120_000 },
+    );
+    if (r.status !== 0) throw new Error(`zntc failed (${r.status}): ${r.stderr}`);
+    return JSON.parse(readFileSync(reportPath, 'utf8'));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    try {
+      rmSync(entry);
+    } catch {}
+  }
+}
+
+describe('mangle pool tree-shake awareness', () => {
+  // 회귀 방지: tree-shake 후 dead 로 판정된 모듈의 top-level binding 이
+  // mangle candidate 풀(짧은 이름 54자) 을 잠식하면 안 된다. 회귀 발생 시
+  // lodash-es 의 slot_count 가 1200대로 급증한다 (fix 전 1203, 후 ~300).
+  test('lodash-es: dead module bindings are excluded from candidate pool', () => {
+    const report = bundle(`
+import { groupBy, sortBy, uniq } from 'lodash-es';
+console.log(groupBy, sortBy, uniq);
+    `);
+
+    // entry 가 named export 3개만 사용 → tree-shake 가 lodash 내부 모듈 대다수
+    // (bind/curry/partial/wrapperLodash 등) 를 dead 로 판정해야 한다. 이 fix 가
+    // 깨지면 모든 모듈의 top-level binding (~1200개) 이 candidate 로 들어와
+    // 짧은 이름 풀 1글자 54개의 67% 가 emit 안 될 binding 에 낭비된다.
+    expect(report.top_level.slot_count).toBeLessThan(500);
+    // bundle 자체 sanity — fix 가 정상 동작하면 ~21KB.
+    expect(report.bundle_size_bytes).toBeLessThan(23_000);
+    // nested 통계가 빈 배열이면 mangle-report.recordNested 회귀 (PR 3228).
+    expect(report.nested.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- `bundler.build` 의 첫 finalize 가 tree-shake 전에 mangle 을 한 번 실행해 dead 모듈의 binding 이 candidate 풀로 굳어버리던 문제 수정.
- `will_tree_shake` 면 첫 finalize 의 mangle 을 skip → post-shake finalize 에서 한 번만 mangle (`is_included` 반영).
- 안전망: `collectUnifiedInput` 에 `tree_shaker_active && !is_included` 모듈 제외 가드 + `default_export` ref=0 제외 가드.
- 회귀 가드 테스트: `tests/benchmark/mangler-tree-shake.test.ts` (149ms, lodash-es slot_count 500 미만 검증).

## 측정 (lodash-es)
| | 수정 전 | 수정 후 |
|---|---|---|
| candidate | 1203 (모두 `is_included=False`) | 296 |
| 1글자 풀 잔존율 | 18/54 (33%) | **54/54 (100%)** |
| 2글자 풀 잔존율 | 283/1149 (25%) | **242/243 (99.6%)** |
| bundle | 21499B | 21336B |

전 fixture 효과 — effect 3글자 식별자 932 → **68** (13배 감소), zod 64.5KB → 64.3KB. functional sanity (node 실행) 정상.

## 진단 데이터 출처
선행 PR #3228 의 `--mangle-report.nested` 수정 + `ZNTC_DEBUG=mangle_dump` 으로 candidate dump → bundle grep 으로 잔존율 정량화 → root cause 확정.

## Test plan
- [x] `zig build` (ReleaseFast) + `zig build test` 통과
- [x] `bun test mangler-tree-shake.test.ts` 통과 — threshold 임시로 100 으로 낮추면 expected fail 정상 동작 확인
- [x] lodash-es bundle node 실행 정상 (`groupBy/sortBy/uniq` 출력)
- [x] minify-bench 6 fixture 모두 size 동일 또는 감소

🤖 Generated with [Claude Code](https://claude.com/claude-code)