### PR TITLE
fix(mangle): statement-level reachability guard + namespace getter dead-export skip

### DIFF
--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -547,6 +547,11 @@ pub fn emitEsmWrappedModule(
                         const l = linker orelse break :skip;
                         if (shouldSkipTreeShakenReExportSource(l, module, eb)) continue;
                     }
+                    // local export 의 declaration 이 tree-shaken 이면 namespace getter
+                    // skip — 안 그러면 dangling reference 가 namespace object 안에 남고,
+                    // 그 binding 은 emit 안 되어 mangle 가드도 함께 long source name 으로
+                    // 남게 되어 size 회귀.
+                    if (eb.kind == .local and !module.isLocalBindingAlive(module.exportBindingLocalName(eb))) continue;
                     try appendExportGetter(&wrapped, allocator, eb.exported_name, blk: {
                         // Symbol table이 단축 경로의 source of truth.
                         // binding_scanner가 `_default = <expr>`가 실제로 emit되는 default만

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -819,6 +819,10 @@ pub const Linker = struct {
                         // 같은 symbol 을 candidates 에 중복 추가하면
                         // mangleAll 의 renames.put 이 이전 value 를 덮어써 leak.
                         if (sym.synthetic_kind == .default_export) continue;
+                        // statement-level dead 가드 — esbuild Part.IsLive / rolldown
+                        // stmt_info_included 와 동일 효과. tree_shaker reconcile + namespace
+                        // getter dead-export skip 과 같은 진실의 원천.
+                        if (self.tree_shaker_active and !m.isStatementAliveBySym(sym_idx_usize)) continue;
 
                         const key = if (sym.canonical_name.len > 0) sym.canonical_name else sym_name;
                         if (key.len <= 1) {

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -507,8 +507,17 @@ fn buildInlineObjectStr(
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(self.allocator);
     try buf.appendSlice(self.allocator, "{");
-    for (exports.items, 0..) |exp, idx| {
-        if (idx > 0) try buf.appendSlice(self.allocator, ", ");
+    var first = true;
+    for (exports.items) |exp| {
+        // declaration 이 tree-shaken 되어 emit 안 되면 namespace getter 도 skip —
+        // dangling reference 방지. declaration 모듈은 init_mod (lazy init) 있으면
+        // 그쪽, 없으면 target (정적 export).
+        const decl_mod_idx = exp.init_mod orelse target_mod_idx;
+        if (self.graph.getModule(@enumFromInt(decl_mod_idx))) |decl_mod| {
+            if (!decl_mod.isLocalBindingAlive(exp.local)) continue;
+        }
+        if (!first) try buf.appendSlice(self.allocator, ", ");
+        first = false;
         const needs_quote = needsPropertyQuoteForExport(exp.exported);
         // export * as ns 패턴이면 재귀 인라인 (값으로 참조)
         if (ns_re_exports.get(exp.exported)) |src_mod| {

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -273,6 +273,15 @@ pub const Module = struct {
     /// `TreeShaker.analyze` 가 finalize 후 set. 기본 false 라 tree-shaking 비활성 시
     /// 의미 없음 — chunk gen 단계에서도 `m.side_effects or entry_set.isSet` 으로 항상 alive 처리.
     is_included: bool = false,
+    /// 이 모듈의 statement-level reachability bitset. tree_shaker 가 mirror 한 borrowed
+    /// 참조 — owner 는 `TreeShaker.reachable_stmts`. tree_shaker.deinit 후엔 dangling
+    /// 이므로 mangle / link 단계에서만 사용. null 이면 tree-shake 미수행 / 정보 없음.
+    /// `is_included=true` 라도 모듈 내부 statement 의 70~90%가 dead 인 UMD 라이브러리
+    /// (three.module.js 등) 에서 mangle candidate 필터링에 사용.
+    reachable_stmts: ?*const std.DynamicBitSet = null,
+    /// symbol_index → declaration stmt_index 역매핑. tree_shaker 가 mirror 한 borrowed.
+    /// `reachable_stmts` 와 짝. 둘 다 null 또는 둘 다 set.
+    symbol_to_stmt: ?[]const ?u32 = null,
     /// package.json "module" 필드를 통해 resolve된 파일.
     /// .js 확장자라도 ESM으로 파싱해야 함.
     is_module_field: bool = false,
@@ -405,6 +414,29 @@ pub const Module = struct {
     pub fn semanticSymbols(self: *const Module) []const Symbol {
         const sem = self.semantic orelse return &.{};
         return sem.symbols.items;
+    }
+
+    /// 이 모듈의 sym_idx binding 의 declaration stmt 가 emit 될 stmt 인지.
+    /// `tree_shaker.reachable_stmts` 정보가 없거나 sym→stmt 매핑이 없으면 conservative
+    /// 하게 true (가드 noop). mangle / namespace getter 가 dead binding 을 candidate
+    /// 또는 dangling getter 로 만들지 않도록 일관 호출. tree_shaker.deinit 후엔
+    /// borrowed pointer 가 dangling — caller 가 lifetime 관리.
+    pub fn isStatementAliveBySym(self: *const Module, sym_idx: usize) bool {
+        const s2s = self.symbol_to_stmt orelse return true;
+        const rs = self.reachable_stmts orelse return true;
+        if (sym_idx >= s2s.len) return true;
+        const stmt_idx = s2s[sym_idx] orelse return true;
+        return stmt_idx >= rs.capacity() or rs.isSet(stmt_idx);
+    }
+
+    /// `local_name` 으로 module-scope binding 을 찾아 declaration stmt reachability
+    /// 검사. semantic / scope_maps 가 없으면 true. namespace getter 빌더 (esm_wrap,
+    /// shared_namespace) 가 사용.
+    pub fn isLocalBindingAlive(self: *const Module, local_name: []const u8) bool {
+        const sem = self.semantic orelse return true;
+        if (sem.scope_maps.len == 0) return true;
+        const sym_idx = sem.scope_maps[0].get(local_name) orelse return true;
+        return self.isStatementAliveBySym(sym_idx);
     }
 
     /// exported_name으로 ExportBinding을 찾는다. #1338 Phase 4c-1 Export Registry.

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -140,6 +140,12 @@ pub const TreeShaker = struct {
     }
 
     pub fn deinit(self: *TreeShaker) void {
+        // Module 에 mirror 한 borrowed pointer 가 dangling 되지 않도록 먼저 null.
+        for (0..self.graph.moduleCount()) |i| {
+            const m = self.moduleAtMut(@intCast(i)) orelse continue;
+            m.reachable_stmts = null;
+            m.symbol_to_stmt = null;
+        }
         var kit = self.used_exports.keyIterator();
         while (kit.next()) |key| self.allocator.free(key.*);
         self.used_exports.deinit();
@@ -593,8 +599,19 @@ pub const TreeShaker = struct {
             }
         }
 
+        // emit-align: emitter (`emitter.zig` dead-stmt skip 경로) 는 reachable_stmts
+        // 가 false 라도 ts_stmt.span 이 transformer-후 AST 에 매칭 안 되면 skip 안 set
+        // → emit. 이 fallback 을 reachable_stmts 에 미리 반영해 진실의 원천을 일원화.
+        // 안 그러면 mangle 이 "unreachable + transformer 가 재작성한 stmt" 의 binding 을
+        // dead 로 잘못 분류해 candidate 제외 → emit 시 long source name 그대로 남음
+        // (effect 라이브러리에서 1900+ binding 이 회귀했던 케이스).
+        try self.reconcileReachableWithTransformedAst();
+
         // ModuleInfo `isIncluded` 노출용 — 최종 included BitSet 을 Module 에 mirror.
         // chunk gen / NAPI 가 BitSet 직접 보유 안 해도 `m.is_included` 로 조회 가능.
+        // 동시에 statement-level reachability (linker.collectUnifiedInput 의 mangle
+        // candidate 필터링용) 도 borrowed pointer 로 mirror — owner 는 self,
+        // 수명은 tree_shaker.deinit 까지.
         {
             var mirror_scope = profile.begin(.shake_mirror);
             defer mirror_scope.end();
@@ -602,6 +619,14 @@ pub const TreeShaker = struct {
             for (0..mod_count) |i| {
                 const m = self.moduleAtMut(@intCast(i)) orelse continue;
                 m.is_included = self.included.isSet(i);
+                m.reachable_stmts = if (i < self.reachable_stmts.len) blk: {
+                    if (self.reachable_stmts[i]) |*rs| break :blk rs;
+                    break :blk null;
+                } else null;
+                m.symbol_to_stmt = if (i < self.module_stmt_infos.len) blk: {
+                    if (self.module_stmt_infos[i]) |infos| break :blk infos.symbol_to_stmt;
+                    break :blk null;
+                } else null;
             }
         }
     }
@@ -610,6 +635,47 @@ pub const TreeShaker = struct {
         if (module_index >= self.reachable_stmts.len) return true;
         const reachable = self.reachable_stmts[module_index] orelse return true;
         return reachable.isSet(stmt_idx);
+    }
+
+    /// reachable_stmts 가 emit 와 어긋나는 케이스를 해소 — emit dead-stmt skip
+    /// (emitter.zig) 은 unreachable 이라도 transformer-후 AST 에 매칭 안 되면 skip 안
+    /// set 한다. 그런 stmt 는 실제로 emit 되므로 reachable 로 보정해 mangle/emit 의
+    /// 진실의 원천을 일원화. analyze() 끝에서 호출.
+    fn reconcileReachableWithTransformedAst(self: *TreeShaker) !void {
+        const mod_count = self.graph.moduleCount();
+        for (0..mod_count) |i| {
+            if (i >= self.reachable_stmts.len or i >= self.module_stmt_infos.len) continue;
+            const reachable_opt: ?*std.DynamicBitSet = if (self.reachable_stmts[i]) |*rs| rs else null;
+            const reachable = reachable_opt orelse continue;
+            const ts_infos = self.module_stmt_infos[i] orelse continue;
+            const m = self.getModule(@intCast(i)) orelse continue;
+            const ast = m.ast orelse continue;
+            if (ast.nodes.items.len == 0) continue;
+            const root = ast.nodes.items[ast.nodes.items.len - 1];
+            if (root.tag != .program) continue;
+            const list = root.data.list;
+            if (list.start + list.len > ast.extra_data.items.len) continue;
+            const stmt_indices = ast.extra_data.items[list.start .. list.start + list.len];
+            for (ts_infos.stmts, 0..) |ts_stmt, si| {
+                if (si >= reachable.capacity()) break;
+                if (reachable.isSet(si)) continue;
+                var matched = false;
+                for (stmt_indices) |raw_ni| {
+                    const ni = @as(usize, raw_ni);
+                    if (ni >= ast.nodes.items.len) continue;
+                    const new_node = ast.nodes.items[ni];
+                    if (new_node.span.start == ts_stmt.span.start and
+                        new_node.span.end == ts_stmt.span.end)
+                    {
+                        matched = true;
+                        break;
+                    }
+                }
+                // matched + unreachable → emitter sets skip_nodes (emit X)
+                // unmatched (transformer 가 변경/제거) → emitter 가 skip 안 set (emit O)
+                if (!matched) reachable.set(si);
+            }
+        }
     }
 
     pub fn getModuleStmtInfos(self: *const TreeShaker, module_index: u32) ?StmtInfos {

--- a/tests/benchmark/mangler-tree-shake.test.ts
+++ b/tests/benchmark/mangler-tree-shake.test.ts
@@ -72,4 +72,31 @@ console.log(groupBy, sortBy, uniq);
     // nested 통계가 빈 배열이면 mangle-report.recordNested 회귀 (PR 3228).
     expect(report.nested.length).toBeGreaterThan(0);
   });
+
+  // 회귀 방지: three.module.js 같은 UMD single-file 라이브러리 — module 자체는
+  // included=true 이지만 안의 statement 대다수가 dead. statement-level 가드 +
+  // tree_shaker emit-align reconcile + namespace getter dead-export skip 의
+  // 3종 fix 가 모두 동작해야 candidate 가 줄어든다 (fix 전 1038 → 후 ~170).
+  test('three: statement-level dead bindings excluded from candidate pool', () => {
+    const report = bundle(`
+import { Vector3 } from 'three';
+const v = new Vector3(1, 2, 3);
+console.log(v.length().toFixed(2));
+    `);
+    expect(report.top_level.slot_count).toBeLessThan(300);
+    expect(report.bundle_size_bytes).toBeLessThan(212_000);
+  });
+
+  // 회귀 방지: namespace getter (effect 처럼 ns getter 무거운 라이브러리) 가
+  // dead local export 의 dangling reference 를 만들면 mangle 가드가 long source
+  // name 을 dead 로 잘못 분류해 size 회귀 (effect 의 경우 +12KB 회귀).
+  test('effect: namespace getter excludes dead local exports', () => {
+    const report = bundle(`
+import { Effect, pipe } from 'effect';
+const p = pipe(Effect.succeed(42), Effect.map((n: number) => n + 1));
+Effect.runPromise(p).then(r => console.log(r));
+    `);
+    // fix 직전 회귀 213.8KB. fix 후 ~187KB.
+    expect(report.bundle_size_bytes).toBeLessThan(195_000);
+  });
 });


### PR DESCRIPTION
## Summary
- UMD single-file 라이브러리 (three.module.js 등) — module=included 지만 statement 70~90%가 dead. 기존 module-level 가드 부족.
- 그 가드를 추가하면 effect 처럼 namespace getter 무거운 라이브러리에서 12KB 회귀 — `__export({ get forEach() { return forEach\$15 } })` 가 dead local export 도 list 해서 mangle 가드가 그 binding 을 long source name 으로 emit.
- 3종 fix 로 emit 와 mangle 의 진실의 원천을 일원화: tree_shaker reconcile, statement-level mangle 가드, namespace getter dead-export skip.

## Why root-cause stack
1. **Tree_shaker reachable_stmts ≠ emit-survivor**: emitter (`emitter.zig:1474`) 는 `isStmtReachable=false` 라도 `ts_stmt.span` 이 transformer-후 AST 에 매칭 안 되면 skip 안 set → emit. 이 fallback 이 mangle 단계에서 안 보여 false-positive dead.
   → `tree_shaker.reconcileReachableWithTransformedAst()` 에서 미리 reachable 로 보정.
2. **`Module.reachable_stmts` + `symbol_to_stmt`**: tree_shaker 가 borrowed pointer mirror. `tree_shaker.deinit` 에서 null clear → dangling 방지.
3. **`Module.isStatementAliveBySym` / `isLocalBindingAlive`** 헬퍼: linker.zig (collectUnifiedInput), esm_wrap.zig (`__export({...})`), shared_namespace.zig (`buildInlineObjectStr`) 3곳에서 단일 호출.
4. **namespace getter dead local export skip**: `eb.kind == .local` 분기에 가드 추가 — re-export 만 있던 가드 (#2398) 와 대칭.

## 측정
| fixture | 회귀 상태 (가드 ON, naïve) | fix 후 | 이전 baseline |
|---|---|---|---|
| effect | 213.8KB | **186.8KB** | 201.2KB (-7.2% **추가 개선**) |
| three  | 206.0KB | 206.0KB | 206.2KB (1글자 40 → **54**) |
| lodash-es / zod / rxjs / react | 동일 | 동일 | (회귀 없음) |

## Reference
esbuild `Part.IsLive` (`internal/linker/linker.go:5397`), rolldown `stmt_info_included` (`crates/rolldown/src/utils/chunk/deconflict_chunk_symbols.rs:106`) 와 동일한 statement-level liveness 모델.

## Test plan
- [x] `zig build` (ReleaseFast) 통과
- [x] `zig build test` baseline (현 main 의 27개 RN codegen FileNotFound 와 동일, 변경 무관)
- [x] `bun test mangler-tree-shake.test.ts` 통과 (3 tests, threshold 임시로 낮춰 정상 fail 확인)
- [x] minify-bench 6 fixture node 실행 정상
- [x] 회귀 가드 테스트 2종 추가 — three slot_count < 300, effect bundle_size < 195KB

🤖 Generated with [Claude Code](https://claude.com/claude-code)