### PR TITLE
feat(minify): IIFE collapse — (()=>X)() → X

### DIFF
--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -1122,6 +1122,10 @@ fn foldCall(ast: *Ast, node_idx: u32, node: Node, changed: *bool) void {
     const flags = ast.readExtra(e, 3);
     if ((flags & ast_mod.CallFlags.optional_chain) != 0) return;
 
+    // IIFE collapse 시도 — `(()=>X)()` / `(()=>{return X})()` → X.
+    // oxc `substitute_iife_call` (substitute_alternate_syntax.rs) 의 최소 스펙.
+    if (tryFoldIife(ast, node_idx, e, changed)) return;
+
     const callee_idx: NodeIndex = @enumFromInt(ast.readExtra(e, 0));
     const callee_ni = @intFromEnum(callee_idx);
     if (callee_ni >= ast.nodes.items.len) return;
@@ -1151,6 +1155,80 @@ fn foldCall(ast: *Ast, node_idx: u32, node: Node, changed: *bool) void {
             replaceNode(ast, node_idx, bool_node, changed);
         }
     }
+}
+
+/// IIFE collapse — arrow function 만, args/params 0, async 아님, body 가
+/// expression(concise) 또는 single-return statement block 인 케이스. callee 의
+/// return expression 으로 call_expression 노드를 in-place 대체. function expression
+/// 은 `this`/`arguments` 의미가 다르고 hoisted name 도 있어 제외.
+///
+/// 보수 가드: returned expression 이 object/function/class literal 이면 abandon
+/// — codegen 이 statement-context paren wrap 보장 안 함 ('{a:1};' 가 block 으로
+/// 파싱되는 statement-level IIFE 회피). expression context (var initializer 등)
+/// 가 99%지만 statement 단독 IIFE side-effect 패턴도 존재.
+fn tryFoldIife(ast: *Ast, node_idx: u32, e: u32, changed: *bool) bool {
+    const args_len = ast.readExtra(e, 2);
+    if (args_len != 0) return false;
+
+    const callee_raw = ast.readExtra(e, 0);
+    if (callee_raw >= ast.nodes.items.len) return false;
+    const callee = unwrapParens(ast, ast.nodes.items[callee_raw]);
+    if (callee.tag != .arrow_function_expression) return false;
+
+    const arrow_e = callee.data.extra;
+    if (!ast.hasExtra(arrow_e, ast_mod.ArrowExtra.flags)) return false;
+    const arrow_flags = ast.readExtra(arrow_e, ast_mod.ArrowExtra.flags);
+    if ((arrow_flags & ast_mod.ArrowFlags.is_async) != 0) return false;
+
+    if (ast.functionParams(callee).len != 0) return false;
+
+    const body_idx = ast.functionBodyBlock(callee) orelse return false;
+    const body_ni = @intFromEnum(body_idx);
+    if (body_ni >= ast.nodes.items.len) return false;
+    const body = ast.nodes.items[body_ni];
+
+    var return_ni: u32 = undefined;
+    if (body.tag == .block_statement) {
+        const list = body.data.list;
+        if (list.len != 1) return false;
+        if (list.start >= ast.extra_data.items.len) return false;
+        const stmt_raw = ast.extra_data.items[list.start];
+        if (stmt_raw >= ast.nodes.items.len) return false;
+        const stmt = ast.nodes.items[stmt_raw];
+        if (stmt.tag != .return_statement) return false;
+        const arg = stmt.data.unary.operand;
+        if (arg.isNone()) return false;
+        return_ni = @intFromEnum(arg);
+    } else {
+        return_ni = body_ni;
+    }
+
+    if (return_ni >= ast.nodes.items.len) return false;
+    const return_node = ast.nodes.items[return_ni];
+
+    // statement-context 위험한 leading-token 형태 (object/function/class)는
+    // parenthesized_expression 으로 감싸 emit 안전성 확보 — `{a:1};` 가 block 으로
+    // 파싱되는 ASI hazard 회피.
+    //
+    // **span 은 inner 그대로 유지** — string_literal/template_literal 등은 span 이
+    // 곧 source text 위치라 call expression span (`(()=>"hi")()` 전체) 으로 덮으면
+    // emit 시 wrong text 가 출력된다. esbuild/oxc 도 inner span 사용.
+    const needs_paren = switch (return_node.tag) {
+        .object_expression, .function_expression, .class_expression => true,
+        else => false,
+    };
+    if (needs_paren) {
+        const wrapped = ast.addNode(.{
+            .tag = .parenthesized_expression,
+            .span = return_node.span,
+            .data = .{ .unary = .{ .operand = @enumFromInt(return_ni), .flags = 0 } },
+        }) catch return false;
+        ast.nodes.items[node_idx] = ast.nodes.items[@intFromEnum(wrapped)];
+    } else {
+        ast.nodes.items[node_idx] = return_node;
+    }
+    changed.* = true;
+    return true;
 }
 
 /// x === true → x, x === false → !x, x !== true → !x, x !== false → x

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -1692,10 +1692,13 @@ test "unused: (class X{})(); — class callee 도 paren 유지" {
     );
 }
 
-test "unused: (() => 1)(); — arrow callee 도 paren 유지" {
+test "unused: (() => 1)(); — IIFE collapse → unused-expr 제거" {
+    // IIFE collapse (`tryFoldIife`) 가 call 을 `1` 로 대체, 그 뒤
+    // simplifyUnusedExprStmt 가 numeric literal-only expression statement 를
+    // empty statement 로 정리.
     try expectMinifyDead(
         "(() => 1)();",
-        "function run() {\n\t(() => 1)();\n}\nrun();",
+        "function run() {\n\t;\n}\nrun();",
     );
 }
 
@@ -2074,5 +2077,77 @@ test "inline: 배열 안에 object — inline" {
     try expectMinifyDead(
         "const data = [{ id: 1 }, { id: 2 }]; console.log(data);",
         "function run() {\n\t;\n\tconsole.log([{ id: 1 }, { id: 2 }]);\n}\nrun();",
+    );
+}
+
+// ================================================================
+// IIFE collapse — `(()=>X)()` / `(()=>{return X})()` → X
+// ================================================================
+
+test "iife: concise expression body" {
+    try expectMinify("const x = (() => 1 + 2)();", "const x = 3;");
+}
+
+test "iife: single return statement body" {
+    try expectMinify("const x = (() => { return 42; })();", "const x = 42;");
+}
+
+test "iife: returning call expression" {
+    try expectMinify(
+        "function f(x) { return x * 2; } const r = (() => f(10))();",
+        "function f(x) {\n\treturn x * 2;\n}\nconst r = f(10);",
+    );
+}
+
+test "iife: returning object — paren-wrapped to keep statement-context safe" {
+    try expectMinify(
+        "const o = (() => { return { value: 3 }; })();",
+        "const o = ({ value: 3 });",
+    );
+}
+
+test "iife: returning paren-wrapped object — paren preserved (codegen lifts later)" {
+    // concise body 가 `({value:3})` parenthesized_expression — collapse 시 paren
+    // 그대로 유지. var initializer 위치라 paren 자체는 무해, codegen 의 paren
+    // simplification 이 별도로 lift 가능.
+    try expectMinify(
+        "const o = (() => ({ value: 3 }))();",
+        "const o = ({ value: 3 });",
+    );
+}
+
+test "iife: with parameter — abandon (not zero-arg arrow)" {
+    // arrow 가 인자 받으면 IIFE 가 아닌 일반 callback 일 가능성. 보수적으로 skip.
+    try expectMinify(
+        "const r = ((x) => x + 1)(5);",
+        "const r = ((x) => x + 1)(5);",
+    );
+}
+
+test "iife: function expression — abandon (this/arguments semantics differ)" {
+    try expectMinify(
+        "const r = (function() { return 7; })();",
+        "const r = (function() {\n\treturn 7;\n})();",
+    );
+}
+
+test "iife: async arrow — abandon (await/promise semantics)" {
+    try expectMinify(
+        "const r = (async () => 5)();",
+        "const r = (async () => 5)();",
+    );
+}
+
+test "iife: multi-statement body — abandon (block has more than 1 statement)" {
+    try expectMinify(
+        "const r = (() => { console.log('side'); return 1; })();",
+        "const r = (() => {\n\tconsole.log(\"side\");\n\treturn 1;\n})();",
+    );
+}
+
+test "iife: bare return — abandon (return; with no argument)" {
+    try expectMinify(
+        "const r = (() => { return; })();",
+        "const r = (() => {\n\treturn;\n})();",
     );
 }


### PR DESCRIPTION
## Summary
oxc `substitute_iife_call` 최소 스펙 — arrow function IIFE 를 inner expression 으로 평탄화.

## Scope
| 패턴 | 동작 | 예 |
|---|---|---|
| concise body | `(() => X)()` → `X` | `(() => 1+2)()` → `1+2` (그 후 fold → `3`) |
| single return | `(() => { return X; })()` → `X` | `(() => { return 42 })()` → `42` |
| object/function/class 반환 | `parenthesized_expression` wrap | `(() => ({a:1}))()` → `({a:1})` |
| parameter 있음 | abandon | `((x) => x+1)(5)` 그대로 |
| function expression | abandon (`this`/`arguments` 의미 차) | `(function() { return 7 })()` 그대로 |
| async / multi-statement / bare return | abandon | 보수적 |

## 설계 노트
- **Span 은 inner 그대로 유지** — `string_literal`/`template_literal` 의 span 이 곧 source text 위치라 call expression span 으로 덮으면 emit 시 wrong text (`"(() => \"hi\")("` 같은 깨진 결과). esbuild/oxc 모두 inner span 사용.
- statement-context `{a:1};` 가 block 으로 파싱되는 ASI hazard 회피 위해 object/function/class 반환 시 paren wrap 강제.
- arrow function 만 — function 은 `this`/`arguments` semantics 차이로 별도 fix 필요.

## Test
- `src/transformer/minify_test.zig` 에 10 새 테스트
- 기존 `(() => 1)();` 테스트 갱신 (collapse → unused-expr 제거 → `;`)
- `zig build test` 통과
- minify-bench 6 fixture 모두 size/sanity 동일 (IIFE 패턴 라이브러리에 없거나 const-prepass 가 이미 처리)

## Followup
probe3 같은 `(() => { const a=1; const b=2; const c=a+b; return {value:c}; })()` 케이스는 inline pass 한계로 body 가 single-statement 로 정리 안 되어 collapse 안 됨. **single-use temp inliner** PR 후 자동 fold 예상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)