### PR TITLE
feat(minify): inline single-use pure compound expressions

### DIFF
--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -1122,6 +1122,10 @@ fn foldCall(ast: *Ast, node_idx: u32, node: Node, changed: *bool) void {
     const flags = ast.readExtra(e, 3);
     if ((flags & ast_mod.CallFlags.optional_chain) != 0) return;
 
+    // IIFE collapse 시도 — `(()=>X)()` / `(()=>{return X})()` → X.
+    // oxc `substitute_iife_call` (substitute_alternate_syntax.rs) 의 최소 스펙.
+    if (tryFoldIife(ast, node_idx, e, changed)) return;
+
     const callee_idx: NodeIndex = @enumFromInt(ast.readExtra(e, 0));
     const callee_ni = @intFromEnum(callee_idx);
     if (callee_ni >= ast.nodes.items.len) return;
@@ -1151,6 +1155,80 @@ fn foldCall(ast: *Ast, node_idx: u32, node: Node, changed: *bool) void {
             replaceNode(ast, node_idx, bool_node, changed);
         }
     }
+}
+
+/// IIFE collapse — arrow function 만, args/params 0, async 아님, body 가
+/// expression(concise) 또는 single-return statement block 인 케이스. callee 의
+/// return expression 으로 call_expression 노드를 in-place 대체. function expression
+/// 은 `this`/`arguments` 의미가 다르고 hoisted name 도 있어 제외.
+///
+/// 보수 가드: returned expression 이 object/function/class literal 이면 abandon
+/// — codegen 이 statement-context paren wrap 보장 안 함 ('{a:1};' 가 block 으로
+/// 파싱되는 statement-level IIFE 회피). expression context (var initializer 등)
+/// 가 99%지만 statement 단독 IIFE side-effect 패턴도 존재.
+fn tryFoldIife(ast: *Ast, node_idx: u32, e: u32, changed: *bool) bool {
+    const args_len = ast.readExtra(e, 2);
+    if (args_len != 0) return false;
+
+    const callee_raw = ast.readExtra(e, 0);
+    if (callee_raw >= ast.nodes.items.len) return false;
+    const callee = unwrapParens(ast, ast.nodes.items[callee_raw]);
+    if (callee.tag != .arrow_function_expression) return false;
+
+    const arrow_e = callee.data.extra;
+    if (!ast.hasExtra(arrow_e, ast_mod.ArrowExtra.flags)) return false;
+    const arrow_flags = ast.readExtra(arrow_e, ast_mod.ArrowExtra.flags);
+    if ((arrow_flags & ast_mod.ArrowFlags.is_async) != 0) return false;
+
+    if (ast.functionParams(callee).len != 0) return false;
+
+    const body_idx = ast.functionBodyBlock(callee) orelse return false;
+    const body_ni = @intFromEnum(body_idx);
+    if (body_ni >= ast.nodes.items.len) return false;
+    const body = ast.nodes.items[body_ni];
+
+    var return_ni: u32 = undefined;
+    if (body.tag == .block_statement) {
+        const list = body.data.list;
+        if (list.len != 1) return false;
+        if (list.start >= ast.extra_data.items.len) return false;
+        const stmt_raw = ast.extra_data.items[list.start];
+        if (stmt_raw >= ast.nodes.items.len) return false;
+        const stmt = ast.nodes.items[stmt_raw];
+        if (stmt.tag != .return_statement) return false;
+        const arg = stmt.data.unary.operand;
+        if (arg.isNone()) return false;
+        return_ni = @intFromEnum(arg);
+    } else {
+        return_ni = body_ni;
+    }
+
+    if (return_ni >= ast.nodes.items.len) return false;
+    const return_node = ast.nodes.items[return_ni];
+
+    // statement-context 위험한 leading-token 형태 (object/function/class)는
+    // parenthesized_expression 으로 감싸 emit 안전성 확보 — `{a:1};` 가 block 으로
+    // 파싱되는 ASI hazard 회피.
+    //
+    // **span 은 inner 그대로 유지** — string_literal/template_literal 등은 span 이
+    // 곧 source text 위치라 call expression span (`(()=>"hi")()` 전체) 으로 덮으면
+    // emit 시 wrong text 가 출력된다. esbuild/oxc 도 inner span 사용.
+    const needs_paren = switch (return_node.tag) {
+        .object_expression, .function_expression, .class_expression => true,
+        else => false,
+    };
+    if (needs_paren) {
+        const wrapped = ast.addNode(.{
+            .tag = .parenthesized_expression,
+            .span = return_node.span,
+            .data = .{ .unary = .{ .operand = @enumFromInt(return_ni), .flags = 0 } },
+        }) catch return false;
+        ast.nodes.items[node_idx] = ast.nodes.items[@intFromEnum(wrapped)];
+    } else {
+        ast.nodes.items[node_idx] = return_node;
+    }
+    changed.* = true;
+    return true;
 }
 
 /// x === true → x, x === false → !x, x !== true → !x, x !== false → x

--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -728,23 +728,29 @@ fn tryInlineDecl(ast: *Ast, ctx: MinifyCtx, counts: []const u32, first_loc: []co
     if (init_ni >= ast.nodes.items.len) return;
     const init_node = ast.nodes.items[init_ni];
 
-    // inline 대상 두 종류: ① 식별자 의존 없는 constant expr (mutable state 무관 → 위치 자유),
-    // ② **immutable binding 의 alias** — `const x = foo;` 에서 `foo` 가 재할당 없는 심볼
-    //   (const / import / param / function·class 선언명; write_count == 0). ②는 read 가 `x`
-    //   선언과 **같은 scope** 에 있을 때만 (아래 scope 검사) — 다른 scope 로 ref 를 옮기면
-    //   `foo` 의 이름이 그 scope 의 다른 binding 에 의해 shadow 될 수 있고, mangler 는
-    //   "outer 심볼 ref 가 그 이름을 shadow 하는 inner scope 안에 나타나는" 상황을 가정 안 함
-    //   (특히 1글자 이름은 skip 되어 원본 유지) → collision. 같은 scope 면 `foo` resolve 가
-    //   선언 위치와 동일하므로 그런 상황이 생기지 않음.
+    // inline 대상 세 종류:
+    //   ① constant expr (mutable state 무관 → 위치 자유)
+    //   ② **immutable binding alias** — `const x = foo;` 에서 `foo` 가 write_count==0
+    //   ③ **pure compound expr** — `const x = a+1;` 처럼 binary/unary/conditional/
+    //      member access 등. 안 의 모든 reference 가 immutable 이어야 ordering 안전.
+    // ②/③ 는 read 가 declaration 과 **같은 scope** 일 때만 (아래 scope 검사) —
+    // 다른 scope 로 ref 를 옮기면 mangle/shadow collision 위험.
     var alias_sym: ?u32 = null;
+    var needs_scope_check = false;
     if (!isConstantExpr(ast, init_idx)) {
-        if (ctx.symbol_ids_mut == null) return; // alias inline 은 mutable symbol_ids 필요
-        if (init_node.tag != .identifier_reference) return;
-        if (init_ni >= ctx.symbol_ids.len) return;
-        const s = ctx.symbol_ids[init_ni] orelse return; // unresolved global → 불변성 확인 불가
-        if (s >= ctx.symbols.len or s == sym_id) return; // self-ref(`const x = x;`) 방어
-        if (ctx.symbols[s].write_count != 0) return; // 어딘가 재할당 → 불변 아님
-        alias_sym = s;
+        if (ctx.symbol_ids_mut == null) return; // symbol_ids mutation 필요한 케이스
+        if (init_node.tag == .identifier_reference) {
+            if (init_ni >= ctx.symbol_ids.len) return;
+            const s = ctx.symbol_ids[init_ni] orelse return;
+            if (s == sym_id) return; // self-ref(`const x = x;`) 방어
+            if (!isImmutableSymbol(ctx, s)) return;
+            alias_sym = s;
+        } else {
+            // pure compound expression — 모든 내부 reference 의 referenced symbol 이
+            // immutable(write_count==0) 이어야 inline 후 ordering 보존.
+            if (!allInnerReferencesImmutable(ast, ctx, init_idx, sym_id)) return;
+        }
+        needs_scope_check = true;
     }
     if (!purity.isExprPure(ast, init_idx, ctx.unresolved_globals)) return;
 
@@ -754,10 +760,11 @@ fn tryInlineDecl(ast: *Ast, ctx: MinifyCtx, counts: []const u32, first_loc: []co
     const read_ni = first_loc[sym_id];
     if (read_ni == std.math.maxInt(u32) or read_ni >= ast.nodes.items.len) return;
 
-    // alias inline: read 위치가 `x` 선언과 같은 scope 여야 안전 (위 주석). read 의 scope 는
-    // pre-minify `references` 에서 `node_index == read_ni` 인 항목으로 조회 — transformer 가
-    // 노드를 copy 했으면 매칭 실패(orphan) → 안전 보수적 skip.
-    if (alias_sym != null) {
+    // alias / pure compound inline: read 위치가 `x` 선언과 같은 scope 여야 안전 (위
+    // 주석). read 의 scope 는 pre-minify `references` 에서 `node_index == read_ni` 인
+    // 항목으로 조회 — transformer 가 노드를 copy 했으면 매칭 실패(orphan) → 안전
+    // 보수적 skip.
+    if (needs_scope_check) {
         var read_scope_ok = false;
         for (ctx.references) |r| {
             if (@intFromEnum(r.node_index) != read_ni) continue;
@@ -780,11 +787,25 @@ fn tryInlineDecl(ast: *Ast, ctx: MinifyCtx, counts: []const u32, first_loc: []co
     // in-place swap: read 위치의 identifier_reference 를 init 의 tag/data 로 덮어쓴다.
     // init 의 자식은 extra_data 공유 → codegen 은 read_ni 에서 init 전체를 출력.
     // span 은 init 의 것을 사용 (source map 에서 inlined 값의 위치 유지).
-    ast.nodes.items[read_ni] = .{
-        .tag = init_node.tag,
-        .span = init_node.span,
-        .data = init_node.data,
-    };
+    //
+    // pure compound expression 은 parenthesized_expression 으로 wrap — codegen 이
+    // precedence-based paren 을 자동 추가하지 않으므로 `const a=x+1; b=a*2;` 가
+    // `b=x+1*2` (잘못, `1*2` 먼저) 가 되는 회귀 방지. constant / alias 분기는 단일
+    // 토큰이라 paren 불필요.
+    const pure_compound = alias_sym == null and needs_scope_check;
+    if (pure_compound) {
+        ast.nodes.items[read_ni] = .{
+            .tag = .parenthesized_expression,
+            .span = init_node.span,
+            .data = .{ .unary = .{ .operand = init_idx, .flags = 0 } },
+        };
+    } else {
+        ast.nodes.items[read_ni] = .{
+            .tag = init_node.tag,
+            .span = init_node.span,
+            .data = init_node.data,
+        };
+    }
     // alias inline: codegen/mangler 의 rename 조회가 symbol_id 기준이므로 read 위치의
     // symbol_id 를 `S` 로 갱신. ref count 는 불변 — init 의 `S`-ref 가 read 위치로 "이동"
     // 하고, decl 제거로 orphan 되는 init 노드가 `reference_count(S)` 를 balance.
@@ -801,6 +822,43 @@ fn tryInlineDecl(ast: *Ast, ctx: MinifyCtx, counts: []const u32, first_loc: []co
     }, changed);
     if (sym_id < ctx.ref_deltas.len) ctx.ref_deltas[sym_id] += 1;
     changed.* = true;
+}
+
+/// 심볼이 어디서도 재할당되지 않는지 (`write_count == 0`). out-of-bounds
+/// 보수적 false. alias inline / pure compound inline 양쪽에서 공유.
+inline fn isImmutableSymbol(ctx: MinifyCtx, sid: u32) bool {
+    return sid < ctx.symbols.len and ctx.symbols[sid].write_count == 0;
+}
+
+/// `idx` 안의 모든 identifier_reference 의 referenced symbol 이 immutable 인지
+/// 재귀 판정. self-reference 도 거부 (decl_sym_id 와 같은 symbol → `const x = x;`
+/// 같은 self-cycle 방어). unresolved global 또는 symbol_ids 미매핑이면 보수적
+/// false.
+///
+/// pure compound expression inline 안전성 — `const a = x+1; b = a*2;` 에서
+/// `x` 가 mutable 이면 inline 후 `b = (x+1)*2;` 의 `x` 평가 시점이 declaration
+/// 위치에서 read 위치로 옮겨가 ordering 의미 변경 위험.
+fn allInnerReferencesImmutable(
+    ast: *const Ast,
+    ctx: MinifyCtx,
+    idx: NodeIndex,
+    decl_sym_id: u32,
+) bool {
+    if (idx.isNone()) return true;
+    const ni = @intFromEnum(idx);
+    if (ni >= ast.nodes.items.len) return true;
+    const node = ast.nodes.items[ni];
+    if (node.tag == .identifier_reference) {
+        if (ni >= ctx.symbol_ids.len) return false;
+        const sid = ctx.symbol_ids[ni] orelse return false;
+        if (sid == decl_sym_id) return false;
+        if (!isImmutableSymbol(ctx, sid)) return false;
+    }
+    var it = ast_walk.children(ast, node);
+    while (it.next()) |child| {
+        if (!allInnerReferencesImmutable(ast, ctx, child, decl_sym_id)) return false;
+    }
+    return true;
 }
 
 /// init 이 식별자 의존성 없는 constant expression 인지 판정.

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -1815,11 +1815,12 @@ test "inline: var — 보존 (hoisting 이슈)" {
     );
 }
 
-test "inline: 식별자 의존 init — 보존 (Phase 3 일반 expression 범위 밖)" {
-    // init 에 outer variable 참조 → isConstantExpr false → inline skip.
+test "inline: 식별자 의존 init — pure compound inline (paren wrap)" {
+    // init 이 pure binary 이고 모든 inner reference (n) 가 immutable 이면 inline.
+    // paren wrap 으로 precedence 보존 — outer 가 statement-root 라도 conservative.
     try expectMinifyDead(
         "function f(n) { const x = n * 2; return x; } f(1);",
-        "function run() {\n\tfunction f(n) {\n\t\tconst x = n * 2;\n\t\treturn x;\n\t}\n\tf(1);\n}\nrun();",
+        "function run() {\n\tfunction f(n) {\n\t\t;\n\t\treturn (n * 2);\n\t}\n\tf(1);\n}\nrun();",
     );
 }
 
@@ -1831,11 +1832,11 @@ test "inline: 함수 호출 init — 보존 (pure 확인 불가)" {
     );
 }
 
-test "inline: shorthand property — 보존 (value 가 identifier_reference)" {
-    // { a } 는 value = identifier_reference → constant expr 아님 → inline 불가.
+test "inline: shorthand property — pure object inline (a 가 immutable param)" {
+    // { a } 의 value identifier_reference 가 immutable parameter → pure compound inline.
     try expectMinifyDead(
         "function f(a) { const o = { a }; return o; } f(1);",
-        "function run() {\n\tfunction f(a) {\n\t\tconst o = { a };\n\t\treturn o;\n\t}\n\tf(1);\n}\nrun();",
+        "function run() {\n\tfunction f(a) {\n\t\t;\n\t\treturn ({ a });\n\t}\n\tf(1);\n}\nrun();",
     );
 }
 
@@ -1946,11 +1947,11 @@ test "inline: object with numeric key — inline" {
     );
 }
 
-test "inline: computed key — 보존" {
-    // [k] 는 expression — constant expr 판정에서 제외.
+test "inline: computed key — pure object inline (k 가 immutable param)" {
+    // [k] 의 k 가 immutable parameter → pure compound inline.
     try expectMinifyDead(
         "function f(k) { const o = { [k]: 1 }; return o; } f('x');",
-        "function run() {\n\tfunction f(k) {\n\t\tconst o = { [k]: 1 };\n\t\treturn o;\n\t}\n\tf(\"x\");\n}\nrun();",
+        "function run() {\n\tfunction f(k) {\n\t\t;\n\t\treturn ({ [k]: 1 });\n\t}\n\tf(\"x\");\n}\nrun();",
     );
 }
 
@@ -2027,25 +2028,26 @@ test "inline: eval 스코프 — 보존 (blocksMangling)" {
     );
 }
 
-test "inline: conditional expression init — 보존 (식별자 의존 가능)" {
+test "inline: conditional expression init — pure compound inline" {
+    // c 가 immutable parameter → pure compound (paren wrap).
     try expectMinifyDead(
         "function f(c) { const x = c ? 1 : 2; return x; } f(true);",
-        "function run() {\n\tfunction f(c) {\n\t\tconst x = c ? 1 : 2;\n\t\treturn x;\n\t}\n\tf(true);\n}\nrun();",
+        "function run() {\n\tfunction f(c) {\n\t\t;\n\t\treturn (c ? 1 : 2);\n\t}\n\tf(true);\n}\nrun();",
     );
 }
 
-test "inline: binary expression init — 보존 (constant fold 이후에도 expr 이면 skip)" {
-    // `n + 1` — fold 후에도 binary 로 남으면 isConstantExpr 에서 제외.
+test "inline: binary expression init — pure compound inline (paren wrap)" {
+    // n + 1 — n 이 immutable parameter, binary 가 pure → inline.
     try expectMinifyDead(
         "function f(n) { const x = n + 1; return x; } f(1);",
-        "function run() {\n\tfunction f(n) {\n\t\tconst x = n + 1;\n\t\treturn x;\n\t}\n\tf(1);\n}\nrun();",
+        "function run() {\n\tfunction f(n) {\n\t\t;\n\t\treturn (n + 1);\n\t}\n\tf(1);\n}\nrun();",
     );
 }
 
-test "inline: unary expression init — 보존" {
+test "inline: unary expression init — pure compound inline (paren wrap)" {
     try expectMinifyDead(
         "function f(n) { const x = -n; return x; } f(1);",
-        "function run() {\n\tfunction f(n) {\n\t\tconst x = -n;\n\t\treturn x;\n\t}\n\tf(1);\n}\nrun();",
+        "function run() {\n\tfunction f(n) {\n\t\t;\n\t\treturn (-n);\n\t}\n\tf(1);\n}\nrun();",
     );
 }
 
@@ -2149,5 +2151,29 @@ test "iife: bare return — abandon (return; with no argument)" {
     try expectMinify(
         "const r = (() => { return; })();",
         "const r = (() => {\n\treturn;\n})();",
+    );
+}
+
+// ================================================================
+// Single-use temp inliner — pure compound expression
+// 회귀 가드: paren wrap 누락 시 precedence 손실로 의미 변경 위험.
+// ================================================================
+
+test "inline: precedence 보존 — chained binary inline" {
+    // const a=x+1; const b=a*2; const c=b-3; return c;
+    // 각 단계 inline 후 paren 누락 시 `x+1*2-3` 가 되어 `x-1` 로 해석 (잘못).
+    // 정답: `((x+1)*2)-3`. node 실행: g(2) → 3.
+    try expectMinifyDead(
+        "function g(x) { const a = x+1; const b = a*2; const c = b-3; return c; } g(2);",
+        "function run() {\n\tfunction g(x) {\n\t\t;\n\t\t;\n\t\t;\n\t\treturn (((x + 1) * 2) - 3);\n\t}\n\tg(2);\n}\nrun();",
+    );
+}
+
+test "inline: mutable referenced symbol — abandon (let)" {
+    // `let x = 1; const a = x + 1; x = 2; ...` — x 가 mutable 이면 inline 후
+    // ordering 변경 위험. allInnerReferencesImmutable 가 false → skip.
+    try expectMinifyDead(
+        "function f() { let x = 1; const a = x + 1; x = 2; return a + x; } f();",
+        "function run() {\n\tfunction f() {\n\t\tlet x = 1;\n\t\tconst a = x + 1;\n\t\tx = 2;\n\t\treturn a + x;\n\t}\n\tf();\n}\nrun();",
     );
 }

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -1692,10 +1692,13 @@ test "unused: (class X{})(); — class callee 도 paren 유지" {
     );
 }
 
-test "unused: (() => 1)(); — arrow callee 도 paren 유지" {
+test "unused: (() => 1)(); — IIFE collapse → unused-expr 제거" {
+    // IIFE collapse (`tryFoldIife`) 가 call 을 `1` 로 대체, 그 뒤
+    // simplifyUnusedExprStmt 가 numeric literal-only expression statement 를
+    // empty statement 로 정리.
     try expectMinifyDead(
         "(() => 1)();",
-        "function run() {\n\t(() => 1)();\n}\nrun();",
+        "function run() {\n\t;\n}\nrun();",
     );
 }
 
@@ -2074,5 +2077,77 @@ test "inline: 배열 안에 object — inline" {
     try expectMinifyDead(
         "const data = [{ id: 1 }, { id: 2 }]; console.log(data);",
         "function run() {\n\t;\n\tconsole.log([{ id: 1 }, { id: 2 }]);\n}\nrun();",
+    );
+}
+
+// ================================================================
+// IIFE collapse — `(()=>X)()` / `(()=>{return X})()` → X
+// ================================================================
+
+test "iife: concise expression body" {
+    try expectMinify("const x = (() => 1 + 2)();", "const x = 3;");
+}
+
+test "iife: single return statement body" {
+    try expectMinify("const x = (() => { return 42; })();", "const x = 42;");
+}
+
+test "iife: returning call expression" {
+    try expectMinify(
+        "function f(x) { return x * 2; } const r = (() => f(10))();",
+        "function f(x) {\n\treturn x * 2;\n}\nconst r = f(10);",
+    );
+}
+
+test "iife: returning object — paren-wrapped to keep statement-context safe" {
+    try expectMinify(
+        "const o = (() => { return { value: 3 }; })();",
+        "const o = ({ value: 3 });",
+    );
+}
+
+test "iife: returning paren-wrapped object — paren preserved (codegen lifts later)" {
+    // concise body 가 `({value:3})` parenthesized_expression — collapse 시 paren
+    // 그대로 유지. var initializer 위치라 paren 자체는 무해, codegen 의 paren
+    // simplification 이 별도로 lift 가능.
+    try expectMinify(
+        "const o = (() => ({ value: 3 }))();",
+        "const o = ({ value: 3 });",
+    );
+}
+
+test "iife: with parameter — abandon (not zero-arg arrow)" {
+    // arrow 가 인자 받으면 IIFE 가 아닌 일반 callback 일 가능성. 보수적으로 skip.
+    try expectMinify(
+        "const r = ((x) => x + 1)(5);",
+        "const r = ((x) => x + 1)(5);",
+    );
+}
+
+test "iife: function expression — abandon (this/arguments semantics differ)" {
+    try expectMinify(
+        "const r = (function() { return 7; })();",
+        "const r = (function() {\n\treturn 7;\n})();",
+    );
+}
+
+test "iife: async arrow — abandon (await/promise semantics)" {
+    try expectMinify(
+        "const r = (async () => 5)();",
+        "const r = (async () => 5)();",
+    );
+}
+
+test "iife: multi-statement body — abandon (block has more than 1 statement)" {
+    try expectMinify(
+        "const r = (() => { console.log('side'); return 1; })();",
+        "const r = (() => {\n\tconsole.log(\"side\");\n\treturn 1;\n})();",
+    );
+}
+
+test "iife: bare return — abandon (return; with no argument)" {
+    try expectMinify(
+        "const r = (() => { return; })();",
+        "const r = (() => {\n\treturn;\n})();",
     );
 }


### PR DESCRIPTION
## Summary
기존 `inlineSingleUse` 가 ① constant ② immutable alias 만 처리하던 것을 ③ pure compound expression (binary/unary/conditional/member/object/array …) 까지 확장. esbuild `substituteSingleUseSymbolInStmt` + oxc `inline_let` 와 동일 효과.

## Probe 검증
| Probe | Before | After |
|---|---|---|
| `const a=x+1; const b=a*2; const c=b-3; return c` | `let c=x+1*2-3; return c` (보존) | `return ((x+1)*2)-3` |
| `const a = n*2; return a` | `const a=n*2; return a` (보존) | `return (n*2)` |
| `const a = c?1:2; return a` | 보존 | `return (c?1:2)` |
| `let x=1; const a=x+1; x=2; return a+x` | 보존 | **여전히 보존** (mutable x → abandon) |

## 안전 가드
- `allInnerReferencesImmutable(ast, ctx, init_idx, decl_sym_id)` — init 안 모든 inner identifier_reference 의 referenced symbol `write_count == 0` 검사
- read 가 declaration 과 같은 scope (alias 분기와 공유) — cross-scope shadow collision 방지
- forward-reference TDZ 가드 (sourceSpanStart, 기존)
- `isExprPure` 통과 (call/new known-pure)
- self-ref 방어 + helper `isImmutableSymbol(ctx, sid)` 두 분기 공유

## paren wrap
codegen 이 precedence-based paren 자동 추가 안 함 → pure compound 결과 항상 `parenthesized_expression` 으로 wrap. 일부 outer paren 잉여 (esbuild 는 precedence-aware) — 의미 안전 우선, 별도 follow-up 후보.

## Test plan
- [x] `zig build test` — 회귀 가드 2종 통과 (precedence 보존 + mutable abandon), 기존 inline 테스트 6종 expected 갱신 (functionally 동등)
- [x] `node /tmp/p9.js` — `g(2) = 3` (precedence 정확)
- [x] minify-bench 6 fixture sanity 통과 (effect 201.2→201.1KB 미세 감소, 다른 fixture 동일)
- [x] baseline 25 RN codegen FileNotFound 와 동일 (변경 무관)

## Followup
1. Precedence-aware paren elimination — outer paren 잉여 케이스 (`return (n+1)*2-3` esbuild vs 우리 `return ((n+1)*2)-3`)
2. probe3 같은 multi-stmt body IIFE — 이번 inliner + PR #3231 IIFE collapse 가 fixpoint 통해 자동 fold

🤖 Generated with [Claude Code](https://claude.com/claude-code)