### PR TITLE
feat(minify): paren-elimination at statement-root for pure compound inline

### DIFF
--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -557,6 +557,27 @@ pub fn markForbiddenInlineSites(ast: *const Ast, forbidden: *std.DynamicBitSet) 
     }
 }
 
+/// 각 statement 의 root expression NodeIndex 를 set — `return X;` /
+/// `X;` (expression_statement) / `var x = X;` (variable_declarator init).
+/// pure compound inline 시 이 위치엔 paren wrap 불필요 — caller context 가
+/// statement 라 precedence 무관.
+pub fn markStatementRootExpressions(ast: *const Ast, roots: *std.DynamicBitSet) void {
+    const cap = roots.capacity();
+    for (ast.nodes.items) |node| switch (node.tag) {
+        .return_statement, .expression_statement => {
+            const operand_ni = @intFromEnum(node.data.unary.operand);
+            if (operand_ni < cap) roots.set(operand_ni);
+        },
+        .variable_declarator => {
+            const e = node.data.extra;
+            if (e + 2 >= ast.extra_data.items.len) continue;
+            const init_ni = ast.extra_data.items[e + 2];
+            if (init_ni < cap) roots.set(init_ni);
+        },
+        else => {},
+    };
+}
+
 fn isPrimitiveConstantExpr(ast: *const Ast, idx: NodeIndex) bool {
     if (idx.isNone()) return false;
     const ni = @intFromEnum(idx);
@@ -649,6 +670,14 @@ fn inlineSingleUse(ast: *Ast, ctx: MinifyCtx, skip_for_binding: ?*const std.Dyna
     defer forbidden.deinit();
     markForbiddenInlineSites(ast, &forbidden);
 
+    // statement-root expression 위치 마킹 — `return X;` / `X;` (expression_statement)
+    // / `var x = X;` (variable_declarator init) 의 root X. pure compound inline 시
+    // 이 위치에 read 가 있으면 caller context 가 statement 라 precedence 무관
+    // → paren wrap 불필요 (`return ((x+1)*2)-3` → `return (x+1)*2-3`).
+    var stmt_roots = std.DynamicBitSet.initEmpty(scratch, ast.nodes.items.len) catch return;
+    defer stmt_roots.deinit();
+    markStatementRootExpressions(ast, &stmt_roots);
+
     // symbol 별 identifier_reference 등장 횟수 + 첫 등장 NodeIndex 를 스캔.
     // 오직 live 영역의 identifier_reference 만 집계한다 — transformer 가 남긴 orphan
     // 을 세면 ref_count 미스매치로 inline 이 어긋난다.
@@ -680,11 +709,11 @@ fn inlineSingleUse(ast: *Ast, ctx: MinifyCtx, skip_for_binding: ?*const std.Dyna
         if (live_nodes) |lives| {
             if (i >= lives.capacity() or !lives.isSet(i)) continue;
         }
-        tryInlineDecl(ast, ctx, counts, first_loc, @intCast(i), node, changed);
+        tryInlineDecl(ast, ctx, counts, first_loc, &stmt_roots, @intCast(i), node, changed);
     }
 }
 
-fn tryInlineDecl(ast: *Ast, ctx: MinifyCtx, counts: []const u32, first_loc: []const u32, decl_stmt_idx: u32, node: Node, changed: *bool) void {
+fn tryInlineDecl(ast: *Ast, ctx: MinifyCtx, counts: []const u32, first_loc: []const u32, stmt_roots: *const std.DynamicBitSet, decl_stmt_idx: u32, node: Node, changed: *bool) void {
     const kind = ast.variableDeclarationKind(node);
     if (kind.isUsing()) return;
     if (kind == .@"var") return;
@@ -793,7 +822,10 @@ fn tryInlineDecl(ast: *Ast, ctx: MinifyCtx, counts: []const u32, first_loc: []co
     // `b=x+1*2` (잘못, `1*2` 먼저) 가 되는 회귀 방지. constant / alias 분기는 단일
     // 토큰이라 paren 불필요.
     const pure_compound = alias_sym == null and needs_scope_check;
-    if (pure_compound) {
+    // statement-root 위치 (return/expression_statement/variable_declarator init) 면
+    // caller context 가 statement 라 precedence 무관 → paren skip.
+    const at_stmt_root = read_ni < stmt_roots.capacity() and stmt_roots.isSet(read_ni);
+    if (pure_compound and !at_stmt_root) {
         ast.nodes.items[read_ni] = .{
             .tag = .parenthesized_expression,
             .span = init_node.span,

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -1820,7 +1820,7 @@ test "inline: 식별자 의존 init — pure compound inline (paren wrap)" {
     // paren wrap 으로 precedence 보존 — outer 가 statement-root 라도 conservative.
     try expectMinifyDead(
         "function f(n) { const x = n * 2; return x; } f(1);",
-        "function run() {\n\tfunction f(n) {\n\t\t;\n\t\treturn (n * 2);\n\t}\n\tf(1);\n}\nrun();",
+        "function run() {\n\tfunction f(n) {\n\t\t;\n\t\treturn n * 2;\n\t}\n\tf(1);\n}\nrun();",
     );
 }
 
@@ -1836,7 +1836,7 @@ test "inline: shorthand property — pure object inline (a 가 immutable param)"
     // { a } 의 value identifier_reference 가 immutable parameter → pure compound inline.
     try expectMinifyDead(
         "function f(a) { const o = { a }; return o; } f(1);",
-        "function run() {\n\tfunction f(a) {\n\t\t;\n\t\treturn ({ a });\n\t}\n\tf(1);\n}\nrun();",
+        "function run() {\n\tfunction f(a) {\n\t\t;\n\t\treturn { a };\n\t}\n\tf(1);\n}\nrun();",
     );
 }
 
@@ -1951,7 +1951,7 @@ test "inline: computed key — pure object inline (k 가 immutable param)" {
     // [k] 의 k 가 immutable parameter → pure compound inline.
     try expectMinifyDead(
         "function f(k) { const o = { [k]: 1 }; return o; } f('x');",
-        "function run() {\n\tfunction f(k) {\n\t\t;\n\t\treturn ({ [k]: 1 });\n\t}\n\tf(\"x\");\n}\nrun();",
+        "function run() {\n\tfunction f(k) {\n\t\t;\n\t\treturn { [k]: 1 };\n\t}\n\tf(\"x\");\n}\nrun();",
     );
 }
 
@@ -2032,7 +2032,7 @@ test "inline: conditional expression init — pure compound inline" {
     // c 가 immutable parameter → pure compound (paren wrap).
     try expectMinifyDead(
         "function f(c) { const x = c ? 1 : 2; return x; } f(true);",
-        "function run() {\n\tfunction f(c) {\n\t\t;\n\t\treturn (c ? 1 : 2);\n\t}\n\tf(true);\n}\nrun();",
+        "function run() {\n\tfunction f(c) {\n\t\t;\n\t\treturn c ? 1 : 2;\n\t}\n\tf(true);\n}\nrun();",
     );
 }
 
@@ -2040,14 +2040,14 @@ test "inline: binary expression init — pure compound inline (paren wrap)" {
     // n + 1 — n 이 immutable parameter, binary 가 pure → inline.
     try expectMinifyDead(
         "function f(n) { const x = n + 1; return x; } f(1);",
-        "function run() {\n\tfunction f(n) {\n\t\t;\n\t\treturn (n + 1);\n\t}\n\tf(1);\n}\nrun();",
+        "function run() {\n\tfunction f(n) {\n\t\t;\n\t\treturn n + 1;\n\t}\n\tf(1);\n}\nrun();",
     );
 }
 
 test "inline: unary expression init — pure compound inline (paren wrap)" {
     try expectMinifyDead(
         "function f(n) { const x = -n; return x; } f(1);",
-        "function run() {\n\tfunction f(n) {\n\t\t;\n\t\treturn (-n);\n\t}\n\tf(1);\n}\nrun();",
+        "function run() {\n\tfunction f(n) {\n\t\t;\n\t\treturn -n;\n\t}\n\tf(1);\n}\nrun();",
     );
 }
 
@@ -2165,7 +2165,7 @@ test "inline: precedence 보존 — chained binary inline" {
     // 정답: `((x+1)*2)-3`. node 실행: g(2) → 3.
     try expectMinifyDead(
         "function g(x) { const a = x+1; const b = a*2; const c = b-3; return c; } g(2);",
-        "function run() {\n\tfunction g(x) {\n\t\t;\n\t\t;\n\t\t;\n\t\treturn (((x + 1) * 2) - 3);\n\t}\n\tg(2);\n}\nrun();",
+        "function run() {\n\tfunction g(x) {\n\t\t;\n\t\t;\n\t\t;\n\t\treturn ((x + 1) * 2) - 3;\n\t}\n\tg(2);\n}\nrun();",
     );
 }
 


### PR DESCRIPTION
## Summary
PR #3232 single-use pure compound inliner 가 read 위치를 항상 paren wrap 하던 것을, statement-root expression 위치에서는 skip — caller context 가 statement 라 precedence 무관.

## 효과
| 위치 | Before | After |
|---|---|---|
| `return X` 의 X | `return (n*2);` | `return n*2;` |
| `X;` (expression_stmt) | `X;` | `X;` (변경 없음) |
| `var x = X;` | `(...)` wrap | wrap skip |
| **nested** (`return (a)*2-3`) | wrap 유지 | wrap 유지 (precedence-aware 는 별도 follow-up) |

probe9 결과:
- 단일 inline (`f`): `return (x+1)` → `return x+1` (-2B)
- 깊은 chain (`g`): `return ((x+1)*2)-3` — outer paren 만 skip. 정답 `g(2)=3` 유지.

## 구현
- `markStatementRootExpressions(ast, roots)` — return/expression_stmt/variable_declarator init 의 root expr NodeIndex BitSet 마킹.
- `tryInlineDecl` 의 paren wrap 분기에 `at_stmt_root` 가드 추가.

## Followup
codegen 단 precedence-aware paren elimination — nested 위치 (`((x+1)*2)` outer paren) 도 정리.

## Test plan
- [x] `zig build test` — 기존 inline 테스트 6종 expected paren 제거로 갱신, chained binary 회귀 가드 (`g(2)=3`) precedence 정확
- [x] minify-bench 6 fixture 동일 (effect 186.8KB / lodash 20.8KB / etc.)
- [x] node sanity 모두 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)