### PR TITLE
perf(bundler): namespace getter minify-whitespace tokens

### DIFF
--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -506,6 +506,14 @@ fn buildInlineObjectStr(
     // circular dep에서 init 시점에 아직 undefined인 변수도 사용 시점에 올바르게 참조.
     var buf: std.ArrayList(u8) = .empty;
     defer buf.deinit(self.allocator);
+    // minify_whitespace 모드 토큰 — getter 패턴의 ` ` 와 `; ` 를 제거.
+    // `get foo() { return bar; }` (30c) → `get foo(){return bar}` (24c).
+    // 1699 getter 가 있는 effect 번들에서 ~10KB 절감.
+    const min_ws = self.minify_whitespace;
+    const list_sep: []const u8 = if (min_ws) "," else ", ";
+    const colon_sep: []const u8 = if (min_ws) ":" else ": ";
+    const get_open: []const u8 = if (min_ws) "(){return " else "() { return ";
+    const get_close: []const u8 = if (min_ws) "}" else "; }";
     try buf.appendSlice(self.allocator, "{");
     var first = true;
     for (exports.items) |exp| {
@@ -516,7 +524,7 @@ fn buildInlineObjectStr(
         if (self.graph.getModule(@enumFromInt(decl_mod_idx))) |decl_mod| {
             if (!decl_mod.isLocalBindingAlive(exp.local)) continue;
         }
-        if (!first) try buf.appendSlice(self.allocator, ", ");
+        if (!first) try buf.appendSlice(self.allocator, list_sep);
         first = false;
         const needs_quote = needsPropertyQuoteForExport(exp.exported);
         // export * as ns 패턴이면 재귀 인라인 (값으로 참조)
@@ -524,11 +532,11 @@ fn buildInlineObjectStr(
             if (needs_quote) {
                 try buf.appendSlice(self.allocator, "\"");
                 try buf.appendSlice(self.allocator, exp.exported);
-                try buf.appendSlice(self.allocator, "\": ");
+                try buf.appendSlice(self.allocator, "\"");
             } else {
                 try buf.appendSlice(self.allocator, exp.exported);
-                try buf.appendSlice(self.allocator, ": ");
             }
+            try buf.appendSlice(self.allocator, colon_sep);
             const nested = try buildInlineObjectStr(self, src_mod, depth + 1);
             defer self.allocator.free(nested);
             try buf.appendSlice(self.allocator, nested);
@@ -542,14 +550,14 @@ fn buildInlineObjectStr(
             } else {
                 try buf.appendSlice(self.allocator, exp.exported);
             }
-            try buf.appendSlice(self.allocator, "() { return ");
+            try buf.appendSlice(self.allocator, get_open);
             if (try allocNamespaceGetterValue(self, exp)) |value| {
                 defer self.allocator.free(value);
                 try buf.appendSlice(self.allocator, value);
             } else {
                 try buf.appendSlice(self.allocator, exp.local);
             }
-            try buf.appendSlice(self.allocator, "; }");
+            try buf.appendSlice(self.allocator, get_close);
         }
     }
     try buf.appendSlice(self.allocator, "}");


### PR DESCRIPTION
## Summary
`buildInlineObjectStr` (shared_namespace.zig) 가 minify_whitespace 모드에서도 getter pattern 의 공백을 그대로 emit 하던 문제 수정. 6 chars/getter 절감.

## 측정
| fixture | Before | After | Δ |
|---|---|---|---|
| **effect** | 186.8KB | **178.7KB** | -8.1KB (-4.3%) |
| zod | 64.3KB | 63.8KB | -0.5KB |
| lodash-es / rxjs / three / react | 동일 | 동일 | — |

effect 번들 1699 namespace getter × 6c = ~10KB 예상, 실측 ~8KB.

## 토큰 분리
- `() { return ` → `(){return ` (-2c)
- `; }` → `}` (-2c)
- `, ` → `,` (object separator)
- `: ` → `:` (key:value separator)

## Followup
zntc 의 60 X_ns inline namespace object 자체 elide — `exported_locals.contains(local_name)` 로 force_inline 되는 re-export pattern 의 transitive callsite rewrite 가 필요 (rolldown 패턴, ~60KB 추가 절감 예상). 별도 epic.

## Test plan
- [x] `zig build test` 통과 (baseline RN codegen FileNotFound 만)
- [x] minify-bench 6 fixture 모두 sanity 통과 (node 실행 정상)

🤖 Generated with [Claude Code](https://claude.com/claude-code)