### PR TITLE
perf(bundler): namespace inline elide for tree-shaken re-exports (root cause)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1169,7 +1169,17 @@ pub const Bundler = struct {
             }
             break :blk s;
         } else null;
+        // tree_shaker pointer 를 linker 로 전달 — namespace force_inline 결정 (3 caller
+        // in metadata.zig) 이 `isExportUsed` 로 transitively used 검사. unused
+        // namespace re-export 의 X_ns inline literal 생성 skip.
+        // clear defer 가 LIFO 로 shaker.deinit 보다 먼저 실행돼 dangling 방지.
+        defer if (linker) |*l| {
+            l.tree_shaker = null;
+        };
         defer if (shaker) |*s| s.deinit();
+        if (linker) |*l| if (shaker) |*s| {
+            l.tree_shaker = s;
+        };
 
         if (timer) |*t| {
             t_shake = t.read();

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -182,6 +182,13 @@ pub const Linker = struct {
     /// false (linker 단독 빌드 / unit test) 면 기존 동작 유지.
     tree_shaker_active: bool = false,
 
+    /// TreeShaker borrowed pointer — `tree_shaker_active=true` 일 때 set. metadata
+    /// builder 의 namespace force_inline 결정이 `isExportUsed(mod, name)` 으로
+    /// transitively used 여부 확인. unused namespace re-export 는 X_ns inline
+    /// literal 생성 skip — namespace-heavy 라이브러리의 dead X_ns 제거.
+    /// bundler 가 tree_shake.analyze() 후 set, deinit 전에 null 로 clear.
+    tree_shaker: ?*const @import("tree_shaker.zig").TreeShaker = null,
+
     /// #1824 IIFE `--globals SPEC=GLOBAL` 매핑 (rollup `output.globals` 호환).
     /// `format == .iife` 일 때만 의미 있음. 매핑된 external specifier 는 UMD/AMD 와
     /// 동일한 factory-param preamble 경로로 처리되고, 매핑 안 된 external 은
@@ -1366,6 +1373,16 @@ pub const Linker = struct {
     /// `ns.prop`만 사용되면 false (직접 치환 가능), `console.log(ns)` 등이면 true (객체 필요).
     pub fn isNamespaceUsedAsValue(allocator: std.mem.Allocator, ast: *const Ast, symbol_ids: []const ?u32, ns_sym_id: u32) bool {
         return namespace_access.isNamespaceUsedAsValue(allocator, ast, symbol_ids, ns_sym_id);
+    }
+
+    /// namespace re-export (`import * as X; export { X };`) 가 cross-module 에서
+    /// transitively 사용되는지. metadata.zig 의 force_inline 결정 (3 caller) 이
+    /// 공유 — unused re-export 는 X_ns inline literal 생성 skip → effect 같은
+    /// namespace-heavy 라이브러리에서 dead X_ns elide.
+    /// tree_shaker 미활성 (단위 테스트) 이면 보수적 true (기존 동작 유지).
+    pub fn isNamespaceExportConsumed(self: *const Linker, module_index: u32, local_name: []const u8) bool {
+        const ts = self.tree_shaker orelse return true;
+        return ts.isExportUsed(module_index, local_name);
     }
 
     pub const NamespaceAccess = namespace_access.NamespaceAccess;

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -582,10 +582,14 @@ pub fn buildMetadataForAst(
                 const effective_syms = override_symbol_ids orelse sem.symbol_ids;
 
                 // esbuild 방식: ns.prop → 직접 치환, ns 값 사용 → 변수 선언 + 참조.
-                // export { ns } 패턴도 값 사용 — namespace 객체를 preamble 변수로 생성 필요.
+                // export { ns } 패턴은 다른 모듈이 그 namespace 를 *transitively
+                // value 로 사용* 할 때만 inline 객체 필요. tree-shake 가 import
+                // 안 하면 그 X_ns 는 dead — linker.isNamespaceExportConsumed 로
+                // cross-module 사용 여부 확인 (effect 의 60 X_ns 중 34 dead 케이스).
                 // shadow 충돌은 registerNamespaceRewrites 가 자체 감지해 ns_inline_list 활성화.
                 const force_inline = isNamespaceUsedAsValue(self.allocator, ast, effective_syms, ns_sym_id) or
-                    exported_locals.contains(local_name);
+                    (exported_locals.contains(local_name) and
+                        self.isNamespaceExportConsumed(module_index, local_name));
                 try self.registerNamespaceRewrites(
                     &ns_rewrite_list,
                     &ns_inline_list,
@@ -654,7 +658,7 @@ pub fn buildMetadataForAst(
                                                 &ns_inline_list,
                                                 &owned_nested_renames,
                                                 &ns_target_to_var,
-                                                true,
+                                                self.isNamespaceExportConsumed(module_index, ib.local_name),
                                                 module_index,
                                                 @intCast(import_sym_id),
                                                 @intFromEnum(src),
@@ -684,7 +688,7 @@ pub fn buildMetadataForAst(
                                     &ns_inline_list,
                                     &owned_nested_renames,
                                     &ns_target_to_var,
-                                    true,
+                                    self.isNamespaceExportConsumed(module_index, ib.local_name),
                                     module_index,
                                     @intCast(imp_sym),
                                     @intCast(ns_target_mod),


### PR DESCRIPTION
## Summary
namespace force_inline 결정 (3 caller — `metadata.zig:587/657/687`) 이 *cross-module transitively used* 검사 없이 무조건 inline 했다. tree_shaken namespace re-export 의 `var X_ns = {get a(){...}, ...}` inline literal 이 dead 인 채로 emit. `tree_shaker.isExportUsed` 통합으로 root cause 차단.

## 진단 (effect 라이브러리)
| Category | Count |
|---|---|
| decl-only (완전 dead) | **34** |
| member-only (rewrite candidate) | 26 |
| truly value-used | **0** |

## Fix
- linker 에 borrowed `tree_shaker: ?*const TreeShaker` 필드
- helper `isNamespaceExportConsumed(mod, name)` 가 `tree_shaker.isExportUsed` 위임
- metadata.zig 의 3 caller 모두 helper 호출로 통일 — `true` 하드코딩 / `exported_locals.contains` 보수적 분기 제거
- LIFO defer 로 tree_shaker pointer null clear → shaker.deinit → linker.deinit, dangling 방지

## 측정
| fixture | Before | After | Δ |
|---|---|---|---|
| **effect** | 178.7KB | **167.0KB** | -11.7KB (-6.5%) |
| 5+ch identifier | 2433 | 1970 | -463 |
| lodash-es / zod / rxjs / three / react | 동일 | 동일 | — |

## Test plan
- [x] `zig build test` 통과 (baseline RN codegen FileNotFound 만)
- [x] minify-bench 6 fixture 모두 sanity (node 실행 정상)
- [x] effect 의 60 X_ns 중 dead 가 elide → 그 안 inner getter (`get foo() { return foo$N }`) 도 사라져 5+ch identifier 463개 감소

## Followup
- 26 member-only X_ns 의 transitive callsite rewrite (rolldown 패턴, 추가 절감 가능)
- effect 외 namespace-heavy 라이브러리 (rxjs/three) — `import * as` 패턴 적은 케이스에선 효과 작음

🤖 Generated with [Claude Code](https://claude.com/claude-code)