### PR TITLE
perf(emitter): elide CJS wrapper module name string in minify mode

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1746,7 +1746,7 @@ pub fn emitModule(
 
     // CJS 래핑: __commonJS 팩토리 함수로 감싸기
     if (module.wrap_kind == .cjs) {
-        const basename = module.wrapperId();
+        const basename = if (options.minify_whitespace) "" else module.wrapperId();
         const preamble_code = if (metadata) |md| md.cjs_import_preamble else null;
 
         const var_name = try module.allocRequireName(allocator);
@@ -1756,6 +1756,12 @@ pub fn emitModule(
         defer wrapped.deinit(allocator);
 
         if (options.minify_whitespace) {
+            // minify_whitespace 모드는 module path key 를 빈 문자열로 emit —
+            // `{""(exports,module){...}}` (JS 의 string-key method shorthand 합법).
+            // $cj helper 는 `cb[Object.keys(cb)[0]]` 로 첫 key 의 method 추출하므로
+            // key 가 빈 문자열이어도 동작. trade-off: stack trace 의 module path
+            // 정보 손실 — minify 출력은 어차피 디버깅 대상 아니라 ROI 큰 정리.
+            // 대형 라이브러리 (rxjs ~100 모듈) 에서 module path × 길이 만큼 절감.
             try wrapped.appendSlice(allocator, "var ");
             try wrapped.appendSlice(allocator, var_name);
             try wrapped.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "({\"");


### PR DESCRIPTION
## Summary
\`var X=\$cj({\"path\"(exports,module){...}})\` 의 \`\"path\"\` key 를 minify_whitespace 모드에서 빈 문자열로 emit. \`\$cj\` helper 가 첫 key 의 method 추출이라 빈 string key 안전.

## 측정
- **rxjs**: 165.4 → 162.5KB (-2.9KB)
- 다른 fixture: 동일/미세 (CJS wrapper 적음)

## Trade-off
stack trace 의 module path 정보 손실. minify 출력은 디버깅 대상 아니라 ROI 큰 정리. dev 모드는 그대로 path 보존.

## Test plan
- [x] zig build test 통과
- [x] minify-bench 6 fixture sanity (node 실행 정상)

🤖 Generated with [Claude Code](https://claude.com/claude-code)