### PR TITLE
docs(astro): fix audit findings — WASM scope, vite link, RN flag split, intro links, chart re-render

### DIFF
--- a/documents/src/components/BenchmarkCharts.tsx
+++ b/documents/src/components/BenchmarkCharts.tsx
@@ -46,14 +46,16 @@ type ChartDefinition = {
 };
 
 function useIsDark(): boolean {
-  const [isDark, setIsDark] = useState(false);
+  // client:only 컴포넌트라 SSR 없음 — 첫 렌더에 DOM 을 바로 읽어
+  // isDark=false → useEffect → setIsDark(true) 로 인한 두 번째 렌더 (echarts 애니메이션 재생) 회피.
+  const [isDark, setIsDark] = useState(() =>
+    typeof document !== "undefined" && document.documentElement.dataset.theme === "dark",
+  );
 
   useEffect(() => {
-    const check = () => {
+    const observer = new MutationObserver(() => {
       setIsDark(document.documentElement.dataset.theme === "dark");
-    };
-    check();
-    const observer = new MutationObserver(check);
+    });
     observer.observe(document.documentElement, {
       attributes: true,
       attributeFilter: ["data-theme"],

--- a/documents/src/content/docs/en/guides/installation.mdx
+++ b/documents/src/content/docs/en/guides/installation.mdx
@@ -196,6 +196,24 @@ const result = transpile("const x: number = 1;");
 console.log(result.code); // "const x = 1;"
 ```
 
+The bundler surface ships in the same package. Load sources into a `VirtualFileSystem` and initialize a separate wasm module with `initBundler` — it's a wasm32-wasi+threads build, so the browser must enable `SharedArrayBuffer` (COOP/COEP headers).
+
+```typescript
+import { initBundler, build, VirtualFileSystem } from "@zntc/wasm";
+
+const vfs = new VirtualFileSystem();
+vfs.writeFile("/src/index.ts", `import { hello } from "./hello"; hello();`);
+vfs.writeFile("/src/hello.ts", `export const hello = () => console.log("hi");`);
+
+await initBundler(vfs);
+const result = build("/src/index.ts", { format: "esm", minify: true });
+console.log(result?.code);
+```
+
+- `build()` — single-file bundle, no code splitting. Dynamic imports are inlined (same as `inlineDynamicImports`)
+- `buildChunks()` — returns a chunk array when `codeSplitting` / `preserveModules` is set
+- `BundleOptionsInput` covers `format` / `platform` / `external` / `minify*` / `target` / `jsx*` / `flow` / `sourcemap` — a subset of the native bundler options
+
 ## Vite plugin
 
 Drop-in replacement for esbuild:

--- a/documents/src/content/docs/en/guides/introduction.md
+++ b/documents/src/content/docs/en/guides/introduction.md
@@ -9,12 +9,12 @@ ZNTC stands for **Zig Native Transpiler & Compiler**. It is a native-speed trans
 
 ## Key Features
 
-- **TypeScript/JSX Transpile**: Type stripping, enum conversion, decorators, JSX (classic/automatic)
-- **Bundling**: Tree-shaking, code splitting, preserve-modules
-- **React Native**: Metro-compatible bundling, Flow stripping, Hermes bytecode compatibility
-- **Plugins**: Rollup/Vite-compatible plugin system (C NAPI, in-process)
-- **Dev Server**: HMR, proxy, static file serving
-- **WASM**: Transpile directly in the browser
+- **TypeScript/JSX transpile** — Type stripping, enum conversion, decorators, JSX (classic/automatic). [Transpile overview](/zntc/en/guides/transpile/) · [Native Transforms](/zntc/en/guides/native-transforms/)
+- **Bundling** — Tree-shaking, code splitting, preserve-modules. [Bundling overview](/zntc/en/guides/bundling/) · [Tree-shaking](/zntc/en/guides/tree-shaking/) · [manualChunks](/zntc/en/guides/manual-chunks/)
+- **React Native** — Metro-compatible bundling, Flow stripping, Hermes bytecode compatibility. [React Native guide](/zntc/en/guides/react-native/) · [Expo](/zntc/en/guides/react-native-expo/)
+- **Plugins** — Rollup/Vite-compatible plugin system (C NAPI, in-process). [Plugins guide](/zntc/en/guides/plugins/) · [Vite adapter](/zntc/en/guides/vite/)
+- **Dev Server** — HMR, proxy, static file serving, SSE/MCP. [Dev Server guide](/zntc/en/guides/dev-server/)
+- **WASM** — Transpile and bundle directly in the browser / Edge / WASI. [Installation guide — WASM](/zntc/en/guides/installation/)
 
 ## 1st-party transforms, no Babel
 

--- a/documents/src/content/docs/en/guides/react-native.md
+++ b/documents/src/content/docs/en/guides/react-native.md
@@ -221,6 +221,8 @@ react-native → browser → module → main
 
 `zntc --bundle --platform=react-native` accepts the standard `react-native bundle` (Metro CLI) flags — a dropin layer so you can swap a `react-native bundle ...` call in `package.json` for `zntc --bundle ...`.
 
+### Compatibility flags that do something
+
 | Metro flag | Description |
 |---|---|
 | `--bundle-output <path>` | Bundle output path (treated like `-o`; used as a fallback when `-o` is not given) |
@@ -229,19 +231,24 @@ react-native → browser → module → main
 | `--sourcemap-sources-root <dir>` | Source map `sourceRoot` (same meaning as `--source-root`) |
 | `--sourcemap-use-absolute-path` | Use absolute paths for sources in the source map |
 | `--assets-dest <dir>` | Destination for copied assets (images/fonts) — in production (not `--dev`) builds the asset loader copies there (iOS 1x/2x/3x, Android `res/`) |
-| `--asset-catalog-dest <dir>` | iOS asset catalog destination — **currently ignored** (accepted but no-op, stderr warning) |
 | `--bundle-encoding <utf8\|utf16le\|ascii>` | Bundle file encoding (default `utf-8`) |
 | `--reset-cache` | Invalidate the cache on startup |
 | `--max-workers <n>` | Parallel worker count — alias of `--jobs` |
-| `--unstable-transform-profile <name>` | Hermes transform profile — **currently ignored** (accepted but no-op, stderr warning) |
 | `--no-interactive` | Disable terminal interactive actions (Metro UI compat) |
 | `--watchFolders <a,b>` | Extra watch roots (Metro's camelCase form, comma-separated) — forwarded to the RN preset's watchFolders. Distinct from the native watcher's `--watch-folder` |
 | `--sourceExts <a,b>` | Extra source extensions (Metro's camelCase form, comma-separated) |
 | `--rn-project-root <dir>` | The RN preset's projectRoot. Defaults to cwd; set it for monorepo roots |
-| `--transform-option key=value` | Metro transformer option (repeatable) — **currently ignored** (Metro graph-bundler only; emits an unsupported-stderr warning) |
-| `--resolver-option key=value` | Metro resolver option (repeatable) — **currently ignored** (same) |
 
-> `--transform-option` / `--resolver-option` are accepted for compatibility but have no effect. Customize the Babel transform via `transformer.babel` in `zntc.config.ts`.
+### Compatibility flags accepted but ignored
+
+The parser accepts these so a `react-native bundle` invocation drops in as-is. They map to Metro stages (asset catalog post-processing, Hermes transform profile selection, Babel transformer arguments) that don't apply to ZNTC's graph bundler model. A stderr warning is emitted on use.
+
+| Metro flag | Why it's ignored |
+|---|---|
+| `--asset-catalog-dest <dir>` | iOS asset catalog post-processing is a separate step that ZNTC's bundler doesn't perform |
+| `--unstable-transform-profile <name>` | Hermes transform profile — ZNTC auto-applies the Hermes matrix when `--platform=react-native` is set |
+| `--transform-option key=value` | Metro's Babel transformer arguments — Babel itself is no longer a dependency. Customize transforms via `compiler` or plugins in `zntc.config.ts` |
+| `--resolver-option key=value` | Metro graph-bundler-only resolver arguments — express your intent via ZNTC's resolver options (`resolveExtensions` / `mainFields` / `conditions` / `alias` / `fallback`) |
 
 ## Flow / Hermes / Watch
 

--- a/documents/src/content/docs/en/reference/cli.md
+++ b/documents/src/content/docs/en/reference/cli.md
@@ -106,7 +106,7 @@ Options:
 | `-o, --out-file <path>`     | Output file path (the JS wrapper also accepts `--outfile` as alias)      |
 | `--outdir <path>`           | Output directory (required for dir input / splitting / preserve-modules) |
 | `--outbase=<dir>`           | Base dir for computing output paths                                      |
-| `--out-extension:.js=<ext>` | Change output extension (e.g. `.mjs`)                                    |
+| `--out-extension:.js=<ext>` | Change JS output extension (e.g. `.mjs` / `.cjs`). Only the `.js` key is supported — `.css` and others are not (esbuild parity) |
 | `--clean`                   | Clear outdir before building                                             |
 
 ## Format / Platform
@@ -117,7 +117,7 @@ Options:
 | `--platform=browser\|node\|neutral\|react-native` | Target platform                                                       |
 | `--rn-platform=ios\|android`                      | RN sub-platform (`.ios.*`/`.android.*` extensions)                    |
 | `--target=<spec>`                                 | ES target: `es2015`–`esnext` or engine versions (`chrome80,safari14`) |
-| `--browserslist=<query>`                          | Browserslist query as the ES downlevel target (`"defaults"`, `"last 2 versions, not dead"` — an alternative to `--target`) |
+| `--browserslist=<query>`                          | Browserslist query as the ES downlevel target (`"defaults"`, `"last 2 versions, not dead"` — an alternative to `--target`, JS wrapper only) |
 | `--runtime-polyfills=auto\|usage\|entry\|off`     | Inject core-js runtime API polyfills. `auto`/`usage` use graph usage  |
 | `--runtime-target=<query>`                        | core-js polyfill Browserslist target. Repeatable (`ios_saf 12`)       |
 | `--core-js=<version>`                             | core-js version used by core-js-compat                                |
@@ -139,7 +139,8 @@ Options:
 | `--rn-project-root=<dir>` | RN preset projectRoot (defaults to cwd; set for monorepo roots) |
 | `--watchFolders=<a,b>` / `--sourceExts=<a,b>` | Metro camelCase forms — forwarded to the RN preset (distinct from `--watch-folder`) |
 | `--sourcemap-sources-root=<dir>` / `--sourcemap-use-absolute-path` / `--no-interactive` | Metro compat options |
-| `--asset-catalog-dest=<dir>` / `--unstable-transform-profile=<name>` / `--transform-option=<k=v>` / `--resolver-option=<k=v>` | Accepted but **currently ignored** (Metro graph-bundler only) |
+
+These four are accepted for compatibility but ignored at runtime (stderr warning): `--asset-catalog-dest=<dir>` / `--unstable-transform-profile=<name>` / `--transform-option=<k=v>` / `--resolver-option=<k=v>`. Rationale and the recommended replacements live in the [React Native guide — compatibility flags accepted but ignored](/zntc/en/guides/react-native/#compatibility-flags-accepted-but-ignored).
 
 Full table + behavior: [React Native guide](/zntc/en/guides/react-native/#metro--react-native-bundle-compatibility-flags)
 
@@ -342,4 +343,4 @@ zntc bench --phase=parse --compare=baseline.json src/main.ts
 - Visualize `--metafile` output on the [Metafile Analyze](/zntc/analyze/) page.
 - Use `@zntc/vite-plugin` or `vitePlugin()` for the Vite adapter.
 - Use `@zntc/rspack-loader` for the Rspack / Webpack 5 adapter. ([guide](/zntc/en/guides/rspack-loader/))
-- Unsupported options and future plans: [docs/ROADMAP.md](https://github.com/ohah/zntc/blob/main/docs/ROADMAP.md).
+- Unsupported options and future plans: [Roadmap](/zntc/en/roadmap/).

--- a/documents/src/content/docs/en/reference/napi.mdx
+++ b/documents/src/content/docs/en/reference/napi.mdx
@@ -481,5 +481,5 @@ console.log(r.phases.parse.mean_ms);
 - [CLI](/zntc/en/reference/cli/) — same options on the command line
 - [Transpile Options](/zntc/en/reference/options/) — full options table from JSON Schema
 - [Plugins guide](/zntc/en/guides/plugins/) — how to author plugin hooks
-- [Vite plugin](/zntc/en/guides/dev-server/) — `@zntc/vite-plugin`
+- [Vite plugin](/zntc/en/guides/vite/) — `@zntc/vite-plugin`
 - [Rspack / Webpack integration](/zntc/en/guides/rspack-loader/) — `@zntc/rspack-loader`

--- a/documents/src/content/docs/en/roadmap.md
+++ b/documents/src/content/docs/en/roadmap.md
@@ -120,6 +120,6 @@ When a barrel module mutates an imported binding (some libraries do this — e.g
 
 Only the first resolve walks the array linearly; subsequent resolves hit the resolver cache. No measurable impact at normal project sizes.
 
-### Public WASM API
+### Public WASM AST API
 
-Limited to internal use by the Playground and Metafile Analyze pages. There is no stabilized public API for users to `import` directly yet (see the "Planned" entry above).
+`@zntc/wasm` exposes `transpile()`, `build()`, `buildChunks()`, and `VirtualFileSystem` for user `import`; see the WASM section of [Installation](/zntc/en/guides/installation/) for the usage surface. Direct module-level access to the ESTree-compatible AST from plugins is the remaining gap — see the "Planned / Public WASM AST API" entry above. AST schema stabilization is the prerequisite.

--- a/documents/src/content/docs/guides/installation.mdx
+++ b/documents/src/content/docs/guides/installation.mdx
@@ -196,6 +196,24 @@ const result = transpile("const x: number = 1;");
 console.log(result.code); // "const x = 1;"
 ```
 
+번들러 surface 도 같은 패키지에서 노출됩니다. `VirtualFileSystem` 에 소스를 올린 뒤 `initBundler` 로 별도 wasm 을 초기화합니다 — wasm32-wasi+threads 빌드라 브라우저에서 `SharedArrayBuffer` (COOP/COEP) 가 필요합니다.
+
+```typescript
+import { initBundler, build, VirtualFileSystem } from "@zntc/wasm";
+
+const vfs = new VirtualFileSystem();
+vfs.writeFile("/src/index.ts", `import { hello } from "./hello"; hello();`);
+vfs.writeFile("/src/hello.ts", `export const hello = () => console.log("hi");`);
+
+await initBundler(vfs);
+const result = build("/src/index.ts", { format: "esm", minify: true });
+console.log(result?.code);
+```
+
+- `build()` — 단일 번들 산출, code splitting 없음. dynamic import 가 있으면 `inlineDynamicImports` 와 동일 동작
+- `buildChunks()` — `codeSplitting` / `preserveModules` 옵션 시 청크 배열 반환
+- `BundleOptionsInput` 필드는 `format` / `platform` / `external` / `minify*` / `target` / `jsx*` / `flow` / `sourcemap` 등 native bundler 의 부분집합
+
 ## Vite 플러그인
 
 esbuild 자리 대체:

--- a/documents/src/content/docs/guides/introduction.md
+++ b/documents/src/content/docs/guides/introduction.md
@@ -9,12 +9,12 @@ ZNTC는 **Zig Native Transpiler & Compiler**의 약자로, JavaScript/TypeScript
 
 ## 주요 기능
 
-- **TypeScript/JSX 트랜스파일**: 타입 스트리핑, enum 변환, decorator, JSX (classic/automatic)
-- **번들링**: Tree-shaking, 코드 스플리팅, preserve-modules
-- **React Native**: Metro 호환 번들링, Flow 스트리핑, Hermes 바이트코드 호환
-- **플러그인**: Rollup/Vite 호환 플러그인 시스템 (C NAPI, in-process)
-- **Dev Server**: HMR, 프록시, 정적 파일 서빙
-- **WASM**: 브라우저에서 직접 트랜스파일 가능
+- **TypeScript/JSX 트랜스파일** — 타입 스트리핑, enum 변환, decorator, JSX (classic/automatic). [트랜스파일 개요](/zntc/guides/transpile/) · [네이티브 트랜스폼](/zntc/guides/native-transforms/)
+- **번들링** — Tree-shaking, 코드 스플리팅, preserve-modules. [번들링 개요](/zntc/guides/bundling/) · [트리쉐이킹](/zntc/guides/tree-shaking/) · [manualChunks](/zntc/guides/manual-chunks/)
+- **React Native** — Metro 호환 번들링, Flow 스트리핑, Hermes 바이트코드 호환. [React Native 가이드](/zntc/guides/react-native/) · [Expo](/zntc/guides/react-native-expo/)
+- **플러그인** — Rollup/Vite 호환 플러그인 시스템 (C NAPI, in-process). [플러그인 가이드](/zntc/guides/plugins/) · [Vite 어댑터](/zntc/guides/vite/)
+- **Dev Server** — HMR, 프록시, 정적 파일 서빙, SSE/MCP. [Dev Server 가이드](/zntc/guides/dev-server/)
+- **WASM** — 브라우저 / Edge / WASI 에서 직접 트랜스파일 + 번들. [설치 가이드의 WASM 섹션](/zntc/guides/installation/)
 
 ## Babel 없이 1st-party 지원
 

--- a/documents/src/content/docs/guides/react-native.md
+++ b/documents/src/content/docs/guides/react-native.md
@@ -221,6 +221,8 @@ react-native → browser → module → main
 
 `zntc --bundle --platform=react-native` 는 `react-native bundle` (Metro CLI) 의 standard flag 를 그대로 받습니다 — `package.json` 의 `react-native bundle ...` 호출을 `zntc --bundle ...` 로 바꿔도 동작하도록 한 dropin layer 입니다.
 
+### 동작하는 호환 옵션
+
 | Metro flag | 설명 |
 |---|---|
 | `--bundle-output <path>` | 번들 출력 경로 (`-o` 와 동일하게 처리, `-o` 미지정 시 fallback) |
@@ -229,19 +231,24 @@ react-native → browser → module → main
 | `--sourcemap-sources-root <dir>` | 소스맵의 `sourceRoot` (`--source-root` 와 동일 의미) |
 | `--sourcemap-use-absolute-path` | 소스맵 내 source 경로를 절대 경로로 |
 | `--assets-dest <dir>` | 이미지/폰트 등 asset 복사 대상 — production (`--dev` 아님) 빌드에서 asset 로더가 해당 디렉토리로 복사 (iOS 는 1x/2x/3x, Android 는 `res/`) |
-| `--asset-catalog-dest <dir>` | iOS asset catalog 대상 — **현재 무시** (받기만 하고 동작 없음, stderr 경고) |
 | `--bundle-encoding <utf8\|utf16le\|ascii>` | 번들 파일 인코딩 (기본 `utf-8`) |
 | `--reset-cache` | 시작 시 캐시 무효화 |
 | `--max-workers <n>` | 병렬 워커 수 — `--jobs` 의 alias |
-| `--unstable-transform-profile <name>` | Hermes transform profile — **현재 무시** (받기만 하고 동작 없음, stderr 경고) |
 | `--no-interactive` | 터미널 인터랙티브 액션 비활성 (Metro UI 호환) |
 | `--watchFolders <a,b>` | 감시 루트 추가 (Metro 의 camelCase 형, comma 구분) — RN preset 의 watchFolders 로 전달. zntc 네이티브 watcher 의 `--watch-folder` 와 별개 |
 | `--sourceExts <a,b>` | 추가 소스 확장자 (Metro 의 camelCase 형, comma 구분) |
 | `--rn-project-root <dir>` | RN preset 의 projectRoot. 기본 cwd, monorepo root 지정 시 사용 |
-| `--transform-option key=value` | Metro transformer 옵션 (반복 가능) — **현재 무시** (Metro graph-bundler 전용, 미지원 stderr 경고만) |
-| `--resolver-option key=value` | Metro resolver 옵션 (반복 가능) — **현재 무시** (위와 동일) |
 
-> `--transform-option` / `--resolver-option` 은 호환을 위해 받기만 하고 동작에 반영하지 않습니다. Babel transform 커스터마이징은 `zntc.config.ts` 의 `transformer.babel` 로 하세요.
+### 받기만 하고 무시되는 호환 flag
+
+`react-native bundle` 호출을 dropin 으로 받기 위해 parser 가 받기만 하고 무시합니다. ZNTC 의 graph bundler 모델과 의미가 맞지 않거나 Metro 의 별도 단계 (asset catalog 후처리, Hermes transform profile 선택, Babel transformer 인자 주입) 가 필요한 옵션입니다. 호출 시 stderr 에 경고가 출력됩니다.
+
+| Metro flag | 무시되는 이유 |
+|---|---|
+| `--asset-catalog-dest <dir>` | iOS asset catalog 후처리는 별도 단계로 ZNTC bundler 에서 수행하지 않음 |
+| `--unstable-transform-profile <name>` | Hermes transform profile — ZNTC 는 `--platform=react-native` 시 Hermes 매트릭스 자동 적용 |
+| `--transform-option key=value` | Metro 의 Babel transformer 인자 — Babel 자체 의존 제거됨. 트랜스폼 커스터마이징은 `zntc.config.ts` 의 `compiler` / plugin |
+| `--resolver-option key=value` | Metro graph-bundler 전용 resolver 인자 — ZNTC resolver 옵션 (`resolveExtensions` / `mainFields` / `conditions` / `alias` / `fallback`) 로 표현 |
 
 ## Flow / Hermes / Watch
 

--- a/documents/src/content/docs/reference/cli.md
+++ b/documents/src/content/docs/reference/cli.md
@@ -103,7 +103,7 @@ Options:
 | `-o, --out-file <path>`     | 출력 파일 경로 (JS wrapper 는 `--outfile` alias 도 받음)         |
 | `--outdir <path>`           | 출력 디렉토리 (디렉토리 입력·`--splitting`·`--preserve-modules`) |
 | `--outbase=<dir>`           | 출력 기준 디렉토리 (공통 prefix 계산)                            |
-| `--out-extension:.js=<ext>` | 출력 확장자 변경 (예: `.mjs`)                                    |
+| `--out-extension:.js=<ext>` | JS 출력 확장자 변경 (예: `.mjs` / `.cjs`). 현재 `.js` 키만 지원 — `.css` 등 다른 확장자는 미지원 (esbuild parity) |
 | `--clean`                   | 빌드 전 outdir 비우기                                            |
 
 ## 모듈 포맷 / 플랫폼
@@ -114,7 +114,7 @@ Options:
 | `--platform=browser\|node\|neutral\|react-native` | 타겟 플랫폼                                                        |
 | `--rn-platform=ios\|android`                      | RN 서브 플랫폼 (`.ios.*`/`.android.*` 확장자)                      |
 | `--target=<spec>`                                 | ES 타겟: `es2015`~`esnext` 또는 엔진 버전 (`chrome80,safari14` 등) |
-| `--browserslist=<query>`                          | Browserslist 쿼리로 ES 다운레벨 타겟 지정 (`"defaults"`, `"last 2 versions, not dead"` 등 — `--target` 의 대안) |
+| `--browserslist=<query>`                          | Browserslist 쿼리로 ES 다운레벨 타겟 지정 (`"defaults"`, `"last 2 versions, not dead"` 등 — `--target` 의 대안, JS wrapper 전용) |
 | `--runtime-polyfills=auto\|usage\|entry\|off`     | core-js 런타임 API 폴리필 주입. `auto`/`usage`는 graph usage 기반  |
 | `--runtime-target=<query>`                        | core-js 폴리필 Browserslist 타겟. 반복 가능 (`ios_saf 12`)         |
 | `--core-js=<version>`                             | core-js-compat 계산에 사용할 core-js 버전                          |
@@ -136,7 +136,8 @@ Options:
 | `--rn-project-root=<dir>` | RN preset projectRoot (기본 cwd, monorepo root 지정 시) |
 | `--watchFolders=<a,b>` / `--sourceExts=<a,b>` | Metro camelCase 형 — RN preset 으로 전달 (`--watch-folder` 와 별개) |
 | `--sourcemap-sources-root=<dir>` / `--sourcemap-use-absolute-path` / `--no-interactive` | Metro 호환 옵션 |
-| `--asset-catalog-dest=<dir>` / `--unstable-transform-profile=<name>` / `--transform-option=<k=v>` / `--resolver-option=<k=v>` | 받기만 하고 **현재 무시** (Metro graph-bundler 전용) |
+
+다음 4개는 호환을 위해 받기만 하고 실제로는 무시됩니다 (stderr 경고 출력): `--asset-catalog-dest=<dir>` / `--unstable-transform-profile=<name>` / `--transform-option=<k=v>` / `--resolver-option=<k=v>`. 이유와 권장 대체는 [React Native 가이드 — 받기만 하고 무시되는 호환 flag](/zntc/guides/react-native/#받기만-하고-무시되는-호환-flag) 참조.
 
 전체 표 + 동작 설명: [React Native 가이드](/zntc/guides/react-native/#metro--react-native-bundle-호환-옵션)
 
@@ -338,4 +339,4 @@ zntc bench --phase=parse --compare=baseline.json src/main.ts
 - `--metafile` 결과는 [Metafile 분석](/zntc/analyze/) 페이지에서 시각화할 수 있습니다.
 - Vite 어댑터는 `@zntc/vite-plugin` 또는 `vitePlugin()`으로 사용하세요.
 - Rspack / Webpack 5 어댑터는 `@zntc/rspack-loader` 를 사용하세요. ([가이드](/zntc/guides/rspack-loader/))
-- 미지원 옵션 / 향후 계획은 [docs/ROADMAP.md](https://github.com/ohah/zntc/blob/main/docs/ROADMAP.md) 참고.
+- 미지원 옵션 / 향후 계획은 [로드맵](/zntc/roadmap/) 참고.

--- a/documents/src/content/docs/reference/napi.mdx
+++ b/documents/src/content/docs/reference/napi.mdx
@@ -479,5 +479,5 @@ console.log(r.phases.parse.mean_ms);
 - [CLI](/zntc/reference/cli/) — 동일 옵션을 명령행에서 사용
 - [Transpile 옵션](/zntc/reference/options/) — JSON Schema 기반 전체 옵션 표
 - [Plugins 가이드](/zntc/guides/plugins/) — plugin hook 작성법
-- [Vite 플러그인](/zntc/guides/dev-server/) — `@zntc/vite-plugin`
+- [Vite 플러그인](/zntc/guides/vite/) — `@zntc/vite-plugin`
 - [Rspack / Webpack 통합](/zntc/guides/rspack-loader/) — `@zntc/rspack-loader`

--- a/documents/src/content/docs/roadmap.md
+++ b/documents/src/content/docs/roadmap.md
@@ -120,6 +120,6 @@ barrel 모듈이 imported binding 을 mutate 하는 경우 (lodash-es 등 일부
 
 첫 resolve 만 선형 스캔이고 이후는 resolve 캐시가 흡수합니다. 일반 프로젝트 규모에서는 실측 영향이 없습니다.
 
-### WASM 공개 API
+### WASM 공개 AST API
 
-현재 Playground / Metafile Analyze 내부 사용에 한정합니다. 사용자가 직접 `import` 할 안정화된 공개 API 는 아직 제공하지 않습니다 (위 "예정 기능" 참조).
+`@zntc/wasm` 의 `transpile()` · `build()` · `buildChunks()` · `VirtualFileSystem` 은 사용자 `import` 용으로 제공됩니다. 사용법은 [설치 가이드](/zntc/guides/installation/) 의 WASM 섹션 참조. 모듈 단위 ESTree 호환 AST 를 plugin 에서 직접 읽고 변환하는 surface 는 위 "예정 기능 > WASM 공개 AST API" 항목 — AST 스키마 안정화가 선행됩니다.


### PR DESCRIPTION
## Summary
- 한↔영 문서 audit 후속. 잘못된 정보 (WASM 공개 API · Vite 링크 · 외부 ROADMAP 링크), 광고만 있고 가이드 없던 부분 (WASM bundler API · 주요 기능 → 후속 가이드), 시각적으로 혼동되던 표 (Metro 호환 옵션 중 받기만 하는 4개) 를 정리.
- 랜딩 페이지 echarts 차트가 다크 테마에서 첫 mount 시 애니메이션이 두 번 재생되던 이슈도 함께 수정 — `useIsDark` 의 `useState(false)` + `useEffect` 패턴이 false→true transition 을 일으켜 `useMemo` 가 새 option 을 만들고 echarts 가 진입 애니메이션을 재생. lazy initializer 로 첫 렌더에 DOM 을 바로 읽어 해결.

## 변경 카테고리
| | 파일 |
|---|---|
| **roadmap** | \`roadmap.md\`, \`en/roadmap.md\` — WASM 항목이 \"공개 API 미제공\" 으로 표기됐는데 실제 \`@zntc/wasm\` 은 \`transpile/build/buildChunks/VirtualFileSystem\` 을 export. installation 가이드와 일치하도록 \"사용자 API 는 제공, AST surface 만 예정\" 으로 정정 |
| **napi.mdx** | \`reference/napi.mdx\`, \`en/reference/napi.mdx\` — \"Vite 플러그인\" 라벨이 \`/guides/dev-server/\` 로 가던 것을 \`/guides/vite/\` 로 |
| **cli.md** | \`reference/cli.md\`, \`en/reference/cli.md\` — (a) 외부 GitHub ROADMAP 링크 → 사이트 내 \`/roadmap/\` (b) \`--browserslist\` JS wrapper 전용 표기 (c) \`--out-extension\` 은 \`.js\` 키만 지원 명시 (esbuild parity) (d) 받기만 하는 Metro 호환 옵션 4개를 본 표에서 분리해 별도 메모로 |
| **react-native** | \`guides/react-native.md\`, \`en/guides/react-native.md\` — 한 표에 섞여있던 옵션을 \"동작하는 호환 옵션\" 과 \"받기만 하고 무시되는 호환 flag\" 로 분리하고 각 무시 사유 + 권장 대체를 명기 |
| **installation** | \`guides/installation.mdx\`, \`en/guides/installation.mdx\` — WASM 섹션에 \`initBundler\`/\`build\`/\`buildChunks\` 예시 추가. 그동안 introduction/comparison 만 광고하고 사용법 가이드가 없었음 |
| **introduction** | \`guides/introduction.md\`, \`en/guides/introduction.md\` — 주요 기능 6개 항목에 후속 가이드 인라인 링크 |
| **chart** | \`BenchmarkCharts.tsx\` — \`useIsDark\` 를 lazy initializer 로 (다크 테마 진입 시 애니메이션 더블 재생 해결) |

## Test plan
- [x] \`bun run build\` (astro build) 통과 — 513 페이지 생성
- [x] \`starlight-links-validator\` 통과 — 모든 내부 링크 유효
- [x] 한↔영 동등 변경 (양쪽 동일 정보)
- [x] \`/simplify\` 3-agent 리뷰 통과 (재사용·품질·효율 모두 깨끗)
- [ ] 다크 테마에서 랜딩 페이지 차트 진입 애니메이션이 1회만 재생되는지 브라우저 확인 (현재 main 의 echarts-for-react SSR 500 이슈로 dev server 검증 보류 — 별도 트랙)

🤖 Generated with [Claude Code](https://claude.com/claude-code)