### PR TITLE
fix(astro): unblock SSR by lazy-loading echarts; mermaid + benchmark share dark hook

### DIFF
--- a/documents/src/components/BenchmarkCharts.tsx
+++ b/documents/src/components/BenchmarkCharts.tsx
@@ -1,292 +1,47 @@
-import { useEffect, useMemo, useState } from "react";
-import ReactEChartsCore from "echarts-for-react/lib/core";
-import * as echarts from "echarts/core";
-import { BarChart } from "echarts/charts";
-import { TooltipComponent, GridComponent, LegendComponent } from "echarts/components";
-import { CanvasRenderer } from "echarts/renderers";
+import { Suspense, lazy } from "react";
 
 import benchmarkData from "../data/benchmark-data.json";
 
-echarts.use([BarChart, TooltipComponent, GridComponent, LegendComponent, CanvasRenderer]);
-
-const SERIES_COLORS: Record<string, string> = {
-  ZNTC: "#f7a41d",
-  esbuild: "#2563eb",
-  SWC: "#dc2626",
-  Bun: "#9333ea",
-  "oxc (node)": "#16a34a",
-  Rolldown: "#0d9488",
-  Rspack: "#e11d48",
-  rolldown: "#0d9488",
-  rspack: "#e11d48",
-  webpack: "#475569",
-  "NAPI (.node)": "#16a34a",
-  "WASM (.wasm)": "#0284c7",
-  "CLI (subprocess)": "#ea580c",
-  simple: "#2563eb",
-  expr: "#db2777",
-  string: "#16a34a",
-  object: "#ca8a04",
-  react: "#7c3aed",
-};
-
-type BenchEntry = {
-  tool: string;
-  scale: string;
-  medianMs: number;
-  minMs?: number;
-  maxMs?: number;
-  p95Ms?: number;
-};
-
-type ChartDefinition = {
-  title: string;
-  description: string;
-  entries: BenchEntry[];
-};
-
-function useIsDark(): boolean {
-  // client:only 컴포넌트라 SSR 없음 — 첫 렌더에 DOM 을 바로 읽어
-  // isDark=false → useEffect → setIsDark(true) 로 인한 두 번째 렌더 (echarts 애니메이션 재생) 회피.
-  const [isDark, setIsDark] = useState(() =>
-    typeof document !== "undefined" && document.documentElement.dataset.theme === "dark",
-  );
-
-  useEffect(() => {
-    const observer = new MutationObserver(() => {
-      setIsDark(document.documentElement.dataset.theme === "dark");
-    });
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["data-theme"],
-    });
-    return () => observer.disconnect();
-  }, []);
-
-  return isDark;
-}
-
-function uniqueInOrder(values: string[]): string[] {
-  return [...new Set(values)];
-}
-
-function formatMs(value: number): string {
-  if (!Number.isFinite(value)) return "-";
-  if (value === 0) return "0";
-  if (value < 1) {
-    const us = value * 1000;
-    return `${us >= 100 ? us.toFixed(0) : us.toFixed(1)}us`;
-  }
-  if (value < 10) return `${value.toFixed(2)}ms`;
-  if (value < 100) return `${value.toFixed(1)}ms`;
-  return `${value.toFixed(0)}ms`;
-}
-
-function chartHeight(entries: BenchEntry[]): number {
-  const scaleCount = uniqueInOrder(entries.map((entry) => entry.scale)).length;
-  const toolCount = uniqueInOrder(entries.map((entry) => entry.tool)).length;
-  return Math.max(320, 112 + scaleCount * Math.max(48, toolCount * 18));
-}
-
-function buildHorizontalBarOption(entries: BenchEntry[], isDark: boolean) {
-  const scales = uniqueInOrder(entries.map((entry) => entry.scale));
-  const tools = uniqueInOrder(entries.map((entry) => entry.tool));
-
-  const textColor = isDark ? "#e5e7eb" : "#374151";
-  const axisLineColor = isDark ? "#57534e" : "#d6d3d1";
-  const gridLineColor = isDark ? "#2a2422" : "#e7e5e4";
-
-  const series = tools.map((tool) => ({
-    name: tool,
-    type: "bar" as const,
-    barMaxWidth: 14,
-    barGap: "16%",
-    emphasis: { focus: "series" as const },
-    itemStyle: {
-      color: SERIES_COLORS[tool] ?? "#78716c",
-      borderRadius: [0, 5, 5, 0],
-    },
-    label: {
-      show: true,
-      position: "right" as const,
-      color: textColor,
-      fontSize: 11,
-      formatter: ({ value }: { value: number | null }) =>
-        typeof value === "number" ? formatMs(value) : "",
-    },
-    data: scales.map((scale) => {
-      const entry = entries.find((item) => item.tool === tool && item.scale === scale);
-      return entry ? Number(entry.medianMs.toFixed(4)) : null;
-    }),
-  }));
-
-  return {
-    animationDuration: 450,
-    tooltip: {
-      trigger: "axis" as const,
-      confine: true,
-      axisPointer: { type: "shadow" as const },
-      formatter: (
-        params: Array<{
-          seriesName: string;
-          axisValue: string;
-          value: number | null;
-          marker: string;
-        }>,
-      ) => {
-        let html = `<strong>${params[0]?.axisValue ?? ""}</strong><br/>`;
-        for (const param of params) {
-          if (typeof param.value !== "number") continue;
-          const entry = entries.find(
-            (item) => item.tool === param.seriesName && item.scale === param.axisValue,
-          );
-          html += `${param.marker} ${param.seriesName}: <strong>${formatMs(param.value)}</strong>`;
-          if (entry?.minMs !== undefined && entry.maxMs !== undefined) {
-            html += ` <span style="color:#8a8580">(${formatMs(entry.minMs)}-${formatMs(entry.maxMs)})</span>`;
-          }
-          if (entry?.p95Ms !== undefined) {
-            html += ` <span style="color:#8a8580">p95 ${formatMs(entry.p95Ms)}</span>`;
-          }
-          html += "<br/>";
-        }
-        return html;
-      },
-    },
-    legend: {
-      type: "scroll" as const,
-      top: 0,
-      left: 0,
-      right: 0,
-      itemWidth: 18,
-      itemHeight: 10,
-      textStyle: { color: textColor, fontSize: 12 },
-    },
-    grid: {
-      left: 160,
-      right: 78,
-      bottom: 28,
-      top: 52,
-      containLabel: false,
-    },
-    xAxis: {
-      type: "value" as const,
-      name: "median wall time",
-      nameLocation: "middle" as const,
-      nameGap: 28,
-      nameTextStyle: { color: textColor, fontSize: 11 },
-      axisLabel: {
-        color: textColor,
-        formatter: (value: number) => formatMs(value),
-      },
-      axisLine: { lineStyle: { color: axisLineColor } },
-      splitLine: { lineStyle: { color: gridLineColor } },
-    },
-    yAxis: {
-      type: "category" as const,
-      inverse: true,
-      data: scales,
-      axisLabel: {
-        color: textColor,
-        fontSize: 12,
-        width: 145,
-        overflow: "break" as const,
-      },
-      axisLine: { lineStyle: { color: axisLineColor } },
-      axisTick: { show: false },
-    },
-    series,
-  };
-}
-
-function ChartPanel({ chart, isDark }: { chart: ChartDefinition; isDark: boolean }) {
-  const option = useMemo(() => buildHorizontalBarOption(chart.entries, isDark), [chart.entries, isDark]);
-
-  return (
-    <section className="not-content overflow-hidden rounded-lg border border-surface-200 bg-white shadow-sm dark:border-surface-800 dark:bg-surface-950/70">
-      <div className="border-b border-surface-200 px-4 py-3 dark:border-surface-800">
-        <h2 className="text-base font-semibold text-neutral-900 dark:text-neutral-100">{chart.title}</h2>
-        <p className="mt-1 text-sm leading-6 text-neutral-600 dark:text-neutral-400">{chart.description}</p>
-      </div>
-      <div className="overflow-x-auto px-2 py-4">
-        <ReactEChartsCore
-          echarts={echarts}
-          option={option}
-          style={{ height: chartHeight(chart.entries), minWidth: 720, width: "100%" }}
-          lazyUpdate
-        />
-      </div>
-    </section>
-  );
-}
+// echarts (~500KB gzip + CJS deep import 인 `echarts-for-react/lib/core`) 를 분리.
+// 빌드타임 / dev SSR 의 모듈 평가 단계에서 CJS body 가 evaluate 되지 않도록 dynamic import.
+// 부수 효과: landing/benchmarks 페이지 진입 시점에만 chunk fetch — 다른 페이지 비용 0.
+const Default = lazy(() => import("./BenchmarkChartsImpl"));
+const Highlight = lazy(() =>
+  import("./BenchmarkChartsImpl").then((m) => ({ default: m.BenchmarkHighlight })),
+);
 
 type BenchmarkResultKey = keyof typeof benchmarkData.results;
 
-/** 단일 차트만 컴팩트하게 렌더 — 랜딩/하이라이트 용. */
-export function BenchmarkHighlight({
-  chartKey,
-  height,
-}: {
-  chartKey: BenchmarkResultKey;
-  height?: number;
-}) {
-  const isDark = useIsDark();
-  const entries = benchmarkData.results[chartKey] as BenchEntry[];
-  const option = useMemo(() => buildHorizontalBarOption(entries, isDark), [entries, isDark]);
+// `BenchmarkChartsImpl` 의 `MIN_CHART_HEIGHT` 와 같은 값.
+// 정적 import 하면 echarts 가 wrapper chunk 로 끌려와 lazy split 의미가 깨짐.
+const MIN_CHART_HEIGHT = 320;
+const PANEL_COUNT = Object.keys(benchmarkData.results).length;
+// header (~70) + gap-5 (20) 누적. lazy resolve 후 차트마다 chartHeight() 가 320 보다 커지면
+// 약간의 reflow 가 발생하나, 0→2000 의 큰 CLS 는 회피.
+const FULL_PAGE_FALLBACK = PANEL_COUNT * (MIN_CHART_HEIGHT + 90) + 80;
 
+function ChartSkeleton({ minHeight }: { minHeight: number }) {
   return (
-    <div className="not-content overflow-x-auto">
-      <ReactEChartsCore
-        echarts={echarts}
-        option={option}
-        style={{ height: height ?? chartHeight(entries), minWidth: 720, width: "100%" }}
-        lazyUpdate
-      />
-    </div>
+    <div
+      className="not-content rounded-lg border border-surface-200 bg-white dark:border-surface-800 dark:bg-surface-950/70"
+      style={{ minHeight, width: "100%" }}
+      aria-hidden
+    />
+  );
+}
+
+export function BenchmarkHighlight(props: { chartKey: BenchmarkResultKey; height?: number }) {
+  return (
+    <Suspense fallback={<ChartSkeleton minHeight={props.height ?? MIN_CHART_HEIGHT} />}>
+      <Highlight {...props} />
+    </Suspense>
   );
 }
 
 export default function BenchmarkCharts() {
-  const isDark = useIsDark();
-  const charts: ChartDefinition[] = [
-    {
-      title: "CLI Transpile",
-      description: "Single-file TypeScript transpilation through direct CLI binaries.",
-      entries: benchmarkData.results.transpileCli,
-    },
-    {
-      title: "CLI Bundle",
-      description: "Small to large deterministic module graphs through direct CLI binaries.",
-      entries: benchmarkData.results.bundleCli,
-    },
-    {
-      title: "NAPI vs WASM vs CLI",
-      description: "Public in-process bindings compared with subprocess CLI startup cost.",
-      entries: benchmarkData.results.napiWasmCli,
-    },
-    {
-      title: "Bundle Perf CI Matrix",
-      description: "Same-run CI-style wall time comparison for ZNTC, Rolldown, and Rspack.",
-      entries: benchmarkData.results.bundlePerf,
-    },
-    {
-      title: "ZNTC Pipeline Patterns",
-      description: "ZNTC profile totals across generated simple, expression-heavy, string-heavy, object, and React-like sources.",
-      entries: benchmarkData.results.pipelineTotal,
-    },
-  ];
-
   return (
-    <div className="not-content flex flex-col gap-5">
-      <div className="rounded-lg border border-surface-200 bg-white px-4 py-3 text-sm leading-6 text-neutral-700 shadow-sm dark:border-surface-800 dark:bg-surface-950/70 dark:text-neutral-300">
-        <strong className="text-neutral-900 dark:text-neutral-100">Measurement:</strong> {benchmarkData.platform}, {benchmarkData.date}.
-        CLI charts use median wall time. Lower is better.
-      </div>
-      {charts.map((chart) => (
-        <ChartPanel key={chart.title} chart={chart} isDark={isDark} />
-      ))}
-      <p className="text-center text-sm text-neutral-500 dark:text-neutral-400">
-        CLI iterations: {benchmarkData.runs.cli.iterations}. NAPI/WASM warmup: {benchmarkData.runs.napi.warmup}, iterations: {benchmarkData.runs.napi.iterations}. Bundle-perf warmup: {benchmarkData.runs.bundlePerf.warmup}, iterations: {benchmarkData.runs.bundlePerf.iterations}.
-      </p>
-    </div>
+    <Suspense fallback={<ChartSkeleton minHeight={FULL_PAGE_FALLBACK} />}>
+      <Default />
+    </Suspense>
   );
 }

--- a/documents/src/components/BenchmarkChartsImpl.tsx
+++ b/documents/src/components/BenchmarkChartsImpl.tsx
@@ -1,0 +1,274 @@
+import { useMemo } from "react";
+import ReactEChartsCore from "echarts-for-react/lib/core";
+import * as echarts from "echarts/core";
+import { BarChart } from "echarts/charts";
+import { TooltipComponent, GridComponent, LegendComponent } from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
+
+import benchmarkData from "../data/benchmark-data.json";
+import { useStarlightDark } from "./useStarlightDark";
+
+echarts.use([BarChart, TooltipComponent, GridComponent, LegendComponent, CanvasRenderer]);
+
+const SERIES_COLORS: Record<string, string> = {
+  ZNTC: "#f7a41d",
+  esbuild: "#2563eb",
+  SWC: "#dc2626",
+  Bun: "#9333ea",
+  "oxc (node)": "#16a34a",
+  Rolldown: "#0d9488",
+  Rspack: "#e11d48",
+  rolldown: "#0d9488",
+  rspack: "#e11d48",
+  webpack: "#475569",
+  "NAPI (.node)": "#16a34a",
+  "WASM (.wasm)": "#0284c7",
+  "CLI (subprocess)": "#ea580c",
+  simple: "#2563eb",
+  expr: "#db2777",
+  string: "#16a34a",
+  object: "#ca8a04",
+  react: "#7c3aed",
+};
+
+type BenchEntry = {
+  tool: string;
+  scale: string;
+  medianMs: number;
+  minMs?: number;
+  maxMs?: number;
+  p95Ms?: number;
+};
+
+type ChartDefinition = {
+  title: string;
+  description: string;
+  entries: BenchEntry[];
+};
+
+function uniqueInOrder(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function formatMs(value: number): string {
+  if (!Number.isFinite(value)) return "-";
+  if (value === 0) return "0";
+  if (value < 1) {
+    const us = value * 1000;
+    return `${us >= 100 ? us.toFixed(0) : us.toFixed(1)}us`;
+  }
+  if (value < 10) return `${value.toFixed(2)}ms`;
+  if (value < 100) return `${value.toFixed(1)}ms`;
+  return `${value.toFixed(0)}ms`;
+}
+
+export const MIN_CHART_HEIGHT = 320;
+
+export function chartHeight(entries: BenchEntry[]): number {
+  const scaleCount = uniqueInOrder(entries.map((entry) => entry.scale)).length;
+  const toolCount = uniqueInOrder(entries.map((entry) => entry.tool)).length;
+  return Math.max(MIN_CHART_HEIGHT, 112 + scaleCount * Math.max(48, toolCount * 18));
+}
+
+function buildHorizontalBarOption(entries: BenchEntry[], isDark: boolean) {
+  const scales = uniqueInOrder(entries.map((entry) => entry.scale));
+  const tools = uniqueInOrder(entries.map((entry) => entry.tool));
+
+  const textColor = isDark ? "#e5e7eb" : "#374151";
+  const axisLineColor = isDark ? "#57534e" : "#d6d3d1";
+  const gridLineColor = isDark ? "#2a2422" : "#e7e5e4";
+
+  const series = tools.map((tool) => ({
+    name: tool,
+    type: "bar" as const,
+    barMaxWidth: 14,
+    barGap: "16%",
+    emphasis: { focus: "series" as const },
+    itemStyle: {
+      color: SERIES_COLORS[tool] ?? "#78716c",
+      borderRadius: [0, 5, 5, 0],
+    },
+    label: {
+      show: true,
+      position: "right" as const,
+      color: textColor,
+      fontSize: 11,
+      formatter: ({ value }: { value: number | null }) =>
+        typeof value === "number" ? formatMs(value) : "",
+    },
+    data: scales.map((scale) => {
+      const entry = entries.find((item) => item.tool === tool && item.scale === scale);
+      return entry ? Number(entry.medianMs.toFixed(4)) : null;
+    }),
+  }));
+
+  return {
+    animationDuration: 450,
+    tooltip: {
+      trigger: "axis" as const,
+      confine: true,
+      axisPointer: { type: "shadow" as const },
+      formatter: (
+        params: Array<{
+          seriesName: string;
+          axisValue: string;
+          value: number | null;
+          marker: string;
+        }>,
+      ) => {
+        let html = `<strong>${params[0]?.axisValue ?? ""}</strong><br/>`;
+        for (const param of params) {
+          if (typeof param.value !== "number") continue;
+          const entry = entries.find(
+            (item) => item.tool === param.seriesName && item.scale === param.axisValue,
+          );
+          html += `${param.marker} ${param.seriesName}: <strong>${formatMs(param.value)}</strong>`;
+          if (entry?.minMs !== undefined && entry.maxMs !== undefined) {
+            html += ` <span style="color:#8a8580">(${formatMs(entry.minMs)}-${formatMs(entry.maxMs)})</span>`;
+          }
+          if (entry?.p95Ms !== undefined) {
+            html += ` <span style="color:#8a8580">p95 ${formatMs(entry.p95Ms)}</span>`;
+          }
+          html += "<br/>";
+        }
+        return html;
+      },
+    },
+    legend: {
+      type: "scroll" as const,
+      top: 0,
+      left: 0,
+      right: 0,
+      itemWidth: 18,
+      itemHeight: 10,
+      textStyle: { color: textColor, fontSize: 12 },
+    },
+    grid: {
+      left: 160,
+      right: 78,
+      bottom: 28,
+      top: 52,
+      containLabel: false,
+    },
+    xAxis: {
+      type: "value" as const,
+      name: "median wall time",
+      nameLocation: "middle" as const,
+      nameGap: 28,
+      nameTextStyle: { color: textColor, fontSize: 11 },
+      axisLabel: {
+        color: textColor,
+        formatter: (value: number) => formatMs(value),
+      },
+      axisLine: { lineStyle: { color: axisLineColor } },
+      splitLine: { lineStyle: { color: gridLineColor } },
+    },
+    yAxis: {
+      type: "category" as const,
+      inverse: true,
+      data: scales,
+      axisLabel: {
+        color: textColor,
+        fontSize: 12,
+        width: 145,
+        overflow: "break" as const,
+      },
+      axisLine: { lineStyle: { color: axisLineColor } },
+      axisTick: { show: false },
+    },
+    series,
+  };
+}
+
+function ChartPanel({ chart, isDark }: { chart: ChartDefinition; isDark: boolean }) {
+  const option = useMemo(() => buildHorizontalBarOption(chart.entries, isDark), [chart.entries, isDark]);
+
+  return (
+    <section className="not-content overflow-hidden rounded-lg border border-surface-200 bg-white shadow-sm dark:border-surface-800 dark:bg-surface-950/70">
+      <div className="border-b border-surface-200 px-4 py-3 dark:border-surface-800">
+        <h2 className="text-base font-semibold text-neutral-900 dark:text-neutral-100">{chart.title}</h2>
+        <p className="mt-1 text-sm leading-6 text-neutral-600 dark:text-neutral-400">{chart.description}</p>
+      </div>
+      <div className="overflow-x-auto px-2 py-4">
+        <ReactEChartsCore
+          echarts={echarts}
+          option={option}
+          style={{ height: chartHeight(chart.entries), minWidth: 720, width: "100%" }}
+          lazyUpdate
+        />
+      </div>
+    </section>
+  );
+}
+
+type BenchmarkResultKey = keyof typeof benchmarkData.results;
+
+/** 단일 차트만 컴팩트하게 렌더 — 랜딩/하이라이트 용. */
+export function BenchmarkHighlight({
+  chartKey,
+  height,
+}: {
+  chartKey: BenchmarkResultKey;
+  height?: number;
+}) {
+  const isDark = useStarlightDark();
+  const entries = benchmarkData.results[chartKey] as BenchEntry[];
+  const option = useMemo(() => buildHorizontalBarOption(entries, isDark), [entries, isDark]);
+
+  return (
+    <div className="not-content overflow-x-auto">
+      <ReactEChartsCore
+        echarts={echarts}
+        option={option}
+        style={{ height: height ?? chartHeight(entries), minWidth: 720, width: "100%" }}
+        lazyUpdate
+      />
+    </div>
+  );
+}
+
+export default function BenchmarkCharts() {
+  const isDark = useStarlightDark();
+  const charts: ChartDefinition[] = [
+    {
+      title: "CLI Transpile",
+      description: "Single-file TypeScript transpilation through direct CLI binaries.",
+      entries: benchmarkData.results.transpileCli,
+    },
+    {
+      title: "CLI Bundle",
+      description: "Small to large deterministic module graphs through direct CLI binaries.",
+      entries: benchmarkData.results.bundleCli,
+    },
+    {
+      title: "NAPI vs WASM vs CLI",
+      description: "Public in-process bindings compared with subprocess CLI startup cost.",
+      entries: benchmarkData.results.napiWasmCli,
+    },
+    {
+      title: "Bundle Perf CI Matrix",
+      description: "Same-run CI-style wall time comparison for ZNTC, Rolldown, and Rspack.",
+      entries: benchmarkData.results.bundlePerf,
+    },
+    {
+      title: "ZNTC Pipeline Patterns",
+      description: "ZNTC profile totals across generated simple, expression-heavy, string-heavy, object, and React-like sources.",
+      entries: benchmarkData.results.pipelineTotal,
+    },
+  ];
+
+  return (
+    <div className="not-content flex flex-col gap-5">
+      <div className="rounded-lg border border-surface-200 bg-white px-4 py-3 text-sm leading-6 text-neutral-700 shadow-sm dark:border-surface-800 dark:bg-surface-950/70 dark:text-neutral-300">
+        <strong className="text-neutral-900 dark:text-neutral-100">Measurement:</strong> {benchmarkData.platform}, {benchmarkData.date}.
+        CLI charts use median wall time. Lower is better.
+      </div>
+      {charts.map((chart) => (
+        <ChartPanel key={chart.title} chart={chart} isDark={isDark} />
+      ))}
+      <p className="text-center text-sm text-neutral-500 dark:text-neutral-400">
+        CLI iterations: {benchmarkData.runs.cli.iterations}. NAPI/WASM warmup: {benchmarkData.runs.napi.warmup}, iterations: {benchmarkData.runs.napi.iterations}. Bundle-perf warmup: {benchmarkData.runs.bundlePerf.warmup}, iterations: {benchmarkData.runs.bundlePerf.iterations}.
+      </p>
+    </div>
+  );
+}

--- a/documents/src/components/Mermaid.tsx
+++ b/documents/src/components/Mermaid.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useId, useRef, useState } from "react";
-import type { Mermaid as MermaidApi } from "mermaid";
+import type { Mermaid as MermaidApi, MermaidConfig } from "mermaid";
+
+import { useStarlightDark } from "./useStarlightDark";
 
 interface Props {
   /** mermaid diagram source (raw text — `flowchart TD`, `sequenceDiagram`, etc.) */
@@ -15,39 +17,57 @@ interface Props {
 let mermaidPromise: Promise<MermaidApi> | null = null;
 function loadMermaid(): Promise<MermaidApi> {
   if (mermaidPromise) return mermaidPromise;
-  mermaidPromise = import("mermaid").then(({ default: mermaid }) => {
-    mermaid.initialize({
-      startOnLoad: false,
-      theme: "base",
-      securityLevel: "loose",
-      fontFamily: "var(--sl-font, sans-serif)",
-      themeVariables: {
-        primaryColor: "#fff7ed",
-        primaryBorderColor: "#f7a41d",
-        primaryTextColor: "#431407",
-        secondaryColor: "#ffedd5",
-        secondaryBorderColor: "#fb923c",
-        tertiaryColor: "#fafaf9",
-        tertiaryBorderColor: "#d6d3d1",
-        clusterBkg: "#1c1816",
-        clusterBorder: "#3a3432",
-        titleColor: "#f5f5f4",
-        edgeLabelBackground: "#141110",
-        lineColor: "#f7a41d",
-        fontSize: "15px",
-      },
-      flowchart: {
-        htmlLabels: true,
-        curve: "basis",
-        nodeSpacing: 44,
-        rankSpacing: 58,
-        padding: 28,
-        useMaxWidth: true,
-      },
-    });
-    return mermaid;
-  });
+  mermaidPromise = import("mermaid").then(({ default: mermaid }) => mermaid);
   return mermaidPromise;
+}
+
+const COMMON_CONFIG: MermaidConfig = {
+  startOnLoad: false,
+  theme: "base",
+  securityLevel: "loose",
+  fontFamily: "var(--sl-font, sans-serif)",
+  flowchart: {
+    htmlLabels: true,
+    curve: "basis",
+    nodeSpacing: 44,
+    rankSpacing: 58,
+    padding: 28,
+    useMaxWidth: true,
+  },
+};
+
+// ZNTC 브랜드 오렌지 (#f7a41d) 는 양쪽 공통, 면/텍스트만 light↔dark 로 토글.
+// [light, dark] 페어로 묶어 한쪽 키만 추가하는 실수를 방지.
+const THEME_PAIRS = {
+  primaryColor: ["#fff7ed", "#1c1816"],
+  primaryBorderColor: ["#f7a41d", "#f7a41d"],
+  primaryTextColor: ["#431407", "#fed7aa"],
+  secondaryColor: ["#ffedd5", "#2a2422"],
+  secondaryBorderColor: ["#fb923c", "#fb923c"],
+  tertiaryColor: ["#fafaf9", "#141110"],
+  tertiaryBorderColor: ["#d6d3d1", "#3a3432"],
+  clusterBkg: ["#fafaf9", "#1c1816"],
+  clusterBorder: ["#d6d3d1", "#3a3432"],
+  titleColor: ["#1c1816", "#f5f5f4"],
+  edgeLabelBackground: ["#ffffff", "#141110"],
+  lineColor: ["#9a3412", "#f7a41d"],
+  fontSize: ["15px", "15px"],
+} as const;
+
+function themeVarsFor(isDark: boolean) {
+  const idx = isDark ? 1 : 0;
+  const out: Record<string, string> = {};
+  for (const [key, pair] of Object.entries(THEME_PAIRS)) out[key] = pair[idx];
+  return out;
+}
+
+// mermaid config 는 module-global. 같은 isDark 로 이미 init 됐으면 다이어그램 N 개의
+// 동시 mount 에서 N-1 번의 redundant initialize 를 skip — 결과는 동일하지만 work 절약.
+let lastInitDark: boolean | null = null;
+function ensureMermaidTheme(mermaid: MermaidApi, isDark: boolean): void {
+  if (lastInitDark === isDark) return;
+  mermaid.initialize({ ...COMMON_CONFIG, themeVariables: themeVarsFor(isDark) });
+  lastInitDark = isDark;
 }
 
 /** Client-side Mermaid renderer with lazy library load. `client:visible` 권장. */
@@ -56,11 +76,15 @@ export default function Mermaid({ chart }: Props) {
   const [error, setError] = useState<string | null>(null);
   const reactId = useId();
   const renderId = `mermaid-${reactId.replace(/:/g, "")}`;
+  const isDark = useStarlightDark();
 
   useEffect(() => {
     let cancelled = false;
     loadMermaid()
-      .then((mermaid) => mermaid.render(renderId, chart))
+      .then((mermaid) => {
+        ensureMermaidTheme(mermaid, isDark);
+        return mermaid.render(renderId, chart);
+      })
       .then(({ svg }) => {
         if (!cancelled && ref.current) ref.current.innerHTML = svg;
       })
@@ -70,7 +94,7 @@ export default function Mermaid({ chart }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [chart, renderId]);
+  }, [chart, renderId, isDark]);
 
   if (error) {
     return (

--- a/documents/src/components/useStarlightDark.ts
+++ b/documents/src/components/useStarlightDark.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Starlight 의 `data-theme="dark"` 마커를 구독.
+ * 진실의 소스는 `<html data-theme>` (Starlight 의 ThemeSelect 가 writer) —
+ * Starlight 가 React hook surface 를 제공하지 않아 직접 dataset 을 읽고 MutationObserver 로 토글 구독.
+ */
+export function useStarlightDark(): boolean {
+  // SSR 가드: useState initializer 는 SSR 패스에서도 실행. client:only 컴포넌트는 영향 없지만,
+  // hook 이 client:visible / client:idle 같은 hydration 모드에서 import 되면 Node 에 document 없음.
+  const [isDark, setIsDark] = useState(() =>
+    typeof document !== "undefined" && document.documentElement.dataset.theme === "dark",
+  );
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setIsDark(document.documentElement.dataset.theme === "dark");
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  return isDark;
+}


### PR DESCRIPTION
## Summary
- main 의 echarts-for-react CJS deep import 가 Vite SSR 평가에서 \`exports is not defined\` 로 **500** 유발 → landing + \`reference/benchmarks\` 페이지 모두 영향. dev server 자체가 안 떠서 #3238 의 chart-double-render 변경 검증도 보류 상태였음.
- \`Mermaid.tsx\` 가 mount 시 한 번만 themeVariables 박고 끝이라 **다크 토글 무시** — 라이트 색이 다크 배경에 그대로 떨어지는 UX 회귀.

## 변경
| 파일 | 변경 |
|---|---|
| \`BenchmarkCharts.tsx\` | 기존 echarts heavy 코드는 \`BenchmarkChartsImpl.tsx\` 로 분리하고, 이 파일은 \`lazy()\` + \`Suspense\` wrapper. SSR 모듈 평가 시 CJS body 가 evaluate 되지 않음. 부수 효과로 echarts chunk 가 페이지 진입 시점에만 fetch |
| \`BenchmarkChartsImpl.tsx\` | rename. \`useIsDark\` 를 새 hook 으로 분리하고 \`chartHeight\` / \`MIN_CHART_HEIGHT\` export 해서 wrapper 의 fallback height 동기화 |
| \`useStarlightDark.ts\` | 신규. \`<html data-theme>\` 을 MutationObserver 로 구독. Starlight 가 React surface 미제공이라 dataset 직접 구독이 정공법 |
| \`Mermaid.tsx\` | \`useStarlightDark\` 사용. \`loadMermaid\` 는 instance 만 캐시, theme initialize 는 useEffect 안으로. THEME_PAIRS \`[light, dark]\` paired 테이블 + \`lastInitDark\` 모듈 가드로 N 개 다이어그램 동시 mount 시 N-1 번의 redundant initialize skip |

## CLS / 효율 후속 수정
- Suspense fallback \`minHeight={400}\` → 실제 \`PANEL_COUNT × (MIN_CHART_HEIGHT + header) + gap\` 계산. 차트 5개 합산 2100px+ 대비 기존 400px 으로는 lazy resolve 후 1700px+ CLS 발생.
- \`useStarlightDark\` 주석을 \"테스트 환경\" → \"SSR 패스 (client:visible 등)\" 으로 정정 (실제로 \`useState\` initializer 는 hydration 모드의 SSR 패스에서 실행됨)

## Test plan
- [x] \`bun run build\` 통과, 513 페이지, starlight-links-validator 깨끗
- [x] dev server: \`/zntc/\` / \`/zntc/reference/benchmarks/\` / \`/zntc/reference/napi/\` (mermaid 포함) 모두 HTTP 200
- [x] \`/simplify\` 3-agent 리뷰 통과
- [ ] 다크 모드에서 mermaid 다이어그램 색이 실제로 토글되는지 브라우저 확인 (PR 머지 후 prod 또는 로컬에서)

## 별도 PR 후보 (이번 PR 밖)
- mermaid / echarts SERIES_COLORS / diagrams.ts 의 hardcoded brand hex (#f7a41d / #fff7ed / #1c1816 ...) 가 4 파일 중복. tailwind \`--color-zig-*\` / \`--color-surface-*\` 와 1:1 — JS 상수 모듈로 일원화 가능
- \`BenchmarkChartsImpl\` + \`MetafileAnalyzer\` 의 \`echarts.use(...)\` 가 분리 register. 멱등이라 런타임 안전하지만 single setup 으로 통합 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)