### PR TITLE
refactor(astro): consolidate brand hex tokens to single source

### DIFF
--- a/documents/src/components/BenchmarkChartsImpl.tsx
+++ b/documents/src/components/BenchmarkChartsImpl.tsx
@@ -6,12 +6,14 @@ import { TooltipComponent, GridComponent, LegendComponent } from "echarts/compon
 import { CanvasRenderer } from "echarts/renderers";
 
 import benchmarkData from "../data/benchmark-data.json";
+import { ZIG } from "../styles/brand-tokens";
 import { useStarlightDark } from "./useStarlightDark";
 
 echarts.use([BarChart, TooltipComponent, GridComponent, LegendComponent, CanvasRenderer]);
 
+// ZNTC 만 brand token 사용. 다른 도구 색은 각자의 brand color 라 토큰화 X.
 const SERIES_COLORS: Record<string, string> = {
-  ZNTC: "#f7a41d",
+  ZNTC: ZIG[500],
   esbuild: "#2563eb",
   SWC: "#dc2626",
   Bun: "#9333ea",

--- a/documents/src/components/Mermaid.tsx
+++ b/documents/src/components/Mermaid.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useRef, useState } from "react";
 import type { Mermaid as MermaidApi, MermaidConfig } from "mermaid";
 
+import { SURFACE, ZIG } from "../styles/brand-tokens";
 import { useStarlightDark } from "./useStarlightDark";
 
 interface Props {
@@ -36,21 +37,21 @@ const COMMON_CONFIG: MermaidConfig = {
   },
 };
 
-// ZNTC 브랜드 오렌지 (#f7a41d) 는 양쪽 공통, 면/텍스트만 light↔dark 로 토글.
-// [light, dark] 페어로 묶어 한쪽 키만 추가하는 실수를 방지.
+// ZNTC 브랜드 오렌지 (zig-500) 는 양쪽 공통, 면/텍스트만 light↔dark 로 토글.
+// [light, dark] 페어로 묶어 한쪽 키만 추가하는 실수를 방지. hex 는 brand-tokens 에서.
 const THEME_PAIRS = {
-  primaryColor: ["#fff7ed", "#1c1816"],
-  primaryBorderColor: ["#f7a41d", "#f7a41d"],
-  primaryTextColor: ["#431407", "#fed7aa"],
-  secondaryColor: ["#ffedd5", "#2a2422"],
-  secondaryBorderColor: ["#fb923c", "#fb923c"],
-  tertiaryColor: ["#fafaf9", "#141110"],
-  tertiaryBorderColor: ["#d6d3d1", "#3a3432"],
-  clusterBkg: ["#fafaf9", "#1c1816"],
-  clusterBorder: ["#d6d3d1", "#3a3432"],
-  titleColor: ["#1c1816", "#f5f5f4"],
-  edgeLabelBackground: ["#ffffff", "#141110"],
-  lineColor: ["#9a3412", "#f7a41d"],
+  primaryColor: [ZIG[50], SURFACE[900]],
+  primaryBorderColor: [ZIG[500], ZIG[500]],
+  primaryTextColor: [ZIG[950], ZIG[200]],
+  secondaryColor: [ZIG[100], SURFACE[800]],
+  secondaryBorderColor: [ZIG[400], ZIG[400]],
+  tertiaryColor: [SURFACE[50], SURFACE[950]],
+  tertiaryBorderColor: [SURFACE[300], SURFACE[700]],
+  clusterBkg: [SURFACE[50], SURFACE[900]],
+  clusterBorder: [SURFACE[300], SURFACE[700]],
+  titleColor: [SURFACE[900], SURFACE[100]],
+  edgeLabelBackground: ["#ffffff", SURFACE[950]],
+  lineColor: [ZIG[800], ZIG[500]],
   fontSize: ["15px", "15px"],
 } as const;
 

--- a/documents/src/components/diagrams.ts
+++ b/documents/src/components/diagrams.ts
@@ -1,7 +1,13 @@
 /**
  * Mermaid diagram source 모음. 한/영 페이지가 동일 다이어그램을 import 해
  * drift 차단. 노드 텍스트는 영어 위주 + 짧은 한글 keyword 만 (locale-neutral).
+ *
+ * classDef 색은 `brand-tokens.ts` 토큰만 사용 (mermaid 가 hex 만 받음).
+ * Mermaid 컴포넌트는 isDark 토글 시 `themeVariables` 도 같이 갱신하므로 light/dark 양쪽에서
+ * 적절한 contrast 가 유지되는 hex (orange tier) 만 classDef 에 박는다.
  */
+
+import { SURFACE, ZIG } from "../styles/brand-tokens";
 
 export const BUNDLER_PIPELINE_CHART = `flowchart TB
     Entry["Entry Points"]
@@ -15,9 +21,9 @@ export const BUNDLER_PIPELINE_CHART = `flowchart TB
 
     Entry --> Resolver --> Graph --> Linker --> Tree --> Chunker --> Emitter --> Output
 
-    classDef entry fill:#fff7ed,stroke:#f7a41d,color:#431407,stroke-width:1.4px;
-    classDef stage fill:#ffedd5,stroke:#fb923c,color:#431407,stroke-width:1.2px;
-    classDef out fill:#f7a41d,stroke:#fed7aa,color:#1c1816,stroke-width:1.6px;
+    classDef entry fill:${ZIG[50]},stroke:${ZIG[500]},color:${ZIG[950]},stroke-width:1.4px;
+    classDef stage fill:${ZIG[100]},stroke:${ZIG[400]},color:${ZIG[950]},stroke-width:1.2px;
+    classDef out fill:${ZIG[500]},stroke:${ZIG[200]},color:${SURFACE[900]},stroke-width:1.6px;
 
     class Entry entry;
     class Resolver,Graph,Linker,Tree,Chunker,Emitter stage;
@@ -31,7 +37,7 @@ export const BUNDLER_CIRCULAR_DEPS_CHART = `flowchart LR
     A -->|"import { B }"| B
     B -->|"import { A }"| A
 
-    classDef mod fill:#ffedd5,stroke:#fb923c,color:#431407,stroke-width:1.2px;
+    classDef mod fill:${ZIG[100]},stroke:${ZIG[400]},color:${ZIG[950]},stroke-width:1.2px;
     class A,B mod;
 `;
 
@@ -47,9 +53,9 @@ export const BUNDLER_CJS_ESM_INTEROP_CHART = `flowchart TD
     Mjs --> NodeMode
     Other --> BabelMode
 
-    classDef decision fill:#fff7ed,stroke:#f7a41d,color:#431407,stroke-width:1.4px;
-    classDef branch fill:#ffedd5,stroke:#fb923c,color:#431407,stroke-width:1.2px;
-    classDef result fill:#f7a41d,stroke:#fed7aa,color:#1c1816,stroke-width:1.6px;
+    classDef decision fill:${ZIG[50]},stroke:${ZIG[500]},color:${ZIG[950]},stroke-width:1.4px;
+    classDef branch fill:${ZIG[100]},stroke:${ZIG[400]},color:${ZIG[950]},stroke-width:1.2px;
+    classDef result fill:${ZIG[500]},stroke:${ZIG[200]},color:${SURFACE[900]},stroke-width:1.6px;
 
     class Start decision;
     class Mjs,Other branch;
@@ -85,10 +91,10 @@ export const NAPI_ARCHITECTURE_CHART = `flowchart TB
     PD -. "threadsafe callback" .-> NAPI
     NAPI --> Frontend
 
-    classDef entry fill:#fff7ed,stroke:#f7a41d,color:#431407,stroke-width:1.4px;
-    classDef js fill:#ffedd5,stroke:#fb923c,color:#431407,stroke-width:1.2px;
-    classDef bridge fill:#f7a41d,stroke:#fed7aa,color:#1c1816,stroke-width:1.6px;
-    classDef native fill:#fafaf9,stroke:#d6d3d1,color:#1c1816,stroke-width:1.2px;
+    classDef entry fill:${ZIG[50]},stroke:${ZIG[500]},color:${ZIG[950]},stroke-width:1.4px;
+    classDef js fill:${ZIG[100]},stroke:${ZIG[400]},color:${ZIG[950]},stroke-width:1.2px;
+    classDef bridge fill:${ZIG[500]},stroke:${ZIG[200]},color:${SURFACE[900]},stroke-width:1.6px;
+    classDef native fill:${SURFACE[50]},stroke:${SURFACE[300]},color:${SURFACE[900]},stroke-width:1.2px;
 
     class UC entry;
     class API,Config,PD js;

--- a/documents/src/styles/brand-tokens.ts
+++ b/documents/src/styles/brand-tokens.ts
@@ -1,0 +1,37 @@
+/**
+ * Mermaid / ECharts / 기타 canvas-rendered surface 가 사용하는 hex 토큰.
+ * `documents/src/styles/tailwind.css` 의 `--color-zig-*` / `--color-surface-*` 와 1:1 sync.
+ *
+ * 왜 CSS variable 을 직접 못 쓰나: mermaid 는 themeVariables 를 받아 SVG attribute 로 직렬화하고,
+ * ECharts 는 canvas 렌더링이라 `var(--color-...)` 문자열을 그대로 fill/stroke 로 보낸다.
+ * computed style 을 읽어주는 단계가 없어 raw hex 가 필요.
+ * 한쪽 갱신 시 tailwind.css 의 동일 토큰도 함께 수정할 것.
+ */
+
+export const ZIG = {
+  50: "#fff7ed",
+  100: "#ffedd5",
+  200: "#fed7aa",
+  300: "#fdba74",
+  400: "#fb923c",
+  500: "#f7a41d",
+  600: "#ea580c",
+  700: "#c2410c",
+  800: "#9a3412",
+  900: "#7c2d12",
+  950: "#431407",
+} as const;
+
+export const SURFACE = {
+  50: "#fafaf9",
+  100: "#f5f5f4",
+  200: "#e7e5e4",
+  300: "#d6d3d1",
+  400: "#a8a29e",
+  500: "#78716c",
+  600: "#57534e",
+  700: "#3a3432",
+  800: "#2a2422",
+  900: "#1c1816",
+  950: "#141110",
+} as const;


### PR DESCRIPTION
## Summary
- mermaid (\`Mermaid.tsx\` THEME_PAIRS, \`diagrams.ts\` classDef) 와 echarts (\`SERIES_COLORS\`) 가 같은 ZNTC 브랜드 hex 를 각자 hard-code — \`tailwind.css\` 의 \`--color-zig-*\` / \`--color-surface-*\` 와 1:1 인데도 4 파일에 흩어짐.
- mermaid 와 echarts 둘 다 CSS custom property 를 직접 못 받음 (SVG attribute 로 직렬화 / canvas 렌더라 computed style 단계가 없음) → raw hex 가 필요. 따라서 \`brand-tokens.ts\` 단일 TS 상수로 모아 import.

## 변경
| 파일 | 변경 |
|---|---|
| \`documents/src/styles/brand-tokens.ts\` | 신규. \`ZIG\` / \`SURFACE\` 11단계 palette export. \`tailwind.css\` 와 sync 유지 의도 주석 |
| \`Mermaid.tsx\` | THEME_PAIRS 12 hex × 2 (light/dark) → 토큰 참조 |
| \`BenchmarkChartsImpl.tsx\` | SERIES_COLORS 의 ZNTC → \`ZIG[500]\`. 다른 도구 (esbuild/SWC/Bun 등) 색은 각자의 brand color 라 그대로 |
| \`diagrams.ts\` | 4개 mermaid 다이어그램의 classDef 8 hex × 4 → 토큰 보간 |

## Visual 변화 없음
같은 hex 가 토큰을 거쳐 emit 되므로 산출물 동일. dev server 로 \`/zntc/\` / \`/zntc/reference/napi/\` (mermaid 포함) / \`/zntc/reference/benchmarks/\` 모두 HTTP 200 확인.

## Test plan
- [x] \`bun run build\` 통과, 513 페이지, starlight-links-validator 깨끗
- [x] dev server smoke test (landing / napi / benchmarks 모두 200)
- [ ] 다크 모드에서 mermaid 다이어그램 색이 light 와 동일한 brand orange 로 그려지는지 브라우저 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)