### PR TITLE
refactor(astro): single echarts-setup module — union register, dedup imports

### DIFF
--- a/documents/src/components/BenchmarkChartsImpl.tsx
+++ b/documents/src/components/BenchmarkChartsImpl.tsx
@@ -1,15 +1,10 @@
 import { useMemo } from "react";
 import ReactEChartsCore from "echarts-for-react/lib/core";
-import * as echarts from "echarts/core";
-import { BarChart } from "echarts/charts";
-import { TooltipComponent, GridComponent, LegendComponent } from "echarts/components";
-import { CanvasRenderer } from "echarts/renderers";
 
 import benchmarkData from "../data/benchmark-data.json";
 import { ZIG } from "../styles/brand-tokens";
+import { echarts } from "./echarts-setup";
 import { useStarlightDark } from "./useStarlightDark";
-
-echarts.use([BarChart, TooltipComponent, GridComponent, LegendComponent, CanvasRenderer]);
 
 // ZNTC 만 brand token 사용. 다른 도구 색은 각자의 brand color 라 토큰화 X.
 const SERIES_COLORS: Record<string, string> = {

--- a/documents/src/components/MetafileAnalyzer.tsx
+++ b/documents/src/components/MetafileAnalyzer.tsx
@@ -1,11 +1,7 @@
 import { useDeferredValue, useMemo, useState, type ReactNode } from "react";
 import ReactEChartsCore from "echarts-for-react/lib/core";
-import * as echarts from "echarts/core";
-import { TreemapChart, GraphChart } from "echarts/charts";
-import { TooltipComponent, LegendComponent } from "echarts/components";
-import { CanvasRenderer } from "echarts/renderers";
 
-echarts.use([TreemapChart, GraphChart, TooltipComponent, LegendComponent, CanvasRenderer]);
+import { echarts } from "./echarts-setup";
 
 type ImportKind =
   | "import-statement"

--- a/documents/src/components/echarts-setup.ts
+++ b/documents/src/components/echarts-setup.ts
@@ -1,0 +1,24 @@
+/**
+ * ECharts core + 사용 중인 charts/components/renderers 의 단일 register 지점.
+ *
+ * `echarts.use()` 는 module-global 이라 어디서 호출하든 효과는 같지만, 여러 컴포넌트가
+ * 각자 부분집합만 register 하면 두 chunk 가 분리될 때 사용자가 "왜 이 chart 만 안 그려지지"
+ * 라는 디버깅을 유발. 한 곳에 모아 union register 하고 호출자는 이 모듈에서 `echarts` 만 import.
+ */
+
+import * as echarts from "echarts/core";
+import { BarChart, GraphChart, TreemapChart } from "echarts/charts";
+import { GridComponent, LegendComponent, TooltipComponent } from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
+
+echarts.use([
+  BarChart,
+  TreemapChart,
+  GraphChart,
+  TooltipComponent,
+  GridComponent,
+  LegendComponent,
+  CanvasRenderer,
+]);
+
+export { echarts };


### PR DESCRIPTION
## Summary
\`BenchmarkChartsImpl.tsx\` 와 \`MetafileAnalyzer.tsx\` 가 각자 \`echarts.use(...)\` 를 호출해 부분집합 (각각 5개 component) 을 register. 멱등이라 런타임 문제는 없지만 두 파일의 \`echarts/charts\` · \`echarts/components\` · \`echarts/renderers\` 5개 import 가 중복되고, 한 곳에서 색 / chart 종류 추가할 때 다른 곳 빠뜨리기 쉬움.

## 변경
- 신규 \`documents/src/components/echarts-setup.ts\` — union register (\`BarChart\` + \`TreemapChart\` + \`GraphChart\` + \`TooltipComponent\` + \`GridComponent\` + \`LegendComponent\` + \`CanvasRenderer\`) + \`echarts\` re-export
- \`BenchmarkChartsImpl.tsx\` / \`MetafileAnalyzer.tsx\` — \`echarts/*\` deep import 제거하고 \`import { echarts } from \"./echarts-setup\"\` 한 줄로 정리

## Test plan
- [x] \`bun run build\` 통과, 513 페이지, starlight-links-validator 깨끗
- [x] dev server: \`/zntc/\` / \`/zntc/reference/benchmarks/\` / \`/zntc/analyze/\` 모두 HTTP 200
- [ ] benchmark 차트 + analyze treemap/graph 가 정상 렌더 (시각적 변화 없음 — 같은 chart types register)

🤖 Generated with [Claude Code](https://claude.com/claude-code)