### PR TITLE
feat(mangler): mangle_audit — Phase A/B base54 1-char skip 측정

### DIFF
--- a/src/codegen/mangler.zig
+++ b/src/codegen/mangler.zig
@@ -62,6 +62,10 @@ pub const ManglerStats = struct {
     reserved_size: usize = 0,
     /// Phase 5 후 renames 에 기록된 심볼 수 (원본과 동일하면 skip 되므로 slot_count 와 다를 수 있음).
     renamed_symbol_count: usize = 0,
+    /// Phase 4 base54 발급 루프에서 reserved/global 충돌로 skip 된 1글자 후보 수.
+    /// 총 skip 수는 `name_counter_final - starting_name_counter - slot_count` 로 derivable
+    /// 이지만, 1-char skip 은 카운터 분포를 모르면 알 수 없어 별도 측정.
+    reserved_skips_1char: usize = 0,
 };
 
 /// mangle() 입력 데이터.
@@ -331,14 +335,10 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
     var name_counter: u32 = input.starting_name_counter;
     var name_buf: [8]u8 = undefined;
     var slot_name_length_sum: usize = 0;
+    var reserved_skips_1char: usize = 0;
     for (sorted_slots) |entry| {
         // 예약어/글로벌 + mangling 제외 심볼의 원본 이름은 건너뜀 (#1609)
-        var name = base54(name_counter, &name_buf);
-        name_counter += 1;
-        while (isReservedOrGlobal(name) or reserved_names.contains(name)) {
-            name = base54(name_counter, &name_buf);
-            name_counter += 1;
-        }
+        const name = nextNonReservedBase54Name(&name_counter, &name_buf, &reserved_names, &reserved_skips_1char);
         slot_names[entry.slot_id] = try allocator.dupe(u8, name);
         slot_name_length_sum += name.len;
     }
@@ -386,6 +386,7 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
             .name_counter_final = name_counter,
             .reserved_size = reserved_names.count(),
             .renamed_symbol_count = renames.count(),
+            .reserved_skips_1char = reserved_skips_1char,
         },
     };
 }
@@ -613,6 +614,22 @@ pub fn nextBase54Name(counter: *u32, buf: *[8]u8) []const u8 {
     while (isReservedOrGlobal(name)) {
         name = base54(counter.*, buf);
         counter.* += 1;
+    }
+    return name;
+}
+
+/// `nextBase54Name` + 외부 reserved set 충돌까지 함께 skip. skip 시 1글자 후보였던
+/// 횟수만 `skips_1char` 에 누적 (총 skip 수는 counter 차로 derivable).
+pub fn nextNonReservedBase54Name(
+    counter: *u32,
+    buf: *[8]u8,
+    reserved: *const std.StringHashMap(void),
+    skips_1char: *usize,
+) []const u8 {
+    var name = nextBase54Name(counter, buf);
+    while (reserved.contains(name)) {
+        if (name.len == 1) skips_1char.* += 1;
+        name = nextBase54Name(counter, buf);
     }
     return name;
 }

--- a/src/codegen/unified_mangler.zig
+++ b/src/codegen/unified_mangler.zig
@@ -17,6 +17,7 @@
 
 const std = @import("std");
 const mangler = @import("mangler.zig");
+const debug_log = @import("../debug_log.zig");
 const Scope = @import("../semantic/scope.zig").Scope;
 const Symbol = @import("../semantic/symbol.zig").Symbol;
 const Reference = @import("../semantic/symbol.zig").Reference;
@@ -110,12 +111,10 @@ pub fn mangleAll(
     var name_buf: [8]u8 = undefined;
     var phase_a_slot_name_length_sum: usize = 0;
     var phase_a_renamed: usize = 0;
+    var phase_a_skips_1char: usize = 0;
 
     for (sorted) |cand| {
-        var new_name = mangler.nextBase54Name(&name_counter, &name_buf);
-        while (reserved.contains(new_name)) {
-            new_name = mangler.nextBase54Name(&name_counter, &name_buf);
-        }
+        const new_name = mangler.nextNonReservedBase54Name(&name_counter, &name_buf, &reserved, &phase_a_skips_1char);
         phase_a_slot_name_length_sum += new_name.len;
 
         if (!std.mem.eql(u8, cand.name, new_name)) {
@@ -136,6 +135,7 @@ pub fn mangleAll(
         .name_counter_final = name_counter,
         .reserved_size = reserved.count(),
         .renamed_symbol_count = phase_a_renamed,
+        .reserved_skips_1char = phase_a_skips_1char,
     };
 
     // ================================================================
@@ -185,6 +185,33 @@ pub fn mangleAll(
             reserved.putAssumeCapacity(entry.value_ptr.*, {});
         }
         take.deinit();
+    }
+
+    if (debug_log.enabled(.mangle_audit)) {
+        var sum_b_slots: usize = 0;
+        var sum_b_skips_1char: usize = 0;
+        var sum_b_counter: u32 = 0;
+        for (phase_b_stats) |s| {
+            sum_b_slots += s.slot_count;
+            sum_b_skips_1char += s.reserved_skips_1char;
+            sum_b_counter += s.name_counter_final;
+        }
+        const phase_a_skips: usize = phase_a.name_counter_final - phase_a.slot_count;
+        const sum_b_skips: usize = @as(usize, sum_b_counter) - sum_b_slots;
+        debug_log.print(.mangle_audit, "PhaseA: slot={d} counter={d} skips={d} skips_1char={d} reserved_size={d}\n", .{
+            phase_a.slot_count,
+            phase_a.name_counter_final,
+            phase_a_skips,
+            phase_a.reserved_skips_1char,
+            phase_a.reserved_size,
+        });
+        debug_log.print(.mangle_audit, "PhaseB[total]: modules={d} slot_sum={d} counter_sum={d} skips_sum={d} skips_1char_sum={d}\n", .{
+            phase_b_stats.len,
+            sum_b_slots,
+            sum_b_counter,
+            sum_b_skips,
+            sum_b_skips_1char,
+        });
     }
 
     return .{

--- a/src/debug_log.zig
+++ b/src/debug_log.zig
@@ -61,6 +61,9 @@ pub const Category = enum {
     /// 불가 — 이 dump 를 외부 grep 으로 bundle 과 대조해 어떤 candidate 가 짧은 이름
     /// 풀을 잠식하는지 확인. mangle 식별자 풀 미소진 진단.
     mangle_dump,
+    /// Phase A (cross-module top-level) + Phase B (per-module nested) 의 1-char
+    /// skip 분포 + slot/counter summary. mangle 식별자 풀 1-char 잠식 진단용.
+    mangle_audit,
 
     /// 카테고리 이름으로 enum 조회 (공백 제거 + 대소문자 무시).
     pub fn fromString(s: []const u8) ?Category {


### PR DESCRIPTION
## Summary

- `mangle_audit` debug 카테고리 추가 (`ZNTC_DEBUG=mangle_audit`)
- `ManglerStats.reserved_skips_1char` 필드 + `mangleAll()` 끝 summary 출력
- `nextNonReservedBase54Name()` helper — Phase 4 / Phase A 의 동일 패턴 합침
- 본 PR 은 진단 인프라만 — size/동작 영향 0

## Why

rolldown/rspack 대비 1-char identifier 활용 5배 격차 (rxjs 측정: zntc 2,167 vs rolldown 11,940) 의 root cause 를 데이터로 좁히기 위한 첫 단계. K2 (Phase B reserved 축소) → K3 (per-function fresh counter) → K4 (per-block) 진행을 위한 측정 인프라.

## 측정 결과 (rxjs deepEntry, --minify, --platform=node)

```
[mangle_audit] PhaseA: slot=1749 counter=1756 skips=7 skips_1char=0 reserved_size=1761
[mangle_audit] PhaseB[total]: modules=224 slot_sum=1194 counter_sum=484907 skips_sum=483713 skips_1char_sum=11016
```

- Phase A (cross-module top-level): slot 1749, 1-char skip = **0** — top-level 은 1-char 자유롭게 사용
- Phase B (per-module nested): 224 모듈 합 counter 484,907 / slot 1,194 → **skip 483,713 회**, 그중 **1-char skip 11,016 회**
- 224 모듈 × 54 (base54 의 1글자 후보) ≈ 12,096 → 거의 모든 모듈에서 1-char 가 reserved 로 막혀 즉시 skip → 2-char fallback. 가설 (Phase B 가 cross-module Phase A reserved 로 1-char 다 막힘) 데이터 확인.

## Test plan

- [x] zig build 통과
- [x] zig build test 통과 (mangler 단위 테스트 변경 없음)
- [x] smoke (134 fixture) Average 0.87x 동일 (size 변동 0)
- [x] rxjs deepEntry node 출력 정확 ({"a":90,...})
- [x] mangle_audit 비활성 시 hot path 영향 없음 (skip 카운트는 base54 collision 발생 시에만 +2 add)

🤖 Generated with [Claude Code](https://claude.com/claude-code)