### PR TITLE
feat(core): lazy auto-init for native API — match esbuild/swc UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,9 @@ npx zntc --bundle index.js --platform=react-native --rn-platform=ios -o bundle.j
 ### `@zntc/core` JS / NAPI API
 
 ```ts
-import { init, transpile, build } from "@zntc/core";
+import { transpile, build } from "@zntc/core";
 
-init(); // NAPI 바인딩 한 번만
-
-// 단일 파일 트랜스파일
+// 단일 파일 트랜스파일 — NAPI 바인딩은 첫 호출 시 자동 로드
 const { code, map } = transpile(source, {
   filename: "input.ts",
   jsx: "automatic",

--- a/documents/src/content/docs/en/guides/installation.mdx
+++ b/documents/src/content/docs/en/guides/installation.mdx
@@ -102,9 +102,7 @@ deno run -A npm:@zntc/core --bundle src/index.ts -o dist/bundle.js
 JS API:
 
 ```typescript
-import { init, transpile, build, buildSync, vitePlugin } from "@zntc/core";
-
-init();
+import { transpile, build, buildSync, vitePlugin } from "@zntc/core";
 
 // Transpile
 const { code } = transpile("const x: number = 1;");

--- a/documents/src/content/docs/en/index.mdx
+++ b/documents/src/content/docs/en/index.mdx
@@ -38,9 +38,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
   ]}
   codeFilename="example.ts"
   codeLang="ts"
-  codeExample={`import { init, transpile } from '@zntc/core';
-
-init();
+  codeExample={`import { transpile } from '@zntc/core';
 
 const { code } = transpile(source, {
   filename: 'input.tsx',

--- a/documents/src/content/docs/en/reference/napi.mdx
+++ b/documents/src/content/docs/en/reference/napi.mdx
@@ -27,19 +27,20 @@ import { NAPI_ARCHITECTURE_CHART } from "@components/diagrams";
 
 Plugin hooks like `onResolve` / `onLoad` are awoken via NAPI threadsafe-fn whenever the native bundler needs them — the Zig worker waits synchronously for the JS callback's response (including Promise resolution).
 
-## Install + initialize
+## Install + use
 
 ```bash
 bun add @zntc/core
 ```
 
 ```ts
-import { init, close, transpile, build, watch } from "@zntc/core";
+import { transpile, build, watch } from "@zntc/core";
 
-init();           // load NAPI addon (call once)
-// ... use ...
-close();          // cleanup on shutdown
+// The first native call auto-loads the addon — same pattern as esbuild / swc.
+const result = transpile(source, { jsx: "automatic" });
 ```
+
+`init(addonPath?)` and `close()` are still exported — call `init` only when you need to pin the prebuild path (tests, non-standard install) or want to control when the addon loads. Normal usage doesn't need it.
 
 ## `transpile(source, options)`
 

--- a/documents/src/content/docs/guides/installation.mdx
+++ b/documents/src/content/docs/guides/installation.mdx
@@ -102,9 +102,7 @@ deno run -A npm:@zntc/core --bundle src/index.ts -o dist/bundle.js
 JS API:
 
 ```typescript
-import { init, transpile, build, buildSync, vitePlugin } from "@zntc/core";
-
-init();
+import { transpile, build, buildSync, vitePlugin } from "@zntc/core";
 
 // 트랜스파일
 const { code } = transpile("const x: number = 1;");

--- a/documents/src/content/docs/guides/plugins.md
+++ b/documents/src/content/docs/guides/plugins.md
@@ -183,8 +183,7 @@ const myPlugin = {
 ## NAPI 플러그인
 
 ```typescript
-import { init, build, vitePlugin } from "@zntc/core";
-init();
+import { build, vitePlugin } from "@zntc/core";
 
 // esbuild 스타일
 const result = await build({

--- a/documents/src/content/docs/index.mdx
+++ b/documents/src/content/docs/index.mdx
@@ -38,9 +38,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
   ]}
   codeFilename="example.ts"
   codeLang="ts"
-  codeExample={`import { init, transpile } from '@zntc/core';
-
-init();
+  codeExample={`import { transpile } from '@zntc/core';
 
 const { code } = transpile(source, {
   filename: 'input.tsx',

--- a/documents/src/content/docs/reference/napi.mdx
+++ b/documents/src/content/docs/reference/napi.mdx
@@ -27,19 +27,20 @@ import { NAPI_ARCHITECTURE_CHART } from "@components/diagrams";
 
 JS plugin 의 `onResolve` / `onLoad` 등은 native bundler 가 모듈을 만나는 시점마다 NAPI threadsafe function 으로 JS dispatcher 를 깨워 호출 — Zig worker 가 응답을 기다리는 sync 모델 (Promise 결과까지 wait).
 
-## 설치 + 초기화
+## 설치 + 사용
 
 ```bash
 bun add @zntc/core
 ```
 
 ```ts
-import { init, close, transpile, build, watch } from "@zntc/core";
+import { transpile, build, watch } from "@zntc/core";
 
-init();           // NAPI addon 로드 (한 번만)
-// ... 사용 ...
-close();          // 종료 시 cleanup
+// 첫 native 호출 시 addon 자동 로드 — esbuild/swc 와 동일 패턴.
+const result = transpile(source, { jsx: "automatic" });
 ```
+
+`init(addonPath?)` 와 `close()` 도 export — `init` 은 prebuild 경로를 직접 지정하거나 (테스트 / 비표준 설치) addon 로딩 시점을 명시적으로 제어할 때만 호출. 일반 사용은 불필요.
 
 ## `transpile(source, options)`
 

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -329,8 +329,9 @@ export type {
 import type { UserConfigInput } from './src/config-loader.ts';
 
 /**
- * NAPI 모듈을 로드한다.
- * 이미 로드된 경우 무시한다.
+ * NAPI addon 을 로드한다 — `transpile()`/`build()`/`watch()` 등 native API 첫 호출 시
+ * 자동으로 호출되므로 명시 호출은 옵션. addon path override (custom prebuild 등) 가
+ * 필요할 때만 직접 호출. 이미 로드된 경우 no-op.
  */
 export function init(addonPath?: string): void {
   if (native) return;
@@ -338,6 +339,16 @@ export function init(addonPath?: string): void {
   // require shadowing 회피 — findAddon() 참고.
   const nodeRequire = createRequire(import.meta.url);
   native = nodeRequire(path) as NativeModule;
+}
+
+/**
+ * native handle 을 반환. lazy auto-init 의 단일 진입점.
+ * TS 가 module-level mutable `let native` 를 `asserts` 시그니처로도 narrowing 못 해
+ * helper 한 곳에 `!` 를 격리. caller 들은 좁혀진 `NativeModule` 을 그대로 사용.
+ */
+function ensureNative(): NativeModule {
+  init();
+  return native!;
 }
 
 /**
@@ -409,8 +420,7 @@ export class TsconfigCache {
   private readonly _handle: NativeTsconfigCacheHandle;
 
   constructor() {
-    if (!native) throw new Error('@zntc/core: not initialized. Call init() first.');
-    this._handle = native.createTsconfigCache();
+    this._handle = ensureNative().createTsconfigCache();
   }
 
   /** 모든 cache entry 와 내부 string 메모리 회수. 인스턴스는 재사용 가능. */
@@ -443,12 +453,11 @@ export function transpile(
   source: string,
   options: TranspileOptions & { cache?: TsconfigCache } = {},
 ): TranspileResult {
-  if (!native) throw new Error('@zntc/core: not initialized. Call init() first.');
   if (!source) throw new Error('@zntc/core: empty source');
   validateTsConfigRaw(options.tsconfigRaw);
 
   const optionsJson = buildOptionsJson(options, resolveUnsupported(options));
-  return native.transpile(
+  return ensureNative().transpile(
     source,
     options.filename ?? 'input.js',
     optionsJson,
@@ -457,22 +466,19 @@ export function transpile(
 }
 
 export function tokenize(source: string, options: TokenizeOptions = {}): TokenizeToken[] {
-  if (!native) throw new Error('@zntc/core: not initialized. Call init() first.');
   if (!source) throw new Error('@zntc/core: empty source');
-  return native.tokenize(source, options.filename ?? 'input.js');
+  return ensureNative().tokenize(source, options.filename ?? 'input.js');
 }
 
 export function configureProfile(
   profile: string[],
   level?: 'summary' | 'detailed' | 'per-module' | 'per-pass',
 ): void {
-  if (!native) throw new Error('@zntc/core: not initialized. Call init() first.');
-  native.configureProfile(profile, level);
+  ensureNative().configureProfile(profile, level);
 }
 
 export function profileReport(format: 'table' | 'tree' | 'json' | 'csv' = 'table'): string {
-  if (!native) throw new Error('@zntc/core: not initialized. Call init() first.');
-  return native.profileReport(format);
+  return ensureNative().profileReport(format);
 }
 
 // ─── Build API ───
@@ -2156,7 +2162,7 @@ function writeOutputFiles(result: BuildResult, options: BuildOptions): void {
  * `closeBundle` 은 write 성공 시에만 호출.
  */
 export async function build(options: BuildOptions): Promise<BuildResult> {
-  if (!native) throw new Error('@zntc/core: not initialized. Call init() first.');
+  const n = ensureNative();
   if (!options.entryPoints?.length) throw new Error('@zntc/core: entryPoints is required');
   validateTsConfigRaw(options.tsconfigRaw);
 
@@ -2169,7 +2175,7 @@ export async function build(options: BuildOptions): Promise<BuildResult> {
   // 위해 writeOutputFiles 다음에 JS layer 가 직접 호출 — native bundle() 끝 시점은 contents
   // 결정 직후라 disk write *전* 이므로 closeBundle 자리 부적합.
   try {
-    const result: BuildResult = wrapOutputFiles(await native.build(napiOptions));
+    const result: BuildResult = wrapOutputFiles(await n.build(napiOptions));
     if (dispatcher) {
       for (const failure of dispatcher.takeLifecycleFailures()) {
         result.errors.push(pluginFailureToDiagnostic(failure));
@@ -2196,7 +2202,7 @@ export async function build(options: BuildOptions): Promise<BuildResult> {
  * JS 플러그인은 sync hook만 지원한다. Promise/async hook은 plugin_error로 실패한다.
  */
 export function buildSync(options: BuildOptions): BuildResult {
-  if (!native) throw new Error('@zntc/core: not initialized. Call init() first.');
+  const n = ensureNative();
   if (!options.entryPoints?.length) throw new Error('@zntc/core: entryPoints is required');
   validateTsConfigRaw(options.tsconfigRaw);
 
@@ -2204,7 +2210,7 @@ export function buildSync(options: BuildOptions): BuildResult {
   const dispatcher = resolveDispatcher(options, 'sync');
   if (dispatcher) napiOptions._pluginDispatcherSync = dispatcher;
   try {
-    const result: BuildResult = wrapOutputFiles(native.buildSync(napiOptions));
+    const result: BuildResult = wrapOutputFiles(n.buildSync(napiOptions));
     if (dispatcher) {
       for (const failure of dispatcher.takeLifecycleFailures()) {
         result.errors.push(pluginFailureToDiagnostic(failure));
@@ -2225,10 +2231,10 @@ export function buildSync(options: BuildOptions): BuildResult {
 }
 
 export function buildAppSync(options: AppBuildOptions = {}): BuildResult {
-  if (!native) throw new Error('@zntc/core: not initialized. Call init() first.');
+  const n = ensureNative();
   const { publicDir, compiler, ...rest } = options;
   return wrapOutputFiles(
-    native.buildAppSync({
+    n.buildAppSync({
       ...rest,
       define: withDefaultAppBuildDefines(options),
       ...(publicDir === false
@@ -2285,9 +2291,9 @@ function buildCompilerNapiFields(compiler: AppBuildOptions['compiler']): Record<
 }
 
 export function prepareAppDevSync(options: AppDevPrepareOptions = {}): AppDevPrepareResult {
-  if (!native) throw new Error('@zntc/core: not initialized. Call init() first.');
+  const n = ensureNative();
   const { publicDir, ...rest } = options;
-  return native.prepareAppDevSync({
+  return n.prepareAppDevSync({
     ...rest,
     ...(publicDir === false
       ? { disablePublicDir: true }
@@ -2369,14 +2375,13 @@ export interface BenchmarkResult {
  * ```
  */
 export function benchmark(options: BenchmarkOptions): BenchmarkResult {
-  if (!native) throw new Error('@zntc/core: not initialized. Call init() first.');
   if (!options.source && !options.file) {
     throw new Error("@zntc/core.benchmark: 'source' or 'file' is required");
   }
   if (!Array.isArray(options.phases) || options.phases.length === 0) {
     throw new Error("@zntc/core.benchmark: 'phases' must be a non-empty string array");
   }
-  return native.benchmark({
+  return ensureNative().benchmark({
     source: options.source,
     file: options.file,
     filename: options.filename ?? 'input.js',
@@ -2662,7 +2667,7 @@ export function vitePlugin(rollupPlugin: RollupPlugin): ZntcPlugin {
  * → onReady/onRebuild → closeBundle. closeBundle 은 callback 이 없거나 throw 해도 호출된다.
  */
 export function watch(options: BuildOptions): WatchHandle {
-  if (!native) throw new Error('call init() first');
+  const n = ensureNative();
 
   const { napiOptions: nativeOpts, cleanup } = prepareNapiOptions(options);
   const dispatcher = resolveDispatcher(options);
@@ -2691,7 +2696,7 @@ export function watch(options: BuildOptions): WatchHandle {
 
   let handle: WatchHandle;
   try {
-    handle = native.watch(nativeOpts);
+    handle = n.watch(nativeOpts);
   } catch (err) {
     cleanup();
     throw err;

--- a/packages/core/test/core/api.ts
+++ b/packages/core/test/core/api.ts
@@ -4,3 +4,4 @@ import './api/jsx';
 import './api/output-options';
 import './api/targets';
 import './api/lifecycle';
+import './api/lazy-auto-init';

--- a/packages/core/test/core/api/lazy-auto-init.ts
+++ b/packages/core/test/core/api/lazy-auto-init.ts
@@ -1,0 +1,12 @@
+import { describe, test, expect } from 'bun:test';
+
+// 일부러 helpers 에서 init()/close() 를 받지 않는다. lazy auto-init 가
+// `transpile()` 의 첫 호출에서 addon 을 자동 로드하는지 검증.
+import { transpile } from '../../../index';
+
+describe('@zntc/core: lazy auto-init', () => {
+  test('init() 명시 호출 없이도 transpile 가 동작', () => {
+    const result = transpile('const x: number = 1;', { filename: 'input.ts' });
+    expect(result.code).toContain('const x = 1;');
+  });
+});


### PR DESCRIPTION
## Summary
\`esbuild\` / \`@swc/core\` / \`oxc\` 는 모듈 import 시점에 native addon 을 자동 로드해서 사용자가 \`init()\` 명시 호출 없이 \`transpile\`/\`build\` 호출 가능. ZNTC 만 명시적 \`init()\` 강요라 다른 도구와 친숙성 차이.

## 변경
\`packages/core/index.ts\` 의 모든 native API 가드를 \`ensureNative()\` helper 로 통일. 첫 호출 시 자동 \`init()\` + native handle 반환.

```ts
function ensureNative(): NativeModule {
  init();
  return native!;
}
```

TS module-level mutable \`let native\` 는 \`asserts\` 시그니처로 narrowing 안 되는 한계가 있어 helper 한 곳에 \`!\` 격리. caller 들은 \`const n = ensureNative();\` 또는 \`return ensureNative().xxx(...)\` 패턴으로 좁혀진 타입 그대로 사용 — caller 측 코드는 \`!\` 없이 깔끔.

\`init(addonPath?)\` 는 여전히 export — prebuild path 직접 지정이나 로딩 시점 명시 제어 용도. 일반 사용은 불필요.

## 사용자 대면 영향
| 파일 | 변경 |
|---|---|
| landing (\`index.mdx\` 한+영) | code example 에서 \`init()\` 줄 제거 |
| \`reference/napi.mdx\` 한+영 | "Install + use" 섹션 재작성 — auto-init 설명 + \`init\`/\`close\` 는 옵션으로 표기 |
| \`guides/installation.mdx\` 한+영 | JS API 예시에서 \`init()\` 제거 |
| \`guides/plugins.md\` | NAPI 플러그인 예시에서 \`init()\` 제거 |
| \`README.md\` | 동일 |

## WASM 은 그대로
\`@zntc/wasm\` 의 \`init()\` 은 비동기 \`WebAssembly.instantiate\` 라 자동화 어려움 (transpile 자체는 동기). esbuild-wasm 도 동일 패턴 (\`await initialize()\`). WASM 쪽은 그대로 명시 호출 유지.

## Test plan
- [x] 신규 \`packages/core/test/core/api/lazy-auto-init.ts\` — \`init()\` 명시 호출 없이 \`transpile()\` 가 동작하는지 검증
- [x] 기존 api.ts test 34 개 모두 통과 (lazy + 기존 33)
- [x] \`bun x tsc -b --force\` 통과 (asserts 트릭 안 쓰고 helper 패턴으로 narrowing)
- [x] \`bun run build\` (Astro docs, 513 페이지) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)