### PR TITLE
fix(astro): preserve landing code-example indent; clean up JSDoc samples

### DIFF
--- a/documents/src/content/docs/en/index.mdx
+++ b/documents/src/content/docs/en/index.mdx
@@ -38,13 +38,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
   ]}
   codeFilename="example.ts"
   codeLang="ts"
-  codeExample={`import { transpile } from '@zntc/core';
-
-const { code } = transpile(source, {
-  filename: 'input.tsx',
-  jsx: 'automatic',
-  target: 'es2022',
-});`}
+  codeExample={"import { transpile } from '@zntc/core';\n\nconst { code } = transpile(source, {\n  filename: 'input.tsx',\n  jsx: 'automatic',\n  target: 'es2022',\n});"}
 />
 
 <StatsStrip

--- a/documents/src/content/docs/index.mdx
+++ b/documents/src/content/docs/index.mdx
@@ -38,13 +38,7 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
   ]}
   codeFilename="example.ts"
   codeLang="ts"
-  codeExample={`import { transpile } from '@zntc/core';
-
-const { code } = transpile(source, {
-  filename: 'input.tsx',
-  jsx: 'automatic',
-  target: 'es2022',
-});`}
+  codeExample={"import { transpile } from '@zntc/core';\n\nconst { code } = transpile(source, {\n  filename: 'input.tsx',\n  jsx: 'automatic',\n  target: 'es2022',\n});"}
 />
 
 <StatsStrip

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -6,8 +6,7 @@
  *
  * @example
  * ```ts
- * import { init, transpile } from "@zntc/core";
- * init();
+ * import { transpile } from "@zntc/core";
  * const result = transpile("const x: number = 1;", { filename: "input.ts" });
  * console.log(result.code);
  * ```
@@ -2363,8 +2362,7 @@ export interface BenchmarkResult {
  *
  * @example
  * ```ts
- * import { init, benchmark } from "@zntc/core";
- * init();
+ * import { benchmark } from "@zntc/core";
  *
  * const result = benchmark({
  *   file: "./src/App.tsx",


### PR DESCRIPTION
## Summary
사용자 보고:
1. 랜딩 페이지의 \`transpile(source, { filename, jsx, target })\` 객체 properties 들여쓰기가 실제 화면에서 빠져 있음 (MDX → JSX prop expression 처리 시 leading whitespace 가 사라짐)
2. \`init()\` 자동화 (#3245) 후에도 일부 자동생성 문서에 \`init()\` 호출이 남아 있음

## 변경
| 파일 | 내용 |
|---|---|
| \`index.mdx\` 한+영 | \`codeExample\` 의 backtick literal → \`\\n\` escape 된 단일 string. \`<Code>\` 가 받는 raw string 에서 indent 가 그대로 보존됨 |
| \`packages/core/index.ts\` | JSDoc @example 2곳 (top-level + benchmark) 에서 \`init()\` 호출 제거. \`reference/api/functions/benchmark.md\` 는 TypeDoc 자동 생성이라 다음 build 에서 자동 갱신 |

## 검증
- 변경 전 렌더 HTML: \`<span>filename:</span>\` (들여쓰기 없음)
- 변경 후 렌더 HTML: \`<span>  filename:</span>\` (2-space 보존) ✅
- \`bun run build\` 통과, 513 페이지, link validator 깨끗
- TypeDoc 가 \`benchmark.md\` 를 \`init()\` 없는 새 예시로 자동 재생성 확인

## WASM 의 await init() 은 그대로
\`@zntc/wasm\` 의 \`init()\` 은 비동기 \`WebAssembly.instantiate\` 라 lazy 자동화 불가. esbuild-wasm 도 동일 패턴이라 그대로 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)