### PR TITLE
feat(mangler): Phase B reserved 를 모듈 단위로 좁힘 (rxjs -3.7%)

### DIFF
--- a/src/codegen/unified_mangler.zig
+++ b/src/codegen/unified_mangler.zig
@@ -107,6 +107,27 @@ pub fn mangleAll(
         }
     }.cmp);
 
+    // Phase B 가 같은 모듈 안 outer Phase A binding 과 shadow 충돌 (#1757) 을 피하려면
+    // Phase A 가 mangle 한 이름을 *그 모듈 단위* 로 reserve 해야 한다. cross-module 끼리는
+    // CJS/ESM wrapper IIFE 로 격리되므로 다른 모듈의 Phase A 이름은 reserve 할 필요 없다.
+    // (`renames` 만으로 derive 못 함 — Phase A 의 no-op rename, 즉 원본 이름과 mangled 이름이
+    // 같은 경우도 reserved 에 등록해야 하지만 `renames` 에는 안 들어가기 때문.)
+    //
+    // init pass 와 seed pass 를 분리 — `StringHashMap.init` 자체는 fail 하지 않으므로
+    // 두 번째 seed loop 의 `put` 이 OOM 해도 모든 entries 가 이미 init 되어 defer 의
+    // `deinit` 이 안전하게 실행된다 (uninit deinit UB 없음).
+    var per_mod_reserved = try allocator.alloc(std.StringHashMap(void), input.modules.len);
+    for (per_mod_reserved) |*s| s.* = std.StringHashMap(void).init(allocator);
+    defer {
+        for (per_mod_reserved) |*s| s.deinit();
+        allocator.free(per_mod_reserved);
+    }
+    // global_reserved (runtime helper 등) 는 모든 모듈에 visible 하므로 each module 의
+    // reserved 에도 포함. global_reserved 는 caller 가 borrowed 로 넘기므로 ptr 공유.
+    for (per_mod_reserved) |*s| {
+        for (input.global_reserved) |r| try s.put(r, {});
+    }
+
     var name_counter: u32 = 0;
     var name_buf: [8]u8 = undefined;
     var phase_a_slot_name_length_sum: usize = 0;
@@ -117,15 +138,23 @@ pub fn mangleAll(
         const new_name = mangler.nextNonReservedBase54Name(&name_counter, &name_buf, &reserved, &phase_a_skips_1char);
         phase_a_slot_name_length_sum += new_name.len;
 
+        // 일반적으로 production caller (linker.collectUnifiedInput) 는 candidate 의
+        // module_index 가 input.modules.len 미만임을 보장한다. 단위 테스트는 candidate 만
+        // 두고 modules 를 비울 수 있어 (Phase A 만 검증), 그 경우 per_mod_reserved 갱신은
+        // 의미 없으므로 skip — 그 module 에 Phase B 호출 자체가 없어 shadow 도 발생 불가.
+        const has_mod_slot = cand.module_index < per_mod_reserved.len;
+
         if (!std.mem.eql(u8, cand.name, new_name)) {
             const duped = try allocator.dupe(u8, new_name);
             errdefer allocator.free(duped);
             try renames.put(.{ .module_index = cand.module_index, .symbol_id = cand.symbol_id }, duped);
             try reserved.put(duped, {});
+            if (has_mod_slot) try per_mod_reserved[cand.module_index].put(duped, {});
             phase_a_renamed += 1;
         } else {
             // 원본과 동일해도 다음 Phase A 후보가 같은 이름을 집지 못하도록 reserved.
             try reserved.put(cand.name, {});
+            if (has_mod_slot) try per_mod_reserved[cand.module_index].put(cand.name, {});
         }
     }
 
@@ -144,14 +173,11 @@ pub fn mangleAll(
     const phase_b_stats = try allocator.alloc(mangler.ManglerStats, input.modules.len);
     errdefer allocator.free(phase_b_stats);
 
+    // Phase B 는 *이 모듈* 의 Phase A mangled name 만 reserved 로 받는다 (per_mod_reserved).
+    // 다른 모듈의 Phase A 이름은 wrapper IIFE 격리로 nested 에서 직접 보이지 않으므로
+    // ban 하지 않아도 안전. cross-module reference 는 모두 import binding (module-scope,
+    // mangler 내부 reserveNameFor 가 자동 reserve) 또는 wrapper symbol 호출로만 접근.
     for (input.modules, 0..) |m, i| {
-        // Phase B 는 per-module 독립 counter 지만 external_reserved 로 전역
-        // `reserved` 를 그대로 전달한다 (#2956). 다른 모듈의 Phase A mangled
-        // 이름이 이 모듈의 nested binding 과 충돌하면 cross-module shadow 가
-        // 발생 (date-fns: outer constructDateFrom='t' 와 다른 모듈 addDays 의
-        // inner const _date='t' 가 자기참조 ReferenceError). 자기 모듈의
-        // top-scope binding 은 Phase A 에서 이미 reserved 에 등록되어 있으므로
-        // 별도 module_reserved 를 만들지 않아도 된다.
         var nested = try mangler.mangle(allocator, .{
             .scopes = m.scopes,
             .symbols = m.symbols,
@@ -159,7 +185,7 @@ pub fn mangleAll(
             .references = m.references,
             .source = m.source,
             .skip_symbols = m.module_scope_symbols,
-            .external_reserved = &reserved,
+            .external_reserved = &per_mod_reserved[i],
         });
         defer nested.deinit();
         phase_b_stats[i] = nested.stats;
@@ -175,14 +201,12 @@ pub fn mangleAll(
             take.deinit();
         }
         try renames.ensureUnusedCapacity(take_count);
-        try reserved.ensureUnusedCapacity(take_count);
 
         var it = take.iterator();
         const mod_idx: u32 = @intCast(i);
         while (it.next()) |entry| {
             const key: ModuleSymKey = .{ .module_index = mod_idx, .symbol_id = entry.key_ptr.* };
             renames.putAssumeCapacity(key, entry.value_ptr.*);
-            reserved.putAssumeCapacity(entry.value_ptr.*, {});
         }
         take.deinit();
     }

--- a/tests/benchmark/mangler-tree-shake.test.ts
+++ b/tests/benchmark/mangler-tree-shake.test.ts
@@ -99,4 +99,24 @@ Effect.runPromise(p).then(r => console.log(r));
     // fix 직전 회귀 213.8KB. fix 후 ~187KB.
     expect(report.bundle_size_bytes).toBeLessThan(195_000);
   });
+
+  // 회귀 방지: Phase B nested mangler 가 cross-module Phase A 의 mangled name 을
+  // reserved 로 잡아 1-char 풀이 막히는 회귀 (rxjs deepEntry: 167KB → 160KB).
+  // 모든 모듈이 CJS/ESM wrapper IIFE 로 격리되므로 cross-module shadow 위험은
+  // 없고, nested 가 outer 의 1-char (a, b, c, ...) 를 자유롭게 재사용 가능해야 한다.
+  // 회귀 발생 시 Phase B 의 base54 1-char 후보가 다른 모듈의 Phase A reserved 와
+  // 충돌해 즉시 2-char 로 fallback → bundle size 가 ~167KB 로 회귀.
+  test('rxjs: Phase B reuses 1-char pool free from cross-module Phase A reserved', () => {
+    const report = bundle(`
+import { of, from, map, filter, scan, take, mergeMap, catchError, throwError, lastValueFrom, toArray, distinct } from 'rxjs';
+(async () => {
+  const a = await lastValueFrom(of(1, 2, 3, 4, 5).pipe(filter((x) => x % 2 === 1), map((x) => x * 10), scan((acc, n) => acc + n, 0), take(3)));
+  const b = await lastValueFrom(from([10, 20, 30]).pipe(mergeMap((n) => of(n + 1)), toArray()));
+  const c = await lastValueFrom(throwError(() => new Error('boom')).pipe(catchError(() => of('caught'))));
+  const d = await lastValueFrom(of(1, 1, 2, 3, 3, 4).pipe(distinct(), toArray()));
+  console.log(JSON.stringify({ a, b, c, d }));
+})();
+    `);
+    expect(report.bundle_size_bytes).toBeLessThan(165_000);
+  });
 });


### PR DESCRIPTION
## Summary

- unified_mangler 의 Phase B 가 *전역 reserved* (모든 Phase A mangled name 누적) 대신 *현재 모듈의 Phase A mangled name 만* `external_reserved` 로 받도록 변경
- nested base54 가 1-char 풀을 자유롭게 사용 → 2-char fallback 회귀 차단
- 회귀 가드 추가 (rxjs deepEntry size guard < 165KB)

## Why

K1 audit (PR #3243) 결과:
- Phase B counter_sum 484,907 / slot 1,194 → skip 483,713 회 중 11,016 회가 1-char skip
- 224 모듈 × 54 (base54 1글자 후보) ≈ 12,096 — 모든 모듈이 cross-module Phase A reserved 와 충돌해 즉시 2-char fallback

이게 rxjs 167KB vs rolldown 137KB 격차의 1차 원인.

## 안전성

| 위험 | 대응 |
|---|---|
| 같은 모듈 outer-nested shadow (#1757) | `per_mod_reserved[mod_idx]` 가 그 모듈 Phase A 이름 모두 reserve → mangler 의 markScopeSubtree 와 결합해 같은 slot 부여 차단 |
| cross-module shadow (#2956 류) | CJS/ESM wrapper IIFE 격리. cross-module reference 는 import binding local (module-scope, mangler 내부 `reserveNameFor` 가 자동 reserve) 또는 wrapper symbol 호출로만 접근 |
| Phase A no-op rename (원본 == mangled) | renames 에는 안 들어가지만 per_mod_reserved 에는 등록 (다른 후보가 같은 이름 못 받게) |

## 측정 (rxjs deepEntry, --minify, --platform=node)

```
size:               166,376 → 160,186 bytes  (-3.7%)
1-char identifier:    2,167 →   8,357        (esbuild 9,168 수준 도달)
2-char identifier:    9,401 →   3,211
PhaseB counter_sum: 484,907 →   1,397        (skip 거의 0)
```

bundle 의 node 출력 정확 (`{"a":90,"b":[11,21,31],...}`).

## Test plan

- [x] `zig build test` 통과 — #1757 (mangler outer fn / inner var shadowing) 포함 모든 mangler 테스트 통과
- [x] smoke 134 fixture 모두 OK (Average ratio 0.87x 동일, 새 회귀 0)
- [x] `mangler-tree-shake.test.ts` guard 4 pass (rxjs guard 추가)
- [x] node 출력 정확 (rxjs deepEntry)

## Follow-up

- K2-perf: mangler 의 N×G global_reserved 복제 회피 (별도 PR — `external_global_reserved` 추가)
- K3: per-function fresh base54 counter (rolldown 137KB 까지 격차 좁히기)

🤖 Generated with [Claude Code](https://claude.com/claude-code)