### PR TITLE
test(mangler): unified mangler Phase A/B 통합 회귀 가드 추가 (#1760)

### DIFF
--- a/tests/integration/tests/helpers.ts
+++ b/tests/integration/tests/helpers.ts
@@ -452,8 +452,10 @@ export async function bundleAndRun(
   files: Record<string, string>,
   entry: string = 'index.ts',
   extraArgs: string[] = [],
+  options: { env?: Record<string, string | undefined> } = {},
 ): Promise<{
   bundleOutput: string;
+  bundleStderr: string;
   runOutput: string;
   runStderr: string;
   exitCode: number;
@@ -463,7 +465,10 @@ export async function bundleAndRun(
   const outFile = join(dir, 'out.js');
 
   try {
-    const bundle = await runZntc(['--bundle', join(dir, entry), '-o', outFile, ...extraArgs]);
+    const bundle = await runZntc(
+      ['--bundle', join(dir, entry), '-o', outFile, ...extraArgs],
+      options.env ? { env: options.env } : undefined,
+    );
 
     if (bundle.exitCode !== 0) {
       throw new Error(`ZNTC bundle failed: ${bundle.stderr}`);
@@ -473,6 +478,7 @@ export async function bundleAndRun(
 
     return {
       bundleOutput: readFileSync(outFile, 'utf-8'),
+      bundleStderr: bundle.stderr,
       runOutput: run.stdout.trim(),
       runStderr: run.stderr,
       exitCode: run.exitCode,

--- a/tests/integration/tests/unified-mangler.test.ts
+++ b/tests/integration/tests/unified-mangler.test.ts
@@ -1,0 +1,187 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { bundleAndRun, createFixture, runZntc } from './helpers';
+
+// Unified Mangler (#1760) Phase A/B 통합 회귀.
+//
+// unified_mangler.zig 가 linker.computeMangling 에서 호출되어 cross-module
+// top-level (Phase A, frequency-sort) + per-module nested (Phase B, liveness)
+// 를 하나의 reserved set 으로 묶는다. unified_mangler.zig 의 단위 테스트는
+// mangleAll API 형태만 검증하므로 실제 번들 파이프라인에서의 회귀는 별도
+// 통합 가드가 필요. 이 파일은 4가지 contract 를 잡는다:
+//   1. cross-module Phase A reserved → Phase B nested 상속 (shadow 차단)
+//   2. 빈도 다양한 cross-module helper 가 mangle 후에도 모두 정확 동작
+//   3. `--mangle-report=<path>` JSON 출력 구조
+//   4. `ZNTC_DEBUG=mangle_audit` stderr 출력 (Phase A/B 라인)
+describe('unified mangler — Phase A/B 통합 회귀', () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  // date-fns 회귀 패턴을 단순화: moduleA 의 top-level helper 가 Phase A 에서
+  // 짧은 mangled 이름을 받고, moduleB 의 nested 안에서 *그 짧은 이름과 겹칠
+  // 만한 자리에* outer 를 참조하는 경우. Phase B 가 Phase A reserved 를 상속하지
+  // 않으면 nested local 이 outer 와 같은 이름을 받아 shadowing → outer 호출이
+  // 잘못된 값.
+  test('cross-module Phase A reserved 가 Phase B nested 와 충돌하지 않는다', async () => {
+    const result = await bundleAndRun(
+      {
+        // helper 5개 — compute.ts 의 nested inner1~5 와 1:1 대응. Phase A 가
+        // 5개 top-level 을 짧은 base54 이름으로 reserve 한 뒤 Phase B 가 같은
+        // pool 에서 nested inner 를 mangle 할 때 충돌이 노출됨.
+        'helpers.ts': `
+          export function helperA(x: number): number { return x + 1; }
+          export function helperB(x: number): number { return x + 2; }
+          export function helperC(x: number): number { return x + 3; }
+          export function helperD(x: number): number { return x + 4; }
+          export function helperE(x: number): number { return x + 5; }
+        `,
+        'compute.ts': `
+          import { helperA, helperB, helperC, helperD, helperE } from './helpers.ts';
+          export function compute(p: number): number {
+            const inner1 = helperA(p);
+            const inner2 = helperB(inner1);
+            const inner3 = helperC(inner2);
+            const inner4 = helperD(inner3);
+            const inner5 = helperE(inner4);
+            return inner5;
+          }
+        `,
+        'index.ts': `
+          import { compute } from './compute.ts';
+          console.log(compute(10));
+        `,
+      },
+      'index.ts',
+      ['--minify', '--platform=node'],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.runStderr).not.toContain('ReferenceError');
+    expect(result.runStderr).not.toContain('SyntaxError');
+    expect(result.exitCode).toBe(0);
+    // 10 + 1 + 2 + 3 + 4 + 5 = 25
+    expect(result.runOutput).toBe('25');
+  });
+
+  // Phase A 의 frequency-sort 가 동작하는지: 호출 횟수가 다른 helper 들이 모두
+  // 정확하게 호출되는지 (Tie-breaker 가 deterministic 하므로 mangled 이름은
+  // 안정적이지만, 정확한 이름은 base54 시퀀스에 의존하므로 *결과* 만 검증).
+  test('frequency 가 다른 cross-module helper 들이 mangle 후 모두 정확 동작', async () => {
+    const result = await bundleAndRun(
+      {
+        'math.ts': `
+          export function hot(x: number): number { return x * 2; }
+          export function warm(x: number): number { return x + 100; }
+          export function cold(x: number): number { return x - 50; }
+        `,
+        // hot 을 빈도 1위로 (다수 호출). warm 2위, cold 1회.
+        'index.ts': `
+          import { hot, warm, cold } from './math.ts';
+          let acc = 0;
+          for (let i = 0; i < 5; i++) acc += hot(i);   // hot ×5
+          acc += warm(1);                              // warm ×1
+          acc += warm(2);                              // warm ×1 (총 2)
+          acc += cold(10);                             // cold ×1
+          console.log(acc);
+        `,
+      },
+      'index.ts',
+      ['--minify', '--platform=node'],
+    );
+    cleanup = result.cleanup;
+
+    // hot: 0+2+4+6+8 = 20, warm: 101+102 = 203, cold: -40 → 합 183
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe('183');
+  });
+
+  // `--mangle-report=<path>` 가 mangle_report.zig 의 JSON 스키마대로 파일을
+  // emit 하는지. Phase A/B 통계가 collector 에 흘러들어가고 직렬화 되는지 가드.
+  // `bundleAndRun` 대신 createFixture+runZntc 직접 호출 — report path 를 fixture
+  // 내부 절대경로로 두어야 test runner cwd 오염 없이 격리됨.
+  test('--mangle-report 가 JSON 출력 파일을 생성한다', async () => {
+    const fixture = await createFixture({
+      'index.ts': `
+        function alpha(x: number): number { return x + 1; }
+        function beta(y: number): number { return alpha(y) * 2; }
+        console.log(beta(3));
+      `,
+    });
+    cleanup = fixture.cleanup;
+
+    const entry = join(fixture.dir, 'index.ts');
+    const outFile = join(fixture.dir, 'out.js');
+    const reportPath = join(fixture.dir, 'mangle-report.json');
+
+    const bundle = await runZntc([
+      '--bundle',
+      entry,
+      '-o',
+      outFile,
+      '--minify',
+      '--platform=node',
+      `--mangle-report=${reportPath}`,
+    ]);
+    expect(bundle.exitCode).toBe(0);
+
+    const raw = readFileSync(reportPath, 'utf-8');
+    const json = JSON.parse(raw);
+    expect(json).toHaveProperty('top_level');
+    expect(json).toHaveProperty('nested');
+    expect(json).toHaveProperty('totals');
+    expect(json).toHaveProperty('bundle_size_bytes');
+    expect(Array.isArray(json.nested)).toBe(true);
+    expect(typeof json.bundle_size_bytes).toBe('number');
+    expect(json.bundle_size_bytes).toBeGreaterThan(0);
+    for (const key of ['top_level', 'totals']) {
+      expect(json[key]).toHaveProperty('slot_count');
+      expect(json[key]).toHaveProperty('slot_name_length_sum');
+      expect(json[key]).toHaveProperty('renamed_symbol_count');
+    }
+  });
+
+  // `ZNTC_DEBUG=mangle_audit` 가 unified_mangler 의 PhaseA/PhaseB[total] 두 라인을
+  // stderr 에 출력하는지. 통계 키 (slot, counter, skips, skips_1char, reserved_size)
+  // 가 모두 노출되고, counter ≥ slot invariant (skips ≥ 0) 가 성립하는지.
+  test('ZNTC_DEBUG=mangle_audit 가 PhaseA/PhaseB[total] 라인을 stderr 에 출력', async () => {
+    // helpers.ts:209-211 의 spawn 은 env 가 set 되면 process.env 를 *대체* 하므로
+    // PATH 등이 누락된다 — spread 로 명시 상속.
+    const result = await bundleAndRun(
+      {
+        'a.ts': `export function a(x: number): number { return x + 1; }`,
+        'b.ts': `export function b(x: number): number { return x + 2; }`,
+        'index.ts': `
+          import { a } from './a.ts';
+          import { b } from './b.ts';
+          console.log(a(1) + b(2));
+        `,
+      },
+      'index.ts',
+      ['--minify', '--platform=node'],
+      { env: { ...process.env, ZNTC_DEBUG: 'mangle_audit' } },
+    );
+    cleanup = result.cleanup;
+
+    expect(result.exitCode).toBe(0);
+    expect(result.runOutput).toBe('6'); // 2 + 4
+
+    const phaseA = result.bundleStderr.match(
+      /PhaseA: slot=(\d+) counter=(\d+) skips=(\d+) skips_1char=(\d+) reserved_size=(\d+)/,
+    );
+    expect(phaseA).not.toBeNull();
+    expect(+phaseA![2]).toBeGreaterThanOrEqual(+phaseA![1]); // counter ≥ slot
+
+    const phaseB = result.bundleStderr.match(
+      /PhaseB\[total\]: modules=(\d+) slot_sum=(\d+) counter_sum=(\d+) skips_sum=(\d+) skips_1char_sum=(\d+)/,
+    );
+    expect(phaseB).not.toBeNull();
+    expect(+phaseB![3]).toBeGreaterThanOrEqual(+phaseB![2]); // counter_sum ≥ slot_sum
+  });
+});


### PR DESCRIPTION
## 배경

[#1760](https://github.com/ohah/zntc/issues/1760) Unified Mangler 는 이미 `linker.computeMangling` 에서 호출되어 production 경로에 연결되어 있지만, 단위 테스트는 `mangleAll` API 형태만 검증한다. 실제 번들 파이프라인에서의 회귀 — Phase A reserved 가 Phase B 에 상속되지 않아 cross-module shadow 가 생기는 케이스 같은 것 — 는 통합 가드가 없었다.

## 변경

`tests/integration/tests/unified-mangler.test.ts` 신규 파일, 4가지 contract 가드:

1. **Phase A reserved → Phase B 상속** — cross-module top-level 5개 helper 와 nested `inner1~5` 가 같은 base54 풀에서 충돌 안 하는지 (#2956 date-fns 패턴 단순화)
2. **Frequency-sort 정확성** — 호출 빈도 다양한 helper 가 mangle 후에도 정상 동작
3. **`--mangle-report` JSON 스키마** — `top_level / nested / totals / bundle_size_bytes` 필드 + `ManglerStats` 내부 키
4. **`ZNTC_DEBUG=mangle_audit` stderr 출력** — `PhaseA: slot=N counter=N ...` / `PhaseB[total]: ...` 라인 + **counter ≥ slot invariant** 검증

`tests/integration/tests/helpers.ts` 의 `bundleAndRun` 시그니처를 backward-compatible 하게 확장:
- 4번째 옵션 인자 `{ env? }` 추가 — env 변수 전달 (T4 용)
- return 에 `bundleStderr` 필드 추가 — ZNTC 자체 stderr capture (audit 검증용)

기존 호출처 (`mangler-minify`, `bundle-smoke`, `downlevel`, `stage3-decorator` 등) 는 3-positional 만 사용해 영향 없음.

## 테스트

- [x] `bun test tests/unified-mangler.test.ts` — 4 pass / 0 fail / 26 expect
- [x] `bun test --timeout 10000` 전체 — 3723 pass / 3 기존 fail (html-env, 본 PR 무관)
- [x] `zig build test` — 통과

## 메모

- `unified_mangler.zig` 의 헤더 주석 (`"이 모듈은 아직 호출되지 않음"`) 은 outdated — 실제로는 production 경로에서 호출되고 있음. 본 PR 범위 외, 별도 cleanup 대상.
- T4 의 `...process.env` spread 는 필수 — `helpers.ts` 의 spawn 이 `env` set 시 process.env 를 *대체* 하기 때문.