### PR TITLE
docs(examples): add react-19 vite + zntc-standalone react-compiler examples

### DIFF
--- a/examples/react-19-vite/README.md
+++ b/examples/react-19-vite/README.md
@@ -1,0 +1,50 @@
+# @zntc/example-react-19-vite
+
+React 19 의 `babel-plugin-react-compiler` (자동 메모이제이션) 와 ZNTC 를 Vite 환경에서 함께 쓰는 예제.
+
+## 동작 원리
+
+```
+파일 변경
+   ↓
+@vitejs/plugin-react (babel) — babel-plugin-react-compiler 적용 (JSX 보존)
+   ↓
+@zntc/vite-plugin — TS strip + JSX automatic runtime + 번들
+   ↓
+브라우저
+```
+
+`vite.config.ts` 의 plugin 순서가 위 흐름을 보장한다. plugin-react 가 transform 후크에서
+먼저 동작해 컴파일러가 JSX 가 살아있는 AST 를 보고, 그 결과를 ZNTC 가 받아 마무리.
+
+## 실행
+
+```bash
+# 루트에서
+bun install
+
+# dev
+cd examples/react-19-vite && bun run dev
+
+# 프로덕션 빌드
+cd examples/react-19-vite && bun run build
+
+# 빌드 결과 미리보기
+cd examples/react-19-vite && bun run preview
+```
+
+`dev` / `build` script 는 실행 전에 `packages/core` JS dist 를 자동으로 빌드한다.
+
+## 지원하는 기능
+
+- React 19 (Server Components, Actions, `useOptimistic` 등) — 라이브러리 차원의 기능은 그대로 사용 가능
+- `babel-plugin-react-compiler` 자동 메모이제이션 — `useMemo` / `useCallback` 을 거의 쓸 필요 없게 됨
+- ZNTC 의 TS strip, JSX automatic runtime, Fast Refresh
+
+## 한계
+
+- react-compiler 의 동작 자체는 babel runtime 위에서 돌아간다 — ZNTC 단일 바이너리로 끝나지 않음.
+  ZNTC 단독 어댑터는 `examples/react-19-zntc/` 참고.
+- React Compiler 가 RC/실험 단계라 패턴 인식 규칙이 변할 수 있다.
+- `babel-plugin-react-compiler` 의 `target` 옵션은 React minor 버전 (`"17"` | `"18"` | `"19"`) 만 받는다 — 컴파일러가 생성하는 helper 의 호환 대상이다.
+- `@vitejs/plugin-react` v5 의 `babel.plugins` 형태 기준. v6 부터는 내부 babel 이 분리되어 `@rolldown/plugin-babel` + 별도 preset 으로 바뀐다.

--- a/examples/react-19-vite/index.html
+++ b/examples/react-19-vite/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ZNTC + Vite + React Compiler (React 19)</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/react-19-vite/package.json
+++ b/examples/react-19-vite/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@zntc/example-react-19-vite",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "predev": "bun run --cwd ../../packages/core build:js",
+    "dev": "vite",
+    "prebuild": "bun run --cwd ../../packages/core build:js",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.27.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^5.0.0",
+    "@zntc/core": "workspace:*",
+    "@zntc/vite-plugin": "workspace:*",
+    "babel-plugin-react-compiler": "^19.0.0",
+    "typescript": "^6.0.3",
+    "vite": "^6.0.0"
+  }
+}

--- a/examples/react-19-vite/src/App.tsx
+++ b/examples/react-19-vite/src/App.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+
+// react-compiler 가 자동 메모이제이션 대상으로 판단할 만한 패턴:
+// props 의존성을 갖는 파생 값 (`filtered`) 이 매 렌더마다 새로 계산되고 자식이
+// 받는 구조. 컴파일러가 같은 deps 일 때 같은 reference 를 유지하도록 자동 캐시
+// 호출을 삽입 — useMemo 를 직접 쓸 필요가 없다.
+function ItemList({ items, filter }: { items: number[]; filter: string }) {
+  const filtered = items.filter((n) => String(n).includes(filter));
+  return (
+    <ul>
+      {filtered.map((n) => (
+        <li key={n}>{n}</li>
+      ))}
+    </ul>
+  );
+}
+
+export function App() {
+  const [count, setCount] = useState(0);
+  const [filter, setFilter] = useState("");
+
+  // 매 렌더마다 새 배열. 컴파일러가 count 의존성을 추론해 동일 count 일 때
+  // 같은 reference 를 유지하도록 자동 캐시.
+  const items = Array.from({ length: 20 }, (_, i) => i + count);
+
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", padding: 24, maxWidth: 720, margin: "0 auto" }}>
+      <h1>ZNTC + Vite + React Compiler</h1>
+      <p>React 19 · babel-plugin-react-compiler 가 Vite 의 babel 단계에서 동작 · 나머지 변환은 ZNTC.</p>
+
+      <section>
+        <label>
+          counter: <strong>{count}</strong>{" "}
+          <button onClick={() => setCount((c) => c + 1)}>+1</button>
+        </label>
+      </section>
+
+      <section style={{ marginTop: 24 }}>
+        <label>
+          filter:{" "}
+          <input value={filter} onChange={(e) => setFilter(e.target.value)} placeholder="e.g. 1" />
+        </label>
+        <ItemList items={items} filter={filter} />
+      </section>
+    </div>
+  );
+}

--- a/examples/react-19-vite/src/main.tsx
+++ b/examples/react-19-vite/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("#root not found");
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/react-19-vite/tsconfig.json
+++ b/examples/react-19-vite/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src/**/*", "vite.config.ts"]
+}

--- a/examples/react-19-vite/vite.config.ts
+++ b/examples/react-19-vite/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { zntc } from "@zntc/vite-plugin";
+
+// React 19 의 babel-plugin-react-compiler 를 Vite 의 babel 단계에서 적용하고,
+// 나머지 TS / 번들 변환은 ZNTC 로 위임한다.
+// 순서: plugin-react 가 먼저 transform 후크에서 JSX 를 *보존한 채* 자동 메모이제이션을
+// 삽입 → zntc 가 그 결과를 받아 TS strip + JSX automatic runtime + 번들.
+export default defineConfig({
+  plugins: [
+    react({
+      babel: {
+        plugins: [["babel-plugin-react-compiler", { target: "19" }]],
+      },
+    }),
+    zntc(),
+  ],
+});

--- a/examples/react-19-zntc/README.md
+++ b/examples/react-19-zntc/README.md
@@ -1,0 +1,48 @@
+# @zntc/example-react-19-zntc
+
+React 19 의 `babel-plugin-react-compiler` (자동 메모이제이션) 를 **Vite 없이 ZNTC 단일 파이프라인** 에서 사용하는 예제. `zntc.config.ts` 안에 onTransform 어댑터 plugin 을 정의해 babel 을 위임한다.
+
+## 동작 원리
+
+```
+파일 변경
+   ↓
+ZNTC pipeline 진입
+   ↓
+onTransform({ filter: /\.[jt]sx$/ }) — @babel/core 호출, babel-plugin-react-compiler 적용
+   ↓
+ZNTC 본체 — TS strip + JSX automatic runtime + 번들 + Fast Refresh
+   ↓
+브라우저
+```
+
+핵심은 onTransform 콜백이 babel 결과 (JSX 가 *살아있는* 코드 + 자동 메모이제이션) 를 반환하고,
+ZNTC 가 그 결과를 받아 나머지 변환을 마무리한다는 점.
+
+## 실행
+
+```bash
+# 루트에서
+bun install
+
+# dev (HMR + Fast Refresh)
+cd examples/react-19-zntc && bun run dev
+
+# 프로덕션 빌드
+cd examples/react-19-zntc && bun run build
+
+# 빌드 결과 미리보기
+cd examples/react-19-zntc && bun run preview
+```
+
+`dev` / `build` / `preview` script 는 실행 전에 `packages/core` JS dist 를 자동으로 빌드한다.
+
+## Vite 예제와의 선택 기준
+
+Vite 생태계 (HMR overlay, vite plugin, vite preview) 를 이미 쓰고 있다면 `examples/react-19-vite/` 가 자연스럽다. ZNTC 단일 도구로 dev/build/preview 까지 끝내고 싶다면 이쪽이다. 기능적 결과 (자동 메모이제이션 적용 여부) 는 같다.
+
+## 한계
+
+- babel runtime 자체는 여전히 Node 위에서 돈다 — *단일 zig 바이너리* 가 아니다. babel-plugin-react-compiler 가 자체 IR / 데이터흐름 분석을 하므로 ZNTC 가 그 일부를 Zig 로 재구현하는 건 별도 큰 작업.
+- onTransform 콜백이 파일마다 babel 을 호출 — `node_modules` 같은 큰 트리는 filter 정규식으로 제외해야 빌드 시간 안정.
+- React Compiler 가 RC/실험 단계라 패턴 인식 규칙이 변할 수 있다.

--- a/examples/react-19-zntc/index.html
+++ b/examples/react-19-zntc/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ZNTC + React Compiler (React 19, standalone)</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/react-19-zntc/package.json
+++ b/examples/react-19-zntc/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@zntc/example-react-19-zntc",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "predev": "bun run --cwd ../../packages/core build:js",
+    "dev": "zntc dev",
+    "prebuild": "bun run --cwd ../../packages/core build:js",
+    "build": "zntc build",
+    "prepreview": "bun run --cwd ../../packages/core build:js",
+    "preview": "zntc preview"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.27.0",
+    "@types/babel__core": "^7.20.5",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@zntc/core": "workspace:*",
+    "babel-plugin-react-compiler": "^19.0.0",
+    "typescript": "^6.0.3"
+  }
+}

--- a/examples/react-19-zntc/src/App.tsx
+++ b/examples/react-19-zntc/src/App.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+
+function ItemList({ items, filter }: { items: number[]; filter: string }) {
+  const filtered = items.filter((n) => String(n).includes(filter));
+  return (
+    <ul>
+      {filtered.map((n) => (
+        <li key={n}>{n}</li>
+      ))}
+    </ul>
+  );
+}
+
+export function App() {
+  const [count, setCount] = useState(0);
+  const [filter, setFilter] = useState("");
+
+  // 매 렌더마다 새 배열. 컴파일러가 count 의존성을 추론해 동일 count 일 때
+  // 같은 reference 를 유지하도록 자동 캐시.
+  const items = Array.from({ length: 20 }, (_, i) => i + count);
+
+  return (
+    <div style={{ fontFamily: "system-ui, sans-serif", padding: 24, maxWidth: 720, margin: "0 auto" }}>
+      <h1>ZNTC + React Compiler (standalone)</h1>
+      <p>
+        React 19 · <code>zntc.config.ts</code> 의 onTransform 어댑터가 babel-plugin-react-compiler
+        를 적용 · 나머지 변환은 ZNTC 단일 파이프라인.
+      </p>
+
+      <section>
+        <label>
+          counter: <strong>{count}</strong>{" "}
+          <button onClick={() => setCount((c) => c + 1)}>+1</button>
+        </label>
+      </section>
+
+      <section style={{ marginTop: 24 }}>
+        <label>
+          filter:{" "}
+          <input value={filter} onChange={(e) => setFilter(e.target.value)} placeholder="e.g. 1" />
+        </label>
+        <ItemList items={items} filter={filter} />
+      </section>
+    </div>
+  );
+}

--- a/examples/react-19-zntc/src/main.tsx
+++ b/examples/react-19-zntc/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("#root not found");
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/react-19-zntc/tsconfig.json
+++ b/examples/react-19-zntc/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src/**/*", "zntc.config.ts"]
+}

--- a/examples/react-19-zntc/zntc.config.ts
+++ b/examples/react-19-zntc/zntc.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, type ZntcPlugin } from "@zntc/core";
+import { transformAsync } from "@babel/core";
+
+// react-compiler 어댑터: ZNTC 의 onTransform 훅에서 @babel/core 를 호출해
+// babel-plugin-react-compiler 를 적용한다. JSX/TS strip 은 그 뒤 ZNTC 본체가 처리하므로
+// 이 plugin 은 *JSX 가 살아있는 상태* 의 코드를 babel 로 넘겨야 한다 — 그래야 컴파일러가
+// reactive scope 를 정확히 추론한다.
+const reactCompilerPlugin: ZntcPlugin = {
+  name: "react-compiler-adapter",
+  setup(build) {
+    build.onTransform({ filter: /\.[jt]sx$/ }, async ({ code, path }) => {
+      // ZNTC 의 onTransform 은 user file / node_modules 를 구분 없이 dispatch 한다.
+      // react-compiler 는 React 컴포넌트 분석 비용이 적지 않아 node_modules tsx/jsx
+      // 까지 거치면 빌드 시간 폭증 — 사용자 코드만 통과시킨다.
+      if (path.includes("/node_modules/")) return null;
+      const result = await transformAsync(code, {
+        filename: path,
+        babelrc: false,
+        configFile: false,
+        parserOpts: { plugins: ["jsx", "typescript"] },
+        plugins: [["babel-plugin-react-compiler", { target: "19" }]],
+        sourceMaps: true,
+      });
+      if (!result?.code) return null;
+      return { code: result.code, map: result.map };
+    });
+  },
+};
+
+export default defineConfig({
+  entryPoints: ["src/main.tsx"],
+  outdir: "dist",
+  format: "esm",
+  platform: "browser",
+  target: "es2022",
+  jsx: "automatic",
+  sourcemap: true,
+  plugins: [reactCompilerPlugin],
+});


### PR DESCRIPTION
## 배경

React 19 의 `babel-plugin-react-compiler` (자동 메모이제이션) 를 ZNTC 와 함께 쓰는 두 가지 경로가 있다 — Vite 플러그인 체인에 끼우는 방식과 ZNTC 단일 파이프라인의 onTransform 어댑터로 흡수하는 방식. 두 방식을 *실행 가능한* 최소 예제로 제공한다.

## 변경

`examples/react-19-vite/` (7 files)
- `vite.config.ts`: `@vitejs/plugin-react` 의 babel 단계에서 `babel-plugin-react-compiler` 적용 후 `@zntc/vite-plugin` 이 TS strip + 번들 마무리.
- plugin 순서가 (react → zntc) 로 고정 — react-compiler 는 JSX 가 살아있는 AST 를 봐야 reactive scope 추론이 정확.

`examples/react-19-zntc/` (7 files)
- `zntc.config.ts` 의 `onTransform` 훅에서 `@babel/core` 로 react-compiler 호출.
- node_modules early-return 가드 포함 — `path.includes('/node_modules/')` 로 의존성 트리는 babel 대상에서 제외 (빌드 시간 안정).
- ZNTC 단일 도구로 dev/build/preview 까지 완결.

## 동작 검증

코드는 작성했지만 **브라우저 실측 미검증** — `bun install` + `bun run dev` 까지의 동작은 사용자가 직접 확인. 정적 측면 (config 옵션 이름, babel parser plugin 이름, plugin 순서, `target: '19'` 의 의미) 은 review 단계에서 검증.

## 한계

- `babel-plugin-react-compiler` 가 RC/실험 단계 — 패턴 인식 규칙이 변할 수 있음.
- `@vitejs/plugin-react` v5 의 `babel.plugins` API 기준. v6 부터는 `@rolldown/plugin-babel` + preset 으로 바뀌므로 예제 갱신 필요할 수 있음.
- 두 예제의 `src/main.tsx` / `index.html` / `tsconfig.json` 이 거의 동일 — examples 의 *각 디렉토리 독립* 컨벤션 (사용자가 한 디렉토리만 보고 따라하기) 을 따른 의도된 중복.