### PR TITLE
perf(emitter): minify CJS wrapper 의 object literal indirection 제거

### DIFF
--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -2717,9 +2717,10 @@ test "#1618 minify: __commonJS → $cj short name" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // minify 모드: preamble이 `var $cj=` 형태로 축약, 호출부도 `=$cj({`
+    // minify 모드: preamble이 `var $cj=` 형태로 축약, 호출부는 직접 함수
+    // (`=$cj((exports,module)=>`) — esbuild 식 cb=function 패턴 (object literal 제거).
     try std.testing.expect(std.mem.indexOf(u8, result.output, "var $cj=") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "=$cj({") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "=$cj((exports,module)=>") != null);
     // 원본 `__commonJS` 이름은 나타나지 않아야 함
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__commonJS") == null);
 }

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1746,7 +1746,6 @@ pub fn emitModule(
 
     // CJS 래핑: __commonJS 팩토리 함수로 감싸기
     if (module.wrap_kind == .cjs) {
-        const basename = if (options.minify_whitespace) "" else module.wrapperId();
         const preamble_code = if (metadata) |md| md.cjs_import_preamble else null;
 
         const var_name = try module.allocRequireName(allocator);
@@ -1756,22 +1755,17 @@ pub fn emitModule(
         defer wrapped.deinit(allocator);
 
         if (options.minify_whitespace) {
-            // minify_whitespace 모드는 module path key 를 빈 문자열로 emit —
-            // `{""(exports,module){...}}` (JS 의 string-key method shorthand 합법).
-            // $cj helper 는 `cb[Object.keys(cb)[0]]` 로 첫 key 의 method 추출하므로
-            // key 가 빈 문자열이어도 동작. trade-off: stack trace 의 module path
-            // 정보 손실 — minify 출력은 어차피 디버깅 대상 아니라 ROI 큰 정리.
-            // 대형 라이브러리 (rxjs ~100 모듈) 에서 module path × 길이 만큼 절감.
+            // emit 의 직접 함수 패턴은 `runtime_helpers.zig` 의 `CJS_RUNTIME_*` 가 cb 를
+            // function 으로 받는 것과 한 쌍 — 한쪽만 바꾸면 runtime TypeError.
             try wrapped.appendSlice(allocator, "var ");
             try wrapped.appendSlice(allocator, var_name);
-            try wrapped.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "({\"");
-            try wrapped.appendSlice(allocator, basename);
-            try wrapped.appendSlice(allocator, "\"(exports,module){");
+            try wrapped.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "((exports,module)=>{");
             if (preamble_code) |p| try wrapped.appendSlice(allocator, p);
             try wrapped.appendSlice(allocator, code);
-            try wrapped.appendSlice(allocator, "}});");
+            try wrapped.appendSlice(allocator, "});");
             if (preamble_lines_out) |out| out.* = 0;
         } else {
+            const basename = module.wrapperId();
             try wrapped.appendSlice(allocator, "var ");
             try wrapped.appendSlice(allocator, var_name);
             try wrapped.appendSlice(allocator, " = __commonJS({\n\t\"");

--- a/src/bundler/emitter/cjs_wrap.zig
+++ b/src/bundler/emitter/cjs_wrap.zig
@@ -22,9 +22,9 @@ pub fn emitDisabledModule(allocator: std.mem.Allocator, module: *const Module, m
         if (minify) {
             try buf.appendSlice(allocator, "var ");
             try buf.appendSlice(allocator, var_name);
-            try buf.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "({\"(optional-missing)\"(exports,module){");
+            try buf.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "((exports,module)=>{");
             try appendOptionalMissingThrow(allocator, &buf, specifier, true);
-            try buf.appendSlice(allocator, "}});");
+            try buf.appendSlice(allocator, "});");
         } else {
             try buf.appendSlice(allocator, "var ");
             try buf.appendSlice(allocator, var_name);
@@ -38,8 +38,8 @@ pub fn emitDisabledModule(allocator: std.mem.Allocator, module: *const Module, m
     if (minify) {
         try buf.appendSlice(allocator, "var ");
         try buf.appendSlice(allocator, var_name);
-        // #1621: minify 시 __commonJS → $cj 축약 (#1618 follow-up).
-        try buf.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "({\"(disabled)\"(exports,module){}});");
+        // #1621: minify 시 __commonJS → $cj 축약.
+        try buf.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "((exports,module)=>{});");
     } else {
         try buf.appendSlice(allocator, "var ");
         try buf.appendSlice(allocator, var_name);
@@ -114,12 +114,10 @@ pub fn emitCjsWrapper(allocator: std.mem.Allocator, module: *const Module, sourc
     if (minify) {
         try buf.appendSlice(allocator, "var ");
         try buf.appendSlice(allocator, var_name);
-        // #1621: minify 시 __commonJS → $cj 축약 (#1618 follow-up).
-        try buf.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "({\"");
-        try buf.appendSlice(allocator, std.fs.path.basename(module.path));
-        try buf.appendSlice(allocator, "\"(exports,module){module.exports=");
+        // #1621: minify 시 __commonJS → $cj 축약.
+        try buf.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "((exports,module)=>{module.exports=");
         try buf.appendSlice(allocator, source);
-        try buf.appendSlice(allocator, "}});");
+        try buf.appendSlice(allocator, "});");
     } else {
         try buf.appendSlice(allocator, "var ");
         try buf.appendSlice(allocator, var_name);

--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -43,14 +43,17 @@ pub const PAIRS = names_mod.PAIRS;
 pub const ALL_SHORT_NAMES = names_mod.ALL_SHORT_NAMES;
 pub const helperName = names_mod.helperName;
 
-/// __commonJS 팩토리 함수 (esbuild 호환)
+// non-minify wrapper 는 cb 가 *object* (디버깅 친화 — `{"path"(exports, module){...}}`
+// 의 module path 보존). minify wrapper 는 cb 가 *함수* — emit 도 직접 함수 인자
+// (`$cj((exports,module)=>{...})`) 와 한 쌍. HMR 의 `Object.keys(cb)[0]` module id
+// 추적은 dev_mode 전용 (minify 시 HMR runtime 자체가 emit 안 됨) 이므로 호환.
 pub const CJS_RUNTIME = "var __commonJS = (cb, mod) => function __require() {\n\treturn mod || (0, cb[Object.keys(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;\n};\n";
-pub const CJS_RUNTIME_MIN = "var " ++ NAMES.CJS_FACTORY_MIN ++ "=(cb,mod)=>function " ++ NAMES.REQUIRE_MIN ++ "(){return mod||(0,cb[Object.keys(cb)[0]])((mod={exports:{}}).exports,mod),mod.exports};";
+pub const CJS_RUNTIME_MIN = "var " ++ NAMES.CJS_FACTORY_MIN ++ "=(cb,mod)=>function " ++ NAMES.REQUIRE_MIN ++ "(){return mod||cb((mod={exports:{}}).exports,mod),mod.exports};";
 
-/// __commonJS ES5 호환: arrow → function.
-pub const CJS_RUNTIME_ES5 = "var __commonJS = function(cb, mod) { return function __require() {\n\treturn mod || (0, cb[Object.keys(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;\n}; };\n";
+// __commonJS ES5 호환 (RN/Hermes — `configurable_exports=true`): arrow → function.
 // #1751: trailing `;` — 뒤따르는 `var __xxx=...` 와 문법 구분 필수 (minify 연속 emit).
-pub const CJS_RUNTIME_ES5_MIN = "var " ++ NAMES.CJS_FACTORY_MIN ++ "=function(cb,mod){return function " ++ NAMES.REQUIRE_MIN ++ "(){return mod||(0,cb[Object.keys(cb)[0]])((mod={exports:{}}).exports,mod),mod.exports}};";
+pub const CJS_RUNTIME_ES5 = "var __commonJS = function(cb, mod) { return function __require() {\n\treturn mod || (0, cb[Object.keys(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;\n}; };\n";
+pub const CJS_RUNTIME_ES5_MIN = "var " ++ NAMES.CJS_FACTORY_MIN ++ "=function(cb,mod){return function " ++ NAMES.REQUIRE_MIN ++ "(){return mod||cb((mod={exports:{}}).exports,mod),mod.exports}};";
 
 /// __toESM: CJS 모듈을 ESM namespace로 변환 (rolldown 호환).
 /// isNodeMode=true(--platform=node)이면 항상 default: mod를 설정.


### PR DESCRIPTION
## Summary

- minify mode 의 CJS wrapper helper (`CJS_RUNTIME_MIN`, `CJS_RUNTIME_ES5_MIN`) 의 `(0, cb[Object.keys(cb)[0]])(...)` indirection 을 `cb(...)` 직접 호출로 단순화
- 모듈 emit 패턴도 한 쌍으로 변경: `$cj({"path"(exports,module){body}})` → `$cj((exports,module)=>{body})` (esbuild 식)
- non-minify path 는 그대로 유지 (디버깅 친화 module path 보존)
- ES5 path (RN/Hermes `configurable_exports=true`) 도 같이 단순화

## Why

esbuild/rolldown vs zntc minify size 격차 분해 결과, zntc 의 CJS wrapper 패턴이 모듈마다 *object literal + key access* 형태로 emit 됨을 발견. 이는 HMR 의 `Object.keys(cb)[0]` module id 추적 위한 design choice 였지만, minify=production 빌드에선 HMR runtime 자체가 emit 안 되므로 indirection 불필요.

## 안전성

| 위험 | 대응 |
|---|---|
| HMR module id 추적 | dev_mode 전용. minify 시 HMR runtime emit 안 됨 → 영향 없음 |
| RN/Hermes (ES5 minify) 회귀 | `CJS_RUNTIME_ES5_MIN` 도 같이 cb=function 으로 단순화 + emit pattern 한 쌍. `--platform=react_native` sanity test 로 동작 확인 |
| non-minify (development) | revert 유지 — `CJS_RUNTIME` 의 `(0, cb[Object.keys(cb)[0]])` 그대로. emit 도 `__commonJS({"path"(exports,module){...}})` 그대로 |

## 측정 (rxjs deepEntry, --minify, --platform=node)

- size: 160,709 → **160,239 bytes** (-470 bytes)
- helper: 22 chars 절약
- 모듈당: 2 chars 절약 (`{""}` → `()`)
- node 출력 정확 (`{"a":90,...}`)

## Test plan

- [x] `zig build test` 통과 — `#1618 minify: __commonJS → $cj` test 갱신 (`=$cj((exports,module)=>` 가드)
- [x] smoke 134 fixture 모두 OK (Average ratio 0.87x 동일, rxjs MATCH)
- [x] RN target (`--platform=react_native --minify`) sanity — node 출력 정확
- [x] non-minify build 영향 없음 (helper/emit 모두 revert)

## Follow-up

- L 후속: `ensureUnusedCapacity` precompute (모듈마다 ArrayList realloc 회피, simplify agent 발견)
- 다른 minify ratio root cause (esbuild 147KB vs 우리 160KB 격차의 나머지 12KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)