### PR TITLE
fix(core): update init-lifecycle tests for lazy auto-init contract

### DIFF
--- a/packages/core/test/core/edge-cases/init-lifecycle.ts
+++ b/packages/core/test/core/edge-cases/init-lifecycle.ts
@@ -1,21 +1,26 @@
-import { describe, test, expect, init, transpile, build, buildSync, close } from '../helpers';
+import { describe, test, expect, transpile, build, buildSync, close } from '../helpers';
 
-describe('@zntc/core edge cases: init lifecycle', () => {
-  test('init 전에 transpile 호출 시 에러', () => {
+// 4d33c4a8 이후 native API 는 lazy auto-init — 사용자가 init() 을 명시 호출하지 않아도
+// 첫 호출 시점에 ensureNative() 가 자동 init. 이전 contract ("init 전 호출은 throw") 는
+// 더 이상 유효하지 않다. 이 파일은 *close() 후에도 다음 호출에서 자동 재초기화되어
+// 정상 동작* 한다는 새 contract 를 가드.
+describe('@zntc/core edge cases: init lifecycle (lazy auto-init)', () => {
+  test('close 후 transpile 호출 시 자동 재초기화', () => {
     close();
-    expect(() => transpile('const x = 1;')).toThrow('not initialized');
-    init();
+    const result = transpile('const x = 1;');
+    expect(result.code).toContain('x');
   });
 
-  test('init 전에 buildSync 호출 시 에러', () => {
+  test('close 후 buildSync 호출 시 자동 재초기화', () => {
     close();
-    expect(() => buildSync({ entryPoints: ['/nonexistent'] })).toThrow('not initialized');
-    init();
+    // entryPoints 가 nonexistent 라 build 단계는 errors 를 만들지만, init 단계는 통과해야 함.
+    const result = buildSync({ entryPoints: ['/nonexistent/file.ts'] });
+    expect(result).toBeDefined();
   });
 
-  test('init 전에 build 호출 시 에러', async () => {
+  test('close 후 build 호출 시 자동 재초기화', async () => {
     close();
-    await expect(build({ entryPoints: ['/nonexistent'] })).rejects.toThrow('not initialized');
-    init();
+    const result = await build({ entryPoints: ['/nonexistent/file.ts'] });
+    expect(result).toBeDefined();
   });
 });


### PR DESCRIPTION
## 배경

[#3245](https://github.com/ohah/zntc/pull/3245) 이 native API 를 lazy auto-init 으로 바꾸면서 ("import 시점 자동 init, 사용자는 `init()` 명시 호출 불필요"), `packages/core/test/core/edge-cases/init-lifecycle.ts` 의 3 테스트가 *사라진 contract* (`"init() 전 호출은 'not initialized' throw"`) 를 검증한 채로 남아 fail.

## 변경

`packages/core/test/core/edge-cases/init-lifecycle.ts` 의 3 테스트를 새 contract 로 갱신:

| 변경 전 (stale) | 변경 후 |
|---|---|
| `init 전에 transpile 호출 시 에러` | `close 후 transpile 호출 시 자동 재초기화` |
| `init 전에 buildSync 호출 시 에러` | `close 후 buildSync 호출 시 자동 재초기화` |
| `init 전에 build 호출 시 에러` | `close 후 build 호출 시 자동 재초기화` |

`close()` 후 다음 호출이 `ensureNative()` 를 거쳐 자동 재초기화되어 정상 결과를 반환하는지 가드 — lazy auto-init 의 본질.

## 검증

```
bun test --timeout 10000 ./test/core/edge-cases/init-lifecycle.ts
→ 3 pass / 0 fail
```

본 PR 이전 main 전체 suite 는 136 fail, 본 PR 적용 후 133 fail — 정확히 3개 감소.
(나머지 130 fail 은 본 PR 무관, 별건.)