### PR TITLE
perf(emitter): CJS wrap callback param 단축 (rxjs -5.7%)

### DIFF
--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -2717,10 +2717,11 @@ test "#1618 minify: __commonJS → $cj short name" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // minify 모드: preamble이 `var $cj=` 형태로 축약, 호출부는 직접 함수
-    // (`=$cj((exports,module)=>`) — esbuild 식 cb=function 패턴 (object literal 제거).
+    // minify 모드: preamble이 `var $cj=` 형태로 축약, 호출부는 직접 함수 + callback param
+    // 단축 (`=$cj((e,m)=>`) — body 의 unresolved `exports`/`module` 도 codegen 에서
+    // `e`/`m` 로 substitute (cjs_wrap_substitute).
     try std.testing.expect(std.mem.indexOf(u8, result.output, "var $cj=") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "=$cj((exports,module)=>") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "=$cj((e,m)=>") != null);
     // 원본 `__commonJS` 이름은 나타나지 않아야 함
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__commonJS") == null);
 }

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1642,6 +1642,9 @@ pub fn emitModule(
         // __esm 모듈: exports.x/module.exports 생성 억제 (__export()가 대신 처리)
         .skip_cjs_exports = module.wrap_kind == .esm,
         .skip_cjs_named_export_decls = module.module_type == .json and module.wrap_kind == .cjs,
+        // CJS wrap minify: callback param `(exports, module)` → `(e, m)` 단축 +
+        // body 의 unresolved `exports`/`module` reference 도 substitute.
+        .cjs_wrap_substitute = module.wrap_kind == .cjs and options.minify_whitespace,
         // __esm 모듈: const → var (TDZ 방지)
         .use_var_for_imports = module.wrap_kind == .esm,
         // cycle 모듈 의 top-level const/let → var 강등 (#2198, esbuild 호환).
@@ -1757,9 +1760,11 @@ pub fn emitModule(
         if (options.minify_whitespace) {
             // emit 의 직접 함수 패턴은 `runtime_helpers.zig` 의 `CJS_RUNTIME_*` 가 cb 를
             // function 으로 받는 것과 한 쌍 — 한쪽만 바꾸면 runtime TypeError.
+            // callback param `(e, m)` 단축 — body 의 `exports`/`module` reference 도
+            // codegen 의 `cjs_wrap_substitute` 가 `e`/`m` 으로 substitute.
             try wrapped.appendSlice(allocator, "var ");
             try wrapped.appendSlice(allocator, var_name);
-            try wrapped.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "((exports,module)=>{");
+            try wrapped.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "((e,m)=>{");
             if (preamble_code) |p| try wrapped.appendSlice(allocator, p);
             try wrapped.appendSlice(allocator, code);
             try wrapped.appendSlice(allocator, "});");

--- a/src/bundler/emitter/cjs_wrap.zig
+++ b/src/bundler/emitter/cjs_wrap.zig
@@ -22,7 +22,8 @@ pub fn emitDisabledModule(allocator: std.mem.Allocator, module: *const Module, m
         if (minify) {
             try buf.appendSlice(allocator, "var ");
             try buf.appendSlice(allocator, var_name);
-            try buf.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "((exports,module)=>{");
+            // body 가 throw 만 — exports/module 참조 없음 → param 인자 0개.
+            try buf.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "(()=>{");
             try appendOptionalMissingThrow(allocator, &buf, specifier, true);
             try buf.appendSlice(allocator, "});");
         } else {
@@ -38,8 +39,8 @@ pub fn emitDisabledModule(allocator: std.mem.Allocator, module: *const Module, m
     if (minify) {
         try buf.appendSlice(allocator, "var ");
         try buf.appendSlice(allocator, var_name);
-        // #1621: minify 시 __commonJS → $cj 축약.
-        try buf.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "((exports,module)=>{});");
+        // #1621: minify 시 __commonJS → $cj 축약. 빈 body — param 0개.
+        try buf.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "(()=>{});");
     } else {
         try buf.appendSlice(allocator, "var ");
         try buf.appendSlice(allocator, var_name);
@@ -114,8 +115,9 @@ pub fn emitCjsWrapper(allocator: std.mem.Allocator, module: *const Module, sourc
     if (minify) {
         try buf.appendSlice(allocator, "var ");
         try buf.appendSlice(allocator, var_name);
-        // #1621: minify 시 __commonJS → $cj 축약.
-        try buf.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "((exports,module)=>{module.exports=");
+        // #1621: minify 시 __commonJS → $cj 축약. body 가 `m.exports=<source>` —
+        // 자체 emit 이라 codegen substitute 안 거치므로 직접 `m` 사용.
+        try buf.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "((e,m)=>{m.exports=");
         try buf.appendSlice(allocator, source);
         try buf.appendSlice(allocator, "});");
     } else {

--- a/src/codegen/mangler.zig
+++ b/src/codegen/mangler.zig
@@ -570,7 +570,12 @@ fn reserveNameFor(reserved: *std.StringHashMap(void), sym: Symbol, name: []const
 // ============================================================
 
 pub fn isReservedOrGlobal(name: []const u8) bool {
-    // JS 예약어 + 리터럴 + 글로벌 (길이 2~6만 체크 — 1글자는 충돌 없고 7글자+는 base54에서 도달 어려움)
+    // CJS wrap callback param 단축 이름 (`(e, m) => {...}`) — emitter 의 `cjs_wrap_substitute`
+    // 가 wrapper body 의 unresolved `exports`/`module` 을 `e`/`m` 로 substitute 한다.
+    // mangler 가 다른 binding 에 같은 이름을 부여하면 wrapper param 과 redeclare/shadow.
+    if (name.len == 1 and (name[0] == 'e' or name[0] == 'm')) return true;
+    // JS 예약어 + 리터럴 + 글로벌 (길이 2~6만 체크 — 1글자는 'e'/'m' 외엔 충돌 없고
+    // 7글자+는 base54에서 도달 어려움)
     const reserved = [_][]const u8{
         // 2글자
         "do",     "if",     "in",     "of",
@@ -681,7 +686,8 @@ test "mangle: string_table 기반 생성 심볼도 rename 결과에 포함" {
     });
     defer result.deinit();
 
-    try std.testing.expectEqualStrings("e", result.renames.get(0).?);
+    // base54 첫 이름 'e' 는 CJS wrap callback param 으로 reserved (다음 후보 't').
+    try std.testing.expectEqualStrings("t", result.renames.get(0).?);
 }
 
 test "markScopeSubtree: declaration scope + 모든 후손 set, sibling/ancestor 는 제외 (#2956)" {

--- a/src/codegen/mangler_test.zig
+++ b/src/codegen/mangler_test.zig
@@ -17,12 +17,14 @@ test "base54: basic encoding" {
     try std.testing.expect(two[0] == 'e');
 }
 
-test "base54: no reserved words in first batch" {
+test "base54: 1글자 'e'/'m' 만 reserved (CJS wrap callback param 충돌 방지)" {
     var buf: [8]u8 = undefined;
-    // 처음 54개 이름 중 예약어가 없는지 확인
+    // base54 첫 54개 (1글자) 중 'e' (idx 0) 와 'm' (idx 14) 만 reserved.
+    // 다른 1글자 이름은 free.
     for (0..54) |i| {
         const name = base54(@intCast(i), &buf);
-        try std.testing.expect(!isReservedOrGlobal(name));
+        const expect_reserved = name.len == 1 and (name[0] == 'e' or name[0] == 'm');
+        try std.testing.expectEqual(expect_reserved, isReservedOrGlobal(name));
     }
 }
 
@@ -41,6 +43,9 @@ test "isReservedOrGlobal" {
     try std.testing.expect(isReservedOrGlobal("return"));
     try std.testing.expect(!isReservedOrGlobal("a"));
     try std.testing.expect(!isReservedOrGlobal("foo"));
+    // 'e', 'm' 은 CJS wrap callback param (`(e, m) => {...}`) 으로 reserved.
+    try std.testing.expect(isReservedOrGlobal("e"));
+    try std.testing.expect(isReservedOrGlobal("m"));
 }
 
 // #1618 / #1621: minify 모드에서 runtime helper 이름이 `$xx` 형태로 축약된다.

--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -118,28 +118,28 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
             // 복원. 치환 안 일어나는 일반 경로는 names 발행 X (size 폭증 회피, esbuild
             // 동일 정책).
 
+            // 3 substitute path (undefined→void 0, linking_metadata renames, cjs_wrap)
+            // 가 모두 sym_id 를 본다 — 단일 호출로 hoist (per-identifier hot path).
+            const sym_id: ?u32 = if (self.options.linking_metadata) |meta|
+                self.resolveSymbolId(idx, meta)
+            else
+                null;
+
             // Peephole: global `undefined` → `(void 0)` (minify_syntax 활성화 시).
             // 9 bytes → 8 bytes, 1 byte 절감. parens는 member/call/new 등 모든 parent
             // context에서 안전하게 해석되도록 유지 — `undefined.x`/`undefined()` 같은
             // 경로를 간단한 치환으로 깨지 않기 위함 (`void 0.x`는 `void (0.x)`로 오파싱).
             // global binding일 때만 치환 (shadow rebind 드물지만 보호).
-            if (self.options.minify_syntax and node.tag == .identifier_reference) {
+            if (self.options.minify_syntax and node.tag == .identifier_reference and sym_id == null) {
                 const text = self.ast.getText(node.span);
                 if (std.mem.eql(u8, text, "undefined")) {
-                    const is_global = if (self.options.linking_metadata) |meta|
-                        self.resolveSymbolId(idx, meta) == null
-                    else
-                        true;
-                    if (is_global) {
-                        try self.addSourceMapping(node.span);
-                        try self.write("(void 0)");
-                        return;
-                    }
+                    try self.addSourceMapping(node.span);
+                    try self.write("(void 0)");
+                    return;
                 }
             }
 
             if (self.options.linking_metadata) |meta| {
-                const sym_id = self.resolveSymbolId(idx, meta);
                 if (sym_id) |sid| {
                     // 상수 인라인: import symbol이 상수이면 리터럴로 대체
                     if (node.tag == .identifier_reference) {
@@ -181,6 +181,28 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
                             return;
                         }
                     }
+                }
+            }
+            // CJS wrap 모듈: unresolved `exports`/`module` reference (= callback param 의
+            // closure capture) 를 짧은 alias `e`/`m` 로 substitute. emitter 의 wrapper
+            // param 변경 (`(e,m)=>{...}`) 과 한 쌍.
+            //
+            // *sym_id 가 null* (= 모듈 안 어떤 binding 도 못 가리키는 reference) 일 때만
+            // substitute. user 가 `function f(exports) {...}` 같이 동명 binding 을 선언한
+            // 케이스는 sym_id 가 있고 wrapper param 이 아닌 user binding 가리키므로 변경 금지.
+            if (self.options.cjs_wrap_substitute and sym_id == null and
+                (node.tag == .identifier_reference or node.tag == .assignment_target_identifier))
+            {
+                const name = self.ast.getText(node.data.string_ref);
+                const alias: ?u8 = switch (name.len) {
+                    7 => if (std.mem.eql(u8, name, "exports")) @as(u8, 'e') else null,
+                    6 => if (std.mem.eql(u8, name, "module")) @as(u8, 'm') else null,
+                    else => null,
+                };
+                if (alias) |c| {
+                    try self.addSourceMappingWithName(node.span, name);
+                    try self.writeByte(c);
+                    return;
                 }
             }
             try self.addSourceMapping(node.span);

--- a/src/codegen/options.zig
+++ b/src/codegen/options.zig
@@ -97,6 +97,11 @@ pub const CodegenOptions = struct {
     /// __esm 래핑 모듈: CJS export 출력 억제 (exports.x, module.exports).
     /// __esm 모듈의 export는 emitter의 __export()가 처리하므로 codegen에서 생성하면 안 됨.
     skip_cjs_exports: bool = false,
+    /// CJS wrap 모듈의 callback param `(exports, module)` 을 minify 시 짧은 이름
+    /// (`(e, m)`) 로 단축 — body 안 unresolved `exports`/`module` reference 도
+    /// substitute 한다. emitter 가 `wrap_kind == .cjs and minify_whitespace` 일 때 set.
+    /// reserved set 에 `e`, `m` 도 함께 등록 — mangler 가 다른 binding 에 부여 안 함.
+    cjs_wrap_substitute: bool = false,
     /// JSON을 CJS require()로 소비할 때 synthetic named export declarations를 생략.
     /// default object는 `module.exports = {...}`로 유지한다.
     skip_cjs_named_export_decls: bool = false,

--- a/src/codegen/unified_mangler.zig
+++ b/src/codegen/unified_mangler.zig
@@ -338,9 +338,10 @@ test "mangleAll: Phase B loop runs with empty module (counter carried through)" 
 }
 
 test "mangleAll: identity rename (name already equals base54 head) — no rename entry" {
-    // 원본 이름이 이미 base54 첫 이름("e") 인 심볼은 renames 에 기록하지 않음 (no-op).
+    // 원본 이름이 base54 의 (reserved 'e'/'m' 을 skip 한 후) 첫 이름 "t" 와 같으면
+    // renames 에 기록하지 않음 (no-op).
     const candidates = [_]TopLevelCandidate{
-        .{ .module_index = 0, .symbol_id = 0, .name = "e", .ref_count = 10 },
+        .{ .module_index = 0, .symbol_id = 0, .name = "t", .ref_count = 10 },
     };
 
     var result = try mangleAll(std.testing.allocator, .{


### PR DESCRIPTION
## Summary

minify CJS wrap 모듈의 callback param 을 짧은 alias 로 단축 + body 안 unresolved `exports`/`module` reference 도 codegen 에서 `e`/`m` 으로 substitute. rolldown 식.

## Why

L1 (PR #3250) 머지 후 rxjs 격차 분석 — `exports` identifier 가 1,334회 사용 (esbuild 3회). bundle 격차의 70% 가 wrapper callback 의 `exports`/`module` 파라미터 mangle 부재.

## 측정 (rxjs deepEntry, --minify, --platform=node)

```
size:                160,239 → 151,144 bytes  (-5.7%, -9,095 bytes)
'exports' identifier: 1,334 → 3
esbuild 격차:           13KB → 4KB (90% 좁힘)
```

bundle 의 node 출력 정확 (`{"a":90,...}`).

## 변경

| 파일 | 변경 |
|---|---|
| `CodegenOptions.cjs_wrap_substitute` | 새 field — `wrap_kind == .cjs and minify_whitespace` 시 set |
| `node_dispatch.zig` | identifier emit fallback 에서 sym_id null + name in {"exports","module"} 시 substitute. `resolveSymbolId` 호출은 함수 진입에서 한 번만 (3 substitute path 공유) |
| `emitter.zig` | minify path 의 wrapper param 을 `(e,m)` 으로 emit |
| `cjs_wrap.zig` | disabled (param 0개) / asset (직접 `(e,m)`) wrapper 도 같은 패턴 |
| `mangler.zig` | `isReservedOrGlobal` 에 1글자 'e'/'m' 추가 — 다른 binding 에 부여 시 wrapper param 과 redeclare/shadow 차단 |

## 안전성

| 위험 | 대응 |
|---|---|
| #1757 류 같은 모듈 outer-nested shadow | mangler 가 'e'/'m' 안 부여 (reserved) |
| #2956 류 cross-module shadow | wrapper IIFE 격리 (K2 와 동일 안전성) |
| user 가 `function f(exports) {...}` 로 동명 binding 선언 | sym_id 있어 substitute 안 함 |

## 다른 번들러 비교

| Bundler | wrapper param | 처리 |
|---|---|---|
| esbuild | 모듈마다 unique mangled (`xr`, `kr`, ...) | mangler 자동 회피 |
| **rolldown** | **`e` 고정** | **'e' reserved** (이번 PR 과 동일) |
| rspack | webpack module factory `(e,r,t)` | 다른 패턴 |

증거: rolldown bundle 의 `errorContext` 모듈 — module-level `let context` 가 `t` mangle 받음 ('e' 회피).

## Test plan

- [x] `zig build test` 통과 (4 test case 갱신: base54 reserved doc, identity rename 'e'→'t', #1618 wrapper pattern)
- [x] smoke 134 fixture 모두 OK (Average ratio 0.87x 동일)
- [x] node 출력 정확 (rxjs/effect/three/express MATCH)

## Follow-up

- 'e'/'m' magic naming 5곳 hardcoded → `runtime_helper_names.zig` const 추출 (별도 cleanup)
- 남은 격차 (151KB vs rolldown 137KB = 14KB) 다른 root cause 영역

🤖 Generated with [Claude Code](https://claude.com/claude-code)