### PR TITLE
perf(emitter): CJS wrap unused 'module' param drop (rxjs -0.3%)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1760,11 +1760,14 @@ pub fn emitModule(
         if (options.minify_whitespace) {
             // emit 의 직접 함수 패턴은 `runtime_helpers.zig` 의 `CJS_RUNTIME_*` 가 cb 를
             // function 으로 받는 것과 한 쌍 — 한쪽만 바꾸면 runtime TypeError.
-            // callback param `(e, m)` 단축 — body 의 `exports`/`module` reference 도
-            // codegen 의 `cjs_wrap_substitute` 가 `e`/`m` 으로 substitute.
+            // body 가 `module` 안 쓰면 wrapper param 도 `(e)` 1 인자로 단축 (rolldown 식).
+            // codegen 의 `cjs_wrap_module_used` 가 substitute 시점에 set.
+            const param_list = if (cg.cjs_wrap_module_used) "(e,m)" else "(e)";
             try wrapped.appendSlice(allocator, "var ");
             try wrapped.appendSlice(allocator, var_name);
-            try wrapped.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "((e,m)=>{");
+            try wrapped.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "(");
+            try wrapped.appendSlice(allocator, param_list);
+            try wrapped.appendSlice(allocator, "=>{");
             if (preamble_code) |p| try wrapped.appendSlice(allocator, p);
             try wrapped.appendSlice(allocator, code);
             try wrapped.appendSlice(allocator, "});");

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -78,6 +78,10 @@ pub const Codegen = struct {
     /// 모든 call expression 에 대해 호출되므로, 해당 종류의 record 가 없으면 O(1) 로 빠짐.
     has_glob_records: bool = false,
     has_require_context_records: bool = false,
+    /// `cjs_wrap_substitute` 가 active 일 때 module body 에서 unresolved `module` reference 를
+    /// 만나 `m` 으로 substitute 한 적이 있는지. emitter 가 wrapper param 결정 시 참조 —
+    /// false 면 `(e)` 1 인자 (rolldown 식), true 면 `(e,m)` 유지.
+    cjs_wrap_module_used: bool = false,
     pub fn init(allocator: std.mem.Allocator, ast: *const Ast) Codegen {
         return initWithOptions(allocator, ast, .{});
     }

--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -200,6 +200,7 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
                     else => null,
                 };
                 if (alias) |c| {
+                    if (c == 'm') self.cjs_wrap_module_used = true;
                     try self.addSourceMappingWithName(node.span, name);
                     try self.writeByte(c);
                     return;


### PR DESCRIPTION
## Summary

module body 가 'module' reference 안 쓰면 wrapper callback param `(e,m)` → `(e)` 1 인자로 단축 (rolldown 식). codegen 의 `cjs_wrap_module_used` flag 가 substitute 시점에 set, emitter 가 wrapper header emit 시 참조.

## Why

M1 (#3252) 머지 후 rolldown vs zntc 비교 — rolldown 의 wrapper callback 이 *항상* `((e=>{...}))` 1 인자. rxjs 의 모든 모듈이 `exports.foo = ...` 만 사용 (module.exports 0회) — module 인자 자체 불필요.

## 측정 (rxjs deepEntry, --minify, --platform=node)

```
size:           151,144 → 150,698 bytes  (-446 bytes)
모든 224 모듈:  (e,m)=> → (e)=>  (rxjs 100%)
esbuild 격차:   4,082  → 3,636 bytes
```

bundle 의 node 출력 정확.

## 안전성

- module body 안 user `module.foo` 또는 `module.exports = X` reference (unresolved) 가 있으면 codegen 의 substitute path 가 'm' 부여 시점에 `cjs_wrap_module_used = true` set → wrapper param 자동 `(e,m)` 유지.
- 즉 *body 가 실제 사용* 할 때만 `(e,m)`, 아니면 `(e)` — 안전.

## 다른 번들러

- **rolldown**: 항상 `((e=>{...}))` 1 인자 (rxjs 모든 모듈 — 동일 패턴)
- **esbuild**: 모듈마다 unique mangled param 1개 (`xr=>{...}`) — 같은 단순화 효과

## Test plan

- [x] zig build test 통과 (5032/5032)
- [x] smoke 134 fixture 모두 OK (Average 0.87x 동일)
- [x] node 출력 정확

🤖 Generated with [Claude Code](https://claude.com/claude-code)