### PR TITLE
perf(emitter): elide createRequire shim when no external require call (-84B)

### DIFF
--- a/src/bundler/emitter/runtime_helpers.zig
+++ b/src/bundler/emitter/runtime_helpers.zig
@@ -34,9 +34,20 @@ pub fn emitBundleRuntimeHelpers(
         if (needs_cjs_runtime and needs_esm_wrap_runtime and needs_to_esm_runtime and needs_to_binary) break;
     }
     if (needs_cjs_runtime or needs_esm_wrap_runtime) {
-        // Node ESM 출력에 CJS wrapper가 섞이면 wrapper 내부 `require()`가 런타임에 미정의.
-        // createRequire shim은 runtime helper 정의보다 먼저 와야 `__commonJS` 래퍼가 참조 가능 (#1456).
-        if (needs_cjs_runtime and options.platform == .node and options.format == .esm) {
+        // Node ESM 출력에서 *external require 호출* (예: `require("fs")`) 이 bundle 에 emit
+        // 되면 그 `require` 가 런타임에 미정의 — `createRequire(import.meta.url)` shim 필요.
+        // 우리 `__commonJS` wrapper 자체는 cb 를 직접 호출하므로 require() 안 씀 (#3252).
+        // 따라서 shim 필요 조건 = `kind=.require and is_external` 한 import_record 가
+        // 어떤 모듈에든 존재. 없으면 84 chars (minify) 절약.
+        const needs_require_shim = if (options.platform == .node and options.format == .esm) blk: {
+            for (sorted_modules) |m| {
+                for (m.import_records) |rec| {
+                    if (rec.kind == .require and rec.is_external) break :blk true;
+                }
+            }
+            break :blk false;
+        } else false;
+        if (needs_require_shim) {
             try rt.appendRequireShim(output, allocator, options.minify_whitespace);
         }
         if (needs_cjs_runtime) {
@@ -161,8 +172,18 @@ pub fn emitChunkRuntimeHelpers(
         if (needs_cjs_runtime and needs_esm_wrap_runtime and needs_to_esm_runtime and needs_to_binary) break;
     }
     if (needs_cjs_runtime or needs_esm_wrap_runtime) {
-        // 단일 번들 경로와 동일: Node ESM + CJS wrap이면 createRequire shim 필요 (#1456)
-        if (needs_cjs_runtime and options.platform == .node and options.format == .esm) {
+        // 단일 번들 경로와 동일 정책 — wrapper 자체는 require() 안 호출하므로 (#3252)
+        // *external require call* 이 모듈에 emit 되는 경우만 shim 필요.
+        const needs_require_shim = if (options.platform == .node and options.format == .esm) blk: {
+            for (chunk.modules.items) |mod_idx| {
+                const m = graph.getModule(mod_idx) orelse continue;
+                for (m.import_records) |rec| {
+                    if (rec.kind == .require and rec.is_external) break :blk true;
+                }
+            }
+            break :blk false;
+        } else false;
+        if (needs_require_shim) {
             try rt.appendRequireShim(output, allocator, options.minify_whitespace);
         }
         if (needs_cjs_runtime) {


### PR DESCRIPTION
## Summary

shim 필요 조건을 정확히 — `kind=.require and is_external` import_record 가 어떤 모듈에든 존재할 때만 emit. wrapper 자체는 require() 안 호출 (M1/M2 후) 이라 `cjs wrap module 존재` 만으로 emit 하던 기존 보수적 판정 수정.

## Why

이전: `needs_cjs_runtime + platform=node + format=esm` → 항상 shim 84 chars emit.
새: 위 + `external require() 호출 존재` 만 emit.

rxjs (모든 require 가 wrapper 호출로 변환됨) 같은 케이스는 shim 완전 dead.

## 측정 (rxjs deepEntry, --minify, --platform=node)

```
size:               150,698 → 150,614 bytes  (-84 bytes)
createRequire 등장:    1 → 0
esbuild 격차:        3,636 → 3,552 bytes
smoke smaller 개수:   117 → 119
```

## 안전성

- *external builtin require* (`require("fs")` 등 — `is_external=true` 한 record) 가 있는 빌드는 shim 그대로 emit
- 두 emit path (single bundle + chunk-aware) 모두 같은 정확 검사 적용

## Test plan

- [x] zig build test 통과
- [x] smoke 134 fixture: Smaller +2 개선 (회귀 0)
- [x] node 출력 정확

🤖 Generated with [Claude Code](https://claude.com/claude-code)