### PR TITLE
perf(emitter): CJS wrapper helper to anonymous arrow (rxjs -16B)

### DIFF
--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -3051,8 +3051,9 @@ test "#1621 minify+react-native: configurable __toESM stays ES5 and compact" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "i<keys.length") != null);
 }
 
-test "#1621 minify: __commonJS body uses $r for __require" {
-    // __commonJS 팩토리 내부 `function __require()` 도 축약되어야 함.
+test "#1621 minify: __commonJS body 는 anonymous arrow (named function 제거)" {
+    // 이전 동작: `function $r() {...}` named function expression — stack trace 친화.
+    // 새 동작: anonymous arrow `()=>(...)` — 17 chars 절약 (esbuild/rolldown 식).
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeCjsWrapFixture(tmp.dir);
@@ -3072,8 +3073,10 @@ test "#1621 minify: __commonJS body uses $r for __require" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // $cj 팩토리 body: `function $r(){...}` 형태여야 한다.
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "function $r()") != null);
+    // helper body: arrow expression body — `(cb,mod)=>()=>(mod||cb(...)...)`.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "(cb,mod)=>()=>") != null);
+    // 이전 named function 패턴은 더 이상 emit 안 됨.
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "function $r()") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__require") == null);
 }
 

--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -47,13 +47,18 @@ pub const helperName = names_mod.helperName;
 // 의 module path 보존). minify wrapper 는 cb 가 *함수* — emit 도 직접 함수 인자
 // (`$cj((exports,module)=>{...})`) 와 한 쌍. HMR 의 `Object.keys(cb)[0]` module id
 // 추적은 dev_mode 전용 (minify 시 HMR runtime 자체가 emit 안 됨) 이므로 호환.
+//
+// minify 의 returned function 은 anonymous arrow (esbuild/rolldown 식) — named
+// function expression (`function __require()`) 보다 17 chars 짧다. stack trace 의
+// 함수 이름 손실은 production minify 에서 trade-off 수용.
 pub const CJS_RUNTIME = "var __commonJS = (cb, mod) => function __require() {\n\treturn mod || (0, cb[Object.keys(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;\n};\n";
-pub const CJS_RUNTIME_MIN = "var " ++ NAMES.CJS_FACTORY_MIN ++ "=(cb,mod)=>function " ++ NAMES.REQUIRE_MIN ++ "(){return mod||cb((mod={exports:{}}).exports,mod),mod.exports};";
+pub const CJS_RUNTIME_MIN = "var " ++ NAMES.CJS_FACTORY_MIN ++ "=(cb,mod)=>()=>(mod||cb((mod={exports:{}}).exports,mod),mod.exports);";
 
 // __commonJS ES5 호환 (RN/Hermes — `configurable_exports=true`): arrow → function.
+// ES5 는 arrow expression body 가 없어 function expression 그대로지만, 이름은 제거.
 // #1751: trailing `;` — 뒤따르는 `var __xxx=...` 와 문법 구분 필수 (minify 연속 emit).
 pub const CJS_RUNTIME_ES5 = "var __commonJS = function(cb, mod) { return function __require() {\n\treturn mod || (0, cb[Object.keys(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;\n}; };\n";
-pub const CJS_RUNTIME_ES5_MIN = "var " ++ NAMES.CJS_FACTORY_MIN ++ "=function(cb,mod){return function " ++ NAMES.REQUIRE_MIN ++ "(){return mod||cb((mod={exports:{}}).exports,mod),mod.exports}};";
+pub const CJS_RUNTIME_ES5_MIN = "var " ++ NAMES.CJS_FACTORY_MIN ++ "=function(cb,mod){return function(){return mod||cb((mod={exports:{}}).exports,mod),mod.exports}};";
 
 /// __toESM: CJS 모듈을 ESM namespace로 변환 (rolldown 호환).
 /// isNodeMode=true(--platform=node)이면 항상 default: mod를 설정.


### PR DESCRIPTION
## Summary

minify CJS factory 의 returned function 을 named function expression 에서 anonymous arrow expression body 로 변경 (esbuild/rolldown 식).

```
이전: var $cj=(cb,mod)=>function $r(){return mod||cb(...),mod.exports};
새:   var $cj=(cb,mod)=>()=>(mod||cb(...),mod.exports);
```

ES5 path (RN/Hermes) 도 같이 — `function $r()` → 익명 `function()` (arrow expression body 는 ES5 비호환).

## 측정

- rxjs: 150,614 → 150,598 bytes (-16 bytes, helper 정의 한 번)
- esbuild 격차: 3,552 → 3,536 bytes
- smoke 134 fixture 회귀 0

## Trade-off

minify=production 빌드의 stack trace 에서 wrapper frame 이 익명. esbuild/rolldown 동일 패턴 — 영향 무시 가능.

## Test plan

- [x] zig build test (#1621 wrapper pattern test 갱신)
- [x] smoke 134 fixture 모두 OK
- [x] node 출력 정확

🤖 Generated with [Claude Code](https://claude.com/claude-code)