### PR TITLE
perf(emitter): CJS_FACTORY_MIN $cj → $c 단축 (rxjs -224B)

### DIFF
--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -243,8 +243,8 @@ test "CJS: minified CJS wrapping" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // #1618: minify 모드에서 CJS 팩토리는 `$cj`로 축약
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "$cj=") != null);
+    // #1618: minify 모드에서 CJS 팩토리는 `$c`로 축약 (#3256 후 1 char 단축)
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$c=") != null);
     // 모듈 경계 주석 없음
     try std.testing.expect(std.mem.indexOf(u8, result.output, "// ---") == null);
 }

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -2717,11 +2717,11 @@ test "#1618 minify: __commonJS → $cj short name" {
     defer result.deinit(std.testing.allocator);
 
     try std.testing.expect(!result.hasErrors());
-    // minify 모드: preamble이 `var $cj=` 형태로 축약, 호출부는 직접 함수 + callback param
-    // 단축 (`=$cj((e,m)=>`) — body 의 unresolved `exports`/`module` 도 codegen 에서
-    // `e`/`m` 로 substitute (cjs_wrap_substitute).
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "var $cj=") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "=$cj((e,m)=>") != null);
+    // minify 모드: preamble이 `var $c=` 형태로 축약 (#3256: $cj → $c 1 char 단축).
+    // 호출부는 직접 함수 + callback param 단축 — body 의 unresolved `exports`/`module`
+    // 도 codegen 에서 `e`/`m` 로 substitute (cjs_wrap_substitute).
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var $c=") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "=$c((e,m)=>") != null);
     // 원본 `__commonJS` 이름은 나타나지 않아야 함
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__commonJS") == null);
 }
@@ -2745,23 +2745,23 @@ test "#1618 non-minify: __commonJS name preserved" {
 
     try std.testing.expect(!result.hasErrors());
     try std.testing.expect(std.mem.indexOf(u8, result.output, "var __commonJS") != null);
-    // 축약 이름은 나타나지 않아야 함
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "var $cj=") == null);
+    // 축약 이름은 나타나지 않아야 함 (#3256: $cj → $c 단축)
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var $c=") == null);
 }
 
-// Edge case: 사용자 코드가 `$cj`와 동일한 이름의 로컬(non-exported) const를 선언.
-// mangler가 `$cj`를 reserved로 알고, base54 할당 시에도 skip하므로 사용자 심볼이
-// `$cj`로 emit되지 않아 preamble 정의와 충돌하지 않아야 함.
-// (mangler는 non-exported + len>1 심볼을 rename 대상으로 가져가므로 사용자 `$cj`는
-//  base54 이름으로 rename됨.)
-test "#1618 minify: user-defined `$cj` local const doesn't collide with runtime helper" {
+// Edge case: 사용자 코드가 `$c`와 동일한 이름의 로컬(non-exported) const를 선언.
+// mangler가 `$c`를 reserved로 알고, base54 할당 시에도 skip하므로 사용자 심볼이
+// `$c`로 emit되지 않아 preamble 정의와 충돌하지 않아야 함.
+// (mangler는 non-exported + len>1 심볼을 rename 대상으로 가져가므로 사용자 `$c`는
+//  base54 이름으로 rename됨.) — #3256: $cj → $c 단축 후.
+test "#1618 minify: user-defined `$c` local const doesn't collide with runtime helper" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "lib.cjs", "module.exports = { greet: () => \"hi\" };");
     try writeFile(tmp.dir, "entry.ts",
         \\const lib = require('./lib.cjs');
-        \\const $cj = { tag: 42 };
-        \\console.log(lib.greet(), $cj.tag);
+        \\const $c = { tag: 42 };
+        \\console.log(lib.greet(), $c.tag);
     );
 
     const entry = try absPath(&tmp, "entry.ts");
@@ -2780,11 +2780,11 @@ test "#1618 minify: user-defined `$cj` local const doesn't collide with runtime 
 
     try std.testing.expect(!result.hasErrors());
     // preamble: runtime helper 정의 존재
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "var $cj=(cb,mod)=>") != null);
-    // 사용자 `$cj`는 mangle되어 별도 선언으로 출력되지 않아야 함 —
-    // preamble의 runtime helper 정의가 `var $cj` 유일한 선언이어야 한다
-    // (두 번째 `var $cj` = 충돌, 사용자 값이 runtime helper를 덮어씀).
-    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, result.output, "var $cj"));
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "var $c=(cb,mod)=>") != null);
+    // 사용자 `$c`는 mangle되어 별도 선언으로 출력되지 않아야 함 —
+    // preamble의 runtime helper 정의가 `var $c` 유일한 선언이어야 한다
+    // (두 번째 `var $c` = 충돌, 사용자 값이 runtime helper를 덮어씀).
+    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, result.output, "var $c"));
 }
 
 // Edge case: 사용자 코드가 `$cj` 함수 호출 (`$cj()` 형태)을 사용하지만 정의는 없는 경우.

--- a/src/codegen/mangler_test.zig
+++ b/src/codegen/mangler_test.zig
@@ -60,7 +60,7 @@ test "isReservedOrGlobal: all #1621 runtime helper short names registered" {
         try std.testing.expect(isReservedOrGlobal(p.short));
     }
     // 경계 케이스: 정확히 일치할 때만 reserved (prefix/suffix, case 구별).
-    try std.testing.expect(!isReservedOrGlobal("$c"));
+    // 주의: `$c` 는 CJS_FACTORY_MIN 이라 reserved (#3256 후 단축).
     try std.testing.expect(!isReservedOrGlobal("$j"));
     try std.testing.expect(!isReservedOrGlobal("$cjq"));
     try std.testing.expect(!isReservedOrGlobal("$te"));

--- a/src/runtime_helper_names.zig
+++ b/src/runtime_helper_names.zig
@@ -16,7 +16,7 @@ const std = @import("std");
 
 pub const NAMES = struct {
     // bundler interop
-    pub const CJS_FACTORY_MIN = "$cj"; // __commonJS
+    pub const CJS_FACTORY_MIN = "$c"; // __commonJS — 호출 빈도 가장 높음 (모듈 wrapper 마다)
     pub const REQUIRE_MIN = "$r"; // __commonJS body 내부 function __require
     pub const ESM_FACTORY_MIN = "$e"; // __esm
     pub const EXPORT_MIN = "$x"; // __export


### PR DESCRIPTION
## Summary

`CJS_FACTORY_MIN` (`__commonJS` 의 minify 별칭) 을 3 chars (`\$cj`) → 2 chars (`\$c`) 단축. CJS-heavy bundle 에서 호출 site 마다 1 char 절약.

## Why

M5 머지 후 헬퍼 호출 빈도 분석 — `\$cj` 만 224회 (다른 helper 0회 in rxjs). 이게 단일 큰 영역.

## 측정 (rxjs deepEntry, --minify, --platform=node)

```
size:           149,710 → 149,486 bytes  (-224 bytes)
esbuild 격차:    2,648 → 2,424 bytes
\$cj 호출 site: 224 → 0 (모두 \$c 로 변경)
```

## 안전성

- 다른 helper 와 distinct (`\$cr`, `\$cp`, `\$cC`, `\$cS` 모두 2+ chars 의 *다른 letter sequence*)
- `\$` prefix 유지 — user binding 거의 안 충돌
- mangler 의 `isReservedOrGlobal` 가 `PAIRS` 자동 등록 — 충돌 자동 차단
- user 가 `\$c` binding 선언 시 mangle 되지 않음 (#1618 test 검증)

## Test plan

- [x] zig build test 통과 (5032/5032)
- [x] smoke 134 fixture 모두 OK
- [x] node 출력 정확
- [x] mangler boundary case test 갱신 (`\$c` 가 reserved, `\$j` 는 not)

🤖 Generated with [Claude Code](https://claude.com/claude-code)