### PR TITLE
fix(test): allow `m.exports` form in CJS wrapper bundle-minify

### DIFF
--- a/packages/core/test/core/build-sync/ts-export-equals-minify-targets/bundle-minify.ts
+++ b/packages/core/test/core/build-sync/ts-export-equals-minify-targets/bundle-minify.ts
@@ -22,8 +22,10 @@ describe('@zntc/core buildSync - TS export equals bundle minify', () => {
       expect(result.errors.length).toBe(0);
       const out = result.outputFiles[0].text;
       // bundle 모드에서는 declaration 과 reference 가 함께 mangle (정합성만 유지하면 OK).
-      expect(out).toMatch(/module\.exports=\w+/);
-      expect(out).toContain('class');
+      // wrapper param 단축 시 `module` → `m` substitute 도 허용.
+      const exportMatch = out.match(/(?:module|m)\.exports=([A-Za-z_$][\w$]*)/);
+      if (!exportMatch) throw new Error(`no module.exports=<id> in output: ${out}`);
+      expect(out).toMatch(new RegExp(`class\\s+${exportMatch[1]}\\b`));
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- `bundle-minify.ts` 의 regex 가 새 minify 형식(`m.exports=`)을 매치 못 해서 CI 가 깨졌음
- regex 를 `(?:module|m)\.exports=([A-Za-z_$][\w$]*)` 로 캡쳐하고, 캡쳐된 식별자가 `class <id>` 선언과 일치하는지 cross-check 로 강화

## 원인

origin/main 에 들어간 CJS wrapper minify 변경 (`8fecd60e` "CJS wrap callback param `(exports,module)` → `(e,m)` 단축" + 후속 substitute commits) 으로 wrapper body 가 다음과 같이 emit 됨:

**전:**
```js
((exports,module)=>{class e{v=1;...}module.exports=e;})
```

**후 (origin/main):**
```js
((e,m)=>{class t{v=1;...}m.exports=t;})
```

테스트의 `expect(out).toMatch(/module\.exports=\w+/)` 가 wrapper body 의 `m.exports=t` 를 못 잡아서 fail. (`__commonJS` helper 안에 남아있는 `mod.exports` 는 `module.exports` 가 아니라 매치 안 됨.)

## 변경

```diff
-      expect(out).toMatch(/module\.exports=\w+/);
-      expect(out).toContain('class');
+      // wrapper param 단축 시 `module` → `m` substitute 도 허용.
+      const exportMatch = out.match(/(?:module|m)\.exports=([A-Za-z_$][\w$]*)/);
+      if (!exportMatch) throw new Error(`no module.exports=<id> in output: ${out}`);
+      expect(out).toMatch(new RegExp(`class\\s+${exportMatch[1]}\\b`));
```

기존 두 expect 는 단순 매칭만 했지만, 새 코드는 캡쳐된 export 식별자가 실제 class 선언의 식별자와 같은지 cross-check — 테스트 이름의 의도(`__commonJS wrapper 안에서 일관된 mangle`)를 더 정확히 검증.

## Test plan

- [x] `bun test ./test/core/build-sync/ts-export-equals-minify-targets.ts` — 7/7 pass
- [x] `bun test ./index.test.ts` — 437/437 pass
- [x] origin/main 의 새 wrapper 형식(`m.exports=t`)에서 cross-check 가 식별자 일치(`class t` ↔ `m.exports=t`) 를 확인
- [x] `bun x tsc -b --force packages/core` — 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)