### PR TITLE
perf(emitter): CJS wrap body 의 trailing `;` elide (rxjs -211B)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1805,7 +1805,9 @@ pub fn emitModule(
             try wrapped.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN);
             try wrapped.appendSlice(allocator, if (cg.cjs_wrap_module_used) "((e,m)=>{" else "((e)=>{");
             if (preamble_code) |p| try wrapped.appendSlice(allocator, p);
-            try wrapped.appendSlice(allocator, code);
+            // body 의 trailing `;` 제거 — 다음 `})` 가 block close 라 ASI 안전.
+            const body_trimmed = if (code.len > 0 and code[code.len - 1] == ';') code[0 .. code.len - 1] else code;
+            try wrapped.appendSlice(allocator, body_trimmed);
             try wrapped.appendSlice(allocator, "});");
             if (preamble_lines_out) |out| out.* = 0;
         } else {


### PR DESCRIPTION
## Summary

minify 시 module body codegen 결과의 trailing \`;\` 제거. 다음 \`})\` (block close) 가 ASI 보장 — \`;\` 없어도 안전.

## Why

M8 머지 후 \`;}\` 패턴 분석 — zntc 217회 vs esbuild/rolldown 모두 0회. esbuild/rolldown 은 block-end 의 trailing \`;\` 자동 elide. 우리만 emit.

## 측정 (rxjs deepEntry, --minify, --platform=node)

\`\`\`
size:        146,583 → 146,372 bytes  (-211 bytes)
';' 등장:     2,950 → 2,739
esbuild 격차: -479 → -690 bytes (esbuild 보다 690B 작음)
\`\`\`

## 안전성

- non-minify path: \`else\` branch 그대로 — 영향 없음
- body 가 `;` 로 끝나지 않으면 (function/class declaration 등) 그대로 emit
- ASI: \`}\` 직전 \`;\` 제거는 모든 JS engine 에서 안전 (block close 가 statement boundary 보장)

## Test plan

- [x] zig build test 통과 (5032/5032)
- [x] smoke 134 fixture 모두 OK
- [x] node 출력 정확

🤖 Generated with [Claude Code](https://claude.com/claude-code)