### PR TITLE
perf(codegen): multi-expr block 을 sequence 로 unwrap (rxjs -61B)

### DIFF
--- a/src/codegen/codegen_test/basic.zig
+++ b/src/codegen/codegen_test/basic.zig
@@ -716,10 +716,20 @@ test "Codegen #3107: 본문이 logical expr + else 없음 은 && 변환 안 함"
     try std.testing.expectEqualStrings("if(c)a||b;", r.output);
 }
 
-test "Codegen #3107: 2개 statement 면 변환 안 함" {
+test "Codegen #3107: 2개 expression statement block — sequence 로 unwrap" {
+    // minify_syntax 활성 시 block 안 모두 expression statement 면 comma operator
+    // sequence 로 합치고 block `{}` 제거. single-stmt unwrap 의 자연 확장.
     var r = try e2eMinAll(std.testing.allocator, "if (c) { a(); b(); } else { x(); }");
     defer r.deinit();
-    try std.testing.expectEqualStrings("if(c){a();b()}else x();", r.output);
+    try std.testing.expectEqualStrings("if(c)a(),b();else x();", r.output);
+}
+
+test "Codegen: do-while 본문 multi-expr block — sequence unwrap + 키워드 spacing" {
+    // do-while 도 emits_braces 체크에 multi-expr unwrap 가드 — 안 하면 `dof(),g();while`
+    // 처럼 `do` 와 첫 식별자가 fuse → 미선언 변수 호출 (회귀 #M11).
+    var r = try e2eMinAll(std.testing.allocator, "do { f(); g(); } while (c);");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("do f(),g();while(c);", r.output);
 }
 
 test "Codegen #3107: else-if 체인 — 안쪽부터 부분 적용" {

--- a/src/codegen/statements.zig
+++ b/src/codegen/statements.zig
@@ -138,7 +138,51 @@ pub fn emitStatementBody(self: anytype, body_idx: NodeIndex) !void {
         try self.emitNode(inner);
         return;
     }
+    if (try emitMultiExprBlockAsSequence(self, body_idx)) return;
     try self.emitNode(body_idx);
+}
+
+/// `body_idx` 가 block 이고 unwrap as sequence 가능한지만 check (emit 안 함).
+/// emitIfVerbatim 의 `else` 키워드 직후 spacing 결정에 사용.
+pub fn canEmitMultiExprBlockAsSequence(self: anytype, body_idx: NodeIndex) bool {
+    if (!self.options.minify_whitespace) return false;
+    if (!self.options.minify_syntax) return false;
+    if (body_idx.isNone()) return false;
+    const body = self.ast.getNode(body_idx);
+    if (body.tag != .block_statement) return false;
+    const list = body.data.list;
+    const indices = self.ast.extra_data.items[list.start .. list.start + list.len];
+    var count: usize = 0;
+    for (indices) |raw| {
+        const idx: NodeIndex = @enumFromInt(raw);
+        if (isElidedStmt(self, idx)) continue;
+        const n = self.ast.getNode(idx);
+        if (n.tag != .expression_statement) return false;
+        count += 1;
+    }
+    return count >= 2;
+}
+
+/// minify 시 block 안 모든 statement 가 expression_statement 이고 2개 이상이면
+/// `{stmt1; stmt2; ...}` → `stmt1, stmt2, ...;` 로 emit (block + 각 `;` 제거,
+/// comma operator sequence). `if/while/for` body 등 의 size 절약.
+/// declaration 또는 control flow statement 가 끼면 false (block 그대로 emit).
+fn emitMultiExprBlockAsSequence(self: anytype, body_idx: NodeIndex) !bool {
+    if (!canEmitMultiExprBlockAsSequence(self, body_idx)) return false;
+    const body = self.ast.getNode(body_idx);
+    const list = body.data.list;
+    const indices = self.ast.extra_data.items[list.start .. list.start + list.len];
+    var first = true;
+    for (indices) |raw| {
+        const idx: NodeIndex = @enumFromInt(raw);
+        if (isElidedStmt(self, idx)) continue;
+        if (!first) try self.writeByte(',');
+        const n = self.ast.getNode(idx);
+        try self.emitNode(n.data.unary.operand);
+        first = false;
+    }
+    try self.writeByte(';');
+    return true;
 }
 
 /// `body_idx` 가 minify 시 `{}` 를 벗길 수 있는 block 이면 그 안의 단일 statement idx,
@@ -499,9 +543,10 @@ fn emitIfVerbatim(self: anytype, t: anytype) !void {
         if (isElidedAlternate(self, t.c)) return;
         if (self.options.minify_whitespace) {
             // else 분기가 `{...}` 로 출력되면 `else{`, 아니면(bare statement 또는
-            // #3094 로 `{}` 가 벗겨지는 block) 키워드 뒤 공백 필수.
+            // single-stmt / multi-expr block unwrap) 키워드 뒤 공백 필수.
             const emits_braces = self.ast.getNode(t.c).tag == .block_statement and
-                unwrappedStatementBody(self, t.c) == null;
+                unwrappedStatementBody(self, t.c) == null and
+                !canEmitMultiExprBlockAsSequence(self, t.c);
             try self.write(if (emits_braces) "else" else "else ");
         } else {
             try self.write(" else ");
@@ -668,7 +713,8 @@ pub fn emitDoWhile(self: anytype, node: Node) !void {
     // block body 면 emitBracedList 가 `{` 앞 공백을 관리. non-block(또는 #3094 로 `{}` 가
     // 벗겨질 block)은 키워드 뒤 공백 필수 (`dox++` 방지).
     const body_is_braces = !body.isNone() and self.ast.getNode(body).tag == .block_statement and
-        unwrappedStatementBody(self, body) == null;
+        unwrappedStatementBody(self, body) == null and
+        !canEmitMultiExprBlockAsSequence(self, body);
     if (!body_is_braces) try self.writeByte(' ');
     try emitStatementBody(self, body);
     if (self.options.minify_whitespace) try self.write("while(") else try self.write(" while (");


### PR DESCRIPTION
## Summary

\`if\`/\`else\`/\`do-while\`/loop body 가 *block 안 모든 statement 가 expression* 이고 2개 이상이면 \`{stmt1;stmt2;}\` → \`stmt1,stmt2;\` 로 unwrap (single-stmt unwrap 의 자연 확장).

## Why

M9 머지 후 rolldown 격차 분석 — rolldown 의 \`;\` 1,718 vs zntc 2,739 (1KB 격차). rolldown 이 *consecutive expression statement* 를 *sequence operator* 로 합치고 \`{}\` 제거. 우리도 같은 unwrap 추가.

## /simplify findings 적용

- ✅ **CRITICAL**: do-while body 도 같은 가드 (\`dof(),g()\` fuse 회귀 차단)
- ✅ Reuse: \`canEmit*\` + \`emit*\` 둘 다 같은 검사 — \`canEmit*\` 가 prefix 로 helper. (병합은 더 큰 refactor — 별도 PR 가치)
- ✅ narration: \`(M11)\` task ref 제거

## 측정 (rxjs deepEntry, --minify, --platform=node)

\`\`\`
size:    146,372 → 146,311 bytes  (-61 bytes)
node:    rxjs 출력 정확
smoke:   Average 0.87x 동일 (회귀 0)
\`\`\`

## 안전성

| 위험 | 대응 |
|---|---|
| else/do/while 키워드 직후 식별자 fuse | \`canEmitMultiExprBlockAsSequence\` 로 keyword spacing 강제 (\`else \`/\`do \`) |
| if/while/for body | \`)\` 로 종료 — fuse 위험 없음 |
| declaration 포함 block | \`expression_statement\` 만 검사 — declaration 있으면 unwrap 거부 |
| empty block 또는 single-stmt | \`count >= 2\` 가드 — 기존 single-unwrap 와 충돌 안 함 |

## Test plan

- [x] zig build test 통과 — \`#3107\` 갱신 + 새 do-while 회귀 test
- [x] smoke 134 fixture 모두 OK
- [x] node 출력 정확

🤖 Generated with [Claude Code](https://claude.com/claude-code)