### PR TITLE
perf(minify): named function expression unused name elide (mobx -593B)

### DIFF
--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -290,6 +290,10 @@ fn runOnce(
             // PR1.5 (a): unused expression statement 축약 — semantic 정보 있을 때만
             // (symbol_ids 가 없으면 identifier local binding 판정 불가)
             .expression_statement => if (ctx.hasSemantic()) unused_expr.simplifyUnusedExprStmt(ast, ctx, i, node, &changed),
+            // function expression 의 name 이 self-reference 안 쓰면 elide. function expression
+            // 의 name binding 은 *그 함수 body 안에서만* visible (spec) — reference_count == 0
+            // 이면 name 안전하게 anonymous. mobx 같은 ES5 class transpile 패턴 큰 영향.
+            .function_expression => if (ctx.hasSemantic()) elideUnusedFnExprName(ast, ctx, node, &changed),
             else => {},
         }
     }
@@ -1032,6 +1036,26 @@ pub fn mergeDecls(ast: *Ast, skip_nodes: ?*const std.DynamicBitSet) void {
 // ================================================================
 // Constant Folding — Binary Expression
 // ================================================================
+
+/// function expression 의 name 이 self-reference 안 쓰이면 elide (anonymous 화).
+/// `function Name() {...}` (expression context, e.g. `prototype.method = function Name() {}`)
+/// 의 Name 은 spec 상 *그 함수 body 안에서만* visible — reference_count == 0 이면
+/// 외부에서 안 보이고 self-ref 도 없음. AST mutate (extra[0] → NodeIndex.none).
+/// mobx 같은 ES5 transpile class 패턴 큰 영향 (모든 prototype method 의 name elide).
+fn elideUnusedFnExprName(ast: *Ast, ctx: MinifyCtx, node: Node, changed: *bool) void {
+    const e = node.data.extra;
+    if (e + 4 > ast.extra_data.items.len) return;
+    const name_raw = ast.extra_data.items[e];
+    const name_idx: NodeIndex = @enumFromInt(name_raw);
+    if (name_idx.isNone()) return;
+    const name_ni = @intFromEnum(name_idx);
+    if (name_ni >= ctx.symbol_ids.len) return;
+    const sym_id = ctx.symbol_ids[name_ni] orelse return;
+    if (sym_id >= ctx.symbols.len) return;
+    if (ctx.symbols[sym_id].reference_count != 0) return;
+    ast.extra_data.items[e] = @intFromEnum(NodeIndex.none);
+    changed.* = true;
+}
 
 fn foldBinary(ast: *Ast, allocator: std.mem.Allocator, node_idx: u32, node: Node, changed: *bool) void {
     const left_ni = @intFromEnum(node.data.binary.left);


### PR DESCRIPTION
## Summary

\`function Name() {...}\` (function expression) 의 Name 이 self-reference 안 쓰이면 AST mutate 로 anonymous 화. ES5 class transpile 패턴 큰 영향.

## Why

mobx 가 zntc 75KB vs rolldown 73KB **(1.85x ratio, worst outlier)** — 분석 결과 \`function Ca\` 가 **127회** 같은 이름 emit. 우리 mangler 가 *named function expression* 의 *unused name* 도 mangle (모두 같은 이름 부여) → bundle 이 비대.

esbuild/rolldown 식 — *self-reference 없는 named function expression* 의 name 제거 → anonymous \`function() {...}\`.

## 측정

```
mobx (production minify):
  size:    74,760 → 74,167 bytes  (-593 bytes, -0.8%)
  ratio:   1.85x → 1.83x (vs rolldown)
  function declarations:  578 → 251 (절반)

rxjs:
  size:    146,311 → 146,293 bytes  (-18 bytes)
  (rxjs 는 function expression 적어 영향 작음)
```

## 안전성

- \`ctx.hasSemantic()\` 가드 — semantic 정보 없으면 skip
- \`reference_count == 0\` 검사 — self-ref 보호
- \`function_declaration\` 영향 없음 — \`.function_expression\` tag 만
- name binding 은 spec 상 *그 함수 body 안에서만* visible (function expression name binding semantics)

## Test plan

- [x] zig build test 통과 (5032/5032)
- [x] smoke 134 fixture 모두 OK
- [x] mobx node 출력 정확

🤖 Generated with [Claude Code](https://claude.com/claude-code)