### PR TITLE
feat(minify): N-step1 — module-level dead toplevel candidate audit

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -307,6 +307,11 @@ pub fn emitWithTreeShaking(
     linker: ?*const Linker,
     shaker: ?*const TreeShaker,
 ) !EmitResult {
+    // N RFC (#3267) audit: 빌드 시작 시 누적기 reset, return 직전 dump.
+    // `ZNTC_DEBUG=dead_toplevel_audit` 활성 시 module-level dead candidate count + size 출력.
+    @import("../transformer/minify.zig").resetDeadToplevelAudit();
+    defer @import("../transformer/minify.zig").dumpDeadToplevelAudit();
+
     // 1. JS/JSON 모듈 필터 + exec_index 순으로 정렬
     var sorted: std.ArrayList(*const Module) = .empty;
     defer sorted.deinit(allocator);

--- a/src/debug_log.zig
+++ b/src/debug_log.zig
@@ -64,6 +64,10 @@ pub const Category = enum {
     /// Phase A (cross-module top-level) + Phase B (per-module nested) 의 1-char
     /// skip 분포 + slot/counter summary. mangle 식별자 풀 1-char 잠식 진단용.
     mangle_audit,
+    /// `removeDeadStores` 가 module-level scope (scope_idx == 0) 가드로 skip 한
+    /// declaration 의 개수 + size 합. mobx production define 후 dead 가 된 error
+    /// message dict 같은 cascade-dead binding 식별. issue #3267 N RFC.
+    dead_toplevel_audit,
 
     /// 카테고리 이름으로 enum 조회 (공백 제거 + 대소문자 무시).
     pub fn fromString(s: []const u8) ?Category {

--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -32,6 +32,7 @@ const ast_walk = @import("../parser/ast_walk.zig");
 const numeric = @import("minify/numeric.zig");
 const unused_expr = @import("minify/unused_expr.zig");
 const string_escape = @import("../string_escape.zig");
+const debug_log = @import("../debug_log.zig");
 
 /// Minify pass 컨텍스트. semantic 정보가 있을 때만 dead store 제거가 동작한다.
 /// `symbols` 는 read-only 로 사용한다 — 과거엔 `reference_count` 를 직접 감산했지만,
@@ -471,7 +472,14 @@ fn tryRemoveDeadDecl(ast: *Ast, ctx: MinifyCtx, node_idx: u32, node: Node, chang
     // top-level (module scope=0) 는 tree-shaker 영역 — 여기서 지우면 bundle 경로의 entry
     // top-level 선언이 사라져 fixture 가 깨진다. 함수/블록 local 만 대상.
     const scope_idx = @intFromEnum(sym.scope_id);
-    if (scope_idx == 0) return;
+    if (scope_idx == 0) {
+        // N RFC (#3267) audit: 다른 가드 (eval/with/exported/ref/purity) 도 통과한
+        // top-level dead candidate 의 size 추적. 실제로는 elide 안 함 — 측정만.
+        if (debug_log.enabled(.dead_toplevel_audit)) {
+            tryAuditDeadToplevel(ast, ctx, sym_id, sym, node, init_idx);
+        }
+        return;
+    }
 
     // eval / with 스코프 안의 선언은 동적 lookup 대상이 될 수 있다. mangler 와 동일 보호
     // (Scope.blocksMangling — subtree_has_direct_eval / subtree_has_with).
@@ -497,6 +505,33 @@ fn tryRemoveDeadDecl(ast: *Ast, ctx: MinifyCtx, node_idx: u32, node: Node, chang
         .span = node.span,
         .data = .{ .none = 0 },
     }, changed);
+}
+
+/// N RFC (#3267) audit 누적기 — `dead_toplevel_audit` 활성 시 minify pass 동안
+/// module-level dead candidate (다른 가드 통과 후 scope_idx==0 으로만 차단된 binding)
+/// 의 개수 + span size 누적. 호출자가 빌드 종료 시 직접 dump 또는 외부 grep.
+var dead_toplevel_count: usize = 0;
+var dead_toplevel_size: usize = 0;
+
+pub fn resetDeadToplevelAudit() void {
+    dead_toplevel_count = 0;
+    dead_toplevel_size = 0;
+}
+
+pub fn dumpDeadToplevelAudit() void {
+    if (!debug_log.enabled(.dead_toplevel_audit)) return;
+    debug_log.print(.dead_toplevel_audit, "module-level dead candidates: count={d} size={d}\n", .{
+        dead_toplevel_count,
+        dead_toplevel_size,
+    });
+}
+
+fn tryAuditDeadToplevel(ast: *Ast, ctx: MinifyCtx, sym_id: u32, sym: symbol_mod.Symbol, node: Node, init_idx: NodeIndex) void {
+    if (sym.isExported()) return;
+    if (ctx.effectiveRefCount(sym_id) != 0 or sym.write_count != 0) return;
+    if (!init_idx.isNone() and !purity.isExprPure(ast, init_idx, ctx.unresolved_globals)) return;
+    dead_toplevel_count += 1;
+    dead_toplevel_size += @as(usize, node.span.end) -| @as(usize, node.span.start);
 }
 
 /// expression 안의 모든 `identifier_reference` 노드를 찾아, symbol_ids 로 symbol 을


### PR DESCRIPTION
## Summary

N RFC (#3267) Step 1 — 측정 인프라. `ZNTC_DEBUG=dead_toplevel_audit` 활성 시 module-level dead candidate (eval/with/exported/ref/purity 가드 통과 후 \`scope_idx == 0\` 만 차단) 의 count + size 누적. size/동작 영향 0.

## 측정 결과

```
mobx (production define):  count=6  size=8200  (~8.2KB elidable)
rxjs:                       count=0  size=0    (영향 없음)
```

mobx 의 18KB 격차 중 ~8KB 가 *순수 dead module-level binding* (mobx error message dict 등). N-step4 (cascade reachability) 후 elide 가능 — 격차의 절반 해결 예상.

## Closes

- Step 1 of #3267

## Test plan

- [x] zig build test 통과
- [x] smoke 134 fixture 모두 OK
- [x] audit 동작 확인 (mobx 8.2KB, rxjs 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)