### PR TITLE
feat(minify): N-step3a — audit per-binding name + span dump

### DIFF
--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -530,8 +530,20 @@ fn tryAuditDeadToplevel(ast: *Ast, ctx: MinifyCtx, sym_id: u32, sym: symbol_mod.
     if (sym.isExported()) return;
     if (ctx.effectiveRefCount(sym_id) != 0 or sym.write_count != 0) return;
     if (!init_idx.isNone() and !purity.isExprPure(ast, init_idx, ctx.unresolved_globals)) return;
+    const size = @as(usize, node.span.end) -| @as(usize, node.span.start);
     dead_toplevel_count += 1;
-    dead_toplevel_size += @as(usize, node.span.end) -| @as(usize, node.span.start);
+    dead_toplevel_size += size;
+    // per-binding dump — count+size 만으로는 어떤 declaration 인지 식별 불가.
+    // root cause 분석 (mobx error message dict 류 / runtime helper 잔여 / TS-emit
+    // temp 등 분류) 에 필요. `sym.nameText(ast.source)` 는 binding identifier span 을
+    // 원본 source 에서 가져오므로 transform 후에도 정확. synthetic 심볼은 합성 이름 반환.
+    const name = sym.nameText(ast.source);
+    debug_log.print(.dead_toplevel_audit, "  - {s}  size={d}  span={d}..{d}\n", .{
+        name,
+        size,
+        node.span.start,
+        node.span.end,
+    });
 }
 
 /// expression 안의 모든 `identifier_reference` 노드를 찾아, symbol_ids 로 symbol 을


### PR DESCRIPTION
## Summary

N RFC (#3267) Step 3a — \`tryAuditDeadToplevel\` 의 per-binding dump 강화. 진단용, 동작 변경 0.

## mobx 분석 결과

\`ZNTC_DEBUG=dead_toplevel_audit\` 출력:

\`\`\`
- niceErrors  size=4009  span=0..4009     ← mobx error message dict (N RFC 의 \`ga\` 패턴!)
- errors      size=69    span=4010..4079
- CREATE      size=22    span=50005..50027
(각 두 번 — prepass + emit 의 두 번째 minify pass)
total: count=6 size=8200
\`\`\`

⇒ **8200 bytes 중 본질적 elide 가능 ≈ 4100 bytes** (중복 제외). 모두 *진짜 dead* (intra-module ref==0, exported==false, pure init). minify 가 이미 식별 완료.

## 진짜 root cause (확정)

\`src/transformer/minify.zig:473-474\`:

\`\`\`zig
const scope_idx = @intFromEnum(sym.scope_id);
if (scope_idx == 0) return;  // ← 6 candidates 모두 이 가드로 차단
\`\`\`

주석 명시: *bundle 경로 transpile 단독에서 entry top-level 선언이 사라지면 안 되기 때문* — 보수 보호. 가드 자체는 정확. **bundle 경로 (tree-shaker active) 에서만 + 안전 조건 하에 풀면 elide 가능**.

## 다음 PR (N-step3b)

가드 조건부 풀기 + 23 unit test 회귀 (이전 시도) 분석 → 안전 가드 설계.

## Closes

- Step 3a of #3267

## Test plan

- [x] zig build test 통과 (회귀 0)
- [x] mobx audit 출력으로 6 candidates 정체 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)