### PR TITLE
perf(minify): N-step3b — module-level dead store elide for user-pure modules (mobx -3.2KB)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1412,6 +1412,12 @@ pub fn emitModule(
         // codegen/mangler 도 `transformer.symbol_ids` 를 읽으므로(override_syms → md.symbol_ids)
         // alias inline 의 symbol_id 갱신이 전파됨. 동일 backing 의 mutable view.
         ctx.symbol_ids_mut = transformer.symbol_ids.items;
+        // module-level dead store elide: tree-shaker active + 모듈이 *user-declared pure*
+        // (package.json `"sideEffects": false`) 일 때만 허용. rolldown 의
+        // `DeterminedSideEffects::UserDefined(false)` 와 동일 게이트 — user 가 명시한
+        // "drop 가능" 신호가 있을 때만 정밀 DCE 적용. mobx/rxjs/lodash 등 라이브러리는
+        // 거의 모두 이 신호를 가지고 있어 mobx 4KB cascade-dead 회수 경로 활성화.
+        ctx.allow_top_level_dead = (shaker != null) and module.isUserDeclaredPure();
         minify_mod.minify(transformer.ast, ctx, arena_alloc, root);
     }
 

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -374,6 +374,13 @@ pub const Module = struct {
         return self.cycle_group != 0;
     }
 
+    /// 모듈이 *user-declared pure* — package.json `"sideEffects": false` 가 명시되어
+    /// "drop 가능" 신호를 준 경우. tree-shaker / module-level dead store 등 정밀 DCE
+    /// 게이트가 공유. rolldown 의 `DeterminedSideEffects::UserDefined(false)` 와 동일.
+    pub inline fn isUserDeclaredPure(self: *const Module) bool {
+        return self.side_effects_user_defined and !self.side_effects;
+    }
+
     /// `entry_error_guard` 활성 시 이 모듈의 init 호출을 `__zntc_guarded(...)` 로 wrap 할지 결정.
     /// TLA (`uses_top_level_await`) 인 ESM 모듈은 await 가 lambda 안에 못 들어가므로 wrap 안 함.
     /// `wrap_kind == .none` (래핑 없음) 도 호출할 init 함수 자체가 없어 wrap 무의미.

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -463,8 +463,7 @@ pub const TreeShaker = struct {
                 // 있을 때만 정밀 DCE — RN core 처럼 sideEffects 미명시 모듈은 기존 보수 동작 유지.
                 // rolldown 의 `try_extract_lazy_barrel_info` (DeterminedSideEffects::UserDefined(false))
                 // 와 동일 게이트.
-                const is_user_declared_pure = m.side_effects_user_defined and !m.side_effects;
-                if (m.wrap_kind == .esm and !is_user_declared_pure) continue;
+                if (m.wrap_kind == .esm and !m.isUserDeclaredPure()) continue;
 
                 if (m.wrap_kind != .cjs) {
                     if (m.prebuilt_stmt_info) |prebuilt| {

--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -60,6 +60,14 @@ pub const MinifyCtx = struct {
     /// Top-level constant inline is a size optimization that can make debug/non-minified
     /// output less readable. Keep it behind minify_syntax.
     allow_top_level_inline: bool = false,
+    /// Module-level dead store removal.
+    ///
+    /// 기본은 false — transpile 단독 경로에선 entry top-level 선언이 사라지면
+    /// 외부 host 의 `import {x} from "./mod"` 가 깨진다. bundle 경로에선 tree-shaker
+    /// 가 cross-module ref 보존을 이미 보장하고, 진짜 dead 인 module-level binding
+    /// (sym.isExported()==false + intra-module ref==0 + pure init) 은 안전하게
+    /// elide 가능. caller (emitter) 가 `shaker != null` 일 때만 true 세팅.
+    allow_top_level_dead: bool = false,
 
     /// semantic 없이 호출할 때 사용. dead store pass 는 skip 된다.
     pub const empty: MinifyCtx = .{
@@ -469,12 +477,17 @@ fn tryRemoveDeadDecl(ast: *Ast, ctx: MinifyCtx, node_idx: u32, node: Node, chang
     if (sym_id >= ctx.symbols.len) return;
     const sym = ctx.symbols[sym_id];
 
-    // top-level (module scope=0) 는 tree-shaker 영역 — 여기서 지우면 bundle 경로의 entry
-    // top-level 선언이 사라져 fixture 가 깨진다. 함수/블록 local 만 대상.
+    // top-level (module scope=0) 의 dead store 는 기본 보수 보호.
+    // - transpile 단독 경로: cross-module ref 정보가 없어 외부 host 의 `import {x} from
+    //   "./mod"` 가 깨질 수 있다 → 그대로 보존.
+    // - bundle 경로 (`ctx.allow_top_level_dead == true`, emitter 가 tree-shaker active 일
+    //   때 세팅): tree-shaker 가 cross-module ref 보존을 이미 보장한다. 같은 binding 이
+    //   외부에서 쓰이면 `is_exported=true` 가드로 보호되고, 아니면 진짜 dead → elide 안전.
+    //   N RFC (#3267) 의 mobx 4KB cascade-dead 회수 경로.
     const scope_idx = @intFromEnum(sym.scope_id);
-    if (scope_idx == 0) {
-        // N RFC (#3267) audit: 다른 가드 (eval/with/exported/ref/purity) 도 통과한
-        // top-level dead candidate 의 size 추적. 실제로는 elide 안 함 — 측정만.
+    if (scope_idx == 0 and !ctx.allow_top_level_dead) {
+        // audit: 다른 가드 (eval/with/exported/ref/purity) 통과한 candidate 의 size 추적.
+        // bundle 모드 (allow_top_level_dead) 에선 진짜 elide 로 가니 여기 안 옴.
         if (debug_log.enabled(.dead_toplevel_audit)) {
             tryAuditDeadToplevel(ast, ctx, sym_id, sym, node, init_idx);
         }


### PR DESCRIPTION
## Summary

N RFC (#3267) Step 3b — 진짜 root cause fix. \`tryRemoveDeadDecl\` 의 \`scope_idx == 0 → return\` 가드를 조건부로 풀고, emitter 가 *tree-shaker active + 모듈이 user-declared pure* (\`package.json "sideEffects": false\`) 일 때만 활성화.

## 측정 — mobx production minify

```
before: 74,448 bytes (audit count=6 size=8,200 — 모두 elide 안 됨)
after:  71,297 bytes (audit count=0 — 모두 elide)
Δ:      -3,151 bytes / -4.2%
```

elide 된 binding:
- \`niceErrors\` (4009B) ← mobx error message dict, N RFC 의 \`ga\` 패턴
- \`errors\` (69B), \`CREATE\` (22B)

## 안전 가드 (3 단계)

1. \`shaker != null\` — tree-shaker 가 cross-module ref 보존 보장
2. \`module.isUserDeclaredPure()\` — \`sideEffects: false\` 명시 모듈만 (rolldown 의 \`DeterminedSideEffects::UserDefined(false)\` 동일)
3. \`sym.isExported() == false\` + intra-module \`ref==0\` + \`write==0\` + pure init (기존 가드)

## 회귀

- zig build test: 통과 (이전 단순 가드 제거 시 23 회귀 → 이번 user-pure 게이트로 0)
- smoke 134 fixture: 모두 OK, mobx 자체도 MATCH ✅

## 부수 정리

- tree_shaker.zig 의 동일 검사 패턴 → \`Module.isUserDeclaredPure()\` helper 통합 (3 → 1)

## Closes

- Step 3b of #3267

## Test plan

- [x] zig build test 통과
- [x] smoke 134 fixture 회귀 0
- [x] mobx audit count=0 확인 (모든 dead elide)
- [x] mobx -3.2KB / -4.2% 실측

🤖 Generated with [Claude Code](https://claude.com/claude-code)