### PR TITLE
feat(linker): shared namespace inline 의 per-entry size audit

### DIFF
--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -14,6 +14,7 @@ const CompiledModule = @import("../compiled_module.zig").CompiledModule;
 const Module = @import("../module.zig").Module;
 const rt = @import("../runtime_helpers.zig");
 const profile = @import("../../profile.zig");
+const debug_log = @import("../../debug_log.zig");
 
 const NsExportPair = Linker.NsExportPair;
 const SharedNsInline = Linker.SharedNsInline;
@@ -301,6 +302,19 @@ pub fn appendSharedNamespacePreambleFiltered(
         try out.appendSlice(self.allocator, " = ");
         try out.appendSlice(self.allocator, entry.object_literal);
         try out.appendSlice(self.allocator, ";\n");
+        // 큰 namespace inline 의 size 영향 측정. `get NAME(){return VAL}` 패턴은
+        // esbuild/rolldown 의 `NAME:()=>VAL` arrow `__export` 보다 per-export ~9 byte 큼
+        // (~9 exports 부터 helper 패턴이 더 짧음). 어느 라이브러리에서 격차가 큰지
+        // 식별용 — export count 는 `get ` prefix 개수로 근사.
+        if (debug_log.enabled(.ns_inline_audit)) {
+            const literal = entry.object_literal;
+            const export_count = std.mem.count(u8, literal, "get ");
+            debug_log.print(.ns_inline_audit, "  - {s}: exports={d} bytes={d}\n", .{
+                entry.var_name,
+                export_count,
+                literal.len,
+            });
+        }
     }
 }
 

--- a/src/debug_log.zig
+++ b/src/debug_log.zig
@@ -68,6 +68,11 @@ pub const Category = enum {
     /// declaration 의 개수 + size 합. mobx production define 후 dead 가 된 error
     /// message dict 같은 cascade-dead binding 식별. issue #3267 N RFC.
     dead_toplevel_audit,
+    /// shared namespace preamble (`var foo_ns = {get a(){return a}, ...};`) per-entry
+    /// dump — var name · export count · object literal bytes. zntc 의 inline `get`
+    /// 패턴 vs esbuild/rolldown 의 arrow `__export(ns, {name:()=>val})` 패턴 격차
+    /// 식별용. 큰 namespace 일수록 zntc 가 손해.
+    ns_inline_audit,
 
     /// 카테고리 이름으로 enum 조회 (공백 제거 + 대소문자 무시).
     pub fn fromString(s: []const u8) ?Category {


### PR DESCRIPTION
## Summary

\`appendSharedNamespacePreambleFiltered\` 의 \`var foo_ns = {get a(){return a}, ...};\` emit loop 에 per-namespace dump 추가. \`ZNTC_DEBUG=ns_inline_audit\` 활성 시 var name · export count · literal bytes 출력.

## 배경

번들러 비교:
| 번들러 | per-export | 10 exports bundle |
|---|---|---|
| **zntc** | \`get NAME(){return VAL}\` ~20B | 338B |
| esbuild | \`NAME:()=>VAL\` (__export helper) ~11B | 287B |
| rolldown | \`NAME:()=>VAL\` (inline IIFE helper) ~11B | 298B |

esbuild + rolldown 둘 다 **arrow + __export helper** 패턴. zntc 만 **inline \`get\` syntax**. ~9 exports 부터 zntc 가 더 큼.

## 측정 예

\`\`\`
\$ ZNTC_DEBUG=ns_inline_audit zntc --bundle entry3.ts --minify
[ns_inline_audit]   - big_ns: exports=10 bytes=192
\`\`\`

## Scope

- 코드/동작 변경 0, dump 만 추가.
- flag off 시 hot-path 영향 0.
- 후속 fix (arrow \`__export\` 전환) 의 ROI 측정 입력.

## 적용 케이스 한계

mobx/rxjs 작은 entry (named import 만) 는 shared ns 안 만듦. ns import + dynamic key access / nested binding shadow 등 *force_inline* 케이스에서만 emit.

## Test plan

- [x] zig build test 통과
- [x] dynamic key 케이스 audit 확인 (\`exports=10 bytes=192\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)