### PR TITLE
refactor(emitter): N-step4b cleanup — alloc+memcpy → Allocator.dupe

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1427,8 +1427,7 @@ pub fn emitModule(
         // delta 가 잘못된 인덱스 매핑되지 않도록 가드 — 드물지만 hydrate skip 이 안전.
         if (module.transform_cache) |cache| {
             if (cache.ref_deltas.len > 0 and ctx.hasSemantic() and cache.ref_deltas.len == ctx.symbols.len) {
-                if (arena_alloc.alloc(u32, cache.ref_deltas.len)) |buf| {
-                    @memcpy(buf, cache.ref_deltas);
+                if (arena_alloc.dupe(u32, cache.ref_deltas)) |buf| {
                     ctx.ref_deltas = buf;
                 } else |_| {}
             }


### PR DESCRIPTION
## Summary

PR #3275 (N-step4b ctx hydrate) 의 ref_deltas 복사를 \`Allocator.dupe(u32, slice)\` 한 줄로 단순화. 동작 변경 0.

## Before

\`\`\`zig
if (arena_alloc.alloc(u32, cache.ref_deltas.len)) |buf| {
    @memcpy(buf, cache.ref_deltas);
    ctx.ref_deltas = buf;
} else |_| {}
\`\`\`

## After

\`\`\`zig
if (arena_alloc.dupe(u32, cache.ref_deltas)) |buf| {
    ctx.ref_deltas = buf;
} else |_| {}
\`\`\`

## Test plan

- [x] zig build test 통과 (0 회귀)

🤖 Generated with [Claude Code](https://claude.com/claude-code)