### PR TITLE
fix(mangler): cross-module Phase A reserve in ESM bundle

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -71,12 +71,17 @@ pub const UnifiedCollect = struct {
     /// reserved 에 들어가야 internal binding 의 mangle 결과가 동일 이름을 받지 않는다.
     /// string 자체는 module source 가 소유 — slice 만 owned.
     reserved_names: [][]const u8,
+    /// `modules[i].cross_module_imports` 의 backing slice 들. modules 가 borrowed
+    /// 라 별도 list 로 보관해 deinit 시 free.
+    import_ref_slices: [][]const @import("../codegen/unified_mangler.zig").ImportRef,
     allocator: std.mem.Allocator,
 
     pub fn deinit(self: *UnifiedCollect) void {
         self.allocator.free(self.top_level_candidates);
         self.allocator.free(self.modules);
         self.allocator.free(self.reserved_names);
+        for (self.import_ref_slices) |s| self.allocator.free(s);
+        self.allocator.free(self.import_ref_slices);
         for (self.bitsets) |*b| b.deinit();
         self.allocator.free(self.bitsets);
     }
@@ -707,6 +712,14 @@ pub const Linker = struct {
             self.allocator.free(bitsets);
         }
 
+        // modules[i].cross_module_imports 의 backing slice 들. 각 모듈마다 별도
+        // alloc — deinit 시 일괄 free. emptyInput 케이스는 default &.{} 라 미할당.
+        var import_ref_slices: std.ArrayListUnmanaged([]const um.ImportRef) = .empty;
+        errdefer {
+            for (import_ref_slices.items) |s| self.allocator.free(s);
+            import_ref_slices.deinit(self.allocator);
+        }
+
         var candidates: std.ArrayListUnmanaged(um.TopLevelCandidate) = .empty;
         errdefer candidates.deinit(self.allocator);
 
@@ -881,6 +894,23 @@ pub const Linker = struct {
                     }
                 }
 
+                // cross_module_imports: 이 모듈이 import 한 cross-module symbol 의
+                // source 위치. `.semantic` variant 만 — `.alias` 는 re-export chain
+                // 중간 노드라 candidate 풀에 없어 renames lookup 이 무의미.
+                var ir_buf: std.ArrayListUnmanaged(um.ImportRef) = .empty;
+                errdefer ir_buf.deinit(self.allocator);
+                for (m.import_bindings) |ib| {
+                    if (ib.symbol != .semantic) continue;
+                    const sem_ref = ib.symbol.semantic;
+                    if (sem_ref.module.isNone() or sem_ref.symbol.isNone()) continue;
+                    try ir_buf.append(self.allocator, .{
+                        .source_module_index = @intFromEnum(sem_ref.module),
+                        .source_symbol_id = @intFromEnum(sem_ref.symbol),
+                    });
+                }
+                const ir_owned = try ir_buf.toOwnedSlice(self.allocator);
+                try import_ref_slices.append(self.allocator, ir_owned);
+
                 modules[mi] = .{
                     .scopes = sem.scopes,
                     .symbols = sem.symbols.items,
@@ -888,6 +918,7 @@ pub const Linker = struct {
                     .references = sem.references,
                     .source = m.source,
                     .module_scope_symbols = bitsets[mi],
+                    .cross_module_imports = ir_owned,
                 };
             } else {
                 modules[mi] = emptyInput(m.source, bitsets[mi]);
@@ -907,6 +938,7 @@ pub const Linker = struct {
             .modules = modules,
             .bitsets = bitsets,
             .reserved_names = reserved_names,
+            .import_ref_slices = try import_ref_slices.toOwnedSlice(self.allocator),
             .allocator = self.allocator,
         };
     }
@@ -924,11 +956,13 @@ pub const Linker = struct {
         const um = @import("../codegen/unified_mangler.zig");
 
         var collected = try self.collectUnifiedInput();
-        // bitsets 은 linker 로 이관 후 free, candidates/modules/reserved 는 여기서 해제.
+        // bitsets 은 linker 로 이관 후 free, candidates/modules/reserved/import_refs 는 여기서 해제.
         defer {
             self.allocator.free(collected.top_level_candidates);
             self.allocator.free(collected.modules);
             self.allocator.free(collected.reserved_names);
+            for (collected.import_ref_slices) |s| self.allocator.free(s);
+            self.allocator.free(collected.import_ref_slices);
         }
 
         var result = try um.mangleAll(self.allocator, .{

--- a/src/codegen/unified_mangler.zig
+++ b/src/codegen/unified_mangler.zig
@@ -27,6 +27,16 @@ pub const ModuleSymKey = struct {
     symbol_id: u32,
 };
 
+/// 이 모듈이 import 한 cross-module symbol 의 source 위치. Phase A → Phase B
+/// 사이에 각 source 의 mangled name 을 이 모듈의 per-mod reserved 에 등록
+/// (selective broadcast) — nested mangle 이 cross-module Phase A 이름과 충돌
+/// 회피. helper module / external 등 source 가 candidate 가 아닌 경우는 renames
+/// 에 없으므로 자동 skip.
+pub const ImportRef = struct {
+    source_module_index: u32,
+    source_symbol_id: u32,
+};
+
 /// Phase B 가 per-module 로 호출하는 mangler 입력. `mangler.MangleInput`
 /// 과 동일한 semantic payload 에 더해, module scope 안의 symbol set 을 함께
 /// 넘긴다 (Phase A 에서 이미 처리된 top-level 심볼을 skip 하기 위함).
@@ -39,6 +49,8 @@ pub const ModuleMangleInput = struct {
     /// scope_maps[0] 의 모든 symbol_id 를 담은 BitSet. `mangle` 이 skip_symbols
     /// 로 그대로 사용한다.
     module_scope_symbols: std.DynamicBitSet,
+    /// 이 모듈이 import 한 cross-module symbol 의 source 위치.
+    cross_module_imports: []const ImportRef = &.{},
 };
 
 /// Phase A 의 mangling 후보. 호출부가 빈도/필터링을 수행해 넘긴다
@@ -107,9 +119,21 @@ pub fn mangleAll(
         }
     }.cmp);
 
-    // Phase B 가 같은 모듈 안 outer Phase A binding 과 shadow 충돌 (#1757) 을 피하려면
-    // Phase A 가 mangle 한 이름을 *그 모듈 단위* 로 reserve 해야 한다. cross-module 끼리는
-    // CJS/ESM wrapper IIFE 로 격리되므로 다른 모듈의 Phase A 이름은 reserve 할 필요 없다.
+    // Phase B 가 outer Phase A binding 과 shadow 충돌 (#1757) 을 피하려면 Phase A 가
+    // mangle 한 이름을 nested mangle 시 reserve 해야 한다.
+    //
+    // **자기 모듈 Phase A**: `per_mod_reserved[cand.module_index]` 에 항상 등록.
+    //
+    // **다른 모듈 Phase A (cross-module)**: 순수 ESM bundle 은 wrapper IIFE 없이 모든 모듈
+    // top-level 이 한 scope — 다른 모듈의 Phase A 이름도 visible 해 nested 가 shadow 가능
+    // (`let n=n(p)` self-init TDZ). Phase B 진입 *전* 에 selective 로 broadcast — 각 모듈
+    // 의 `cross_module_imports` 에 해당하는 source 의 mangled name 만 per-mod reserved 에
+    // 추가 (전역 broadcast 가 아니라 실제 import 한 source 만 — size 회귀 회피).
+    //
+    // 보강 메커니즘 (`mangler.reserveNameFor` 가 import binding 의 `canonical_name` 으로
+    // 자동 reserve) 는 `Symbol.canonical_name` 이 `mangleAll` 반환 *후* 에 linker 가
+    // set 하므로 Phase B 진입 시점에는 빈 상태 — 여기서 명시적 selective broadcast 가 필요.
+    //
     // (`renames` 만으로 derive 못 함 — Phase A 의 no-op rename, 즉 원본 이름과 mangled 이름이
     // 같은 경우도 reserved 에 등록해야 하지만 `renames` 에는 안 들어가기 때문.)
     //
@@ -155,6 +179,18 @@ pub fn mangleAll(
             // 원본과 동일해도 다음 Phase A 후보가 같은 이름을 집지 못하도록 reserved.
             try reserved.put(cand.name, {});
             if (has_mod_slot) try per_mod_reserved[cand.module_index].put(cand.name, {});
+        }
+    }
+
+    // Phase A 완료 후, 각 모듈의 cross-module import 의 source mangled name 을
+    // *그 모듈* 의 per-mod reserved 에 추가. helper module / external 등 candidate
+    // 가 아닌 source 는 `renames.get` 이 null 이라 자동 skip.
+    for (input.modules, 0..) |m, mi| {
+        for (m.cross_module_imports) |ref| {
+            const key: ModuleSymKey = .{ .module_index = ref.source_module_index, .symbol_id = ref.source_symbol_id };
+            if (renames.get(key)) |mangled| {
+                try per_mod_reserved[mi].put(mangled, {});
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- ESM bundle 에서 cross-module shadow → TDZ ReferenceError 회귀 fix
- `unified_mangler` 에 selective broadcast 추가 — 각 모듈의 import binding source 만 reserve
- **size 회귀 0** (전역 broadcast 가 아닌 selective approach)

## 원인

`bundle --format=esm --minify` 에서:

**전 (회귀):**
```js
function n(x){return x+1}        // helpers.ts: helperA (Phase A mangled)
function r(x){return x+2}        // helpers.ts: helperB
...
function t(p){
  let n=n(p),r=r(n),i=i(r),a=a(i),o=o(a);  // ← inner1 도 'n' 받음 → self-init TDZ
  return o
}
console.log(t(10));
// ReferenceError: Cannot access 'n' before initialization
```

`unified_mangler.mangleAll()` 의 `per_mod_reserved[i]` 가 *자기 모듈* 의 Phase A 이름만 등록 — 기존 코멘트의 "wrapper IIFE 로 격리되니 다른 모듈 Phase A 이름은 reserve 불필요" 가정이 **순수 ESM bundle** 에서 깨짐 (wrapper 없이 모든 모듈 top-level 이 한 scope).

`mangler.reserveNameFor` 가 `Symbol.canonical_name` 으로 자동 보강하는 메커니즘이 있지만 `canonical_name` 은 `mangleAll` 반환 **후** linker 가 주입하므로 Phase B 진입 시점에는 빈 상태 — 미작동.

## Fix (selective broadcast)

전역 broadcast 가 아닌 **실제 import 한 source 만** reserve:

1. `ModuleMangleInput` 에 `cross_module_imports: []const ImportRef` 추가
2. Phase A 직후, 각 모듈의 import binding 의 source mangled name 만 그 모듈의 `per_mod_reserved` 에 등록

`src/codegen/mangler.zig:559` 의 "전역 공유는 +5~10% size 회귀" 경고와 양립.

## Size 측정

| fixture | baseline | broadcast (rejected) | selective (this PR) |
|---|---|---|---|
| rxjs | 145,668 | +6,179 (+4.24%) | **0** |
| mobx | 71,017 | 0 | **0** |
| lodash-es | 16,294 | +1,361 (+8.35%) | **0** |

## Test plan

- [x] `tests/integration/tests/unified-mangler.test.ts` — 4/4 pass (이전 1 fail)
- [x] `zig build test` 통과
- [x] `bun run test:integration` 의 mangler/bundler 영역 0 회귀
- [ ] 별개 회귀: `tests/integration/tests/node-compat.test.ts:299` (splitting CJS shim) — 별 PR 진행 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)