### PR TITLE
test(node-compat): align CJS shim splitting test with cbd201f6

### DIFF
--- a/tests/integration/tests/node-compat.test.ts
+++ b/tests/integration/tests/node-compat.test.ts
@@ -270,13 +270,17 @@ describe('Node.js 호환 edge case', () => {
       expect(bundled).not.toContain('createRequire');
     });
 
-    test('code splitting: shim injected in chunk containing CJS wrap', async () => {
+    test('code splitting: shim injected in chunk containing external require', async () => {
+      // shim 필요 조건은 `kind=.require and is_external` 한 import_record 의 존재
+      // (#cbd201f6 — `__commonJS` wrapper 자체는 cb 직접 호출이라 native require 안 씀).
+      // CJS dep 의 `index.cjs` 안에서 builtin `require('node:fs')` 호출 → external
+      // require → 해당 dep 이 들어간 chunk 에 `createRequire(import.meta.url)` shim emit.
       const f = await createFixture({
         'app.ts': `const lazy = import('./lazy');\nlazy.then((m) => console.log(m.run()));`,
-        'lazy.ts': `import dep from 'cjs-dep';\nexport function run() { return dep.x; }`,
+        'lazy.ts': `import dep from 'cjs-dep';\nexport function run() { return dep.has; }`,
         'package.json': `{"type": "module"}`,
         'node_modules/cjs-dep/package.json': `{"name":"cjs-dep","main":"index.cjs"}`,
-        'node_modules/cjs-dep/index.cjs': `module.exports = { x: 42 };`,
+        'node_modules/cjs-dep/index.cjs': `const fs = require('node:fs');\nmodule.exports = { has: typeof fs.readFileSync };`,
       });
       cleanup = f.cleanup;
 


### PR DESCRIPTION
## Summary

- `cbd201f6 perf(emitter): elide createRequire shim when no external require call` 가 shim emit 조건을 정확히 좁힌 후 test fixture 가 깨짐
- fixture 의 `index.cjs` 안에서 `require('node:fs')` 추가 — external require 트리거 → chunk 에 shim emit
- test 의도 (#1456 "code splitting 시 chunk-level shim inject") 유지

## 원인

`cbd201f6` 가 shim emit 을 `kind=.require and is_external` 조건으로 좁힘 — `__commonJS` wrapper cb 는 직접 호출이라 native require 안 쓰므로 정확. 기존 fixture 의 `module.exports = { x: 42 }` 는 external require 가 없어 shim 정상 elide → test 의 `expect(hasShim).toBe(true)` 가 fail.

## 변경

```diff
- 'node_modules/cjs-dep/index.cjs': `module.exports = { x: 42 };`,
+ 'node_modules/cjs-dep/index.cjs': `const fs = require('node:fs');\nmodule.exports = { has: typeof fs.readFileSync };`,
```

`index.cjs` 안의 `require('node:fs')` 가 external builtin → `kind=.require + is_external` import_record 생성 → 그 dep 이 들어간 chunk (lazy.js) 에 `createRequire(import.meta.url)` shim emit. test 의 splitting + chunk-level shim 검증 의도 유지.

테스트 이름도 "containing CJS wrap" → "containing external require" 로 정확화.

## Test plan

- [x] `tests/integration/tests/node-compat.test.ts` — 13/13 pass (이전 1 fail)
- [x] 다른 12 케이스 회귀 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)