### PR TITLE
refactor(minify): dead_toplevel_audit counter atomic 화

### DIFF
--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -524,19 +524,23 @@ fn tryRemoveDeadDecl(ast: *Ast, ctx: MinifyCtx, node_idx: u32, node: Node, chang
 /// N RFC (#3267) audit 누적기 — `dead_toplevel_audit` 활성 시 minify pass 동안
 /// module-level dead candidate (다른 가드 통과 후 scope_idx==0 으로만 차단된 binding)
 /// 의 개수 + span size 누적. 호출자가 빌드 종료 시 직접 dump 또는 외부 grep.
-var dead_toplevel_count: usize = 0;
-var dead_toplevel_size: usize = 0;
+///
+/// emit_arena 는 chunk 단위 thread pool 로 병렬 호출되므로 audit 카운터는 atomic.
+/// `.monotonic` 으로 충분 — counter 의 정확한 합만 필요하고 다른 메모리 ordering 보장
+/// 의존 없음. 비활성 시엔 increment 자체 호출 안 됨 (caller debug_log.enabled 가드).
+var dead_toplevel_count: std.atomic.Value(usize) = std.atomic.Value(usize).init(0);
+var dead_toplevel_size: std.atomic.Value(usize) = std.atomic.Value(usize).init(0);
 
 pub fn resetDeadToplevelAudit() void {
-    dead_toplevel_count = 0;
-    dead_toplevel_size = 0;
+    dead_toplevel_count.store(0, .monotonic);
+    dead_toplevel_size.store(0, .monotonic);
 }
 
 pub fn dumpDeadToplevelAudit() void {
     if (!debug_log.enabled(.dead_toplevel_audit)) return;
     debug_log.print(.dead_toplevel_audit, "module-level dead candidates: count={d} size={d}\n", .{
-        dead_toplevel_count,
-        dead_toplevel_size,
+        dead_toplevel_count.load(.monotonic),
+        dead_toplevel_size.load(.monotonic),
     });
 }
 
@@ -545,8 +549,8 @@ fn tryAuditDeadToplevel(ast: *Ast, ctx: MinifyCtx, sym_id: u32, sym: symbol_mod.
     if (ctx.effectiveRefCount(sym_id) != 0 or sym.write_count != 0) return;
     if (!init_idx.isNone() and !purity.isExprPure(ast, init_idx, ctx.unresolved_globals)) return;
     const size = @as(usize, node.span.end) -| @as(usize, node.span.start);
-    dead_toplevel_count += 1;
-    dead_toplevel_size += size;
+    _ = dead_toplevel_count.fetchAdd(1, .monotonic);
+    _ = dead_toplevel_size.fetchAdd(size, .monotonic);
     // per-binding dump — count+size 만으로는 어떤 declaration 인지 식별 불가.
     // root cause 분석 (mobx error message dict 류 / runtime helper 잔여 / TS-emit
     // temp 등 분류) 에 필요. `sym.nameText(ast.source)` 는 binding identifier span 을


### PR DESCRIPTION
## Summary

PR #3268 (N-step1 audit infra) 의 file-level mutable counter \`dead_toplevel_count\` / \`dead_toplevel_size\` 가 *emitter chunk thread pool 의 병렬 minify* 시 race — \`+= 1\` 가 atomic 아니라 audit 결과 under-count.

\`std.atomic.Value(usize)\` + \`fetchAdd(.monotonic)\` 로 변경. debug-only 카테고리라 동작 영향 0, audit 결과 정확해짐.

## /simplify retroactive review

PR #3268 ~ #3274 5개 PR 별 정식 3-view 통합 review 진행 결과:
- #3268: ⚠ thread-safety race (본 PR 로 fix)
- #3271/3272/3273/3274: ✓ APPROVE (false positive 만)

## Closes

- Follow-up of #3267

## Test plan

- [x] zig build test 통과 (0 회귀)

🤖 Generated with [Claude Code](https://claude.com/claude-code)