### PR TITLE
feat(flow): support labeled tuple elements

### DIFF
--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -92,6 +92,39 @@ test "Flow: array type T[] stripped" {
     try std.testing.expectEqualStrings("let x=[];", r.output);
 }
 
+test "Flow: tuple type [T, U] stripped" {
+    var r = try e2eFlow(std.testing.allocator, "let x: [number, string] = [1, 'a'];");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=[1,\"a\"];", r.output);
+}
+
+test "Flow: labeled tuple element stripped" {
+    var r = try e2eFlow(
+        std.testing.allocator,
+        "type Pair = [first: number, second: string];\nlet x = 1;",
+    );
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
+test "Flow: optional labeled tuple element stripped" {
+    var r = try e2eFlow(
+        std.testing.allocator,
+        "type T = [name?: string, count: number];\nlet x = 1;",
+    );
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
+test "Flow: labeled tuple with generic ReadonlyArray (metro Server.js regression)" {
+    var r = try e2eFlow(
+        std.testing.allocator,
+        "type T = ReadonlyArray<[pathnamePrefix: string, normalizedRootDir: string]>;\nlet x = 1;",
+    );
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
 test "Flow: type alias with generic stripped" {
     var r = try e2eFlow(std.testing.allocator, "type List<T> = Array<T>;\nlet x = 1;");
     defer r.deinit();

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -980,7 +980,7 @@ fn parseFlowTypeMember(self: *Parser) ParseError2!NodeIndex {
 // Tuple Type
 // ================================================================
 
-/// 튜플 타입: [T, U]
+/// 튜플 타입: [T, U] / [name: T, name?: U] (Flow 0.212+ labeled tuple element)
 fn parseTupleType(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
     try self.advance(); // skip '['
@@ -988,6 +988,29 @@ fn parseTupleType(self: *Parser) ParseError2!NodeIndex {
     const scratch_top = self.saveScratch();
     while (self.current() != .r_bracket and self.current() != .eof) {
         const loop_guard_pos = self.scanner.token.span.start;
+
+        // Labeled tuple element: `name: T` 또는 `name?: T` (Flow 0.212+).
+        // 라벨은 문서화 메타데이터일 뿐이라 type strip 시 무시하고 type만 보존.
+        // `name?` 다음이 `:`이 아니면 일반 type으로 후퇴해야 안전 (ts.zig 패턴 미러).
+        if (self.current() == .identifier) {
+            const next = try self.peekNextKind();
+            const is_labeled = next == .colon or (next == .question and blk: {
+                const saved = self.saveState();
+                const err_count = self.errors.items.len;
+                self.advance() catch break :blk false;
+                self.advance() catch break :blk false;
+                const after_question = self.current();
+                self.restoreState(saved);
+                self.rollbackErrors(err_count);
+                break :blk after_question == .colon;
+            });
+            if (is_labeled) {
+                try self.advance();
+                _ = try self.eat(.question);
+                try self.expect(.colon);
+            }
+        }
+
         const ty = try parseType(self);
         try self.scratch.append(self.allocator, ty);
         if (!try self.eat(.comma)) break;

--- a/tests/integration/tests/fixtures/flow-libs/draft-js/src/component/base/DraftEditor.react.js
+++ b/tests/integration/tests/fixtures/flow-libs/draft-js/src/component/base/DraftEditor.react.js
@@ -1,0 +1,687 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall draft_js
+ * @preventMunge
+ */
+
+'use strict';
+
+import type {BlockMap} from 'BlockMap';
+import type {DraftEditorModes} from 'DraftEditorModes';
+import type {DraftEditorDefaultProps, DraftEditorProps} from 'DraftEditorProps';
+import type {DraftScrollPosition} from 'DraftScrollPosition';
+
+const DefaultDraftBlockRenderMap = require('DefaultDraftBlockRenderMap');
+const DefaultDraftInlineStyle = require('DefaultDraftInlineStyle');
+const DraftEditorCompositionHandler = require('DraftEditorCompositionHandler');
+const DraftEditorContents = require('DraftEditorContents.react');
+const DraftEditorDragHandler = require('DraftEditorDragHandler');
+const DraftEditorEditHandler = require('DraftEditorEditHandler');
+const flushControlled = require('DraftEditorFlushControlled');
+const DraftEditorPlaceholder = require('DraftEditorPlaceholder.react');
+const DraftEffects = require('DraftEffects');
+const EditorState = require('EditorState');
+const Scroll = require('Scroll');
+const Style = require('Style');
+const UserAgent = require('UserAgent');
+
+const cx = require('cx');
+const generateRandomKey = require('generateRandomKey');
+const getDefaultKeyBinding = require('getDefaultKeyBinding');
+const getScrollPosition = require('getScrollPosition');
+const gkx = require('gkx');
+const invariant = require('invariant');
+const isHTMLElement = require('isHTMLElement');
+const nullthrows = require('nullthrows');
+const React = require('react');
+
+const isIE = UserAgent.isBrowser('IE');
+
+// IE does not support the `input` event on contentEditable, so we can't
+// observe spellcheck behavior.
+const allowSpellCheck = !isIE;
+
+// Define a set of handler objects to correspond to each possible `mode`
+// of editor behavior.
+const handlerMap = {
+  edit: DraftEditorEditHandler,
+  composite: DraftEditorCompositionHandler,
+  drag: DraftEditorDragHandler,
+  cut: null,
+  render: null,
+};
+
+type State = {contentsKey: number};
+
+let didInitODS = false;
+
+class UpdateDraftEditorFlags extends React.Component<{
+  editor: DraftEditor,
+  editorState: EditorState,
+}> {
+  render(): React.Node {
+    return null;
+  }
+  componentDidMount(): mixed {
+    this._update();
+  }
+  componentDidUpdate(): mixed {
+    this._update();
+  }
+  _update() {
+    const editor = this.props.editor;
+    /**
+     * Sometimes a render triggers a 'focus' or other event, and that will
+     * schedule a second render pass.
+     * In order to make sure the second render pass gets the latest editor
+     * state, we update it here.
+     * Example:
+     * render #1
+     * +
+     * |
+     * | cWU -> Nothing ... latestEditorState = STALE_STATE :(
+     * |
+     * | render -> this.props.editorState = FRESH_STATE
+     * | +         *and* set latestEditorState = FRESH_STATE
+     *   |
+     * | |
+     * | +--> triggers 'focus' event, calling 'handleFocus' with latestEditorState
+     * |                                                +
+     * |                                                |
+     * +>cdU -> latestEditorState = FRESH_STATE         | the 'handleFocus' call schedules render #2
+     *                                                  | with latestEditorState, which is FRESH_STATE
+     *                                                  |
+     * render #2 <--------------------------------------+
+     * +
+     * |
+     * | cwU -> nothing updates
+     * |
+     * | render -> this.props.editorState = FRESH_STATE which was passed in above
+     * |
+     * +>cdU fires and resets latestEditorState = FRESH_STATE
+     * ---
+     * Note that if we don't set latestEditorState in 'render' in the above
+     * diagram, then STALE_STATE gets passed to render #2.
+     */
+    editor._latestEditorState = this.props.editorState;
+
+    /**
+     * The reason we set this 'blockSelectEvents' flag is that  IE will fire a
+     * 'selectionChange' event when we programmatically change the selection,
+     * meaning it would trigger a new select event while we are in the middle
+     * of updating.
+     * We found that the 'selection.addRange' was what triggered the stray
+     * selectionchange event in IE.
+     * To be clear - we have not been able to reproduce specific bugs related
+     * to this stray selection event, but have recorded logs that some
+     * conditions do cause it to get bumped into during editOnSelect.
+     */
+    editor._blockSelectEvents = true;
+  }
+}
+
+const EDITOR_ID_PLACEHOLDER = '{{editor_id_placeholder}}';
+
+/**
+ * `DraftEditor` is the root editor component. It composes a `contentEditable`
+ * div, and provides a wide variety of useful function props for managing the
+ * state of the editor. See `DraftEditorProps` for details.
+ */
+class DraftEditor extends React.Component<DraftEditorProps, State> {
+  static defaultProps: DraftEditorDefaultProps = {
+    ariaDescribedBy: EDITOR_ID_PLACEHOLDER,
+    blockRenderMap: DefaultDraftBlockRenderMap,
+    blockRendererFn() {
+      return null;
+    },
+    blockStyleFn() {
+      return '';
+    },
+    keyBindingFn: getDefaultKeyBinding,
+    readOnly: false,
+    spellCheck: false,
+    stripPastedStyles: false,
+  };
+
+  _blockSelectEvents: boolean;
+  _clipboard: ?BlockMap;
+  _handler: ?Object;
+  _dragCount: number;
+  _internalDrag: boolean = false;
+  _editorKey: string;
+  _placeholderAccessibilityID: string;
+  _latestEditorState: EditorState;
+  _latestCommittedEditorState: EditorState;
+  _pendingStateFromBeforeInput: void | EditorState;
+
+  /**
+   * Define proxies that can route events to the current handler.
+   */
+  _onBeforeInput: Function;
+  _onBlur: Function;
+  _onCharacterData: Function;
+  _onCompositionEnd: Function;
+  _onCompositionStart: Function;
+  _onCopy: Function;
+  _onCut: Function;
+  _onDragEnd: Function;
+  _onDragOver: Function;
+  _onDragStart: Function;
+  _onDrop: Function;
+  _onInput: Function;
+  _onFocus: Function;
+  _onKeyDown: Function;
+  _onKeyPress: Function;
+  _onKeyUp: Function;
+  _onMouseDown: Function;
+  _onMouseUp: Function;
+  _onPaste: Function;
+  _onSelect: Function;
+
+  editor: ?HTMLElement;
+  editorContainer: ?HTMLElement;
+  getEditorKey: () => string;
+  // See `restoreEditorDOM()`.
+  state: State = {contentsKey: 0};
+
+  constructor(props: DraftEditorProps) {
+    super(props);
+
+    this._blockSelectEvents = false;
+    this._clipboard = null;
+    this._handler = null;
+    this._dragCount = 0;
+    this._editorKey = props.editorKey || generateRandomKey();
+    this._placeholderAccessibilityID = 'placeholder-' + this._editorKey;
+    this._latestEditorState = props.editorState;
+    this._latestCommittedEditorState = props.editorState;
+
+    this._onBeforeInput = this._buildHandler('onBeforeInput');
+    this._onBlur = this._buildHandler('onBlur');
+    this._onCharacterData = this._buildHandler('onCharacterData');
+    this._onCompositionEnd = this._buildHandler('onCompositionEnd');
+    this._onCompositionStart = this._buildHandler('onCompositionStart');
+    this._onCopy = this._buildHandler('onCopy');
+    this._onCut = this._buildHandler('onCut');
+    this._onDragEnd = this._buildHandler('onDragEnd');
+    this._onDragOver = this._buildHandler('onDragOver');
+    this._onDragStart = this._buildHandler('onDragStart');
+    this._onDrop = this._buildHandler('onDrop');
+    this._onInput = this._buildHandler('onInput');
+    this._onFocus = this._buildHandler('onFocus');
+    this._onKeyDown = this._buildHandler('onKeyDown');
+    this._onKeyPress = this._buildHandler('onKeyPress');
+    this._onKeyUp = this._buildHandler('onKeyUp');
+    this._onMouseDown = this._buildHandler('onMouseDown');
+    this._onMouseUp = this._buildHandler('onMouseUp');
+    this._onPaste = this._buildHandler('onPaste');
+    this._onSelect = this._buildHandler('onSelect');
+
+    this.getEditorKey = () => this._editorKey;
+
+    if (__DEV__) {
+      [
+        'onDownArrow',
+        'onEscape',
+        'onLeftArrow',
+        'onRightArrow',
+        'onTab',
+        'onUpArrow',
+      ].forEach(propName => {
+        if (props.hasOwnProperty(propName)) {
+          // eslint-disable-next-line fb-www/no-console
+          console.warn(
+            `Supplying an \`${propName}\` prop to \`DraftEditor\` has ` +
+              'been deprecated. If your handler needs access to the keyboard ' +
+              'event, supply a custom `keyBindingFn` prop that falls back to ' +
+              'the default one (eg. https://is.gd/wHKQ3W).',
+          );
+        }
+      });
+    }
+  }
+
+  /**
+   * Build a method that will pass the event to the specified handler method.
+   * This allows us to look up the correct handler function for the current
+   * editor mode, if any has been specified.
+   */
+  _buildHandler(eventName: string): Function {
+    // Wrap event handlers in `flushControlled`. In sync mode, this is
+    // effectively a no-op. In async mode, this ensures all updates scheduled
+    // inside the handler are flushed before React yields to the browser.
+    return e => {
+      if (!this.props.readOnly) {
+        const method = this._handler && this._handler[eventName];
+        if (method) {
+          if (flushControlled) {
+            flushControlled(() => method(this, e));
+          } else {
+            method(this, e);
+          }
+        }
+      }
+    };
+  }
+
+  _handleEditorContainerRef: (HTMLElement | null) => void = (
+    node: HTMLElement | null,
+  ): void => {
+    this.editorContainer = node;
+    // Instead of having a direct ref on the child, we'll grab it here.
+    // This is safe as long as the rendered structure is static (which it is).
+    // This lets the child support ref={props.editorRef} without merging refs.
+    this.editor = node !== null ? (node: any).firstChild : null;
+  };
+
+  _showPlaceholder(): boolean {
+    return (
+      !!this.props.placeholder &&
+      !this.props.editorState.isInCompositionMode() &&
+      !this.props.editorState.getCurrentContent().hasText()
+    );
+  }
+
+  _renderPlaceholder(): React.Node {
+    if (this._showPlaceholder()) {
+      const placeHolderProps = {
+        ariaHidden: this.props.placeholderAriaHidden,
+        accessibilityID: this._placeholderAccessibilityID,
+        className: this.props.placeholderClassName,
+        editorState: this.props.editorState,
+        text: nullthrows(this.props.placeholder),
+        textAlignment: this.props.textAlignment,
+      };
+
+      /* $FlowFixMe[incompatible-type] (>=0.112.0 site=www,mobile) This comment
+       * suppresses an error found when Flow v0.112 was deployed. To see the
+       * error delete this comment and run Flow. */
+      return <DraftEditorPlaceholder {...placeHolderProps} />;
+    }
+    return null;
+  }
+
+  /**
+   * returns ariaDescribedBy prop with EDITOR_ID_PLACEHOLDER replaced with
+   * the DOM id of the placeholder (if it exists)
+   * @returns aria-describedby attribute value
+   */
+  _renderARIADescribedBy(): ?string {
+    const describedBy = this.props.ariaDescribedBy || '';
+    if (this.props.placeholderAriaHidden) {
+      return describedBy === EDITOR_ID_PLACEHOLDER ? undefined : describedBy;
+    }
+    const placeholderID = this._showPlaceholder()
+      ? this._placeholderAccessibilityID
+      : '';
+    return (
+      describedBy.replace(EDITOR_ID_PLACEHOLDER, placeholderID) || undefined
+    );
+  }
+
+  render(): React.Node {
+    const {
+      blockRenderMap,
+      blockRendererFn,
+      blockStyleFn,
+      customStyleFn,
+      customStyleMap,
+      editorState,
+      preventScroll,
+      readOnly,
+      textAlignment,
+      textDirectionality,
+    } = this.props;
+
+    const rootClass = cx({
+      'DraftEditor/root': true,
+      'DraftEditor/alignLeft': textAlignment === 'left',
+      'DraftEditor/alignRight': textAlignment === 'right',
+      'DraftEditor/alignCenter': textAlignment === 'center',
+    });
+
+    const contentStyle = {
+      outline: 'none',
+      // fix parent-draggable Safari bug. #1326
+      userSelect: 'text',
+      WebkitUserSelect: 'text',
+      whiteSpace: 'pre-wrap',
+      wordWrap: 'break-word',
+    };
+
+    // The aria-expanded and aria-haspopup properties should only be rendered
+    // for a combobox.
+    /* $FlowFixMe[prop-missing] (>=0.68.0 site=www,mobile) This comment
+     * suppresses an error found when Flow v0.68 was deployed. To see the error
+     * delete this comment and run Flow. */
+    const ariaRole = this.props.role || 'textbox';
+    const ariaExpanded =
+      ariaRole === 'combobox' ? !!this.props.ariaExpanded : null;
+
+    const editorContentsProps = {
+      blockRenderMap,
+      blockRendererFn,
+      blockStyleFn,
+      customStyleMap: {
+        ...DefaultDraftInlineStyle,
+        ...customStyleMap,
+      },
+      customStyleFn,
+      editorKey: this._editorKey,
+      editorState,
+      preventScroll,
+      textDirectionality,
+    };
+
+    const contentClassName =
+      this.props.contentClassName != null
+        ? this.props.contentClassName + ' '
+        : '';
+
+    return (
+      <div className={rootClass}>
+        {this._renderPlaceholder()}
+        <div
+          className={cx('DraftEditor/editorContainer')}
+          ref={this._handleEditorContainerRef}>
+          {/* Note: _handleEditorContainerRef assumes this div won't move: */}
+          <div
+            aria-activedescendant={
+              readOnly ? null : this.props.ariaActiveDescendantID
+            }
+            aria-autocomplete={readOnly ? null : this.props.ariaAutoComplete}
+            aria-controls={readOnly ? null : this.props.ariaControls}
+            aria-describedby={this._renderARIADescribedBy()}
+            aria-expanded={readOnly ? null : ariaExpanded}
+            aria-label={this.props.ariaLabel ?? this.props.placeholder}
+            aria-labelledby={this.props.ariaLabelledBy}
+            aria-multiline={this.props.ariaMultiline}
+            aria-owns={readOnly ? null : this.props.ariaOwneeID}
+            aria-required={this.props.ariaRequired}
+            autoCapitalize={this.props.autoCapitalize}
+            autoComplete={this.props.autoComplete}
+            autoCorrect={this.props.autoCorrect}
+            className={
+              // eslint-disable-next-line fb-www/cx-concat
+              contentClassName +
+              cx({
+                // Chrome's built-in translation feature mutates the DOM in ways
+                // that Draft doesn't expect (ex: adding <font> tags inside
+                // DraftEditorLeaf spans) and causes problems. We add notranslate
+                // here which makes its autotranslation skip over this subtree.
+                notranslate: !readOnly,
+                'public/DraftEditor/content': true,
+              })
+            }
+            contentEditable={!readOnly}
+            data-testid={this.props.webDriverTestID}
+            onBeforeInput={this._onBeforeInput}
+            onBlur={this._onBlur}
+            onCompositionEnd={this._onCompositionEnd}
+            onCompositionStart={this._onCompositionStart}
+            onCopy={this._onCopy}
+            onCut={this._onCut}
+            onDragEnd={this._onDragEnd}
+            onDragEnter={this.onDragEnter}
+            onDragLeave={this.onDragLeave}
+            onDragOver={this._onDragOver}
+            onDragStart={this._onDragStart}
+            onDrop={this._onDrop}
+            onFocus={this._onFocus}
+            onInput={this._onInput}
+            onKeyDown={this._onKeyDown}
+            onKeyPress={this._onKeyPress}
+            onKeyUp={this._onKeyUp}
+            onMouseDown={this._onMouseDown}
+            onMouseUp={this._onMouseUp}
+            onPaste={this._onPaste}
+            onSelect={this._onSelect}
+            ref={this.props.editorRef}
+            role={readOnly ? null : ariaRole}
+            spellCheck={allowSpellCheck && this.props.spellCheck}
+            style={contentStyle}
+            suppressContentEditableWarning
+            tabIndex={this.props.tabIndex}>
+            {/*
+              Needs to come earlier in the tree as a sibling (not ancestor) of
+              all DraftEditorLeaf nodes so it's first in postorder traversal.
+            */}
+            <UpdateDraftEditorFlags editor={this} editorState={editorState} />
+            <DraftEditorContents
+              {...editorContentsProps}
+              key={'contents' + this.state.contentsKey}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  componentDidMount(): void {
+    this._blockSelectEvents = false;
+    if (!didInitODS && gkx('draft_ods_enabled')) {
+      didInitODS = true;
+      DraftEffects.initODS();
+    }
+    this.setMode('edit');
+
+    /**
+     * IE has a hardcoded "feature" that attempts to convert link text into
+     * anchors in contentEditable DOM. This breaks the editor's expectations of
+     * the DOM, and control is lost. Disable it to make IE behave.
+     * See: http://blogs.msdn.com/b/ieinternals/archive/2010/09/15/
+     * ie9-beta-minor-change-list.aspx
+     */
+    if (isIE) {
+      // editor can be null after mounting
+      // https://stackoverflow.com/questions/44074747/componentdidmount-called-before-ref-callback
+      if (!this.editor) {
+        global.execCommand('AutoUrlDetect', false, false);
+      } else {
+        this.editor.ownerDocument.execCommand('AutoUrlDetect', false, false);
+      }
+    }
+  }
+
+  componentDidUpdate(): void {
+    this._blockSelectEvents = false;
+    this._latestEditorState = this.props.editorState;
+    this._latestCommittedEditorState = this.props.editorState;
+  }
+
+  /**
+   * Used via `this.focus()`.
+   *
+   * Force focus back onto the editor node.
+   *
+   * We attempt to preserve scroll position when focusing. You can also pass
+   * a specified scroll position (for cases like `cut` behavior where it should
+   * be restored to a known position).
+   */
+  // eslint-disable-next-line fb-www/extra-arrow-initializer
+  focus: (scrollPosition?: DraftScrollPosition) => void = (
+    scrollPosition?: DraftScrollPosition,
+  ): void => {
+    const {editorState} = this.props;
+    const alreadyHasFocus = editorState.getSelection().getHasFocus();
+    const editorNode = this.editor;
+
+    if (!editorNode) {
+      // once in a while people call 'focus' in a setTimeout, and the node has
+      // been deleted, so it can be null in that case.
+      return;
+    }
+
+    const scrollParent = Style.getScrollParent(editorNode);
+    const {x, y} = scrollPosition || getScrollPosition(scrollParent);
+
+    invariant(isHTMLElement(editorNode), 'editorNode is not an HTMLElement');
+
+    editorNode.focus({preventScroll: true});
+
+    // Restore scroll position
+    if (scrollParent === window) {
+      window.scrollTo(x, y);
+    } else {
+      Scroll.setTop(scrollParent, y);
+    }
+
+    // On Chrome and Safari, calling focus on contenteditable focuses the
+    // cursor at the first character. This is something you don't expect when
+    // you're clicking on an input element but not directly on a character.
+    // Put the cursor back where it was before the blur.
+    if (!alreadyHasFocus) {
+      this.update(
+        EditorState.forceSelection(editorState, editorState.getSelection()),
+      );
+    }
+  };
+
+  // eslint-disable-next-line fb-www/extra-arrow-initializer
+  blur: () => void = (): void => {
+    const editorNode = this.editor;
+    if (!editorNode) {
+      return;
+    }
+    invariant(isHTMLElement(editorNode), 'editorNode is not an HTMLElement');
+    editorNode.blur();
+  };
+
+  /**
+   * Used via `this.setMode(...)`.
+   *
+   * Set the behavior mode for the editor component. This switches the current
+   * handler module to ensure that DOM events are managed appropriately for
+   * the active mode.
+   */
+  // eslint-disable-next-line fb-www/extra-arrow-initializer
+  setMode: DraftEditorModes => void = (mode: DraftEditorModes): void => {
+    const {onPaste, onCut, onCopy} = this.props;
+    const editHandler = {...handlerMap.edit};
+
+    if (onPaste) {
+      /* $FlowFixMe[incompatible-type] (>=0.117.0 site=www,mobile) This comment
+       * suppresses an error found when Flow v0.117 was deployed. To see the
+       * error delete this comment and run Flow. */
+      editHandler.onPaste = onPaste;
+    }
+
+    if (onCut) {
+      editHandler.onCut = onCut;
+    }
+
+    if (onCopy) {
+      editHandler.onCopy = onCopy;
+    }
+
+    const handler = {
+      ...handlerMap,
+      edit: editHandler,
+    };
+    this._handler = handler[mode];
+  };
+
+  // eslint-disable-next-line fb-www/extra-arrow-initializer
+  exitCurrentMode: () => void = (): void => {
+    this.setMode('edit');
+  };
+
+  /**
+   * Used via `this.restoreEditorDOM()`.
+   *
+   * Force a complete re-render of the DraftEditorContents based on the current
+   * EditorState. This is useful when we know we are going to lose control of
+   * the DOM state (cut command, IME) and we want to make sure that
+   * reconciliation occurs on a version of the DOM that is synchronized with
+   * our EditorState.
+   */
+  // eslint-disable-next-line fb-www/extra-arrow-initializer
+  restoreEditorDOM: (scrollPosition?: DraftScrollPosition) => void = (
+    scrollPosition?: DraftScrollPosition,
+  ): void => {
+    // Wrap state updates in `flushControlled`. In sync mode, this is
+    // effectively a no-op. In async mode, this ensures all updates scheduled
+    // inside are flushed before React yields to the browser.
+    if (flushControlled) {
+      flushControlled(() =>
+        this.setState({contentsKey: this.state.contentsKey + 1}, () => {
+          this.focus(scrollPosition);
+        }),
+      );
+    } else {
+      this.setState({contentsKey: this.state.contentsKey + 1}, () => {
+        this.focus(scrollPosition);
+      });
+    }
+  };
+
+  /**
+   * Used via `this.setClipboard(...)`.
+   *
+   * Set the clipboard state for a cut/copy event.
+   */
+  // eslint-disable-next-line fb-www/extra-arrow-initializer
+  setClipboard: (?BlockMap) => void = (clipboard: ?BlockMap): void => {
+    this._clipboard = clipboard;
+  };
+
+  /**
+   * Used via `this.getClipboard()`.
+   *
+   * Retrieve the clipboard state for a cut/copy event.
+   */
+  // eslint-disable-next-line fb-www/extra-arrow-initializer
+  getClipboard: () => ?BlockMap = (): ?BlockMap => {
+    return this._clipboard;
+  };
+
+  /**
+   * Used via `this.update(...)`.
+   *
+   * Propagate a new `EditorState` object to higher-level components. This is
+   * the method by which event handlers inform the `DraftEditor` component of
+   * state changes. A component that composes a `DraftEditor` **must** provide
+   * an `onChange` prop to receive state updates passed along from this
+   * function.
+   */
+  // eslint-disable-next-line fb-www/extra-arrow-initializer
+  update: EditorState => void = (editorState: EditorState): void => {
+    const onChange = this.props.onChange;
+    this._latestEditorState = editorState;
+    // Wrap state updates in `flushControlled`. In sync mode, this is
+    // effectively a no-op. In async mode, this ensures all updates scheduled
+    // inside are flushed before React yields to the browser.
+    if (flushControlled) {
+      flushControlled(() => onChange(editorState));
+    } else {
+      onChange(editorState);
+    }
+  };
+
+  /**
+   * Used in conjunction with `onDragLeave()`, by counting the number of times
+   * a dragged element enters and leaves the editor (or any of its children),
+   * to determine when the dragged element absolutely leaves the editor.
+   */
+  onDragEnter: () => void = (): void => {
+    this._dragCount++;
+  };
+
+  /**
+   * See `onDragEnter()`.
+   */
+  onDragLeave: () => void = (): void => {
+    this._dragCount--;
+    if (this._dragCount === 0) {
+      this.exitCurrentMode();
+    }
+  };
+}
+
+module.exports = DraftEditor;

--- a/tests/integration/tests/fixtures/flow-libs/draft-js/src/component/handlers/edit/editOnInput.js
+++ b/tests/integration/tests/fixtures/flow-libs/draft-js/src/component/handlers/edit/editOnInput.js
@@ -1,0 +1,228 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall draft_js
+ */
+
+'use strict';
+
+import type {SelectionObject} from 'DraftDOMTypes';
+import type DraftEditor from 'DraftEditor.react';
+
+const DraftModifier = require('DraftModifier');
+const DraftOffsetKey = require('DraftOffsetKey');
+const EditorState = require('EditorState');
+const UserAgent = require('UserAgent');
+
+const {notEmptyKey} = require('draftKeyUtils');
+const findAncestorOffsetKey = require('findAncestorOffsetKey');
+const keyCommandPlainBackspace = require('keyCommandPlainBackspace');
+const nullthrows = require('nullthrows');
+
+const isGecko = UserAgent.isEngine('Gecko');
+
+const DOUBLE_NEWLINE = '\n\n';
+
+function onInputType(inputType: string, editorState: EditorState): EditorState {
+  switch (inputType) {
+    case 'deleteContentBackward':
+      return keyCommandPlainBackspace(editorState);
+  }
+  return editorState;
+}
+
+/**
+ * This function serves two purposes
+ *
+ * 1. To update the editorState and call onChange method with the new
+ * editorState. This editorState is calculated in editOnBeforeInput but the
+ * onChange method is not called with the new state until this method does it.
+ * It is done to handle a specific case where certain character inputs might
+ * be replaced with something else. E.g. snippets ('rc' might be replaced
+ * with boilerplate code for react component). More information on the
+ * exact problem can be found here -
+ * https://github.com/facebook/draft-js/commit/07892ba479bd4dfc6afd1e0ed179aaf51cd138b1
+ *
+ * 2. intended to handle spellcheck and autocorrect changes,
+ * which occur in the DOM natively without any opportunity to observe or
+ * interpret the changes before they occur.
+ *
+ * The `input` event fires in contentEditable elements reliably for non-IE
+ * browsers, immediately after changes occur to the editor DOM. Since our other
+ * handlers override or otherwise handle cover other varieties of text input,
+ * the DOM state should match the model in all controlled input cases. Thus,
+ * when an `input` change leads to a DOM/model mismatch, the change should be
+ * due to a spellcheck change, and we can incorporate it into our model.
+ */
+function editOnInput(editor: DraftEditor, event: ?SyntheticInputEvent<>): void {
+  // This will happen for most simple insertions. The new state is already
+  // computed. Let's just call "editor.update". Things should match nicely so
+  // this function will exit below where we check "domText === modelText".
+  if (editor._pendingStateFromBeforeInput !== undefined) {
+    editor.update(editor._pendingStateFromBeforeInput);
+    editor._pendingStateFromBeforeInput = undefined;
+  }
+
+  // at this point editor is not null for sure (after input)
+  const castedEditorElement: HTMLElement = (editor.editor: any);
+  const domSelection: SelectionObject =
+    castedEditorElement.ownerDocument.defaultView.getSelection();
+
+  const {anchorNode, isCollapsed} = domSelection;
+  const isNotTextOrElementNode =
+    anchorNode?.nodeType !== Node.TEXT_NODE &&
+    anchorNode?.nodeType !== Node.ELEMENT_NODE;
+
+  if (anchorNode == null || isNotTextOrElementNode) {
+    // TODO: (t16149272) figure out context for this change
+    return;
+  }
+
+  if (
+    anchorNode.nodeType === Node.TEXT_NODE &&
+    (anchorNode.previousSibling !== null || anchorNode.nextSibling !== null)
+  ) {
+    // When typing at the beginning of a visual line, Chrome splits the text
+    // nodes into two. Why? No one knows. This commit is suspicious:
+    // https://chromium.googlesource.com/chromium/src/+/a3b600981286b135632371477f902214c55a1724
+    // To work around, we'll merge the sibling text nodes back into this one.
+    const span = anchorNode.parentNode;
+    if (span == null) {
+      // Handle null-parent case.
+      return;
+    }
+    anchorNode.nodeValue = span.textContent;
+    for (
+      let child = span.firstChild;
+      child != null;
+      child = child.nextSibling
+    ) {
+      if (child !== anchorNode) {
+        span.removeChild(child);
+      }
+    }
+  }
+
+  let domText = anchorNode.textContent;
+  const editorState = editor._latestEditorState;
+  const offsetKey = nullthrows(findAncestorOffsetKey(anchorNode));
+  const {blockKey, decoratorKey, leafKey} = DraftOffsetKey.decode(offsetKey);
+
+  const {start, end} = editorState
+    .getBlockTree(blockKey)
+    .getIn([decoratorKey, 'leaves', leafKey]);
+
+  const content = editorState.getCurrentContent();
+  const block = content.getBlockForKey(blockKey);
+  const modelText = block.getText().slice(start, end);
+
+  // Special-case soft newlines here. If the DOM text ends in a soft newline,
+  // we will have manually inserted an extra soft newline in DraftEditorLeaf.
+  // We want to remove this extra newline for the purpose of our comparison
+  // of DOM and model text.
+  if (domText.endsWith(DOUBLE_NEWLINE)) {
+    domText = domText.slice(0, -1);
+  }
+
+  // No change -- the DOM is up to date. Nothing to do here.
+  if (domText === modelText) {
+    // This can be buggy for some Android keyboards because they don't fire
+    // standard onkeydown/pressed events and only fired editOnInput
+    // so domText is already changed by the browser and ends up being equal
+    // to modelText unexpectedly.
+    // Newest versions of Android support the dom-inputevent-inputtype
+    // and we can use the `inputType` to properly apply the state changes.
+
+    /* $FlowFixMe[prop-missing] inputType is only defined on a draft of a
+     * standard. https://w3c.github.io/input-events/#dom-inputevent-inputtype
+     */
+    const inputType = event ? event.nativeEvent.inputType : undefined;
+    if (inputType) {
+      const newEditorState = onInputType(inputType, editorState);
+      if (newEditorState !== editorState) {
+        editor.restoreEditorDOM();
+        editor.update(newEditorState);
+        return;
+      }
+    }
+    return;
+  }
+
+  const selection = editorState.getSelection();
+
+  // We'll replace the entire leaf with the text content of the target.
+  const targetRange = selection.merge({
+    anchorOffset: start,
+    focusOffset: end,
+    isBackward: false,
+  });
+
+  const entityKey = block.getEntityAt(start);
+  const entity = notEmptyKey(entityKey) ? content.getEntity(entityKey) : null;
+  const entityType = entity != null ? entity.getMutability() : null;
+  const preserveEntity = entityType === 'MUTABLE';
+
+  // Immutable or segmented entities cannot properly be handled by the
+  // default browser undo, so we have to use a different change type to
+  // force using our internal undo method instead of falling through to the
+  // native browser undo.
+  const changeType = preserveEntity ? 'spellcheck-change' : 'apply-entity';
+
+  const newContent = DraftModifier.replaceText(
+    content,
+    targetRange,
+    domText,
+    block.getInlineStyleAt(start),
+    preserveEntity ? block.getEntityAt(start) : null,
+  );
+
+  let anchorOffset, focusOffset, startOffset, endOffset;
+
+  const isDeleteWordForward =
+    // $FlowFixMe[prop-missing] Flow doesn't know if can be an InputEvent w/ inputType
+    event?.nativeEvent?.inputType === 'deleteWordForward';
+
+  // Adjust our selection if appropriate. If we're deleting the word forward, we
+  // don't do this, since we want to stay at the same offset.
+  if (isGecko && !isDeleteWordForward) {
+    // Firefox selection does not change while the context menu is open, so
+    // we preserve the anchor and focus values of the DOM selection.
+    anchorOffset = domSelection.anchorOffset;
+    focusOffset = domSelection.focusOffset;
+    startOffset = start + Math.min(anchorOffset, focusOffset);
+    endOffset = startOffset + Math.abs(anchorOffset - focusOffset);
+    anchorOffset = startOffset;
+    focusOffset = endOffset;
+  } else if (!isDeleteWordForward) {
+    // Browsers other than Firefox may adjust DOM selection while the context
+    // menu is open, and Safari autocorrect is prone to providing an inaccurate
+    // DOM selection. Don't trust it. Instead, use our existing SelectionState
+    // and adjust it based on the number of characters changed during the
+    // mutation.
+    const charDelta = domText.length - modelText.length;
+    startOffset = selection.getStartOffset();
+    endOffset = selection.getEndOffset();
+
+    anchorOffset = isCollapsed ? endOffset + charDelta : startOffset;
+    focusOffset = endOffset + charDelta;
+  }
+
+  // Segmented entities are completely or partially removed when their
+  // text content changes. For this case we do not want any text to be selected
+  // after the change, so we are not merging the selection.
+  const contentWithAdjustedDOMSelection = newContent.merge({
+    selectionBefore: content.getSelectionAfter(),
+    selectionAfter: selection.merge({anchorOffset, focusOffset}),
+  });
+
+  editor.update(
+    EditorState.push(editorState, contentWithAdjustedDOMSelection, changeType),
+  );
+}
+
+module.exports = editOnInput;

--- a/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/decorators/CompositeDraftDecorator.js
+++ b/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/decorators/CompositeDraftDecorator.js
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall draft_js
+ */
+
+'use strict';
+
+import type {BlockNodeRecord} from 'BlockNodeRecord';
+import type ContentState from 'ContentState';
+import type {DraftDecorator} from 'DraftDecorator';
+
+const Immutable = require('immutable');
+
+const {List} = Immutable;
+
+const DELIMITER = '.';
+
+/**
+ * A CompositeDraftDecorator traverses through a list of DraftDecorator
+ * instances to identify sections of a ContentBlock that should be rendered
+ * in a "decorated" manner. For example, hashtags, mentions, and links may
+ * be intended to stand out visually, be rendered as anchors, etc.
+ *
+ * The list of decorators supplied to the constructor will be used in the
+ * order they are provided. This allows the caller to specify a priority for
+ * string matching, in case of match collisions among decorators.
+ *
+ * For instance, I may have a link with a `#` in its text. Though this section
+ * of text may match our hashtag decorator, it should not be treated as a
+ * hashtag. I should therefore list my link DraftDecorator
+ * before my hashtag DraftDecorator when constructing this composite
+ * decorator instance.
+ *
+ * Thus, when a collision like this is encountered, the earlier match is
+ * preserved and the new match is discarded.
+ */
+class CompositeDraftDecorator {
+  _decorators: $ReadOnlyArray<DraftDecorator>;
+
+  constructor(decorators: $ReadOnlyArray<DraftDecorator>) {
+    // Copy the decorator array, since we use this array order to determine
+    // precedence of decoration matching. If the array is mutated externally,
+    // we don't want to be affected here.
+    this._decorators = decorators.slice();
+  }
+
+  /**
+   * Returns true if this CompositeDraftDecorator has the same decorators as
+   * the given array. This does a reference check, so the decorators themselves
+   * have to be the same objects.
+   */
+  isCompositionOfDecorators(arr: $ReadOnlyArray<DraftDecorator>): boolean {
+    if (this._decorators.length !== arr.length) {
+      return false;
+    }
+    for (let ii = 0; ii < arr.length; ii++) {
+      if (this._decorators[ii] !== arr[ii]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  getDecorators(): $ReadOnlyArray<DraftDecorator> {
+    return this._decorators;
+  }
+
+  getDecorations(
+    block: BlockNodeRecord,
+    contentState: ContentState,
+  ): List<?string> {
+    const decorations = Array(block.getText().length).fill(null);
+
+    this._decorators.forEach((decorator: DraftDecorator, ii: number) => {
+      let counter = 0;
+      const strategy = decorator.strategy;
+      function getDecorationsChecker(start: number, end: number) {
+        // Find out if any of our matching range is already occupied
+        // by another decorator. If so, discard the match. Otherwise, store
+        // the component key for rendering.
+        if (canOccupySlice(decorations, start, end)) {
+          occupySlice(decorations, start, end, ii + DELIMITER + counter);
+          counter++;
+        }
+      }
+      strategy(block, getDecorationsChecker, contentState);
+    });
+
+    return List(decorations);
+  }
+
+  getComponentForKey(key: string): Function {
+    const componentKey = parseInt(key.split(DELIMITER)[0], 10);
+    return this._decorators[componentKey].component;
+  }
+
+  getPropsForKey(key: string): ?Object {
+    const componentKey = parseInt(key.split(DELIMITER)[0], 10);
+    return this._decorators[componentKey].props;
+  }
+}
+
+/**
+ * Determine whether we can occupy the specified slice of the decorations
+ * array.
+ */
+function canOccupySlice(
+  decorations: Array<?string>,
+  start: number,
+  end: number,
+): boolean {
+  for (let ii = start; ii < end; ii++) {
+    if (decorations[ii] != null) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Splice the specified component into our decoration array at the desired
+ * range.
+ */
+function occupySlice(
+  targetArr: Array<?string>,
+  start: number,
+  end: number,
+  componentKey: string,
+): void {
+  for (let ii = start; ii < end; ii++) {
+    targetArr[ii] = componentKey;
+  }
+}
+
+module.exports = CompositeDraftDecorator;

--- a/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/immutable/BlockMapBuilder.js
+++ b/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/immutable/BlockMapBuilder.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall draft_js
+ */
+
+'use strict';
+
+import type {BlockMap} from 'BlockMap';
+import type {BlockNodeRecord} from 'BlockNodeRecord';
+
+const Immutable = require('immutable');
+
+const {OrderedMap} = Immutable;
+
+const BlockMapBuilder = {
+  createFromArray(blocks: Array<BlockNodeRecord>): BlockMap {
+    return OrderedMap(blocks.map(block => [block.getKey(), block]));
+  },
+};
+
+module.exports = BlockMapBuilder;

--- a/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/immutable/CharacterMetadata.js
+++ b/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/immutable/CharacterMetadata.js
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall draft_js
+ */
+
+'use strict';
+
+import type {DraftInlineStyle} from 'DraftInlineStyle';
+
+const {Map, OrderedSet, Record} = require('immutable');
+
+// Immutable.map is typed such that the value for every key in the map
+// must be the same type
+type CharacterMetadataConfigValueType = DraftInlineStyle | ?string;
+type CharacterMetadataConfigRawValueType = Array<string> | ?string;
+
+export type CharacterMetadataRawConfig = {
+  style?: CharacterMetadataConfigRawValueType,
+  entity?: CharacterMetadataConfigRawValueType,
+  ...
+};
+
+type CharacterMetadataConfig = interface {
+  style?: CharacterMetadataConfigValueType,
+  entity?: CharacterMetadataConfigValueType,
+};
+
+const EMPTY_SET = OrderedSet<string>();
+
+const defaultRecord: CharacterMetadataConfig = {
+  style: EMPTY_SET,
+  entity: null,
+};
+
+const CharacterMetadataRecord = (Record(defaultRecord): any);
+
+class CharacterMetadata extends CharacterMetadataRecord {
+  getStyle(): DraftInlineStyle {
+    return this.get('style');
+  }
+
+  getEntity(): ?string {
+    return this.get('entity');
+  }
+
+  hasStyle(style: string): boolean {
+    return this.getStyle().includes(style);
+  }
+
+  static applyStyle(
+    record: CharacterMetadata,
+    style: string,
+  ): CharacterMetadata {
+    const withStyle = record.set('style', record.getStyle().add(style));
+    return CharacterMetadata.create(withStyle);
+  }
+
+  static removeStyle(
+    record: CharacterMetadata,
+    style: string,
+  ): CharacterMetadata {
+    const withoutStyle = record.set('style', record.getStyle().remove(style));
+    return CharacterMetadata.create(withoutStyle);
+  }
+
+  static applyEntity(
+    record: CharacterMetadata,
+    entityKey: ?string,
+  ): CharacterMetadata {
+    const withEntity =
+      record.getEntity() === entityKey
+        ? record
+        : record.set('entity', entityKey);
+    return CharacterMetadata.create(withEntity);
+  }
+
+  /**
+   * Use this function instead of the `CharacterMetadata` constructor.
+   * Since most content generally uses only a very small number of
+   * style/entity permutations, we can reuse these objects as often as
+   * possible.
+   */
+  static create(config?: CharacterMetadataConfig): CharacterMetadata {
+    if (!config) {
+      return EMPTY;
+    }
+
+    const defaultConfig: CharacterMetadataConfig = {
+      style: EMPTY_SET,
+      entity: (null: ?string),
+    };
+
+    // Fill in unspecified properties, if necessary.
+    // $FlowFixMe[incompatible-call] added when improving typing for this parameters
+    const configMap = Map(defaultConfig).merge(config);
+
+    const existing: ?CharacterMetadata = pool.get(configMap);
+    if (existing) {
+      return existing;
+    }
+
+    const newCharacter = new CharacterMetadata(configMap);
+    pool = pool.set(configMap, newCharacter);
+    return newCharacter;
+  }
+
+  static fromJS({
+    style,
+    entity,
+  }: CharacterMetadataRawConfig): CharacterMetadata {
+    return new CharacterMetadata({
+      style: Array.isArray(style) ? OrderedSet(style) : style,
+      entity: Array.isArray(entity) ? OrderedSet(entity) : entity,
+    });
+  }
+}
+
+const EMPTY = new CharacterMetadata();
+let pool: Map<Map<any, any>, CharacterMetadata> = Map([
+  // $FlowFixMe[incompatible-call] added when improving typing for this parameters
+  [Map(defaultRecord), EMPTY],
+]);
+
+CharacterMetadata.EMPTY = EMPTY;
+
+module.exports = CharacterMetadata;

--- a/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/immutable/ContentBlock.js
+++ b/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/immutable/ContentBlock.js
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall draft_js
+ */
+
+'use strict';
+
+import type {BlockNode, BlockNodeConfig, BlockNodeKey} from 'BlockNode';
+import type {DraftBlockType} from 'DraftBlockType';
+import type {DraftInlineStyle} from 'DraftInlineStyle';
+
+const CharacterMetadata = require('CharacterMetadata');
+
+const findRangesImmutable = require('findRangesImmutable');
+const Immutable = require('immutable');
+
+const {List, Map, OrderedSet, Record, Repeat} = Immutable;
+
+const EMPTY_SET = OrderedSet<string>();
+
+const defaultRecord: BlockNodeConfig = {
+  key: '',
+  type: 'unstyled',
+  text: '',
+  characterList: List(),
+  depth: 0,
+  data: Map(),
+};
+
+const ContentBlockRecord = (Record(defaultRecord): any);
+
+const decorateCharacterList = (config: BlockNodeConfig): BlockNodeConfig => {
+  if (!config) {
+    return config;
+  }
+
+  const {characterList, text} = config;
+
+  if (text && !characterList) {
+    config.characterList = List(Repeat(CharacterMetadata.EMPTY, text.length));
+  }
+
+  return config;
+};
+
+class ContentBlock extends ContentBlockRecord implements BlockNode {
+  constructor(config: BlockNodeConfig) {
+    super(decorateCharacterList(config));
+  }
+
+  // $FlowFixMe[method-unbinding]
+  getKey(): BlockNodeKey {
+    return this.get('key');
+  }
+
+  // $FlowFixMe[method-unbinding]
+  getType(): DraftBlockType {
+    return this.get('type');
+  }
+
+  // $FlowFixMe[method-unbinding]
+  getText(): string {
+    return this.get('text');
+  }
+
+  // $FlowFixMe[method-unbinding]
+  getCharacterList(): List<CharacterMetadata> {
+    return this.get('characterList');
+  }
+
+  // $FlowFixMe[method-unbinding]
+  getLength(): number {
+    return this.getText().length;
+  }
+
+  // $FlowFixMe[method-unbinding]
+  getDepth(): number {
+    return this.get('depth');
+  }
+
+  // $FlowFixMe[method-unbinding]
+  getData(): Map<any, any> {
+    return this.get('data');
+  }
+
+  // $FlowFixMe[method-unbinding]
+  getInlineStyleAt(offset: number): DraftInlineStyle {
+    const character = this.getCharacterList().get(offset);
+    return character ? character.getStyle() : EMPTY_SET;
+  }
+
+  // $FlowFixMe[method-unbinding]
+  getEntityAt(offset: number): ?string {
+    const character = this.getCharacterList().get(offset);
+    return character ? character.getEntity() : null;
+  }
+
+  /**
+   * Execute a callback for every contiguous range of styles within the block.
+   */
+  // $FlowFixMe[method-unbinding]
+  findStyleRanges(
+    filterFn: (value: CharacterMetadata) => boolean,
+    callback: (start: number, end: number) => void,
+  ): void {
+    findRangesImmutable(
+      this.getCharacterList(),
+      haveEqualStyle,
+      filterFn,
+      callback,
+    );
+  }
+
+  /**
+   * Execute a callback for every contiguous range of entities within the block.
+   */
+  // $FlowFixMe[method-unbinding]
+  findEntityRanges(
+    filterFn: (value: CharacterMetadata) => boolean,
+    callback: (start: number, end: number) => void,
+  ): void {
+    findRangesImmutable(
+      this.getCharacterList(),
+      haveEqualEntity,
+      filterFn,
+      callback,
+    );
+  }
+}
+
+function haveEqualStyle(
+  charA: CharacterMetadata,
+  charB: CharacterMetadata,
+): boolean {
+  return charA.getStyle() === charB.getStyle();
+}
+
+function haveEqualEntity(
+  charA: CharacterMetadata,
+  charB: CharacterMetadata,
+): boolean {
+  return charA.getEntity() === charB.getEntity();
+}
+
+module.exports = ContentBlock;

--- a/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/immutable/ContentBlockNode.js
+++ b/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/immutable/ContentBlockNode.js
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * This file is a fork of ContentBlock adding support for nesting references by
+ * providing links to children, parent, prevSibling, and nextSibling.
+ *
+ * This is unstable and not part of the public API and should not be used by
+ * production systems. This file may be update/removed without notice.
+ *
+ * @flow
+ * @format
+ * @oncall draft_js
+ */
+
+'use strict';
+
+import type {BlockNode, BlockNodeConfig, BlockNodeKey} from 'BlockNode';
+import type {DraftBlockType} from 'DraftBlockType';
+import type {DraftInlineStyle} from 'DraftInlineStyle';
+
+const CharacterMetadata = require('CharacterMetadata');
+
+const findRangesImmutable = require('findRangesImmutable');
+const Immutable = require('immutable');
+
+const {List, Map, OrderedSet, Record, Repeat} = Immutable;
+
+type ContentBlockNodeConfig = BlockNodeConfig & {
+  children?: List<BlockNodeKey>,
+  parent?: ?BlockNodeKey,
+  prevSibling?: ?BlockNodeKey,
+  nextSibling?: ?BlockNodeKey,
+  ...
+};
+
+const EMPTY_SET = OrderedSet<string>();
+
+const defaultRecord: ContentBlockNodeConfig = {
+  parent: null,
+  characterList: List(),
+  data: Map(),
+  depth: 0,
+  key: '',
+  text: '',
+  type: 'unstyled',
+  children: List(),
+  prevSibling: null,
+  nextSibling: null,
+};
+
+const haveEqualStyle = (
+  charA: CharacterMetadata,
+  charB: CharacterMetadata,
+): boolean => charA.getStyle() === charB.getStyle();
+
+const haveEqualEntity = (
+  charA: CharacterMetadata,
+  charB: CharacterMetadata,
+): boolean => charA.getEntity() === charB.getEntity();
+
+const decorateCharacterList = (
+  config: ContentBlockNodeConfig,
+): ContentBlockNodeConfig => {
+  if (!config) {
+    return config;
+  }
+
+  const {characterList, text} = config;
+
+  if (text && !characterList) {
+    config.characterList = List(Repeat(CharacterMetadata.EMPTY, text.length));
+  }
+
+  return config;
+};
+
+class ContentBlockNode
+  extends (Record(defaultRecord): any)
+  implements BlockNode
+{
+  constructor(props: ContentBlockNodeConfig = defaultRecord) {
+    /* eslint-disable-next-line constructor-super */
+    super(decorateCharacterList(props));
+  }
+
+  // $FlowFixMe[method-unbinding]
+  getKey(): BlockNodeKey {
+    return this.get('key');
+  }
+
+  // $FlowFixMe[method-unbinding]
+  getType(): DraftBlockType {
+    return this.get('type');
+  }
+
+  // $FlowFixMe[method-unbinding]
+  getText(): string {
+    return this.get('text');
+  }
+
+  // $FlowFixMe[method-unbinding]
+  getCharacterList(): List<CharacterMetadata> {
+    return this.get('characterList');
+  }
+
+  // $FlowFixMe[method-unbinding]
+  getLength(): number {
+    return this.getText().length;
+  }
+
+  // $FlowFixMe[method-unbinding]
+  getDepth(): number {
+    return this.get('depth');
+  }
+
+  // $FlowFixMe[method-unbinding]
+  getData(): Map<any, any> {
+    return this.get('data');
+  }
+
+  // $FlowFixMe[method-unbinding]
+  getInlineStyleAt(offset: number): DraftInlineStyle {
+    const character = this.getCharacterList().get(offset);
+    return character ? character.getStyle() : EMPTY_SET;
+  }
+
+  // $FlowFixMe[method-unbinding]
+  getEntityAt(offset: number): ?string {
+    const character = this.getCharacterList().get(offset);
+    return character ? character.getEntity() : null;
+  }
+
+  getChildKeys(): List<BlockNodeKey> {
+    return this.get('children');
+  }
+
+  getParentKey(): ?BlockNodeKey {
+    return this.get('parent');
+  }
+
+  getPrevSiblingKey(): ?BlockNodeKey {
+    return this.get('prevSibling');
+  }
+
+  getNextSiblingKey(): ?BlockNodeKey {
+    return this.get('nextSibling');
+  }
+
+  // $FlowFixMe[method-unbinding]
+  findStyleRanges(
+    filterFn: (value: CharacterMetadata) => boolean,
+    callback: (start: number, end: number) => void,
+  ): void {
+    findRangesImmutable(
+      this.getCharacterList(),
+      haveEqualStyle,
+      filterFn,
+      callback,
+    );
+  }
+
+  // $FlowFixMe[method-unbinding]
+  findEntityRanges(
+    filterFn: (value: CharacterMetadata) => boolean,
+    callback: (start: number, end: number) => void,
+  ): void {
+    findRangesImmutable(
+      this.getCharacterList(),
+      haveEqualEntity,
+      filterFn,
+      callback,
+    );
+  }
+}
+
+module.exports = ContentBlockNode;

--- a/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/immutable/ContentState.js
+++ b/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/immutable/ContentState.js
@@ -1,0 +1,318 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall draft_js
+ */
+
+'use strict';
+
+import type {BlockMap} from 'BlockMap';
+import type {BlockNodeRawConfig} from 'BlockNode';
+import type {BlockNodeRecord} from 'BlockNodeRecord';
+import type {ContentStateRawType} from 'ContentStateRawType';
+import type DraftEntityInstance from 'DraftEntityInstance';
+import type {DraftEntityMutability} from 'DraftEntityMutability';
+import type {DraftEntityType} from 'DraftEntityType';
+import type {EntityMap} from 'EntityMap';
+
+const BlockMapBuilder = require('BlockMapBuilder');
+const CharacterMetadata = require('CharacterMetadata');
+const ContentBlock = require('ContentBlock');
+const ContentBlockNode = require('ContentBlockNode');
+const DraftEntity = require('DraftEntity');
+const SelectionState = require('SelectionState');
+
+const generateRandomKey = require('generateRandomKey');
+const getOwnObjectValues = require('getOwnObjectValues');
+const gkx = require('gkx');
+const Immutable = require('immutable');
+const sanitizeDraftText = require('sanitizeDraftText');
+
+const {List, Record, Repeat, Map: ImmutableMap, OrderedMap} = Immutable;
+
+type ContentStateRecordType = {
+  entityMap: ?any,
+  blockMap: ?BlockMap,
+  selectionBefore: ?SelectionState,
+  selectionAfter: ?SelectionState,
+  ...
+};
+
+const defaultRecord: ContentStateRecordType = {
+  entityMap: null,
+  blockMap: null,
+  selectionBefore: null,
+  selectionAfter: null,
+};
+
+// Immutable 3 typedefs are not good, so ContentState ends up
+// subclassing `any`. Define a rudimentary type for the
+// supercalss here instead.
+declare class ContentStateRecordHelper {
+  constructor(args: any): ContentState;
+  merge(args: any): any;
+  setIn(keyPath: Array<string>, value: any): ContentState;
+  equals(other: ContentState): boolean;
+  mergeDeep(other: any): ContentState;
+}
+
+const ContentStateRecord: typeof ContentStateRecordHelper = (Record(
+  defaultRecord,
+): any);
+
+/* $FlowFixMe[signature-verification-failure] Supressing a `signature-
+ * verification-failure` error here. TODO: T65949050 Clean up the branch for
+ * this GK */
+const ContentBlockNodeRecord = gkx('draft_tree_data_support')
+  ? ContentBlockNode
+  : ContentBlock;
+
+class ContentState extends ContentStateRecord {
+  getEntityMap(): EntityMap {
+    // TODO: update this when we fully remove DraftEntity
+    return DraftEntity;
+  }
+
+  getBlockMap(): BlockMap {
+    // $FlowFixMe[prop-missing] found when removing casts of this to any
+    return this.get('blockMap');
+  }
+
+  getSelectionBefore(): SelectionState {
+    // $FlowFixMe[prop-missing] found when removing casts of this to any
+    return this.get('selectionBefore');
+  }
+
+  getSelectionAfter(): SelectionState {
+    // $FlowFixMe[prop-missing] found when removing casts of this to any
+    return this.get('selectionAfter');
+  }
+
+  getBlockForKey(key: string): BlockNodeRecord {
+    const block: BlockNodeRecord = this.getBlockMap().get(key);
+    return block;
+  }
+
+  getKeyBefore(key: string): ?string {
+    return this.getBlockMap()
+      .reverse()
+      .keySeq()
+      .skipUntil(v => v === key)
+      .skip(1)
+      .first();
+  }
+
+  getKeyAfter(key: string): ?string {
+    return this.getBlockMap()
+      .keySeq()
+      .skipUntil(v => v === key)
+      .skip(1)
+      .first();
+  }
+
+  getBlockAfter(key: string): ?BlockNodeRecord {
+    return this.getBlockMap()
+      .skipUntil((_, k) => k === key)
+      .skip(1)
+      .first();
+  }
+
+  getBlockBefore(key: string): ?BlockNodeRecord {
+    return this.getBlockMap()
+      .reverse()
+      .skipUntil((_, k) => k === key)
+      .skip(1)
+      .first();
+  }
+
+  getBlocksAsArray(): Array<BlockNodeRecord> {
+    return this.getBlockMap().toArray();
+  }
+
+  getFirstBlock(): BlockNodeRecord {
+    return this.getBlockMap().first();
+  }
+
+  getLastBlock(): BlockNodeRecord {
+    return this.getBlockMap().last();
+  }
+
+  getPlainText(delimiter?: string): string {
+    return this.getBlockMap()
+      .map(block => {
+        return block ? block.getText() : '';
+      })
+      .join(delimiter || '\n');
+  }
+
+  getLastCreatedEntityKey(): string {
+    // TODO: update this when we fully remove DraftEntity
+    return DraftEntity.__getLastCreatedEntityKey();
+  }
+
+  hasText(): boolean {
+    const blockMap = this.getBlockMap();
+    return (
+      blockMap.size > 1 ||
+      // make sure that there are no zero width space chars
+      escape(blockMap.first().getText()).replace(/%u200B/g, '').length > 0
+    );
+  }
+
+  createEntity(
+    type: DraftEntityType,
+    mutability: DraftEntityMutability,
+    data?: Object,
+  ): ContentState {
+    // TODO: update this when we fully remove DraftEntity
+    DraftEntity.__create(type, mutability, data);
+    return this;
+  }
+
+  mergeEntityData(
+    key: string,
+    toMerge: {[key: string]: any, ...},
+  ): ContentState {
+    // TODO: update this when we fully remove DraftEntity
+    DraftEntity.__mergeData(key, toMerge);
+    return this;
+  }
+
+  replaceEntityData(
+    key: string,
+    newData: interface {[key: string]: any},
+  ): ContentState {
+    // TODO: update this when we fully remove DraftEntity
+    /* $FlowFixMe[class-object-subtyping] added when improving typing for this
+     * parameters */
+    DraftEntity.__replaceData(key, newData);
+    return this;
+  }
+
+  addEntity(instance: DraftEntityInstance): ContentState {
+    // TODO: update this when we fully remove DraftEntity
+    DraftEntity.__add(instance);
+    return this;
+  }
+
+  getEntity(key: string): DraftEntityInstance {
+    // TODO: update this when we fully remove DraftEntity
+    return DraftEntity.__get(key);
+  }
+
+  getAllEntities(): OrderedMap<string, DraftEntityInstance> {
+    return DraftEntity.__getAll();
+  }
+
+  setEntityMap(
+    entityMap: OrderedMap<string, DraftEntityInstance>,
+  ): ContentState {
+    DraftEntity.__loadWithEntities(entityMap);
+    return this;
+  }
+
+  static mergeEntityMaps(
+    to: OrderedMap<string, DraftEntityInstance>,
+    from: EntityMap,
+  ): OrderedMap<string, DraftEntityInstance> {
+    return to.merge(from.__getAll());
+  }
+
+  // TODO: when EntityMap is moved into content state this and `setEntityMap`
+  // Will be the exact same. Merge them then.
+  replaceEntityMap(entityMap: EntityMap): ContentState {
+    return this.setEntityMap(entityMap.__getAll());
+  }
+
+  setSelectionBefore(selection: SelectionState): ContentState {
+    // $FlowFixMe[prop-missing] found when removing casts of this to any
+    return this.set('selectionBefore', selection);
+  }
+
+  setSelectionAfter(selection: SelectionState): ContentState {
+    // $FlowFixMe[prop-missing] found when removing casts of this to any
+    return this.set('selectionAfter', selection);
+  }
+
+  setBlockMap(blockMap: BlockMap): ContentState {
+    // $FlowFixMe[prop-missing] found when removing casts of this to any
+    return this.set('blockMap', blockMap);
+  }
+
+  static createFromBlockArray(
+    // TODO: update flow type when we completely deprecate the old entity API
+    blocks:
+      | Array<BlockNodeRecord>
+      | {contentBlocks: Array<BlockNodeRecord>, ...},
+    entityMap: ?any,
+  ): ContentState {
+    // TODO: remove this when we completely deprecate the old entity API
+    const theBlocks = Array.isArray(blocks) ? blocks : blocks.contentBlocks;
+    const blockMap = BlockMapBuilder.createFromArray(theBlocks);
+    const selectionState = blockMap.isEmpty()
+      ? new SelectionState()
+      : SelectionState.createEmpty(blockMap.first().getKey());
+    return new ContentState({
+      blockMap,
+      entityMap: entityMap || DraftEntity,
+      selectionBefore: selectionState,
+      selectionAfter: selectionState,
+    });
+  }
+
+  static createFromText(
+    text: string,
+    delimiter?: string | RegExp = /\r\n?|\n/g,
+  ): ContentState {
+    const strings = text.split(delimiter);
+    const blocks = strings.map(block => {
+      block = sanitizeDraftText(block);
+      return new ContentBlockNodeRecord({
+        key: generateRandomKey(),
+        text: block,
+        type: 'unstyled',
+        characterList: List(Repeat(CharacterMetadata.EMPTY, block.length)),
+      });
+    });
+    return ContentState.createFromBlockArray(blocks);
+  }
+
+  static fromJS(state: ContentStateRawType): ContentState {
+    return new ContentState({
+      ...state,
+      blockMap: OrderedMap<string, BlockNodeRawConfig>(state.blockMap).map(
+        // $FlowFixMe[method-unbinding]
+        ContentState.createContentBlockFromJS,
+      ),
+      selectionBefore: new SelectionState(state.selectionBefore),
+      selectionAfter: new SelectionState(state.selectionAfter),
+    });
+  }
+
+  static createContentBlockFromJS(
+    block: BlockNodeRawConfig,
+  ): ContentBlockNodeRecord {
+    const characterList = block.characterList;
+
+    return new ContentBlockNodeRecord({
+      ...block,
+      data: ImmutableMap(block.data),
+      characterList:
+        characterList != null
+          ? List(
+              (Array.isArray(characterList)
+                ? characterList
+                : getOwnObjectValues(characterList)
+              ).map(c => CharacterMetadata.fromJS(c)),
+            )
+          : undefined,
+    });
+  }
+}
+
+module.exports = ContentState;

--- a/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/immutable/EditorState.js
+++ b/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/immutable/EditorState.js
@@ -1,0 +1,764 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall draft_js
+ */
+
+'use strict';
+
+import type {BlockMap} from 'BlockMap';
+import type {DecoratorRangeRawType} from 'BlockTree';
+import type {ContentStateRawType} from 'ContentStateRawType';
+import type {DraftDecoratorType} from 'DraftDecoratorType';
+import type {DraftInlineStyle} from 'DraftInlineStyle';
+import type {EditorChangeType} from 'EditorChangeType';
+import type {EntityMap} from 'EntityMap';
+
+const BlockTree = require('BlockTree');
+const ContentState = require('ContentState');
+const EditorBidiService = require('EditorBidiService');
+const SelectionState = require('SelectionState');
+
+const Immutable = require('immutable');
+
+const {OrderedSet, Record, Stack, OrderedMap, List} = Immutable;
+
+// When configuring an editor, the user can chose to provide or not provide
+// basically all keys. `currentContent` varies, so this type doesn't include it.
+// (See the types defined below.)
+type BaseEditorStateConfig = {
+  allowUndo?: boolean,
+  decorator?: ?DraftDecoratorType,
+  directionMap?: ?OrderedMap<string, string>,
+  forceSelection?: boolean,
+  inCompositionMode?: boolean,
+  inlineStyleOverride?: ?DraftInlineStyle,
+  lastChangeType?: ?EditorChangeType,
+  nativelyRenderedContent?: ?ContentState,
+  redoStack?: Stack<ContentState>,
+  selection?: ?SelectionState,
+  treeMap?: ?OrderedMap<string, List<any>>,
+  undoStack?: Stack<ContentState>,
+};
+
+type BaseEditorStateRawConfig = {
+  allowUndo?: boolean,
+  decorator?: ?DraftDecoratorType,
+  directionMap?: ?{...},
+  forceSelection?: boolean,
+  inCompositionMode?: boolean,
+  inlineStyleOverride?: ?Array<String>,
+  lastChangeType?: ?EditorChangeType,
+  nativelyRenderedContent?: ?ContentStateRawType,
+  redoStack?: Array<ContentStateRawType>,
+  selection?: ?{...},
+  treeMap?: ?Map<string, Array<DecoratorRangeRawType>>,
+  undoStack?: Array<ContentStateRawType>,
+};
+
+// When crating an editor, we want currentContent to be set.
+type EditorStateCreationConfigType = {
+  ...BaseEditorStateConfig,
+  currentContent: ContentState,
+};
+
+type EditorStateCreationConfigRawType = {
+  ...BaseEditorStateRawConfig,
+  currentContent: ContentStateRawType,
+};
+
+// When using EditorState.set(...), currentContent is optional
+type EditorStateChangeConfigType = {
+  ...BaseEditorStateConfig,
+  currentContent?: ?ContentState,
+};
+
+type EditorStateRecordType = {
+  allowUndo: boolean,
+  currentContent: ?ContentState,
+  decorator: ?DraftDecoratorType,
+  directionMap: ?OrderedMap<string, string>,
+  forceSelection: boolean,
+  inCompositionMode: boolean,
+  inlineStyleOverride: ?DraftInlineStyle,
+  lastChangeType: ?EditorChangeType,
+  nativelyRenderedContent: ?ContentState,
+  redoStack: Stack<ContentState>,
+  selection: ?SelectionState,
+  treeMap: ?OrderedMap<string, List<any>>,
+  undoStack: Stack<ContentState>,
+  ...
+};
+
+const defaultRecord: EditorStateRecordType = {
+  allowUndo: true,
+  currentContent: null,
+  decorator: null,
+  directionMap: null,
+  forceSelection: false,
+  inCompositionMode: false,
+  inlineStyleOverride: null,
+  lastChangeType: null,
+  nativelyRenderedContent: null,
+  redoStack: Stack(),
+  selection: null,
+  treeMap: null,
+  undoStack: Stack(),
+};
+
+const EditorStateRecord = (Record(defaultRecord): any);
+
+class EditorState {
+  // $FlowFixMe[value-as-type]
+  _immutable: EditorStateRecord;
+
+  static createEmpty(decorator?: ?DraftDecoratorType): EditorState {
+    return this.createWithText('', decorator);
+  }
+
+  static createWithText(
+    text: string,
+    decorator?: ?DraftDecoratorType,
+  ): EditorState {
+    return EditorState.createWithContent(
+      ContentState.createFromText(text),
+      decorator,
+    );
+  }
+
+  static createWithContent(
+    contentState: ContentState,
+    decorator?: ?DraftDecoratorType,
+  ): EditorState {
+    if (contentState.getBlockMap().count() === 0) {
+      return EditorState.createEmpty(decorator);
+    }
+    const firstKey = contentState.getBlockMap().first().getKey();
+    return EditorState.create({
+      currentContent: contentState,
+      undoStack: Stack(),
+      redoStack: Stack(),
+      decorator: decorator || null,
+      selection: SelectionState.createEmpty(firstKey),
+    });
+  }
+
+  static create(config: EditorStateCreationConfigType): EditorState {
+    const {currentContent, decorator} = config;
+    const recordConfig = {
+      ...config,
+      treeMap: generateNewTreeMap(currentContent, decorator),
+      directionMap: EditorBidiService.getDirectionMap(currentContent),
+    };
+    return new EditorState(new EditorStateRecord(recordConfig));
+  }
+
+  static fromJS(config: EditorStateCreationConfigRawType): EditorState {
+    return new EditorState(
+      new EditorStateRecord({
+        ...config,
+        directionMap:
+          config.directionMap != null
+            ? OrderedMap(config.directionMap)
+            : config.directionMap,
+        inlineStyleOverride:
+          config.inlineStyleOverride != null
+            ? OrderedSet(config.inlineStyleOverride)
+            : config.inlineStyleOverride,
+        nativelyRenderedContent:
+          config.nativelyRenderedContent != null
+            ? ContentState.fromJS(config.nativelyRenderedContent)
+            : config.nativelyRenderedContent,
+        redoStack:
+          config.redoStack != null
+            ? Stack(config.redoStack.map(v => ContentState.fromJS(v)))
+            : config.redoStack,
+        selection:
+          config.selection != null
+            ? new SelectionState(config.selection)
+            : config.selection,
+        treeMap:
+          config.treeMap != null
+            ? OrderedMap(config.treeMap).map(v =>
+                List(v).map(v => BlockTree.fromJS(v)),
+              )
+            : config.treeMap,
+        undoStack:
+          config.undoStack != null
+            ? Stack(config.undoStack.map(v => ContentState.fromJS(v)))
+            : config.undoStack,
+        currentContent: ContentState.fromJS(config.currentContent),
+      }),
+    );
+  }
+
+  static set(
+    editorState: EditorState,
+    put: EditorStateChangeConfigType,
+  ): EditorState {
+    const map = editorState.getImmutable().withMutations(state => {
+      const existingDecorator = state.get('decorator');
+      let decorator: ?DraftDecoratorType = existingDecorator;
+      if (put.decorator === null) {
+        decorator = null;
+      } else if (put.decorator) {
+        decorator = put.decorator;
+      }
+
+      const newContent = put.currentContent || editorState.getCurrentContent();
+
+      if (decorator !== existingDecorator) {
+        const treeMap: OrderedMap<string, any> = state.get('treeMap');
+        let newTreeMap;
+        if (decorator && existingDecorator) {
+          newTreeMap = regenerateTreeForNewDecorator(
+            newContent,
+            newContent.getBlockMap(),
+            treeMap,
+            decorator,
+            existingDecorator,
+          );
+        } else {
+          newTreeMap = generateNewTreeMap(newContent, decorator);
+        }
+
+        state.merge({
+          decorator,
+          treeMap: newTreeMap,
+          nativelyRenderedContent: null,
+        });
+        return;
+      }
+
+      const existingContent = editorState.getCurrentContent();
+      if (newContent !== existingContent) {
+        state.set(
+          'treeMap',
+          regenerateTreeForNewBlocks(
+            editorState,
+            newContent.getBlockMap(),
+            newContent.getEntityMap(),
+            decorator,
+          ),
+        );
+      }
+
+      state.merge(put);
+    });
+
+    return new EditorState(map);
+  }
+
+  toJS(): Object {
+    return this.getImmutable().toJS();
+  }
+
+  getAllowUndo(): boolean {
+    return this.getImmutable().get('allowUndo');
+  }
+
+  getCurrentContent(): ContentState {
+    return this.getImmutable().get('currentContent');
+  }
+
+  getUndoStack(): Stack<ContentState> {
+    return this.getImmutable().get('undoStack');
+  }
+
+  getRedoStack(): Stack<ContentState> {
+    return this.getImmutable().get('redoStack');
+  }
+
+  getSelection(): SelectionState {
+    return this.getImmutable().get('selection');
+  }
+
+  getDecorator(): ?DraftDecoratorType {
+    return this.getImmutable().get('decorator');
+  }
+
+  isInCompositionMode(): boolean {
+    return this.getImmutable().get('inCompositionMode');
+  }
+
+  mustForceSelection(): boolean {
+    return this.getImmutable().get('forceSelection');
+  }
+
+  getNativelyRenderedContent(): ?ContentState {
+    return this.getImmutable().get('nativelyRenderedContent');
+  }
+
+  getLastChangeType(): ?EditorChangeType {
+    return this.getImmutable().get('lastChangeType');
+  }
+
+  /**
+   * While editing, the user may apply inline style commands with a collapsed
+   * cursor, intending to type text that adopts the specified style. In this
+   * case, we track the specified style as an "override" that takes precedence
+   * over the inline style of the text adjacent to the cursor.
+   *
+   * If null, there is no override in place.
+   */
+  getInlineStyleOverride(): ?DraftInlineStyle {
+    return this.getImmutable().get('inlineStyleOverride');
+  }
+
+  static setInlineStyleOverride(
+    editorState: EditorState,
+    inlineStyleOverride: DraftInlineStyle,
+  ): EditorState {
+    return EditorState.set(editorState, {inlineStyleOverride});
+  }
+
+  /**
+   * Get the appropriate inline style for the editor state. If an
+   * override is in place, use it. Otherwise, the current style is
+   * based on the location of the selection state.
+   */
+  getCurrentInlineStyle(): DraftInlineStyle {
+    const override = this.getInlineStyleOverride();
+    if (override != null) {
+      return override;
+    }
+
+    const content = this.getCurrentContent();
+    const selection = this.getSelection();
+
+    if (selection.isCollapsed()) {
+      return getInlineStyleForCollapsedSelection(content, selection);
+    }
+
+    return getInlineStyleForNonCollapsedSelection(content, selection);
+  }
+
+  getBlockTree(blockKey: string): List<any> {
+    return this.getImmutable().getIn(['treeMap', blockKey]);
+  }
+
+  isSelectionAtStartOfContent(): boolean {
+    const firstKey = this.getCurrentContent().getBlockMap().first().getKey();
+    return this.getSelection().hasEdgeWithin(firstKey, 0, 0);
+  }
+
+  isSelectionAtEndOfContent(): boolean {
+    const content = this.getCurrentContent();
+    const blockMap = content.getBlockMap();
+    const last = blockMap.last();
+    const end = last.getLength();
+    return this.getSelection().hasEdgeWithin(last.getKey(), end, end);
+  }
+
+  getDirectionMap(): ?OrderedMap<any, any> {
+    return this.getImmutable().get('directionMap');
+  }
+
+  /**
+   * Incorporate native DOM selection changes into the EditorState. This
+   * method can be used when we simply want to accept whatever the DOM
+   * has given us to represent selection, and we do not need to re-render
+   * the editor.
+   *
+   * To forcibly move the DOM selection, see `EditorState.forceSelection`.
+   */
+  static acceptSelection(
+    editorState: EditorState,
+    selection: SelectionState,
+  ): EditorState {
+    return updateSelection(editorState, selection, false);
+  }
+
+  /**
+   * At times, we need to force the DOM selection to be where we
+   * need it to be. This can occur when the anchor or focus nodes
+   * are non-text nodes, for instance. In this case, we want to trigger
+   * a re-render of the editor, which in turn forces selection into
+   * the correct place in the DOM. The `forceSelection` method
+   * accomplishes this.
+   *
+   * This method should be used in cases where you need to explicitly
+   * move the DOM selection from one place to another without a change
+   * in ContentState.
+   */
+  static forceSelection(
+    editorState: EditorState,
+    selection: SelectionState,
+  ): EditorState {
+    if (!selection.getHasFocus()) {
+      selection = selection.set('hasFocus', true);
+    }
+    return updateSelection(editorState, selection, true);
+  }
+
+  /**
+   * Move selection to the end of the editor without forcing focus.
+   */
+  static moveSelectionToEnd(editorState: EditorState): EditorState {
+    const content = editorState.getCurrentContent();
+    const lastBlock = content.getLastBlock();
+    const lastKey = lastBlock.getKey();
+    const length = lastBlock.getLength();
+
+    return EditorState.acceptSelection(
+      editorState,
+      new SelectionState({
+        anchorKey: lastKey,
+        anchorOffset: length,
+        focusKey: lastKey,
+        focusOffset: length,
+        isBackward: false,
+      }),
+    );
+  }
+
+  /**
+   * Force focus to the end of the editor. This is useful in scenarios
+   * where we want to programmatically focus the input and it makes sense
+   * to allow the user to continue working seamlessly.
+   */
+  static moveFocusToEnd(editorState: EditorState): EditorState {
+    const afterSelectionMove = EditorState.moveSelectionToEnd(editorState);
+    return EditorState.forceSelection(
+      afterSelectionMove,
+      afterSelectionMove.getSelection(),
+    );
+  }
+
+  /**
+   * Push the current ContentState onto the undo stack if it should be
+   * considered a boundary state, and set the provided ContentState as the
+   * new current content.
+   */
+  static push(
+    editorState: EditorState,
+    contentState: ContentState,
+    changeType: EditorChangeType,
+    forceSelection: boolean = true,
+  ): EditorState {
+    if (editorState.getCurrentContent() === contentState) {
+      return editorState;
+    }
+
+    const directionMap = EditorBidiService.getDirectionMap(
+      contentState,
+      editorState.getDirectionMap(),
+    );
+
+    if (!editorState.getAllowUndo()) {
+      return EditorState.set(editorState, {
+        currentContent: contentState,
+        directionMap,
+        lastChangeType: changeType,
+        selection: contentState.getSelectionAfter(),
+        forceSelection,
+        inlineStyleOverride: null,
+      });
+    }
+
+    const selection = editorState.getSelection();
+    const currentContent = editorState.getCurrentContent();
+    let undoStack = editorState.getUndoStack();
+    let newContent = contentState;
+
+    if (
+      selection !== currentContent.getSelectionAfter() ||
+      mustBecomeBoundary(editorState, changeType)
+    ) {
+      undoStack = undoStack.push(currentContent);
+      newContent = newContent.setSelectionBefore(selection);
+    } else if (
+      changeType === 'insert-characters' ||
+      changeType === 'backspace-character' ||
+      changeType === 'delete-character'
+    ) {
+      // Preserve the previous selection.
+      newContent = newContent.setSelectionBefore(
+        currentContent.getSelectionBefore(),
+      );
+    }
+
+    let inlineStyleOverride = editorState.getInlineStyleOverride();
+
+    // Don't discard inline style overrides for the following change types:
+    const overrideChangeTypes = [
+      'adjust-depth',
+      'change-block-type',
+      'split-block',
+    ];
+
+    if (overrideChangeTypes.indexOf(changeType) === -1) {
+      inlineStyleOverride = null;
+    }
+
+    const editorStateChanges = {
+      currentContent: newContent,
+      directionMap,
+      undoStack,
+      redoStack: Stack<ContentState>(),
+      lastChangeType: changeType,
+      selection: contentState.getSelectionAfter(),
+      forceSelection,
+      inlineStyleOverride,
+    };
+
+    return EditorState.set(editorState, editorStateChanges);
+  }
+
+  /**
+   * Make the top ContentState in the undo stack the new current content and
+   * push the current content onto the redo stack.
+   */
+  static undo(editorState: EditorState): EditorState {
+    if (!editorState.getAllowUndo()) {
+      return editorState;
+    }
+
+    const undoStack = editorState.getUndoStack();
+    const newCurrentContent = undoStack.peek();
+    if (!newCurrentContent) {
+      return editorState;
+    }
+
+    const currentContent = editorState.getCurrentContent();
+    const directionMap = EditorBidiService.getDirectionMap(
+      newCurrentContent,
+      editorState.getDirectionMap(),
+    );
+
+    return EditorState.set(editorState, {
+      currentContent: newCurrentContent,
+      directionMap,
+      undoStack: undoStack.shift(),
+      redoStack: editorState.getRedoStack().push(currentContent),
+      forceSelection: true,
+      inlineStyleOverride: null,
+      lastChangeType: 'undo',
+      nativelyRenderedContent: null,
+      selection: currentContent.getSelectionBefore(),
+    });
+  }
+
+  /**
+   * Make the top ContentState in the redo stack the new current content and
+   * push the current content onto the undo stack.
+   */
+  static redo(editorState: EditorState): EditorState {
+    if (!editorState.getAllowUndo()) {
+      return editorState;
+    }
+
+    const redoStack = editorState.getRedoStack();
+    const newCurrentContent = redoStack.peek();
+    if (!newCurrentContent) {
+      return editorState;
+    }
+
+    const currentContent = editorState.getCurrentContent();
+    const directionMap = EditorBidiService.getDirectionMap(
+      newCurrentContent,
+      editorState.getDirectionMap(),
+    );
+
+    return EditorState.set(editorState, {
+      currentContent: newCurrentContent,
+      directionMap,
+      undoStack: editorState.getUndoStack().push(currentContent),
+      redoStack: redoStack.shift(),
+      forceSelection: true,
+      inlineStyleOverride: null,
+      lastChangeType: 'redo',
+      nativelyRenderedContent: null,
+      selection: newCurrentContent.getSelectionAfter(),
+    });
+  }
+
+  /**
+   * Not for public consumption.
+   */
+  // $FlowFixMe[value-as-type]
+  constructor(immutable: EditorStateRecord) {
+    this._immutable = immutable;
+  }
+
+  /**
+   * Not for public consumption.
+   */
+  // $FlowFixMe[value-as-type]
+  getImmutable(): EditorStateRecord {
+    return this._immutable;
+  }
+}
+
+/**
+ * Set the supplied SelectionState as the new current selection, and set
+ * the `force` flag to trigger manual selection placement by the view.
+ */
+function updateSelection(
+  editorState: EditorState,
+  selection: SelectionState,
+  forceSelection: boolean,
+): EditorState {
+  return EditorState.set(editorState, {
+    selection,
+    forceSelection,
+    nativelyRenderedContent: null,
+    inlineStyleOverride: null,
+  });
+}
+
+/**
+ * Regenerate the entire tree map for a given ContentState and decorator.
+ * Returns an OrderedMap that maps all available ContentBlock objects.
+ */
+function generateNewTreeMap(
+  contentState: ContentState,
+  decorator?: ?DraftDecoratorType,
+): OrderedMap<string, List<any>> {
+  return contentState
+    .getBlockMap()
+    .map(block => BlockTree.generate(contentState, block, decorator))
+    .toOrderedMap();
+}
+
+/**
+ * Regenerate tree map objects for all ContentBlocks that have changed
+ * between the current editorState and newContent. Returns an OrderedMap
+ * with only changed regenerated tree map objects.
+ */
+function regenerateTreeForNewBlocks(
+  editorState: EditorState,
+  newBlockMap: BlockMap,
+  newEntityMap: EntityMap,
+  decorator?: ?DraftDecoratorType,
+): OrderedMap<string, List<any>> {
+  const contentState = editorState
+    .getCurrentContent()
+    .replaceEntityMap(newEntityMap);
+  const prevBlockMap = contentState.getBlockMap();
+  const prevTreeMap = editorState.getImmutable().get('treeMap');
+  return prevTreeMap.merge(
+    newBlockMap
+      .toSeq()
+      .filter((block, key) => block !== prevBlockMap.get(key))
+      .map(block => BlockTree.generate(contentState, block, decorator)),
+  );
+}
+
+/**
+ * Generate tree map objects for a new decorator object, preserving any
+ * decorations that are unchanged from the previous decorator.
+ *
+ * Note that in order for this to perform optimally, decoration Lists for
+ * decorators should be preserved when possible to allow for direct immutable
+ * List comparison.
+ */
+function regenerateTreeForNewDecorator(
+  content: ContentState,
+  blockMap: BlockMap,
+  previousTreeMap: OrderedMap<string, List<any>>,
+  decorator: DraftDecoratorType,
+  existingDecorator: DraftDecoratorType,
+): OrderedMap<string, List<any>> {
+  return previousTreeMap.merge(
+    blockMap
+      .toSeq()
+      .filter(block => {
+        return (
+          decorator.getDecorations(block, content) !==
+          existingDecorator.getDecorations(block, content)
+        );
+      })
+      .map(block => BlockTree.generate(content, block, decorator)),
+  );
+}
+
+/**
+ * Return whether a change should be considered a boundary state, given
+ * the previous change type. Allows us to discard potential boundary states
+ * during standard typing or deletion behavior.
+ */
+function mustBecomeBoundary(
+  editorState: EditorState,
+  changeType: EditorChangeType,
+): boolean {
+  const lastChangeType = editorState.getLastChangeType();
+  return (
+    changeType !== lastChangeType ||
+    (changeType !== 'insert-characters' &&
+      changeType !== 'backspace-character' &&
+      changeType !== 'delete-character')
+  );
+}
+
+function getInlineStyleForCollapsedSelection(
+  content: ContentState,
+  selection: SelectionState,
+): DraftInlineStyle {
+  const startKey = selection.getStartKey();
+  const startOffset = selection.getStartOffset();
+  const startBlock = content.getBlockForKey(startKey);
+
+  // If the cursor is not at the start of the block, look backward to
+  // preserve the style of the preceding character.
+  if (startOffset > 0) {
+    return startBlock.getInlineStyleAt(startOffset - 1);
+  }
+
+  // The caret is at position zero in this block. If the block has any
+  // text at all, use the style of the first character.
+  if (startBlock.getLength()) {
+    return startBlock.getInlineStyleAt(0);
+  }
+
+  // Otherwise, look upward in the document to find the closest character.
+  return lookUpwardForInlineStyle(content, startKey);
+}
+
+function getInlineStyleForNonCollapsedSelection(
+  content: ContentState,
+  selection: SelectionState,
+): DraftInlineStyle {
+  const startKey = selection.getStartKey();
+  const startOffset = selection.getStartOffset();
+  const startBlock = content.getBlockForKey(startKey);
+
+  // If there is a character just inside the selection, use its style.
+  if (startOffset < startBlock.getLength()) {
+    return startBlock.getInlineStyleAt(startOffset);
+  }
+
+  // Check if the selection at the end of a non-empty block. Use the last
+  // style in the block.
+  if (startOffset > 0) {
+    return startBlock.getInlineStyleAt(startOffset - 1);
+  }
+
+  // Otherwise, look upward in the document to find the closest character.
+  return lookUpwardForInlineStyle(content, startKey);
+}
+
+function lookUpwardForInlineStyle(
+  content: ContentState,
+  fromKey: string,
+): DraftInlineStyle {
+  const lastNonEmpty = content
+    .getBlockMap()
+    .reverse()
+    .skipUntil((_, k) => k === fromKey)
+    .skip(1)
+    .skipUntil((block, _) => block.getLength())
+    .first();
+
+  if (lastNonEmpty) {
+    return lastNonEmpty.getInlineStyleAt(lastNonEmpty.getLength() - 1);
+  }
+  return OrderedSet();
+}
+
+module.exports = EditorState;

--- a/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/immutable/SelectionState.js
+++ b/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/immutable/SelectionState.js
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall draft_js
+ */
+
+'use strict';
+
+const Immutable = require('immutable');
+
+const {Record} = Immutable;
+
+const defaultRecord: {
+  anchorKey: string,
+  anchorOffset: number,
+  focusKey: string,
+  focusOffset: number,
+  isBackward: boolean,
+  hasFocus: boolean,
+  ...
+} = {
+  anchorKey: '',
+  anchorOffset: 0,
+  focusKey: '',
+  focusOffset: 0,
+  isBackward: false,
+  hasFocus: false,
+};
+
+/* $FlowFixMe[unclear-type] This comment suppresses an error found when
+ * automatically adding a type annotation with the codemod Komodo/Annotate_
+ * exports. To see the error delete this comment and run Flow. */
+const SelectionStateRecord = (Record(defaultRecord): any);
+
+class SelectionState extends SelectionStateRecord {
+  serialize(): string {
+    return (
+      'Anchor: ' +
+      this.getAnchorKey() +
+      ':' +
+      this.getAnchorOffset() +
+      ', ' +
+      'Focus: ' +
+      this.getFocusKey() +
+      ':' +
+      this.getFocusOffset() +
+      ', ' +
+      'Is Backward: ' +
+      String(this.getIsBackward()) +
+      ', ' +
+      'Has Focus: ' +
+      String(this.getHasFocus())
+    );
+  }
+
+  getAnchorKey(): string {
+    return this.get('anchorKey');
+  }
+
+  getAnchorOffset(): number {
+    return this.get('anchorOffset');
+  }
+
+  getFocusKey(): string {
+    return this.get('focusKey');
+  }
+
+  getFocusOffset(): number {
+    return this.get('focusOffset');
+  }
+
+  getIsBackward(): boolean {
+    return this.get('isBackward');
+  }
+
+  getHasFocus(): boolean {
+    return this.get('hasFocus');
+  }
+
+  /**
+   * Return whether the specified range overlaps with an edge of the
+   * SelectionState.
+   */
+  hasEdgeWithin(blockKey: string, start: number, end: number): boolean {
+    const anchorKey = this.getAnchorKey();
+    const focusKey = this.getFocusKey();
+
+    if (anchorKey === focusKey && anchorKey === blockKey) {
+      const selectionStart = this.getStartOffset();
+      const selectionEnd = this.getEndOffset();
+      return (
+        (start <= selectionStart && selectionStart <= end) || // selectionStart is between start and end, or
+        (start <= selectionEnd && selectionEnd <= end) // selectionEnd is between start and end
+      );
+    }
+
+    if (blockKey !== anchorKey && blockKey !== focusKey) {
+      return false;
+    }
+
+    const offsetToCheck =
+      blockKey === anchorKey ? this.getAnchorOffset() : this.getFocusOffset();
+
+    return start <= offsetToCheck && end >= offsetToCheck;
+  }
+
+  isCollapsed(): boolean {
+    return (
+      this.getAnchorKey() === this.getFocusKey() &&
+      this.getAnchorOffset() === this.getFocusOffset()
+    );
+  }
+
+  getStartKey(): string {
+    return this.getIsBackward() ? this.getFocusKey() : this.getAnchorKey();
+  }
+
+  getStartOffset(): number {
+    return this.getIsBackward()
+      ? this.getFocusOffset()
+      : this.getAnchorOffset();
+  }
+
+  getEndKey(): string {
+    return this.getIsBackward() ? this.getAnchorKey() : this.getFocusKey();
+  }
+
+  getEndOffset(): number {
+    return this.getIsBackward()
+      ? this.getAnchorOffset()
+      : this.getFocusOffset();
+  }
+
+  static createEmpty(key: string): SelectionState {
+    return new SelectionState({
+      anchorKey: key,
+      anchorOffset: 0,
+      focusKey: key,
+      focusOffset: 0,
+      isBackward: false,
+      hasFocus: false,
+    });
+  }
+}
+
+module.exports = SelectionState;

--- a/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/keys/generateRandomKey.js
+++ b/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/keys/generateRandomKey.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ * @oncall draft_js
+ */
+
+'use strict';
+
+const seenKeys: {[string]: boolean} = {};
+const MULTIPLIER = Math.pow(2, 24);
+
+function generateRandomKey(): string {
+  let key;
+  while (key === undefined || seenKeys.hasOwnProperty(key) || !isNaN(+key)) {
+    key = Math.floor(Math.random() * MULTIPLIER).toString(32);
+  }
+  seenKeys[key] = true;
+  return key;
+}
+
+module.exports = generateRandomKey;

--- a/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/modifier/AtomicBlockUtils.js
+++ b/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/modifier/AtomicBlockUtils.js
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall draft_js
+ */
+
+'use strict';
+
+import type {BlockNodeRecord} from 'BlockNodeRecord';
+import type {DraftInsertionType} from 'DraftInsertionType';
+import type SelectionState from 'SelectionState';
+
+const BlockMapBuilder = require('BlockMapBuilder');
+const CharacterMetadata = require('CharacterMetadata');
+const ContentBlock = require('ContentBlock');
+const ContentBlockNode = require('ContentBlockNode');
+const DraftModifier = require('DraftModifier');
+const EditorState = require('EditorState');
+
+const generateRandomKey = require('generateRandomKey');
+const gkx = require('gkx');
+const Immutable = require('immutable');
+const moveBlockInContentState = require('moveBlockInContentState');
+
+const experimentalTreeDataSupport = gkx('draft_tree_data_support');
+const ContentBlockRecord = experimentalTreeDataSupport
+  ? ContentBlockNode
+  : ContentBlock;
+
+const {List, Repeat} = Immutable;
+
+const AtomicBlockUtils = {
+  insertAtomicBlock(
+    editorState: EditorState,
+    entityKey: string,
+    character: string,
+  ): EditorState {
+    const contentState = editorState.getCurrentContent();
+    const selectionState = editorState.getSelection();
+
+    const afterRemoval = DraftModifier.removeRange(
+      contentState,
+      selectionState,
+      'backward',
+    );
+
+    const targetSelection = afterRemoval.getSelectionAfter();
+    const afterSplit = DraftModifier.splitBlock(afterRemoval, targetSelection);
+    const insertionTarget = afterSplit.getSelectionAfter();
+
+    const asAtomicBlock = DraftModifier.setBlockType(
+      afterSplit,
+      insertionTarget,
+      'atomic',
+    );
+
+    const charData = CharacterMetadata.create({entity: entityKey});
+
+    let atomicBlockConfig = {
+      key: generateRandomKey(),
+      type: 'atomic',
+      text: character,
+      characterList: List(Repeat(charData, character.length)),
+    };
+
+    let atomicDividerBlockConfig = {
+      key: generateRandomKey(),
+      type: 'unstyled',
+    };
+
+    if (experimentalTreeDataSupport) {
+      atomicBlockConfig = {
+        ...atomicBlockConfig,
+        nextSibling: atomicDividerBlockConfig.key,
+      };
+      atomicDividerBlockConfig = {
+        ...atomicDividerBlockConfig,
+        prevSibling: atomicBlockConfig.key,
+      };
+    }
+
+    const fragmentArray = [
+      new ContentBlockRecord(atomicBlockConfig),
+      new ContentBlockRecord(atomicDividerBlockConfig),
+    ];
+
+    const fragment = BlockMapBuilder.createFromArray(fragmentArray);
+
+    const withAtomicBlock = DraftModifier.replaceWithFragment(
+      asAtomicBlock,
+      insertionTarget,
+      fragment,
+    );
+
+    const newContent = withAtomicBlock.merge({
+      selectionBefore: selectionState,
+      selectionAfter: withAtomicBlock.getSelectionAfter().set('hasFocus', true),
+    });
+
+    return EditorState.push(editorState, newContent, 'insert-fragment');
+  },
+
+  moveAtomicBlock(
+    editorState: EditorState,
+    atomicBlock: BlockNodeRecord,
+    targetRange: SelectionState,
+    insertionMode?: DraftInsertionType,
+  ): EditorState {
+    const contentState = editorState.getCurrentContent();
+    const selectionState = editorState.getSelection();
+
+    let withMovedAtomicBlock;
+
+    if (insertionMode === 'before' || insertionMode === 'after') {
+      const targetBlock = contentState.getBlockForKey(
+        insertionMode === 'before'
+          ? targetRange.getStartKey()
+          : targetRange.getEndKey(),
+      );
+
+      withMovedAtomicBlock = moveBlockInContentState(
+        contentState,
+        atomicBlock,
+        targetBlock,
+        insertionMode,
+      );
+    } else {
+      const afterRemoval = DraftModifier.removeRange(
+        contentState,
+        targetRange,
+        'backward',
+      );
+
+      const selectionAfterRemoval = afterRemoval.getSelectionAfter();
+      const targetBlock = afterRemoval.getBlockForKey(
+        selectionAfterRemoval.getFocusKey(),
+      );
+
+      if (selectionAfterRemoval.getStartOffset() === 0) {
+        withMovedAtomicBlock = moveBlockInContentState(
+          afterRemoval,
+          atomicBlock,
+          targetBlock,
+          'before',
+        );
+      } else if (
+        selectionAfterRemoval.getEndOffset() === targetBlock.getLength()
+      ) {
+        withMovedAtomicBlock = moveBlockInContentState(
+          afterRemoval,
+          atomicBlock,
+          targetBlock,
+          'after',
+        );
+      } else {
+        const afterSplit = DraftModifier.splitBlock(
+          afterRemoval,
+          selectionAfterRemoval,
+        );
+
+        const selectionAfterSplit = afterSplit.getSelectionAfter();
+        const targetBlock = afterSplit.getBlockForKey(
+          selectionAfterSplit.getFocusKey(),
+        );
+
+        withMovedAtomicBlock = moveBlockInContentState(
+          afterSplit,
+          atomicBlock,
+          targetBlock,
+          'before',
+        );
+      }
+    }
+
+    const newContent = withMovedAtomicBlock.merge({
+      selectionBefore: selectionState,
+      selectionAfter: withMovedAtomicBlock
+        .getSelectionAfter()
+        .set('hasFocus', true),
+    });
+
+    return EditorState.push(editorState, newContent, 'move-block');
+  },
+};
+
+module.exports = AtomicBlockUtils;

--- a/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/modifier/DraftModifier.js
+++ b/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/modifier/DraftModifier.js
@@ -1,0 +1,265 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall draft_js
+ */
+
+'use strict';
+
+import type {BlockMap} from 'BlockMap';
+import type ContentState from 'ContentState';
+import type {DraftBlockType} from 'DraftBlockType';
+import type {DraftInlineStyle} from 'DraftInlineStyle';
+import type {DraftRemovalDirection} from 'DraftRemovalDirection';
+import type SelectionState from 'SelectionState';
+import type {Map} from 'immutable';
+import type {BlockDataMergeBehavior} from 'insertFragmentIntoContentState';
+
+const CharacterMetadata = require('CharacterMetadata');
+const ContentStateInlineStyle = require('ContentStateInlineStyle');
+
+const applyEntityToContentState = require('applyEntityToContentState');
+const getCharacterRemovalRange = require('getCharacterRemovalRange');
+const getContentStateFragment = require('getContentStateFragment');
+const Immutable = require('immutable');
+const insertFragmentIntoContentState = require('insertFragmentIntoContentState');
+const insertTextIntoContentState = require('insertTextIntoContentState');
+const invariant = require('invariant');
+const modifyBlockForContentState = require('modifyBlockForContentState');
+const removeEntitiesAtEdges = require('removeEntitiesAtEdges');
+const removeRangeFromContentState = require('removeRangeFromContentState');
+const splitBlockInContentState = require('splitBlockInContentState');
+
+const {OrderedSet} = Immutable;
+
+/**
+ * `DraftModifier` provides a set of convenience methods that apply
+ * modifications to a `ContentState` object based on a target `SelectionState`.
+ *
+ * Any change to a `ContentState` should be decomposable into a series of
+ * transaction functions that apply the required changes and return output
+ * `ContentState` objects.
+ *
+ * These functions encapsulate some of the most common transaction sequences.
+ */
+const DraftModifier = {
+  replaceText(
+    contentState: ContentState,
+    rangeToReplace: SelectionState,
+    text: string,
+    inlineStyle?: DraftInlineStyle,
+    entityKey?: ?string,
+  ): ContentState {
+    const withoutEntities = removeEntitiesAtEdges(contentState, rangeToReplace);
+    const withoutText = removeRangeFromContentState(
+      withoutEntities,
+      rangeToReplace,
+    );
+
+    const character = CharacterMetadata.create({
+      style: inlineStyle || OrderedSet(),
+      entity: entityKey || null,
+    });
+
+    return insertTextIntoContentState(
+      withoutText,
+      withoutText.getSelectionAfter(),
+      text,
+      character,
+    );
+  },
+
+  insertText(
+    contentState: ContentState,
+    targetRange: SelectionState,
+    text: string,
+    inlineStyle?: DraftInlineStyle,
+    entityKey?: ?string,
+  ): ContentState {
+    invariant(
+      targetRange.isCollapsed(),
+      'Target range must be collapsed for `insertText`.',
+    );
+    return DraftModifier.replaceText(
+      contentState,
+      targetRange,
+      text,
+      inlineStyle,
+      entityKey,
+    );
+  },
+
+  moveText(
+    contentState: ContentState,
+    removalRange: SelectionState,
+    targetRange: SelectionState,
+  ): ContentState {
+    const movedFragment = getContentStateFragment(contentState, removalRange);
+
+    const afterRemoval = DraftModifier.removeRange(
+      contentState,
+      removalRange,
+      'backward',
+    );
+
+    return DraftModifier.replaceWithFragment(
+      afterRemoval,
+      targetRange,
+      movedFragment,
+    );
+  },
+
+  replaceWithFragment(
+    contentState: ContentState,
+    targetRange: SelectionState,
+    fragment: BlockMap,
+    mergeBlockData?: BlockDataMergeBehavior = 'REPLACE_WITH_NEW_DATA',
+  ): ContentState {
+    const withoutEntities = removeEntitiesAtEdges(contentState, targetRange);
+    const withoutText = removeRangeFromContentState(
+      withoutEntities,
+      targetRange,
+    );
+
+    return insertFragmentIntoContentState(
+      withoutText,
+      withoutText.getSelectionAfter(),
+      fragment,
+      mergeBlockData,
+    );
+  },
+
+  removeRange(
+    contentState: ContentState,
+    rangeToRemove: SelectionState,
+    removalDirection: DraftRemovalDirection,
+  ): ContentState {
+    let startKey, endKey, startBlock, endBlock;
+    if (rangeToRemove.getIsBackward()) {
+      rangeToRemove = rangeToRemove.merge({
+        anchorKey: rangeToRemove.getFocusKey(),
+        anchorOffset: rangeToRemove.getFocusOffset(),
+        focusKey: rangeToRemove.getAnchorKey(),
+        focusOffset: rangeToRemove.getAnchorOffset(),
+        isBackward: false,
+      });
+    }
+    startKey = rangeToRemove.getAnchorKey();
+    endKey = rangeToRemove.getFocusKey();
+    startBlock = contentState.getBlockForKey(startKey);
+    endBlock = contentState.getBlockForKey(endKey);
+    const startOffset = rangeToRemove.getStartOffset();
+    const endOffset = rangeToRemove.getEndOffset();
+
+    const startEntityKey = startBlock.getEntityAt(startOffset);
+    const endEntityKey = endBlock.getEntityAt(endOffset - 1);
+
+    // Check whether the selection state overlaps with a single entity.
+    // If so, try to remove the appropriate substring of the entity text.
+    if (startKey === endKey) {
+      if (startEntityKey && startEntityKey === endEntityKey) {
+        const adjustedRemovalRange = getCharacterRemovalRange(
+          contentState.getEntityMap(),
+          startBlock,
+          endBlock,
+          rangeToRemove,
+          removalDirection,
+        );
+        return removeRangeFromContentState(contentState, adjustedRemovalRange);
+      }
+    }
+
+    const withoutEntities = removeEntitiesAtEdges(contentState, rangeToRemove);
+    return removeRangeFromContentState(withoutEntities, rangeToRemove);
+  },
+
+  splitBlock(
+    contentState: ContentState,
+    selectionState: SelectionState,
+  ): ContentState {
+    const withoutEntities = removeEntitiesAtEdges(contentState, selectionState);
+    const withoutText = removeRangeFromContentState(
+      withoutEntities,
+      selectionState,
+    );
+
+    return splitBlockInContentState(
+      withoutText,
+      withoutText.getSelectionAfter(),
+    );
+  },
+
+  applyInlineStyle(
+    contentState: ContentState,
+    selectionState: SelectionState,
+    inlineStyle: string,
+  ): ContentState {
+    return ContentStateInlineStyle.add(
+      contentState,
+      selectionState,
+      inlineStyle,
+    );
+  },
+
+  removeInlineStyle(
+    contentState: ContentState,
+    selectionState: SelectionState,
+    inlineStyle: string,
+  ): ContentState {
+    return ContentStateInlineStyle.remove(
+      contentState,
+      selectionState,
+      inlineStyle,
+    );
+  },
+
+  setBlockType(
+    contentState: ContentState,
+    selectionState: SelectionState,
+    blockType: DraftBlockType,
+  ): ContentState {
+    return modifyBlockForContentState(contentState, selectionState, block =>
+      block.merge({type: blockType, depth: 0}),
+    );
+  },
+
+  setBlockData(
+    contentState: ContentState,
+    selectionState: SelectionState,
+    blockData: Map<any, any>,
+  ): ContentState {
+    return modifyBlockForContentState(contentState, selectionState, block =>
+      block.merge({data: blockData}),
+    );
+  },
+
+  mergeBlockData(
+    contentState: ContentState,
+    selectionState: SelectionState,
+    blockData: Map<any, any>,
+  ): ContentState {
+    return modifyBlockForContentState(contentState, selectionState, block =>
+      block.merge({data: block.getData().merge(blockData)}),
+    );
+  },
+
+  applyEntity(
+    contentState: ContentState,
+    selectionState: SelectionState,
+    entityKey: ?string,
+  ): ContentState {
+    const withoutEntities = removeEntitiesAtEdges(contentState, selectionState);
+    return applyEntityToContentState(
+      withoutEntities,
+      selectionState,
+      entityKey,
+    );
+  },
+};
+
+module.exports = DraftModifier;

--- a/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/modifier/RichTextEditorUtil.js
+++ b/tests/integration/tests/fixtures/flow-libs/draft-js/src/model/modifier/RichTextEditorUtil.js
@@ -1,0 +1,376 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall draft_js
+ */
+
+'use strict';
+
+import type ContentState from 'ContentState';
+import type {DraftBlockType} from 'DraftBlockType';
+import type {DraftEditorCommand} from 'DraftEditorCommand';
+import type {DataObjectForLink, RichTextUtils} from 'RichTextUtils';
+import type SelectionState from 'SelectionState';
+import type URI from 'URI';
+
+const DraftModifier = require('DraftModifier');
+const EditorState = require('EditorState');
+
+const adjustBlockDepthForContentState = require('adjustBlockDepthForContentState');
+const nullthrows = require('nullthrows');
+
+const RichTextEditorUtil: RichTextUtils = {
+  currentBlockContainsLink(editorState: EditorState): boolean {
+    const selection = editorState.getSelection();
+    const contentState = editorState.getCurrentContent();
+    return contentState
+      .getBlockForKey(selection.getAnchorKey())
+      .getCharacterList()
+      .slice(selection.getStartOffset(), selection.getEndOffset())
+      .some(v => {
+        const entity = v.getEntity();
+        return !!entity && contentState.getEntity(entity).getType() === 'LINK';
+      });
+  },
+
+  getCurrentBlockType(editorState: EditorState): DraftBlockType {
+    const selection = editorState.getSelection();
+    return editorState
+      .getCurrentContent()
+      .getBlockForKey(selection.getStartKey())
+      .getType();
+  },
+
+  getDataObjectForLinkURL(uri: URI): DataObjectForLink {
+    return {url: uri.toString()};
+  },
+
+  handleKeyCommand(
+    editorState: EditorState,
+    command: DraftEditorCommand | string,
+    eventTimeStamp: ?number,
+  ): ?EditorState {
+    switch (command) {
+      case 'bold':
+        return RichTextEditorUtil.toggleInlineStyle(editorState, 'BOLD');
+      case 'italic':
+        return RichTextEditorUtil.toggleInlineStyle(editorState, 'ITALIC');
+      case 'underline':
+        return RichTextEditorUtil.toggleInlineStyle(editorState, 'UNDERLINE');
+      case 'strikethrough':
+        return RichTextEditorUtil.toggleInlineStyle(
+          editorState,
+          'STRIKETHROUGH',
+        );
+      case 'code':
+        return RichTextEditorUtil.toggleCode(editorState);
+      case 'backspace':
+      case 'backspace-word':
+      case 'backspace-to-start-of-line':
+        return RichTextEditorUtil.onBackspace(editorState);
+      case 'delete':
+      case 'delete-word':
+      case 'delete-to-end-of-block':
+        return RichTextEditorUtil.onDelete(editorState);
+      default:
+        // they may have custom editor commands; ignore those
+        return null;
+    }
+  },
+
+  insertSoftNewline(editorState: EditorState): EditorState {
+    const contentState = DraftModifier.insertText(
+      editorState.getCurrentContent(),
+      editorState.getSelection(),
+      '\n',
+      editorState.getCurrentInlineStyle(),
+      null,
+    );
+
+    const newEditorState = EditorState.push(
+      editorState,
+      contentState,
+      'insert-characters',
+    );
+
+    return EditorState.forceSelection(
+      newEditorState,
+      contentState.getSelectionAfter(),
+    );
+  },
+
+  /**
+   * For collapsed selections at the start of styled blocks, backspace should
+   * just remove the existing style.
+   */
+  onBackspace(editorState: EditorState): ?EditorState {
+    const selection = editorState.getSelection();
+    if (
+      !selection.isCollapsed() ||
+      selection.getAnchorOffset() ||
+      selection.getFocusOffset()
+    ) {
+      return null;
+    }
+
+    // First, try to remove a preceding atomic block.
+    const content = editorState.getCurrentContent();
+    const startKey = selection.getStartKey();
+    const blockBefore = content.getBlockBefore(startKey);
+
+    if (blockBefore && blockBefore.getType() === 'atomic') {
+      const blockMap = content.getBlockMap().delete(blockBefore.getKey());
+      const withoutAtomicBlock = content.merge({
+        blockMap,
+        selectionAfter: selection,
+      });
+      if (withoutAtomicBlock !== content) {
+        return EditorState.push(
+          editorState,
+          withoutAtomicBlock,
+          'remove-range',
+        );
+      }
+    }
+
+    // If that doesn't succeed, try to remove the current block style.
+    const withoutBlockStyle =
+      RichTextEditorUtil.tryToRemoveBlockStyle(editorState);
+
+    if (withoutBlockStyle) {
+      return EditorState.push(
+        editorState,
+        withoutBlockStyle,
+        'change-block-type',
+      );
+    }
+
+    return null;
+  },
+
+  onDelete(editorState: EditorState): ?EditorState {
+    const selection = editorState.getSelection();
+    if (!selection.isCollapsed()) {
+      return null;
+    }
+
+    const content = editorState.getCurrentContent();
+    const startKey = selection.getStartKey();
+    const block = content.getBlockForKey(startKey);
+    const length = block.getLength();
+
+    // The cursor is somewhere within the text. Behave normally.
+    if (selection.getStartOffset() < length) {
+      return null;
+    }
+
+    const blockAfter = content.getBlockAfter(startKey);
+
+    if (!blockAfter || blockAfter.getType() !== 'atomic') {
+      return null;
+    }
+
+    const atomicBlockTarget = selection.merge({
+      focusKey: blockAfter.getKey(),
+      focusOffset: blockAfter.getLength(),
+    });
+
+    const withoutAtomicBlock = DraftModifier.removeRange(
+      content,
+      atomicBlockTarget,
+      'forward',
+    );
+
+    if (withoutAtomicBlock !== content) {
+      return EditorState.push(editorState, withoutAtomicBlock, 'remove-range');
+    }
+
+    return null;
+  },
+
+  onTab(
+    event: SyntheticKeyboardEvent<>,
+    editorState: EditorState,
+  ): EditorState {
+    const selection = editorState.getSelection();
+    const key = selection.getAnchorKey();
+
+    const content = editorState.getCurrentContent();
+    const block = content.getBlockForKey(key);
+    const type = block.getType();
+    if (type !== 'unordered-list-item' && type !== 'ordered-list-item') {
+      return editorState;
+    }
+
+    event.preventDefault();
+
+    const withAdjustment = adjustBlockDepthForContentState(
+      content,
+      selection,
+      event.shiftKey ? -1 : 1,
+    );
+
+    return EditorState.push(editorState, withAdjustment, 'adjust-depth');
+  },
+
+  toggleBlockType(
+    editorState: EditorState,
+    blockType: DraftBlockType,
+  ): EditorState {
+    const selection = editorState.getSelection();
+    const startKey = selection.getStartKey();
+    let endKey = selection.getEndKey();
+    const content = editorState.getCurrentContent();
+    let target = selection;
+
+    // Triple-click can lead to a selection that includes offset 0 of the
+    // following block. The `SelectionState` for this case is accurate, but
+    // we should avoid toggling block type for the trailing block because it
+    // is a confusing interaction.
+    if (startKey !== endKey && selection.getEndOffset() === 0) {
+      const blockBefore = nullthrows(content.getBlockBefore(endKey));
+      endKey = blockBefore.getKey();
+      target = target.merge({
+        anchorKey: startKey,
+        anchorOffset: selection.getStartOffset(),
+        focusKey: endKey,
+        focusOffset: blockBefore.getLength(),
+        isBackward: false,
+      });
+    }
+
+    const hasAtomicBlock = content
+      .getBlockMap()
+      .skipWhile((_, k) => k !== startKey)
+      .reverse()
+      .skipWhile((_, k) => k !== endKey)
+      .some(v => v.getType() === 'atomic');
+
+    if (hasAtomicBlock) {
+      return editorState;
+    }
+
+    const typeToSet =
+      content.getBlockForKey(startKey).getType() === blockType
+        ? 'unstyled'
+        : blockType;
+
+    return EditorState.push(
+      editorState,
+      DraftModifier.setBlockType(content, target, typeToSet),
+      'change-block-type',
+    );
+  },
+
+  toggleCode(editorState: EditorState): EditorState {
+    const selection = editorState.getSelection();
+    const anchorKey = selection.getAnchorKey();
+    const focusKey = selection.getFocusKey();
+
+    if (selection.isCollapsed() || anchorKey !== focusKey) {
+      return RichTextEditorUtil.toggleBlockType(editorState, 'code-block');
+    }
+
+    return RichTextEditorUtil.toggleInlineStyle(editorState, 'CODE');
+  },
+
+  /**
+   * Toggle the specified inline style for the selection. If the
+   * user's selection is collapsed, apply or remove the style for the
+   * internal state. If it is not collapsed, apply the change directly
+   * to the document state.
+   */
+  toggleInlineStyle(
+    editorState: EditorState,
+    inlineStyle: string,
+  ): EditorState {
+    const selection = editorState.getSelection();
+    const currentStyle = editorState.getCurrentInlineStyle();
+
+    // If the selection is collapsed, toggle the specified style on or off and
+    // set the result as the new inline style override. This will then be
+    // used as the inline style for the next character to be inserted.
+    if (selection.isCollapsed()) {
+      return EditorState.setInlineStyleOverride(
+        editorState,
+        currentStyle.has(inlineStyle)
+          ? currentStyle.remove(inlineStyle)
+          : currentStyle.add(inlineStyle),
+      );
+    }
+
+    // If characters are selected, immediately apply or remove the
+    // inline style on the document state itself.
+    const content = editorState.getCurrentContent();
+    let newContent;
+
+    // If the style is already present for the selection range, remove it.
+    // Otherwise, apply it.
+    if (currentStyle.has(inlineStyle)) {
+      newContent = DraftModifier.removeInlineStyle(
+        content,
+        selection,
+        inlineStyle,
+      );
+    } else {
+      newContent = DraftModifier.applyInlineStyle(
+        content,
+        selection,
+        inlineStyle,
+      );
+    }
+
+    return EditorState.push(editorState, newContent, 'change-inline-style');
+  },
+
+  toggleLink(
+    editorState: EditorState,
+    targetSelection: SelectionState,
+    entityKey: ?string,
+  ): EditorState {
+    const withoutLink = DraftModifier.applyEntity(
+      editorState.getCurrentContent(),
+      targetSelection,
+      entityKey,
+    );
+
+    return EditorState.push(editorState, withoutLink, 'apply-entity');
+  },
+
+  /**
+   * When a collapsed cursor is at the start of a styled block, changes block
+   * type to 'unstyled'. Returns null if selection does not meet that criteria.
+   */
+  tryToRemoveBlockStyle(editorState: EditorState): ?ContentState {
+    const selection = editorState.getSelection();
+    const offset = selection.getAnchorOffset();
+    if (selection.isCollapsed() && offset === 0) {
+      const key = selection.getAnchorKey();
+      const content = editorState.getCurrentContent();
+      const block = content.getBlockForKey(key);
+
+      const type = block.getType();
+      const blockBefore = content.getBlockBefore(key);
+      if (
+        type === 'code-block' &&
+        blockBefore &&
+        blockBefore.getType() === 'code-block' &&
+        blockBefore.getLength() !== 0
+      ) {
+        return null;
+      }
+
+      if (type !== 'unstyled') {
+        return DraftModifier.setBlockType(content, selection, 'unstyled');
+      }
+    }
+    return null;
+  },
+};
+
+module.exports = RichTextEditorUtil;

--- a/tests/integration/tests/fixtures/flow-libs/metro/Assets.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/Assets.js
@@ -1,0 +1,345 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {AssetPath} from './node-haste/lib/AssetPaths';
+
+import {normalizePathSeparatorsToPosix} from './lib/pathUtils';
+import * as AssetPaths from './node-haste/lib/AssetPaths';
+import crypto from 'crypto';
+import fs from 'fs';
+// $FlowFixMe[untyped-import] image-size
+import getImageSize from 'image-size';
+import path from 'path';
+
+export type AssetInfo = {
+  +files: Array<string>,
+  +hash: string,
+  +name: string,
+  +scales: Array<number>,
+  +type: string,
+};
+
+export type AssetDataWithoutFiles = {
+  +__packager_asset: boolean,
+  +fileSystemLocation: string,
+  +hash: string,
+  +height: ?number,
+  +httpServerLocation: string,
+  +name: string,
+  +scales: Array<number>,
+  +type: string,
+  +width: ?number,
+  ...
+};
+export type AssetDataFiltered = {
+  +__packager_asset: boolean,
+  +hash: string,
+  +height: ?number,
+  +httpServerLocation: string,
+  +name: string,
+  +scales: Array<number>,
+  +type: string,
+  +width: ?number,
+  ...
+};
+
+// Test extension against all types supported by image-size module.
+// If it's not one of these, we won't treat it as an image.
+export function isAssetTypeAnImage(type: string): boolean {
+  return (
+    [
+      'png',
+      'jpg',
+      'jpeg',
+      'bmp',
+      'gif',
+      'webp',
+      'psd',
+      'svg',
+      'tiff',
+      'ktx',
+    ].indexOf(type) !== -1
+  );
+}
+
+export function getAssetSize(
+  type: string,
+  content: Buffer,
+  filePath: string,
+): ?{+width: number, +height: number} {
+  if (!isAssetTypeAnImage(type)) {
+    return null;
+  }
+  if (content.length === 0) {
+    throw new Error(`Image asset \`${filePath}\` cannot be an empty file.`);
+  }
+  const {width, height} = getImageSize(content);
+  return {width, height};
+}
+
+export type AssetData = AssetDataWithoutFiles & {+files: Array<string>, ...};
+
+export type AssetDataPlugin = (
+  assetData: AssetData,
+) => AssetData | Promise<AssetData>;
+
+function buildAssetMap(
+  dir: string,
+  files: ReadonlyArray<string>,
+  platform: ?string,
+): Map<string, {files: Array<string>, scales: Array<number>}> {
+  const platforms = new Set(platform != null ? [platform] : []);
+  const assets = files.map((file: string) =>
+    AssetPaths.tryParse(file, platforms),
+  );
+  const map = new Map<string, {files: Array<string>, scales: Array<number>}>();
+  assets.forEach(function (asset: ?AssetPath, i: number) {
+    if (asset == null) {
+      return;
+    }
+    const file = files[i];
+    const assetKey = getAssetKey(asset.assetName, asset.platform);
+    let record = map.get(assetKey);
+    if (!record) {
+      record = {
+        scales: [],
+        files: [],
+      };
+      map.set(assetKey, record);
+    }
+
+    let insertIndex;
+    const length = record.scales.length;
+
+    for (insertIndex = 0; insertIndex < length; insertIndex++) {
+      if (asset.resolution < record.scales[insertIndex]) {
+        break;
+      }
+    }
+    record.scales.splice(insertIndex, 0, asset.resolution);
+    record.files.splice(insertIndex, 0, path.join(dir, file));
+  });
+
+  return map;
+}
+
+function getAssetKey(assetName: string, platform: ?string): string {
+  if (platform != null) {
+    return `${assetName} : ${platform}`;
+  } else {
+    return assetName;
+  }
+}
+
+async function getAbsoluteAssetRecord(
+  assetPath: string,
+  platform: ?string = null,
+): Promise<{files: Array<string>, scales: Array<number>}> {
+  const filename = path.basename(assetPath);
+  const dir = path.dirname(assetPath);
+  const files = await fs.promises.readdir(dir);
+
+  const assetData = AssetPaths.parse(
+    filename,
+    new Set(platform != null ? [platform] : []),
+  );
+
+  const map = buildAssetMap(dir, files, platform);
+
+  let record;
+  if (platform != null) {
+    record =
+      map.get(getAssetKey(assetData.assetName, platform)) ||
+      map.get(assetData.assetName);
+  } else {
+    record = map.get(assetData.assetName);
+  }
+
+  if (!record) {
+    throw new Error(
+      `Asset not found: ${assetPath} for platform: ${
+        platform ?? '(unspecified)'
+      }`,
+    );
+  }
+
+  return record;
+}
+
+async function getAbsoluteAssetInfo(
+  assetPath: string,
+  platform: ?string = null,
+): Promise<AssetInfo> {
+  const nameData = AssetPaths.parse(
+    assetPath,
+    new Set(platform != null ? [platform] : []),
+  );
+  const {name, type} = nameData;
+
+  const {scales, files} = await getAbsoluteAssetRecord(assetPath, platform);
+  const hasher = crypto.createHash('md5');
+
+  const fileData = await Promise.all(
+    files.map(file => fs.promises.readFile(file)),
+  );
+
+  for (const data of fileData) {
+    hasher.update(data);
+  }
+
+  return {files, hash: hasher.digest('hex'), name, scales, type};
+}
+
+export async function getAssetData(
+  assetPath: string,
+  localPath: string,
+  assetDataPlugins: ReadonlyArray<string>,
+  platform: ?string,
+  publicPath: string,
+): Promise<AssetData> {
+  // If the path of the asset is outside of the projectRoot, we don't want to
+  // use `path.join` since this will generate an incorrect URL path. In that
+  // case we just concatenate the publicPath with the relative path.
+  let assetUrlPath = localPath.startsWith('..')
+    ? publicPath.replace(/\/$/, '') + '/' + path.dirname(localPath)
+    : path.join(publicPath, path.dirname(localPath));
+
+  // On Windows, change backslashes to slashes to get proper URL path from file path.
+  assetUrlPath = normalizePathSeparatorsToPosix(assetUrlPath);
+
+  const isImage = isAssetTypeAnImage(path.extname(assetPath).slice(1));
+  const assetInfo = await getAbsoluteAssetInfo(assetPath, platform ?? null);
+
+  const isImageInput = assetInfo.files[0].includes('.zip/')
+    ? fs.readFileSync(assetInfo.files[0])
+    : assetInfo.files[0];
+  const dimensions = isImage ? getImageSize(isImageInput) : null;
+  const scale = assetInfo.scales[0];
+
+  const assetData = {
+    __packager_asset: true,
+    fileSystemLocation: path.dirname(assetPath),
+    httpServerLocation: assetUrlPath,
+    width: dimensions ? dimensions.width / scale : undefined,
+    height: dimensions ? dimensions.height / scale : undefined,
+    scales: assetInfo.scales,
+    files: assetInfo.files,
+    hash: assetInfo.hash,
+    name: assetInfo.name,
+    type: assetInfo.type,
+  };
+  return await applyAssetDataPlugins(assetDataPlugins, assetData);
+}
+
+async function applyAssetDataPlugins(
+  assetDataPlugins: ReadonlyArray<string>,
+  assetData: AssetData,
+): Promise<AssetData> {
+  if (!assetDataPlugins.length) {
+    return assetData;
+  }
+
+  const [currentAssetPlugin, ...remainingAssetPlugins] = assetDataPlugins;
+  // $FlowFixMe[unsupported-syntax]: impossible to type a dynamic require.
+  const assetPluginFunction: AssetDataPlugin = require(currentAssetPlugin);
+  const resultAssetData = await assetPluginFunction(assetData);
+  return await applyAssetDataPlugins(remainingAssetPlugins, resultAssetData);
+}
+
+/**
+ * Returns all the associated files (for different resolutions) of an asset.
+ **/
+export async function getAssetFiles(
+  assetPath: string,
+  platform: ?string = null,
+): Promise<Array<string>> {
+  const assetData = await getAbsoluteAssetRecord(assetPath, platform);
+
+  return assetData.files;
+}
+
+/**
+ * Return a buffer with the actual image given a request for an image by path.
+ * The relativePath can contain a resolution postfix, in this case we need to
+ * find that image (or the closest one to it's resolution) in one of the
+ * project roots:
+ *
+ * 1. We first parse the directory of the asset
+ * 2. We then build a map of all assets and their scales in this directory
+ * 3. Then try to pick platform-specific asset records
+ * 4. Then pick the closest resolution (rounding up) to the requested one
+ */
+export async function getAsset(
+  relativePath: string,
+  projectRoot: string,
+  watchFolders: ReadonlyArray<string>,
+  platform: ?string,
+  assetExts: ReadonlyArray<string>,
+  fileExistsInFileMap?: (absolutePath: string) => boolean,
+): Promise<Buffer> {
+  const assetData = AssetPaths.parse(
+    relativePath,
+    new Set(platform != null ? [platform] : []),
+  );
+
+  const absolutePath = path.resolve(projectRoot, relativePath);
+
+  if (!assetExts.includes(assetData.type)) {
+    throw new Error(
+      `'${relativePath}' cannot be loaded as its extension is not registered in assetExts`,
+    );
+  }
+
+  // NOTE: If fileExistsInFileMap is not provided, we fall back to pathBelongsToRoots for backward compatibility, as getAsset is part of the public API.
+  if (
+    fileExistsInFileMap == null &&
+    !pathBelongsToRoots(absolutePath, [projectRoot, ...watchFolders])
+  ) {
+    throw new Error(
+      `'${relativePath}' could not be found, because it cannot be found in the project root or any watch folder`,
+    );
+  }
+
+  const record = await getAbsoluteAssetRecord(absolutePath, platform ?? null);
+
+  for (let i = 0; i < record.scales.length; i++) {
+    if (record.scales[i] >= assetData.resolution) {
+      if (
+        fileExistsInFileMap != null &&
+        !fileExistsInFileMap(record.files[i])
+      ) {
+        continue;
+      }
+      return fs.promises.readFile(record.files[i]);
+    }
+  }
+
+  const lastFile = record.files[record.files.length - 1];
+  if (fileExistsInFileMap != null && !fileExistsInFileMap(lastFile)) {
+    throw new Error(
+      `'${relativePath}' could not be found, because it is not within the projectRoot or watchFolders, or it is blocked via the resolver.blockList config`,
+    );
+  }
+  return fs.promises.readFile(lastFile);
+}
+
+function pathBelongsToRoots(
+  pathToCheck: string,
+  roots: ReadonlyArray<string>,
+): boolean {
+  for (const rootFolder of roots) {
+    if (pathToCheck.startsWith(path.resolve(rootFolder))) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/tests/integration/tests/fixtures/flow-libs/metro/Bundler.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/Bundler.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {TransformResultWithSource} from './DeltaBundler';
+import type {TransformOptions} from './DeltaBundler/Worker';
+import type EventEmitter from 'events';
+import type {ConfigT} from 'metro-config';
+
+import Transformer from './DeltaBundler/Transformer';
+import DependencyGraph from './node-haste/DependencyGraph';
+
+export type BundlerOptions = Readonly<{
+  hasReducedPerformance?: boolean,
+  watch?: boolean,
+}>;
+
+export default class Bundler {
+  _depGraph: DependencyGraph;
+  _initializedPromise: Promise<void>;
+  _transformer: Transformer;
+
+  constructor(config: ConfigT, options?: BundlerOptions) {
+    this._depGraph = new DependencyGraph(config, options);
+
+    this._initializedPromise = this._depGraph
+      .ready()
+      .then(() => {
+        config.reporter.update({type: 'transformer_load_started'});
+        this._transformer = new Transformer(config, {
+          getOrComputeSha1: filePath =>
+            this._depGraph.getOrComputeSha1(filePath),
+        });
+        config.reporter.update({type: 'transformer_load_done'});
+      })
+      .catch(error => {
+        console.error('Failed to construct transformer: ', error);
+        config.reporter.update({
+          type: 'transformer_load_failed',
+          error,
+        });
+      });
+  }
+
+  getWatcher(): EventEmitter {
+    return this._depGraph.getWatcher();
+  }
+
+  async end(): Promise<void> {
+    await this.ready();
+
+    await this._transformer.end();
+    await this._depGraph.end();
+  }
+
+  async getDependencyGraph(): Promise<DependencyGraph> {
+    await this.ready();
+
+    return this._depGraph;
+  }
+
+  async transformFile(
+    filePath: string,
+    transformOptions: TransformOptions,
+    /** Optionally provide the file contents, this can be used to provide virtual contents for a file. */
+    fileBuffer?: Buffer,
+  ): Promise<TransformResultWithSource<>> {
+    // We need to be sure that the DependencyGraph has been initialized.
+    // TODO: Remove this ugly hack!
+    await this.ready();
+
+    return this._transformer.transformFile(
+      filePath,
+      transformOptions,
+      fileBuffer,
+    );
+  }
+
+  // Waits for the bundler to become ready.
+  async ready(): Promise<void> {
+    await this._initializedPromise;
+  }
+}

--- a/tests/integration/tests/fixtures/flow-libs/metro/DeltaBundler.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/DeltaBundler.js
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {
+  DeltaResult,
+  Graph,
+  // eslint-disable-next-line no-unused-vars
+  MixedOutput,
+  Options,
+  ReadOnlyGraph,
+} from './DeltaBundler/types';
+import type EventEmitter from 'events';
+
+import DeltaCalculator from './DeltaBundler/DeltaCalculator';
+
+export type {
+  DeltaResult,
+  Graph,
+  Dependencies,
+  MixedOutput,
+  Module,
+  ReadOnlyGraph,
+  TransformFn,
+  TransformResult,
+  TransformResultDependency,
+  TransformResultWithSource,
+} from './DeltaBundler/types';
+
+/**
+ * `DeltaBundler` uses the `DeltaTransformer` to build bundle deltas. This
+ * module handles all the transformer instances so it can support multiple
+ * concurrent clients requesting their own deltas. This is done through the
+ * `clientId` param (which maps a client to a specific delta transformer).
+ */
+export default class DeltaBundler<T = MixedOutput> {
+  _changeEventSource: EventEmitter;
+  _deltaCalculators: Map<Graph<T>, DeltaCalculator<T>> = new Map();
+
+  constructor(changeEventSource: EventEmitter) {
+    this._changeEventSource = changeEventSource;
+  }
+
+  end(): void {
+    this._deltaCalculators.forEach((deltaCalculator: DeltaCalculator<T>) =>
+      deltaCalculator.end(),
+    );
+    this._deltaCalculators = new Map();
+  }
+
+  async getDependencies(
+    entryPoints: ReadonlyArray<string>,
+    options: Options<T>,
+  ): Promise<ReadOnlyGraph<T>['dependencies']> {
+    const deltaCalculator = new DeltaCalculator(
+      new Set(entryPoints),
+      this._changeEventSource,
+      options,
+    );
+
+    await deltaCalculator.getDelta({reset: true, shallow: options.shallow});
+    const graph = deltaCalculator.getGraph();
+
+    deltaCalculator.end();
+    return graph.dependencies;
+  }
+
+  // Note: the graph returned by this function needs to be ended when finished
+  // so that we don't leak graphs that are not reachable.
+  // To get just the dependencies, use getDependencies which will not leak graphs.
+  async buildGraph(
+    entryPoints: ReadonlyArray<string>,
+    options: Options<T>,
+  ): Promise<Graph<T>> {
+    const deltaCalculator = new DeltaCalculator(
+      new Set(entryPoints),
+      this._changeEventSource,
+      options,
+    );
+
+    await deltaCalculator.getDelta({reset: true, shallow: options.shallow});
+    const graph = deltaCalculator.getGraph();
+
+    this._deltaCalculators.set(graph, deltaCalculator);
+    return graph;
+  }
+
+  async getDelta(
+    graph: Graph<T>,
+    {
+      reset,
+      shallow,
+    }: {
+      reset: boolean,
+      shallow: boolean,
+      ...
+    },
+  ): Promise<DeltaResult<T>> {
+    const deltaCalculator = this._deltaCalculators.get(graph);
+
+    if (!deltaCalculator) {
+      throw new Error('Graph not found');
+    }
+
+    return await deltaCalculator.getDelta({reset, shallow});
+  }
+
+  listen(graph: Graph<T>, callback: () => Promise<void>): () => void {
+    const deltaCalculator = this._deltaCalculators.get(graph);
+
+    if (!deltaCalculator) {
+      throw new Error('Graph not found');
+    }
+
+    deltaCalculator.on('change', callback);
+
+    return () => {
+      deltaCalculator.removeListener('change', callback);
+    };
+  }
+
+  endGraph(graph: Graph<T>): void {
+    const deltaCalculator = this._deltaCalculators.get(graph);
+
+    if (!deltaCalculator) {
+      throw new Error('Graph not found');
+    }
+
+    deltaCalculator.end();
+
+    this._deltaCalculators.delete(graph);
+  }
+}

--- a/tests/integration/tests/fixtures/flow-libs/metro/DeltaBundler/DeltaCalculator.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/DeltaBundler/DeltaCalculator.js
@@ -1,0 +1,336 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {DeltaResult, Options} from './types';
+import type {ChangeEvent} from 'metro-file-map';
+
+import {Graph} from './Graph';
+import crypto from 'crypto';
+import EventEmitter from 'events';
+import path from 'path';
+
+// eslint-disable-next-line import/no-commonjs
+const debug = require('debug')('Metro:DeltaCalculator');
+
+/**
+ * Assigns a unique, stable `changeId` to each `ChangeEvent` from the file
+ * watcher. Since all `DeltaCalculator` instances share the same
+ * `ChangeEvent` object reference per file system change, the `WeakMap`
+ * ensures each gets the same `changeId`.
+ */
+const changeEventIds: WeakMap<ChangeEvent, string> = new WeakMap();
+
+/**
+ * This class is in charge of calculating the delta of changed modules that
+ * happen between calls. To do so, it subscribes to file changes, so it can
+ * traverse the files that have been changed between calls and avoid having to
+ * traverse the whole dependency tree for trivial small changes.
+ */
+export default class DeltaCalculator<T> extends EventEmitter {
+  _changeEventSource: EventEmitter;
+  _options: Options<T>;
+
+  _currentBuildPromise: ?Promise<DeltaResult<T>>;
+  _deletedFiles: Set<string> = new Set();
+  _modifiedFiles: Set<string> = new Set();
+  _addedFiles: Set<string> = new Set();
+  _requiresReset: boolean = false;
+
+  _graph: Graph<T>;
+
+  constructor(
+    entryPoints: ReadonlySet<string>,
+    changeEventSource: EventEmitter,
+    options: Options<T>,
+  ) {
+    super();
+
+    this._options = options;
+    this._changeEventSource = changeEventSource;
+
+    this._graph = new Graph({
+      entryPoints,
+      transformOptions: this._options.transformOptions,
+    });
+
+    this._changeEventSource.on('change', this._handleMultipleFileChanges);
+  }
+
+  /**
+   * Stops listening for file changes and clears all the caches.
+   */
+  end(): void {
+    this._changeEventSource.removeListener(
+      'change',
+      this._handleMultipleFileChanges,
+    );
+
+    this.removeAllListeners();
+
+    // Clean up all the cache data structures to deallocate memory.
+    this._graph = new Graph({
+      entryPoints: this._graph.entryPoints,
+      transformOptions: this._options.transformOptions,
+    });
+    this._modifiedFiles = new Set();
+    this._deletedFiles = new Set();
+    this._addedFiles = new Set();
+  }
+
+  /**
+   * Main method to calculate the delta of modules. It returns a DeltaResult,
+   * which contain the modified/added modules and the removed modules.
+   */
+  async getDelta({
+    reset,
+    shallow,
+  }: {
+    reset: boolean,
+    shallow: boolean,
+    ...
+  }): Promise<DeltaResult<T>> {
+    debug('Calculating delta (reset: %s, shallow: %s)', reset, shallow);
+    // If there is already a build in progress, wait until it finish to start
+    // processing a new one (delta server doesn't support concurrent builds).
+    if (this._currentBuildPromise) {
+      await this._currentBuildPromise;
+    }
+
+    // We don't want the modified files Set to be modified while building the
+    // bundle, so we isolate them by using the current instance for the bundling
+    // and creating a new instance for the file watcher.
+    const modifiedFiles = this._modifiedFiles;
+    this._modifiedFiles = new Set();
+    const deletedFiles = this._deletedFiles;
+    this._deletedFiles = new Set();
+    const addedFiles = this._addedFiles;
+    this._addedFiles = new Set();
+    const requiresReset = this._requiresReset;
+    this._requiresReset = false;
+
+    // Revisit all files if changes require a graph reset - resolutions may be
+    // invalidated but we don't yet know which. This should be optimized in the
+    // future.
+    if (requiresReset) {
+      const markModified = (file: string) => {
+        if (!addedFiles.has(file) && !deletedFiles.has(file)) {
+          modifiedFiles.add(file);
+        }
+      };
+      this._graph.dependencies.forEach((_, key) => markModified(key));
+      this._graph.entryPoints.forEach(markModified);
+    }
+
+    // Concurrent requests should reuse the same bundling process. To do so,
+    // this method stores the promise as an instance variable, and then it's
+    // removed after it gets resolved.
+    this._currentBuildPromise = this._getChangedDependencies(
+      modifiedFiles,
+      deletedFiles,
+      addedFiles,
+    );
+
+    let result;
+
+    try {
+      result = await this._currentBuildPromise;
+    } catch (error) {
+      // In case of error, we don't want to mark the modified files as
+      // processed (since we haven't actually created any delta). If we do not
+      // do so, asking for a delta after an error will produce an empty Delta,
+      // which is not correct.
+      modifiedFiles.forEach((file: string) => this._modifiedFiles.add(file));
+      deletedFiles.forEach((file: string) => this._deletedFiles.add(file));
+      addedFiles.forEach((file: string) => this._addedFiles.add(file));
+
+      throw error;
+    } finally {
+      this._currentBuildPromise = null;
+    }
+
+    // Return all the modules if the client requested a reset delta.
+    if (reset) {
+      this._graph.reorderGraph({shallow});
+
+      return {
+        added: this._graph.dependencies,
+        deleted: new Set(),
+        modified: new Map(),
+        reset: true,
+      };
+    }
+
+    return result;
+  }
+
+  /**
+   * Returns the graph with all the dependencies. Each module contains the
+   * needed information to do the traversing (dependencies, inverseDependencies)
+   * plus some metadata.
+   */
+  getGraph(): Graph<T> {
+    return this._graph;
+  }
+
+  #shouldReset(
+    canonicalPath: string,
+    metadata: {+isSymlink: boolean, ...},
+  ): boolean {
+    if (metadata.isSymlink) {
+      return true;
+    }
+
+    if (
+      this._options.unstable_enablePackageExports &&
+      (canonicalPath === 'package.json' ||
+        canonicalPath.endsWith(path.sep + 'package.json'))
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
+  _handleMultipleFileChanges = (changeEvent: ChangeEvent) => {
+    const {changes, logger, rootDir} = changeEvent;
+
+    // Process added files: deleted+added = modified, otherwise added
+    for (const [canonicalPath, metadata] of changes.addedFiles) {
+      debug('Handling add: %s', canonicalPath);
+      if (this.#shouldReset(canonicalPath, metadata)) {
+        this._requiresReset = true;
+      }
+      const absolutePath = path.join(rootDir, canonicalPath);
+      if (this._deletedFiles.has(absolutePath)) {
+        this._deletedFiles.delete(absolutePath);
+        this._modifiedFiles.add(absolutePath);
+      } else {
+        this._addedFiles.add(absolutePath);
+        this._modifiedFiles.delete(absolutePath);
+      }
+    }
+
+    // Process modified files: added+modified stays added, otherwise modified
+    for (const [canonicalPath, metadata] of changes.modifiedFiles) {
+      debug('Handling change: %s', canonicalPath);
+      if (this.#shouldReset(canonicalPath, metadata)) {
+        this._requiresReset = true;
+      }
+      const absolutePath = path.join(rootDir, canonicalPath);
+      if (!this._addedFiles.has(absolutePath)) {
+        this._modifiedFiles.add(absolutePath);
+      }
+      this._deletedFiles.delete(absolutePath);
+    }
+
+    // Process removed files: added+deleted = no change, otherwise deleted
+    for (const [canonicalPath, metadata] of changes.removedFiles) {
+      debug('Handling delete: %s', canonicalPath);
+      if (this.#shouldReset(canonicalPath, metadata)) {
+        this._requiresReset = true;
+      }
+      const absolutePath = path.resolve(rootDir, canonicalPath);
+      if (this._addedFiles.has(absolutePath)) {
+        this._addedFiles.delete(absolutePath);
+      } else {
+        this._deletedFiles.add(absolutePath);
+        this._modifiedFiles.delete(absolutePath);
+      }
+    }
+
+    let changeId = changeEventIds.get(changeEvent);
+    if (changeId == null) {
+      changeId = crypto.randomUUID();
+      changeEventIds.set(changeEvent, changeId);
+    }
+
+    this.emit('change', {logger, changeId});
+  };
+
+  async _getChangedDependencies(
+    modifiedFiles: Set<string>,
+    deletedFiles: Set<string>,
+    addedFiles: Set<string>,
+  ): Promise<DeltaResult<T>> {
+    if (!this._graph.dependencies.size) {
+      const {added} = await this._graph.initialTraverseDependencies(
+        this._options,
+      );
+
+      return {
+        added,
+        deleted: new Set(),
+        modified: new Map(),
+        reset: true,
+      };
+    }
+
+    // If a file has been deleted, we want to invalidate any other file that
+    // depends on it, so we can process it and correctly return an error.
+    deletedFiles.forEach((filePath: string) => {
+      for (const modifiedModulePath of this._graph.getModifiedModulesForDeletedPath(
+        filePath,
+      )) {
+        // Only mark the inverse dependency as modified if it's not already
+        // marked as deleted (in that case we can just ignore it).
+        if (!deletedFiles.has(modifiedModulePath)) {
+          modifiedFiles.add(modifiedModulePath);
+        }
+      }
+    });
+
+    // NOTE(EvanBacon): This check adds extra complexity so we feature gate it
+    // to enable users to opt out.
+    if (this._options.unstable_allowRequireContext) {
+      // Check if any added or removed files are matched in a context module.
+      // We only need to do this for added files because (1) deleted files will have a context
+      // module as an inverse dependency, (2) modified files don't invalidate the contents
+      // of the context module.
+      addedFiles.forEach(filePath => {
+        this._graph.markModifiedContextModules(filePath, modifiedFiles);
+      });
+    }
+
+    // We only want to process files that are in the bundle.
+    const modifiedDependencies = Array.from(modifiedFiles).filter(
+      (filePath: string) => this._graph.dependencies.has(filePath),
+    );
+
+    // No changes happened. Return empty delta.
+    if (modifiedDependencies.length === 0) {
+      return {
+        added: new Map(),
+        deleted: new Set(),
+        modified: new Map(),
+        reset: false,
+      };
+    }
+
+    debug('Traversing dependencies for %s paths', modifiedDependencies.length);
+    const {added, modified, deleted} = await this._graph.traverseDependencies(
+      modifiedDependencies,
+      this._options,
+    );
+    debug(
+      'Calculated graph delta {added: %s, modified: %d, deleted: %d}',
+      added.size,
+      modified.size,
+      deleted.size,
+    );
+
+    return {
+      added,
+      deleted,
+      modified,
+      reset: false,
+    };
+  }
+}

--- a/tests/integration/tests/fixtures/flow-libs/metro/DeltaBundler/Graph.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/DeltaBundler/Graph.js
@@ -1,0 +1,970 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+/**
+ * Portions of this code are based on the Synchronous Cycle Collection
+ * algorithm described in:
+ *
+ * David F. Bacon and V. T. Rajan. 2001. Concurrent Cycle Collection in
+ * Reference Counted Systems. In Proceedings of the 15th European Conference on
+ * Object-Oriented Programming (ECOOP '01). Springer-Verlag, Berlin,
+ * Heidelberg, 207–235.
+ *
+ * Notable differences from the algorithm in the paper:
+ * 1. Our implementation uses the inverseDependencies set (which we already
+ *    have to maintain) instead of a separate refcount variable. A module's
+ *    reference count is equal to the size of its inverseDependencies set, plus
+ *    1 if it's an entry point of the graph.
+ * 2. We keep the "root buffer" (possibleCycleRoots) free of duplicates by
+ *    making it a Set, instead of storing a "buffered" flag on each node.
+ * 3. On top of tracking edges between nodes, we also count references between
+ *    nodes and entries in the importBundleNodes set.
+ */
+
+import type {RequireContext} from '../lib/contextModule';
+import type {RequireContextParams} from '../ModuleGraph/worker/collectDependencies';
+import type {
+  Dependencies,
+  Dependency,
+  GraphInputOptions,
+  MixedOutput,
+  Module,
+  ModuleData,
+  Options,
+  ResolvedDependency,
+  TransformInputOptions,
+} from './types';
+
+import {fileMatchesContext} from '../lib/contextModule';
+import CountingSet from '../lib/CountingSet';
+import {isResolvedDependency} from '../lib/isResolvedDependency';
+import {buildSubgraph} from './buildSubgraph';
+import invariant from 'invariant';
+import nullthrows from 'nullthrows';
+
+// TODO: Convert to a Flow enum
+type NodeColor =
+  // In use or free
+  | 'black'
+
+  // Possible member of cycle
+  | 'gray'
+
+  // Member of garbage cycle
+  | 'white'
+
+  // Possible root of cycle
+  | 'purple'
+
+  // Inherently acyclic node (Not currently used)
+  | 'green';
+
+export type Result<T> = {
+  added: Map<string, Module<T>>,
+  modified: Map<string, Module<T>>,
+  deleted: Set<string>,
+};
+
+/*
+ * Internal data structure that the traversal logic uses to know which of the
+ * files have been modified. This allows to return the added modules before the
+ * modified ones (which is useful for things like Hot Module Reloading).
+ */
+type Delta<T> = Readonly<{
+  // `added` and `deleted` are mutually exclusive.
+  // Internally, a module can be in both `touched` and (either) `added` or
+  // `deleted`. Before returning the result, we'll calculate
+  // modified = touched - added - deleted.
+  added: Set<string>,
+  touched: Set<string>,
+  deleted: Set<string>,
+
+  updatedModuleData: ReadonlyMap<string, ModuleData<T>>,
+  baseModuleData: Map<string, ModuleData<T>>,
+  errors: ReadonlyMap<string, Error>,
+}>;
+
+type InternalOptions<T> = Readonly<{
+  lazy: boolean,
+  onDependencyAdd: () => unknown,
+  onDependencyAdded: () => unknown,
+  resolve: Options<T>['resolve'],
+  transform: Options<T>['transform'],
+  shallow: boolean,
+}>;
+
+function getInternalOptions<T>({
+  transform,
+  resolve,
+  onProgress,
+  lazy,
+  shallow,
+}: Options<T>): InternalOptions<T> {
+  let numProcessed = 0;
+  let total = 0;
+
+  return {
+    lazy,
+    onDependencyAdd: () => onProgress && onProgress(numProcessed, ++total),
+    onDependencyAdded: () => onProgress && onProgress(++numProcessed, total),
+    resolve,
+    shallow,
+    transform,
+  };
+}
+
+function isWeakOrLazy<T>(
+  dependency: ResolvedDependency,
+  options: InternalOptions<T>,
+): boolean {
+  const asyncType = dependency.data.data.asyncType;
+  return asyncType === 'weak' || (asyncType != null && options.lazy);
+}
+
+export class Graph<T = MixedOutput> {
+  +entryPoints: ReadonlySet<string>;
+  +transformOptions: TransformInputOptions;
+  +dependencies: Dependencies<T> = new Map();
+  +#importBundleNodes: Map<
+    string,
+    Readonly<{
+      inverseDependencies: CountingSet<string>,
+    }>,
+  > = new Map();
+
+  /// GC state for nodes in the graph (this.dependencies)
+  +#gc: {
+    +color: Map<string, NodeColor>,
+    +possibleCycleRoots: Set<string>,
+  } = {
+    color: new Map(),
+    possibleCycleRoots: new Set(),
+  };
+
+  /** Resolved context parameters from `require.context`. */
+  #resolvedContexts: Map<string, RequireContext> = new Map();
+
+  constructor(options: GraphInputOptions) {
+    this.entryPoints = options.entryPoints;
+    this.transformOptions = options.transformOptions;
+  }
+
+  /**
+   * Dependency Traversal logic for the Delta Bundler. This method calculates
+   * the modules that should be included in the bundle by traversing the
+   * dependency graph.
+   * Instead of traversing the whole graph each time, it just calculates the
+   * difference between runs by only traversing the added/removed dependencies.
+   * To do so, it uses the passed graph dependencies and it mutates it.
+   * The paths parameter contains the absolute paths of the root files that the
+   * method should traverse. Normally, these paths should be the modified files
+   * since the last traversal.
+   */
+  async traverseDependencies(
+    paths: ReadonlyArray<string>,
+    options: Options<T>,
+  ): Promise<Result<T>> {
+    const internalOptions = getInternalOptions(options);
+
+    const modifiedPathsInBaseGraph = new Set(
+      paths.filter(path => this.dependencies.has(path)),
+    );
+
+    const allModifiedPaths = new Set(paths);
+
+    const delta = await this._buildDelta(
+      modifiedPathsInBaseGraph,
+      internalOptions,
+      // Traverse new or modified paths
+      absolutePath =>
+        !this.dependencies.has(absolutePath) ||
+        allModifiedPaths.has(absolutePath),
+    );
+
+    // If we have errors we might need to roll back any changes - take
+    // snapshots of all modified modules at the base state. We'll also snapshot
+    // unmodified modules that become unreachable as they are released, so that
+    // we have everything we need to restore the graph to base.
+    if (delta.errors.size > 0) {
+      for (const modified of modifiedPathsInBaseGraph) {
+        delta.baseModuleData.set(
+          modified,
+          this._moduleSnapshot(nullthrows(this.dependencies.get(modified))),
+        );
+      }
+    }
+
+    // Commit changes in a subtractive pass and then an additive pass - this
+    // ensures that any errors encountered on the additive pass would also be
+    // encountered on a fresh build (implying legitimate errors in the graph,
+    // rather than an error in a module that's no longer reachable).
+    for (const modified of modifiedPathsInBaseGraph) {
+      // Skip this module if it has errors. Hopefully it will be removed -
+      // if not, we'll throw during the additive pass.
+      if (delta.errors.has(modified)) {
+        continue;
+      }
+      const module = this.dependencies.get(modified);
+      // The module may have already been released from the graph - we'll readd
+      // it if necessary later.
+      if (module == null) {
+        continue;
+      }
+      // Process the transform result and dependency removals. This should
+      // never encounter an error.
+      this._recursivelyCommitModule(modified, delta, internalOptions, {
+        onlyRemove: true,
+      });
+    }
+
+    // Ensure we have released any unreachable modules before the additive
+    // pass.
+    this._collectCycles(delta, internalOptions);
+
+    // Additive pass - any errors we encounter here should be thrown after
+    // rolling back the commit.
+    try {
+      for (const modified of modifiedPathsInBaseGraph) {
+        const module = this.dependencies.get(modified);
+        // The module may have already been released from the graph (it may yet
+        // be readded via another dependency).
+        if (module == null) {
+          continue;
+        }
+
+        this._recursivelyCommitModule(modified, delta, internalOptions);
+      }
+    } catch (error) {
+      // Roll back to base before re-throwing.
+      const rollbackDelta: Delta<T> = {
+        added: delta.added,
+        baseModuleData: new Map(),
+        deleted: delta.deleted,
+        errors: new Map(),
+        touched: new Set(),
+        updatedModuleData: delta.baseModuleData,
+      };
+      for (const modified of modifiedPathsInBaseGraph) {
+        const module = this.dependencies.get(modified);
+        // The module may have already been released from the graph (it may yet
+        // be readded via another dependency).
+        if (module == null) {
+          continue;
+        }
+        // Set the module and descendants back to base state.
+        this._recursivelyCommitModule(modified, rollbackDelta, internalOptions);
+      }
+      // Collect cycles again after rolling back. There's no need if we're
+      // not rolling back, because we have not removed any edges.
+      this._collectCycles(delta, internalOptions);
+
+      // Cheap check to validate the rollback.
+      invariant(
+        rollbackDelta.added.size === 0 && rollbackDelta.deleted.size === 0,
+        'attempted to roll back a graph commit but there were still changes',
+      );
+
+      // Re-throw the transform or resolution error originally seen by
+      // `buildSubgraph`.
+      throw error;
+    }
+
+    const added = new Map<string, Module<T>>();
+    for (const path of delta.added) {
+      added.set(path, nullthrows(this.dependencies.get(path)));
+    }
+
+    const modified = new Map<string, Module<T>>();
+    for (const path of modifiedPathsInBaseGraph) {
+      if (
+        delta.touched.has(path) &&
+        !delta.deleted.has(path) &&
+        !delta.added.has(path)
+      ) {
+        modified.set(path, nullthrows(this.dependencies.get(path)));
+      }
+    }
+
+    return {
+      added,
+      deleted: delta.deleted,
+      modified,
+    };
+  }
+
+  async initialTraverseDependencies(options: Options<T>): Promise<Result<T>> {
+    const internalOptions = getInternalOptions(options);
+
+    invariant(
+      this.dependencies.size === 0,
+      'initialTraverseDependencies called on nonempty graph',
+    );
+
+    this.#gc.color.clear();
+    this.#gc.possibleCycleRoots.clear();
+    this.#importBundleNodes.clear();
+
+    for (const path of this.entryPoints) {
+      // Each entry point implicitly has a refcount of 1, so mark them all black.
+      this.#gc.color.set(path, 'black');
+    }
+
+    const delta = await this._buildDelta(this.entryPoints, internalOptions);
+
+    if (delta.errors.size > 0) {
+      // If we encountered any errors during traversal, throw one of them.
+      // Since errors are encountered in a non-deterministic order, even on
+      // fresh builds, it's valid to arbitrarily pick the first.
+      throw delta.errors.values().next().value;
+    }
+
+    for (const path of this.entryPoints) {
+      // We have already thrown on userland errors in the delta, so any error
+      // encountered here would be exceptional and fatal.
+      this._recursivelyCommitModule(path, delta, internalOptions);
+    }
+
+    this.reorderGraph({
+      shallow: options.shallow,
+    });
+
+    return {
+      added: this.dependencies,
+      deleted: new Set(),
+      modified: new Map(),
+    };
+  }
+
+  async _buildDelta(
+    pathsToVisit: ReadonlySet<string>,
+    options: InternalOptions<T>,
+    moduleFilter?: (path: string) => boolean,
+  ): Promise<Delta<T>> {
+    const subGraph = await buildSubgraph(pathsToVisit, this.#resolvedContexts, {
+      resolve: options.resolve,
+      shouldTraverse: (dependency: ResolvedDependency) => {
+        if (options.shallow || isWeakOrLazy(dependency, options)) {
+          return false;
+        }
+        return moduleFilter == null || moduleFilter(dependency.absolutePath);
+      },
+      transform: async (absolutePath, requireContext) => {
+        options.onDependencyAdd();
+        const result = await options.transform(absolutePath, requireContext);
+        options.onDependencyAdded();
+        return result;
+      },
+    });
+
+    return {
+      added: new Set(),
+      baseModuleData: new Map(),
+      deleted: new Set(),
+      errors: subGraph.errors,
+      touched: new Set(),
+      updatedModuleData: subGraph.moduleData,
+    };
+  }
+
+  _recursivelyCommitModule(
+    path: string,
+    delta: Delta<T>,
+    options: InternalOptions<T>,
+    commitOptions: Readonly<{
+      onlyRemove: boolean,
+    }> = {onlyRemove: false},
+  ): Module<T> {
+    if (delta.errors.has(path)) {
+      throw delta.errors.get(path);
+    }
+
+    const previousModule = this.dependencies.get(path);
+    const currentModule: ModuleData<T> = nullthrows(
+      delta.updatedModuleData.get(path) ?? delta.baseModuleData.get(path),
+    );
+
+    const previousDependencies = previousModule?.dependencies ?? new Map();
+    const {
+      dependencies: currentDependencies,
+      resolvedContexts,
+      ...transformResult
+    } = currentModule;
+
+    const nextModule = {
+      ...(previousModule ?? {
+        inverseDependencies: new CountingSet(),
+        path,
+      }),
+      ...transformResult,
+      dependencies: new Map(previousDependencies),
+    };
+
+    // Update the module information.
+    this.dependencies.set(nextModule.path, nextModule);
+
+    if (previousModule == null) {
+      // If the module is not currently in the graph, it is either new or was
+      // released earlier in the commit.
+      if (delta.deleted.has(path)) {
+        // Mark the addition by clearing a prior deletion.
+        delta.deleted.delete(path);
+      } else {
+        // Mark the addition in the added set.
+        delta.added.add(path);
+      }
+    }
+
+    // Diff dependencies (1/3): remove dependencies that have changed or been removed.
+    let dependenciesRemoved = false;
+    for (const [key, prevDependency] of previousDependencies) {
+      const curDependency = currentDependencies.get(key);
+      if (
+        !curDependency ||
+        !dependenciesEqual(prevDependency, curDependency, options)
+      ) {
+        dependenciesRemoved = true;
+        this._removeDependency(nextModule, key, prevDependency, delta, options);
+      }
+    }
+
+    // Diff dependencies (2/3): add dependencies that have changed or been added.
+    let dependenciesAdded = false;
+    if (!commitOptions.onlyRemove) {
+      for (const [key, curDependency] of currentDependencies) {
+        const prevDependency = previousDependencies.get(key);
+        if (
+          !prevDependency ||
+          !dependenciesEqual(prevDependency, curDependency, options)
+        ) {
+          dependenciesAdded = true;
+          this._addDependency(
+            nextModule,
+            key,
+            curDependency,
+            resolvedContexts.get(key),
+            delta,
+            options,
+          );
+        }
+      }
+    }
+
+    // Diff dependencies (3/3): detect changes in the ordering of dependency
+    // keys, which must be committed even if no other changes were made.
+    const previousDependencyKeys = [...previousDependencies.keys()];
+    const dependencyKeysChangedOrReordered =
+      currentDependencies.size !== previousDependencies.size ||
+      [...currentDependencies.keys()].some(
+        (currentKey, index) => currentKey !== previousDependencyKeys[index],
+      );
+
+    if (
+      previousModule != null &&
+      !transformOutputMayDiffer(previousModule, nextModule) &&
+      !dependenciesRemoved &&
+      !dependenciesAdded &&
+      !dependencyKeysChangedOrReordered
+    ) {
+      // We have not operated on nextModule, so restore previousModule
+      // to aid diffing. Don't add this path to delta.touched.
+      this.dependencies.set(previousModule.path, previousModule);
+      return previousModule;
+    }
+
+    delta.touched.add(path);
+
+    // Replace dependencies with the correctly-ordered version, matching the
+    // transform output. Because this assignment does not add or remove edges,
+    // it does NOT invalidate any of the garbage collection state.
+
+    // A subtractive pass only partially commits modules, so our dependencies
+    // are not generally complete yet. We'll address ordering in the next pass
+    // after processing additions.
+    if (commitOptions.onlyRemove) {
+      return nextModule;
+    }
+
+    // Catch obvious errors with a cheap assertion.
+    invariant(
+      nextModule.dependencies.size === currentDependencies.size,
+      'Failed to add the correct dependencies',
+    );
+
+    nextModule.dependencies = new Map(currentDependencies);
+
+    return nextModule;
+  }
+
+  _addDependency(
+    parentModule: Module<T>,
+    key: string,
+    dependency: Dependency,
+    requireContext: ?RequireContext,
+    delta: Delta<T>,
+    options: InternalOptions<T>,
+  ): void {
+    if (options.shallow) {
+      // Don't add a node for the module if the graph is shallow (single-module).
+    } else if (!isResolvedDependency(dependency)) {
+      // If the dependency is a missing optional dependency, it has no node of
+      // its own. We just need to add it to the parent's dependency map.
+    } else if (dependency.data.data.asyncType === 'weak') {
+      // Exclude weak dependencies from the bundle.
+    } else if (options.lazy && dependency.data.data.asyncType != null) {
+      // Don't add a node for the module if we are traversing async dependencies
+      // lazily (and this is an async dependency). Instead, record it in
+      // importBundleNodes.
+      this._incrementImportBundleReference(dependency, parentModule);
+    } else {
+      // The module may already exist, in which case we just need to update some
+      // bookkeeping instead of adding a new node to the graph.
+      const path = dependency.absolutePath;
+      let module = this.dependencies.get(path);
+
+      if (!module) {
+        try {
+          module = this._recursivelyCommitModule(path, delta, options);
+        } catch (error) {
+          // If we couldn't add this module but it was added to the graph
+          // before failing on a sub-dependency, it may be orphaned. Mark it as
+          // a possible garbage root.
+          const module = this.dependencies.get(path);
+          if (module) {
+            if (module.inverseDependencies.size > 0) {
+              this._markAsPossibleCycleRoot(module);
+            } else {
+              this._releaseModule(module, delta, options);
+            }
+          }
+          throw error;
+        }
+      }
+
+      // We either added a new node to the graph, or we're updating an existing one.
+      module.inverseDependencies.add(parentModule.path);
+      this._markModuleInUse(module);
+    }
+
+    if (isResolvedDependency(dependency)) {
+      const path = dependency.absolutePath;
+      if (requireContext) {
+        this.#resolvedContexts.set(path, requireContext);
+      } else {
+        // This dependency may have existed previously as a require.context -
+        // clean it up.
+        this.#resolvedContexts.delete(path);
+      }
+    }
+
+    // Update the parent's dependency map unless we failed to add a dependency.
+    // This means the parent's dependencies can get desynced from
+    // inverseDependencies and the other fields in the case of lazy edges.
+    // Not an optimal representation :(
+    parentModule.dependencies.set(key, dependency);
+  }
+
+  _removeDependency(
+    parentModule: Module<T>,
+    key: string,
+    dependency: Dependency,
+    delta: Delta<T>,
+    options: InternalOptions<T>,
+  ): void {
+    parentModule.dependencies.delete(key);
+
+    if (
+      !isResolvedDependency(dependency) ||
+      dependency.data.data.asyncType === 'weak'
+    ) {
+      // Weak and unresolved dependencies are excluded from the bundle.
+      return;
+    }
+
+    const {absolutePath} = dependency;
+
+    const module = this.dependencies.get(absolutePath);
+
+    if (options.lazy && dependency.data.data.asyncType != null) {
+      this._decrementImportBundleReference(dependency, parentModule);
+    } else if (module) {
+      // Decrement inverseDependencies only if the dependency is not async,
+      // mirroring the increment conditions in _addDependency.
+      module.inverseDependencies.delete(parentModule.path);
+    }
+
+    if (!module) {
+      return;
+    }
+    if (
+      module.inverseDependencies.size > 0 ||
+      this.entryPoints.has(absolutePath)
+    ) {
+      // The reference count has decreased, but not to zero.
+      // NOTE: Each entry point implicitly has a refcount of 1.
+      this._markAsPossibleCycleRoot(module);
+    } else {
+      // The reference count has decreased to zero.
+      this._releaseModule(module, delta, options);
+    }
+  }
+
+  /**
+   * Collect a list of context modules which include a given file.
+   */
+  markModifiedContextModules(
+    filePath: string,
+    modifiedPaths: Set<string> | CountingSet<string>,
+  ) {
+    for (const [absolutePath, context] of this.#resolvedContexts) {
+      if (
+        !modifiedPaths.has(absolutePath) &&
+        fileMatchesContext(filePath, context)
+      ) {
+        modifiedPaths.add(absolutePath);
+      }
+    }
+  }
+
+  /**
+   * Gets the list of modules affected by the deletion of a given file. The
+   * caller is expected to mark these modules as modified in the next call to
+   * traverseDependencies. Note that the list may contain duplicates.
+   */
+  *getModifiedModulesForDeletedPath(filePath: string): Iterable<string> {
+    yield* this.dependencies.get(filePath)?.inverseDependencies ?? [];
+    yield* this.#importBundleNodes.get(filePath)?.inverseDependencies ?? [];
+  }
+
+  /**
+   * Re-traverse the dependency graph in DFS order to reorder the modules and
+   * guarantee the same order between runs. This method mutates the passed graph.
+   */
+  reorderGraph(options: {shallow: boolean, ...}): void {
+    const orderedDependencies = new Map<string, Module<T>>();
+
+    this.entryPoints.forEach((entryPoint: string) => {
+      const mainModule = this.dependencies.get(entryPoint);
+
+      if (!mainModule) {
+        throw new ReferenceError(
+          'Module not registered in graph: ' + entryPoint,
+        );
+      }
+
+      this._reorderDependencies(mainModule, orderedDependencies, options);
+    });
+    this.dependencies.clear();
+    for (const [key, dep] of orderedDependencies) {
+      this.dependencies.set(key, dep);
+    }
+  }
+
+  _reorderDependencies(
+    module: Module<T>,
+    orderedDependencies: Map<string, Module<T>>,
+    options: {shallow: boolean, ...},
+  ): void {
+    if (module.path) {
+      if (orderedDependencies.has(module.path)) {
+        return;
+      }
+
+      orderedDependencies.set(module.path, module);
+    }
+
+    module.dependencies.forEach(dependency => {
+      const path = dependency.absolutePath;
+      if (path == null) {
+        // If the dependency is not a missing optional dependency, it has no children to reorder.
+        return;
+      }
+      const childModule = this.dependencies.get(path);
+
+      if (!childModule) {
+        if (dependency.data.data.asyncType != null || options.shallow) {
+          return;
+        } else {
+          throw new ReferenceError('Module not registered in graph: ' + path);
+        }
+      }
+
+      this._reorderDependencies(childModule, orderedDependencies, options);
+    });
+  }
+
+  /** Garbage collection functions */
+
+  // Add an entry to importBundleNodes (or record an inverse dependency of an existing one)
+  _incrementImportBundleReference(
+    dependency: ResolvedDependency,
+    parentModule: Module<T>,
+  ) {
+    const {absolutePath} = dependency;
+    const importBundleNode = this.#importBundleNodes.get(absolutePath) ?? {
+      inverseDependencies: new CountingSet(),
+    };
+    importBundleNode.inverseDependencies.add(parentModule.path);
+    this.#importBundleNodes.set(absolutePath, importBundleNode);
+  }
+
+  // Decrease the reference count of an entry in importBundleNodes (and delete it if necessary)
+  _decrementImportBundleReference(
+    dependency: ResolvedDependency,
+    parentModule: Module<T>,
+  ) {
+    const {absolutePath} = dependency;
+
+    const importBundleNode = nullthrows(
+      this.#importBundleNodes.get(absolutePath),
+    );
+    invariant(
+      importBundleNode.inverseDependencies.has(parentModule.path),
+      'lazy: import bundle inverse references',
+    );
+    importBundleNode.inverseDependencies.delete(parentModule.path);
+    if (importBundleNode.inverseDependencies.size === 0) {
+      this.#importBundleNodes.delete(absolutePath);
+    }
+  }
+
+  // Mark a module as in use (ref count >= 1)
+  _markModuleInUse(module: Module<T>) {
+    this.#gc.color.set(module.path, 'black');
+  }
+
+  // Iterate "children" of the given module - i.e. non-weak / async
+  // dependencies having a corresponding inverse dependency.
+  *_children(
+    module: Module<T>,
+    options: InternalOptions<T>,
+  ): Iterator<Module<T>> {
+    for (const dependency of module.dependencies.values()) {
+      if (
+        !isResolvedDependency(dependency) ||
+        isWeakOrLazy(dependency, options)
+      ) {
+        continue;
+      }
+      yield nullthrows(this.dependencies.get(dependency.absolutePath));
+    }
+  }
+
+  _moduleSnapshot(module: Module<T>): ModuleData<T> {
+    const {dependencies, getSource, output, unstable_transformResultKey} =
+      module;
+
+    const resolvedContexts: Map<string, RequireContext> = new Map();
+    for (const [key, dependency] of dependencies) {
+      if (!isResolvedDependency(dependency)) {
+        continue;
+      }
+      const resolvedContext = this.#resolvedContexts.get(
+        dependency.absolutePath,
+      );
+      if (resolvedContext != null) {
+        resolvedContexts.set(key, resolvedContext);
+      }
+    }
+    return {
+      dependencies: new Map(dependencies),
+      getSource,
+      output,
+      resolvedContexts,
+      unstable_transformResultKey,
+    };
+  }
+
+  // Delete an unreachable module (and its outbound edges) from the graph
+  // immediately.
+  // Called when the reference count of a module has reached 0.
+  _releaseModule(
+    module: Module<T>,
+    delta: Delta<T>,
+    options: InternalOptions<T>,
+  ) {
+    if (
+      !delta.updatedModuleData.has(module.path) &&
+      !delta.baseModuleData.has(module.path)
+    ) {
+      // Before releasing a module, take a snapshot of the data we might need
+      // to reintroduce it to the graph later in this commit. As it is not
+      // already present in updatedModuleData we can infer it has not been modified,
+      // so the transform output and dependencies we copy here are current.
+      delta.baseModuleData.set(module.path, this._moduleSnapshot(module));
+    }
+
+    for (const [key, dependency] of module.dependencies) {
+      if (!isResolvedDependency(dependency)) {
+        // If the dependency is not a missing optional dependency, it has no children to remove.
+        continue;
+      }
+      this._removeDependency(module, key, dependency, delta, options);
+    }
+    this.#gc.color.set(module.path, 'black');
+    this._freeModule(module, delta);
+  }
+
+  // Delete an unreachable module from the graph.
+  _freeModule(module: Module<T>, delta: Delta<T>) {
+    if (delta.added.has(module.path)) {
+      // Mark the deletion by clearing a prior addition.
+      delta.added.delete(module.path);
+    } else {
+      // Mark the deletion in the deleted set.
+      delta.deleted.add(module.path);
+    }
+
+    // This module is not used anywhere else! We can clear it from the bundle.
+    // Clean up all the state associated with this module in order to correctly
+    // re-add it if we encounter it again.
+    this.dependencies.delete(module.path);
+    this.#gc.possibleCycleRoots.delete(module.path);
+    this.#gc.color.delete(module.path);
+    this.#resolvedContexts.delete(module.path);
+  }
+
+  // Mark a module as a possible cycle root
+  _markAsPossibleCycleRoot(module: Module<T>) {
+    if (this.#gc.color.get(module.path) !== 'purple') {
+      this.#gc.color.set(module.path, 'purple');
+      this.#gc.possibleCycleRoots.add(module.path);
+    }
+  }
+
+  // Collect any unreachable cycles in the graph.
+  _collectCycles(delta: Delta<T>, options: InternalOptions<T>) {
+    // Mark recursively from roots (trial deletion)
+    for (const path of this.#gc.possibleCycleRoots) {
+      const module = nullthrows(this.dependencies.get(path));
+      const color = nullthrows(this.#gc.color.get(path));
+      if (color === 'purple') {
+        this._markGray(module, options);
+      } else {
+        this.#gc.possibleCycleRoots.delete(path);
+        if (
+          color === 'black' &&
+          module.inverseDependencies.size === 0 &&
+          !this.entryPoints.has(path)
+        ) {
+          this._freeModule(module, delta);
+        }
+      }
+    }
+    // Scan recursively from roots (undo unsuccessful trial deletions)
+    for (const path of this.#gc.possibleCycleRoots) {
+      const module = nullthrows(this.dependencies.get(path));
+      this._scan(module, options);
+    }
+    // Collect recursively from roots (free unreachable cycles)
+    for (const path of this.#gc.possibleCycleRoots) {
+      this.#gc.possibleCycleRoots.delete(path);
+      const module = nullthrows(this.dependencies.get(path));
+      this._collectWhite(module, delta);
+    }
+  }
+
+  _markGray(module: Module<T>, options: InternalOptions<T>) {
+    const color = nullthrows(this.#gc.color.get(module.path));
+    if (color !== 'gray') {
+      this.#gc.color.set(module.path, 'gray');
+      for (const childModule of this._children(module, options)) {
+        // The inverse dependency will be restored during the scan phase if this module remains live.
+        childModule.inverseDependencies.delete(module.path);
+        this._markGray(childModule, options);
+      }
+    }
+  }
+
+  _scan(module: Module<T>, options: InternalOptions<T>) {
+    const color = nullthrows(this.#gc.color.get(module.path));
+    if (color === 'gray') {
+      if (
+        module.inverseDependencies.size > 0 ||
+        this.entryPoints.has(module.path)
+      ) {
+        this._scanBlack(module, options);
+      } else {
+        this.#gc.color.set(module.path, 'white');
+        for (const childModule of this._children(module, options)) {
+          this._scan(childModule, options);
+        }
+      }
+    }
+  }
+
+  _scanBlack(module: Module<T>, options: InternalOptions<T>) {
+    this.#gc.color.set(module.path, 'black');
+    for (const childModule of this._children(module, options)) {
+      // The inverse dependency must have been deleted during the mark phase.
+      childModule.inverseDependencies.add(module.path);
+      const childColor = nullthrows(this.#gc.color.get(childModule.path));
+      if (childColor !== 'black') {
+        this._scanBlack(childModule, options);
+      }
+    }
+  }
+
+  _collectWhite(module: Module<T>, delta: Delta<T>) {
+    const color = nullthrows(this.#gc.color.get(module.path));
+    if (color === 'white' && !this.#gc.possibleCycleRoots.has(module.path)) {
+      this.#gc.color.set(module.path, 'black');
+      for (const dependency of module.dependencies.values()) {
+        if (!isResolvedDependency(dependency)) {
+          continue;
+        }
+        const childModule = this.dependencies.get(dependency.absolutePath);
+        // The child may already have been collected.
+        if (childModule) {
+          this._collectWhite(childModule, delta);
+        }
+      }
+      this._freeModule(module, delta);
+    }
+  }
+
+  /** End of garbage collection functions */
+}
+
+function dependenciesEqual(
+  a: Dependency,
+  b: Dependency,
+  options: Readonly<{lazy: boolean, ...}>,
+): boolean {
+  return (
+    a === b ||
+    (a.absolutePath === b.absolutePath &&
+      (!options.lazy || a.data.data.asyncType === b.data.data.asyncType) &&
+      contextParamsEqual(a.data.data.contextParams, b.data.data.contextParams))
+  );
+}
+
+function contextParamsEqual(
+  a: ?RequireContextParams,
+  b: ?RequireContextParams,
+): boolean {
+  return (
+    a === b ||
+    (a == null && b == null) ||
+    (a != null &&
+      b != null &&
+      a.recursive === b.recursive &&
+      a.filter.pattern === b.filter.pattern &&
+      a.filter.flags === b.filter.flags &&
+      a.mode === b.mode)
+  );
+}
+
+function transformOutputMayDiffer<T>(a: Module<T>, b: Module<T>): boolean {
+  return (
+    a.unstable_transformResultKey == null ||
+    a.unstable_transformResultKey !== b.unstable_transformResultKey
+  );
+}

--- a/tests/integration/tests/fixtures/flow-libs/metro/DeltaBundler/Transformer.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/DeltaBundler/Transformer.js
@@ -1,0 +1,209 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {TransformResult, TransformResultWithSource} from '../DeltaBundler';
+import type {TransformerConfig, TransformOptions} from './Worker';
+import type {ConfigT} from 'metro-config';
+
+import {normalizePathSeparatorsToPosix} from '../lib/pathUtils';
+import getTransformCacheKey from './getTransformCacheKey';
+import WorkerFarm from './WorkerFarm';
+import assert from 'assert';
+import crypto from 'crypto';
+import fs from 'fs';
+import {Cache, stableHash} from 'metro-cache';
+import path from 'path';
+
+// eslint-disable-next-line import/no-commonjs
+const debug = require('debug')('Metro:Transformer');
+
+type GetOrComputeSha1Fn = string => Promise<
+  Readonly<{content?: Buffer, sha1: string}>,
+>;
+
+export default class Transformer {
+  _config: ConfigT;
+  _cache: Cache<TransformResult<>>;
+  _baseHash: string;
+  _getSha1: GetOrComputeSha1Fn;
+  _workerFarm: WorkerFarm;
+
+  constructor(
+    config: ConfigT,
+    opts: Readonly<{getOrComputeSha1: GetOrComputeSha1Fn}>,
+  ) {
+    this._config = config;
+
+    this._config.watchFolders.forEach(verifyRootExists);
+    this._cache = new Cache(config.cacheStores);
+    this._getSha1 = opts.getOrComputeSha1;
+
+    // Remove the transformer config params that we don't want to pass to the
+    // transformer. We should change the config object and move them away so we
+    // can treat the transformer config params as opaque.
+    const {
+      getTransformOptions: _getTransformOptions,
+      transformVariants: _transformVariants,
+      unstable_workerThreads: _workerThreads,
+      ...transformerConfig
+    } = this._config.transformer;
+
+    const transformerOptions: TransformerConfig = {
+      transformerPath: this._config.transformerPath,
+      transformerConfig,
+    };
+
+    this._workerFarm = new WorkerFarm(config, transformerOptions);
+
+    const globalCacheKey = this._cache.isDisabled
+      ? ''
+      : getTransformCacheKey({
+          cacheVersion: this._config.cacheVersion,
+          projectRoot: this._config.projectRoot,
+          transformerConfig: transformerOptions,
+        });
+
+    const baseHashBuffer = stableHash([globalCacheKey]);
+    this._baseHash = baseHashBuffer.toString('binary');
+    debug('Base hash: %s', baseHashBuffer.toString('hex'));
+  }
+
+  async transformFile(
+    filePath: string,
+    transformerOptions: TransformOptions,
+    fileBuffer?: Buffer,
+  ): Promise<TransformResultWithSource<>> {
+    const cache = this._cache;
+
+    const {
+      customTransformOptions,
+      dev,
+      experimentalImportSupport,
+      inlinePlatform,
+      inlineRequires,
+      minify,
+      nonInlinedRequires,
+      platform,
+      type,
+      unstable_transformProfile,
+      unstable_memoizeInlineRequires,
+      unstable_nonMemoizedInlineRequires,
+      ...extra
+    } = transformerOptions;
+
+    for (const key in extra) {
+      // $FlowFixMe[cannot-resolve-name]
+      if (hasOwnProperty.call(extra, key)) {
+        throw new Error(
+          'Extra keys detected: ' + Object.keys(extra).join(', '),
+        );
+      }
+    }
+
+    const localPath = path.relative(this._config.projectRoot, filePath);
+
+    const partialKey = stableHash([
+      // This is the hash related to the global Bundler config.
+      this._baseHash,
+
+      // Project-relative, posix-separated path for portability. Necessary in
+      // addition to content hash because transformers receive path as an
+      // input, and may apply e.g. extension-based logic.
+      normalizePathSeparatorsToPosix(localPath),
+      customTransformOptions,
+      dev,
+      experimentalImportSupport,
+      inlinePlatform,
+      inlineRequires,
+      minify,
+      nonInlinedRequires,
+      platform,
+      type,
+      unstable_memoizeInlineRequires,
+      unstable_nonMemoizedInlineRequires,
+      unstable_transformProfile,
+    ]);
+
+    let sha1: string;
+    let content: ?Buffer;
+    if (fileBuffer) {
+      // Shortcut for virtual modules which provide the contents with the filename.
+      sha1 = crypto.createHash('sha1').update(fileBuffer).digest('hex');
+      content = fileBuffer;
+    } else {
+      const result = await this._getSha1(filePath);
+      sha1 = result.sha1;
+      if (result.content) {
+        content = result.content;
+      }
+    }
+
+    let fullKey = Buffer.concat([partialKey, Buffer.from(sha1, 'hex')]);
+    let result;
+    try {
+      result = await cache.get(fullKey);
+    } catch (error) {
+      this._config.reporter.update({
+        type: 'cache_read_error',
+        error,
+      });
+      throw error;
+    }
+
+    // A valid result from the cache is used directly; otherwise we call into
+    // the transformer to computed the corresponding result.
+    const data: Readonly<{
+      result: TransformResult<>,
+      sha1: string,
+    }> = result
+      ? {result, sha1}
+      : await this._workerFarm.transform(
+          localPath,
+          transformerOptions,
+          content,
+        );
+
+    // Only re-compute the full key if the SHA-1 changed. This is because
+    // references are used by the cache implementation in a weak map to keep
+    // track of the cache that returned the result.
+    if (sha1 !== data.sha1) {
+      fullKey = Buffer.concat([partialKey, Buffer.from(data.sha1, 'hex')]);
+    }
+
+    // Fire-and-forget cache set promise.
+    cache.set(fullKey, data.result).catch(error => {
+      this._config.reporter.update({
+        type: 'cache_write_error',
+        error,
+      });
+    });
+
+    return {
+      ...data.result,
+      unstable_transformResultKey: fullKey.toString(),
+      getSource(): Buffer {
+        if (fileBuffer) {
+          return fileBuffer;
+        }
+        return fs.readFileSync(filePath);
+      },
+    };
+  }
+
+  async end(): Promise<void> {
+    await this._workerFarm.kill();
+  }
+}
+
+function verifyRootExists(root: string): void {
+  // Verify that the root exists.
+  assert(fs.statSync(root).isDirectory(), 'Root has to be a valid directory');
+}

--- a/tests/integration/tests/fixtures/flow-libs/metro/DeltaBundler/Worker.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/DeltaBundler/Worker.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+/* eslint-disable import/no-commonjs */
+
+'use strict';
+
+/*::
+export type * from './Worker.flow';
+*/
+
+try {
+  require('metro-babel-register').unstable_registerForMetroMonorepo();
+} catch {}
+
+module.exports = require('./Worker.flow');

--- a/tests/integration/tests/fixtures/flow-libs/metro/DeltaBundler/WorkerFarm.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/DeltaBundler/WorkerFarm.js
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {TransformResult} from '../DeltaBundler';
+import type {TransformerConfig, TransformOptions, Worker} from './Worker';
+import type {ConfigT} from 'metro-config';
+import type {Readable} from 'stream';
+
+import {Worker as JestWorker} from 'jest-worker';
+import {Logger} from 'metro-core';
+
+type WorkerInterface = Readonly<{
+  ...Worker,
+  end(): void | Promise<void>,
+  getStdout(): Readable,
+  getStderr(): Readable,
+}>;
+
+type TransformerResult = Readonly<{
+  result: TransformResult<>,
+  sha1: string,
+}>;
+
+export default class WorkerFarm {
+  _config: ConfigT;
+  _transformerConfig: TransformerConfig;
+  _worker: WorkerInterface | Worker;
+
+  constructor(config: ConfigT, transformerConfig: TransformerConfig) {
+    this._config = config;
+    this._transformerConfig = transformerConfig;
+    const absoluteWorkerPath = require.resolve('./Worker.js');
+
+    if (this._config.maxWorkers > 1) {
+      const worker = this._makeFarm(
+        absoluteWorkerPath,
+        ['transform'],
+        this._config.maxWorkers,
+      );
+
+      worker.getStdout().on('data', chunk => {
+        this._config.reporter.update({
+          type: 'worker_stdout_chunk',
+          chunk: chunk.toString('utf8'),
+        });
+      });
+      worker.getStderr().on('data', chunk => {
+        this._config.reporter.update({
+          type: 'worker_stderr_chunk',
+          chunk: chunk.toString('utf8'),
+        });
+      });
+
+      this._worker = worker;
+    } else {
+      // eslint-disable-next-line import/no-commonjs
+      this._worker = require('./Worker') as Worker;
+    }
+  }
+
+  async kill(): Promise<void> {
+    if (this._worker && typeof this._worker.end === 'function') {
+      await this._worker.end();
+    }
+  }
+
+  async transform(
+    filename: string,
+    options: TransformOptions,
+    fileBuffer?: Buffer,
+  ): Promise<TransformerResult> {
+    try {
+      const data = await this._worker.transform(
+        filename,
+        options,
+        this._config.projectRoot,
+        this._transformerConfig,
+        fileBuffer,
+      );
+
+      Logger.log(data.transformFileStartLogEntry);
+      Logger.log(data.transformFileEndLogEntry);
+
+      return {
+        result: data.result,
+        sha1: data.sha1,
+      };
+    } catch (err) {
+      if (err.loc) {
+        throw this._formatBabelError(err, filename);
+      } else {
+        throw this._formatGenericError(err, filename);
+      }
+    }
+  }
+
+  _makeFarm(
+    absoluteWorkerPath: string,
+    exposedMethods: ReadonlyArray<string>,
+    numWorkers: number,
+  ): WorkerInterface {
+    const env = {
+      ...process.env,
+      // Force color to print syntax highlighted code frames.
+      FORCE_COLOR: 1,
+    };
+
+    return new JestWorker<Worker>(absoluteWorkerPath, {
+      computeWorkerKey: this._config.stickyWorkers
+        ? // $FlowFixMe[method-unbinding] added when improving typing for this parameters
+          // $FlowFixMe[incompatible-type]
+          this._computeWorkerKey
+        : undefined,
+      exposedMethods,
+      enableWorkerThreads: this._config.transformer.unstable_workerThreads,
+      forkOptions: {env},
+      numWorkers,
+      // Prefer using lower numbered available workers repeatedly rather than
+      // spreading jobs over the whole pool evenly (round-robin). This is more
+      // likely to use faster, hot workers earlier in graph traversal, when
+      // we want to be able to fan out as quickly as possible, and therefore
+      // gets us to full speed faster.
+      workerSchedulingPolicy: 'in-order',
+    });
+  }
+
+  _computeWorkerKey(method: string, filename: string): ?string {
+    // Only when transforming a file we want to stick to the same worker; and
+    // we'll shard by file path. If not; we return null, which tells the worker
+    // to pick the first available one.
+    if (method === 'transform') {
+      return filename;
+    }
+
+    return null;
+  }
+
+  _formatGenericError(
+    err: Readonly<{message: string, stack?: string, ...}>,
+    filename: string,
+  ): TransformError {
+    const error = new TransformError(`${filename}: ${err.message}`);
+
+    // $FlowFixMe[unsafe-object-assign]
+    return Object.assign(error, {
+      stack: (err.stack || '').split('\n').slice(0, -1).join('\n'),
+      lineNumber: 0,
+    });
+  }
+
+  _formatBabelError(
+    err: Readonly<{
+      message: string,
+      stack?: string,
+      type?: string,
+      codeFrame?: unknown,
+      loc: {line?: number, column?: number, ...},
+      ...
+    }>,
+    filename: string,
+  ): TransformError {
+    const error = new TransformError(
+      `${err.type ?? 'Error'}${
+        err.message.includes(filename) ? '' : ' in ' + filename
+      }: ${err.message}`,
+    );
+
+    // $FlowFixMe[prop-missing]
+    // $FlowExpectedError[unsafe-object-assign] : TODO(t67543470): Change this to properly extend the error.
+    return Object.assign(error, {
+      stack: err.stack,
+      snippet: err.codeFrame,
+      lineNumber: err.loc.line,
+      column: err.loc.column,
+      filename,
+    });
+  }
+}
+
+class TransformError extends SyntaxError {
+  type: string = 'TransformError';
+
+  constructor(message: string) {
+    super(message);
+    Error.captureStackTrace && Error.captureStackTrace(this, TransformError);
+  }
+}

--- a/tests/integration/tests/fixtures/flow-libs/metro/DeltaBundler/buildSubgraph.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/DeltaBundler/buildSubgraph.js
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {RequireContext} from '../lib/contextModule';
+import type {
+  Dependency,
+  ModuleData,
+  ResolvedDependency,
+  ResolveFn,
+  TransformFn,
+  TransformResultDependency,
+} from './types';
+
+import {deriveAbsolutePathFromContext} from '../lib/contextModule';
+import {isResolvedDependency} from '../lib/isResolvedDependency';
+import path from 'path';
+
+type Parameters<T> = Readonly<{
+  resolve: ResolveFn,
+  transform: TransformFn<T>,
+  shouldTraverse: ResolvedDependency => boolean,
+}>;
+
+function resolveDependencies(
+  parentPath: string,
+  dependencies: ReadonlyArray<TransformResultDependency>,
+  resolve: ResolveFn,
+): {
+  dependencies: Map<string, Dependency>,
+  resolvedContexts: Map<string, RequireContext>,
+} {
+  const maybeResolvedDeps = new Map<string, Dependency>();
+  const resolvedContexts = new Map<string, RequireContext>();
+
+  for (const dep of dependencies) {
+    let maybeResolvedDep: Dependency;
+    const key = dep.data.key;
+
+    // `require.context`
+    const {contextParams} = dep.data;
+    if (contextParams) {
+      // Ensure the filepath has uniqueness applied to ensure multiple `require.context`
+      // statements can be used to target the same file with different properties.
+      const from = path.join(parentPath, '..', dep.name);
+      const absolutePath = deriveAbsolutePathFromContext(from, contextParams);
+
+      const resolvedContext: RequireContext = {
+        filter: new RegExp(
+          contextParams.filter.pattern,
+          contextParams.filter.flags,
+        ),
+        from,
+        mode: contextParams.mode,
+        recursive: contextParams.recursive,
+      };
+
+      resolvedContexts.set(key, resolvedContext);
+
+      maybeResolvedDep = {
+        absolutePath,
+        data: dep,
+      };
+    } else {
+      try {
+        maybeResolvedDep = {
+          absolutePath: resolve(parentPath, dep).filePath,
+          data: dep,
+        };
+      } catch (error) {
+        // Ignore unavailable optional dependencies. They are guarded
+        // with a try-catch block and will be handled during runtime.
+        if (dep.data.isOptional !== true) {
+          throw error;
+        }
+        maybeResolvedDep = {
+          data: dep,
+        };
+      }
+    }
+
+    if (maybeResolvedDeps.has(key)) {
+      throw new Error(
+        `resolveDependencies: Found duplicate dependency key '${key}' in ${parentPath}`,
+      );
+    }
+    maybeResolvedDeps.set(key, maybeResolvedDep);
+  }
+
+  return {
+    dependencies: maybeResolvedDeps,
+    resolvedContexts,
+  };
+}
+
+export async function buildSubgraph<T>(
+  entryPaths: ReadonlySet<string>,
+  resolvedContexts: ReadonlyMap<string, ?RequireContext>,
+  {resolve, transform, shouldTraverse}: Parameters<T>,
+): Promise<{
+  moduleData: Map<string, ModuleData<T>>,
+  errors: Map<string, Error>,
+}> {
+  const moduleData: Map<string, ModuleData<T>> = new Map();
+  const errors: Map<string, Error> = new Map();
+  const visitedPaths: Set<string> = new Set();
+
+  async function visit(
+    absolutePath: string,
+    requireContext: ?RequireContext,
+  ): Promise<void> {
+    if (visitedPaths.has(absolutePath)) {
+      return;
+    }
+    visitedPaths.add(absolutePath);
+    const transformResult = await transform(absolutePath, requireContext);
+
+    // Get the absolute path of all sub-dependencies (some of them could have been
+    // moved but maintain the same relative path).
+    const resolutionResult = resolveDependencies(
+      absolutePath,
+      transformResult.dependencies,
+      resolve,
+    );
+
+    moduleData.set(absolutePath, {
+      ...transformResult,
+      ...resolutionResult,
+    });
+
+    await Promise.all(
+      [...resolutionResult.dependencies.values()]
+        .filter(
+          dependency =>
+            isResolvedDependency(dependency) && shouldTraverse(dependency),
+        )
+        .map(dependency =>
+          visit(
+            dependency.absolutePath,
+            resolutionResult.resolvedContexts.get(dependency.data.data.key),
+          ).catch(error => errors.set(dependency.absolutePath, error)),
+        ),
+    );
+  }
+
+  await Promise.all(
+    [...entryPaths].map(absolutePath =>
+      visit(absolutePath, resolvedContexts.get(absolutePath)).catch(error =>
+        errors.set(absolutePath, error),
+      ),
+    ),
+  );
+
+  return {errors, moduleData};
+}

--- a/tests/integration/tests/fixtures/flow-libs/metro/DeltaBundler/mergeDeltas.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/DeltaBundler/mergeDeltas.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {DeltaBundle} from 'metro-runtime/src/modules/types';
+
+export default function mergeDeltas(
+  delta1: DeltaBundle,
+  delta2: DeltaBundle,
+): DeltaBundle {
+  const added1 = new Map(delta1.added);
+  const modified1 = new Map(delta1.modified);
+  const deleted1 = new Set(delta1.deleted);
+  const added2 = new Map(delta2.added);
+  const modified2 = new Map(delta2.modified);
+  const deleted2 = new Set(delta2.deleted);
+  const added = new Map<number, string>();
+  const modified = new Map<number, string>();
+  const deleted = new Set<number>();
+
+  for (const [id, code] of added1) {
+    if (!deleted2.has(id) && !modified2.has(id)) {
+      added.set(id, code);
+    }
+  }
+
+  for (const [id, code] of modified1) {
+    if (!deleted2.has(id) && !modified2.has(id)) {
+      modified.set(id, code);
+    }
+  }
+
+  for (const id of deleted1) {
+    if (!added2.has(id)) {
+      deleted.add(id);
+    }
+  }
+
+  for (const [id, code] of added2) {
+    if (deleted1.has(id)) {
+      modified.set(id, code);
+    } else {
+      added.set(id, code);
+    }
+  }
+
+  for (const [id, code] of modified2) {
+    if (added1.has(id)) {
+      added.set(id, code);
+    } else {
+      modified.set(id, code);
+    }
+  }
+
+  for (const id of deleted2) {
+    if (!added1.has(id)) {
+      deleted.add(id);
+    }
+  }
+
+  return {
+    added: [...added.entries()],
+    modified: [...modified.entries()],
+    deleted: [...deleted],
+  };
+}

--- a/tests/integration/tests/fixtures/flow-libs/metro/DeltaBundler/types.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/DeltaBundler/types.js
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {RequireContext} from '../lib/contextModule';
+import type {RequireContextParams} from '../ModuleGraph/worker/collectDependencies';
+import type {ReadonlySourceLocation} from '../shared/types';
+import type {Graph} from './Graph';
+import type {JsTransformOptions} from 'metro-transform-worker';
+
+import CountingSet from '../lib/CountingSet';
+
+export type MixedOutput = {
+  +data: unknown,
+  +type: string,
+};
+
+export type AsyncDependencyType = 'async' | 'maybeSync' | 'prefetch' | 'weak';
+
+export type TransformResultDependency = Readonly<{
+  /**
+   * The literal name provided to a require or import call. For example 'foo' in
+   * case of `require('foo')`.
+   */
+  name: string,
+
+  /**
+   * Extra data returned by the dependency extractor.
+   */
+  data: Readonly<{
+    /**
+     * A locally unique key for this dependency within the current module.
+     */
+    key: string,
+    /**
+     * If not null, this dependency is due to a dynamic `import()` or `__prefetchImport()` call.
+     */
+    asyncType: AsyncDependencyType | null,
+    /**
+     * True if the dependency is declared with a static "import x from 'y'" or
+     * an import() call.
+     */
+    isESMImport: boolean,
+    /**
+     * The dependency is enclosed in a try/catch block.
+     */
+    isOptional?: boolean,
+
+    locs: ReadonlyArray<ReadonlySourceLocation>,
+
+    /** Context for requiring a collection of modules. */
+    contextParams?: RequireContextParams,
+  }>,
+}>;
+
+export type ResolvedDependency = Readonly<{
+  absolutePath: string,
+  data: TransformResultDependency,
+}>;
+
+export type Dependency =
+  | ResolvedDependency
+  | Readonly<{
+      data: TransformResultDependency,
+    }>;
+
+export type Module<T = MixedOutput> = Readonly<{
+  dependencies: Map<string, Dependency>,
+  inverseDependencies: CountingSet<string>,
+  output: ReadonlyArray<T>,
+  path: string,
+  getSource: () => Buffer,
+  unstable_transformResultKey?: ?string,
+}>;
+
+export type ModuleData<T = MixedOutput> = Readonly<{
+  dependencies: ReadonlyMap<string, Dependency>,
+  resolvedContexts: ReadonlyMap<string, RequireContext>,
+  output: ReadonlyArray<T>,
+  getSource: () => Buffer,
+  unstable_transformResultKey?: ?string,
+}>;
+
+export type Dependencies<T = MixedOutput> = Map<string, Module<T>>;
+export type ReadOnlyDependencies<T = MixedOutput> = ReadonlyMap<
+  string,
+  Module<T>,
+>;
+
+export type TransformInputOptions = Omit<
+  JsTransformOptions,
+  'inlinePlatform' | 'inlineRequires',
+>;
+
+export type GraphInputOptions = Readonly<{
+  entryPoints: ReadonlySet<string>,
+  // Unused in core but useful for custom serializers / experimentalSerializerHook
+  transformOptions: TransformInputOptions,
+}>;
+
+export interface ReadOnlyGraph<T = MixedOutput> {
+  +entryPoints: ReadonlySet<string>;
+  // Unused in core but useful for custom serializers / experimentalSerializerHook
+  +transformOptions: Readonly<TransformInputOptions>;
+  +dependencies: ReadOnlyDependencies<T>;
+}
+
+export type {Graph};
+
+export type TransformResult<T = MixedOutput> = Readonly<{
+  dependencies: ReadonlyArray<TransformResultDependency>,
+  output: ReadonlyArray<T>,
+  unstable_transformResultKey?: ?string,
+}>;
+
+export type TransformResultWithSource<T = MixedOutput> = Readonly<{
+  ...TransformResult<T>,
+  getSource: () => Buffer,
+}>;
+
+export type TransformFn<T = MixedOutput> = (
+  string,
+  ?RequireContext,
+) => Promise<TransformResultWithSource<T>>;
+
+export type ResolveFn = (
+  from: string,
+  dependency: TransformResultDependency,
+) => BundlerResolution;
+
+export type AllowOptionalDependenciesWithOptions = {
+  +exclude: Array<string>,
+};
+export type AllowOptionalDependencies =
+  | boolean
+  | AllowOptionalDependenciesWithOptions;
+
+export type BundlerResolution = Readonly<{
+  type: 'sourceFile',
+  filePath: string,
+}>;
+
+export type Options<T = MixedOutput> = Readonly<{
+  resolve: ResolveFn,
+  transform: TransformFn<T>,
+  transformOptions: TransformInputOptions,
+  onProgress: ?(numProcessed: number, total: number) => unknown,
+  lazy: boolean,
+  unstable_allowRequireContext: boolean,
+  unstable_enablePackageExports: boolean,
+  unstable_incrementalResolution: boolean,
+  shallow: boolean,
+}>;
+
+export type DeltaResult<T = MixedOutput> = {
+  +added: Map<string, Module<T>>,
+  +modified: Map<string, Module<T>>,
+  +deleted: Set<string>,
+  +reset: boolean,
+};
+
+export type SerializerOptions = Readonly<{
+  asyncRequireModulePath: string,
+  createModuleId: string => number,
+  dev: boolean,
+  getRunModuleStatement: (
+    moduleId: number | string,
+    globalPrefix: string,
+  ) => string,
+  globalPrefix: string,
+  includeAsyncPaths: boolean,
+  inlineSourceMap: ?boolean,
+  modulesOnly: boolean,
+  processModuleFilter: (module: Module<>) => boolean,
+  projectRoot: string,
+  runBeforeMainModule: ReadonlyArray<string>,
+  runModule: boolean,
+  serverRoot: string,
+  shouldAddToIgnoreList: (Module<>) => boolean,
+  sourceMapUrl: ?string,
+  sourceUrl: ?string,
+  getSourceUrl: ?(Module<>) => string,
+}>;

--- a/tests/integration/tests/fixtures/flow-libs/metro/HmrServer.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/HmrServer.js
@@ -1,0 +1,404 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {
+  RevisionId,
+  default as IncrementalBundler,
+} from './IncrementalBundler';
+import type {GraphOptions} from './shared/types';
+import type {ConfigT, RootPerfLogger} from 'metro-config';
+import type {
+  HmrClientMessage,
+  HmrErrorMessage,
+  HmrMessage,
+  HmrUpdateMessage,
+} from 'metro-runtime/src/modules/types';
+
+import hmrJSBundle from './DeltaBundler/Serializers/hmrJSBundle';
+import GraphNotFoundError from './IncrementalBundler/GraphNotFoundError';
+import RevisionNotFoundError from './IncrementalBundler/RevisionNotFoundError';
+import debounceAsyncQueue from './lib/debounceAsyncQueue';
+import formatBundlingError from './lib/formatBundlingError';
+import getGraphId from './lib/getGraphId';
+import parseBundleOptionsFromBundleRequestUrl from './lib/parseBundleOptionsFromBundleRequestUrl';
+import splitBundleOptions from './lib/splitBundleOptions';
+import * as transformHelpers from './lib/transformHelpers';
+import {Logger} from 'metro-core';
+import nullthrows from 'nullthrows';
+
+// eslint-disable-next-line import/no-commonjs
+const debug = require('debug')('Metro:HMR');
+
+const {createActionStartEntry, createActionEndEntry, log} = Logger;
+
+export type Client = {
+  optedIntoHMR: boolean,
+  revisionIds: Array<RevisionId>,
+  +sendFn: string => void,
+};
+
+type ClientGroup = {
+  +clients: Set<Client>,
+  clientUrl: URL,
+  revisionId: RevisionId,
+  +unlisten: () => void,
+  +graphOptions: GraphOptions,
+};
+
+function send(sendFns: Array<(string) => void>, message: HmrMessage): void {
+  const strMessage = JSON.stringify(message);
+  sendFns.forEach((sendFn: string => void) => sendFn(strMessage));
+}
+
+/**
+ * The HmrServer (Hot Module Reloading) implements a lightweight interface
+ * to communicate easily to the logic in the React Native repository (which
+ * is the one that handles the Web Socket connections).
+ *
+ * This interface allows the HmrServer to hook its own logic to WS clients
+ * getting connected, disconnected or having errors (through the
+ * `onClientConnect`, `onClientDisconnect` and `onClientError` methods).
+ */
+export default class HmrServer<TClient extends Client> {
+  _config: ConfigT;
+  _bundler: IncrementalBundler;
+  _createModuleId: (path: string) => number;
+  _clientGroups: Map<RevisionId, ClientGroup>;
+
+  constructor(
+    bundler: IncrementalBundler,
+    createModuleId: (path: string) => number,
+    config: ConfigT,
+  ) {
+    this._config = config;
+    this._bundler = bundler;
+    this._createModuleId = createModuleId;
+    this._clientGroups = new Map();
+  }
+
+  onClientConnect: (
+    requestUrl: string,
+    sendFn: (data: string) => void,
+  ) => Promise<Client> = async (requestUrl, sendFn) => {
+    return {
+      sendFn,
+      revisionIds: [],
+      optedIntoHMR: false,
+    };
+  };
+
+  async _registerEntryPoint(
+    client: Client,
+    originalRequestUrl: string,
+    sendFn: (data: string) => void,
+  ): Promise<void> {
+    debug('Registering entry point: %s', originalRequestUrl);
+    const requestUrl =
+      this._config.server.rewriteRequestUrl(originalRequestUrl);
+    debug('Rewritten as: %s', requestUrl);
+
+    const {bundleType: _bundleType, ...options} =
+      parseBundleOptionsFromBundleRequestUrl(
+        requestUrl,
+        new Set(this._config.resolver.platforms),
+      );
+    const {entryFile, resolverOptions, transformOptions, graphOptions} =
+      splitBundleOptions(options);
+
+    /**
+     * `entryFile` is relative to projectRoot, we need to use resolution function
+     * to find the appropriate file with supported extensions.
+     */
+    const resolutionFn = await transformHelpers.getResolveDependencyFn(
+      this._bundler.getBundler(),
+      transformOptions.platform,
+      resolverOptions,
+    );
+    const resolvedEntryFilePath = resolutionFn(
+      (this._config.server.unstable_serverRoot ?? this._config.projectRoot) +
+        '/.',
+      {
+        name: entryFile,
+        data: {
+          key: entryFile,
+          asyncType: null,
+          isESMImport: false,
+          locs: [],
+        },
+      },
+    ).filePath;
+    const graphId = getGraphId(resolvedEntryFilePath, transformOptions, {
+      resolverOptions,
+      shallow: graphOptions.shallow,
+      lazy: graphOptions.lazy,
+      unstable_allowRequireContext:
+        this._config.transformer.unstable_allowRequireContext,
+    });
+    const revPromise = this._bundler.getRevisionByGraphId(graphId);
+    if (!revPromise) {
+      send([sendFn], {
+        type: 'error',
+        body: formatBundlingError(new GraphNotFoundError(graphId)),
+      });
+      return;
+    }
+
+    const {graph, id} = await revPromise;
+    client.revisionIds.push(id);
+
+    let clientGroup: ?ClientGroup = this._clientGroups.get(id);
+    if (clientGroup != null) {
+      clientGroup.clients.add(client);
+    } else {
+      const clientUrl = new URL(requestUrl);
+
+      // Prepare the clientUrl to be used as sourceUrl in HMR updates.
+      clientUrl.protocol = 'http';
+
+      const clientQuery = clientUrl.searchParams;
+      clientQuery.delete('bundleEntry');
+      clientQuery.set('dev', clientQuery.get('dev') || 'true');
+      clientQuery.set('minify', clientQuery.get('minify') || 'false');
+      clientQuery.set('modulesOnly', 'true');
+      clientQuery.set('runModule', clientQuery.get('runModule') || 'false');
+      clientQuery.set('shallow', 'true');
+
+      clientGroup = {
+        clients: new Set([client]),
+        clientUrl: new URL(clientUrl),
+        revisionId: id,
+        graphOptions,
+        unlisten: (): void => unlisten(),
+      };
+
+      this._clientGroups.set(id, clientGroup);
+
+      let latestChangeEvent: ?{
+        +logger: ?RootPerfLogger,
+        +changeId: string,
+      } = null;
+
+      const debounceCallHandleFileChange = debounceAsyncQueue(async () => {
+        await this._handleFileChange(
+          nullthrows(clientGroup),
+          {isInitialUpdate: false},
+          latestChangeEvent,
+        );
+      }, 50);
+
+      const unlisten = this._bundler
+        .getDeltaBundler()
+        .listen(graph, async changeEvent => {
+          latestChangeEvent = changeEvent;
+          await debounceCallHandleFileChange();
+        });
+    }
+
+    await this._handleFileChange(clientGroup, {isInitialUpdate: true});
+    send([sendFn], {type: 'bundle-registered'});
+  }
+
+  onClientMessage: (
+    client: TClient,
+    message: string | Buffer | ArrayBuffer | Array<Buffer>,
+    sendFn: (data: string) => void,
+  ) => Promise<void> = async (client, message, sendFn) => {
+    let data: HmrClientMessage;
+    try {
+      data = JSON.parse(String(message));
+    } catch (error) {
+      send([sendFn], {
+        type: 'error',
+        body: formatBundlingError(error),
+      });
+      return Promise.resolve();
+    }
+    if (data && data.type) {
+      switch (data.type) {
+        case 'register-entrypoints':
+          return Promise.all(
+            data.entryPoints.map(entryPoint =>
+              this._registerEntryPoint(client, entryPoint, sendFn),
+            ),
+          );
+        case 'log':
+          if (this._config.server.forwardClientLogs) {
+            this._config.reporter.update({
+              type: 'client_log',
+              level: data.level,
+              data: data.data,
+              mode: data.mode,
+            });
+          }
+          break;
+        case 'log-opt-in':
+          client.optedIntoHMR = true;
+          break;
+        case 'heartbeat':
+          debug('Heartbeat received');
+          sendFn(String(message));
+          break;
+        default:
+          break;
+      }
+    }
+    return Promise.resolve();
+  };
+
+  onClientError: (client: TClient, e: Error) => void = (client, e) => {
+    this._config.reporter.update({
+      type: 'hmr_client_error',
+      error: e,
+    });
+    this.onClientDisconnect(client);
+  };
+
+  onClientDisconnect: (client: TClient) => void = client => {
+    client.revisionIds.forEach(revisionId => {
+      const group = this._clientGroups.get(revisionId);
+      if (group != null) {
+        if (group.clients.size === 1) {
+          this._clientGroups.delete(revisionId);
+          group.unlisten();
+        } else {
+          group.clients.delete(client);
+        }
+      }
+    });
+  };
+
+  async _handleFileChange(
+    group: ClientGroup,
+    options: {isInitialUpdate: boolean},
+    changeEvent: ?{
+      +logger: ?RootPerfLogger,
+      +changeId?: string,
+    },
+  ): Promise<void> {
+    const logger = !options.isInitialUpdate ? changeEvent?.logger : null;
+    if (logger) {
+      logger.point('fileChange_end');
+      logger.point('hmrPrepareAndSendMessage_start');
+    }
+
+    const optedIntoHMR = [...group.clients].some(
+      (client: Client) => client.optedIntoHMR,
+    );
+    const processingHmrChange = log(
+      createActionStartEntry({
+        // Even when HMR is disabled on the client, this function still
+        // runs so we can stash updates while it's off and apply them later.
+        // However, this would mess up our internal analytics because we track
+        // HMR as being used even for people who have it disabled.
+        // As a workaround, we use a different event name for clients
+        // that didn't explicitly opt into HMR.
+        action_name: optedIntoHMR
+          ? 'Processing HMR change'
+          : 'Processing HMR change (no client opt-in)',
+      }),
+    );
+
+    const sendFns = [...group.clients].map((client: Client) => client.sendFn);
+
+    send(sendFns, {
+      type: 'update-start',
+      body: options,
+    });
+
+    const message = await this._prepareMessage(group, options, changeEvent);
+    send(sendFns, message);
+    send(sendFns, {
+      type: 'update-done',
+      body: {changeId: changeEvent?.changeId},
+    });
+
+    log({
+      ...createActionEndEntry(processingHmrChange),
+      outdated_modules:
+        message.type === 'update'
+          ? message.body.added.length + message.body.modified.length
+          : undefined,
+    });
+
+    if (logger) {
+      logger.point('hmrPrepareAndSendMessage_end');
+      logger.end('SUCCESS');
+    }
+  }
+
+  async _prepareMessage(
+    group: ClientGroup,
+    options: {isInitialUpdate: boolean},
+    changeEvent: ?{
+      +logger: ?RootPerfLogger,
+      +changeId?: string,
+    },
+  ): Promise<HmrUpdateMessage | HmrErrorMessage> {
+    const logger = !options.isInitialUpdate ? changeEvent?.logger : null;
+    try {
+      const revPromise = this._bundler.getRevision(group.revisionId);
+      if (!revPromise) {
+        return {
+          type: 'error',
+          body: formatBundlingError(
+            new RevisionNotFoundError(group.revisionId),
+          ),
+        };
+      }
+
+      logger?.point('updateGraph_start');
+
+      const {revision, delta} = await this._bundler.updateGraph(
+        await revPromise,
+        false,
+      );
+
+      logger?.point('updateGraph_end');
+
+      this._clientGroups.delete(group.revisionId);
+      group.revisionId = revision.id;
+      for (const client of group.clients) {
+        client.revisionIds = client.revisionIds.filter(
+          revisionId => revisionId !== group.revisionId,
+        );
+        client.revisionIds.push(revision.id);
+      }
+      this._clientGroups.set(group.revisionId, group);
+
+      logger?.point('serialize_start');
+
+      const hmrUpdate = hmrJSBundle(delta, revision.graph, {
+        clientUrl: new URL(group.clientUrl),
+        createModuleId: this._createModuleId,
+        includeAsyncPaths: group.graphOptions.lazy,
+        projectRoot: this._config.projectRoot,
+        serverRoot:
+          this._config.server.unstable_serverRoot ?? this._config.projectRoot,
+      });
+
+      logger?.point('serialize_end');
+
+      return {
+        type: 'update',
+        body: {
+          revisionId: revision.id,
+          isInitialUpdate: options.isInitialUpdate,
+          ...hmrUpdate,
+        },
+      };
+    } catch (error) {
+      const formattedError = formatBundlingError(error);
+
+      this._config.reporter.update({type: 'bundling_error', error});
+
+      return {type: 'error', body: formattedError};
+    }
+  }
+}

--- a/tests/integration/tests/fixtures/flow-libs/metro/IncrementalBundler.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/IncrementalBundler.js
@@ -1,0 +1,370 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall react_native
+ */
+
+import type {DeltaResult, Graph, MixedOutput, Module} from './DeltaBundler';
+import type {
+  Options as DeltaBundlerOptions,
+  ReadOnlyDependencies,
+  TransformInputOptions,
+} from './DeltaBundler/types';
+import type {GraphId} from './lib/getGraphId';
+import type {ResolverInputOptions} from './shared/types';
+import type {ConfigT} from 'metro-config';
+
+import Bundler from './Bundler';
+import DeltaBundler from './DeltaBundler';
+import ResourceNotFoundError from './IncrementalBundler/ResourceNotFoundError';
+import getGraphId from './lib/getGraphId';
+import getPrependedScripts from './lib/getPrependedScripts';
+import * as transformHelpers from './lib/transformHelpers';
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+export opaque type RevisionId: string = string;
+
+export type OutputGraph = Graph<>;
+
+type OtherOptions = Readonly<{
+  onProgress: DeltaBundlerOptions<>['onProgress'],
+  shallow: boolean,
+  lazy: boolean,
+}>;
+
+export type GraphRevision = {
+  // Identifies the last computed revision.
+  +id: RevisionId,
+  +date: Date,
+  +graphId: GraphId,
+  +graph: OutputGraph,
+  +prepend: ReadonlyArray<Module<>>,
+};
+
+export type IncrementalBundlerOptions = Readonly<{
+  hasReducedPerformance?: boolean,
+  watch?: boolean,
+}>;
+
+function createRevisionId(): RevisionId {
+  return crypto.randomBytes(8).toString('hex');
+}
+
+function revisionIdFromString(str: string): RevisionId {
+  return str;
+}
+
+export default class IncrementalBundler {
+  _config: ConfigT;
+  _bundler: Bundler;
+  _deltaBundler: DeltaBundler<>;
+  _revisionsById: Map<RevisionId, Promise<GraphRevision>> = new Map();
+  _revisionsByGraphId: Map<GraphId, Promise<GraphRevision>> = new Map();
+
+  static revisionIdFromString: (str: string) => RevisionId =
+    revisionIdFromString;
+
+  constructor(config: ConfigT, options?: IncrementalBundlerOptions) {
+    this._config = config;
+    this._bundler = new Bundler(config, options);
+    this._deltaBundler = new DeltaBundler(this._bundler.getWatcher());
+  }
+
+  async end(): Promise<void> {
+    this._deltaBundler.end();
+    await this._bundler.end();
+  }
+
+  getBundler(): Bundler {
+    return this._bundler;
+  }
+
+  getDeltaBundler(): DeltaBundler<> {
+    return this._deltaBundler;
+  }
+
+  getRevision(revisionId: RevisionId): ?Promise<GraphRevision> {
+    return this._revisionsById.get(revisionId);
+  }
+
+  getRevisionByGraphId(graphId: GraphId): ?Promise<GraphRevision> {
+    return this._revisionsByGraphId.get(graphId);
+  }
+
+  async buildGraphForEntries(
+    entryFiles: ReadonlyArray<string>,
+    transformOptions: TransformInputOptions,
+    resolverOptions: ResolverInputOptions,
+    otherOptions?: OtherOptions = {
+      onProgress: null,
+      shallow: false,
+      lazy: false,
+    },
+  ): Promise<OutputGraph> {
+    const absoluteEntryFiles = await this._getAbsoluteEntryFiles(entryFiles);
+
+    const graph = await this._deltaBundler.buildGraph(absoluteEntryFiles, {
+      resolve: await transformHelpers.getResolveDependencyFn(
+        this._bundler,
+        transformOptions.platform,
+        resolverOptions,
+      ),
+      transform: await transformHelpers.getTransformFn(
+        absoluteEntryFiles,
+        this._bundler,
+        this._deltaBundler,
+        this._config,
+        transformOptions,
+        resolverOptions,
+      ),
+      transformOptions,
+      onProgress: otherOptions.onProgress,
+      lazy: otherOptions.lazy,
+      unstable_allowRequireContext:
+        this._config.transformer.unstable_allowRequireContext,
+      unstable_enablePackageExports:
+        this._config.resolver.unstable_enablePackageExports,
+      unstable_incrementalResolution:
+        this._config.resolver.unstable_incrementalResolution,
+      shallow: otherOptions.shallow,
+    });
+
+    this._config.serializer.experimentalSerializerHook(graph, {
+      added: graph.dependencies,
+      modified: new Map(),
+      deleted: new Set(),
+      reset: true,
+    });
+
+    return graph;
+  }
+
+  async getDependencies(
+    entryFiles: ReadonlyArray<string>,
+    transformOptions: TransformInputOptions,
+    resolverOptions: ResolverInputOptions,
+    otherOptions?: OtherOptions = {
+      onProgress: null,
+      shallow: false,
+      lazy: false,
+    },
+  ): Promise<ReadOnlyDependencies<>> {
+    const absoluteEntryFiles = await this._getAbsoluteEntryFiles(entryFiles);
+
+    const dependencies = await this._deltaBundler.getDependencies(
+      absoluteEntryFiles,
+      {
+        resolve: await transformHelpers.getResolveDependencyFn(
+          this._bundler,
+          transformOptions.platform,
+          resolverOptions,
+        ),
+        transform: await transformHelpers.getTransformFn(
+          absoluteEntryFiles,
+          this._bundler,
+          this._deltaBundler,
+          this._config,
+          transformOptions,
+          resolverOptions,
+        ),
+        transformOptions,
+        onProgress: otherOptions.onProgress,
+        lazy: otherOptions.lazy,
+        unstable_allowRequireContext:
+          this._config.transformer.unstable_allowRequireContext,
+        unstable_enablePackageExports:
+          this._config.resolver.unstable_enablePackageExports,
+        unstable_incrementalResolution:
+          this._config.resolver.unstable_incrementalResolution,
+        shallow: otherOptions.shallow,
+      },
+    );
+
+    return dependencies;
+  }
+
+  async buildGraph(
+    entryFile: string,
+    transformOptions: TransformInputOptions,
+    resolverOptions: ResolverInputOptions,
+    otherOptions?: OtherOptions = {
+      onProgress: null,
+      shallow: false,
+      lazy: false,
+    },
+  ): Promise<{+graph: OutputGraph, +prepend: ReadonlyArray<Module<>>}> {
+    const graph = await this.buildGraphForEntries(
+      [entryFile],
+      transformOptions,
+      resolverOptions,
+      otherOptions,
+    );
+
+    const {type: _, ...transformOptionsWithoutType} = transformOptions;
+
+    const prepend = await getPrependedScripts(
+      this._config,
+      transformOptionsWithoutType,
+      resolverOptions,
+      this._bundler,
+      this._deltaBundler,
+    );
+
+    return {
+      prepend,
+      graph,
+    };
+  }
+
+  // TODO T34760750 (alexkirsz) Eventually, I'd like to get to a point where
+  // this class exposes only initializeGraph and updateGraph.
+  async initializeGraph(
+    entryFile: string,
+    transformOptions: TransformInputOptions,
+    resolverOptions: ResolverInputOptions,
+    otherOptions?: OtherOptions = {
+      onProgress: null,
+      shallow: false,
+      lazy: false,
+    },
+  ): Promise<{
+    delta: DeltaResult<>,
+    revision: GraphRevision,
+    ...
+  }> {
+    const graphId = getGraphId(entryFile, transformOptions, {
+      resolverOptions,
+      shallow: otherOptions.shallow,
+      lazy: otherOptions.lazy,
+      unstable_allowRequireContext:
+        this._config.transformer.unstable_allowRequireContext,
+    });
+    const revisionId = createRevisionId();
+    const revisionPromise = (async () => {
+      const {graph, prepend} = await this.buildGraph(
+        entryFile,
+        transformOptions,
+        resolverOptions,
+        otherOptions,
+      );
+      return {
+        id: revisionId,
+        date: new Date(),
+        graphId,
+        graph,
+        prepend,
+      };
+    })();
+
+    this._revisionsById.set(revisionId, revisionPromise);
+    this._revisionsByGraphId.set(graphId, revisionPromise);
+    try {
+      const revision = await revisionPromise;
+      const delta = {
+        added: revision.graph.dependencies,
+        modified: new Map<string, Module<MixedOutput>>(),
+        deleted: new Set<string>(),
+        reset: true,
+      };
+      return {
+        revision,
+        delta,
+      };
+    } catch (err) {
+      // Evict a bad revision from the cache since otherwise
+      // we'll keep getting it even after the build is fixed.
+      this._revisionsById.delete(revisionId);
+      this._revisionsByGraphId.delete(graphId);
+      throw err;
+    }
+  }
+
+  async updateGraph(
+    revision: GraphRevision,
+    reset: boolean,
+  ): Promise<{
+    delta: DeltaResult<>,
+    revision: GraphRevision,
+    ...
+  }> {
+    const delta = await this._deltaBundler.getDelta(revision.graph, {
+      reset,
+      shallow: false,
+    });
+
+    this._config.serializer.experimentalSerializerHook(revision.graph, delta);
+
+    if (
+      delta.added.size > 0 ||
+      delta.modified.size > 0 ||
+      delta.deleted.size > 0
+    ) {
+      this._revisionsById.delete(revision.id);
+      revision = {
+        ...revision,
+        // Generate a new revision id, to be used to verify the next incremental
+        // request.
+        id: crypto.randomBytes(8).toString('hex'),
+        date: new Date(),
+      };
+      const revisionPromise = Promise.resolve(revision);
+      this._revisionsById.set(revision.id, revisionPromise);
+      this._revisionsByGraphId.set(revision.graphId, revisionPromise);
+    }
+
+    return {revision, delta};
+  }
+
+  async endGraph(graphId: GraphId): Promise<void> {
+    const revPromise = this._revisionsByGraphId.get(graphId);
+    if (!revPromise) {
+      return;
+    }
+    const revision = await revPromise;
+    this._deltaBundler.endGraph(revision.graph);
+    this._revisionsByGraphId.delete(graphId);
+    this._revisionsById.delete(revision.id);
+  }
+
+  async _getAbsoluteEntryFiles(
+    entryFiles: ReadonlyArray<string>,
+  ): Promise<ReadonlyArray<string>> {
+    const absoluteEntryFiles = entryFiles.map((entryFile: string) =>
+      path.resolve(
+        this._config.server.unstable_serverRoot ?? this._config.projectRoot,
+        entryFile,
+      ),
+    );
+
+    await Promise.all(
+      absoluteEntryFiles.map(
+        (entryFile: string) =>
+          new Promise((resolve: void => void, reject: unknown => unknown) => {
+            // This should throw an error if the file doesn't exist.
+            // Using this instead of fs.exists to account for SimLinks.
+            fs.realpath(entryFile, err => {
+              if (err) {
+                reject(new ResourceNotFoundError(entryFile));
+              } else {
+                resolve();
+              }
+            });
+          }),
+      ),
+    );
+
+    return absoluteEntryFiles;
+  }
+
+  // Wait for the bundler to become ready.
+  async ready(): Promise<void> {
+    await this._bundler.ready();
+  }
+}

--- a/tests/integration/tests/fixtures/flow-libs/metro/Server.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/Server.js
@@ -1,0 +1,1817 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall react_native
+ */
+
+import type {AssetData} from './Assets';
+import type {ExplodedSourceMap} from './DeltaBundler/Serializers/getExplodedSourceMap';
+import type {RamBundleInfo} from './DeltaBundler/Serializers/getRamBundleInfo';
+import type {
+  MixedOutput,
+  Module,
+  ReadOnlyDependencies,
+  ReadOnlyGraph,
+  TransformInputOptions,
+  TransformResult,
+} from './DeltaBundler/types';
+import type {RevisionId} from './IncrementalBundler';
+import type {GraphId} from './lib/getGraphId';
+import type {JsonData} from './lib/parseJsonBody';
+import type {Reporter} from './lib/reporting';
+import type {StackFrameInput, StackFrameOutput} from './Server/symbolicate';
+import type {
+  BuildOptions,
+  BundleOptions,
+  GraphOptions,
+  ResolverInputOptions,
+  SplitBundleOptions,
+} from './shared/types';
+import type {IncomingMessage} from 'connect';
+import type {ServerResponse} from 'http';
+import type {CacheStore} from 'metro-cache';
+import type {ConfigT, RootPerfLogger} from 'metro-config';
+import type {
+  ActionLogEntryData,
+  ActionStartLogEntry,
+} from 'metro-core/private/Logger';
+import type {CustomResolverOptions} from 'metro-resolver/private/types';
+import type {CustomTransformOptions} from 'metro-transform-worker';
+
+import {getAsset} from './Assets';
+import baseJSBundle from './DeltaBundler/Serializers/baseJSBundle';
+import getAllFiles from './DeltaBundler/Serializers/getAllFiles';
+import getAssets from './DeltaBundler/Serializers/getAssets';
+import {getExplodedSourceMap} from './DeltaBundler/Serializers/getExplodedSourceMap';
+import getRamBundleInfo from './DeltaBundler/Serializers/getRamBundleInfo';
+import {sourceMapStringNonBlocking} from './DeltaBundler/Serializers/sourceMapString';
+import IncrementalBundler from './IncrementalBundler';
+import ResourceNotFoundError from './IncrementalBundler/ResourceNotFoundError';
+import {calculateBundleProgressRatio} from './lib/bundleProgressUtils';
+import bundleToString from './lib/bundleToString';
+import formatBundlingError from './lib/formatBundlingError';
+import getGraphId from './lib/getGraphId';
+import parseBundleOptionsFromBundleRequestUrl from './lib/parseBundleOptionsFromBundleRequestUrl';
+import parseJsonBody from './lib/parseJsonBody';
+import splitBundleOptions from './lib/splitBundleOptions';
+import * as transformHelpers from './lib/transformHelpers';
+import {UnableToResolveError} from './node-haste/DependencyGraph/ModuleResolution';
+import parsePlatformFilePath from './node-haste/lib/parsePlatformFilePath';
+import MultipartResponse from './Server/MultipartResponse';
+import symbolicate from './Server/symbolicate';
+import {SourcePathsMode} from './shared/types';
+import {codeFrameColumns} from '@babel/code-frame';
+import * as fs from 'graceful-fs';
+import * as jscSafeUrl from 'jsc-safe-url';
+import {Logger} from 'metro-core';
+import mime from 'mime-types';
+import nullthrows from 'nullthrows';
+import path from 'path';
+import {performance} from 'perf_hooks';
+import querystring from 'querystring';
+
+// eslint-disable-next-line import/no-commonjs
+const debug = require('debug')('Metro:Server');
+
+const {createActionStartEntry, createActionEndEntry, log} = Logger;
+
+const noopLogger: RootPerfLogger = {
+  start: () => {},
+  point: () => {},
+  annotate: () => {},
+  subSpan: () => noopLogger,
+  end: () => {},
+};
+
+export type SegmentLoadData = {[number]: [Array<number>, ?number], ...};
+export type BundleMetadata = {
+  hash: string,
+  otaBuildNumber: ?string,
+  mobileConfigs: Array<string>,
+  segmentHashes: Array<string>,
+  segmentLoadData: SegmentLoadData,
+  ...
+};
+
+type ProcessStartContext = {
+  ...SplitBundleOptions,
+  +buildNumber: number,
+  +bundleOptions: BundleOptions,
+  +graphId: GraphId,
+  +graphOptions: GraphOptions,
+  +mres: MultipartResponse | ServerResponse,
+  +req: IncomingMessage,
+  +revisionId?: ?RevisionId,
+  +bundlePerfLogger: RootPerfLogger,
+  +requestStartTimestamp: number,
+};
+
+type ProcessDeleteContext = {
+  +graphId: GraphId,
+  +req: IncomingMessage,
+  +res: ServerResponse,
+};
+
+type ProcessEndContext<T> = {
+  ...ProcessStartContext,
+  +result: T,
+};
+
+export type ServerOptions = Readonly<{
+  hasReducedPerformance?: boolean,
+  onBundleBuilt?: (bundlePath: string) => void,
+  watch?: boolean,
+}>;
+
+const DELTA_ID_HEADER = 'X-Metro-Delta-ID';
+const FILES_CHANGED_COUNT_HEADER = 'X-Metro-Files-Changed-Count';
+
+type FetchTiming = {
+  graphId: GraphId,
+  startTime: number,
+  endTime: number | null,
+  isPrefetch: boolean,
+};
+
+export default class Server {
+  _bundler: IncrementalBundler;
+  _config: ConfigT;
+  _createModuleId: (path: string) => number;
+  _isEnded: boolean;
+  _logger: typeof Logger;
+  _nextBundleBuildNumber: number;
+  _platforms: Set<string>;
+  _reporter: Reporter;
+  _serverOptions: ServerOptions | void;
+  _allowedSuffixesForSourceRequests: ReadonlyArray<string>;
+  _sourceRequestRoutingMap: ReadonlyArray<
+    [pathnamePrefix: string, normalizedRootDir: string],
+  >;
+  _fetchTimings: Array<FetchTiming>;
+  _activeFetchCount: number;
+
+  constructor(config: ConfigT, options?: ServerOptions) {
+    this._config = config;
+    this._serverOptions = options;
+
+    if (this._config.resetCache) {
+      this._config.cacheStores.forEach((store: CacheStore<TransformResult<>>) =>
+        store.clear(),
+      );
+      this._config.reporter.update({type: 'transform_cache_reset'});
+    }
+
+    this._reporter = config.reporter;
+    this._logger = Logger;
+    this._platforms = new Set(this._config.resolver.platforms);
+    this._allowedSuffixesForSourceRequests = [
+      ...new Set(
+        [
+          ...this._config.resolver.sourceExts,
+          ...this._config.watcher.additionalExts,
+          ...this._config.resolver.assetExts,
+        ].map(ext => '.' + ext),
+      ),
+    ];
+    this._sourceRequestRoutingMap = [
+      ['/[metro-project]/', path.resolve(this._config.projectRoot)],
+      ...this._config.watchFolders.map((watchFolder, index) => [
+        `/[metro-watchFolders]/${index}/`,
+        path.resolve(watchFolder),
+      ]),
+    ];
+    this._isEnded = false;
+    this._fetchTimings = [];
+    this._activeFetchCount = 0;
+
+    // TODO(T34760917): These two properties should eventually be instantiated
+    // elsewhere and passed as parameters, since they are also needed by
+    // the HmrServer.
+    // The whole bundling/serializing logic should follow as well.
+    this._createModuleId = config.serializer.createModuleIdFactory();
+    this._bundler = new IncrementalBundler(config, {
+      hasReducedPerformance: options && options.hasReducedPerformance,
+      watch: options ? options.watch : undefined,
+    });
+    this._nextBundleBuildNumber = 1;
+  }
+
+  async end() {
+    if (!this._isEnded) {
+      await this._bundler.end();
+      this._isEnded = true;
+    }
+  }
+
+  getBundler(): IncrementalBundler {
+    return this._bundler;
+  }
+
+  getCreateModuleId(): (path: string) => number {
+    return this._createModuleId;
+  }
+
+  async _serializeGraph({
+    splitOptions,
+    prepend,
+    graph,
+  }: Readonly<{
+    splitOptions: SplitBundleOptions,
+    prepend: ReadonlyArray<Module<>>,
+    graph: ReadOnlyGraph<>,
+  }>): Promise<{code: string, map: string}> {
+    const {
+      entryFile,
+      graphOptions,
+      resolverOptions,
+      serializerOptions,
+      transformOptions,
+    } = splitOptions;
+
+    const entryPoint = this._getEntryPointAbsolutePath(entryFile);
+
+    const bundleOptions = {
+      asyncRequireModulePath: await this._resolveRelativePath(
+        this._config.transformer.asyncRequireModulePath,
+        {
+          relativeTo: 'project',
+          resolverOptions,
+          transformOptions,
+        },
+      ),
+      processModuleFilter: this._config.serializer.processModuleFilter,
+      createModuleId: this._createModuleId,
+      getRunModuleStatement: this._config.serializer.getRunModuleStatement,
+      globalPrefix: this._config.transformer.globalPrefix,
+      dev: transformOptions.dev,
+      includeAsyncPaths: graphOptions.lazy,
+      projectRoot: this._config.projectRoot,
+      modulesOnly: serializerOptions.modulesOnly,
+      runBeforeMainModule:
+        this._config.serializer.getModulesRunBeforeMainModule(
+          path.relative(this._config.projectRoot, entryPoint),
+        ),
+      runModule: serializerOptions.runModule,
+      sourceMapUrl: serializerOptions.sourceMapUrl,
+      sourceUrl: serializerOptions.sourceUrl,
+      inlineSourceMap: serializerOptions.inlineSourceMap,
+      serverRoot:
+        this._config.server.unstable_serverRoot ?? this._config.projectRoot,
+      shouldAddToIgnoreList: (module: Module<>) =>
+        this._shouldAddModuleToIgnoreList(module),
+      getSourceUrl: (module: Module<>) =>
+        this._getModuleSourceUrl(module, serializerOptions.sourcePaths),
+    };
+    let bundleCode = null;
+    let bundleMap = null;
+    if (this._config.serializer.customSerializer) {
+      const bundle = await this._config.serializer.customSerializer(
+        entryPoint,
+        prepend,
+        graph,
+        bundleOptions,
+      );
+      if (typeof bundle === 'string') {
+        bundleCode = bundle;
+      } else {
+        bundleCode = bundle.code;
+        bundleMap = bundle.map;
+      }
+    } else {
+      bundleCode = bundleToString(
+        baseJSBundle(entryPoint, prepend, graph, bundleOptions),
+      ).code;
+    }
+    if (!bundleMap) {
+      bundleMap = await sourceMapStringNonBlocking(
+        [...prepend, ...this._getSortedModules(graph)],
+        {
+          excludeSource: serializerOptions.excludeSource,
+          processModuleFilter: this._config.serializer.processModuleFilter,
+          shouldAddToIgnoreList: bundleOptions.shouldAddToIgnoreList,
+          getSourceUrl: (module: Module<>) =>
+            this._getModuleSourceUrl(module, serializerOptions.sourcePaths),
+        },
+      );
+    }
+    return {
+      code: bundleCode,
+      map: bundleMap,
+    };
+  }
+
+  async build(
+    bundleOptions: BundleOptions,
+    {withAssets}: BuildOptions = {},
+  ): Promise<{
+    code: string,
+    map: string,
+    assets?: ReadonlyArray<AssetData>,
+    ...
+  }> {
+    const splitOptions = splitBundleOptions(bundleOptions);
+    const {
+      entryFile,
+      graphOptions,
+      onProgress,
+      resolverOptions,
+      transformOptions,
+    } = splitOptions;
+
+    const {prepend, graph} = await this._bundler.buildGraph(
+      entryFile,
+      transformOptions,
+      resolverOptions,
+      {
+        onProgress,
+        shallow: graphOptions.shallow,
+        lazy: graphOptions.lazy,
+      },
+    );
+
+    const [{code, map}, assets] = await Promise.all([
+      this._serializeGraph({
+        splitOptions,
+        prepend,
+        graph,
+      }),
+      withAssets
+        ? this._getAssetsFromDependencies(
+            graph.dependencies,
+            bundleOptions.platform,
+          )
+        : null,
+    ]);
+
+    return {
+      code,
+      map,
+      ...(withAssets ? {assets: nullthrows(assets)} : null),
+    };
+  }
+
+  async getRamBundleInfo(options: BundleOptions): Promise<RamBundleInfo> {
+    const {
+      entryFile,
+      graphOptions,
+      onProgress,
+      resolverOptions,
+      serializerOptions,
+      transformOptions,
+    } = splitBundleOptions(options);
+
+    const {prepend, graph} = await this._bundler.buildGraph(
+      entryFile,
+      transformOptions,
+      resolverOptions,
+      {
+        onProgress,
+        shallow: graphOptions.shallow,
+        lazy: graphOptions.lazy,
+      },
+    );
+
+    const entryPoint = this._getEntryPointAbsolutePath(entryFile);
+
+    return await getRamBundleInfo(entryPoint, prepend, graph, {
+      asyncRequireModulePath: await this._resolveRelativePath(
+        this._config.transformer.asyncRequireModulePath,
+        {
+          relativeTo: 'project',
+          resolverOptions,
+          transformOptions,
+        },
+      ),
+      processModuleFilter: this._config.serializer.processModuleFilter,
+      createModuleId: this._createModuleId,
+      dev: transformOptions.dev,
+      excludeSource: serializerOptions.excludeSource,
+      getRunModuleStatement: this._config.serializer.getRunModuleStatement,
+      getTransformOptions: this._config.transformer.getTransformOptions,
+      globalPrefix: this._config.transformer.globalPrefix,
+      includeAsyncPaths: graphOptions.lazy,
+      platform: transformOptions.platform,
+      projectRoot: this._config.projectRoot,
+      modulesOnly: serializerOptions.modulesOnly,
+      runBeforeMainModule:
+        this._config.serializer.getModulesRunBeforeMainModule(
+          path.relative(this._config.projectRoot, entryPoint),
+        ),
+      runModule: serializerOptions.runModule,
+      sourceMapUrl: serializerOptions.sourceMapUrl,
+      sourceUrl: serializerOptions.sourceUrl,
+      inlineSourceMap: serializerOptions.inlineSourceMap,
+      serverRoot:
+        this._config.server.unstable_serverRoot ?? this._config.projectRoot,
+      shouldAddToIgnoreList: (module: Module<>) =>
+        this._shouldAddModuleToIgnoreList(module),
+      getSourceUrl: (module: Module<>) =>
+        this._getModuleSourceUrl(module, serializerOptions.sourcePaths),
+    });
+  }
+
+  async getAssets(options: BundleOptions): Promise<ReadonlyArray<AssetData>> {
+    const {entryFile, onProgress, resolverOptions, transformOptions} =
+      splitBundleOptions(options);
+
+    const dependencies = await this._bundler.getDependencies(
+      [entryFile],
+      transformOptions,
+      resolverOptions,
+      {onProgress, shallow: false, lazy: false},
+    );
+
+    return this._getAssetsFromDependencies(
+      dependencies,
+      transformOptions.platform,
+    );
+  }
+
+  async _getAssetsFromDependencies(
+    dependencies: ReadOnlyDependencies<>,
+    platform: ?string,
+  ): Promise<ReadonlyArray<AssetData>> {
+    return await getAssets(dependencies, {
+      processModuleFilter: this._config.serializer.processModuleFilter,
+      assetPlugins: this._config.transformer.assetPlugins,
+      platform,
+      projectRoot: this._getServerRootDir(),
+      publicPath: this._config.transformer.publicPath,
+    });
+  }
+
+  async getOrderedDependencyPaths(options: {
+    +dev: boolean,
+    +entryFile: string,
+    +minify: boolean,
+    +platform: ?string,
+    ...
+  }): Promise<Array<string>> {
+    const {
+      entryFile,
+      onProgress,
+      resolverOptions,
+      transformOptions,
+      /* $FlowFixMe[cannot-spread-inexact](>=0.122.0 site=react_native_fb) This comment suppresses an
+       * error found when Flow v0.122.0 was deployed. To see the error, delete
+       * this comment and run Flow. */
+    } = splitBundleOptions({
+      ...Server.DEFAULT_BUNDLE_OPTIONS,
+      ...options,
+    });
+
+    const {prepend, graph} = await this._bundler.buildGraph(
+      entryFile,
+      transformOptions,
+      resolverOptions,
+      {onProgress, shallow: false, lazy: false},
+    );
+
+    const platform =
+      transformOptions.platform ||
+      parsePlatformFilePath(entryFile, this._platforms).platform;
+
+    // $FlowFixMe[incompatible-type]
+    return await getAllFiles(prepend, graph, {
+      platform,
+      processModuleFilter: this._config.serializer.processModuleFilter,
+    });
+  }
+
+  _rangeRequestMiddleware(
+    req: IncomingMessage,
+    res: ServerResponse,
+    data: string | Buffer,
+    assetPath: string,
+  ): Buffer | string {
+    if (req.headers && req.headers.range) {
+      const [rangeStart, rangeEnd] = req.headers.range
+        .replace(/bytes=/, '')
+        .split('-');
+      const dataStart = parseInt(rangeStart, 10);
+      const dataEnd = rangeEnd ? parseInt(rangeEnd, 10) : data.length - 1;
+      const chunksize = dataEnd - dataStart + 1;
+
+      res.writeHead(206, {
+        'Accept-Ranges': 'bytes',
+        'Content-Length': chunksize.toString(),
+        'Content-Range': `bytes ${dataStart}-${dataEnd}/${data.length}`,
+      });
+
+      return data.slice(dataStart, dataEnd + 1);
+    }
+
+    res.setHeader('Content-Length', String(Buffer.byteLength(data)));
+
+    return data;
+  }
+
+  async _processSingleAssetRequest(
+    req: IncomingMessage,
+    res: ServerResponse,
+  ): Promise<void> {
+    debug('Processing single asset request: %s', req.url);
+    if (!URL.canParse(req.url, 'resolve://')) {
+      throw new Error('Could not parse URL', {cause: req.url});
+    }
+
+    const urlObj = new URL(req.url, 'resolve://');
+    const formattedUrl = urlObj.toString();
+    if (req.url !== formattedUrl) {
+      debug('Formatted as:    %s', formattedUrl);
+    }
+
+    // using this Metro particular convention for decoding URL paths into file paths
+    let [, assetPath] =
+      urlObj.pathname
+        .split('/')
+        .map(segment => decodeURIComponent(segment))
+        .join('/')
+        .match(/^\/assets\/(.+)$/) || [];
+    if (!assetPath && urlObj.searchParams.get('unstable_path')) {
+      const [, actualPath, secondaryQuery] = nullthrows(
+        (urlObj.searchParams.get('unstable_path') || '').match(
+          /^([^?]*)\??(.*)$/,
+        ),
+      );
+      if (secondaryQuery) {
+        Object.entries(querystring.parse(secondaryQuery)).forEach(
+          ([key, value]) => {
+            urlObj.searchParams.set(key, value);
+          },
+        );
+      }
+      assetPath = actualPath;
+    }
+
+    if (!assetPath) {
+      throw new Error('Could not extract asset path from URL');
+    }
+
+    const processingAssetRequestLogEntry = log(
+      createActionStartEntry({
+        action_name: 'Processing asset request',
+        asset: assetPath[1],
+      }),
+    );
+
+    try {
+      const depGraph = await this._bundler.getBundler().getDependencyGraph();
+      const data = await getAsset(
+        assetPath,
+        this._config.projectRoot,
+        this._config.watchFolders,
+        urlObj.searchParams.get('platform'),
+        this._config.resolver.assetExts,
+        filePath => depGraph.doesFileExist(filePath),
+      );
+      // Tell clients to cache this for 1 year.
+      // This is safe as the asset url contains a hash of the asset.
+      // $FlowFixMe[incompatible-type]
+      /* $FlowFixMe[invalid-compare] Error discovered during Constant Condition
+       * roll out. See https://fburl.com/workplace/4oq3zi07. */
+      if (process.env.REACT_NATIVE_ENABLE_ASSET_CACHING === true) {
+        res.setHeader('Cache-Control', 'max-age=31536000');
+      }
+      res.setHeader('Content-Type', mime.lookup(path.basename(assetPath)));
+      res.end(this._rangeRequestMiddleware(req, res, data, assetPath));
+      process.nextTick(() => {
+        log(createActionEndEntry(processingAssetRequestLogEntry));
+      });
+    } catch (error) {
+      console.error(error.stack);
+      res.writeHead(404);
+      res.end('Asset not found');
+    }
+  }
+
+  processRequest: (
+    IncomingMessage,
+    ServerResponse,
+    ((e: ?Error) => void),
+  ) => void = (
+    req: IncomingMessage,
+    res: ServerResponse,
+    next: (?Error) => void,
+  ) => {
+    this._processRequest(req, res, next).catch(next);
+  };
+
+  _parseOptions(url: string): BundleOptions {
+    const {bundleType: _bundleType, ...bundleOptions} =
+      parseBundleOptionsFromBundleRequestUrl(
+        url,
+        new Set(this._config.resolver.platforms),
+      );
+    return bundleOptions;
+  }
+
+  _rewriteAndNormalizeUrl(requestUrl: string): string {
+    return jscSafeUrl.toNormalUrl(
+      this._config.server.rewriteRequestUrl(jscSafeUrl.toNormalUrl(requestUrl)),
+    );
+  }
+
+  async _processRequest(
+    req: IncomingMessage,
+    res: ServerResponse,
+    next: (?Error) => void,
+  ): Promise<void> {
+    const originalUrl = req.url;
+    debug('Handling request:    %s', originalUrl);
+    req.url = this._rewriteAndNormalizeUrl(req.url);
+    if (req.url !== originalUrl) {
+      debug('Rewritten to:    %s', req.url);
+    }
+    const reqHost = req.headers['x-forwarded-host'] || req.headers['host'];
+    debug('Request host is:    %s', req.headers['host']);
+    if (req.headers['x-forwarded-host']) {
+      debug(
+        'Request x-forwarded-host is:    %s',
+        req.headers['x-forwarded-host'],
+      );
+    }
+    if (!reqHost) {
+      throw new Error('No host header was found.');
+    }
+
+    const reqProtocol =
+      req.headers['x-forwarded-proto'] ||
+      // $FlowFixMe[prop-missing] not missing for https requests
+      (req.socket?.encrypted === true ? 'https' : 'http');
+    const urlObj = new URL(req.url, reqProtocol + '://' + reqHost);
+
+    const formattedUrl = urlObj.toString();
+    if (req.url !== formattedUrl) {
+      debug('Formatted as:    %s', formattedUrl);
+    }
+
+    const pathname = urlObj.pathname || '';
+
+    // using this Metro particular convention for decoding URL paths into file paths
+    const filePathname = pathname
+      .split('/')
+      .map(segment => decodeURIComponent(segment))
+      .join('/');
+
+    const buildNumber = this.getNewBuildNumber();
+    if (pathname.endsWith('.bundle')) {
+      const options = this._parseOptions(formattedUrl);
+      await this._processBundleRequest(req, res, options, {
+        buildNumber,
+        bundlePerfLogger:
+          this._config.unstable_perfLoggerFactory?.('BUNDLING_REQUEST', {
+            key: buildNumber,
+          }) ?? noopLogger,
+      });
+
+      if (this._serverOptions && this._serverOptions.onBundleBuilt) {
+        this._serverOptions.onBundleBuilt(filePathname);
+      }
+    } else if (pathname.endsWith('.map')) {
+      // Chrome dev tools may need to access the source maps.
+      res.setHeader('Access-Control-Allow-Origin', 'devtools://devtools');
+      await this._processSourceMapRequest(
+        req,
+        res,
+        this._parseOptions(formattedUrl),
+        {
+          buildNumber,
+          bundlePerfLogger: noopLogger,
+        },
+      );
+    } else if (pathname.endsWith('.assets')) {
+      await this._processAssetsRequest(
+        req,
+        res,
+        this._parseOptions(formattedUrl),
+        {
+          buildNumber,
+          bundlePerfLogger: noopLogger,
+        },
+      );
+    } else if (pathname.startsWith('/assets/') || pathname === '/assets') {
+      await this._processSingleAssetRequest(req, res);
+    } else if (pathname === '/symbolicate') {
+      await this._symbolicate(req, res);
+    } else {
+      let handled = false;
+      for (const [pathnamePrefix, normalizedRootDir] of this
+        ._sourceRequestRoutingMap) {
+        if (filePathname.startsWith(pathnamePrefix)) {
+          const relativeFilePathname = filePathname.substr(
+            pathnamePrefix.length,
+          );
+          await this._processSourceRequest(
+            relativeFilePathname,
+            normalizedRootDir,
+            res,
+          );
+          handled = true;
+          break;
+        }
+      }
+      if (!handled) {
+        next();
+      }
+    }
+  }
+
+  async _processSourceRequest(
+    relativeFilePathname: string,
+    rootDir: string,
+    res: ServerResponse,
+  ): Promise<void> {
+    if (
+      !this._allowedSuffixesForSourceRequests.some(suffix =>
+        relativeFilePathname.endsWith(suffix),
+      )
+    ) {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    const depGraph = await this._bundler.getBundler().getDependencyGraph();
+    const filePath = path.join(rootDir, relativeFilePathname);
+    try {
+      await depGraph.getOrComputeSha1(filePath);
+    } catch {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    const mimeType = mime.lookup(path.basename(relativeFilePathname));
+    res.setHeader('Content-Type', mimeType);
+    const stream = fs.createReadStream(filePath);
+    stream.pipe(res);
+    stream.on('error', error => {
+      if (error.code === 'ENOENT') {
+        res.writeHead(404);
+        res.end();
+      } else {
+        res.writeHead(500);
+        res.end();
+      }
+    });
+  }
+
+  _createRequestProcessor<T>({
+    bundleType,
+    createStartEntry,
+    createEndEntry,
+    build,
+    delete: deleteFn,
+    finish,
+  }: {
+    +bundleType: 'assets' | 'bundle' | 'map',
+    +createStartEntry: (context: ProcessStartContext) => ActionLogEntryData,
+    +createEndEntry: (
+      context: ProcessEndContext<T>,
+    ) => Partial<ActionStartLogEntry>,
+    +build: (context: ProcessStartContext) => Promise<T>,
+    +delete?: (context: ProcessDeleteContext) => Promise<void>,
+    +finish: (context: ProcessEndContext<T>) => void,
+  }): (
+    req: IncomingMessage,
+    res: ServerResponse,
+    bundleOptions: BundleOptions,
+    buildContext: Readonly<{
+      buildNumber: number,
+      bundlePerfLogger: RootPerfLogger,
+    }>,
+  ) => Promise<void> {
+    return async function requestProcessor(
+      this: Server,
+      req: IncomingMessage,
+      res: ServerResponse,
+      bundleOptions: BundleOptions,
+      buildContext: Readonly<{
+        buildNumber: number,
+        bundlePerfLogger: RootPerfLogger,
+      }>,
+    ): Promise<void> {
+      const requestStartTimestamp = performance.timeOrigin + performance.now();
+      const {buildNumber} = buildContext;
+      const {
+        entryFile,
+        graphOptions,
+        resolverOptions,
+        serializerOptions,
+        transformOptions,
+      } = splitBundleOptions(bundleOptions);
+
+      /**
+       * `entryFile` is relative to projectRoot, we need to use resolution function
+       * to find the appropriate file with supported extensions.
+       */
+      let resolvedEntryFilePath;
+      try {
+        resolvedEntryFilePath = await this._resolveRelativePath(entryFile, {
+          relativeTo: 'server',
+          resolverOptions,
+          transformOptions,
+        });
+      } catch (error) {
+        const formattedError = formatBundlingError(error);
+
+        const status = error instanceof UnableToResolveError ? 404 : 500;
+        res.writeHead(status, {
+          'Content-Type': 'application/json; charset=UTF-8',
+        });
+        res.end(JSON.stringify(formattedError));
+        return;
+      }
+      const graphId = getGraphId(resolvedEntryFilePath, transformOptions, {
+        unstable_allowRequireContext:
+          this._config.transformer.unstable_allowRequireContext,
+        resolverOptions,
+        shallow: graphOptions.shallow,
+        lazy: graphOptions.lazy,
+      });
+
+      // For resources that support deletion, handle the DELETE method.
+      if (deleteFn && req.method === 'DELETE') {
+        const deleteContext = {
+          graphId,
+          req,
+          res,
+        };
+        try {
+          await deleteFn(deleteContext);
+        } catch (error) {
+          const formattedError = formatBundlingError(error);
+
+          const status = error instanceof ResourceNotFoundError ? 404 : 500;
+          res.writeHead(status, {
+            'Content-Type': 'application/json; charset=UTF-8',
+          });
+          res.end(JSON.stringify(formattedError));
+        }
+        return;
+      }
+
+      const mres = MultipartResponse.wrapIfSupported(req, res);
+
+      let onProgress = null;
+      let lastRatio = -1;
+      if (this._config.reporter) {
+        onProgress = (transformedFileCount: number, totalFileCount: number) => {
+          const newRatio = calculateBundleProgressRatio(
+            transformedFileCount,
+            totalFileCount,
+            lastRatio,
+          );
+
+          if (newRatio > lastRatio) {
+            if (mres instanceof MultipartResponse) {
+              mres.writeChunk(
+                {'Content-Type': 'application/json'},
+                JSON.stringify({
+                  done: transformedFileCount,
+                  total: totalFileCount,
+                  percent: Math.floor(newRatio * 100),
+                }),
+              );
+            }
+
+            // The `uncork` called internally in Node via `promise.nextTick()` may not fire
+            // until all of the Promises are resolved because the microtask queue we're
+            // in could be starving the event loop. This can cause a bug where the progress
+            // is not actually sent in the response until after bundling is complete. This
+            // would defeat the purpose of sending progress, so we `uncork` the stream now
+            // which will force the response to flush to the client immediately.
+            // $FlowFixMe[method-unbinding] added when improving typing for this parameters
+            if (res.socket != null && res.socket.uncork != null) {
+              res.socket.uncork();
+            }
+
+            lastRatio = newRatio;
+          }
+
+          this._reporter.update({
+            buildID: getBuildID(buildNumber),
+            type: 'bundle_transform_progressed',
+            transformedFileCount,
+            totalFileCount,
+          });
+        };
+      }
+
+      this._reporter.update({
+        buildID: getBuildID(buildNumber),
+        bundleDetails: {
+          bundleType,
+          customResolverOptions: bundleOptions.customResolverOptions,
+          customTransformOptions: bundleOptions.customTransformOptions,
+          dev: transformOptions.dev,
+          entryFile: resolvedEntryFilePath,
+          minify: transformOptions.minify,
+          platform: transformOptions.platform,
+        },
+        isPrefetch: req.method === 'HEAD',
+        type: 'bundle_build_started',
+      });
+
+      const startContext: ProcessStartContext = {
+        buildNumber,
+        bundleOptions,
+        entryFile: resolvedEntryFilePath,
+        graphId,
+        graphOptions,
+        mres,
+        onProgress,
+        req,
+        resolverOptions,
+        serializerOptions,
+        transformOptions,
+        bundlePerfLogger: buildContext.bundlePerfLogger,
+        requestStartTimestamp,
+      };
+      const logEntry = log(
+        createActionStartEntry(createStartEntry(startContext)),
+      );
+
+      const fetchTiming: FetchTiming = {
+        graphId,
+        startTime: requestStartTimestamp,
+        endTime: null,
+        isPrefetch: req.method === 'HEAD',
+      };
+
+      let result;
+      try {
+        this._fetchTimings.push(fetchTiming);
+        this._activeFetchCount++;
+
+        result = await build(startContext);
+      } catch (error) {
+        const formattedError = formatBundlingError(error);
+
+        const status = error instanceof ResourceNotFoundError ? 404 : 500;
+        mres.writeHead(status, {
+          'Content-Type': 'application/json; charset=UTF-8',
+        });
+        mres.end(JSON.stringify(formattedError));
+
+        this._reporter.update({
+          buildID: getBuildID(buildNumber),
+          type: 'bundle_build_failed',
+          bundleOptions,
+        });
+
+        this._reporter.update({error, type: 'bundling_error'});
+
+        log({
+          action_name: 'bundling_error',
+          error_type: formattedError.type,
+          log_entry_label: 'bundling_error',
+          bundle_id: graphId,
+          build_id: getBuildID(buildNumber),
+          stack: formattedError.message,
+        });
+
+        debug('Bundling error', error);
+
+        buildContext.bundlePerfLogger.end('FAIL');
+
+        return;
+      } finally {
+        fetchTiming.endTime = performance.timeOrigin + performance.now();
+
+        if (!fetchTiming.isPrefetch) {
+          buildContext.bundlePerfLogger.annotate({
+            bool: {
+              had_competing_prefetch: this._fetchTimings
+                // fetching the same bundle as a prefetch don't compete, since they resolve a shared promise for the same graph id
+                .filter(t => t.isPrefetch && t.graphId !== graphId)
+                .some(prefetch => {
+                  const prefetchEndTime =
+                    prefetch.endTime ?? Number.MAX_SAFE_INTEGER;
+                  const fetchEndTime =
+                    fetchTiming.endTime ?? Number.MAX_SAFE_INTEGER;
+                  return (
+                    prefetch.startTime < fetchEndTime &&
+                    prefetchEndTime > fetchTiming.startTime
+                  );
+                }),
+            },
+          });
+        }
+
+        this._activeFetchCount--;
+        if (this._activeFetchCount === 0) {
+          this._fetchTimings = [];
+        }
+      }
+
+      const endContext: ProcessEndContext<T> = {
+        ...startContext,
+        result,
+      };
+      finish(endContext);
+
+      this._reporter.update({
+        buildID: getBuildID(buildNumber),
+        type: 'bundle_build_done',
+      });
+
+      log(
+        /* $FlowFixMe[cannot-spread-inexact](>=0.122.0 site=react_native_fb) This comment suppresses
+         * an error found when Flow v0.122.0 was deployed. To see the error,
+         * delete this comment and run Flow. */
+        createActionEndEntry({
+          ...logEntry,
+          ...createEndEntry(endContext),
+        }),
+      );
+    };
+  }
+
+  _processBundleRequest: (
+    req: IncomingMessage,
+    res: ServerResponse,
+    bundleOptions: BundleOptions,
+    buildContext: Readonly<{
+      buildNumber: number,
+      bundlePerfLogger: RootPerfLogger,
+    }>,
+  ) => Promise<void> = this._createRequestProcessor({
+    bundleType: 'bundle',
+    createStartEntry(context: ProcessStartContext) {
+      return {
+        action_name: 'Requesting bundle',
+        bundle_url: context.req.url,
+        bundle_original_url: context.req.originalUrl ?? 'unknown',
+        entry_point: context.entryFile,
+        bundler: 'delta',
+        build_id: getBuildID(context.buildNumber),
+        bundle_options: context.bundleOptions,
+        bundle_hash: context.graphId,
+        user_agent: context.req.headers['user-agent'] ?? 'unknown',
+      };
+    },
+    createEndEntry(
+      context: ProcessEndContext<{
+        bundle: string,
+        lastModifiedDate: Date,
+        nextRevId: RevisionId,
+        numModifiedFiles: number,
+      }>,
+    ) {
+      return {
+        outdated_modules: context.result.numModifiedFiles,
+      };
+    },
+    build: async ({
+      entryFile,
+      graphId,
+      graphOptions,
+      onProgress,
+      resolverOptions,
+      serializerOptions,
+      transformOptions,
+      bundlePerfLogger,
+      requestStartTimestamp,
+    }) => {
+      bundlePerfLogger.start({
+        timestamp: requestStartTimestamp,
+      });
+      bundlePerfLogger.annotate({
+        string: {
+          bundle_url: entryFile,
+        },
+      });
+      const revPromise = this._bundler.getRevisionByGraphId(graphId);
+
+      bundlePerfLogger.point('resolvingAndTransformingDependencies_start');
+      bundlePerfLogger.annotate({
+        bool: {
+          initial_build: revPromise == null,
+        },
+      });
+      const {delta, revision} = await (revPromise != null
+        ? this._bundler.updateGraph(await revPromise, false)
+        : this._bundler.initializeGraph(
+            entryFile,
+            transformOptions,
+            resolverOptions,
+            {
+              onProgress,
+              shallow: graphOptions.shallow,
+              lazy: graphOptions.lazy,
+            },
+          ));
+
+      bundlePerfLogger.annotate({
+        int: {
+          graph_node_count: revision.graph.dependencies.size,
+        },
+      });
+
+      bundlePerfLogger.point('resolvingAndTransformingDependencies_end');
+      bundlePerfLogger.point('serializingBundle_start');
+      const serializer =
+        this._config.serializer.customSerializer ||
+        ((entryPoint, preModules, graph, options) =>
+          bundleToString(baseJSBundle(entryPoint, preModules, graph, options))
+            .code);
+
+      const bundle = await serializer(
+        entryFile,
+        revision.prepend,
+        revision.graph,
+        {
+          asyncRequireModulePath: await this._resolveRelativePath(
+            this._config.transformer.asyncRequireModulePath,
+            {
+              relativeTo: 'project',
+              resolverOptions,
+              transformOptions,
+            },
+          ),
+          processModuleFilter: this._config.serializer.processModuleFilter,
+          createModuleId: this._createModuleId,
+          getRunModuleStatement: this._config.serializer.getRunModuleStatement,
+          globalPrefix: this._config.transformer.globalPrefix,
+          includeAsyncPaths: graphOptions.lazy,
+          dev: transformOptions.dev,
+          projectRoot: this._config.projectRoot,
+          modulesOnly: serializerOptions.modulesOnly,
+          runBeforeMainModule:
+            this._config.serializer.getModulesRunBeforeMainModule(
+              path.relative(this._config.projectRoot, entryFile),
+            ),
+          runModule: serializerOptions.runModule,
+          sourceMapUrl: serializerOptions.sourceMapUrl,
+          sourceUrl: serializerOptions.sourceUrl,
+          inlineSourceMap: serializerOptions.inlineSourceMap,
+          serverRoot:
+            this._config.server.unstable_serverRoot ?? this._config.projectRoot,
+          shouldAddToIgnoreList: (module: Module<>) =>
+            this._shouldAddModuleToIgnoreList(module),
+          getSourceUrl: (module: Module<>) =>
+            this._getModuleSourceUrl(module, serializerOptions.sourcePaths),
+        },
+      );
+      bundlePerfLogger.point('serializingBundle_end');
+
+      const bundleCode = typeof bundle === 'string' ? bundle : bundle.code;
+
+      return {
+        numModifiedFiles: delta.reset
+          ? delta.added.size + revision.prepend.length
+          : delta.added.size + delta.modified.size + delta.deleted.size,
+        lastModifiedDate: revision.date,
+        nextRevId: revision.id,
+        bundle: bundleCode,
+      };
+    },
+    finish({req, mres, serializerOptions, result, bundlePerfLogger}) {
+      bundlePerfLogger.annotate({
+        int: {
+          bundle_length: result.bundle.length,
+          bundle_byte_length: Buffer.byteLength(result.bundle),
+        },
+      });
+      mres.once('error', () => {
+        bundlePerfLogger.end('FAIL');
+      });
+      mres.once('finish', () => {
+        bundlePerfLogger.end('SUCCESS');
+      });
+      if (
+        // We avoid parsing the dates since the client should never send a more
+        // recent date than the one returned by the Delta Bundler (if that's the
+        // case it's fine to return the whole bundle).
+        req.headers['if-modified-since'] ===
+        result.lastModifiedDate.toUTCString()
+      ) {
+        bundlePerfLogger.annotate({
+          string: {
+            http_status: '304',
+          },
+        });
+        debug('Responding with 304');
+        mres.writeHead(304);
+        mres.end();
+      } else {
+        bundlePerfLogger.annotate({
+          string: {
+            http_status: '200',
+          },
+        });
+        mres.setHeader(
+          FILES_CHANGED_COUNT_HEADER,
+          String(result.numModifiedFiles),
+        );
+        mres.setHeader(DELTA_ID_HEADER, String(result.nextRevId));
+        if (serializerOptions?.sourceUrl != null) {
+          mres.setHeader('Content-Location', serializerOptions.sourceUrl);
+        }
+        mres.setHeader('Content-Type', 'application/javascript; charset=UTF-8');
+        mres.setHeader('Last-Modified', result.lastModifiedDate.toUTCString());
+        mres.setHeader(
+          'Content-Length',
+          String(Buffer.byteLength(result.bundle)),
+        );
+        mres.end(result.bundle);
+      }
+    },
+    delete: async ({graphId, res}) => {
+      await this._bundler.endGraph(graphId);
+      res.statusCode = 204;
+      res.end();
+    },
+  });
+
+  // This function ensures that modules in source maps are sorted in the same
+  // order as in a plain JS bundle.
+  _getSortedModules(graph: ReadOnlyGraph<>): ReadonlyArray<Module<>> {
+    const modules = [...graph.dependencies.values()];
+    // Assign IDs to modules in a consistent order
+    for (const module of modules) {
+      this._createModuleId(module.path);
+    }
+    // Sort by IDs
+    return modules.sort(
+      (a: Module<MixedOutput>, b: Module<MixedOutput>) =>
+        this._createModuleId(a.path) - this._createModuleId(b.path),
+    );
+  }
+
+  _processSourceMapRequest: (
+    req: IncomingMessage,
+    res: ServerResponse,
+    bundleOptions: BundleOptions,
+    buildContext: Readonly<{
+      buildNumber: number,
+      bundlePerfLogger: RootPerfLogger,
+    }>,
+  ) => Promise<void> = this._createRequestProcessor({
+    bundleType: 'map',
+    createStartEntry(context: ProcessStartContext) {
+      return {
+        action_name: 'Requesting sourcemap',
+        bundle_url: context.req.url,
+        entry_point: context.entryFile,
+        bundler: 'delta',
+      };
+    },
+    createEndEntry(context: ProcessEndContext<string>) {
+      return {
+        bundler: 'delta',
+      };
+    },
+    build: async ({
+      entryFile,
+      graphId,
+      graphOptions,
+      onProgress,
+      resolverOptions,
+      serializerOptions,
+      transformOptions,
+    }) => {
+      let revision;
+      const revPromise = this._bundler.getRevisionByGraphId(graphId);
+      if (revPromise == null) {
+        ({revision} = await this._bundler.initializeGraph(
+          entryFile,
+          transformOptions,
+          resolverOptions,
+          {
+            onProgress,
+            shallow: graphOptions.shallow,
+            lazy: graphOptions.lazy,
+          },
+        ));
+      } else {
+        ({revision} = await this._bundler.updateGraph(await revPromise, false));
+      }
+
+      let {prepend, graph} = revision;
+      if (serializerOptions.modulesOnly) {
+        prepend = [];
+      }
+
+      return await sourceMapStringNonBlocking(
+        [...prepend, ...this._getSortedModules(graph)],
+        {
+          excludeSource: serializerOptions.excludeSource,
+          processModuleFilter: this._config.serializer.processModuleFilter,
+          shouldAddToIgnoreList: (module: Module<>) =>
+            this._shouldAddModuleToIgnoreList(module),
+          getSourceUrl: (module: Module<>) =>
+            this._getModuleSourceUrl(module, serializerOptions.sourcePaths),
+        },
+      );
+    },
+    finish({mres, result}) {
+      mres.setHeader('Content-Type', 'application/json');
+      mres.end(result.toString());
+    },
+  });
+
+  _processAssetsRequest: (
+    req: IncomingMessage,
+    res: ServerResponse,
+    bundleOptions: BundleOptions,
+    buildContext: Readonly<{
+      buildNumber: number,
+      bundlePerfLogger: RootPerfLogger,
+    }>,
+  ) => Promise<void> = this._createRequestProcessor({
+    bundleType: 'assets',
+    createStartEntry(context: ProcessStartContext) {
+      return {
+        action_name: 'Requesting assets',
+        bundle_url: context.req.url,
+        entry_point: context.entryFile,
+        bundler: 'delta',
+      };
+    },
+    createEndEntry(context: ProcessEndContext<ReadonlyArray<AssetData>>) {
+      return {
+        bundler: 'delta',
+      };
+    },
+    build: async ({
+      entryFile,
+      onProgress,
+      resolverOptions,
+      transformOptions,
+    }) => {
+      const dependencies = await this._bundler.getDependencies(
+        [entryFile],
+        transformOptions,
+        resolverOptions,
+        {onProgress, shallow: false, lazy: false},
+      );
+
+      return await getAssets(dependencies, {
+        processModuleFilter: this._config.serializer.processModuleFilter,
+        assetPlugins: this._config.transformer.assetPlugins,
+        platform: transformOptions.platform,
+        publicPath: this._config.transformer.publicPath,
+        projectRoot: this._config.projectRoot,
+      });
+    },
+    finish({mres, result}) {
+      mres.setHeader('Content-Type', 'application/json');
+      mres.end(JSON.stringify(result));
+    },
+  });
+
+  async _symbolicate(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const depGraph = await this._bundler.getBundler().getDependencyGraph();
+
+    const getCodeFrame = (
+      urls: Set<string>,
+      symbolicatedStack: ReadonlyArray<StackFrameOutput>,
+    ) => {
+      const allFramesCollapsed = symbolicatedStack.every(
+        ({collapse}) => collapse,
+      );
+
+      for (let i = 0; i < symbolicatedStack.length; i++) {
+        const {collapse, column, file, lineNumber} = symbolicatedStack[i];
+
+        if (
+          // If all the frames are collapsed then we should ignore the collapse flag
+          // and always show the first valid frame.
+          (!allFramesCollapsed && collapse) ||
+          lineNumber == null ||
+          (file != null && urls.has(file))
+        ) {
+          continue;
+        }
+
+        const fileAbsolute = path.resolve(this._config.projectRoot, file ?? '');
+        if (!depGraph.doesFileExist(fileAbsolute)) {
+          debug(
+            'Skipping code frame for file not in dependency graph.',
+            fileAbsolute,
+          );
+          continue;
+        }
+        try {
+          return {
+            content: codeFrameColumns(
+              fs.readFileSync(fileAbsolute, 'utf8'),
+              {
+                // Metro returns 0 based columns but codeFrameColumns expects 1-based columns
+                // $FlowFixMe[unsafe-addition]
+                start: {column: column + 1, line: lineNumber},
+              },
+              {forceColor: true},
+            ),
+            location: {
+              row: lineNumber,
+              column,
+            },
+            fileName: file,
+          };
+        } catch (error) {
+          debug(
+            'Generating code frame failed on file read.',
+            fileAbsolute,
+            error,
+          );
+        }
+      }
+
+      return null;
+    };
+
+    let inputValidated = false;
+    try {
+      const symbolicatingLogEntry = log(
+        createActionStartEntry('Symbolicating'),
+      );
+      debug('Start symbolication');
+
+      let parsedBody;
+      if ('rawBody' in req) {
+        // TODO: Remove this branch once we are no longer targeting React Native
+        // < 0.80 and Expo SDK < 53
+        // $FlowFixMe[prop-missing] - rawBody assigned by legacy CLI integrations
+        const body = await req.rawBody;
+        parsedBody = JSON.parse(body) as JsonData;
+      } else {
+        parsedBody = await parseJsonBody(req, {strict: false});
+      }
+
+      let validatedBody: {
+        stack: ReadonlyArray<JsonData>,
+        extraData?: JsonData,
+      };
+
+      if (
+        parsedBody != null &&
+        typeof parsedBody === 'object' &&
+        !Array.isArray(parsedBody) &&
+        Array.isArray(parsedBody['stack'])
+      ) {
+        const maybeStack: Array<JsonData> = parsedBody['stack'];
+        const extraData = parsedBody['extraData'];
+        validatedBody = {
+          stack: maybeStack,
+          extraData,
+        };
+      } else {
+        throw new Error(
+          `Bad symbolication input, expected object with stack array, got: ${JSON.stringify(parsedBody)}`,
+        );
+      }
+
+      const validateAndNormalizeStackFrame = (
+        frame: JsonData,
+      ): StackFrameInput => {
+        if (
+          frame == null ||
+          typeof frame !== 'object' ||
+          Array.isArray(frame)
+        ) {
+          throw new Error('Expected frame to be a JSON object');
+        }
+        if (frame.file != null && typeof frame.file !== 'string') {
+          throw new Error('Expected file to be string or nullish');
+        }
+        let frameFile = frame.file;
+        if (frameFile != null && frameFile.includes('://')) {
+          frameFile = this._rewriteAndNormalizeUrl(frameFile);
+        }
+        if (frame.methodName != null && typeof frame.methodName !== 'string') {
+          throw new Error('Expected methodName to be string or nullish');
+        }
+        if (frame.lineNumber != null && typeof frame.lineNumber !== 'number') {
+          throw new Error('Expected lineNumber to be number or nullish');
+        }
+        if (frame.column != null && typeof frame.column !== 'number') {
+          throw new Error('Expected column to be number or nullish');
+        }
+        return {
+          ...frame,
+          file: frameFile,
+          lineNumber: frame.lineNumber,
+          column: frame.column,
+          methodName: frame.methodName,
+        };
+      };
+
+      const stack = validatedBody.stack.map((frame, lineNumber) => {
+        try {
+          return validateAndNormalizeStackFrame(frame);
+        } catch (e) {
+          throw new Error(`Bad frame at line ${lineNumber}: ${e.message}`);
+        }
+      });
+
+      inputValidated = true;
+      // In case of multiple bundles / HMR, some stack frames can have different URLs from others
+      const urls = new Set<string>();
+
+      stack.forEach(frame => {
+        // These urls have been rewritten and normalized above.
+        const sourceUrl = frame.file;
+        // Skip `/debuggerWorker.js` which does not need symbolication.
+        if (
+          sourceUrl != null &&
+          !urls.has(sourceUrl) &&
+          !sourceUrl.endsWith('/debuggerWorker.js') &&
+          sourceUrl.startsWith('http')
+        ) {
+          urls.add(sourceUrl);
+        }
+      });
+
+      debug('Getting source maps for symbolication');
+      const sourceMaps = await Promise.all(
+        Array.from(urls.values()).map(normalizedUrl =>
+          this._explodedSourceMapForBundleOptions(
+            this._parseOptions(normalizedUrl),
+          ),
+        ),
+      );
+
+      debug('Performing fast symbolication');
+      const symbolicatedStack = await symbolicate(
+        stack,
+        zip(urls.values(), sourceMaps),
+        this._config,
+        validatedBody.extraData ?? {},
+      );
+
+      debug('Symbolication done');
+      res.end(
+        JSON.stringify({
+          codeFrame: getCodeFrame(urls, symbolicatedStack),
+          stack: symbolicatedStack,
+        }),
+      );
+      process.nextTick(() => {
+        log(createActionEndEntry(symbolicatingLogEntry));
+      });
+    } catch (error) {
+      debug('Symbolication failed', error.stack || error);
+      res.statusCode = inputValidated ? 500 : 400;
+      res.end(JSON.stringify({error: error.message}));
+    }
+  }
+
+  async _explodedSourceMapForBundleOptions(
+    bundleOptions: BundleOptions,
+  ): Promise<ExplodedSourceMap> {
+    const {
+      entryFile,
+      graphOptions,
+      onProgress,
+      resolverOptions,
+      serializerOptions,
+      transformOptions,
+    } = splitBundleOptions(bundleOptions);
+
+    /**
+     * `entryFile` is relative to projectRoot, we need to use resolution function
+     * to find the appropriate file with supported extensions.
+     */
+    const resolvedEntryFilePath = await this._resolveRelativePath(entryFile, {
+      relativeTo: 'server',
+      resolverOptions,
+      transformOptions,
+    });
+
+    const graphId = getGraphId(resolvedEntryFilePath, transformOptions, {
+      unstable_allowRequireContext:
+        this._config.transformer.unstable_allowRequireContext,
+      resolverOptions,
+      shallow: graphOptions.shallow,
+      lazy: graphOptions.lazy,
+    });
+    let revision;
+    const revPromise = this._bundler.getRevisionByGraphId(graphId);
+    if (revPromise == null) {
+      ({revision} = await this._bundler.initializeGraph(
+        resolvedEntryFilePath,
+        transformOptions,
+        resolverOptions,
+        {
+          onProgress,
+          shallow: graphOptions.shallow,
+          lazy: graphOptions.lazy,
+        },
+      ));
+    } else {
+      ({revision} = await this._bundler.updateGraph(await revPromise, false));
+    }
+
+    let {prepend, graph} = revision;
+    if (serializerOptions.modulesOnly) {
+      prepend = [];
+    }
+
+    return getExplodedSourceMap(
+      [...prepend, ...this._getSortedModules(graph)],
+      {
+        processModuleFilter: this._config.serializer.processModuleFilter,
+      },
+    );
+  }
+
+  _resolveWatchFolderPrefix(
+    filePath: string,
+  ): {rootDir: string, filePath: string} | null {
+    const watchFolderMatch = filePath.match(
+      /^\.\/\[metro-watchFolders\]\/(\d+)\/(.*)/,
+    );
+    if (watchFolderMatch != null) {
+      const index = parseInt(watchFolderMatch[1], 10);
+      const watchFolder = this._config.watchFolders[index];
+      if (watchFolder != null) {
+        return {
+          rootDir: path.resolve(watchFolder),
+          filePath:
+            '.' + path.sep + watchFolderMatch[2].split('/').join(path.sep),
+        };
+      }
+    }
+    const projectMatch = filePath.match(/^\.\/\[metro-project\]\/(.*)/);
+    if (projectMatch != null) {
+      return {
+        rootDir: path.resolve(this._config.projectRoot),
+        filePath: '.' + path.sep + projectMatch[1].split('/').join(path.sep),
+      };
+    }
+    return null;
+  }
+
+  async _resolveRelativePath(
+    filePath: string,
+    {
+      relativeTo,
+      resolverOptions,
+      transformOptions,
+    }: Readonly<{
+      relativeTo: 'project' | 'server',
+      resolverOptions: ResolverInputOptions,
+      transformOptions: TransformInputOptions,
+    }>,
+  ): Promise<string> {
+    const resolutionFn = await transformHelpers.getResolveDependencyFn(
+      this._bundler.getBundler(),
+      transformOptions.platform,
+      resolverOptions,
+    );
+    const resolved = this._resolveWatchFolderPrefix(filePath);
+    const rootDir =
+      resolved != null
+        ? resolved.rootDir
+        : relativeTo === 'server'
+          ? this._getServerRootDir()
+          : this._config.projectRoot;
+    const resolvedFilePath = resolved != null ? resolved.filePath : filePath;
+    return resolutionFn(`${rootDir}/.`, {
+      name: resolvedFilePath,
+      data: {
+        key: resolvedFilePath,
+        locs: [],
+        asyncType: null,
+        isESMImport: false,
+      },
+    }).filePath;
+  }
+
+  getNewBuildNumber(): number {
+    return this._nextBundleBuildNumber++;
+  }
+
+  getPlatforms(): ReadonlyArray<string> {
+    return this._config.resolver.platforms;
+  }
+
+  getWatchFolders(): ReadonlyArray<string> {
+    return this._config.watchFolders;
+  }
+
+  static DEFAULT_GRAPH_OPTIONS: Readonly<{
+    customResolverOptions: CustomResolverOptions,
+    customTransformOptions: CustomTransformOptions,
+    dev: boolean,
+    minify: boolean,
+    unstable_transformProfile: 'default',
+  }> = {
+    customResolverOptions: Object.create(null),
+    customTransformOptions: Object.create(null),
+    dev: true,
+    minify: false,
+    unstable_transformProfile: 'default',
+  };
+
+  static DEFAULT_BUNDLE_OPTIONS: {
+    ...typeof Server.DEFAULT_GRAPH_OPTIONS,
+    excludeSource: false,
+    inlineSourceMap: false,
+    lazy: false,
+    modulesOnly: false,
+    onProgress: null,
+    runModule: true,
+    shallow: false,
+    sourceMapUrl: null,
+    sourceUrl: null,
+    sourcePaths: SourcePathsMode,
+  } = {
+    ...Server.DEFAULT_GRAPH_OPTIONS,
+    excludeSource: false,
+    inlineSourceMap: false,
+    lazy: false,
+    modulesOnly: false,
+    onProgress: null,
+    runModule: true,
+    shallow: false,
+    sourceMapUrl: null,
+    sourceUrl: null,
+    sourcePaths: SourcePathsMode.Absolute,
+  };
+
+  _getServerRootDir(): string {
+    return this._config.server.unstable_serverRoot ?? this._config.projectRoot;
+  }
+
+  _getEntryPointAbsolutePath(entryFile: string): string {
+    const resolved = this._resolveWatchFolderPrefix(entryFile);
+    if (resolved != null) {
+      return path.resolve(resolved.rootDir, resolved.filePath);
+    }
+    return path.resolve(this._getServerRootDir(), entryFile);
+  }
+
+  // Wait for the server to finish initializing.
+  async ready(): Promise<void> {
+    await this._bundler.ready();
+  }
+
+  _shouldAddModuleToIgnoreList(module: Module<>): boolean {
+    // TODO: Add flag to Module signifying whether it represents generated code
+    // and clean up these heuristics.
+    return (
+      // Prelude code, see getPrependedScripts.js
+      module.path === '__prelude__' ||
+      // Generated require.context() module, see contextModule.js
+      module.path.includes('?ctx=') ||
+      this._config.serializer.isThirdPartyModule(module)
+    );
+  }
+
+  // Flow checking is enough to ensure that a value is returned in all cases.
+  // eslint-disable-next-line consistent-return
+  _getModuleSourceUrl(module: Module<>, mode: SourcePathsMode): string {
+    switch (mode) {
+      case SourcePathsMode.ServerUrl:
+        for (const [pathnamePrefix, normalizedRootDir] of this
+          ._sourceRequestRoutingMap) {
+          if (module.path.startsWith(normalizedRootDir + path.sep)) {
+            const relativePath = module.path.slice(
+              normalizedRootDir.length + 1,
+            );
+            const relativePathPosix = relativePath
+              .split(path.sep)
+              .map(segment => encodeURIComponent(segment))
+              .join('/');
+            return pathnamePrefix + relativePathPosix;
+          }
+        }
+        // Ordinarily all files should match one of the roots above. If they
+        // don't, try to preserve useful information, even if fetching the path
+        // from Metro might fail.
+        const modulePathPosix = module.path
+          .split(path.sep)
+          .map(segment => encodeURIComponent(segment))
+          .join('/');
+        return modulePathPosix.startsWith('/')
+          ? modulePathPosix
+          : '/' + modulePathPosix;
+      case SourcePathsMode.Absolute:
+        return module.path;
+    }
+  }
+}
+
+function* zip<X, Y>(xs: Iterable<X>, ys: Iterable<Y>): Iterable<[X, Y]> {
+  //$FlowFixMe[incompatible-type] #9324959
+  const ysIter: Iterator<Y> = ys[Symbol.iterator]();
+  for (const x of xs) {
+    const y = ysIter.next();
+    if (y.done) {
+      return;
+    }
+    yield [x, y.value];
+  }
+}
+
+function getBuildID(buildNumber: number): string {
+  return buildNumber.toString(36);
+}

--- a/tests/integration/tests/fixtures/flow-libs/metro/Server/MultipartResponse.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/Server/MultipartResponse.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ * @oncall react_native
+ */
+
+import type {IncomingMessage, ServerResponse} from 'http';
+
+import accepts from 'accepts';
+
+const CRLF = '\r\n';
+const BOUNDARY = '3beqjf3apnqeu3h5jqorms4i';
+type Data = string | Buffer | Uint8Array;
+type Headers = {[string]: string | number};
+
+export default class MultipartResponse {
+  static wrapIfSupported(
+    req: IncomingMessage,
+    res: ServerResponse,
+  ): MultipartResponse | ServerResponse {
+    if (accepts(req).types().includes('multipart/mixed')) {
+      return new MultipartResponse(res);
+    }
+
+    return res;
+  }
+
+  static serializeHeaders(headers: Headers): string {
+    return Object.keys(headers)
+      .map(key => `${key}: ${headers[key]}`)
+      .join(CRLF);
+  }
+
+  res: ServerResponse;
+  headers: Headers;
+
+  constructor(res: ServerResponse) {
+    this.res = res;
+    this.headers = {};
+    res.writeHead(200, {
+      'Content-Type': `multipart/mixed; boundary="${BOUNDARY}"`,
+    });
+    res.write(
+      'If you are seeing this, your client does not support multipart response',
+    );
+  }
+
+  writeChunk(
+    headers: Headers | null,
+    data?: Data,
+    isLast?: boolean = false,
+  ): void {
+    if (this.res.finished) {
+      return;
+    }
+
+    this.res.write(`${CRLF}--${BOUNDARY}${CRLF}`);
+    if (headers) {
+      this.res.write(MultipartResponse.serializeHeaders(headers) + CRLF + CRLF);
+    }
+
+    if (data != null) {
+      this.res.write(data);
+    }
+
+    if (isLast) {
+      this.res.write(`${CRLF}--${BOUNDARY}--${CRLF}`);
+    }
+  }
+
+  writeHead(status: number, headers?: Headers): void {
+    // We can't actually change the response HTTP status code
+    // because the headers have already been sent
+    this.setHeader('X-Http-Status', status);
+    if (!headers) {
+      return;
+    }
+    for (const key in headers) {
+      this.setHeader(key, headers[key]);
+    }
+  }
+
+  setHeader(name: string, value: string | number): void {
+    this.headers[name] = value;
+  }
+
+  end(data?: Data): void {
+    this.writeChunk(this.headers, data, true);
+    this.res.end();
+  }
+
+  once(name: string, fn: () => unknown): this {
+    this.res.once(name, fn);
+    return this;
+  }
+}

--- a/tests/integration/tests/fixtures/flow-libs/metro/Server/symbolicate.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/Server/symbolicate.js
@@ -1,0 +1,218 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {
+  FBSourceFunctionMap,
+  MetroSourceMapSegmentTuple,
+} from '../../../metro-source-map/src/source-map';
+import type {ExplodedSourceMap} from '../DeltaBundler/Serializers/getExplodedSourceMap';
+import type {ConfigT} from 'metro-config';
+
+import {greatestLowerBound} from 'metro-source-map/private/Consumer/search';
+import {SourceMetadataMapConsumer} from 'metro-symbolicate/private/Symbolication';
+
+export type StackFrameInput = {
+  +file: ?string,
+  +lineNumber: ?number,
+  +column: ?number,
+  +methodName: ?string,
+  ...
+};
+export type IntermediateStackFrame = {
+  ...StackFrameInput,
+  collapse?: boolean,
+  ...
+};
+export type StackFrameOutput = Readonly<IntermediateStackFrame>;
+type ExplodedSourceMapModule = ExplodedSourceMap[number];
+type Position = {+line1Based: number, column0Based: number};
+
+function createFunctionNameGetter(
+  module: ExplodedSourceMapModule,
+): Position => ?string {
+  const consumer = new SourceMetadataMapConsumer(
+    {
+      version: 3,
+      mappings: '',
+      sources: ['dummy'],
+      names: [],
+      x_facebook_sources: [[module.functionMap]],
+    },
+    name => name /* no normalization needed */,
+  );
+  return ({line1Based, column0Based}) =>
+    consumer.functionNameFor({
+      line: line1Based,
+      column: column0Based,
+      source: 'dummy',
+    });
+}
+
+export default async function symbolicate(
+  stack: ReadonlyArray<StackFrameInput>,
+  maps: Iterable<[string, ExplodedSourceMap]>,
+  config: ConfigT,
+  extraData: unknown,
+): Promise<ReadonlyArray<StackFrameOutput>> {
+  const mapsByUrl = new Map<?string, ExplodedSourceMap>();
+  for (const [url, map] of maps) {
+    mapsByUrl.set(url, map);
+  }
+  const functionNameGetters = new Map<
+    {
+      +firstLine1Based: number,
+      +functionMap: ?FBSourceFunctionMap,
+      +map: Array<MetroSourceMapSegmentTuple>,
+      +path: string,
+    },
+    (Position) => ?string,
+  >();
+
+  function findModule(frame: StackFrameInput): ?ExplodedSourceMapModule {
+    const map = mapsByUrl.get(frame.file);
+    if (!map || frame.lineNumber == null) {
+      return null;
+    }
+    const moduleIndex = greatestLowerBound(
+      map,
+      frame.lineNumber,
+      (target, candidate) => target - candidate.firstLine1Based,
+    );
+    if (moduleIndex == null) {
+      return null;
+    }
+    return map[moduleIndex];
+  }
+
+  function findOriginalPos(
+    frame: StackFrameInput,
+    module: ExplodedSourceMapModule,
+  ): ?Position {
+    if (
+      module.map == null ||
+      frame.lineNumber == null ||
+      frame.column == null
+    ) {
+      return null;
+    }
+    const generatedPosInModule = {
+      line1Based: frame.lineNumber - module.firstLine1Based + 1,
+      column0Based: frame.column,
+    };
+    const mappingIndex = greatestLowerBound(
+      module.map,
+      generatedPosInModule,
+      (target, candidate) => {
+        if (target.line1Based === candidate[0]) {
+          return target.column0Based - candidate[1];
+        }
+        return target.line1Based - candidate[0];
+      },
+    );
+    if (mappingIndex == null) {
+      return null;
+    }
+    const mapping = module.map[mappingIndex];
+    if (
+      mapping[0] !== generatedPosInModule.line1Based ||
+      mapping.length < 4 /* no source line/column info */
+    ) {
+      return null;
+    }
+    return {
+      // $FlowFixMe[invalid-tuple-index]: Length checks do not refine tuple unions.
+      line1Based: mapping[2],
+      // $FlowFixMe[invalid-tuple-index]: Length checks do not refine tuple unions.
+      column0Based: mapping[3],
+    };
+  }
+
+  function findFunctionName(
+    originalPos: Position,
+    module: {
+      +firstLine1Based: number,
+      +functionMap: ?FBSourceFunctionMap,
+      +map: Array<MetroSourceMapSegmentTuple>,
+      +path: string,
+    },
+  ): ?string {
+    if (module.functionMap) {
+      let getFunctionName = functionNameGetters.get(module);
+      if (!getFunctionName) {
+        getFunctionName = createFunctionNameGetter(module);
+        functionNameGetters.set(module, getFunctionName);
+      }
+      return getFunctionName(originalPos);
+    }
+    return null;
+  }
+
+  function symbolicateFrame(frame: StackFrameInput): IntermediateStackFrame {
+    const module = findModule(frame);
+    if (!module) {
+      return {...frame};
+    }
+    if (!Array.isArray(module.map)) {
+      throw new Error(
+        `Unexpected module with serialized source map found: ${module.path}`,
+      );
+    }
+    const originalPos = findOriginalPos(frame, module);
+    if (!originalPos) {
+      return {...frame};
+    }
+    const methodName =
+      findFunctionName(originalPos, module) ?? frame.methodName;
+    return {
+      ...frame,
+      methodName,
+      file: module.path,
+      lineNumber: originalPos.line1Based,
+      column: originalPos.column0Based,
+    };
+  }
+
+  /**
+   * `customizeFrame` allows for custom modifications of the symbolicated frame in a stack.
+   * It can be used to collapse stack frames that are not relevant to users, pointing them
+   * to more relevant product code instead.
+   *
+   * An example usecase is a library throwing an error while sanitizing inputs from product code.
+   * In some cases, it's more useful to point the developer looking at the error towards the product code directly.
+   */
+  async function customizeFrame(
+    frame: IntermediateStackFrame,
+  ): Promise<IntermediateStackFrame> {
+    const customizations =
+      (await config.symbolicator.customizeFrame(frame)) || {};
+    return {...frame, ...customizations};
+  }
+
+  /**
+   * `customizeStack` allows for custom modifications of a symbolicated stack.
+   * Where `customizeFrame` operates on individual frames, this hook can process the entire stack in context.
+   *
+   * Note: `customizeStack` has access to an `extraData` object which can be used to attach metadata
+   * to the error coming in, to be used by the customizeStack hook.
+   */
+  async function customizeStack(
+    symbolicatedStack: Array<IntermediateStackFrame>,
+  ): Promise<Array<IntermediateStackFrame>> {
+    return await config.symbolicator.customizeStack(
+      symbolicatedStack,
+      extraData,
+    );
+  }
+
+  return Promise.all(stack.map(symbolicateFrame).map(customizeFrame)).then(
+    customizeStack,
+  );
+}

--- a/tests/integration/tests/fixtures/flow-libs/metro/cli-utils.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/cli-utils.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ * @oncall react_native
+ */
+
+import fs from 'fs';
+
+export const watchFile = async function (
+  filename: string,
+  callback: () => unknown,
+): Promise<void> {
+  fs.watchFile(filename, () => {
+    callback();
+  });
+
+  await callback();
+};
+
+export const makeAsyncCommand =
+  <T>(command: (argv: T) => Promise<void>): ((argv: T) => void) =>
+  (argv: T) => {
+    Promise.resolve(command(argv)).catch(error => {
+      console.error(error.stack);
+      process.exitCode = 1;
+    });
+  };

--- a/tests/integration/tests/fixtures/flow-libs/metro/cli.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/cli.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+/* eslint-disable import/no-commonjs */
+
+'use strict';
+
+try {
+  // $FlowFixMe[untyped-import]
+  require('metro-babel-register').unstable_registerForMetroMonorepo();
+} catch {}
+
+const {attachMetroCli} = require('./index');
+const yargs = require('yargs');
+
+// $FlowFixMe[unused-promise]
+attachMetroCli(yargs.demandCommand(1)).argv;

--- a/tests/integration/tests/fixtures/flow-libs/metro/index.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/index.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+/* eslint-disable import/no-commonjs */
+
+'use strict';
+
+/*::
+export type * from './index.flow';
+*/
+
+try {
+  require('metro-babel-register').unstable_registerForMetroMonorepo();
+} catch {}
+
+module.exports = require('./index.flow');

--- a/tests/integration/tests/fixtures/flow-libs/metro/lib/TerminalReporter.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/lib/TerminalReporter.js
@@ -1,0 +1,554 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {BundleDetails, ReportableEvent} from './reporting';
+import type {Terminal} from 'metro-core';
+import type {HealthCheckResult, WatcherStatus} from 'metro-file-map';
+import type {BackgroundColors, ForegroundColors, Modifiers} from 'util';
+
+import {calculateBundleProgressRatio} from './bundleProgressUtils';
+import logToConsole from './logToConsole';
+import * as reporting from './reporting';
+// $FlowFixMe[untyped-import] lodash.throttle
+import throttle from 'lodash.throttle';
+import {AmbiguousModuleResolutionError} from 'metro-core';
+import path from 'path';
+import util from 'util';
+
+type StyleFormat = ReadonlyArray<
+  ForegroundColors | BackgroundColors | Modifiers,
+>;
+const style = (format: StyleFormat, text: string): string =>
+  util.styleText(format, text);
+
+type BundleProgress = {
+  bundleDetails: BundleDetails,
+  transformedFileCount: number,
+  totalFileCount: number,
+  ratio: number,
+  isPrefetch?: boolean,
+  ...
+};
+
+export type TerminalReportableEvent =
+  | ReportableEvent
+  | {
+      buildID: string,
+      type: 'bundle_transform_progressed_throttled',
+      transformedFileCount: number,
+      totalFileCount: number,
+      ...
+    }
+  | {
+      type: 'unstable_server_log',
+      level: 'info' | 'warn' | 'error',
+      data: string | Array<unknown>,
+      ...
+    }
+  | {
+      type: 'unstable_server_menu_updated',
+      message: string,
+      ...
+    }
+  | {
+      type: 'unstable_server_menu_cleared',
+      ...
+    };
+
+type BuildPhase = 'in_progress' | 'done' | 'failed';
+
+interface SnippetError extends Error {
+  code?: string;
+  filename?: string;
+  snippet?: string;
+}
+
+const DARK_BLOCK_CHAR = '\u2593';
+const LIGHT_BLOCK_CHAR = '\u2591';
+const MAX_PROGRESS_BAR_CHAR_WIDTH = 16;
+
+/**
+ * We try to print useful information to the terminal for interactive builds.
+ * This implements the `Reporter` interface from the './reporting' module.
+ */
+export default class TerminalReporter {
+  /**
+   * The bundle builds for which we are actively maintaining the status on the
+   * terminal, ie. showing a progress bar. There can be several bundles being
+   * built at the same time.
+   */
+  _activeBundles: Map<string, BundleProgress>;
+
+  _interactionStatus: ?string;
+
+  _scheduleUpdateBundleProgress: {
+    (data: {
+      buildID: string,
+      transformedFileCount: number,
+      totalFileCount: number,
+      ...
+    }): void,
+    cancel(): void,
+  };
+  _prevHealthCheckResult: ?HealthCheckResult;
+
+  +terminal: Terminal;
+
+  constructor(terminal: Terminal) {
+    this._activeBundles = new Map();
+    this._scheduleUpdateBundleProgress = throttle(data => {
+      this.update({...data, type: 'bundle_transform_progressed_throttled'});
+    }, 100);
+    this.terminal = terminal;
+  }
+
+  /**
+   * Construct a message that represents the progress of a
+   * single bundle build, for example:
+   *
+   *     BUNDLE path/to/bundle.js ▓▓▓▓▓░░░░░░░░░░░ 36.6% (4790/7922)
+   */
+  _getBundleStatusMessage(
+    {
+      bundleDetails: {entryFile, bundleType},
+      transformedFileCount,
+      totalFileCount,
+      ratio,
+      isPrefetch,
+    }: BundleProgress,
+    phase: BuildPhase,
+  ): string {
+    const localPath = path.relative('.', entryFile);
+    const filledBar = Math.floor(ratio * MAX_PROGRESS_BAR_CHAR_WIDTH);
+    const bundleTypeColor: StyleFormat =
+      phase === 'done' ? ['green'] : phase === 'failed' ? ['red'] : ['yellow'];
+    const progress =
+      phase === 'in_progress'
+        ? style(['green', 'bgGreen'], DARK_BLOCK_CHAR.repeat(filledBar)) +
+          style(
+            ['bgWhite', 'white'],
+            LIGHT_BLOCK_CHAR.repeat(MAX_PROGRESS_BAR_CHAR_WIDTH - filledBar),
+          ) +
+          style(['bold'], ` ${Math.floor(100 * ratio)}% `) +
+          style(['dim'], `(${transformedFileCount}/${totalFileCount})`)
+        : '';
+
+    return (
+      style(
+        [...bundleTypeColor, 'inverse', 'bold'],
+        ` ${isPrefetch === true ? 'PREBUNDLE' : bundleType.toUpperCase()} `,
+      ) +
+      style(['reset', 'dim'], ` ${path.dirname(localPath)}/`) +
+      style(['bold'], path.basename(localPath)) +
+      ' ' +
+      progress
+    );
+  }
+
+  _logBundleBuildDone(buildID: string): void {
+    const progress = this._activeBundles.get(buildID);
+    if (progress != null) {
+      const msg = this._getBundleStatusMessage(
+        {
+          ...progress,
+          ratio: 1,
+          transformedFileCount: progress.totalFileCount,
+        },
+        'done',
+      );
+      this.terminal.log(msg);
+      this._activeBundles.delete(buildID);
+    }
+  }
+
+  _logBundleBuildFailed(buildID: string): void {
+    const progress = this._activeBundles.get(buildID);
+    if (progress != null) {
+      const msg = this._getBundleStatusMessage(progress, 'failed');
+      this.terminal.log(msg);
+    }
+  }
+
+  _logInitializing(port: number, hasReducedPerformance: boolean): void {
+    const logo = [
+      '',
+      '                        ▒▒▓▓▓▓▒▒',
+      '                     ▒▓▓▓▒▒░░▒▒▓▓▓▒',
+      '                  ▒▓▓▓▓░░░▒▒▒▒░░░▓▓▓▓▒',
+      '                 ▓▓▒▒▒▓▓▓▓▓▓▓▓▓▓▓▓▒▒▒▓▓',
+      '                 ▓▓░░░░░▒▓▓▓▓▓▓▒░░░░░▓▓',
+      '                 ▓▓░░▓▓▒░░░▒▒░░░▒▓▒░░▓▓',
+      '                 ▓▓░░▓▓▓▓▓▒▒▒▒▓▓▓▓▒░░▓▓',
+      '                 ▓▓░░▓▓▓▓▓▓▓▓▓▓▓▓▓▒░░▓▓',
+      '                 ▓▓▒░░▒▒▓▓▓▓▓▓▓▓▒░░░▒▓▓',
+      '                  ▒▓▓▓▒░░░▒▓▓▒░░░▒▓▓▓▒',
+      '                     ▒▓▓▓▒░░░░▒▓▓▓▒',
+      '                        ▒▒▓▓▓▓▒▒',
+      '',
+      '',
+    ];
+
+    const color: StyleFormat = hasReducedPerformance ? ['red'] : ['blue'];
+    this.terminal.log(style(color, logo.join('\n')));
+  }
+
+  _logInitializingFailed(port: number, error: SnippetError): void {
+    if (error.code === 'EADDRINUSE') {
+      this.terminal.log(
+        style(['bgRed', 'bold'], ' ERROR '),
+        style(
+          ['red'],
+          `Metro can't listen on port ${style(['bold'], String(port))}`,
+        ),
+      );
+      this.terminal.log(
+        'Most likely another process is already using this port',
+      );
+      this.terminal.log('Run the following command to find out which process:');
+      this.terminal.log('\n  ', style(['bold'], 'lsof -i :' + port), '\n');
+      this.terminal.log('Then, you can either shut down the other process:');
+      this.terminal.log('\n  ', style(['bold'], 'kill -9 <PID>'), '\n');
+      this.terminal.log('or run Metro on different port.');
+    } else {
+      this.terminal.log(
+        style(['bgRed', 'bold'], ' ERROR '),
+        style(['red'], error.message),
+      );
+      const errorAttributes = JSON.stringify(error);
+      if (errorAttributes !== '{}') {
+        this.terminal.log(style(['red'], errorAttributes));
+      }
+      this.terminal.log(style(['red'], String(error.stack)));
+    }
+  }
+
+  /**
+   * This function is only concerned with logging and should not do state
+   * or terminal status updates.
+   */
+  _log(event: TerminalReportableEvent): void {
+    switch (event.type) {
+      case 'initialize_started':
+        this._logInitializing(event.port, event.hasReducedPerformance);
+        break;
+      case 'initialize_failed':
+        this._logInitializingFailed(event.port, event.error);
+        break;
+      case 'bundle_build_done':
+        this._logBundleBuildDone(event.buildID);
+        break;
+      case 'bundle_save_log':
+        this.terminal.log('LOG:' + event.message);
+        break;
+      case 'bundle_build_failed':
+        this._logBundleBuildFailed(event.buildID);
+        break;
+      case 'bundling_error':
+        this._logBundlingError(event.error);
+        break;
+      case 'resolver_warning':
+        this._logWarning(event.message);
+        break;
+      case 'transform_cache_reset':
+        reporting.logWarning(this.terminal, 'the transform cache was reset.');
+        break;
+      case 'worker_stdout_chunk':
+        this._logWorkerChunk('stdout', event.chunk);
+        break;
+      case 'worker_stderr_chunk':
+        this._logWorkerChunk('stderr', event.chunk);
+        break;
+      case 'hmr_client_error':
+        this._logHmrClientError(event.error);
+        break;
+      case 'client_log':
+        logToConsole(this.terminal, event.level, ...event.data);
+        break;
+      case 'unstable_server_log':
+        const logFn = {
+          info: reporting.logInfo,
+          warn: reporting.logWarning,
+          error: reporting.logError,
+        }[event.level];
+        const [format, ...args] = [].concat(event.data);
+        logFn(this.terminal, String(format), ...args);
+        break;
+      case 'dep_graph_loading':
+        const color: StyleFormat = event.hasReducedPerformance
+          ? ['red']
+          : ['blue'];
+        // eslint-disable-next-line import/no-commonjs
+        // $FlowFixMe[untyped-import] package.json
+        const version = 'v' + require('../../package.json').version;
+        this.terminal.log(
+          style(
+            [...color, 'bold'],
+            ' '.repeat(19 - version.length / 2) +
+              ' Welcome to Metro ' +
+              style(['white'], version) +
+              '\n',
+          ) + style(['dim'], '              Fast - Scalable - Integrated\n\n'),
+        );
+
+        if (event.hasReducedPerformance) {
+          this.terminal.log(
+            style(
+              ['red'],
+              'Metro is operating with reduced performance.\n' +
+                'Please fix the problem above and restart Metro.\n\n',
+            ),
+          );
+        }
+
+        break;
+      case 'watcher_health_check_result':
+        this._logWatcherHealthCheckResult(event.result);
+        break;
+      case 'watcher_status':
+        this._logWatcherStatus(event.status);
+        break;
+    }
+  }
+
+  /**
+   * We do not want to log the whole stacktrace for bundling error, because
+   * these are operational errors, not programming errors, and the stacktrace
+   * is not actionable to end users.
+   */
+  _logBundlingError(error: SnippetError): void {
+    if (error instanceof AmbiguousModuleResolutionError) {
+      const he = error.hasteError;
+      const message =
+        'ambiguous resolution: module `' +
+        `${error.fromModulePath}\` tries to require \`${he.hasteName}\`, ` +
+        'but there are several files providing this module. You can delete ' +
+        'or fix them: \n\n' +
+        Object.keys(he.duplicatesSet)
+          .sort()
+          .map(dupFilePath => `  * \`${dupFilePath}\`\n`)
+          .join('');
+      reporting.logError(this.terminal, message);
+      return;
+    }
+
+    let {message} = error;
+
+    // Do not log the stack trace for SyntaxError (because it will always be in
+    // the parser, which is not helpful).
+    if (!(error instanceof SyntaxError)) {
+      if (error.snippet == null && error.stack != null) {
+        message = error.stack;
+      }
+    }
+
+    const filename = error.filename;
+    if (filename?.length && !message.includes(filename)) {
+      message += ` [${filename}]`;
+    }
+
+    if (error.snippet != null) {
+      message += '\n' + error.snippet;
+    }
+    reporting.logError(this.terminal, message);
+  }
+
+  _logWorkerChunk(origin: 'stdout' | 'stderr', chunk: string): void {
+    const lines = chunk.split('\n');
+    if (lines.length >= 1 && lines[lines.length - 1] === '') {
+      lines.splice(lines.length - 1, 1);
+    }
+    lines.forEach((line: string) => {
+      this.terminal.log(`transform[${origin}]: ${line}`);
+    });
+  }
+
+  _updateBundleProgress({
+    buildID,
+    transformedFileCount,
+    totalFileCount,
+  }: {
+    buildID: string,
+    transformedFileCount: number,
+    totalFileCount: number,
+    ...
+  }): void {
+    const currentProgress = this._activeBundles.get(buildID);
+    if (currentProgress == null) {
+      return;
+    }
+
+    const ratio = calculateBundleProgressRatio(
+      transformedFileCount,
+      totalFileCount,
+      currentProgress.ratio,
+    );
+
+    // $FlowFixMe[unsafe-object-assign]
+    Object.assign(currentProgress, {
+      ratio,
+      transformedFileCount,
+      totalFileCount,
+    });
+  }
+
+  /**
+   * This function is exclusively concerned with updating the internal state.
+   * No logging or status updates should be done at this point.
+   */
+  _updateState(event: TerminalReportableEvent): void {
+    switch (event.type) {
+      case 'bundle_build_done':
+      case 'bundle_build_failed':
+        this._activeBundles.delete(event.buildID);
+        break;
+      case 'bundle_build_started':
+        const bundleProgress: BundleProgress = {
+          bundleDetails: event.bundleDetails,
+          transformedFileCount: 0,
+          totalFileCount: 1,
+          ratio: 0,
+          isPrefetch: event.isPrefetch,
+        };
+        this._activeBundles.set(event.buildID, bundleProgress);
+        break;
+
+      case 'bundle_transform_progressed_throttled':
+        this._updateBundleProgress(event);
+        break;
+      case 'unstable_server_menu_updated':
+        this._interactionStatus = event.message;
+        break;
+      case 'unstable_server_menu_cleared':
+        this._interactionStatus = null;
+        break;
+    }
+  }
+
+  /**
+   * Return a status message that is always consistent with the current state
+   * of the application. Having this single function ensures we don't have
+   * different callsites overriding each other status messages.
+   */
+  _getStatusMessage(): string {
+    return Array.from(this._activeBundles.entries())
+      .map(([_, progress]: [string, BundleProgress]) =>
+        this._getBundleStatusMessage(progress, 'in_progress'),
+      )
+      .concat([this._interactionStatus])
+      .filter((str: ?string) => str != null)
+      .join('\n');
+  }
+
+  _logHmrClientError(e: Error): void {
+    reporting.logError(
+      this.terminal,
+      'A WebSocket client got a connection error. Please reload your device ' +
+        'to get HMR working again: %s',
+      e,
+    );
+  }
+
+  _logWarning(message: string): void {
+    reporting.logWarning(this.terminal, message);
+  }
+
+  _logWatcherHealthCheckResult(result: HealthCheckResult) {
+    // Don't be spammy; only report changes in status.
+    if (
+      !this._prevHealthCheckResult ||
+      result.type !== this._prevHealthCheckResult.type ||
+      (result.type === 'timeout' &&
+        this._prevHealthCheckResult.type === 'timeout' &&
+        (result.pauseReason ?? null) !==
+          (this._prevHealthCheckResult.pauseReason ?? null))
+    ) {
+      const watcherName = "'" + (result.watcher ?? 'unknown') + "'";
+      switch (result.type) {
+        case 'success':
+          // Only report success after a prior failure.
+          if (this._prevHealthCheckResult) {
+            this.terminal.log(
+              style(['green'], `Watcher ${watcherName} is now healthy.`),
+            );
+          }
+          break;
+        case 'error':
+          reporting.logWarning(
+            this.terminal,
+            'Failed to perform watcher health check. Check whether the project root is writable.',
+          );
+          break;
+        case 'timeout':
+          const why =
+            result.pauseReason != null
+              ? ` This may be because: ${result.pauseReason}`
+              : '';
+          reporting.logWarning(
+            this.terminal,
+            `Watcher ${watcherName} failed to detect a file change within ${result.timeout}ms.` +
+              why,
+          );
+          break;
+      }
+    }
+    this._prevHealthCheckResult = result;
+  }
+
+  _logWatcherStatus(status: WatcherStatus) {
+    switch (status.type) {
+      case 'watchman_warning':
+        const warning =
+          typeof status.warning === 'string'
+            ? status.warning
+            : `unknown warning (type: ${typeof status.warning})`;
+        reporting.logWarning(
+          this.terminal,
+          `Watchman \`${status.command}\` returned a warning: ${warning}`,
+        );
+        break;
+      case 'watchman_slow_command':
+        this.terminal.log(
+          style(
+            ['dim'],
+            `Waiting for Watchman \`${status.command}\` (${Math.round(
+              status.timeElapsed / 1000,
+            )}s)...`,
+          ),
+        );
+        break;
+      case 'watchman_slow_command_complete':
+        this.terminal.log(
+          style(
+            ['green'],
+            `Watchman \`${status.command}\` finished after ${(
+              status.timeElapsed / 1000
+            ).toFixed(1)}s.`,
+          ),
+        );
+        break;
+    }
+  }
+
+  /**
+   * Single entry point for reporting events. That allows us to implement the
+   * corresponding JSON reporter easily and have a consistent reporting.
+   */
+  update(event: TerminalReportableEvent): void {
+    if (event.type === 'bundle_transform_progressed') {
+      this._scheduleUpdateBundleProgress(event);
+      return;
+    }
+
+    this._log(event);
+    this._updateState(event);
+    this.terminal.status(this._getStatusMessage());
+  }
+}

--- a/tests/integration/tests/fixtures/flow-libs/metro/lib/contextModule.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/lib/contextModule.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {
+  ContextMode,
+  RequireContextParams,
+} from '../ModuleGraph/worker/collectDependencies';
+
+import crypto from 'crypto';
+import nullthrows from 'nullthrows';
+import path from 'path';
+
+export type RequireContext = Readonly<{
+  /* Should search for files recursively. Optional, default `true` when `require.context` is used */
+  recursive: boolean,
+  /* Filename filter pattern for use in `require.context`. Optional, default `.*` (any file) when `require.context` is used */
+  filter: RegExp,
+  /** Mode for resolving dynamic dependencies. Defaults to `sync` */
+  mode: ContextMode,
+  /** Absolute path of the directory to search in */
+  from: string,
+}>;
+
+function toHash(value: string): string {
+  // Use `hex` to ensure filepath safety.
+  return crypto.createHash('sha1').update(value).digest('hex');
+}
+
+/** Given a fully qualified require context, return a virtual file path that ensures uniqueness between paths with different contexts. */
+export function deriveAbsolutePathFromContext(
+  from: string,
+  context: RequireContextParams,
+): string {
+  // Drop the trailing slash, require.context should always be matched against a folder
+  // and we want to normalize the folder name as much as possible to prevent duplicates.
+  // This also makes the files show up in the correct location when debugging in Chrome.
+  const filePath = from.endsWith(path.sep) ? from.slice(0, -1) : from;
+  return (
+    filePath +
+    '?ctx=' +
+    toHash(
+      [
+        context.mode,
+        context.recursive ? 'recursive' : '',
+        new RegExp(context.filter.pattern, context.filter.flags).toString(),
+      ]
+        .filter(Boolean)
+        .join(' '),
+    )
+  );
+}
+
+/** Match a file against a require context. */
+export function fileMatchesContext(
+  testPath: string,
+  context: RequireContext,
+): boolean {
+  // NOTE(EvanBacon): Ensure this logic is synchronized with the similar
+  // functionality in `metro-file-map/src/lib/TreeFS.js` (`matchFiles()`)
+
+  const filePath = path.relative(nullthrows(context.from), testPath);
+  const filter = context.filter;
+  if (
+    // Ignore everything outside of the provided `root`.
+    !(filePath && !filePath.startsWith('..')) ||
+    // Prevent searching in child directories during a non-recursive search.
+    (!context.recursive && filePath.includes(path.sep)) ||
+    // Test against the filter.
+    !filter.test(
+      // NOTE(EvanBacon): Ensure files start with `./` for matching purposes
+      // this ensures packages work across Metro and Webpack (ex: Storybook for React DOM / React Native).
+      // `a/b.js` -> `./a/b.js`
+      './' + filePath.replace(/\\/g, '/'),
+    )
+  ) {
+    return false;
+  }
+
+  return true;
+}

--- a/tests/integration/tests/fixtures/flow-libs/metro/lib/formatBundlingError.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/lib/formatBundlingError.js
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import type {FormattedError} from 'metro-runtime/src/modules/types';
+
+import GraphNotFoundError from '../IncrementalBundler/GraphNotFoundError';
+import ResourceNotFoundError from '../IncrementalBundler/ResourceNotFoundError';
+import RevisionNotFoundError from '../IncrementalBundler/RevisionNotFoundError';
+import {UnableToResolveError} from '../node-haste/DependencyGraph/ModuleResolution';
+import {codeFrameColumns} from '@babel/code-frame';
+import ErrorStackParser from 'error-stack-parser';
+import fs from 'fs';
+import {AmbiguousModuleResolutionError} from 'metro-core';
+import serializeError from 'serialize-error';
+
+export type CustomError = Error &
+  interface {
+    +type?: string,
+    filename?: string,
+    lineNumber?: number,
+    errors?: Array<{
+      description: string,
+      filename: string,
+      lineNumber: number,
+      ...
+    }>,
+  };
+
+export default function formatBundlingError(
+  error: CustomError,
+): FormattedError {
+  if (error instanceof AmbiguousModuleResolutionError) {
+    const he = error.hasteError;
+    const message =
+      "Ambiguous resolution: module '" +
+      `${error.fromModulePath}\' tries to require \'${he.hasteName}\', but ` +
+      'there are several files providing this module. You can delete or ' +
+      'fix them: \n\n' +
+      Object.keys(he.duplicatesSet)
+        .sort()
+        .map(dupFilePath => `${dupFilePath}`)
+        .join('\n\n');
+
+    return {
+      type: 'AmbiguousModuleResolutionError',
+      message,
+      errors: [{description: message}],
+    };
+  }
+
+  if (
+    error instanceof UnableToResolveError ||
+    (error instanceof Error &&
+      /* $FlowFixMe[invalid-compare] Error discovered during Constant Condition
+       * roll out. See https://fburl.com/workplace/4oq3zi07. */
+      (error.type === 'TransformError' || error.type === 'NotFoundError'))
+  ) {
+    return {
+      ...serializeError(error),
+      // Ensure the type is passed to the client.
+      type: error.type,
+      errors: [
+        {
+          description: error.message,
+          filename: error.filename,
+          lineNumber: error.lineNumber,
+        },
+      ],
+    };
+  } else if (error instanceof ResourceNotFoundError) {
+    return {
+      type: 'ResourceNotFoundError',
+      // $FlowFixMe[incompatible-type]
+      errors: [],
+      message: error.message,
+    };
+  } else if (error instanceof GraphNotFoundError) {
+    return {
+      type: 'GraphNotFoundError',
+      // $FlowFixMe[incompatible-type]
+      errors: [],
+      message: error.message,
+    };
+  } else if (error instanceof RevisionNotFoundError) {
+    return {
+      type: 'RevisionNotFoundError',
+      // $FlowFixMe[incompatible-type]
+      errors: [],
+      message: error.message,
+    };
+  } else {
+    const stack = ErrorStackParser.parse(error);
+    const fileName = stack[0].fileName;
+    const column = stack[0].columnNumber;
+    const line = stack[0].lineNumber;
+
+    let codeFrame = '';
+    try {
+      codeFrame = codeFrameColumns(
+        // If the error was thrown in a node.js builtin module, this call will fail and mask the real error.
+        fs.readFileSync(fileName, 'utf8'),
+        {
+          start: {column, line},
+        },
+        {forceColor: true},
+      );
+    } catch {}
+
+    return {
+      type: 'InternalError',
+      errors: [],
+      message: `Metro has encountered an error: ${error.message}: ${fileName} (${line}:${column})\n\n${codeFrame}`,
+    };
+  }
+}

--- a/tests/integration/tests/fixtures/flow-libs/metro/lib/getGraphId.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/lib/getGraphId.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {TransformInputOptions} from '../DeltaBundler/types';
+import type {ResolverInputOptions} from '../shared/types';
+
+import canonicalize from 'metro-core/private/canonicalize';
+
+export opaque type GraphId: string = string;
+
+export default function getGraphId(
+  entryFile: string,
+  options: TransformInputOptions,
+  {
+    shallow,
+    lazy,
+    unstable_allowRequireContext,
+    resolverOptions,
+  }: Readonly<{
+    shallow: boolean,
+    lazy: boolean,
+    unstable_allowRequireContext: boolean,
+    resolverOptions: ResolverInputOptions,
+  }>,
+): GraphId {
+  return JSON.stringify(
+    {
+      entryFile,
+      options: {
+        customResolverOptions: resolverOptions.customResolverOptions ?? {},
+        customTransformOptions: options.customTransformOptions ?? null,
+        dev: options.dev,
+        experimentalImportSupport: options.experimentalImportSupport || false,
+        minify: options.minify,
+        platform: options.platform != null ? options.platform : null,
+        type: options.type,
+        lazy,
+        unstable_allowRequireContext,
+        shallow,
+        unstable_transformProfile:
+          options.unstable_transformProfile || 'default',
+      },
+    },
+    canonicalize,
+  );
+}

--- a/tests/integration/tests/fixtures/flow-libs/metro/shared/types.js
+++ b/tests/integration/tests/fixtures/flow-libs/metro/shared/types.js
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {
+  Options as DeltaBundlerOptions,
+  TransformInputOptions,
+} from '../DeltaBundler/types';
+import type {TransformProfile} from 'metro-babel-transformer';
+import type {CustomResolverOptions} from 'metro-resolver';
+import type {
+  MetroSourceMapSegmentTuple,
+  MixedSourceMap,
+} from 'metro-source-map';
+import type {
+  CustomTransformOptions,
+  MinifierOptions,
+} from 'metro-transform-worker';
+
+type MetroSourceMapOrMappings =
+  | MixedSourceMap
+  | Array<MetroSourceMapSegmentTuple>;
+
+export enum SourcePathsMode {
+  /* Use absolute paths for source files in source maps (default). */
+  Absolute = 'absolute',
+  /* Use server-relative URL paths for source files in source maps. */
+  ServerUrl = 'url-server',
+}
+
+export type ReadonlySourceLocation = Readonly<{
+  start: Readonly<{
+    line: number,
+    column: number,
+  }>,
+  end: Readonly<{
+    line: number,
+    column: number,
+  }>,
+}>;
+
+export type BundleOptions = {
+  +customResolverOptions: CustomResolverOptions,
+  customTransformOptions: CustomTransformOptions,
+  dev: boolean,
+  entryFile: string,
+  +excludeSource: boolean,
+  +inlineSourceMap: boolean,
+  +lazy: boolean,
+  minify: boolean,
+  +modulesOnly: boolean,
+  onProgress: ?(doneCont: number, totalCount: number) => unknown,
+  +platform: ?string,
+  +runModule: boolean,
+  +shallow: boolean,
+  sourceMapUrl: ?string,
+  sourceUrl: ?string,
+  createModuleIdFactory?: () => (path: string) => number,
+  +unstable_transformProfile: TransformProfile,
+  +sourcePaths: SourcePathsMode,
+};
+
+export type BuildOptions = Readonly<{
+  withAssets?: boolean,
+}>;
+
+export type ResolverInputOptions = Readonly<{
+  customResolverOptions?: CustomResolverOptions,
+  dev: boolean,
+}>;
+
+export type SerializerOptions = {
+  +sourceMapUrl: ?string,
+  +sourceUrl: ?string,
+  +runModule: boolean,
+  +excludeSource: boolean,
+  +inlineSourceMap: boolean,
+  +modulesOnly: boolean,
+  +sourcePaths: SourcePathsMode,
+};
+
+export type GraphOptions = {
+  +lazy: boolean,
+  +shallow: boolean,
+};
+
+// Stricter representation of BundleOptions.
+export type SplitBundleOptions = Readonly<{
+  entryFile: string,
+  resolverOptions: ResolverInputOptions,
+  transformOptions: TransformInputOptions,
+  serializerOptions: SerializerOptions,
+  graphOptions: GraphOptions,
+  onProgress: DeltaBundlerOptions<>['onProgress'],
+}>;
+
+export type ModuleGroups = {
+  groups: Map<number, Set<number>>,
+  modulesById: Map<number, ModuleTransportLike>,
+  modulesInGroups: Set<number>,
+};
+
+export type ModuleTransportLike = {
+  +code: string,
+  +id: number,
+  +map: ?MetroSourceMapOrMappings,
+  +name?: string,
+  +sourcePath: string,
+  ...
+};
+export type ModuleTransportLikeStrict = {
+  +code: string,
+  +id: number,
+  +map: ?MetroSourceMapOrMappings,
+  +name?: string,
+  +sourcePath: string,
+};
+export type RamModuleTransport = {
+  ...ModuleTransportLikeStrict,
+  +source: string,
+  +type: string,
+};
+
+export type OutputOptions = {
+  bundleOutput: string,
+  bundleEncoding?: 'utf8' | 'utf16le' | 'ascii',
+  dev?: boolean,
+  indexedRamBundle?: boolean,
+  platform: string,
+  sourcemapOutput?: string,
+  sourcemapSourcesRoot?: string,
+  sourcemapUseAbsolutePath?: boolean,
+  ...
+};
+
+type SafeOptionalProps<T> = {
+  [K in keyof T]: T[K] extends void ? void | T[K] : T[K],
+};
+
+export type RequestOptions = Readonly<
+  SafeOptionalProps<{
+    entryFile: string,
+    inlineSourceMap?: boolean,
+    sourceMapUrl?: string,
+    dev?: boolean,
+    minify: boolean,
+    platform: string,
+    createModuleIdFactory?: () => (path: string) => number,
+    onProgress?: (transformedFileCount: number, totalFileCount: number) => void,
+    customResolverOptions?: CustomResolverOptions,
+    customTransformOptions?: CustomTransformOptions,
+    unstable_transformProfile?: TransformProfile,
+  }>,
+>;
+
+export type {MinifierOptions};

--- a/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/mutations/applyOptimisticMutation.js
+++ b/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/mutations/applyOptimisticMutation.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+import type {GraphQLTaggedNode} from '../query/GraphQLTag';
+import type {
+  IEnvironment,
+  MutationParameters,
+  SelectorStoreUpdater,
+} from '../store/RelayStoreTypes';
+import type {Disposable, Variables} from '../util/RelayRuntimeTypes';
+import type {DeclarativeMutationConfig} from './RelayDeclarativeMutationConfig';
+
+const {getRequest} = require('../query/GraphQLTag');
+const isRelayModernEnvironment = require('../store/isRelayModernEnvironment');
+const {
+  createOperationDescriptor,
+} = require('../store/RelayModernOperationDescriptor');
+const RelayDeclarativeMutationConfig = require('./RelayDeclarativeMutationConfig');
+const invariant = require('invariant');
+
+export type OptimisticMutationConfig<TMutation extends MutationParameters> = {
+  configs?: ?Array<DeclarativeMutationConfig>,
+  mutation: GraphQLTaggedNode,
+  variables: Variables,
+  optimisticUpdater?: ?SelectorStoreUpdater<TMutation['response']>,
+  optimisticResponse?: Object,
+};
+
+/**
+ * Higher-level helper function to execute a mutation against a specific
+ * environment.
+ */
+function applyOptimisticMutation<TMutation extends MutationParameters>(
+  environment: IEnvironment,
+  config: OptimisticMutationConfig<TMutation>,
+): Disposable {
+  invariant(
+    isRelayModernEnvironment(environment),
+    'commitMutation: expected `environment` to be an instance of ' +
+      '`RelayModernEnvironment`.',
+  );
+  const mutation = getRequest(config.mutation);
+  if (mutation.params.operationKind !== 'mutation') {
+    throw new Error('commitMutation: Expected mutation operation');
+  }
+  let {optimisticUpdater} = config;
+  const {configs, optimisticResponse, variables} = config;
+  const operation = createOperationDescriptor(mutation, variables);
+  if (configs) {
+    ({optimisticUpdater} = RelayDeclarativeMutationConfig.convert(
+      configs,
+      mutation,
+      optimisticUpdater,
+    ));
+  }
+
+  return environment.applyMutation({
+    operation,
+    response: optimisticResponse,
+    updater: optimisticUpdater,
+  });
+}
+
+module.exports = applyOptimisticMutation;

--- a/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/mutations/commitMutation.js
+++ b/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/mutations/commitMutation.js
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+import type {PayloadError, UploadableMap} from '../network/RelayNetworkTypes';
+import type {GraphQLTaggedNode} from '../query/GraphQLTag';
+import type {
+  IEnvironment,
+  MutationParameters,
+  SelectorStoreUpdater,
+} from '../store/RelayStoreTypes';
+import type {
+  CacheConfig,
+  Disposable,
+  Mutation,
+  Variables,
+} from '../util/RelayRuntimeTypes';
+import type {DeclarativeMutationConfig} from './RelayDeclarativeMutationConfig';
+
+const {getRequest} = require('../query/GraphQLTag');
+const {generateUniqueClientID} = require('../store/ClientID');
+const isRelayModernEnvironment = require('../store/isRelayModernEnvironment');
+const {
+  createOperationDescriptor,
+} = require('../store/RelayModernOperationDescriptor');
+const RelayDeclarativeMutationConfig = require('./RelayDeclarativeMutationConfig');
+const validateMutation = require('./validateMutation');
+const invariant = require('invariant');
+const warning = require('warning');
+
+export type MutationConfig<TMutation extends MutationParameters> = Readonly<{
+  cacheConfig?: CacheConfig,
+  configs?: Array<DeclarativeMutationConfig>,
+  mutation: GraphQLTaggedNode,
+  onCompleted?: ?(
+    response: TMutation['response'],
+    errors: ?Array<PayloadError>,
+  ) => void,
+  onError?: ?(error: Error) => void,
+  onNext?: ?() => void,
+  onUnsubscribe?: ?() => void,
+  optimisticResponse?: {
+    +rawResponse?: {...},
+    ...TMutation,
+    ...
+  }['rawResponse'],
+  optimisticUpdater?: ?SelectorStoreUpdater<TMutation['response']>,
+  updater?: ?SelectorStoreUpdater<TMutation['response']>,
+  uploadables?: UploadableMap,
+  variables: TMutation['variables'],
+}>;
+
+export type CommitMutationConfig<TVariables, TData, TRawResponse> = Readonly<{
+  cacheConfig?: CacheConfig,
+  configs?: Array<DeclarativeMutationConfig>,
+  mutation: Mutation<TVariables, TData, TRawResponse>,
+  onCompleted?: ?(response: TData, errors: ?Array<PayloadError>) => void,
+  onError?: ?(error: Error) => void,
+  onNext?: ?() => void,
+  onUnsubscribe?: ?() => void,
+  optimisticResponse?: TRawResponse,
+  optimisticUpdater?: ?SelectorStoreUpdater<TData>,
+  updater?: ?SelectorStoreUpdater<TData>,
+  uploadables?: UploadableMap,
+  variables: NoInfer<TVariables>,
+}>;
+
+/**
+ * Higher-level helper function to execute a mutation against a specific
+ * environment.
+ */
+function commitMutation<
+  TVariables extends Variables,
+  TData,
+  TRawResponse = {...},
+>(
+  environment: IEnvironment,
+  config: CommitMutationConfig<TVariables, TData, TRawResponse>,
+): Disposable {
+  invariant(
+    isRelayModernEnvironment(environment),
+    'commitMutation: expected `environment` to be an instance of ' +
+      '`RelayModernEnvironment`.',
+  );
+  const mutation = getRequest(config.mutation);
+  if (mutation.params.operationKind !== 'mutation') {
+    throw new Error('commitMutation: Expected mutation operation');
+  }
+  if (mutation.kind !== 'Request') {
+    throw new Error('commitMutation: Expected mutation to be of type request');
+  }
+  let {optimisticResponse, optimisticUpdater, updater} = config;
+  const {configs, cacheConfig, onError, onUnsubscribe, variables, uploadables} =
+    config;
+  const operation = createOperationDescriptor(
+    mutation,
+    variables,
+    cacheConfig,
+    generateUniqueClientID(),
+  );
+  // TODO: remove this check after we fix flow.
+  if (typeof optimisticResponse === 'function') {
+    /* $FlowFixMe[incompatible-use] error exposed when improving flow typing of
+     * commitMutation */
+    optimisticResponse = optimisticResponse();
+    warning(
+      false,
+      'commitMutation: Expected `optimisticResponse` to be an object, ' +
+        'received a function.',
+    );
+  }
+  if (__DEV__) {
+    if (optimisticResponse instanceof Object) {
+      validateMutation(optimisticResponse, mutation, variables);
+    }
+  }
+  if (configs) {
+    ({optimisticUpdater, updater} = RelayDeclarativeMutationConfig.convert<{
+      variables: TVariables,
+      /* $FlowFixMe[incompatible-type] error exposed when improving flow typing
+       * of commitMutation */
+      response: TData,
+    }>(configs, mutation, optimisticUpdater, updater));
+  }
+  const errors: Array<PayloadError> = [];
+  const subscription = environment
+    .executeMutation<{
+      variables: TVariables,
+      /* $FlowFixMe[incompatible-type] error exposed when improving flow typing
+       * of commitMutation */
+      response: TData,
+    }>({
+      operation,
+      optimisticResponse,
+      optimisticUpdater,
+      updater,
+      uploadables,
+    })
+    .subscribe({
+      complete: () => {
+        const {onCompleted} = config;
+        if (onCompleted) {
+          const snapshot = environment.lookup(operation.fragment);
+          onCompleted(
+            snapshot.data as $FlowFixMe,
+            errors.length !== 0 ? errors : null,
+          );
+        }
+      },
+      error: onError,
+      next: payload => {
+        if (Array.isArray(payload)) {
+          payload.forEach(item => {
+            if (item.errors) {
+              errors.push(...item.errors);
+            }
+          });
+        } else {
+          if (payload.errors) {
+            errors.push(...payload.errors);
+          }
+        }
+        config.onNext?.();
+      },
+      unsubscribe: onUnsubscribe,
+    });
+  return {dispose: subscription.unsubscribe};
+}
+
+module.exports = commitMutation;

--- a/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/network/RelayNetwork.js
+++ b/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/network/RelayNetwork.js
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+import type {RequestParameters} from '../util/RelayConcreteNode';
+import type {CacheConfig, Variables} from '../util/RelayRuntimeTypes';
+import type {
+  FetchFunction,
+  GraphQLResponse,
+  INetwork,
+  LogRequestInfoFunction,
+  SubscribeFunction,
+  UploadableMap,
+} from './RelayNetworkTypes';
+import type RelayObservable from './RelayObservable';
+
+const withProvidedVariables = require('../util/withProvidedVariables');
+const {convertFetch} = require('./ConvertToExecuteFunction');
+const invariant = require('invariant');
+
+/**
+ * Creates an implementation of the `Network` interface defined in
+ * `RelayNetworkTypes` given `fetch` and `subscribe` functions.
+ */
+function create(
+  fetchFn: FetchFunction,
+  subscribe?: SubscribeFunction,
+): INetwork {
+  // Convert to functions that returns RelayObservable.
+  const observeFetch = convertFetch(fetchFn);
+
+  function execute(
+    request: RequestParameters,
+    variables: Variables,
+    cacheConfig: CacheConfig,
+    uploadables?: ?UploadableMap,
+    logRequestInfo: ?LogRequestInfoFunction,
+  ): RelayObservable<GraphQLResponse> {
+    const operationVariables = withProvidedVariables(
+      variables,
+      request.providedVariables,
+    );
+    if (request.operationKind === 'subscription') {
+      invariant(
+        subscribe,
+        'RelayNetwork: This network layer does not support Subscriptions. ' +
+          'To use Subscriptions, provide a custom network layer.',
+      );
+
+      invariant(
+        !uploadables,
+        'RelayNetwork: Cannot provide uploadables while subscribing.',
+      );
+      return subscribe(request, operationVariables, cacheConfig);
+    }
+
+    const pollInterval = cacheConfig.poll;
+    if (pollInterval != null) {
+      invariant(
+        !uploadables,
+        'RelayNetwork: Cannot provide uploadables while polling.',
+      );
+      return observeFetch(request, operationVariables, {force: true}).poll(
+        pollInterval,
+      );
+    }
+
+    return observeFetch(
+      request,
+      operationVariables,
+      cacheConfig,
+      uploadables,
+      logRequestInfo,
+    );
+  }
+
+  return {execute};
+}
+
+module.exports = {create};

--- a/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/network/RelayObservable.js
+++ b/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/network/RelayObservable.js
@@ -1,0 +1,633 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+const isPromise = require('../util/isPromise');
+
+/**
+ * A Subscription object is returned from .subscribe(), which can be
+ * unsubscribed or checked to see if the resulting subscription has closed.
+ */
+export type Subscription = {
+  +unsubscribe: () => void,
+  +closed: boolean,
+};
+
+type SubscriptionFn = {
+  (): unknown,
+  +unsubscribe?: void,
+  +closed?: void,
+  ...
+};
+
+/**
+ * An Observer is an object of optional callback functions provided to
+ * .subscribe(). Each callback function is invoked when that event occurs.
+ */
+export type Observer<-T> = {
+  +start?: ?(Subscription) => unknown,
+  +next?: ?(T) => unknown,
+  +error?: ?(Error) => unknown,
+  +complete?: ?() => unknown,
+  +unsubscribe?: ?(Subscription) => unknown,
+};
+
+/**
+ * A Sink is an object of methods provided by Observable during construction.
+ * The methods are to be called to trigger each event. It also contains a closed
+ * field to see if the resulting subscription has closed.
+ */
+export type Sink<-T> = {
+  +next: T => void,
+  +error: (Error, isUncaughtThrownError?: boolean) => void,
+  +complete: () => void,
+  +closed: boolean,
+};
+
+/**
+ * A Source is the required argument when constructing a new Observable. Similar
+ * to a Promise constructor, this is a function which is invoked with a Sink,
+ * and may return either a cleanup function or a Subscription instance (for use
+ * when composing Observables).
+ */
+export type Source<+T> = (Sink<T>) => void | Subscription | SubscriptionFn;
+
+/**
+ * A Subscribable is an interface describing any object which can be subscribed.
+ *
+ * Note: A sink may be passed directly to .subscribe() as its observer,
+ * allowing for easily composing Subscribables.
+ */
+export interface Subscribable<+T> {
+  subscribe(observer: Observer<T> | Sink<T>): Subscription;
+}
+
+export type ObservableFromValue<+T> = Subscribable<T> | Promise<T> | T;
+
+let hostReportError:
+  | ((Error, isUncaughtThrownError: boolean) => unknown)
+  | ((_error: Error, _isUncaughtThrownError: boolean) => void) = swallowError;
+
+/**
+ * Limited implementation of ESObservable, providing the limited set of behavior
+ * Relay networking requires.
+ *
+ * Observables retain the benefit of callbacks which can be called
+ * synchronously, avoiding any UI jitter, while providing a compositional API,
+ * which simplifies logic and prevents mishandling of errors compared to
+ * the direct use of callback functions.
+ *
+ * ESObservable: https://github.com/tc39/proposal-observable
+ */
+class RelayObservable<+T> implements Subscribable<T> {
+  +_source: Source<T>;
+
+  static create<V>(source: Source<V>): RelayObservable<V> {
+    return new RelayObservable(source as any);
+  }
+
+  // Use RelayObservable.create()
+  constructor(source: empty): void {
+    if (__DEV__) {
+      // Early runtime errors for ill-formed sources.
+      if (!source || typeof source !== 'function') {
+        throw new Error('Source must be a Function: ' + String(source));
+      }
+    }
+    (this as any)._source = source;
+  }
+
+  /**
+   * When an emitted error event is not handled by an Observer, it is reported
+   * to the host environment (what the ESObservable spec refers to as
+   * "HostReportErrors()").
+   *
+   * The default implementation in development rethrows thrown errors, and
+   * logs emitted error events to the console, while in production does nothing
+   * (swallowing unhandled errors).
+   *
+   * Called during application initialization, this method allows
+   * application-specific handling of unhandled errors. Allowing, for example,
+   * integration with error logging or developer tools.
+   *
+   * A second parameter `isUncaughtThrownError` is true when the unhandled error
+   * was thrown within an Observer handler, and false when the unhandled error
+   * was an unhandled emitted event.
+   *
+   *  - Uncaught thrown errors typically represent avoidable errors thrown from
+   *    application code, which should be handled with a try/catch block, and
+   *    usually have useful stack traces.
+   *
+   *  - Unhandled emitted event errors typically represent unavoidable events in
+   *    application flow such as network failure, and may not have useful
+   *    stack traces.
+   */
+  static onUnhandledError(
+    callback: (Error, isUncaughtThrownError: boolean) => unknown,
+  ): void {
+    hostReportError = callback;
+  }
+
+  /**
+   * Accepts various kinds of data sources, and always returns a RelayObservable
+   * useful for accepting the result of a user-provided FetchFunction.
+   */
+  static from<V>(obj: ObservableFromValue<V>): RelayObservable<V> {
+    return isObservable<V>(obj)
+      ? fromObservable(obj)
+      : isPromise<V>(obj)
+        ? fromPromise(obj)
+        : fromValue(obj);
+  }
+
+  /**
+   * Similar to promise.catch(), observable.catch() handles error events, and
+   * provides an alternative observable to use in it's place.
+   *
+   * If the catch handler throws a new error, it will appear as an error event
+   * on the resulting Observable.
+   */
+  catch<U>(fn: Error => RelayObservable<U>): RelayObservable<T | U> {
+    return RelayObservable.create(sink => {
+      let subscription;
+      this.subscribe({
+        start: sub => {
+          subscription = sub;
+        },
+        next: sink.next,
+        complete: sink.complete,
+        error(error) {
+          try {
+            fn(error).subscribe({
+              start: sub => {
+                subscription = sub;
+              },
+              next: sink.next,
+              complete: sink.complete,
+              error: sink.error,
+            });
+          } catch (error2) {
+            sink.error(error2, true /* isUncaughtThrownError */);
+          }
+        },
+      });
+      return () => subscription.unsubscribe();
+    });
+  }
+
+  /**
+   * Returns a new Observable which first yields values from this Observable,
+   * then yields values from the next Observable. This is useful for chaining
+   * together Observables of finite length.
+   */
+  concat<U>(next: RelayObservable<U>): RelayObservable<T | U> {
+    return RelayObservable.create(sink => {
+      let current: Subscription;
+      this.subscribe({
+        start(subscription) {
+          current = subscription;
+        },
+        next: sink.next,
+        error: sink.error,
+        complete() {
+          current = next.subscribe(sink);
+        },
+      });
+      return () => {
+        current && current.unsubscribe();
+      };
+    });
+  }
+
+  /**
+   * Returns a new Observable which returns the same values as this one, but
+   * modified so that the provided Observer is called to perform a side-effects
+   * for all events emitted by the source.
+   *
+   * Any errors that are thrown in the side-effect Observer are unhandled, and
+   * do not affect the source Observable or its Observer.
+   *
+   * This is useful for when debugging your Observables or performing other
+   * side-effects such as logging or performance monitoring.
+   */
+  do(observer: Observer<T>): RelayObservable<T> {
+    return RelayObservable.create(sink => {
+      const both = (action: any) =>
+        function () {
+          try {
+            observer[action] && observer[action].apply(observer, arguments);
+          } catch (error) {
+            hostReportError(error, true /* isUncaughtThrownError */);
+          }
+          sink[action] && sink[action].apply(sink, arguments);
+        };
+      return this.subscribe({
+        start: both('start'),
+        next: both('next'),
+        error: both('error'),
+        complete: both('complete'),
+        unsubscribe: both('unsubscribe'),
+      });
+    });
+  }
+
+  /**
+   * Returns a new Observable which returns the same values as this one, but
+   * modified so that the finally callback is performed after completion,
+   * whether normal or due to error or unsubscription.
+   *
+   * This is useful for cleanup such as resource finalization.
+   */
+  finally(fn: () => unknown): RelayObservable<T> {
+    return RelayObservable.create(sink => {
+      const subscription = this.subscribe(sink);
+      return () => {
+        subscription.unsubscribe();
+        fn();
+      };
+    });
+  }
+
+  /**
+   * Returns a new Observable which is identical to this one, unless this
+   * Observable completes before yielding any values, in which case the new
+   * Observable will yield the values from the alternate Observable.
+   *
+   * If this Observable does yield values, the alternate is never subscribed to.
+   *
+   * This is useful for scenarios where values may come from multiple sources
+   * which should be tried in order, i.e. from a cache before a network.
+   */
+  ifEmpty<U>(alternate: RelayObservable<U>): RelayObservable<T | U> {
+    return RelayObservable.create(sink => {
+      let hasValue = false;
+      let current: ?Subscription;
+      current = this.subscribe({
+        next(value) {
+          hasValue = true;
+          sink.next(value);
+        },
+        error: sink.error,
+        complete() {
+          if (hasValue) {
+            sink.complete();
+          } else {
+            current = alternate.subscribe(sink);
+          }
+        },
+      });
+      return () => {
+        current && current.unsubscribe();
+      };
+    });
+  }
+
+  /**
+   * Observable's primary API: returns an unsubscribable Subscription to the
+   * source of this Observable.
+   *
+   * Note: A sink may be passed directly to .subscribe() as its observer,
+   * allowing for easily composing Observables.
+   */
+  subscribe(observer: Observer<T> | Sink<T>): Subscription {
+    if (__DEV__) {
+      // Early runtime errors for ill-formed observers.
+      if (!observer || typeof observer !== 'object') {
+        throw new Error(
+          'Observer must be an Object with callbacks: ' + String(observer),
+        );
+      }
+    }
+    return subscribe(this._source, observer);
+  }
+
+  /**
+   * Returns a new Observerable where each value has been transformed by
+   * the mapping function.
+   */
+  map<U>(fn: T => U): RelayObservable<U> {
+    return RelayObservable.create(sink => {
+      const subscription = this.subscribe({
+        complete: sink.complete,
+        error: sink.error,
+        next: value => {
+          try {
+            const mapValue = fn(value);
+            sink.next(mapValue);
+          } catch (error) {
+            sink.error(error, true /* isUncaughtThrownError */);
+          }
+        },
+      });
+      return () => {
+        subscription.unsubscribe();
+      };
+    });
+  }
+
+  /**
+   * Returns a new Observable where each value is replaced with a new Observable
+   * by the mapping function, the results of which returned as a single
+   * merged Observable.
+   */
+  mergeMap<U>(fn: T => ObservableFromValue<U>): RelayObservable<U> {
+    return RelayObservable.create(sink => {
+      const subscriptions = [];
+
+      type ObservableContext = {_sub?: Subscription};
+
+      function start(this: ObservableContext, subscription: Subscription) {
+        this._sub = subscription;
+        subscriptions.push(subscription);
+      }
+
+      function complete(this: ObservableContext) {
+        /* $FlowFixMe[incompatible-type] Error exposed after improved typing of
+         * Array.{includes,indexOf,lastIndexOf} */
+        subscriptions.splice(subscriptions.indexOf(this._sub), 1);
+        if (subscriptions.length === 0) {
+          sink.complete();
+        }
+      }
+
+      this.subscribe({
+        start,
+        next(value) {
+          try {
+            if (!sink.closed) {
+              RelayObservable.from(fn(value)).subscribe({
+                start,
+                next: sink.next,
+                error: sink.error,
+                complete,
+              });
+            }
+          } catch (error) {
+            sink.error(error, true /* isUncaughtThrownError */);
+          }
+        },
+        error: sink.error,
+        complete,
+      });
+
+      return () => {
+        subscriptions.forEach(sub => sub.unsubscribe());
+        subscriptions.length = 0;
+      };
+    });
+  }
+
+  /**
+   * Returns a new Observable which first mirrors this Observable, then when it
+   * completes, waits for `pollInterval` milliseconds before re-subscribing to
+   * this Observable again, looping in this manner until unsubscribed.
+   *
+   * The returned Observable never completes.
+   */
+  poll(pollInterval: number): RelayObservable<T> {
+    if (__DEV__) {
+      if (typeof pollInterval !== 'number' || pollInterval <= 0) {
+        throw new Error(
+          'RelayObservable: Expected pollInterval to be positive, got: ' +
+            pollInterval,
+        );
+      }
+    }
+    return RelayObservable.create(sink => {
+      let subscription;
+      let timeout;
+      const poll = () => {
+        subscription = this.subscribe({
+          next: sink.next,
+          error: sink.error,
+          complete() {
+            timeout = setTimeout(poll, pollInterval);
+          },
+        });
+      };
+      poll();
+      return () => {
+        clearTimeout(timeout);
+        subscription.unsubscribe();
+      };
+    });
+  }
+
+  /**
+   * Returns a Promise which resolves when this Observable yields a first value
+   * or when it completes with no value.
+   *
+   * NOTE: The source Observable is *NOT* canceled when the returned Promise
+   * resolves. The Observable is always run to completion.
+   */
+  toPromise(): Promise<T | void> {
+    return new Promise((resolve, reject) => {
+      let resolved = false;
+      this.subscribe({
+        next(val) {
+          if (!resolved) {
+            resolved = true;
+            resolve(val);
+          }
+        },
+        error: reject,
+        complete: resolve,
+      });
+    });
+  }
+}
+
+// Use declarations to teach Flow how to check isObservable.
+declare function isObservable<T>(obj: unknown): obj is Subscribable<T>;
+
+function isObservable(obj: unknown) {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    typeof obj.subscribe === 'function'
+  );
+}
+
+function fromObservable<T>(obj: Subscribable<T>): RelayObservable<T> {
+  return obj instanceof RelayObservable
+    ? obj
+    : RelayObservable.create(sink => obj.subscribe(sink));
+}
+
+function fromPromise<T>(promise: Promise<T>): RelayObservable<T> {
+  return RelayObservable.create(sink => {
+    // Since sink methods do not throw, the resulting Promise can be ignored.
+    promise.then(value => {
+      sink.next(value);
+      sink.complete();
+    }, sink.error);
+  });
+}
+
+function fromValue<T>(value: T): RelayObservable<T> {
+  return RelayObservable.create(sink => {
+    sink.next(value);
+    sink.complete();
+  });
+}
+
+function subscribe<T>(
+  source: Source<T>,
+  observer: Observer<T> | Sink<T>,
+): Subscription {
+  let closed = false;
+  let cleanup;
+
+  // Ideally we would simply describe a `get closed()` method on the Sink and
+  // Subscription objects below, however not all flow environments we expect
+  // Relay to be used within will support property getters, and many minifier
+  // tools still do not support ES5 syntax. Instead, we can use defineProperty.
+  const withClosed: <O>(obj: O) => {...O, +closed: boolean} = (obj =>
+    Object.defineProperty(obj, 'closed', {get: () => closed} as any)) as any;
+
+  function doCleanup() {
+    if (cleanup) {
+      if (cleanup.unsubscribe) {
+        cleanup.unsubscribe();
+      } else {
+        try {
+          cleanup();
+        } catch (error) {
+          hostReportError(error, true /* isUncaughtThrownError */);
+        }
+      }
+      cleanup = undefined;
+    }
+  }
+
+  // Create a Subscription.
+  const subscription: Subscription = withClosed({
+    unsubscribe() {
+      if (!closed) {
+        closed = true;
+
+        // Tell Observer that unsubscribe was called.
+        try {
+          observer.unsubscribe && observer.unsubscribe(subscription);
+        } catch (error) {
+          hostReportError(error, true /* isUncaughtThrownError */);
+        } finally {
+          doCleanup();
+        }
+      }
+    },
+  });
+
+  // Tell Observer that observation is about to begin.
+  try {
+    observer.start && observer.start(subscription);
+  } catch (error) {
+    hostReportError(error, true /* isUncaughtThrownError */);
+  }
+
+  // If closed already, don't bother creating a Sink.
+  if (closed) {
+    return subscription;
+  }
+
+  // Create a Sink respecting subscription state and cleanup.
+  const sink: Sink<T> = withClosed({
+    next(value) {
+      if (!closed && observer.next) {
+        try {
+          observer.next(value);
+        } catch (error) {
+          hostReportError(error, true /* isUncaughtThrownError */);
+        }
+      }
+    },
+    error(error, isUncaughtThrownError) {
+      if (closed || !observer.error) {
+        closed = true;
+        hostReportError(error, isUncaughtThrownError || false);
+        doCleanup();
+      } else {
+        closed = true;
+        try {
+          observer.error(error);
+        } catch (error2) {
+          hostReportError(error2, true /* isUncaughtThrownError */);
+        } finally {
+          doCleanup();
+        }
+      }
+    },
+    complete() {
+      if (!closed) {
+        closed = true;
+        try {
+          observer.complete && observer.complete();
+        } catch (error) {
+          hostReportError(error, true /* isUncaughtThrownError */);
+        } finally {
+          doCleanup();
+        }
+      }
+    },
+  });
+
+  // If anything goes wrong during observing the source, handle the error.
+  try {
+    cleanup = source(sink);
+  } catch (error) {
+    sink.error(error, true /* isUncaughtThrownError */);
+  }
+
+  if (__DEV__) {
+    // Early runtime errors for ill-formed returned cleanup.
+    if (
+      cleanup !== undefined &&
+      typeof cleanup !== 'function' &&
+      (!cleanup || typeof cleanup.unsubscribe !== 'function')
+    ) {
+      throw new Error(
+        'Returned cleanup function which cannot be called: ' + String(cleanup),
+      );
+    }
+  }
+
+  // If closed before the source function existed, cleanup now.
+  if (closed) {
+    doCleanup();
+  }
+
+  return subscription;
+}
+
+function swallowError(_error: Error, _isUncaughtThrownError: boolean): void {
+  // do nothing.
+}
+
+if (__DEV__) {
+  // Default implementation of HostReportErrors() in development builds.
+  // Can be replaced by the host application environment.
+  RelayObservable.onUnhandledError((error, isUncaughtThrownError) => {
+    if (isUncaughtThrownError) {
+      // Rethrow uncaught thrown errors on the next frame to avoid breaking
+      // current logic.
+      setTimeout(() => {
+        throw error;
+      });
+    } else if (typeof console !== 'undefined') {
+      // Otherwise, log the unhandled error for visibility.
+      // eslint-disable-next-line no-console
+      console.error('RelayObservable: Unhandled Error', error);
+    }
+  });
+}
+
+module.exports = RelayObservable;

--- a/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/network/RelayQueryResponseCache.js
+++ b/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/network/RelayQueryResponseCache.js
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+import type {Variables} from '../util/RelayRuntimeTypes';
+import type {
+  GraphQLResponse,
+  GraphQLSingularResponse,
+} from './RelayNetworkTypes';
+
+const {stableCopy} = require('../util/stableCopy');
+const invariant = require('invariant');
+
+type Response = {
+  fetchTime: number,
+  payload: GraphQLResponse,
+  ...
+};
+
+/**
+ * A cache for storing query responses, featuring:
+ * - `get` with TTL
+ * - cache size limiting, with least-recently *updated* entries purged first
+ */
+class RelayQueryResponseCache {
+  _responses: Map<string, Response>;
+  _size: number;
+  _ttl: number;
+
+  constructor({size, ttl}: {size: number, ttl: number, ...}) {
+    invariant(
+      size > 0,
+      'RelayQueryResponseCache: Expected the max cache size to be > 0, got ' +
+        '`%s`.',
+      size,
+    );
+    invariant(
+      ttl > 0,
+      'RelayQueryResponseCache: Expected the max ttl to be > 0, got `%s`.',
+      ttl,
+    );
+    this._responses = new Map();
+    this._size = size;
+    this._ttl = ttl;
+  }
+
+  clear(): void {
+    this._responses.clear();
+  }
+
+  get(queryID: string, variables: Variables): ?GraphQLResponse {
+    const cacheKey = getCacheKey(queryID, variables);
+    this._responses.forEach((response, key) => {
+      if (!isCurrent(response.fetchTime, this._ttl)) {
+        this._responses.delete(key);
+      }
+    });
+    const response = this._responses.get(cacheKey);
+    if (response == null) {
+      return null;
+    }
+    if (Array.isArray(response.payload)) {
+      return response.payload.map(
+        payload =>
+          ({
+            ...payload,
+            extensions: {
+              ...payload.extensions,
+              cacheTimestamp: response.fetchTime,
+            },
+          }) as GraphQLSingularResponse,
+      );
+    }
+    return {
+      ...response.payload,
+      extensions: {
+        ...response.payload.extensions,
+        cacheTimestamp: response.fetchTime,
+      },
+    } as GraphQLSingularResponse;
+  }
+
+  set(queryID: string, variables: Variables, payload: GraphQLResponse): void {
+    const fetchTime = Date.now();
+    const cacheKey = getCacheKey(queryID, variables);
+    this._responses.delete(cacheKey); // deletion resets key ordering
+    this._responses.set(cacheKey, {
+      fetchTime,
+      payload,
+    });
+    // Purge least-recently updated key when max size reached
+    if (this._responses.size > this._size) {
+      const firstKey = this._responses.keys().next();
+      if (!firstKey.done) {
+        this._responses.delete(firstKey.value);
+      }
+    }
+  }
+}
+
+function getCacheKey(queryID: string, variables: Variables): string {
+  return JSON.stringify(stableCopy({queryID, variables}));
+}
+
+/**
+ * Determine whether a response fetched at `fetchTime` is still valid given
+ * some `ttl`.
+ */
+function isCurrent(fetchTime: number, ttl: number): boolean {
+  return fetchTime + ttl >= Date.now();
+}
+
+module.exports = RelayQueryResponseCache;

--- a/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/query/fetchQuery.js
+++ b/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/query/fetchQuery.js
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+import type {
+  IEnvironment,
+  OperationDescriptor,
+  Snapshot,
+} from '../store/RelayStoreTypes';
+import type {
+  CacheConfig,
+  FetchQueryFetchPolicy,
+  OperationType,
+  Query,
+  Variables,
+} from '../util/RelayRuntimeTypes';
+
+const RelayObservable = require('../network/RelayObservable');
+const {
+  createOperationDescriptor,
+} = require('../store/RelayModernOperationDescriptor');
+const {
+  handlePotentialSnapshotErrors,
+} = require('../util/handlePotentialSnapshotErrors');
+const fetchQueryInternal = require('./fetchQueryInternal');
+const {getRequest} = require('./GraphQLTag');
+const invariant = require('invariant');
+
+/**
+ * Fetches the given query and variables on the provided environment,
+ * and de-dupes identical in-flight requests.
+ *
+ * Observing a request:
+ * ====================
+ * fetchQuery returns an Observable which you can call .subscribe()
+ * on. Subscribe optionally takes an Observer, which you can provide to
+ * observe network events:
+ *
+ * ```
+ * fetchQuery(environment, query, variables).subscribe({
+ *   // Called when network requests starts
+ *   start: (subsctiption) => {},
+ *
+ *   // Called after a payload is received and written to the local store
+ *   next: (payload) => {},
+ *
+ *   // Called when network requests errors
+ *   error: (error) => {},
+ *
+ *   // Called when network requests fully completes
+ *   complete: () => {},
+ *
+ *   // Called when network request is unsubscribed
+ *   unsubscribe: (subscription) => {},
+ * });
+ * ```
+ *
+ * Request Promise:
+ * ================
+ * The obervable can be converted to a Promise with .toPromise(), which will
+ * resolve to a snapshot of the query data when the first response is received
+ * from the server.
+ *
+ * ```
+ * fetchQuery(environment, query, variables).toPromise().then((data) => {
+ *   // ...
+ * });
+ * ```
+ *
+ * In-flight request de-duping:
+ * ============================
+ * By default, calling fetchQuery multiple times with the same
+ * environment, query and variables will not initiate a new request if a request
+ * for those same parameters is already in flight.
+ *
+ * A request is marked in-flight from the moment it starts until the moment it
+ * fully completes, regardless of error or successful completion.
+ *
+ * NOTE: If the request completes _synchronously_, calling fetchQuery
+ * a second time with the same arguments in the same tick will _NOT_ de-dupe
+ * the request given that it will no longer be in-flight.
+ *
+ *
+ * Data Retention:
+ * ===============
+ * This function will NOT retain query data, meaning that it is not guaranteed
+ * that the fetched data will remain in the Relay store after the request has
+ * completed.
+ * If you need to retain the query data outside of the network request,
+ * you need to use `environment.retain()`.
+ *
+ *
+ * Cancelling requests:
+ * ====================
+ * If the disposable returned by subscribe is called while the
+ * request is in-flight, the request will be cancelled.
+ *
+ * ```
+ * const disposable = fetchQuery(...).subscribe(...);
+ *
+ * // This will cancel the request if it is in-flight.
+ * disposable.dispose();
+ * ```
+ * NOTE: When using .toPromise(), the request cannot be cancelled.
+ */
+function fetchQuery<TVariables extends Variables, TData, TRawResponse>(
+  environment: IEnvironment,
+  query: Query<TVariables, TData, TRawResponse>,
+  variables: NoInfer<TVariables>,
+  options?: Readonly<{
+    fetchPolicy?: FetchQueryFetchPolicy,
+    networkCacheConfig?: CacheConfig,
+  }>,
+): RelayObservable<TData> {
+  const queryNode = getRequest(query);
+  invariant(
+    queryNode.params.operationKind === 'query',
+    'fetchQuery: Expected query operation',
+  );
+  const networkCacheConfig = {
+    force: true,
+    ...options?.networkCacheConfig,
+  };
+  const operation = createOperationDescriptor(
+    queryNode,
+    variables,
+    networkCacheConfig,
+  );
+  const fetchPolicy = options?.fetchPolicy ?? 'network-only';
+
+  function readData(snapshot: Snapshot): TData {
+    handlePotentialSnapshotErrors(environment, snapshot.fieldErrors);
+    /* $FlowFixMe[incompatible-type] we assume readData returns the right
+     * data just having written it from network or checked availability. */
+    return snapshot.data;
+  }
+
+  switch (fetchPolicy) {
+    case 'network-only': {
+      return getNetworkObservable<$FlowFixMe>(environment, operation).map(
+        readData,
+      );
+    }
+    case 'store-or-network': {
+      const queryAvailability = environment.check(operation);
+      const shouldFetch = queryAvailability.status !== 'available';
+      let observable;
+      if (!shouldFetch) {
+        observable = RelayObservable.from<Snapshot>(
+          environment.lookup(operation.fragment),
+        ).map(readData);
+      } else {
+        observable = getNetworkObservable<$FlowFixMe>(
+          environment,
+          operation,
+        ).map(readData);
+      }
+      environment.__log({
+        name: 'fetchquery.fetch',
+        operation,
+        fetchPolicy,
+        queryAvailability,
+        shouldFetch,
+      });
+      return observable;
+    }
+    default:
+      fetchPolicy as empty;
+      throw new Error('fetchQuery: Invalid fetchPolicy ' + fetchPolicy);
+  }
+}
+
+function getNetworkObservable<TQuery extends OperationType>(
+  environment: IEnvironment,
+  operation: OperationDescriptor,
+): RelayObservable<TQuery['response']> {
+  return fetchQueryInternal
+    .fetchQuery(environment, operation)
+    .map(() => environment.lookup(operation.fragment));
+}
+
+module.exports = fetchQuery;

--- a/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/query/fetchQueryInternal.js
+++ b/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/query/fetchQueryInternal.js
@@ -1,0 +1,340 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+import type {GraphQLResponse} from '../network/RelayNetworkTypes';
+import type {Subscription} from '../network/RelayObservable';
+import type {
+  IEnvironment,
+  OperationDescriptor,
+  RequestDescriptor,
+} from '../store/RelayStoreTypes';
+import type {RequestIdentifier} from '../util/getRequestIdentifier';
+
+const Observable = require('../network/RelayObservable');
+const RelayReplaySubject = require('../util/RelayReplaySubject');
+const invariant = require('invariant');
+
+type RequestCacheEntry = {
+  +identifier: RequestIdentifier,
+  +subject: RelayReplaySubject<GraphQLResponse>,
+  +subjectForInFlightStatus: RelayReplaySubject<GraphQLResponse>,
+  +subscription: Subscription,
+  promise: ?Promise<void>,
+};
+
+const WEAKMAP_SUPPORTED = typeof WeakMap === 'function';
+
+const requestCachesByEnvironment = WEAKMAP_SUPPORTED
+  ? new WeakMap<IEnvironment, Map<RequestIdentifier, RequestCacheEntry>>()
+  : new Map<IEnvironment, Map<RequestIdentifier, RequestCacheEntry>>();
+
+/**
+ * Fetches the given query and variables on the provided environment,
+ * and de-dupes identical in-flight requests.
+ *
+ * Observing a request:
+ * ====================
+ * fetchQuery returns an Observable which you can call .subscribe()
+ * on. subscribe() takes an Observer, which you can provide to
+ * observe network events:
+ *
+ * ```
+ * fetchQuery(environment, query, variables).subscribe({
+ *   // Called when network requests starts
+ *   start: (subscription) => {},
+ *
+ *   // Called after a payload is received and written to the local store
+ *   next: (payload) => {},
+ *
+ *   // Called when network requests errors
+ *   error: (error) => {},
+ *
+ *   // Called when network requests fully completes
+ *   complete: () => {},
+ *
+ *   // Called when network request is unsubscribed
+ *   unsubscribe: (subscription) => {},
+ * });
+ * ```
+ *
+ * In-flight request de-duping:
+ * ============================
+ * By default, calling fetchQuery multiple times with the same
+ * environment, query and variables will not initiate a new request if a request
+ * for those same parameters is already in flight.
+ *
+ * A request is marked in-flight from the moment it starts until the moment it
+ * fully completes, regardless of error or successful completion.
+ *
+ * NOTE: If the request completes _synchronously_, calling fetchQuery
+ * a second time with the same arguments in the same tick will _NOT_ de-dupe
+ * the request given that it will no longer be in-flight.
+ *
+ *
+ * Data Retention:
+ * ===============
+ * This function will not retain any query data outside the scope of the
+ * request, which means it is not guaranteed that it won't be garbage
+ * collected after the request completes.
+ * If you need to retain data, you can do so manually with environment.retain().
+ *
+ * Cancelling requests:
+ * ====================
+ * If the subscription returned by subscribe is called while the
+ * request is in-flight, the request will be cancelled.
+ *
+ * ```
+ * const subscription = fetchQuery(...).subscribe(...);
+ *
+ * // This will cancel the request if it is in-flight.
+ * subscription.unsubscribe();
+ * ```
+ */
+function fetchQuery(
+  environment: IEnvironment,
+  operation: OperationDescriptor,
+): Observable<GraphQLResponse> {
+  return fetchQueryDeduped(environment, operation.request.identifier, () =>
+    environment.execute({
+      operation,
+    }),
+  );
+}
+
+/**
+ * Low-level implementation details of `fetchQuery`.
+ *
+ * `fetchQueryDeduped` can also be used to share a single cache for
+ * requests that aren't using `fetchQuery` directly (e.g. because they don't
+ * have an `OperationDescriptor` when they are called).
+ */
+function fetchQueryDeduped(
+  environment: IEnvironment,
+  identifier: RequestIdentifier,
+  fetchFn: () => Observable<GraphQLResponse>,
+): Observable<GraphQLResponse> {
+  return Observable.create(sink => {
+    const requestCache = getRequestCache(environment);
+    let cachedRequest = requestCache.get(identifier);
+
+    if (!cachedRequest) {
+      fetchFn()
+        .finally(() => requestCache.delete(identifier))
+        .subscribe({
+          start: subscription => {
+            cachedRequest = {
+              identifier,
+              subject: new RelayReplaySubject(),
+              subjectForInFlightStatus: new RelayReplaySubject(),
+              subscription: subscription,
+              promise: null,
+            };
+            requestCache.set(identifier, cachedRequest);
+          },
+          next: response => {
+            const cachedReq = getCachedRequest(requestCache, identifier);
+            cachedReq.subject.next(response);
+            cachedReq.subjectForInFlightStatus.next(response);
+          },
+          error: error => {
+            const cachedReq = getCachedRequest(requestCache, identifier);
+            cachedReq.subject.error(error);
+            cachedReq.subjectForInFlightStatus.error(error);
+          },
+          complete: () => {
+            const cachedReq = getCachedRequest(requestCache, identifier);
+            cachedReq.subject.complete();
+            cachedReq.subjectForInFlightStatus.complete();
+          },
+          unsubscribe: subscription => {
+            const cachedReq = getCachedRequest(requestCache, identifier);
+            cachedReq.subject.unsubscribe();
+            cachedReq.subjectForInFlightStatus.unsubscribe();
+          },
+        });
+    }
+
+    invariant(
+      cachedRequest != null,
+      '[fetchQueryInternal] fetchQueryDeduped: Expected `start` to be ' +
+        'called synchronously',
+    );
+    return getObservableForCachedRequest(requestCache, cachedRequest).subscribe(
+      sink,
+    );
+  });
+}
+
+/**
+ * @private
+ */
+function getObservableForCachedRequest(
+  requestCache: Map<RequestIdentifier, RequestCacheEntry>,
+  cachedRequest: RequestCacheEntry,
+): Observable<GraphQLResponse> {
+  return Observable.create(sink => {
+    const subscription = cachedRequest.subject.subscribe(sink);
+
+    return () => {
+      subscription.unsubscribe();
+      const cachedRequestInstance = requestCache.get(cachedRequest.identifier);
+      if (cachedRequestInstance) {
+        const requestSubscription = cachedRequestInstance.subscription;
+        if (
+          requestSubscription != null &&
+          cachedRequestInstance.subject.getObserverCount() === 0
+        ) {
+          requestSubscription.unsubscribe();
+          requestCache.delete(cachedRequest.identifier);
+        }
+      }
+    };
+  });
+}
+
+/**
+ * @private
+ */
+function getActiveStatusObservableForCachedRequest(
+  environment: IEnvironment,
+  requestCache: Map<RequestIdentifier, RequestCacheEntry>,
+  cachedRequest: RequestCacheEntry,
+): Observable<void> {
+  return Observable.create(sink => {
+    const subscription = cachedRequest.subjectForInFlightStatus.subscribe({
+      error: sink.error,
+      next: response => {
+        if (!environment.isRequestActive(cachedRequest.identifier)) {
+          sink.complete();
+          return;
+        }
+        sink.next();
+      },
+      complete: sink.complete,
+      unsubscribe: sink.complete,
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  });
+}
+
+/**
+ * If a request is active for the given query, variables and environment,
+ * this function will return a Promise that will resolve when that request
+ * stops being active (receives a final payload), and the data has been saved
+ * to the store.
+ * If no request is active, null will be returned
+ */
+function getPromiseForActiveRequest(
+  environment: IEnvironment,
+  request: RequestDescriptor,
+): Promise<void> | null {
+  const requestCache = getRequestCache(environment);
+  const cachedRequest = requestCache.get(request.identifier);
+  if (!cachedRequest) {
+    return null;
+  }
+  if (!environment.isRequestActive(cachedRequest.identifier)) {
+    return null;
+  }
+  const promise = new Promise<void>((resolve, reject) => {
+    let resolveOnNext = false;
+    getActiveStatusObservableForCachedRequest(
+      environment,
+      requestCache,
+      cachedRequest,
+    ).subscribe({
+      complete: resolve,
+      error: reject,
+      next: response => {
+        /*
+         * The underlying `RelayReplaySubject` will synchronously replay events
+         * as soon as we subscribe, but since we want the *next* asynchronous
+         * one, we'll ignore them until the replay finishes.
+         */
+        if (resolveOnNext) {
+          resolve(response);
+        }
+      },
+    });
+    resolveOnNext = true;
+  });
+  return promise;
+}
+
+/**
+ * If there is a pending request for the given query, returns an Observable of
+ * *all* its responses. Existing responses are published synchronously and
+ * subsequent responses are published asynchronously. Returns null if there is
+ * no pending request. This is similar to fetchQuery() except that it will not
+ * issue a fetch if there isn't already one pending.
+ */
+function getObservableForActiveRequest(
+  environment: IEnvironment,
+  request: RequestDescriptor,
+): Observable<void> | null {
+  const requestCache = getRequestCache(environment);
+  const cachedRequest = requestCache.get(request.identifier);
+  if (!cachedRequest) {
+    return null;
+  }
+  if (!environment.isRequestActive(cachedRequest.identifier)) {
+    return null;
+  }
+
+  return getActiveStatusObservableForCachedRequest(
+    environment,
+    requestCache,
+    cachedRequest,
+  );
+}
+
+/**
+ * @private
+ */
+function getRequestCache(
+  environment: IEnvironment,
+): Map<RequestIdentifier, RequestCacheEntry> {
+  const cached: ?Map<RequestIdentifier, RequestCacheEntry> =
+    requestCachesByEnvironment.get(environment);
+  if (cached != null) {
+    return cached;
+  }
+  const requestCache: Map<RequestIdentifier, RequestCacheEntry> = new Map();
+  requestCachesByEnvironment.set(environment, requestCache);
+  return requestCache;
+}
+
+/**
+ * @private
+ */
+function getCachedRequest(
+  requestCache: Map<RequestIdentifier, RequestCacheEntry>,
+  identifier: RequestIdentifier,
+) {
+  const cached = requestCache.get(identifier);
+  invariant(
+    cached != null,
+    '[fetchQueryInternal] getCachedRequest: Expected request to be cached',
+  );
+  return cached;
+}
+
+module.exports = {
+  fetchQuery,
+  fetchQueryDeduped,
+  getPromiseForActiveRequest,
+  getObservableForActiveRequest,
+};

--- a/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/store/RelayModernEnvironment.js
+++ b/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/store/RelayModernEnvironment.js
@@ -1,0 +1,542 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+import type {HandlerProvider} from '../handlers/RelayDefaultHandlerProvider';
+import type {ActorIdentifier} from '../multi-actor-environment/ActorIdentifier';
+import type {
+  GraphQLResponse,
+  INetwork,
+  PayloadData,
+} from '../network/RelayNetworkTypes';
+import type {Sink} from '../network/RelayObservable';
+import type {Disposable, RenderPolicy} from '../util/RelayRuntimeTypes';
+import type {ActiveState} from './OperationExecutor';
+import type {GetDataID} from './RelayResponseNormalizer';
+import type {
+  ExecuteMutationConfig,
+  IEnvironment,
+  LogFunction,
+  MissingFieldHandler,
+  MutationParameters,
+  NormalizeResponseFunction,
+  OperationAvailability,
+  OperationDescriptor,
+  OperationLoader,
+  OperationTracker,
+  OptimisticResponseConfig,
+  OptimisticUpdateFunction,
+  PublishQueue,
+  RelayFieldLogger,
+  SelectorStoreUpdater,
+  SingularReaderSelector,
+  Snapshot,
+  Store,
+  StoreUpdater,
+  TaskScheduler,
+} from './RelayStoreTypes';
+
+const RelayDefaultHandlerProvider = require('../handlers/RelayDefaultHandlerProvider');
+const {
+  INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+  assertInternalActorIdentifier,
+} = require('../multi-actor-environment/ActorIdentifier');
+const RelayObservable = require('../network/RelayObservable');
+const wrapNetworkWithLogObserver = require('../network/wrapNetworkWithLogObserver');
+const RelayOperationTracker = require('../store/RelayOperationTracker');
+const registerEnvironmentWithDevTools = require('../util/registerEnvironmentWithDevTools');
+const defaultGetDataID = require('./defaultGetDataID');
+const defaultRelayFieldLogger = require('./defaultRelayFieldLogger');
+const normalizeResponse = require('./normalizeResponse');
+const OperationExecutor = require('./OperationExecutor');
+const RelayModernStore = require('./RelayModernStore');
+const RelayPublishQueue = require('./RelayPublishQueue');
+const RelayRecordSource = require('./RelayRecordSource');
+const invariant = require('invariant');
+
+export type EnvironmentConfig = {
+  +configName?: string,
+  +handlerProvider?: ?HandlerProvider,
+  +treatMissingFieldsAsNull?: boolean,
+  +deferDeduplicatedFields?: boolean,
+  +log?: ?LogFunction,
+  +operationLoader?: ?OperationLoader,
+  +network: INetwork,
+  +normalizeResponse?: ?NormalizeResponseFunction,
+  +scheduler?: ?TaskScheduler,
+  +store?: Store,
+  +missingFieldHandlers?: ?ReadonlyArray<MissingFieldHandler>,
+  +operationTracker?: ?OperationTracker,
+  +getDataID?: ?GetDataID,
+  +UNSTABLE_defaultRenderPolicy?: ?RenderPolicy,
+  +options?: unknown,
+  +isServer?: boolean,
+  +relayFieldLogger?: ?RelayFieldLogger,
+  +shouldProcessClientComponents?: ?boolean,
+};
+
+class RelayModernEnvironment implements IEnvironment {
+  __log: LogFunction;
+  +_defaultRenderPolicy: RenderPolicy;
+  _operationLoader: ?OperationLoader;
+  _shouldProcessClientComponents: ?boolean;
+  _network: INetwork;
+  _publishQueue: PublishQueue;
+  _scheduler: ?TaskScheduler;
+  _store: Store;
+  configName: ?string;
+  _missingFieldHandlers: ReadonlyArray<MissingFieldHandler>;
+  _operationTracker: OperationTracker;
+  _getDataID: GetDataID;
+  _treatMissingFieldsAsNull: boolean;
+  _deferDeduplicatedFields: boolean;
+  _operationExecutions: Map<string, ActiveState>;
+  +options: unknown;
+  +_isServer: boolean;
+  relayFieldLogger: RelayFieldLogger;
+  _normalizeResponse: NormalizeResponseFunction;
+
+  constructor(config: EnvironmentConfig) {
+    this.configName = config.configName;
+    this._treatMissingFieldsAsNull = config.treatMissingFieldsAsNull === true;
+    this._deferDeduplicatedFields = config.deferDeduplicatedFields === true;
+    const operationLoader = config.operationLoader;
+    if (__DEV__) {
+      if (operationLoader != null) {
+        invariant(
+          typeof operationLoader === 'object' &&
+            typeof operationLoader.get === 'function' &&
+            typeof operationLoader.load === 'function',
+          'RelayModernEnvironment: Expected `operationLoader` to be an object ' +
+            'with get() and load() functions, got `%s`.',
+          operationLoader,
+        );
+      }
+    }
+    const store =
+      config.store ??
+      new RelayModernStore(new RelayRecordSource(), {
+        getDataID: config.getDataID,
+        log: config.log,
+        operationLoader: config.operationLoader,
+        shouldProcessClientComponents: config.shouldProcessClientComponents,
+      });
+
+    this.__log = config.log ?? emptyFunction;
+    this.relayFieldLogger = config.relayFieldLogger ?? defaultRelayFieldLogger;
+    this._defaultRenderPolicy =
+      config.UNSTABLE_defaultRenderPolicy ?? 'partial';
+    this._operationLoader = operationLoader;
+    this._operationExecutions = new Map();
+    this._network = wrapNetworkWithLogObserver(this, config.network);
+    this._getDataID = config.getDataID ?? defaultGetDataID;
+    this._missingFieldHandlers = config.missingFieldHandlers ?? [];
+    this._publishQueue = new RelayPublishQueue(
+      store,
+      config.handlerProvider ?? RelayDefaultHandlerProvider,
+      this._getDataID,
+      this._missingFieldHandlers,
+      this.__log,
+    );
+    this._scheduler = config.scheduler ?? null;
+    this._store = store;
+    this.options = config.options;
+    this._isServer = config.isServer ?? false;
+    this._normalizeResponse = config.normalizeResponse ?? normalizeResponse;
+
+    (this as any).__setNet = newNet =>
+      (this._network = wrapNetworkWithLogObserver(this, newNet));
+
+    if (__DEV__) {
+      const {inspect} = require('./StoreInspector');
+      (this as any).DEBUG_inspect = (dataID: ?string) => inspect(this, dataID);
+    }
+
+    this._operationTracker =
+      config.operationTracker ?? new RelayOperationTracker();
+    this._shouldProcessClientComponents = config.shouldProcessClientComponents;
+
+    // Register this Relay Environment with Relay DevTools if it exists.
+    // Note: this must always be the last step in the constructor.
+    registerEnvironmentWithDevTools(this);
+  }
+
+  getStore(): Store {
+    return this._store;
+  }
+
+  getNetwork(): INetwork {
+    return this._network;
+  }
+
+  getOperationTracker(): RelayOperationTracker {
+    return this._operationTracker;
+  }
+
+  getScheduler(): ?TaskScheduler {
+    return this._scheduler;
+  }
+
+  isRequestActive(requestIdentifier: string): boolean {
+    const activeState = this._operationExecutions.get(requestIdentifier);
+    return activeState === 'active';
+  }
+
+  UNSTABLE_getDefaultRenderPolicy(): RenderPolicy {
+    return this._defaultRenderPolicy;
+  }
+
+  applyUpdate(optimisticUpdate: OptimisticUpdateFunction): Disposable {
+    const dispose = () => {
+      this._scheduleUpdates(() => {
+        this._publishQueue.revertUpdate(optimisticUpdate);
+        this._publishQueue.run();
+      });
+    };
+    this._scheduleUpdates(() => {
+      this._publishQueue.applyUpdate(optimisticUpdate);
+      this._publishQueue.run();
+    });
+    return {dispose};
+  }
+
+  revertUpdate(update: OptimisticUpdateFunction): void {
+    this._scheduleUpdates(() => {
+      this._publishQueue.revertUpdate(update);
+      this._publishQueue.run();
+    });
+  }
+
+  replaceUpdate(
+    update: OptimisticUpdateFunction,
+    newUpdate: OptimisticUpdateFunction,
+  ): void {
+    this._scheduleUpdates(() => {
+      this._publishQueue.revertUpdate(update);
+      this._publishQueue.applyUpdate(newUpdate);
+      this._publishQueue.run();
+    });
+  }
+
+  applyMutation<TMutation extends MutationParameters>(
+    optimisticConfig: OptimisticResponseConfig<TMutation>,
+  ): Disposable {
+    const subscription = this._execute({
+      createSource: () => RelayObservable.create(_sink => {}),
+      isClientPayload: false,
+      operation: optimisticConfig.operation,
+      optimisticConfig,
+      updater: null,
+    }).subscribe({});
+    return {
+      dispose: () => subscription.unsubscribe(),
+    };
+  }
+
+  check(operation: OperationDescriptor): OperationAvailability {
+    if (
+      this._missingFieldHandlers.length === 0 &&
+      !operationHasClientAbstractTypes(operation)
+    ) {
+      return this._store.check(operation);
+    }
+    return this._checkSelectorAndHandleMissingFields(
+      operation,
+      this._missingFieldHandlers,
+    );
+  }
+
+  commitPayload(operation: OperationDescriptor, payload: PayloadData): void {
+    this._execute({
+      createSource: () => RelayObservable.from({data: payload}),
+      isClientPayload: true,
+      operation,
+      optimisticConfig: null,
+      updater: null,
+    }).subscribe({});
+  }
+
+  commitUpdate(updater: StoreUpdater): void {
+    this._scheduleUpdates(() => {
+      this._publishQueue.commitUpdate(updater);
+      this._publishQueue.run();
+    });
+  }
+
+  lookup(readSelector: SingularReaderSelector): Snapshot {
+    return this._store.lookup(readSelector);
+  }
+
+  subscribe(
+    snapshot: Snapshot,
+    callback: (snapshot: Snapshot) => void,
+  ): Disposable {
+    return this._store.subscribe(snapshot, callback);
+  }
+
+  retain(operation: OperationDescriptor): Disposable {
+    return this._store.retain(operation);
+  }
+
+  experimental_batchUpdates(callback: () => void): void {
+    // $FlowFixMe[prop-missing] - experimental method not on Store interface
+    const batchFn = this._store.experimental_batchUpdates;
+    invariant(
+      typeof batchFn === 'function',
+      'RelayModernEnvironment: The current store does not support experimental_batchUpdates.',
+    );
+    // We must use .call to preserve Flow's narrowing from the above typeof check.
+    batchFn.call(this._store, callback);
+  }
+
+  isServer(): boolean {
+    return this._isServer;
+  }
+
+  _checkSelectorAndHandleMissingFields(
+    operation: OperationDescriptor,
+    handlers: ReadonlyArray<MissingFieldHandler>,
+  ): OperationAvailability {
+    const target = RelayRecordSource.create();
+    const source = this._store.getSource();
+    const result = this._store.check(operation, {
+      defaultActorIdentifier: INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+      getSourceForActor(actorIdentifier: ActorIdentifier) {
+        assertInternalActorIdentifier(actorIdentifier);
+        return source;
+      },
+      getTargetForActor(actorIdentifier: ActorIdentifier) {
+        assertInternalActorIdentifier(actorIdentifier);
+        return target;
+      },
+      handlers,
+    });
+    if (target.size() > 0) {
+      this._scheduleUpdates(() => {
+        this._publishQueue.commitSource(target);
+        this._publishQueue.run();
+      });
+    }
+    return result;
+  }
+
+  _scheduleUpdates(task: () => void) {
+    const scheduler = this._scheduler;
+    if (scheduler != null) {
+      scheduler.schedule(task);
+    } else {
+      task();
+    }
+  }
+
+  /**
+   * Returns an Observable of GraphQLResponse resulting from executing the
+   * provided Query operation, each result of which is then
+   * normalized and committed to the publish queue.
+   *
+   * Note: Observables are lazy, so calling this method will do nothing until
+   * the result is subscribed to: environment.execute({...}).subscribe({...}).
+   */
+  execute({
+    operation,
+  }: {
+    operation: OperationDescriptor,
+  }): RelayObservable<GraphQLResponse> {
+    return this._execute({
+      createSource: () => {
+        return this.getNetwork().execute(
+          operation.request.node.params,
+          operation.request.variables,
+          operation.request.cacheConfig || {},
+          null,
+          undefined,
+          undefined,
+          undefined,
+          () => this.check(operation),
+        );
+      },
+      isClientPayload: false,
+      operation,
+      optimisticConfig: null,
+      updater: null,
+    });
+  }
+
+  /**
+   * Returns an Observable of GraphQLResponse resulting from executing the
+   * provided Subscription operation, each result of which is then
+   * normalized and committed to the publish queue.
+   *
+   * Note: Observables are lazy, so calling this method will do nothing until
+   * the result is subscribed to: environment.execute({...}).subscribe({...}).
+   */
+  executeSubscription<TMutation extends MutationParameters>({
+    operation,
+    updater,
+  }: {
+    operation: OperationDescriptor,
+    updater?: ?SelectorStoreUpdater<TMutation['response']>,
+  }): RelayObservable<GraphQLResponse> {
+    return this._execute({
+      createSource: () =>
+        this.getNetwork().execute(
+          operation.request.node.params,
+          operation.request.variables,
+          operation.request.cacheConfig || {},
+          null,
+        ),
+      isClientPayload: false,
+      operation,
+      optimisticConfig: null,
+      updater,
+    });
+  }
+
+  /**
+   * Returns an Observable of GraphQLResponse resulting from executing the
+   * provided Mutation operation, the result of which is then normalized and
+   * committed to the publish queue along with an optional optimistic response
+   * or updater.
+   *
+   * Note: Observables are lazy, so calling this method will do nothing until
+   * the result is subscribed to:
+   * environment.executeMutation({...}).subscribe({...}).
+   */
+  executeMutation<TMutation extends MutationParameters>({
+    operation,
+    optimisticResponse,
+    optimisticUpdater,
+    updater,
+    uploadables,
+  }: ExecuteMutationConfig<TMutation>): RelayObservable<GraphQLResponse> {
+    let optimisticConfig;
+    if (optimisticResponse || optimisticUpdater) {
+      optimisticConfig = {
+        operation,
+        response: optimisticResponse,
+        updater: optimisticUpdater,
+      };
+    }
+    return this._execute({
+      createSource: () =>
+        this.getNetwork().execute(
+          operation.request.node.params,
+          operation.request.variables,
+          {
+            ...operation.request.cacheConfig,
+            force: true,
+          },
+          uploadables,
+        ),
+      isClientPayload: false,
+      operation,
+      optimisticConfig,
+      updater,
+    });
+  }
+
+  /**
+   * Returns an Observable of GraphQLResponse resulting from executing the
+   * provided Query or Subscription operation responses, the result of which is
+   * then normalized and committed to the publish queue.
+   *
+   * Note: Observables are lazy, so calling this method will do nothing until
+   * the result is subscribed to:
+   * environment.executeWithSource({...}).subscribe({...}).
+   */
+  executeWithSource({
+    operation,
+    source,
+  }: {
+    operation: OperationDescriptor,
+    source: RelayObservable<GraphQLResponse>,
+  }): RelayObservable<GraphQLResponse> {
+    return this._execute({
+      createSource: () => source,
+      isClientPayload: false,
+      operation,
+      optimisticConfig: null,
+      updater: null,
+    });
+  }
+
+  toJSON(): unknown {
+    return `RelayModernEnvironment(${this.configName ?? ''})`;
+  }
+
+  _execute<TMutation extends MutationParameters>({
+    createSource,
+    isClientPayload,
+    operation,
+    optimisticConfig,
+    updater,
+  }: {
+    createSource: () => RelayObservable<GraphQLResponse>,
+    isClientPayload: boolean,
+    operation: OperationDescriptor,
+    optimisticConfig: ?OptimisticResponseConfig<TMutation>,
+    updater: ?SelectorStoreUpdater<TMutation['response']>,
+  }): RelayObservable<GraphQLResponse> {
+    const publishQueue = this._publishQueue;
+    const store = this._store;
+    return RelayObservable.create((sink: Sink<GraphQLResponse>) => {
+      const executor = OperationExecutor.execute<$FlowFixMe>({
+        actorIdentifier: INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+        getDataID: this._getDataID,
+        getPublishQueue(actorIdentifier: ActorIdentifier) {
+          assertInternalActorIdentifier(actorIdentifier);
+          return publishQueue;
+        },
+        getStore(actorIdentifier: ActorIdentifier) {
+          assertInternalActorIdentifier(actorIdentifier);
+          return store;
+        },
+        isClientPayload,
+        log: this.__log,
+        normalizeResponse: this._normalizeResponse,
+        operation,
+        operationExecutions: this._operationExecutions,
+        operationLoader: this._operationLoader,
+        operationTracker: this._operationTracker,
+        optimisticConfig,
+        scheduler: this._scheduler,
+        shouldProcessClientComponents: this._shouldProcessClientComponents,
+        sink,
+        // NOTE: Some product tests expect `Network.execute` to be called only
+        //       when the Observable is executed.
+        source: createSource(),
+        treatMissingFieldsAsNull: this._treatMissingFieldsAsNull,
+        deferDeduplicatedFields: this._deferDeduplicatedFields,
+        updater,
+      });
+      return () => executor.cancel();
+    });
+  }
+}
+
+function operationHasClientAbstractTypes(
+  operation: OperationDescriptor,
+): boolean {
+  return (
+    operation.root.node.kind === 'Operation' &&
+    operation.root.node.clientAbstractTypes != null
+  );
+}
+
+// Add a sigil for detection by `isRelayModernEnvironment()` to avoid a
+// realm-specific instanceof check, and to aid in module tree-shaking to
+// avoid requiring all of RelayRuntime just to detect its environment.
+(RelayModernEnvironment as any).prototype['@@RelayModernEnvironment'] = true;
+
+function emptyFunction() {}
+
+module.exports = RelayModernEnvironment;

--- a/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/store/RelayModernStore.js
+++ b/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/store/RelayModernStore.js
@@ -1,0 +1,1151 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+import type {ActorIdentifier} from '../multi-actor-environment/ActorIdentifier';
+import type {DataID, Disposable} from '../util/RelayRuntimeTypes';
+import type {Availability} from './DataChecker';
+import type {UpdatedRecords} from './live-resolvers/LiveResolverCache';
+import type {GetDataID} from './RelayResponseNormalizer';
+import type {NormalizationOptions} from './RelayResponseNormalizer';
+import type {
+  CheckOptions,
+  DataIDSet,
+  LogFunction,
+  MutableRecordSource,
+  OperationAvailability,
+  OperationDescriptor,
+  OperationLoader,
+  RecordSource,
+  RequestDescriptor,
+  ResolverContext,
+  Scheduler,
+  SingularReaderSelector,
+  Snapshot,
+  Store,
+  StoreSubscriptions,
+} from './RelayStoreTypes';
+
+const {
+  INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+  assertInternalActorIdentifier,
+} = require('../multi-actor-environment/ActorIdentifier');
+const deepFreeze = require('../util/deepFreeze');
+const RelayFeatureFlags = require('../util/RelayFeatureFlags');
+const resolveImmediate = require('../util/resolveImmediate');
+const DataChecker = require('./DataChecker');
+const defaultGetDataID = require('./defaultGetDataID');
+const {
+  LiveResolverCache,
+  RELAY_RESOLVER_LIVE_STATE_SUBSCRIPTION_KEY,
+  getUpdatedDataIDs,
+} = require('./live-resolvers/LiveResolverCache');
+const RelayModernRecord = require('./RelayModernRecord');
+const RelayOptimisticRecordSource = require('./RelayOptimisticRecordSource');
+const RelayReader = require('./RelayReader');
+const RelayReferenceMarker = require('./RelayReferenceMarker');
+const RelayStoreSubscriptions = require('./RelayStoreSubscriptions');
+const RelayStoreUtils = require('./RelayStoreUtils');
+const {
+  FIELD_GRANULAR_NOTIFICATIONS_KEY,
+  ROOT_ID,
+  ROOT_TYPE,
+  getFieldNotificationKey,
+} = require('./RelayStoreUtils');
+const invariant = require('invariant');
+
+export opaque type InvalidationState = {
+  dataIDs: ReadonlyArray<DataID>,
+  invalidations: Map<DataID, ?number>,
+};
+
+type InvalidationSubscription = {
+  callback: () => void,
+  invalidationState: InvalidationState,
+};
+
+type Batch = {
+  sourceOperations: Array<OperationDescriptor>,
+  invalidateStore: boolean,
+};
+
+const DEFAULT_RELEASE_BUFFER_SIZE = 10;
+
+/**
+ * @public
+ *
+ * An implementation of the `Store` interface defined in `RelayStoreTypes`.
+ *
+ * Note that a Store takes ownership of all records provided to it: other
+ * objects may continue to hold a reference to such records but may not mutate
+ * them. The static Relay core is architected to avoid mutating records that may have been
+ * passed to a store: operations that mutate records will either create fresh
+ * records or clone existing records and modify the clones. Record immutability
+ * is also enforced in development mode by freezing all records passed to a store.
+ */
+class RelayModernStore implements Store {
+  _currentWriteEpoch: number;
+  _gcHoldCounter: number;
+  _gcReleaseBufferSize: number;
+  _gcRun: ?Generator<void, void, void>;
+  _gcScheduler: Scheduler;
+  _getDataID: GetDataID;
+  _globalInvalidationEpoch: ?number;
+  _invalidationSubscriptions: Set<InvalidationSubscription>;
+  _invalidatedRecordIDs: DataIDSet;
+  __log: ?LogFunction;
+  _queryCacheExpirationTime: ?number;
+  _operationLoader: ?OperationLoader;
+  _optimisticSource: ?MutableRecordSource;
+  _recordSource: MutableRecordSource;
+  _resolverCache: LiveResolverCache;
+  _releaseBuffer: Array<string>;
+  _roots: Map<
+    string,
+    {
+      operation: OperationDescriptor,
+      refCount: number,
+      epoch: ?number,
+      fetchTime: ?number,
+    },
+  >;
+  _shouldRetainWithinTTL_EXPERIMENTAL: boolean;
+  _shouldScheduleGC: boolean;
+  _storeSubscriptions: StoreSubscriptions;
+  _updatedRecordIDs: DataIDSet;
+  _shouldProcessClientComponents: ?boolean;
+  _resolverContext: ?ResolverContext;
+  _actorIdentifier: ?ActorIdentifier;
+  _treatMissingFieldsAsNull: boolean;
+  _deferDeduplicatedFields: boolean;
+  _batch: Batch | null;
+
+  constructor(
+    source: MutableRecordSource,
+    options?: {
+      gcScheduler?: ?Scheduler,
+      log?: ?LogFunction,
+      operationLoader?: ?OperationLoader,
+      getDataID?: ?GetDataID,
+      gcReleaseBufferSize?: ?number,
+      queryCacheExpirationTime?: ?number,
+      shouldProcessClientComponents?: ?boolean,
+      resolverContext?: ResolverContext,
+
+      // Experimental
+      shouldRetainWithinTTL_EXPERIMENTAL?: boolean,
+
+      // These additional config options are only used if the experimental
+      // @outputType resolver feature is used
+      treatMissingFieldsAsNull?: ?boolean,
+      deferDeduplicatedFields?: ?boolean,
+      actorIdentifier?: ?ActorIdentifier,
+    },
+  ) {
+    // Prevent mutation of a record from outside the store.
+    if (__DEV__) {
+      const storeIDs = source.getRecordIDs();
+      for (let ii = 0; ii < storeIDs.length; ii++) {
+        const record = source.get(storeIDs[ii]);
+        if (record) {
+          RelayModernRecord.freeze(record);
+        }
+      }
+    }
+    this._currentWriteEpoch = 0;
+    this._gcHoldCounter = 0;
+    this._gcReleaseBufferSize =
+      options?.gcReleaseBufferSize ?? DEFAULT_RELEASE_BUFFER_SIZE;
+    this._shouldRetainWithinTTL_EXPERIMENTAL =
+      options?.shouldRetainWithinTTL_EXPERIMENTAL ?? false;
+    this._gcRun = null;
+    this._gcScheduler = options?.gcScheduler ?? resolveImmediate;
+    this._getDataID = options?.getDataID ?? defaultGetDataID;
+    this._globalInvalidationEpoch = null;
+    this._invalidationSubscriptions = new Set();
+    this._invalidatedRecordIDs = new Set();
+    this.__log = options?.log ?? null;
+    this._queryCacheExpirationTime = options?.queryCacheExpirationTime;
+    this._operationLoader = options?.operationLoader ?? null;
+    this._optimisticSource = null;
+    this._recordSource = source;
+    this._releaseBuffer = [];
+    this._roots = new Map();
+    this._shouldScheduleGC = false;
+    this._resolverCache = new LiveResolverCache(
+      () => this._getMutableRecordSource(),
+      this,
+    );
+    this._resolverContext = options?.resolverContext;
+    this._storeSubscriptions = new RelayStoreSubscriptions(
+      options?.log,
+      this._resolverCache,
+      this._resolverContext,
+    );
+    this._updatedRecordIDs = new Set();
+    this._shouldProcessClientComponents =
+      options?.shouldProcessClientComponents ?? false;
+
+    this._treatMissingFieldsAsNull = options?.treatMissingFieldsAsNull ?? false;
+    this._deferDeduplicatedFields = options?.deferDeduplicatedFields ?? false;
+    this._actorIdentifier = options?.actorIdentifier;
+    this._batch = null;
+
+    initializeRecordSource(this._recordSource);
+  }
+
+  getSource(): RecordSource {
+    return this._optimisticSource ?? this._recordSource;
+  }
+
+  getOperationLoader(): ?OperationLoader {
+    return this._operationLoader;
+  }
+
+  _getMutableRecordSource(): MutableRecordSource {
+    return this._optimisticSource ?? this._recordSource;
+  }
+
+  getLiveResolverPromise(recordID: DataID): Promise<void> {
+    return this._resolverCache.getLiveResolverPromise(recordID);
+  }
+
+  /**
+   * When an external data provider knows it's going to notify us about multiple
+   * Live Resolver state updates in a single tick, it can batch them into a
+   * single Relay update by notifying us within a batch. All updates received by
+   * Relay during the evaluation of the provided `callback` will be aggregated
+   * into a single Relay update.
+   *
+   * A typical use with a Flux store might look like this:
+   *
+   * const originalDispatch = fluxStore.dispatch;
+   *
+   * function wrapped(action) {
+   *   relayStore.batchLiveStateUpdates(() => {
+   *     originalDispatch(action);
+   *   })
+   * }
+   *
+   * fluxStore.dispatch = wrapped;
+   */
+  batchLiveStateUpdates(callback: () => void) {
+    if (this.__log != null) {
+      this.__log({name: 'liveresolver.batch.start'});
+    }
+    try {
+      this._resolverCache.batchLiveStateUpdates(callback);
+    } finally {
+      if (this.__log != null) {
+        this.__log({name: 'liveresolver.batch.end'});
+      }
+    }
+  }
+
+  /**
+   * Batch multiple store updates into a single notification pass.
+   *
+   * Fragments will still correctly Suspend on their own parent query during
+   * a batch. However, cross-operation Suspense (a fragment suspending on a
+   * *different* in-flight operation) may not work correctly for operations
+   * that complete during the batch.
+   */
+  experimental_batchUpdates(callback: () => void): void {
+    if (this._batch != null) {
+      throw new Error(
+        'RelayModernStore: Cannot batch updates while already batching updates.',
+      );
+    }
+    const log = this.__log;
+    if (log != null) {
+      log({name: 'store.batch.start'});
+    }
+    const batch: Batch = {sourceOperations: [], invalidateStore: false};
+    this._batch = batch;
+    try {
+      callback();
+    } finally {
+      this._batch = null;
+      this.notify(undefined, batch.invalidateStore);
+      for (const sourceOperation of batch.sourceOperations) {
+        this._recordSourceOperation(sourceOperation);
+      }
+      if (log != null) {
+        log({
+          name: 'store.batch.complete',
+          sourceOperations: batch.sourceOperations,
+          invalidateStore: batch.invalidateStore,
+        });
+      }
+    }
+  }
+
+  batchLiveStateUpdatesWithoutNotify(callback: () => void): boolean {
+    if (this.__log != null) {
+      this.__log({name: 'liveresolver.batch.start'});
+    }
+    let hasPublished = false;
+    try {
+      hasPublished =
+        this._resolverCache.batchLiveStateUpdatesWithoutNotify(callback);
+    } finally {
+      if (this.__log != null) {
+        this.__log({name: 'liveresolver.batch.end'});
+      }
+    }
+    return hasPublished;
+  }
+
+  check(
+    operation: OperationDescriptor,
+    options?: CheckOptions,
+  ): OperationAvailability {
+    const selector = operation.root;
+    const source = this._getMutableRecordSource();
+    const globalInvalidationEpoch = this._globalInvalidationEpoch;
+    const useExecTimeResolvers =
+      operation.request.node.operation.use_exec_time_resolvers ??
+      operation.request.node.operation.exec_time_resolvers_enabled_provider?.get() ===
+        true ??
+      false;
+
+    const rootEntry = this._roots.get(operation.request.identifier);
+    const operationLastWrittenAt = rootEntry != null ? rootEntry.epoch : null;
+
+    // Check if store has been globally invalidated
+    if (globalInvalidationEpoch != null) {
+      // If so, check if the operation we're checking was last written
+      // before or after invalidation occurred.
+      if (
+        operationLastWrittenAt == null ||
+        operationLastWrittenAt <= globalInvalidationEpoch
+      ) {
+        // If the operation was written /before/ global invalidation occurred,
+        // or if this operation has never been written to the store before,
+        // we will consider the data for this operation to be stale
+        // (i.e. not resolvable from the store).
+        return {status: 'stale'};
+      }
+    }
+
+    const handlers = options?.handlers ?? [];
+    const getSourceForActor =
+      options?.getSourceForActor ??
+      (actorIdentifier => {
+        assertInternalActorIdentifier(actorIdentifier);
+        return source;
+      });
+    const getTargetForActor =
+      options?.getTargetForActor ??
+      (actorIdentifier => {
+        assertInternalActorIdentifier(actorIdentifier);
+        return source;
+      });
+
+    const operationAvailability = DataChecker.check(
+      getSourceForActor,
+      getTargetForActor,
+      options?.defaultActorIdentifier ?? INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+      selector,
+      handlers,
+      this._operationLoader,
+      this._getDataID,
+      this._shouldProcessClientComponents,
+      this.__log,
+      useExecTimeResolvers,
+    );
+
+    return getAvailabilityStatus(
+      operationAvailability,
+      operationLastWrittenAt,
+      rootEntry?.fetchTime,
+      this._queryCacheExpirationTime,
+    );
+  }
+
+  retain(operation: OperationDescriptor): Disposable {
+    const id = operation.request.identifier;
+    let disposed = false;
+    const dispose = () => {
+      // Ensure each retain can only dispose once
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      // For Flow: guard against the entry somehow not existing
+      const rootEntry = this._roots.get(id);
+      if (rootEntry == null) {
+        return;
+      }
+      // Decrement the ref count: if it becomes zero it is eligible
+      // for release.
+      rootEntry.refCount--;
+
+      if (rootEntry.refCount === 0) {
+        const {_queryCacheExpirationTime} = this;
+        const rootEntryIsStale =
+          rootEntry.fetchTime != null &&
+          _queryCacheExpirationTime != null &&
+          rootEntry.fetchTime <= Date.now() - _queryCacheExpirationTime;
+
+        if (rootEntryIsStale) {
+          if (!this._shouldRetainWithinTTL_EXPERIMENTAL) {
+            this._roots.delete(id);
+          }
+          this.scheduleGC();
+        } else {
+          this._releaseBuffer.push(id);
+
+          // If the release buffer is now over-full, remove the least-recently
+          // added entry and schedule a GC. Note that all items in the release
+          // buffer have a refCount of 0.
+          if (this._releaseBuffer.length > this._gcReleaseBufferSize) {
+            const _id = this._releaseBuffer.shift();
+            if (!this._shouldRetainWithinTTL_EXPERIMENTAL) {
+              // $FlowFixMe[incompatible-type]
+              this._roots.delete(_id);
+            }
+            this.scheduleGC();
+          }
+        }
+      }
+    };
+
+    const rootEntry = this._roots.get(id);
+    if (rootEntry != null) {
+      if (rootEntry.refCount === 0) {
+        // This entry should be in the release buffer, but it no longer belongs
+        // there since it's retained. Remove it to maintain the invariant that
+        // all release buffer entries have a refCount of 0.
+        this._releaseBuffer = this._releaseBuffer.filter(_id => _id !== id);
+      }
+      // If we've previously retained this operation, increment the refCount
+      rootEntry.refCount += 1;
+    } else {
+      // Otherwise create a new entry for the operation
+      this._roots.set(id, {
+        operation,
+        refCount: 1,
+        epoch: null,
+        fetchTime: null,
+      });
+    }
+
+    return {dispose};
+  }
+
+  lookup(selector: SingularReaderSelector): Snapshot {
+    const log = this.__log;
+    if (log != null) {
+      log({
+        name: 'store.lookup.start',
+        selector,
+      });
+    }
+    const source = this.getSource();
+    const snapshot = RelayReader.read(
+      source,
+      selector,
+      log,
+      this._resolverCache,
+      this._resolverContext,
+    );
+    if (__DEV__) {
+      deepFreeze(snapshot);
+    }
+    if (log != null) {
+      log({
+        name: 'store.lookup.end',
+        selector,
+      });
+    }
+    return snapshot;
+  }
+
+  // This method will return a list of updated owners from the subscriptions
+  notify(
+    sourceOperation?: OperationDescriptor,
+    invalidateStore?: boolean,
+  ): ReadonlyArray<RequestDescriptor> {
+    // If we're inside a batchUpdates() call, defer notification.
+    const batch = this._batch;
+    if (batch != null) {
+      if (sourceOperation != null) {
+        batch.sourceOperations.push(sourceOperation);
+      }
+      if (invalidateStore === true) {
+        batch.invalidateStore = true;
+      }
+      // Returning [] here means the OperationExecutor's _updateOperationTracker
+      // will be a no-op for this call, since it relies on notify() returning
+      // the list of affected owners. See the experimental_batchUpdates JSDoc.
+      return [];
+    }
+
+    const log = this.__log;
+    if (log != null) {
+      log({
+        name: 'store.notify.start',
+        sourceOperation,
+      });
+    }
+
+    if (!RelayFeatureFlags.OPTIMIZE_NOTIFY) {
+      // Increment the current write when notifying after executing
+      // a set of changes to the store.
+      this._currentWriteEpoch++;
+
+      if (invalidateStore === true) {
+        this._globalInvalidationEpoch = this._currentWriteEpoch;
+      }
+    }
+
+    // When a record is updated, we need to also handle records that depend on it,
+    // specifically Relay Resolver result records containing results based on the
+    // updated records. This both adds to updatedRecordIDs and invalidates any
+    // cached data as needed.
+    if (!RelayFeatureFlags.OPTIMIZE_NOTIFY || this._updatedRecordIDs.size > 0) {
+      this._resolverCache.invalidateDataIDs(this._updatedRecordIDs);
+    }
+
+    const source = this.getSource();
+    const updatedOwners: Array<RequestDescriptor> = [];
+    if (!RelayFeatureFlags.OPTIMIZE_NOTIFY || this._updatedRecordIDs.size > 0) {
+      this._storeSubscriptions.updateSubscriptions(
+        source,
+        this._updatedRecordIDs,
+        updatedOwners,
+        sourceOperation,
+      );
+    } else {
+      // If no record is updated, we still need to traverse stale subscriptions for
+      // subscriptions that were using values from optimistic updates
+      this._storeSubscriptions.updateStaleSubscriptions(
+        source,
+        this._updatedRecordIDs,
+        updatedOwners,
+        sourceOperation,
+      );
+    }
+
+    if (
+      RelayFeatureFlags.OPTIMIZE_NOTIFY &&
+      (this._updatedRecordIDs.size > 0 ||
+        updatedOwners.length > 0 ||
+        this._invalidatedRecordIDs.size > 0 ||
+        invalidateStore === true ||
+        this._globalInvalidationEpoch === this._currentWriteEpoch)
+    ) {
+      // Increment the current write when notifying after executing
+      // a set of changes to the store.
+      this._currentWriteEpoch++;
+
+      if (invalidateStore === true) {
+        this._globalInvalidationEpoch = this._currentWriteEpoch;
+      }
+    }
+
+    if (
+      !RelayFeatureFlags.OPTIMIZE_NOTIFY ||
+      this._invalidatedRecordIDs.size > 0 ||
+      invalidateStore === true
+    ) {
+      this._invalidationSubscriptions.forEach(subscription => {
+        this._updateInvalidationSubscription(
+          subscription,
+          invalidateStore === true,
+        );
+      });
+    }
+
+    if (sourceOperation != null) {
+      this._recordSourceOperation(sourceOperation);
+    }
+
+    if (log != null) {
+      log({
+        name: 'store.notify.complete',
+        sourceOperation,
+        updatedRecordIDs: this._updatedRecordIDs,
+        invalidatedRecordIDs: this._invalidatedRecordIDs,
+        subscriptionsSize: this._storeSubscriptions.size(),
+        updatedOwners,
+      });
+    }
+
+    this._updatedRecordIDs.clear();
+    this._invalidatedRecordIDs.clear();
+
+    return updatedOwners;
+  }
+
+  /**
+   * Record that a source operation was written at the current epoch.
+   * We only track the epoch at which the operation was written if
+   * it was previously retained, to keep the size of our operation
+   * epoch map bounded. If a query wasn't retained, we assume it can
+   * be deleted at any moment and thus is not relevant for us to track
+   * for the purposes of invalidation.
+   */
+  _recordSourceOperation(sourceOperation: OperationDescriptor): void {
+    const id = sourceOperation.request.identifier;
+    const rootEntry = this._roots.get(id);
+    if (rootEntry != null) {
+      rootEntry.epoch = this._currentWriteEpoch;
+      rootEntry.fetchTime = Date.now();
+    } else if (
+      sourceOperation.request.node.params.operationKind === 'query' &&
+      this._gcReleaseBufferSize > 0 &&
+      this._releaseBuffer.length < this._gcReleaseBufferSize
+    ) {
+      // The operation isn't retained but there is space in the release buffer:
+      // temporarily track this operation in case the data can be reused soon.
+      const temporaryRootEntry = {
+        operation: sourceOperation,
+        refCount: 0,
+        epoch: this._currentWriteEpoch,
+        fetchTime: Date.now(),
+      };
+      this._releaseBuffer.push(id);
+      /* $FlowFixMe[incompatible-type] Natural Inference rollout. See
+       * https://fburl.com/gdoc/y8dn025u */
+      this._roots.set(id, temporaryRootEntry);
+    }
+  }
+
+  publish(source: RecordSource, idsMarkedForInvalidation?: DataIDSet): void {
+    const target = this._getMutableRecordSource();
+    updateTargetFromSource(
+      target,
+      source,
+      // We increment the current epoch at the end of the set of updates,
+      // in notify(). Here, we pass what will be the incremented value of
+      // the epoch to use to write to invalidated records.
+      this._currentWriteEpoch + 1,
+      idsMarkedForInvalidation,
+      this._updatedRecordIDs,
+      this._invalidatedRecordIDs,
+    );
+    // NOTE: log *after* processing the source so that even if a bad log function
+    // mutates the source, it doesn't affect Relay processing of it.
+    const log = this.__log;
+    if (log != null) {
+      log({
+        name: 'store.publish',
+        source,
+        optimistic: target === this._optimisticSource,
+      });
+    }
+  }
+
+  subscribe(
+    snapshot: Snapshot,
+    callback: (snapshot: Snapshot) => void,
+  ): Disposable {
+    return this._storeSubscriptions.subscribe(snapshot, callback);
+  }
+
+  holdGC(): Disposable {
+    if (this._gcRun) {
+      this._gcRun = null;
+      this._shouldScheduleGC = true;
+    }
+    this._gcHoldCounter++;
+    const dispose = () => {
+      if (this._gcHoldCounter > 0) {
+        this._gcHoldCounter--;
+        if (this._gcHoldCounter === 0 && this._shouldScheduleGC) {
+          this.scheduleGC();
+          this._shouldScheduleGC = false;
+        }
+      }
+    };
+    return {dispose};
+  }
+
+  toJSON(): unknown {
+    return 'RelayModernStore()';
+  }
+
+  getEpoch(): number {
+    return this._currentWriteEpoch;
+  }
+
+  // Internal API
+  __getUpdatedRecordIDs(): DataIDSet {
+    return this._updatedRecordIDs;
+  }
+
+  lookupInvalidationState(dataIDs: ReadonlyArray<DataID>): InvalidationState {
+    const invalidations = new Map<DataID, ?number>();
+    dataIDs.forEach(dataID => {
+      const record = this.getSource().get(dataID);
+      invalidations.set(
+        dataID,
+        RelayModernRecord.getInvalidationEpoch(record) ?? null,
+      );
+    });
+    invalidations.set('global', this._globalInvalidationEpoch);
+    return {
+      dataIDs,
+      invalidations,
+    };
+  }
+
+  checkInvalidationState(prevInvalidationState: InvalidationState): boolean {
+    const latestInvalidationState = this.lookupInvalidationState(
+      prevInvalidationState.dataIDs,
+    );
+    const currentInvalidations = latestInvalidationState.invalidations;
+    const prevInvalidations = prevInvalidationState.invalidations;
+
+    // Check if global invalidation has changed
+    if (
+      currentInvalidations.get('global') !== prevInvalidations.get('global')
+    ) {
+      return true;
+    }
+
+    // Check if the invalidation state for any of the ids has changed.
+    for (const dataID of prevInvalidationState.dataIDs) {
+      if (currentInvalidations.get(dataID) !== prevInvalidations.get(dataID)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  subscribeToInvalidationState(
+    invalidationState: InvalidationState,
+    callback: () => void,
+  ): Disposable {
+    const subscription = {callback, invalidationState};
+    const dispose = () => {
+      this._invalidationSubscriptions.delete(subscription);
+    };
+    this._invalidationSubscriptions.add(subscription);
+    return {dispose};
+  }
+
+  _updateInvalidationSubscription(
+    subscription: InvalidationSubscription,
+    invalidatedStore: boolean,
+  ) {
+    const {callback, invalidationState} = subscription;
+    const {dataIDs} = invalidationState;
+    const isSubscribedToInvalidatedIDs =
+      invalidatedStore ||
+      dataIDs.some(dataID => this._invalidatedRecordIDs.has(dataID));
+    if (!isSubscribedToInvalidatedIDs) {
+      return;
+    }
+    callback();
+  }
+
+  snapshot(): void {
+    invariant(
+      this._optimisticSource == null,
+      'RelayModernStore: Unexpected call to snapshot() while a previous ' +
+        'snapshot exists.',
+    );
+    const log = this.__log;
+    if (log != null) {
+      log({
+        name: 'store.snapshot',
+      });
+    }
+    this._storeSubscriptions.snapshotSubscriptions(this.getSource());
+    if (this._gcRun) {
+      this._gcRun = null;
+      this._shouldScheduleGC = true;
+    }
+    this._optimisticSource = RelayOptimisticRecordSource.create(
+      this.getSource(),
+    );
+  }
+
+  restore(): void {
+    const optimisticSource = this._optimisticSource;
+    invariant(
+      optimisticSource,
+      'RelayModernStore: Unexpected call to restore(), expected a snapshot ' +
+        'to exist (make sure to call snapshot()).',
+    );
+    const log = this.__log;
+    if (log != null) {
+      log({
+        name: 'store.restore',
+      });
+    }
+    const optimisticIDs =
+      RelayOptimisticRecordSource.getOptimisticRecordIDs(optimisticSource);
+
+    // Clean up any LiveResolver subscriptions made while in the optimistic
+    // state.
+    this._resolverCache.unsubscribeFromLiveResolverRecords(optimisticIDs);
+    this._optimisticSource = null;
+    if (this._shouldScheduleGC) {
+      this.scheduleGC();
+    }
+    this._storeSubscriptions.restoreSubscriptions();
+    this._resolverCache.invalidateResolverRecords(optimisticIDs);
+  }
+
+  scheduleGC() {
+    if (this._gcHoldCounter > 0) {
+      this._shouldScheduleGC = true;
+      return;
+    }
+    if (this._gcRun) {
+      return;
+    }
+    this._gcRun = this._collect();
+    this._gcScheduler(this._gcStep);
+  }
+
+  /**
+   * Run a full GC synchronously.
+   */
+  __gc(): void {
+    // Don't run GC while there are optimistic updates applied
+    if (this._optimisticSource != null) {
+      return;
+    }
+    const gcRun = this._collect();
+    while (!gcRun.next().done) {}
+  }
+
+  _gcStep = () => {
+    if (this._gcRun) {
+      if (this._gcRun.next().done) {
+        this._gcRun = null;
+      } else {
+        this._gcScheduler(this._gcStep);
+      }
+    }
+  };
+
+  *_collect(): Generator<void, void, void> {
+    if (
+      this._shouldRetainWithinTTL_EXPERIMENTAL &&
+      this._queryCacheExpirationTime == null
+    ) {
+      // Null expiration time indicates infinite TTL, so we don't need to
+      // run GC.
+      return;
+    }
+    /* eslint-disable no-labels */
+    const log = this.__log;
+    top: while (true) {
+      if (log != null) {
+        log({
+          name: 'store.gc.start',
+        });
+      }
+      const startEpoch = this._currentWriteEpoch;
+      const references = new Set<DataID>();
+
+      for (const [
+        dataID,
+        {operation, refCount, fetchTime},
+      ] of this._roots.entries()) {
+        if (this._shouldRetainWithinTTL_EXPERIMENTAL) {
+          // Do not mark records that should be garbage collected
+          const {_queryCacheExpirationTime} = this;
+          invariant(
+            _queryCacheExpirationTime != null,
+            'Query cache expiration time should be non-null if executing GC',
+          );
+          const recordHasExpired =
+            fetchTime == null ||
+            fetchTime <= Date.now() - _queryCacheExpirationTime;
+          const recordShouldBeCollected =
+            recordHasExpired &&
+            refCount === 0 &&
+            !this._releaseBuffer.includes(dataID);
+          if (recordShouldBeCollected) {
+            continue;
+          }
+        }
+
+        // Mark all records that are traversable from a root that is still valid
+        const selector = operation.root;
+        const useExecTimeResolvers =
+          operation.request.node.operation.use_exec_time_resolvers ??
+          operation.request.node.operation.exec_time_resolvers_enabled_provider?.get() ===
+            true ??
+          false;
+        RelayReferenceMarker.mark(
+          this._recordSource,
+          selector,
+          references,
+          this._operationLoader,
+          this._shouldProcessClientComponents,
+          useExecTimeResolvers,
+        );
+        // Yield for other work after each operation
+        yield;
+
+        // If the store was updated, restart
+        if (startEpoch !== this._currentWriteEpoch) {
+          if (log != null) {
+            log({
+              name: 'store.gc.interrupted',
+            });
+          }
+          continue top;
+        }
+      }
+
+      // NOTE: It may be tempting to use `this._recordSource.clear()`
+      // when no references are found, but that would prevent calling
+      // maybeResolverSubscription() on any records that have an active
+      // resolver subscription. This would result in a memory leak.
+
+      // Evict any unreferenced nodes
+      const storeIDs = this._recordSource.getRecordIDs();
+      for (let ii = 0; ii < storeIDs.length; ii++) {
+        const dataID = storeIDs[ii];
+        if (!references.has(dataID)) {
+          const record = this._recordSource.get(dataID);
+          if (record != null) {
+            const maybeResolverSubscription = RelayModernRecord.getValue(
+              record,
+              RELAY_RESOLVER_LIVE_STATE_SUBSCRIPTION_KEY,
+            );
+            if (maybeResolverSubscription != null) {
+              // $FlowFixMe[not-a-function] - this value if it is not null, it is a function
+              maybeResolverSubscription();
+            }
+          }
+          this._recordSource.remove(dataID);
+          if (this._shouldRetainWithinTTL_EXPERIMENTAL) {
+            // Note: A record that was never retained will not be in the roots map
+            // but the following line should not throw
+            this._roots.delete(dataID);
+          }
+        }
+      }
+
+      if (log != null) {
+        log({
+          name: 'store.gc.end',
+          references,
+        });
+      }
+      return;
+    }
+  }
+
+  // Internal API for normalizing @outputType payloads in LiveResolverCache.
+  __getNormalizationOptions(path: ReadonlyArray<string>): NormalizationOptions {
+    return {
+      path,
+      getDataID: this._getDataID,
+      log: this.__log,
+      treatMissingFieldsAsNull: this._treatMissingFieldsAsNull,
+      deferDeduplicatedFields: this._deferDeduplicatedFields,
+      shouldProcessClientComponents: this._shouldProcessClientComponents,
+      actorIdentifier: this._actorIdentifier,
+    };
+  }
+
+  // Internal API that can be only invoked from the LiveResolverCache
+  // to notify subscribers of `updatedRecords`.
+  __notifyUpdatedSubscribers(updatedRecords: UpdatedRecords): void {
+    const nextUpdatedRecordIDs = getUpdatedDataIDs(updatedRecords);
+    const prevUpdatedRecordIDs = this._updatedRecordIDs;
+    this._updatedRecordIDs = nextUpdatedRecordIDs;
+    this.notify();
+    this._updatedRecordIDs = prevUpdatedRecordIDs;
+  }
+}
+
+function initializeRecordSource(target: MutableRecordSource) {
+  if (!target.has(ROOT_ID)) {
+    const rootRecord = RelayModernRecord.create(ROOT_ID, ROOT_TYPE);
+    if (RelayFeatureFlags.ENABLE_FIELD_GRANULAR_NOTIFICATIONS) {
+      RelayModernRecord.setValue(
+        rootRecord,
+        FIELD_GRANULAR_NOTIFICATIONS_KEY,
+        true,
+      );
+    }
+    target.set(ROOT_ID, rootRecord);
+  }
+}
+
+/**
+ * Updates the target with information from source, also updating a mapping of
+ * which records in the target were changed as a result.
+ * Additionally, will mark records as invalidated at the current write epoch
+ * given the set of record ids marked as stale in this update.
+ */
+function updateTargetFromSource(
+  target: MutableRecordSource,
+  source: RecordSource,
+  currentWriteEpoch: number,
+  idsMarkedForInvalidation: ?DataIDSet,
+  updatedRecordIDs: DataIDSet,
+  invalidatedRecordIDs: DataIDSet,
+): void {
+  // First, update any records that were marked for invalidation.
+  // For each provided dataID that was invalidated, we write the
+  // INVALIDATED_AT_KEY on the record, indicating
+  // the epoch at which the record was invalidated.
+  if (idsMarkedForInvalidation) {
+    idsMarkedForInvalidation.forEach(dataID => {
+      const targetRecord = target.get(dataID);
+      const sourceRecord = source.get(dataID);
+
+      // If record was deleted during the update (and also invalidated),
+      // we don't need to count it as an invalidated id
+      if (sourceRecord === null) {
+        return;
+      }
+
+      let nextRecord;
+      if (targetRecord != null) {
+        // If the target record exists, use it to set the epoch
+        // at which it was invalidated. This record will be updated with
+        // any changes from source in the section below
+        // where we update the target records based on the source.
+        nextRecord = RelayModernRecord.clone(targetRecord);
+      } else {
+        // If the target record doesn't exist, it means that a new record
+        // in the source was created (and also invalidated), so we use that
+        // record to set the epoch at which it was invalidated. This record
+        // will be updated with any changes from source in the section below
+        // where we update the target records based on the source.
+        nextRecord =
+          sourceRecord != null ? RelayModernRecord.clone(sourceRecord) : null;
+      }
+      if (!nextRecord) {
+        return;
+      }
+      RelayModernRecord.setValue(
+        nextRecord,
+        RelayStoreUtils.INVALIDATED_AT_KEY,
+        currentWriteEpoch,
+      );
+      invalidatedRecordIDs.add(dataID);
+      target.set(dataID, nextRecord);
+    });
+  }
+
+  // Update the target based on the changes present in source
+  const dataIDs = source.getRecordIDs();
+  for (let ii = 0; ii < dataIDs.length; ii++) {
+    const dataID = dataIDs[ii];
+    const sourceRecord = source.get(dataID);
+    const targetRecord = target.get(dataID);
+
+    // Prevent mutation of a record from outside the store.
+    if (__DEV__) {
+      if (sourceRecord) {
+        RelayModernRecord.freeze(sourceRecord);
+      }
+    }
+    if (sourceRecord && targetRecord) {
+      const nextRecord = RelayModernRecord.update(targetRecord, sourceRecord);
+      if (nextRecord !== targetRecord) {
+        // Prevent mutation of a record from outside the store.
+        if (__DEV__) {
+          RelayModernRecord.freeze(nextRecord);
+        }
+        updatedRecordIDs.add(dataID);
+        target.set(dataID, nextRecord);
+
+        // Add per-field notification keys for field-granular records
+        if (
+          RelayModernRecord.getValue(
+            nextRecord,
+            FIELD_GRANULAR_NOTIFICATIONS_KEY,
+          )
+        ) {
+          const fields = RelayModernRecord.getFields(nextRecord);
+          for (let jj = 0; jj < fields.length; jj++) {
+            const storageKey = fields[jj];
+            // Skip internal metadata keys (all start with '__')
+            if (storageKey.startsWith('__')) {
+              continue;
+            }
+            if (
+              RelayModernRecord.hasFieldChanged(
+                targetRecord,
+                nextRecord,
+                storageKey,
+              )
+            ) {
+              updatedRecordIDs.add(getFieldNotificationKey(dataID, storageKey));
+            }
+          }
+        }
+      }
+    } else if (sourceRecord === null) {
+      target.delete(dataID);
+      if (targetRecord !== null) {
+        updatedRecordIDs.add(dataID);
+      }
+    } else if (sourceRecord) {
+      target.set(dataID, sourceRecord);
+      updatedRecordIDs.add(dataID);
+    } // don't add explicit undefined
+  }
+}
+
+/**
+ * Returns an OperationAvailability given the Availability returned
+ * by checking an operation, and when that operation was last written to the store.
+ * Specifically, the provided Availability of an operation will contain the
+ * value of when a record referenced by the operation was most recently
+ * invalidated; given that value, and given when this operation was last
+ * written to the store, this function will return the overall
+ * OperationAvailability for the operation.
+ */
+function getAvailabilityStatus(
+  operationAvailability: Availability,
+  operationLastWrittenAt: ?number,
+  operationFetchTime: ?number,
+  queryCacheExpirationTime: ?number,
+): OperationAvailability {
+  const {mostRecentlyInvalidatedAt, status} = operationAvailability;
+  if (typeof mostRecentlyInvalidatedAt === 'number') {
+    // If some record referenced by this operation is stale, then the operation itself is stale
+    // if either the operation itself was never written *or* the operation was last written
+    // before the most recent invalidation of its reachable records.
+    if (
+      operationLastWrittenAt == null ||
+      mostRecentlyInvalidatedAt > operationLastWrittenAt
+    ) {
+      return {status: 'stale'};
+    }
+  }
+
+  if (status === 'missing') {
+    return {status: 'missing'};
+  }
+
+  if (operationFetchTime != null && queryCacheExpirationTime != null) {
+    const isStale = operationFetchTime <= Date.now() - queryCacheExpirationTime;
+    if (isStale) {
+      return {status: 'stale'};
+    }
+  }
+
+  // There were no invalidations of any reachable records *or* the operation is known to have
+  // been fetched after the most recent record invalidation.
+  return {status: 'available', fetchTime: operationFetchTime ?? null};
+}
+
+module.exports = RelayModernStore;

--- a/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/store/RelayPublishQueue.js
+++ b/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/store/RelayPublishQueue.js
@@ -1,0 +1,484 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+import type {HandlerProvider} from '../handlers/RelayDefaultHandlerProvider';
+import type {Disposable} from '../util/RelayRuntimeTypes';
+import type {GetDataID} from './RelayResponseNormalizer';
+import type {
+  LogFunction,
+  MissingFieldHandler,
+  MutationParameters,
+  OperationDescriptor,
+  OptimisticUpdate,
+  PublishQueue,
+  RecordSource,
+  RelayResponsePayload,
+  RequestDescriptor,
+  SelectorData,
+  SelectorStoreUpdater,
+  SingularReaderSelector,
+  Store,
+  StoreUpdater,
+} from './RelayStoreTypes';
+
+const RelayRecordSourceMutator = require('../mutations/RelayRecordSourceMutator');
+const RelayRecordSourceProxy = require('../mutations/RelayRecordSourceProxy');
+const RelayRecordSourceSelectorProxy = require('../mutations/RelayRecordSourceSelectorProxy');
+const RelayFeatureFlags = require('../util/RelayFeatureFlags');
+const RelayReader = require('./RelayReader');
+const RelayRecordSource = require('./RelayRecordSource');
+const invariant = require('invariant');
+const warning = require('warning');
+
+type PendingCommit<TMutation extends MutationParameters> =
+  | PendingRelayPayload<TMutation>
+  | PendingRecordSource
+  | PendingUpdater;
+type PendingRelayPayload<TMutation extends MutationParameters> = {
+  +kind: 'payload',
+  +operation: OperationDescriptor,
+  +payload: RelayResponsePayload,
+  +updater: ?SelectorStoreUpdater<TMutation['response']>,
+};
+type PendingRecordSource = {
+  +kind: 'source',
+  +source: RecordSource,
+};
+type PendingUpdater = {
+  +kind: 'updater',
+  +updater: StoreUpdater,
+};
+
+const _global: typeof global | $FlowFixMe =
+  typeof global !== 'undefined'
+    ? global
+    : // $FlowFixMe[cannot-resolve-name]
+      typeof window !== 'undefined'
+      ? // $FlowFixMe[cannot-resolve-name]
+        window
+      : undefined;
+
+const applyWithGuard =
+  _global?.ErrorUtils?.applyWithGuard ??
+  ((callback, context, args, onError, name) => callback.apply(context, args));
+
+/**
+ * Coordinates the concurrent modification of a `Store` due to optimistic and
+ * non-revertable client updates and server payloads:
+ * - Applies optimistic updates.
+ * - Reverts optimistic updates, rebasing any subsequent updates.
+ * - Commits client updates (typically for client schema extensions).
+ * - Commits server updates:
+ *   - Normalizes query/mutation/subscription responses.
+ *   - Executes handlers for "handle" fields.
+ *   - Reverts and reapplies pending optimistic updates.
+ */
+class RelayPublishQueue implements PublishQueue {
+  _store: Store;
+  _handlerProvider: ?HandlerProvider;
+  _missingFieldHandlers: ReadonlyArray<MissingFieldHandler>;
+  _getDataID: GetDataID;
+  _log: ?LogFunction;
+
+  _hasStoreSnapshot: boolean;
+  // True if the next `run()` should apply the backup and rerun all optimistic
+  // updates performing a rebase.
+  _pendingBackupRebase: boolean;
+  // Payloads to apply or Sources to publish to the store with the next `run()`.
+  // $FlowFixMe[unclear-type] See explanation below.
+  _pendingData: Set<PendingCommit<any>>;
+  // Optimistic updaters to add with the next `run()`.
+  // $FlowFixMe[unclear-type] See explanation below.
+  _pendingOptimisticUpdates: Set<OptimisticUpdate<any>>;
+  // Optimistic updaters that are already added and might be rerun in order to
+  // rebase them.
+  // $FlowFixMe[unclear-type] See explanation below.
+  _appliedOptimisticUpdates: Set<OptimisticUpdate<any>>;
+  // For _pendingOptimisticUpdates, _appliedOptimisticUpdates, and _pendingData,
+  // we want to parametrize by "any" since the type is effectively
+  // "the union of all T's that PublishQueue's methods were called with".
+
+  // Garbage collection hold, should rerun gc on dispose
+  _gcHold: ?Disposable;
+  _isRunning: ?boolean;
+
+  constructor(
+    store: Store,
+    handlerProvider?: ?HandlerProvider,
+    getDataID: GetDataID,
+    missingFieldHandlers: ReadonlyArray<MissingFieldHandler>,
+    log: LogFunction,
+  ) {
+    this._hasStoreSnapshot = false;
+    this._handlerProvider = handlerProvider || null;
+    this._pendingBackupRebase = false;
+    this._pendingData = new Set();
+    this._pendingOptimisticUpdates = new Set();
+    this._store = store;
+    this._appliedOptimisticUpdates = new Set();
+    this._gcHold = null;
+    this._getDataID = getDataID;
+    this._missingFieldHandlers = missingFieldHandlers;
+    this._log = log;
+  }
+
+  /**
+   * Schedule applying an optimistic updates on the next `run()`.
+   */
+  applyUpdate<TMutation extends MutationParameters>(
+    updater: OptimisticUpdate<TMutation>,
+  ): void {
+    invariant(
+      !this._appliedOptimisticUpdates.has(updater) &&
+        !this._pendingOptimisticUpdates.has(updater),
+      'RelayPublishQueue: Cannot apply the same update function more than ' +
+        'once concurrently.',
+    );
+    this._pendingOptimisticUpdates.add(updater);
+  }
+
+  /**
+   * Schedule reverting an optimistic updates on the next `run()`.
+   */
+  revertUpdate<TMutation extends MutationParameters>(
+    updater: OptimisticUpdate<TMutation>,
+  ): void {
+    if (this._pendingOptimisticUpdates.has(updater)) {
+      // Reverted before it was applied
+      this._pendingOptimisticUpdates.delete(updater);
+    } else if (this._appliedOptimisticUpdates.has(updater)) {
+      this._pendingBackupRebase = true;
+      this._appliedOptimisticUpdates.delete(updater);
+    }
+  }
+
+  /**
+   * Schedule a revert of all optimistic updates on the next `run()`.
+   */
+  revertAll(): void {
+    this._pendingBackupRebase = true;
+    this._pendingOptimisticUpdates.clear();
+    this._appliedOptimisticUpdates.clear();
+  }
+
+  /**
+   * Schedule applying a payload to the store on the next `run()`.
+   */
+  commitPayload<TMutation extends MutationParameters>(
+    operation: OperationDescriptor,
+    payload: RelayResponsePayload,
+    updater?: ?SelectorStoreUpdater<TMutation['response']>,
+  ): void {
+    this._pendingBackupRebase = true;
+    this._pendingData.add({
+      kind: 'payload',
+      operation,
+      payload,
+      updater,
+    });
+  }
+
+  /**
+   * Schedule an updater to mutate the store on the next `run()` typically to
+   * update client schema fields.
+   */
+  commitUpdate(updater: StoreUpdater): void {
+    this._pendingBackupRebase = true;
+    this._pendingData.add({
+      kind: 'updater',
+      updater,
+    });
+  }
+
+  /**
+   * Schedule a publish to the store from the provided source on the next
+   * `run()`. As an example, to update the store with substituted fields that
+   * are missing in the store.
+   */
+  commitSource(source: RecordSource): void {
+    this._pendingBackupRebase = true;
+    this._pendingData.add({kind: 'source', source});
+  }
+
+  /**
+   * Execute all queued up operations from the other public methods.
+   */
+  run(sourceOperation?: OperationDescriptor): ReadonlyArray<RequestDescriptor> {
+    const runWillClearGcHold =
+      // $FlowFixMe[incompatible-type]
+      /* $FlowFixMe[invalid-compare] Error discovered during Constant Condition
+       * roll out. See https://fburl.com/workplace/4oq3zi07. */
+      this._appliedOptimisticUpdates === 0 && !!this._gcHold;
+    const runIsANoop =
+      // this._pendingBackupRebase is true if an applied optimistic
+      // update has potentially been reverted or if this._pendingData is not empty.
+      !this._pendingBackupRebase &&
+      this._pendingOptimisticUpdates.size === 0 &&
+      !runWillClearGcHold;
+
+    warning(
+      !runIsANoop,
+      'RelayPublishQueue.run was called, but the call would have been a noop.',
+    );
+    RelayFeatureFlags.DISALLOW_NESTED_UPDATES
+      ? invariant(
+          this._isRunning !== true,
+          'A store update was detected within another store update. Please ' +
+            "make sure new store updates aren't being executed within an " +
+            'updater function for a different update.',
+        )
+      : warning(
+          this._isRunning !== true,
+          'A store update was detected within another store update. Please ' +
+            "make sure new store updates aren't being executed within an " +
+            'updater function for a different update.',
+        );
+    this._isRunning = true;
+
+    if (runIsANoop) {
+      this._isRunning = false;
+      return [];
+    }
+
+    if (this._pendingBackupRebase) {
+      if (this._hasStoreSnapshot) {
+        this._store.restore();
+        this._hasStoreSnapshot = false;
+      }
+    }
+    const invalidatedStore = this._commitData();
+    if (
+      this._pendingOptimisticUpdates.size ||
+      (this._pendingBackupRebase && this._appliedOptimisticUpdates.size)
+    ) {
+      if (!this._hasStoreSnapshot) {
+        this._store.snapshot();
+        this._hasStoreSnapshot = true;
+      }
+      this._applyUpdates();
+    }
+    this._pendingBackupRebase = false;
+    if (this._appliedOptimisticUpdates.size > 0) {
+      if (!this._gcHold) {
+        this._gcHold = this._store.holdGC();
+      }
+    } else {
+      if (this._gcHold) {
+        this._gcHold.dispose();
+        this._gcHold = null;
+      }
+    }
+    this._isRunning = false;
+    return this._store.notify(sourceOperation, invalidatedStore);
+  }
+
+  /**
+   * _publishSourceFromPayload will return a boolean indicating if the
+   * publish caused the store to be globally invalidated.
+   */
+  _publishSourceFromPayload<TMutation extends MutationParameters>(
+    pendingPayload: PendingRelayPayload<TMutation>,
+  ): boolean {
+    const {payload, operation, updater} = pendingPayload;
+    const {source, fieldPayloads} = payload;
+    const mutator = new RelayRecordSourceMutator(
+      this._store.getSource(),
+      source,
+    );
+    const recordSourceProxy = new RelayRecordSourceProxy(
+      mutator,
+      this._getDataID,
+      this._handlerProvider,
+      this._missingFieldHandlers,
+      this._log,
+    );
+    if (fieldPayloads && fieldPayloads.length) {
+      fieldPayloads.forEach(fieldPayload => {
+        const handler =
+          this._handlerProvider && this._handlerProvider(fieldPayload.handle);
+        invariant(
+          handler,
+          'RelayModernEnvironment: Expected a handler to be provided for ' +
+            'handle `%s`.',
+          fieldPayload.handle,
+        );
+        handler.update(recordSourceProxy, fieldPayload);
+      });
+    }
+    if (updater) {
+      const selector = operation.fragment;
+      invariant(
+        selector != null,
+        'RelayModernEnvironment: Expected a selector to be provided with updater function.',
+      );
+      const recordSourceSelectorProxy = new RelayRecordSourceSelectorProxy(
+        mutator,
+        recordSourceProxy,
+        selector,
+        this._missingFieldHandlers,
+      );
+      const selectorData = lookupSelector(source, selector);
+      updater(recordSourceSelectorProxy, selectorData);
+    }
+    const idsMarkedForInvalidation =
+      recordSourceProxy.getIDsMarkedForInvalidation();
+    this._store.publish(source, idsMarkedForInvalidation);
+    return recordSourceProxy.isStoreMarkedForInvalidation();
+  }
+
+  /**
+   * _commitData will return a boolean indicating if any of
+   * the pending commits caused the store to be globally invalidated.
+   */
+  _commitData(): boolean {
+    if (!this._pendingData.size) {
+      return false;
+    }
+    let invalidatedStore = false;
+    this._pendingData.forEach(data => {
+      if (data.kind === 'payload') {
+        const payloadInvalidatedStore = this._publishSourceFromPayload(data);
+        invalidatedStore = invalidatedStore || payloadInvalidatedStore;
+      } else if (data.kind === 'source') {
+        const source = data.source;
+        this._store.publish(source);
+      } else {
+        const updater = data.updater;
+        const sink = RelayRecordSource.create();
+        const mutator = new RelayRecordSourceMutator(
+          this._store.getSource(),
+          sink,
+        );
+        const recordSourceProxy = new RelayRecordSourceProxy(
+          mutator,
+          this._getDataID,
+          this._handlerProvider,
+          this._missingFieldHandlers,
+          this._log,
+        );
+        applyWithGuard(
+          updater,
+          null,
+          [recordSourceProxy],
+          null,
+          'RelayPublishQueue:commitData',
+        );
+        invalidatedStore =
+          invalidatedStore || recordSourceProxy.isStoreMarkedForInvalidation();
+        const idsMarkedForInvalidation =
+          recordSourceProxy.getIDsMarkedForInvalidation();
+
+        this._store.publish(sink, idsMarkedForInvalidation);
+      }
+    });
+    this._pendingData.clear();
+    return invalidatedStore;
+  }
+
+  /**
+   * Note that unlike _commitData, _applyUpdates will NOT return a boolean
+   * indicating if the store was globally invalidated, since invalidating the
+   * store during an optimistic update is a no-op.
+   */
+  _applyUpdates(): void {
+    const sink = RelayRecordSource.create();
+    const mutator = new RelayRecordSourceMutator(this._store.getSource(), sink);
+    const recordSourceProxy = new RelayRecordSourceProxy(
+      mutator,
+      this._getDataID,
+      this._handlerProvider,
+      this._missingFieldHandlers,
+      this._log,
+    );
+
+    // $FlowFixMe[unclear-type] see explanation above.
+    const processUpdate = (optimisticUpdate: OptimisticUpdate<any>) => {
+      if (optimisticUpdate.storeUpdater) {
+        const {storeUpdater} = optimisticUpdate;
+        applyWithGuard(
+          storeUpdater,
+          null,
+          [recordSourceProxy],
+          null,
+          'RelayPublishQueue:applyUpdates',
+        );
+      } else {
+        const {operation, payload, updater} = optimisticUpdate;
+        const {source, fieldPayloads} = payload;
+        if (source) {
+          recordSourceProxy.publishSource(source, fieldPayloads);
+        }
+        if (updater) {
+          let selectorData;
+          if (source) {
+            selectorData = lookupSelector(source, operation.fragment);
+          }
+          const recordSourceSelectorProxy = new RelayRecordSourceSelectorProxy(
+            mutator,
+            recordSourceProxy,
+            operation.fragment,
+            this._missingFieldHandlers,
+          );
+          applyWithGuard(
+            updater,
+            null,
+            [recordSourceSelectorProxy, selectorData],
+            null,
+            'RelayPublishQueue:applyUpdates',
+          );
+        }
+      }
+    };
+
+    // rerun all updaters in case we are running a rebase
+    if (this._pendingBackupRebase && this._appliedOptimisticUpdates.size) {
+      this._appliedOptimisticUpdates.forEach(processUpdate);
+    }
+
+    // apply any new updaters
+    if (this._pendingOptimisticUpdates.size) {
+      this._pendingOptimisticUpdates.forEach(optimisticUpdate => {
+        processUpdate(optimisticUpdate);
+        this._appliedOptimisticUpdates.add(optimisticUpdate);
+      });
+      this._pendingOptimisticUpdates.clear();
+    }
+
+    this._store.publish(sink);
+  }
+}
+
+function lookupSelector(
+  source: RecordSource,
+  selector: SingularReaderSelector,
+): ?SelectorData {
+  const selectorData = RelayReader.read(
+    source,
+    selector,
+    // The reader here is used to read the selector data for the updater.
+    // It is normal to not use all data in the update, so we don't pass
+    // the logger to skip tracking usages.
+    null,
+    undefined,
+    undefined,
+  ).data;
+  if (__DEV__) {
+    const deepFreeze = require('../util/deepFreeze');
+    if (selectorData) {
+      deepFreeze(selectorData);
+    }
+  }
+  return selectorData;
+}
+
+module.exports = RelayPublishQueue;

--- a/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/store/RelayReader.js
+++ b/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/store/RelayReader.js
@@ -1,0 +1,1830 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+import type {Result} from '../experimental';
+import type {
+  CatchFieldTo,
+  ReaderActorChange,
+  ReaderAliasedInlineFragmentSpread,
+  ReaderCatchField,
+  ReaderClientEdge,
+  ReaderFragment,
+  ReaderFragmentSpread,
+  ReaderInlineDataFragmentSpread,
+  ReaderInlineFragment,
+  ReaderLinkedField,
+  ReaderModuleImport,
+  ReaderNode,
+  ReaderRelayLiveResolver,
+  ReaderRelayResolver,
+  ReaderRequiredField,
+  ReaderScalarField,
+  ReaderSelection,
+} from '../util/ReaderNode';
+import type {DataID, Variables} from '../util/RelayRuntimeTypes';
+import type {
+  ClientEdgeTraversalInfo,
+  DataIDSet,
+  FieldError,
+  FieldErrors,
+  LogFunction,
+  MissingClientEdgeRequestInfo,
+  Record,
+  RecordSource,
+  RequestDescriptor,
+  ResolverContext,
+  SelectorData,
+  SingularReaderSelector,
+  Snapshot,
+} from './RelayStoreTypes';
+import type {Arguments} from './RelayStoreUtils';
+import type {EvaluationResult, ResolverCache} from './ResolverCache';
+
+const RelayFeatureFlags = require('../util/RelayFeatureFlags');
+const {
+  isSuspenseSentinel,
+} = require('./live-resolvers/LiveResolverSuspenseSentinel');
+const RelayConcreteVariables = require('./RelayConcreteVariables');
+const RelayModernRecord = require('./RelayModernRecord');
+const {
+  CLIENT_EDGE_TRAVERSAL_PATH,
+  FIELD_GRANULAR_NOTIFICATIONS_KEY,
+  FRAGMENT_OWNER_KEY,
+  FRAGMENT_PROP_NAME_KEY,
+  FRAGMENTS_KEY,
+  ID_KEY,
+  MODULE_COMPONENT_KEY,
+  ROOT_ID,
+  getArgumentValues,
+  getFieldNotificationKey,
+  getModuleComponentKey,
+  getStorageKey,
+} = require('./RelayStoreUtils');
+const {NoopResolverCache} = require('./ResolverCache');
+const {
+  RESOLVER_FRAGMENT_ERRORED_SENTINEL,
+  withResolverContext,
+} = require('./ResolverFragments');
+const {generateTypeID} = require('./TypeID');
+const invariant = require('invariant');
+
+function read(
+  recordSource: RecordSource,
+  selector: SingularReaderSelector,
+  log: ?LogFunction,
+  resolverCache?: ResolverCache,
+  resolverContext?: ResolverContext,
+): Snapshot {
+  const reader = new RelayReader(
+    recordSource,
+    selector,
+    log,
+    resolverCache ?? new NoopResolverCache(),
+    resolverContext,
+  );
+  return reader.read();
+}
+
+/**
+ * @private
+ */
+class RelayReader {
+  _clientEdgeTraversalPath: Array<ClientEdgeTraversalInfo | null>;
+  _isMissingData: boolean;
+  _missingClientEdges: Array<MissingClientEdgeRequestInfo>;
+  _missingLiveResolverFields: Array<DataID>;
+  _isWithinUnmatchedTypeRefinement: boolean;
+  _fieldErrors: ?FieldErrors;
+  _fieldGranularNotificationDataID: ?DataID;
+  _owner: RequestDescriptor;
+  // Exec time resolvers are run before reaching the Relay store so the store already contains
+  // the normalized data; the same as if the data were sent from the server. However, since a
+  // resolver could be used at read time or exec time in different queries, the reader AST for
+  // a resolver is the read time AST. At runtime, this flag is used to ignore the extra
+  // information in the read time resolver AST and use the "standard", non-resolver read paths
+  _useExecTimeResolvers: boolean;
+  _recordSource: RecordSource;
+  _seenRecords: DataIDSet;
+  _updatedDataIDs: DataIDSet;
+  _selector: SingularReaderSelector;
+  _variables: Variables;
+  _resolverCache: ResolverCache;
+  _fragmentName: string;
+  _resolverContext: ?ResolverContext;
+  // The log function currently is only used to log fragment spread accesses for unused
+  // fragments detection, so it is not passed in from all callsites. If we decide to
+  // extend the logging, this needs to be updated.
+  _log: ?LogFunction;
+
+  constructor(
+    recordSource: RecordSource,
+    selector: SingularReaderSelector,
+    log: ?LogFunction,
+    resolverCache: ResolverCache,
+    resolverContext: ?ResolverContext,
+  ) {
+    this._clientEdgeTraversalPath = selector.clientEdgeTraversalPath?.length
+      ? [...selector.clientEdgeTraversalPath]
+      : [];
+    this._missingClientEdges = [];
+    this._missingLiveResolverFields = [];
+    this._isMissingData = false;
+    this._isWithinUnmatchedTypeRefinement = false;
+    this._fieldErrors = null;
+    this._fieldGranularNotificationDataID = null;
+    this._owner = selector.owner;
+    this._useExecTimeResolvers =
+      this._owner.node.operation.use_exec_time_resolvers ??
+      this._owner.node.operation.exec_time_resolvers_enabled_provider?.get() ===
+        true ??
+      false;
+    this._recordSource = recordSource;
+    this._seenRecords = new Set();
+    this._selector = selector;
+    this._variables = selector.variables;
+    this._resolverCache = resolverCache;
+    this._fragmentName = selector.node.name;
+    this._updatedDataIDs = new Set();
+    this._resolverContext = resolverContext;
+    this._log = log;
+  }
+
+  read(): Snapshot {
+    const {node, dataID, isWithinUnmatchedTypeRefinement} = this._selector;
+    const {abstractKey} = node;
+    const record = this._recordSource.get(dataID);
+
+    // Relay historically allowed child fragments to be read even if the root object
+    // did not match the type of the fragment: either the root object has a different
+    // concrete type than the fragment (for concrete fragments) or the root object does
+    // not conform to the interface/union for abstract fragments.
+    // For suspense purposes, however, we want to accurately compute whether any data
+    // is missing: but if the fragment type doesn't match (or a parent type didn't
+    // match), then no data is expected to be present.
+
+    // By default data is expected to be present unless this selector was read out
+    // from within a non-matching type refinement in a parent fragment:
+    let isDataExpectedToBePresent = !isWithinUnmatchedTypeRefinement;
+
+    // If this is a concrete fragment and the concrete type of the record does not
+    // match, then no data is expected to be present.
+    if (isDataExpectedToBePresent && abstractKey == null && record != null) {
+      if (!this._recordMatchesTypeCondition(record, node.type)) {
+        isDataExpectedToBePresent = false;
+      }
+    }
+
+    // If this is an abstract fragment (and the precise refinement GK is enabled)
+    // then data is only expected to be present if the record type is known to
+    // implement the interface. If we aren't sure whether the record implements
+    // the interface, that itself constitutes "expected" data being missing.
+    if (isDataExpectedToBePresent && abstractKey != null && record != null) {
+      const implementsInterface = this._implementsInterface(
+        record,
+        abstractKey,
+      );
+      if (implementsInterface === false) {
+        // Type known to not implement the interface
+        isDataExpectedToBePresent = false;
+      }
+    }
+
+    this._isWithinUnmatchedTypeRefinement = !isDataExpectedToBePresent;
+    let data = this._traverse(node, dataID, null);
+
+    // If the fragment/operation was marked with @catch, we need to handle any
+    // errors that were encountered while reading the fields within it.
+    const catchTo = this._selector.node.metadata?.catchTo;
+    if (catchTo != null) {
+      data = this._catchErrors(data, catchTo, null) as $FlowFixMe;
+    }
+
+    if (this._updatedDataIDs.size > 0) {
+      this._resolverCache.notifyUpdatedSubscribers(this._updatedDataIDs);
+      this._updatedDataIDs.clear();
+    }
+
+    if (RelayFeatureFlags.ENABLE_READER_FRAGMENTS_LOGGING) {
+      this._log?.({
+        name: 'reader.read',
+        selector: this._selector,
+      });
+    }
+
+    return {
+      data,
+      fieldErrors: this._fieldErrors,
+      isMissingData: this._isMissingData && isDataExpectedToBePresent,
+      missingClientEdges: this._missingClientEdges.length
+        ? this._missingClientEdges
+        : null,
+      missingLiveResolverFields: this._missingLiveResolverFields,
+      seenRecords: this._seenRecords,
+      selector: this._selector,
+    };
+  }
+
+  _maybeAddFieldErrors(record: Record, storageKey: string): void {
+    const errors = RelayModernRecord.getErrors(record, storageKey);
+
+    if (errors == null) {
+      return;
+    }
+    const owner = this._fragmentName;
+
+    if (this._fieldErrors == null) {
+      this._fieldErrors = [];
+    }
+    for (let i = 0; i < errors.length; i++) {
+      const error = errors[i];
+      this._fieldErrors.push({
+        error,
+        fieldPath: (error.path ?? []).join('.'),
+        handled: false,
+        kind: 'relay_field_payload.error',
+        owner,
+        shouldThrow: this._selector.node.metadata?.throwOnFieldError ?? false,
+        // the uiContext is always undefined here.
+        // the loggingContext is provided by hooks - and assigned to uiContext in handlePotentialSnapshotErrors
+        uiContext: undefined,
+      });
+    }
+  }
+
+  _markDataAsMissing(fieldName: string): void {
+    if (this._isWithinUnmatchedTypeRefinement) {
+      return;
+    }
+    if (this._fieldErrors == null) {
+      this._fieldErrors = [];
+    }
+
+    // we will add the path later
+    const owner = this._fragmentName;
+
+    this._fieldErrors.push(
+      (this._selector.node.metadata?.throwOnFieldError ?? false)
+        ? {
+            fieldPath: fieldName,
+            handled: false,
+            kind: 'missing_expected_data.throw',
+            owner,
+            // the uiContext is always undefined here.
+            // the loggingContext is provided by hooks - and assigned to uiContext in handlePotentialSnapshotErrors
+            uiContext: undefined,
+          }
+        : {
+            fieldPath: fieldName,
+            kind: 'missing_expected_data.log',
+            owner,
+            // the uiContext is always undefined here.
+            // the loggingContext is provided by hooks - and assigned to uiContext in handlePotentialSnapshotErrors
+            uiContext: undefined,
+          },
+    );
+
+    this._isMissingData = true;
+
+    if (this._clientEdgeTraversalPath.length) {
+      const top =
+        this._clientEdgeTraversalPath[this._clientEdgeTraversalPath.length - 1];
+      // Top can be null if we've traversed past a client edge into an ordinary
+      // client extension field; we never want to fetch in response to missing
+      // data off of a client extension field.
+      if (top !== null) {
+        this._missingClientEdges.push({
+          clientEdgeDestinationID: top.clientEdgeDestinationID,
+          request: top.readerClientEdge.operation,
+        });
+      }
+    }
+  }
+
+  _traverse(
+    node: ReaderNode,
+    dataID: DataID,
+    prevData: ?SelectorData,
+  ): ?SelectorData {
+    const record = this._recordSource.get(dataID);
+    const prevFieldGranularDataID = this._fieldGranularNotificationDataID;
+    if (
+      record != null &&
+      RelayModernRecord.getValue(record, FIELD_GRANULAR_NOTIFICATIONS_KEY)
+    ) {
+      this._fieldGranularNotificationDataID = dataID;
+    } else {
+      this._seenRecords.add(dataID);
+      this._fieldGranularNotificationDataID = null;
+    }
+    if (record == null) {
+      if (record === undefined) {
+        this._markDataAsMissing('<record>');
+      }
+      this._fieldGranularNotificationDataID = prevFieldGranularDataID;
+      // $FlowFixMe[incompatible-type]
+      return record;
+    }
+    const data = prevData || {};
+    const hadRequiredData = this._traverseSelections(
+      node.selections,
+      record,
+      data,
+    );
+    this._fieldGranularNotificationDataID = prevFieldGranularDataID;
+    return hadRequiredData ? data : null;
+  }
+
+  _getVariableValue(name: string): unknown {
+    invariant(
+      this._variables.hasOwnProperty(name),
+      'RelayReader(): Undefined variable `%s`.',
+      name,
+    );
+    return this._variables[name];
+  }
+
+  _maybeReportUnexpectedNull(selection: ReaderRequiredField) {
+    if (selection.action === 'NONE') {
+      return;
+    }
+    const owner = this._fragmentName;
+
+    if (this._fieldErrors == null) {
+      this._fieldErrors = [];
+    }
+
+    let fieldName: string;
+    if (selection.field.linkedField != null) {
+      fieldName =
+        selection.field.linkedField.alias ?? selection.field.linkedField.name;
+    } else {
+      fieldName = selection.field.alias ?? selection.field.name;
+    }
+
+    switch (selection.action) {
+      case 'THROW':
+        this._fieldErrors.push({
+          fieldPath: fieldName,
+          handled: false,
+          kind: 'missing_required_field.throw',
+          owner,
+          // the uiContext is always undefined here.
+          // the loggingContext is provided by hooks - and assigned to uiContext in handlePotentialSnapshotErrors
+          uiContext: undefined,
+        });
+        return;
+      case 'LOG':
+        this._fieldErrors.push({
+          fieldPath: fieldName,
+          kind: 'missing_required_field.log',
+          owner,
+          // the uiContext is always undefined here.
+          // the loggingContext is provided by hooks - and assigned to uiContext in handlePotentialSnapshotErrors
+          uiContext: undefined,
+        });
+        return;
+      default:
+        selection.action as empty;
+    }
+  }
+
+  _handleRequiredFieldValue(
+    selection: ReaderRequiredField,
+    value: unknown,
+  ): boolean /*should continue to siblings*/ {
+    if (value == null) {
+      this._maybeReportUnexpectedNull(selection);
+      // We are going to throw, or our parent is going to get nulled out.
+      // Either way, sibling values are going to be ignored, so we can
+      // bail early here as an optimization.
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Fields, aliased inline fragments, fragments and operations with `@catch`
+   * directives must handle the case that errors were encountered while reading
+   * any fields within them.
+   *
+   * 1. Before traversing into the selection(s) marked as `@catch`, the caller
+   *   stores the previous field errors (`this._fieldErrors`) in a
+   *   variable.
+   * 2. After traversing into the selection(s) marked as `@catch`, the caller
+   *   calls this method with the resulting value, the `to` value from the
+   *   `@catch` directive, and the previous field errors.
+   *
+   * This method will then:
+   *
+   * 1. Compute the correct value to return based on any errors encountered and the supplied `to` type.
+   * 2. Mark any errors encountered within the `@catch` as "handled" to ensure they don't cause the reader to throw.
+   * 3. Merge any errors encountered within the `@catch` with the previous field errors.
+   */
+  _catchErrors<T>(
+    _value: T,
+    to: CatchFieldTo,
+    previousResponseFields: ?FieldErrors,
+  ): ?T | Result<T, unknown> {
+    let value: T | null | Result<T, unknown> = _value;
+    switch (to) {
+      case 'RESULT':
+        value = this._asResult(_value);
+        break;
+      case 'NULL':
+        if (this._fieldErrors != null && this._fieldErrors.length > 0) {
+          value = null;
+        }
+        break;
+      default:
+        to as empty;
+    }
+
+    const childrenFieldErrors = this._fieldErrors;
+
+    this._fieldErrors = previousResponseFields;
+
+    // Merge any errors encountered within the @catch with the previous field
+    // errors, but mark them as "handled" first.
+    if (childrenFieldErrors != null) {
+      if (this._fieldErrors == null) {
+        this._fieldErrors = [];
+      }
+      for (let i = 0; i < childrenFieldErrors.length; i++) {
+        // We mark any errors encountered within the @catch as "handled"
+        // to ensure that they don't cause the reader to throw, but can
+        // still be logged.
+        this._fieldErrors.push(
+          markFieldErrorHasHandled(childrenFieldErrors[i]),
+        );
+      }
+    }
+    return value;
+  }
+
+  /**
+   * Convert a value into a Result object based on the presence of errors in the
+   * `this._fieldErrors` array.
+   *
+   * **Note**: This method does _not_ mark errors as handled. It is the caller's
+   * responsibility to ensure that errors are marked as handled.
+   */
+  _asResult<T>(value: T): Result<T, unknown> {
+    if (this._fieldErrors == null || this._fieldErrors.length === 0) {
+      return {ok: true, value};
+    }
+
+    // TODO: Should we be hiding log level events here?
+    const errors = this._fieldErrors
+      .map(error => {
+        switch (error.kind) {
+          case 'relay_field_payload.error':
+            const {message, ...displayError} = error.error;
+            return displayError;
+          case 'missing_expected_data.throw':
+          case 'missing_expected_data.log':
+            return {
+              path: error.fieldPath.split('.'),
+            };
+          case 'relay_resolver.error':
+            return {
+              message: `Relay: Error in resolver for field at ${error.fieldPath} in ${error.owner}`,
+            };
+          case 'missing_required_field.throw':
+            // If we have a nested @required(THROW) that will throw,
+            // we want to catch that error and provide it
+            return {
+              message: `Relay: Missing @required value at path '${error.fieldPath}' in '${error.owner}'.`,
+            };
+          case 'missing_required_field.log':
+            // For backwards compatibility, we don't surface log level missing required fields
+            return null;
+          default:
+            error.kind as empty;
+            invariant(
+              false,
+              'Unexpected error fieldError kind: %s',
+              error.kind,
+            );
+        }
+      })
+      .filter(Boolean);
+
+    return {errors, ok: false};
+  }
+
+  _traverseSelections(
+    selections: ReadonlyArray<ReaderSelection>,
+    record: Record,
+    data: SelectorData,
+  ): boolean /* had all expected data */ {
+    for (let i = 0; i < selections.length; i++) {
+      const selection = selections[i];
+
+      switch (selection.kind) {
+        case 'RequiredField':
+          const requiredFieldValue = this._readClientSideDirectiveField(
+            selection,
+            record,
+            data,
+          );
+          if (!this._handleRequiredFieldValue(selection, requiredFieldValue)) {
+            return false;
+          }
+          break;
+        case 'CatchField': {
+          const previousResponseFields = this._fieldErrors;
+
+          this._fieldErrors = null;
+
+          const catchFieldValue = this._readClientSideDirectiveField(
+            selection,
+            record,
+            data,
+          );
+
+          const field = selection.field?.backingField ?? selection.field;
+          const fieldName = field?.alias ?? field?.name;
+          // ReaderClientExtension doesn't have `alias` or `name`
+          // so we don't support this yet
+          invariant(
+            fieldName != null,
+            "Couldn't determine field name for this field. It might be a ReaderClientExtension - which is not yet supported.",
+          );
+
+          data[fieldName] = this._catchErrors(
+            catchFieldValue,
+            selection.to,
+            previousResponseFields,
+          );
+
+          break;
+        }
+        case 'ScalarField':
+          this._readScalar(selection, record, data);
+          break;
+        case 'LinkedField':
+          if (selection.plural) {
+            this._readPluralLink(selection, record, data);
+          } else {
+            this._readLink(selection, record, data);
+          }
+          break;
+        case 'Condition':
+          const conditionValue = Boolean(
+            this._getVariableValue(selection.condition),
+          );
+          if (conditionValue === selection.passingValue) {
+            const hasExpectedData = this._traverseSelections(
+              selection.selections,
+              record,
+              data,
+            );
+            if (!hasExpectedData) {
+              return false;
+            }
+          }
+          break;
+        case 'InlineFragment': {
+          const hasExpectedData = this._readInlineFragment(
+            selection,
+            record,
+            data,
+            false,
+          );
+          if (hasExpectedData === false) {
+            // We are missing @required data, so we bubble up.
+            return false;
+          }
+          break;
+        }
+        case 'RelayLiveResolver':
+        case 'RelayResolver': {
+          if (this._useExecTimeResolvers) {
+            this._readScalar(selection, record, data);
+          } else {
+            this._readResolverField(selection, record, data);
+          }
+          break;
+        }
+        case 'FragmentSpread':
+          this._createFragmentPointer(selection, record, data);
+          break;
+        case 'AliasedInlineFragmentSpread': {
+          this._readAliasedInlineFragment(selection, record, data);
+          break;
+        }
+        case 'ModuleImport':
+          this._readModuleImport(selection, record, data);
+          break;
+        case 'InlineDataFragmentSpread':
+          this._createInlineDataOrResolverFragmentPointer(
+            selection,
+            record,
+            data,
+          );
+          break;
+        case 'Defer':
+        case 'ClientExtension': {
+          const isMissingData = this._isMissingData;
+          const alreadyMissingClientEdges = this._missingClientEdges.length;
+          this._clientEdgeTraversalPath.push(null);
+          const hasExpectedData = this._traverseSelections(
+            selection.selections,
+            record,
+            data,
+          );
+          // The only case where we want to suspend due to missing data off of
+          // a client extension is if we reached a client edge that we might be
+          // able to fetch, or there is a missing data in one of the live resolvers.
+          this._isMissingData =
+            isMissingData ||
+            this._missingClientEdges.length > alreadyMissingClientEdges ||
+            this._missingLiveResolverFields.length > 0;
+          this._clientEdgeTraversalPath.pop();
+          if (!hasExpectedData) {
+            return false;
+          }
+          break;
+        }
+        case 'Stream': {
+          const hasExpectedData = this._traverseSelections(
+            selection.selections,
+            record,
+            data,
+          );
+          if (!hasExpectedData) {
+            return false;
+          }
+          break;
+        }
+        case 'ActorChange':
+          this._readActorChange(selection, record, data);
+          break;
+        case 'ClientEdgeToClientObject':
+        case 'ClientEdgeToServerObject':
+          if (
+            this._useExecTimeResolvers &&
+            (selection.backingField.kind === 'RelayResolver' ||
+              selection.backingField.kind === 'RelayLiveResolver')
+          ) {
+            const {linkedField} = selection;
+            if (linkedField.plural) {
+              this._readPluralLink(linkedField, record, data);
+            } else {
+              this._readLink(linkedField, record, data);
+            }
+          } else {
+            this._readClientEdge(selection, record, data);
+          }
+          break;
+        default:
+          selection as empty;
+          invariant(
+            false,
+            'RelayReader(): Unexpected ast kind `%s`.',
+            selection.kind,
+          );
+      }
+    }
+    return true;
+  }
+
+  _readClientSideDirectiveField(
+    selection: ReaderRequiredField | ReaderCatchField,
+    record: Record,
+    data: SelectorData,
+  ): ?unknown {
+    switch (selection.field.kind) {
+      case 'ScalarField':
+        return this._readScalar(selection.field, record, data);
+      case 'LinkedField':
+        if (selection.field.plural) {
+          return this._readPluralLink(selection.field, record, data);
+        } else {
+          return this._readLink(selection.field, record, data);
+        }
+
+      case 'RelayResolver':
+      case 'RelayLiveResolver': {
+        if (this._useExecTimeResolvers) {
+          return this._readScalar(selection.field, record, data);
+        } else {
+          return this._readResolverField(selection.field, record, data);
+        }
+      }
+      case 'ClientEdgeToClientObject':
+      case 'ClientEdgeToServerObject':
+        if (
+          this._useExecTimeResolvers &&
+          (selection.field.backingField.kind === 'RelayResolver' ||
+            selection.field.backingField.kind === 'RelayLiveResolver')
+        ) {
+          const {field} = selection;
+          if (field.linkedField.plural) {
+            return this._readPluralLink(field.linkedField, record, data);
+          } else {
+            return this._readLink(field.linkedField, record, data);
+          }
+        } else {
+          return this._readClientEdge(selection.field, record, data);
+        }
+      case 'AliasedInlineFragmentSpread':
+        return this._readAliasedInlineFragment(selection.field, record, data);
+      default:
+        selection.field.kind as empty;
+        invariant(
+          false,
+          'RelayReader(): Unexpected ast kind `%s`.',
+          selection.field.kind,
+        );
+    }
+  }
+
+  _readResolverField(
+    field: ReaderRelayResolver | ReaderRelayLiveResolver,
+    record: Record,
+    data: SelectorData,
+  ): unknown {
+    const parentRecordID = RelayModernRecord.getDataID(record);
+    const prevErrors = this._fieldErrors;
+    this._fieldErrors = null;
+    const result = this._readResolverFieldImpl(field, parentRecordID);
+
+    const fieldName = field.alias ?? field.name;
+    this._prependPreviousErrors(prevErrors, fieldName);
+    data[fieldName] = result;
+    return result;
+  }
+
+  _readResolverFieldImpl(
+    field: ReaderRelayResolver | ReaderRelayLiveResolver,
+    parentRecordID: DataID,
+  ): unknown {
+    const {fragment} = field;
+
+    // Found when reading the resolver fragment, which can happen either when
+    // evaluating the resolver and it calls readFragment, or when checking if the
+    // inputs have changed since a previous evaluation:
+    let snapshot: ?Snapshot;
+
+    // The function `getDataForResolverFragment` serves two purposes:
+    // 1. To memoize reads of the resolver's root fragment. This is important
+    //    because we may read it twice. Once to check if the results have changed
+    //    since last read, and once when we actually evaluate.
+    // 2. To intercept the snapshot so that it can be cached by the resolver
+    //    cache. This is what enables the change detection described in #1.
+    //
+    // Note: In the future this can be moved into the ResolverCache.
+    const getDataForResolverFragment = (
+      singularReaderSelector: SingularReaderSelector,
+    ) => {
+      if (snapshot != null) {
+        // It was already read when checking for input staleness; no need to read it again.
+        // Note that the variables like fragmentSeenRecordIDs in the outer closure will have
+        // already been set and will still be used in this case.
+        return {
+          data: snapshot.data,
+          fieldErrors: snapshot.fieldErrors,
+          isMissingData: snapshot.isMissingData,
+        };
+      }
+
+      snapshot = read(
+        this._recordSource,
+        singularReaderSelector,
+        // This reads data for a rootFragment in read time resolvers. There is no fragment
+        // spread created for it so the existing fragment spread logger can't be used to log
+        // unused rootFragments. Thus we skip passing the logger here for now.
+        null,
+        this._resolverCache,
+        undefined,
+      );
+
+      return {
+        data: snapshot.data,
+        fieldErrors: snapshot.fieldErrors,
+        isMissingData: snapshot.isMissingData,
+      };
+    };
+
+    // This function `evaluate` tells the resolver cache how to read this
+    // resolver. It returns an `EvaluationResult` which gives the resolver cache:
+    // * `resolverResult` The value returned by the resolver function
+    // * `snapshot` The snapshot returned when reading the resolver's root fragment (if it has one)
+    // * `error` If the resolver throws, its error is caught (inside
+    //   `getResolverValue`) and converted into an error object.
+    const evaluate = (): EvaluationResult<unknown> => {
+      if (fragment != null) {
+        const key: SelectorData = {
+          __fragmentOwner: this._owner,
+          __fragments: {
+            [fragment.name]: fragment.args
+              ? getArgumentValues(fragment.args, this._variables)
+              : {},
+          },
+          __id: parentRecordID,
+        };
+        if (
+          this._clientEdgeTraversalPath.length > 0 &&
+          this._clientEdgeTraversalPath[
+            this._clientEdgeTraversalPath.length - 1
+          ] !== null
+        ) {
+          key[CLIENT_EDGE_TRAVERSAL_PATH] = [...this._clientEdgeTraversalPath];
+        }
+        const resolverContext = {getDataForResolverFragment};
+        // $FlowFixMe[incompatible-type]
+        return withResolverContext(resolverContext, () => {
+          const [resolverResult, resolverError] = getResolverValue(
+            field,
+            this._variables,
+            key,
+            this._resolverContext,
+          );
+          return {error: resolverError, resolverResult, snapshot};
+        });
+      } else {
+        const [resolverResult, resolverError] = getResolverValue(
+          field,
+          this._variables,
+          null,
+          this._resolverContext,
+        );
+        return {error: resolverError, resolverResult, snapshot: undefined};
+      }
+    };
+
+    const [
+      result,
+      seenRecord,
+      resolverError,
+      cachedSnapshot,
+      suspenseID,
+      updatedDataIDs,
+    ] = this._resolverCache.readFromCacheOrEvaluate(
+      parentRecordID,
+      field,
+      this._variables,
+      evaluate,
+      getDataForResolverFragment,
+    );
+
+    this._propagateResolverMetadata(
+      field.path,
+      cachedSnapshot,
+      resolverError,
+      seenRecord,
+      suspenseID,
+      updatedDataIDs,
+    );
+
+    return result;
+  }
+
+  // Reading a resolver field can uncover missing data, errors, suspense,
+  // additional seen records and updated dataIDs. All of these facts must be
+  // represented in the snapshot we return for this fragment.
+  _propagateResolverMetadata(
+    fieldPath: string,
+    cachedSnapshot: ?Snapshot,
+    resolverError: ?Error,
+    seenRecord: ?DataID,
+    suspenseID: ?DataID,
+    updatedDataIDs: ?DataIDSet,
+  ) {
+    // The resolver's root fragment (if there is one) may be missing data, have
+    // errors, or be in a suspended state. Here we propagate those cases
+    // upwards to mimic the behavior of having traversed into that fragment directly.
+    if (cachedSnapshot != null) {
+      if (cachedSnapshot.missingClientEdges != null) {
+        for (let i = 0; i < cachedSnapshot.missingClientEdges.length; i++) {
+          const missing = cachedSnapshot.missingClientEdges[i];
+          this._missingClientEdges.push(missing);
+        }
+      }
+      if (cachedSnapshot.missingLiveResolverFields != null) {
+        this._isMissingData =
+          this._isMissingData ||
+          cachedSnapshot.missingLiveResolverFields.length > 0;
+
+        for (
+          let i = 0;
+          i < cachedSnapshot.missingLiveResolverFields.length;
+          i++
+        ) {
+          const missingResolverField =
+            cachedSnapshot.missingLiveResolverFields[i];
+          this._missingLiveResolverFields.push(missingResolverField);
+        }
+      }
+      if (cachedSnapshot.fieldErrors != null) {
+        if (this._fieldErrors == null) {
+          this._fieldErrors = [];
+        }
+        for (let i = 0; i < cachedSnapshot.fieldErrors.length; i++) {
+          const error = cachedSnapshot.fieldErrors[i];
+          if (this._selector.node.metadata?.throwOnFieldError === true) {
+            // If this fragment is @throwOnFieldError, any destructive error
+            // encountered inside a resolver's fragment is equivilent to the
+            // resolver field having a field error, and we want that to cause this
+            // fragment to throw. So, we propagate all errors as is.
+            this._fieldErrors.push(error);
+          } else {
+            // If this fragment is _not_ @throwOnFieldError, we will simply
+            // accept that any destructive errors encountered in the resolver's
+            // root fragment will cause the resolver to return null, and well
+            // pass the errors along to the logger marked as "handled".
+            this._fieldErrors.push(markFieldErrorHasHandled(error));
+          }
+        }
+      }
+      this._isMissingData = this._isMissingData || cachedSnapshot.isMissingData;
+    }
+
+    // If the resolver errored, we track that as part of our traversal so that
+    // the errors can be attached to this read's snapshot. This allows the error
+    // to be logged.
+    if (resolverError) {
+      const errorEvent: FieldError = {
+        error: resolverError,
+        fieldPath,
+        handled: false,
+        kind: 'relay_resolver.error',
+        owner: this._fragmentName,
+        shouldThrow: this._selector.node.metadata?.throwOnFieldError ?? false,
+        // the uiContext is always undefined here.
+        // the loggingContext is provided by hooks - and assigned to uiContext in handlePotentialSnapshotErrors
+        uiContext: undefined,
+      };
+      if (this._fieldErrors == null) {
+        this._fieldErrors = [errorEvent];
+      } else {
+        this._fieldErrors.push(errorEvent);
+      }
+    }
+
+    // The resolver itself creates a record in the store. We record that we've
+    // read this record so that subscribers to this snapshot also subscribe to
+    // this resolver.
+    if (seenRecord != null) {
+      this._seenRecords.add(seenRecord);
+    }
+
+    // If this resolver, or a dependency of this resolver, has suspended, we
+    // need to report that in our snapshot. The `suspenseID` is the key in to
+    // store where the suspended LiveState value lives. This ID allows readers
+    // of the snapshot to subscribe to updates on that live resolver so that
+    // they know when to unsuspend.
+    if (suspenseID != null) {
+      this._isMissingData = true;
+      this._missingLiveResolverFields.push(suspenseID);
+    }
+    if (updatedDataIDs != null) {
+      // Iterating a Set with for of is okay
+      // eslint-disable-next-line relay-internal/no-for-of-loops
+      updatedDataIDs.forEach(recordID => {
+        this._updatedDataIDs.add(recordID);
+      });
+    }
+  }
+
+  _readClientEdge(
+    field: ReaderClientEdge,
+    record: Record,
+    data: SelectorData,
+  ): ?unknown {
+    const backingField = field.backingField;
+
+    // Because ReaderClientExtension doesn't have `alias` or `name` and so I don't know
+    // how to get its fieldName or storageKey yet:
+    invariant(
+      backingField.kind !== 'ClientExtension',
+      'Client extension client edges are not yet implemented.',
+    );
+
+    const fieldName = backingField.alias ?? backingField.name;
+    const backingFieldData = {};
+    this._traverseSelections([backingField], record, backingFieldData);
+    // At this point, backingFieldData is an object with a single key (fieldName)
+    // whose value is the value returned from the resolver, or a suspense sentinel.
+
+    // $FlowFixMe[invalid-computed-prop]
+    const clientEdgeResolverResponse = backingFieldData[fieldName];
+    if (
+      clientEdgeResolverResponse == null ||
+      isSuspenseSentinel(clientEdgeResolverResponse)
+    ) {
+      data[fieldName] = clientEdgeResolverResponse;
+      return clientEdgeResolverResponse;
+    }
+
+    if (field.linkedField.plural) {
+      invariant(
+        Array.isArray(clientEdgeResolverResponse),
+        'Expected plural Client Edge Relay Resolver at `%s` in `%s` to return an array containing IDs or objects with shape {id}.',
+        backingField.path,
+        this._owner.identifier,
+      );
+      let storeIDs: ReadonlyArray<DataID>;
+      invariant(
+        field.kind === 'ClientEdgeToClientObject',
+        'Unexpected Client Edge to plural server type `%s`. This should be prevented by the compiler.',
+        field.kind,
+      );
+      if (field.backingField.normalizationInfo == null) {
+        // @edgeTo case where we need to ensure that the record has `id` field
+        storeIDs = clientEdgeResolverResponse.map(itemResponse => {
+          const concreteType = field.concreteType ?? itemResponse.__typename;
+          invariant(
+            typeof concreteType === 'string',
+            'Expected resolver for field at `%s` in `%s` modeling an edge to an abstract type to return an object with a `__typename` property.',
+            backingField.path,
+            this._owner.identifier,
+          );
+          const localId = extractIdFromResponse(
+            itemResponse,
+            backingField.path,
+            this._owner.identifier,
+          );
+          const id = this._resolverCache.ensureClientRecord(
+            localId,
+            concreteType,
+          );
+
+          const modelResolvers = field.modelResolvers;
+          if (modelResolvers != null) {
+            const modelResolver = modelResolvers[concreteType];
+            invariant(
+              modelResolver !== undefined,
+              'Invalid `__typename` returned by resolver at `%s` in `%s`. Expected one of %s but got `%s`.',
+              backingField.path,
+              this._owner.identifier,
+              Object.keys(modelResolvers).join(', '),
+              concreteType,
+            );
+            const model = this._readResolverFieldImpl(modelResolver, id);
+            return model != null ? id : null;
+          }
+          return id;
+        });
+      } else {
+        // The normalization process in LiveResolverCache should take care of generating the correct ID.
+        storeIDs = clientEdgeResolverResponse.map(obj =>
+          extractIdFromResponse(obj, backingField.path, this._owner.identifier),
+        );
+      }
+      this._clientEdgeTraversalPath.push(null);
+      const edgeValues = this._readLinkedIds(
+        field.linkedField,
+        storeIDs,
+        record,
+        data,
+      );
+      this._clientEdgeTraversalPath.pop();
+      data[fieldName] = edgeValues;
+      return edgeValues;
+    } else {
+      const id = extractIdFromResponse(
+        clientEdgeResolverResponse,
+        backingField.path,
+        this._owner.identifier,
+      );
+      let storeID: DataID;
+      const concreteType =
+        field.concreteType ?? clientEdgeResolverResponse.__typename;
+      let traversalPathSegment: ClientEdgeTraversalInfo | null;
+      if (field.kind === 'ClientEdgeToClientObject') {
+        if (field.backingField.normalizationInfo == null) {
+          invariant(
+            typeof concreteType === 'string',
+            'Expected resolver for field at `%s` in `%s` modeling an edge to an abstract type to return an object with a `__typename` property.',
+            backingField.path,
+            this._owner.identifier,
+          );
+          // @edgeTo case where we need to ensure that the record has `id` field
+          storeID = this._resolverCache.ensureClientRecord(id, concreteType);
+          traversalPathSegment = null;
+        } else {
+          // The normalization process in LiveResolverCache should take care of generating the correct ID.
+          storeID = id;
+          traversalPathSegment = null;
+        }
+      } else {
+        storeID = id;
+        traversalPathSegment = {
+          clientEdgeDestinationID: id,
+          readerClientEdge: field,
+        };
+      }
+
+      const modelResolvers = field.modelResolvers;
+      if (modelResolvers != null) {
+        invariant(
+          typeof concreteType === 'string',
+          'Expected resolver for field at `%s` in `%s` modeling an edge to an abstract type to return an object with a `__typename` property.',
+          backingField.path,
+          this._owner.identifier,
+        );
+        const modelResolver = modelResolvers[concreteType];
+        invariant(
+          modelResolver !== undefined,
+          'Invalid `__typename` returned by resolver at `%s` in `%s`. Expected one of %s but got `%s`.',
+          backingField.path,
+          this._owner.identifier,
+          Object.keys(modelResolvers).join(', '),
+          concreteType,
+        );
+        const model = this._readResolverFieldImpl(modelResolver, storeID);
+        if (model == null) {
+          // If the model resolver returns undefined, we should still return null
+          // to match GQL behavior.
+          data[fieldName] = null;
+          return null;
+        }
+      }
+      this._clientEdgeTraversalPath.push(traversalPathSegment);
+
+      const prevData = data[fieldName];
+      invariant(
+        prevData == null || typeof prevData === 'object',
+        'RelayReader(): Expected data for field at `%s` in `%s` on record `%s` ' +
+          'to be an object, got `%s`.',
+        backingField.path,
+        this._owner.identifier,
+        RelayModernRecord.getDataID(record),
+        prevData,
+      );
+      const prevErrors = this._fieldErrors;
+      this._fieldErrors = null;
+      const edgeValue = this._traverse(
+        field.linkedField,
+        storeID,
+        // $FlowFixMe[incompatible-variance]
+        prevData,
+      );
+      this._prependPreviousErrors(prevErrors, fieldName);
+      this._clientEdgeTraversalPath.pop();
+      data[fieldName] = edgeValue;
+      return edgeValue;
+    }
+  }
+
+  _readScalar(
+    field: ReaderScalarField | ReaderRelayResolver | ReaderRelayLiveResolver,
+    record: Record,
+    data: SelectorData,
+  ): ?unknown {
+    const fieldName = field.alias ?? field.name;
+    const storageKey = getStorageKey(field, this._variables);
+    if (this._fieldGranularNotificationDataID != null) {
+      this._seenRecords.add(
+        getFieldNotificationKey(
+          this._fieldGranularNotificationDataID,
+          storageKey,
+        ),
+      );
+    }
+    const value = RelayModernRecord.getValue(record, storageKey);
+    if (
+      value === null ||
+      (RelayFeatureFlags.ENABLE_NONCOMPLIANT_ERROR_HANDLING_ON_LISTS &&
+        Array.isArray(value) &&
+        value.length === 0)
+    ) {
+      this._maybeAddFieldErrors(record, storageKey);
+    } else if (value === undefined) {
+      this._markDataAsMissing(fieldName);
+    }
+    data[fieldName] = value;
+    return value;
+  }
+
+  _readLink(
+    field: ReaderLinkedField,
+    record: Record,
+    data: SelectorData,
+  ): ?unknown {
+    const fieldName = field.alias ?? field.name;
+    const storageKey = getStorageKey(field, this._variables);
+    if (this._fieldGranularNotificationDataID != null) {
+      this._seenRecords.add(
+        getFieldNotificationKey(
+          this._fieldGranularNotificationDataID,
+          storageKey,
+        ),
+      );
+    }
+    const linkedID = RelayModernRecord.getLinkedRecordID(record, storageKey);
+    if (linkedID == null) {
+      data[fieldName] = linkedID;
+      if (linkedID === null) {
+        this._maybeAddFieldErrors(record, storageKey);
+      } else if (linkedID === undefined) {
+        this._markDataAsMissing(fieldName);
+      }
+      return linkedID;
+    }
+
+    const prevData = data[fieldName];
+    invariant(
+      prevData == null || typeof prevData === 'object',
+      'RelayReader(): Expected data for field `%s` at `%s` on record `%s` ' +
+        'to be an object, got `%s`.',
+      fieldName,
+      this._owner.identifier,
+      RelayModernRecord.getDataID(record),
+      prevData,
+    );
+    const prevErrors = this._fieldErrors;
+    this._fieldErrors = null;
+    // $FlowFixMe[incompatible-variance]
+    const value = this._traverse(field, linkedID, prevData);
+
+    this._prependPreviousErrors(prevErrors, fieldName);
+    data[fieldName] = value;
+    return value;
+  }
+
+  /**
+   * Adds a set of field errors to `this._fieldErrors`, ensuring the
+   * `fieldPath` property of existing field errors are prefixed with the given
+   * `fieldNameOrIndex`.
+   *
+   * In order to make field errors maximally useful in logs/errors, we want to
+   * include the path to the field that caused the error. A naive approach would
+   * be to maintain a path property on RelayReader which we push/pop field names
+   * to as we traverse into fields/etc. However, this would be expensive to
+   * maintain, and in the common case where there are no field errors, the work
+   * would go unused.
+   *
+   * Instead, we take a lazy approach where as we exit the recurison into a
+   * field/etc we prepend any errors encountered while traversing that field
+   * with the field name. This is somewhat more expensive in the error case, but
+   * ~free in the common case where there are no errors.
+   *
+   * To achieve this, named field readers must do the following to correctly
+   * track error filePaths:
+   *
+   * 1. Stash the value of `this._fieldErrors` in a local variable
+   * 2. Set `this._fieldErrors` to `null`
+   * 3. Traverse into the field
+   * 4. Call this method with the stashed errors and the field's name
+   *
+   * Similarly, when creating field errors, we simply initialize the `fieldPath`
+   * as the direct field name.
+   *
+   * Today we only use this apporach for `missing_expected_data` and
+   * `missing_required_field` errors, but we intend to broaden it to handle all
+   * field error paths.
+   */
+  _prependPreviousErrors(
+    prevErrors: ?Array<FieldError>,
+    fieldNameOrIndex: string | number,
+  ): void {
+    if (this._fieldErrors != null) {
+      for (let i = 0; i < this._fieldErrors.length; i++) {
+        const event = this._fieldErrors[i];
+        if (
+          event.owner === this._fragmentName &&
+          (event.kind === 'missing_expected_data.throw' ||
+            event.kind === 'missing_expected_data.log' ||
+            event.kind === 'missing_required_field.throw' ||
+            event.kind === 'missing_required_field.log')
+        ) {
+          event.fieldPath = `${fieldNameOrIndex}.${event.fieldPath}`;
+        }
+      }
+      if (prevErrors != null) {
+        for (let i = this._fieldErrors.length - 1; i >= 0; i--) {
+          prevErrors.push(this._fieldErrors[i]);
+        }
+        this._fieldErrors = prevErrors;
+      }
+    } else {
+      this._fieldErrors = prevErrors;
+    }
+  }
+
+  _readActorChange(
+    field: ReaderActorChange,
+    record: Record,
+    data: SelectorData,
+  ): ?unknown {
+    const fieldName = field.alias ?? field.name;
+    const storageKey = getStorageKey(field, this._variables);
+    const externalRef = RelayModernRecord.getActorLinkedRecordID(
+      record,
+      storageKey,
+    );
+
+    if (externalRef == null) {
+      data[fieldName] = externalRef;
+      if (externalRef === undefined) {
+        this._markDataAsMissing(fieldName);
+      } else if (externalRef === null) {
+        this._maybeAddFieldErrors(record, storageKey);
+      }
+      return data[fieldName];
+    }
+    const [actorIdentifier, dataID] = externalRef;
+
+    const fragmentRef = {};
+    this._createFragmentPointer(
+      field.fragmentSpread,
+      RelayModernRecord.fromObject<>({
+        __id: dataID,
+      }),
+      fragmentRef,
+    );
+    data[fieldName] = {
+      __fragmentRef: fragmentRef,
+      __viewer: actorIdentifier,
+    };
+    return data[fieldName];
+  }
+
+  _readPluralLink(
+    field: ReaderLinkedField,
+    record: Record,
+    data: SelectorData,
+  ): ?unknown {
+    const storageKey = getStorageKey(field, this._variables);
+    if (this._fieldGranularNotificationDataID != null) {
+      this._seenRecords.add(
+        getFieldNotificationKey(
+          this._fieldGranularNotificationDataID,
+          storageKey,
+        ),
+      );
+    }
+    const linkedIDs = RelayModernRecord.getLinkedRecordIDs(record, storageKey);
+    if (
+      linkedIDs === null ||
+      (RelayFeatureFlags.ENABLE_NONCOMPLIANT_ERROR_HANDLING_ON_LISTS &&
+        Array.isArray(linkedIDs) &&
+        linkedIDs.length === 0)
+    ) {
+      this._maybeAddFieldErrors(record, storageKey);
+    }
+    return this._readLinkedIds(field, linkedIDs, record, data);
+  }
+
+  _readLinkedIds(
+    field: ReaderLinkedField,
+    linkedIDs: ?ReadonlyArray<?DataID>,
+    record: Record,
+    data: SelectorData,
+  ): ?unknown {
+    const fieldName = field.alias ?? field.name;
+
+    if (linkedIDs == null) {
+      data[fieldName] = linkedIDs;
+      if (linkedIDs === undefined) {
+        this._markDataAsMissing(fieldName);
+      }
+      return linkedIDs;
+    }
+
+    const prevData = data[fieldName];
+    invariant(
+      prevData == null || Array.isArray(prevData),
+      'RelayReader(): Expected data for field `%s` on record `%s` ' +
+        'to be an array, got `%s`.',
+      fieldName,
+      RelayModernRecord.getDataID(record),
+      prevData,
+    );
+    const prevErrors = this._fieldErrors;
+    this._fieldErrors = null;
+    const linkedArray = prevData || [];
+    linkedIDs.forEach((linkedID, nextIndex) => {
+      if (linkedID == null) {
+        if (linkedID === undefined) {
+          this._markDataAsMissing(String(nextIndex));
+        }
+        // $FlowFixMe[cannot-write]
+        linkedArray[nextIndex] = linkedID;
+        return;
+      }
+      const prevItem = linkedArray[nextIndex];
+      invariant(
+        prevItem == null || typeof prevItem === 'object',
+        'RelayReader(): Expected data for field `%s` on record `%s` ' +
+          'to be an object, got `%s`.',
+        fieldName,
+        RelayModernRecord.getDataID(record),
+        prevItem,
+      );
+      const prevErrors = this._fieldErrors;
+      this._fieldErrors = null;
+      // $FlowFixMe[cannot-write]
+      // $FlowFixMe[incompatible-variance]
+      linkedArray[nextIndex] = this._traverse(field, linkedID, prevItem);
+      this._prependPreviousErrors(prevErrors, nextIndex);
+    });
+    this._prependPreviousErrors(prevErrors, fieldName);
+    data[fieldName] = linkedArray;
+    return linkedArray;
+  }
+
+  /**
+   * Reads a ReaderModuleImport, which was generated from using the @module
+   * directive.
+   */
+  _readModuleImport(
+    moduleImport: ReaderModuleImport,
+    record: Record,
+    data: SelectorData,
+  ): void {
+    // Determine the component module from the store: if the field is missing
+    // it means we don't know what component to render the match with.
+    const componentKey = getModuleComponentKey(moduleImport.documentName);
+    const relayStoreComponent = RelayModernRecord.getValue(
+      record,
+      componentKey,
+    );
+    // componentModuleProvider is used by Client 3D for read time resolvers.
+    const component =
+      relayStoreComponent !== undefined
+        ? relayStoreComponent
+        : moduleImport.componentModuleProvider;
+    if (component == null) {
+      if (component === undefined) {
+        this._markDataAsMissing('<module-import>');
+      }
+      return;
+    }
+
+    // Otherwise, read the fragment and module associated to the concrete
+    // type, and put that data with the result:
+    // - For the matched fragment, create the relevant fragment pointer and add
+    //   the expected fragmentPropName
+    // - For the matched module, create a reference to the module
+    this._createFragmentPointer(
+      {
+        args: moduleImport.args,
+        kind: 'FragmentSpread',
+        name: moduleImport.fragmentName,
+      },
+      record,
+      data,
+    );
+    data[FRAGMENT_PROP_NAME_KEY] = moduleImport.fragmentPropName;
+    data[MODULE_COMPONENT_KEY] = component;
+  }
+
+  /**
+   * Aliased inline fragments allow the user to check if the data in an inline
+   * fragment was fetched. Data in the inline fragment can be conditional in the
+   * case of a type condition on the inline fragment or directives like `@skip`
+   * or `@include`.
+   *
+   * We model aliased inline fragments as a special reader node wrapped around a
+   * regular inline fragment reader node.
+   *
+   * This allows us to read the inline fragment as normal, check if it matched,
+   * and then define the alias to either contain the inline fragment's data, or
+   * null.
+   */
+  _readAliasedInlineFragment(
+    aliasedInlineFragment: ReaderAliasedInlineFragmentSpread,
+    record: Record,
+    data: SelectorData,
+  ): ?unknown {
+    const prevErrors = this._fieldErrors;
+    this._fieldErrors = null;
+    let fieldValue = this._readInlineFragment(
+      aliasedInlineFragment.fragment,
+      record,
+      {},
+      true,
+    );
+    this._prependPreviousErrors(prevErrors, aliasedInlineFragment.name);
+    if (fieldValue === false) {
+      fieldValue = null;
+    }
+    data[aliasedInlineFragment.name] = fieldValue;
+    return fieldValue;
+  }
+
+  // Has three possible return values:
+  // * null: The type condition did not match
+  // * undefined: We are missing data
+  // * false: The selection contained missing @required fields
+  // * data: The successfully populated SelectorData object
+  //
+  // The `skipUnmatchedAbstractTypes` flag is used to signal if we should skip
+  // reading the contents of an inline fragment on an abstract type if we _know_
+  // the type condition does not match.
+  _readInlineFragment(
+    inlineFragment: ReaderInlineFragment,
+    record: Record,
+    data: SelectorData,
+    skipUnmatchedAbstractTypes: boolean,
+  ): ?(SelectorData | false) {
+    if (inlineFragment.type == null) {
+      // Inline fragment without a type condition: always read data
+      // Usually this would get compiled away, but fragments with @alias
+      // and no type condition will get preserved.
+      const hasExpectedData = this._traverseSelections(
+        inlineFragment.selections,
+        record,
+        data,
+      );
+      if (hasExpectedData === false) {
+        return false;
+      }
+      return data;
+    }
+    const {abstractKey} = inlineFragment;
+    if (abstractKey == null) {
+      // concrete type refinement: only read data if the type exactly matches
+      if (!this._recordMatchesTypeCondition(record, inlineFragment.type)) {
+        // This selection does not match the fragment spread. Do nothing.
+        return null;
+      } else {
+        const hasExpectedData = this._traverseSelections(
+          inlineFragment.selections,
+          record,
+          data,
+        );
+        if (!hasExpectedData) {
+          // Bubble up null due to a missing @required field
+          return false;
+        }
+      }
+    } else {
+      const implementsInterface = this._implementsInterface(
+        record,
+        abstractKey,
+      );
+
+      if (implementsInterface === false && skipUnmatchedAbstractTypes) {
+        return null;
+      }
+
+      // store flags to reset after reading
+      const parentIsMissingData = this._isMissingData;
+      const parentIsWithinUnmatchedTypeRefinement =
+        this._isWithinUnmatchedTypeRefinement;
+
+      this._isWithinUnmatchedTypeRefinement =
+        parentIsWithinUnmatchedTypeRefinement || implementsInterface === false;
+
+      // @required is allowed within inline fragments on abstract types if they
+      // have @alias. So we must bubble up null if we have a missing @required
+      // field.
+      const hasMissingData = this._traverseSelections(
+        inlineFragment.selections,
+        record,
+        data,
+      );
+
+      // Reset
+      this._isWithinUnmatchedTypeRefinement =
+        parentIsWithinUnmatchedTypeRefinement;
+
+      if (implementsInterface === false) {
+        // Type known to not implement the interface, no data expected
+        this._isMissingData = parentIsMissingData;
+        return null;
+      } else if (implementsInterface == null) {
+        // Don't know if the type implements the interface or not
+        return undefined;
+      } else if (hasMissingData === false) {
+        // Bubble up null due to a missing @required field
+        return false;
+      }
+    }
+    return data;
+  }
+
+  _recordMatchesTypeCondition(record: Record, type: string): boolean {
+    const typeName = RelayModernRecord.getType(record);
+    return (
+      (typeName != null && typeName === type) ||
+      // The root record type is a special `__Root` type and may not match the
+      // type on the ast, so ignore type mismatches at the root.  We currently
+      // detect whether we're at the root by checking against ROOT_ID, but this
+      // does not work for mutations/subscriptions which generate unique root
+      // ids. This is acceptable in practice as we don't read data for
+      // mutations/subscriptions in a situation where we would use
+      // isMissingData to decide whether to suspend or not.
+      // TODO T96653810: Correctly detect reading from root of mutation/subscription
+      RelayModernRecord.getDataID(record) === ROOT_ID
+    );
+  }
+
+  _createFragmentPointer(
+    fragmentSpread: ReaderFragmentSpread,
+    record: Record,
+    data: SelectorData,
+  ): void {
+    let fragmentPointers = data[FRAGMENTS_KEY];
+    if (fragmentPointers == null) {
+      fragmentPointers = data[FRAGMENTS_KEY] = {} as {
+        [string]: Arguments,
+      };
+    }
+    invariant(
+      typeof fragmentPointers === 'object' && fragmentPointers != null,
+      'RelayReader: Expected fragment spread data to be an object, got `%s`.',
+      fragmentPointers,
+    );
+
+    if (data[ID_KEY] == null) {
+      data[ID_KEY] = RelayModernRecord.getDataID(record);
+    }
+    const args = getArgumentValues(
+      fragmentSpread.args,
+      this._variables,
+      this._isWithinUnmatchedTypeRefinement,
+    );
+    // $FlowFixMe[cannot-write] - writing into read-only field
+    fragmentPointers[fragmentSpread.name] = args;
+    data[FRAGMENT_OWNER_KEY] = this._owner;
+
+    if (
+      this._clientEdgeTraversalPath.length > 0 &&
+      this._clientEdgeTraversalPath[
+        this._clientEdgeTraversalPath.length - 1
+      ] !== null
+    ) {
+      data[CLIENT_EDGE_TRAVERSAL_PATH] = [...this._clientEdgeTraversalPath];
+    }
+
+    if (RelayFeatureFlags.ENABLE_READER_FRAGMENTS_LOGGING) {
+      this._log?.({
+        name: 'reader.fragmentSpread',
+        fragmentName: fragmentSpread.name,
+        data,
+      });
+    }
+  }
+
+  _createInlineDataOrResolverFragmentPointer(
+    fragmentSpreadOrFragment: ReaderInlineDataFragmentSpread | ReaderFragment,
+    record: Record,
+    data: SelectorData,
+  ): void {
+    let fragmentPointers = data[FRAGMENTS_KEY];
+    if (fragmentPointers == null) {
+      fragmentPointers = data[FRAGMENTS_KEY] = {} as {[string]: {...}};
+    }
+    invariant(
+      typeof fragmentPointers === 'object' && fragmentPointers != null,
+      'RelayReader: Expected fragment spread data to be an object, got `%s`.',
+      fragmentPointers,
+    );
+    if (data[ID_KEY] == null) {
+      data[ID_KEY] = RelayModernRecord.getDataID(record);
+    }
+    const inlineData = {};
+    const parentFragmentName = this._fragmentName;
+    this._fragmentName = fragmentSpreadOrFragment.name;
+
+    const parentVariables = this._variables;
+
+    // If the inline fragment spread has arguments, we need to temporarily
+    // switch this._variables to include the fragment spread's arguments
+    // for the duration of its traversal.
+    const argumentVariables = fragmentSpreadOrFragment.args
+      ? getArgumentValues(fragmentSpreadOrFragment.args, this._variables)
+      : {};
+
+    this._variables = RelayConcreteVariables.getFragmentVariables(
+      fragmentSpreadOrFragment,
+      this._owner.variables,
+      argumentVariables,
+    );
+
+    this._traverseSelections(
+      fragmentSpreadOrFragment.selections,
+      record,
+      inlineData,
+    );
+
+    // Put the parent variables back
+    this._variables = parentVariables;
+
+    this._fragmentName = parentFragmentName;
+    // $FlowFixMe[cannot-write] - writing into read-only field
+    fragmentPointers[fragmentSpreadOrFragment.name] = inlineData;
+  }
+
+  _implementsInterface(record: Record, abstractKey: string): ?boolean {
+    const typeName = RelayModernRecord.getType(record);
+    const typeRecord = this._recordSource.get(generateTypeID(typeName));
+    const implementsInterface =
+      typeRecord != null
+        ? RelayModernRecord.getValue(typeRecord, abstractKey)
+        : null;
+
+    if (implementsInterface == null) {
+      // In some cases, like a graph relationship change, we might have never
+      // fetched the `__is[AbstractType]` flag for this concrete type. In this
+      // case we need to report that we are missing data, in case that field is
+      // still in flight.
+      this._markDataAsMissing('<abstract-type-hint>');
+    }
+    // $FlowFixMe[incompatible-type] Casting record value
+    return implementsInterface;
+  }
+}
+
+function markFieldErrorHasHandled(event: FieldError): FieldError {
+  switch (event.kind) {
+    case 'missing_expected_data.throw':
+    case 'missing_required_field.throw':
+    case 'relay_field_payload.error':
+    case 'relay_resolver.error':
+      return {...event, handled: true};
+    case 'missing_expected_data.log':
+    case 'missing_required_field.log':
+      return event;
+    default:
+      event.kind as empty;
+      invariant(false, 'Unexpected error response field kind: %s', event.kind);
+  }
+}
+
+// Constructs the arguments for a resolver function and then evaluates it.
+//
+// If the resolver's fragment is missing data (query is in-flight, a dependency
+// field is suspending, or is missing required fields) then `readFragment` will
+// throw `RESOLVER_FRAGMENT_MISSING_DATA_SENTINEL`. This function ensures that
+// we catch that error and instead create an error object which can be
+// propagated to the reader snapshot.
+function getResolverValue(
+  field: ReaderRelayResolver | ReaderRelayLiveResolver,
+  variables: Variables,
+  fragmentKey: unknown,
+  resolverContext: ?ResolverContext,
+): [unknown, ?Error] {
+  // Support for languages that work (best) with ES6 modules, such as TypeScript.
+  const resolverFunction =
+    typeof field.resolverModule === 'function'
+      ? field.resolverModule
+      : field.resolverModule.default;
+
+  let resolverResult = null;
+  let resolverError = null;
+
+  try {
+    const resolverFunctionArgs = [];
+    if (field.fragment != null) {
+      resolverFunctionArgs.push(fragmentKey);
+    }
+    const args = field.args
+      ? getArgumentValues(field.args, variables)
+      : undefined;
+
+    resolverFunctionArgs.push(args);
+
+    resolverFunctionArgs.push(resolverContext);
+
+    resolverResult = resolverFunction.apply(null, resolverFunctionArgs);
+  } catch (e) {
+    // GraphQL coerces resolver errors to null or nullable fields, and Relay
+    // does not support non-nullable Relay Resolvers.
+    resolverResult = null;
+    if (e !== RESOLVER_FRAGMENT_ERRORED_SENTINEL) {
+      resolverError = e;
+    }
+  }
+  return [resolverResult, resolverError];
+}
+
+function extractIdFromResponse(
+  individualResponse: unknown,
+  path: string,
+  owner: string,
+): string {
+  if (typeof individualResponse === 'string') {
+    return individualResponse;
+  } else if (
+    typeof individualResponse === 'object' &&
+    individualResponse != null &&
+    typeof individualResponse.id === 'string'
+  ) {
+    return individualResponse.id;
+  }
+  invariant(
+    false,
+    'Expected object returned from edge resolver to be a string or an object with an `id` property at path %s in %s,',
+    path,
+    owner,
+  );
+}
+
+module.exports = {read};

--- a/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/store/RelayResponseNormalizer.js
+++ b/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/store/RelayResponseNormalizer.js
@@ -1,0 +1,980 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+import type {ActorIdentifier} from '../multi-actor-environment/ActorIdentifier';
+import type {PayloadData, PayloadError} from '../network/RelayNetworkTypes';
+import type {
+  NormalizationActorChange,
+  NormalizationClientEdgeToClientObject,
+  NormalizationDefer,
+  NormalizationInlineFragment,
+  NormalizationLinkedField,
+  NormalizationLiveResolverField,
+  NormalizationModuleImport,
+  NormalizationNode,
+  NormalizationResolverField,
+  NormalizationScalarField,
+  NormalizationStream,
+} from '../util/NormalizationNode';
+import type {DataID, Variables} from '../util/RelayRuntimeTypes';
+import type {RelayErrorTrie} from './RelayErrorTrie';
+import type {
+  FollowupPayload,
+  HandleFieldPayload,
+  IdCollisionTypenameLogEvent,
+  IncrementalDataPlaceholder,
+  LogFunction,
+  MutableRecordSource,
+  NormalizationSelector,
+  Record,
+  RelayResponsePayload,
+} from './RelayStoreTypes';
+
+const {
+  ACTOR_IDENTIFIER_FIELD_NAME,
+  getActorIdentifierFromPayload,
+} = require('../multi-actor-environment/ActorUtils');
+const RelayFeatureFlags = require('../util/RelayFeatureFlags');
+const {generateClientID, isClientID} = require('./ClientID');
+const {getLocalVariables} = require('./RelayConcreteVariables');
+const {
+  buildErrorTrie,
+  getErrorsByKey,
+  getNestedErrorTrieByKey,
+} = require('./RelayErrorTrie');
+const RelayModernRecord = require('./RelayModernRecord');
+const {createNormalizationSelector} = require('./RelayModernSelector');
+const {
+  ROOT_ID,
+  ROOT_TYPE,
+  TYPENAME_KEY,
+  getArgumentValues,
+  getHandleStorageKey,
+  getModuleComponentKey,
+  getModuleOperationKey,
+  getStorageKey,
+} = require('./RelayStoreUtils');
+const {TYPE_SCHEMA_TYPE, generateTypeID} = require('./TypeID');
+const areEqual = require('areEqual');
+const invariant = require('invariant');
+const warning = require('warning');
+
+export type GetDataID = (
+  fieldValue: {+[string]: unknown},
+  typeName: string,
+) => unknown;
+
+export type NormalizationOptions = {
+  +getDataID: GetDataID,
+  +treatMissingFieldsAsNull: boolean,
+  +deferDeduplicatedFields: boolean,
+  +log: ?LogFunction,
+  +path?: ReadonlyArray<string>,
+  +shouldProcessClientComponents?: ?boolean,
+  +actorIdentifier?: ?ActorIdentifier,
+};
+
+/**
+ * Normalizes the results of a query and standard GraphQL response, writing the
+ * normalized records/fields into the given MutableRecordSource.
+ */
+function normalize(
+  recordSource: MutableRecordSource,
+  selector: NormalizationSelector,
+  response: PayloadData,
+  options: NormalizationOptions,
+  errors?: Array<PayloadError>,
+  useExecTimeResolvers?: boolean,
+): RelayResponsePayload {
+  const {dataID, node, variables} = selector;
+  const normalizer = new RelayResponseNormalizer(
+    recordSource,
+    variables,
+    options,
+    useExecTimeResolvers ?? false,
+  );
+  return normalizer.normalizeResponse(node, dataID, response, errors);
+}
+
+/**
+ * @private
+ *
+ * Helper for handling payloads.
+ */
+class RelayResponseNormalizer {
+  _actorIdentifier: ?ActorIdentifier;
+  _getDataId: GetDataID;
+  _handleFieldPayloads: Array<HandleFieldPayload>;
+  _treatMissingFieldsAsNull: boolean;
+  _deferDeduplicatedFields: boolean;
+  _incrementalPlaceholders: Array<IncrementalDataPlaceholder>;
+  _isClientExtension: boolean;
+  _isUnmatchedAbstractType: boolean;
+  _followupPayloads: Array<FollowupPayload>;
+  _path: Array<string>;
+  _recordSource: MutableRecordSource;
+  _variables: Variables;
+  _useExecTimeResolvers: boolean;
+  _shouldProcessClientComponents: ?boolean;
+  _errorTrie: RelayErrorTrie | null;
+  _log: ?LogFunction;
+  _s2cExecutions: Map<
+    DataID,
+    {
+      selections: Array<
+        | NormalizationClientEdgeToClientObject
+        | NormalizationLiveResolverField
+        | NormalizationResolverField,
+      >,
+      typeName: string,
+    },
+  >;
+
+  constructor(
+    recordSource: MutableRecordSource,
+    variables: Variables,
+    options: NormalizationOptions,
+    useExecTimeResolvers: boolean,
+  ) {
+    this._actorIdentifier = options.actorIdentifier;
+    this._getDataId = options.getDataID;
+    this._handleFieldPayloads = [];
+    this._treatMissingFieldsAsNull = options.treatMissingFieldsAsNull;
+    this._deferDeduplicatedFields = options.deferDeduplicatedFields;
+    this._incrementalPlaceholders = [];
+    this._isClientExtension = false;
+    this._isUnmatchedAbstractType = false;
+    this._useExecTimeResolvers = useExecTimeResolvers;
+    this._followupPayloads = [];
+    this._path = options.path ? [...options.path] : [];
+    this._recordSource = recordSource;
+    this._variables = variables;
+    this._shouldProcessClientComponents = options.shouldProcessClientComponents;
+    this._log = options.log;
+    this._s2cExecutions = new Map();
+  }
+
+  normalizeResponse(
+    node: NormalizationNode,
+    dataID: DataID,
+    data: PayloadData,
+    errors?: Array<PayloadError>,
+  ): RelayResponsePayload {
+    const record = this._recordSource.get(dataID);
+    invariant(
+      record,
+      'RelayResponseNormalizer(): Expected root record `%s` to exist.',
+      dataID,
+    );
+    this._assignClientAbstractTypes(node);
+    this._errorTrie = buildErrorTrie(errors);
+    this._traverseSelections(node, record, data);
+    return {
+      errors,
+      fieldPayloads: this._handleFieldPayloads,
+      followupPayloads: this._followupPayloads,
+      incrementalPlaceholders: this._incrementalPlaceholders,
+      isFinal: false,
+      s2cExecutions:
+        this._s2cExecutions.size > 0
+          ? Array.from(this._s2cExecutions.entries()).map(
+              ([recordID, entry]) => ({
+                recordID,
+                selections: entry.selections,
+                typeName: entry.typeName,
+              }),
+            )
+          : undefined,
+      source: this._recordSource,
+    };
+  }
+
+  // For abstract types defined in the client schema extension, we won't be
+  // getting `__is<AbstractType>` hints from the server. To handle this, the
+  // compiler attaches additional metadata on the normalization artifact,
+  // which we need to record into the store.
+  _assignClientAbstractTypes(node: NormalizationNode) {
+    const {clientAbstractTypes} = node;
+    if (clientAbstractTypes != null) {
+      for (const abstractType of Object.keys(clientAbstractTypes)) {
+        for (const concreteType of clientAbstractTypes[abstractType]) {
+          const typeID = generateTypeID(concreteType);
+          let typeRecord = this._recordSource.get(typeID);
+          if (typeRecord == null) {
+            typeRecord = RelayModernRecord.create(typeID, TYPE_SCHEMA_TYPE);
+            this._recordSource.set(typeID, typeRecord);
+          }
+          RelayModernRecord.setValue(typeRecord, abstractType, true);
+        }
+      }
+    }
+  }
+
+  _getVariableValue(name: string): unknown {
+    invariant(
+      this._variables.hasOwnProperty(name),
+      'RelayResponseNormalizer(): Undefined variable `%s`.',
+      name,
+    );
+    return this._variables[name];
+  }
+
+  _getRecordType(data: PayloadData): string {
+    const typeName = (data as any)[TYPENAME_KEY];
+    invariant(
+      typeName != null,
+      'RelayResponseNormalizer(): Expected a typename for record `%s`.',
+      JSON.stringify(data, null, 2),
+    );
+    return typeName;
+  }
+
+  _traverseSelections(
+    node: NormalizationNode,
+    record: Record,
+    data: PayloadData,
+  ): void {
+    for (let i = 0; i < node.selections.length; i++) {
+      const selection = node.selections[i];
+      switch (selection.kind) {
+        case 'ScalarField':
+        case 'LinkedField':
+          this._normalizeField(selection, record, data);
+          break;
+        case 'Condition':
+          const conditionValue = Boolean(
+            this._getVariableValue(selection.condition),
+          );
+          if (conditionValue === selection.passingValue) {
+            this._traverseSelections(selection, record, data);
+          }
+          break;
+        case 'FragmentSpread': {
+          const prevVariables = this._variables;
+          this._variables = getLocalVariables(
+            this._variables,
+            selection.fragment.argumentDefinitions,
+            selection.args,
+          );
+          this._traverseSelections(selection.fragment, record, data);
+          this._variables = prevVariables;
+          break;
+        }
+        case 'InlineFragment': {
+          this._normalizeInlineFragment(selection, record, data);
+          break;
+        }
+        case 'TypeDiscriminator': {
+          const {abstractKey} = selection;
+          // $FlowFixMe[method-unbinding] - data could be prototype less
+          const implementsInterface = Object.prototype.hasOwnProperty.call(
+            data,
+            abstractKey,
+          );
+          const typeName = RelayModernRecord.getType(record);
+          const typeID = generateTypeID(typeName);
+          let typeRecord = this._recordSource.get(typeID);
+          if (typeRecord == null) {
+            typeRecord = RelayModernRecord.create(typeID, TYPE_SCHEMA_TYPE);
+            this._recordSource.set(typeID, typeRecord);
+          }
+          RelayModernRecord.setValue(
+            typeRecord,
+            abstractKey,
+            implementsInterface,
+          );
+          break;
+        }
+        case 'LinkedHandle':
+        case 'ScalarHandle':
+          const args = selection.args
+            ? getArgumentValues(selection.args, this._variables)
+            : {};
+          const fieldKey = getStorageKey(selection, this._variables);
+          const handleKey = getHandleStorageKey(selection, this._variables);
+          this._handleFieldPayloads.push({
+            args,
+            dataID: RelayModernRecord.getDataID(record),
+            fieldKey,
+            handle: selection.handle,
+            handleArgs: selection.handleArgs
+              ? getArgumentValues(selection.handleArgs, this._variables)
+              : {},
+            handleKey,
+          });
+          break;
+        case 'ModuleImport':
+          this._normalizeModuleImport(selection, record, data);
+          break;
+        case 'Defer':
+          this._normalizeDefer(selection, record, data);
+          break;
+        case 'Stream':
+          this._normalizeStream(selection, record, data);
+          break;
+        case 'ClientExtension':
+          const isClientExtension = this._isClientExtension;
+          this._isClientExtension = true;
+          this._traverseSelections(selection, record, data);
+          this._isClientExtension = isClientExtension;
+          break;
+        case 'ClientComponent':
+          if (this._shouldProcessClientComponents === false) {
+            break;
+          }
+          this._traverseSelections(selection.fragment, record, data);
+          break;
+        case 'ActorChange':
+          this._normalizeActorChange(selection, record, data);
+          break;
+        case 'RelayResolver':
+        case 'RelayLiveResolver':
+          if (!this._useExecTimeResolvers) {
+            this._normalizeResolver(selection, record, data);
+          } else if (selection.resolverInfo?.rootFragment != null) {
+            this._collectS2CExecution(selection, record);
+          }
+          break;
+        case 'ClientEdgeToClientObject':
+          if (!this._useExecTimeResolvers) {
+            this._normalizeResolver(selection.backingField, record, data);
+          } else if (
+            selection.backingField.resolverInfo?.rootFragment != null
+          ) {
+            this._collectS2CExecution(selection, record);
+          }
+          break;
+        default:
+          selection as empty;
+          invariant(
+            false,
+            'RelayResponseNormalizer(): Unexpected ast kind `%s`.',
+            selection.kind,
+          );
+      }
+    }
+  }
+
+  _normalizeInlineFragment(
+    selection: NormalizationInlineFragment,
+    record: Record,
+    data: PayloadData,
+  ) {
+    const {abstractKey} = selection;
+    if (abstractKey == null) {
+      const typeName = RelayModernRecord.getType(record);
+      if (
+        typeName === selection.type ||
+        // The root record type is a special `__Root` type and may not match the
+        // type on the ast, so ignore type mismatches at the root.  We currently
+        // detect whether we're at the root by checking against ROOT_ID, but this
+        // does not work for mutations/subscriptions which generate unique root
+        // ids. This is acceptable in practice as we don't read data for
+        // mutations/subscriptions in a situation where we would use
+        // isMissingData to decide whether to suspend or not.
+        // TODO T96653810: Correctly detect reading from root of mutation/subscription
+        typeName === ROOT_TYPE
+      ) {
+        this._traverseSelections(selection, record, data);
+      }
+    } else {
+      // $FlowFixMe[method-unbinding] - data could be prototype less
+      const implementsInterface = Object.prototype.hasOwnProperty.call(
+        data,
+        abstractKey,
+      );
+      const typeName = RelayModernRecord.getType(record);
+      const typeID = generateTypeID(typeName);
+      let typeRecord = this._recordSource.get(typeID);
+      if (typeRecord == null) {
+        typeRecord = RelayModernRecord.create(typeID, TYPE_SCHEMA_TYPE);
+        this._recordSource.set(typeID, typeRecord);
+      }
+      RelayModernRecord.setValue(typeRecord, abstractKey, implementsInterface);
+      if (implementsInterface) {
+        this._traverseSelections(selection, record, data);
+      }
+    }
+  }
+
+  _normalizeResolver(
+    resolver: NormalizationResolverField | NormalizationLiveResolverField,
+    record: Record,
+    data: PayloadData,
+  ) {
+    if (resolver.fragment != null) {
+      this._normalizeInlineFragment(resolver.fragment, record, data);
+    }
+  }
+
+  _collectS2CExecution(
+    selection:
+      | NormalizationClientEdgeToClientObject
+      | NormalizationLiveResolverField
+      | NormalizationResolverField,
+    record: Record,
+  ): void {
+    const recordID = RelayModernRecord.getDataID(record);
+    const typeName = RelayModernRecord.getType(record);
+    let entry = this._s2cExecutions.get(recordID);
+    if (entry == null) {
+      entry = {selections: [], typeName};
+      this._s2cExecutions.set(recordID, entry);
+    }
+    entry.selections.push(selection);
+  }
+
+  _normalizeDefer(
+    defer: NormalizationDefer,
+    record: Record,
+    data: PayloadData,
+  ) {
+    const isDeferred = defer.if === null || this._getVariableValue(defer.if);
+    if (__DEV__) {
+      warning(
+        typeof isDeferred === 'boolean',
+        'RelayResponseNormalizer: Expected value for @defer `if` argument to ' +
+          'be a boolean, got `%s`.',
+        isDeferred,
+      );
+    }
+    if (isDeferred === false) {
+      // If defer is disabled there will be no additional response chunk:
+      // normalize the data already present.
+      this._traverseSelections(defer, record, data);
+    } else {
+      // Otherwise data *for this selection* should not be present: enqueue
+      // metadata to process the subsequent response chunk.
+      this._incrementalPlaceholders.push({
+        actorIdentifier: this._actorIdentifier,
+        data,
+        kind: 'defer',
+        label: defer.label,
+        path: [...this._path],
+        selector: createNormalizationSelector(
+          defer,
+          RelayModernRecord.getDataID(record),
+          this._variables,
+        ),
+        typeName: RelayModernRecord.getType(record),
+      });
+    }
+  }
+
+  _normalizeStream(
+    stream: NormalizationStream,
+    record: Record,
+    data: PayloadData,
+  ) {
+    // Always normalize regardless of whether streaming is enabled or not,
+    // this populates the initial array value (including any items when
+    // initial_count > 0).
+    this._traverseSelections(stream, record, data);
+    const isStreamed = stream.if === null || this._getVariableValue(stream.if);
+    if (__DEV__) {
+      warning(
+        typeof isStreamed === 'boolean',
+        'RelayResponseNormalizer: Expected value for @stream `if` argument ' +
+          'to be a boolean, got `%s`.',
+        isStreamed,
+      );
+    }
+    if (isStreamed === true) {
+      // If streaming is enabled, *also* emit metadata to process any
+      // response chunks that may be delivered.
+      this._incrementalPlaceholders.push({
+        actorIdentifier: this._actorIdentifier,
+        kind: 'stream',
+        label: stream.label,
+        node: stream,
+        parentID: RelayModernRecord.getDataID(record),
+        path: [...this._path],
+        variables: this._variables,
+      });
+    }
+  }
+
+  _normalizeModuleImport(
+    moduleImport: NormalizationModuleImport,
+    record: Record,
+    data: PayloadData,
+  ): void {
+    invariant(
+      typeof data === 'object' && data,
+      'RelayResponseNormalizer: Expected data for @module to be an object.',
+    );
+    const typeName: string = RelayModernRecord.getType(record);
+    const componentKey = getModuleComponentKey(moduleImport.documentName);
+    const componentReference =
+      moduleImport.componentModuleProvider || data[componentKey];
+    RelayModernRecord.setValue(
+      record,
+      componentKey,
+      componentReference ?? null,
+    );
+    const operationKey = getModuleOperationKey(moduleImport.documentName);
+    const operationReference =
+      moduleImport.operationModuleProvider || data[operationKey];
+    RelayModernRecord.setValue(
+      record,
+      operationKey,
+      operationReference ?? null,
+    );
+    if (operationReference != null) {
+      this._followupPayloads.push({
+        actorIdentifier: this._actorIdentifier,
+        args: moduleImport.args,
+        data,
+        dataID: RelayModernRecord.getDataID(record),
+        kind: 'ModuleImportPayload',
+        operationReference,
+        path: [...this._path],
+        typeName,
+        variables: this._variables,
+      });
+    }
+  }
+
+  _normalizeField(
+    selection: NormalizationLinkedField | NormalizationScalarField,
+    record: Record,
+    data: PayloadData,
+  ): void {
+    invariant(
+      typeof data === 'object' && data,
+      'writeField(): Expected data for field `%s` to be an object.',
+      selection.name,
+    );
+    const responseKey = selection.alias || selection.name;
+    const storageKey = getStorageKey(selection, this._variables);
+    const fieldValue = data[responseKey];
+    const isNoncompliantlyNullish =
+      RelayFeatureFlags.ENABLE_NONCOMPLIANT_ERROR_HANDLING_ON_LISTS &&
+      Array.isArray(fieldValue) &&
+      fieldValue.length === 0;
+    if (fieldValue == null || isNoncompliantlyNullish) {
+      if (fieldValue === undefined) {
+        // Fields may be missing in the response in two main cases:
+        // - Inside a client extension: the server will not generally return
+        //   values for these fields, but a local update may provide them.
+        // - Inside an abstract type refinement where the concrete type does
+        //   not conform to the interface/union.
+        // However an otherwise-required field may also be missing if the server
+        // is configured to skip fields with `null` values, in which case the
+        // client is assumed to be correctly configured with
+        // treatMissingFieldsAsNull=true.
+        const isOptionalField =
+          this._isClientExtension ||
+          this._isUnmatchedAbstractType ||
+          this._deferDeduplicatedFields;
+
+        if (isOptionalField) {
+          // Field not expected to exist regardless of whether the server is pruning null
+          // fields or not.
+          return;
+        } else if (!this._treatMissingFieldsAsNull) {
+          // Not optional and the server is not pruning null fields: field is expected
+          // to be present
+          if (__DEV__) {
+            warning(
+              false,
+              'RelayResponseNormalizer: Payload did not contain a value ' +
+                'for field `%s: %s`. Check that you are parsing with the same ' +
+                'query that was used to fetch the payload.',
+              responseKey,
+              storageKey,
+            );
+          }
+          return;
+        }
+      }
+      if (selection.kind === 'ScalarField') {
+        this._validateConflictingFieldsWithIdenticalId(
+          record,
+          storageKey,
+          // When using `treatMissingFieldsAsNull` the conflicting validation raises a false positive
+          // because the value is set using `null` but validated using `fieldValue` which at this point
+          // will be `undefined`.
+          // Setting this to `null` matches the value that we actually set to the `fieldValue`.
+          null,
+        );
+      }
+      if (isNoncompliantlyNullish) {
+        // We need to preserve the fact that we received an empty list
+        if (selection.kind === 'LinkedField') {
+          RelayModernRecord.setLinkedRecordIDs(record, storageKey, []);
+        } else {
+          RelayModernRecord.setValue(record, storageKey, []);
+        }
+      } else {
+        RelayModernRecord.setValue(record, storageKey, null);
+      }
+      const errorTrie = this._errorTrie;
+      if (errorTrie != null) {
+        const errors = getErrorsByKey(errorTrie, responseKey);
+        if (errors != null) {
+          RelayModernRecord.setErrors(record, storageKey, errors);
+        }
+      }
+      return;
+    }
+
+    if (selection.kind === 'ScalarField') {
+      this._validateConflictingFieldsWithIdenticalId(
+        record,
+        storageKey,
+        fieldValue,
+      );
+      RelayModernRecord.setValue(record, storageKey, fieldValue);
+    } else if (selection.kind === 'LinkedField') {
+      this._path.push(responseKey);
+      const oldErrorTrie = this._errorTrie;
+      this._errorTrie =
+        oldErrorTrie == null
+          ? null
+          : getNestedErrorTrieByKey(oldErrorTrie, responseKey);
+      if (selection.plural) {
+        this._normalizePluralLink(selection, record, storageKey, fieldValue);
+      } else {
+        this._normalizeLink(selection, record, storageKey, fieldValue);
+      }
+      this._errorTrie = oldErrorTrie;
+      this._path.pop();
+    } else {
+      selection as empty;
+      invariant(
+        false,
+        'RelayResponseNormalizer(): Unexpected ast kind `%s` during normalization.',
+        selection.kind,
+      );
+    }
+  }
+
+  _normalizeActorChange(
+    selection: NormalizationActorChange,
+    record: Record,
+    data: PayloadData,
+  ): void {
+    const field = selection.linkedField;
+    invariant(
+      typeof data === 'object' && data,
+      '_normalizeActorChange(): Expected data for field `%s` to be an object.',
+      field.name,
+    );
+    const responseKey = field.alias || field.name;
+    const storageKey = getStorageKey(field, this._variables);
+    const fieldValue = data[responseKey];
+
+    if (fieldValue == null) {
+      if (fieldValue === undefined) {
+        const isOptionalField =
+          this._isClientExtension || this._isUnmatchedAbstractType;
+
+        if (isOptionalField) {
+          return;
+        } else if (!this._treatMissingFieldsAsNull) {
+          if (__DEV__) {
+            warning(
+              false,
+              'RelayResponseNormalizer: Payload did not contain a value ' +
+                'for field `%s: %s`. Check that you are parsing with the same ' +
+                'query that was used to fetch the payload.',
+              responseKey,
+              storageKey,
+            );
+          }
+          return;
+        }
+      }
+      RelayModernRecord.setValue(record, storageKey, null);
+      return;
+    }
+
+    const actorIdentifier = getActorIdentifierFromPayload(fieldValue);
+    if (actorIdentifier == null) {
+      if (__DEV__) {
+        warning(
+          false,
+          'RelayResponseNormalizer: Payload did not contain a value ' +
+            'for field `%s`. Check that you are parsing with the same ' +
+            'query that was used to fetch the payload. Payload is `%s`.',
+          ACTOR_IDENTIFIER_FIELD_NAME,
+          JSON.stringify(fieldValue, null, 2),
+        );
+      }
+      RelayModernRecord.setValue(record, storageKey, null);
+      return;
+    }
+
+    // $FlowFixMe[incompatible-type]
+    const typeName = field.concreteType ?? this._getRecordType(fieldValue);
+    const nextID =
+      this._getDataId(
+        // $FlowFixMe[incompatible-type]
+        fieldValue,
+        typeName,
+      ) ||
+      RelayModernRecord.getLinkedRecordID(record, storageKey) ||
+      generateClientID(RelayModernRecord.getDataID(record), storageKey);
+
+    invariant(
+      typeof nextID === 'string',
+      'RelayResponseNormalizer: Expected id on field `%s` to be a string.',
+      storageKey,
+    );
+
+    RelayModernRecord.setActorLinkedRecordID(
+      record,
+      storageKey,
+      actorIdentifier,
+      nextID,
+    );
+
+    this._followupPayloads.push({
+      actorIdentifier,
+      data: fieldValue as $FlowFixMe,
+      dataID: nextID,
+      kind: 'ActorPayload',
+      node: field,
+      path: [...this._path, responseKey],
+      typeName,
+      variables: this._variables,
+    });
+  }
+
+  _normalizeLink(
+    field: NormalizationLinkedField,
+    record: Record,
+    storageKey: string,
+    fieldValue: unknown,
+  ): void {
+    invariant(
+      typeof fieldValue === 'object' && fieldValue,
+      'RelayResponseNormalizer: Expected data for field `%s` to be an object.',
+      storageKey,
+    );
+    const nextID =
+      this._getDataId(
+        // $FlowFixMe[incompatible-variance]
+        fieldValue,
+        // $FlowFixMe[incompatible-variance]
+        field.concreteType ?? this._getRecordType(fieldValue),
+      ) ||
+      // Reuse previously generated client IDs
+      RelayModernRecord.getLinkedRecordID(record, storageKey) ||
+      generateClientID(RelayModernRecord.getDataID(record), storageKey);
+    invariant(
+      typeof nextID === 'string',
+      'RelayResponseNormalizer: Expected id on field `%s` to be a string.',
+      storageKey,
+    );
+    this._validateConflictingLinkedFieldsWithIdenticalId(
+      RelayModernRecord.getLinkedRecordID(record, storageKey),
+      nextID,
+      storageKey,
+    );
+    RelayModernRecord.setLinkedRecordID(record, storageKey, nextID);
+    let nextRecord = this._recordSource.get(nextID);
+    if (!nextRecord) {
+      // $FlowFixMe[incompatible-variance]
+      const typeName = field.concreteType || this._getRecordType(fieldValue);
+      nextRecord = RelayModernRecord.create(nextID, typeName);
+      this._recordSource.set(nextID, nextRecord);
+    } else {
+      this._validateRecordType(nextRecord, field, fieldValue);
+    }
+    // $FlowFixMe[incompatible-variance]
+    this._traverseSelections(field, nextRecord, fieldValue);
+  }
+
+  _normalizePluralLink(
+    field: NormalizationLinkedField,
+    record: Record,
+    storageKey: string,
+    fieldValue: unknown,
+  ): void {
+    invariant(
+      Array.isArray(fieldValue),
+      'RelayResponseNormalizer: Expected data for field `%s` to be an array ' +
+        'of objects.',
+      storageKey,
+    );
+    const prevIDs = RelayModernRecord.getLinkedRecordIDs(record, storageKey);
+    const nextIDs: Array<?DataID> = [];
+    fieldValue.forEach((item, nextIndex) => {
+      // validate response data
+      if (item == null) {
+        nextIDs.push(item);
+        return;
+      }
+      this._path.push(String(nextIndex));
+      const oldErrorTrie = this._errorTrie;
+      this._errorTrie =
+        oldErrorTrie == null
+          ? null
+          : getNestedErrorTrieByKey(oldErrorTrie, nextIndex);
+      invariant(
+        typeof item === 'object',
+        'RelayResponseNormalizer: Expected elements for field `%s` to be ' +
+          'objects.',
+        storageKey,
+      );
+      const nextID =
+        this._getDataId(
+          // $FlowFixMe[incompatible-variance]
+          item,
+          // $FlowFixMe[incompatible-variance]
+          field.concreteType ?? this._getRecordType(item),
+        ) ||
+        (prevIDs && prevIDs[nextIndex]) || // Reuse previously generated client IDs:
+        generateClientID(
+          RelayModernRecord.getDataID(record),
+          storageKey,
+          nextIndex,
+        );
+      invariant(
+        typeof nextID === 'string',
+        'RelayResponseNormalizer: Expected id of elements of field `%s` to ' +
+          'be strings.',
+        storageKey,
+      );
+
+      nextIDs.push(nextID);
+      let nextRecord = this._recordSource.get(nextID);
+      if (!nextRecord) {
+        // $FlowFixMe[incompatible-variance]
+        const typeName = field.concreteType || this._getRecordType(item);
+        nextRecord = RelayModernRecord.create(nextID, typeName);
+        this._recordSource.set(nextID, nextRecord);
+      } else {
+        this._validateRecordType(nextRecord, field, item);
+      }
+      if (prevIDs) {
+        this._validateConflictingLinkedFieldsWithIdenticalId(
+          prevIDs[nextIndex],
+          nextID,
+          storageKey,
+        );
+      }
+      // $FlowFixMe[incompatible-variance]
+      this._traverseSelections(field, nextRecord, item);
+      this._errorTrie = oldErrorTrie;
+      this._path.pop();
+    });
+    RelayModernRecord.setLinkedRecordIDs(record, storageKey, nextIDs);
+  }
+
+  /**
+   * Warns if the type of the record does not match the type of the field/payload.
+   */
+  _validateRecordType(
+    record: Record,
+    field: NormalizationLinkedField,
+    payload: Object,
+  ): void {
+    if (RelayFeatureFlags.ENABLE_STORE_ID_COLLISION_LOGGING) {
+      const typeName = field.concreteType ?? this._getRecordType(payload);
+      const dataID = RelayModernRecord.getDataID(record);
+      const expected =
+        (isClientID(dataID) && dataID !== ROOT_ID) ||
+        RelayModernRecord.getType(record) === typeName;
+      if (!expected) {
+        const logEvent: IdCollisionTypenameLogEvent = {
+          name: 'idCollision.typename',
+          new_typename: typeName,
+          previous_typename: RelayModernRecord.getType(record),
+        };
+        if (this._log != null) {
+          this._log(logEvent);
+        }
+      }
+    }
+    // NOTE: Only emit a warning in DEV
+    if (__DEV__) {
+      const typeName = field.concreteType ?? this._getRecordType(payload);
+      const dataID = RelayModernRecord.getDataID(record);
+      const expected =
+        (isClientID(dataID) && dataID !== ROOT_ID) ||
+        RelayModernRecord.getType(record) === typeName;
+      warning(
+        expected,
+        'RelayResponseNormalizer: Invalid record `%s`. Expected %s to be ' +
+          'consistent, but the record was assigned conflicting types `%s` ' +
+          'and `%s`. The GraphQL server likely violated the globally unique ' +
+          'id requirement by returning the same id for different objects.',
+        dataID,
+        TYPENAME_KEY,
+        RelayModernRecord.getType(record),
+        typeName,
+      );
+    }
+  }
+
+  /**
+   * Warns if a single response contains conflicting fields with the same id
+   */
+  _validateConflictingFieldsWithIdenticalId(
+    record: Record,
+    storageKey: string,
+    fieldValue: unknown,
+  ): void {
+    // NOTE: Only emit a warning in DEV
+    if (__DEV__) {
+      const previousValue = RelayModernRecord.getValue(record, storageKey);
+      const dataID = RelayModernRecord.getDataID(record);
+      const expected =
+        storageKey === TYPENAME_KEY ||
+        previousValue === undefined ||
+        areEqual(previousValue, fieldValue);
+      warning(
+        expected,
+        'RelayResponseNormalizer: Invalid record. The record contains two ' +
+          'instances of the same id: `%s` with conflicting field, %s and its values: %s and %s. ' +
+          'If two fields are different but share ' +
+          'the same id, one field will overwrite the other.',
+        dataID,
+        storageKey,
+        previousValue,
+        fieldValue,
+      );
+    }
+  }
+
+  /**
+   * Warns if a single response contains conflicting fields with the same id
+   */
+  _validateConflictingLinkedFieldsWithIdenticalId(
+    prevID: ?DataID,
+    nextID: DataID,
+    storageKey: string,
+  ): void {
+    // NOTE: Only emit a warning in DEV
+    if (__DEV__) {
+      const expected = prevID === undefined || prevID === nextID;
+      warning(
+        expected,
+        'RelayResponseNormalizer: Invalid record. The record contains ' +
+          'references to the conflicting field, %s and its id values: %s and %s. ' +
+          'We need to make sure that the record the field points ' +
+          'to remains consistent or one field will overwrite the other.',
+        storageKey,
+        prevID,
+        nextID,
+      );
+    }
+  }
+}
+
+module.exports = {
+  normalize,
+};

--- a/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/subscription/requestSubscription.js
+++ b/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/subscription/requestSubscription.js
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+import type {DeclarativeMutationConfig} from '../mutations/RelayDeclarativeMutationConfig';
+import type {
+  IEnvironment,
+  SelectorStoreUpdater,
+} from '../store/RelayStoreTypes';
+import type {
+  CacheConfig,
+  Disposable,
+  GraphQLSubscription,
+  Variables,
+} from '../util/RelayRuntimeTypes';
+
+const RelayDeclarativeMutationConfig = require('../mutations/RelayDeclarativeMutationConfig');
+const {getRequest} = require('../query/GraphQLTag');
+const {
+  createOperationDescriptor,
+} = require('../store/RelayModernOperationDescriptor');
+const {createReaderSelector} = require('../store/RelayModernSelector');
+const warning = require('warning');
+
+export type SubscriptionParameters = {
+  +response: {...},
+  +variables: {...},
+  +rawResponse?: {...},
+};
+
+/**
+ * Updated Flow type that makes use of typed graphql tagged literals with
+ * type information.
+ */
+export type GraphQLSubscriptionConfig<TVariables, TData, TRawResponse> =
+  Readonly<{
+    configs?: Array<DeclarativeMutationConfig>,
+    cacheConfig?: CacheConfig,
+    subscription: GraphQLSubscription<TVariables, TData, TRawResponse>,
+    variables: NoInfer<TVariables>,
+    onCompleted?: ?() => void,
+    onError?: ?(error: Error) => void,
+    onNext?: ?(response: ?TData) => void,
+    updater?: ?SelectorStoreUpdater<TData>,
+  }>;
+
+function requestSubscription<TVariables extends Variables, TData, TRawResponse>(
+  environment: IEnvironment,
+  config: GraphQLSubscriptionConfig<TVariables, TData, TRawResponse>,
+): Disposable {
+  const subscription = getRequest(config.subscription);
+  if (subscription.params.operationKind !== 'subscription') {
+    throw new Error('requestSubscription: Must use Subscription operation');
+  }
+  const {configs, onCompleted, onError, onNext, variables, cacheConfig} =
+    config;
+  const operation = createOperationDescriptor(
+    subscription,
+    variables,
+    cacheConfig,
+  );
+
+  warning(
+    !(config.updater && configs),
+    'requestSubscription: Expected only one of `updater` and `configs` to be provided',
+  );
+
+  const {updater} = configs
+    ? RelayDeclarativeMutationConfig.convert<$FlowFixMe>(
+        configs,
+        subscription,
+        null /* optimisticUpdater */,
+        config.updater,
+      )
+    : config;
+
+  const sub = environment
+    .executeSubscription<$FlowFixMe>({
+      operation,
+      updater,
+    })
+    .subscribe({
+      complete: onCompleted,
+      error: onError,
+      next: responses => {
+        if (onNext != null) {
+          let selector = operation.fragment;
+          let nextID;
+          if (Array.isArray(responses)) {
+            nextID = responses[0]?.extensions?.__relay_subscription_root_id;
+          } else {
+            nextID = responses.extensions?.__relay_subscription_root_id;
+          }
+          if (typeof nextID === 'string') {
+            selector = createReaderSelector(
+              selector.node,
+              nextID,
+              selector.variables,
+              selector.owner,
+            );
+          }
+          const data = environment.lookup(selector).data;
+          // $FlowFixMe[incompatible-type]
+          onNext(data as TData);
+        }
+      },
+    });
+  return {
+    dispose: sub.unsubscribe,
+  };
+}
+
+module.exports = requestSubscription;

--- a/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/util/RelayConcreteNode.js
+++ b/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/util/RelayConcreteNode.js
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+import type {
+  NormalizationOperation,
+  NormalizationSplitOperation,
+} from './NormalizationNode';
+import type {ReaderFragment, ReaderInlineDataFragment} from './ReaderNode';
+
+/**
+ * Represents a common GraphQL request that can be executed, an `operation`
+ * containing information to normalize the results, and a `fragment` derived
+ * from that operation to read the response data (masking data from child
+ * fragments).
+ */
+export type ConcreteRequest = {
+  +kind: 'Request',
+  +fragment: ReaderFragment,
+  +operation: NormalizationOperation,
+  +params: RequestParameters,
+};
+
+export type ConcreteUpdatableQuery = {
+  +kind: 'UpdatableQuery',
+  +fragment: ReaderFragment,
+};
+
+export type NormalizationRootNode =
+  | ConcreteRequest
+  | NormalizationSplitOperation;
+
+export type ProvidedVariableType = {get(): unknown};
+
+export type ProvidedVariablesType = {+[key: string]: {get(): unknown}};
+
+/**
+ * Contains the parameters required for executing a GraphQL request.
+ * The operation can either be provided as a persisted `id` or `text` or both.
+ * If `text` format is provided, a `cacheID` as a hash of the text should be set
+ * to be used for local caching.
+ */
+export type RequestParameters =
+  | {
+      +id: string,
+      +text: string | null,
+      // common fields
+      +name: string,
+      +operationKind: 'mutation' | 'query' | 'subscription',
+      +providedVariables?: ProvidedVariablesType,
+      +metadata: {[key: string]: unknown, ...},
+    }
+  | {
+      +cacheID: string,
+      +id: null,
+      +text: string | null,
+      // common fields
+      +name: string,
+      +operationKind: 'mutation' | 'query' | 'subscription',
+      +providedVariables?: ProvidedVariablesType,
+      +metadata: {[key: string]: unknown, ...},
+    };
+
+export type ClientRequestParameters = {
+  +cacheID: string,
+  +id: null,
+  +text: null,
+  // common fields
+  +name: string,
+  +operationKind: 'query' | 'mutation',
+  +providedVariables?: ProvidedVariablesType,
+  +metadata: {[key: string]: unknown, ...},
+};
+
+export type ClientRequest = {
+  +kind: 'Request',
+  +fragment: ReaderFragment,
+  +operation: NormalizationOperation,
+  +params: ClientRequestParameters,
+};
+
+export type GeneratedNode =
+  | ConcreteRequest
+  | ReaderFragment
+  | ReaderInlineDataFragment
+  | NormalizationSplitOperation
+  | ConcreteUpdatableQuery;
+
+const RelayConcreteNode = {
+  ACTOR_CHANGE: 'ActorChange',
+  CATCH_FIELD: 'CatchField',
+  CONDITION: 'Condition',
+  CLIENT_COMPONENT: 'ClientComponent',
+  CLIENT_EDGE_TO_SERVER_OBJECT: 'ClientEdgeToServerObject',
+  CLIENT_EDGE_TO_CLIENT_OBJECT: 'ClientEdgeToClientObject',
+  CLIENT_EXTENSION: 'ClientExtension',
+  DEFER: 'Defer',
+  CONNECTION: 'Connection',
+  FRAGMENT: 'Fragment',
+  FRAGMENT_SPREAD: 'FragmentSpread',
+  INLINE_DATA_FRAGMENT_SPREAD: 'InlineDataFragmentSpread',
+  INLINE_DATA_FRAGMENT: 'InlineDataFragment',
+  INLINE_FRAGMENT: 'InlineFragment',
+  LINKED_FIELD: 'LinkedField',
+  LINKED_HANDLE: 'LinkedHandle',
+  LITERAL: 'Literal',
+  LIST_VALUE: 'ListValue',
+  LOCAL_ARGUMENT: 'LocalArgument',
+  MODULE_IMPORT: 'ModuleImport',
+  ALIASED_FRAGMENT_SPREAD: 'AliasedFragmentSpread',
+  ALIASED_INLINE_FRAGMENT_SPREAD: 'AliasedInlineFragmentSpread',
+  RELAY_RESOLVER: 'RelayResolver',
+  RELAY_LIVE_RESOLVER: 'RelayLiveResolver',
+  REQUIRED_FIELD: 'RequiredField',
+  OBJECT_VALUE: 'ObjectValue',
+  OPERATION: 'Operation',
+  REQUEST: 'Request',
+  ROOT_ARGUMENT: 'RootArgument',
+  SCALAR_FIELD: 'ScalarField',
+  SCALAR_HANDLE: 'ScalarHandle',
+  SPLIT_OPERATION: 'SplitOperation',
+  STREAM: 'Stream',
+  TYPE_DISCRIMINATOR: 'TypeDiscriminator',
+  UPDATABLE_QUERY: 'UpdatableQuery',
+  VARIABLE: 'Variable',
+} as const;
+
+module.exports = RelayConcreteNode;

--- a/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/util/RelayProfiler.js
+++ b/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/util/RelayProfiler.js
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+type EventName = 'fetchRelayQuery';
+type ProfileHandler = (name: EventName, state?: any) => (error?: Error) => void;
+
+const profileHandlersByName: {
+  [name: EventName]: Array<ProfileHandler>,
+} = {};
+
+const defaultProfiler: {stop: (error?: Error) => void, ...} = {
+  stop() {},
+};
+
+/**
+ * @public
+ *
+ * Instruments methods to allow profiling various parts of Relay. Profiling code
+ * in Relay consists of three steps:
+ *
+ *  - Instrument the function to be profiled.
+ *  - Attach handlers to the instrumented function.
+ *  - Run the code which triggers the handlers.
+ *
+ * Handlers attached to instrumented methods are called with an instrumentation
+ * name and a callback that must be synchronously executed:
+ *
+ *   instrumentedMethod.attachHandler(function(name, callback) {
+ *     const start = performance.now();
+ *     callback();
+ *     console.log('Duration', performance.now() - start);
+ *   });
+ *
+ * Handlers for profiles are callbacks that return a stop method:
+ *
+ *   RelayProfiler.attachProfileHandler('profileName', (name, state) => {
+ *     const start = performance.now();
+ *     return function stop(name, state) {
+ *       console.log(`Duration (${name})`, performance.now() - start);
+ *     }
+ *   });
+ */
+const RelayProfiler = {
+  /**
+   * Instruments profiling for arbitrarily asynchronous code by a name.
+   *
+   *   const timerProfiler = RelayProfiler.profile('timeout');
+   *   setTimeout(function() {
+   *     timerProfiler.stop();
+   *   }, 1000);
+   *
+   *   RelayProfiler.attachProfileHandler('timeout', ...);
+   *
+   * Arbitrary state can also be passed into `profile` as a second argument. The
+   * attached profile handlers will receive this as the second argument.
+   */
+  profile(name: EventName, state?: any): {stop: (error?: Error) => void, ...} {
+    const handlers = profileHandlersByName[name];
+    if (handlers && handlers.length > 0) {
+      const stopHandlers: Array<(error?: Error) => void> = [];
+      for (let ii = handlers.length - 1; ii >= 0; ii--) {
+        const stopHandler = handlers[ii](name, state);
+        stopHandlers.unshift(stopHandler);
+      }
+      return {
+        stop(error?: Error): void {
+          stopHandlers.forEach(stopHandler => stopHandler(error));
+        },
+      };
+    }
+    return defaultProfiler;
+  },
+
+  /**
+   * Attaches a handler to profiles with the supplied name.
+   */
+  attachProfileHandler(name: EventName, handler: ProfileHandler): void {
+    if (!profileHandlersByName.hasOwnProperty(name)) {
+      profileHandlersByName[name] = [];
+    }
+    profileHandlersByName[name].push(handler);
+  },
+
+  /**
+   * Detaches a handler attached via `attachProfileHandler`.
+   */
+  detachProfileHandler(name: EventName, handler: ProfileHandler): void {
+    if (profileHandlersByName.hasOwnProperty(name)) {
+      removeFromArray(profileHandlersByName[name], handler);
+    }
+  },
+};
+
+function removeFromArray<T>(array: Array<T>, element: T): void {
+  var index = array.indexOf(element);
+  if (index !== -1) {
+    array.splice(index, 1);
+  }
+}
+
+module.exports = RelayProfiler;

--- a/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/util/getRelayHandleKey.js
+++ b/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/util/getRelayHandleKey.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+const {DEFAULT_HANDLE_KEY} = require('./RelayDefaultHandleKey');
+const invariant = require('invariant');
+
+/**
+ * @internal
+ *
+ * Helper to create a unique name for a handle field based on the handle name, handle key and
+ * source field.
+ */
+function getRelayHandleKey(
+  handleName: string,
+  key: ?string,
+  fieldName: ?string,
+): string {
+  if (key && key !== DEFAULT_HANDLE_KEY) {
+    return `__${key}_${handleName}`;
+  }
+
+  invariant(
+    fieldName != null,
+    'getRelayHandleKey: Expected either `fieldName` or `key` in `handle` to be provided',
+  );
+  return `__${fieldName}_${handleName}`;
+}
+
+module.exports = getRelayHandleKey;

--- a/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/util/recycleNodesInto.js
+++ b/tests/integration/tests/fixtures/flow-libs/relay/packages/relay-runtime/util/recycleNodesInto.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+/**
+ * Recycles subtrees from `prevData` by replacing equal subtrees in `nextData`.
+ * Does not mutate a frozen subtree.
+ */
+function recycleNodesInto<T>(prevData: T, nextData: T): T {
+  return recycleNodesIntoImpl(prevData, nextData, true);
+}
+
+function recycleNodesIntoImpl<T>(
+  prevData: T,
+  nextData: T,
+  canMutate: boolean,
+): T {
+  if (
+    prevData === nextData ||
+    typeof prevData !== 'object' ||
+    !prevData ||
+    (prevData.constructor !== Object && !Array.isArray(prevData)) ||
+    typeof nextData !== 'object' ||
+    !nextData ||
+    (nextData.constructor !== Object && !Array.isArray(nextData))
+  ) {
+    return nextData;
+  }
+  let canRecycle = false;
+
+  // Assign local variables to preserve Flow type refinement.
+  const prevArray: ?Array<unknown> = Array.isArray(prevData) ? prevData : null;
+  const nextArray: ?Array<unknown> = Array.isArray(nextData) ? nextData : null;
+  if (prevArray && nextArray) {
+    const canMutateNext = canMutate && !Object.isFrozen(nextArray);
+    canRecycle =
+      nextArray.reduce((wasEqual, nextItem, ii) => {
+        const prevValue = prevArray[ii];
+        const nextValue = recycleNodesIntoImpl(
+          prevValue,
+          nextItem,
+          canMutateNext,
+        );
+        if (nextValue !== nextArray[ii] && canMutateNext) {
+          nextArray[ii] = nextValue;
+        }
+        return wasEqual && nextValue === prevArray[ii];
+      }, true) && prevArray.length === nextArray.length;
+  } else if (!prevArray && !nextArray) {
+    // Assign local variables to preserve Flow type refinement.
+    const prevObject = prevData;
+    const nextObject = nextData;
+    const prevKeys = Object.keys(prevObject);
+    const nextKeys = Object.keys(nextObject);
+    const canMutateNext = canMutate && !Object.isFrozen(nextObject);
+    canRecycle =
+      nextKeys.reduce((wasEqual, key) => {
+        const prevValue = prevObject[key];
+        const nextValue = recycleNodesIntoImpl(
+          prevValue,
+          nextObject[key],
+          canMutateNext,
+        );
+        if (nextValue !== nextObject[key] && canMutateNext) {
+          // $FlowFixMe[cannot-write]
+          nextObject[key] = nextValue;
+        }
+        return wasEqual && nextValue === prevObject[key];
+      }, true) && prevKeys.length === nextKeys.length;
+  }
+  return canRecycle ? prevData : nextData;
+}
+
+module.exports = recycleNodesInto;

--- a/tests/integration/tests/flow-libs.test.ts
+++ b/tests/integration/tests/flow-libs.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect } from 'bun:test';
+import { ZNTC_BIN } from './helpers';
+import { join, resolve } from 'node:path';
+
+/**
+ * Flow를 적극 사용하는 유명 라이브러리(Metro / Relay / Draft.js)의 실제 소스 파일을
+ * --flow --jsx-in-js로 트랜스파일하여 파서 호환성을 추적한다.
+ * fixtures/flow-libs/{metro,relay,draft-js}/ 아래의 모든 .js 파일을 자동 수집.
+ */
+
+const FIXTURES_ROOT = resolve(import.meta.dir, 'fixtures/flow-libs');
+
+const SKIPPED = new Set<string>([]);
+
+function transpile(file: string): { exitCode: number | null; stderr: string } {
+  const proc = Bun.spawnSync([ZNTC_BIN, '--flow', '--jsx-in-js', file]);
+  return {
+    exitCode: proc.exitCode,
+    stderr: proc.stderr.toString(),
+  };
+}
+
+function expectPass(file: string) {
+  const result = transpile(file);
+  expect(result.exitCode).toBe(0);
+  expect(result.stderr).not.toContain('error:');
+}
+
+for (const lib of ['metro', 'relay', 'draft-js'] as const) {
+  const libRoot = join(FIXTURES_ROOT, lib);
+  const files = Array.from(new Bun.Glob('**/*.js').scanSync(libRoot)).sort();
+  describe(`Flow libs: ${lib} (${files.length} files)`, () => {
+    for (const rel of files) {
+      const full = join(libRoot, rel);
+      const key = `${lib}/${rel}`;
+      if (SKIPPED.has(key)) {
+        test.skip(rel, () => expectPass(full));
+      } else {
+        test(rel, () => expectPass(full));
+      }
+    }
+  });
+}
+

--- a/tests/integration/tests/flow-libs.test.ts
+++ b/tests/integration/tests/flow-libs.test.ts
@@ -41,4 +41,3 @@ for (const lib of ['metro', 'relay', 'draft-js'] as const) {
     }
   });
 }
-


### PR DESCRIPTION
## 요약

Flow 0.212+ 의 labeled tuple element 신규 문법(`[name: T]`, `[name?: T]`) 을 zntc 파서가 지원하도록 추가. Metro 의 `[pathnamePrefix: string, normalizedRootDir: string]` 같은 실소스에서 떨어지던 `ZNTC0608 (Property key expected)` 회귀를 fix.

## 발견 경위

`tests/integration/tests/flow-libs.test.ts` (신규) 추가 중 Metro `Server.js` 1건이 파싱 실패. root cause 분석 결과 Flow 0.212+ 에서 도입된 labeled tuple element 신규 문법을 zntc 파서가 지원하지 않는 것이 원인.

기존 `parseTupleType` 은 `[T, U]` 만 지원하고 `[name: T, name: U]` 라벨드 형태를 처리하지 못해 다중 에러를 던졌음.

## 변경 사항

### `src/parser/flow.zig`
- `parseTupleType` element 진입 시 lookahead 로 `identifier ':'` 또는 `identifier '?:'` 패턴 감지.
- `name?` 다음이 `:` 이 아니면 일반 type 으로 후퇴 (saveState/restoreState + rollbackErrors). `src/parser/ts.zig` `parseTupleElementInner` 의 안전 패턴을 미러링.
- 라벨은 type strip 컨텍스트에서 메타데이터일 뿐이라 skip 후 type 만 보존.

### 단위 테스트 (`src/codegen/codegen_test/flow.zig`)
- `Flow: tuple type [T, U]` — 기존 형태 회귀
- `Flow: labeled tuple element` — `[first: number, second: string]`
- `Flow: optional labeled tuple element` — `[name?: string, count: number]`
- `Flow: labeled tuple with generic ReadonlyArray (metro Server.js regression)` — 실제 발견 케이스 그대로

### 회귀 테스트 (`tests/integration/tests/flow-libs.test.ts`)
Flow 를 적극 사용하는 유명 라이브러리 3개의 실소스 파일을 fixture 로 추가:
- Metro 24 (node_modules `.js.flow` → `.js` 복사)
- Relay 17 (GitHub main 에서 fetch)
- Draft.js 14 (GitHub main 에서 fetch)

`Bun.Glob('**/*.js')` 로 동적 수집해 `zntc --flow --jsx-in-js` 실행.

## 결과

- `zig build test`: PASS
- `bun x tsc -b --force`: PASS
- 통합 테스트: **flow-libs 55/55 + flow-rn 50/50 = 105/105 pass**

## 영향 범위

- 새 파서 분기는 Flow 모드에서만 실행 (`src/parser/flow.zig`).
- 기존 `[T, U]` 케이스는 lookahead 가 colon/question 을 못 보면 그대로 `parseType` 으로 떨어져 동작 변화 없음.
- TypeScript 파서는 영향 없음 (별도 경로).

Closes #3281