### PR TITLE
refactor(flow): tuple element parsing follows Hermes spec

### DIFF
--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -125,6 +125,51 @@ test "Flow: labeled tuple with generic ReadonlyArray (metro Server.js regression
     try std.testing.expectEqualStrings("let x=1;", r.output);
 }
 
+test "Flow: variance +/- labeled tuple stripped" {
+    var r = try e2eFlow(
+        std.testing.allocator,
+        "type T = [+a: number, -b: string];\nlet x = 1;",
+    );
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
+test "Flow: variance readonly/writeonly labeled tuple stripped" {
+    var r = try e2eFlow(
+        std.testing.allocator,
+        "type T = [readonly a: number, writeonly b: string];\nlet x = 1;",
+    );
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
+test "Flow: rest tuple element stripped" {
+    var r = try e2eFlow(
+        std.testing.allocator,
+        "type T = [number, ...Array<string>];\nlet x = 1;",
+    );
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
+test "Flow: rest tuple element with label stripped" {
+    var r = try e2eFlow(
+        std.testing.allocator,
+        "type T = [first: number, ...rest: Array<string>];\nlet x = 1;",
+    );
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
+test "Flow: readonly used as plain type identifier (not variance)" {
+    var r = try e2eFlow(
+        std.testing.allocator,
+        "type Readonly = string;\ntype T = [readonly, number];\nlet x = 1;",
+    );
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
 test "Flow: type alias with generic stripped" {
     var r = try e2eFlow(std.testing.allocator, "type List<T> = Array<T>;\nlet x = 1;");
     defer r.deinit();

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -980,7 +980,12 @@ fn parseFlowTypeMember(self: *Parser) ParseError2!NodeIndex {
 // Tuple Type
 // ================================================================
 
-/// 튜플 타입: [T, U] / [name: T, name?: U] (Flow 0.212+ labeled tuple element)
+/// 튜플 타입 (Flow 0.212+):
+///   [T, U]                         일반 type 시퀀스
+///   [name: T, name?: T]            labeled element
+///   [+name: T, -name: T]           variance + label
+///   [readonly name: T, writeonly name: T]
+///   [...T, ...name: T]             rest spread (with optional label)
 fn parseTupleType(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
     try self.advance(); // skip '['
@@ -988,30 +993,7 @@ fn parseTupleType(self: *Parser) ParseError2!NodeIndex {
     const scratch_top = self.saveScratch();
     while (self.current() != .r_bracket and self.current() != .eof) {
         const loop_guard_pos = self.scanner.token.span.start;
-
-        // Labeled tuple element: `name: T` 또는 `name?: T` (Flow 0.212+).
-        // 라벨은 문서화 메타데이터일 뿐이라 type strip 시 무시하고 type만 보존.
-        // `name?` 다음이 `:`이 아니면 일반 type으로 후퇴해야 안전 (ts.zig 패턴 미러).
-        if (self.current() == .identifier) {
-            const next = try self.peekNextKind();
-            const is_labeled = next == .colon or (next == .question and blk: {
-                const saved = self.saveState();
-                const err_count = self.errors.items.len;
-                self.advance() catch break :blk false;
-                self.advance() catch break :blk false;
-                const after_question = self.current();
-                self.restoreState(saved);
-                self.rollbackErrors(err_count);
-                break :blk after_question == .colon;
-            });
-            if (is_labeled) {
-                try self.advance();
-                _ = try self.eat(.question);
-                try self.expect(.colon);
-            }
-        }
-
-        const ty = try parseType(self);
+        const ty = try parseTupleElement(self);
         try self.scratch.append(self.allocator, ty);
         if (!try self.eat(.comma)) break;
         if (try self.ensureLoopProgress(loop_guard_pos)) break;
@@ -1026,6 +1008,59 @@ fn parseTupleType(self: *Parser) ParseError2!NodeIndex {
         .{ .start = start, .end = self.currentSpan().start },
         list,
     );
+}
+
+/// Tuple element 하나를 파싱. Hermes 의 parse-first-then-reinterpret 패턴:
+/// 먼저 type 을 파싱한 뒤 다음 토큰이 `:`/`?:` 이면 그 type 을 라벨로 reinterpret
+/// (라벨은 type strip 컨텍스트에서 메타데이터일 뿐이라 결과 AST 에는 element type 만 보존).
+fn parseTupleElement(self: *Parser) ParseError2!NodeIndex {
+    if (self.current() == .dot3) {
+        try self.advance();
+        const first = try parseType(self);
+        if (try self.eat(.colon)) {
+            return try parseType(self); // 첫 type 은 라벨이었음
+        }
+        return first;
+    }
+
+    // variance 마커가 라벨 없이 끝나면 일반 type 으로 후퇴 — speculative AST node
+    // 까지 정확히 되돌리기 위해 SpeculationCheckpoint 사용.
+    const cp = Parser.SpeculationCheckpoint.save(self);
+    var consumed_variance = false;
+    if (self.current() == .plus or self.current() == .minus) {
+        try self.advance();
+        consumed_variance = true;
+    } else if (self.isContextual("readonly") or self.isContextual("writeonly")) {
+        const next = try self.peekNextKind();
+        if (!rejectsVarianceInterpretation(next)) {
+            try self.advance();
+            consumed_variance = true;
+        }
+    }
+
+    const first = try parseType(self);
+
+    if (self.current() == .colon or self.current() == .question) {
+        _ = try self.eat(.question);
+        try self.expect(.colon);
+        return try parseType(self); // 첫 type 은 라벨이었음
+    }
+
+    if (consumed_variance) {
+        cp.rollback(self);
+        return try parseType(self);
+    }
+
+    return first;
+}
+
+/// `readonly`/`writeonly` 식별자가 variance modifier 가 아니라 일반 type 으로
+/// 해석돼야 함을 가리키는 후행 토큰.
+inline fn rejectsVarianceInterpretation(kind: Kind) bool {
+    return switch (kind) {
+        .colon, .comma, .r_bracket, .eq, .question => true,
+        else => false,
+    };
 }
 
 // ================================================================


### PR DESCRIPTION
## 요약

#3282 의 follow-up. 단순 labeled tuple 외에도 Flow 0.212+ 의 variance modifier / rest spread 까지 Hermes(Meta 공식 Flow 파서) 의 `parse-first-then-reinterpret` 패턴에 맞춰 확장.

## 배경

#3282 직후 사용자 요청으로 `references/babel` 과 `references/hermes` 의 Flow tuple 구현을 비교 검토. 결과:

- **Babel** (`flowParseTupleType`): labeled tuple 미지원 — `flowParseType()` 만 호출. Flow 신규 문법 catch-up 안 됨.
- **Hermes** (`parseTupleElementFlow`, JSParserImpl-flow.cpp:3713): parse-first-then-reinterpret 패턴. variance(+/-/readonly/writeonly), rest+label, qualified label 모두 처리.
- **zntc (#3282)**: lookahead-first 패턴, 단순 `[name: T]` 만 처리.

Hermes 가 Flow 의 reference implementation 이므로 그 패턴에 정렬.

## 변경 사항

### `src/parser/flow.zig`
- `parseTupleType` 를 단순 loop 로 정리, element 처리는 새 헬퍼 `parseTupleElement` 로 분리.
- `parseTupleElement` 가 처리하는 형태:
  - `...T` / `...name: T` — rest spread (with optional label)
  - `+T:`, `-T:` — variance modifier (라벨 전용)
  - `readonly T:`, `writeonly T:` — contextual variance (다음 토큰 lookahead 로 `readonly` 자체가 단독 type identifier 인 경우와 구분)
  - 일반 element 는 `parseType` 후 다음 토큰이 `:`/`?:` 이면 라벨로 reinterpret 하고 실제 element type 을 다시 파싱
- speculative variance 후퇴 시 `Parser.SpeculationCheckpoint.save/rollback` 사용. 이전 PR 의 `saveState` + `rollbackErrors` 조합만으로는 `parseType` 이 ast.nodes/ast.extra_data 에 append 한 노드가 leak 되는 문제가 있었음.
- negative lookahead 체인을 `rejectsVarianceInterpretation` helper 로 추출.

### 단위 테스트 (`src/codegen/codegen_test/flow.zig`)
- `Flow: variance +/- labeled tuple stripped`
- `Flow: variance readonly/writeonly labeled tuple stripped`
- `Flow: rest tuple element stripped`
- `Flow: rest tuple element with label stripped`
- `Flow: readonly used as plain type identifier (not variance)` — lookahead 경계 회귀

## 결과
- `zig build test`: PASS
- `bun x tsc -b --force`: PASS
- 통합 테스트: **flow-libs 55/55 + flow-rn 50/50 = 105/105 pass**

## 영향 범위
- 새 분기는 Flow 모드에서만 실행. TypeScript 파서 (`src/parser/ts.zig`) 는 영향 없음.
- 기존 `[T, U]` 케이스는 변경 후에도 그대로 동작 (rest 분기 미진입 → variance 분기 미진입 → parseType → colon/question 없음 → 그대로 반환).