### PR TITLE
perf(minify): elide function body trailing return; (-7B)

### DIFF
--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -303,7 +303,14 @@ fn runOnce(
             // 의 name binding 은 *그 함수 body 안에서만* visible (spec) — reference_count == 0
             // 이면 name 안전하게 anonymous. mobx 같은 ES5 class transpile 패턴 큰 영향.
             // debug/stack-trace 식별성을 깨므로 minify_syntax 일 때만 적용 (line 596/753 패턴).
-            .function_expression => if (ctx.hasSemantic() and ctx.allow_top_level_inline) elideUnusedFnExprName(ast, ctx, node, &changed),
+            .function_expression => {
+                if (ctx.hasSemantic() and ctx.allow_top_level_inline) elideUnusedFnExprName(ast, ctx, node, &changed);
+                if (ctx.allow_top_level_inline) elideTrailingEmptyReturn(ast, node, &changed);
+            },
+            // 함수 body 마지막 `return;` (no operand) → empty_statement. implicit return undefined
+            // 와 동등. minify_whitespace 가 empty 자동 elide. arrow body 도 block 일 때만 적용
+            // (concise body 는 expression — functionBodyBlock 가 block 만 반환해 자동 skip).
+            .function_declaration, .function, .arrow_function_expression, .method_definition => if (ctx.allow_top_level_inline) elideTrailingEmptyReturn(ast, node, &changed),
             else => {},
         }
     }
@@ -1127,6 +1134,44 @@ pub fn mergeDecls(ast: *Ast, skip_nodes: ?*const std.DynamicBitSet) void {
 // ================================================================
 // Constant Folding — Binary Expression
 // ================================================================
+
+/// 함수 body 마지막 `return;` (operand 없음) 을 `empty_statement` 로 변환.
+/// implicit `return undefined` 와 의미 동등 — 함수 끝 자연 도달 시 undefined 반환.
+/// emit 시 minify_whitespace 가 empty_statement 자동 elide → ~7 byte 절감.
+/// arrow function 의 concise body (expression) 는 functionBodyBlock 가 block 만 반환해 자동 skip.
+fn elideTrailingEmptyReturn(ast: *Ast, node: Node, changed: *bool) void {
+    const body_idx = ast.functionBodyBlock(node) orelse return;
+    const body_ni = @intFromEnum(body_idx);
+    if (body_ni >= ast.nodes.items.len) return;
+    const body = ast.nodes.items[body_ni];
+    if (body.tag != .block_statement) return;
+    const list = body.data.list;
+    if (list.len == 0) return;
+    if (list.start + list.len > ast.extra_data.items.len) return;
+    const indices = ast.extra_data.items[list.start .. list.start + list.len];
+    var last_raw: u32 = 0;
+    var found = false;
+    var k: usize = indices.len;
+    while (k > 0) {
+        k -= 1;
+        const raw = indices[k];
+        if (raw >= ast.nodes.items.len) continue;
+        if (ast.nodes.items[raw].tag == .empty_statement) continue;
+        last_raw = raw;
+        found = true;
+        break;
+    }
+    if (!found) return;
+    const last_node = ast.nodes.items[last_raw];
+    if (last_node.tag != .return_statement) return;
+    if (!last_node.data.unary.operand.isNone()) return;
+    ast.nodes.items[last_raw] = .{
+        .tag = .empty_statement,
+        .span = last_node.span,
+        .data = .{ .none = 0 },
+    };
+    changed.* = true;
+}
 
 /// function expression 의 name 이 self-reference 안 쓰이면 elide (anonymous 화).
 /// `function Name() {...}` (expression context, e.g. `prototype.method = function Name() {}`)

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -15,6 +15,13 @@ fn expectMinifySyntax(input: []const u8, expected: []const u8) !void {
     return expectMinifyOpts(input, expected, .{ .minify_syntax = true });
 }
 
+/// minify_syntax + minify_whitespace 모두 활성. fold 가 ctx.allow_top_level_inline
+/// (= minify_syntax flag) 가드를 검사하는 케이스 (e.g. function body trailing return elide,
+/// function expression name elide) 의 회귀 가드용.
+fn expectMinifyFull(input: []const u8, expected: []const u8) !void {
+    return expectMinifyOpts(input, expected, .{ .minify_syntax = true, .minify_whitespace = true });
+}
+
 fn expectMinifyOpts(
     input: []const u8,
     expected: []const u8,
@@ -32,7 +39,9 @@ fn expectMinifyOpts(
     var transformer = try Transformer.init(a, &parser.ast, .{});
     const root = try transformer.transform();
 
-    minify_mod.minify(transformer.ast, .empty, a, root);
+    var ctx: minify_mod.MinifyCtx = .empty;
+    ctx.allow_top_level_inline = codegen_opts.minify_syntax;
+    minify_mod.minify(transformer.ast, ctx, a, root);
     minify_mod.mergeDecls(transformer.ast, null);
 
     var cg = Codegen.initWithOptions(a, transformer.ast, codegen_opts);
@@ -240,6 +249,22 @@ test "minify: typeof boolean literal" {
 
 test "minify: typeof null" {
     try expectMinify("const x = typeof null;", "const x = \"object\";");
+}
+
+test "minify: function body trailing return; → empty (implicit return undefined)" {
+    try expectMinifyFull(
+        \\function f() { foo(); return; }
+    ,
+        \\function f(){foo()}
+    );
+}
+
+test "minify: arrow body trailing return; → empty" {
+    try expectMinifyFull(
+        \\const f = () => { foo(); return; };
+    ,
+        \\let f=()=>{foo()};
+    );
 }
 
 test "minify: strict equality numbers" {


### PR DESCRIPTION
## Summary

함수 body 마지막 \`return;\` (operand 없음) 을 \`empty_statement\` 로 변환. implicit \`return undefined\` 와 동등. minify_whitespace 가 empty 자동 elide.

대상: function_declaration / function_expression / function / arrow_function_expression / method_definition.

## 측정

- mobx: 71,097 → **71,090 (-7B)** (1 occurrence)
- zig build test: 0 회귀, 새 unit test 2 (회귀 가드)
- smoke 134: 0 회귀, Average 0.87x 유지

## 한계

mobx 의 다른 `return;` 16개 중 15개는 *if-block 안 nested* — control flow 분석 필요한 별도 epic.

## Closes

- #3267 Q-step2

🤖 Generated with [Claude Code](https://claude.com/claude-code)