### PR TITLE
fix(flow): conditional type infer/extends priority follows Hermes

### DIFF
--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -170,6 +170,82 @@ test "Flow: readonly used as plain type identifier (not variance)" {
     try std.testing.expectEqualStrings("let x=1;", r.output);
 }
 
+// ================================================================
+// Conditional + infer (Hermes parity)
+// ================================================================
+
+test "Flow: simple conditional type stripped" {
+    var r = try e2eFlow(
+        std.testing.allocator,
+        "type T<X> = X extends string ? 1 : 0;\nlet x = 1;",
+    );
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
+test "Flow: conditional with infer T stripped" {
+    var r = try e2eFlow(
+        std.testing.allocator,
+        "type Unwrap<X> = X extends Array<infer U> ? U : X;\nlet x = 1;",
+    );
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
+test "Flow: conditional with infer T extends Bound stripped" {
+    var r = try e2eFlow(
+        std.testing.allocator,
+        "type S<X> = X extends infer Y extends string ? Y : never;\nlet x = 1;",
+    );
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
+test "Flow: nested conditional (true branch)" {
+    var r = try e2eFlow(
+        std.testing.allocator,
+        "type T<X> = X extends string ? (X extends 'a' ? 1 : 2) : 3;\nlet x = 1;",
+    );
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
+test "Flow: nested conditional (false branch)" {
+    var r = try e2eFlow(
+        std.testing.allocator,
+        "type T<X> = X extends string ? 1 : X extends number ? 2 : 3;\nlet x = 1;",
+    );
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
+test "Flow: parenthesized conditional inside extends type" {
+    var r = try e2eFlow(
+        std.testing.allocator,
+        "type T<X> = X extends (Y extends Z ? A : B) ? 1 : 0;\nlet x = 1;",
+    );
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
+test "Flow: infer in array element position" {
+    var r = try e2eFlow(
+        std.testing.allocator,
+        "type First<X> = X extends [infer H, ...infer T] ? H : never;\nlet x = 1;",
+    );
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
+test "Flow: infer with constrained Bound inside parens" {
+    var r = try e2eFlow(
+        std.testing.allocator,
+        "type T<X> = X extends (infer Y extends number) ? Y : 0;\nlet x = 1;",
+    );
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+}
+
 test "Flow: type alias with generic stripped" {
     var r = try e2eFlow(std.testing.allocator, "type List<T> = Array<T>;\nlet x = 1;");
     defer r.deinit();

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -85,13 +85,23 @@ pub fn tryParseReturnType(self: *Parser) ParseError2!NodeIndex {
 /// Flow 타입을 파싱한다.
 /// Babel: flowParseType → flowParseUnionType
 pub fn parseType(self: *Parser) ParseError2!NodeIndex {
+    const enter_allow = self.flow_allow_conditional_type;
     const t = try parseUnionType(self);
 
     // conditional type: T extends X ? Y : Z
-    if (self.current() == .kw_extends) {
-        try self.advance(); // skip 'extends'
-        _ = try parseType(self); // check type
+    // Hermes 와 동일: extends type 안에서는 conditional 금지 — `A extends infer B
+    // extends C ? D : E` 가 `A extends (infer B extends C) ? D : E` 로 결합되도록.
+    if (self.current() == .kw_extends and enter_allow) {
+        try self.advance();
+        {
+            const prev = self.flow_allow_conditional_type;
+            self.flow_allow_conditional_type = false;
+            defer self.flow_allow_conditional_type = prev;
+            _ = try parseUnionType(self); // extends type
+        }
         try self.expect(.question);
+        // true/false branch 는 자체 parseType 진입이 자신의 enter_allow 를 캡처하므로
+        // 여기서 flag 를 만질 필요 없음.
         _ = try parseType(self); // true branch
         try self.expect(.colon);
         _ = try parseType(self); // false branch
@@ -261,10 +271,22 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
     if (self.current() == .identifier and self.isContextual("infer")) {
         try self.advance(); // skip 'infer'
         try self.advance(); // skip type variable name
-        // infer T extends Bound (constrained infer)
+        // infer T extends Bound (constrained infer).
+        // `infer A extends B ?` 일 때 outer 가 conditional 받을 수 있는 상태
+        // (flow_allow_conditional_type=true) 면 `extends B` 는 outer 의 일부 —
+        // backtrack 해서 infer 는 `infer A` 만으로 종료. Hermes 와 동일 (line 3466-3493).
         if (self.current() == .kw_extends) {
+            const cp = Parser.SpeculationCheckpoint.save(self);
             try self.advance();
-            _ = try parseType(self);
+            const prev = self.flow_allow_conditional_type;
+            self.flow_allow_conditional_type = false;
+            defer self.flow_allow_conditional_type = prev;
+            _ = parseUnionType(self) catch {
+                cp.rollback(self);
+            };
+            if (prev and self.current() == .question) {
+                cp.rollback(self);
+            }
         }
         return try self.ast.addNode(.{
             .tag = .flow_literal_type,
@@ -592,6 +614,10 @@ fn parseTypeParameter(self: *Parser) ParseError2!NodeIndex {
 fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
     try self.advance(); // skip '('
+    // 괄호 안은 conditional 항상 가능 — outer context 가 disallow 였더라도 reset.
+    const prev_allow_cond = self.flow_allow_conditional_type;
+    self.flow_allow_conditional_type = true;
+    defer self.flow_allow_conditional_type = prev_allow_cond;
 
     // 빈 괄호: () => Type
     if (self.current() == .r_paren) {

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -201,6 +201,11 @@ pub const Parser = struct {
     /// Flow 반환 타입 파싱 중 — shorthand 함수 타입 `Type => Type` 금지.
     /// (): any => {} 에서 any 뒤 =>가 arrow body인지 shorthand인지 구분.
     flow_in_return_type: bool = false,
+    /// Flow conditional type 의 check/extends 타입 파싱 중인지. true 면 outer
+    /// `?` 가 conditional 의 일부이므로, `infer A extends B ?` 같은 모호한
+    /// sequence 에서 `extends B` 를 infer 가 흡수하지 않고 outer 로 양보.
+    /// Hermes 의 `allowConditionalType_` 와 동등. 기본 true.
+    flow_allow_conditional_type: bool = true,
     /// enum 멤버 초기값 파싱 중인지.
     /// true이면 await/yield를 키워드가 아닌 식별자로 취급한다.
     /// (enum 내에서 다른 멤버를 참조: `enum X { await = 1, y = await }`)


### PR DESCRIPTION
## 요약

`A extends infer B extends C ? D : E` 를 Flow 공식(Hermes) 의미론에 맞춰 `A extends (infer B extends C) ? D : E` 로 결합하도록 fix. 기존엔 `extends C` 를 outer parseType 의 conditional 분기가 흡수해 `infer B extends (C ? D : E)` 로 우-결합되던 버그.

## Root cause

Hermes 의 `allowConditionalType_` flag 의미론 부재. 의미는 두 가지:
- conditional type 의 extends type 안에서는 `?` 가 outer 의 일부 → 그 안 infer 가 `extends X ?` 패턴을 만나면 `extends X` 를 흡수하지 말고 양보해야 함
- 일반 type position 에서는 conditional 가능 → infer 가 `extends X` 를 흡수해도 됨

## 변경

### `src/parser/parser.zig`
- `Parser` 에 `flow_allow_conditional_type: bool = true` 추가.

### `src/parser/flow.zig`
- `parseType`: 진입 시 caller flag (`enter_allow`) 캡처. conditional 분기는 `enter_allow == true` 일 때만 진입. extends type 파싱 동안 flag = false (Hermes line 3110). true/false branch 는 재귀 parseType 이 자기 flag 를 캡처하므로 별도 manipulation 불필요.
- `parsePrimaryType` infer 분기: `extends Bound` 를 `parseUnionType` 으로 파싱 후 caller flag 가 true 이고 `?` 가 보이면 `SpeculationCheckpoint.rollback` — `extends B` 가 outer 의 일부였음을 의미 (Hermes line 3466-3493).
- `parseParenOrFunctionType`: 괄호는 conditional 항상 가능 — flag = true reset.

### 단위 테스트 (`src/codegen/codegen_test/flow.zig`) — 8 개 추가
- simple conditional `X extends string ? 1 : 0`
- conditional + infer `X extends Array<infer U> ? U : X`
- **conditional + infer extends Bound** `X extends infer Y extends string ? Y : never` ← root cause regression
- nested conditional (true branch)
- nested conditional (false branch)
- parenthesized conditional inside extends type
- infer in array element + rest position
- infer with constrained Bound inside parens `(infer Y extends number) ? Y : 0`

## 결과
- `zig build test`: PASS
- 통합 테스트: **flow-libs 55/55 + flow-rn 50/50 = 105/105 pass**

## Reviewer 가이드
parseType 의 conditional 진입 조건 (`enter_allow`) + infer 의 SpeculationCheckpoint backtrack 두 군데가 핵심. 자세한 흐름은 commit body 참조.