### PR TITLE
perf(minify): return/throw + paren/unary 공백 제거 (three -14B, mobx -13B, S3)

### DIFF
--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -235,7 +235,7 @@ test "ES2022: static block with methods preserved" {
 test "ES2017: async function declaration" {
     var r = try e2eFull(std.testing.allocator, "export async function foo() { return await bar(); }", .{ .unsupported = TransformOptions.compat.fromESTarget(.es2016) }, .{ .minify_whitespace = true }, ".mts");
     defer r.deinit();
-    try std.testing.expectEqualStrings("export function foo(){return __async(function*(){return (yield bar());}).call(this);}", r.output);
+    try std.testing.expectEqualStrings("export function foo(){return __async(function*(){return(yield bar());}).call(this);}", r.output);
 }
 
 test "ES2017: async arrow block body" {
@@ -247,7 +247,7 @@ test "ES2017: async arrow block body" {
 test "ES2017: async arrow expression body" {
     var r = try e2eFull(std.testing.allocator, "export const f = async () => await x;", .{ .unsupported = TransformOptions.compat.fromESTarget(.es2016) }, .{ .minify_whitespace = true }, ".mts");
     defer r.deinit();
-    try std.testing.expectEqualStrings("export const f=()=>__async(function*(){return (yield x);}).call(this);", r.output);
+    try std.testing.expectEqualStrings("export const f=()=>__async(function*(){return(yield x);}).call(this);", r.output);
 }
 
 test "ES2017: no transform on es2017" {

--- a/src/codegen/expressions.zig
+++ b/src/codegen/expressions.zig
@@ -81,7 +81,7 @@ pub fn emitBinary(self: anytype, node: Node) !void {
 
 /// unary_expression / update_expression 의 extra = [operand, flags]. flags 의 low byte 가
 /// 연산자 Kind. extra 범위 밖이면 null.
-fn unaryOpKind(self: anytype, extra_base: u32) ?Kind {
+pub fn unaryOpKind(self: anytype, extra_base: u32) ?Kind {
     const extras = self.ast.extra_data.items;
     if (extra_base + 1 >= extras.len) return null;
     return @enumFromInt(@as(u8, @truncate(extras[extra_base + 1])));

--- a/src/codegen/statements.zig
+++ b/src/codegen/statements.zig
@@ -284,7 +284,7 @@ pub fn emitReturn(self: anytype, node: Node) !void {
     try self.addSourceMapping(node.span);
     try self.write("return");
     if (!node.data.unary.operand.isNone()) {
-        try self.writeByte(' ');
+        try writeKeywordOperandSeparator(self, node.data.unary.operand);
         try emitNoLineTerminatorOperand(self, node.data.unary.operand);
     }
     try self.writeByte(';');
@@ -292,9 +292,79 @@ pub fn emitReturn(self: anytype, node: Node) !void {
 
 pub fn emitThrow(self: anytype, node: Node) !void {
     try self.addSourceMapping(node.span);
-    try self.write("throw ");
+    try self.write("throw");
+    try writeKeywordOperandSeparator(self, node.data.unary.operand);
     try emitNoLineTerminatorOperand(self, node.data.unary.operand);
     try self.writeByte(';');
+}
+
+/// `return`/`throw` 같은 keyword 와 *expression operand* 사이의 separator 를 emit.
+/// minify_whitespace 시 operand 가 *non-identifier-start* (paren/string/array/object/
+/// template/unary punctuator `!`/`~`/`-`/`+`) 면 공백 생략 — `return!1` / `return(x)` /
+/// `return"a"` / `return[1]` / `return{x:1}`. 그 외 (identifier/keyword unary
+/// `void`/`typeof`/`delete`/`await`/`yield`/`new`/`function`/`class`) 는 공백 필수.
+/// esbuild/rolldown/rspack 동일 정책.
+fn writeKeywordOperandSeparator(self: anytype, operand: ast_mod.NodeIndex) !void {
+    if (self.options.minify_whitespace and !operandStartsIdentifierLike(self, operand)) return;
+    try self.writeByte(' ');
+}
+
+fn operandStartsIdentifierLike(self: anytype, idx: ast_mod.NodeIndex) bool {
+    return operandStartsIdentifierLikeDepth(self, idx, 0);
+}
+
+/// expression 의 *leftmost token* 이 identifier-like (alphanumeric/keyword) 인지 검사.
+/// binary/logical/assignment/conditional/sequence/member 는 left/object 로 재귀 — 출력
+/// 시작 토큰이 leftmost 자식의 시작 토큰과 같으므로. depth 가드는 기형 AST 안전망.
+fn operandStartsIdentifierLikeDepth(self: anytype, idx: ast_mod.NodeIndex, depth: u32) bool {
+    if (depth >= 32) return true;
+    if (idx.isNone() or @intFromEnum(idx) >= self.ast.nodes.items.len) return true;
+    const n = self.ast.getNode(idx);
+    return switch (n.tag) {
+        // S3 보수적: paren / unary punctuator 만 처리. string/template/array/object 는
+        // codegen_test/{basic,flow,es_downlevel}.zig 의 expected substring 30+ 곳 update
+        // 필요 (generator self-loop helper 의 ASYNC_SENT_RETURN_PREFIX 포함) — 별도 PR S3b.
+        .parenthesized_expression => false,
+        // `return /x/.test(a)` → `return/x/.test(a)` 는 `/x/` 가 division 으로
+        // 오토큰화 가능 — minify_sourcemap ASI-sensitive boundary 회귀 가드 (#1577).
+        .regexp_literal => true,
+        // `new Foo()` 출력 시작은 `new ` 키워드 → identifier-like.
+        .new_expression => true,
+        // unary `!`/`~`/`-`/`+` start with punctuator. `void`/`typeof`/`delete`/`await`/
+        // `yield` 같은 keyword unary 는 identifier-like.
+        .unary_expression => switch (@import("expressions.zig").unaryOpKind(self, n.data.extra) orelse return true) {
+            .bang, .tilde, .minus, .plus => false,
+            else => true,
+        },
+        // prefix `++x`/`--x` 는 punctuator 시작, postfix `x++` 는 identifier 시작.
+        .update_expression => blk: {
+            const extras = self.ast.extra_data.items;
+            if (n.data.extra + 1 >= extras.len) break :blk true;
+            break :blk ast_mod.UnaryFlags.isPostfix(extras[n.data.extra + 1]);
+        },
+        // leftmost 자식으로 따라가기 (출력 시작 토큰 = leftmost child 의 시작).
+        .binary_expression, .logical_expression, .assignment_expression => operandStartsIdentifierLikeDepth(self, n.data.binary.left, depth + 1),
+        .conditional_expression => operandStartsIdentifierLikeDepth(self, n.data.ternary.a, depth + 1),
+        .static_member_expression, .computed_member_expression, .private_field_expression => blk: {
+            const ex = n.data.extra;
+            if (ex >= self.ast.extra_data.items.len) break :blk true;
+            const obj_idx: ast_mod.NodeIndex = @enumFromInt(self.ast.extra_data.items[ex]);
+            break :blk operandStartsIdentifierLikeDepth(self, obj_idx, depth + 1);
+        },
+        .call_expression => blk: {
+            const ex = n.data.extra;
+            if (ex >= self.ast.extra_data.items.len) break :blk true;
+            const callee_idx: ast_mod.NodeIndex = @enumFromInt(self.ast.extra_data.items[ex]);
+            break :blk operandStartsIdentifierLikeDepth(self, callee_idx, depth + 1);
+        },
+        .sequence_expression => blk: {
+            const list = n.data.list;
+            if (list.len == 0) break :blk true;
+            const indices = self.ast.extra_data.items[list.start .. list.start + list.len];
+            break :blk operandStartsIdentifierLikeDepth(self, @enumFromInt(indices[0]), depth + 1);
+        },
+        else => true,
+    };
 }
 
 /// `return` / `throw` 처럼 ECMAScript `NoLineTerminator` restriction 이 있는

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1746,6 +1746,10 @@ pub const MemberFlags = struct {
 /// operator_and_flags: bits [0-7] = operator Kind, bit 8 = postfix, bits [16-31] = 확장 플래그
 pub const UnaryFlags = struct {
     pub const postfix: u32 = 0x100; // x++ / x--
+
+    pub fn isPostfix(flags: u32) bool {
+        return (flags & postfix) != 0;
+    }
 };
 
 /// arrow_function_expression의 flags (D082).

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -267,6 +267,109 @@ test "minify: arrow body trailing return; → empty" {
     );
 }
 
+// ================================================================
+// S3: return / throw + non-identifier-start operand 공백 제거
+// ================================================================
+
+test "minify_whitespace: return + paren expression — space 제거" {
+    try expectMinifyFull(
+        \\function f() { return (a + b); }
+    ,
+        \\function f(){return(a+b)}
+    );
+}
+
+test "minify_whitespace: return + unary `!` — space 제거" {
+    try expectMinifyFull(
+        \\function f() { return !x; }
+    ,
+        \\function f(){return!x}
+    );
+}
+
+test "minify_whitespace: return + unary `-x` — space 제거 (identifier operand)" {
+    try expectMinifyFull(
+        \\function f(x) { return -x; }
+    ,
+        \\function f(x){return-x}
+    );
+}
+
+test "minify_whitespace: return + numeric literal `-1` — 공백 유지 (parser fold)" {
+    // parser 가 `-1` 을 numeric_literal(-1) 로 fold 하므로 unary_expression 으로 들어오지 않음.
+    // 보수적으로 공백 유지 (literal raw text 첫 char 검사 미적용).
+    try expectMinifyFull(
+        \\function f() { return -1; }
+    ,
+        \\function f(){return -1}
+    );
+}
+
+test "minify_whitespace: return + binary 의 left=paren — recursive 검출" {
+    // `return (1-t)*x;` 의 leftmost 토큰이 `(` 라 공백 불필요.
+    try expectMinifyFull(
+        \\function f(t, x) { return (1 - t) * x; }
+    ,
+        \\function f(t,x){return(1-t)*x}
+    );
+}
+
+test "minify_whitespace: return + identifier — 공백 보존 필수" {
+    try expectMinifyFull(
+        \\function f() { return foo; }
+    ,
+        \\function f(){return foo}
+    );
+}
+
+test "minify_whitespace: return + `void 0` — 공백 보존 필수 (keyword unary)" {
+    try expectMinifyFull(
+        \\function f() { return void 0; }
+    ,
+        \\function f(){return void 0}
+    );
+}
+
+test "minify_whitespace: throw + paren — 공백 제거" {
+    try expectMinifyFull(
+        \\function f() { throw (a + b); }
+    ,
+        \\function f(){throw(a+b)}
+    );
+}
+
+test "minify_whitespace: throw + string literal — 공백 보존 (S3 보수 — string 별도 PR)" {
+    try expectMinifyFull(
+        \\function f() { throw "err"; }
+    ,
+        \\function f(){throw "err"}
+    );
+}
+
+test "minify_whitespace: throw + `new` keyword — 공백 보존 필수" {
+    try expectMinifyFull(
+        \\function f() { throw new Error("x"); }
+    ,
+        \\function f(){throw new Error("x")}
+    );
+}
+
+test "minify_whitespace: return + postfix update `x++` — 공백 보존" {
+    try expectMinifyFull(
+        \\function f(x) { return x++; }
+    ,
+        \\function f(x){return x++}
+    );
+}
+
+test "minify_whitespace: return + prefix update `++x` — 공백 제거" {
+    try expectMinifyFull(
+        \\function f(x) { return ++x; }
+    ,
+        \\function f(x){return++x}
+    );
+}
+
 test "minify: typeof X === \"number\" → typeof X == \"number\" (operator only)" {
     try expectMinify(
         \\const a = typeof v === "number";


### PR DESCRIPTION
## Summary

`return X;` / `throw X;` 출력 시 X 의 *leftmost token* 이 *non-identifier-start* (`(` 또는 unary punctuator `!`/`~`/`-`/`+`/`++`/`--`) 면 keyword 와 operand 사이의 공백을 생략 (minify_whitespace 모드 한정). esbuild/rolldown/rspack 동일.

- three.js: 210862 → 210848 (-14B, 16 paren occurrences)
- mobx: 55688 → 55675 (-13B)

## 보수 정책 (S3 = paren + unary punctuator 만)

string/template/array/object literal 의 공백 제거는 codegen_test/{basic,flow,es_downlevel}.zig 의 expected substring 30+ 곳 update 필요 (특히 generator self-loop helper 의 `ASYNC_SENT_RETURN_PREFIX = "_state.sent();return [3,"` 가 패턴 매치 의존). 변경 단위가 커서 **별도 PR (S3b) 으로 분리**.

regexp_literal 은 `return /x/.test(a)` → `return/x/.test(a)` 시 `/x/` 가 division 으로 오토큰화 가능 — minify_sourcemap ASI-sensitive boundary 회귀 가드 (#1577) 에 따라 보수적으로 공백 유지.

## 구현

- `writeKeywordOperandSeparator(self, operand)` — emitReturn / emitThrow 가 공유. minify_whitespace 시만 검사 (else 항상 공백).
- `operandStartsIdentifierLikeDepth(self, idx, depth)` — leftmost-walk (binary.left, ternary.a, member.object, call.callee, sequence.first 로 재귀, depth 32 가드)
- `unaryOpKind` (expressions.zig) 를 pub 으로 promote 후 재사용 — extra layout 중복 cast 제거
- `UnaryFlags.isPostfix(flags)` helper 추가 — `(flags & postfix) != 0` 패턴 centralize

## es_downlevel test 2건 expected update

`return (yield bar());` 가 `return(yield bar());` 로 출력 — paren 케이스의 정상 동작 적용. 의미 동일.

## Test plan

- [x] zig build test — 5056/5060 통과 (회귀 0; 4 skip)
- [x] minify_test.zig 회귀 가드 12개 신규 (paren / `!` / `-x` / numeric -1 보수 / binary-left=paren / identifier 보존 / `void 0` 보존 / throw paren / throw string 보수 / throw `new` 보존 / postfix `x++` 보존 / prefix `++x` 제거)
- [x] three: -14B 확인 / mobx: -13B 확인
- [x] simplify 후 3-agent review 적용 (unaryOpKind 재사용 + UnaryFlags.isPostfix + .new_expression 별도 arm)

## 후속 PR

- **S3b**: string/array/object/template + test bulk update (격차 큼)
- **S4**: ASI semicolon elision (~2KB three)
- **S5 RFC**: namespace re-export property-level deep tree-shake (~56KB three)

🤖 Generated with [Claude Code](https://claude.com/claude-code)