### PR TITLE
perf(minify): const → let 변환 + mergeDecls 통합 (three -40B, S4b)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1638,6 +1638,14 @@ pub fn emitModule(
         @import("../transformer/minify.zig").downgradeToVar(transformer.ast);
     }
 
+    // S4b: function/class body 안 const → let 변환 (전체 AST). minify_syntax 시
+    // *섞인 const/let 시퀀스* 도 mergeDecls 가 *let 단일 kind* 로 합칠 수 있게 한다.
+    // 재할당 의미 변경 (TypeError → silent) 은 minify-only 모드라 정상 — terser/esbuild/
+    // rolldown/rspack 동일.
+    if (options.minify_syntax) {
+        @import("../transformer/minify.zig").convertConstToLet(transformer.ast);
+    }
+
     // Private field name mangle (#1632 Phase 1) — `#commit_callbacks` 같은 긴 이름을
     // class 별 독립 범위로 `#a`, `#b`, ... 단축. JS 언어 규약상 private name 은 선언된
     // class body 바깥에서 참조 불가 → per-class 안전. minify_identifiers 플래그와 묶음.

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -1255,6 +1255,10 @@ pub const Ast = struct {
         return VariableDeclarationKind.fromU32(self.extra_data.items[node.data.extra]);
     }
 
+    pub inline fn setVariableDeclarationKind(self: *Ast, node: Node, kind: VariableDeclarationKind) void {
+        self.extra_data.items[node.data.extra] = @intFromEnum(kind);
+    }
+
     /// `formal_parameters` 노드를 생성한다. transformer가 function/method를 새로 만들 때
     /// slot 1(arrow는 slot 0)에 넣을 NodeIndex를 반환 — caller는 `@intFromEnum(...)` 으로 extras에 기록.
     pub fn addFormalParameters(self: *Ast, list: NodeList, span: Span) !NodeIndex {

--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -1112,7 +1112,28 @@ pub fn downgradeToVar(ast: *Ast) void {
 
         const e = stmt.data.extra;
         if (e >= ast.extra_data.items.len) continue;
-        ast.extra_data.items[e] = 0; // VariableDeclarationKind.var = 0
+        ast.setVariableDeclarationKind(stmt, .@"var");
+    }
+}
+
+/// `const` → `let` 으로 변환 (전체 AST 순회).
+///
+/// **호출자 계약**: minify_syntax 모드에서만 호출 + `mergeDecls` 직전. *재할당 의미 변경*
+/// (TypeError → silent) 을 허용하므로 minify-only 파이프라인 외에선 호출 금지.
+/// for-loop init / for-of/for-in left binding 의 const 도 let 으로 변환해 동일 (각 iter
+/// 새 binding 의미 유지). esbuild/rolldown/rspack/terser 동일.
+///
+/// **목적**: `mergeDecls` 가 *동일 kind* 만 merge — `const a=1; let b=2; const c=3;` 같은
+/// *섞인 시퀀스* 는 *3 declaration* 으로 남는다. const → let 통일 후 `let a=1,b=2,c=3;`
+/// 로 합쳐져 *2 declaration + 2 byte* 절감.
+pub fn convertConstToLet(ast: *Ast) void {
+    for (ast.nodes.items) |stmt| {
+        if (stmt.tag != .variable_declaration) continue;
+        const e = stmt.data.extra;
+        if (e >= ast.extra_data.items.len) continue;
+        if (ast.extra_data.items[e] == @intFromEnum(VariableDeclarationKind.@"const")) {
+            ast.setVariableDeclarationKind(stmt, .let);
+        }
     }
 }
 

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -708,6 +708,29 @@ test "merge decls: 다른 kind는 merge 안 함" {
     );
 }
 
+test "S4b: convertConstToLet + mergeDecls — const/let 섞임 → let 합침" {
+    // S4b: minify_syntax 시 const → let 변환 후 mergeDecls 가 동일 kind 로 합침.
+    // 호출자 (transpile.zig / emitter.zig) 가 convertConstToLet 직후 mergeDecls 실행.
+    const a_alloc = std.testing.allocator;
+    var arena = std.heap.ArenaAllocator.init(a_alloc);
+    defer arena.deinit();
+    const a = arena.allocator();
+    var scanner = try Scanner.init(a, "const a = 1; let b = 2; const c = 3;");
+    var parser = Parser.init(a, &scanner);
+    _ = try parser.parse();
+    var transformer = try Transformer.init(a, &parser.ast, .{});
+    const root = try transformer.transform();
+    var ctx: minify_mod.MinifyCtx = .empty;
+    ctx.allow_top_level_inline = true;
+    minify_mod.minify(transformer.ast, ctx, a, root);
+    minify_mod.convertConstToLet(transformer.ast);
+    minify_mod.mergeDecls(transformer.ast, null);
+    var cg = Codegen.initWithOptions(a, transformer.ast, .{ .minify_whitespace = true, .minify_syntax = true });
+    const result = try cg.generate(root);
+    const trimmed = std.mem.trimRight(u8, result, "\n");
+    try std.testing.expectEqualStrings("let a=1,b=2,c=3;", trimmed);
+}
+
 test "merge decls: const/let 섞임은 merge 안 함" {
     try expectMinify(
         "const a = 1; let b = 2;",

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -1317,6 +1317,8 @@ fn transpileWithCallbackInternal(
             .allow_top_level_inline = options.minify_syntax,
         };
         minify_mod.minify(transformer.ast, ctx, arena_alloc, root);
+        // S4b: 단일 파일 모드에서도 const → let 변환 후 mergeDecls — esbuild parity.
+        if (options.minify_syntax) minify_mod.convertConstToLet(transformer.ast);
         minify_mod.mergeDecls(transformer.ast, null);
     }
 


### PR DESCRIPTION
## Summary

`minify_syntax` 모드에서 모든 `const` 를 `let` 으로 변환 후 `mergeDecls` 가 *섞인 시퀀스* 를 단일 kind 로 합치도록 한다 (esbuild/rolldown/rspack/terser 동일 정책).

- **three**: 210848 → 210808 (-40B, function/class body 안 const 6275/9088 변환, mergeDecls 가 추가 10 declaration 합침)
- **mobx**: 변화 없음 (이미 let-dominant 분포)

## Root cause

기존 `mergeDecls` 는 *동일 kind* (let+let, const+const, var+var) 만 merge. `const a=1; let b=2; const c=3;` 같은 *섞인 시퀀스* 는 *3 declaration* 으로 남았다. *같은 kind* 로 통일 후 single-statement merge 가 가능.

re할당 의미 변경 (`const x=1; x=2;` 가 *runtime TypeError* → *silent*) 은 minify-only 모드라 정상 — terser/esbuild/rolldown/rspack 모두 동일 정책.

## 구현

- `src/transformer/minify.zig`: `convertConstToLet(ast)` 추가 — 전체 AST 의 variable_declaration 의 kind 를 const → let 으로 일괄 변환
- `src/parser/ast.zig`: `setVariableDeclarationKind` 헬퍼 추가 (기존 raw 인덱스 접근 패턴 정리)
- `src/bundler/emitter.zig`: `convertConstToLet` 호출 추가 (downgradeToVar 다음, mergeDecls 직전, minify_syntax 가드)
- `src/transpile.zig`: 단일 파일 모드도 동일 호출 — esbuild parity
- `downgradeToVar` 도 raw `0` literal → `setVariableDeclarationKind` 로 정리 (3-agent simplify Q1 적용)

## 3-agent simplify findings 적용

- ✅ Q1: raw `2` / `1` literal → `@intFromEnum(VariableDeclarationKind.@"const")` + `setVariableDeclarationKind` 헬퍼 추가 (`downgradeToVar` 도 동일 패턴 정리)
- ✅ Q2: 도c-comment 의 *호출자 계약* 명시 (gating 은 caller 에 두고 doc 으로 표현)
- ⏭️ Q3 (full walk): 의도된 동작 (function body 안 const 도 처리해야 함)
- ⏭️ Q4 (helper 추출): caller 별 gating 다름 — duplication 비용 < abstraction 위험

## Test plan

- [x] zig build test — 5086/5090 통과 (회귀 0; 4 skip + 1 새 회귀 가드)
- [x] minify_test: `S4b: convertConstToLet + mergeDecls — const/let 섞임 → let 합침` 가드
- [x] three.js bundle: -40B 확인

## 후속 PR

- **S5**: namespace re-export property-level deep tree-shake (three -56KB potential — 별도 RFC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)