### PR TITLE
perf(minify): if-else multi-expr block → ternary (three -54B, jotai -6B, S6-step1)

### DIFF
--- a/src/codegen/codegen_test/basic.zig
+++ b/src/codegen/codegen_test/basic.zig
@@ -716,12 +716,12 @@ test "Codegen #3107: 본문이 logical expr + else 없음 은 && 변환 안 함"
     try std.testing.expectEqualStrings("if(c)a||b;", r.output);
 }
 
-test "Codegen #3107: 2개 expression statement block — sequence 로 unwrap" {
-    // minify_syntax 활성 시 block 안 모두 expression statement 면 comma operator
-    // sequence 로 합치고 block `{}` 제거. single-stmt unwrap 의 자연 확장.
+test "Codegen #3107: if-else multi-expr block — ternary 로 합침 (S6)" {
+    // S6: minify_syntax 시 if-else 의 양쪽 본문이 expression statement (single 또는
+    // multi-expr block) 면 `c?(a,b):x;` ternary 로 합침. comma sequence 는 paren 보호.
     var r = try e2eMinAll(std.testing.allocator, "if (c) { a(); b(); } else { x(); }");
     defer r.deinit();
-    try std.testing.expectEqualStrings("if(c)a(),b();else x();", r.output);
+    try std.testing.expectEqualStrings("c?(a(),b()):x();", r.output);
 }
 
 test "Codegen: do-while 본문 multi-expr block — sequence unwrap + 키워드 spacing" {

--- a/src/codegen/statements.zig
+++ b/src/codegen/statements.zig
@@ -169,6 +169,14 @@ pub fn canEmitMultiExprBlockAsSequence(self: anytype, body_idx: NodeIndex) bool 
 /// declaration 또는 control flow statement 가 끼면 false (block 그대로 emit).
 fn emitMultiExprBlockAsSequence(self: anytype, body_idx: NodeIndex) !bool {
     if (!canEmitMultiExprBlockAsSequence(self, body_idx)) return false;
+    try emitMultiExprBlockSeqInner(self, body_idx);
+    try self.writeByte(';');
+    return true;
+}
+
+/// `canEmitMultiExprBlockAsSequence` 가 true 인 block 의 expr statement 들을
+/// `a,b,c` (trailing `;` 없음) 로 emit. ternary branch 등 `;` 가 부적합한 위치 공유.
+fn emitMultiExprBlockSeqInner(self: anytype, body_idx: NodeIndex) !void {
     const body = self.ast.getNode(body_idx);
     const list = body.data.list;
     const indices = self.ast.extra_data.items[list.start .. list.start + list.len];
@@ -181,8 +189,28 @@ fn emitMultiExprBlockAsSequence(self: anytype, body_idx: NodeIndex) !bool {
         try self.emitNode(n.data.unary.operand);
         first = false;
     }
-    try self.writeByte(';');
-    return true;
+}
+
+/// `if` branch 가 ternary 의 한 쪽 (`c ? X : Y`) 으로 출력 가능한지 — single
+/// expression statement 또는 multi-expr block (comma sequence) 면 true.
+fn canEmitTernaryBranch(self: anytype, branch_idx: NodeIndex) bool {
+    if (singleExprStmt(self, branch_idx) != null) return true;
+    return canEmitMultiExprBlockAsSequence(self, branch_idx);
+}
+
+/// ternary branch emit. comma sequence (single sequence_expression 또는 multi-expr
+/// block) 는 paren 으로 감싼다 — comma 가 `?:` 보다 우선순위 낮음.
+fn emitTernaryBranch(self: anytype, branch_idx: NodeIndex) !void {
+    if (singleExprStmt(self, branch_idx)) |e| {
+        const seq = self.ast.getNode(e).tag == .sequence_expression;
+        if (seq) try self.writeByte('(');
+        try self.emitNode(e);
+        if (seq) try self.writeByte(')');
+        return;
+    }
+    try self.writeByte('(');
+    try emitMultiExprBlockSeqInner(self, branch_idx);
+    try self.writeByte(')');
 }
 
 /// `body_idx` 가 minify 시 `{}` 를 벗길 수 있는 block 이면 그 안의 단일 statement idx,
@@ -572,10 +600,10 @@ fn isSafeAndOperand(tag: ast_mod.Node.Tag) bool {
 /// minify_syntax 전용. 양쪽 본문이 단일 expression statement 이고 paren-safety 충족 시만.
 fn tryEmitIfExprStatement(self: anytype, t: anytype) !bool {
     if (!self.options.minify_syntax) return false;
-    const then_expr = singleExprStmt(self, t.b) orelse return false;
     const has_else = !t.c.isNone() and !isElidedAlternate(self, t.c);
     if (!has_else) {
         // `if(c)a();` → `c&&a();` — c 와 a() 둘 다 `&&` 피연산자로 paren 없이 와야 함.
+        const then_expr = singleExprStmt(self, t.b) orelse return false;
         if (!isSafeAndOperand(self.ast.getNode(t.a).tag)) return false;
         if (!isSafeAndOperand(self.ast.getNode(then_expr).tag)) return false;
         try self.emitNode(t.a);
@@ -586,19 +614,20 @@ fn tryEmitIfExprStatement(self: anytype, t: anytype) !bool {
         try self.writeByte(';');
         return true;
     }
-    const else_expr = singleExprStmt(self, t.c) orelse return false;
+    // `if(c){A}else{B}` → `c?A:B;`. A/B 는 single expr statement 또는 multi-expr
+    // block (comma sequence) — 둘 다 ternary branch 로 paren-safe emit (S6).
     if (!isSafeTernaryTest(self.ast.getNode(t.a).tag)) return false;
-    if (self.ast.getNode(then_expr).tag == .sequence_expression) return false;
-    if (self.ast.getNode(else_expr).tag == .sequence_expression) return false;
+    if (!canEmitTernaryBranch(self, t.b)) return false;
+    if (!canEmitTernaryBranch(self, t.c)) return false;
     try self.emitNode(t.a);
     try writeSpace(self);
     try self.writeByte('?');
     try writeSpace(self);
-    try self.emitNode(then_expr);
+    try emitTernaryBranch(self, t.b);
     try writeSpace(self);
     try self.writeByte(':');
     try writeSpace(self);
-    try self.emitNode(else_expr);
+    try emitTernaryBranch(self, t.c);
     try self.writeByte(';');
     return true;
 }

--- a/src/transformer/minify_test.zig
+++ b/src/transformer/minify_test.zig
@@ -708,6 +708,40 @@ test "merge decls: 다른 kind는 merge 안 함" {
     );
 }
 
+test "S6-step1: if-else else=sequence → ternary (paren 보호)" {
+    try expectMinifyFull(
+        \\function f(o) { if (typeof o == "function") o.read = 1; else { o.init = 2; o.read = 3; } return o; }
+    ,
+        \\function f(o){typeof o=="function"?o.read=1:(o.init=2,o.read=3);return o}
+    );
+}
+
+test "S6-step1: if-else then=multi-block, else=single → ternary" {
+    try expectMinifyFull(
+        \\function f(c) { if (c) { a(); b(); } else { x(); } }
+    ,
+        \\function f(c){c?(a(),b()):x()}
+    );
+}
+
+test "S6-step1: if-else 둘 다 single expr → ternary (paren 불필요)" {
+    try expectMinifyFull(
+        \\function f(c) { if (c) a(); else b(); }
+    ,
+        \\function f(c){c?a():b()}
+    );
+}
+
+test "S6-step1: if (no else) multi-stmt block — block 유지 (&& 변환은 별도 step)" {
+    // else 없고 then 이 multi-expr block 이면 `c&&(a,b)` 변환 미지원 (별도 step).
+    // M10/M11 의 multi-expr unwrap 으로 `if(c)a(),b()` 만 — block `{}` 제거.
+    try expectMinifyFull(
+        \\function f(c) { if (c) { a(); b(); } }
+    ,
+        \\function f(c){if(c)a(),b()}
+    );
+}
+
 test "S4b: convertConstToLet + mergeDecls — const/let 섞임 → let 합침" {
     // S4b: minify_syntax 시 const → let 변환 후 mergeDecls 가 동일 kind 로 합침.
     // 호출자 (transpile.zig / emitter.zig) 가 convertConstToLet 직후 mergeDecls 실행.


### PR DESCRIPTION
## Summary

S6 RFC 첫 step — `if(c){A}else{B}` → `c?A:B;` 변환을 *A/B 가 multi-expr block* 인 경우까지 확장. 기존엔 sequence_expression branch 를 거부했으나, 이제 comma sequence 를 paren 으로 감싸 ternary branch 로 emit (esbuild/rolldown/rspack/terser 동일).

- **three**: 210808 → 210754 (-54B)
- **jotai**: 393 → 387 (-6B — esbuild 389 / rolldown 392 보다 작음 ✅)
- mobx: 변화 없음 (이미 ternary 위주)

## Root cause

jotai/three 의 `if (typeof x === 'function') { config.read = x; } else { config.init = x; config.read = d; config.write = w; }` 같은 패턴 — else 본문이 *3 statement block*. `singleExprStmt` 가 *single statement* 만 처리해 변환 거부 → if-else verbatim. rspack 은 `(u.init=e,u.read=n,u.write=i)` 로 comma sequence 변환.

## 구현

- `emitMultiExprBlockAsSequence` → `emitMultiExprBlockSeqInner` (trailing `;` 없음) + thin wrapper 로 분리. ternary branch 와 공유.
- `canEmitTernaryBranch(branch_idx)` — single expr stmt 또는 multi-expr block 이면 true
- `emitTernaryBranch(branch_idx)` — single (sequence 면 paren) 또는 multi-expr block (항상 `(a,b,c)` paren). comma 가 `?:` 보다 우선순위 낮아 paren 필수.
- `tryEmitIfExprStatement` else-branch path 가 새 helper 사용 (sequence 거부 가드 제거)

## Test plan

- [x] zig build test — 5090/5094 통과 (회귀 0; 4 skip)
- [x] minify_test: S6-step1 회귀 가드 4개 (else=seq / then=multi-block / 둘다 single / no-else multi-block 은 block 유지)
- [x] basic.zig #3107 expected update: `if(c)a(),b();else x();` → `c?(a(),b()):x();` (새 동작이 더 짧고 정확)
- [x] three -54B / jotai -6B 확인
- [x] 3-agent simplify: clean — 변경 불필요 판정

## 후속 PR (S6 RFC)

- **S6-step2**: if (no else) multi-expr block → `c&&(a,b)` 변환
- **S6-step3**: production define 자동 (rspack mode parity) 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)