### PR TITLE
perf(minify): shared-ns getter object → arrow __export (zod -930B, G1-step2)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -811,6 +811,7 @@ pub const Bundler = struct {
         var worker_linker = Linker.init(arena_alloc, &worker_graph, format);
         // #1621: worker 청크도 minify 시 preamble 축약 이름 사용.
         worker_linker.minify_whitespace = self.options.minify_whitespace;
+        worker_linker.configurable_exports = self.options.configurable_exports;
         worker_linker.inline_requires = self.options.platform == .react_native;
         try worker_linker.link();
         try worker_linker.finalize(.{
@@ -1100,6 +1101,7 @@ pub const Bundler = struct {
             l.inline_requires = self.options.platform == .react_native;
             // #1621: preamble/metadata 가 __toESM/__toCommonJS 를 축약 이름으로 emit.
             l.minify_whitespace = self.options.minify_whitespace;
+            l.configurable_exports = self.options.configurable_exports;
             // #1791 Phase D: value-ref 0 binding elision 정책을 transformer 와 동기화.
             l.verbatim_module_syntax = self.options.verbatim_module_syntax;
             // #1824: IIFE external globals 매핑 — linker 가 매핑 유무로 preamble 경로 분기.

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -173,6 +173,9 @@ pub const Linker = struct {
     /// 를 linker 생성 직후 설정한다. dev_mode 에서는 `__zntc_g.__xxx` 경로를
     /// 사용하므로 이 플래그는 무시된다.
     minify_whitespace: bool = false,
+    /// RN/Hermes: defineProperty 에 configurable:true 필요. G1-step2 의 ns arrow
+    /// `__export` helper 변형 선택에 사용 (minify_whitespace 와 동일하게 생성 직후 set).
+    configurable_exports: bool = false,
 
     /// --shim-missing-exports: missing export에 대해 `var xxx = void 0;` shim 생성.
     shim_missing_exports: bool = false,

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -292,11 +292,42 @@ pub fn appendSharedNamespacePreambleFiltered(
     };
     std.mem.sort(u32, sorted_targets, SortCtx{ .linker = self }, SortCtx.lessThan);
 
+    // G1-step2: 첫 arrow 변환 entry 직전에 helper 를 같은 buffer (preamble) 맨 앞쪽에
+    // lazy emit — `$x(V,{...})` 사용처보다 물리적으로 먼저 정의되어 emit-order 무관.
+    // helper 본문은 canonical `rt.EXPORT_RUNTIME_*_MIN` 재사용 (3rd copy drift 방지) +
+    // configurable variant 로 RN/Hermes 의 `configurable:true` 보존. `$x`/`$dp` 는
+    // NAMES 등록 이름이라 mangler-safe; esm-wrap 가 같은 variant 를 정의해도 `var`
+    // 재선언 + 동일 본문이라 무해.
+    var helper_emitted = false;
     for (sorted_targets) |target_mod_idx| {
         if (target_filter) |f| {
             if (!f.contains(target_mod_idx)) continue;
         }
         const entry = self.ns_shared_inline_cache.get(target_mod_idx) orelse continue;
+        if (self.minify_whitespace) {
+            if (try tryRewriteGetterObjToArrowExport(self.allocator, entry.object_literal)) |arrow_map| {
+                defer self.allocator.free(arrow_map);
+                if (!helper_emitted) {
+                    try out.appendSlice(self.allocator, "var " ++ rt.NAMES.DEF_PROP_MIN ++ "=Object.defineProperty;");
+                    try out.appendSlice(self.allocator, if (self.configurable_exports)
+                        rt.EXPORT_RUNTIME_CONFIGURABLE_MIN
+                    else
+                        rt.EXPORT_RUNTIME_MIN);
+                    try out.appendSlice(self.allocator, "\n");
+                    helper_emitted = true;
+                }
+                try out.appendSlice(self.allocator, "var ");
+                try out.appendSlice(self.allocator, entry.var_name);
+                try out.appendSlice(self.allocator, "={};");
+                try out.appendSlice(self.allocator, rt.NAMES.EXPORT_MIN);
+                try out.appendSlice(self.allocator, "(");
+                try out.appendSlice(self.allocator, entry.var_name);
+                try out.appendSlice(self.allocator, ",");
+                try out.appendSlice(self.allocator, arrow_map);
+                try out.appendSlice(self.allocator, ");\n");
+                continue;
+            }
+        }
         try out.appendSlice(self.allocator, "var ");
         try out.appendSlice(self.allocator, entry.var_name);
         try out.appendSlice(self.allocator, " = ");
@@ -316,6 +347,104 @@ pub fn appendSharedNamespacePreambleFiltered(
             });
         }
     }
+}
+
+/// G1-step2: export 개수 임계 — 미만이면 helper 고정비용(~84B)이 절감을 못 넘는다.
+const ARROW_EXPORT_MIN = 9;
+
+fn isIdentChar(c: u8) bool {
+    return (c >= 'a' and c <= 'z') or (c >= 'A' and c <= 'Z') or
+        (c >= '0' and c <= '9') or c == '_' or c == '$';
+}
+
+/// minify_whitespace getter object `{get a(){return x},get "b"(){return f(y)}}`
+/// → arrow export map `{a:()=>x,"b":()=>f(y)}` (caller 가 `var V={};$x(V,<map>)`).
+/// 순수 getter object (모든 멤버 `get NAME(){return VAL}`) + export ≥ ARROW_EXPORT_MIN
+/// 일 때만 성공. nested re-export (`NAME:{...}`) 등 다른 형태 1개라도 섞이면 null
+/// (getter object 유지). 우리 codegen 이 생성한 deterministic 형식 전제 — VAL 안의
+/// string/template 만 상태 추적, 그 외는 depth-balance (zod 검증).
+fn tryRewriteGetterObjToArrowExport(
+    allocator: std.mem.Allocator,
+    obj: []const u8,
+) std.mem.Allocator.Error!?[]const u8 {
+    if (obj.len < 2 or obj[0] != '{' or obj[obj.len - 1] != '}') return null;
+    var result: std.ArrayList(u8) = .empty;
+    // `return null` 과 error(`try`) 양쪽 모두 ok=false 상태 → 단일 defer 로 정리.
+    // 성공 시에만 ok=true 로 소유권 이전 (toOwnedSlice).
+    var ok = false;
+    defer if (!ok) result.deinit(allocator);
+    try result.append(allocator, '{');
+    var i: usize = 1;
+    var count: usize = 0;
+    const end = obj.len - 1; // 마지막 `}` 제외
+    while (i < end) {
+        if (!std.mem.startsWith(u8, obj[i..], "get ")) return null;
+        i += 4;
+        const name_start = i;
+        if (i < end and obj[i] == '"') {
+            i += 1;
+            while (i < end and obj[i] != '"') : (i += 1) {
+                if (obj[i] == '\\') i += 1;
+            }
+            if (i >= end) return null;
+            i += 1; // closing "
+        } else {
+            while (i < end and isIdentChar(obj[i])) : (i += 1) {}
+        }
+        if (i == name_start) return null;
+        const name = obj[name_start..i];
+        if (!std.mem.startsWith(u8, obj[i..], "(){return ")) return null;
+        i += 10;
+        const val_start = i;
+        var depth: usize = 0;
+        var in_str: u8 = 0;
+        while (i < obj.len) : (i += 1) {
+            const c = obj[i];
+            if (in_str != 0) {
+                if (c == '\\') {
+                    i += 1;
+                } else if (c == in_str) {
+                    in_str = 0;
+                }
+                continue;
+            }
+            switch (c) {
+                '"', '\'', '`' => in_str = c,
+                '(', '[', '{' => depth += 1,
+                ')', ']' => {
+                    if (depth == 0) return null;
+                    depth -= 1;
+                },
+                '}' => {
+                    if (depth == 0) break;
+                    depth -= 1;
+                },
+                else => {},
+            }
+        }
+        if (i >= obj.len or obj[i] != '}') return null;
+        const val = obj[val_start..i];
+        if (val.len == 0) return null;
+        i += 1; // skip getter close `}`
+        if (count > 0) try result.append(allocator, ',');
+        try result.appendSlice(allocator, name);
+        try result.appendSlice(allocator, ":()=>");
+        // VAL 이 `{` 로 시작하면 arrow body 가 block 으로 오파싱 (`()=>{k:1}` 은
+        // label statement). object literal 반환은 paren 필수 — `()=>({k:1})`.
+        const wrap_obj = val[0] == '{';
+        if (wrap_obj) try result.append(allocator, '(');
+        try result.appendSlice(allocator, val);
+        if (wrap_obj) try result.append(allocator, ')');
+        count += 1;
+        if (i < end) {
+            if (obj[i] != ',') return null;
+            i += 1;
+        }
+    }
+    if (count < ARROW_EXPORT_MIN) return null;
+    try result.append(allocator, '}');
+    ok = true;
+    return try result.toOwnedSlice(allocator);
 }
 
 pub fn restoreSharedNamespaceDecls(self: *const Linker, decls: []const CompiledModule.SharedNsDecl) std.mem.Allocator.Error!void {
@@ -705,4 +834,53 @@ fn needsPropertyQuoteForExport(name: []const u8) bool {
     if (name[0] >= '0' and name[0] <= '9') return true;
     if (name[0] != '_' and name[0] != '$' and !(name[0] >= 'a' and name[0] <= 'z') and !(name[0] >= 'A' and name[0] <= 'Z')) return true;
     return false;
+}
+
+// ================================================================
+// G1-step2: tryRewriteGetterObjToArrowExport 회귀 가드
+// ================================================================
+
+test "G1-step2: 순수 getter object ≥9 → arrow map 변환" {
+    const a = std.testing.allocator;
+    // 9 getter (= ARROW_EXPORT_MIN), 모두 단순 identifier value
+    const obj = "{get a(){return x},get b(){return y},get c(){return z}," ++
+        "get d(){return p},get e(){return q},get f(){return r}," ++
+        "get g(){return s},get h(){return t},get i(){return u}}";
+    const got = (try tryRewriteGetterObjToArrowExport(a, obj)).?;
+    defer a.free(got);
+    try std.testing.expectEqualStrings(
+        "{a:()=>x,b:()=>y,c:()=>z,d:()=>p,e:()=>q,f:()=>r,g:()=>s,h:()=>t,i:()=>u}",
+        got,
+    );
+}
+
+test "G1-step2: export < 9 → null (helper 고정비용 미회수)" {
+    const a = std.testing.allocator;
+    const obj = "{get a(){return x},get b(){return y}}";
+    try std.testing.expect((try tryRewriteGetterObjToArrowExport(a, obj)) == null);
+}
+
+test "G1-step2: nested re-export (non-getter prop) 섞이면 null" {
+    const a = std.testing.allocator;
+    // 8 getter + 1 nested `ns:{...}` → 순수 getter object 아님 → null
+    const obj = "{get a(){return x},get b(){return y},get c(){return z}," ++
+        "get d(){return p},get e(){return q},get f(){return r}," ++
+        "get g(){return s},get h(){return t},ns:{get k(){return w}}}";
+    try std.testing.expect((try tryRewriteGetterObjToArrowExport(a, obj)) == null);
+}
+
+test "G1-step2: 복잡 VAL (call/string/depth) depth-track 보존" {
+    const a = std.testing.allocator;
+    // VAL 안에 (), {}, string literal 의 `}` `,` 가 있어도 정확히 분리
+    const obj = "{get a(){return f(p,q)},get b(){return {k:1}}," ++
+        "get c(){return \"a,b}c\"},get d(){return r},get e(){return s}," ++
+        "get f(){return t},get g(){return u},get h(){return v}," ++
+        "get \"q-x\"(){return w}}";
+    const got = (try tryRewriteGetterObjToArrowExport(a, obj)).?;
+    defer a.free(got);
+    try std.testing.expectEqualStrings(
+        "{a:()=>f(p,q),b:()=>({k:1}),c:()=>\"a,b}c\",d:()=>r,e:()=>s," ++
+            "f:()=>t,g:()=>u,h:()=>v,\"q-x\":()=>w}",
+        got,
+    );
 }


### PR DESCRIPTION
## Summary

shared namespace inline preamble 의 getter object `var V={get a(){return x},...};` 를 export ≥9 + 순수 getter object 일 때 `var $dp=...,$x=...;var V={};$x(V,{a:()=>x,...});` arrow `__export` 패턴으로 전환 (esbuild/rolldown/rspack 동일, per-export ~10B).

- **zod: 63942 → 63012 (-930B / -1.5%)** + 런타임 검증 `{success:true,data:'a@b.com'}` (live binding 유지)
- three/mobx/jotai/lodash: 변화 없음 (ns inline <9 또는 nested re-export)

## Root cause + emit-order 해법

zod 의 큰 single ns object (127 getter) 가 getter-object 로 inline (`return `+189, `(){`+107 byte overhead). 

기존 시도 ([#3299](https://github.com/ohah/zntc/issues/3299)) blocker: `ns_shared_inline_cache` 가 *모듈 emit 중* lazy 채워져 helper 주입(@emitter:487)보다 항상 늦음 → `$x undefined`.

**본 해법**: helper 를 preamble 과 *같은 buffer* 에 첫 arrow entry 직전 lazy emit. `$x(V,...)` 사용처보다 물리적으로 먼저 정의 → emit-order 무관. 2-pass RFC 불요.

## 구현

- `tryRewriteGetterObjToArrowExport(allocator, obj)` — depth/string-aware scan. nested re-export 등 순수 getter 아니면 null. VAL 이 `{` 시작이면 `()=>({...})` paren wrap (arrow block 오파싱 방지)
- helper 본문 canonical `rt.EXPORT_RUNTIME_MIN`/`EXPORT_RUNTIME_CONFIGURABLE_MIN` 재사용 — `Linker.configurable_exports` 로 RN/Hermes `configurable:true` 보존

## 3-agent simplify 적용

- **#4 (real)**: helper string 3rd copy drift + RN/Hermes configurable 버그 → canonical rt 상수 재사용 + `Linker.configurable_exports` flag (bundler 2곳 set). RN emit 검증: `function...configurable:true`
- #2: unused `var_name` param 제거
- #3: `result.deinit + return null` 7회 → `defer if(!ok)` 단일 정리

## Test plan

- [x] zig build test — 5114/5118 통과 (회귀 0; 4 skip + G1 회귀 가드 4개)
- [x] zod -930B + 런타임 live binding 검증 (`{success:true}`)
- [x] RN `--platform=react-native`: configurable variant emit 확인
- [x] tryRewriteGetterObjToArrowExport unit test 4개 (≥9 변환 / <9 null / nested null / depth-track 복잡 VAL+object paren)

Closes part of #3299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)