### PR TITLE
feat(flow): precise match expression lowering (scalar patterns)

### DIFF
--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -790,3 +790,113 @@ test "Flow enum: usage — member access / cast helper 호출 정합" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "const x=Color.Red") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "const y=Color.cast(\"red\")") != null);
 }
+
+// ================================================================
+// Match expression — 정밀 lowering 동작 검증 (substring)
+// ================================================================
+
+test "Flow match: literal + wildcard → if (_m===lit) / catch-all" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\const r = match (v) { 1 => "a", _ => "b" };
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "===1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "return\"a\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "return\"b\"") != null);
+}
+
+test "Flow match: OR pattern → t1 || t2" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\const r = match (v) { 1 | 2 | 3 => "x", _ => "y" };
+    );
+    defer r.deinit();
+    // 1|2|3 이 bitwise 가 아니라 === OR 체인으로 lower 되어야 한다.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "===1||") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "===2||") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "===3") != null);
+}
+
+test "Flow match: binding pattern → let x = _m" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\const r = match (v) { const x => x };
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "let x=") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "return x") != null);
+}
+
+test "Flow match: guard → binding 후 if (cond)" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\const r = match (v) { const n if (n > 10) => n, _ => 0 };
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "let n=") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "n>10") != null);
+}
+
+test "Flow match: as pattern → 추가 binding" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\const r = match (v) { 1 as one => one, _ => 0 };
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "===1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "let one=") != null);
+}
+
+test "Flow match: member pattern → _m === Member" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\const r = match (v) { Status.Active => 1, _ => 0 };
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "===Status.Active") != null);
+}
+
+test "Flow match: null/true literal pattern → _m === lit" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\const r = match (v) { null => "n", true => "t", _ => "w" };
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "===null") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "===true") != null);
+}
+
+test "Flow match: negative unary in OR (-1 | -2) keeps | as separator" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\const r = match (v) { -1 | -2 => "neg", _ => "o" };
+    );
+    defer r.deinit();
+    // `-1 | -2` 가 bitwise 가 아니라 `_m===-1 || _m===-2` 로 lower.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "=== -1||") != null or
+        std.mem.indexOf(u8, r.output, "===-1||") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "-2") != null);
+}
+
+test "Flow match: as-binding wrapping OR ((1|2) as x)" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\const r = match (v) { (1 | 2) as x => x, _ => 0 };
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "===1||") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "let x=") != null);
+}
+
+test "Flow match: nested OR in parens ((1|2)|3)" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\const r = match (v) { (1 | 2) | 3 => "x", _ => "y" };
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "===1||") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "===3") != null);
+}
+
+test "Flow match: object/array pattern → opaque (valid, dead arm DCE)" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\const r = match (v) { {a:1} => "o", [1] => "a", _ => "w" };
+    );
+    defer r.deinit();
+    // 정밀 구조분해는 후속 — opaque arm 은 `if(false)` 로 lower 되어 DCE 됨.
+    // 동작: object/array discriminant 도 wildcard 로 fall (valid, 보수적).
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "return\"w\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"o\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"a\"") == null);
+}

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -397,6 +397,21 @@ pub const Node = struct {
         /// right=body }. `visitFlowMatch` 가 arms list 를 iterate 하며 각 arm 의
         /// binary.left/right 를 읽는다. `#1822` 에서 outer expr 와 tag 분리.
         flow_match_arm,
+        /// OR pattern `p1 | p2 | ...` — list = subpatterns. 매치 = 하나라도 매치.
+        /// Flow spec 상 OR 내부 binding 금지 (transformer 가 binding 무시).
+        flow_match_or_pattern,
+        /// binding pattern `const x` (let/var 도 문법상 허용). leaf, span = 식별자.
+        /// 항상 매치하고 식별자를 discriminant 로 바인딩.
+        flow_match_binding_pattern,
+        /// as pattern `pattern as x` / `pattern as const x`.
+        /// binary = { left=inner pattern, right=binding identifier }.
+        flow_match_as_pattern,
+        /// guarded pattern `pattern if (cond)`. binary = { left=inner pattern,
+        /// right=guard expression }. transformer 가 inner 매치 && guard 로 변환.
+        flow_match_guard_pattern,
+        /// object/array match pattern 의 opaque placeholder (정밀 lowering 후속).
+        /// transformer 가 `false` 로 lower — 해당 arm 은 매치 안 됨 (valid JS).
+        flow_match_opaque_pattern,
         /// Flow component with ref → React.forwardRef wrapper
         /// extra = [func_decl, const_decl]
         /// func_decl: function Name_withRef({...props}, ref) { body }
@@ -542,6 +557,10 @@ pub const Node = struct {
                 // 실체가 leaf 이며 codegen 이 data 를 읽지 않음 (TS/Flow strip 대상).
                 .ts_literal_type,
                 .flow_literal_type,
+                // flow_match_binding_pattern: leaf, span = 식별자
+                .flow_match_binding_pattern,
+                // flow_match_opaque_pattern: leaf, opaque (transformer 가 false 로 lower)
+                .flow_match_opaque_pattern,
                 => .{ .kind = .leaf },
 
                 // === unary ===
@@ -626,6 +645,10 @@ pub const Node = struct {
                 // flow_match_arm: binary = { left=pattern, right=body, flags }
                 // outer flow_match_expression (extra layout) 의 arms list 구성원.
                 .flow_match_arm,
+                // flow_match_as_pattern: binary = { left=inner, right=binding id }
+                .flow_match_as_pattern,
+                // flow_match_guard_pattern: binary = { left=inner, right=guard expr }
+                .flow_match_guard_pattern,
                 => .{ .kind = .binary },
 
                 // === ternary ===
@@ -667,6 +690,8 @@ pub const Node = struct {
                 .flow_exact_object_type,
                 .flow_type_parameter_declaration,
                 .flow_type_parameter_instantiation,
+                // flow_match_or_pattern: list = subpatterns
+                .flow_match_or_pattern,
                 => .{ .kind = .list },
 
                 // === extra: 태그별 NodeIndex 오프셋 명시 ===

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -605,7 +605,7 @@ fn parseBinaryExpression(self: *Parser, min_prec: u8) ParseError2!NodeIndex {
     return left;
 }
 
-fn parseUnaryExpression(self: *Parser) ParseError2!NodeIndex {
+pub fn parseUnaryExpression(self: *Parser) ParseError2!NodeIndex {
     const kind = self.current();
     switch (kind) {
         .bang, .tilde, .minus, .plus, .kw_typeof, .kw_void, .kw_delete => {
@@ -761,6 +761,8 @@ fn parsePostfixExpression(self: *Parser) ParseError2!NodeIndex {
     while (self.current() == .identifier and !self.scanner.token.has_newline_before) {
         const text = self.tokenText();
         const is_as = std.mem.eql(u8, text, "as");
+        // match pattern 안의 `as` 는 type-cast 가 아니라 binding 구분자.
+        if (is_as and self.flow_in_match_pattern) break;
         const is_satisfies = !is_as and !self.is_flow and std.mem.eql(u8, text, "satisfies");
         if (!is_as and !is_satisfies) break;
         const expr_start = self.ast.getNode(expr).span.start;

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -1816,14 +1816,22 @@ pub fn parseMatchExpression(self: *Parser) ParseError2!NodeIndex {
     while (self.current() != .r_curly and self.current() != .eof) {
         const loop_guard_pos = self.scanner.token.span.start;
 
-        const pattern = try parseMatchPattern(self);
+        var pattern = try parseMatchPattern(self);
 
-        // case guard: `Pattern if (expr) =>` — 소비만 (transformer 후속).
+        // case guard: `Pattern if (expr) =>` → flow_match_guard_pattern 으로 wrap.
         if (self.current() == .kw_if) {
+            const g_start = self.currentSpan().start;
             try self.advance();
             try self.expect(.l_paren);
-            _ = try self.parseAssignmentExpression();
+            const guard_expr = try self.parseAssignmentExpression();
             try self.expect(.r_paren);
+            pattern = try self.ast.addBinaryNode(
+                .flow_match_guard_pattern,
+                .{ .start = g_start, .end = self.currentSpan().start },
+                pattern,
+                guard_expr,
+                0,
+            );
         }
 
         try self.expect(.arrow);
@@ -1881,16 +1889,14 @@ fn matchWildcard(self: *Parser, span: anytype) ParseError2!NodeIndex {
     });
 }
 
-/// object/array match pattern 의 opaque placeholder. 정밀 lowering 은 후속
-/// (parser-only scope) 이라, transformer 의 `_m === <here>` 가 valid JS 가
-/// 되도록 빈 object expression `{}` 을 emit — `_m==={}` 는 항상 false (객체
-/// 레퍼런스 비교) 이며 codegen 안전. literal 노드는 codegen 이 span 텍스트
-/// (`{`/`[`) 를 그대로 출력해 깨진 JS 가 되므로 tag 기반 emit 노드를 쓴다.
+/// object/array/instance match pattern 의 opaque placeholder. 정밀 구조분해
+/// lowering 은 후속 PR — 이번엔 transformer 가 `false` 로 lower 해 해당 arm 을
+/// 매치 안 시킴 (valid JS, 동작은 보수적).
 fn matchOpaquePattern(self: *Parser, span: anytype) ParseError2!NodeIndex {
     return try self.ast.addNode(.{
-        .tag = .object_expression,
+        .tag = .flow_match_opaque_pattern,
         .span = span,
-        .data = .{ .list = .{ .start = 0, .len = 0 } },
+        .data = .{ .none = 0 },
     });
 }
 
@@ -1908,31 +1914,69 @@ fn tryConsumeMatchBinding(self: *Parser) ParseError2!bool {
 
 /// match pattern (top-level). Hermes parseMatchPatternFlow (line 1104) 미러:
 ///   [`|`] subpattern (`|` subpattern)*  [`as` (const|var|let)? ident]
-/// OR / as 는 정확히 소비하되 AST 에는 첫 subpattern 만 보존 (transformer 후속).
+/// OR → flow_match_or_pattern, as → flow_match_as_pattern 으로 구조 보존.
 fn parseMatchPattern(self: *Parser) ParseError2!NodeIndex {
+    const prev_in_match = self.flow_in_match_pattern;
+    self.flow_in_match_pattern = true;
+    defer self.flow_in_match_pattern = prev_in_match;
+
+    const start = self.currentSpan().start;
     _ = try self.eat(.pipe); // 선행 `|` 허용
     const first = try parseMatchSubpattern(self);
-    while (self.current() == .pipe) {
-        try self.advance();
-        _ = try parseMatchSubpattern(self);
+
+    var pat = first;
+    if (self.current() == .pipe) {
+        const scratch_top = self.saveScratch();
+        try self.scratch.append(self.allocator, first);
+        while (self.current() == .pipe) {
+            try self.advance();
+            try self.scratch.append(self.allocator, try parseMatchSubpattern(self));
+        }
+        const list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+        self.scratch.shrinkRetainingCapacity(scratch_top);
+        pat = try self.ast.addListNode(
+            .flow_match_or_pattern,
+            .{ .start = start, .end = self.currentSpan().start },
+            list,
+        );
     }
+
     // `as` binding: `pattern as x`, `pattern as const x`
     if (self.isContextual("as")) {
         try self.advance();
         _ = try tryConsumeMatchBinding(self);
+        const id_span = self.currentSpan();
         _ = try self.parseSimpleIdentifier();
+        const id = try self.ast.addNode(.{
+            .tag = .identifier_reference,
+            .span = id_span,
+            .data = .{ .string_ref = id_span },
+        });
+        pat = try self.ast.addBinaryNode(
+            .flow_match_as_pattern,
+            .{ .start = start, .end = self.currentSpan().start },
+            pat,
+            id,
+            0,
+        );
     }
-    return first;
+    return pat;
 }
 
 /// match subpattern. Hermes parseMatchSubpatternFlow (line 1149) 미러.
 /// 모든 종류를 정확히 소비. AST 는 기존 expression 노드 재활용.
 fn parseMatchSubpattern(self: *Parser) ParseError2!NodeIndex {
     switch (self.current()) {
-        // binding pattern: const x / var x / let x
+        // binding pattern: const x / var x / let x → flow_match_binding_pattern
         .kw_const, .kw_var, .kw_let => {
             try self.advance(); // skip const/var/let
-            return try self.parseSimpleIdentifier();
+            const id_span = self.currentSpan();
+            _ = try self.parseSimpleIdentifier(); // 소비 + 검증
+            return try self.ast.addNode(.{
+                .tag = .flow_match_binding_pattern,
+                .span = id_span,
+                .data = .{ .none = 0 },
+            });
         },
         // parenthesized pattern: ( pattern )
         .l_paren => {
@@ -1945,10 +1989,10 @@ fn parseMatchSubpattern(self: *Parser) ParseError2!NodeIndex {
         .l_curly => return try parseMatchObjectPattern(self),
         // array pattern: [ pat, ...rest ]
         .l_bracket => return try parseMatchArrayPattern(self),
-        // unary literal pattern: +1, -2.5 — unary expression 으로 정확 파싱
-        // (transformer `_m === -1` 가 정확하게 동작).
-        .plus, .minus => return try self.parseAssignmentExpression(),
-        // identifier: wildcard `_` / binding ident / member / instance pattern
+        // unary literal pattern: +1, -2.5 — parseUnaryExpression 으로 파싱해
+        // `|` 가 binary 로 흡수되지 않게 (OR-pattern 구분자로 남김).
+        .plus, .minus => return try self.parseUnaryExpression(),
+        // identifier: wildcard `_` / member / instance pattern
         .identifier => {
             const s = self.currentSpan();
             const text = self.ast.source[s.start..s.end];
@@ -1956,16 +2000,18 @@ fn parseMatchSubpattern(self: *Parser) ParseError2!NodeIndex {
                 try self.advance();
                 return try matchWildcard(self, s);
             }
-            // identifier + (.member | [literal])* + optional `{ ... }` instance pattern.
-            // parseAssignmentExpression 이 member chain 까지 정확 소비.
-            const expr = try self.parseAssignmentExpression();
+            // identifier + (.member | [literal])* — parseUnaryExpression 이 member
+            // chain 까지 소비하고 binary(`|`)/optional-`{` 는 안 먹는다.
+            const expr = try self.parseUnaryExpression();
             if (self.current() == .l_curly) {
-                _ = try parseMatchObjectPattern(self); // instance pattern body
+                _ = try parseMatchObjectPattern(self); // instance body 소비
+                return try matchOpaquePattern(self, s); // instance = opaque (후속)
             }
-            return expr;
+            return expr; // member/identifier value compare (`_m === expr`)
         },
-        // literal pattern (null/true/false/number/string/bigint) — parseAssignmentExpression 재활용
-        else => return try self.parseAssignmentExpression(),
+        // literal pattern (null/true/false/number/string/bigint) —
+        // parseUnaryExpression 으로 단일 리터럴만 (binary `|` 미흡수).
+        else => return try self.parseUnaryExpression(),
     }
 }
 

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -206,6 +206,9 @@ pub const Parser = struct {
     /// sequence 에서 `extends B` 를 infer 가 흡수하지 않고 outer 로 양보.
     /// Hermes 의 `allowConditionalType_` 와 동등. 기본 true.
     flow_allow_conditional_type: bool = true,
+    /// Flow match pattern 파싱 중인지. true 면 postfix `as` 를 type-cast 가
+    /// 아니라 match `as`-binding 구분자로 남긴다 (`1 as x` 의 `as` 는 binding).
+    flow_in_match_pattern: bool = false,
     /// enum 멤버 초기값 파싱 중인지.
     /// true이면 await/yield를 키워드가 아닌 식별자로 취급한다.
     /// (enum 내에서 다른 멤버를 참조: `enum X { await = 1, y = await }`)
@@ -1625,6 +1628,12 @@ pub const Parser = struct {
 
     pub fn parseAssignmentExpression(self: *Parser) ParseError2!NodeIndex {
         return expression.parseAssignmentExpression(self);
+    }
+
+    /// unary + postfix 까지만 (binary 없음). Flow match subpattern 에서 `|`
+    /// 를 OR-pattern 구분자로 남기려면 binary 를 흡수하면 안 된다.
+    pub fn parseUnaryExpression(self: *Parser) ParseError2!NodeIndex {
+        return expression.parseUnaryExpression(self);
     }
 
     pub fn parseCallExpression(self: *Parser) ParseError2!NodeIndex {

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -752,6 +752,19 @@ pub fn makeMathPowCall(self: anytype, left: NodeIndex, right: NodeIndex, span: S
     });
 }
 
+/// boolean literal 노드 생성. codegen(node_dispatch) 와 DCE 가 boolean_literal
+/// 을 `.data` flag 가 아니라 **span 텍스트**로 읽으므로, span 은 반드시 실제
+/// "true"/"false" 문자열을 가리켜야 한다 (addString). 이 footgun 을 호출처에
+/// 노출하지 않도록 여기서 addString 까지 묶는다.
+pub fn makeBoolLiteral(self: anytype, val: bool) !NodeIndex {
+    const s = try self.ast.addString(if (val) "true" else "false");
+    return self.ast.addNode(.{
+        .tag = .boolean_literal,
+        .span = s,
+        .data = .{ .none = if (val) 1 else 0 },
+    });
+}
+
 /// binding_identifier 노드 생성 (변수 바인딩용).
 /// span은 이미 addString된 이름 span.
 pub fn makeBindingIdentifier(self: anytype, name_span: Span) !NodeIndex {

--- a/src/transformer/transformer/flow.zig
+++ b/src/transformer/transformer/flow.zig
@@ -6,10 +6,104 @@ const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const NodeList = ast_mod.NodeList;
 const token_mod = @import("../../lexer/token.zig");
+const Span = token_mod.Span;
 const es_helpers = @import("../es_helpers.zig");
 const transformer_mod = @import("../transformer.zig");
 const Transformer = transformer_mod.Transformer;
 const Error = Transformer.Error;
+
+/// 한 pattern 의 lowering 결과.
+///   test_expr : subject 와 비교한 boolean 식 (true literal = 무조건 매치)
+///   bindings  : test 통과 후 선언할 `let <id> = subject;` 문 (binding/as).
+///               arena 소유 — then_stmts 와 달리 의도적으로 free 하지 않음.
+///   guard     : binding 선언 이후 평가할 추가 조건식 (.none = 없음)
+const LoweredPattern = struct {
+    test_expr: NodeIndex,
+    bindings: []const NodeIndex,
+    guard: NodeIndex,
+};
+
+fn mkBool(self: *Transformer, val: bool) Error!NodeIndex {
+    return es_helpers.makeBoolLiteral(self, val);
+}
+
+fn mkBin(self: *Transformer, span: Span, left: NodeIndex, right: NodeIndex, kind: token_mod.Kind) Error!NodeIndex {
+    return self.ast.addBinaryNode(.binary_expression, span, left, right, @intFromEnum(kind));
+}
+
+fn mkBlock(self: *Transformer, span: Span, stmts: []const NodeIndex) Error!NodeIndex {
+    const list = try self.ast.addNodeList(stmts);
+    return self.ast.addNode(.{ .tag = .block_statement, .span = span, .data = .{ .list = list } });
+}
+
+/// `let <id_span> = <subject>;` variable declaration 생성.
+fn mkBindingDecl(self: *Transformer, id_span: Span, match_var: Span, span: Span) Error!NodeIndex {
+    const subj = try es_helpers.makeTempVarRef(self, match_var, match_var);
+    const bind = try es_helpers.makeBindingIdentifier(self, id_span);
+    const decl = try es_helpers.makeDeclarator(self, bind, subj, span);
+    return es_helpers.makeVarDeclaration(self, &.{decl}, .let, span);
+}
+
+/// match pattern → (test, bindings, guard). discriminant 는 `match_var` temp.
+/// Flow match semantics:
+///   wildcard `_`            → 항상 매치
+///   binding `const x`       → 항상 매치 + `let x = _m`
+///   literal/member/unary    → `_m === <expr>`
+///   OR `a | b`              → `test(a) || test(b)` (OR 내부 binding/guard 무시)
+///   as `p as x`             → test(p) + `let x = _m`
+///   guard `p if (c)`        → test(p), binding 후 `c` 평가
+///   object/array/instance   → opaque (false, 후속 PR 에서 정밀 구조분해)
+fn lowerMatchPattern(self: *Transformer, pattern: NodeIndex, match_var: Span, span: Span) Error!LoweredPattern {
+    const pnode = self.ast.getNode(pattern);
+    switch (pnode.tag) {
+        .flow_match_opaque_pattern => return .{
+            .test_expr = try mkBool(self, false),
+            .bindings = &.{},
+            .guard = .none,
+        },
+        .flow_match_binding_pattern => {
+            const binds = try self.allocator.alloc(NodeIndex, 1);
+            binds[0] = try mkBindingDecl(self, pnode.span, match_var, span);
+            return .{ .test_expr = try mkBool(self, true), .bindings = binds, .guard = .none };
+        },
+        .flow_match_or_pattern => {
+            const lst = pnode.data.list;
+            var acc: NodeIndex = .none;
+            var i: u32 = 0;
+            while (i < lst.len) : (i += 1) {
+                const sub: NodeIndex = @enumFromInt(self.ast.extra_data.items[lst.start + i]);
+                const lp = try lowerMatchPattern(self, sub, match_var, span);
+                acc = if (acc.isNone()) lp.test_expr else try mkBin(self, span, acc, lp.test_expr, .pipe2);
+            }
+            if (acc.isNone()) acc = try mkBool(self, false);
+            return .{ .test_expr = acc, .bindings = &.{}, .guard = .none };
+        },
+        .flow_match_as_pattern => {
+            const lp = try lowerMatchPattern(self, pnode.data.binary.left, match_var, span);
+            const id_node = self.ast.getNode(pnode.data.binary.right);
+            const extra_decl = try mkBindingDecl(self, id_node.span, match_var, span);
+            const binds = try self.allocator.alloc(NodeIndex, lp.bindings.len + 1);
+            std.mem.copyForwards(NodeIndex, binds[0..lp.bindings.len], lp.bindings);
+            binds[lp.bindings.len] = extra_decl;
+            return .{ .test_expr = lp.test_expr, .bindings = binds, .guard = lp.guard };
+        },
+        .flow_match_guard_pattern => {
+            const lp = try lowerMatchPattern(self, pnode.data.binary.left, match_var, span);
+            const g = try self.visitNode(pnode.data.binary.right);
+            const combined = if (lp.guard.isNone()) g else try mkBin(self, span, lp.guard, g, .amp2);
+            return .{ .test_expr = lp.test_expr, .bindings = lp.bindings, .guard = combined };
+        },
+        // wildcard `_` 는 무조건 매치.
+        .identifier_reference => if (std.mem.eql(u8, self.ast.getText(pnode.span), "_")) {
+            return .{ .test_expr = try mkBool(self, true), .bindings = &.{}, .guard = .none };
+        },
+        else => {},
+    }
+    // identifier(non-`_`) / literal / member / unary → `_m === <expr>`
+    const subj = try es_helpers.makeTempVarRef(self, match_var, match_var);
+    const v = try self.visitNode(pattern);
+    return .{ .test_expr = try mkBin(self, span, subj, v, .eq3), .bindings = &.{}, .guard = .none };
+}
 
 /// Flow match expression → (function(_m){if(_m===P){B}else if...})(expr)
 pub fn visitFlowMatch(self: *Transformer, node: Node) Error!NodeIndex {
@@ -31,77 +125,51 @@ pub fn visitFlowMatch(self: *Transformer, node: Node) Error!NodeIndex {
     // 임시 변수 _m
     const match_var = try es_helpers.makeTempVarSpan(self);
     const match_param = try es_helpers.makeBindingIdentifier(self, match_var);
-    var else_branch: NodeIndex = .none;
 
-    var i: usize = arm_indices.len;
-    while (i > 0) {
-        i -= 1;
-        const arm = self.ast.getNode(@enumFromInt(arm_indices[i]));
+    // 각 arm → `if (<test>) { <bindings>; [if (<guard>)] return <body>; }`
+    // 을 순서대로 나열. 매치되면 return 으로 함수 탈출, 아니면 다음 if 로 진행.
+    // self.scratch 는 lowerMatchPattern 내부 visitNode(guard) 가 재사용하므로
+    // 충돌 방지를 위해 local alloc 으로 if 문 리스트를 모은다.
+    const if_stmts = try self.allocator.alloc(NodeIndex, arm_indices.len);
+    defer self.allocator.free(if_stmts);
+
+    for (arm_indices, 0..) |ai, k| {
+        const arm = self.ast.getNode(@enumFromInt(ai));
         const pattern = arm.data.binary.left;
-        const body_idx = arm.data.binary.right;
-        const new_body_raw = try self.visitNode(body_idx);
-        // body를 { return body; } 또는 block 그대로 사용
-        const body_node = self.ast.getNode(new_body_raw);
-        const new_body = if (body_node.tag == .block_statement)
-            new_body_raw
-        else blk: {
-            // expression → { return expr; }
-            const return_stmt = try self.ast.addNode(.{
-                .tag = .return_statement,
-                .span = span,
-                .data = .{ .unary = .{ .operand = new_body_raw, .flags = 0 } },
-            });
-            const stmts = try self.ast.addNodeList(&.{return_stmt});
-            break :blk try self.ast.addNode(.{
-                .tag = .block_statement,
-                .span = span,
-                .data = .{ .list = stmts },
-            });
-        };
+        const new_body_raw = try self.visitNode(arm.data.binary.right);
+        const ret = try self.ast.addNode(.{
+            .tag = .return_statement,
+            .span = span,
+            .data = .{ .unary = .{ .operand = new_body_raw, .flags = 0 } },
+        });
 
-        // wildcard `_` 감지
-        const pat_node = self.ast.getNode(pattern);
-        const is_wildcard = blk: {
-            if (pat_node.tag == .identifier_reference) {
-                const text = self.ast.getText(pat_node.span);
-                break :blk std.mem.eql(u8, text, "_");
-            }
-            break :blk false;
-        };
+        const lp = try lowerMatchPattern(self, pattern, match_var, span);
 
-        if (is_wildcard) {
-            else_branch = new_body;
-        } else {
-            const new_pattern = try self.visitNode(pattern);
-            const match_ref = try es_helpers.makeTempVarRef(self, match_var, match_var);
-            // _m === pattern
-            const test_expr = try self.ast.addNode(.{
-                .tag = .binary_expression,
-                .span = span,
-                .data = .{ .binary = .{
-                    .left = match_ref,
-                    .right = new_pattern,
-                    .flags = @intFromEnum(token_mod.Kind.eq3),
-                } },
-            });
-            else_branch = try self.ast.addNode(.{
-                .tag = .if_statement,
-                .span = span,
-                .data = .{ .ternary = .{ .a = test_expr, .b = new_body, .c = else_branch } },
-            });
-        }
+        // then-block: bindings... + (guard ? if (guard) return body : return body)
+        const tail = if (lp.guard.isNone()) ret else try self.ast.addNode(.{
+            .tag = .if_statement,
+            .span = span,
+            .data = .{ .ternary = .{
+                .a = lp.guard,
+                .b = try mkBlock(self, span, &.{ret}),
+                .c = NodeIndex.none,
+            } },
+        });
+        const then_stmts = try self.allocator.alloc(NodeIndex, lp.bindings.len + 1);
+        defer self.allocator.free(then_stmts);
+        std.mem.copyForwards(NodeIndex, then_stmts[0..lp.bindings.len], lp.bindings);
+        then_stmts[lp.bindings.len] = tail;
+        const then_block = try mkBlock(self, span, then_stmts);
+
+        if_stmts[k] = try self.ast.addNode(.{
+            .tag = .if_statement,
+            .span = span,
+            .data = .{ .ternary = .{ .a = lp.test_expr, .b = then_block, .c = NodeIndex.none } },
+        });
     }
 
-    // function(_m) { if-chain }
-    const body_list = if (!else_branch.isNone())
-        try self.ast.addNodeList(&.{else_branch})
-    else
-        NodeList{ .start = 0, .len = 0 };
-    const fn_body = try self.ast.addNode(.{
-        .tag = .block_statement,
-        .span = span,
-        .data = .{ .list = body_list },
-    });
+    // function(_m) { if-list }
+    const fn_body = try mkBlock(self, span, if_stmts);
     const fn_params_list = try self.ast.addNodeList(&.{match_param});
     const fn_params_node = try self.ast.addFormalParameters(fn_params_list, span);
     const fn_extra = try self.ast.addExtras(&.{


### PR DESCRIPTION
## 요약

#3298 은 match pattern 을 **파싱만** 정확히 했고 object/array/binding/OR/as/guard 를 opaque placeholder 로 버려, match 를 실제로 쓰면 **런타임 동작이 틀렸음** (예: `match(v){{type:'a'}=>1,_=>2}` 가 v 와 무관하게 항상 2). 이 PR 이 **scalar pattern 의 진짜 root cause(정밀 lowering)** 를 완결.

## Root cause

transformer 가 모든 pattern 을 `_m === placeholder` 로 변환 → 복합/binding pattern 의미 손실. AST 가 pattern 구조를 보존하지 않아 transformer 가 정밀 변환 불가.

## 변경

### AST (`src/parser/ast.zig`)
구조 보존 노드: `flow_match_or_pattern`(list), `flow_match_binding_pattern`(leaf), `flow_match_as_pattern`(binary), `flow_match_guard_pattern`(binary), `flow_match_opaque_pattern`(leaf).

### 파서
- `parseMatchSubpattern` 이 `parseUnaryExpression` 사용 → `|` 가 bitwise 로 흡수되지 않고 OR 구분자로 남음.
- `parseMatchPattern` 이 OR→`flow_match_or`, as→`flow_match_as` 구조 보존.
- `flow_in_match_pattern` flag: match pattern 안 postfix `as` 를 type-cast 가 아닌 match as-binding 으로 (`1 as x`).
- `parseUnaryExpression` pub wrapper.

### transformer (`src/transformer/transformer/flow.zig`)
`lowerMatchPattern` 재귀 → `{test_expr, bindings, guard}`:
| pattern | lowering |
|---|---|
| wildcard `_` | 항상 매치 |
| binding `const x` | 항상 매치 + `let x = _m` |
| literal/member/unary | `_m === <expr>` |
| OR `a\|b\|c` | `_m===a \|\| _m===b \|\| _m===c` |
| as `p as x` | test(p) + `let x = _m` |
| guard `p if (c)` | test(p), binding 후 `if (c) return body` |
| object/array/instance | `false` (DCE → wildcard fall; 정밀 구조분해 후속) |

`visitFlowMatch` flat if-list 재작성 (scratch ↔ visitNode 충돌 → local alloc).

### es_helpers
`makeBoolLiteral` 추가 — `boolean_literal` 은 codegen/DCE 가 **span 텍스트**로 읽으므로 `addString` 을 헬퍼에 묶어 footgun 제거 (리뷰 지적).

## 런타임 검증 (수동 node 실행)
`match(1)=one`, `match(2|3)=two-or-three`, `match(15){const n if(n>10)}=big:15`, as-binding, null/true/unary/member — 전부 Flow match 의미와 일치.

## 단위 테스트
- parser 19 (기존) + codegen substring 11 (literal+wildcard / OR / binding / guard / as / member / null·true / `-1\|-2` / `(1\|2) as x` / nested OR / opaque DCE)
- 회귀: flow-libs 55 + flow-rn 50 = **105/105**

## 후속 (별도 issue 권장)
object/array/instance **정밀 구조분해**: `_m!=null && _m.k===v`, `Array.isArray(_m) && _m.length`, `_m instanceof Point`, rest 수집. 현재는 opaque(보수적 dead arm, valid).