### PR TITLE
feat(flow): precise match object/array/instance destructuring + block-body regression fix

### DIFF
--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -889,14 +889,75 @@ test "Flow match: nested OR in parens ((1|2)|3)" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "===3") != null);
 }
 
-test "Flow match: object/array pattern → opaque (valid, dead arm DCE)" {
+test "Flow match: object pattern → typeof guard + key in + value" {
     var r = try e2eFlow(std.testing.allocator,
-        \\const r = match (v) { {a:1} => "o", [1] => "a", _ => "w" };
+        \\const r = match (v) { {a: 1} => "o", _ => "w" };
     );
     defer r.deinit();
-    // 정밀 구조분해는 후속 — opaque arm 은 `if(false)` 로 lower 되어 DCE 됨.
-    // 동작: object/array discriminant 도 wildcard 로 fall (valid, 보수적).
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "return\"w\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"o\"") == null);
-    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"a\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "!=null") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "typeof") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"object\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"a\" in") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "[\"a\"]===1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "return\"o\"") != null);
+}
+
+test "Flow match: object shorthand binding → let from member" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\const r = match (v) { {const x} => x, _ => 0 };
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"x\" in") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "let x=") != null);
+}
+
+test "Flow match: object rest → Object.assign + delete" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\const r = match (v) { {a: 1, ...const rest} => rest, _ => 0 };
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Object.assign(") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "delete ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "let rest=") != null);
+}
+
+test "Flow match: array pattern → Array.isArray + length + index" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\const r = match (v) { [1, const x] => x, _ => 0 };
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Array.isArray(") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, ".length===2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "[0]===1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "let x=") != null);
+}
+
+test "Flow match: array rest → length >= N + slice" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\const r = match (v) { [1, ...const t] => t, _ => 0 };
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, ".length>=1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, ".slice(1)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "let t=") != null);
+}
+
+test "Flow match: instance pattern → S instanceof Ctor && body" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\const r = match (v) { Point {x: const px} => px, _ => 0 };
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "instanceof Point") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "let px=") != null);
+}
+
+test "Flow match: nested object/array binding" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\const r = match (v) { {pt: [const x, const y]} => x + y, _ => 0 };
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "\"pt\" in") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Array.isArray(") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "let x=") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "let y=") != null);
 }

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -412,6 +412,22 @@ pub const Node = struct {
         /// object/array match pattern 의 opaque placeholder (정밀 lowering 후속).
         /// transformer 가 `false` 로 lower — 해당 arm 은 매치 안 됨 (valid JS).
         flow_match_opaque_pattern,
+        /// object match pattern `{ k: p, const x, ...r }`. list = props
+        /// (flow_match_object_prop | flow_match_rest).
+        flow_match_object_pattern,
+        /// object pattern 의 한 property. binary = { left=key(identifier_reference
+        /// /string_literal), right=value pattern }. shorthand `const x` 는
+        /// value=flow_match_binding_pattern.
+        flow_match_object_prop,
+        /// array match pattern `[ p, ...r ]`. list = elements
+        /// (pattern | flow_match_rest, rest 는 항상 마지막).
+        flow_match_array_pattern,
+        /// rest element `...` / `...const x`. leaf. data.none = 1 이면 binding
+        /// 있음(span=식별자), 0 이면 inexact marker(수집 안 함).
+        flow_match_rest,
+        /// instance pattern `Ctor { ... }`. binary = { left=ctor expression,
+        /// right=flow_match_object_pattern }.
+        flow_match_instance_pattern,
         /// Flow component with ref → React.forwardRef wrapper
         /// extra = [func_decl, const_decl]
         /// func_decl: function Name_withRef({...props}, ref) { body }
@@ -561,6 +577,8 @@ pub const Node = struct {
                 .flow_match_binding_pattern,
                 // flow_match_opaque_pattern: leaf, opaque (transformer 가 false 로 lower)
                 .flow_match_opaque_pattern,
+                // flow_match_rest: leaf, data.none = has-binding flag
+                .flow_match_rest,
                 => .{ .kind = .leaf },
 
                 // === unary ===
@@ -649,6 +667,10 @@ pub const Node = struct {
                 .flow_match_as_pattern,
                 // flow_match_guard_pattern: binary = { left=inner, right=guard expr }
                 .flow_match_guard_pattern,
+                // flow_match_object_prop: binary = { left=key, right=value pattern }
+                .flow_match_object_prop,
+                // flow_match_instance_pattern: binary = { left=ctor, right=object pat }
+                .flow_match_instance_pattern,
                 => .{ .kind = .binary },
 
                 // === ternary ===
@@ -692,6 +714,10 @@ pub const Node = struct {
                 .flow_type_parameter_instantiation,
                 // flow_match_or_pattern: list = subpatterns
                 .flow_match_or_pattern,
+                // flow_match_object_pattern: list = props/rest
+                .flow_match_object_pattern,
+                // flow_match_array_pattern: list = elements/rest
+                .flow_match_array_pattern,
                 => .{ .kind = .list },
 
                 // === extra: 태그별 NodeIndex 오프셋 명시 ===

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -1836,14 +1836,14 @@ pub fn parseMatchExpression(self: *Parser) ParseError2!NodeIndex {
 
         try self.expect(.arrow);
 
-        // body: { ... } (block) 또는 expression
+        // body: { ... } (block) 또는 expression. 둘 다 trailing comma optional.
         var body: NodeIndex = .none;
         if (self.current() == .l_curly) {
             body = try self.parseBlockStatement();
         } else {
             body = try self.parseAssignmentExpression();
-            _ = try self.eat(.comma);
         }
+        _ = try self.eat(.comma);
 
         // arm: binary { left=pattern, right=body }. 별도 tag (`flow_match_arm`)
         // 로 outer `flow_match_expression` (extra layout) 과 분리 — 이전엔 tag
@@ -2004,8 +2004,15 @@ fn parseMatchSubpattern(self: *Parser) ParseError2!NodeIndex {
             // chain 까지 소비하고 binary(`|`)/optional-`{` 는 안 먹는다.
             const expr = try self.parseUnaryExpression();
             if (self.current() == .l_curly) {
-                _ = try parseMatchObjectPattern(self); // instance body 소비
-                return try matchOpaquePattern(self, s); // instance = opaque (후속)
+                // instance pattern `Ctor { ... }`
+                const obj = try parseMatchObjectPattern(self);
+                return try self.ast.addBinaryNode(
+                    .flow_match_instance_pattern,
+                    .{ .start = s.start, .end = self.currentSpan().start },
+                    expr,
+                    obj,
+                    0,
+                );
             }
             return expr; // member/identifier value compare (`_m === expr`)
         },
@@ -2015,65 +2022,96 @@ fn parseMatchSubpattern(self: *Parser) ParseError2!NodeIndex {
     }
 }
 
-/// object match pattern: `{ key: pat, const x, ...rest }`. Hermes
-/// parseMatchObjectPatternPropertiesFlow (line 1439) 미러. AST 는 소비 후
-/// wildcard-like placeholder (object pattern 은 transformer 후속).
+/// object match pattern: `{ key: pat, const x, ...rest }`.
+/// list = [flow_match_object_prop... , flow_match_rest?]
 fn parseMatchObjectPattern(self: *Parser) ParseError2!NodeIndex {
     const s = self.currentSpan();
     try self.expect(.l_curly);
+    const scratch_top = self.saveScratch();
     while (self.current() != .r_curly and self.current() != .eof) {
         const guard_pos = self.scanner.token.span.start;
         if (self.current() == .dot3) {
-            try parseMatchRestPattern(self);
+            try self.scratch.append(self.allocator, try parseMatchRestPattern(self));
             break;
         }
+        const prop_start = self.currentSpan().start;
+        var key: NodeIndex = .none;
+        var value: NodeIndex = .none;
         if (try tryConsumeMatchBinding(self)) {
-            // shorthand binding: `const x` == `x: const x`
+            // shorthand `const x` == `x: const x`
+            const id_span = self.currentSpan();
             _ = try self.parseSimpleIdentifier();
+            key = try self.ast.addNode(.{ .tag = .identifier_reference, .span = id_span, .data = .{ .string_ref = id_span } });
+            value = try self.ast.addNode(.{ .tag = .flow_match_binding_pattern, .span = id_span, .data = .{ .none = 0 } });
         } else {
-            // key : subpattern — key 는 identifier/string/number/bigint 만
-            // (Hermes parseMatchObjectPatternPropertiesFlow). parseAssignmentExpression
-            // 은 contextual keyword(`type` 등)에서 오작동하므로 토큰 종류별 소비.
+            // key : subpattern — key 는 identifier/string/number/bigint
             const k = self.current();
+            const key_span = self.currentSpan();
             if (k == .identifier or k == .string_literal or k.isNumericLiteral() or k.isBigIntLiteral()) {
                 try self.advance();
             } else break;
+            const key_tag: Tag = if (k == .string_literal) .string_literal else .identifier_reference;
+            key = try self.ast.addNode(.{ .tag = key_tag, .span = key_span, .data = .{ .string_ref = key_span } });
             try self.expect(.colon);
-            _ = try parseMatchPattern(self);
+            value = try parseMatchPattern(self);
         }
+        try self.scratch.append(self.allocator, try self.ast.addBinaryNode(
+            .flow_match_object_prop,
+            .{ .start = prop_start, .end = self.currentSpan().start },
+            key,
+            value,
+            0,
+        ));
         if (!try self.eat(.comma)) break;
         if (try self.ensureLoopProgress(guard_pos)) break;
     }
     try self.expect(.r_curly);
-    return try matchOpaquePattern(self, s);
+    const list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+    self.scratch.shrinkRetainingCapacity(scratch_top);
+    return try self.ast.addListNode(
+        .flow_match_object_pattern,
+        .{ .start = s.start, .end = self.currentSpan().start },
+        list,
+    );
 }
 
-/// array match pattern: `[ pat, pat, ...rest ]`. Hermes parseMatchArrayPatternFlow
-/// (line 1580) 미러.
+/// array match pattern: `[ pat, pat, ...rest ]`.
+/// list = [pattern... , flow_match_rest?]
 fn parseMatchArrayPattern(self: *Parser) ParseError2!NodeIndex {
     const s = self.currentSpan();
     try self.expect(.l_bracket);
+    const scratch_top = self.saveScratch();
     while (self.current() != .r_bracket and self.current() != .eof) {
         const guard_pos = self.scanner.token.span.start;
         if (self.current() == .dot3) {
-            try parseMatchRestPattern(self);
+            try self.scratch.append(self.allocator, try parseMatchRestPattern(self));
             break;
         }
-        _ = try parseMatchPattern(self);
+        try self.scratch.append(self.allocator, try parseMatchPattern(self));
         if (!try self.eat(.comma)) break;
         if (try self.ensureLoopProgress(guard_pos)) break;
     }
     try self.expect(.r_bracket);
-    return try matchOpaquePattern(self, s);
+    const list = try self.ast.addNodeList(self.scratch.items[scratch_top..]);
+    self.scratch.shrinkRetainingCapacity(scratch_top);
+    return try self.ast.addListNode(
+        .flow_match_array_pattern,
+        .{ .start = s.start, .end = self.currentSpan().start },
+        list,
+    );
 }
 
-/// rest pattern: `... [const|var|let ident]`. Hermes parseMatchRestPatternFlow
-/// (line 1423) 미러. 소비만.
-fn parseMatchRestPattern(self: *Parser) ParseError2!void {
+/// rest pattern: `...` / `...const x`. flow_match_rest — data.none=1(binding,
+/// span=식별자) / 0(inexact marker, 수집 안 함).
+fn parseMatchRestPattern(self: *Parser) ParseError2!NodeIndex {
+    const s = self.currentSpan();
     try self.expect(.dot3);
     if (try tryConsumeMatchBinding(self)) {
+        const id_span = self.currentSpan();
         _ = try self.parseSimpleIdentifier();
+        return try self.ast.addNode(.{ .tag = .flow_match_rest, .span = id_span, .data = .{ .none = 1 } });
     }
+    return try self.ast.addNode(.{ .tag = .flow_match_rest, .span = s, .data = .{ .none = 0 } });
 }
 
 // ===== Flow enum (#2401) =====

--- a/src/transformer/transformer/flow.zig
+++ b/src/transformer/transformer/flow.zig
@@ -37,23 +37,184 @@ fn mkBlock(self: *Transformer, span: Span, stmts: []const NodeIndex) Error!NodeI
 }
 
 /// `let <id_span> = <subject>;` variable declaration 생성.
-fn mkBindingDecl(self: *Transformer, id_span: Span, match_var: Span, span: Span) Error!NodeIndex {
-    const subj = try es_helpers.makeTempVarRef(self, match_var, match_var);
+/// subject 는 1회용 AST 노드라 cloneNode 로 복제해 쓴다.
+fn mkBindingDecl(self: *Transformer, id_span: Span, subject: NodeIndex, span: Span) Error!NodeIndex {
+    const subj = try es_helpers.cloneNode(self, subject);
     const bind = try es_helpers.makeBindingIdentifier(self, id_span);
     const decl = try es_helpers.makeDeclarator(self, bind, subj, span);
     return es_helpers.makeVarDeclaration(self, &.{decl}, .let, span);
 }
 
-/// match pattern → (test, bindings, guard). discriminant 는 `match_var` temp.
+fn mkNum(self: *Transformer, val: usize) Error!NodeIndex {
+    return es_helpers.makeNumericLiteral(self, @intCast(val));
+}
+
+/// match object key 노드 → JS literal (computed-member 인덱스 & `in` 좌변).
+/// 매 호출 새 노드 (1회용).
+fn mkKeyLit(self: *Transformer, key: NodeIndex) Error!NodeIndex {
+    const kn = self.ast.getNode(key);
+    return switch (kn.tag) {
+        // 이미 따옴표 포함 span — 그대로 string literal.
+        .string_literal => self.ast.addNode(.{ .tag = .string_literal, .span = kn.span, .data = .{ .string_ref = kn.span } }),
+        // 식별자 키 → `"k"` 문자열 리터럴.
+        .identifier_reference => es_helpers.buildQuotedKeyLiteral(self, kn.span),
+        // numeric/bigint 키.
+        else => self.ast.addNode(.{ .tag = .numeric_literal, .span = kn.span, .data = .{ .string_ref = kn.span } }),
+    };
+}
+
+/// 항상-true test(`&& true`) 생략용 판별. `data.none == 1` 은
+/// es_helpers.makeBoolLiteral 의 true 인코딩 계약 (변경 시 동반 수정 필요).
+fn isAlwaysTrue(self: *Transformer, n: NodeIndex) bool {
+    const nd = self.ast.getNode(n);
+    return nd.tag == .boolean_literal and nd.data.none == 1;
+}
+
+fn mkStrLit(self: *Transformer, text: []const u8) Error!NodeIndex {
+    const quoted = try std.fmt.allocPrint(self.allocator, "\"{s}\"", .{text});
+    const sp = try self.ast.addString(quoted);
+    return self.ast.addNode(.{ .tag = .string_literal, .span = sp, .data = .{ .string_ref = sp } });
+}
+
+/// `typeof <subject> === "object"` — `in`/속성 접근 전 object 가드.
+fn mkTypeofObject(self: *Transformer, subject: NodeIndex, span: Span) Error!NodeIndex {
+    const tof_extra = try self.ast.addExtras(&.{
+        @intFromEnum(try es_helpers.cloneNode(self, subject)),
+        @intFromEnum(token_mod.Kind.kw_typeof),
+    });
+    const tof = try self.ast.addNode(.{ .tag = .unary_expression, .span = span, .data = .{ .extra = tof_extra } });
+    return mkBin(self, span, tof, try mkStrLit(self, "object"), .eq3);
+}
+
+/// object match pattern: `S != null && ("k" in S) && <sub(S.k)> && ...` (+rest).
+fn lowerObjectPattern(self: *Transformer, pnode: Node, subject: NodeIndex, span: Span) Error!LoweredPattern {
+    const lst = pnode.data.list;
+    // S != null && typeof S === "object" — primitive/null 이면 `in` throw 방지.
+    var test_acc = try mkBin(
+        self,
+        span,
+        try es_helpers.makeNeqNull(self, try es_helpers.cloneNode(self, subject), span),
+        try mkTypeofObject(self, subject, span),
+        .amp2,
+    );
+    var binds: std.ArrayListUnmanaged(NodeIndex) = .{};
+    var guard_acc: NodeIndex = .none;
+
+    // rest binding 을 위해 명시 키 노드 수집.
+    var key_lits: std.ArrayListUnmanaged(NodeIndex) = .{};
+
+    var i: u32 = 0;
+    while (i < lst.len) : (i += 1) {
+        const child: NodeIndex = @enumFromInt(self.ast.extra_data.items[lst.start + i]);
+        const cn = self.ast.getNode(child);
+        if (cn.tag == .flow_match_rest) {
+            if (cn.data.none == 1) {
+                // let <rest> = Object.assign({}, S); delete <rest>.k1; ...
+                const empty_obj = try self.ast.addNode(.{ .tag = .object_expression, .span = span, .data = .{ .list = .{ .start = 0, .len = 0 } } });
+                const copy_call = try es_helpers.makeObjectAssignCall(self, &.{ empty_obj, try es_helpers.cloneNode(self, subject) }, span);
+                const bind = try es_helpers.makeBindingIdentifier(self, cn.span);
+                const decl = try es_helpers.makeDeclarator(self, bind, copy_call, span);
+                try binds.append(self.allocator, try es_helpers.makeVarDeclaration(self, &.{decl}, .let, span));
+                for (key_lits.items) |kl| {
+                    const rest_ref = try es_helpers.makeIdentifierRefFromSpan(self, cn.span);
+                    const del_member = try es_helpers.makeComputedMember(self, rest_ref, kl, span);
+                    const del_extra = try self.ast.addExtras(&.{ @intFromEnum(del_member), @intFromEnum(token_mod.Kind.kw_delete) });
+                    const del = try self.ast.addNode(.{ .tag = .unary_expression, .span = span, .data = .{ .extra = del_extra } });
+                    try binds.append(self.allocator, try es_helpers.makeExprStmt(self, del, span));
+                }
+            }
+            continue; // inexact marker (none==0): 추가 체크 없음
+        }
+        // flow_match_object_prop: binary { key, value }
+        const key = cn.data.binary.left;
+        const value = cn.data.binary.right;
+        const member = try es_helpers.makeComputedMember(self, try es_helpers.cloneNode(self, subject), try mkKeyLit(self, key), span);
+        const sub = try lowerMatchPattern(self, value, member, span);
+        const in_expr = try mkBin(self, span, try mkKeyLit(self, key), try es_helpers.cloneNode(self, subject), .kw_in);
+        try key_lits.append(self.allocator, try mkKeyLit(self, key));
+        test_acc = try andJoin(self, span, test_acc, in_expr);
+        if (!isAlwaysTrue(self, sub.test_expr)) test_acc = try andJoin(self, span, test_acc, sub.test_expr);
+        for (sub.bindings) |b| try binds.append(self.allocator, b);
+        if (!sub.guard.isNone()) guard_acc = try andJoin(self, span, guard_acc, sub.guard);
+    }
+    return .{ .test_expr = test_acc, .bindings = binds.items, .guard = guard_acc };
+}
+
+/// array match pattern: `Array.isArray(S) && S.length (===|>=) N && <sub(S[i])>` (+rest slice).
+fn lowerArrayPattern(self: *Transformer, pnode: Node, subject: NodeIndex, span: Span) Error!LoweredPattern {
+    const lst = pnode.data.list;
+    var elem_count: usize = 0;
+    var rest_node: NodeIndex = .none;
+    var i: u32 = 0;
+    while (i < lst.len) : (i += 1) {
+        const child: NodeIndex = @enumFromInt(self.ast.extra_data.items[lst.start + i]);
+        if (self.ast.getNode(child).tag == .flow_match_rest) {
+            rest_node = child;
+        } else elem_count += 1;
+    }
+
+    const is_arr = try es_helpers.makeCallExpr(
+        self,
+        try es_helpers.makeStaticMember(self, try es_helpers.makeIdentifierRef(self, "Array"), try es_helpers.makeIdentifierRef(self, "isArray"), span),
+        &.{try es_helpers.cloneNode(self, subject)},
+        span,
+    );
+    const len_member = try es_helpers.makeStaticMember(self, try es_helpers.cloneNode(self, subject), try es_helpers.makeIdentifierRef(self, "length"), span);
+    const len_cmp_kind: token_mod.Kind = if (rest_node.isNone()) .eq3 else .gt_eq;
+    const len_test = try mkBin(self, span, len_member, try mkNum(self, elem_count), len_cmp_kind);
+    var test_acc = try mkBin(self, span, is_arr, len_test, .amp2);
+
+    var binds: std.ArrayListUnmanaged(NodeIndex) = .{};
+    var guard_acc: NodeIndex = .none;
+    var idx: usize = 0;
+    i = 0;
+    while (i < lst.len) : (i += 1) {
+        const child: NodeIndex = @enumFromInt(self.ast.extra_data.items[lst.start + i]);
+        if (self.ast.getNode(child).tag == .flow_match_rest) continue;
+        const member = try es_helpers.makeComputedMember(self, try es_helpers.cloneNode(self, subject), try mkNum(self, idx), span);
+        const sub = try lowerMatchPattern(self, child, member, span);
+        if (!isAlwaysTrue(self, sub.test_expr)) test_acc = try andJoin(self, span, test_acc, sub.test_expr);
+        for (sub.bindings) |b| try binds.append(self.allocator, b);
+        if (!sub.guard.isNone()) guard_acc = try andJoin(self, span, guard_acc, sub.guard);
+        idx += 1;
+    }
+    if (!rest_node.isNone() and self.ast.getNode(rest_node).data.none == 1) {
+        // let <rest> = S.slice(elem_count)
+        const slice_call = try es_helpers.makeCallExpr(
+            self,
+            try es_helpers.makeStaticMember(self, try es_helpers.cloneNode(self, subject), try es_helpers.makeIdentifierRef(self, "slice"), span),
+            &.{try mkNum(self, elem_count)},
+            span,
+        );
+        const bind = try es_helpers.makeBindingIdentifier(self, self.ast.getNode(rest_node).span);
+        const decl = try es_helpers.makeDeclarator(self, bind, slice_call, span);
+        try binds.append(self.allocator, try es_helpers.makeVarDeclaration(self, &.{decl}, .let, span));
+    }
+    return .{ .test_expr = test_acc, .bindings = binds.items, .guard = guard_acc };
+}
+
+fn andJoin(self: *Transformer, span: Span, a: NodeIndex, b: NodeIndex) Error!NodeIndex {
+    if (a.isNone()) return b;
+    return mkBin(self, span, a, b, .amp2);
+}
+
+/// match pattern → (test, bindings, guard). `subject` 는 비교 대상 expression
+/// (`_m`, `_m["k"]`, `_m[0]` …). AST 노드는 1회용이라 사용 시마다 cloneNode.
+/// cloneNode 는 **shallow** copy — 자식 인덱스를 공유한다. 따라서 subject 의
+/// 자식은 모두 leaf(temp ident / key literal)여야 안전하며, 실제로 그렇다
+/// (member chain 의 base 는 항상 `_m` temp, key 는 literal). 더 깊은 subject
+/// 가 필요해지면 deep clone 또는 thunk 로 바꿔야 한다.
 /// Flow match semantics:
 ///   wildcard `_`            → 항상 매치
-///   binding `const x`       → 항상 매치 + `let x = _m`
-///   literal/member/unary    → `_m === <expr>`
+///   binding `const x`       → 항상 매치 + `let x = S`
+///   literal/member/unary    → `S === <expr>`
 ///   OR `a | b`              → `test(a) || test(b)` (OR 내부 binding/guard 무시)
-///   as `p as x`             → test(p) + `let x = _m`
+///   as `p as x`             → test(p) + `let x = S`
 ///   guard `p if (c)`        → test(p), binding 후 `c` 평가
-///   object/array/instance   → opaque (false, 후속 PR 에서 정밀 구조분해)
-fn lowerMatchPattern(self: *Transformer, pattern: NodeIndex, match_var: Span, span: Span) Error!LoweredPattern {
+///   object `{k: p, ...r}`   → `S != null && ("k" in S) && test(p, S.k)` + rest
+///   array `[p, ...r]`       → `Array.isArray(S) && length && test(p, S[i])` + rest
+///   instance `C { ... }`    → `S instanceof C && <object body>`
+fn lowerMatchPattern(self: *Transformer, pattern: NodeIndex, subject: NodeIndex, span: Span) Error!LoweredPattern {
     const pnode = self.ast.getNode(pattern);
     switch (pnode.tag) {
         .flow_match_opaque_pattern => return .{
@@ -63,7 +224,7 @@ fn lowerMatchPattern(self: *Transformer, pattern: NodeIndex, match_var: Span, sp
         },
         .flow_match_binding_pattern => {
             const binds = try self.allocator.alloc(NodeIndex, 1);
-            binds[0] = try mkBindingDecl(self, pnode.span, match_var, span);
+            binds[0] = try mkBindingDecl(self, pnode.span, subject, span);
             return .{ .test_expr = try mkBool(self, true), .bindings = binds, .guard = .none };
         },
         .flow_match_or_pattern => {
@@ -72,26 +233,36 @@ fn lowerMatchPattern(self: *Transformer, pattern: NodeIndex, match_var: Span, sp
             var i: u32 = 0;
             while (i < lst.len) : (i += 1) {
                 const sub: NodeIndex = @enumFromInt(self.ast.extra_data.items[lst.start + i]);
-                const lp = try lowerMatchPattern(self, sub, match_var, span);
+                const lp = try lowerMatchPattern(self, sub, try es_helpers.cloneNode(self, subject), span);
                 acc = if (acc.isNone()) lp.test_expr else try mkBin(self, span, acc, lp.test_expr, .pipe2);
             }
             if (acc.isNone()) acc = try mkBool(self, false);
             return .{ .test_expr = acc, .bindings = &.{}, .guard = .none };
         },
         .flow_match_as_pattern => {
-            const lp = try lowerMatchPattern(self, pnode.data.binary.left, match_var, span);
+            const lp = try lowerMatchPattern(self, pnode.data.binary.left, try es_helpers.cloneNode(self, subject), span);
             const id_node = self.ast.getNode(pnode.data.binary.right);
-            const extra_decl = try mkBindingDecl(self, id_node.span, match_var, span);
+            const extra_decl = try mkBindingDecl(self, id_node.span, subject, span);
             const binds = try self.allocator.alloc(NodeIndex, lp.bindings.len + 1);
             std.mem.copyForwards(NodeIndex, binds[0..lp.bindings.len], lp.bindings);
             binds[lp.bindings.len] = extra_decl;
             return .{ .test_expr = lp.test_expr, .bindings = binds, .guard = lp.guard };
         },
         .flow_match_guard_pattern => {
-            const lp = try lowerMatchPattern(self, pnode.data.binary.left, match_var, span);
+            const lp = try lowerMatchPattern(self, pnode.data.binary.left, subject, span);
             const g = try self.visitNode(pnode.data.binary.right);
             const combined = if (lp.guard.isNone()) g else try mkBin(self, span, lp.guard, g, .amp2);
             return .{ .test_expr = lp.test_expr, .bindings = lp.bindings, .guard = combined };
+        },
+        .flow_match_object_pattern => return lowerObjectPattern(self, pnode, subject, span),
+        .flow_match_array_pattern => return lowerArrayPattern(self, pnode, subject, span),
+        .flow_match_instance_pattern => {
+            // S instanceof Ctor && <object body test>
+            const ctor = try self.visitNode(pnode.data.binary.left);
+            const inst = try mkBin(self, span, try es_helpers.cloneNode(self, subject), ctor, .kw_instanceof);
+            const body = self.ast.getNode(pnode.data.binary.right);
+            const lp = try lowerObjectPattern(self, body, subject, span);
+            return .{ .test_expr = try andJoin(self, span, inst, lp.test_expr), .bindings = lp.bindings, .guard = lp.guard };
         },
         // wildcard `_` 는 무조건 매치.
         .identifier_reference => if (std.mem.eql(u8, self.ast.getText(pnode.span), "_")) {
@@ -99,10 +270,13 @@ fn lowerMatchPattern(self: *Transformer, pattern: NodeIndex, match_var: Span, sp
         },
         else => {},
     }
-    // identifier(non-`_`) / literal / member / unary → `_m === <expr>`
-    const subj = try es_helpers.makeTempVarRef(self, match_var, match_var);
+    // identifier(non-`_`) / literal / member / unary → `S === <expr>`
     const v = try self.visitNode(pattern);
-    return .{ .test_expr = try mkBin(self, span, subj, v, .eq3), .bindings = &.{}, .guard = .none };
+    return .{
+        .test_expr = try mkBin(self, span, try es_helpers.cloneNode(self, subject), v, .eq3),
+        .bindings = &.{},
+        .guard = .none,
+    };
 }
 
 /// Flow match expression → (function(_m){if(_m===P){B}else if...})(expr)
@@ -137,29 +311,51 @@ pub fn visitFlowMatch(self: *Transformer, node: Node) Error!NodeIndex {
         const arm = self.ast.getNode(@enumFromInt(ai));
         const pattern = arm.data.binary.left;
         const new_body_raw = try self.visitNode(arm.data.binary.right);
-        const ret = try self.ast.addNode(.{
-            .tag = .return_statement,
-            .span = span,
-            .data = .{ .unary = .{ .operand = new_body_raw, .flags = 0 } },
-        });
+        const body_node = self.ast.getNode(new_body_raw);
 
-        const lp = try lowerMatchPattern(self, pattern, match_var, span);
+        // body 가 block `{ s1; s2; }` 이면 statement 들을 펼치고 `return;` 으로
+        // 함수 탈출 (값 없는 statement-arm). expression 이면 `return <expr>;`.
+        // `return <block>` 으로 wrap 하면 codegen 이 object literal 로 출력해 깨짐.
+        var body_stmts: std.ArrayListUnmanaged(NodeIndex) = .{};
+        if (body_node.tag == .block_statement) {
+            const blist = body_node.data.list;
+            var bi: u32 = 0;
+            while (bi < blist.len) : (bi += 1) {
+                try body_stmts.append(self.allocator, @enumFromInt(self.ast.extra_data.items[blist.start + bi]));
+            }
+            try body_stmts.append(self.allocator, try self.ast.addNode(.{
+                .tag = .return_statement,
+                .span = span,
+                .data = .{ .unary = .{ .operand = NodeIndex.none, .flags = 0 } },
+            }));
+        } else {
+            try body_stmts.append(self.allocator, try self.ast.addNode(.{
+                .tag = .return_statement,
+                .span = span,
+                .data = .{ .unary = .{ .operand = new_body_raw, .flags = 0 } },
+            }));
+        }
 
-        // then-block: bindings... + (guard ? if (guard) return body : return body)
-        const tail = if (lp.guard.isNone()) ret else try self.ast.addNode(.{
-            .tag = .if_statement,
-            .span = span,
-            .data = .{ .ternary = .{
-                .a = lp.guard,
-                .b = try mkBlock(self, span, &.{ret}),
-                .c = NodeIndex.none,
-            } },
-        });
-        const then_stmts = try self.allocator.alloc(NodeIndex, lp.bindings.len + 1);
-        defer self.allocator.free(then_stmts);
-        std.mem.copyForwards(NodeIndex, then_stmts[0..lp.bindings.len], lp.bindings);
-        then_stmts[lp.bindings.len] = tail;
-        const then_block = try mkBlock(self, span, then_stmts);
+        const subject = try es_helpers.makeTempVarRef(self, match_var, match_var);
+        const lp = try lowerMatchPattern(self, pattern, subject, span);
+
+        // then-block: bindings... + (guard ? if (guard) { body } : body)
+        var then_list: std.ArrayListUnmanaged(NodeIndex) = .{};
+        for (lp.bindings) |b| try then_list.append(self.allocator, b);
+        if (lp.guard.isNone()) {
+            for (body_stmts.items) |s| try then_list.append(self.allocator, s);
+        } else {
+            try then_list.append(self.allocator, try self.ast.addNode(.{
+                .tag = .if_statement,
+                .span = span,
+                .data = .{ .ternary = .{
+                    .a = lp.guard,
+                    .b = try mkBlock(self, span, body_stmts.items),
+                    .c = NodeIndex.none,
+                } },
+            }));
+        }
+        const then_block = try mkBlock(self, span, then_list.items);
 
         if_stmts[k] = try self.ast.addNode(.{
             .tag = .if_statement,


### PR DESCRIPTION
## 요약

#3301(scalar match lowering)의 후속이자, **#3301이 도입한 block-body 회귀**(CI `Integration Tests` / `Hermes Validation (RN Bundle)` 실패)를 함께 fix.

## 1. 정밀 구조분해 (object/array/instance)

#3301에서 opaque(`false`)로 버려 **동작이 틀렸던** 복합 pattern을 실제 Flow match 의미대로 lowering.

- **AST**: `flow_match_object_pattern` / `object_prop` / `array_pattern` / `rest` / `instance_pattern` 노드로 구조 보존 (parser).
- `lowerMatchPattern` subject를 `Span`→`NodeIndex`로 일반화, nested는 `cloneNode`(shallow — child가 leaf라 안전, doc 명시) 재사용.
- object `{k: p, const x, ...r}` → `S != null && typeof S === "object" && "k" in S && <sub(S["k"])>`; shorthand `const x` = `{x: const x}`; rest = `Object.assign({},S)` + 명시키 `delete`.
- array `[p, ...r]` → `Array.isArray(S) && S.length ===|>= N && <sub(S[i])>`; rest = `S.slice(N)`.
- instance `C { ... }` → `S instanceof C && <object body>`.
- nested(object 안 array 등) 재귀.

**런타임 검증(node 실행)**: circle/rect/nested-pt/array+rest/object-rest/instance/primitive-fallthrough 전부 Flow match 의미와 일치.

## 2. block body 회귀 fix (#3301 regression)

#3301 재작성에서 arm body가 block `{ s1; s2; }`일 때 `return <block>`으로 wrap → codegen이 **object literal로 출력** → hermesc `'{' expected` (react-native VirtualView의 `match` 사용처에서 CI 실패).

- transformer: block body는 statement들을 펼치고 `return;`으로 함수 탈출, expression body만 `return <expr>`.
- parser: block body 뒤 trailing comma도 optional eat.

## /simplify 반영
중복 제거: `mkNum`→`makeNumericLiteral`, `S!=null`→`makeNeqNull`, `mkKeyLit` ident분기→`buildQuotedKeyLiteral`, `Object.assign`→`makeObjectAssignCall`. `cloneNode` shallow 불변식 doc 명시, `isAlwaysTrue` 인코딩 계약 주석.

## 결과
- `zig build test` PASS, `tsc -b --force` PASS
- 통합 **3781 pass / 0 fail** (이전 3 fail → 해결: RN ExampleApp 번들 Node 실행 + hermesc 0 errors)
- flow-libs 55 + flow-rn 50

이로써 Flow match 전 pattern 종류가 **런타임까지 정확**. 잔여 없음. #3301 CI 회귀도 본 PR 머지로 해소됨.