### PR TITLE
docs(plugins): correct plugin status drift vs actual code

### DIFF
--- a/docs/AST_PLUGINS.md
+++ b/docs/AST_PLUGINS.md
@@ -155,6 +155,10 @@ modified_body가 있으면 result 노드 패치
 trailing_nodes가 있으면 함수 뒤에 삽입
 ```
 
+> 참고: 내장 Zig 플러그인 중 `onFunction`(AST 훅)을 쓰는 것은 `worklet_plugin`
+> 하나뿐이다. `rn_codegen_plugin` 은 `.transform`(string 훅)만 사용하므로
+> 위 AST 훅 흐름과는 별개 경로다.
+
 ## 내장 플러그인 추가 방법
 
 1. `src/transformer/plugins/my_plugin.zig` 생성

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -109,7 +109,7 @@ const result = await build({
 });
 ```
 
-**제한사항**: `buildSync()`에서는 JS 플러그인 미지원 (메인 스레드 데드락). `build()` / `watch()`에서 사용 가능.
+**제한사항**: `buildSync()`에서는 **async 플러그인 훅**이 미지원 (메인 스레드 데드락). sync 훅은 sync dispatcher 로 동작한다. async 훅이 필요하면 `build()` / `watch()`를 사용.
 
 ### 4단계: Vite/Rollup 호환 어댑터 ✅ 완료 (#992, #1004, #1007)
 - `vitePlugin()` 함수로 Rollup 스타일 플러그인을 ZNTC 플러그인으로 변환
@@ -191,19 +191,25 @@ pub const Plugin = struct {
 - lifecycle: `buildStart → buildEnd → closeBundle` 순서로 모두 실행. `buildEnd` / `closeBundle` 에러는 본 build 결과를 가리지 않도록 swallow
 - watch lifecycle: `buildStart → buildEnd → onReady/onRebuild → closeBundle` 순서로 초기 build와 매 rebuild마다 실행
 
-## Builtin 플러그인 (Zig 구현)
+## Builtin 처리 (Zig 구현)
+
+> 아래는 독립 `Plugin` struct 가 아니라 graph 의 **loader/codegen 경로**로
+> 네이티브 구현된 기능이다 ("플러그인"이라는 명칭은 역할상 분류일 뿐).
+
 ```
 ┌────────────────────────┬───────────────────────────────────────┐
-│ 플러그인               │ 기능                                   │
+│ 기능                   │ 동작                                   │
 ├────────────────────────┼───────────────────────────────────────┤
 │ json                   │ JSON → export default + named exports  │
 │ asset                  │ 이미지/폰트 → 해시 파일명 + URL export │
 │ text                   │ 텍스트 파일 → 문자열 export            │
 │ glob-import            │ import.meta.glob(...) 처리             │
-│ dynamic-import-vars    │ import(`./pages/${name}.ts`) 처리     │
-│ wasm                   │ WASM 파일 로딩                         │
+│ require context        │ require(`./pages/` + name) webpack식 확장 │
 └────────────────────────┴───────────────────────────────────────┘
 ```
+
+> 미구현: Vite 식 dynamic-import-vars (`import(\`./x/${n}.ts\`)`), `.wasm`
+> 모듈 로더. (`Loader` enum 에 wasm 없음 — ROADMAP 미지원 참조)
 
 ## Vite 호환 확장 (4단계)
 - resolveId / load / transform — Rollup 호환 (어댑터로 변환)
@@ -296,8 +302,12 @@ const modules = import.meta.glob(['./src/**/*.ts', '!**/*.test.ts'])
 
 ### Dynamic Import Variables
 ```typescript
-import(`./pages/${name}.ts`)
-// → glob 패턴으로 확대하여 가능한 모듈 전부 번들에 포함
+// 현재 지원: webpack 식 require context
+require(`./pages/` + name)
+// → 디렉토리 스캔으로 가능한 모듈 전부 번들에 포함
+
+// 미구현: Vite 식 변수 동적 import
+// import(`./pages/${name}.ts`)
 ```
 
 ### Web Workers
@@ -336,10 +346,10 @@ new Worker(new URL('./worker.ts', import.meta.url))
 ### CLI에 노출됨
 
 - `--tsconfig-raw` — tsconfig JSON 문자열 오버라이드
-
-### 아직 CLI에 미노출
 - `--conditions`, `--node-paths` — resolver 조건/추가 탐색 경로
 - `--ignore-annotations`, `--jsx-side-effects`
+
+### 아직 CLI에 미노출
 - `--mangle-props`, `--mangle-cache`, `--reserve-props`
 - `--log-override`
 - CORS 설정

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -188,7 +188,7 @@ esbuild / rolldown / rspack 기준으로 ZNTC에 빠진 기능 목록.
   `--asset-names`, `--public-path` 지원.
 
 - ~~**플러그인 API**~~ — ✅ 완료 ([PLUGINS.md](./PLUGINS.md) 참조)
-  - 1단계: ✅ Zig Builtin 플러그인 — 함수 포인터 기반 Plugin struct, 5개 훅 (worklet/refresh 등 내부 전용)
+  - 1단계: ✅ Zig Builtin 플러그인 — 함수 포인터 기반 Plugin struct, 5개 string 훅 + onFunction AST 훅. 내장 AST 플러그인 프리셋(`builtin.zig`)에 등록된 것은 `worklet` 하나뿐 — refresh/styled/emotion 등은 별도 graph-level transform 플래그(`transformer/options.zig`)이지 onFunction 내장 플러그인이 아님
   - ~~2단계: JS 플러그인 subprocess~~ — ❌ D101로 제거. NAPI(3단계)가 기본 경로
   - 3단계: ✅ N-API .node addon — in-process 호출, TSFN 기반 async 브릿지 (기본 JS 플러그인 경로)
   - 4단계: ✅ Vite/Rollup 어댑터 — vitePlugin() + async 훅 + renderChunk/generateBundle + lifecycle/watch


### PR DESCRIPTION
## 요약

플러그인 관련 문서(PLUGINS.md / AST_PLUGINS.md / ROADMAP.md)의 "구현 상태 주장"을 실제 코드와 교차 대조해 불일치를 정정. **코드 변경 없음, 문서만**.

검증: 2개 서브에이전트가 각 문서의 모든 상태 표기(✅완료/❌미구현/예정/미노출)를 코드(`src/bundler/plugin.zig`, `packages/core/index.ts`, `src/cli/options.zig` 등)와 file:line 단위로 대조.

## A. 문서가 앞섬 (있다는데 실제 미구현·부정확)

| 항목 | 정정 |
|---|---|
| Builtin 표 `wasm` 로더 | 제거 — `Loader` enum 에 없음 |
| `dynamic-import-vars` | Vite 식 `import(\`./${n}\`)` 미구현, webpack require-context 만 지원으로 명시 |
| buildSync 제한 | "JS 플러그인 미지원" → "async 훅만 미지원, sync 훅은 sync dispatcher 동작" |

## B. 문서가 뒤처짐 (이미 노출됐는데 "미노출")

`--conditions` / `--node-paths` / `--ignore-annotations` / `--jsx-side-effects` → "아직 CLI 에 미노출" 에서 "CLI 에 노출됨" 으로 이동 (모두 `options.zig` 에 실재).

## C. 표현 정정 (코드 구조 ≠ 문서)

- Builtin 표가 독립 `Plugin` struct 가 아니라 graph 의 loader/codegen 경로임을 명시.
- ROADMAP 1단계 "5개 훅 (worklet/refresh 등)" → 내장 AST 플러그인 프리셋엔 `worklet` 하나뿐, refresh/styled/emotion 은 graph-level transform 플래그임을 명시.
- AST_PLUGINS.md 실행 흐름: `onFunction`(AST 훅) 쓰는 내장 플러그인은 worklet 하나, `rn_codegen` 은 `.transform`(string 훅) 별개 경로임을 주석 추가.

## 정확했던 것 (수정 불필요, 참고)

AST_PLUGINS.md 4분류 표(JS=✅완료 / Zig내장=✅완료 / 공유라이브러리=❌미구현 / WASM 플러그인=❌미구현)는 **전부 정확**. 특히 외부 개발자용 JS 플러그인은 `onAstFunction` 까지 end-to-end 실재(`plugin_bridge.zig` 직렬화 + `index.ts:1195` API + Zig 디스패치) 확인. vitePlugin 8훅 / this.resolve·emitFile 미지원 / 5단계 Tapable 예정 / 로더 표 / import.meta.glob / Web Workers / Virtual Modules 모두 일치.

> docs-only 변경이라 `/simplify`(코드 리뷰)·테스트는 해당 없음.