### PR TITLE
docs(pages): correct buildSync plugin limitation on deployed site

### DIFF
--- a/documents/src/content/docs/en/guides/plugins.md
+++ b/documents/src/content/docs/en/guides/plugins.md
@@ -33,7 +33,7 @@ Sorted by status: ✅ Supported → ⚠️ Partial → ➖ no-op → ❌ Unsuppo
 | Plugin context `this.addWatchFile()` | ➖ no-op | Callable but not propagated to the native watcher (SFC `<style src="..."/>` external dep may go stale) |
 | Plugin context `this.resolve()` / `this.emitFile()` | ❌ Unsupported | Throws an informative Error — graph mutation surface is missing |
 | **Framework SFC** (`.vue` / `.svelte`) | ❌ Unsupported | Requires recognising virtual module IDs and `?vue&type=style&lang.css` query sub-imports — [details + workarounds →](/zntc/en/guides/plugin-recipes/#framework-sfc-vue--svelte--currently-unsupported) |
-| `buildSync()` + JS plugins | ❌ Unsupported | use async `build()` / `watch()` |
+| `buildSync()` + async JS hooks | ❌ Unsupported (sync hooks work) | use `build()` / `watch()` for async hooks |
 
 The native ZNTC worker calls JS hooks through NAPI threadsafe functions when it reaches a module and waits for the response. Keep hook filters narrow, and prefer the built-in `loader` option for simple extension-based handling.
 

--- a/documents/src/content/docs/guides/plugins.md
+++ b/documents/src/content/docs/guides/plugins.md
@@ -33,7 +33,7 @@ ZNTC 플러그인은 Rollup/Vite 호환 인터페이스로, `@zntc/core`의 NAPI
 | Plugin context `this.addWatchFile()` | ➖ no-op | 호출 가능하지만 native watcher 에 전파 X (SFC `<style src="..."/>` 외부 dep stale 가능) |
 | Plugin context `this.resolve()` / `this.emitFile()` | ❌ 미지원 | 호출 시 informative Error throw — graph mutation surface 부재 |
 | **프레임워크 SFC** (`.vue` / `.svelte`) | ❌ 미지원 | virtual module ID + `?vue&type=style&lang.css` query sub-import 인식 필요 — [자세히 + 대안 →](/zntc/guides/plugin-recipes/#프레임워크-sfc-vue--svelte--현재-미지원) |
-| `buildSync()` + JS plugin | ❌ 미지원 | async `build()` / `watch()` 사용 |
+| `buildSync()` + async JS 훅 | ❌ 미지원 (sync 훅은 동작) | async 훅이 필요하면 `build()` / `watch()` |
 
 ZNTC native worker는 module을 만날 때 NAPI threadsafe function으로 JS hook을 호출하고 응답을 기다립니다. 따라서 hook filter를 좁게 잡고, 단순 확장자 처리는 `loader` 옵션을 먼저 쓰는 편이 빠릅니다.
 
@@ -214,7 +214,7 @@ const result2 = await build({
 });
 ```
 
-> **참고**: `buildSync()`에서는 JS 플러그인을 사용할 수 없습니다 (메인 스레드 데드락). `build()` (async)에서만 지원됩니다.
+> **참고**: `buildSync()`에서는 **async 플러그인 훅**이 동작하지 않습니다 (메인 스레드 데드락). sync 훅은 그대로 동작하며, async 훅이 필요하면 `build()` / `watch()`를 사용하세요.
 
 ## 설정 파일
 


### PR DESCRIPTION
## 요약

GitHub Pages 배포 문서(`documents/`)의 `plugins.md`(ko/en)가 내부 PLUGINS.md와 **동일한 부정확**을 갖고 있어 정정 (#3306 후속 — 배포 문서 누락분).

코드 검증(`packages/core/index.ts:2209-2225`): `buildSync()`는 sync 플러그인 훅을 sync dispatcher로 정상 실행. **async 훅만** 미지원.

## 변경

- `documents/.../guides/plugins.md` (ko): 한계 표 행 + 본문 참고 노트
- `documents/.../en/guides/plugins.md` (en): 한계 표 행

> "JS 플러그인 사용 불가" → "async 훅만 미지원, sync 훅은 동작"

## 확인 (수정 불필요)

- 배포 문서 `WASM plugin ❌ 추후 지원 예정` → 코드와 **일치** (WASM 플러그인 런타임 미구현, 정확).
- 내부 문서에만 있던 drift(wasm 로더 / Vite식 dynamic-import-vars / `--conditions` 등 CLI)는 배포 문서엔 **애초에 없음** — #3306에서 내부 PLUGINS.md/ROADMAP/AST_PLUGINS 정정 완료.

사용자 관점 문서 원칙 유지 (한계만 정확히 서술, PR번호/내부용어 없음). docs-only.