### PR TITLE
refactor: transparent type-wrapper 태그를 단일 predicate 로 통합 (#3129)

### DIFF
--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -38,6 +38,10 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
     // 컨테이너 노드 (program, block_statement, function_body, class_body, static_block,
     // switch_statement, try_statement) 는 자식이 매핑하므로 자체 발행 안 함.
 
+    // TS/Flow type wrapper: operand 만 출력 (type 스트리핑, #3129 단일 source).
+    // pre-visit body codegen 시 TS/Flow 노드가 남아있을 수 있어 명시 처리.
+    if (ast_mod.Node.Tag.isTransparentTypeWrapper(node.tag)) return self.emitNode(node.data.unary.operand);
+
     switch (node.tag) {
         .program => try statement_emit.emitProgram(self, node),
         .block_statement => try statement_emit.emitBlock(self, node),
@@ -345,16 +349,7 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
         // init expression 이 없으면 base_type 에 따라 default value (string/number/...).
         .flow_enum_declaration => try type_runtime_emit.emitFlowEnum(self, node),
 
-        // TS/Flow expression 노드: operand만 출력 (type 부분 스트리핑).
-        // pre-visit body를 codegen할 때 (e.g. worklet __initData.code) TS/Flow 노드가 남아있을 수 있음.
-        .ts_as_expression,
-        .ts_satisfies_expression,
-        .ts_non_null_expression,
-        .ts_type_assertion,
-        .ts_instantiation_expression,
-        .flow_as_expression,
-        .flow_type_cast_expression,
-        => try self.emitNode(node.data.unary.operand),
+        // (TS/Flow type wrapper 는 switch 진입 전 #3129 single-source 처리)
 
         // TS 타입 전용 노드: 출력 안 함
         .ts_type_alias_declaration,

--- a/src/parser/ast.zig
+++ b/src/parser/ast.zig
@@ -479,6 +479,30 @@ pub const Node = struct {
             };
         }
 
+        /// TS/Flow runtime-transparent type wrapper 태그 (괄호 제외).
+        /// 모두 `data.unary.operand` 로 안쪽 값 노드에 접근 가능하며 런타임상
+        /// noop — 타입 스트립 후 operand 만 남는다. 새 wrapper 태그 추가 시
+        /// 이 함수만 갱신하면 코드베이스 전 분기가 따라온다 (#3129).
+        pub fn isTransparentTypeWrapper(tag: Tag) bool {
+            return switch (tag) {
+                .ts_as_expression,
+                .ts_satisfies_expression,
+                .ts_non_null_expression,
+                .ts_type_assertion,
+                .ts_instantiation_expression,
+                .flow_as_expression,
+                .flow_type_cast_expression,
+                => true,
+                else => false,
+            };
+        }
+
+        /// `isTransparentTypeWrapper` + `parenthesized_expression`.
+        /// `unwrapTransparentWrappers` 처럼 괄호까지 통과해야 하는 곳에서 사용.
+        pub fn isTransparentWrapper(tag: Tag) bool {
+            return tag == .parenthesized_expression or isTransparentTypeWrapper(tag);
+        }
+
         /// 노드 데이터의 종류. AST 워커가 자식 노드를 일관되게 탐색하기 위해 사용.
         pub const DataKind = enum {
             /// 리프 노드: 자식 없음 (none, string_ref, number_bytes)

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -1252,6 +1252,13 @@ pub const SemanticAnalyzer = struct {
         if (@intFromEnum(idx) >= self.ast.nodes.items.len) return;
 
         const node = self.ast.getNode(idx);
+        // TS/Flow 타입 wrapper: 값(operand)만 순회, 타입 부분 스킵 (#3129 단일 source).
+        // as/satisfies 는 binary(left=expr,right=type) 이나 extern union 이라
+        // unary.operand == binary.left — 값 부분만 방문된다.
+        if (Tag.isTransparentTypeWrapper(node.tag)) {
+            try self.visitNode(node.data.unary.operand);
+            return;
+        }
         switch (node.tag) {
             // ---- 스코프 생성 노드 ----
             .program => try self.visitProgram(node),
@@ -1634,21 +1641,7 @@ pub const SemanticAnalyzer = struct {
                 try self.visitNode(node.data.unary.operand);
             },
 
-            // ---- TS expression: 값 부분만 순회, 타입 부분은 스킵 ----
-            // ts_as_expression, ts_satisfies_expression은 binary(left=expr, right=type)이지만
-            // extern union이므로 unary.operand == binary.left — 값(expr) 부분만 방문한다.
-            // ts_non_null_expression은 unary(operand=expr).
-            // ts_type_assertion, ts_instantiation_expression은 현재 파서가 생성하지 않지만 안전을 위해 포함.
-            .ts_as_expression,
-            .ts_satisfies_expression,
-            .ts_non_null_expression,
-            .ts_type_assertion,
-            .ts_instantiation_expression,
-            .flow_type_cast_expression,
-            .flow_as_expression,
-            => {
-                try self.visitNode(node.data.unary.operand);
-            },
+            // (TS/Flow type wrapper 는 switch 진입 전 #3129 single-source 처리)
 
             // destructuring assignment targets — 이전에는 else 케이스로 skip되어
             // 내부 식별자의 write 참조가 카운트되지 않는 analysis gap이 있었다 (#1608 follow-up).

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -1509,14 +1509,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
 
             // TS/Flow 타입 wrapper 는 런타임상 noop 이므로 통과한다. 그러지 않으면 타입 스트립
             // 이후 `(await x) as T` 가 추출되지 못한 raw `(yield x)` 로 남는다.
-            if (node.tag == .ts_as_expression or
-                node.tag == .ts_satisfies_expression or
-                node.tag == .ts_non_null_expression or
-                node.tag == .ts_type_assertion or
-                node.tag == .ts_instantiation_expression or
-                node.tag == .flow_as_expression or
-                node.tag == .flow_type_cast_expression)
-            {
+            if (Tag.isTransparentTypeWrapper(node.tag)) {
                 return visitExprWithYieldExtraction(self, node.data.unary.operand, ops, next_label);
             }
 

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -132,18 +132,10 @@ pub fn unwrapTransparentWrappersAst(ast: *const @import("../parser/ast.zig").Ast
     while (true) {
         if (cur.isNone()) return cur;
         const node = ast.getNode(cur);
-        switch (node.tag) {
-            .parenthesized_expression,
-            .ts_as_expression,
-            .ts_satisfies_expression,
-            .ts_type_assertion,
-            .ts_instantiation_expression,
-            .ts_non_null_expression,
-            .flow_as_expression,
-            .flow_type_cast_expression,
-            => cur = node.data.unary.operand,
-            else => return cur,
-        }
+        // 단일 source: ast.Node.Tag.isTransparentWrapper (paren + type wrapper, #3129).
+        if (@import("../parser/ast.zig").Node.Tag.isTransparentWrapper(node.tag)) {
+            cur = node.data.unary.operand;
+        } else return cur;
     }
 }
 

--- a/src/transformer/transformer/enum.zig
+++ b/src/transformer/transformer/enum.zig
@@ -147,6 +147,14 @@ fn evalConstEnumExpr(
     ctx: ConstEnumEvalCtx,
 ) Error!?ConstEnumValue {
     const node = self.ast.getNode(expr_idx);
+    // 괄호 + TS/Flow 타입 wrapper — 값엔 영향 없으니 inner 만 평가 (#2193, #3129).
+    // 누락 시 `Blue = "B" as any` 같은 cast 멤버 하나로 collectConstEnum 의
+    // `orelse return` 이 enum 전체 등록을 실패시켜 ReferenceError 가 된다.
+    if (Tag.isTransparentWrapper(node.tag)) {
+        const inner = node.data.unary.operand;
+        if (inner.isNone()) return null;
+        return evalConstEnumExpr(self, inner, ctx);
+    }
     switch (node.tag) {
         .numeric_literal => {
             const text = self.ast.getText(node.span);
@@ -165,27 +173,6 @@ fn evalConstEnumExpr(
         .boolean_literal => {
             // ECMAScript: true=1, false=0 (Number 변환).
             return .{ .number = if (node.data.none == 1) 1 else 0 };
-        },
-        .parenthesized_expression => {
-            const inner = node.data.unary.operand;
-            if (inner.isNone()) return null;
-            return evalConstEnumExpr(self, inner, ctx);
-        },
-        // TS / Flow 타입 wrapper — 값에는 영향 없으니 inner 만 평가 (#2193).
-        // 누락 시 `Blue = "B" as any` 같은 cast 가 들어간 멤버 한 개 때문에
-        // collectConstEnum 의 `orelse return` 으로 enum 전체 등록이 실패하고,
-        // declaration 은 transformer 가 drop 한 상태로 참조만 남아 ReferenceError.
-        .ts_as_expression,
-        .ts_satisfies_expression,
-        .ts_non_null_expression,
-        .ts_type_assertion,
-        .ts_instantiation_expression,
-        .flow_as_expression,
-        .flow_type_cast_expression,
-        => {
-            const inner = node.data.unary.operand;
-            if (inner.isNone()) return null;
-            return evalConstEnumExpr(self, inner, ctx);
         },
         .unary_expression => {
             const ue = node.data.extra;

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -64,16 +64,10 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
     // --------------------------------------------------------
     // 4단계: 태그별 분기 (switch 기반 visitor)
     // --------------------------------------------------------
+    // TS/Flow type wrapper: 타입 부분만 제거, 값 보존 (#3129 단일 source).
+    if (ast_mod.Node.Tag.isTransparentTypeWrapper(node.tag)) return self.visitTsExpression(idx);
+
     return switch (node.tag) {
-        // === TS expressions: 타입 부분만 제거, 값 보존 ===
-        .ts_as_expression,
-        .ts_satisfies_expression,
-        .ts_non_null_expression,
-        .ts_type_assertion,
-        .ts_instantiation_expression,
-        .flow_as_expression,
-        .flow_type_cast_expression,
-        => self.visitTsExpression(idx),
 
         .flow_match_expression => self.visitFlowMatch(node),
 

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -68,7 +68,6 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
     if (ast_mod.Node.Tag.isTransparentTypeWrapper(node.tag)) return self.visitTsExpression(idx);
 
     return switch (node.tag) {
-
         .flow_match_expression => self.visitFlowMatch(node),
 
         // Flow component with ref → function Name_withRef + const Name = React.forwardRef(...)

--- a/src/transformer/transformer/styled_components.zig
+++ b/src/transformer/transformer/styled_components.zig
@@ -292,22 +292,9 @@ pub fn maybeWrapAssignment(self: *Transformer, assignment_idx: NodeIndex) Error!
 
 /// `parenthesized_expression` + 모든 type assertion 류 — 공통적으로 unary { operand, flags }
 /// 데이터 변형. wrapStyledTagInExpr 와 isWrappableExpr 가 이 set 을 공유.
-///
-/// 주의: codegen / semantic / worklet 등 다른 pass 도 비슷한 set 을 가짐. 향후 cross-cutting
-/// refactor 로 es_helpers 의 `TRANSPARENT_WRAPPER_TAGS` 같은 단일 source 화 권장 (별도 PR).
+/// 단일 source: `ast.Node.Tag.isTransparentWrapper` (#3129).
 fn isUnaryWrapperTag(tag: ast_mod.Node.Tag) bool {
-    return switch (tag) {
-        .parenthesized_expression,
-        .ts_as_expression,
-        .ts_satisfies_expression,
-        .ts_type_assertion,
-        .ts_non_null_expression,
-        .ts_instantiation_expression,
-        .flow_as_expression,
-        .flow_type_cast_expression,
-        => true,
-        else => false,
-    };
+    return ast_mod.Node.Tag.isTransparentWrapper(tag);
 }
 
 /// 표현식이 styled tagged template 을 (직접 / wrapper 안에) 포함하면 wrap.


### PR DESCRIPTION
## 요약

`Closes #3129`. 동일한 TS/Flow runtime-transparent wrapper 태그 집합이 코드베이스 **7곳에 하드코딩 반복**돼 새 wrapper 추가 시 누락 위험(예: PR #3126)이 컸다. 단일 predicate 로 통합.

## 변경

`ast.Node.Tag` 에 sibling predicate 2개 추가 (`isLiteralTag`/`isTypeOnlyDeclaration` 와 동일 idiom):

- `isTransparentTypeWrapper(tag)` — `ts_as`/`ts_satisfies`/`ts_non_null`/`ts_type_assertion`/`ts_instantiation`/`flow_as`/`flow_type_cast` (7개, paren 제외)
- `isTransparentWrapper(tag)` — + `parenthesized_expression`

**동작 불변** 교체 (switch arm → switch 진입 전 if-guard 추출):
| 파일 | 변경 |
|---|---|
| es2015_generator | or-chain → predicate |
| transformer/node_dispatch | 7-tag arm → 진입 전 if |
| codegen/node_dispatch | 7-tag arm → 진입 전 if |
| semantic/analyzer | 7-tag arm → 진입 전 if + return |
| transformer/enum | paren arm + 7-tag arm 병합 → `isTransparentWrapper` |
| styled_components.isUnaryWrapperTag | 본문 predicate 위임 |
| es_helpers.unwrapTransparentWrappersAst | switch → predicate 일원화 |

순감 35줄 (90 삭제 / 55 추가).

## 의도적 제외 (다른 집합/접근 — 통합 대상 아님)

- `worklet.zig`: `data.binary.left` 처리 + `ts_non_null` 제외
- `node_dispatch.zig:217` inner_tag: `ts_instantiation` 없는 6개
- `cover.zig`: as/satisfies 만 (assignment target)
- `scan.zig`: + spread/rest (yield scan, 다른 목적)
- `ast.zig` enum 선언 / DataKind layout, `expression.zig` tag 생성

## 검증

순수 behavior-preserving refactor:
- `zig build test` 전체 PASS
- 통합 flow-libs 55 + flow-rn 50 = **105/105**
- `tsc -b --force` PASS
- smoke: `x as number`→`x`, `z!`→`z`, generator `(yield p) as T`→`(yield p)` 정상
- **`/simplify` 3-agent 리뷰**: 7곳 semantic 동일성 + 제외 5곳 정당성 + 누락 0 + predicate 배치 idiom 일치 확인, correctness risk 없음