### PR TITLE
fix(semantic): forward export to import binding via read-only side-table (D20)

### DIFF
--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -33,6 +33,7 @@ const checker = @import("checker.zig");
 const diagnostic = @import("../diagnostic.zig");
 pub const Diagnostic = diagnostic.Diagnostic;
 const ErrorCode = @import("../error_codes.zig").Code;
+const runtime_helper_modules = @import("../runtime_helper_modules.zig");
 
 const AllocError = std.mem.Allocator.Error;
 
@@ -150,6 +151,16 @@ pub const SemanticAnalyzer = struct {
     /// scope_maps 가 아닌 이 풀에서만 lookup.
     helper_scope_map: std.StringHashMapUnmanaged(usize) = .empty,
 
+    /// RFC #3310 (D20): forward `export { X }; import X from './x'` 지원용 read-only
+    /// side-table. key = top-level default/namespace import 의 local name.
+    /// ECMAScript 상 import 는 module top 으로 hoist 되므로 export 가 import 보다
+    /// 소스상 앞이어도 valid. 단일 패스 analyzer 가 forward import symbol 을 못 찾을
+    /// 때 `checkExportBinding` 의 fallback 으로만 참조 — **symbol/scope 선언을 절대
+    /// 하지 않는다**. helper import 는 항상 named import_specifier 이고 default/
+    /// namespace 만 기록하므로 helper local 이 구조적으로 섞이지 않는다 (runtime
+    /// helper scope isolation 모델 무침범).
+    forward_import_names: std.StringHashMapUnmanaged(void) = .empty,
+
     /// per-reference 배열. resolveIdentifier에서 symbol resolve 성공 시 기록.
     /// mangler liveness 및 위치 기반 최적화(dead store, single-use inline 등) consumer의 입력.
     references: std.ArrayList(symbol_mod.Reference),
@@ -259,6 +270,7 @@ pub const SemanticAnalyzer = struct {
         self.errors.deinit(self.allocator);
         self.symbol_ids.deinit(self.allocator);
         self.helper_scope_map.deinit(self.allocator);
+        self.forward_import_names.deinit(self.allocator);
         self.references.deinit(self.allocator);
         self.numeric_const_texts.deinit(self.allocator);
         for (self.class_private_declared.items) |*map| map.deinit();
@@ -1889,6 +1901,9 @@ pub const SemanticAnalyzer = struct {
                 .function_declaration => try self.predeclareFuncDecl(node),
                 .class_declaration => try self.predeclareClassDecl(node),
                 .ts_enum_declaration => try self.predeclareEnumDecl(node),
+                // RFC #3310 (D20): forward `export {}; import default/namespace`.
+                // local name 만 side-table 에 기록 — symbol/scope 선언 절대 안 함.
+                .import_declaration => try self.recordForwardImportNames(node),
                 .export_named_declaration => {
                     // export const x = ..., export function f() {}, export class C {}
                     const extra_start = node.data.extra;
@@ -2132,6 +2147,64 @@ pub const SemanticAnalyzer = struct {
         if (!name_idx.isNone()) {
             const name_node = self.ast.getNode(name_idx);
             try self.declareSymbolWithNode(name_node.span, .variable_var, node.span, @intFromEnum(name_idx));
+        }
+    }
+
+    /// RFC #3310 (D20): top-level import declaration 의 모든 specifier (default/
+    /// namespace/named) local name 을 `forward_import_names` side-table 에 기록한다.
+    /// 절대 symbol/scope/helper_scope_map 을 건드리지 않는다 — `checkExportBinding`
+    /// 의 read-only fallback 전용.
+    ///
+    /// helper 배제: runtime helper import 는 항상 `\x00zntc:runtime/...` virtual
+    /// source 이므로 source guard 가 helper import declaration 을 **통째로** skip
+    /// 한다. helper 는 Pass 1 (user source only) 엔 아예 없고, Pass 2 (helper 주입
+    /// 후) 엔 virtual source 로 배제되므로 helper local (`__extends` 등) 이 side-table
+    /// 에 구조적으로 섞이지 않는다. side-table 은 symbol 선언을 하지 않아 helper/
+    /// user scope isolation 모델 (helper_scope_map / canonical name) 무침범.
+    /// grpc-js src/index.ts 는 default+named forward 혼재라 named 도 기록해야 완전
+    /// 해결 (full semantic 경로에선 named forward 도 ZNTC1201 노출).
+    fn recordForwardImportNames(self: *SemanticAnalyzer, node: Node) AllocError!void {
+        const extra_start = node.data.extra;
+        const extras = self.ast.extra_data.items;
+        // import_declaration extra: [specs_start, specs_len, source, ...]
+        if (extra_start + 2 >= extras.len) return;
+        const specs_start = extras[extra_start];
+        const specs_len = extras[extra_start + 1];
+        if (specs_len == 0) return; // side-effect import
+        if (specs_start + specs_len > extras.len) return;
+
+        // 방어: helper virtual module (`\x00zntc:runtime/...`) import 는 skip.
+        // source 노드 텍스트는 따옴표 포함 (`"\x00zntc:runtime/extends"`).
+        const source_idx: NodeIndex = @enumFromInt(extras[extra_start + 2]);
+        if (!source_idx.isNone() and @intFromEnum(source_idx) < self.ast.nodes.items.len) {
+            const raw = self.ast.getText(self.ast.getNode(source_idx).span);
+            const unquoted = if (raw.len >= 2 and (raw[0] == '\'' or raw[0] == '"' or raw[0] == '`'))
+                raw[1 .. raw.len - 1]
+            else
+                raw;
+            if (runtime_helper_modules.isVirtualId(unquoted)) return;
+        }
+
+        for (extras[specs_start .. specs_start + specs_len]) |raw_idx| {
+            const spec_idx: NodeIndex = @enumFromInt(raw_idx);
+            if (spec_idx.isNone()) continue;
+            if (@intFromEnum(spec_idx) >= self.ast.nodes.items.len) continue;
+            const spec_node = self.ast.getNode(spec_idx);
+            // local name span: default/namespace 는 spec.span (string_ref, 별도 name
+            // 노드 없음), named 는 binary.right (= local) 노드의 span.
+            const name_span: Span = switch (spec_node.tag) {
+                .import_default_specifier, .import_namespace_specifier => spec_node.span,
+                .import_specifier => blk: {
+                    const local_idx = spec_node.data.binary.right;
+                    if (local_idx.isNone()) continue;
+                    if (@intFromEnum(local_idx) >= self.ast.nodes.items.len) continue;
+                    break :blk self.ast.getNode(local_idx).span;
+                },
+                else => continue,
+            };
+            if (self.ast.getText(name_span).len == 0) continue;
+            const stable = try self.ast.getTextStable(self.allocator, name_span);
+            try self.forward_import_names.put(self.allocator, stable, {});
         }
     }
 
@@ -3491,6 +3564,10 @@ pub const SemanticAnalyzer = struct {
             const sym_name = self.ast.getText(sym.name);
             if (std.mem.eql(u8, sym_name, name)) return; // 존재
         }
+        // RFC #3310 (D20): forward `export { X }; import X from './x'` — import 는
+        // module top hoist 라 valid. 단일 패스라 X import symbol 이 아직 안 보이면
+        // side-table fallback (recordForwardImportNames 가 1st pass 에 채움).
+        if (self.forward_import_names.contains(name)) return;
         // 찾지 못함 → 에러
         try self.addErrorMsgCode(span, try std.fmt.allocPrint(
             self.allocator,

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -1018,6 +1018,41 @@ test "Enum: undefined export still errors" {
 // 보존해야 같은 file 안의 다른 (value) import 와 함께 있을 때 export 검증
 // 이 그 binding 을 인식한다.
 
+test "Export: forward ref to default/namespace import binding (D20 #3310)" {
+    // @grpc/grpc-js src/index.ts 패턴 — `export { X };` 가 X 를 바인딩하는
+    // default/namespace import 보다 소스상 앞. ECMAScript: import 는 module top
+    // hoist 라 valid (webpack/rollup/babel/tsc/swc 통과). 단일 패스 analyzer 가
+    // forward import 를 못 찾아 ZNTC1201 오진단하던 회귀.
+    try analyzeNoErrors(
+        \\export { Deadline };
+        \\import Deadline from './deadline';
+    );
+    try analyzeNoErrors(
+        \\export { ns };
+        \\import * as ns from './mod';
+    );
+    // default + named 혼재 forward
+    try analyzeNoErrors(
+        \\export { a, b };
+        \\import a from './a';
+        \\import { b } from './b';
+    );
+    // 정상 순서 (import 가 export 앞) — regression guard
+    try analyzeNoErrors(
+        \\import Deadline from './deadline';
+        \\export { Deadline };
+    );
+}
+
+test "Export: undefined name still errors (D20 negative guard)" {
+    // side-table fallback 이 진짜 미정의 export 까지 통과시키면 안 됨.
+    var r = try analyzeModule(
+        \\export { totallyMissing };
+    );
+    defer r.deinit();
+    try expectAnalyzeError(&r, "totallyMissing");
+}
+
 test "Import: type-only + namespace value from same source — export resolves" {
     try analyzeNoErrors(
         \\import type { Foo } from './x';


### PR DESCRIPTION
Closes #3310

## Summary

`export { X };` 가 X 를 바인딩하는 import 보다 **소스상 앞**일 때 `Export 'X' is not defined [ZNTC1201]` 오진단 fix. ECMAScript 상 import 는 module top hoist 라 valid (webpack/rollup/babel/tsc/swc 통과). `@grpc/grpc-js` `src/index.ts`.

## 재현 (fix 전)

```ts
export { Deadline };
import Deadline from './deadline';   // × Export 'Deadline' is not defined [ZNTC1201]
```

## 이전 정공법이 막힌 이유 (RFC #3310)

`predeclareTopLevelBindings` 에 `declareSymbolWithNode` 추가 (ECMAScript hoist 의미상 정확) → bundler runtime-helper scope isolation 모델 (`helper_scope_map`, `__extends` canonical name) 과 충돌, **11 회귀** (`runtime_helper_shadow`, `default_deconflict`, `minify_loader` 등) → rollback.

## RFC Candidate (C) — read-only side-table

핵심: **symbol 선언을 절대 하지 않는** side-table 이라 helper scope isolation 모델을 구조적으로 침범 불가.

- `forward_import_names: StringHashMapUnmanaged(void)` 필드 + deinit
- `recordForwardImportNames`: predeclare 1st pass 에서 import declaration 의 default/namespace(`spec.span`) / named(`binary.right`) local name 만 side-table 에 기록. scope/symbol/helper_scope_map 무접촉.
- **helper 배제**: helper import 는 항상 `\x00zntc:runtime/...` virtual source → source guard 가 helper import declaration 통째 skip. Pass 1 (helper 없음) / Pass 2 (virtual source 배제) 양쪽에서 helper local 미혼입.
- `checkExportBinding`: symbol 미발견 시 `forward_import_names.contains(name)` fallback. 진짜 미정의 export 는 여전히 ZNTC1201.

## 회귀 가드

- forward default / namespace / named / 혼재 / 정상순서 (analyzer_test.zig)
- negative: `export { totallyMissing }` 여전히 에러

## Fuzz / test

| | 결과 |
|---|---|
| grpc-js src | **0 / 107** (이전 1) |
| zod 4.4.1 | 0 / 390 |
| immer 11 | 0 / 18 |
| type-fest 4 | 0 / 166 |
| mobx 6.15 | 0 / 115 |
| rxjs 7.8 src | 0 / 251 |
| zig build test | Debug + ReleaseFast **0 fail** |
| 11 runtime-helper test | **전부 통과** |

## Review (3-agent /simplify)

7/7 체크포인트 PASS — read-only 확인 / virtual-source guard / getTextStable 키 lifetime (helper_scope_map 와 동형, leak 0) / negative guard / Pass1·2 / helper isolation 무침범 / AST layout 일치. 회귀·누수·double-emission 위험 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)