### PR TITLE
chore(semantic): clean D20 stale comments + forward value-use guard

### DIFF
--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -1890,8 +1890,8 @@ pub const SemanticAnalyzer = struct {
                 .function_declaration => try self.predeclareFuncDecl(node),
                 .class_declaration => try self.predeclareClassDecl(node),
                 .ts_enum_declaration => try self.predeclareEnumDecl(node),
-                // RFC #3310 (D20): forward `export {}; import default/namespace`.
-                // local name 만 side-table 에 기록 — symbol/scope 선언 절대 안 함.
+                // RFC #3310 (D20): import 는 module top hoist — user binding 을
+                // .import_binding symbol 로 1st-pass 등록 (forward export/value use).
                 .import_declaration => try self.predeclareImportDecl(node),
                 .export_named_declaration => {
                     // export const x = ..., export function f() {}, export class C {}
@@ -2142,8 +2142,7 @@ pub const SemanticAnalyzer = struct {
     /// RFC #3310 (D20) 완전 근본 해결 — top-level import 의 user binding 을 1st-pass
     /// 에서 진짜 `.import_binding` symbol 로 등록 (var/func/class predeclare 와 동일
     /// 패턴). ECMAScript: import 는 module top hoist 라 forward `export {}` / forward
-    /// value use 모두 valid. (#3311 의 read-only side-table 은 PR-3 에서 제거됨 —
-    /// 정공법 symbol 등록이 모든 경로를 커버.)
+    /// value use 모두 valid.
     ///
     /// helper 배제 3중 방어 (이전 11 회귀 무재발):
     ///   1. virtual-source guard: `\x00zntc:runtime/...` import declaration 통째 skip
@@ -3564,11 +3563,9 @@ pub const SemanticAnalyzer = struct {
     /// export { x } (without from) — x가 선언된 바인딩인지 검증한다.
     /// module scope에서 VarDeclaredNames + LexicallyDeclaredNames에 없으면 에러.
     fn checkExportBinding(self: *SemanticAnalyzer, name: []const u8, span: Span) AllocError!void {
-        // 현재 module scope에서 해당 이름의 심볼을 찾는다. RFC #3310 (D20): import 는
-        // module top hoist 라 forward `export { X }; import X` 도 valid —
-        // predeclareImportDecl 가 1st-pass 에서 user import 를 진짜 .import_binding
-        // symbol 로 등록하므로 이 symbol scan 이 forward import 도 hit (별도 fallback
-        // 불필요; PR-3 에서 read-only side-table 제거).
+        // RFC #3310 (D20): import 는 module top hoist 라 forward `export { X };
+        // import X` 도 valid — predeclareImportDecl 가 1st-pass 에서 user import 를
+        // .import_binding symbol 로 등록하므로 이 symbol scan 이 forward import 도 hit.
         for (self.symbols.items) |sym| {
             const sym_name = self.ast.getText(sym.name);
             if (std.mem.eql(u8, sym_name, name)) return; // 존재

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -1045,12 +1045,31 @@ test "Export: forward ref to default/namespace import binding (D20 #3310)" {
 }
 
 test "Export: undefined name still errors (D20 negative guard)" {
-    // side-table fallback 이 진짜 미정의 export 까지 통과시키면 안 됨.
+    // 정공법 symbol 등록이 진짜 미정의 export 까지 통과시키면 안 됨.
     var r = try analyzeModule(
         \\export { totallyMissing };
     );
     defer r.deinit();
     try expectAnalyzeError(&r, "totallyMissing");
+}
+
+test "Import: forward value use resolves to hoisted import binding (D20)" {
+    // RFC #3310 정공법 고유 범위 — analyzer 가 import 를 1st-pass hoisted symbol
+    // 로 등록하므로 forward `export {}` 뿐 아니라 import 보다 소스상 앞선 value
+    // use 도 resolve (이전 read-only side-table 은 export specifier 만 커버했음).
+    // ECMAScript: import 는 module top hoist 라 valid.
+    try analyzeNoErrors(
+        \\console.log(foo);
+        \\import foo from './foo';
+    );
+    try analyzeNoErrors(
+        \\const x = ns.y;
+        \\import * as ns from './m';
+    );
+    try analyzeNoErrors(
+        \\export default function () { return helper(); }
+        \\import { helper } from './h';
+    );
 }
 
 test "Import: redeclared with let/const/function/class is error (D20 PR-2 spec-correct)" {


### PR DESCRIPTION
PR-3 (#3314) /simplify follow-up.

## 배경

`/simplify` 3-agent review 가 PR-3 (side-table 제거) 에서 발견:
- Agent 1 (reuse): 순수 dead-code deletion, 올바름 (잔존 참조 0)
- Agent 2 (quality): **stale/PR-단계 주석 3건** (feedback_no_reference_comments 위반)
- Agent 3 (efficiency): 회귀 0, 효율 개선만

## 수정

**주석 정리** (PR 단계 서술 금지, RFC #3310/D20 식별자는 추적용 보존):
- `predeclareTopLevelBindings` import arm: side-table 제거 후에도 *"local name 만 side-table 에 기록 — symbol 선언 절대 안 함"* — **코드와 정반대** stale 주석 → 정공법 동작으로 정정
- `predeclareImportDecl` / `checkExportBinding` doc 의 *"PR-3 에서 제거됨"* 작업 단계 서술 제거

**테스트 추가** — 정공법 고유 범위 회귀 가드:
- forward **value use** (import 보다 소스상 앞선 식별자 사용) → hoisted import binding resolve. read-only side-table 은 export specifier 만 커버했으나 정공법은 value use 도 커버 — 근본 해결 범위 명시
- default / namespace / named import × forward use 3종

## 검증

- Debug + ReleaseFast `zig build test` **0 fail**
- stale 참조/주석 grep **0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)