### PR TITLE
fix(parser): class field named get/set with type/optional/definite (D21)

### DIFF
--- a/src/parser/declaration.zig
+++ b/src/parser/declaration.zig
@@ -625,9 +625,14 @@ fn parseClassMember(self: *Parser) ParseError2!NodeIndex {
         // class body에서 get\nx()는 accessor (줄바꿈 있어도). 단, get\n*x()는 ASI.
         // TypeScript PR#60225: newline은 * 앞에서만 ASI 유발
         // `get<T>()` / `set<T>()`는 TS generic method 이름이지 accessor가 아니다.
+        // D21: `get`/`set` 이 필드 이름인 경우 — `get: T` / `get?: T` (optional) /
+        // `get!: T` (definite assignment) 도 accessor 가 아닌 일반 필드 (effect
+        // internal/ref.ts). ECMAScript MethodDefinition contextual keyword 규칙.
         const is_accessor_target = next_tok.kind != .l_paren and
             next_tok.kind != .l_angle and
             next_tok.kind != .semicolon and next_tok.kind != .eq and
+            next_tok.kind != .colon and next_tok.kind != .question and
+            next_tok.kind != .bang and
             next_tok.kind != .r_curly and next_tok.kind != .eof;
         const newline_blocks = next_tok.has_newline_before and
             (next_tok.kind == .star or next_tok.kind == .kw_async);

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -3539,6 +3539,28 @@ test "TS: strict-mode reserved word cannot be used as binding (D16)" {
     try expectParseErrorWithExt("let f = (arguments: any) => true;", ".ts", .{ .message_contains = "arguments" });
 }
 
+test "TS: class field named get/set (D21 — effect internal/ref.ts)" {
+    // effect `internal/ref.ts:29` 등 5파일 — 클래스 멤버 이름이 `get`/`set` 인
+    // 필드 (`get: T`, `readonly get: T`, `get?: T`, `get!: T`). parseClassMember
+    // 의 `is_accessor_target` 검사가 `.colon`/`.question`/`.bang` 누락 → `get`/`set`
+    // 다음이 `:` 면 무조건 accessor 로 파싱해 `Property key expected [ZNTC0608]`.
+    // ECMAScript MethodDefinition 문법상 get/set 은 contextual keyword — 다음
+    // 토큰이 PropertyName 이 아니면 일반 멤버 (Babel/tsc/swc/oxc 동일).
+    try expectNoParseErrorWithExt("class C { get: number = 1 }", ".ts");
+    try expectNoParseErrorWithExt("class C { set: number = 2 }", ".ts");
+    try expectNoParseErrorWithExt("class C { readonly get: number = 1 }", ".ts");
+    try expectNoParseErrorWithExt("class C { get?: number }", ".ts");
+    try expectNoParseErrorWithExt("class C { set?: number }", ".ts");
+    try expectNoParseErrorWithExt("class C { get!: number }", ".ts");
+    try expectNoParseErrorWithExt("class C { static get: number = 1 }", ".ts");
+    try expectNoParseErrorWithExt("class C { get; set; }", ".ts");
+    try expectNoParseErrorWithExt("class C { get = 1; set = 2; }", ".ts");
+    // 진짜 accessor / 메서드 는 그대로 (regression guard)
+    try expectNoParseErrorWithExt("class C { get foo() { return 1; } set foo(v) {} }", ".ts");
+    try expectNoParseErrorWithExt("class C { get() {} set() {} }", ".ts");
+    try expectNoParseErrorWithExt("class C { get [k]() { return 1; } }", ".ts");
+}
+
 test "TS: object literal method shorthand named get/set/async with generics (D17)" {
     // mobx `src/api/observable.ts` 의 `set<T = any>(...)` 패턴. object literal property
     // parser 의 get/set/async 분기가 `peek != .l_paren/.colon/.comma/.r_curly` 만 검사 →


### PR DESCRIPTION
## Summary

effect `internal/ref.ts:29` 등 **5파일** — 클래스 멤버 이름이 `get`/`set` 인 필드가 `Property key expected [ZNTC0608]` 로 거부.

```ts
class C { get: number = 1 }          // ZNTC0608 (fix 전)
class C { readonly get: number = 1 } // ZNTC0608
class C { get?: number }             // ZNTC0608
class C { get!: number }             // ZNTC0608
```

## 원인

`parseClassMember` 의 `is_accessor_target` 검사가 `.colon`/`.question`/`.bang` 누락 → `get`/`set` 다음이 `:`(type ann) / `?`(optional) / `!`(definite assignment) 면 무조건 accessor 로 파싱.

ECMAScript MethodDefinition 문법상 `get`/`set` 은 **contextual keyword** — 다음 토큰이 PropertyName 이 아니면 일반 멤버 (Babel/tsc/swc/oxc 동일). D17 (#3185) object-literal generic disambiguation 의 class-field 버전.

## 수정

`is_accessor_target` 에 `.colon`/`.question`/`.bang` 추가 (1-token lookahead, O(1) 무비용). 두 컨텍스트(object/class)는 종결 토큰 집합이 구조적으로 달라 inline 유지가 net 단순 (review 평가 — 통합 시 복잡도 증가).

## 검증

| | 결과 |
|---|---|
| Babel/tsc parity | **11/11 의미 일치** |
| effect/src | 8 → **3** (D21 5파일 해소; 잔존 = D22 Schema/core `× )` 2 + D23 queue panic 1, 별개) |
| zod/mobx/immer/type-fest/rxjs | 940 파일 회귀 **0** |
| zig build test | Debug + ReleaseFast **0 fail** |
| 회귀 가드 | 12종 (field type/optional/definite/static/bare/init + accessor·method·computed regression) |
| /simplify 2-agent | reuse+quality / parity+efficiency **PASS** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)