### PR TITLE
fix(parser): typed arrow with return type in ternary consequent (D22)

### DIFF
--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -1383,7 +1383,15 @@ fn parsePrimaryExpression(self: *Parser) ParseError2!NodeIndex {
             const paren_saved = self.enterAllowInContext(true);
             const saved_in_decorator = self.ctx.in_decorator;
             self.ctx.in_decorator = false;
+            // D22: parenthesized expression 안은 새 expression 컨텍스트 — 바깥
+            // ternary separator 무관 (oxc allow_return_type 복원). isTypedArrowFunction
+            // 이 false 라 여기 도달했으므로 이 `(`는 arrow params 가 아님. 안의
+            // `((b): T => b)` 같은 inner arrow 가 D22 commit gate 에 잘못 걸리지
+            // 않도록 reset.
+            const saved_paren_ternary = self.in_ternary_consequent;
+            self.in_ternary_consequent = false;
             const expr = try parseExpressionOrRest(self);
+            self.in_ternary_consequent = saved_paren_ternary;
             self.ctx.in_decorator = saved_in_decorator;
             self.restoreContext(paren_saved);
 
@@ -1617,8 +1625,13 @@ fn parseTemplateLiteral(self: *Parser, is_tagged: bool) ParseError2!NodeIndex {
 
     while (true) {
         // expression inside ${} — `in` 연산자 항상 허용 (ECMAScript: TemplateMiddleList[+In])
+        // D22: template substitution 도 새 expression 컨텍스트 — 바깥 ternary
+        // separator 무관 (oxc allow_return_type 복원).
         const tmpl_saved = self.enterAllowInContext(true);
+        const saved_tmpl_ternary = self.in_ternary_consequent;
+        self.in_ternary_consequent = false;
         const expr = try parseExpression(self);
+        self.in_ternary_consequent = saved_tmpl_ternary;
         self.restoreContext(tmpl_saved);
         try self.scratch.append(self.allocator, expr);
 
@@ -1666,6 +1679,13 @@ fn parseTemplateLiteral(self: *Parser, is_tagged: bool) ParseError2!NodeIndex {
 fn parseArrayExpression(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
     try self.advance(); // skip [
+
+    // D22: array element 는 새 expression 컨텍스트 — 바깥 ternary separator `:`
+    // 무관 (oxc allow_return_type 복원). `cond ? [(b): T => b] : 0` 의 element
+    // arrow 가 D22 commit gate 에 잘못 걸리지 않도록 reset (call-args/paren 과 동일).
+    const saved_in_ternary = self.in_ternary_consequent;
+    self.in_ternary_consequent = false;
+    defer self.in_ternary_consequent = saved_in_ternary;
 
     var elements: std.ArrayList(NodeIndex) = .empty;
     defer elements.deinit(self.allocator);
@@ -1827,6 +1847,15 @@ fn parseHex4(s: []const u8) ?u16 {
 /// 여는 괄호 `(`는 이미 소비된 상태에서 호출.
 /// 닫는 괄호 `)`까지 소비한다.
 fn parseArgumentList(self: *Parser) ParseError2!NodeList {
+    // D22: call/new argument 는 새 expression 컨텍스트 — 바깥 ternary 의 separator
+    // `:` 영향을 받지 않는다 (oxc allow_return_type_in_arrow_function 복원).
+    // `cond ? f((b): T => b) : 0` 에서 인자 arrow 의 `: T` 는 return type 이고
+    // body 다음은 `)` 이므로, in_ternary_consequent 를 reset 하지 않으면 D22
+    // commit gate 가 잘못 rollback 한다.
+    const saved_in_ternary = self.in_ternary_consequent;
+    self.in_ternary_consequent = false;
+    defer self.in_ternary_consequent = saved_in_ternary;
+
     const scratch_top = self.saveScratch();
     while (self.current() != .r_paren and self.current() != .eof) {
         const arg = try parseSpreadOrAssignment(self);

--- a/src/parser/parser.zig
+++ b/src/parser/parser.zig
@@ -1847,19 +1847,13 @@ pub const Parser = struct {
 
         try self.advance(); // skip (
 
-        // (): Type => ... — 빈 파라미터 + 리턴 타입
+        // (): Type => ... — 빈 파라미터 + 리턴 타입.
+        // D22: ternary consequent 가드는 detection 에서 제거 — shape 로만 판정
+        // (oxc Tristate). 진짜 ternary `cond ? (x): y` 와의 모호성은
+        // `parseTypedArrowParams` 가 commit 직전 ternary-separator 규칙으로 gate.
         if (self.current() == .r_paren) {
             try self.advance();
-            if (self.current() != .colon) return false;
-            // ternary consequent 안에서는 `:` 가 ternary separator일 수 있다.
-            if (!self.in_ternary_consequent) return true;
-            // Flow: `:` 뒤에 type keyword가 오면 return type annotation 확정.
-            // void, number 등은 expression start로 사용되지 않으므로 ternary `:` 와 구분 가능.
-            if (self.is_flow) {
-                const after = try self.peekNextKind();
-                if (after == .kw_void or after == .kw_typeof) return true;
-            }
-            return false;
+            return self.current() == .colon;
         }
 
         // (...rest: Type) => ... — rest parameter with type
@@ -1874,7 +1868,7 @@ pub const Parser = struct {
             // ternary consequent 안에서는 `:` 가 ternary separator일 수 있으므로 여기서 판단하지 않는다.
             if (self.current() == .r_paren) {
                 try self.advance();
-                return self.current() == .colon and !self.in_ternary_consequent;
+                return self.current() == .colon;
             }
             // (a?: Type) — optional parameter
             if (self.current() == .question) return true;
@@ -1885,7 +1879,7 @@ pub const Parser = struct {
                 try self.skipDefaultValueToCommaOrRParen();
                 if (self.current() == .r_paren) {
                     try self.advance();
-                    return self.current() == .colon and !self.in_ternary_consequent;
+                    return self.current() == .colon;
                 }
                 // comma → 아래 typed-param 검사 loop 로 fall-through
             }
@@ -1902,7 +1896,7 @@ pub const Parser = struct {
                     // arrow 판별 가능. @reduxjs/toolkit listenerMiddleware.test-d.ts.
                     if (self.current() == .r_paren) {
                         try self.advance();
-                        return self.current() == .colon and !self.in_ternary_consequent;
+                        return self.current() == .colon;
                     }
                     // rest parameter with type
                     if (self.current() == .dot3) return true;
@@ -1913,7 +1907,7 @@ pub const Parser = struct {
                         if (self.current() == .colon or self.current() == .question) return true;
                         if (self.current() == .r_paren) {
                             try self.advance();
-                            return self.current() == .colon and !self.in_ternary_consequent;
+                            return self.current() == .colon;
                         }
                         // default value 가 있는 다음 param — expression 통과 후 계속.
                         if (self.current() == .eq) {
@@ -1922,7 +1916,7 @@ pub const Parser = struct {
                             if (self.current() == .comma) continue;
                             if (self.current() == .r_paren) {
                                 try self.advance();
-                                return self.current() == .colon and !self.in_ternary_consequent;
+                                return self.current() == .colon;
                             }
                         }
                         // 이 파라미터에도 타입이 없으면 다음 파라미터 확인
@@ -1973,12 +1967,13 @@ pub const Parser = struct {
 
         // return type annotation: ): Type =>
         // Flow: shorthand 함수 타입 금지 — (): any => {} 에서 =>는 arrow body
-        {
+        const had_return_type = blk: {
             const saved_flow_flag = self.flow_in_return_type;
             self.flow_in_return_type = true;
             defer self.flow_in_return_type = saved_flow_flag;
-            _ = try self.tryParseReturnType();
-        }
+            const rt = try self.tryParseReturnType();
+            break :blk !rt.isNone();
+        };
 
         // => 확인
         if (self.current() != .arrow or self.scanner.token.has_newline_before) {
@@ -2002,6 +1997,20 @@ pub const Parser = struct {
 
         try self.advance(); // skip =>
         const body = try expression.parseArrowBody(self, is_async, params_node);
+
+        // D22 (oxc arrow.rs:380-393): ternary consequent 에서 return type 을 소비한
+        // arrow 는 진짜 ternary `cond ? (x): T : y` 와 모호하다. arrow body 직후
+        // 토큰이 ternary separator `:` 일 때만 commit — 아니면 rollback 해 호출부가
+        // paren-expr 로 재파싱 (bare second `:` 가 없으면 어차피 JS syntax error
+        // 이므로 `:` 존재가 arrow 의도를 증명). 진짜 ternary 는 `=>` 가 없어 위
+        // 검사에서 이미 걸러지므로 had_return_type 케이스만 추가 확인.
+        if (self.in_ternary_consequent and had_return_type and self.current() != .colon) {
+            self.restoreScratch(scratch_top);
+            self.rollbackErrors(errors_before);
+            self.restoreState(saved);
+            return null;
+        }
+
         const flags: u32 = if (is_async) 0x01 else 0;
         const ae = try self.ast.addExtras(&.{ @intFromEnum(params_node), @intFromEnum(body), flags });
         return try self.ast.addNode(.{

--- a/src/parser/parser_test.zig
+++ b/src/parser/parser_test.zig
@@ -3671,6 +3671,37 @@ test "Flow: typed arrow in ternary consequent" {
     try expectNoParseErrorFlow("const x = true ? (): void => { return; } : null;");
     // typeof도 type keyword로 감지
     try expectNoParseErrorFlow("const x = true ? (): typeof a => { return a; } : null;");
+    // D22: 무타입 param + return-type annotation arrow (Flow parity)
+    try expectNoParseErrorFlow("const x = c ? (b): T => b : 0;");
+}
+
+test "TS: untyped-param arrow with return type in ternary consequent (D22 — effect core.ts)" {
+    // effect `internal/core.ts:988` / `Schema.ts:10519` —
+    // `cond ? flatMap(self, (b): Effect<A,E,R> => x) : y`. isTypedArrowFunction
+    // 의 `!in_ternary_consequent` 가드가 무타입 param + return-type annotation
+    // 화살표의 `:` 를 ternary separator 로 오인 → `× )`. param 에 타입이 있으면
+    // typed-arrow 일찍 확정돼 우회됨. oxc 방식: shape 로 detect 후 commit 을
+    // ternary-separator 규칙으로 gate (param 타입 유무 무관 일관 처리).
+    try expectNoParseErrorWithExt("const x = c ? ((b): T => b) : 0;", ".ts");
+    try expectNoParseErrorWithExt("const x = c ? f((b): T => b) : 0;", ".ts");
+    try expectNoParseErrorWithExt("const x = c ? (b): T => b : 0;", ".ts");
+    try expectNoParseErrorWithExt("const x = true ? f((b): b is T => true) : 0;", ".ts");
+    try expectNoParseErrorWithExt("const x = c ? g(1, (b): T => b) : 0;", ".ts");
+    // array element / template substitution sub-expr (oxc allow_return_type 복원)
+    try expectNoParseErrorWithExt("const x = c ? [(b): T => b] : 0;", ".ts");
+    try expectNoParseErrorWithExt("const x = c ? `${(b): T => b}` : 0;", ".ts");
+    // 중첩 effect-style
+    try expectNoParseErrorWithExt(
+        "const r = isEffect(self) ? flatMap(self, (b): Effect<A1, E1, R1> => (b ? a() : c())) : zip(self);",
+        ".ts",
+    );
+    // param 에 타입 있는 경우 (이전부터 통과) — regression guard
+    try expectNoParseErrorWithExt("const x = c ? f((b: number): T => b) : 0;", ".ts");
+    // 진짜 ternary — typed-arrow 로 오인해 `: y` 삼키면 안 됨 (regression guard)
+    try expectNoParseErrorWithExt("const y = cond ? (x) : y;", ".ts");
+    try expectNoParseErrorWithExt("const y = cond ? (x) : (y);", ".ts");
+    try expectNoParseErrorWithExt("const y = cond ? x ? a : b : c;", ".ts");
+    try expectNoParseErrorWithExt("const y = cond ? <T>(v: T) => v : null;", ".ts");
 }
 
 test "Flow: single type param generic arrow in JSX mode" {


### PR DESCRIPTION
## Summary

effect `internal/core.ts:988` / `Schema.ts:10519` — `cond ? flatMap(self, (b): Effect<A,E,R> => x) : y` 등이 `× )` 로 parse fail.

```ts
const x = c ? ((b): T => b) : 0;          // × ) (fix 전)
const x = c ? f((b): T => b) : 0;         // × )
const x = c ? [(b): T => b] : 0;          // × ]
const x = c ? `${(b): T => b}` : 0;       // × template
```

## Root cause

ternary consequent 에서 무타입-param + return-type annotation 화살표의 `:` 를 ternary separator 로 오인. `isTypedArrowFunction` 의 `!in_ternary_consequent` 가드가 speculative parse 진입 자체를 차단 + `in_ternary_consequent` 가 call-args/nested-paren/array/template sub-expr 까지 과전파.

## Fix (oxc `arrow.rs:343-396` `allow_return_type_in_arrow_function` 모델)

- **Step A**: `isTypedArrowFunction` 5 사이트 + empty-param 의 ternary 가드 제거 → detection 은 token shape 만 (oxc Tristate). Flow 전용 `kw_void/kw_typeof` lookahead 도 제거 (Step A+B 가 일반화 흡수)
- **Step B**: `parseTypedArrowParams` 가 `had_return_type` 추적, body parse 후 `in_ternary_consequent and had_return_type and current != .colon` 면 rollback (진짜 ternary 와의 모호성은 trailing `:` 존재로 arrow 의도 증명 — oxc arrow.rs:380-393). 기존 restoreState 재사용 (scanner-only, orphan 은 arena)
- **sub-expr 복원**: parseArgumentList / paren-expr primary / parseArrayExpression / template substitution 진입 시 `in_ternary_consequent` reset (oxc 가 args/paren/array/template 에 `allow_return_type=true`)

## 검증

| | 결과 |
|---|---|
| effect/src | 3 → **1** (Schema.ts + core.ts 해소; 잔존 1 = D23 queue panic 별개) |
| zod/mobx/rxjs/grpc-js | 회귀 **0** |
| zig build test | Debug + ReleaseFast **0 fail** |
| 회귀 가드 | D22 핵심(paren/call/array/template/predicate/nested) + 진짜 ternary + typed-param + Flow parity |
| D11/D14/D17/D21 | in-suite 무회귀 |
| /simplify 3-agent | oxc parity 1:1 / rollback 메모리 안전 / 회귀 0 / Flow subsume **PASS** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)