### PR TITLE
fix(transformer): use-after-free in derived-class param property lowering (D23)

### DIFF
--- a/src/transformer/transformer/declarations.zig
+++ b/src/transformer/transformer/declarations.zig
@@ -423,13 +423,20 @@ pub fn buildParameterPropertyStatements(self: *Transformer, prop_names: []const 
 /// derived class constructor 의 super() 직후에 this.x = x; 문들을 삽입한다.
 /// (kept-class 경로 — visitMethodDefinition. ES5 lowering 은 postProcessDerivedConstructorBody 사용).
 pub fn insertParameterPropertyAssignmentsAfterSuper(self: *Transformer, body_idx: NodeIndex, prop_names: []const NodeIndex) Error!NodeIndex {
+    // `buildParameterPropertyStatements` 가 생성한 statement 인덱스를
+    // `extra_data` (stable offset) 에 보관한다. 여기서 곧바로 `self.scratch` 로
+    // 복사해 그 슬라이스를 `insertStatementsAfterSuper` 에 넘기면, 그 함수가
+    // 다시 `self.scratch.append` 로 scratch 를 키우다 realloc 이 일어나는 순간
+    // 넘긴 슬라이스(= 옛 backing buffer 포인터)가 무효화돼 freed 메모리
+    // (0xAAAAAAAA) 를 읽는다 (#D23). 따라서 scratch 와 aliasing 되지 않는
+    // 별도 힙 버퍼로 복사해 전달한다. extra_data 자체는 stable 하므로
+    // 그 슬라이스를 직접 dup 해서 쓰는 것으로 충분하다.
     const pp_list = try self.buildParameterPropertyStatements(prop_names);
-    const scratch_top = self.scratch.items.len;
-    defer self.scratch.shrinkRetainingCapacity(scratch_top);
-    for (self.ast.extra_data.items[pp_list.start .. pp_list.start + pp_list.len]) |raw_idx| {
-        try self.scratch.append(self.allocator, @enumFromInt(raw_idx));
-    }
-    return self.insertStatementsAfterSuper(body_idx, self.scratch.items[scratch_top..]);
+    const pp_raw = self.ast.extra_data.items[pp_list.start .. pp_list.start + pp_list.len];
+    const stmts = try self.allocator.alloc(NodeIndex, pp_raw.len);
+    defer self.allocator.free(stmts);
+    for (pp_raw, 0..) |raw_idx, i| stmts[i] = @enumFromInt(raw_idx);
+    return self.insertStatementsAfterSuper(body_idx, stmts);
 }
 
 /// block_statement 바디 앞에 this.x = x; 문들을 삽입한다 (base class ctor 용).


### PR DESCRIPTION
## Summary

effect `internal/queue.ts` (`class QueueImpl<in out A> extends Effectable.Class<A>` + TS parameter property constructor) → **hard panic** `index out of bounds: 0xAAAAAAAA (Zig freed memory), exit 134`. 충분히 큰 derived class + parameter property 면 어디서나 재현되는 **use-after-free 안전성 버그**.

## Root cause

`insertParameterPropertyAssignmentsAfterSuper` 가 `buildParameterPropertyStatements` 결과를 `self.scratch` (ArrayList) 로 복사 후 `self.scratch.items[scratch_top..]` **슬라이스**를 `insertStatementsAfterSuper` 에 전달. callee 가 super() 전후 재구성 위해 **같은 `self.scratch`** 에 다시 `append` → realloc 시 옛 backing buffer free → 전달 슬라이스(옛 포인터)가 `0xAAAAAAAA` 읽음 → 새 constructor block stmt list 에 기록 → codegen 역참조 panic.

classic **aliased-slice-into-growing-ArrayList**. 작은 파일은 scratch 여유 용량이라 realloc 미발생 → whole-file-shape sensitive (minimal repro 격리 불가, creduce 로 trigger 조건만 확인).

## Fix

`pp_list` extra_data 슬라이스(stable)를 scratch 가 아닌 **독립 힙 버퍼**로 dup 전달 — scratch/extra_data aliasing 완전 제거. `es_helpers.zig:968` `lowerObjectSpreadProps` 의 **동일 버그 클래스 canonical 패턴** (`dupe`+`defer free`) 과 일치 (arena free no-op, #1287 무관 — 단일 alloc/free 쌍).

13줄 (`src/transformer/transformer/declarations.zig`).

## 검증

| | 결과 |
|---|---|
| effect/src | **0 / 362** (D21·D22·D23 누적 8→0 완전 클린) |
| queue.ts | exit 0, derived ctor `super(); this.a=a; this.b=b;` 정확 |
| derived/non-derived/super 없는 derived/혼재/다수/nested | 정상 |
| zig build test | Debug + ReleaseFast **0 fail** |
| /simplify 3-agent | 근본 해결 / arena 규칙 / 회귀 0 / canonical 패턴 일치 **PASS** |

D23 = D21/D22 (parser fix) 무관 독립 transformer 메모리 버그.

🤖 Generated with [Claude Code](https://claude.com/claude-code)