### PR TITLE
feat(bundler): per-chunk CSS splitting for code splitting

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1289,6 +1289,16 @@ pub const Bundler = struct {
         var output_scope = profile.begin(.emit_output);
         var output: []const u8 = "";
         var outputs: ?[]OutputFile = null;
+        // code splitting 경로에서 청크별로 분리 emit 한 CSS (null = 비-splitting,
+        // 이 경우 아래에서 entry 당 단일 CSS 로 fallback). 소비 후 null 로 되돌린다.
+        var css_chunk_files: ?[]OutputFile = null;
+        errdefer if (css_chunk_files) |f| {
+            for (f) |o| {
+                self.allocator.free(o.path);
+                self.allocator.free(o.contents);
+            }
+            self.allocator.free(f);
+        };
 
         // dev mode용 per-module codes + sourcemap
         var module_dev_codes_from_emit: ?[]const types.ModuleDevCode = null;
@@ -1366,6 +1376,13 @@ pub const Bundler = struct {
                 }
                 self.allocator.free(outs);
             };
+
+            // code splitting (preserve-modules 제외): JS 청크별로 CSS 분리.
+            // chunk_graph 가 살아있는 이 시점에서만 수집 가능. CSS 실패는
+            // 번들 실패로 번지지 않게 흡수(기존 css emit 의 관용과 동일).
+            if (!self.options.preserve_modules) {
+                css_chunk_files = @import("css_emitter.zig").emitCssChunks(self.allocator, &graph, &chunk_graph) catch null;
+            }
 
             // output은 빈 문자열 — code splitting 시 outputs를 사용
             output = try self.allocator.dupe(u8, "");
@@ -1497,11 +1514,23 @@ pub const Bundler = struct {
         defer css_output_files.deinit(self.allocator);
         {
             const css_emit = @import("css_emitter.zig");
-            for (self.options.entry_points) |ep| {
-                // 엔트리 경로 → 모듈 인덱스 찾기
-                const resolved = graph.path_to_module.get(ep) orelse continue;
-                if (css_emit.emitCssBundle(self.allocator, &graph, resolved, self.options.css_names)) |css_out| {
-                    css_output_files.append(self.allocator, css_out) catch {};
+            if (css_chunk_files) |files| {
+                // code splitting: 청크별 CSS 를 그대로 사용 (소유권 이전).
+                for (files) |f| {
+                    css_output_files.append(self.allocator, f) catch {
+                        self.allocator.free(f.path);
+                        self.allocator.free(f.contents);
+                    };
+                }
+                self.allocator.free(files);
+                css_chunk_files = null;
+            } else {
+                // 비-splitting / preserve-modules: entry 당 단일 CSS (기존 동작).
+                for (self.options.entry_points) |ep| {
+                    const resolved = graph.path_to_module.get(ep) orelse continue;
+                    if (css_emit.emitCssBundle(self.allocator, &graph, resolved, self.options.css_names)) |css_out| {
+                        css_output_files.append(self.allocator, css_out) catch {};
+                    }
                 }
             }
         }

--- a/src/bundler/css_emitter.zig
+++ b/src/bundler/css_emitter.zig
@@ -6,8 +6,13 @@
 
 const std = @import("std");
 const Module = @import("module.zig").Module;
-const ModuleIndex = @import("types.zig").ModuleIndex;
+const types = @import("types.zig");
+const ModuleIndex = types.ModuleIndex;
+const ChunkIndex = types.ChunkIndex;
 const ModuleGraph = @import("graph.zig").ModuleGraph;
+const chunk_mod = @import("chunk.zig");
+const ChunkGraph = chunk_mod.ChunkGraph;
+const Chunk = chunk_mod.Chunk;
 const emitter = @import("emitter.zig");
 const OutputFile = emitter.OutputFile;
 
@@ -41,19 +46,7 @@ pub fn emitCssBundle(
     var output: std.ArrayListUnmanaged(u8) = .empty;
     defer output.deinit(allocator);
 
-    for (css_modules.items) |mod| {
-        const strip_end: u32 = if (mod.css_data) |cd| cd.strip_end else 0;
-        const stripped = if (strip_end > 0 and strip_end < mod.source.len) mod.source[strip_end..] else mod.source;
-        // 공백만 있는 경우 건너뜀
-        const trimmed = std.mem.trim(u8, stripped, " \t\n\r");
-        if (trimmed.len == 0) continue;
-
-        output.appendSlice(allocator, stripped) catch continue;
-        // 모듈 간 줄바꿈 구분
-        if (stripped.len > 0 and stripped[stripped.len - 1] != '\n') {
-            output.append(allocator, '\n') catch {};
-        }
-    }
+    appendCssModules(allocator, &output, css_modules.items) catch {};
 
     if (output.items.len == 0) return null;
 
@@ -66,6 +59,165 @@ pub fn emitCssBundle(
         .path = css_path,
         .contents = output.toOwnedSlice(allocator) catch return null,
     };
+}
+
+/// 정렬된 CSS 모듈들을 @import strip 후 줄바꿈 구분하여 buf 에 이어붙인다.
+/// emitCssBundle(단일) / emitCssChunks(청크별) 가 공유.
+fn appendCssModules(
+    allocator: std.mem.Allocator,
+    buf: *std.ArrayListUnmanaged(u8),
+    css_modules: []const *const Module,
+) !void {
+    for (css_modules) |mod| {
+        const strip_end: u32 = if (mod.css_data) |cd| cd.strip_end else 0;
+        const stripped = if (strip_end > 0 and strip_end < mod.source.len) mod.source[strip_end..] else mod.source;
+        const trimmed = std.mem.trim(u8, stripped, " \t\n\r");
+        if (trimmed.len == 0) continue;
+        try buf.appendSlice(allocator, stripped);
+        if (stripped.len > 0 and stripped[stripped.len - 1] != '\n') {
+            try buf.append(allocator, '\n');
+        }
+    }
+}
+
+/// code splitting 시 JS 청크별로 CSS 를 분리하여 OutputFile 목록을 생성한다.
+///
+/// 각 CSS 모듈은 그것을 import 하는 JS 모듈이 속한 청크 중
+/// `(chunk.exec_order, importer.exec_index)` 가 가장 앞서는 단 하나의 청크에
+/// 귀속된다(전역 dedup — 공유 CSS 가 여러 청크에 복제되지 않음).
+/// CSS→CSS(@import) 의존은 같은 귀속 청크로 함께 묶인다.
+/// 반환 슬라이스와 각 OutputFile 의 path/contents 는 모두 `allocator` 소유.
+/// 분리할 CSS 가 없으면 길이 0 슬라이스를 반환한다.
+pub fn emitCssChunks(
+    allocator: std.mem.Allocator,
+    graph: *const ModuleGraph,
+    chunk_graph: *const ChunkGraph,
+) ![]OutputFile {
+    const n_chunks = chunk_graph.chunkCount();
+    if (n_chunks == 0) return allocator.alloc(OutputFile, 0);
+
+    // 1패스: CSS 모듈 → 귀속 청크(최소 rank 우승). owner_rank/visited 는 DFS 중에만 필요.
+    var owner = std.AutoHashMap(ModuleIndex, ChunkIndex).init(allocator);
+    defer owner.deinit();
+    var owner_rank = std.AutoHashMap(ModuleIndex, u64).init(allocator);
+    defer owner_rank.deinit();
+    var visited = std.AutoHashMap(ModuleIndex, void).init(allocator);
+    defer visited.deinit();
+
+    var it = graph.modulesIterator();
+    while (it.next()) |m| {
+        if (m.module_type == .css) continue;
+        const ci = chunk_graph.getModuleChunk(m.index);
+        if (ci.isNone()) continue;
+        const ch = chunk_graph.getChunk(ci);
+        const rank: u64 = (@as(u64, ch.exec_order) << 32) | @as(u64, m.exec_index);
+        visited.clearRetainingCapacity();
+        for (m.dependencies.items) |dep| {
+            walkCssOwner(graph, dep, ci, rank, &owner, &owner_rank, &visited);
+        }
+    }
+
+    if (owner.count() == 0) return allocator.alloc(OutputFile, 0);
+
+    // owner 를 청크별 역색인으로 1회 변환 (청크마다 owner 전체를 재스캔하지 않도록).
+    var chunk_mods = std.AutoHashMap(u32, std.ArrayListUnmanaged(*const Module)).init(allocator);
+    defer {
+        var vit = chunk_mods.valueIterator();
+        while (vit.next()) |list| list.deinit(allocator);
+        chunk_mods.deinit();
+    }
+    var oit = owner.iterator();
+    while (oit.next()) |e| {
+        const mm = graph.getModule(e.key_ptr.*) orelse continue;
+        if (mm.module_type != .css or mm.css_data == null) continue;
+        const gop = try chunk_mods.getOrPut(@intFromEnum(e.value_ptr.*));
+        if (!gop.found_existing) gop.value_ptr.* = .empty;
+        try gop.value_ptr.append(allocator, mm);
+    }
+
+    var out_list: std.ArrayListUnmanaged(OutputFile) = .empty;
+    errdefer {
+        for (out_list.items) |o| {
+            allocator.free(o.path);
+            allocator.free(o.contents);
+        }
+        out_list.deinit(allocator);
+    }
+
+    // 청크 인덱스 순회 → 출력 순서가 결정적(HashMap 순회 순서와 무관).
+    var chunk_idx: usize = 0;
+    while (chunk_idx < n_chunks) : (chunk_idx += 1) {
+        const list = chunk_mods.getPtr(@intCast(chunk_idx)) orelse continue;
+        if (list.items.len == 0) continue;
+
+        std.mem.sort(*const Module, list.items, {}, struct {
+            fn lessThan(_: void, a: *const Module, b: *const Module) bool {
+                return a.exec_index < b.exec_index;
+            }
+        }.lessThan);
+
+        var buf: std.ArrayListUnmanaged(u8) = .empty;
+        defer buf.deinit(allocator);
+        try appendCssModules(allocator, &buf, list.items);
+        if (buf.items.len == 0) continue;
+
+        const cidx: ChunkIndex = @enumFromInt(@as(u32, @intCast(chunk_idx)));
+        const css_path = try cssPathForChunk(allocator, chunk_graph.getChunk(cidx));
+        errdefer allocator.free(css_path);
+        const contents = try buf.toOwnedSlice(allocator);
+        try out_list.append(allocator, .{ .path = css_path, .contents = contents });
+    }
+
+    return out_list.toOwnedSlice(allocator);
+}
+
+/// CSS 서브그래프를 DFS 하며 각 CSS 모듈의 귀속 청크를 최소 rank 로 갱신한다.
+/// JS 모듈은 따라가지 않는다(각 JS 모듈은 호출부에서 개별 처리).
+/// `visited` 는 JS 모듈(루트)마다 clear 되며 `rank` 는 한 루트 안에서 불변 →
+/// 같은 루트 내 재방문은 정보가 없어 skip 해도 안전하고, 다른 루트(다른 rank)
+/// 에서는 visited 가 비워져 재평가되므로 최소 rank 가 누락되지 않는다.
+fn walkCssOwner(
+    graph: *const ModuleGraph,
+    idx: ModuleIndex,
+    ci: ChunkIndex,
+    rank: u64,
+    owner: *std.AutoHashMap(ModuleIndex, ChunkIndex),
+    owner_rank: *std.AutoHashMap(ModuleIndex, u64),
+    visited: *std.AutoHashMap(ModuleIndex, void),
+) void {
+    if (idx.isNone()) return;
+    if (visited.contains(idx)) return;
+    visited.put(idx, {}) catch return;
+    const mod = graph.getModule(idx) orelse return;
+    if (mod.module_type != .css) return;
+
+    const better = if (owner_rank.get(idx)) |r| rank < r else true;
+    if (better) {
+        owner.put(idx, ci) catch return;
+        owner_rank.put(idx, rank) catch return;
+    }
+    for (mod.dependencies.items) |dep| {
+        walkCssOwner(graph, dep, ci, rank, owner, owner_rank, visited);
+    }
+}
+
+/// JS 청크에 대응하는 CSS 출력 경로를 결정한다.
+/// 청크의 최종 JS 파일명(basename)에서 확장자를 `.css` 로 치환 → JS 청크와 1:1 페어링.
+fn cssPathForChunk(allocator: std.mem.Allocator, chunk: *const Chunk) ![]const u8 {
+    const base = chunk.filename orelse chunk.name orelse {
+        return std.fmt.allocPrint(allocator, "chunk{d}.css", .{@intFromEnum(chunk.index)});
+    };
+    return jsStemToCssName(allocator, std.fs.path.basename(base));
+}
+
+/// "route-a-abc123.js" → "route-a-abc123.css" (마지막 '.' 이후 확장자만 치환).
+/// 확장자가 없으면 ".css" 를 덧붙인다.
+fn jsStemToCssName(allocator: std.mem.Allocator, basename: []const u8) ![]const u8 {
+    const stem = if (std.mem.lastIndexOfScalar(u8, basename, '.')) |dot|
+        basename[0..dot]
+    else
+        basename;
+    return std.fmt.allocPrint(allocator, "{s}.css", .{stem});
 }
 
 /// DFS로 모듈 그래프를 탐색하여 CSS 모듈을 수집한다.
@@ -127,4 +279,60 @@ test "applyCssNamingPattern: custom pattern" {
     const result = try applyCssNamingPattern(std.testing.allocator, "styles/[name]", "/app/src/main.tsx");
     defer std.testing.allocator.free(result);
     try std.testing.expectEqualStrings("styles/main.css", result);
+}
+
+test "jsStemToCssName: hashed js chunk → css" {
+    const r = try jsStemToCssName(std.testing.allocator, "route-a-abc123.js");
+    defer std.testing.allocator.free(r);
+    try std.testing.expectEqualStrings("route-a-abc123.css", r);
+}
+
+test "jsStemToCssName: mjs/cjs extension swapped" {
+    const a = try jsStemToCssName(std.testing.allocator, "vendor.mjs");
+    defer std.testing.allocator.free(a);
+    try std.testing.expectEqualStrings("vendor.css", a);
+    const b = try jsStemToCssName(std.testing.allocator, "common.cjs");
+    defer std.testing.allocator.free(b);
+    try std.testing.expectEqualStrings("common.css", b);
+}
+
+test "jsStemToCssName: no extension appends .css" {
+    const r = try jsStemToCssName(std.testing.allocator, "chunkname");
+    defer std.testing.allocator.free(r);
+    try std.testing.expectEqualStrings("chunkname.css", r);
+}
+
+test "jsStemToCssName: only last dot is treated as extension" {
+    const r = try jsStemToCssName(std.testing.allocator, "a.b.c-hash.js");
+    defer std.testing.allocator.free(r);
+    try std.testing.expectEqualStrings("a.b.c-hash.css", r);
+}
+
+test "cssPathForChunk: uses filename basename, strips dir" {
+    const bits = try chunk_mod.BitSet.init(std.testing.allocator, 1);
+    var ch = Chunk.init(@enumFromInt(0), .common, bits);
+    defer ch.deinit(std.testing.allocator);
+    ch.filename = "assets/route-a-9f8e.js";
+    const r = try cssPathForChunk(std.testing.allocator, &ch);
+    defer std.testing.allocator.free(r);
+    try std.testing.expectEqualStrings("route-a-9f8e.css", r);
+}
+
+test "cssPathForChunk: falls back to name" {
+    const bits1 = try chunk_mod.BitSet.init(std.testing.allocator, 1);
+    var ch1 = Chunk.init(@enumFromInt(0), .common, bits1);
+    defer ch1.deinit(std.testing.allocator);
+    ch1.name = "vendor";
+    const r1 = try cssPathForChunk(std.testing.allocator, &ch1);
+    defer std.testing.allocator.free(r1);
+    try std.testing.expectEqualStrings("vendor.css", r1);
+}
+
+test "cssPathForChunk: falls back to chunk index" {
+    const bits2 = try chunk_mod.BitSet.init(std.testing.allocator, 1);
+    var ch2 = Chunk.init(@enumFromInt(7), .common, bits2);
+    defer ch2.deinit(std.testing.allocator);
+    const r2 = try cssPathForChunk(std.testing.allocator, &ch2);
+    defer std.testing.allocator.free(r2);
+    try std.testing.expectEqualStrings("chunk7.css", r2);
 }

--- a/tests/integration/tests/css-code-splitting.test.ts
+++ b/tests/integration/tests/css-code-splitting.test.ts
@@ -1,0 +1,161 @@
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import { join } from 'node:path';
+import { createFixture } from './helpers';
+import { init, close, build } from '../../../packages/core/index';
+
+// P0-1: code splitting 시 JS 청크별로 CSS 를 분리 emit 하는지 검증.
+// 기존 동작(단일 파일 번들 = entry 당 하나의 CSS)은 회귀로 함께 검증한다.
+// 관련: #3321 (일반 청크 백로그 P0)
+
+const cssFiles = (outs: { path: string; text: string }[]) =>
+  outs.filter((o) => o.path.endsWith('.css'));
+
+describe('CSS code splitting (per-chunk CSS)', () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  beforeAll(() => init());
+  afterAll(() => close());
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  test('동적 import 청크마다 자기 CSS 만 분리된다', async () => {
+    const fixture = await createFixture({
+      'entry.ts': `
+        import './common.css';
+        export async function load(which: string) {
+          if (which === 'a') return (await import('./route-a')).default;
+          return (await import('./route-b')).default;
+        }
+      `,
+      'route-a.ts': `import './a.css';\nexport default "ROUTE_A";`,
+      'route-b.ts': `import './b.css';\nexport default "ROUTE_B";`,
+      'common.css': `.common { color: black; }`,
+      'a.css': `.route-a { color: red; }`,
+      'b.css': `.route-b { color: blue; }`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'entry.ts')],
+      splitting: true,
+    });
+
+    const css = cssFiles(result.outputFiles!);
+    // 최소 3개 청크(entry/route-a/route-b)로 CSS 가 분리되어야 한다.
+    expect(css.length).toBeGreaterThanOrEqual(3);
+
+    const aCss = css.find((c) => c.text.includes('color: red'));
+    const bCss = css.find((c) => c.text.includes('color: blue'));
+    const commonCss = css.find((c) => c.text.includes('color: black'));
+    expect(aCss).toBeDefined();
+    expect(bCss).toBeDefined();
+    expect(commonCss).toBeDefined();
+
+    // 각 청크 CSS 는 자기 규칙만 포함 (다른 라우트 CSS 가 섞이면 안 됨)
+    expect(aCss!.text).not.toContain('color: blue');
+    expect(aCss!.text).not.toContain('color: black');
+    expect(bCss!.text).not.toContain('color: red');
+    expect(bCss!.text).not.toContain('color: black');
+
+    // 서로 다른 파일이어야 함
+    expect(aCss!.path).not.toBe(bCss!.path);
+  });
+
+  test('여러 라우트가 공유하는 CSS 는 중복 없이 한 청크에만 들어간다', async () => {
+    const fixture = await createFixture({
+      'entry.ts': `
+        export async function load(which: string) {
+          if (which === 'a') return (await import('./route-a')).default;
+          return (await import('./route-b')).default;
+        }
+      `,
+      'route-a.ts': `import './shared.css';\nimport './a.css';\nexport default "A";`,
+      'route-b.ts': `import './shared.css';\nimport './b.css';\nexport default "B";`,
+      'shared.css': `.shared { color: green; }`,
+      'a.css': `.a { color: red; }`,
+      'b.css': `.b { color: blue; }`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'entry.ts')],
+      splitting: true,
+    });
+
+    const css = cssFiles(result.outputFiles!);
+    const sharedHits = css.filter((c) => c.text.includes('color: green'));
+    // shared.css 규칙은 정확히 한 청크 CSS 에만 존재해야 한다 (중복 금지)
+    expect(sharedHits.length).toBe(1);
+  });
+
+  test('CSS 없는 청크는 CSS 파일을 만들지 않는다', async () => {
+    const fixture = await createFixture({
+      'entry.ts': `
+        export async function load() {
+          return (await import('./route-nocss')).default;
+        }
+      `,
+      'route-nocss.ts': `export default 42;`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'entry.ts')],
+      splitting: true,
+    });
+
+    expect(cssFiles(result.outputFiles!).length).toBe(0);
+  });
+
+  test('회귀: 비-splitting 단일 번들은 entry 당 단일 CSS 그대로', async () => {
+    const fixture = await createFixture({
+      'index.ts': `import './a.css';\nimport './b.css';\nconsole.log("x");`,
+      'a.css': `.a { color: red; }`,
+      'b.css': `.b { color: blue; }`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      splitting: false,
+    });
+
+    const css = cssFiles(result.outputFiles!);
+    expect(css.length).toBe(1);
+    expect(css[0].text).toContain('color: red');
+    expect(css[0].text).toContain('color: blue');
+  });
+
+  test('manualChunks 로 분리된 청크의 CSS 도 따라 분리된다', async () => {
+    const fixture = await createFixture({
+      'entry.ts': `
+        import { v } from './vendor';
+        import { a } from './app';
+        console.log(v, a);
+      `,
+      'vendor.ts': `import './vendor.css';\nexport const v = 1;`,
+      'app.ts': `import './app.css';\nexport const a = 2;`,
+      'vendor.css': `.vendor { color: red; }`,
+      'app.css': `.app { color: blue; }`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'entry.ts')],
+      splitting: true,
+      manualChunks: (id: string) => (id.includes('vendor') ? 'vendor' : null),
+    });
+
+    const css = cssFiles(result.outputFiles!);
+    const vendorCss = css.find((c) => c.text.includes('.vendor'));
+    const appCss = css.find((c) => c.text.includes('.app'));
+    expect(vendorCss).toBeDefined();
+    expect(appCss).toBeDefined();
+    expect(vendorCss!.path).not.toBe(appCss!.path);
+    expect(vendorCss!.text).not.toContain('.app');
+  });
+});


### PR DESCRIPTION
## 요약

code splitting 시 **entry 당 단일 CSS** 대신 **JS 청크별로 CSS 를 분리** emit 한다. 일반 청크 백로그(#3321)의 **P0-1** (CSS 청크 분리의 첫 단계 — 핵심 수집/분리). `@import` 재작성·동적 import 청크의 런타임 `<link>` 주입은 후속 PR.

## 동작

- 각 CSS 모듈은 그것을 import 하는 JS 모듈이 속한 청크 중 `(chunk.exec_order, importer.exec_index)` 가 가장 앞서는 **단 하나의 청크**에 귀속 (전역 dedup — 공유 CSS 가 여러 청크에 복제되지 않음). CSS→CSS(@import) 의존은 같은 귀속 청크로 묶임.
- CSS 파일명은 JS 청크 파일명 basename 의 확장자를 `.css` 로 치환 → JS 청크와 1:1 페어링.
- **비-splitting / preserve-modules 경로는 기존 동작(entry 당 단일 CSS) 그대로** — 회귀 테스트로 보존 검증.

## 구현 메모 (Zig)

- `emitCssChunks` 는 `owner`(CSS→청크) 를 **청크별 역색인으로 1패스 변환**해 `O(chunks×css)` 재스캔을 제거(watch 재빌드 hot path).
- strip+concat 로직은 `appendCssModules` 헬퍼로 `emitCssBundle` 과 공유(중복 제거).
- 청크 인덱스 순회로 출력 순서 결정적(HashMap 순회 순서 무관).
- 소유권: `emitCssChunks` 반환 슬라이스/항목은 allocator 소유, bundler 가 소비 후 `css_chunk_files=null` 로 errdefer 이중해제 방지.

## 테스트

- 신규 통합 `tests/integration/tests/css-code-splitting.test.ts` 5 케이스: 동적 import 청크별 분리·공유 CSS dedup·CSS 없는 청크·**비-splitting 회귀**·manualChunks 분리.
- `css_emitter.zig` 단위 테스트 추가: `jsStemToCssName`(확장자/무확장자/다중 점), `cssPathForChunk`(filename/name/index fallback).
- 검증: 전체 `zig build test` 통과 · 통합 73/73 · smoke 무회귀(집계 동일) · `/simplify`(재사용/품질/효율 3-에이전트) 반영.

Refs #3321

🤖 Generated with [Claude Code](https://claude.com/claude-code)
