### PR TITLE
test(e2e): runtime CSS <link> injection for dynamic chunks

### DIFF
--- a/tests/e2e/tests/css-code-splitting-e2e.test.ts
+++ b/tests/e2e/tests/css-code-splitting-e2e.test.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { serve, closeServer } from './serve';
+
+/**
+ * CSS 코드스플리팅 런타임 E2E — 동적 import 된 청크가 자기 CSS 를
+ * 런타임 `<link>` 로 주입하고, 그 스타일이 실제 브라우저에서 적용되는지
+ * computed style 로 검증한다 (#3321 P0-3).
+ *
+ * 통합 테스트(bun test)는 출력 문자열까지만 본다 — 본 테스트는 실제
+ * 크롬에서 dynamic import → link 주입 → stylesheet 적용을 끝까지 확인.
+ */
+const ZNTC_BIN = resolve(__dirname, '../../../zig-out/bin/zntc');
+
+const FIXTURE: Record<string, string> = {
+  'index.ts': `
+const box = document.createElement('div');
+box.setAttribute('data-testid', 'box');
+box.textContent = 'hello';
+document.body.appendChild(box);
+import('./route').then((m) => {
+  m.mark();
+  (window as any).__routeLoaded = true;
+});
+`,
+  'route.ts': `
+import './route.css';
+export function mark() {
+  document.querySelector('[data-testid="box"]')!.classList.add('themed');
+}
+`,
+  // 의도적으로 흔치 않은 색 → 기본값과 확실히 구분
+  'route.css': `.themed { color: rgb(1, 2, 3); }`,
+};
+
+test('동적 청크의 CSS 가 런타임 <link> 주입으로 실제 적용된다', async ({ page }) => {
+  const dir = await mkdtemp(join(tmpdir(), 'zntc-css-split-e2e-'));
+  try {
+    for (const [name, content] of Object.entries(FIXTURE)) {
+      await writeFile(join(dir, name), content);
+    }
+    const dist = join(dir, 'dist');
+    await mkdir(dist, { recursive: true });
+
+    const build = spawnSync(
+      ZNTC_BIN,
+      [
+        '--bundle',
+        join(dir, 'index.ts'),
+        '--splitting',
+        '--outdir',
+        dist,
+        '--entry-names=[name]',
+        '--format=esm',
+        '--platform=browser',
+      ],
+      { stdio: 'pipe', timeout: 15000 },
+    );
+    expect(build.status, `ZNTC build failed: ${build.stderr?.toString().slice(0, 400)}`).toBe(0);
+
+    await writeFile(
+      join(dist, 'index.html'),
+      `<!DOCTYPE html><html><head><meta charset="utf-8"></head><body><script type="module" src="./index.js"></script></body></html>`,
+    );
+
+    const { server, port } = await serve(dist);
+    try {
+      const errors: string[] = [];
+      page.on('pageerror', (e) => errors.push(e.message));
+
+      await page.goto(`http://localhost:${port}/`);
+      await page.waitForFunction(() => (window as any).__routeLoaded === true, {
+        timeout: 5000,
+      });
+
+      // 동적 청크가 주입한 stylesheet <link> 가 head 에 존재
+      const hrefs = await page.evaluate(() =>
+        [...document.querySelectorAll('link[rel="stylesheet"]')].map((l) =>
+          (l as HTMLLinkElement).getAttribute('href'),
+        ),
+      );
+      expect(hrefs.some((h) => !!h && h.endsWith('.css'))).toBe(true);
+
+      // 그 stylesheet 가 실제로 로드·적용되어 computed style 이 바뀜
+      const color = await page.evaluate(() => {
+        const el = document.querySelector('[data-testid="box"]')!;
+        return getComputedStyle(el).color;
+      });
+      expect(color).toBe('rgb(1, 2, 3)');
+
+      expect(errors, `browser errors: ${errors.join(', ')}`).toHaveLength(0);
+    } finally {
+      await closeServer(server);
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 요약

P0-3 3 sub-PR 중 **③: 예제 청킹 앱 + 실제 브라우저 E2E**. P0-3 (CSS 코드스플리팅 런타임 link 주입) 의 끝단 검증으로, **CSS 변경 없음 — 신규 e2e 테스트 파일만 추가**.

## 검증 내용

`tests/e2e/tests/css-code-splitting-e2e.test.ts`:
- 동적 import + CSS import 하는 예제 앱을 `zntc --bundle --splitting --format=esm` 으로 빌드
- 실제 Chromium(Playwright)에서 로드 → 동적 import 완료 대기
- 단언: ① `<link rel="stylesheet">` 가 head 에 주입됨 ② `getComputedStyle().color === 'rgb(1, 2, 3)'` → 주입된 stylesheet 이 **실제 로드·적용**됨(이중 검증, false-positive 차단) ③ 브라우저 에러 0

기존 e2e 패턴 재사용: `serve.ts`/`closeServer`, `ZNTC_BIN` resolve, browser-smoke 의 spawnSync/Playwright 구조.

## 검증

- e2e 통과(실제 Chromium). `/simplify` 3-에이전트: 품질 우수, 반영(closeServer 헬퍼 사용·build timeout 15s). pre-push oxfmt 통과.

P0-3 완료 → CSS 코드스플리팅(분리 emit·content-hash·런타임 적용) 기능 완결.

Refs #3321

🤖 Generated with [Claude Code](https://claude.com/claude-code)
