### PR TITLE
chore(mangler): collision invariant assert for RFC #3288 (PR a, safety net)

### DIFF
--- a/src/codegen/unified_mangler.zig
+++ b/src/codegen/unified_mangler.zig
@@ -16,6 +16,7 @@
 //!   4. 구 API / Symbol.canonical_name 제거
 
 const std = @import("std");
+const builtin = @import("builtin");
 const mangler = @import("mangler.zig");
 const debug_log = @import("../debug_log.zig");
 const Scope = @import("../semantic/scope.zig").Scope;
@@ -286,6 +287,22 @@ pub fn mangleAll(
         var it = take.iterator();
         const mod_idx: u32 = @intCast(i);
         while (it.next()) |entry| {
+            // RFC #3288 (a) collision invariant: Phase B 가 발급한 nested 이름은
+            // per_mod_reserved[i] (= Phase A this-module + cross-module import
+            // source mangled 이름 = 그 모듈에서 회피해야 할 외부 top-level 집합)
+            // 와 절대 겹치면 안 된다. nextNonReservedBase54Name 의 회피 로직이
+            // 이를 보장하므로 정상 경로에선 fire 0. fire 하면 bare scope-hoist
+            // 후 같은 top-level scope 에서 동일 이름 → silent broken (예: `.alias`
+            // re-export source 가 per_mod_reserved 누락 시). debug 빌드 안전망 —
+            // (c) 코어 통합이 1-char 압력을 키우기 전에 정합성을 기계 증명.
+            if (builtin.mode == .Debug) {
+                if (per_mod_reserved[i].contains(entry.value_ptr.*)) {
+                    std.debug.panic(
+                        "RFC#3288 collision: module {d} nested '{s}' shadows reserved top-level name (silent-broken)",
+                        .{ mod_idx, entry.value_ptr.* },
+                    );
+                }
+            }
             const key: ModuleSymKey = .{ .module_index = mod_idx, .symbol_id = entry.key_ptr.* };
             renames.putAssumeCapacity(key, entry.value_ptr.*);
         }


### PR DESCRIPTION
RFC #3288 (mangler 1-char pool 고갈, oxc-통합 경로) **다단계 PR 의 (a) 안전망**.

## 배경

ZNTC mangler 2-phase 분리 (Phase A 전역 base54 선점 → Phase B nested 2-char fallback, zod ~2.3KB). 안전경로 = 단일패스 oxc 모델 통합 (ZNTC 가 이미 oxc liveness 모델). Plan 순서 강제: **(a) 안전망 → (b) `.alias` broadcast 보강 → (c) 코어 통합 → (d) 정리. (b) 없이 (c) 금지** (silent-broken).

이 PR = (a). 코어 통합이 1-char 압력을 키우기 **전에** cross-module shadow 정합성을 기계 증명.

## 변경

`mangleAll` 의 Phase B nested rename 이관 루프에 debug-only invariant assert:
- Phase B `nextNonReservedBase54Name` 회피 로직이 nested 이름을 `per_mod_reserved` (Phase A this-module + cross-module import source mangled = bare scope-hoist 후 회피 대상 외부 top-level) 와 안 겹치게 보장
- assert = 그 invariant 의 정확한 역. 정상 fire 0, fire 시 silent-broken (같은 top-level scope 동일 이름)

## (b) 와의 결합

현 `linker.zig:906` 이 `.alias` re-export source skip = silent-broken 잠재 결함. (b) 가 alias 를 `per_mod_reserved` 입력에 추가하면 **assert 코드 무변경**으로 alias collision 자동 커버 (입력 set 만 확장).

## 안전성

- `builtin.mode == .Debug` 게이트 — ReleaseFast 무영향, debug 도 nested 당 O(1)
- **false-positive 코드상 불가**: `mangler.zig:205-208/679` 회피 루프와 동일 set 검사 — 정상이면 절대 contains 안 됨 (3-agent 입증)

## 검증

- 전체 `zig build test` + zod/effect 실번들 collision panic **0** (현행 정상 케이스 invariant 보존)
- /simplify 3-agent: false-positive 0 입증 / (b) 결합 적합 / debug-only 정당 / quality **PASS**

Refs #3288

🤖 Generated with [Claude Code](https://claude.com/claude-code)