### PR TITLE
fix(linker): broadcast .alias re-export source to per_mod_reserved (RFC #3288 b)

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -898,13 +898,38 @@ pub const Linker = struct {
                 }
 
                 // cross_module_imports: 이 모듈이 import 한 cross-module symbol 의
-                // source 위치. `.semantic` variant 만 — `.alias` 는 re-export chain
-                // 중간 노드라 candidate 풀에 없어 renames lookup 이 무의미.
+                // source 위치 (= per_mod_reserved 에 broadcast → Phase B nested 가
+                // 그 mangled 이름 회피). RFC #3288 (b): `.alias` (re-export chain
+                // 중간 노드) 도 resolveExportChain 으로 궁극 `.semantic` source 를
+                // 도출해 포함 — 누락 시 bare scope-hoist 후 nested 가 re-export
+                // source 이름을 재사용해 silent-broken (PR (a) collision assert 가
+                // 이 누락을 잡도록 설계됨). 미해결/순환은 외부·shim 이라 mangle
+                // 대상 아님 → skip 안전.
                 var ir_buf: std.ArrayListUnmanaged(um.ImportRef) = .empty;
                 errdefer ir_buf.deinit(self.allocator);
                 for (m.import_bindings) |ib| {
-                    if (ib.symbol != .semantic) continue;
-                    const sem_ref = ib.symbol.semantic;
+                    const sr: bundler_symbol.SymbolRef = switch (ib.symbol) {
+                        .semantic => ib.symbol,
+                        .alias => |a| blk: {
+                            if (a.module.isNone()) continue;
+                            // resolveExportChain → (chain.module, export_name).
+                            // 그 declaring 모듈의 export_bindings 에서 exported_name
+                            // 매칭으로 궁극 `.semantic` 도출. chain 미해결/순환/
+                            // non-semantic 은 외부·shim → skip 안전.
+                            const chain = self.resolveExportChain(a.module, ib.imported_name, 0) orelse continue;
+                            const cm = self.getModule(@intFromEnum(chain.module_index)) orelse continue;
+                            var resolved: ?bundler_symbol.SymbolRef = null;
+                            for (cm.export_bindings) |eb| {
+                                if (std.mem.eql(u8, eb.exported_name, chain.export_name)) {
+                                    resolved = eb.symbol;
+                                    break;
+                                }
+                            }
+                            break :blk resolved orelse continue;
+                        },
+                    };
+                    if (sr != .semantic) continue;
+                    const sem_ref = sr.semantic;
                     if (sem_ref.module.isNone() or sem_ref.symbol.isNone()) continue;
                     try ir_buf.append(self.allocator, .{
                         .source_module_index = @intFromEnum(sem_ref.module),


### PR DESCRIPTION
RFC #3288 다단계 PR **(b)** — `.alias` cross-module broadcast 보강. Plan 순서: (a) 안전망 ✅ #3327 → **(b) 본 PR** → (c) 코어 통합(실효) → (d) 정리.

## 결함

`collectUnifiedInput` 의 cross_module_imports 수집이 `if (ib.symbol != .semantic) continue;` 로 `.alias` (re-export chain 중간) skip → 그 mangled 이름이 `per_mod_reserved` 누락 → bare scope-hoist 후 Phase B nested 가 re-export source 이름 재사용 → 같은 top-level scope 동일 이름 **silent-broken**. (c) 코어 통합이 1-char 압력을 키우면 발현 확률 증가 → (c) 전 필수.

## 수정

`.alias` → `resolveExportChain(a.module, ib.imported_name)` chain 끝 `(module, export_name)` → declaring 모듈 `export_bindings` 매칭 → 궁극 `.semantic` source → ir_buf. `resolveExportChainInner` 가 declaring `.local` export 까지 추적하므로 매칭 `eb.symbol` 은 `.semantic` 보장 (chain 중간 재skip silent-broken 재발 없음). 미해결/순환/non-semantic = 외부·CJS·shim → skip 안전 (PR(a) assert 잔여 안전망).

## 검증

| | 결과 |
|---|---|
| zig build test Debug+ReleaseFast | **0 fail** |
| effect/rxjs/zod alias-heavy 실번들 | collision panic **0** (PR(a) assert active, broadcast 후 invariant 보존) |
| size 회귀 | **0** (broadcast = renames non-null 시 reserved 추가 = 누락 정합성 복구) |
| /simplify 3-agent | chain-end 보장 / skip 안전 / size 회귀 0 / 시점 안전 **PASS** |

PR(a) collision assert 가 입력 set 확장만으로 alias collision 자동 검증 (assert 코드 무변경). (c) 코어 통합 안전 전제 충족.

Refs #3288

🤖 Generated with [Claude Code](https://claude.com/claude-code)