### PR TITLE
fix(bundler): don't force content hash into chunk CSS names

### DIFF
--- a/src/bundler/css_emitter.zig
+++ b/src/bundler/css_emitter.zig
@@ -280,37 +280,34 @@ fn cssPathForChunk(
     return applyCssChunkName(allocator, css_names, idx_name, contents);
 }
 
-/// `css_names` 패턴의 `[name]`/`[hash]` 를 치환한다. `.css` 확장자를 보장하고,
-/// 패턴에 `[hash]` 가 없으면 확장자 앞에 `-<hash>` 를 강제 삽입한다(청크 캐시 안전).
-/// chunks.zig 의 `applyNamingPattern` 과 분리 유지 — 그쪽은 buffer 기반·[ext] 처리
-/// 이고 여기는 CSS 전용(강제 hash + .css 보장)이라 의미가 다르다.
+/// `css_names` 패턴의 `[name]`/`[hash]` 를 충실히 치환하고 `.css` 확장자를
+/// 보장한다. `[hash]`(= CSS 내용 wyhash) 는 패턴에 명시됐을 때만 삽입한다 —
+/// 강제 삽입은 app-builder 의 안정 파일명(`[name]`→`main.css`, HTML link
+/// rewrite) 기대를 깨므로 하지 않는다. 캐시 버스팅이 필요하면 css_names 에
+/// `[hash]` 를 넣는다(JS 청크의 entry_names/chunk_names 와 동일 계약).
+/// chunks.zig 의 `applyNamingPattern` 과 분리 유지 — 그쪽은 buffer 기반·[ext]
+/// 처리이고 여기는 CSS 전용(.css 보장)이라 의미가 다르다.
 fn applyCssChunkName(
     allocator: std.mem.Allocator,
     pattern: []const u8,
     stem: []const u8,
     contents: []const u8,
 ) ![]const u8 {
-    const h = wyhash.hashHex8(contents);
     var out: std.ArrayListUnmanaged(u8) = .empty;
     errdefer out.deinit(allocator);
-    var had_hash = false;
     var i: usize = 0;
     while (i < pattern.len) {
         if (std.mem.startsWith(u8, pattern[i..], "[name]")) {
             try out.appendSlice(allocator, stem);
             i += "[name]".len;
         } else if (std.mem.startsWith(u8, pattern[i..], "[hash]")) {
+            const h = wyhash.hashHex8(contents);
             try out.appendSlice(allocator, &h);
-            had_hash = true;
             i += "[hash]".len;
         } else {
             try out.append(allocator, pattern[i]);
             i += 1;
         }
-    }
-    if (!had_hash) {
-        try out.append(allocator, '-');
-        try out.appendSlice(allocator, &h);
     }
     if (!std.mem.endsWith(u8, out.items, ".css")) {
         try out.appendSlice(allocator, ".css");
@@ -379,34 +376,25 @@ test "applyCssNamingPattern: custom pattern" {
     try std.testing.expectEqualStrings("styles/main.css", result);
 }
 
-test "applyCssChunkName: empty stem still produces -hash.css" {
+test "applyCssChunkName: empty stem → just .css (no forced hash)" {
     const a = std.testing.allocator;
-    const h = wyhash.hashHex8(".");
-    const expect = try std.fmt.allocPrint(a, "-{s}.css", .{h});
-    defer a.free(expect);
     const r = try applyCssChunkName(a, "[name]", "", ".");
     defer a.free(r);
-    try std.testing.expectEqualStrings(expect, r);
+    try std.testing.expectEqualStrings(".css", r);
 }
 
-test "applyCssChunkName: pattern with no placeholders forces -hash" {
+test "applyCssChunkName: pattern with no placeholders → literal + .css (no forced hash)" {
     const a = std.testing.allocator;
-    const h = wyhash.hashHex8("x");
-    const expect = try std.fmt.allocPrint(a, "styles/main-{s}.css", .{h});
-    defer a.free(expect);
     const r = try applyCssChunkName(a, "styles/main", "idx", "x");
     defer a.free(r);
-    try std.testing.expectEqualStrings(expect, r);
+    try std.testing.expectEqualStrings("styles/main.css", r);
 }
 
-test "applyCssChunkName: [name] only forces -hash before .css" {
+test "applyCssChunkName: [name] only → stem.css (no forced hash — app-builder 안정 파일명)" {
     const a = std.testing.allocator;
-    const h = wyhash.hashHex8(".x{}");
-    const expect = try std.fmt.allocPrint(a, "route-a-{s}.css", .{h});
-    defer a.free(expect);
     const r = try applyCssChunkName(a, "[name]", "route-a", ".x{}");
     defer a.free(r);
-    try std.testing.expectEqualStrings(expect, r);
+    try std.testing.expectEqualStrings("route-a.css", r);
 }
 
 test "applyCssChunkName: explicit [hash] not duplicated" {
@@ -447,7 +435,18 @@ test "applyCssChunkName: hash depends only on contents (determinism + sensitivit
     try std.testing.expect(std.mem.indexOf(u8, r4, &h) != null);
 }
 
-test "cssPathForChunk: uses chunk.name + content hash" {
+test "cssPathForChunk: [name] → chunk.name.css (안정 파일명, 강제 hash 없음)" {
+    const a = std.testing.allocator;
+    const bits = try chunk_mod.BitSet.init(a, 1);
+    var ch = Chunk.init(@enumFromInt(0), .common, bits);
+    defer ch.deinit(a);
+    ch.name = "vendor";
+    const r = try cssPathForChunk(a, &ch, "[name]", ".v{}");
+    defer a.free(r);
+    try std.testing.expectEqualStrings("vendor.css", r);
+}
+
+test "cssPathForChunk: [name]-[hash] → chunk.name + content hash" {
     const a = std.testing.allocator;
     const bits = try chunk_mod.BitSet.init(a, 1);
     var ch = Chunk.init(@enumFromInt(0), .common, bits);
@@ -456,7 +455,7 @@ test "cssPathForChunk: uses chunk.name + content hash" {
     const h = wyhash.hashHex8(".v{}");
     const expect = try std.fmt.allocPrint(a, "vendor-{s}.css", .{h});
     defer a.free(expect);
-    const r = try cssPathForChunk(a, &ch, "[name]", ".v{}");
+    const r = try cssPathForChunk(a, &ch, "[name]-[hash]", ".v{}");
     defer a.free(r);
     try std.testing.expectEqualStrings(expect, r);
 }

--- a/tests/integration/tests/css-code-splitting.test.ts
+++ b/tests/integration/tests/css-code-splitting.test.ts
@@ -159,32 +159,10 @@ describe('CSS code splitting (per-chunk CSS)', () => {
     expect(vendorCss!.text).not.toContain('.app');
   });
 
-  // P0-2: 청크 CSS 는 자기 content-hash 를 가져야 한다 (JS 해시 종속 X).
-  test('청크 CSS 파일명에 content-hash 가 붙는다', async () => {
-    const fixture = await createFixture({
-      'entry.ts': `
-        export async function load() {
-          return (await import('./route-a')).default;
-        }
-      `,
-      'route-a.ts': `import './a.css';\nexport default 1;`,
-      'a.css': `.route-a { color: red; }`,
-    });
-    cleanup = fixture.cleanup;
-
-    const result = await build({
-      entryPoints: [join(fixture.dir, 'entry.ts')],
-      splitting: true,
-    });
-
-    const css = cssFiles(result.outputFiles!);
-    const aCss = css.find((c) => c.text.includes('color: red'))!;
-    expect(aCss).toBeDefined();
-    // <stem>-<8 hex>.css 형태
-    expect(aCss.path).toMatch(/-[0-9a-f]{8}\.css$/);
-  });
-
-  test('동일 입력 재빌드 시 청크 CSS 파일명(해시)이 결정적', async () => {
+  // P0-2: css_names 패턴 충실 적용. 기본 "[name]" 은 안정 파일명(강제 hash
+  // 없음 — app-builder HTML link rewrite 호환). [hash] 동작은 css_emitter.zig
+  // applyCssChunkName 단위테스트가 커버 (build() JS API 에 cssNames 미노출).
+  test('동일 입력 재빌드 시 청크 CSS 파일명이 결정적', async () => {
     const files = {
       'entry.ts': `export async function load(){ return (await import('./r')).default; }`,
       'r.ts': `import './s.css';\nexport default 1;`,
@@ -201,25 +179,6 @@ describe('CSS code splitting (per-chunk CSS)', () => {
     const p2 = cssFiles(r2.outputFiles!).find((c) => c.text.includes('teal'))!.path;
 
     expect(p1).toBe(p2);
-  });
-
-  test('CSS 내용이 다르면 해시가 다르다', async () => {
-    const mk = (rule: string) => ({
-      'entry.ts': `export async function load(){ return (await import('./r')).default; }`,
-      'r.ts': `import './s.css';\nexport default 1;`,
-      's.css': rule,
-    });
-    const fa = await createFixture(mk('.s { color: red; }'));
-    const ra = await build({ entryPoints: [join(fa.dir, 'entry.ts')], splitting: true });
-    const pa = cssFiles(ra.outputFiles!).find((c) => c.text.includes('color'))!.path;
-    await fa.cleanup();
-
-    const fb = await createFixture(mk('.s { color: blue; }'));
-    cleanup = fb.cleanup;
-    const rb = await build({ entryPoints: [join(fb.dir, 'entry.ts')], splitting: true });
-    const pb = cssFiles(rb.outputFiles!).find((c) => c.text.includes('color'))!.path;
-
-    expect(pa).not.toBe(pb);
   });
 
   // P0-3②: 동적 import 된 청크는 자기 CSS 를 런타임 <link> 로 주입한다.


### PR DESCRIPTION
## 요약

**회귀 수정.** P0-2(#3323)가 `css_names` 에 `[hash]` 가 없어도 청크 CSS 파일명에 `-<hash>` 를 **강제 삽입**했는데, Vite app-builder 는 `[name]`→`main.css` 안정 파일명 + HTML `<link>` rewrite 를 기대한다. 그래서 CLI app-builder styles 테스트 4개 중 **3개가 회귀**(PostCSS / Tailwind v4 / build-collision).

## 수정

`applyCssChunkName` 이 `css_names` 패턴을 **충실히** 따르도록 변경:
- `[name]`/`[hash]` 치환 + `.css` 보장만 수행
- `[hash]`(CSS 내용 wyhash)는 **패턴에 명시됐을 때만** 삽입 (강제 삽입 제거)
- 캐시 버스팅이 필요하면 `css_names` 에 `[hash]` 명시 — JS 청크의 `entry_names`/`chunk_names` 와 동일 계약
- 부수효과: 기본 `[name]` 에서 불필요한 해시 계산도 제거

## 테스트

- forced-hash 전제였던 단위/통합 테스트 갱신, `[hash]` 동작은 `applyCssChunkName` 단위테스트가 커버 (build() JS API 에 cssNames 미노출이라 통합에서 [hash] 직접 테스트 불가).
- 검증: 회귀 3개 CLI 테스트 통과 · 전체 `zig build test` · css 통합 75/75 · smoke 무회귀 · P0-3② e2e(실제 Chromium) 통과 · `/simplify` 3-에이전트(수정 불필요 결론).

## 범위 밖 (별도 이슈 대상)

4번째 실패 **Sass** (`Sass/SCSS app styles are compiled before app build`) 는 **P0-1 이전 baseline `9e3506d9` 에서도 동일 재현** — 본 회귀와 무관한 기존 app-builder Sass HTML-link 버그. 본 PR 범위 아님.

Refs #3321

🤖 Generated with [Claude Code](https://claude.com/claude-code)
