### PR TITLE
fix(bundler): collect CSS through tree-shaken proxy modules (#3330)

### DIFF
--- a/src/bundler/css_emitter.zig
+++ b/src/bundler/css_emitter.zig
@@ -125,7 +125,7 @@ pub fn planCssChunks(
         const rank: u64 = (@as(u64, ch.exec_order) << 32) | @as(u64, m.exec_index);
         visited.clearRetainingCapacity();
         for (m.dependencies.items) |dep| {
-            walkCssOwner(graph, dep, ci, rank, &owner, &owner_rank, &visited);
+            walkCssOwner(graph, chunk_graph, dep, ci, rank, &owner, &owner_rank, &visited);
         }
     }
 
@@ -233,12 +233,17 @@ pub fn emitCssChunks(
 }
 
 /// CSS 서브그래프를 DFS 하며 각 CSS 모듈의 귀속 청크를 최소 rank 로 갱신한다.
-/// JS 모듈은 따라가지 않는다(각 JS 모듈은 호출부에서 개별 처리).
+/// 자체 chunk 를 가진 JS 모듈은 멈춘다(호출부 개별 순회가 처리 — 과귀속 방지).
+/// 단 chunk 미할당 JS(= tree-shaken 된 `.css.js` 류 side-effect proxy: Sass/CSS
+/// Modules 가 `import "./x.scss"` → proxy → `import "./x.css"` 로 생성)는 통과해
+/// 그 너머 CSS 를 현재 청크에 귀속한다 — 통과 안 하면 splitting 경로에서 CSS 가
+/// 통째로 누락된다(#3330).
 /// `visited` 는 JS 모듈(루트)마다 clear 되며 `rank` 는 한 루트 안에서 불변 →
 /// 같은 루트 내 재방문은 정보가 없어 skip 해도 안전하고, 다른 루트(다른 rank)
 /// 에서는 visited 가 비워져 재평가되므로 최소 rank 가 누락되지 않는다.
 fn walkCssOwner(
     graph: *const ModuleGraph,
+    chunk_graph: *const ChunkGraph,
     idx: ModuleIndex,
     ci: ChunkIndex,
     rank: u64,
@@ -250,15 +255,25 @@ fn walkCssOwner(
     if (visited.contains(idx)) return;
     visited.put(idx, {}) catch return;
     const mod = graph.getModule(idx) orelse return;
-    if (mod.module_type != .css) return;
 
-    const better = if (owner_rank.get(idx)) |r| rank < r else true;
-    if (better) {
-        owner.put(idx, ci) catch return;
-        owner_rank.put(idx, rank) catch return;
+    if (mod.module_type == .css) {
+        const better = if (owner_rank.get(idx)) |r| rank < r else true;
+        if (better) {
+            owner.put(idx, ci) catch return;
+            owner_rank.put(idx, rank) catch return;
+        }
+        // CSS→CSS(@import) 체인
+        for (mod.dependencies.items) |dep| {
+            walkCssOwner(graph, chunk_graph, dep, ci, rank, owner, owner_rank, visited);
+        }
+        return;
     }
+
+    // 비-CSS(JS 등): 자체 chunk 가 있으면 호출부 개별 순회가 담당하므로 멈춘다.
+    // chunk 미할당(tree-shaken side-effect proxy)만 통과해 너머 CSS 를 찾는다.
+    if (!chunk_graph.getModuleChunk(mod.index).isNone()) return;
     for (mod.dependencies.items) |dep| {
-        walkCssOwner(graph, dep, ci, rank, owner, owner_rank, visited);
+        walkCssOwner(graph, chunk_graph, dep, ci, rank, owner, owner_rank, visited);
     }
 }
 

--- a/tests/integration/tests/css-code-splitting.test.ts
+++ b/tests/integration/tests/css-code-splitting.test.ts
@@ -181,6 +181,45 @@ describe('CSS code splitting (per-chunk CSS)', () => {
     expect(p1).toBe(p2);
   });
 
+  // #3330: Sass/CSS Modules 는 `import "./x.scss"` 를 `.css.js` proxy
+  // (`import "./x.css"` 한 줄) 로 rewrite 한다. proxy JS 모듈은 tree-shake
+  // 되어 chunk 미할당이 되는데, splitting 경로가 그 너머 CSS 를 놓치면 안 됨.
+  test('side-effect proxy(.css.js) 체인 너머 CSS 도 분리 emit 된다', async () => {
+    const fixture = await createFixture({
+      'entry.ts': `import './style.css.js';\nconsole.log("x");`,
+      'style.css.js': `import './style.css';`,
+      'style.css': `.proxied { color: rebeccapurple; }`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'entry.ts')],
+      splitting: true,
+    });
+
+    const css = cssFiles(result.outputFiles!);
+    expect(css.length).toBeGreaterThanOrEqual(1);
+    expect(css.some((c) => c.text.includes('rebeccapurple'))).toBe(true);
+  });
+
+  test('다단계 proxy 체인(JS→JS→CSS) 너머 CSS 도 수집된다', async () => {
+    const fixture = await createFixture({
+      'entry.ts': `import './p1.js';\nconsole.log("x");`,
+      'p1.js': `import './p2.js';`,
+      'p2.js': `import './deep.css';`,
+      'deep.css': `.deep { color: seagreen; }`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'entry.ts')],
+      splitting: true,
+    });
+
+    const css = cssFiles(result.outputFiles!);
+    expect(css.some((c) => c.text.includes('seagreen'))).toBe(true);
+  });
+
   // P0-3②: 동적 import 된 청크는 자기 CSS 를 런타임 <link> 로 주입한다.
   test('동적 청크 JS 에 CSS <link> 주입 prologue 가 들어간다', async () => {
     const fixture = await createFixture({


### PR DESCRIPTION
## 요약

**이슈 #3330 수정** (선재 버그). Sass/CSS Modules 는 `import "./x.scss"` 를 `.css.js` proxy(`import "./x.css"` 한 줄)로 rewrite 하는데, **splitting CSS 경로**(`planCssChunks`/`walkCssOwner`)가 tree-shaken 되어 chunk 미할당된 그 proxy JS 모듈을 통과하지 않아 **너머 CSS 를 통째로 누락**했다. 결과적으로 `zntc build` 의 Sass 케이스에서 dist 에 CSS 파일과 HTML `<link>` 가 전혀 안 나왔다.

## 근거 (sass 무관 재현)

- `zntc --bundle <e>` (비-splitting): proxy 체인으로 `main.css` 정상 emit (collectCssModules 가 의존 그래프 전체 DFS).
- `zntc --bundle <e> --splitting --format=esm`: **css 누락** — splitting 경로 버그 확정. sass 와 무관.
- P0-1 이전 baseline `9e3506d9` 에서도 동일 실패 → 선재 버그(코드스플리팅 작업이 유발한 회귀 아님).

## 수정

`walkCssOwner`: 자체 chunk 를 가진 JS 모듈은 멈추고(호출부 개별 순회가 담당 — 과귀속 방지), **chunk 미할당(tree-shaken side-effect proxy) JS 만 통과**해 너머 CSS 를 현재 청크에 귀속. rank/visited 불변식 유지(다중 루트 최소 rank 정확).

## 테스트

- 통합: side-effect proxy(.css.js) 1단계 + 다단계(JS→JS→CSS) 체인 → CSS 분리 emit 검증.
- app-builder styles 스위트 **14/14 통과** (Sass 2케이스 + PostCSS + Tailwind v4 + build-collision 포함 — 이전 실패하던 #3330 케이스 포함).
- 전체 `zig build test` · css 통합 76/76 · 실제 Chromium e2e · smoke 무회귀 · `/simplify` 3-에이전트(수정 권장 결론).

Closes #3330

🤖 Generated with [Claude Code](https://claude.com/claude-code)
