### PR TITLE
docs(bundler): document literal-only dynamic import policy + minChunkSize

### DIFF
--- a/docs/BUNDLER.md
+++ b/docs/BUNDLER.md
@@ -323,8 +323,26 @@ pub const CjsExportFact = struct {
 ## Code splitting 전략
 - 동적 import (`import('./page')`) 기준 청크 분할
 - 공통 모듈 추출: 여러 진입점이 공유하는 모듈 → 별도 청크
+- 작은 common 청크 자동 병합: `minChunkSize` (Rollup `experimentalMinChunkSize` 류).
+  `src.bits ⊆ dst.bits`(over-fetch 없음)인 경우만 병합, entry/manual/dynamic 보존
 - 순환 참조: 같은 청크로 묶기
 - 런타임 로더: 청크를 동적 로드하는 코드 생성 (ESM 기반)
+
+### 동적 import specifier 정책 (literal-only)
+
+**지원**: `import("./page.js")` 처럼 **문자열 리터럴** specifier 만 정적 분석되어
+청크 경계로 인식·분할된다.
+
+**한계**: 변수 / 템플릿 리터럴 / 문자열 연결 등 **비-리터럴 specifier**
+(`import(name)`, `` import(`./m-${n}.js`) ``, `import("./a"+b)`) 는 정적 분석
+범위 밖이라 **코드 분할 대상이 아니다**. 해당 호출은 변형 없이 네이티브 런타임
+`import()` 로 그대로 남아 브라우저/런타임이 처리한다(번들에 미수집·미인라인,
+별도 진단 없음).
+
+**원리**: 어떤 모듈이 로드될지 빌드 타임에 알 수 없으면 안전한 청크 그래프를
+구성할 수 없다. 무분별한 디렉터리 통째 번들링(over-bundling)을 피하기 위한
+의도된 제약이며 esbuild/Rollup 과 동일한 경계다. 디렉터리 단위 동적 로딩이
+필요하면 `require.context`(Metro/webpack 호환, 인자 전부 리터럴)를 쓴다.
 
 ## 테스트 전략 (TDD)
 - **원칙**: 버그 하나 = 테스트 하나. 이슈 재현 테스트 먼저 → 수정 → 같은 버그 재발 방지


### PR DESCRIPTION
## 요약

일반 청크 백로그 #3321 의 **P1** 관련 — **문서 갭 해소**. P1 조사 결과, 비-literal 동적 import 의 처리(네이티브 `import()` passthrough, 코드분할 대상 아님)는 **동작은 이미 올바르나**(esbuild/Rollup 동등) 그 정책이 **코드 주석에만 존재하고 문서에 없었다**. `docs/BUNDLER.md` Code splitting 섹션에 명문화.

## 내용

- **지원**: 문자열 리터럴 specifier 만 정적 분석·청크 경계 인식
- **한계**: 변수/템플릿/연결 specifier 는 코드분할 대상 아님 — 변형 없이 네이티브 런타임 `import()` passthrough(번들 미수집·미인라인, 진단 없음)
- **원리**: 정적 분석 경계, over-bundling 방지, esbuild/Rollup 동등. 디렉터리 단위는 `require.context`
- P2 `minChunkSize` 항목도 Code splitting 전략에 함께 기재

## 비고

- 문서 전용 변경 — `/simplify`(변경 코드 리뷰)·빌드/회귀 해당 없음.
- 비-literal 동적 import **경고 진단** 추가는 scanner/resolve/chunk/codegen 코어 import 경로를 건드려 회귀면이 커, 본 PR 에서 분리(별도 PR 시 명시 검토 필요).

Refs #3321

🤖 Generated with [Claude Code](https://claude.com/claude-code)
