### PR TITLE
feat(bundler): warn on non-literal dynamic import() specifier (P1)

### DIFF
--- a/src/bundler/graph/parser_metadata.zig
+++ b/src/bundler/graph/parser_metadata.zig
@@ -47,6 +47,7 @@ pub fn materialize(
                 .context_filter_flags = sr.context_filter_flags,
                 .context_mode = ctx_mode,
                 .context_invalid_reason = sr.context_invalid_reason,
+                .dynamic_invalid_reason = sr.dynamic_invalid_reason,
             };
         }
         module.import_records = records;

--- a/src/bundler/graph/resolve_imports.zig
+++ b/src/bundler/graph/resolve_imports.zig
@@ -382,6 +382,14 @@ pub fn resolveModuleImports(self: *ModuleGraph, idx: ModuleIndex) !void {
     for (records, 0..) |record, rec_i| {
         if (record.kind == .glob) continue;
         if (record.kind == .require_context) continue;
+        if (record.kind == .dynamic_import) {
+            if (record.dynamic_invalid_reason) |reason| {
+                // 비-literal dynamic import: warning 후 resolved=.none 유지 →
+                // chunk/codegen 무시(원본 import() 네이티브 passthrough).
+                self.addDiag(.unresolved_import, .warning, module_path, record.span, .resolve, reason, null);
+                continue;
+            }
+        }
         if (record.resolved != .none or record.is_external) continue;
         const should_link = graph_requested_exports.shouldLinkResolvedRecordForModule(self, mod_idx, rec_i, record);
 

--- a/src/bundler/import_scanner.zig
+++ b/src/bundler/import_scanner.zig
@@ -460,7 +460,16 @@ fn tryExtractDynamicImport(ast: *const Ast, node: Node) ?ImportRecord {
     if (arg_idx.isNone()) return null;
 
     const arg_node = ast.getNode(arg_idx);
-    if (arg_node.tag != .string_literal) return null;
+    if (arg_node.tag != .string_literal) {
+        // 비-literal specifier: record(빈 specifier + reason). resolve 단계가
+        // warning 후 resolved=.none 유지 → chunk/codegen 무시(native passthrough).
+        return .{
+            .specifier = "",
+            .kind = .dynamic_import,
+            .span = arg_node.span,
+            .dynamic_invalid_reason = scan_results.dynamic_import_non_literal_reason,
+        };
+    }
 
     const specifier = stripQuotes(ast.getText(arg_node.span)) orelse return null;
 

--- a/src/bundler/import_scanner_test.zig
+++ b/src/bundler/import_scanner_test.zig
@@ -239,11 +239,31 @@ test "dynamic import (string literal)" {
     try std.testing.expectEqual(ImportKind.dynamic_import, records[0].kind);
 }
 
-test "dynamic import (computed) — not extracted" {
+test "dynamic import (computed) — marked invalid (not code-split, native passthrough)" {
     const alloc = std.testing.allocator;
     const records = try parseAndExtract(alloc, "const m = import(foo);");
     defer alloc.free(records);
-    try std.testing.expectEqual(@as(usize, 0), records.len);
+    try std.testing.expectEqual(@as(usize, 1), records.len);
+    try std.testing.expectEqual(ImportKind.dynamic_import, records[0].kind);
+    try std.testing.expectEqualStrings("", records[0].specifier);
+    try std.testing.expect(records[0].dynamic_invalid_reason != null);
+}
+
+test "dynamic import (template literal) — marked invalid" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "const m = import(`./m-${n}.js`);");
+    defer alloc.free(records);
+    try std.testing.expectEqual(@as(usize, 1), records.len);
+    try std.testing.expect(records[0].dynamic_invalid_reason != null);
+    try std.testing.expectEqualStrings("", records[0].specifier);
+}
+
+test "dynamic import (string literal) — not marked invalid" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc, "const m = import('./lazy');");
+    defer alloc.free(records);
+    try std.testing.expectEqual(@as(usize, 1), records.len);
+    try std.testing.expect(records[0].dynamic_invalid_reason == null);
 }
 
 test "multiple imports" {

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -623,6 +623,11 @@ pub const ImportRecord = struct {
     /// require.context: invalid arguments 발견 시 reason. graph 단계에서 BundlerDiagnostic 으로
     /// 변환되어 사용자에게 표시. null 이면 valid.
     context_invalid_reason: ?[]const u8 = null,
+    /// dynamic import(): specifier 가 비-literal(변수/템플릿/연결)이라 정적 분석
+    /// 불가 시 reason. graph resolve 단계에서 warning diagnostic 으로 변환.
+    /// 이 record 는 resolved=.none 유지 → chunk/codegen 이 무시(원본 import()
+    /// 가 네이티브 런타임 import() 로 그대로 passthrough). null = literal/valid.
+    dynamic_invalid_reason: ?[]const u8 = null,
     /// require.context: 매칭된 파일 목록. host plugin (`resolveContext`) 또는 내장 fallback 이
     /// graph 단계에서 채운다. codegen 이 이 목록을 보고 webpackContext 함수를 emit (Phase 3).
     /// null = 아직 평가 안 됨, &.{} = 매칭 0개 (empty context).

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -178,6 +178,14 @@ pub fn parseImportCallArgs(self: *Parser, start: u32) ParseError2!NodeIndex {
             const raw = self.ast.source[arg_node.span.start..arg_node.span.end];
             const spec = extractImportSpecifier(self, raw);
             _ = appendImportRecord(self, spec, .dynamic_import, arg_node.span);
+        } else {
+            // 비-literal specifier: record(빈 specifier + reason). graph resolve
+            // 가 warning 후 resolved=.none 유지 → 원본 import() 네이티브 passthrough.
+            const idx = appendImportRecord(self, "", .dynamic_import, arg_node.span);
+            if (idx < self.scan_import_records.items.len) {
+                self.scan_import_records.items[idx].dynamic_invalid_reason =
+                    scan_results_mod.dynamic_import_non_literal_reason;
+            }
         }
     }
 

--- a/src/parser/scan_results.zig
+++ b/src/parser/scan_results.zig
@@ -40,6 +40,10 @@ pub const DefineEntry = struct {
 };
 
 /// 파서가 수집하는 import 레코드. bundler ImportRecord의 경량 버전.
+/// 비-literal dynamic import() specifier 경고 메시지 (parser/scanner 공용).
+pub const dynamic_import_non_literal_reason =
+    "dynamic import() requires a string literal specifier; non-literal (variable/template/concatenated) specifiers are left as native runtime import() and not code-split";
+
 pub const ScanImportRecord = struct {
     /// 원본 import 경로 (따옴표 제거됨, 소스 코드 참조)
     specifier: []const u8,
@@ -63,6 +67,9 @@ pub const ScanImportRecord = struct {
     context_mode: RequireContextMode = .sync,
     /// require.context: invalid 인자 reason (graph 가 BundlerDiagnostic 으로 변환)
     context_invalid_reason: ?[]const u8 = null,
+    /// dynamic import(): 비-literal specifier reason. graph resolve 가 warning
+    /// 으로 변환, record 는 resolved=.none 유지 → native import() passthrough.
+    dynamic_invalid_reason: ?[]const u8 = null,
 };
 
 /// import 바인딩 종류.

--- a/tests/integration/tests/dynamic-import-non-literal.test.ts
+++ b/tests/integration/tests/dynamic-import-non-literal.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import { join } from 'node:path';
+import { createFixture } from './helpers';
+import { init, close, build } from '../../../packages/core/index';
+
+// P1 (#3321): 비-literal 동적 import specifier 는 코드분할 대상이 아니며
+// 네이티브 런타임 import() 로 그대로 passthrough — 동작은 불변, 단
+// 사용자가 알 수 있도록 warning 진단을 1회 emit 한다.
+
+describe('non-literal dynamic import warning', () => {
+  let cleanup: (() => Promise<void>) | undefined;
+  beforeAll(() => init());
+  afterAll(() => close());
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  test('변수 specifier → warning + 원본 import() passthrough(미변형)', async () => {
+    const fixture = await createFixture({
+      'index.ts': `const name = "./mod";\nexport const p = import(name);\nconsole.log("entry");`,
+      'mod.ts': `export default 1;`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({ entryPoints: [join(fixture.dir, 'index.ts')] });
+
+    // warning 1회 (메시지에 string literal 안내 포함)
+    const w = result.warnings ?? [];
+    expect(w.some((d) => /string literal/i.test(d.text ?? ''))).toBe(true);
+
+    // 빌드는 실패하지 않고 출력 생성
+    const js = (result.outputFiles ?? []).map((o) => o.text).join('\n');
+    expect(js).toContain('entry');
+    // 원본 import(name) 이 그대로 남음 (코드분할/래퍼 변형 없음)
+    expect(js).toContain('import(name)');
+  });
+
+  test('템플릿 리터럴 specifier → warning, 빌드 성공', async () => {
+    const fixture = await createFixture({
+      'index.ts': `const n = 2;\nexport const p = import(\`./m-\${n}.js\`);\nconsole.log("ok");`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({ entryPoints: [join(fixture.dir, 'index.ts')] });
+    const w = result.warnings ?? [];
+    expect(w.some((d) => /string literal/i.test(d.text ?? ''))).toBe(true);
+    const js = (result.outputFiles ?? []).map((o) => o.text).join('\n');
+    expect(js).toContain('ok');
+  });
+
+  test('회귀: 리터럴 specifier 는 warning 없음(정상 코드분할)', async () => {
+    const fixture = await createFixture({
+      'index.ts': `export const p = import('./mod');\nconsole.log("lit");`,
+      'mod.ts': `export default 1;`,
+    });
+    cleanup = fixture.cleanup;
+
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      splitting: true,
+    });
+    const w = result.warnings ?? [];
+    expect(w.some((d) => /string literal/i.test(d.text ?? ''))).toBe(false);
+  });
+});


### PR DESCRIPTION
## 요약

일반 청크 백로그 #3321 **P1**: 비-literal 동적 import() specifier 에 **warning 진단** 추가. 동작은 불변(esbuild/Rollup 동등 — 네이티브 런타임 `import()` passthrough, 코드분할 대상 아님)이나, 지금까지 사용자에게 아무 안내가 없어 혼동되던 것을 명시.

## 설계 (require.context 선례 미러)

- parser 인라인 스캔(`enable_scan` — JS record 실제 소스) + `import_scanner` 양쪽에서 비-literal specifier 시 **빈 specifier + `dynamic_invalid_reason`** 레코드 생성
- `ScanImportRecord` → `types.ImportRecord` 전파(`parser_metadata`)
- graph `resolveModuleImports` 가 `kind==.dynamic_import && dynamic_invalid_reason` 시 **warning** diagnostic 후 `continue` → `resolved=.none` 유지 → chunk/codegen 이 원본 `import()` 를 **그대로 passthrough**(회귀 0, codegen 은 `rec.resolved != .none` 게이트)
- 메시지는 `scan_results` 공용 const

## 테스트

- 유닛(`import_scanner_test`): computed/template → invalid 마킹, literal → 무마킹
- 통합(`dynamic-import-non-literal.test.ts`): 변수·템플릿 → `result.warnings` + 원본 `import(name)` 미변형 passthrough, 리터럴 → 무경고(회귀)
- 검증: 전체 `zig build test` · 청크/css/manual 회귀 80/80 · **app-builder styles 14/14** · e2e · smoke 무회귀 · `/simplify` 3-에이전트(중복 메시지 const 통합 반영)

Refs #3321

🤖 Generated with [Claude Code](https://claude.com/claude-code)
