### PR TITLE
chore(mangler): remove refuted c2/M2 dead infra (RFC #3288)

### DIFF
--- a/src/codegen/mangler.zig
+++ b/src/codegen/mangler.zig
@@ -91,26 +91,6 @@ pub const MangleInput = struct {
     /// `external_reserved` 가 *per-module* (예: Phase A 의 이 모듈 mangled 이름)
     /// 라면 본 필드는 *전 모듈 공통* (예: runtime helper 이름) 으로 분리된다.
     external_reserved_global: ?*const std.StringHashMap(void) = null,
-    /// RFC #3288 c2 인프라: set 된 symbol 은 liveness 초기화를 *선언 scope
-    /// 단독* 으로 한다 (`markScopeSubtree` 대신). references 의 ancestor-path
-    /// 마킹은 그대로라, 결과 liveness = 선언 scope + 실제 참조 경로 (reference-
-    /// precise). 이를 통해 그 symbol 을 free-ref 하지 않는 nested scope 가 같은
-    /// slot(1-char) 을 안전하게 재사용 — esbuild/oxc top-level↔nested 공유 모델.
-    ///
-    /// **정확성 불변식**: 이 집합의 symbol 은 *모든 사용처* 가 `references` 에
-    /// 등장해야 한다 (누락 시 under-mark → nested 가 잘못 재사용 → silent
-    /// broken). top-level (scope 0) 처럼 subtree 가 모듈 전체라 항상 disjoint
-    /// 실패하던 binding 을 reference 기반으로 정밀화하는 용도. caller 소유 유지.
-    /// default=null → 전 symbol `markScopeSubtree` (기존 동작 byte-identical).
-    precise_liveness: ?*const std.DynamicBitSet = null,
-    /// RFC #3288 M2: per-module `sym_idx → bundle-wide frequency rank`
-    /// (rank 0 = 번들 최다 참조 = 최단 이름 우선). 주어지면 slot 정렬이
-    /// rank 보유 slot 을 먼저(rank 오름차순), 그 다음 기존 total_refs
-    /// 내림차순. Phase A 의 load-bearing 전역 frequency 를 slot 공유
-    /// 모델에서 보존 (c2 +61KB 회귀 정면 회피). null → 기존 total_refs
-    /// 정렬 그대로 (byte-identical). caller 소유. PR-2 inert (미연결);
-    /// PR-3 가 unified_mangler 에서 buildGlobalFrequencyRank 결과 주입.
-    global_freq_rank: ?*const std.AutoHashMap(u32, u32) = null,
 };
 
 /// Liveness 기반 mangling.
@@ -177,20 +157,7 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
     // scope 가 같아 이미 충돌 (intersect) 처리되므로 영향 없음.
     for (symbols, 0..) |sym, i| {
         if (!sym.scope_id.isNone() and sym.scope_id.toIndex() < scope_count) {
-            const decl_idx = sym.scope_id.toIndex();
-            const precise = if (input.precise_liveness) |pl|
-                i < pl.capacity() and pl.isSet(i)
-            else
-                false;
-            if (precise) {
-                // 선언 scope 단독 — subtree 생략. references 의 ancestor-path
-                // 마킹(아래)이 실제 사용 scope 만 정밀 추가 → free-ref 없는
-                // nested 가 slot 재사용 가능. 불변식: 사용처가 references 에
-                // 완전히 등장해야 함 (MangleInput.precise_liveness 주석 참조).
-                symbol_liveness[i].set(decl_idx);
-            } else {
-                markScopeSubtree(&symbol_liveness[i], children, decl_idx);
-            }
+            markScopeSubtree(&symbol_liveness[i], children, sym.scope_id.toIndex());
         }
     }
 
@@ -364,8 +331,7 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
         };
     }
 
-    // slot 정렬: (M2) rank 보유 slot 먼저 rank 오름차순, 그 다음 기존
-    // total_refs 내림차순, 동률이면 slot_id 오름차순.
+    // slot 정렬: total_refs 내림차순, 동률이면 slot_id 오름차순
     const sorted_slots = try allocator.alloc(SlotSortEntry, slot_count);
     defer allocator.free(sorted_slots);
     for (sorted_slots, 0..) |*entry, i| {
@@ -374,26 +340,8 @@ pub fn mangle(allocator: std.mem.Allocator, input: MangleInput) !ManglerResult {
             .total_refs = slots.items[i].total_refs,
         };
     }
-    // 각 slot 의 최소 rank 산출 (slot 은 liveness-disjoint 여러 symbol 공유
-    // 가능 — 그 중 가장 우선순위 높은(rank 작은) symbol 이 slot 우선순위
-    // 결정: 그 symbol 이 최단 이름을 원함). global_freq_rank null 이면 전부
-    // null 유지 → 정렬이 기존과 byte-identical.
-    if (input.global_freq_rank) |gr| {
-        for (0..symbol_count) |si| {
-            const slot_id = symbol_to_slot[si] orelse continue;
-            const r = gr.get(@intCast(si)) orelse continue;
-            const cur = &sorted_slots[slot_id].global_rank;
-            if (cur.* == null or r < cur.*.?) cur.* = r;
-        }
-    }
     std.mem.sortUnstable(SlotSortEntry, sorted_slots, {}, struct {
         fn cmp(_: void, a: SlotSortEntry, b: SlotSortEntry) bool {
-            // rank 보유 slot 이 무rank 보다 항상 먼저, 동시 보유면 rank 오름차순.
-            if (a.global_rank != null and b.global_rank == null) return true;
-            if (a.global_rank == null and b.global_rank != null) return false;
-            if (a.global_rank) |ar| {
-                if (ar != b.global_rank.?) return ar < b.global_rank.?;
-            }
             if (a.total_refs != b.total_refs) return a.total_refs > b.total_refs;
             return a.slot_id < b.slot_id;
         }
@@ -619,10 +567,6 @@ const SymBinding = struct {
 const SlotSortEntry = struct {
     slot_id: u32,
     total_refs: u32,
-    /// RFC #3288 M2: 이 slot 에 속한 symbol 중 최소(최우선) bundle-wide
-    /// frequency rank. null = rank 없는 slot (nested 등) → 기존 total_refs
-    /// 기준. 전 slot null 이면 정렬이 기존과 동일 (byte-identical).
-    global_rank: ?u32 = null,
 };
 
 // ============================================================
@@ -838,192 +782,4 @@ test "markScopeSubtree: leaf scope 은 자기 자신만 set" {
     markScopeSubtree(&liveness, children, 1);
     try std.testing.expect(liveness.isSet(1));
     try std.testing.expect(!liveness.isSet(0));
-}
-
-test "precise_liveness: free-ref 없는 nested 가 top-level slot 재사용 (RFC #3288 c2 인프라)" {
-    const allocator = std.testing.allocator;
-
-    // scope tree:  0(global) ├─ 1(fn, aa 참조)  └─ 2(fn, bb 선언·참조, aa 미참조)
-    const scopes = [_]Scope{
-        .{ .parent = .none, .kind = .global, .is_strict = false, .symbol_count = 1 },
-        .{ .parent = @enumFromInt(0), .kind = .function, .is_strict = false, .symbol_count = 0 },
-        .{ .parent = @enumFromInt(0), .kind = .function, .is_strict = false, .symbol_count = 1 },
-    };
-    const stb: u32 = 0x80000000;
-    const symbols = [_]Symbol{
-        .{ // 0: aa — top-level (scope 0). subtree=모듈전체라 기존엔 항상 disjoint 실패
-            .name = .{ .start = stb, .end = stb + 2 },
-            .scope_id = @enumFromInt(0),
-            .origin_scope = @enumFromInt(0),
-            .kind = .variable_var,
-            .decl_flags = SymbolKind.variable_var.declFlags(),
-            .declaration_span = Span{ .start = stb, .end = stb + 2 },
-            .reference_count = 1,
-            .synthetic_name = "aa",
-        },
-        .{ // 1: bb — scope 2 nested. aa 를 free-ref 안 함
-            .name = .{ .start = stb, .end = stb + 2 },
-            .scope_id = @enumFromInt(2),
-            .origin_scope = @enumFromInt(2),
-            .kind = .variable_var,
-            .decl_flags = SymbolKind.variable_var.declFlags(),
-            .declaration_span = Span{ .start = stb, .end = stb + 2 },
-            .reference_count = 1,
-            .synthetic_name = "bb",
-        },
-    };
-    var s0 = std.StringHashMap(usize).init(allocator);
-    defer s0.deinit();
-    try s0.put("aa", 0);
-    var s1 = std.StringHashMap(usize).init(allocator);
-    defer s1.deinit();
-    var s2 = std.StringHashMap(usize).init(allocator);
-    defer s2.deinit();
-    try s2.put("bb", 1);
-    const scope_maps = [_]std.StringHashMap(usize){ s0, s1, s2 };
-    const refs = [_]Reference{
-        .{ .node_index = @enumFromInt(0), .scope_id = @enumFromInt(1), .symbol_id = @enumFromInt(0), .flags = .{ .read = true } },
-        .{ .node_index = @enumFromInt(1), .scope_id = @enumFromInt(2), .symbol_id = @enumFromInt(1), .flags = .{ .read = true } },
-    };
-
-    // (1) precise_liveness=null → aa subtree(0)={0,1,2} ∩ bb subtree(2)={2} ≠ ∅
-    //     → 다른 slot → 다른 이름 (기존 동작, 회귀 0 보장).
-    var r_def = try mangle(allocator, .{
-        .scopes = &scopes,
-        .symbols = &symbols,
-        .scope_maps = &scope_maps,
-        .references = &refs,
-        .source = "",
-    });
-    defer r_def.deinit();
-    try std.testing.expect(!std.mem.eql(u8, r_def.renames.get(0).?, r_def.renames.get(1).?));
-
-    // (2) precise_liveness={0} → aa={0}∪path(1→0)={0,1} ∩ bb subtree(2)={2} = ∅
-    //     → 같은 slot 재사용 → 같은 이름 (esbuild/oxc top-level↔nested 공유).
-    var pl = try std.DynamicBitSet.initEmpty(allocator, symbols.len);
-    defer pl.deinit();
-    pl.set(0);
-    var r_pre = try mangle(allocator, .{
-        .scopes = &scopes,
-        .symbols = &symbols,
-        .scope_maps = &scope_maps,
-        .references = &refs,
-        .source = "",
-        .precise_liveness = &pl,
-    });
-    defer r_pre.deinit();
-    try std.testing.expectEqualStrings(r_pre.renames.get(0).?, r_pre.renames.get(1).?);
-}
-
-test "precise_liveness: 참조되는 scope 의 nested 와는 여전히 slot 분리 (shadow-safety, silent-broken 방지)" {
-    const allocator = std.testing.allocator;
-
-    // 위와 동일 tree, 단 aa 가 scope 2 에서도 참조됨 → bb 와 같은 이름이면
-    // scope 2 에서 aa 가 bb 에 가려져 silent broken. precise 라도 분리돼야 함.
-    const scopes = [_]Scope{
-        .{ .parent = .none, .kind = .global, .is_strict = false, .symbol_count = 1 },
-        .{ .parent = @enumFromInt(0), .kind = .function, .is_strict = false, .symbol_count = 0 },
-        .{ .parent = @enumFromInt(0), .kind = .function, .is_strict = false, .symbol_count = 1 },
-    };
-    const stb: u32 = 0x80000000;
-    const symbols = [_]Symbol{
-        .{
-            .name = .{ .start = stb, .end = stb + 2 },
-            .scope_id = @enumFromInt(0),
-            .origin_scope = @enumFromInt(0),
-            .kind = .variable_var,
-            .decl_flags = SymbolKind.variable_var.declFlags(),
-            .declaration_span = Span{ .start = stb, .end = stb + 2 },
-            .reference_count = 2,
-            .synthetic_name = "aa",
-        },
-        .{
-            .name = .{ .start = stb, .end = stb + 2 },
-            .scope_id = @enumFromInt(2),
-            .origin_scope = @enumFromInt(2),
-            .kind = .variable_var,
-            .decl_flags = SymbolKind.variable_var.declFlags(),
-            .declaration_span = Span{ .start = stb, .end = stb + 2 },
-            .reference_count = 1,
-            .synthetic_name = "bb",
-        },
-    };
-    var s0 = std.StringHashMap(usize).init(allocator);
-    defer s0.deinit();
-    try s0.put("aa", 0);
-    var s1 = std.StringHashMap(usize).init(allocator);
-    defer s1.deinit();
-    var s2 = std.StringHashMap(usize).init(allocator);
-    defer s2.deinit();
-    try s2.put("bb", 1);
-    const scope_maps = [_]std.StringHashMap(usize){ s0, s1, s2 };
-    const refs = [_]Reference{
-        .{ .node_index = @enumFromInt(0), .scope_id = @enumFromInt(1), .symbol_id = @enumFromInt(0), .flags = .{ .read = true } },
-        .{ .node_index = @enumFromInt(2), .scope_id = @enumFromInt(2), .symbol_id = @enumFromInt(0), .flags = .{ .read = true } },
-        .{ .node_index = @enumFromInt(1), .scope_id = @enumFromInt(2), .symbol_id = @enumFromInt(1), .flags = .{ .read = true } },
-    };
-
-    var pl = try std.DynamicBitSet.initEmpty(allocator, symbols.len);
-    defer pl.deinit();
-    pl.set(0);
-    var r = try mangle(allocator, .{
-        .scopes = &scopes,
-        .symbols = &symbols,
-        .scope_maps = &scope_maps,
-        .references = &refs,
-        .source = "",
-        .precise_liveness = &pl,
-    });
-    defer r.deinit();
-    // aa={0}∪path(1→0)∪path(2→0)={0,1,2} ∩ bb subtree(2)={2} ≠ ∅ → 다른 이름.
-    try std.testing.expect(!std.mem.eql(u8, r.renames.get(0).?, r.renames.get(1).?));
-}
-
-test "global_freq_rank: rank 보유 symbol 이 더 짧은 이름 우선 (RFC #3288 M2 PR-2)" {
-    const allocator = std.testing.allocator;
-    // scope tree: 0(global) ├─ 1(fn)  symbols: aa(rc1, rank0) / bb(rc99, rank없음)
-    // bb 가 total_refs 압도적이나 aa 가 rank 0 → aa 가 먼저(짧은) 이름.
-    const scopes = [_]Scope{
-        .{ .parent = .none, .kind = .global, .is_strict = false, .symbol_count = 1 },
-        .{ .parent = @enumFromInt(0), .kind = .function, .is_strict = false, .symbol_count = 1 },
-    };
-    const stb: u32 = 0x80000000;
-    const symbols = [_]Symbol{
-        .{ .name = .{ .start = stb, .end = stb + 2 }, .scope_id = @enumFromInt(0), .origin_scope = @enumFromInt(0), .kind = .variable_var, .decl_flags = SymbolKind.variable_var.declFlags(), .declaration_span = Span{ .start = stb, .end = stb + 2 }, .reference_count = 1, .synthetic_name = "aa" },
-        .{ .name = .{ .start = stb, .end = stb + 2 }, .scope_id = @enumFromInt(1), .origin_scope = @enumFromInt(1), .kind = .variable_var, .decl_flags = SymbolKind.variable_var.declFlags(), .declaration_span = Span{ .start = stb, .end = stb + 2 }, .reference_count = 99, .synthetic_name = "bb" },
-    };
-    var s0 = std.StringHashMap(usize).init(allocator);
-    defer s0.deinit();
-    try s0.put("aa", 0);
-    var s1 = std.StringHashMap(usize).init(allocator);
-    defer s1.deinit();
-    try s1.put("bb", 1);
-    const scope_maps = [_]std.StringHashMap(usize){ s0, s1 };
-    const refs = [_]Reference{
-        .{ .node_index = @enumFromInt(0), .scope_id = @enumFromInt(0), .symbol_id = @enumFromInt(0), .flags = .{ .read = true } },
-        .{ .node_index = @enumFromInt(1), .scope_id = @enumFromInt(1), .symbol_id = @enumFromInt(1), .flags = .{ .read = true } },
-    };
-
-    // rank 없이: bb(rc99) 가 먼저 → 첫 base54, aa 는 다음.
-    var r0 = try mangle(allocator, .{ .scopes = &scopes, .symbols = &symbols, .scope_maps = &scope_maps, .references = &refs, .source = "" });
-    defer r0.deinit();
-    const bb0 = r0.renames.get(1).?;
-    const aa0 = r0.renames.get(0).?;
-
-    // aa 에 rank 0 부여 → aa 가 bb 보다 먼저(같거나 더 짧은) 이름.
-    var gr = std.AutoHashMap(u32, u32).init(allocator);
-    defer gr.deinit();
-    try gr.put(0, 0); // sym 0 (aa) = rank 0
-    var r1 = try mangle(allocator, .{ .scopes = &scopes, .symbols = &symbols, .scope_maps = &scope_maps, .references = &refs, .source = "", .global_freq_rank = &gr });
-    defer r1.deinit();
-    const aa1 = r1.renames.get(0).?;
-    const bb1 = r1.renames.get(1).?;
-
-    // 우선순위 역전의 정밀 증명 (base54 절대값 무관):
-    // 무rank → bb(rc99) 가 최우선 → 첫 발급 이름 N0 = bb0, aa0 = N1.
-    // rank0(aa) → aa 슬롯이 무rank bb 슬롯보다 먼저 → aa1 = N0, bb1 = N1.
-    // 따라서 aa1==bb0 (aa 가 우선 이름 차지) & bb1==aa0 (bb 강등) & aa 이동.
-    try std.testing.expectEqualStrings(bb0, aa1);
-    try std.testing.expectEqualStrings(aa0, bb1);
-    try std.testing.expect(!std.mem.eql(u8, aa0, aa1));
 }

--- a/src/codegen/unified_mangler.zig
+++ b/src/codegen/unified_mangler.zig
@@ -68,10 +68,9 @@ pub const TopLevelCandidate = struct {
     ref_count: u32,
 };
 
-/// bundle-wide frequency 정렬 비교자. ref_count 내림차순, 동률은 name →
+/// Phase A 빈도순 정렬 비교자. ref_count 내림차순, 동률은 name →
 /// module_index → symbol_id (병렬 파싱 비결정 회피 — name 은 computeRenames
-/// 이후 bundle-wide 유일하므로 결정적). Phase A 정렬과 buildGlobalFrequencyRank
-/// 가 공유 (동일 우선순위 보장).
+/// 이후 bundle-wide 유일하므로 결정적).
 fn candidateLessThan(_: void, a: TopLevelCandidate, b: TopLevelCandidate) bool {
     if (a.ref_count != b.ref_count) return a.ref_count > b.ref_count;
     const name_order = std.mem.order(u8, a.name, b.name);
@@ -80,42 +79,11 @@ fn candidateLessThan(_: void, a: TopLevelCandidate, b: TopLevelCandidate) bool {
     return a.symbol_id < b.symbol_id;
 }
 
-/// RFC #3288 M2: bundle-wide frequency rank 맵 (key=ModuleSymKey, value=rank;
-/// rank 0 = 최다 참조 = 최우선 1-char 후보). Phase A 의 *전역 frequency-sort*
-/// (load-bearing — c2 가 이를 상실해 +61KB 회귀) 를 Phase B slot 발급
-/// 우선순위로 보존하기 위한 자료구조. PR-1 inert (미연결); PR-2+ 가 소비.
-/// caller 가 deinit 소유.
-pub fn buildGlobalFrequencyRank(
-    allocator: std.mem.Allocator,
-    candidates: []const TopLevelCandidate,
-) !std.AutoHashMap(ModuleSymKey, u32) {
-    const sorted = try allocator.alloc(TopLevelCandidate, candidates.len);
-    defer allocator.free(sorted);
-    @memcpy(sorted, candidates);
-    std.mem.sortUnstable(TopLevelCandidate, sorted, {}, candidateLessThan);
-
-    var rank = std.AutoHashMap(ModuleSymKey, u32).init(allocator);
-    errdefer rank.deinit();
-    try rank.ensureUnusedCapacity(@intCast(sorted.len));
-    for (sorted, 0..) |c, i| {
-        // 같은 (module,symbol) 중복 candidate 는 첫(최우선) rank 유지.
-        const gop = rank.getOrPutAssumeCapacity(.{ .module_index = c.module_index, .symbol_id = c.symbol_id });
-        if (!gop.found_existing) gop.value_ptr.* = @intCast(i);
-    }
-    return rank;
-}
-
 pub const UnifiedMangleInput = struct {
     modules: []const ModuleMangleInput,
     top_level_candidates: []const TopLevelCandidate,
     /// 런타임 헬퍼 이름 등 외부 예약어. Phase A 초기 reserved set 에 포함.
     global_reserved: []const []const u8 = &.{},
-    /// RFC #3288 M2: true 면 Phase A candidate 를 즉시 base54 발급하지 않고
-    /// Phase B slot pool 에 bundle-wide frequency 우선순위로 합류 (frequency
-    /// 보존 + slot 공유). PR-1 inert (default false → 기존 Phase A 경로 100%
-    /// 보존, byte-identical); PR-3 가 소비. c2(+61KB) 회귀를 frequency 보존
-    /// 으로 정면 회피하는 경로의 게이트.
-    enable_shared_slot_pool: bool = false,
 };
 
 pub const UnifiedMangleResult = struct {
@@ -504,39 +472,4 @@ test "mangleAll: identity rename (name already equals base54 head) — no rename
     try std.testing.expectEqual(@as(u32, 0), @as(u32, @intCast(result.renames.count())));
     try std.testing.expectEqual(@as(usize, 1), result.phase_a.slot_count);
     try std.testing.expectEqual(@as(usize, 0), result.phase_a.renamed_symbol_count);
-}
-
-test "buildGlobalFrequencyRank: ref_count 내림차순 + 결정적 tie-break" {
-    const allocator = std.testing.allocator;
-    // ref_count: c=9, a=5, b=5(name tie → 'a'<'b'), d=5(mod tie-break), e=1
-    const cands = [_]TopLevelCandidate{
-        .{ .module_index = 0, .symbol_id = 10, .name = "bb", .ref_count = 5 },
-        .{ .module_index = 0, .symbol_id = 11, .name = "aa", .ref_count = 5 },
-        .{ .module_index = 0, .symbol_id = 12, .name = "zz", .ref_count = 9 },
-        .{ .module_index = 2, .symbol_id = 13, .name = "aa", .ref_count = 5 },
-        .{ .module_index = 0, .symbol_id = 14, .name = "qq", .ref_count = 1 },
-    };
-    var rank = try buildGlobalFrequencyRank(allocator, &cands);
-    defer rank.deinit();
-
-    // zz(rc9)=0; aa@mod0(rc5)=1; aa@mod2(rc5,mod tie)=2; bb(rc5)=3; qq(rc1)=4
-    try std.testing.expectEqual(@as(u32, 0), rank.get(.{ .module_index = 0, .symbol_id = 12 }).?);
-    try std.testing.expectEqual(@as(u32, 1), rank.get(.{ .module_index = 0, .symbol_id = 11 }).?);
-    try std.testing.expectEqual(@as(u32, 2), rank.get(.{ .module_index = 2, .symbol_id = 13 }).?);
-    try std.testing.expectEqual(@as(u32, 3), rank.get(.{ .module_index = 0, .symbol_id = 10 }).?);
-    try std.testing.expectEqual(@as(u32, 4), rank.get(.{ .module_index = 0, .symbol_id = 14 }).?);
-}
-
-test "buildGlobalFrequencyRank: 중복 (module,symbol) 은 최우선 rank 유지" {
-    const allocator = std.testing.allocator;
-    const cands = [_]TopLevelCandidate{
-        .{ .module_index = 1, .symbol_id = 7, .name = "xx", .ref_count = 2 },
-        .{ .module_index = 0, .symbol_id = 3, .name = "yy", .ref_count = 8 }, // 최다 → rank 0
-        .{ .module_index = 1, .symbol_id = 7, .name = "xx", .ref_count = 2 }, // 중복
-    };
-    var rank = try buildGlobalFrequencyRank(allocator, &cands);
-    defer rank.deinit();
-    try std.testing.expectEqual(@as(u32, 0), rank.get(.{ .module_index = 0, .symbol_id = 3 }).?);
-    try std.testing.expectEqual(@as(u32, 1), rank.get(.{ .module_index = 1, .symbol_id = 7 }).?);
-    try std.testing.expectEqual(@as(u32, 2), rank.count());
 }


### PR DESCRIPTION
RFC #3288 mangler size-gap 회수 경로 **c2 + M2 둘 다 측정 반증** 후 dead infra 정리.

## 반증 (실측)

| | main | c2 | M2 (freq 보존) |
|---|---|---|---|
| zod | 306815 | 310065 (+3.2KB) | 310065 (+3.2KB) |
| effect | 1036156 | 1097353 (+61KB) | 1100927 (**+64KB**) |
| rxjs | 67801 | 68055 | 68055 |

global_freq_rank 로 Phase A 전역 frequency 를 보존해도 c2 와 동일 회귀. 근본 = per-module Phase B slot pool 이 Phase A 단일 전역 counter 의 cross-module 이름 조정을 대체 불가. → "top-level→per-module Phase B" 경로 전체 재시도 금지 (메모리 기록).

## 제거 (전부 inert → byte-identical)

- `mangler.zig`: `precise_liveness`/`global_freq_rank` 필드, liveness precise 분기, `SlotSortEntry.global_rank`+min-rank pass+cmp rank 분기, 유닛 3
- `unified_mangler.zig`: `buildGlobalFrequencyRank`, `enable_shared_slot_pool`, 유닛 2
- **잔존**: `candidateLessThan` 추출 (Phase A sort 사용, 구 inline 과 byte-identical DRY)

315줄 삭제, dead 참조 0.

## 검증

- c2-직전 main 대비 `mangler.zig` diff **0줄** (정확 원형 복원)
- zig build test Debug+ReleaseFast **0 fail**
- zod/effect/rxjs 실번들 main **byte-identical** (306815/1036156/67801)
- /simplify 3-agent PASS

a/b/namespace (#3328/#3332), collision assert (#3327) 는 독립 valid — 영향 없음. zod/effect mangler 격차는 rolldown 식 chunk-재파싱(emit 아키텍처 전면)뿐이라 deferred 확정.

Refs #3288

🤖 Generated with [Claude Code](https://claude.com/claude-code)