### PR TITLE
feat(bundler): preserve-modules + CJS output (P3-A, #3321)

### DIFF
--- a/src/bundler/bundler_test/splitting_dev.zig
+++ b/src/bundler/bundler_test/splitting_dev.zig
@@ -247,7 +247,39 @@ test "CodeSplitting: CJS format returns error" {
 
 // preserveModules + non-ESM 은 별도 error name 으로 — code_splitting 미설정 사용자에게
 // "CodeSplittingRequiresESM" 가 misleading 이라 분기.
-test "PreserveModules: CJS format returns PreserveModulesRequiresESM" {
+test "PreserveModules: CJS format succeeds with require()/exports (P3-A #3321)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "dep.ts", "export const dep = 1;");
+    try writeFile(tmp.dir, "entry.ts", "import { dep } from './dep';\nexport const x = dep;");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var bnd = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .preserve_modules = true,
+        .format = .cjs,
+    });
+    defer bnd.deinit();
+    const result = try bnd.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+
+    // cross-module 결합은 ESM import 아닌 require(), export 는 exports.x
+    var has_require = false;
+    var has_exports = false;
+    for (outs) |o| {
+        if (std.mem.indexOf(u8, o.contents, "require(\"") != null or
+            std.mem.indexOf(u8, o.contents, "require('") != null) has_require = true;
+        if (std.mem.indexOf(u8, o.contents, "exports.") != null) has_exports = true;
+    }
+    try std.testing.expect(has_require);
+    try std.testing.expect(has_exports);
+}
+
+test "PreserveModules: IIFE format still returns PreserveModulesRequiresESM" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.ts", "export const x = 1;");
@@ -258,7 +290,7 @@ test "PreserveModules: CJS format returns PreserveModulesRequiresESM" {
     var bnd = Bundler.init(std.testing.allocator, .{
         .entry_points = &.{entry},
         .preserve_modules = true,
-        .format = .cjs,
+        .format = .iife,
     });
     defer bnd.deinit();
     const result = bnd.bundle();

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -62,14 +62,16 @@ pub fn emitChunks(
     linker: ?*Linker,
 ) ![]OutputFile {
     const module_count = graph.moduleCount();
-    // Code splitting / preserve-modules 모두 ESM 출력만 지원 — CJS/IIFE 에는 네이티브
-    // import() 가 없다. 두 경로가 같은 제약을 공유하지만 caller 가 켠 옵션에 맞는 error
-    // name 으로 분기 — preserveModules 만 켠 사용자에게 "CodeSplitting..." 에러는 misleading.
+    // code splitting 은 ESM 전용(네이티브 import() 필요). preserve-modules 는
+    // 모듈 1:1 파일이라 CJS 도 가능(Node 네이티브 require 가 경로로 해석, P3-A
+    // #3321). IIFE/UMD/AMD 는 아직 미지원.
     if (options.format != .esm) {
-        return if (options.preserve_modules)
-            error.PreserveModulesRequiresESM
-        else
-            error.CodeSplittingRequiresESM;
+        // emitChunks 내: preserve_modules=false → code splitting 경로(ESM 전용),
+        // preserve_modules=true → 모듈 1:1 파일(CJS 도 가능, 그 외 포맷 불가).
+        if (!options.preserve_modules)
+            return error.CodeSplittingRequiresESM;
+        if (options.format != .cjs)
+            return error.PreserveModulesRequiresESM;
     }
 
     // splitting / manualChunks 모드에서도 namespace import 의 object literal 을
@@ -247,6 +249,11 @@ pub fn emitChunks(
             alias_strs.deinit(allocator);
         }
 
+        // preserve-modules + CJS (P3-A): cross-module 결합을 ESM import 대신
+        // `const {x}=require("...")` / `require("...")` 로 (codegen 이 export 측은
+        // 이미 exports.x 로 CJS 화). 내부 모듈 본문은 그대로.
+        const pm_cjs = options.preserve_modules and options.format == .cjs;
+
         for (chunk.cross_chunk_imports.items) |dep_chunk_idx| {
             const dep_chunk = chunk_graph.getChunk(dep_chunk_idx);
             var dep_buf: [128]u8 = undefined;
@@ -267,9 +274,9 @@ pub fn emitChunks(
             if (symbols != null and symbols.?.items.len > 0) {
                 // 심볼 수준 import: import { a, b } from './chunk-xxx.js';
                 if (!options.minify_whitespace) {
-                    try chunk_output.appendSlice(allocator, "import { ");
+                    try chunk_output.appendSlice(allocator, if (pm_cjs) "const { " else "import { ");
                 } else {
-                    try chunk_output.appendSlice(allocator, "import{");
+                    try chunk_output.appendSlice(allocator, if (pm_cjs) "const{" else "import{");
                 }
                 // 결정론적 출력을 위해 심볼명 정렬
                 std.mem.sort([]const u8, symbols.?.items, {}, types.stringLessThan);
@@ -284,7 +291,7 @@ pub fn emitChunks(
                         const alias = try std.fmt.allocPrint(allocator, "{s}${d}", .{ name, seen });
                         try alias_strs.append(allocator, alias);
                         try chunk_output.appendSlice(allocator, name);
-                        try chunk_output.appendSlice(allocator, " as ");
+                        try chunk_output.appendSlice(allocator, if (pm_cjs) ": " else " as ");
                         try chunk_output.appendSlice(allocator, alias);
                     } else {
                         try chunk_output.appendSlice(allocator, name);
@@ -298,24 +305,24 @@ pub fn emitChunks(
                     }
                 }
                 if (!options.minify_whitespace) {
-                    try chunk_output.appendSlice(allocator, " } from \"");
+                    try chunk_output.appendSlice(allocator, if (pm_cjs) " } = require(\"" else " } from \"");
                     try chunk_output.appendSlice(allocator, resolved_path);
-                    try chunk_output.appendSlice(allocator, "\";\n");
+                    try chunk_output.appendSlice(allocator, if (pm_cjs) "\");\n" else "\";\n");
                 } else {
-                    try chunk_output.appendSlice(allocator, "}from\"");
+                    try chunk_output.appendSlice(allocator, if (pm_cjs) "}=require(\"" else "}from\"");
                     try chunk_output.appendSlice(allocator, resolved_path);
-                    try chunk_output.appendSlice(allocator, "\";");
+                    try chunk_output.appendSlice(allocator, if (pm_cjs) "\");" else "\";");
                 }
             } else {
                 // 심볼 정보 없음 → side-effect import (실행 순서 보장용)
                 if (!options.minify_whitespace) {
-                    try chunk_output.appendSlice(allocator, "import \"");
+                    try chunk_output.appendSlice(allocator, if (pm_cjs) "require(\"" else "import \"");
                     try chunk_output.appendSlice(allocator, resolved_path);
-                    try chunk_output.appendSlice(allocator, "\";\n");
+                    try chunk_output.appendSlice(allocator, if (pm_cjs) "\");\n" else "\";\n");
                 } else {
-                    try chunk_output.appendSlice(allocator, "import\"");
+                    try chunk_output.appendSlice(allocator, if (pm_cjs) "require(\"" else "import\"");
                     try chunk_output.appendSlice(allocator, resolved_path);
-                    try chunk_output.appendSlice(allocator, "\";");
+                    try chunk_output.appendSlice(allocator, if (pm_cjs) "\");" else "\";");
                 }
             }
         }

--- a/tests/integration/tests/preserve-modules-cjs.test.ts
+++ b/tests/integration/tests/preserve-modules-cjs.test.ts
@@ -1,0 +1,104 @@
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import { join } from 'node:path';
+import { createFixture } from './helpers';
+import { init, close, build } from '../../../packages/core/index';
+
+// P3-A (#3321): preserve-modules + format=cjs — 모듈 1:1 파일, cross-module
+// 결합은 require()/module.exports (Node 네이티브 require 가 경로로 해석).
+// code splitting 없음(전부 빌드타임 known). ESM preserve-modules / 단일
+// CJS 번들 경로는 불변(회귀).
+
+const byContent = (outs: { path: string; text: string }[], needle: string) =>
+  outs.find((o) => o.text.includes(needle));
+
+describe('preserve-modules + cjs (P3-A)', () => {
+  let cleanup: (() => Promise<void>) | undefined;
+  beforeAll(() => init());
+  afterAll(() => close());
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  const files = {
+    'dep.ts': `export const dep = "DEP_MARKER";`,
+    'index.ts': `import { dep } from "./dep";\nexport function main(){ return dep + "!"; }\nconsole.log(main());`,
+  };
+
+  test('모듈당 파일 분리 + cross-module require() + exports', async () => {
+    const fixture = await createFixture(files);
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      preserveModules: true,
+      format: 'cjs',
+    });
+    const outs = result.outputFiles!;
+    const js = outs.filter((o) => o.path.endsWith('.js'));
+    // 모듈 1:1 → index, dep 두 파일
+    expect(js.length).toBeGreaterThanOrEqual(2);
+
+    const idx = byContent(outs, 'function main');
+    const dep = byContent(outs, 'DEP_MARKER');
+    expect(idx).toBeDefined();
+    expect(dep).toBeDefined();
+
+    // index: cross-module 는 ESM import 아닌 require()
+    expect(idx!.text).toContain('require("');
+    expect(idx!.text).not.toMatch(/^\s*import\s/m);
+    expect(idx!.text).toContain('exports.main');
+    // dep: CJS export
+    expect(dep!.text).toContain('exports.dep');
+    expect(dep!.text).not.toMatch(/^\s*export\s/m);
+  });
+
+  test('minify + side-effect import: require("..."); 가 닫힘(괄호 누락 없음)', async () => {
+    const fixture = await createFixture({
+      'side.ts': `console.log("SIDE_FX");`,
+      'index.ts': `import "./side";\nexport const ok = 1;`,
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      preserveModules: true,
+      format: 'cjs',
+      minifyWhitespace: true,
+    });
+    const idx = byContent(result.outputFiles!, 'exports.ok')!;
+    expect(idx).toBeDefined();
+    // side-effect require 가 well-formed: require("...."); (괄호+세미콜론)
+    expect(idx.text).toMatch(/require\("[^"]+"\);/);
+    // 잘못된 형태 require("...."; (괄호 누락) 가 없어야 함
+    expect(idx.text).not.toMatch(/require\("[^"]+";/);
+  });
+
+  test('회귀: preserve-modules + esm 는 ESM import/export 그대로', async () => {
+    const fixture = await createFixture(files);
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      preserveModules: true,
+      format: 'esm',
+    });
+    const outs = result.outputFiles!;
+    const idx = byContent(outs, 'function main')!;
+    expect(idx.text).toMatch(/import\s*\{\s*dep\s*\}\s*from/);
+    expect(idx.text).not.toContain('require("');
+  });
+
+  test('회귀: 단일 CJS 번들(preserve-modules 아님)은 불변', async () => {
+    const fixture = await createFixture(files);
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      format: 'cjs',
+    });
+    const outs = result.outputFiles!;
+    // 단일 번들 — DEP_MARKER 와 main 이 한 파일에
+    const single = byContent(outs, 'DEP_MARKER')!;
+    expect(single).toBeDefined();
+    expect(single.text).toContain('function main');
+  });
+});


### PR DESCRIPTION
## 요약

RFC `docs/RFC_CJS_IIFE_CODE_SPLITTING.md` 의 **P3-A**(최소 슬라이스, #3321): `preserve-modules` 에서 **format=cjs** 출력 허용. 모듈 1:1 파일 + cross-module 결합을 ESM import 대신 `const {x}=require("./p.js")` / `require("./p.js")` 로 emit. export 측은 codegen 이 이미 `exports.x` 로 CJS 화(실측: Node 실행 `DEP!` 성공). **커스텀 레지스트리 불필요** — Node 네이티브 require 가 경로 해석(Rollup `--format cjs --preserve-modules` 와 동일). code splitting 은 여전히 ESM 전용, IIFE/UMD/AMD 미지원.

## 변경

- `chunks.zig` ESM-only 가드 정정: format!=esm 시 — splitting(preserve_modules=false)→`CodeSplittingRequiresESM`, preserve_modules+cjs→통과, preserve_modules+그외포맷→`PreserveModulesRequiresESM`.
- cross-chunk import 4개 emit 지점 `pm_cjs` 분기(심볼 require 구조분해 `name: alias`, side-effect `require("…");`).
- `/simplify` 발견 **실버그 수정**: minify side-effect 닫기에서 cjs `)` 누락(`require("p";` → `require("p");`) + 회귀 테스트.

## 테스트

- 통합 `preserve-modules-cjs.test.ts`: 모듈분리·require·exports / ESM 회귀 / 단일 CJS 회귀 / minify side-effect well-formed.
- **기존 단위 테스트 갱신**: `splitting_dev.zig` 의 "PreserveModules: CJS → PreserveModulesRequiresESM"(옛 동작 박제)를 P3-A 새 동작(require/exports 성공)으로 교체 + IIFE 거부 경로 테스트 추가(누수도 그 옛-에러-경로 테스트가 성공경로 미정리한 탓 → 해소).
- 검증: **`zig build test` EXIT=0 전체 통과** · 통합 P3-A+청크/CSS/P1 회귀 GREEN · app-builder styles 14/14 · e2e · smoke 무회귀 · `/simplify` 3-에이전트 반영.

## 비고 (정직)

초장기 세션 중 `zig build test` 에서 `parser ast_walk`/`mainServer panic`/leaked 가 1↔26 가변으로 간헐 발생 — Zig 병렬 테스트 하네스의 환경적 불안정. 그 노이즈에 가려 있던 **진짜 결정적 실패는 `splitting_dev` 옛-동작 테스트**였고(pre-push 훅이 정확히 포착), 본 PR 에서 갱신 후 클린런 EXIT=0 확인.

Refs #3321 · RFC `docs/RFC_CJS_IIFE_CODE_SPLITTING.md` P3-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
