### PR TITLE
feat(bundler): P3-B CJS code splitting emit 연결 (#3321)

### DIFF
--- a/docs/RFC_CJS_IIFE_CODE_SPLITTING.md
+++ b/docs/RFC_CJS_IIFE_CODE_SPLITTING.md
@@ -131,7 +131,8 @@ P3-A 를 먼저(작고 안전, esbuild 도 안 하는 영역의 최소 가치), 
 | PR | 내용 | 상태 |
 |---|---|---|
 | **P3-B PR1** | 하위 인프라만 — `module_id.zig`(relative-path 안정 ID) + `runtime_helpers.zig` 레지스트리 상수(`__zntc_mods`/`__zntc_require`/`__zntc_register`/`__zntc_load_chunk`, normal+min). 유닛테스트. emit 미연결·가드 불변(무동작 회귀 0). **MF §4.1 공유 계층** | 본 PR |
-| **P3-B PR2** | emit 연결 — 가드 완화(`format==.cjs`+splitting), 비-엔트리 청크 self-register wrapper, cross-chunk static require 재작성, `import()`→`__zntc_load_chunk(...).then(()=>__zntc_require(id))`, 엔트리 레지스트리 프렐류드 주입. integration/e2e/smoke | 후속 |
+| **P3-B PR2** | emit 연결(CJS) — 가드 완화(`format==.cjs`+splitting), cross-chunk static→`const{x}=require("./chunk.js")`, common 청크 CJS `exports.x`(emitCjsEntryExports 미도달 보완), `import()`→`Promise.resolve().then(()=>require("./chunk.js"))`. **CJS/Node 는 네이티브 require 가 곧 레지스트리**(RFC §4.3) — PR1 의 `__zntc_*` 레지스트리는 IIFE/MF 추상 로더 계층(PR3)으로 미사용 대기. Node 실행 검증(통합 테스트), pm_cjs/ESM/smoke 무회귀 | **완료** |
+| **P3-B PR3** | IIFE/UMD: `__zntc_*` 레지스트리 활성화 + self-register wrapper + 브라우저 청크 로더(script 주입/조건부 import()). cjs 의 native-require 가 없는 환경 | 후속 |
 
 ---
 
@@ -151,6 +152,7 @@ P3-A 를 먼저(작고 안전, esbuild 도 안 하는 영역의 최소 가치), 
 - **[결정됨 2026-05-16] 모듈 ID 스킴 = relative-path 기반.** content-hash·숫자 인덱스 대비: 디버깅/스택트레이스 가독성, MF expose 키 자연 호환, 빌드 결정성, 내용 변경에도 ID 불변(MF 계약 핀 안정). MF RFC §4.1/§6.1(모듈 안정 런타임 ID) 과 **공동 결정** — 동일 `module_id.zig` 공유. (트레이드오프: 소스 디렉터리 구조가 ID 로 노출 — 수용.)
 - IIFE 동적 로더의 브라우저 청크 fetch 방식(script 주입 vs 조건부 import()) — public_path/CSP 영향. (P3-B PR2 이후 IIFE 단계에서 결정.)
 - preserve-modules CJS 의 Node `__esModule`/interop 경계(default/namespace).
+- **[선재 한계, P3-B 비회귀]** cross-chunk re-export(`export { x } from "./y"` 에서 y 가 별도 청크)는 splitting 파이프라인에서 깨짐 — referrer 가 side-effect import 만 받고 심볼 미바인딩(ReferenceError). **ESM splitting 도 동일하게 깨짐**(P3-B 가 그 동작을 충실히 미러). P3-B 도입 버그 아님 — splitting linker 의 re-export forwarding 갭. cjs/esm 공통 후속 과제(별도 이슈). P3-B CJS 범위 = ESM splitting 패리티(정적 cross-chunk 심볼 import·default/named 동적 import 는 Node 실행 검증됨).
 - P3-A 가치 대비 비용: esbuild 미지원 영역. 수요(누가 CJS/IIFE+splitting 을 원하나) 확인 후 P3-B 착수 여부 게이트.
 
 ---

--- a/src/bundler/bundler_test/splitting_dev.zig
+++ b/src/bundler/bundler_test/splitting_dev.zig
@@ -225,7 +225,44 @@ test "CodeSplitting: multiple common chunks have unique filenames" {
     }
 }
 
-test "CodeSplitting: CJS format returns error" {
+test "CodeSplitting: CJS format succeeds — cross-chunk require + 동적 require (P3-B #3321)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    // entry 가 lazy 를 동적 import → 별도 청크. shared 는 정적 cross-chunk.
+    try writeFile(tmp.dir, "shared.ts", "export const s = 'S';");
+    try writeFile(tmp.dir, "lazy.ts", "import { s } from './shared';\nexport const lazy = s;");
+    try writeFile(tmp.dir, "entry.ts", "import { s } from './shared';\nconst x = import('./lazy');\nconsole.log(s, x);");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var bnd = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .code_splitting = true,
+        .format = .cjs,
+    });
+    defer bnd.deinit();
+    // P3-B: CJS + code_splitting 은 더 이상 에러 아님 — 네이티브 require 가
+    // 청크 경계 해석(RFC §4.3). 옛 동작("returns error") 무효화.
+    const result = try bnd.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+
+    var has_xchunk_require = false;
+    var has_dyn_require = false;
+    for (outs) |o| {
+        if (std.mem.indexOf(u8, o.contents, "= require(\"") != null) has_xchunk_require = true;
+        if (std.mem.indexOf(u8, o.contents, "Promise.resolve().then(()=>require(\"") != null) has_dyn_require = true;
+        // CJS 청크에 ESM import/export 누출 금지(Node 가 .js 를 CJS 로 로드).
+        try std.testing.expect(std.mem.indexOf(u8, o.contents, "\nexport {") == null);
+        try std.testing.expect(std.mem.indexOf(u8, o.contents, "\nimport {") == null);
+    }
+    try std.testing.expect(has_xchunk_require);
+    try std.testing.expect(has_dyn_require);
+}
+
+test "CodeSplitting: IIFE format still returns CodeSplittingRequiresESM" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.ts", "const x = import('./lazy');\nconsole.log(x);");
@@ -237,10 +274,10 @@ test "CodeSplitting: CJS format returns error" {
     var bnd = Bundler.init(std.testing.allocator, .{
         .entry_points = &.{entry},
         .code_splitting = true,
-        .format = .cjs,
+        .format = .iife,
     });
     defer bnd.deinit();
-    // CJS + code_splitting은 에러
+    // iife/umd/amd 는 네이티브 require/import 없음 → PR3 까지 미지원(가드 유지).
     const result = bnd.bundle();
     try std.testing.expect(result == error.CodeSplittingRequiresESM);
 }

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -66,12 +66,16 @@ pub fn emitChunks(
     // 모듈 1:1 파일이라 CJS 도 가능(Node 네이티브 require 가 경로로 해석, P3-A
     // #3321). IIFE/UMD/AMD 는 아직 미지원.
     if (options.format != .esm) {
-        // emitChunks 내: preserve_modules=false → code splitting 경로(ESM 전용),
-        // preserve_modules=true → 모듈 1:1 파일(CJS 도 가능, 그 외 포맷 불가).
-        if (!options.preserve_modules)
-            return error.CodeSplittingRequiresESM;
-        if (options.format != .cjs)
-            return error.PreserveModulesRequiresESM;
+        // ESM: 네이티브 import() 로 청크 경계 해석.
+        // CJS: P3-A=preserve-modules(모듈 1:1 파일), P3-B=splitting(네이티브
+        //   require 가 청크 경계 해석 — RFC_CJS_IIFE_CODE_SPLITTING.md §4.3).
+        // IIFE/UMD/AMD: 아직 미지원(네이티브 require/import 없음 — PR3).
+        if (options.format != .cjs) {
+            return if (options.preserve_modules)
+                error.PreserveModulesRequiresESM
+            else
+                error.CodeSplittingRequiresESM;
+        }
     }
 
     // splitting / manualChunks 모드에서도 namespace import 의 object literal 을
@@ -249,10 +253,15 @@ pub fn emitChunks(
             alias_strs.deinit(allocator);
         }
 
-        // preserve-modules + CJS (P3-A): cross-module 결합을 ESM import 대신
-        // `const {x}=require("...")` / `require("...")` 로 (codegen 이 export 측은
-        // 이미 exports.x 로 CJS 화). 내부 모듈 본문은 그대로.
+        // CJS 청크 경계 결합을 ESM import 대신 `const {x}=require("...")` /
+        // `require("...")` 로 (export 측은 P3-A=모듈별 exports.x / P3-B=Edit 3
+        // 의 cross-chunk exports.x). 내부 모듈 본문은 호이스팅 그대로.
+        // - pm_cjs (P3-A): preserve-modules+cjs, resolved_path=상대경로
+        // - cjs_split (P3-B): cjs+splitting, resolved_path=청크 stem
+        //   (둘 다 Node 네이티브 require 가 정적 string 으로 해석).
         const pm_cjs = options.preserve_modules and options.format == .cjs;
+        const cjs_split = options.format == .cjs and !options.preserve_modules;
+        const cjs_require = pm_cjs or cjs_split;
 
         for (chunk.cross_chunk_imports.items) |dep_chunk_idx| {
             const dep_chunk = chunk_graph.getChunk(dep_chunk_idx);
@@ -274,9 +283,9 @@ pub fn emitChunks(
             if (symbols != null and symbols.?.items.len > 0) {
                 // 심볼 수준 import: import { a, b } from './chunk-xxx.js';
                 if (!options.minify_whitespace) {
-                    try chunk_output.appendSlice(allocator, if (pm_cjs) "const { " else "import { ");
+                    try chunk_output.appendSlice(allocator, if (cjs_require) "const { " else "import { ");
                 } else {
-                    try chunk_output.appendSlice(allocator, if (pm_cjs) "const{" else "import{");
+                    try chunk_output.appendSlice(allocator, if (cjs_require) "const{" else "import{");
                 }
                 // 결정론적 출력을 위해 심볼명 정렬
                 std.mem.sort([]const u8, symbols.?.items, {}, types.stringLessThan);
@@ -291,7 +300,7 @@ pub fn emitChunks(
                         const alias = try std.fmt.allocPrint(allocator, "{s}${d}", .{ name, seen });
                         try alias_strs.append(allocator, alias);
                         try chunk_output.appendSlice(allocator, name);
-                        try chunk_output.appendSlice(allocator, if (pm_cjs) ": " else " as ");
+                        try chunk_output.appendSlice(allocator, if (cjs_require) ": " else " as ");
                         try chunk_output.appendSlice(allocator, alias);
                     } else {
                         try chunk_output.appendSlice(allocator, name);
@@ -305,24 +314,24 @@ pub fn emitChunks(
                     }
                 }
                 if (!options.minify_whitespace) {
-                    try chunk_output.appendSlice(allocator, if (pm_cjs) " } = require(\"" else " } from \"");
+                    try chunk_output.appendSlice(allocator, if (cjs_require) " } = require(\"" else " } from \"");
                     try chunk_output.appendSlice(allocator, resolved_path);
-                    try chunk_output.appendSlice(allocator, if (pm_cjs) "\");\n" else "\";\n");
+                    try chunk_output.appendSlice(allocator, if (cjs_require) "\");\n" else "\";\n");
                 } else {
-                    try chunk_output.appendSlice(allocator, if (pm_cjs) "}=require(\"" else "}from\"");
+                    try chunk_output.appendSlice(allocator, if (cjs_require) "}=require(\"" else "}from\"");
                     try chunk_output.appendSlice(allocator, resolved_path);
-                    try chunk_output.appendSlice(allocator, if (pm_cjs) "\");" else "\";");
+                    try chunk_output.appendSlice(allocator, if (cjs_require) "\");" else "\";");
                 }
             } else {
                 // 심볼 정보 없음 → side-effect import (실행 순서 보장용)
                 if (!options.minify_whitespace) {
-                    try chunk_output.appendSlice(allocator, if (pm_cjs) "require(\"" else "import \"");
+                    try chunk_output.appendSlice(allocator, if (cjs_require) "require(\"" else "import \"");
                     try chunk_output.appendSlice(allocator, resolved_path);
-                    try chunk_output.appendSlice(allocator, if (pm_cjs) "\");\n" else "\";\n");
+                    try chunk_output.appendSlice(allocator, if (cjs_require) "\");\n" else "\";\n");
                 } else {
-                    try chunk_output.appendSlice(allocator, if (pm_cjs) "require(\"" else "import\"");
+                    try chunk_output.appendSlice(allocator, if (cjs_require) "require(\"" else "import\"");
                     try chunk_output.appendSlice(allocator, resolved_path);
-                    try chunk_output.appendSlice(allocator, if (pm_cjs) "\");" else "\";");
+                    try chunk_output.appendSlice(allocator, if (cjs_require) "\");" else "\";");
                 }
             }
         }
@@ -514,7 +523,7 @@ pub fn emitChunks(
         // 다른 청크가 이 청크에서 심볼을 가져가는 경우에만 출력.
         // preserve-modules에서는 모듈 자체의 export가 유지되므로 cross-chunk export 불필요.
         // linker가 심볼을 rename한 경우 export { local_name as export_name } 형태로 출력.
-        if ((chunk.exports_to.count() > 0 or rbm_export_names.items.len > 0) and !options.preserve_modules) {
+        if ((chunk.exports_to.count() > 0 or rbm_export_names.items.len > 0) and !options.preserve_modules) xchunk_exports: {
             // 결정론적 출력을 위해 이름을 정렬
             var export_names: std.ArrayList([]const u8) = .empty;
             defer export_names.deinit(allocator);
@@ -527,10 +536,26 @@ pub fn emitChunks(
             }
             std.mem.sort([]const u8, export_names.items, {}, types.stringLessThan);
 
-            if (!options.minify_whitespace) {
-                try chunk_output.appendSlice(allocator, "export { ");
-            } else {
-                try chunk_output.appendSlice(allocator, "export{");
+            // cjs(P3-A pm / P3-B splitting): 청크가 .js 로 require 되므로
+            // ESM `export {}` 를 emit 하면 Node 가 CJS 로 로드 → SyntaxError.
+            //  - common/manual 청크(entry 모듈 없음): emitCjsEntryExports 가
+            //    안 도므로 cross-chunk 노출 수단이 이 경로뿐 → `exports.x=local;`.
+            //  - entry/dynamic 청크(entry_mod_idx != null): entry 모듈 exports
+            //    를 emitCjsEntryExports 가 이미 `exports.x`(default/__esModule
+            //    interop 포함)로 깔며, cross-chunk 소비자도 그 동일 객체를
+            //    require 로 읽음 → 여기서 또 emit 하면 이중정의·module.exports=
+            //    재대입 손상·re-export local 미바인딩(ReferenceError). 따라서
+            //    **emit 생략**(emitCjsEntryExports 에 일임)이 정확.
+            const cjs_fmt = options.format == .cjs;
+            if (cjs_fmt and entry_mod_idx != null) break :xchunk_exports;
+            const cjs_x = cjs_fmt;
+
+            if (!cjs_x) {
+                if (!options.minify_whitespace) {
+                    try chunk_output.appendSlice(allocator, "export { ");
+                } else {
+                    try chunk_output.appendSlice(allocator, "export{");
+                }
             }
             for (export_names.items, 0..) |name, ni| {
                 // export_name의 원본 심볼이 이 청크에서 rename되었는지 확인.
@@ -558,6 +583,16 @@ pub fn emitChunks(
                     break :blk found_local orelse name;
                 } else name;
 
+                if (cjs_x) {
+                    // exports.<name> = <local>;  (min: 공백 제거, 형태 동일)
+                    try chunk_output.appendSlice(allocator, "exports.");
+                    try chunk_output.appendSlice(allocator, name);
+                    try chunk_output.appendSlice(allocator, if (options.minify_whitespace) "=" else " = ");
+                    try chunk_output.appendSlice(allocator, local_name);
+                    try chunk_output.appendSlice(allocator, if (options.minify_whitespace) ";" else ";\n");
+                    continue;
+                }
+
                 try chunk_output.appendSlice(allocator, local_name);
                 // local_name과 export_name이 다르면 as 절 추가
                 if (!std.mem.eql(u8, local_name, name)) {
@@ -572,10 +607,12 @@ pub fn emitChunks(
                     }
                 }
             }
-            if (!options.minify_whitespace) {
-                try chunk_output.appendSlice(allocator, " };\n");
-            } else {
-                try chunk_output.appendSlice(allocator, "};");
+            if (!cjs_x) {
+                if (!options.minify_whitespace) {
+                    try chunk_output.appendSlice(allocator, " };\n");
+                } else {
+                    try chunk_output.appendSlice(allocator, "};");
+                }
             }
         }
 
@@ -1061,6 +1098,23 @@ fn rewriteDynamicImports(
         else
             try std.fmt.allocPrint(allocator, "./{s}{s}", .{ stem, out_ext });
         defer allocator.free(replacement);
+
+        // cjs+splitting(P3-B): 네이티브 import() 가 없으므로 호출 전체를
+        //   Promise.resolve().then(()=>require("./chunk.js"))
+        // 로 재작성(RFC §4.3, 디리스크 스파이크 검증). 대상 청크는 dynamic
+        // entry 라 emitCjsEntryExports 가 exports.x 를 깔아둠 → require() 결과가
+        // 곧 namespace. require 캐시가 재호출 시 상태 보존(스파이크 count 검증).
+        // ESM 은 specifier 만 청크 파일명으로 치환(네이티브 import() 유지).
+        const cjs_split = emit_options.format == .cjs and !emit_options.preserve_modules;
+        if (cjs_split) {
+            const wrapper = try std.fmt.allocPrint(allocator, "Promise.resolve().then(()=>require(\"{s}\"))", .{replacement});
+            defer allocator.free(wrapper);
+            if (try rewriteImportCallToWrapper(allocator, result, rec.specifier, wrapper)) |new_result| {
+                allocator.free(result);
+                result = new_result;
+            }
+            continue;
+        }
 
         // 코드에서 원본 specifier를 찾아 교체
         if (std.mem.indexOf(u8, result, rec.specifier)) |pos| {

--- a/tests/integration/tests/cjs-code-splitting.test.ts
+++ b/tests/integration/tests/cjs-code-splitting.test.ts
@@ -1,0 +1,155 @@
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import { join } from 'node:path';
+import { createFixture, runNode, byContent, writeOutputs } from './helpers';
+import { init, close, build } from '../../../packages/core/index';
+
+// P3-B (#3321): format=cjs + splitting=true — 진짜 code splitting.
+// 디리스크 스파이크(RFC §6)가 Node CJS 에서 증명한 행동을 빌더 산출물로 영구화:
+//   (1) 가드 완화 — cjs+splitting 이 더 이상 CodeSplittingRequiresESM 아님
+//   (2) 정적 cross-chunk → require() (ESM import 아님)
+//   (3) 동적 import → 별도 청크 파일 + 런타임 로드
+//   (4) Node 에서 실제 실행 시 cross-chunk + 동적 로드 + 캐시 보존 동작
+// ESM splitting / 단일 CJS 번들 / preserve-modules+cjs(P3-A)는 불변(회귀).
+
+describe('cjs + code splitting (P3-B)', () => {
+  let cleanup: (() => Promise<void>) | undefined;
+  beforeAll(() => init());
+  afterAll(() => close());
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  test('가드 완화: cjs + splitting 이 에러 아님', async () => {
+    const fixture = await createFixture({
+      'index.ts': `
+        export async function load() { return (await import("./page")).render(); }
+        load().then((r) => console.log("R:" + r));
+      `,
+      'page.ts': `import { label } from "./shared";\nexport function render(){ return label; }`,
+      'shared.ts': `export const label = "SHARED_OK";`,
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      format: 'cjs',
+      splitting: true,
+    });
+    expect(result.outputFiles).toBeDefined();
+    const js = result.outputFiles!.filter((o) => o.path.endsWith('.js'));
+    // 동적 import → 최소 2개 청크(entry + dyn page)
+    expect(js.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('스파이크 시나리오: 정적 cross-chunk + 동적 청크 로드가 Node 에서 동작', async () => {
+    const fixture = await createFixture({
+      'index.ts': `
+        import { bump, label } from "./shared";
+        async function main() {
+          const out = [];
+          out.push("static:" + label + ":" + bump());      // shared count=1
+          const page = await import("./page");
+          out.push("dynamic:" + page.render());             // count=2
+          out.push("again:" + page.render());               // count=3 (캐시)
+          console.log(out.join("\\n"));
+        }
+        main();
+      `,
+      // shared 는 entry + page 양쪽에서 import → common 청크. 상태(count) 보존 검증.
+      'shared.ts': `let count = 0;\nexport function bump(){ return ++count; }\nexport const label = "S";`,
+      'page.ts': `import { bump, label } from "./shared";\nexport function render(){ return label + ":" + bump(); }`,
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      format: 'cjs',
+      splitting: true,
+    });
+    const outs = result.outputFiles!;
+    writeOutputs(
+      fixture.dir,
+      outs.map((o) => ({ path: o.path, text: o.text })),
+    );
+
+    const entry = outs.find((o) => o.path.includes('index') && o.path.endsWith('.js'))!;
+    expect(entry).toBeDefined();
+    // 정적 cross-chunk 결합은 ESM import 가 아니라 require/__zntc_require 경유
+    expect(entry.text).not.toMatch(/^\s*import\s+[\{*]/m);
+
+    const { stdout } = await runNode(join(fixture.dir, entry.path));
+    expect(stdout).toBe(['static:S:1', 'dynamic:S:2', 'again:S:3'].join('\n'));
+  });
+
+  test('default + named export 를 동적 import (entry/dynamic 청크는 emitCjsEntryExports 일임)', async () => {
+    // gated form 회귀 가드: dynamic 청크는 entry 모듈이 있어 cross-chunk
+    // export 블록을 건너뛰고 emitCjsEntryExports 만 → default/__esModule
+    // interop 정확. (이중 emit·module.exports= 손상 #3 방지)
+    const fixture = await createFixture({
+      'index.ts': `
+        import { bump } from "./shared";
+        async function main() {
+          const o = [];
+          o.push("st:" + bump());
+          const p = await import("./page");
+          o.push("def:" + p.default());
+          o.push("tag:" + p.tag);
+          o.push("again:" + p.default());
+          console.log(o.join("|"));
+        }
+        main();
+      `,
+      'shared.ts': `let c = 0;\nexport function bump(){ return ++c; }`,
+      'page.ts': `import { bump } from "./shared";\nexport default function(){ return "D" + bump(); }\nexport const tag = "PG";`,
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      format: 'cjs',
+      splitting: true,
+    });
+    const outs = result.outputFiles!;
+    writeOutputs(fixture.dir, outs);
+    const page = outs.find((o) => o.path.includes('page') && o.path.endsWith('.js'))!;
+    // dynamic 청크는 CJS interop: exports.default + __esModule, ESM export 없음
+    expect(page.text).toContain('exports.default');
+    expect(page.text).toContain('__esModule');
+    expect(page.text).not.toMatch(/^\s*export[\s{]/m);
+
+    const entry = outs.find((o) => o.path.includes('index') && o.path.endsWith('.js'))!;
+    const { stdout } = await runNode(join(fixture.dir, entry.path));
+    expect(stdout).toBe('st:1|def:D2|tag:PG|again:D3');
+  });
+
+  test('회귀: esm + splitting 은 native import() 그대로', async () => {
+    const fixture = await createFixture({
+      'index.ts': `export async function load(){ return (await import("./d")).v; }`,
+      'd.ts': `export const v = 1;`,
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      format: 'esm',
+      splitting: true,
+    });
+    const idx = byContent(result.outputFiles!, 'load')!;
+    expect(idx.text).not.toContain('__zntc_load_chunk');
+    expect(idx.text).not.toContain('require(');
+  });
+
+  test('회귀: 단일 CJS 번들(splitting 아님)은 불변', async () => {
+    const fixture = await createFixture({
+      'dep.ts': `export const dep = "DEP_X";`,
+      'index.ts': `import { dep } from "./dep";\nconsole.log(dep);`,
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      format: 'cjs',
+    });
+    const single = byContent(result.outputFiles!, 'DEP_X')!;
+    expect(single).toBeDefined();
+    expect(single.text).not.toContain('__zntc_load_chunk');
+  });
+});

--- a/tests/integration/tests/helpers.ts
+++ b/tests/integration/tests/helpers.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'bun';
 import { mkdtemp, rm, writeFile, mkdir, symlink, stat } from 'node:fs/promises';
-import { readFileSync, statSync, openSync, closeSync } from 'node:fs';
+import { readFileSync, statSync, openSync, closeSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, relative, resolve } from 'node:path';
 
@@ -487,5 +487,21 @@ export async function bundleAndRun(
   } catch (e) {
     await cleanup();
     throw e;
+  }
+}
+
+// ─── outputFiles 검사/기록 공용 헬퍼 ───
+
+/** outputFiles 에서 특정 문자열을 포함하는 첫 산출물. */
+export const byContent = <T extends { text: string }>(outs: T[], needle: string): T | undefined =>
+  outs.find((o) => o.text.includes(needle));
+
+/** outputFiles 를 dir 에 경로 보존(중첩 디렉터리 생성)하여 기록. 멀티-청크
+ *  번들을 `runNode` 로 실제 실행 검증할 때 사용. */
+export function writeOutputs(dir: string, outs: { path: string; text: string }[]): void {
+  for (const o of outs) {
+    const abs = join(dir, o.path);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, o.text);
   }
 }

--- a/tests/integration/tests/preserve-modules-cjs.test.ts
+++ b/tests/integration/tests/preserve-modules-cjs.test.ts
@@ -1,15 +1,12 @@
 import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
 import { join } from 'node:path';
-import { createFixture } from './helpers';
+import { createFixture, byContent } from './helpers';
 import { init, close, build } from '../../../packages/core/index';
 
 // P3-A (#3321): preserve-modules + format=cjs — 모듈 1:1 파일, cross-module
 // 결합은 require()/module.exports (Node 네이티브 require 가 경로로 해석).
 // code splitting 없음(전부 빌드타임 known). ESM preserve-modules / 단일
 // CJS 번들 경로는 불변(회귀).
-
-const byContent = (outs: { path: string; text: string }[], needle: string) =>
-  outs.find((o) => o.text.includes(needle));
 
 describe('preserve-modules + cjs (P3-A)', () => {
   let cleanup: (() => Promise<void>) | undefined;


### PR DESCRIPTION
## 개요

#3321 **P3-B PR2** — `format=cjs` + `splitting=true` (진짜 code splitting)를 emit 경로에 연결. **PR1(#3344, 머지됨)** 의 하위 인프라 위에 올라가며, **CJS/Node 는 네이티브 `require` 가 곧 레지스트리**(RFC §4.3)라 PR1 의 `__zntc_*` 레지스트리는 IIFE/MF 추상 로더(PR3)용으로 미사용 대기.

디리스크 스파이크(RFC §6, PASS)가 Node CJS 에서 증명한 행동을 빌더 산출물로 영구화.

## 변경 (chunks.zig 4지점)

1. **가드 완화** (`:65`): `cjs+splitting` 허용. `iife/umd/amd` 는 여전 `CodeSplittingRequiresESM` (네이티브 require/import 없음 — PR3). `cjs+preserve`(P3-A) 불변.
2. **`cjs_require = pm_cjs ∪ cjs_split`**: cross-chunk static import → `const {x}=require("./chunk.js")` / side-effect `require(...)`. pm_cjs 4지점 재사용, `resolved_path`=청크 stem.
3. **common/manual 청크 cross-chunk export → CJS `exports.x=local;`** (entry 모듈 없어 `emitCjsEntryExports` 미도달, 유일 노출 수단). **entry/dynamic 청크는 `emitCjsEntryExports` 에 일임** — `/simplify` 3-에이전트가 이중 emit·`module.exports=` 손상·re-export 미바인딩(#3 critical)을 잡아 **gated form**(`entry_mod_idx == null`)으로 수정.
4. **`rewriteDynamicImports`**: cjs_split 시 cross-chunk `import()` → `Promise.resolve().then(()=>require("./chunk.js"))`. require 캐시가 상태 보존(스파이크 count 1→2→3).

## 산출물 (실제)

```
// index.js
const { bump, label } = require("./chunk-4e05c6cc.js");
... await Promise.resolve().then(()=>require("./page.js"));
// chunk-4e05c6cc.js (common/shared)
let count = 0; function bump(){...} const label = "S";
exports.bump = bump; exports.label = label;
// page.js (dynamic, emitCjsEntryExports interop)
const { bump, label } = require("./chunk-4e05c6cc.js");
function render(){...}  exports.default = render; exports.tag = tag;
Object.defineProperty(exports, "__esModule", {value: true});
```

## 테스트
- `zig build test`: **5182/5186 pass, 4 skip, 0 fail** (splitting_dev: 옛 "CJS returns error"→"CJS succeeds" 갱신 + IIFE 가드 유지 테스트 추가)
- 통합 `cjs-code-splitting.test.ts`(신규): 가드/스파이크 시나리오 **Node 실행**/default+named 동적 import/ESM·단일CJS 회귀 — pm·esm splitting 포함 **9 pass 0 fail**
- app-builder CLI `bin/zntc.test.ts -t styles`: **14 pass 0 fail**
- smoke: **3/3 esbuild baseline MATCH** (ESM 무회귀)
- `byContent`·`writeOutputs` → `helpers.ts` 공용화(preserve-modules-cjs 중복 제거)

## 알려진 한계 (P3-B 비회귀)
- cross-chunk **re-export** (`export {x} from "./y"`, y 별도 청크): referrer 가 심볼 미바인딩(ReferenceError). **ESM splitting 도 동일하게 깨짐** — splitting linker 의 re-export forwarding 갭(P3-B 도입 아님). cjs/esm 공통 후속 과제(RFC §7 기록).
- `__zntc_*` 레지스트리: IIFE/MF 미사용 대기 → **P3-B PR3**(IIFE/UMD: 레지스트리 활성화 + self-register wrapper + 브라우저 로더).

RFC `docs/RFC_CJS_IIFE_CODE_SPLITTING.md` §4.2/§4.3/§5/§7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)