### PR TITLE
perf(transformer): compact private-field postfix update in statement context

### DIFF
--- a/src/transformer/transformer/node_helpers.zig
+++ b/src/transformer/transformer/node_helpers.zig
@@ -134,10 +134,37 @@ pub fn attachRootScopeSymbolByName(self: anytype, node_idx: NodeIndex, name: []c
 /// 단항 노드: operand를 재귀 방문 후 복사.
 pub fn visitUnaryNode(self: anytype, idx: NodeIndex) Error!NodeIndex {
     const node = self.ast.getNode(idx);
-    const old_operand = node.data.unary.operand;
+    var old_operand = node.data.unary.operand;
+
+    // statement context(`this.#x++;`)는 postfix 반환값이 폐기되므로 prefix 와
+    // 의미 동일. private-field 다운레벨이 활성일 때 postfix→prefix 정규화하면
+    // `(_t=get(),set(_t+1),_t)` 3-part 시퀀스 대신 compact `set(get()+1)` 로
+    // lowering (lru-cache@es2021 등 private-heavy es2021 size 회수, 의미 보존).
+    if (node.tag == .expression_statement and
+        (self.options.unsupported.class or self.options.unsupported.class_private_field))
+    {
+        const opn = self.ast.getNode(old_operand);
+        if (opn.tag == .update_expression) {
+            const ue = opn.data.extra;
+            if (ue + 1 < self.ast.extra_data.items.len) {
+                const inner_idx = readNodeIdx(self, ue, 0);
+                const op_flags = readU32(self, ue, 1);
+                if ((op_flags & ast_mod.UnaryFlags.postfix) != 0 and
+                    self.ast.getNode(inner_idx).tag == .private_field_expression)
+                {
+                    old_operand = try addExtraNode(self, .update_expression, opn.span, &.{
+                        @intFromEnum(inner_idx),
+                        op_flags & ~ast_mod.UnaryFlags.postfix,
+                    });
+                }
+            }
+        }
+    }
+
     const new_operand = try self.visitNode(old_operand);
-    // 자식 unchanged -> 부모도 identity. ast.addNode 호출 제거.
-    if (new_operand == old_operand) return idx;
+    // 자식 unchanged -> 부모도 identity. 단 위에서 operand 를 재작성했으면
+    // (old_operand != 원본) 반드시 새 노드로 재구성 (early-return 시 원본 operand 유지 버그).
+    if (new_operand == old_operand and old_operand == node.data.unary.operand) return idx;
     return self.ast.addNode(.{
         .tag = node.tag,
         .span = node.span,


### PR DESCRIPTION
## 배경

RFC #3288 mangler 격차 CLOSED 후 다음 큰 size 원인 탐색 → smoke 실측 최대 이상치 **`lru-cache@es2021` 1.44x/+9.7KB** (ES2021 private-field 다운레벨). 진단 중 발견한 부분 개선.

## 변경

`this.#x++;` (expression_statement = 결과 폐기) 는 `++this.#x` 와 부수효과 동일하나, ES2021 다운레벨이 statement 문맥에서도 `(_t=get(),set(_t+1),_t)` 3-part 시퀀스를 emit. `visitUnaryNode` 에서 expression_statement 의 operand 가 private-field postfix update (다운레벨 활성) 면 postfix bit 제거 → prefix 경로(`set(get()+1)`).

- 식 문맥(`x=this.#a++`, `return …++`) 미적용 (반환값 필요, 3-part 유지)
- for-update 슬롯 보수적 skip / 네이티브 #x 빌드 무변경
- identity short-circuit 가드 보강 (재작성 시 원본 operand 유지 버그 차단)

## 의미 보존 (절대원칙)

/simplify Agent2 반례 탐색: ++/-- 는 lvalue 종류 무관 read1+write1, prefix=postfix 부수효과 동일 (BigInt / accessor get→set 순서 / private method TypeError 시점 모두 동등). expression_statement 는 결과-폐기 문맥. tiny runtime MATCH (`__R__=2`).

## 영향 (정직한 스코프)

- lru-cache@es2021 **-36B** (해당 패턴 3회뿐 — **1.44x 주범 아님**: 주범은 private-field 다운레벨 helper 스킴 verbosity = 별도 후속)
- update-heavy 코드(`this.#i++` 카운터/루프 statement) 패턴당 ~18B 절감
- 의미 보존 codegen 개선 (S-series 류)

## 검증

- zig build test Debug **0 fail**, 회귀 0
- tiny private-field runtime MATCH
- /simplify 3-agent (재사용 / 품질·의미보존 / 효율) 전원 **PASS**

Refs #3288

🤖 Generated with [Claude Code](https://claude.com/claude-code)