### PR TITLE
perf(runtime): terse TypeError messages in minified private-field helpers

### DIFF
--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -807,7 +807,9 @@ pub const PRIVATE_METHOD_INIT_RUNTIME =
     \\};
     \\
 ;
-pub const PRIVATE_METHOD_INIT_RUNTIME_MIN = "var " ++ NAMES.PRIVATE_METHOD_INIT_MIN ++ "=function(obj,privateSet){if(privateSet.has(obj))throw new TypeError(\"Cannot initialize the same private elements twice on an object\");privateSet.add(obj)};";
+// MIN 변형은 진단 메시지 축약 (esbuild/terser 관행 — TypeError 타입·throw
+// 조건 동일, message 텍스트는 비계약. dev 변형은 descriptive 유지).
+pub const PRIVATE_METHOD_INIT_RUNTIME_MIN = "var " ++ NAMES.PRIVATE_METHOD_INIT_MIN ++ "=function(obj,privateSet){if(privateSet.has(obj))throw new TypeError(\"private re-init\");privateSet.add(obj)};";
 
 /// __classPrivateMethodGet: brand check + private method 접근 (SWC 호환).
 /// this.#method() 호출 시 brand check 후 함수 참조 반환.
@@ -819,7 +821,7 @@ pub const PRIVATE_METHOD_GET_RUNTIME =
     \\
 ;
 // #1751: trailing `;` — 뒤따르는 `var __xxx=...` 와 문법 구분 필수.
-pub const PRIVATE_METHOD_GET_RUNTIME_MIN = "var " ++ NAMES.PRIVATE_METHOD_GET_MIN ++ "=function(receiver,privateSet,fn){if(!privateSet.has(receiver))throw new TypeError(\"attempted to get private field on non-instance\");return fn};";
+pub const PRIVATE_METHOD_GET_RUNTIME_MIN = "var " ++ NAMES.PRIVATE_METHOD_GET_MIN ++ "=function(receiver,privateSet,fn){if(!privateSet.has(receiver))throw new TypeError(\"private brand\");return fn};";
 
 // ============================================================
 // Static Private Field (ES2022 downlevel)
@@ -860,8 +862,8 @@ pub const STATIC_PRIVATE_FIELD_RUNTIME =
     \\
 ;
 pub const STATIC_PRIVATE_FIELD_RUNTIME_MIN =
-    "var " ++ NAMES.STATIC_PRIVATE_ACCESS_MIN ++ "=function(receiver,classConstructor){if(receiver!==classConstructor)throw new TypeError(\"Private static access of wrong provenance\")};" ++
-    "var " ++ NAMES.STATIC_PRIVATE_DESC_MIN ++ "=function(descriptor,action){if(descriptor===undefined)throw new TypeError(\"attempted to \"+action+\" private static field before its declaration\")};" ++
+    "var " ++ NAMES.STATIC_PRIVATE_ACCESS_MIN ++ "=function(receiver,classConstructor){if(receiver!==classConstructor)throw new TypeError(\"private static\")};" ++
+    "var " ++ NAMES.STATIC_PRIVATE_DESC_MIN ++ "=function(descriptor,action){if(descriptor===undefined)throw new TypeError(\"private static \"+action)};" ++
     "var " ++ NAMES.STATIC_PRIVATE_GET_MIN ++ "=function(receiver,classConstructor,descriptor){" ++
     NAMES.STATIC_PRIVATE_ACCESS_MIN ++ "(receiver,classConstructor);" ++
     NAMES.STATIC_PRIVATE_DESC_MIN ++ "(descriptor,\"get\");" ++


### PR DESCRIPTION
## 배경
RFC #3288 mangler CLOSED 후 다음 size 원인 탐색 → `lru-cache@es2021` 진단 중 발견한 bounded 안전 win. (1.44x 주범은 private-field per-access verbosity = diffuse, 별도 task #41.)

## 변경
ES2021 private-method/static-private 다운레벨 helper 의 **_RUNTIME_MIN(minified) 변형**의 verbose 영문 TypeError 메시지를 terse 로 (dev `_RUNTIME` 은 descriptive 유지 = esbuild dev/minify 모델):

| before | after |
|---|---|
| `Cannot initialize the same private elements twice on an object` | `private re-init` |
| `attempted to get private field on non-instance` | `private brand` |
| `Private static access of wrong provenance` | `private static` |
| `attempted to "+action+" private static field before its declaration` | `private static "+action` |

## 의미 보존 (절대원칙)
TypeError 타입·throw 조건 불변, `.message` 텍스트만 단축. ECMAScript 의미가 message 텍스트에 비의존 (esbuild/terser/swc 동일 관행). 옛 문자열 단언 테스트 없음 (integration-regen RN fixture 만 매치 — 단언 아님).

## 검증
- zig build test Debug **0 fail**, 회귀 0
- private-method runtime MATCH (throw 동작 보존)
- lru-cache@es2021 --minify **23787→23635 (-152B)**, 전 es2021/private 번들 적용 (helper 번들당 1회)
- /simplify (재사용/품질·의미보존/효율) — 3-agent 서버 rate-limit 으로 **inline 엄정 수행, 이슈 0**

Refs #3288

🤖 Generated with [Claude Code](https://claude.com/claude-code)