### PR TITLE
feat(bundler): P3-B IIFE code splitting — 런타임 레지스트리 활성화 (#3321)

### DIFF
--- a/docs/RFC_CJS_IIFE_CODE_SPLITTING.md
+++ b/docs/RFC_CJS_IIFE_CODE_SPLITTING.md
@@ -132,7 +132,8 @@ P3-A 를 먼저(작고 안전, esbuild 도 안 하는 영역의 최소 가치), 
 |---|---|---|
 | **P3-B PR1** | 하위 인프라만 — `module_id.zig`(relative-path 안정 ID) + `runtime_helpers.zig` 레지스트리 상수(`__zntc_mods`/`__zntc_require`/`__zntc_register`/`__zntc_load_chunk`, normal+min). 유닛테스트. emit 미연결·가드 불변(무동작 회귀 0). **MF §4.1 공유 계층** | 본 PR |
 | **P3-B PR2** | emit 연결(CJS) — 가드 완화(`format==.cjs`+splitting), cross-chunk static→`const{x}=require("./chunk.js")`, common 청크 CJS `exports.x`(emitCjsEntryExports 미도달 보완), `import()`→`Promise.resolve().then(()=>require("./chunk.js"))`. **CJS/Node 는 네이티브 require 가 곧 레지스트리**(RFC §4.3) — PR1 의 `__zntc_*` 레지스트리는 IIFE/MF 추상 로더 계층(PR3)으로 미사용 대기. Node 실행 검증(통합 테스트), pm_cjs/ESM/smoke 무회귀 | **완료** |
-| **P3-B PR3** | IIFE/UMD: `__zntc_*` 레지스트리 활성화 + self-register wrapper + 브라우저 청크 로더(script 주입/조건부 import()). cjs 의 native-require 가 없는 환경 | 후속 |
+| **P3-B PR3** | **IIFE** splitting: PR1 `__zntc_*` 레지스트리 활성화 — 자기설치형 `__zntc_register`(모든 청크 멱등 prelude) + entry 전용 해석 계층(`__zntc_require`+브라우저 `<script>` 로더+`__zntc_public_path`) + 청크별 self-register factory(안정 모듈 ID 키, common 은 청크 stem) + cross-chunk static→`const{x}=__zntc_require("<id>")` + `import()`→`__zntc_load_chunk("<f>").then(()=>__zntc_require("<id>"))`. entry/dynamic 청크는 emitCjsEntryExports(factory-bound, default/__esModule). 브라우저 시뮬 Node 실행 검증. esm/cjs/pm/smoke 무회귀 | **완료** |
+| **P3-B PR4** | UMD/AMD splitting + 비-DOM(worker/Deno) 로더 폴백 + RSC 디렉티브×IIFE-factory + CSP nonce/public-path 옵션. (PR3 한계 §7) | 후속 |
 
 ---
 
@@ -145,13 +146,18 @@ P3-A 를 먼저(작고 안전, esbuild 도 안 하는 영역의 최소 가치), 
 **결과: PASS (2026-05-16).** Node 24 CJS 에서 (1) 런타임 레지스트리·캐시, (2) 정적 cross-chunk require, (3) 동적 청크 로드(`__zntc_load_chunk`→`Promise.resolve().then(()=>require(static))`), (4) 동적 로드 청크의 shared 모듈 캐시 재사용(상태 보존 count 1→2→3) 모두 동작 확인.
 **스파이크가 잡은 설계 제약**: 모듈 factory 의 `require` 인자는 `__zntc_require`(모듈ID 레지스트리)다. sibling 청크 *파일* eager 로드는 청크 **최상위**에서 Node `require("./chunk.js")`(정적 string)로 해야 한다 — 청크파일 로드 ≠ 모듈ID require. PR2 의 정적 cross-chunk 재작성은 이 분리를 따른다(§4.2 의도와 일치).
 
+**IIFE 브라우저 스파이크: PASS (2026-05-16).** `<script>` 주입 로더 + self-register factory 청크 2개를 동기 `document` 스텁으로 시뮬레이션 → (1) 레지스트리/캐시 (2) 정적 cross-chunk `__zntc_require` (3) `<script>` 주입 동적 로드 (4) 동적 청크가 common 캐시 재사용(상태 보존 count 1→2→3) 모두 동작.
+**IIFE 스파이크가 잡은 설계 제약**: 정적 dep 청크가 entry(레지스트리 코어)보다 먼저 평가되면 `__zntc_register` 미존재로 실패. → **등록/해석 계층 분리**: `__zntc_register` 는 **자기설치형**(`g.__zntc_register||(g.__zntc_register=function(map){...g.__zntc_mods...})`, mods 맵만 필요, 모든 청크가 멱등 prelude 로 보유), `__zntc_require`+로더는 entry 전용(멱등). 그러면 load-order 요구가 "entry 가 정적 dep 들 뒤(마지막) 평가" 하나로 축소된다(호스트 책임 — RFC §5/§7 한계 기록). PR3 의 self-register wrapper·레지스트리 코어는 이 분리를 따른다.
+
 ---
 
 ## 7. 미해결 / 결정 필요
 
 - **[결정됨 2026-05-16] 모듈 ID 스킴 = relative-path 기반.** content-hash·숫자 인덱스 대비: 디버깅/스택트레이스 가독성, MF expose 키 자연 호환, 빌드 결정성, 내용 변경에도 ID 불변(MF 계약 핀 안정). MF RFC §4.1/§6.1(모듈 안정 런타임 ID) 과 **공동 결정** — 동일 `module_id.zig` 공유. (트레이드오프: 소스 디렉터리 구조가 ID 로 노출 — 수용.)
-- IIFE 동적 로더의 브라우저 청크 fetch 방식(script 주입 vs 조건부 import()) — public_path/CSP 영향. (P3-B PR2 이후 IIFE 단계에서 결정.)
+- **[결정됨 2026-05-16] IIFE 브라우저 동적 로더 = `<script>` 주입** (webpack jsonp 방식): `document.createElement("script")`+onload/onerror Promise, src=`__zntc_public_path`+청크파일. self-register payload 라 평가만 하면 `__zntc_register` 호출. 조건부 import() 대비: 클래식 스크립트 환경 포함 최대 호환, IIFE 포맷과 무충돌, public_path 자연 연동. (트레이드오프: CSP `script-src` 영향 — public_path/nonce 는 후속 옵션.) worker/Deno 등 non-DOM 폴백은 PR3 범위 외(필요 시 후속).
 - preserve-modules CJS 의 Node `__esModule`/interop 경계(default/namespace).
+- **[PR3 한계, 문서화]** IIFE 정적 cross-chunk 는 dep 청크 `<script>` 가 entry 보다 먼저 평가돼야 함(`__zntc_require`가 동기) — 호스트가 dep 스크립트를 entry 앞에 배치하거나 동적 `import()`(로드 await)만 사용. self-installing register 로 load-order 요구는 "entry 마지막" 하나로 축소(RFC §6). umd/amd·preserve-modules+iife·비-DOM 로더·RSC 디렉티브×factory·CSP nonce 는 PR4 후속.
+- **[선재 한계, cjs/iife 공통]** entry 모듈이 `wrap_kind==.cjs`(자체 CJS 모듈)면 emitModule 이 final_exports 블록 전에 early-return → `iife_split_factory`/cjs entry-export 경로 미적용(factory-bound exports 누락 가능). PR2/PR3 공통, 신규 회귀 아님. 후속.
 - **[선재 한계, P3-B 비회귀]** cross-chunk re-export(`export { x } from "./y"` 에서 y 가 별도 청크)는 splitting 파이프라인에서 깨짐 — referrer 가 side-effect import 만 받고 심볼 미바인딩(ReferenceError). **ESM splitting 도 동일하게 깨짐**(P3-B 가 그 동작을 충실히 미러). P3-B 도입 버그 아님 — splitting linker 의 re-export forwarding 갭. cjs/esm 공통 후속 과제(별도 이슈). P3-B CJS 범위 = ESM splitting 패리티(정적 cross-chunk 심볼 import·default/named 동적 import 는 Node 실행 검증됨).
 - P3-A 가치 대비 비용: esbuild 미지원 영역. 수요(누가 CJS/IIFE+splitting 을 원하나) 확인 후 P3-B 착수 여부 게이트.
 

--- a/src/bundler/bundler_test/splitting_dev.zig
+++ b/src/bundler/bundler_test/splitting_dev.zig
@@ -262,7 +262,50 @@ test "CodeSplitting: CJS format succeeds — cross-chunk require + 동적 requir
     try std.testing.expect(has_dyn_require);
 }
 
-test "CodeSplitting: IIFE format still returns CodeSplittingRequiresESM" {
+test "CodeSplitting: IIFE format succeeds — 레지스트리 + self-register factory (P3-B PR3 #3321)" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "shared.ts", "export const s = 'S';");
+    try writeFile(tmp.dir, "lazy.ts", "import { s } from './shared';\nexport const lazy = s;");
+    try writeFile(tmp.dir, "entry.ts", "import { s } from './shared';\nconst x = import('./lazy');\nconsole.log(s, x);");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var bnd = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .code_splitting = true,
+        .format = .iife,
+    });
+    defer bnd.deinit();
+    // PR3: iife + code_splitting 은 더 이상 에러 아님 — 런타임 레지스트리
+    // (`__zntc_*`) + self-register factory + `<script>` 로더(RFC §4.1/§4.3).
+    const result = try bnd.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+    const outs = result.outputs orelse return error.TestUnexpectedResult;
+
+    var has_register = false;
+    var has_require = false;
+    var has_loader = false;
+    var has_factory = false;
+    for (outs) |o| {
+        if (std.mem.indexOf(u8, o.contents, "__zntc_register") != null) has_register = true;
+        if (std.mem.indexOf(u8, o.contents, "__zntc_require(\"") != null) has_require = true;
+        if (std.mem.indexOf(u8, o.contents, "__zntc_load_chunk(\"") != null) has_loader = true;
+        if (std.mem.indexOf(u8, o.contents, "function(exports, module, require)") != null or
+            std.mem.indexOf(u8, o.contents, "function(exports,module,require)") != null) has_factory = true;
+        // IIFE 청크에 ESM import/export 누출 금지.
+        try std.testing.expect(std.mem.indexOf(u8, o.contents, "\nexport {") == null);
+        try std.testing.expect(std.mem.indexOf(u8, o.contents, "\nimport {") == null);
+    }
+    try std.testing.expect(has_register);
+    try std.testing.expect(has_require);
+    try std.testing.expect(has_loader);
+    try std.testing.expect(has_factory);
+}
+
+test "CodeSplitting: UMD format still returns CodeSplittingRequiresESM" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeFile(tmp.dir, "entry.ts", "const x = import('./lazy');\nconsole.log(x);");
@@ -274,10 +317,10 @@ test "CodeSplitting: IIFE format still returns CodeSplittingRequiresESM" {
     var bnd = Bundler.init(std.testing.allocator, .{
         .entry_points = &.{entry},
         .code_splitting = true,
-        .format = .iife,
+        .format = .umd,
     });
     defer bnd.deinit();
-    // iife/umd/amd 는 네이티브 require/import 없음 → PR3 까지 미지원(가드 유지).
+    // umd/amd 는 레지스트리 부트스트랩 상이 → 아직 미지원(후속).
     const result = bnd.bundle();
     try std.testing.expect(result == error.CodeSplittingRequiresESM);
 }

--- a/src/bundler/compiled_cache.zig
+++ b/src/bundler/compiled_cache.zig
@@ -90,7 +90,7 @@ pub const InputHasher = struct {
 /// `EmitOptions` 필드 개수. 구조체가 바뀌면 이 값을 갱신하고 hashEmitOptions
 /// 에 새 필드를 반영해야 한다 — comptime 에 필드 누락을 감지하는 fail-stop.
 /// 누락이 invisible bug (stale cache) 로 번지므로 이 barrier 는 load-bearing.
-const expected_emit_options_field_count: usize = 55;
+const expected_emit_options_field_count: usize = 56;
 
 comptime {
     const actual = @typeInfo(EmitOptions).@"struct".fields.len;
@@ -201,6 +201,7 @@ pub fn hashEmitOptions(h: *InputHasher, options: *const EmitOptions) void {
     h.addBool(options.strict_execution_order);
     h.addBool(options.entry_error_guard);
     h.addStrList(options.silent_console_error_patterns);
+    h.addBool(options.iife_split_factory);
     h.addBool(options.preserve_modules);
     h.addOptStr(options.preserve_modules_root);
     // #1961 PR 1f: transform_options_base — emit 시점에는 EmitOptions 의 다른 필드 (정의된

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -194,6 +194,11 @@ pub const EmitOptions = struct {
     /// `entry_error_guard` 와 직교 — consumer 가 환경 (e.g. expo) 감지 후 패턴 주입.
     /// vanilla RN CLI 빌드는 비어있어 dead code 0.
     silent_console_error_patterns: []const []const u8 = &.{},
+    /// IIFE splitting(P3-B PR3): entry 모듈이 self-register factory 안에서
+    /// emit 됨 → emitWrappedEntryExports 의 `return {...}` 는 레지스트리가
+    /// 버리므로 억제. export 노출은 청크-레벨 factory-bound `exports.x=`
+    /// (chunks.zig xchunk_exports). emitChunks 가 emitModule 호출 시 set.
+    iife_split_factory: bool = false,
     /// preserve-modules: 모듈 1개 = 출력 파일 1개
     preserve_modules: bool = false,
     /// preserve-modules-root: 출력 디렉토리 구조의 기준 경로
@@ -1882,7 +1887,11 @@ pub fn emitModule(
     defer if (final_exports_buf) |buf| allocator.free(buf);
 
     const final_exports = if (final_export_entries) |entries| blk: {
-        if (options.format.isWrappedFormat()) {
+        // IIFE splitting: 청크 factory 가 `exports`/`module`/`require` 를 주므로
+        // CJS 와 동일 모델 — wrapped `return{}`(레지스트리가 버림) 대신 아래
+        // emitCjsEntryExports 경로로 factory-bound exports(default/__esModule
+        // interop 포함)를 emit. global_name 은 chunks.zig bootstrap 이 처리.
+        if (options.format.isWrappedFormat() and !options.iife_split_factory) {
             if (options.format != .iife or options.global_name != null) {
                 final_exports_buf = try emitWrappedEntryExports(allocator, entries, options.minify_whitespace);
                 break :blk final_exports_buf;
@@ -1890,7 +1899,7 @@ pub fn emitModule(
             // 래핑 포맷 (globalName 없음, IIFE): export는 syntax error이므로 제거
             break :blk @as(?[]const u8, null);
         }
-        if (options.format == .cjs) {
+        if (options.format == .cjs or options.iife_split_factory) {
             // mode (auto/named/default_/none) 별 emit 분기는 emitCjsEntryExports 에서 결정.
             final_exports_buf = emitCjsEntryExports(allocator, entries, options.output_exports) catch |err| switch (err) {
                 error.OutputExportsDefaultRequiresSingleDefault => {
@@ -1942,6 +1951,7 @@ const cjs_wrap = @import("emitter/cjs_wrap.zig");
 const emitDisabledModule = cjs_wrap.emitDisabledModule;
 const emitAssetModule = cjs_wrap.emitAssetModule;
 pub const emitCjsWrapper = cjs_wrap.emitCjsWrapper;
+pub const appendJsStringLiteral = cjs_wrap.appendJsStringLiteral;
 
 /// 런타임 헬퍼 문자열을 ArrayList에 주입한다 (re-export for backward compat).
 pub const appendRuntimeHelpers = rt.appendRuntimeHelpers;

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -6,6 +6,7 @@ const ModuleIndex = types.ModuleIndex;
 const ModuleType = types.ModuleType;
 const WrapKind = types.WrapKind;
 const rt = @import("../runtime_helpers.zig");
+const module_id = @import("../module_id.zig");
 const chunk_mod = @import("../chunk.zig");
 const ChunkGraph = chunk_mod.ChunkGraph;
 const Chunk = chunk_mod.Chunk;
@@ -62,15 +63,16 @@ pub fn emitChunks(
     linker: ?*Linker,
 ) ![]OutputFile {
     const module_count = graph.moduleCount();
-    // code splitting 은 ESM 전용(네이티브 import() 필요). preserve-modules 는
-    // 모듈 1:1 파일이라 CJS 도 가능(Node 네이티브 require 가 경로로 해석, P3-A
-    // #3321). IIFE/UMD/AMD 는 아직 미지원.
+    // 청크 경계 해석 방식별 허용 포맷(RFC_CJS_IIFE_CODE_SPLITTING.md):
+    // - ESM: 네이티브 import().
+    // - CJS: P3-A=preserve-modules(모듈 1:1), P3-B=splitting(네이티브 require, §4.3).
+    // - IIFE: P3-B PR3=splitting(런타임 레지스트리 `__zntc_*` + `<script>`
+    //   로더, §4.1/§4.3). preserve-modules+IIFE 는 미지원.
+    // - UMD/AMD: 아직 미지원(레지스트리 부트스트랩 상이 — 후속).
     if (options.format != .esm) {
-        // ESM: 네이티브 import() 로 청크 경계 해석.
-        // CJS: P3-A=preserve-modules(모듈 1:1 파일), P3-B=splitting(네이티브
-        //   require 가 청크 경계 해석 — RFC_CJS_IIFE_CODE_SPLITTING.md §4.3).
-        // IIFE/UMD/AMD: 아직 미지원(네이티브 require/import 없음 — PR3).
-        if (options.format != .cjs) {
+        const cjs_ok = options.format == .cjs;
+        const iife_ok = options.format == .iife and !options.preserve_modules;
+        if (!cjs_ok and !iife_ok) {
             return if (options.preserve_modules)
                 error.PreserveModulesRequiresESM
             else
@@ -100,6 +102,49 @@ pub fn emitChunks(
     const sorted_indices = try allocator.alloc(usize, chunk_graph.chunkCount());
     defer allocator.free(sorted_indices);
     for (sorted_indices, 0..) |*idx, i| idx.* = i;
+
+    // IIFE splitting(P3-B PR3): 런타임 레지스트리 활성화. 안정 모듈 ID 의
+    // root = preserve_modules_root ?? 모든 entry-point 청크 모듈 절대경로의
+    // 공통 조상(module_id, 결정적). 루프 1회 전 계산해 모든 청크가 공유.
+    const iife_split = options.format == .iife and !options.preserve_modules;
+    var iife_id_root: ?[]const u8 = null;
+    defer if (iife_id_root) |r| allocator.free(r);
+    if (iife_split) {
+        if (options.preserve_modules_root) |r| {
+            iife_id_root = try allocator.dupe(u8, r);
+        } else {
+            var entry_paths: std.ArrayList([]const u8) = .empty;
+            defer entry_paths.deinit(allocator);
+            for (chunk_graph.chunks.items) |*c| {
+                switch (c.kind) {
+                    .entry_point => |info| {
+                        if (graph.getModule(info.module)) |m|
+                            try entry_paths.append(allocator, m.path);
+                    },
+                    .common, .manual => {},
+                }
+            }
+            iife_id_root = try module_id.commonAncestorDir(allocator, entry_paths.items);
+        }
+    }
+
+    // 청크 레지스트리 ID 캐시(chunkidx→id). self-register 키·cross-chunk
+    // `__zntc_require`·동적 import 가 같은 청크 ID 를 여러 번 요구 →
+    // 빌드당 1회 채워 borrow(없으면 O(chunks²) alloc). 끝에서 일괄 해제.
+    var reg_ids: [][]const u8 = &.{};
+    defer {
+        for (reg_ids) |id| allocator.free(id);
+        if (reg_ids.len > 0) allocator.free(reg_ids);
+    }
+    // iife_split_factory 만 다른 EmitOptions — 빌드당 1회(모듈 루프 밖).
+    var iife_emit_opts: EmitOptions = undefined;
+    if (iife_split) {
+        reg_ids = try allocator.alloc([]const u8, chunk_graph.chunkCount());
+        for (chunk_graph.chunks.items, 0..) |*c, i|
+            reg_ids[i] = try chunkRegistryId(allocator, c, graph, iife_id_root, options);
+        iife_emit_opts = options.*;
+        iife_emit_opts.iife_split_factory = true;
+    }
 
     const SortCtx = struct {
         chunks: []const Chunk,
@@ -157,6 +202,37 @@ pub fn emitChunks(
         if (options.intro_js) |intro| {
             try chunk_output.appendSlice(allocator, intro);
             try chunk_output.append(allocator, '\n');
+        }
+
+        // IIFE splitting(P3-B PR3): 레지스트리 활성화 + self-register factory.
+        // 순서: [banner/intro] → [entry: public_path + 해석 계층] →
+        //   [factory prefix] → [CSS/runtime-helpers/모듈본문/cross-chunk
+        //   exports — 모두 factory 안] → [factory suffix] → [entry: bootstrap].
+        // prefix 를 여기서(모듈 루프 전) eager emit → sourcemap module_line
+        // base offset 이 자연히 정확(insertSlice 회피, RFC §6 IIFE 스파이크
+        // 검증 모델: 자기설치형 register + entry 전용 해석 계층).
+        if (iife_split) {
+            const id = reg_ids[ci]; // borrow (빌드-1회 캐시)
+            const min = options.minify_whitespace;
+
+            if (chunk_is_user_entry) {
+                // public_path 는 동적 청크 <script> src 접두사(런타임). 결정적
+                // JSON 문자열(따옴표/역슬래시/개행 이스케이프).
+                try chunk_output.appendSlice(allocator, "globalThis.__zntc_public_path=");
+                try parent.appendJsStringLiteral(allocator, &chunk_output, options.public_path);
+                try chunk_output.appendSlice(allocator, if (min) ";" else ";\n");
+                // 해석 계층(__zntc_require + 브라우저 <script> 로더), 멱등.
+                try rt.appendZntcResolveBrowser(&chunk_output, allocator, min);
+            }
+            // self-register factory prefix (모든 청크). 본문·exports 가 안에.
+            try chunk_output.appendSlice(allocator, "(function(g){");
+            try chunk_output.appendSlice(allocator, rt.ZNTC_REGISTER_INSTALL);
+            try chunk_output.appendSlice(allocator, "({\"");
+            try chunk_output.appendSlice(allocator, id);
+            try chunk_output.appendSlice(allocator, if (min)
+                "\":function(exports,module,require){"
+            else
+                "\": function(exports, module, require) {\n");
         }
 
         // CSS 코드스플리팅: 이 청크가 소유한 CSS 를 런타임 <link> 로 주입.
@@ -269,13 +345,26 @@ pub fn emitChunks(
             const dep_stem = chunkPlaceholderStem(dep_chunk, &dep_buf, options);
             const dep_ci = @intFromEnum(dep_chunk_idx);
 
+            // IIFE splitting: 청크 경계는 레지스트리 — 경로 대신 dep 청크의
+            // 레지스트리 ID 로 `__zntc_require("<id>")`. resolved_path 불필요.
+            const dep_id = if (iife_split) reg_ids[@intFromEnum(dep_chunk_idx)] else "";
+
             // import 경로 결정: preserve-modules면 상대 경로, 아니면 "./{stem}{ext}"
-            const resolved_path = if (options.preserve_modules) blk: {
+            const resolved_path = if (iife_split)
+                try allocator.dupe(u8, "")
+            else if (options.preserve_modules) blk: {
                 const src_path = chunk.rel_dir orelse "./";
                 const dep_path = dep_chunk.rel_dir orelse "./";
                 break :blk try computeRelativeImportPath(allocator, src_path, dep_path, ext, options.preserve_modules_root);
             } else try std.fmt.allocPrint(allocator, "./{s}{s}", .{ dep_stem, ext });
             defer allocator.free(resolved_path);
+
+            // 청크 경계 결합 형태: esm `import{}from""` / cjs `const{}=require("")`
+            // / iife `const{}=__zntc_require("<id>")`. brace·alias 표기는 cjs 와
+            // iife 가 동일(`const {` / `name: alias`) — reg_like 로 공유.
+            const reg_like = cjs_require or iife_split;
+            // iife 의 결합 인자는 dep_id, 그 외는 resolved_path.
+            const bind_arg = if (iife_split) dep_id else resolved_path;
 
             // imports_from에서 이 청크→dep_chunk로 가져오는 심볼 목록 조회
             const symbols = chunk.imports_from.get(dep_ci);
@@ -283,9 +372,9 @@ pub fn emitChunks(
             if (symbols != null and symbols.?.items.len > 0) {
                 // 심볼 수준 import: import { a, b } from './chunk-xxx.js';
                 if (!options.minify_whitespace) {
-                    try chunk_output.appendSlice(allocator, if (cjs_require) "const { " else "import { ");
+                    try chunk_output.appendSlice(allocator, if (reg_like) "const { " else "import { ");
                 } else {
-                    try chunk_output.appendSlice(allocator, if (cjs_require) "const{" else "import{");
+                    try chunk_output.appendSlice(allocator, if (reg_like) "const{" else "import{");
                 }
                 // 결정론적 출력을 위해 심볼명 정렬
                 std.mem.sort([]const u8, symbols.?.items, {}, types.stringLessThan);
@@ -300,7 +389,7 @@ pub fn emitChunks(
                         const alias = try std.fmt.allocPrint(allocator, "{s}${d}", .{ name, seen });
                         try alias_strs.append(allocator, alias);
                         try chunk_output.appendSlice(allocator, name);
-                        try chunk_output.appendSlice(allocator, if (cjs_require) ": " else " as ");
+                        try chunk_output.appendSlice(allocator, if (reg_like) ": " else " as ");
                         try chunk_output.appendSlice(allocator, alias);
                     } else {
                         try chunk_output.appendSlice(allocator, name);
@@ -313,26 +402,34 @@ pub fn emitChunks(
                         }
                     }
                 }
-                if (!options.minify_whitespace) {
-                    try chunk_output.appendSlice(allocator, if (cjs_require) " } = require(\"" else " } from \"");
-                    try chunk_output.appendSlice(allocator, resolved_path);
-                    try chunk_output.appendSlice(allocator, if (cjs_require) "\");\n" else "\";\n");
-                } else {
-                    try chunk_output.appendSlice(allocator, if (cjs_require) "}=require(\"" else "}from\"");
-                    try chunk_output.appendSlice(allocator, resolved_path);
-                    try chunk_output.appendSlice(allocator, if (cjs_require) "\");" else "\";");
-                }
+                // 결합 open: iife=`__zntc_require("`, cjs=`require("`, esm=`from"`
+                const sym_open = if (iife_split)
+                    (if (options.minify_whitespace) "}=__zntc_require(\"" else " } = __zntc_require(\"")
+                else if (cjs_require)
+                    (if (options.minify_whitespace) "}=require(\"" else " } = require(\"")
+                else
+                    (if (options.minify_whitespace) "}from\"" else " } from \"");
+                const sym_close = if (reg_like)
+                    (if (options.minify_whitespace) "\");" else "\");\n")
+                else
+                    (if (options.minify_whitespace) "\";" else "\";\n");
+                try chunk_output.appendSlice(allocator, sym_open);
+                try chunk_output.appendSlice(allocator, bind_arg);
+                try chunk_output.appendSlice(allocator, sym_close);
             } else {
-                // 심볼 정보 없음 → side-effect import (실행 순서 보장용)
-                if (!options.minify_whitespace) {
-                    try chunk_output.appendSlice(allocator, if (cjs_require) "require(\"" else "import \"");
-                    try chunk_output.appendSlice(allocator, resolved_path);
-                    try chunk_output.appendSlice(allocator, if (cjs_require) "\");\n" else "\";\n");
-                } else {
-                    try chunk_output.appendSlice(allocator, if (cjs_require) "require(\"" else "import\"");
-                    try chunk_output.appendSlice(allocator, resolved_path);
-                    try chunk_output.appendSlice(allocator, if (cjs_require) "\");" else "\";");
-                }
+                // 심볼 정보 없음 → side-effect (실행/등록 순서 보장용)
+                const se_open = if (iife_split)
+                    "__zntc_require(\""
+                else if (cjs_require)
+                    "require(\""
+                else if (options.minify_whitespace) "import\"" else "import \"";
+                const se_close = if (reg_like)
+                    (if (options.minify_whitespace) "\");" else "\");\n")
+                else
+                    (if (options.minify_whitespace) "\";" else "\";\n");
+                try chunk_output.appendSlice(allocator, se_open);
+                try chunk_output.appendSlice(allocator, bind_arg);
+                try chunk_output.appendSlice(allocator, se_close);
             }
         }
 
@@ -415,10 +512,13 @@ pub fn emitChunks(
                 if (module_names.len > 0) allocator.free(module_names);
             }
             var module_preamble_lines: u32 = 0;
+            // IIFE splitting: emitModule 에 wrapped `return{}` 억제 플래그 전달
+            // (factory 가 함수 스코프 제공, export 는 emitCjsEntryExports/
+            // xchunk_exports 가 담당). iife_emit_opts 는 빌드당 1회 복사.
             const raw_code = try emitModule(
                 allocator,
                 m,
-                options,
+                if (iife_split) &iife_emit_opts else options,
                 linker,
                 is_entry,
                 null,
@@ -434,7 +534,7 @@ pub fn emitChunks(
             defer allocator.free(raw_code);
 
             // 동적 import 경로 리라이트: import('./page') → import('./page.js')
-            const code = try rewriteDynamicImports(allocator, raw_code, m, graph, chunk_graph, options.public_path, ext, options);
+            const code = try rewriteDynamicImports(allocator, raw_code, m, graph, chunk_graph, options.public_path, ext, options, reg_ids);
             defer allocator.free(code);
 
             // entry 모듈(또는 preserve-modules의 단일 모듈)의 directive prologue 추출.
@@ -546,9 +646,15 @@ pub fn emitChunks(
             //    require 로 읽음 → 여기서 또 emit 하면 이중정의·module.exports=
             //    재대입 손상·re-export local 미바인딩(ReferenceError). 따라서
             //    **emit 생략**(emitCjsEntryExports 에 일임)이 정확.
-            const cjs_fmt = options.format == .cjs;
-            if (cjs_fmt and entry_mod_idx != null) break :xchunk_exports;
-            const cjs_x = cjs_fmt;
+            //  - IIFE(iife_split): factory 가 `exports`/`module`/`require`
+            //    파라미터를 주므로 CJS 와 동일 모델. entry/dynamic 청크는
+            //    emitCjsEntryExports(emitter 가 iife_split_factory 시 CJS 경로로
+            //    라우팅 — Edit 9)가 factory-bound exports 를 깔고, common/manual
+            //    은 이 경로가 cross-chunk `exports.x=local;`. → cjs 와 동일하게
+            //    entry 청크는 break(이중정의·module.exports= 손상 방지).
+            const reg_fmt = options.format == .cjs or iife_split;
+            if (reg_fmt and entry_mod_idx != null) break :xchunk_exports;
+            const cjs_x = reg_fmt;
 
             if (!cjs_x) {
                 if (!options.minify_whitespace) {
@@ -613,6 +719,30 @@ pub fn emitChunks(
                 } else {
                     try chunk_output.appendSlice(allocator, "};");
                 }
+            }
+        }
+
+        // IIFE splitting: self-register factory 닫기 + (entry) bootstrap.
+        // prefix `(function(g){<INSTALL>({"id":function(exports,module,require){`
+        // 의 짝: factory fn `}` + 객체 `}` + register 호출 `)` + `;` + wrapper
+        // fn `}` + wrapper 호출 `)` + GLOBAL + `;`.
+        if (iife_split) {
+            const min = options.minify_whitespace;
+            try chunk_output.appendSlice(allocator, if (min) "}});})" else "\n}});})");
+            try chunk_output.appendSlice(allocator, rt.ZNTC_IIFE_GLOBAL);
+            try chunk_output.appendSlice(allocator, if (min) ";" else ";\n");
+            if (chunk_is_user_entry) {
+                // entry 모듈은 정적 dep 들 뒤에 평가 → bootstrap 으로 실행 개시.
+                // global_name 지정 시 그 결과를 전역 var 로 노출(emitter 의
+                // wrapped-return 은 PR3 가 억제 — Edit 8).
+                if (options.global_name) |gn| {
+                    try chunk_output.appendSlice(allocator, "var ");
+                    try chunk_output.appendSlice(allocator, gn);
+                    try chunk_output.appendSlice(allocator, if (min) "=" else " = ");
+                }
+                try chunk_output.appendSlice(allocator, "globalThis.__zntc_require(\"");
+                try chunk_output.appendSlice(allocator, reg_ids[ci]);
+                try chunk_output.appendSlice(allocator, if (min) "\");" else "\");\n");
             }
         }
 
@@ -1018,6 +1148,7 @@ fn rewriteDynamicImports(
     public_path: []const u8,
     out_ext: []const u8,
     emit_options: *const EmitOptions,
+    reg_ids: []const []const u8,
 ) ![]const u8 {
     // dynamic import가 없으면 그대로 복사해서 반환
     if (module.import_records.len == 0) {
@@ -1105,6 +1236,25 @@ fn rewriteDynamicImports(
         // entry 라 emitCjsEntryExports 가 exports.x 를 깔아둠 → require() 결과가
         // 곧 namespace. require 캐시가 재호출 시 상태 보존(스파이크 count 검증).
         // ESM 은 specifier 만 청크 파일명으로 치환(네이티브 import() 유지).
+        // iife+splitting(P3-B PR3): 네이티브 import() 없음 →
+        //   __zntc_load_chunk("<stem><ext>").then(function(){return __zntc_require("<id>")})
+        // 청크파일은 bare(접두 ./ 없음) — 로더가 __zntc_public_path 접두.
+        // 대상 청크는 dynamic entry → id = entry 모듈 안정 모듈 ID. require
+        // 캐시가 상태 보존(스파이크 검증). RFC §4.3 + PR3 결정(<script>).
+        const iife_split = emit_options.format == .iife and !emit_options.preserve_modules;
+        if (iife_split) {
+            const target_id = reg_ids[@intFromEnum(target_chunk_idx)]; // borrow
+            const chunkfile = try std.fmt.allocPrint(allocator, "{s}{s}", .{ stem, out_ext });
+            defer allocator.free(chunkfile);
+            const wrapper = try std.fmt.allocPrint(allocator, "__zntc_load_chunk(\"{s}\").then(function(){{return __zntc_require(\"{s}\")}})", .{ chunkfile, target_id });
+            defer allocator.free(wrapper);
+            if (try rewriteImportCallToWrapper(allocator, result, rec.specifier, wrapper)) |new_result| {
+                allocator.free(result);
+                result = new_result;
+            }
+            continue;
+        }
+
         const cjs_split = emit_options.format == .cjs and !emit_options.preserve_modules;
         if (cjs_split) {
             const wrapper = try std.fmt.allocPrint(allocator, "Promise.resolve().then(()=>require(\"{s}\"))", .{replacement});
@@ -1363,6 +1513,32 @@ fn buildPlaceholder(chunk: *const Chunk, ph: *[HASH_PLACEHOLDER_PREFIX.len + HAS
     @memcpy(ph[0..HASH_PLACEHOLDER_PREFIX.len], HASH_PLACEHOLDER_PREFIX);
     const idx_hash = chunkIndexHash(chunk);
     _ = std.fmt.bufPrint(ph[HASH_PLACEHOLDER_PREFIX.len..], "{x:0>8}", .{@as(u32, @truncate(idx_hash))}) catch unreachable;
+}
+
+/// IIFE splitting 의 청크 레지스트리 키(allocator 소유).
+/// - entry/dynamic 청크: entry 모듈의 안정 모듈 ID(module_id, relative-path).
+///   동적 import 재작성·소비자가 같은 ID 로 `__zntc_require` 한다.
+/// - common/manual 청크: 단일 boundary 모듈이 없음 → 청크 placeholder stem
+///   (결정적, 청크=레지스트리 단위; 소비자는 named destructure). stem 안의
+///   hash placeholder 는 resolveContentHashes 가 self-register 키·소비자
+///   `__zntc_require` 인자 양쪽을 같은 최종 해시로 치환 → 일관.
+fn chunkRegistryId(
+    allocator: std.mem.Allocator,
+    chunk: *const Chunk,
+    graph: *const ModuleGraph,
+    id_root: ?[]const u8,
+    options: *const EmitOptions,
+) ![]const u8 {
+    switch (chunk.kind) {
+        .entry_point => |info| {
+            if (graph.getModule(info.module)) |m|
+                return module_id.moduleId(allocator, m.path, id_root);
+        },
+        .common, .manual => {},
+    }
+    var buf: [128]u8 = undefined;
+    const stem = chunkPlaceholderStem(chunk, &buf, options);
+    return allocator.dupe(u8, stem);
 }
 
 /// 청크의 placeholder stem을 반환한다 (확장자 없음).

--- a/src/bundler/emitter/cjs_wrap.zig
+++ b/src/bundler/emitter/cjs_wrap.zig
@@ -74,7 +74,7 @@ fn appendOptionalMissingThrow(
     try buf.appendSlice(allocator, " + \"\\\"\");\n\t\te.code = \"MODULE_NOT_FOUND\";\n\t\tthrow e;\n");
 }
 
-fn appendJsStringLiteral(allocator: std.mem.Allocator, buf: *std.ArrayList(u8), value: []const u8) !void {
+pub fn appendJsStringLiteral(allocator: std.mem.Allocator, buf: *std.ArrayList(u8), value: []const u8) !void {
     const hex = "0123456789abcdef";
     try buf.append(allocator, '"');
     for (value) |c| {

--- a/src/bundler/runtime_helpers.zig
+++ b/src/bundler/runtime_helpers.zig
@@ -217,6 +217,77 @@ pub fn appendZntcRegistry(buf: *std.ArrayList(u8), allocator: std.mem.Allocator,
     try buf.appendSlice(allocator, if (minify) ZNTC_REGISTRY_RUNTIME_MIN else ZNTC_REGISTRY_RUNTIME);
 }
 
+// ============================================================
+// IIFE code splitting 런타임 (P3-B PR3)
+// ============================================================
+//
+// IIFE/브라우저는 네이티브 require 가 없어 PR1 레지스트리를 *활성화*한다.
+// 디리스크 스파이크(RFC §6 IIFE)가 잡은 제약: 정적 dep 청크가 entry(해석
+// 계층)보다 먼저 평가되면 `__zntc_register` 미존재로 실패. → **등록/해석
+// 분리**:
+//  - 등록(`__zntc_register`)은 **자기설치형** — 모든 청크 wrapper 가 멱등
+//    prelude 로 보유, `g.__zntc_mods` 맵만 건드림. 코어보다 먼저여도 안전.
+//  - 해석(`__zntc_require` + 브라우저 `<script>` 로더)은 entry 전용·멱등.
+// load-order 요구는 "entry 가 정적 dep 들 뒤에 평가" 하나로 축소(호스트
+// 책임 — RFC §5/§7). 이름은 cross-file 계약이라 mangle 금지(리터럴 emit).
+
+/// 모든 IIFE 청크 wrapper 가 보유하는 자기설치형 register 식.
+/// 사용: `(function(g){` ++ THIS ++ `({"<id>":function(exports,module,require){`
+///       ++ <hoisted body+exports> ++ `}});})(typeof globalThis...)`
+pub const ZNTC_REGISTER_INSTALL =
+    "(g.__zntc_register||(g.__zntc_register=function(map){var M=g.__zntc_mods||(g.__zntc_mods={});for(var k in map)M[k]=map[k];}))";
+
+pub const ZNTC_IIFE_GLOBAL = "(typeof globalThis!==\"undefined\"?globalThis:this)";
+
+/// entry 청크 전용 해석 계층 — `__zntc_require`(모듈ID→factory, 캐시) +
+/// 브라우저 `<script>` 주입 동적 로더(`__zntc_load_chunk`, public_path 기반,
+/// Promise 캐시). `if(!g.__zntc_require)` 멱등 가드. 스파이크 검증 형태.
+///
+/// TODO(P3-C): `__zntc_require`/캐시 코어가 PR1 `ZNTC_REGISTRY_RUNTIME`
+/// (현재 dormant, CJS-Node 로더 바인딩) 과 의도상 동일. MF P1 수렴 시
+/// 코어를 공유 fragment 로 분해해 CJS-Node·IIFE-`<script>` 로더가 합성하도록
+/// 통일(중복 spell 제거). PR3 에서는 PR1 테스트 안정성 위해 분리 유지.
+pub const ZNTC_IIFE_RESOLVE_BROWSER =
+    \\(function (g) {
+    \\  if (g.__zntc_require) return;
+    \\  var __zntc_cache = {};
+    \\  var __zntc_cs = {};
+    \\  g.__zntc_require = function (id) {
+    \\    var c = __zntc_cache[id];
+    \\    if (c) return c.exports;
+    \\    var m = { exports: {} };
+    \\    __zntc_cache[id] = m;
+    \\    (0, g.__zntc_mods[id])(m.exports, m, g.__zntc_require);
+    \\    return m.exports;
+    \\  };
+    \\  g.__zntc_load_chunk = function (spec) {
+    \\    if (__zntc_cs[spec]) return __zntc_cs[spec];
+    \\    return (__zntc_cs[spec] = new Promise(function (res, rej) {
+    \\      var s = document.createElement("script");
+    \\      s.src = (g.__zntc_public_path || "") + spec;
+    \\      s.onload = function () { res(); };
+    \\      s.onerror = function () { rej(new Error("chunk load failed: " + spec)); };
+    \\      document.head.appendChild(s);
+    \\    }));
+    \\  };
+    \\})(typeof globalThis !== "undefined" ? globalThis : this);
+    \\
+;
+pub const ZNTC_IIFE_RESOLVE_BROWSER_MIN =
+    "(function(g){if(g.__zntc_require)return;var __zntc_cache={},__zntc_cs={};" ++
+    "g.__zntc_require=function(id){var c=__zntc_cache[id];if(c)return c.exports;" ++
+    "var m={exports:{}};__zntc_cache[id]=m;(0,g.__zntc_mods[id])(m.exports,m,g.__zntc_require);return m.exports};" ++
+    "g.__zntc_load_chunk=function(spec){if(__zntc_cs[spec])return __zntc_cs[spec];" ++
+    "return __zntc_cs[spec]=new Promise(function(res,rej){var s=document.createElement(\"script\");" ++
+    "s.src=(g.__zntc_public_path||\"\")+spec;s.onload=function(){res()};" ++
+    "s.onerror=function(){rej(new Error(\"chunk load failed: \"+spec))};document.head.appendChild(s)})};" ++
+    "})(typeof globalThis!==\"undefined\"?globalThis:this);";
+
+/// entry 청크에 해석 계층(브라우저)을 1회 주입.
+pub fn appendZntcResolveBrowser(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, minify: bool) !void {
+    try buf.appendSlice(allocator, if (minify) ZNTC_IIFE_RESOLVE_BROWSER_MIN else ZNTC_IIFE_RESOLVE_BROWSER);
+}
+
 /// __export: ESM namespace 객체에 live getter 등록 (esbuild 호환).
 /// var foo_exports = {}; __export(foo_exports, { greet: () => greet });
 /// __defProp은 __toESM 런타임에 이미 정의됨.

--- a/tests/integration/tests/iife-code-splitting.test.ts
+++ b/tests/integration/tests/iife-code-splitting.test.ts
@@ -1,0 +1,283 @@
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import { join } from 'node:path';
+import { writeFileSync } from 'node:fs';
+import { createFixture, runNode, byContent, writeOutputs } from './helpers';
+import { init, close, build } from '../../../packages/core/index';
+
+// P3-B PR3 (#3321): format=iife + splitting=true — 런타임 require 레지스트리
+// (`__zntc_*`) + self-register factory + `<script>` 동적 로더(RFC §4.1/§4.3).
+// 디리스크 스파이크(RFC §6 IIFE)가 브라우저 시뮬레이션으로 증명한 행동을
+// 빌더 산출물로 영구화. ESM/CJS splitting·단일 IIFE 번들은 불변(회귀).
+
+/**
+ * 브라우저 시뮬레이션 드라이버를 dir 에 기록. <script> 주입을 동기 eval+onload
+ * 로 스텁(스파이크 검증 모델). 정적 cross-chunk 는 dep 가 entry 보다 먼저
+ * 평가돼야 하므로 entry 외 모든 청크를 먼저 eval, 그 다음 entry. 동적
+ * __zntc_load_chunk 는 document.head.appendChild 경유 재-eval(멱등 register).
+ */
+function writeBrowserDriver(dir: string, entryFile: string, allJs: string[]): string {
+  const others = allJs.filter((p) => p !== entryFile);
+  const driver = join(dir, '__driver.cjs');
+  writeFileSync(
+    driver,
+    `const fs=require("fs"),path=require("path");const here=${JSON.stringify(dir)};
+function ev(f){(0,eval)(fs.readFileSync(path.join(here,f),"utf8"));}
+globalThis.__zntc_public_path="";
+globalThis.document={createElement(){return {};},head:{appendChild(s){try{ev(s.src);if(s.onload)s.onload();}catch(e){if(s.onerror)s.onerror(e);}}}};
+${others.map((f) => `ev(${JSON.stringify(f)});`).join('\n')}
+ev(${JSON.stringify(entryFile)});
+`,
+  );
+  return driver;
+}
+
+const jsOf = (outs: { path: string }[]) =>
+  outs.filter((o) => o.path.endsWith('.js')).map((o) => o.path);
+
+describe('iife + code splitting (P3-B PR3)', () => {
+  let cleanup: (() => Promise<void>) | undefined;
+  beforeAll(() => init());
+  afterAll(() => close());
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  test('가드 완화: iife + splitting 이 에러 아님 + 다중 청크', async () => {
+    const fixture = await createFixture({
+      'index.ts': `export async function load(){ return (await import("./page")).render(); }\nload();`,
+      'page.ts': `import { label } from "./shared";\nexport function render(){ return label; }`,
+      'shared.ts': `export const label = "SHARED_OK";`,
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      format: 'iife',
+      splitting: true,
+    });
+    expect(result.outputFiles).toBeDefined();
+    expect(jsOf(result.outputFiles!).length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('구조: 레지스트리 + self-register factory + 로더, ESM 누출 없음', async () => {
+    const fixture = await createFixture({
+      'index.ts': `import { v } from "./s";\nconst p = import("./d");\nconsole.log(v, p);`,
+      's.ts': `export const v = "V";`,
+      'd.ts': `export const d = 1;`,
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      format: 'iife',
+      splitting: true,
+    });
+    const outs = result.outputFiles!;
+    const entry = byContent(outs, '__zntc_require(')!;
+    expect(entry).toBeDefined();
+    // 엔트리: 해석 계층 + 부트스트랩
+    expect(entry.text).toContain('globalThis.__zntc_public_path=');
+    expect(entry.text).toMatch(/g\.__zntc_require\s*=\s*function/);
+    expect(entry.text).toContain('document.createElement("script")');
+    // self-register factory wrapper
+    expect(entry.text).toContain('__zntc_register');
+    expect(entry.text).toMatch(/function\s*\(exports,\s*module,\s*require\)/);
+    // 동적 import → __zntc_load_chunk(...).then
+    expect(entry.text).toMatch(/__zntc_load_chunk\("[^"]+"\)\.then\(/);
+    // 정적 cross-chunk → __zntc_require, ESM import/export 없음
+    for (const o of outs.filter((x) => x.path.endsWith('.js'))) {
+      expect(o.text).not.toMatch(/^\s*import\s+[{*]/m);
+      expect(o.text).not.toMatch(/^\s*export\s+[{*]/m);
+    }
+  });
+
+  test('스파이크 시나리오: 정적 cross-chunk + 동적 로드 + 캐시 보존 (브라우저 시뮬 Node 실행)', async () => {
+    const fixture = await createFixture({
+      'index.ts': `
+        import { bump, label } from "./shared";
+        async function main() {
+          const out = [];
+          out.push("static:" + label + ":" + bump());   // count=1
+          const page = await import("./page");
+          out.push("dynamic:" + page.render());          // count=2
+          out.push("again:" + page.render());            // count=3 (캐시)
+          console.log(out.join("|"));
+        }
+        main();
+      `,
+      'shared.ts': `let count = 0;\nexport function bump(){ return ++count; }\nexport const label = "S";`,
+      'page.ts': `import { bump, label } from "./shared";\nexport function render(){ return label + ":" + bump(); }`,
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      format: 'iife',
+      splitting: true,
+    });
+    const outs = result.outputFiles!;
+    writeOutputs(fixture.dir, outs);
+    const entry = outs.find((o) => o.path.includes('index') && o.path.endsWith('.js'))!;
+    const driver = writeBrowserDriver(fixture.dir, entry.path, jsOf(outs));
+    const { stdout } = await runNode(driver);
+    expect(stdout).toBe('static:S:1|dynamic:S:2|again:S:3');
+  });
+
+  test('default + named export 동적 import (factory-bound exports)', async () => {
+    const fixture = await createFixture({
+      'index.ts': `
+        import { bump } from "./shared";
+        async function main(){
+          const o=[];
+          o.push("st:"+bump());
+          const p=await import("./page");
+          o.push("def:"+p.default());
+          o.push("tag:"+p.tag);
+          o.push("again:"+p.default());
+          console.log(o.join("|"));
+        }
+        main();
+      `,
+      'shared.ts': `let c=0;\nexport function bump(){ return ++c; }`,
+      'page.ts': `import { bump } from "./shared";\nexport default function(){ return "D"+bump(); }\nexport const tag = "PG";`,
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      format: 'iife',
+      splitting: true,
+    });
+    const outs = result.outputFiles!;
+    writeOutputs(fixture.dir, outs);
+    const entry = outs.find((o) => o.path.includes('index') && o.path.endsWith('.js'))!;
+    const driver = writeBrowserDriver(fixture.dir, entry.path, jsOf(outs));
+    const { stdout } = await runNode(driver);
+    expect(stdout).toBe('st:1|def:D2|tag:PG|again:D3');
+  });
+
+  test('global_name: 엔트리 결과를 전역 var 로 노출', async () => {
+    const fixture = await createFixture({
+      'index.ts': `export const answer = 42;\nexport function hello(){ return "hi"; }`,
+      'd.ts': `export const d = 1;`,
+      'use.ts': `export async function load(){ return import("./d"); }`,
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      format: 'iife',
+      splitting: true,
+      globalName: 'MyLib',
+    });
+    const entry = result.outputFiles!.find(
+      (o) => o.path.includes('index') && o.path.endsWith('.js'),
+    )!;
+    expect(entry.text).toMatch(/var MyLib\s*=\s*globalThis\.__zntc_require\("/);
+  });
+
+  test('minify: 단일행 레지스트리/factory 도 브라우저 시뮬에서 동작', async () => {
+    const fixture = await createFixture({
+      'index.ts': `
+        import { tag } from "./shared";
+        async function main(){ const p = await import("./page"); console.log(tag + "|" + p.go()); }
+        main();
+      `,
+      'shared.ts': `export const tag = "T";`,
+      'page.ts': `import { tag } from "./shared";\nexport function go(){ return "GO:" + tag; }`,
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      format: 'iife',
+      splitting: true,
+      minifyWhitespace: true,
+    });
+    const outs = result.outputFiles!;
+    // min: 레지스트리 런타임에 개행 없음(연속 emit 안전)
+    const entry = outs.find((o) => o.path.includes('index') && o.path.endsWith('.js'))!;
+    expect(entry.text).toContain('__zntc_require');
+    writeOutputs(fixture.dir, outs);
+    const driver = writeBrowserDriver(fixture.dir, entry.path, jsOf(outs));
+    const { stdout } = await runNode(driver);
+    expect(stdout).toBe('T|GO:T');
+  });
+
+  test('다중 동적 청크: 각각 독립 로드 + 공유 common 캐시', async () => {
+    const fixture = await createFixture({
+      'index.ts': `
+        import { base } from "./shared";
+        async function main(){
+          const a = await import("./a");
+          const b = await import("./b");
+          console.log(base + "|" + a.ay() + "|" + b.by());
+        }
+        main();
+      `,
+      'shared.ts': `let n=0;\nexport const base="B";\nexport function tick(){ return ++n; }`,
+      'a.ts': `import { tick } from "./shared";\nexport function ay(){ return "A" + tick(); }`,
+      'b.ts': `import { tick } from "./shared";\nexport function by(){ return "B" + tick(); }`,
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      format: 'iife',
+      splitting: true,
+    });
+    const outs = result.outputFiles!;
+    expect(jsOf(outs).length).toBeGreaterThanOrEqual(3);
+    writeOutputs(fixture.dir, outs);
+    const entry = outs.find((o) => o.path.includes('index') && o.path.endsWith('.js'))!;
+    const driver = writeBrowserDriver(fixture.dir, entry.path, jsOf(outs));
+    const { stdout } = await runNode(driver);
+    // shared 의 tick 카운터가 a,b 동적 청크 간에 공유(common 캐시)
+    expect(stdout).toBe('B|A1|B2');
+  });
+
+  test('회귀: esm + splitting 은 native import() 그대로 (레지스트리 없음)', async () => {
+    const fixture = await createFixture({
+      'index.ts': `export async function load(){ return (await import("./d")).v; }`,
+      'd.ts': `export const v = 1;`,
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      format: 'esm',
+      splitting: true,
+    });
+    const idx = byContent(result.outputFiles!, 'load')!;
+    expect(idx.text).not.toContain('__zntc_require');
+    expect(idx.text).not.toContain('__zntc_load_chunk');
+  });
+
+  test('회귀: cjs + splitting 은 native require (레지스트리 미사용)', async () => {
+    const fixture = await createFixture({
+      'index.ts': `import { v } from "./s";\nconst p = import("./d");\nconsole.log(v, p);`,
+      's.ts': `export const v = "V";`,
+      'd.ts': `export const d = 1;`,
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      format: 'cjs',
+      splitting: true,
+    });
+    const entry = byContent(result.outputFiles!, 'require(')!;
+    expect(entry.text).toContain('require(');
+    expect(entry.text).not.toContain('__zntc_require');
+  });
+
+  test('회귀: 단일 IIFE 번들(splitting 아님)은 불변', async () => {
+    const fixture = await createFixture({
+      'dep.ts': `export const dep = "DEP_X";`,
+      'index.ts': `import { dep } from "./dep";\nconsole.log(dep);`,
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      format: 'iife',
+    });
+    const single = byContent(result.outputFiles!, 'DEP_X')!;
+    expect(single).toBeDefined();
+    expect(single.text).not.toContain('__zntc_register');
+    expect(single.text).not.toContain('__zntc_load_chunk');
+  });
+});


### PR DESCRIPTION
## 개요

#3321 **P3-B PR3** — `format=iife` + `splitting=true`. PR1 의 `__zntc_*` 레지스트리를 **활성화**(브라우저는 네이티브 require 없음 — esbuild 도 의도적 미지원 영역). PR1/PR2 머지 위에 진행.

**디리스크 스파이크(RFC §6 IIFE) PASS** — 브라우저 시뮬레이션으로 등록/해석 분리 모델 검증. 스파이크가 잡은 제약: 정적 dep 청크가 entry(해석 계층)보다 먼저 평가되면 `__zntc_register` 미존재 → **자기설치형 register**(모든 청크 멱등 prelude, `g.__zntc_mods` 만) + **entry 전용 해석 계층**(`__zntc_require`+`<script>` 로더, 멱등)으로 분리. load-order 요구가 "entry 마지막" 하나로 축소.

## 변경

**runtime_helpers.zig**: `ZNTC_REGISTER_INSTALL`(자기설치형 register 식), `ZNTC_IIFE_GLOBAL`, `ZNTC_IIFE_RESOLVE_BROWSER{,_MIN}`(해석 계층: require+캐시 + `<script>` 주입 로더 + `__zntc_public_path`), `appendZntcResolveBrowser`. P3-C 코어 통합 TODO 교차참조.

**chunks.zig**:
- 가드 완화: `iife`(+`!preserve_modules`) 허용. umd/amd 는 여전 `CodeSplittingRequiresESM`(후속).
- 청크별 **self-register factory wrapper**. 키 = 안정 모듈 ID(entry/dynamic, `module_id`) / 청크 stem(common). `reg_ids` 빌드-1회 캐시.
- cross-chunk static → `const {x}=__zntc_require("<id>")` (esm/cjs/iife 3-way `reg_like`/`bind_arg`).
- `import()` → `__zntc_load_chunk("<f>").then(()=>__zntc_require("<id>"))`.
- entry 청크: `__zntc_public_path` + 해석 계층 + bootstrap(`global_name` 시 전역 var).

**emitter.zig**: `iife_split_factory` 플래그 → wrapped `return{}` 억제하고 CJS export 경로(`emitCjsEntryExports`) 라우팅 → factory-bound `exports.x`/`default`/`__esModule`. common 청크는 `xchunk_exports`. `appendJsStringLiteral` pub 재노출(재사용).

**compiled_cache.zig**: EmitOptions 필드 55→56 + hash.

## 산출물 (실제, 검증)
```
// index.js (entry)
globalThis.__zntc_public_path="";
(function(g){ if(g.__zntc_require)return; ... <script> 로더 ... })(globalThis);
(function(g){(g.__zntc_register||(...))({"index.js":function(exports,module,require){
const { bump,label } = __zntc_require("chunk-XXXX");
... __zntc_load_chunk("page.js").then(function(){return __zntc_require("page.js")}) ...
}});})(globalThis);
globalThis.__zntc_require("index.js");
// page.js (dynamic): self-register factory + exports.render = render;
// chunk-XXXX.js (common): factory + exports.bump=bump; exports.label=label;
```

## 테스트
- `zig build test`: **5183/5187 pass, 0 fail** (splitting_dev: IIFE 성공 + UMD 가드 신규)
- 통합 `iife-code-splitting.test.ts`(신규, **브라우저 시뮬 Node 실행**): 가드/구조/스파이크 시나리오/default+named/global_name/minify/다중 동적 청크 캐시 보존/esm·cjs·단일IIFE 회귀 — iife+cjs+pm+esm splitting 합 **68 pass 0 fail**
- app-builder CLI styles **14 pass 0 fail**, smoke **3/3 esbuild MATCH**(ESM 무회귀)
- `/simplify` 3-에이전트: **차단 버그 0**(우선 정확성 항목 전부 CONSISTENT 검증). 효율 2건 적용(루프 밖 `emit_opts` 호이스트, `reg_ids` 빌드-1회 캐시 → O(chunks²) alloc 제거 + 파라미터 정리), P3-C 코어 통합 TODO + RFC 한계 반영

## 알려진 한계 (RFC §7, P3-B 비회귀)
- IIFE 정적 cross-chunk 는 dep `<script>` 가 entry 앞 평가 필요(호스트 책임) 또는 동적 `import()` 사용
- umd/amd · preserve-modules+iife · 비-DOM(worker/Deno) 로더 · RSC×factory · CSP nonce → **PR4** 후속
- cross-chunk re-export / `wrap_kind==.cjs` entry → cjs/iife 공통 선재 한계(신규 회귀 아님)
- `__zntc_*` 코어 PR1↔PR3 중복 spell → P3-C(MF 수렴) 시 fragment 통일(TODO 교차참조)

RFC `docs/RFC_CJS_IIFE_CODE_SPLITTING.md` §4.1/§4.3/§5/§6/§7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)