### PR TITLE
fix(bundler): cross-chunk re-export 심볼 미바인딩 (#3321 후속)

### DIFF
--- a/docs/RFC_CJS_IIFE_CODE_SPLITTING.md
+++ b/docs/RFC_CJS_IIFE_CODE_SPLITTING.md
@@ -158,7 +158,8 @@ P3-A 를 먼저(작고 안전, esbuild 도 안 하는 영역의 최소 가치), 
 - preserve-modules CJS 의 Node `__esModule`/interop 경계(default/namespace).
 - **[PR3 한계, 문서화]** IIFE 정적 cross-chunk 는 dep 청크 `<script>` 가 entry 보다 먼저 평가돼야 함(`__zntc_require`가 동기) — 호스트가 dep 스크립트를 entry 앞에 배치하거나 동적 `import()`(로드 await)만 사용. self-installing register 로 load-order 요구는 "entry 마지막" 하나로 축소(RFC §6). umd/amd·preserve-modules+iife·비-DOM 로더·RSC 디렉티브×factory·CSP nonce 는 PR4 후속.
 - **[선재 한계, cjs/iife 공통]** entry 모듈이 `wrap_kind==.cjs`(자체 CJS 모듈)면 emitModule 이 final_exports 블록 전에 early-return → `iife_split_factory`/cjs entry-export 경로 미적용(factory-bound exports 누락 가능). PR2/PR3 공통, 신규 회귀 아님. 후속.
-- **[선재 한계, P3-B 비회귀]** cross-chunk re-export(`export { x } from "./y"` 에서 y 가 별도 청크)는 splitting 파이프라인에서 깨짐 — referrer 가 side-effect import 만 받고 심볼 미바인딩(ReferenceError). **ESM splitting 도 동일하게 깨짐**(P3-B 가 그 동작을 충실히 미러). P3-B 도입 버그 아님 — splitting linker 의 re-export forwarding 갭. cjs/esm 공통 후속 과제(별도 이슈). P3-B CJS 범위 = ESM splitting 패리티(정적 cross-chunk 심볼 import·default/named 동적 import 는 Node 실행 검증됨).
+- **[수정됨 2026-05-16]** cross-chunk re-export(`export {x} from "./y"`, y 별도 청크) → 심볼 미바인딩 ReferenceError. 근본원인 (a) `computeCrossChunkLinks` 가 re-export `export_bindings` 미처리 (b) 심볼 canonical 청크가 직접 의존이 아니면 `cross_chunk_imports` 누락 → emitter named import 못 냄. 둘 다 수정(esm/cjs/iife, Node 실행 검증). star/namespace re-export(`export *`/`export * as ns`)는 별도 후속.
+- **[선재 한계, 별개 버그 B]** ESM 에서 한 심볼이 *동시에* (re-export 됨 + 정적 cross-chunk import 됨) 이고 그 청크가 *동적 entry* 이기도 하면 `export {}` 중복(xchunk_exports + entry-final-exports) → `Duplicate export` SyntaxError. cjs/iife 는 `entry_mod_idx != null` break 로 회피하나 ESM 은 게이트 없음. re-export 픽스와 무관한 ESM entry/xchunk export dedup 이슈 — 별도 후속(PR4 후보).
 - P3-A 가치 대비 비용: esbuild 미지원 영역. 수요(누가 CJS/IIFE+splitting 을 원하나) 확인 후 P3-B 착수 여부 게이트.
 
 ---

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -942,6 +942,41 @@ fn removeModuleFromList(list: *std.ArrayListUnmanaged(ModuleIndex), target: Modu
 /// linker가 null이면 청크 수준 의존성만 계산 (side-effect import).
 ///
 /// 이 함수는 generateChunks 이후에 호출한다.
+/// cross-chunk 심볼(src 청크 + export 이름)을 chunk.imports_from +
+/// src.exports_to + chunk.cross_chunk_imports 에 등록. import_bindings 경로와
+/// re-export 경로가 **동일 로직**을 쓰도록 단일화 — 두 경로 divergence 가 곧
+/// 이 버그였다(#3321 후속). `seen_static` 로 cross_chunk_imports dedup.
+/// imports_from 중복 검사는 O(n) 선형(소스별 심볼 수 작음, import_bindings
+/// 기존 패턴과 동일 — 프로파일 시 set 전환은 양 경로 공동 과제).
+fn addCrossChunkSymbol(
+    allocator: std.mem.Allocator,
+    chunk_graph: *ChunkGraph,
+    chunk: *Chunk,
+    seen_static: *std.AutoHashMapUnmanaged(u32, void),
+    src_chunk_idx: ChunkIndex,
+    export_name: []const u8,
+) !void {
+    const src_ci = @intFromEnum(src_chunk_idx);
+
+    // 심볼의 canonical 청크가 *직접 의존*이 아닐 수 있다(re-export 체인
+    // importer→page→inner: importer 는 inner 를 직접 의존 안 함). emitter 는
+    // cross_chunk_imports 를 순회하며 imports_from 을 조회하므로, canonical
+    // 청크가 거기 없으면 named import 누락 → 심볼 미바인딩(ReferenceError).
+    const gop = try seen_static.getOrPut(allocator, src_ci);
+    if (!gop.found_existing)
+        try chunk.cross_chunk_imports.append(allocator, src_chunk_idx);
+
+    const ifgop = try chunk.imports_from.getOrPut(allocator, src_ci);
+    if (!ifgop.found_existing) ifgop.value_ptr.* = .empty;
+    for (ifgop.value_ptr.items) |existing| {
+        if (std.mem.eql(u8, existing, export_name)) break;
+    } else {
+        try ifgop.value_ptr.append(allocator, export_name);
+    }
+
+    try chunk_graph.chunks.items[src_ci].exports_to.put(allocator, export_name, {});
+}
+
 pub fn computeCrossChunkLinks(
     chunk_graph: *ChunkGraph,
     graph: *const ModuleGraph,
@@ -1002,29 +1037,25 @@ pub fn computeCrossChunkLinks(
                     if (src_chunk_idx.isNone()) continue;
                     if (src_chunk_idx == chunk.index) continue; // 같은 청크 → 스킵
 
-                    const src_ci = @intFromEnum(src_chunk_idx);
-                    const export_name = rb.canonical.export_name;
+                    try addCrossChunkSymbol(allocator, chunk_graph, chunk, &seen_static, src_chunk_idx, rb.canonical.export_name);
+                }
 
-                    // imports_from에 심볼 이름 추가 (중복 방지)
-                    const ifgop = try chunk.imports_from.getOrPut(allocator, src_ci);
-                    if (!ifgop.found_existing) {
-                        ifgop.value_ptr.* = .empty;
-                    }
-                    // 이미 추가된 이름인지 확인
-                    var already = false;
-                    for (ifgop.value_ptr.items) |existing| {
-                        if (std.mem.eql(u8, existing, export_name)) {
-                            already = true;
-                            break;
-                        }
-                    }
-                    if (!already) {
-                        try ifgop.value_ptr.append(allocator, export_name);
-                    }
-
-                    // 소스 청크의 exports_to에 심볼 이름 추가
-                    const src_chunk = &chunk_graph.chunks.items[src_ci];
-                    try src_chunk.exports_to.put(allocator, export_name, {});
+                // named re-export (`export { x } from "./y"`): import_binding 이
+                // 없어(P 가 x 를 *사용*하지 않고 *전달*만 함) 위 루프가 놓친다.
+                // canonical 이 다른 청크면 P 의 청크가 named 로 가져와야 (a) P 가
+                // `exports.x=x`/`export {x}` 의 로컬 x 를 바인딩하고 (b) 소스
+                // 청크가 x 를 노출한다. 없으면 side-effect import 만 나와
+                // ReferenceError (#3321 후속, esm/cjs/iife 공통 선재 버그).
+                // star/namespace re-export 는 별도 케이스 — 후속.
+                for (m.export_bindings) |eb| {
+                    if (eb.kind != .re_export) continue;
+                    const canon = lnk.resolveExportChain(mod_idx, eb.exported_name, 0) orelse continue;
+                    const canon_mi = @intFromEnum(canon.module_index);
+                    if (canon_mi >= module_count) continue;
+                    const src_chunk_idx = chunk_graph.getModuleChunk(canon.module_index);
+                    if (src_chunk_idx.isNone()) continue;
+                    if (src_chunk_idx == chunk.index) continue; // 같은 청크 → 스킵
+                    try addCrossChunkSymbol(allocator, chunk_graph, chunk, &seen_static, src_chunk_idx, canon.export_name);
                 }
             }
 

--- a/tests/integration/tests/cross-chunk-reexport.test.ts
+++ b/tests/integration/tests/cross-chunk-reexport.test.ts
@@ -1,0 +1,142 @@
+import { describe, test, expect, beforeAll, afterAll, afterEach } from 'bun:test';
+import { join } from 'node:path';
+import { writeFileSync } from 'node:fs';
+import { createFixture, runNode, writeOutputs } from './helpers';
+import { init, close, build } from '../../../packages/core/index';
+
+// #3321 후속 버그픽스: cross-chunk re-export.
+// `export { x } from "./y"` 에서 y 가 별도 청크면, 재-export 심볼이
+// cross-chunk imports_from 으로 전파되지 않아 referrer 가 심볼 미바인딩
+// → ReferenceError. esm/cjs/iife splitting 공통 선재 버그. 근본 원인:
+//   (a) computeCrossChunkLinks 가 export_bindings(re-export)를 안 봄
+//   (b) 심볼 canonical 청크가 직접 의존이 아니면 cross_chunk_imports 누락
+//       → emitter 가 named import 를 못 냄
+// 둘 다 수정. esm/cjs 는 Node 직접 실행, iife 는 브라우저 시뮬 실행.
+
+function browserDriver(dir: string, entryFile: string, allJs: string[]): string {
+  const others = allJs.filter((p) => p !== entryFile);
+  const drv = join(dir, '__rxdrv.cjs');
+  writeFileSync(
+    drv,
+    `const fs=require("fs"),path=require("path");const here=${JSON.stringify(dir)};
+function ev(f){(0,eval)(fs.readFileSync(path.join(here,f),"utf8"));}
+globalThis.__zntc_public_path="";
+globalThis.document={createElement(){return {};},head:{appendChild(s){ev(s.src);if(s.onload)s.onload();}}};
+${others.map((f) => `ev(${JSON.stringify(f)});`).join('\n')}
+ev(${JSON.stringify(entryFile)});
+`,
+  );
+  return drv;
+}
+
+const jsPaths = (outs: { path: string }[]) =>
+  outs.filter((o) => o.path.endsWith('.js')).map((o) => o.path);
+
+describe('cross-chunk re-export (#3321 follow-up bugfix)', () => {
+  let cleanup: (() => Promise<void>) | undefined;
+  beforeAll(() => init());
+  afterAll(() => close());
+  afterEach(async () => {
+    if (cleanup) {
+      await cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  // page 가 inner 를 re-export, index 가 page 에서 그 심볼을 정적 import +
+  // page 를 동적 import. inner 는 별도 common 청크가 됨.
+  const reexportFixture = {
+    'inner.ts': `export const reexported = "RX";\nexport const other = "OT";`,
+    'page.ts': `export { reexported } from "./inner";\nexport function pageOnly(){ return "PO"; }`,
+    'index.ts': `
+      import { reexported } from "./page";
+      async function main(){
+        const m = await import("./page");
+        console.log("rx:" + reexported + " po:" + m.pageOnly());
+      }
+      main();
+    `,
+  };
+
+  for (const format of ['esm', 'cjs', 'iife'] as const) {
+    test(`${format}: re-export 심볼이 referrer·재-exporter 양쪽에 바인딩 + Node 실행`, async () => {
+      const fixture = await createFixture(reexportFixture);
+      cleanup = fixture.cleanup;
+      const result = await build({
+        entryPoints: [join(fixture.dir, 'index.ts')],
+        format,
+        splitting: true,
+        platform: format === 'iife' ? 'browser' : 'node',
+      });
+      const outs = result.outputFiles!;
+      expect(jsPaths(outs).length).toBeGreaterThanOrEqual(3); // index, page, inner
+
+      // 재-exporter(page) 청크는 re-export 심볼을 named 로 가져와야 함
+      // (side-effect import 만 있으면 미바인딩).
+      const page = outs.find((o) => o.path.includes('page') && o.path.endsWith('.js'))!;
+      expect(page).toBeDefined();
+      if (format === 'esm') {
+        expect(page.text).toMatch(/import\s*\{[^}]*reexported[^}]*\}\s*from/);
+      } else {
+        expect(page.text).toMatch(/(reexported[^=]*=\s*(__zntc_)?require|__zntc_require)/);
+      }
+
+      writeOutputs(fixture.dir, outs);
+      const entry = outs.find((o) => o.path.includes('index') && o.path.endsWith('.js'))!;
+      let stdout: string;
+      if (format === 'iife') {
+        const drv = browserDriver(fixture.dir, entry.path, jsPaths(outs));
+        ({ stdout } = await runNode(drv));
+      } else {
+        ({ stdout } = await runNode(join(fixture.dir, entry.path)));
+      }
+      expect(stdout).toBe('rx:RX po:PO');
+    });
+  }
+
+  // 정적 전용 gap (b): a 가 page 의 re-export 심볼 사용, manualChunks 로
+  // inner 를 별도 청크 강제(동적 entry 아님 → 버그 B 무관). canonical
+  // 청크(inner)가 a 의 직접 의존이 아님 — cross_chunk_imports 보장 회귀 가드.
+  for (const format of ['esm', 'cjs'] as const) {
+    test(`${format}: 정적 전용 re-export (canonical 청크 ≠ 직접 의존, manualChunks)`, async () => {
+      const fixture = await createFixture({
+        'inner.ts': `export const v = "INNER";`,
+        'page.ts': `export { v } from "./inner";\nexport const pg = "PAGE";`,
+        'a.ts': `import { v } from "./page";\nexport function useA(){ return "uA:" + v; }`,
+        'index.ts': `import { useA } from "./a";\nimport { pg } from "./page";\nconsole.log(useA() + " " + pg);`,
+      });
+      cleanup = fixture.cleanup;
+      const result = await build({
+        entryPoints: [join(fixture.dir, 'index.ts')],
+        format,
+        splitting: true,
+        manualChunks: (id: string) =>
+          id.includes('inner') ? 'innerchunk' : id.includes('page') ? 'pagechunk' : null,
+      });
+      const outs = result.outputFiles!;
+      expect(jsPaths(outs).length).toBeGreaterThanOrEqual(2);
+      writeOutputs(fixture.dir, outs);
+      const entry = outs.find((o) => o.path.includes('index') && o.path.endsWith('.js'))!;
+      const { stdout } = await runNode(join(fixture.dir, entry.path));
+      expect(stdout).toBe('uA:INNER PAGE');
+    });
+  }
+
+  test('회귀: 단일 번들(splitting 아님) re-export 불변', async () => {
+    const fixture = await createFixture({
+      'inner.ts': `export const k = "K";`,
+      'mid.ts': `export { k } from "./inner";`,
+      'index.ts': `import { k } from "./mid";\nconsole.log("k:" + k);`,
+    });
+    cleanup = fixture.cleanup;
+    const result = await build({
+      entryPoints: [join(fixture.dir, 'index.ts')],
+      format: 'esm',
+    });
+    writeOutputs(fixture.dir, result.outputFiles!);
+    const out = result.outputFiles!.filter((o) => o.path.endsWith('.js'));
+    expect(out.length).toBe(1);
+    const { stdout } = await runNode(join(fixture.dir, out[0].path));
+    expect(stdout).toBe('k:K');
+  });
+});


### PR DESCRIPTION
## 버그

`export { x } from "./y"` 에서 y 가 별도 청크면 **re-export 심볼이 cross-chunk 로 전파되지 않아** referrer·재-exporter 양쪽에서 심볼 미바인딩 → 런타임 `ReferenceError`. **esm/cjs/iife splitting 공통 선재 버그** (P3-B 가 ESM 동작을 미러한 것; ESM splitting 도 동일하게 깨짐). #3321 작업 중 발견·기록했던 한계를 수정.

## 근본 원인 (`computeCrossChunkLinks`)

1. **(a)** re-export `export_bindings`(`.re_export`) 미처리 — P 가 심볼을 *사용* 안 하고 *전달*만 하므로 `import_binding` 이 없어 기존 import_bindings 루프가 놓침.
2. **(b)** 심볼 canonical 청크가 *직접 의존*이 아니면(importer→page→inner: importer 는 inner 직접 의존 안 함) `cross_chunk_imports` 에 안 들어감. emitter 는 `cross_chunk_imports` 를 순회하며 `imports_from` 을 조회하므로 → named import 누락 → 미바인딩.

## 수정

- import_bindings 루프: canonical 청크를 `cross_chunk_imports` 에 보장(seen_static dedup).
- 신설 `.re_export` `export_bindings` 루프: `resolveExportChain` 으로 canonical 해석 후 동일 등록.
- 양 경로를 단일 **`addCrossChunkSymbol`** 헬퍼로 통일 — *두 경로 divergence 가 곧 이 버그*였으므로 구조적으로 재발 차단(`/simplify` 권고 반영).
- star/namespace re-export(`export *`/`export * as ns`)는 별도 후속(범위 명시).

## 검증
- 신규 `tests/integration/tests/cross-chunk-reexport.test.ts`: esm/cjs/iife re-export 를 **실제 Node 실행**(iife 는 브라우저 시뮬) — `rx:RX po:PO`; 정적-전용 gap(b) `manualChunks` 결정 분리; 단일 번들 회귀. **픽스 없으면 6중 5 실패(정확한 `ReferenceError`), 픽스 후 6/6 통과**(에이전트 실증).
- `zig build test` **5183/5187 (0 fail)** — core(`computeCrossChunkLinks`) 변경이나 esm/cjs/iife/pm/manual-chunks 전 splitting 무회귀
- splitting 통합 **74 pass 0 fail**, app-builder CLI **14 pass**, smoke **3/3 esbuild MATCH**
- `/simplify` 3-에이전트: **정확성 버그 0**(공유 `seen_static` 무손실·aliased re-export·idempotency SAFE 검증), 헬퍼 추출·doc 정리 반영

## 별개 버그(범위 외, 기록만)
- **버그 B**: ESM 에서 한 심볼이 (re-export + 정적 cross-import) 이고 그 청크가 동적 entry 이기도 하면 `export {}` 중복 → `Duplicate export`. cjs/iife 는 `entry_mod_idx` break 로 회피, ESM 게이트 없음. re-export 픽스와 무관한 ESM entry/xchunk dedup 이슈 — RFC §7 후속 기록(PR4 후보).

RFC `docs/RFC_CJS_IIFE_CODE_SPLITTING.md` §7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)