### PR TITLE
fix(linker): reserve all-scope 1-char identifiers in Phase A (cross-module shadow)

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -760,6 +760,24 @@ pub const Linker = struct {
                     try exported.put(local_name, {});
                 }
             }
+            // Phase B 는 1-char binding 을 literal 로 보존한다 (mangler.zig
+            // shouldSkip `name.len <= 1`). bare scope-hoist 는 전 모듈이 한 scope
+            // 라, *nested* scope 의 1-char local (예: `for (let i=0; ...)`) 도
+            // 그 위치에서 free-ref 되는 Phase A top-level 이름과 같으면 shadow
+            // → 잘못된 binding 참조 (effect: `pipe`→`i` 가 Hash.js `for(let i)`
+            // 안에서 shadow → `i is not a function`). 기존 #2965 처리는
+            // module scope(scope_maps[0]) 1-char 만 reserved 에 넣어 nested 를
+            // 놓쳤다. 모든 scope 의 1-char 식별자를 Phase A reserved 에 등록해
+            // Phase A 가 그 이름을 다른 top-level 에 부여하지 못하게 한다.
+            // bounded: 1-char 이름은 최대 ~64종.
+            if (m.semantic) |sem| {
+                for (sem.scope_maps) |smap| {
+                    var sm_it = smap.iterator();
+                    while (sm_it.next()) |e| {
+                        if (e.key_ptr.len <= 1) try reserved.put(e.key_ptr.*, {});
+                    }
+                }
+            }
         }
 
         const helper_modules = @import("../runtime_helper_modules.zig");

--- a/tests/integration/tests/mangler-minify.test.ts
+++ b/tests/integration/tests/mangler-minify.test.ts
@@ -357,4 +357,48 @@ describe('mangler --minify 회귀', () => {
     expect(result.transpileExitCode).toBe(0);
     expect(result.runOutput).toBe('8');
   });
+
+  // 회귀 가드: Phase B 가 1-char binding 을 literal 로 보존하는데, bare scope-hoist
+  // 단일 scope 에서 *nested* 1-char local (`for (let i=0;...)`) 이 그 위치에서
+  // free-ref 되는 Phase A top-level 과 같은 이름이면 shadow → 잘못된 binding.
+  // effect 재현: `pipe`→`i` 가 Hash.js `for(let i)` 안에서 shadow → `i is not
+  // a function`. 기존 #2965 처리가 module-scope 1-char 만 reserved 등록해
+  // nested 를 놓친 것이 root cause. 다수 top-level 함수로 Phase A short-name
+  // 압력을 만들고, 다른 모듈 nested for-loop(`let i`) 안에서 그 함수를 호출 →
+  // --minify-identifiers 에서 수치가 정확해야 (shadow 시 TypeError/오값).
+  test('nested 1-char loop var 가 cross-module Phase A top-level 을 shadow 하지 않는다 (effect pipe/Hash.js 회귀)', async () => {
+    const fns = Array.from(
+      { length: 12 },
+      (_, k) =>
+        `export function comb${k}(a: number, b: number): number { return (a * 53) ^ (b + ${k}); }`,
+    ).join('\n');
+    const result = await bundleAndRun(
+      {
+        'fns.ts': fns,
+        'hash.ts': [
+          "import { comb0, comb1, comb2, comb3, comb4, comb5, comb6, comb7, comb8, comb9, comb10, comb11 } from './fns';",
+          'const all = [comb0, comb1, comb2, comb3, comb4, comb5, comb6, comb7, comb8, comb9, comb10, comb11];',
+          'export function hashArr(arr: number[]): number {',
+          '  let h = 6151;',
+          '  for (let i = 0; i < arr.length; i++) {',
+          '    h = all[i % all.length](h, arr[i]);', // top-level fn ref inside nested `let i` loop
+          '  }',
+          '  return h >>> 0;',
+          '}',
+        ].join('\n'),
+        'index.ts': [
+          "import { hashArr } from './hash';",
+          'console.log(hashArr([1, 2, 3, 4, 5, 6, 7, 8]));',
+        ].join('\n'),
+      },
+      'index.ts',
+      ['--minify-identifiers', '--platform=node'],
+    );
+    cleanup = result.cleanup;
+
+    expect(result.runStderr).not.toContain('is not a function');
+    expect(result.exitCode).toBe(0);
+    // 비-minify 기준값과 동일해야 (shadow 시 값이 달라지거나 throw).
+    expect(result.runOutput).toBe('610012807');
+  });
 });


### PR DESCRIPTION
## 증상
`import {runSync} from "effect/Effect.js"` (또는 effect barrel `import * as M`) + `--minify-identifiers`/`--minify` → 런타임 `TypeError: i is not a function`. named import·non-minify·`--minify-syntax`·14개 타 라이브러리는 정상.

## 루트커즈 (repro 최소화 + 런타임 계측으로 확정, 추측 4회 반증 후)
Phase B 는 `name.len <= 1` binding 을 literal 보존 (mangler `shouldSkip`). bare scope-hoist 는 전 모듈이 한 scope. effect Hash.js `export const array = arr => { let h=6151; for (let i=0; ...){ h = pipe(h, ...) } }` 의 nested 1-char loop var `i` 가 literal 인데, Function.js `export function pipe` 가 Phase A 에서 `i` 로 mangle → 단일 scope 에서 `pipe`(=`i`) 참조가 `for(let i)` 에 shadow → `i(h,...)`=숫자 호출 → TypeError.

`collectUnifiedInput` 의 Phase A `reserved` 단계가 **module-scope(scope_maps[0]) 1-char 만** 등록(#2965)하고 *nested* scope 1-char local 을 누락한 것이 원인.

## 수정
모든 `scope_maps` 의 1-char 식별자를 Phase A `reserved` 에 등록 → Phase A 가 그 이름을 다른 top-level 에 부여 불가. bounded (1-char ≤~64종, collectUnifiedInput 빌드당 1회 prep).

## 검증
| | |
|---|---|
| effect Effect.js+`--minify-identifiers` | **R 42** (이전 TypeError) |
| effect barrel import*+`--minify`/`--minify-identifiers` | **RB 42** |
| 14 lib(nanoid/klona/remeda/valibot/rxjs/date-fns/immer…) 런타임 | 회귀 0 |
| zig build test Debug+ReleaseFast | 0 fail |
| size | zod +107B(+0.03%)/effect +2021B(+0.2%)/rxjs +65B — silent-broken 수정 대가(이전엔 깨진 번들), correctness > size |
| 통합 fail-set (main vs fix apples-to-apples) | **fix-only 추가 0** (회귀 0; 차이는 main-only CSS-split flaky chunk-hash 뿐) |
| 신규 회귀 가드 테스트 | mangler-minify 16 pass/0 fail (다수 top-level fn + 타 모듈 nested `for(let i)` 호출, --minify-identifiers, 수치 정확성) |
| /simplify 3-agent | 의미보존 PASS(반례 없음)·재사용/효율 머지가능 |

#2965 reserved.put 와 idempotent 중복은 correctness 수정 표면 최소화 위해 의도적 잔존(가드 상이로 비동치 — 별도 cleanup).

Refs #3288

🤖 Generated with [Claude Code](https://claude.com/claude-code)