### PR TITLE
feat(bundler): sideEffects:false 모듈 top-level 멤버대입 member-augment 귀속

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1585,7 +1585,10 @@ pub fn emitModule(
                             }
                         } else {
                             // tree-shaker 없으면 기존 방식 (모듈 내부 computeReachable)
-                            if (stmt_info_mod.build(arena_alloc, transformer.ast, sem.symbols.items, sym_ids, &sem.unresolved_references, module.wrap_kind == .cjs)) |maybe_infos| {
+                            // member-augment 귀속은 tree-shaker BFS 경로 전용
+                            // (X→stmt writer 엣지가 cross-module reachability 에서만
+                            // 의미). non-tree-shaker fallback 은 게이트 off.
+                            if (stmt_info_mod.build(arena_alloc, transformer.ast, sem.symbols.items, sym_ids, &sem.unresolved_references, module.wrap_kind == .cjs, false)) |maybe_infos| {
                                 if (maybe_infos) |infos| {
                                     var used_sym_buf: std.ArrayListUnmanaged(u32) = .empty;
                                     defer used_sym_buf.deinit(arena_alloc);

--- a/src/bundler/graph/json_module.zig
+++ b/src/bundler/graph/json_module.zig
@@ -61,6 +61,8 @@ pub fn parse(self: *ModuleGraph, module: *Module) void {
                 analyzer.references.items,
                 if (module.semantic) |*s| &s.unresolved_references else null,
                 false,
+                // JSON 모듈엔 member-augment 패턴 없음 — 게이트 off.
+                false,
             ) catch null;
         }
     } else |_| {}

--- a/src/bundler/graph/parse_module.zig
+++ b/src/bundler/graph/parse_module.zig
@@ -201,6 +201,12 @@ pub fn parseModule(self: *ModuleGraph, idx: ModuleIndex) void {
             // Semantic Analyzer에서 사전 수집한 stmt↔symbol 매핑으로 StmtInfo 구축.
             // tree_shaker가 AST를 다시 순회하지 않아도 된다 (Phase 2 최적화).
             if (analyzer.stmt_info_count > 0) {
+                // 파싱 시점엔 package sideEffects 가 아직 resolve 안 됐을 수
+                // 있어 isUserDeclaredPure() 가 false 면 게이트 off — 이 경우
+                // transform_prepass resync 가 정확한 게이트로 재빌드한다
+                // (minify_identifiers 시 shouldRun=true).
+                const gate_member_augment =
+                    module.memberAugmentGate(self.transform_options_base.minify_syntax);
                 module.prebuilt_stmt_info = stmt_info_mod.buildFromSemantic(
                     arena_alloc,
                     &parser.ast,
@@ -209,6 +215,7 @@ pub fn parseModule(self: *ModuleGraph, idx: ModuleIndex) void {
                     analyzer.references.items,
                     if (module.semantic) |*s| &s.unresolved_references else null,
                     false,
+                    gate_member_augment,
                 ) catch null;
             }
         }

--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -305,6 +305,12 @@ fn refreshSemanticAndStmtInfoAfterAstMutation(
 
         module.prebuilt_stmt_info = null;
         if (analyzer.stmt_info_count > 0) {
+            // 주의: package sideEffects 는 이 시점(parseModule 내부 prepass)
+            // **이후** applySideEffectsFromPackageJson 으로 적용되므로 여기서는
+            // isUserDeclaredPure() 가 거의 항상 false → 게이트 off. 실제 게이트
+            // 적용은 tree_shaker 가 정확한 side-effect 상태로 재빌드할 때 일어난다.
+            const gate_member_augment =
+                module.memberAugmentGate(self.transform_options_base.minify_syntax);
             module.prebuilt_stmt_info = try stmt_info_mod.buildFromSemantic(
                 arena_alloc,
                 ast,
@@ -313,6 +319,7 @@ fn refreshSemanticAndStmtInfoAfterAstMutation(
                 analyzer.references.items,
                 if (module.semantic) |*s| &s.unresolved_references else null,
                 false,
+                gate_member_augment,
             );
         }
     }

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -387,6 +387,13 @@ pub const Module = struct {
         return self.side_effects_user_defined and !self.side_effects;
     }
 
+    /// member-augment 귀속 게이트: user-declared pure 모듈이고 크기 최적화
+    /// (minify_syntax) 일 때만 top-level `X.member = pureRHS` 를 X 의
+    /// augmentation 으로 귀속한다 (dev/non-minify 회귀 방지).
+    pub inline fn memberAugmentGate(self: *const Module, minify_syntax: bool) bool {
+        return self.isUserDeclaredPure() and minify_syntax;
+    }
+
     /// `entry_error_guard` 활성 시 이 모듈의 init 호출을 `__zntc_guarded(...)` 로 wrap 할지 결정.
     /// TLA (`uses_top_level_await`) 인 ESM 모듈은 await 가 lambda 안에 못 들어가므로 wrap 안 함.
     /// `wrap_kind == .none` (래핑 없음) 도 호출할 init 함수 자체가 없어 wrap 무의미.

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -13,6 +13,7 @@ const Ast = ast_mod.Ast;
 const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const Span = @import("../lexer/token.zig").Span;
+const TokenKind = @import("../lexer/token.zig").Kind;
 const Symbol = @import("../semantic/symbol.zig").Symbol;
 const Reference = @import("../semantic/symbol.zig").Reference;
 const scope_mod = @import("../semantic/scope.zig");
@@ -1040,6 +1041,93 @@ fn finalizeBucket(
     return try allocator.dupe(u32, bucket.items[0..out_len]);
 }
 
+/// 멤버-증강 귀속 (gated, #1577 semantic-preserving).
+///
+/// side-effects-free 로 user 가 선언한(`sideEffects:false`) 모듈에서 다음 형태의
+/// top-level 문장:
+///
+///     X.member = pureRHS;            // X = 이 모듈의 top-level 로컬 바인딩
+///
+/// 을 ESM 의미상 무조건적 부작용으로 시드하지 않고 "심볼 X 의 augmentation" 으로
+/// 귀속한다 (X 가 live 면 reachable, X 가 dead 면 stmt + cascade 제거).
+///
+/// 매칭 시 base object 의 심볼 인덱스 X 를 반환. 호출자는
+///   (1) 해당 stmt 의 has_side_effects 를 false 로 두고
+///   (2) stmt 를 X 의 writer bucket 에 추가 (X live ⇒ stmt reachable 의 X→stmt 방향)
+/// 한다.
+///
+/// 엄격 게이트 (모두 만족 시에만 반환):
+///   - 호출자 게이트: module.side_effects == false && side_effects_user_defined == true
+///     (`gate` 파라미터로 전달).
+///   - stmt = expression_statement → assignment_expression (`=` 단순 대입).
+///   - LHS = static_member_expression, base object = 단일 identifier_reference.
+///   - base 가 이 모듈 top-level (scope_id == 0) 비-import 로컬 심볼 X.
+///   - RHS 가 purity.isExprPure (PURE 주석 존중).
+/// 구조적 매칭만 수행 (심볼 해석 제외) — 매칭 시 base object 의 identifier
+/// NodeIndex 를 반환. 호출자가 symbol_ids (build) 또는 references
+/// (buildFromSemantic) 로 심볼을 해석하고 scope_id==0 + 비-import 를 검증한다.
+fn gatedMemberAugmentObjectNode(
+    ast: *const Ast,
+    stmt_node: Node,
+    unresolved_globals: ?*const purity.GlobalRefSet,
+) ?NodeIndex {
+    if (stmt_node.tag != .expression_statement) return null;
+    const expr_idx = stmt_node.data.unary.operand;
+    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return null;
+    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
+    if (expr.tag != .assignment_expression) return null;
+
+    // `=` (단순 대입) 만. `+=` 등 compound 는 X.member 를 read+write 하므로
+    // X dead 여도 단순 drop 이 안전하지 않아 제외 (assignment_expression 의
+    // operator 는 binary.flags 에 토큰 Kind 로 저장됨 — import_scanner 와 동일).
+    const op: TokenKind = @enumFromInt(expr.data.binary.flags);
+    if (op != .eq) return null;
+
+    const left_idx = expr.data.binary.left;
+    const right_idx = expr.data.binary.right;
+    if (left_idx.isNone() or @intFromEnum(left_idx) >= ast.nodes.items.len) return null;
+
+    // LHS = static_member_expression (computed / private / 중첩 멤버 제외).
+    const parts = staticMemberParts(ast, left_idx) orelse return null;
+    const obj = ast.nodes.items[@intFromEnum(parts.object)];
+    if (obj.tag != .identifier_reference) return null;
+
+    // base 가 unresolved global (`window.x = ...`) 이면 글로벌 변이 — 제외.
+    if (unresolved_globals) |globals| {
+        if (globals.contains(ast.getText(obj.span))) return null;
+    }
+
+    // RHS 순수성 (three 의 mergeUniforms 는 /*@__PURE__*/ 주석으로 pure 판정).
+    if (!purity.isExprPure(ast, right_idx, unresolved_globals)) return null;
+
+    return parts.object;
+}
+
+/// base identifier 심볼 X 가 이 모듈 top-level (scope_id==0) 비-import 로컬인지
+/// 검증해 X 의 심볼 인덱스를 반환. 아니면 null.
+fn validateMemberAugmentBaseSymbol(symbols: []const Symbol, x_sym: u32) ?u32 {
+    if (x_sym >= symbols.len) return null;
+    const sym = &symbols[x_sym];
+    if (@intFromEnum(sym.scope_id) != 0) return null;
+    if (sym.decl_flags.is_import) return null;
+    return x_sym;
+}
+
+/// `build` (symbol_ids 보유) 경로용 thin wrapper.
+fn gatedMemberAugmentSymbol(
+    ast: *const Ast,
+    stmt_node: Node,
+    symbol_ids: []const ?u32,
+    symbols: []const Symbol,
+    unresolved_globals: ?*const purity.GlobalRefSet,
+) ?u32 {
+    const obj_node = gatedMemberAugmentObjectNode(ast, stmt_node, unresolved_globals) orelse return null;
+    const obj_node_i = @intFromEnum(obj_node);
+    if (obj_node_i >= symbol_ids.len) return null;
+    const x_sym = symbol_ids[obj_node_i] orelse return null;
+    return validateMemberAugmentBaseSymbol(symbols, x_sym);
+}
+
 /// 두 builder (buildFromSemantic / build) 의 per-stmt Phase 1 본체.
 /// stmt 노드에서 cjs_export_facts 를 추가하고 side_effects 를 결정해 StmtInfo
 /// 슬롯을 만든다. `symbol_ids` 가 있으면 rhs_symbol 도 채움 (build), null 이면
@@ -1121,6 +1209,10 @@ pub fn buildFromSemantic(
     references: []const Reference,
     unresolved_globals: ?*const purity.GlobalRefSet,
     collect_cjs_exports: bool,
+    /// member-augment 귀속 게이트. `build` 의 동명 파라미터와 동일 의미 —
+    /// 호출자가 Module.memberAugmentGate() 로 판정해 전달. ESM 프리빌드
+    /// 경로(transform_prepass)가 이 함수를 쓰므로 실제 효과는 여기서 발생한다.
+    gate_member_augment: bool,
 ) !?ModuleStmtInfos {
     // program 노드 (마지막 노드)에서 top-level statement 인덱스 추출
     if (ast.nodes.items.len == 0) return null;
@@ -1150,6 +1242,11 @@ pub fn buildFromSemantic(
     var cjs_export_facts_buf: std.ArrayListUnmanaged(CjsExportFact) = .empty;
     errdefer deinitCjsExportFactsBuf(allocator, &cjs_export_facts_buf);
 
+    // 게이트 통과한 member-augment 문장: object identifier NodeIndex → stmt_idx.
+    // references 패스에서 이 노드의 symbol_id 를 해석해 writer bucket 에 귀속.
+    var member_augment_obj_to_stmt: std.AutoHashMapUnmanaged(u32, u32) = .empty;
+    defer member_augment_obj_to_stmt.deinit(allocator);
+
     // Pass 1: span + side-effect 결정. declared/referenced 는 빈 상태로 초기화.
     for (stmt_raw_indices, 0..) |raw_idx, stmt_i| {
         const idx: NodeIndex = @enumFromInt(raw_idx);
@@ -1164,6 +1261,18 @@ pub fn buildFromSemantic(
             &cjs_export_facts_buf,
             null,
         );
+
+        if (gate_member_augment and stmts[stmt_i].has_side_effects and ni < ast.nodes.items.len) {
+            if (gatedMemberAugmentObjectNode(
+                ast,
+                ast.nodes.items[ni],
+                unresolved_globals,
+            )) |obj_node| {
+                // has_side_effects 해제는 base 가 top-level 로컬임을 references
+                // 패스에서 확정한 뒤에 한다 (조건부). 우선 후보로만 등록.
+                try member_augment_obj_to_stmt.put(allocator, @intFromEnum(obj_node), @intCast(stmt_i));
+            }
+        }
     }
 
     // Pass 2: references → declared/referenced per-stmt bucket 분배.
@@ -1196,6 +1305,18 @@ pub fn buildFromSemantic(
         if (r.stmt_idx >= stmt_count) continue;
         const sym_u32: u32 = @intFromEnum(r.symbol_id);
         if (sym_u32 >= symbols.len) continue;
+
+        // member-augment 귀속: 이 ref 가 게이트 통과 stmt 의 base object
+        // identifier 면 X = sym_u32 가 top-level 로컬인지 확정. 맞으면
+        // stmt 의 has_side_effects 를 해제하고 X 의 writer bucket 에 등록한다.
+        if (member_augment_obj_to_stmt.fetchRemove(@intFromEnum(r.node_index))) |kv| {
+            const aug_stmt = kv.value;
+            if (validateMemberAugmentBaseSymbol(symbols, sym_u32)) |x_sym| {
+                stmts[aug_stmt].has_side_effects = false;
+                try writer_buckets[x_sym].append(allocator, aug_stmt);
+            }
+        }
+
         if (r.flags.declare) {
             // #1669: analyzer 가 모든 scope 선언에 declare ref 를 남기므로 top-level (scope_id==0)
             // 만 bucket 분배. 함수/블록 내부 declare ref 는 `scope_stmt_idx` 와 함께 references
@@ -1294,6 +1415,12 @@ pub fn build(
     symbol_ids: []const ?u32,
     unresolved_globals: ?*const purity.GlobalRefSet,
     collect_cjs_exports: bool,
+    /// member-augment 귀속 게이트. 호출자가 Module.memberAugmentGate()
+    /// (side_effects==false && side_effects_user_defined==true && minify_syntax)
+    /// 로 판정해 전달. true 이면 top-level `X.member = pureRHS`
+    /// (X = 이 모듈 top-level 로컬) 를 무조건 side-effect 시드 대신
+    /// X 의 augmentation 으로 귀속한다.
+    gate_member_augment: bool,
 ) !?ModuleStmtInfos {
     // program 노드 (마지막 노드)
     if (ast.nodes.items.len == 0) return null;
@@ -1327,6 +1454,12 @@ pub fn build(
     var stmt_spans = try allocator.alloc(Span, stmt_count);
     defer allocator.free(stmt_spans);
 
+    // 게이트 통과한 member-augment 문장 → 귀속 대상 심볼 X. Phase 2 의
+    // writer_bufs 채우기 직전에 X 의 writer bucket 에 추가한다 (X live ⇒
+    // stmt reachable, X dead ⇒ stmt + cascade drop). (stmt_i, x_sym) 쌍.
+    var member_augment_pairs: std.ArrayListUnmanaged([2]u32) = .empty;
+    defer member_augment_pairs.deinit(allocator);
+
     for (stmt_raw_indices, 0..) |raw_idx, stmt_i| {
         const idx: NodeIndex = @enumFromInt(raw_idx);
         const ni = @intFromEnum(idx);
@@ -1341,6 +1474,22 @@ pub fn build(
             symbol_ids,
         );
         stmt_spans[stmt_i] = stmts[stmt_i].span;
+
+        // member-augment 귀속: 게이트 ON + has_side_effects 로 분류된
+        // top-level `X.member = pureRHS` 만 대상. CJS export fact 로 이미
+        // 안전 처리된 stmt (has_side_effects=false) 는 건드리지 않는다.
+        if (gate_member_augment and stmts[stmt_i].has_side_effects and ni < ast.nodes.items.len) {
+            if (gatedMemberAugmentSymbol(
+                ast,
+                ast.nodes.items[ni],
+                symbol_ids,
+                symbols,
+                unresolved_globals,
+            )) |x_sym| {
+                stmts[stmt_i].has_side_effects = false;
+                try member_augment_pairs.append(allocator, .{ @intCast(stmt_i), x_sym });
+            }
+        }
     }
 
     // Phase 2: 모든 AST 노드를 단일 패스로 순회하며 심볼 수집 — O(N log S)
@@ -1414,6 +1563,20 @@ pub fn build(
         }
         if (referenced_bufs[stmt_i].items.len > 0) {
             stmt.referenced_symbols = try referenced_bufs[stmt_i].toOwnedSlice(allocator);
+        }
+    }
+
+    // member-augment 귀속: 게이트 통과한 `X.member = pureRHS` 를 X 의 writer
+    // bucket 에 등록 → tree_shaker 가 X 가 live 가 되면 enqueueSymbolLiveStatements
+    // / referenced_symbols→writerStmts 경로로 이 stmt 를 reachable 시킨다.
+    // X 가 끝까지 dead 면 stmt 는 has_side_effects=false 라 seed 되지 않고
+    // RHS cascade (three 의 ShaderChunk/GLSL) 까지 함께 제거된다.
+    for (member_augment_pairs.items) |pair| {
+        const stmt_i_u32 = pair[0];
+        const x_sym = pair[1];
+        if (x_sym >= writer_bufs.len) continue;
+        if (std.mem.indexOfScalar(u32, writer_bufs[x_sym].items, stmt_i_u32) == null) {
+            try writer_bufs[x_sym].append(allocator, stmt_i_u32);
         }
     }
 

--- a/src/bundler/stmt_info_test.zig
+++ b/src/bundler/stmt_info_test.zig
@@ -35,6 +35,7 @@ fn buildTestInfos(allocator: std.mem.Allocator, source: []const u8) !struct {
         analyzer.symbol_ids.items,
         &analyzer.unresolved_references,
         false,
+        false,
     )) orelse return error.NullResult;
 
     return .{ .infos = infos, .arena = arena };
@@ -342,6 +343,7 @@ fn buildTestInfosWithCjs(allocator: std.mem.Allocator, source: []const u8) !stru
         analyzer.symbol_ids.items,
         &analyzer.unresolved_references,
         true,
+        false,
     )) orelse return error.NullResult;
 
     return .{ .infos = infos, .arena = arena };

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -465,7 +465,39 @@ pub const TreeShaker = struct {
                 // 와 동일 게이트.
                 if (m.wrap_kind == .esm and !m.isUserDeclaredPure()) continue;
 
+                // package sideEffects 는 transform_prepass(=prebuilt_stmt_info
+                // 생성 시점) **이후**에 applySideEffectsFromPackageJson 으로
+                // 적용되므로, prebuilt 은 항상 gate=false 로 만들어진다. 게이트가
+                // 성립하는 (pure + minify) 모듈은 prebuilt 을 버리고 여기서
+                // buildFromSemantic (prebuilt 과 동일 알고리즘) 으로 정확한
+                // side-effect 상태 + 게이트 ON 으로 재빌드한다. build() (span 기반
+                // 휴리스틱) 으로 바꾸면 down-level 된 AST (es2021 private-field 등)
+                // 에서 stmt↔symbol 매핑이 어긋나 과도 shake 회귀가 난다 — 반드시
+                // prebuilt 과 같은 references 기반 buildFromSemantic 을 쓴다.
+                const gate_member_augment =
+                    m.memberAugmentGate(self.graph.transform_options_base.minify_syntax);
+
                 if (m.wrap_kind != .cjs) {
+                    if (gate_member_augment) {
+                        if (m.semantic) |*sem| {
+                            if (m.ast) |*ast| {
+                                if (stmt_info_mod.buildFromSemantic(
+                                    self.allocator,
+                                    ast,
+                                    sem.symbols.items,
+                                    sem.scopes,
+                                    sem.references,
+                                    &sem.unresolved_references,
+                                    false,
+                                    true,
+                                ) catch null) |rebuilt| {
+                                    module_stmt_infos[i] = rebuilt;
+                                    continue;
+                                }
+                            }
+                        }
+                        // 재빌드 실패 → prebuilt fallback (게이트 미적용, 안전).
+                    }
                     if (m.prebuilt_stmt_info) |prebuilt| {
                         module_stmt_infos[i] = prebuilt;
                         prebuilt_mask.set(i);
@@ -482,6 +514,7 @@ pub const TreeShaker = struct {
                     sem.symbol_ids,
                     &sem.unresolved_references,
                     m.wrap_kind == .cjs,
+                    gate_member_augment,
                 ) catch null;
             }
         }


### PR DESCRIPTION
## 배경

`import { Vector3 } from 'three'` 를 minify 번들하면 ZNTC/esbuild/rolldown 은 ~215KB, rspack 은 ~136KB 였습니다. 격차 전부가 three.module.js 의 거대 GLSL 셰이더 문자열 상수(`ShaderChunk`, ~110KB)였습니다.

루트코즈는 three.module.js 의 top-level 한 줄:

```js
ShaderLib.physical = { uniforms: /*@__PURE__*/ mergeUniforms([ ShaderLib.standard.uniforms, ... ]), ... };
```

이 `X.member = ...` 톱레벨 멤버대입을 ZNTC tree-shaker 가 **무조건 ESM 부작용**으로 분류해 reachable 시드 → `ShaderLib → ShaderChunk → 수백 개 GLSL 문자열` 을 전부 핀으로 박았습니다. rspack 은 three 의 `package.json` `sideEffects` 글롭(`./src/nodes/**/*`)에 `build/three.module.js` 가 안 걸리는 걸 보고 모듈을 순수하다고 신뢰 → 이 대입문을 삭제 → 캐스케이드 제거합니다.

## 변경

`Module.isUserDeclaredPure()` (= package.json `"sideEffects": false`) 인 모듈에서, top-level

```
X.member = pureRHS;   // X = 이 모듈 top-level 로컬 바인딩
```

을 무조건 부작용 시드하지 않고 **심볼 X 의 augmentation 으로 귀속**합니다. X 가 live 면 reachable, X 가 dead 면 그 문장과 RHS cascade(three 의 ShaderChunk/GLSL)까지 함께 제거됩니다. rolldown 의 `DeterminedSideEffects::UserDefined(false)` 게이트와 같은 안전 기준입니다.

### 엄격 게이트 (모두 만족 시에만)

- `Module.memberAugmentGate()` = `isUserDeclaredPure() && minify_syntax` — dev/non-minify 는 기존 보수 동작 유지(회귀 방지)
- `=` 단순 대입만 (`+=` 등 read+write 는 제외)
- LHS = 정적 멤버, base = 이 모듈 top-level(scope_id==0) 비-import 로컬 심볼
- base 가 unresolved global(`window.x = ...`) 이면 제외
- RHS 가 `purity.isExprPure` (PURE 주석 존중)

> Zig 초보 메모: `?NodeIndex` 는 "AST 노드 인덱스 또는 null" 인 옵셔널입니다. `gatedMemberAugmentObjectNode` 는 구조 매칭만 하고 base identifier 의 NodeIndex 만 돌려줍니다. 심볼 해석(이 식별자가 정말 top-level 로컬 X 인가)은 `build` 경로는 `symbol_ids` 배열, `buildFromSemantic` 경로는 `references` 패스에서 각각 확정합니다 — 두 빌더가 가진 정보가 달라 매칭/귀속 코드가 둘로 나뉜 이유입니다. 귀속은 X 의 *writer bucket* 에 그 문장을 넣는 방식이라, tree-shaker BFS 가 "X 가 live 가 되면 그 writer 문장도 reachable" 로 자연히 X→stmt 방향을 만듭니다.

`package sideEffects` 는 prebuilt_stmt_info 생성(parse/prepass) **이후** 에 적용되므로 prebuilt 은 항상 게이트 off 입니다. 게이트가 성립하는 모듈은 tree_shaker 가 정확한 side-effect 상태로 `buildFromSemantic` 재빌드(prebuilt 과 동일 references 기반 알고리즘 — `build()` span 휴리스틱은 down-level AST 에서 stmt↔symbol 어긋나 과도 shake)합니다.

## 측정 (ReleaseFast)

| 케이스 | ZNTC | 비고 |
|---|---|---|
| three (`Vector3`) minify | 206KB → **12KB** | rspack 136KB 대비 0.09x, Output MATCH |
| three deep (8 클래스) minify | 51KB | 실행 결과 esbuild 와 **바이트 동일** |
| effect / zod minify | 148KB / 62KB | 실행 결과 esbuild 와 동일, 회귀 없음 |

**전체 smoke 매트릭스(144) baseline 대비**: 크기 변화 `three: 206→12KB` **단 1건**, 나머지 143개 전부 바이트 동일(|Δ|<0.3KB), Output MATCH/DIFF 집합 완전 동일 — **회귀 0**. (사전 존재 DIFF: lodash-es default/chrome80·preact·nanoid@node16 — 기능 stash baseline 에서도 동일하게 발생, 본 변경과 무관.)

## 검증

- `zig build test` 통과 (error/fail/panic 0)
- 통합 테스트 235 pass / 0 fail (tree-shake-precision, export-preserve-minify, minify-orphan-dead-store, bundle-smoke, mangler-minify, circular, dynamic-import, library-smoke 등)
- RN fixture 오염 0

## 관련 이슈

관련 #2060 (번들 사이즈 최적화 로드맵 — 정확한 resolution 유지 + 안전 증명 가능한 공격적 DCE). 본 PR 은 그 방향의 구체 기여이며 로드맵 전체를 닫지는 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)