### PR TITLE
test(smoke): 함수참조/비결정 entry 를 값·동작 기반으로 교체 (false-positive DIFF 제거)

### DIFF
--- a/tests/benchmark/smoke.ts
+++ b/tests/benchmark/smoke.ts
@@ -357,7 +357,7 @@ const projects: ProjectConfig[] = [
   {
     name: 'lodash-es',
     pkg: 'lodash-es',
-    entry: `import { groupBy, sortBy, uniq } from 'lodash-es';\nconsole.log(groupBy, sortBy, uniq);`,
+    entry: `import { groupBy, sortBy, uniq } from 'lodash-es';\nconsole.log(JSON.stringify(groupBy([{ c: 'a', n: 1 }, { c: 'b', n: 2 }, { c: 'a', n: 3 }], 'c')), JSON.stringify(sortBy([{ n: 3 }, { n: 1 }, { n: 2 }], 'n')), JSON.stringify(uniq([1, 2, 2, 3, 3, 3])));`,
     deepEntry: `import { groupBy, sortBy, uniq, chunk, flatMap, keyBy, mapValues, pick, omit, debounce } from 'lodash-es';
 const arr = [{ c: 'a', n: 1 }, { c: 'b', n: 2 }, { c: 'a', n: 3 }, { c: 'b', n: 4 }, { c: 'a', n: 5 }];
 const grouped = groupBy(arr, 'c');
@@ -386,7 +386,7 @@ console.log(JSON.stringify({
   {
     name: 'preact',
     pkg: 'preact',
-    entry: `import { h, render } from 'preact';\nconsole.log(h, render);`,
+    entry: `import { h, render } from 'preact';\nconst v = h('div', { id: 't' }, 'x');\nconsole.log(v.type, JSON.stringify(v.props), typeof render);`,
     deepEntry: `import { h, Fragment, Component, cloneElement, createRef, createContext, options } from 'preact';
 const el = h('div', { id: 't' }, h('span', null, 'a'), h('span', null, 'b'));
 const cloned = cloneElement(el, { 'data-x': '1' });
@@ -1745,7 +1745,7 @@ console.log(JSON.stringify({
   {
     name: 'lodash-es@chrome80',
     pkg: 'lodash-es',
-    entry: `import { groupBy, sortBy, uniq } from 'lodash-es';\nconsole.log(groupBy, sortBy, uniq);`,
+    entry: `import { groupBy, sortBy, uniq } from 'lodash-es';\nconsole.log(JSON.stringify(groupBy([{ c: 'a', n: 1 }, { c: 'b', n: 2 }, { c: 'a', n: 3 }], 'c')), JSON.stringify(sortBy([{ n: 3 }, { n: 1 }, { n: 2 }], 'n')), JSON.stringify(uniq([1, 2, 2, 3, 3, 3])));`,
     target: 'chrome80',
   },
   {
@@ -1763,7 +1763,7 @@ console.log(JSON.stringify({
   {
     name: 'nanoid@node16',
     pkg: 'nanoid',
-    entry: `import { nanoid } from 'nanoid';\nconsole.log(nanoid());`,
+    entry: `import { nanoid } from 'nanoid';\nconst id = nanoid();\nconsole.log(typeof id, id.length, /^[A-Za-z0-9_-]+$/.test(id));`,
     target: 'node16',
     platform: 'node',
   },


### PR DESCRIPTION
## 요약

`smoke.ts --minify-all` 에서 `lodash-es`, `lodash-es@chrome80`, `preact`, `nanoid@node16` 가 Output **DIFF** 로 뜨던 것은 번들러 정확성 버그가 아니라 **harness false-positive** 였습니다 (#3360). 해당 entry 가 비-semantic 출력을 비교했습니다:

- `console.log(groupBy, sortBy, uniq)` / `console.log(h, render)` → minify 된 함수 `.name` (`[Function: wn]` vs `[Function: Gi]` …) — 번들러별 mangler 산물이라 다른 게 정상
- `console.log(nanoid())` → 매 실행 랜덤값 — 번들러 무관 항상 다름

이 때문에 `outputs match` 카운트가 실제보다 낮고, 진짜 회귀가 "원래 DIFF" 로 묻힐 위험(false negative)이 있었습니다.

## 변경

`lodash-es@es5/@es2015` 변형(이미 MATCH, 값 기반)과 동일하게 **결과 값/구조를 출력**하도록 4개 entry 교체:

| project | before | after |
|---|---|---|
| lodash-es, @chrome80 | `console.log(groupBy, sortBy, uniq)` | `groupBy/sortBy/uniq` 실행 결과 `JSON.stringify` |
| preact | `console.log(h, render)` | `h()` vnode 의 `type`/`props` + `typeof render` |
| nanoid@node16 | `console.log(nanoid())` | `typeof` / `length`(21) / charset 정규식 (랜덤값 자체 비교 금지) |

## 검증

4개 모두 ZNTC/esbuild/rolldown **MATCH** 로 전환 (`6/6 outputs match baseline`). 이제 이 라이브러리들에서 실제 동작 회귀가 발생하면 정상적으로 DIFF 로 드러납니다. 번들러 코드 변경 없음 — `tests/benchmark/smoke.ts` projects 정의만 수정. PR #3359 와 독립.

Closes #3360

🤖 Generated with [Claude Code](https://claude.com/claude-code)