### PR TITLE
RN HMR Refresh 심볼 바인딩 보존

### DIFF
--- a/packages/core/test/core/react-refresh/transpile.ts
+++ b/packages/core/test/core/react-refresh/transpile.ts
@@ -20,6 +20,15 @@ describe('React Refresh: transpile() single-file path', () => {
     expect(code).toContain('$RefreshReg$(_c, "MyArrow")');
   });
 
+  test('ES5 lowering 경로에서도 arrow assignment 컴포넌트를 등록', () => {
+    const code = transpileReactRefreshCode(
+      `const PermissionDialog = () => <div />;\nexport default PermissionDialog;`,
+      { target: 'es5', reactRefresh: true },
+    );
+    expect(code).toContain('_c = PermissionDialog');
+    expect(code).toContain('$RefreshReg$(_c, "PermissionDialog")');
+  });
+
   test('function expression assignment 컴포넌트도 binding 이름으로 등록', () => {
     const code = transpileReactRefreshCode(
       `const MyFE = function() { return null; };\nexport default MyFE;`,

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -1980,6 +1980,53 @@ test "react_native preserve_symlinks: CJS-wrapped package ESM imports resolve fr
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require_hoist_non_react_statics") != null);
 }
 
+test "preserve_symlinks: alias to pnpm symlink package root bundles package entry" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("apps/app/node_modules");
+    try writeFile(tmp.dir, "node_modules/.pnpm/react@1/node_modules/react/package.json", "{\"main\":\"index.js\"}");
+    try writeFile(tmp.dir, "node_modules/.pnpm/react@1/node_modules/react/index.js", "exports.version = 'test';\n");
+    tmp.dir.symLink(
+        "../../../node_modules/.pnpm/react@1/node_modules/react",
+        "apps/app/node_modules/react",
+        .{ .is_directory = true },
+    ) catch |err| switch (err) {
+        error.AccessDenied, error.PermissionDenied => return error.SkipZigTest,
+        else => return err,
+    };
+
+    try writeFile(tmp.dir, "apps/app/index.js",
+        \\const React = require("react");
+        \\console.log(React.version);
+    );
+
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+    const entry = try absPath(&tmp, "apps/app/index.js");
+    defer std.testing.allocator.free(entry);
+    const react_root = try std.fs.path.join(std.testing.allocator, &.{ root, "apps/app/node_modules/react" });
+    defer std.testing.allocator.free(react_root);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .browser,
+        .format = .iife,
+        .tree_shaking = false,
+        .metafile = true,
+        .preserve_symlinks = true,
+        .alias = &.{.{ .from = "react", .to = react_root }},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    const metafile = result.metafile_json orelse return error.TestUnexpectedResult;
+    try std.testing.expect(std.mem.indexOf(u8, metafile, "apps/app/node_modules/react/index.js") != null);
+    try std.testing.expect(std.mem.indexOf(u8, metafile, "apps/app/node_modules/react\"") == null);
+}
+
 test "shimMissingExports: missing export에 shim 변수 생성" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/bundler_test/splitting_dev.zig
+++ b/src/bundler/bundler_test/splitting_dev.zig
@@ -4,6 +4,7 @@ const types = @import("../types.zig");
 const emitter = @import("../emitter.zig");
 const ResolveCache = @import("../resolve_cache.zig").ResolveCache;
 const ModuleGraph = @import("../graph.zig").ModuleGraph;
+const compat = @import("../../transformer/compat.zig");
 const test_helpers = @import("../test_helpers.zig");
 const writeFile = test_helpers.writeFile;
 const absPath = test_helpers.absPath;
@@ -1678,6 +1679,80 @@ test "Bundler: refresh — user-land .tsx still registers (positive control)" {
     try std.testing.expect(!result.hasErrors());
 
     try std.testing.expect(std.mem.indexOf(u8, result.output, "$RefreshReg$(_c, \"MyComp\"") != null);
+}
+
+test "Bundler: refresh — ES5 lexical lowering preserves arrow component registration" {
+    // RN/Hermes 하위 타겟처럼 const/arrow lowering 이 켜져도, variable declarator
+    // 후처리(React Refresh registration)가 누락되면 안 된다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "PermissionDialog.tsx",
+        \\const PermissionDialog = () => null;
+        \\export default PermissionDialog;
+    );
+
+    const entry = try absPath(&tmp, "PermissionDialog.tsx");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .react_refresh = true,
+        .unsupported = compat.fromESTarget(.es5),
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "_c = PermissionDialog") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$RefreshReg$(_c, \"PermissionDialog\"") != null);
+}
+
+test "Bundler: refresh — registration follows linker rename through barrel export" {
+    // `const Component = () => {}; export default Component;` 모듈을 barrel 이
+    // 같은 이름으로 re-export 하면 linker 가 한쪽을 `Component$1` 로 rename 한다.
+    // Refresh 등록용 `_c = Component` 참조도 같은 symbol_id 를 따라가야 한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.tsx",
+        \\import './shadow';
+        \\import { EquipmentSearchBody } from './EquipmentSearch';
+        \\console.log(EquipmentSearchBody);
+    );
+    try writeFile(tmp.dir, "shadow.ts",
+        \\const EquipmentSearchBody = 'shadow';
+        \\console.log(EquipmentSearchBody);
+    );
+    try writeFile(tmp.dir, "EquipmentSearch.ts",
+        \\import EquipmentSearchBody from './EquipmentSearchBody';
+        \\export { EquipmentSearchBody };
+    );
+    try writeFile(tmp.dir, "EquipmentSearchBody.tsx",
+        \\const EquipmentSearchBody = () => null;
+        \\EquipmentSearchBody.propTypes = {};
+        \\export default EquipmentSearchBody;
+    );
+
+    const entry = try absPath(&tmp, "entry.tsx");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .react_refresh = true,
+        .unsupported = compat.fromESTarget(.es5),
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expect(!result.hasErrors());
+
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "= EquipmentSearchBody$") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "= EquipmentSearchBody;\n") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$RefreshReg$(_c, \"EquipmentSearchBody\"") != null);
 }
 
 test "Bundler: dev mode ES5 runtime helpers injected globally" {

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -418,17 +418,15 @@ pub const Resolver = struct {
                 defer self.allocator.free(raw);
                 const candidate = try std.fs.path.resolve(self.allocator, &.{raw});
                 defer self.allocator.free(candidate);
-                if (try self.tryResolveAbsolutePath(candidate)) |r| return r;
+                if (try self.tryResolvePathLike(candidate)) |r| return r;
             }
         }
         return null;
     }
 
     /// 절대 경로 1 개에 대해 `resolveInner` 의 pass #1–#4 와 동일 로직으로 resolve 시도.
-    fn tryResolveAbsolutePath(self: *Resolver, abs_path: []const u8) ResolveError!?ResolveResult {
-        return self.tryResolvePathLike(abs_path);
-    }
-
+    /// pnpm symlink package root alias 처럼 file 과 dir 양쪽으로 보이는 경우는
+    /// `tryDirectoryIndex` 를 먼저 시도해 package entry(index/main/exports) 로 간다.
     fn tryResolvePathLike(self: *Resolver, abs_path: []const u8) ResolveError!?ResolveResult {
         const maybe_dir = self.dirExists(abs_path);
         if (maybe_dir) {

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -424,13 +424,27 @@ pub const Resolver = struct {
         return null;
     }
 
-    /// 절대 경로 1 개에 대해 파일 존재 → 확장자 → TS 매핑 → index 순으로 resolve 시도.
-    /// `resolveInner` 의 pass #1–#4 와 동일 로직을 독립 함수로 추출한 것.
+    /// 절대 경로 1 개에 대해 `resolveInner` 의 pass #1–#4 와 동일 로직으로 resolve 시도.
     fn tryResolveAbsolutePath(self: *Resolver, abs_path: []const u8) ResolveError!?ResolveResult {
-        if (self.fileExists(abs_path)) return (try self.makeResult(abs_path));
-        if (try self.tryExtensions(abs_path)) |r| return r;
-        if (try self.tryTsExtensionMapping(abs_path)) |r| return r;
-        if (try self.tryDirectoryIndex(abs_path)) |r| return r;
+        return self.tryResolvePathLike(abs_path);
+    }
+
+    fn tryResolvePathLike(self: *Resolver, abs_path: []const u8) ResolveError!?ResolveResult {
+        const maybe_dir = self.dirExists(abs_path);
+        if (maybe_dir) {
+            // DirEntryCache 는 symlink target 을 readdir 만으로 알 수 없어 file+dir
+            // 양쪽에 등록한다. pnpm package symlink root 를 alias 로 직접 가리키면
+            // fileExists 가 먼저 true 가 되어 package entry(index/main/exports)를 건너뛰므로,
+            // ambiguous directory 후보는 package/directory resolve 를 먼저 시도한다.
+            if (try self.tryDirectoryIndex(abs_path)) |result| return result;
+        }
+
+        if (self.fileExists(abs_path)) return try self.makeResult(abs_path);
+        if (try self.tryExtensions(abs_path)) |result| return result;
+        if (try self.tryTsExtensionMapping(abs_path)) |result| return result;
+        if (!maybe_dir) {
+            if (try self.tryDirectoryIndex(abs_path)) |result| return result;
+        }
         return null;
     }
 
@@ -494,25 +508,7 @@ pub const Resolver = struct {
         };
         defer self.allocator.free(joined);
 
-        // 1. 정확한 경로가 파일로 존재하는지
-        if (self.fileExists(joined)) {
-            return (try self.makeResult(joined)).?;
-        }
-
-        // 2. 확장자 추가 탐색 (.ts, .tsx, .js, .jsx, .json)
-        if (try self.tryExtensions(joined)) |result| {
-            return result;
-        }
-
-        // 3. TS 확장자 매핑 (./foo.js → ./foo.ts, ./foo.tsx)
-        if (try self.tryTsExtensionMapping(joined)) |result| {
-            return result;
-        }
-
-        // 4. 디렉토리 index 탐색 (./dir → ./dir/index.ts)
-        if (try self.tryDirectoryIndex(joined)) |result| {
-            return result;
-        }
+        if (try self.tryResolvePathLike(joined)) |result| return result;
 
         return error.ModuleNotFound;
     }

--- a/src/bundler/resolver_test.zig
+++ b/src/bundler/resolver_test.zig
@@ -614,6 +614,48 @@ test "resolve.alias — multiple entries first match wins" {
     try std.testing.expectEqualStrings("preact/compat", result.?);
 }
 
+test "resolve.alias — symlink package root resolves package entry" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("apps/app/src");
+    try tmp.dir.makePath("apps/app/node_modules");
+    try writeFile(tmp.dir, "node_modules/.pnpm/react@1/node_modules/react/package.json", "{\"main\":\"index.js\"}");
+    try writeFile(tmp.dir, "node_modules/.pnpm/react@1/node_modules/react/index.js", "exports.version = 'test';\n");
+    tmp.dir.symLink(
+        "../../../node_modules/.pnpm/react@1/node_modules/react",
+        "apps/app/node_modules/react",
+        .{ .is_directory = true },
+    ) catch |err| switch (err) {
+        error.AccessDenied, error.PermissionDenied => return error.SkipZigTest,
+        else => return err,
+    };
+
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+    const source_dir = try std.fs.path.join(std.testing.allocator, &.{ root, "apps/app/src" });
+    defer std.testing.allocator.free(source_dir);
+    const react_root = try std.fs.path.join(std.testing.allocator, &.{ root, "apps/app/node_modules/react" });
+    defer std.testing.allocator.free(react_root);
+
+    var cache = DirEntryCache.init(std.testing.allocator);
+    defer cache.deinit();
+
+    const aliases: []const AliasEntry = &.{
+        .{ .from = "react", .to = react_root },
+    };
+    var resolver = Resolver.init(std.testing.allocator);
+    resolver.dir_cache = &cache;
+    resolver.preserve_symlinks = true;
+    resolver.alias = aliases;
+
+    const result = try resolver.resolve(source_dir, "react");
+    defer std.testing.allocator.free(result.path);
+
+    try std.testing.expect(pathEndsWith(result.path, "apps/app/node_modules/react/index.js"));
+    try std.testing.expect(!pathEndsWith(result.path, "apps/app/node_modules/react"));
+}
+
 // ============================================================
 // DirEntryCache
 // ============================================================

--- a/src/transformer/plugin_state.zig
+++ b/src/transformer/plugin_state.zig
@@ -37,6 +37,9 @@ pub const WorkletState = struct {
 pub const RefreshRegistration = struct {
     /// _c / _c2 핸들 변수의 string_table Span (재사용)
     handle_span: Span,
+    /// 등록 대상 컴포넌트 binding node. linker rename 이 Refresh assignment 에도
+    /// 적용되도록 symbol_id 를 이 노드에서 복사한다.
+    component_idx: NodeIndex = .none,
     /// 컴포넌트 이름 (문자열)
     name: []const u8,
 };

--- a/src/transformer/plugin_state.zig
+++ b/src/transformer/plugin_state.zig
@@ -38,8 +38,9 @@ pub const RefreshRegistration = struct {
     /// _c / _c2 핸들 변수의 string_table Span (재사용)
     handle_span: Span,
     /// 등록 대상 컴포넌트 binding node. linker rename 이 Refresh assignment 에도
-    /// 적용되도록 symbol_id 를 이 노드에서 복사한다.
-    component_idx: NodeIndex = .none,
+    /// 적용되도록 symbol_id 를 이 노드에서 복사한다. 호출자(`appendRefreshRegistration`)
+    /// 는 component 이름이 확정된 뒤에만 등록을 추가하므로 항상 non-none.
+    component_idx: NodeIndex,
     /// 컴포넌트 이름 (문자열)
     name: []const u8,
 };

--- a/src/transformer/transformer/declarations.zig
+++ b/src/transformer/transformer/declarations.zig
@@ -24,6 +24,49 @@ inline fn isBindingPattern(self: *const Transformer, idx: NodeIndex) bool {
     return tag == .object_pattern or tag == .array_pattern;
 }
 
+fn postProcessVariableDeclaratorInit(
+    self: *Transformer,
+    new_name: NodeIndex,
+    new_init: NodeIndex,
+) Error!NodeIndex {
+    var init = new_init;
+
+    // styled-components: tag 를 `.withConfig({displayName})` 로 wrap. fast-path 로 1) 옵션,
+    // 2) binding 감지, 3) init.tag == tagged_template_expression 을 사전 거른 뒤에만
+    // 본 helper 호출. var_name 은 block-scoping rename 후 안전하도록 new_name 에서 읽음.
+    if (!new_name.isNone() and styled_components_mod.shouldAttemptWrap(self, init)) {
+        const new_name_node = self.ast.getNode(new_name);
+        if (new_name_node.tag == .binding_identifier or new_name_node.tag == .identifier_reference) {
+            const var_name = self.ast.getText(new_name_node.data.string_ref);
+            init = try styled_components_mod.wrapStyledTagInExpr(self, init, var_name);
+        }
+    }
+    // emotion autoLabel: const X = css`...` → css`label:X;...`
+    if (self.options.emotion and !new_name.isNone() and !init.isNone()) {
+        const new_name_node = self.ast.getNode(new_name);
+        if (new_name_node.tag == .binding_identifier or new_name_node.tag == .identifier_reference) {
+            const var_name = self.ast.getText(new_name_node.data.string_ref);
+            init = try emotion_mod.maybeTransformEmotionTemplate(self, init, var_name);
+        }
+    }
+    // styled-components named helper minify: const X = css`...` / keyframes`...` 등.
+    // helper 는 컴포넌트가 아니라 CSS 조각이라 displayName/componentId 는 안 붙임.
+    if (self.options.styled_components and !init.isNone()) {
+        init = try styled_components_mod.maybeMinifyHelperTemplate(self, init);
+    }
+    // React Fast Refresh: `const Foo = () => ...` / `const Foo = function() {...}` 등록
+    // (function declaration 은 visitFunction 단계에서 자체 이름으로 등록됨).
+    if (!new_name.isNone() and !init.isNone()) {
+        const name_node = self.ast.getNode(new_name);
+        if (name_node.tag == .binding_identifier) {
+            const binding_text = self.ast.getText(name_node.data.string_ref);
+            try self.maybeRegisterRefreshComponentByBinding(init, new_name, binding_text);
+        }
+    }
+
+    return init;
+}
+
 pub fn visitVariableDeclaration(self: *Transformer, node: Node) Error!NodeIndex {
     // ES2015: destructuring pattern → 개별 declarator로 분해
     // ES2018: object rest (...rest) → __rest 호출 (target < es2018)
@@ -96,7 +139,8 @@ pub fn visitVariableDeclaration(self: *Transformer, node: Node) Error!NodeIndex 
                 const new_decl = try self.addExtraNode(.variable_declarator, decl.span, &.{ @intFromEnum(new_name), none, init_node });
                 try self.scratch.append(self.allocator, new_decl);
             } else {
-                const new_init = try self.visitNode(init_idx);
+                var new_init = try self.visitNode(init_idx);
+                new_init = try postProcessVariableDeclaratorInit(self, new_name, new_init);
                 const none = @intFromEnum(NodeIndex.none);
                 const new_decl = try self.addExtraNode(.variable_declarator, decl.span, &.{ @intFromEnum(new_name), none, @intFromEnum(new_init) });
                 try self.scratch.append(self.allocator, new_decl);
@@ -116,38 +160,7 @@ pub fn visitVariableDeclarator(self: *Transformer, node: Node) Error!NodeIndex {
     const e = node.data.extra;
     const new_name = try self.visitNode(self.readNodeIdx(e, 0));
     var new_init = try self.visitNode(self.readNodeIdx(e, 2));
-    // styled-components: tag 를 `.withConfig({displayName})` 로 wrap. fast-path 로 1) 옵션,
-    // 2) binding 감지, 3) init.tag == tagged_template_expression 을 사전 거른 뒤에만
-    // 본 helper 호출. var_name 은 block-scoping rename 후 안전하도록 new_name 에서 읽음.
-    if (!new_name.isNone() and styled_components_mod.shouldAttemptWrap(self, new_init)) {
-        const new_name_node = self.ast.getNode(new_name);
-        if (new_name_node.tag == .binding_identifier or new_name_node.tag == .identifier_reference) {
-            const var_name = self.ast.getText(new_name_node.data.string_ref);
-            new_init = try styled_components_mod.wrapStyledTagInExpr(self, new_init, var_name);
-        }
-    }
-    // emotion autoLabel: const X = css`...` → css`label:X;...`
-    if (self.options.emotion and !new_name.isNone() and !new_init.isNone()) {
-        const new_name_node = self.ast.getNode(new_name);
-        if (new_name_node.tag == .binding_identifier or new_name_node.tag == .identifier_reference) {
-            const var_name = self.ast.getText(new_name_node.data.string_ref);
-            new_init = try emotion_mod.maybeTransformEmotionTemplate(self, new_init, var_name);
-        }
-    }
-    // styled-components named helper minify: const X = css`...` / keyframes`...` 등.
-    // helper 는 컴포넌트가 아니라 CSS 조각이라 displayName/componentId 는 안 붙임.
-    if (self.options.styled_components and !new_init.isNone()) {
-        new_init = try styled_components_mod.maybeMinifyHelperTemplate(self, new_init);
-    }
-    // React Fast Refresh: `const Foo = () => ...` / `const Foo = function() {...}` 등록
-    // (function declaration 은 visitFunction 단계에서 자체 이름으로 등록됨).
-    if (!new_name.isNone() and !new_init.isNone()) {
-        const name_node = self.ast.getNode(new_name);
-        if (name_node.tag == .binding_identifier) {
-            const binding_text = self.ast.getText(name_node.data.string_ref);
-            try self.maybeRegisterRefreshComponentByBinding(new_init, binding_text);
-        }
-    }
+    new_init = try postProcessVariableDeclaratorInit(self, new_name, new_init);
     const none = @intFromEnum(NodeIndex.none);
     return self.addExtraNode(.variable_declarator, node.span, &.{ @intFromEnum(new_name), none, @intFromEnum(new_init) });
 }

--- a/src/transformer/transformer/refresh.zig
+++ b/src/transformer/transformer/refresh.zig
@@ -203,11 +203,7 @@ pub fn buildRefreshAssignment(self: *Transformer, reg: RefreshRegistration) Erro
         .span = comp_span,
         .data = .{ .string_ref = comp_span },
     });
-    if (!reg.component_idx.isNone()) {
-        self.copySymbolId(reg.component_idx, comp_ref);
-    } else {
-        self.attachRootScopeSymbolByName(comp_ref, reg.name);
-    }
+    self.copySymbolId(reg.component_idx, comp_ref);
     const assign = try self.ast.addNode(.{
         .tag = .assignment_expression,
         .span = zero_span,

--- a/src/transformer/transformer/refresh.zig
+++ b/src/transformer/transformer/refresh.zig
@@ -58,13 +58,19 @@ pub inline fn refreshEnabled(self: *const Transformer) bool {
 /// 함수 노드에서 이름 텍스트를 추출한다.
 /// function_declaration의 extra[0]이 binding_identifier.
 /// ast의 extra_data에서 읽음 (visitFunction이 이미 노드를 생성했으므로).
-pub fn getFunctionName(self: *Transformer, func_node: Node) ?[]const u8 {
+fn getFunctionNameIndex(self: *Transformer, func_node: Node) ?NodeIndex {
     const e = func_node.data.extra;
     if (e >= self.ast.extra_data.items.len) return null;
     const name_idx: NodeIndex = @enumFromInt(self.ast.extra_data.items[e]);
     if (name_idx.isNone()) return null;
     const name_node = self.ast.getNode(name_idx);
     if (name_node.tag != .binding_identifier and name_node.tag != .identifier_reference) return null;
+    return name_idx;
+}
+
+pub fn getFunctionName(self: *Transformer, func_node: Node) ?[]const u8 {
+    const name_idx = getFunctionNameIndex(self, func_node) orelse return null;
+    const name_node = self.ast.getNode(name_idx);
     return self.ast.getText(name_node.data.string_ref);
 }
 
@@ -78,10 +84,12 @@ pub fn maybeRegisterRefreshComponent(self: *Transformer, new_func_idx: NodeIndex
     // function_expression의 이름은 함수 내부 스코프에서만 접근 가능하므로
     // 외부에서 $RefreshReg$에 등록하면 ReferenceError 발생
     if (func_node.tag == .function_expression) return;
-    const name = self.getFunctionName(func_node) orelse return;
+    const name_idx = getFunctionNameIndex(self, func_node) orelse return;
+    const name_node = self.ast.getNode(name_idx);
+    const name = self.ast.getText(name_node.data.string_ref);
     if (!isComponentName(name)) return;
 
-    try appendRefreshRegistration(self, name);
+    try appendRefreshRegistration(self, name, name_idx);
 }
 
 /// 변수 binding 기반 컴포넌트 등록 — `const Foo = () => ...` / `const Foo = function() {...}`
@@ -90,6 +98,7 @@ pub fn maybeRegisterRefreshComponent(self: *Transformer, new_func_idx: NodeIndex
 pub fn maybeRegisterRefreshComponentByBinding(
     self: *Transformer,
     init_idx: NodeIndex,
+    binding_idx: NodeIndex,
     binding_name: []const u8,
 ) Error!void {
     if (!refreshEnabled(self)) return;
@@ -103,13 +112,14 @@ pub fn maybeRegisterRefreshComponentByBinding(
         init_tag == .function;
     if (!is_target) return;
 
-    try appendRefreshRegistration(self, binding_name);
+    try appendRefreshRegistration(self, binding_name, binding_idx);
 }
 
-fn appendRefreshRegistration(self: *Transformer, name: []const u8) Error!void {
+fn appendRefreshRegistration(self: *Transformer, name: []const u8, component_idx: NodeIndex) Error!void {
     const handle_span = try self.makeRefreshHandle();
     try self.plugins.refresh.registrations.append(self.allocator, .{
         .handle_span = handle_span,
+        .component_idx = component_idx,
         .name = name,
     });
 }
@@ -187,11 +197,17 @@ pub fn buildRefreshAssignment(self: *Transformer, reg: RefreshRegistration) Erro
         .span = reg.handle_span,
         .data = .{ .string_ref = reg.handle_span },
     });
+    const comp_span = try self.ast.addString(reg.name);
     const comp_ref = try self.ast.addNode(.{
         .tag = .identifier_reference,
-        .span = zero_span,
-        .data = .{ .string_ref = try self.ast.addString(reg.name) },
+        .span = comp_span,
+        .data = .{ .string_ref = comp_span },
     });
+    if (!reg.component_idx.isNone()) {
+        self.copySymbolId(reg.component_idx, comp_ref);
+    } else {
+        self.attachRootScopeSymbolByName(comp_ref, reg.name);
+    }
     const assign = try self.ast.addNode(.{
         .tag = .assignment_expression,
         .span = zero_span,


### PR DESCRIPTION
## 요약

React Native 개발 번들에서 HMR/React Refresh가 생성한 합성 참조가 linker rename을 따라가지 못해 런타임 ReferenceError가 발생하던 문제를 수정했습니다.

대표적으로 다음 형태의 앱 코드에서 문제가 재현됐습니다.

```js
const EquipmentSearchBody = () => null;
EquipmentSearchBody.propTypes = {};
export default EquipmentSearchBody;
```

다른 모듈이나 barrel export와 결합되면서 linker가 실제 선언을 `EquipmentSearchBody$1`로 rename했지만, React Refresh 등록용 합성 코드가 `_c = EquipmentSearchBody;`로 남아 런타임에서 `Property 'EquipmentSearchBody' doesn't exist`가 발생했습니다.\n\n## 원인\n\nReact Refresh registration은 컴포넌트 이름 문자열만 저장하고 있었습니다. 이후 `$RefreshReg$` 등록 전에 추가되는 `_c = Component` 합성 identifier는 원래 binding node의 `symbol_id`와 연결되지 않았습니다.\n\n또한 합성 identifier의 span이 `zero_span`이라 semantic/linker 단계에서 원래 선언과 같은 심볼로 취급되지 못했습니다. 그 결과 실제 선언은 rename되는데 Refresh assignment만 rename 대상에서 빠졌습니다.\n\n## 수정\n\n- Refresh registration에 컴포넌트 binding node index를 함께 저장하도록 변경했습니다.\n- Refresh assignment를 만들 때 컴포넌트 identifier에 원래 binding의 `symbol_id`를 복사하도록 했습니다.\n- 합성 identifier도 실제 string table span을 갖도록 해서 semantic/linker가 안정적으로 이름을 해석할 수 있게 했습니다.\n- ES5 lexical lowering 경로에서도 variable declarator 후처리가 동일하게 수행되도록 정리했습니다.\n- preserveSymlinks 환경에서 pnpm package symlink root alias가 package entry를 건너뛰던 resolver 케이스도 함께 보강했습니다.\n\n## 테스트\n\n다음 검증을 수행했습니다.\n\n```sh\nzig build test --summary all -Dtest-filter="Bundler: refresh — registration follows linker rename through barrel export"\nzig build test --summary all -Dtest-filter="Bundler: refresh"\nbun test ./packages/core/test/core/react-refresh.ts --timeout 10000\nzig build test --summary all -Dtest-filter="symlink package root"\ngit diff --check\n```\n\n추가로 로컬 `packages/core` 빌드 후 실제 RN 앱 개발 서버를 zntc로 재시작해서 번들을 직접 확인했습니다.\n\n- 기존 문제 형태: `_c = EquipmentSearchBody;` 없음\n- 수정 후 형태: `_c$639 = EquipmentSearchBody$1;`\n- HMR 모듈 `fn` 참조 누락: 0개\n- 실제 파일 수정 HMR probe 로그도 `v1 -> v2 -> 제거` 순서로 반영 확인\n