### PR TITLE
fix(bundler): splitting 단일/같은 청크 namespace whole-value 미합성 (#3367)

### DIFF
--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -1130,6 +1130,10 @@ fn linkNamespaceCrossChunk(
     if (tgt_chunk.isNone()) return;
     if (tgt_chunk == chunk.index) return; // 같은 청크 → 배선 불필요
 
+    // cross-chunk 확정 — registerNamespaceRewrites 가 shared 경로를 쓰도록
+    // 마킹. same-chunk(여기 도달 안 함)는 비-shared self-contained 경로 (#3367).
+    try @constCast(lnk).markNsCrossChunk(target);
+
     // computeCrossChunkLinks 가 namespace 메타데이터보다 먼저 도는 timing
     // seam — ensureSharedNsVar 가 선제 materialize. 상세는 그 doc 참조.
     const ns_var = try lnk.ensureSharedNsVar(target);

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -89,7 +89,10 @@ pub fn emitChunks(
     // finalizeNamespaceData 가 referrer 측 object_literal 을 빈 문자열로 두고,
     // linker 의 ns_shared_inline_cache 에 정의자 mod_idx + 실 object_literal 저장
     // — 청크 emit 시 정의자 모듈이 속한 청크 preamble 에서 inline.
-    if (linker) |l| @constCast(l).use_shared_ns_preamble = true;
+    if (linker) |l| {
+        @constCast(l).use_shared_ns_preamble = true;
+        @constCast(l).ns_preamble_chunked = true;
+    }
 
     var outputs: std.ArrayList(OutputFile) = .empty;
     errdefer {

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -237,7 +237,20 @@ pub const Linker = struct {
     ns_shared_inline_cache: std.AutoHashMapUnmanaged(u32, SharedNsInline) = .{},
     ns_shared_inline_order: std.ArrayListUnmanaged(u32) = .empty,
     ns_shared_var_names: std.StringHashMapUnmanaged(void) = .{},
+    /// computeCrossChunkLinks(메타데이터 前 실행, chunk graph 보유)가 채우는
+    /// "정의자 청크가 다른" namespace re-export target 집합. registerNamespace
+    /// Rewrites 는 metadata 시점에 chunk 정보가 없으므로 이 집합으로 shared
+    /// (cross-chunk, #3366) vs 비-shared(same-chunk self-contained, 타이밍
+    /// 무관) inline 경로를 가른다 (#3367). 비어 있으면(splitting off 등)
+    /// 전부 비-shared — 기존 단일번들 동작 유지.
+    ns_cross_chunk_targets: std.AutoHashMapUnmanaged(u32, void) = .{},
     use_shared_ns_preamble: bool = false,
+    /// chunked(splitting) emit 경로 여부. 이 경로는 shared ns preamble 을
+    /// per-module metadata **이전**에 emit 하므로, same-chunk target 은 정의자
+    /// 청크 pre-materialize(#3366)가 닿지 않아 shared 가 타이밍상 빈다(#3367).
+    /// 단일번들 경로(metadata 後 emit)는 무관해 false. useSharedNsInline 이 이
+    /// 플래그로 경로를 가른다.
+    ns_preamble_chunked: bool = false,
     /// ns_export_cache / ns_inline_cache 동시 접근 보호.
     /// emitter 가 `emitModuleThread` 로 buildMetadataForAst 를 병렬 호출하므로 필수.
     /// Fast path (get) → unlock → compute → lock → double-check → put 패턴으로
@@ -342,6 +355,7 @@ pub const Linker = struct {
         self.ns_shared_inline_cache.deinit(self.allocator);
         self.ns_shared_inline_order.deinit(self.allocator);
         self.ns_shared_var_names.deinit(self.allocator);
+        self.ns_cross_chunk_targets.deinit(self.allocator);
         // #1791 fatal diag message 해제 (allocPrint owned)
         for (self.fatal_diagnostics.items) |d| self.allocator.free(d.message);
         self.fatal_diagnostics.deinit(self.allocator);
@@ -1793,6 +1807,26 @@ pub const Linker = struct {
 
     pub const registerNamespaceRewrites = shared_namespace.registerNamespaceRewrites;
     pub const ensureSharedNsVar = shared_namespace.ensureSharedNsVar;
+
+    /// computeCrossChunkLinks 가 cross-chunk namespace re-export target 마킹
+    /// (#3367). metadata 시점엔 chunk 정보 부재 — registerNamespaceRewrites 가
+    /// 이 마킹으로 shared(cross-chunk) vs 비-shared(same-chunk) 경로 선택.
+    /// **불변식**: computeCrossChunkLinks(단일스레드, emitChunks 前 완료)에서만
+    /// write. 이후 병렬 metadata 가 read-only 로 본다 — 그 뒤 write 시 데이터
+    /// 레이스.
+    pub fn markNsCrossChunk(self: *Linker, target: ModuleIndex) std.mem.Allocator.Error!void {
+        try self.ns_cross_chunk_targets.put(self.allocator, target.toU32(), {});
+    }
+
+    /// shared(정의자 청크 preamble) vs 비-shared(모듈 self-preamble) namespace
+    /// inline 경로 결정. 단일번들(metadata 後 emit, 다중 importer dedup #1940)·
+    /// chunked-cross-chunk(#3366)는 shared. chunked-same-chunk 만 비-shared
+    /// self-contained — chunked preamble 이 metadata 前이라 same-chunk
+    /// pre-materialize 부재(#3367).
+    pub fn useSharedNsInline(self: *const Linker, target_mod_idx: u32) bool {
+        return self.use_shared_ns_preamble and
+            (!self.ns_preamble_chunked or self.ns_cross_chunk_targets.contains(target_mod_idx));
+    }
     pub const appendSharedNamespacePreamble = shared_namespace.appendSharedNamespacePreamble;
     pub const appendSharedNamespacePreambleFiltered = shared_namespace.appendSharedNamespacePreambleFiltered;
     pub const restoreSharedNamespaceDecls = shared_namespace.restoreSharedNamespaceDecls;

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -143,9 +143,7 @@ pub fn registerNamespaceRewrites(
             const ns_var = if (ns_target_to_var.get(target)) |cached|
                 cached
             else blk: {
-                // splitting 시엔 referrer 청크 self-preamble 대신 정의자 청크 preamble 에
-                // namespace 가 위치하도록 shared cache 경유.
-                if (self.use_shared_ns_preamble) {
+                if (self.useSharedNsInline(target)) {
                     const ns_var_name = try appendSharedNsInlineEntry(self, ns_inline_list, null, target, &seen_exports);
                     try ns_target_to_var.put(target, ns_var_name);
                     break :blk ns_var_name;
@@ -191,7 +189,7 @@ pub fn registerNamespaceRewrites(
     // ns_inline_list 활성화 조건: caller 가 명시 (force_inline) 또는 shadow 충돌 발생.
     // 후자의 경우 codegen fallback 이 namespace 객체 access 로 emit 할 수 있도록 객체가 필요.
     if (force_inline or has_shadow) {
-        if (self.use_shared_ns_preamble) {
+        if (self.useSharedNsInline(target_mod_idx)) {
             _ = try appendSharedNsInlineEntry(self, ns_inline_list, symbol_id, target_mod_idx, &seen_exports);
         } else {
             const obj_str = try buildInlineObjectStr(self, target_mod_idx, 0);

--- a/tests/integration/tests/cross-chunk-reexport.test.ts
+++ b/tests/integration/tests/cross-chunk-reexport.test.ts
@@ -339,17 +339,13 @@ describe('cross-chunk re-export (#3321 follow-up bugfix)', () => {
       'A PV B',
     ));
 
-  // [추적 — 별개 선재 이슈, #3321 후속] 아래 둘은 이번 cross-chunk 배선과
-  // 무관한, 다른 서브시스템의 선재 버그. 루트커즈 규명 완료. 수정/회귀 시
-  // loud 하도록 skip 유지.
-  //  (1) 단일번들 namespace whole-value: 동적 import 없어 split 미발생 →
-  //      단일 청크. `export * as ns` 직접형을 whole-value(`Object.keys(ns)`)
-  //      로 쓰면 ns_inline rewrite(`ns`→`ns_var`)는 적용되나 비-shared
-  //      ns_inline **선언(`var ns_var={...}`)이 importer preamble 에 미emit**
-  //      → ReferenceError. 실제 split 발생 시는 cross-chunk 경로가 정의자
-  //      청크에 객체를 materialize 하므로 정상(검증됨). 단일번들 ns preamble
-  //      emission 버그 (별개 후속, cross-chunk 무관).
-  test.skip('[PREEXISTING] 단일번들 export * as ns whole-value 미합성', () =>
+  // splitting:true 인데 동적 import 가 없어 단일 청크가 되는 경우 `export *
+  // as ns` 를 whole-value(`Object.keys(ns)`)로 쓰면, chunked emit 의 shared
+  // preamble 이 per-module metadata 보다 먼저 돌아 same-chunk ns 객체가
+  // 미materialize 되던 버그(#3367). registerNamespaceRewrites 가
+  // ns_preamble_chunked+isNsCrossChunk 로 same-chunk 는 비-shared
+  // self-contained 경로(모듈 preamble 직접 emit) 선택 → 해소.
+  test('export * as ns whole-value 단일청크 (#3367)', () =>
     runNsSplit(
       {
         'inner.ts': `export const a = "A";\nexport const b = "B";`,
@@ -359,12 +355,16 @@ describe('cross-chunk re-export (#3321 follow-up bugfix)', () => {
       { format: 'esm' },
       'a,b',
     ));
-  //  (2) 중첩 ns re-export 체인: `export {inner} from "./mid"` + mid
-  //      `export * as inner from "./inner"`. 루트커즈 — cross-chunk 배선
-  //      이전 단계의 tree-shaker 가 inner/mid 모듈을 통째 dead 로 제거(멤버
-  //      접근 elision + 동적만 사용 → live export 0 으로 오판) → 청킹 시점에
-  //      대상 모듈 부재라 ns 객체 materialize 불가. namespace re-export 체인의
-  //      tree-shake over-elimination (별개 후속, cross-chunk 무관).
+
+  // [추적 — 별개 선재 이슈, #3368] 이번/이전 cross-chunk 배선과 무관한
+  // 다른 서브시스템(tree-shaker) 버그. 루트커즈 규명 완료. 수정/회귀 시
+  // loud 하도록 skip 유지.
+  //  중첩 ns re-export 체인: `export {inner} from "./mid"` + mid
+  //  `export * as inner from "./inner"`. 루트커즈 — cross-chunk 배선 이전
+  //  단계의 tree-shaker 가 inner/mid 모듈을 통째 dead 로 제거(멤버 접근
+  //  elision + 동적만 사용 → live export 0 으로 오판) → 청킹 시점에 대상
+  //  모듈 부재라 ns 객체 materialize 불가. namespace re-export 체인의
+  //  tree-shake over-elimination (#3368, cross-chunk 무관).
   test.skip('[PREEXISTING] 중첩 ns re-export 체인 tree-shake 제거', () =>
     runNsSplit(
       {


### PR DESCRIPTION
## 배경
`splitting: true` 인데 동적 import 가 없어 단일 청크가 되거나, namespace 정의자가 consumer 와 같은 청크일 때, `export * as ns from "m"` 를 whole-value(`Object.keys(ns)` 등)로 쓰면 ns 객체가 미합성 → `ns_var is not defined`. #3366 에서 별개 선재버그로 분리 추적하던 #3367.

## 근본 원인
chunked(splitting) emit 경로는 shared ns preamble 을 per-module metadata **이전**에 emit(`appendSharedNamespacePreambleFiltered`). #3366 의 정의자-청크 pre-materialize(`computeCrossChunkLinks` → `ensureSharedNsVar`)는 **cross-chunk target 만** 채우고 same-chunk 는 early-return skip → metadata 시점에 shared 캐시가 비어 `var ns_var={...}` 선언이 어디에도 안 나옴. 단일번들 경로(`appendSharedNamespacePreamble`, metadata 後 emit)는 무관해 정상이었음.

## 수정
- `computeCrossChunkLinks`(메타데이터 前·단일스레드)가 cross-chunk namespace target 을 linker 에 마킹(`markNsCrossChunk`).
- chunked emit 경로는 `ns_preamble_chunked` 플래그 set (단일번들 경로와 구분 — 단일번들은 timing OK + 다중 importer dedup #1940 위해 shared 유지).
- `registerNamespaceRewrites` 는 `useSharedNsInline(target)` 으로 경로 정밀 선택:
  - 단일번들 / chunked-cross-chunk → **shared** (#1940/#3366 불변)
  - chunked-same-chunk → **비-shared self-contained** (`buildInlineObjectStr` 리터럴을 모듈 preamble 에 직접 emit, `force_inline` 게이트 유지 → dead-var 회귀 없음, chunk preamble 타이밍 무관)

`/simplify` 3-에이전트 반영: `useSharedNsInline` 헬퍼로 중복 게이트식 단일화, `ModuleIndex.toU32()` 컨벤션(#1553), 순서 불변식 doc 명시.

## 검증
- 9-케이스 namespace 매트릭스: **8 pass** (value-as-whole 단일청크 ✅ 추가)
- `zig build test` 전체 **회귀 0** — 정밀 게이트로 단일번들 shared 동작(`default_deconflict` shared-preamble 2건) 보존
- 통합 `cross-chunk-reexport.test.ts`: **17 pass / 1 skip / 0 fail**
- app-builder CLI 14/0, react smoke ✅

## 잔여
#3368(중첩 ns re-export 체인 tree-shake over-elimination)은 별개 tree-shaker 선재버그 — 추적 `test.skip` 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)