### PR TITLE
feat(linker): ESM wrapper-barrel default import scope-aware member 분석 (정밀 lazy 선행 PR-1)

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -29,6 +29,7 @@ const CompiledModule = @import("compiled_module.zig").CompiledModule;
 const preamble_writer = @import("linker/preamble_writer.zig");
 const namespace_access = @import("linker/namespace_access.zig");
 const shared_namespace = @import("linker/shared_namespace.zig");
+const graph_requested_exports = @import("graph/requested_exports.zig");
 pub const PreambleWriter = preamble_writer.PreambleWriter;
 pub const cjsImportNeedsToEsmInterop = preamble_writer.cjsImportNeedsToEsmInterop;
 pub const LinkingMetadata = @import("linker/metadata_types.zig").LinkingMetadata;
@@ -372,13 +373,30 @@ pub const Linker = struct {
         return self.graph.moduleAtMut(ModuleIndex.fromUsize(idx));
     }
 
+    /// importer 의 import_record 가 가리키는 resolved source 모듈. 인덱스
+    /// 범위 밖이거나 미해결이면 null.
+    fn importedModule(self: *const Linker, importer: *const Module, record_idx: u32) ?*const Module {
+        if (record_idx >= importer.import_records.len) return null;
+        const src_idx = importer.import_records[record_idx].resolved;
+        if (src_idx.isNone()) return null;
+        return self.graph.getModule(src_idx);
+    }
+
     fn isCjsDefaultBinding(self: *const Linker, importer: *const Module, ib: ImportBinding) bool {
         if (ib.kind != .default) return false;
-        if (ib.import_record_index >= importer.import_records.len) return false;
-        const src_idx = importer.import_records[ib.import_record_index].resolved;
-        if (src_idx.isNone()) return false;
-        const src = self.graph.getModule(src_idx) orelse return false;
+        const src = self.importedModule(importer, ib.import_record_index) orelse return false;
         return src.wrap_kind == .cjs;
+    }
+
+    /// `import _ from './w'; _.foo()` 에서 source 가 wrapper-barrel
+    /// (`BASE.PROP = importLocal; export default BASE`, lodash-es lodash.default.js)
+    /// 인 default binding. CJS default 와 동일하게 scope-aware member 분석으로
+    /// `namespace_used_properties` 를 채워, wrapper-barrel 의 prop 단위 정밀
+    /// lazy 링크가 소비자 사용 prop 집합을 알 수 있게 한다.
+    fn isEsmWrapperDefaultBinding(self: *const Linker, importer: *const Module, ib: ImportBinding) bool {
+        if (ib.kind != .default) return false;
+        const src = self.importedModule(importer, ib.import_record_index) orelse return false;
+        return graph_requested_exports.isWrapperBarrel(self.graph, src);
     }
 
     /// 링킹 실행: export 맵 구축 → import 바인딩 해결.
@@ -1712,6 +1730,7 @@ pub const Linker = struct {
                     if (ib.kind == .namespace) break :blk true;
                     if (ib.kind == .named and ib.namespace_used_properties == null) break :blk true;
                     if (self.isCjsDefaultBinding(importer, ib)) break :blk true;
+                    if (self.isEsmWrapperDefaultBinding(importer, ib)) break :blk true;
                 }
                 break :blk false;
             };
@@ -1737,7 +1756,12 @@ pub const Linker = struct {
                 if (source_mod_idx.isNone()) continue;
                 const source = self.graph.getModule(source_mod_idx) orelse continue;
                 const is_cjs_default_candidate = ib.kind == .default and source.wrap_kind == .cjs;
-                if (!is_namespace and !is_named_candidate and !is_cjs_default_candidate) continue;
+                const is_esm_wrapper_default_candidate = ib.kind == .default and
+                    !is_cjs_default_candidate and
+                    graph_requested_exports.isWrapperBarrel(self.graph, source);
+                const should_analyze_binding = is_namespace or is_named_candidate or
+                    is_cjs_default_candidate or is_esm_wrapper_default_candidate;
+                if (!should_analyze_binding) continue;
 
                 // `.named` 경로는 virtual namespace (re_export_namespace 타겟)일 때만 처리.
                 // `.namespace`/CJS default는 항상 scope-aware 재평가 대상 — member-only
@@ -1768,10 +1792,11 @@ pub const Linker = struct {
                 defer access.deinit(self.allocator);
 
                 if (access.kind == .@"opaque") {
-                    // `.namespace`와 CJS default는 text-based 결과를 신뢰하지 않음 —
-                    // null로 덮어써 전체 namespace/default fallback. `.named` virtual ns는
-                    // null 유지(기존 동작).
-                    if (is_namespace or is_cjs_default_candidate) {
+                    // `.namespace`/CJS default/ESM wrapper default 는 opaque(동적
+                    // 접근·escape) 시 null 로 덮어써 전체 fallback — wrapper-barrel
+                    // 정밀 lazy 가 보수적(전체 링크)으로 떨어지는 안전 경로.
+                    // `.named` virtual ns 는 null 유지(기존 동작).
+                    if (is_namespace or is_cjs_default_candidate or is_esm_wrapper_default_candidate) {
                         ib.namespace_used_properties = null;
                         ib.namespace_used_property_stmts = null;
                     }

--- a/src/bundler/namespace_access_test.zig
+++ b/src/bundler/namespace_access_test.zig
@@ -210,3 +210,42 @@ test "analyzeNamespaceAccess: 함수 내부 로컬 변수 shadowing" {
     defer h.deinit(std.testing.allocator);
     try expectMembers(&h.access, &.{"foo"});
 }
+
+// ============================================================
+// Default-import member 분석 (PR-1 contract).
+// `populateNamespaceAccesses` 가 ESM wrapper-barrel default binding 을
+// 이 symbol-aware 분석으로 라우팅한다 — wrapper-barrel 정밀 lazy 의
+// 입력(소비자 사용 prop / escape 시 opaque)을 제공.
+// ============================================================
+
+test "analyzeNamespaceAccess: default import member-only" {
+    var h = try runAccess(std.testing.allocator,
+        \\import _ from './mod';
+        \\_.foo();
+        \\_.bar;
+    , "_");
+    defer h.deinit(std.testing.allocator);
+    try expectMembers(&h.access, &.{ "foo", "bar" });
+}
+
+test "analyzeNamespaceAccess: default import 값 전달 → opaque" {
+    var h = try runAccess(std.testing.allocator,
+        \\import _ from './mod';
+        \\function sink(o) { return o.bar(); }
+        \\_.foo();
+        \\sink(_);
+    , "_");
+    defer h.deinit(std.testing.allocator);
+    try std.testing.expectEqual(NamespaceAccess.Kind.@"opaque", h.access.kind);
+}
+
+test "analyzeNamespaceAccess: default import computed access → opaque" {
+    var h = try runAccess(std.testing.allocator,
+        \\import _ from './mod';
+        \\const k = globalThis.x ? 'bar' : 'baz';
+        \\_.foo();
+        \\_[k]();
+    , "_");
+    defer h.deinit(std.testing.allocator);
+    try std.testing.expectEqual(NamespaceAccess.Kind.@"opaque", h.access.kind);
+}


### PR DESCRIPTION
## 배경

`populateNamespaceAccesses` 의 default import 멤버 정밀 분석은 **CJS default (`source.wrap_kind == .cjs`) 에만** 적용됐습니다. ESM wrapper-barrel — `BASE.PROP = importLocal; export default BASE` (lodash-es `lodash.default.js` 의 `lodash.uniq = array.uniq` 류 ~304개) — default import 는 분석 안 돼, `import _ from 'pkg'; _.foo()` 의 `_` 가 항상 전체사용(null) 로 남았습니다. wrapper-barrel 정밀 lazy 링크의 입력 데이터 부재입니다.

로드맵 🟡 lazyBarrel "wrapper-barrel mutation 정밀화" 의 **선행(enabling) PR-1** 입니다. 2-PR 분할:
- **PR-1 (이 PR)**: default-of-wrapper-barrel 을 symbol-aware member 분석으로 라우팅 (enabling, 행동상 inert)
- **PR-2 (후속)**: wrapper `BASE.PROP=importLocal` → prop→record 맵 + 소비자 used-prop 전파 + `shouldLinkResolvedRecordForModule` 정밀화 (win 동작)

## 변경

- `isEsmWrapperDefaultBinding` (`isCjsDefaultBinding` 대칭): `ib.kind == .default` 이고 source 가 `isWrapperBarrel`.
- `populateNamespaceAccesses` 의 `has_candidate` / per-binding candidate / opaque-null 조건을 ESM-wrapper-default 로 확장.
- `importedModule` 헬퍼로 import_record→resolved source 조회 중복 제거 (두 default-binding 헬퍼 공통화).

결과: `import _ from wrapperBarrel; _.foo()` → `_.namespace_used_properties = {foo}`. 값전달/computed 등 escape 시 opaque → **null fallback** = 후속 정밀 lazy 가 보수적 전체 링크로 안전하게 떨어지는 경로.

## 검증

- 전체 유닛 스위트 `zig build test` **EXIT=0 (회귀 0)** — enabling 단계라 동작 불변 (wrapper-barrel 은 PR-2 전까지 보수적 전체 링크 유지)
- 신규 contract 테스트 3개 (namespace_access_test.zig): default import member-only / 값전달 opaque / computed opaque — 전부 green. PR-2 가 의존하는 분석 primitive 정확성 보증
- ReleaseFast 빌드 통과
- 최신 main rebase (pre-push/CI oxfmt clean)

## /simplify

3-에이전트 리뷰 반영: `importedModule` 헬퍼 추출(중복 제거), 게이트 3중 부정 → `should_analyze_binding` 긍정 변수화. (isCjs/isEsmWrapper 헬퍼 통합은 wrap_kind vs isWrapperBarrel 의미 분리로 정당 — 보류.)

관련 #2060 (공격적 DCE 로드맵 — lazyBarrel wrapper-barrel 정밀화). PR-2 에서 동작 win + escape SAFETY 테스트 동반.

🤖 Generated with [Claude Code](https://claude.com/claude-code)