### PR TITLE
fix(tree-shaker): 중첩 ns re-export 체인 모듈 over-elimination (#3368)

### DIFF
--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -1340,6 +1340,17 @@ pub const TreeShaker = struct {
             }
         }
 
+        // `export * as z from "src"` (re_export_namespace): namespace 소스는
+        // export_binding.import_record 에 있어 위 import_bindings 스캔이 못
+        // 잡는다. 중첩 체인(`export {z} from "./mid"` → mid `export * as z
+        // from "./inner"`)에서 canonical=(mid,"z") 로 풀리면 src(inner)가
+        // 통째 tree-shaken → `var z_ns={}` 미바인딩 (#3368). followImport
+        // 와 동일하게 캐시된 exported_name→source 맵으로 O(1) 조회.
+        if (try self.ensureReExportNamespaceSourceMap(canon_mod)) |ns_map| {
+            if (ns_map.get(canonical.export_name)) |ns_src|
+                try self.markAndSeedAllStmts(ns_src, queue, module_stmt_infos, reachable_stmts);
+        }
+
         if (canon_mod != target_mod and target_mod < mod_count) {
             var intermediate_scope = profile.begin(.shake_fixpoint_bfs_seed_export_intermediate);
             defer intermediate_scope.end();

--- a/tests/integration/tests/cross-chunk-reexport.test.ts
+++ b/tests/integration/tests/cross-chunk-reexport.test.ts
@@ -359,13 +359,13 @@ describe('cross-chunk re-export (#3321 follow-up bugfix)', () => {
   // [추적 — 별개 선재 이슈, #3368] 이번/이전 cross-chunk 배선과 무관한
   // 다른 서브시스템(tree-shaker) 버그. 루트커즈 규명 완료. 수정/회귀 시
   // loud 하도록 skip 유지.
-  //  중첩 ns re-export 체인: `export {inner} from "./mid"` + mid
-  //  `export * as inner from "./inner"`. 루트커즈 — cross-chunk 배선 이전
-  //  단계의 tree-shaker 가 inner/mid 모듈을 통째 dead 로 제거(멤버 접근
-  //  elision + 동적만 사용 → live export 0 으로 오판) → 청킹 시점에 대상
-  //  모듈 부재라 ns 객체 materialize 불가. namespace re-export 체인의
-  //  tree-shake over-elimination (#3368, cross-chunk 무관).
-  test.skip('[PREEXISTING] 중첩 ns re-export 체인 tree-shake 제거', () =>
+  // 중첩 ns re-export 체인: `export {inner} from "./mid"` + mid
+  // `export * as inner from "./inner"`. seedExport 가 `import * as z;
+  // export {z}`(import_binding) 만 소스 시드하고 `export * as z from`
+  // (re_export_namespace, export_binding) 은 미처리 → resolveExportChain
+  // canonical=(mid,"inner") 에서 inner.ts 가 통째 tree-shaken 되던 버그.
+  // seedExport 에 re_export_namespace 소스 시드 추가로 해소 (#3368).
+  test('중첩 ns re-export 체인 (#3368)', () =>
     runNsSplit(
       {
         'inner.ts': `export const a = "A";`,


### PR DESCRIPTION
## 배경
`export { z } from "./mid"` + mid `export * as z from "./inner"` 처럼 named re-export 가 namespace re-export 를 경유하는 중첩 체인에서, `inner` 모듈이 통째 tree-shaken → `var z_ns = {}`(빈 객체) + `z is not defined`. **splitting·dynamic 무관, 단일번들에서도 재현** — 순수 tree-shake 버그(#3367/#3366 의 cross-chunk 배선과 무관, 별개 추적이던 #3368).

## 근본 원인
`seedExport` 는 canonical 이 `import * as z; export {z}`(import_binding)를 가리킬 때만 namespace 소스 모듈을 시드한다(기존 `canon_m.import_bindings` 스캔). `export * as z from "src"`(re_export_namespace — 소스가 `export_binding.import_record` 에 있음)는 미처리. 중첩 체인은 `resolveExportChain` 이 canonical=(mid,"z") 로 풀리는데 src(inner)를 시드하지 않아 inner 가 dead 로 제거 → ns 객체 materialize 불가.

## 수정
`seedExport` 의 import_bindings namespace 스캔 옆에, canonical 모듈의 `re_export_namespace` 소스를 시드하는 경로 추가.

`/simplify` 3-에이전트 반영:
- `followImport`(#1603)가 이미 쓰는 캐시 `ensureReExportNamespaceSourceMap`(exported_name→source, 모듈당 lazy 1회 빌드) 재사용 → barrel `O(n)` 선형 스캔을 `O(1)` 해시로
- `markAndSeedAllStmts` 헬퍼 재사용 → 중복 3줄(markAllExportsUsed+included.set+seedAllStmts) 제거
- 최종 11줄, getModule null 체크·first-match-wins 는 캐시 빌드에 내장

## 검증
- 9-케이스 namespace 매트릭스 **9/9 전부 통과** (중첩 체인 포함)
- `zig build test` 전체 **회귀 0**
- 통합 `cross-chunk-reexport.test.ts`: **18 pass / 0 skip / 0 fail** (#3368 skip 해제)
- app-builder CLI 14/0, react smoke ✅

#3366(cross-chunk 배선)·#3367(splitting same-chunk whole-value)에 이은 namespace re-export 계열 마지막 정식 수정. 매트릭스 잔여 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)