### PR TITLE
fix(rn): HMR 이후 sourcemap 유지

### DIFF
--- a/packages/core/src/napi/watch.zig
+++ b/packages/core/src/napi/watch.zig
@@ -138,9 +138,7 @@ const LazySourceMapCache = struct {
     /// 현재 캐시된 bundle + module builder 들을 모두 free + 맵 clear. 내부에서 lock
     /// 하지 않으므로 caller 가 `mutex` 를 이미 잡았거나 (stop 경로처럼) 동시 접근이
     /// 없음을 보장해야 한다.
-    fn clear(self: *LazySourceMapCache, allocator: std.mem.Allocator) void {
-        if (self.bundle) |sm| sm.destroy(allocator);
-        self.bundle = null;
+    fn clearModules(self: *LazySourceMapCache, allocator: std.mem.Allocator) void {
         var it = self.modules.iterator();
         while (it.next()) |entry| {
             allocator.free(entry.key_ptr.*);
@@ -149,8 +147,19 @@ const LazySourceMapCache = struct {
         self.modules.clearRetainingCapacity();
     }
 
+    fn clear(self: *LazySourceMapCache, allocator: std.mem.Allocator) void {
+        if (self.bundle) |sm| sm.destroy(allocator);
+        self.bundle = null;
+        self.clearModules(allocator);
+    }
+
     /// rebuild 완료 후 builder 들을 swap. 이전 builder 는 free. **내부에서 `mutex` 를
     /// 직접 acquire** — caller 는 추가 lock 불필요.
+    ///
+    /// Dev HMR rebuild 는 full bundle output 을 생략할 수 있어 `new_bundle == null`
+    /// 로 들어온다. 이때 기존 full-bundle sourcemap 을 지우면 `/index.map` 이 첫 HMR
+    /// 이후 404 가 되므로, null 은 "bundle map unchanged" 로 처리하고 module map 만
+    /// 최신 rebuild 결과로 교체한다.
     ///
     /// Side effect: `module_codes` 의 각 엔트리 `.sm_builder` 를 null 로 되돌린다
     /// (소유권 이전). 이후 `ModuleDevCode.freeAll` 이 double-free 없이 나머지 필드만 정리.
@@ -162,8 +171,11 @@ const LazySourceMapCache = struct {
     ) void {
         self.mutex.lock();
         defer self.mutex.unlock();
-        self.clear(allocator);
-        self.bundle = new_bundle;
+        if (new_bundle) |sm| {
+            if (self.bundle) |old| old.destroy(allocator);
+            self.bundle = sm;
+        }
+        self.clearModules(allocator);
         for (module_codes) |*mc| {
             const builder = mc.sm_builder orelse continue;
             const id_copy = allocator.dupe(u8, mc.id) catch {

--- a/packages/react-native/src/dev-server/platform-state.ts
+++ b/packages/react-native/src/dev-server/platform-state.ts
@@ -55,6 +55,10 @@ function getBundleText(result: Awaited<ReturnType<typeof bundleRn>>): string {
   return jsFile.text.replace(SOURCE_MAPPING_URL_RE, '');
 }
 
+function getBundleSourceMapText(result: Awaited<ReturnType<typeof bundleRn>>): string | null {
+  return result.outputFiles.find((file) => file.path.endsWith('.map'))?.text ?? null;
+}
+
 /**
  * platform 별 watch + state 생성. 첫 build 는 비동기 — caller 가
  * `waitForBuild(state)` 로 대기. RN runtime 이 ios+android 동시 요청 시
@@ -95,6 +99,8 @@ export function createPlatformState(
     refreshPromise = bundleRn(platformBundle)
       .then((result) => {
         state.bundle = getBundleText(result);
+        const sourceMap = getBundleSourceMapText(result);
+        state.sourceMapCache = sourceMap ? postProcessSourceMap(sourceMap) : null;
         state.buildError = null;
         state.bundleStale = false;
       })

--- a/packages/react-native/src/dev-server/serve.test.ts
+++ b/packages/react-native/src/dev-server/serve.test.ts
@@ -111,10 +111,17 @@ describe('serveRn — sourcemap lifecycle', () => {
       expect(initialMap.status).toBe(200);
 
       writeFileSync(entryPath, 'console.log("hi after hmr");\n');
-      await Promise.race([
-        rebuilt,
-        new Promise((_resolve, reject) => setTimeout(() => reject(new Error('rebuild timeout')), 5000)),
-      ]);
+      let rebuildTimer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await Promise.race([
+          rebuilt,
+          new Promise((_resolve, reject) => {
+            rebuildTimer = setTimeout(() => reject(new Error('rebuild timeout')), 5000);
+          }),
+        ]);
+      } finally {
+        if (rebuildTimer) clearTimeout(rebuildTimer);
+      }
 
       const afterHmrMap = await fetch(`${base}/index.map?platform=ios&dev=true`);
       expect(afterHmrMap.status).toBe(200);

--- a/packages/react-native/src/dev-server/serve.test.ts
+++ b/packages/react-native/src/dev-server/serve.test.ts
@@ -3,7 +3,9 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { createDevHttpServer } from './http-server.ts';
 import { buildRnDevServerOptions } from './options.ts';
+import { createPlatformStateRegistry, waitForBuild } from './platform-state.ts';
 import { serveRn } from './serve.ts';
 
 let dir: string;
@@ -78,5 +80,47 @@ describe('serveRn — lifecycle', () => {
     expect(handle.platforms.platforms.size).toBe(1);
     await handle.stop();
     expect(handle.platforms.platforms.size).toBe(0);
+  });
+});
+
+describe('serveRn — sourcemap lifecycle', () => {
+  test('bundle sourcemap remains available after dev HMR rebuild', async () => {
+    let resolveRebuild: (() => void) | null = null;
+    const rebuilt = new Promise<void>((resolve) => {
+      resolveRebuild = resolve;
+    });
+    const options = buildRnDevServerOptions({
+      bundle: { entry: entryPath, projectRoot: dir, rnPlatform: 'ios', dev: true },
+      port: 0,
+      terminalActions: false,
+    });
+    const platforms = createPlatformStateRegistry(options, {
+      onRebuild(_state, event) {
+        if (event.success) resolveRebuild?.();
+      },
+    });
+    const http = await createDevHttpServer(options, { broadcast: () => {}, platforms });
+    try {
+      const state = platforms.getOrCreate('ios');
+      await waitForBuild(state);
+      const addr = http.server.address();
+      if (typeof addr === 'string' || !addr) throw new Error('no address');
+      const base = `http://localhost:${addr.port}`;
+
+      const initialMap = await fetch(`${base}/index.map?platform=ios&dev=true`);
+      expect(initialMap.status).toBe(200);
+
+      writeFileSync(entryPath, 'console.log("hi after hmr");\n');
+      await Promise.race([
+        rebuilt,
+        new Promise((_resolve, reject) => setTimeout(() => reject(new Error('rebuild timeout')), 5000)),
+      ]);
+
+      const afterHmrMap = await fetch(`${base}/index.map?platform=ios&dev=true`);
+      expect(afterHmrMap.status).toBe(200);
+    } finally {
+      await http.stop();
+      await platforms.stopAll();
+    }
   });
 });


### PR DESCRIPTION
## 개요

RN dev server에서 첫 HMR rebuild 이후 `/index.map`이 404가 되어 LogBox/DevTools symbolication이 원본 소스로 매핑되지 않는 문제를 수정합니다.

## 원인

watch rebuild의 `LazySourceMapCache.swap()`은 rebuild 결과를 받을 때마다 기존 bundle sourcemap과 module sourcemap을 모두 지운 뒤 새 값을 넣고 있었습니다.

그런데 RN dev HMR rebuild는 full bundle output을 생략할 수 있고, 이 경우 native watch 결과의 `sourcemap_builder`가 `null`로 들어옵니다. 기존 구현은 이 `null`을 “bundle sourcemap 없음”으로 처리해서 캐시를 지웠고, 그 결과 최초 full build 때 있던 bundle sourcemap이 첫 HMR 이후 사라졌습니다.

즉, HMR 경로에서 `new_bundle == null`은 “bundle sourcemap 삭제”가 아니라 “full bundle sourcemap은 변경 없음”으로 해석해야 합니다.

## 변경 사항

- `LazySourceMapCache`에서 bundle map과 module map clear 경로를 분리했습니다.
- HMR rebuild에서 `new_bundle == null`이면 기존 full-bundle sourcemap을 보존하고, per-module sourcemap만 최신 rebuild 결과로 교체하도록 수정했습니다.
- graph refresh로 full bundle을 다시 생성하는 경로에서는 `.map` output을 읽어 `sourceMapCache`까지 함께 갱신하도록 했습니다.
- 실제 RN dev HTTP server를 띄운 뒤 `/index.map`을 확인하고, 파일 수정으로 HMR을 발생시킨 뒤에도 `/index.map`이 계속 200인지 검증하는 회귀 테스트를 추가했습니다.

## 검증

- `bun test packages/react-native/src/dev-server/serve.test.ts --timeout 10000`
  - 5 pass / 0 fail

## 영향

- HMR update code의 per-module sourcemap 교체 동작은 유지됩니다.
- full bundle sourcemap은 full bundle rebuild가 있을 때만 교체되고, HMR-only rebuild에서는 기존 값을 유지합니다.
- `/index.map`, `/symbolicate`가 HMR 이후에도 안정적으로 원본 소스를 참조할 수 있습니다.