### PR TITLE
fix(linker): wrapper-barrel default 술어를 default_export_named_local 로 교정 (#3370 후속)

### DIFF
--- a/src/bundler/binding_scanner.zig
+++ b/src/bundler/binding_scanner.zig
@@ -118,6 +118,16 @@ pub const ExportBinding = struct {
             std.mem.eql(u8, self.local_name, "default");
     }
 
+    /// `export default <named-local>` (예: `var lib={}; export default lib`,
+    /// lodash-es lodash.default.js) — default 가 이름 있는 로컬 바인딩.
+    /// 표현식 default 는 binding_scanner 가 합성 `_default` 를 local_name 으로
+    /// 쓰므로 제외. `isDefaultDirectReExport`(re-export 형) 와 상보적.
+    pub fn isNamedLocalDefault(self: ExportBinding) bool {
+        return self.kind == .local and
+            std.mem.eql(u8, self.exported_name, "default") and
+            !std.mem.eql(u8, self.local_name, "_default");
+    }
+
     /// 이 export 때문에 현재 모듈에 `_default` 합성 변수가 생기는지 확인.
     /// #1338 Phase 4e-2d-a: synthetic_default는 항상 semantic 공간에 등록됨.
     pub fn hasSyntheticDefault(

--- a/src/bundler/graph/requested_exports.zig
+++ b/src/bundler/graph/requested_exports.zig
@@ -75,12 +75,15 @@ pub fn isWrapperBarrel(self: anytype, m: *const Module) bool {
 pub fn computeBarrelFlags(m: *Module) void {
     var is_wrapper = false;
     var has_local = false;
+    var default_named_local = false;
     for (m.export_bindings) |eb| {
         if (eb.isDefaultDirectReExport()) is_wrapper = true;
         if (eb.kind == .local) has_local = true;
+        if (eb.isNamedLocalDefault()) default_named_local = true;
     }
     m.is_wrapper_barrel = is_wrapper;
     m.has_local_export = has_local;
+    m.default_export_named_local = default_named_local;
 }
 
 pub fn nameHasDirectNonStarExport(m: *const Module, name: []const u8) bool {

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -29,7 +29,6 @@ const CompiledModule = @import("compiled_module.zig").CompiledModule;
 const preamble_writer = @import("linker/preamble_writer.zig");
 const namespace_access = @import("linker/namespace_access.zig");
 const shared_namespace = @import("linker/shared_namespace.zig");
-const graph_requested_exports = @import("graph/requested_exports.zig");
 pub const PreambleWriter = preamble_writer.PreambleWriter;
 pub const cjsImportNeedsToEsmInterop = preamble_writer.cjsImportNeedsToEsmInterop;
 pub const LinkingMetadata = @import("linker/metadata_types.zig").LinkingMetadata;
@@ -388,15 +387,20 @@ pub const Linker = struct {
         return src.wrap_kind == .cjs;
     }
 
-    /// `import _ from './w'; _.foo()` 에서 source 가 wrapper-barrel
-    /// (`BASE.PROP = importLocal; export default BASE`, lodash-es lodash.default.js)
-    /// 인 default binding. CJS default 와 동일하게 scope-aware member 분석으로
-    /// `namespace_used_properties` 를 채워, wrapper-barrel 의 prop 단위 정밀
-    /// lazy 링크가 소비자 사용 prop 집합을 알 수 있게 한다.
+    /// `import _ from './w'; _.foo()` 에서 source 가 `export default <named-local>`
+    /// (예: `var lib={}; lib.foo=…; export default lib`, lodash-es lodash.default.js)
+    /// 인 ESM default binding. CJS default 와 동일하게 scope-aware member 분석으로
+    /// `namespace_used_properties` 를 채워, wrapper-barrel mutation 의 prop 단위
+    /// 정밀 lazy 가 소비자 사용 prop 집합을 알 수 있게 한다.
+    ///
+    /// `is_wrapper_barrel` (=`export {default} from` re-export 형) 이 아니라
+    /// `default_export_named_local` 를 본다 — 실제 mutation 패턴은 default 가
+    /// 로컬 객체이고 `.local` export 라 `is_wrapper_barrel`/`isLazyBarrelCandidate`
+    /// 가 false 이기 때문 (실측 확정).
     fn isEsmWrapperDefaultBinding(self: *const Linker, importer: *const Module, ib: ImportBinding) bool {
         if (ib.kind != .default) return false;
         const src = self.importedModule(importer, ib.import_record_index) orelse return false;
-        return graph_requested_exports.isWrapperBarrel(self.graph, src);
+        return src.wrap_kind != .cjs and src.default_export_named_local;
     }
 
     /// 링킹 실행: export 맵 구축 → import 바인딩 해결.
@@ -1758,7 +1762,7 @@ pub const Linker = struct {
                 const is_cjs_default_candidate = ib.kind == .default and source.wrap_kind == .cjs;
                 const is_esm_wrapper_default_candidate = ib.kind == .default and
                     !is_cjs_default_candidate and
-                    graph_requested_exports.isWrapperBarrel(self.graph, source);
+                    source.default_export_named_local;
                 const should_analyze_binding = is_namespace or is_named_candidate or
                     is_cjs_default_candidate or is_esm_wrapper_default_candidate;
                 if (!should_analyze_binding) continue;

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -265,6 +265,12 @@ pub const Module = struct {
     /// 순수 re-export barrel 이 아니므로 `isLazyBarrelCandidate` 에서 제외 (body 가 import 참조).
     /// `is_wrapper_barrel` 과 같은 패스에서 채워지는 hot-path 캐시.
     has_local_export: bool = false,
+    /// `export default <named-local>` (예: `var lib={}; ...; export default lib`,
+    /// lodash-es lodash.default.js) — default export 가 합성 `_default` 표현식이
+    /// 아니라 이름 있는 로컬 바인딩. wrapper-barrel mutation 정밀 lazy 의
+    /// 소비자 `_.foo` 접근 분석 게이트 (linker `isEsmWrapperDefaultBinding`).
+    /// `is_wrapper_barrel`(=`export {default} from` 형) 과 다른 패턴이라 별도 캐시.
+    default_export_named_local: bool = false,
     /// platform=browser에서 Node 빌트인 모듈을 빈 CJS로 대체 (esbuild "(disabled)" 방식).
     /// AST가 없고, emitter가 빈 __commonJS wrapper를 출력한다.
     is_disabled: bool = false,


### PR DESCRIPTION
## 배경

#3370 (`feat(linker): ESM wrapper-barrel default import scope-aware member 분석`, merged) 의 `isEsmWrapperDefaultBinding` 이 **`isWrapperBarrel`** 을 검사했습니다. 그런데 `isWrapperBarrel` = `isLazyBarrelCandidate && is_wrapper_barrel`, `is_wrapper_barrel` = `eb.isDefaultDirectReExport()` = **`export { default } from './m'`** (re-export 형).

실제 타깃 패턴 — lodash-es `lodash.default.js` / 합성 repro — 은 **`var lib={}; lib.X=…; export default lib`** 입니다. 이건 `.local` export → `has_local_export=true` → `isLazyBarrelCandidate=false` → `isWrapperBarrel=false`.

**실측 확정 (instrumented probe):** 합성 wrapper repro 에서 #3370 술어는 `has_candidate=false` → `populateNamespaceAccesses` 통째 skip → 소비자 `import _ from wrapper` 의 `_` 가 `namespace_used_properties=null` 로 남음. 즉 **#3370 의 enabling 이 실제로 발동하지 않았습니다** (inert 라 회귀는 없으나 실효 없음).

## 변경

- `ExportBinding.isNamedLocalDefault()` 추가 — `kind==.local && exported=="default" && local_name!="_default"`. 기존 `isDefaultDirectReExport()`(re-export 형) 와 상보적, 같은 파일 관습(인라인 리터럴) 일치.
- `computeBarrelFlags` 가 같은 export_bindings 패스에서 `Module.default_export_named_local` 캐시 채움.
- `isEsmWrapperDefaultBinding` + `populateNamespaceAccesses` per-binding candidate 가 `isWrapperBarrel` 대신 `src.wrap_kind != .cjs and src.default_export_named_local`.
- 미사용 `graph_requested_exports` import 제거.

## 검증

- **실측 재확정**: corrected 술어로 합성 repro `esm_wrap_cand=true` (이전 `false`) — 갭 닫힘. 소비자 `_.foo()` → `namespace_used_properties={foo}` 채워짐 (escape 시 opaque→null).
- 여전히 **enabling 단계 — 행동 inert** (채워진 prop 집합 소비하는 정밀 lazy 는 후속 PR-2). 전체 유닛 스위트 `zig build test` **EXIT=0, 회귀 0**.
- 부수효과: `has_candidate` hot path 가 `isLazyBarrelCandidate` 다중조건 → 캐시 bool 2읽기로 단순화 (소폭 개선).
- ReleaseFast 빌드 통과. 최신 main(#3370 포함) 기준.

## /simplify

3-에이전트 리뷰 반영: 술어를 `ExportBinding.isNamedLocalDefault()` 메서드로 중앙화 (computeBarrelFlags 인라인 제거, `isDefaultDirectReExport` 형제 패턴). `"_default"` 전역 상수화는 다파일 chore·기존 `isDefaultDirectReExport` 도 인라인이라 범위 밖으로 보류. 중복 술어(헬퍼/per-binding)는 컨텍스트 차이(source 핸들 재사용)로 정당 — 유지.

관련 #2060. 후속 PR-2 가 이 `namespace_used_properties` 를 소비해 wrapper-barrel writer-edge 를 prop 단위로 정밀 lazy (lodash-es 등 size win + escape SAFETY 보수 fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)