### PR TITLE
refactor(stmt-info): extract memberAssignTargetParts 공통 코어 (#3359 중복 제거)

### DIFF
--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -246,6 +246,29 @@ fn staticMemberParts(ast: *const Ast, idx: NodeIndex) ?struct { object: NodeInde
     return .{ .object = obj_idx, .property = prop_idx };
 }
 
+/// top-level `BASE.PROP = RHS;` (단순 `=` 대입, LHS 정적 멤버, BASE 단일
+/// identifier) 의 base identifier / rhs 노드. 아니면 null.
+/// `gatedMemberAugmentObjectNode` 가 RHS 순수성·글로벌 검사를 덧붙이는
+/// 공통 구조 추출 코어 (#3359 중복 제거).
+fn memberAssignTargetParts(
+    ast: *const Ast,
+    stmt_node: Node,
+) ?struct { base: NodeIndex, rhs: NodeIndex } {
+    if (stmt_node.tag != .expression_statement) return null;
+    const expr_idx = stmt_node.data.unary.operand;
+    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return null;
+    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
+    if (expr.tag != .assignment_expression) return null;
+    // `=` (단순 대입) 만. `+=` 등 compound 는 read+write 라 dead 여도 단순
+    // drop 이 안전하지 않아 제외 (operator 는 binary.flags 에 토큰 Kind).
+    const op: TokenKind = @enumFromInt(expr.data.binary.flags);
+    if (op != .eq) return null;
+    const parts = staticMemberParts(ast, expr.data.binary.left) orelse return null;
+    const obj = ast.nodes.items[@intFromEnum(parts.object)];
+    if (obj.tag != .identifier_reference) return null;
+    return .{ .base = parts.object, .rhs = expr.data.binary.right };
+}
+
 fn isModuleExportsLhs(ast: *const Ast, lhs: NodeIndex) bool {
     const parts = staticMemberParts(ast, lhs) orelse return false;
     const obj = ast.nodes.items[@intFromEnum(parts.object)];
@@ -1071,26 +1094,8 @@ fn gatedMemberAugmentObjectNode(
     stmt_node: Node,
     unresolved_globals: ?*const purity.GlobalRefSet,
 ) ?NodeIndex {
-    if (stmt_node.tag != .expression_statement) return null;
-    const expr_idx = stmt_node.data.unary.operand;
-    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return null;
-    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
-    if (expr.tag != .assignment_expression) return null;
-
-    // `=` (단순 대입) 만. `+=` 등 compound 는 X.member 를 read+write 하므로
-    // X dead 여도 단순 drop 이 안전하지 않아 제외 (assignment_expression 의
-    // operator 는 binary.flags 에 토큰 Kind 로 저장됨 — import_scanner 와 동일).
-    const op: TokenKind = @enumFromInt(expr.data.binary.flags);
-    if (op != .eq) return null;
-
-    const left_idx = expr.data.binary.left;
-    const right_idx = expr.data.binary.right;
-    if (left_idx.isNone() or @intFromEnum(left_idx) >= ast.nodes.items.len) return null;
-
-    // LHS = static_member_expression (computed / private / 중첩 멤버 제외).
-    const parts = staticMemberParts(ast, left_idx) orelse return null;
-    const obj = ast.nodes.items[@intFromEnum(parts.object)];
-    if (obj.tag != .identifier_reference) return null;
+    const m = memberAssignTargetParts(ast, stmt_node) orelse return null;
+    const obj = ast.nodes.items[@intFromEnum(m.base)];
 
     // base 가 unresolved global (`window.x = ...`) 이면 글로벌 변이 — 제외.
     if (unresolved_globals) |globals| {
@@ -1098,9 +1103,9 @@ fn gatedMemberAugmentObjectNode(
     }
 
     // RHS 순수성 (three 의 mergeUniforms 는 /*@__PURE__*/ 주석으로 pure 판정).
-    if (!purity.isExprPure(ast, right_idx, unresolved_globals)) return null;
+    if (!purity.isExprPure(ast, m.rhs, unresolved_globals)) return null;
 
-    return parts.object;
+    return m.base;
 }
 
 /// base identifier 심볼 X 가 이 모듈 top-level (scope_id==0) 비-import 로컬인지


### PR DESCRIPTION
## 배경

#3359 (member-augment) 의 `gatedMemberAugmentObjectNode` 는 `BASE.PROP = RHS` 구조 검출(expression_statement → assignment_expression(`=`) → static_member → identifier) 을 인라인으로 갖고 있었습니다. PR-2(wrapper-barrel 정밀 lazy) 작업의 `/simplify` 3-에이전트 리뷰가 이 구조 검출을 공통 코어로 추출하라고 (reuse+quality 양쪽) 권고했고, 그 dedup 자체는 PR-2와 독립한 순수 가치입니다.

> PR-2 본체(wrapper-barrel 정밀 lazy)는 **실세계 적용처 0 으로 폐기**했습니다 (3중 실측: ① 벤치 ~140 패키지 중 `obj.PROP=import` 패턴 0 ② `import _ from 'lodash-es'` 는 순수 barrel lodash.js 로 resolve, wrapper lodash.default.js 미경유 ③ esbuild/rolldown/rspack 전부 이 최적화 미구현 + 적용해도 ZNTC 179B > esbuild 151B). 그 과정에서 도출된 이 dedup 만 분리해 살립니다.

## 변경

`memberAssignTargetParts(ast, stmt_node) ?{ base, rhs }` 공통 코어 추출. `gatedMemberAugmentObjectNode` 는 그 코어 + RHS 순수성/unresolved-global 검사만 남긴 thin wrapper 로 축소 (단일 파일 stmt_info.zig, +27/-22).

## 검증

- 순수 **behavior-preserving** 리팩터: staticMemberParts 호출/노드 접근/검사 순서 동일. bounds 체크는 staticMemberParts 위임으로 오히려 강화(object/property 추가 검증).
- three (#3359 member-augment) **12KB MATCH 불변**, `zig build test -Dtest-filter=stmt_info` **EXIT=0**.
- ReleaseFast 빌드 통과. 최신 main 기준.

## /simplify

3-에이전트 리뷰: **전원 APPROVED, behavior-preserving, 블로커 없음**. 익명 struct 는 `staticMemberParts` 관습과 일관, 문서 정확, dead code 없음. 유일 지적(미사용 `property` 필드 — 소비자 없음)을 반영해 struct 를 `{ base, rhs }` 최소 코어로 정리. (다른 cjs 함수의 `expressionFromStatement` 류 추가 추출은 "현 PR 범위 아님"으로 보류.)

관련 #2060. PR-2 폐기 경위·재시도 금지 근거는 메모리에 별도 기록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)