### PR TITLE
feat(mf): P1-0 Module Federation config 표면 + 검증 (#3382)

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -618,6 +618,33 @@ type BuildTarget = import('../shared/index').Target | (string & {});
  * Common build options shared by all platforms.
  * `platform` + `target` 조합은 `BuildOptions` 에서 discriminated union으로 제한됨.
  */
+/** Module Federation `shared` 의존 옵션 (MF2 `SharedConfig` 부분집합, #3318). */
+export interface MfSharedConfig {
+  singleton?: boolean;
+  requiredVersion?: string;
+  strictVersion?: boolean;
+  eager?: boolean;
+}
+
+/** Module Federation config 블록 (#3318 P1-0). webpack/rspack
+ * `ModuleFederationPlugin` 과 동형 record 형태 — `@module-federation/runtime`
+ * 계약 타겟. **P1-0 은 zntc.config 파싱·검증만**(emit 미연결, P1-1+ 소비;
+ * build()/NAPI mf 추출도 P1-1+). `shared` array/boolean shorthand 는
+ * P1-1+ — P1-0 은 record-of-object 만. */
+export interface ModuleFederationConfig {
+  /** remote 식별자. `exposes`/`remotes` 사용 시 필수. */
+  name?: string;
+  /** 노출 모듈: `{ "./Widget": "./src/Widget.tsx" }`. */
+  exposes?: Record<string, string>;
+  /** 소비 remote: `{ remoteA: "remoteA@https://…/mf-manifest.json" }`. */
+  remotes?: Record<string, string>;
+  /** 공유 의존: `{ react: { singleton: true, requiredVersion: "^18" } }`.
+   * (P1-0: record-of-object 만. boolean/array shorthand 는 P1-1+.) */
+  shared?: Record<string, MfSharedConfig>;
+  /** share scope 이름 (기본 `"default"`). */
+  shareScope?: string;
+}
+
 interface BuildOptionsCommon {
   entryPoints: string[];
   format?: 'esm' | 'cjs' | 'iife' | 'umd' | 'amd';
@@ -641,6 +668,10 @@ interface BuildOptionsCommon {
    * 바이트 미만인 작은 common 청크를, 도달성이 상위집합인(over-fetch 없는)
    * 청크로 자동 병합. entry/manual/dynamic 청크는 보존. 0/미지정 = 비활성. */
   minChunkSize?: number;
+  /** Module Federation 설정 (#3318 P1-0). 파싱·검증만 — emit 은 후속(P1-1+).
+   * nested 객체라 config/`build()` 전용(CLI flag 없음 — 생태계 전부
+   * config-driven). MF2 계약(`name`/`exposes`/`remotes`/`shared`/`shareScope`). */
+  mf?: ModuleFederationConfig;
   sourcemap?: boolean;
   /**
    * sourcemap 출력 형식 (`sourcemap: true` 일 때만 의미). esbuild / rolldown 호환 (#2152).

--- a/src/cli/options.zig
+++ b/src/cli/options.zig
@@ -383,6 +383,13 @@ fn applyZntcConfigJson(opts: *CliOptions, allocator: std.mem.Allocator) !void {
             .patterns = patterns,
         });
     };
+    // Module Federation (#3318 P1-0): 구조 검증만. emit 은 P1-1+ 가 소비 —
+    // 아직 CliOptions 에 저장 안 함(consumer 없음, arena 수명 deep-dupe 불요).
+    // 검증 실패는 caller 가 `[zntc] zntc.config.json load failed: …` 로 표면화.
+    // ⚠️ 검증은 이 Zig CLI 의 zntc.config.json 경로 한정 — build()/NAPI
+    // (`packages/core/src/napi/options.zig`)는 아직 mf 키를 추출조차 안 함.
+    // P1-1+ 에서 NAPI mf 추출 + validateMf 연결 필수(silent drift 주의).
+    if (dto.mf) |*mf| try lib.transpile.validateMf(mf);
 }
 
 /// CLI 인자를 파싱하여 CliOptions를 반환한다.

--- a/src/config_options_dto_test.zig
+++ b/src/config_options_dto_test.zig
@@ -56,6 +56,7 @@ const bundler_only_fields = [_][]const u8{
     "manualChunks",
     "sourcemapMode",
     "outputExports",
+    "mf", // Module Federation config 블록 (#3318 P1-0)
 };
 
 /// TS interface 본문에서 필드명을 추출한다. 간단 파서: `interface <name> {` 블록

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -38,6 +38,8 @@ pub const TranspileOptionsDto = transpile_options.TranspileOptionsDto;
 pub const AliasDto = transpile_options.AliasDto;
 pub const ManualChunkDto = transpile_options.ManualChunkDto;
 pub const LoaderDto = transpile_options.LoaderDto;
+pub const MfConfigDto = transpile_options.MfConfigDto;
+pub const validateMf = transpile_options.validateMf;
 pub const applyTranspileSharedFields = transpile_options.applyTranspileSharedFields;
 pub const optionsFromJson = transpile_options.optionsFromJson;
 

--- a/src/transpile/options.zig
+++ b/src/transpile/options.zig
@@ -163,7 +163,106 @@ pub const ConfigOptionsDto = struct {
     inlineDynamicImports: ?bool = null,
     minChunkSize: ?u32 = null,
     manualChunks: ?[]const ManualChunkDto = null,
+    /// Module Federation (#3318 P1-0). **파싱·검증만 — emit 미연결**(P1-1+
+    /// 가 소비). MF2 생태계·public TS 타입과 동일하게 **record 형태** 직접
+    /// 파싱(define/alias 의 array-of-entry 관례와 다름 — MF config 는
+    /// webpack/rspack/vite 전부 record `{ "./W": "./w" }` 라 그에 맞춤,
+    /// 이원성·wrapper 변환 없음). **검증은 Zig CLI 의 zntc.config.json 경로
+    /// 한정** — build()/NAPI(`packages/core/src/napi/options.zig`)의 mf
+    /// 추출+검증은 P1-1+ 에서 연결(현재 미지원, 아래 주석 참조). nested
+    /// 객체라 CLI flag 없음(생태계 전부 config-driven, #3382 스코프).
+    mf: ?MfConfigDto = null,
 };
+
+/// MF config 블록 DTO. MF2 `ModuleFederationPlugin` 과 동형 record 형태로
+/// **직접 파싱**(`std.json.ArrayHashMap`). public 타입
+/// `packages/core/index.ts:ModuleFederationConfig` 와 1:1 — 변환 계층 없음.
+/// P1-0 은 record-of-object `shared` 만(`{react:{singleton:true}}`).
+/// array/boolean shorthand(`shared:['react']`/`{react:true}`)는 P1-1+.
+pub const MfConfigDto = struct {
+    name: ?[]const u8 = null,
+    /// `{ "./Widget": "./src/Widget.tsx" }` (exported name → 소스 경로)
+    exposes: ?std.json.ArrayHashMap([]const u8) = null,
+    /// `{ "remoteA": "remoteA@http://…/mf-manifest.json" }`
+    remotes: ?std.json.ArrayHashMap([]const u8) = null,
+    /// `{ "react": { singleton:true, requiredVersion:"^18" } }`
+    shared: ?std.json.ArrayHashMap(MfSharedDto) = null,
+    shareScope: ?[]const u8 = null,
+};
+
+pub const MfSharedDto = struct {
+    singleton: ?bool = null,
+    requiredVersion: ?[]const u8 = null,
+    strictVersion: ?bool = null,
+    eager: ?bool = null,
+};
+
+pub const MfValidationError = error{
+    MfNameRequired,
+    MfExposeEmptyPath,
+    MfRemoteEmptyEntry,
+};
+
+/// MF config 구조 검증 (P1-0 — emit 없음, 구조 sanity 만). exposes/remotes 가
+/// 비어있지 않으면 name 필수(MF2: remote 식별자). 빈 경로/엔트리 거부.
+/// (빈 record `{}` 는 "미선언" 취급 — count()==0.)
+pub fn validateMf(mf: *const MfConfigDto) MfValidationError!void {
+    const has_exposes = if (mf.exposes) |e| e.map.count() > 0 else false;
+    const has_remotes = if (mf.remotes) |r| r.map.count() > 0 else false;
+    if (has_exposes or has_remotes) {
+        const name = mf.name orelse return error.MfNameRequired;
+        if (name.len == 0) return error.MfNameRequired;
+    }
+    if (mf.exposes) |e| {
+        var it = e.map.iterator();
+        while (it.next()) |kv| if (kv.value_ptr.*.len == 0) return error.MfExposeEmptyPath;
+    }
+    if (mf.remotes) |r| {
+        var it = r.map.iterator();
+        while (it.next()) |kv| if (kv.value_ptr.*.len == 0) return error.MfRemoteEmptyEntry;
+    }
+}
+
+test "validateMf: record 형태 + exposes/remotes 있으면 name 필수" {
+    const a = std.testing.allocator;
+    const J = struct {
+        fn p(alloc: std.mem.Allocator, s: []const u8) !std.json.Parsed(MfConfigDto) {
+            return std.json.parseFromSlice(MfConfigDto, alloc, s, .{ .ignore_unknown_fields = true });
+        }
+    };
+
+    {
+        const v = try J.p(a, "{\"name\":\"app\",\"exposes\":{\"./W\":\"./w.ts\"}}");
+        defer v.deinit();
+        try validateMf(&v.value);
+    }
+    {
+        const v = try J.p(a, "{\"exposes\":{\"./W\":\"./w.ts\"}}");
+        defer v.deinit();
+        try std.testing.expectError(error.MfNameRequired, validateMf(&v.value));
+    }
+    {
+        const v = try J.p(a, "{\"name\":\"app\",\"exposes\":{\"./W\":\"\"}}");
+        defer v.deinit();
+        try std.testing.expectError(error.MfExposeEmptyPath, validateMf(&v.value));
+    }
+    {
+        const v = try J.p(a, "{\"name\":\"app\",\"remotes\":{\"r\":\"\"}}");
+        defer v.deinit();
+        try std.testing.expectError(error.MfRemoteEmptyEntry, validateMf(&v.value));
+    }
+    { // shared-only(host) 는 name 불요
+        const v = try J.p(a, "{\"shared\":{\"react\":{\"singleton\":true}}}");
+        defer v.deinit();
+        try validateMf(&v.value);
+        try std.testing.expect(v.value.shared.?.map.get("react").?.singleton.?);
+    }
+    { // 빈 record = 미선언
+        const v = try J.p(a, "{\"exposes\":{}}");
+        defer v.deinit();
+        try validateMf(&v.value);
+    }
+}
 
 pub const TranspileOptionsDto = ConfigOptionsDto;
 

--- a/tests/integration/tests/zntc-config-bundler.test.ts
+++ b/tests/integration/tests/zntc-config-bundler.test.ts
@@ -298,4 +298,66 @@ describe('Zig CLI: zntc.config.json bundler-only 옵션 (#2105)', () => {
     expect(r.exitCode).toBe(0);
     expect(readFileSync(r.outFile!, 'utf8')).toContain('TSCONFIG_OK');
   });
+
+  // ─── Module Federation config 블록 (#3318 P1-0) ──────────────────────────
+  // P1-0 은 파싱·검증만 — emit 미연결. 유효 mf 는 빌드 정상(출력 불변),
+  // 무효 mf 는 config 검증 경고가 stderr 로 표면화(기존 config-error 정책:
+  // non-fatal warn). emit/소비는 P1-1+. mf 는 **record 형태**(public TS
+  // 타입·MF2 생태계와 동일, define/alias 의 array 관례와 다름) — zntc DTO
+  // 가 std.json.ArrayHashMap 으로 직접 파싱, 변환 계층 없음. 사용자가
+  // 문서/타입대로 쓰는 그 경로를 그대로 검증.
+
+  test('mf: 유효 config 블록(name/exposes/remotes/shared/shareScope) 파싱 성공', async () => {
+    const r = await runConfigBundle({
+      files: {
+        'index.ts': `console.log("mf-ok");`,
+        'zntc.config.json': JSON.stringify({
+          mf: {
+            name: 'app',
+            exposes: { './Widget': './widget.ts' },
+            remotes: { remoteA: 'remoteA@http://localhost/mf-manifest.json' },
+            shared: { react: { singleton: true, requiredVersion: '^18' } },
+            shareScope: 'default',
+          },
+        }),
+      },
+    });
+    cleanup = r.cleanup;
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr).not.toContain('load failed');
+    // emit 미연결 — 출력은 일반 번들 그대로
+    expect(readFileSync(r.outFile!, 'utf8')).toContain('mf-ok');
+  });
+
+  test('mf: exposes 인데 name 없으면 검증 경고(MfNameRequired) 표면화', async () => {
+    const r = await runConfigBundle({
+      files: {
+        'index.ts': `console.log("mf-bad");`,
+        'zntc.config.json': JSON.stringify({
+          mf: { exposes: { './Widget': './widget.ts' } },
+        }),
+      },
+    });
+    cleanup = r.cleanup;
+
+    // 기존 config-error 정책상 non-fatal warn — stderr 로 검증 실패 표면화
+    expect(r.stderr).toContain('load failed');
+    expect(r.stderr).toContain('MfNameRequired');
+  });
+
+  test('mf: shared-only(host) 는 name 없이도 유효', async () => {
+    const r = await runConfigBundle({
+      files: {
+        'index.ts': `console.log("host");`,
+        'zntc.config.json': JSON.stringify({
+          mf: { shared: { react: { singleton: true } } },
+        }),
+      },
+    });
+    cleanup = r.cleanup;
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr).not.toContain('load failed');
+  });
 });


### PR DESCRIPTION
#3318 P1 의 prereq. zntc.config 에 `mf` 블록(name/exposes/remotes/shared/shareScope) + 검증. **파싱·검증만 — emit 미연결**(P1-1+ 소비).

## 변경
- `ConfigOptionsDto.mf: ?MfConfigDto` — MF2 생태계·public TS 타입과 동일한 **record 형태**를 `std.json.ArrayHashMap` 으로 직접 파싱. define/alias 의 array-of-entry 관례와 의도적으로 다름(MF config 는 webpack/rspack/vite 전부 record `{ "./W": "./w" }` — 이원성/wrapper 변환 없이 public 타입과 1:1).
- `validateMf` — exposes/remotes 비어있지 않으면 `name` 필수, 빈 경로/엔트리 거부. Zig CLI `zntc.config.json` 경로에서 호출, 실패는 기존 config-error 정책대로 non-fatal warn(`load failed`).
- `packages/core/index.ts`: `ModuleFederationConfig`/`MfSharedConfig` (record; P1-0 은 record-of-object `shared` 만 — array/boolean shorthand 는 P1-1+). `BuildOptionsCommon.mf` + `bundler_only_fields` allowlist → #2112 schema-sync 통과.
- **CLI flag 없음** (스코프 결정): nested 객체라 flat flag 로 `shared:{react:{singleton}}` 표현 불가, MF 는 생태계 전부 config-driven. 코드 주석에 근거 명시(#3382 본문의 "+ CLI 플래그"에서 축소 — 사용자 확인 사항).
- ⚠️ build()/NAPI(`napi/options.zig`) mf 추출+검증은 **P1-1+** (현재 Zig CLI config 경로 한정 — 주석에 silent-drift 경고 기록).

## /simplify 3-agent 반영
3 에이전트가 수렴한 실 함정 정면 수정: 초기 array-DTO + 거짓 "JS wrapper 가 record→array 변환(define/alias 동일)" 주석 → 실제로 변환기 부재 + record 입력 시 config 전체 silent-fail 함정이었음. **DTO 를 record 직접 파싱으로 재설계**(이원성·거짓주석 제거), 통합테스트를 record 실사용자 경로로 교정, NAPI 검증 갭 주석 명시, entry struct 정리.

## 검증
`zig build test` 전체 통과(#2112/TranspileOptions schema-sync 2건 + validateMf record 유닛), MF 통합 3/0, app-builder 14/0, react smoke ✅. 회귀 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)