### PR TITLE
feat(mangler): nested-scope slot 인프라 — esbuild AssignNestedScopeSlots 이식 (RFC #3391 PR-1)

### DIFF
--- a/src/codegen/mangler.zig
+++ b/src/codegen/mangler.zig
@@ -478,14 +478,15 @@ fn bitsetIntersects(a: std.DynamicBitSet, b: std.DynamicBitSet) bool {
 // Children 역산 (parent -> children adjacency list)
 // ============================================================
 
-const ChildrenList = struct {
+// pub: nested_slots.zig (RFC #3391) 가 parent-only scope tree 의 children 역산에 재사용.
+pub const ChildrenList = struct {
     /// offsets[scope_id] = children_list 내 시작 인덱스. 길이 = scope_count + 1.
     offsets: []u32,
     /// flat children 배열.
     list: []u32,
 };
 
-fn buildChildrenList(allocator: std.mem.Allocator, scopes: []const Scope) !ChildrenList {
+pub fn buildChildrenList(allocator: std.mem.Allocator, scopes: []const Scope) !ChildrenList {
     const n = scopes.len;
 
     // Pass 1: 각 scope의 children 수 카운트
@@ -573,7 +574,8 @@ const SlotSortEntry = struct {
 // mangling 제외 판정
 // ============================================================
 
-fn shouldSkip(sym: Symbol, name: []const u8) bool {
+// pub: nested_slots.zig (RFC #3391) 가 slot namespace 분류에 재사용 (단일 소스).
+pub fn shouldSkip(sym: Symbol, name: []const u8) bool {
     if (sym.isExported()) return true;
     if (sym.decl_flags.is_import) return true;
     // `const Foo = class Bar {}` 의 inner `Bar` (#2197). mangle 시 `.name` 프로퍼티도

--- a/src/codegen/mod.zig
+++ b/src/codegen/mod.zig
@@ -23,6 +23,7 @@ pub const function_map = @import("function_map.zig");
 pub const FunctionMapBuilder = function_map.FunctionMapBuilder;
 pub const mangler = @import("mangler.zig");
 pub const unified_mangler = @import("unified_mangler.zig");
+pub const nested_slots = @import("nested_slots.zig");
 
 test {
     _ = codegen;
@@ -31,6 +32,7 @@ test {
     _ = function_map;
     _ = mangler;
     _ = unified_mangler;
+    _ = nested_slots;
 
     // test files
     _ = @import("codegen_test.zig");

--- a/src/codegen/nested_slots.zig
+++ b/src/codegen/nested_slots.zig
@@ -1,0 +1,343 @@
+//! ZNTC Nested-Scope Slot Assignment — esbuild `renamer.go` 1:1 이식
+//!
+//! RFC #3391 / 트래킹 이슈 #3392, PR-1.
+//!
+//! 미니파이 격차의 유일·진짜 레버: 현 mangler 의 flat per-module 처리를
+//! esbuild 의 재귀 nested-scope-slot walk 로 교체하기 위한 *인프라*.
+//!
+//! 이 PR(PR-1)에서는 slot 할당 알고리즘만 구현하고 mangler 파이프라인에
+//! **연결하지 않는다** — `mangle()` 은 이 모듈을 호출하지 않으므로 번들
+//! 동작은 완전히 무변경. 이름 발급(`AssignNamesByFrequency`)·Phase A 통합·
+//! flag 게이트는 PR-2/PR-3 에서 추가한다.
+//!
+//! ## esbuild 알고리즘 (internal/renamer/renamer.go)
+//!
+//! `AssignNestedScopeSlots(moduleScope, symbols)`:
+//!   1. module(top-level) 멤버를 일시적으로 "valid" 마킹 → nested scope 에서
+//!      slot 을 안 받게 (호이스팅된 `var` 가 top-level 심볼이 되는 것 보호).
+//!   2. moduleScope 의 각 자식에 대해 빈 SlotCounts 로 helper 재귀 →
+//!      자식 subtree 마다 독립된 slot 공간 (형제 subtree 는 동시 live 불가).
+//!   3. top-level 멤버 마킹 원복 (top-level 은 nested slot 없음).
+//!
+//! `assignNestedScopeSlotsHelper(scope, symbols, slot)`:
+//!   - 이 scope 멤버를 inner-index 순으로 정렬 (결정성).
+//!   - 아직 미할당이고 `must_not_be_renamed` 가 아니면
+//!     `slot[ns]` 부여 후 `slot[ns] += 1`.
+//!   - 자식 scope 들에 *부모 카운트를 복사*해 전달 → 형제는 같은 slot 재사용,
+//!     자식은 부모 카운트 *이후*부터 시작 → closure-capture 된 outer 이름과
+//!     **구성적으로 충돌 불가** (이게 flat-mangle 이 못 주던 안전성, #2956
+//!     subtree-liveness 와 동치).
+//!   - `UnionMax` 로 형제 간 최대 slot 수 집계.
+//!
+//! ## ZNTC ↔ esbuild 매핑
+//!
+//! | esbuild | ZNTC |
+//! |---|---|
+//! | `moduleScope.Children` (포인터) | parent-only `scopes` → `buildChildrenList` 역산 |
+//! | `scope.Members` (map ref→symbol) | `scope_maps[scope_id]` (name→symbol_idx) |
+//! | `scope.Generated` | 없음 — ZNTC 합성 심볼은 `scope_id=none`, 어느 scope_map 에도 없어 자연 제외 (helper 가 방문 안 함) |
+//! | `scope.Label` | 없음 — ZNTC 는 label 을 심볼로 모델링 안 함 (label namespace 미사용) |
+//! | `Symbol.NestedScopeSlot` (`ast.Index32`) | `Symbol.nested_scope_slot: ?u32` (null=invalid) |
+//! | `Symbol.SlotNamespace()` | `slotNamespace()` (mangler.shouldSkip 재사용, 단일 소스) |
+//!
+//! 호출 불변식: `scope_maps.len == scopes.len`, `scopes[0]` = module(top-level)
+//! scope. 방어적 경계 가드가 있으나, 위반 시 tail scope 의 slot 이 조용히
+//! 누락되므로 PR-2 연결 시 caller 가 보장해야 한다.
+
+const std = @import("std");
+const Scope = @import("../semantic/scope.zig").Scope;
+const ScopeId = @import("../semantic/scope.zig").ScopeId;
+const symbol_mod = @import("../semantic/symbol.zig");
+const Symbol = symbol_mod.Symbol;
+const SlotNamespace = symbol_mod.SlotNamespace;
+const mangler = @import("mangler.zig");
+
+/// namespace 별 slot 카운터 (esbuild `ast.SlotCounts` = `[3]uint32`).
+/// `SlotNamespace.must_not_be_renamed` (=3) 은 sentinel 이라 인덱싱 전에 걸러진다.
+pub const SlotCounts = struct {
+    counts: [SlotNamespace.indexable_count]u32 = .{ 0, 0, 0 },
+
+    pub fn get(self: SlotCounts, ns: SlotNamespace) u32 {
+        return self.counts[@intFromEnum(ns)];
+    }
+
+    fn incr(self: *SlotCounts, ns: SlotNamespace) void {
+        self.counts[@intFromEnum(ns)] += 1;
+    }
+
+    /// element-wise max (esbuild `SlotCounts.UnionMax`).
+    fn unionMax(self: *SlotCounts, other: SlotCounts) void {
+        inline for (0..SlotNamespace.indexable_count) |i| {
+            if (other.counts[i] > self.counts[i]) self.counts[i] = other.counts[i];
+        }
+    }
+};
+
+/// top-level 심볼을 nested walk 동안 "할당됨" 으로 일시 마킹하는 sentinel
+/// (esbuild `ast.MakeIndex32(1)` 대응). validity 모델은 `!= null` — 이 값은
+/// non-null 이기만 하면 되고 실제 slot 번호와 절대 겹치지 않으면 된다
+/// (`maxInt` 라 실제 slot 발급 범위와 분리). walk 종료 시 null 로 원복.
+pub const TOPLEVEL_SENTINEL: u32 = std.math.maxInt(u32);
+
+/// esbuild `Symbol.SlotNamespace()` 대응. mangler 의 skip 판정을 **단일 소스로
+/// 재사용** — exported / import / class-expr-name / `arguments` / 이미 1글자
+/// 인 심볼은 rename 금지(`must_not_be_renamed`), 나머지는 `default`.
+/// (ZNTC 는 label·private 필드를 심볼로 모델링하지 않아 그 둘은 미등장.)
+pub fn slotNamespace(sym: Symbol, name: []const u8) SlotNamespace {
+    if (mangler.shouldSkip(sym, name)) return .must_not_be_renamed;
+    return .default;
+}
+
+/// walk 전반에 불변인 컨텍스트. 재귀 프레임마다 슬라이스 4개를 복사하지
+/// 않도록 한 번 묶어 포인터로 전달 (esbuild 는 receiver/closure 로 공유).
+const Ctx = struct {
+    symbols: []Symbol,
+    scope_maps: []const std.StringHashMap(usize),
+    children: mangler.ChildrenList,
+    /// 정규 심볼의 이름은 source span 에 있으므로 `nameText` 에 원본이 필요.
+    source: []const u8,
+    scratch_allocator: std.mem.Allocator,
+};
+
+/// module(top-level=scope 0) 멤버 전체의 `nested_scope_slot` 을 `value` 로 설정.
+/// 마킹(`TOPLEVEL_SENTINEL`) 과 원복(`null`) 양쪽에서 쓰는 단일 경로.
+fn setModuleSymbolSlots(ctx: *const Ctx, value: ?u32) void {
+    if (ctx.scope_maps.len == 0) return;
+    var it = ctx.scope_maps[0].valueIterator();
+    while (it.next()) |sym_idx| {
+        if (sym_idx.* < ctx.symbols.len) {
+            ctx.symbols[sym_idx.*].nested_scope_slot = value;
+        }
+    }
+}
+
+/// esbuild `AssignNestedScopeSlots`. `symbols` 를 in-place mutate
+/// (`slot_namespace`/`nested_scope_slot` 채움). 반환값 = 모듈 전체에서 필요한
+/// namespace 별 nested slot 수.
+///
+/// `source` = 모듈 원본 (정규 심볼 이름 추출용). 전제: `scopes[0]` = module scope.
+pub fn assignNestedScopeSlots(
+    allocator: std.mem.Allocator,
+    scopes: []const Scope,
+    symbols: []Symbol,
+    scope_maps: []const std.StringHashMap(usize),
+    source: []const u8,
+) !SlotCounts {
+    var result: SlotCounts = .{};
+    if (scopes.len == 0) return result;
+
+    const children = try mangler.buildChildrenList(allocator, scopes);
+    defer allocator.free(children.offsets);
+    defer allocator.free(children.list);
+
+    const ctx: Ctx = .{
+        .symbols = symbols,
+        .scope_maps = scope_maps,
+        .children = children,
+        .source = source,
+        .scratch_allocator = allocator,
+    };
+
+    // 1. top-level(module scope=0) 멤버를 일시 valid 마킹 → nested scope 에서
+    //    slot 안 받음 (nested 에서 선언됐지만 module 로 호이스팅된 `var` 가
+    //    실제로는 top-level 심볼인 경우 보호; esbuild 와 동일).
+    setModuleSymbolSlots(&ctx, TOPLEVEL_SENTINEL);
+
+    // 2. module scope 의 각 자식 subtree 에 *빈* SlotCounts 로 진입 — 자식
+    //    subtree 끼리는 동시 live 불가하므로 각자 0 부터 독립 numbering.
+    {
+        const start = children.offsets[0];
+        const end = children.offsets[1];
+        var ci = start;
+        while (ci < end) : (ci += 1) {
+            result.unionMax(try assignNestedScopeSlotsHelper(&ctx, children.list[ci], .{}));
+        }
+    }
+
+    // 3. top-level 마킹 원복 — top-level 심볼은 nested slot 을 가지지 않는다.
+    setModuleSymbolSlots(&ctx, null);
+
+    return result;
+}
+
+/// esbuild `assignNestedScopeSlotsHelper`. `slot_in` 은 부모가 자신의 멤버를
+/// 배정한 *이후*의 카운트를 값으로 복사받는다 → 형제는 같은 번호 재사용,
+/// 자식은 부모 카운트 이후부터.
+fn assignNestedScopeSlotsHelper(ctx: *const Ctx, scope_idx: u32, slot_in: SlotCounts) !SlotCounts {
+    var slot = slot_in;
+
+    // 결정성: 멤버를 symbol inner-index 오름차순으로 (esbuild `sort.Ints`).
+    if (scope_idx < ctx.scope_maps.len) {
+        var members: std.ArrayList(u32) = .empty;
+        defer members.deinit(ctx.scratch_allocator);
+
+        var it = ctx.scope_maps[scope_idx].valueIterator();
+        while (it.next()) |sym_idx| {
+            if (sym_idx.* < ctx.symbols.len) {
+                try members.append(ctx.scratch_allocator, @intCast(sym_idx.*));
+            }
+        }
+        std.mem.sortUnstable(u32, members.items, {}, std.sort.asc(u32));
+
+        for (members.items) |sym_idx| {
+            const sym = &ctx.symbols[sym_idx];
+            const ns = slotNamespace(sym.*, sym.nameText(ctx.source));
+            sym.slot_namespace = ns;
+            // 이미 valid (top-level 마킹 또는 이미 배정) 면 건너뜀 — 부모
+            // scope 의 slot 을 그대로 쓴다 (esbuild `!IsValid()` 가드).
+            if (ns != .must_not_be_renamed and sym.nested_scope_slot == null) {
+                sym.nested_scope_slot = slot.get(ns);
+                slot.incr(ns);
+            }
+        }
+    }
+
+    // 자식 scope 들: 각자 부모 카운트(`slot`)의 *복사본*을 받는다.
+    var slot_counts = slot;
+    if (scope_idx + 1 < ctx.children.offsets.len) {
+        const start = ctx.children.offsets[scope_idx];
+        const end = ctx.children.offsets[scope_idx + 1];
+        var ci = start;
+        while (ci < end) : (ci += 1) {
+            slot_counts.unionMax(try assignNestedScopeSlotsHelper(ctx, ctx.children.list[ci], slot));
+        }
+    }
+    return slot_counts;
+}
+
+// ============================================================
+// 유닛 테스트 — esbuild renamer.go fixture 1:1 slot 동치
+// ============================================================
+//
+// 테스트 심볼은 `synthetic_name` 을 채운다 → `nameText` 가 source 슬라이싱
+// 없이 그 이름을 반환하므로 정규 심볼처럼 분류(renamable). exported 심볼은
+// is_exported 로 must_not_be_renamed 강제. (정규 심볼의 실 source-span
+// nameText 경로는 PR-2 파이프라인 연결 시 통합 테스트로 커버.)
+
+const testing = std.testing;
+const Span = @import("../lexer/token.zig").Span;
+
+const TestSym = struct { name: []const u8, scope: u32, exported: bool = false };
+
+/// scopes(parent 배열) + per-scope 심볼 목록으로 테스트 입력을 구성하고
+/// assignNestedScopeSlots 를 돌린 뒤, 심볼별 nested_scope_slot 을 반환.
+fn runFixture(
+    allocator: std.mem.Allocator,
+    parents: []const u32, // parents[i] = scope i 의 부모 (0xFFFFFFFF = none)
+    syms: []const TestSym,
+    out_slots: []?u32,
+) !SlotCounts {
+    var scopes = try allocator.alloc(Scope, parents.len);
+    defer allocator.free(scopes);
+    for (parents, 0..) |p, i| {
+        scopes[i] = .{
+            .parent = if (p == 0xFFFFFFFF) ScopeId.none else @enumFromInt(p),
+            .kind = if (i == 0) .module else .block,
+            .is_strict = true,
+        };
+    }
+
+    var symbols = try allocator.alloc(Symbol, syms.len);
+    defer allocator.free(symbols);
+    for (syms, 0..) |s, i| {
+        symbols[i] = .{
+            .name = Span{ .start = 0, .end = 0 },
+            .scope_id = @enumFromInt(s.scope),
+            .kind = .variable_let,
+            .declaration_span = Span{ .start = 0, .end = 0 },
+            .synthetic_name = s.name, // nameText 가 이걸 반환 → 정상 분류
+        };
+        symbols[i].decl_flags.is_exported = s.exported;
+    }
+
+    var scope_maps = try allocator.alloc(std.StringHashMap(usize), parents.len);
+    defer {
+        for (scope_maps) |*m| m.deinit();
+        allocator.free(scope_maps);
+    }
+    for (scope_maps) |*m| m.* = std.StringHashMap(usize).init(allocator);
+    for (syms, 0..) |s, i| {
+        try scope_maps[s.scope].put(s.name, i);
+    }
+
+    // synthetic_name 이 채워져 있어 source 는 미사용 — "" 안전.
+    const counts = try assignNestedScopeSlots(allocator, scopes, symbols, scope_maps, "");
+    for (symbols, 0..) |sym, i| out_slots[i] = sym.nested_scope_slot;
+    return counts;
+}
+
+test "형제 scope 는 같은 slot 재사용" {
+    const a = testing.allocator;
+    // 0:module → 1:childA(a), 2:childB(b)
+    var slots: [2]?u32 = undefined;
+    const counts = try runFixture(a, &.{ 0xFFFFFFFF, 0, 0 }, &.{
+        .{ .name = "aa", .scope = 1 },
+        .{ .name = "bb", .scope = 2 },
+    }, &slots);
+    try testing.expectEqual(@as(?u32, 0), slots[0]); // a → slot 0
+    try testing.expectEqual(@as(?u32, 0), slots[1]); // b → slot 0 (형제 재사용)
+    try testing.expectEqual(@as(u32, 1), counts.get(.default));
+}
+
+test "자식 scope 는 부모 카운트 이후부터 (closure 충돌 불가)" {
+    const a = testing.allocator;
+    // 0:module → 1:fn(x) → 2:block(y)
+    var slots: [2]?u32 = undefined;
+    const counts = try runFixture(a, &.{ 0xFFFFFFFF, 0, 1 }, &.{
+        .{ .name = "xx", .scope = 1 },
+        .{ .name = "yy", .scope = 2 },
+    }, &slots);
+    try testing.expectEqual(@as(?u32, 0), slots[0]); // x → slot 0
+    try testing.expectEqual(@as(?u32, 1), slots[1]); // y → slot 1 (부모 이후)
+    try testing.expectEqual(@as(u32, 2), counts.get(.default));
+}
+
+test "깊은 nesting + depth-2 형제 재사용" {
+    const a = testing.allocator;
+    // 0:module → 1:fn(p) → {2:b1(x), 3:b2(yy)}
+    var slots: [3]?u32 = undefined;
+    const counts = try runFixture(a, &.{ 0xFFFFFFFF, 0, 1, 1 }, &.{
+        .{ .name = "pp", .scope = 1 },
+        .{ .name = "xx", .scope = 2 },
+        .{ .name = "yy", .scope = 3 },
+    }, &slots);
+    try testing.expectEqual(@as(?u32, 0), slots[0]); // p → 0
+    try testing.expectEqual(@as(?u32, 1), slots[1]); // x → 1
+    try testing.expectEqual(@as(?u32, 1), slots[2]); // y → 1 (b1/b2 형제 재사용)
+    try testing.expectEqual(@as(u32, 2), counts.get(.default));
+}
+
+test "top-level 심볼은 nested slot 을 받지 않는다" {
+    const a = testing.allocator;
+    // module(m) → 1:fn(local). m 은 top-level → 항상 null.
+    var slots: [2]?u32 = undefined;
+    _ = try runFixture(a, &.{ 0xFFFFFFFF, 0 }, &.{
+        .{ .name = "mm", .scope = 0 },
+        .{ .name = "local", .scope = 1 },
+    }, &slots);
+    try testing.expectEqual(@as(?u32, null), slots[0]); // top-level → null
+    try testing.expectEqual(@as(?u32, 0), slots[1]); // nested local → 0
+}
+
+test "must_not_be_renamed(exported) 는 slot 을 소비하지 않는다" {
+    const a = testing.allocator;
+    // 0:module → 1:fn{ exp(exported), v }
+    var slots: [2]?u32 = undefined;
+    const counts = try runFixture(a, &.{ 0xFFFFFFFF, 0 }, &.{
+        .{ .name = "exp", .scope = 1, .exported = true },
+        .{ .name = "vv", .scope = 1 },
+    }, &slots);
+    try testing.expectEqual(@as(?u32, null), slots[0]); // exported → 미할당
+    try testing.expectEqual(@as(?u32, 0), slots[1]); // v → slot 0 (exp 가 0 안 먹음)
+    try testing.expectEqual(@as(u32, 1), counts.get(.default));
+}
+
+test "빈 입력 / module-only 안전" {
+    const a = testing.allocator;
+    var slots: [1]?u32 = undefined;
+    const counts = try runFixture(a, &.{0xFFFFFFFF}, &.{
+        .{ .name = "only", .scope = 0 },
+    }, &slots);
+    try testing.expectEqual(@as(?u32, null), slots[0]);
+    try testing.expectEqual(@as(u32, 0), counts.get(.default));
+}

--- a/src/semantic/symbol.zig
+++ b/src/semantic/symbol.zig
@@ -242,6 +242,26 @@ pub const ConstValue = struct {
     }
 };
 
+/// Mangler slot namespace (esbuild `ast.SlotNamespace` 1:1).
+///
+/// 식별자는 namespace 별로 독립된 slot 공간을 가진다 — 같은 slot 번호라도
+/// namespace 가 다르면 충돌하지 않는다 (label `x:` 와 변수 `x` 는 별개 문법
+/// 위치). `must_not_be_renamed` 는 slot 을 받지 않는 sentinel (예약/외부/이미
+/// 1글자 등). ZNTC 는 현재 label/private 필드를 심볼로 모델링하지 않으므로
+/// 실제로는 `default` / `must_not_be_renamed` 만 등장한다 (RFC #3391 / #3392 —
+/// label·private 은 후속 PR 에서 심볼화 시 자연히 채워짐). 이 enum 을 semantic
+/// 에 두는 이유: Symbol 이 codegen 을 import 하면 레이어 역전 (mangler 가
+/// runtime_helper_names 를 공용 모듈로 분리한 것과 동일 원칙).
+pub const SlotNamespace = enum(u8) {
+    default = 0,
+    label = 1,
+    private_name = 2,
+    must_not_be_renamed = 3,
+
+    /// slot 카운터를 가지는 namespace 수 (`must_not_be_renamed` 은 sentinel 이라 제외).
+    pub const indexable_count = 3;
+};
+
 /// 심볼 하나의 데이터.
 /// symbols[symbol_id]로 접근.
 pub const Symbol = struct {
@@ -293,6 +313,21 @@ pub const Symbol = struct {
     /// 미지정 (원본 이름 유지). 소유권은 linker (`canonical_strings` ArrayList)
     /// — Symbol은 non-owning slice만 보유. linker가 살아있는 동안만 유효.
     canonical_name: []const u8 = "",
+
+    /// Mangler slot namespace (RFC #3391 / #3392 — nested-scope renamer port).
+    /// `assignNestedScopeSlots` (codegen/nested_slots.zig) 가 walk 중 계산해
+    /// 채운다. PR-1 시점엔 파이프라인 미연결이라 동작 무변경. 캐시 보유 vs
+    /// 매번 재계산(esbuild 는 `Symbol.SlotNamespace()` 메서드)의 트레이드오프
+    /// 는 PR-2 이름 발급 연결 시 확정한다.
+    slot_namespace: SlotNamespace = .default,
+
+    /// Nested-scope slot 번호. null = 미할당 (esbuild `ast.Index32{}` 의 invalid
+    /// 대응). top-level 심볼은 nested slot 을 받지 않으므로 walk 후 항상 null.
+    /// 형제 scope 끼리 같은 번호를 재사용하고 자식 scope 는 부모 카운트 *이후*
+    /// 부터 부여되어, closure-capture 된 outer 이름과 구성적으로 충돌 불가
+    /// (esbuild renamer.go 의 핵심 안전 불변식). PR-1: 필드만 추가 — 아직
+    /// mangler 가 소비하지 않음 (behavior 무변경).
+    nested_scope_slot: ?u32 = null,
 
     /// 이 심볼의 이름을 반환. 합성은 `synthetic_name`, 정규는 source Span에서.
     pub fn nameText(self: *const Symbol, source: []const u8) []const u8 {


### PR DESCRIPTION
## 무엇 / 왜

RFC #3391 (`docs/RFC_NESTED_SCOPE_RENAMER.md`) · 트래킹 이슈 #3392 의 **PR-1**.

미니파이 격차의 **유일·진짜 레버** = 현 mangler 의 flat per-module Phase B 를 esbuild `renamer.go` 의 재귀 nested-scope-slot walk 로 교체하는 것. 이 PR 은 그 첫 단계로 **slot 할당 인프라만** 추가하고 **파이프라인에 연결하지 않는다** → 번들 출력 byte-identical, behavior 완전 무변경.

## 변경

| 파일 | 내용 |
|---|---|
| `src/semantic/symbol.zig` | `SlotNamespace` enum + Symbol 에 `slot_namespace`/`nested_scope_slot` 2 필드 (기본값 → 무영향). enum 을 semantic 에 둔 이유 = `Symbol` 이 codegen 을 import 하면 레이어 역전 (mangler 의 `runtime_helper_names` 분리와 동일 원칙) |
| `src/codegen/nested_slots.zig` (신규) | esbuild `AssignNestedScopeSlots`/`assignNestedScopeSlotsHelper` **1:1 이식**. ZNTC parent-only scope tree → `buildChildrenList` 역산, `scope_maps` 로 멤버 순회 |
| `src/codegen/mangler.zig` | `shouldSkip`/`buildChildrenList`/`ChildrenList` 를 `pub` (단일 소스 재사용 — 동작 무변경, `pub` 만 추가) |
| `src/codegen/mod.zig` | nested_slots 모듈/테스트 등록 |

## 핵심 안전 불변식 (esbuild 이식)

- **형제 scope 는 같은 slot 재사용** (동시 live 불가) = 구성적 그래프 컬러링
- **자식 scope 는 부모 카운트 *이후*부터** → closure-capture 된 outer 이름과 **구성적으로 충돌 불가** (flat-mangle 이 못 주던 안전성, #2956 subtree-liveness 와 동치)
- **top-level 심볼은 nested slot 미부여** (호이스팅 `var` 보호 — 일시 마킹 후 원복)
- **`must_not_be_renamed` skip** (exported/import 등은 slot 소비 안 함)

## 테스트

esbuild fixture slot 동치 유닛테스트 6종 (위 4대 불변식 + 깊은 nesting + 빈입력). 전체 회귀 0 — **Debug + ReleaseFast 모두 5200 passed / 0 fail** (`feedback_release_only_bugs` 준수).

## /simplify 반영

3-에이전트 리뷰 후 수정: (1) `source` 파라미터 추가 — `nameText` 가 정규 심볼에 OOB/오분류되던 CRITICAL fix, (2) 불변 컨텍스트 `Ctx` 구조체로 파라미터 sprawl 해소 + 미사용 `scopes` 제거, (3) top-level mark/restore 중복 → `setModuleSymbolSlots` 통합, (4) 캐시 결정 주석 정정. pub→공유모듈 이동·sentinel 재설계·ArrayList scratch 는 세 에이전트 합의로 PR-2 연기 (PR-1 비차단).

## 다음 (RFC #3391 §6)

PR-2 = `AssignNamesByFrequency` slot 모델 + Phase A 통합 (flag off). PR-3 = flag on, 전수 smoke gate ON/OFF — 압축률 0.547→~0.43 미회수 시 즉시 종결 (measure-first 게이트).

Refs #3392 · RFC #3391

🤖 Generated with [Claude Code](https://claude.com/claude-code)