### PR TITLE
feat(mf): P1-1 연합 경계 모듈 식별·표시 + 안정 ID (#3383)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -89,11 +89,17 @@ pub const OutputExports = enum {
     }
 };
 
+/// Module Federation 번들 옵션 (#3318 P1-1). 정의는 `types.zig`
+/// (federation.zig ↔ bundler.zig circular import 회피, types 는 양쪽 공통).
+pub const MfBundleConfig = types.MfBundleConfig;
+
 pub const BundleOptions = struct {
     entry_points: []const []const u8,
     format: EmitOptions.Format = .esm,
     platform: Platform = .browser,
     external: []const []const u8 = &.{},
+    /// Module Federation (#3318 P1-1). null = 비-MF 빌드(영향 0).
+    mf: ?MfBundleConfig = null,
     minify_whitespace: bool = false,
     minify_identifiers: bool = false,
     minify_syntax: bool = false,
@@ -1048,6 +1054,18 @@ pub const Bundler = struct {
             } else {
                 try graph.build(self.options.entry_points);
             }
+        }
+
+        // Module Federation 연합 경계 식별 (#3318 P1-1). mf!=null 일 때만 —
+        // 비-MF 빌드 영향 0. 표시·안정 ID 만(분석); wrap_kind/출력 불변.
+        if (self.options.mf) |*mf| {
+            try @import("federation.zig").markBoundary(
+                &graph,
+                mf,
+                self.allocator,
+                self.options.entry_points,
+                self.options.preserve_modules_root,
+            );
         }
 
         if (graph.runtime_polyfill_roots.items.len > 0) {

--- a/src/bundler/federation.zig
+++ b/src/bundler/federation.zig
@@ -1,0 +1,189 @@
+//! Module Federation 연합 경계 식별 (#3318 P1-1).
+//!
+//! `mf.exposes` 타겟 ∪ `mf.shared` 패키지 ∪ shared 전방-의존 폐포를
+//! **연합 경계 모듈**로 표시(`Module.is_federation_boundary`)하고 안정
+//! ID(`module_id.zig`, relative-path)를 부여한다.
+//!
+//! **P1-1 은 분석·표시만** — 스코프 호이스팅 소거 제외 *enforcement*·
+//! container/manifest emit 은 P1-2+ 가 이 플래그/ID 를 소비. wrap_kind·
+//! entry_points·출력 불변(비-MF 빌드 영향 0 — caller 가 mf!=null 일 때만 호출).
+//!
+//! 위험 격리: 기존 스코프호이스팅/링커 결정 코드 미변경. graph build 직후
+//! ~ link 전 단일스레드 분석 패스(다른 build 패스와 동일 위치·동시성 모델).
+
+const std = @import("std");
+const types = @import("types.zig");
+const ModuleIndex = types.ModuleIndex;
+const module_id = @import("module_id.zig");
+const resolve_cache = @import("resolve_cache.zig");
+
+/// 경계 식별 + 표시 + 안정 ID 부여. `mf` 비면 호출 안 됨(caller gate).
+/// `entry_points`/`preserve_root` 는 `module_id` root 도출용.
+pub fn markBoundary(
+    graph: anytype,
+    mf: *const types.MfBundleConfig,
+    allocator: std.mem.Allocator,
+    entry_points: []const []const u8,
+    preserve_root: ?[]const u8,
+) !void {
+    const count = graph.moduleCount();
+    if (count == 0) return;
+
+    // module_id root: preserve-modules-root ?? entry 공통 조상 (P3-B 와 동일).
+    const root: ?[]const u8 = if (preserve_root) |r|
+        r
+    else
+        module_id.commonAncestorDir(allocator, entry_points) catch null;
+    defer if (preserve_root == null) if (root) |r| allocator.free(r);
+
+    // ── exposes: config 값(cwd 상대 가능)을 abs 로 정규화해 모듈과 매칭 ──
+    const cwd = std.fs.cwd().realpathAlloc(allocator, ".") catch null;
+    defer if (cwd) |c| allocator.free(c);
+    for (mf.exposes) |kv| {
+        const abs = resolveAbs(allocator, cwd, kv.value) catch continue;
+        defer allocator.free(abs);
+        var matched = false;
+        var i: usize = 0;
+        while (i < count) : (i += 1) {
+            const idx: ModuleIndex = @enumFromInt(@as(u32, @intCast(i)));
+            // moduleAtMut 직접 호출: 이 패스는 graph build 完~link 前 단일
+            // 스레드(파서 워커 race 무관) — bundler.zig store-transfer 와 동일
+            // 관례(accessors.zig 금지 주석은 병렬 워커 한정).
+            const m = graph.moduleAtMut(idx) orelse continue;
+            if (std.mem.eql(u8, m.path, abs)) {
+                try setBoundary(allocator, m, root);
+                matched = true;
+                break;
+            }
+        }
+        // 미해결 expose 는 P1-2+ enforcement 가 잘못된 결과를 내므로 조용히
+        // 넘기지 말고 진단(분석단계라 빌드 실패는 과함 — RBM/entry 와 동일 warn).
+        if (!matched)
+            std.log.warn("[mf] expose target not in module graph: {s} ({s})", .{ kv.key, kv.value });
+    }
+
+    // ── shared: `/node_modules/<pkg>/` 매칭 시드 → 전방-의존 폐포 DFS ──
+    if (mf.shared.len > 0) {
+        var seeds: std.ArrayListUnmanaged(ModuleIndex) = .empty;
+        defer seeds.deinit(allocator);
+        var i: usize = 0;
+        while (i < count) : (i += 1) {
+            const idx: ModuleIndex = @enumFromInt(@as(u32, @intCast(i)));
+            const m = graph.getModule(idx) orelse continue;
+            if (pkgOf(m.path)) |pkg| {
+                for (mf.shared) |s| {
+                    if (std.mem.eql(u8, s, pkg)) {
+                        try seeds.append(allocator, idx);
+                        break;
+                    }
+                }
+            }
+        }
+        try markClosure(graph, allocator, root, seeds.items);
+    }
+}
+
+/// 시드들의 전방-의존 폐포를 표시. **명시적 스택**(재귀 아님) — 깊은
+/// 모듈 체인 stack overflow 회피(`graph/cycles.zig` 와 동일 규율). visited
+/// 로 각 모듈 1회 — O(V+E), 메모리 O(V).
+fn markClosure(
+    graph: anytype,
+    allocator: std.mem.Allocator,
+    root: ?[]const u8,
+    seeds: []const ModuleIndex,
+) !void {
+    var visited = std.AutoHashMapUnmanaged(u32, void){};
+    defer visited.deinit(allocator);
+    var stack: std.ArrayListUnmanaged(ModuleIndex) = .empty;
+    defer stack.deinit(allocator);
+    try stack.appendSlice(allocator, seeds);
+    while (stack.pop()) |idx| {
+        const gop = try visited.getOrPut(allocator, @intFromEnum(idx));
+        if (gop.found_existing) continue;
+        const m = graph.moduleAtMut(idx) orelse continue;
+        try setBoundary(allocator, m, root);
+        try stack.appendSlice(allocator, m.dependencies.items);
+    }
+}
+
+fn setBoundary(allocator: std.mem.Allocator, m: anytype, root: ?[]const u8) !void {
+    if (m.is_federation_boundary) return; // 멱등 — id 재할당·중복 free 방지
+    m.is_federation_boundary = true;
+    m.federation_id = try module_id.moduleId(allocator, m.path, root);
+}
+
+/// cwd(또는 null) 기준 상대경로를 abs 로. realpath 실패 시 resolve 결과 사용.
+fn resolveAbs(allocator: std.mem.Allocator, cwd: ?[]const u8, value: []const u8) ![]const u8 {
+    if (std.fs.path.isAbsolute(value)) return allocator.dupe(u8, value);
+    const base = cwd orelse ".";
+    const joined = try std.fs.path.resolve(allocator, &.{ base, value });
+    defer allocator.free(joined);
+    return std.fs.cwd().realpathAlloc(allocator, joined) catch allocator.dupe(u8, joined);
+}
+
+/// path 의 최내곽 node_modules 패키지명(`@scope/pkg` 포함). scoped 분기·
+/// OS sep 처리는 `resolve_cache.findPackageDirPath`(단일 소스) 재사용 —
+/// 그것이 주는 패키지 *디렉터리* path 에서 이름 부분만 슬라이스.
+fn pkgOf(path: []const u8) ?[]const u8 {
+    const dir = resolve_cache.findPackageDirPath(path) orelse return null;
+    const nm = "node_modules" ++ std.fs.path.sep_str;
+    const at = std.mem.lastIndexOf(u8, dir, nm) orelse return null;
+    return dir[at + nm.len ..];
+}
+
+test "markBoundary: shared 시드 + 전방-의존 폐포 표시, 무관 모듈 미표시" {
+    const a = std.testing.allocator;
+    const StubMod = struct {
+        path: []const u8,
+        dependencies: std.ArrayList(ModuleIndex) = .empty,
+        is_federation_boundary: bool = false,
+        federation_id: ?[]const u8 = null,
+    };
+    // 0=app(entry, 비경계) 1=node_modules/react/index.js(shared seed)
+    // 2=node_modules/react/jsx.js(react 전방-의존, 폐포로 표시돼야)
+    var mods = [_]StubMod{
+        .{ .path = "/p/src/app.ts" },
+        .{ .path = "/p/node_modules/react/index.js" },
+        .{ .path = "/p/node_modules/react/jsx.js" },
+    };
+    try mods[1].dependencies.append(a, @enumFromInt(2)); // react → jsx
+    defer for (&mods) |*m| {
+        m.dependencies.deinit(a);
+        if (m.federation_id) |id| a.free(id);
+    };
+    const StubGraph = struct {
+        ms: []StubMod,
+        fn moduleCount(self: @This()) usize {
+            return self.ms.len;
+        }
+        fn getModule(self: @This(), idx: ModuleIndex) ?*const StubMod {
+            return &self.ms[@intFromEnum(idx)];
+        }
+        fn moduleAtMut(self: @This(), idx: ModuleIndex) ?*StubMod {
+            return &self.ms[@intFromEnum(idx)];
+        }
+    };
+    var g = StubGraph{ .ms = &mods };
+    const mf = types.MfBundleConfig{ .name = "app", .shared = &.{"react"} };
+    try markBoundary(&g, &mf, a, &.{"/p/src/app.ts"}, "/p");
+
+    try std.testing.expect(!mods[0].is_federation_boundary); // app 비경계
+    try std.testing.expect(mods[1].is_federation_boundary); // react seed
+    try std.testing.expect(mods[2].is_federation_boundary); // 전방-의존 폐포
+    try std.testing.expectEqualStrings("node_modules/react/index.js", mods[1].federation_id.?);
+    try std.testing.expect(mods[0].federation_id == null);
+}
+
+test "pkgOf: scoped/일반 패키지 추출" {
+    try std.testing.expectEqualStrings("react", pkgOf("/p/node_modules/react/index.js").?);
+    try std.testing.expectEqualStrings(
+        "@scope/pkg",
+        pkgOf("/p/node_modules/@scope/pkg/dist/x.js").?,
+    );
+    try std.testing.expect(pkgOf("/p/src/app.ts") == null);
+    // 중첩 node_modules → 가장 안쪽 패키지
+    try std.testing.expectEqualStrings(
+        "b",
+        pkgOf("/p/node_modules/a/node_modules/b/i.js").?,
+    );
+}

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -68,6 +68,7 @@ pub const ChunkKind = chunk.ChunkKind;
 pub const ChunkGraph = chunk.ChunkGraph;
 pub const Bundler = bundler_core.Bundler;
 pub const BundleOptions = bundler_core.BundleOptions;
+pub const MfBundleConfig = types.MfBundleConfig; // #3318 P1-1
 pub const OutputExports = bundler_core.OutputExports;
 pub const BundleResult = bundler_core.BundleResult;
 pub const RN_BOOL_PRESET = bundler_core.RN_BOOL_PRESET;

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -301,6 +301,15 @@ pub const Module = struct {
     /// esbuild의 entryPointKind과 동일 — 정렬 순서나 exec_index와 무관하게
     /// 엔트리를 100% 정확히 식별한다.
     is_entry_point: bool = false,
+    /// Module Federation 연합 경계 모듈 (#3318 P1-1). `mf.exposes` 타겟 ∪
+    /// `mf.shared` ∪ shared 전방-의존 폐포. P1-1 은 **표시·안정 ID 계산만**
+    /// (분석) — 스코프 호이스팅 소거 제외 *enforcement*·container/manifest
+    /// emit 은 P1-2+ 가 이 플래그/ID 를 소비. mf 미지정 시 항상 false →
+    /// 비-MF 빌드 영향 0(구성상 회귀 없음).
+    is_federation_boundary: bool = false,
+    /// 경계 모듈의 안정 ID(`module_id.zig`, relative-path). is_federation_
+    /// boundary=true 일 때만 set. graph allocator 소유. (#3318 P1-1)
+    federation_id: ?[]const u8 = null,
     /// DFS 후위 순서 = ESM 실행 순서 (D058, D076).
     /// maxInt = 미방문 (DFS에서 할당되지 않음).
     exec_index: u32,

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -39,6 +39,22 @@ pub const ModuleDevCode = struct {
 
 /// 모듈 그래프에서 모듈을 식별하는 인덱스.
 /// NodeIndex, SymbolId, ScopeId와 동일한 u32 enum 패턴.
+/// Module Federation 번들 옵션 (#3318 P1-1). zntc.config `mf` 블록의
+/// 해석본 — exposes/remotes 는 [{key,value}] 평탄화, shared 는 패키지명만
+/// (P1-1 은 경계 식별·표시·안정 ID 만 소비). emit/container 는 P1-2+.
+/// `types.zig` 에 둠 — federation.zig·bundler.zig 양쪽 공통(circular 회피).
+pub const MfBundleConfig = struct {
+    pub const KV = struct { key: []const u8, value: []const u8 };
+    name: ?[]const u8 = null,
+    /// `{ "./Widget": "./src/Widget.tsx" }` → [{"./Widget","./src/Widget.tsx"}]
+    exposes: []const KV = &.{},
+    /// `{ remoteA: "remoteA@url" }`
+    remotes: []const KV = &.{},
+    /// shared 패키지명 (`["react","react-dom"]`)
+    shared: []const []const u8 = &.{},
+    share_scope: []const u8 = "default",
+};
+
 pub const ModuleIndex = enum(u32) {
     none = std.math.maxInt(u32),
     _,

--- a/src/cli/options.zig
+++ b/src/cli/options.zig
@@ -85,6 +85,10 @@ pub const CliOptions = struct {
     /// `zntc.config.json` 의 `manualChunks` (record form: `[{name, patterns}]`) 매핑.
     /// CLI flag 없음 — config.json 만. function form 은 JS-only 라 NAPI 경유.
     manual_chunks_list: std.ArrayList(ManualChunkEntry) = .empty,
+    /// Module Federation (#3318 P1-1). zntc.config `mf` 해석본 — allocator
+    /// 소유(applyZntcConfigJson 에서 deep-dupe). null = 비-MF. P1-1 은
+    /// 경계 식별·표시 소비. CLI flag 없음(config 전용, #3382).
+    mf: ?lib.bundler.MfBundleConfig = null,
     /// --block-list=PATTERN (반복). Metro resolver.blockList 호환.
     /// JS regex source 스타일 문자열 (`\/ios\/`, `\.bak$` 등).
     block_list: std.ArrayList([]const u8) = .empty,
@@ -386,10 +390,62 @@ fn applyZntcConfigJson(opts: *CliOptions, allocator: std.mem.Allocator) !void {
     // Module Federation (#3318 P1-0): 구조 검증만. emit 은 P1-1+ 가 소비 —
     // 아직 CliOptions 에 저장 안 함(consumer 없음, arena 수명 deep-dupe 불요).
     // 검증 실패는 caller 가 `[zntc] zntc.config.json load failed: …` 로 표면화.
-    // ⚠️ 검증은 이 Zig CLI 의 zntc.config.json 경로 한정 — build()/NAPI
+    // ⚠️ 검증·해석은 이 Zig CLI 의 zntc.config.json 경로 한정 — build()/NAPI
     // (`packages/core/src/napi/options.zig`)는 아직 mf 키를 추출조차 안 함.
     // P1-1+ 에서 NAPI mf 추출 + validateMf 연결 필수(silent drift 주의).
-    if (dto.mf) |*mf| try lib.transpile.validateMf(mf);
+    if (dto.mf) |*mf| {
+        try lib.transpile.validateMf(mf);
+        // P1-1 소비자(federation.markBoundary) 용 해석본을 allocator(=CliOptions
+        // 수명) 으로 deep-dupe. dto 는 arena(이 함수 종료 시 해제) 라 borrow 불가.
+        opts.mf = try mfBundleFromDto(allocator, mf);
+    }
+}
+
+/// `MfConfigDto`(arena, record) → `MfBundleConfig`(CliOptions 수명, 평탄화).
+/// exposes/remotes record → []KV, shared record → 패키지명 []. 모든 문자열
+/// `allocator.dupe` (외부 mf list/main.zig 가 build 끝까지 참조).
+/// JSON record(`std.json.ArrayHashMap`)→`[]KV` deep-dupe. exposes/remotes
+/// 공용(DRY). 중간 OOM 시 이미 dup 한 항목+list 해제(errdefer).
+fn dupeKvMap(
+    allocator: std.mem.Allocator,
+    map: anytype,
+) ![]const lib.bundler.MfBundleConfig.KV {
+    const KV = lib.bundler.MfBundleConfig.KV;
+    const list = try allocator.alloc(KV, map.count());
+    var done: usize = 0;
+    errdefer {
+        for (list[0..done]) |kv| {
+            allocator.free(kv.key);
+            allocator.free(kv.value);
+        }
+        allocator.free(list);
+    }
+    var it = map.iterator();
+    while (it.next()) |kv| : (done += 1) list[done] = .{
+        .key = try allocator.dupe(u8, kv.key_ptr.*),
+        .value = try allocator.dupe(u8, kv.value_ptr.*),
+    };
+    return list;
+}
+
+fn mfBundleFromDto(
+    allocator: std.mem.Allocator,
+    dto: *const lib.transpile.MfConfigDto,
+) !lib.bundler.MfBundleConfig {
+    var out: lib.bundler.MfBundleConfig = .{};
+    if (dto.name) |n| out.name = try allocator.dupe(u8, n);
+    if (dto.shareScope) |s| out.share_scope = try allocator.dupe(u8, s);
+
+    if (dto.exposes) |e| out.exposes = try dupeKvMap(allocator, &e.map);
+    if (dto.remotes) |r| out.remotes = try dupeKvMap(allocator, &r.map);
+    if (dto.shared) |sh| {
+        var list = try allocator.alloc([]const u8, sh.map.count());
+        var it = sh.map.iterator();
+        var i: usize = 0;
+        while (it.next()) |kv| : (i += 1) list[i] = try allocator.dupe(u8, kv.key_ptr.*);
+        out.shared = list;
+    }
+    return out;
 }
 
 /// CLI 인자를 파싱하여 CliOptions를 반환한다.

--- a/src/main.zig
+++ b/src/main.zig
@@ -614,6 +614,7 @@ pub fn main() !void {
             .format = opts.bundle_format,
             .platform = opts.platform,
             .external = opts.external_list.items,
+            .mf = opts.mf, // Module Federation (#3318 P1-1). null=비-MF.
             .minify_whitespace = opts.minify_whitespace,
             .minify_identifiers = opts.minify_identifiers,
             .minify_syntax = opts.minify_syntax,


### PR DESCRIPTION
#3318 P1 (#3382 P1-0 의존). `mf.exposes` 타겟 / `mf.shared` 패키지 / shared 전방-의존 폐포를 `Module.is_federation_boundary` 로 표시 + `module_id.zig`(relative-path) 안정 ID 부여. **분석·표시만 — wrap_kind/entry_points/출력 불변**, emit·스코프호이스팅 소거 *enforcement* 는 P1-2+ 가 소비.

## 변경
- **`src/bundler/federation.zig`(신규)** `markBoundary`: graph build 完~link 前 **단일스레드 분석 패스**, `mf!=null` gate → 비-MF 빌드 영향 0(구성상 회귀 없음). exposes 경로 abs 정규화 후 모듈 매칭, shared `node_modules` 시드 → 전방-의존 폐포(명시 스택).
- `types.zig` `MfBundleConfig`(federation↔bundler circular 회피), `Module.{is_federation_boundary,federation_id}`, `BundleOptions.mf`, `cli/options.zig` `CliOptions.mf` + `mfBundleFromDto`(P1-0 record DTO deep-dupe), `main.zig` 배선 — P1-0 DTO 의 첫 consumer.

## /simplify 3-agent 반영
- **(블로킹) `dfsMark` 재귀 → `markClosure` 명시 스택** — `graph/cycles.zig` 가 명문화한 규율(깊은 의존체인 stack overflow 회피)
- `pkgOf` → `resolve_cache.findPackageDirPath` 재사용 — scoped/OS-sep 패키지명 파싱 단일 소스화(중복 3곳 통합)
- 미해결 expose → `std.log.warn` 진단(silent 함정 제거)
- `dupeKvMap` 헬퍼 추출 + `errdefer`(exposes/remotes DRY, OOM 부분누수)
- `moduleAtMut` 직접호출 근거 주석(단일스레드 post-build, store-transfer 선례 — accessor 금지 주석은 병렬 워커 한정)
- (스킵·근거: `CliOptions.deinit` mf 미해제는 banner_js 등 기존 1회 dup 스칼라와 동일 패턴 / nested defer free 정합 / accessor 거짓양성)

## 검증
`zig build test` 비-환경 실패 **0**(rn_codegen 은 선재 환경노이즈 — clean 트리에서 동일 재현, 본 변경 무관). federation `markBoundary`/`pkgOf` 유닛 통과, MF 통합 3/0, app-builder 14/0, react smoke ✅. 회귀 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)