### PR TITLE
feat(mf): shared 글로벌 seam 자동 파생 — boundary shared 의존을 글로벌-파라미터로 (#3384)

### DIFF
--- a/src/cli/options.zig
+++ b/src/cli/options.zig
@@ -398,6 +398,69 @@ fn applyZntcConfigJson(opts: *CliOptions, allocator: std.mem.Allocator) !void {
         // P1-1 소비자(federation.markBoundary) 용 해석본을 allocator(=CliOptions
         // 수명) 으로 deep-dupe. dto 는 arena(이 함수 종료 시 해제) 라 borrow 불가.
         opts.mf = try mfBundleFromDto(allocator, mf);
+        // P1-2 (#3384): shared 글로벌 seam 자동 파생. mf.shared 패키지를
+        // external(번들 제외 — shared 는 shareScope 에서 옴) + GlobalEntry
+        // (IIFE/UMD/AMD 글로벌-파라미터 seam) 로 합친다. 스파이크 S2 가
+        // `--external pkg --globals pkg=__mf_shared_pkg` 로 검증한 기계를
+        // 그대로 재사용 — bundler/emitter/codegen 무변경.
+        if (opts.mf) |mfb| try applyMfSharedSeam(allocator, opts, mfb.shared);
+    }
+}
+
+/// mf.shared 패키지명 → 결정적 container-소유 글로벌 식별자.
+/// 비-식별자(`@ / - .`) → `_`. react→`__mf_shared_react`,
+/// react-dom→`__mf_shared_react_dom`, @scope/pkg→`__mf_shared__scope_pkg`.
+fn mfSharedGlobalName(allocator: std.mem.Allocator, pkg: []const u8) ![]const u8 {
+    const prefix = "__mf_shared_";
+    var buf = try allocator.alloc(u8, prefix.len + pkg.len);
+    @memcpy(buf[0..prefix.len], prefix);
+    for (pkg, 0..) |c, i| buf[prefix.len + i] = switch (c) {
+        '@', '/', '-', '.' => '_',
+        else => c,
+    };
+    return buf;
+}
+
+/// mf.shared → external_list + globals_list 파생.
+///
+/// **호출 순서 불변조건**: applyZntcConfigJson(config defaults)은 CLI arg
+/// 루프(`--globals`/`--external` 파싱)보다 *먼저* 돈다. 따라서 여기서 append
+/// 한 mf-파생 GlobalEntry 가 사용자 `--globals` 보다 list **앞**에 온다 →
+/// `GlobalEntry.lookup`(first-match) 이 mf-파생을 채택. shared 의 글로벌명은
+/// container 계약이라 mf-파생이 authoritative(RFC §8.1 #1) — 이 순서가 그
+/// 의미를 자연히 만든다(별도 prepend 불요).
+///
+/// 메모리: `pkg` 는 `opts.mf`(CliOptions 수명, mfBundleFromDto 가 dupe) 를
+/// borrow — specifier/external 은 재-dupe 안 함(parseGlobalsArg 의 borrow
+/// 모델과 일관). `global_name` 만 신규 alloc(프로세스 1회 수명; deinit
+/// container-only 미해제는 external_list config 경로(#2105)와 동일 기성
+/// 패턴 — 신규 회귀 아님).
+fn applyMfSharedSeam(
+    allocator: std.mem.Allocator,
+    opts: *CliOptions,
+    shared: []const []const u8,
+) !void {
+    for (shared) |pkg| {
+        try opts.external_list.append(allocator, pkg); // borrow (opts.mf 소유)
+        try opts.globals_list.append(allocator, .{
+            .specifier = pkg, // borrow
+            .global_name = try mfSharedGlobalName(allocator, pkg),
+        });
+    }
+}
+
+test "mfSharedGlobalName: 결정적 식별자 변환" {
+    const a = std.testing.allocator;
+    const cases = [_]struct { in: []const u8, want: []const u8 }{
+        .{ .in = "react", .want = "__mf_shared_react" },
+        .{ .in = "react-dom", .want = "__mf_shared_react_dom" },
+        .{ .in = "@scope/pkg", .want = "__mf_shared__scope_pkg" },
+        .{ .in = "lodash.merge", .want = "__mf_shared_lodash_merge" },
+    };
+    for (cases) |c| {
+        const got = try mfSharedGlobalName(a, c.in);
+        defer a.free(got);
+        try std.testing.expectEqualStrings(c.want, got);
     }
 }
 

--- a/tests/integration/tests/zntc-config-bundler.test.ts
+++ b/tests/integration/tests/zntc-config-bundler.test.ts
@@ -360,4 +360,28 @@ describe('Zig CLI: zntc.config.json bundler-only 옵션 (#2105)', () => {
     expect(r.exitCode).toBe(0);
     expect(r.stderr).not.toContain('load failed');
   });
+
+  // P1-2 (#3384): mf.shared → external + 글로벌-파라미터 seam 자동 emit.
+  // --external/--globals 플래그 없이 config 만으로 스파이크 S2 메커니즘.
+  test('mf.shared: IIFE 글로벌 seam 자동 emit + shared 비번들', async () => {
+    const r = await runConfigBundle({
+      files: {
+        'index.ts': `import { useState } from "react";\nexport function App() { return useState(0); }`,
+        'zntc.config.json': JSON.stringify({
+          mf: { name: 'app', shared: { react: { singleton: true } } },
+        }),
+      },
+      args: ['--format=iife', '--global-name=__app'],
+    });
+    cleanup = r.cleanup;
+
+    expect(r.exitCode).toBe(0);
+    const out = readFileSync(r.outFile!, 'utf8');
+    // container-소유 글로벌 파라미터 seam (P1-3 가 shareScope→이 글로벌 주입)
+    expect(out).toContain('((__mf_shared_react) => {');
+    expect(out).toContain(')(__mf_shared_react);');
+    expect(out).toContain('__mf_shared_react.useState');
+    // react 는 번들에 인라인되지 않음(external — shareScope 에서 옴)
+    expect(out).not.toMatch(/react\/cjs|node_modules[\\/]react/);
+  });
 });


### PR DESCRIPTION
## 무엇 (#3384, MF epic P1-2)

`mf.shared` 패키지를 **external(번들 제외)** + **글로벌-파라미터 seam(GlobalEntry)** 으로 `zntc.config.json` 만으로 자동 파생합니다. 사용자가 `--external react --globals react=__mf_shared_react` 를 손으로 줄 필요가 없어집니다.

shared 는 host 의 `shareScope` 에서 주입되므로 번들에 인라인하면 안 되고(싱글톤 깨짐), container 가 글로벌명을 소유해야 합니다(RFC §8.1 #1).

## 어떻게

웹 스파이크 S2 가 검증한 기계(`--external pkg` + `--globals pkg=__mf_shared_pkg` → IIFE 글로벌-파라미터)를 **그대로 재사용** — bundler/emitter/codegen **무변경**, config-assembly(`src/cli/options.zig`)에서만 파생.

- **`mfSharedGlobalName`**: `pkg → __mf_shared_<sanitized>` (비식별자→`_`, 소문자/scope 보존). 단사·결정적이라 P1-3 가 `shareScope` → 이 글로벌을 정확히 주입 가능. UMD/AMD 의 `specifierToParamName`(PascalCase·scope제거, 비단사)과 출력 도메인이 달라 **별도 함수가 옳음**(재사용 시 글로벌 키 충돌).
- **`applyMfSharedSeam`**: 호출 순서 불변조건(`applyZntcConfigJson` = config defaults 가 CLI arg 루프보다 **먼저** 돔)으로, mf-파생 GlobalEntry 가 사용자 `--globals` 보다 list 앞에 와 `GlobalEntry.lookup`(first-match)이 mf-파생을 자연히 채택 → container 계약 authoritative. 별도 prepend 불요.
- 메모리: `pkg` 는 `opts.mf`(CliOptions 수명, mfBundleFromDto 가 dupe) **borrow** — specifier/external 재-dupe 안 함(`parseGlobalsArg` borrow 모델과 일관). `global_name` 만 신규 alloc(프로세스 1회 수명; external_list config 경로 #2105 와 동일 기성 패턴, 신규 회귀 아님).

## 검증

- 통합 테스트 신규: `zntc.config.json {"mf":{"name":"app","shared":{"react":{"singleton":true}}}}` + `--format=iife`(플래그 0) → `var __app = ((__mf_shared_react) => { ... })(__mf_shared_react);`, react 비인라인 단언.
- 유닛: `mfSharedGlobalName` 결정적 변환(react→`__mf_shared_react`, @scope/pkg→`__mf_shared__scope_pkg`).
- 회귀 0: `zig build test`(비-환경 실패 0) / MF 통합 4·0 / 번들·청크·react 스모크 196·0.

## /simplify

3-에이전트 리뷰 반영: ① `toOwnedSlice` prepend 왕복은 호출 순서상 globals_list 가 항상 빈 list → **죽은 복잡도 제거**(단순 append). ② 실동작(mf-win)과 정반대였던 주석 교정 + 호출 순서 불변조건 명문화. ③ `pkg` borrow 전환으로 globals_list 신규 owned-string 누수 클래스 제거(parseGlobalsArg borrow 모델과 일관).

🤖 Generated with [Claude Code](https://claude.com/claude-code)