### PR TITLE
feat(mf): webpack-style container emit (remoteEntry) — init/get + 실 MF2 runtime interop (#3385)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -668,6 +668,7 @@
         "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
         "@emotion/utils": "^1.4.2",
         "@emotion/weak-memoize": "^0.4.0",
+        "@module-federation/runtime": "2.4.0",
         "@swc/cli": "^0.8.1",
         "@swc/core": "^1.15.24",
         "@types/bun": "latest",
@@ -997,7 +998,7 @@
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
-    "@babel/standalone": ["@babel/standalone@7.29.2", "", {}, "sha512-VSuvywmVRS8efooKrvJzs6BlVSxRvAdLeGrAKUrWoBx1fFBSeE/oBpUZCQ5BcprLyXy04W8skzz7JT8GqlNRJg=="],
+    "@babel/standalone": ["@babel/standalone@7.29.4", "", {}, "sha512-QuPlodN3HBcX/HcKRz0fkpr8hmqhY+OKwX89h/vBVKuSat5ohvZw4XGNwfF1LtwScmp5ILBAO7puXwJDcMEtJQ=="],
 
     "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
 
@@ -1569,15 +1570,15 @@
 
     "@microsoft/signalr": ["@microsoft/signalr@8.0.17", "", { "dependencies": { "abort-controller": "^3.0.0", "eventsource": "^2.0.2", "fetch-cookie": "^2.0.3", "node-fetch": "^2.6.7", "ws": "^7.5.10" } }, "sha512-5pM6xPtKZNJLO0Tq5nQasVyPFwi/WBY3QB5uc/v3dIPTpS1JXQbaXAQAPxFoQ5rTBFE094w8bbqkp17F9ReQvA=="],
 
-    "@module-federation/error-codes": ["@module-federation/error-codes@0.22.0", "", {}, "sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug=="],
+    "@module-federation/error-codes": ["@module-federation/error-codes@2.4.0", "", {}, "sha512-ktCZtwOoiKR1URJyBt223OsOFAUvc13rICYif55mt7+DomtELlh5FicnEz6mPLBUwmNM9vyBMvkxOdp+fQ5oUg=="],
 
-    "@module-federation/runtime": ["@module-federation/runtime@0.22.0", "", { "dependencies": { "@module-federation/error-codes": "0.22.0", "@module-federation/runtime-core": "0.22.0", "@module-federation/sdk": "0.22.0" } }, "sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA=="],
+    "@module-federation/runtime": ["@module-federation/runtime@2.4.0", "", { "dependencies": { "@module-federation/error-codes": "2.4.0", "@module-federation/runtime-core": "2.4.0", "@module-federation/sdk": "2.4.0" } }, "sha512-IrLAMwUuteRgFlEkg9jrn4bk8uC897FnXvfNmkKD8/qIoNtSd+32e5ouQn+PEYbX/RjRUB1TYveY6rYHpTPkyg=="],
 
-    "@module-federation/runtime-core": ["@module-federation/runtime-core@0.22.0", "", { "dependencies": { "@module-federation/error-codes": "0.22.0", "@module-federation/sdk": "0.22.0" } }, "sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA=="],
+    "@module-federation/runtime-core": ["@module-federation/runtime-core@2.4.0", "", { "dependencies": { "@module-federation/error-codes": "2.4.0", "@module-federation/sdk": "2.4.0" } }, "sha512-0S8fDw28DXDW17lTQwq5vfJWe2lG0Lw3+w4vk3DVVImLwXXay+OGxLDxzWUfypWcMznfpnoAnFUMO3PtuXziuA=="],
 
     "@module-federation/runtime-tools": ["@module-federation/runtime-tools@0.22.0", "", { "dependencies": { "@module-federation/runtime": "0.22.0", "@module-federation/webpack-bundler-runtime": "0.22.0" } }, "sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA=="],
 
-    "@module-federation/sdk": ["@module-federation/sdk@0.22.0", "", {}, "sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g=="],
+    "@module-federation/sdk": ["@module-federation/sdk@2.4.0", "", { "peerDependencies": { "node-fetch": "^2.7.0 || ^3.3.2" }, "optionalPeers": ["node-fetch"] }, "sha512-eZDdF5B69W9npuka0VL24FY7XDM+YAwwfkscSeWOSqv4/8Hm0xmcmSurlP6NIOrwbeogerRCtEcnx/TFXYjoow=="],
 
     "@module-federation/webpack-bundler-runtime": ["@module-federation/webpack-bundler-runtime@0.22.0", "", { "dependencies": { "@module-federation/runtime": "0.22.0", "@module-federation/sdk": "0.22.0" } }, "sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA=="],
 
@@ -2501,7 +2502,7 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
-    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
@@ -3307,7 +3308,7 @@
 
     "commoner": ["commoner@0.10.8", "", { "dependencies": { "commander": "^2.5.0", "detective": "^4.3.1", "glob": "^5.0.15", "graceful-fs": "^4.1.2", "iconv-lite": "^0.4.5", "mkdirp": "^0.5.0", "private": "^0.1.6", "q": "^1.1.2", "recast": "^0.11.17" }, "bin": { "commonize": "./bin/commonize" } }, "sha512-3/qHkNMM6o/KGXHITA14y78PcfmXh4+AOCJpSoF73h4VY1JpdGv3CHMS5+JW6SwLhfJt4RhNmLAa7+RRX/62EQ=="],
 
-    "compat-table": ["compat-table@github:kangax/compat-table#8f4179f", { "dependencies": { "@babel/standalone": "latest", "chalk": "^1.1.3", "cheerio": "^0.20.0", "core-js-bundle": "^3.0.0", "es5-shim": "latest", "es6-shim": "latest", "es6-transpiler": "latest", "es7-shim": "latest", "esdown": "latest", "espree": "latest", "esprima": "latest", "fast-levenshtein": "^3.0.0", "google-closure-compiler-js": "^20170521.0.0", "jshint": "latest", "jstransform": "latest", "lodash.pickby": "^4.6.0", "object.assign": "^4.0.4", "regenerator-runtime": "^0.13.2", "traceur": "latest", "typescript": "latest", "yargs": "^16.1.0" } }, "compat-table-compat-table-8f4179f", "sha512-Fbgib6nbtRVaILlMt8y/67/zadHBwWHqlUjBSOvr5JPl1x34+eAd33SGYH7E3T0Sxx1BCBXBCaiG3nh8+97Yag=="],
+    "compat-table": ["compat-table@github:kangax/compat-table#1bcd416", { "dependencies": { "@babel/standalone": "latest", "chalk": "^1.1.3", "cheerio": "^0.20.0", "core-js-bundle": "^3.0.0", "es5-shim": "latest", "es6-shim": "latest", "es6-transpiler": "latest", "es7-shim": "latest", "esdown": "latest", "espree": "latest", "esprima": "latest", "fast-levenshtein": "^3.0.0", "google-closure-compiler-js": "^20170521.0.0", "jshint": "latest", "jstransform": "latest", "lodash.pickby": "^4.6.0", "object.assign": "^4.0.4", "regenerator-runtime": "^0.13.2", "traceur": "latest", "typescript": "latest", "yargs": "^16.1.0" } }, "compat-table-compat-table-1bcd416", "sha512-jyO7KiYLSFmnLT3jnbkctsvWfeqCf2nuPMtcRh7GrBDKmX+FdRLJcGb+8Wgf3dWxtMtNd9NT2RbyiTi8sziRpA=="],
 
     "component-emitter": ["component-emitter@1.3.1", "", {}, "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ=="],
 
@@ -6533,6 +6534,12 @@
 
     "@mdx-js/mdx/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
+    "@module-federation/runtime-tools/@module-federation/runtime": ["@module-federation/runtime@0.22.0", "", { "dependencies": { "@module-federation/error-codes": "0.22.0", "@module-federation/runtime-core": "0.22.0", "@module-federation/sdk": "0.22.0" } }, "sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA=="],
+
+    "@module-federation/webpack-bundler-runtime/@module-federation/runtime": ["@module-federation/runtime@0.22.0", "", { "dependencies": { "@module-federation/error-codes": "0.22.0", "@module-federation/runtime-core": "0.22.0", "@module-federation/sdk": "0.22.0" } }, "sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA=="],
+
+    "@module-federation/webpack-bundler-runtime/@module-federation/sdk": ["@module-federation/sdk@0.22.0", "", {}, "sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g=="],
+
     "@napi-rs/wasm-runtime/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 
     "@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
@@ -6693,7 +6700,7 @@
 
     "@tailwindcss/vite/tailwindcss": ["tailwindcss@4.2.4", "", {}, "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA=="],
 
-    "@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "@types/sax/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
@@ -7708,6 +7715,16 @@
     "@jest/types/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "@manypkg/find-root/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
+    "@module-federation/runtime-tools/@module-federation/runtime/@module-federation/error-codes": ["@module-federation/error-codes@0.22.0", "", {}, "sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug=="],
+
+    "@module-federation/runtime-tools/@module-federation/runtime/@module-federation/runtime-core": ["@module-federation/runtime-core@0.22.0", "", { "dependencies": { "@module-federation/error-codes": "0.22.0", "@module-federation/sdk": "0.22.0" } }, "sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA=="],
+
+    "@module-federation/runtime-tools/@module-federation/runtime/@module-federation/sdk": ["@module-federation/sdk@0.22.0", "", {}, "sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g=="],
+
+    "@module-federation/webpack-bundler-runtime/@module-federation/runtime/@module-federation/error-codes": ["@module-federation/error-codes@0.22.0", "", {}, "sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug=="],
+
+    "@module-federation/webpack-bundler-runtime/@module-federation/runtime/@module-federation/runtime-core": ["@module-federation/runtime-core@0.22.0", "", { "dependencies": { "@module-federation/error-codes": "0.22.0", "@module-federation/sdk": "0.22.0" } }, "sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA=="],
 
     "@napi-rs/wasm-runtime/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
 

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1051,6 +1051,15 @@ pub const Bundler = struct {
                     reparsed_paths_out = list;
                 }
                 self.allocator.free(inc_result.reparsed_indices);
+            } else if (if (self.options.mf) |*mf| mf.exposes.len > 0 else false) {
+                // P1-3: exposes 있는 remote → exposes 를 그래프 루트에 합류
+                // (독립 루트). chunk gen entry_points 는 불변(exposes 는
+                // 동적 lazy 청크로만). host(exposes 없음)는 경로 불변.
+                const fed = @import("federation.zig");
+                const mf = &self.options.mf.?;
+                const be = try fed.entryWithExposes(self.allocator, mf, self.options.entry_points);
+                defer fed.freeStrList(self.allocator, be);
+                try graph.build(be);
             } else {
                 try graph.build(self.options.entry_points);
             }
@@ -1458,6 +1467,12 @@ pub const Bundler = struct {
                 }
                 self.allocator.free(outs);
             };
+
+            // P1-3 (#3385): MF container emit — entry 청크 부트스트랩을
+            // webpack-style container(init/get, globalName 대입)로 후처리
+            // wrap. 게이트는 markBoundary(graph.build 후)와 동일 관례.
+            if (self.options.mf) |*mf|
+                try @import("federation_emit.zig").wrapContainer(self.allocator, outputs.?, mf, &graph);
 
             // emitChunks 가 href 를 청크 내용으로 복사 완료 → 이제 plan 의
             // path/contents 소유권을 OutputFile 로 이전(plan 컨테이너만 해제).

--- a/src/bundler/chunk.zig
+++ b/src/bundler/chunk.zig
@@ -432,6 +432,29 @@ pub fn mergeSmallChunks(
     }
 }
 
+/// 모듈 `idx` 를 동적(lazy) entry 로 등록 — external 제외, `dynamic_seen`
+/// 멱등, 이미 user-entry(non-dynamic)면 skip. Phase 1b 동적-import 블록과
+/// P1-3 (#3385) federation-expose 블록이 **공유**(dedup/append 규칙 단일
+/// 소스 — 한쪽만 바뀌어 규칙 드리프트 방지).
+fn addDynamicEntry(
+    allocator: std.mem.Allocator,
+    entries: *std.ArrayList(EntryInfo),
+    dynamic_seen: *std.AutoHashMap(u32, void),
+    graph: *const ModuleGraph,
+    idx: ModuleIndex,
+) !void {
+    if (graph.getModule(idx)) |m| {
+        if (m.is_external) return; // external phantom 은 async chunk 불요(번들 외부)
+    }
+    const di = @intFromEnum(idx);
+    const gop = try dynamic_seen.getOrPut(di);
+    if (gop.found_existing) return;
+    for (entries.items) |e| {
+        if (@intFromEnum(e.module_idx) == di and !e.is_dynamic) return; // 이미 user entry
+    }
+    try entries.append(allocator, .{ .module_idx = idx, .is_dynamic = true });
+}
+
 pub fn generateChunks(
     allocator: std.mem.Allocator,
     graph: *const ModuleGraph,
@@ -480,30 +503,24 @@ pub fn generateChunks(
     if (!inline_dynamic_imports) {
         var it = graph.modulesIterator();
         while (it.next()) |m| {
-            for (m.dynamic_imports.items) |dyn_idx| {
-                const di = @intFromEnum(dyn_idx);
-                // External phantom 이 dyn-imported 면 async chunk 만들 필요 없음 (번들 외부)
-                if (graph.getModule(dyn_idx)) |dyn_mod| {
-                    if (dyn_mod.is_external) continue;
-                }
-                const gop = try dynamic_seen.getOrPut(di);
-                if (!gop.found_existing) {
-                    // 이미 유저 엔트리로 등록된 모듈인지 확인
-                    var is_user_entry = false;
-                    for (entries.items) |e| {
-                        if (@intFromEnum(e.module_idx) == di and !e.is_dynamic) {
-                            is_user_entry = true;
-                            break;
-                        }
-                    }
-                    if (!is_user_entry) {
-                        try entries.append(allocator, .{
-                            .module_idx = dyn_idx,
-                            .is_dynamic = true,
-                        });
-                    }
-                }
-            }
+            for (m.dynamic_imports.items) |dyn_idx|
+                try addDynamicEntry(allocator, &entries, &dynamic_seen, graph, dyn_idx);
+        }
+    }
+
+    // P1-3 (#3385): MF expose 타깃 → 동적-import 타깃과 동일한 lazy 청크.
+    // entry 모듈 reg_id = module_id.moduleId(path, root) = federation_id 가
+    // 되어 container.get 이 `__zntc_load_chunk().then(()=>__zntc_require(id))`
+    // (동적 wrapper) 를 그대로 재사용. inline_dynamic_imports 와 무관 —
+    // 연합 경계는 항상 분리(아니면 container 가 expose 에 도달 불가).
+    // dedup/append 은 addDynamicEntry 공유(위 동적 블록과 동일 규칙).
+    {
+        var mi: usize = 0;
+        while (mi < module_count) : (mi += 1) {
+            const fidx = ModuleIndex.fromUsize(mi);
+            const fm = graph.getModule(fidx) orelse continue;
+            if (!fm.is_federation_expose) continue;
+            try addDynamicEntry(allocator, &entries, &dynamic_seen, graph, fidx);
         }
     }
 

--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -240,6 +240,8 @@ pub fn emitChunks(
                 try rt.appendZntcResolveBrowser(&chunk_output, allocator, min);
             }
             // self-register factory prefix (모든 청크). 본문·exports 가 안에.
+            // ⚠ federation_emit.zig(P1-3)가 `({"<reg_id>"` 부분문자열로 expose
+            // 청크를 식별 — 이 prefix 형태 변경 시 동반 수정 필요.
             try chunk_output.appendSlice(allocator, "(function(g){");
             try chunk_output.appendSlice(allocator, rt.ZNTC_REGISTER_INSTALL);
             try chunk_output.appendSlice(allocator, "({\"");
@@ -792,6 +794,9 @@ pub fn emitChunks(
             try chunk_output.appendSlice(allocator, if (min) ";" else ";\n");
             if (chunk_is_user_entry) {
                 // entry 모듈은 정적 dep 들 뒤에 평가 → bootstrap 으로 실행 개시.
+                // ⚠ federation_emit.bootstrapSpan(P1-3)이 아래 두 형태(`return
+                // globalThis.__zntc_require("` / `[var <gn> [ ]=[ ]]globalThis.
+                // __zntc_require("`)에 강결합 — 변경 시 동반 수정 필요.
                 const umd_amd = options.format == .umd or options.format == .amd;
                 if (umd_amd) {
                     // UMD/AMD: factory() 반환값 = entry exports. 보편 wrapper 가

--- a/src/bundler/federation.zig
+++ b/src/bundler/federation.zig
@@ -52,6 +52,7 @@ pub fn markBoundary(
             const m = graph.moduleAtMut(idx) orelse continue;
             if (std.mem.eql(u8, m.path, abs)) {
                 try setBoundary(allocator, m, root);
+                m.is_federation_expose = true; // P1-3: expose→자기 lazy 청크
                 matched = true;
                 break;
             }
@@ -112,8 +113,49 @@ fn setBoundary(allocator: std.mem.Allocator, m: anytype, root: ?[]const u8) !voi
     m.federation_id = try module_id.moduleId(allocator, m.path, root);
 }
 
+/// graph.build 루트 = user entry ∪ exposes. P1-3: exposes 는 user entry
+/// 에서 도달 안 될 수 있는 **독립 루트**(webpack 동일) — 그래프에 없으면
+/// markBoundary 가 매칭 실패. 반환 slice 의 모든 원소 allocator-dup(소유
+/// 명확) → `freeStrList` 로 해제. chunk gen 의 entry_points 는 불변(exposes
+/// 는 is_federation_expose → 동적 lazy 청크, user-entry 아님).
+pub fn entryWithExposes(
+    allocator: std.mem.Allocator,
+    mf: *const types.MfBundleConfig,
+    entries: []const []const u8,
+) ![][]const u8 {
+    const cwd = std.fs.cwd().realpathAlloc(allocator, ".") catch null;
+    defer if (cwd) |c| allocator.free(c);
+    var list: std.ArrayListUnmanaged([]const u8) = .empty;
+    errdefer {
+        for (list.items) |s| allocator.free(s);
+        list.deinit(allocator);
+    }
+    for (entries) |e| try list.append(allocator, try allocator.dupe(u8, e));
+    for (mf.exposes) |kv| {
+        const abs = resolveAbs(allocator, cwd, kv.value) catch continue;
+        var seen = false;
+        for (list.items) |s| {
+            if (std.mem.eql(u8, s, abs)) {
+                seen = true;
+                break;
+            }
+        }
+        if (seen) {
+            allocator.free(abs);
+            continue;
+        }
+        try list.append(allocator, abs);
+    }
+    return list.toOwnedSlice(allocator);
+}
+
+pub fn freeStrList(allocator: std.mem.Allocator, list: [][]const u8) void {
+    for (list) |s| allocator.free(s);
+    allocator.free(list);
+}
+
 /// cwd(또는 null) 기준 상대경로를 abs 로. realpath 실패 시 resolve 결과 사용.
-fn resolveAbs(allocator: std.mem.Allocator, cwd: ?[]const u8, value: []const u8) ![]const u8 {
+pub fn resolveAbs(allocator: std.mem.Allocator, cwd: ?[]const u8, value: []const u8) ![]const u8 {
     if (std.fs.path.isAbsolute(value)) return allocator.dupe(u8, value);
     const base = cwd orelse ".";
     const joined = try std.fs.path.resolve(allocator, &.{ base, value });
@@ -138,6 +180,7 @@ test "markBoundary: shared 시드 + 전방-의존 폐포 표시, 무관 모듈 �
         dependencies: std.ArrayList(ModuleIndex) = .empty,
         is_federation_boundary: bool = false,
         federation_id: ?[]const u8 = null,
+        is_federation_expose: bool = false, // P1-3 — Module 미러
     };
     // 0=app(entry, 비경계) 1=node_modules/react/index.js(shared seed)
     // 2=node_modules/react/jsx.js(react 전방-의존, 폐포로 표시돼야)

--- a/src/bundler/federation_emit.zig
+++ b/src/bundler/federation_emit.zig
@@ -1,0 +1,191 @@
+//! P1-3 (#3385): webpack-style container emit (remoteEntry).
+//!
+//! emitChunks 산출 후처리 — entry(remoteEntry) 청크의 eager bootstrap
+//! `[var X = ]globalThis.__zntc_require("<id>");` 을 container 객체로 치환.
+//! container = `{ get(expose):Promise<factory>, init(shareScope,initScope) }`,
+//! `g.<name>` 에 대입(globalName 소유 = container).
+//!
+//! exposed 모듈은 P1-3 `chunk.zig` 가 동적-import 타깃과 동일하게 자기 lazy
+//! 청크로 분리했으므로(reg_id = federation_id), get 은 동적-import wrapper
+//! `__zntc_load_chunk(file).then(()=>__zntc_require(fed_id))` 를 그대로 emit
+//! — exposed 번들 eval 은 get() 까지 지연(reg_split self-register 가 lazy
+//! 보장). init-before-get 은 `__zntc_mf_inited` 가드 + MF2 런타임 계약
+//! (RUNTIME-009)에 위임.
+//!
+//! 비-목표: init 의 실제 shared 글로벌 채움·shareScopeMap(P1-4), 별도
+//! mf-manifest.json/remoteEntry.js 파일 에미터(P1-5), host remotes 소비(P1-6).
+const std = @import("std");
+const types = @import("types.zig");
+const federation = @import("federation.zig");
+const rt = @import("runtime_helpers.zig");
+const emitter = @import("emitter.zig");
+
+/// 부트스트랩 호출(=entry 청크 식별 앵커). cross-chunk/동적 wrapper 의
+/// `__zntc_require("` 와 달리 `globalThis.` 접두가 붙는 건 부트스트랩뿐
+/// (chunks.zig:809) → 유일 식별.
+const BOOTSTRAP_ANCHOR = "globalThis.__zntc_require(\"";
+
+const MfEmitError = error{RemoteEntryAnchorMissing};
+
+fn isIdentChar(c: u8) bool {
+    return c == '_' or c == '$' or std.ascii.isAlphanumeric(c);
+}
+
+/// `mf.name` 이 유효 JS 식별자인가(첫 글자 비-숫자).
+fn isJsIdent(name: []const u8) bool {
+    if (name.len == 0) return false;
+    if (std.ascii.isDigit(name[0])) return false;
+    for (name) |c| if (!isIdentChar(c)) return false;
+    return true;
+}
+
+/// graph 에서 expose value(abs) 와 path 가 일치하는 모듈의 federation_id
+/// (graph allocator 소유 — wrap 시점 graph 생존, borrow).
+fn exposeFedId(graph: anytype, abs: []const u8) ?[]const u8 {
+    const count = graph.moduleCount();
+    var i: usize = 0;
+    while (i < count) : (i += 1) {
+        const idx: types.ModuleIndex = @enumFromInt(@as(u32, @intCast(i)));
+        const m = graph.getModule(idx) orelse continue;
+        if (std.mem.eql(u8, m.path, abs)) return m.federation_id;
+    }
+    return null;
+}
+
+/// fed_id 의 self-register prefix(`({"<id>"`, min/비-min 공통)를 포함하는
+/// 청크 산출의 파일명(basename) → `__zntc_load_chunk` 인자.
+fn exposeChunkFile(outputs: []const emitter.OutputFile, allocator: std.mem.Allocator, fed_id: []const u8) !?[]const u8 {
+    const needle = try std.fmt.allocPrint(allocator, "({{\"{s}\"", .{fed_id});
+    defer allocator.free(needle);
+    for (outputs) |o| {
+        if (std.mem.indexOf(u8, o.contents, needle) != null)
+            return std.fs.path.basename(o.path);
+    }
+    return null;
+}
+
+/// 부트스트랩 문장 `[var <id> = ]globalThis.__zntc_require("<id>");` 의
+/// [start, end) 바이트 범위. start 는 선행 부트스트랩 접두를 흡수(남기면
+/// `var X = <container>` / `return <container>` 가 되어 globalName 바인딩·
+/// wrapper 반환 의미가 깨짐). 정본 두 형태(emitter/chunks.zig:801,809):
+///   - iife: `[var <gn> = ]globalThis.__zntc_require("<id>");`
+///   - umd/amd: `return globalThis.__zntc_require("<id>");`
+/// → 이 함수는 그 출력 형태에 강결합. chunks.zig 부트스트랩 변경 시 동반
+/// 수정 필요(앵커 없으면 wrapContainer 가 fail-fast).
+fn bootstrapSpan(text: []const u8) ?struct { start: usize, end: usize } {
+    const p = std.mem.indexOf(u8, text, BOOTSTRAP_ANCHOR) orelse return null;
+    const rel = std.mem.indexOf(u8, text[p..], "\");") orelse return null;
+    const end = p + rel + 3; // `")` + `;`
+
+    var s = p;
+    while (s > 0 and text[s - 1] == ' ') s -= 1;
+    if (s > 0 and text[s - 1] == '=') {
+        // iife: 선행 `[var <ident> ]=` 흡수
+        s -= 1;
+        while (s > 0 and text[s - 1] == ' ') s -= 1;
+        while (s > 0 and isIdentChar(text[s - 1])) s -= 1;
+        while (s > 0 and text[s - 1] == ' ') s -= 1;
+        if (s >= 4 and std.mem.eql(u8, text[s - 4 .. s], "var ")) s -= 4;
+    } else if (s >= 6 and std.mem.eql(u8, text[s - 6 .. s], "return") and
+        (s == 6 or !isIdentChar(text[s - 7])))
+    {
+        // umd/amd: 선행 `return ` 흡수(`=` 분기와 대칭). 키워드 경계
+        // 확인(앞이 식별자 문자 아님)으로 `xreturn` 오인 방지.
+        s -= 6;
+    }
+    return .{ .start = s, .end = end };
+}
+
+/// emitChunks 산출을 in-place 로 container 화. 게이트는 호출부
+/// (`if (options.mf) |mf|`, bundler.zig — markBoundary 와 동일 관례).
+pub fn wrapContainer(
+    allocator: std.mem.Allocator,
+    outputs: []emitter.OutputFile,
+    mf: *const types.MfBundleConfig,
+    graph: anytype,
+) !void {
+    if (mf.exposes.len == 0) return; // host(shared/remotes-only) = container 아님
+    const name = mf.name orelse return; // remote 는 P1-0 검증이 name 강제
+
+    const cwd = std.fs.cwd().realpathAlloc(allocator, ".") catch null;
+    defer if (cwd) |c| allocator.free(c);
+
+    // ── container 객체 문자열 빌드(min-무관 compact, 유효 JS) ──
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    defer buf.deinit(allocator);
+    const w = buf.writer(allocator);
+
+    try buf.appendSlice(allocator, "(function(g){var __zntc_mf_container={get:function(e){var M={");
+    var first = true;
+    for (mf.exposes) |kv| {
+        const abs = federation.resolveAbs(allocator, cwd, kv.value) catch continue;
+        defer allocator.free(abs);
+        const fed_id = exposeFedId(graph, abs) orelse {
+            std.log.warn("[mf] expose '{s}' has no federation_id (P1-1 미표시) — container.get 누락", .{kv.key});
+            continue;
+        };
+        const file = (try exposeChunkFile(outputs, allocator, fed_id)) orelse {
+            std.log.warn("[mf] expose '{s}' 청크 산출 없음 — container.get 누락", .{kv.key});
+            continue;
+        };
+        if (!first) try buf.appendSlice(allocator, ",");
+        first = false;
+        // MF2 계약: get(expose) ⇒ Promise<factory>, factory() ⇒ Module
+        // (webpack remoteEntry: `.then(()=>()=>require(id))`). 모듈 자체가
+        // 아니라 thunk resolve — factory() 호출 전엔 미평가(추가 lazy).
+        // "<expose>":function(){return __zntc_load_chunk("<file>").then(function(){return function(){return __zntc_require("<fed_id>")}})}
+        try w.print(
+            "\"{s}\":function(){{return __zntc_load_chunk(\"{s}\").then(function(){{return function(){{return __zntc_require(\"{s}\")}}}})}}",
+            .{ kv.key, file, fed_id },
+        );
+    }
+    try w.print(
+        "}};if(!M[e])throw new Error(\"Module \\\"\"+e+\"\\\" does not exist in container {s}.\");return M[e]()}},",
+        .{name},
+    );
+    // init: P1-3 은 init-before-get 가드만(shared 글로벌 채움은 P1-4).
+    // runtime 은 init(shareScope, initScope, remoteEntryInitOptions) 로 호출
+    // (s,i 외 무시).
+    try buf.appendSlice(allocator, "init:function(s,i){if(g.__zntc_mf_inited)return;g.__zntc_mf_inited=true;}};");
+    // MF2 계약: @module-federation/runtime 은 container 를
+    // `globalThis["__FEDERATION_<name>:custom__"]` 에서 읽는다(getRemote
+    // EntryExports default key, rspack/webpack MF 산출과 동일). 추가로
+    // 친화 글로벌(window.<name>)도 — 직접 접근/디버깅용.
+    try w.print("g[\"__FEDERATION_{s}:custom__\"]=__zntc_mf_container;", .{name});
+    if (isJsIdent(name)) {
+        try w.print("g.{s}=__zntc_mf_container;", .{name});
+    } else {
+        try buf.appendSlice(allocator, "g[");
+        try emitter.appendJsStringLiteral(allocator, &buf, name);
+        try buf.appendSlice(allocator, "]=__zntc_mf_container;");
+    }
+    // MF2 runtime(Node) 의 loadScriptNode 는 entry 를 (exports,module,...)
+    // 래퍼로 vm 실행 후 module.exports 를 container 로 읽는다(webpack MF
+    // commonjs-module 타깃). 브라우저는 module 부재 → 글로벌 사용. UMD 식
+    // 이중 노출로 runtime-Node interop + 브라우저 둘 다 충족.
+    try buf.appendSlice(allocator, "if(typeof module!==\"undefined\"&&module&&module.exports)module.exports=__zntc_mf_container;");
+    try buf.appendSlice(allocator, "})");
+    try buf.appendSlice(allocator, rt.ZNTC_IIFE_GLOBAL);
+    try buf.appendSlice(allocator, ";");
+
+    // ── remoteEntry(부트스트랩 보유 청크) 의 bootstrap 을 container 로 치환 ──
+    for (outputs) |*o| {
+        const span = bootstrapSpan(o.contents) orelse continue;
+        var next: std.ArrayListUnmanaged(u8) = .empty;
+        errdefer next.deinit(allocator);
+        try next.appendSlice(allocator, o.contents[0..span.start]);
+        try next.appendSlice(allocator, buf.items);
+        try next.appendSlice(allocator, o.contents[span.end..]);
+        // toOwnedSlice 성공 *후* 기존 contents free — 먼저 free 하면
+        // toOwnedSlice OOM 시 o.contents 가 dangling, bundler.zig 의
+        // outputs errdefer 가 그걸 재-free → double-free.
+        const owned = try next.toOwnedSlice(allocator);
+        allocator.free(o.contents);
+        o.contents = owned;
+        return;
+    }
+    // mf 빌드인데 reg_split 부트스트랩이 없음 = 잘못된 구성(format/splitting).
+    // 조용한 오작동(container 없는 산출) 금지 — federation.zig 진단 관례.
+    std.log.err("[mf] remoteEntry 부트스트랩 앵커 없음 — mf 빌드는 --format=iife/umd/amd + splitting 필요", .{});
+    return MfEmitError.RemoteEntryAnchorMissing;
+}

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -310,6 +310,11 @@ pub const Module = struct {
     /// 경계 모듈의 안정 ID(`module_id.zig`, relative-path). is_federation_
     /// boundary=true 일 때만 set. graph allocator 소유. (#3318 P1-1)
     federation_id: ?[]const u8 = null,
+    /// `mf.exposes` 타깃(shared-폐포 제외). P1-3: expose 모듈을 동적-import
+    /// 타깃과 동일하게 자기 lazy 청크로 분리 → reg_id=federation_id 가 되어
+    /// container.get 이 `__zntc_load_chunk().then(()=>__zntc_require(id))`
+    /// (동적 wrapper) 재사용. boundary ⊇ expose (shared 는 expose 아님).
+    is_federation_expose: bool = false,
     /// DFS 후위 순서 = ESM 실행 순서 (D058, D076).
     /// maxInt = 미방문 (DFS에서 할당되지 않음).
     exec_index: u32,
@@ -614,6 +619,7 @@ pub const Module = struct {
         self.dynamic_imports.deinit(allocator);
         self.dynamic_importers.deinit(allocator);
         if (self.resolve_dir) |dir| allocator.free(dir);
+        if (self.federation_id) |id| allocator.free(id); // #3318 P1-1 (setBoundary alloc)
         for (self.resolved_deps.items) |dep| {
             allocator.free(dep.path);
             if (dep.resolve_dir) |dir| allocator.free(dir);

--- a/src/cli/options.zig
+++ b/src/cli/options.zig
@@ -263,6 +263,8 @@ pub const CliOptions = struct {
         self.watch_include_list.deinit(alloc);
         self.watch_exclude_list.deinit(alloc);
         self.globals_list.deinit(alloc);
+        // #3318 mf: 해제는 freeMfBundle 단일 소스(mfBundleFromDto errdefer 와 공유).
+        if (self.mf) |mfb| freeMfBundle(alloc, mfb);
     }
 };
 
@@ -403,7 +405,15 @@ fn applyZntcConfigJson(opts: *CliOptions, allocator: std.mem.Allocator) !void {
         // (IIFE/UMD/AMD 글로벌-파라미터 seam) 로 합친다. 스파이크 S2 가
         // `--external pkg --globals pkg=__mf_shared_pkg` 로 검증한 기계를
         // 그대로 재사용 — bundler/emitter/codegen 무변경.
-        if (opts.mf) |mfb| try applyMfSharedSeam(allocator, opts, mfb.shared);
+        if (opts.mf) |mfb| {
+            try applyMfSharedSeam(allocator, opts, mfb.shared);
+            // P1-3 (#3385): exposes 있는 mf = remote → container/exposes 는
+            // reg_split 다중-청크(chunk.zig 가 expose→lazy 청크) 위에 얹으므로
+            // splitting 필수(부트스트랩은 format=iife/umd/amd 필요 — 없으면
+            // wrapContainer fail-fast). exposes 없는 host(shared/remotes-only)
+            // 는 강제 안 함 — P1-2 단일파일 seam 경로 불변.
+            if (mfb.exposes.len > 0) opts.splitting = true;
+        }
     }
 }
 
@@ -491,20 +501,50 @@ fn dupeKvMap(
     return list;
 }
 
+/// mfBundleFromDto 가 allocator-dup 한 것 일괄 해제. CliOptions.deinit 과
+/// mfBundleFromDto 의 errdefer 가 **공유**(해제 모델 단일 소스 — 부분
+/// 실패/정상 종료 대칭). len>0 가드: exposes/remotes/shared default 는
+/// static `&.{}` (오해제 방지, chunks.zig reg_ids 와 동일 관용). name 은
+/// set 시 항상 dup, share_scope 는 항상 dup(아래 통일). **불변: mf 는
+/// mfBundleFromDto 로만 생성**(외부 생성 시 share_scope 리터럴 free 위험).
+fn freeMfBundle(alloc: std.mem.Allocator, mfb: lib.bundler.MfBundleConfig) void {
+    if (mfb.name) |n| alloc.free(n);
+    alloc.free(mfb.share_scope);
+    for (mfb.exposes) |kv| {
+        alloc.free(kv.key);
+        alloc.free(kv.value);
+    }
+    if (mfb.exposes.len > 0) alloc.free(mfb.exposes);
+    for (mfb.remotes) |kv| {
+        alloc.free(kv.key);
+        alloc.free(kv.value);
+    }
+    if (mfb.remotes.len > 0) alloc.free(mfb.remotes);
+    for (mfb.shared) |s| alloc.free(s);
+    if (mfb.shared.len > 0) alloc.free(mfb.shared);
+}
+
 fn mfBundleFromDto(
     allocator: std.mem.Allocator,
     dto: *const lib.transpile.MfConfigDto,
 ) !lib.bundler.MfBundleConfig {
     var out: lib.bundler.MfBundleConfig = .{};
+    // 부분 dup 후 실패 시 누수 방지 — deinit 과 동일 해제로 대칭.
+    // out.shared 는 루프 완료 후에야 대입 → 진행 중 list 는 블록 errdefer 가.
+    errdefer freeMfBundle(allocator, out);
     if (dto.name) |n| out.name = try allocator.dupe(u8, n);
-    if (dto.shareScope) |s| out.share_scope = try allocator.dupe(u8, s);
+    // share_scope 는 항상 owned(default 도 dup) — deinit 해제 대칭(리터럴/
+    // owned 혼재 회피).
+    out.share_scope = try allocator.dupe(u8, dto.shareScope orelse "default");
 
     if (dto.exposes) |e| out.exposes = try dupeKvMap(allocator, &e.map);
     if (dto.remotes) |r| out.remotes = try dupeKvMap(allocator, &r.map);
     if (dto.shared) |sh| {
-        var list = try allocator.alloc([]const u8, sh.map.count());
+        const list = try allocator.alloc([]const u8, sh.map.count());
+        errdefer allocator.free(list);
         var it = sh.map.iterator();
         var i: usize = 0;
+        errdefer for (list[0..i]) |s| allocator.free(s);
         while (it.next()) |kv| : (i += 1) list[i] = try allocator.dupe(u8, kv.key_ptr.*);
         out.shared = list;
     }

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -25,6 +25,7 @@
     "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
     "@emotion/utils": "^1.4.2",
     "@emotion/weak-memoize": "^0.4.0",
+    "@module-federation/runtime": "2.4.0",
     "@swc/cli": "^0.8.1",
     "@swc/core": "^1.15.24",
     "@types/bun": "latest",

--- a/tests/integration/tests/mf-container-emit.test.ts
+++ b/tests/integration/tests/mf-container-emit.test.ts
@@ -1,0 +1,110 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { runConfigBundle, writeOutputs, runNode } from './helpers';
+
+// P1-3 (#3385): webpack-style container emit (remoteEntry).
+//   - entry 청크의 eager bootstrap(`var X=__zntc_require("id")`)을
+//     container 객체(`init(shareScope,initScope)` / `get(id):Promise<factory>`,
+//     globalName 대입)로 wrap. exposed 모듈은 자기 lazy 청크.
+//   - get(expose) = `__zntc_load_chunk(stem).then(()=>__zntc_require(fed_id))`
+//     (P3-B 동적 import wrapper 재사용 — exposed 번들 eval 은 get() 까지 지연).
+//   - 비-목표: shareScopeMap/shared→async 협상(P1-4), 별도 manifest 파일(P1-5).
+describe('MF P1-3: webpack-style container emit', () => {
+  let cleanup: (() => Promise<void>) | undefined;
+  afterEach(async () => {
+    await cleanup?.();
+    cleanup = undefined;
+  });
+
+  test('container 형태: init/get + globalName 대입, eager bootstrap 제거', async () => {
+    const r = await runConfigBundle({
+      files: {
+        'index.ts': `export const sentinel = "remote-entry";`,
+        'Widget.ts': `export default function Widget() { return "WIDGET-OK"; }`,
+        'zntc.config.json': JSON.stringify({
+          mf: { name: 'app', exposes: { './Widget': './Widget.ts' } },
+        }),
+      },
+      args: ['--format=iife'],
+      outDir: 'out',
+    });
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+
+    const files = readdirSync(r.outDir!);
+    const entryFile = files.find(
+      (f) =>
+        f.endsWith('.js') &&
+        readFileSync(join(r.outDir!, f), 'utf8').includes('__zntc_mf_container'),
+    );
+    expect(entryFile).toBeDefined();
+    const entry = readFileSync(join(r.outDir!, entryFile!), 'utf8');
+
+    // container 객체 + globalName 대입 (mf.name='app' → 유효 식별자 → g.app=)
+    expect(entry).toMatch(/\bg\.app\s*=\s*__zntc_mf_container\b/);
+    expect(entry).toContain('init:');
+    expect(entry).toContain('get:');
+    // MF2 runtime 계약(실 @module-federation/runtime interop 검증으로 포착):
+    //  ① 기본 키 globalThis["__FEDERATION_<name>:custom__"]
+    //  ② loadScriptNode(Node) 는 module.exports 를 container 로 읽음
+    expect(entry).toContain('"__FEDERATION_app:custom__"]=__zntc_mf_container');
+    expect(entry).toMatch(/module\.exports\s*=\s*__zntc_mf_container/);
+    // get(expose) ⇒ Promise<factory>, factory()⇒Module (MF2 thunk 계약)
+    expect(entry).toMatch(/"\.\/Widget"\s*:\s*function/);
+    expect(entry).toMatch(
+      /__zntc_load_chunk\([^)]*\)\.then\(function\(\)\{return function\(\)\{return __zntc_require\(/,
+    );
+    // eager bootstrap 제거 — container 는 자기실행 금지(host 가 init/get 구동)
+    expect(entry).not.toMatch(/var\s+\w+\s*=\s*globalThis\.__zntc_require\(/);
+  });
+
+  test('interop 계약: init→get 으로 exposed 모듈 lazy 도달 (S1/S3 형태)', async () => {
+    const r = await runConfigBundle({
+      files: {
+        // exposed 모듈은 import 시 side-effect — get() 전엔 평가 안 됨(lazy) 검증용
+        'Widget.ts': `globalThis.__widget_evaluated = true;\nexport default function Widget() { return "WIDGET-42"; }`,
+        'index.ts': `export const sentinel = "remote-entry";`,
+        'zntc.config.json': JSON.stringify({
+          mf: { name: 'app', exposes: { './Widget': './Widget.ts' } },
+        }),
+      },
+      args: ['--format=iife'],
+      outDir: 'out',
+    });
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+
+    const outs = readdirSync(r.outDir!).map((f) => ({
+      path: f,
+      text: readFileSync(join(r.outDir!, f), 'utf8'),
+    }));
+    writeOutputs(r.dir, outs);
+    const entryFile = outs.find((o) => o.text.includes('__zntc_mf_container'))!.path;
+
+    // 동적 청크 로더(nondom: import(url)) → publicPath = file://<dir>/
+    // entry(remoteEntry) 가 자기 __zntc_public_path 를 "" 로 초기화하므로,
+    // 표준 MF 패턴대로 entry import *후* host 가 publicPath 주입.
+    const driver = `
+      await import(${JSON.stringify('file://' + join(r.dir, entryFile))});
+      globalThis.__zntc_public_path = ${JSON.stringify('file://' + r.dir + '/')};
+      const c = globalThis.app;
+      if (typeof c.init !== 'function' || typeof c.get !== 'function')
+        throw new Error('container 계약 위반: init/get 없음');
+      // init-before-get: init() 후 get(). get 전엔 Widget 미평가(lazy).
+      c.init({});
+      if (globalThis.__widget_evaluated) throw new Error('lazy 위반: get 전 Widget 평가됨');
+      const factory = await c.get('./Widget');
+      const mod = factory();
+      const Widget = mod.default ?? mod;
+      console.log('RESULT=' + Widget());
+      console.log('EVALUATED=' + !!globalThis.__widget_evaluated);
+    `;
+    const driverPath = join(r.dir, 'driver.mjs');
+    require('node:fs').writeFileSync(driverPath, driver);
+    const { stdout, stderr } = await runNode(driverPath);
+    expect(stderr).toBe('');
+    expect(stdout).toContain('RESULT=WIDGET-42');
+    expect(stdout).toContain('EVALUATED=true');
+  });
+});

--- a/tests/integration/tests/mf-runtime-interop-smoke.test.ts
+++ b/tests/integration/tests/mf-runtime-interop-smoke.test.ts
@@ -1,0 +1,97 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { createServer, type Server } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { writeFileSync, rmSync } from 'node:fs';
+import { join, basename } from 'node:path';
+import { createRequire } from 'node:module';
+import { createFixture, runZntcInDir, runNode } from './helpers';
+
+// P1-3 (#3385) 실-런타임 interop 스모크 (S3 정방향):
+// **실제 @module-federation/[email protected]**(rspack/webpack MF 가 쓰는
+// 바로 그 interop 계약 패키지)이 zntc-emit container 를 자기 init/loadRemote
+// 파이프라인으로 구동·실행하는지 검증. RFC §8.1 S3 를 영구 박제.
+//   - 계약 키: runtime 의 loadScriptNode 가 entry 를 (exports,module,...)
+//     래퍼로 vm 실행 후 module.exports 를 container 로 읽음 + 기본 글로벌
+//     `__FEDERATION_<name>:custom__`.
+//   - entry 는 http(runtime fetch), chunk publicPath 는 file://(Node import).
+// 전체 브라우저 Playwright interop CI(S4 역방향 포함)는 P1-7.
+describe('MF P1-3: 실 @module-federation/runtime interop (S3)', () => {
+  let server: Server | undefined;
+  let cleanup: (() => Promise<void>) | undefined;
+  let driverPath: string | undefined;
+  afterEach(async () => {
+    await new Promise<void>((r) => (server ? server.close(() => r()) : r()));
+    server = undefined;
+    if (driverPath) {
+      rmSync(driverPath, { force: true });
+      driverPath = undefined;
+    }
+    await cleanup?.();
+    cleanup = undefined;
+  });
+
+  test('runtime init→loadRemote 로 zntc remote 의 expose 렌더 + lazy', async () => {
+    const fx = await createFixture({
+      'Widget.ts': `globalThis.__w_eval = true;\nexport default function Widget() { return "ZNTC-RT-OK"; }\nexport const meta = { from: "zntc" };`,
+      'index.ts': `export const sentinel = "remote-entry";`,
+      'zntc.config.json': JSON.stringify({
+        mf: { name: 'app', exposes: { './Widget': './Widget.ts' } },
+      }),
+    });
+    cleanup = fx.cleanup;
+    const dist = join(fx.dir, 'dist');
+
+    const b = await runZntcInDir(fx.dir, [
+      '--bundle',
+      join(fx.dir, 'index.ts'),
+      '--outdir',
+      dist,
+      '--format=iife',
+      // entry 는 http 로 서빙되지만 chunk publicPath 는 file:// (Node import).
+      `--public-path=file://${dist}/`,
+    ]);
+    expect(b.exitCode).toBe(0);
+
+    // dist 정적 서버 (runtime 의 Node entry 로더는 http fetch 필요).
+    server = createServer(async (req, res) => {
+      try {
+        const f = join(dist, req.url === '/' ? '/index.js' : req.url!);
+        res.writeHead(200, { 'content-type': 'application/javascript' });
+        res.end(await readFile(f));
+      } catch {
+        res.writeHead(404).end();
+      }
+    });
+    await new Promise<void>((r) => server!.listen(0, r));
+    const port = (server.address() as { port: number }).port;
+
+    // @module-federation/runtime 절대경로(워크스페이스 .bun 레이아웃 →
+    // os-tmpdir fixture 에서 bare 해소 불가, resolve 경로 주입).
+    const mfRuntime = createRequire(import.meta.url).resolve('@module-federation/runtime');
+    driverPath = join(fx.dir, 'rt-driver.mjs');
+    writeFileSync(
+      driverPath,
+      `import mf from ${JSON.stringify('file://' + mfRuntime)};
+const { init, loadRemote } = mf;
+init({ name: 'host-mf2', remotes: [{ name: 'app', entry: 'http://localhost:${port}/index.js' }] });
+console.log('BEFORE=' + !!globalThis.__w_eval);
+const m = await loadRemote('app/Widget');
+const W = m && (m.default ?? m);
+console.log('TYPEOF=' + typeof W);
+console.log('RESULT=' + (typeof W === 'function' ? W() : ''));
+console.log('META=' + JSON.stringify(m && m.meta));
+console.log('AFTER=' + !!globalThis.__w_eval);
+`,
+    );
+    const { stdout, stderr } = await runNode(driverPath);
+
+    // 실 MF2 runtime 이 container.init→get→factory 구동, expose 실행
+    expect(stdout).toContain('TYPEOF=function');
+    expect(stdout).toContain('RESULT=ZNTC-RT-OK');
+    expect(stdout).toContain('META={"from":"zntc"}');
+    // get 전 미평가 → factory 후 평가 (lazy)
+    expect(stdout).toContain('BEFORE=false');
+    expect(stdout).toContain('AFTER=true');
+    expect(stderr).not.toMatch(/RUNTIME-00\d|does not contain "init"/);
+  }, 30000);
+});

--- a/tests/integration/tests/zntc-config-bundler.test.ts
+++ b/tests/integration/tests/zntc-config-bundler.test.ts
@@ -307,14 +307,16 @@ describe('Zig CLI: zntc.config.json bundler-only 옵션 (#2105)', () => {
   // 가 std.json.ArrayHashMap 으로 직접 파싱, 변환 계층 없음. 사용자가
   // 문서/타입대로 쓰는 그 경로를 그대로 검증.
 
-  test('mf: 유효 config 블록(name/exposes/remotes/shared/shareScope) 파싱 성공', async () => {
+  // exposes 동작(container emit)은 P1-3 부터라 mf-container-emit.test.ts 가
+  // 전담. 여기선 비-remote 필드(name/remotes/shared/shareScope) 파싱 +
+  // host 빌드 출력 불변만(exposes 넣으면 remote→container 경로로 빠짐).
+  test('mf: 유효 config 블록(name/remotes/shared/shareScope) 파싱 성공', async () => {
     const r = await runConfigBundle({
       files: {
         'index.ts': `console.log("mf-ok");`,
         'zntc.config.json': JSON.stringify({
           mf: {
             name: 'app',
-            exposes: { './Widget': './widget.ts' },
             remotes: { remoteA: 'remoteA@http://localhost/mf-manifest.json' },
             shared: { react: { singleton: true, requiredVersion: '^18' } },
             shareScope: 'default',
@@ -326,7 +328,7 @@ describe('Zig CLI: zntc.config.json bundler-only 옵션 (#2105)', () => {
 
     expect(r.exitCode).toBe(0);
     expect(r.stderr).not.toContain('load failed');
-    // emit 미연결 — 출력은 일반 번들 그대로
+    // exposes 없음(host) — 출력은 일반 번들 그대로
     expect(readFileSync(r.outFile!, 'utf8')).toContain('mf-ok');
   });
 


### PR DESCRIPTION
## 무엇 (#3385, MF epic P1-3)

`mf.exposes`(=remote) 빌드의 entry 청크 reg_split bootstrap 을 **webpack-style container** 로 후처리 wrap. `init(shareScope,initScope)` / `get(expose):Promise<factory>` / globalName 대입, init-before-get.

**핵심: 실제 `@module-federation/[email protected]`(rspack/webpack MF 가 쓰는 바로 그 interop 계약 패키지)이 zntc-emit container 를 자기 `init`/`loadRemote` resolution 으로 구동·실행함을 검증**(RFC §8.1 S3 정방향, 영구 스모크 박제). 사용자 요청 "실제 rspack MF 와 스모크 비교 최종검증" 충족.

## 어떻게

- **`federation_emit.zig`(신규)** `wrapContainer`: emitChunks 산출 후처리. bootstrap `[var X = | return ]globalThis.__zntc_require("id");` → container 치환. `get` = `__zntc_load_chunk(file).then(()=>()=>__zntc_require(fed_id))` — **P3-B 동적 wrapper 재사용**, exposed eval 은 `get()`→`factory()` 까지 지연(MF2 thunk 계약). bundler/emitter/codegen 무변경.
- **3중 노출**(실 runtime interop 이 포착한 계약): `globalThis["__FEDERATION_<name>:custom__"]`(MF2 기본 키) + `g.<name>` + CJS `module.exports`(runtime `loadScriptNode` 가 vm 래퍼 `module.exports` 로 읽음 — webpack commonjs-module 타깃).
- **`chunk.zig`**: exposes 모듈을 동적-import 타깃과 동일 lazy 청크로 분리(reg_id=federation_id). dedup/append 는 `addDynamicEntry` 헬퍼로 Phase 1b 와 공유.
- **`federation.zig`**: `is_federation_expose`(exposes만) + `entryWithExposes`(exposes 를 graph 루트 합류 — webpack 처럼 독립 루트).
- **`cli/options.zig`**: `exposes>0`(=remote)일 때만 splitting 강제 — host(shared/remotes-only)·P1-2 단일파일 seam 경로 불변.

## 검증

- 실 `@module-federation/[email protected]` interop 스모크(S3 영구 박제): http 서버 entry → `init`+`loadRemote('app/Widget')` → 렌더(`RESULT=ZNTC-RT-OK`)·factory 계약·lazy(`BEFORE=false`→`AFTER=true`)·named export, RUNTIME-00x 0.
- 통합 `mf-container-emit.test.ts`: container 형태(init/get·3중 노출·thunk·eager bootstrap 제거) + 행동 interop.
- 회귀 0: `zig build test` EXIT=0(비-환경 0) / mf 통합 20·0(실-runtime 포함) / 번들·청크·react 스모크 196·0.

## /simplify (3-에이전트)

- **차단**: `wrapContainer` free→toOwnedSlice 순서 OOM double-free → toOwnedSlice 성공 후 free.
- **정확성**: `bootstrapSpan` umd/amd `return ` 접두 미흡수 → `=` 분기 대칭 추가(키워드 경계 확인).
- **누수 대칭**: `freeMfBundle` 단일 소스(`CliOptions.deinit` ↔ `mfBundleFromDto` errdefer 공유, 부분-dup 누수 차단). + `module.zig` deinit federation_id free(P1-1 선재).
- **재사용**: `addDynamicEntry` 공유; chunks.zig↔federation_emit 강결합 cross-ref 주석.
- follow-up(별 PR, P3-C 선례): 동적 wrapper fragment 공유(chunks.zig:1362), `exposeFedId`↔`markBoundary` 단일 진실원천화, `applyZntcConfigJson` 분해.

## 비-목표 (decomposition)

shareScopeMap/shared→async(P1-4) · mf-manifest/remoteEntry 파일 에미터(P1-5) · host remotes 소비(P1-6) · 전체 브라우저 Playwright interop CI + S4 역방향(P1-7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)