### PR TITLE
fix(rn): 릴리즈 번들 평가 안정화

### DIFF
--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -174,6 +174,131 @@ test "Bundler: minify가 require 래퍼 합성 심볼도 짧은 이름으로 바
     try std.testing.expect(std.mem.indexOf(u8, result.output, "console.log") != null);
 }
 
+test "Bundler: RN minified require(JSON) rewrites CJS module param" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\const colors = require('./colors.json');
+        \\console.log(colors.black);
+    );
+    try writeFile(tmp.dir, "colors.json",
+        \\{"black":"#000000","white":"#ffffff"}
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .esm,
+        .minify_whitespace = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$c((exports,module)=>{module.exports={") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$c((e)=>{module.exports") == null);
+}
+
+test "Bundler: RN minified CJS wrapper keeps Node parameter names" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\const styled = require('./styled.cjs').default;
+        \\console.log(typeof styled);
+    );
+    try writeFile(tmp.dir, "styled.cjs",
+        \\Object.defineProperty(exports, "__esModule", { value: true });
+        \\var e = require("./dep.cjs");
+        \\exports.default = function styled(component) {
+        \\  return function template() {
+        \\    return e.value + component;
+        \\  };
+        \\};
+    );
+    try writeFile(tmp.dir, "dep.cjs",
+        \\exports.value = "ok";
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .esm,
+        .minify_whitespace = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$c((exports,module)=>{Object.defineProperty(exports") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "$c((e)=>{Object.defineProperty(e") == null);
+}
+
+test "Bundler: RN minified keeps computed global assignment side effect" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js",
+        \\import { HeaderShownContext } from 'nav-elements';
+        \\console.log(HeaderShownContext);
+    );
+    try writeFile(tmp.dir, "node_modules/nav-elements/package.json",
+        \\{"name":"nav-elements","main":"index.js","sideEffects":false}
+    );
+    try writeFile(tmp.dir, "node_modules/nav-elements/index.js",
+        \\export { default as HeaderShownContext } from './HeaderShownContext.js';
+    );
+    try writeFile(tmp.dir, "node_modules/nav-elements/HeaderShownContext.js",
+        \\import getNamedContext from './getNamedContext.js';
+        \\const HeaderShownContext = getNamedContext('HeaderShownContext', false);
+        \\export default HeaderShownContext;
+    );
+    try writeFile(tmp.dir, "node_modules/nav-elements/getNamedContext.js",
+        \\const contexts = '__react_navigation__elements_contexts';
+        \\global[contexts] = global[contexts] ?? new Map();
+        \\
+        \\export default function getNamedContext(name, initialValue) {
+        \\  let context = global[contexts].get(name);
+        \\  if (context) {
+        \\    return context;
+        \\  }
+        \\  context = { name, initialValue };
+        \\  global[contexts].set(name, context);
+        \\  return context;
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .esm,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "new Map") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, ".get(") != null);
+}
+
 test "Bundler: define으로 죽은 require 분기는 그래프에 포함하지 않음" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -2718,10 +2718,10 @@ test "#1618 minify: __commonJS → $cj short name" {
 
     try std.testing.expect(!result.hasErrors());
     // minify 모드: preamble이 `var $c=` 형태로 축약 (#3256: $cj → $c 1 char 단축).
-    // 호출부는 직접 함수 + callback param 단축 — body 의 unresolved `exports`/`module`
-    // 도 codegen 에서 `e`/`m` 로 substitute (cjs_wrap_substitute).
+    // 호출부는 직접 함수 패턴을 쓰되 callback param 은 Node/Metro 호환성을 위해
+    // minify에서도 `exports, module` 을 유지.
     try std.testing.expect(std.mem.indexOf(u8, result.output, "var $c=") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "=$c((e,m)=>") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "=$c((exports,module)=>") != null);
     // 원본 `__commonJS` 이름은 나타나지 않아야 함
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__commonJS") == null);
 }

--- a/src/bundler/bundler_test/tree_shake/writers.zig
+++ b/src/bundler/bundler_test/tree_shake/writers.zig
@@ -192,3 +192,179 @@ test "TreeShaking: compound/update writers inside function body are not writer-e
     try std.testing.expect(std.mem.indexOf(u8, result.output, "dead_inc") == null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "COMPOUND_WRITER_DROP_MARKER") == null);
 }
+
+test "TreeShaking: unused worklet metadata assignments do not keep pure modules live" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import './node_modules/worklet-pkg/lib';
+        \\console.log('WORKLET_METADATA_ENTRY');
+    );
+    try writeFile(tmp.dir, "node_modules/worklet-pkg/package.json",
+        \\{"name":"worklet-pkg","sideEffects":false}
+    );
+    try writeFile(tmp.dir, "node_modules/worklet-pkg/lib.ts",
+        \\export {};
+        \\class ReanimatedError extends Error {}
+        \\function validateAnimatedStyles(styles) {
+        \\  if (typeof styles !== 'object') throw new ReanimatedError('bad');
+        \\}
+        \\validateAnimatedStyles.__workletHash = 4291796598;
+        \\validateAnimatedStyles.__closure = {
+        \\  ReanimatedError,
+        \\  ReanimatedError__classFactory: ReanimatedError.classFactory,
+        \\};
+        \\validateAnimatedStyles.__initData = { code: 'function validateAnimatedStyles(){}' };
+        \\validateAnimatedStyles.__stackDetails = [new global.Error(), -3, -27];
+        \\validateAnimatedStyles.__pluginVersion = '0.7.2';
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+        .minify_syntax = true,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .platform = .react_native,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "WORKLET_METADATA_ENTRY") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "validateAnimatedStyles") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__workletHash") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "ReanimatedError") == null);
+}
+
+test "TreeShaking: unused worklet metadata assignments are dropped when sibling exports stay live" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { useAnimatedStyle } from './node_modules/worklet-pkg/useAnimatedStyle';
+        \\console.log(useAnimatedStyle({ onFrame: true }));
+    );
+    try writeFile(tmp.dir, "node_modules/worklet-pkg/package.json",
+        \\{"name":"worklet-pkg","sideEffects":false}
+    );
+    try writeFile(tmp.dir, "node_modules/worklet-pkg/utils.ts",
+        \\class ReanimatedError extends Error {}
+        \\export function isAnimated(prop) {
+        \\  return !!prop.onFrame;
+        \\}
+        \\isAnimated.__workletHash = 125899194;
+        \\isAnimated.__closure = {};
+        \\export function shallowEqual(a, b) {
+        \\  return Object.keys(a).length === Object.keys(b).length;
+        \\}
+        \\shallowEqual.__workletHash = 125899195;
+        \\shallowEqual.__closure = {};
+        \\export function validateAnimatedStyles(styles) {
+        \\  throw new ReanimatedError('VALIDATE_ANIMATED_STYLES_MARKER');
+        \\}
+        \\validateAnimatedStyles.__workletHash = 4291796598;
+        \\validateAnimatedStyles.__closure = {
+        \\  ReanimatedError,
+        \\  ReanimatedError__classFactory: ReanimatedError.classFactory,
+        \\};
+        \\validateAnimatedStyles.__initData = { code: 'function validateAnimatedStyles(){}' };
+        \\validateAnimatedStyles.__stackDetails = [new global.Error(), -3, -27];
+        \\validateAnimatedStyles.__pluginVersion = '0.7.2';
+    );
+    try writeFile(tmp.dir, "node_modules/worklet-pkg/useAnimatedStyle.ts",
+        \\import { isAnimated, shallowEqual, validateAnimatedStyles } from './utils';
+        \\export function useAnimatedStyle(style) {
+        \\  if (__DEV__) {
+        \\    validateAnimatedStyles(style);
+        \\  }
+        \\  return isAnimated(style) && shallowEqual({ a: 1 }, { a: 1 });
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+        .minify_syntax = true,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .platform = .react_native,
+        .define = &.{.{ .key = "__DEV__", .value = "false" }},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "onFrame") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "shallowEqual") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "validateAnimatedStyles") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "4291796598") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "VALIDATE_ANIMATED_STYLES_MARKER") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "ReanimatedError") == null);
+}
+
+test "TreeShaking: native worklet transform does not leave metadata for dead dev-only export" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { useAnimatedStyle } from './node_modules/worklet-pkg/useAnimatedStyle';
+        \\console.log(useAnimatedStyle({ onFrame: true }));
+    );
+    try writeFile(tmp.dir, "node_modules/worklet-pkg/package.json",
+        \\{"name":"worklet-pkg","sideEffects":false}
+    );
+    try writeFile(tmp.dir, "node_modules/worklet-pkg/utils.ts",
+        \\class ReanimatedError extends Error {}
+        \\export function isAnimated(prop) {
+        \\  'worklet';
+        \\  return !!prop.onFrame;
+        \\}
+        \\export function shallowEqual(a, b) {
+        \\  'worklet';
+        \\  return Object.keys(a).length === Object.keys(b).length;
+        \\}
+        \\export function validateAnimatedStyles(styles) {
+        \\  'worklet';
+        \\  throw new ReanimatedError('VALIDATE_ANIMATED_STYLES_MARKER');
+        \\}
+    );
+    try writeFile(tmp.dir, "node_modules/worklet-pkg/useAnimatedStyle.ts",
+        \\import { isAnimated, shallowEqual, validateAnimatedStyles } from './utils';
+        \\export function useAnimatedStyle(style) {
+        \\  if (__DEV__) {
+        \\    validateAnimatedStyles(style);
+        \\  }
+        \\  return isAnimated(style) && shallowEqual({ a: 1 }, { a: 1 });
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .tree_shaking = true,
+        .minify_syntax = true,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .platform = .react_native,
+        .worklet_transform = true,
+        .define = &.{.{ .key = "__DEV__", .value = "false" }},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "onFrame") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "validateAnimatedStyles") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "VALIDATE_ANIMATED_STYLES_MARKER") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "ReanimatedError") == null);
+}

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1541,7 +1541,24 @@ pub fn emitModule(
                                         const new_stmt_indices = transformer.ast.extra_data.items[new_list.start .. new_list.start + new_list.len];
                                         for (ts_infos.stmts, 0..) |ts_stmt, si| {
                                             if (s.isStmtReachable(mod_idx, @intCast(si))) continue;
-                                            // 변환 후 top-level statement만 스캔 (O(stmts) not O(nodes))
+                                            // 변환 후 AST와 StmtInfo가 같은 snapshot이면 node_idx가 가장
+                                            // 정확하다. 플러그인이 생성한 top-level 문장은 span이 0인
+                                            // 경우가 많아 span fallback만 쓰면 첫 zero-span stmt를
+                                            // 반복해서 매칭한다.
+                                            var matched = false;
+                                            if (ts_stmt.node_idx < transformer.ast.nodes.items.len) {
+                                                for (new_stmt_indices) |raw_ni| {
+                                                    if (raw_ni == ts_stmt.node_idx) {
+                                                        md.skip_nodes.set(ts_stmt.node_idx);
+                                                        matched = true;
+                                                        break;
+                                                    }
+                                                }
+                                            }
+                                            if (matched) continue;
+
+                                            // legacy/re-transform 경로에서는 statement node가 새로 만들어질
+                                            // 수 있으므로 span fallback 유지 (O(stmts) not O(nodes)).
                                             for (new_stmt_indices) |raw_ni| {
                                                 const ni = @as(usize, raw_ni);
                                                 if (ni >= transformer.ast.nodes.items.len) continue;
@@ -1722,9 +1739,10 @@ pub fn emitModule(
         // __esm 모듈: exports.x/module.exports 생성 억제 (__export()가 대신 처리)
         .skip_cjs_exports = module.wrap_kind == .esm,
         .skip_cjs_named_export_decls = module.module_type == .json and module.wrap_kind == .cjs,
-        // CJS wrap minify: callback param `(exports, module)` → `(e, m)` 단축 +
-        // body 의 unresolved `exports`/`module` reference 도 substitute.
-        .cjs_wrap_substitute = module.wrap_kind == .cjs and options.minify_whitespace,
+        // CJS wrap은 minify에서도 Node/Metro의 `(exports, module)` 이름을 유지한다.
+        // 고정 alias `(e, m)` 는 이미 minify된 dependency의 top-level `var e`/`var m`
+        // 과 같은 함수 스코프에서 충돌해 exports 객체를 잃을 수 있다.
+        .cjs_wrap_substitute = false,
         // __esm 모듈: const → var (TDZ 방지)
         .use_var_for_imports = module.wrap_kind == .esm,
         // cycle 모듈 의 top-level const/let → var 강등 (#2198, esbuild 호환).
@@ -1840,12 +1858,11 @@ pub fn emitModule(
         if (options.minify_whitespace) {
             // emit 의 직접 함수 패턴은 `runtime_helpers.zig` 의 `CJS_RUNTIME_*` 가 cb 를
             // function 으로 받는 것과 한 쌍 — 한쪽만 바꾸면 runtime TypeError.
-            // body 가 `module` 안 쓰면 wrapper param 도 `(e)` 1 인자로 단축.
-            // codegen 의 `cjs_wrap_module_used` 가 substitute 시점에 set.
+            // param 이름은 Node/Metro 호환성을 위해 minify에서도 `exports, module` 유지.
             try wrapped.appendSlice(allocator, "var ");
             try wrapped.appendSlice(allocator, var_name);
             try wrapped.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN);
-            try wrapped.appendSlice(allocator, if (cg.cjs_wrap_module_used) "((e,m)=>{" else "((e)=>{");
+            try wrapped.appendSlice(allocator, "((exports,module)=>{");
             if (preamble_code) |p| try wrapped.appendSlice(allocator, p);
             // body 의 trailing `;` 제거 — 다음 `})` 가 block close 라 ASI 안전.
             const body_trimmed = if (code.len > 0 and code[code.len - 1] == ';') code[0 .. code.len - 1] else code;

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1739,10 +1739,6 @@ pub fn emitModule(
         // __esm 모듈: exports.x/module.exports 생성 억제 (__export()가 대신 처리)
         .skip_cjs_exports = module.wrap_kind == .esm,
         .skip_cjs_named_export_decls = module.module_type == .json and module.wrap_kind == .cjs,
-        // CJS wrap은 minify에서도 Node/Metro의 `(exports, module)` 이름을 유지한다.
-        // 고정 alias `(e, m)` 는 이미 minify된 dependency의 top-level `var e`/`var m`
-        // 과 같은 함수 스코프에서 충돌해 exports 객체를 잃을 수 있다.
-        .cjs_wrap_substitute = false,
         // __esm 모듈: const → var (TDZ 방지)
         .use_var_for_imports = module.wrap_kind == .esm,
         // cycle 모듈 의 top-level const/let → var 강등 (#2198, esbuild 호환).

--- a/src/bundler/emitter/cjs_wrap.zig
+++ b/src/bundler/emitter/cjs_wrap.zig
@@ -112,9 +112,9 @@ pub fn emitCjsWrapper(allocator: std.mem.Allocator, module: *const Module, sourc
     if (minify) {
         try buf.appendSlice(allocator, "var ");
         try buf.appendSlice(allocator, var_name);
-        // #1621: minify 시 __commonJS → $cj 축약. body 가 `m.exports=<source>` —
-        // 자체 emit 이라 codegen substitute 안 거치므로 직접 `m` 사용.
-        try buf.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "((e,m)=>{m.exports=");
+        // #1621: minify 시 __commonJS → $cj 축약. callback parameter 는 Node/Metro
+        // 호환성을 위해 `exports, module` 유지.
+        try buf.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN ++ "((exports,module)=>{module.exports=");
         try buf.appendSlice(allocator, source);
         try buf.appendSlice(allocator, "});");
     } else {

--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -150,8 +150,13 @@ pub fn run(self: anytype, module: *Module, arena_alloc: std.mem.Allocator) void 
     var prepass_ref_deltas: []u32 = &.{};
     if (self.transform_options_base.minify_syntax) {
         const minify_mod = @import("../../transformer/minify.zig");
+        // This flag controls top-level constant/function inlining, not
+        // module-level dead-store removal. `MinifyCtx.allow_top_level_dead`
+        // remains false here; top-level pruning is owned by the resynced
+        // tree-shaker/emitter path.
+        const allow_top_level_inline = true;
         var ctx: minify_mod.MinifyCtx = if (module.semantic != null)
-            minify_mod.MinifyCtx.fromSemantic(&module.semantic.?, transformer.symbol_ids.items, true)
+            minify_mod.MinifyCtx.fromSemantic(&module.semantic.?, transformer.symbol_ids.items, allow_top_level_inline)
         else
             .empty;
         if (ctx.hasSemantic()) {

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -486,7 +486,7 @@ pub const Resolver = struct {
 
         // bare specifier → node_modules 탐색
         if (!isRelativeOrAbsolute(effective_specifier)) {
-            return self.resolveNodeModules(source_dir, effective_specifier, false) catch |err| {
+            return self.resolveNodeModules(source_dir, effective_specifier) catch |err| {
                 if (err == error.ModuleNotFound and self.resolve_symlink_siblings) {
                     if (self.resolveNodeModulesFromRealpath(source_dir, effective_specifier)) |r| return r else |fallback_err| {
                         if (fallback_err != error.ModuleNotFound) return fallback_err;
@@ -733,7 +733,10 @@ pub const Resolver = struct {
 
     /// bare specifier를 node_modules에서 탐색한다.
     /// source_dir에서 시작하여 상위 디렉토리로 올라가며 node_modules/<pkg>를 찾는다.
-    fn resolveNodeModules(self: *Resolver, source_dir: []const u8, specifier: []const u8, include_node_paths: bool) ResolveError!ResolveResult {
+    /// NODE_PATH 폴백은 caller (`resolveNodeModulesFromNodePaths`) 가 실패 후 별도로
+    /// 실행한다 — `resolve_symlink_siblings` 보다 나중에 동작해 real package 옆
+    /// peer dependency 가 전역 .pnpm/node_modules 의 다른 버전보다 우선되게 한다.
+    fn resolveNodeModules(self: *Resolver, source_dir: []const u8, specifier: []const u8) ResolveError!ResolveResult {
         // 패키지 이름과 서브패스 분리: "@scope/pkg/utils" → ("@scope/pkg", "./utils")
         const split = splitBareSpecifier(specifier);
         const pkg_name = split.pkg_name;
@@ -761,13 +764,7 @@ pub const Resolver = struct {
             current_dir = parent;
         }
 
-        if (!include_node_paths) return error.ModuleNotFound;
-
-        // NODE_PATH 폴백: --node-paths로 지정된 추가 경로에서 탐색.
-        // 일반 bare lookup 실패 후, resolve_symlink_siblings 보다 나중에 실행되어야 한다.
-        // pnpm/RN 에서는 real package 옆 peer dependency 가 전역 .pnpm/node_modules 의
-        // 다른 버전보다 우선되어야 Metro/Node 의 package-local 해상도와 맞는다.
-        return self.resolveNodeModulesInNodePaths(pkg_name, subpath);
+        return error.ModuleNotFound;
     }
 
     fn resolveNodeModulesFromNodePaths(self: *Resolver, specifier: []const u8) ResolveError!ResolveResult {
@@ -803,7 +800,7 @@ pub const Resolver = struct {
         };
         defer self.allocator.free(real_source_dir);
         if (std.mem.eql(u8, real_source_dir, source_dir)) return error.ModuleNotFound;
-        return self.resolveNodeModules(real_source_dir, specifier, false);
+        return self.resolveNodeModules(real_source_dir, specifier);
     }
 
     /// 패키지 디렉토리에서 엔트리포인트를 해석한다.

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -37,10 +37,10 @@ pub const ResolveResult = struct {
     /// package.json "module" 필드를 통해 resolve된 파일.
     /// .js 확장자라도 ESM으로 파싱해야 함.
     is_module_field: bool = false,
-    /// `resolveSymlinkSiblings` fallback 으로 realpath 디렉토리에서 sibling 을 찾은 경우,
-    /// 그 모듈의 후속 dependency lookup 도 realpath 디렉토리에서 시작해야 한다.
-    /// null 이면 dirname(path) 를 사용 — esbuild 호환 `preserveSymlinks` 만 켠 경우
-    /// path 가 이미 link path 이므로 dirname(path) 가 자연스럽게 logical lookup root.
+    /// `preserveSymlinks` 로 module identity 는 logical path 로 유지하되,
+    /// `resolveSymlinkSiblings` 에서 symlink target 이 확인된 경우 후속 dependency
+    /// lookup 은 realpath 디렉토리에서 시작해야 한다.
+    /// null 이면 dirname(path) 를 사용한다.
     resolve_dir: ?[]const u8 = null,
 };
 
@@ -302,17 +302,19 @@ pub const Resolver = struct {
     /// 기본값은 테스트용 (브라우저 ESM).
     conditions: []const []const u8 = &.{ "import", "module", "browser", "default" },
     /// symlink 를 따라가지 않고 링크 자체 경로로 해석 (--preserve-symlinks).
-    /// esbuild/Node `--preserve-symlinks` 호환: makeResult() 에서 realpath 호출을
-    /// skip 하고 link path 를 module identity 로 그대로 사용한다.
-    /// 같은 realpath 라도 link path 가 다르면 별도 모듈 인스턴스로 취급된다 — RN/pnpm
-    /// 처럼 peer-dependency 의 sibling 을 realpath 디렉토리에서 찾고 싶다면
-    /// `resolve_symlink_siblings` 도 함께 켠다.
+    /// esbuild/Node `--preserve-symlinks` 호환: makeResult() 에서 link path 를 module
+    /// identity 로 그대로 사용한다. 같은 realpath 라도 link path 가 다르면 별도 모듈
+    /// 인스턴스로 취급된다 — RN/pnpm 처럼 identity 는 logical 로 유지하되 후속 bare
+    /// lookup 을 real package 디렉토리에서 시작하고 싶다면 `resolve_symlink_siblings` 도
+    /// 함께 켠다.
     preserve_symlinks: bool = false,
-    /// bare specifier 의 일반 (logical) `node_modules` 탐색이 실패한 경우,
-    /// `source_dir` 의 realpath 디렉토리에서 다시 한 번 탐색한다.
+    /// `preserve_symlinks` 로 logical path 를 module identity 로 보존하는 경우에도,
+    /// symlink 로 resolve 된 모듈의 후속 bare specifier 는 realpath 디렉토리에서
+    /// 시작할 수 있게 한다.
     /// pnpm 처럼 `app/node_modules/pkg` 가 `.pnpm/.../pkg` 로 symlink 된 환경에서,
     /// `pkg` 의 sibling dependency (예: `code-push`) 가 `.pnpm/.../node_modules/` 에만
-    /// 존재하는 경우 resolve 가 실패하지 않도록 fallback 한다.
+    /// 존재하거나, `.pnpm/node_modules` 의 다른 버전보다 package-local 버전이 우선되어야
+    /// 하는 경우 Metro/Node 와 같은 결과를 만든다.
     /// `preserve_symlinks` 와 직교한 옵션이며, 둘은 함께 켜는 것이 일반적이다.
     resolve_symlink_siblings: bool = false,
     /// `resolveNodeModules` 의 parent dir walk-up 차단 (Metro `resolver.
@@ -484,9 +486,14 @@ pub const Resolver = struct {
 
         // bare specifier → node_modules 탐색
         if (!isRelativeOrAbsolute(effective_specifier)) {
-            return self.resolveNodeModules(source_dir, effective_specifier) catch |err| {
+            return self.resolveNodeModules(source_dir, effective_specifier, false) catch |err| {
                 if (err == error.ModuleNotFound and self.resolve_symlink_siblings) {
                     if (self.resolveNodeModulesFromRealpath(source_dir, effective_specifier)) |r| return r else |fallback_err| {
+                        if (fallback_err != error.ModuleNotFound) return fallback_err;
+                    }
+                }
+                if (err == error.ModuleNotFound and self.node_paths.len > 0) {
+                    if (self.resolveNodeModulesFromNodePaths(effective_specifier)) |r| return r else |fallback_err| {
                         if (fallback_err != error.ModuleNotFound) return fallback_err;
                     }
                 }
@@ -726,7 +733,7 @@ pub const Resolver = struct {
 
     /// bare specifier를 node_modules에서 탐색한다.
     /// source_dir에서 시작하여 상위 디렉토리로 올라가며 node_modules/<pkg>를 찾는다.
-    fn resolveNodeModules(self: *Resolver, source_dir: []const u8, specifier: []const u8) ResolveError!ResolveResult {
+    fn resolveNodeModules(self: *Resolver, source_dir: []const u8, specifier: []const u8, include_node_paths: bool) ResolveError!ResolveResult {
         // 패키지 이름과 서브패스 분리: "@scope/pkg/utils" → ("@scope/pkg", "./utils")
         const split = splitBareSpecifier(specifier);
         const pkg_name = split.pkg_name;
@@ -754,7 +761,21 @@ pub const Resolver = struct {
             current_dir = parent;
         }
 
-        // NODE_PATH 폴백: --node-paths로 지정된 추가 경로에서 탐색
+        if (!include_node_paths) return error.ModuleNotFound;
+
+        // NODE_PATH 폴백: --node-paths로 지정된 추가 경로에서 탐색.
+        // 일반 bare lookup 실패 후, resolve_symlink_siblings 보다 나중에 실행되어야 한다.
+        // pnpm/RN 에서는 real package 옆 peer dependency 가 전역 .pnpm/node_modules 의
+        // 다른 버전보다 우선되어야 Metro/Node 의 package-local 해상도와 맞는다.
+        return self.resolveNodeModulesInNodePaths(pkg_name, subpath);
+    }
+
+    fn resolveNodeModulesFromNodePaths(self: *Resolver, specifier: []const u8) ResolveError!ResolveResult {
+        const split = splitBareSpecifier(specifier);
+        return self.resolveNodeModulesInNodePaths(split.pkg_name, split.subpath);
+    }
+
+    fn resolveNodeModulesInNodePaths(self: *Resolver, pkg_name: []const u8, subpath: []const u8) ResolveError!ResolveResult {
         for (self.node_paths) |np| {
             const pkg_dir_path = std.fs.path.resolve(self.allocator, &.{ np, pkg_name }) catch
                 return error.OutOfMemory;
@@ -782,7 +803,7 @@ pub const Resolver = struct {
         };
         defer self.allocator.free(real_source_dir);
         if (std.mem.eql(u8, real_source_dir, source_dir)) return error.ModuleNotFound;
-        return self.resolveNodeModules(real_source_dir, specifier);
+        return self.resolveNodeModules(real_source_dir, specifier, false);
     }
 
     /// 패키지 디렉토리에서 엔트리포인트를 해석한다.
@@ -892,7 +913,9 @@ pub const Resolver = struct {
     }
 
     fn makeResult(self: *Resolver, path: []const u8) ResolveError!?ResolveResult {
-        // preserve_symlinks=true → realpath 호출 skip, link path 를 그대로 사용 (esbuild/Node).
+        // preserve_symlinks=true → link path 를 module identity 로 그대로 사용 (esbuild/Node).
+        // resolve_symlink_siblings=true 이면 identity 는 유지하되 resolve_dir 만 realpath 로
+        // 기록해 후속 bare lookup 이 pnpm package-local dependency 를 먼저 보게 한다.
         // false → bun(.bun/) / pnpm(.pnpm/) 의 symlink 를 realpath 로 해석해 중첩 node_modules
         // 탐색이 올바른 계층에서 동작하게 한다.
         const resolved = blk: {
@@ -908,11 +931,37 @@ pub const Resolver = struct {
             break :blk fs.realpath(self.allocator, path) catch
                 self.allocator.dupe(u8, path) catch return error.OutOfMemory;
         };
+        errdefer self.allocator.free(resolved);
+        const resolve_dir = if (self.preserve_symlinks and self.resolve_symlink_siblings)
+            try self.realResolveDirForLogicalPath(path, resolved)
+        else
+            null;
+        errdefer if (resolve_dir) |dir| self.allocator.free(dir);
         const ext = std.fs.path.extension(resolved);
         return .{
             .path = resolved,
             .module_type = ModuleType.fromExtension(ext),
+            .resolve_dir = resolve_dir,
         };
+    }
+
+    fn realResolveDirForLogicalPath(self: *Resolver, path: []const u8, logical_path: []const u8) ResolveError!?[]const u8 {
+        const real_path = blk: {
+            var realpath_scope = profile.begin(.resolve_realpath);
+            defer realpath_scope.end();
+            if (self.realpath_cache) |cache| {
+                break :blk cache.resolve(path) catch return error.OutOfMemory;
+            }
+            break :blk fs.realpath(self.allocator, path) catch
+                self.allocator.dupe(u8, path) catch return error.OutOfMemory;
+        };
+        defer self.allocator.free(real_path);
+
+        if (std.mem.eql(u8, real_path, logical_path)) return null;
+        const real_dir = std.fs.path.dirname(real_path) orelse return null;
+        const logical_dir = std.fs.path.dirname(logical_path) orelse return null;
+        if (std.mem.eql(u8, real_dir, logical_dir)) return null;
+        return self.allocator.dupe(u8, real_dir) catch return error.OutOfMemory;
     }
 
     fn fileExists(self: *const Resolver, path: []const u8) bool {

--- a/src/bundler/resolver_test.zig
+++ b/src/bundler/resolver_test.zig
@@ -368,9 +368,12 @@ test "resolve: preserve_symlinks + resolve_symlink_siblings — pnpm 에서 link
     logical_resolver.resolve_symlink_siblings = true;
     const logical_ui = try logical_resolver.resolve(root, "ui");
     defer std.testing.allocator.free(logical_ui.path);
+    defer if (logical_ui.resolve_dir) |dir| std.testing.allocator.free(dir);
     // preserve_symlinks=true → identity 는 link path. `.pnpm` 미포함, `node_modules/ui` 로 끝남.
     try std.testing.expect(std.mem.indexOf(u8, logical_ui.path, ".pnpm") == null);
     try std.testing.expect(pathEndsWith(logical_ui.path, "node_modules/ui/dist/index.js"));
+    try std.testing.expect(logical_ui.resolve_dir != null);
+    try std.testing.expect(std.mem.indexOf(u8, logical_ui.resolve_dir.?, ".pnpm/ui@1_react@18/node_modules/ui/dist") != null);
 
     const logical_ui_dir = std.fs.path.dirname(logical_ui.path).?;
     // peer dependency dedupe: lookup root 는 link path → walk up 으로 root node_modules/react 도달.
@@ -383,11 +386,112 @@ test "resolve: preserve_symlinks + resolve_symlink_siblings — pnpm 에서 link
     // resolve_symlink_siblings fallback 으로 `.pnpm/.../node_modules/code-push` 발견.
     const package_owned_dep = try logical_resolver.resolve(logical_ui_dir, "code-push");
     defer std.testing.allocator.free(package_owned_dep.path);
+    defer if (package_owned_dep.resolve_dir) |dir| std.testing.allocator.free(dir);
     try std.testing.expect(std.mem.indexOf(u8, package_owned_dep.path, ".pnpm/ui@1_react@18/node_modules/code-push") != null);
 
     const package_owned_subpath = try logical_resolver.resolve(logical_ui_dir, "code-push/script/acquisition-sdk");
     defer std.testing.allocator.free(package_owned_subpath.path);
+    defer if (package_owned_subpath.resolve_dir) |dir| std.testing.allocator.free(dir);
     try std.testing.expect(std.mem.indexOf(u8, package_owned_subpath.path, ".pnpm/ui@1_react@18/node_modules/code-push/script/acquisition-sdk.js") != null);
+}
+
+test "resolve: preserve_symlinks sibling fallback beats global node_paths version" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("apps/app/node_modules/@scope");
+    try writeFile(tmp.dir, "node_modules/.pnpm/pkg@1/node_modules/@scope/pkg/package.json", "{\"main\":\"dist/index.js\"}");
+    try createFile(tmp.dir, "node_modules/.pnpm/pkg@1/node_modules/@scope/pkg/dist/index.js");
+    try writeFile(tmp.dir, "node_modules/.pnpm/pkg@1/node_modules/dep/package.json", "{\"main\":\"index.js\"}");
+    try createFile(tmp.dir, "node_modules/.pnpm/pkg@1/node_modules/dep/index.js");
+    try writeFile(tmp.dir, "node_modules/.pnpm/node_modules/dep/package.json", "{\"main\":\"index.js\"}");
+    try createFile(tmp.dir, "node_modules/.pnpm/node_modules/dep/index.js");
+
+    tmp.dir.symLink(
+        "../../../../node_modules/.pnpm/pkg@1/node_modules/@scope/pkg",
+        "apps/app/node_modules/@scope/pkg",
+        .{ .is_directory = true },
+    ) catch |err| switch (err) {
+        error.AccessDenied, error.PermissionDenied => return error.SkipZigTest,
+        else => return err,
+    };
+
+    const app_root = try tmp.dir.realpathAlloc(std.testing.allocator, "apps/app");
+    defer std.testing.allocator.free(app_root);
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+    const pnpm_global = try std.fs.path.resolve(std.testing.allocator, &.{ root, "node_modules/.pnpm/node_modules" });
+    defer std.testing.allocator.free(pnpm_global);
+    const node_paths = [_][]const u8{pnpm_global};
+
+    var resolver = Resolver.init(std.testing.allocator);
+    resolver.preserve_symlinks = true;
+    resolver.resolve_symlink_siblings = true;
+    resolver.node_paths = &node_paths;
+
+    const pkg = try resolver.resolve(app_root, "@scope/pkg");
+    defer std.testing.allocator.free(pkg.path);
+    defer if (pkg.resolve_dir) |dir| std.testing.allocator.free(dir);
+    try std.testing.expect(pathEndsWith(pkg.path, "apps/app/node_modules/@scope/pkg/dist/index.js"));
+
+    const pkg_dir = std.fs.path.dirname(pkg.path).?;
+    const dep = try resolver.resolve(pkg_dir, "dep");
+    defer std.testing.allocator.free(dep.path);
+    defer if (dep.resolve_dir) |dir| std.testing.allocator.free(dir);
+    try std.testing.expect(std.mem.indexOf(u8, dep.path, ".pnpm/pkg@1/node_modules/dep/index.js") != null);
+    try std.testing.expect(std.mem.indexOf(u8, dep.path, ".pnpm/node_modules/dep/index.js") == null);
+}
+
+test "resolve: global node_paths symlink records real resolve_dir before hoisted dependency" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("apps/app");
+    try tmp.dir.makePath("node_modules/.pnpm/node_modules");
+    try writeFile(tmp.dir, "node_modules/.pnpm/pkg@1/node_modules/pkg/package.json", "{\"main\":\"index.js\"}");
+    try writeFile(tmp.dir, "node_modules/.pnpm/pkg@1/node_modules/pkg/index.js", "exports.value = require('dep').value;");
+    try writeFile(tmp.dir, "node_modules/.pnpm/pkg@1/node_modules/dep/package.json", "{\"main\":\"index.js\"}");
+    try writeFile(tmp.dir, "node_modules/.pnpm/pkg@1/node_modules/dep/index.js", "exports.value = 'local';");
+    try writeFile(tmp.dir, "node_modules/.pnpm/node_modules/dep/package.json", "{\"main\":\"index.js\"}");
+    try writeFile(tmp.dir, "node_modules/.pnpm/node_modules/dep/index.js", "exports.value = 'global';");
+
+    tmp.dir.symLink(
+        "../pkg@1/node_modules/pkg",
+        "node_modules/.pnpm/node_modules/pkg",
+        .{ .is_directory = true },
+    ) catch |err| switch (err) {
+        error.AccessDenied, error.PermissionDenied => return error.SkipZigTest,
+        else => return err,
+    };
+
+    const app_root = try tmp.dir.realpathAlloc(std.testing.allocator, "apps/app");
+    defer std.testing.allocator.free(app_root);
+    const root = try tmp.dir.realpathAlloc(std.testing.allocator, ".");
+    defer std.testing.allocator.free(root);
+    const pnpm_global = try std.fs.path.resolve(std.testing.allocator, &.{ root, "node_modules/.pnpm/node_modules" });
+    defer std.testing.allocator.free(pnpm_global);
+    const node_paths = [_][]const u8{pnpm_global};
+
+    var resolver = Resolver.init(std.testing.allocator);
+    resolver.preserve_symlinks = true;
+    resolver.resolve_symlink_siblings = true;
+    resolver.node_paths = &node_paths;
+
+    const pkg = try resolver.resolve(app_root, "pkg");
+    defer std.testing.allocator.free(pkg.path);
+    defer if (pkg.resolve_dir) |dir| std.testing.allocator.free(dir);
+
+    try std.testing.expect(std.mem.indexOf(u8, pkg.path, "node_modules/.pnpm/node_modules/pkg/index.js") != null);
+    try std.testing.expect(pkg.resolve_dir != null);
+    try std.testing.expect(std.mem.indexOf(u8, pkg.resolve_dir.?, "node_modules/.pnpm/pkg@1/node_modules/pkg") != null);
+
+    const dep_source_dir = pkg.resolve_dir orelse std.fs.path.dirname(pkg.path).?;
+    const dep = try resolver.resolve(dep_source_dir, "dep");
+    defer std.testing.allocator.free(dep.path);
+    defer if (dep.resolve_dir) |dir| std.testing.allocator.free(dir);
+
+    try std.testing.expect(std.mem.indexOf(u8, dep.path, "node_modules/.pnpm/pkg@1/node_modules/dep/index.js") != null);
+    try std.testing.expect(std.mem.indexOf(u8, dep.path, "node_modules/.pnpm/node_modules/dep/index.js") == null);
 }
 
 test "resolve: bare specifier walk up directories" {

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -247,13 +247,13 @@ fn staticMemberParts(ast: *const Ast, idx: NodeIndex) ?struct { object: NodeInde
 }
 
 /// top-level `BASE.PROP = RHS;` (단순 `=` 대입, LHS 정적 멤버, BASE 단일
-/// identifier) 의 base identifier / rhs 노드. 아니면 null.
+/// identifier) 의 base/property identifier / rhs 노드. 아니면 null.
 /// `gatedMemberAugmentObjectNode` 가 RHS 순수성·글로벌 검사를 덧붙이는
 /// 공통 구조 추출 코어 (#3359 중복 제거).
 fn memberAssignTargetParts(
     ast: *const Ast,
     stmt_node: Node,
-) ?struct { base: NodeIndex, rhs: NodeIndex } {
+) ?struct { base: NodeIndex, property: NodeIndex, rhs: NodeIndex } {
     if (stmt_node.tag != .expression_statement) return null;
     const expr_idx = stmt_node.data.unary.operand;
     if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return null;
@@ -266,7 +266,34 @@ fn memberAssignTargetParts(
     const parts = staticMemberParts(ast, expr.data.binary.left) orelse return null;
     const obj = ast.nodes.items[@intFromEnum(parts.object)];
     if (obj.tag != .identifier_reference) return null;
-    return .{ .base = parts.object, .rhs = expr.data.binary.right };
+    return .{ .base = parts.object, .property = parts.property, .rhs = expr.data.binary.right };
+}
+
+fn isWorkletMetadataProperty(name: []const u8) bool {
+    return std.mem.eql(u8, name, "__workletHash") or
+        std.mem.eql(u8, name, "__closure") or
+        std.mem.eql(u8, name, "__initData") or
+        std.mem.eql(u8, name, "__stackDetails") or
+        std.mem.eql(u8, name, "__pluginVersion") or
+        std.mem.eql(u8, name, "__bundleData");
+}
+
+fn workletMetadataObjectNode(
+    ast: *const Ast,
+    stmt_node: Node,
+    unresolved_globals: ?*const purity.GlobalRefSet,
+) ?NodeIndex {
+    const m = memberAssignTargetParts(ast, stmt_node) orelse return null;
+    const obj = ast.nodes.items[@intFromEnum(m.base)];
+
+    if (unresolved_globals) |globals| {
+        if (globals.contains(ast.getText(obj.span))) return null;
+    }
+
+    const prop = ast.nodes.items[@intFromEnum(m.property)];
+    if (prop.tag != .identifier_reference) return null;
+    if (!isWorkletMetadataProperty(ast.getText(prop.span))) return null;
+    return m.base;
 }
 
 fn isModuleExportsLhs(ast: *const Ast, lhs: NodeIndex) bool {
@@ -1086,6 +1113,9 @@ fn finalizeBucket(
 ///   - LHS = static_member_expression, base object = 단일 identifier_reference.
 ///   - base 가 이 모듈 top-level (scope_id == 0) 비-import 로컬 심볼 X.
 ///   - RHS 가 purity.isExprPure (PURE 주석 존중).
+///   - 예외: Reanimated/Babel worklet metadata (`X.__workletHash`,
+///     `X.__closure` 등)는 synthetic 함수 부속 데이터라 RHS 가 class static read 를
+///     포함해 일반 purity 를 통과하지 못해도 X 의 augmentation 으로 귀속한다.
 /// 구조적 매칭만 수행 (심볼 해석 제외) — 매칭 시 base object 의 identifier
 /// NodeIndex 를 반환. 호출자가 symbol_ids (build) 또는 references
 /// (buildFromSemantic) 로 심볼을 해석하고 scope_id==0 + 비-import 를 검증한다.
@@ -1100,6 +1130,11 @@ fn gatedMemberAugmentObjectNode(
     // base 가 unresolved global (`window.x = ...`) 이면 글로벌 변이 — 제외.
     if (unresolved_globals) |globals| {
         if (globals.contains(ast.getText(obj.span))) return null;
+    }
+
+    const prop = ast.nodes.items[@intFromEnum(m.property)];
+    if (prop.tag == .identifier_reference and isWorkletMetadataProperty(ast.getText(prop.span))) {
+        return m.base;
     }
 
     // RHS 순수성 (three 의 mergeUniforms 는 /*@__PURE__*/ 주석으로 pure 판정).
@@ -1118,6 +1153,36 @@ fn validateMemberAugmentBaseSymbol(symbols: []const Symbol, x_sym: u32) ?u32 {
     return x_sym;
 }
 
+fn findUniqueTopLevelLocalSymbolByName(ast: *const Ast, symbols: []const Symbol, name: []const u8) ?u32 {
+    var found: ?u32 = null;
+    for (symbols, 0..) |*sym, sym_idx| {
+        if (@intFromEnum(sym.scope_id) != 0) continue;
+        if (sym.decl_flags.is_import) continue;
+        if (!std.mem.eql(u8, sym.nameText(ast.source), name)) continue;
+        if (found != null) return null;
+        found = @intCast(sym_idx);
+    }
+    return found;
+}
+
+fn memberAugmentSymbolFromObjectNode(
+    ast: *const Ast,
+    obj_node: NodeIndex,
+    symbol_ids: []const ?u32,
+    symbols: []const Symbol,
+) ?u32 {
+    const obj_node_i = @intFromEnum(obj_node);
+    if (obj_node_i < symbol_ids.len) {
+        if (symbol_ids[obj_node_i]) |x_sym| {
+            return validateMemberAugmentBaseSymbol(symbols, x_sym);
+        }
+    }
+    if (obj_node_i >= ast.nodes.items.len) return null;
+    const obj = ast.nodes.items[obj_node_i];
+    if (obj.tag != .identifier_reference) return null;
+    return findUniqueTopLevelLocalSymbolByName(ast, symbols, ast.getText(obj.span));
+}
+
 /// `build` (symbol_ids 보유) 경로용 thin wrapper.
 fn gatedMemberAugmentSymbol(
     ast: *const Ast,
@@ -1127,10 +1192,18 @@ fn gatedMemberAugmentSymbol(
     unresolved_globals: ?*const purity.GlobalRefSet,
 ) ?u32 {
     const obj_node = gatedMemberAugmentObjectNode(ast, stmt_node, unresolved_globals) orelse return null;
-    const obj_node_i = @intFromEnum(obj_node);
-    if (obj_node_i >= symbol_ids.len) return null;
-    const x_sym = symbol_ids[obj_node_i] orelse return null;
-    return validateMemberAugmentBaseSymbol(symbols, x_sym);
+    return memberAugmentSymbolFromObjectNode(ast, obj_node, symbol_ids, symbols);
+}
+
+fn workletMetadataSymbol(
+    ast: *const Ast,
+    stmt_node: Node,
+    symbol_ids: []const ?u32,
+    symbols: []const Symbol,
+    unresolved_globals: ?*const purity.GlobalRefSet,
+) ?u32 {
+    const obj_node = workletMetadataObjectNode(ast, stmt_node, unresolved_globals) orelse return null;
+    return memberAugmentSymbolFromObjectNode(ast, obj_node, symbol_ids, symbols);
 }
 
 /// 두 builder (buildFromSemantic / build) 의 per-stmt Phase 1 본체.
@@ -1267,12 +1340,16 @@ pub fn buildFromSemantic(
             null,
         );
 
-        if (gate_member_augment and stmts[stmt_i].has_side_effects and ni < ast.nodes.items.len) {
-            if (gatedMemberAugmentObjectNode(
-                ast,
-                ast.nodes.items[ni],
-                unresolved_globals,
-            )) |obj_node| {
+        if (stmts[stmt_i].has_side_effects and ni < ast.nodes.items.len) {
+            const stmt_node = ast.nodes.items[ni];
+            const augment_obj_node =
+                workletMetadataObjectNode(ast, stmt_node, unresolved_globals) orelse
+                if (gate_member_augment)
+                    gatedMemberAugmentObjectNode(ast, stmt_node, unresolved_globals)
+                else
+                    null;
+
+            if (augment_obj_node) |obj_node| {
                 // has_side_effects 해제는 base 가 top-level 로컬임을 references
                 // 패스에서 확정한 뒤에 한다 (조건부). 우선 후보로만 등록.
                 try member_augment_obj_to_stmt.put(allocator, @intFromEnum(obj_node), @intCast(stmt_i));
@@ -1338,6 +1415,23 @@ pub fn buildFromSemantic(
                 try writer_buckets[sym_u32].append(allocator, r.stmt_idx);
             }
         }
+    }
+
+    // Transformer/plugin generated nodes can be appended after the first semantic
+    // pass. A later resync normally records references for them, but generated
+    // string-table identifiers are still allowed to miss the reference pass in
+    // older plugin paths. Resolve remaining member-augment candidates by name,
+    // but only when the name maps to one unique top-level local binding.
+    var remaining_augment_it = member_augment_obj_to_stmt.iterator();
+    while (remaining_augment_it.next()) |entry| {
+        const obj_idx: NodeIndex = @enumFromInt(entry.key_ptr.*);
+        if (@intFromEnum(obj_idx) >= ast.nodes.items.len) continue;
+        const obj = ast.nodes.items[@intFromEnum(obj_idx)];
+        if (obj.tag != .identifier_reference) continue;
+        const x_sym = findUniqueTopLevelLocalSymbolByName(ast, symbols, ast.getText(obj.span)) orelse continue;
+        const aug_stmt = entry.value_ptr.*;
+        stmts[aug_stmt].has_side_effects = false;
+        try writer_buckets[x_sym].append(allocator, aug_stmt);
     }
 
     // Pass 3a: declared bucket → sort + dedupe → stmts[i].declared_symbols + sym_to_stmt 역매핑.
@@ -1483,16 +1577,18 @@ pub fn build(
         // member-augment 귀속: 게이트 ON + has_side_effects 로 분류된
         // top-level `X.member = pureRHS` 만 대상. CJS export fact 로 이미
         // 안전 처리된 stmt (has_side_effects=false) 는 건드리지 않는다.
-        if (gate_member_augment and stmts[stmt_i].has_side_effects and ni < ast.nodes.items.len) {
-            if (gatedMemberAugmentSymbol(
-                ast,
-                ast.nodes.items[ni],
-                symbol_ids,
-                symbols,
-                unresolved_globals,
-            )) |x_sym| {
+        if (stmts[stmt_i].has_side_effects and ni < ast.nodes.items.len) {
+            const stmt_node = ast.nodes.items[ni];
+            const x_sym =
+                workletMetadataSymbol(ast, stmt_node, symbol_ids, symbols, unresolved_globals) orelse
+                if (gate_member_augment)
+                    gatedMemberAugmentSymbol(ast, stmt_node, symbol_ids, symbols, unresolved_globals)
+                else
+                    null;
+
+            if (x_sym) |sym| {
                 stmts[stmt_i].has_side_effects = false;
-                try member_augment_pairs.append(allocator, .{ @intCast(stmt_i), x_sym });
+                try member_augment_pairs.append(allocator, .{ @intCast(stmt_i), sym });
             }
         }
     }

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -269,6 +269,12 @@ fn memberAssignTargetParts(
     return .{ .base = parts.object, .property = parts.property, .rhs = expr.data.binary.right };
 }
 
+/// Reanimated/react-native-worklets Babel plugin 이 worklet 함수에 부착하는
+/// 메타데이터 프로퍼티. ZNTC native worklet 변환 (`transformer/worklet.zig`) 은
+/// 앞 3 개 (`__workletHash`, `__closure`, `__initData`) 만 emit 하고, 나머지는
+/// 외부 Babel plugin 산출물을 인식해 base symbol augmentation 으로 함께 tree-shake
+/// 하기 위해 reserve 한 이름들이다. `__bundleData` 는 react-native-worklets 의
+/// bundle worklet (worklet body 가 별도 번들로 빌드되는 모드) 출력.
 fn isWorkletMetadataProperty(name: []const u8) bool {
     return std.mem.eql(u8, name, "__workletHash") or
         std.mem.eql(u8, name, "__closure") or

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -1253,6 +1253,7 @@ pub const TreeShaker = struct {
             var enqueue_scope = profile.begin(.shake_fixpoint_bfs_seed_export_enqueue_symbol);
             defer enqueue_scope.end();
 
+            try self.seedEvaluatedModuleSideEffectStmts(target_u32, target_infos, queue, reachable_stmts);
             try self.enqueueSymbolLiveStatements(target_u32, target_infos, direct_sym, reachable_stmts, queue);
         }
 
@@ -1357,6 +1358,9 @@ pub const TreeShaker = struct {
 
             try self.markExportUsed(@intCast(target_mod), imported_name);
             self.included.set(target_mod);
+            if (module_stmt_infos[target_mod]) |mid_infos| {
+                try self.seedEvaluatedModuleSideEffectStmts(@intCast(target_mod), mid_infos, queue, reachable_stmts);
+            }
             // 중간 모듈의 export 선언 statement도 reachable로 마킹
             const mid_module = self.getModule(@intCast(target_mod)).?.*;
             if (mid_module.semantic) |mid_sem| {
@@ -1407,10 +1411,14 @@ pub const TreeShaker = struct {
             var enqueue_scope = profile.begin(.shake_fixpoint_bfs_seed_export_enqueue_symbol);
             defer enqueue_scope.end();
 
+            // A live ESM export means this module is evaluated. `sideEffects:false`
+            // can drop unused modules, but it must not remove observable
+            // top-level initialization inside an evaluated module.
+            try self.seedEvaluatedModuleSideEffectStmts(@intCast(canon_mod), target_infos, queue, reachable_stmts);
             try self.enqueueSymbolLiveStatements(@intCast(canon_mod), target_infos, @intCast(sym_idx), reachable_stmts, queue);
         }
 
-        // side-effect statement는 enqueueStmt에서 lazy 시드됨
+        // Symbol-attached side-effect statements are also lazily seeded by enqueue().
     }
 
     fn seedCjsExportOrAll(
@@ -1726,6 +1734,35 @@ pub const TreeShaker = struct {
         }
         for (infos.stmts, 0..) |stmt, si| {
             if (!stmt.has_side_effects) continue;
+            try self.enqueue(mod_idx, @intCast(si), reachable_stmts, queue);
+        }
+    }
+
+    fn seedEvaluatedModuleSideEffectStmts(
+        self: *TreeShaker,
+        mod_idx: u32,
+        infos: StmtInfos,
+        queue: *std.ArrayListUnmanaged(BfsItem),
+        reachable_stmts: []?std.DynamicBitSet,
+    ) std.mem.Allocator.Error!void {
+        self.included.set(mod_idx);
+        if (reachable_stmts[mod_idx] == null) {
+            reachable_stmts[mod_idx] = try std.DynamicBitSet.initEmpty(self.allocator, infos.stmts.len);
+        }
+
+        const m = self.getModule(mod_idx);
+        const ast = if (m) |module| module.ast else null;
+        for (infos.stmts, 0..) |stmt, si| {
+            if (!stmt.has_side_effects) continue;
+            if (ast) |module_ast| {
+                const ni: usize = stmt.node_idx;
+                if (ni < module_ast.nodes.items.len) {
+                    switch (module_ast.nodes.items[ni].tag) {
+                        .export_all_declaration => continue,
+                        else => {},
+                    }
+                }
+            }
             try self.enqueue(mod_idx, @intCast(si), reachable_stmts, queue);
         }
     }

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -1253,7 +1253,7 @@ pub const TreeShaker = struct {
             var enqueue_scope = profile.begin(.shake_fixpoint_bfs_seed_export_enqueue_symbol);
             defer enqueue_scope.end();
 
-            try self.seedEvaluatedModuleSideEffectStmts(target_u32, target_infos, queue, reachable_stmts);
+            try self.seedSideEffectStmts(target_u32, target_infos, queue, reachable_stmts);
             try self.enqueueSymbolLiveStatements(target_u32, target_infos, direct_sym, reachable_stmts, queue);
         }
 
@@ -1359,7 +1359,7 @@ pub const TreeShaker = struct {
             try self.markExportUsed(@intCast(target_mod), imported_name);
             self.included.set(target_mod);
             if (module_stmt_infos[target_mod]) |mid_infos| {
-                try self.seedEvaluatedModuleSideEffectStmts(@intCast(target_mod), mid_infos, queue, reachable_stmts);
+                try self.seedSideEffectStmts(@intCast(target_mod), mid_infos, queue, reachable_stmts);
             }
             // 중간 모듈의 export 선언 statement도 reachable로 마킹
             const mid_module = self.getModule(@intCast(target_mod)).?.*;
@@ -1414,7 +1414,7 @@ pub const TreeShaker = struct {
             // A live ESM export means this module is evaluated. `sideEffects:false`
             // can drop unused modules, but it must not remove observable
             // top-level initialization inside an evaluated module.
-            try self.seedEvaluatedModuleSideEffectStmts(@intCast(canon_mod), target_infos, queue, reachable_stmts);
+            try self.seedSideEffectStmts(@intCast(canon_mod), target_infos, queue, reachable_stmts);
             try self.enqueueSymbolLiveStatements(@intCast(canon_mod), target_infos, @intCast(sym_idx), reachable_stmts, queue);
         }
 
@@ -1721,24 +1721,10 @@ pub const TreeShaker = struct {
         try self.seedModuleExportsRequireProxyTargetsAll(mod_idx, queue, module_stmt_infos, reachable_stmts);
     }
 
+    /// 평가되는 모듈의 top-level side-effect statement 를 seed. `export_all_declaration`
+    /// 은 re-export 알고리즘이 별도 처리하므로 여기서는 제외 (CJS 컨텍스트에는 등장하지
+    /// 않아 no-op).
     fn seedSideEffectStmts(
-        self: *TreeShaker,
-        mod_idx: u32,
-        infos: StmtInfos,
-        queue: *std.ArrayListUnmanaged(BfsItem),
-        reachable_stmts: []?std.DynamicBitSet,
-    ) std.mem.Allocator.Error!void {
-        self.included.set(mod_idx);
-        if (reachable_stmts[mod_idx] == null) {
-            reachable_stmts[mod_idx] = try std.DynamicBitSet.initEmpty(self.allocator, infos.stmts.len);
-        }
-        for (infos.stmts, 0..) |stmt, si| {
-            if (!stmt.has_side_effects) continue;
-            try self.enqueue(mod_idx, @intCast(si), reachable_stmts, queue);
-        }
-    }
-
-    fn seedEvaluatedModuleSideEffectStmts(
         self: *TreeShaker,
         mod_idx: u32,
         infos: StmtInfos,

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -78,9 +78,8 @@ pub const Codegen = struct {
     /// 모든 call expression 에 대해 호출되므로, 해당 종류의 record 가 없으면 O(1) 로 빠짐.
     has_glob_records: bool = false,
     has_require_context_records: bool = false,
-    /// `cjs_wrap_substitute` 가 active 일 때 module body 에서 unresolved `module` reference 를
-    /// 만나 `m` 으로 substitute 한 적이 있는지. emitter 가 wrapper param 결정 시 참조 —
-    /// false 면 `(e)` 1 인자, true 면 `(e,m)` 유지.
+    /// Legacy `cjs_wrap_substitute` path 에서 module body 의 unresolved `module`
+    /// reference 를 substitute 한 적이 있는지 추적.
     cjs_wrap_module_used: bool = false,
     pub fn init(allocator: std.mem.Allocator, ast: *const Ast) Codegen {
         return initWithOptions(allocator, ast, .{});

--- a/src/codegen/codegen.zig
+++ b/src/codegen/codegen.zig
@@ -78,9 +78,6 @@ pub const Codegen = struct {
     /// 모든 call expression 에 대해 호출되므로, 해당 종류의 record 가 없으면 O(1) 로 빠짐.
     has_glob_records: bool = false,
     has_require_context_records: bool = false,
-    /// Legacy `cjs_wrap_substitute` path 에서 module body 의 unresolved `module`
-    /// reference 를 substitute 한 적이 있는지 추적.
-    cjs_wrap_module_used: bool = false,
     pub fn init(allocator: std.mem.Allocator, ast: *const Ast) Codegen {
         return initWithOptions(allocator, ast, .{});
     }

--- a/src/codegen/codegen_test/basic.zig
+++ b/src/codegen/codegen_test/basic.zig
@@ -8,6 +8,14 @@ const e2eWithOptions = helpers.e2eWithOptions;
 const e2eSourceMap = helpers.e2eSourceMap;
 const TransformOptions = helpers.TransformOptions;
 const CodegenOptions = helpers.CodegenOptions;
+const Scanner = helpers.Scanner;
+const Parser = helpers.Parser;
+const Transformer = helpers.Transformer;
+const Codegen = helpers.Codegen;
+const TestResult = helpers.TestResult;
+const NodeIndex = @import("../../parser/ast.zig").NodeIndex;
+const SemanticAnalyzer = @import("../../semantic/analyzer.zig").SemanticAnalyzer;
+const LinkingMetadata = @import("../../bundler/linker.zig").LinkingMetadata;
 
 test "Codegen: empty program" {
     var r = try e2e(std.testing.allocator, "");
@@ -137,6 +145,73 @@ test "Codegen: enum with initializer" {
     );
 }
 
+fn e2eEnumWithRename(backing_allocator: std.mem.Allocator, source: []const u8, renamed: []const u8) !TestResult {
+    var arena = std.heap.ArenaAllocator.init(backing_allocator);
+    errdefer arena.deinit();
+    const allocator = arena.allocator();
+
+    var scanner = try Scanner.init(allocator, source);
+    var parser = Parser.init(allocator, &scanner);
+    parser.configureFromExtension(".ts");
+    _ = try parser.parse();
+
+    var analyzer = SemanticAnalyzer.init(allocator, &parser.ast);
+    analyzer.is_strict_mode = parser.is_strict_mode;
+    analyzer.is_module = parser.is_module;
+    analyzer.is_ts = parser.source_mode == .ts;
+    analyzer.is_flow = parser.is_flow;
+    try analyzer.analyze();
+
+    var transformer = try Transformer.init(allocator, &parser.ast, .{});
+    try transformer.initSymbolIds(analyzer.symbol_ids.items);
+    transformer.symbols = analyzer.symbols.items;
+    transformer.references = analyzer.references.items;
+    const root = try transformer.transform();
+
+    const root_node = transformer.ast.getNode(root);
+    const list = root_node.data.list;
+    var enum_name_idx: NodeIndex = .none;
+    for (transformer.ast.extra_data.items[list.start .. list.start + list.len]) |raw_idx| {
+        const stmt_idx: NodeIndex = @enumFromInt(raw_idx);
+        const stmt = transformer.ast.getNode(stmt_idx);
+        if (stmt.tag == .ts_enum_declaration) {
+            enum_name_idx = @enumFromInt(transformer.ast.extra_data.items[stmt.data.extra]);
+            break;
+        }
+    }
+    if (enum_name_idx.isNone()) return error.MissingEnumDeclaration;
+    const enum_symbol_id = transformer.symbol_ids.items[@intFromEnum(enum_name_idx)] orelse return error.MissingEnumSymbol;
+
+    const skip = try std.DynamicBitSet.initEmpty(allocator, transformer.ast.nodes.items.len);
+    var renames = std.AutoHashMap(u32, []const u8).init(allocator);
+    try renames.put(enum_symbol_id, renamed);
+    var md: LinkingMetadata = .{
+        .skip_nodes = skip,
+        .renames = renames,
+        .final_exports = null,
+        .symbol_ids = transformer.symbol_ids.items,
+        .allocator = allocator,
+    };
+    defer md.deinit();
+
+    var cg = Codegen.initWithOptions(allocator, transformer.ast, .{
+        .minify_whitespace = true,
+        .esm_var_assign_only = true,
+        .linking_metadata = &md,
+    });
+    const output = try cg.generate(root);
+    return .{ .output = output, .arena = arena };
+}
+
+test "Codegen: enum IIFE uses renamed binding in esm assignment mode" {
+    var r = try e2eEnumWithRename(std.testing.allocator, "enum RuntimeKind { ReactNative = 1, UI = 2 }", "Tv");
+    defer r.deinit();
+
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Tv = /* @__PURE__ */") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, ")(Tv || {});") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "RuntimeKind = /* @__PURE__ */") == null);
+}
+
 test "Codegen: const enum removed" {
     var r = try e2e(std.testing.allocator, "const enum Dir { Up, Down }");
     defer r.deinit();
@@ -238,6 +313,17 @@ test "Codegen #1564: for-of inside outer for-init preserves in_for_init" {
     );
     defer r.deinit();
     try std.testing.expect(std.mem.indexOf(u8, r.output, ";;") == null);
+}
+
+test "Codegen: for-init context does not leak into nested function body" {
+    var r = try e2eWithOptions(
+        std.testing.allocator,
+        "for (var a = function () { var b = g(); if (Object(b) === b) { return b; } return this; }, i = 0; i < 1; i++) {}",
+        .{ .minify_whitespace = true, .minify_syntax = true },
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "g()return") == null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "var b=g();return") != null);
 }
 
 test "Codegen #1564: let/const mixed with nested for-in" {

--- a/src/codegen/codegen_test/minify_sourcemap.zig
+++ b/src/codegen/codegen_test/minify_sourcemap.zig
@@ -82,6 +82,18 @@ test "Minify: omits trailing semicolon before block boundary" {
     try std.testing.expectEqualStrings("function f(){let x=1;x++}f();", r.output);
 }
 
+test "Minify: keeps empty for body semicolon before block boundary" {
+    var r = try e2eWithOptions(std.testing.allocator, "function f() { try { for (; a; b++); } catch (e) {} }", .{ .minify_whitespace = true, .minify_syntax = true });
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "for(;a;b++);}") != null);
+}
+
+test "Minify: keeps nested empty for body semicolon before block boundary" {
+    var r = try e2eWithOptions(std.testing.allocator, "function f() { try { if (a) b(); else for (; c; d++); } catch (e) {} }", .{ .minify_whitespace = true, .minify_syntax = true });
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "else for(;c;d++);}") != null);
+}
+
 test "Minify: keeps semicolon between adjacent block statements" {
     var r = try e2eWithOptions(std.testing.allocator, "for (var i = 0; i < 3; i++) { var x = i; console.log(x); }", .{ .minify_whitespace = true, .minify_syntax = true });
     defer r.deinit();

--- a/src/codegen/function_class.zig
+++ b/src/codegen/function_class.zig
@@ -7,6 +7,18 @@ const NodeIndex = ast_mod.NodeIndex;
 const debug_metadata = @import("debug_metadata.zig");
 const statement_emit = @import("statements.zig");
 
+fn emitNestedExecutionBody(self: anytype, body: NodeIndex) !void {
+    const saved_for_init = self.in_for_init;
+    const saved_skip_var_init = self.skip_var_init;
+    self.in_for_init = false;
+    self.skip_var_init = false;
+    defer {
+        self.in_for_init = saved_for_init;
+        self.skip_var_init = saved_skip_var_init;
+    }
+    try self.emitNode(body);
+}
+
 /// keepNames: name 노드가 rename되었으면 (original_name, new_name) 쌍을 수집.
 /// emitter가 코드젠 완료 후 __name(newName, "originalName") 호출을 append.
 fn collectKeepNameEntry(self: anytype, name_idx: NodeIndex) void {
@@ -119,7 +131,7 @@ pub fn emitFunction(self: anytype, node: Node) !void {
     try self.writeByte('(');
     try self.emitNodeList(params_start, params_len, ",");
     try self.writeByte(')');
-    try self.emitNode(body);
+    try emitNestedExecutionBody(self, body);
 
     // #1751: assignment 로 변환된 form 은 expression statement 라서 `;` 종결 필요.
     // 다음 statement 가 directive ("use strict") 처럼 ASI 로 구분 안 되는 경우
@@ -178,7 +190,7 @@ pub fn emitArrow(self: anytype, node: Node) !void {
     // expression (member/binary/conditional 의 left chain) 을 검사.
     const needs_paren = !is_block_body and !body.isNone() and expressionStartsWithBrace(self, body);
     if (needs_paren) try self.writeByte('(');
-    try self.emitNode(body);
+    try emitNestedExecutionBody(self, body);
     if (needs_paren) try self.writeByte(')');
 }
 
@@ -310,7 +322,7 @@ pub fn emitClass(self: anytype, node: Node) !void {
         try self.write(" extends ");
         try self.emitNode(super_class);
     }
-    try self.emitNode(body);
+    try emitNestedExecutionBody(self, body);
 
     if (convert_to_assign or convert_to_var_class_expr) {
         try self.writeByte(';');
@@ -338,7 +350,7 @@ pub fn emitStaticBlock(self: anytype, node: Node) !void {
     }
     try self.write("static");
     try self.writeSpace();
-    try self.emitNode(node.data.unary.operand);
+    try emitNestedExecutionBody(self, node.data.unary.operand);
 }
 
 pub fn emitMethodDef(self: anytype, node: Node) !void {
@@ -379,7 +391,7 @@ pub fn emitMethodDef(self: anytype, node: Node) !void {
     try self.writeByte('(');
     try self.emitNodeList(params_start, params_len, ",");
     try self.writeByte(')');
-    try self.emitNode(body);
+    try emitNestedExecutionBody(self, body);
 }
 
 pub fn emitPropertyDef(self: anytype, node: Node) !void {

--- a/src/codegen/mangler.zig
+++ b/src/codegen/mangler.zig
@@ -601,9 +601,9 @@ fn reserveNameFor(reserved: *std.StringHashMap(void), sym: Symbol, name: []const
 // ============================================================
 
 pub fn isReservedOrGlobal(name: []const u8) bool {
-    // CJS wrap callback param 단축 이름 (`(e, m) => {...}`) — emitter 의 `cjs_wrap_substitute`
-    // 가 wrapper body 의 unresolved `exports`/`module` 을 `e`/`m` 로 substitute 한다.
-    // mangler 가 다른 binding 에 같은 이름을 부여하면 wrapper param 과 redeclare/shadow.
+    // Legacy CJS wrap alias path 의 단축 이름 (`e`, `m`). Bundler 기본 경로는
+    // Node/Metro 호환성을 위해 `(exports, module)` 을 유지하지만, 별도 alias 경로가
+    // 켜질 때 mangler 가 같은 이름을 부여하지 않도록 보존한다.
     if (name.len == 1 and (name[0] == 'e' or name[0] == 'm')) return true;
     // JS 예약어 + 리터럴 + 글로벌 (길이 2~6만 체크 — 1글자는 'e'/'m' 외엔 충돌 없고
     // 7글자+는 base54에서 도달 어려움)
@@ -730,7 +730,7 @@ test "mangle: string_table 기반 생성 심볼도 rename 결과에 포함" {
     });
     defer result.deinit();
 
-    // base54 첫 이름 'e' 는 CJS wrap callback param 으로 reserved (다음 후보 't').
+    // base54 첫 이름 'e' 는 legacy CJS wrap alias 용으로 reserved (다음 후보 't').
     try std.testing.expectEqualStrings("t", result.renames.get(0).?);
 }
 

--- a/src/codegen/mangler_test.zig
+++ b/src/codegen/mangler_test.zig
@@ -17,7 +17,7 @@ test "base54: basic encoding" {
     try std.testing.expect(two[0] == 'e');
 }
 
-test "base54: 1글자 'e'/'m' 만 reserved (CJS wrap callback param 충돌 방지)" {
+test "base54: 1글자 'e'/'m' 만 reserved (legacy CJS alias 충돌 방지)" {
     var buf: [8]u8 = undefined;
     // base54 첫 54개 (1글자) 중 'e' (idx 0) 와 'm' (idx 14) 만 reserved.
     // 다른 1글자 이름은 free.
@@ -43,7 +43,7 @@ test "isReservedOrGlobal" {
     try std.testing.expect(isReservedOrGlobal("return"));
     try std.testing.expect(!isReservedOrGlobal("a"));
     try std.testing.expect(!isReservedOrGlobal("foo"));
-    // 'e', 'm' 은 CJS wrap callback param (`(e, m) => {...}`) 으로 reserved.
+    // 'e', 'm' 은 legacy CJS alias path 용으로 reserved.
     try std.testing.expect(isReservedOrGlobal("e"));
     try std.testing.expect(isReservedOrGlobal("m"));
 }

--- a/src/codegen/modules.zig
+++ b/src/codegen/modules.zig
@@ -497,12 +497,7 @@ pub fn emitExportDefault(self: anytype, node: Node) !void {
             }
             return;
         }
-        if (self.options.cjs_wrap_substitute) {
-            self.cjs_wrap_module_used = true;
-            try self.write("m.exports=");
-        } else {
-            try self.write("module.exports=");
-        }
+        try self.write("module.exports=");
         try self.emitNode(node.data.unary.operand);
         try self.writeByte(';');
         return;

--- a/src/codegen/modules.zig
+++ b/src/codegen/modules.zig
@@ -497,7 +497,12 @@ pub fn emitExportDefault(self: anytype, node: Node) !void {
             }
             return;
         }
-        try self.write("module.exports=");
+        if (self.options.cjs_wrap_substitute) {
+            self.cjs_wrap_module_used = true;
+            try self.write("m.exports=");
+        } else {
+            try self.write("module.exports=");
+        }
         try self.emitNode(node.data.unary.operand);
         try self.writeByte(';');
         return;

--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -201,9 +201,9 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
                     }
                 }
             }
-            // CJS wrap 모듈: unresolved `exports`/`module` reference (= callback param 의
-            // closure capture) 를 짧은 alias `e`/`m` 로 substitute. emitter 의 wrapper
-            // param 변경 (`(e,m)=>{...}`) 과 한 쌍.
+            // Legacy CJS wrap alias path: unresolved `exports`/`module` reference
+            // (= callback param 의 closure capture) 를 짧은 alias 로 substitute.
+            // Bundler 기본 경로는 minify에서도 `(exports, module)` 을 유지한다.
             //
             // *sym_id 가 null* (= 모듈 안 어떤 binding 도 못 가리키는 reference) 일 때만
             // substitute. user 가 `function f(exports) {...}` 같이 동명 binding 을 선언한

--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -14,11 +14,6 @@ const binding_emit = @import("bindings.zig");
 
 const Error = std.mem.Allocator.Error;
 
-/// `"use strict"` directive 의 quote 양쪽 형태. CJS wrap 안에서 elide 시 비교 (chunks.zig
-/// 의 USE_CLIENT_*/USE_SERVER_* 와 같은 패턴).
-const USE_STRICT_DQ = "\"use strict\"";
-const USE_STRICT_SQ = "'use strict'";
-
 pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
     if (idx.isNone()) return;
 
@@ -74,15 +69,6 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
         .labeled_statement => try statement_emit.emitLabeled(self, node),
         .with_statement => try statement_emit.emitWith(self, node),
         .directive => {
-            // CJS wrap 모듈 의 `"use strict"` 는 redundant — wrapper IIFE 가 ESM bundle
-            // (format=.esm) 안에서 실행되므로 자동 strict mode. 다른 directive
-            // (`"use server"` 등) 는 의미 보존 위해 유지.
-            if (self.options.cjs_wrap_substitute) {
-                const text = self.ast.getText(node.span);
-                if (std.mem.eql(u8, text, USE_STRICT_DQ) or std.mem.eql(u8, text, USE_STRICT_SQ)) {
-                    return;
-                }
-            }
             try self.addSourceMapping(node.span);
             // span 은 문자열 리터럴 범위 (따옴표 포함). quote_style 정규화를 적용해
             // `'use server'` → `"use server"` 같은 변환이 일반 string_literal 과 동일하게
@@ -199,29 +185,6 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
                             return;
                         }
                     }
-                }
-            }
-            // Legacy CJS wrap alias path: unresolved `exports`/`module` reference
-            // (= callback param 의 closure capture) 를 짧은 alias 로 substitute.
-            // Bundler 기본 경로는 minify에서도 `(exports, module)` 을 유지한다.
-            //
-            // *sym_id 가 null* (= 모듈 안 어떤 binding 도 못 가리키는 reference) 일 때만
-            // substitute. user 가 `function f(exports) {...}` 같이 동명 binding 을 선언한
-            // 케이스는 sym_id 가 있고 wrapper param 이 아닌 user binding 가리키므로 변경 금지.
-            if (self.options.cjs_wrap_substitute and sym_id == null and
-                (node.tag == .identifier_reference or node.tag == .assignment_target_identifier))
-            {
-                const name = self.ast.getText(node.data.string_ref);
-                const alias: ?u8 = switch (name.len) {
-                    7 => if (std.mem.eql(u8, name, "exports")) @as(u8, 'e') else null,
-                    6 => if (std.mem.eql(u8, name, "module")) @as(u8, 'm') else null,
-                    else => null,
-                };
-                if (alias) |c| {
-                    if (c == 'm') self.cjs_wrap_module_used = true;
-                    try self.addSourceMappingWithName(node.span, name);
-                    try self.writeByte(c);
-                    return;
                 }
             }
             try self.addSourceMapping(node.span);

--- a/src/codegen/options.zig
+++ b/src/codegen/options.zig
@@ -97,10 +97,6 @@ pub const CodegenOptions = struct {
     /// __esm 래핑 모듈: CJS export 출력 억제 (exports.x, module.exports).
     /// __esm 모듈의 export는 emitter의 __export()가 처리하므로 codegen에서 생성하면 안 됨.
     skip_cjs_exports: bool = false,
-    /// Legacy CJS wrap alias path. 활성화하면 callback param `(exports, module)` 을
-    /// 짧은 이름으로 substitute 한다. Bundler 기본 경로는 Node/Metro 호환성을 위해
-    /// minify에서도 `(exports, module)` 을 유지한다.
-    cjs_wrap_substitute: bool = false,
     /// JSON을 CJS require()로 소비할 때 synthetic named export declarations를 생략.
     /// default object는 `module.exports = {...}`로 유지한다.
     skip_cjs_named_export_decls: bool = false,

--- a/src/codegen/options.zig
+++ b/src/codegen/options.zig
@@ -97,10 +97,9 @@ pub const CodegenOptions = struct {
     /// __esm 래핑 모듈: CJS export 출력 억제 (exports.x, module.exports).
     /// __esm 모듈의 export는 emitter의 __export()가 처리하므로 codegen에서 생성하면 안 됨.
     skip_cjs_exports: bool = false,
-    /// CJS wrap 모듈의 callback param `(exports, module)` 을 minify 시 짧은 이름
-    /// (`(e, m)`) 로 단축 — body 안 unresolved `exports`/`module` reference 도
-    /// substitute 한다. emitter 가 `wrap_kind == .cjs and minify_whitespace` 일 때 set.
-    /// reserved set 에 `e`, `m` 도 함께 등록 — mangler 가 다른 binding 에 부여 안 함.
+    /// Legacy CJS wrap alias path. 활성화하면 callback param `(exports, module)` 을
+    /// 짧은 이름으로 substitute 한다. Bundler 기본 경로는 Node/Metro 호환성을 위해
+    /// minify에서도 `(exports, module)` 을 유지한다.
     cjs_wrap_substitute: bool = false,
     /// JSON을 CJS require()로 소비할 때 synthetic named export declarations를 생략.
     /// default object는 `module.exports = {...}`로 유지한다.

--- a/src/codegen/statements.zig
+++ b/src/codegen/statements.zig
@@ -57,6 +57,42 @@ inline fn isElidedStmt(self: anytype, idx: NodeIndex) bool {
     return self.ast.nodes.items[ni].tag == .empty_statement;
 }
 
+fn lastNonElidedStmt(self: anytype, indices: []const u32) ?NodeIndex {
+    var i = indices.len;
+    while (i > 0) {
+        i -= 1;
+        const idx: NodeIndex = @enumFromInt(indices[i]);
+        if (idx.isNone()) continue;
+        if (isElidedStmt(self, idx)) continue;
+        return idx;
+    }
+    return null;
+}
+
+fn stmtNeedsTrailingSemicolonBeforeBlockClose(self: anytype, idx: NodeIndex) bool {
+    if (idx.isNone()) return false;
+    const node = self.ast.getNode(idx);
+    return switch (node.tag) {
+        .for_statement => blk: {
+            const e = node.data.extra;
+            if (e + 3 >= self.ast.extra_data.items.len) break :blk false;
+            break :blk stmtNeedsTrailingSemicolonBeforeBlockClose(self, @enumFromInt(self.ast.extra_data.items[e + 3]));
+        },
+        .for_in_statement, .for_of_statement, .for_await_of_statement => stmtNeedsTrailingSemicolonBeforeBlockClose(self, node.data.ternary.c),
+        .while_statement => stmtNeedsTrailingSemicolonBeforeBlockClose(self, node.data.binary.right),
+        .if_statement => blk: {
+            const t = node.data.ternary;
+            if (!t.c.isNone() and !isElidedAlternate(self, t.c)) {
+                break :blk stmtNeedsTrailingSemicolonBeforeBlockClose(self, t.c);
+            }
+            break :blk stmtNeedsTrailingSemicolonBeforeBlockClose(self, t.b);
+        },
+        .labeled_statement, .with_statement => stmtNeedsTrailingSemicolonBeforeBlockClose(self, node.data.binary.right),
+        .empty_statement => true,
+        else => false,
+    };
+}
+
 pub fn emitProgram(self: anytype, node: Node) !void {
     const list = node.data.list;
     const indices = self.ast.extra_data.items[list.start .. list.start + list.len];
@@ -296,7 +332,11 @@ pub fn emitBracedList(self: anytype, node: Node) !void {
         }
         self.indent_level -= 1;
     }
-    trimTrailingSemicolonBeforeMinifyBoundary(self);
+    if (lastNonElidedStmt(self, indices)) |last_stmt| {
+        if (!stmtNeedsTrailingSemicolonBeforeBlockClose(self, last_stmt)) {
+            trimTrailingSemicolonBeforeMinifyBoundary(self);
+        }
+    }
     try writeNewline(self);
     try writeIndent(self);
     try self.writeByte('}');

--- a/src/codegen/type_runtime.zig
+++ b/src/codegen/type_runtime.zig
@@ -105,7 +105,7 @@ pub fn emitEnumIIFE(self: anytype, node: Node) !void {
     // esm_var_assign_only: var 선언은 이미 __esm 밖 top-level에 hoisted.
     // factory 안에서는 할당만 출력.
     if (!self.options.esm_var_assign_only) try self.write("var ");
-    try self.write(name_text);
+    try self.emitNode(name_idx);
     try self.write(" = /* @__PURE__ */ ((");
     try self.write(param_name);
     try self.write(") => {");
@@ -196,7 +196,7 @@ pub fn emitEnumIIFE(self: anytype, node: Node) !void {
     try self.write("return ");
     try self.write(param_name);
     try self.write(";})(");
-    try self.write(name_text);
+    try self.emitNode(name_idx);
     try self.write(" || {});");
 }
 

--- a/src/transformer/transformer/worklet.zig
+++ b/src/transformer/transformer/worklet.zig
@@ -561,7 +561,7 @@ fn buildPropAssignment(self: *Transformer, func_name_span: Span, prop_name: []co
     const assign = try self.ast.addNode(.{
         .tag = .assignment_expression,
         .span = zero_span,
-        .data = .{ .binary = .{ .left = member, .right = value, .flags = 0 } },
+        .data = .{ .binary = .{ .left = member, .right = value, .flags = @intFromEnum(token_mod.Kind.eq) } },
     });
 
     // expression statement wrapper


### PR DESCRIPTION
## 요약

RN 릴리즈 번들에서 연속으로 드러난 평가 순서/트리쉐이킹/런타임 wrapper 문제를 루트 원인 기준으로 정리해 수정했습니다.

주요 수정은 세 가지입니다.

1. CJS wrapper 파라미터를 minify하지 않고 `exports`, `module` contract로 고정합니다.
2. `sideEffects:false` 패키지라도 실제로 평가되는 ESM 모듈의 top-level side effect는 보존합니다.
3. native worklet 변환기가 생성하는 metadata assignment AST에 `=` 토큰 플래그를 채워 tree shaker가 writer statement로 정확히 분류하게 합니다.

추가로 RN/Metro 호환성 관련 resolver/codegen 회귀 가드도 함께 포함되어 있습니다.

## 루트 원인

### 1. CJS wrapper parameter collision

RN 릴리즈 번들에서 CJS wrapper가 다음처럼 짧은 파라미터 이름을 사용할 수 있었습니다.

```js
$c((e) => {
  Object.defineProperty(e, "__esModule", { value: true });
  var e = require("./dep");
});
```

이 경우 wrapper의 `exports` 역할을 하는 파라미터와 내부 CJS 코드의 top-level local binding이 같은 function scope에서 충돌합니다. CJS wrapper boundary는 일반 모듈 내부 identifier minify와 달리 Node CJS contract를 표현하는 경계라서, `exports`, `module` 이름을 유지하는 쪽이 안전합니다.

이번 PR에서는 단기 안정 해법으로 CJS wrapper 파라미터를 `exports`, `module`로 유지합니다. 장기적으로 런타임/코드젠 contract를 별도 alias로 명시하는 option 2는 #3403에 백로그로 분리했습니다.

### 2. `sideEffects:false` 모듈의 evaluated side effect 누락

`sideEffects:false`는 “사용되지 않는 모듈을 통째로 제거할 수 있다”는 신호이지, 이미 live export 때문에 평가되는 모듈의 observable top-level initialization까지 제거해도 된다는 의미는 아닙니다.

실패 케이스는 다음 구조였습니다.

```js
const contexts = "__react_navigation__elements_contexts";
global[contexts] = global[contexts] ?? new Map();

export default function getNamedContext(name, initialValue) {
  let context = global[contexts].get(name);
  ...
}
```

live export가 `getNamedContext`를 사용하므로 모듈은 평가됩니다. 그런데 기존 tree shaker는 export symbol만 seed하고 evaluated module의 top-level side-effect statement를 별도로 seed하지 않아, `global[contexts] = ... new Map()` 초기화가 사라질 수 있었습니다.

이번 PR에서는 live ESM export를 seed할 때 해당 모듈의 side-effect statement도 함께 seed합니다. 단, `export *` statement는 named import canonical resolution 경로가 따로 처리하므로 fan-out을 피하기 위해 제외했습니다.

### 3. native worklet metadata assignment 분류 오류

native worklet transform이 생성하는 `X.__workletHash = ...` 같은 assignment node가 `assignment_expression`인데도 operator flag가 `0`으로 남아 있었습니다.

`stmt_info`는 단순 `=` 대입만 member augmentation writer로 분류합니다. operator flag가 비어 있으니 worklet metadata assignment를 writer로 귀속하지 못하고 일반 side effect로 취급했고, evaluated module side-effect 보존을 추가하자 죽은 dev-only worklet metadata가 다시 살아났습니다.

이번 PR에서는 worklet transform의 synthetic assignment node에 `token_mod.Kind.eq`를 채웁니다. Zig 관점에서는 AST node의 tag만 맞아도 충분하지 않고, 후속 pass가 읽는 payload invariant까지 같이 맞춰야 합니다.

## 변경 내용

- RN CJS wrapper 출력에서 `exports`, `module` 파라미터를 유지하도록 조정
- JSON/asset CJS wrapper 테스트 기대값 갱신
- evaluated ESM module side-effect seeding 추가
- `export *` statement는 evaluated side-effect seeding에서 제외
- worklet metadata property assignment의 operator flag 보정
- worklet metadata가 dead export를 살리지 않는 회귀 테스트 추가
- computed global assignment side effect 보존 회귀 테스트 추가
- RN minified CJS wrapper collision 회귀 테스트 추가
- resolver/codegen 쪽 RN/Metro 호환 회귀 가드 보강

## 검증

다음 테스트를 `origin/main` 기준 새 브랜치에서 실행했습니다.

```sh
zig build test -Dtest-filter="computed global assignment" --summary all
zig build test -Dtest-filter="native worklet transform does not leave metadata" --summary all
zig build test -Dtest-filter="RN minified" --summary all
zig build test --summary all
```

결과:

- focused tests 통과
- 전체 테스트 통과: `5209/5213 tests passed`, `4 skipped`

릴리즈 번들 정적 확인도 별도로 수행했습니다.

- generated bundle syntax check 통과
- `__react_navigation__elements_contexts = ... new Map()` 초기화가 릴리즈 번들에 남아 있음 확인
- 이전 CJS wrapper collision 패턴이 사라졌음 확인
- dead worklet marker 문자열이 테스트 번들에서 제거됨 확인

## 관련 백로그

- #3403
