### PR TITLE
fix(mf): WASI realpath @compileError — wasm-bundler 빌드 복구 (#3318)

### DIFF
--- a/src/bundler/federation.zig
+++ b/src/bundler/federation.zig
@@ -12,10 +12,21 @@
 //! ~ link 전 단일스레드 분석 패스(다른 build 패스와 동일 위치·동시성 모델).
 
 const std = @import("std");
+const builtin = @import("builtin");
 const types = @import("types.zig");
 const ModuleIndex = types.ModuleIndex;
 const module_id = @import("module_id.zig");
 const resolve_cache = @import("resolve_cache.zig");
+
+/// cwd 절대경로(realpath). **WASI 는 realpath 미지원** — `std.fs.cwd().
+/// realpathAlloc` 는 wasm32-wasi 에서 `@compileError`(runtime catch 무관,
+/// 참조 자체가 컴파일 실패). comptime os 분기로 비-WASI 만 realpath, WASI
+/// 는 null(MF 는 web/native 기능 — wasm-bundler 경로 매칭은 비정규화
+/// fallback 으로 충분). 비-WASI 동작 불변.
+pub fn cwdRealpath(allocator: std.mem.Allocator) ?[]const u8 {
+    if (comptime builtin.os.tag == .wasi) return null;
+    return std.fs.cwd().realpathAlloc(allocator, ".") catch null;
+}
 
 /// 경계 식별 + 표시 + 안정 ID 부여. `mf` 비면 호출 안 됨(caller gate).
 /// `entry_points`/`preserve_root` 는 `module_id` root 도출용.
@@ -37,7 +48,7 @@ pub fn markBoundary(
     defer if (preserve_root == null) if (root) |r| allocator.free(r);
 
     // ── exposes: config 값(cwd 상대 가능)을 abs 로 정규화해 모듈과 매칭 ──
-    const cwd = std.fs.cwd().realpathAlloc(allocator, ".") catch null;
+    const cwd = cwdRealpath(allocator);
     defer if (cwd) |c| allocator.free(c);
     for (mf.exposes) |kv| {
         const abs = resolveAbs(allocator, cwd, kv.value) catch continue;
@@ -123,7 +134,7 @@ pub fn entryWithExposes(
     mf: *const types.MfBundleConfig,
     entries: []const []const u8,
 ) ![][]const u8 {
-    const cwd = std.fs.cwd().realpathAlloc(allocator, ".") catch null;
+    const cwd = cwdRealpath(allocator);
     defer if (cwd) |c| allocator.free(c);
     var list: std.ArrayListUnmanaged([]const u8) = .empty;
     errdefer {
@@ -160,6 +171,8 @@ pub fn resolveAbs(allocator: std.mem.Allocator, cwd: ?[]const u8, value: []const
     const base = cwd orelse ".";
     const joined = try std.fs.path.resolve(allocator, &.{ base, value });
     defer allocator.free(joined);
+    // WASI 는 realpath @compileError → comptime 분기(비-WASI 동작 불변).
+    if (comptime builtin.os.tag == .wasi) return allocator.dupe(u8, joined);
     return std.fs.cwd().realpathAlloc(allocator, joined) catch allocator.dupe(u8, joined);
 }
 

--- a/src/bundler/federation_emit.zig
+++ b/src/bundler/federation_emit.zig
@@ -107,7 +107,7 @@ pub fn wrapContainer(
     if (mf.exposes.len == 0) return; // host(shared/remotes-only) = container 아님
     const name = mf.name orelse return; // remote 는 P1-0 검증이 name 강제
 
-    const cwd = std.fs.cwd().realpathAlloc(allocator, ".") catch null;
+    const cwd = federation.cwdRealpath(allocator); // WASI-safe(comptime 분기)
     defer if (cwd) |c| allocator.free(c);
 
     // ── container 객체 문자열 빌드(min-무관 compact, 유효 JS) ──

--- a/tests/integration/tests/mf-runtime-interop-smoke.test.ts
+++ b/tests/integration/tests/mf-runtime-interop-smoke.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, afterEach } from 'bun:test';
 import { createServer, type Server } from 'node:http';
 import { readFile } from 'node:fs/promises';
 import { writeFileSync, rmSync } from 'node:fs';
-import { join, basename } from 'node:path';
+import { join } from 'node:path';
 import { createRequire } from 'node:module';
 import { createFixture, runZntcInDir, runNode } from './helpers';
 


### PR DESCRIPTION
## 문제 (CI 파손)

`zig build wasm-bundler` 실패:
```
std/fs/Dir.zig:1308:9: error: realpath is not available on WASI
```

`std.fs.cwd().realpathAlloc` 는 wasm32-wasi 에서 **`@compileError`** — runtime `catch null` 무관하게 **참조 자체가 컴파일 실패**. federation.zig/federation_emit.zig 의 expose 경로 정규화 4개 사이트(markBoundary·entryWithExposes·resolveAbs·wrapContainer)가 `wasm-bundler` 타깃(wasm32-wasip1-threads)을 깨뜨림.

P1-1(#3394) `resolveAbs` 부터 존재했으나 P1-1/P1-2 의 CI run 이 후속 머지로 **cancelled** 되어 미표면 → P1-3(#3401) run 이 WASM 잡을 완주하며 노출.

## 수정

- `federation.cwdRealpath`(pub) 헬퍼: `comptime builtin.os.tag == .wasi` → null, 아니면 `realpathAlloc`. comptime 분기라 WASI 타깃은 realpath 갈래를 **의미분석 안 함**(@compileError 미발생). markBoundary/entryWithExposes/federation_emit 공유, `resolveAbs` 도 동일 comptime 분기.
- WASI 는 비정규화 fallback(MF 는 web/native 기능 — wasm-bundler 경로 매칭에 충분). **비-WASI(native) 동작 완전 불변**.
- 부수: `mf-runtime-interop-smoke` 미사용 import(`basename`) 제거.

## 검증

- `zig build wasm` / `zig build wasm-bundler` EXIT=0 (이전 realpath 컴파일 실패).
- `zig build test` EXIT=0, mf 통합 3·0 (native realpath 경로 불변 — comptime 비-wasi 갈래).
- lint/fmt:check EXIT=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)