### PR TITLE
feat(linker): namespace member-access → 직접심볼 재작성 (RFC #3399 PR-2)

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1173,7 +1173,8 @@ pub const Linker = struct {
     /// 모듈의 중첩 스코프 (비-모듈 스코프) 에 해당 이름이 존재하는지 확인.
     /// esbuild/rolldown/rollup 과 동일하게 semantic.scope_maps 직접 scan — scope 깊이는
     /// 보통 1~10 정도라 별도 cache 없이 충분.
-    fn hasNestedBinding(self: *const Linker, module_index: u32, name: []const u8) bool {
+    // pub: shared_namespace.zig (RFC #3399 PR-2) 가 동일 scan 을 재사용 (단일 소스 — 복제 제거).
+    pub fn hasNestedBinding(self: *const Linker, module_index: u32, name: []const u8) bool {
         const m = self.getModule(module_index) orelse return false;
         const sem = m.semantic orelse return false;
         for (sem.scope_maps, 0..) |scope_map, scope_idx| {
@@ -1181,6 +1182,22 @@ pub const Linker = struct {
             if (scope_map.get(name) != null) return true;
         }
         return false;
+    }
+
+    /// RFC #3399 PR-2: namespace `X.member` → exp.local 직접 재작성(ns-object
+    /// 제거) 이 shadow-safe 한 빌드 경로인가. 안전성은 측정 우연이 아니라
+    /// **mangler invariant**: `collectUnifiedInput` 이 namespace target export
+    /// 를 항상 importer 의 cross_module_imports 로 등록 → `unified_mangler` 가
+    /// 그 mangled 이름을 importer per-module reserved 에 넣어 nested local 이
+    /// 절대 같은 이름을 받지 않음 (Debug panic 으로 기계 증명). 단 이는
+    /// mangle 활성 시에만 성립 — 비-minify/dev/preserve-modules 는 exp.local
+    /// 이 source 이름 그대로라 importer nested binding 과 자기-shadow 충돌
+    /// 실재 → 보수적 shadow-skip 유지. 세 플래그 모두 graph 단일 출처에서
+    /// 읽어 dev_mode 출처 혼용을 방지한다.
+    pub fn nsMemberRewriteSafe(self: *const Linker) bool {
+        return self.graph.minify_identifiers and
+            !self.graph.preserve_modules and
+            !self.graph.dev_mode;
     }
 
     /// ECMAScript 예약어 + CJS 런타임 + 브라우저/Node 주요 글로벌인지 확인.

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -6,6 +6,7 @@
 //! resolution and symbol population.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const linker_mod = @import("../linker.zig");
 const Linker = linker_mod.Linker;
 const LinkingMetadata = linker_mod.LinkingMetadata;
@@ -20,16 +21,27 @@ const NsExportPair = Linker.NsExportPair;
 const SharedNsInline = Linker.SharedNsInline;
 const max_chain_depth = 100;
 
-/// 모듈의 중첩 스코프 (비-모듈 스코프) 에 해당 이름이 존재하는지 확인.
-/// linker.zig 의 method 와 동일.
-fn hasNestedBinding(self: *const Linker, module_index: u32, name: []const u8) bool {
-    const m = self.getModule(module_index) orelse return false;
-    const sem = m.semantic orelse return false;
-    for (sem.scope_maps, 0..) |scope_map, scope_idx| {
-        if (scope_idx == 0) continue;
-        if (scope_map.get(name) != null) return true;
+// RFC PR-2 (#3399) kill-switch: env `ZNTC_NO_NS_REWRITE` presence → namespace
+// member-rewrite 강제 비활성 (회귀 시 운영 비상 차단 + measure-first OFF
+// 측정). force-ON 은 *제공하지 않는다* — 비-minify 강제 ON 은 의도적으로
+// 깨진 출력(자기-shadow 무한재귀)을 만들 수 있어 footgun. 활성 여부는
+// `Linker.nsMemberRewriteSafe()` (mangler invariant 기반) 가 단독 결정하고
+// 이 env 는 그것을 덮어 끄기만 한다. transpile.zig fast-path 와 동일 관례
+// (std.once thread-safe 캐시, WASI 가드).
+var ns_rewrite_disabled_once = std.once(computeNsRewriteDisabled);
+var ns_rewrite_disabled_value: bool = false;
+
+fn computeNsRewriteDisabled() void {
+    if (comptime builtin.os.tag == .wasi and !builtin.link_libc) {
+        ns_rewrite_disabled_value = false;
+        return;
     }
-    return false;
+    ns_rewrite_disabled_value = std.process.hasEnvVarConstant("ZNTC_NO_NS_REWRITE");
+}
+
+pub fn nsRewriteDisabled() bool {
+    ns_rewrite_disabled_once.call();
+    return ns_rewrite_disabled_value;
 }
 
 /// ESM namespace import를 위한 namespace 객체 preamble 생성.
@@ -134,8 +146,14 @@ pub fn registerNamespaceRewrites(
         }
         source_init_cache.deinit();
     }
+    // RFC PR-2 (#3399): mangle-safe 경로면 shadow-skip 을 끄고 멤버를 inner_map
+    // 에 등록 → `emitStaticMember` 가 `X.member`→exp.local 직접 재작성 →
+    // ns-object 불요 (effect −20.6%). 안전성 근거·스코핑은
+    // `Linker.nsMemberRewriteSafe` docstring. `ZNTC_NO_NS_REWRITE` 는 회귀 시
+    // 강제 비활성(kill-switch) — 안전 경로에서도 끌 수만 있고 켤 수는 없다.
+    const ns_rewrite = !nsRewriteDisabled() and self.nsMemberRewriteSafe();
     for (cached_exports) |exp| {
-        if (hasNestedBinding(self, importer_mod_idx, exp.exported)) {
+        if (!ns_rewrite and self.hasNestedBinding(importer_mod_idx, exp.exported)) {
             has_shadow = true;
             continue;
         }


### PR DESCRIPTION
## 무엇 / 왜

RFC #3398 · 이슈 #3399 의 **PR-2** (base = epic `shared-ns-dead-emit-3399`, main 아님). 이 size-epic 전체에서 **member-augment(#3359) 이후 첫 진짜 win**.

**직접 빌드파일 diff** 로 근본 확정: effect `ZNTC 160,811 vs rolldown 125,417` 격차의 **105%(37,047B)가 `var X_ns={};augment(X_ns,{...getters})` namespace 스캐폴드** (rolldown 동일패턴 3개≈0). competitor 는 객체를 만드는 대신 **`X.member` 접근을 직접 심볼로 재작성**해 객체를 통째 제거. ZNTC 는 `X.member` 문법을 보존해 객체를 부득이 포함하던 것 → PR-1 의 gate(조건부 억제)는 dead 판정 liveness-blind 로 실패했으나, **rewrite 는 dead/live 무관 전부 소멸**.

## 변경 (2 파일)

- `shared_namespace.zig`: mangle-safe 경로면 `hasNestedBinding` shadow-skip 을 끄고 멤버를 inner_map 에 등록 → `emitStaticMember` 가 `X.member`→exp.local 재작성 → ns-object 미생성. `ZNTC_NO_NS_REWRITE` kill-switch.
- `linker.zig`: `nsMemberRewriteSafe()` 술어 캡슐화(graph 단일 출처) + `hasNestedBinding` `pub` 단일 소스화(복제 제거).

## 측정 (직접 + 전수)

| | OFF/kill-switch | ON(기본·safe경로) |
|---|---|---|
| effect minified | 160,811 | **127,765 (−20.6%)** — rolldown 격차 93% 해소, X_ns 43→2 |
| 전수 144-lib smoke | — | **build 회귀 0, runtime MATCH 회귀 0, size 증가 0** |
| 런타임 | 43 | 43 (정확) |
| corpus 총합 | — | −0.65% (effect 단독 — ns-barrel cohort 집중, C 스파이크 caveat 그대로) |

회귀 0 Debug 5197 / ReleaseFast 5197. `ZNTC_NO_NS_REWRITE=1` → 160,811 = pre-PR byte-identical (kill-switch 검증).

## 정확성 (correctness-critical)

3-에이전트 /simplify: **silent-broken CRITICAL 0**. 안전성은 측정 우연이 아니라 **mangler invariant** — `collectUnifiedInput` 이 namespace target export 를 flag 무관하게 항상 importer `cross_module_imports` 로 등록 → `unified_mangler` 가 그 mangled 이름을 importer per-module reserved 에 넣어 nested local 이 절대 동명 못 받음 (`unified_mangler.zig` Debug panic 으로 기계 증명). `finalize()` ordering 상 `registerNamespaceRewrites` 시점에 exp.local 은 이미 mangled. 비-minify/dev/preserve-modules 는 미-mangle 이라 자기-shadow 충돌 실재 → 기존 보수적 shadow-skip 유지 (`nsMemberRewriteSafe()` 가 차단).

/simplify 반영: env footgun 제거(force-ON→kill-switch 전용), gate 술어 캡슐화, hasNestedBinding dedup, 주석 단일화.

## 미측정 영역 (정직)

144-lib smoke 에 **RN production 번들(dev_mode=false + minify)** 미포함 — invariant 상 안전하나 실측 외. corpus 효과는 effect/@effect/fp-ts cohort 집중.

## 다음

PR-3: /simplify 잔여(EnvBoolOnce 제너릭 추출 — transpile.zig 와 N=2 boilerplate, 별도) + 문서/메모리 영속.

Refs #3399 · RFC #3398

🤖 Generated with [Claude Code](https://claude.com/claude-code)