### PR TITLE
refactor(env): env-presence flag 제너릭 통합 + RFC 결과 기록 (RFC #3399 PR-3)

### DIFF
--- a/docs/RFC_SHARED_NS_DEAD_EMIT.md
+++ b/docs/RFC_SHARED_NS_DEAD_EMIT.md
@@ -86,3 +86,12 @@ ZNTC 는 `isNamespaceUsedAsValue`(값-escape) 만 보고, esbuild 의 **"실 use
 ## 8. 결론
 
 minify 잔존 레버 중 member-augment(#3359) 이후 처음으로 **측정·코드근거·scoped·prior-메모리 미배제**. esbuild `StarNameLoc=nil` gate 의 직접 이식이며 M 규모. effect-cohort 집중이라 corpus 효과는 modest 하나 ROI-per-effort 가 명확하고, PR-1 의 measure-first kill-switch 가 nested-renamer 식 과대평가를 구조적으로 차단한다.
+
+## 9. 실행 결과 (epic 기록)
+
+- **PR-1 (gate)**: `has_shadow` access-aware 억제. kill-switch **NO-GO** — `analyzeNamespaceAccess` liveness-blind 라 dead 도 member-access=true → effect 0% 회수. 폐기.
+- **루트커즈 정정 (직접 빌드파일 diff)**: effect `ZNTC 160,811 vs rolldown 125,417` 격차의 **105%(37KB)가 `var X_ns={};augment(...)` 스캐폴드 43개**. competitor 는 gate 아닌 **`X.member`→직접심볼 전면 재작성**으로 객체 제거. RFC §2~§6 초안(gate/force_inline)은 계측·직접측정으로 반증 — 상단 정정 박스 + 본 절이 권위.
+- **PR-2 (rewrite, GO·머지)** #3407: `Linker.nsMemberRewriteSafe()` (mangle-safe) 일 때 `hasNestedBinding` shadow-skip 비활성 → `X.member`→exp.local 재작성. **effect 160,811→127,765 (−20.6%)**, 전수 144-lib build/runtime MATCH 회귀 0·size 증가 0. 안전성=mangler invariant(`collectUnifiedInput` ns target 항상 cross_module reserve, Debug panic 증명). `ZNTC_NO_NS_REWRITE` kill-switch(force-ON 미제공). 비-minify/dev/preserve-modules 는 보수적 shadow-skip 유지.
+- **PR-3 (cleanup)**: env-presence flag 중복 boilerplate → `src/env_flag.zig` `Once()` 제너릭 단일화 (transpile fast-path + ns-rewrite kill-switch). byte-identical.
+- **순효과**: corpus −0.65% (effect/@effect/fp-ts cohort 집중 — zod/three 등 ns-barrel 없는 lib 불변). member-augment 이후 첫 진짜 size win. RN production minify 는 144-lib smoke 미포함(invariant 상 안전, 실측 외).
+- **메타**: bounded *gate*(PR-1·prior NO-GO)만 재시도 금지, *rewrite*(PR-2·GO)는 competitor 실기법으로 유효 — 별개. 근본 규명 결정타 = 내부 추정 아닌 **직접 빌드파일 diff**.

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -6,7 +6,6 @@
 //! resolution and symbol population.
 
 const std = @import("std");
-const builtin = @import("builtin");
 const linker_mod = @import("../linker.zig");
 const Linker = linker_mod.Linker;
 const LinkingMetadata = linker_mod.LinkingMetadata;
@@ -26,22 +25,11 @@ const max_chain_depth = 100;
 // 측정). force-ON 은 *제공하지 않는다* — 비-minify 강제 ON 은 의도적으로
 // 깨진 출력(자기-shadow 무한재귀)을 만들 수 있어 footgun. 활성 여부는
 // `Linker.nsMemberRewriteSafe()` (mangler invariant 기반) 가 단독 결정하고
-// 이 env 는 그것을 덮어 끄기만 한다. transpile.zig fast-path 와 동일 관례
-// (std.once thread-safe 캐시, WASI 가드).
-var ns_rewrite_disabled_once = std.once(computeNsRewriteDisabled);
-var ns_rewrite_disabled_value: bool = false;
-
-fn computeNsRewriteDisabled() void {
-    if (comptime builtin.os.tag == .wasi and !builtin.link_libc) {
-        ns_rewrite_disabled_value = false;
-        return;
-    }
-    ns_rewrite_disabled_value = std.process.hasEnvVarConstant("ZNTC_NO_NS_REWRITE");
-}
+// 이 env 는 그것을 덮어 끄기만 한다.
+const ns_rewrite_disabled_env = @import("../../env_flag.zig").Once("ZNTC_NO_NS_REWRITE");
 
 pub fn nsRewriteDisabled() bool {
-    ns_rewrite_disabled_once.call();
-    return ns_rewrite_disabled_value;
+    return ns_rewrite_disabled_env.enabled();
 }
 
 /// ESM namespace import를 위한 namespace 객체 preamble 생성.

--- a/src/env_flag.zig
+++ b/src/env_flag.zig
@@ -1,0 +1,42 @@
+//! 프로세스 1회 캐시 env-presence boolean flag.
+//!
+//! `std.once` thread-safe 1회 평가 + WASI 가드 + `hasEnvVarConstant`
+//! (allocator 불필요) 패턴이 transpile fast-path / shared-namespace rewrite
+//! kill-switch 등에서 토큰 단위로 중복되던 것을 단일 소스로 통합 (RFC #3399
+//! PR-3 cleanup). 새 토글은 이 제너릭을 쓴다.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+/// `env_name` 환경변수의 *존재 여부* 를 프로세스당 1회 평가해 캐시한다.
+/// thread-safe (std.once). 같은 comptime `env_name` 인스턴스화는 동일 타입
+/// (캐시 공유), 다른 이름은 독립 캐시. WASI(+!link_libc) 는 항상 false.
+///
+/// 사용: `const fooEnabled = env_flag.Once("ZNTC_FOO");` → `fooEnabled.enabled()`.
+pub fn Once(comptime env_name: []const u8) type {
+    return struct {
+        var once = std.once(compute);
+        var value: bool = false;
+
+        fn compute() void {
+            if (comptime builtin.os.tag == .wasi and !builtin.link_libc) {
+                value = false;
+                return;
+            }
+            value = std.process.hasEnvVarConstant(env_name);
+        }
+
+        pub fn enabled() bool {
+            once.call();
+            return value;
+        }
+    };
+}
+
+test "Once: 미설정 env 는 false" {
+    // 테스트 환경에 거의 없을 임의 이름 — 존재하지 않으면 false.
+    const f = Once("ZNTC_ENV_FLAG_UNITTEST_ABSENT_XYZ");
+    try std.testing.expect(!f.enabled());
+    // 1회 캐시: 재호출도 동일.
+    try std.testing.expect(!f.enabled());
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -45,6 +45,7 @@ test {
     _ = server;
     _ = app;
     _ = @import("test_arena.zig");
+    _ = @import("env_flag.zig");
     _ = util.wyhash;
 
     // diagnostic system

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -9,7 +9,6 @@
 //!   - 향후 NAPI 바인딩의 단일 파일 API
 
 const std = @import("std");
-const builtin = @import("builtin");
 const Scanner = @import("lexer/mod.zig").Scanner;
 const Parser = @import("parser/parser.zig").Parser;
 const ast_mod = @import("parser/ast.zig");
@@ -137,20 +136,11 @@ fn prependImportLine(allocator: std.mem.Allocator, prefix: ?[]const u8, body: []
     return combined.items;
 }
 
-var fast_path_disabled_once = std.once(computeFastPathDisabledByEnv);
-var fast_path_disabled_value: bool = false;
-
-fn computeFastPathDisabledByEnv() void {
-    if (comptime builtin.os.tag == .wasi and !builtin.link_libc) {
-        fast_path_disabled_value = false;
-        return;
-    }
-    fast_path_disabled_value = std.process.hasEnvVarConstant("ZNTC_DISABLE_TRANSPILE_FAST_PATH");
-}
+// env-presence flag — 공용 제너릭 (RFC #3399 PR-3: 중복 boilerplate 통합).
+const fast_path_disabled_env = @import("env_flag.zig").Once("ZNTC_DISABLE_TRANSPILE_FAST_PATH");
 
 fn transpileFastPathDisabledByEnv() bool {
-    fast_path_disabled_once.call();
-    return fast_path_disabled_value;
+    return fast_path_disabled_env.enabled();
 }
 
 fn collectAstFacts(ast: *const Ast) AstFacts {


### PR DESCRIPTION
## 무엇 / 왜

RFC #3398 · 이슈 #3399 의 **PR-3 cleanup** (base = epic `shared-ns-dead-emit-3399`).

`std.once` + `hasEnvVarConstant` + WASI 가드 env-presence flag boilerplate 가 transpile fast-path 와 PR-2 의 ns-rewrite kill-switch 두 곳에서 토큰 단위로 중복 — 신규 `src/env_flag.zig` `Once()` 제너릭으로 단일화 (/simplify Agent 1 권고).

## 변경

| 파일 | 내용 |
|---|---|
| `src/env_flag.zig` (신규) | `Once(comptime name)` 제너릭 — comptime-name 메모이제이션(같은 이름=static 캐시 공유, 다른 이름=독립), std.once thread-safe, WASI 가드. 유닛테스트 포함 |
| `transpile.zig` | fast-path flag boilerplate → `Once()`. 미사용 `builtin` import 제거 |
| `shared_namespace.zig` | ns-rewrite kill-switch boilerplate → `Once()`. `builtin` import 제거 |
| `root.zig` | env_flag 테스트 등록 |
| `docs/RFC_SHARED_NS_DEAD_EMIT.md` | §9 실행결과 (epic 기록) |

## 검증

**순수 DRY 리팩터 — 동작 byte-identical**:
- 회귀 0: Debug 5198 / ReleaseFast 5198, 0 fail
- effect 기본 127,765 (PR-2 −20.6% win 보존), `ZNTC_NO_NS_REWRITE=1` → 160,811 (kill-switch 보존), 런타임 43
- 3-에이전트 /simplify: **CRITICAL 0**. comptime 메모이제이션·thread-safety 원본 동치 경험적 검증, leaf 모듈(순환 불가)
- /simplify 반영: transpile.zig 잔여 dead `builtin` import 제거 (shared_namespace 와 비대칭 해소)

debug_log/profile 의 env 처리는 패턴 상이(getEnvVarOwned/값파싱/non-once)로 통합 대상 아님 — 별개 유지가 정확 (Agent 1 확정).

## RFC §9 실행결과 요약

PR-1(gate) NO-GO → 직접 빌드파일 diff 로 근본 규명(effect gap 105%=X_ns 스캐폴드) → PR-2(rewrite) GO·머지 (effect −20.6%, 144-lib 회귀 0). 순효과 corpus −0.65% (effect/@effect/fp-ts cohort 집중). member-augment(#3359) 이후 첫 진짜 size win.

Refs #3399 · RFC #3398

🤖 Generated with [Claude Code](https://claude.com/claude-code)