### PR TITLE
perf(linker): namespace member-access 직접심볼 재작성 — effect −20.5% (RFC #3399 epic)

### DIFF
--- a/docs/RFC_SHARED_NS_DEAD_EMIT.md
+++ b/docs/RFC_SHARED_NS_DEAD_EMIT.md
@@ -115,3 +115,12 @@ ZNTC 는 `isNamespaceUsedAsValue`(값-escape) 만 보고, esbuild 의 **"실 use
 ## 8. 결론
 
 minify 잔존 레버 중 member-augment(#3359) 이후 처음으로 **측정·코드근거·scoped·prior-메모리 미배제**. esbuild `StarNameLoc=nil` gate 의 직접 이식이며 M 규모. effect-cohort 집중이라 corpus 효과는 modest 하나 ROI-per-effort 가 명확하고, PR-1 의 measure-first kill-switch 가 nested-renamer 식 과대평가를 구조적으로 차단한다.
+
+## 9. 실행 결과 (epic 기록)
+
+- **PR-1 (gate)**: `has_shadow` access-aware 억제. kill-switch **NO-GO** — `analyzeNamespaceAccess` liveness-blind 라 dead 도 member-access=true → effect 0% 회수. 폐기.
+- **루트커즈 정정 (직접 빌드파일 diff)**: effect `ZNTC 160,811 vs rolldown 125,417` 격차의 **105%(37KB)가 `var X_ns={};augment(...)` 스캐폴드 43개**. competitor 는 gate 아닌 **`X.member`→직접심볼 전면 재작성**으로 객체 제거. RFC §2~§6 초안(gate/force_inline)은 계측·직접측정으로 반증 — 상단 정정 박스 + 본 절이 권위.
+- **PR-2 (rewrite, GO·머지)** #3407: `Linker.nsMemberRewriteSafe()` (mangle-safe) 일 때 `hasNestedBinding` shadow-skip 비활성 → `X.member`→exp.local 재작성. **effect 160,811→127,765 (−20.6%)**, 전수 144-lib build/runtime MATCH 회귀 0·size 증가 0. 안전성=mangler invariant(`collectUnifiedInput` ns target 항상 cross_module reserve, Debug panic 증명). `ZNTC_NO_NS_REWRITE` kill-switch(force-ON 미제공). 비-minify/dev/preserve-modules 는 보수적 shadow-skip 유지.
+- **PR-3 (cleanup)**: env-presence flag 중복 boilerplate → `src/env_flag.zig` `Once()` 제너릭 단일화 (transpile fast-path + ns-rewrite kill-switch). byte-identical.
+- **순효과**: corpus −0.65% (effect/@effect/fp-ts cohort 집중 — zod/three 등 ns-barrel 없는 lib 불변). member-augment 이후 첫 진짜 size win. RN production minify 는 144-lib smoke 미포함(invariant 상 안전, 실측 외).
+- **메타**: bounded *gate*(PR-1·prior NO-GO)만 재시도 금지, *rewrite*(PR-2·GO)는 competitor 실기법으로 유효 — 별개. 근본 규명 결정타 = 내부 추정 아닌 **직접 빌드파일 diff**.

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1173,7 +1173,8 @@ pub const Linker = struct {
     /// 모듈의 중첩 스코프 (비-모듈 스코프) 에 해당 이름이 존재하는지 확인.
     /// esbuild/rolldown/rollup 과 동일하게 semantic.scope_maps 직접 scan — scope 깊이는
     /// 보통 1~10 정도라 별도 cache 없이 충분.
-    fn hasNestedBinding(self: *const Linker, module_index: u32, name: []const u8) bool {
+    // pub: shared_namespace.zig (RFC #3399 PR-2) 가 동일 scan 을 재사용 (단일 소스 — 복제 제거).
+    pub fn hasNestedBinding(self: *const Linker, module_index: u32, name: []const u8) bool {
         const m = self.getModule(module_index) orelse return false;
         const sem = m.semantic orelse return false;
         for (sem.scope_maps, 0..) |scope_map, scope_idx| {
@@ -1181,6 +1182,22 @@ pub const Linker = struct {
             if (scope_map.get(name) != null) return true;
         }
         return false;
+    }
+
+    /// RFC #3399 PR-2: namespace `X.member` → exp.local 직접 재작성(ns-object
+    /// 제거) 이 shadow-safe 한 빌드 경로인가. 안전성은 측정 우연이 아니라
+    /// **mangler invariant**: `collectUnifiedInput` 이 namespace target export
+    /// 를 항상 importer 의 cross_module_imports 로 등록 → `unified_mangler` 가
+    /// 그 mangled 이름을 importer per-module reserved 에 넣어 nested local 이
+    /// 절대 같은 이름을 받지 않음 (Debug panic 으로 기계 증명). 단 이는
+    /// mangle 활성 시에만 성립 — 비-minify/dev/preserve-modules 는 exp.local
+    /// 이 source 이름 그대로라 importer nested binding 과 자기-shadow 충돌
+    /// 실재 → 보수적 shadow-skip 유지. 세 플래그 모두 graph 단일 출처에서
+    /// 읽어 dev_mode 출처 혼용을 방지한다.
+    pub fn nsMemberRewriteSafe(self: *const Linker) bool {
+        return self.graph.minify_identifiers and
+            !self.graph.preserve_modules and
+            !self.graph.dev_mode;
     }
 
     /// ECMAScript 예약어 + CJS 런타임 + 브라우저/Node 주요 글로벌인지 확인.

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -6,7 +6,6 @@
 //! resolution and symbol population.
 
 const std = @import("std");
-const builtin = @import("builtin");
 const linker_mod = @import("../linker.zig");
 const Linker = linker_mod.Linker;
 const LinkingMetadata = linker_mod.LinkingMetadata;
@@ -26,22 +25,11 @@ const max_chain_depth = 100;
 // 측정). force-ON 은 *제공하지 않는다* — 비-minify 강제 ON 은 의도적으로
 // 깨진 출력(자기-shadow 무한재귀)을 만들 수 있어 footgun. 활성 여부는
 // `Linker.nsMemberRewriteSafe()` (mangler invariant 기반) 가 단독 결정하고
-// 이 env 는 그것을 덮어 끄기만 한다. transpile.zig fast-path 와 동일 관례
-// (std.once thread-safe 캐시, WASI 가드).
-var ns_rewrite_disabled_once = std.once(computeNsRewriteDisabled);
-var ns_rewrite_disabled_value: bool = false;
-
-fn computeNsRewriteDisabled() void {
-    if (comptime builtin.os.tag == .wasi and !builtin.link_libc) {
-        ns_rewrite_disabled_value = false;
-        return;
-    }
-    ns_rewrite_disabled_value = std.process.hasEnvVarConstant("ZNTC_NO_NS_REWRITE");
-}
+// 이 env 는 그것을 덮어 끄기만 한다.
+const ns_rewrite_disabled_env = @import("../../env_flag.zig").Once("ZNTC_NO_NS_REWRITE");
 
 pub fn nsRewriteDisabled() bool {
-    ns_rewrite_disabled_once.call();
-    return ns_rewrite_disabled_value;
+    return ns_rewrite_disabled_env.enabled();
 }
 
 /// ESM namespace import를 위한 namespace 객체 preamble 생성.

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -6,6 +6,7 @@
 //! resolution and symbol population.
 
 const std = @import("std");
+const builtin = @import("builtin");
 const linker_mod = @import("../linker.zig");
 const Linker = linker_mod.Linker;
 const LinkingMetadata = linker_mod.LinkingMetadata;
@@ -20,16 +21,27 @@ const NsExportPair = Linker.NsExportPair;
 const SharedNsInline = Linker.SharedNsInline;
 const max_chain_depth = 100;
 
-/// 모듈의 중첩 스코프 (비-모듈 스코프) 에 해당 이름이 존재하는지 확인.
-/// linker.zig 의 method 와 동일.
-fn hasNestedBinding(self: *const Linker, module_index: u32, name: []const u8) bool {
-    const m = self.getModule(module_index) orelse return false;
-    const sem = m.semantic orelse return false;
-    for (sem.scope_maps, 0..) |scope_map, scope_idx| {
-        if (scope_idx == 0) continue;
-        if (scope_map.get(name) != null) return true;
+// RFC PR-2 (#3399) kill-switch: env `ZNTC_NO_NS_REWRITE` presence → namespace
+// member-rewrite 강제 비활성 (회귀 시 운영 비상 차단 + measure-first OFF
+// 측정). force-ON 은 *제공하지 않는다* — 비-minify 강제 ON 은 의도적으로
+// 깨진 출력(자기-shadow 무한재귀)을 만들 수 있어 footgun. 활성 여부는
+// `Linker.nsMemberRewriteSafe()` (mangler invariant 기반) 가 단독 결정하고
+// 이 env 는 그것을 덮어 끄기만 한다. transpile.zig fast-path 와 동일 관례
+// (std.once thread-safe 캐시, WASI 가드).
+var ns_rewrite_disabled_once = std.once(computeNsRewriteDisabled);
+var ns_rewrite_disabled_value: bool = false;
+
+fn computeNsRewriteDisabled() void {
+    if (comptime builtin.os.tag == .wasi and !builtin.link_libc) {
+        ns_rewrite_disabled_value = false;
+        return;
     }
-    return false;
+    ns_rewrite_disabled_value = std.process.hasEnvVarConstant("ZNTC_NO_NS_REWRITE");
+}
+
+pub fn nsRewriteDisabled() bool {
+    ns_rewrite_disabled_once.call();
+    return ns_rewrite_disabled_value;
 }
 
 /// ESM namespace import를 위한 namespace 객체 preamble 생성.
@@ -134,8 +146,14 @@ pub fn registerNamespaceRewrites(
         }
         source_init_cache.deinit();
     }
+    // RFC PR-2 (#3399): mangle-safe 경로면 shadow-skip 을 끄고 멤버를 inner_map
+    // 에 등록 → `emitStaticMember` 가 `X.member`→exp.local 직접 재작성 →
+    // ns-object 불요 (effect −20.6%). 안전성 근거·스코핑은
+    // `Linker.nsMemberRewriteSafe` docstring. `ZNTC_NO_NS_REWRITE` 는 회귀 시
+    // 강제 비활성(kill-switch) — 안전 경로에서도 끌 수만 있고 켤 수는 없다.
+    const ns_rewrite = !nsRewriteDisabled() and self.nsMemberRewriteSafe();
     for (cached_exports) |exp| {
-        if (hasNestedBinding(self, importer_mod_idx, exp.exported)) {
+        if (!ns_rewrite and self.hasNestedBinding(importer_mod_idx, exp.exported)) {
             has_shadow = true;
             continue;
         }

--- a/src/env_flag.zig
+++ b/src/env_flag.zig
@@ -1,0 +1,42 @@
+//! 프로세스 1회 캐시 env-presence boolean flag.
+//!
+//! `std.once` thread-safe 1회 평가 + WASI 가드 + `hasEnvVarConstant`
+//! (allocator 불필요) 패턴이 transpile fast-path / shared-namespace rewrite
+//! kill-switch 등에서 토큰 단위로 중복되던 것을 단일 소스로 통합 (RFC #3399
+//! PR-3 cleanup). 새 토글은 이 제너릭을 쓴다.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+/// `env_name` 환경변수의 *존재 여부* 를 프로세스당 1회 평가해 캐시한다.
+/// thread-safe (std.once). 같은 comptime `env_name` 인스턴스화는 동일 타입
+/// (캐시 공유), 다른 이름은 독립 캐시. WASI(+!link_libc) 는 항상 false.
+///
+/// 사용: `const fooEnabled = env_flag.Once("ZNTC_FOO");` → `fooEnabled.enabled()`.
+pub fn Once(comptime env_name: []const u8) type {
+    return struct {
+        var once = std.once(compute);
+        var value: bool = false;
+
+        fn compute() void {
+            if (comptime builtin.os.tag == .wasi and !builtin.link_libc) {
+                value = false;
+                return;
+            }
+            value = std.process.hasEnvVarConstant(env_name);
+        }
+
+        pub fn enabled() bool {
+            once.call();
+            return value;
+        }
+    };
+}
+
+test "Once: 미설정 env 는 false" {
+    // 테스트 환경에 거의 없을 임의 이름 — 존재하지 않으면 false.
+    const f = Once("ZNTC_ENV_FLAG_UNITTEST_ABSENT_XYZ");
+    try std.testing.expect(!f.enabled());
+    // 1회 캐시: 재호출도 동일.
+    try std.testing.expect(!f.enabled());
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -45,6 +45,7 @@ test {
     _ = server;
     _ = app;
     _ = @import("test_arena.zig");
+    _ = @import("env_flag.zig");
     _ = util.wyhash;
 
     // diagnostic system

--- a/src/transpile.zig
+++ b/src/transpile.zig
@@ -9,7 +9,6 @@
 //!   - 향후 NAPI 바인딩의 단일 파일 API
 
 const std = @import("std");
-const builtin = @import("builtin");
 const Scanner = @import("lexer/mod.zig").Scanner;
 const Parser = @import("parser/parser.zig").Parser;
 const ast_mod = @import("parser/ast.zig");
@@ -137,20 +136,11 @@ fn prependImportLine(allocator: std.mem.Allocator, prefix: ?[]const u8, body: []
     return combined.items;
 }
 
-var fast_path_disabled_once = std.once(computeFastPathDisabledByEnv);
-var fast_path_disabled_value: bool = false;
-
-fn computeFastPathDisabledByEnv() void {
-    if (comptime builtin.os.tag == .wasi and !builtin.link_libc) {
-        fast_path_disabled_value = false;
-        return;
-    }
-    fast_path_disabled_value = std.process.hasEnvVarConstant("ZNTC_DISABLE_TRANSPILE_FAST_PATH");
-}
+// env-presence flag — 공용 제너릭 (RFC #3399 PR-3: 중복 boilerplate 통합).
+const fast_path_disabled_env = @import("env_flag.zig").Once("ZNTC_DISABLE_TRANSPILE_FAST_PATH");
 
 fn transpileFastPathDisabledByEnv() bool {
-    fast_path_disabled_once.call();
-    return fast_path_disabled_value;
+    return fast_path_disabled_env.enabled();
 }
 
 fn collectAstFacts(ast: *const Ast) AstFacts {


### PR DESCRIPTION
## epic 승격 (shared-ns dead-emit, 이슈 #3399 / RFC #3398)

measure-first 게이트 **통과** → epic 격리 브랜치를 main 으로 승격. nested-renamer epic(NO-GO 폐기)과 달리 **실제 win**. member-augment(#3359) 이후 이 size-epic 첫 진짜 win.

### 포함 (최신 main rebase + 2 커밋)
- **PR-2 #3407**: namespace `X.member` → exp.local 직접 재작성 (esbuild `StarNameLoc` 기법). `Linker.nsMemberRewriteSafe()` (mangle-safe 경로) 일 때 `hasNestedBinding` shadow-skip 비활성 → ns-object 미생성. `ZNTC_NO_NS_REWRITE` kill-switch.
- **PR-3 #3408**: env-presence flag boilerplate → `src/env_flag.zig` `Once()` 제너릭 단일화 (byte-identical).

### 종합 회귀 검증 (승격 직전, 최신 main 대비)
| 검증 | 결과 |
|---|---|
| 유닛 Debug + ReleaseFast | 5211/5215, **0 fail** |
| 전수 smoke 144-lib build 회귀 | **0** |
| runtime outputMatch 회귀 | **0** (정확성 전수 보존) |
| size 증가 | **0** (회귀 lib 없음) |
| effect | 160,876 → 127,830 **(−20.5%)** |
| corpus 총합 | −33,046 B (−0.642%, effect 단독) |

### 근본 (직접 빌드파일 diff 가 결정타)
effect `ZNTC 160,876 vs rolldown 125,417` 격차의 105%(37KB)가 `var X_ns={};augment(...)` 스캐폴드 43개 — competitor 는 `X.member`→직접심볼 재작성으로 객체 통째 제거. 안전성 = mangler invariant (`collectUnifiedInput` 이 ns target 을 항상 cross_module reserve → nested local 동명 불가, Debug panic 증명). 비-minify/dev/preserve-modules 는 보수적 shadow-skip 유지.

### caveat (정직)
순효과는 effect/@effect/fp-ts cohort 집중 (ns-barrel 없는 zod/three 등 불변). RN production minify 번들은 144-lib smoke 미포함 (invariant 상 안전, 실측 외).

Closes #3399

🤖 Generated with [Claude Code](https://claude.com/claude-code)