### PR TITLE
feat(mf): mf-manifest.json 에미터 — webpack/rspack MF 호환 스키마 (#3387)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1350,6 +1350,10 @@ pub const Bundler = struct {
         var output_scope = profile.begin(.emit_output);
         var output: []const u8 = "";
         var outputs: ?[]OutputFile = null;
+        // #3318 P1-5: MF remote 의 mf-manifest.json (wrapContainer 산출,
+        // asset_outputs 로 편입). errdefer 로 부분실패 누수 방지.
+        var mf_manifest: ?[]const u8 = null;
+        errdefer if (mf_manifest) |m| self.allocator.free(m);
         // code splitting 경로에서 청크별로 분리 emit 한 CSS (null = 비-splitting,
         // 이 경우 아래에서 entry 당 단일 CSS 로 fallback). 소비 후 null 로 되돌린다.
         var css_chunk_files: ?[]OutputFile = null;
@@ -1472,7 +1476,7 @@ pub const Bundler = struct {
             // webpack-style container(init/get, globalName 대입)로 후처리
             // wrap. 게이트는 markBoundary(graph.build 후)와 동일 관례.
             if (self.options.mf) |*mf|
-                try @import("federation_emit.zig").wrapContainer(self.allocator, outputs.?, mf, &graph);
+                mf_manifest = try @import("federation_emit.zig").wrapContainer(self.allocator, outputs.?, mf, &graph, self.options.public_path);
 
             // emitChunks 가 href 를 청크 내용으로 복사 완료 → 이제 plan 의
             // path/contents 소유권을 OutputFile 로 이전(plan 컨테이너만 해제).
@@ -1637,10 +1641,11 @@ pub const Bundler = struct {
             }
         }
 
-        // Worker + CSS 출력 파일을 asset_outputs에 합침
-        const final_asset_outputs: ?[]OutputFile = if (worker_output_files.items.len > 0 or asset_outputs != null or css_output_files.items.len > 0) blk: {
+        // Worker + CSS + mf-manifest 출력 파일을 asset_outputs에 합침
+        const final_asset_outputs: ?[]OutputFile = if (worker_output_files.items.len > 0 or asset_outputs != null or css_output_files.items.len > 0 or mf_manifest != null) blk: {
             const existing = if (asset_outputs) |a| a.len else 0;
-            const total = existing + worker_output_files.items.len + css_output_files.items.len;
+            const mf_n: usize = if (mf_manifest != null) 1 else 0;
+            const total = existing + worker_output_files.items.len + css_output_files.items.len + mf_n;
             const merged = try self.allocator.alloc(OutputFile, total);
             if (asset_outputs) |a| {
                 @memcpy(merged[0..a.len], a);
@@ -1652,6 +1657,14 @@ pub const Bundler = struct {
             const css_start = existing + worker_output_files.items.len;
             for (css_output_files.items, 0..) |cf, i| {
                 merged[css_start + i] = cf;
+            }
+            if (mf_manifest) |m| {
+                // path dup 먼저(실패해도 errdefer 가 m 해제). 성공 후 소유권
+                // 이전 + mf_manifest=null(errdefer 이중해제 방지). deinit 이
+                // asset_outputs path/contents 해제 — 소유 일관.
+                const p = try self.allocator.dupe(u8, "mf-manifest.json");
+                merged[css_start + css_output_files.items.len] = .{ .path = p, .contents = m };
+                mf_manifest = null;
             }
             break :blk merged;
         } else asset_outputs;
@@ -1807,30 +1820,10 @@ fn generateMetafileJson(
     return buf.toOwnedSlice(allocator);
 }
 
-fn appendJsonString(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, s: []const u8) !void {
-    try buf.append(allocator, '"');
-    for (s) |c| {
-        switch (c) {
-            '"' => try buf.appendSlice(allocator, "\\\""),
-            '\\' => try buf.appendSlice(allocator, "\\\\"),
-            '\n' => try buf.appendSlice(allocator, "\\n"),
-            '\r' => try buf.appendSlice(allocator, "\\r"),
-            '\t' => try buf.appendSlice(allocator, "\\t"),
-            // JSON spec: 0x00–0x1F 모든 control char 는 반드시 escape.
-            // ZNTC virtual specifier (NUL+"zntc:runtime/...") 등이 raw NUL 그대로
-            // 들어가면 JSON.parse 가 "Bad control character" 로 reject.
-            0x00...0x07, 0x0B, 0x0E...0x1F => {
-                var tmp: [6]u8 = .{ '\\', 'u', '0', '0', 0, 0 };
-                const hex = "0123456789abcdef";
-                tmp[4] = hex[(c >> 4) & 0xF];
-                tmp[5] = hex[c & 0xF];
-                try buf.appendSlice(allocator, &tmp);
-            },
-            else => try buf.append(allocator, c),
-        }
-    }
-    try buf.append(allocator, '"');
-}
+// JSON 문자열 리터럴 단일 소스(metafile + mf-manifest 공유). emitter.zig
+// 가 정본 — 양쪽이 import 하는 중립 모듈(circular import 회피, types.zig
+// 패턴과 동일 규율).
+const appendJsonString = emitter.appendJsonString;
 
 fn appendInt(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, val: usize) !void {
     var tmp: [20]u8 = undefined;

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1966,6 +1966,28 @@ const emitAssetModule = cjs_wrap.emitAssetModule;
 pub const emitCjsWrapper = cjs_wrap.emitCjsWrapper;
 pub const appendJsStringLiteral = cjs_wrap.appendJsStringLiteral;
 
+/// JSON 문자열 리터럴 emit (metafile + mf-manifest 단일 소스). JSON spec:
+/// C0 control(0x00–0x1F) 은 전부 escape — 전용 escape 가 있는 \t(0x09)\n
+/// (0x0A)\r(0x0D) 외 **0x08(\b)·0x0C(\f) 포함** 누락 시 raw 출력 →
+/// JSON.parse "Bad control character" reject(ZNTC virtual specifier 의
+/// raw NUL 등). `*std.ArrayList(u8)` = Zig 0.15.2 에선 Unmanaged 와 동일.
+pub fn appendJsonString(buf: *std.ArrayList(u8), allocator: std.mem.Allocator, s: []const u8) !void {
+    try buf.append(allocator, '"');
+    for (s) |c| switch (c) {
+        '"' => try buf.appendSlice(allocator, "\\\""),
+        '\\' => try buf.appendSlice(allocator, "\\\\"),
+        '\n' => try buf.appendSlice(allocator, "\\n"),
+        '\r' => try buf.appendSlice(allocator, "\\r"),
+        '\t' => try buf.appendSlice(allocator, "\\t"),
+        0x00...0x08, 0x0B, 0x0C, 0x0E...0x1F => {
+            const hex = "0123456789abcdef";
+            try buf.appendSlice(allocator, &[_]u8{ '\\', 'u', '0', '0', hex[(c >> 4) & 0xF], hex[c & 0xF] });
+        },
+        else => try buf.append(allocator, c),
+    };
+    try buf.append(allocator, '"');
+}
+
 /// 런타임 헬퍼 문자열을 ArrayList에 주입한다 (re-export for backward compat).
 pub const appendRuntimeHelpers = rt.appendRuntimeHelpers;
 

--- a/src/bundler/federation_emit.zig
+++ b/src/bundler/federation_emit.zig
@@ -96,27 +96,23 @@ fn bootstrapSpan(text: []const u8) ?struct { start: usize, end: usize } {
     return .{ .start = s, .end = end };
 }
 
-/// emitChunks 산출을 in-place 로 container 화. 게이트는 호출부
-/// (`if (options.mf) |mf|`, bundler.zig — markBoundary 와 동일 관례).
-pub fn wrapContainer(
+/// expose 명·federation_id·lazy 청크 파일명 묶음. 모두 borrow
+/// (name=mf.exposes KV, fed_id=graph 모듈, chunk_file=outputs[].path basename)
+/// — wrapContainer 수명 동안 mf/graph/outputs 생존. 슬라이스만 caller free.
+const ExposeInfo = struct { name: []const u8, fed_id: []const u8, chunk_file: []const u8 };
+
+/// exposes → (명, fed_id, lazy 청크 파일) 수집. container.get 맵과
+/// mf-manifest 가 **동일 스캔**을 쓰므로 단일 소스(exposeFedId/
+/// exposeChunkFile 재사용). 미해결 expose 는 warn 후 skip(부분 산출).
+fn collectExposes(
     allocator: std.mem.Allocator,
-    outputs: []emitter.OutputFile,
+    outputs: []const emitter.OutputFile,
     mf: *const types.MfBundleConfig,
     graph: anytype,
-) !void {
-    if (mf.exposes.len == 0) return; // host(shared/remotes-only) = container 아님
-    const name = mf.name orelse return; // remote 는 P1-0 검증이 name 강제
-
-    const cwd = federation.cwdRealpath(allocator); // WASI-safe(comptime 분기)
-    defer if (cwd) |c| allocator.free(c);
-
-    // ── container 객체 문자열 빌드(min-무관 compact, 유효 JS) ──
-    var buf: std.ArrayListUnmanaged(u8) = .empty;
-    defer buf.deinit(allocator);
-    const w = buf.writer(allocator);
-
-    try buf.appendSlice(allocator, "(function(g){var __zntc_mf_container={get:function(e){var M={");
-    var first = true;
+    cwd: ?[]const u8,
+) ![]ExposeInfo {
+    var list: std.ArrayListUnmanaged(ExposeInfo) = .empty;
+    errdefer list.deinit(allocator);
     for (mf.exposes) |kv| {
         const abs = federation.resolveAbs(allocator, cwd, kv.value) catch continue;
         defer allocator.free(abs);
@@ -128,15 +124,45 @@ pub fn wrapContainer(
             std.log.warn("[mf] expose '{s}' 청크 산출 없음 — container.get 누락", .{kv.key});
             continue;
         };
-        if (!first) try buf.appendSlice(allocator, ",");
-        first = false;
+        try list.append(allocator, .{ .name = kv.key, .fed_id = fed_id, .chunk_file = file });
+    }
+    return list.toOwnedSlice(allocator);
+}
+
+/// emitChunks 산출을 in-place 로 container 화 + mf-manifest.json 산출.
+/// 반환: manifest JSON(allocator 소유, caller=bundler.zig 가 asset_outputs
+/// 로 편입·해제). host(exposes 없음)면 null. 게이트는 호출부
+/// (`if (options.mf) |mf|`, bundler.zig — markBoundary 와 동일 관례).
+pub fn wrapContainer(
+    allocator: std.mem.Allocator,
+    outputs: []emitter.OutputFile,
+    mf: *const types.MfBundleConfig,
+    graph: anytype,
+    public_path: []const u8,
+) !?[]const u8 {
+    if (mf.exposes.len == 0) return null; // host(shared/remotes-only) = container 아님
+    const name = mf.name orelse return null; // remote 는 P1-0 검증이 name 강제
+
+    const cwd = federation.cwdRealpath(allocator); // WASI-safe(comptime 분기)
+    defer if (cwd) |c| allocator.free(c);
+
+    const exposes = try collectExposes(allocator, outputs, mf, graph, cwd);
+    defer allocator.free(exposes);
+
+    // ── container 객체 문자열 빌드(min-무관 compact, 유효 JS) ──
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    defer buf.deinit(allocator);
+    const w = buf.writer(allocator);
+
+    try buf.appendSlice(allocator, "(function(g){var __zntc_mf_container={get:function(e){var M={");
+    for (exposes, 0..) |ex, ei| {
+        if (ei > 0) try buf.appendSlice(allocator, ",");
         // MF2 계약: get(expose) ⇒ Promise<factory>, factory() ⇒ Module
         // (webpack remoteEntry: `.then(()=>()=>require(id))`). 모듈 자체가
         // 아니라 thunk resolve — factory() 호출 전엔 미평가(추가 lazy).
-        // "<expose>":function(){return __zntc_load_chunk("<file>").then(function(){return function(){return __zntc_require("<fed_id>")}})}
         try w.print(
             "\"{s}\":function(){{return __zntc_load_chunk(\"{s}\").then(function(){{return function(){{return __zntc_require(\"{s}\")}}}})}}",
-            .{ kv.key, file, fed_id },
+            .{ ex.name, ex.chunk_file, ex.fed_id },
         );
     }
     try w.print(
@@ -195,6 +221,9 @@ pub fn wrapContainer(
     // ── remoteEntry(부트스트랩 보유 청크) 의 bootstrap 을 container 로 치환 ──
     for (outputs) |*o| {
         const span = bootstrapSpan(o.contents) orelse continue;
+        // entry 청크 = remoteEntry. o.path 는 splice 후에도 불변(해시 확정)
+        // → basename = manifest.metaData.remoteEntry.name.
+        const remote_entry = std.fs.path.basename(o.path);
         var next: std.ArrayListUnmanaged(u8) = .empty;
         errdefer next.deinit(allocator);
         try next.appendSlice(allocator, o.contents[0..span.start]);
@@ -206,10 +235,75 @@ pub fn wrapContainer(
         const owned = try next.toOwnedSlice(allocator);
         allocator.free(o.contents);
         o.contents = owned;
-        return;
+        // mf-manifest.json (S4 박제 스키마 — runtime SnapshotHandler 가
+        // metaData/exposes/shared 필수). 같은 시점이라 모든 해시 확정.
+        return try buildManifest(allocator, name, exposes, remote_entry, public_path);
     }
     // mf 빌드인데 reg_split 부트스트랩이 없음 = 잘못된 구성(format/splitting).
     // 조용한 오작동(container 없는 산출) 금지 — federation.zig 진단 관례.
     std.log.err("[mf] remoteEntry 부트스트랩 앵커 없음 — mf 빌드는 --format=iife/umd/amd + splitting 필요", .{});
     return MfEmitError.RemoteEntryAnchorMissing;
+}
+
+/// JSON 문자열 리터럴 — emitter.zig 단일 소스(metafile 과 공유, 0x08/
+/// 0x0C 포함 C0 전체 escape). 중립 모듈이라 circular import 없음.
+const appendJsonStr = emitter.appendJsonString;
+
+/// mf-manifest.json (webpack/rspack MF 호환, `@module-federation/sdk@2.4.0`
+/// Manifest 타입 + runtime-core SnapshotHandler:161 필수필드 실측).
+/// runtime 동작필수: metaData(remoteEntry/buildInfo/globalName/publicPath)·
+/// exposes·shared(빈 배열 OK)·remotes. types/.d.ts·shared 정밀화는 비-목표
+/// (P3/P1-6). public_path 비면 "auto"(runtime 이 manifestUrl 에서 추론).
+/// buildVersion/pluginVersion="0.1.0" 박제: runtime 은 이 값을 snapshot
+/// 식별/캐시 힌트로만 쓰고 의미 검증 안 함(generateSnapshotFromManifest)
+/// — lockstep 패키지 버전 추적은 불필요(P1-6 비-목표). build-time 주입은
+/// 후속 백로그.
+fn buildManifest(
+    allocator: std.mem.Allocator,
+    name: []const u8,
+    exposes: []const ExposeInfo,
+    remote_entry: []const u8,
+    public_path: []const u8,
+) ![]const u8 {
+    var b: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer b.deinit(allocator);
+    const pp = if (public_path.len > 0) public_path else "auto";
+
+    try b.appendSlice(allocator, "{\"id\":");
+    try appendJsonStr(&b, allocator, name);
+    try b.appendSlice(allocator, ",\"name\":");
+    try appendJsonStr(&b, allocator, name);
+    try b.appendSlice(allocator, ",\"metaData\":{\"name\":");
+    try appendJsonStr(&b, allocator, name);
+    // type:"app"(MFModuleType.APP — remote 도 app). remoteEntry.type:"global"
+    // (P1-3 가 globalName 전역 노출 = webpack global 라이브러리). path:""→
+    // runtime simpleJoinRemoteEntry 가 name 만 → publicPath+name URL 합성.
+    try b.appendSlice(allocator, ",\"type\":\"app\",\"buildInfo\":{\"buildVersion\":\"0.1.0\",\"buildName\":");
+    try appendJsonStr(&b, allocator, name);
+    try b.appendSlice(allocator, "},\"remoteEntry\":{\"name\":");
+    try appendJsonStr(&b, allocator, remote_entry);
+    try b.appendSlice(allocator, ",\"path\":\"\",\"type\":\"global\"},\"types\":{\"path\":\"\",\"name\":\"\",\"zip\":\"\",\"api\":\"\"},\"globalName\":");
+    try appendJsonStr(&b, allocator, name);
+    try b.appendSlice(allocator, ",\"pluginVersion\":\"0.1.0\",\"publicPath\":");
+    try appendJsonStr(&b, allocator, pp);
+    try b.appendSlice(allocator, "},\"shared\":[],\"remotes\":[],\"exposes\":[");
+    for (exposes, 0..) |ex, ei| {
+        if (ei > 0) try b.append(allocator, ',');
+        // id = "<name>:<expose키에서 './' 제거>" (MF 규약, 예 app:Widget).
+        const short = if (std.mem.startsWith(u8, ex.name, "./")) ex.name[2..] else ex.name;
+        try b.appendSlice(allocator, "{\"id\":");
+        const id = try std.fmt.allocPrint(allocator, "{s}:{s}", .{ name, short });
+        defer allocator.free(id);
+        try appendJsonStr(&b, allocator, id);
+        try b.appendSlice(allocator, ",\"name\":");
+        try appendJsonStr(&b, allocator, ex.name);
+        try b.appendSlice(allocator, ",\"path\":");
+        try appendJsonStr(&b, allocator, ex.name);
+        // expose 는 자기 lazy 청크 → js.async=[청크], sync=[]. css 는 비-목표.
+        try b.appendSlice(allocator, ",\"assets\":{\"js\":{\"sync\":[],\"async\":[");
+        try appendJsonStr(&b, allocator, ex.chunk_file);
+        try b.appendSlice(allocator, "]},\"css\":{\"sync\":[],\"async\":[]}}}");
+    }
+    try b.appendSlice(allocator, "]}");
+    return b.toOwnedSlice(allocator);
 }

--- a/tests/integration/tests/mf-runtime-interop-smoke.test.ts
+++ b/tests/integration/tests/mf-runtime-interop-smoke.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, afterEach } from 'bun:test';
 import { createServer, type Server } from 'node:http';
-import { readFile } from 'node:fs/promises';
+import { readFile, readdir } from 'node:fs/promises';
 import { writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { createRequire } from 'node:module';
@@ -167,4 +167,75 @@ console.log('SAME=' + (m && m.usedHook === hostReact.useState));
     expect(stdout).toContain('SAME=true'); // host↔remote 동일 react 인스턴스
     expect(stderr).not.toMatch(/RUNTIME-00\d|does not contain "init"|eager consumption/);
   }, 30000);
+
+  // P1-5 (#3387): mf-manifest.json 에미터. webpack/rspack MF 호환 스키마
+  // (@module-federation/sdk@2.4.0 Manifest 타입 + runtime-core
+  // SnapshotHandler:161 필수키 metaData/exposes/shared). content-hash
+  // 청크 배선(S5 재사용). manifest-driven 실브라우저 loadRemote 전체 실행
+  // 은 P1-7(Playwright — Node 는 http chunk import 미지원). 여기선
+  // 결정적 스키마 + 실제 산출 파일명 배선 검증.
+  test('mf-manifest.json: S4 스키마 + content-hash 청크 배선', async () => {
+    const fx = await createFixture({
+      'Widget.ts': `export default function Widget() { return "M-OK"; }`,
+      'index.ts': `export const sentinel = "remote-entry";`,
+      'zntc.config.json': JSON.stringify({
+        mf: { name: 'app', exposes: { './Widget': './Widget.ts', './a/B': './Widget.ts' } },
+      }),
+    });
+    cleanup = fx.cleanup;
+    const dist = join(fx.dir, 'dist');
+    const b = await runZntcInDir(fx.dir, [
+      '--bundle',
+      join(fx.dir, 'index.ts'),
+      '--outdir',
+      dist,
+      '--format=iife',
+    ]);
+    expect(b.exitCode).toBe(0);
+
+    const files = await readdir(dist);
+    expect(files).toContain('mf-manifest.json');
+    const mani = JSON.parse(await readFile(join(dist, 'mf-manifest.json'), 'utf8'));
+
+    // runtime-core SnapshotHandler:161 필수키(없으면 assert throw)
+    expect(mani.metaData).toBeDefined();
+    expect(Array.isArray(mani.exposes)).toBe(true);
+    expect(Array.isArray(mani.shared)).toBe(true);
+    expect(Array.isArray(mani.remotes)).toBe(true);
+    // top-level + metaData (S4 박제)
+    expect(mani.id).toBe('app');
+    expect(mani.name).toBe('app');
+    expect(mani.metaData.globalName).toBe('app');
+    expect(mani.metaData.type).toBe('app');
+    expect(mani.metaData.remoteEntry.type).toBe('global');
+    expect(mani.metaData.publicPath).toBe('auto'); // --public-path 미지정 → runtime 추론
+    expect(mani.metaData.buildInfo.buildVersion).toBeTruthy();
+    // remoteEntry.name == 실제 산출된 entry 청크 파일명
+    const entryFile = files.find(
+      (f) =>
+        f.endsWith('.js') &&
+        f !== 'mf-manifest.json' &&
+        readFileSyncSafe(join(dist, f)).includes('__zntc_mf_container'),
+    );
+    expect(mani.metaData.remoteEntry.name).toBe(entryFile);
+    // exposes: id="app:<short>", name=키, assets.js.async=실제 lazy 청크
+    expect(mani.exposes.length).toBe(2);
+    const w = mani.exposes.find((e: { name: string }) => e.name === './Widget');
+    expect(w.id).toBe('app:Widget');
+    expect(w.path).toBe('./Widget');
+    expect(w.assets.js.sync).toEqual([]);
+    expect(w.assets.js.async.length).toBe(1);
+    expect(files).toContain(w.assets.js.async[0]); // 매니페스트가 가리키는 청크 실재
+    expect(w.assets.css).toEqual({ sync: [], async: [] });
+    const ab = mani.exposes.find((e: { name: string }) => e.name === './a/B');
+    expect(ab.id).toBe('app:a/B'); // './' 만 제거(중첩 경로 보존)
+  });
 });
+
+function readFileSyncSafe(p: string): string {
+  try {
+    return require('node:fs').readFileSync(p, 'utf8');
+  } catch {
+    return '';
+  }
+}


### PR DESCRIPTION
## 무엇 (#3387, MF epic P1-5)

zntc remote(`mf.exposes`) 빌드에 별도 **`mf-manifest.json`** 산출. S4 가 실 `@rspack/core`+`@module-federation/enhanced` 로 박제하고 **`@module-federation/sdk@2.4.0` Manifest 타입 + `runtime-core` SnapshotHandler:161 필수키**(metaData/exposes/shared)로 실측 검증한 스키마.

## 어떻게

- **`collectExposes` 추출**: `wrapContainer` get-map 루프와 manifest 가 expose 스캔(`exposeFedId`/`exposeChunkFile`)을 **1회만 공유**(단일 소스, 중복 스캔 0).
- **`buildManifest`**: S4 스키마 JSON — `{id,name,metaData{name,type:"app",buildInfo,remoteEntry{name:실entry청크,path:"",type:"global"},globalName,publicPath},shared:[],remotes:[],exposes:[{id:"<name>:<short>",name,path,assets:{js:{sync:[],async:[실lazy청크]},css:{...}}}]}`. `--public-path` 비면 `"auto"`(runtime 이 manifestUrl 에서 추론). content-hash 청크 파일명은 emitChunks 직후(해시 확정) 시점에 배선(S5 재사용).
- **`wrapContainer` `!void`→`!?[]const u8`**(manifest 반환, host=null) + `public_path` 인자. `bundler.zig` 가 반환 manifest 를 `asset_outputs` merge(worker/css 동형 패턴)에 `OutputFile` 편입 → CLI/JS API outdir 자동 기록. errdefer/소유권: dupe-먼저 → `mf_manifest=null`(이중해제 방지), `BundleResult.deinit` 일관.

## 검증

- 실 `@module-federation/[email protected]` S2/S3 회귀 + **mf-manifest 형태**: SnapshotHandler 필수키 존재, `metaData.remoteEntry.name` == 실제 산출 entry 청크, `exposes[].assets.js.async` == 실제 lazy 청크(실재 확인), 중첩 expose `./a/B` → id `app:a/B`(`./` 만 제거) — **3·0**.
- 회귀 0: mf/iife/umd/amd/cjs splitting/dynamic/cross-chunk/smoke **278·0**. `zig build test`/`wasm-bundler` EXIT=0. lint/fmt 0.

> Node 는 http chunk `import()` 미지원 → manifest-driven 실브라우저 `loadRemote` 전체 실행은 **P1-7(Playwright)**. P1-5 Node 검증 = 결정적 스키마 + 실 산출 파일명 배선(runtime↔container 계약은 S3/S2 가 이미 입증).

## /simplify (3-에이전트)

차단 0. **`appendJsonString` emitter.zig 단일소스화**(metafile+manifest 공유, circular import 회피 = 중립 모듈). 부수 **잠재 버그 수정**: 기존 `appendJsonString` 의 `0x08(\b)`/`0x0C(\f)` escape 누락(raw 출력 → `JSON.parse` reject) → C0 전체 escape 로 교정(metafile 도 수혜). `collectExposes`/asset_outputs 편입/ExposeInfo borrow 는 기존 패턴 일관(거짓양성). buildVersion 박제 근거 주석.

## 비-목표 (decomposition)

P1-6 host 통합·shared manifest 정밀(`shared:[]`) · P1-7 Playwright manifest-driven 실행/S4 역방향 · `.d.ts` type-hinting(D3/P3) · mf-stats.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)