### PR TITLE
feat(mf): host 통합 — @module-federation/runtime 재사용 (config→init 배선) (#3388)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1730,6 +1730,18 @@ pub const Bundler = struct {
             else
                 null;
 
+        // #3318 P1-6: host(mf.remotes) — 단일파일 출력에 init prelude +
+        // 원격 동적 import→loadRemote 재작성. split 경로(output="" — host
+        // 가 동시에 remote 인 niche)는 후속(follow-up). 게이트 = wrapContainer
+        // 와 동일 관례(markBoundary).
+        if (self.options.mf) |*mf| {
+            if (mf.remotes.len > 0 and output.len > 0) {
+                const host_out = try @import("federation_emit.zig").emitHostInit(self.allocator, output, mf);
+                self.allocator.free(output);
+                output = host_out;
+            }
+        }
+
         return .{
             .output = output,
             .sourcemap = dev_sourcemap,

--- a/src/bundler/federation.zig
+++ b/src/bundler/federation.zig
@@ -18,6 +18,20 @@ const ModuleIndex = types.ModuleIndex;
 const module_id = @import("module_id.zig");
 const resolve_cache = @import("resolve_cache.zig");
 
+/// P1-6 host: 스펙 런타임 패키지(자체 재구현 금지=D1) 및 그 글로벌 seam.
+/// **단일 소스** — applyMfRemotesSeam(cli/options.zig)이 external+글로벌로
+/// 걸고 emitHostInit(federation_emit.zig)이 그 글로벌로 init/loadRemote
+/// 배선. 두 곳이 반드시 일치해야 동작(mfSharedGlobalName 단일소스 선례).
+pub const MF_RUNTIME_PKG = "@module-federation/runtime";
+pub const MF_RUNTIME_GLOBAL = "__mf_runtime";
+
+/// specifier 가 원격(`<key>` 정확 또는 `<key>/...` sub-path)인가.
+/// resolve_cache.matchPackageSubPath 재사용 — host 치환 판정과 런타임
+/// external 판정이 **동일 규칙**(분기 시 `react/*` 류 key 에서 불일치).
+pub fn matchesRemoteSpec(spec: []const u8, key: []const u8) bool {
+    return std.mem.eql(u8, spec, key) or resolve_cache.matchPackageSubPath(key, spec);
+}
+
 /// cwd 절대경로(realpath). **WASI 는 realpath 미지원** — `std.fs.cwd().
 /// realpathAlloc` 는 wasm32-wasi 에서 `@compileError`(runtime catch 무관,
 /// 참조 자체가 컴파일 실패). comptime os 분기로 비-WASI 만 realpath, WASI

--- a/src/bundler/federation_emit.zig
+++ b/src/bundler/federation_emit.zig
@@ -27,6 +27,95 @@ const BOOTSTRAP_ANCHOR = "globalThis.__zntc_require(\"";
 
 const MfEmitError = error{RemoteEntryAnchorMissing};
 
+const MF_RUNTIME_GLOBAL = federation.MF_RUNTIME_GLOBAL; // 단일 소스
+
+/// `mf.remotes` KV.value(`<name>@<entry>`) → (name, entry). `@` 첫 등장
+/// split. name 부분 비면 KV.key fallback. `@` 없으면 value 전체=entry.
+/// 한계: scoped-like value(`@scope/x@url`)는 첫 `@`(idx 0) split →
+/// name="" → key fallback, entry 는 `@` 손실(`scope/x@url`). MF remote
+/// value 관례는 `bareName@url` 라 비규약 입력 — 비지원(문서화).
+fn parseRemote(kv: types.MfBundleConfig.KV) struct { name: []const u8, entry: []const u8 } {
+    if (std.mem.indexOfScalar(u8, kv.value, '@')) |at| {
+        const nm = kv.value[0..at];
+        return .{ .name = if (nm.len > 0) nm else kv.key, .entry = kv.value[at + 1 ..] };
+    }
+    return .{ .name = kv.key, .entry = kv.value };
+}
+
+/// specifier 가 어떤 remote(`<key>`/`<key>/...`)에 매칭 — 판정 규칙은
+/// federation.matchesRemoteSpec 단일 소스(런타임 external 판정과 동일).
+fn isRemoteSpec(spec: []const u8, mf: *const types.MfBundleConfig) bool {
+    for (mf.remotes) |kv| if (federation.matchesRemoteSpec(spec, kv.key)) return true;
+    return false;
+}
+
+/// P1-6 host emit: 스펙 `@module-federation/runtime` 재사용(D1 — 자체
+/// 재구현 금지). src 앞에 init prelude(`globalThis.__mf_runtime.init({name,
+/// remotes})`)를 prepend + 원격 동적 `import("remote/x")` 를
+/// `globalThis.__mf_runtime.loadRemote("remote/x")` 로 치환. runtime 은
+/// applyMfRemotesSeam 이 external+글로벌(__mf_runtime) 처리 → host 환경이
+/// 그 글로벌로 스펙 런타임 제공(P1-2/P1-3 글로벌-seam 모델 일관, iife/umd/
+/// amd valid). 반환 = 새 owned 문자열(caller 가 기존 src free). 정적
+/// `import X from "remote/x"` 는 비-목표(async 강등 필요 — 후속).
+pub fn emitHostInit(
+    allocator: std.mem.Allocator,
+    src: []const u8,
+    mf: *const types.MfBundleConfig,
+) ![]const u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+    const w = out.writer(allocator);
+
+    // ── init prelude (멱등: runtime.init 자체 멱등) ──
+    try out.appendSlice(allocator, "(function(){var R=globalThis." ++ MF_RUNTIME_GLOBAL ++ ";if(R&&R.init)R.init({\"name\":");
+    try emitter.appendJsonString(&out, allocator, mf.name orelse "host");
+    try out.appendSlice(allocator, ",\"remotes\":[");
+    for (mf.remotes, 0..) |kv, i| {
+        if (i > 0) try out.append(allocator, ',');
+        const r = parseRemote(kv);
+        try out.appendSlice(allocator, "{\"name\":");
+        try emitter.appendJsonString(&out, allocator, r.name);
+        try out.appendSlice(allocator, ",\"entry\":");
+        try emitter.appendJsonString(&out, allocator, r.entry);
+        try out.append(allocator, '}');
+    }
+    try out.appendSlice(allocator, "]});})();");
+
+    // ── 원격 동적 import 재작성: `import(<q><remote>...)` →
+    //    `globalThis.__mf_runtime.loadRemote(<q><remote>...)`. 매칭 외 구간은
+    //    appendSlice 청크 복사(바이트별 append 회피 — 출력크기 비례 O(n),
+    //    wrapContainer splice 와 동일 관례). `import(` 만 교체, 따옴표·
+    //    specifier·잔여(2nd-arg/attributes 포함)는 그대로 보존. ──
+    const NEEDLE = "import(";
+    var last: usize = 0;
+    var i: usize = 0;
+    while (std.mem.indexOfPos(u8, src, i, NEEDLE)) |p| {
+        // 식별자 경계 — `myimport(`/`Reimport(` 부분일치 배제.
+        if (p > 0 and isIdentChar(src[p - 1])) {
+            i = p + NEEDLE.len;
+            continue;
+        }
+        var j = p + NEEDLE.len;
+        while (j < src.len and (src[j] == ' ' or src[j] == '\t')) j += 1;
+        if (j < src.len and (src[j] == '"' or src[j] == '\'')) {
+            const q = src[j];
+            const s0 = j + 1;
+            if (std.mem.indexOfScalarPos(u8, src, s0, q)) |s1| {
+                if (isRemoteSpec(src[s0..s1], mf)) {
+                    try out.appendSlice(allocator, src[last..p]);
+                    try w.print("globalThis.{s}.loadRemote(", .{MF_RUNTIME_GLOBAL});
+                    last = p + NEEDLE.len; // 따옴표부터는 다음 flush 가 보존
+                    i = last;
+                    continue;
+                }
+            }
+        }
+        i = p + NEEDLE.len;
+    }
+    try out.appendSlice(allocator, src[last..]);
+    return out.toOwnedSlice(allocator);
+}
+
 fn isIdentChar(c: u8) bool {
     return c == '_' or c == '$' or std.ascii.isAlphanumeric(c);
 }

--- a/src/cli/options.zig
+++ b/src/cli/options.zig
@@ -407,6 +407,11 @@ fn applyZntcConfigJson(opts: *CliOptions, allocator: std.mem.Allocator) !void {
         // 그대로 재사용 — bundler/emitter/codegen 무변경.
         if (opts.mf) |mfb| {
             try applyMfSharedSeam(allocator, opts, mfb.shared);
+            // P1-6 (#3388): host = remotes 소비자. 원격 specifier(`remoteA`,
+            // `remoteA/...`)와 `@module-federation/runtime`(스펙 런타임, 자체
+            // 재구현 금지=D1) 를 external + 글로벌 seam(P1-2 와 동일 기계) 로.
+            // emitHostInit 이 `__mf_runtime.init/loadRemote` 로 배선.
+            if (mfb.remotes.len > 0) try applyMfRemotesSeam(allocator, opts, mfb.remotes);
             // P1-3 (#3385): exposes 있는 mf = remote → container/exposes 는
             // reg_split 다중-청크(chunk.zig 가 expose→lazy 청크) 위에 얹으므로
             // splitting 필수(부트스트랩은 format=iife/umd/amd 필요 — 없으면
@@ -445,6 +450,32 @@ fn applyMfSharedSeam(
             .global_name = s.global_seam, // borrow (mfBundleFromDto 가 1회 생성·소유)
         });
     }
+}
+
+/// 스펙 런타임 pkg/글로벌 — federation.zig 단일 소스 재노출(emitHostInit
+/// 과 반드시 일치). 고정 상수라 alloc/소유 무관(static literal).
+const MF_RUNTIME_PKG = lib.bundler.federation.MF_RUNTIME_PKG;
+const MF_RUNTIME_GLOBAL = lib.bundler.federation.MF_RUNTIME_GLOBAL;
+
+/// mf.remotes → host 소비 seam. 원격 specifier(KV.key, 예 `remoteA`)는
+/// external — resolve_cache sub-path 매칭이 `remoteA/Widget` 도 자동 external
+/// (esbuild 동등). `@module-federation/runtime` 도 external + 글로벌
+/// (`__mf_runtime`) — host 가 그 글로벌로 스펙 런타임 제공(P1-2 와 동일
+/// 기계, container 글로벌 소비 모델과 일관). emitHostInit 이 init/loadRemote
+/// 를 그 글로벌로 배선. 모든 문자열 borrow(opts.mf KV / static literal).
+fn applyMfRemotesSeam(
+    allocator: std.mem.Allocator,
+    opts: *CliOptions,
+    remotes: []const lib.bundler.MfBundleConfig.KV,
+) !void {
+    for (remotes) |kv| {
+        try opts.external_list.append(allocator, kv.key); // borrow (opts.mf 소유)
+    }
+    try opts.external_list.append(allocator, MF_RUNTIME_PKG);
+    try opts.globals_list.append(allocator, .{
+        .specifier = MF_RUNTIME_PKG,
+        .global_name = MF_RUNTIME_GLOBAL,
+    });
 }
 
 /// `MfConfigDto`(arena, record) → `MfBundleConfig`(CliOptions 수명, 평탄화).

--- a/tests/integration/tests/mf-runtime-interop-smoke.test.ts
+++ b/tests/integration/tests/mf-runtime-interop-smoke.test.ts
@@ -230,6 +230,95 @@ console.log('SAME=' + (m && m.usedHook === hostReact.useState));
     const ab = mani.exposes.find((e: { name: string }) => e.name === './a/B');
     expect(ab.id).toBe('app:a/B'); // './' 만 제거(중첩 경로 보존)
   });
+
+  // P1-6 (#3388): zntc-빌드 host 가 실 @module-federation/runtime 로 remote
+  // 소비. zntc 가 emit 한 init prelude + `import("remote/x")`→loadRemote
+  // 재작성 코드가 **실 스펙 런타임**으로 동작(host-emit 검증, D1 — 자체
+  // 재구현 안 함). remote=zntc(P1-3/5 container+mf-manifest). 정적 import
+  // async 강등·split-host·실브라우저 = P1-7/후속.
+  test('host-emit: zntc host 가 실 runtime 으로 zntc remote 소비', async () => {
+    // 1) zntc remote 빌드(container+mf-manifest, chunk publicPath=file://)
+    const remoteFx = await createFixture({
+      'Widget.ts': `export default function Widget() { return "HOST-CONSUMED-OK"; }`,
+      'index.ts': `export const sentinel = "remote-entry";`,
+      'zntc.config.json': JSON.stringify({
+        mf: { name: 'app', exposes: { './Widget': './Widget.ts' } },
+      }),
+    });
+    const rdist = join(remoteFx.dir, 'dist');
+    const rb = await runZntcInDir(remoteFx.dir, [
+      '--bundle',
+      join(remoteFx.dir, 'index.ts'),
+      '--outdir',
+      rdist,
+      '--format=iife',
+      `--public-path=file://${rdist}/`,
+    ]);
+    expect(rb.exitCode).toBe(0);
+
+    // remote dist http 서빙(.json→application/json — runtime manifest 감지)
+    server = createServer(async (req, res) => {
+      try {
+        const u = req.url === '/' ? '/index.js' : req.url!;
+        const ct = u.endsWith('.json') ? 'application/json' : 'application/javascript';
+        res.writeHead(200, { 'content-type': ct });
+        res.end(await readFile(join(rdist, u)));
+      } catch {
+        res.writeHead(404).end();
+      }
+    });
+    await new Promise<void>((r) => server!.listen(0, r));
+    const port = (server.address() as { port: number }).port;
+
+    // 2) zntc host 빌드(단일파일 iife). mf.remotes → init prelude +
+    //    import("remoteA/Widget")→globalThis.__mf_runtime.loadRemote 재작성.
+    const hostFx = await createFixture({
+      'index.ts':
+        `async function main(){ const m = await import("remoteA/Widget");` +
+        ` console.log("HOST=" + (m.default ?? m)()); }\nmain();`,
+      // 직접 remoteEntry(.js) — runtime 이 http fetch(S3 검증 형태). manifest
+      // (.json) entry 는 publicPath-derived chunk 가 Node http import 불가
+      // (P1-5 분석) → P1-7 Playwright. remote 는 chunk publicPath=file://.
+      'zntc.config.json': JSON.stringify({
+        mf: { name: 'host', remotes: { remoteA: `remoteA@http://localhost:${port}/index.js` } },
+      }),
+    });
+    cleanup = async () => {
+      await hostFx.cleanup();
+      await remoteFx.cleanup();
+    };
+    const hostOut = join(hostFx.dir, 'host.js');
+    const hb = await runZntcInDir(hostFx.dir, [
+      '--bundle',
+      join(hostFx.dir, 'index.ts'),
+      '-o',
+      hostOut,
+      '--format=iife',
+    ]);
+    expect(hb.exitCode).toBe(0);
+    const hostSrc = readFileSyncSafe(hostOut);
+    // init prelude: var R=globalThis.__mf_runtime;if(R&&R.init)R.init({...})
+    expect(hostSrc).toContain('var R=globalThis.__mf_runtime');
+    expect(hostSrc).toContain(
+      'R.init({"name":"host","remotes":[{"name":"remoteA","entry":"http://localhost:',
+    );
+    // 원격 동적 import 재작성
+    expect(hostSrc).toContain('globalThis.__mf_runtime.loadRemote("remoteA/Widget")');
+
+    // 3) 실 @module-federation/runtime 을 글로벌로 제공 후 host 번들 실행
+    const mfRuntime = createRequire(import.meta.url).resolve('@module-federation/runtime');
+    driverPath = join(hostFx.dir, 'host-driver.mjs');
+    writeFileSync(
+      driverPath,
+      `import mf from ${JSON.stringify('file://' + mfRuntime)};\n` +
+        `globalThis.__mf_runtime = mf;\n` +
+        `await import(${JSON.stringify('file://' + hostOut)});\n` +
+        `await new Promise(r => setTimeout(r, 500));\n`,
+    );
+    const { stdout, stderr } = await runNode(driverPath);
+    expect(stdout).toContain('HOST=HOST-CONSUMED-OK'); // zntc host→실 runtime→zntc remote
+    expect(stderr).not.toMatch(/RUNTIME-00\d|does not contain "init"/);
+  }, 30000);
 });
 
 function readFileSyncSafe(p: string): string {


### PR DESCRIPTION
## 무엇 (#3388, MF epic P1-6, D1 하이브리드)

zntc 로 빌드한 **host 앱**이 `mf.remotes` 로 원격 모듈 소비. **스펙 `@module-federation/runtime` 재사용**(자체 재구현 금지=D1 — S3 가 공식 runtime 이 우리 container 구동 증명). **zntc-emit host(init prelude + loadRemote 재작성)가 실 `@module-federation/[email protected]` 으로 zntc remote 를 소비함을 검증**(host-emit 영구 스모크 — `HOST-CONSUMED-OK`).

## 어떻게

- **`applyMfRemotesSeam`**(cli/options.zig): `mf.remotes` key + `@module-federation/runtime` → external + 글로벌 seam(`__mf_runtime`). P1-2 `applyMfSharedSeam` 와 동형(resolve_cache sub-path 가 `remoteA/Widget` 자동 external).
- **`emitHostInit`**(federation_emit.zig): 단일파일 출력 앞에 init prelude `(function(){var R=globalThis.__mf_runtime;if(R&&R.init)R.init({name,remotes});})();` prepend + 원격 동적 `import("remote/x")` → `globalThis.__mf_runtime.loadRemote("remote/x")` 재작성. 글로벌-seam 모델(P1-2/3/4 일관, iife/umd/amd valid). 멱등=runtime.init 자체, RUNTIME-009=prelude 가 본문 앞(자연 충족).
- **bundler.zig**: 단일파일 경로 게이트(`mf.remotes>0 && output.len>0`, wrapContainer 게이트 동형).

## 검증

- **host-emit interop**(영구 스모크): zntc host(단일파일 iife) → 실 `@module-federation/[email protected]`(globalThis.__mf_runtime) → zntc remote(P1-3/5 container) → `HOST=HOST-CONSUMED-OK`. init prelude/loadRemote 재작성 형태 단언 + RUNTIME-00x 0.
- 회귀 0: S2/S3/manifest + host-emit **4·0**, mf/iife/umd/amd/cjs splitting/dynamic/cross-chunk/smoke **279·0**. `zig build test`/`wasm-bundler` EXIT=0, lint 0.

## /simplify (3-에이전트, 차단 0)

① 스캐너 `indexOfPos`+`appendSlice` 청크 복사(바이트별 append 제거 — 출력크기 비례 O(n), wrapContainer splice 관례) + `import(` **식별자 경계검사**(`myimport(`/`Reimport(` 부분일치 배제). ② `MF_RUNTIME_PKG/GLOBAL` + `matchesRemoteSpec` 를 **federation.zig 단일소스**(런타임 external 판정 ↔ 치환 판정 동일 규칙 — `resolve_cache.matchPackageSubPath` 재사용, `mfSharedGlobalName` 단일소스 선례). ③ `parseRemote` scoped-like value 한계 문서화.

## 비-목표 (decomposition)

정적 `import X from "remote/x"` async 강등 / split-host(`output=""` niche) — follow-up · 실브라우저 manifest-driven loadRemote 전체 실행(Node http chunk import 한계) = **P1-7 Playwright** · remotes `alias/type/shareScope` 정밀(`{name,entry}` 만, 과설계 금지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)