### PR TITLE
feat(mf): manifest.shared 정밀 — SharedEntry → ManifestShared (#3420)

### DIFF
--- a/src/bundler/federation_emit.zig
+++ b/src/bundler/federation_emit.zig
@@ -326,7 +326,7 @@ pub fn wrapContainer(
         o.contents = owned;
         // mf-manifest.json (S4 박제 스키마 — runtime SnapshotHandler 가
         // metaData/exposes/shared 필수). 같은 시점이라 모든 해시 확정.
-        return try buildManifest(allocator, name, exposes, remote_entry, public_path);
+        return try buildManifest(allocator, name, mf, exposes, remote_entry, public_path);
     }
     // mf 빌드인데 reg_split 부트스트랩이 없음 = 잘못된 구성(format/splitting).
     // 조용한 오작동(container 없는 산출) 금지 — federation.zig 진단 관례.
@@ -350,6 +350,7 @@ const appendJsonStr = emitter.appendJsonString;
 fn buildManifest(
     allocator: std.mem.Allocator,
     name: []const u8,
+    mf: *const types.MfBundleConfig,
     exposes: []const ExposeInfo,
     remote_entry: []const u8,
     public_path: []const u8,
@@ -375,7 +376,31 @@ fn buildManifest(
     try appendJsonStr(&b, allocator, name);
     try b.appendSlice(allocator, ",\"pluginVersion\":\"0.1.0\",\"publicPath\":");
     try appendJsonStr(&b, allocator, pp);
-    try b.appendSlice(allocator, "},\"shared\":[],\"remotes\":[],\"exposes\":[");
+    // P2-0 (#3420): manifest.shared 정밀. `@module-federation/sdk`
+    // ManifestShared = {id,name,version,singleton,requiredVersion,hash,
+    // assets}. version 은 SharedEntry 에 설치버전이 없어(external+글로벌
+    // seam 처리) requiredVersion 대용 — 정밀 버전 해석은 P2 비-목표(과설계
+    // 경계). assets 빈(seam 이 로딩 담당, generateSnapshotFromManifest 가
+    // name/version 으로 버전협상). hash=""(무결성=P2-2). remotes 는 P2-1.
+    try b.appendSlice(allocator, "},\"shared\":[");
+    for (mf.shared, 0..) |se, si| {
+        if (si > 0) try b.append(allocator, ',');
+        const rv = se.required_version orelse "";
+        try b.appendSlice(allocator, "{\"id\":");
+        const sid = try std.fmt.allocPrint(allocator, "{s}:{s}", .{ name, se.name });
+        defer allocator.free(sid);
+        try appendJsonStr(&b, allocator, sid);
+        try b.appendSlice(allocator, ",\"name\":");
+        try appendJsonStr(&b, allocator, se.name);
+        try b.appendSlice(allocator, ",\"version\":");
+        try appendJsonStr(&b, allocator, rv);
+        try b.appendSlice(allocator, ",\"singleton\":");
+        try b.appendSlice(allocator, if (se.singleton) "true" else "false");
+        try b.appendSlice(allocator, ",\"requiredVersion\":");
+        try appendJsonStr(&b, allocator, rv);
+        try b.appendSlice(allocator, ",\"hash\":\"\",\"assets\":{\"js\":{\"sync\":[],\"async\":[]},\"css\":{\"sync\":[],\"async\":[]}}}");
+    }
+    try b.appendSlice(allocator, "],\"remotes\":[],\"exposes\":[");
     for (exposes, 0..) |ex, ei| {
         if (ei > 0) try b.append(allocator, ',');
         // id = "<name>:<expose키에서 './' 제거>" (MF 규약, 예 app:Widget).

--- a/tests/integration/tests/mf-runtime-interop-smoke.test.ts
+++ b/tests/integration/tests/mf-runtime-interop-smoke.test.ts
@@ -234,14 +234,13 @@ console.log('SAME=' + (m && m.usedHook === hostReact.useState));
     expect(ab.id).toBe('app:a/B'); // './' 만 제거(중첩 경로 보존)
   });
 
-  // P1 알려진 한계 가드(레퍼런스 generateSnapshotFromManifest 대비): zntc
-  // 는 mf.shared 가 있어도 mf-manifest.json 의 shared/remotes 를 항상 빈
-  // 배열로 emit(federation_emit.zig buildManifest). runtime 의 필수키
-  // *존재* assert 는 통과(거부 안 됨)하나, manifest-driven host 는 zntc
-  // remote 의 shared 요구를 manifest 로 알 수 없음 — shared 협상은 글로벌
-  // -seam(P1-2/4)으로만. shared manifest 정밀화는 RFC §7 P2 범위. 이
-  // 가드는 그 한계를 박제(P2 구현 시 의도적으로 갱신).
-  test('알려진 한계: mf.shared 있어도 manifest.shared/remotes = [] (P2 범위)', async () => {
+  // P2-0 (#3420): manifest.shared 정밀. mf.shared → ManifestShared
+  // (@module-federation/sdk: id/name/version/singleton/requiredVersion/
+  // hash/assets). 표준 generateSnapshotFromManifest 가 name/version 으로
+  // 버전협상 — P1 한계(#3419 가드 shared==[]) 해소. remotes 는 P2-1 까지
+  // [] 유지(host 경로, scope 분리). version 은 requiredVersion 대용
+  // (SharedEntry 에 설치버전 없음 — 정밀해석 P2 비-목표).
+  test('P2-0 manifest.shared 정밀: SharedEntry → ManifestShared', async () => {
     const fx = await createFixture({
       'Widget.ts': `import { useState } from "react";\nexport default () => typeof useState;`,
       'index.ts': `export const sentinel = "re";`,
@@ -249,7 +248,10 @@ console.log('SAME=' + (m && m.usedHook === hostReact.useState));
         mf: {
           name: 'app',
           exposes: { './Widget': './Widget.ts' },
-          shared: { react: { singleton: true, requiredVersion: '^19' } },
+          shared: {
+            react: { singleton: true, requiredVersion: '^19' },
+            'react-dom': {},
+          },
         },
       }),
     });
@@ -264,9 +266,25 @@ console.log('SAME=' + (m && m.usedHook === hostReact.useState));
     ]);
     expect(b.exitCode).toBe(0);
     const mani = JSON.parse(await readFile(join(dist, 'mf-manifest.json'), 'utf8'));
-    // 현재 한계: shared 설정돼도 manifest 에는 비어있음. runtime presence
-    // assert 는 통과(배열 존재). P2 에서 shared 정밀 emit 시 이 단언 갱신.
-    expect(mani.shared).toEqual([]);
+    expect(Array.isArray(mani.shared)).toBe(true);
+    expect(mani.shared.length).toBe(2);
+    const r = mani.shared.find((s: { name: string }) => s.name === 'react');
+    expect(r.id).toBe('app:react');
+    expect(r.singleton).toBe(true);
+    expect(r.requiredVersion).toBe('^19');
+    expect(r.version).toBe('^19'); // requiredVersion 대용(P2 경계)
+    expect(r.hash).toBe(''); // 무결성=P2-2
+    // ManifestShared 필수 7필드 전부 + StatsAssets 형태(seam 처리 → 빈)
+    expect(r.assets).toEqual({
+      js: { sync: [], async: [] },
+      css: { sync: [], async: [] },
+    });
+    const rd = mani.shared.find((s: { name: string }) => s.name === 'react-dom');
+    expect(rd.id).toBe('app:react-dom');
+    expect(rd.singleton).toBe(false); // 미지정 → false
+    expect(rd.requiredVersion).toBe(''); // 미지정 → 빈
+    expect(rd.version).toBe(''); // version=requiredVersion 경계(값 없음 쪽도 박제)
+    // remotes 는 P2-1 범위 — 아직 []
     expect(mani.remotes).toEqual([]);
     expect(Array.isArray(mani.exposes) && mani.exposes.length).toBe(1);
   });


### PR DESCRIPTION
## 무엇 (#3420, MF epic P2-0)

`buildManifest` 의 `"shared":[]` 하드코딩 → `mf.shared`(SharedEntry) 순회 → **`@module-federation/sdk` ManifestShared**(id/name/version/singleton/requiredVersion/hash/assets — 7필수) emit. 표준 `generateSnapshotFromManifest` 가 name/version 으로 zntc remote 의 shared 를 **버전협상**에 포함 가능 → P1 한계(#3419 가드 `shared==[]`) 해소.

## 어떻게

- `federation_emit.zig buildManifest`: `mf` 인자 추가(호출부 `wrapContainer` 1곳). shared 루프 = 바로 아래 exposes 루프 **동형**(allocPrint id + per-iter defer free + `appendJsonStr` emitter 단일소스 + assets 리터럴).
- `version` = `required_version` 대용 — `SharedEntry` 에 실제 설치버전 없음(external+글로벌 seam 처리). 정밀 버전해석(package.json)은 **P2 비-목표/과설계 경계**(RFC §7.2 난점 명시). `hash=""`(무결성=P2-2). `assets` 빈 `StatsAssets`(seam 이 로딩 담당, sdk 스키마 1:1). `singleton` bool 리터럴.
- `remotes` 는 **P2-1 까지 `[]` 유지**(host 경로, scope 분리).
- #3419 한계 가드 → P2-0 정밀 검증으로 갱신(ManifestShared 7필수·StatsAssets 형태·version=requiredVersion 양방향 경계·singleton 미지정=false·multi-entry 콤마·remotes=[]).

## 검증

`react(singleton/^19)`+`react-dom({})` → `manifest.shared` 2 ManifestShared 정밀 emit(실측 확인). mf 통합 **7·0**, mf e2e **S3/S4 2·0**(실 `@module-federation/[email protected]` 이 채워진 shared 수용), `zig build test`/`wasm-bundler` EXIT=0, lint/fmt 0. /simplify 3-에이전트 차단 0(defer-in-loop=exposes 동형 검증관례, JSON valid, 시그니처 1호출자 — 거짓양성 확인).

## 비-목표 (RFC §7.2)

정밀 설치버전 해석(package.json) · manifest.hash 무결성(P2-2) · remotes(P2-1) · named-scope 다중.

🤖 Generated with [Claude Code](https://claude.com/claude-code)