### PR TITLE
fix(test): linkNodeModules 가 transitive dep 를 실제로 링크 (CI ubuntu unresolved 수정)

### DIFF
--- a/tests/integration/tests/helpers.ts
+++ b/tests/integration/tests/helpers.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'bun';
-import { mkdtemp, rm, writeFile, mkdir, symlink, stat } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile, mkdir, symlink, realpath } from 'node:fs/promises';
 import { readFileSync, statSync, openSync, closeSync, mkdirSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { dirname, join, relative, resolve } from 'node:path';
 
@@ -12,15 +13,21 @@ export const ZNTC_JS_CLI = join(PROJECT_ROOT, 'packages/core/bin/zntc.mjs');
 const INTEGRATION_NODE_MODULES = resolve(import.meta.dir, '../node_modules');
 const LOOKUP_ROOTS = [join(PROJECT_ROOT, 'node_modules'), INTEGRATION_NODE_MODULES];
 
+/// linkNodeModules 가 helper 레벨에서 해석 못 한 패키지 — 프로세스당 1회만 경고.
+const warnedUnresolved = new Set<string>();
+
+function hasPackageJson(dir: string): boolean {
+  try {
+    statSync(join(dir, 'package.json'));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /// PROJECT_ROOT/node_modules 우선, tests/integration/node_modules fallback으로 패키지 존재 검사.
 export function hasPackage(name: string): boolean {
-  for (const root of LOOKUP_ROOTS) {
-    try {
-      statSync(join(root, name, 'package.json'));
-      return true;
-    } catch {}
-  }
-  return false;
+  return LOOKUP_ROOTS.some((root) => hasPackageJson(join(root, name)));
 }
 
 export async function createFixture(
@@ -162,22 +169,78 @@ export async function linkNodeModules(
   await mkdir(nmDir, { recursive: true });
   const scopes = new Set(packages.filter((p) => p.startsWith('@')).map((p) => p.split('/')[0]));
   await Promise.all([...scopes].map((s) => mkdir(join(nmDir, s), { recursive: true })));
-  await Promise.all(
-    packages.map(async (pkg) => {
-      for (const root of roots) {
-        const target = join(root, pkg);
-        try {
-          await stat(join(target, 'package.json'));
-        } catch {
-          continue;
-        }
-        try {
-          await symlink(target, join(nmDir, pkg));
-          return;
-        } catch {}
+
+  // 순차 처리 필수 — 이미 해석된 패키지 실경로를 그 transitive dep 의 해석 기점으로
+  // 재사용하므로(resolvePackageDir 3단계). 해석 실패 시 throw 하지 않고 스킵하는 것은
+  // 의도된 tolerant 계약(번들러 store 해석에 위임; styled-components 의 tslib 등).
+  const resolvedDirs: string[] = [];
+  for (const pkg of packages) {
+    const target = await resolvePackageDir(pkg, roots, resolvedDirs);
+    if (!target) {
+      if (!warnedUnresolved.has(pkg)) {
+        warnedUnresolved.add(pkg);
+        console.warn(
+          `[linkNodeModules] '${pkg}' 미해석 — 심링크 스킵 (번들러 store 해석에 위임). ` +
+            `CI/OS 별 resolve 차이로 깨질 수 있으니 루트 워크스페이스 설치 여부 확인.`,
+        );
       }
-    }),
-  );
+      continue;
+    }
+    resolvedDirs.push(target);
+    try {
+      await symlink(target, join(nmDir, pkg));
+    } catch (e) {
+      // 동일 scope 내 중복 등으로 이미 존재하면 무시 (멱등).
+      if ((e as NodeJS.ErrnoException)?.code !== 'EEXIST') throw e;
+    }
+  }
+}
+
+/// 패키지의 실제 디렉터리를 해석한다.
+/// 1) LOOKUP_ROOTS 의 top-level `<root>/<pkg>/package.json`
+/// 2) 각 root 기준 Node 모듈 해석 (`<pkg>/package.json` exports → 없으면 entry 에서 상위 탐색)
+/// 3) 이미 해석된 패키지 디렉터리 기준 Node 해석 (transitive dep — store-nested sibling 포함)
+async function resolvePackageDir(
+  pkg: string,
+  roots: string[],
+  resolvedDirs: string[],
+): Promise<string | null> {
+  for (const root of roots) {
+    const target = join(root, pkg);
+    if (!hasPackageJson(target)) continue;
+    // 심링크(PROJECT_ROOT/node_modules/@tanstack/react-query → bun store)를 realpath
+    // 정규화. 미정규화 시 이 dir 기점 transitive 해석(query-core)이 심링크 traversal
+    // 동작에 의존해 OS/실행순서마다 달라진다 — CI(ubuntu) 비결정 깨짐의 근인.
+    return await realpath(target);
+  }
+  const bases = [
+    ...roots.map((r) => join(r, 'index.js')),
+    ...resolvedDirs.map((d) => join(d, 'package.json')),
+  ];
+  for (const base of bases) {
+    const dir = resolveViaNode(pkg, base);
+    if (dir) return dir;
+  }
+  return null;
+}
+
+function resolveViaNode(pkg: string, fromFile: string): string | null {
+  const req = createRequire(fromFile);
+  try {
+    return dirname(req.resolve(`${pkg}/package.json`));
+  } catch {}
+  // exports 가 `./package.json` 을 막는 패키지: entry 를 해석한 뒤 package.json 까지
+  // 상위 탐색 (파일시스템 루트 도달 시 종료).
+  try {
+    let cur = dirname(req.resolve(pkg));
+    for (;;) {
+      if (hasPackageJson(cur)) return cur;
+      const parent = dirname(cur);
+      if (parent === cur) break;
+      cur = parent;
+    }
+  } catch {}
+  return null;
 }
 
 /// emotion v10 격리 fixture (`tests/integration/fixtures/emotion-v10/node_modules`).


### PR DESCRIPTION
## 무엇이 깨졌나
`react-query-v5-smoke` 가 **CI(ubuntu)에서만** 실패. 로컬(macOS)에서는 ReleaseFast·fresh dist·10회 반복 모두 통과 → OS/환경 의존 **비결정성**.

## 근본 원인
테스트는 `linkNodeModules(... ['@tanstack/react-query', '@tanstack/query-core', 'react'])` 로 query-core 도 링크하도록 요청하지만, 기존 `linkNodeModules` 는 top-level `LOOKUP_ROOTS` 에만 패키지 존재를 검사했다. `@tanstack/query-core` 는 bun store **안에 nested** 로만 존재 → 심링크 생성이 **조용히 스킵**되고, 번들러가 react-query 심링크를 따라 store sibling 으로 query-core 를 해석해주는 동작에 *암묵 의존*하고 있었다. 이 sibling 해석이 OS/install 토폴로지·실행순서마다 달라 macOS 통과 / ubuntu unresolved → `bundle.exitCode≠0` 으로 ~188ms 즉시 실패(보고된 시간과 일치).

### 왜 "어느 순간부터" 깨졌나
`e8e5bfbf` (2026-05-14) **`fix(resolver): split preserveSymlinks into esbuild-style identity + new resolveSymlinkSiblings fallback`** 이 `src/bundler/resolver.zig` 의 심링크 sibling 해석을 분리/재작성했다. 그 전엔 통합 preserveSymlinks 로직이 query-core(react-query 심링크의 store sibling)를 macOS/Linux 양쪽에서 우연히 잘 해석했는데, 분리 후 해석 경로가 realpath/토폴로지에 민감해져 ubuntu에서 깨졌다. 테스트가 애초에 query-core 를 직접 링크하지 않고 이 번들러 동작에 기대고 있었기 때문에, **잠재 취약점이 e8e5bfbf 로 실제 CI 실패로 전환**된 것 (테스트/프로덕션 코드 자체 버그 아님).

## 수정 (구조적 — `tests/integration/tests/helpers.ts`)
fixture 가 번들러의 심링크 해석에 의존하지 않고 **self-contained / OS 독립적**이 되도록 resolution 강화:

1. **순차 해석 + Node 모듈 해석 fallback**: top-level → 각 root 기준 Node 해석 → **이미 해석된 패키지(react-query) 실경로 기준 transitive 해석** 으로 query-core 를 실제 fixture 에 링크 (`resolvePackageDir`/`resolveViaNode`).
2. **realpath 정규화 (핵심)**: top-level 적중 시 심링크 그대로 반환하면 거기서의 transitive 해석이 다시 심링크 traversal 에 의존 → 비결정. realpath 정규화로 query-core 가 **실행순서 무관 결정적**으로 해석/링크됨.
3. 못 찾으면 기존 tolerant 계약대로 스킵하되 **프로세스당 1회 경고** (styled-components 의 tslib 등 깊은 transitive — 기존부터 store 해석으로 정상이라 동작 보존).

`/simplify` 반영: `hasPackageJson` 추출(probe 3중 중복 제거), 매직넘버 `12` 제거(루트 break 로 종료 보장), 변경-내역 narration 주석 → WHY 만 유지.

## 검증
- 영향받는 4개 스위트 (react-query / css-library / emotion-v10 / runtime-polyfills) **29/29 통과**
- query-core 미해석 경고 **0** (실행순서 3종 교차 확인 → 실제 fixture 에 링크됨)
- `react-query-v5-smoke` 단독·ReleaseFast 통과
- oxlint / oxfmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)