### PR TITLE
docs(site): 벤치마크에 번들 크기(tree-shake+minify) 비교 추가

### DIFF
--- a/documents/src/components/BenchmarkChartsImpl.tsx
+++ b/documents/src/components/BenchmarkChartsImpl.tsx
@@ -4,6 +4,7 @@ import ReactEChartsCore from "echarts-for-react/lib/core";
 import benchmarkData from "../data/benchmark-data.json";
 import { ZIG } from "../styles/brand-tokens";
 import { echarts } from "./echarts-setup";
+import { formatBytes } from "./format";
 import { useStarlightDark } from "./useStarlightDark";
 
 // ZNTC 만 brand token 사용. 다른 도구 색은 각자의 brand color 라 토큰화 X.
@@ -31,17 +32,29 @@ const SERIES_COLORS: Record<string, string> = {
 type BenchEntry = {
   tool: string;
   scale: string;
-  medianMs: number;
+  medianMs?: number;
   minMs?: number;
   maxMs?: number;
   p95Ms?: number;
+  bytes?: number;
 };
+
+type ChartMetric = "ms" | "bytes";
 
 type ChartDefinition = {
   title: string;
   description: string;
   entries: BenchEntry[];
 };
+
+/** entry 모양으로 단위를 추론 — `bytes` 가 있으면 크기 차트, 아니면 시간 차트. */
+function metricOf(entries: BenchEntry[]): ChartMetric {
+  return entries.some((e) => typeof e.bytes === "number") ? "bytes" : "ms";
+}
+
+function valueOf(entry: BenchEntry, metric: ChartMetric): number | undefined {
+  return metric === "bytes" ? entry.bytes : entry.medianMs;
+}
 
 function uniqueInOrder(values: string[]): string[] {
   return [...new Set(values)];
@@ -59,6 +72,10 @@ function formatMs(value: number): string {
   return `${value.toFixed(0)}ms`;
 }
 
+function formatValue(value: number, metric: ChartMetric): string {
+  return metric === "bytes" ? formatBytes(value) : formatMs(value);
+}
+
 export const MIN_CHART_HEIGHT = 320;
 
 export function chartHeight(entries: BenchEntry[]): number {
@@ -68,6 +85,7 @@ export function chartHeight(entries: BenchEntry[]): number {
 }
 
 function buildHorizontalBarOption(entries: BenchEntry[], isDark: boolean) {
+  const metric = metricOf(entries);
   const scales = uniqueInOrder(entries.map((entry) => entry.scale));
   const tools = uniqueInOrder(entries.map((entry) => entry.tool));
 
@@ -91,11 +109,12 @@ function buildHorizontalBarOption(entries: BenchEntry[], isDark: boolean) {
       color: textColor,
       fontSize: 11,
       formatter: ({ value }: { value: number | null }) =>
-        typeof value === "number" ? formatMs(value) : "",
+        typeof value === "number" ? formatValue(value, metric) : "",
     },
     data: scales.map((scale) => {
       const entry = entries.find((item) => item.tool === tool && item.scale === scale);
-      return entry ? Number(entry.medianMs.toFixed(4)) : null;
+      const value = entry ? valueOf(entry, metric) : undefined;
+      return typeof value === "number" ? Number(value.toFixed(4)) : null;
     }),
   }));
 
@@ -114,17 +133,30 @@ function buildHorizontalBarOption(entries: BenchEntry[], isDark: boolean) {
         }>,
       ) => {
         let html = `<strong>${params[0]?.axisValue ?? ""}</strong><br/>`;
+        const zntcEntry = entries.find(
+          (item) => item.tool === "ZNTC" && item.scale === params[0]?.axisValue,
+        );
+        const zntcValue = zntcEntry ? valueOf(zntcEntry, metric) : undefined;
         for (const param of params) {
           if (typeof param.value !== "number") continue;
           const entry = entries.find(
             (item) => item.tool === param.seriesName && item.scale === param.axisValue,
           );
-          html += `${param.marker} ${param.seriesName}: <strong>${formatMs(param.value)}</strong>`;
+          html += `${param.marker} ${param.seriesName}: <strong>${formatValue(param.value, metric)}</strong>`;
           if (entry?.minMs !== undefined && entry.maxMs !== undefined) {
             html += ` <span style="color:#8a8580">(${formatMs(entry.minMs)}-${formatMs(entry.maxMs)})</span>`;
           }
           if (entry?.p95Ms !== undefined) {
             html += ` <span style="color:#8a8580">p95 ${formatMs(entry.p95Ms)}</span>`;
+          }
+          if (
+            metric === "bytes" &&
+            param.seriesName !== "ZNTC" &&
+            typeof zntcValue === "number" &&
+            zntcValue > 0
+          ) {
+            const ratio = param.value / zntcValue;
+            html += ` <span style="color:#8a8580">ZNTC ${ratio >= 1 ? `${ratio.toFixed(2)}x smaller` : `${(1 / ratio).toFixed(2)}x larger`}</span>`;
           }
           html += "<br/>";
         }
@@ -149,13 +181,13 @@ function buildHorizontalBarOption(entries: BenchEntry[], isDark: boolean) {
     },
     xAxis: {
       type: "value" as const,
-      name: "median wall time",
+      name: metric === "bytes" ? "bundle size (raw)" : "median wall time",
       nameLocation: "middle" as const,
       nameGap: 28,
       nameTextStyle: { color: textColor, fontSize: 11 },
       axisLabel: {
         color: textColor,
-        formatter: (value: number) => formatMs(value),
+        formatter: (value: number) => formatValue(value, metric),
       },
       axisLine: { lineStyle: { color: axisLineColor } },
       splitLine: { lineStyle: { color: gridLineColor } },
@@ -238,6 +270,12 @@ export default function BenchmarkCharts() {
       entries: benchmarkData.results.bundleCli,
     },
     {
+      title: "Bundle Size — Tree-shake + Minify",
+      description:
+        "Real npm libraries bundled and minified with the same input. Raw output bytes — lower is better. Tree-shaking + minifier quality, not speed.",
+      entries: benchmarkData.results.bundleSize,
+    },
+    {
       title: "NAPI vs WASM vs CLI",
       description: "Public in-process bindings compared with subprocess CLI startup cost.",
       entries: benchmarkData.results.napiWasmCli,
@@ -259,6 +297,8 @@ export default function BenchmarkCharts() {
       <div className="rounded-lg border border-surface-200 bg-white px-4 py-3 text-sm leading-6 text-neutral-700 shadow-sm dark:border-surface-800 dark:bg-surface-950/70 dark:text-neutral-300">
         <strong className="text-neutral-900 dark:text-neutral-100">Measurement:</strong> {benchmarkData.platform}, {benchmarkData.date}.
         CLI charts use median wall time. Lower is better.
+        <br />
+        <strong className="text-neutral-900 dark:text-neutral-100">Bundle Size:</strong> {benchmarkData.sizeBenchmark.libraries} real npm libraries, {benchmarkData.sizeBenchmark.date}, {benchmarkData.sizeBenchmark.mode}. {benchmarkData.sizeBenchmark.note}
       </div>
       {charts.map((chart) => (
         <ChartPanel key={chart.title} chart={chart} isDark={isDark} />

--- a/documents/src/components/MetafileAnalyzer.tsx
+++ b/documents/src/components/MetafileAnalyzer.tsx
@@ -2,6 +2,7 @@ import { useDeferredValue, useMemo, useState, type ReactNode } from "react";
 import ReactEChartsCore from "echarts-for-react/lib/core";
 
 import { echarts } from "./echarts-setup";
+import { formatBytes } from "./format";
 
 type ImportKind =
   | "import-statement"
@@ -95,13 +96,6 @@ const sampleMetafile = JSON.stringify(
 );
 
 const nf = new Intl.NumberFormat("en-US");
-
-function formatBytes(bytes: number): string {
-  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
-}
 
 function parseMetafile(text: string): { meta?: Metafile; error?: string } {
   try {

--- a/documents/src/components/format.ts
+++ b/documents/src/components/format.ts
@@ -1,0 +1,6 @@
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}

--- a/documents/src/content/docs/en/index.mdx
+++ b/documents/src/content/docs/en/index.mdx
@@ -87,6 +87,45 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
   </div>
 </Section>
 
+<Section padding="py-16">
+  <div class="not-content mx-auto max-w-5xl">
+    <h2 class="mb-2 text-center text-2xl font-bold sm:text-3xl">Bundle size — Tree-shake + Minify</h2>
+    <p class="mb-8 text-center text-sm text-[color:var(--sl-color-gray-3)]">
+      Speed is not everything — output size matters too. Real npm libraries bundled + minified with the same input (raw bytes, lower is better).
+    </p>
+
+    <BenchmarkHighlight chartKey="bundleSize" client:only="react" />
+
+    <div class="mt-6 grid gap-4 text-sm sm:grid-cols-3">
+      <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
+        <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">three</div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">35 KB</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1st)</span></div>
+        <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
+          <strong>6.2× smaller</strong> than esbuild 217 KB · rspack 136 KB (tree-shaking)
+        </div>
+      </div>
+      <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
+        <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">effect</div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">122 KB</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1st)</span></div>
+        <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
+          <strong>1.16–1.56× smaller</strong> than esbuild 191 KB · rspack 142 KB
+        </div>
+      </div>
+      <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
+        <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">zod · mobx · preact</div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">±10%</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">parity</span></div>
+        <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
+          Essentially on par with esbuild / rolldown / rspack
+        </div>
+      </div>
+    </div>
+
+    <p class="mt-6 text-center text-xs text-[color:var(--sl-color-gray-3)]">
+      2026-05-17 · darwin arm64 · 9 real npm libraries · <code>--minify-all</code> (see <a href="/zntc/en/reference/benchmarks/" class="text-zig-400 hover:underline">full benchmarks →</a>)
+    </p>
+  </div>
+</Section>
+
 <FeatureGrid
   heading="Why ZNTC"
   subheading="A JS/TS toolchain that combines the strengths of existing tools."

--- a/documents/src/content/docs/en/reference/benchmarks.mdx
+++ b/documents/src/content/docs/en/reference/benchmarks.mdx
@@ -5,7 +5,7 @@ description: Performance comparison between ZNTC and other tools
 
 import BenchmarkCharts from '../../../../components/BenchmarkCharts.tsx';
 
-ZNTC compares transpile and bundle performance against esbuild, SWC, Bun, Rolldown, Rspack, and related tools.
+ZNTC compares transpile and bundle performance — and final bundle size (tree-shaking + minifier quality) — against esbuild, SWC, Bun, Rolldown, Rspack, and related tools.
 
 ## Environment
 
@@ -15,8 +15,9 @@ ZNTC compares transpile and bundle performance against esbuild, SWC, Bun, Rolldo
 - **NAPI / WASM / CLI**: `napi-bench.ts`, 3 warmups + 10-run median
 - **Bundle perf**: `bundle-perf.ts`, 5 warmups + 20-run median, CI-style same-run ZNTC/Rolldown/Rspack comparison
 - **Pipeline**: `pipeline.ts`, 5-run median, profile total
+- **Bundle size**: `smoke.ts --minify-all`, 2026-05-17, 9 real npm libraries bundled + minified, raw output bytes
 
-Lower values are faster. The number at the end of each bar is median wall time.
+For time charts, lower is faster (bar label = median wall time). For the bundle-size chart, lower is smaller (bar label = raw bytes).
 
 <BenchmarkCharts client:only="react" />
 
@@ -31,4 +32,8 @@ bun run tests/benchmark/bench.ts
 bun run tests/benchmark/napi-bench.ts
 bun run tests/benchmark/bundle-perf.ts --no-fail --output bundle-perf.json
 bun run tests/benchmark/pipeline.ts
+
+bun run tests/benchmark/smoke.ts --minify-all \
+  --filter=zod,effect,lodash-es,preact,immer,date-fns,rxjs,mobx,three \
+  --json=size.json
 ```

--- a/documents/src/content/docs/index.mdx
+++ b/documents/src/content/docs/index.mdx
@@ -87,6 +87,45 @@ import { Tabs, TabItem } from "@astrojs/starlight/components";
   </div>
 </Section>
 
+<Section padding="py-16">
+  <div class="not-content mx-auto max-w-5xl">
+    <h2 class="mb-2 text-center text-2xl font-bold sm:text-3xl">번들 크기 비교 — Tree-shake + Minify</h2>
+    <p class="mb-8 text-center text-sm text-[color:var(--sl-color-gray-3)]">
+      속도뿐 아니라 출력 크기도 중요합니다. 실제 npm 라이브러리를 동일 입력으로 번들 + minify 한 raw 크기 (낮을수록 작음).
+    </p>
+
+    <BenchmarkHighlight chartKey="bundleSize" client:only="react" />
+
+    <div class="mt-6 grid gap-4 text-sm sm:grid-cols-3">
+      <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
+        <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">three</div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">35 KB</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1위)</span></div>
+        <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
+          esbuild 217 KB · rspack 136 KB 대비 <strong>6.2× 작음</strong> (tree-shaking)
+        </div>
+      </div>
+      <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
+        <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">effect</div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">122 KB</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">(1위)</span></div>
+        <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
+          esbuild 191 KB · rspack 142 KB 대비 <strong>1.16–1.56× 작음</strong>
+        </div>
+      </div>
+      <div class="rounded-lg border border-[color:var(--sl-color-gray-5)] bg-[color:var(--sl-color-gray-7)]/30 p-4">
+        <div class="mb-1 text-xs uppercase tracking-wide text-[color:var(--sl-color-gray-3)]">zod · mobx · preact</div>
+        <div class="font-mono text-lg"><strong class="text-zig-400">±10%</strong> <span class="text-xs text-[color:var(--sl-color-gray-3)]">parity</span></div>
+        <div class="mt-1 text-xs text-[color:var(--sl-color-gray-3)]">
+          esbuild / rolldown / rspack 와 사실상 동급 크기
+        </div>
+      </div>
+    </div>
+
+    <p class="mt-6 text-center text-xs text-[color:var(--sl-color-gray-3)]">
+      2026-05-17 · darwin arm64 · 9개 실제 npm 라이브러리 · <code>--minify-all</code> (자세히는 <a href="/zntc/reference/benchmarks/" class="text-zig-400 hover:underline">전체 벤치마크 →</a>)
+    </p>
+  </div>
+</Section>
+
 <FeatureGrid
   heading="왜 ZNTC 인가"
   subheading="기존 도구의 장점을 조합한 JavaScript/TypeScript 툴체인."

--- a/documents/src/content/docs/reference/benchmarks.mdx
+++ b/documents/src/content/docs/reference/benchmarks.mdx
@@ -5,7 +5,7 @@ description: ZNTC와 다른 도구들의 성능 비교
 
 import BenchmarkCharts from '../../../components/BenchmarkCharts.tsx';
 
-ZNTC의 트랜스파일/번들 성능을 esbuild, SWC, Bun, Rolldown, Rspack 등과 비교합니다.
+ZNTC의 트랜스파일/번들 성능과 최종 번들 크기(tree-shaking + minifier 품질)를 esbuild, SWC, Bun, Rolldown, Rspack 등과 비교합니다.
 
 ## 측정 환경
 
@@ -15,8 +15,9 @@ ZNTC의 트랜스파일/번들 성능을 esbuild, SWC, Bun, Rolldown, Rspack 등
 - **NAPI / WASM / CLI**: `napi-bench.ts` warmup 3회 + median 10회
 - **Bundle perf**: `bundle-perf.ts` warmup 5회 + median 20회, CI와 같은 ZNTC/Rolldown/Rspack same-run 비교
 - **Pipeline**: `pipeline.ts` median 5회, profile total 기준
+- **번들 크기**: `smoke.ts --minify-all`, 2026-05-17, 실제 npm 라이브러리 9종을 번들 + minify 한 raw 출력 바이트
 
-차트는 낮을수록 빠른 값이며, 막대 끝 숫자는 median wall time입니다.
+시간 차트는 낮을수록 빠르며(막대 끝 숫자 = median wall time), 번들 크기 차트는 낮을수록 작습니다(막대 끝 숫자 = raw bytes).
 
 <BenchmarkCharts client:only="react" />
 
@@ -31,4 +32,8 @@ bun run tests/benchmark/bench.ts
 bun run tests/benchmark/napi-bench.ts
 bun run tests/benchmark/bundle-perf.ts --no-fail --output bundle-perf.json
 bun run tests/benchmark/pipeline.ts
+
+bun run tests/benchmark/smoke.ts --minify-all \
+  --filter=zod,effect,lodash-es,preact,immer,date-fns,rxjs,mobx,three \
+  --json=size.json
 ```

--- a/documents/src/data/benchmark-data.json
+++ b/documents/src/data/benchmark-data.json
@@ -104,6 +104,59 @@
       { "tool": "string", "scale": "50K lines", "medianMs": 24.6 },
       { "tool": "object", "scale": "50K lines", "medianMs": 44.0 },
       { "tool": "react", "scale": "50K lines", "medianMs": 75.2 }
+    ],
+    "bundleSize": [
+      { "tool": "ZNTC", "scale": "immer", "bytes": 8963 },
+      { "tool": "esbuild", "scale": "immer", "bytes": 8074 },
+      { "tool": "rolldown", "scale": "immer", "bytes": 8023 },
+      { "tool": "rspack", "scale": "immer", "bytes": 7850 },
+
+      { "tool": "ZNTC", "scale": "preact", "bytes": 10415 },
+      { "tool": "esbuild", "scale": "preact", "bytes": 10434 },
+      { "tool": "rolldown", "scale": "preact", "bytes": 10290 },
+      { "tool": "rspack", "scale": "preact", "bytes": 10405 },
+
+      { "tool": "ZNTC", "scale": "lodash-es", "bytes": 19587 },
+      { "tool": "esbuild", "scale": "lodash-es", "bytes": 20661 },
+      { "tool": "rolldown", "scale": "lodash-es", "bytes": 18419 },
+      { "tool": "rspack", "scale": "lodash-es", "bytes": 17654 },
+
+      { "tool": "ZNTC", "scale": "date-fns", "bytes": 19957 },
+      { "tool": "esbuild", "scale": "date-fns", "bytes": 19989 },
+      { "tool": "rolldown", "scale": "date-fns", "bytes": 19411 },
+      { "tool": "rspack", "scale": "date-fns", "bytes": 18540 },
+
+      { "tool": "ZNTC", "scale": "three", "bytes": 36047 },
+      { "tool": "esbuild", "scale": "three", "bytes": 222275 },
+      { "tool": "rolldown", "scale": "three", "bytes": 220177 },
+      { "tool": "rspack", "scale": "three", "bytes": 139674 },
+
+      { "tool": "ZNTC", "scale": "mobx", "bytes": 55975 },
+      { "tool": "esbuild", "scale": "mobx", "bytes": 55532 },
+      { "tool": "rolldown", "scale": "mobx", "bytes": 53877 },
+      { "tool": "rspack", "scale": "mobx", "bytes": 53967 },
+
+      { "tool": "ZNTC", "scale": "zod", "bytes": 63826 },
+      { "tool": "esbuild", "scale": "zod", "bytes": 59586 },
+      { "tool": "rolldown", "scale": "zod", "bytes": 56428 },
+      { "tool": "rspack", "scale": "zod", "bytes": 56403 },
+
+      { "tool": "ZNTC", "scale": "effect", "bytes": 125330 },
+      { "tool": "esbuild", "scale": "effect", "bytes": 196059 },
+      { "tool": "rolldown", "scale": "effect", "bytes": 125426 },
+      { "tool": "rspack", "scale": "effect", "bytes": 145559 },
+
+      { "tool": "ZNTC", "scale": "rxjs", "bytes": 157131 },
+      { "tool": "esbuild", "scale": "rxjs", "bytes": 146677 },
+      { "tool": "rolldown", "scale": "rxjs", "bytes": 136800 },
+      { "tool": "rspack", "scale": "rxjs", "bytes": 141278 }
     ]
+  },
+  "sizeBenchmark": {
+    "date": "2026-05-17",
+    "platform": "darwin arm64",
+    "mode": "--minify-all (production minify + tree-shake)",
+    "libraries": 9,
+    "note": "실제 npm 라이브러리를 동일 입력으로 번들 + minify 한 최종 출력 크기 (raw bytes). 낮을수록 작음."
   }
 }


### PR DESCRIPTION
## 요약

사이트 벤치마크가 **속도(ms)** 만 보여줘서, **번들 크기(tree-shaking + minifier 품질)** 비교를 추가했습니다. 메인 랜딩(ko/en)과 `레퍼런스 > 벤치마크` 페이지 양쪽에 노출됩니다.

## 데이터 (실측)

`bun run tests/benchmark/smoke.ts --minify-all --filter=zod,effect,lodash-es,preact,immer,date-fns,rxjs,mobx,three --json=...` — darwin arm64, 2026-05-17, 실제 npm 9종을 동일 입력으로 번들 + minify 한 raw 출력 바이트.

| 라이브러리 | ZNTC | esbuild | rolldown | rspack |
|---|--:|--:|--:|--:|
| three | **36KB** | 217KB | 220KB | 140KB |
| effect | **122KB** | 191KB | 122KB | 142KB |
| lodash-es | 19KB | 20KB | 18KB | 18KB |
| zod | 62KB | 58KB | 55KB | 55KB |
| rxjs | 153KB | 143KB | 134KB | 138KB |

three(tree-shaking 우위로 6.2× 작음)·effect 큰 우위, zod/rxjs/immer 는 ZNTC 가 5~13% 큼 — **체리피킹 없이 그대로 반영**.

## 변경

- `benchmark-data.json`: `bundleSize` 카테고리 + `sizeBenchmark` 메타
- `BenchmarkChartsImpl.tsx`: bytes 메트릭 지원. `metricOf`/`valueOf` 로 entry 모양에서 단위 추론 → 기존 5개 ms 차트는 동작 불변. B/KB/MB 포맷, x축/툴팁 단위 분기, 툴팁에 "vs ZNTC N×" 비율
- `components/format.ts`: `formatBytes` 공유 모듈로 추출 (`MetafileAnalyzer` 와 중복 제거, 동작 동일 — /simplify 리뷰 반영)
- `index.mdx`(ko/en): 크기 비교 섹션 + 요약 카드 3개
- `benchmarks.mdx`(ko/en): 측정 환경·재현 명령 갱신

## 검증

- `bun run build` 통과 (517 페이지, 내부 링크 전부 유효)
- `/simplify` 3-에이전트 리뷰: 효율성 이슈 없음, `formatBytes` 중복만 수정. MDX 카드 하드코딩 수치는 인접 기존 bundle-perf 섹션과 동일 컨벤션이라 유지(차트가 JSON source-of-truth)

> Zig 초보자 노트: 이 PR 은 Zig 코드 변경 없음 — `documents/` 의 Astro/React 문서 사이트만 수정. 벤치마크 *데이터* 는 기존 Zig 바이너리(`zig-out/bin/zntc`)로 실측해 JSON 으로 박제.

🤖 Generated with [Claude Code](https://claude.com/claude-code)