### PR TITLE
feat(mf): manifest.remotes 정밀 — mf.remotes → ManifestRemote (#3421)

### DIFF
--- a/src/bundler/federation_emit.zig
+++ b/src/bundler/federation_emit.zig
@@ -400,7 +400,30 @@ fn buildManifest(
         try appendJsonStr(&b, allocator, rv);
         try b.appendSlice(allocator, ",\"hash\":\"\",\"assets\":{\"js\":{\"sync\":[],\"async\":[]},\"css\":{\"sync\":[],\"async\":[]}}}");
     }
-    try b.appendSlice(allocator, "],\"remotes\":[],\"exposes\":[");
+    // P2-1 (#3421): manifest.remotes 정밀. exposes 있는 remote 가 다른
+    // remote 도 소비하면 그 의존을 manifest 로 기술(표준 contract — host 가
+    // 이 remote 로드 시 transitive deps 인지). `@module-federation/sdk`
+    // ManifestRemote = Omit<RemoteWithEntry,'name'> & {federationContainer
+    // Name,moduleName,alias} = {entry,federationContainerName,moduleName,
+    // alias}. generateSnapshotFromManifest 가 federationContainerName(키)+
+    // entry 소비. parseRemote(emitHostInit 공용) 재사용. host-only(exposes
+    // 0)는 wrapContainer null → manifest 미산출(표준 일치 — manifest 는
+    // remote-producer 산출물).
+    try b.appendSlice(allocator, "],\"remotes\":[");
+    for (mf.remotes, 0..) |kv, ri| {
+        if (ri > 0) try b.append(allocator, ',');
+        const r = parseRemote(kv); // {name=container, entry}
+        try b.appendSlice(allocator, "{\"entry\":");
+        try appendJsonStr(&b, allocator, r.entry);
+        try b.appendSlice(allocator, ",\"federationContainerName\":");
+        try appendJsonStr(&b, allocator, r.name);
+        try b.appendSlice(allocator, ",\"moduleName\":");
+        try appendJsonStr(&b, allocator, r.name);
+        try b.appendSlice(allocator, ",\"alias\":");
+        try appendJsonStr(&b, allocator, kv.key); // 로컬 참조 alias
+        try b.append(allocator, '}');
+    }
+    try b.appendSlice(allocator, "],\"exposes\":[");
     for (exposes, 0..) |ex, ei| {
         if (ei > 0) try b.append(allocator, ',');
         // id = "<name>:<expose키에서 './' 제거>" (MF 규약, 예 app:Widget).

--- a/tests/integration/tests/mf-runtime-interop-smoke.test.ts
+++ b/tests/integration/tests/mf-runtime-interop-smoke.test.ts
@@ -284,9 +284,61 @@ console.log('SAME=' + (m && m.usedHook === hostReact.useState));
     expect(rd.singleton).toBe(false); // 미지정 → false
     expect(rd.requiredVersion).toBe(''); // 미지정 → 빈
     expect(rd.version).toBe(''); // version=requiredVersion 경계(값 없음 쪽도 박제)
-    // remotes 는 P2-1 범위 — 아직 []
+    // remotes 미선언 → [] (P2-1 은 remotes 선언 시 채움 — 별 테스트)
     expect(mani.remotes).toEqual([]);
     expect(Array.isArray(mani.exposes) && mani.exposes.length).toBe(1);
+  });
+
+  // P2-1 (#3421): exposes 있는 remote 가 remotes 도 선언 → manifest.remotes
+  // = ManifestRemote[](Omit<RemoteWithEntry,'name'> & {federationContainer
+  // Name,moduleName,alias}). 표준 generateSnapshotFromManifest 가
+  // federationContainerName+entry 로 transitive remote 인지. host-only
+  // (exposes 0)는 manifest 미산출(표준 일치 — manifest=remote-producer 산출).
+  test('P2-1 manifest.remotes 정밀: mf.remotes → ManifestRemote', async () => {
+    const fx = await createFixture({
+      'W.ts': `export default () => "W";`,
+      'index.ts': `export const sentinel = "re";`,
+      'zntc.config.json': JSON.stringify({
+        mf: {
+          name: 'mid',
+          exposes: { './W': './W.ts' },
+          remotes: {
+            up: 'up_ctr@http://localhost:9/mf-manifest.json',
+            bare: 'http://localhost:8/remoteEntry.js', // @ 없음 → name=key
+          },
+        },
+      }),
+    });
+    cleanup = fx.cleanup;
+    const dist = join(fx.dir, 'dist');
+    const b = await runZntcInDir(fx.dir, [
+      '--bundle',
+      join(fx.dir, 'index.ts'),
+      '--outdir',
+      dist,
+      '--format=iife',
+    ]);
+    expect(b.exitCode).toBe(0);
+    const mani = JSON.parse(await readFile(join(dist, 'mf-manifest.json'), 'utf8'));
+    expect(Array.isArray(mani.remotes)).toBe(true);
+    expect(mani.remotes.length).toBe(2);
+    const up = mani.remotes.find((r: { alias: string }) => r.alias === 'up');
+    expect(up.entry).toBe('http://localhost:9/mf-manifest.json');
+    expect(up.federationContainerName).toBe('up_ctr'); // <name>@<entry> 의 name
+    expect(up.moduleName).toBe('up_ctr');
+    // ManifestRemote 4필드 전부(name 은 Omit)
+    expect(Object.keys(up).sort()).toEqual([
+      'alias',
+      'entry',
+      'federationContainerName',
+      'moduleName',
+    ]);
+    const bare = mani.remotes.find((r: { alias: string }) => r.alias === 'bare');
+    expect(bare.entry).toBe('http://localhost:8/remoteEntry.js');
+    expect(bare.federationContainerName).toBe('bare'); // @ 없음 → KV.key fallback
+    // P2-0 무회귀: shared 도 정밀 유지
+    expect(Array.isArray(mani.shared) && mani.shared.length).toBe(0);
+    expect(mani.exposes.length).toBe(1);
   });
 
   // P1-6 (#3388): zntc-빌드 host 가 실 @module-federation/runtime 로 remote


### PR DESCRIPTION
## 무엇 (#3421, MF epic P2-1)

`buildManifest` 의 `"remotes":[]` 하드코딩 → `mf.remotes`(KV) 순회 → **`@module-federation/sdk` ManifestRemote**(`Omit<RemoteWithEntry,'name'> & {federationContainerName,moduleName,alias}` = entry/federationContainerName/moduleName/alias 4필드) emit. exposes 있는 remote 가 remotes 도 선언하면 그 transitive 의존을 manifest 로 기술 — 표준 `generateSnapshotFromManifest` 가 `federationContainerName`+`entry` 로 인지.

## 어떻게

- P2-0 shared 루프 **동형**(`parseRemote` 슬라이스 borrow — alloc 0, `appendJsonStr` emitter 단일소스).
- `parseRemote`(emitHostInit 공용) 재사용 → host init prelude.remotes ↔ manifest.remotes **동일 해석**(단일 소스, 불일치 불가). `@` 없는 value 는 name=KV.key fallback(host 배선과 동일).
- **host-only(exposes 0)는 manifest 미산출**(wrapContainer null) — 표준 일치(manifest=remote-producer 산출물; 표준 rspack remote 도 remotes 미선언 시 `[]`).

## 검증

`mid`(exposes+remotes+shared) → `manifest.remotes` 정밀 emit 실측. 신규 P2-1 테스트(up=`up_ctr@url`·bare=`url`(@없음→key) — 4필드 `Object.keys` 정확·표준 소비 2필드·multi-entry·P2-0 무회귀). mf 통합 **11·0**, mf e2e **S3/S4 2·0**, `zig build test`/`wasm-bundler` 0, lint/fmt 0. /simplify 3-에이전트 차단 0(sdk 2.4.0 1:1·host init 단일소스 일관·`RemoteWithVersion` form 은 명시적 비-목표 — 거짓양성 확인).

## 비-목표

`RemoteWithVersion`(name@version) form(parseRemote 가 entry-form 만, 후속) · host-only manifest(표준 미산출) · 무결성 hash(P2-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)