### PR TITLE
feat(mf): SHA-256 무결성 다이제스트 sidecar (#3422)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1645,7 +1645,8 @@ pub const Bundler = struct {
         const final_asset_outputs: ?[]OutputFile = if (worker_output_files.items.len > 0 or asset_outputs != null or css_output_files.items.len > 0 or mf_manifest != null) blk: {
             const existing = if (asset_outputs) |a| a.len else 0;
             const mf_n: usize = if (mf_manifest != null) 1 else 0;
-            const total = existing + worker_output_files.items.len + css_output_files.items.len + mf_n;
+            // P2-2 (#3422): manifest 산출 시 SHA-256 무결성 sidecar 도 1개.
+            const total = existing + worker_output_files.items.len + css_output_files.items.len + mf_n * 2;
             const merged = try self.allocator.alloc(OutputFile, total);
             if (asset_outputs) |a| {
                 @memcpy(merged[0..a.len], a);
@@ -1659,12 +1660,25 @@ pub const Bundler = struct {
                 merged[css_start + i] = cf;
             }
             if (mf_manifest) |m| {
-                // path dup 먼저(실패해도 errdefer 가 m 해제). 성공 후 소유권
-                // 이전 + mf_manifest=null(errdefer 이중해제 방지). deinit 이
-                // asset_outputs path/contents 해제 — 소유 일관.
-                const p = try self.allocator.dupe(u8, "mf-manifest.json");
-                merged[css_start + css_output_files.items.len] = .{ .path = p, .contents = m };
-                mf_manifest = null;
+                const slot = css_start + css_output_files.items.len;
+                // P2-2: manifest + 모든 JS 출력 청크의 SHA-256 SRI sidecar.
+                // m(아직 살아있음) + outputs(최종 바이트, placeholder 치환
+                // 완료) 입력. sidecar 자신·서명은 미포함(P2-3 서명 자기참조
+                // 순환 회피). 컴퓨트→dup 순서 + errdefer 로 부분실패 누수 차단
+                // (성공 전 mf_manifest 가 m 소유 → 이중해제 없음).
+                const sidecar = try @import("mf_integrity.zig").buildSidecar(
+                    self.allocator,
+                    "mf-manifest.json",
+                    m,
+                    outputs orelse &.{},
+                );
+                errdefer self.allocator.free(sidecar);
+                const pm = try self.allocator.dupe(u8, "mf-manifest.json");
+                errdefer self.allocator.free(pm);
+                const ps = try self.allocator.dupe(u8, "mf-manifest.json.integrity.json");
+                merged[slot] = .{ .path = pm, .contents = m };
+                merged[slot + 1] = .{ .path = ps, .contents = sidecar };
+                mf_manifest = null; // 소유권 이전 — errdefer(:1356) 이중해제 방지
             }
             break :blk merged;
         } else asset_outputs;

--- a/src/bundler/mf_integrity.zig
+++ b/src/bundler/mf_integrity.zig
@@ -1,0 +1,88 @@
+//! P2-2 (#3422): MF 산출 SHA-256 무결성 다이제스트.
+//!
+//! **파일명 content-hash 는 Wyhash 불변**(RFC §9 — 부분 재배포 결정성 S5
+//! 의존). 무결성만 SHA-256. content-hash 의 2패스 placeholder-skip
+//! (chunks.zig) 와 **무관** — 최종 산출 바이트(placeholder 치환 완료) raw
+//! 1패스. P2-3(RS256 서명)의 토대(sidecar 단일 파일 = 서명 대상).
+//!
+//! 표준 schema 불침습: `@module-federation` 에 서명/SHA 부재(zntc 고유, D3
+//! 인접). manifest.metaData/ManifestShared.hash 인라인 금지 — 별도 sidecar
+//! `mf-manifest.json.integrity.json`(표준 runtime 미fetch, interop 불침습).
+const std = @import("std");
+const emitter = @import("emitter.zig");
+const OutputFile = emitter.OutputFile;
+
+/// 바이트 → SRI(`sha256-<base64>`). owned(caller free). 표준 Subresource
+/// Integrity 표기 — P2-3/P4 검증기 재사용.
+pub fn computeSri(allocator: std.mem.Allocator, bytes: []const u8) ![]const u8 {
+    var digest: [std.crypto.hash.sha2.Sha256.digest_length]u8 = undefined;
+    std.crypto.hash.sha2.Sha256.hash(bytes, &digest, .{});
+    const Encoder = std.base64.standard.Encoder;
+    const b64 = try allocator.alloc(u8, Encoder.calcSize(digest.len));
+    defer allocator.free(b64);
+    _ = Encoder.encode(b64, &digest);
+    return std.fmt.allocPrint(allocator, "sha256-{s}", .{b64});
+}
+
+/// `{version,algorithm,files:{<basename>:"sha256-<b64>"}}` JSON(owned).
+/// manifest + 모든 JS 출력 청크(`chunks`) 무결성. 결정성 위해 파일명 정렬.
+/// CSS/worker 청크 무결성은 1차 비-목표(후속). JSON 문자열 escape 는
+/// emitter.appendJsonString 단일 소스 재사용.
+pub fn buildSidecar(
+    allocator: std.mem.Allocator,
+    manifest_name: []const u8,
+    manifest_bytes: []const u8,
+    chunks: []const OutputFile,
+) ![]const u8 {
+    const Entry = struct { name: []const u8, sri: []const u8 };
+    var entries: std.ArrayListUnmanaged(Entry) = .empty;
+    defer {
+        for (entries.items) |e| allocator.free(e.sri);
+        entries.deinit(allocator);
+    }
+    try entries.append(allocator, .{
+        .name = manifest_name,
+        .sri = try computeSri(allocator, manifest_bytes),
+    });
+    // basename 키 — 현 MF 산출은 flat outdir 라 동명 충돌 불가. nested
+    // 출력 도입 시 P2-3(서명) 전 키 충돌 재검토 필요(현재 거짓양성).
+    for (chunks) |c| {
+        try entries.append(allocator, .{
+            .name = std.fs.path.basename(c.path),
+            .sri = try computeSri(allocator, c.contents),
+        });
+    }
+    // 결정적 출력 — 파일명 사전순(맵 순회/청크 순서 비결정 차단).
+    std.mem.sort(Entry, entries.items, {}, struct {
+        fn lt(_: void, a: Entry, b: Entry) bool {
+            return std.mem.lessThan(u8, a.name, b.name);
+        }
+    }.lt);
+
+    var b: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer b.deinit(allocator);
+    try b.appendSlice(allocator, "{\"version\":1,\"algorithm\":\"sha256\",\"files\":{");
+    for (entries.items, 0..) |e, i| {
+        if (i > 0) try b.append(allocator, ',');
+        try emitter.appendJsonString(&b, allocator, e.name);
+        try b.append(allocator, ':');
+        try emitter.appendJsonString(&b, allocator, e.sri);
+    }
+    try b.appendSlice(allocator, "}}");
+    return b.toOwnedSlice(allocator);
+}
+
+test "computeSri: SHA-256 SRI 결정성·정확성" {
+    const a = std.testing.allocator;
+    // 빈 입력의 SHA-256 = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    // base64 = 47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
+    const s1 = try computeSri(a, "");
+    defer a.free(s1);
+    try std.testing.expectEqualStrings("sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=", s1);
+    const s2 = try computeSri(a, "zntc");
+    defer a.free(s2);
+    const s3 = try computeSri(a, "zntc");
+    defer a.free(s3);
+    try std.testing.expectEqualStrings(s2, s3); // 결정성
+    try std.testing.expect(!std.mem.eql(u8, s1, s2)); // 입력 다르면 다름
+}

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -122,6 +122,7 @@ test {
     _ = @import("linker_test.zig");
     _ = @import("emitter_test.zig");
     _ = @import("chunk_test.zig");
+    _ = @import("mf_integrity.zig"); // #3422 inline test (computeSri)
     _ = @import("statement_shaker_test.zig");
     _ = @import("graph_test.zig");
     _ = @import("graph/project_root.zig");

--- a/tests/integration/tests/mf-runtime-interop-smoke.test.ts
+++ b/tests/integration/tests/mf-runtime-interop-smoke.test.ts
@@ -1,7 +1,8 @@
 import { describe, test, expect, afterEach } from 'bun:test';
 import { createServer, type Server } from 'node:http';
 import { readFile, readdir } from 'node:fs/promises';
-import { writeFileSync, rmSync } from 'node:fs';
+import { writeFileSync, rmSync, readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 import { createRequire } from 'node:module';
 import { createFixture, runZntcInDir, runNode } from './helpers';
@@ -273,7 +274,10 @@ console.log('SAME=' + (m && m.usedHook === hostReact.useState));
     expect(r.singleton).toBe(true);
     expect(r.requiredVersion).toBe('^19');
     expect(r.version).toBe('^19'); // requiredVersion 대용(P2 경계)
-    expect(r.hash).toBe(''); // 무결성=P2-2
+    // ManifestShared.hash 는 runtime 미소비(generateSnapshotFromManifest
+    // 가 안 읽음) → 의도적 빈값 유지. 무결성은 별도 sidecar(P2-2,
+    // mf-manifest.json.integrity.json) — 표준 schema 불침습.
+    expect(r.hash).toBe('');
     // ManifestShared 필수 7필드 전부 + StatsAssets 형태(seam 처리 → 빈)
     expect(r.assets).toEqual({
       js: { sync: [], async: [] },
@@ -339,6 +343,69 @@ console.log('SAME=' + (m && m.usedHook === hostReact.useState));
     // P2-0 무회귀: shared 도 정밀 유지
     expect(Array.isArray(mani.shared) && mani.shared.length).toBe(0);
     expect(mani.exposes.length).toBe(1);
+  });
+
+  // P2-2 (#3422): SHA-256 무결성 sidecar. 파일명 content-hash 는 Wyhash
+  // 불변(§9), 무결성만 SHA-256. 표준 schema 불침습(별도 파일, runtime
+  // 미fetch — S3/S4 interop 무영향). P2-3 RS256 서명의 토대. 런타임 강제
+  // verify=P3/P4(비-목표) — 여기선 산출·정확성·결정성·변조탐지 박제.
+  test('P2-2 SHA-256 무결성 sidecar: 정확성·결정성·변조탐지', async () => {
+    const files = {
+      'W.ts': `export default () => "W";`,
+      'index.ts': `export const sentinel = "re";`,
+      'zntc.config.json': JSON.stringify({
+        mf: { name: 'app', exposes: { './W': './W.ts' }, shared: { react: { singleton: true } } },
+      }),
+    };
+    const fx = await createFixture(files);
+    cleanup = fx.cleanup;
+    const dist = join(fx.dir, 'dist');
+    const args = ['--bundle', join(fx.dir, 'index.ts'), '--outdir', dist, '--format=iife'];
+    expect((await runZntcInDir(fx.dir, args)).exitCode).toBe(0);
+
+    const dir = await readdir(dist);
+    expect(dir).toContain('mf-manifest.json.integrity.json');
+    const sc = JSON.parse(await readFile(join(dist, 'mf-manifest.json.integrity.json'), 'utf8'));
+    expect(sc.version).toBe(1);
+    expect(sc.algorithm).toBe('sha256');
+    // manifest + 모든 JS 출력 청크 무결성(파일명 정렬·SRI 형식)
+    const sri = (f: string) =>
+      'sha256-' +
+      createHash('sha256')
+        .update(readFileSync(join(dist, f)))
+        .digest('base64');
+    const jsFiles = dir.filter((f) => f.endsWith('.js'));
+    for (const f of [...jsFiles, 'mf-manifest.json']) {
+      expect(sc.files[f]).toMatch(/^sha256-[A-Za-z0-9+/]+=*$/);
+      // Zig SHA-256 ≡ Node crypto (정확성 교차검증)
+      expect(sc.files[f], `integrity ${f}`).toBe(sri(f));
+    }
+    // 결정성: 동일 fixture 재빌드 → sidecar byte-동일
+    const fx2 = await createFixture(files);
+    const prev = cleanup;
+    cleanup = async () => {
+      await prev?.();
+      await fx2.cleanup();
+    };
+    const dist2 = join(fx2.dir, 'dist');
+    expect(
+      (
+        await runZntcInDir(fx2.dir, [
+          '--bundle',
+          join(fx2.dir, 'index.ts'),
+          '--outdir',
+          dist2,
+          '--format=iife',
+        ])
+      ).exitCode,
+    ).toBe(0);
+    const sc2 = await readFile(join(dist2, 'mf-manifest.json.integrity.json'), 'utf8');
+    expect(sc2).toBe(await readFile(join(dist, 'mf-manifest.json.integrity.json'), 'utf8'));
+
+    // 변조탐지: 청크 1바이트 수정 → 재계산 SRI ≠ sidecar(P3/P4 검증 토대)
+    const chunk = jsFiles[0];
+    writeFileSync(join(dist, chunk), readFileSync(join(dist, chunk), 'utf8') + '//x');
+    expect(sri(chunk)).not.toBe(sc.files[chunk]);
   });
 
   // P1-6 (#3388): zntc-빌드 host 가 실 @module-federation/runtime 로 remote


### PR DESCRIPTION
## 무엇 (#3422, MF epic P2-2)

MF 산출(`mf-manifest.json` + 모든 JS 출력 청크)의 **SHA-256 무결성 sidecar** `mf-manifest.json.integrity.json`. **파일명 content-hash 는 Wyhash 불변**(RFC §9 — 부분 재배포 결정성 S5 의존), 무결성만 SHA-256 신규. **P2-3(RS256 서명)의 토대** — sidecar 단일 파일이 서명 대상.

## 어떻게

- 신규 `src/bundler/mf_integrity.zig`: `computeSri`(`std.crypto.Sha256` → `sha256-<base64>` SRI, 코드베이스 `base64.standard.Encoder` 선례 일관), `buildSidecar`(`{version,algorithm,files:{basename:sri}}` JSON — 파일명 정렬=결정성, `emitter.appendJsonString` 단일소스 escape). inline test(빈입력 표준벡터+결정성). **content-hash 2패스 placeholder-skip 와 무관** — 최종 산출 바이트 raw 1패스(혼동 방지 물리 분리).
- `bundler.zig` merge 블록: P1-5/P2-0 `mf_manifest` 편입 **동형**(`total += mf_n*2`, `buildSidecar(m+outputs)`→errdefer→pm/ps dup→`merged[slot]/[slot+1]`→`mf_manifest=null` — 소유 `BundleResult.deinit` 일괄, 이중해제無).
- **표준 schema 불침습**: `@module-federation` 에 서명/SHA 부재(zntc 고유, D3 인접). `ManifestShared.hash` 는 runtime 미소비라 의도적 `""` 유지(P2-0 가드 보존). sidecar 는 표준 runtime 미fetch → S3/S4 interop 무영향.

## 검증

Node `crypto` 교차검증(Zig SHA-256 정확)·결정성(재빌드 byte-동일)·변조탐지·전 `.js`+manifest 커버. mf 통합 **12·0**, e2e **S3/S4 2·0**(sidecar interop 불침습), `zig build test`/`wasm-bundler` 0(computeSri inline 포함), lint/fmt 0. /simplify 3-에이전트 차단 0(merge errdefer/slot 범위/basename dangling 정밀 검증 — 거짓양성 확인; basename flat-outdir 가정 주석 반영).

## 비-목표

런타임 강제 verify(P3/P4) · RS256 서명(P2-3) · CSS/worker 청크 무결성(후속) · 표준 `ManifestShared.hash` 채움(runtime 미소비 — 영구 비-목표).

🤖 Generated with [Claude Code](https://claude.com/claude-code)