### PR TITLE
feat(mf): Ed25519 무결성 sidecar 서명 에미터 + verify (#3423)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -258,6 +258,9 @@ pub const BundleOptions = struct {
     /// `--mangle-report=<path>` — mangler property 측정 JSON 저장 (#1760).
     /// `minify_identifiers=true` 일 때만 의미 있음 (그 외에는 빈 report).
     mangle_report_path: ?[]const u8 = null,
+    /// #3423 P2-3: MF 무결성 sidecar Ed25519 서명 키(raw 32B seed base64
+    /// 파일). null=서명 미산출(opt-in).
+    mf_sign_key_path: ?[]const u8 = null,
     /// 번들 분석 출력 (--analyze). metafile을 내부적으로 강제 활성화.
     analyze: bool = false,
     /// 모든 모듈에 자동 import (--inject:./file.js). 절대 경로 목록.
@@ -1646,7 +1649,9 @@ pub const Bundler = struct {
             const existing = if (asset_outputs) |a| a.len else 0;
             const mf_n: usize = if (mf_manifest != null) 1 else 0;
             // P2-2 (#3422): manifest 산출 시 SHA-256 무결성 sidecar 도 1개.
-            const total = existing + worker_output_files.items.len + css_output_files.items.len + mf_n * 2;
+            // P2-3 (#3423): + 키 지정 시 Ed25519 `.sig` 1개 (opt-in).
+            const sig_n: usize = if (mf_n == 1 and self.options.mf_sign_key_path != null) 1 else 0;
+            const total = existing + worker_output_files.items.len + css_output_files.items.len + mf_n * 2 + sig_n;
             const merged = try self.allocator.alloc(OutputFile, total);
             if (asset_outputs) |a| {
                 @memcpy(merged[0..a.len], a);
@@ -1676,8 +1681,34 @@ pub const Bundler = struct {
                 const pm = try self.allocator.dupe(u8, "mf-manifest.json");
                 errdefer self.allocator.free(pm);
                 const ps = try self.allocator.dupe(u8, "mf-manifest.json.integrity.json");
+                errdefer self.allocator.free(ps);
+                // P2-3: 키 지정 시 sidecar 를 Ed25519 서명 → 별도 `.sig`
+                // (자기참조 순환 회피 — sidecar 불변). 키 오류=fail-fast
+                // (보안 의도라 silent skip 금지). 부분실패 누수는 errdefer.
+                var sig_json: ?[]const u8 = null;
+                errdefer if (sig_json) |s| self.allocator.free(s);
+                var psig: ?[]const u8 = null;
+                errdefer if (psig) |p| self.allocator.free(p);
+                if (self.options.mf_sign_key_path) |keypath| {
+                    const key_txt = std.fs.cwd().readFileAlloc(self.allocator, keypath, 4096) catch
+                        return error.MfSignKeyRead;
+                    defer self.allocator.free(key_txt);
+                    const trimmed = std.mem.trim(u8, key_txt, " \t\r\n");
+                    const Dec = std.base64.standard.Decoder;
+                    var seed: [32]u8 = undefined;
+                    if ((Dec.calcSizeForSlice(trimmed) catch return error.MfSignKeyInvalid) != seed.len)
+                        return error.MfSignKeyInvalid;
+                    Dec.decode(&seed, trimmed) catch return error.MfSignKeyInvalid;
+                    sig_json = try @import("mf_integrity.zig").signSidecar(self.allocator, sidecar, seed);
+                    psig = try self.allocator.dupe(u8, "mf-manifest.json.integrity.json.sig");
+                }
                 merged[slot] = .{ .path = pm, .contents = m };
                 merged[slot + 1] = .{ .path = ps, .contents = sidecar };
+                if (sig_json) |s| {
+                    merged[slot + 2] = .{ .path = psig.?, .contents = s };
+                    sig_json = null; // 소유권 이전
+                    psig = null;
+                }
                 mf_manifest = null; // 소유권 이전 — errdefer(:1356) 이중해제 방지
             }
             break :blk merged;

--- a/src/bundler/mf_integrity.zig
+++ b/src/bundler/mf_integrity.zig
@@ -72,6 +72,68 @@ pub fn buildSidecar(
     return b.toOwnedSlice(allocator);
 }
 
+/// P2-3 (#3423): P2-2 sidecar 를 **Ed25519** 서명. RS256 비채택 — Zig
+/// 0.15.2 std.crypto 에 RSA 서명 부재(crypto.zig:174-176: sign 은 Ed25519/
+/// ecdsa 만; Certificate.rsa 는 X.509 *검증* 전용). 표준 @module-federation
+/// 에 서명 부재(zntc 고유, RFC §5.4 RS256 은 예시일 뿐) → 알고리즘 선택
+/// 자유, alg 필드는 실제(`ed25519`) 정직 표기. seed=raw 32B(KeyPair.
+/// generateDeterministic). 서명 결정적(sign(msg,null)) → sidecar 결정성
+/// (P2-2)과 합쳐 `.sig` byte-재현. 별도 `.sig` 파일(자기참조 순환 회피 —
+/// sidecar 불변). 반환 = `.sig` JSON(owned).
+pub fn signSidecar(
+    allocator: std.mem.Allocator,
+    sidecar_bytes: []const u8,
+    seed: [32]u8,
+) ![]const u8 {
+    const Ed = std.crypto.sign.Ed25519;
+    const kp = Ed.KeyPair.generateDeterministic(seed) catch return error.MfSignKeyInvalid;
+    const sig = kp.sign(sidecar_bytes, null) catch return error.MfSignFailed;
+    const sig_bytes = sig.toBytes(); // 64B
+    const pk_bytes = kp.public_key.toBytes(); // 32B
+    const Enc = std.base64.standard.Encoder;
+    const sig64 = try allocator.alloc(u8, Enc.calcSize(sig_bytes.len));
+    defer allocator.free(sig64);
+    _ = Enc.encode(sig64, &sig_bytes);
+    const pk64 = try allocator.alloc(u8, Enc.calcSize(pk_bytes.len));
+    defer allocator.free(pk64);
+    _ = Enc.encode(pk64, &pk_bytes);
+    var b: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer b.deinit(allocator);
+    try b.appendSlice(allocator, "{\"version\":1,\"alg\":\"ed25519\",\"signature\":");
+    try emitter.appendJsonString(&b, allocator, sig64);
+    try b.appendSlice(allocator, ",\"publicKey\":");
+    try emitter.appendJsonString(&b, allocator, pk64);
+    try b.append(allocator, '}');
+    return b.toOwnedSlice(allocator);
+}
+
+/// `.sig` JSON 으로 sidecar 무결성 서명 검증(round-trip/변조탐지). 런타임
+/// 강제 verify 는 비-목표(P3/P4) — 인프라+테스트용. 실패 시 명확한 error.
+pub fn verifySidecar(
+    allocator: std.mem.Allocator,
+    sidecar_bytes: []const u8,
+    sig_json: []const u8,
+) !void {
+    const Sig = struct { alg: []const u8, signature: []const u8, publicKey: []const u8 };
+    const parsed = std.json.parseFromSlice(Sig, allocator, sig_json, .{
+        .ignore_unknown_fields = true,
+    }) catch return error.MfSigMalformed;
+    defer parsed.deinit();
+    if (!std.mem.eql(u8, parsed.value.alg, "ed25519")) return error.MfSigUnsupportedAlg;
+    const Ed = std.crypto.sign.Ed25519;
+    const Dec = std.base64.standard.Decoder;
+    var sigb: [Ed.Signature.encoded_length]u8 = undefined; // 64
+    if ((Dec.calcSizeForSlice(parsed.value.signature) catch return error.MfSigMalformed) != sigb.len)
+        return error.MfSigMalformed;
+    Dec.decode(&sigb, parsed.value.signature) catch return error.MfSigMalformed;
+    var pkb: [Ed.PublicKey.encoded_length]u8 = undefined; // 32
+    if ((Dec.calcSizeForSlice(parsed.value.publicKey) catch return error.MfSigMalformed) != pkb.len)
+        return error.MfSigMalformed;
+    Dec.decode(&pkb, parsed.value.publicKey) catch return error.MfSigMalformed;
+    const pk = Ed.PublicKey.fromBytes(pkb) catch return error.MfSigMalformed;
+    Ed.Signature.fromBytes(sigb).verify(sidecar_bytes, pk) catch return error.MfSigMismatch;
+}
+
 test "computeSri: SHA-256 SRI 결정성·정확성" {
     const a = std.testing.allocator;
     // 빈 입력의 SHA-256 = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
@@ -85,4 +147,22 @@ test "computeSri: SHA-256 SRI 결정성·정확성" {
     defer a.free(s3);
     try std.testing.expectEqualStrings(s2, s3); // 결정성
     try std.testing.expect(!std.mem.eql(u8, s1, s2)); // 입력 다르면 다름
+}
+
+test "signSidecar/verifySidecar: round-trip·변조탐지·결정성" {
+    const a = std.testing.allocator;
+    var seed: [32]u8 = undefined;
+    for (&seed, 0..) |*x, i| x.* = @intCast(i); // 결정적 테스트 seed
+    const payload = "{\"version\":1,\"algorithm\":\"sha256\",\"files\":{}}";
+    const sig1 = try signSidecar(a, payload, seed);
+    defer a.free(sig1);
+    const sig2 = try signSidecar(a, payload, seed);
+    defer a.free(sig2);
+    try std.testing.expectEqualStrings(sig1, sig2); // 결정적 서명
+    try std.testing.expect(std.mem.indexOf(u8, sig1, "\"alg\":\"ed25519\"") != null);
+    try verifySidecar(a, payload, sig1); // round-trip OK
+    // 변조: payload 1바이트 변경 → 불일치
+    try std.testing.expectError(error.MfSigMismatch, verifySidecar(a, payload[0 .. payload.len - 1], sig1));
+    // 깨진 sig JSON
+    try std.testing.expectError(error.MfSigMalformed, verifySidecar(a, payload, "{not json"));
 }

--- a/src/cli/options.zig
+++ b/src/cli/options.zig
@@ -113,6 +113,10 @@ pub const CliOptions = struct {
     metafile_path: ?[]const u8 = null,
     /// --mangle-report=<path>: mangler property 측정 JSON 저장 (#1760).
     mangle_report_path: ?[]const u8 = null,
+    /// --mf-sign-key=<path>: MF 무결성 sidecar Ed25519 서명 키(raw 32B
+    /// seed base64). 미지정 시 `.sig` 미산출(opt-in). argv 슬라이스 borrow
+    /// — free 불요(metafile_path/mangle_report_path 동일 관례) (#3423).
+    mf_sign_key_path: ?[]const u8 = null,
     analyze: bool = false,
     legal_comments: @import("zntc_lib").bundler.types.LegalComments = .default,
     inject_list: std.ArrayList([]const u8) = .empty,
@@ -990,6 +994,8 @@ pub fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator)
             opts.metafile_path = "meta.json";
         } else if (std.mem.startsWith(u8, arg, "--mangle-report=")) {
             opts.mangle_report_path = arg["--mangle-report=".len..];
+        } else if (std.mem.startsWith(u8, arg, "--mf-sign-key=")) {
+            opts.mf_sign_key_path = arg["--mf-sign-key=".len..];
         } else if (std.mem.eql(u8, arg, "--analyze")) {
             opts.analyze = true;
         } else if (std.mem.eql(u8, arg, "--keep-names")) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -648,6 +648,7 @@ pub fn main() !void {
             .loader_overrides = opts.loader_list.items,
             .metafile = opts.metafile_path != null or opts.analyze,
             .mangle_report_path = opts.mangle_report_path,
+            .mf_sign_key_path = opts.mf_sign_key_path,
             .analyze = opts.analyze,
             .legal_comments = opts.legal_comments,
             .inject = opts.inject_list.items,

--- a/tests/integration/tests/mf-runtime-interop-smoke.test.ts
+++ b/tests/integration/tests/mf-runtime-interop-smoke.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, afterEach } from 'bun:test';
 import { createServer, type Server } from 'node:http';
 import { readFile, readdir } from 'node:fs/promises';
 import { writeFileSync, rmSync, readFileSync } from 'node:fs';
-import { createHash } from 'node:crypto';
+import { createHash, randomBytes, createPublicKey, verify as cryptoVerify } from 'node:crypto';
 import { join } from 'node:path';
 import { createRequire } from 'node:module';
 import { createFixture, runZntcInDir, runNode } from './helpers';
@@ -406,6 +406,127 @@ console.log('SAME=' + (m && m.usedHook === hostReact.useState));
     const chunk = jsFiles[0];
     writeFileSync(join(dist, chunk), readFileSync(join(dist, chunk), 'utf8') + '//x');
     expect(sri(chunk)).not.toBe(sc.files[chunk]);
+  });
+
+  // P2-3 (#3423): Ed25519 서명 에미터. P2-2 sidecar 를 서명한 별도 .sig
+  // (자기참조 순환 회피). RS256 비채택(Zig std RSA 부재) — alg="ed25519"
+  // 정직 표기. opt-in(--mf-sign-key). 런타임 강제 verify=P3/P4(비-목표).
+  // raw 32B ed25519 pubkey → SPKI DER 래핑(prefix 302a300506032b6570032100).
+  const SPKI_ED25519 = Buffer.from('302a300506032b6570032100', 'hex');
+  const edPub = (b64: string) =>
+    createPublicKey({
+      key: Buffer.concat([SPKI_ED25519, Buffer.from(b64, 'base64')]),
+      format: 'der',
+      type: 'spki',
+    });
+  test('P2-3 Ed25519 서명: opt-in·round-trip·변조탐지·결정성·fail-fast', async () => {
+    const files = {
+      'W.ts': `export default () => "W";`,
+      'index.ts': `export const sentinel = "re";`,
+      'zntc.config.json': JSON.stringify({ mf: { name: 'app', exposes: { './W': './W.ts' } } }),
+    };
+    // (1) opt-in off — 키 없으면 .sig 미산출
+    const off = await createFixture(files);
+    cleanup = off.cleanup;
+    const offDist = join(off.dir, 'dist');
+    expect(
+      (
+        await runZntcInDir(off.dir, [
+          '--bundle',
+          join(off.dir, 'index.ts'),
+          '--outdir',
+          offDist,
+          '--format=iife',
+        ])
+      ).exitCode,
+    ).toBe(0);
+    expect(await readdir(offDist)).not.toContain('mf-manifest.json.integrity.json.sig');
+
+    // (2) 서명 산출 + Node Ed25519 교차검증
+    const fx = await createFixture(files);
+    const prev = cleanup;
+    cleanup = async () => {
+      await prev?.();
+      await fx.cleanup();
+    };
+    const keyPath = join(fx.dir, 'sign.key');
+    writeFileSync(keyPath, randomBytes(32).toString('base64'));
+    const dist = join(fx.dir, 'dist');
+    const args = [
+      '--bundle',
+      join(fx.dir, 'index.ts'),
+      '--outdir',
+      dist,
+      '--format=iife',
+      `--mf-sign-key=${keyPath}`,
+    ];
+    expect((await runZntcInDir(fx.dir, args)).exitCode).toBe(0);
+    const sidecarBytes = readFileSync(join(dist, 'mf-manifest.json.integrity.json'));
+    const sig = JSON.parse(
+      await readFile(join(dist, 'mf-manifest.json.integrity.json.sig'), 'utf8'),
+    );
+    expect(sig.version).toBe(1);
+    expect(sig.alg).toBe('ed25519');
+    // Zig Ed25519 ≡ Node crypto verify (정확성 교차검증)
+    expect(
+      cryptoVerify(null, sidecarBytes, edPub(sig.publicKey), Buffer.from(sig.signature, 'base64')),
+    ).toBe(true);
+    // 변조: sidecar 1바이트 → 검증 실패
+    expect(
+      cryptoVerify(
+        null,
+        Buffer.concat([sidecarBytes, Buffer.from('x')]),
+        edPub(sig.publicKey),
+        Buffer.from(sig.signature, 'base64'),
+      ),
+    ).toBe(false);
+
+    // (3) 결정성: 동일 fixture+키 재빌드 → .sig byte-동일(결정적 서명)
+    const fx2 = await createFixture(files);
+    const prev2 = cleanup;
+    cleanup = async () => {
+      await prev2?.();
+      await fx2.cleanup();
+    };
+    const kp2 = join(fx2.dir, 'sign.key');
+    writeFileSync(kp2, readFileSync(keyPath)); // 동일 키
+    const dist2 = join(fx2.dir, 'dist');
+    expect(
+      (
+        await runZntcInDir(fx2.dir, [
+          '--bundle',
+          join(fx2.dir, 'index.ts'),
+          '--outdir',
+          dist2,
+          '--format=iife',
+          `--mf-sign-key=${kp2}`,
+        ])
+      ).exitCode,
+    ).toBe(0);
+    expect(await readFile(join(dist2, 'mf-manifest.json.integrity.json.sig'), 'utf8')).toBe(
+      await readFile(join(dist, 'mf-manifest.json.integrity.json.sig'), 'utf8'),
+    );
+
+    // (4) fail-fast: 잘못된 키(짧음/비-base64) → 빌드 실패
+    const bad = await createFixture(files);
+    const prev3 = cleanup;
+    cleanup = async () => {
+      await prev3?.();
+      await bad.cleanup();
+    };
+    writeFileSync(join(bad.dir, 'bad.key'), 'not-a-valid-32byte-seed');
+    expect(
+      (
+        await runZntcInDir(bad.dir, [
+          '--bundle',
+          join(bad.dir, 'index.ts'),
+          '--outdir',
+          join(bad.dir, 'dist'),
+          '--format=iife',
+          `--mf-sign-key=${join(bad.dir, 'bad.key')}`,
+        ])
+      ).exitCode,
+    ).not.toBe(0);
   });
 
   // P1-6 (#3388): zntc-빌드 host 가 실 @module-federation/runtime 로 remote


### PR DESCRIPTION
## 무엇 (#3423, MF epic P2-3)

P2-2 SHA-256 무결성 sidecar(`mf-manifest.json.integrity.json`)를 **Ed25519 서명**한 별도 `.sig`(`mf-manifest.json.integrity.json.sig`). opt-in `--mf-sign-key=<path>`(raw 32B seed base64). 표준 `@module-federation` 에 서명 부재 = zntc 고유(D3 인접). **P2-3 RS256 → Ed25519 비채택 근거**: Zig 0.15.2 `std.crypto` 에 RSA *서명* 부재(`sign` 은 Ed25519/ecdsa 만; `Certificate.rsa` 는 X.509 *검증* 전용). RS256 직접구현=과대범위. 산출물이 zntc 고유(RFC §5.4 RS256 은 예시)라 알고리즘 선택 자유 → `alg` 필드 실제값(`ed25519`) 정직 표기.

## 어떻게

- `mf_integrity.zig`: `signSidecar`(`KeyPair.generateDeterministic`→`sign(msg,null)`=결정적→`{version,alg:"ed25519",signature:<b64 64B>,publicKey:<b64 32B>}`), `verifySidecar`(`std.json`→base64 디코드→`Signature.verify`, `MfSig*` 에러). inline test(round-trip·변조·결정성·깨진 sig). base64 Enc/Dec·`appendJsonString` 단일소스 재사용(`computeSri` 동형).
- `bundler.zig` merge: `sig_n` 슬롯 + 키 `readFileAlloc`(4096 상한)→base64 디코드 32B seed→`signSidecar`→`.sig` OutputFile. **키 오류=fail-fast**(보안 의도 — silent skip 금지). errdefer 체인(sidecar/pm/ps/sig_json/psig) — 부분실패 누수·이중해제 차단, 성공 시 소유 `BundleResult.deinit` 일괄.
- `cli/options.zig` `--mf-sign-key=`(--mangle-report= 동형), `main.zig` 전달.
- **별도 `.sig` 파일** = 자기참조 순환 회피(sidecar 불변) + 표준 runtime 미fetch → S3/S4 interop 불침습(opt-in off 시 미산출).

## 검증

Node `crypto` Ed25519(raw pubkey→SPKI DER `302a300506032b6570032100` 래핑) **교차검증**(Zig↔Node 정확성)·변조탐지(false)·결정성(재빌드 byte-동일)·opt-in off(.sig 미산출)·fail-fast(잘못된 키 exitCode≠0). mf 통합 **13·0**, e2e **S3/S4 2·0**, `zig build test`/`wasm-bundler` 0(sign/verify inline 포함), lint/fmt 0. /simplify 3-에이전트 차단 0(merge errdefer/slot 범위/verify 정밀 검증 — 거짓양성 확인).

## 비-목표

런타임/빌드 강제 verify(P3/P4) · JWS/JWT 표준 호환 · RSA 직접구현 · 키 회전/PKI(P4) · remoteEntry 본문 서명(P4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)