### PR TITLE
feat(mf): metafile MF 산출 표식 — additive zntcMf 키 (#3424)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1601,7 +1601,14 @@ pub const Bundler = struct {
         // 7. Metafile JSON 생성 (--metafile / --analyze)
         var metafile_scope = profile.begin(.emit_metafile);
         const metafile_json: ?[]const u8 = if (self.options.metafile or self.options.analyze)
-            try generateMetafileJson(self.allocator, &graph, output, outputs)
+            try generateMetafileJson(
+                self.allocator,
+                &graph,
+                output,
+                outputs,
+                if (self.options.mf) |*mf| mf else null,
+                self.options.mf_sign_key_path != null,
+            )
         else
             null;
         metafile_scope.end();
@@ -1818,6 +1825,8 @@ fn generateMetafileJson(
     graph: *const @import("graph.zig").ModuleGraph,
     single_output: []const u8,
     multi_outputs: ?[]const OutputFile,
+    mf: ?*const MfBundleConfig,
+    mf_signed: bool,
 ) ![]const u8 {
     var buf: std.ArrayList(u8) = .empty;
     errdefer buf.deinit(allocator);
@@ -1873,7 +1882,42 @@ fn generateMetafileJson(
         try buf.appendSlice(allocator, " }");
     }
 
-    try buf.appendSlice(allocator, "\n  }\n}\n");
+    try buf.appendSlice(allocator, "\n  }");
+    // P2-4 (#3424): MF 산출 표식 — additive 최상위 `zntcMf` 키(esbuild
+    // 메타파일 스키마는 {inputs,outputs}; 알 수 없는 키는 분석기가 무시 →
+    // 호환 불변). exposes>0(=remote-producer, manifest/integrity/sig 산출
+    // 시점)일 때만. 산출 파일명은 결정적 상수(P1-5/P2-2/P2-3) — 청크별
+    // 매핑은 mf-manifest.json 본문이라 metafile 은 포인터/마커만(중복 회피).
+    if (mf) |m| {
+        if (m.exposes.len > 0) {
+            try buf.appendSlice(allocator, ",\n  \"zntcMf\": { \"name\": ");
+            // P1-0 validateMf 가 exposes>0 ⟹ name 강제 → orelse 는 도달
+            // 불가 방어(wrapContainer 게이트와 동치).
+            try appendJsonString(&buf, allocator, m.name orelse "");
+            try buf.appendSlice(allocator, ", \"manifest\": \"mf-manifest.json\", \"integrity\": \"mf-manifest.json.integrity.json\", \"signature\": ");
+            if (mf_signed)
+                try buf.appendSlice(allocator, "\"mf-manifest.json.integrity.json.sig\"")
+            else
+                try buf.appendSlice(allocator, "null");
+            try buf.appendSlice(allocator, ", \"exposes\": [");
+            for (m.exposes, 0..) |kv, i| {
+                if (i > 0) try buf.appendSlice(allocator, ", ");
+                try appendJsonString(&buf, allocator, kv.key);
+            }
+            try buf.appendSlice(allocator, "], \"shared\": [");
+            for (m.shared, 0..) |se, i| {
+                if (i > 0) try buf.appendSlice(allocator, ", ");
+                try appendJsonString(&buf, allocator, se.name);
+            }
+            try buf.appendSlice(allocator, "], \"remotes\": [");
+            for (m.remotes, 0..) |kv, i| {
+                if (i > 0) try buf.appendSlice(allocator, ", ");
+                try appendJsonString(&buf, allocator, kv.key);
+            }
+            try buf.appendSlice(allocator, "] }");
+        }
+    }
+    try buf.appendSlice(allocator, "\n}\n");
     return buf.toOwnedSlice(allocator);
 }
 

--- a/tests/integration/tests/mf-runtime-interop-smoke.test.ts
+++ b/tests/integration/tests/mf-runtime-interop-smoke.test.ts
@@ -529,6 +529,108 @@ console.log('SAME=' + (m && m.usedHook === hostReact.useState));
     ).not.toBe(0);
   });
 
+  // P2-4 (#3424): metafile MF 산출 표식. esbuild 메타파일 스키마
+  // ({inputs,outputs}) 불변 — additive 최상위 `zntcMf` 키(분석기 무시).
+  // 산출 파일명 결정적 상수(P1-5/P2-2/P2-3) 포인터 + config 메타. 非-MF
+  // 빌드엔 zntcMf 부재(호환 회귀 가드).
+  test('P2-4 metafile zntcMf 표식: additive·esbuild 호환 불변', async () => {
+    const keyName = 'mfk';
+    const fx = await createFixture({
+      'W.ts': `export default () => "W";`,
+      'index.ts': `export const sentinel = "re";`,
+      [keyName]: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+      'zntc.config.json': JSON.stringify({
+        mf: {
+          name: 'app',
+          exposes: { './W': './W.ts' },
+          shared: { react: { singleton: true } },
+          remotes: { up: 'u@http://h/mf-manifest.json' },
+        },
+      }),
+    });
+    cleanup = fx.cleanup;
+    const meta = join(fx.dir, 'meta.json');
+    expect(
+      (
+        await runZntcInDir(fx.dir, [
+          '--bundle',
+          join(fx.dir, 'index.ts'),
+          '--outdir',
+          join(fx.dir, 'dist'),
+          '--format=iife',
+          `--metafile=${meta}`,
+          `--mf-sign-key=${join(fx.dir, keyName)}`,
+        ])
+      ).exitCode,
+    ).toBe(0);
+    const m = JSON.parse(await readFile(meta, 'utf8'));
+    // esbuild 스키마 불변
+    expect(m.inputs).toBeDefined();
+    expect(m.outputs).toBeDefined();
+    // additive zntcMf
+    expect(m.zntcMf).toEqual({
+      name: 'app',
+      manifest: 'mf-manifest.json',
+      integrity: 'mf-manifest.json.integrity.json',
+      signature: 'mf-manifest.json.integrity.json.sig', // 키 지정 → .sig
+      exposes: ['./W'],
+      shared: ['react'],
+      remotes: ['up'],
+    });
+
+    // 키 미지정 → signature:null
+    const fx2 = await createFixture({
+      'W.ts': `export default () => "W";`,
+      'index.ts': `export const sentinel = "re";`,
+      'zntc.config.json': JSON.stringify({ mf: { name: 'app', exposes: { './W': './W.ts' } } }),
+    });
+    const prev = cleanup;
+    cleanup = async () => {
+      await prev?.();
+      await fx2.cleanup();
+    };
+    const meta2 = join(fx2.dir, 'meta.json');
+    expect(
+      (
+        await runZntcInDir(fx2.dir, [
+          '--bundle',
+          join(fx2.dir, 'index.ts'),
+          '--outdir',
+          join(fx2.dir, 'dist'),
+          '--format=iife',
+          `--metafile=${meta2}`,
+        ])
+      ).exitCode,
+    ).toBe(0);
+    const m2 = JSON.parse(await readFile(meta2, 'utf8'));
+    expect(m2.zntcMf.signature).toBe(null);
+    expect(m2.zntcMf.shared).toEqual([]);
+    expect(m2.zntcMf.remotes).toEqual([]);
+
+    // 非-MF 빌드: zntcMf 부재(esbuild 호환 회귀 가드)
+    const fx3 = await createFixture({ 'p.ts': `export const s = 1;\nconsole.log(s);` });
+    const prev3 = cleanup;
+    cleanup = async () => {
+      await prev3?.();
+      await fx3.cleanup();
+    };
+    const meta3 = join(fx3.dir, 'meta.json');
+    expect(
+      (
+        await runZntcInDir(fx3.dir, [
+          '--bundle',
+          join(fx3.dir, 'p.ts'),
+          '-o',
+          join(fx3.dir, 'o.js'),
+          `--metafile=${meta3}`,
+        ])
+      ).exitCode,
+    ).toBe(0);
+    const m3 = JSON.parse(await readFile(meta3, 'utf8'));
+    expect(m3.inputs).toBeDefined();
+    expect(m3.zntcMf).toBeUndefined();
+  });
+
   // P1-6 (#3388): zntc-빌드 host 가 실 @module-federation/runtime 로 remote
   // 소비. zntc 가 emit 한 init prelude + `import("remote/x")`→loadRemote
   // 재작성 코드가 **실 스펙 런타임**으로 동작(host-emit 검증, D1 — 자체


### PR DESCRIPTION
## 무엇 (#3424, MF epic P2-4)

`generateMetafileJson` 에 outputs 닫기 직후 **additive 최상위 `zntcMf` 키**(exposes>0=remote-producer 시만): `{name,manifest:"mf-manifest.json",integrity:"...integrity.json",signature:<".sig"|null>,exposes:[키],shared:[name],remotes:[키]}`.

## 어떻게

- **esbuild 메타파일 스키마({inputs,outputs}) 불변** — 분석기(esbuild analyze/bundle-buddy/visualizer)는 `outputs`/`inputs` 키로 인덱싱, 최상위 미지 키 무시 → 호환 불변(케이스3 非-MF 회귀 가드로 보강).
- 산출 파일명 = 결정적 상수(P1-5/P2-2/P2-3) **포인터/마커**만 — 청크별 매핑은 `mf-manifest.json` 본문이라 metafile 중복 회피.
- 게이트 `exposes.len>0` = `wrapContainer` manifest 산출 조건(exposes>0 && name!=null, P1-0 가 동치 보장)과 일치 → **없는 파일 포인터 不**. `signature` 는 `mf_sign_key_path != null`(P2-3 `.sig` 산출 게이트)과 일치. 닫기 시퀀스 분리(outputs `}` / 루트 `}`)로 全 경로 valid JSON. `appendJsonString` 단일소스 escape, 신규 alloc 없음.
- 호출부(:1604) mf/signed 전달(호출자 1곳, 시그니처 무파급).

## 검증

MF(서명有 `.sig`/無 `null`)·非-MF(`zntcMf` undefined=esbuild 호환 회귀 가드)·빈 shared/remotes(`[]`) — `toEqual` 전체 비교. `inputs`/`outputs` 존재 불변. mf 통합 **14·0**, e2e **S3/S4 2·0**(metafile 미사용 무회귀), `zig build test`/`wasm-bundler` 0, lint/fmt 0. /simplify 3-에이전트 차단 0(JSON 균형/게이트 일치/메모리 정밀 — 거짓양성만, `m.name orelse` 방어 주석 반영).

## 비-목표

청크별 무결성 metafile 인라인(mf-manifest 본문 중복) · MF output role 세분(remoteEntry/expose 청크 분류 — manifest 가 이미 보유).

🤖 Generated with [Claude Code](https://claude.com/claude-code)