### PR TITLE
feat(mf): 빌드타임 계약 검증 토대 — RemoteContract parse+resolve (#3435)

### DIFF
--- a/src/bundler/federation_emit.zig
+++ b/src/bundler/federation_emit.zig
@@ -188,7 +188,9 @@ fn bootstrapSpan(text: []const u8) ?struct { start: usize, end: usize } {
 /// expose 명·federation_id·lazy 청크 파일명 묶음. 모두 borrow
 /// (name=mf.exposes KV, fed_id=graph 모듈, chunk_file=outputs[].path basename)
 /// — wrapContainer 수명 동안 mf/graph/outputs 생존. 슬라이스만 caller free.
-const ExposeInfo = struct { name: []const u8, fed_id: []const u8, chunk_file: []const u8 };
+// pub: P3-0 mf_contract.zig 의 emit↔parse 라운드트립 테스트가 스키마
+// 단일 소스 박제를 위해 buildManifest 와 함께 소비(RFC §7.3).
+pub const ExposeInfo = struct { name: []const u8, fed_id: []const u8, chunk_file: []const u8 };
 
 /// exposes → (명, fed_id, lazy 청크 파일) 수집. container.get 맵과
 /// mf-manifest 가 **동일 스캔**을 쓰므로 단일 소스(exposeFedId/
@@ -347,7 +349,7 @@ const appendJsonStr = emitter.appendJsonString;
 /// 식별/캐시 힌트로만 쓰고 의미 검증 안 함(generateSnapshotFromManifest)
 /// — lockstep 패키지 버전 추적은 불필요(P1-6 비-목표). build-time 주입은
 /// 후속 백로그.
-fn buildManifest(
+pub fn buildManifest(
     allocator: std.mem.Allocator,
     name: []const u8,
     mf: *const types.MfBundleConfig,

--- a/src/bundler/mf_contract.zig
+++ b/src/bundler/mf_contract.zig
@@ -1,0 +1,259 @@
+//! P3-0 (#3435): 빌드타임 계약 검증 토대 — host 빌드가 `mf.remotes` 의
+//! remote 가 게시한 `mf-manifest.json` 을 resolve+parse 하여
+//! `RemoteContract` 데이터 모델로 만든다. **검증 없음(파싱·표면만)** —
+//! expose 존재(P3-1)·shared 버전 호환(P3-2)·무결성(P3-3)·런타임 가드
+//! (P3-5)는 이 토대를 소비하는 후속 단위가 얹는다(중복 파서 금지).
+//!
+//! 스키마 단일 소스: `federation_emit.zig:buildManifest` 가 emit 하는
+//! `@module-federation/sdk@2.4.0` Manifest 형태(name/exposes[].name/
+//! shared[].{name,version,requiredVersion,singleton})를 그대로 읽는다.
+//! emit↔parse 정합은 inline test 가 buildManifest 산출을 라운드트립으로
+//! 박제(스키마 drift 시 컴파일·테스트 fail = 단일 소스 보장).
+//!
+//! 경계(RFC §7.3 ③): remote manifest 의 **네트워크 fetch(http/https)는
+//! 비-목표** — local/file resolve 우선(`MfContractNetworkUnsupported`).
+//! 신뢰 모델·캐시·HTTP 다운로드는 P4(RN 보안 모델)/후속. 에러 명명은
+//! `mf_integrity.zig` 의 `MfSig*` 선례를 답습(`MfContract*`).
+const std = @import("std");
+
+pub const MfContractError = error{
+    /// JSON 파싱 실패 또는 manifest 스키마 불일치.
+    MfContractMalformed,
+    /// remote entry 가 http/https — 빌드타임 네트워크 fetch 비-목표(P4).
+    MfContractNetworkUnsupported,
+    /// resolve 된 manifest 파일이 없음(sibling 빌드 미산출 등) — P3-1 이
+    /// "remote manifest 부재"를 파싱 실패와 구분해 fail-fast 메시지.
+    MfContractManifestNotFound,
+};
+
+/// OOM 은 빌드 환경 자원 문제이므로 manifest 결함(MfContractMalformed)과
+/// 섞지 않는다(진단 정확성). std.json/alloc 의 OutOfMemory 는 그대로 전파.
+const ParseError = MfContractError || std.mem.Allocator.Error;
+
+/// remote 가 게시한 shared 의존 1건(계약면). version 은 remote 가 박은 값,
+/// required_version 은 remote 의 요구 range — P3-2 가 host 요구와 교차검증.
+pub const SharedContract = struct {
+    name: []const u8,
+    version: []const u8,
+    required_version: []const u8,
+    singleton: bool,
+};
+
+/// remote 가 게시한 계약면(파싱 결과). 모든 슬라이스/문자열은 `arena`
+/// 소유 — `manifest_bytes` 수명과 독립(alloc_always). 소비 측은
+/// `defer rc.deinit()` 하나로 일괄 해제(CLAUDE.md arena 규약: 개별
+/// deinit 금지, 단일 소유자만 arena.deinit()).
+pub const RemoteContract = struct {
+    arena: std.heap.ArenaAllocator,
+    /// manifest.name (= container globalName).
+    name: []const u8,
+    /// manifest.exposes[].name (공개 키, 예 "./Widget"). P3-1 이 host
+    /// import 와 대조.
+    exposes: []const []const u8,
+    /// manifest.shared[] (name/version/requiredVersion/singleton). P3-2.
+    shared: []const SharedContract,
+
+    pub fn deinit(self: *RemoteContract) void {
+        self.arena.deinit();
+    }
+};
+
+// federation_emit.buildManifest 가 emit 하는 키만 추림(나머지 무시).
+// 필드명 = JSON 키 그대로(camelCase requiredVersion) — std.json 매핑.
+const ExposeJson = struct { name: []const u8 = "" };
+const SharedJson = struct {
+    name: []const u8 = "",
+    version: []const u8 = "",
+    requiredVersion: []const u8 = "",
+    singleton: bool = false,
+};
+const ManifestJson = struct {
+    name: []const u8 = "",
+    exposes: []const ExposeJson = &.{},
+    shared: []const SharedJson = &.{},
+};
+
+/// `mf-manifest.json` 바이트 → `RemoteContract`. unknown 필드 무시
+/// (metaData/remotes/exposes.assets 등 표준 부가키 관용). 모든 문자열은
+/// arena 로 dup(alloc_always) — caller 가 manifest_bytes 를 free 해도 안전.
+/// host-only manifest(exposes/shared 키 부재)는 빈 슬라이스(관용 — 검증은
+/// P3-1+ 책임). 실패 시 `MfContractMalformed`.
+pub fn parseContract(gpa: std.mem.Allocator, manifest_bytes: []const u8) ParseError!RemoteContract {
+    var arena = std.heap.ArenaAllocator.init(gpa);
+    errdefer arena.deinit();
+    const a = arena.allocator();
+
+    const m = std.json.parseFromSliceLeaky(ManifestJson, a, manifest_bytes, .{
+        .ignore_unknown_fields = true,
+        .allocate = .alloc_always,
+    }) catch |e| switch (e) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.MfContractMalformed, // 스키마/구문 결함
+    };
+
+    const exposes = try a.alloc([]const u8, m.exposes.len);
+    for (m.exposes, 0..) |e, i| exposes[i] = e.name;
+
+    const shared = try a.alloc(SharedContract, m.shared.len);
+    for (m.shared, 0..) |s, i| shared[i] = .{
+        .name = s.name,
+        .version = s.version,
+        .required_version = s.requiredVersion,
+        .singleton = s.singleton,
+    };
+
+    return .{ .arena = arena, .name = m.name, .exposes = exposes, .shared = shared };
+}
+
+fn isHttp(s: []const u8) bool {
+    return std.mem.startsWith(u8, s, "http://") or std.mem.startsWith(u8, s, "https://");
+}
+
+/// remote spec entry(`parseRemote` 의 entry — remoteEntry URL/경로) →
+/// 그 remote 의 `mf-manifest.json` **로컬 경로**(owned, caller free).
+/// 규약: entry 가 `.json` 으로 끝나면 그 자체가 manifest, 아니면
+/// `<entry 디렉터리>/mf-manifest.json`(zntc 가 remoteEntry 와 나란히 산출 —
+/// federation_emit). 정규화만(realpath 안 함 — sibling 빌드 산출이라
+/// 아직 미존재 가능, FS 비의존 = 단위테스트 결정적). http/https 는
+/// `MfContractNetworkUnsupported`(네트워크 fetch=P4/후속, RFC §7.3 ③).
+pub fn resolveManifestPath(
+    gpa: std.mem.Allocator,
+    cwd: ?[]const u8,
+    entry: []const u8,
+) !([]const u8) {
+    if (isHttp(entry)) return error.MfContractNetworkUnsupported;
+    const base = cwd orelse ".";
+    const joined = if (std.fs.path.isAbsolute(entry))
+        try gpa.dupe(u8, entry)
+    else
+        try std.fs.path.join(gpa, &.{ base, entry });
+    if (std.mem.endsWith(u8, joined, ".json")) return joined;
+    defer gpa.free(joined);
+    const dir = std.fs.path.dirname(joined) orelse base;
+    return std.fs.path.join(gpa, &.{ dir, "mf-manifest.json" });
+}
+
+/// resolveManifestPath → 파일 읽기 → parseContract 의 편의 결합.
+/// local/file only. manifest 최대 4MiB(표준 manifest 는 수 KB).
+pub fn loadContract(
+    gpa: std.mem.Allocator,
+    cwd: ?[]const u8,
+    entry: []const u8,
+) !RemoteContract {
+    const path = try resolveManifestPath(gpa, cwd, entry);
+    defer gpa.free(path);
+    const bytes = std.fs.cwd().readFileAlloc(gpa, path, 4 * 1024 * 1024) catch |e| switch (e) {
+        error.FileNotFound => return error.MfContractManifestNotFound, // 부재 ≠ 결함
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return error.MfContractMalformed, // 읽기 실패(권한·IO 등)
+    };
+    defer gpa.free(bytes);
+    return parseContract(gpa, bytes);
+}
+
+// ── inline tests (zig build test — mod.zig 등록) ──────────────────────
+
+test "parseContract: buildManifest 스키마 — name/exposes/shared 추출, unknown 무시" {
+    const a = std.testing.allocator;
+    // federation_emit.zig:362-444 가 emit 하는 형태(metaData/remotes/
+    // exposes.assets 등 부가키 포함 — 전부 무시되어야).
+    const json =
+        \\{"id":"app","name":"app","metaData":{"name":"app","type":"app",
+        \\"buildInfo":{"buildVersion":"0.1.0"},"globalName":"app"},
+        \\"shared":[{"id":"app:react","name":"react","version":"^19",
+        \\"singleton":true,"requiredVersion":"^19","hash":"","assets":{}}],
+        \\"remotes":[{"entry":"x","federationContainerName":"y"}],
+        \\"exposes":[{"id":"app:Widget","name":"./Widget","path":"./Widget",
+        \\"assets":{"js":{"async":["w.js"]}}},
+        \\{"id":"app:Btn","name":"./Btn","path":"./Btn","assets":{}}]}
+    ;
+    var rc = try parseContract(a, json);
+    defer rc.deinit();
+    try std.testing.expectEqualStrings("app", rc.name);
+    try std.testing.expectEqual(@as(usize, 2), rc.exposes.len);
+    try std.testing.expectEqualStrings("./Widget", rc.exposes[0]);
+    try std.testing.expectEqualStrings("./Btn", rc.exposes[1]);
+    try std.testing.expectEqual(@as(usize, 1), rc.shared.len);
+    try std.testing.expectEqualStrings("react", rc.shared[0].name);
+    try std.testing.expectEqualStrings("^19", rc.shared[0].version);
+    try std.testing.expectEqualStrings("^19", rc.shared[0].required_version);
+    try std.testing.expect(rc.shared[0].singleton);
+}
+
+test "parseContract: host-only(exposes/shared 키 부재) 관용 — 빈 슬라이스" {
+    const a = std.testing.allocator;
+    var rc = try parseContract(a, "{\"name\":\"host\",\"metaData\":{}}");
+    defer rc.deinit();
+    try std.testing.expectEqualStrings("host", rc.name);
+    try std.testing.expectEqual(@as(usize, 0), rc.exposes.len);
+    try std.testing.expectEqual(@as(usize, 0), rc.shared.len);
+}
+
+test "parseContract: 깨진 JSON → MfContractMalformed" {
+    try std.testing.expectError(error.MfContractMalformed, parseContract(std.testing.allocator, "{not json"));
+}
+
+test "parseContract: arena 자기완결 — manifest_bytes free 후에도 유효" {
+    const a = std.testing.allocator;
+    const src = "{\"name\":\"r\",\"exposes\":[{\"name\":\"./X\"}]}";
+    const buf = try a.dupe(u8, src);
+    var rc = try parseContract(a, buf);
+    defer rc.deinit();
+    a.free(buf); // 입력 해제 — alloc_always 라 rc 는 독립 소유
+    try std.testing.expectEqualStrings("r", rc.name);
+    try std.testing.expectEqualStrings("./X", rc.exposes[0]);
+}
+
+test "resolveManifestPath: .json 직접·remoteEntry sibling·절대·http 거부" {
+    const a = std.testing.allocator;
+    // 1) .json 직접 → 그대로(정규화)
+    const p1 = try resolveManifestPath(a, "/proj", "rmt/mf-manifest.json");
+    defer a.free(p1);
+    try std.testing.expectEqualStrings("/proj/rmt/mf-manifest.json", p1);
+    // 2) remoteEntry.js → sibling mf-manifest.json
+    const p2 = try resolveManifestPath(a, "/proj", "rmt/dist/remoteEntry.js");
+    defer a.free(p2);
+    try std.testing.expectEqualStrings("/proj/rmt/dist/mf-manifest.json", p2);
+    // 3) 절대 entry → cwd 무시
+    const p3 = try resolveManifestPath(a, "/proj", "/abs/r/mf-manifest.json");
+    defer a.free(p3);
+    try std.testing.expectEqualStrings("/abs/r/mf-manifest.json", p3);
+    // 4) http/https → 비-목표
+    try std.testing.expectError(error.MfContractNetworkUnsupported, resolveManifestPath(a, "/p", "https://cdn/x/remoteEntry.js"));
+    try std.testing.expectError(error.MfContractNetworkUnsupported, resolveManifestPath(a, "/p", "http://cdn/x/mf-manifest.json"));
+}
+
+// 스키마 단일 소스 박제: federation_emit.buildManifest 가 emit 한 실제
+// manifest 를 parseContract 가 라운드트립. emit 스키마가 drift 하면 이
+// 테스트가 fail = "P2-0/P2-1 sdk 타입 단일 재사용"(RFC §7.3) 강제.
+test "emit↔parse 라운드트립: buildManifest 산출을 parseContract 가 복원" {
+    const a = std.testing.allocator;
+    const types = @import("types.zig");
+    const fe = @import("federation_emit.zig");
+    const shared = [_]types.MfBundleConfig.SharedEntry{
+        .{ .name = "react", .singleton = true, .required_version = "^19" },
+    };
+    const mf = types.MfBundleConfig{
+        .name = "app",
+        .shared = &shared,
+    };
+    const exposes = [_]fe.ExposeInfo{
+        .{ .name = "./Widget", .fed_id = "fid0", .chunk_file = "w.js" },
+        .{ .name = "./Btn", .fed_id = "fid1", .chunk_file = "b.js" },
+    };
+    const manifest = try fe.buildManifest(a, "app", &mf, &exposes, "remoteEntry.js", "auto");
+    defer a.free(manifest);
+
+    var rc = try parseContract(a, manifest);
+    defer rc.deinit();
+    try std.testing.expectEqualStrings("app", rc.name);
+    try std.testing.expectEqual(@as(usize, 2), rc.exposes.len);
+    try std.testing.expectEqualStrings("./Widget", rc.exposes[0]);
+    try std.testing.expectEqualStrings("./Btn", rc.exposes[1]);
+    try std.testing.expectEqual(@as(usize, 1), rc.shared.len);
+    try std.testing.expectEqualStrings("react", rc.shared[0].name);
+    try std.testing.expect(rc.shared[0].singleton);
+    // P2-0: version 은 required_version 대용 → 둘 다 "^19"
+    try std.testing.expectEqualStrings("^19", rc.shared[0].version);
+    try std.testing.expectEqualStrings("^19", rc.shared[0].required_version);
+}

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -123,6 +123,7 @@ test {
     _ = @import("emitter_test.zig");
     _ = @import("chunk_test.zig");
     _ = @import("mf_integrity.zig"); // #3422 inline test (computeSri)
+    _ = @import("mf_contract.zig"); // #3435 P3-0 inline test (parseContract)
     _ = @import("statement_shaker_test.zig");
     _ = @import("graph_test.zig");
     _ = @import("graph/project_root.zig");


### PR DESCRIPTION
## 개요
P3-0 — MF 에픽 #3318 **P3(빌드타임 계약 검증 D3)의 토대**(RFC §7.3). host 빌드가 `mf.remotes` 의 remote 가 게시한 `mf-manifest.json` 을 읽어 **`RemoteContract`** 데이터 모델로 만든다. **검증 없음(파싱·표면만)** — expose 존재(P3-1)·shared 버전 호환(P3-2)·무결성(P3-3)·런타임 가드(P3-5)가 이 토대를 소비(중복 파서 금지).

## 변경
- **`src/bundler/mf_contract.zig`** (신규)
  - `RemoteContract`{arena, name, exposes[], shared[`SharedContract`]} — `std.heap.ArenaAllocator` 단일 소유(CLAUDE.md 규약, by-value move 안전 검증됨).
  - `parseContract`: `std.json.parseFromSliceLeaky` + `alloc_always`(입력 `manifest_bytes` 와 독립 소유) + `ignore_unknown_fields`(`metaData`/`remotes`/`assets` 등 표준 부가키 관용). host-only(exposes/shared 키 부재) → 빈 슬라이스 관용.
  - `resolveManifestPath`: **local/file only** — `.json` 직접 또는 `<entry 디렉터리>/mf-manifest.json`. realpath 회피(sibling 빌드 미산출 허용 + 단위테스트 결정성). http/https → `MfContractNetworkUnsupported`(네트워크 fetch = P4/후속, **RFC §7.3 경계 ③**).
  - `loadContract`: resolve+read+parse 결합. 파일부재 → `MfContractManifestNotFound`(P3-1 이 *부재 ≠ 결함* 을 구분해 fail-fast), OOM 은 manifest 결함과 미혼동(진단 정확성).
  - **inline test 6**: 스키마 추출 / host-only 관용 / malformed / arena 자기완결 / resolve 경로 / **emit↔parse 라운드트립**.
- `federation_emit.zig`: `ExposeInfo`·`buildManifest` → `pub`(라운드트립 단일소스 박제 전용, 최소 노출).
- `mod.zig`: 테스트 등록 1줄.

## 스키마 단일 소스 보장
`emit↔parse 라운드트립` 테스트가 실제 `federation_emit.buildManifest` 산출을 `parseContract` 로 복원해 1:1 대조 — emit 스키마가 drift 하면 이 테스트가 fail. P2-0 의 `version`=`requiredVersion` 대용까지 명시 박제. **"P2-0/P2-1 sdk Manifest 타입 단일 재사용"(RFC §7.3) 강제.** 에러명명 `MfContract*` = `mf_integrity.MfSig*` 선례 답습.

## 검증
- `zig build test` **0**(신규 inline 6 포함), `zig build wasm-bundler` **0**(WASI 호환 = realpath 회피 검증).
- MF 통합 스모크 **14 pass**, MF e2e **4 passed**(emit 동작 무회귀 — `pub` 전환만, 행위 불변).
- `/simplify` 3-에이전트(재사용·품질·효율 통합) **차단 0**: arena by-value move dangling·`alloc_always` 독립소유·라운드트립 drift 포착을 std 소스까지 정밀 검증해 안전 확인. 비차단 R1(OOM 오분류)·R2(파일부재↔파싱 합침) **반영 완료**.

## 경계 (RFC §7.3)
파싱·표면만 — `parseContract`/`loadContract` 어디서도 expose 존재·버전 호환을 검증하지 않음(P3-1/2 책임). 네트워크 fetch = 비-목표(③). host-only 빈 슬라이스 = 후속 검증 단위의 안전한 토대.

Closes #3435

🤖 Generated with [Claude Code](https://claude.com/claude-code)