### PR TITLE
feat(mf): 빌드타임 expose 계약 검증 — 부재 expose import fail-fast (#3436)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1788,7 +1788,13 @@ pub const Bundler = struct {
         // 와 동일 관례(markBoundary).
         if (self.options.mf) |*mf| {
             if (mf.remotes.len > 0 and output.len > 0) {
-                const host_out = try @import("federation_emit.zig").emitHostInit(self.allocator, output, mf);
+                // P3-1 (#3436): emit 전 expose 계약 빌드타임 검증 — host
+                // import 가 remote manifest 에 없으면 fail-fast(S6, 런타임
+                // 깨짐 아님). resolve 불가 remote 는 skip(정밀 fail-fast).
+                const fe = @import("federation_emit.zig");
+                const cwd: ?[]const u8 = if (self.options.project_root.len > 0) self.options.project_root else null;
+                try fe.verifyHostExposes(self.allocator, output, mf, cwd);
+                const host_out = try fe.emitHostInit(self.allocator, output, mf);
                 self.allocator.free(output);
                 output = host_out;
             }

--- a/src/bundler/federation_emit.zig
+++ b/src/bundler/federation_emit.zig
@@ -19,6 +19,7 @@ const types = @import("types.zig");
 const federation = @import("federation.zig");
 const rt = @import("runtime_helpers.zig");
 const emitter = @import("emitter.zig");
+const mf_contract = @import("mf_contract.zig"); // P3-1 계약 검증 토대(P3-0)
 
 /// 부트스트랩 호출(=entry 청크 식별 앵커). cross-chunk/동적 wrapper 의
 /// `__zntc_require("` 와 달리 `globalThis.` 접두가 붙는 건 부트스트랩뿐
@@ -28,6 +29,10 @@ const BOOTSTRAP_ANCHOR = "globalThis.__zntc_require(\"";
 const MfEmitError = error{RemoteEntryAnchorMissing};
 
 const MF_RUNTIME_GLOBAL = federation.MF_RUNTIME_GLOBAL; // 단일 소스
+
+/// 동적 import 어휘 앵커 — emitHostInit(재작성)·verifyHostExposes(P3-1
+/// 계약 검증)가 같은 스캐너를 공유(단일 소스).
+const IMPORT_NEEDLE = "import(";
 
 /// `mf.remotes` KV.value(`<name>@<entry>`) → (name, entry). `@` 첫 등장
 /// split. name 부분 비면 KV.key fallback. `@` 없으면 value 전체=entry.
@@ -85,35 +90,108 @@ pub fn emitHostInit(
     //    `globalThis.__mf_runtime.loadRemote(<q><remote>...)`. 매칭 외 구간은
     //    appendSlice 청크 복사(바이트별 append 회피 — 출력크기 비례 O(n),
     //    wrapContainer splice 와 동일 관례). `import(` 만 교체, 따옴표·
-    //    specifier·잔여(2nd-arg/attributes 포함)는 그대로 보존. ──
-    const NEEDLE = "import(";
+    //    specifier·잔여(2nd-arg/attributes 포함)는 그대로 보존. 스캔은
+    //    nextRemoteImport 단일 소스(verifyHostExposes 와 규칙 공유). ──
     var last: usize = 0;
     var i: usize = 0;
-    while (std.mem.indexOfPos(u8, src, i, NEEDLE)) |p| {
-        // 식별자 경계 — `myimport(`/`Reimport(` 부분일치 배제.
-        if (p > 0 and isIdentChar(src[p - 1])) {
-            i = p + NEEDLE.len;
+    while (nextRemoteImport(src, mf, &i)) |h| {
+        try out.appendSlice(allocator, src[last..h.p]);
+        try w.print("globalThis.{s}.loadRemote(", .{MF_RUNTIME_GLOBAL});
+        last = h.p + IMPORT_NEEDLE.len; // 따옴표부터는 다음 flush 가 보존
+    }
+    try out.appendSlice(allocator, src[last..]);
+    return out.toOwnedSlice(allocator);
+}
+
+const RemoteImportHit = struct { p: usize, spec: []const u8 };
+
+/// host src 의 다음 **원격** 동적 import. `import(` 어휘 스캔 +
+/// federation.matchesRemoteSpec 단일 규칙(런타임 external 판정과 동일).
+/// `i` 는 진행점(in/out) — 다음 호출이 그 뒤부터. 비원격/식별자경계
+/// (`xfoo import(` 의 `myimport(`)·따옴표 없는 동적 import 는 내부에서
+/// skip, 원격 매칭만 반환. emitHostInit(재작성)·verifyHostExposes(P3-1
+/// 계약 검증) 공용 → 스캔·매칭 중복 파서 금지(단일 소스).
+fn nextRemoteImport(src: []const u8, mf: *const types.MfBundleConfig, i: *usize) ?RemoteImportHit {
+    var k = i.*;
+    while (std.mem.indexOfPos(u8, src, k, IMPORT_NEEDLE)) |p| {
+        if (p > 0 and isIdentChar(src[p - 1])) { // `myimport(` 부분일치 배제
+            k = p + IMPORT_NEEDLE.len;
             continue;
         }
-        var j = p + NEEDLE.len;
+        var j = p + IMPORT_NEEDLE.len;
         while (j < src.len and (src[j] == ' ' or src[j] == '\t')) j += 1;
         if (j < src.len and (src[j] == '"' or src[j] == '\'')) {
             const q = src[j];
             const s0 = j + 1;
             if (std.mem.indexOfScalarPos(u8, src, s0, q)) |s1| {
                 if (isRemoteSpec(src[s0..s1], mf)) {
-                    try out.appendSlice(allocator, src[last..p]);
-                    try w.print("globalThis.{s}.loadRemote(", .{MF_RUNTIME_GLOBAL});
-                    last = p + NEEDLE.len; // 따옴표부터는 다음 flush 가 보존
-                    i = last;
-                    continue;
+                    i.* = p + IMPORT_NEEDLE.len;
+                    return .{ .p = p, .spec = src[s0..s1] };
                 }
             }
         }
-        i = p + NEEDLE.len;
+        k = p + IMPORT_NEEDLE.len;
     }
-    try out.appendSlice(allocator, src[last..]);
-    return out.toOwnedSlice(allocator);
+    i.* = k;
+    return null;
+}
+
+fn stripDotSlash(s: []const u8) []const u8 {
+    return if (std.mem.startsWith(u8, s, "./")) s[2..] else s;
+}
+
+/// host import spec(매칭 remote `key`)이 가리키는 expose 가 remote 가
+/// 게시한 계약(`exposes`)에 존재하나. spec==key → 컨테이너 기본 expose
+/// "."(드묾), 아니면 `key/<rest>`. manifest expose 는 mf.exposes 키 그대로
+/// (관례 "./Widget") — 양쪽 선행 "./" 1회 정규화 후 정확 비교.
+fn exposeListed(exposes: []const []const u8, spec: []const u8, key: []const u8) bool {
+    const sub: []const u8 = if (std.mem.eql(u8, spec, key))
+        "."
+    else if (spec.len > key.len + 1 and std.mem.startsWith(u8, spec, key) and spec[key.len] == '/')
+        spec[key.len + 1 ..]
+    else
+        spec; // 방어(matchesRemoteSpec 통과면 위 둘 중 하나)
+    const sn = stripDotSlash(sub);
+    for (exposes) |e| if (std.mem.eql(u8, stripDotSlash(e), sn)) return true;
+    return false;
+}
+
+/// P3-1 (#3436): 빌드타임 expose 계약 검증. host 가 `import("<remote>/
+/// <subpath>")` 하는 expose 가 그 remote 가 게시한 mf-manifest.json 의
+/// exposes 에 **부재**면 빌드 fail-fast(`error.MfHostExposeMissing`) —
+/// 런타임이 깨지는 게 아니라 빌드 단계에서 차단(스파이크 S6). manifest 를
+/// 로컬 resolve 불가(http=네트워크 비-목표 P4 / 부재 / 파싱불가)면
+/// **검증 불가 ≠ 위반** → skip(정밀 fail-fast — 거짓 빌드중단 방지,
+/// http remote·미산출 sibling 의 기존 동작 불변). 검증만 — emit/재작성
+/// 부작용 없음(P3-0 mf_contract 토대 소비, 중복 파서 없음). emitHostInit
+/// 게이트(remotes>0·단일출력)와 동일 적용점에서 emit *전* 호출.
+pub fn verifyHostExposes(
+    allocator: std.mem.Allocator,
+    src: []const u8,
+    mf: *const types.MfBundleConfig,
+    cwd: ?[]const u8,
+) !void {
+    var i: usize = 0;
+    while (nextRemoteImport(src, mf, &i)) |h| {
+        const kv = for (mf.remotes) |kv| {
+            if (federation.matchesRemoteSpec(h.spec, kv.key)) break kv;
+        } else continue;
+        const r = parseRemote(kv);
+        // 검증 불가(http=P4 / 부재 / 파싱불가) = 위반 아님 → skip(정밀
+        // fail-fast). 단 OOM 은 빌드 자원 문제 → silent skip 금지, 전파.
+        var rc = mf_contract.loadContract(allocator, cwd, r.entry) catch |e| switch (e) {
+            error.OutOfMemory => return error.OutOfMemory,
+            else => continue,
+        };
+        defer rc.deinit();
+        if (!exposeListed(rc.exposes, h.spec, kv.key)) {
+            std.log.err(
+                "zntc: MF expose 계약 위반 — host import \"{s}\" 가 remote \"{s}\" 의 mf-manifest.json exposes 에 없음 (빌드 차단; remote 재배포 또는 스펙 정렬 필요)",
+                .{ h.spec, kv.key },
+            );
+            return error.MfHostExposeMissing;
+        }
+    }
 }
 
 fn isIdentChar(c: u8) bool {
@@ -445,4 +523,48 @@ pub fn buildManifest(
     }
     try b.appendSlice(allocator, "]}");
     return b.toOwnedSlice(allocator);
+}
+
+// ── P3-1 inline tests (스캔·매칭 순수 로직 — 계약 IO 는 통합테스트) ──
+
+fn tMf(remotes: []const types.MfBundleConfig.KV) types.MfBundleConfig {
+    return .{ .name = "host", .remotes = remotes };
+}
+
+test "nextRemoteImport: 원격만 추출 — 비원격/식별자경계/따옴표없음 skip" {
+    const remotes = [_]types.MfBundleConfig.KV{.{ .key = "app", .value = "app@./r/mf-manifest.json" }};
+    const mf = tMf(&remotes);
+    const src =
+        "var a=import('app/Widget');myimport('app/X');import('lodash');" ++
+        "import(\"app/B\");import(dyn);";
+    var i: usize = 0;
+    const h1 = nextRemoteImport(src, &mf, &i).?;
+    try std.testing.expectEqualStrings("app/Widget", h1.spec);
+    try std.testing.expectEqual(@as(u8, 'i'), src[h1.p]); // p = `import(` 시작
+    const h2 = nextRemoteImport(src, &mf, &i).?;
+    try std.testing.expectEqualStrings("app/B", h2.spec); // myimport/lodash skip
+    try std.testing.expect(nextRemoteImport(src, &mf, &i) == null); // import(dyn) skip
+}
+
+test "exposeListed: ./ 정규화·정확매칭·부재·중첩·bare key" {
+    const exposes = [_][]const u8{ "./Widget", "./a/B" };
+    try std.testing.expect(exposeListed(&exposes, "app/Widget", "app")); // ./Widget ↔ Widget
+    try std.testing.expect(exposeListed(&exposes, "app/a/B", "app")); // 중첩 보존
+    try std.testing.expect(!exposeListed(&exposes, "app/Missing", "app")); // 부재
+    try std.testing.expect(!exposeListed(&exposes, "app/widget", "app")); // 대소문자 구분
+    const def = [_][]const u8{"."};
+    try std.testing.expect(exposeListed(&def, "app", "app")); // spec==key → "."
+    try std.testing.expect(!exposeListed(&exposes, "app", "app")); // 기본 expose 미게시
+}
+
+test "emitHostInit 회귀: 원격 동적 import → loadRemote, 비원격 보존" {
+    const a = std.testing.allocator;
+    const remotes = [_]types.MfBundleConfig.KV{.{ .key = "app", .value = "app@http://x/r.js" }};
+    const mf = tMf(&remotes);
+    const src = "const x=import(\"app/W\");const y=import(\"lodash\");";
+    const out = try emitHostInit(a, src, &mf);
+    defer a.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "globalThis." ++ MF_RUNTIME_GLOBAL ++ ".loadRemote(\"app/W\")") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "import(\"lodash\")") != null); // 비원격 불변
+    try std.testing.expect(std.mem.indexOf(u8, out, ".init({\"name\":\"host\"") != null); // prelude
 }

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -124,6 +124,7 @@ test {
     _ = @import("chunk_test.zig");
     _ = @import("mf_integrity.zig"); // #3422 inline test (computeSri)
     _ = @import("mf_contract.zig"); // #3435 P3-0 inline test (parseContract)
+    _ = @import("federation_emit.zig"); // #3436 P3-1 inline test (verifyHostExposes 스캔/매칭)
     _ = @import("statement_shaker_test.zig");
     _ = @import("graph_test.zig");
     _ = @import("graph/project_root.zig");

--- a/tests/integration/tests/mf-runtime-interop-smoke.test.ts
+++ b/tests/integration/tests/mf-runtime-interop-smoke.test.ts
@@ -720,6 +720,75 @@ console.log('SAME=' + (m && m.usedHook === hostReact.useState));
     expect(stderr).not.toMatch(/RUNTIME-00\d|does not contain "init"/);
   }, 30000);
 
+  // P3-1 (#3436): 빌드타임 expose 계약 검증(D3, 스파이크 S6). host import
+  // 가 remote 의 게시 mf-manifest.json exposes 에 **없으면 빌드 fail-fast**
+  // (런타임 깨짐 아님 — MF2 의 stale 런타임-실패 대비 차별화). resolve
+  // 불가 remote(http=네트워크 비-목표 P4 / 로컬 부재)는 검증 불가 ≠ 위반
+  // → skip(정밀 fail-fast, 기존 http host interop 무회귀 보장).
+  test('P3-1 expose 계약: 부재 expose → 빌드 fail-fast(S6); 존재·http·부재manifest 통과', async () => {
+    // zntc remote 빌드 → rdist/mf-manifest.json (exposes name "./Widget")
+    const remoteFx = await createFixture({
+      'Widget.ts': `export default function W(){ return "OK"; }`,
+      'index.ts': `export const s = "re";`,
+      'zntc.config.json': JSON.stringify({
+        mf: { name: 'app', exposes: { './Widget': './Widget.ts' } },
+      }),
+    });
+    const rdist = join(remoteFx.dir, 'dist');
+    const rb = await runZntcInDir(remoteFx.dir, [
+      '--bundle',
+      join(remoteFx.dir, 'index.ts'),
+      '--outdir',
+      rdist,
+      '--format=iife',
+    ]);
+    expect(rb.exitCode).toBe(0);
+    const manifestAbs = join(rdist, 'mf-manifest.json');
+    const prev = cleanup;
+    cleanup = async () => {
+      await prev?.();
+      await remoteFx.cleanup();
+    };
+
+    // host 빌드 헬퍼 — 동적 import spec·remote entry 가변(단일파일 iife,
+    // host-emit 게이트 동일: app=external 라 split 없음 → output.len>0).
+    const buildHost = async (spec: string, entry: string) => {
+      const hostFx = await createFixture({
+        'index.ts': `async function m(){ const x = await import(${JSON.stringify(spec)}); console.log(x); }\nm();`,
+        'zntc.config.json': JSON.stringify({
+          mf: { name: 'host', remotes: { app: `app@${entry}` } },
+        }),
+      });
+      const r = await runZntcInDir(hostFx.dir, [
+        '--bundle',
+        join(hostFx.dir, 'index.ts'),
+        '-o',
+        join(hostFx.dir, 'host.js'),
+        '--format=iife',
+      ]);
+      await hostFx.cleanup();
+      return r;
+    };
+
+    // ① 존재 expose → 빌드 성공
+    expect((await buildHost('app/Widget', manifestAbs)).exitCode).toBe(0);
+
+    // ② 부재 expose → 빌드 fail-fast(런타임 아님) + 명확한 메시지.
+    //    성공-우회 명시 배제(거짓통과 차단).
+    const bad = await buildHost('app/Missing', manifestAbs);
+    expect(bad.exitCode).not.toBe(0);
+    expect(bad.stderr).toContain('MF expose 계약 위반');
+    expect(bad.stderr).toContain('mf-manifest.json exposes');
+
+    // ③ http remote(네트워크 비-목표) → 검증 불가 ≠ 위반 → 빌드 통과
+    //    (정밀 fail-fast: 기존 http host interop 무회귀).
+    expect((await buildHost('app/Whatever', 'http://localhost:9/index.js')).exitCode).toBe(0);
+
+    // ④ 로컬 manifest 부재(네트워크 아님) → 검증 불가 → 통과(부재 ≠ 위반)
+    const noMani = join(remoteFx.dir, 'nope', 'mf-manifest.json');
+    expect((await buildHost('app/Whatever', noMani)).exitCode).toBe(0);
+  }, 30000);
+
   // 갭 보강(레퍼런스 module-federation/core 대비). zntc remote dir 빌드 +
   // .js entry http 서빙(S3/host-emit 검증 형태, Node-safe — chunk=file://).
   async function buildZntcRemote(


### PR DESCRIPTION
## 개요
P3-1 — MF 에픽 #3318 **P3(빌드타임 계약 검증 D3)**, 스파이크 **S6**. host 가 `import("<remote>/<subpath>")` 하는 expose 가 그 remote 가 게시한 `mf-manifest.json` 의 `exposes` 에 **부재면 빌드 fail-fast**(런타임이 깨지는 게 아니라 빌드 단계에서 차단 — MF 2.0 의 stale 런타임-실패 대비 핵심 차별화). P3-0 `mf_contract` 토대를 소비(중복 파서 없음).

## 변경
- **`federation_emit.zig`**
  - 기존 `import(` 스캔 루프를 **`nextRemoteImport` iterator 로 추출** — `emitHostInit`(재작성)·`verifyHostExposes`(검증)가 공유하는 **단일 소스**(`matchesRemoteSpec`/`parseRemote` 재사용). `emitHostInit` 동작은 원본과 **byte 등가**(원본 `last`/`i` 진행점 1:1, 회귀 inline test 로 박제).
  - **`verifyHostExposes(allocator, src, mf, cwd)`**: 원격 동적 import 열거 → `loadContract` → `exposeListed`(`./` 정규화, `spec==key`→`"."`). 부재면 `std.log.err`(remote·spec·조치 명시) + `return error.MfHostExposeMissing`. `loadContract` 실패(http=P4 비-목표 / 부재 / 파싱불가)는 **skip — 검증 불가 ≠ 위반(정밀 fail-fast)**, 기존 http host interop 무회귀. **OOM 은 silent skip 금지·전파**(진단 정확성, `/simplify` 권고 반영).
- **`bundler.zig`**: `emitHostInit` 직전 `verifyHostExposes` 호출(게이트 동일: `remotes>0`·`output.len>0` — split 경로는 emit 과 함께 후속). `cwd = project_root or null`.
- **`mod.zig`**: `federation_emit.zig` 테스트 등록 1줄.
- **통합테스트 4-케이스**: 존재→통과 / 부재→fail-fast(`exitCode≠0` + stderr `MF expose 계약 위반`) / http→skip / 부재manifest→skip — 정밀 fail-fast 4분기 1:1. + **inline 3**: `nextRemoteImport` 스캔 · `exposeListed` 매칭 · `emitHostInit` 회귀.

## 정밀 fail-fast (RFC §7.3 P3-1/P3-3 경계)
P3-1 범위 = expose **존재**. manifest 무결성/파싱불가는 P3-3(별도). 그래서 resolve 불가(network/notfound/malformed)는 **거짓 빌드중단 회피를 위해 skip** — 외부 빌더 산출 remote 의 스키마 차이에 false-positive 없음. 부재 expose 의 false-negative 는 런타임 MF2 계약(`does not exist in container`)이 잡으며 이는 S6 의 "런타임 깨짐 아님" 경계 안.

## 검증
- `zig build test` **0** / `zig build wasm-bundler` **0** / `zig build`(install) **0**.
- MF 통합 스모크 **15 pass**(P3-1 신규 포함), MF e2e **4 passed**(`emitHostInit` 무회귀 = `nextRemoteImport` 리팩터 등가 입증).
- `/simplify` 3-에이전트(재사용·품질·효율 통합) **차단 0**: `nextRemoteImport` byte 등가성·정밀 fail-fast 의미론·S6 거짓통과 방지(②가 ①의 skip-거짓통과 보강)를 코드로 정밀 재검증. 비차단 (a) OOM 전파 **반영**, (b) 통합테스트 stale 바이너리 의존은 **CI 무관**(CI 는 freshly-built `zig-out/bin/zntc` 아티팩트 사용 — 로컬 dev 함정, 메모리 기록).

Closes #3436

🤖 Generated with [Claude Code](https://claude.com/claude-code)