### PR TITLE
feat(mf): 빌드타임 shared 버전 호환 검증 — singleton fail-fast (#3437)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1788,12 +1788,13 @@ pub const Bundler = struct {
         // 와 동일 관례(markBoundary).
         if (self.options.mf) |*mf| {
             if (mf.remotes.len > 0 and output.len > 0) {
-                // P3-1 (#3436): emit 전 expose 계약 빌드타임 검증 — host
-                // import 가 remote manifest 에 없으면 fail-fast(S6, 런타임
-                // 깨짐 아님). resolve 불가 remote 는 skip(정밀 fail-fast).
+                // P3-1/P3-2 (#3436/#3437): emit 전 host 계약 빌드타임
+                // 검증 — expose 부재·shared singleton 불일치는 fail-fast
+                // (S6, 런타임 깨짐 아님), shared 버전 비호환은 경고.
+                // resolve 불가 remote 는 skip(정밀 fail-fast).
                 const fe = @import("federation_emit.zig");
                 const cwd: ?[]const u8 = if (self.options.project_root.len > 0) self.options.project_root else null;
-                try fe.verifyHostExposes(self.allocator, output, mf, cwd);
+                try fe.verifyHostContract(self.allocator, output, mf, cwd);
                 const host_out = try fe.emitHostInit(self.allocator, output, mf);
                 self.allocator.free(output);
                 output = host_out;

--- a/src/bundler/federation_emit.zig
+++ b/src/bundler/federation_emit.zig
@@ -20,6 +20,7 @@ const federation = @import("federation.zig");
 const rt = @import("runtime_helpers.zig");
 const emitter = @import("emitter.zig");
 const mf_contract = @import("mf_contract.zig"); // P3-1 계약 검증 토대(P3-0)
+const semver = @import("semver.zig"); // P3-2 shared 버전 호환 단일 소스
 
 /// 부트스트랩 호출(=entry 청크 식별 앵커). cross-chunk/동적 wrapper 의
 /// `__zntc_require("` 와 달리 `globalThis.` 접두가 붙는 건 부트스트랩뿐
@@ -30,7 +31,7 @@ const MfEmitError = error{RemoteEntryAnchorMissing};
 
 const MF_RUNTIME_GLOBAL = federation.MF_RUNTIME_GLOBAL; // 단일 소스
 
-/// 동적 import 어휘 앵커 — emitHostInit(재작성)·verifyHostExposes(P3-1
+/// 동적 import 어휘 앵커 — emitHostInit(재작성)·verifyHostContract(P3-1
 /// 계약 검증)가 같은 스캐너를 공유(단일 소스).
 const IMPORT_NEEDLE = "import(";
 
@@ -91,7 +92,7 @@ pub fn emitHostInit(
     //    appendSlice 청크 복사(바이트별 append 회피 — 출력크기 비례 O(n),
     //    wrapContainer splice 와 동일 관례). `import(` 만 교체, 따옴표·
     //    specifier·잔여(2nd-arg/attributes 포함)는 그대로 보존. 스캔은
-    //    nextRemoteImport 단일 소스(verifyHostExposes 와 규칙 공유). ──
+    //    nextRemoteImport 단일 소스(verifyHostContract 와 규칙 공유). ──
     var last: usize = 0;
     var i: usize = 0;
     while (nextRemoteImport(src, mf, &i)) |h| {
@@ -109,7 +110,7 @@ const RemoteImportHit = struct { p: usize, spec: []const u8 };
 /// federation.matchesRemoteSpec 단일 규칙(런타임 external 판정과 동일).
 /// `i` 는 진행점(in/out) — 다음 호출이 그 뒤부터. 비원격/식별자경계
 /// (`xfoo import(` 의 `myimport(`)·따옴표 없는 동적 import 는 내부에서
-/// skip, 원격 매칭만 반환. emitHostInit(재작성)·verifyHostExposes(P3-1
+/// skip, 원격 매칭만 반환. emitHostInit(재작성)·verifyHostContract(P3-1
 /// 계약 검증) 공용 → 스캔·매칭 중복 파서 금지(단일 소스).
 fn nextRemoteImport(src: []const u8, mf: *const types.MfBundleConfig, i: *usize) ?RemoteImportHit {
     var k = i.*;
@@ -156,16 +157,44 @@ fn exposeListed(exposes: []const []const u8, spec: []const u8, key: []const u8) 
     return false;
 }
 
-/// P3-1 (#3436): 빌드타임 expose 계약 검증. host 가 `import("<remote>/
-/// <subpath>")` 하는 expose 가 그 remote 가 게시한 mf-manifest.json 의
-/// exposes 에 **부재**면 빌드 fail-fast(`error.MfHostExposeMissing`) —
-/// 런타임이 깨지는 게 아니라 빌드 단계에서 차단(스파이크 S6). manifest 를
-/// 로컬 resolve 불가(http=네트워크 비-목표 P4 / 부재 / 파싱불가)면
+/// host↔remote shared 1쌍 판정(순수 — IO·로그 없음, 단위테스트 가능).
+const SharedVerdict = enum {
+    ok, // 호환(또는 검증 불가 = 정밀 fail-fast 로 통과)
+    singleton_conflict, // singleton 불일치 — 결정적, 인스턴스 분열 → fail-fast
+    version_warn, // host range 가 remote concrete version 불만족 → 경고(비차단)
+};
+
+/// host shared 선언 vs remote 가 게시한 shared. singleton 불일치는
+/// 버전과 무관한 **결정적** 위반(런타임 인스턴스 분열 보장) → fail-fast.
+/// 버전은 host required_version(range) 가 remote 의 concrete version 을
+/// 만족하나 — semver.satisfies 가 `null`(remote.version 비-concrete:
+/// zntc P2-0 는 version=range 대용 / range 지원밖)이면 **판정 불가 →
+/// ok**(정밀 fail-fast: 거짓 경고 금지). `false` 일 때만 version_warn.
+fn sharedVerdict(host: types.MfBundleConfig.SharedEntry, remote: mf_contract.SharedContract) SharedVerdict {
+    if (host.singleton != remote.singleton) return .singleton_conflict;
+    const hr = host.required_version orelse return .ok; // host 무제약 → 버전 검사 없음
+    const sat = semver.satisfies(hr, remote.version) orelse return .ok; // 판정 불가 → 통과
+    return if (sat) .ok else .version_warn;
+}
+
+/// P3-1 (#3436) expose + P3-2 (#3437) shared: 빌드타임 host 계약 검증.
+/// host 가 `import("<remote>/<subpath>")` 하는 각 remote 의 게시
+/// mf-manifest.json 을 1회 로드(P3-0 mf_contract 토대)해:
+///   - **expose 부재** → fail-fast `error.MfHostExposeMissing`(S6 — 런타임
+///     깨짐이 아니라 빌드 차단).
+///   - **shared singleton 불일치** → fail-fast
+///     `error.MfSharedSingletonConflict`(결정적, react 등 인스턴스 분열).
+///   - **shared 버전 비호환**(host range ⊅ remote concrete version) →
+///     **경고**(std.log.warn, 비차단) — D3 빌드타임 가시성. 판정 불가
+///     (remote.version 비-concrete=zntc P2-0 / range 지원밖)는 skip.
+/// manifest 로컬 resolve 불가(http=네트워크 비-목표 P4 / 부재 / 파싱불가)면
 /// **검증 불가 ≠ 위반** → skip(정밀 fail-fast — 거짓 빌드중단 방지,
-/// http remote·미산출 sibling 의 기존 동작 불변). 검증만 — emit/재작성
-/// 부작용 없음(P3-0 mf_contract 토대 소비, 중복 파서 없음). emitHostInit
-/// 게이트(remotes>0·단일출력)와 동일 적용점에서 emit *전* 호출.
-pub fn verifyHostExposes(
+/// http remote·미산출 sibling 기존 동작 불변). 검증만 — emit/재작성
+/// 부작용 없음(중복 파서 없음, nextRemoteImport·matchesRemoteSpec 단일
+/// 소스 재사용). emitHostInit 게이트(remotes>0·단일출력)와 동일 적용점
+/// 에서 emit *전* 호출. 같은 remote 다중 import 시 경고 중복 가능(소규모
+/// — P3-1 선례대로 허용, dedup 은 후속).
+pub fn verifyHostContract(
     allocator: std.mem.Allocator,
     src: []const u8,
     mf: *const types.MfBundleConfig,
@@ -184,12 +213,33 @@ pub fn verifyHostExposes(
             else => continue,
         };
         defer rc.deinit();
+        // P3-1: expose 존재
         if (!exposeListed(rc.exposes, h.spec, kv.key)) {
             std.log.err(
                 "zntc: MF expose 계약 위반 — host import \"{s}\" 가 remote \"{s}\" 의 mf-manifest.json exposes 에 없음 (빌드 차단; remote 재배포 또는 스펙 정렬 필요)",
                 .{ h.spec, kv.key },
             );
             return error.MfHostExposeMissing;
+        }
+        // P3-2: 양쪽이 선언한 shared 패키지의 singleton·버전 호환
+        for (mf.shared) |hs| {
+            for (rc.shared) |rs| {
+                if (!std.mem.eql(u8, hs.name, rs.name)) continue;
+                switch (sharedVerdict(hs, rs)) {
+                    .ok => {},
+                    .singleton_conflict => {
+                        std.log.err(
+                            "zntc: MF shared singleton 충돌 — '{s}' 가 host(singleton={}) ↔ remote \"{s}\"(singleton={}) 불일치 (빌드 차단; 인스턴스 분열 — 양측 shareConfig.singleton 정렬 필요)",
+                            .{ hs.name, hs.singleton, kv.key, rs.singleton },
+                        );
+                        return error.MfSharedSingletonConflict;
+                    },
+                    .version_warn => std.log.warn(
+                        "zntc: MF shared 버전 경고 — host requiredVersion '{s}' 가 remote \"{s}\" 의 '{s}' 게시버전 '{s}' 을 불만족 (런타임 버전협상 시 폴백 가능; 계약 정렬 권장)",
+                        .{ hs.required_version orelse "", kv.key, rs.name, rs.version },
+                    ),
+                }
+            }
         }
     }
 }
@@ -567,4 +617,34 @@ test "emitHostInit 회귀: 원격 동적 import → loadRemote, 비원격 보존
     try std.testing.expect(std.mem.indexOf(u8, out, "globalThis." ++ MF_RUNTIME_GLOBAL ++ ".loadRemote(\"app/W\")") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "import(\"lodash\")") != null); // 비원격 불변
     try std.testing.expect(std.mem.indexOf(u8, out, ".init({\"name\":\"host\"") != null); // prelude
+}
+
+test "sharedVerdict: singleton 충돌 fail-fast / 버전 경고 / 판정불가 ok" {
+    const SE = types.MfBundleConfig.SharedEntry;
+    const SC = mf_contract.SharedContract;
+    // singleton 불일치 → 결정적 충돌(버전 무관)
+    try std.testing.expectEqual(SharedVerdict.singleton_conflict, sharedVerdict(
+        .{ .name = "react", .singleton = true, .required_version = "^19" },
+        .{ .name = "react", .version = "19.2.4", .required_version = "^19", .singleton = false },
+    ));
+    // singleton 일치 + host range 가 remote concrete version 불만족 → 경고
+    try std.testing.expectEqual(SharedVerdict.version_warn, sharedVerdict(
+        SE{ .name = "react", .singleton = true, .required_version = "^18" },
+        SC{ .name = "react", .version = "19.2.4", .required_version = "^19", .singleton = true },
+    ));
+    // 호환 → ok
+    try std.testing.expectEqual(SharedVerdict.ok, sharedVerdict(
+        SE{ .name = "react", .singleton = true, .required_version = "^19" },
+        SC{ .name = "react", .version = "19.2.4", .required_version = "^19", .singleton = true },
+    ));
+    // remote.version 비-concrete(zntc P2-0 version=range 대용) → 판정 불가 → ok
+    try std.testing.expectEqual(SharedVerdict.ok, sharedVerdict(
+        SE{ .name = "react", .singleton = true, .required_version = "^19" },
+        SC{ .name = "react", .version = "^19", .required_version = "^19", .singleton = true },
+    ));
+    // host 무제약(required_version=null) → singleton 일치면 ok
+    try std.testing.expectEqual(SharedVerdict.ok, sharedVerdict(
+        SE{ .name = "react", .singleton = false, .required_version = null },
+        SC{ .name = "react", .version = "19.2.4", .required_version = "^19", .singleton = false },
+    ));
 }

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -124,7 +124,8 @@ test {
     _ = @import("chunk_test.zig");
     _ = @import("mf_integrity.zig"); // #3422 inline test (computeSri)
     _ = @import("mf_contract.zig"); // #3435 P3-0 inline test (parseContract)
-    _ = @import("federation_emit.zig"); // #3436 P3-1 inline test (verifyHostExposes 스캔/매칭)
+    _ = @import("semver.zig"); // #3437 P3-2 inline test (satisfies)
+    _ = @import("federation_emit.zig"); // #3436/#3437 P3-1/2 inline test (verifyHostContract)
     _ = @import("statement_shaker_test.zig");
     _ = @import("graph_test.zig");
     _ = @import("graph/project_root.zig");

--- a/src/bundler/semver.zig
+++ b/src/bundler/semver.zig
@@ -1,0 +1,131 @@
+//! 최소 semver range 매칭 — MF P3-2(#3437) shared 버전 호환 빌드타임
+//! 검증 단일 소스. npm range 전체가 아니라 shared 의존에 실제로 쓰이는
+//! 부분집합만: `^`/`~`/정확/`*`(any)/`>=`,`>`,`<=`,`<`. **그 외(복합
+//! `>=1 <2`, `||`, hyphen `A - B`, prerelease 의미)는 판정 불가(`null`)
+//! → 호출측이 skip**(정밀 fail-fast 원칙 — 못 푸는 입력에 거짓 경고/
+//! 빌드중단 금지, P3-1 "검증 불가 ≠ 위반" 답습). 코드베이스에 기존
+//! semver 구현 없음(신규 단일 소스 — 중복 구현 금지).
+const std = @import("std");
+
+const Ver = [3]u64; // major, minor, patch
+
+/// "X[.Y[.Z]]"(선행 `v` 허용, prerelease/build `-`/`+` 절단) → {버전,
+/// 명시 컴포넌트 수}. range 문자(`^~><=|*x ` 등)·비숫자 코어는 null.
+/// `n` 은 tilde upper bound 계산용(npm: `~1`=`<2.0.0` vs `~1.2`=`<1.3.0`).
+fn parseVerN(raw: []const u8) ?struct { v: Ver, n: u8 } {
+    var s = std.mem.trim(u8, raw, " \t\r\nv");
+    if (s.len == 0) return null;
+    if (std.mem.indexOfAny(u8, s, "-+")) |c| s = s[0..c]; // prerelease/build 절단
+    var out: Ver = .{ 0, 0, 0 };
+    var it = std.mem.splitScalar(u8, s, '.');
+    var i: usize = 0;
+    while (it.next()) |part| : (i += 1) {
+        if (i >= 3) return null; // X.Y.Z.W 비규약
+        if (part.len == 0) return null;
+        out[i] = std.fmt.parseInt(u64, part, 10) catch return null; // 'x'/'*'/range → null
+    }
+    return .{ .v = out, .n = @intCast(i) };
+}
+
+/// concrete 버전(컴포넌트 수 무시). 호출측 다수가 Ver 만 필요.
+fn parseVer(raw: []const u8) ?Ver {
+    return (parseVerN(raw) orelse return null).v;
+}
+
+fn cmp(a: Ver, b: Ver) std.math.Order {
+    for (0..3) |i| {
+        if (a[i] != b[i]) return std.math.order(a[i], b[i]);
+    }
+    return .eq;
+}
+
+/// `range` 가 concrete `version` 을 허용하나. `true`/`false` = 확정 판정,
+/// **`null` = 판정 불가**(version 비-concrete, 또는 range 가 지원 밖
+/// 형태) → 호출측은 null 을 위반으로 보지 말 것(skip).
+pub fn satisfies(range: []const u8, version: []const u8) ?bool {
+    const v = parseVer(version) orelse return null;
+    const r = std.mem.trim(u8, range, " \t\r\n");
+    if (r.len == 0 or std.mem.eql(u8, r, "*") or std.mem.eql(u8, r, "x") or
+        std.mem.eql(u8, r, "latest")) return true;
+    // 복합/대안 range 는 비-목표 → 판정 불가.
+    if (std.mem.indexOfAny(u8, r, " ,|") != null) return null;
+
+    if (r[0] == '^') {
+        const b = parseVer(r[1..]) orelse return null;
+        if (cmp(v, b) == .lt) return false;
+        // caret: major>0 → <(M+1).0.0; 0.m(>0) → <0.(m+1).0; 0.0.p → ==
+        const upper: Ver = if (b[0] > 0)
+            .{ b[0] + 1, 0, 0 }
+        else if (b[1] > 0)
+            .{ 0, b[1] + 1, 0 }
+        else
+            .{ 0, 0, b[2] + 1 };
+        return cmp(v, upper) == .lt;
+    }
+    if (r[0] == '~') {
+        const p = parseVerN(r[1..]) orelse return null;
+        const b = p.v;
+        if (cmp(v, b) == .lt) return false;
+        // npm tilde: minor 명시 시 `<X.(Y+1).0`, major 만(`~1`)이면
+        // `<(X+1).0.0`(minor 변경 허용).
+        const upper: Ver = if (p.n >= 2) .{ b[0], b[1] + 1, 0 } else .{ b[0] + 1, 0, 0 };
+        return cmp(v, upper) == .lt;
+    }
+    if (std.mem.startsWith(u8, r, ">=")) {
+        const b = parseVer(r[2..]) orelse return null;
+        return cmp(v, b) != .lt;
+    }
+    if (std.mem.startsWith(u8, r, "<=")) {
+        const b = parseVer(r[2..]) orelse return null;
+        return cmp(v, b) != .gt;
+    }
+    if (r[0] == '>') {
+        const b = parseVer(r[1..]) orelse return null;
+        return cmp(v, b) == .gt;
+    }
+    if (r[0] == '<') {
+        const b = parseVer(r[1..]) orelse return null;
+        return cmp(v, b) == .lt;
+    }
+    // 정확(`=` 접두 허용). 비-concrete operand → 판정 불가.
+    const exact = if (r[0] == '=') r[1..] else r;
+    const b = parseVer(exact) orelse return null;
+    return cmp(v, b) == .eq;
+}
+
+test "satisfies: caret — major>0 / 0.x / 0.0.x" {
+    try std.testing.expectEqual(@as(?bool, true), satisfies("^19.0.0", "19.2.4"));
+    try std.testing.expectEqual(@as(?bool, true), satisfies("^19", "19.9.9")); // ^19 = ^19.0.0
+    try std.testing.expectEqual(@as(?bool, false), satisfies("^19.0.0", "20.0.0"));
+    try std.testing.expectEqual(@as(?bool, false), satisfies("^19.2.0", "19.1.0"));
+    try std.testing.expectEqual(@as(?bool, true), satisfies("^0.3.0", "0.3.9")); // 0.x → minor 고정
+    try std.testing.expectEqual(@as(?bool, false), satisfies("^0.3.0", "0.4.0"));
+    try std.testing.expectEqual(@as(?bool, true), satisfies("^0.0.5", "0.0.5")); // 0.0.x → exact
+    try std.testing.expectEqual(@as(?bool, false), satisfies("^0.0.5", "0.0.6"));
+}
+
+test "satisfies: tilde / 비교자 / any / 정확" {
+    try std.testing.expectEqual(@as(?bool, true), satisfies("~1.2.3", "1.2.9"));
+    try std.testing.expectEqual(@as(?bool, false), satisfies("~1.2.3", "1.3.0"));
+    // npm: ~1.2 = <1.3.0 (minor 명시) / ~1 = <2.0.0 (major 만)
+    try std.testing.expectEqual(@as(?bool, false), satisfies("~1.2", "1.3.0"));
+    try std.testing.expectEqual(@as(?bool, true), satisfies("~1", "1.9.9"));
+    try std.testing.expectEqual(@as(?bool, false), satisfies("~1", "2.0.0"));
+    try std.testing.expectEqual(@as(?bool, true), satisfies(">=18.0.0", "19.2.4"));
+    try std.testing.expectEqual(@as(?bool, false), satisfies(">=20", "19.2.4"));
+    try std.testing.expectEqual(@as(?bool, true), satisfies("<2.0.0", "1.9.9"));
+    try std.testing.expectEqual(@as(?bool, true), satisfies("*", "19.2.4"));
+    try std.testing.expectEqual(@as(?bool, true), satisfies("", "1.0.0"));
+    try std.testing.expectEqual(@as(?bool, true), satisfies("1.2.3", "1.2.3"));
+    try std.testing.expectEqual(@as(?bool, false), satisfies("=1.2.3", "1.2.4"));
+}
+
+test "satisfies: 판정 불가 → null (정밀 fail-fast)" {
+    // version 비-concrete(zntc P2-0 remote 의 version=range 대용)
+    try std.testing.expectEqual(@as(?bool, null), satisfies("^19", "^19"));
+    try std.testing.expectEqual(@as(?bool, null), satisfies("^19", "19.x"));
+    // range 가 지원 밖(복합/대안/hyphen)
+    try std.testing.expectEqual(@as(?bool, null), satisfies(">=1.0.0 <2.0.0", "1.5.0"));
+    try std.testing.expectEqual(@as(?bool, null), satisfies("18 || 19", "19.0.0"));
+    try std.testing.expectEqual(@as(?bool, null), satisfies("1.0.0 - 2.0.0", "1.5.0"));
+}

--- a/tests/integration/tests/mf-runtime-interop-smoke.test.ts
+++ b/tests/integration/tests/mf-runtime-interop-smoke.test.ts
@@ -789,6 +789,80 @@ console.log('SAME=' + (m && m.usedHook === hostReact.useState));
     expect((await buildHost('app/Whatever', noMani)).exitCode).toBe(0);
   }, 30000);
 
+  // P3-2 (#3437): 빌드타임 shared 버전 호환 검증(D3). host 가 import 하는
+  // remote 의 게시 shared 와 host shared 선언이: singleton 불일치 →
+  // **빌드 fail-fast**(결정적·인스턴스 분열); 버전 비호환 → 경고(비차단,
+  // semver). remote.version 이 비-concrete(zntc P2-0 = version=range 대용)
+  // 면 판정 불가 → 통과(정밀 fail-fast — 거짓 빌드중단 금지).
+  test('P3-2 shared 호환: singleton 불일치 → 빌드 fail-fast; 일치·무선언 통과', async () => {
+    // zntc remote: ./Widget expose + shared react(singleton:true,^19).
+    // manifest.shared = [{react, version:"^19"(P2-0 range 대용), singleton:true}]
+    const remoteFx = await createFixture({
+      'Widget.ts': `import { useState } from "react";\nexport default function W(){ return typeof useState; }`,
+      'index.ts': `export const s = "re";`,
+      'zntc.config.json': JSON.stringify({
+        mf: {
+          name: 'app',
+          exposes: { './Widget': './Widget.ts' },
+          shared: { react: { singleton: true, requiredVersion: '^19' } },
+        },
+      }),
+    });
+    const rdist = join(remoteFx.dir, 'dist');
+    const rb = await runZntcInDir(remoteFx.dir, [
+      '--bundle',
+      join(remoteFx.dir, 'index.ts'),
+      '--outdir',
+      rdist,
+      '--format=iife',
+    ]);
+    expect(rb.exitCode).toBe(0);
+    const manifestAbs = join(rdist, 'mf-manifest.json');
+    const prev = cleanup;
+    cleanup = async () => {
+      await prev?.();
+      await remoteFx.cleanup();
+    };
+
+    // host 빌드 — shared 선언 가변(undefined=무선언). import("app/Widget")
+    // 로 verifyHostContract 의 loadContract 패스 트리거.
+    const buildHost = async (sharedCfg: unknown) => {
+      const mf: Record<string, unknown> = {
+        name: 'host',
+        remotes: { app: `app@${manifestAbs}` },
+      };
+      if (sharedCfg !== undefined) mf.shared = sharedCfg;
+      const hostFx = await createFixture({
+        'index.ts': `async function m(){ const x = await import("app/Widget"); console.log(x); }\nm();`,
+        'zntc.config.json': JSON.stringify({ mf }),
+      });
+      const r = await runZntcInDir(hostFx.dir, [
+        '--bundle',
+        join(hostFx.dir, 'index.ts'),
+        '-o',
+        join(hostFx.dir, 'host.js'),
+        '--format=iife',
+      ]);
+      await hostFx.cleanup();
+      return r;
+    };
+
+    // ① singleton 불일치(host:false ↔ remote:true) → 빌드 fail-fast.
+    //    성공-우회 명시 배제(거짓통과 차단).
+    const conflict = await buildHost({ react: { singleton: false, requiredVersion: '^19' } });
+    expect(conflict.exitCode).not.toBe(0);
+    expect(conflict.stderr).toContain('MF shared singleton 충돌');
+
+    // ② singleton 일치 → 통과(remote.version="^19" 비-concrete → 버전
+    //    판정 불가 → 정밀 fail-fast 로 경고 없이 통과).
+    expect((await buildHost({ react: { singleton: true, requiredVersion: '^19' } })).exitCode).toBe(
+      0,
+    );
+
+    // ③ host shared 무선언 → 페어링 없음 → 통과(expose 는 존재).
+    expect((await buildHost(undefined)).exitCode).toBe(0);
+  }, 30000);
+
   // 갭 보강(레퍼런스 module-federation/core 대비). zntc remote dir 빌드 +
   // .js entry http 서빙(S3/host-emit 검증 형태, Node-safe — chunk=file://).
   async function buildZntcRemote(


### PR DESCRIPTION
## 개요
P3-2 — MF 에픽 #3318 **P3(빌드타임 계약 검증 D3)**. host 가 `import` 하는 remote 의 게시 `mf-manifest.json` shared 와 host `shared` 선언을 빌드타임 교차검증. P3-0 `mf_contract` 토대 + P3-1 `verifyHostExposes` 일반화(같은 `loadContract` 패스 재사용 — 중복 IO 0).

## 변경
- **`semver.zig`** (신규, **단일 소스** — 코드베이스 기존 semver 없음): `satisfies(range, version) ?bool`. `^`/`~`/정확/`*`/`>=`,`>`,`<=`,`<` 부분집합(shared 의존 실사용 범위). 복합/`||`/hyphen·비-concrete version → **`null`(판정 불가)**. npm tilde 정합(`~1`=`<2.0.0` / `~1.2`=`<1.3.0` — 컴포넌트 수 추적, `/simplify` 권고 반영).
- **`federation_emit.zig`**: `verifyHostExposes` → **`verifyHostContract`** 일반화. 순수 `sharedVerdict(SharedEntry, SharedContract)`:
  - **singleton 불일치 → fail-fast** `error.MfSharedSingletonConflict`(결정적 — react 등 인스턴스 분열, S6류)
  - host range ⊅ remote concrete version → **`std.log.warn`**(비차단, D3 빌드타임 가시성)
  - `satisfies` null(remote.version 비-concrete = zntc P2-0 `version`=range 대용 / range 지원밖) → **ok**(정밀 fail-fast — 거짓경고 금지, P3-1 "검증 불가 ≠ 위반" 답습). host 무제약/편측 선언 → 미검사.
  - P3-1 expose 검사 보존(같은 함수, expose→shared 순).
- **`bundler.zig`**: 호출 rename. **`mod.zig`**: semver 등록.
- **통합 3-케이스**: singleton 충돌→빌드 fail-fast(`exitCode≠0`+stderr `MF shared singleton 충돌`) / 일치→통과 / 무선언→통과. **inline**: semver `satisfies` 매트릭스(caret 0.x/0.0.x·tilde `~major` 경계·비교자·판정불가) + `sharedVerdict` 결정표.

## 등급 근거 (RFC §7.3 "fail-fast/경고")
- **singleton = fail-fast**: 결정적 인스턴스 분열(§3.5 "shared 싱글톤 = 본질적으로 못 피함"), 버전 무관 불리언 → false-positive 0.
- **버전 = 경고**: 런타임 버전협상 폴백 여지 + zntc P2-0 remote `version`=range(비-concrete)라 빌드타임 확정 불가 → fail-fast 시 거짓 빌드중단 위험. P3-5 런타임 가드가 보강선. (§3.4 버전축 분리)
- `version_warn` 은 zntc P2-0 가 concrete version 을 emit 못 해 통합으로 직접 박제 불가 → inline `sharedVerdict`/`semver` 매트릭스가 망라(타당한 분담).

## 검증
- `zig build test` **0** / `wasm-bundler` **0** / `zig build`(install) **0**.
- MF 통합 스모크 **16 pass**(P3-2 신규, P3-1 무회귀), MF e2e **4 passed**(`emitHostInit` 불변).
- `/simplify` 3-에이전트(재사용·품질·효율) **차단 0**: semver 정확성(거짓경고/누락)·fail-fast vs warn 등급 타당성·P3-1 무회귀·거짓통과 방지를 코드로 정밀 검증. 비차단 권고(`~major` npm divergence) **반영**.

## 경계 (RFC §7.3)
검증만(emit 부작용 0). 네트워크 fetch=비-목표(skip), malformed manifest=P3-3 별도(skip). 같은 remote 다중 import 시 경고 중복 가능(소규모 — P3-1 선례 허용, dedup 후속).

Closes #3437

🤖 Generated with [Claude Code](https://claude.com/claude-code)