### PR TITLE
fix(rn): lazy barrel deferred import skip 처리

### DIFF
--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -2124,6 +2124,86 @@ test "ESM ns-access: opaque path (bare ref after member access) doesn't leak" {
     // leak 발생 시 `zig build test` 가 테스트 실패 처리.
 }
 
+test "ESM wrapped static import under strict order does not emit raw require" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath("node_modules/@tanstack/react-query/build/modern");
+    try tmp.dir.makePath("node_modules/@tanstack/query-core/build/modern");
+    try writeFile(tmp.dir, "entry.js",
+        \\import { useQueries } from '@tanstack/react-query';
+        \\console.log(useQueries());
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/react-query/package.json",
+        \\{
+        \\  "name": "@tanstack/react-query",
+        \\  "type": "module",
+        \\  "main": "build/legacy/index.cjs",
+        \\  "module": "build/legacy/index.js",
+        \\  "exports": {
+        \\    ".": {
+        \\      "import": { "default": "./build/modern/index.js" },
+        \\      "require": { "default": "./build/modern/index.cjs" }
+        \\    }
+        \\  },
+        \\  "sideEffects": false
+        \\}
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/query-core/package.json",
+        \\{
+        \\  "name": "@tanstack/query-core",
+        \\  "type": "module",
+        \\  "exports": {
+        \\    ".": { "import": { "default": "./build/modern/index.js" } }
+        \\  },
+        \\  "sideEffects": false
+        \\}
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/query-core/build/modern/index.js",
+        \\export const core = 'core';
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/react-query/build/modern/types.js",
+        \\export {};
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/react-query/build/modern/index.js",
+        \\export * from "@tanstack/query-core";
+        \\export * from "./types.js";
+        \\import { useQueries } from './useQueries.js';
+        \\import { queryOptions } from './queryOptions.js';
+        \\export { useQueries, queryOptions };
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/react-query/build/modern/useQueries.js",
+        \\export function useQueries() {
+        \\  return 'queries';
+        \\}
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/react-query/build/modern/queryOptions.js",
+        \\export function queryOptions() {
+        \\  return 'options';
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .strict_execution_order = true,
+        .minify_syntax = true,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "queries") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./useQueries.js\")") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./queryOptions.js\")") == null);
+}
+
 // ============================================================
 // `.cjs` / `.cts` 는 Node CommonJS 컨벤션상 ESM 구문 (`import`/`export`) 거부.
 // 이전엔 graph/parser_setup.zig 가 모든 모듈을 is_module=true 로 promote 해서

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -772,7 +772,19 @@ pub fn buildMetadataForAst(
             var hoisted_specifiers = std.StringHashMap(void).init(self.allocator);
             defer hoisted_specifiers.deinit();
             for (m.import_records, 0..) |rec, rec_i| {
-                if (rec.resolved.isNone()) continue;
+                if (rec.resolved.isNone()) {
+                    // Lazy barrel tree-shaking can intentionally leave unrequested
+                    // static import records unresolved. The source AST still has
+                    // the original import declaration, and wrapped IIFE/CJS
+                    // codegen would lower it to a raw `require("...")`. React
+                    // Native does not provide a global require there, so skip the
+                    // original import node when graph linking also decided not to
+                    // resolve this record.
+                    if (!self.graph.shouldLinkResolvedRecordForModule(module_index, rec_i, rec)) {
+                        try hoisted_specifiers.put(rec.specifier, {});
+                    }
+                    continue;
+                }
                 const tidx = @intFromEnum(rec.resolved);
                 const tmod = self.graph.getModule(rec.resolved) orelse continue;
                 if (tmod.wrap_kind == .none) {


### PR DESCRIPTION
## 요약
- React Native IIFE/strictExecutionOrder 조합에서 lazy barrel의 미사용 static import가 raw `require()`로 남는 문제를 수정했습니다.
- graph가 의도적으로 resolve하지 않은 lazy barrel import record도 wrapped module body의 원본 `import` declaration emit 대상에서 제외합니다.
- `@tanstack/react-query` 형태의 `sideEffects:false` ESM barrel 회귀 테스트를 추가했습니다.

## 원인
`sideEffects:false` barrel에서 요청되지 않은 export의 static import는 트리쉐이킹을 위해 resolve를 미룹니다. 그런데 AST에는 원본 `import { queryOptions } from "./queryOptions.js"`가 그대로 남아 있었습니다. wrapped IIFE/CJS codegen은 unresolved import declaration을 `require("./queryOptions.js")` 형태로 낮추기 때문에, React Native 런타임처럼 전역 `require`가 없는 환경에서 크래시가 발생했습니다.

Zig 코드 기준으로는 `metadata.zig`의 skip node 계산이 `rec.resolved.isNone()`이면 바로 지나가서 deferred lazy import를 원본 import 제거 대상으로 보지 못한 것이 핵심입니다. 이번 수정은 graph의 `shouldLinkResolvedRecordForModule` 판단과 metadata skip 판단을 맞춰, graph가 “이 import는 링크하지 않는다”고 결정한 경우 AST import declaration도 emit하지 않게 합니다.

## 테스트
- `zig build test -Dtest-filter="ESM wrapped static import under strict order" --summary all`
- `git diff --check`