### PR TITLE
feat(minify): minify_syntax 시 valid-identifier 객체 키 quote 제거

### DIFF
--- a/src/codegen/expressions.zig
+++ b/src/codegen/expressions.zig
@@ -5,7 +5,28 @@ const ast_mod = @import("../parser/ast.zig");
 const Node = ast_mod.Node;
 const NodeIndex = ast_mod.NodeIndex;
 const Kind = @import("../lexer/token.zig").Kind;
+const unicode = @import("../lexer/unicode.zig");
 const calls = @import("calls.zig");
+
+/// minify_syntax 시 string_literal 객체 키를 따옴표 없이 emit 가능한지.
+/// `raw` 는 따옴표 포함 리터럴 텍스트. escape 없는 단순 리터럴이고 valid ES
+/// IdentifierName 이며 `__proto__` 가 아닐 때만 true. 객체 키는 reserved
+/// word 도 valid 라 reserved 검사 불필요; `{"__proto__":v}` 는 일반 프로퍼티,
+/// `{__proto__:v}` 는 proto setter 라 semantic 이 달라져 반드시 제외.
+fn objectKeyUnquotable(raw: []const u8) bool {
+    if (raw.len < 2) return false;
+    const q = raw[0];
+    if ((q != '"' and q != '\'') or raw[raw.len - 1] != q) return false;
+    const s = raw[1 .. raw.len - 1];
+    if (s.len == 0) return false;
+    if (std.mem.indexOfScalar(u8, s, '\\') != null) return false;
+    if (std.mem.eql(u8, s, "__proto__")) return false;
+    if (!unicode.isIdentifierStart(s[0])) return false;
+    for (s[1..]) |c| {
+        if (!unicode.isIdentifierContinue(c)) return false;
+    }
+    return true;
+}
 
 pub fn emitUnary(self: anytype, node: Node) !void {
     try self.addSourceMapping(node.span);
@@ -260,6 +281,13 @@ pub fn emitObjectProperty(self: anytype, node: Node) !void {
         const key_node = self.ast.getNode(key);
         if (key_node.tag == .identifier_reference) {
             try self.writeSpan(key_node.data.string_ref);
+        } else if (key_node.tag == .string_literal and self.options.minify_syntax) {
+            const raw = self.ast.getText(key_node.span);
+            if (objectKeyUnquotable(raw)) {
+                try self.write(ast_mod.Ast.stripStringQuotes(raw));
+            } else {
+                try self.emitNode(key);
+            }
         } else {
             try self.emitNode(key);
         }
@@ -414,4 +442,27 @@ pub fn emitComputedMember(self: anytype, node: Node) !void {
     try self.writeByte('[');
     try self.emitNode(property);
     try self.writeByte(']');
+}
+
+test "objectKeyUnquotable: valid IdentifierName 만 unquote (semantic-preserving)" {
+    const t = std.testing;
+    // valid: 따옴표 벗겨도 동일 — reserved word 도 객체 키로는 valid
+    try t.expect(objectKeyUnquotable("\"source\""));
+    try t.expect(objectKeyUnquotable("\"extensions\""));
+    try t.expect(objectKeyUnquotable("'compressible'"));
+    try t.expect(objectKeyUnquotable("\"_x\""));
+    try t.expect(objectKeyUnquotable("\"$a\""));
+    try t.expect(objectKeyUnquotable("\"a1\""));
+    try t.expect(objectKeyUnquotable("\"if\"")); // reserved word: {if:1} 은 valid JS
+    // invalid: quote 유지해야 정확성 보존
+    try t.expect(!objectKeyUnquotable("\"\"")); // 빈 키
+    try t.expect(!objectKeyUnquotable("\"1a\"")); // 숫자 시작
+    try t.expect(!objectKeyUnquotable("\"a-b\"")); // 하이픈
+    try t.expect(!objectKeyUnquotable("\"application/json\"")); // 슬래시
+    try t.expect(!objectKeyUnquotable("\"a b\"")); // 공백
+    try t.expect(!objectKeyUnquotable("\"a\\nb\"")); // escape — 디코드 회피(보수적)
+    try t.expect(!objectKeyUnquotable("\"__proto__\"")); // proto setter semantic 보존
+    try t.expect(!objectKeyUnquotable("source")); // 따옴표 없는 raw 는 대상 아님
+    try t.expect(!objectKeyUnquotable("\"")); // 길이 부족
+    try t.expect(!objectKeyUnquotable("\"a'")); // quote 불일치
 }


### PR DESCRIPTION
## 문제

`codegen/emitObjectProperty` 가 `string_literal` 객체 키를 minify 에서도 **항상 quote 보존**했습니다. mime-db 류 `{"source":"iana","extensions":[...]}` 가 `{source:"iana",extensions:[...]}` 로 안 줄어듦. esbuild/rolldown/rspack 은 모두 valid identifier 키의 quote 를 제거합니다. **mangler 아키텍처와 무관한 별개 codegen 누락** (size-gap 탐색으로 measure-first 규명 — type-is/mime-types 격차의 ~96% 가 이 한 원인).

## 수정

`objectKeyUnquotable(raw)`: `minify_syntax` + escape 없는 단순 리터럴 + valid ES IdentifierName + non-`__proto__` 일 때만 따옴표 제거.

- 객체 키는 reserved word 도 valid (`{if:1}`) → reserved 검사 불필요
- `{"__proto__":v}`(일반 프로퍼티) vs `{__proto__:v}`(proto setter) 는 semantic 이 달라 `__proto__` 는 반드시 제외 — **semantic-preserving 절대원칙(#1577)**
- escape 포함 키는 디코드 회피 위해 보수적으로 quote 유지
- 기존 `Ast.stripStringQuotes` / `unicode.isIdentifierStart|Continue` 재사용

## 측정 (144-lib smoke `--minify-all`, ReleaseFast, main vs fix)

| | main | fix | Δ |
|---|--:|--:|--:|
| 141 lib 합산 | 4,822,956 | 4,794,626 | **−28,330 (−0.587%)** |

- **개선 19 / 회귀 0 / 무변 122** — 순수 win
- TOP: express **−8,928**, mime-types **−8,604**, type-is **−8,604**, iconv-lite −986, vue −378, ajv −322, color-convert −296
- **런타임 MATCH 전수** (outputMatch 회귀 0개)
- Debug + ReleaseFast 유닛 테스트 통과 (`objectKeyUnquotable` semantic-preserving 케이스 망라)

## 후속 (별도 PR)

`/simplify` 리뷰: valid-identifier 판정이 `expressions`/`jsx_lowering`/`view_config_emitter`/`json_to_esm` 4곳 중복. `unicode.zig` 에 reserved-미검사 `isValidIdentifierName` 공유 추출 권고 — correctness-sensitive (reserved·ASCII 정책 차이 보존 + 회귀 가드) 라 본 PR 범위 밖, 별도 진행.

> Zig 초보자 노트: `emitObjectProperty` 는 객체 리터럴의 `key: value` 를 출력하는 codegen 함수입니다. 기존엔 키가 `identifier_reference`(이미 따옴표 없는 식별자)면 그대로, `string_literal`(`"source"`)이면 따옴표째 출력했습니다. 이번 변경은 string_literal 이라도 그 내용이 JS 식별자로 쓸 수 있는 형태면(`source` O, `application/json` X — 슬래시 불가) minify 시 따옴표를 떼는 분기를 추가한 것입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)