### PR TITLE
fix(rn): CJS namespace require의 lazy getter target 보존

### DIFF
--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -1788,6 +1788,70 @@ test "ESM re-export: named re-export from CJS binds via require getter (#1425)" 
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require_registry().getAssetByID") != null);
 }
 
+test "CJS raw require namespace keeps lazy getter require target" {
+    // ReactNativePrivateInterface pattern: a CJS namespace is read through raw
+    // require(), then one getter property lazily requires another module. The
+    // namespace read makes every getter observable, including Flow-typed getter
+    // bodies that have no direct named export use yet.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "rn-private.js",
+        \\// @flow strict-local
+        \\import typeof ReactFiberErrorDialog from './dialog.js';
+        \\
+        \\module.exports = {
+        \\  get ReactFiberErrorDialog(): ReactFiberErrorDialog {
+        \\    return require('./dialog.js').default;
+        \\  },
+        \\};
+    );
+    try writeFile(tmp.dir, "dialog.js",
+        \\// @flow strict-local
+        \\export type CapturedError = {
+        \\  +componentStack: string,
+        \\  +error: mixed,
+        \\};
+        \\
+        \\const ReactFiberErrorDialog = {
+        \\  showErrorDialog(_capturedError: CapturedError): boolean {
+        \\    return false;
+        \\  },
+        \\};
+        \\export default ReactFiberErrorDialog;
+    );
+    try writeFile(tmp.dir, "renderer.js",
+        \\const iface = require('./rn-private.js');
+        \\if (typeof iface.ReactFiberErrorDialog.showErrorDialog !== 'function') {
+        \\  throw new Error('missing dialog');
+        \\}
+    );
+    try writeFile(tmp.dir, "entry.js",
+        \\require('./renderer.js');
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .minify_syntax = true,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .flow = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "showErrorDialog") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "missing dialog") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "return !1") != null or
+        std.mem.indexOf(u8, result.output, "return!1") != null);
+}
+
 test "ESM namespace import: CJS named re-export member binds via require getter" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -732,6 +732,11 @@ pub const TreeShaker = struct {
     /// (#2683 PR β-2) RN core `module.exports = { get DevSettings() { require('./X') } }`
     /// 같은 single-statement object literal 의 sub-unit 단위 reachability.
     fn lazyRequireMatchedExportUsed(self: *const TreeShaker, mod_idx: u32, rec_span: Span) bool {
+        // `require("./cjs")` returns the whole CJS namespace. If that namespace is
+        // marked live with the "*" sentinel, every lazy getter is observable even
+        // when no individual getter export was recorded as used yet.
+        if (self.isExportUsed(mod_idx, ALL_EXPORTS_SENTINEL)) return true;
+
         const m = self.getModule(mod_idx) orelse return true;
         const ast = &(m.ast orelse return true);
         if (mod_idx >= self.module_stmt_infos.len) return true;


### PR DESCRIPTION
## 요약
- CJS namespace를 raw `require()`로 읽는 경우 lazy getter 내부 require target이 tree-shaking으로 빠지는 문제를 수정했습니다.
- `*` export sentinel이 찍힌 CJS namespace는 모든 getter가 관찰 가능하므로, 개별 getter export 사용 여부와 무관하게 lazy require를 보존합니다.
- React Native `ReactNativePrivateInterface` 형태를 재현하는 Flow fixture 테스트를 추가했습니다.

## 원인
CJS 모듈을 `const iface = require("./rn-private")`처럼 namespace 전체로 읽으면 해당 namespace의 모든 getter가 런타임에 접근 가능해집니다. 기존 `lazyRequireMatchedExportUsed`는 getter 내부 require를 살릴지 판단할 때 개별 getter export 이름만 확인했고, namespace 전체 사용을 뜻하는 `ALL_EXPORTS_SENTINEL`(`*`)은 보지 않았습니다.

그 결과 getter 함수 자체는 남아도 getter body가 require하는 target 모듈의 실제 초기화/body가 빠질 수 있었습니다. RN 런타임에서는 이 상태가 `init_*`/`require_*` 누락 또는 getter 접근 시 undefined 계열 오류로 이어집니다.

Zig 초보자 관점에서는 `ALL_EXPORTS_SENTINEL`이 “이 모듈의 특정 export 하나가 아니라 namespace 전체가 live”라는 표시입니다. 이번 수정은 lazy getter 필터가 그 표시를 먼저 확인하도록 해 graph/tree-shaker의 live 판단을 일치시킨 것입니다.

## 테스트
- `zig build test -Dtest-filter="CJS raw require namespace keeps lazy getter require target" --summary all`
- `git diff --check`