### PR TITLE
fix(rn): require namespace의 re-export source 보존

### DIFF
--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -1788,6 +1788,48 @@ test "ESM re-export: named re-export from CJS binds via require getter (#1425)" 
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require_registry().getAssetByID") != null);
 }
 
+test "ESM re-export: CJS require member access keeps re-export source body" {
+    // RN asset loader pattern: generated asset modules call
+    // `require("AssetRegistry").registerAsset(...)`. The raw require observes
+    // the ESM facade namespace, so the facade's CJS re-export source must also
+    // keep the actual export fact body.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "registry.js",
+        \\const assets = [];
+        \\function registerAsset(asset) { assets.push(asset); return assets.length; }
+        \\function getAssetByID(id) { return assets[id - 1]; }
+        \\module.exports = { registerAsset, getAssetByID };
+    );
+    try writeFile(tmp.dir, "AssetRegistry.js",
+        \\export { registerAsset, getAssetByID } from './registry.js';
+    );
+    try writeFile(tmp.dir, "asset.js",
+        \\module.exports = require('./AssetRegistry.js').registerAsset({ name: 'test' });
+    );
+    try writeFile(tmp.dir, "entry.js",
+        \\const asset = require('./asset.js');
+        \\globalThis.asset = asset;
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "registerAsset(asset)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "module.exports = { registerAsset, getAssetByID }") != null);
+}
+
 test "ESM namespace import: CJS named re-export member binds via require getter" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -977,20 +977,31 @@ pub const TreeShaker = struct {
                             if (!try import_records.importRecordBelongsToStmt(self, @intCast(item.mod), infos, @intCast(item.stmt), @intCast(rec_i))) continue;
                             const target_mod_idx = @intFromEnum(rec.resolved);
                             const target_module = self.graph.getModule(rec.resolved) orelse continue;
-                            if (target_module.wrap_kind != .cjs) continue;
-                            if (!self.isExportUsed(item.mod, ALL_EXPORTS_SENTINEL) and
-                                !self.isExportUsed(@intCast(target_mod_idx), ALL_EXPORTS_SENTINEL) and
-                                self.hasAnyUsedExportDirect(@intCast(target_mod_idx)) and
-                                cjs_patterns.moduleExportsRequireProxyMatches(o, infos, @intCast(item.stmt), rec.resolved))
-                            {
-                                const target_infos = module_stmt_infos[target_mod_idx] orelse {
-                                    try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
+                            if (target_module.wrap_kind == .cjs) {
+                                if (!self.isExportUsed(item.mod, ALL_EXPORTS_SENTINEL) and
+                                    !self.isExportUsed(@intCast(target_mod_idx), ALL_EXPORTS_SENTINEL) and
+                                    self.hasAnyUsedExportDirect(@intCast(target_mod_idx)) and
+                                    cjs_patterns.moduleExportsRequireProxyMatches(o, infos, @intCast(item.stmt), rec.resolved))
+                                {
+                                    const target_infos = module_stmt_infos[target_mod_idx] orelse {
+                                        try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
+                                        continue;
+                                    };
+                                    try self.seedSideEffectStmts(@intCast(target_mod_idx), target_infos, &queue, reachable_stmts);
                                     continue;
-                                };
-                                try self.seedSideEffectStmts(@intCast(target_mod_idx), target_infos, &queue, reachable_stmts);
+                                }
+                                try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
                                 continue;
                             }
-                            try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
+                            if (target_module.wrap_kind.isWrapped()) {
+                                // `require()` observes the module namespace. For an
+                                // ESM facade, the facade body alone is not enough:
+                                // its re-export sources contain the actual CJS
+                                // export facts used by generated RN asset modules
+                                // such as `require(AssetRegistry).registerAsset(...)`.
+                                try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
+                                try self.seedReExportSourcesForRequireNamespace(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
+                            }
                         }
                     }
                 }
@@ -1763,6 +1774,31 @@ pub const TreeShaker = struct {
         try self.markAllExportsUsed(mod_idx);
         self.included.set(mod_idx);
         try self.seedAllStmts(mod_idx, queue, module_stmt_infos, reachable_stmts);
+    }
+
+    fn seedReExportSourcesForRequireNamespace(
+        self: *TreeShaker,
+        mod_idx: u32,
+        queue: *std.ArrayListUnmanaged(BfsItem),
+        module_stmt_infos: []?StmtInfos,
+        reachable_stmts: []?std.DynamicBitSet,
+    ) std.mem.Allocator.Error!void {
+        const m = self.getModule(mod_idx) orelse return;
+        for (m.export_bindings) |eb| {
+            if (!eb.kind.isAnyReExport()) continue;
+            const rec_idx = eb.import_record_index orelse continue;
+            if (rec_idx >= m.import_records.len) continue;
+            const src_idx = m.import_records[rec_idx].resolved;
+            const src_module = self.graph.getModule(src_idx) orelse continue;
+            const src = @intFromEnum(src_idx);
+            if (eb.kind == .re_export_star or eb.kind.isReExportAll()) {
+                try self.markAndSeedAllStmts(@intCast(src), queue, module_stmt_infos, reachable_stmts);
+            } else if (src_module.wrap_kind == .cjs) {
+                try self.seedCjsExportOrAll(@intCast(src), m.exportBindingLocalName(eb), queue, module_stmt_infos, reachable_stmts);
+            } else {
+                try self.seedExport(src, m.exportBindingLocalName(eb), queue, module_stmt_infos, reachable_stmts);
+            }
+        }
     }
 
     fn seedModuleExportsRequireProxyTargetsAll(


### PR DESCRIPTION
## 요약
- CJS `require()`가 ESM facade namespace를 관찰하는 경우 facade의 re-export source까지 tree-shaker가 시드하도록 수정했습니다.
- RN generated asset module 형태인 `require(AssetRegistry).registerAsset(...)` 회귀 테스트를 추가했습니다.

## 원인
기존 BFS require follow-up은 require target이 CJS wrapper일 때만 전파하고, `target_module.wrap_kind != .cjs`이면 바로 건너뛰었습니다. 하지만 RN asset module의 target은 실제 registry CJS 모듈이 아니라 `AssetRegistry.js` 같은 ESM facade일 수 있습니다.

이 경우 facade 자체만 live로 보거나 아예 건너뛰면, facade가 re-export하는 CJS source의 `registerAsset` export fact body가 seed되지 않습니다. 결과적으로 번들에는 namespace 접근 모양은 남아도 실제 `registerAsset` 구현이 빠져 런타임에서 undefined/function 누락 오류가 납니다.

수정 후에는 require target이 wrapped ESM이면 facade를 시드하고, 그 facade의 re-export source도 namespace 관찰 경로로 따라가 CJS export fact를 보존합니다. Zig 초보자 관점에서는 BFS 큐가 “실행되어야 할 statement”를 확장하는 단계이고, 이번 변경은 require target이 facade일 때 큐가 실제 구현 모듈까지 도달하도록 한 것입니다.

## 테스트
- `zig build test -Dtest-filter="ESM re-export: CJS require member access keeps re-export source body" --summary all`
- `git diff --check`