### PR TITLE
fix(rn): require 런타임 누락 경로 보정

### DIFF
--- a/packages/core/src/napi/watch.zig
+++ b/packages/core/src/napi/watch.zig
@@ -30,12 +30,12 @@ const installManualChunksResolver = plugin_bridge.installManualChunksResolver;
 /// Issue #1223 Phase 1: 워처 튜닝 상수.
 /// - watch_poll_timeout_ms: stop_flag 체크 주기 (이벤트 워처에서도 주기적으로 깨어나기 위함).
 /// - watch_debounce_ms: 첫 이벤트 이후 정적(idle) 구간 — 연속 저장 병합 윈도우.
-///   debounce loop 첫 iteration 이 kqueue/inotify 에서 최소 이 시간만큼 블로킹되므로
-///   HMR detect 페이즈에 그대로 더해진다. 25ms 는 VS Code / vim 의 atomic save
-///   (rename + write) 사이 간격(5-15ms)을 여전히 흡수하면서 detect 비용을 절반으로.
+///   phase1c 의 공개 계약은 50ms 내 연속 저장 병합이다. macOS kqueue 는 CI 부하에 따라
+///   같은 파일의 후속 NOTE_WRITE 전달이 25ms idle 뒤에 도착할 수 있으므로, idle window 를
+///   계약값인 50ms 로 맞춰 빠른 저장을 한 rebuild 로 안정적으로 합친다.
 /// - watch_debounce_max_ms: 디바운스 최대 대기 시간 — 지속 변경되는 파일에 의한 기아 방지.
 const watch_poll_timeout_ms: u32 = 200;
-const watch_debounce_ms: u32 = 25;
+const watch_debounce_ms: u32 = 50;
 const watch_debounce_max_ms: u64 = 500;
 
 /// 파일 내용 해시 상한 (#1233). RN 등 대형 프로젝트의 vendor 번들/asset catalog/locale

--- a/packages/react-native/src/plugins/asset.test.ts
+++ b/packages/react-native/src/plugins/asset.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -90,14 +90,26 @@ describe('createAssetPlugin', () => {
     }
   });
 
-  test('내장 SVG component transformer — 사용자 babelTransformerPath 가 있으면 등록하지 않음', () => {
+  test('내장 SVG component transformer — 사용자 babelTransformerPath 가 있어도 SVG는 ZNTC가 처리', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-rn-svg-builtin-with-custom-'));
+    const svgPath = join(dir, 'custom.svg');
+    writeFileSync(svgPath, '<svg viewBox="0 0 1 1"/>');
     const handlers = captureHandlers({
       ...baseConfig,
+      projectRoot: dir,
       sourceExts: ['.ts', '.tsx', '.js', '.jsx', '.svg'],
       babelTransformerPath: 'react-native-svg-transformer',
     });
-    expect(handlers.length).toBe(2);
-    expect(handlers[1]!.filter.test('/abs/icon.svg')).toBe(true);
+    try {
+      expect(handlers.length).toBe(2);
+      const svgHandler = handlers[1]!;
+      expect(svgHandler.filter.test(svgPath)).toBe(true);
+      const result = await svgHandler.handler({ path: svgPath });
+      expect(result?.contents).toContain('function SvgCustom(props)');
+      expect(result?.contents).toContain('export default SvgCustom');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   test('createSvgComponentModule — JS identifier 로 안전한 component name 생성', () => {
@@ -115,7 +127,7 @@ describe('createAssetPlugin', () => {
     expect(handlers.length).toBe(1);
   });
 
-  test('babelTransformerPath + customExts (.svg) — 두 번째 onLoad 등록', () => {
+  test('babelTransformerPath + .svg sourceExt — SVG는 내장 onLoad 만 등록', () => {
     const handlers = captureHandlers({
       ...baseConfig,
       sourceExts: ['.ts', '.tsx', '.js', '.jsx', '.svg'],
@@ -127,14 +139,59 @@ describe('createAssetPlugin', () => {
     expect(customHandler.filter.test('/abs/foo.ts')).toBe(false);
   });
 
+  test('babelTransformerPath transformer — non-SVG customExt 에 Metro projectRoot/dev 옵션 전달', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'zntc-rn-custom-transformer-'));
+    try {
+      writeFileSync(join(dir, 'package.json'), '{"name":"fixture","private":true}');
+      mkdirSync(join(dir, 'node_modules', 'fake-transformer'), { recursive: true });
+      mkdirSync(join(dir, 'node_modules', '@babel', 'core'), { recursive: true });
+      writeFileSync(
+        join(dir, 'node_modules', 'fake-transformer', 'package.json'),
+        '{"name":"fake-transformer","main":"index.js"}',
+      );
+      writeFileSync(
+        join(dir, 'node_modules', 'fake-transformer', 'index.js'),
+        `
+module.exports.transform = ({ options }) => {
+  if (options.projectRoot !== ${JSON.stringify(dir)}) {
+    throw new Error('missing projectRoot');
+  }
+  if (options.dev !== false || options.hot !== false) {
+    throw new Error('dev flag was not forwarded');
+  }
+  return { code: 'export default "ok";' };
+};
+`,
+      );
+      writeFileSync(
+        join(dir, 'node_modules', '@babel', 'core', 'index.js'),
+        `throw new Error('Babel should not be loaded for code-returning custom transformers');`,
+      );
+      const customPath = join(dir, 'query.graphql');
+      writeFileSync(customPath, 'query Example { id }');
+
+      const handlers = captureHandlers({
+        ...baseConfig,
+        projectRoot: dir,
+        dev: false,
+        sourceExts: ['.ts', '.tsx', '.js', '.jsx', '.graphql'],
+        babelTransformerPath: 'fake-transformer',
+      });
+      const result = await handlers[1]!.handler({ path: customPath });
+      expect(result?.contents).toBe('export default "ok";');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test('customExts 패턴 — JS/TS/JSON 표준 확장자 제외', () => {
     const handlers = captureHandlers({
       ...baseConfig,
       sourceExts: ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.json', '.svg', '.graphql'],
       babelTransformerPath: 'any-transformer',
     });
-    const customHandler = handlers[1]!;
-    expect(customHandler.filter.test('/abs/x.svg')).toBe(true);
+    const customHandler = handlers[2]!;
+    expect(customHandler.filter.test('/abs/x.svg')).toBe(false);
     expect(customHandler.filter.test('/abs/x.graphql')).toBe(true);
     expect(customHandler.filter.test('/abs/x.ts')).toBe(false);
     expect(customHandler.filter.test('/abs/x.json')).toBe(false);

--- a/packages/react-native/src/plugins/asset.ts
+++ b/packages/react-native/src/plugins/asset.ts
@@ -1,8 +1,7 @@
 // React Native runtime injection plugin — Metro 의 HMRClient.js 를 ZNTC HMR
-// runtime (`runtime/zntc-hmr-client.js`) 으로 교체 + 사용자 babelTransformerPath
-// (예: react-native-svg-transformer) 통합. Asset registry / scale variant 처리는
-// ZNTC 코어가 직접 (preset 의 assetRegistry/loader/alias 옵션) — 이 plugin 의
-// 책임 아님.
+// runtime (`runtime/zntc-hmr-client.js`) 으로 교체 + RN source asset transformer
+// 통합. Asset registry / scale variant 처리는 ZNTC 코어가 직접 (preset 의
+// assetRegistry/loader/alias 옵션) 처리한다.
 
 import { readFileSync } from 'node:fs';
 import { basename, extname } from 'node:path';
@@ -11,7 +10,7 @@ import type { ZntcPlugin } from '@zntc/core';
 
 import { HMR_CLIENT_SUFFIX, ZNTC_HMR_CLIENT_CODE } from '../runtime-loader.ts';
 import { escapeRegex } from './escape-regex.ts';
-import { type BabelInstance, getErrorMessage, normalizeExt, requireFromCli } from './internal.ts';
+import { getErrorMessage, normalizeExt, requireFromCli } from './internal.ts';
 import type { PluginConfig } from './types.ts';
 
 interface MetroTransformerResult {
@@ -23,7 +22,12 @@ interface MetroTransformer {
   transform(args: {
     src: string;
     filename: string;
-    options: { platform: 'ios' | 'android'; dev: boolean };
+    options: {
+      platform: 'ios' | 'android';
+      dev: boolean;
+      hot: boolean;
+      projectRoot: string;
+    };
   }): Promise<MetroTransformerResult> | MetroTransformerResult;
 }
 
@@ -60,9 +64,9 @@ export function createSvgComponentModule(svg: string, filePath: string): string 
 /**
  * RN runtime 통합 plugin:
  * - Metro HMRClient.js path → ZNTC HMR runtime (`runtime/zntc-hmr-client.js`) 교체
- * - 사용자 babelTransformerPath (예: react-native-svg-transformer) — Metro
- *   호환 시그니처 (`transform({src, filename, options})` → `{code}` or `{ast}`)
- *   로 호출, AST 반환 시 babel.transformFromAstSync 로 generate.
+ * - `.svg` sourceExt 는 ZNTC 내장 transformer 로 직접 JS module 생성
+ * - 사용자 babelTransformerPath 는 ZNTC 내장 transformer 가 처리하지 않는 custom
+ *   sourceExt 에만 적용한다. Babel AST 반환은 처리하지 않는다.
  */
 export function createAssetPlugin(config: PluginConfig): ZntcPlugin {
   return {
@@ -75,7 +79,7 @@ export function createAssetPlugin(config: PluginConfig): ZntcPlugin {
       }));
 
       const hasSvgSource = config.sourceExts.some((e) => normalizeExt(e).toLowerCase() === '.svg');
-      if (!config.babelTransformerPath && hasSvgSource) {
+      if (hasSvgSource) {
         build.onLoad({ filter: /\.svg$/i }, (args) => ({
           contents: createSvgComponentModule(readFileSync(args.path, 'utf8'), args.path),
         }));
@@ -83,14 +87,14 @@ export function createAssetPlugin(config: PluginConfig): ZntcPlugin {
 
       if (config.babelTransformerPath) {
         let customTransformer: MetroTransformer | null = null;
-        let babel: BabelInstance | null = null;
         const transformerPath = config.babelTransformerPath;
+        const dev = config.dev ?? true;
 
         // 사용자 transformer 적용 대상 — sourceExts 중 ts/tsx/js/jsx/mjs/cjs/json
-        // 외 (RN-specific 확장자, 예: .svg). 표준 JS/TS 는 ZNTC 가 처리하므로 제외.
+        // 외 확장자. `.svg` 는 위의 ZNTC 내장 transformer 가 처리하므로 제외.
         const customExts = config.sourceExts
           .map((e) => normalizeExt(e).slice(1))
-          .filter((e) => !/^(tsx?|jsx?|mjs|cjs|json)$/.test(e))
+          .filter((e) => !/^(tsx?|jsx?|mjs|cjs|json|svg)$/.test(e))
           .join('|');
 
         if (customExts) {
@@ -102,28 +106,28 @@ export function createAssetPlugin(config: PluginConfig): ZntcPlugin {
                   requireFromCli.resolve(transformerPath, { paths: [config.projectRoot] }),
                 ) as MetroTransformer;
               }
-              if (!babel) {
-                babel = requireFromCli('@babel/core') as BabelInstance;
-              }
               const src = readFileSync(args.path, 'utf8');
               const result = await customTransformer.transform({
                 src,
                 filename: args.path,
-                options: { platform: config.rnPlatform, dev: true },
+                options: {
+                  platform: config.rnPlatform,
+                  dev,
+                  hot: dev,
+                  projectRoot: config.projectRoot,
+                },
               });
               if (result?.code) return { contents: result.code };
               if (result?.ast) {
-                const generated = babel.transformFromAstSync?.(result.ast, undefined, {
-                  filename: args.path,
-                  babelrc: false,
-                  configFile: false,
-                });
-                if (generated?.code) return { contents: generated.code };
+                throw new Error(
+                  `${transformerPath} returned a Babel AST for ${args.path}. ZNTC custom source transformers must return code; use a ZNTC native transformer for this extension.`,
+                );
               }
             } catch (err: unknown) {
               process.stderr.write(
                 `[zntc:transformer] ${args.path.split('/').pop()}: ${getErrorMessage(err)}\n`,
               );
+              throw err;
             }
             return null;
           });

--- a/packages/react-native/src/plugins/babel.test.ts
+++ b/packages/react-native/src/plugins/babel.test.ts
@@ -261,6 +261,93 @@ describe('createBabelTransformer — project root 기준 Babel cwd', () => {
       rmSync(foreignCwd, { recursive: true, force: true });
     }
   });
+
+  test('babel-plugin-root-import 처럼 module load 시 process.cwd() 를 캡처하는 plugin 에 root 옵션을 주입', () => {
+    const originalCwd = process.cwd();
+    const foreignCwd = mkdtempSync(join(tmpdir(), 'zntc-rn-root-import-cwd-'));
+
+    try {
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'root-import-test' }));
+      mkdirSync(join(dir, 'src'), { recursive: true });
+      mkdirSync(join(dir, 'node_modules/@babel/core'), { recursive: true });
+      writeFileSync(
+        join(dir, 'node_modules/@babel/core/package.json'),
+        JSON.stringify({ name: '@babel/core', main: 'index.js' }),
+      );
+      writeFileSync(
+        join(dir, 'node_modules/@babel/core/index.js'),
+        `
+          module.exports = {
+            transformSync(code, options) {
+              const entry = options.plugins[0];
+              const pluginPath = Array.isArray(entry) ? entry[0] : entry;
+              const pluginOptions = Array.isArray(entry) ? entry[1] || {} : {};
+              const plugin = require(pluginPath)({
+                types: {
+                  stringLiteral(value) {
+                    return { value };
+                  },
+                },
+              });
+              const importPath = { node: { source: { value: '~/App' } } };
+              plugin.visitor.ImportDeclaration(importPath, {
+                filename: options.filename,
+                file: { opts: options },
+                opts: pluginOptions,
+              });
+              return {
+                code: 'import App from "' + importPath.node.source.value + '";\\nexport default App;',
+              };
+            },
+          };
+        `,
+      );
+      mkdirSync(join(dir, 'node_modules/babel-plugin-root-import'), { recursive: true });
+      writeFileSync(
+        join(dir, 'node_modules/babel-plugin-root-import/package.json'),
+        JSON.stringify({ name: 'babel-plugin-root-import', main: 'index.js' }),
+      );
+      writeFileSync(
+        join(dir, 'node_modules/babel-plugin-root-import/index.js'),
+        `
+          const path = require('node:path');
+          const defaultRoot = process.cwd();
+          module.exports = function rootImportLike({ types: t }) {
+            return {
+              visitor: {
+                ImportDeclaration(importPath, state) {
+                  const source = importPath.node.source.value;
+                  if (!source.startsWith('~/')) return;
+                  const root = state.opts.root || defaultRoot;
+                  const target = path.join(root, state.opts.rootPathSuffix || './', source.slice(2));
+                  let relative = path.relative(path.dirname(state.filename), target).replace(/\\\\/g, '/');
+                  if (!relative.startsWith('.')) relative = './' + relative;
+                  importPath.node.source = t.stringLiteral(relative);
+                },
+              },
+            };
+          };
+        `,
+      );
+      writeFileSync(
+        join(dir, 'babel.config.js'),
+        `module.exports = { plugins: [['babel-plugin-root-import', { rootPathPrefix: '~/', rootPathSuffix: './src' }]] };`,
+      );
+
+      process.chdir(foreignCwd);
+      const transformer = createBabelTransformer(dir);
+      const transformed = transformer(
+        `import App from '~/App';\nexport default App;\n`,
+        join(dir, 'src/index.js'),
+      );
+
+      expect(transformed).toContain('from "./App"');
+      expect(transformed).not.toContain('zntc-rn-root-import-cwd-');
+    } finally {
+      process.chdir(originalCwd);
+      rmSync(foreignCwd, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('ZNTC_NATIVE_PLUGIN_PATTERNS', () => {

--- a/packages/react-native/src/plugins/babel.test.ts
+++ b/packages/react-native/src/plugins/babel.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 
 import {
   applyBabelPluginPrefix,
+  createBabelTransformer,
   detectCustomPlugins,
   isZntcNativePlugin,
   ZNTC_NATIVE_PLUGIN_PATTERNS,
@@ -174,6 +175,91 @@ describe('detectCustomPlugins — inline config (#2605 transformer.babel)', () =
         plugins: [['babel-plugin-root-import', { rootPathPrefix: '~/' }]],
       }),
     ).toBe(true);
+  });
+});
+
+describe('createBabelTransformer — project root 기준 Babel cwd', () => {
+  test('custom Babel plugin 이 process.cwd() 대신 projectRoot 기준으로 alias 를 계산', () => {
+    const originalCwd = process.cwd();
+    const foreignCwd = mkdtempSync(join(tmpdir(), 'zntc-rn-babel-cwd-'));
+
+    try {
+      writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'cwd-test' }));
+      mkdirSync(join(dir, 'src'), { recursive: true });
+      mkdirSync(join(dir, 'node_modules/@babel/core'), { recursive: true });
+      writeFileSync(
+        join(dir, 'node_modules/@babel/core/package.json'),
+        JSON.stringify({ name: '@babel/core', main: 'index.js' }),
+      );
+      writeFileSync(
+        join(dir, 'node_modules/@babel/core/index.js'),
+        `
+          module.exports = {
+            transformSync(code, options) {
+              const pluginFactory = require(options.plugins[0]);
+              const plugin = pluginFactory({
+                types: {
+                  stringLiteral(value) {
+                    return { value };
+                  },
+                },
+              });
+              const importPath = { node: { source: { value: '~/App' } } };
+              const effectiveOptions = { ...options, cwd: options.cwd || process.cwd() };
+              plugin.visitor.ImportDeclaration(importPath, {
+                filename: options.filename,
+                file: { opts: effectiveOptions },
+              });
+              return {
+                code: 'import App from "' + importPath.node.source.value + '";\\nexport default App;',
+              };
+            },
+          };
+        `,
+      );
+      mkdirSync(join(dir, 'node_modules/babel-plugin-cwd-root-import'), { recursive: true });
+      writeFileSync(
+        join(dir, 'node_modules/babel-plugin-cwd-root-import/package.json'),
+        JSON.stringify({ name: 'babel-plugin-cwd-root-import', main: 'index.js' }),
+      );
+      writeFileSync(
+        join(dir, 'node_modules/babel-plugin-cwd-root-import/index.js'),
+        `
+          const path = require('node:path');
+          module.exports = function cwdRootImport({ types: t }) {
+            return {
+              visitor: {
+                ImportDeclaration(importPath, state) {
+                  const source = importPath.node.source.value;
+                  if (!source.startsWith('~/')) return;
+                  const target = path.join(state.file.opts.cwd, 'src', source.slice(2));
+                  let relative = path.relative(path.dirname(state.filename), target).replace(/\\\\/g, '/');
+                  if (!relative.startsWith('.')) relative = './' + relative;
+                  importPath.node.source = t.stringLiteral(relative);
+                },
+              },
+            };
+          };
+        `,
+      );
+      writeFileSync(
+        join(dir, 'babel.config.js'),
+        `module.exports = { plugins: ['cwd-root-import'] };`,
+      );
+
+      process.chdir(foreignCwd);
+      const transformer = createBabelTransformer(dir);
+      const transformed = transformer(
+        `import App from '~/App';\nexport default App;\n`,
+        join(dir, 'src/index.js'),
+      );
+
+      expect(transformed).toContain('from "./App"');
+      expect(transformed).not.toContain('zntc-rn-babel-cwd-');
+    } finally {
+      process.chdir(originalCwd);
+      rmSync(foreignCwd, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/react-native/src/plugins/babel.ts
+++ b/packages/react-native/src/plugins/babel.ts
@@ -238,6 +238,11 @@ export function createBabelTransformer(
     babelOptions = {
       presets: customPresets,
       plugins: customPlugins,
+      // Babel plugin 들은 기본적으로 process.cwd() 기준으로 project-relative path 를
+      // 계산한다. ZNTC CLI/server cwd 가 app root 밖이면 root-import 류 plugin 이
+      // 잘못된 상대경로를 만들므로 Metro 처럼 app projectRoot 를 기준으로 고정한다.
+      cwd: projectRoot,
+      root: projectRoot,
       babelrc: false,
       configFile: false,
       compact: false,

--- a/packages/react-native/src/plugins/babel.ts
+++ b/packages/react-native/src/plugins/babel.ts
@@ -116,6 +116,40 @@ function parserPluginsFor(filename: string): string[] {
   return ['jsx'];
 }
 
+function isRootImportPluginName(name: string): boolean {
+  const normalized = name.replace(/\\/g, '/');
+  return (
+    normalized === 'root-import' ||
+    normalized === 'babel-plugin-root-import' ||
+    normalized.endsWith('/babel-plugin-root-import') ||
+    normalized.includes('/babel-plugin-root-import/')
+  );
+}
+
+function injectRootImportRootOption(
+  options: Record<string, unknown> | undefined,
+  projectRoot: string,
+): Record<string, unknown> {
+  const next: Record<string, unknown> = options ? { ...options } : {};
+  const paths = next.paths;
+
+  if (Array.isArray(paths)) {
+    next.paths = paths.map((pathOption) => {
+      if (!pathOption || typeof pathOption !== 'object' || Array.isArray(pathOption)) {
+        return pathOption;
+      }
+      const record = pathOption as Record<string, unknown>;
+      return 'root' in record ? record : { ...record, root: projectRoot };
+    });
+  } else if (paths && typeof paths === 'object') {
+    const record = paths as Record<string, unknown>;
+    next.paths = 'root' in record ? record : { ...record, root: projectRoot };
+  }
+
+  if (!('root' in next)) next.root = projectRoot;
+  return next;
+}
+
 /**
  * Babel pass 가 필요한지 판정. (a) babel.config.js 의 plugins 또는 (b) inline
  * config (zntc.config.ts `transformer.babel`) 중 하나라도 ZNTC native list 외
@@ -188,14 +222,33 @@ export function createBabelTransformer(
     function resolveEntry(entry: BabelEntry): unknown {
       if (Array.isArray(entry)) {
         try {
+          const resolvedPath = resolvePluginPath(entry[0]);
+          const shouldInjectRoot =
+            isRootImportPluginName(entry[0]) ||
+            isRootImportPluginName(applyBabelPluginPrefix(entry[0])) ||
+            isRootImportPluginName(resolvedPath);
+          if (shouldInjectRoot) {
+            return [
+              resolvedPath,
+              injectRootImportRootOption(entry[1], projectRoot),
+              ...entry.slice(2),
+            ];
+          }
           // 2nd/3rd 요소 (options + instanceName) 그대로 보존 — slice spread.
-          return [resolvePluginPath(entry[0]), ...entry.slice(1)];
+          return [resolvedPath, ...entry.slice(1)];
         } catch {
           return entry;
         }
       }
       try {
-        return resolvePluginPath(entry);
+        const resolvedPath = resolvePluginPath(entry);
+        const shouldInjectRoot =
+          isRootImportPluginName(entry) ||
+          isRootImportPluginName(applyBabelPluginPrefix(entry)) ||
+          isRootImportPluginName(resolvedPath);
+        return shouldInjectRoot
+          ? [resolvedPath, injectRootImportRootOption(undefined, projectRoot)]
+          : resolvedPath;
       } catch {
         return entry;
       }

--- a/packages/react-native/src/plugins/internal.ts
+++ b/packages/react-native/src/plugins/internal.ts
@@ -18,6 +18,8 @@ export interface BabelInstance {
 }
 
 export interface BabelTransformOptions {
+  cwd?: string;
+  root?: string;
   filename?: string;
   presets?: unknown[];
   plugins?: unknown[];

--- a/packages/react-native/src/plugins/types.ts
+++ b/packages/react-native/src/plugins/types.ts
@@ -14,6 +14,8 @@ export interface PluginConfig {
   assetExts: string[];
   /** RN runtime platform — codegen / asset 의 platform 분기. */
   rnPlatform: 'ios' | 'android';
+  /** Metro transformer dev flag. 미지정 시 기존 dev-server 기본값인 true. */
+  dev?: boolean;
   /** Source 확장자 (`.ts` / `.tsx` / `.js` / `.jsx` / `.svg` 등). */
   sourceExts: string[];
   /** Metro 호환 custom file transformer path (예: react-native-svg-transformer). */

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -390,6 +390,7 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
       projectRoot,
       assetExts,
       rnPlatform,
+      dev,
       sourceExts,
       babelTransformerPath: extra?.babelTransformerPath,
     }),

--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -1788,6 +1788,70 @@ test "ESM re-export: named re-export from CJS binds via require getter (#1425)" 
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require_registry().getAssetByID") != null);
 }
 
+test "CJS raw require namespace keeps lazy getter require target" {
+    // ReactNativePrivateInterface pattern: a CJS namespace is read through raw
+    // require(), then one getter property lazily requires another module. The
+    // namespace read makes every getter observable, including Flow-typed getter
+    // bodies that have no direct named export use yet.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "rn-private.js",
+        \\// @flow strict-local
+        \\import typeof ReactFiberErrorDialog from './dialog.js';
+        \\
+        \\module.exports = {
+        \\  get ReactFiberErrorDialog(): ReactFiberErrorDialog {
+        \\    return require('./dialog.js').default;
+        \\  },
+        \\};
+    );
+    try writeFile(tmp.dir, "dialog.js",
+        \\// @flow strict-local
+        \\export type CapturedError = {
+        \\  +componentStack: string,
+        \\  +error: mixed,
+        \\};
+        \\
+        \\const ReactFiberErrorDialog = {
+        \\  showErrorDialog(_capturedError: CapturedError): boolean {
+        \\    return false;
+        \\  },
+        \\};
+        \\export default ReactFiberErrorDialog;
+    );
+    try writeFile(tmp.dir, "renderer.js",
+        \\const iface = require('./rn-private.js');
+        \\if (typeof iface.ReactFiberErrorDialog.showErrorDialog !== 'function') {
+        \\  throw new Error('missing dialog');
+        \\}
+    );
+    try writeFile(tmp.dir, "entry.js",
+        \\require('./renderer.js');
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .minify_syntax = true,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .flow = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "showErrorDialog") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "missing dialog") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "return !1") != null or
+        std.mem.indexOf(u8, result.output, "return!1") != null);
+}
+
 test "ESM namespace import: CJS named re-export member binds via require getter" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -2124,6 +2124,86 @@ test "ESM ns-access: opaque path (bare ref after member access) doesn't leak" {
     // leak 발생 시 `zig build test` 가 테스트 실패 처리.
 }
 
+test "ESM wrapped static import under strict order does not emit raw require" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath("node_modules/@tanstack/react-query/build/modern");
+    try tmp.dir.makePath("node_modules/@tanstack/query-core/build/modern");
+    try writeFile(tmp.dir, "entry.js",
+        \\import { useQueries } from '@tanstack/react-query';
+        \\console.log(useQueries());
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/react-query/package.json",
+        \\{
+        \\  "name": "@tanstack/react-query",
+        \\  "type": "module",
+        \\  "main": "build/legacy/index.cjs",
+        \\  "module": "build/legacy/index.js",
+        \\  "exports": {
+        \\    ".": {
+        \\      "import": { "default": "./build/modern/index.js" },
+        \\      "require": { "default": "./build/modern/index.cjs" }
+        \\    }
+        \\  },
+        \\  "sideEffects": false
+        \\}
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/query-core/package.json",
+        \\{
+        \\  "name": "@tanstack/query-core",
+        \\  "type": "module",
+        \\  "exports": {
+        \\    ".": { "import": { "default": "./build/modern/index.js" } }
+        \\  },
+        \\  "sideEffects": false
+        \\}
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/query-core/build/modern/index.js",
+        \\export const core = 'core';
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/react-query/build/modern/types.js",
+        \\export {};
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/react-query/build/modern/index.js",
+        \\export * from "@tanstack/query-core";
+        \\export * from "./types.js";
+        \\import { useQueries } from './useQueries.js';
+        \\import { queryOptions } from './queryOptions.js';
+        \\export { useQueries, queryOptions };
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/react-query/build/modern/useQueries.js",
+        \\export function useQueries() {
+        \\  return 'queries';
+        \\}
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/react-query/build/modern/queryOptions.js",
+        \\export function queryOptions() {
+        \\  return 'options';
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .strict_execution_order = true,
+        .minify_syntax = true,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "queries") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./useQueries.js\")") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./queryOptions.js\")") == null);
+}
+
 // ============================================================
 // `.cjs` / `.cts` 는 Node CommonJS 컨벤션상 ESM 구문 (`import`/`export`) 거부.
 // 이전엔 graph/parser_setup.zig 가 모든 모듈을 is_module=true 로 promote 해서

--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -2310,6 +2310,127 @@ test "ESM wrapped static import under strict order does not emit raw require" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./queryOptions.js\")") == null);
 }
 
+test "ESM wrapped barrel namespace import under strict order does not emit raw require" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath("node_modules/@tanstack/react-query/build/modern");
+    try tmp.dir.makePath("node_modules/@tanstack/query-core/build/modern");
+    try writeFile(tmp.dir, "entry.js",
+        \\import * as ReactQuery from '@tanstack/react-query';
+        \\console.log(ReactQuery.useQueries(), ReactQuery.QueryClientProvider());
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/react-query/package.json",
+        \\{
+        \\  "name": "@tanstack/react-query",
+        \\  "type": "module",
+        \\  "main": "build/legacy/index.cjs",
+        \\  "module": "build/legacy/index.js",
+        \\  "exports": {
+        \\    ".": {
+        \\      "import": { "default": "./build/modern/index.js" },
+        \\      "require": { "default": "./build/modern/index.cjs" }
+        \\    }
+        \\  },
+        \\  "sideEffects": false
+        \\}
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/query-core/package.json",
+        \\{
+        \\  "name": "@tanstack/query-core",
+        \\  "type": "module",
+        \\  "exports": {
+        \\    ".": { "import": { "default": "./build/modern/index.js" } }
+        \\  },
+        \\  "sideEffects": false
+        \\}
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/query-core/build/modern/index.js",
+        \\export const QueryClient = 'core-client';
+        \\export const skipToken = 'skip-token';
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/react-query/build/modern/types.js",
+        \\export {};
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/react-query/build/modern/index.js",
+        \\export * from "@tanstack/query-core";
+        \\export * from "./types.js";
+        \\import { useQueries } from './useQueries.js';
+        \\import { useQuery } from './useQuery.js';
+        \\import { useMutation } from './useMutation.js';
+        \\import { QueryClientProvider, useQueryClient } from './QueryClientProvider.js';
+        \\import { HydrationBoundary } from './HydrationBoundary.js';
+        \\import { QueryErrorResetBoundary, useQueryErrorResetBoundary } from './QueryErrorResetBoundary.js';
+        \\export {
+        \\  useQueries,
+        \\  useQuery,
+        \\  useMutation,
+        \\  QueryClientProvider,
+        \\  useQueryClient,
+        \\  HydrationBoundary,
+        \\  QueryErrorResetBoundary,
+        \\  useQueryErrorResetBoundary,
+        \\};
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/react-query/build/modern/useQueries.js",
+        \\export function useQueries() {
+        \\  return 'queries';
+        \\}
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/react-query/build/modern/useQuery.js",
+        \\export function useQuery() {
+        \\  return 'query';
+        \\}
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/react-query/build/modern/useMutation.js",
+        \\export function useMutation() {
+        \\  return 'mutation';
+        \\}
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/react-query/build/modern/QueryClientProvider.js",
+        \\export function QueryClientProvider() {
+        \\  return 'provider';
+        \\}
+        \\export function useQueryClient() {
+        \\  return 'client';
+        \\}
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/react-query/build/modern/HydrationBoundary.js",
+        \\export function HydrationBoundary() {
+        \\  return 'hydration';
+        \\}
+    );
+    try writeFile(tmp.dir, "node_modules/@tanstack/react-query/build/modern/QueryErrorResetBoundary.js",
+        \\export function QueryErrorResetBoundary() {
+        \\  return 'boundary';
+        \\}
+        \\export function useQueryErrorResetBoundary() {
+        \\  return 'reset';
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .strict_execution_order = true,
+        .minify_syntax = true,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "queries") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "provider") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./useQueries.js\")") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./QueryClientProvider.js\")") == null);
+}
+
 // ============================================================
 // `.cjs` / `.cts` 는 Node CommonJS 컨벤션상 ESM 구문 (`import`/`export`) 거부.
 // 이전엔 graph/parser_setup.zig 가 모든 모듈을 is_module=true 로 promote 해서

--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -1852,6 +1852,48 @@ test "CJS raw require namespace keeps lazy getter require target" {
         std.mem.indexOf(u8, result.output, "return!1") != null);
 }
 
+test "ESM re-export: CJS require member access keeps re-export source body" {
+    // RN asset loader pattern: generated asset modules call
+    // `require("AssetRegistry").registerAsset(...)`. The raw require observes
+    // the ESM facade namespace, so the facade's CJS re-export source must also
+    // keep the actual export fact body.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "registry.js",
+        \\const assets = [];
+        \\function registerAsset(asset) { assets.push(asset); return assets.length; }
+        \\function getAssetByID(id) { return assets[id - 1]; }
+        \\module.exports = { registerAsset, getAssetByID };
+    );
+    try writeFile(tmp.dir, "AssetRegistry.js",
+        \\export { registerAsset, getAssetByID } from './registry.js';
+    );
+    try writeFile(tmp.dir, "asset.js",
+        \\module.exports = require('./AssetRegistry.js').registerAsset({ name: 'test' });
+    );
+    try writeFile(tmp.dir, "entry.js",
+        \\const asset = require('./asset.js');
+        \\globalThis.asset = asset;
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "registerAsset(asset)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "module.exports = { registerAsset, getAssetByID }") != null);
+}
+
 test "ESM namespace import: CJS named re-export member binds via require getter" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/bundler_test/expressions.zig
+++ b/src/bundler/bundler_test/expressions.zig
@@ -690,6 +690,46 @@ test "Expression: nullish coalescing across modules" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "\"default\"") != null);
 }
 
+test "Expression: imported class method nullish temp is method scoped for ES5" {
+    const compat = @import("../../transformer/compat.zig");
+
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { C } from './dep';
+        \\function hash(x) { return x; }
+        \\function get(x) { return x; }
+        \\console.log(new C().m({ queryKey: 1 }, hash, get));
+    );
+    try writeFile(tmp.dir, "dep.ts",
+        \\export class C {
+        \\  m(options, hash, get) {
+        \\    var queryKey = options.queryKey;
+        \\    var queryHash = options.queryHash ?? hash(queryKey);
+        \\    var query = get(queryHash);
+        \\    return query;
+        \\  }
+        \\}
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .format = .cjs,
+        .unsupported = compat.fromESTarget(.es5),
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "function(options,hash,get) {\n\t\tvar _a") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "(_a = options.queryHash)") != null or
+        std.mem.indexOf(u8, result.output, "(_a=options.queryHash)") != null);
+}
+
 test "Expression: logical assignment across modules" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -176,6 +176,57 @@ pub fn buildSkipNodes(allocator: std.mem.Allocator, ast: *const Ast, skip_import
     return skip_nodes;
 }
 
+fn importDeclarationHasNamespaceSpecifier(ast: *const Ast, import_decl: *const @import("../../parser/ast.zig").Node) bool {
+    const ie = import_decl.data.extra;
+    if (ie + 2 >= ast.extra_data.items.len) return false;
+    const specs_start = ast.extra_data.items[ie];
+    const specs_len = ast.extra_data.items[ie + 1];
+    if (specs_len == 0) return false;
+    if (specs_start + specs_len > ast.extra_data.items.len) return false;
+
+    for (ast.extra_data.items[specs_start .. specs_start + specs_len]) |raw_idx| {
+        if (raw_idx >= ast.nodes.items.len) continue;
+        if (ast.nodes.items[raw_idx].tag == .import_namespace_specifier) return true;
+    }
+    return false;
+}
+
+fn markReactNativeWrappedBindingImports(
+    self: *const Linker,
+    ast: *const Ast,
+    module: *const Module,
+    skip_nodes: *std.DynamicBitSet,
+) !void {
+    if (self.graph.resolve_cache.platform != .react_native) return;
+    if (!module.wrap_kind.isWrapped()) return;
+
+    var linked_specifiers = std.StringHashMap(void).init(self.allocator);
+    defer linked_specifiers.deinit();
+    for (module.import_records) |rec| {
+        try linked_specifiers.put(rec.specifier, {});
+    }
+    if (linked_specifiers.count() == 0) return;
+
+    for (ast.nodes.items, 0..) |inode, inode_idx| {
+        if (inode.tag != .import_declaration) continue;
+        const ie = inode.data.extra;
+        if (ie + 3 > ast.extra_data.items.len) continue;
+        const specs_len = ast.extra_data.items[ie + 1];
+        if (specs_len == 0) continue;
+        if (importDeclarationHasNamespaceSpecifier(ast, &inode)) continue;
+
+        const source_idx: NodeIndex = @enumFromInt(ast.extra_data.items[ie + 2]);
+        if (source_idx.isNone()) continue;
+        const src_node = ast.getNode(source_idx);
+        if (src_node.tag != .string_literal) continue;
+        const raw = ast.getText(src_node.data.string_ref);
+        const spec = Ast.stripStringQuotes(raw);
+        if (linked_specifiers.contains(spec)) {
+            skip_nodes.set(inode_idx);
+        }
+    }
+}
+
 /// rename 문자열을 dupe 해서 metadata 가 소유하도록 저장 (#2429). canonical_strings /
 /// unified_result 의 borrowed slice 는 per-chunk recompute 또는 deinit 시 freed →
 /// 0xAA UAF 발생. dupe + owned 추적으로 회피.
@@ -250,8 +301,11 @@ pub fn buildMetadataForAst(
     // scope hoisted ESM 타겟에 대한 rename/preamble도 생성.
     if (m.wrap_kind.isWrapped() and m.semantic == null) {
         const node_count = ast.nodes.items.len;
+        var skip_nodes = try std.DynamicBitSet.initEmpty(self.allocator, node_count);
+        errdefer skip_nodes.deinit();
+        try markReactNativeWrappedBindingImports(self, ast, &m, &skip_nodes);
         return .{
-            .skip_nodes = try std.DynamicBitSet.initEmpty(self.allocator, node_count),
+            .skip_nodes = skip_nodes,
             .renames = std.AutoHashMap(u32, []const u8).init(self.allocator),
             .final_exports = null,
             .symbol_ids = &.{},
@@ -273,6 +327,7 @@ pub fn buildMetadataForAst(
         break :blk result;
     };
     errdefer skip_nodes.deinit();
+    try markReactNativeWrappedBindingImports(self, ast, &m, &skip_nodes);
 
     var renames = std.AutoHashMap(u32, []const u8).init(self.allocator);
     errdefer renames.deinit();
@@ -771,7 +826,10 @@ pub fn buildMetadataForAst(
         if (m.wrap_kind.isWrapped()) {
             var hoisted_specifiers = std.StringHashMap(void).init(self.allocator);
             defer hoisted_specifiers.deinit();
+            var linked_specifiers = std.StringHashMap(void).init(self.allocator);
+            defer linked_specifiers.deinit();
             for (m.import_records, 0..) |rec, rec_i| {
+                try linked_specifiers.put(rec.specifier, {});
                 if (rec.resolved.isNone()) {
                     // Lazy barrel tree-shaking can intentionally leave unrequested
                     // static import records unresolved. The source AST still has
@@ -814,11 +872,12 @@ pub fn buildMetadataForAst(
                 }
             }
             // AST에서 해당 specifier의 import_declaration 노드를 skip
-            if (hoisted_specifiers.count() > 0) {
+            if (hoisted_specifiers.count() > 0 or linked_specifiers.count() > 0) {
                 for (ast.nodes.items, 0..) |inode, inode_idx| {
                     if (inode.tag != .import_declaration) continue;
                     const ie = inode.data.extra;
                     if (ie + 3 > ast.extra_data.items.len) continue;
+                    const specs_len = ast.extra_data.items[ie + 1];
                     const source_idx: NodeIndex = @enumFromInt(ast.extra_data.items[ie + 2]);
                     if (source_idx.isNone()) continue;
                     const src_node = ast.getNode(source_idx);
@@ -826,6 +885,25 @@ pub fn buildMetadataForAst(
                     const raw = ast.getText(src_node.data.string_ref);
                     const spec = Ast.stripStringQuotes(raw);
                     if (hoisted_specifiers.contains(spec)) {
+                        skip_nodes.set(inode_idx);
+                    } else if (specs_len > 0 and linked_specifiers.contains(spec) and !importDeclarationHasNamespaceSpecifier(ast, &inode)) {
+                        // Wrapped ESM lowers retained import declarations as CJS
+                        // assignments in the factory body. For named/default
+                        // imports, linker metadata already represents the value
+                        // through canonical renames or preamble/init calls. If a
+                        // binding import declaration reaches body codegen here,
+                        // React Native IIFE has no global require and crashes.
+                        // Namespace imports are the exception: body codegen may
+                        // need to assign the namespace object value, so keep them
+                        // unless the target-specific branch above marked them.
+                        skip_nodes.set(inode_idx);
+                    } else if (specs_len > 0 and !linked_specifiers.contains(spec)) {
+                        // Tree-shaking can remove an unrequested barrel import
+                        // record while the transformed AST still contains the
+                        // original import declaration. Wrapped module codegen
+                        // lowers remaining import declarations to require().
+                        // React Native has no global require in that factory
+                        // scope, so orphaned binding imports must be elided here.
                         skip_nodes.set(inode_idx);
                     }
                 }

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -772,7 +772,19 @@ pub fn buildMetadataForAst(
             var hoisted_specifiers = std.StringHashMap(void).init(self.allocator);
             defer hoisted_specifiers.deinit();
             for (m.import_records, 0..) |rec, rec_i| {
-                if (rec.resolved.isNone()) continue;
+                if (rec.resolved.isNone()) {
+                    // Lazy barrel tree-shaking can intentionally leave unrequested
+                    // static import records unresolved. The source AST still has
+                    // the original import declaration, and wrapped IIFE/CJS
+                    // codegen would lower it to a raw `require("...")`. React
+                    // Native does not provide a global require there, so skip the
+                    // original import node when graph linking also decided not to
+                    // resolve this record.
+                    if (!self.graph.shouldLinkResolvedRecordForModule(module_index, rec_i, rec)) {
+                        try hoisted_specifiers.put(rec.specifier, {});
+                    }
+                    continue;
+                }
                 const tidx = @intFromEnum(rec.resolved);
                 const tmod = self.graph.getModule(rec.resolved) orelse continue;
                 if (tmod.wrap_kind == .none) {

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -327,7 +327,9 @@ pub fn buildMetadataForAst(
         break :blk result;
     };
     errdefer skip_nodes.deinit();
-    try markReactNativeWrappedBindingImports(self, ast, &m, &skip_nodes);
+    // wrap_kind.isWrapped() 인 경우 아래 본 분기 (`if (m.wrap_kind.isWrapped())`)
+    // 가 같은 노드를 idempotent 하게 set 하므로 RN 헬퍼 호출은 early-return path
+    // (semantic == null) 에서만 필요하다.
 
     var renames = std.AutoHashMap(u32, []const u8).init(self.allocator);
     errdefer renames.deinit();

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -732,6 +732,11 @@ pub const TreeShaker = struct {
     /// (#2683 PR β-2) RN core `module.exports = { get DevSettings() { require('./X') } }`
     /// 같은 single-statement object literal 의 sub-unit 단위 reachability.
     fn lazyRequireMatchedExportUsed(self: *const TreeShaker, mod_idx: u32, rec_span: Span) bool {
+        // `require("./cjs")` returns the whole CJS namespace. If that namespace is
+        // marked live with the "*" sentinel, every lazy getter is observable even
+        // when no individual getter export was recorded as used yet.
+        if (self.isExportUsed(mod_idx, ALL_EXPORTS_SENTINEL)) return true;
+
         const m = self.getModule(mod_idx) orelse return true;
         const ast = &(m.ast orelse return true);
         if (mod_idx >= self.module_stmt_infos.len) return true;

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -982,20 +982,31 @@ pub const TreeShaker = struct {
                             if (!try import_records.importRecordBelongsToStmt(self, @intCast(item.mod), infos, @intCast(item.stmt), @intCast(rec_i))) continue;
                             const target_mod_idx = @intFromEnum(rec.resolved);
                             const target_module = self.graph.getModule(rec.resolved) orelse continue;
-                            if (target_module.wrap_kind != .cjs) continue;
-                            if (!self.isExportUsed(item.mod, ALL_EXPORTS_SENTINEL) and
-                                !self.isExportUsed(@intCast(target_mod_idx), ALL_EXPORTS_SENTINEL) and
-                                self.hasAnyUsedExportDirect(@intCast(target_mod_idx)) and
-                                cjs_patterns.moduleExportsRequireProxyMatches(o, infos, @intCast(item.stmt), rec.resolved))
-                            {
-                                const target_infos = module_stmt_infos[target_mod_idx] orelse {
-                                    try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
+                            if (target_module.wrap_kind == .cjs) {
+                                if (!self.isExportUsed(item.mod, ALL_EXPORTS_SENTINEL) and
+                                    !self.isExportUsed(@intCast(target_mod_idx), ALL_EXPORTS_SENTINEL) and
+                                    self.hasAnyUsedExportDirect(@intCast(target_mod_idx)) and
+                                    cjs_patterns.moduleExportsRequireProxyMatches(o, infos, @intCast(item.stmt), rec.resolved))
+                                {
+                                    const target_infos = module_stmt_infos[target_mod_idx] orelse {
+                                        try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
+                                        continue;
+                                    };
+                                    try self.seedSideEffectStmts(@intCast(target_mod_idx), target_infos, &queue, reachable_stmts);
                                     continue;
-                                };
-                                try self.seedSideEffectStmts(@intCast(target_mod_idx), target_infos, &queue, reachable_stmts);
+                                }
+                                try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
                                 continue;
                             }
-                            try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
+                            if (target_module.wrap_kind.isWrapped()) {
+                                // `require()` observes the module namespace. For an
+                                // ESM facade, the facade body alone is not enough:
+                                // its re-export sources contain the actual CJS
+                                // export facts used by generated RN asset modules
+                                // such as `require(AssetRegistry).registerAsset(...)`.
+                                try self.markAndSeedAllStmts(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
+                                try self.seedReExportSourcesForRequireNamespace(@intCast(target_mod_idx), &queue, module_stmt_infos, reachable_stmts);
+                            }
                         }
                     }
                 }
@@ -1768,6 +1779,31 @@ pub const TreeShaker = struct {
         try self.markAllExportsUsed(mod_idx);
         self.included.set(mod_idx);
         try self.seedAllStmts(mod_idx, queue, module_stmt_infos, reachable_stmts);
+    }
+
+    fn seedReExportSourcesForRequireNamespace(
+        self: *TreeShaker,
+        mod_idx: u32,
+        queue: *std.ArrayListUnmanaged(BfsItem),
+        module_stmt_infos: []?StmtInfos,
+        reachable_stmts: []?std.DynamicBitSet,
+    ) std.mem.Allocator.Error!void {
+        const m = self.getModule(mod_idx) orelse return;
+        for (m.export_bindings) |eb| {
+            if (!eb.kind.isAnyReExport()) continue;
+            const rec_idx = eb.import_record_index orelse continue;
+            if (rec_idx >= m.import_records.len) continue;
+            const src_idx = m.import_records[rec_idx].resolved;
+            const src_module = self.graph.getModule(src_idx) orelse continue;
+            const src = @intFromEnum(src_idx);
+            if (eb.kind == .re_export_star or eb.kind.isReExportAll()) {
+                try self.markAndSeedAllStmts(@intCast(src), queue, module_stmt_infos, reachable_stmts);
+            } else if (src_module.wrap_kind == .cjs) {
+                try self.seedCjsExportOrAll(@intCast(src), m.exportBindingLocalName(eb), queue, module_stmt_infos, reachable_stmts);
+            } else {
+                try self.seedExport(src, m.exportBindingLocalName(eb), queue, module_stmt_infos, reachable_stmts);
+            }
+        }
     }
 
     fn seedModuleExportsRequireProxyTargetsAll(

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -1796,7 +1796,7 @@ pub const TreeShaker = struct {
             const src_idx = m.import_records[rec_idx].resolved;
             const src_module = self.graph.getModule(src_idx) orelse continue;
             const src = @intFromEnum(src_idx);
-            if (eb.kind == .re_export_star or eb.kind.isReExportAll()) {
+            if (eb.kind.isReExportAll()) {
                 try self.markAndSeedAllStmts(@intCast(src), queue, module_stmt_infos, reachable_stmts);
             } else if (src_module.wrap_kind == .cjs) {
                 try self.seedCjsExportOrAll(@intCast(src), m.exportBindingLocalName(eb), queue, module_stmt_infos, reachable_stmts);

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -2915,6 +2915,20 @@ test "ES2020: temp var hoisted for ?? in preserved class method" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "(_a=options.queryHash)") != null);
 }
 
+test "ES2020: temp var hoisted inside async state machine" {
+    var r = try e2eTarget(std.testing.allocator, "async function f(context){return context.fetchOptions?.meta;}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function(_state){{var _a;") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "(_a=context.fetchOptions)") != null);
+}
+
+test "ES2020: temp var hoisted inside generator state machine" {
+    var r = try e2eTarget(std.testing.allocator, "function* f(context){yield 1;return context.fetchOptions?.meta;}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function(_state){{var _a;") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "(_a=context.fetchOptions)") != null);
+}
+
 test "ES2020: temp var hoisted for ?. in function" {
     var r = try e2eTarget(std.testing.allocator, "function f(){return foo()?.bar;}", .es2019);
     defer r.deinit();

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -514,6 +514,17 @@ test "ES5: async generator with await wraps via __await (#1911)" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__await(") != null);
 }
 
+test "ES5: async generator state temps are not redeclared inside callback (#1911)" {
+    var r = try e2eTarget(
+        std.testing.allocator,
+        "async function* g() { yield 1; await Promise.resolve(); yield 2; } async function f(){ for await (var v of g()) {} }",
+        .es5,
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__asyncGenerator(this,arguments,") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function(_state){{var _a") == null);
+}
+
 test "ES5: regular async function still uses __async (not __asyncGenerator) (#1911 regression)" {
     // is_async + !is_generator 케이스가 새 분기로 잘못 빠지지 않게 회귀 방지.
     var r = try e2eTarget(std.testing.allocator, "async function f() { return await Promise.resolve(1); }", .es5);
@@ -3261,6 +3272,7 @@ test "ES5: for-await-of hoists loop var to function top (#1901)" {
         std.mem.indexOf(u8, r.output, ",v=") != null or
         std.mem.indexOf(u8, r.output, ",v,") != null;
     try std.testing.expect(has_v_decl);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function(_state){{var _a") == null);
 }
 
 test "ES5: async for-in body extracts await into state machine" {

--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -2901,6 +2901,20 @@ test "ES2020: temp var hoisted for ?? in function" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "_a=foo()") != null);
 }
 
+test "ES2020: temp var hoisted for ?? in class method" {
+    var r = try e2eTarget(std.testing.allocator, "class C{m(options){var queryHash=options.queryHash??hash(options.queryKey);return queryHash;}}", .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "value:function(options){var _a;") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "(_a=options.queryHash)") != null);
+}
+
+test "ES2020: temp var hoisted for ?? in preserved class method" {
+    var r = try e2eTarget(std.testing.allocator, "class C{m(options){return options.queryHash??hash(options.queryKey);}}", .es2019);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "m(options){var _a;") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "(_a=options.queryHash)") != null);
+}
+
 test "ES2020: temp var hoisted for ?. in function" {
     var r = try e2eTarget(std.testing.allocator, "function f(){return foo()?.bar;}", .es2019);
     defer r.deinit();

--- a/src/codegen/codegen_test/private_jsx_advanced.zig
+++ b/src/codegen/codegen_test/private_jsx_advanced.zig
@@ -58,6 +58,37 @@ test "private method: es5 → WeakSet + function + prototype" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "__classPrivateMethodGet(this,_bar,_bar_fn).call(this)") != null);
 }
 
+test "private method: nullish temp is hoisted into standalone function" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Foo {
+        \\  #compute(options) {
+        \\    return options.value ?? false;
+        \\  }
+        \\  method(options) { return this.#compute(options); }
+        \\}
+    , .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function _compute_fn(options){var _a;") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "(_a=options.value)") != null);
+}
+
+test "private method: conditional nullish temp is hoisted into standalone function" {
+    var r = try e2eTarget(std.testing.allocator,
+        \\class Foo {
+        \\  #compute() {
+        \\    return (typeof this.options.refetchInterval === "function"
+        \\      ? this.options.refetchInterval(this.query)
+        \\      : this.options.refetchInterval) ?? false;
+        \\  }
+        \\  method() { return this.#compute(); }
+        \\}
+    , .es5);
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "function _compute_fn(){var _a;") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "(_a=(typeof this.options.refetchInterval===\"function\"") != null or
+        std.mem.indexOf(u8, r.output, "(_a=(typeof this.options.refetchInterval==\"function\"") != null);
+}
+
 test "private method: multiple methods" {
     var r = try e2eTarget(std.testing.allocator,
         \\class Foo {

--- a/src/transformer/es2015_class/constructors.zig
+++ b/src/transformer/es2015_class/constructors.zig
@@ -197,6 +197,8 @@ pub fn Constructors(comptime Transformer: type) type {
             if (nt_ctx) |ctx| self.new_target_ctx = ctx;
             defer self.new_target_ctx = saved_nt;
 
+            const saved_temp_counter = self.temp_var_counter;
+
             var new_body = try self.visitNode(body_idx);
 
             // arrow가 this/arguments를 사용했으면 var _this = this; 등 삽입
@@ -228,6 +230,11 @@ pub fn Constructors(comptime Transformer: type) type {
 
                 new_body = try self.prependStatementsToBody(new_body, capture_stmts[0..capture_count]);
             }
+
+            if (self.temp_var_counter > saved_temp_counter and !new_body.isNone()) {
+                new_body = try self.hoistTempVars(new_body, saved_temp_counter, span);
+            }
+            self.temp_var_counter = saved_temp_counter;
 
             self.arrow_this_depth = saved_arrow_depth;
             self.needs_this_var = saved_needs_this;

--- a/src/transformer/es2015_class/methods.zig
+++ b/src/transformer/es2015_class/methods.zig
@@ -119,6 +119,7 @@ pub fn Methods(comptime Transformer: type) type {
                     defer es_helpers.popArrowEnv(self, arrow_env);
 
                     const sm_result = try GenMod.buildStateMachine(self, body_idx, span);
+                    defer self.generator_temp_var_spans.clearRetainingCapacity();
                     if (!sm_result.body.isNone()) {
                         const gen_call = try GenMod.buildGeneratorHelperCall(self, sm_result.body, span);
                         const gen_wrapper = try es_helpers.wrapInFunction(self, gen_call, span);

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -99,10 +99,11 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             const saved_temp_counter = self.temp_var_counter;
 
             const sm_result = try buildStateMachine(self, body_idx, span);
+            defer self.generator_temp_var_spans.clearRetainingCapacity();
             if (sm_result.body.isNone()) return .none;
             var sm_body = sm_result.body;
             if (self.temp_var_counter > saved_temp_counter) {
-                sm_body = try self.hoistTempVars(sm_body, saved_temp_counter, span);
+                sm_body = try self.hoistTempVarsSkippingSpans(sm_body, saved_temp_counter, span, self.generator_temp_var_spans.items);
             }
             self.temp_var_counter = saved_temp_counter;
 
@@ -226,7 +227,6 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 const declarator = try es_helpers.makeDeclarator(self, binding, .none, span);
                 try self.scratch.append(self.allocator, declarator);
             }
-            self.generator_temp_var_spans.clearRetainingCapacity();
             return es_helpers.makeVarDeclaration(self, self.scratch.items[scratch_top..], .@"var", span);
         }
 

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -96,8 +96,15 @@ pub fn ES2015Generator(comptime Transformer: type) type {
 
             const new_params = try self.visitExtraList(.{ .start = params_start, .len = params_len });
 
+            const saved_temp_counter = self.temp_var_counter;
+
             const sm_result = try buildStateMachine(self, body_idx, span);
             if (sm_result.body.isNone()) return .none;
+            var sm_body = sm_result.body;
+            if (self.temp_var_counter > saved_temp_counter) {
+                sm_body = try self.hoistTempVars(sm_body, saved_temp_counter, span);
+            }
+            self.temp_var_counter = saved_temp_counter;
 
             // generator function 이름이 있으면 프로토타입 체인 설정을 위해 __generator에 전달.
             // #1756: makeIdentifierRefFromSpan 만 쓰면 symbol_id 가 전파되지 않아
@@ -109,7 +116,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
                 try self.makeIdentifierRefWithSymbol(self.ast.getNode(new_name).data.string_ref, new_name)
             else
                 .none;
-            const gen_call = try buildGeneratorHelperCallWithProto(self, sm_result.body, genFn_ref, span);
+            const gen_call = try buildGeneratorHelperCallWithProto(self, sm_body, genFn_ref, span);
 
             // return __generator(...) 문
             const ret_stmt = try self.ast.addNode(.{

--- a/src/transformer/es2017.zig
+++ b/src/transformer/es2017.zig
@@ -264,8 +264,12 @@ pub fn ES2017(comptime Transformer: type) type {
             // 같은 이름을 다시 hoist 하지 않도록 한다.
             const saved_temp_counter = self.temp_var_counter;
 
-            const sm_result = try GenMod.buildStateMachine(self, body_idx, span);
+            var sm_result = try GenMod.buildStateMachine(self, body_idx, span);
             if (sm_result.body.isNone()) return .none;
+            if (self.temp_var_counter > saved_temp_counter) {
+                sm_result.body = try self.hoistTempVars(sm_result.body, saved_temp_counter, span);
+            }
+            self.temp_var_counter = saved_temp_counter;
 
             const gen_call = try GenMod.buildGeneratorHelperCall(self, sm_result.body, span);
             // __async는 fn.apply()로 함수를 호출하므로 iterator를 직접 전달 불가.
@@ -292,16 +296,11 @@ pub fn ES2017(comptime Transformer: type) type {
                 try self.scratch.append(self.allocator, return_stmt);
                 break :blk try self.ast.addNodeList(self.scratch.items[scratch_top..]);
             };
-            var wrapper_body = try self.ast.addNode(.{
+            const wrapper_body = try self.ast.addNode(.{
                 .tag = .block_statement,
                 .span = span,
                 .data = .{ .list = body_list },
             });
-
-            if (self.temp_var_counter > saved_temp_counter) {
-                wrapper_body = try self.hoistTempVars(wrapper_body, saved_temp_counter, span);
-            }
-            self.temp_var_counter = saved_temp_counter;
 
             // 일반 function으로 변환 (async + generator 플래그 모두 제거)
             const new_flags = flags & ~(ast_mod.FunctionFlags.is_async | @as(u32, ast_mod.FunctionFlags.is_generator));
@@ -332,6 +331,8 @@ pub fn ES2017(comptime Transformer: type) type {
             const params_idx: NodeIndex = self.readNodeIdx(e, 0);
             const body_idx: NodeIndex = self.readNodeIdx(e, 1);
 
+            const saved_temp_counter = self.temp_var_counter;
+
             const lowered = blk: {
                 // Async arrow skips ES2015Arrow.lowerArrowFunction(), so enter
                 // the arrow lexical environment while visiting params/body.
@@ -343,8 +344,12 @@ pub fn ES2017(comptime Transformer: type) type {
                 break :blk .{ .params_list = params_list, .sm_result = sm_result };
             };
             const params_list = lowered.params_list;
-            const sm_result = lowered.sm_result;
+            var sm_result = lowered.sm_result;
             if (sm_result.body.isNone()) return .none;
+            if (self.temp_var_counter > saved_temp_counter) {
+                sm_result.body = try self.hoistTempVars(sm_result.body, saved_temp_counter, span);
+            }
+            self.temp_var_counter = saved_temp_counter;
 
             const gen_call = try GenMod.buildGeneratorHelperCall(self, sm_result.body, span);
             const gen_wrapper_func = try es_helpers.wrapInFunction(self, gen_call, span);

--- a/src/transformer/es2017.zig
+++ b/src/transformer/es2017.zig
@@ -259,15 +259,18 @@ pub fn ES2017(comptime Transformer: type) type {
             const new_params = try self.visitExtraList(.{ .start = params_start, .len = params_len });
 
             // visitFunctionLike 를 거치지 않으므로 임시 변수 카운터를 직접 관리한다 (#1960).
-            // state machine 안에서 destructuring lowering 이 만든 _a 등을 outer wrapper body 에
-            // hoist 하고 함수 스코프 종료 시 카운터를 복원해 outer scope 의 hoistTempVars 가
-            // 같은 이름을 다시 hoist 하지 않도록 한다.
+            // state machine 안에서 optional chaining/nullish/destructuring lowering 이 만든
+            // callback-local temp 는 __generator callback 안에 hoist 하고, for-await/yield
+            // extraction 이 만든 state temp 는 sm_result.var_decl 로 wrapper top 에만 둔다.
+            // 함수 스코프 종료 시 카운터를 복원해 outer scope 의 hoistTempVars 가 같은 이름을
+            // 다시 hoist 하지 않도록 한다.
             const saved_temp_counter = self.temp_var_counter;
 
             var sm_result = try GenMod.buildStateMachine(self, body_idx, span);
+            defer self.generator_temp_var_spans.clearRetainingCapacity();
             if (sm_result.body.isNone()) return .none;
             if (self.temp_var_counter > saved_temp_counter) {
-                sm_result.body = try self.hoistTempVars(sm_result.body, saved_temp_counter, span);
+                sm_result.body = try self.hoistTempVarsSkippingSpans(sm_result.body, saved_temp_counter, span, self.generator_temp_var_spans.items);
             }
             self.temp_var_counter = saved_temp_counter;
 
@@ -345,9 +348,10 @@ pub fn ES2017(comptime Transformer: type) type {
             };
             const params_list = lowered.params_list;
             var sm_result = lowered.sm_result;
+            defer self.generator_temp_var_spans.clearRetainingCapacity();
             if (sm_result.body.isNone()) return .none;
             if (self.temp_var_counter > saved_temp_counter) {
-                sm_result.body = try self.hoistTempVars(sm_result.body, saved_temp_counter, span);
+                sm_result.body = try self.hoistTempVarsSkippingSpans(sm_result.body, saved_temp_counter, span, self.generator_temp_var_spans.items);
             }
             self.temp_var_counter = saved_temp_counter;
 

--- a/src/transformer/es_helpers.zig
+++ b/src/transformer/es_helpers.zig
@@ -1306,6 +1306,8 @@ pub fn buildStandaloneFunc(self: anytype, name: []const u8, method_idx: NodeInde
     const arrow_env = pushArrowEnv(self);
     defer popArrowEnv(self, arrow_env);
 
+    const saved_temp_counter = self.temp_var_counter;
+
     const new_params = try self.visitExtraList(.{ .start = params_start, .len = params_len });
 
     var new_body = try self.visitNode(body_idx);
@@ -1316,6 +1318,10 @@ pub fn buildStandaloneFunc(self: anytype, name: []const u8, method_idx: NodeInde
         const capture_count = try fillThisArgumentsCaptures(self, &capture_stmts, span);
         new_body = try self.prependStatementsToBody(new_body, capture_stmts[0..capture_count]);
     }
+    if (self.temp_var_counter > saved_temp_counter and !new_body.isNone()) {
+        new_body = try self.hoistTempVars(new_body, saved_temp_counter, span);
+    }
+    self.temp_var_counter = saved_temp_counter;
 
     const name_span = try self.ast.addString(name);
     const name_node = try makeBindingIdentifier(self, name_span);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -361,6 +361,7 @@ pub const Transformer = struct {
     pub const buildUniqueName = lists_mod.buildUniqueName;
     pub const buildVarDecl = lists_mod.buildVarDecl;
     pub const hoistTempVars = lists_mod.hoistTempVars;
+    pub const hoistTempVarsSkippingSpans = lists_mod.hoistTempVarsSkippingSpans;
 
     // ================================================================
     // Flow syntax 변환 — transformer/flow.zig로 위임

--- a/src/transformer/transformer/lists.zig
+++ b/src/transformer/transformer/lists.zig
@@ -283,6 +283,21 @@ pub fn buildVarDecl(self: *Transformer, name: []const u8, init_value: NodeIndex,
 /// 처럼 declaration 형태로 직접 emit 하는 패스가 있어 mergeAdjacentDecls 가 `var _a, _a = init, ...`
 /// 같은 어색한 출력을 만드는 회귀 방지 (#1960).
 pub fn hoistTempVars(self: *Transformer, body_idx: NodeIndex, saved_counter: u32, span: Span) Error!NodeIndex {
+    return hoistTempVarsSkippingSpans(self, body_idx, saved_counter, span, &.{});
+}
+
+/// 임시 변수 호이스팅: saved_counter..current counter 범위의 var _a, _b, ... 선언을 body 앞에 삽입.
+/// `skip_spans`에 들어있는 synthetic temp 이름은 선언하지 않는다.
+///
+/// generator state machine은 두 종류의 temp를 동시에 만든다.
+/// - generator_temp_var_spans: for-await/yield extraction처럼 resume 사이에 값이 유지돼야 하는
+///   state temp. wrapper function top에만 선언해야 한다.
+/// - temp_var_counter-only: optional chaining/nullish/destructuring lowering처럼 callback 한 번의
+///   평가 안에서만 쓰이는 expression temp. __generator callback 안에 선언해야 한다.
+///
+/// 이 helper는 state-machine callback-local hoist가 state temp를 다시 선언해 shadowing하지
+/// 않도록 skip 목록을 받는다.
+pub fn hoistTempVarsSkippingSpans(self: *Transformer, body_idx: NodeIndex, saved_counter: u32, span: Span, skip_spans: []const Span) Error!NodeIndex {
     const count = self.temp_var_counter - saved_counter;
     if (count == 0) return body_idx;
 
@@ -299,6 +314,7 @@ pub fn hoistTempVars(self: *Transformer, body_idx: NodeIndex, saved_counter: u32
     while (i < self.temp_var_counter) : (i += 1) {
         var buf: [16]u8 = undefined;
         const name = es_helpers.tempVarName(i, &buf);
+        if (tempNameInSpans(self, name, skip_spans)) continue;
         if (has_block and bodyHasTopLevelVarBinding(self, body_node, name)) continue;
         const name_span = try self.ast.addString(name);
         const binding = try self.ast.addNode(.{
@@ -323,6 +339,13 @@ pub fn hoistTempVars(self: *Transformer, body_idx: NodeIndex, saved_counter: u32
     });
 
     return self.prependStatementsToBody(body_idx, &.{var_decl});
+}
+
+fn tempNameInSpans(self: *const Transformer, name: []const u8, spans: []const Span) bool {
+    for (spans) |sp| {
+        if (std.mem.eql(u8, self.ast.getText(sp), name)) return true;
+    }
+    return false;
 }
 
 /// body (block_statement / program / function_body) 의 top-level var declaration 에서

--- a/src/transformer/transformer/members.zig
+++ b/src/transformer/transformer/members.zig
@@ -70,6 +70,11 @@ pub fn visitMethodDefinition(self: *Transformer, node: Node) Error!NodeIndex {
             params_span = pnode.span;
         }
     }
+    // Method params/body are a function scope. Temps produced by transforms such
+    // as `foo() ?? bar` must be declared inside the method body, not at the
+    // class/module scope.
+    const saved_temp_counter = self.temp_var_counter;
+
     var pp = try self.visitParamsCollectProperties(params_list_old);
     defer pp.prop_names.deinit(self.allocator);
 
@@ -134,6 +139,11 @@ pub fn visitMethodDefinition(self: *Transformer, node: Node) Error!NodeIndex {
 
         new_body = try self.prependStatementsToBody(new_body, capture_stmts[0..capture_count]);
     }
+
+    if (self.temp_var_counter > saved_temp_counter and !new_body.isNone()) {
+        new_body = try self.hoistTempVars(new_body, saved_temp_counter, node.span);
+    }
+    self.temp_var_counter = saved_temp_counter;
 
     self.arrow_this_depth = saved_arrow_depth;
     self.needs_this_var = saved_needs_this;


### PR DESCRIPTION
## 요약
- RN IIFE/release 번들에서 `require` 계열 런타임 누락으로 이어지는 경로와 RN source asset 누락 경로를 하나의 PR에 묶었습니다.
- 커밋은 원인별로 분리했습니다.
  - lazy barrel deferred import가 raw `require()`로 emit되는 문제
  - CJS namespace require에서 lazy getter target이 tree-shaking으로 빠지는 문제
  - CJS require가 ESM facade namespace를 관찰할 때 re-export source body가 빠지는 문제
  - Babel custom plugin이 CLI/server `process.cwd()` 기준으로 alias를 계산해 resolver를 우회하는 문제
  - `babel-plugin-root-import`가 module load 시점의 `process.cwd()`를 캡처해 Babel `cwd/root`만으로는 보정되지 않는 문제
  - RN wrapped ESM factory 안에 named/default import declaration이 남아 raw `require("...")`로 낮아지는 문제
  - RN `.svg` source asset이 custom transformer 실패 뒤 module registry에서 누락되는 문제
  - ES5 class method lowering에서 `??`/`?.` temp var가 method scope가 아니라 outer/module scope에 선언되는 문제
  - ES2022 private method lowering에서 standalone `_name_fn` 내부 temp var가 function scope에 선언되지 않는 문제
  - async/generator state machine callback 내부 temp var가 callback scope가 아니라 outer wrapper scope에 hoist되는 문제

## 원인 1: lazy barrel deferred import
`sideEffects:false` ESM barrel에서 요청되지 않은 static import는 graph가 의도적으로 resolve를 미룹니다. 그런데 metadata skip 계산은 `rec.resolved.isNone()`인 import declaration을 그대로 남겼고, wrapped IIFE/CJS codegen이 이를 raw `require("...")`로 낮췄습니다. RN 런타임에는 이 위치의 전역 `require`가 없어서 크래시가 납니다.

수정은 graph가 링크하지 않기로 한 deferred lazy import에 대해 AST 원본 import declaration도 skip하도록 맞춘 것입니다.

## 원인 2: CJS namespace require + lazy getter
`const iface = require("./rn-private")`처럼 CJS namespace 전체를 읽으면 해당 namespace의 모든 getter가 관찰 가능합니다. 기존 `lazyRequireMatchedExportUsed`는 개별 getter export 이름만 보고 `ALL_EXPORTS_SENTINEL`(`*`)은 보지 않아, getter body가 require하는 target module body/init이 빠질 수 있었습니다.

수정은 `*` sentinel이 찍힌 namespace read에서는 모든 lazy getter require를 live로 간주하는 것입니다. Flow 타입 import/export가 포함된 RN core 형태 fixture로 고정했습니다.

## 원인 3: require target이 ESM facade인 경우
RN generated asset module은 `require(AssetRegistry).registerAsset(...)`처럼 CJS require로 ESM facade namespace를 관찰할 수 있습니다. 기존 BFS require follow-up은 target이 CJS wrapper일 때만 전파하고, wrapped ESM facade는 건너뛰었습니다. 그래서 facade의 re-export source인 CJS registry의 `registerAsset` export fact body가 tree-shake로 빠질 수 있었습니다.

수정은 require target이 wrapped ESM이면 facade를 seed하고 re-export source까지 namespace 관찰 경로로 따라가도록 한 것입니다.

## 원인 4: Babel custom plugin cwd
Metro 호환 Babel custom plugin은 보통 프로젝트 루트 기준으로 path alias를 계산합니다. ZNTC CLI/server가 앱 루트 밖에서 실행되면 Babel 기본 `cwd`가 `process.cwd()`로 잡혀 custom plugin이 `~/App` 같은 import를 서버 실행 위치 기준의 잘못된 상대경로로 바꿀 수 있습니다.

수정은 Babel `transformSync`에 `cwd`와 `root`를 `projectRoot`로 명시해, Babel 옵션을 따르는 custom plugin이 Metro처럼 앱 프로젝트 기준으로 동작하게 한 것입니다.

## 원인 5: babel-plugin-root-import module-load cwd 캡처
`babel-plugin-root-import@6.x`는 entry에서 `global.rootPath = process.cwd()`를 설정하고 helper가 module load 시점에 그 값을 default root로 캡처합니다. 즉 Babel `cwd/root`를 넘겨도 plugin이 이미 잘못된 root를 잡으면 `~/App`이 `../../../<server-cwd>/src/App` 같은 경로로 변환될 수 있습니다. 이 경로는 ZNTC alias resolver를 우회하고 raw `require(...)`로 남아 RN 런타임에서 `Property 'require' doesn't exist` 계열 오류로 이어집니다.

수정은 `root-import` / `babel-plugin-root-import` 계열 plugin을 resolve할 때 사용자가 `root`를 명시하지 않은 경우 `projectRoot`를 plugin option에 주입하는 것입니다. `paths` 옵션을 쓰는 형태도 각 path option에 `root`를 보강합니다. 사용자가 이미 `root`를 지정한 경우에는 덮어쓰지 않습니다.

## 원인 6: RN wrapped ESM factory 안의 binding import
`@tanstack/react-query/build/modern/index.js` 같은 ESM barrel은 RN preset에서 `__esm` factory로 감싸집니다. 이때 named/default import declaration이 factory body에 남으면 body codegen이 CommonJS 호환 출력을 만들면서 `({ useQueries } = require("./useQueries.js"))` 형태로 낮춥니다. Metro/RN runtime의 이 factory scope에는 전역 `require`가 없으므로 release/dev-server release bundle에서 `Property 'require' doesn't exist` 또는 이후 연쇄 오류로 이어질 수 있습니다.

수정은 React Native wrapped module metadata에서 linked import record가 있는 named/default import declaration을 skip 처리하는 것입니다. semantic metadata가 없는 wrapped module 조기 반환 경로에도 동일한 skip 계산을 적용했습니다. namespace import는 namespace object 값 자체가 필요할 수 있으므로 유지합니다.

이 문제는 테스트 fixture만으로는 놓칠 수 있어 실제 RN release bundle도 별도로 확인했습니다. 현재 worktree native core로 직접 build한 release bundle에서는 `require("./useQueries.js")`가 더 이상 남지 않습니다.

## 원인 7: `.svg` source asset module 누락
RN에서 `.svg`를 `sourceExts`에 넣고 `babelTransformerPath`도 설정하면 기존 asset plugin은 SVG 내장 transformer 등록을 건너뛰고 custom transformer 경로로만 위임했습니다. 그런데 custom transformer가 실패하거나 Babel AST만 반환하고 code generation이 실패하면, 기존 구현은 에러를 stderr에만 쓰고 `null`을 반환했습니다.

그 결과 resolver/import rewrite는 여전히 `__zntc_modules[".../Icon.svg"].fn()`을 참조하지만, 실제 SVG module wrapper는 bundle에 emit되지 않았습니다. 런타임에서는 `Cannot read property 'fn' of undefined` / 컴포넌트 undefined 계열 오류로 이어집니다.

수정은 다음처럼 root cause를 직접 막았습니다.
- `.svg` sourceExt는 `babelTransformerPath` 존재 여부와 무관하게 ZNTC 내장 SVG transformer가 처리합니다.
- custom transformer 대상에서 `.svg`를 제외합니다.
- non-SVG custom source transformer는 `{ code }` 반환만 허용합니다.
- custom transformer 실패를 `null`로 삼키지 않고 fail-fast로 올립니다.
- Metro 호환 custom transformer 옵션에 `projectRoot`, `dev`, `hot`, `platform`을 전달합니다.

이 경로에서는 `@babel/core`를 호출하지 않습니다. Babel AST 반환을 ZNTC가 대신 codegen하는 fallback도 제거했습니다. ZNTC 자체 transformer가 처리해야 하는 확장자는 자체 transformer가 담당하고, 아직 native transformer가 없는 custom 확장자는 code-returning transformer만 받도록 경계를 명확히 했습니다.

## 원인 8: 클래스 메서드 내부 `??` temp var 스코프
CI의 React Query v5 smoke는 `QueryCache.build()` 같은 클래스 메서드 내부에서 `options.queryHash ?? hashQueryKeyByOptions(...)`를 ES5로 낮춥니다. 기존 변환기는 일반 함수 방문 경로에서는 `foo() ?? bar`가 만든 `_a` temp var를 함수 body에 hoist했지만, class method 방문 경로에서는 temp counter를 함수 스코프로 저장/복원하지 않았습니다.

그 결과 ES5 class lowering 후 메서드 body 안에는 `(_a = options.queryHash) != null ? _a : ...`가 남고, `var _a`는 method function 밖의 class/module scope에 붙었습니다. 단일 파일에서는 우연히 top-level `var _a`가 남아 실행될 수 있지만, 번들링된 import module에서는 tree-shaking이 nested method body의 synthetic temp read를 top-level var declaration의 live reference로 보지 못해 `var _a`만 제거될 수 있습니다. CI 런타임의 `ReferenceError: _a is not defined`가 이 케이스입니다.

수정은 method를 실제 함수 스코프로 취급하도록 맞춘 것입니다. preserved class method 경로(`visitMethodDefinition`)와 ES5 class lowering 경로(`visitMethodBodyWithCtxImpl`) 모두에서 temp counter를 저장하고, method body 변환 후 증가분을 해당 body 앞에 hoist한 뒤 counter를 복원합니다. 이렇게 하면 `var _a`가 `value: function(...) { var _a, ... }` 내부에 emit되어 tree-shaking이 선언만 따로 제거할 수 없습니다.

회귀 테스트는 두 층으로 추가했습니다. codegen 테스트는 preserved class와 ES5-lowered class method 양쪽에서 method-local temp 선언을 확인하고, bundler 테스트는 CI와 같은 “import된 class method + ES5 target + CJS bundle” 형태를 직접 고정합니다.

## 원인 9: private method standalone function 내부 `??` temp var 스코프
React Query v5의 실제 실패 지점은 일반 class method가 아니라 `#computeRefetchInterval()` private method가 `_computeRefetchInterval_fn` standalone function으로 낮아진 뒤의 `??`였습니다. `buildStandaloneFunc`는 private method body를 꺼내 `function _name_fn(...) { ... }`로 만들지만, 이 경로도 `visitFunction`을 지나지 않아 temp counter 저장/hoist/복원이 빠져 있었습니다.

그래서 `_computeRefetchInterval_fn` body에는 `(_a = (...)) != null ? _a : false`가 들어가고 `var _a`는 standalone function 밖에 붙거나 tree-shaking에서 빠질 수 있었습니다. CI macOS 로그의 `ReferenceError: _a is not defined` at `_computeRefetchInterval_fn`이 이 케이스입니다.

수정은 private method를 standalone function으로 추출하는 `buildStandaloneFunc`에도 같은 함수 스코프 temp hoist 규칙을 적용한 것입니다. params/body 방문 전 temp counter를 저장하고, body 변환 후 증가분을 standalone function body 앞에 hoist한 뒤 counter를 복원합니다. React Query 표현식과 같은 conditional `??` 형태를 회귀 테스트로 추가했습니다.

## 원인 10: async/generator state machine callback 내부 `?.` temp var 스코프
private method temp를 고친 뒤 CI의 다음 실패는 async method lowering이 만든 `__generator(this, function(_state) { ... })` callback 내부였습니다. React Query의 async fetch path에서 `context.fetchOptions?.meta`가 `((_c = context.fetchOptions) == null ? void 0 : _c.meta)`로 낮아졌는데, `_c` declaration은 callback 내부가 아니라 outer async wrapper 쪽에 붙거나 tree-shaking에서 제거될 수 있었습니다. CI 로그의 `ReferenceError: _c is not defined` at `_Class.<anonymous>`가 이 케이스입니다.

수정은 state machine이 만든 switch body 자체에 temp vars를 hoist하는 것입니다. `lowerAsyncToStateMachine`, `lowerAsyncArrowToStateMachine`, `lowerGeneratorFunction` 모두에서 `buildStateMachine()` 전후로 temp counter를 저장/복원하고, 증가분은 `function(_state) { ... }` callback body 안에 넣습니다. generator의 실제 `var` hoist(`sm_result.var_decl`)는 기존처럼 outer wrapper에 두되, `??`/`?.` expression-local temp는 switch callback scope에 둡니다.

이렇게 하면 `function(_state) { { var _c; switch (...) { ... ((_c = context.fetchOptions) ... } } }` 형태가 되어 callback 내부 참조와 선언이 같은 scope에 있게 됩니다. async function과 generator function 양쪽 회귀 테스트를 추가했고, async class method 최소 재현을 ES5/CJS로 변환해 Node 실행까지 확인했습니다.

## 검증 중 발견한 환경 이슈
worktree의 `node_modules`가 원본 repo의 `node_modules`로 symlink되어 있어, `zntc dev --platform=react-native`가 worktree에서 수정/빌드한 native addon이 아니라 원본 repo 쪽 `@zntc/react-native`/`@zntc/core`를 물 수 있었습니다. 그래서 서버 실행 검증 시에는 현재 worktree의 `packages/core/dist/index.js`와 `packages/react-native/src/preset.ts` 또는 현재 worktree에서 빌드한 `packages/react-native/dist/index.js`를 직접 사용해 검증했습니다.

## Zig 초보자용 메모
여기서 `seed`는 tree-shaker BFS 큐에 “살려야 할 statement”를 넣는 동작입니다. 이번 PR의 공통점은 실제 런타임에서 `require()`가 namespace/getter/facade를 통해 값을 읽을 수 있는데, 기존 큐 전파가 그 관찰 가능성을 충분히 따라가지 못해 필요한 초기화 문장을 제거했거나, Babel plugin이 프로젝트 루트 밖의 cwd를 기준으로 import 경로를 바꿔 ZNTC resolver를 우회했거나, RN wrapped factory 안에 import declaration이 남아 전역 `require`에 의존하는 코드가 생겼거나, RN source asset module 생성 실패를 빌드 타임에 멈추지 않아 런타임 module registry 누락으로 넘어갔다는 점입니다.

## 테스트
- `zig build test -Dtest-filter="ES2020: temp var hoisted inside async state machine" --summary all`
- `zig build test -Dtest-filter="ES2020: temp var hoisted inside generator state machine" --summary all`
- `zig build test -Dtest-filter="async state machine" --summary all`
- async state machine 최소 재현 실행 확인: class async method의 `context.fetchOptions?.meta` ES5/CJS 변환 결과를 `node out.cjs`로 실행해 `true` 출력 확인
- `zig build test -Dtest-filter="private method: nullish temp is hoisted into standalone function" --summary all`
- `zig build test -Dtest-filter="private method: conditional nullish temp is hoisted into standalone function" --summary all`
- `zig build test -Dtest-filter="private method" --summary all`
- private method 최소 재현 실행 확인: `#compute()`의 conditional `??` ES5/CJS 변환 결과를 `node out.cjs`로 실행해 `false` 출력 확인
- `zig build test -Dtest-filter="ES2020: temp var hoisted for ?? in class method" --summary all`
- `zig build test -Dtest-filter="ES2020: temp var hoisted for ?? in preserved class method" --summary all`
- `zig build test -Dtest-filter="Expression: imported class method nullish temp is method scoped for ES5" --summary all`
- `zig build test -Dtest-filter="ES2020: temp var hoisted" --summary all`
- `zig build test -Dtest-filter="Expression: nullish" --summary all`
- `zig build test --summary all`
- 최소 재현 bundle 실행 확인: imported class method의 `options.queryHash ?? ...` ES5/CJS bundle을 `node out.cjs`로 실행해 `1` 출력 확인
- `zig build test -Dtest-filter="ESM wrapped static import under strict order" --summary all`
- `zig build test -Dtest-filter="ESM wrapped barrel namespace import under strict order" --summary all`
- `zig build test -Dtest-filter="ESM wrapped" --summary all`
- `zig build test -Dtest-filter="CJS raw require namespace keeps lazy getter require target" --summary all`
- `zig build test -Dtest-filter="ESM re-export: CJS require member access keeps re-export source body" --summary all`
- `bun test packages/react-native/src/plugins/babel.test.ts --timeout 10000 --rerun-each 1`
- `bun test packages/react-native/src/plugins/asset.test.ts`
- `git diff --check`
- `bun run --cwd packages/core build:napi && cp zig-out/lib/zntc.node packages/core/zntc.node`
- `bun run --cwd packages/react-native build:bundle`
- 실제 RN iOS dev-server bundle에서 SVG wrapper가 emit되는지 확인: `#region CrownFill.svg`, `init_CrownFill` 존재
- 실제 RN iOS dev-server 앱 실행 확인: `runtime not ready`, `ReferenceError`, `TypeError`, `fn of undefined`, `EquipmentSearchBody` 계열 로그 없음, 앱 첫 화면 렌더링 확인
- 현재 worktree native core로 RN iOS release bundle 직접 생성 후 `require("./useQueries.js") === false` 확인

참고: 통합 worktree에서 `bun run --cwd packages/core build:local`은 native/js build까지 진행됐으나 dts 단계에서 `@types/node` type definition 누락으로 실패했습니다. 이번 CI 재현용 JS CLI integration도 현재 로컬 checkout의 `node_modules`가 원본 repo symlink이고 optional `core-js-compat`가 없어 bundle 단계에서 멈췄습니다. CI 실패 지점인 runtime `_a` 누락은 동일한 import/class-method/ES5 bundle 최소 재현과 Zig 회귀 테스트로 확인했습니다. PR 변경과 직접 관련된 Zig/Bun 회귀 테스트 및 RN bundle/runtime 확인은 통과했습니다.
## 원인 11: state-machine temp lifetime 혼합으로 인한 generator/for-await 값 리셋
원인 10에서 `?.`/`??` expression-local temp를 `__generator(function(_state) { ... })` callback 안에 선언하도록 고치면서, 같은 temp counter를 쓰는 다른 종류의 temp까지 함께 callback 안에 다시 선언하는 회귀가 생겼습니다.

state machine에는 temp가 두 종류 있습니다.
- `generator_temp_var_spans`: `for-await`, `yield` extraction, iterator helper처럼 resume 사이에 값이 유지돼야 하는 state temp입니다. 이 값들은 `__generator` callback 밖, 즉 wrapper function top의 `var _a, _b, ...`에 있어야 합니다.
- `temp_var_counter` only: optional chaining/nullish/destructuring lowering이 한 번의 callback 평가 안에서 쓰는 expression-local temp입니다. 이 값들은 callback 내부에 있어야 합니다.

직전 구현은 이 둘을 구분하지 않고 `saved_counter..temp_var_counter` 전체를 callback body에 hoist했습니다. 그래서 `for await`에서 wrapper top에 이미 선언된 `_a.._f`가 callback 안에 다시 `var _a,_b,...`로 선언되어 outer state temp를 shadowing했습니다. Hermes CI의 `for-await-of var hoist`가 `RES:6` 대신 `RES:0`, `async function*`가 `RES:1,2,3` 대신 빈 배열을 출력한 이유가 이것입니다. 같은 원인으로 macOS integration의 async/generator runtime 케이스들도 함께 깨졌습니다.

수정은 temp lifetime을 명시적으로 분리한 것입니다.
- `buildStateMachine()`이 만든 `generator_temp_var_spans`를 caller가 callback-local hoist까지 참고할 수 있도록 clear 시점을 caller 뒤로 옮겼습니다.
- 새 helper `hoistTempVarsSkippingSpans()`를 추가해 callback-local hoist 시 state temp 이름은 제외합니다.
- `lowerGeneratorFunction`, `lowerAsyncToStateMachine`, `lowerAsyncArrowToStateMachine`은 callback-local temp만 callback 안에 선언하고, state temp는 기존처럼 `sm_result.var_decl`로 wrapper top에 둡니다.
- class async method 경로도 `buildStateMachine()` 이후 state temp 목록을 caller scope에서 정리하도록 맞췄습니다.

이건 fallback이나 방어 코드가 아니라 root cause 수정입니다. 동일한 `_a` 계열 이름을 쓰더라도 “resume 사이에 살아야 하는 temp”와 “callback 평가 안에서만 필요한 temp”는 선언 위치가 달라야 하고, 이번 변경은 그 생명주기를 코드 구조에 반영합니다.

## 추가 검증
- `zig build test -Dtest-filter="state temps" --summary all`
- `zig build test --summary all`
- `bun test tests/hermes-runtime.test.ts --timeout 600000`
- `bun test tests/swc-compare.test.ts --timeout 600000`
- `bun test tests/downlevel.test.ts --timeout 600000`
- `bun test tests/downlevel-edge.test.ts --timeout 600000`
- `bun test tests/hermes-runtime.test.ts tests/swc-compare.test.ts --timeout 600000`

로컬 `React Query v5 smoke`는 현재 worktree의 `node_modules`가 symlink된 환경에서 optional `core-js-compat`가 없어 JS CLI가 `runtimePolyfills requires the optional 'core-js-compat' package`로 종료됩니다. 이번 실패의 런타임 root cause와는 별개이며, CI의 dependency install 경로에서는 해당 단계 이후 런타임 검증까지 진행됩니다.

## 원인 12: HMR debounce 계약과 실제 idle window 불일치
macOS NAPI CI에서 `Issue #1223 HMR perf - latency and debounce - quick saves`가 간헐적으로 `rebuildCount=3`을 관측했습니다. 테스트 계약은 "첫 리빌드 후 50ms 내 두 번 저장은 한 번으로 병합"인데, 실제 watch 구현의 idle window는 25ms였습니다.

macOS kqueue는 CI 부하에 따라 같은 파일의 후속 `NOTE_WRITE`가 25ms idle 뒤에 도착할 수 있습니다. 그러면 10ms 간격의 빠른 저장이라도 watch loop가 첫 이벤트 뒤 25ms 조용하다고 판단하고 rebuild를 먼저 시작한 다음, 뒤늦게 도착한 후속 이벤트로 다시 rebuild하여 총 3회가 됩니다.

수정은 debounce idle window를 공개 계약과 같은 50ms로 맞춘 것입니다. starvation cap은 500ms 그대로 유지하므로 지속 저장 상황에서 rebuild가 무기한 밀리지는 않습니다. latency 테스트도 200ms 기준 안에 들어오는 것을 확인했습니다.

## 원인 12 검증
- `zig build napi`
- `bun test ./packages/core/test/core/hmr-perf/latency-debounce/quick-saves.ts ./packages/core/test/core/hmr-perf/latency-debounce/latency.ts ./packages/core/test/core/hmr-perf/latency-debounce/starvation-cap.ts --timeout 20000`
- `bun test ./packages/core/test/core/hmr-perf.ts --timeout 20000`
- `zig build test --summary all`
- `git diff --check`
