### PR TITLE
feat(codegen): CJS wrapper exports/module 이름 옵션 인프라 (RFC PR-1)

### DIFF
--- a/src/codegen/modules.zig
+++ b/src/codegen/modules.zig
@@ -386,7 +386,8 @@ pub fn emitExportNamedCJS(self: anytype, decl: NodeIndex, specs_start: u32, spec
             const exported_text = self.ast.getText(self.ast.getNode(exported_idx).span);
             const local_text = self.ast.getText(self.ast.getNode(local_idx).span);
 
-            try self.write("exports.");
+            try self.write(self.options.cjs_exports_name);
+            try self.writeByte('.');
             try self.write(exported_text);
             try self.writeByte('=');
             if (has_source) {
@@ -426,7 +427,8 @@ pub fn emitCJSExportBinding(self: anytype, decl_idx: NodeIndex) !void {
                             name
                     else
                         name;
-                    try self.write("exports.");
+                    try self.write(self.options.cjs_exports_name);
+                    try self.writeByte('.');
                     try self.write(name);
                     try self.writeByte('=');
                     try self.write(ref_name);
@@ -447,7 +449,8 @@ pub fn emitCJSExportBinding(self: anytype, decl_idx: NodeIndex) !void {
                         name
                 else
                     name;
-                try self.write("exports.");
+                try self.write(self.options.cjs_exports_name);
+                try self.writeByte('.');
                 try self.write(name);
                 try self.writeByte('=');
                 try self.write(ref_name);
@@ -497,7 +500,8 @@ pub fn emitExportDefault(self: anytype, node: Node) !void {
             }
             return;
         }
-        try self.write("module.exports=");
+        try self.write(self.options.cjs_module_name);
+        try self.write(".exports=");
         try self.emitNode(node.data.unary.operand);
         try self.writeByte(';');
         return;
@@ -593,7 +597,9 @@ pub fn emitExportAll(self: anytype, node: Node) !void {
     const x = module_parser.readExportAllExtras(self.ast, node.data.extra);
     if (self.options.module_format == .cjs) {
         // export * from './bar' → Object.assign(exports,require('./bar'));
-        try self.write("Object.assign(exports,require(");
+        try self.write("Object.assign(");
+        try self.write(self.options.cjs_exports_name);
+        try self.write(",require(");
         try self.emitNode(x.source);
         try self.write("));");
         return;

--- a/src/codegen/options.zig
+++ b/src/codegen/options.zig
@@ -100,6 +100,15 @@ pub const CodegenOptions = struct {
     /// JSON을 CJS require()로 소비할 때 synthetic named export declarations를 생략.
     /// default object는 `module.exports = {...}`로 유지한다.
     skip_cjs_named_export_decls: bool = false,
+    /// CJS wrapper 본문의 `exports`/`module` 식별자 이름. `exports`/`module`
+    /// 은 `__commonJS` wrapper 의 arrow 파라미터(`(exports,module)=>{...}`)라
+    /// 순수 함수 지역 바인딩 — 호출자(`cb((mod={exports:{}}).exports,mod)`)
+    /// 와 무관해 이름만 바꿔도 의미 불변. 기본값은 원본 그대로라 옵션 미주입
+    /// 시 바이트 동일(회귀 0). emitter 가 wrapper 파라미터와 같은 값을 주입해
+    /// codegen 합성 구문(`exports.x=`, `module.exports=`)과 본문 free 참조를
+    /// 단일 소스로 동기화한다.
+    cjs_exports_name: []const u8 = "exports",
+    cjs_module_name: []const u8 = "module",
     /// 번들 모드에서 ESM이 아닐 때 import.meta -> {} 치환 (esbuild 호환)
     replace_import_meta: bool = false,
     /// 타겟 플랫폼. import.meta polyfill 방식을 결정한다.


### PR DESCRIPTION
## 배경

ZNTC minify CJS wrapper: `var X=$c((exports,module)=>{ exports.foo=... })` — `exports`/`module` 이 `__commonJS` arrow **파라미터(순수 지역 바인딩)** 인데 codegen 이 리터럴 하드코딩 → minify 에서 mangle 안 됨. esbuild 는 `g((c,l)=>{ c.foo=... })` 로 축약.

measure-first 규명: 143-lib 집계 `exports` ZNTC 4,842 vs esbuild 1,057 / `module` 1,793 vs 126 → **corpus 절감 상한 ≈ 25,593 B**. mangler 아키텍처(NO-GO 박제 영역)와 **무관한 별개 codegen 누락** (객체키 quote fix #3446 와 같은 계보).

## PR-1 (인프라 · flag off · 회귀 0)

이 epic 의 1단계. **동작 무변경** — 후속 PR 이 짧은 이름을 주입할 수 있는 토대만 마련.

- `CodegenOptions` 에 `cjs_exports_name`/`cjs_module_name` 필드 (기본 `"exports"`/`"module"` → 미주입 시 출력 동일)
- `modules.zig` CJS 합성 구문 5곳(`exports.x=` ×3, `module.exports=`, `Object.assign(exports,require(`)을 옵션 기반 write 로 교체
- 안전 근거: `exports`/`module` 은 wrapper arrow 지역 인자(`cb((mod={exports:{}}).exports,mod)` 호출자와 무관) → 이름만 바꿔도 의미 불변

## 검증

- **크기 8/8 lib 바이트 동일** (ajv/express/rxjs/type-is/zod/qs/react-dom/axios) — flag off 회귀 0
- 런타임 동일, Debug+ReleaseFast 유닛테스트 통과
- 부수 발견: mangler 출력이 **기존부터 비결정적**(동일 바이너리 3회 빌드 해시 상이, 크기·런타임은 결정적) — 검증을 해시 아닌 크기+런타임 기준으로 수행. 이 비결정성은 PR-1 과 무관한 별개 이슈

## 후속 (epic 내)

- PR-2: `node_dispatch.zig` free `exports`/`module` 참조 치환 가드 (shadow/property-key/string 자동 제외, sym_id==null 가드 재사용)
- PR-3: `emitter.zig` wrapper 합성 + kill-switch `ZNTC_CJS_WRAP_MANGLE`
- PR-4: measure-first 게이트(런타임 MATCH 전수 + corpus 회귀 0 + 절감 ≥ 25KB 의 70% + mangle_audit 무회귀) 통과 시 `epic/cjs-wrap-mangle` → main, 미달 시 epic 폐기(main 무영향)

> Zig 초보자 노트: `CodegenOptions` 는 코드 출력 방식을 정하는 설정 묶음입니다. 기존에 `newline`, `source_root` 처럼 문자열 옵션이 있었고 동일 패턴으로 2개를 추가했습니다. 기본값을 원래 쓰던 문자열(`"exports"`)로 둬서, 이 PR 만으로는 출력이 한 글자도 안 바뀝니다(회귀 0). 실제 크기 절감은 후속 PR 이 짧은 이름을 넣을 때 발생합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)