### PR TITLE
feat(mf): 소유권 경계 린트 — 경계 모듈 store 자체생성 비-차단 경고 (#3439)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1071,13 +1071,18 @@ pub const Bundler = struct {
         // Module Federation 연합 경계 식별 (#3318 P1-1). mf!=null 일 때만 —
         // 비-MF 빌드 영향 0. 표시·안정 ID 만(분석); wrap_kind/출력 불변.
         if (self.options.mf) |*mf| {
-            try @import("federation.zig").markBoundary(
+            const fed = @import("federation.zig");
+            try fed.markBoundary(
                 &graph,
                 mf,
                 self.allocator,
                 self.options.entry_points,
                 self.options.preserve_modules_root,
             );
+            // P3-4 (#3439): 소유권 경계 린트 — 경계 모듈이 host-owned
+            // store/Provider 자체 생성 시 비-차단 경고. markBoundary 직후
+            // (경계 플래그 완료, 동일 graph 순회). 빌드 영향 0(경고만).
+            fed.lintOwnershipBoundary(&graph);
         }
 
         if (graph.runtime_polyfill_roots.items.len > 0) {

--- a/src/bundler/federation.zig
+++ b/src/bundler/federation.zig
@@ -170,6 +170,85 @@ fn setBoundary(allocator: std.mem.Allocator, m: anytype, root: ?[]const u8) !voi
     m.federation_id = try module_id.moduleId(allocator, m.path, root);
 }
 
+/// specifier 가 패키지 `pkg` 또는 그 subpath(`pkg/...`)인가.
+fn pkgMatch(spec: []const u8, pkg: []const u8) bool {
+    return std.mem.eql(u8, spec, pkg) or
+        (spec.len > pkg.len and std.mem.startsWith(u8, spec, pkg) and spec[pkg.len] == '/');
+}
+
+/// (import 패키지, import 심볼명) 이 host-owned **store/Provider 생성**
+/// API 인가 → 사람이 읽는 라벨, 아니면 null. **정밀 휴리스틱**: store
+/// *생성* 팩토리 심볼만 매칭 — `createSlice`/`useSelector`/`atom`/
+/// `useStore`(주입·소비 = GOOD 패턴)는 비매칭(낮은 false-positive).
+/// AST 미보존이라 호출 여부는 못 봄 → 심볼 import 자체를 신호로 사용
+/// (그 심볼을 import 하면 호출 의도). RFC §3.2(host 단일 store, remote
+/// 는 주입) · §7.3 ②(휴리스틱, FP 가능 — 경고는 "확인 권고").
+/// **알려진 한계**(false-negative, RFC §7.3 ② 완전 데이터플로 비-목표):
+/// namespace import(`import * as RTK; RTK.configureStore()` → imported_
+/// name="*") · 재export 경유는 미탐지. 직접 명명 import 만 신호.
+fn prohibitedStoreFactory(specifier: []const u8, name: []const u8) ?[]const u8 {
+    const eq = std.mem.eql;
+    if (pkgMatch(specifier, "@reduxjs/toolkit")) {
+        if (eq(u8, name, "configureStore")) return "Redux configureStore";
+    } else if (pkgMatch(specifier, "redux")) {
+        if (eq(u8, name, "createStore") or eq(u8, name, "legacy_createStore")) return "Redux createStore";
+    } else if (pkgMatch(specifier, "zustand")) {
+        // zustand: named {create,createStore} 또는 default export(=create).
+        if (eq(u8, name, "create") or eq(u8, name, "createStore") or eq(u8, name, "default"))
+            return "Zustand store";
+    } else if (pkgMatch(specifier, "jotai")) {
+        if (eq(u8, name, "createStore")) return "Jotai createStore";
+    } else if (pkgMatch(specifier, "react-redux")) {
+        if (eq(u8, name, "Provider")) return "react-redux Provider";
+    }
+    return null;
+}
+
+/// P3-4 (#3439): 소유권 경계 린트. 연합 경계 모듈(exposes ∪ shared
+/// 폐포)이 host-owned store/Provider 생성 심볼을 import 하면 **비-차단
+/// 빌드 경고**(std.log.warn — P3-2 선례, 빌드 실패 아님 · #3336
+/// non-literal dynamic import 진단 선례 미러: 탐지→비-차단 경고).
+/// markBoundary 직후 호출(경계 플래그 설정 완료 — 동일 단일소스 순회,
+/// emit/검증 부작용 0). 휴리스틱이라 false-positive 가능(RFC §7.3 ②) —
+/// 메시지가 "의도된 격리면 무시"를 명시. 경고는 절대 빌드를 막지 않음.
+pub fn lintOwnershipBoundary(graph: anytype) void {
+    const count = graph.moduleCount();
+    var i: usize = 0;
+    while (i < count) : (i += 1) {
+        const idx: ModuleIndex = @enumFromInt(@as(u32, @intCast(i)));
+        const m = graph.getModule(idx) orelse continue;
+        if (!m.is_federation_boundary) continue;
+        for (m.import_bindings) |ib| {
+            if (ib.import_record_index >= m.import_records.len) continue;
+            const spec = m.import_records[ib.import_record_index].specifier;
+            const label = prohibitedStoreFactory(spec, ib.imported_name) orelse continue;
+            std.log.warn(
+                "[mf] 소유권 경계 — 연합 경계 모듈 '{s}' 이 host-owned {s} 을(를) 자체 생성(import '{s}' from '{s}'). remote 는 host store 에 slice/reducer 를 주입하세요(RFC §3.2). 비-차단 — 의도된 격리면 무시.",
+                .{ m.federation_id orelse m.path, label, ib.imported_name, spec },
+            );
+        }
+    }
+}
+
+test "prohibitedStoreFactory: store-생성 심볼만 매칭(주입·소비는 비매칭)" {
+    // 매칭(자체 store/Provider 생성 정황)
+    try std.testing.expect(prohibitedStoreFactory("@reduxjs/toolkit", "configureStore") != null);
+    try std.testing.expect(prohibitedStoreFactory("redux", "createStore") != null);
+    try std.testing.expect(prohibitedStoreFactory("zustand", "create") != null);
+    try std.testing.expect(prohibitedStoreFactory("zustand/vanilla", "createStore") != null); // subpath
+    try std.testing.expect(prohibitedStoreFactory("zustand", "default") != null); // default=create
+    try std.testing.expect(prohibitedStoreFactory("jotai", "createStore") != null);
+    try std.testing.expect(prohibitedStoreFactory("react-redux", "Provider") != null);
+    // 비매칭 — 주입·소비(GOOD 패턴) → false-positive 회피
+    try std.testing.expect(prohibitedStoreFactory("@reduxjs/toolkit", "createSlice") == null);
+    try std.testing.expect(prohibitedStoreFactory("react-redux", "useSelector") == null);
+    try std.testing.expect(prohibitedStoreFactory("react-redux", "useDispatch") == null);
+    try std.testing.expect(prohibitedStoreFactory("jotai", "atom") == null);
+    try std.testing.expect(prohibitedStoreFactory("zustand", "useStore") == null);
+    try std.testing.expect(prohibitedStoreFactory("react", "useState") == null); // 무관 패키지
+    try std.testing.expect(prohibitedStoreFactory("jotai", "createStoreX") == null); // 부분일치 아님
+}
+
 /// graph.build 루트 = user entry ∪ exposes. P1-3: exposes 는 user entry
 /// 에서 도달 안 될 수 있는 **독립 루트**(webpack 동일) — 그래프에 없으면
 /// markBoundary 가 매칭 실패. 반환 slice 의 모든 원소 allocator-dup(소유

--- a/tests/integration/tests/mf-runtime-interop-smoke.test.ts
+++ b/tests/integration/tests/mf-runtime-interop-smoke.test.ts
@@ -1115,6 +1115,67 @@ console.log('SAME=' + (m && m.usedHook === hostReact.useState));
     expect(stdout).not.toContain('REM=TIMEOUT');
     expect(stdout).toMatch(/REM=\S/);
   }, 30000);
+
+  // P3-4 (#3439): 소유권 경계 린트. 연합 경계 모듈(expose/shared 폐포)
+  // 이 host-owned store/Provider 를 자체 생성하면 **비-차단 빌드 경고**
+  // (#3336 진단 선례 미러 — 탐지→경고, 빌드 실패 아님). 휴리스틱이라
+  // FP 가능(RFC §7.3 ②): store *생성* 심볼만 매칭, 주입·소비(createSlice
+  // /useSelector/atom)는 비매칭. 경계 모듈만 — 비-경계는 무경고.
+  test('P3-4 소유권 경계: 경계 모듈 store 자체생성 → 비-차단 경고; 주입·비경계 무경고', async () => {
+    // 로컬 stub node_modules(@reduxjs/toolkit) — bare import 가 resolve
+    // 되어 IIFE 번들에 포함(P1 제약: 미해결 bare external 은 IIFE emit
+    // 불가). 린트는 import 바인딩(specifier+심볼)만 보므로 stub 으로 충분.
+    const rtkStub = {
+      'node_modules/@reduxjs/toolkit/package.json': '{"name":"@reduxjs/toolkit","main":"index.js"}',
+      'node_modules/@reduxjs/toolkit/index.js':
+        'export const configureStore=()=>({});\nexport const createSlice=()=>({});',
+    };
+
+    // ① 경계(expose) 모듈이 configureStore 자체 생성 → 경고 + 빌드 성공
+    const fxBad = await createFixture({
+      ...rtkStub,
+      'Widget.ts': `import { configureStore } from "@reduxjs/toolkit";\nexport default function W(){ return typeof configureStore; }`,
+      'index.ts': `export const s = "re";`,
+      'zntc.config.json': JSON.stringify({
+        mf: { name: 'app', exposes: { './Widget': './Widget.ts' } },
+      }),
+    });
+    cleanup = fxBad.cleanup;
+    const bad = await runZntcInDir(fxBad.dir, [
+      '--bundle',
+      join(fxBad.dir, 'index.ts'),
+      '--outdir',
+      join(fxBad.dir, 'dist'),
+      '--format=iife',
+    ]);
+    expect(bad.exitCode).toBe(0); // 경고는 비-차단(빌드 성공)
+    expect(bad.stderr).toContain('소유권 경계');
+    expect(bad.stderr).toContain('Redux configureStore');
+    await fxBad.cleanup();
+    cleanup = undefined;
+
+    // ② GOOD 패턴(경계는 createSlice 주입) + 비-경계 entry 의
+    //    configureStore → 경고 없음(휴리스틱 정밀: 생성 심볼만·경계만).
+    const fxOk = await createFixture({
+      ...rtkStub,
+      'Widget.ts': `import { createSlice } from "@reduxjs/toolkit";\nexport default function W(){ return typeof createSlice; }`,
+      // index.ts(비-경계 entry)는 configureStore 써도 무경고(경계 아님)
+      'index.ts': `import { configureStore } from "@reduxjs/toolkit";\nexport const store = configureStore;`,
+      'zntc.config.json': JSON.stringify({
+        mf: { name: 'app', exposes: { './Widget': './Widget.ts' } },
+      }),
+    });
+    cleanup = fxOk.cleanup;
+    const ok = await runZntcInDir(fxOk.dir, [
+      '--bundle',
+      join(fxOk.dir, 'index.ts'),
+      '--outdir',
+      join(fxOk.dir, 'dist'),
+      '--format=iife',
+    ]);
+    expect(ok.exitCode).toBe(0);
+    expect(ok.stderr).not.toContain('소유권 경계');
+  }, 30000);
 });
 
 function readFileSyncSafe(p: string): string {


### PR DESCRIPTION
## 개요
P3-4 — MF 에픽 #3318 **P3(빌드타임 계약 검증 D3)**, RFC §3.2(host 단일 store, remote 는 slice/reducer 주입)·§7.3. 연합 경계 모듈(exposes ∪ shared 폐포)이 host-owned **store/Provider 생성** 심볼을 import 하면 **비-차단 빌드 경고** — #3336 non-literal dynamic import 진단 선례 미러(탐지→경고, **빌드 실패 아님**). 휴리스틱이라 false-positive 가능(§7.3 ②) — 경고는 "확인 권고".

## 변경
- **`federation.zig`**
  - `pkgMatch(spec, pkg)`: 정확/subpath(`zustand/vanilla` 등).
  - `prohibitedStoreFactory(specifier, name) ?[]const u8` — **순수**: store *생성* 팩토리 심볼만 라벨. `@reduxjs/toolkit` configureStore · `redux` createStore/legacy_createStore · `zustand` create/createStore/default(=create) · `jotai` createStore · `react-redux` Provider. **createSlice/useSelector/useDispatch/atom/useStore(주입·소비=GOOD 패턴) 비매칭 → 낮은 FP**. AST 미보존이라 호출 여부 못 봄 → 심볼 import 자체가 신호. 한계 명시: namespace import(`* as RTK`)·재export 미탐지(§7.3 ② 완전 DFA 비-목표).
  - `lintOwnershipBoundary(graph) void` — `is_federation_boundary` 모듈 순회 → `import_bindings` 의 `(specifier, imported_name)` 매칭 시 `std.log.warn`(P3-2 비-차단 채널, markBoundary 의 expose-miss warn 과 동일). **error 없음 = 빌드 절대 안 막음**. 무할당 O(N).
  - inline test: 매칭/비매칭(FP 회피) 매트릭스.
- **`bundler.zig`**: `markBoundary` 직후 호출(경계 플래그 완료, 동일 graph 단일소스 순회, `mf!=null` 게이트 — 비-MF 영향 0, read-only).
- **통합 2-케이스**: 경계 configureStore → 경고 + `exitCode 0`(비-차단 동시 단언) / GOOD createSlice·비-경계 entry configureStore → 무경고(정밀·경계한정 동시 박제). stub `node_modules` 로 bare import resolve(P1 미해결 bare external IIFE 제약 우회 — 린트는 import 바인딩만 봄).

## 검증
- `zig build test` **0** / `wasm-bundler` **0** / `zig build`(install) **0**.
- MF 통합 스모크 **18 pass**(P3-4 신규, P3-1/P3-2/P3-3 무회귀), MF e2e **4 passed**.
- `/simplify` 3-에이전트(재사용·품질·효율) **차단 0**: 비-차단 보장(`void`·`std.log.warn`, 빌드 절대 안 깨짐)·markBoundary 단일소스 재사용·휴리스틱 FP 타당성·거짓통과 방지(경고+exitCode0 동시 단언)를 코드로 정밀 검증. 비차단 #1(namespace/재export 미탐지 한계) 주석 **반영**, 나머지(경고 dedup) P3-1/2/3 누적 후속.

## 경계 (RFC §7.3 ②)
휴리스틱 **비-차단** 경고 — false-positive 가능(react-redux Provider 가 정당한 격리일 수 있음 → "의도된 격리면 무시" 명시). 완전 데이터플로 분석·namespace/재export 추적은 비-목표.

Closes #3439

🤖 Generated with [Claude Code](https://claude.com/claude-code)