### PR TITLE
feat(codegen): CJS wrapper free exports/module 참조 치환 가드 (RFC PR-2)

### DIFF
--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 const ast_mod = @import("../parser/ast.zig");
 const Ast = ast_mod.Ast;
 const NodeIndex = ast_mod.NodeIndex;
+const cg_options = @import("options.zig");
 const statement_emit = @import("statements.zig");
 const module_emit = @import("modules.zig");
 const type_runtime_emit = @import("type_runtime.zig");
@@ -185,6 +186,31 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
                             return;
                         }
                     }
+                }
+            }
+            // CJS wrapper free `exports`/`module` 참조 치환 (RFC PR-2). wrapper
+            // 파라미터를 짧은 이름으로 바꿀 때 본문 자유참조도 동기화한다.
+            // sym_id == null = 모듈 내 로컬 선언 없음 = __commonJS arrow 파라미터
+            // 를 가리킴 → 사용자 shadow(`var exports`)는 sym_id 가 잡혀 이 분기에
+            // 도달하지 않으므로 자동 제외. property key(`obj.exports`)·string·
+            // computed 는 다른 노드 태그라 미해당. 기본 이름이면 no-op (회귀 0).
+            if (self.options.module_format == .cjs and sym_id == null and
+                (node.tag == .identifier_reference or node.tag == .assignment_target_identifier))
+            {
+                const ident = self.ast.getText(node.data.string_ref);
+                const repl: ?[]const u8 =
+                    if (std.mem.eql(u8, ident, "exports") and
+                    !std.mem.eql(u8, self.options.cjs_exports_name, cg_options.default_cjs_exports_name))
+                        self.options.cjs_exports_name
+                    else if (std.mem.eql(u8, ident, "module") and
+                    !std.mem.eql(u8, self.options.cjs_module_name, cg_options.default_cjs_module_name))
+                        self.options.cjs_module_name
+                    else
+                        null;
+                if (repl) |name| {
+                    try self.addSourceMappingWithName(node.span, ident);
+                    try self.write(name);
+                    return;
                 }
             }
             try self.addSourceMapping(node.span);

--- a/src/codegen/options.zig
+++ b/src/codegen/options.zig
@@ -66,6 +66,12 @@ pub const JsxRuntime = enum {
     }
 };
 
+/// CJS wrapper `exports`/`module` 식별자 기본 이름. 옵션 default 와 PR-2
+/// free-ref 가드의 "기본값이면 no-op(회귀 0)" 판정이 이 단일 소스를 공유 —
+/// 리터럴 중복 시 default 변경이 회귀 0 불변식을 silent 로 깨므로 const 화.
+pub const default_cjs_exports_name = "exports";
+pub const default_cjs_module_name = "module";
+
 pub const CodegenOptions = struct {
     module_format: ModuleFormat = .esm,
     /// 문자열 따옴표 스타일 (기본: 쌍따옴표, esbuild/oxc 호환)
@@ -107,8 +113,8 @@ pub const CodegenOptions = struct {
     /// 시 바이트 동일(회귀 0). emitter 가 wrapper 파라미터와 같은 값을 주입해
     /// codegen 합성 구문(`exports.x=`, `module.exports=`)과 본문 free 참조를
     /// 단일 소스로 동기화한다.
-    cjs_exports_name: []const u8 = "exports",
-    cjs_module_name: []const u8 = "module",
+    cjs_exports_name: []const u8 = default_cjs_exports_name,
+    cjs_module_name: []const u8 = default_cjs_module_name,
     /// 번들 모드에서 ESM이 아닐 때 import.meta -> {} 치환 (esbuild 호환)
     replace_import_meta: bool = false,
     /// 타겟 플랫폼. import.meta polyfill 방식을 결정한다.


### PR DESCRIPTION
## PR-2 (가드 · flag off no-op · 회귀 0)

epic `cjs-wrap-mangle` 2단계. PR-1(옵션 인프라) 위에 **free 참조 치환 가드**를 얹는다. 실 치환은 PR-3(emitter wrapper 합성)이 옵션을 주입할 때 발생 — 이 PR 만으로는 동작 무변경.

`node_dispatch.zig` 식별자 fallthrough 직전 가드:
- `module_format == .cjs` + `sym_id == null` + tag(`identifier_reference`/`assignment_target_identifier`) + 텍스트 정확히 `exports`/`module`
- → 옵션 이름으로 치환 + `addSourceMappingWithName`(DevTools 원형 복원)
- **shadow 자동 제외**: 사용자 `var exports`는 `resolveSymbolId`가 sym_id를 잡아 이 분기 미도달
- **property-key/string/computed 미해당**: 다른 노드 태그
- 기본 이름이면 no-op (회귀 0)

## /simplify 반영

기본값 `"exports"`/`"module"` 리터럴이 options.zig default와 stringly-coupled → `options.default_cjs_exports_name`/`default_cjs_module_name` const 로 단일 소스화. default 변경이 "flag off=회귀0" 불변식을 silent로 깨지 못하게 컴파일타임 고정. (효율·재사용 리뷰: gating short-circuit으로 ESM 경로 비용 0, getText O(1), helper/hoist는 분기 상이·fast-path 회귀로 부적합 — as-is)

## 검증

- epic(PR-1) vs PR-2 **크기 8/8 동일 + 런타임 MATCH** (ajv/express/rxjs/type-is/zod/qs/react-dom/lodash-es) — flag off no-op
- Debug + ReleaseFast 유닛테스트 통과, zig fmt 통과

## 후속

PR-3: `emitter.zig` wrapper 합성(`(exports,module)=>` → 짧은 이름) + kill-switch `ZNTC_CJS_WRAP_MANGLE`, codegen 옵션 주입 → 실 치환 발생. PR-4: measure-first 게이트(런타임 MATCH 전수 + corpus 회귀 0 + 절감 ≥ 25KB의 70% + mangle_audit 무회귀) 통과 시 epic→main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)