### PR TITLE
feat(mf): 런타임 가드 폴백 emit + 빌드핀·가드 e2e 박제 (#3440)

### DIFF
--- a/src/bundler/federation_emit.zig
+++ b/src/bundler/federation_emit.zig
@@ -35,6 +35,24 @@ const MF_RUNTIME_GLOBAL = federation.MF_RUNTIME_GLOBAL; // 단일 소스
 /// 계약 검증)가 같은 스캐너를 공유(단일 소스).
 const IMPORT_NEEDLE = "import(";
 
+/// P3-5 (#3440): 런타임 가드. host 의 `import("remote/x")` 는
+/// `<MF_GUARDED>(...)` 로 치환되고, prelude 가 이 글로벌을 정의 —
+/// `loadRemote` 를 감싸 **거부 시 graceful 폴백**(셸 크래시 방지).
+/// D3 "빌드 핀 + 런타임 가드"의 런타임 절반: P3-1/2/3 은 manifest 가
+/// 로컬 resolve 가능할 때만 빌드 차단(http remote·배포후 drift 는
+/// 검증 불가→skip) → 그 사각을 런타임 가드가 메움. 성공 경로는 불변
+/// (loadRemote 결과 passthrough → S3/S4/P2-5 interop 보존), 거부만
+/// catch. 폴백은 silent 아님: console.error + `__mfUnavailable:true`
+/// (관측가능·비-차단). loadRemote 인자 그대로 forward(`arguments`).
+const MF_GUARDED = "globalThis.__mfGuardedLoad";
+const GUARD_DEF = MF_GUARDED ++ "=function(){var RR=globalThis." ++ MF_RUNTIME_GLOBAL ++
+    ",a=arguments,id=a[0];function F(){return{default:function(){return null;},__mfUnavailable:true};}" ++
+    "try{return Promise.resolve(RR.loadRemote.apply(RR,a)).catch(function(e){" ++
+    "console.error(\"[mf] runtime guard: remote '\"+id+\"' failed to load (contract drift or unreachable; " ++
+    "build-time P3 verification applies only when the manifest is locally resolvable). Rendering fallback.\",e);" ++
+    "return F();});}catch(e){console.error(\"[mf] runtime guard: remote '\"+id+\"' sync error.\",e);" ++
+    "return Promise.resolve(F());}};";
+
 /// `mf.remotes` KV.value(`<name>@<entry>`) → (name, entry). `@` 첫 등장
 /// split. name 부분 비면 KV.key fallback. `@` 없으면 value 전체=entry.
 /// 한계: scoped-like value(`@scope/x@url`)는 첫 `@`(idx 0) split →
@@ -57,12 +75,13 @@ fn isRemoteSpec(spec: []const u8, mf: *const types.MfBundleConfig) bool {
 
 /// P1-6 host emit: 스펙 `@module-federation/runtime` 재사용(D1 — 자체
 /// 재구현 금지). src 앞에 init prelude(`globalThis.__mf_runtime.init({name,
-/// remotes})`)를 prepend + 원격 동적 `import("remote/x")` 를
-/// `globalThis.__mf_runtime.loadRemote("remote/x")` 로 치환. runtime 은
-/// applyMfRemotesSeam 이 external+글로벌(__mf_runtime) 처리 → host 환경이
-/// 그 글로벌로 스펙 런타임 제공(P1-2/P1-3 글로벌-seam 모델 일관, iife/umd/
-/// amd valid). 반환 = 새 owned 문자열(caller 가 기존 src free). 정적
-/// `import X from "remote/x"` 는 비-목표(async 강등 필요 — 후속).
+/// remotes})`)를 prepend + 런타임 가드(`__mfGuardedLoad`, P3-5) 정의 +
+/// 원격 동적 `import("remote/x")` 를 `globalThis.__mfGuardedLoad(
+/// "remote/x")` 로 치환(가드가 내부에서 `loadRemote` 호출 + 거부 폴백).
+/// runtime 은 applyMfRemotesSeam 이 external+글로벌(__mf_runtime) 처리 →
+/// host 환경이 그 글로벌로 스펙 런타임 제공(P1-2/P1-3 글로벌-seam 모델
+/// 일관, iife/umd/amd valid). 반환 = 새 owned 문자열(caller 가 기존 src
+/// free). 정적 `import X from "remote/x"` 는 비-목표(async 강등 — 후속).
 pub fn emitHostInit(
     allocator: std.mem.Allocator,
     src: []const u8,
@@ -70,9 +89,8 @@ pub fn emitHostInit(
 ) ![]const u8 {
     var out: std.ArrayListUnmanaged(u8) = .empty;
     errdefer out.deinit(allocator);
-    const w = out.writer(allocator);
 
-    // ── init prelude (멱등: runtime.init 자체 멱등) ──
+    // ── init prelude (멱등: runtime.init 자체 멱등) + 런타임 가드 정의 ──
     try out.appendSlice(allocator, "(function(){var R=globalThis." ++ MF_RUNTIME_GLOBAL ++ ";if(R&&R.init)R.init({\"name\":");
     try emitter.appendJsonString(&out, allocator, mf.name orelse "host");
     try out.appendSlice(allocator, ",\"remotes\":[");
@@ -85,19 +103,21 @@ pub fn emitHostInit(
         try emitter.appendJsonString(&out, allocator, r.entry);
         try out.append(allocator, '}');
     }
-    try out.appendSlice(allocator, "]});})();");
+    // P3-5: init 후 가드 정의(글로벌 — 모듈 스코프 재작성 코드가 호출).
+    try out.appendSlice(allocator, "]});" ++ GUARD_DEF ++ "})();");
 
     // ── 원격 동적 import 재작성: `import(<q><remote>...)` →
-    //    `globalThis.__mf_runtime.loadRemote(<q><remote>...)`. 매칭 외 구간은
-    //    appendSlice 청크 복사(바이트별 append 회피 — 출력크기 비례 O(n),
-    //    wrapContainer splice 와 동일 관례). `import(` 만 교체, 따옴표·
-    //    specifier·잔여(2nd-arg/attributes 포함)는 그대로 보존. 스캔은
+    //    `globalThis.__mfGuardedLoad(<q><remote>...)`(P3-5 가드 경유 —
+    //    내부서 loadRemote + 거부 폴백). 매칭 외 구간은 appendSlice 청크
+    //    복사(바이트별 append 회피, wrapContainer splice 관례). `import(`
+    //    만 교체 — 따옴표·specifier·잔여(2nd-arg/attributes)·닫는 괄호는
+    //    그대로 보존(가드가 인자 forward → 닫는 괄호 추적 불요). 스캔은
     //    nextRemoteImport 단일 소스(verifyHostContract 와 규칙 공유). ──
     var last: usize = 0;
     var i: usize = 0;
     while (nextRemoteImport(src, mf, &i)) |h| {
         try out.appendSlice(allocator, src[last..h.p]);
-        try w.print("globalThis.{s}.loadRemote(", .{MF_RUNTIME_GLOBAL});
+        try out.appendSlice(allocator, MF_GUARDED ++ "(");
         last = h.p + IMPORT_NEEDLE.len; // 따옴표부터는 다음 flush 가 보존
     }
     try out.appendSlice(allocator, src[last..]);
@@ -630,14 +650,19 @@ test "exposeListed: ./ 정규화·정확매칭·부재·중첩·bare key" {
     try std.testing.expect(!exposeListed(&exposes, "app", "app")); // 기본 expose 미게시
 }
 
-test "emitHostInit 회귀: 원격 동적 import → loadRemote, 비원격 보존" {
+test "emitHostInit 회귀: 원격 import → __mfGuardedLoad(P3-5), 가드 정의, 비원격 보존" {
     const a = std.testing.allocator;
     const remotes = [_]types.MfBundleConfig.KV{.{ .key = "app", .value = "app@http://x/r.js" }};
     const mf = tMf(&remotes);
     const src = "const x=import(\"app/W\");const y=import(\"lodash\");";
     const out = try emitHostInit(a, src, &mf);
     defer a.free(out);
-    try std.testing.expect(std.mem.indexOf(u8, out, "globalThis." ++ MF_RUNTIME_GLOBAL ++ ".loadRemote(\"app/W\")") != null);
+    // P3-5: 원격 동적 import 가 가드 경유(인자=specifier 그대로 forward)
+    try std.testing.expect(std.mem.indexOf(u8, out, MF_GUARDED ++ "(\"app/W\")") != null);
+    // 가드 정의(prelude) + 내부서 표준 loadRemote 호출(interop 보존)
+    try std.testing.expect(std.mem.indexOf(u8, out, MF_GUARDED ++ "=function(") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "RR.loadRemote.apply(RR,a)") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "__mfUnavailable:true") != null); // 폴백
     try std.testing.expect(std.mem.indexOf(u8, out, "import(\"lodash\")") != null); // 비원격 불변
     try std.testing.expect(std.mem.indexOf(u8, out, ".init({\"name\":\"host\"") != null); // prelude
 }

--- a/tests/e2e/tests/mf-interop-e2e.test.ts
+++ b/tests/e2e/tests/mf-interop-e2e.test.ts
@@ -473,3 +473,129 @@ test('P2-5 shared singleton(실브라우저): host react ≡ zntc remote react',
     await rm(hostDir, { recursive: true, force: true });
   }
 });
+
+// P3-5 (#3440): D3 "빌드 핀 + 런타임 가드" 양쪽을 영구 박제.
+// (A) 빌드-핀: 로컬 resolve 가능 remote 의 부재 expose import → 빌드
+//     fail-fast(S6, P3-1). (B) 런타임-가드: http/도달불가 remote(빌드타임
+//     검증 불가→skip)가 런타임에 거부 → __mfGuardedLoad 가 폴백, 셸
+//     생존(white-screen 아님). 표준 @module-federation/[email protected].
+test('P3-5 빌드-핀(S6): 로컬 remote 부재 expose import → 빌드 fail-fast', async () => {
+  test.setTimeout(90_000);
+  const remoteDir = await mkdtemp(join(tmpdir(), 'zntc-p35bf-remote-'));
+  const hostDir = await mkdtemp(join(tmpdir(), 'zntc-p35bf-host-'));
+  try {
+    const remoteDist = join(remoteDir, 'dist');
+    await mkdir(remoteDist, { recursive: true });
+    await writeFile(join(remoteDir, 'Widget.ts'), `export default () => "OK";`);
+    await writeFile(join(remoteDir, 'index.ts'), `export const s = "re";`);
+    await writeFile(
+      join(remoteDir, 'zntc.config.json'),
+      JSON.stringify({ mf: { name: 'app', exposes: { './Widget': './Widget.ts' } } }),
+    );
+    const rb = spawnSync(
+      ZNTC_BIN,
+      ['--bundle', join(remoteDir, 'index.ts'), '--outdir', remoteDist, '--format=iife'],
+      { cwd: remoteDir, stdio: 'pipe', timeout: 20000 },
+    );
+    expect(rb.status, `remote build: ${rb.stderr?.toString().slice(0, 400)}`).toBe(0);
+    const manifestAbs = join(remoteDist, 'mf-manifest.json');
+
+    const buildHost = async (spec: string) => {
+      await writeFile(
+        join(hostDir, 'index.ts'),
+        `async function m(){ const x = await import(${JSON.stringify(spec)}); console.log(x); }\nm();`,
+      );
+      await writeFile(
+        join(hostDir, 'zntc.config.json'),
+        JSON.stringify({ mf: { name: 'host', remotes: { app: `app@${manifestAbs}` } } }),
+      );
+      return spawnSync(
+        ZNTC_BIN,
+        ['--bundle', join(hostDir, 'index.ts'), '-o', join(hostDir, 'host.js'), '--format=iife'],
+        { cwd: hostDir, stdio: 'pipe', timeout: 20000 },
+      );
+    };
+    // 존재 expose → 빌드 성공(정밀 fail-fast: blanket 아님)
+    expect((await buildHost('app/Widget')).status).toBe(0);
+    // 부재 expose → 빌드 fail-fast(런타임 깨짐 아님)
+    const bad = await buildHost('app/Missing');
+    expect(bad.status).not.toBe(0);
+    expect(bad.stderr?.toString()).toContain('MF expose 계약 위반');
+  } finally {
+    await rm(remoteDir, { recursive: true, force: true });
+    await rm(hostDir, { recursive: true, force: true });
+  }
+});
+
+test('P3-5 런타임-가드(실브라우저): 도달불가 remote → 폴백 렌더, 셸 생존', async ({ page }) => {
+  test.setTimeout(90_000);
+  const hostDir = await mkdtemp(join(tmpdir(), 'zntc-p35rg-host-'));
+  let hostSrv: Awaited<ReturnType<typeof serve>> | undefined;
+  try {
+    // http 도달불가 remote(port 1=connection refused). http → P3-1/2/3
+    // 빌드타임 검증 skip(검증 불가 ≠ 위반) → 빌드 성공 → 런타임 가드
+    // 가 유일 안전망. m.__mfUnavailable 폴백 감지 → 셸 생존.
+    await writeFile(
+      join(hostDir, 'index.ts'),
+      `async function main(){ const m = await import("app/Widget");` +
+        ` document.getElementById("out").textContent = (m && m.__mfUnavailable)` +
+        ` ? "GUARD-OK" : ("NO-GUARD:" + String(m && (m.default || m)));` +
+        ` window.__done = true; }\n` +
+        `main().catch((e) => { window.__err = String((e && e.stack) || e); window.__done = true; });`,
+    );
+    await writeFile(
+      join(hostDir, 'zntc.config.json'),
+      JSON.stringify({
+        mf: { name: 'host', remotes: { app: 'app@http://127.0.0.1:1/mf-manifest.json' } },
+      }),
+    );
+    const hb = spawnSync(
+      ZNTC_BIN,
+      [
+        '--bundle',
+        join(hostDir, 'index.ts'),
+        '-o',
+        join(hostDir, 'host.js'),
+        '--format=iife',
+        '--platform=browser',
+      ],
+      { cwd: hostDir, stdio: 'pipe', timeout: 20000 },
+    );
+    // http remote 라 빌드타임 검증 skip → 빌드 성공(런타임 가드 시나리오)
+    expect(hb.status, `zntc host build: ${hb.stderr?.toString().slice(0, 500)}`).toBe(0);
+
+    await buildGlue(hostDir);
+    await writeFile(
+      join(hostDir, 'index.html'),
+      `<!DOCTYPE html><html><head><meta charset="utf-8">` +
+        `<script src="./glue.js"></script></head><body><div id="out">pending</div>` +
+        `<script src="./host.js"></script></body></html>`,
+    );
+    hostSrv = await serve(hostDir);
+
+    const pageErrors: string[] = [];
+    page.on('pageerror', (e) => pageErrors.push(e.message));
+    const consoleErrs: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrs.push(msg.text());
+    });
+    await page.goto(`http://localhost:${hostSrv.port}/`);
+    await page.waitForFunction(() => (window as { __done?: boolean }).__done === true, {
+      timeout: 20000,
+    });
+
+    // 가드가 거부를 catch → main() 정상 완료(throw 아님), 셸 생존
+    expect(await page.evaluate(() => (window as { __err?: string }).__err)).toBeFalsy();
+    expect(await page.locator('#out').textContent()).toBe('GUARD-OK');
+    // 폴백은 silent 아님 — 관측가능한 console.error
+    expect(
+      consoleErrs.some((t) => t.includes('[mf] runtime guard')),
+      `console errors: ${consoleErrs.join(' | ')}`,
+    ).toBe(true);
+    // unhandled pageerror 없음(가드가 흡수 — white-screen 방지)
+    expect(pageErrors, `pageerror: ${pageErrors.join(', ')}`).toHaveLength(0);
+  } finally {
+    if (hostSrv) await closeServer(hostSrv.server);
+    await rm(hostDir, { recursive: true, force: true });
+  }
+});

--- a/tests/integration/tests/mf-runtime-interop-smoke.test.ts
+++ b/tests/integration/tests/mf-runtime-interop-smoke.test.ts
@@ -702,8 +702,11 @@ console.log('SAME=' + (m && m.usedHook === hostReact.useState));
     expect(hostSrc).toContain(
       'R.init({"name":"host","remotes":[{"name":"remoteA","entry":"http://localhost:',
     );
-    // 원격 동적 import 재작성
-    expect(hostSrc).toContain('globalThis.__mf_runtime.loadRemote("remoteA/Widget")');
+    // 원격 동적 import 재작성 — P3-5 런타임 가드 경유(인자 그대로
+    // forward) + 가드 정의(내부서 표준 loadRemote 호출 = interop 보존)
+    expect(hostSrc).toContain('globalThis.__mfGuardedLoad("remoteA/Widget")');
+    expect(hostSrc).toContain('globalThis.__mfGuardedLoad=function(');
+    expect(hostSrc).toContain('RR.loadRemote.apply(RR,a)');
 
     // 3) 실 @module-federation/runtime 을 글로벌로 제공 후 host 번들 실행
     const mfRuntime = createRequire(import.meta.url).resolve('@module-federation/runtime');
@@ -1062,8 +1065,8 @@ console.log('SAME=' + (m && m.usedHook === hostReact.useState));
     // prelude remotes 배열에 두 remote 모두 + 각각 loadRemote 재작성
     expect(hostSrc).toMatch(/"name":"appA","entry":"http:\/\/localhost:\d+\/index\.js"/);
     expect(hostSrc).toMatch(/"name":"appB","entry":"http:\/\/localhost:\d+\/index\.js"/);
-    expect(hostSrc).toContain('globalThis.__mf_runtime.loadRemote("appA/X")');
-    expect(hostSrc).toContain('globalThis.__mf_runtime.loadRemote("appB/Y")');
+    expect(hostSrc).toContain('globalThis.__mfGuardedLoad("appA/X")'); // P3-5 가드 경유
+    expect(hostSrc).toContain('globalThis.__mfGuardedLoad("appB/Y")');
 
     const mfRuntime = createRequire(import.meta.url).resolve('@module-federation/runtime');
     driverPath = join(hostFx.dir, 'mr-driver.mjs');


### PR DESCRIPTION
## 개요
P3-5 — MF 에픽 #3318 **P3 의 마지막 단위**. RFC §4.1(line 90: host 검증 + **런타임 가드 폴백**) · §9("빌드 핀 + 런타임 가드"). P3-1/2/3 빌드 핀은 host 가 remote manifest 를 **로컬 resolve 가능할 때만** fail-fast — http remote·배포후 drift 는 검증 불가 → skip. **P3-5 = 그 사각의 런타임 안전망**: 계약 위반/도달불가 시 셸 크래시 대신 graceful 폴백.

## 변경
- **`federation_emit.zig`**
  - `MF_GUARDED` + `GUARD_DEF`(comptime `++` 상수, 런타임 할당 0): `__mfGuardedLoad` = `loadRemote` 를 감싸 거부/sync-throw → `console.error('[mf] runtime guard…')` + 폴백 `{default:()=>null, __mfUnavailable:true}`.
  - `emitHostInit`: prelude 끝에 `GUARD_DEF` 정의(글로벌), 재작성 callee 를 `globalThis.__mf_runtime.loadRemote(` → `globalThis.__mfGuardedLoad(` 로 교체. **인자·닫는 괄호 그대로 forward**(가드가 `arguments`→`loadRemote` 호출 → 닫는 괄호 추적 불요, `nextRemoteImport` 단일소스 불변). 미사용화된 `const w` 제거.
  - **성공 경로 불변**: `Promise.resolve(RR.loadRemote.apply(RR,a))` passthrough → `.catch` 미발동 → S3/S4/P2-5 interop·lazy·shared singleton 보존. `RR` lazy 평가(호출 시점 — init/glue 순서 무관). D1: loadRemote=스펙 호출, 가드는 얇은 try/catch 래퍼(코어 재구현 아님).
  - inline 회귀 test 갱신.
- **smoke 3 단언 갱신**(loadRemote→`__mfGuardedLoad`; prelude/remotes 단언 유지 — step3 실 `@module-federation/runtime` 드라이버가 가드 경유 success-path 를 통합 레벨 실증).
- **e2e 2 신규**(P2-5 하네스):
  - ① **빌드-핀(S6)**: 로컬 remote 부재 expose import → `status≠0` + stderr `'MF expose 계약 위반'`(정밀 — 존재 expose 는 `status 0`).
  - ② **런타임-가드(실 Chromium)**: `http://127.0.0.1:1` 도달불가 remote(http=P3 빌드검증 skip → **빌드 성공**) → `__mfGuardedLoad` 폴백 → `#out`=="GUARD-OK" + `window.__err` falsy(셸 생존) + `console.error '[mf] runtime guard'` 관측 + `pageerror` 0(white-screen 방지).

## 폴백 의미론 (RFC §4.1 line 90)
거부 흡수는 graceful degradation — **비-silent**(console.error) + **관측가능**(`__mfUnavailable` 플래그). 셸 생존이 white-screen 보다 우월. 항상-on 정당: 빌드 핀이 로컬 resolve 가능 시만 차단하므로 http remote 는 가드가 유일 안전망(§9 정합).

## 검증
- `zig build test` **0** / `wasm-bundler` **0** / `zig build`(install) **0**.
- MF 통합 스모크 **18 pass**(무회귀), MF e2e **6 passed**(S3/S4/P2-5 무회귀 = passthrough 보존, P3-5 2 신규).
- `/simplify` 3-에이전트(재사용·품질·효율) **차단 0·수정 0**: GUARD_DEF `node --check` JS 문법·escape 정확, 성공 passthrough 코드+e2e 실증, 폴백 의미론 RFC 정합, 거짓통과 3중 단언 방어를 정밀 검증.

## P3 완결
분해(#3441) + **P3-0(#3442)·P3-1(#3443)·P3-2(#3444)·P3-3(#3450)·P3-4(#3452)·P3-5** = 빌드 핀(expose·shared·무결성) + 소유권 린트 + 런타임 가드 전부.

Closes #3440

🤖 Generated with [Claude Code](https://claude.com/claude-code)