### PR TITLE
test(mf): P3 회귀-방어 커버리지 보강 — 가드 noop·비-네트워크 reject·loadContract (#3318)

### DIFF
--- a/src/bundler/mf_contract.zig
+++ b/src/bundler/mf_contract.zig
@@ -361,3 +361,21 @@ test "sidecarFileSri: 변조 manifest → SRI 불일치 탐지" {
     defer a.free(tampered);
     try std.testing.expect(!std.mem.eql(u8, expected, tampered)); // verifyIntegrity 의 mismatch 핵심
 }
+
+test "loadContract: 부재 → MfContractManifestNotFound, 디렉터리(IsDir) → MfContractMalformed" {
+    const a = std.testing.allocator;
+    // 부재(절대 .json) → 부재 ≠ 결함(P3-1 이 구분해 fail-fast 메시지)
+    try std.testing.expectError(
+        error.MfContractManifestNotFound,
+        loadContract(a, null, "/zntc-nonexistent-xyzzy/mf-manifest.json"),
+    );
+    // read-fail(권한/IO 류) — 디렉터리를 manifest 경로로 → IsDir → 결함
+    var td = std.testing.tmpDir(.{});
+    defer td.cleanup();
+    try td.dir.makeDir("d.json");
+    const base = try td.dir.realpathAlloc(a, ".");
+    defer a.free(base);
+    const dirpath = try std.fs.path.join(a, &.{ base, "d.json" });
+    defer a.free(dirpath);
+    try std.testing.expectError(error.MfContractMalformed, loadContract(a, null, dirpath));
+}

--- a/tests/e2e/tests/mf-interop-e2e.test.ts
+++ b/tests/e2e/tests/mf-interop-e2e.test.ts
@@ -535,11 +535,16 @@ test('P3-5 런타임-가드(실브라우저): 도달불가 remote → 폴백 렌
     // http 도달불가 remote(port 1=connection refused). http → P3-1/2/3
     // 빌드타임 검증 skip(검증 불가 ≠ 위반) → 빌드 성공 → 런타임 가드
     // 가 유일 안전망. m.__mfUnavailable 폴백 감지 → 셸 생존.
+    // 폴백 모듈(F())의 default 를 **실제 호출** — noop 이 throw 없이
+    // null 반환해야 실사용 셸 생존(GUARD_DEF default:()=>null 계약 회귀
+    // 방어: __mfUnavailable 만 보면 default() 회귀를 못 잡음).
     await writeFile(
       join(hostDir, 'index.ts'),
       `async function main(){ const m = await import("app/Widget");` +
-        ` document.getElementById("out").textContent = (m && m.__mfUnavailable)` +
-        ` ? "GUARD-OK" : ("NO-GUARD:" + String(m && (m.default || m)));` +
+        ` const v = (m && (m.default || m))();` +
+        ` document.getElementById("out").textContent =` +
+        ` (m && m.__mfUnavailable && v === null) ? "GUARD-OK"` +
+        ` : ("NO-GUARD:" + String(m && m.__mfUnavailable) + ":" + String(v));` +
         ` window.__done = true; }\n` +
         `main().catch((e) => { window.__err = String((e && e.stack) || e); window.__done = true; });`,
     );
@@ -596,6 +601,113 @@ test('P3-5 런타임-가드(실브라우저): 도달불가 remote → 폴백 렌
     expect(pageErrors, `pageerror: ${pageErrors.join(', ')}`).toHaveLength(0);
   } finally {
     if (hostSrv) await closeServer(hostSrv.server);
+    await rm(hostDir, { recursive: true, force: true });
+  }
+});
+
+// P3-5 보강: 런타임 가드는 **네트워크 거부만이 아니라 모든 loadRemote
+// 거부**(expose 런타임 부재 등)를 흡수해야 한다. reachable zntc remote
+// (./Widget)를 http 서빙하되 host 는 부재 expose `app/Missing` import →
+// http remote 라 빌드타임 P3-1 skip(빌드 성공) → 표준 runtime
+// loadRemote 가 expose-missing 으로 reject → 가드 폴백 → 셸 생존.
+test('P3-5 런타임-가드(실브라우저): 도달가능 remote의 런타임 expose 부재 → 폴백', async ({
+  page,
+}) => {
+  test.setTimeout(90_000);
+  const remoteDir = await mkdtemp(join(tmpdir(), 'zntc-p35rg2-remote-'));
+  const hostDir = await mkdtemp(join(tmpdir(), 'zntc-p35rg2-host-'));
+  let remoteSrv: Awaited<ReturnType<typeof serve>> | undefined;
+  let hostSrv: Awaited<ReturnType<typeof serve>> | undefined;
+  try {
+    const remoteDist = join(remoteDir, 'dist');
+    await mkdir(remoteDist, { recursive: true });
+    remoteSrv = await serve(remoteDist, { 'Access-Control-Allow-Origin': '*' });
+    const rOrigin = `http://localhost:${remoteSrv.port}`;
+    await writeFile(join(remoteDir, 'Widget.ts'), `export default () => "REAL";`);
+    await writeFile(join(remoteDir, 'index.ts'), `export const sentinel = "re";`);
+    await writeFile(
+      join(remoteDir, 'zntc.config.json'),
+      JSON.stringify({ mf: { name: 'app', exposes: { './Widget': './Widget.ts' } } }),
+    );
+    const rb = spawnSync(
+      ZNTC_BIN,
+      [
+        '--bundle',
+        join(remoteDir, 'index.ts'),
+        '--outdir',
+        remoteDist,
+        '--format=iife',
+        '--platform=browser',
+        `--public-path=${rOrigin}/`,
+      ],
+      { cwd: remoteDir, stdio: 'pipe', timeout: 20000 },
+    );
+    expect(rb.status, `remote build: ${rb.stderr?.toString().slice(0, 400)}`).toBe(0);
+
+    // host 는 **존재하지 않는** expose import. http manifest entry →
+    // 빌드타임 P3-1 검증 skip(네트워크=비-목표) → 빌드 성공.
+    await writeFile(
+      join(hostDir, 'index.ts'),
+      `async function main(){ const m = await import("app/Missing");` +
+        ` const v = (m && (m.default || m))();` +
+        ` document.getElementById("out").textContent =` +
+        ` (m && m.__mfUnavailable && v === null) ? "GUARD-OK"` +
+        ` : ("NO-GUARD:" + String(m && m.__mfUnavailable) + ":" + String(v));` +
+        ` window.__done = true; }\n` +
+        `main().catch((e) => { window.__err = String((e && e.stack) || e); window.__done = true; });`,
+    );
+    await writeFile(
+      join(hostDir, 'zntc.config.json'),
+      JSON.stringify({
+        mf: { name: 'host', remotes: { app: `app@${rOrigin}/mf-manifest.json` } },
+      }),
+    );
+    const hb = spawnSync(
+      ZNTC_BIN,
+      [
+        '--bundle',
+        join(hostDir, 'index.ts'),
+        '-o',
+        join(hostDir, 'host.js'),
+        '--format=iife',
+        '--platform=browser',
+      ],
+      { cwd: hostDir, stdio: 'pipe', timeout: 20000 },
+    );
+    expect(hb.status, `host build: ${hb.stderr?.toString().slice(0, 500)}`).toBe(0);
+
+    await buildGlue(hostDir);
+    await writeFile(
+      join(hostDir, 'index.html'),
+      `<!DOCTYPE html><html><head><meta charset="utf-8">` +
+        `<script src="./glue.js"></script></head><body><div id="out">pending</div>` +
+        `<script src="./host.js"></script></body></html>`,
+    );
+    hostSrv = await serve(hostDir);
+
+    const pageErrors: string[] = [];
+    page.on('pageerror', (e) => pageErrors.push(e.message));
+    const consoleErrs: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrs.push(msg.text());
+    });
+    await page.goto(`http://localhost:${hostSrv.port}/`);
+    await page.waitForFunction(() => (window as { __done?: boolean }).__done === true, {
+      timeout: 20000,
+    });
+
+    expect(await page.evaluate(() => (window as { __err?: string }).__err)).toBeFalsy();
+    // expose-missing reject(네트워크 아님) 도 가드가 흡수 → 폴백 noop=null
+    expect(await page.locator('#out').textContent()).toBe('GUARD-OK');
+    expect(
+      consoleErrs.some((t) => t.includes('[mf] runtime guard')),
+      `console errors: ${consoleErrs.join(' | ')}`,
+    ).toBe(true);
+    expect(pageErrors, `pageerror: ${pageErrors.join(', ')}`).toHaveLength(0);
+  } finally {
+    if (remoteSrv) await closeServer(remoteSrv.server);
+    if (hostSrv) await closeServer(hostSrv.server);
+    await rm(remoteDir, { recursive: true, force: true });
     await rm(hostDir, { recursive: true, force: true });
   }
 });

--- a/tests/integration/tests/mf-runtime-interop-smoke.test.ts
+++ b/tests/integration/tests/mf-runtime-interop-smoke.test.ts
@@ -1178,6 +1178,10 @@ console.log('SAME=' + (m && m.usedHook === hostReact.useState));
     ]);
     expect(ok.exitCode).toBe(0);
     expect(ok.stderr).not.toContain('소유권 경계');
+    // 주: shared 패키지는 seam 으로 external 화 → 그 모듈은 graph 에
+    // 없어 lintOwnershipBoundary(graph 순회) 대상이 아님. external dep
+    // 내부의 store 생성은 RFC §7.3 ②(외부/완전 데이터플로 미탐지 =
+    // 문서화된 휴리스틱 한계, 비-목표) — expose 경계 모듈만 린트 대상.
   }, 30000);
 });
 


### PR DESCRIPTION
## 개요
P3-0~P3-5(#3435~#3440) 머지 후 **테스트 커버리지 갭 감사** → 실동작은 전부 통과하나(zig/wasm/install 0, MF통합 18, e2e 6) **회귀를 못 잡는 빈 구멍** 보강. **구현 무변경** — 스펙(RFC §7.3/§3.2/§9) 정합 불변, 테스트만 추가.

## 변경 (test-only)
- **Gap1 [e2e]** — P3-5 런타임-가드(도달불가) 강화: host 가 폴백 `m.default()` 를 **실제 호출**해 `v===null` 단언. 기존엔 `__mfUnavailable` 만 봐서 `GUARD_DEF` 의 `default:()=>null` noop 계약 회귀를 못 잡음(throw→`__err` / 비-null→`#out` 2중 방어).
- **Gap2 [e2e 신규]** — reachable zntc remote(http 서빙) + host 가 부재 `app/Missing` import → http=빌드타임 P3-1 **skip**(빌드 성공) → 표준 `@module-federation/[email protected]` `loadRemote` 가 **expose-missing(비-네트워크)** 으로 reject → 가드가 흡수(폴백 `GUARD-OK`+`default()===null`+`console.error` 관측+`pageerror 0`). #6(connection refused)과 별개 reject 소스 — `GUARD_DEF.catch` 의 **모든 reject 흡수** 계약 박제.
- **Gap4 [unit]** — `mf_contract.loadContract` inline: 부재 절대 `.json`→`MfContractManifestNotFound`, 디렉터리(`IsDir`)→`MfContractMalformed`(`std.testing.tmpDir` 결정적 FS). 부재≠결함 진단 분기 회귀가 어떤 테스트로도 안 잡히던 곳.
- **Gap3 [기각]** — shared-폐포 린트 케이스를 추가했다 제거: shared 패키지는 P1-2 seam 으로 **external 화** → 그 모듈이 module graph 에 없음 → `lintOwnershipBoundary`(graph 순회) 도달 불가. 감사 에이전트가 seam 상호작용을 놓침 = **실제 갭 아님**(RFC §7.3 ② 외부/완전 데이터플로 미탐지 = 문서화된 휴리스틱 한계). 순변경 = 그 사유 설명 주석 4줄.
- **Gap5 [수용]** — `lintOwnershipBoundary` unit: `std.log.warn` 부작용이라 src 리팩터 없이 unit 단언 불가. `prohibitedStoreFactory` 15-케이스 inline + 통합 ①② 가 실경로 커버 → 추가 불요.

## 갭 분류 결과
실제 갭 = Gap1·2·4(보강 완료). Gap3 = 도달불가 시나리오(기각, 사유 박제). Gap5 = 수용. 나머지(version_warn 통합/bare import/singleton 양방향 등)는 inline 박제 충분 또는 RFC 비-목표.

## 검증
- `zig build test` **0**(Gap4 inline) / `wasm-bundler` **0** / `zig build`(install) **0**.
- MF 통합 스모크 **18 pass**, MF e2e **7 passed**(S3/S4/P2-5/P3-1~5 무회귀, P3-5 가드 #6 강화·#7 신규).
- `/simplify` 3-에이전트 통합 **차단 0**: Gap1/2 가 GUARD_DEF noop-default·비-네트워크 reject 흡수 계약을 실제 박제(2중 방어), Gap4 FS 분기 Zig 0.15.2 실증, Gap3 제거 판단(seam-external 한계) 정확, S3/S4/P2-5/P3-1~5 무회귀를 코드로 재확인.

P3 에픽(#3318) 후속 커버리지 보강 — 닫을 별도 이슈 없음(웹 MF 3페이즈 P1/P2/P3 전부 완결 상태 유지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)