### PR TITLE
feat(emitter): CJS wrapper mangle 기본 ON + RN 가드 (RFC PR-4)

### DIFF
--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -2718,10 +2718,11 @@ test "#1618 minify: __commonJS → $cj short name" {
 
     try std.testing.expect(!result.hasErrors());
     // minify 모드: preamble이 `var $c=` 형태로 축약 (#3256: $cj → $c 1 char 단축).
-    // 호출부는 직접 함수 패턴을 쓰되 callback param 은 Node/Metro 호환성을 위해
-    // minify에서도 `exports, module` 을 유지.
+    // RFC PR-4 기본 ON: browser/node CJS wrapper param 은 `$e`/`$m` 로 mangle
+    // (codegen 합성·free-ref 와 단일 소스 동기, 144-lib 런타임 MATCH 전수).
+    // react_native 만 Metro 호환 위해 `exports`/`module` 보존 (별도 RN 테스트).
     try std.testing.expect(std.mem.indexOf(u8, result.output, "var $c=") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "=$c((exports,module)=>") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "=$c(($e,$m)=>") != null);
     // 원본 `__commonJS` 이름은 나타나지 않아야 함
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__commonJS") == null);
 }

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -40,10 +40,10 @@ const CodegenOptions = @import("../codegen/codegen.zig").CodegenOptions;
 const cg_options = @import("../codegen/options.zig");
 const SourceMap = @import("../codegen/sourcemap.zig");
 
-/// kill-switch (RFC PR-3, 기본 OFF). set 일 때만 CJS wrapper 의
-/// `exports`/`module` arrow 파라미터·본문 free 참조를 짧은 이름으로
-/// mangle. unset 시 codegen 옵션·wrapper 모두 default → 출력 무변경.
-const cjs_wrap_mangle_env = @import("../env_flag.zig").Once("ZNTC_CJS_WRAP_MANGLE");
+/// kill-switch (RFC PR-4, 기본 ON — measure-first 게이트 통과: 144-lib
+/// −25,694B 회귀0·런타임 MATCH 전수). set 시 CJS wrapper exports/module
+/// mangle 비활성화 → codegen 옵션·wrapper 모두 default 로 복귀.
+const cjs_wrap_mangle_disabled = @import("../env_flag.zig").Once("ZNTC_NO_CJS_WRAP_MANGLE");
 
 /// CJS wrapper mangle 시 사용할 모듈-로컬 2글자 이름. arrow 파라미터라
 /// 모듈 스코프에 격리(타 모듈/top-level 빈도풀 무관) — codegen 합성·free
@@ -1742,11 +1742,15 @@ pub fn emitModule(
     }
 
     // Codegen: AST → JS 문자열
-    // CJS wrapper exports/module mangle (RFC PR-3): kill-switch + CJS wrap
-    // + minify 일 때만. codegen 합성/free-ref 와 wrapper 파라미터가 같은
-    // 이름을 써야 하므로 단일 소스로 계산. 비활성 시 default → 무변경.
-    const cjs_mangle = cjs_wrap_mangle_env.enabled() and
-        module.wrap_kind == .cjs and options.minify_whitespace;
+    // CJS wrapper exports/module mangle (RFC PR-4, 기본 ON): CJS wrap +
+    // minify 일 때 적용. codegen 합성/free-ref 와 wrapper 파라미터가 같은
+    // 이름을 써야 하므로 단일 소스로 계산. kill-switch 시 default → 무변경.
+    // react_native 제외: Metro serializer/require 시스템이 CJS wrapper
+    // 파라미터 이름(`exports`/`module`)을 가정하므로 RN 빌드는 보존 필수
+    // (semantic-preserving — RN 은 이 레버 포기, 정확성 우선).
+    const cjs_mangle = !cjs_wrap_mangle_disabled.enabled() and
+        module.wrap_kind == .cjs and options.minify_whitespace and
+        options.platform != .react_native;
     const cjs_ex_name = if (cjs_mangle) CJS_MANGLE_EXPORTS else cg_options.default_cjs_exports_name;
     const cjs_mod_name = if (cjs_mangle) CJS_MANGLE_MODULE else cg_options.default_cjs_module_name;
 


### PR DESCRIPTION
## PR-4 (default-on 승격 · RN 가드 · 게이트 통과 확정)

epic `cjs-wrap-mangle` 최종 단계. measure-first 게이트 통과(PR-3: 144-lib **−25,694B / 회귀0 / 런타임 MATCH 전수**)로 default-on 승격.

- `ZNTC_CJS_WRAP_MANGLE`(opt-in) → `ZNTC_NO_CJS_WRAP_MANGLE`(kill-switch) 반전. 성공 size 레버 컨벤션 — `ZNTC_NO_DECL_COALESCE`와 동형(기본 적용 + NO_ 비활성 토글)
- **RN 가드**: `platform == .react_native` 는 mangle 제외. Metro serializer/require 시스템이 CJS wrapper 파라미터 이름(`exports`/`module`)을 가정하므로 RN 빌드는 보존 필수 — semantic-preserving 절대원칙, RN은 이 레버 포기(정확성 우선). 기존 RN 테스트 2건(`RN minified ... keeps Node parameter names`, `... rewrites CJS module param`)이 이 계약을 검증 → 통과
- `#1618`(browser) 기대값을 default-ON 새 동작(`$e`/`$m`)으로 갱신 — browser는 Metro 무관, smoke 런타임 MATCH 전수로 정확성 입증된 의도적 변경(스냅샷 성격)

## pre-push 게이트 미스 → 수정

PR-3 smoke 게이트(platform=node)가 **RN 경로를 커버 못 함**. pre-push `zig build test`가 RN 테스트 3건 회귀를 잡아냄(measure-first 게이트의 안전망 작동). RN 가드로 Metro 계약 복원, #1618은 의도된 변경이라 기대값 갱신. → `zig build test` 5225 전체 통과.

## 검증

- node default mangle 유지 (ajv −2,601, `$e`), `ZNTC_NO_CJS_WRAP_MANGLE=1` 복귀 (120,161 = epic baseline)
- RN 빌드 `exports`/`module` 보존 (RN 테스트 2건 통과)
- `zig build test` 전체 통과 (5225), Debug+ReleaseFast OK, zig fmt 통과

## 후속

epic `cjs-wrap-mangle` → main 승격 PR (PR-1~4 누적: corpus −25KB CJS wrapper mangle, mangler 아키텍처 무관 별개 루트커즈).

🤖 Generated with [Claude Code](https://claude.com/claude-code)