### PR TITLE
perf(minify): CJS wrapper exports/module mangle — corpus −25KB (epic, RFC PR-1~4)

### DIFF
--- a/src/bundler/bundler_test/minify_loader.zig
+++ b/src/bundler/bundler_test/minify_loader.zig
@@ -2718,10 +2718,11 @@ test "#1618 minify: __commonJS → $cj short name" {
 
     try std.testing.expect(!result.hasErrors());
     // minify 모드: preamble이 `var $c=` 형태로 축약 (#3256: $cj → $c 1 char 단축).
-    // 호출부는 직접 함수 패턴을 쓰되 callback param 은 Node/Metro 호환성을 위해
-    // minify에서도 `exports, module` 을 유지.
+    // RFC PR-4 기본 ON: browser/node CJS wrapper param 은 `$e`/`$m` 로 mangle
+    // (codegen 합성·free-ref 와 단일 소스 동기, 144-lib 런타임 MATCH 전수).
+    // react_native 만 Metro 호환 위해 `exports`/`module` 보존 (별도 RN 테스트).
     try std.testing.expect(std.mem.indexOf(u8, result.output, "var $c=") != null);
-    try std.testing.expect(std.mem.indexOf(u8, result.output, "=$c((exports,module)=>") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "=$c(($e,$m)=>") != null);
     // 원본 `__commonJS` 이름은 나타나지 않아야 함
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__commonJS") == null);
 }

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -40,10 +40,10 @@ const CodegenOptions = @import("../codegen/codegen.zig").CodegenOptions;
 const cg_options = @import("../codegen/options.zig");
 const SourceMap = @import("../codegen/sourcemap.zig");
 
-/// kill-switch (RFC PR-3, 기본 OFF). set 일 때만 CJS wrapper 의
-/// `exports`/`module` arrow 파라미터·본문 free 참조를 짧은 이름으로
-/// mangle. unset 시 codegen 옵션·wrapper 모두 default → 출력 무변경.
-const cjs_wrap_mangle_env = @import("../env_flag.zig").Once("ZNTC_CJS_WRAP_MANGLE");
+/// kill-switch (RFC PR-4, 기본 ON — measure-first 게이트 통과: 144-lib
+/// −25,694B 회귀0·런타임 MATCH 전수). set 시 CJS wrapper exports/module
+/// mangle 비활성화 → codegen 옵션·wrapper 모두 default 로 복귀.
+const cjs_wrap_mangle_disabled = @import("../env_flag.zig").Once("ZNTC_NO_CJS_WRAP_MANGLE");
 
 /// CJS wrapper mangle 시 사용할 모듈-로컬 2글자 이름. arrow 파라미터라
 /// 모듈 스코프에 격리(타 모듈/top-level 빈도풀 무관) — codegen 합성·free
@@ -1742,11 +1742,15 @@ pub fn emitModule(
     }
 
     // Codegen: AST → JS 문자열
-    // CJS wrapper exports/module mangle (RFC PR-3): kill-switch + CJS wrap
-    // + minify 일 때만. codegen 합성/free-ref 와 wrapper 파라미터가 같은
-    // 이름을 써야 하므로 단일 소스로 계산. 비활성 시 default → 무변경.
-    const cjs_mangle = cjs_wrap_mangle_env.enabled() and
-        module.wrap_kind == .cjs and options.minify_whitespace;
+    // CJS wrapper exports/module mangle (RFC PR-4, 기본 ON): CJS wrap +
+    // minify 일 때 적용. codegen 합성/free-ref 와 wrapper 파라미터가 같은
+    // 이름을 써야 하므로 단일 소스로 계산. kill-switch 시 default → 무변경.
+    // react_native 제외: Metro serializer/require 시스템이 CJS wrapper
+    // 파라미터 이름(`exports`/`module`)을 가정하므로 RN 빌드는 보존 필수
+    // (semantic-preserving — RN 은 이 레버 포기, 정확성 우선).
+    const cjs_mangle = !cjs_wrap_mangle_disabled.enabled() and
+        module.wrap_kind == .cjs and options.minify_whitespace and
+        options.platform != .react_native;
     const cjs_ex_name = if (cjs_mangle) CJS_MANGLE_EXPORTS else cg_options.default_cjs_exports_name;
     const cjs_mod_name = if (cjs_mangle) CJS_MANGLE_MODULE else cg_options.default_cjs_module_name;
 

--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -37,7 +37,21 @@ const cache_mod = @import("compiled_cache.zig");
 pub const CompiledOutputCache = cache_mod.CompiledOutputCache;
 const Codegen = @import("../codegen/codegen.zig").Codegen;
 const CodegenOptions = @import("../codegen/codegen.zig").CodegenOptions;
+const cg_options = @import("../codegen/options.zig");
 const SourceMap = @import("../codegen/sourcemap.zig");
+
+/// kill-switch (RFC PR-3, 기본 OFF). set 일 때만 CJS wrapper 의
+/// `exports`/`module` arrow 파라미터·본문 free 참조를 짧은 이름으로
+/// mangle. unset 시 codegen 옵션·wrapper 모두 default → 출력 무변경.
+const cjs_wrap_mangle_env = @import("../env_flag.zig").Once("ZNTC_CJS_WRAP_MANGLE");
+
+/// CJS wrapper mangle 시 사용할 모듈-로컬 2글자 이름. arrow 파라미터라
+/// 모듈 스코프에 격리(타 모듈/top-level 빈도풀 무관) — codegen 합성·free
+/// 참조와 wrapper 파라미터가 이 이름을 공유한다. `$` prefix 는 mangler
+/// base54 알파벳(`$` 비포함) 및 runtime helper 와 비충돌: 144-lib smoke
+/// 런타임 MATCH 전수 통과로 실증.
+const CJS_MANGLE_EXPORTS = "$e";
+const CJS_MANGLE_MODULE = "$m";
 const error_codes = @import("../error_codes.zig");
 
 /// ZNTC0002 TLA+non-ESM 경고 주석. comptime 고정 — 코드/메시지가 error_codes와 항상 일치.
@@ -1728,8 +1742,18 @@ pub fn emitModule(
     }
 
     // Codegen: AST → JS 문자열
+    // CJS wrapper exports/module mangle (RFC PR-3): kill-switch + CJS wrap
+    // + minify 일 때만. codegen 합성/free-ref 와 wrapper 파라미터가 같은
+    // 이름을 써야 하므로 단일 소스로 계산. 비활성 시 default → 무변경.
+    const cjs_mangle = cjs_wrap_mangle_env.enabled() and
+        module.wrap_kind == .cjs and options.minify_whitespace;
+    const cjs_ex_name = if (cjs_mangle) CJS_MANGLE_EXPORTS else cg_options.default_cjs_exports_name;
+    const cjs_mod_name = if (cjs_mangle) CJS_MANGLE_MODULE else cg_options.default_cjs_module_name;
+
     var cg = Codegen.initWithOptions(arena_alloc, transformer.ast, .{
         .minify_whitespace = options.minify_whitespace,
+        .cjs_exports_name = cjs_ex_name,
+        .cjs_module_name = cjs_mod_name,
         // Peephole boolean 축약 등 codegen-레벨 출력 최적화(#1552).
         .minify_syntax = options.minify_syntax,
         // scope-hoisted 모듈은 항상 ESM codegen 사용 (bare declarations).
@@ -1854,11 +1878,16 @@ pub fn emitModule(
         if (options.minify_whitespace) {
             // emit 의 직접 함수 패턴은 `runtime_helpers.zig` 의 `CJS_RUNTIME_*` 가 cb 를
             // function 으로 받는 것과 한 쌍 — 한쪽만 바꾸면 runtime TypeError.
-            // param 이름은 Node/Metro 호환성을 위해 minify에서도 `exports, module` 유지.
+            // param 이름은 codegen 합성/free-ref 와 동일 소스(cjs_ex_name/cjs_mod_name).
+            // kill-switch OFF 면 default `exports`/`module` (Node/Metro 호환 유지).
             try wrapped.appendSlice(allocator, "var ");
             try wrapped.appendSlice(allocator, var_name);
             try wrapped.appendSlice(allocator, "=" ++ rt.NAMES.CJS_FACTORY_MIN);
-            try wrapped.appendSlice(allocator, "((exports,module)=>{");
+            try wrapped.appendSlice(allocator, "((");
+            try wrapped.appendSlice(allocator, cjs_ex_name);
+            try wrapped.appendSlice(allocator, ",");
+            try wrapped.appendSlice(allocator, cjs_mod_name);
+            try wrapped.appendSlice(allocator, ")=>{");
             if (preamble_code) |p| try wrapped.appendSlice(allocator, p);
             // body 의 trailing `;` 제거 — 다음 `})` 가 block close 라 ASI 안전.
             const body_trimmed = if (code.len > 0 and code[code.len - 1] == ';') code[0 .. code.len - 1] else code;

--- a/src/codegen/modules.zig
+++ b/src/codegen/modules.zig
@@ -386,7 +386,8 @@ pub fn emitExportNamedCJS(self: anytype, decl: NodeIndex, specs_start: u32, spec
             const exported_text = self.ast.getText(self.ast.getNode(exported_idx).span);
             const local_text = self.ast.getText(self.ast.getNode(local_idx).span);
 
-            try self.write("exports.");
+            try self.write(self.options.cjs_exports_name);
+            try self.writeByte('.');
             try self.write(exported_text);
             try self.writeByte('=');
             if (has_source) {
@@ -426,7 +427,8 @@ pub fn emitCJSExportBinding(self: anytype, decl_idx: NodeIndex) !void {
                             name
                     else
                         name;
-                    try self.write("exports.");
+                    try self.write(self.options.cjs_exports_name);
+                    try self.writeByte('.');
                     try self.write(name);
                     try self.writeByte('=');
                     try self.write(ref_name);
@@ -447,7 +449,8 @@ pub fn emitCJSExportBinding(self: anytype, decl_idx: NodeIndex) !void {
                         name
                 else
                     name;
-                try self.write("exports.");
+                try self.write(self.options.cjs_exports_name);
+                try self.writeByte('.');
                 try self.write(name);
                 try self.writeByte('=');
                 try self.write(ref_name);
@@ -497,7 +500,8 @@ pub fn emitExportDefault(self: anytype, node: Node) !void {
             }
             return;
         }
-        try self.write("module.exports=");
+        try self.write(self.options.cjs_module_name);
+        try self.write(".exports=");
         try self.emitNode(node.data.unary.operand);
         try self.writeByte(';');
         return;
@@ -593,7 +597,9 @@ pub fn emitExportAll(self: anytype, node: Node) !void {
     const x = module_parser.readExportAllExtras(self.ast, node.data.extra);
     if (self.options.module_format == .cjs) {
         // export * from './bar' → Object.assign(exports,require('./bar'));
-        try self.write("Object.assign(exports,require(");
+        try self.write("Object.assign(");
+        try self.write(self.options.cjs_exports_name);
+        try self.write(",require(");
         try self.emitNode(x.source);
         try self.write("));");
         return;

--- a/src/codegen/node_dispatch.zig
+++ b/src/codegen/node_dispatch.zig
@@ -4,6 +4,7 @@ const std = @import("std");
 const ast_mod = @import("../parser/ast.zig");
 const Ast = ast_mod.Ast;
 const NodeIndex = ast_mod.NodeIndex;
+const cg_options = @import("options.zig");
 const statement_emit = @import("statements.zig");
 const module_emit = @import("modules.zig");
 const type_runtime_emit = @import("type_runtime.zig");
@@ -185,6 +186,31 @@ pub fn emitNode(self: anytype, idx: NodeIndex) Error!void {
                             return;
                         }
                     }
+                }
+            }
+            // CJS wrapper free `exports`/`module` 참조 치환 (RFC PR-2). wrapper
+            // 파라미터를 짧은 이름으로 바꿀 때 본문 자유참조도 동기화한다.
+            // sym_id == null = 모듈 내 로컬 선언 없음 = __commonJS arrow 파라미터
+            // 를 가리킴 → 사용자 shadow(`var exports`)는 sym_id 가 잡혀 이 분기에
+            // 도달하지 않으므로 자동 제외. property key(`obj.exports`)·string·
+            // computed 는 다른 노드 태그라 미해당. 기본 이름이면 no-op (회귀 0).
+            if (self.options.module_format == .cjs and sym_id == null and
+                (node.tag == .identifier_reference or node.tag == .assignment_target_identifier))
+            {
+                const ident = self.ast.getText(node.data.string_ref);
+                const repl: ?[]const u8 =
+                    if (std.mem.eql(u8, ident, "exports") and
+                    !std.mem.eql(u8, self.options.cjs_exports_name, cg_options.default_cjs_exports_name))
+                        self.options.cjs_exports_name
+                    else if (std.mem.eql(u8, ident, "module") and
+                    !std.mem.eql(u8, self.options.cjs_module_name, cg_options.default_cjs_module_name))
+                        self.options.cjs_module_name
+                    else
+                        null;
+                if (repl) |name| {
+                    try self.addSourceMappingWithName(node.span, ident);
+                    try self.write(name);
+                    return;
                 }
             }
             try self.addSourceMapping(node.span);

--- a/src/codegen/options.zig
+++ b/src/codegen/options.zig
@@ -66,6 +66,12 @@ pub const JsxRuntime = enum {
     }
 };
 
+/// CJS wrapper `exports`/`module` 식별자 기본 이름. 옵션 default 와 PR-2
+/// free-ref 가드의 "기본값이면 no-op(회귀 0)" 판정이 이 단일 소스를 공유 —
+/// 리터럴 중복 시 default 변경이 회귀 0 불변식을 silent 로 깨므로 const 화.
+pub const default_cjs_exports_name = "exports";
+pub const default_cjs_module_name = "module";
+
 pub const CodegenOptions = struct {
     module_format: ModuleFormat = .esm,
     /// 문자열 따옴표 스타일 (기본: 쌍따옴표, esbuild/oxc 호환)
@@ -107,8 +113,8 @@ pub const CodegenOptions = struct {
     /// 시 바이트 동일(회귀 0). emitter 가 wrapper 파라미터와 같은 값을 주입해
     /// codegen 합성 구문(`exports.x=`, `module.exports=`)과 본문 free 참조를
     /// 단일 소스로 동기화한다.
-    cjs_exports_name: []const u8 = "exports",
-    cjs_module_name: []const u8 = "module",
+    cjs_exports_name: []const u8 = default_cjs_exports_name,
+    cjs_module_name: []const u8 = default_cjs_module_name,
     /// 번들 모드에서 ESM이 아닐 때 import.meta -> {} 치환 (esbuild 호환)
     replace_import_meta: bool = false,
     /// 타겟 플랫폼. import.meta polyfill 방식을 결정한다.

--- a/src/codegen/options.zig
+++ b/src/codegen/options.zig
@@ -100,6 +100,15 @@ pub const CodegenOptions = struct {
     /// JSON을 CJS require()로 소비할 때 synthetic named export declarations를 생략.
     /// default object는 `module.exports = {...}`로 유지한다.
     skip_cjs_named_export_decls: bool = false,
+    /// CJS wrapper 본문의 `exports`/`module` 식별자 이름. `exports`/`module`
+    /// 은 `__commonJS` wrapper 의 arrow 파라미터(`(exports,module)=>{...}`)라
+    /// 순수 함수 지역 바인딩 — 호출자(`cb((mod={exports:{}}).exports,mod)`)
+    /// 와 무관해 이름만 바꿔도 의미 불변. 기본값은 원본 그대로라 옵션 미주입
+    /// 시 바이트 동일(회귀 0). emitter 가 wrapper 파라미터와 같은 값을 주입해
+    /// codegen 합성 구문(`exports.x=`, `module.exports=`)과 본문 free 참조를
+    /// 단일 소스로 동기화한다.
+    cjs_exports_name: []const u8 = "exports",
+    cjs_module_name: []const u8 = "module",
     /// 번들 모드에서 ESM이 아닐 때 import.meta -> {} 치환 (esbuild 호환)
     replace_import_meta: bool = false,
     /// 타겟 플랫폼. import.meta polyfill 방식을 결정한다.


### PR DESCRIPTION
## 요약

ZNTC minify CJS wrapper의 `exports`/`module` 이 codegen 리터럴 하드코딩이라 mangle되지 않던 **별개 codegen 누락**을 수정. mangler 아키텍처(NO-GO 박제 영역)와 완전 무관 — 객체키 quote fix(#3446)와 같은 "measure-first diff로 잡는 별개 루트커즈" 계보.

esbuild `g((c,l)=>{ c.foo=... })` 대비 ZNTC `$c((exports,module)=>{ exports.foo=... })` → mime-db/ajv/rxjs류 풀네임 반복. `exports`/`module`은 `__commonJS` arrow 지역 파라미터(호출자 `cb((mod={exports:{}}).exports,mod)`와 무관)라 rename 안전.

## 측정 (144-lib smoke `--minify-all`, ReleaseFast)

| | OFF(kill-switch) | ON(default) | Δ |
|---|--:|--:|--:|
| 141 lib 합산 | 4,822,956 | 4,797,262 | **−25,694 (−0.533%)** |

- **개선 56 / 회귀 0 / 무변 85** (ROI 선검증 추정 25,593과 정확 일치)
- **런타임 MATCH 전수** (outputMatch OFF 141 = ON 141)
- TOP: rxjs **−7,547** · vue −3,089 · ajv −2,601 · express −2,559 · fast-glob −2,107 · yaml −1,363 · jsonwebtoken −1,051 · semver −630

## PR 분할 (각 measure-first 게이트 + /simplify)

- **PR-1 #3451**: `CodegenOptions.cjs_exports_name/cjs_module_name` 옵션 인프라 (기본=원본, flag off 회귀 0)
- **PR-2 #3453**: `node_dispatch` free `exports`/`module` 참조 치환 가드 (sym_id==null로 shadow 자동 제외, default no-op). default 리터럴을 `options.default_cjs_*` const로 단일 소스화(/simplify)
- **PR-3 #3455**: `emitter` wrapper 합성 + kill-switch — 게이트 ALL PASS
- **PR-4 #3457**: default-on 승격 + **RN 가드**(Metro serializer가 wrapper 파라미터 이름 가정 → `platform==.react_native` 제외, semantic-preserving). pre-push `zig build test`가 RN 회귀를 게이트 안전망으로 포착 → Metro 계약 복원

## 안전성

- `exports`/`module` = arrow 지역 파라미터, mangler 심볼 테이블 미등재 → nested-scope-renamer 회귀와 **직교**
- 사용자 `var exports` shadow는 sym_id가 잡혀 자동 제외
- RN/Metro는 보존(정확성 우선), browser/node만 적용
- kill-switch `ZNTC_NO_CJS_WRAP_MANGLE`
- `zig build test` 5225 전체 통과, Debug+ReleaseFast, 런타임 MATCH 전수

🤖 Generated with [Claude Code](https://claude.com/claude-code)