### PR TITLE
fix(emitter): CJS wrapper mangle 에 eval/with 가드 (정확성 hardening)

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1748,9 +1748,21 @@ pub fn emitModule(
     // react_native 제외: Metro serializer/require 시스템이 CJS wrapper
     // 파라미터 이름(`exports`/`module`)을 가정하므로 RN 빌드는 보존 필수
     // (semantic-preserving — RN 은 이 레버 포기, 정확성 우선).
+    //
+    // eval/with 가드: direct `eval(...)`/`with` 가 있으면 식별자가 동적
+    // 으로 참조될 수 있어(eval 문자열·with scope 는 AST 치환 비대상),
+    // wrapper 파라미터를 `$e`/`$m` 로 바꾸면 eval 내부 `exports` 참조와
+    // 불일치 → ReferenceError. analyzer 가 `markScopeFieldToRoot` 로
+    // root(scope 0)에 전파하므로 root.blocksMangling() 으로 모듈 전체
+    // 판정 (linker.zig Phase B 와 동일 관용구). semantic 부재 또는
+    // scope 부재(판정 불가) 는 보수적으로 mangle 차단(정확성 우선).
+    const mangle_blocked = if (module.semantic) |sem|
+        (sem.scopes.len == 0 or sem.scopes[0].blocksMangling())
+    else
+        true;
     const cjs_mangle = !cjs_wrap_mangle_disabled.enabled() and
         module.wrap_kind == .cjs and options.minify_whitespace and
-        options.platform != .react_native;
+        options.platform != .react_native and !mangle_blocked;
     const cjs_ex_name = if (cjs_mangle) CJS_MANGLE_EXPORTS else cg_options.default_cjs_exports_name;
     const cjs_mod_name = if (cjs_mangle) CJS_MANGLE_MODULE else cg_options.default_cjs_module_name;
 


### PR DESCRIPTION
## 배경

머지된 CJS wrapper `exports`/`module` mangle(#3458) 후속 **정확성 hardening**. 이전 분석에서 짚은 잠재 갭을 닫음:

`eval("exports.foo=1")`처럼 문자열 안 코드 / `with(o){exports}`의 식별자는 AST 치환 비대상 → wrapper 파라미터를 `exports`→`$e`로 바꾸면 eval 내부 `exports`와 불일치 → 실행 시 ReferenceError 또는 엉뚱한 전역 참조 가능. 144-lib 런타임 MATCH 전수 통과로 코퍼스엔 해당 패턴 없었으나(실무 극히 드묾) 이론적 위험.

## 수정

`cjs_mangle` 게이트에 `!mangle_blocked` 추가:
```
const mangle_blocked = if (module.semantic) |sem|
    (sem.scopes.len == 0 or sem.scopes[0].blocksMangling())
else true;
```
`blocksMangling()` = `subtree_has_direct_eval or subtree_has_with` — analyzer가 `markScopeFieldToRoot`로 root(scope 0)에 전파. **mangler/minify/linker가 eval/with mangle-skip에 쓰는 바로 그 표준 헬퍼 재사용**(linker.zig:843/867과 동일 관용구). semantic/scope 부재 시 보수적으로 mangle 차단(정확성 우선).

## 안전성

- **추가 제외 조건**이라 회귀 불가 — 절감을 줄이는 방향, 정확성만 향상
- ajv −2,601 / rxjs −7,547 / express −2,559 절감 정확 유지(코퍼스 CJS lib이 eval/with 거의 미사용 → corpus −25.7KB 거의 그대로, eval/with lib만 추가 보호)
- 런타임 MATCH 전수, `zig build test` 전체 통과, Debug+ReleaseFast OK, zig fmt

## /simplify

재사용: `blocksMangling()` 재사용은 정석(linker.zig Phase B 동일 관용구, 자체 eval/with 탐지 재구현 0). 품질: `dyn_scope`→`mangle_blocked` 리네임(`!mangle_blocked` 이중부정 가독성 + `blocksMangling` 도메인 어휘 정합), 보수 의도·linker 관용구 주석 보강. 효율: per-module O(1) scope[0] 접근, hot path 아님.

🤖 Generated with [Claude Code](https://claude.com/claude-code)