### PR TITLE
feat(mf): 정적 import "remote/x" seam 인프라 — PR-1 (#3459)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -826,6 +826,7 @@ pub const Bundler = struct {
         worker_linker.minify_whitespace = self.options.minify_whitespace;
         worker_linker.configurable_exports = self.options.configurable_exports;
         worker_linker.inline_requires = self.options.platform == .react_native;
+        if (self.options.mf) |*m| worker_linker.mf_remotes = m.remotes; // PR-1 (#3459) 일관
         try worker_linker.link();
         try worker_linker.finalize(.{
             .compute_renames = true,
@@ -1175,6 +1176,8 @@ pub const Bundler = struct {
             l.verbatim_module_syntax = self.options.verbatim_module_syntax;
             // #1824: IIFE external globals 매핑 — linker 가 매핑 유무로 preamble 경로 분기.
             l.iife_globals = self.options.globals;
+            // PR-1 (#3459): 정적 remote import → seam 글로벌 매핑용 KV.
+            if (self.options.mf) |*m| l.mf_remotes = m.remotes;
             if (mangle_report_enabled) l.mangle_report = &mangle_collector;
             try l.link();
             // Phase 3b (#1328): populateReExportAliases 가 canonical_name 을 채우려면

--- a/src/bundler/federation.zig
+++ b/src/bundler/federation.zig
@@ -49,10 +49,25 @@ pub fn cwdRealpath(allocator: std.mem.Allocator) ?[]const u8 {
 /// (cli/options.zig P1-2 도 이걸 호출). 비식별자(`@/-.`)→`_`, 소문자/scope
 /// 보존(react→__mf_shared_react, @scope/pkg→__mf_shared__scope_pkg).
 pub fn mfSharedGlobalName(allocator: std.mem.Allocator, pkg: []const u8) ![]const u8 {
-    const prefix = "__mf_shared_";
-    var buf = try allocator.alloc(u8, prefix.len + pkg.len);
+    return mfSeamName(allocator, "__mf_shared_", pkg);
+}
+
+/// specifier → host 정적 import seam 글로벌(`__mf_remote_<sanitized>`).
+/// PR-1(#3459): 정적 `import X from "remoteA/Widget"` 의 binding 을 이
+/// 글로벌 참조로 재작성(metadata.zig IIFE mapped 경로 재사용 → 에러
+/// 회피). per-spec(subpath 포함) 단위 — `remoteA/Widget`·`remoteA/Btn`
+/// 가 서로 다른 글로벌. PR-2 의 async preload-gate 가 `loadRemote` 결과로
+/// 채움. sanitize 규칙은 mfSharedGlobalName 과 **단일 소스**(mfSeamName).
+pub fn mfRemoteGlobalName(allocator: std.mem.Allocator, spec: []const u8) ![]const u8 {
+    return mfSeamName(allocator, "__mf_remote_", spec);
+}
+
+/// `<prefix><sanitized name>` — 비식별자(`@/-.`)→`_`, 그 외 보존.
+/// mfShared/mfRemote 글로벌명 단일 sanitize 규칙(두 seam 일관 필수).
+fn mfSeamName(allocator: std.mem.Allocator, prefix: []const u8, name: []const u8) ![]const u8 {
+    var buf = try allocator.alloc(u8, prefix.len + name.len);
     @memcpy(buf[0..prefix.len], prefix);
-    for (pkg, 0..) |c, i| buf[prefix.len + i] = switch (c) {
+    for (name, 0..) |c, i| buf[prefix.len + i] = switch (c) {
         '@', '/', '-', '.' => '_',
         else => c,
     };
@@ -72,6 +87,25 @@ test "mfSharedGlobalName: 결정적 식별자 변환" {
         defer a.free(got);
         try std.testing.expectEqualStrings(c.want, got);
     }
+}
+
+test "mfRemoteGlobalName: per-spec 결정적 변환(subpath 포함, shared 와 sanitize 일관)" {
+    const a = std.testing.allocator;
+    const cases = [_]struct { in: []const u8, want: []const u8 }{
+        .{ .in = "remoteA", .want = "__mf_remote_remoteA" },
+        .{ .in = "remoteA/Widget", .want = "__mf_remote_remoteA_Widget" },
+        .{ .in = "remoteA/Btn", .want = "__mf_remote_remoteA_Btn" }, // subpath 별 구분
+        .{ .in = "@scope/app/X", .want = "__mf_remote__scope_app_X" },
+    };
+    for (cases) |c| {
+        const got = try mfRemoteGlobalName(a, c.in);
+        defer a.free(got);
+        try std.testing.expectEqualStrings(c.want, got);
+    }
+    // shared 와 동일 sanitize 규칙(prefix 만 차이) — 단일소스 mfSeamName 보장
+    const r = try mfRemoteGlobalName(a, "react-dom");
+    defer a.free(r);
+    try std.testing.expectEqualStrings("__mf_remote_react_dom", r);
 }
 
 /// 경계 식별 + 표시 + 안정 ID 부여. `mf` 비면 호출 안 됨(caller gate).

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -203,6 +203,13 @@ pub const Linker = struct {
     /// 기존 IIFE unresolved 에러 경로를 탄다. bundler 가 init 후 설정 — borrowed.
     iife_globals: []const types.GlobalEntry = &.{},
 
+    /// PR-1 (#3459): MF host `mf.remotes` KV. 정적 `import X from
+    /// "remote/x"` 의 unresolved external 을 metadata.zig 가 per-spec
+    /// seam 글로벌(`__mf_remote_<san>`)로 매핑해 IIFE 에러를 회피.
+    /// bundler 가 init 후 설정 — borrowed(opts.mf 소유). 비-MF 빌드는
+    /// 빈 슬라이스 → 동작·출력 불변(무회귀).
+    mf_remotes: []const types.MfBundleConfig.KV = &.{},
+
     /// --mangle-report 수집기 (#1760). `null` 이면 instrumentation skip.
     /// Bundler 가 생성 및 소유. Linker 는 참조만 보유.
     mangle_report: ?*MangleReportCollector = null,

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -12,6 +12,7 @@ const Span = @import("../../lexer/token.zig").Span;
 const NodeIndex = @import("../../parser/ast.zig").NodeIndex;
 const Ast = @import("../../parser/ast.zig").Ast;
 const semantic_symbol = @import("../../semantic/symbol.zig");
+const federation = @import("../federation.zig"); // PR-1 (#3459) mfRemoteGlobalName/matchesRemoteSpec 단일소스
 const linker_mod = @import("../linker.zig");
 const Linker = linker_mod.Linker;
 const LinkingMetadata = linker_mod.LinkingMetadata;
@@ -394,7 +395,23 @@ pub fn buildMetadataForAst(
                     // 에 이미 `var _jsxDEV, _Fragment;` 선언이 호이스팅됨 (esm_wrap). init 함수
                     // 본문에서 `var` 로 재선언하면 outer scope 를 shadow → #1209.
                     const is_helper_esm = ib.is_helper and m.wrap_kind == .esm;
-                    const mapped_param = try mappedExternalParam(self.format, self.iife_globals, rec, self.allocator);
+                    const mapped_param = blk: {
+                        if (try mappedExternalParam(self.format, self.iife_globals, rec, self.allocator)) |mp|
+                            break :blk mp;
+                        // PR-1 (#3459): 정적 `import X from "remote/x"` 의
+                        // unresolved external 을 per-spec seam 글로벌
+                        // (`__mf_remote_<san>`)로 합성 → 아래 mapped 경로
+                        // 재사용(IIFE 에러 회피, GlobalEntry.lookup 무변경
+                        // = shared/일반 external 무회귀). 런타임 값은 PR-2
+                        // async preload-gate 가 채움(현재는 미정의).
+                        if (self.format == .iife and rec.is_external) {
+                            for (self.mf_remotes) |kv| {
+                                if (federation.matchesRemoteSpec(rec.specifier, kv.key))
+                                    break :blk try federation.mfRemoteGlobalName(self.allocator, rec.specifier);
+                            }
+                        }
+                        break :blk null;
+                    };
                     if (mapped_param) |param_name| {
                         defer self.allocator.free(param_name);
                         // IIFE/UMD/AMD: factory 매개변수에서 직접 참조. emitter 의 wrapper

--- a/tests/integration/tests/mf-runtime-interop-smoke.test.ts
+++ b/tests/integration/tests/mf-runtime-interop-smoke.test.ts
@@ -1183,6 +1183,66 @@ console.log('SAME=' + (m && m.usedHook === hostReact.useState));
     // 내부의 store 생성은 RFC §7.3 ②(외부/완전 데이터플로 미탐지 =
     // 문서화된 휴리스틱 한계, 비-목표) — expose 경계 모듈만 린트 대상.
   }, 30000);
+
+  // PR-1 (#3459): 정적 `import X from "remote/x"` seam 인프라(토대).
+  // 기존엔 `unresolved import ... IIFE format` 빌드 에러 → 이제 per-spec
+  // seam 글로벌(`__mf_remote_<san>`)로 binding 재작성, 빌드 성공.
+  // **런타임 값은 PR-2 async preload-gate 가 채움**(현재 미정의 —
+  // P3-0 "토대, 검증 없음" 방식: 빌드/emit 형태만 박제, 실행 아님).
+  test('PR-1 정적 import seam: 빌드 에러 소멸 + 3형태 seam 글로벌 재작성', async () => {
+    const rfx = await createFixture({
+      'Widget.ts': `export default function W(){ return "S-OK"; }\nexport const meta = "m";`,
+      'index.ts': `export const s = "re";`,
+      'zntc.config.json': JSON.stringify({
+        mf: { name: 'app', exposes: { './Widget': './Widget.ts' } },
+      }),
+    });
+    const rdist = join(rfx.dir, 'dist');
+    expect(
+      (
+        await runZntcInDir(rfx.dir, [
+          '--bundle',
+          join(rfx.dir, 'index.ts'),
+          '--outdir',
+          rdist,
+          '--format=iife',
+        ])
+      ).exitCode,
+    ).toBe(0);
+    const manifestAbs = join(rdist, 'mf-manifest.json');
+    const hfx = await createFixture({
+      // default · named · namespace 3형태
+      'index.ts': `import W from "app/Widget";\nimport { meta } from "app/Widget";\nimport * as NS from "app/Widget";\nglobalThis.__r = [typeof W, meta, typeof NS];`,
+      'zntc.config.json': JSON.stringify({
+        mf: { name: 'host', remotes: { app: `app@${manifestAbs}` } },
+      }),
+    });
+    const prev = cleanup;
+    cleanup = async () => {
+      await prev?.();
+      await rfx.cleanup();
+      await hfx.cleanup();
+    };
+    const hostOut = join(hfx.dir, 'host.js');
+    const hb = await runZntcInDir(hfx.dir, [
+      '--bundle',
+      join(hfx.dir, 'index.ts'),
+      '-o',
+      hostOut,
+      '--format=iife',
+      '--platform=browser',
+    ]);
+    // 빌드 에러 소멸(P1 IIFE bare-external 거부 우회)
+    expect(hb.exitCode, hb.stderr).toBe(0);
+    expect(hb.stderr).not.toContain('cannot be emitted in IIFE');
+    const src = readFileSync(hostOut, 'utf8');
+    // 3형태 → per-spec seam 글로벌 binding(런타임은 PR-2 가 채움)
+    expect(src).toContain('var W = __mf_remote_app_Widget;'); // default
+    expect(src).toContain('var meta = __mf_remote_app_Widget.meta;'); // named
+    expect(src).toContain('var NS = __mf_remote_app_Widget;'); // namespace
+    // 정적 import 구문은 IIFE 출력에 잔존하지 않음(codegen elide)
+    expect(src).not.toMatch(/(^|\n)\s*import\b.*["']app\/Widget["']/);
+  }, 30000);
 });
 
 function readFileSyncSafe(p: string): string {


### PR DESCRIPTION
## 개요
정적 `import X from "remote/x"` async-boundary 변환(이슈 #3459, 공식 `@module-federation/[email protected]` 대비 최대 기능 격차)의 **3-PR 분해 중 PR-1(seam 인프라)**. 현재 정적 remote import = `unresolved import ... cannot be emitted in IIFE format` **빌드 에러**(P1 제약, emitHostInit 도달 전 linking 단계 실패). PR-1 = binding 을 per-spec seam 글로벌(`__mf_remote_<san>`)로 재작성해 **빌드 성공**시킴. **런타임 값은 PR-2 async preload-gate 가 채움** — P3-0 "토대, 검증 없음" 방식(빌드/emit 형태만 박제, 실행 아님).

## 변경
- **`federation.zig`**: sanitize 로직 → `mfSeamName(alloc,prefix,name)` 추출. `mfSharedGlobalName`=그 wrapper(**byte 동일**, 기존 inline test 무회귀), 신규 `mfRemoteGlobalName`(per-spec, `remoteA/Widget`≠`remoteA/Btn` subpath 구분). inline test 추가.
- **`linker.zig`**: `Linker.mf_remotes: []const KV = &.{}`(borrowed=opts.mf 소유, 비-MF=빈 슬라이스 → 0회 루프 → 출력·동작 **완전 불변**).
- **`metadata.zig`**: unresolved-external static/side_effect/re_export 분기의 `mapped_param` 산출을 `blk:` 로 — `mappedExternalParam` **non-null 즉시 보존**(shared/일반 `--globals` external 영향 0), `null ∧ iife ∧ is_external ∧ matchesRemoteSpec` **4중 AND** 일 때만 `mfRemoteGlobalName` 합성(기존 mapped preamble 경로 재사용 → IIFE 에러 회피, **GlobalEntry.lookup 무변경**). 합성/기존 모두 단일 `defer free` 소유권 정합.
- **`bundler.zig`**: 메인·worker linker 둘 다 `mf.remotes` 배선.
- **통합 test**: 정적 import 3형태(default/named/namespace) 빌드 성공 + seam preamble(`var W = __mf_remote_app_Widget;` 등) 박제 + import 구문 elide. **런타임 미실행 정직 명시**.

## 무회귀 근거 (linker-코어)
`applyMfRemotesSeam` 이 remote 를 `globals_list` **미등록** + `GlobalEntry.lookup` **exact-match** → IIFE 에서 remote subpath spec 은 항상 `mappedExternalParam==null` → 신규 fallback 이 **유일 핸들러**(mapped 경로와 구조적 배타, 중첩 0). 비-MF/ESM/CJS/UMD/shared/일반 external 전부 불변.

## 검증
- `zig build test` **0**(`mfRemoteGlobalName` inline) / `wasm-bundler` **0** / `zig build`(install) **0**.
- MF 통합 스모크 **19 pass**(PR-1 신규, 0 fail), MF e2e **7 passed**(S3/S4/P2-5/P3-* 무회귀).
- **blocker 실측**: IIFE codegen 이 remote `import` declaration 을 elide(shared seam 선례 동형) — 출력에 stray import 0, seam preamble 만.
- `/simplify` 3-에이전트(재사용·품질·효율) **차단 0**: `mfSeamName` byte 동치·`blk` fallback 기존경로 불침범·소유권·borrowed 수명·거짓통과 방지(런타임 미실행 정직 박제)를 코드로 정밀 검증.

## 분해 진행
PR-1 (seam infra, 본 PR) → **PR-2** (emitHostInit async preload-gate + body-wrap) → **PR-3** (e2e + 무회귀 박제). 비차단 이월: PR-2 가 re_export/side-effect 도 seam 글로벌 채움 가정 재확인.

epic: #3318 / 부모: #3459

🤖 Generated with [Claude Code](https://claude.com/claude-code)