### PR TITLE
feat(mf): 정적 import P3-1 검증 통합 + e2e 박제 — PR-3 (#3459)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1811,7 +1811,7 @@ pub const Bundler = struct {
                 // resolve 불가 remote 는 skip(정밀 fail-fast).
                 const fe = @import("federation_emit.zig");
                 const cwd: ?[]const u8 = if (self.options.project_root.len > 0) self.options.project_root else null;
-                try fe.verifyHostContract(self.allocator, output, mf, cwd);
+                try fe.verifyHostContract(self.allocator, output, mf, cwd, mf_static_remotes.keys());
                 const host_out = try fe.emitHostInit(self.allocator, output, mf, mf_static_remotes.keys());
                 self.allocator.free(output);
                 output = host_out;

--- a/src/bundler/federation_emit.zig
+++ b/src/bundler/federation_emit.zig
@@ -260,69 +260,91 @@ pub fn verifyHostContract(
     src: []const u8,
     mf: *const types.MfBundleConfig,
     cwd: ?[]const u8,
+    /// PR-3 (#3459): 정적 `import … from "remote/x"` 는 codegen 이
+    /// elide(PR-1) → `nextRemoteImport`(동적 `import(` 스캔)에 안 잡힘.
+    /// metadata.zig 가 수집한 정적 spec(emitHostInit 와 동일 집합)을
+    /// 받아 동적과 **동일 per-spec 검증**(P3-1/2/3) 적용 — 정적 import
+    /// 의 expose 부재 fail-fast 갭을 닫는다(verifyOneRemoteSpec 단일소스).
+    static_specs: []const []const u8,
 ) !void {
     var i: usize = 0;
-    while (nextRemoteImport(src, mf, &i)) |h| {
-        const kv = for (mf.remotes) |kv| {
-            if (federation.matchesRemoteSpec(h.spec, kv.key)) break kv;
-        } else continue;
-        const r = parseRemote(kv);
-        // 검증 불가(http=P4 / 부재 / 파싱불가) = 위반 아님 → skip(정밀
-        // fail-fast). 단 OOM 은 빌드 자원 문제 → silent skip 금지, 전파.
-        var rc = mf_contract.loadContract(allocator, cwd, r.entry) catch |e| switch (e) {
-            error.OutOfMemory => return error.OutOfMemory,
-            else => continue,
-        };
-        defer rc.deinit();
-        // P3-3: 무결성 — sidecar(P2-2 SHA-256)/`.sig`(P2-3 Ed25519)와
-        // manifest 일치. stale/변조면 fail-fast(D3 런타임가드의 빌드타임
-        // 절반). sidecar/sig 부재·malformed = 검증 불가 ≠ 위반 → expose/
-        // shared 로 진행(continue 아님 — 무결성 미검증이 P3-1/2 를 건너뛰면
-        // 안 됨). 정밀 fail-fast: 확정 변조만 차단.
-        mf_contract.verifyIntegrity(allocator, cwd, r.entry) catch |e| switch (e) {
-            error.OutOfMemory => return error.OutOfMemory,
-            error.MfIntegrityMismatch => {
-                std.log.err(
-                    "zntc: MF 무결성 위반 — remote \"{s}\" 의 mf-manifest.json 이 sidecar(.integrity.json) SHA-256 과 불일치 (stale 또는 변조; 빌드 차단 — remote 재배포 필요)",
-                    .{kv.key},
-                );
-                return error.MfIntegrityMismatch;
-            },
-            error.MfIntegritySignatureInvalid => {
-                std.log.err(
-                    "zntc: MF 서명 위반 — remote \"{s}\" 의 sidecar Ed25519 `.sig` 검증 실패 (변조 또는 잘못된 키; 빌드 차단)",
-                    .{kv.key},
-                );
-                return error.MfIntegritySignatureInvalid;
-            },
-            else => {}, // 검증 불가(sidecar 부재/malformed/network) → 진행
-        };
-        // P3-1: expose 존재
-        if (!exposeListed(rc.exposes, h.spec, kv.key)) {
+    while (nextRemoteImport(src, mf, &i)) |h|
+        try verifyOneRemoteSpec(allocator, h.spec, mf, cwd);
+    for (static_specs) |spec|
+        try verifyOneRemoteSpec(allocator, spec, mf, cwd);
+}
+
+/// host import spec 1개의 P3-1(expose)·P3-2(shared)·P3-3(무결성) 검증.
+/// 동적(`nextRemoteImport`)·정적(`static_specs`) 양쪽이 공유하는 단일
+/// 소스(중복 검증 로직 금지). spec 이 remote 와 매칭 안 됨 / manifest
+/// 로컬 resolve 불가(http=P4·부재·파싱불가)면 **검증 불가 ≠ 위반 →
+/// 통과**(정밀 fail-fast). 같은 spec 다중 import·정적∩동적 중복 검증
+/// 가능(소규모 — P3-1 선례대로 허용, dedup 후속).
+fn verifyOneRemoteSpec(
+    allocator: std.mem.Allocator,
+    spec: []const u8,
+    mf: *const types.MfBundleConfig,
+    cwd: ?[]const u8,
+) !void {
+    const kv = for (mf.remotes) |kv| {
+        if (federation.matchesRemoteSpec(spec, kv.key)) break kv;
+    } else return;
+    const r = parseRemote(kv);
+    // 검증 불가(http=P4 / 부재 / 파싱불가) = 위반 아님 → 통과(정밀
+    // fail-fast). 단 OOM 은 빌드 자원 문제 → silent skip 금지, 전파.
+    var rc = mf_contract.loadContract(allocator, cwd, r.entry) catch |e| switch (e) {
+        error.OutOfMemory => return error.OutOfMemory,
+        else => return,
+    };
+    defer rc.deinit();
+    // P3-3: 무결성 — sidecar(P2-2 SHA-256)/`.sig`(P2-3 Ed25519)와
+    // manifest 일치. stale/변조면 fail-fast(D3 런타임가드의 빌드타임
+    // 절반). sidecar/sig 부재·malformed = 검증 불가 ≠ 위반 → expose/
+    // shared 로 진행(continue 아님 — 무결성 미검증이 P3-1/2 를 건너뛰면
+    // 안 됨). 정밀 fail-fast: 확정 변조만 차단.
+    mf_contract.verifyIntegrity(allocator, cwd, r.entry) catch |e| switch (e) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.MfIntegrityMismatch => {
             std.log.err(
-                "zntc: MF expose 계약 위반 — host import \"{s}\" 가 remote \"{s}\" 의 mf-manifest.json exposes 에 없음 (빌드 차단; remote 재배포 또는 스펙 정렬 필요)",
-                .{ h.spec, kv.key },
+                "zntc: MF 무결성 위반 — remote \"{s}\" 의 mf-manifest.json 이 sidecar(.integrity.json) SHA-256 과 불일치 (stale 또는 변조; 빌드 차단 — remote 재배포 필요)",
+                .{kv.key},
             );
-            return error.MfHostExposeMissing;
-        }
-        // P3-2: 양쪽이 선언한 shared 패키지의 singleton·버전 호환
-        for (mf.shared) |hs| {
-            for (rc.shared) |rs| {
-                if (!std.mem.eql(u8, hs.name, rs.name)) continue;
-                switch (sharedVerdict(hs, rs)) {
-                    .ok => {},
-                    .singleton_conflict => {
-                        std.log.err(
-                            "zntc: MF shared singleton 충돌 — '{s}' 가 host(singleton={}) ↔ remote \"{s}\"(singleton={}) 불일치 (빌드 차단; 인스턴스 분열 — 양측 shareConfig.singleton 정렬 필요)",
-                            .{ hs.name, hs.singleton, kv.key, rs.singleton },
-                        );
-                        return error.MfSharedSingletonConflict;
-                    },
-                    .version_warn => std.log.warn(
-                        "zntc: MF shared 버전 경고 — host requiredVersion '{s}' 가 remote \"{s}\" 의 '{s}' 게시버전 '{s}' 을 불만족 (런타임 버전협상 시 폴백 가능; 계약 정렬 권장)",
-                        .{ hs.required_version orelse "", kv.key, rs.name, rs.version },
-                    ),
-                }
+            return error.MfIntegrityMismatch;
+        },
+        error.MfIntegritySignatureInvalid => {
+            std.log.err(
+                "zntc: MF 서명 위반 — remote \"{s}\" 의 sidecar Ed25519 `.sig` 검증 실패 (변조 또는 잘못된 키; 빌드 차단)",
+                .{kv.key},
+            );
+            return error.MfIntegritySignatureInvalid;
+        },
+        else => {}, // 검증 불가(sidecar 부재/malformed/network) → 진행
+    };
+    // P3-1: expose 존재
+    if (!exposeListed(rc.exposes, spec, kv.key)) {
+        std.log.err(
+            "zntc: MF expose 계약 위반 — host import \"{s}\" 가 remote \"{s}\" 의 mf-manifest.json exposes 에 없음 (빌드 차단; remote 재배포 또는 스펙 정렬 필요)",
+            .{ spec, kv.key },
+        );
+        return error.MfHostExposeMissing;
+    }
+    // P3-2: 양쪽이 선언한 shared 패키지의 singleton·버전 호환
+    for (mf.shared) |hs| {
+        for (rc.shared) |rs| {
+            if (!std.mem.eql(u8, hs.name, rs.name)) continue;
+            switch (sharedVerdict(hs, rs)) {
+                .ok => {},
+                .singleton_conflict => {
+                    std.log.err(
+                        "zntc: MF shared singleton 충돌 — '{s}' 가 host(singleton={}) ↔ remote \"{s}\"(singleton={}) 불일치 (빌드 차단; 인스턴스 분열 — 양측 shareConfig.singleton 정렬 필요)",
+                        .{ hs.name, hs.singleton, kv.key, rs.singleton },
+                    );
+                    return error.MfSharedSingletonConflict;
+                },
+                .version_warn => std.log.warn(
+                    "zntc: MF shared 버전 경고 — host requiredVersion '{s}' 가 remote \"{s}\" 의 '{s}' 게시버전 '{s}' 을 불만족 (런타임 버전협상 시 폴백 가능; 계약 정렬 권장)",
+                    .{ hs.required_version orelse "", kv.key, rs.name, rs.version },
+                ),
             }
         }
     }

--- a/tests/e2e/tests/mf-interop-e2e.test.ts
+++ b/tests/e2e/tests/mf-interop-e2e.test.ts
@@ -711,3 +711,109 @@ test('P3-5 런타임-가드(실브라우저): 도달가능 remote의 런타임 e
     await rm(hostDir, { recursive: true, force: true });
   }
 });
+
+// PR-3 (#3459): 정적 `import X from "remote/x"` 가 **실 Chromium** 에서
+// 표준 @module-federation/[email protected] 으로 동작(S3-대칭, 동적 대신
+// 정적). PR-2 async preload-gate 가 정적 import binding(seam 글로벌)을
+// loadRemote 결과로 채운 뒤 host body 실행. default/named/namespace
+// 3형태 + http manifest entry + cross-origin http chunk 전체경로.
+test('PR-3 정적 import(실브라우저): default/named/namespace 표준 runtime 렌더', async ({
+  page,
+}) => {
+  test.setTimeout(90_000);
+  const remoteDir = await mkdtemp(join(tmpdir(), 'zntc-pr3si-remote-'));
+  const hostDir = await mkdtemp(join(tmpdir(), 'zntc-pr3si-host-'));
+  let remoteSrv: Awaited<ReturnType<typeof serve>> | undefined;
+  let hostSrv: Awaited<ReturnType<typeof serve>> | undefined;
+  try {
+    const remoteDist = join(remoteDir, 'dist');
+    await mkdir(remoteDist, { recursive: true });
+    remoteSrv = await serve(remoteDist, { 'Access-Control-Allow-Origin': '*' });
+    const rOrigin = `http://localhost:${remoteSrv.port}`;
+    await writeFile(
+      join(remoteDir, 'Widget.ts'),
+      `export default () => "DEF-OK";\nexport const meta = "MET-OK";`,
+    );
+    await writeFile(join(remoteDir, 'index.ts'), `export const sentinel = "re";`);
+    await writeFile(
+      join(remoteDir, 'zntc.config.json'),
+      JSON.stringify({ mf: { name: 'app', exposes: { './Widget': './Widget.ts' } } }),
+    );
+    const rb = spawnSync(
+      ZNTC_BIN,
+      [
+        '--bundle',
+        join(remoteDir, 'index.ts'),
+        '--outdir',
+        remoteDist,
+        '--format=iife',
+        '--platform=browser',
+        `--public-path=${rOrigin}/`,
+      ],
+      { cwd: remoteDir, stdio: 'pipe', timeout: 20000 },
+    );
+    expect(rb.status, `remote build: ${rb.stderr?.toString().slice(0, 400)}`).toBe(0);
+
+    // 정적 3형태 — PR-1 elide + PR-2 gate. body 는 gate `.then` 으로
+    // deferral(seam 채운 뒤 실행). http manifest entry → 빌드타임 P3-1
+    // skip(네트워크=비-목표) → 빌드 성공, 런타임 표준 runtime 이 로드.
+    await writeFile(
+      join(hostDir, 'index.ts'),
+      `import W from "app/Widget";\n` +
+        `import { meta } from "app/Widget";\n` +
+        `import * as NS from "app/Widget";\n` +
+        `document.getElementById("out").textContent = W() + "|" + meta + "|" + (typeof NS.default);\n` +
+        `window.__done = true;`,
+    );
+    await writeFile(
+      join(hostDir, 'zntc.config.json'),
+      JSON.stringify({
+        mf: { name: 'host', remotes: { app: `app@${rOrigin}/mf-manifest.json` } },
+      }),
+    );
+    const hb = spawnSync(
+      ZNTC_BIN,
+      [
+        '--bundle',
+        join(hostDir, 'index.ts'),
+        '-o',
+        join(hostDir, 'host.js'),
+        '--format=iife',
+        '--platform=browser',
+      ],
+      { cwd: hostDir, stdio: 'pipe', timeout: 20000 },
+    );
+    expect(hb.status, `host build: ${hb.stderr?.toString().slice(0, 500)}`).toBe(0);
+
+    await buildGlue(hostDir);
+    await writeFile(
+      join(hostDir, 'index.html'),
+      `<!DOCTYPE html><html><head><meta charset="utf-8">` +
+        `<script src="./glue.js"></script></head><body><div id="out">pending</div>` +
+        `<script src="./host.js"></script></body></html>`,
+    );
+    hostSrv = await serve(hostDir);
+
+    const pageErrors: string[] = [];
+    page.on('pageerror', (e) => pageErrors.push(e.message));
+    const seen: Record<string, number> = {};
+    page.on('response', (r) => {
+      if (r.url() === `${rOrigin}/mf-manifest.json`) seen.manifest = r.status();
+    });
+    await page.goto(`http://localhost:${hostSrv.port}/`);
+    await page.waitForFunction(() => (window as { __done?: boolean }).__done === true, {
+      timeout: 20000,
+    });
+
+    // 정적 3형태 실행: default→W()=DEF-OK, named→meta=MET-OK,
+    // namespace→typeof NS.default=function. 폴백/스텁이면 불일치 → fail.
+    expect(await page.locator('#out').textContent()).toBe('DEF-OK|MET-OK|function');
+    expect(seen.manifest, 'remote mf-manifest.json fetched').toBe(200);
+    expect(pageErrors, `pageerror: ${pageErrors.join(', ')}`).toHaveLength(0);
+  } finally {
+    if (remoteSrv) await closeServer(remoteSrv.server);
+    if (hostSrv) await closeServer(hostSrv.server);
+    await rm(remoteDir, { recursive: true, force: true });
+    await rm(hostDir, { recursive: true, force: true });
+  }
+});

--- a/tests/integration/tests/mf-runtime-interop-smoke.test.ts
+++ b/tests/integration/tests/mf-runtime-interop-smoke.test.ts
@@ -808,6 +808,63 @@ console.log('SAME=' + (m && m.usedHook === hostReact.useState));
     expect(stderr).not.toMatch(/RUNTIME-00\d|runtime guard|does not contain "init"/);
   }, 30000);
 
+  // PR-3 (#3459): 정적 import 도 P3-1 expose 계약 검증. 정적 import 는
+  // codegen elide → verifyHostContract 의 동적 `import(` 스캔에 안 잡혀
+  // 검증 갭이었음. metadata.zig 수집 정적 spec 을 verifyHostContract
+  // 가 동적과 동일 per-spec 검증(verifyOneRemoteSpec 단일소스) →
+  // 정적 부재 expose 도 빌드 fail-fast(S6).
+  test('PR-3 정적 import P3-1: 부재 expose 정적 import → 빌드 fail-fast', async () => {
+    const rfx = await createFixture({
+      'Widget.ts': `export default function W(){ return "OK"; }`,
+      'index.ts': `export const s = "re";`,
+      'zntc.config.json': JSON.stringify({
+        mf: { name: 'app', exposes: { './Widget': './Widget.ts' } },
+      }),
+    });
+    const rdist = join(rfx.dir, 'dist');
+    expect(
+      (
+        await runZntcInDir(rfx.dir, [
+          '--bundle',
+          join(rfx.dir, 'index.ts'),
+          '--outdir',
+          rdist,
+          '--format=iife',
+        ])
+      ).exitCode,
+    ).toBe(0);
+    const manifestAbs = join(rdist, 'mf-manifest.json');
+    const prev = cleanup;
+    cleanup = async () => {
+      await prev?.();
+      await rfx.cleanup();
+    };
+    const buildHost = async (importLine: string) => {
+      const hfx = await createFixture({
+        'index.ts': `${importLine}\nglobalThis.__r = 1;`,
+        'zntc.config.json': JSON.stringify({
+          mf: { name: 'host', remotes: { app: `app@${manifestAbs}` } },
+        }),
+      });
+      const r = await runZntcInDir(hfx.dir, [
+        '--bundle',
+        join(hfx.dir, 'index.ts'),
+        '-o',
+        join(hfx.dir, 'host.js'),
+        '--format=iife',
+      ]);
+      await hfx.cleanup();
+      return r;
+    };
+    // 정적 존재 expose → 빌드 성공(정밀 — blanket 아님)
+    expect((await buildHost('import W from "app/Widget";')).exitCode).toBe(0);
+    // 정적 부재 expose → 빌드 fail-fast(verifyOneRemoteSpec 정적 경로)
+    const bad = await buildHost('import X from "app/Missing";');
+    expect(bad.exitCode).not.toBe(0);
+    expect(bad.stderr).toContain('MF expose 계약 위반');
+    expect(bad.stderr).toContain('"app/Missing"');
+  }, 30000);
+
   // P3-1 (#3436): 빌드타임 expose 계약 검증(D3, 스파이크 S6). host import
   // 가 remote 의 게시 mf-manifest.json exposes 에 **없으면 빌드 fail-fast**
   // (런타임 깨짐 아님 — MF2 의 stale 런타임-실패 대비 차별화). resolve


### PR DESCRIPTION
## 개요
정적 `import X from "remote/x"` async-boundary 변환(이슈 #3459) **3-PR 마지막 — 기능 완결**. PR-2 `/simplify` 이월 갭: 정적 import 는 codegen elide → `verifyHostContract` 의 동적 `import(` 스캔(`nextRemoteImport`)에 안 잡혀 **P3-1 expose 검증 갭**. PR-3 이 폐쇄 + 실 Chromium e2e 박제.

## 변경
- **`federation_emit.zig`**: `verifyHostContract` 의 per-spec 검증(kv 매칭 → `loadContract` → `verifyIntegrity`[P3-3] → `exposeListed`[P3-1] → `sharedVerdict`[P3-2])을 **`verifyOneRemoteSpec` 단일소스 추출**(원본 byte 동치 — `continue`→`return` 의미 등가). `verifyHostContract` = 동적 루프(`nextRemoteImport`)→helper + **정적 루프(`static_specs`)→helper**. `static_specs` 파라미터(metadata.zig 수집 = `emitHostInit` gate 와 **동일 집합** → preload 대상 ↔ 검증 대상 정합). 불필요 외곽 블록 제거(가독성, `/simplify` 권고).
- **`bundler.zig`**: `verifyHostContract` 에 `mf_static_remotes.keys()` 전달.
- **통합 test**: 정적 부재 expose import → 빌드 fail-fast(`exitCode≠0` + stderr `MF expose 계약 위반` + `"app/Missing"`), 정적 존재 → `exitCode 0`(정밀 — blanket 아님).
- **e2e test**: 실 Chromium 정적 3형태(default/named/namespace) http remote + 표준 `@module-federation/[email protected]` 렌더(`DEF-OK|MET-OK|function`) + manifest 200 + pageerror 0.

## #3459 완결
정적 import = **PR-1(seam infra, #3462) + PR-2(async preload-gate 실동작, #3463) + PR-3(P3-1 검증 갭 폐쇄 + e2e, 본 PR)**. 공식 `@module-federation/enhanced` 대비 **최대 기능 격차(MF 최빈 패턴 — 기존 webpack/rspack 코드 이관)** 해소.

## 검증
- `zig build test` **0** / `wasm-bundler` **0** / `zig build`(install) **0**.
- MF 통합 스모크 **21 pass**(PR-3 신규 + S3/S4/P2-5/P3-* 무회귀), MF e2e **8 passed**(정적 import 실 Chromium 포함).
- `/simplify` 3-에이전트 **차단 0**: `verifyOneRemoteSpec` byte-동치 추출(원본 git show 대조)·정적 P3-1 갭 폐쇄 정밀(부재→fail-fast/존재→통과)·gate↔verify 동일집합 정합·거짓통과 방지(폴백 스텁이면 불일치 fail)를 코드+테스트로 정밀 검증. 비차단 권고(외곽 블록 제거) 반영.

epic: #3318 / 부모: #3459

🤖 Generated with [Claude Code](https://claude.com/claude-code)