### PR TITLE
feat(mf): shareStrategy/strictVersion config 표면 + manifest/init emit (#3318)

### DIFF
--- a/src/bundler/federation_emit.zig
+++ b/src/bundler/federation_emit.zig
@@ -110,8 +110,13 @@ pub fn emitHostInit(
         try emitter.appendJsonString(&out, allocator, r.entry);
         try out.append(allocator, '}');
     }
+    // #2 (감사): shareStrategy 를 init 인자로 배선 — 표준
+    // @module-federation/runtime 이 Options.shareStrategy 로 읽어 협상
+    // 순서(version-first|loaded-first) 적용(D1 위임, zntc 자체 협상 X).
+    try out.appendSlice(allocator, "],\"shareStrategy\":");
+    try emitter.appendJsonString(&out, allocator, mf.share_strategy);
     // P3-5: init 후 가드 정의(글로벌 — 모듈 스코프 재작성 코드가 호출).
-    try out.appendSlice(allocator, "]});" ++ GUARD_DEF ++ "})();");
+    try out.appendSlice(allocator, "});" ++ GUARD_DEF ++ "})();");
 
     // PR-2 (#3459): 정적 remote import async preload-gate. 정적 import
     // 구문은 PR-1 이 elide 하고 `var X = __mf_remote_<san>[.default]`
@@ -634,6 +639,13 @@ pub fn buildManifest(
         try b.appendSlice(allocator, if (se.singleton) "true" else "false");
         try b.appendSlice(allocator, ",\"requiredVersion\":");
         try appendJsonStr(&b, allocator, rv);
+        // #2 (감사): strictVersion additive 게시(producer contract).
+        // 표준 sdk ManifestShared 스키마 필드는 아님 — ManifestShared-
+        // typed consumer 는 무시(무해), 표준 강제는 host init shareConfig
+        // 가 표준 runtime 에 위임(share.ts strictVersion→error). zntc 는
+        // 이 게시값을 P3-2 빌드타임 fail-fast 격상에 사용(별 PR).
+        try b.appendSlice(allocator, ",\"strictVersion\":");
+        try b.appendSlice(allocator, if (se.strict_version) "true" else "false");
         try b.appendSlice(allocator, ",\"hash\":\"\",\"assets\":{\"js\":{\"sync\":[],\"async\":[]},\"css\":{\"sync\":[],\"async\":[]}}}");
     }
     // P2-1 (#3421): manifest.remotes 정밀. exposes 있는 remote 가 다른

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -49,6 +49,13 @@ pub const MfBundleConfig = struct {
         name: []const u8,
         singleton: bool = false,
         required_version: ?[]const u8 = null,
+        /// `shared.<pkg>.strictVersion`(표준 MF *shareConfig* 개념 —
+        /// 표준 sdk ManifestShared 스키마 필드는 아님). manifest 에
+        /// additive 게시(producer contract — ManifestShared-typed
+        /// consumer 는 무시) + P3-2 빌드타임: strict 선언 + concrete
+        /// version 비호환 → 경고 아닌 **fail-fast** 격상(별 PR). 런타임
+        /// 강제는 표준 runtime 책임(D1 위임 — share.ts strictVersion→error).
+        strict_version: bool = false,
         eager: bool = false,
         /// container 소유 글로벌 식별자(`__mf_shared_<name>`). mfBundleFromDto
         /// 가 1회 생성·소유(freeMfBundle 해제) → P1-2 seam·P1-4 init 은
@@ -65,6 +72,11 @@ pub const MfBundleConfig = struct {
     /// seam(`__mf_shared_<pkg>`) 채움. 버전 satisfy 판정은 host runtime 책임.
     shared: []const SharedEntry = &.{},
     share_scope: []const u8 = "default",
+    /// host shared 협상 순서. emitHostInit 가 `R.init({…,shareStrategy})`
+    /// 로 배선 → 표준 @module-federation/runtime 이 협상에 적용(D1 위임).
+    /// 기본 "version-first"(runtime default 와 동일). mfBundleFromDto 가
+    /// 항상 owned dup(freeMfBundle 대칭, share_scope 동일 패턴).
+    share_strategy: []const u8 = "version-first",
 };
 
 pub const ModuleIndex = enum(u32) {

--- a/src/cli/options.zig
+++ b/src/cli/options.zig
@@ -518,6 +518,7 @@ fn dupeKvMap(
 fn freeMfBundle(alloc: std.mem.Allocator, mfb: lib.bundler.MfBundleConfig) void {
     if (mfb.name) |n| alloc.free(n);
     alloc.free(mfb.share_scope);
+    alloc.free(mfb.share_strategy);
     for (mfb.exposes) |kv| {
         alloc.free(kv.key);
         alloc.free(kv.value);
@@ -548,6 +549,8 @@ fn mfBundleFromDto(
     // share_scope 는 항상 owned(default 도 dup) — deinit 해제 대칭(리터럴/
     // owned 혼재 회피).
     out.share_scope = try allocator.dupe(u8, dto.shareScope orelse "default");
+    // share_strategy 도 항상 owned(default 도 dup) — freeMfBundle 대칭.
+    out.share_strategy = try allocator.dupe(u8, dto.shareStrategy orelse "version-first");
 
     if (dto.exposes) |e| out.exposes = try dupeKvMap(allocator, &e.map);
     if (dto.remotes) |r| out.remotes = try dupeKvMap(allocator, &r.map);
@@ -573,6 +576,7 @@ fn mfBundleFromDto(
                 .name = nm,
                 .singleton = c.singleton orelse false,
                 .required_version = rv,
+                .strict_version = c.strictVersion orelse false,
                 .eager = c.eager orelse false,
                 // 글로벌명 1회 생성·소유(seam·init borrow). 단일 규칙.
                 .global_seam = try lib.bundler.federation.mfSharedGlobalName(allocator, nm),

--- a/src/transpile/options.zig
+++ b/src/transpile/options.zig
@@ -188,6 +188,11 @@ pub const MfConfigDto = struct {
     /// `{ "react": { singleton:true, requiredVersion:"^18" } }`
     shared: ?std.json.ArrayHashMap(MfSharedDto) = null,
     shareScope: ?[]const u8 = null,
+    /// host shared 협상 순서(`@module-federation/runtime` Options.
+    /// shareStrategy). `"version-first"`(기본) | `"loaded-first"`.
+    /// emitHostInit 가 `R.init({…,shareStrategy})` 로 배선 → 표준
+    /// runtime 이 실제 협상에 적용(zntc 자체 협상 아님, D1 위임).
+    shareStrategy: ?[]const u8 = null,
 };
 
 pub const MfSharedDto = struct {

--- a/tests/integration/tests/mf-runtime-interop-smoke.test.ts
+++ b/tests/integration/tests/mf-runtime-interop-smoke.test.ts
@@ -293,6 +293,100 @@ console.log('SAME=' + (m && m.usedHook === hostReact.useState));
     expect(Array.isArray(mani.exposes) && mani.exposes.length).toBe(1);
   });
 
+  // #2 감사: shareStrategy/strictVersion config 표면. strictVersion →
+  // ManifestShared 게시(producer contract, sdk 호환). shareStrategy →
+  // host R.init({…,shareStrategy}) 배선(표준 runtime Options.share
+  // Strategy 가 협상순서 적용 — D1 위임). 런타임 강제·P3-2 fail-fast
+  // 격상은 표준 runtime/별 PR. 여기선 config→manifest/init emit 박제.
+  test('#2 shareStrategy/strictVersion: manifest 게시 + host init 배선', async () => {
+    // remote: shared react strictVersion → manifest.shared[].strictVersion
+    const rfx = await createFixture({
+      'Widget.ts': `import { useState } from "react";\nexport default () => typeof useState;`,
+      'index.ts': `export const s = "re";`,
+      'zntc.config.json': JSON.stringify({
+        mf: {
+          name: 'app',
+          exposes: { './Widget': './Widget.ts' },
+          shared: {
+            react: { singleton: true, requiredVersion: '^19', strictVersion: true },
+            'react-dom': { requiredVersion: '^19' }, // strictVersion 미지정 → false
+          },
+        },
+      }),
+    });
+    cleanup = rfx.cleanup;
+    const rdist = join(rfx.dir, 'dist');
+    expect(
+      (
+        await runZntcInDir(rfx.dir, [
+          '--bundle',
+          join(rfx.dir, 'index.ts'),
+          '--outdir',
+          rdist,
+          '--format=iife',
+        ])
+      ).exitCode,
+    ).toBe(0);
+    const mani = JSON.parse(await readFile(join(rdist, 'mf-manifest.json'), 'utf8'));
+    const r = mani.shared.find((s: { name: string }) => s.name === 'react');
+    expect(r.strictVersion).toBe(true); // 명시 → true
+    const rd = mani.shared.find((s: { name: string }) => s.name === 'react-dom');
+    expect(rd.strictVersion).toBe(false); // 미지정 → false(P2-0 7필드 + strictVersion)
+    await rfx.cleanup();
+    cleanup = undefined;
+
+    // host: shareStrategy → R.init({…,"shareStrategy":"loaded-first"})
+    const hfx = await createFixture({
+      'index.ts': `globalThis.__x = import("app/W");`,
+      'zntc.config.json': JSON.stringify({
+        mf: {
+          name: 'host',
+          remotes: { app: 'app@http://x/r.js' },
+          shareStrategy: 'loaded-first',
+        },
+      }),
+    });
+    const hostOut = join(hfx.dir, 'host.js');
+    expect(
+      (
+        await runZntcInDir(hfx.dir, [
+          '--bundle',
+          join(hfx.dir, 'index.ts'),
+          '-o',
+          hostOut,
+          '--format=iife',
+        ])
+      ).exitCode,
+    ).toBe(0);
+    const hsrc = readFileSyncSafe(hostOut);
+    // 표준 @module-federation/runtime 이 읽는 Options.shareStrategy 위치
+    expect(hsrc).toContain('"shareStrategy":"loaded-first"');
+    expect(hsrc).toContain('R.init({"name":"host"'); // 기존 init 보존
+    await hfx.cleanup();
+
+    // 미지정 → runtime default 와 동일 "version-first" 명시 emit
+    const hfx2 = await createFixture({
+      'index.ts': `globalThis.__y = import("a/Z");`,
+      'zntc.config.json': JSON.stringify({
+        mf: { name: 'h2', remotes: { a: 'a@http://x/y' } },
+      }),
+    });
+    cleanup = hfx2.cleanup;
+    const o2 = join(hfx2.dir, 'h2.js');
+    expect(
+      (
+        await runZntcInDir(hfx2.dir, [
+          '--bundle',
+          join(hfx2.dir, 'index.ts'),
+          '-o',
+          o2,
+          '--format=iife',
+        ])
+      ).exitCode,
+    ).toBe(0);
+    expect(readFileSyncSafe(o2)).toContain('"shareStrategy":"version-first"');
+  });
+
   // P2-1 (#3421): exposes 있는 remote 가 remotes 도 선언 → manifest.remotes
   // = ManifestRemote[](Omit<RemoteWithEntry,'name'> & {federationContainer
   // Name,moduleName,alias}). 표준 generateSnapshotFromManifest 가


### PR DESCRIPTION
## 개요
공식 `@module-federation/[email protected]` 대비 감사가 식별한 ❌갭 **#2(shareStrategy/strictVersion config 표면 부재, 中)**의 **2-PR 중 PR#1 — 표면+emit**(빌드타임 동작변경 0, 무회귀 명확). zntc=host runtime 자체구현 안 함(D1, 표준 runtime 위임) → 책임 = config 표면 + manifest 게시 + host init 배선.

## 변경
- **`transpile/options.zig`**: `MfConfigDto.shareStrategy: ?[]const u8`. (`MfSharedDto.strictVersion` 은 기존 존재했으나 미plumb.)
- **`types.zig`**: `SharedEntry.strict_version: bool=false` + `MfBundleConfig.share_strategy: []const u8="version-first"`.
- **`cli/options.zig` `mfBundleFromDto`**: `share_strategy` 항상 owned dup(`share_scope` 동일 검증 패턴, `freeMfBundle` 대칭 `alloc.free`), shared 루프 `strict_version=c.strictVersion orelse false`.
- **`federation_emit.zig`**:
  - `emitHostInit` init prelude 에 `],"shareStrategy":<json>});` — **표준 runtime `Options.shareStrategy` 정확 키·위치**(remotes 배열 *뒤* 추가 → 기존 init prefix 보존). `appendJsonString` escape(임의 config 값 안전).
  - `buildManifest` ManifestShared 에 `,"strictVersion":bool`(requiredVersion→strictVersion→hash, valid JSON). **표준 sdk ManifestShared 스키마 필드는 아닌 additive 게시**(typed consumer 무시·무해 — producer contract + P3-2 용).
- **통합 test**: strictVersion manifest 게시(명시 `true`/미지정 `false`, P2-0 7필드 위 additive) + shareStrategy host init 배선(`loaded-first`/default `version-first`, `R.init({"name":"host"` prefix 보존).

## 키 정확성 (references/ 대조)
`runtime-core/.../config.ts:133` `Options.shareStrategy?: ShareStrategy`, `ShareStrategy='version-first'|'loaded-first'`(기본 version-first), `share.ts:402` `strictVersion→error` — emit 키·값·기본값 모두 upstream 과 정확 일치. 런타임 enforcement 는 표준 runtime 책임(host `shareConfig.strictVersion`, manifest-driven 아님).

## 검증
- `zig build test` **0** / `wasm-bundler` **0** / `zig build`(install) **0**.
- MF 통합 스모크 **22 pass**(P2-0/host-emit/S3/S4/P2-5 무회귀, #2 신규), MF e2e **8 passed**.
- `/simplify` 3-에이전트 **차단 0**: init prefix 보존(remotes 뒤 추가, toContain prefix 무손상)·표준 runtime 키 정확성(references 인용)·manifest JSON 구조·`share_strategy` 소유권(`share_scope` 검증 패턴 동치)·거짓통과 방지를 코드+실측으로 정밀 검증. 비차단 주석 정정(ManifestShared 스키마 필드 아닌 additive 게시 명시) **반영**.

## 분해
**PR#1(본 PR — 표면+emit)** → **PR#2**(P3-2 `sharedVerdict`: strictVersion 선언 + concrete version 비호환 → `version_warn`→fail-fast 격상 = 감사 갭 #2 빌드타임 enforcement 절반, 정밀 fail-fast 정합).

epic: #3318 / 감사 출처: 공식 module-federation-core 대조(#3464 후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)