### PR TITLE
feat(mf): strictVersion 빌드타임 fail-fast 격상 — #2 완결 (#3318)

### DIFF
--- a/src/bundler/federation_emit.zig
+++ b/src/bundler/federation_emit.zig
@@ -228,6 +228,7 @@ const SharedVerdict = enum {
     ok, // 호환(또는 검증 불가 = 정밀 fail-fast 로 통과)
     singleton_conflict, // singleton 불일치 — 결정적, 인스턴스 분열 → fail-fast
     version_warn, // host range 가 remote concrete version 불만족 → 경고(비차단)
+    strict_version_conflict, // ↑ + host strictVersion 선언 → fail-fast 격상
 };
 
 /// host shared 선언 vs remote 가 게시한 shared. singleton 불일치는
@@ -235,12 +236,17 @@ const SharedVerdict = enum {
 /// 버전은 host required_version(range) 가 remote 의 concrete version 을
 /// 만족하나 — semver.satisfies 가 `null`(remote.version 비-concrete:
 /// zntc P2-0 는 version=range 대용 / range 지원밖)이면 **판정 불가 →
-/// ok**(정밀 fail-fast: 거짓 경고 금지). `false` 일 때만 version_warn.
+/// ok**(정밀 fail-fast: 거짓 경고/차단 금지 — strict 여도 불변). 확정
+/// `false`(concrete 판정) 일 때만: host.strict_version → fail-fast
+/// (strict_version_conflict), 아니면 경고(version_warn). strict +
+/// required_version=null 은 강제할 제약 자체가 없음 → ok(no-op 설정,
+/// 위반 아님 — 정밀 fail-fast).
 fn sharedVerdict(host: types.MfBundleConfig.SharedEntry, remote: mf_contract.SharedContract) SharedVerdict {
     if (host.singleton != remote.singleton) return .singleton_conflict;
-    const hr = host.required_version orelse return .ok; // host 무제약 → 버전 검사 없음
+    const hr = host.required_version orelse return .ok; // host 무제약 → 검사 없음
     const sat = semver.satisfies(hr, remote.version) orelse return .ok; // 판정 불가 → 통과
-    return if (sat) .ok else .version_warn;
+    if (sat) return .ok;
+    return if (host.strict_version) .strict_version_conflict else .version_warn;
 }
 
 /// P3-1 (#3436) expose + P3-2 (#3437) shared: 빌드타임 host 계약 검증.
@@ -350,6 +356,13 @@ fn verifyOneRemoteSpec(
                     "zntc: MF shared 버전 경고 — host requiredVersion '{s}' 가 remote \"{s}\" 의 '{s}' 게시버전 '{s}' 을 불만족 (런타임 버전협상 시 폴백 가능; 계약 정렬 권장)",
                     .{ hs.required_version orelse "", kv.key, rs.name, rs.version },
                 ),
+                .strict_version_conflict => {
+                    std.log.err(
+                        "zntc: MF shared strictVersion 위반 — host strictVersion '{s}' 의 requiredVersion '{s}' 가 remote \"{s}\" 의 '{s}' 게시버전 '{s}' 을 불만족 (빌드 차단; strictVersion 은 런타임 폴백 불허 — 버전 정렬 또는 strictVersion 해제 필요)",
+                        .{ hs.name, hs.required_version orelse "", kv.key, rs.name, rs.version },
+                    );
+                    return error.MfSharedStrictVersionMismatch;
+                },
             }
         }
     }
@@ -797,5 +810,26 @@ test "sharedVerdict: singleton 충돌 fail-fast / 버전 경고 / 판정불가 o
     try std.testing.expectEqual(SharedVerdict.ok, sharedVerdict(
         SE{ .name = "react", .singleton = false, .required_version = null },
         SC{ .name = "react", .version = "19.2.4", .required_version = "^19", .singleton = false },
+    ));
+    // PR#2: strictVersion + concrete 비호환 → version_warn 대신 fail-fast 격상
+    try std.testing.expectEqual(SharedVerdict.strict_version_conflict, sharedVerdict(
+        SE{ .name = "react", .singleton = true, .required_version = "^18", .strict_version = true },
+        SC{ .name = "react", .version = "19.2.4", .required_version = "^19", .singleton = true },
+    ));
+    // strictVersion 이어도 호환이면 ok(격상 안 함)
+    try std.testing.expectEqual(SharedVerdict.ok, sharedVerdict(
+        SE{ .name = "react", .singleton = true, .required_version = "^19", .strict_version = true },
+        SC{ .name = "react", .version = "19.2.4", .required_version = "^19", .singleton = true },
+    ));
+    // strictVersion + 판정 불가(remote.version 비-concrete=zntc P2-0) → ok
+    // (정밀 fail-fast: strict 여도 확정 못 하면 차단 금지 — 거짓 빌드중단 방지)
+    try std.testing.expectEqual(SharedVerdict.ok, sharedVerdict(
+        SE{ .name = "react", .singleton = true, .required_version = "^18", .strict_version = true },
+        SC{ .name = "react", .version = "^19", .required_version = "^19", .singleton = true },
+    ));
+    // strictVersion + required_version=null → 강제할 제약 없음 → ok(no-op 설정)
+    try std.testing.expectEqual(SharedVerdict.ok, sharedVerdict(
+        SE{ .name = "react", .singleton = true, .required_version = null, .strict_version = true },
+        SC{ .name = "react", .version = "19.2.4", .required_version = "^19", .singleton = true },
     ));
 }

--- a/tests/integration/tests/mf-runtime-interop-smoke.test.ts
+++ b/tests/integration/tests/mf-runtime-interop-smoke.test.ts
@@ -387,6 +387,93 @@ console.log('SAME=' + (m && m.usedHook === hostReact.useState));
     expect(readFileSyncSafe(o2)).toContain('"shareStrategy":"version-first"');
   });
 
+  // #2 PR#2: P3-2 strictVersion 빌드타임 fail-fast 격상. host
+  // strictVersion 선언 + remote 게시 concrete version 이 host
+  // requiredVersion 불만족 → version_warn(비차단) 대신 **빌드 차단**.
+  // 정밀 fail-fast 불변: 판정 불가(remote.version 비-concrete=zntc
+  // P2-0 range)는 strict 여도 ok(거짓 빌드중단 금지).
+  test('#2 strictVersion fail-fast: concrete 비호환+strict→차단; non-strict/판정불가→통과', async () => {
+    const rfx = await createFixture({
+      'Widget.ts': `import { useState } from "react";\nexport default () => typeof useState;`,
+      'index.ts': `export const s = "re";`,
+      // remote singleton:true (host 와 일치 → singleton_conflict 가 version
+      // 검사를 가리지 않게). requiredVersion ^19 → manifest version 대용.
+      'zntc.config.json': JSON.stringify({
+        mf: {
+          name: 'app',
+          exposes: { './Widget': './Widget.ts' },
+          shared: { react: { singleton: true, requiredVersion: '^19' } },
+        },
+      }),
+    });
+    cleanup = rfx.cleanup;
+    const rdist = join(rfx.dir, 'dist');
+    expect(
+      (
+        await runZntcInDir(rfx.dir, [
+          '--bundle',
+          join(rfx.dir, 'index.ts'),
+          '--outdir',
+          rdist,
+          '--format=iife',
+        ])
+      ).exitCode,
+    ).toBe(0);
+    const manifestAbs = join(rdist, 'mf-manifest.json');
+    const sidecarAbs = join(rdist, 'mf-manifest.json.integrity.json');
+    // 외부 빌더 remote 모사: react shared version 을 concrete 로 재작성
+    // (zntc P2-0 는 version=range 라 strict 판정불가 — concrete 필요).
+    // sidecar 제거 → P3-3 무결성 검증 skip(아니면 변조로 먼저 fail).
+    const m = JSON.parse(readFileSync(manifestAbs, 'utf8'));
+    m.shared.find((s: { name: string }) => s.name === 'react').version = '19.2.4';
+    writeFileSync(manifestAbs, JSON.stringify(m));
+    rmSync(sidecarAbs, { force: true });
+
+    const buildHost = async (requiredVersion: string, strictVersion: boolean) => {
+      const hfx = await createFixture({
+        'index.ts': `globalThis.__x = import("app/Widget");`,
+        'zntc.config.json': JSON.stringify({
+          mf: {
+            name: 'host',
+            remotes: { app: `app@${manifestAbs}` },
+            shared: { react: { singleton: true, requiredVersion, strictVersion } },
+          },
+        }),
+      });
+      const r = await runZntcInDir(hfx.dir, [
+        '--bundle',
+        join(hfx.dir, 'index.ts'),
+        '-o',
+        join(hfx.dir, 'host.js'),
+        '--format=iife',
+      ]);
+      await hfx.cleanup();
+      return r;
+    };
+
+    // ① strict + concrete 비호환(^18 ⊅ 19.2.4) → 빌드 fail-fast
+    const bad = await buildHost('^18', true);
+    expect(bad.exitCode).not.toBe(0);
+    expect(bad.stderr).toContain('MF shared strictVersion 위반');
+    // ② non-strict + 동일 비호환 → version_warn(비차단, 빌드 성공)
+    const warn = await buildHost('^18', false);
+    expect(warn.exitCode).toBe(0);
+    expect(warn.stderr).toContain('MF shared 버전 경고');
+    // ③ strict + 호환(^19 ⊇ 19.2.4) → 격상 안 함(빌드 성공)
+    expect((await buildHost('^19', true)).exitCode).toBe(0);
+
+    // ④ 정밀 fail-fast: zntc remote(version=range "^19", sidecar 복원)
+    //    → satisfies 판정불가 → strict 여도 ok(거짓 빌드중단 금지).
+    await runZntcInDir(rfx.dir, [
+      '--bundle',
+      join(rfx.dir, 'index.ts'),
+      '--outdir',
+      rdist,
+      '--format=iife',
+    ]); // 원본 재빌드(version=range, sidecar 재생성)
+    expect((await buildHost('^18', true)).exitCode).toBe(0);
+  });
+
   // P2-1 (#3421): exposes 있는 remote 가 remotes 도 선언 → manifest.remotes
   // = ManifestRemote[](Omit<RemoteWithEntry,'name'> & {federationContainer
   // Name,moduleName,alias}). 표준 generateSnapshotFromManifest 가


### PR DESCRIPTION
## 개요
감사 갭 **#2(shareStrategy/strictVersion, 中)**의 **2-PR 중 PR#2 — 빌드타임 enforcement(완결)**. PR#1(#3465: config 표면 + manifest 게시 + shareStrategy host-init 배선)에 이어, P3-2 `sharedVerdict` 에 **strictVersion 빌드타임 fail-fast**를 정밀 fail-fast 정합으로 추가.

## 변경
- **`federation_emit.zig`**
  - `SharedVerdict` 에 `strict_version_conflict` 추가(exhaustive switch — enum 누락 시 컴파일에러 안전).
  - `sharedVerdict`: 마지막 분기만 변경 — `if (sat) return .ok; return if (host.strict_version) .strict_version_conflict else .version_warn;`. **singleton·`required_version=null`·`satisfies=null`(판정불가)은 strict 분기 *전* 조기반환** → `strict_version=false`면 PR#1 이전과 **verdict byte 동치**(비-strict 5경로 무회귀), **정밀 fail-fast 불변**(판정불가/무제약은 strict 여도 ok — 거짓 빌드중단 금지). 확정 `false` + `host.strict_version` 일 때만 격상.
  - `verifyOneRemoteSpec` switch `.strict_version_conflict` arm → `std.log.err`(행동가능 메시지 "버전 정렬 또는 strictVersion 해제 필요") + `error.MfSharedStrictVersionMismatch`. **`host.strict_version` 만 트리거**(RFC §4.1 D3 — host 가 enforcement 주체, remote 게시 strictVersion 무관).
  - inline `sharedVerdict` test 4(비호환+strict→격상 / 호환→ok / 판정불가→ok / `required_version=null`→ok).
- **통합 test 4**: strict 비호환→빌드 fail-fast(`exitCode≠0`+stderr `MF shared strictVersion 위반`) / non-strict→`version_warn`(비차단, exitCode 0) / strict 호환→ok / **zntc range remote 판정불가→ok**(정밀 fail-fast 박제). 하네스: remote 빌드 → manifest react version concrete 재작성 + sidecar 제거(P3-3 verifyIntegrity skip) → host strict cases. remote `singleton:true` 로 singleton_conflict 간섭 배제.

## #2 완결
shareStrategy 기능 배선(PR#1) + strictVersion config/manifest 게시(PR#1) + **strictVersion 빌드타임 fail-fast(PR#2)** — 공식 `@module-federation/enhanced` 대비 감사 갭 #2 해소(strictVersion 이 zntc D3 빌드타임에서 실제 fail-fast).

## 검증
- `zig build test` **0** / `wasm-bundler` **0** / `zig build`(install) **0**.
- MF 통합 스모크 **23 pass**(P3-2/S2~S4/P2-5 무회귀, #2 PR#2 신규), MF e2e **8 passed**.
- `/simplify` 3-에이전트 **차단 0·발견 0**: 비-strict 경로 byte 동치 무회귀·정밀 fail-fast 불변(판정불가/`required_version=null`→ok)·switch exhaustive·거짓통과 방지를 코드+실증(`zig build test` 전체·MF통합 23 무회귀·신규 7 expect)으로 정밀 검증.

epic: #3318 / 감사 갭 #2 (공식 module-federation-core 대조, #3464 후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)