### PR TITLE
fix(transformer): es5 class async 메서드 optional-chaining temp hoist 누락 (react-query v5 CI)

### DIFF
--- a/src/codegen/codegen_test/es_downlevel.zig
+++ b/src/codegen/codegen_test/es_downlevel.zig
@@ -3322,3 +3322,41 @@ test "ES5: async switch case block extracts await" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "requestCameraPermission()") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "_state.sent()") != null);
 }
+
+test "ES5: class async method + nested-member optional-call hoists temp decl (react-query v5 regression)" {
+    // es5 에서 class → IIFE 로 먼저 lowering → async 메서드는 es2015_class/
+    // methods.zig 의 class-async-state-machine 경로로 처리된다. 이 경로만
+    // es2017.zig 의 불변식(saved_temp_counter + hoistTempVarsSkippingSpans +
+    // counter 복원)을 빠뜨려, optional chaining nested-member-call 이 만든
+    // temp(_a/_b)의 `var` 선언이 함수 body 에 지역 hoist 되지 않고 counter 가
+    // module-top 으로 누수됐다. scope-hoist 번들 모듈에서 per-module resync 가
+    // 미사용 module-top `var _a..` 를 elide → `ReferenceError: _c is not
+    // defined` (react-query v5 mutation execute). bundle-level end-to-end
+    // 회귀 가드는 tests/integration/tests/react-query-v5-smoke.test.ts.
+    var r = try e2eTarget(std.testing.allocator,
+        \\class M {
+        \\  o = { cb: async function (v) { return v; } };
+        \\  async run(v) {
+        \\    await Promise.resolve();
+        \\    const c = await this.o.cb?.(v);
+        \\    return (c ?? 0) + v;
+        \\  }
+        \\}
+    , .es5);
+    defer r.deinit();
+    // class async 메서드도 state machine 으로 변환.
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "__generator") != null);
+    // optional-chaining nested-member-call temp 가 출력에 쓰이면 반드시 그
+    // `var` 선언이 함께 emit 돼야 한다 — 선언 없는 `_a`/`_b` 사용 = 회귀.
+    const uses_temp = std.mem.indexOf(u8, r.output, "_b.call(") != null or
+        std.mem.indexOf(u8, r.output, "(_b=") != null or
+        std.mem.indexOf(u8, r.output, "(_b =") != null or
+        std.mem.indexOf(u8, r.output, "(_a=") != null or
+        std.mem.indexOf(u8, r.output, "(_a =") != null;
+    if (uses_temp) {
+        try std.testing.expect(std.mem.indexOf(u8, r.output, "var _a") != null or
+            std.mem.indexOf(u8, r.output, "var _b") != null or
+            std.mem.indexOf(u8, r.output, ",_a") != null or
+            std.mem.indexOf(u8, r.output, ",_b") != null);
+    }
+}

--- a/src/transformer/es2015_class/methods.zig
+++ b/src/transformer/es2015_class/methods.zig
@@ -118,9 +118,26 @@ pub fn Methods(comptime Transformer: type) type {
                     const arrow_env = es_helpers.pushArrowEnv(self);
                     defer es_helpers.popArrowEnv(self, arrow_env);
 
-                    const sm_result = try GenMod.buildStateMachine(self, body_idx, span);
+                    // es2017.zig 의 async-lowering 과 동일 불변식: state machine
+                    // 안에서 optional chaining/nullish/destructuring lowering 이
+                    // 만든 callback-local temp 의 `var _a,_b,..` 선언을 wrapper
+                    // body 안에 지역 hoist 한다. class 메서드 경로(es5 에서 class
+                    // → IIFE 로 먼저 lowering 됨)만 이 hoist 가 누락돼 있었다 —
+                    // 누락 시 temp counter 가 module-top 으로 누수되어, scope-hoist
+                    // 번들 모듈에서 per-module resync 가 module-top `var _a..` 를
+                    // 미사용으로 elide → generator body 의 `_c` 가 미선언 →
+                    // `ReferenceError: _c is not defined` (react-query v5 smoke).
+                    const saved_temp_counter = self.temp_var_counter;
+                    var sm_result = try GenMod.buildStateMachine(self, body_idx, span);
                     defer self.generator_temp_var_spans.clearRetainingCapacity();
+                    // body == none 은 buildStateMachine 의 empty-body 조기반환뿐
+                    // (temp 미할당) → counter 복원 불필요, non-generator 경로로
+                    // fall-through 안전. 복원은 hoist 와 함께 if 안에서만 수행.
                     if (!sm_result.body.isNone()) {
+                        if (self.temp_var_counter > saved_temp_counter) {
+                            sm_result.body = try self.hoistTempVarsSkippingSpans(sm_result.body, saved_temp_counter, span, self.generator_temp_var_spans.items);
+                        }
+                        self.temp_var_counter = saved_temp_counter;
                         const gen_call = try GenMod.buildGeneratorHelperCall(self, sm_result.body, span);
                         const gen_wrapper = try es_helpers.wrapInFunction(self, gen_call, span);
                         const async_call = try es_helpers.buildAsyncHelperCall(self, gen_wrapper, span);


### PR DESCRIPTION
## 증상

`tests/integration/tests/react-query-v5-smoke.test.ts` CI 실패(macOS+ubuntu). `@tanstack/react-query` v5 를 `--target=es5 --format=cjs --runtime-polyfills=auto` 번들 후 런타임 `ReferenceError: _c is not defined` at `__generator` step.

## 루트커즈 (계측으로 확정)

es5 에서 class → IIFE 로 먼저 lowering → async 메서드는 `es2015_class/methods.zig` 의 class-async-state-machine 경로로 처리된다. state-machine lowering 경로는 4개:
- `es2017.zig:267-275` (`lowerAsyncToStateMachine`) ✅ 불변식 준수
- `es2017.zig:337-356` (`lowerAsyncArrowToStateMachine`) ✅
- `es2015_generator.zig:99-108` (`lowerGeneratorFunction`) ✅
- **`es2015_class/methods.zig` (class-async) ❌ 누락**

그 불변식 = `saved_temp_counter` 캡처 → `buildStateMachine` → `hoistTempVarsSkippingSpans`(optional chaining/destructuring lowering 이 만든 callback-local temp `var _a,_b,_c` 를 wrapper body 에 **지역 hoist**) → counter 복원. class-method 경로만 이를 빠뜨려 temp counter 가 module-top 으로 누수 → scope-hoist 번들 모듈에서 per-module resync 가 미사용 module-top `var _a..` 를 elide → generator body 의 `_c` 가 미선언 → `ReferenceError`.

single-module 은 module-top `var` hoisting 으로 **우연히** 동작했고, scope-hoist 번들(2-module+)에서만 노출. 계측(es2017:272 직전 saved/cur counter): single `saved=10 cur=10`(execute 전 temp 생성·top-level 선언), 2-module `saved=0 cur=0`(hoist skip → 선언 누락).

## Fix

`methods.zig` class-async-state-machine 분기에 **es2017.zig:267-275 패턴을 1:1 정렬**(신규 로직 0, 검증된 불변식 4번째 경로 적용). `const sm_result`→`var`(body 재할당). none fall-through 안전성 주석 명시(buildStateMachine empty-body 조기반환은 temp 미할당이라 복원 no-op).

## 회귀 가드

- `es_downlevel.zig` codegen 단위: class async method + nested-member optional-call → state machine 변환 + temp 선언 동반(react-query 무의존, 빠름)
- 기존 `react-query-v5-smoke.test.ts` 가 bundle-level end-to-end 가드 — 이 fix 로 RED→GREEN

## 검증

- react-query smoke **1 pass / 0 fail** (macOS 로컬 재현→GREEN)
- `zig build test` **5254/5258 passed · 0 fail**(새 단위 포함), Debug+ReleaseFast OK, zig fmt
- 최소 재현 2-module fixture PASS, single-module 회귀 0

## 안전성·후속

semantic-preserving(JS `var` hoisting 으로 동작 동일, 선언 위치만 함수-scope 정렬 — spec 정합). 침습 = 단일 분기 ~5줄 + 검증 패턴 복제, 회귀 시 hunk revert 즉시 원복. 후속(별도 리팩터): 4중 state-machine hoist 시퀀스(es2017×2/es2015_generator/methods) 공통 헬퍼 추출 — cross-cutting·회귀민감이라 CI hotfix 와 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)