### PR TITLE
docs(mf): manifest assets 정확성 — js.async 단일청크 정합 명시, CSS 갭 추적 (#3318)

### DIFF
--- a/src/bundler/federation_emit.zig
+++ b/src/bundler/federation_emit.zig
@@ -697,7 +697,21 @@ pub fn buildManifest(
         try appendJsonStr(&b, allocator, ex.name);
         try b.appendSlice(allocator, ",\"path\":");
         try appendJsonStr(&b, allocator, ex.name);
-        // expose 는 자기 lazy 청크 → js.async=[청크], sync=[]. css 는 비-목표.
+        // assets 정확성(#3 감사): zntc(P1-3)는 expose + 그 전이 **정적**
+        // 의존을 단일 lazy 청크로 co-bundle(BitSet 도달성 splitting) →
+        // `js.async`=[그 1 청크]가 **완전**(표준 esbuild 의 정적-의존
+        // 트리 분할과 형태만 다를 뿐, 그 1 파일이 전부 포함). 표준
+        // `preloadRemote` 가 이 파일을 prefetch 하면 container.get 이
+        // 같은 파일을 로드 → 의존 충족(기능 정합 — 부정확/누락 아님).
+        // `js.sync`=[] 는 의도: 분리된 정적-의존 청크가 없고 entry 는
+        // metaData.remoteEntry 가 담당. shared.assets=[] 도 의도(seam
+        // 글로벌 로딩 — 표준 runtime 은 이를 preload 소스로 안 쓰고
+        // dedup-제외 set 으로만 읽음, 빈 배열이라 제외 대상 0 = 무해,
+        // P1-4). **CSS assets** 만
+        // 실제 갭(expose 가 CSS import 시 zntc 는 CSS 청크 산출하나
+        // 여기 미기재 → preloadRemote 가 stylesheet prefetch 불가):
+        // css_plan→chunk_index→wrapContainer plumbing 필요한 별도 집중
+        // 단위로 추적(트래커). 그 외는 정확.
         try b.appendSlice(allocator, ",\"assets\":{\"js\":{\"sync\":[],\"async\":[");
         try appendJsonStr(&b, allocator, ex.chunk_file);
         try b.appendSlice(allocator, "]},\"css\":{\"sync\":[],\"async\":[]}}}");


### PR DESCRIPTION
## 개요
감사 갭 **#3("preload/prefetch 힌트 부정확", 中)** 정밀 분석(공식 module-federation-core 대조) 결론: **대부분 오해**. `buildManifest` 의 오해성 주석 `// css 는 비-목표`(전체 assets emit 이 미완/비-목표인 듯한 인상)를 **정확한 설계 근거**로 교체. **동작/출력 변경 0**(주석만, 13 insert/1 delete 전부 `//`).

## 분석 결론
| 필드 | 판정 | 근거 |
|---|---|---|
| `exposes[].assets.js.async`=[1 청크] | ✅ **정합(갭 아님)** | zntc(P1-3) expose+전이 정적 의존을 단일 lazy 청크 co-bundle(BitSet 도달성, `chunk.zig`) → 그 1 파일이 완전. 표준 `preloadRemote` prefetch→`container.get` 같은 파일 로드→의존 충족. esbuild 트리분할과 **형태만 다름**(누락/거짓 아님) |
| `js.sync`=[] | ✅ 의도 | 분리 정적-의존 청크 없음, entry=`metaData.remoteEntry` |
| `shared.assets`=[] | ✅ 의도·무해 | 표준 runtime 은 preload 소스 아닌 **dedup-제외 set** 으로만 읽음(빈 배열=제외 대상 0) |
| `exposes[].assets.css` | ❌ **유일 실제 갭** | expose CSS import 시 zntc 는 CSS 청크 산출하나 manifest 미기재 → preloadRemote stylesheet prefetch 불가 |

## CSS 서브갭 → 트래커 #3468
유일한 실제 갭(CSS assets)은 `css_plan→chunk_index→wrapContainer` plumbing(chunk_graph·css_emit·federation_emit·manifest **4 서브시스템 결합**)이 필요한 별도 집중 단위 — 정확한 범위와 함께 **이슈 #3468** 로 추적(#3459 정적 import 처럼 자체 탐색/TDD/리스크리뷰 요하는 단위, session-tail 급 cross-subsystem 변경 회피).

## 검증
- `zig fmt` **0** / `zig build test` **0**(주석만 — 무해).
- `/simplify` 1-에이전트 **차단 0**: 주석 4 주장을 `chunk.zig`(BitSet co-bundle) · `references/module-federation-core`(`generate-preload-assets`/`generateSnapshotFromManifest` 의 `js.async` 소비·`shared.assets` dedup-제외) 로 **사실 대조** — 과장/허위 0, CSS 갭 정직 인정. 비차단 표현 정밀화(shared.assets dedup-제외) 반영.

## #3 처리
"부정확" 오해 해소(js/sync/shared 정합을 코드/레퍼런스 근거로 명시) + CSS 서브갭 #3468 정확 추적. 기능적으로 표준 `preloadRemote` 는 zntc manifest 로 JS prefetch **정상 동작**.

epic: #3318 / 감사 출처: 공식 module-federation-core 대조 (#3464/#3466 후속)

🤖 Generated with [Claude Code](https://claude.com/claude-code)