### PR TITLE
refactor(transformer): state-machine temp-hoist 4중 중복 → 단일 helper

### DIFF
--- a/src/transformer/es2015_class/methods.zig
+++ b/src/transformer/es2015_class/methods.zig
@@ -132,12 +132,9 @@ pub fn Methods(comptime Transformer: type) type {
                     defer self.generator_temp_var_spans.clearRetainingCapacity();
                     // body == none 은 buildStateMachine 의 empty-body 조기반환뿐
                     // (temp 미할당) → counter 복원 불필요, non-generator 경로로
-                    // fall-through 안전. 복원은 hoist 와 함께 if 안에서만 수행.
+                    // fall-through 안전. hoist+복원은 if 안에서만 수행.
                     if (!sm_result.body.isNone()) {
-                        if (self.temp_var_counter > saved_temp_counter) {
-                            sm_result.body = try self.hoistTempVarsSkippingSpans(sm_result.body, saved_temp_counter, span, self.generator_temp_var_spans.items);
-                        }
-                        self.temp_var_counter = saved_temp_counter;
+                        sm_result.body = try self.hoistStateMachineTempsAndRestore(sm_result.body, saved_temp_counter, span);
                         const gen_call = try GenMod.buildGeneratorHelperCall(self, sm_result.body, span);
                         const gen_wrapper = try es_helpers.wrapInFunction(self, gen_call, span);
                         const async_call = try es_helpers.buildAsyncHelperCall(self, gen_wrapper, span);

--- a/src/transformer/es2015_generator.zig
+++ b/src/transformer/es2015_generator.zig
@@ -101,11 +101,7 @@ pub fn ES2015Generator(comptime Transformer: type) type {
             const sm_result = try buildStateMachine(self, body_idx, span);
             defer self.generator_temp_var_spans.clearRetainingCapacity();
             if (sm_result.body.isNone()) return .none;
-            var sm_body = sm_result.body;
-            if (self.temp_var_counter > saved_temp_counter) {
-                sm_body = try self.hoistTempVarsSkippingSpans(sm_body, saved_temp_counter, span, self.generator_temp_var_spans.items);
-            }
-            self.temp_var_counter = saved_temp_counter;
+            const sm_body = try self.hoistStateMachineTempsAndRestore(sm_result.body, saved_temp_counter, span);
 
             // generator function 이름이 있으면 프로토타입 체인 설정을 위해 __generator에 전달.
             // #1756: makeIdentifierRefFromSpan 만 쓰면 symbol_id 가 전파되지 않아

--- a/src/transformer/es2017.zig
+++ b/src/transformer/es2017.zig
@@ -269,10 +269,7 @@ pub fn ES2017(comptime Transformer: type) type {
             var sm_result = try GenMod.buildStateMachine(self, body_idx, span);
             defer self.generator_temp_var_spans.clearRetainingCapacity();
             if (sm_result.body.isNone()) return .none;
-            if (self.temp_var_counter > saved_temp_counter) {
-                sm_result.body = try self.hoistTempVarsSkippingSpans(sm_result.body, saved_temp_counter, span, self.generator_temp_var_spans.items);
-            }
-            self.temp_var_counter = saved_temp_counter;
+            sm_result.body = try self.hoistStateMachineTempsAndRestore(sm_result.body, saved_temp_counter, span);
 
             const gen_call = try GenMod.buildGeneratorHelperCall(self, sm_result.body, span);
             // __async는 fn.apply()로 함수를 호출하므로 iterator를 직접 전달 불가.
@@ -350,10 +347,7 @@ pub fn ES2017(comptime Transformer: type) type {
             var sm_result = lowered.sm_result;
             defer self.generator_temp_var_spans.clearRetainingCapacity();
             if (sm_result.body.isNone()) return .none;
-            if (self.temp_var_counter > saved_temp_counter) {
-                sm_result.body = try self.hoistTempVarsSkippingSpans(sm_result.body, saved_temp_counter, span, self.generator_temp_var_spans.items);
-            }
-            self.temp_var_counter = saved_temp_counter;
+            sm_result.body = try self.hoistStateMachineTempsAndRestore(sm_result.body, saved_temp_counter, span);
 
             const gen_call = try GenMod.buildGeneratorHelperCall(self, sm_result.body, span);
             const gen_wrapper_func = try es_helpers.wrapInFunction(self, gen_call, span);

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -362,6 +362,7 @@ pub const Transformer = struct {
     pub const buildVarDecl = lists_mod.buildVarDecl;
     pub const hoistTempVars = lists_mod.hoistTempVars;
     pub const hoistTempVarsSkippingSpans = lists_mod.hoistTempVarsSkippingSpans;
+    pub const hoistStateMachineTempsAndRestore = lists_mod.hoistStateMachineTempsAndRestore;
 
     // ================================================================
     // Flow syntax 변환 — transformer/flow.zig로 위임

--- a/src/transformer/transformer/lists.zig
+++ b/src/transformer/transformer/lists.zig
@@ -278,6 +278,23 @@ pub fn buildVarDecl(self: *Transformer, name: []const u8, init_value: NodeIndex,
     });
 }
 
+/// state-machine lowering 후 callback-local temp(`_a..`)의 `var` 선언을
+/// `sm_body` 에 지역 hoist 하고 temp counter 를 `saved_counter` 로 복원한다.
+/// 4개 state-machine lowering 경로(es2017 async/arrow, es2015 generator,
+/// es5 class-async)의 공통 불변식 — 누락 시 temp counter 가 outer 로 누수돼
+/// scope-hoist 번들 모듈에서 미선언 참조(`ReferenceError`)를 유발한다.
+/// caller 가 none-body 정책(early return / fall-through)을 호출 전에 결정하므로
+/// 이 helper 는 항상 non-none `sm_body` 로 호출된다.
+pub fn hoistStateMachineTempsAndRestore(self: *Transformer, sm_body: NodeIndex, saved_counter: u32, span: Span) Error!NodeIndex {
+    std.debug.assert(!sm_body.isNone());
+    var body = sm_body;
+    if (self.temp_var_counter > saved_counter) {
+        body = try self.hoistTempVarsSkippingSpans(body, saved_counter, span, self.generator_temp_var_spans.items);
+    }
+    self.temp_var_counter = saved_counter;
+    return body;
+}
+
 /// 임시 변수 호이스팅: saved_counter..current counter 범위의 var _a, _b, ... 선언을 body 앞에 삽입.
 /// body 의 top-level var 선언에 이미 같은 이름이 있으면 skip — `lowerDestructuringDeclaration`
 /// 처럼 declaration 형태로 직접 emit 하는 패스가 있어 mergeAdjacentDecls 가 `var _a, _a = init, ...`


### PR DESCRIPTION
## 배경

PR #3467(es5 class-async optional-chaining temp hoist 누락 fix)의 `/simplify` 재사용 리뷰 follow-up. 4개 state-machine lowering 경로에 동일 시퀀스가 반복돼 있었고, 그 중 **1곳(class-async)만 빠뜨려 #3467 런타임 회귀**(`ReferenceError: _c`)가 발생했음. 중복을 helper로 묶어 "hoist 후 temp counter 복원" 불변식을 캡슐화 → 1누락 재발 표면 제거.

## 변경 (동작 무변경 순수 리팩터)

- `lists.zig` 신규 `hoistStateMachineTempsAndRestore(self, sm_body, saved_counter, span)` — `if (temp_var_counter > saved) hoistTempVarsSkippingSpans(..); temp_var_counter = saved;` 캡슐화. 진입부 `assert(!sm_body.isNone())` 로 "non-none 호출" 계약 강제
- `transformer.zig` 인접 `hoistTempVars`/`hoistTempVarsSkippingSpans` 와 동일 패턴 `pub const` 재노출
- 4곳 교체: `es2017.zig`(lowerAsyncToStateMachine, lowerAsyncArrowToStateMachine) · `es2015_generator.zig`(lowerGeneratorFunction) · `es2015_class/methods.zig`(class-async)
- none-body 정책(early return vs fall-through)은 caller마다 달라 helper 밖에 유지 — 공통부(counter 비교/hoist/복원)만 절단

## /simplify

- **재사용**: 4곳 빠짐없이 커버, 5번째 누락 없음(`constructors`/`es_helpers`/`declarations`/`members`의 `hoistTempVars`는 state-machine 경로 아닌 별개 추상화 — 묶지 않음이 정답). 위임 정확·재노출 일관·non-leaky 확인
- **품질**: 주석 `(PR #3467 …)` 이력 표기 제거(feedback_no_reference_comments), `assert(!sm_body.isNone())`로 가정을 주석→코드 격상(이번 버그가 정확히 4경로 1누락 부류). 네이밍/형태/책임결합 유지(불변식 캡슐화로 정당)

## 검증

동작 무변경 — `zig build test` **5256/5260 · 0 fail**(assert panic 0 = 4 caller 전부 non-none 보장), `react-query-v5-smoke` **GREEN 유지**, Debug+ReleaseFast OK, zig fmt. #3467 follow-up 완결.

🤖 Generated with [Claude Code](https://claude.com/claude-code)