### PR TITLE
test(mf): __mfGuardedLoad↔표준 errorLoadRemote 비-충돌 검증·문서화 — ⚠️ 해소 (#3318)

### DIFF
--- a/src/bundler/federation_emit.zig
+++ b/src/bundler/federation_emit.zig
@@ -44,6 +44,21 @@ const IMPORT_NEEDLE = "import(";
 /// (loadRemote 결과 passthrough → S3/S4/P2-5 interop 보존), 거부만
 /// catch. 폴백은 silent 아님: console.error + `__mfUnavailable:true`
 /// (관측가능·비-차단). loadRemote 인자 그대로 forward(`arguments`).
+///
+/// **표준 `errorLoadRemote` hook 과의 관계(감사 ⚠️ 검증 결론)**:
+/// 선점/이중발화 **없음**(module-federation-core runtime-core/src/
+/// remote/index.ts:250-266 단일 errorLoadRemote emit + 본 가드 외곽
+/// wrap). host 가 표준
+/// `init/registerPlugins({errorLoadRemote})` 로 fallback module 을
+/// 반환하면 표준 loadRemote 가 **resolve** → 이 가드의 `.catch`
+/// **미발화** → host hook fallback 그대로 passthrough(가드가
+/// 가로채지 않음 — e2e 박제). 가드는 loadRemote 가 **reject** 할
+/// 때만(=hook 미등록 / hook 이 falsy 반환·throw → 표준상 전파) 개입
+/// → 표준이면 앱 error-boundary 로 throw 전파될 것을 P3-5 sentinel
+/// 로 graceful 흡수. 이는 **의도된 P3-5 opinion**(빌드핀 사각의
+/// white-screen 방지, 비-목표=표준 throw 전파)이며 버그 아님. 표준
+/// 에러 전파를 원하면 host hook 이 fallback 을 반환하는 spec 경로를
+/// 쓰면 됨(가드 통과).
 const MF_GUARDED = "globalThis.__mfGuardedLoad";
 const GUARD_DEF = MF_GUARDED ++ "=function(){var RR=globalThis." ++ MF_RUNTIME_GLOBAL ++
     ",a=arguments,id=a[0];function F(){return{default:function(){return null;},__mfUnavailable:true};}" ++

--- a/tests/e2e/tests/mf-interop-e2e.test.ts
+++ b/tests/e2e/tests/mf-interop-e2e.test.ts
@@ -817,3 +817,123 @@ test('PR-3 정적 import(실브라우저): default/named/namespace 표준 runtim
     await rm(hostDir, { recursive: true, force: true });
   }
 });
+
+// ⚠️ 감사: zntc __mfGuardedLoad(P3-5) ↔ 표준 @module-federation/runtime
+// errorLoadRemote hook **비-충돌 박제**. host 가 표준 plugin 으로
+// errorLoadRemote fallback module 을 반환하면 표준 loadRemote 가
+// resolve → zntc 가드 `.catch` 미발화 → host hook fallback 그대로
+// passthrough(가드가 **선점/이중발화 안 함**). reject 경로만 P3-5
+// sentinel(별 테스트 #7) — 이건 의도된 opinion. 여기선 hook-resolve
+// 경로가 깨끗함을 실 Chromium + 실 runtime 으로 확정.
+test('⚠️ 표준 errorLoadRemote hook fallback 이 zntc 가드 통과(선점 없음)', async ({ page }) => {
+  test.setTimeout(90_000);
+  const remoteDir = await mkdtemp(join(tmpdir(), 'zntc-hk-remote-'));
+  const hostDir = await mkdtemp(join(tmpdir(), 'zntc-hk-host-'));
+  let remoteSrv: Awaited<ReturnType<typeof serve>> | undefined;
+  let hostSrv: Awaited<ReturnType<typeof serve>> | undefined;
+  try {
+    const remoteDist = join(remoteDir, 'dist');
+    await mkdir(remoteDist, { recursive: true });
+    remoteSrv = await serve(remoteDist, { 'Access-Control-Allow-Origin': '*' });
+    const rOrigin = `http://localhost:${remoteSrv.port}`;
+    await writeFile(join(remoteDir, 'Widget.ts'), `export default () => "REAL";`);
+    await writeFile(join(remoteDir, 'index.ts'), `export const sentinel = "re";`);
+    await writeFile(
+      join(remoteDir, 'zntc.config.json'),
+      JSON.stringify({ mf: { name: 'app', exposes: { './Widget': './Widget.ts' } } }),
+    );
+    const rb = spawnSync(
+      ZNTC_BIN,
+      [
+        '--bundle',
+        join(remoteDir, 'index.ts'),
+        '--outdir',
+        remoteDist,
+        '--format=iife',
+        '--platform=browser',
+        `--public-path=${rOrigin}/`,
+      ],
+      { cwd: remoteDir, stdio: 'pipe', timeout: 20000 },
+    );
+    expect(rb.status, `remote build: ${rb.stderr?.toString().slice(0, 400)}`).toBe(0);
+
+    // host 는 **부재 expose** import → 표준 loadRemote reject 유발.
+    // 단, 표준 errorLoadRemote hook 이 fallback module 을 반환하므로
+    // 표준 loadRemote 가 resolve → zntc 가드 .catch 미발화여야 함.
+    await writeFile(
+      join(hostDir, 'index.ts'),
+      `async function main(){ const m = await import("app/Missing");` +
+        ` const v = (m && m.default) ? m.default() : ("NONE:" + JSON.stringify(m));` +
+        ` document.getElementById("out").textContent =` +
+        ` (m && m.__mfUnavailable) ? ("GUARD-PREEMPTED:" + v) : v;` +
+        ` window.__done = true; }\n` +
+        `main().catch((e) => { window.__err = String((e && e.stack) || e); window.__done = true; });`,
+    );
+    await writeFile(
+      join(hostDir, 'zntc.config.json'),
+      JSON.stringify({
+        mf: { name: 'host', remotes: { app: `app@${rOrigin}/mf-manifest.json` } },
+      }),
+    );
+    const hb = spawnSync(
+      ZNTC_BIN,
+      [
+        '--bundle',
+        join(hostDir, 'index.ts'),
+        '-o',
+        join(hostDir, 'host.js'),
+        '--format=iife',
+        '--platform=browser',
+      ],
+      { cwd: hostDir, stdio: 'pipe', timeout: 20000 },
+    );
+    expect(hb.status, `host build: ${hb.stderr?.toString().slice(0, 500)}`).toBe(0);
+
+    await buildGlue(hostDir);
+    // glue → **errorLoadRemote 등록 스크립트** → host.js. 등록 스크립트는
+    // host.js prelude(R.init = FederationInstance 생성) *후* sync 실행
+    // 되어야 registerPlugins 가능 → 그래서 host.js 뒤에 배치. 모든
+    // sync 스크립트가 loadRemote 비동기 실패(microtask)보다 먼저 끝남.
+    await writeFile(
+      join(hostDir, 'index.html'),
+      `<!DOCTYPE html><html><head><meta charset="utf-8">` +
+        `<script src="./glue.js"></script></head><body><div id="out">pending</div>` +
+        `<script src="./host.js"></script>` +
+        `<script>globalThis.__mf_runtime.registerPlugins([{name:"efb",` +
+        `errorLoadRemote:function(args){console.log("HOOK-FIRED:"+(args&&args.id));` +
+        `return {default:function(){return "HOOK-FB";}};}}]);</script>` +
+        `</body></html>`,
+    );
+    hostSrv = await serve(hostDir);
+
+    const pageErrors: string[] = [];
+    page.on('pageerror', (e) => pageErrors.push(e.message));
+    const allConsole: string[] = [];
+    page.on('console', (msg) => allConsole.push(`${msg.type()}:${msg.text()}`));
+    await page.goto(`http://localhost:${hostSrv.port}/`);
+    await page.waitForFunction(() => (window as { __done?: boolean }).__done === true, {
+      timeout: 20000,
+    });
+
+    expect(await page.evaluate(() => (window as { __err?: string }).__err)).toBeFalsy();
+    // hook fallback 이 표준 loadRemote 를 resolve → 가드 passthrough →
+    // host 가 hook 의 module 을 그대로 받음("HOOK-FB"). 가드가 선점했다면
+    // "GUARD-PREEMPTED:..." 또는 null sentinel — 그건 실패.
+    expect(await page.locator('#out').textContent()).toBe('HOOK-FB');
+    // hook 실제 발화(표준 runtime 이 호출) + 가드 catch 미발화(선점 없음)
+    expect(
+      allConsole.some((t) => t.includes('HOOK-FIRED:app/Missing')),
+      `console: ${allConsole.join(' | ')}`,
+    ).toBe(true);
+    expect(
+      allConsole.some((t) => t.includes('[mf] runtime guard')),
+      `guard catch fired(선점) — console: ${allConsole.join(' | ')}`,
+    ).toBe(false);
+    expect(pageErrors, `pageerror: ${pageErrors.join(', ')}`).toHaveLength(0);
+  } finally {
+    if (remoteSrv) await closeServer(remoteSrv.server);
+    if (hostSrv) await closeServer(hostSrv.server);
+    await rm(remoteDir, { recursive: true, force: true });
+    await rm(hostDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 개요
공식 module-federation-core 대조 감사가 식별한 **⚠️**("zntc P3-5 `__mfGuardedLoad` 가 표준 `@module-federation/runtime` `errorLoadRemote` hook 과 이중발화/선점") 정밀분석 결론: **선점/이중발화 없음**. **코드 무변경** — 검증 e2e + 정확 문서화로 해소(#3469 오해-해소 선례 일관).

## 분석 (references/module-federation-core)
`runtime-core/src/remote/index.ts:250-266`: loadRemote 실패 시 `errorLoadRemote` **단일 emit**.
- hook 이 fallback module 반환 → 표준 loadRemote **resolve** → zntc `__mfGuardedLoad` 외곽 `.catch` **미발화** → host hook fallback **passthrough**(가드 선점 안 함) ✅
- hook 미등록/falsy/throw → loadRemote **reject** → 가드가 P3-5 sentinel 흡수 = **의도된 opinion**(빌드핀 사각 white-screen 방지, 별 테스트 #7) — 버그 아님

→ 주 우려(hook-resolve 선점)는 **실재하지 않음**. 코드 수정 불요(감사 결론 = reference 로직·async loadRemote 구조로 재확인).

## 변경
- **`federation_emit.zig`**: `GUARD_DEF` 주석에 검증된 interop 의미만 추가 — **비주석 토큰 변경 0**(가드 동작 byte 불변 → P3-5/S3/S4/P2-5 무회귀 코드 보장). 표준 에러 전파 원하면 host hook 이 fallback 반환하는 spec 경로 안내.
- **e2e 신규**: 실 Chromium + 실 `@module-federation/[email protected]` — host 가 `registerPlugins` 로 `errorLoadRemote`(부재 expose → fallback module) 등록 → `#out`=="HOOK-FB"(hook module 의 `default()`, 가드 미선점) + `HOOK-FIRED` 발화 + `[mf] runtime guard` console **부재**(가드 catch 미발화 = 비-선점 직접 증거). **3중 단언**으로 거짓 green 구조적 불가.

## 검증
- `zig build test` **0** / `wasm-bundler` **0** / `zig build`(install) **0**.
- MF 통합 스모크 **24 pass**, MF e2e **9 passed**(P3-5 #5/#6/#7·S3/S4/P2-5/PR-3 무회귀, ⚠️ 신규).
- `/simplify` 3-에이전트 **차단 0**: federation_emit 비주석 변경 0(가드 동작 불변)·e2e 거짓통과 방지(async loadRemote 라 동기-throw 플레이키 불가, 3중 단언)·타이밍 견고성(glue→host.js prelude→registerPlugins sync 순서)·reference 사실 대조를 정밀 검증. 비차단 reference 패키지 경로(`runtime-core`) 보정 반영.

감사 ⚠️ 해소(코드 무변경, 비-충돌 실증 + 정확 문서). epic: #3318 / #3470 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)