### PR TITLE
docs(rfc): mangler size-gap RFC 141-lib 재검증 도장

### DIFF
--- a/docs/RFC_MANGLER_SIZE_GAP_CLOSED.md
+++ b/docs/RFC_MANGLER_SIZE_GAP_CLOSED.md
@@ -18,6 +18,8 @@ ZNTC 트리셰이킹은 경쟁사 대비 최강(144-lib non-minify 총합 ~0.76x
 | vue / express | 1.02~1.04x | mangler 분산 (대형 lib top-level 1글자 풀 잠식) |
 | ts-pattern 1.69x / typebox 1.28x | — | **착시** — ZNTC ≈ esbuild ≈ rolldown. rspack(SWC multi-pass compress)만 outlier로 작음. ZNTC 문제 아님 |
 
+**재검증 도장 (2026-05-18, 141-lib, main `96579159`, `smoke.ts --minify-all` ReleaseFast)**: 표본을 119→141 lib 으로 확대 재측정해도 결론 동일. corpus ZNTC 4,768,602 / gap(>0 합) 196,906 = **4.13%** (ZNTC 최소 34 lib / 최대 107 lib). 절대 gap 상위 = vue +24,209(1.04x mangler 분산) · express +14,097(vs rolldown, esbuild 는 827,763 으로 더 큼) · rxjs +12,772(1.09x) · zod +7,423(1.13x) · zlib +6,863(1.13x, 1글자풀) — 전부 §1 표의 mangler 분류 그대로. ts-pattern 1.69x / typebox 1.28x 도 ZNTC≈esbuild≈rolldown·rspack-only outlier 재확인(착시). **표본 확대로도 별개 codegen 루트커즈 0 신규·결론 불변** = §3~§6 종결 유효.
+
 ## 2. 루트커즈 (코드 확정)
 
 ZNTC mangler 2-phase:


### PR DESCRIPTION
## 배경

사용자 요청 "차이를 개선할 방법을 찾아야 하는데" → measure-first 로 최신 main(`96579159`)에서 141-lib `smoke.ts --minify-all` 4-tool(ZNTC/esbuild/rolldown/rspack) size 재측정.

`RFC_MANGLER_SIZE_GAP_CLOSED.md`(PR #3460 MERGED)는 작성 당시 **119-lib** 머지 후 재분석으로 "별개 codegen 루트커즈 소진, 잔존은 mangler 아키텍처 bounded(닫기 불가)"를 종결했습니다. 이번에 표본을 **141-lib** 으로 확대해도 결론이 그대로임을 검증했습니다.

## 변경

RFC §1 에 **재검증 도장** 1문단 추가 (코드 변경 0, 결정 문서만):

- corpus ZNTC 4,768,602 / gap(>0 합) 196,906 = **4.13%** (ZNTC 최소 34 lib / 최대 107 lib)
- 절대 gap 상위 = vue +24,209(1.04x) · express +14,097(vs rolldown; esbuild 는 827,763 으로 더 큼) · rxjs +12,772 · zod +7,423 · zlib +6,863 — **전부 §1 표의 mangler 분류 그대로**
- ts-pattern 1.69x / typebox 1.28x = ZNTC≈esbuild≈rolldown, rspack(SWC)-only outlier **착시 재확인**
- **별개 codegen 루트커즈 0 신규** → §3~§6 종결 유효

## "XL emit-overhaul RFC 정식 평가" 답

사용자가 선택한 "XL RFC 정식 평가"는 새 작업이 아니라 **이미 완료·머지됨**입니다. RFC §3 표("앞단 단일모델 통일 XXL — ROI 선검증: 낙관 −1.7% / esbuild 동형 +45% 회귀")·§5(chunk-reparse 전면 emit 오버홀 "사실상 닫힘")·§6 결론이 정확히 그 정식 평가이며, 이번 PR 은 더 큰 표본으로 그 결론을 재확인하는 검증 도장입니다.

## 검증

- 측정 수치 전부 smoke `--json` 출력과 대조 일치
- 코드 변경 0 (빌드/테스트 영향 없음)
- 기존 RFC 형식(굵은 제목 + 측정 수치) 준수

🤖 Generated with [Claude Code](https://claude.com/claude-code)