### PR TITLE
feat(mf): per-shared shareScope config 표면 — named scope 다중 #4-0 (#3318)

### DIFF
--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -61,6 +61,11 @@ pub const MfBundleConfig = struct {
         /// 가 1회 생성·소유(freeMfBundle 해제) → P1-2 seam·P1-4 init 은
         /// borrow(재-alloc 0, 누수 0). 단일 규칙=federation.mfSharedGlobalName.
         global_seam: []const u8 = "",
+        /// #4-0: 이 shared 가 속할 named share scope. mfBundleFromDto 가
+        /// per-shared→번들→"default" 해석 후 항상 owned dup(소유·불변 규칙은
+        /// 번들 `share_scope` 와 동일). #4-1 컨테이너 init 다중-scope 해석
+        /// (`remoteEntryInitOptions.shareScopeMap[scope]`)에서 소비.
+        share_scope: []const u8 = "default",
     };
     name: ?[]const u8 = null,
     /// `{ "./Widget": "./src/Widget.tsx" }` → [{"./Widget","./src/Widget.tsx"}]

--- a/src/cli/options.zig
+++ b/src/cli/options.zig
@@ -509,6 +509,16 @@ fn dupeKvMap(
     return list;
 }
 
+/// 한 SharedEntry 의 owned 필드 해제. freeMfBundle 정상경로와
+/// mfBundleFromDto 부분실패 errdefer 가 **동일 본문 공유**(필드 추가 시
+/// 한 곳만 — #4-0 share_scope 가 양쪽 동기화 부담 노출).
+fn freeSharedEntry(alloc: std.mem.Allocator, s: lib.bundler.MfBundleConfig.SharedEntry) void {
+    alloc.free(s.name);
+    if (s.required_version) |rv| alloc.free(rv);
+    if (s.global_seam.len > 0) alloc.free(s.global_seam);
+    alloc.free(s.share_scope); // name 과 동일 — 항상 owned(default 도 dup)
+}
+
 /// mfBundleFromDto 가 allocator-dup 한 것 일괄 해제. CliOptions.deinit 과
 /// mfBundleFromDto 의 errdefer 가 **공유**(해제 모델 단일 소스 — 부분
 /// 실패/정상 종료 대칭). len>0 가드: exposes/remotes/shared default 는
@@ -529,11 +539,7 @@ fn freeMfBundle(alloc: std.mem.Allocator, mfb: lib.bundler.MfBundleConfig) void 
         alloc.free(kv.value);
     }
     if (mfb.remotes.len > 0) alloc.free(mfb.remotes);
-    for (mfb.shared) |s| {
-        alloc.free(s.name);
-        if (s.required_version) |rv| alloc.free(rv);
-        if (s.global_seam.len > 0) alloc.free(s.global_seam);
-    }
+    for (mfb.shared) |s| freeSharedEntry(alloc, s);
     if (mfb.shared.len > 0) alloc.free(mfb.shared);
 }
 
@@ -560,18 +566,18 @@ fn mfBundleFromDto(
         errdefer allocator.free(list);
         var it = sh.map.iterator();
         var i: usize = 0;
-        // 부분 실패 시: 이미 채운 항목 전체 해제(freeMfBundle 와 대칭).
-        errdefer for (list[0..i]) |s| {
-            allocator.free(s.name);
-            if (s.required_version) |rv| allocator.free(rv);
-            if (s.global_seam.len > 0) allocator.free(s.global_seam);
-        };
+        // 부분 실패 시: 이미 채운 항목 해제(list[0..i] — 실패 iteration 의
+        // i 는 미증가라 제외, in-progress 는 아래 per-field errdefer 가).
+        errdefer for (list[0..i]) |s| freeSharedEntry(allocator, s);
         while (it.next()) |kv| : (i += 1) {
             const c = kv.value_ptr.*; // MfSharedDto (P1-0 파싱, 여기서 소비)
             const nm = try allocator.dupe(u8, kv.key_ptr.*);
             errdefer allocator.free(nm);
             const rv = if (c.requiredVersion) |v| try allocator.dupe(u8, v) else null;
             errdefer if (rv) |r| allocator.free(r);
+            // #4-0 해석 3-tier + 항상-owned 근거: SharedEntry.share_scope doc.
+            const sc = try allocator.dupe(u8, c.shareScope orelse dto.shareScope orelse "default");
+            errdefer allocator.free(sc);
             list[i] = .{
                 .name = nm,
                 .singleton = c.singleton orelse false,
@@ -580,6 +586,7 @@ fn mfBundleFromDto(
                 .eager = c.eager orelse false,
                 // 글로벌명 1회 생성·소유(seam·init borrow). 단일 규칙.
                 .global_seam = try lib.bundler.federation.mfSharedGlobalName(allocator, nm),
+                .share_scope = sc,
             };
         }
         out.shared = list;
@@ -1202,3 +1209,32 @@ pub fn parseCliArguments(args: []const []const u8, allocator: std.mem.Allocator)
 }
 
 const DefineEntry = lib.transformer.DefineEntry;
+
+test "#4-0 mfBundleFromDto: per-shared share_scope 명시 + 번들 상속 + free 대칭" {
+    const a = std.testing.allocator;
+    const P = struct {
+        fn p(alloc: std.mem.Allocator, s: []const u8) !std.json.Parsed(lib.transpile.MfConfigDto) {
+            return std.json.parseFromSlice(lib.transpile.MfConfigDto, alloc, s, .{ .ignore_unknown_fields = true });
+        }
+        fn scopeOf(mfb: lib.bundler.MfBundleConfig, nm: []const u8) []const u8 {
+            for (mfb.shared) |s| if (std.mem.eql(u8, s.name, nm)) return s.share_scope;
+            return "<missing>";
+        }
+    };
+
+    { // 번들 shareScope="host": react 는 명시 "ui", lodash 미지정 → "host" 상속
+        const v = try P.p(a, "{\"shareScope\":\"host\",\"shared\":{\"react\":{\"shareScope\":\"ui\"},\"lodash\":{}}}");
+        defer v.deinit();
+        const mfb = try mfBundleFromDto(a, &v.value);
+        defer freeMfBundle(a, mfb); // testing.allocator = 누수 탐지(항상-owned free 대칭 강제)
+        try std.testing.expectEqualStrings("ui", P.scopeOf(mfb, "react"));
+        try std.testing.expectEqualStrings("host", P.scopeOf(mfb, "lodash"));
+    }
+    { // 번들 shareScope 미지정 + per-shared 미지정 → "default"
+        const v = try P.p(a, "{\"shared\":{\"react\":{}}}");
+        defer v.deinit();
+        const mfb = try mfBundleFromDto(a, &v.value);
+        defer freeMfBundle(a, mfb);
+        try std.testing.expectEqualStrings("default", P.scopeOf(mfb, "react"));
+    }
+}

--- a/src/transpile/options.zig
+++ b/src/transpile/options.zig
@@ -200,6 +200,12 @@ pub const MfSharedDto = struct {
     requiredVersion: ?[]const u8 = null,
     strictVersion: ?bool = null,
     eager: ?bool = null,
+    /// #4-0: 이 shared 가 속할 named share scope. 미지정 → 번들 `shareScope`
+    /// 상속(그것도 미지정이면 "default"). MF2 `shared[].shareScope` 동형.
+    /// string-first — `string[]` 다중-scope 는 후속(P1-0 array/boolean
+    /// shorthand 이연 선례 동일). default 외 사용처: gradual upgrade·
+    /// 도메인 격리. emit 반영은 #4-1(컨테이너 init 다중-scope 해석).
+    shareScope: ?[]const u8 = null,
 };
 
 pub const MfValidationError = error{
@@ -261,6 +267,12 @@ test "validateMf: record 형태 + exposes/remotes 있으면 name 필수" {
         defer v.deinit();
         try validateMf(&v.value);
         try std.testing.expect(v.value.shared.?.map.get("react").?.singleton.?);
+    }
+    { // #4-0: per-shared shareScope 파싱(string). 미지정 = null(번들 상속)
+        const v = try J.p(a, "{\"shared\":{\"react\":{\"shareScope\":\"ui\"},\"lodash\":{}}}");
+        defer v.deinit();
+        try std.testing.expectEqualStrings("ui", v.value.shared.?.map.get("react").?.shareScope.?);
+        try std.testing.expect(v.value.shared.?.map.get("lodash").?.shareScope == null);
     }
     { // 빈 record = 미선언
         const v = try J.p(a, "{\"exposes\":{}}");


### PR DESCRIPTION
## 무엇

표준 MF2 는 `shared[].shareScope` 로 shared 모듈별 **named share scope** 를 지정해 gradual upgrade·도메인 격리를 지원합니다. zntc 는 번들 전역 단일 `share_scope` 만 있어 **default scope 만** 가능했습니다.

이는 RFC §7.2 ③ 이연 항목 — 전략 안티골(예: `@mf-types`)도 설계 한계(예: 런타임 동적 remote 검증)도 아닌 **순수 미구현 갭**이라 RN(P4)과 무관하게 단독 진행 가능한 유일 웹 MF 잔여 항목입니다.

## 범위 (#4-0 = infra-first config 표면만)

P1-0/P2-0 선례대로 분해: **#4-0 config 표면 → #4-1 emit(컨테이너 init 다중-scope 해석) → #4-2 enhanced 다중-scope interop 박제**. 이 PR 은 #4-0, **emit 무변경**.

- `MfSharedDto.shareScope: ?[]const u8` — JS config 표면. string-first (`string[]` 다중-scope 는 후속 — P1-0 array/boolean shorthand 이연과 동형)
- `SharedEntry.share_scope: []const u8` — per-shared → 번들 `shareScope` → `"default"` 3-tier 해석본. 항상 owned dup(번들 `share_scope`/`share_strategy` 소유·불변 규칙 동일)
- `mfBundleFromDto` 해석+dup. `freeSharedEntry` 헬퍼 추출 → 정상경로/부분실패 errdefer 가 단일 본문 공유(필드 추가 시 동기화 부담 제거 — #4-0 가 노출한 3중복 정리)

## 왜 emit 무변경인데 의미가 있나

`@module-federation/sdk` **ManifestShared 스키마에 scope 필드가 없습니다**(references 확인). 다중-scope 는 매니페스트가 아니라 **컨테이너 `init` 런타임 계약**(`init(shareScope, initScope, remoteEntryInitOptions)` 의 3rd-arg `remoteEntryInitOptions.shareScopeMap[scope]`)에서 표현됩니다. #4-0 은 그 해석에 필요한 config 표면을 먼저 박제하고, default-only config 의 출력은 **byte 동일**(무회귀)을 보장합니다.

## 검증

- `zig build test` **0** — 신규 유닛 2건: DTO 파싱(명시 `"ui"` / 미지정 `null`), `mfBundleFromDto` 3-tier(명시·번들상속·default) + `std.testing.allocator` 누수탐지로 free 대칭 강제
- `zig build wasm-bundler` 0 · `zig build`(install) 0
- MF 통합 **25·0** (`mf-runtime-interop-smoke` + `mf-container-emit`), MF e2e **9·0** (playwright `mf-interop-e2e`) — emit 무변경 byte 동일 회귀 확인
- `/simplify` 3-에이전트: 정확성(누수·이중해제·errdefer LIFO/`i` 미증가) **차단 0**. `freeSharedEntry` 추출 + 주석/필드 doc 4중복 트림 반영. `P.p`/`J.p` 3줄 test 헬퍼 모듈간 공유는 과설계로 보류(기존 local `J.p` 선례 일관)

## Zig 초보자 메모

`errdefer` 는 "이 지점 이후 함수가 에러로 빠져나가면 실행"입니다. 루프에서 `: (i += 1)` 은 **본문 성공 후** 평가되므로, 중간 실패 시 `i` 가 아직 안 늘어 `list[0..i]` 가 실패한 항목을 제외 → 진행 중 항목은 per-field errdefer, 완료 항목은 슬라이스 errdefer 가 맡아 이중해제가 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)