### PR TITLE
feat(mf): 컨테이너 init 다중 named scope 해석 — #4-1 (#3318)

### DIFF
--- a/src/bundler/federation_emit.zig
+++ b/src/bundler/federation_emit.zig
@@ -602,27 +602,42 @@ pub fn wrapContainer(
         "}};if(!M[e])throw new Error(\"Module \\\"\"+e+\"\\\" does not exist in container {s}.\");return M[e]()}},",
         .{name},
     );
-    // init(P1-4): runtime 은 `init(shareScope, initScope, remoteEntryInit
-    // Options)` 로 호출하며 **반환값을 await**(@module-federation/runtime-core
-    // module/index.js:73) → init 을 async(Promise 반환) 로 만들어 shared
-    // 해석을 끝낸 *후* host 가 get() 호출(init-before-get). 멱등: 같은
-    // Promise 재반환. 인자 `s` = host 의 해당 scope 객체(shareScopeMap 전체
-    // 아님 — runtime-core 가 scope 만 전달). 버전 satisfy/singleton 판정은
-    // host runtime(getRegisteredShare) 책임 → container 는 scope[pkg] 의
-    // 가용 버전 1개를 취해 글로벌 seam 에 대입만(과설계 금지).
-    try buf.appendSlice(allocator, "init:function(s,i){if(g.__zntc_mf_inited)return g.__zntc_mf_inited;g.__zntc_mf_inited=(async function(){");
+    // init(P1-4/#4-1): runtime-core 는 `init(shareScope, initScope,
+    // remoteEntryInitOptions)` 로 호출하며 **반환값을 await**
+    // (@module-federation/runtime-core module/index.js:73) → init 을
+    // async(Promise 반환) 로 shared 해석 후 host 가 get() (init-before-
+    // get). 멱등: 같은 Promise 재반환.
+    //
+    // per-shared scope 선택(#4-1) — **모던 host 면 그 scope 만, 없으면
+    // skip; 레거시 host 일 때만 positional `s`**:
+    //   `SC = (o && o.shareScopeMap) ? o.shareScopeMap[scope] : s`
+    // · `o.shareScopeMap`=전체 named scope 맵(runtime-core `// TODO use
+    //   shareScopeMap if exist`). 모던 host 면 이게 진실 소스.
+    // · `s`=레거시 positional 단일 scope(`localShareScopeMap
+    //   [shareScopeKeys[0]]`). o/shareScopeMap 부재(진짜 레거시 host)일
+    //   때만 채널이라 사용.
+    // 무회귀: default scope+모던 host 면 `o.shareScopeMap["default"]===s`
+    // (둘 다 같은 localShareScopeMap 인덱싱, 동작 동일). 레거시 host(o
+    // 부재)면 `s` 로 기존과 동일. **`||s` 가 아닌 ternary 인 이유**: 모던
+    // host 가 producer 선언 scope 를 미등록 시 `||s` 면 *다른* scope(s)
+    // 의 동명 pkg 로 silent 오결합(singleton/버전 위반) — ternary 는
+    // 미등록→SC undefined→아래 가드가 skip(seam 미설정→정상 협상 폴백).
+    // 버전 satisfy/singleton 은 host runtime(getRegisteredShare) 책임 →
+    // container 는 scope[pkg] 가용 1버전을 글로벌 seam 에 대입만.
+    try buf.appendSlice(allocator, "init:function(s,i,o){if(g.__zntc_mf_inited)return g.__zntc_mf_inited;g.__zntc_mf_inited=(async function(){");
     for (mf.shared) |se| {
         const glob = se.global_seam; // borrow (mfBundleFromDto 1회 생성·소유)
-        // scope[pkg] = { "<ver>": { lib?, get?:()=>Promise<factory|module> } }.
-        // eager=lib(모듈|팩토리), lazy=get→factory thunk(우리 get 과 동형) |
-        // 직접 모듈. 두 형태 모두 흡수(host 등록형은 PR-B 실 runtime 검증).
-        // K[0] = 첫 버전 채택 — 버전 satisfy/다중버전 선택은 host runtime
-        // (getRegisteredShare) 책임이라 scope 에 이미 해소된 버전만 옴(P1-4
-        // 비-목표, P1-6 다중-remote 에서 정밀화). se.name 은 JS 문자열에 raw
-        // 삽입 — npm 패키지명은 `"`/제어문자 불가라 escape 불요(mf.name 은
-        // 임의값 가능해 appendJsStringLiteral, pkg 명은 규약상 안전).
+        // scope 키는 임의 user config → appendJsonStr escape(mf.name·
+        // buildManifest 동일 single-source; se.name=npm 패키지명은 규약상
+        // 안전해 raw). scope[pkg]={"<ver>":{lib?|get?}} — eager=lib, lazy=
+        // get→factory thunk, K[0]=첫 버전(satisfy/다중버전은 host
+        // getRegisteredShare 책임, scope 에 해소된 버전만 옴). var SC/V/e/
+        // f/L/K 재선언은 기존 패턴 동형(JS var 함수스코프, 무해).
+        try buf.appendSlice(allocator, "var SC=(o&&o.shareScopeMap)?o.shareScopeMap[");
+        try appendJsonStr(&buf, allocator, se.share_scope);
+        try buf.appendSlice(allocator, "]:s;");
         try w.print(
-            "if(s&&s[\"{s}\"]){{var V=s[\"{s}\"],K=Object.keys(V);if(K.length){{var e=V[K[0]],L;" ++
+            "if(SC&&SC[\"{s}\"]){{var V=SC[\"{s}\"],K=Object.keys(V);if(K.length){{var e=V[K[0]],L;" ++
                 "if(e){{if(e.lib){{L=(typeof e.lib===\"function\")?e.lib():e.lib;}}" ++
                 "else if(e.get){{var f=await e.get();L=(typeof f===\"function\")?f():f;}}}}" ++
                 "if(L)g.{s}=L;}}}}",

--- a/tests/integration/tests/mf-container-emit.test.ts
+++ b/tests/integration/tests/mf-container-emit.test.ts
@@ -59,6 +59,54 @@ describe('MF P1-3: webpack-style container emit', () => {
     expect(entry).not.toMatch(/var\s+\w+\s*=\s*globalThis\.__zntc_require\(/);
   });
 
+  // #4-1 (#3318): named share scope 다중. 표준 runtime-core 는
+  // init(shareScope,initScope,remoteEntryInitOptions) 로 호출하고
+  // remoteEntryInitOptions.shareScopeMap 에 전체 named scope 맵을 싣는다
+  // (// TODO use shareScopeMap if exist). 모던 host 면 그 맵[scope] 만,
+  // 미등록이면 skip(seam 미설정→정상 협상); 레거시 host(맵 부재)일 때만
+  // positional s. `||s` 가 아닌 ternary — 미등록 scope 가 *다른* scope
+  // 로 silent 오결합(singleton/버전 위반)되지 않게.
+  test('다중 named scope: init 3rd-arg + per-shared o.shareScopeMap[scope] 해석', async () => {
+    const r = await runConfigBundle({
+      files: {
+        'index.ts': `export const sentinel = "remote-entry";`,
+        'Widget.ts': `export default function Widget() { return "W"; }`,
+        'zntc.config.json': JSON.stringify({
+          mf: {
+            name: 'app',
+            exposes: { './Widget': './Widget.ts' },
+            // react = 명시 "ui" scope, lodash = 미지정 → 번들 default 상속
+            shared: { react: { singleton: true, shareScope: 'ui' }, lodash: {} },
+          },
+        }),
+      },
+      args: ['--format=iife'],
+      outDir: 'out',
+    });
+    cleanup = r.cleanup;
+    expect(r.exitCode).toBe(0);
+
+    const files = readdirSync(r.outDir!);
+    const entryFile = files.find(
+      (f) =>
+        f.endsWith('.js') &&
+        readFileSync(join(r.outDir!, f), 'utf8').includes('__zntc_mf_container'),
+    )!;
+    const entry = readFileSync(join(r.outDir!, entryFile), 'utf8');
+
+    // 3rd-arg(remoteEntryInitOptions) 수신
+    expect(entry).toMatch(/init:function\(s,i,o\)\{/);
+    // react → 명시 "ui" scope, lodash → 번들 default scope
+    expect(entry).toContain('o.shareScopeMap["ui"]');
+    expect(entry).toContain('o.shareScopeMap["default"]');
+    // 선택 형태: (o&&o.shareScopeMap) ? o.shareScopeMap[scope] : s
+    //  — ternary(모던=scope만/미등록 skip, 레거시=s). `||s` 오결합 방지
+    expect(entry).toMatch(/var SC=\(o&&o\.shareScopeMap\)\?o\.shareScopeMap\["ui"\]:s;/);
+    expect(entry).not.toContain('])||s;'); // `||s` 폴백 잔존 금지
+    // 단일 positional 직접 조회(s["react"])는 더 이상 1차 경로 아님
+    expect(entry).not.toContain('if(s&&s["react"])');
+  });
+
   test('interop 계약: init→get 으로 exposed 모듈 lazy 도달 (S1/S3 형태)', async () => {
     const r = await runConfigBundle({
       files: {


### PR DESCRIPTION
## 무엇

#4-0(per-shared `shareScope` config 표면) 위에 **emit** 을 얹습니다. 표준 `@module-federation/runtime-core` 는 컨테이너를 `init(shareScope, initScope, remoteEntryInitOptions)` 로 호출하고 `remoteEntryInitOptions.shareScopeMap` 에 **전체 named scope 맵**을 싣습니다(runtime-core 소스 `// TODO use shareScopeMap if exist`). zntc 컨테이너는 positional `s` 하나로 전 shared 를 해석 = **단일-scope 한계**였습니다.

## 변경

- 컨테이너 `init` 시그니처 `s,i` → `s,i,o` (3rd-arg = remoteEntryInitOptions)
- per-shared: `var SC=(o&&o.shareScopeMap)?o.shareScopeMap[<scope>]:s;` 후 `SC[pkg]` 해석. scope 키는 `appendJsonStr` 로 escape(임의 user config — `mf.name`·`buildManifest` 와 동일 single-source; pkg 명은 npm 규약상 raw)

## 무회귀 (emit 변경이나 행위 보존)

- **default scope + 모던 host**: `o.shareScopeMap["default"]` 와 positional `s` 는 둘 다 같은 `localShareScopeMap` 을 인덱싱(runtime-core `s = localShareScopeMap[shareScopeKeys[0]]`) → **동일 객체** → 동작 동일
- **레거시 host(`o` 부재)**: ternary → `s` → 기존과 동일
- 기존 MF 통합 25 + e2e 9(전부 default scope, 실 `@module-federation/[email protected]`)가 행위 회귀로 통과

## /simplify 가 잡은 정확성 결함 → 교정

3-에이전트 효율 리뷰가 초안의 `(o&&o.shareScopeMap&&o.shareScopeMap[scope])||s` 폴백에서 **silent wrong-scope 버그**를 포착:

> producer 가 non-default `shareScope`(예: `react`→`"rsc"`)를 선언했는데 소비 host 가 그 scope 를 등록 안 하면 `o.shareScopeMap["rsc"]` = `undefined` → `||s` 가 **default scope 의 `react` 로 잘못 바인딩**(흔히 default 에도 react 가 shared 라 `if(SC&&SC["react"])` 가드도 못 막음 → singleton/버전 위반).

교정: `(o&&o.shareScopeMap) ? o.shareScopeMap[scope] : s` ternary — **모던 host = 해당 scope 만**(미등록 → `SC` undefined → 가드 skip → seam 미설정 → 표준 share 협상으로 정상 폴백), **레거시 host 일 때만 `s`**. 함께: reuse(a) `appendJsStringLiteral`→`appendJsonStr` 정합, quality 무회귀 근거 주석 init 블록 1곳 통합. test entry-탐색 중복은 동일 파일 sibling 선례 일치 → #4-1 범위 밖으로 보류(note).

## 검증

- `zig build test` **0** · `zig build wasm-bundler` 0 · `zig build`(install) 0
- MF 통합 **26·0** (`mf-container-emit` 다중-scope emit-shape 신규 1 + `mf-runtime-interop-smoke` 25 회귀)
- MF e2e **9·0** (playwright `mf-interop-e2e` — 표준 runtime default-scope 행위 회귀)
- `/simplify` 3-에이전트(reuse/quality/efficiency): 정확성 결함 1건 포착 → ternary 교정 적용, 재검증 후 **차단 0**

## 다음

#4-2 = `@module-federation/enhanced`(rspack) 다중 named scope host ↔ zntc remote 양방향 interop e2e 박제 → named scope 다중 완결.

## Zig 초보자 메모

emit 은 "실행 코드가 아니라 *문자열*을 만드는" 단계입니다. `buf.appendSlice`(고정 문자열) + `appendJsonStr`(임의 user 값을 JS 문자열로 escape) + `w.print`(`{s}` 포맷)를 같은 `buf` 에 섞어 쓰는 게 이 파일의 관례 — scope 키를 `{s}` 로 그냥 박으면 따옴표/제어문자 미escape 로 깨지므로 반드시 escape 헬퍼를 통합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)