### PR TITLE
test(mf): named share scope 다중 interop 박제 — #4-2 완결 (#3318)

### DIFF
--- a/tests/integration/tests/mf-runtime-interop-smoke.test.ts
+++ b/tests/integration/tests/mf-runtime-interop-smoke.test.ts
@@ -172,6 +172,90 @@ console.log('SAME=' + (m && m.usedHook === hostReact.useState));
     expect(stderr).not.toMatch(/RUNTIME-00\d|does not contain "init"|eager consumption/);
   }, 30000);
 
+  // #4-2 (#3318): named share scope 다중 완결 박제. S2 와 동일하나 react
+  // 를 **non-default named scope "ui"** 로. zntc remote: shared.react.
+  // shareScope='ui'(#4-0 표면). 컨테이너 init: SC=(o&&o.shareScopeMap)?
+  // o.shareScopeMap["ui"]:s(#4-1 emit). 표준 @module-federation/runtime
+  // host 는 remote 를 shareScope:'ui' 로 등록(runtime-core shareScopeKeys
+  // =['ui'] → localShareScopeMap['ui'] 생성·remoteEntryInitOptions.
+  // shareScopeMap 으로 전달) + react 를 scope:'ui' 로 등록(registerShared
+  // → shareScopeMap['ui']['react']). 실 [email protected] 으로 named
+  // scope 경유 singleton identity 검증 = #4-0+#4-1 end-to-end 완결.
+  test('#4-2 named scope "ui": zntc remote shared 가 host named scope 에서 해석 (singleton)', async () => {
+    const fx = await createFixture({
+      'Widget.ts':
+        `import { useState } from "react";\n` +
+        `export const usedHook = useState;\n` +
+        `export default function Widget() { return typeof useState === "function" ? "UI-OK" : "UI-NO"; }`,
+      'index.ts': `export const sentinel = "remote-entry";`,
+      'zntc.config.json': JSON.stringify({
+        mf: {
+          name: 'app',
+          exposes: { './Widget': './Widget.ts' },
+          // #4-0: per-shared shareScope = non-default "ui"
+          shared: { react: { singleton: true, requiredVersion: '^19', shareScope: 'ui' } },
+        },
+      }),
+    });
+    cleanup = fx.cleanup;
+    const dist = join(fx.dir, 'dist');
+
+    const b = await runZntcInDir(fx.dir, [
+      '--bundle',
+      join(fx.dir, 'index.ts'),
+      '--outdir',
+      dist,
+      '--format=iife',
+      `--public-path=file://${dist}/`,
+    ]);
+    expect(b.exitCode).toBe(0);
+
+    // #4-1 emit 형태 직접 확인: "ui" scope ternary (||s 오결합 아님)
+    const entrySrc = readFileSync(join(dist, 'index.js'), 'utf8');
+    expect(entrySrc).toContain('init:function(s,i,o){');
+    expect(entrySrc).toMatch(/var SC=\(o&&o\.shareScopeMap\)\?o\.shareScopeMap\["ui"\]:s;/);
+
+    server = createServer(async (req, res) => {
+      try {
+        const f = join(dist, req.url === '/' ? '/index.js' : req.url!);
+        res.writeHead(200, { 'content-type': 'application/javascript' });
+        res.end(await readFile(f));
+      } catch {
+        res.writeHead(404).end();
+      }
+    });
+    await new Promise<void>((r) => server!.listen(0, r));
+    const port = (server.address() as { port: number }).port;
+
+    const mfRuntime = createRequire(import.meta.url).resolve('@module-federation/runtime');
+    const reactPath = createRequire(import.meta.url).resolve('react');
+    driverPath = join(fx.dir, 'rt-driver.mjs');
+    writeFileSync(
+      driverPath,
+      `import mf from ${JSON.stringify('file://' + mfRuntime)};
+import * as hostReact from ${JSON.stringify('file://' + reactPath)};
+const { init, loadRemote } = mf;
+// remote 를 named scope 'ui' 로 등록(runtime-core remoteInfo.shareScope
+// → shareScopeKeys=['ui'] → o.shareScopeMap['ui'] 생성·전달).
+// react 를 scope:'ui' 로 등록(registerShared → shareScopeMap['ui'].react).
+init({
+  name: 'host-mf2',
+  remotes: [{ name: 'app', entry: 'http://localhost:${port}/index.js', shareScope: 'ui' }],
+  shared: { react: { version: '19.2.4', scope: 'ui', lib: () => hostReact, shareConfig: { singleton: true, requiredVersion: '^19' } } },
+});
+const m = await loadRemote('app/Widget');
+const W = m && (m.default ?? m);
+console.log('RENDER=' + (typeof W === 'function' ? W() : 'no'));
+console.log('SAME=' + (m && m.usedHook === hostReact.useState));
+`,
+    );
+    const { stdout, stderr } = await runNode(driverPath);
+
+    expect(stdout).toContain('RENDER=UI-OK'); // 'ui' scope seam 해석 성공
+    expect(stdout).toContain('SAME=true'); // named scope 경유 동일 react 인스턴스
+    expect(stderr).not.toMatch(/RUNTIME-00\d|does not contain "init"|eager consumption/);
+  }, 30000);
+
   // P1-5 (#3387): mf-manifest.json 에미터. webpack/rspack MF 호환 스키마
   // (@module-federation/sdk@2.4.0 Manifest 타입 + runtime-core
   // SnapshotHandler:161 필수키 metaData/exposes/shared). content-hash


### PR DESCRIPTION
## 무엇

`named share scope 다중` 3-PR 분해의 마지막 단위 — **#4-0**(per-shared `shareScope` config 표면, #3476) · **#4-1**(컨테이너 `init` 다중-scope emit, #3477) 의 **end-to-end 박제**.

기존 S2(default scope singleton identity) 테스트를 미러해 **non-default named scope "ui"** 로 실증합니다. 코드 무변경 — 테스트 전용.

## 검증 구성 (거짓통과 불가)

- zntc remote: `shared.react.shareScope='ui'` (#4-0 표면)
- 컨테이너 emit: `SC=(o&&o.shareScopeMap)?o.shareScopeMap["ui"]:s` (#4-1) — emit-shape 직접 단언으로 `||s` 오결합 회귀 핀
- 표준 `@module-federation/[email protected]` host: remote 를 `shareScope:'ui'` 등록(runtime-core `shareScopeKeys=['ui']` → `localShareScopeMap['ui']` 생성 → `remoteEntryInitOptions.shareScopeMap` 전달) + react 를 `scope:'ui'` 등록(`registerShared` → `shareScopeMap['ui'].react`)
- `m.usedHook === hostReact.useState` → **named scope 경유 singleton identity** 실증

**default scope 를 어디에도 등록하지 않음** → scope 해석이 깨지면 react seam 미설정 → `RENDER=UI-NO`/`SAME=false`. default 폴백으로 가려질 수 없음(/simplify 효율 에이전트가 격리 검증).

## 검증

- `zig build test` **0** · `zig build`(install) 0 (코드 무변경 sanity)
- MF 통합 **27·0** (신규 named-scope 1 + `mf-runtime-interop-smoke`/`mf-container-emit` 26 회귀)
- MF e2e **9·0** (playwright — 표준 runtime default-scope 행위 회귀)
- `/simplify` 3-에이전트(reuse/quality/efficiency): **차단 0** — named-scope 격리(거짓통과 불가) 확인, teardown contract S2 동일, 단언 견고. 파일 전반 server/driver 인라인 중복은 **선재**(#4-2 미악화) → backlog

## 의의

`named share scope 다중`(#4-0/#4-1/#4-2) **완결** → RFC §7.2 ③ 이연 항목 해소. 이는 공식 `@module-federation/enhanced` 대비 zntc 웹 Module Federation 의 **마지막 RN-독립 실기능 갭**이었습니다(나머지 미구현은 전부 전략적 비-목표/설계 한계/MF 범위 밖). → zntc 웹 MF 실질 기능 동등 + D3 빌드타임 계약검증 차별화까지 완성.

## Zig 초보자 메모

이 PR 은 Zig 코드를 바꾸지 않습니다 — #4-1 에서 emit(컨테이너가 생성하는 JS 문자열)을 이미 바꿨고, 여기서는 그 결과가 **실제 표준 런타임과 named scope 로 맞물리는지**를 실 `@module-federation/[email protected]` 으로 끝까지 돌려 증명(박제)합니다. "박제" = 한 번 검증한 동작을 영구 회귀 테스트로 고정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)