### PR TITLE
fix(rn): stabilize zntc release bundle

### DIFF
--- a/packages/core/bin/cli-flags.mjs
+++ b/packages/core/bin/cli-flags.mjs
@@ -111,9 +111,9 @@ export const FLAG_REGISTRY = [
     target: 'preserveModulesRoot',
     forms: ['equal'],
   },
-  { kind: 'string', flag: '--rn-platform', target: 'rnPlatform', forms: ['equal'] },
+  { kind: 'string', flag: '--rn-platform', target: 'rnPlatform', forms: ['equal', 'pair'] },
   // #2540 PR #7 — RN preset 의 projectRoot. 기본 cwd, 사용자 monorepo root 지정 시 사용.
-  { kind: 'string', flag: '--rn-project-root', target: 'rnProjectRoot', forms: ['equal'] },
+  { kind: 'string', flag: '--rn-project-root', target: 'rnProjectRoot', forms: ['equal', 'pair'] },
   // ─── RN CLI 호환 flag 매트릭스 (#2605 audit P0) ───
   // `react-native bundle` / Metro CLI 의 standard flag 들 — `zntc bundle --platform=react-native`
   // 가 dropin 으로 동작하기 위한 호환 layer. zntc 내부 옵션 (outfile 등) 과 별개로 받아 매핑.

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -777,6 +777,20 @@ async function runRnBundle(opts, config) {
     }),
   });
 
+  if (result.errors.length > 0 && opts.logLevel !== 'silent') {
+    for (const err of result.errors) {
+      const loc = err.location ? `${err.location.file}: ` : '';
+      const detail = err.specifier ? ` (${err.specifier})` : '';
+      console.error(`error: ${loc}${err.text}${detail}`);
+    }
+  }
+  if (result.warnings.length > 0 && opts.logLevel !== 'silent' && opts.logLevel !== 'error') {
+    for (const warn of result.warnings) {
+      const detail = warn.specifier ? ` (${warn.specifier})` : '';
+      console.error(`warning: ${warn.text}${detail}`);
+    }
+  }
+
   // caller-side write — bundle / sourcemap path 분리 + URL override 적용.
   if (callerWrite && result.errors.length === 0 && result.outputFiles?.length) {
     const bundlePath = resolve(outfile);

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -444,6 +444,27 @@ function safeRealpath(p) {
   }
 }
 
+/**
+ * BuildResult / NAPI diag 의 errors / warnings 를 stderr 로 출력.
+ * `logLevel === 'silent'` 면 출력 안 함, `'error'` 면 errors 만.
+ * `err.specifier` 는 NAPI 가 diag suggestion 으로 노출하는 import specifier.
+ */
+function printResultDiagnostics(result, logLevel) {
+  if (result.errors.length > 0 && logLevel !== 'silent') {
+    for (const err of result.errors) {
+      const loc = err.location ? `${err.location.file}: ` : '';
+      const detail = err.specifier ? ` (${err.specifier})` : '';
+      console.error(`error: ${loc}${err.text}${detail}`);
+    }
+  }
+  if (result.warnings.length > 0 && logLevel !== 'silent' && logLevel !== 'error') {
+    for (const warn of result.warnings) {
+      const detail = warn.specifier ? ` (${warn.specifier})` : '';
+      console.error(`warning: ${warn.text}${detail}`);
+    }
+  }
+}
+
 function assertCanWriteOutput(outPath, resolvedEntries) {
   if (!resolvedEntries) return;
   if (resolvedEntries.has(safeRealpath(outPath))) {
@@ -777,19 +798,7 @@ async function runRnBundle(opts, config) {
     }),
   });
 
-  if (result.errors.length > 0 && opts.logLevel !== 'silent') {
-    for (const err of result.errors) {
-      const loc = err.location ? `${err.location.file}: ` : '';
-      const detail = err.specifier ? ` (${err.specifier})` : '';
-      console.error(`error: ${loc}${err.text}${detail}`);
-    }
-  }
-  if (result.warnings.length > 0 && opts.logLevel !== 'silent' && opts.logLevel !== 'error') {
-    for (const warn of result.warnings) {
-      const detail = warn.specifier ? ` (${warn.specifier})` : '';
-      console.error(`warning: ${warn.text}${detail}`);
-    }
-  }
+  printResultDiagnostics(result, opts.logLevel);
 
   // caller-side write — bundle / sourcemap path 분리 + URL override 적용.
   if (callerWrite && result.errors.length === 0 && result.outputFiles?.length) {
@@ -1298,17 +1307,7 @@ async function runBundle(opts, config) {
 
   const result = plugins.length > 0 ? await build(buildOpts) : buildSync(buildOpts);
 
-  if (result.errors.length > 0 && opts.logLevel !== 'silent') {
-    for (const err of result.errors) {
-      const loc = err.location ? `${err.location.file}: ` : '';
-      console.error(`error: ${loc}${err.text}`);
-    }
-  }
-  if (result.warnings.length > 0 && opts.logLevel !== 'silent' && opts.logLevel !== 'error') {
-    for (const warn of result.warnings) {
-      console.error(`warning: ${warn.text}`);
-    }
-  }
+  printResultDiagnostics(result, opts.logLevel);
 
   // 출력
   if (opts.outfile || opts.outdir) {

--- a/packages/core/src/napi/result.zig
+++ b/packages/core/src/napi/result.zig
@@ -157,6 +157,12 @@ pub fn buildResultToJS(env: c.napi_env, result: *const bundler_mod.BundleResult,
             _ = c.napi_set_named_property(env, js_diag, "location", js_loc);
         }
 
+        if (d.suggestion) |suggestion| {
+            var js_suggestion: c.napi_value = undefined;
+            _ = c.napi_create_string_utf8(env, suggestion.ptr, suggestion.len, &js_suggestion);
+            _ = c.napi_set_named_property(env, js_diag, "specifier", js_suggestion);
+        }
+
         if (is_err) {
             _ = c.napi_set_element(env, js_errors, err_idx, js_diag);
             err_idx += 1;

--- a/packages/core/test/cli/react-native-bundle.ts
+++ b/packages/core/test/cli/react-native-bundle.ts
@@ -71,4 +71,21 @@ describe('CLI: bundle --platform=react-native (#2540 PR #7)', () => {
     expect(exitCode).toBe(0);
     expect(existsSync(out)).toBe(true);
   });
+
+  test('RN CLI 호환: --rn-platform / --rn-project-root pair form도 허용', () => {
+    const out = join(dir, 'out-pair.js');
+    const { exitCode } = runCli([
+      '--bundle',
+      join(dir, 'src/index.ts'),
+      '--platform=react-native',
+      '--rn-platform',
+      'ios',
+      '--rn-project-root',
+      dir,
+      '-o',
+      out,
+    ]);
+    expect(exitCode).toBe(0);
+    expect(existsSync(out)).toBe(true);
+  });
 });

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -67,19 +67,51 @@ describe('buildRnBundleOptions — 기본 RN preset 필드', () => {
 });
 
 describe('buildRnBundleOptions — platform 분기 (resolveExtensions)', () => {
-  test('iOS — `.ios.*` 가 prefix', () => {
+  test('iOS — Metro sourceExts 순서대로 `.ios.*` / `.native.*` / base 를 탐색', () => {
     const opts = buildRnBundleOptions(baseInput({ rnPlatform: 'ios' }));
-    expect(opts.resolveExtensions?.[0]).toBe('.ios.ts');
-    expect(opts.resolveExtensions?.[1]).toBe('.ios.tsx');
-    expect(opts.resolveExtensions).toContain('.native.ts');
-    expect(opts.resolveExtensions).toContain('.ts');
+    expect(opts.resolveExtensions?.slice(0, 15)).toEqual([
+      '.ios.js',
+      '.native.js',
+      '.js',
+      '.ios.jsx',
+      '.native.jsx',
+      '.jsx',
+      '.ios.json',
+      '.native.json',
+      '.json',
+      '.ios.ts',
+      '.native.ts',
+      '.ts',
+      '.ios.tsx',
+      '.native.tsx',
+      '.tsx',
+    ]);
   });
 
-  test('Android — `.android.*` 가 prefix', () => {
+  test('Android — Metro sourceExts 순서대로 `.android.*` / `.native.*` / base 를 탐색', () => {
     const opts = buildRnBundleOptions(baseInput({ rnPlatform: 'android' }));
-    expect(opts.resolveExtensions?.[0]).toBe('.android.ts');
-    expect(opts.resolveExtensions?.[1]).toBe('.android.tsx');
-    expect(opts.resolveExtensions).toContain('.native.ts');
+    expect(opts.resolveExtensions?.slice(0, 6)).toEqual([
+      '.android.js',
+      '.native.js',
+      '.js',
+      '.android.jsx',
+      '.native.jsx',
+      '.jsx',
+    ]);
+  });
+
+  test('extra.sourceExts 도 Metro 방식의 순서를 보존', () => {
+    const opts = buildRnBundleOptions(
+      baseInput({ rnPlatform: 'ios', extra: { sourceExts: ['ts', 'js'] } }),
+    );
+    expect(opts.resolveExtensions).toEqual([
+      '.ios.ts',
+      '.native.ts',
+      '.ts',
+      '.ios.js',
+      '.native.js',
+      '.js',
+    ]);
   });
 });
 
@@ -108,7 +140,7 @@ describe('buildRnBundleOptions — extra.platforms validation', () => {
     const opts = buildRnBundleOptions(
       baseInput({ rnPlatform: 'ios', extra: { platforms: ['ios', 'android', 'web'] } }),
     );
-    expect(opts.resolveExtensions?.[0]).toBe('.ios.ts');
+    expect(opts.resolveExtensions?.[0]).toBe('.ios.js');
     expect(opts.resolveExtensions).not.toContain('.web.ts');
   });
 });

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -410,9 +410,9 @@ describe('buildRnBundleOptions — dev mode 분기 (jsx / devMode / reactRefresh
     expect(opts.collectModuleCodes).toBe(true);
   });
 
-  test('dev=false — jsx 미정의 (NAPI default), devMode/reactRefresh/collectModuleCodes 미설정', () => {
+  test('dev=false — jsx=automatic, devMode/reactRefresh/collectModuleCodes 미설정', () => {
     const opts = buildRnBundleOptions(baseInput({ dev: false }));
-    expect(opts.jsx).toBeUndefined();
+    expect(opts.jsx).toBe('automatic');
     expect(opts.devMode).toBeUndefined();
     expect(opts.reactRefresh).toBeUndefined();
     expect(opts.collectModuleCodes).toBeUndefined();

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -158,7 +158,7 @@ export interface RnBundleInput {
   workletPluginVersion?: string;
 }
 
-const DEFAULT_SOURCE_EXTS = ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.json'];
+const DEFAULT_SOURCE_EXTS = ['.js', '.jsx', '.json', '.ts', '.tsx', '.mjs', '.cjs'];
 // Metro 호환 + RN 흔한 폰트/이미지 — bungae DEFAULT_RESOLVER.assetExts 와 동일.
 // caller 가 `extra.assetExts` 로 override 하면 이 list 무시.
 export const DEFAULT_ASSET_EXTS: string[] = [
@@ -202,23 +202,22 @@ export const DEFAULT_ASSET_EXTS: string[] = [
   '.woff2',
 ];
 
-const NATIVE_AND_BASE = [
-  '.native.ts',
-  '.native.tsx',
-  '.native.js',
-  '.native.jsx',
-  '.ts',
-  '.tsx',
-  '.js',
-  '.jsx',
-  '.json',
-];
+function buildResolveExtensions(rnPlatform: 'ios' | 'android', sourceExts: readonly string[]): string[] {
+  const platformPrefix = `.${rnPlatform}`;
+  const extensions: string[] = [];
+  const seen = new Set<string>();
 
-function buildResolveExtensions(rnPlatform: 'ios' | 'android'): string[] {
-  if (rnPlatform === 'ios') {
-    return ['.ios.ts', '.ios.tsx', '.ios.js', '.ios.jsx', ...NATIVE_AND_BASE];
+  for (const sourceExt of sourceExts) {
+    const ext = normalizeExt(sourceExt);
+    for (const candidate of [`${platformPrefix}${ext}`, `.native${ext}`, ext]) {
+      if (!seen.has(candidate)) {
+        seen.add(candidate);
+        extensions.push(candidate);
+      }
+    }
   }
-  return ['.android.ts', '.android.tsx', '.android.js', '.android.jsx', ...NATIVE_AND_BASE];
+
+  return extensions;
 }
 
 function buildAssetLoaders(assetExts: readonly string[]): Record<string, string> {
@@ -473,7 +472,7 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
     strictExecutionOrder: true,
     workletTransform: true,
     codegenTransform: true,
-    resolveExtensions: buildResolveExtensions(rnPlatform),
+    resolveExtensions: buildResolveExtensions(rnPlatform, sourceExts),
     mainFields: ['react-native', 'browser', 'main'],
     loader: baseLoader,
     // RN core packages must be singletons. pnpm exposes peer folders such as

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -202,7 +202,10 @@ export const DEFAULT_ASSET_EXTS: string[] = [
   '.woff2',
 ];
 
-function buildResolveExtensions(rnPlatform: 'ios' | 'android', sourceExts: readonly string[]): string[] {
+function buildResolveExtensions(
+  rnPlatform: 'ios' | 'android',
+  sourceExts: readonly string[],
+): string[] {
   const platformPrefix = `.${rnPlatform}`;
   const extensions: string[] = [];
   const seen = new Set<string>();

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -505,8 +505,9 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
   // hide 도 추가.
   preset.footer = buildFooter(dev);
 
+  preset.jsx = dev ? 'automatic-dev' : 'automatic';
+
   if (dev) {
-    preset.jsx = 'automatic-dev';
     preset.devMode = true;
     preset.reactRefresh = true;
     preset.collectModuleCodes = true;

--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -513,6 +513,34 @@ test "Bundler: unresolved import produces error diagnostic" {
     try std.testing.expectEqual(types.BundlerDiagnostic.ErrorCode.unresolved_import, diags[0].code);
 }
 
+test "Bundler: webpack runtime helper calls are not resolved as imports" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.js",
+        \\var __webpack_modules__ = {
+        \\  "./src/a.ts": function(module, exports, __webpack_require__) {
+        \\    var socket = __webpack_require__("react-native-tcp-socket");
+        \\    return socket;
+        \\  },
+        \\};
+        \\export const value = 1;
+    );
+
+    const entry = try absPath(&tmp, "index.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+}
+
 test "Bundler: circular dependency produces warning" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -1980,6 +1980,52 @@ test "react_native preserve_symlinks: CJS-wrapped package ESM imports resolve fr
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require_hoist_non_react_statics") != null);
 }
 
+test "react_native preserve_symlinks: workspace symlink package resolves app logical dependencies first" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("apps/app/node_modules/@scope");
+    try tmp.dir.makePath("apps/app/node_modules/react-native-tcp-socket");
+    try tmp.dir.makePath("packages/pkg/dist");
+    try writeFile(tmp.dir, "apps/app/node_modules/react-native-tcp-socket/package.json", "{\"main\":\"index.js\"}");
+    try writeFile(tmp.dir, "apps/app/node_modules/react-native-tcp-socket/index.js", "module.exports = { createConnection() {} };");
+    try writeFile(tmp.dir, "packages/pkg/package.json", "{\"main\":\"dist/index.js\"}");
+    try writeFile(tmp.dir, "packages/pkg/dist/index.js",
+        \\import TcpSocket from "react-native-tcp-socket";
+        \\export const socket = TcpSocket;
+    );
+
+    tmp.dir.symLink(
+        "../../../../packages/pkg",
+        "apps/app/node_modules/@scope/pkg",
+        .{ .is_directory = true },
+    ) catch |err| switch (err) {
+        error.AccessDenied, error.PermissionDenied => return error.SkipZigTest,
+        else => return err,
+    };
+
+    try writeFile(tmp.dir, "apps/app/index.js",
+        \\import { socket } from "@scope/pkg";
+        \\console.log(socket);
+    );
+
+    const entry = try absPath(&tmp, "apps/app/index.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .preserve_symlinks = true,
+        .resolve_symlink_siblings = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "react-native-tcp-socket") == null);
+}
+
 test "preserve_symlinks: alias to pnpm symlink package root bundles package entry" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -3718,6 +3718,47 @@ test "react_native inlineRequires: namespace member rewrite initializes source m
     try std.testing.expect(std.mem.indexOf(u8, result.output, selector_member_init) != null);
 }
 
+test "react_native release: namespace member rewrite initializes export-star source modules" {
+    // ProductTabContainer/modalSelectors 축소 재현:
+    // release(tree_shaking=true) 에서 `import * as selectors from './selectors'`
+    // 뒤 `selectors.getVisible` 을 직접 binding 으로 rewrite 할 때, export-star
+    // barrel 자체가 아니라 실제 getter source 모듈도 init 해야 한다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try tmp.dir.makePath("selectors");
+    try writeFile(tmp.dir, "entry.js",
+        \\import * as selectors from './selectors';
+        \\globalThis.__zntcSelectorResult = selectors.getVisible({ modal: { visible: true } });
+    );
+    try writeFile(tmp.dir, "selectors/index.js",
+        \\export * from './product';
+    );
+    try writeFile(tmp.dir, "selectors/product.js",
+        \\export const getVisible = (state) => state.modal.visible;
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .tree_shaking = true,
+        .dev_mode = false,
+        .entry_error_guard = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "init_product") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "return init_product") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, ", getVisible)") != null);
+}
+
 test "react_native inlineRequires: namespace import from export-star barrel initializes source getters" {
     // react-native-animatable 축소 재현:
     // `import * as defs from './definitions'`를 값으로 넘기면 namespace object가

--- a/src/bundler/bundler_test/tree_shake/cjs_define_property.zig
+++ b/src/bundler/bundler_test/tree_shake/cjs_define_property.zig
@@ -28,6 +28,265 @@ test "TreeShaking CJS: named import prunes unused Object.defineProperty exports 
     try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_DEFINE_PROPERTY_MARKER") == null);
 }
 
+test "TreeShaking CJS: __export getter keeps returned local binding" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.js", "import { useIsRestoring } from './lib.js'; console.log(useIsRestoring());");
+    try writeFile(tmp.dir, "lib.js",
+        \\var __defProp = Object.defineProperty;
+        \\var __export = (target, all) => {
+        \\  for (var name in all) __defProp(target, name, { get: all[name], enumerable: true });
+        \\};
+        \\var __toCommonJS = (mod) => mod;
+        \\var lib_exports = {};
+        \\__export(lib_exports, {
+        \\  useIsRestoring: () => useIsRestoring,
+        \\  unusedExport: () => unusedExport
+        \\});
+        \\module.exports = __toCommonJS(lib_exports);
+        \\var useIsRestoring = () => "USED_CJS_EXPORT_HELPER_MARKER";
+        \\var unusedExport = () => "UNUSED_CJS_EXPORT_HELPER_MARKER";
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .strict_execution_order = true,
+        .minify_syntax = true,
+        .minify_whitespace = true,
+        .minify_identifiers = false,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_CJS_EXPORT_HELPER_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_CJS_EXPORT_HELPER_MARKER") == null);
+}
+
+test "TreeShaking CJS: whole require preserves member export assignments" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+    try writeFile(tmp.dir, "entry.js",
+        \\const ReactFabric = require("./shim.js").default;
+        \\console.log(ReactFabric.render());
+    );
+    try writeFile(tmp.dir, "shim.js",
+        \\const ReactFabric = __DEV__ ? require("./renderer-dev.js") : require("./renderer-prod.js");
+        \\globalThis.RN$stopSurface = ReactFabric.stopSurface;
+        \\globalThis.registerCallableModule("ReactFabric", ReactFabric);
+        \\exports.default = ReactFabric;
+    );
+    try writeFile(tmp.dir, "renderer-dev.js",
+        \\exports.render = function render() { return "UNUSED_WHOLE_REQUIRE_DEV_RENDER_MARKER"; };
+    );
+    try writeFile(tmp.dir, "renderer-prod.js",
+        \\exports.render = function render() { return "USED_WHOLE_REQUIRE_RENDER_MARKER"; };
+        \\exports.stopSurface = function stopSurface() { return "USED_WHOLE_REQUIRE_STOP_MARKER"; };
+        \\exports.unmountComponentAtNode = function unmountComponentAtNode() {
+        \\  return "USED_WHOLE_REQUIRE_UNMOUNT_MARKER";
+        \\};
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .strict_execution_order = true,
+        .minify_syntax = true,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .define = &.{.{ .key = "__DEV__", .value = "false" }},
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_WHOLE_REQUIRE_RENDER_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_WHOLE_REQUIRE_STOP_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_WHOLE_REQUIRE_UNMOUNT_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_WHOLE_REQUIRE_DEV_RENDER_MARKER") == null);
+}
+
+test "TreeShaking CJS: namespace sentinel preserves member export assignments" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+    try writeFile(tmp.dir, "entry.js",
+        \\import("./renderer.js").then((renderer) => {
+        \\  globalThis.registerCallableModule("ReactFabric", renderer);
+        \\});
+    );
+    try writeFile(tmp.dir, "renderer.js",
+        \\exports.render = function render() { return "USED_CJS_SENTINEL_RENDER_MARKER"; };
+        \\exports.stopSurface = function stopSurface() { return "USED_CJS_SENTINEL_STOP_MARKER"; };
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .strict_execution_order = true,
+        .minify_syntax = true,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_CJS_SENTINEL_RENDER_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_CJS_SENTINEL_STOP_MARKER") != null);
+}
+
+test "TreeShaking CJS: default import preserves bare module.exports assignment" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+    try writeFile(tmp.dir, "entry.js",
+        \\import Color from './color.js';
+        \\class Card {
+        \\  render(backgroundColor) {
+        \\    return typeof backgroundColor === "string" ? Color(backgroundColor).alpha() : false;
+        \\  }
+        \\}
+        \\console.log(new Card().render("#fff"));
+    );
+    try writeFile(tmp.dir, "color.js",
+        \\const normalize = require("./normalize.js");
+        \\function Color(value) {
+        \\  if (!(this instanceof Color)) return new Color(value);
+        \\  this.value = normalize(value);
+        \\}
+        \\Color.prototype.alpha = function alpha() {
+        \\  return "USED_BARE_MODULE_EXPORTS_ALPHA_MARKER";
+        \\};
+        \\module.exports = Color;
+    );
+    try writeFile(tmp.dir, "normalize.js",
+        \\module.exports = function normalize(value) {
+        \\  return value;
+        \\};
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .strict_execution_order = true,
+        .minify_syntax = true,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_BARE_MODULE_EXPORTS_ALPHA_MARKER") != null);
+    var module_exports_count: usize = 0;
+    var search_from: usize = 0;
+    while (std.mem.indexOf(u8, result.output[search_from..], "module.exports=")) |offset| {
+        module_exports_count += 1;
+        search_from += offset + "module.exports=".len;
+    }
+    try std.testing.expect(module_exports_count >= 2);
+}
+
+test "TreeShaking CJS: re-exported require member keeps CJS export assignment" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+    try writeFile(tmp.dir, "entry.js",
+        \\import { setupURLPolyfill } from './auto.js';
+        \\setupURLPolyfill();
+        \\console.log(new globalThis.URLSearchParams().tag);
+    );
+    try writeFile(tmp.dir, "auto.js",
+        \\export { setupURLPolyfill } from './index.js';
+    );
+    try writeFile(tmp.dir, "index.js",
+        \\export * from './url.js';
+        \\export * from './url-search-params.js';
+        \\function polyfillGlobal(name, getValue) {
+        \\  globalThis[name] = getValue();
+        \\}
+        \\export function setupURLPolyfill() {
+        \\  polyfillGlobal("URL", () => require("./url.js").URL);
+        \\  polyfillGlobal("URLSearchParams", () => require("./url-search-params.js").URLSearchParams);
+        \\}
+    );
+    try writeFile(tmp.dir, "url.js",
+        \\import { URL } from './whatwg.js';
+        \\URL.createObjectURL = function createObjectURL() {};
+        \\export { URL };
+    );
+    try writeFile(tmp.dir, "url-search-params.js",
+        \\export { URLSearchParams } from './whatwg.js';
+    );
+    try writeFile(tmp.dir, "whatwg.js",
+        \\const { URL, URLSearchParams } = require("./wrapper.js");
+        \\const sharedGlobalObject = {};
+        \\URL.install(sharedGlobalObject);
+        \\URLSearchParams.install(sharedGlobalObject);
+        \\exports.URL = sharedGlobalObject.URL;
+        \\exports.URLSearchParams = sharedGlobalObject.URLSearchParams;
+    );
+    try writeFile(tmp.dir, "wrapper.js",
+        \\exports.URL = {
+        \\  install(object) {
+        \\    object.URL = function URL() {
+        \\      this.tag = "UNUSED_URL_MARKER";
+        \\    };
+        \\  },
+        \\};
+        \\exports.URLSearchParams = {
+        \\  install(object) {
+        \\    object.URLSearchParams = function URLSearchParams() {
+        \\      this.tag = "USED_URL_SEARCH_PARAMS_MARKER";
+        \\    };
+        \\  },
+        \\};
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .strict_execution_order = true,
+        .minify_syntax = true,
+        .minify_whitespace = true,
+        .minify_identifiers = false,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_URL_SEARCH_PARAMS_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "exports.URLSearchParams=sharedGlobalObject.URLSearchParams") != null);
+}
+
 test "TreeShaking CJS: module.exports defineProperty keeps helper and require target" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/bundler_test/tree_shake/rn_esm_wrap.zig
+++ b/src/bundler/bundler_test/tree_shake/rn_esm_wrap.zig
@@ -248,3 +248,142 @@ test "TreeShaking #2398: RN namespace import (`import * as ns`) 가 .esm wrap pu
     try std.testing.expect(std.mem.indexOf(u8, result.output, "NS_B_MARKER") != null);
     try std.testing.expect(std.mem.indexOf(u8, result.output, "NS_C_MARKER") != null);
 }
+
+test "TreeShaking: RN .esm wrap unused namespace re-export drops orphan import init" {
+    // Sentry-style barrel:
+    //   import * as logger from './logs/public-api.js';
+    //   export { logger };
+    //
+    // If consumers only use another export from the same pure wrapper, the
+    // namespace target can be tree-shaken. The original import declaration must
+    // be skipped too; otherwise the wrapper body still executes
+    // `(init_public_api$N(), __toCommonJS(exports_public_api$N))` even though
+    // that target wrapper was not emitted.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used } from 'pkg';
+        \\console.log(used());
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/index.js",
+        \\import * as logger from './logs/public-api.js';
+        \\export { logger };
+        \\export function used() { return 'USED_EXPORT_MARKER'; }
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/logs/public-api.js",
+        \\import { capture } from './internal.js';
+        \\export { fmt } from '../utils/parameterize.js';
+        \\export function debug() { return capture('UNUSED_LOGGER_MARKER'); }
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/logs/internal.js",
+        \\export function capture(value) { return value; }
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/utils/parameterize.js",
+        \\export function fmt(value) { return value; }
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/package.json", "{\"name\": \"pkg\", \"main\": \"index.js\", \"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_EXPORT_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_LOGGER_MARKER") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "pkg_logs_public_api") == null);
+}
+
+test "TreeShaking: RN .esm wrap used namespace re-export includes namespace target" {
+    // `export { logger }` where `logger` is `import * as logger` must keep the
+    // namespace source. Otherwise the re-exporting wrapper can be live while its
+    // generated import init points at a pruned wrapper.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { logger } from 'pkg';
+        \\console.log(logger.debug());
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/index.js",
+        \\import * as logger from './logs/public-api.js';
+        \\export { logger };
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/logs/public-api.js",
+        \\import { capture } from './internal.js';
+        \\export { fmt } from '../utils/parameterize.js';
+        \\export function debug() { return capture('USED_LOGGER_MARKER'); }
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/logs/internal.js",
+        \\export function capture(value) { return value; }
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/utils/parameterize.js",
+        \\export function fmt(value) { return value; }
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/package.json", "{\"name\": \"pkg\", \"main\": \"index.js\", \"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_LOGGER_MARKER") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "init_pkg_logs_public_api") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "exports_pkg_logs_public_api") != null);
+}
+
+test "TreeShaking: RN .esm wrap export-star drops getter for pruned source" {
+    // `export * from './style.js'` expands into lazy getters on the barrel
+    // exports object. If the star source is tree-shaken, those getters must be
+    // omitted too; otherwise the live barrel can contain
+    // `init_style()` / `exports_style.foo` references to a wrapper that was not
+    // emitted in the release bundle.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { used } from 'pkg';
+        \\console.log(used());
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/index.js",
+        \\export { used } from './used.js';
+        \\export * from './style.js';
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/used.js",
+        \\export function used() { return 'USED_FROM_STAR_BARREL'; }
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/style.js",
+        \\export const unusedStyle = 'UNUSED_STAR_STYLE_MARKER';
+    );
+    try writeFile(tmp.dir, "node_modules/pkg/package.json", "{\"name\": \"pkg\", \"main\": \"index.js\", \"sideEffects\": false}");
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .tree_shaking = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_FROM_STAR_BARREL") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "UNUSED_STAR_STYLE_MARKER") == null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "pkg_style") == null);
+}

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -1256,6 +1256,8 @@ fn makeStarGetterValue(
     name: []const u8,
     options: *const EmitOptions,
 ) !?[]const u8 {
+    if (l.tree_shaker_active and !src_mod.is_included) return null;
+
     switch (src_mod.wrap_kind) {
         .none => {
             // scope-hoisted: export의 local_name을 찾아 canonical name으로 변환
@@ -1273,6 +1275,7 @@ fn makeStarGetterValue(
             if (l.resolveExportChain(@enumFromInt(src_i), name, 0)) |resolved| {
                 const canonical_mod_i = resolved.module_index.toU32();
                 const canonical_mod = l.graph.getModule(resolved.module_index) orelse return null;
+                if (l.tree_shaker_active and !canonical_mod.is_included) return null;
                 // canonical 모듈이 래핑되어 있으면 exports_xxx.name 형태
                 if (canonical_mod.wrap_kind == .esm) {
                     const ev = try canonical_mod.allocExportsName(allocator);

--- a/src/bundler/import_scanner_test.zig
+++ b/src/bundler/import_scanner_test.zig
@@ -1280,6 +1280,37 @@ test "require.context: plain require is not require_context" {
     try std.testing.expect(has_require);
 }
 
+test "require: webpack runtime helper calls are not static imports" {
+    const alloc = std.testing.allocator;
+    const records = try parseAndExtract(alloc,
+        \\var __webpack_modules__ = {
+        \\  "./src/a.ts": function(module, exports, __webpack_require__) {
+        \\    var dep = __webpack_require__("./src/dep.ts");
+        \\    return dep;
+        \\  },
+        \\};
+    );
+    defer alloc.free(records);
+
+    try std.testing.expectEqual(@as(usize, 0), records.len);
+}
+
+test "inline scan require: webpack runtime helper calls are not static imports" {
+    const alloc = std.testing.allocator;
+    const records = try parseInlineScanRecords(alloc,
+        \\var __webpack_modules__ = {
+        \\  "./src/a.ts": function(module, exports, __webpack_require__) {
+        \\    var dep = __webpack_require__("./src/dep.ts");
+        \\    var bare = __webpack_require__("react-native-tcp-socket");
+        \\    return dep;
+        \\  },
+        \\};
+    );
+    defer alloc.free(records);
+
+    try std.testing.expectEqual(@as(usize, 0), records.len);
+}
+
 test "require.context: Symbol.context is ignored" {
     const alloc = std.testing.allocator;
     const records = try parseAndExtract(alloc, "Symbol.context('./pages');");

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -880,12 +880,16 @@ pub fn buildMetadataForAst(
                 } else if (tmod.wrap_kind == .esm and tidx != module_index) {
                     // __esm → __esm live binding: named import만 skip.
                     // namespace import는 body codegen이 exports_xxx 할당을 생성해야 함.
+                    // 단 tree-shaking 이 target wrapper 를 제거한 경우에는 원본 import
+                    // lowering 도 반드시 제거해야 한다. 그렇지 않으면 body 에
+                    // `(init_removed(), __toCommonJS(exports_removed))` orphan 호출이 남아
+                    // RN release 런타임에서 ReferenceError 가 난다.
                     // self-import는 제외 (순환 자기 참조 시 body codegen이 처리).
                     const has_namespace = for (m.import_bindings) |ib| {
                         if (ib.import_record_index == rec_i and ib.kind == .namespace)
                             break true;
                     } else false;
-                    if (!has_namespace) {
+                    if (!has_namespace or (self.tree_shaker_active and !tmod.is_included)) {
                         try hoisted_specifiers.put(rec.specifier, {});
                     }
                 }

--- a/src/bundler/linker/shared_namespace.zig
+++ b/src/bundler/linker/shared_namespace.zig
@@ -116,7 +116,9 @@ pub fn registerNamespaceRewrites(
     errdefer if (!inner_map_transferred) inner_map.deinit();
     var has_shadow = false;
     // target_init 은 target_mod_idx 에만 의존하므로 export 마다 재계산할 필요가 없다.
-    // 비-dev 빌드는 wrap 자체가 불필요하므로 호출도 생략한다 (lazy 런타임 미사용).
+    // dev lazy runtime 에서는 access site 가 package entry 도 깨워야 하므로 target init 을
+    // 포함한다. release 는 module preamble 이 target init 을 이미 보장하므로 source init 만
+    // rewrite value 에 붙인다.
     const target_init: ?[]const u8 = if (self.dev_mode)
         try allocEsmInitExprForModuleIndex(self, target_mod_idx)
     else
@@ -170,17 +172,15 @@ pub fn registerNamespaceRewrites(
             try inner_map.put(exp.exported, ns_var);
             continue;
         }
-        if (self.dev_mode) {
-            if (try allocNamespaceMemberRewriteValue(self, target_init, target_mod_idx, exp, &source_init_cache)) |rewrite_value| {
-                var owned_by_list = false;
-                errdefer if (!owned_by_list) self.allocator.free(rewrite_value);
-                // ns_member_rewrites map 은 포인터만 빌리고, 실제 소유권은
-                // LinkingMetadata.owned_rename_values 로 이전해 metadata deinit 에서 해제한다.
-                try owned_rewrite_values.append(self.allocator, rewrite_value);
-                owned_by_list = true;
-                try inner_map.put(exp.exported, rewrite_value);
-                continue;
-            }
+        if (try allocNamespaceMemberRewriteValue(self, target_init, target_mod_idx, exp, &source_init_cache)) |rewrite_value| {
+            var owned_by_list = false;
+            errdefer if (!owned_by_list) self.allocator.free(rewrite_value);
+            // ns_member_rewrites map 은 포인터만 빌리고, 실제 소유권은
+            // LinkingMetadata.owned_rename_values 로 이전해 metadata deinit 에서 해제한다.
+            try owned_rewrite_values.append(self.allocator, rewrite_value);
+            owned_by_list = true;
+            try inner_map.put(exp.exported, rewrite_value);
+            continue;
         }
         // exp.local 은 owned=true 면 ns_export_cache 가, 아니면 target module 이 소유한다.
         // metadata map 은 값 포인터만 빌린다.

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -140,8 +140,9 @@ pub const Module = struct {
     index: ModuleIndex,
     /// 절대 파일 경로. graph의 path_to_module 키와 동일한 메모리를 참조 (빌림).
     path: []const u8,
-    /// dependency lookup 시작 디렉토리. preserve_symlinks=true 에서 symlink 를 거친
-    /// logical dirname 을 보존한다. null 이면 dirname(path)를 사용.
+    /// dependency lookup 시작 디렉토리. null 이면 dirname(path)를 사용한다.
+    /// preserve_symlinks=true 에서는 보통 null 로 두어 logical dirname 이 1차 기준이
+    /// 되게 한다. realpath sibling lookup 은 resolver fallback 에서 처리한다.
     resolve_dir: ?[]const u8 = null,
     /// dev mode 모듈 ID. bundler에서 한 번 계산 (path의 서브슬라이스, 할당 없음).
     dev_id: []const u8 = "",

--- a/src/bundler/resolver.zig
+++ b/src/bundler/resolver.zig
@@ -304,17 +304,17 @@ pub const Resolver = struct {
     /// symlink 를 따라가지 않고 링크 자체 경로로 해석 (--preserve-symlinks).
     /// esbuild/Node `--preserve-symlinks` 호환: makeResult() 에서 link path 를 module
     /// identity 로 그대로 사용한다. 같은 realpath 라도 link path 가 다르면 별도 모듈
-    /// 인스턴스로 취급된다 — RN/pnpm 처럼 identity 는 logical 로 유지하되 후속 bare
-    /// lookup 을 real package 디렉토리에서 시작하고 싶다면 `resolve_symlink_siblings` 도
-    /// 함께 켠다.
+    /// 인스턴스로 취급된다. RN/pnpm 처럼 identity 와 후속 bare lookup 의 1차 기준을
+    /// logical path 로 유지하되, real package 옆 dependency 를 fallback 으로 보려면
+    /// `resolve_symlink_siblings` 도 함께 켠다.
     preserve_symlinks: bool = false,
-    /// `preserve_symlinks` 로 logical path 를 module identity 로 보존하는 경우에도,
-    /// symlink 로 resolve 된 모듈의 후속 bare specifier 는 realpath 디렉토리에서
-    /// 시작할 수 있게 한다.
+    /// `preserve_symlinks` 로 logical path 를 module identity 로 보존한 상태에서,
+    /// logical node_modules 탐색이 실패한 bare specifier 를 realpath 디렉토리 기준으로
+    /// 한 번 더 찾는다.
     /// pnpm 처럼 `app/node_modules/pkg` 가 `.pnpm/.../pkg` 로 symlink 된 환경에서,
     /// `pkg` 의 sibling dependency (예: `code-push`) 가 `.pnpm/.../node_modules/` 에만
-    /// 존재하거나, `.pnpm/node_modules` 의 다른 버전보다 package-local 버전이 우선되어야
-    /// 하는 경우 Metro/Node 와 같은 결과를 만든다.
+    /// 존재하는 경우 Metro/Node 와 같은 결과를 만든다. workspace symlink 패키지는
+    /// 앱의 logical node_modules 를 먼저 보므로 consuming app dependency 를 놓치지 않는다.
     /// `preserve_symlinks` 와 직교한 옵션이며, 둘은 함께 켜는 것이 일반적이다.
     resolve_symlink_siblings: bool = false,
     /// `resolveNodeModules` 의 parent dir walk-up 차단 (Metro `resolver.
@@ -910,9 +910,13 @@ pub const Resolver = struct {
     }
 
     fn makeResult(self: *Resolver, path: []const u8) ResolveError!?ResolveResult {
-        // preserve_symlinks=true → link path 를 module identity 로 그대로 사용 (esbuild/Node).
-        // resolve_symlink_siblings=true 이면 identity 는 유지하되 resolve_dir 만 realpath 로
-        // 기록해 후속 bare lookup 이 pnpm package-local dependency 를 먼저 보게 한다.
+        // preserve_symlinks=true → link path 를 module identity 와 1차 resolve 기준으로
+        // 그대로 사용한다 (Metro/Node --preserve-symlinks). 일반 app/workspace
+        // node_modules symlink 는 realpath sibling lookup 을 resolveInner() fallback 에서만
+        // 수행한다. 여기서 resolve_dir 을 realpath 로 바꾸면 workspace symlink package 가
+        // consuming app node_modules 를 건너뛰는 회귀가 발생한다. 단,
+        // `.pnpm/node_modules` virtual store 엔트리는 그 자체가 global hoist facade 이므로
+        // package-local dependency 우선순위를 위해 real resolve_dir 을 유지한다.
         // false → bun(.bun/) / pnpm(.pnpm/) 의 symlink 를 realpath 로 해석해 중첩 node_modules
         // 탐색이 올바른 계층에서 동작하게 한다.
         const resolved = blk: {
@@ -929,7 +933,9 @@ pub const Resolver = struct {
                 self.allocator.dupe(u8, path) catch return error.OutOfMemory;
         };
         errdefer self.allocator.free(resolved);
-        const resolve_dir = if (self.preserve_symlinks and self.resolve_symlink_siblings)
+        const resolve_dir = if (self.preserve_symlinks and
+            self.resolve_symlink_siblings and
+            shouldUseRealResolveDirForLogicalPath(path))
             try self.realResolveDirForLogicalPath(path, resolved)
         else
             null;
@@ -940,6 +946,11 @@ pub const Resolver = struct {
             .module_type = ModuleType.fromExtension(ext),
             .resolve_dir = resolve_dir,
         };
+    }
+
+    fn shouldUseRealResolveDirForLogicalPath(path: []const u8) bool {
+        return std.mem.indexOf(u8, path, ".pnpm/node_modules/") != null or
+            std.mem.indexOf(u8, path, ".pnpm\\node_modules\\") != null;
     }
 
     fn realResolveDirForLogicalPath(self: *Resolver, path: []const u8, logical_path: []const u8) ResolveError!?[]const u8 {

--- a/src/bundler/resolver_test.zig
+++ b/src/bundler/resolver_test.zig
@@ -372,8 +372,7 @@ test "resolve: preserve_symlinks + resolve_symlink_siblings — pnpm 에서 link
     // preserve_symlinks=true → identity 는 link path. `.pnpm` 미포함, `node_modules/ui` 로 끝남.
     try std.testing.expect(std.mem.indexOf(u8, logical_ui.path, ".pnpm") == null);
     try std.testing.expect(pathEndsWith(logical_ui.path, "node_modules/ui/dist/index.js"));
-    try std.testing.expect(logical_ui.resolve_dir != null);
-    try std.testing.expect(std.mem.indexOf(u8, logical_ui.resolve_dir.?, ".pnpm/ui@1_react@18/node_modules/ui/dist") != null);
+    try std.testing.expect(logical_ui.resolve_dir == null);
 
     const logical_ui_dir = std.fs.path.dirname(logical_ui.path).?;
     // peer dependency dedupe: lookup root 는 link path → walk up 으로 root node_modules/react 도달.

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -54,6 +54,8 @@ pub const CjsExportFact = struct {
     export_assignment_node: u32,
     property_node: ?u32 = null,
     rhs_symbol: ?u32 = null,
+    helper_symbol: ?u32 = null,
+    target_symbol: ?u32 = null,
     kind: Kind = .assignment,
     is_safe_to_prune: bool = true,
 };
@@ -207,6 +209,8 @@ const CjsExportCandidate = struct {
     export_assignment_node: u32,
     rhs_node: NodeIndex,
     property_node: ?u32 = null,
+    helper_node: NodeIndex = .none,
+    target_node: NodeIndex = .none,
     kind: CjsExportFact.Kind = .assignment,
 };
 
@@ -344,6 +348,24 @@ fn cjsExportCandidateForStmt(alloc: std.mem.Allocator, ast: *const Ast, stmt_nod
     if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return null;
     const expr = ast.nodes.items[@intFromEnum(expr_idx)];
     if (expr.tag != .assignment_expression) return null;
+
+    if (isModuleExportsLhs(ast, expr.data.binary.left)) {
+        const rhs_idx = expr.data.binary.right;
+        if (!rhs_idx.isNone() and @intFromEnum(rhs_idx) < ast.nodes.items.len) {
+            const rhs = ast.nodes.items[@intFromEnum(rhs_idx)];
+            // `module.exports = { ... }` has its own object-shape extractor so named
+            // imports can prune individual properties. Treating the whole object as
+            // default here would hide that more precise path.
+            if (rhs.tag != .object_expression) {
+                return .{
+                    .export_name = try alloc.dupe(u8, "default"),
+                    .export_assignment_node = @intFromEnum(expr_idx),
+                    .rhs_node = rhs_idx,
+                };
+            }
+        }
+    }
+
     const prop_idx = cjsExportNamePropFromLhs(ast, expr.data.binary.left) orelse return null;
     const export_name = (try ast.staticKeyName(alloc, prop_idx)) orelse return null;
     return .{
@@ -414,6 +436,11 @@ fn isBooleanLiteral(ast: *const Ast, idx: NodeIndex, expected: []const u8) bool 
 fn isIdentifierReference(ast: *const Ast, idx: NodeIndex) bool {
     if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) return false;
     return ast.nodes.items[@intFromEnum(idx)].tag == .identifier_reference;
+}
+
+fn identifierReferenceText(ast: *const Ast, idx: NodeIndex) ?[]const u8 {
+    if (!isIdentifierReference(ast, idx)) return null;
+    return ast.getText(ast.nodes.items[@intFromEnum(idx)].span);
 }
 
 /// defineProperty descriptor 의 `value` 위치에서 의존성 시드로 쓸 노드를 반환.
@@ -605,6 +632,133 @@ fn cjsDefinePropertyExportCandidateForStmt(
         .rhs_node = descriptor_export.rhs_node,
         .kind = descriptor_export.kind,
     };
+}
+
+fn cjsModuleExportsAssignedObjectName(ast: *const Ast, stmt_node: Node) ?[]const u8 {
+    if (stmt_node.tag != .expression_statement) return null;
+    const expr_idx = stmt_node.data.unary.operand;
+    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return null;
+    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
+    if (expr.tag != .assignment_expression) return null;
+    if (!isModuleExportsLhs(ast, expr.data.binary.left)) return null;
+
+    const rhs_idx = expr.data.binary.right;
+    if (identifierReferenceText(ast, rhs_idx)) |name| return name;
+    if (rhs_idx.isNone() or @intFromEnum(rhs_idx) >= ast.nodes.items.len) return null;
+    const rhs = ast.nodes.items[@intFromEnum(rhs_idx)];
+    if (rhs.tag != .call_expression) return null;
+    if (!ast.hasExtra(rhs.data.extra, 2)) return null;
+    const callee_idx = ast.readExtraNode(rhs.data.extra, 0);
+    if (!std.mem.eql(u8, identifierReferenceText(ast, callee_idx) orelse return null, "__toCommonJS")) return null;
+    const args_start = ast.readExtra(rhs.data.extra, 1);
+    const args_len = ast.readExtra(rhs.data.extra, 2);
+    if (args_len != 1 or args_start + args_len > ast.extra_data.items.len) return null;
+    const arg_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start]);
+    return identifierReferenceText(ast, arg_idx);
+}
+
+fn collectCjsExportObjectNames(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    stmt_raw_indices: []const u32,
+) !std.StringHashMapUnmanaged(void) {
+    var names: std.StringHashMapUnmanaged(void) = .{};
+    errdefer names.deinit(allocator);
+
+    for (stmt_raw_indices) |raw_idx| {
+        const idx: NodeIndex = @enumFromInt(raw_idx);
+        if (idx.isNone() or @intFromEnum(idx) >= ast.nodes.items.len) continue;
+        const stmt_node = ast.nodes.items[@intFromEnum(idx)];
+        const name = cjsModuleExportsAssignedObjectName(ast, stmt_node) orelse continue;
+        try names.put(allocator, name, {});
+    }
+
+    return names;
+}
+
+fn isCjsExportHelperTarget(
+    ast: *const Ast,
+    target_idx: NodeIndex,
+    export_object_names: ?*const std.StringHashMapUnmanaged(void),
+) bool {
+    if (isCjsExportObjectExpr(ast, target_idx)) return true;
+    const name = identifierReferenceText(ast, target_idx) orelse return false;
+    const names = export_object_names orelse return false;
+    return names.contains(name);
+}
+
+fn collectCjsExportHelperCandidates(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    stmt_node: Node,
+    export_object_names: ?*const std.StringHashMapUnmanaged(void),
+) !?[]CjsExportCandidate {
+    if (stmt_node.tag != .expression_statement) return null;
+    const expr_idx = stmt_node.data.unary.operand;
+    if (expr_idx.isNone() or @intFromEnum(expr_idx) >= ast.nodes.items.len) return null;
+    const expr = ast.nodes.items[@intFromEnum(expr_idx)];
+    if (expr.tag != .call_expression) return null;
+
+    const e = expr.data.extra;
+    if (!ast.hasExtra(e, 2)) return null;
+    const callee_idx = ast.readExtraNode(e, 0);
+    if (!std.mem.eql(u8, identifierReferenceText(ast, callee_idx) orelse return null, "__export")) return null;
+
+    const args_start = ast.readExtra(e, 1);
+    const args_len = ast.readExtra(e, 2);
+    if (args_len != 2 or args_start + args_len > ast.extra_data.items.len) return null;
+
+    const target_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start]);
+    const defs_idx: NodeIndex = @enumFromInt(ast.extra_data.items[args_start + 1]);
+    if (!isCjsExportHelperTarget(ast, target_idx, export_object_names)) return null;
+    if (defs_idx.isNone() or @intFromEnum(defs_idx) >= ast.nodes.items.len) return null;
+    const defs = ast.nodes.items[@intFromEnum(defs_idx)];
+    if (defs.tag != .object_expression) return null;
+
+    const list = defs.data.list;
+    if (list.start + list.len > ast.extra_data.items.len) return null;
+    const indices = ast.extra_data.items[list.start .. list.start + list.len];
+    if (indices.len == 0) return null;
+
+    var out: std.ArrayListUnmanaged(CjsExportCandidate) = .empty;
+    var success = false;
+    defer if (!success) {
+        for (out.items) |c| allocator.free(c.export_name);
+        out.deinit(allocator);
+    };
+    var seen: std.StringHashMapUnmanaged(void) = .{};
+    defer seen.deinit(allocator);
+
+    for (indices) |raw_prop| {
+        const prop_idx: NodeIndex = @enumFromInt(raw_prop);
+        if (prop_idx.isNone() or @intFromEnum(prop_idx) >= ast.nodes.items.len) return null;
+        const prop = ast.nodes.items[@intFromEnum(prop_idx)];
+        if (prop.tag != .object_property) return null;
+
+        const name = (try ast.staticKeyName(allocator, prop.data.binary.left)) orelse return null;
+        var name_transferred = false;
+        defer if (!name_transferred) allocator.free(name);
+
+        if (std.mem.eql(u8, name, "__proto__")) return null;
+        const entry = try seen.getOrPut(allocator, name);
+        if (entry.found_existing) return null;
+
+        const returned = zeroParamFunctionReturnIdentifier(ast, Ast.objectPropertyValue(prop)) orelse return null;
+        try out.append(allocator, .{
+            .export_name = name,
+            .export_assignment_node = @intFromEnum(expr_idx),
+            .property_node = @intFromEnum(prop_idx),
+            .rhs_node = returned,
+            .helper_node = callee_idx,
+            .target_node = target_idx,
+            .kind = .define_property_getter,
+        });
+        name_transferred = true;
+    }
+
+    const slice = try out.toOwnedSlice(allocator);
+    success = true;
+    return slice;
 }
 
 fn isSafeEsModuleDefinePropertyDescriptor(ast: *const Ast, descriptor_idx: NodeIndex) bool {
@@ -839,6 +993,8 @@ fn collectAndAppendCjsObjectFacts(
             .export_assignment_node = candidate.export_assignment_node,
             .property_node = candidate.property_node,
             .rhs_symbol = rhsSymbolFor(symbol_ids, candidate.rhs_node),
+            .helper_symbol = rhsSymbolFor(symbol_ids, candidate.helper_node),
+            .target_symbol = rhsSymbolFor(symbol_ids, candidate.target_node),
             .kind = candidate.kind,
             .is_safe_to_prune = true,
         });
@@ -866,10 +1022,45 @@ fn appendCjsDefinePropertyFact(
         .export_assignment_node = candidate.export_assignment_node,
         .property_node = candidate.property_node,
         .rhs_symbol = rhsSymbolFor(symbol_ids, candidate.rhs_node),
+        .helper_symbol = rhsSymbolFor(symbol_ids, candidate.helper_node),
+        .target_symbol = rhsSymbolFor(symbol_ids, candidate.target_node),
         .kind = candidate.kind,
         .is_safe_to_prune = true,
     });
     transferred = true;
+    return true;
+}
+
+fn appendCjsExportHelperFacts(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    node: Node,
+    stmt_i: u32,
+    export_object_names: ?*const std.StringHashMapUnmanaged(void),
+    facts: *std.ArrayListUnmanaged(CjsExportFact),
+    symbol_ids: ?[]const ?u32,
+) !bool {
+    const candidates = (try collectCjsExportHelperCandidates(allocator, ast, node, export_object_names)) orelse return false;
+    defer allocator.free(candidates);
+
+    var transferred: usize = 0;
+    errdefer for (candidates[transferred..]) |c| allocator.free(c.export_name);
+
+    try facts.ensureUnusedCapacity(allocator, candidates.len);
+    for (candidates) |candidate| {
+        facts.appendAssumeCapacity(.{
+            .export_name = candidate.export_name,
+            .statement_index = stmt_i,
+            .export_assignment_node = candidate.export_assignment_node,
+            .property_node = candidate.property_node,
+            .rhs_symbol = rhsSymbolFor(symbol_ids, candidate.rhs_node),
+            .helper_symbol = rhsSymbolFor(symbol_ids, candidate.helper_node),
+            .target_symbol = rhsSymbolFor(symbol_ids, candidate.target_node),
+            .kind = candidate.kind,
+            .is_safe_to_prune = true,
+        });
+        transferred += 1;
+    }
     return true;
 }
 
@@ -1223,6 +1414,7 @@ fn buildStmtInfoSlot(
     stmt_i: u32,
     collect_cjs_exports: bool,
     unresolved_globals: ?*const purity.GlobalRefSet,
+    cjs_export_object_names: ?*const std.StringHashMapUnmanaged(void),
     cjs_export_facts_buf: *std.ArrayListUnmanaged(CjsExportFact),
     symbol_ids: ?[]const ?u32,
 ) !StmtInfo {
@@ -1252,6 +1444,8 @@ fn buildStmtInfoSlot(
             .export_assignment_node = candidate.export_assignment_node,
             .property_node = candidate.property_node,
             .rhs_symbol = rhsSymbolFor(symbol_ids, candidate.rhs_node),
+            .helper_symbol = rhsSymbolFor(symbol_ids, candidate.helper_node),
+            .target_symbol = rhsSymbolFor(symbol_ids, candidate.target_node),
             .kind = candidate.kind,
             .is_safe_to_prune = !cjsExportAssignmentHasSideEffects(ast, candidate, unresolved_globals),
         });
@@ -1259,6 +1453,7 @@ fn buildStmtInfoSlot(
     } else if (collect_cjs_exports) {
         cjs_shape_extracted =
             try appendCjsDefinePropertyFact(allocator, ast, node, stmt_i, unresolved_globals, cjs_export_facts_buf, symbol_ids) or
+            try appendCjsExportHelperFacts(allocator, ast, node, stmt_i, cjs_export_object_names, cjs_export_facts_buf, symbol_ids) or
             try isSafeCjsEsModuleMarkerStmt(allocator, ast, node, unresolved_globals) or
             try collectAndAppendCjsObjectFacts(allocator, ast, node, stmt_i, unresolved_globals, cjs_export_facts_buf, symbol_ids);
     }
@@ -1325,6 +1520,11 @@ pub fn buildFromSemantic(
 
     var cjs_export_facts_buf: std.ArrayListUnmanaged(CjsExportFact) = .empty;
     errdefer deinitCjsExportFactsBuf(allocator, &cjs_export_facts_buf);
+    var cjs_export_object_names = if (collect_cjs_exports)
+        try collectCjsExportObjectNames(allocator, ast, stmt_raw_indices)
+    else
+        std.StringHashMapUnmanaged(void){};
+    defer cjs_export_object_names.deinit(allocator);
 
     // 게이트 통과한 member-augment 문장: object identifier NodeIndex → stmt_idx.
     // references 패스에서 이 노드의 symbol_id 를 해석해 writer bucket 에 귀속.
@@ -1342,6 +1542,7 @@ pub fn buildFromSemantic(
             @intCast(stmt_i),
             collect_cjs_exports,
             unresolved_globals,
+            if (collect_cjs_exports) &cjs_export_object_names else null,
             &cjs_export_facts_buf,
             null,
         );
@@ -1554,6 +1755,11 @@ pub fn build(
 
     var cjs_export_facts_buf: std.ArrayListUnmanaged(CjsExportFact) = .empty;
     errdefer deinitCjsExportFactsBuf(allocator, &cjs_export_facts_buf);
+    var cjs_export_object_names = if (collect_cjs_exports)
+        try collectCjsExportObjectNames(allocator, ast, stmt_raw_indices)
+    else
+        std.StringHashMapUnmanaged(void){};
+    defer cjs_export_object_names.deinit(allocator);
 
     // Phase 1: statement span 배열 + side-effects 판정 + 초기화
     var stmt_spans = try allocator.alloc(Span, stmt_count);
@@ -1575,6 +1781,7 @@ pub fn build(
             @intCast(stmt_i),
             collect_cjs_exports,
             unresolved_globals,
+            if (collect_cjs_exports) &cjs_export_object_names else null,
             &cjs_export_facts_buf,
             symbol_ids,
         );

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -912,8 +912,25 @@ pub const TreeShaker = struct {
                 //   (1) entry: 번들 외부 사용자가 접근 가능 — 모든 export live.
                 //   (2) ALL_EXPORTS_SENTINEL 마킹된 모듈: dynamic import target(#1260) 또는 export * 전파 대상.
                 // non-entry·sentinel 없음: followImport만으로 도달해야 가짜 used 확산을 막는다.
-                const is_bfs_seed = self.entry_set.isSet(i) or self.isExportUsed(@intCast(i), ALL_EXPORTS_SENTINEL);
+                const has_specific_cjs_exports = m.wrap_kind == .cjs and self.hasAnySpecificUsedExport(@intCast(i));
+                const is_bfs_seed = self.entry_set.isSet(i) or
+                    self.isExportUsed(@intCast(i), ALL_EXPORTS_SENTINEL) or
+                    has_specific_cjs_exports;
                 if (is_bfs_seed) {
+                    if (m.wrap_kind == .cjs) {
+                        const has_specific_exports = has_specific_cjs_exports;
+                        if (self.entry_set.isSet(i) or !has_specific_exports) {
+                            try self.seedAllCjsExportFacts(@intCast(i), infos, &queue, reachable_stmts);
+                        } else {
+                            var names = try self.collectDirectUsedExportNames(@intCast(i));
+                            defer names.deinit(self.allocator);
+                            for (names.items) |name| {
+                                try self.seedCjsExportOrAll(@intCast(i), name, &queue, module_stmt_infos, reachable_stmts);
+                            }
+                        }
+                        continue;
+                    }
+
                     const sem = m.semantic orelse continue;
                     if (sem.scope_maps.len == 0) continue;
                     for (m.export_bindings) |eb| {
@@ -1175,17 +1192,19 @@ pub const TreeShaker = struct {
 
         if (target_module_for_import.wrap_kind == .cjs and ib.kind == .default) {
             if (ib.namespace_used_properties) |props| {
-                for (props, 0..) |prop_name, pi| {
-                    if (dispatch_stmt) |ds| gate: {
-                        const prop_stmts = ib.namespace_used_property_stmts orelse break :gate;
-                        if (pi >= prop_stmts.len) break :gate;
-                        if (!containsU32(prop_stmts[pi], ds)) continue;
+                if (props.len > 0) {
+                    for (props, 0..) |prop_name, pi| {
+                        if (dispatch_stmt) |ds| gate: {
+                            const prop_stmts = ib.namespace_used_property_stmts orelse break :gate;
+                            if (pi >= prop_stmts.len) break :gate;
+                            if (!containsU32(prop_stmts[pi], ds)) continue;
+                        }
+                        try self.seedCjsExportOrAll(@intCast(target), prop_name, queue, module_stmt_infos, reachable_stmts);
                     }
-                    try self.seedCjsExportOrAll(@intCast(target), prop_name, queue, module_stmt_infos, reachable_stmts);
+                    return;
                 }
-                return;
             }
-            try self.markAndSeedAllStmts(@intCast(target), queue, module_stmt_infos, reachable_stmts);
+            try self.seedCjsExportOrAll(@intCast(target), "default", queue, module_stmt_infos, reachable_stmts);
             return;
         }
 
@@ -1545,6 +1564,25 @@ pub const TreeShaker = struct {
         return found;
     }
 
+    fn seedAllCjsExportFacts(
+        self: *TreeShaker,
+        mod_idx: u32,
+        infos: StmtInfos,
+        queue: *std.ArrayListUnmanaged(BfsItem),
+        reachable_stmts: []?std.DynamicBitSet,
+    ) std.mem.Allocator.Error!void {
+        for (infos.cjs_export_facts) |fact| {
+            if (!fact.is_safe_to_prune and fact.statement_index < infos.stmts.len) {
+                if (reachable_stmts[mod_idx] == null) {
+                    reachable_stmts[mod_idx] = try std.DynamicBitSet.initEmpty(self.allocator, infos.stmts.len);
+                }
+                try self.enqueue(mod_idx, fact.statement_index, reachable_stmts, queue);
+                continue;
+            }
+            try self.seedCjsExportFact(mod_idx, infos, fact, queue, reachable_stmts);
+        }
+    }
+
     fn seedCjsExportFact(
         self: *TreeShaker,
         mod_idx: u32,
@@ -1566,11 +1604,24 @@ pub const TreeShaker = struct {
             reachable_stmts[mod_idx].?.set(fact.statement_index);
         }
 
-        const rhs_sym = fact.rhs_symbol orelse return;
-        if (infos.declaredStmtBySymbol(rhs_sym)) |dep_stmt| {
+        try self.seedCjsExportFactSymbol(mod_idx, infos, fact.helper_symbol, queue, reachable_stmts);
+        try self.seedCjsExportFactSymbol(mod_idx, infos, fact.target_symbol, queue, reachable_stmts);
+        try self.seedCjsExportFactSymbol(mod_idx, infos, fact.rhs_symbol, queue, reachable_stmts);
+    }
+
+    fn seedCjsExportFactSymbol(
+        self: *TreeShaker,
+        mod_idx: u32,
+        infos: StmtInfos,
+        maybe_sym: ?u32,
+        queue: *std.ArrayListUnmanaged(BfsItem),
+        reachable_stmts: []?std.DynamicBitSet,
+    ) std.mem.Allocator.Error!void {
+        const sym = maybe_sym orelse return;
+        if (infos.declaredStmtBySymbol(sym)) |dep_stmt| {
             try self.enqueue(mod_idx, dep_stmt, reachable_stmts, queue);
         }
-        for (infos.writerStmts(rhs_sym)) |writer_stmt| {
+        for (infos.writerStmts(sym)) |writer_stmt| {
             try self.enqueue(mod_idx, writer_stmt, reachable_stmts, queue);
         }
     }
@@ -1606,8 +1657,12 @@ pub const TreeShaker = struct {
                     try self.markAndSeedAllStmts(@intCast(target), queue, module_stmt_infos, reachable_stmts);
                 } else if (ib.kind == .default) {
                     if (ib.namespace_used_properties) |props| {
-                        for (props) |prop_name| {
-                            try self.seedCjsExportOrAll(@intCast(target), prop_name, queue, module_stmt_infos, reachable_stmts);
+                        if (props.len > 0) {
+                            for (props) |prop_name| {
+                                try self.seedCjsExportOrAll(@intCast(target), prop_name, queue, module_stmt_infos, reachable_stmts);
+                            }
+                        } else {
+                            try self.seedCjsExportOrAll(@intCast(target), "default", queue, module_stmt_infos, reachable_stmts);
                         }
                     } else {
                         try self.markAndSeedAllStmts(@intCast(target), queue, module_stmt_infos, reachable_stmts);
@@ -1779,6 +1834,12 @@ pub const TreeShaker = struct {
         try self.markAllExportsUsed(mod_idx);
         self.included.set(mod_idx);
         try self.seedAllStmts(mod_idx, queue, module_stmt_infos, reachable_stmts);
+        const module = self.getModule(mod_idx) orelse return;
+        if (module.wrap_kind != .cjs) return;
+        const infos = if (mod_idx < module_stmt_infos.len) module_stmt_infos[mod_idx] else null;
+        if (infos) |target_infos| {
+            try self.seedAllCjsExportFacts(mod_idx, target_infos, queue, reachable_stmts);
+        }
     }
 
     fn seedReExportSourcesForRequireNamespace(
@@ -1803,6 +1864,20 @@ pub const TreeShaker = struct {
             } else {
                 try self.seedExport(src, m.exportBindingLocalName(eb), queue, module_stmt_infos, reachable_stmts);
             }
+        }
+
+        // `require("./facade").name` observes the facade namespace at runtime. If
+        // the facade was generated from `export { name } from "./cjs"`, the
+        // re-export source must stay namespace-live too. Some CJS re-export
+        // facades lower to a getter over `require(source).name`, so keeping only
+        // the facade body can leave the source's `exports.name = ...` assignment
+        // shaken out and make the getter return undefined.
+        for (m.import_records) |rec| {
+            if (rec.kind != .re_export) continue;
+            if (rec.resolved.isNone()) continue;
+            const src = @intFromEnum(rec.resolved);
+            if (self.graph.getModule(rec.resolved) == null) continue;
+            try self.markAndSeedAllStmts(@intCast(src), queue, module_stmt_infos, reachable_stmts);
         }
     }
 
@@ -1905,16 +1980,35 @@ pub const TreeShaker = struct {
                 const src_idx = m.import_records[rec_idx].resolved;
                 const src_module = self.graph.getModule(src_idx) orelse continue;
                 const src = @intFromEnum(src_idx);
+                const all_exports_used = self.isExportUsed(@intCast(i), ALL_EXPORTS_SENTINEL);
                 // 평가 부수효과가 없는 source 는 사용된 export 가 있을 때만 끌어옴.
                 // `export *` 의 named import 는 seedExport 가 canonical source 로 직접 시드하므로,
                 // 전체 namespace 가 사용되지 않는 한 unrelated star source 까지 fan out 하지 않는다.
                 if (check_used and !module_effects.hasEvaluationEffect(src_module)) {
                     const probe_name = if (eb.kind == .re_export_star) ALL_EXPORTS_SENTINEL else eb.exported_name;
-                    if (!self.isExportUsed(@intCast(i), probe_name)) continue;
+                    if (!all_exports_used and !self.isExportUsed(@intCast(i), probe_name)) continue;
                 }
                 if (!self.included.isSet(src)) {
                     self.included.set(src);
                     changed = true;
+                }
+                if (all_exports_used) {
+                    if (src_module.wrap_kind == .cjs and eb.kind == .re_export) {
+                        try self.markExportUsed(@intCast(src), m.exportBindingLocalName(eb));
+                    } else if (src_module.wrap_kind == .cjs or eb.kind.isReExportAll()) {
+                        try self.markAllExportsUsed(@intCast(src));
+                    } else {
+                        try self.markExportUsed(@intCast(src), m.exportBindingLocalName(eb));
+                    }
+                }
+                // A named re-export from CJS is still observed through the CJS
+                // namespace at runtime. If an ESM facade such as
+                // `export { URLSearchParams } from "cjs"` is later read via
+                // `require("./facade").URLSearchParams`, keeping only the
+                // facade getter can leave the source-side
+                // `exports.URLSearchParams = ...` assignment shaken out.
+                if (src_module.wrap_kind == .cjs and eb.kind == .re_export) {
+                    try self.markExportUsed(@intCast(src), m.exportBindingLocalName(eb));
                 }
                 // wrapper-barrel intermediate 보존: chain 끝 canonical 까지의 intermediate
                 // (lodash.default.js) 가 prune phase 에서 hasAnyUsedExport=false 로 unset
@@ -2045,8 +2139,12 @@ pub const TreeShaker = struct {
             if (target_module.wrap_kind == .cjs) {
                 if (ib.kind == .default) {
                     if (ib.namespace_used_properties) |props| {
-                        for (props) |prop_name| {
-                            try self.markExportUsed(@intCast(target_mod), prop_name);
+                        if (props.len > 0) {
+                            for (props) |prop_name| {
+                                try self.markExportUsed(@intCast(target_mod), prop_name);
+                            }
+                        } else {
+                            try self.markExportUsed(@intCast(target_mod), "default");
                         }
                     } else {
                         try self.markAllExportsUsed(@intCast(target_mod));
@@ -2192,6 +2290,20 @@ pub const TreeShaker = struct {
     fn hasAnyUsedExportDirect(self: *const TreeShaker, module_index: u32) bool {
         if (module_index < self.has_direct_used_export.len) {
             return self.has_direct_used_export[module_index];
+        }
+        return false;
+    }
+
+    fn hasAnySpecificUsedExport(self: *const TreeShaker, module_index: u32) bool {
+        var it = self.used_exports.keyIterator();
+        while (it.next()) |key_ptr| {
+            const key = key_ptr.*;
+            if (key.len < 5 or key[4] != 0) continue;
+            var key_module: u32 = undefined;
+            @memcpy(std.mem.asBytes(&key_module), key[0..4]);
+            if (key_module != module_index) continue;
+            const name = key[5..];
+            if (!std.mem.eql(u8, name, ALL_EXPORTS_SENTINEL)) return true;
         }
         return false;
     }

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -71,6 +71,12 @@ pub const TreeShaker = struct {
     opaque_visited: ?std.DynamicBitSet = null,
     /// 모듈별 used export 존재 여부 (hasAnyUsedExportDirect 최적화: O(1) 조회).
     has_direct_used_export: []bool = &.{},
+    /// 모듈별 sentinel 이 아닌 specific named export 가 markExportUsed 된 적이 있는지.
+    /// `hasAnySpecificUsedExport` 를 O(1) 로 조회. `has_direct_used_export` 와 분리한
+    /// 이유는 `markAllExportsUsed` 가 내부적으로 `markExportUsed(ALL_EXPORTS_SENTINEL)`
+    /// 를 호출해 sentinel-only 마킹된 모듈도 `has_direct_used_export = true` 가 되기
+    /// 때문이다.
+    has_specific_used_export: []bool = &.{},
     /// prebuilt StmtInfo를 사용하는 모듈 마스크.
     /// prebuilt는 parse_arena가 소유하므로 deinit에서 해제하지 않는다.
     prebuilt_mask: ?std.DynamicBitSet = null,
@@ -196,6 +202,9 @@ pub const TreeShaker = struct {
         }
         if (self.has_direct_used_export.len > 0) {
             self.allocator.free(self.has_direct_used_export);
+        }
+        if (self.has_specific_used_export.len > 0) {
+            self.allocator.free(self.has_specific_used_export);
         }
         self.numeric_dfs_stack.deinit(self.allocator);
         if (self.materialize_scratch) |*s| s.deinit();
@@ -422,10 +431,13 @@ pub const TreeShaker = struct {
                 }
             }
 
-            // has_direct_used_export 배열 초기화 (hasAnyUsedExportDirect O(1) 조회용)
+            // has_direct_used_export / has_specific_used_export 배열 초기화 (O(1) 조회용)
             const has_due = try self.allocator.alloc(bool, mod_count);
             @memset(has_due, false);
             self.has_direct_used_export = has_due;
+            const has_specific = try self.allocator.alloc(bool, mod_count);
+            @memset(has_specific, false);
+            self.has_specific_used_export = has_specific;
 
             // entry / context_dep 모듈의 모든 export를 사용으로 마킹 — runtime require 로
             // 접근하는 모듈은 어떤 export 가 쓰일지 정적으로 알 수 없음 (dynamic import 와 유사).
@@ -918,8 +930,7 @@ pub const TreeShaker = struct {
                     has_specific_cjs_exports;
                 if (is_bfs_seed) {
                     if (m.wrap_kind == .cjs) {
-                        const has_specific_exports = has_specific_cjs_exports;
-                        if (self.entry_set.isSet(i) or !has_specific_exports) {
+                        if (self.entry_set.isSet(i) or !has_specific_cjs_exports) {
                             try self.seedAllCjsExportFacts(@intCast(i), infos, &queue, reachable_stmts);
                         } else {
                             var names = try self.collectDirectUsedExportNames(@intCast(i));
@@ -1992,23 +2003,21 @@ pub const TreeShaker = struct {
                     self.included.set(src);
                     changed = true;
                 }
-                if (all_exports_used) {
-                    if (src_module.wrap_kind == .cjs and eb.kind == .re_export) {
-                        try self.markExportUsed(@intCast(src), m.exportBindingLocalName(eb));
-                    } else if (src_module.wrap_kind == .cjs or eb.kind.isReExportAll()) {
-                        try self.markAllExportsUsed(@intCast(src));
-                    } else {
-                        try self.markExportUsed(@intCast(src), m.exportBindingLocalName(eb));
-                    }
-                }
                 // A named re-export from CJS is still observed through the CJS
                 // namespace at runtime. If an ESM facade such as
                 // `export { URLSearchParams } from "cjs"` is later read via
                 // `require("./facade").URLSearchParams`, keeping only the
                 // facade getter can leave the source-side
                 // `exports.URLSearchParams = ...` assignment shaken out.
-                if (src_module.wrap_kind == .cjs and eb.kind == .re_export) {
+                const cjs_named_reexport = src_module.wrap_kind == .cjs and eb.kind == .re_export;
+                if (cjs_named_reexport) {
                     try self.markExportUsed(@intCast(src), m.exportBindingLocalName(eb));
+                } else if (all_exports_used) {
+                    if (src_module.wrap_kind == .cjs or eb.kind.isReExportAll()) {
+                        try self.markAllExportsUsed(@intCast(src));
+                    } else {
+                        try self.markExportUsed(@intCast(src), m.exportBindingLocalName(eb));
+                    }
                 }
                 // wrapper-barrel intermediate 보존: chain 끝 canonical 까지의 intermediate
                 // (lodash.default.js) 가 prune phase 에서 hasAnyUsedExport=false 로 unset
@@ -2214,6 +2223,11 @@ pub const TreeShaker = struct {
         if (module_index < self.has_direct_used_export.len) {
             self.has_direct_used_export[module_index] = true;
         }
+        if (!std.mem.eql(u8, export_name, ALL_EXPORTS_SENTINEL) and
+            module_index < self.has_specific_used_export.len)
+        {
+            self.has_specific_used_export[module_index] = true;
+        }
     }
 
     fn applyNodeBufferCapabilityFacts(self: *TreeShaker) !void {
@@ -2295,15 +2309,8 @@ pub const TreeShaker = struct {
     }
 
     fn hasAnySpecificUsedExport(self: *const TreeShaker, module_index: u32) bool {
-        var it = self.used_exports.keyIterator();
-        while (it.next()) |key_ptr| {
-            const key = key_ptr.*;
-            if (key.len < 5 or key[4] != 0) continue;
-            var key_module: u32 = undefined;
-            @memcpy(std.mem.asBytes(&key_module), key[0..4]);
-            if (key_module != module_index) continue;
-            const name = key[5..];
-            if (!std.mem.eql(u8, name, ALL_EXPORTS_SENTINEL)) return true;
+        if (module_index < self.has_specific_used_export.len) {
+            return self.has_specific_used_export[module_index];
         }
         return false;
     }


### PR DESCRIPTION
## 요약

React Native 앱을 ZNTC release 번들로 실행할 때 발견된 런타임 회귀를 루트커즈 기준으로 수정했습니다.

이번 PR의 핵심은 다음 네 가지입니다.

- RN preset의 resolver 확장자 순서를 Metro의 `sourceExts` 순서와 맞췄습니다.
- CJS export fact 분석과 tree-shaking 전파를 보강해 release 번들에서 필요한 CJS export assignment가 제거되지 않게 했습니다.
- RN `.esm` wrapper / shared namespace / CJS helper 패턴의 실제 평가 순서와 live export 전파를 보강했습니다.
- RN CLI 호환 flag, 소스맵/diagnostic 출력, symlink resolver 동작을 함께 보정했습니다.

## 수정한 문제

### 1. RN resolver 확장자 순서가 Metro와 달라 잘못된 파일이 선택됨

기존 RN preset은 `.ts`, `.tsx`를 `.js`보다 먼저 탐색했습니다. Metro의 기본 `sourceExts`는 `js`, `jsx`, `json`, `ts`, `tsx` 순서라서, 같은 패키지에 `Draggable.js`와 `Draggable.tsx`가 같이 있을 때 ZNTC가 Metro와 다른 파일을 선택했습니다.

실제 증상은 `react-native-draggable`에서 `Draggable.tsx`가 선택되면서 React 19에서 function component `defaultProps`가 적용되지 않았고, `onDrag`가 `undefined`인 상태로 호출되어 장비 연결 화면에서 crash가 발생하는 형태였습니다.

수정 후에는 `sourceExts` 순서를 기준으로 `.<platform>.<ext>`, `.native.<ext>`, `.<ext>`를 생성합니다. 기본 순서는 Metro와 맞춰 `.js` 계열이 먼저 옵니다.

### 2. CJS named re-export가 ESM facade를 통해 require될 때 source export assignment가 제거됨

네트워크 실패 토스트의 직접 원인은 앱의 API 호출 자체가 아니라, `URLSearchParams` 전역이 `undefined`로 덮인 것이었습니다.

경로는 다음과 같습니다.

- `react-native-url-polyfill/auto`
- `setupURLPolyfill()`
- `polyfillGlobal('URLSearchParams', () => require('./js/URLSearchParams').URLSearchParams)`
- `./js/URLSearchParams`는 `whatwg-url-without-unicode`의 `URLSearchParams`를 re-export
- ZNTC release tree-shaking이 `whatwg-url-without-unicode/index.js`의 `exports.URLSearchParams = sharedGlobalObject.URLSearchParams`를 제거
- 결과적으로 polyfill이 RN이 세팅한 `global.URLSearchParams`를 `undefined`로 덮음
- axios `params instanceof URLSearchParams`에서 `right operand of 'instanceof' is not an object` 발생
- configuration 저장 saga가 catch로 들어가 네트워크 실패 토스트 표시

수정 후에는 CJS specific export가 live로 표시된 모듈도 BFS seed 대상에 포함하고, ESM facade가 CJS named re-export를 런타임 namespace로 노출하는 경우 source CJS의 해당 export fact를 보존합니다.

### 3. CJS export helper / default proxy / whole require 패턴 보강

Release tree-shaking에서 다음 패턴들이 실제 RN/라이브러리 코드와 맞지 않게 과하게 제거되는 문제가 있었습니다.

- `module.exports = __toCommonJS(exportsObject)` 뒤의 `__export(exportsObject, { name: () => local })`
- `module.exports = require('./target')` default proxy에서 실제 접근한 멤버만 전파하는 경로
- `require('./cjs')` 전체 namespace가 escape되는 경우의 member assignment 보존
- RN `.esm` wrapper가 re-export source를 실제 평가해야 하는 경우

StmtInfo에 CJS helper/target/rhs symbol을 더 보존하고, tree-shaker가 필요한 export fact만 시드하되 namespace 관찰 시에는 필요한 source를 놓치지 않도록 했습니다.

### 4. RN monorepo/pnpm symlink resolver 보정

`preserveSymlinks`를 켠 RN/pnpm 구조에서 module identity는 logical path로 유지해야 합니다. 다만 package-local sibling dependency fallback이 필요한 경우가 있어 `resolve_symlink_siblings`와의 조합을 정리했습니다.

이번 수정은 consuming app의 logical `node_modules` 탐색을 먼저 유지하고, `.pnpm/node_modules` virtual store 형태에서는 real resolve dir fallback을 허용하는 쪽입니다.

## 테스트

로컬에서 다음을 확인했습니다.

- `zig build test --summary failures`
- `bun test packages/react-native/src/preset.test.ts`
- `bun test ./packages/core/test/cli/react-native-bundle.ts`
- RN release 번들 생성
  - `node packages/core/bin/zntc.mjs --bundle index.js --platform=react-native --rn-platform ios ...`
- 생성 번들 확인
  - `react-native-draggable`가 `Draggable.js`로 선택됨
  - `whatwg-url-without-unicode/index.js`에 `exports.URLSearchParams = sharedGlobalObject.URLSearchParams` 보존됨
- iOS simulator release app에 ZNTC bundle 주입 후 실행
  - 앱 프로세스 실행 확인
  - 최근 로그에서 기존 원인인 `right operand of 'instanceof'`, `store configuration error`, `latestPayherePrinter`, `URLSearchParams` 관련 오류 미발생 확인

Hermes compile warning은 기존 RN/라이브러리 전역 경고이며, 이번 네트워크 실패 원인이던 `URLSearchParams` undefined와는 별개입니다.
