### PR TITLE
fix(mf): 발행 @zntc/core 가 zntc.config mf 를 native 로 전달 (#3318)

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -1280,6 +1280,10 @@ async function runBundle(opts, config) {
     // 누락 시 `zntc.config.json` 의 `compiler` 설정이 silently drop 돼 1st-party transform
     // (autoLabel 등) 이 활성화 안 됨.
     compiler: config?.compiler,
+    // PR-plumb (#3318): zntc.config 의 `mf`(Module Federation) 를 NAPI 로
+    // forward. 누락 시 `mf` 가 silently drop → 발행 패키지에서 MF 미동작
+    // (native CLI 만 zntc.config.json mf 를 직접 읽어 동작했던 갭).
+    mf: config?.mf,
   };
 
   const result = plugins.length > 0 ? await build(buildOpts) : buildSync(buildOpts);

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1991,6 +1991,16 @@ function prepareNapiOptions(options: BuildOptions): {
   if (options.manualChunks) {
     napiOptions._manualChunks = options.manualChunks;
   }
+  // PR-plumb (#3318): Module Federation. nested record(name/exposes/remotes/
+  // shared/shareScope/shareStrategy)를 NAPI 로 깊게 직렬화하는 대신 JSON
+  // string `mfRaw` 로 전달(transport 는 `tsconfigRaw` 와 동형 — JSON string
+  // over NAPI). Zig NAPI 는 native CLI(applyZntcConfigJson)와 **동일 단일
+  // 소스**(`mf_options.fromDto` + std.json `MfConfigDto`/`validateMf`)로
+  // 파싱 — silent drift 봉인.
+  delete napiOptions.mf;
+  if (options.mf) {
+    napiOptions.mfRaw = JSON.stringify(options.mf);
+  }
   // blockList: RegExp는 .source로 추출해 string[]으로 넘긴다 (NAPI는 string만).
   if (options.blockList) {
     napiOptions.blockList = options.blockList.map((p) => {

--- a/packages/core/src/napi/options.zig
+++ b/packages/core/src/napi/options.zig
@@ -254,6 +254,14 @@ pub fn freeOptionsTypedSlices(opts: *const BundleOptions) void {
     if (opts.fallback.len > 0) native_alloc.free(opts.fallback);
     if (opts.globals.len > 0) native_alloc.free(opts.globals);
     if (opts.loader_overrides.len > 0) native_alloc.free(opts.loader_overrides);
+    // PR-plumb (#3318): mf 있을 때만(비-MF 무영향). opts.external=combined
+    // (ext_c), opts.globals=combined(gl_c, 위 줄에서 free). exts/옛 entries_buf
+    // 는 owned_string_arrays/파싱블록이 별도 소유 → 여기서 안 건드림(이중
+    // 해제 없음). mfb 의 dup 문자열은 freeMfBundle 단일 소스(CLI 와 공유).
+    if (opts.mf) |mfb| {
+        native_alloc.free(opts.external); // combined 컨테이너(원소 borrow)
+        bundler_mod.mf_options.freeMfBundle(native_alloc, mfb);
+    }
     if (opts.runtime_polyfills) |plan| {
         if (plan.candidates.len > 0) native_alloc.free(plan.candidates);
         if (plan.entry_modules.len > 0) native_alloc.free(plan.entry_modules);
@@ -697,30 +705,96 @@ pub fn parseBuildOptions(
         if (!trackArr(owned_string_arrays, arr)) return null;
     }
 
+    // RN block_list 머지를 여기서 선계산(hoist) — return literal 안에 두면
+    // mf 블록 *이후* fallible(concat OOM/trackArr) 가 생겨 mf 의 mfb/
+    // combined 가 null 경로에서 leak. 위로 끌어 mf 블록 이후 무-fallible
+    // 보장(merged 는 trackArr 로 owned_string_arrays 소유 → null 경로도 정리).
+    const block_list_final: []const []const u8 = blk: {
+        const user = block_list orelse &.{};
+        if (platform == .react_native) {
+            const merged = std.mem.concat(native_alloc, []const u8, &.{ bundler_mod.RN_DEFAULT_BLOCK_LIST, user }) catch return null;
+            if (!trackArr(owned_string_arrays, merged)) return null;
+            break :blk merged;
+        }
+        break :blk user;
+    };
+
+    // PR-plumb (#3318): Module Federation. `mfRaw`(index.ts =
+    // JSON.stringify(config.mf))를 JSON string 으로 받아 **CLI 와 동일
+    // 단일 소스**(`mf_options`; src/cli/options.zig applyZntcConfigJson 의
+    // arena+parseFromSliceLeaky 선례와 동형)로 변환·seam 유도. 배경/
+    // silent-drift 봉인 근거 = `mf_options.zig` 모듈 doc. mf 없으면 블록
+    // 미진입 → external/globals/.mf 기존 그대로(비-MF byte 동일 무회귀).
+    //
+    // 메모리: 이 파일은 `catch return null`(에러 아님)이라 errdefer 무효
+    // 이고, 호출자는 null 시 freeOptionsTypedSlices 를 안 거친다 → 블록
+    // 내 실패는 **명시 free 로 롤백**해야 leak 0. 성공 시 mfb/combined 는
+    // BundleOptions 로 넘어가 freeOptionsTypedSlices 가 mf-게이트로 해제
+    // (combined 컨테이너만; 원소 borrow=mfb/static, exts/옛globals 는 각
+    // owned_string_arrays/아래 free 소유). 블록 *이후* fallible 가 없도록
+    // RN block_list 머지는 위에서 const 로 선계산(literal 내 잔존 X).
+    const MfParsed = struct {
+        mfb: bundler_mod.mf_options.MfBundleConfig,
+        external: []const []const u8,
+        globals: []const bundler_mod.types.GlobalEntry,
+    };
+    const mf_parsed: ?MfParsed = blk: {
+        const raw = getObjectString(env, opts_obj, "mfRaw", native_alloc) orelse break :blk null;
+        defer native_alloc.free(raw);
+        var mf_arena = std.heap.ArenaAllocator.init(native_alloc);
+        defer mf_arena.deinit();
+        const dto = std.json.parseFromSliceLeaky(zntc_lib.transpile.MfConfigDto, mf_arena.allocator(), raw, .{ .ignore_unknown_fields = true }) catch return null;
+        zntc_lib.transpile.validateMf(&dto) catch return null;
+        // fromDto 실패 = 내부 errdefer 가 부분 mfb 해제(여기 롤백 불요).
+        const mfb = bundler_mod.mf_options.fromDto(native_alloc, &dto) catch return null;
+        // 이후 실패는 mfb(+필요 시 ext_c) 명시 free 후 return null.
+        const se = bundler_mod.mf_options.seamExternals(native_alloc, mfb) catch {
+            bundler_mod.mf_options.freeMfBundle(native_alloc, mfb);
+            return null;
+        };
+        defer native_alloc.free(se); // 컨테이너만(원소 borrow)
+        const sg = bundler_mod.mf_options.seamGlobals(native_alloc, mfb) catch {
+            bundler_mod.mf_options.freeMfBundle(native_alloc, mfb);
+            return null;
+        };
+        defer native_alloc.free(sg);
+        const base_ext: []const []const u8 = external orelse &.{};
+        const ext_c = std.mem.concat(native_alloc, []const u8, &.{ base_ext, se }) catch {
+            bundler_mod.mf_options.freeMfBundle(native_alloc, mfb);
+            return null;
+        };
+        const gl_c = std.mem.concat(native_alloc, bundler_mod.types.GlobalEntry, &.{ globals, sg }) catch {
+            native_alloc.free(ext_c);
+            bundler_mod.mf_options.freeMfBundle(native_alloc, mfb);
+            return null;
+        };
+        // 옛 globals(entries_buf)는 어디서도 추적 안 됨 → concat 이 복사한
+        // *후* 해제(cleanup 은 combined gl_c=opts.globals 만; exts 는
+        // owned_string_arrays 소유라 미해제).
+        if (globals.len > 0) native_alloc.free(globals);
+        break :blk .{ .mfb = mfb, .external = ext_c, .globals = gl_c };
+    };
+
     const minify = getObjectBool(env, opts_obj, "minify", false);
     return .{
         .entry_points = entries,
         .format = format,
         .platform = platform,
-        .external = external orelse &.{},
+        .external = if (mf_parsed) |m| m.external else (external orelse &.{}),
+        .mf = if (mf_parsed) |m| m.mfb else null,
         .debug = debug_categories orelse &.{},
         .define = define_entries,
         .alias = alias_entries,
         .ts_paths = ts_path_entries,
         .fallback = fallback_entries,
-        .block_list = blk: {
-            const user = block_list orelse &.{};
-            if (platform == .react_native) {
-                const merged = std.mem.concat(native_alloc, []const u8, &.{ bundler_mod.RN_DEFAULT_BLOCK_LIST, user }) catch return null;
-                if (!trackArr(owned_string_arrays, merged)) return null;
-                break :blk merged;
-            }
-            break :blk user;
-        },
+        .block_list = block_list_final,
         .minify_whitespace = if (minify) true else getObjectBool(env, opts_obj, "minifyWhitespace", false),
         .minify_identifiers = if (minify) true else getObjectBool(env, opts_obj, "minifyIdentifiers", false),
         .minify_syntax = if (minify) true else getObjectBool(env, opts_obj, "minifySyntax", false),
-        .code_splitting = getObjectBool(env, opts_obj, "splitting", false),
+        // mf.exposes(remote) → expose=lazy 청크라 splitting 강제(CLI
+        // options.zig 의 `if (mfb.exposes.len>0) opts.splitting=true` 미러).
+        .code_splitting = getObjectBool(env, opts_obj, "splitting", false) or
+            (if (mf_parsed) |m| m.mfb.exposes.len > 0 else false),
         .inline_dynamic_imports = getObjectBool(env, opts_obj, "inlineDynamicImports", false),
         .min_chunk_size = @as(usize, getObjectUint32(env, opts_obj, "minChunkSize", 0)),
         .sourcemap = .{
@@ -749,7 +823,7 @@ pub fn parseBuildOptions(
         .intro_js = intro_js,
         .outro_js = outro_js,
         .global_name = global_name,
-        .globals = globals,
+        .globals = if (mf_parsed) |m| m.globals else globals,
         .public_path = public_path orelse "",
         .entry_names = entry_names orelse "[name]",
         .chunk_names = chunk_names orelse "[name]-[hash]",

--- a/packages/core/src/typo-suggest.ts
+++ b/packages/core/src/typo-suggest.ts
@@ -191,6 +191,8 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'quotes',
   // ─── 1st-party transform 네임스페이스 (compiler.styledComponents/emotion 등) ───
   'compiler',
+  // ─── Module Federation ───
+  'mf',
   // ─── 기타 ───
   'flow',
   'plugins',

--- a/src/bundler/mf_options.zig
+++ b/src/bundler/mf_options.zig
@@ -1,0 +1,220 @@
+//! Module Federation 옵션 단일 소스. `MfConfigDto`(zntc.config 의 `mf`)
+//! → `MfBundleConfig` 변환 + shared/remotes seam 유도를 **CLI(`src/cli/
+//! options.zig`)와 NAPI(`packages/core/src/napi/options.zig`) 양쪽이 위임**
+//! 한다. 과거 mf 변환·seam 이 cli/options.zig 에만 있어 NAPI 가 silent
+//! 하게 갈라진 갭(발행 @zntc/core 에서 MF 미동작)을 구조적으로 봉인.
+//!
+//! seam* 는 **순수 유도 함수**(CliOptions/BundleOptions 비의존, 입력=mfb,
+//! 출력=owned 슬라이스). 적용은 호출자가(CLI=ArrayList append, NAPI=napi
+//! 배열 concat). 향후 seam 을 번들러 코어로 단일 적용점화(④)할 때 이
+//! 순수 함수를 그대로 재사용 — 무손실 디딤돌.
+
+const std = @import("std");
+const types = @import("types.zig");
+const federation = @import("federation.zig");
+const transpile = @import("../transpile.zig");
+
+pub const MfBundleConfig = types.MfBundleConfig;
+const KV = MfBundleConfig.KV;
+const SharedEntry = MfBundleConfig.SharedEntry;
+const GlobalEntry = types.GlobalEntry;
+const MfConfigDto = transpile.MfConfigDto;
+
+/// 스펙 런타임 pkg/글로벌 — federation.zig 단일 소스 재노출(emitHostInit
+/// 과 반드시 일치). 고정 상수라 alloc/소유 무관(static literal).
+pub const MF_RUNTIME_PKG = federation.MF_RUNTIME_PKG;
+pub const MF_RUNTIME_GLOBAL = federation.MF_RUNTIME_GLOBAL;
+
+/// 한 SharedEntry 의 owned 필드 해제. fromDto 정상경로와 부분실패
+/// errdefer 가 **동일 본문 공유**(필드 추가 시 한 곳만 — #4-0 share_scope
+/// 가 양쪽 동기화 부담 노출).
+pub fn freeSharedEntry(alloc: std.mem.Allocator, s: SharedEntry) void {
+    alloc.free(s.name);
+    if (s.required_version) |rv| alloc.free(rv);
+    if (s.global_seam.len > 0) alloc.free(s.global_seam);
+    alloc.free(s.share_scope); // name 과 동일 — 항상 owned(default 도 dup)
+}
+
+/// fromDto 가 allocator-dup 한 것 일괄 해제. 소유자(CLI=CliOptions.deinit,
+/// NAPI=cleanup)의 정상 종료와 fromDto 의 errdefer 가 **공유**(해제 모델
+/// 단일 소스 — 부분 실패/정상 종료 대칭). len>0 가드: exposes/remotes/
+/// shared default 는 static `&.{}`(오해제 방지). name 은 set 시 항상 dup,
+/// share_scope 는 항상 dup. **불변: mfb 는 fromDto 로만 생성**(외부 생성
+/// 시 share_scope 리터럴 free 위험).
+pub fn freeMfBundle(alloc: std.mem.Allocator, mfb: MfBundleConfig) void {
+    if (mfb.name) |n| alloc.free(n);
+    alloc.free(mfb.share_scope);
+    alloc.free(mfb.share_strategy);
+    for (mfb.exposes) |kv| {
+        alloc.free(kv.key);
+        alloc.free(kv.value);
+    }
+    if (mfb.exposes.len > 0) alloc.free(mfb.exposes);
+    for (mfb.remotes) |kv| {
+        alloc.free(kv.key);
+        alloc.free(kv.value);
+    }
+    if (mfb.remotes.len > 0) alloc.free(mfb.remotes);
+    for (mfb.shared) |s| freeSharedEntry(alloc, s);
+    if (mfb.shared.len > 0) alloc.free(mfb.shared);
+}
+
+/// JSON record(`std.json.ArrayHashMap`)→`[]KV` deep-dupe. exposes/remotes
+/// 공용(DRY). 중간 OOM 시 이미 dup 한 항목+list 해제(errdefer).
+fn dupeKvMap(allocator: std.mem.Allocator, map: anytype) ![]const KV {
+    const list = try allocator.alloc(KV, map.count());
+    var done: usize = 0;
+    errdefer {
+        for (list[0..done]) |kv| {
+            allocator.free(kv.key);
+            allocator.free(kv.value);
+        }
+        allocator.free(list);
+    }
+    var it = map.iterator();
+    while (it.next()) |kv| : (done += 1) list[done] = .{
+        .key = try allocator.dupe(u8, kv.key_ptr.*),
+        .value = try allocator.dupe(u8, kv.value_ptr.*),
+    };
+    return list;
+}
+
+/// `MfConfigDto`(arena, record) → `MfBundleConfig`(소유자 수명, 평탄화).
+/// 모든 문자열 `allocator.dupe`(외부 mf list / emit 이 build 끝까지 참조).
+/// 중간 OOM 시 freeMfBundle 로 일괄 해제(errdefer = 정상해제 대칭).
+pub fn fromDto(
+    allocator: std.mem.Allocator,
+    dto: *const MfConfigDto,
+) !MfBundleConfig {
+    var out: MfBundleConfig = .{};
+    errdefer freeMfBundle(allocator, out);
+    if (dto.name) |n| out.name = try allocator.dupe(u8, n);
+    // share_scope/share_strategy 는 항상 owned(default 도 dup) — freeMfBundle
+    // 무조건 free 와 대칭(리터럴/owned 혼재 회피).
+    out.share_scope = try allocator.dupe(u8, dto.shareScope orelse "default");
+    out.share_strategy = try allocator.dupe(u8, dto.shareStrategy orelse "version-first");
+
+    if (dto.exposes) |e| out.exposes = try dupeKvMap(allocator, &e.map);
+    if (dto.remotes) |r| out.remotes = try dupeKvMap(allocator, &r.map);
+    if (dto.shared) |sh| {
+        const list = try allocator.alloc(SharedEntry, sh.map.count());
+        errdefer allocator.free(list);
+        var it = sh.map.iterator();
+        var i: usize = 0;
+        // 부분 실패 시: 이미 채운 항목 해제(list[0..i] — 실패 iteration 의
+        // i 는 미증가라 제외, in-progress 는 아래 per-field errdefer 가).
+        errdefer for (list[0..i]) |s| freeSharedEntry(allocator, s);
+        while (it.next()) |kv| : (i += 1) {
+            const c = kv.value_ptr.*; // MfSharedDto
+            const nm = try allocator.dupe(u8, kv.key_ptr.*);
+            errdefer allocator.free(nm);
+            const rv = if (c.requiredVersion) |v| try allocator.dupe(u8, v) else null;
+            errdefer if (rv) |r| allocator.free(r);
+            // #4-0 해석 3-tier + 항상-owned 근거: SharedEntry.share_scope doc.
+            const sc = try allocator.dupe(u8, c.shareScope orelse dto.shareScope orelse "default");
+            errdefer allocator.free(sc);
+            list[i] = .{
+                .name = nm,
+                .singleton = c.singleton orelse false,
+                .required_version = rv,
+                .strict_version = c.strictVersion orelse false,
+                .eager = c.eager orelse false,
+                // 글로벌명 1회 생성·소유(seam·init borrow). 단일 규칙.
+                .global_seam = try federation.mfSharedGlobalName(allocator, nm),
+                .share_scope = sc,
+            };
+        }
+        out.shared = list;
+    }
+    return out;
+}
+
+/// shared/remotes → host 소비 seam 의 **external specifier** 집합(순수
+/// 유도). shared pkg + remote key + (remotes 있으면)`@module-federation/
+/// runtime`. 모든 원소 borrow(mfb 소유 / static MF_RUNTIME_PKG) — 컨테
+/// 이너만 owned(호출자 free). CLI applyMf*Seam·NAPI concat 단일 소스.
+pub fn seamExternals(allocator: std.mem.Allocator, mfb: MfBundleConfig) ![]const []const u8 {
+    const has_remotes = mfb.remotes.len > 0;
+    const n = mfb.shared.len + (if (has_remotes) mfb.remotes.len + 1 else 0);
+    const out = try allocator.alloc([]const u8, n);
+    var i: usize = 0;
+    for (mfb.shared) |s| {
+        out[i] = s.name; // borrow (mfb 소유)
+        i += 1;
+    }
+    if (has_remotes) {
+        for (mfb.remotes) |kv| {
+            out[i] = kv.key; // borrow
+            i += 1;
+        }
+        out[i] = MF_RUNTIME_PKG; // static
+        i += 1;
+    }
+    return out;
+}
+
+/// shared/remotes → host 소비 seam 의 **GlobalEntry** 집합(순수 유도).
+/// {shared.name → global_seam} + (remotes 있으면){MF_RUNTIME_PKG →
+/// MF_RUNTIME_GLOBAL}. specifier/global_name borrow(mfb 소유 / static).
+pub fn seamGlobals(allocator: std.mem.Allocator, mfb: MfBundleConfig) ![]const GlobalEntry {
+    const has_remotes = mfb.remotes.len > 0;
+    const n = mfb.shared.len + (if (has_remotes) @as(usize, 1) else 0);
+    const out = try allocator.alloc(GlobalEntry, n);
+    var i: usize = 0;
+    for (mfb.shared) |s| {
+        out[i] = .{ .specifier = s.name, .global_name = s.global_seam }; // borrow
+        i += 1;
+    }
+    if (has_remotes) {
+        out[i] = .{ .specifier = MF_RUNTIME_PKG, .global_name = MF_RUNTIME_GLOBAL };
+        i += 1;
+    }
+    return out;
+}
+
+test "fromDto: 기본 dup + free 대칭(누수 0)" {
+    const a = std.testing.allocator;
+    const P = struct {
+        fn p(alloc: std.mem.Allocator, s: []const u8) !std.json.Parsed(MfConfigDto) {
+            return std.json.parseFromSlice(MfConfigDto, alloc, s, .{ .ignore_unknown_fields = true });
+        }
+    };
+    const v = try P.p(a, "{\"name\":\"app\",\"exposes\":{\"./W\":\"./w.ts\"}," ++
+        "\"remotes\":{\"r\":\"r@u\"},\"shared\":{\"react\":{\"singleton\":true,\"shareScope\":\"ui\"}}}");
+    defer v.deinit();
+    const mfb = try fromDto(a, &v.value);
+    defer freeMfBundle(a, mfb); // testing.allocator = 누수/이중해제 탐지
+    try std.testing.expectEqualStrings("app", mfb.name.?);
+    try std.testing.expectEqual(@as(usize, 1), mfb.shared.len);
+    try std.testing.expectEqualStrings("ui", mfb.shared[0].share_scope);
+}
+
+test "seamExternals/seamGlobals: 순수 유도 형태 + 컨테이너만 owned" {
+    const a = std.testing.allocator;
+    const P = struct {
+        fn p(alloc: std.mem.Allocator, s: []const u8) !std.json.Parsed(MfConfigDto) {
+            return std.json.parseFromSlice(MfConfigDto, alloc, s, .{ .ignore_unknown_fields = true });
+        }
+    };
+    const v = try P.p(a, "{\"name\":\"app\",\"remotes\":{\"r\":\"r@u\"}," ++
+        "\"shared\":{\"react\":{\"singleton\":true}}}");
+    defer v.deinit();
+    const mfb = try fromDto(a, &v.value);
+    defer freeMfBundle(a, mfb);
+
+    const ext = try seamExternals(a, mfb);
+    defer a.free(ext); // 컨테이너만 — 원소는 mfb/static 소유(free 금지)
+    // shared react + remote r + MF_RUNTIME_PKG
+    try std.testing.expectEqual(@as(usize, 3), ext.len);
+    try std.testing.expectEqualStrings("react", ext[0]);
+    try std.testing.expectEqualStrings("r", ext[1]);
+    try std.testing.expectEqualStrings(MF_RUNTIME_PKG, ext[2]);
+
+    const gl = try seamGlobals(a, mfb);
+    defer a.free(gl);
+    // {react→seam} + {MF_RUNTIME_PKG→MF_RUNTIME_GLOBAL}
+    try std.testing.expectEqual(@as(usize, 2), gl.len);
+    try std.testing.expectEqualStrings("react", gl[0].specifier);
+    try std.testing.expectEqualStrings(MF_RUNTIME_PKG, gl[1].specifier);
+    try std.testing.expectEqualStrings(MF_RUNTIME_GLOBAL, gl[1].global_name);
+}

--- a/src/bundler/mod.zig
+++ b/src/bundler/mod.zig
@@ -70,6 +70,7 @@ pub const Bundler = bundler_core.Bundler;
 pub const BundleOptions = bundler_core.BundleOptions;
 pub const MfBundleConfig = types.MfBundleConfig; // #3318 P1-1
 pub const federation = @import("federation.zig"); // #3318 (mfSharedGlobalName 단일 소스)
+pub const mf_options = @import("mf_options.zig"); // #3318 mf DTO→Bundle + seam 단일 소스(CLI·NAPI 공용)
 pub const OutputExports = bundler_core.OutputExports;
 pub const BundleResult = bundler_core.BundleResult;
 pub const RN_BOOL_PRESET = bundler_core.RN_BOOL_PRESET;
@@ -124,6 +125,7 @@ test {
     _ = @import("chunk_test.zig");
     _ = @import("mf_integrity.zig"); // #3422 inline test (computeSri)
     _ = @import("mf_contract.zig"); // #3435 P3-0 inline test (parseContract)
+    _ = @import("mf_options.zig"); // #3318 inline test (fromDto/seam 단일소스)
     _ = @import("semver.zig"); // #3437 P3-2 inline test (satisfies)
     _ = @import("federation_emit.zig"); // #3436/#3437 P3-1/2 inline test (verifyHostContract)
     _ = @import("statement_shaker_test.zig");

--- a/src/cli/options.zig
+++ b/src/cli/options.zig
@@ -2,6 +2,10 @@ const std = @import("std");
 const lib = @import("zntc_lib");
 const BundleOptions = lib.bundler.BundleOptions;
 const usage_cli = @import("usage.zig");
+/// mf DTO→Bundle 변환 + seam 유도 단일 소스(CLI·NAPI 공용). 과거
+/// 이 로직이 cli/options.zig 에만 있어 NAPI 가 silent drift → 발행
+/// @zntc/core 에서 MF 미동작했던 갭을 구조적으로 봉인(#3318).
+const mf_options = lib.bundler.mf_options;
 
 /// CLI 인자를 파싱한 결과를 담는 구조체.
 /// main()에서 개별 변수 30여 개로 흩어져 있던 옵션을 하나로 모은다.
@@ -267,8 +271,9 @@ pub const CliOptions = struct {
         self.watch_include_list.deinit(alloc);
         self.watch_exclude_list.deinit(alloc);
         self.globals_list.deinit(alloc);
-        // #3318 mf: 해제는 freeMfBundle 단일 소스(mfBundleFromDto errdefer 와 공유).
-        if (self.mf) |mfb| freeMfBundle(alloc, mfb);
+        // #3318 mf: 해제는 mf_options.freeMfBundle 단일 소스(fromDto errdefer·
+        // NAPI cleanup 과 공유).
+        if (self.mf) |mfb| mf_options.freeMfBundle(alloc, mfb);
     }
 };
 
@@ -401,21 +406,23 @@ fn applyZntcConfigJson(opts: *CliOptions, allocator: std.mem.Allocator) !void {
     // P1-1+ 에서 NAPI mf 추출 + validateMf 연결 필수(silent drift 주의).
     if (dto.mf) |*mf| {
         try lib.transpile.validateMf(mf);
-        // P1-1 소비자(federation.markBoundary) 용 해석본을 allocator(=CliOptions
-        // 수명) 으로 deep-dupe. dto 는 arena(이 함수 종료 시 해제) 라 borrow 불가.
-        opts.mf = try mfBundleFromDto(allocator, mf);
-        // P1-2 (#3384): shared 글로벌 seam 자동 파생. mf.shared 패키지를
-        // external(번들 제외 — shared 는 shareScope 에서 옴) + GlobalEntry
-        // (IIFE/UMD/AMD 글로벌-파라미터 seam) 로 합친다. 스파이크 S2 가
-        // `--external pkg --globals pkg=__mf_shared_pkg` 로 검증한 기계를
-        // 그대로 재사용 — bundler/emitter/codegen 무변경.
+        // 해석본을 allocator(=CliOptions 수명) 으로 deep-dupe. dto 는 arena
+        // (이 함수 종료 시 해제) 라 borrow 불가. 변환·seam 은 mf_options
+        // 단일 소스(NAPI 와 공용 — silent drift 봉인).
+        opts.mf = try mf_options.fromDto(allocator, mf);
+        // P1-2/P1-6: shared/remotes 글로벌 seam 자동 파생. shared pkg +
+        // remote key + `@module-federation/runtime` 를 external(번들 제외 —
+        // shareScope/host 에서 옴) + GlobalEntry(IIFE/UMD/AMD 글로벌-파라
+        // 미터 seam) 로. seamExternals/seamGlobals 순수 유도 → opts list 에
+        // appendSlice(원소 borrow=opts.mf 소유, 컨테이너는 임시→free).
+        // 산출 순서·내용은 기존 applyMf*Seam 과 byte 동일(무회귀).
         if (opts.mf) |mfb| {
-            try applyMfSharedSeam(allocator, opts, mfb.shared);
-            // P1-6 (#3388): host = remotes 소비자. 원격 specifier(`remoteA`,
-            // `remoteA/...`)와 `@module-federation/runtime`(스펙 런타임, 자체
-            // 재구현 금지=D1) 를 external + 글로벌 seam(P1-2 와 동일 기계) 로.
-            // emitHostInit 이 `__mf_runtime.init/loadRemote` 로 배선.
-            if (mfb.remotes.len > 0) try applyMfRemotesSeam(allocator, opts, mfb.remotes);
+            const seam_ext = try mf_options.seamExternals(allocator, mfb);
+            defer allocator.free(seam_ext); // 컨테이너만(원소는 mfb/static)
+            try opts.external_list.appendSlice(allocator, seam_ext);
+            const seam_gl = try mf_options.seamGlobals(allocator, mfb);
+            defer allocator.free(seam_gl);
+            try opts.globals_list.appendSlice(allocator, seam_gl);
             // P1-3 (#3385): exposes 있는 mf = remote → container/exposes 는
             // reg_split 다중-청크(chunk.zig 가 expose→lazy 청크) 위에 얹으므로
             // splitting 필수(부트스트랩은 format=iife/umd/amd 필요 — 없으면
@@ -424,174 +431,6 @@ fn applyZntcConfigJson(opts: *CliOptions, allocator: std.mem.Allocator) !void {
             if (mfb.exposes.len > 0) opts.splitting = true;
         }
     }
-}
-
-/// mf.shared 패키지명 → 결정적 container-소유 글로벌 식별자.
-/// 비-식별자(`@ / - .`) → `_`. react→`__mf_shared_react`,
-/// react-dom→`__mf_shared_react_dom`, @scope/pkg→`__mf_shared__scope_pkg`.
-/// mf.shared → external_list + globals_list 파생.
-///
-/// **호출 순서 불변조건**: applyZntcConfigJson(config defaults)은 CLI arg
-/// 루프(`--globals`/`--external` 파싱)보다 *먼저* 돈다. 따라서 여기서 append
-/// 한 mf-파생 GlobalEntry 가 사용자 `--globals` 보다 list **앞**에 온다 →
-/// `GlobalEntry.lookup`(first-match) 이 mf-파생을 채택. shared 의 글로벌명은
-/// container 계약이라 mf-파생이 authoritative(RFC §8.1 #1) — 이 순서가 그
-/// 의미를 자연히 만든다(별도 prepend 불요).
-///
-/// 메모리: name·global_seam 모두 `opts.mf`(CliOptions 수명, mfBundleFromDto
-/// 가 1회 생성·소유, freeMfBundle 해제) 를 **borrow** — 여기서 재-alloc 0,
-/// 누수 0(P1-4 에서 global_seam 을 SharedEntry 로 끌어올려 P1-2 의 per-call
-/// alloc 누수 제거). parseGlobalsArg 의 borrow 모델과 일관.
-fn applyMfSharedSeam(
-    allocator: std.mem.Allocator,
-    opts: *CliOptions,
-    shared: []const lib.bundler.MfBundleConfig.SharedEntry,
-) !void {
-    for (shared) |s| {
-        try opts.external_list.append(allocator, s.name); // borrow (opts.mf 소유)
-        try opts.globals_list.append(allocator, .{
-            .specifier = s.name, // borrow
-            .global_name = s.global_seam, // borrow (mfBundleFromDto 가 1회 생성·소유)
-        });
-    }
-}
-
-/// 스펙 런타임 pkg/글로벌 — federation.zig 단일 소스 재노출(emitHostInit
-/// 과 반드시 일치). 고정 상수라 alloc/소유 무관(static literal).
-const MF_RUNTIME_PKG = lib.bundler.federation.MF_RUNTIME_PKG;
-const MF_RUNTIME_GLOBAL = lib.bundler.federation.MF_RUNTIME_GLOBAL;
-
-/// mf.remotes → host 소비 seam. 원격 specifier(KV.key, 예 `remoteA`)는
-/// external — resolve_cache sub-path 매칭이 `remoteA/Widget` 도 자동 external
-/// (esbuild 동등). `@module-federation/runtime` 도 external + 글로벌
-/// (`__mf_runtime`) — host 가 그 글로벌로 스펙 런타임 제공(P1-2 와 동일
-/// 기계, container 글로벌 소비 모델과 일관). emitHostInit 이 init/loadRemote
-/// 를 그 글로벌로 배선. 모든 문자열 borrow(opts.mf KV / static literal).
-fn applyMfRemotesSeam(
-    allocator: std.mem.Allocator,
-    opts: *CliOptions,
-    remotes: []const lib.bundler.MfBundleConfig.KV,
-) !void {
-    for (remotes) |kv| {
-        try opts.external_list.append(allocator, kv.key); // borrow (opts.mf 소유)
-    }
-    try opts.external_list.append(allocator, MF_RUNTIME_PKG);
-    try opts.globals_list.append(allocator, .{
-        .specifier = MF_RUNTIME_PKG,
-        .global_name = MF_RUNTIME_GLOBAL,
-    });
-}
-
-/// `MfConfigDto`(arena, record) → `MfBundleConfig`(CliOptions 수명, 평탄화).
-/// exposes/remotes record → []KV, shared record → 패키지명 []. 모든 문자열
-/// `allocator.dupe` (외부 mf list/main.zig 가 build 끝까지 참조).
-/// JSON record(`std.json.ArrayHashMap`)→`[]KV` deep-dupe. exposes/remotes
-/// 공용(DRY). 중간 OOM 시 이미 dup 한 항목+list 해제(errdefer).
-fn dupeKvMap(
-    allocator: std.mem.Allocator,
-    map: anytype,
-) ![]const lib.bundler.MfBundleConfig.KV {
-    const KV = lib.bundler.MfBundleConfig.KV;
-    const list = try allocator.alloc(KV, map.count());
-    var done: usize = 0;
-    errdefer {
-        for (list[0..done]) |kv| {
-            allocator.free(kv.key);
-            allocator.free(kv.value);
-        }
-        allocator.free(list);
-    }
-    var it = map.iterator();
-    while (it.next()) |kv| : (done += 1) list[done] = .{
-        .key = try allocator.dupe(u8, kv.key_ptr.*),
-        .value = try allocator.dupe(u8, kv.value_ptr.*),
-    };
-    return list;
-}
-
-/// 한 SharedEntry 의 owned 필드 해제. freeMfBundle 정상경로와
-/// mfBundleFromDto 부분실패 errdefer 가 **동일 본문 공유**(필드 추가 시
-/// 한 곳만 — #4-0 share_scope 가 양쪽 동기화 부담 노출).
-fn freeSharedEntry(alloc: std.mem.Allocator, s: lib.bundler.MfBundleConfig.SharedEntry) void {
-    alloc.free(s.name);
-    if (s.required_version) |rv| alloc.free(rv);
-    if (s.global_seam.len > 0) alloc.free(s.global_seam);
-    alloc.free(s.share_scope); // name 과 동일 — 항상 owned(default 도 dup)
-}
-
-/// mfBundleFromDto 가 allocator-dup 한 것 일괄 해제. CliOptions.deinit 과
-/// mfBundleFromDto 의 errdefer 가 **공유**(해제 모델 단일 소스 — 부분
-/// 실패/정상 종료 대칭). len>0 가드: exposes/remotes/shared default 는
-/// static `&.{}` (오해제 방지, chunks.zig reg_ids 와 동일 관용). name 은
-/// set 시 항상 dup, share_scope 는 항상 dup(아래 통일). **불변: mf 는
-/// mfBundleFromDto 로만 생성**(외부 생성 시 share_scope 리터럴 free 위험).
-fn freeMfBundle(alloc: std.mem.Allocator, mfb: lib.bundler.MfBundleConfig) void {
-    if (mfb.name) |n| alloc.free(n);
-    alloc.free(mfb.share_scope);
-    alloc.free(mfb.share_strategy);
-    for (mfb.exposes) |kv| {
-        alloc.free(kv.key);
-        alloc.free(kv.value);
-    }
-    if (mfb.exposes.len > 0) alloc.free(mfb.exposes);
-    for (mfb.remotes) |kv| {
-        alloc.free(kv.key);
-        alloc.free(kv.value);
-    }
-    if (mfb.remotes.len > 0) alloc.free(mfb.remotes);
-    for (mfb.shared) |s| freeSharedEntry(alloc, s);
-    if (mfb.shared.len > 0) alloc.free(mfb.shared);
-}
-
-fn mfBundleFromDto(
-    allocator: std.mem.Allocator,
-    dto: *const lib.transpile.MfConfigDto,
-) !lib.bundler.MfBundleConfig {
-    var out: lib.bundler.MfBundleConfig = .{};
-    // 부분 dup 후 실패 시 누수 방지 — deinit 과 동일 해제로 대칭.
-    // out.shared 는 루프 완료 후에야 대입 → 진행 중 list 는 블록 errdefer 가.
-    errdefer freeMfBundle(allocator, out);
-    if (dto.name) |n| out.name = try allocator.dupe(u8, n);
-    // share_scope 는 항상 owned(default 도 dup) — deinit 해제 대칭(리터럴/
-    // owned 혼재 회피).
-    out.share_scope = try allocator.dupe(u8, dto.shareScope orelse "default");
-    // share_strategy 도 항상 owned(default 도 dup) — freeMfBundle 대칭.
-    out.share_strategy = try allocator.dupe(u8, dto.shareStrategy orelse "version-first");
-
-    if (dto.exposes) |e| out.exposes = try dupeKvMap(allocator, &e.map);
-    if (dto.remotes) |r| out.remotes = try dupeKvMap(allocator, &r.map);
-    if (dto.shared) |sh| {
-        const SE = lib.bundler.MfBundleConfig.SharedEntry;
-        const list = try allocator.alloc(SE, sh.map.count());
-        errdefer allocator.free(list);
-        var it = sh.map.iterator();
-        var i: usize = 0;
-        // 부분 실패 시: 이미 채운 항목 해제(list[0..i] — 실패 iteration 의
-        // i 는 미증가라 제외, in-progress 는 아래 per-field errdefer 가).
-        errdefer for (list[0..i]) |s| freeSharedEntry(allocator, s);
-        while (it.next()) |kv| : (i += 1) {
-            const c = kv.value_ptr.*; // MfSharedDto (P1-0 파싱, 여기서 소비)
-            const nm = try allocator.dupe(u8, kv.key_ptr.*);
-            errdefer allocator.free(nm);
-            const rv = if (c.requiredVersion) |v| try allocator.dupe(u8, v) else null;
-            errdefer if (rv) |r| allocator.free(r);
-            // #4-0 해석 3-tier + 항상-owned 근거: SharedEntry.share_scope doc.
-            const sc = try allocator.dupe(u8, c.shareScope orelse dto.shareScope orelse "default");
-            errdefer allocator.free(sc);
-            list[i] = .{
-                .name = nm,
-                .singleton = c.singleton orelse false,
-                .required_version = rv,
-                .strict_version = c.strictVersion orelse false,
-                .eager = c.eager orelse false,
-                // 글로벌명 1회 생성·소유(seam·init borrow). 단일 규칙.
-                .global_seam = try lib.bundler.federation.mfSharedGlobalName(allocator, nm),
-                .share_scope = sc,
-            };
-        }
-        out.shared = list;
-    }
-    return out;
 }
 
 /// CLI 인자를 파싱하여 CliOptions를 반환한다.
@@ -1225,16 +1064,16 @@ test "#4-0 mfBundleFromDto: per-shared share_scope 명시 + 번들 상속 + free
     { // 번들 shareScope="host": react 는 명시 "ui", lodash 미지정 → "host" 상속
         const v = try P.p(a, "{\"shareScope\":\"host\",\"shared\":{\"react\":{\"shareScope\":\"ui\"},\"lodash\":{}}}");
         defer v.deinit();
-        const mfb = try mfBundleFromDto(a, &v.value);
-        defer freeMfBundle(a, mfb); // testing.allocator = 누수 탐지(항상-owned free 대칭 강제)
+        const mfb = try mf_options.fromDto(a, &v.value);
+        defer mf_options.freeMfBundle(a, mfb); // testing.allocator = 누수 탐지(항상-owned free 대칭)
         try std.testing.expectEqualStrings("ui", P.scopeOf(mfb, "react"));
         try std.testing.expectEqualStrings("host", P.scopeOf(mfb, "lodash"));
     }
     { // 번들 shareScope 미지정 + per-shared 미지정 → "default"
         const v = try P.p(a, "{\"shared\":{\"react\":{}}}");
         defer v.deinit();
-        const mfb = try mfBundleFromDto(a, &v.value);
-        defer freeMfBundle(a, mfb);
+        const mfb = try mf_options.fromDto(a, &v.value);
+        defer mf_options.freeMfBundle(a, mfb);
         try std.testing.expectEqualStrings("default", P.scopeOf(mfb, "react"));
     }
 }

--- a/tests/integration/tests/mf-container-emit.test.ts
+++ b/tests/integration/tests/mf-container-emit.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, afterEach } from 'bun:test';
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { runConfigBundle, writeOutputs, runNode } from './helpers';
+import { runConfigBundle, writeOutputs, runNode, createFixture, runZntcInDir } from './helpers';
 
 // P1-3 (#3385): webpack-style container emit (remoteEntry).
 //   - entry 청크의 eager bootstrap(`var X=__zntc_require("id")`)을
@@ -106,6 +106,41 @@ describe('MF P1-3: webpack-style container emit', () => {
     // 단일 positional 직접 조회(s["react"])는 더 이상 1차 경로 아님
     expect(entry).not.toContain('if(s&&s["react"])');
   });
+
+  // PR-plumb (#3318): 발행 @zntc/core JS CLI(NAPI 경로) 가 zntc.config 의
+  // `mf` 를 native 번들러로 전달하는지. 기존 MF 테스트는 전부 ZNTC_BIN
+  // (native) 만 → 사용자가 실제 쓰는 JS CLI 경로 갭이 미검출이었다.
+  // bin:'js' = packages/core/bin/zntc.mjs (NAPI) 경로.
+  test('JS CLI(NAPI): zntc.config mf → 컨테이너/매니페스트 산출', async () => {
+    const fx = await createFixture({
+      'Widget.ts': `export default function Widget() { return "JS-CLI-OK"; }`,
+      'index.ts': `export const sentinel = "remote-entry";`,
+      'zntc.config.json': JSON.stringify({
+        mf: {
+          name: 'app',
+          exposes: { './Widget': './Widget.ts' },
+          shared: { react: { singleton: true, requiredVersion: '^19' } },
+        },
+      }),
+    });
+    cleanup = fx.cleanup;
+    const dist = join(fx.dir, 'dist');
+    const r = await runZntcInDir(
+      fx.dir,
+      ['--bundle', join(fx.dir, 'index.ts'), '--outdir', dist, '--format=iife'],
+      { bin: 'js' },
+    );
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr).not.toContain("unknown config key 'mf'");
+
+    const files = readdirSync(dist);
+    const entryFile = files.find(
+      (f) =>
+        f.endsWith('.js') && readFileSync(join(dist, f), 'utf8').includes('__zntc_mf_container'),
+    );
+    expect(entryFile).toBeDefined(); // ← native 와 동일하게 컨테이너 emit
+    expect(files).toContain('mf-manifest.json'); // ← 매니페스트도
+  }, 30000);
 
   test('interop 계약: init→get 으로 exposed 모듈 lazy 도달 (S1/S3 형태)', async () => {
     const r = await runConfigBundle({


### PR DESCRIPTION
## 무엇 (사용자 도달 갭)

웹 Module Federation 은 native 번들러엔 완결됐으나, **발행 `@zntc/core`**(NAPI 경로 — 사용자가 `npm i @zntc/core` 후 `zntc build` 로 실제 쓰는 길)에선 `mf` 키가 추출조차 안 돼 동작하지 않았습니다: `@zntc/core: unknown config key 'mf'` → plain bundle, **컨테이너/매니페스트 0**.

모든 MF 통합·e2e 테스트가 native 바이너리(`ZNTC_BIN`)만 직접 spawn 해 통과했고, 사용자가 실제 쓰는 JS CLI(`packages/core/bin/zntc.mjs`, NAPI) 경로는 한 번도 안 탔습니다. **MF 사용자 예제앱을 작성하다 이 갭이 드러났습니다.** (`index.ts:632` 주석이 "build()/NAPI mf 추출 P1-1+"로 이연을 명시했었음.)

## 어떻게 (단일 소스 + JSON-string 경계)

- **`src/bundler/mf_options.zig` 신설** — `fromDto`/`freeMfBundle`/`freeSharedEntry`/`dupeKvMap` 를 `cli/options.zig` 에서 이관·`pub` + 순수 `seamExternals`/`seamGlobals`. **CLI·NAPI 양쪽 위임** → mf 변환·seam 이 한 곳 → silent drift(이번 갭의 본질) 구조적 봉인. (후속 ④ "seam 을 번들러 코어 단일 적용점" 의 무손실 디딤돌 — `seamLists`/`fromDto` 순수함수 그대로 재사용)
- **`cli/options.zig`**: mf_options 위임(`applyMf*Seam` 삭제, `seam*` `appendSlice`). 산출 순서·내용 byte 동일 → **CLI 무손실**
- **`napi/options.zig`**: `mfRaw`(JSON string, `tsconfigRaw` 와 동형 transport) → `MfConfigDto` → `validateMf` → `mf_options.fromDto` → `BundleOptions.mf` + seam concat(**mf-게이트 = 비-MF byte 동일 무회귀**) + `freeOptionsTypedSlices` 에 `freeMfBundle`/combined free + `mf.exposes` 시 `code_splitting` 강제(CLI 미러)
- **JS**: `KNOWN_CONFIG_KEYS += 'mf'`, `zntc.mjs` buildOpts `mf`, `index.ts` prepareNapiOptions `mf → mfRaw=JSON.stringify`

## /simplify 가 잡은 실 누수 결함 → 수정

3-에이전트 효율 리뷰가 포착: `parseBuildOptions → null`(OOM·malformed) 시 호출자가 `freeOptionsTypedSlices` 를 안 거쳐 `mfb`/combined 가 **leak**(가장 도달: RN+blockList `std.mem.concat` OOM 이 mf 블록 *이후* return literal 안에서). 이 파일은 `catch return null`(에러 아님)이라 errdefer 무효.

→ **수정**: RN block_list 머지를 return literal 밖 `const` 로 hoist(→ mf 블록 이후 **무-fallible**) + 블록 내 각 실패점 **명시 롤백** + 수동 `alloc`+`@memcpy` → `std.mem.concat`(동파일 선례 재사용). 이중해제·UAF 없음 확인. NAPI mf 검증에러가 generic("invalid build options")로 degrade 하는 건 **파일전반 선재 패턴**(모든 NAPI 옵션 에러 동일) → 후속(#25 인접), 본 PR 범위 밖.

## 검증

- `zig build test` **0** (mf_options inline + cli #4-0 + 이관 무회귀) · wasm 0 · install 0 · napi 0
- MF 통합 **28·0** — `mf-container-emit` 의 **JS-CLI(NAPI) 경로 RED→GREEN**(컨테이너+매니페스트 산출) + native 회귀, `mf-runtime-interop-smoke` **CLI native 무손실 23·0**
- MF e2e **9·0** (실 Chromium + 실 rspack/enhanced)
- `/simplify` 3-에이전트: 누수 결함 1 포착 → 수정·재검증 후 차단 0. reuse(std.mem.concat·precedent 주석)·quality(주석 4중복 트림) 반영

## 영향

이로써 **발행 `@zntc/core` 사용자가 `zntc.config` 의 `mf` 로 실제 MF 를 쓸 수 있습니다.** 이번 세션의 "웹 MF 완결"이 native 한정이었던 것을 사용자 도달까지 닫음. 후속: PR-A 예제앱(이제 unblock) · PR-B 가이드 · #25 ④ 번들러-코어 단일적용점.

## Zig 초보자 메모

NAPI = JS 가 Zig 를 in-process 호출하는 다리. JS 객체를 Zig 가 읽기 어려운 중첩 구조라, `mf` 를 `JSON.stringify` 한 **문자열**로 넘기고(`tsconfigRaw` 와 같은 방식) Zig 가 `std.json` 으로 파싱 — 이미 검증된 CLI 변환 코드(`mf_options`)를 그대로 재사용해 양쪽이 갈라질 일이 없게 했습니다. Zig 의 `catch { ...; return null; }` 는 "실패하면 정리하고 빠져나간다"인데, 이 파일은 에러 대신 `null` 을 반환하는 관례라 자동 정리(`errdefer`)가 안 걸려서 실패 지점마다 손으로 `free` 를 넣었습니다(메모리 누수 방지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)