### PR TITLE
docs(mf): examples/module-federation 실행 예제앱 — PR-A (#3318)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -68,6 +68,18 @@
         "vite": "^7",
       },
     },
+    "examples/module-federation": {
+      "name": "@zntc/example-module-federation",
+      "version": "0.0.0",
+      "dependencies": {
+        "@module-federation/runtime": "2.4.0",
+        "react": "^19.0.0",
+      },
+      "devDependencies": {
+        "@zntc/core": "workspace:*",
+        "typescript": "^6.0.3",
+      },
+    },
     "examples/react-native-bare": {
       "name": "zntc-example-react-native-bare",
       "version": "0.0.1",
@@ -2890,6 +2902,8 @@
     "@zntc/core": ["@zntc/core@workspace:packages/core"],
 
     "@zntc/e2e": ["@zntc/e2e@workspace:tests/e2e"],
+
+    "@zntc/example-module-federation": ["@zntc/example-module-federation@workspace:examples/module-federation"],
 
     "@zntc/example-web": ["@zntc/example-web@workspace:examples/web"],
 
@@ -6826,6 +6840,8 @@
     "@zntc/benchmark/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
     "@zntc/benchmark/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@zntc/example-module-federation/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
     "@zntc/example-web/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 

--- a/examples/module-federation/.gitignore
+++ b/examples/module-federation/.gitignore
@@ -1,0 +1,2 @@
+# zntc 가 생성하는 remote 빌드 산출물 (bun run build / demo)
+remote/dist/

--- a/examples/module-federation/README.md
+++ b/examples/module-federation/README.md
@@ -1,0 +1,79 @@
+# Module Federation 예제 (zntc remote ↔ 표준 host)
+
+zntc 로 빌드한 **remote** 를, 별도 zntc 런타임 없이 표준
+`@module-federation/runtime` **host** 가 그대로 소비하는 최소 예제입니다
+(이 예제가 보여주는 방향). zntc 는 표준 Module Federation 런타임 계약을
+타깃하므로, 더 넓은 interop 범위·원리·한계는 문서 사이트의 Module
+Federation 가이드를 참고하세요.
+
+## 구성
+
+```
+remote/
+  zntc.config.json   # mf: name / exposes / shared
+  src/Button.tsx      # 노출(expose)하는 React 컴포넌트 (react 는 shared)
+  src/index.ts        # remote entry (컨테이너는 mf.exposes 에서 생성)
+host.mjs              # 표준 @module-federation/runtime 으로 remote 소비
+```
+
+`remote/zntc.config.json`:
+
+```json
+{
+  "mf": {
+    "name": "remote_app",
+    "exposes": { "./Button": "./src/Button.tsx" },
+    "shared": { "react": { "singleton": true, "requiredVersion": "^19" } }
+  }
+}
+```
+
+- `exposes` — 다른 앱이 가져갈 수 있게 노출할 모듈
+- `shared` — 번들에 포함하지 않고 host 가 제공하는 단일 인스턴스를
+  공유할 의존성. `singleton` + `requiredVersion` 으로 버전 계약을 건다
+  (React 처럼 인스턴스가 갈리면 안 되는 라이브러리에 필수).
+
+## 실행
+
+리포지토리 루트에서 한 번 설치한 뒤:
+
+```sh
+bun install
+bun run --cwd examples/module-federation demo
+```
+
+`demo` 는 (1) zntc 로 `remote/` 를 빌드하고 (2) `host.mjs` 를 실행합니다.
+빌드는 앱이 아니라 **MF remote 컨테이너**라서 app 모드 `zntc build` 가
+아닌 core 모드 `zntc --bundle … --format=iife` 를 씁니다(다른 예제는
+app 모드). 개별 실행:
+
+```sh
+bun run --cwd examples/module-federation build   # zntc → remote/dist
+bun run --cwd examples/module-federation start   # host.mjs
+```
+
+기대 출력:
+
+```
+component: true / shared React singleton: true
+element type === Button: true
+OK — zntc remote 컴포넌트를 표준 host 가 소비, react 단일 인스턴스 공유
+```
+
+## 무엇을 보여주나
+
+- `host.mjs` 에 **zntc 의존성이 전혀 없다** — 표준
+  `@module-federation/runtime` 의 `init` / `loadRemote` 만 쓴다.
+- `loadRemote('remote_app/Button')` 가 zntc 가 emit 한 컨테이너에서
+  컴포넌트를 가져온다.
+- remote 의 `react` 가 host 가 등록한 `react` 와 **동일 인스턴스**다
+  (`shared` singleton 성립 — hooks 가 깨지지 않는 조건).
+
+`host.mjs` 는 데모 목적상 react-dom 없이 컴포넌트/싱글톤만 확인한다.
+브라우저 host 면 가져온 컴포넌트를 그대로 `react-dom` 으로 렌더하면 된다.
+remote **entry** 만 http 로 서빙하고 청크는 entry 의 publicPath(빌드 시
+`file://dist/`)로 로드된다 — Node 는 http import 미지원이라 "entry=http /
+chunk=file://" 하이브리드가 표준 Node interop 패턴(브라우저면 양쪽 http).
+
+> 개념 설명(원리·설정·한계)은 문서 사이트의 Module Federation 가이드를
+> 참고하세요.

--- a/examples/module-federation/host.mjs
+++ b/examples/module-federation/host.mjs
@@ -1,0 +1,68 @@
+// host 앱 — zntc 로 빌드한 remote 의 컴포넌트를 표준
+// @module-federation/runtime 으로 소비한다. zntc 는 remote/host 양쪽
+// 모두 표준 런타임 계약을 타깃하므로 별도 zntc 런타임 없이 그대로
+// interop 된다(이 파일에 zntc 의존성이 전혀 없다는 점에 주목).
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as hostReact from 'react';
+// @module-federation/runtime 은 CJS — namespace import 후 default 추출
+// (Node 의 CJS↔ESM interop. 독립 프로젝트도 동일).
+import * as mfNs from '@module-federation/runtime';
+
+const mf = mfNs.default ?? mfNs;
+const { createElement } = hostReact;
+const here = dirname(fileURLToPath(import.meta.url));
+const dist = join(here, 'remote', 'dist');
+
+// 1) remote **entry** 만 http 로 서빙(실제 배포에선 CDN/별도 호스트).
+//    청크는 entry 의 publicPath(빌드 시 file://dist/) 로 로드된다 — Node
+//    는 http import 를 지원 안 해 "entry=http / chunk=file://" 하이브
+//    리드가 표준 Node interop 패턴(브라우저면 양쪽 다 http).
+const server = createServer(async (request, res) => {
+  try {
+    const f = join(dist, request.url === '/' ? '/index.js' : request.url);
+    res.writeHead(200, { 'content-type': 'application/javascript' });
+    res.end(await readFile(f));
+  } catch {
+    res.writeHead(404).end();
+  }
+});
+await new Promise((r) => server.listen(0, r));
+const port = server.address().port;
+
+// 2) 표준 host. host 가 자기 react 를 shared 로 등록 → remote 의
+//    `shared: { react }` 가 이 단일 인스턴스를 공유(hooks 동작 조건).
+const { init, loadRemote } = mf;
+init({
+  name: 'host_app',
+  remotes: [{ name: 'remote_app', entry: `http://localhost:${port}/index.js` }],
+  shared: {
+    react: {
+      version: '19.0.0',
+      lib: () => hostReact,
+      shareConfig: { singleton: true, requiredVersion: '^19' },
+    },
+  },
+});
+
+// 3) remote 컴포넌트를 동적으로 가져온다(표준 loadRemote — zntc remote).
+const mod = await loadRemote('remote_app/Button');
+const Button = mod.default ?? mod;
+
+// 4) 검증: (a) 컴포넌트가 함수로 도달했고 (b) remote 의 react 가 host 의
+//    react 와 **동일 인스턴스**다(= shared singleton 성립, hooks 안전).
+//    실제 앱이라면 여기서 react-dom 으로 <Button/> 을 렌더하면 된다.
+const isComponent = typeof Button === 'function';
+const sharedSingleton = mod.usedHook === hostReact.useState;
+const el = isComponent ? createElement(Button) : null;
+
+console.log('component:', isComponent, '/ shared React singleton:', sharedSingleton);
+console.log('element type === Button:', el?.type === Button);
+const ok = isComponent && sharedSingleton && el?.type === Button;
+console.log(
+  ok ? 'OK — zntc remote 컴포넌트를 표준 host 가 소비, react 단일 인스턴스 공유' : 'FAIL',
+);
+await new Promise((r) => server.close(r));
+process.exit(ok ? 0 : 1);

--- a/examples/module-federation/package.json
+++ b/examples/module-federation/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@zntc/example-module-federation",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "prebuild": "bun run --cwd ../../packages/core build:js",
+    "build": "cd remote && zntc --bundle src/index.ts --outdir dist --format=iife --public-path=file://$PWD/dist/",
+    "start": "node host.mjs",
+    "demo": "bun run build && bun run start"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "@module-federation/runtime": "2.4.0"
+  },
+  "devDependencies": {
+    "@zntc/core": "workspace:*",
+    "typescript": "^6.0.3"
+  }
+}

--- a/examples/module-federation/remote/src/Button.tsx
+++ b/examples/module-federation/remote/src/Button.tsx
@@ -1,0 +1,19 @@
+// remote 가 노출(expose)하는 실제 React 컴포넌트.
+// `react` 는 zntc.config 의 mf.shared 로 선언 → 번들에 포함되지 않고
+// host 가 제공하는 단일 react 인스턴스를 공유한다(useState 가 host 의
+// 그것과 동일 인스턴스라야 hooks 가 동작).
+import { useState, createElement } from 'react';
+
+// 데모 전용 스캐폴딩: host.mjs 가 `mod.usedHook === hostReact.useState`
+// 로 shared singleton(remote↔host 동일 react 인스턴스) 성립을 검증하기
+// 위해서만 노출한다. 실제 컴포넌트에는 불필요.
+export const usedHook = useState;
+
+export default function Button() {
+  const [count, setCount] = useState(0);
+  return createElement(
+    'button',
+    { onClick: () => setCount(count + 1) },
+    `remote Button — count: ${count}`,
+  );
+}

--- a/examples/module-federation/remote/src/index.ts
+++ b/examples/module-federation/remote/src/index.ts
@@ -1,0 +1,3 @@
+// remote entry. zntc 는 mf.exposes 로부터 컨테이너(remoteEntry)를
+// 생성하므로 이 파일 자체는 entry sentinel 역할만 한다.
+export const name = 'remote_app';

--- a/examples/module-federation/remote/zntc.config.json
+++ b/examples/module-federation/remote/zntc.config.json
@@ -1,0 +1,11 @@
+{
+  "mf": {
+    "name": "remote_app",
+    "exposes": {
+      "./Button": "./src/Button.tsx"
+    },
+    "shared": {
+      "react": { "singleton": true, "requiredVersion": "^19" }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "./packages/rspack-loader",
     "./documents",
     "./examples/web",
+    "./examples/module-federation",
     "./examples/react-native-bare",
     "./examples/react-native-large",
     "./examples/react-native-expo",


### PR DESCRIPTION
## 무엇

zntc 로 빌드한 **remote** 를 표준 `@module-federation/runtime` **host** 가 별도 zntc 런타임 없이 소비하는 최소 **실행** 예제. 사용자 "MF 예제앱 있나?" 질문 → 이 예제 작성이 PR-plumb(#3483, 발행 `@zntc/core` 가 `mf` 미전달하던 사용자 도달 갭) 을 드러냈고, 그 머지 후 이제 **사용자가 실제 쓰는 경로로 end-to-end 동작**합니다.

```
examples/module-federation/
  remote/zntc.config.json   # mf: name / exposes / shared(react singleton)
  remote/src/Button.tsx     # expose React 컴포넌트 (react = shared)
  remote/src/index.ts       # remote entry sentinel
  host.mjs                  # 표준 init/loadRemote 만 (zntc 의존 0)
  package.json / README / .gitignore
```

## 검증 (문서화된 명령으로)

```sh
bun install
bun run --cwd examples/module-federation demo
# → component: true / shared React singleton: true
#   OK — zntc remote 컴포넌트를 표준 host 가 소비, react 단일 인스턴스 공유   (exit 0)
```

`demo` = zntc(JS CLI/NAPI) 로 remote 빌드 → `host.mjs` 가 표준 런타임으로 `loadRemote('remote_app/Button')` → 컴포넌트 함수 도달 + `mod.usedHook === hostReact.useState`(shared singleton) 검증. **PR-plumb 의 사용자 경로를 실증**(`unknown config key 'mf'` 없이 컨테이너/매니페스트 산출).

## /simplify 3-에이전트 반영

- **createRequire 우회 제거**: 리뷰어 지적 → workspace 멤버 등록 + `bun install` 후 plain bare `import 'react'` 가 동작함을 **실증**(node_modules 심링크), 단 `@module-federation/runtime` 만 CJS 라 `import * as` + `default ?? ns` 추출. 교육 예제의 명료성 회복
- **README**: 양방향 webpack/rspack interop 과장 → 예제가 실제 보인 방향으로 축소(넓은 범위는 가이드로 위임) + core `--bundle`(remote 컨테이너) vs sibling app `zntc build` 차이 1줄 + `entry=http / chunk=file://` 하이브리드(Node http-import 미지원 — 스모크 S2/S3 동형) 명시
- **Button.usedHook**: 데모-전용 스캐폴딩임을 주석 명시(실 컴포넌트엔 불필요)
- `server.close()` await 후 `process.exit` (no-op 제거)
- 빌드산출물(`remote/dist/`) `.gitignore`, `node_modules` 전역 ignore — 소스만 커밋

## 위치

PR 분해: ✅PR-plumb(#3483) → ✅**PR-A(이 PR) 예제앱** → ⏭PR-B documents 가이드(user-perspective ko+en) → ⏭#25 ④(번들러-코어 단일적용점, 단독 코어 리팩터).

## Zig 초보자 메모

이 예제엔 Zig 코드가 없습니다 — zntc(번들러)를 **사용하는 쪽** 입니다. `host.mjs` 에 zntc import 가 0개라는 점이 핵심: zntc 가 표준 Module Federation 계약대로 산출하므로, 소비자는 webpack/rspack 과 똑같이 표준 `@module-federation/runtime` 만으로 zntc remote 를 씁니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)