### PR TITLE
docs(mf): Module Federation 사용자 가이드 (ko+en) — PR-B (#3318)

### DIFF
--- a/documents/astro.config.mjs
+++ b/documents/astro.config.mjs
@@ -1,29 +1,29 @@
 // @ts-check
-import { defineConfig } from "astro/config";
-import starlight from "@astrojs/starlight";
-import react from "@astrojs/react";
-import tailwindcss from "@tailwindcss/vite";
-import starlightLinksValidator from "starlight-links-validator";
-import starlightTypeDoc, { typeDocSidebarGroup } from "starlight-typedoc";
+import { defineConfig } from 'astro/config';
+import starlight from '@astrojs/starlight';
+import react from '@astrojs/react';
+import tailwindcss from '@tailwindcss/vite';
+import starlightLinksValidator from 'starlight-links-validator';
+import starlightTypeDoc, { typeDocSidebarGroup } from 'starlight-typedoc';
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://ohah.github.io",
-  base: "/zntc",
+  site: 'https://ohah.github.io',
+  base: '/zntc',
   integrations: [
     starlight({
-      title: "ZNTC",
-      description: "Zig Native Transpiler & Compiler",
+      title: 'ZNTC',
+      description: 'Zig Native Transpiler & Compiler',
       expressiveCode: {
-        themes: ["github-dark", "github-light"],
+        themes: ['github-dark', 'github-light'],
         styleOverrides: {
-          borderRadius: "0.375rem",
-          codePaddingBlock: "0.875rem",
-          codePaddingInline: "1.125rem",
-          codeFontSize: "0.875rem",
-          codeLineHeight: "1.7",
+          borderRadius: '0.375rem',
+          codePaddingBlock: '0.875rem',
+          codePaddingInline: '1.125rem',
+          codeFontSize: '0.875rem',
+          codeLineHeight: '1.7',
           frames: {
-            shadowColor: "rgba(0, 0, 0, 0.12)",
+            shadowColor: 'rgba(0, 0, 0, 0.12)',
           },
         },
         defaultProps: {
@@ -33,14 +33,19 @@ export default defineConfig({
       },
       plugins: [
         starlightLinksValidator({
-          exclude: ["/zntc/playground/", "/zntc/en/playground/", "/zntc/analyze/", "/zntc/en/analyze/"],
+          exclude: [
+            '/zntc/playground/',
+            '/zntc/en/playground/',
+            '/zntc/analyze/',
+            '/zntc/en/analyze/',
+          ],
         }),
         starlightTypeDoc({
-          entryPoints: ["../packages/core/index.ts"],
-          tsconfig: "../packages/core/tsconfig.json",
-          output: "reference/api",
+          entryPoints: ['../packages/core/index.ts'],
+          tsconfig: '../packages/core/tsconfig.json',
+          output: 'reference/api',
           sidebar: {
-            label: "API Reference",
+            label: 'API Reference',
             collapsed: true,
           },
           typeDoc: {
@@ -49,135 +54,180 @@ export default defineConfig({
           },
         }),
       ],
-      defaultLocale: "root",
+      defaultLocale: 'root',
       locales: {
-        root: { label: "한국어", lang: "ko" },
-        en: { label: "English", lang: "en" },
+        root: { label: '한국어', lang: 'ko' },
+        en: { label: 'English', lang: 'en' },
       },
       social: [
         {
-          icon: "github",
-          label: "GitHub",
-          href: "https://github.com/ohah/zntc",
+          icon: 'github',
+          label: 'GitHub',
+          href: 'https://github.com/ohah/zntc',
         },
       ],
       sidebar: [
         {
-          label: "가이드",
-          translations: { en: "Guides" },
+          label: '가이드',
+          translations: { en: 'Guides' },
           items: [
-            { label: "소개", slug: "guides/introduction", translations: { en: "Introduction" } },
-            { label: "설치", slug: "guides/installation", translations: { en: "Installation" } },
-            { label: "빠른 시작", slug: "guides/quick-start", translations: { en: "Quick Start" } },
-            { label: "설정 파일", slug: "guides/config-file", translations: { en: "Config File" } },
+            { label: '소개', slug: 'guides/introduction', translations: { en: 'Introduction' } },
+            { label: '설치', slug: 'guides/installation', translations: { en: 'Installation' } },
+            { label: '빠른 시작', slug: 'guides/quick-start', translations: { en: 'Quick Start' } },
+            { label: '설정 파일', slug: 'guides/config-file', translations: { en: 'Config File' } },
           ],
         },
         {
-          label: "트랜스파일",
-          translations: { en: "Transpile" },
+          label: '트랜스파일',
+          translations: { en: 'Transpile' },
           items: [
-            { label: "개요", slug: "guides/transpile", translations: { en: "Overview" } },
+            { label: '개요', slug: 'guides/transpile', translations: { en: 'Overview' } },
             {
-              label: "네이티브 트랜스폼 (Babel 없이)",
-              slug: "guides/native-transforms",
-              translations: { en: "Native Transforms (No Babel)" },
+              label: '네이티브 트랜스폼 (Babel 없이)',
+              slug: 'guides/native-transforms',
+              translations: { en: 'Native Transforms (No Babel)' },
             },
           ],
         },
         {
-          label: "번들러",
-          translations: { en: "Bundler" },
+          label: '번들러',
+          translations: { en: 'Bundler' },
           items: [
-            { label: "개요", slug: "guides/bundling", translations: { en: "Overview" } },
-            { label: "트리쉐이킹", slug: "guides/tree-shaking", translations: { en: "Tree-shaking" } },
+            { label: '개요', slug: 'guides/bundling', translations: { en: 'Overview' } },
             {
-              label: "런타임 폴리필 (core-js)",
-              slug: "guides/runtime-polyfills",
-              translations: { en: "Runtime Polyfills (core-js)" },
+              label: '트리쉐이킹',
+              slug: 'guides/tree-shaking',
+              translations: { en: 'Tree-shaking' },
             },
-            { label: "manualChunks", slug: "guides/manual-chunks", translations: { en: "manualChunks" } },
             {
-              label: "구조와 동작 원리",
-              slug: "guides/bundler-deep-dive",
-              translations: { en: "Architecture & Internals" },
+              label: '런타임 폴리필 (core-js)',
+              slug: 'guides/runtime-polyfills',
+              translations: { en: 'Runtime Polyfills (core-js)' },
+            },
+            {
+              label: 'manualChunks',
+              slug: 'guides/manual-chunks',
+              translations: { en: 'manualChunks' },
+            },
+            {
+              label: 'Module Federation',
+              slug: 'guides/module-federation',
+              translations: { en: 'Module Federation' },
+            },
+            {
+              label: '구조와 동작 원리',
+              slug: 'guides/bundler-deep-dive',
+              translations: { en: 'Architecture & Internals' },
             },
           ],
         },
         {
-          label: "플러그인",
-          translations: { en: "Plugins" },
+          label: '플러그인',
+          translations: { en: 'Plugins' },
           items: [
-            { label: "플러그인", slug: "guides/plugins", translations: { en: "Plugins" } },
-            { label: "플러그인 레시피", slug: "guides/plugin-recipes", translations: { en: "Plugin Recipes" } },
+            { label: '플러그인', slug: 'guides/plugins', translations: { en: 'Plugins' } },
             {
-              label: "Rspack / Webpack 통합",
-              slug: "guides/rspack-loader",
-              translations: { en: "Rspack / Webpack" },
+              label: '플러그인 레시피',
+              slug: 'guides/plugin-recipes',
+              translations: { en: 'Plugin Recipes' },
+            },
+            {
+              label: 'Rspack / Webpack 통합',
+              slug: 'guides/rspack-loader',
+              translations: { en: 'Rspack / Webpack' },
             },
           ],
         },
         {
-          label: "마이그레이션",
-          translations: { en: "Migration" },
+          label: '마이그레이션',
+          translations: { en: 'Migration' },
           items: [
-            { label: "도구 비교", slug: "guides/comparison", translations: { en: "Tool Comparison" } },
-            { label: "다른 도구에서 이관", slug: "guides/migration", translations: { en: "From Other Tools" } },
-            { label: "Babel 이관 (RN)", slug: "guides/babel-migration", translations: { en: "Babel Migration (RN)" } },
-          ],
-        },
-        {
-          label: "레시피",
-          translations: { en: "Recipes" },
-          items: [
-            { label: "Dev Server (SSE/MCP)", slug: "guides/dev-server" },
-            { label: "Electron", slug: "guides/electron" },
-            { label: "Vite", slug: "guides/vite" },
-            { label: "Rspack / Webpack", slug: "guides/rspack" },
-            { label: "Web (standalone)", slug: "guides/web-starter" },
-            { label: "React Native", slug: "guides/react-native" },
-            { label: "React Native + Expo", slug: "guides/react-native-expo" },
-            { label: "Flow 지원", slug: "guides/flow-support", translations: { en: "Flow Support" } },
-          ],
-        },
-        {
-          label: "레퍼런스",
-          translations: { en: "Reference" },
-          items: [
-            { label: "CLI", slug: "reference/cli", translations: { en: "CLI" } },
-            { label: "NAPI / JS API", slug: "reference/napi", translations: { en: "NAPI / JS API" } },
-            { label: "Transpile 옵션", slug: "reference/options", translations: { en: "Transpile Options" } },
-            { label: "옵션 매트릭스", slug: "reference/options-matrix", translations: { en: "Options Matrix" } },
-            { label: "벤치마크", slug: "reference/benchmarks", translations: { en: "Benchmarks" } },
-            { label: "Metafile 분석", link: "/analyze/", translations: { en: "Metafile Analyze" } },
-            { label: "로드맵", slug: "roadmap", translations: { en: "Roadmap" } },
             {
-              label: "에러 코드",
-              translations: { en: "Error Codes" },
+              label: '도구 비교',
+              slug: 'guides/comparison',
+              translations: { en: 'Tool Comparison' },
+            },
+            {
+              label: '다른 도구에서 이관',
+              slug: 'guides/migration',
+              translations: { en: 'From Other Tools' },
+            },
+            {
+              label: 'Babel 이관 (RN)',
+              slug: 'guides/babel-migration',
+              translations: { en: 'Babel Migration (RN)' },
+            },
+          ],
+        },
+        {
+          label: '레시피',
+          translations: { en: 'Recipes' },
+          items: [
+            { label: 'Dev Server (SSE/MCP)', slug: 'guides/dev-server' },
+            { label: 'Electron', slug: 'guides/electron' },
+            { label: 'Vite', slug: 'guides/vite' },
+            { label: 'Rspack / Webpack', slug: 'guides/rspack' },
+            { label: 'Web (standalone)', slug: 'guides/web-starter' },
+            { label: 'React Native', slug: 'guides/react-native' },
+            { label: 'React Native + Expo', slug: 'guides/react-native-expo' },
+            {
+              label: 'Flow 지원',
+              slug: 'guides/flow-support',
+              translations: { en: 'Flow Support' },
+            },
+          ],
+        },
+        {
+          label: '레퍼런스',
+          translations: { en: 'Reference' },
+          items: [
+            { label: 'CLI', slug: 'reference/cli', translations: { en: 'CLI' } },
+            {
+              label: 'NAPI / JS API',
+              slug: 'reference/napi',
+              translations: { en: 'NAPI / JS API' },
+            },
+            {
+              label: 'Transpile 옵션',
+              slug: 'reference/options',
+              translations: { en: 'Transpile Options' },
+            },
+            {
+              label: '옵션 매트릭스',
+              slug: 'reference/options-matrix',
+              translations: { en: 'Options Matrix' },
+            },
+            { label: '벤치마크', slug: 'reference/benchmarks', translations: { en: 'Benchmarks' } },
+            { label: 'Metafile 분석', link: '/analyze/', translations: { en: 'Metafile Analyze' } },
+            { label: '로드맵', slug: 'roadmap', translations: { en: 'Roadmap' } },
+            {
+              label: '에러 코드',
+              translations: { en: 'Error Codes' },
               collapsed: true,
-              autogenerate: { directory: "reference/errors" },
+              autogenerate: { directory: 'reference/errors' },
             },
           ],
         },
         typeDocSidebarGroup,
         {
-          label: "Playground",
+          label: 'Playground',
           items: [
             {
-              label: "트랜스파일러",
-              link: "/playground/",
-              translations: { en: "Transpiler" },
+              label: '트랜스파일러',
+              link: '/playground/',
+              translations: { en: 'Transpiler' },
             },
             {
-              label: "번들러",
-              link: "/playground/bundler/",
-              translations: { en: "Bundler" },
+              label: '번들러',
+              link: '/playground/bundler/',
+              translations: { en: 'Bundler' },
             },
           ],
         },
       ],
-      customCss: ["./src/styles/tailwind.css", "./src/styles/custom.css"],
+      customCss: ['./src/styles/tailwind.css', './src/styles/custom.css'],
       components: {
-        PageTitle: "./src/overrides/PageTitle.astro",
+        PageTitle: './src/overrides/PageTitle.astro',
       },
     }),
     react(),
@@ -185,15 +235,15 @@ export default defineConfig({
   vite: {
     plugins: [tailwindcss()],
     ssr: {
-      noExternal: ["@monaco-editor/react", "echarts-for-react"],
+      noExternal: ['@monaco-editor/react', 'echarts-for-react'],
     },
     // SharedArrayBuffer 사용 (#1885 Phase 2 — bundler WASM 의 wasm32-wasi+threads).
     // dev 서버에서 COOP/COEP 헤더 set 으로 cross-origin isolation 활성. prod 환경
     // (GitHub Pages) 은 헤더 set 불가 — coi-serviceworker 로 우회 (별도 PR).
     server: {
       headers: {
-        "Cross-Origin-Opener-Policy": "same-origin",
-        "Cross-Origin-Embedder-Policy": "require-corp",
+        'Cross-Origin-Opener-Policy': 'same-origin',
+        'Cross-Origin-Embedder-Policy': 'require-corp',
       },
     },
   },

--- a/documents/src/content/docs/en/guides/module-federation.md
+++ b/documents/src/content/docs/en/guides/module-federation.md
@@ -1,0 +1,122 @@
+---
+title: Module Federation
+description: ZNTC Module Federation — expose and consume modules across independently built apps, interop with the standard runtime, and verify contracts at build time.
+---
+
+Module Federation lets separately built and deployed apps consume each
+other's modules at runtime. The side that exports modules is a
+**remote**; the side that consumes them is a **host**.
+
+ZNTC does not reimplement the host runtime — it **targets the standard
+`@module-federation/runtime` contract**. So a remote built with ZNTC can
+be consumed as-is by a host built with webpack 5 / rspack, and a ZNTC
+host can consume a standard remote (web).
+
+## Configuration
+
+Declare it in the `mf` block of `zntc.config` (`.ts`/`.js`/`.json`).
+
+### Remote (exposes modules)
+
+```json
+{
+  "mf": {
+    "name": "remote_app",
+    "exposes": { "./Button": "./src/Button.tsx" },
+    "shared": { "react": { "singleton": true, "requiredVersion": "^19" } }
+  }
+}
+```
+
+- `name` — remote identifier (the host references it by this name).
+- `exposes` — modules to expose: `{ publicPath: sourcePath }`.
+- `shared` — dependencies that are not bundled but consumed as a single
+  instance provided by the host. Required for libraries that must not be
+  duplicated, like React.
+  - `singleton` — allow only one instance.
+  - `requiredVersion` — allowed version range (semver).
+  - `strictVersion` — escalate a version mismatch to a **build failure**
+    instead of a runtime fallback.
+  - `shareScope` — the named share scope this dependency belongs to
+    (default `"default"`). Used for gradual upgrades / domain isolation.
+
+A remote is a container, not an app, so build it in core mode:
+
+```sh
+zntc --bundle src/index.ts --outdir dist --format=iife
+```
+
+Output: the container (remoteEntry) + `mf-manifest.json` +
+content-hashed chunks.
+
+### Host (consumes a remote)
+
+```json
+{
+  "mf": {
+    "name": "host_app",
+    "remotes": { "remote_app": "remote_app@https://cdn.example.com/mf-manifest.json" },
+    "shared": { "react": { "singleton": true, "requiredVersion": "^19" } }
+  }
+}
+```
+
+Host code can use both static and dynamic imports:
+
+```ts
+import Button from 'remote_app/Button';        // static
+const m = await import('remote_app/Button');   // dynamic
+```
+
+`shareStrategy` (`"version-first"` default | `"loaded-first"`) controls
+the shared negotiation order.
+
+## How it works
+
+- **Container / manifest** — the remote emits a container and a
+  `mf-manifest.json` per the standard contract. The host consumes them
+  via the standard runtime's `init`/`loadRemote` (no ZNTC runtime
+  dependency).
+- **Shared dependencies** — packages declared in `shared` are not
+  bundled; they use the single instance the host registers. Host and
+  remote therefore share the same React instance and hooks work.
+  Multiple named scopes can be used simultaneously.
+- **Build-time contract verification** — ZNTC's differentiator. The host
+  build reads the consumed remote's `mf-manifest.json` and catches
+  contract violations **at build time, not at runtime**:
+  - If a `remote/<subpath>` the host imports is missing from the
+    consumed remote's manifest, the host build fails.
+  - If a shared dependency's version/singleton does not match the host's
+    requirement, a warning (or a build failure under `strictVersion`).
+  - If manifest integrity (digest/signature) is tampered or stale, the
+    build fails.
+- **Runtime guard** — cases that cannot be verified at build time
+  (unreachable remote, runtime-registered remotes) degrade gracefully at
+  runtime so the shell survives.
+- **CSS** — when an exposed module imports CSS, the CSS assets are
+  recorded in the manifest so the standard runtime preloads the
+  stylesheet alongside.
+
+## Limitations
+
+- **Web only** — React Native is not supported yet.
+- **Runtime-registered remotes** — remotes that host code registers **at
+  runtime** via the standard runtime's `registerRemotes()` /
+  `init({ remotes })` do not exist at build time, so their contract
+  cannot be build-verified. They still work (delegated to the standard
+  runtime) and the runtime guard covers that blind spot. Build
+  verification targets remotes identified via config `remotes` and the
+  static/dynamic imports scanned at build time.
+- **Remote manifest fetch** — build-time contract verification targets
+  locally resolvable manifests. A manifest only reachable over the
+  network is not verified at build time and is left to the runtime
+  guard.
+- **No type generation** — ZNTC does not auto-generate `.d.ts` for a
+  remote. Consumers use their own type declarations (ZNTC's
+  differentiator is build-time contract verification, not type-hint
+  downloading).
+
+For a minimal working example, see
+[`examples/module-federation`](https://github.com/ohah/zntc/tree/main/examples/module-federation)
+— a ZNTC remote consumed by a standard `@module-federation/runtime`
+host, verifying a single shared React instance.

--- a/documents/src/content/docs/guides/module-federation.md
+++ b/documents/src/content/docs/guides/module-federation.md
@@ -1,0 +1,112 @@
+---
+title: Module Federation
+description: ZNTC 의 Module Federation — 독립 빌드된 앱끼리 모듈을 노출·소비하고, 표준 런타임과 interop 하며, 계약을 빌드 시점에 검증합니다.
+---
+
+Module Federation 은 따로 빌드·배포된 앱들이 런타임에 서로의 모듈을
+가져다 쓰게 하는 방식입니다. 모듈을 내보내는 쪽이 **remote**, 가져다
+쓰는 쪽이 **host** 입니다.
+
+ZNTC 는 host 런타임을 자체 구현하지 않고 **표준
+`@module-federation/runtime` 계약을 타깃**합니다. 따라서 ZNTC 로 만든
+remote 를 webpack 5 / rspack 으로 만든 host 가 그대로 소비할 수 있고,
+반대로 ZNTC host 가 표준 remote 를 소비할 수도 있습니다(웹).
+
+## 설정
+
+`zntc.config`(`.ts`/`.js`/`.json`)의 `mf` 블록으로 선언합니다.
+
+### Remote (모듈을 노출)
+
+```json
+{
+  "mf": {
+    "name": "remote_app",
+    "exposes": { "./Button": "./src/Button.tsx" },
+    "shared": { "react": { "singleton": true, "requiredVersion": "^19" } }
+  }
+}
+```
+
+- `name` — remote 식별자(host 가 이 이름으로 참조).
+- `exposes` — 외부에 노출할 모듈. `{ 공개경로: 소스경로 }`.
+- `shared` — 번들에 포함하지 않고 host 가 제공하는 단일 인스턴스를
+  공유할 의존성. React 처럼 인스턴스가 갈리면 안 되는 라이브러리에 필수.
+  - `singleton` — 한 인스턴스만 허용.
+  - `requiredVersion` — 허용 버전 범위(semver).
+  - `strictVersion` — 버전 불일치 시 런타임 폴백 대신 **빌드 실패**로 격상.
+  - `shareScope` — 이 의존성이 속할 named share scope(기본 `"default"`).
+    점진적 업그레이드·도메인 격리에 사용.
+
+remote 빌드는 앱이 아니라 컨테이너이므로 core 모드로 빌드합니다:
+
+```sh
+zntc --bundle src/index.ts --outdir dist --format=iife
+```
+
+산출물: 컨테이너(remoteEntry) + `mf-manifest.json` + content-hash 청크.
+
+### Host (remote 를 소비)
+
+```json
+{
+  "mf": {
+    "name": "host_app",
+    "remotes": { "remote_app": "remote_app@https://cdn.example.com/mf-manifest.json" },
+    "shared": { "react": { "singleton": true, "requiredVersion": "^19" } }
+  }
+}
+```
+
+host 코드에서는 정적·동적 import 둘 다 됩니다:
+
+```ts
+import Button from 'remote_app/Button';        // 정적
+const m = await import('remote_app/Button');   // 동적
+```
+
+`shareStrategy`(`"version-first"` 기본 | `"loaded-first"`)로 공유 협상
+순서를 정할 수 있습니다.
+
+## 동작 원리
+
+- **컨테이너 / 매니페스트** — remote 는 표준 계약대로 컨테이너와
+  `mf-manifest.json` 을 emit 합니다. host 는 표준 런타임의
+  `init`/`loadRemote` 로 이를 소비합니다(ZNTC 런타임 의존 없음).
+- **공유 의존성** — `shared` 로 선언한 패키지는 번들에 포함되지 않고,
+  host 가 등록한 단일 인스턴스를 가져다 씁니다. 그래서 host 와 remote 가
+  같은 React 인스턴스를 공유해 hooks 가 정상 동작합니다. named scope
+  여러 개를 동시에 쓸 수 있습니다.
+- **빌드타임 계약 검증** — ZNTC 의 차별점. host 빌드가 소비하는
+  remote 의 `mf-manifest.json` 을 읽어, 계약 위반을 **런타임이 아니라
+  빌드에서** 잡습니다:
+  - host 가 import 하는 `remote/<subpath>` 가 소비 대상 remote 의
+    매니페스트에 없으면 host 빌드 실패.
+  - 공유 의존성의 버전/싱글톤이 host 요구와 불일치하면 경고(또는
+    `strictVersion` 시 빌드 실패).
+  - 매니페스트 무결성(다이제스트/서명)이 변조·stale 이면 빌드 실패.
+- **런타임 가드** — 빌드 시점에 검증할 수 없는 경우(도달 불가 remote,
+  런타임 동적 등록 등)는 런타임에서 graceful 폴백으로 셸이 살아남습니다.
+- **CSS** — 노출 모듈이 CSS 를 import 하면 매니페스트에 CSS 자산이
+  기재돼 표준 런타임이 stylesheet 를 함께 preload 합니다.
+
+## 한계
+
+- **웹 전용** — React Native 는 아직 지원하지 않습니다.
+- **런타임 동적 등록** — host 코드가 표준 런타임의
+  `registerRemotes()` / `init({ remotes })` 로 **런타임에** 등록하는
+  remote 는 빌드 시점에 존재 자체가 미지라 계약을 빌드검증할 수
+  없습니다. 동작은 표준 런타임 위임으로 정상이며, 그 사각은 런타임
+  가드가 메웁니다. 빌드검증은 config `remotes` 및 빌드 시 스캔되는
+  정적/동적 import 로 식별되는 remote 가 대상입니다.
+- **원격 매니페스트 fetch** — 빌드타임 계약 검증은 로컬에서 해석
+  가능한 매니페스트가 대상입니다. 네트워크로만 받을 수 있는 매니페스트는
+  빌드 시점에 검증하지 않고 런타임 가드에 맡깁니다.
+- **타입 자동 생성 없음** — remote 의 `.d.ts` 를 자동 생성하지
+  않습니다. 소비 측은 자체 타입 선언을 사용합니다(ZNTC 의 차별점은
+  타입 힌트 다운로드가 아니라 빌드타임 계약 검증입니다).
+
+동작하는 최소 예제는
+[`examples/module-federation`](https://github.com/ohah/zntc/tree/main/examples/module-federation)
+을 참고하세요 — ZNTC remote 를 표준 `@module-federation/runtime` host 가
+소비하고 React 단일 인스턴스 공유를 검증합니다.


### PR DESCRIPTION
## 무엇

발행 `@zntc/core` 에서 MF 가 실제 동작하게 된 뒤(PR-plumb #3483 · 예제 PR-A #3485) **사용자 관점 가이드**를 docs 사이트에 추가합니다. `feedback` 규칙대로 **지원 기능 + 동작 원리 + 한계만, 내부 참조(PR#/이슈/D·P 코드/RFC §/소스 파일) 0**.

- `documents/src/content/docs/guides/module-federation.md` + `en/` 미러 (의미·구조 1:1)
- `astro.config.mjs` 번들러 사이드바 등록
- 내용: `mf` config(name/exposes/remotes/shared{singleton·requiredVersion·strictVersion·shareScope}/shareScope/shareStrategy) · remote/host 셋업 · 표준 `@module-federation/runtime` interop · **빌드타임 계약 검증**(차별점, 사용자 표현) · 한계(웹 전용·런타임 동적등록 미검증·원격 매니페스트 fetch·타입 자동생성 없음)
- 동작 예제는 `examples/module-federation`(PR-A) GitHub 링크

## 검증

- `documents` astro build **0** (519p, 내부 링크 전부 유효)
- `/simplify` 3-에이전트: **user-perspective 규칙 준수(내부 참조 0)·ko↔en 정확 동기 통과**. 반영:
  - 누락 expose → 빌드실패 문장을 **host-측 매니페스트 검증**으로 명확화 (remote 자체 미해결 expose 는 warn 이므로 reader 오해 방지)
  - 예제 포인터 **GitHub 링크화** (sibling 가이드 관례 — 발행 사이트 reader 가 클릭 가능)

> `astro.config.mjs` diff 가 큰 것은 pre-push `oxfmt` 훅이 파일 전체를 정규 포맷으로 reflow 했기 때문입니다(사이드바 1항목 추가가 본질). 훅이 강제하므로 불가피.

## MF 사용자 자산 분해 — 완결

| 단위 | 상태 |
|---|---|
| PR-plumb (#3483) — 발행 패키지 mf 도달 | ✅ |
| PR-A (#3485) — 실행 예제앱 | ✅ |
| **PR-B (이 PR) — 사용자 가이드 ko+en** | ✅ |

남은 MF 작업은 `#25 ④`(MF seam 을 번들러 코어 단일 적용점으로 — RN-독립이 아닌 코어 리팩터, init fallible + ResolveCache 소유, 단독 PR)뿐입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)