### PR TITLE
refactor(mf): MF seam 을 옵션 레이어→번들러 단일 적용점 — ④ (#3318)

### DIFF
--- a/packages/core/src/napi/options.zig
+++ b/packages/core/src/napi/options.zig
@@ -254,14 +254,11 @@ pub fn freeOptionsTypedSlices(opts: *const BundleOptions) void {
     if (opts.fallback.len > 0) native_alloc.free(opts.fallback);
     if (opts.globals.len > 0) native_alloc.free(opts.globals);
     if (opts.loader_overrides.len > 0) native_alloc.free(opts.loader_overrides);
-    // PR-plumb (#3318): mf 있을 때만(비-MF 무영향). opts.external=combined
-    // (ext_c), opts.globals=combined(gl_c, 위 줄에서 free). exts/옛 entries_buf
-    // 는 owned_string_arrays/파싱블록이 별도 소유 → 여기서 안 건드림(이중
-    // 해제 없음). mfb 의 dup 문자열은 freeMfBundle 단일 소스(CLI 와 공유).
-    if (opts.mf) |mfb| {
-        native_alloc.free(opts.external); // combined 컨테이너(원소 borrow)
-        bundler_mod.mf_options.freeMfBundle(native_alloc, mfb);
-    }
+    // #3318: mfb 의 dup 문자열 해제(freeMfBundle 단일 소스, CLI 와 공유).
+    // ④ 로 seam 은 번들러가 하므로 NAPI 는 combined external/globals 를
+    // 더 이상 할당 안 함 — opts.external/globals 는 기존 owned_string_
+    // arrays/entries_buf 경로가 소유(여기 미해제, 이중해제 없음).
+    if (opts.mf) |mfb| bundler_mod.mf_options.freeMfBundle(native_alloc, mfb);
     if (opts.runtime_polyfills) |plan| {
         if (plan.candidates.len > 0) native_alloc.free(plan.candidates);
         if (plan.entry_modules.len > 0) native_alloc.free(plan.entry_modules);
@@ -705,74 +702,28 @@ pub fn parseBuildOptions(
         if (!trackArr(owned_string_arrays, arr)) return null;
     }
 
-    // RN block_list 머지를 여기서 선계산(hoist) — return literal 안에 두면
-    // mf 블록 *이후* fallible(concat OOM/trackArr) 가 생겨 mf 의 mfb/
-    // combined 가 null 경로에서 leak. 위로 끌어 mf 블록 이후 무-fallible
-    // 보장(merged 는 trackArr 로 owned_string_arrays 소유 → null 경로도 정리).
-    const block_list_final: []const []const u8 = blk: {
-        const user = block_list orelse &.{};
-        if (platform == .react_native) {
-            const merged = std.mem.concat(native_alloc, []const u8, &.{ bundler_mod.RN_DEFAULT_BLOCK_LIST, user }) catch return null;
-            if (!trackArr(owned_string_arrays, merged)) return null;
-            break :blk merged;
-        }
-        break :blk user;
-    };
-
-    // PR-plumb (#3318): Module Federation. `mfRaw`(index.ts =
-    // JSON.stringify(config.mf))를 JSON string 으로 받아 **CLI 와 동일
-    // 단일 소스**(`mf_options`; src/cli/options.zig applyZntcConfigJson 의
-    // arena+parseFromSliceLeaky 선례와 동형)로 변환·seam 유도. 배경/
-    // silent-drift 봉인 근거 = `mf_options.zig` 모듈 doc. mf 없으면 블록
-    // 미진입 → external/globals/.mf 기존 그대로(비-MF byte 동일 무회귀).
-    //
-    // 메모리: 이 파일은 `catch return null`(에러 아님)이라 errdefer 무효
-    // 이고, 호출자는 null 시 freeOptionsTypedSlices 를 안 거친다 → 블록
-    // 내 실패는 **명시 free 로 롤백**해야 leak 0. 성공 시 mfb/combined 는
-    // BundleOptions 로 넘어가 freeOptionsTypedSlices 가 mf-게이트로 해제
-    // (combined 컨테이너만; 원소 borrow=mfb/static, exts/옛globals 는 각
-    // owned_string_arrays/아래 free 소유). 블록 *이후* fallible 가 없도록
-    // RN block_list 머지는 위에서 const 로 선계산(literal 내 잔존 X).
-    const MfParsed = struct {
-        mfb: bundler_mod.mf_options.MfBundleConfig,
-        external: []const []const u8,
-        globals: []const bundler_mod.types.GlobalEntry,
-    };
-    const mf_parsed: ?MfParsed = blk: {
+    // #3318: Module Federation. `mfRaw`(index.ts = JSON.stringify
+    // (config.mf))를 JSON string 으로 받아 **CLI 와 동일 단일 소스**
+    // (`mf_options`, applyZntcConfigJson arena+parseFromSliceLeaky 동형)로
+    // **변환만** 한다. shared/remote external+글로벌 seam 유도는 옵션
+    // 레이어가 아니라 **번들러 단일 지점(④, bundler.bundle())** — 여기선
+    // BundleOptions.mf 만 세팅(CLI 와 대칭). mf 없으면 .mf=null(무회귀).
+    // 메모리: `catch return null`(errdefer 무효)·호출자 null 시
+    // freeOptionsTypedSlices 미실행. fromDto 실패는 내부 errdefer 가
+    // 부분 mfb 해제(롤백 불요). ④ 로 seam 이 제거돼 leak window 는
+    // 크게 줄었으나 *제로는 아님*: mfb 바인딩 *후* return literal 의
+    // RN block_list `std.mem.concat/trackArr` 가 OOM 으로 `return null`
+    // 하면 mfb 가 누수(RN+OOM 한정 — 이 파일 모든 null-path 가 동일
+    // 패턴, 본 PR 범위 밖 파일전반 한계). 성공 mfb 는 BundleOptions.mf
+    // 로 넘어가 freeOptionsTypedSlices 가 freeMfBundle.
+    const mf_cfg: ?bundler_mod.mf_options.MfBundleConfig = blk: {
         const raw = getObjectString(env, opts_obj, "mfRaw", native_alloc) orelse break :blk null;
         defer native_alloc.free(raw);
         var mf_arena = std.heap.ArenaAllocator.init(native_alloc);
         defer mf_arena.deinit();
         const dto = std.json.parseFromSliceLeaky(zntc_lib.transpile.MfConfigDto, mf_arena.allocator(), raw, .{ .ignore_unknown_fields = true }) catch return null;
         zntc_lib.transpile.validateMf(&dto) catch return null;
-        // fromDto 실패 = 내부 errdefer 가 부분 mfb 해제(여기 롤백 불요).
-        const mfb = bundler_mod.mf_options.fromDto(native_alloc, &dto) catch return null;
-        // 이후 실패는 mfb(+필요 시 ext_c) 명시 free 후 return null.
-        const se = bundler_mod.mf_options.seamExternals(native_alloc, mfb) catch {
-            bundler_mod.mf_options.freeMfBundle(native_alloc, mfb);
-            return null;
-        };
-        defer native_alloc.free(se); // 컨테이너만(원소 borrow)
-        const sg = bundler_mod.mf_options.seamGlobals(native_alloc, mfb) catch {
-            bundler_mod.mf_options.freeMfBundle(native_alloc, mfb);
-            return null;
-        };
-        defer native_alloc.free(sg);
-        const base_ext: []const []const u8 = external orelse &.{};
-        const ext_c = std.mem.concat(native_alloc, []const u8, &.{ base_ext, se }) catch {
-            bundler_mod.mf_options.freeMfBundle(native_alloc, mfb);
-            return null;
-        };
-        const gl_c = std.mem.concat(native_alloc, bundler_mod.types.GlobalEntry, &.{ globals, sg }) catch {
-            native_alloc.free(ext_c);
-            bundler_mod.mf_options.freeMfBundle(native_alloc, mfb);
-            return null;
-        };
-        // 옛 globals(entries_buf)는 어디서도 추적 안 됨 → concat 이 복사한
-        // *후* 해제(cleanup 은 combined gl_c=opts.globals 만; exts 는
-        // owned_string_arrays 소유라 미해제).
-        if (globals.len > 0) native_alloc.free(globals);
-        break :blk .{ .mfb = mfb, .external = ext_c, .globals = gl_c };
+        break :blk bundler_mod.mf_options.fromDto(native_alloc, &dto) catch return null;
     };
 
     const minify = getObjectBool(env, opts_obj, "minify", false);
@@ -780,21 +731,29 @@ pub fn parseBuildOptions(
         .entry_points = entries,
         .format = format,
         .platform = platform,
-        .external = if (mf_parsed) |m| m.external else (external orelse &.{}),
-        .mf = if (mf_parsed) |m| m.mfb else null,
+        .external = external orelse &.{},
+        .mf = mf_cfg,
         .debug = debug_categories orelse &.{},
         .define = define_entries,
         .alias = alias_entries,
         .ts_paths = ts_path_entries,
         .fallback = fallback_entries,
-        .block_list = block_list_final,
+        .block_list = blk: {
+            const user = block_list orelse &.{};
+            if (platform == .react_native) {
+                const merged = std.mem.concat(native_alloc, []const u8, &.{ bundler_mod.RN_DEFAULT_BLOCK_LIST, user }) catch return null;
+                if (!trackArr(owned_string_arrays, merged)) return null;
+                break :blk merged;
+            }
+            break :blk user;
+        },
         .minify_whitespace = if (minify) true else getObjectBool(env, opts_obj, "minifyWhitespace", false),
         .minify_identifiers = if (minify) true else getObjectBool(env, opts_obj, "minifyIdentifiers", false),
         .minify_syntax = if (minify) true else getObjectBool(env, opts_obj, "minifySyntax", false),
         // mf.exposes(remote) → expose=lazy 청크라 splitting 강제(CLI
         // options.zig 의 `if (mfb.exposes.len>0) opts.splitting=true` 미러).
         .code_splitting = getObjectBool(env, opts_obj, "splitting", false) or
-            (if (mf_parsed) |m| m.mfb.exposes.len > 0 else false),
+            (if (mf_cfg) |m| m.exposes.len > 0 else false),
         .inline_dynamic_imports = getObjectBool(env, opts_obj, "inlineDynamicImports", false),
         .min_chunk_size = @as(usize, getObjectUint32(env, opts_obj, "minChunkSize", 0)),
         .sourcemap = .{
@@ -823,7 +782,7 @@ pub fn parseBuildOptions(
         .intro_js = intro_js,
         .outro_js = outro_js,
         .global_name = global_name,
-        .globals = if (mf_parsed) |m| m.globals else globals,
+        .globals = globals,
         .public_path = public_path orelse "",
         .entry_names = entry_names orelse "[name]",
         .chunk_names = chunk_names orelse "[name]-[hash]",

--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -602,6 +602,17 @@ pub const Bundler = struct {
     resolve_cache: ResolveCache,
     /// 외부 소유 ResolveCache 포인터. non-null이면 이것을 사용하고 resolve_cache 필드는 무시.
     resolve_cache_ref: ?*ResolveCache = null,
+    /// #3318 ④: MF seam(shared/remote external + 글로벌)을 옵션 레이어가
+    /// 아닌 번들러 단일 지점(bundle() 초입)에서 `opts.mf` 로부터 유도한
+    /// combined 버퍼. self.allocator 소유 → **deinit 가 유일 free 지점**
+    /// (필드 set 이후 errdefer 잔존 0 → bundle() 후속 try 실패+deinit
+    /// 이중해제 없음). 원소는 borrow(opts.mf/static). mf 없으면 null.
+    /// watch(persistent ResolveCache): 매 bundle() 가 resolve *전*
+    /// setExternalPatterns 를 **무조건** 재주입(mf=sx / non-mf=options.
+    /// external) → deinit 가 sx 를 free 해도 persistent cache 가 freed
+    /// 포인터를 parking 하지 않음(mf→non-mf 전환·조기 resolve 안전).
+    mf_eff_external: ?[]const []const u8 = null,
+    mf_eff_globals: ?[]const types.GlobalEntry = null,
 
     /// platform=react-native → Hermes unsupported matrix로 덮어쓰기.
     /// 사용자가 --target으로 지정한 값은 무시된다 (Hermes는 ES 버전으로 표현 불가능한
@@ -661,6 +672,9 @@ pub const Bundler = struct {
         if (self.resolve_cache_ref == null) {
             self.resolve_cache.deinit();
         }
+        // #3318 ④ combined seam 버퍼(컨테이너만; 원소 borrow).
+        if (self.mf_eff_external) |x| self.allocator.free(x);
+        if (self.mf_eff_globals) |x| self.allocator.free(x);
     }
 
     /// BundleOptions → TransformOptions base 변환 (#1961 PR 1f). graph 와 emitter
@@ -973,6 +987,40 @@ pub const Bundler = struct {
         // remote seam 합성 시 append) → emitHostInit async preload-gate.
         var mf_static_remotes: @import("federation.zig").MfStaticRemotes = .{};
         defer mf_static_remotes.deinit(self.allocator);
+
+        // #3318 ④: MF seam 단일 적용점(옵션 레이어가 아닌 번들러 1곳).
+        // 소유/수명·watch 불변식은 `mf_eff_external` 필드 doc, 주입이
+        // resolve 전이라 안전한 근거는 setExternalPatterns doc 참조.
+        // 실패 시 명시 free(잔존 errdefer 0 → 소유권이 필드로 이전된
+        // *뒤* bundle() 후속 try 실패해도 이중해제 없음). mf 없으면 미진입.
+        if (self.options.mf) |mfb| {
+            const mfo = @import("mf_options.zig");
+            const se = try mfo.seamExternals(self.allocator, mfb);
+            const sx = std.mem.concat(self.allocator, []const u8, &.{ self.options.external, se }) catch |e| {
+                self.allocator.free(se);
+                return e;
+            };
+            self.allocator.free(se); // 이후 live = sx
+            const sg = mfo.seamGlobals(self.allocator, mfb) catch |e| {
+                self.allocator.free(sx);
+                return e;
+            };
+            const gx = std.mem.concat(self.allocator, types.GlobalEntry, &.{ self.options.globals, sg }) catch |e| {
+                self.allocator.free(sg);
+                self.allocator.free(sx);
+                return e;
+            };
+            self.allocator.free(sg);
+            // 소유권을 필드로 이전 — 이후 sx/gx free 는 오직 deinit.
+            self.mf_eff_external = sx;
+            self.mf_eff_globals = gx;
+            self.options.globals = gx; // emit/linker 가 self.options.globals 소비
+        }
+        // external_patterns 는 매 bundle() **무조건** 재주입(resolve 전):
+        // mf 면 combined(sx), 아니면 self.options.external. persistent
+        // ResolveCache(watch)가 이전 빌드의 freed sx 를 parking 하지
+        // 않게 — mf→non-mf 전환·조기 resolve 에도 dangling 0.
+        self.getResolveCache().setExternalPatterns(self.mf_eff_external orelse self.options.external);
 
         // 1. 모듈 그래프 구축
         var graph_scope = profile.begin(.graph);

--- a/src/bundler/federation.zig
+++ b/src/bundler/federation.zig
@@ -45,7 +45,7 @@ pub const MfStaticRemotes = struct {
 };
 
 /// P1-6 host: 스펙 런타임 패키지(자체 재구현 금지=D1) 및 그 글로벌 seam.
-/// **단일 소스** — applyMfRemotesSeam(cli/options.zig)이 external+글로벌로
+/// **단일 소스** — mf_options.seamGlobals/번들러 ④ 가 external+글로벌로
 /// 걸고 emitHostInit(federation_emit.zig)이 그 글로벌로 init/loadRemote
 /// 배선. 두 곳이 반드시 일치해야 동작(mfSharedGlobalName 단일소스 선례).
 pub const MF_RUNTIME_PKG = "@module-federation/runtime";

--- a/src/bundler/federation_emit.zig
+++ b/src/bundler/federation_emit.zig
@@ -93,7 +93,7 @@ fn isRemoteSpec(spec: []const u8, mf: *const types.MfBundleConfig) bool {
 /// remotes})`)를 prepend + 런타임 가드(`__mfGuardedLoad`, P3-5) 정의 +
 /// 원격 동적 `import("remote/x")` 를 `globalThis.__mfGuardedLoad(
 /// "remote/x")` 로 치환(가드가 내부에서 `loadRemote` 호출 + 거부 폴백).
-/// runtime 은 applyMfRemotesSeam 이 external+글로벌(__mf_runtime) 처리 →
+/// runtime 은 번들러 ④(mf_options.seam*)가 external+글로벌(__mf_runtime) 처리 →
 /// host 환경이 그 글로벌로 스펙 런타임 제공(P1-2/P1-3 글로벌-seam 모델
 /// 일관, iife/umd/amd valid). 반환 = 새 owned 문자열(caller 가 기존 src
 /// free). 정적 `import X from "remote/x"` 는 비-목표(async 강등 — 후속).

--- a/src/bundler/resolve_cache.zig
+++ b/src/bundler/resolve_cache.zig
@@ -765,6 +765,16 @@ pub const ResolveCache = struct {
 
     /// specifier가 external인지 판별.
     /// exact match + `*` 글롭 매칭 (D069).
+    /// external 패턴 슬라이스 교체(#3318 ④). `external_patterns` 는
+    /// init 시 borrow 저장만 되고 실제 소비는 `isExternal`(resolve 단계
+    /// lazy)이라, resolve 시작 *전* 에 교체하면 init 무변경으로 무손실.
+    /// 슬라이스는 여전히 **borrow**(소유모델 불변) — 호출자(Bundler)가
+    /// combined 버퍼 소유·해제. MF seam 을 옵션 레이어가 아닌 번들러
+    /// 단일 지점에서 주입하는 데 사용.
+    pub fn setExternalPatterns(self: *ResolveCache, patterns: []const []const u8) void {
+        self.external_patterns = patterns;
+    }
+
     pub fn isExternal(self: *const ResolveCache, specifier: []const u8) bool {
         // node: 프리픽스는 platform과 무관하게 항상 external
         if (std.mem.startsWith(u8, specifier, "node:")) return true;

--- a/src/cli/options.zig
+++ b/src/cli/options.zig
@@ -407,27 +407,16 @@ fn applyZntcConfigJson(opts: *CliOptions, allocator: std.mem.Allocator) !void {
     if (dto.mf) |*mf| {
         try lib.transpile.validateMf(mf);
         // 해석본을 allocator(=CliOptions 수명) 으로 deep-dupe. dto 는 arena
-        // (이 함수 종료 시 해제) 라 borrow 불가. 변환·seam 은 mf_options
-        // 단일 소스(NAPI 와 공용 — silent drift 봉인).
+        // (이 함수 종료 시 해제) 라 borrow 불가. 변환은 mf_options 단일
+        // 소스. **seam(shared/remote external+글로벌) 유도는 옵션 레이어가
+        // 아니라 번들러 단일 지점(#3318 ④, bundler.bundle())** — CLI·NAPI
+        // 둘 다 opts.mf 만 세팅.
         opts.mf = try mf_options.fromDto(allocator, mf);
-        // P1-2/P1-6: shared/remotes 글로벌 seam 자동 파생. shared pkg +
-        // remote key + `@module-federation/runtime` 를 external(번들 제외 —
-        // shareScope/host 에서 옴) + GlobalEntry(IIFE/UMD/AMD 글로벌-파라
-        // 미터 seam) 로. seamExternals/seamGlobals 순수 유도 → opts list 에
-        // appendSlice(원소 borrow=opts.mf 소유, 컨테이너는 임시→free).
-        // 산출 순서·내용은 기존 applyMf*Seam 과 byte 동일(무회귀).
         if (opts.mf) |mfb| {
-            const seam_ext = try mf_options.seamExternals(allocator, mfb);
-            defer allocator.free(seam_ext); // 컨테이너만(원소는 mfb/static)
-            try opts.external_list.appendSlice(allocator, seam_ext);
-            const seam_gl = try mf_options.seamGlobals(allocator, mfb);
-            defer allocator.free(seam_gl);
-            try opts.globals_list.appendSlice(allocator, seam_gl);
-            // P1-3 (#3385): exposes 있는 mf = remote → container/exposes 는
-            // reg_split 다중-청크(chunk.zig 가 expose→lazy 청크) 위에 얹으므로
-            // splitting 필수(부트스트랩은 format=iife/umd/amd 필요 — 없으면
-            // wrapContainer fail-fast). exposes 없는 host(shared/remotes-only)
-            // 는 강제 안 함 — P1-2 단일파일 seam 경로 불변.
+            // exposes 있는 mf = remote → container/exposes 는 reg_split
+            // 다중-청크 위에 얹으므로 splitting 필수(부트스트랩 format=
+            // iife/umd/amd 없으면 wrapContainer fail-fast). exposes 없는
+            // host(shared/remotes-only)는 강제 안 함(단일파일 seam 불변).
             if (mfb.exposes.len > 0) opts.splitting = true;
         }
     }


### PR DESCRIPTION
## 무엇

PR-plumb 의 `mf_options` 단일소스를 디딤돌로, MF seam(shared/remote → external + 글로벌) 유도를 **`cli/options` + `napi/options` 두 곳**에서 빼고 **번들러 한 곳**(`bundle()` 초입, resolve 전)으로 일원화. CLI·NAPI 는 이제 `opts.mf` 만 세팅.

## 설계 (무손실 · 최소 ripple)

애초 ④ 를 "init→`!Bundler` + ResolveCache 소유모델 변경(10~20 호출부 ripple)" 으로 우려했으나 — 조사 결과 `external_patterns` 는 `init` 에서 **borrow 저장만** 되고 실제 소비는 `isExternal`(resolve 단계 lazy). 따라서 **init 시그니처/소유모델 무변경**으로 resolve 전 교체만으로 충분:

- `resolve_cache.zig`: `setExternalPatterns`(borrow 슬라이스 교체, 소유모델 불변 — Bundler 가 combined 소유)
- `bundler.zig`: `mf_eff_external/globals` 필드 + `bundle()` 초입 단일 적용점 + `deinit` free. `external_patterns` 는 매 `bundle()` **무조건** 재주입(mf=combined / non-mf=`options.external`) → watch persistent cache dangling 원천 차단
- `cli/options.zig`·`napi/options.zig`: seam 유도 전부 제거. NAPI 의 leak-prone combined-concat·block_list hoist·combined-free 동반 소거(④ 부수 이득). CLI splitting 강제만 유지
- `federation*.zig`: 죽은 `applyMf*Seam` doc 참조 정정

## 무손실 검증

seam 을 옵션 레이어 → 번들러로 **이동**(순서·내용 동일) → CLI native byte-behavior · JS-CLI/NAPI · 브라우저 전부 보존.

- `zig build test/wasm-bundler/install/napi` **0**
- MF 통합 **28·0** (`mf-container-emit` CLI native + JS-CLI/NAPI, `mf-runtime-interop-smoke` CLI native)
- MF e2e **9·0** (실 Chromium + 실 rspack/enhanced)
- 예제 `bun run demo` OK (JS-CLI→NAPI→번들러 ④ 전 경로)

## /simplify 가 잡은 실 결함 → 수정

3-에이전트 효율 리뷰가 **도달 가능한 double-free** 포착: 초안의 `errdefer free(sx)` 가 ④ 블록 성공 후에도 `bundle()` 끝까지 armed → 후속 graph/link/emit `try` 실패(정상 사용자 에러경로) 시 errdefer 가 `sx` free + caller `deinit` 가 재-free.

→ **수정**: errdefer 제거, 블록 내 각 실패점 명시 `catch`+free(소유권 필드 이전 *후* free 는 `deinit` 단일). + watch 잠재 UAF(non-mf-after-mf on persistent cache, 현재 미도달이나 fragile) → `setExternalPatterns` **무조건 재주입**으로 locally-safe 화. + ④ 근거 주석 3중복 트림(필드 doc=수명/watch, setExternalPatterns doc=lazy-consume 안전). + NAPI 잔존 leak(RN+OOM block_list concat — 파일전반 null-path 패턴) 거짓-"소거" 주장 → 정직 명시. + 죽은 doc 참조 정정.

## 의미

MF 의 마지막 작업. seam 이 이제 **번들러 단일 지점**(`mf_options` 순수함수)에서만 — CLI/NAPI 변환 레이어는 `opts.mf` 만. 향후 mf 확장은 한 곳. 동작 무변경(순수 내부 정합 + leak-prone NAPI 코드 소거).

## Zig 초보자 메모

`errdefer` 는 "이 지점 이후 함수가 **에러**로 빠져나가면 실행". 문제는 errdefer 가 함수 전체 스코프라, 소유권이 다른 변수(`self.mf_eff_external`)로 넘어간 *뒤* 에도 살아 있어 나중 에러 때 또 free → 이미 deinit 가 free 할 걸 두 번. 해법은 errdefer 를 안 쓰고 각 실패 분기에서 손으로 정리(소유권 이전 시점 = errdefer 책임 종료를 명시적으로).

🤖 Generated with [Claude Code](https://claude.com/claude-code)