### PR TITLE
docs(roadmap): Module Federation 지원 상태 정정 (❌ → 🟡)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -244,7 +244,7 @@ esbuild / rolldown / rspack 기준으로 ZNTC에 빠진 기능 목록.
 | ~~**external phantom**~~     | ✅     | ❌      | ✅                | ❌             | ✅  | external 도 graph 1급 노드 — Rollup `getModuleInfo("react").isExternal` 동작     |
 | **innerGraph**               | L      | ❌      | ✅                | ✅             | 🟡  | 변수 할당 추적으로 정밀 DCE — straight-line dead store 일부 완료                 |
 | **Persistent caching**       | XL     | ❌      | ❌                | ✅             | ❌  | 디스크 캐시, 콜드 리빌드 250%↑                                                   |
-| **Module Federation**        | XL     | ❌      | ❌                | ✅             | ❌  | 마이크로프론트엔드 코드/리소스 공유                                              |
+| **Module Federation**        | XL     | ❌      | ❌                | ✅             | 🟡  | 마이크로프론트엔드 코드/리소스 공유 — RFC #3318 P1 진행 중 (컨테이너 init / named share scope 다중 / strictVersion fail-fast / CSS·assets manifest 게시 구현, 런타임 동적 remote 빌드검증은 설계 한계). [RFC](./RFC_MODULE_FEDERATION.md) |
 | **Lazy compilation**         | XL     | ❌      | ❌                | ✅             | ❌  | 온디맨드 모듈 컴파일 (dev 시작 가속)                                             |
 | ~~**Stage 3 decorators**~~   | ✅     | ❌      | ✅                | ✅             | ✅  | TC39 Stage 3 데코레이터 (legacy + Stage 3)                                       |
 | **mangleProps**              | XL     | ✅      | ❌                | ❌             | ❌  | cross-module 프로퍼티 난독화                                                     |
@@ -285,6 +285,7 @@ esbuild / rolldown / rspack 기준으로 ZNTC에 빠진 기능 목록.
   mangleProps (1주+) — cross-module 프로퍼티 추적
   Stage 3 decorators ✅ 완료 — TC39 Stage 3 데코레이터 (legacy + Stage 3, MobX 6 호환)
   Module Concatenation 고도화 — rspack/rolldown 수준 scope hoisting
+  Module Federation 🟡 RFC #3318 P1 진행 중 — 컨테이너 init/named share scope/strictVersion/manifest 게시 (런타임 동적 remote 빌드검증은 설계 한계)
   manualChunks ✅ 완료 — Rollup 호환 (record + function + meta API 13/14 필드)
   innerGraph 🟡 부분 완료 — straight-line local dead store 제거 완료. 다음: reference 기반 일반 dead store/control-flow 확장
   Rollup ModuleInfo Phase B (#1880) — plugin context API + meta 필드 (1.5~2주)


### PR DESCRIPTION
## 배경

ROADMAP.md 의 `번들러 인프라 — rolldown/rspack 비교` 테이블에서 **Module Federation 이 ZNTC `❌` 로 표기**되어 있었습니다. 그러나 실제 코드베이스는 RFC #3318 (epic) 로 MF P1 단계가 광범위하게 머지된 상태입니다:

- 컨테이너 `init` 다중 named share scope 해석 (#4-1)
- per-shared `shareScope` config 표면 (#4-0)
- `strictVersion` 빌드타임 fail-fast 격상 (#2)
- `shareStrategy`/`strictVersion` config 표면 + manifest/init emit
- CSS·assets manifest 게시 (#3468)

즉 `rspack 전유 항목` 이 아니게 되어 문서가 stale 했습니다.

## 변경

- 비교 테이블 247행: `ZNTC ❌` → `🟡` + P1 구현 범위(컨테이너 init / named share scope 다중 / strictVersion / CSS·assets manifest)와 설계 한계(런타임 동적 remote 빌드검증) 명시 + RFC 문서 링크
- `단독 XL` 진행 블록에 MF P1 진행 항목 추가

문서 단독 변경입니다 (코드/동작 무변경).

🤖 Generated with [Claude Code](https://claude.com/claude-code)