### PR TITLE
feat(cli): config·NAPI 구현 옵션을 CLI 플래그로 노출

### DIFF
--- a/packages/core/bin/cli-flags.mjs
+++ b/packages/core/bin/cli-flags.mjs
@@ -67,6 +67,13 @@ export const FLAG_REGISTRY = [
   { kind: 'bool', flag: '--sourcemap-debug-ids', target: 'sourcemapDebugIds' },
   { kind: 'bool', flag: '--splitting', target: 'splitting' },
   { kind: 'bool', flag: '--no-splitting', target: 'splitting', value: false },
+  // tree shaking / scope hoisting / .map 디스크 쓰기 — 엔진 기본값 true.
+  // string-bool toggle (`--tree-shaking=false`) + 명시적 `--no-*` bool 양쪽 제공
+  // (`--no-splitting` 선례와 동형). `--no-*` 는 opts=false 로 두는데, config 머지
+  // default=true 루프가 `opts===true` 일 때만 동작하므로 config true 가 못 덮는다.
+  { kind: 'bool', flag: '--no-tree-shaking', target: 'treeShaking', value: false },
+  { kind: 'bool', flag: '--no-scope-hoist', target: 'scopeHoist', value: false },
+  { kind: 'bool', flag: '--no-emit-disk-sourcemap', target: 'emitDiskSourcemap', value: false },
   { kind: 'bool', flag: '--analyze', target: 'analyze', extra: { metafile: 'meta.json' } },
   { kind: 'bool', flag: '--flow', target: 'flow' },
   { kind: 'bool', flag: '--experimental-decorators', target: 'experimentalDecorators' },
@@ -167,6 +174,8 @@ export const FLAG_REGISTRY = [
   { kind: 'int', flag: '--port', target: 'port' },
   { kind: 'int', flag: '--log-limit', target: 'logLimit', forms: ['equal'] },
   { kind: 'int', flag: '--line-limit', target: 'lineLimit', forms: ['equal'] },
+  // Rollup output.experimentalMinChunkSize 류 — 작은 common 청크 자동 병합 (bytes).
+  { kind: 'int', flag: '--min-chunk-size', target: 'minChunkSize', forms: ['equal'] },
   // RN CLI 호환 — `--max-workers N` (Metro). zntc `--jobs` 와 의미 동일이므로 alias.
   { kind: 'int', flag: '--max-workers', target: 'jobs', forms: ['equal'] },
 
@@ -177,6 +186,8 @@ export const FLAG_REGISTRY = [
   // ─── kind=array — push (반복 지정) ───
   { kind: 'array', flag: '--external', target: 'external' },
   { kind: 'array', flag: '--drop', target: 'drop', forms: ['equal'] },
+  // 해석 차단 패턴 (Metro resolver.blockList / webpack IgnorePlugin 호환). 반복 지정.
+  { kind: 'array', flag: '--block-list', target: 'blockList', forms: ['equal'] },
   { kind: 'array', flag: '--plugin', target: 'pluginPaths', forms: ['pair'] },
   { kind: 'array', flag: '--runtime-target', target: 'runtimeTargetQueries' },
   // scope hoisting 시 예약할 전역 식별자 (반복 가능). NAPI BuildOptions.globalIdentifiers.
@@ -208,6 +219,10 @@ export const FLAG_REGISTRY = [
   // ─── kind=key-value — `--key:K=V` → opts[target][K]=V ───
   { kind: 'key-value', flag: '--define', target: 'define' },
   { kind: 'key-value', flag: '--alias', target: 'alias' },
+  // Fallback resolution — 해석 실패 시에만 적용 (webpack resolve.fallback /
+  // Metro extraNodeModules 호환). `--fallback:crypto=crypto-browserify`.
+  // 값 "false" → 빈-모듈 강제 + specifier 제약은 normalizeFallback 참조.
+  { kind: 'key-value', flag: '--fallback', target: 'fallback' },
   { kind: 'key-value', flag: '--loader', target: 'loader' },
   { kind: 'key-value', flag: '--global', target: 'globals' },
   // RN CLI 호환 (#2605 audit P0) — Metro `--transform-option key=value` /
@@ -239,9 +254,27 @@ export const FLAG_REGISTRY = [
 
   // ─── kind=string-bool — default=true 의 toggle. `--key=false` → false, 그 외 → true ───
   { kind: 'string-bool', flag: '--sources-content', target: 'sourcesContent' },
+  { kind: 'string-bool', flag: '--tree-shaking', target: 'treeShaking' },
+  { kind: 'string-bool', flag: '--scope-hoist', target: 'scopeHoist' },
+  { kind: 'string-bool', flag: '--emit-disk-sourcemap', target: 'emitDiskSourcemap' },
   { kind: 'string-bool', flag: '--use-define-for-class-fields', target: 'useDefineForClassFields' },
   { kind: 'string-bool', flag: '--tokenize', target: 'tokenize' },
 ];
+
+/**
+ * `--fallback:K=V` 로 수집된 dict 를 BuildOptions.fallback (`Record<string,string|false>`)
+ * 으로 정규화. CLI key-value 는 RHS 를 항상 string 으로 수집하므로 `"false"` 를 boolean
+ * false (빈-모듈 대체) 로 강제한다. config 가 준 실제 boolean false 는 strict `===` 에
+ * 안 걸려 그대로 보존. 빈 dict 는 undefined (NAPI 미전달).
+ *
+ * 한계: 값이 정확히 `"false"` 인 specifier 는 CLI 로 지정 불가 (항상 빈-모듈로 강제됨).
+ * 그 경우는 `zntc.config` 의 `fallback` 을 사용.
+ */
+export function normalizeFallback(fb) {
+  const keys = Object.keys(fb);
+  if (keys.length === 0) return undefined;
+  return Object.fromEntries(keys.map((k) => [k, fb[k] === 'false' ? false : fb[k]]));
+}
 
 /** spec 의 canonical + alias 를 한 array 로. spec.flag (canonical) 항상 첫번째. */
 export const flagsOf = (spec) => [spec.flag, ...(spec.aliases ?? [])];

--- a/packages/core/bin/cli-flags.test.ts
+++ b/packages/core/bin/cli-flags.test.ts
@@ -1,0 +1,111 @@
+/**
+ * CLI flag 파싱 유닛 테스트 — matchFlagFromRegistry + applyFlagAction.
+ *
+ * 본 PR 에서 추가한 엔진-옵션 노출 flag (config·NAPI 에는 이미 있었으나 CLI 부재)
+ * 의 파싱 정확성을 회귀 가드. string-bool toggle, 명시적 `--no-*` negation,
+ * key-value, array, int 각 kind 의 동작과 default=true 옵션의 비활성 경로를 검증.
+ */
+import { describe, expect, test } from 'bun:test';
+
+import { applyFlagAction, matchFlagFromRegistry, normalizeFallback } from './cli-flags.mjs';
+
+/** 단일 토큰을 registry 로 매칭 후 빈 opts 에 적용한 결과 반환. */
+function parseOne(arg, next) {
+  const args = next === undefined ? [arg] : [arg, next];
+  const m = matchFlagFromRegistry(arg, args, 0);
+  if (!m) return { matched: false, opts: {} };
+  const opts = {};
+  applyFlagAction(opts, m.spec, m.action);
+  return { matched: true, opts, consumed: m.consumed };
+}
+
+describe('엔진-옵션 노출 flag — string-bool toggle (default=true)', () => {
+  for (const [flag, key] of [
+    ['--tree-shaking', 'treeShaking'],
+    ['--scope-hoist', 'scopeHoist'],
+    ['--emit-disk-sourcemap', 'emitDiskSourcemap'],
+  ]) {
+    test(`${flag} 단독 → ${key}=true`, () => {
+      expect(parseOne(flag).opts[key]).toBe(true);
+    });
+    test(`${flag}=false → ${key}=false`, () => {
+      expect(parseOne(`${flag}=false`).opts[key]).toBe(false);
+    });
+    test(`${flag}=true → ${key}=true`, () => {
+      expect(parseOne(`${flag}=true`).opts[key]).toBe(true);
+    });
+  }
+});
+
+describe('엔진-옵션 노출 flag — 명시적 --no-* negation', () => {
+  for (const [flag, key] of [
+    ['--no-tree-shaking', 'treeShaking'],
+    ['--no-scope-hoist', 'scopeHoist'],
+    ['--no-emit-disk-sourcemap', 'emitDiskSourcemap'],
+  ]) {
+    test(`${flag} → ${key}=false`, () => {
+      expect(parseOne(flag).opts[key]).toBe(false);
+    });
+  }
+});
+
+describe('--fallback — key-value 파싱 (false 강제는 normalizeFallback, 여기선 string)', () => {
+  test('--fallback:crypto=crypto-browserify → fallback 객체', () => {
+    expect(parseOne('--fallback:crypto=crypto-browserify').opts.fallback).toEqual({
+      crypto: 'crypto-browserify',
+    });
+  });
+  test('--fallback:fs=false → 문자열 "false" (boolean 변환은 normalizeFallback 책임)', () => {
+    expect(parseOne('--fallback:fs=false').opts.fallback).toEqual({ fs: 'false' });
+  });
+});
+
+describe('normalizeFallback — "false" → boolean false 강제 + boolean 보존', () => {
+  test('빈 dict → undefined (NAPI 미전달)', () => {
+    expect(normalizeFallback({})).toBeUndefined();
+  });
+  test('CLI string "false" → boolean false (빈-모듈 대체)', () => {
+    expect(normalizeFallback({ fs: 'false' })).toEqual({ fs: false });
+  });
+  test('config 가 준 실제 boolean false 보존', () => {
+    expect(normalizeFallback({ fs: false })).toEqual({ fs: false });
+  });
+  test('일반 specifier 문자열은 그대로', () => {
+    expect(normalizeFallback({ crypto: 'crypto-browserify' })).toEqual({
+      crypto: 'crypto-browserify',
+    });
+  });
+  test('혼합 — string/false/specifier 동시', () => {
+    expect(normalizeFallback({ a: 'false', b: false, c: 'x' })).toEqual({
+      a: false,
+      b: false,
+      c: 'x',
+    });
+  });
+});
+
+describe('--block-list — array push (반복 누적)', () => {
+  test('--block-list=node_modules/foo → blockList 배열', () => {
+    expect(parseOne('--block-list=node_modules/foo').opts.blockList).toEqual(['node_modules/foo']);
+  });
+  test('반복 지정 누적', () => {
+    const opts = {};
+    for (const arg of ['--block-list=a', '--block-list=b']) {
+      const m = matchFlagFromRegistry(arg, [arg], 0);
+      applyFlagAction(opts, m.spec, m.action);
+    }
+    expect(opts.blockList).toEqual(['a', 'b']);
+  });
+});
+
+describe('--min-chunk-size — int', () => {
+  test('--min-chunk-size=1024 → 숫자 1024', () => {
+    expect(parseOne('--min-chunk-size=1024').opts.minChunkSize).toBe(1024);
+  });
+  test('비숫자 → invalid-int (parseError 경로)', () => {
+    const m = matchFlagFromRegistry('--min-chunk-size=abc', ['--min-chunk-size=abc'], 0);
+    const opts = {};
+    applyFlagAction(opts, m.spec, m.action);
+    expect(opts.parseError).toBe(true);
+  });
+});

--- a/packages/core/bin/zntc-cli-schema-sync.test.ts
+++ b/packages/core/bin/zntc-cli-schema-sync.test.ts
@@ -275,6 +275,11 @@ describe('CLI flag ↔ BuildOptions / TranspileOptions schema sync', () => {
     '--watch-delay=',
     '--serve',
     '--no-splitting',
+    // 엔진 기본값 true 옵션의 명시적 비활성 negation flag (positive `--tree-shaking`/
+    // `--scope-hoist`/`--emit-disk-sourcemap` 는 string-bool 로 BuildOptions 키와 직접 매핑).
+    '--no-tree-shaking',
+    '--no-scope-hoist',
+    '--no-emit-disk-sourcemap',
     '--open',
     '--clean',
     // 설정 / 환경
@@ -393,6 +398,7 @@ describe('CLI flag ↔ BuildOptions / TranspileOptions schema sync', () => {
     ...NAPI_INTERNAL_ONLY_KEYS,
     // 함수형 / 중첩 객체 (CLI 표현 불가)
     'compiler', // compiler.styledComponents / compiler.emotion — 중첩 객체, CLI 미노출
+    'mf', // Module Federation (#3318) — nested 객체, config/build() 전용 (CLI flag 없음)
     'manualChunks',
     'plugins',
     'moduleSpecifierMap',
@@ -408,7 +414,6 @@ describe('CLI flag ↔ BuildOptions / TranspileOptions schema sync', () => {
     'inlineDynamicImports',
     'outExtension', // namespace 객체 — `--out-extension:.js=` 가 일부 cover
     'outbase',
-    'treeShaking',
     'watch', // BuildOptions 의 watch 와 CLI --watch 는 의미 다름
     // CLI 가 enum→boolean 변환 (`--charset=utf8` → charsetUtf8: true)
     'charsetUtf8',

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -14,7 +14,12 @@ import { createServer as createHttpsServer } from 'node:https';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 
-import { applyFlagAction, KNOWN_FLAGS, matchFlagFromRegistry } from './cli-flags.mjs';
+import {
+  applyFlagAction,
+  KNOWN_FLAGS,
+  matchFlagFromRegistry,
+  normalizeFallback,
+} from './cli-flags.mjs';
 import { copyRnAssets } from './rn-asset-copy.mjs';
 import {
   buildRnBundleExtra,
@@ -160,6 +165,12 @@ function usageLines(command) {
     '  --global:SPEC=NAME         Map external specifier to IIFE/UMD global',
     '  --intro=<text>             Insert wrapper-internal text before bundle code',
     '  --outro=<text>             Insert wrapper-internal text after bundle code',
+    '  --tree-shaking[=false]     Tree shaking (default: true; --no-tree-shaking to disable)',
+    '  --scope-hoist[=false]      Scope hoisting (default: true; --no-scope-hoist to disable)',
+    '  --emit-disk-sourcemap[=false] Write .map to disk in watch mode (default: true)',
+    '  --fallback:SPEC=TARGET     Fallback resolution on failure (=false → empty module)',
+    '  --block-list=<pattern>     Block module resolution by pattern (repeatable)',
+    '  --min-chunk-size=<n>       Merge small common chunks below n bytes',
     '  --ignore-annotations       Ignore pure/sideEffects annotations',
     '  --jsx-side-effects         Preserve unused JSX expressions',
     '  --profile=<csv>            Collect profile categories (all, parse, transform, ...)',
@@ -231,6 +242,11 @@ function parseArgs(argv) {
     metafile: undefined,
     analyze: false,
     treeShaking: true,
+    // 엔진 기본값 true — `--no-*` / `--*=false` 또는 config false 로만 끈다.
+    scopeHoist: true,
+    emitDiskSourcemap: true,
+    fallback: {},
+    blockList: [],
     external: [],
     packagesExternal: false,
     define: {},
@@ -269,6 +285,7 @@ function parseArgs(argv) {
     jobs: undefined,
     logLimit: undefined,
     lineLimit: undefined,
+    minChunkSize: undefined,
     clean: false,
     allowOverwrite: false,
     preserveModules: false,
@@ -1052,6 +1069,7 @@ function mergeConfigIntoOpts(opts, config) {
     'logLevel',
     'logLimit',
     'lineLimit',
+    'minChunkSize',
     'outputExports',
     'outExtensionJs',
     'metafile',
@@ -1110,9 +1128,15 @@ function mergeConfigIntoOpts(opts, config) {
       opts[key] = true;
     }
   }
-  // sourcesContent / treeShaking / useDefineForClassFields 는 default=true.
-  // CLI 가 default 면 config 가 false 일 때 false 로.
-  for (const key of ['sourcesContent', 'treeShaking', 'useDefineForClassFields']) {
+  // default=true 옵션: CLI 가 default(true) 면 config=false 일 때만 false 로 내린다
+  // (개별 키는 아래 배열 — 추가 시 여기만 갱신).
+  for (const key of [
+    'sourcesContent',
+    'treeShaking',
+    'scopeHoist',
+    'emitDiskSourcemap',
+    'useDefineForClassFields',
+  ]) {
     if (opts[key] === true && config[key] === false) {
       opts[key] = false;
     }
@@ -1130,6 +1154,7 @@ function mergeConfigIntoOpts(opts, config) {
     'conditions',
     'nodePaths',
     'profile',
+    'blockList',
   ];
   for (const key of ARRAY_KEYS) {
     if (opts[key].length === 0 && Array.isArray(config[key]) && config[key].length > 0) {
@@ -1137,7 +1162,7 @@ function mergeConfigIntoOpts(opts, config) {
     }
   }
 
-  for (const key of ['define', 'alias', 'loader', 'globals']) {
+  for (const key of ['define', 'alias', 'loader', 'globals', 'fallback']) {
     if (config[key] && typeof config[key] === 'object') {
       opts[key] = { ...config[key], ...opts[key] };
     }
@@ -1202,6 +1227,11 @@ async function runBundle(opts, config) {
     sourcesContent: opts.sourcesContent,
     sourceRoot: opts.sourceRoot,
     treeShaking: opts.treeShaking,
+    scopeHoist: opts.scopeHoist,
+    emitDiskSourcemap: opts.emitDiskSourcemap,
+    fallback: normalizeFallback(opts.fallback),
+    blockList: opts.blockList.length > 0 ? opts.blockList : undefined,
+    minChunkSize: opts.minChunkSize,
     metafile: !!opts.metafile,
     keepNames: opts.keepNames,
     shimMissingExports: opts.shimMissingExports,

--- a/packages/core/src/typo-suggest.ts
+++ b/packages/core/src/typo-suggest.ts
@@ -153,6 +153,7 @@ export const KNOWN_CONFIG_KEYS: readonly string[] = [
   'preserveModulesRoot',
   'inlineDynamicImports',
   'manualChunks',
+  'minChunkSize',
   'metafile',
   'treeShaking',
   'shimMissingExports',


### PR DESCRIPTION
## 배경

`zntc.config` / `build()` (NAPI) 에는 이미 구현돼 있으나 **CLI 플래그만 없던** 엔진 옵션들이 있었습니다. 디버깅·CI·dropin 시나리오에서 CLI 만으로 제어가 안 돼 불편 (특히 `--no-tree-shaking` 같은 표준 토글 부재).

## 변경 — 노출 플래그

| 플래그 | BuildOptions 키 | kind (선례) |
|---|---|---|
| `--tree-shaking[=false]` / `--no-tree-shaking` | `treeShaking` | string-bool / bool (`--no-splitting`) |
| `--scope-hoist[=false]` / `--no-scope-hoist` | `scopeHoist` | 〃 |
| `--emit-disk-sourcemap[=false]` / `--no-emit-disk-sourcemap` | `emitDiskSourcemap` | 〃 |
| `--fallback:SPEC=TARGET` | `fallback` | key-value (`--define`) |
| `--block-list=<pattern>` | `blockList` | array (`--drop`) |
| `--min-chunk-size=<n>` | `minChunkSize` | int (`--line-limit`) |

- 새 `kind` 추가 없음 — 전부 기존 registry kind 재사용. 머지는 SCALAR/ARRAY/object-merge/default=true 기존 루프에 키 추가만으로 config 와 동형 동작 (CLI 명시 false 가 config true 에 안 덮이는 우선순위도 `treeShaking` 기존 동작과 비트 동형).
- `--fallback:fs=false` → CLI 는 string `"false"` 로 수집되므로 `Record<string,string|false>` 계약상 boolean `false` (빈-모듈) 로 강제. 이 정규화를 import-safe 한 `cli-flags.mjs` 의 `normalizeFallback` 헬퍼로 추출 (config 가 준 실제 boolean false 는 strict `===` 로 보존). **한계**: 정확히 `"false"` 인 specifier 는 CLI 표현 불가 → `zntc.config` 사용 (헬퍼 doc 명시).
- `manualChunks` 는 함수형 콜백이라 CLI argv 로 표현 불가 — 의도적 제외 (allowlist 유지).

## 부수 — 기존 schema drift 해소

`mf` / `minChunkSize` (epic #3318 에서 BuildOptions 에 추가됐으나 allowlist 미갱신) 로 `zntc-cli-schema-sync` + `typo-suggest` 테스트가 **main 에서 이미 fail** 중이었습니다. 같은 테스트를 수정하는 김에 구조적으로 정리:
- `mf` → `buildOptionsOnlyKeys` (nested 객체, `compiler`/`manualChunks` 와 같은 분류)
- `minChunkSize` → `KNOWN_CONFIG_KEYS` (이제 CLI+config 1급 옵션)

## 테스트

- 신규 `bin/cli-flags.test.ts`: 파싱(string-bool/negation/key-value/array/int) + `normalizeFallback` 24 케이스
- 기존 `zntc-cli-schema-sync` / `typo-suggest` fail → green
- `bin/` + `typo-suggest` 356 pass / 0 fail

## /simplify

3-에이전트 리뷰 완료 — 정확성 버그 0. 지적된 주석 stale 2건 정정, fallback 3중 중첩 → 헬퍼 추출(+유닛테스트), WHAT 주석 삭제 반영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)