### PR TITLE
feat(cli): --version/-v, --no-config, --color/--no-color 추가

### DIFF
--- a/packages/core/bin/banner.mjs
+++ b/packages/core/bin/banner.mjs
@@ -12,6 +12,38 @@ const colors = {
   cyan: '\x1b[36m',
 };
 
+/**
+ * 색상(ANSI) 출력 사용 여부. NO_COLOR / FORCE_COLOR 관례(no-color.org,
+ * supports-color) 준수: `NO_COLOR` 가 비어있지 않으면 무조건 비활성,
+ * `FORCE_COLOR` 가 "0"/"false" 가 아니면(빈 문자열 포함 — supports-color 관례상
+ * 활성) 무조건 활성, 둘 다 없으면 TTY 여부.
+ */
+export function shouldUseColor() {
+  const { NO_COLOR, FORCE_COLOR } = process.env;
+  if (NO_COLOR) return false;
+  if (FORCE_COLOR !== undefined) return FORCE_COLOR !== '0' && FORCE_COLOR !== 'false';
+  return Boolean(process.stdout.isTTY);
+}
+
+/**
+ * `zntc --color` / `--no-color` 를 NO_COLOR/FORCE_COLOR env 로 환원해 shouldUseColor()
+ * 단일 경로로 합류시킨다. 명시 flag 는 **반대편 env 를 제거**해 기존 env 보다
+ * 우선한다 (`NO_COLOR=1 zntc --color` → 색상 ON). `color` 미지정(undefined) 시
+ * env 무변경 → 기존 NO_COLOR/FORCE_COLOR/TTY 자동 판정 유지.
+ *
+ * @param {boolean | undefined} color  opts.color (true=강제, false=억제, undefined=자동)
+ * @param {Record<string, string | undefined>} env  기본 process.env (테스트는 주입)
+ */
+export function applyColorPreference(color, env = process.env) {
+  if (color === true) {
+    delete env.NO_COLOR;
+    env.FORCE_COLOR = '1';
+  } else if (color === false) {
+    delete env.FORCE_COLOR;
+    env.NO_COLOR = '1';
+  }
+}
+
 const BANNER_WIDTH = 59;
 
 function bannerLine(content) {
@@ -49,8 +81,9 @@ const TAGLINES = {
 /**
  * ZNTC 시작 banner 출력.
  *
- * - `silent: true` 또는 비-TTY 환경에서는 plain 한 줄 (`zntc <flavor> v0.1.0`) 만 출력.
- *   ASCII art 의 ANSI escape 가 CI 로그 / pipe 에서 노이즈가 되는 것을 막는다.
+ * - `silent: true` 또는 색상 비활성 환경(비-TTY / NO_COLOR / `--no-color`)에서는
+ *   plain 한 줄 (`zntc <flavor> v0.1.0`) 만 출력. ASCII art 의 ANSI escape 가 CI
+ *   로그 / pipe 에서 노이즈가 되는 것을 막는다.
  *
  * @param {{ flavor: 'web' | 'rn', version?: string, silent?: boolean }} opts
  */
@@ -61,7 +94,7 @@ export function printZntcBanner({ flavor, version, silent = false }) {
 
   const versionText = version ? `v${version}` : '';
 
-  if (!process.stdout.isTTY) {
+  if (!shouldUseColor()) {
     console.log(`zntc ${flavor}${versionText ? ` ${versionText}` : ''} — ${tagline}`);
     return;
   }

--- a/packages/core/bin/cli-conveniences.test.ts
+++ b/packages/core/bin/cli-conveniences.test.ts
@@ -1,0 +1,105 @@
+/**
+ * CLI 편의 flag 회귀 가드 — --version/-v, --no-config, --color/--no-color 파싱 및
+ * banner.shouldUseColor() 의 NO_COLOR/FORCE_COLOR/TTY 우선순위.
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { applyColorPreference, shouldUseColor } from './banner.mjs';
+import { applyFlagAction, matchFlagFromRegistry } from './cli-flags.mjs';
+
+function parseOne(arg) {
+  const m = matchFlagFromRegistry(arg, [arg], 0);
+  if (!m) return {};
+  const opts = {};
+  applyFlagAction(opts, m.spec, m.action);
+  return opts;
+}
+
+describe('CLI 편의 flag 파싱', () => {
+  test('--version → version=true', () => {
+    expect(parseOne('--version').version).toBe(true);
+  });
+  test('-v 별칭 → version=true', () => {
+    expect(parseOne('-v').version).toBe(true);
+  });
+  test('--no-config → noConfig=true', () => {
+    expect(parseOne('--no-config').noConfig).toBe(true);
+  });
+  test('--color → color=true', () => {
+    expect(parseOne('--color').color).toBe(true);
+  });
+  test('--no-color → color=false', () => {
+    expect(parseOne('--no-color').color).toBe(false);
+  });
+});
+
+describe('shouldUseColor — NO_COLOR/FORCE_COLOR/TTY 우선순위', () => {
+  const savedNo = process.env.NO_COLOR;
+  const savedForce = process.env.FORCE_COLOR;
+  const savedTty = process.stdout.isTTY;
+
+  afterEach(() => {
+    if (savedNo === undefined) delete process.env.NO_COLOR;
+    else process.env.NO_COLOR = savedNo;
+    if (savedForce === undefined) delete process.env.FORCE_COLOR;
+    else process.env.FORCE_COLOR = savedForce;
+    process.stdout.isTTY = savedTty;
+  });
+
+  function setEnv({ no, force, tty }) {
+    if (no === undefined) delete process.env.NO_COLOR;
+    else process.env.NO_COLOR = no;
+    if (force === undefined) delete process.env.FORCE_COLOR;
+    else process.env.FORCE_COLOR = force;
+    process.stdout.isTTY = tty;
+  }
+
+  test('NO_COLOR 가 비어있지 않으면 무조건 false (TTY/FORCE_COLOR 무시)', () => {
+    setEnv({ no: '1', force: '1', tty: true });
+    expect(shouldUseColor()).toBe(false);
+  });
+  test('FORCE_COLOR 설정 시 비-TTY 라도 true', () => {
+    setEnv({ no: undefined, force: '1', tty: false });
+    expect(shouldUseColor()).toBe(true);
+  });
+  test('FORCE_COLOR=0 → false', () => {
+    setEnv({ no: undefined, force: '0', tty: true });
+    expect(shouldUseColor()).toBe(false);
+  });
+  test('FORCE_COLOR=false → false', () => {
+    setEnv({ no: undefined, force: 'false', tty: true });
+    expect(shouldUseColor()).toBe(false);
+  });
+  test('env 없음 + TTY → true', () => {
+    setEnv({ no: undefined, force: undefined, tty: true });
+    expect(shouldUseColor()).toBe(true);
+  });
+  test('env 없음 + 비-TTY → false', () => {
+    setEnv({ no: undefined, force: undefined, tty: false });
+    expect(shouldUseColor()).toBe(false);
+  });
+  test("FORCE_COLOR='' (빈 문자열) → true (supports-color 관례)", () => {
+    setEnv({ no: undefined, force: '', tty: false });
+    expect(shouldUseColor()).toBe(true);
+  });
+});
+
+describe('applyColorPreference — 명시 flag 가 반대편 env 제거 (override)', () => {
+  test('--color (true): NO_COLOR 가 이미 set 돼 있어도 제거 + FORCE_COLOR set', () => {
+    const env = { NO_COLOR: '1' };
+    applyColorPreference(true, env);
+    expect(env.NO_COLOR).toBeUndefined();
+    expect(env.FORCE_COLOR).toBe('1');
+  });
+  test('--no-color (false): FORCE_COLOR 제거 + NO_COLOR set', () => {
+    const env = { FORCE_COLOR: '1' };
+    applyColorPreference(false, env);
+    expect(env.FORCE_COLOR).toBeUndefined();
+    expect(env.NO_COLOR).toBe('1');
+  });
+  test('미지정(undefined): env 무변경 (자동 판정 유지)', () => {
+    const env = { NO_COLOR: '1', FORCE_COLOR: '1' };
+    applyColorPreference(undefined, env);
+    expect(env).toEqual({ NO_COLOR: '1', FORCE_COLOR: '1' });
+  });
+});

--- a/packages/core/bin/cli-flags.mjs
+++ b/packages/core/bin/cli-flags.mjs
@@ -41,6 +41,13 @@
 export const FLAG_REGISTRY = [
   // ─── kind=bool — boolean toggle ───
   { kind: 'bool', flag: '--help', target: 'help', aliases: ['-h'] },
+  // 버전 출력 후 즉시 종료 (config/NAPI 로드 불필요 — main 에서 early dispatch).
+  { kind: 'bool', flag: '--version', target: 'version', aliases: ['-v'] },
+  // config 파일 자동 탐색·로드 우회 (CLI flag 만으로 빌드 — 재현/테스트). --config 보다 우선.
+  { kind: 'bool', flag: '--no-config', target: 'noConfig' },
+  // 색상 출력 강제/억제. 미지정 시 NO_COLOR/FORCE_COLOR env + TTY 자동 판정.
+  { kind: 'bool', flag: '--color', target: 'color' },
+  { kind: 'bool', flag: '--no-color', target: 'color', value: false },
   { kind: 'bool', flag: '--bundle', target: 'bundle' },
   { kind: 'bool', flag: '--watch', target: 'watch', aliases: ['-w'] },
   { kind: 'bool', flag: '--watch-json', target: 'watchJson', extra: { watch: true } },

--- a/packages/core/bin/zntc-cli-schema-sync.test.ts
+++ b/packages/core/bin/zntc-cli-schema-sync.test.ts
@@ -269,6 +269,12 @@ describe('CLI flag ↔ BuildOptions / TranspileOptions schema sync', () => {
   const cliOnlyFlags: ReadonlySet<string> = new Set([
     // 빌드 모드 / 명령
     '--help',
+    // CLI flow 전용 — BuildOptions 키 매핑 없음 (버전 출력 후 종료 / config 우회 /
+    // 색상 토글은 NO_COLOR·FORCE_COLOR env 로 환원).
+    '--version',
+    '--no-config',
+    '--color',
+    '--no-color',
     '--bundle',
     '--watch',
     '--watch-json',

--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -26,7 +26,7 @@ import {
   buildRnBundleOverride,
   buildRnDevServerInput,
 } from './rn-dev-input.mjs';
-import { printZntcBanner } from './banner.mjs';
+import { applyColorPreference, printZntcBanner } from './banner.mjs';
 
 function isMissingBuiltCore(error) {
   if (!error || error.code !== 'ERR_MODULE_NOT_FOUND') return false;
@@ -188,6 +188,9 @@ function usageLines(command) {
     '  --watch, -w                Rebuild on changes',
     '  --serve [dir]              Serve bundled output',
     '  --config <path>            Config file path',
+    '  --no-config                Skip config file discovery/loading (CLI flags only)',
+    '  --color, --no-color        Force or disable colored output (honors NO_COLOR)',
+    '  --version, -v              Print version and exit',
     '  --test262 <dir>            Run Zig Test262 runner via zig build test262-run',
     '  --help, -h                 Show this help message',
   ];
@@ -204,6 +207,12 @@ function parseArgs(argv) {
   const opts = {
     appCommand,
     help: false,
+    version: false,
+    // config 자동 탐색·로드 우회 (--no-config). --config 명시보다 우선.
+    // workspace 모드(--workspace)는 config 가 본질이라 미적용 (경고만).
+    noConfig: false,
+    // 색상 출력 강제(true)/억제(false). undefined = NO_COLOR/FORCE_COLOR + TTY 자동.
+    color: undefined,
     parseError: false,
     appRoot: undefined,
     previewDir: undefined,
@@ -1007,12 +1016,15 @@ async function runTranspile(opts) {
  * 실패 시 `Error("failed to load config — ...")` 를 throw — main 의 try/catch 가 처리.
  */
 async function loadAutoConfig(opts) {
-  const explicit = opts.configPath ? resolve(opts.configPath) : null;
+  // --no-config: 명시(--config)·자동 탐색 모두 우회. env(.env/define)는 config 와
+  // 독립이므로 계속 로드해 `{ config: null }` 만 반환.
+  const noConfig = opts.noConfig === true;
+  const explicit = !noConfig && opts.configPath ? resolve(opts.configPath) : null;
   if (explicit && !existsSync(explicit)) {
     throw new Error(`failed to load config — file not found: ${explicit}`);
   }
   const configSearchDir = getAutoConfigSearchDir(opts);
-  const configPath = explicit ?? findConfigPath(configSearchDir);
+  const configPath = noConfig ? null : (explicit ?? findConfigPath(configSearchDir));
 
   const command = opts.serve ? 'serve' : opts.watch ? 'watch' : 'bundle';
   const mode = opts.mode ?? (command === 'bundle' ? 'production' : 'development');
@@ -1036,7 +1048,7 @@ async function loadAutoConfig(opts) {
 
   // mode-specific config 자동 탐색 + 머지 (#2110). `--config <path>` 명시 시
   // 그 파일이 단독 source — mode-specific 자동 탐색 안 함 (사용자 의도 존중).
-  const modeConfigPath = explicit ? null : findModeConfigPath(configSearchDir, mode);
+  const modeConfigPath = noConfig || explicit ? null : findModeConfigPath(configSearchDir, mode);
 
   if (!configPath && !modeConfigPath) return { config: null, env, dotenvVars };
 
@@ -1474,13 +1486,15 @@ function computeRestartTriggers(opts) {
   const envDir = opts.envDir ? resolve(opts.envDir) : configSearchDir;
   dirs.add(envDir);
 
-  const explicitConfig = opts.configPath ? resolve(opts.configPath) : null;
-  const autoConfig = explicitConfig ?? findConfigPath(configSearchDir);
+  // --no-config 면 config 를 안 읽으므로 그 변경도 restart trigger 아님.
+  const noConfig = opts.noConfig === true;
+  const explicitConfig = !noConfig && opts.configPath ? resolve(opts.configPath) : null;
+  const autoConfig = noConfig ? null : (explicitConfig ?? findConfigPath(configSearchDir));
   if (autoConfig) dirs.add(dirname(autoConfig));
 
   const mode = opts.mode ?? (opts.serve || opts.watch ? 'development' : 'production');
   // mode-specific config (`zntc.config.${mode}.{ext}`) 변경도 restart trigger (#2110).
-  const modeConfig = explicitConfig ? null : findModeConfigPath(configSearchDir, mode);
+  const modeConfig = noConfig || explicitConfig ? null : findModeConfigPath(configSearchDir, mode);
   if (modeConfig) dirs.add(dirname(modeConfig));
 
   const configBase = autoConfig ? basename(autoConfig) : null;
@@ -2008,6 +2022,11 @@ function buildSubOpts(opts, w, merged) {
  * `--workspace=<name>` 필터로 단일 entry 만 남기면 serve/watch 허용.
  */
 async function runWorkspace(opts, workspacePath) {
+  // workspace 모드는 root/entry config 가 본질이라 --no-config 미적용. silent
+  // 무시는 혼란을 주므로 1회 경고 (loadAutoConfig 경로와 달리 게이트하지 않음).
+  if (opts.noConfig) {
+    console.warn('zntc: --no-config is ignored in workspace mode (--workspace)');
+  }
   const command = opts.serve ? 'serve' : opts.watch ? 'watch' : 'bundle';
   const mode = opts.mode ?? (command === 'bundle' ? 'production' : 'development');
   const env = { command, mode, env: process.env };
@@ -2090,8 +2109,16 @@ async function runWorkspace(opts, workspacePath) {
 async function main() {
   const opts = parseArgs(process.argv);
 
+  // --color/--no-color 를 NO_COLOR/FORCE_COLOR env 로 환원 (명시 flag 가 기존 env override).
+  applyColorPreference(opts.color);
+
   if (opts.help) {
     printUsage(opts.appCommand);
+    return;
+  }
+
+  if (opts.version) {
+    console.log(getCliVersion() ?? 'unknown');
     return;
   }
 


### PR DESCRIPTION
## 배경

표준 CLI 관례인데 ZNTC 에 없던 편의 플래그 3종을 추가합니다 (이전 옵션 매트릭스 조사에서 `높음` 우선순위로 식별).

## 변경

| 플래그 | 동작 |
|---|---|
| `--version` / `-v` | `getCliVersion()` 출력 후 즉시 종료 (config/NAPI 로드 **이전** early dispatch, 실패 시 `unknown`) |
| `--no-config` | config 파일 자동 탐색·로드 우회. `--config` 명시보다 우선. `.env`/define 은 config 와 독립이라 계속 로드 (`{ config: null }` 반환) |
| `--color` / `--no-color` | `NO_COLOR`/`FORCE_COLOR` env 로 환원. 명시 flag 가 **반대편 env 를 제거**해 기존 env override (`NO_COLOR=1 zntc --color` → 색상 ON) |

- 색상 판정을 `banner.mjs` 의 `shouldUseColor()` (no-color.org / supports-color 관례: `NO_COLOR` > `FORCE_COLOR` > TTY, `FORCE_COLOR=''` = 활성) 단일 경로로 통합. 기존 `isTTY` 게이트를 이걸로 교체 (기본 동작 무변경 — env 없으면 TTY 판정 동일).
- `--no-config` 는 `loadAutoConfig` + `computeRestartTriggers`(watch restart) 양쪽 게이트해 빌드와 watch 가 동일 config 관점 유지.

## 알려진 한계 / 범위

- **workspace 모드(`--workspace`)**: root/entry config 가 본질이라 `--no-config` 미적용 — silent 무시 대신 **1회 경고** + 주석/help 명시 (honor 는 별도 이슈로).
- **`--no-config` 경로 중복**: `loadAutoConfig`/`computeRestartTriggers` 의 path-resolve 삼항은 **이 PR 이전부터** 대칭 중복이던 패턴으로, noConfig 게이트도 양쪽 대칭 추가. 헬퍼 추출은 두 함수의 반환/모드 계산이 달라 과한 추상화 (재사용 리뷰 에이전트 의견) → 현행 유지.
- **RN dev-server banner**: `packages/react-native` logger 의 banner 는 색상 게이트가 부재(sync 주석과 불일치 — 기존 상태). `shouldUseColor` 를 `export` 해둬 추후 공유 가능 — 별도 follow-up.

## 테스트

- 신규 `bin/cli-conveniences.test.ts`: flag 파싱(--version/-v/--no-config/--color/--no-color) + `shouldUseColor` 우선순위 + `applyColorPreference` override 14 케이스
- `bin/` 301 pass / 0 fail

## /simplify

3-에이전트 리뷰 완료. **반드시 수정** 1건 반영: `--color` 가 이미 set 된 `NO_COLOR` 를 override 못 하던 버그(주석↔동작 불일치) → 명시 flag 가 반대 env 를 제거하도록 `applyColorPreference` 헬퍼화 + 회귀 테스트. workspace 사각 경고, `FORCE_COLOR=''` 의도 주석/테스트 보강.

## ⚠️ 머지 순서

`zntc-cli-schema-sync` / `typo-suggest` 의 `mf, minChunkSize` schema drift 는 **main 기존 실패**로, PR #3489 가 수정합니다. 본 PR 은 main 분기라 그 1건을 상속 (PR3 자체는 신규 실패 0). **#3489 머지 후 rebase** 시 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)