### PR TITLE
fix(examples): sherif — module-federation 의존성 알파벳 정렬

### DIFF
--- a/examples/module-federation/package.json
+++ b/examples/module-federation/package.json
@@ -10,8 +10,8 @@
     "demo": "bun run build && bun run start"
   },
   "dependencies": {
-    "react": "^19.0.0",
-    "@module-federation/runtime": "2.4.0"
+    "@module-federation/runtime": "2.4.0",
+    "react": "^19.0.0"
   },
   "devDependencies": {
     "@zntc/core": "workspace:*",


### PR DESCRIPTION
## 문제

`Publish Smoke Test` 의 `sherif` (workspace metadata 일관성) 검사가 **main 에서 fail** 중입니다 (진행 중 PR #3488/#3489/#3490/#3491 전부 이 실패를 상속해 머지 차단).

```
1 issue found in ./examples/module-federation/package.json:
 ⨯ error dependencies should be ordered alphabetically. unordered-dependencies
```

epic #3318 (`66c576db docs(mf): examples/module-federation 실행 예제앱`) 에서 추가된 `examples/module-federation/package.json` 의 `dependencies` 가 알파벳 순이 아님 (`react` 가 `@module-federation/runtime` 보다 앞).

## 수정

`bunx sherif -f` autofix — 2줄 순서만 정렬 (`@module-federation/runtime` → `react`). 동작 무영향.

main clean 체크아웃에서 재현 확인 (내 다른 변경과 무관한 pre-existing main breakage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)