### PR TITLE
fix(rn): stabilize minified release bundles

### DIFF
--- a/packages/core/bin/zntc.mjs
+++ b/packages/core/bin/zntc.mjs
@@ -816,6 +816,8 @@ async function runRnBundle(opts, config) {
     sourcemap: wantsSourcemap,
     minify:
       opts.minify || opts.minifyWhitespace || opts.minifyIdentifiers || opts.minifySyntax || false,
+    dropConsole: opts.drop.includes('console'),
+    dropDebugger: opts.drop.includes('debugger'),
     extra,
     override: buildRnBundleOverride({
       config: cfg,

--- a/packages/core/test/cli/react-native-bundle.ts
+++ b/packages/core/test/cli/react-native-bundle.ts
@@ -88,4 +88,22 @@ describe('CLI: bundle --platform=react-native (#2540 PR #7)', () => {
     expect(exitCode).toBe(0);
     expect(existsSync(out)).toBe(true);
   });
+
+  test('RN CLI 호환: --drop=console 이 RN bundle 경로에도 적용된다', () => {
+    const out = join(dir, 'out-drop-console.js');
+    const { exitCode } = runCli([
+      '--bundle',
+      join(dir, 'src/index.ts'),
+      '--platform=react-native',
+      '--rn-platform=ios',
+      `--rn-project-root=${dir}`,
+      '--drop=console',
+      '-o',
+      out,
+    ]);
+    expect(exitCode).toBe(0);
+    expect(existsSync(out)).toBe(true);
+    const content = readFileSync(out, 'utf8');
+    expect(content).not.toContain('console.log("rn-bundle")');
+  });
 });

--- a/packages/core/test/core/edge-combinations.ts
+++ b/packages/core/test/core/edge-combinations.ts
@@ -4,3 +4,4 @@ import './edge-combinations/plugins';
 import './edge-combinations/errors';
 import './edge-combinations/react';
 import './edge-combinations/minify-identifiers';
+import './edge-combinations/minify-syntax';

--- a/packages/core/test/core/edge-combinations/minify-identifiers.ts
+++ b/packages/core/test/core/edge-combinations/minify-identifiers.ts
@@ -5,6 +5,7 @@ import {
   describe,
   expect,
   join,
+  runBundleStdout,
   test,
   writeFileSync,
 } from '../helpers';
@@ -46,5 +47,38 @@ describe('엣지 케이스 + 조합 보강: minify identifiers', () => {
     });
     expect(result.errors.length).toBe(0);
     expect(result.outputFiles[0].text).not.toContain('longName');
+  });
+
+  test('minifyIdentifiers: re-export 경유 top-level 이름을 함수 local 이름과 충돌시키지 않음', async () => {
+    writeFileSync(
+      join(fixture.dir, 'colors.ts'),
+      'export const COLORS = { white: "#fff", black: "#000" };\n',
+    );
+    writeFileSync(join(fixture.dir, 'theme.ts'), 'export * from "./colors";\n');
+    writeFileSync(join(fixture.dir, 'ui.ts'), 'export * from "./theme";\n');
+    writeFileSync(join(fixture.dir, 'intl.ts'), 'export function msg(id) { return id; }\n');
+    writeFileSync(
+      join(fixture.dir, 'reexport-local-shadow.ts'),
+      [
+        'import { COLORS } from "./ui";',
+        'import { msg } from "./intl";',
+        'function render() {',
+        '  const local0 = msg("l0");',
+        '  const oneIsEnough = msg("local");',
+        '  return COLORS.white + oneIsEnough + local0;',
+        '}',
+        'console.log(render());',
+      ].join('\n'),
+    );
+
+    const result = buildSync({
+      entryPoints: [join(fixture.dir, 'reexport-local-shadow.ts')],
+      bundle: true,
+      format: 'iife',
+      minify: true,
+    });
+
+    expect(result.errors.length).toBe(0);
+    await expect(runBundleStdout(result.outputFiles[0].text)).resolves.toBe('#ffflocall0');
   });
 });

--- a/packages/core/test/core/edge-combinations/minify-syntax.ts
+++ b/packages/core/test/core/edge-combinations/minify-syntax.ts
@@ -1,0 +1,56 @@
+import {
+  afterAll,
+  beforeAll,
+  buildSync,
+  describe,
+  expect,
+  join,
+  runBundleStdout,
+  test,
+  writeFileSync,
+} from '../helpers';
+import { createEdgeCombinationFixture, type EdgeCombinationFixture } from './fixture';
+
+describe('엣지 케이스 + 조합 보강: minify syntax', () => {
+  let fixture: EdgeCombinationFixture;
+
+  beforeAll(() => {
+    fixture = createEdgeCombinationFixture();
+  });
+
+  afterAll(() => fixture.cleanup());
+
+  test('minifySyntax: 죽은 분기 참조 감산이 살아있는 const 함수 선언을 제거하지 않음', async () => {
+    writeFileSync(
+      join(fixture.dir, 'dead-branch-function-ref.js'),
+      [
+        'const DEBUG_NETWORK_SEND_DELAY = false;',
+        'function send(data) {',
+        '  let nativeResponseType = "text";',
+        '  const doSend = () => {',
+        '    globalThis.result = nativeResponseType + ":" + data;',
+        '  };',
+        '  if (DEBUG_NETWORK_SEND_DELAY) {',
+        '    setTimeout(doSend, DEBUG_NETWORK_SEND_DELAY);',
+        '  } else {',
+        '    doSend();',
+        '  }',
+        '}',
+        'send("ok");',
+        'console.log(globalThis.result);',
+      ].join('\n'),
+    );
+
+    for (const options of [{ minifySyntax: true }, { minify: true }]) {
+      const result = buildSync({
+        entryPoints: [join(fixture.dir, 'dead-branch-function-ref.js')],
+        bundle: true,
+        format: 'iife',
+        ...options,
+      });
+
+      expect(result.errors.length).toBe(0);
+      await expect(runBundleStdout(result.outputFiles[0].text)).resolves.toBe('text:ok');
+    }
+  });
+});

--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -664,4 +664,10 @@ describe('buildRnBundleOptions — sourcemap / minify', () => {
   test('minify explicit', () => {
     expect(buildRnBundleOptions(baseInput({ minify: true })).minify).toBe(true);
   });
+
+  test('dropConsole / dropDebugger explicit', () => {
+    const opts = buildRnBundleOptions(baseInput({ dropConsole: true, dropDebugger: true }));
+    expect(opts.dropConsole).toBe(true);
+    expect(opts.dropDebugger).toBe(true);
+  });
 });

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -378,8 +378,17 @@ function deepMerge<T extends Record<string, unknown>>(base: T, override: Partial
  * 분기와 동등 동작.
  */
 export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
-  const { entry, projectRoot, rnPlatform, dev, sourcemap, minify, dropConsole, dropDebugger, extra } =
-    input;
+  const {
+    entry,
+    projectRoot,
+    rnPlatform,
+    dev,
+    sourcemap,
+    minify,
+    dropConsole,
+    dropDebugger,
+    extra,
+  } = input;
 
   if (extra?.platforms && !extra.platforms.includes(rnPlatform)) {
     throw new Error(

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -59,6 +59,10 @@ export interface RnBundleInput {
   sourcemap?: boolean;
   /** prod build 의 minify. */
   minify?: boolean;
+  /** console.* 호출 제거. Metro production Babel plugin 과 같은 정책을 원하는 release 경로에서 사용. */
+  dropConsole?: boolean;
+  /** debugger statement 제거. */
+  dropDebugger?: boolean;
   /**
    * preset 위에 user override. semantics:
    * - **Object dict** (`define` / `loader` / `alias` / `fallback` 등) — preset
@@ -374,7 +378,8 @@ function deepMerge<T extends Record<string, unknown>>(base: T, override: Partial
  * 분기와 동등 동작.
  */
 export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
-  const { entry, projectRoot, rnPlatform, dev, sourcemap, minify, extra } = input;
+  const { entry, projectRoot, rnPlatform, dev, sourcemap, minify, dropConsole, dropDebugger, extra } =
+    input;
 
   if (extra?.platforms && !extra.platforms.includes(rnPlatform)) {
     throw new Error(
@@ -466,6 +471,8 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
     platform: 'react-native',
     sourcemap: sourcemap ?? dev,
     minify: minify ?? false,
+    dropConsole: dropConsole ?? false,
+    dropDebugger: dropDebugger ?? false,
     plugins,
     emitDiskSourcemap: !dev,
     target: 'es5',

--- a/src/bundler/bundler_test/basic.zig
+++ b/src/bundler/bundler_test/basic.zig
@@ -102,6 +102,38 @@ test "Bundler: minified output" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "// ---") == null);
 }
 
+test "Bundler: unresolved globals reserve minified top-level names" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "dep.ts",
+        \\function localFunctionName() { return 1; }
+        \\export const value = localFunctionName();
+    );
+    try writeFile(tmp.dir, "entry.ts",
+        \\import { value } from './dep';
+        \\globalThis.__RESULT__ = [value, t];
+    );
+
+    const entry = try absPath(&tmp, "entry.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "globalThis.__RESULT__") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, ",t]") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "function t(") == null);
+}
+
 test "Bundler: minify가 래퍼 합성 심볼을 짧은 이름으로 바꿈" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/bundler_test/plugin_misc.zig
+++ b/src/bundler/bundler_test/plugin_misc.zig
@@ -3988,6 +3988,47 @@ test "react_native inlineRequires: simple parameter default visits ESM value imp
     try std.testing.expect(std.mem.indexOf(u8, result.output, lazy) != null);
 }
 
+test "react_native inlineRequires: minified bare parameter default visits ESM value import" {
+    // `function f(a = IMPORTED_CONST)` — release/minify 에서 bare named import
+    // default initializer 의 symbol_id 가 빠지면 import 원본 이름이 전역 조회로
+    // 남아 RN 런타임에서 ReferenceError 가 난다.
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    try writeFile(tmp.dir, "entry.js",
+        \\import useThrottleEventHandler from './hook';
+        \\globalThis.__zntcBareParamDefaultResult = useThrottleEventHandler();
+    );
+    try writeFile(tmp.dir, "ui.js",
+        \\export const DEFAULT_THROTTLE_MILLISECONDS = 2000;
+    );
+    try writeFile(tmp.dir, "hook.js",
+        \\import { DEFAULT_THROTTLE_MILLISECONDS } from './ui';
+        \\const useThrottleEventHandler = (throttleTime = DEFAULT_THROTTLE_MILLISECONDS) => throttleTime;
+        \\export default useThrottleEventHandler;
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .tree_shaking = false,
+        .entry_error_guard = true,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+        .minify_syntax = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "=DEFAULT_THROTTLE_MILLISECONDS") == null);
+}
+
 test "react_native inlineRequires: array pattern default visits ESM value import" {
     // `function f([a = X.y])` — array_pattern element default.
     var tmp = std.testing.tmpDir(.{});

--- a/src/bundler/bundler_test/tree_shake/cjs_define_property.zig
+++ b/src/bundler/bundler_test/tree_shake/cjs_define_property.zig
@@ -439,6 +439,48 @@ test "TreeShaking CJS: default import keeps __esModule defineProperty marker" {
     try std.testing.expect(std.mem.indexOf(u8, result.output, "__esModule") != null);
 }
 
+test "TreeShaking CJS: minified default import keeps __esModule marker for object default export" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "package.json", "{\"sideEffects\": false}");
+    try writeFile(tmp.dir, "entry.js",
+        \\import BootSplash from './bootsplash.js';
+        \\globalThis.__bootSplashHide = BootSplash.hide;
+    );
+    try writeFile(tmp.dir, "bootsplash.js",
+        \\Object.defineProperty(exports, "__esModule", { value: true });
+        \\exports.default = void 0;
+        \\exports.hide = hide;
+        \\exports.isVisible = isVisible;
+        \\function hide() { return "USED_BOOT_SPLASH_HIDE_MARKER"; }
+        \\function isVisible() { return true; }
+        \\var BootSplash = exports.default = { hide, isVisible };
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .strict_execution_order = true,
+        .minify_syntax = true,
+        .minify_whitespace = true,
+        .minify_identifiers = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "USED_BOOT_SPLASH_HIDE_MARKER") != null);
+    try std.testing.expect(
+        std.mem.indexOf(u8, result.output, "Object.defineProperty(exports,\"__esModule\"") != null or
+            std.mem.indexOf(u8, result.output, "$dp(exports,\"__esModule\"") != null,
+    );
+}
+
 test "TreeShaking CJS: unsafe Object.defineProperty export forms are preserved" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/bundler/graph/parser_metadata.zig
+++ b/src/bundler/graph/parser_metadata.zig
@@ -150,6 +150,7 @@ pub fn materialize(
     module.exports_kind = determineExportsKind(scan_result, module.path);
     module.wrap_kind = if (module.exports_kind == .commonjs) .cjs else .none;
     module.has_cjs_export_signal = scan_result.has_module_exports or scan_result.has_exports_dot;
+    module.has_esmodule_marker = scan_result.has_esmodule_marker;
     module.can_skip_cjs_default_interop = Module.computeCanSkipCjsDefaultInterop(
         module.wrap_kind == .cjs,
         scan_result.has_module_exports,

--- a/src/bundler/graph/transform_prepass.zig
+++ b/src/bundler/graph/transform_prepass.zig
@@ -476,6 +476,7 @@ pub fn resyncAfterAstMutation(
         module.exports_kind = if (preserve_esm) previous_kind else refreshed_kind;
         module.wrap_kind = if (module.exports_kind == .commonjs) .cjs else .none;
         module.has_cjs_export_signal = refreshed_scan_result.has_module_exports or refreshed_scan_result.has_exports_dot;
+        module.has_esmodule_marker = refreshed_scan_result.has_esmodule_marker;
         module.can_skip_cjs_default_interop = Module.computeCanSkipCjsDefaultInterop(
             module.wrap_kind == .cjs,
             refreshed_scan_result.has_module_exports,

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -787,6 +787,16 @@ pub const Linker = struct {
         defer exported.deinit();
         var reserved = std.StringHashMap(void).init(self.allocator);
         defer reserved.deinit();
+
+        // Scope-hoisted output shares one top-level lexical environment. If a
+        // minified top-level declaration reuses an unresolved global name
+        // (`Set`, `Promise`, app-provided globals, ...), the declaration is
+        // hoisted and shadows that global even in modules evaluated earlier.
+        var global_it = self.reserved_globals.keyIterator();
+        while (global_it.next()) |name| {
+            try reserved.put(name.*, {});
+        }
+
         var mit = self.graph.modulesIterator();
         while (mit.next()) |m| {
             if (m.is_entry_point) {
@@ -1069,6 +1079,8 @@ pub const Linker = struct {
         defer scope.end();
 
         const um = @import("../codegen/unified_mangler.zig");
+
+        try self.collectReservedGlobals();
 
         var collected = try self.collectUnifiedInput();
         // bitsets 은 linker 로 이관 후 free, candidates/modules/reserved/import_refs 는 여기서 해제.

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -1021,8 +1021,24 @@ pub const Linker = struct {
                         }
                         continue;
                     }
-                    // .alias 는 re-export chain 중간 노드 → 궁극 `.semantic` 도출.
-                    // 미해결/순환/non-semantic 은 외부·shim → skip 안전.
+                    // 일반 named import 도 codegen/metadata 는 resolveExportChain 결과
+                    // (최종 export source)를 직접 참조로 rewrite 할 수 있다. importer 의
+                    // Phase B local 이름이 그 최종 source 의 Phase A mangled 이름을
+                    // 재사용하면 bare scope-hoist 에서 `COLORS.white` → `local.white`
+                    // 같은 silent-broken 이 발생하므로, import record 의 resolved module
+                    // 기준으로 먼저 궁극 `.semantic` source 를 예약한다.
+                    if (ib.import_record_index < m.import_records.len) {
+                        const tgt = m.import_records[ib.import_record_index].resolved;
+                        if (!tgt.isNone()) {
+                            if (self.resolveSemanticExportSource(tgt, ib.imported_name)) |sr| {
+                                try appendSem(self.allocator, &ir_buf, sr);
+                                continue;
+                            }
+                        }
+                    }
+                    // fallback: 미해결/순환/non-semantic 은 외부·shim 이라 mangle 대상이
+                    // 아니지만, populateImportSymbols 가 이미 source-side symbol 을 넣은
+                    // 단순 import 는 기존 경로로 보존한다.
                     const sr: bundler_symbol.SymbolRef = switch (ib.symbol) {
                         .semantic => ib.symbol,
                         .alias => |a| blk: {

--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -245,6 +245,9 @@ pub const Module = struct {
     /// scanner가 `module.exports`/`exports.*` 런타임 export 신호를 본 경우.
     /// export-star fallback은 빈 type barrel이 임의 이름을 claim하지 않도록 이 값으로 제한한다.
     has_cjs_export_signal: bool = false,
+    /// scanner가 `exports.__esModule` / `module.exports.__esModule` / defineProperty marker 를 본 경우.
+    /// CJS default interop 과 default-import property pruning 은 이 marker 를 존중해야 한다.
+    has_esmodule_marker: bool = false,
     /// CJS default import를 `__toESM(require_x()).default` 대신 `require_x()`로 낮출 수 있는지.
     /// 직접 `module.exports = ...` shape이고 `__esModule`/exports member 신호가 없을 때만 true.
     can_skip_cjs_default_interop: bool = false,

--- a/src/bundler/stmt_info.zig
+++ b/src/bundler/stmt_info.zig
@@ -37,12 +37,13 @@ pub const CjsExportFact = struct {
         object_property,
         define_property_value,
         define_property_getter,
+        es_module_marker,
 
         /// stmt 자체가 단일 export 라 BFS seed 시 stmt 전체를 enqueue 하면 충분한지.
         /// `assignment` (`exports.foo = rhs`) 만 그렇고, 나머지는 같은 stmt 안에 여러 export
         /// 가 공존할 수 있어 호출자가 rhs symbol 만 시드한다.
         pub fn seedsWholeStatement(self: Kind) bool {
-            return self == .assignment;
+            return self == .assignment or self == .es_module_marker;
         }
     };
 
@@ -1064,6 +1065,28 @@ fn appendCjsExportHelperFacts(
     return true;
 }
 
+fn appendCjsEsModuleMarkerFact(
+    allocator: std.mem.Allocator,
+    ast: *const Ast,
+    node: Node,
+    node_idx: u32,
+    stmt_i: u32,
+    unresolved_globals: ?*const purity.GlobalRefSet,
+    facts: *std.ArrayListUnmanaged(CjsExportFact),
+) !bool {
+    if (!try isSafeCjsEsModuleMarkerStmt(allocator, ast, node, unresolved_globals)) return false;
+    const export_name = try allocator.dupe(u8, "__esModule");
+    errdefer allocator.free(export_name);
+    try facts.append(allocator, .{
+        .export_name = export_name,
+        .statement_index = stmt_i,
+        .export_assignment_node = node_idx,
+        .kind = .es_module_marker,
+        .is_safe_to_prune = true,
+    });
+    return true;
+}
+
 fn invalidateConflictingCjsExportFacts(facts: []CjsExportFact, stmts: []StmtInfo) void {
     for (facts, 0..) |fact, i| {
         if (!fact.is_safe_to_prune) continue;
@@ -1454,7 +1477,7 @@ fn buildStmtInfoSlot(
         cjs_shape_extracted =
             try appendCjsDefinePropertyFact(allocator, ast, node, stmt_i, unresolved_globals, cjs_export_facts_buf, symbol_ids) or
             try appendCjsExportHelperFacts(allocator, ast, node, stmt_i, cjs_export_object_names, cjs_export_facts_buf, symbol_ids) or
-            try isSafeCjsEsModuleMarkerStmt(allocator, ast, node, unresolved_globals) or
+            try appendCjsEsModuleMarkerFact(allocator, ast, node, ni, stmt_i, unresolved_globals, cjs_export_facts_buf) or
             try collectAndAppendCjsObjectFacts(allocator, ast, node, stmt_i, unresolved_globals, cjs_export_facts_buf, symbol_ids);
     }
     const side_effects = if (node.tag == .import_declaration)

--- a/src/bundler/tree_shaker.zig
+++ b/src/bundler/tree_shaker.zig
@@ -1202,7 +1202,8 @@ pub const TreeShaker = struct {
         }
 
         if (target_module_for_import.wrap_kind == .cjs and ib.kind == .default) {
-            if (ib.namespace_used_properties) |props| {
+            if (!target_module_for_import.has_esmodule_marker and ib.namespace_used_properties != null) {
+                const props = ib.namespace_used_properties.?;
                 if (props.len > 0) {
                     for (props, 0..) |prop_name, pi| {
                         if (dispatch_stmt) |ds| gate: {
@@ -1359,6 +1360,7 @@ pub const TreeShaker = struct {
                 return;
             };
             try self.seedCjsExportFact(canon_mod, target_infos, fact, queue, reachable_stmts);
+            try self.seedCjsEsModuleMarkerForDefault(canon_mod, target_infos, canonical.export_name, queue, reachable_stmts);
             return;
         }
 
@@ -1496,6 +1498,7 @@ pub const TreeShaker = struct {
             return;
         };
         try self.seedCjsExportFact(mod_idx, target_infos, fact, queue, reachable_stmts);
+        try self.seedCjsEsModuleMarkerForDefault(mod_idx, target_infos, export_name, queue, reachable_stmts);
     }
 
     fn seedNodeBufferModuleObjectExport(
@@ -1573,6 +1576,18 @@ pub const TreeShaker = struct {
             try self.seedCjsExportFact(mod_idx, infos, fact, queue, reachable_stmts);
         }
         return found;
+    }
+
+    fn seedCjsEsModuleMarkerForDefault(
+        self: *TreeShaker,
+        mod_idx: u32,
+        infos: StmtInfos,
+        export_name: []const u8,
+        queue: *std.ArrayListUnmanaged(BfsItem),
+        reachable_stmts: []?std.DynamicBitSet,
+    ) std.mem.Allocator.Error!void {
+        if (!std.mem.eql(u8, export_name, "default")) return;
+        _ = try self.seedCjsExportFactsByName(mod_idx, infos, "__esModule", queue, reachable_stmts);
     }
 
     fn seedAllCjsExportFacts(
@@ -1667,7 +1682,8 @@ pub const TreeShaker = struct {
                 if (ib.kind == .namespace) {
                     try self.markAndSeedAllStmts(@intCast(target), queue, module_stmt_infos, reachable_stmts);
                 } else if (ib.kind == .default) {
-                    if (ib.namespace_used_properties) |props| {
+                    if (!target_module.has_esmodule_marker and ib.namespace_used_properties != null) {
+                        const props = ib.namespace_used_properties.?;
                         if (props.len > 0) {
                             for (props) |prop_name| {
                                 try self.seedCjsExportOrAll(@intCast(target), prop_name, queue, module_stmt_infos, reachable_stmts);
@@ -2147,7 +2163,8 @@ pub const TreeShaker = struct {
 
             if (target_module.wrap_kind == .cjs) {
                 if (ib.kind == .default) {
-                    if (ib.namespace_used_properties) |props| {
+                    if (!target_module.has_esmodule_marker and ib.namespace_used_properties != null) {
+                        const props = ib.namespace_used_properties.?;
                         if (props.len > 0) {
                             for (props) |prop_name| {
                                 try self.markExportUsed(@intCast(target_mod), prop_name);

--- a/src/codegen/codegen_test/basic.zig
+++ b/src/codegen/codegen_test/basic.zig
@@ -124,6 +124,18 @@ test "Codegen: drop console" {
     try std.testing.expectEqualStrings("const x=1;", r.output);
 }
 
+test "Codegen: drop console preserves required statement bodies" {
+    var r = try e2eFull(
+        std.testing.allocator,
+        "for (var x of xs) console.log(x); while (ok) console.log(ok); if (cond) console.log('then'); else keep(); label: console.log('label'); do console.log('body'); while (ok);",
+        .{ .drop_console = true },
+        .{ .minify_whitespace = true },
+        ".ts",
+    );
+    defer r.deinit();
+    try std.testing.expectEqualStrings("for(var x of xs);while(ok);if(cond);else keep();label:;do ;while(ok);", r.output);
+}
+
 test "Codegen: formatted output with tab" {
     var r = try e2eWithOptions(std.testing.allocator, "const x = 1;", .{});
     defer r.deinit();

--- a/src/semantic/analyzer.zig
+++ b/src/semantic/analyzer.zig
@@ -2554,7 +2554,7 @@ pub const SemanticAnalyzer = struct {
                     try self.declareArrowParams(@enumFromInt(raw_idx));
                 }
             },
-            .assignment_pattern, .assignment_expression => {
+            .assignment_pattern, .assignment_expression, .assignment_target_with_default => {
                 // 기본값: x = 1 → left는 파라미터, right는 기본값 표현식
                 try self.declareArrowParams(node.data.binary.left);
                 try self.visitNode(node.data.binary.right);
@@ -3623,7 +3623,7 @@ pub const SemanticAnalyzer = struct {
                     try self.visitNode(node.data.binary.right);
                 }
             },
-            .assignment_pattern, .assignment_target_with_default => {
+            .assignment_pattern, .assignment_expression, .assignment_target_with_default => {
                 // binary: { left = binding, right = default_value }
                 try self.registerBinding(node.data.binary.left, kind);
                 // 기본값 순회 — 식별자 참조를 포함할 수 있음 (e.g. function f(a = imported))

--- a/src/semantic/analyzer_test.zig
+++ b/src/semantic/analyzer_test.zig
@@ -1641,6 +1641,33 @@ test "references: node_index 로 AST 위치 역참조" {
     try std.testing.expect(refs.items[0].flags.read and !refs.items[0].flags.write);
 }
 
+test "references: arrow parameter default records imported value use" {
+    var fx = try RefFixture.init("import { value } from './dep'; const f = (x = value) => x;");
+    defer fx.deinit();
+
+    var refs: std.ArrayList(symbol_mod.Reference) = .empty;
+    defer refs.deinit(std.testing.allocator);
+    try fx.collectRefs("value", &refs);
+
+    var read_seen = false;
+    for (refs.items) |r| {
+        if (r.flags.read and !r.flags.write and r.isValueUse()) {
+            read_seen = true;
+            break;
+        }
+    }
+    try std.testing.expect(read_seen);
+
+    for (fx.ana.symbols.items) |sym| {
+        const name = sym.nameText(fx.parser.ast.source);
+        if (std.mem.eql(u8, name, "value")) {
+            try std.testing.expectEqual(@as(u32, 1), sym.reference_count);
+            return;
+        }
+    }
+    try std.testing.expect(false);
+}
+
 test "references: unresolved (전역) 은 기록 안 됨" {
     var fx = try RefFixture.init("console.log(1);");
     defer fx.deinit();

--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -452,9 +452,7 @@ fn removeDeadStores(ast: *Ast, ctx: MinifyCtx, skip_for_binding: ?*const std.Dyn
     for (ast.nodes.items, 0..) |node, i| {
         if (node.tag != .variable_declaration) continue;
         if (skip.isSet(i)) continue;
-        if (live_nodes) |lives| {
-            if (i >= lives.capacity() or !lives.isSet(i)) continue;
-        }
+        if (!isLiveMinifyNode(live_nodes, @intCast(i))) continue;
         tryRemoveDeadDecl(ast, ctx, @intCast(i), node, changed);
     }
 }
@@ -787,9 +785,7 @@ fn inlineTopLevelPrimitiveConstants(ast: *Ast, ctx: MinifyCtx, live_nodes: ?*con
                 if (read_i >= ctx.symbol_ids.len) continue;
                 if ((ctx.symbol_ids[read_i] orelse continue) != sym_id) continue;
                 if (forbidden.isSet(read_i)) continue;
-                if (live_nodes) |lives| {
-                    if (read_i >= lives.capacity() or !lives.isSet(read_i)) continue;
-                }
+                if (!isLiveMinifyNode(live_nodes, @intCast(read_i))) continue;
                 if (sourceSpanStart(read_node) <= decl_start) continue;
                 ast.nodes.items[read_i] = .{
                     .tag = init_node.tag,
@@ -839,9 +835,7 @@ fn inlineSingleUse(ast: *Ast, ctx: MinifyCtx, skip_for_binding: ?*const std.Dyna
 
     for (ast.nodes.items, 0..) |node, i| {
         if (node.tag != .identifier_reference) continue;
-        if (live_nodes) |lives| {
-            if (i >= lives.capacity() or !lives.isSet(i)) continue;
-        }
+        if (!isLiveMinifyNode(live_nodes, @intCast(i))) continue;
         if (i >= ctx.symbol_ids.len) continue;
         const sid = ctx.symbol_ids[i] orelse continue;
         if (sid >= counts.len) continue;
@@ -855,9 +849,7 @@ fn inlineSingleUse(ast: *Ast, ctx: MinifyCtx, skip_for_binding: ?*const std.Dyna
     for (ast.nodes.items, 0..) |node, i| {
         if (node.tag != .variable_declaration) continue;
         if (skip.isSet(i)) continue;
-        if (live_nodes) |lives| {
-            if (i >= lives.capacity() or !lives.isSet(i)) continue;
-        }
+        if (!isLiveMinifyNode(live_nodes, @intCast(i))) continue;
         tryInlineDecl(ast, ctx, counts, first_loc, &stmt_roots, @intCast(i), node, changed);
     }
 }

--- a/src/transformer/minify.zig
+++ b/src/transformer/minify.zig
@@ -318,6 +318,7 @@ fn runOnce(
     var changed = false;
     var i: u32 = 0;
     while (i < ast.nodes.items.len) : (i += 1) {
+        if (!isLiveMinifyNode(live_nodes, i)) continue;
         const node = ast.nodes.items[i];
         switch (node.tag) {
             .binary_expression => foldBinary(ast, scratch, i, node, &changed),
@@ -364,6 +365,11 @@ fn runOnce(
         removeDeadStores(ast, ctx, skip_for_binding, live_nodes, &changed);
     }
     return changed;
+}
+
+fn isLiveMinifyNode(live_nodes: ?*const std.DynamicBitSet, node_idx: u32) bool {
+    const lives = live_nodes orelse return true;
+    return node_idx < lives.capacity() and lives.isSet(node_idx);
 }
 
 fn markCallCalleeSequences(ast: *const Ast, protected_sequences: *std.DynamicBitSet) void {

--- a/src/transformer/transformer.zig
+++ b/src/transformer/transformer.zig
@@ -345,6 +345,8 @@ pub const Transformer = struct {
     // Control-flow visitors — transformer/control_flow.zig로 위임
     // ================================================================
     const control_flow_mod = @import("transformer/control_flow.zig");
+    pub const visitIfStatement = control_flow_mod.visitIfStatement;
+    pub const visitBinaryStatementBody = control_flow_mod.visitBinaryStatementBody;
     pub const visitForInOfTernary = control_flow_mod.visitForInOfTernary;
     pub const tryLowerForInOfPrivateTarget = control_flow_mod.tryLowerForInOfPrivateTarget;
     pub const visitForStatement = control_flow_mod.visitForStatement;

--- a/src/transformer/transformer/control_flow.zig
+++ b/src/transformer/transformer/control_flow.zig
@@ -12,6 +12,61 @@ const transformer_mod = @import("../transformer.zig");
 const Transformer = transformer_mod.Transformer;
 const Error = Transformer.Error;
 
+fn makeEmptyStatement(self: *Transformer, span: Span) Error!NodeIndex {
+    return self.ast.addNode(.{
+        .tag = .empty_statement,
+        .span = span,
+        .data = .{ .none = 0 },
+    });
+}
+
+fn ensureStatementBody(self: *Transformer, original_idx: NodeIndex, visited_idx: NodeIndex, parent_span: Span) Error!NodeIndex {
+    if (!visited_idx.isNone()) return visited_idx;
+    const span = if (!original_idx.isNone()) self.ast.getNode(original_idx).span else parent_span;
+    return makeEmptyStatement(self, span);
+}
+
+/// if-statement 의 then/else body 는 문법상 반드시 Statement 여야 한다.
+/// `--drop=console` 같은 pass 가 body expression_statement 를 `.none` 으로 지워도
+/// list context 처럼 제거하면 `if(cond)else ...` 가 되므로 empty_statement 로 보존한다.
+pub fn visitIfStatement(self: *Transformer, node: Node) Error!NodeIndex {
+    const t = node.data.ternary;
+    const new_test = try self.visitNode(t.a);
+    const raw_then = try self.visitNode(t.b);
+    const new_then = try ensureStatementBody(self, t.b, raw_then, node.span);
+    const raw_else = try self.visitNode(t.c);
+    const new_else = if (t.c.isNone())
+        raw_else
+    else
+        try ensureStatementBody(self, t.c, raw_else, node.span);
+    return self.ast.addNode(.{
+        .tag = .if_statement,
+        .span = node.span,
+        .data = .{ .ternary = .{ .a = new_test, .b = new_then, .c = new_else } },
+    });
+}
+
+/// while/do/with/labeled 처럼 `binary.right` 가 Statement body 인 노드 전용 visitor.
+/// body 가 drop 되어도 빈 statement 를 남겨 syntactic boundary 를 유지한다.
+pub fn visitBinaryStatementBody(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
+    const node = self.ast.getNode(idx);
+    const old_left = node.data.binary.left;
+    const old_right = node.data.binary.right;
+    const new_left = try self.visitNode(old_left);
+    const raw_right = try self.visitNode(old_right);
+    const new_right = try ensureStatementBody(self, old_right, raw_right, node.span);
+    if (new_left == old_left and new_right == old_right) return idx;
+    return self.ast.addNode(.{
+        .tag = node.tag,
+        .span = node.span,
+        .data = .{ .binary = .{
+            .left = new_left,
+            .right = new_right,
+            .flags = node.data.binary.flags,
+        } },
+    });
+}
+
 /// for-in/for-of/for-await-of 헤더 전용 ternary visit.
 /// `a`(left) 방문 시 in_for_in_of_header 플래그를 켜서, block_scoping 다운레벨로
 /// let/const → var 변환 시 불필요한 `= void 0` init 주입을 막는다 (#1386).
@@ -42,7 +97,8 @@ pub fn visitForInOfTernary(self: *Transformer, node: Node) Error!NodeIndex {
             const new_a = try self.visitNode(node.data.ternary.a);
             self.in_for_in_of_header = saved;
             const new_b = try self.visitNode(node.data.ternary.b);
-            const new_c = try self.visitNode(orig_body_idx);
+            const raw_c = try self.visitNode(orig_body_idx);
+            const new_c = try ensureStatementBody(self, orig_body_idx, raw_c, node.span);
 
             if (has_capture) {
                 const result = try BlockScoping.buildLoopClosureWithFlow(
@@ -81,7 +137,8 @@ pub fn visitForInOfTernary(self: *Transformer, node: Node) Error!NodeIndex {
     const new_a = try self.visitNode(node.data.ternary.a);
     self.in_for_in_of_header = saved;
     const new_b = try self.visitNode(node.data.ternary.b);
-    const new_c = try self.visitNode(node.data.ternary.c);
+    const raw_c = try self.visitNode(node.data.ternary.c);
+    const new_c = try ensureStatementBody(self, node.data.ternary.c, raw_c, node.span);
     return self.ast.addNode(.{
         .tag = node.tag,
         .span = node.span,
@@ -196,7 +253,8 @@ pub fn visitForStatement(self: *Transformer, node: Node) Error!NodeIndex {
             const new_init = try self.visitNode(init_idx);
             const new_test = try self.visitNode(self.readNodeIdx(e, 1));
             const new_update = try self.visitNode(self.readNodeIdx(e, 2));
-            const new_body = try self.visitNode(orig_body_idx);
+            const raw_body = try self.visitNode(orig_body_idx);
+            const new_body = try ensureStatementBody(self, orig_body_idx, raw_body, node.span);
 
             if (has_capture) {
                 const result = try BlockScoping.buildLoopClosureWithFlow(
@@ -235,7 +293,9 @@ pub fn visitForStatement(self: *Transformer, node: Node) Error!NodeIndex {
     const new_init = try self.visitNode(init_idx);
     const new_test = try self.visitNode(self.readNodeIdx(e, 1));
     const new_update = try self.visitNode(self.readNodeIdx(e, 2));
-    const new_body = try self.visitNode(self.readNodeIdx(e, 3));
+    const old_body = self.readNodeIdx(e, 3);
+    const raw_body = try self.visitNode(old_body);
+    const new_body = try ensureStatementBody(self, old_body, raw_body, node.span);
     return self.addExtraNode(.for_statement, node.span, &.{
         @intFromEnum(new_init), @intFromEnum(new_test), @intFromEnum(new_update), @intFromEnum(new_body),
     });

--- a/src/transformer/transformer/node_dispatch.zig
+++ b/src/transformer/transformer/node_dispatch.zig
@@ -357,6 +357,8 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
         .while_statement,
         .do_while_statement,
         .with_statement,
+        => self.visitBinaryStatementBody(idx),
+
         // JSX
         .jsx_attribute,
         .jsx_namespaced_name,
@@ -428,7 +430,9 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
         => self.visitUnaryExtra(node),
 
         // === 삼항 노드: 자식 3개 재귀 방문 ===
-        .if_statement, .conditional_expression, .for_in_statement => {
+        .if_statement => self.visitIfStatement(node),
+        .conditional_expression => self.visitTernaryNode(node),
+        .for_in_statement => {
             if (node.tag == .for_in_statement and self.current_private_fields.len > 0) {
                 if (try self.tryLowerForInOfPrivateTarget(node)) |result| return result;
             }
@@ -483,7 +487,7 @@ pub fn visitNodeInner(self: *Transformer, idx: NodeIndex) Error!NodeIndex {
                     return es2015_for_of.ES2015ForOf(Transformer).lowerForOfStatementLabeled(self, child, new_label);
                 }
             }
-            return self.visitBinaryNode(idx);
+            return self.visitBinaryStatementBody(idx);
         },
 
         // === extra 기반 노드: 별도 처리 ===

--- a/tests/benchmark/_runner.ts
+++ b/tests/benchmark/_runner.ts
@@ -12,6 +12,11 @@ import { join, resolve } from 'node:path';
 export const ROOT = resolve(__dirname, '../..');
 export const ZNTC_BIN = join(ROOT, 'zig-out/bin/zntc');
 
+/// `spawnSync` 의 기본 maxBuffer (1MB) 가 `--profile-level=detailed` 의 1000-module
+/// profile JSON 출력 등을 자를 수 있다 (#3494 perf 회귀). 64MB 면 detailed profile
+/// 도 충분히 수용. 다른 벤치마크에서도 동일한 truncate 회피용으로 재사용.
+export const BENCHMARK_MAX_BUFFER = 64 * 1024 * 1024;
+
 export function buildBin(label: string): void {
   if (existsSync(ZNTC_BIN)) return;
   console.log(`[${label}] zntc binary not found, building ReleaseFast...`);

--- a/tests/benchmark/bundle-perf.ts
+++ b/tests/benchmark/bundle-perf.ts
@@ -23,6 +23,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { performance } from 'node:perf_hooks';
 import {
+  BENCHMARK_MAX_BUFFER,
   ROOT,
   ZNTC_BIN,
   buildBin as buildBinShared,
@@ -107,7 +108,11 @@ function runZntc(
   }
 
   const start = performance.now();
-  const r = spawnSync(ZNTC_BIN, args, { stdio: 'pipe', timeout: 30000 });
+  const r = spawnSync(ZNTC_BIN, args, {
+    stdio: 'pipe',
+    timeout: 30000,
+    maxBuffer: BENCHMARK_MAX_BUFFER,
+  });
   const wall_ms = performance.now() - start;
   if (r.status !== 0) {
     throw new Error(`zntc failed: ${r.stderr?.toString().slice(0, 400)}`);
@@ -132,7 +137,11 @@ function runRolldown(bin: string, entry: string, outDir: string, externals: stri
   if (externals.length > 0) args.push('--external', externals.join(','));
 
   const start = performance.now();
-  const r = spawnSync(bin, args, { stdio: 'pipe', timeout: 30000 });
+  const r = spawnSync(bin, args, {
+    stdio: 'pipe',
+    timeout: 30000,
+    maxBuffer: BENCHMARK_MAX_BUFFER,
+  });
   const wall_ms = performance.now() - start;
   if (r.status !== 0) {
     throw new Error(`rolldown failed: ${r.stderr?.toString().slice(0, 600)}`);
@@ -169,6 +178,7 @@ function runRspack(bin: string, configPath: string, outDir: string): RunResult {
     cwd: ROOT,
     stdio: 'pipe',
     timeout: 30000,
+    maxBuffer: BENCHMARK_MAX_BUFFER,
   });
   const wall_ms = performance.now() - start;
   if (r.status !== 0) {


### PR DESCRIPTION
## 요약

RN release 번들에서 `--minify` / `--drop=console` 조합으로 실제 앱을 실행하며 발견한 문제들을 루트커즈 기준으로 하나의 PR에 커밋 단위로 쌓아 수정합니다.

핵심은 fallback이 아니라, ZNTC가 release/minify 경로에서도 Metro와 동일하게 안전한 JavaScript 의미를 보존하도록 하는 것입니다.

## 수정한 루트커즈

1. RN bundle CLI 경로에 `--drop=console/debugger` 옵션이 preset까지 전달되지 않던 문제
2. `console.*` 제거 후 필수 statement body 자리가 사라져 invalid JS가 생성되던 문제
3. 릴리즈 미니파이에서 unresolved global 이름(`Set` 등)을 top-level 로컬 이름으로 재사용해 전역 객체를 shadowing하던 문제
4. CommonJS default interop marker가 미니파이/interop 경로에서 보존되지 않아 default import가 깨지던 문제
5. re-export를 경유한 export/import 이름이 minify identifier와 충돌해 실제 export 값이 바뀌던 문제
6. `minifySyntax`가 root에서 도달 불가능한 orphan AST 노드까지 fold하면서 reference count를 중복 감산하고, 살아있는 `const` 함수 선언을 제거하던 문제
7. RN transform 후 parameter default initializer 안의 imported value reference가 semantic resync에서 누락되어 release bundle에 bare global lookup이 남던 문제

## 루트커즈 1: RN CLI drop 옵션 누락

`bundle --platform=react-native` 경로에서 CLI의 `--drop=console` / `--drop=debugger` 옵션이 `buildRnBundleOptions`까지 전달되지 않았습니다.

그 결과 일반 bundle 경로와 RN preset 경로의 release 옵션이 달라졌고, Xcode build phase에서 기대한 console 제거 정책이 실제 RN bundle에 적용되지 않을 수 있었습니다.

수정은 CLI drop 옵션을 RN preset 옵션까지 명시적으로 forwarding하는 것입니다.

## 루트커즈 2: console drop 후 statement body invariant 깨짐

`--drop=console`은 `console.log(...)` 같은 expression statement를 `.none`으로 치환합니다. statement list 안에서는 `.none`을 제거하는 것이 맞지만, 아래 위치들은 JavaScript 문법상 body가 반드시 Statement여야 합니다.

- `for (...) <body>`
- `for (... of ...) <body>` / `for (... in ...) <body>`
- `while (...) <body>`
- `do <body> while (...)`
- `if (...) <then>` 및 `else <else>`
- `label: <body>`
- `with (...) <body>`

기존 transformer는 list context와 statement-body context를 구분하지 않아, 예를 들어 다음 입력이:

```js
for (var x of xs) console.log(x);
```

console drop 이후 body가 `.none`이 되고, minify codegen에서 다음처럼 깨질 수 있었습니다.

```js
for(var x of xs)}
```

혹은 여러 statement가 이어질 때 boundary가 없어져 `for(var x of xs)while(ok)...`처럼 다음 statement가 body처럼 붙는 문제가 생겼습니다.

수정은 statement-body 전용 visitor에서 body 결과가 `.none`이면 `empty_statement`로 보정하는 방식입니다. statement list에서는 기존처럼 `.none` 제거 정책을 유지합니다.

즉 이 변경은 console drop을 숨기거나 fallback하는 것이 아니라, AST transform 후에도 JavaScript 문법상 필요한 statement boundary를 보존하는 invariant 수정입니다.

## 루트커즈 3: minify name shadowing

릴리즈 앱 실행 중 아래 형태의 runtime crash가 발생했습니다.

```text
TypeError: Cannot convert undefined value to object
```

실제 생성된 minified bundle에서는 외부 라이브러리 내부 함수가 다음처럼 `Set`으로 축약되었습니다.

```js
function Set(id) { ... }
```

동시에 React Native core 쪽 모듈은 top-level에서 전역 built-in `Set`을 사용합니다.

```js
new Set([...])
```

ZNTC release output은 scope-hoisted top-level lexical environment를 공유합니다. 이 상태에서 minifier가 top-level 함수명을 `Set`으로 만들면, function declaration hoisting 때문에 모듈 평가 순서와 무관하게 bundle 전체에서 전역 built-in `Set`을 가립니다.

그래서 RN core가 먼저 평가되더라도 `new Set(...)`은 built-in이 아니라 다른 모듈의 로컬 함수 `Set`을 보게 되고, 해당 함수 내부 state가 준비되지 않아 runtime crash가 발생할 수 있었습니다.

### 왜 dev/Metro에서는 괜찮았나

- ZNTC dev/non-minify 경로에서는 내부 함수가 `Set`으로 축약되지 않았습니다.
- Metro는 각 모듈 factory scope가 분리되어 있으므로 한 모듈의 로컬 `function Set`이 다른 모듈의 top-level built-in `Set` 참조를 shadowing하지 않습니다.
- `strictExecutionOrder`는 factory/init 호출 순서를 보장하지만, 이번 문제는 실행 전에 lexical hoisting으로 이름이 이미 shadowing되는 문제라서 실행 순서 옵션만으로 해결되지 않습니다.

### 수정

minify identifier 계산 전에 모든 모듈의 unresolved reference와 외부 global identifier를 수집하고, unified mangle의 reserved pool에 주입합니다.

이제 bundle 안에서 unresolved global로 관측된 이름(`Set`, `Promise`, RN/app-provided globals 등)은 top-level minified local name 후보로 재사용되지 않습니다.

## 루트커즈 4: CJS default interop marker 보존

일부 CommonJS 패키지는 default interop 판정에 내부 marker나 export shape를 의존합니다. 기존 release/minify 경로에서 이 marker가 충분히 보존되지 않아 default import 결과가 함수/컴포넌트가 아니라 wrapper 또는 `undefined`가 되는 케이스가 있었습니다.

그 결과 RN 화면 등록이나 navigator 구성에서 다음 류의 문제가 발생할 수 있었습니다.

```text
Element type is invalid: expected a string or a class/function but got: undefined
```

수정은 CommonJS default interop marker를 번들링/미니파이 후에도 보존하도록 하는 것입니다.

## 루트커즈 5: re-export import 이름 예약 누락

re-export 체인을 거친 top-level 이름이 minify identifier와 충돌하면서, 실제로는 import/export binding으로 예약돼야 할 이름이 함수 local 이름으로 재사용될 수 있었습니다.

이 문제는 화면 색상/테마 객체처럼 re-export된 상수를 사용하는 코드에서 잘못된 값 참조로 드러났습니다.

수정은 re-export 경유 import/export 이름도 minifier의 reserved set에 포함해, top-level/local mangle 과정에서 충돌하지 않도록 하는 것입니다.

## 루트커즈 6: minifySyntax가 orphan AST까지 fold하며 ref count 중복 감산

전화번호 인증 요청 실패는 네트워크/API 문제가 아니라, RN core의 `XMLHttpRequest.send` 내부 함수 선언이 release minify에서 제거된 것이 원인이었습니다.

원본 RN 패턴은 다음과 같습니다.

```js
const DEBUG_NETWORK_SEND_DELAY = false;
function send(data) {
  let nativeResponseType = 'text';
  const doSend = () => {
    RCTNetworking.sendRequest(...);
  };
  if (DEBUG_NETWORK_SEND_DELAY) {
    setTimeout(doSend, DEBUG_NETWORK_SEND_DELAY);
  } else {
    doSend();
  }
}
```

`DEBUG_NETWORK_SEND_DELAY`가 false로 fold되면 then branch의 `doSend` 참조는 제거되고 else branch의 `doSend()`는 살아있어야 합니다.

그런데 transformer가 visit 과정에서 만든 orphan/duplicate AST 노드까지 `minifySyntax` fold loop가 모두 순회했습니다. 그 결과 dead branch ref 감산이 root에서 도달 가능한 실제 노드뿐 아니라 orphan 노드에서도 반복 적용되어, `doSend`의 effective ref count가 0으로 떨어졌습니다.

이후 dead store 제거가 살아있는 `const doSend = ...` 선언을 제거했고, 최종 번들은 다음처럼 깨졌습니다.

```js
{ doSend() }
```

실제 앱에서는 이 때문에 XHR 전송 전에 아래 오류가 발생했습니다.

```text
Property 'doSend' doesn't exist
```

### 수정

`minify`는 이미 매 iteration마다 root에서 도달 가능한 live node set을 계산하고 있었습니다. 다만 이 live set을 dead-store/inline 단계에만 쓰고, 앞단 fold loop에는 적용하지 않았습니다.

이번 수정은 `runOnce`의 fold loop도 live node만 처리하도록 바꿉니다.

- root에서 도달 가능한 실제 AST만 fold
- orphan/duplicate AST는 ref count 감산 대상에서 제외
- newly appended node는 다음 fixed-point iteration에서 다시 live set을 계산해 처리

이렇게 하면 dead branch ref 감산은 실제 코드 경로 기준으로 한 번만 일어나고, 살아있는 `doSend()` 참조 때문에 `const doSend = ...` 선언이 정상 보존됩니다.

## 루트커즈 7: transformed parameter default의 import reference 누락

`연결대기` 진입 중 아래 형태의 release-only runtime crash가 발생했습니다.

```text
ReferenceError: Property 'DEFAULT_THROTTLE_MILLISECONDS' doesn't exist
```

앱 소스는 다음처럼 imported const를 arrow function parameter default에서 사용합니다.

```js
import { DEFAULT_THROTTLE_MILLISECONDS } from '~/lib/constant/ui';

const useThrottleEventHandler = (
  throttleTime = DEFAULT_THROTTLE_MILLISECONDS,
) => {
  // ...
};
```

원본 AST 기준 semantic analyzer는 arrow parameter default의 imported value use를 기록합니다. 하지만 RN release/minify 경로에서는 transform prepass 이후 arrow가 일반 `function` 형태로 낮아지고, parameter default가 `assignment_expression` 형태로 남는 경로가 있었습니다.

기존 `registerBinding`은 일반 function parameter default에서 `assignment_pattern` / `assignment_target_with_default`만 default initializer로 처리했고, `assignment_expression`은 처리하지 않았습니다. 그 결과 transform 이후 semantic resync에서 default initializer의 `DEFAULT_THROTTLE_MILLISECONDS` 참조가 symbol에 연결되지 않았습니다.

symbol id가 빠진 상태로 codegen/linking이 진행되면 ESM import getter/init 호출이 주입되지 못하고, release bundle에 다음처럼 bare global lookup이 남았습니다.

```js
function(throttleTime = DEFAULT_THROTTLE_MILLISECONDS) { ... }
```

React Native 런타임에는 그런 전역 property가 없으므로 해당 화면 진입 시 `ReferenceError`가 발생했습니다.

### 수정

- arrow parameter 선언 경로에서 `assignment_target_with_default`도 default initializer로 순회하도록 보강했습니다.
- 일반 function parameter binding 경로에서 `assignment_expression`도 parameter default로 처리해 right-hand side value references를 방문하도록 수정했습니다.
- release/minify RN bundle 회귀 테스트를 추가해 bare imported const가 남지 않고 lazy module init expression으로 바뀌는지 검증했습니다.

수정 후 실제 bundle의 해당 부분은 다음처럼 import module init이 보존됩니다.

```js
function(ne = (initUiModule(), defaultThrottleMs)) { ... }
```

즉 이번 수정은 런타임에서 `undefined`를 막는 방어가 아니라, transform 이후 semantic resync가 default initializer의 value-use를 놓치지 않도록 하는 루트커즈 수정입니다.

## 테스트

이번 PR에서 추가/확인한 주요 테스트입니다.

```sh
zig build test -Dtest-filter="Codegen: drop console preserves required statement bodies"
zig build test -Dtest-filter="drop console"
zig build test -Dtest-filter=Codegen
```

```sh
zig build test -Dtest-filter="Bundler: unresolved globals reserve minified top-level names"
zig build test -Dtest-filter=Bundler
```

```sh
bun test ./packages/core/test/cli/react-native-bundle.ts packages/react-native/src/preset.test.ts
```

```sh
bun test ./packages/core/test/core/edge-combinations/minify-identifiers.ts ./packages/core/test/core/edge-combinations.ts
```

```sh
bun test ./packages/core/test/core/edge-combinations/minify-syntax.ts -t '죽은 분기'
bun test ./packages/core/test/core/edge-combinations/minify-syntax.ts ./packages/core/test/core/edge-combinations.ts
zig build test --summary all -Dtest-filter="Minify"
```

```sh
zig build test --summary all -Dtest-filter="arrow parameter default records imported value use"
zig build test --summary all -Dtest-filter="minified bare parameter default"
zig build test --summary all -Dtest-filter="react_native inlineRequires"
```

확인 결과:

- 신규 `minifySyntax` 회귀 테스트는 수정 전 실패, 수정 후 통과
- edge combination 테스트 통과
- Zig `Minify` 테스트 70개 통과
- RN preset/CLI 테스트 통과
- transformed/default parameter import reference 회귀 테스트 통과
- RN inlineRequires 테스트 31개 통과
- `zig build napi` 통과

## 실제 RN release 검증

외부 RN 앱에서 Xcode Release simulator build phase를 ZNTC script로 연결해 검증했습니다.

확인 조건:

- `Release`
- `iphonesimulator`
- ZNTC script 경유
- `--minify --drop=console`
- Hermes bytecode compile 포함

확인한 동작:

- release 앱 실행
- 스플래시 이후 화면 진입
- 로그인/인증번호 요청 성공
- 주요 탭 진입 중 기존 crash 재현 안 됨
- 색상/테마 re-export 값 정상 표시
- MQTT/env 값 정상 주입
- `연결대기` 진입 크래쉬 원인이던 `DEFAULT_THROTTLE_MILLISECONDS` bare global lookup 제거 확인

특히 OTP 요청은 앱 로그에서 XHR이 실제 API endpoint까지 나가고 성공 콜백까지 도달하는 것을 확인했습니다. 이전 실패 원인이던 `Property 'doSend' doesn't exist`는 재현되지 않았습니다.

`연결대기` 크래쉬 건은 새 ZNTC NAPI로 release/minified raw bundle을 재생성한 뒤, 문제 지점이 아래처럼 바뀐 것을 확인했습니다.

```js
function(ne = (initUiModule(), defaultThrottleMs)) { ... }
```

이후 Hermes bytecode로 컴파일해 시뮬레이터 앱의 `main.jsbundle`을 교체하고 앱을 실행했습니다. 앱 프로세스는 정상 유지됐고, launch 직후 로그에서 `DEFAULT_THROTTLE`, JavaScript fatal exception, native fatal exception은 재현되지 않았습니다.

참고로 중간 실패 중 하나는 ZNTC 문제가 아니라 `/tmp` 디스크 부족이었습니다.

```text
libtool: can't write to output file (No space left on device)
```

이후 DerivedData/tmp 정리 후 같은 조건으로 재빌드해 성공했습니다.
