### PR TITLE
docs(napi): 설치 예제를 패키지매니저 탭으로 통일

### DIFF
--- a/documents/src/content/docs/en/reference/napi.mdx
+++ b/documents/src/content/docs/en/reference/napi.mdx
@@ -5,6 +5,7 @@ description: Reference for @zntc/core's transpile / build / watch / vitePlugin a
 
 {/* Options below are cherry-picked — source of truth is reference/options. Update both when adding options. */}
 
+import { Tabs, TabItem } from "@astrojs/starlight/components";
 import Mermaid from "@components/Mermaid";
 import { NAPI_ARCHITECTURE_CHART } from "@components/diagrams";
 
@@ -29,9 +30,33 @@ Plugin hooks like `onResolve` / `onLoad` are awoken via NAPI threadsafe-fn whene
 
 ## Install + use
 
-```bash
-bun add @zntc/core
-```
+<Tabs syncKey="pkg">
+  <TabItem label="bun">
+    ```bash
+    bun add @zntc/core
+    ```
+  </TabItem>
+  <TabItem label="npm">
+    ```bash
+    npm i @zntc/core
+    ```
+  </TabItem>
+  <TabItem label="pnpm">
+    ```bash
+    pnpm add @zntc/core
+    ```
+  </TabItem>
+  <TabItem label="yarn">
+    ```bash
+    yarn add @zntc/core
+    ```
+  </TabItem>
+  <TabItem label="deno">
+    ```bash
+    deno add npm:@zntc/core
+    ```
+  </TabItem>
+</Tabs>
 
 ```ts
 import { transpile, build, watch } from "@zntc/core";

--- a/documents/src/content/docs/reference/napi.mdx
+++ b/documents/src/content/docs/reference/napi.mdx
@@ -5,6 +5,7 @@ description: "@zntc/core 의 transpile / build / watch / vitePlugin 등 주요 �
 
 {/* 옵션 표는 cherry-pick — source-of-truth 는 reference/options. 옵션 추가 시 양쪽 모두 갱신 검토. */}
 
+import { Tabs, TabItem } from "@astrojs/starlight/components";
 import Mermaid from "@components/Mermaid";
 import { NAPI_ARCHITECTURE_CHART } from "@components/diagrams";
 
@@ -29,9 +30,33 @@ JS plugin 의 `onResolve` / `onLoad` 등은 native bundler 가 모듈을 만나�
 
 ## 설치 + 사용
 
-```bash
-bun add @zntc/core
-```
+<Tabs syncKey="pkg">
+  <TabItem label="bun">
+    ```bash
+    bun add @zntc/core
+    ```
+  </TabItem>
+  <TabItem label="npm">
+    ```bash
+    npm i @zntc/core
+    ```
+  </TabItem>
+  <TabItem label="pnpm">
+    ```bash
+    pnpm add @zntc/core
+    ```
+  </TabItem>
+  <TabItem label="yarn">
+    ```bash
+    yarn add @zntc/core
+    ```
+  </TabItem>
+  <TabItem label="deno">
+    ```bash
+    deno add npm:@zntc/core
+    ```
+  </TabItem>
+</Tabs>
 
 ```ts
 import { transpile, build, watch } from "@zntc/core";


### PR DESCRIPTION
## 배경

[reference/napi](https://ohah.github.io/zntc/reference/napi/) 의 `설치 + 사용` 섹션이 `bun add @zntc/core` **단독**이라, 다른 문서(`guides/installation`)의 패키지매니저 탭 UI 와 불일치했습니다.

## 변경

`guides/installation.mdx` 와 동일한 `@astrojs/starlight/components` 의 `<Tabs syncKey="pkg">` + `<TabItem>` 패턴으로 교체 (bun / npm / pnpm / yarn / deno 5종). `syncKey="pkg"` 라 사이트 전역에서 선택한 매니저가 동기화됩니다.

- `@zntc/core` 는 프로그래머블(런타임) 사용이므로 `-D` 없이 일반 의존으로 표기 (install 페이지의 devDep `-D` 와 의도적으로 구분, 기존 napi 표기 유지)
- 사용 예제(`ts` 코드블록)는 매니저 무관이라 단일 블록 유지 (installation.mdx 의 코드 예제 관례와 동일)
- i18n: ko(`docs/reference/napi.mdx`) + en(`docs/en/reference/napi.mdx`) 양쪽 동시 수정

문서 단독 변경. 태그 균형/​import 검증 완료 (Tabs 1:1, TabItem 5:5, 기존 검증된 패턴 미러링).

🤖 Generated with [Claude Code](https://claude.com/claude-code)