### PR TITLE
refactor(regexp): AST → 패턴 텍스트 printer 추가 (#1475 PR1)

### DIFF
--- a/src/regexp/mod.zig
+++ b/src/regexp/mod.zig
@@ -22,6 +22,7 @@ pub const ast = @import("ast.zig");
 pub const flags = @import("flags.zig");
 pub const diagnostics = @import("diagnostics.zig");
 pub const parser = @import("parser.zig");
+pub const printer = @import("printer.zig");
 pub const unicode_property = @import("unicode_property.zig");
 
 /// 정규식 리터럴을 검증한다.
@@ -82,6 +83,7 @@ test {
     _ = flags;
     _ = diagnostics;
     _ = parser;
+    _ = printer;
     _ = unicode_property;
 
     // test files
@@ -89,4 +91,5 @@ test {
     _ = @import("unicode_property_test.zig");
     _ = @import("flags_test.zig");
     _ = @import("ast_test.zig");
+    _ = @import("printer_test.zig");
 }

--- a/src/regexp/printer.zig
+++ b/src/regexp/printer.zig
@@ -1,0 +1,265 @@
+//! RegExp AST → 패턴 텍스트 직렬화기.
+//!
+//! `parser.zig` 가 빌드한 `ast.RegExpAst` 를 다시 패턴 문자열로 복원한다.
+//! 노드 `data` 만으로 재구성하므로 변환 후 생성된 합성 노드도 그대로 출력된다
+//! (source span 에 의존하지 않음 — 변환 시 span 은 stale).
+//!
+//! 출력은 canonical form 이다: 같은 의미의 입력이라도 표현이 정규화될 수 있다
+//! (예: `\u{41}`→`A` 고정 폭, `\ca`→`\cA` 대문자, `a{3,3}`→`a{3}`).
+//! 따라서 라운드트립 불변식은 "바이트 동일" 이 아니라 "print 멱등 + 구조
+//! 보존" 이다 (printer_test.zig 의 라운드트립 테스트 참조).
+//!
+//! 알려진 비-라운드트립 (AST layout 한계, printer 책임 아님):
+//!   - `\p{Script=Greek}` 의 `=value` 는 parser 가 name 범위만 보존하므로
+//!     `\p{Script}` 로 축약된다 (#1475 후속 PR 에서 AST 확장 시 해소).
+
+const std = @import("std");
+const ast = @import("ast.zig");
+
+pub const PrintError = error{ OutOfMemory, InvalidUtf8 };
+
+/// AST 전체를 패턴 텍스트로 직렬화한다. 반환 슬라이스 소유권은 호출자.
+pub fn print(tree: ast.RegExpAst, allocator: std.mem.Allocator) PrintError![]u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    errdefer buf.deinit(allocator);
+    var p = Printer{ .tree = tree, .buf = &buf, .allocator = allocator };
+    try p.node(tree.root);
+    return buf.toOwnedSlice(allocator);
+}
+
+const UNBOUNDED = std.math.maxInt(u32);
+const UNNAMED = std.math.maxInt(u32);
+
+const Printer = struct {
+    tree: ast.RegExpAst,
+    buf: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+
+    fn w(self: *Printer, s: []const u8) PrintError!void {
+        try self.buf.appendSlice(self.allocator, s);
+    }
+
+    fn wb(self: *Printer, b: u8) PrintError!void {
+        try self.buf.append(self.allocator, b);
+    }
+
+    /// codepoint 를 UTF-8 로 인코딩해 append.
+    fn wCp(self: *Printer, cp: u32) PrintError!void {
+        if (cp > 0x10FFFF or (cp >= 0xD800 and cp <= 0xDFFF)) return PrintError.InvalidUtf8;
+        var tmp: [4]u8 = undefined;
+        const n = std.unicode.utf8Encode(@intCast(cp), &tmp) catch return PrintError.InvalidUtf8;
+        try self.w(tmp[0..n]);
+    }
+
+    /// comptime 포맷 스펙으로 정수를 직렬화 (codegen/writer.zig 의 hex emit 관례와 동일).
+    /// u32 최대 10자리(10진)/8자리(16진)/11자리(8진) → [12]u8 로 충분.
+    fn fmtInt(self: *Printer, comptime spec: []const u8, v: u32) PrintError!void {
+        var tmp: [12]u8 = undefined;
+        const s = std.fmt.bufPrint(&tmp, spec, .{v}) catch unreachable;
+        try self.w(s);
+    }
+
+    /// modifier 비트 (i=1, m=2, s=4) → 문자.
+    fn modifiers(self: *Printer, bits: u32) PrintError!void {
+        if (bits & 1 != 0) try self.wb('i');
+        if (bits & 2 != 0) try self.wb('m');
+        if (bits & 4 != 0) try self.wb('s');
+    }
+
+    fn childList(self: *Printer, list: ast.NodeList, sep: []const u8) PrintError!void {
+        const ids = self.tree.getNodeList(list);
+        for (ids, 0..) |child, i| {
+            if (i != 0 and sep.len != 0) try self.w(sep);
+            try self.node(@enumFromInt(child));
+        }
+    }
+
+    fn node(self: *Printer, idx: ast.NodeIndex) PrintError!void {
+        if (idx == .none) return;
+        const n = self.tree.getNode(idx);
+        switch (n.tag) {
+            .disjunction => try self.childList(n.getNodeList(), "|"),
+            .alternative => try self.childList(n.getNodeList(), ""),
+
+            .boundary_assertion => switch (@as(ast.BoundaryAssertionKind, @enumFromInt(n.data[0]))) {
+                .start => try self.wb('^'),
+                .end => try self.wb('$'),
+                .boundary => try self.w("\\b"),
+                .negative_boundary => try self.w("\\B"),
+            },
+
+            .lookaround_assertion => {
+                try self.w(switch (@as(ast.LookAroundAssertionKind, @enumFromInt(n.data[0]))) {
+                    .lookahead => "(?=",
+                    .negative_lookahead => "(?!",
+                    .lookbehind => "(?<=",
+                    .negative_lookbehind => "(?<!",
+                });
+                try self.node(@enumFromInt(n.data[1]));
+                try self.wb(')');
+            },
+
+            .character => try self.character(n),
+            .dot => try self.wb('.'),
+
+            .character_class_escape => {
+                try self.wb('\\');
+                try self.wb(switch (@as(ast.CharacterClassEscapeKind, @enumFromInt(n.data[0]))) {
+                    .d => 'd',
+                    .negative_d => 'D',
+                    .s => 's',
+                    .negative_s => 'S',
+                    .w => 'w',
+                    .negative_w => 'W',
+                });
+            },
+
+            .unicode_property_escape => {
+                try self.w(if (n.data[2] != 0) "\\P{" else "\\p{");
+                try self.w(self.tree.source[n.data[0]..n.data[1]]);
+                try self.wb('}');
+            },
+
+            .character_class => {
+                const negative = (n.data[0] & 1) != 0;
+                const kind: ast.CharacterClassContentsKind = @enumFromInt((n.data[0] >> 1) & 0x3);
+                try self.wb('[');
+                if (negative) try self.wb('^');
+                try self.childList(n.getClassBody(), switch (kind) {
+                    .@"union" => "",
+                    .intersection => "&&",
+                    .subtraction => "--",
+                });
+                try self.wb(']');
+            },
+
+            .character_class_range => {
+                try self.node(@enumFromInt(n.data[0]));
+                try self.wb('-');
+                try self.node(@enumFromInt(n.data[1]));
+            },
+
+            .class_string_disjunction => {
+                try self.w("\\q{");
+                try self.childList(n.getNodeList(), "|");
+                try self.wb('}');
+            },
+            .class_string => try self.childList(n.getNodeList(), ""),
+
+            .capturing_group => {
+                if (n.data[0] == UNNAMED) {
+                    try self.wb('(');
+                } else {
+                    try self.w("(?<");
+                    try self.w(self.tree.source[n.data[0]..n.data[1]]);
+                    try self.wb('>');
+                }
+                try self.node(@enumFromInt(n.data[2]));
+                try self.wb(')');
+            },
+
+            .ignore_group => {
+                const enabling = n.data[0];
+                const disabling = n.data[1];
+                if (enabling == 0 and disabling == 0) {
+                    try self.w("(?:");
+                } else {
+                    try self.w("(?");
+                    try self.modifiers(enabling);
+                    if (disabling != 0) {
+                        try self.wb('-');
+                        try self.modifiers(disabling);
+                    }
+                    try self.wb(':');
+                }
+                try self.node(@enumFromInt(n.data[2]));
+                try self.wb(')');
+            },
+
+            .quantifier => {
+                try self.node(n.getQuantifierBody());
+                const min = n.data[0];
+                const max = n.data[1];
+                if (min == 0 and max == UNBOUNDED) {
+                    try self.wb('*');
+                } else if (min == 1 and max == UNBOUNDED) {
+                    try self.wb('+');
+                } else if (min == 0 and max == 1) {
+                    try self.wb('?');
+                } else {
+                    try self.wb('{');
+                    try self.fmtInt("{d}", min);
+                    if (max == UNBOUNDED) {
+                        try self.wb(',');
+                    } else if (max != min) {
+                        try self.wb(',');
+                        try self.fmtInt("{d}", max);
+                    }
+                    try self.wb('}');
+                }
+                if (!n.isGreedy()) try self.wb('?');
+            },
+
+            .indexed_reference => {
+                try self.wb('\\');
+                try self.fmtInt("{d}", n.data[0]);
+            },
+            .named_reference => {
+                try self.w("\\k<");
+                try self.w(self.tree.source[n.data[0]..n.data[1]]);
+                try self.wb('>');
+            },
+        }
+    }
+
+    fn character(self: *Printer, n: ast.Node) PrintError!void {
+        const cp = n.data[0];
+        switch (@as(ast.CharacterKind, @enumFromInt(n.data[1]))) {
+            .symbol => try self.wCp(cp),
+            .single_escape => {
+                try self.wb('\\');
+                try self.wb(switch (cp) {
+                    0x08 => @as(u8, 'b'), // class 내 `[\b]` = backspace
+                    0x0C => 'f',
+                    0x0A => 'n',
+                    0x0D => 'r',
+                    0x09 => 't',
+                    0x0B => 'v',
+                    // 알려진 single escape 가 아니면 identity 로 폴백.
+                    else => {
+                        try self.wCp(cp);
+                        return;
+                    },
+                });
+            },
+            .control_letter => {
+                try self.w("\\c");
+                // parser 가 ctrl & 0x1F 로 저장 → letter 복원: | 0x40 ('A'..'Z').
+                try self.wb(@intCast((cp & 0x1F) | 0x40));
+            },
+            .null_char => try self.w("\\0"),
+            .octal => {
+                try self.wb('\\');
+                try self.fmtInt("{o}", cp);
+            },
+            .hexadecimal_escape => {
+                try self.w("\\x");
+                try self.fmtInt("{x:0>2}", cp);
+            },
+            .unicode_escape => {
+                if (cp <= 0xFFFF) {
+                    try self.w("\\u");
+                    try self.fmtInt("{x:0>4}", cp);
+                } else {
+                    try self.w("\\u{");
+                    try self.fmtInt("{x}", cp);
+                    try self.wb('}');
+                }
+            },
+            .identifier => {
+                try self.wb('\\');
+                try self.wCp(cp);
+            },
+        }
+    }
+};

--- a/src/regexp/printer_test.zig
+++ b/src/regexp/printer_test.zig
@@ -1,0 +1,129 @@
+//! printer.zig 라운드트립 테스트.
+//!
+//! 불변식: printer 는 canonical 직렬화기이므로 "바이트 동일" 이 아니라
+//! **print 멱등 + 재파싱 성공** 을 검증한다.
+//!   parse(p) → t1 → print → s1
+//!   parse(s1) → t2 → print → s2
+//!   ⇒ s1 == s2  (s1 은 printer 출력의 고정점)
+//! 첫 print 가 정규화를 끝내므로 두 번째부터는 변하지 않아야 한다.
+
+const std = @import("std");
+const mod = @import("mod.zig");
+const printer = @import("printer.zig");
+
+/// p 를 flags 로 파싱→print 한 뒤, 그 결과를 다시 파싱→print 해
+/// 두 번째 출력이 첫 출력과 동일(멱등)함을 확인한다.
+fn expectIdempotent(p: []const u8, flag_text: []const u8) !void {
+    const a = std.testing.allocator;
+
+    var t1 = mod.parse(p, flag_text, a) orelse {
+        std.debug.print("parse failed (corpus invalid): /{s}/{s}\n", .{ p, flag_text });
+        return error.ParseFailed;
+    };
+    defer t1.deinit();
+    const s1 = try printer.print(t1, a);
+    defer a.free(s1);
+
+    var t2 = mod.parse(s1, flag_text, a) orelse {
+        std.debug.print("re-parse failed: /{s}/ -> /{s}/\n", .{ p, s1 });
+        return error.ReParseFailed;
+    };
+    defer t2.deinit();
+    const s2 = try printer.print(t2, a);
+    defer a.free(s2);
+
+    std.testing.expectEqualStrings(s1, s2) catch |e| {
+        std.debug.print("not idempotent: /{s}/ -> '{s}' -> '{s}'\n", .{ p, s1, s2 });
+        return e;
+    };
+
+    // 구조 교차검증: 멱등(s1==s2)만으로는 "lossy 하지만 안정적인" 변형
+    // (예: 노드를 누락하고 그 손실된 출력이 다시 안정적으로 파싱되는 경우)을
+    // 못 잡는다. canonical 입력→AST 와 그 재파싱 AST 는 노드 수·tag 열이
+    // 동일해야 한다 (printer 가 노드를 누락/치환하지 않았다는 보장).
+    std.testing.expectEqual(t1.nodeCount(), t2.nodeCount()) catch |e| {
+        std.debug.print("node count drift: /{s}/ {d} -> '{s}' {d}\n", .{ p, t1.nodeCount(), s1, t2.nodeCount() });
+        return e;
+    };
+    for (t1.nodes, t2.nodes, 0..) |a_node, b_node, i| {
+        if (a_node.tag != b_node.tag) {
+            std.debug.print("tag drift at #{d}: /{s}/ {s} -> '{s}' {s}\n", .{ i, p, @tagName(a_node.tag), s1, @tagName(b_node.tag) });
+            return error.TagDrift;
+        }
+    }
+}
+
+/// 입력이 이미 canonical 인 경우 print 결과가 입력과 정확히 같아야 한다
+/// (회귀 가드 — 정규화가 의도치 않게 모양을 바꾸지 않는지).
+fn expectExact(p: []const u8, flag_text: []const u8, expected: []const u8) !void {
+    const a = std.testing.allocator;
+    var t = mod.parse(p, flag_text, a) orelse return error.ParseFailed;
+    defer t.deinit();
+    const s = try printer.print(t, a);
+    defer a.free(s);
+    try std.testing.expectEqualStrings(expected, s);
+}
+
+test "printer roundtrip — atoms / classes / quantifiers" {
+    const cases = [_][2][]const u8{
+        .{ "abc", "" },
+        .{ "a|b|c", "" },
+        .{ "a.b", "" },
+        .{ "^abc$", "" },
+        .{ "\\bword\\B", "" },
+        .{ "\\d\\D\\w\\W\\s\\S", "" },
+        .{ "[abc]", "" },
+        .{ "[^a-z0-9]", "" },
+        .{ "[\\d-]", "" },
+        .{ "a*", "" },
+        .{ "a+?", "" },
+        .{ "a??", "" },
+        .{ "a{3}", "" },
+        .{ "a{2,}", "" },
+        .{ "a{2,5}", "" },
+        .{ "a{2,5}?", "" },
+        .{ "(ab)c", "" },
+        .{ "(?:ab)+", "" },
+        .{ "(?=ab)", "" },
+        .{ "(?!ab)", "" },
+        .{ "(?<=ab)", "" },
+        .{ "(?<!ab)", "" },
+        .{ "(?<year>\\d{4})-\\k<year>", "" },
+        .{ "(a)\\1", "" },
+        .{ "\\n\\r\\t\\f\\v", "" },
+        .{ "[\\b]", "" }, // class 내 backspace — C1 회귀 가드
+        .{ "[a\\b\\t]", "" },
+        .{ "\\0", "" },
+        .{ "\\x41", "" },
+        .{ "\\cA", "" },
+        .{ "\\.\\*\\+\\?\\(\\)\\[\\]", "" },
+        .{ "a(?i:bc)d", "" },
+        .{ "a(?i-m:bc)d", "" },
+        .{ "\\u{1F600}", "u" },
+        .{ "\\uD83D", "" },
+        .{ "\\p{Letter}", "u" },
+        .{ "\\P{ASCII}", "u" },
+        .{ "[\\q{abc|de}]", "v" },
+        .{ "[\\w&&[a-z]]", "v" },
+        .{ "[\\w--[a-z]]", "v" },
+        .{ "(a|b)*c{1,3}|d", "" },
+    };
+    for (cases) |c| try expectIdempotent(c[0], c[1]);
+}
+
+test "printer exact — canonical input unchanged" {
+    try expectExact("(?<n>ab)\\k<n>", "", "(?<n>ab)\\k<n>");
+    try expectExact("[^a-z]+?", "", "[^a-z]+?");
+    try expectExact("a{2,5}", "", "a{2,5}");
+    try expectExact("(?:x|y)\\d*", "", "(?:x|y)\\d*");
+    try expectExact("\\bfoo\\B", "", "\\bfoo\\B");
+    try expectExact("(?i-s:Ab)", "", "(?i-s:Ab)");
+}
+
+test "printer canonicalization — equivalent forms converge" {
+    // {n,n} → {n}, * / + / ? 정규화 등은 멱등이면 충분.
+    try expectIdempotent("a{3,3}", "");
+    try expectIdempotent("a{0,}", "");
+    try expectIdempotent("a{1,}", "");
+    try expectIdempotent("a{0,1}", "");
+}


### PR DESCRIPTION
## 배경

[#1475](../../issues/1475) — `src/transformer/regex_lower.zig`(524줄)의 ad-hoc 패턴 워크(dotAll/named-group strip/sticky/`\u{}`)를 `src/regexp/` 정식 AST 기반으로 통합. boundary-bug 재발 위험 + 파서와의 중복 walk 해소가 목적.

이슈 plan 의 **PR1 = AST→text printer + 라운드트립 테스트** (단독 머지 가능한 기반). PR2 에서 regex_lower 4변환을 이 printer+parser 로 재구현 예정.

## 변경

- **`src/regexp/printer.zig`** (신규): `ast.RegExpAst` → 패턴 문자열. 17개 `ast.Tag` + 전 sub-enum 전수 직렬화. `node.data` 만으로 재구성하므로 **변환 후 생성된 합성 노드도 출력** (source span 비의존 — 변환 시 span stale). 출력은 canonical form.
- **`src/regexp/printer_test.zig`** (신규): 라운드트립 불변식 = `print 멱등(s1==s2)` + `재파싱 성공` + **t1/t2 노드수·tag 열 구조 교차검증** (멱등만으로 못 잡는 "lossy-but-stable" 변형 차단).
- **`src/regexp/mod.zig`**: `pub const printer` + 표준대로 `test {}` 에서 `printer_test` aggregate.

## 검증

- printer 테스트 통과 (Debug + **ReleaseFast** 둘 다 — feedback: RF-only 회귀 대비)
- 전체 `zig build test` **5274/5278 pass / 0 fail** (4 skip = 기존 baseline, 신규 +3 무회귀)
- `/simplify` 3에이전트 반영:
  - **정합성 fix**: `single_escape` 의 `[\b]`(0x08 backspace) arm 누락 → 라운드트립 깨짐. 수정 + 회귀 corpus(`[\b]`,`[a\b\t]`) 추가. 구조 교차검증이 이 부류를 영구 차단.
  - **reuse**: 수기 hex/octal 변환 루프(~55줄) → `std.fmt` `{x:0>N}`/`{x}`/`{o}` (codegen/writer.zig 관례 통일).
  - **style**: 인라인 `.{ .start=.., .len=.. }` → `n.getClassBody()` 헬퍼.
  - **known limit**: `\p{Script=Greek}` 의 `=value` 는 parser AST 가 name 범위만 보존 → `\p{Script}` 축약. printer 책임 아님(AST layout 한계), 헤더에 명시. #1475 후속 PR 에서 AST 확장 시 해소.

cold path (regex_lower.lower 는 미지원 flag downlevel 시에만 진입, modern target no-op). production importer 0 — 단독 안전.

Refs #1475 (PR2/PR3 후속이므로 미-close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)