### PR TITLE
refactor(regexp): regex_lower ad-hoc walk → parse+AST transform+printer (#1475 PR2)

### DIFF
--- a/src/regexp/mod.zig
+++ b/src/regexp/mod.zig
@@ -23,6 +23,7 @@ pub const flags = @import("flags.zig");
 pub const diagnostics = @import("diagnostics.zig");
 pub const parser = @import("parser.zig");
 pub const printer = @import("printer.zig");
+pub const transform = @import("transform.zig");
 pub const unicode_property = @import("unicode_property.zig");
 
 /// 정규식 리터럴을 검증한다.
@@ -87,6 +88,7 @@ test {
     _ = diagnostics;
     _ = parser;
     _ = printer;
+    _ = transform;
     _ = unicode_property;
 
     // test files
@@ -95,4 +97,5 @@ test {
     _ = @import("flags_test.zig");
     _ = @import("ast_test.zig");
     _ = @import("printer_test.zig");
+    _ = @import("transform_test.zig");
 }

--- a/src/regexp/transform.zig
+++ b/src/regexp/transform.zig
@@ -1,0 +1,279 @@
+//! regexp AST transform 패스 (#1475 PR2 정공법).
+//!
+//! parse → **이 패스가 새 AST 를 재빌드** → dumb printer 직렬화.
+//! (babel regjsparser→AST transform→regjsgen, oxc AST→transform→Display 와 동형.
+//!  printer 는 변환을 모른다 — serializer 와 transform 의 관심사 분리.)
+//!
+//! 입력 AST 는 불변(소유권은 호출자). 출력 Result.ast 는 새 노드/extra 배열을
+//! 소유한다. name 슬라이스는 입력 source 를 가리키므로 Result 사용 동안
+//! 입력 AST 의 source 가 살아 있어야 한다.
+
+const std = @import("std");
+const ast = @import("ast.zig");
+
+const NodeIndex = ast.NodeIndex;
+const Node = ast.Node;
+const UNNAMED = std.math.maxInt(u32);
+
+pub const Options = struct {
+    /// `.` (character class 밖) → `[\s\S]`
+    dotall: bool = false,
+    /// `(?<name>…)` → `(…)`, `\k<name>` → `\N` (positional)
+    strip_named: bool = false,
+    /// astral `\u{XXXXX}` (cp>0xFFFF) → surrogate pair 2 노드
+    unicode_brace: bool = false,
+};
+
+pub const NamedGroup = struct {
+    name: []const u8, // 입력 source 슬라이스
+    index: u32, // 1-based capture index
+};
+
+pub const Result = struct {
+    ast: ast.RegExpAst,
+    named_groups: []NamedGroup,
+    allocator: std.mem.Allocator,
+
+    pub fn deinit(self: *Result) void {
+        self.ast.deinit();
+        self.allocator.free(self.named_groups);
+    }
+};
+
+pub const TransformError = error{OutOfMemory};
+
+/// 입력 AST 의 capture group 을 source(=opening paren) 순서로 세어
+/// named group 의 (name, 1-based index) 를 수집한다.
+fn collectNamed(
+    in: ast.RegExpAst,
+    idx: NodeIndex,
+    ctr: *u32,
+    out: *std.ArrayList(NamedGroup),
+    a: std.mem.Allocator,
+) TransformError!void {
+    if (idx == .none) return;
+    const n = in.getNode(idx);
+    switch (n.tag) {
+        .capturing_group => {
+            ctr.* += 1;
+            if (n.data[0] != UNNAMED) {
+                try out.append(a, .{ .name = in.source[n.data[0]..n.data[1]], .index = ctr.* });
+            }
+            try collectNamed(in, @enumFromInt(n.data[2]), ctr, out, a);
+        },
+        .ignore_group => try collectNamed(in, @enumFromInt(n.data[2]), ctr, out, a),
+        .lookaround_assertion => try collectNamed(in, @enumFromInt(n.data[1]), ctr, out, a),
+        .quantifier => try collectNamed(in, n.getQuantifierBody(), ctr, out, a),
+        .disjunction, .alternative => {
+            for (in.getNodeList(n.getNodeList())) |c| {
+                try collectNamed(in, @enumFromInt(c), ctr, out, a);
+            }
+        },
+        // character class 내부엔 capturing group 이 올 수 없음.
+        else => {},
+    }
+}
+
+const Builder = struct {
+    nodes: std.ArrayList(Node) = .empty,
+    extra: std.ArrayList(u32) = .empty,
+    a: std.mem.Allocator,
+
+    fn add(self: *Builder, n: Node) TransformError!NodeIndex {
+        try self.nodes.append(self.a, n);
+        return @enumFromInt(@as(u32, @intCast(self.nodes.items.len - 1)));
+    }
+
+    fn addList(self: *Builder, ids: []const u32) TransformError!ast.NodeList {
+        const start: u32 = @intCast(self.extra.items.len);
+        try self.extra.appendSlice(self.a, ids);
+        return .{ .start = start, .len = @intCast(ids.len) };
+    }
+
+    fn deinitErr(self: *Builder) void {
+        self.nodes.deinit(self.a);
+        self.extra.deinit(self.a);
+    }
+};
+
+const T = struct {
+    in: ast.RegExpAst,
+    b: *Builder,
+    opts: Options,
+    names: []const NamedGroup,
+    /// character class 내부 여부. 파서는 class 안 `\k<n>` 도 named_reference
+    /// 노드로 내지만 ECMAScript 상 backreference 가 아니므로(ad-hoc 도
+    /// `!in_class` 에서만 치환) strip_named 을 적용하지 않는다.
+    in_class: bool = false,
+
+    fn resolveIndex(self: *T, name: []const u8) ?u32 {
+        for (self.names) |g| {
+            if (std.mem.eql(u8, g.name, name)) return g.index;
+        }
+        return null;
+    }
+
+    /// surrogate pair 2 노드를 list 에 push (cp>0xFFFF).
+    fn pushSurrogate(self: *T, span: ast.Span, cp: u32, out: *std.ArrayList(u32)) TransformError!void {
+        // 표준 UTF-16 surrogate 분해 (ECMA-262). regexp 는 transformer 레이어에
+        // 의존하면 안 되므로 동일 공식이 unicode_escape_lower 와 독립 존재.
+        const v = cp - 0x10000;
+        const hi: u32 = 0xD800 | (v >> 10);
+        const lo: u32 = 0xDC00 | (v & 0x3FF);
+        const uk = @intFromEnum(ast.CharacterKind.unicode_escape);
+        const a = try self.b.add(.{ .tag = .character, .span = span, .data = .{ hi, uk, 0 } });
+        const c = try self.b.add(.{ .tag = .character, .span = span, .data = .{ lo, uk, 0 } });
+        try out.append(self.b.a, @intFromEnum(a));
+        try out.append(self.b.a, @intFromEnum(c));
+    }
+
+    fn makeDotAllClass(self: *T, span: ast.Span) TransformError!NodeIndex {
+        const sk = @intFromEnum(ast.CharacterClassEscapeKind.s);
+        const nsk = @intFromEnum(ast.CharacterClassEscapeKind.negative_s);
+        const e_s = try self.b.add(.{ .tag = .character_class_escape, .span = span, .data = .{ sk, 0, 0 } });
+        const e_ns = try self.b.add(.{ .tag = .character_class_escape, .span = span, .data = .{ nsk, 0, 0 } });
+        const list = try self.b.addList(&.{ @intFromEnum(e_s), @intFromEnum(e_ns) });
+        // character_class data: [flags, list_start, list_len], flags bit0=neg, bits1-2=kind(union=0)
+        return self.b.add(.{ .tag = .character_class, .span = span, .data = .{ 0, list.start, list.len } });
+    }
+
+    fn isAstralUnicodeEscape(n: Node) bool {
+        if (n.tag != .character) return false;
+        const kind: ast.CharacterKind = @enumFromInt(n.data[1]);
+        return kind == .unicode_escape and n.data[0] > 0xFFFF;
+    }
+
+    /// list 컨텍스트(alternative term / class atom / class_string char): 자식이
+    /// 1→N 으로 확장될 수 있음 (astral→surrogate 2개).
+    fn expandList(self: *T, list: ast.NodeList) TransformError!ast.NodeList {
+        var ids: std.ArrayList(u32) = .empty;
+        defer ids.deinit(self.b.a);
+        for (self.in.getNodeList(list)) |cid| {
+            const child: NodeIndex = @enumFromInt(cid);
+            const cn = self.in.getNode(child);
+            if (self.opts.unicode_brace and isAstralUnicodeEscape(cn)) {
+                try self.pushSurrogate(cn.span, cn.data[0], &ids);
+            } else {
+                try ids.append(self.b.a, @intFromEnum(try self.node(child)));
+            }
+        }
+        return self.b.addList(ids.items);
+    }
+
+    /// 정확히 1 노드를 내는 컨텍스트(group/quantifier/lookaround body, range
+    /// endpoint). astral→surrogate split 은 단일 컨텍스트에서 불가하므로
+    /// 발생 시 그대로 둔다 (range endpoint 의 astral — 테스트 없음, ES5
+    /// 다운레벨 불가의 본질적 한계. ad-hoc 도 깨진 출력이었음).
+    fn node(self: *T, idx: NodeIndex) TransformError!NodeIndex {
+        if (idx == .none) return .none;
+        const n = self.in.getNode(idx);
+        switch (n.tag) {
+            .disjunction => {
+                var ids: std.ArrayList(u32) = .empty;
+                defer ids.deinit(self.b.a);
+                for (self.in.getNodeList(n.getNodeList())) |c| {
+                    try ids.append(self.b.a, @intFromEnum(try self.node(@enumFromInt(c))));
+                }
+                const l = try self.b.addList(ids.items);
+                return self.b.add(.{ .tag = .disjunction, .span = n.span, .data = .{ l.start, l.len, 0 } });
+            },
+            .alternative => {
+                const l = try self.expandList(n.getNodeList());
+                return self.b.add(.{ .tag = .alternative, .span = n.span, .data = .{ l.start, l.len, 0 } });
+            },
+            .boundary_assertion,
+            .character,
+            .character_class_escape,
+            .unicode_property_escape,
+            .indexed_reference,
+            => return self.b.add(n),
+            .dot => {
+                if (self.opts.dotall) return self.makeDotAllClass(n.span);
+                return self.b.add(n);
+            },
+            .named_reference => {
+                if (self.opts.strip_named and !self.in_class) {
+                    if (self.resolveIndex(self.in.source[n.data[0]..n.data[1]])) |gi| {
+                        return self.b.add(.{ .tag = .indexed_reference, .span = n.span, .data = .{ gi, 0, 0 } });
+                    }
+                }
+                return self.b.add(n); // 못 찾으면 보존 (ad-hoc 동일)
+            },
+            .lookaround_assertion => {
+                const body = try self.node(@enumFromInt(n.data[1]));
+                return self.b.add(.{ .tag = .lookaround_assertion, .span = n.span, .data = .{ n.data[0], @intFromEnum(body), 0 } });
+            },
+            .character_class => {
+                const saved = self.in_class;
+                self.in_class = true;
+                const l = try self.expandList(n.getClassBody());
+                self.in_class = saved;
+                return self.b.add(.{ .tag = .character_class, .span = n.span, .data = .{ n.data[0], l.start, l.len } });
+            },
+            .character_class_range => {
+                const mn = try self.node(@enumFromInt(n.data[0]));
+                const mx = try self.node(@enumFromInt(n.data[1]));
+                return self.b.add(.{ .tag = .character_class_range, .span = n.span, .data = .{ @intFromEnum(mn), @intFromEnum(mx), 0 } });
+            },
+            .class_string_disjunction => {
+                var ids: std.ArrayList(u32) = .empty;
+                defer ids.deinit(self.b.a);
+                for (self.in.getNodeList(n.getNodeList())) |c| {
+                    try ids.append(self.b.a, @intFromEnum(try self.node(@enumFromInt(c))));
+                }
+                const l = try self.b.addList(ids.items);
+                return self.b.add(.{ .tag = .class_string_disjunction, .span = n.span, .data = .{ l.start, l.len, 0 } });
+            },
+            .class_string => {
+                const l = try self.expandList(n.getNodeList());
+                return self.b.add(.{ .tag = .class_string, .span = n.span, .data = .{ l.start, l.len, 0 } });
+            },
+            .capturing_group => {
+                const body = try self.node(@enumFromInt(n.data[2]));
+                const name0: u32 = if (self.opts.strip_named) UNNAMED else n.data[0];
+                const name1: u32 = if (self.opts.strip_named) 0 else n.data[1];
+                return self.b.add(.{ .tag = .capturing_group, .span = n.span, .data = .{ name0, name1, @intFromEnum(body) } });
+            },
+            .ignore_group => {
+                const body = try self.node(@enumFromInt(n.data[2]));
+                return self.b.add(.{ .tag = .ignore_group, .span = n.span, .data = .{ n.data[0], n.data[1], @intFromEnum(body) } });
+            },
+            .quantifier => {
+                const body = try self.node(n.getQuantifierBody());
+                const greedy: u32 = if (n.isGreedy()) 0x80000000 else 0;
+                const packed_body = (@intFromEnum(body) & 0x7FFFFFFF) | greedy;
+                return self.b.add(.{ .tag = .quantifier, .span = n.span, .data = .{ n.data[0], n.data[1], packed_body } });
+            },
+        }
+    }
+};
+
+pub fn transform(in: ast.RegExpAst, opts: Options, allocator: std.mem.Allocator) TransformError!Result {
+    var ng: std.ArrayList(NamedGroup) = .empty;
+    errdefer ng.deinit(allocator);
+    var ctr: u32 = 0;
+    try collectNamed(in, in.root, &ctr, &ng, allocator);
+
+    var b = Builder{ .a = allocator };
+    errdefer b.deinitErr();
+    var t = T{ .in = in, .b = &b, .opts = opts, .names = ng.items };
+    const new_root = try t.node(in.root);
+
+    const nodes = try b.nodes.toOwnedSlice(allocator);
+    errdefer allocator.free(nodes);
+    const extra = try b.extra.toOwnedSlice(allocator);
+    errdefer allocator.free(extra);
+    const named = try ng.toOwnedSlice(allocator);
+
+    return .{
+        .ast = .{
+            .nodes = nodes,
+            .extra_data = extra,
+            .root = new_root,
+            .source = in.source,
+            .allocator = allocator,
+        },
+        .named_groups = named,
+        .allocator = allocator,
+    };
+}

--- a/src/regexp/transform_test.zig
+++ b/src/regexp/transform_test.zig
@@ -1,0 +1,74 @@
+//! regexp AST transform 패스 테스트.
+//!
+//! 정공법 PR2(#1475): parse → AST transform → dumb printer.
+//! 검증: parse(pattern,flags) → transform(opts) → printer.print == expected.
+//! (babel regjsparser→AST transform→regjsgen, oxc AST→transform→Display 와 동형)
+
+const std = @import("std");
+const mod = @import("mod.zig");
+const transform = @import("transform.zig");
+const printer = @import("printer.zig");
+
+fn expectTransform(
+    pattern: []const u8,
+    flag_text: []const u8,
+    opts: transform.Options,
+    expected: []const u8,
+) !void {
+    const a = std.testing.allocator;
+    var in = mod.parse(pattern, flag_text, a) orelse return error.ParseFailed;
+    defer in.deinit();
+
+    var r = try transform.transform(in, opts, a);
+    defer r.deinit();
+
+    const out = try printer.print(r.ast, a);
+    defer a.free(out);
+    try std.testing.expectEqualStrings(expected, out);
+}
+
+test "transform dotall — `.` (class 밖) → [\\s\\S]" {
+    const o = transform.Options{ .dotall = true };
+    try expectTransform("a.b", "", o, "a[\\s\\S]b");
+    try expectTransform("a\\.b", "", o, "a\\.b"); // escaped dot 불변
+    try expectTransform("[a.]b", "", o, "[a.]b"); // class 안 dot 불변
+    try expectTransform("a.b", "", .{}, "a.b"); // opt off → no-op
+}
+
+test "transform strip_named — group unname + \\k<name> → \\N" {
+    const o = transform.Options{ .strip_named = true };
+    try expectTransform("(?<year>\\d{4})", "", o, "(\\d{4})");
+    try expectTransform("(?<y>\\d{4})-(?<m>\\d{2})", "", o, "(\\d{4})-(\\d{2})");
+    try expectTransform("(?<dup>a+)b\\k<dup>", "", o, "(a+)b\\1");
+    try expectTransform("(\\d+)-(?<word>[a-z]+)-\\k<word>", "", o, "(\\d+)-([a-z]+)-\\2");
+    try expectTransform("(?:foo)(?<n>\\d+)\\k<n>", "", o, "(?:foo)(\\d+)\\1");
+    try expectTransform("(?<=\\$)(?<n>\\d+)\\k<n>", "", o, "(?<=\\$)(\\d+)\\1");
+    // class 안 \k<n> 은 named_reference 가 아니라 identity → 불변
+    try expectTransform("(?<n>a)[\\k<n>]", "", o, "(a)[\\k<n>]");
+}
+
+test "transform unicode_brace — astral → surrogate pair" {
+    const o = transform.Options{ .unicode_brace = true };
+    try expectTransform("\\u{1F600}", "u", o, "\\uD83D\\uDE00");
+    try expectTransform("\\u{41}", "u", o, "\\u0041");
+    try expectTransform("[\\u{1F600}]", "u", o, "[\\uD83D\\uDE00]");
+}
+
+test "transform 조합 — dotall + strip_named" {
+    const o = transform.Options{ .dotall = true, .strip_named = true };
+    try expectTransform("(?<a>.)b", "", o, "([\\s\\S])b"); // dotall 은 group 안에도 적용
+    try expectTransform("(?<a>x).(?<b>y)\\k<b>", "", o, "(x)[\\s\\S](y)\\2");
+}
+
+test "transform named_groups 매핑 추출 (capture index)" {
+    const a = std.testing.allocator;
+    var in = mod.parse("(\\d+)-(?<word>[a-z]+)-(?<n>\\d)", "", a) orelse return error.ParseFailed;
+    defer in.deinit();
+    var r = try transform.transform(in, .{}, a);
+    defer r.deinit();
+    try std.testing.expectEqual(@as(usize, 2), r.named_groups.len);
+    try std.testing.expectEqualStrings("word", r.named_groups[0].name);
+    try std.testing.expectEqual(@as(u32, 2), r.named_groups[0].index);
+    try std.testing.expectEqualStrings("n", r.named_groups[1].name);
+    try std.testing.expectEqual(@as(u32, 3), r.named_groups[1].index);
+}

--- a/src/transformer/regex_lower.zig
+++ b/src/transformer/regex_lower.zig
@@ -15,7 +15,7 @@
 
 const std = @import("std");
 const compat = @import("compat.zig");
-const unicode_escape_lower = @import("unicode_escape_lower.zig");
+const regexp = @import("../regexp/mod.zig");
 
 pub const Options = struct {
     unsupported: compat.UnsupportedFeatures,
@@ -58,8 +58,31 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
 
     if (!need_dotall and !need_named and !need_sticky and !need_unicode) return .{ .text = null };
 
-    // named capture mapping 추출 (strip 전에 — strip 후엔 named group 이 사라져 인덱스 추적 불가).
-    // 호출자가 `__wrapRegExp(re, {...})` 합성에 사용.
+    // sticky 는 flag strip 만 → 패턴 무변경. dotall/named/unicode 만 패턴 변환.
+    // sticky-only 면 parse/transform/print 를 건너뛰고 원본 패턴 verbatim
+    // (불필요 작업 제거 + canonical 정규화 미적용 — ad-hoc 과 동일 바이트).
+    const need_pattern_xform = need_dotall or need_named or need_unicode;
+
+    // parse → AST transform → dumb printer (#1475 PR2 정공법; ad-hoc byte-walk
+    // 제거). 파서는 렉서 validate 와 동일하므로(이미 통과한 리터럴) parse 실패는
+    // 없어야 하나, 방어적으로 실패 시 변환 생략(.text=null = 원본 유지).
+    var owned_pattern: ?[]u8 = null;
+    defer if (owned_pattern) |p| allocator.free(p);
+    const pattern_text: []const u8 = if (need_pattern_xform) blk: {
+        var in_ast = regexp.parse(pattern, flags, allocator) orelse return .{ .text = null };
+        defer in_ast.deinit();
+        var tr = try regexp.transform.transform(in_ast, .{
+            .dotall = need_dotall,
+            .strip_named = need_named,
+            .unicode_brace = need_unicode,
+        }, allocator);
+        defer tr.deinit();
+        owned_pattern = regexp.printer.print(tr.ast, allocator) catch return .{ .text = null };
+        break :blk owned_pattern.?;
+    } else pattern;
+
+    // named capture mapping 추출 — 패턴 변환 성공 후 (early-return 누수 방지).
+    // 원본 pattern 기준이라 변환 순서와 무관. 호출자가 `__wrapRegExp` 합성에 사용.
     var named_groups: ?[]const NamedGroupMapping = null;
     errdefer if (named_groups) |ng| allocator.free(ng);
     if (need_named) {
@@ -67,16 +90,12 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
         if (map.len > 0) named_groups = map else allocator.free(map);
     }
 
-    // /pattern/flags 를 단일 버퍼로 조립. dotAll/unicode 치환을 고려해 +8 여유.
+    // /pattern/flags 조립 + 변환된 flag strip.
     var out: std.ArrayList(u8) = .empty;
     errdefer out.deinit(allocator);
-    try out.ensureTotalCapacity(allocator, raw.len + 8);
+    try out.ensureTotalCapacity(allocator, pattern_text.len + flags.len + 2);
     try out.append(allocator, '/');
-    try rewritePattern(allocator, &out, pattern, .{
-        .dotall = need_dotall,
-        .strip_named = need_named,
-        .unicode_brace = need_unicode,
-    });
+    try out.appendSlice(allocator, pattern_text);
     try out.append(allocator, '/');
     for (flags) |c| {
         if (need_dotall and c == 's') continue;
@@ -87,146 +106,7 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
     return .{ .text = try out.toOwnedSlice(allocator), .named_groups = named_groups };
 }
 
-const PatternOpts = struct {
-    dotall: bool,
-    strip_named: bool,
-    unicode_brace: bool,
-};
-
-/// pattern 내부를 character class / escape 를 고려하며 순회하여 변환.
-///
-/// strip_named 활성 시 named group 위치를 capture group 인덱스로 추적해
-/// `\k<name>` named backreference 를 `\N` (positional)으로 함께 변환한다.
-fn rewritePattern(
-    allocator: std.mem.Allocator,
-    out: *std.ArrayList(u8),
-    pattern: []const u8,
-    opts: PatternOpts,
-) !void {
-    // ECMAScript named capture group 은 한도가 없다 (V8/SpiderMonkey 모두 unbounded).
-    // 자동 생성된 lexer/regex 등에서 32+ 도 합법이라 dynamic ArrayList 로 처리한다.
-    const NamedEntry = struct { name: []const u8, idx: u32 };
-    var named: std.ArrayList(NamedEntry) = .empty;
-    defer named.deinit(allocator);
-    var group_idx: u32 = 0;
-
-    var i: usize = 0;
-    var in_class: bool = false;
-    while (i < pattern.len) {
-        const c = pattern[i];
-
-        // escape
-        if (c == '\\') {
-            // `\u{XXXX}` brace unicode escape → surrogate pair / BMP escape
-            if (opts.unicode_brace and i + 2 < pattern.len and pattern[i + 1] == 'u' and pattern[i + 2] == '{') {
-                if (unicode_escape_lower.parseBraceHex(pattern, i + 2)) |r| {
-                    try unicode_escape_lower.appendCodepoint(out, allocator, r.cp);
-                    i = r.end;
-                    continue;
-                }
-            }
-            // `\k<name>` named backreference (character class 밖에서만 의미 있음).
-            // strip_named 일 때 동일 이름의 capture group 인덱스를 찾아 `\N` 으로 치환.
-            // 이름을 못 찾으면 (해당 named group이 아직 안 나옴) 원본을 보존하지만,
-            // ECMAScript spec상 정상 패턴이라면 named group이 항상 먼저 정의되어 있다.
-            if (!in_class and opts.strip_named and i + 2 < pattern.len and pattern[i + 1] == 'k' and pattern[i + 2] == '<') {
-                if (std.mem.indexOfScalarPos(u8, pattern, i + 3, '>')) |gt| {
-                    const name = pattern[i + 3 .. gt];
-                    var found_idx: ?u32 = null;
-                    for (named.items) |e| {
-                        if (std.mem.eql(u8, e.name, name)) {
-                            found_idx = e.idx;
-                            break;
-                        }
-                    }
-                    if (found_idx) |idx| {
-                        var buf: [16]u8 = undefined;
-                        // u32 최대값 출력해도 11자 + '\\' = 12자 → 16바이트 버퍼로 충분.
-                        const s = std.fmt.bufPrint(&buf, "\\{d}", .{idx}) catch unreachable;
-                        try out.appendSlice(allocator, s);
-                        i = gt + 1;
-                        continue;
-                    }
-                }
-            }
-            try out.append(allocator, c);
-            if (i + 1 < pattern.len) {
-                try out.append(allocator, pattern[i + 1]);
-                i += 2;
-            } else {
-                i += 1;
-            }
-            continue;
-        }
-
-        if (in_class) {
-            try out.append(allocator, c);
-            if (c == ']') in_class = false;
-            i += 1;
-            continue;
-        }
-
-        switch (c) {
-            '[' => {
-                in_class = true;
-                try out.append(allocator, c);
-                i += 1;
-            },
-            '.' => {
-                if (opts.dotall) {
-                    try out.appendSlice(allocator, "[\\s\\S]");
-                } else {
-                    try out.append(allocator, c);
-                }
-                i += 1;
-            },
-            '(' => {
-                // `(?` 로 시작하는 그룹 분류:
-                //   `(?:...)` non-capturing → capture index 카운트 X
-                //   `(?=...)`, `(?!...)` lookahead → capture index 카운트 X
-                //   `(?<=...)`, `(?<!...)` lookbehind → capture index 카운트 X
-                //   `(?<name>...)` named capture → capture index 카운트 O, strip_named 시 strip
-                if (i + 2 < pattern.len and pattern[i + 1] == '?') {
-                    const tag = pattern[i + 2];
-                    if (tag == ':' or tag == '=' or tag == '!') {
-                        try out.append(allocator, c);
-                        i += 1;
-                        continue;
-                    }
-                    if (tag == '<') {
-                        if (i + 3 < pattern.len and (pattern[i + 3] == '=' or pattern[i + 3] == '!')) {
-                            try out.append(allocator, c);
-                            i += 1;
-                            continue;
-                        }
-                        group_idx += 1;
-                        if (std.mem.indexOfScalarPos(u8, pattern, i + 3, '>')) |gt| {
-                            try named.append(allocator, .{ .name = pattern[i + 3 .. gt], .idx = group_idx });
-                            if (opts.strip_named) {
-                                try out.append(allocator, '(');
-                                i = gt + 1;
-                                continue;
-                            }
-                        }
-                        try out.append(allocator, c);
-                        i += 1;
-                        continue;
-                    }
-                }
-                group_idx += 1;
-                try out.append(allocator, c);
-                i += 1;
-            },
-            else => {
-                try out.append(allocator, c);
-                i += 1;
-            },
-        }
-    }
-}
-
 /// `String.prototype.replace` replacement string 의 `$<name>` 변환을 위한 매핑 항목.
-/// 같은 walk 로 named group 인덱스를 추적해 외부에 노출한다.
 pub const NamedGroupMapping = struct {
     name: []const u8, // pattern 내부 원본 슬라이스 (수명: pattern 원본)
     index: u32, // 1-based capture group 인덱스


### PR DESCRIPTION
## 배경

[#1475](../../issues/1475): `regex_lower.rewritePattern` 의 ad-hoc byte-walk 는 정규식 구조 이해(class 경계·escape·named group 인덱싱)를 파서와 **따로 재구현** → #1474/#2472 버그 발생 + `in_class:bool` 이 v-flag 중첩클래스(`[[a]&&[b]]`) 표현 불가한 잠재 정확성 갭.

선행(머지 완료): PR1 printer #3500 · R1 #3502(파서 동적 버퍼) · R2 #3504(printer oxc 대문자=ad-hoc 바이트동일). 양대 blocker 해소로 PR2 = **clean swap**.

## 변경 (정공법 — babel/oxc 동형)

`regexp.parse` → **`transform.zig` 가 새 AST 재빌드** → PR1 dumb printer 직렬화. **printer 무변경** (serializer 와 transform 관심사 분리; print-time 치환 안티패턴 회피).

- **`src/regexp/transform.zig`** (신규): 입력 AST 불변 → 변환 AST 소유. `dotall`(`.`→`[\s\S]` charclass) / `strip_named`(`(?<n>…)`→`(…)`, `\k<n>`→`\N`) / `unicode_brace`(astral `\u{}`→surrogate 2노드). `in_class` 가드로 class 내 `\k` 보존. `collectNamed`=capture-group pre-order ordinal(spec 정확 1-based).
- **`regex_lower.lower()`**: parse→transform→print. **sticky-only 는 패턴 변환 불필요 → verbatim** (불필요 parse/transform/print 제거 + 의도치 않은 canonical 변경 제거 = ad-hoc 과 동일 바이트). dead `rewritePattern` 139줄 + `unicode_escape_lower` 의존 제거. `extractNamedGroupMap`/`rewriteReplacementNamedRefs` 시그니처·동작 무변경.

## 검증 (TDD)

- 신규 `transform_test.zig` (dotall/strip_named/unicode_brace/조합/매핑)
- **기존 `regex_lower` 23 테스트(#2472 50-named 포함) byte-identical green = spec 가드** → AST 재구현이 ad-hoc 과 출력 동일 확정
- Debug + **ReleaseFast** 전체 **5289/5293 pass / 0 fail** (4 skip = 기존 baseline, 무회귀)
- `/simplify` 3에이전트: **encode parity 전 tag 검증 · collectNamed · in_class · errdefer 체인 · 메모리/aliasing 전원 correctness clean**. 반영: ①sticky-only verbatim(불필요 작업+canonical 변경 제거) ②named_groups early-return 누수 차단(성공 후 추출) ③`Slice`→`ast.NodeList` 중복 제거. (surrogate-split 공유 헬퍼는 regexp→transformer 레이어링 위반이라 의도적 미적용 — 표준 3줄 공식)

## follow-up (범위 외)

- `extractNamedGroupMap`/`hasNamedGroup` 도 AST 경유 가능하나 `pub` 시그니처 변경 + 호출부 필요 → 별도
- range-endpoint astral(`[\u{1F600}-…]` + u strip): ES5 다운레벨 본질적 불가, pre-existing(ad-hoc 도 깨짐), 무테스트
- `mod.parse` 에러경로 누수 #3503 (pre-existing, 별개)

Closes #1475

🤖 Generated with [Claude Code](https://claude.com/claude-code)