### PR TITLE
fix(regexp): mod.parse 에러 경로 ast_nodes/ast_extra 누수 차단 (#3503)

### DIFF
--- a/src/regexp/mod.zig
+++ b/src/regexp/mod.zig
@@ -72,11 +72,13 @@ pub fn parse(
     }
 
     // 2. 패턴 파싱 + AST 빌드
-    // parse()가 소유권을 toOwnedSlice()로 이전하므로 별도 deinit 불필요.
-    // 에러 시 parse() 내부에서 deinit 처리.
+    // 성공 시 parse()가 toOwnedSlice 로 소유권 이전 → p.deinit()은 빈
+    // ArrayList 해제(no-op). 에러 시 parse()는 ast_nodes/ast_extra 를
+    // 해제하지 않으므로 defer p.deinit()이 누수를 막는다 (#3503).
     const parsed_flags = flags.parse(flag_text);
     const Parser = parser.PatternParser(true);
     var p = Parser.initWithAllocator(pattern, parsed_flags, allocator);
+    defer p.deinit();
     return p.parse();
 }
 

--- a/src/regexp/parser_test.zig
+++ b/src/regexp/parser_test.zig
@@ -933,3 +933,20 @@ test "#3501 validate: 40 named backrefs accepted (>[32] cap)" {
     p.ext_alloc = a;
     try std.testing.expect(p.validate() == null);
 }
+
+// ============================================================
+// #3503: mod.parse 에러 경로에서 ast_nodes/ast_extra 미해제 누수
+// ============================================================
+
+test "#3503 mod.parse: 문법 에러 정규식 누수 없음" {
+    const mod = @import("mod.zig");
+    // flag 는 유효(flag 검증 통과) 하나 패턴이 문법 에러 →
+    // parse() 가 ast 빌드 도중 err → null 반환. testing.allocator 가
+    // ast_nodes/ast_extra 미해제 시 누수 패닉.
+    for ([_][]const u8{ "(", "(?<n>", "[a-", "\\", "a{2,1}", "(?<n>a)(?<n>b)" }) |pat| {
+        try std.testing.expect(mod.parse(pat, "", std.testing.allocator) == null);
+    }
+    // 성공 경로도 누수 0 (toOwnedSlice 후 p.deinit no-op 검증).
+    var ok = mod.parse("(a)\\1", "", std.testing.allocator) orelse return error.ParseFailed;
+    ok.deinit();
+}


### PR DESCRIPTION
## 배경

[#3503](../../issues/3503) (PR #3505 /simplify 발견, pre-existing): `parser.zig` `parse()` 는 `err_message != null` 시 `ast_nodes`/`ast_extra`(`initWithAllocator` 의 pre-alloc 32/64 + 빌드분)를 **해제하지 않고** null 반환. `mod.parse` 에 `defer p.deinit()` 이 없어 → **문법 에러 정규식 파싱마다 누수**.

## 변경

`mod.parse` 에 `defer p.deinit()` 1줄 + 부정확 주석 정정("에러 시 parse() 내부에서 deinit 처리"는 사실 아님).

- **성공 경로**: `parse()` 가 `toOwnedSlice` 로 nodes/extra 소유권 이전 → ArrayList cap0 → `p.deinit()` 빈 해제 no-op. 반환 `RegExpAst` 는 슬라이스 by-value 보유(p와 disjoint) → **UAF/double-free 없음**.
- **에러 경로**: nodes/extra 미해제 상태 → `defer p.deinit()` 가 해제 (= 수정).
- `deinitScratch` 이중 호출(parse defer + deinit)은 #3502 로 idempotent.

## 검증 (TDD)

RED→GREEN: `#3503` 테스트 — 6종 문법에러(`(`, `(?<n>`, `[a-`, `\`, `a{2,1}`, dup named) + 성공경로, `std.testing.allocator` 누수가드(누수 시 패닉).

- Debug + ReleaseFast 전체 **5290/5294 pass / 0 fail** (4 skip = 기존 baseline, 무회귀)
- `/simplify`: ownership 전 경로(success no-op·error free·double-call idempotent) 검증 **clean**, textbook RAII.

Closes #3503

🤖 Generated with [Claude Code](https://claude.com/claude-code)