### PR TITLE
docs(regexp): printer 헤더 예시 오타 수정 (\u{41}→A)

### DIFF
--- a/src/regexp/printer.zig
+++ b/src/regexp/printer.zig
@@ -6,7 +6,7 @@
 //!
 //! 출력은 oxc(`oxc_regular_expression` display.rs) canonical form 에 맞춘다:
 //! hex 는 대문자, unicode_escape 는 4자리 `\uXXXX`/`\u{XXXXX}` 로 통일
-//! (`\xab`→`\xAB`, `\u{41}`→`A`, `\u{1f600}`→`\u{1F600}`), `\ca`→`\cA`,
+//! (`\xab`→`\xAB`, `\u{41}`→`\u0041`, `\u{1f600}`→`\u{1F600}`), `\ca`→`\cA`,
 //! `a{3,3}`→`a{3}`. 따라서 라운드트립 불변식은 "바이트 동일" 이
 //! 아니라 "print 멱등 + 구조 보존" 이다 (printer_test.zig 참조).
 //!


### PR DESCRIPTION
printer.zig 헤더 canonical 예시가 `\u{41}`→`A` 로 잘못 표기. 파서는 `\u{41}` 을 `unicode_escape` kind(cp=0x41)로 보존하고 printer 는 `\uXXXX` 4자리로 출력하므로 실제는 `\u{41}`→`A` (oxc display.rs 동일). #3505 `/simplify` 에서 발견된 pre-existing 주석 오타.

주석 1줄, 코드/동작 무변경 → `/simplify` 생략 (docs-only, #3497/#3499 선례).

🤖 Generated with [Claude Code](https://claude.com/claude-code)