### PR TITLE
feat(regexp): positive class astral u-downlevel — surrogate-alternation (#3509)

### DIFF
--- a/src/regexp/codepoint_set.zig
+++ b/src/regexp/codepoint_set.zig
@@ -1,0 +1,109 @@
+//! Code-point 집합 + astral→surrogate-pair 분해 (#3509 핵심 조각).
+//!
+//! regexpu-core / regenerate 의 `encodeSurrogateRange` 와 동형:
+//! astral code-point range 를 ES5-safe surrogate-pair 조각들로 분해한다.
+//! 외부 Unicode 데이터 불필요 — 순수 결정론 알고리즘.
+
+const std = @import("std");
+
+pub const Range = struct { min: u32, max: u32 }; // inclusive
+
+/// surrogate 조각: high∈[hi_min,hi_max] 뒤 low∈[lo_min,lo_max].
+/// hi_min==hi_max 면 `\uHi`, 아니면 `[\uHi_min-\uHi_max]`.
+/// lo_min==lo_max 면 `\uLo`, 아니면 `[\uLo_min-\uLo_max]`.
+pub const Piece = struct { hi_min: u32, hi_max: u32, lo_min: u32, lo_max: u32 };
+
+pub const CodePointSet = struct {
+    ranges: std.ArrayList(Range) = .empty,
+
+    pub fn deinit(self: *CodePointSet, a: std.mem.Allocator) void {
+        self.ranges.deinit(a);
+    }
+
+    pub fn addRange(self: *CodePointSet, a: std.mem.Allocator, min: u32, max: u32) !void {
+        if (min > max) return;
+        try self.ranges.append(a, .{ .min = min, .max = max });
+    }
+
+    pub fn addOne(self: *CodePointSet, a: std.mem.Allocator, cp: u32) !void {
+        try self.ranges.append(a, .{ .min = cp, .max = cp });
+    }
+
+    pub fn isEmpty(self: *const CodePointSet) bool {
+        return self.ranges.items.len == 0;
+    }
+
+    /// 정렬 + 중첩/인접(max+1==next.min) range 병합.
+    pub fn normalize(self: *CodePointSet, a: std.mem.Allocator) !void {
+        const rs = self.ranges.items;
+        if (rs.len <= 1) return;
+        std.mem.sort(Range, rs, {}, struct {
+            fn lt(_: void, x: Range, y: Range) bool {
+                return x.min < y.min or (x.min == y.min and x.max < y.max);
+            }
+        }.lt);
+        var merged: std.ArrayList(Range) = .empty;
+        errdefer merged.deinit(a);
+        var cur = rs[0];
+        for (rs[1..]) |r| {
+            // 인접/중첩 — r.min 이 cur.max+1 이하 (cur.max==maxInt 방어).
+            if (r.min <= cur.max or (cur.max != std.math.maxInt(u32) and r.min == cur.max + 1)) {
+                if (r.max > cur.max) cur.max = r.max;
+            } else {
+                try merged.append(a, cur);
+                cur = r;
+            }
+        }
+        try merged.append(a, cur);
+        self.ranges.deinit(a);
+        self.ranges = merged;
+    }
+
+    pub fn items(self: *const CodePointSet) []const Range {
+        return self.ranges.items;
+    }
+};
+
+/// astral codepoint(≥0x10000) → UTF-16 surrogate pair. 표준 ECMA-262 공식.
+/// regexp 모듈 내 단일 출처 (transform.pushSurrogate 도 이것을 사용).
+pub fn splitSurrogatePair(cp: u32) struct { hi: u32, lo: u32 } {
+    const v = cp - 0x10000;
+    return .{ .hi = 0xD800 + (v >> 10), .lo = 0xDC00 + (v & 0x3FF) };
+}
+
+/// astral range [lo,hi] (둘 다 0x10000..0x10FFFF) → surrogate 조각들.
+/// regenerate 알고리즘: 시작/끝 부분 low 행 + 가운데 full-low 블록.
+pub fn encodeSurrogateRange(
+    lo: u32,
+    hi: u32,
+    out: *std.ArrayList(Piece),
+    a: std.mem.Allocator,
+) !void {
+    std.debug.assert(lo >= 0x10000 and hi <= 0x10FFFF and lo <= hi);
+    const s1 = splitSurrogatePair(lo);
+    const s2 = splitSurrogatePair(hi);
+    const h1 = s1.hi;
+    const l1 = s1.lo;
+    const h2 = s2.hi;
+    const l2 = s2.lo;
+
+    if (h1 == h2) {
+        try out.append(a, .{ .hi_min = h1, .hi_max = h1, .lo_min = l1, .lo_max = l2 });
+        return;
+    }
+
+    const lo_full = (l1 == 0xDC00); // 시작이 low 행 전체 → mid 로 흡수
+    const hi_full = (l2 == 0xDFFF); // 끝이 low 행 전체 → mid 로 흡수
+
+    if (!lo_full) {
+        try out.append(a, .{ .hi_min = h1, .hi_max = h1, .lo_min = l1, .lo_max = 0xDFFF });
+    }
+    const mid_lo: u32 = if (lo_full) h1 else h1 + 1;
+    const mid_hi: u32 = if (hi_full) h2 else h2 - 1;
+    if (mid_lo <= mid_hi) {
+        try out.append(a, .{ .hi_min = mid_lo, .hi_max = mid_hi, .lo_min = 0xDC00, .lo_max = 0xDFFF });
+    }
+    if (!hi_full) {
+        try out.append(a, .{ .hi_min = h2, .hi_max = h2, .lo_min = 0xDC00, .lo_max = l2 });
+    }
+}

--- a/src/regexp/codepoint_set_test.zig
+++ b/src/regexp/codepoint_set_test.zig
@@ -1,0 +1,65 @@
+//! codepoint_set.zig 테스트 — #3509 핵심 조각.
+//! regexpu/regenerate `encodeSurrogateRange` 동형 검증.
+
+const std = @import("std");
+const cps = @import("codepoint_set.zig");
+
+test "CodePointSet normalize — 정렬 + 인접/중첩 병합" {
+    const a = std.testing.allocator;
+    var s = cps.CodePointSet{};
+    defer s.deinit(a);
+    try s.addRange(a, 0x41, 0x5A); // A-Z
+    try s.addOne(a, 0x30); // 0
+    try s.addRange(a, 0x5B, 0x60); // 인접 → A-` 로 병합
+    try s.addRange(a, 0x45, 0x50); // 중첩
+    try s.normalize(a);
+    const r = s.items();
+    try std.testing.expectEqual(@as(usize, 2), r.len);
+    try std.testing.expectEqual(@as(u32, 0x30), r[0].min);
+    try std.testing.expectEqual(@as(u32, 0x30), r[0].max);
+    try std.testing.expectEqual(@as(u32, 0x41), r[1].min);
+    try std.testing.expectEqual(@as(u32, 0x60), r[1].max);
+}
+
+fn expectPieces(lo: u32, hi: u32, expected: []const cps.Piece) !void {
+    const a = std.testing.allocator;
+    var out: std.ArrayList(cps.Piece) = .empty;
+    defer out.deinit(a);
+    try cps.encodeSurrogateRange(lo, hi, &out, a);
+    try std.testing.expectEqualSlices(cps.Piece, expected, out.items);
+}
+
+test "encodeSurrogateRange — 동일 high surrogate (1F600-1F64F)" {
+    try expectPieces(0x1F600, 0x1F64F, &.{
+        .{ .hi_min = 0xD83D, .hi_max = 0xD83D, .lo_min = 0xDE00, .lo_max = 0xDE4F },
+    });
+}
+
+test "encodeSurrogateRange — 단일 astral codepoint (1F600)" {
+    try expectPieces(0x1F600, 0x1F600, &.{
+        .{ .hi_min = 0xD83D, .hi_max = 0xD83D, .lo_min = 0xDE00, .lo_max = 0xDE00 },
+    });
+}
+
+test "encodeSurrogateRange — high 교차, 부분 경계 (1F600-1F900)" {
+    try expectPieces(0x1F600, 0x1F900, &.{
+        .{ .hi_min = 0xD83D, .hi_max = 0xD83D, .lo_min = 0xDE00, .lo_max = 0xDFFF },
+        .{ .hi_min = 0xD83E, .hi_max = 0xD83E, .lo_min = 0xDC00, .lo_max = 0xDD00 },
+    });
+}
+
+test "encodeSurrogateRange — 전체 astral (10000-10FFFF) 전 low 경계 fold → 1 piece" {
+    try expectPieces(0x10000, 0x10FFFF, &.{
+        .{ .hi_min = 0xD800, .hi_max = 0xDBFF, .lo_min = 0xDC00, .lo_max = 0xDFFF },
+    });
+}
+
+test "encodeSurrogateRange — mid 블록 포함 (1F600-2F800)" {
+    // lo 1F600: c=0xF600 H=0xD83D L=0xDE00
+    // hi 2F800: c=0x1F800 H=0xD800+(0x1F800>>10)=0xD87E L=0xDC00+(0x1F800&0x3FF)=0xDC00
+    try expectPieces(0x1F600, 0x2F800, &.{
+        .{ .hi_min = 0xD83D, .hi_max = 0xD83D, .lo_min = 0xDE00, .lo_max = 0xDFFF },
+        .{ .hi_min = 0xD83E, .hi_max = 0xD87D, .lo_min = 0xDC00, .lo_max = 0xDFFF },
+        .{ .hi_min = 0xD87E, .hi_max = 0xD87E, .lo_min = 0xDC00, .lo_max = 0xDC00 },
+    });
+}

--- a/src/regexp/mod.zig
+++ b/src/regexp/mod.zig
@@ -24,6 +24,7 @@ pub const diagnostics = @import("diagnostics.zig");
 pub const parser = @import("parser.zig");
 pub const printer = @import("printer.zig");
 pub const transform = @import("transform.zig");
+pub const codepoint_set = @import("codepoint_set.zig");
 pub const unicode_property = @import("unicode_property.zig");
 
 /// 정규식 리터럴을 검증한다.
@@ -91,6 +92,7 @@ test {
     _ = parser;
     _ = printer;
     _ = transform;
+    _ = codepoint_set;
     _ = unicode_property;
 
     // test files
@@ -100,4 +102,5 @@ test {
     _ = @import("ast_test.zig");
     _ = @import("printer_test.zig");
     _ = @import("transform_test.zig");
+    _ = @import("codepoint_set_test.zig");
 }

--- a/src/regexp/printer.zig
+++ b/src/regexp/printer.zig
@@ -6,7 +6,7 @@
 //!
 //! 출력은 oxc(`oxc_regular_expression` display.rs) canonical form 에 맞춘다:
 //! hex 는 대문자, unicode_escape 는 4자리 `\uXXXX`/`\u{XXXXX}` 로 통일
-//! (`\xab`→`\xAB`, `\u{41}`→`A`, `\u{1f600}`→`\u{1F600}`), `\ca`→`\cA`,
+//! (`\xab`→`\xAB`, `\u{41}`→`\u0041`, `\u{1f600}`→`\u{1F600}`), `\ca`→`\cA`,
 //! `a{3,3}`→`a{3}`. 따라서 라운드트립 불변식은 "바이트 동일" 이
 //! 아니라 "print 멱등 + 구조 보존" 이다 (printer_test.zig 참조).
 //!

--- a/src/regexp/transform.zig
+++ b/src/regexp/transform.zig
@@ -10,10 +10,19 @@
 
 const std = @import("std");
 const ast = @import("ast.zig");
+const cps = @import("codepoint_set.zig");
 
 const NodeIndex = ast.NodeIndex;
 const Node = ast.Node;
 const UNNAMED = std.math.maxInt(u32);
+const UESC = @intFromEnum(ast.CharacterKind.unicode_escape);
+
+/// ECMAScript `\s` 집합 (WhiteSpace + LineTerminator). 전부 BMP.
+const WS_RANGES = [_][2]u32{
+    .{ 0x09, 0x0D },     .{ 0x20, 0x20 },     .{ 0xA0, 0xA0 },     .{ 0x1680, 0x1680 },
+    .{ 0x2000, 0x200A }, .{ 0x2028, 0x2029 }, .{ 0x202F, 0x202F }, .{ 0x205F, 0x205F },
+    .{ 0x3000, 0x3000 }, .{ 0xFEFF, 0xFEFF },
+};
 
 pub const Options = struct {
     /// `.` (character class 밖) → `[\s\S]`
@@ -32,6 +41,10 @@ pub const NamedGroup = struct {
 pub const Result = struct {
     ast: ast.RegExpAst,
     named_groups: []NamedGroup,
+    /// unicode_brace 요청 시, astral 을 정확히 ES5 로 내리지 못한 구문
+    /// (negated/\p{}/class_string 등)을 만났는가. true 면 호출자는 `u`
+    /// flag 를 strip 하면 안 된다 (silent 오변환 방지 — 부분 커버리지).
+    astral_u_incomplete: bool,
     allocator: std.mem.Allocator,
 
     pub fn deinit(self: *Result) void {
@@ -105,6 +118,8 @@ const T = struct {
     /// 노드로 내지만 ECMAScript 상 backreference 가 아니므로(ad-hoc 도
     /// `!in_class` 에서만 치환) strip_named 을 적용하지 않는다.
     in_class: bool = false,
+    /// 정확히 다운레벨 못한 astral 구문 발견 (lower() 가 u-strip 보류 판단).
+    astral_u_incomplete: bool = false,
 
     fn resolveIndex(self: *T, name: []const u8) ?u32 {
         for (self.names) |g| {
@@ -115,14 +130,9 @@ const T = struct {
 
     /// surrogate pair 2 노드를 list 에 push (cp>0xFFFF).
     fn pushSurrogate(self: *T, span: ast.Span, cp: u32, out: *std.ArrayList(u32)) TransformError!void {
-        // 표준 UTF-16 surrogate 분해 (ECMA-262). regexp 는 transformer 레이어에
-        // 의존하면 안 되므로 동일 공식이 unicode_escape_lower 와 독립 존재.
-        const v = cp - 0x10000;
-        const hi: u32 = 0xD800 | (v >> 10);
-        const lo: u32 = 0xDC00 | (v & 0x3FF);
-        const uk = @intFromEnum(ast.CharacterKind.unicode_escape);
-        const a = try self.b.add(.{ .tag = .character, .span = span, .data = .{ hi, uk, 0 } });
-        const c = try self.b.add(.{ .tag = .character, .span = span, .data = .{ lo, uk, 0 } });
+        const sp = cps.splitSurrogatePair(cp);
+        const a = try self.b.add(.{ .tag = .character, .span = span, .data = .{ sp.hi, UESC, 0 } });
+        const c = try self.b.add(.{ .tag = .character, .span = span, .data = .{ sp.lo, UESC, 0 } });
         try out.append(self.b.a, @intFromEnum(a));
         try out.append(self.b.a, @intFromEnum(c));
     }
@@ -141,6 +151,123 @@ const T = struct {
         if (n.tag != .character) return false;
         const kind: ast.CharacterKind = @enumFromInt(n.data[1]);
         return kind == .unicode_escape and n.data[0] > 0xFFFF;
+    }
+
+    // ── #3509: positive character class 의 astral → surrogate-alternation ──
+
+    fn mkChar(self: *T, cp: u32, span: ast.Span) TransformError!NodeIndex {
+        return self.b.add(.{ .tag = .character, .span = span, .data = .{ cp, UESC, 0 } });
+    }
+
+    /// character 노드(또는 그 인덱스)의 codepoint. character 아니면 null.
+    fn charCp(self: *T, idx: NodeIndex) ?u32 {
+        const cn = self.in.getNode(idx);
+        return if (cn.tag == .character) cn.data[0] else null;
+    }
+
+    /// class body 에 astral(cp>0xFFFF) 멤버가 있는가 (빠른 사전 판정).
+    fn classHasAstral(self: *T, n: Node) bool {
+        for (self.in.getNodeList(n.getClassBody())) |cid| {
+            const m = self.in.getNode(@enumFromInt(cid));
+            switch (m.tag) {
+                .character => if (m.data[0] > 0xFFFF) return true,
+                .character_class_range => {
+                    if (self.charCp(@enumFromInt(m.data[1]))) |mx| if (mx > 0xFFFF) return true;
+                },
+                else => {},
+            }
+        }
+        return false;
+    }
+
+    /// class body → CodePointSet. 단순 positive(character/range/\d\w\s)만
+    /// 지원. negative-escape(\D\W\S)/property/class_string/nested → false.
+    fn collectClassSet(self: *T, n: Node, set: *cps.CodePointSet) TransformError!bool {
+        const a = self.b.a;
+        for (self.in.getNodeList(n.getClassBody())) |cid| {
+            const m = self.in.getNode(@enumFromInt(cid));
+            switch (m.tag) {
+                .character => try set.addOne(a, m.data[0]),
+                .character_class_range => {
+                    const lo = self.charCp(@enumFromInt(m.data[0])) orelse return false;
+                    const hi = self.charCp(@enumFromInt(m.data[1])) orelse return false;
+                    try set.addRange(a, lo, hi);
+                },
+                .character_class_escape => {
+                    switch (@as(ast.CharacterClassEscapeKind, @enumFromInt(m.data[0]))) {
+                        .d => try set.addRange(a, 0x30, 0x39),
+                        .w => {
+                            try set.addRange(a, 0x30, 0x39);
+                            try set.addRange(a, 0x41, 0x5A);
+                            try set.addRange(a, 0x61, 0x7A);
+                            try set.addOne(a, 0x5F);
+                        },
+                        .s => for (WS_RANGES) |r| try set.addRange(a, r[0], r[1]),
+                        // \D \W \S = 보수(astral 포함) — slice 미지원.
+                        else => return false,
+                    }
+                },
+                // property/class_string/nested class → slice 미지원.
+                else => return false,
+            }
+        }
+        return true;
+    }
+
+    /// 단일 → `character`(\uX), 범위 → `character_class_range` 노드.
+    /// class body 의 직접 자식으로 쓰는 형태(클래스 미포장).
+    fn rangeChild(self: *T, mn: u32, mx: u32, span: ast.Span) TransformError!NodeIndex {
+        if (mn == mx) return self.mkChar(mn, span);
+        const a = try self.mkChar(mn, span);
+        const b = try self.mkChar(mx, span);
+        return self.b.add(.{ .tag = .character_class_range, .span = span, .data = .{ @intFromEnum(a), @intFromEnum(b), 0 } });
+    }
+
+    /// surrogate 조각의 standalone atom: 단일 → `\uX`, 범위 → `[\uX-\uY]`.
+    fn surAtom(self: *T, mn: u32, mx: u32, span: ast.Span) TransformError!NodeIndex {
+        const rc = try self.rangeChild(mn, mx, span);
+        if (mn == mx) return rc; // `\uX`
+        const l = try self.b.addList(&.{@intFromEnum(rc)});
+        return self.b.add(.{ .tag = .character_class, .span = span, .data = .{ 0, l.start, l.len } });
+    }
+
+    /// CodePointSet → `(?:[bmp]|\uHi[\uLo-\uLo]|…)` ignore_group.
+    fn buildAstralClassRewrite(self: *T, set: *cps.CodePointSet, span: ast.Span) TransformError!NodeIndex {
+        try set.normalize(self.b.a);
+        var alts: std.ArrayList(u32) = .empty;
+        defer alts.deinit(self.b.a);
+
+        // BMP 부분 → 단일 character_class alternative.
+        var bmp_kids: std.ArrayList(u32) = .empty;
+        defer bmp_kids.deinit(self.b.a);
+        var pieces: std.ArrayList(cps.Piece) = .empty;
+        defer pieces.deinit(self.b.a);
+
+        for (set.items()) |r| {
+            if (r.min <= 0xFFFF) {
+                try bmp_kids.append(self.b.a, @intFromEnum(try self.rangeChild(r.min, @min(r.max, 0xFFFF), span)));
+            }
+            if (r.max >= 0x10000) {
+                try cps.encodeSurrogateRange(@max(r.min, 0x10000), r.max, &pieces, self.b.a);
+            }
+        }
+        if (bmp_kids.items.len != 0) {
+            const cl = try self.b.addList(bmp_kids.items);
+            const cls = try self.b.add(.{ .tag = .character_class, .span = span, .data = .{ 0, cl.start, cl.len } });
+            const al = try self.b.addList(&.{@intFromEnum(cls)});
+            try alts.append(self.b.a, @intFromEnum(try self.b.add(.{ .tag = .alternative, .span = span, .data = .{ al.start, al.len, 0 } })));
+        }
+        for (pieces.items) |p| {
+            const hi = try self.surAtom(p.hi_min, p.hi_max, span);
+            const lo = try self.surAtom(p.lo_min, p.lo_max, span);
+            const al = try self.b.addList(&.{ @intFromEnum(hi), @intFromEnum(lo) });
+            try alts.append(self.b.a, @intFromEnum(try self.b.add(.{ .tag = .alternative, .span = span, .data = .{ al.start, al.len, 0 } })));
+        }
+
+        const dl = try self.b.addList(alts.items);
+        const disj = try self.b.add(.{ .tag = .disjunction, .span = span, .data = .{ dl.start, dl.len, 0 } });
+        // ignore_group: enabling=0, disabling=0 → `(?:…)`
+        return self.b.add(.{ .tag = .ignore_group, .span = span, .data = .{ 0, 0, @intFromEnum(disj) } });
     }
 
     /// list 컨텍스트(alternative term / class atom / class_string char): 자식이
@@ -204,6 +331,21 @@ const T = struct {
                 return self.b.add(.{ .tag = .lookaround_assertion, .span = n.span, .data = .{ n.data[0], @intFromEnum(body), 0 } });
             },
             .character_class => {
+                // #3509: u-strip 시 astral 포함 positive class 를 정확
+                // surrogate-alternation 으로. negative/property/class_string
+                // 등은 미지원 → incomplete 표시 후 기존 경로(기존 동작 유지,
+                // lower() 가 u 보존 판단).
+                if (self.opts.unicode_brace and self.classHasAstral(n)) {
+                    const negative = (n.data[0] & 1) != 0;
+                    if (!negative) {
+                        var set = cps.CodePointSet{};
+                        defer set.deinit(self.b.a);
+                        if (try self.collectClassSet(n, &set)) {
+                            return self.buildAstralClassRewrite(&set, n.span);
+                        }
+                    }
+                    self.astral_u_incomplete = true;
+                }
                 const saved = self.in_class;
                 self.in_class = true;
                 const l = try self.expandList(n.getClassBody());
@@ -274,6 +416,7 @@ pub fn transform(in: ast.RegExpAst, opts: Options, allocator: std.mem.Allocator)
             .allocator = allocator,
         },
         .named_groups = named,
+        .astral_u_incomplete = t.astral_u_incomplete,
         .allocator = allocator,
     };
 }

--- a/src/regexp/transform_test.zig
+++ b/src/regexp/transform_test.zig
@@ -47,11 +47,37 @@ test "transform strip_named — group unname + \\k<name> → \\N" {
     try expectTransform("(?<n>a)[\\k<n>]", "", o, "(a)[\\k<n>]");
 }
 
-test "transform unicode_brace — astral → surrogate pair" {
+test "transform unicode_brace — astral atom → surrogate pair" {
     const o = transform.Options{ .unicode_brace = true };
-    try expectTransform("\\u{1F600}", "u", o, "\\uD83D\\uDE00");
-    try expectTransform("\\u{41}", "u", o, "\\u0041");
-    try expectTransform("[\\u{1F600}]", "u", o, "[\\uD83D\\uDE00]");
+    try expectTransform("\\u{1F600}", "u", o, "\\uD83D\\uDE00"); // 단독 atom: 그대로
+    try expectTransform("\\u{41}", "u", o, "\\u0041"); // BMP
+}
+
+test "#3509 transform — positive class astral → surrogate-alternation (regexpu식)" {
+    const o = transform.Options{ .unicode_brace = true };
+    // 단일 astral class → (?:\uHi\uLo)
+    try expectTransform("[\\u{1F600}]", "u", o, "(?:\\uD83D\\uDE00)");
+    // 동일 high-surrogate range → (?:\uHi[\uLo-\uLo])  ← #3509 본 케이스
+    try expectTransform("[\\u{1F600}-\\u{1F64F}]", "u", o, "(?:\\uD83D[\\uDE00-\\uDE4F])");
+    // high 교차 range → alternation
+    try expectTransform("[\\u{1F600}-\\u{1F900}]", "u", o, "(?:\\uD83D[\\uDE00-\\uDFFF]|\\uD83E[\\uDC00-\\uDD00])");
+    // BMP + astral 혼합 → (?:[bmp]|astral-alt)
+    try expectTransform("[a\\u{1F600}]", "u", o, "(?:[\\u0061]|\\uD83D\\uDE00)");
+    // 전체 astral
+    try expectTransform("[\\u{10000}-\\u{10FFFF}]", "u", o, "(?:[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])");
+}
+
+test "#3509 safety gate — negated/property astral 는 미변환(incomplete)" {
+    const a = std.testing.allocator;
+    const o = transform.Options{ .unicode_brace = true };
+    // negated astral class → slice 미지원 → 변환 안 함 + incomplete 표시
+    {
+        var in = mod.parse("[^\\u{1F600}]", "u", a) orelse return error.ParseFailed;
+        defer in.deinit();
+        var r = try transform.transform(in, o, a);
+        defer r.deinit();
+        try std.testing.expect(r.astral_u_incomplete);
+    }
 }
 
 test "transform 조합 — dotall + strip_named" {

--- a/src/transformer/regex_lower.zig
+++ b/src/transformer/regex_lower.zig
@@ -68,6 +68,9 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
     // 없어야 하나, 방어적으로 실패 시 변환 생략(.text=null = 원본 유지).
     var owned_pattern: ?[]u8 = null;
     defer if (owned_pattern) |p| allocator.free(p);
+    // #3509: astral 을 정확히 ES5 로 못 내린 경우(negated/\p{}/class_string)
+    // u flag 를 strip 하면 silent 오변환 → u 보존(부분 커버리지, 틀린 출력 0).
+    var astral_u_incomplete = false;
     const pattern_text: []const u8 = if (need_pattern_xform) blk: {
         var in_ast = regexp.parse(pattern, flags, allocator) orelse return .{ .text = null };
         defer in_ast.deinit();
@@ -77,9 +80,11 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
             .unicode_brace = need_unicode,
         }, allocator);
         defer tr.deinit();
+        astral_u_incomplete = tr.astral_u_incomplete;
         owned_pattern = regexp.printer.print(tr.ast, allocator) catch return .{ .text = null };
         break :blk owned_pattern.?;
     } else pattern;
+    const strip_u = need_unicode and !astral_u_incomplete;
 
     // named capture mapping 추출 — 패턴 변환 성공 후 (early-return 누수 방지).
     // 원본 pattern 기준이라 변환 순서와 무관. 호출자가 `__wrapRegExp` 합성에 사용.
@@ -100,7 +105,7 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
     for (flags) |c| {
         if (need_dotall and c == 's') continue;
         if (need_sticky and c == 'y') continue;
-        if (need_unicode and c == 'u') continue;
+        if (strip_u and c == 'u') continue;
         try out.append(allocator, c);
     }
     return .{ .text = try out.toOwnedSlice(allocator), .named_groups = named_groups };
@@ -342,10 +347,28 @@ test "regex: u flag 없으면 no-op" {
     try testing.expect(out == null);
 }
 
-test "regex: u + character class" {
+test "regex: u + character class — #3509 정확 surrogate-alternation" {
+    // 이전 ad-hoc 은 깨진 [😀](code-unit alternation) 출력.
+    // #3509: regexpu식 정확 형태 (?:😀) 로 재기준.
     const out = (try runLower("/[\\u{1F600}]/u", .{ .unicode_brace_escape = true })).?;
     defer testing.allocator.free(out);
-    try testing.expectEqualStrings("/[\\uD83D\\uDE00]/", out);
+    try testing.expectEqualStrings("/(?:\\uD83D\\uDE00)/", out);
+}
+
+test "regex: u + astral class range — #3509" {
+    const out = (try runLower("/[\\u{1F600}-\\u{1F64F}]/u", .{ .unicode_brace_escape = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expectEqualStrings("/(?:\\uD83D[\\uDE00-\\uDE4F])/", out);
+}
+
+test "regex: u + negated astral class — u 보존(미변환, silent 오변환 방지)" {
+    // slice 미지원(negated) → astral_u_incomplete → u strip 보류.
+    const out = try runLower("/[^\\u{1F600}]/u", .{ .unicode_brace_escape = true });
+    // u 가 유지되므로 출력은 원본과 동등(변환 없음 → null) 또는 u 포함.
+    if (out) |o| {
+        defer testing.allocator.free(o);
+        try testing.expect(std.mem.endsWith(u8, o, "/u"));
+    }
 }
 
 test "regex: esnext (미지원 없음) no-op" {


### PR DESCRIPTION
## 배경

[#3509](../../issues/3509): `[\u{1F600}-\u{1F64F}]/u` astral character-class 가 u-strip 다운레벨 시 깨졌음. 조사 → babel `regexpu-core`/`regenerate` surrogate-pair alternation 이 유일한 정답 레퍼런스(swc=punt, esbuild=미변환, oxc=polyfill). "바벨처럼". 전체 regexpu 패리티는 XL이라 **핵심 알고리즘 슬라이스**(positive class astral)만 이 PR, 나머지 백로그 분리.

## 변경

- **`src/regexp/codepoint_set.zig`** (신규): 정렬·인접병합 range set + `splitSurrogatePair` + `encodeSurrogateRange`(regenerate start/mid/end-row 분해, lo/hi-full fold). 외부 Unicode 데이터 0.
- **transform.zig**: u-strip 시 positive `character_class` → `CodePointSet`(char/range/`\d\w\s`) → `(?:[bmp]|\uHi[\uLo-\uLo]|…)`. 안전게이트: negated/`\p{}`/class_string/nested/`\D\W\S` → `astral_u_incomplete`.
- **regex_lower.lower()**: `astral_u_incomplete` 면 `u` strip 보류 → silent 오변환 0.

### ⚠️ 의도적 동작 변경
astral-in-class: 깨진 `[😀]` → 정확 `(?:😀)`. `[\u{1F600}-\u{1F64F}]`→`(?:\uD83D[\uDE00-\uDE4F])`. 영향 테스트 regexpu-정확형 재기준. 비-astral byte-identical 유지.

## 검증 (TDD)

- `codepoint_set_test` 유닛 + `#3509` 케이스(range/cross-high/bmp혼합/full/safety-gate)
- Debug + ReleaseFast **5300/5304 / 0 fail** (4 skip baseline, 무회귀)
- `/simplify` 3에이전트: **regexpu-core 오라클 독립 대조 동일**, encode parity 전 tag, safety gate 무 silent-miscompile, 메모리 clean. 반영: `splitSurrogatePair`/`rangeChild` 중복 제거.

## 백로그 (substrate=이 PR 의존)
#3511 iu case-fold · #3512 \p{} property · #3513 negated astral

Closes #3509

🤖 Generated with [Claude Code](https://claude.com/claude-code)