### PR TITLE
test(e2e): content-type 스모크 — default→named import 정정

### DIFF
--- a/tests/e2e/tests/browser-smoke.test.ts
+++ b/tests/e2e/tests/browser-smoke.test.ts
@@ -432,7 +432,10 @@ const cases: BrowserSmokeCase[] = [
   {
     name: 'content-type',
     pkg: 'content-type',
-    entry: `import ct from 'content-type';\nconsole.log(ct.parse('text/html').type);`,
+    // content-type 최신판은 __esModule:true + named export(parse/format)만 두고
+    // default export 가 없다. `import ct from` 의 default 는 표준 ESM↔CJS
+    // 인터롭에서 undefined (esbuild 동일) — named import 가 올바른 사용법.
+    entry: `import { parse } from 'content-type';\nconsole.log(parse('text/html').type);`,
     expected: 'text/html',
   },
   {


### PR DESCRIPTION
## 증상

CI e2e `browser: content-type` 가 실패:

```
Browser errors in content-type: Cannot read properties of undefined (reading 'parse')
```

## 원인 (번들러 버그 아님)

`content-type` 최신판은 `Object.defineProperty(exports, "__esModule", { value: true })` 를 설정하고 `parse`/`format` 만 named export 하며 **`default` export 가 없다**.

표준 ESM↔CJS 인터롭에서 `__esModule:true` 모듈의 default 는 `module.exports` 로 합성되지 않으므로 `import ct from 'content-type'` 의 `ct` 는 `undefined` → `ct.parse` TypeError.

**esbuild 로 동일 입력을 번들해도 똑같이 실패**(`import_content_type.default.parse` → 같은 TypeError)함을 확인. ZNTC 번들러는 표준 동작과 일치하며, 잘못된 것은 테스트 픽스처의 default import 사용이다.

## 수정

엔트리를 named import 로 정정 (인접 `cookie` 케이스의 `import { serialize }` 와 동일 패턴):

```diff
-import ct from 'content-type';
-console.log(ct.parse('text/html').type);
+import { parse } from 'content-type';
+console.log(parse('text/html').type);
```

## 검증

```
npx playwright test browser-smoke.test.ts -g "content-type"
  ✓  browser: content-type (1.7s)
  1 passed
```

`import { parse } from 'content-type'` 는 ZNTC 번들 후 `text/html` 정상 출력. esbuild 와 ZNTC 모두 default import 에서 동일 실패하는 것도 별도 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)