### PR TITLE
feat(regexp): negated class u-downlevel — complement surrogate-alternation (#3513)

### DIFF
--- a/src/regexp/codepoint_set.zig
+++ b/src/regexp/codepoint_set.zig
@@ -62,6 +62,22 @@ pub const CodePointSet = struct {
     pub fn items(self: *const CodePointSet) []const Range {
         return self.ranges.items;
     }
+
+    /// [0, 0x10FFFF] 전체 대비 여집합을 새 set 으로 반환 (regexpu
+    /// `UNICODE_SET.clone().remove(set)` 와 동형). 호출자가 deinit.
+    pub fn complement(self: *CodePointSet, a: std.mem.Allocator) !CodePointSet {
+        try self.normalize(a);
+        var out = CodePointSet{};
+        errdefer out.deinit(a);
+        var next: u32 = 0;
+        for (self.ranges.items) |r| {
+            if (r.min > next) try out.addRange(a, next, r.min - 1);
+            if (r.max == 0x10FFFF) return out; // 더 이상 gap 없음
+            next = r.max + 1;
+        }
+        try out.addRange(a, next, 0x10FFFF);
+        return out;
+    }
 };
 
 /// astral codepoint(≥0x10000) → UTF-16 surrogate pair. 표준 ECMA-262 공식.

--- a/src/regexp/codepoint_set_test.zig
+++ b/src/regexp/codepoint_set_test.zig
@@ -21,6 +21,42 @@ test "CodePointSet normalize — 정렬 + 인접/중첩 병합" {
     try std.testing.expectEqual(@as(u32, 0x60), r[1].max);
 }
 
+test "CodePointSet complement — [0,0x10FFFF] 여집합 (#3513)" {
+    const a = std.testing.allocator;
+    var s = cps.CodePointSet{};
+    defer s.deinit(a);
+    try s.addOne(a, 0x61); // {a}
+    var c = try s.complement(a);
+    defer c.deinit(a);
+    const r = c.items();
+    try std.testing.expectEqual(@as(usize, 2), r.len);
+    try std.testing.expectEqual(@as(u32, 0), r[0].min);
+    try std.testing.expectEqual(@as(u32, 0x60), r[0].max);
+    try std.testing.expectEqual(@as(u32, 0x62), r[1].min);
+    try std.testing.expectEqual(@as(u32, 0x10FFFF), r[1].max);
+}
+
+test "CodePointSet complement — 빈 집합 → 전체 / 전체 → 빈" {
+    const a = std.testing.allocator;
+    {
+        var s = cps.CodePointSet{};
+        defer s.deinit(a);
+        var c = try s.complement(a);
+        defer c.deinit(a);
+        try std.testing.expectEqual(@as(usize, 1), c.items().len);
+        try std.testing.expectEqual(@as(u32, 0), c.items()[0].min);
+        try std.testing.expectEqual(@as(u32, 0x10FFFF), c.items()[0].max);
+    }
+    {
+        var s = cps.CodePointSet{};
+        defer s.deinit(a);
+        try s.addRange(a, 0, 0x10FFFF);
+        var c = try s.complement(a);
+        defer c.deinit(a);
+        try std.testing.expectEqual(@as(usize, 0), c.items().len);
+    }
+}
+
 fn expectPieces(lo: u32, hi: u32, expected: []const cps.Piece) !void {
     const a = std.testing.allocator;
     var out: std.ArrayList(cps.Piece) = .empty;

--- a/src/regexp/transform.zig
+++ b/src/regexp/transform.zig
@@ -31,6 +31,9 @@ pub const Options = struct {
     strip_named: bool = false,
     /// astral `\u{XXXXX}` (cp>0xFFFF) → surrogate pair 2 노드
     unicode_brace: bool = false,
+    /// `i` flag 활성 여부. negated class 의 정확 다운레벨은 case-fold 와
+    /// 얽히므로(#3511), `i`+`u` negated 는 보수적으로 게이트(미변환).
+    ignore_case: bool = false,
 };
 
 pub const NamedGroup = struct {
@@ -331,20 +334,34 @@ const T = struct {
                 return self.b.add(.{ .tag = .lookaround_assertion, .span = n.span, .data = .{ n.data[0], @intFromEnum(body), 0 } });
             },
             .character_class => {
-                // #3509: u-strip 시 astral 포함 positive class 를 정확
-                // surrogate-alternation 으로. negative/property/class_string
-                // 등은 미지원 → incomplete 표시 후 기존 경로(기존 동작 유지,
-                // lower() 가 u 보존 판단).
-                if (self.opts.unicode_brace and self.classHasAstral(n)) {
+                // u-strip 시 class 를 code-point set 으로 정확 다운레벨:
+                //  - positive + astral (#3509): set → surrogate-alternation
+                //  - negated (#3513): u 에선 code-point 의미 → 항상 complement
+                //    ([0,0x10FFFF]-set) 재작성 (regexpu UNICODE_SET-singleChars).
+                //    단 i+u negated 는 case-fold 얽힘(#3511) → 게이트 유지.
+                // 미지원(\p{}/class_string/\D\W\S/i+u-neg) → incomplete →
+                // 기존 경로 + lower() 가 u 보존(silent 오변환 0).
+                if (self.opts.unicode_brace) {
                     const negative = (n.data[0] & 1) != 0;
-                    if (!negative) {
+                    if (negative) {
+                        if (!self.opts.ignore_case) {
+                            var set = cps.CodePointSet{};
+                            defer set.deinit(self.b.a);
+                            if (try self.collectClassSet(n, &set)) {
+                                var comp = try set.complement(self.b.a);
+                                defer comp.deinit(self.b.a);
+                                return self.buildAstralClassRewrite(&comp, n.span);
+                            }
+                        }
+                        self.astral_u_incomplete = true;
+                    } else if (self.classHasAstral(n)) {
                         var set = cps.CodePointSet{};
                         defer set.deinit(self.b.a);
                         if (try self.collectClassSet(n, &set)) {
                             return self.buildAstralClassRewrite(&set, n.span);
                         }
+                        self.astral_u_incomplete = true;
                     }
-                    self.astral_u_incomplete = true;
                 }
                 const saved = self.in_class;
                 self.in_class = true;

--- a/src/regexp/transform_test.zig
+++ b/src/regexp/transform_test.zig
@@ -67,14 +67,27 @@ test "#3509 transform — positive class astral → surrogate-alternation (regex
     try expectTransform("[\\u{10000}-\\u{10FFFF}]", "u", o, "(?:[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])");
 }
 
-test "#3509 safety gate — negated/property astral 는 미변환(incomplete)" {
-    const a = std.testing.allocator;
+test "#3513 negated class (non-i) → complement surrogate-alternation" {
     const o = transform.Options{ .unicode_brace = true };
-    // negated astral class → slice 미지원 → 변환 안 함 + incomplete 표시
+    // [^a]/u = code-point 의미 → [0,0x10FFFF]-{a} complement.
+    try expectTransform("[^a]", "u", o, "(?:[\\u0000-\\u0060\\u0062-\\uFFFF]|[\\uD800-\\uDBFF][\\uDC00-\\uDFFF])");
+}
+
+test "#3513 safety gate — i+u negated 는 미변환(case-fold #3511)" {
+    const a = std.testing.allocator;
+    // i+u negated → case-fold 얽힘 → 보수적 게이트(incomplete, u 보존).
     {
-        var in = mod.parse("[^\\u{1F600}]", "u", a) orelse return error.ParseFailed;
+        var in = mod.parse("[^\\u{1F600}]", "iu", a) orelse return error.ParseFailed;
         defer in.deinit();
-        var r = try transform.transform(in, o, a);
+        var r = try transform.transform(in, .{ .unicode_brace = true, .ignore_case = true }, a);
+        defer r.deinit();
+        try std.testing.expect(r.astral_u_incomplete);
+    }
+    // \p{} 포함 → 여전히 미지원(데이터 백로그 #3512).
+    {
+        var in = mod.parse("[\\p{L}\\u{1F600}]", "u", a) orelse return error.ParseFailed;
+        defer in.deinit();
+        var r = try transform.transform(in, .{ .unicode_brace = true }, a);
         defer r.deinit();
         try std.testing.expect(r.astral_u_incomplete);
     }

--- a/src/transformer/regex_lower.zig
+++ b/src/transformer/regex_lower.zig
@@ -48,6 +48,7 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
     const has_s = std.mem.indexOfScalar(u8, flags, 's') != null;
     const has_y = std.mem.indexOfScalar(u8, flags, 'y') != null;
     const has_u = std.mem.indexOfScalar(u8, flags, 'u') != null;
+    const has_i = std.mem.indexOfScalar(u8, flags, 'i') != null;
 
     const need_dotall = has_s and opts.unsupported.regex_dotall;
     const need_named = opts.unsupported.regex_named_groups and hasNamedGroup(pattern);
@@ -78,6 +79,7 @@ pub fn lower(allocator: std.mem.Allocator, raw: []const u8, opts: Options) !Resu
             .dotall = need_dotall,
             .strip_named = need_named,
             .unicode_brace = need_unicode,
+            .ignore_case = has_i,
         }, allocator);
         defer tr.deinit();
         astral_u_incomplete = tr.astral_u_incomplete;
@@ -361,13 +363,21 @@ test "regex: u + astral class range — #3509" {
     try testing.expectEqualStrings("/(?:\\uD83D[\\uDE00-\\uDE4F])/", out);
 }
 
-test "regex: u + negated astral class — u 보존(미변환, silent 오변환 방지)" {
-    // slice 미지원(negated) → astral_u_incomplete → u strip 보류.
-    const out = try runLower("/[^\\u{1F600}]/u", .{ .unicode_brace_escape = true });
-    // u 가 유지되므로 출력은 원본과 동등(변환 없음 → null) 또는 u 포함.
+test "regex: u + negated class (non-i) — #3513 complement 다운레벨" {
+    // [^😀]/u → [0,0x10FFFF]-{😀} complement surrogate-alternation, u strip.
+    const out = (try runLower("/[^\\u{1F600}]/u", .{ .unicode_brace_escape = true })).?;
+    defer testing.allocator.free(out);
+    try testing.expect(std.mem.startsWith(u8, out, "/(?:"));
+    try testing.expect(!std.mem.endsWith(u8, out, "/u")); // u strip 됨
+    try testing.expect(std.mem.indexOf(u8, out, "\\u{") == null); // brace 잔존 없음
+}
+
+test "regex: iu + negated astral — u 보존(미변환, #3511 case-fold 게이트)" {
+    // i+u negated 는 case-fold 얽힘 → 게이트 → u 보존(silent 오변환 0).
+    const out = try runLower("/[^\\u{1F600}]/iu", .{ .unicode_brace_escape = true });
     if (out) |o| {
         defer testing.allocator.free(o);
-        try testing.expect(std.mem.endsWith(u8, o, "/u"));
+        try testing.expect(std.mem.endsWith(u8, o, "/iu") or std.mem.endsWith(u8, o, "/ui"));
     }
 }
 


### PR DESCRIPTION
## 배경

[#3513](../../issues/3513) (#3509 백로그): `[^X]/u` 는 u-mode 에서 **code-point 의미**(astral 포함)라, u-strip 다운레벨 시 단순 `[^X]` 비-u 로 두면 astral 매칭이 깨짐. regexpu `processCharacterClass`(rewrite-pattern.js:604-607)는 negated 를 `UNICODE_SET.clone().remove(singleChars)` = **complement 집합을 positive surrogate-alternation 으로** emit. #3509 substrate(CodePointSet/encodeSurrogateRange/buildAstralClassRewrite) 그대로 재사용.

## 변경

- **codepoint_set.zig**: `complement` — [0,0x10FFFF] 대비 여집합(gap-walk, u32 under/overflow 가드, empty↔full).
- **transform.zig**: negated class + `unicode_brace`:
  - `!ignore_case` + `collectClassSet` 성공 → `complement` → `buildAstralClassRewrite` (정확 다운레벨, classHasAstral 무관 — negated 는 항상 astral 의미)
  - `i`+`u` negated (case-fold 얽힘, **#3511**) / `\p{}`·class_string·`\D\W\S` → `astral_u_incomplete` → **u 보존**(silent 오변환 0, 부분 커버리지)
  - `Options.ignore_case` 추가, `lower()` 가 `has_i` 전달
- positive/#3509 경로 **무변경**.

### 의도적 동작 변경

non-i negated class: 게이트(u 보존) → **정확 complement 다운레벨**. 예: `[^a]` + u → BMP 보집합 클래스 `|` astral surrogate-pair 형태의 `(?: ... )` 로 변환(소문자 a=U+0061 제외 전 범위). 영향 테스트 재기준(positive/#3509 는 byte-identical 유지).

## 검증 (TDD)

- `complement` 유닛(여집합/empty/full) + `[^a]` exact + i+u-negated→incomplete + `\p{}`→incomplete
- Debug + ReleaseFast **5304/5308 / 0 fail** (4 skip baseline, 무회귀)
- `/simplify`: **regexpu-core 를 오라클로 set-level 정확 일치 교차검증** (`[^a]` / `[^\u{1F600}]` / `[^a-c\u{1F600}]` / `[^\d]` / empty / full), under/overflow·게이트·메모리 clean → 결함 0, 수정 0.

남은 백로그: #3511 iu case-fold · #3512 \p{} property (둘 다 XL Unicode 데이터, 게이트로 이미 SAFE).

Closes #3513

🤖 Generated with [Claude Code](https://claude.com/claude-code)
