### PR TITLE
chore(e2e): content-type 케이스 주석 터스 1줄로 정리

### DIFF
--- a/tests/e2e/tests/browser-smoke.test.ts
+++ b/tests/e2e/tests/browser-smoke.test.ts
@@ -429,12 +429,10 @@ const cases: BrowserSmokeCase[] = [
     entry: `import ar from 'ansi-regex';\nconsole.log(typeof ar);`,
     expected: 'function',
   },
+  // content-type: 최신판 __esModule + named export 만 — default 는 undefined (esbuild 동일), named import 필수
   {
     name: 'content-type',
     pkg: 'content-type',
-    // content-type 최신판은 __esModule:true + named export(parse/format)만 두고
-    // default export 가 없다. `import ct from` 의 default 는 표준 ESM↔CJS
-    // 인터롭에서 undefined (esbuild 동일) — named import 가 올바른 사용법.
     entry: `import { parse } from 'content-type';\nconsole.log(parse('text/html').type);`,
     expected: 'text/html',
   },


### PR DESCRIPTION
## 배경

PR #3515 후속. `/simplify` 정식 3-에이전트 리뷰를 (요청에 따라) 다시 돌린 결과:

- **재사용**: ✅ 통과 (`graphql`/`yaml` 와 동일한 named `import { parse }` 패턴)
- **효율**: ✅ 영향 없음
- **품질**: 주석은 정당한 WHY 이나, 이 파일의 다른 케이스 주석(터스한 1줄, 예: glob-parent/remeda)보다 3배 장황 → 컨벤션에 맞춰 압축 권장

## 변경

3줄 inline 주석을 케이스 `{` 위 1줄로 압축 (패키지명 접두 + em-dash — 파일 기존 스타일과 동일). WHY(default 가 undefined, esbuild 동일, named 필수)는 그대로 유지.

```diff
+  // content-type: 최신판 __esModule + named export 만 — default 는 undefined (esbuild 동일), named import 필수
   {
     name: 'content-type',
     pkg: 'content-type',
-    // (3줄 주석)
     entry: `import { parse } from 'content-type';\nconsole.log(parse('text/html').type);`,
```

순수 주석 정리 — 테스트 로직/동작 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)