### PR TITLE
fix(rn): deconflict non-inlined CJS imports

### DIFF
--- a/src/bundler/bundler_test/cjs_esm.zig
+++ b/src/bundler/bundler_test/cjs_esm.zig
@@ -2431,6 +2431,56 @@ test "ESM wrapped barrel namespace import under strict order does not emit raw r
     try std.testing.expect(std.mem.indexOf(u8, result.output, "require(\"./QueryClientProvider.js\")") == null);
 }
 
+test "ESM wrap: RN non-inlined CJS named import is deconflicted with wrapped locals" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makePath("node_modules/react");
+    try writeFile(tmp.dir, "node_modules/react/package.json",
+        \\{
+        \\  "name": "react",
+        \\  "main": "index.js"
+        \\}
+    );
+    try writeFile(tmp.dir, "node_modules/react/index.js",
+        \\exports.useEffect = function useEffect(value) {
+        \\  return 'effect:' + value;
+        \\};
+    );
+    try writeFile(tmp.dir, "entry.js",
+        \\import { runOverlay } from './overlay.js';
+        \\import { touch } from './api.js';
+        \\console.log(typeof touch, runOverlay('ok'));
+    );
+    try writeFile(tmp.dir, "overlay.js",
+        \\import { useEffect as Q } from 'react';
+        \\export function runOverlay(value) {
+        \\  return Q(value);
+        \\}
+    );
+    try writeFile(tmp.dir, "api.js",
+        \\var Q = class InterceptorPlugin {};
+        \\export const touch = Q;
+    );
+
+    const entry = try absPath(&tmp, "entry.js");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .platform = .react_native,
+        .format = .iife,
+        .dev_mode = true,
+    });
+    defer b.deinit();
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(!result.hasErrors());
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "__zntc_modules[") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "useEffect") != null);
+    try std.testing.expect(std.mem.indexOf(u8, result.output, "Q$") != null);
+}
+
 // ============================================================
 // `.cjs` / `.cts` 는 Node CommonJS 컨벤션상 ESM 구문 (`import`/`export`) 거부.
 // 이전엔 graph/parser_setup.zig 가 모든 모듈을 is_module=true 로 promote 해서

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -57,6 +57,19 @@ pub inline fn isImportExpressionRename(rename: []const u8) bool {
     return isNamespaceRename(rename) or std.mem.indexOf(u8, rename, EXPR_RENAME_MARKER) != null;
 }
 
+/// Metro inlineRequires가 eager/non-inline로 유지하는 RN core specifier.
+/// 이 specifier들의 named CJS import는 `require_xxx().name` expression으로
+/// 치환하지 않고 outer binding var를 만든다. 링커의 collision 수집과 metadata
+/// preamble 생성이 같은 기준을 써야 한다.
+pub inline fn isMetroNonInlinedRequireSpecifier(specifier: []const u8) bool {
+    return std.mem.eql(u8, specifier, "React") or
+        std.mem.eql(u8, specifier, "react") or
+        std.mem.eql(u8, specifier, "react/jsx-dev-runtime") or
+        std.mem.eql(u8, specifier, "react/jsx-runtime") or
+        std.mem.eql(u8, specifier, "react-compiler-runtime") or
+        std.mem.eql(u8, specifier, "react-native");
+}
+
 /// `Linker.collectUnifiedInput` 반환 컨테이너. unified_mangler.mangleAll 에
 /// 그대로 넘길 수 있는 형태.
 ///
@@ -524,7 +537,11 @@ pub const Linker = struct {
                             // CJS named import는 `require_xxx().prop` 직접 참조로 치환하므로
                             // 별도 top-level var를 만들지 않는다. helper binding (JSX runtime
                             // 등) 은 call site 가 식별자 (`_jsx(...)`) 라 var 할당이 필요.
-                            if (target_wrap == .cjs and ib.kind == .named and !ib.is_helper) break :blk false;
+                            if (target_wrap == .cjs and ib.kind == .named and !ib.is_helper and
+                                !isMetroNonInlinedRequireSpecifier(rec.specifier))
+                            {
+                                break :blk false;
+                            }
                             // __esm: scope-hoisted 타겟의 import는 skip되어 var 미생성
                             break :blk target_wrap != .none;
                         } else {

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -61,13 +61,17 @@ pub inline fn isImportExpressionRename(rename: []const u8) bool {
 /// 이 specifier들의 named CJS import는 `require_xxx().name` expression으로
 /// 치환하지 않고 outer binding var를 만든다. 링커의 collision 수집과 metadata
 /// preamble 생성이 같은 기준을 써야 한다.
+const METRO_NON_INLINED_REQUIRE_SPECIFIERS = std.StaticStringMap(void).initComptime(.{
+    .{ "React", {} },
+    .{ "react", {} },
+    .{ "react/jsx-dev-runtime", {} },
+    .{ "react/jsx-runtime", {} },
+    .{ "react-compiler-runtime", {} },
+    .{ "react-native", {} },
+});
+
 pub inline fn isMetroNonInlinedRequireSpecifier(specifier: []const u8) bool {
-    return std.mem.eql(u8, specifier, "React") or
-        std.mem.eql(u8, specifier, "react") or
-        std.mem.eql(u8, specifier, "react/jsx-dev-runtime") or
-        std.mem.eql(u8, specifier, "react/jsx-runtime") or
-        std.mem.eql(u8, specifier, "react-compiler-runtime") or
-        std.mem.eql(u8, specifier, "react-native");
+    return METRO_NON_INLINED_REQUIRE_SPECIFIERS.has(specifier);
 }
 
 /// `Linker.collectUnifiedInput` 반환 컨테이너. unified_mangler.mangleAll 에

--- a/src/bundler/linker/metadata.zig
+++ b/src/bundler/linker/metadata.zig
@@ -33,6 +33,7 @@ const EXPR_RENAME_MARKER = linker_mod.EXPR_RENAME_MARKER;
 const shared_ns = @import("shared_namespace.zig");
 const allocEsmInitExpr = shared_ns.allocEsmInitExpr;
 const writeEsmInitExprBody = shared_ns.writeEsmInitExprBody;
+const isMetroNonInlinedRequireSpecifier = linker_mod.isMetroNonInlinedRequireSpecifier;
 
 inline fn cjsInteropMode(self: *const Linker, importer: *const Module) types.Interop {
     if (self.graph.resolve_cache.platform == .react_native) return .babel;
@@ -587,7 +588,10 @@ pub fn buildMetadataForAst(
             {
                 if (canonical_m_opt.?.wrap_kind == .cjs) {
                     const req_var = try getOrCreateCjsRequireRef(self, &cjs_var_cache, @intCast(canonical_mod));
-                    if (ib.kind == .named and !std.mem.eql(u8, ib.imported_name, "default")) {
+                    if (ib.kind == .named and
+                        !std.mem.eql(u8, ib.imported_name, "default") and
+                        !isMetroNonInlinedRequireSpecifier(rec.specifier))
+                    {
                         if (ib.local_symbol.semanticIndex()) |sym_idx| {
                             const direct_access = try std.fmt.allocPrint(self.allocator, "{s}" ++ EXPR_RENAME_MARKER ++ "{s}", .{ req_var, ib.imported_name });
                             errdefer self.allocator.free(direct_access);
@@ -688,6 +692,7 @@ pub fn buildMetadataForAst(
                 lazy_esm_import = self.inline_requires and
                     m.wrap_kind == .esm and
                     rec.kind == .static_import and
+                    !isMetroNonInlinedRequireSpecifier(rec.specifier) and
                     canonical_mod != module_index and
                     !is_helper_binding and
                     ib.kind == .named and


### PR DESCRIPTION
## 요약
- RN dev bundle에서 Metro가 non-inline로 유지하는 CJS named import(`react`, `react-native`, JSX runtime 등)를 ZNTC의 이름 충돌 수집에도 동일하게 반영했습니다.
- `__esm` 래퍼 밖으로 hoist되는 import binding var가 다른 wrapped ESM 모듈의 top-level local과 같은 이름을 공유하지 않도록 canonical rename 대상에 포함했습니다.
- 실제 슈퍼앱 RN 0.85 dev bundle에서 `overlay-kit`의 `useEffect as Q`와 다른 모듈의 `Q` class가 충돌해 `Cannot call a class as a function`으로 redbox가 뜨는 케이스를 재현 테스트로 고정했습니다.

## 원인
RN inlineRequires 경로에서 ZNTC는 Metro와 동일하게 `react`, `react-native`, `react/jsx-runtime`, `react/jsx-dev-runtime`, `react-compiler-runtime` 같은 specifier를 non-inline/eager로 처리합니다.

그런데 기존 구현은 metadata emit 단계에서는 이 specifier들의 CJS named import를 outer binding var로 만들면서도, `Linker.collectModuleNames()`의 충돌 후보 수집에서는 일반 CJS named import처럼 `require_xxx().prop` expression rename으로만 처리된다고 판단해 이름 점유를 건너뛰었습니다.

그 결과 `__esm` 래퍼 밖에 실제로는 아래와 같은 top-level binding이 만들어질 수 있었습니다.

```js
var Q;
Q = require_react().useEffect;
```

동시에 다른 wrapped ESM 모듈도 자체 top-level local `Q`를 hoist하면 두 모듈이 하나의 bundle scope에서 같은 `Q`를 공유하게 됩니다. 실제 앱에서는 `overlay-kit`의 React hook alias `Q`가 `@payhereinc/api-sdk` 쪽 class `Q`로 덮여, overlay component가 `Q(...)`를 호출할 때 class-call-check가 터졌습니다.

## 수정
- Metro의 `baseIgnoredInlineRequires`와 같은 specifier 목록을 `linker.zig`의 공용 helper로 이동했습니다.
- metadata emit과 collision 수집이 같은 helper를 사용하게 했습니다.
- RN non-inline CJS named import는 실제 outer var를 생성하므로 `collectModuleNames()`에서 top-level 이름 점유자로 등록되도록 수정했습니다.

## 테스트
- `zig build test -Dtest-filter="ESM wrap: RN non-inlined CJS named import is deconflicted with wrapped locals"`
- `zig build test -Dtest-filter="ESM wrapped static import under strict order does not emit raw require"`
- `zig build test -Dtest-filter="ESM wrapped barrel namespace import under strict order does not emit raw require"`
- `zig build`

추가 실앱 검증:
- `packages/core` N-API를 재빌드한 뒤 슈퍼앱 RN 0.85 ZNTC dev server로 번들 생성
- 번들에서 `overlay-kit`의 `useEffect as Q`가 `Q$1`로 deconflict되는 것 확인
- iOS 26.4 simulator에서 `com.payhereuntact.ios` 재실행 후 기존 `Cannot call a class as a function` redbox가 사라지고 온보딩 화면까지 렌더링되는 것 확인

참고: `/tmp` worktree에서 clean cherry-pick 후 테스트를 한 번 더 돌리려 했으나, 해당 worktree의 `vendor/mimalloc/src/static.c`가 비어 있는 상태라 Zig cache check가 `FileNotFound`로 실패했습니다. 실제 테스트/빌드는 원본 repository worktree에서 통과했습니다.
