### PR TITLE
chore(react-native): deprecated applyMapPathOptions 제거 (dead code)

### DIFF
--- a/.changeset/remove-apply-map-path-options.md
+++ b/.changeset/remove-apply-map-path-options.md
@@ -1,0 +1,11 @@
+---
+"@zntc/react-native": minor
+---
+
+deprecated `applyMapPathOptions` 제거 (dead code 전수조사 결과 — 내부 사용 0, deprecated 별칭)
+
+### Breaking
+
+`@zntc/react-native` 의 `applyMapPathOptions(rawJson, options)` export 가 제거되었습니다. 이 함수는 `postProcessSourceMap` 로 그대로 위임하던 deprecated 별칭이었습니다.
+
+마이그레이션: `applyMapPathOptions(rawJson, opts)` → `postProcessSourceMap(rawJson, opts)` (시그니처 동일).

--- a/packages/react-native/src/dev-server/index.ts
+++ b/packages/react-native/src/dev-server/index.ts
@@ -56,11 +56,7 @@ export {
   isMapRoute,
 } from './routes/bundle.ts';
 export { handleSymbolicateRequest, isSymbolicateRoute } from './routes/symbolicate.ts';
-export {
-  applyMapPathOptions,
-  postProcessSourceMap,
-  type SourcemapPathOptions,
-} from './sourcemap.ts';
+export { postProcessSourceMap, type SourcemapPathOptions } from './sourcemap.ts';
 export {
   setupTerminalActions,
   type TerminalActionsCallbacks,

--- a/packages/react-native/src/dev-server/sourcemap.test.ts
+++ b/packages/react-native/src/dev-server/sourcemap.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import { applyMapPathOptions, postProcessSourceMap } from './sourcemap.ts';
+import { postProcessSourceMap } from './sourcemap.ts';
 
 describe('postProcessSourceMap', () => {
   test('invalid JSON → rawJson 그대로', () => {
@@ -194,87 +194,5 @@ describe('postProcessSourceMap — path 옵션 통합 (#2605 audit P2)', () => {
       'bun:sqlite',
       'data:text/javascript;base64,Zm9v',
     ]);
-  });
-});
-
-describe('applyMapPathOptions — Metro sourcemap path 옵션 (#2605 audit P2)', () => {
-  test('미설정 — raw 그대로 (no-op)', () => {
-    const raw = JSON.stringify({ version: 3, sources: ['a.ts'] });
-    expect(applyMapPathOptions(raw, {})).toBe(raw);
-  });
-
-  test('sourceRoot — Metro sourcemapSourcesRoot 설정', () => {
-    const raw = JSON.stringify({ version: 3, sources: ['a.ts'] });
-    const out = JSON.parse(applyMapPathOptions(raw, { sourceRoot: '/abs/proj' }));
-    expect(out.sourceRoot).toBe('/abs/proj');
-  });
-
-  test('sourceRoot — 빈 string 도 valid (Metro 호환)', () => {
-    const raw = JSON.stringify({ version: 3, sources: ['a.ts'] });
-    const out = JSON.parse(applyMapPathOptions(raw, { sourceRoot: '' }));
-    expect(out.sourceRoot).toBe('');
-  });
-
-  test('useAbsolutePath — sources 의 상대 경로를 projectRoot 기준 절대화', () => {
-    const raw = JSON.stringify({
-      version: 3,
-      sources: ['src/app.ts', 'src/utils/foo.ts'],
-    });
-    const out = JSON.parse(
-      applyMapPathOptions(raw, { useAbsolutePath: true, projectRoot: '/abs/proj' }),
-    );
-    expect(out.sources).toEqual(['/abs/proj/src/app.ts', '/abs/proj/src/utils/foo.ts']);
-  });
-
-  test('useAbsolutePath — virtual module (`zntc:` / NUL prefix) 는 그대로', () => {
-    const NUL = String.fromCharCode(0);
-    const raw = JSON.stringify({
-      version: 3,
-      sources: ['src/app.ts', `${NUL}zntc:runtime/foo`, 'http://cdn.example.com/lib.js'],
-    });
-    const out = JSON.parse(
-      applyMapPathOptions(raw, { useAbsolutePath: true, projectRoot: '/abs/proj' }),
-    );
-    expect(out.sources[0]).toBe('/abs/proj/src/app.ts');
-    expect(out.sources[1]).toBe(`${NUL}zntc:runtime/foo`);
-    expect(out.sources[2]).toBe('http://cdn.example.com/lib.js');
-  });
-
-  test('useAbsolutePath — 절대 경로는 idempotent', () => {
-    const raw = JSON.stringify({ version: 3, sources: ['/abs/already.ts'] });
-    const out = JSON.parse(
-      applyMapPathOptions(raw, { useAbsolutePath: true, projectRoot: '/abs/proj' }),
-    );
-    expect(out.sources[0]).toBe('/abs/already.ts');
-  });
-
-  test('sourceRoot + useAbsolutePath 둘 다 적용', () => {
-    const raw = JSON.stringify({ version: 3, sources: ['src/app.ts'] });
-    const out = JSON.parse(
-      applyMapPathOptions(raw, {
-        sourceRoot: '/root',
-        useAbsolutePath: true,
-        projectRoot: '/abs/proj',
-      }),
-    );
-    expect(out.sourceRoot).toBe('/root');
-    expect(out.sources).toEqual(['/abs/proj/src/app.ts']);
-  });
-
-  test('invalid JSON — raw 그대로', () => {
-    expect(applyMapPathOptions('not json', { sourceRoot: '/x' })).toBe('not json');
-  });
-
-  test('version != 3 — raw 그대로', () => {
-    const raw = JSON.stringify({ version: 2 });
-    expect(applyMapPathOptions(raw, { sourceRoot: '/x' })).toBe(raw);
-  });
-
-  test('non-string source 항목 무시 (절대화 skip)', () => {
-    const raw = JSON.stringify({ version: 3, sources: ['src/a.ts', 42, null] });
-    const out = JSON.parse(
-      applyMapPathOptions(raw, { useAbsolutePath: true, projectRoot: '/abs/proj' }),
-    );
-    expect(out.sources).toEqual(['/abs/proj/src/a.ts', 42, null]);
   });
 });

--- a/packages/react-native/src/dev-server/sourcemap.ts
+++ b/packages/react-native/src/dev-server/sourcemap.ts
@@ -120,8 +120,3 @@ export function postProcessSourceMap(rawJson: string, pathOpts?: SourcemapPathOp
     return rawJson;
   }
 }
-
-/** @deprecated `postProcessSourceMap(rawJson, opts)` 의 path 옵션 사용. */
-export function applyMapPathOptions(rawJson: string, options: SourcemapPathOptions): string {
-  return postProcessSourceMap(rawJson, options);
-}

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -71,7 +71,6 @@ export {
   logError,
   logInfo,
   logWarn,
-  applyMapPathOptions,
   postProcessSourceMap,
   type SourcemapPathOptions,
   printZntcRnBanner,


### PR DESCRIPTION
## 배경

전체 코드 데드코드 전수조사(4개 영역 병렬 감사) 결과 코드베이스는 매우 깨끗했고, **유일한 확실 데드코드**가 이것입니다.

`@zntc/react-native` 의 `applyMapPathOptions(rawJson, options)` — `@deprecated` 태그가 붙은, `postProcessSourceMap` 로 그대로 위임하는 1줄 별칭. 프로덕션 호출처 0 (자기 정의 + barrel 재export 2곳 + 전용 테스트뿐).

## 변경

- `sourcemap.ts` 함수 정의 삭제
- `index.ts` / `dev-server/index.ts` barrel export 제거
- `sourcemap.test.ts` 전용 describe(10 케이스) + import 제거 — `postProcessSourceMap` path-옵션 커버리지는 별도 describe(`#2605 audit P2`)로 유지
- `.changeset/remove-apply-map-path-options.md` 동봉 (0.x 공개 API 제거 = breaking → `minor` + `### Breaking` + 마이그레이션 한 줄)

마이그레이션: `applyMapPathOptions(rawJson, opts)` → `postProcessSourceMap(rawJson, opts)` (시그니처 동일).

## 검증

- `bun test sourcemap.test.ts` → 18 pass / 0 fail
- `tsc -b packages/react-native --force` → exit 0
- 잔여 참조 0 (src/·packages/·docs/·examples/ grep)
- `/simplify` 3-에이전트 통과 (reuse/quality/efficiency clean)
- pre-push oxfmt 통과

나머지 미사용 코드(Module Federation, CSS Phase 2, WASM AST API, RN preset es5 하드코드, AST enum parity 태그 등)는 ROADMAP/RFC 에 문서화된 **의도된 계획 scaffolding** 이라 보존.

🤖 Generated with [Claude Code](https://claude.com/claude-code)