### PR TITLE
refactor(bundler): #1c-a store transfer 를 graph 메서드로 캡슐화

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1813,17 +1813,7 @@ pub const Bundler = struct {
         // putModule이 parse_arena 소유권을 store로 가져가므로
         // graph.deinit()에서 이중 해제가 발생하지 않는다.
         if (self.options.module_store) |store| {
-            for (0..graph.moduleCount()) |i| {
-                // store transfer 가 m.parse_arena 소유권 이동 → *Module mutable 필요.
-                // TODO #1c: store transfer 전용 accessor 메서드 도입 검토.
-                const m = graph.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
-                if (m.parse_arena == null) continue; // disabled 등 arena 없는 모듈 스킵
-                // mtime 은 buildIncremental / build 가 이미 module.mtime 에 기록. 여기서 재-stat
-                // 하면 watcher-driven mtime cache 효과가 half-revert 됨 (Issue #1727 §3).
-                // 0 이면 초기 경로에서 실패했던 모듈 — fallback 으로 한 번 더 stat.
-                const mtime = if (m.mtime != 0) m.mtime else (ModuleGraph.getMtime(m.path) catch 0);
-                store.putModule(m.path, m, mtime);
-            }
+            graph.transferModulesToStore(store);
         }
 
         var first_err: ?*const types.BundlerDiagnostic = null;

--- a/src/bundler/graph.zig
+++ b/src/bundler/graph.zig
@@ -306,6 +306,7 @@ pub const ModuleGraph = struct {
     pub const IncrementalBuildResult = graph_build_flow.IncrementalBuildResult;
     pub const buildIncremental = graph_build_flow.buildIncremental;
     pub const getMtime = graph_build_flow.getMtime;
+    pub const transferModulesToStore = graph_build_flow.transferModulesToStore;
 
     // Import resolution and resolved dependency application — graph/resolve_imports.zig로 위임
     const graph_resolve_imports = @import("graph/resolve_imports.zig");

--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -511,3 +511,24 @@ pub fn getMtime(path: []const u8) !i128 {
     const stat = try fs.statFile(path);
     return stat.mtime;
 }
+
+/// 증분 빌드 teardown: `graph.deinit()` 직전에 모든 모듈을 persistent
+/// store 로 이전한다. `putModule` 이 `parse_arena` 소유권을 store 로
+/// 가져가므로 이후 `graph.deinit()` 에서 이중 해제가 발생하지 않는다.
+///
+/// store transfer 는 `parse_arena` 소유권 이동이라 `*Module` mutable 이
+/// 필요하다. graph 내부 전용 `moduleAtMut` 호출을 이 graph 메서드 안으로
+/// 가두어, bundler 등 외부 호출자가 raw `moduleAtMut` 를 직접 잡지 않게
+/// 한다 (phase accessor 불변식 — graph.zig accessor 주석 참조).
+pub fn transferModulesToStore(self: *ModuleGraph, store: *module_store.PersistentModuleStore) void {
+    for (0..self.moduleCount()) |i| {
+        const m = self.moduleAtMut(ModuleIndex.fromUsize(i)) orelse continue;
+        if (m.parse_arena == null) continue; // disabled 등 arena 없는 모듈 스킵
+        // mtime 은 buildIncremental / build 가 이미 module.mtime 에 기록.
+        // 여기서 재-stat 하면 watcher-driven mtime cache 효과가 half-revert
+        // 됨 (Issue #1727 §3). 0 이면 초기 경로에서 실패했던 모듈 —
+        // fallback 으로 한 번 더 stat.
+        const mtime = if (m.mtime != 0) m.mtime else (getMtime(m.path) catch 0);
+        store.putModule(m.path, m, mtime);
+    }
+}


### PR DESCRIPTION
## 배경

데드코드 전수조사 후속 — (C) 분류된 `#1c` 내부 리팩터링을 실측 베이스라인 확보 후 진행. `#1c` 의 가장 작고 안전한 조각(`bundler.zig:1818` TODO)부터.

`bundler.zig` 가 빌드 teardown 에서 raw `graph.moduleAtMut()` 루프로 모듈을 persistent store 로 이전했는데, `graph.zig` accessor 주석이 명시한 불변식("`moduleAtMut` 는 accessor 내부 전용. 다른 호출자는 phase accessor 를 쓸 것")의 **외부 위반 호출자**였음.

## 변경

- `graph/build_flow.zig` 에 `transferModulesToStore(self: *ModuleGraph, store)` 추출 (getMtime 옆 — 이미 module_store/fs/ModuleGraph import 보유)
- `graph.zig` 에 `pub const` 노출
- `bundler.zig` 블록 → `if (self.options.module_store) |store| graph.transferModulesToStore(store);`

순수 추출 — 루프 경계(`0..moduleCount()`), `moduleAtMut orelse continue`, `parse_arena==null` skip, mtime fallback(`m.mtime!=0 ? : getMtime catch 0`), `putModule` 전부 동일. byte-identical 동작.

## 실측 / 검증

- 베이스라인: 변경 전 `zig build test` exit 0 (green) + Debug 파이프라인 프로파일 기록
- 변경 후: `zig build test` exit 0 (green, 동일) — `incremental_test` 가 store-transfer 경로 커버
- 파이프라인 프로파일 변경 전후 동일 (perf-neutral, teardown 비-핫패스)
- `/simplify` 3-에이전트 통과: 추출 faithful, `build_flow.zig` 배치 적절, dead import 없음, 효율 무변화

## 범위

`#1c` 의 첫 조각(store-transfer 캡슐화)만. 남은 `#1c`(import_records slice-identity freeze, promote-only 단조 가드)는 후속 PR 에서 동일 절차로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)