### PR TITLE
fix(flow): function type 의 this 파라미터 미지원 — strip 출력 오염 수정

### DIFF
--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -961,3 +961,21 @@ test "Flow match: nested object/array binding" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "let x=") != null);
     try std.testing.expect(std.mem.indexOf(u8, r.output, "let y=") != null);
 }
+
+test "Flow: bare this-param function type alias fully stripped" {
+    var r = try e2eFlow(std.testing.allocator, "type Fn = (this: Foo, x: number) => void;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("", r.output);
+}
+
+test "Flow: this-param function type — with usage stripped" {
+    var r = try e2eFlow(std.testing.allocator, "type Fn = (this: Foo, x: number) => void; let f: Fn = (function () {});");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let f=(function(){});", r.output);
+}
+
+test "Flow: this-param inline function type annotation stripped" {
+    var r = try e2eFlow(std.testing.allocator, "let cb: (this: Window, e: number) => void = (function () {});");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let cb=(function(){});", r.output);
+}

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -630,6 +630,9 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
     // ...rest 또는 identifier: → 확정적 named/rest function param
     const is_definite_fn = blk: {
         if (self.current() == .dot3) break :blk true;
+        // Flow `this` 파라미터(`(this: T, …) => R`): `this` 는 binding name 토큰이
+        // 아니라 아래 분기에 안 걸려 parseType(this) 로 오파싱됨 → 함수타입 확정.
+        if (self.current() == .kw_this and (try self.peekNextKind()) == .colon) break :blk true;
         if (self.current().canBeBindingName()) {
             const next = try self.peekNextKind();
             break :blk (next == .colon or next == .question);
@@ -741,6 +744,21 @@ fn parseFunctionTypeParamList(self: *Parser) ParseError2!ast_mod.NodeList {
     while (self.current() != .r_paren and self.current() != .eof) {
         const loop_guard_pos = self.scanner.token.span.start;
         const param_start = self.currentSpan().start;
+
+        // Flow `this` 파라미터: `(this: T, ...) => R`. strip 전용이라 토큰만
+        // 소비 — `this` 는 binding name 토큰이 아니라 아래 canBeBindingName
+        // 분기에 안 걸려 positional parseType(this) 로 빠지면 함수타입 전체가
+        // 오파싱돼 출력이 오염된다 (bare type alias 일 때 표면화).
+        if (self.current() == .kw_this) {
+            try self.advance();
+            if (try self.eat(.colon)) {
+                const this_type = try parseType(self);
+                try self.scratch.append(self.allocator, this_type);
+            }
+            if (!try self.eat(.comma)) break;
+            if (try self.ensureLoopProgress(loop_guard_pos)) break;
+            continue;
+        }
 
         // ...rest 파라미터 — name 정보 안 가짐, 단순 strip.
         if (self.current() == .dot3) {


### PR DESCRIPTION
## 배경

큐된 작업: Metro/Flow 파서 레퍼런스(`references/babel-flow`) 전수조사 → ZNTC 미지원 Flow 문법을 **TDD 로 먼저 재현(깨짐 확인)** 후 수정.

광역 probe 로 **실제 깨지는 2건** 확정(나머지는 정상 strip): ① `this`-param function type ② `%checks` inferred-predicate arrow. 이 PR = ①(바운디드 parser fix).

## 버그

`type Fn = (this: Foo, x: number) => void;` (표준 Flow, babel-flow 지원) → ZNTC strip 출력 `;Foo,x;;number;;;void ;` **(오염)**. 루트커즈: `this`(`.kw_this`)는 binding-name 토큰이 아니라 `parseParenOrFunctionType` 의 `is_definite_fn` 및 `parseFunctionTypeParamList` 가 인지 못 해 `parseType(this)` 로 빠져 함수타입 전체 오파싱.

## 변경 (`src/parser/flow.zig`, flow_ 독립·strip 전용)

- `is_definite_fn`: `this :` → 함수타입 확정 인지 (route → parseFunctionTypeParamList)
- `parseFunctionTypeParamList`: `this[: Type]` 소비 분기 (termination-safe: advance 가 진행 보장)

## 검증 (TDD)

- RED 재현(garbage) → GREEN. 가드 3종: bare alias→`""`, with-usage, inline annotation
- Flow 119/119 · Debug + **ReleaseFast** 전체 **5310/5314 / 0 fail** (4 skip = baseline, 무회귀)
- `/simplify`: 파서 fix **correct·termination-safe·is_definite_fn 정밀도·무회귀** 검증. 반영: ZZ-probe(assertion 없는 scratch) 제거, 가드 테스트 3종 정리, 외부심볼 주석 제거(feedback_no_reference_comments)

## 별개 발견 (follow-up)

`const x = (y): %checks => …` inferred-predicate arrow → `const x=y;%checks;;…` 오염. 별개 버그 → 추적 이슈 등록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)