### PR TITLE
fix(flow): inferred-predicate arrow %checks strip 출력 오염 (#3527)

### DIFF
--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -979,3 +979,21 @@ test "Flow: this-param inline function type annotation stripped" {
     defer r.deinit();
     try std.testing.expectEqualStrings("let cb=(function(){});", r.output);
 }
+
+test "Flow: inferred-predicate arrow `): %checks =>` stripped (#3527)" {
+    var r = try e2eFlow(std.testing.allocator, "const x = (y: mixed): %checks => typeof y === 'string';");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("const x=y=>typeof y===\"string\";", r.output);
+}
+
+test "Flow: %checks(expr) inferred-predicate arrow stripped (#3527)" {
+    var r = try e2eFlow(std.testing.allocator, "const f = (x: mixed): %checks(typeof x === 'number') => true;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("const f=x=>true;", r.output);
+}
+
+test "Flow: trailing %checks 선언문 회귀 가드 (#3527)" {
+    var r = try e2eFlow(std.testing.allocator, "function f(x: number): boolean %checks { return !!x; }");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("function f(x){return!!x;}", r.output);
+}

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -47,38 +47,42 @@ pub fn tryParseTypeAnnotation(self: *Parser) ParseError2!NodeIndex {
     return parseType(self);
 }
 
-/// 리턴 타입 어노테이션 (`: Type`). 함수 선언에서 사용.
-/// Flow의 `%checks` predicate도 여기서 소비한다 (타입 뒤에 붙을 수 있음).
+/// Flow `%checks` predicate (`%checks` | `%checks(expr)`) 를 소비. strip 전용
+/// — 토큰만 먹고 버린다. 소비했으면 true. `%`는 .percent, `checks`는 identifier.
+fn consumeChecksPredicate(self: *Parser) ParseError2!bool {
+    if (self.current() != .percent) return false;
+    if ((try self.peekNextKind()) != .identifier) return false;
+    const saved = self.saveState();
+    try self.advance(); // '%'
+    if (!std.mem.eql(u8, self.tokenText(), "checks")) {
+        self.restoreState(saved); // %foo 같은 임의 identifier 는 무시
+        return false;
+    }
+    try self.advance(); // 'checks'
+    if (self.current() == .l_paren) {
+        try self.advance(); // '('
+        _ = try self.parseAssignmentExpression();
+        try self.expect(.r_paren);
+    }
+    return true;
+}
+
+/// 리턴 타입 어노테이션 (`: Type`). 함수 선언/arrow 에서 사용.
+/// Flow `%checks` predicate 도 소비: 선행(타입 없는 inferred — arrow
+/// `): %checks =>`) + 후행(`: T %checks`) 둘 다.
 pub fn tryParseReturnType(self: *Parser) ParseError2!NodeIndex {
     if (self.current() != .colon) return NodeIndex.none;
     try self.advance();
+    // 선행 %checks: 타입 없는 inferred predicate. parseType 전에 처리하지
+    // 않으면 parseType(`%`) 가 실패해 arrow 감지가 붕괴된다 (#3527).
+    if (try consumeChecksPredicate(self)) return NodeIndex.none;
     var ty = try parseType(self);
     // type predicate: value is Type — Flow type guard (TS와 동일 구문)
     if (self.current() == .identifier and self.isContextual("is")) {
         try self.advance(); // skip 'is'
         ty = try parseType(self);
     }
-    // %checks — Flow type guard predicate. 타입 스트리핑에서는 무시.
-    // `%`는 .percent 토큰, `checks`는 identifier.
-    if (self.current() == .percent) {
-        const next = try self.peekNextKind();
-        if (next == .identifier) {
-            // %checks만 유효 — %foo 같은 임의 identifier는 무시
-            const saved = self.saveState();
-            try self.advance(); // skip '%'
-            if (!std.mem.eql(u8, self.tokenText(), "checks")) {
-                self.restoreState(saved);
-                return ty;
-            }
-            try self.advance(); // skip 'checks'
-            // %checks(expr) 형태도 가능
-            if (self.current() == .l_paren) {
-                try self.advance(); // skip '('
-                _ = try self.parseAssignmentExpression();
-                try self.expect(.r_paren);
-            }
-        }
-    }
+    _ = try consumeChecksPredicate(self); // 후행 %checks
     return ty;
 }
 


### PR DESCRIPTION
## 배경

Flow 레퍼런스 전수조사(#3526 동반 발견)의 2번째 실 버그.

## 버그

`const x = (y: mixed): %checks => typeof y === 'string';` (표준 Flow inferred predicate, babel-flow 지원) → ZNTC strip `const x=y;%checks;;typeof y==="string";` **(오염)**.

루트커즈: `tryParseReturnType` 가 `:` 후 **무조건 `parseType` 먼저** 호출 → 타입 없는 선행 `%checks` 에서 `parseType('%')` 실패 → arrow 감지 붕괴(→ paren-expr fallback). 후행 `: T %checks` 만 처리되고 선행 inferred predicate 는 미지원.

## 변경 (`src/parser/flow.zig`, flow_ 독립·strip 전용)

- `%checks`/`%checks(expr)` 소비를 **`consumeChecksPredicate` 헬퍼로 추출(DRY** — 기존 inline 로직과 동작 동일).
- `tryParseReturnType`: `parseType` **전** 선행 호출(소비 시 `.none` 반환 → arrow 감지 정상 완결) + 후행 호출(`: T %checks`).

## 검증 (TDD)

- RED 재현(garbage) → GREEN. 가드 3종: 선행 `%checks` arrow, `%checks(expr)` arrow, **trailing `%checks` 선언문 회귀 가드**
- Flow 122/122 · Debug + **ReleaseFast** 전체 **5313/5317 / 0 fail** (4 skip baseline, 무회귀)
- `/simplify`: arrow 감지 실제 완결·`%foo` rollback 안전·trailing/`name is` 무회귀·DRY 동작 동일·ReleaseFast 무회귀 **전수 검증 → 결함 0**

이로써 Flow 전수조사에서 발견된 미지원 문법 2건(#3526 this-param, #3527 %checks-arrow) **모두 수정 완료**.

Closes #3527

🤖 Generated with [Claude Code](https://claude.com/claude-code)