### PR TITLE
ci: segment Zig 빌드 캐시 키로 cross-job thrash 제거

### DIFF
--- a/.github/actions/setup-zntc/action.yml
+++ b/.github/actions/setup-zntc/action.yml
@@ -14,6 +14,13 @@ inputs:
     description: Optional Zig CPU feature set for portable CI artifacts.
     required: false
     default: ""
+  cache-key:
+    description: >-
+      Zig 빌드 캐시 세그먼트. mlugg/setup-zig 의 캐시 키는 레포 전역이며 OS+zig
+      버전만 자동 포함 → 빌드 프로파일(cpu/napi 조합)이 다른 caller 가 같은 키를
+      공유하면 서로 덮어쓰며 thrash. caller 마다 고유 값을 넘길 것.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -22,6 +29,7 @@ runs:
       uses: mlugg/setup-zig@v2
       with:
         version: 0.15.2
+        cache-key: ${{ inputs.cache-key }}
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,6 +35,7 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          cache-key: benchmark
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          cache-key: debug
 
       - name: Build (Debug)
         run: zig build
@@ -58,6 +59,7 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          cache-key: release-${{ matrix.optimize }}
 
       # Windows GitHub runner (7GB RAM) 는 Debug LLVM 메모리 상한에 걸림
       # ("LLVM ERROR: out of memory"). Debug 빌드·테스트 커버리지는 Linux/macOS
@@ -77,6 +79,9 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          # zig fmt --check 만 실행 — 빌드 캐시 미생성. 캐싱은 순수 오버헤드이고,
+          # 키 미지정 시 전역 기본 키를 build job 들과 공유해 thrash 유발하므로 off.
+          use-cache: false
 
       - name: Check formatting
         run: zig fmt --check src/
@@ -117,6 +122,7 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          cache-key: napi
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -234,6 +240,7 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          cache-key: napi-smoke-${{ matrix.platform }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -344,6 +351,8 @@ jobs:
       # 나머지 publishable workspace package 빌드만 하면 된다.
       - name: Setup ZNTC (core + NAPI)
         uses: ./.github/actions/setup-zntc
+        with:
+          cache-key: publish-smoke
 
       - name: Build wasm binaries
         run: zig build wasm && zig build wasm-bundler
@@ -388,6 +397,7 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          cache-key: wasm
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,8 @@ jobs:
       - uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          # ci.yml 의 wasm job 과 동일 빌드 프로파일 — 키 공유로 cross-workflow 재사용.
+          cache-key: wasm
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           cpu: baseline
           install: "false"
+          cache-key: zntc-ubuntu-baseline
 
       - name: Upload ZNTC build artifact
         uses: actions/upload-artifact@v4
@@ -88,6 +89,7 @@ jobs:
           cpu: baseline
           napi: "false"
           install: "false"
+          cache-key: zntc-cli-baseline
 
       - name: Upload ZNTC CLI artifact
         uses: actions/upload-artifact@v4
@@ -108,6 +110,7 @@ jobs:
       - uses: ./.github/actions/setup-zntc
         with:
           install: "false"
+          cache-key: zntc-macos
 
       - name: Upload ZNTC build artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
       - uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          cache-key: napi-${{ matrix.zig_target }}
 
       - name: Build NAPI (ReleaseFast)
         shell: bash
@@ -135,6 +136,7 @@ jobs:
       - uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          cache-key: cli-${{ matrix.target }}
 
       - name: Build CLI (ReleaseFast)
         run: zig build -Doptimize=ReleaseFast -Dtarget=${{ matrix.target }}
@@ -163,6 +165,9 @@ jobs:
       - uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          # 이 job 은 zig build 를 직접 돌리지 않음 (artifact download) — 전역
+          # 기본 키 공유로 인한 thrash 만 격리.
+          cache-key: release-publish
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -30,6 +30,7 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          cache-key: test262-unit
 
       - name: Run Test262 runner unit tests
         run: zig build test262
@@ -49,6 +50,9 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          # lexer/parser job 이 동일 ReleaseFast 빌드를 의도적으로 공유 (cross-job
+          # 캐시 재사용). 분리하지 말 것 — save race 는 동일 산출물이라 무해.
+          cache-key: test262-run
 
       - name: Build (ReleaseFast)
         run: zig build -Doptimize=ReleaseFast
@@ -110,6 +114,8 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           version: 0.15.2
+          # test262-lexer 와 동일 ReleaseFast 빌드 — 키 공유로 cross-job 재사용.
+          cache-key: test262-run
 
       - name: Build (ReleaseFast)
         run: zig build -Doptimize=ReleaseFast


### PR DESCRIPTION
## 문제

CI가 느린 원인을 측정으로 추적: 최근 성공 run 기준 CI ~35분, Integration&E2E ~42분, 거의 모든 빌드 잡이 매번 콜드 Zig 컴파일.

근본 원인 — `mlugg/setup-zig@v2`는 글로벌+로컬 Zig 캐시를 **기본 캐시**하지만, GitHub Actions 캐시 키는 **레포 전역**이며 OS+zig 버전만 자동 포함한다. `cache-key`를 **어디에도 지정하지 않아서**, 모든 워크플로의 동일 OS 빌드 잡이 단 하나의 2GiB 캐시 칸을 공유 → 25개+ 빌드 프로파일(debug, ReleaseSafe/Fast/Small, napi, 9개 cross 타깃, wasm, baseline cpu …)이 서로 덮어쓰며 thrash → 캐시가 사실상 무력화.

검증: `grep -rn cache-key .github` → 변경 전 0건.

## 변경

빌드 프로파일별로 안정적인 `cache-key` 부여 (순수 additive, CI 설정 한정):

- `setup-zig` 15개 호출처: `ci.yml`(debug / release-${optimize} / napi / napi-smoke-${platform} / wasm), `test262.yml`, `benchmark.yml`, `docs.yml`, `release.yml`(napi-${target} / cli-${target} / release-publish)
- `setup-zntc` 합성 액션에 `cache-key` 입력 추가 → `integration.yml` 3 caller + `ci.yml` publish-smoke에서 지정
- `lint` 잡: `zig fmt --check`만 실행해 빌드 캐시 미생성 → `use-cache: false`로 캐시 I/O 자체 제거
- `test262` lexer/parser: 동일 ReleaseFast 빌드라 의도적으로 키 공유(cross-job 재사용) — 분리 방지 주석 명시
- `docs.yml` wasm 빌드: `ci.yml` wasm 잡과 동일 프로파일이라 키 공유로 cross-workflow 재사용

## 효과

캐시 히트 시 동일 타깃 반복 빌드 잡이 Zig incremental(content-addressed)로 50~80% 단축 기대. 매트릭스/병렬 잡 간 캐시 격리로 thrash 제거. 첫 run은 캐시 워밍이라 효과는 후속 run부터.

## 범위 밖 (후속 검토 가능)

release-build 3×3 매트릭스 PR 축소, napi-package-smoke 9플랫폼 PR 축소, Publish Smoke main-only, Integration 샤딩 — 이번 PR은 사용자 합의대로 "Zig 캐시 공유"만.

## 리스크

소스/테스트 무변경. 캐시 키 변경은 최악의 경우 캐시 미스(=현 상태)로 안전 degrade. 레포 전역 10GB 캐시 한도는 LRU로 관리되며 단일 키 충돌보다 항상 우월.

🤖 Generated with [Claude Code](https://claude.com/claude-code)