### PR TITLE
docs(logo): 문서 사이트 로고 시안 3종 + 비교 페이지

### DIFF
--- a/logo-concepts/concept-abstract.svg
+++ b/logo-concepts/concept-abstract.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ZNTC abstract mark">
+  <defs>
+    <linearGradient id="ab" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f7a41d"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+    <clipPath id="abc"><rect x="14" y="14" width="100" height="100" rx="26"/></clipPath>
+  </defs>
+  <!-- 글자/은유 없는 순수 형태 — 라운드 타일에 forward 노치 음각 -->
+  <g clip-path="url(#abc)">
+    <rect x="14" y="14" width="100" height="100" fill="url(#ab)"/>
+    <path fill="#1b1714" d="M58 6 L112 64 L58 122 L84 64 Z"/>
+  </g>
+</svg>

--- a/logo-concepts/concept-bundle.svg
+++ b/logo-concepts/concept-bundle.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ZNTC module bundle">
+  <defs>
+    <linearGradient id="bd" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f7a41d"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <!-- bundle container -->
+  <rect x="16" y="16" width="96" height="96" rx="22" fill="none" stroke="url(#bd)" stroke-width="7"/>
+  <!-- packed modules -->
+  <g fill="url(#bd)">
+    <rect x="34" y="36" width="42" height="20" rx="5"/>
+    <rect x="52" y="62" width="42" height="20" rx="5"/>
+    <rect x="34" y="88" width="42" height="20" rx="5"/>
+  </g>
+</svg>

--- a/logo-concepts/concept-pipeline.svg
+++ b/logo-concepts/concept-pipeline.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 152 128" role="img" aria-label="ZNTC transform pipeline">
+  <defs>
+    <linearGradient id="p" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f7a41d"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <!-- source (raw 코드 라인) -->
+  <g fill="#8a807a">
+    <rect x="12" y="44" width="34" height="11" rx="5"/>
+    <rect x="12" y="58" width="24" height="11" rx="5"/>
+    <rect x="12" y="72" width="34" height="11" rx="5"/>
+  </g>
+  <!-- transform arrow -->
+  <path fill="url(#p)" d="M56 56 H78 V46 L100 64 L78 82 V72 H56 Z"/>
+  <!-- bundled output -->
+  <rect x="108" y="42" width="44" height="44" rx="12" fill="url(#p)"/>
+</svg>

--- a/logo-concepts/concept-speed.svg
+++ b/logo-concepts/concept-speed.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ZNTC native speed">
+  <defs>
+    <linearGradient id="s" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#fb923c"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <!-- motion trails -->
+  <g fill="url(#s)">
+    <rect x="6" y="40" width="22" height="9" rx="4"/>
+    <rect x="6" y="59" width="32" height="9" rx="4"/>
+    <rect x="6" y="78" width="22" height="9" rx="4"/>
+  </g>
+  <!-- forward arrowhead (속도) -->
+  <path fill="url(#s)" d="M48 18 L104 64 L48 110 L70 64 Z"/>
+</svg>

--- a/logo-concepts/index.html
+++ b/logo-concepts/index.html
@@ -195,6 +195,99 @@
       <div class="wm light"><img src="mark-g-outline.svg" width="30" height="30"><b>ZNTC</b></div>
     </div>
   </div>
+
+  <div class="card" style="grid-column:1/-1; background:#241f1c;">
+    <h2 style="color:#fdba74;">개념 우선 — Z 글자 버림</h2>
+    <p class="desc" style="margin:0;">이니셜 모노그램 관성을 버리고 <b>로고가 전달할 가치</b>(변환·속도·번들링) 또는 글자 없는 순수 형태로 다시 잡은 4종. 워드마크 "ZNTC"는 텍스트로 병기.</p>
+  </div>
+
+  <!-- P1 -->
+  <div class="card">
+    <h2>⑧ 변환 파이프라인</h2>
+    <p class="desc">raw 코드 라인 → 변환 화살표 → 묶인 출력 블록. 트랜스파일·번들 in→out 을 직설적으로. 도구 본질 전달력 최고.</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="concept-pipeline.svg" height="16"><figcaption>h16</figcaption></figure>
+        <figure><img src="concept-pipeline.svg" height="32"><figcaption>h32</figcaption></figure>
+        <figure><img src="concept-pipeline.svg" height="48"><figcaption>h48</figcaption></figure>
+        <figure><img src="concept-pipeline.svg" height="80"><figcaption>h80</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="concept-pipeline.svg" height="32"><figcaption>h32</figcaption></figure>
+        <figure><img src="concept-pipeline.svg" height="56"><figcaption>h56</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="concept-pipeline.svg" height="26"><b>ZNTC</b></div>
+      <div class="wm light"><img src="concept-pipeline.svg" height="26"><b>ZNTC</b></div>
+    </div>
+  </div>
+
+  <!-- P2 -->
+  <div class="card">
+    <h2>⑨ 속도 / 네이티브</h2>
+    <p class="desc">모션 잔상 + forward 화살촉. Zig 네이티브 속도 에너지. 글자 없이 추상적, 작은 크기에서도 또렷. (vite 계열 톤)</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="concept-speed.svg" width="16" height="16"><figcaption>16</figcaption></figure>
+        <figure><img src="concept-speed.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="concept-speed.svg" width="48" height="48"><figcaption>48</figcaption></figure>
+        <figure><img src="concept-speed.svg" width="96" height="96"><figcaption>96</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="concept-speed.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="concept-speed.svg" width="64" height="64"><figcaption>64</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="concept-speed.svg" width="28" height="28"><b>ZNTC</b></div>
+      <div class="wm light"><img src="concept-speed.svg" width="28" height="28"><b>ZNTC</b></div>
+    </div>
+  </div>
+
+  <!-- P3 -->
+  <div class="card">
+    <h2>⑩ 모듈 번들링</h2>
+    <p class="desc">컨테이너 안에 모듈 타일이 차곡 패킹. 번들러 핵심 기능 은유. 의미 명확, 16px에선 stroke 얇아질 수 있음.</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="concept-bundle.svg" width="16" height="16"><figcaption>16</figcaption></figure>
+        <figure><img src="concept-bundle.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="concept-bundle.svg" width="48" height="48"><figcaption>48</figcaption></figure>
+        <figure><img src="concept-bundle.svg" width="96" height="96"><figcaption>96</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="concept-bundle.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="concept-bundle.svg" width="64" height="64"><figcaption>64</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="concept-bundle.svg" width="30" height="30"><b>ZNTC</b></div>
+      <div class="wm light"><img src="concept-bundle.svg" width="30" height="30"><b>ZNTC</b></div>
+    </div>
+  </div>
+
+  <!-- P4 -->
+  <div class="card">
+    <h2>⑪ 추상 기하 마크</h2>
+    <p class="desc">글자·은유 없는 순수 형태 — 라운드 타일에 forward 노치 음각. 가장 중립·확장적, "ZNTC" 워드마크와 페어. (esbuild/oxc 톤)</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="concept-abstract.svg" width="16" height="16"><figcaption>16</figcaption></figure>
+        <figure><img src="concept-abstract.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="concept-abstract.svg" width="48" height="48"><figcaption>48</figcaption></figure>
+        <figure><img src="concept-abstract.svg" width="96" height="96"><figcaption>96</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="concept-abstract.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="concept-abstract.svg" width="64" height="64"><figcaption>64</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="concept-abstract.svg" width="30" height="30"><b>ZNTC</b></div>
+      <div class="wm light"><img src="concept-abstract.svg" width="30" height="30"><b>ZNTC</b></div>
+    </div>
+  </div>
 </section>
 
 <footer>

--- a/logo-concepts/index.html
+++ b/logo-concepts/index.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>ZNTC 로고 시안 비교</title>
+<style>
+  :root { font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: #141110; color: #e7e5e4; }
+  header { padding: 28px 32px; border-bottom: 1px solid #2a2422; }
+  header h1 { margin: 0 0 6px; font-size: 20px; }
+  header p { margin: 0; color: #a8a29e; font-size: 14px; }
+  .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; background: #2a2422; }
+  @media (max-width: 900px){ .grid { grid-template-columns: 1fr; } }
+  .card { background: #1c1816; padding: 24px; }
+  .card h2 { margin: 0 0 4px; font-size: 16px; color: #f7a41d; }
+  .card .desc { margin: 0 0 18px; font-size: 13px; color: #a8a29e; line-height: 1.5; }
+  .swatches { display: flex; gap: 16px; flex-wrap: wrap; align-items: flex-end; }
+  .bgblock { padding: 18px; border-radius: 10px; display: flex; gap: 16px; align-items: flex-end; }
+  .dark { background: #0d0a07; }
+  .light { background: #fafaf9; }
+  .sizes { display: flex; gap: 14px; align-items: flex-end; }
+  .sizes figure { margin: 0; display: flex; flex-direction: column; align-items: center; gap: 6px; }
+  .sizes figcaption { font-size: 10px; color: #78716c; }
+  .light .sizes figcaption { color: #a8a29e; }
+  .lockup { margin-top: 20px; display: flex; gap: 22px; flex-wrap: wrap; }
+  .wm { display: flex; align-items: center; gap: 10px; padding: 12px 16px; border-radius: 10px; }
+  .wm.dark { background: #0d0a07; }
+  .wm.light { background: #fafaf9; color: #1c1816; }
+  .wm b { font-size: 22px; font-weight: 800; letter-spacing: .06em; }
+  .wm.dark b { color: #fafaf9; }
+  footer { padding: 24px 32px; border-top: 1px solid #2a2422; color: #a8a29e; font-size: 13px; }
+  code { background: #0d0a07; padding: 2px 6px; border-radius: 4px; color: #fdba74; font-size: 12px; }
+  pre { background: #0d0a07; padding: 14px 16px; border-radius: 8px; overflow:auto; font-size: 12px; color: #d6d3d1; }
+</style>
+</head>
+<body>
+<header>
+  <h1>ZNTC 로고 시안 — 보고 고르세요</h1>
+  <p>Zig 오렌지 <code>#f7a41d</code> · 사이트 다크 배경 <code>#0d0a07</code> 기준. 각 시안을 다크/라이트 · 파비콘(16·32)~로고(48·128) · 워드마크 락업으로 표시.</p>
+</header>
+
+<section class="grid">
+  <!-- A -->
+  <div class="card">
+    <h2>① 모노그램 타일 Z</h2>
+    <p class="desc">라운드 사각 타일 + 각진 Z 음각. swc/oxc/esbuild 계열과 어울리는 정석 마크. 16px 파비콘에서 가장 또렷함.</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="mark-a-monogram.svg" width="16" height="16"><figcaption>16</figcaption></figure>
+        <figure><img src="mark-a-monogram.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="mark-a-monogram.svg" width="48" height="48"><figcaption>48</figcaption></figure>
+        <figure><img src="mark-a-monogram.svg" width="96" height="96"><figcaption>96</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="mark-a-monogram.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="mark-a-monogram.svg" width="64" height="64"><figcaption>64</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="mark-a-monogram.svg" width="30" height="30"><b>ZNTC</b></div>
+      <div class="wm light"><img src="mark-a-monogram.svg" width="30" height="30"><b>ZNTC</b></div>
+    </div>
+  </div>
+
+  <!-- B -->
+  <div class="card">
+    <h2>② 번개 (속도)</h2>
+    <p class="desc">투명 배경 + 오렌지 그라디언트 볼트. Zig 네이티브 속도/컴파일 에너지. 다이나믹하고 고유성 높음. 작은 크기에선 디테일 손실 주의.</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="mark-b-bolt.svg" width="16" height="16"><figcaption>16</figcaption></figure>
+        <figure><img src="mark-b-bolt.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="mark-b-bolt.svg" width="48" height="48"><figcaption>48</figcaption></figure>
+        <figure><img src="mark-b-bolt.svg" width="96" height="96"><figcaption>96</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="mark-b-bolt.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="mark-b-bolt.svg" width="64" height="64"><figcaption>64</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="mark-b-bolt.svg" width="28" height="28"><b>ZNTC</b></div>
+      <div class="wm light"><img src="mark-b-bolt.svg" width="28" height="28"><b>ZNTC</b></div>
+    </div>
+  </div>
+
+  <!-- C -->
+  <div class="card">
+    <h2>③ 브래킷 [ Z ]</h2>
+    <p class="desc">각진 브래킷 사이 오렌지 Z. 소스→출력 트랜스파일/번들러 의미 직접 은유. (컬리 <code>{ }</code>는 16px에서 깨져 각진 브래킷으로 구현 — 원하면 컬리로 재작업.)</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="mark-c-brackets.svg" height="16"><figcaption>h16</figcaption></figure>
+        <figure><img src="mark-c-brackets.svg" height="32"><figcaption>h32</figcaption></figure>
+        <figure><img src="mark-c-brackets.svg" height="48"><figcaption>h48</figcaption></figure>
+        <figure><img src="mark-c-brackets.svg" height="80"><figcaption>h80</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="mark-c-brackets.svg" height="32"><figcaption>h32</figcaption></figure>
+        <figure><img src="mark-c-brackets.svg" height="56"><figcaption>h56</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="mark-c-brackets.svg" height="26"><b>ZNTC</b></div>
+      <div class="wm light"><img src="mark-c-brackets.svg" height="26"><b>ZNTC</b></div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <p><b>다음 단계</b> — 고른 번호를 알려주시면: ① <code>documents/public/favicon.svg</code> 교체(라이트/다크 prefers-color-scheme 대응 추가), ② <code>documents/astro.config.mjs</code> Starlight <code>logo</code> 키 배선(아이콘+ZNTC 텍스트). 색·디테일 조정도 가능.</p>
+  <pre>// astro.config.mjs · starlight({ ... })
+starlight({
+  logo: { src: './src/assets/zntc-mark.svg', alt: 'ZNTC' },
+  // replacesTitle: false  // 아이콘 + "ZNTC" 텍스트 병기
+})</pre>
+  <p>이 <code>logo-concepts/</code> 디렉토리는 비교용 스크래치이며 커밋되지 않았습니다 — 선택 후 실제 위치로 이동/정리합니다.</p>
+</footer>
+</body>
+</html>

--- a/logo-concepts/index.html
+++ b/logo-concepts/index.html
@@ -288,6 +288,158 @@
       <div class="wm light"><img src="concept-abstract.svg" width="30" height="30"><b>ZNTC</b></div>
     </div>
   </div>
+
+  <div class="card" style="grid-column:1/-1; background:#241f1c;">
+    <h2 style="color:#fdba74;">단일 심볼 / 텍스트-캐릭터 — Z 자리에 들어갈 한 덩어리 마크</h2>
+    <p class="desc" style="margin:0;">흩어진 "장면"이 아니라 16px에서도 한 글리프로 읽히는 단일 심볼. ⑰⑱은 글자는 아니지만 CLI/코드 텍스트 느낌 캐릭터(`&gt;_`, `=&gt;`).</p>
+  </div>
+
+  <!-- 12 --><div class="card">
+    <h2>⑫ 스퀘어클 볼트</h2>
+    <p class="desc">라운드 타일에 볼트 음각 — 앱아이콘처럼 닫힌 한 덩어리. ②볼트의 enclosed 버전, 파비콘 강함.</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="sym-squircle-bolt.svg" width="16" height="16"><figcaption>16</figcaption></figure>
+        <figure><img src="sym-squircle-bolt.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="sym-squircle-bolt.svg" width="48" height="48"><figcaption>48</figcaption></figure>
+        <figure><img src="sym-squircle-bolt.svg" width="96" height="96"><figcaption>96</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="sym-squircle-bolt.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="sym-squircle-bolt.svg" width="64" height="64"><figcaption>64</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="sym-squircle-bolt.svg" width="30" height="30"><b>ZNTC</b></div>
+      <div class="wm light"><img src="sym-squircle-bolt.svg" width="30" height="30"><b>ZNTC</b></div>
+    </div>
+  </div>
+
+  <!-- 13 --><div class="card">
+    <h2>⑬ 아이소 큐브</h2>
+    <p class="desc">3면 아이소메트릭 큐브 — 묶인 빌드 산출물 / 네이티브. 무채색 단순, 매우 아이코닉.</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="sym-cube.svg" width="16" height="16"><figcaption>16</figcaption></figure>
+        <figure><img src="sym-cube.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="sym-cube.svg" width="48" height="48"><figcaption>48</figcaption></figure>
+        <figure><img src="sym-cube.svg" width="96" height="96"><figcaption>96</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="sym-cube.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="sym-cube.svg" width="64" height="64"><figcaption>64</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="sym-cube.svg" width="30" height="30"><b>ZNTC</b></div>
+      <div class="wm light"><img src="sym-cube.svg" width="30" height="30"><b>ZNTC</b></div>
+    </div>
+  </div>
+
+  <!-- 14 --><div class="card">
+    <h2>⑭ 3-blade 로터</h2>
+    <p class="desc">회전 대칭 3날 — 변환/처리 모션. 역동적, 패턴화 가능. 16px에선 날 끝 디테일 주의.</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="sym-pinwheel.svg" width="16" height="16"><figcaption>16</figcaption></figure>
+        <figure><img src="sym-pinwheel.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="sym-pinwheel.svg" width="48" height="48"><figcaption>48</figcaption></figure>
+        <figure><img src="sym-pinwheel.svg" width="96" height="96"><figcaption>96</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="sym-pinwheel.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="sym-pinwheel.svg" width="64" height="64"><figcaption>64</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="sym-pinwheel.svg" width="30" height="30"><b>ZNTC</b></div>
+      <div class="wm light"><img src="sym-pinwheel.svg" width="30" height="30"><b>ZNTC</b></div>
+    </div>
+  </div>
+
+  <!-- 15 --><div class="card">
+    <h2>⑮ 슬라이스 forward</h2>
+    <p class="desc">재생 삼각을 가로로 슬라이스 — 속도/실행. 극단 미니멀, 어느 크기든 또렷.</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="sym-split-triangle.svg" width="16" height="16"><figcaption>16</figcaption></figure>
+        <figure><img src="sym-split-triangle.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="sym-split-triangle.svg" width="48" height="48"><figcaption>48</figcaption></figure>
+        <figure><img src="sym-split-triangle.svg" width="96" height="96"><figcaption>96</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="sym-split-triangle.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="sym-split-triangle.svg" width="64" height="64"><figcaption>64</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="sym-split-triangle.svg" width="28" height="28"><b>ZNTC</b></div>
+      <div class="wm light"><img src="sym-split-triangle.svg" width="28" height="28"><b>ZNTC</b></div>
+    </div>
+  </div>
+
+  <!-- 16 --><div class="card">
+    <h2>⑯ 노치 링</h2>
+    <p class="desc">C형 링 — 빌드 사이클/처리. 단일 stroke, 모노톤 전환 쉬움. 16px에선 두께 확보 필요.</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="sym-notched-ring.svg" width="16" height="16"><figcaption>16</figcaption></figure>
+        <figure><img src="sym-notched-ring.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="sym-notched-ring.svg" width="48" height="48"><figcaption>48</figcaption></figure>
+        <figure><img src="sym-notched-ring.svg" width="96" height="96"><figcaption>96</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="sym-notched-ring.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="sym-notched-ring.svg" width="64" height="64"><figcaption>64</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="sym-notched-ring.svg" width="30" height="30"><b>ZNTC</b></div>
+      <div class="wm light"><img src="sym-notched-ring.svg" width="30" height="30"><b>ZNTC</b></div>
+    </div>
+  </div>
+
+  <!-- 17 --><div class="card">
+    <h2>⑰ 터미널 <code>&gt;_</code></h2>
+    <p class="desc">터미널 프롬프트 — CLI 트랜스파일러 정체성 직설. 글자 아닌 텍스트-캐릭터, 개발자 코드감 최고.</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="txt-prompt.svg" width="16" height="16"><figcaption>16</figcaption></figure>
+        <figure><img src="txt-prompt.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="txt-prompt.svg" width="48" height="48"><figcaption>48</figcaption></figure>
+        <figure><img src="txt-prompt.svg" width="96" height="96"><figcaption>96</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="txt-prompt.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="txt-prompt.svg" width="64" height="64"><figcaption>64</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="txt-prompt.svg" width="30" height="30"><b>ZNTC</b></div>
+      <div class="wm light"><img src="txt-prompt.svg" width="30" height="30"><b>ZNTC</b></div>
+    </div>
+  </div>
+
+  <!-- 18 --><div class="card">
+    <h2>⑱ Fat arrow <code>=&gt;</code></h2>
+    <p class="desc">JS/TS 변환 코드 시그니처. 텍스트-캐릭터, 트랜스파일 의미 + 단순 형태.</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="txt-arrow.svg" width="16" height="16"><figcaption>16</figcaption></figure>
+        <figure><img src="txt-arrow.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="txt-arrow.svg" width="48" height="48"><figcaption>48</figcaption></figure>
+        <figure><img src="txt-arrow.svg" width="96" height="96"><figcaption>96</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="txt-arrow.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="txt-arrow.svg" width="64" height="64"><figcaption>64</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="txt-arrow.svg" width="30" height="30"><b>ZNTC</b></div>
+      <div class="wm light"><img src="txt-arrow.svg" width="30" height="30"><b>ZNTC</b></div>
+    </div>
+  </div>
 </section>
 
 <footer>

--- a/logo-concepts/index.html
+++ b/logo-concepts/index.html
@@ -440,6 +440,158 @@
       <div class="wm light"><img src="txt-arrow.svg" width="30" height="30"><b>ZNTC</b></div>
     </div>
   </div>
+
+  <div class="card" style="grid-column:1/-1; background:#241f1c;">
+    <h2 style="color:#fdba74;">다양한 컨셉 — 렌더링 스타일까지 다르게</h2>
+    <p class="desc" style="margin:0;">같은 오렌지 도형 반복을 벗어나 컨셉·표현 기법 자체를 분산: Zig 어원(지구라트)·분광·그래프·폴드·위브·모노라인·픽셀.</p>
+  </div>
+
+  <!-- 19 --><div class="card">
+    <h2>⑲ 지구라트</h2>
+    <p class="desc">계단식 피라미드 — "Zig"(←ziggurat) 어원/네이티브 기반. 글자 없이 Zig 정체성, 안정적 실루엣.</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="sym-ziggurat.svg" width="16" height="16"><figcaption>16</figcaption></figure>
+        <figure><img src="sym-ziggurat.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="sym-ziggurat.svg" width="48" height="48"><figcaption>48</figcaption></figure>
+        <figure><img src="sym-ziggurat.svg" width="96" height="96"><figcaption>96</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="sym-ziggurat.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="sym-ziggurat.svg" width="64" height="64"><figcaption>64</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="sym-ziggurat.svg" width="30" height="30"><b>ZNTC</b></div>
+      <div class="wm light"><img src="sym-ziggurat.svg" width="30" height="30"><b>ZNTC</b></div>
+    </div>
+  </div>
+
+  <!-- 20 --><div class="card">
+    <h2>⑳ 프리즘 분광</h2>
+    <p class="desc">raw 빔 → 프리즘 → 스펙트럼. 한 소스 → 다중 ES 타깃 다운레벨링의 강한 은유. 고유성 높음.</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="sym-prism.svg" height="16"><figcaption>h16</figcaption></figure>
+        <figure><img src="sym-prism.svg" height="32"><figcaption>h32</figcaption></figure>
+        <figure><img src="sym-prism.svg" height="48"><figcaption>h48</figcaption></figure>
+        <figure><img src="sym-prism.svg" height="80"><figcaption>h80</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="sym-prism.svg" height="32"><figcaption>h32</figcaption></figure>
+        <figure><img src="sym-prism.svg" height="56"><figcaption>h56</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="sym-prism.svg" height="28"><b>ZNTC</b></div>
+      <div class="wm light"><img src="sym-prism.svg" height="28"><b>ZNTC</b></div>
+    </div>
+  </div>
+
+  <!-- 21 --><div class="card">
+    <h2>㉑ 의존성 그래프</h2>
+    <p class="desc">노드+엣지 — 파서/번들러 핵심(AST·모듈 그래프). 모노라인 렌더링, 기술적 인상.</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="sym-graph.svg" width="16" height="16"><figcaption>16</figcaption></figure>
+        <figure><img src="sym-graph.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="sym-graph.svg" width="48" height="48"><figcaption>48</figcaption></figure>
+        <figure><img src="sym-graph.svg" width="96" height="96"><figcaption>96</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="sym-graph.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="sym-graph.svg" width="64" height="64"><figcaption>64</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="sym-graph.svg" width="30" height="30"><b>ZNTC</b></div>
+      <div class="wm light"><img src="sym-graph.svg" width="30" height="30"><b>ZNTC</b></div>
+    </div>
+  </div>
+
+  <!-- 22 --><div class="card">
+    <h2>㉒ 폴드 (오리가미)</h2>
+    <p class="desc">dog-ear 접힘 — 소스가 변환(fold)되는 은유. 깔끔한 단일 형태, 모던.</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="sym-fold.svg" width="16" height="16"><figcaption>16</figcaption></figure>
+        <figure><img src="sym-fold.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="sym-fold.svg" width="48" height="48"><figcaption>48</figcaption></figure>
+        <figure><img src="sym-fold.svg" width="96" height="96"><figcaption>96</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="sym-fold.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="sym-fold.svg" width="64" height="64"><figcaption>64</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="sym-fold.svg" width="30" height="30"><b>ZNTC</b></div>
+      <div class="wm light"><img src="sym-fold.svg" width="30" height="30"><b>ZNTC</b></div>
+    </div>
+  </div>
+
+  <!-- 23 --><div class="card">
+    <h2>㉓ 위브 허브</h2>
+    <p class="desc">여러 스트랜드 → 하나의 허브. 모듈 응집/번들. 스포크 패턴, 대칭.</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="sym-weave-hub.svg" width="16" height="16"><figcaption>16</figcaption></figure>
+        <figure><img src="sym-weave-hub.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="sym-weave-hub.svg" width="48" height="48"><figcaption>48</figcaption></figure>
+        <figure><img src="sym-weave-hub.svg" width="96" height="96"><figcaption>96</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="sym-weave-hub.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="sym-weave-hub.svg" width="64" height="64"><figcaption>64</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="sym-weave-hub.svg" width="30" height="30"><b>ZNTC</b></div>
+      <div class="wm light"><img src="sym-weave-hub.svg" width="30" height="30"><b>ZNTC</b></div>
+    </div>
+  </div>
+
+  <!-- 24 --><div class="card">
+    <h2>㉔ 모노라인 포커스</h2>
+    <p class="desc">동심 타깃 — 최적화/정밀. 순수 라인 렌더링(다른 표현 기법), 모노톤 전환 쉬움.</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="sym-focus.svg" width="16" height="16"><figcaption>16</figcaption></figure>
+        <figure><img src="sym-focus.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="sym-focus.svg" width="48" height="48"><figcaption>48</figcaption></figure>
+        <figure><img src="sym-focus.svg" width="96" height="96"><figcaption>96</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="sym-focus.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="sym-focus.svg" width="64" height="64"><figcaption>64</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="sym-focus.svg" width="30" height="30"><b>ZNTC</b></div>
+      <div class="wm light"><img src="sym-focus.svg" width="30" height="30"><b>ZNTC</b></div>
+    </div>
+  </div>
+
+  <!-- 25 --><div class="card">
+    <h2>㉕ 픽셀 forward</h2>
+    <p class="desc">8-bit 픽셀 화살표 — 컴파일/빌드. 레트로 개발 톤, 스타일 자체가 차별점.</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="sym-pixel.svg" width="16" height="16"><figcaption>16</figcaption></figure>
+        <figure><img src="sym-pixel.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="sym-pixel.svg" width="48" height="48"><figcaption>48</figcaption></figure>
+        <figure><img src="sym-pixel.svg" width="96" height="96"><figcaption>96</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="sym-pixel.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="sym-pixel.svg" width="64" height="64"><figcaption>64</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="sym-pixel.svg" width="30" height="30"><b>ZNTC</b></div>
+      <div class="wm light"><img src="sym-pixel.svg" width="30" height="30"><b>ZNTC</b></div>
+    </div>
+  </div>
 </section>
 
 <footer>

--- a/logo-concepts/index.html
+++ b/logo-concepts/index.html
@@ -67,7 +67,7 @@
   <!-- B -->
   <div class="card">
     <h2>② 번개 (속도)</h2>
-    <p class="desc">투명 배경 + 오렌지 그라디언트 볼트. Zig 네이티브 속도/컴파일 에너지. 다이나믹하고 고유성 높음. 작은 크기에선 디테일 손실 주의.</p>
+    <p class="desc">투명 배경 + 오렌지 그라디언트 볼트. Zig 네이티브 속도/컴파일 에너지. <b>꼭지 평평 잘림 → 단일 꼭짓점으로 수정함.</b> 작은 크기에선 디테일 손실 주의.</p>
     <div class="swatches">
       <div class="bgblock dark"><div class="sizes">
         <figure><img src="mark-b-bolt.svg" width="16" height="16"><figcaption>16</figcaption></figure>
@@ -105,6 +105,94 @@
     <div class="lockup">
       <div class="wm dark"><img src="mark-c-brackets.svg" height="26"><b>ZNTC</b></div>
       <div class="wm light"><img src="mark-c-brackets.svg" height="26"><b>ZNTC</b></div>
+    </div>
+  </div>
+
+  <!-- D -->
+  <div class="card">
+    <h2>④ 육각 칩 Z</h2>
+    <p class="desc">육각 칩 + Z 음각. "Zig 네이티브 / 실리콘" 뉘앙스. 모노그램(①)과 같은 Z 글리프라 패밀리 일관성, 타일보다 기술적 인상.</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="mark-d-hex.svg" width="16" height="16"><figcaption>16</figcaption></figure>
+        <figure><img src="mark-d-hex.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="mark-d-hex.svg" width="48" height="48"><figcaption>48</figcaption></figure>
+        <figure><img src="mark-d-hex.svg" width="96" height="96"><figcaption>96</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="mark-d-hex.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="mark-d-hex.svg" width="64" height="64"><figcaption>64</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="mark-d-hex.svg" width="30" height="30"><b>ZNTC</b></div>
+      <div class="wm light"><img src="mark-d-hex.svg" width="30" height="30"><b>ZNTC</b></div>
+    </div>
+  </div>
+
+  <!-- E -->
+  <div class="card">
+    <h2>⑤ 이중 셰브론 »</h2>
+    <p class="desc">두 겹 셰브론 — 컴파일 fast-forward / 속도. Z 없이 추상적, 매우 단순해 16px도 또렷. 단점: 미디어 FF로 읽힐 여지.</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="mark-e-chevron.svg" width="16" height="16"><figcaption>16</figcaption></figure>
+        <figure><img src="mark-e-chevron.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="mark-e-chevron.svg" width="48" height="48"><figcaption>48</figcaption></figure>
+        <figure><img src="mark-e-chevron.svg" width="96" height="96"><figcaption>96</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="mark-e-chevron.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="mark-e-chevron.svg" width="64" height="64"><figcaption>64</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="mark-e-chevron.svg" width="28" height="28"><b>ZNTC</b></div>
+      <div class="wm light"><img src="mark-e-chevron.svg" width="28" height="28"><b>ZNTC</b></div>
+    </div>
+  </div>
+
+  <!-- F -->
+  <div class="card">
+    <h2>⑥ 스택 번들 Z</h2>
+    <p class="desc">Z 글리프 2겹 오프셋 — 모듈을 청크로 묶는 <b>번들러</b> 정체성. ①과 같은 글리프의 레이어드 변형, 깊이감.</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="mark-f-stack.svg" width="16" height="16"><figcaption>16</figcaption></figure>
+        <figure><img src="mark-f-stack.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="mark-f-stack.svg" width="48" height="48"><figcaption>48</figcaption></figure>
+        <figure><img src="mark-f-stack.svg" width="96" height="96"><figcaption>96</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="mark-f-stack.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="mark-f-stack.svg" width="64" height="64"><figcaption>64</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="mark-f-stack.svg" width="30" height="30"><b>ZNTC</b></div>
+      <div class="wm light"><img src="mark-f-stack.svg" width="30" height="30"><b>ZNTC</b></div>
+    </div>
+  </div>
+
+  <!-- G -->
+  <div class="card">
+    <h2>⑦ 아웃라인 모노그램</h2>
+    <p class="desc">①의 경량 변형 — 타일은 stroke만, Z는 솔리드. 미니멀·가벼움. 다크 배경에서 또렷, 16px에선 테두리가 얇아질 수 있음.</p>
+    <div class="swatches">
+      <div class="bgblock dark"><div class="sizes">
+        <figure><img src="mark-g-outline.svg" width="16" height="16"><figcaption>16</figcaption></figure>
+        <figure><img src="mark-g-outline.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="mark-g-outline.svg" width="48" height="48"><figcaption>48</figcaption></figure>
+        <figure><img src="mark-g-outline.svg" width="96" height="96"><figcaption>96</figcaption></figure>
+      </div></div>
+      <div class="bgblock light"><div class="sizes">
+        <figure><img src="mark-g-outline.svg" width="32" height="32"><figcaption>32</figcaption></figure>
+        <figure><img src="mark-g-outline.svg" width="64" height="64"><figcaption>64</figcaption></figure>
+      </div></div>
+    </div>
+    <div class="lockup">
+      <div class="wm dark"><img src="mark-g-outline.svg" width="30" height="30"><b>ZNTC</b></div>
+      <div class="wm light"><img src="mark-g-outline.svg" width="30" height="30"><b>ZNTC</b></div>
     </div>
   </div>
 </section>

--- a/logo-concepts/mark-a-monogram.svg
+++ b/logo-concepts/mark-a-monogram.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ZNTC monogram">
+  <defs>
+    <linearGradient id="a" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f7a41d"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="116" height="116" rx="26" fill="url(#a)"/>
+  <path fill="#171210" fill-rule="evenodd"
+        d="M40 40 H88 V54 H40 Z
+           M40 74 H88 V88 H40 Z
+           M88 54 L70 54 L40 74 L58 74 Z"/>
+</svg>

--- a/logo-concepts/mark-b-bolt.svg
+++ b/logo-concepts/mark-b-bolt.svg
@@ -6,6 +6,7 @@
       <stop offset="1" stop-color="#ea580c"/>
     </linearGradient>
   </defs>
+  <!-- 단일 꼭짓점 top — 기존의 평평하게 잘린 삼각 꼭지 제거 -->
   <path fill="url(#b)"
-        d="M74 14 L34 70 L58 70 L50 114 L96 54 L70 54 L82 14 Z"/>
+        d="M70 16 L33 72 L55 72 L46 112 L95 56 L69 56 Z"/>
 </svg>

--- a/logo-concepts/mark-b-bolt.svg
+++ b/logo-concepts/mark-b-bolt.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ZNTC bolt">
+  <defs>
+    <linearGradient id="b" x1="0" y1="0" x2="0.4" y2="1">
+      <stop offset="0" stop-color="#fbbf24"/>
+      <stop offset="0.55" stop-color="#f7a41d"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#b)"
+        d="M74 14 L34 70 L58 70 L50 114 L96 54 L70 54 L82 14 Z"/>
+</svg>

--- a/logo-concepts/mark-c-brackets.svg
+++ b/logo-concepts/mark-c-brackets.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 168 128" role="img" aria-label="ZNTC brackets">
+  <defs>
+    <linearGradient id="c" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f7a41d"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <!-- [ -->
+  <path fill="#8a807a" d="M28 26 H52 V38 H42 V90 H52 V102 H28 Z"/>
+  <!-- ] -->
+  <path fill="#8a807a" d="M140 26 H116 V38 H126 V90 H116 V102 H140 Z"/>
+  <!-- Z -->
+  <path fill="url(#c)" fill-rule="evenodd"
+        d="M64 38 H104 V50 H64 Z
+           M64 78 H104 V90 H64 Z
+           M104 50 L90 50 L64 78 L78 78 Z"/>
+</svg>

--- a/logo-concepts/mark-d-hex.svg
+++ b/logo-concepts/mark-d-hex.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ZNTC hex chip">
+  <defs>
+    <linearGradient id="d" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f7a41d"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <!-- 육각 칩 (네이티브/실리콘 뉘앙스) -->
+  <path fill="url(#d)" d="M122 64 L93 114 L35 114 L6 64 L35 14 L93 14 Z"/>
+  <!-- Z 음각 (모노그램과 동일 글리프) -->
+  <path fill="#171210" fill-rule="evenodd"
+        d="M40 40 H88 V54 H40 Z
+           M40 74 H88 V88 H40 Z
+           M88 54 L70 54 L40 74 L58 74 Z"/>
+</svg>

--- a/logo-concepts/mark-e-chevron.svg
+++ b/logo-concepts/mark-e-chevron.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ZNTC fast-forward">
+  <defs>
+    <linearGradient id="e" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#fb923c"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <!-- 이중 셰브론 »  — 컴파일 fast-forward / 속도 -->
+  <path fill="url(#e)" d="M22 26 L64 64 L22 102 L44 102 L86 64 L44 26 Z"/>
+  <path fill="url(#e)" d="M58 26 L100 64 L58 102 L80 102 L122 64 L80 26 Z"/>
+</svg>

--- a/logo-concepts/mark-f-stack.svg
+++ b/logo-concepts/mark-f-stack.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ZNTC bundle stack">
+  <defs>
+    <linearGradient id="f" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f7a41d"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <!-- 뒤 레이어 (번들 묶음 깊이) -->
+  <path fill="#9a3412" fill-rule="evenodd"
+        d="M47 47 H95 V61 H47 Z
+           M47 81 H95 V95 H47 Z
+           M95 61 L77 61 L47 81 L65 81 Z"/>
+  <!-- 앞 레이어 -->
+  <path fill="url(#f)" fill-rule="evenodd"
+        d="M37 37 H85 V51 H37 Z
+           M37 71 H85 V85 H37 Z
+           M85 51 L67 51 L37 71 L55 71 Z"/>
+</svg>

--- a/logo-concepts/mark-g-outline.svg
+++ b/logo-concepts/mark-g-outline.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ZNTC outline monogram">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f7a41d"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <!-- 아웃라인 타일 (미니멀 — A 의 경량 변형) -->
+  <rect x="9" y="9" width="110" height="110" rx="26" fill="none" stroke="url(#g)" stroke-width="7"/>
+  <path fill="url(#g)" fill-rule="evenodd"
+        d="M40 40 H88 V54 H40 Z
+           M40 74 H88 V88 H40 Z
+           M88 54 L70 54 L40 74 L58 74 Z"/>
+</svg>

--- a/logo-concepts/sym-cube.svg
+++ b/logo-concepts/sym-cube.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ZNTC cube">
+  <!-- 아이소메트릭 큐브 — 묶인 빌드 산출물 / 네이티브 -->
+  <path fill="#fbbf24" d="M64 14 L108 39 L64 64 L20 39 Z"/>
+  <path fill="#ea580c" d="M20 39 L64 64 L64 114 L20 89 Z"/>
+  <path fill="#f7a41d" d="M108 39 L108 89 L64 114 L64 64 Z"/>
+</svg>

--- a/logo-concepts/sym-focus.svg
+++ b/logo-concepts/sym-focus.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ZNTC focus">
+  <defs>
+    <linearGradient id="fc" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f7a41d"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <!-- 모노라인 동심 포커스 — 최적화/정밀 (순수 라인 렌더링) -->
+  <g fill="none" stroke="url(#fc)" stroke-width="6" stroke-linecap="round">
+    <circle cx="64" cy="64" r="42" stroke-dasharray="210 264"/>
+    <circle cx="64" cy="64" r="25" stroke-dasharray="118 158"/>
+  </g>
+  <circle cx="64" cy="64" r="9" fill="url(#fc)"/>
+</svg>

--- a/logo-concepts/sym-fold.svg
+++ b/logo-concepts/sym-fold.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ZNTC fold">
+  <defs>
+    <linearGradient id="fd" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f7a41d"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <!-- 종이 접힘(dog-ear) — 소스가 변환(fold)되는 은유 -->
+  <path fill="url(#fd)"
+        d="M20 34 Q20 20 34 20 L86 20 L108 42 L108 94 Q108 108 94 108 L34 108 Q20 108 20 94 Z"/>
+  <path fill="#9a3412" d="M86 20 L108 42 L86 42 Z"/>
+</svg>

--- a/logo-concepts/sym-graph.svg
+++ b/logo-concepts/sym-graph.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ZNTC dependency graph">
+  <defs>
+    <linearGradient id="gr" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f7a41d"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <!-- 의존성/AST 그래프 — 파서·번들러 정체성 (모노라인 + 노드) -->
+  <g stroke="url(#gr)" stroke-width="6" stroke-linecap="round">
+    <line x1="64" y1="30" x2="32" y2="72"/>
+    <line x1="64" y1="30" x2="96" y2="72"/>
+    <line x1="32" y1="72" x2="96" y2="72"/>
+    <line x1="32" y1="72" x2="64" y2="106"/>
+    <line x1="96" y1="72" x2="64" y2="106"/>
+  </g>
+  <g fill="url(#gr)">
+    <circle cx="64" cy="30" r="13"/>
+    <circle cx="32" cy="72" r="11"/>
+    <circle cx="96" cy="72" r="11"/>
+    <circle cx="64" cy="106" r="11"/>
+  </g>
+</svg>

--- a/logo-concepts/sym-notched-ring.svg
+++ b/logo-concepts/sym-notched-ring.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ZNTC build ring">
+  <defs>
+    <linearGradient id="nr" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f7a41d"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <!-- 노치 링 — 빌드 사이클 / 처리 (단일 C 형태) -->
+  <circle cx="64" cy="64" r="40" fill="none" stroke="url(#nr)" stroke-width="14"
+          stroke-linecap="round" stroke-dasharray="200 251"/>
+</svg>

--- a/logo-concepts/sym-pinwheel.svg
+++ b/logo-concepts/sym-pinwheel.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ZNTC rotor">
+  <defs>
+    <linearGradient id="pw" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#fbbf24"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <!-- 3-blade 로터 — 변환/처리 모션 (회전 대칭) -->
+  <g fill="url(#pw)">
+    <path d="M64 64 L46 26 L82 22 Z"/>
+    <path d="M64 64 L46 26 L82 22 Z" transform="rotate(120 64 64)"/>
+    <path d="M64 64 L46 26 L82 22 Z" transform="rotate(240 64 64)"/>
+  </g>
+</svg>

--- a/logo-concepts/sym-pixel.svg
+++ b/logo-concepts/sym-pixel.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ZNTC pixel forward">
+  <defs>
+    <linearGradient id="px" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#fbbf24"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <!-- 픽셀/레트로 forward — 컴파일/빌드 (8-bit 스타일, 렌더링 다양화) -->
+  <g fill="url(#px)">
+    <rect x="20" y="20" width="14" height="14"/>
+    <rect x="38" y="20" width="14" height="14"/>
+    <rect x="38" y="38" width="14" height="14"/>
+    <rect x="56" y="38" width="14" height="14"/>
+    <rect x="56" y="56" width="14" height="14"/>
+    <rect x="74" y="56" width="14" height="14"/>
+    <rect x="56" y="74" width="14" height="14"/>
+    <rect x="38" y="74" width="14" height="14"/>
+    <rect x="38" y="92" width="14" height="14"/>
+    <rect x="20" y="92" width="14" height="14"/>
+  </g>
+</svg>

--- a/logo-concepts/sym-prism.svg
+++ b/logo-concepts/sym-prism.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 156 128" role="img" aria-label="ZNTC prism">
+  <defs>
+    <linearGradient id="pr" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f7a41d"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <!-- 입력 빔(raw) → 프리즘 → 분광 출력 = 한 소스 → 다중 ES 타깃 -->
+  <rect x="4" y="59" width="54" height="10" rx="3" fill="#8a807a"/>
+  <path fill="url(#pr)" d="M70 26 L44 98 L96 98 Z"/>
+  <g stroke-width="7" stroke-linecap="round">
+    <line x1="86" y1="70" x2="150" y2="34" stroke="#fde68a"/>
+    <line x1="87" y1="72" x2="150" y2="58" stroke="#fbbf24"/>
+    <line x1="87" y1="75" x2="150" y2="82" stroke="#f7a41d"/>
+    <line x1="86" y1="78" x2="150" y2="106" stroke="#ea580c"/>
+  </g>
+</svg>

--- a/logo-concepts/sym-split-triangle.svg
+++ b/logo-concepts/sym-split-triangle.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ZNTC split forward">
+  <defs>
+    <linearGradient id="st" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#f7a41d"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <!-- forward 재생 삼각을 슬라이스 — 속도/실행 -->
+  <path fill="url(#st)" d="M40 22 L104 60 L40 60 Z"/>
+  <path fill="url(#st)" d="M40 68 L104 68 L40 106 Z"/>
+</svg>

--- a/logo-concepts/sym-squircle-bolt.svg
+++ b/logo-concepts/sym-squircle-bolt.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ZNTC squircle bolt">
+  <defs>
+    <linearGradient id="sb" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f7a41d"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+    <mask id="sbm">
+      <rect x="12" y="12" width="104" height="104" rx="28" fill="#fff"/>
+      <path d="M66 32 L40 70 L55 70 L48 96 L88 58 L66 58 Z" fill="#000"/>
+    </mask>
+  </defs>
+  <rect x="12" y="12" width="104" height="104" rx="28" fill="url(#sb)" mask="url(#sbm)"/>
+</svg>

--- a/logo-concepts/sym-weave-hub.svg
+++ b/logo-concepts/sym-weave-hub.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ZNTC weave hub">
+  <defs>
+    <linearGradient id="wh" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#fbbf24"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <!-- 여러 모듈 → 하나의 허브 (번들 응집) -->
+  <g stroke="url(#wh)" stroke-width="16" stroke-linecap="round">
+    <line x1="22" y1="64" x2="106" y2="64"/>
+    <line x1="22" y1="64" x2="106" y2="64" transform="rotate(60 64 64)"/>
+    <line x1="22" y1="64" x2="106" y2="64" transform="rotate(120 64 64)"/>
+  </g>
+  <circle cx="64" cy="64" r="13" fill="#7c2d12"/>
+</svg>

--- a/logo-concepts/sym-ziggurat.svg
+++ b/logo-concepts/sym-ziggurat.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ZNTC ziggurat">
+  <defs>
+    <linearGradient id="zg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#fbbf24"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <!-- 계단식 지구라트 — "Zig"(←ziggurat) 어원 / 네이티브 기반, 글자 없음 -->
+  <g fill="url(#zg)">
+    <rect x="55" y="22" width="18" height="16" rx="2"/>
+    <rect x="44" y="42" width="40" height="16" rx="2"/>
+    <rect x="32" y="62" width="64" height="16" rx="2"/>
+    <rect x="20" y="82" width="88" height="16" rx="2"/>
+    <rect x="10" y="102" width="108" height="16" rx="2"/>
+  </g>
+</svg>

--- a/logo-concepts/txt-arrow.svg
+++ b/logo-concepts/txt-arrow.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ZNTC fat arrow">
+  <defs>
+    <linearGradient id="ta" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#f7a41d"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <!-- => fat arrow — JS/TS 변환 코드 시그니처 -->
+  <g fill="url(#ta)">
+    <rect x="18" y="49" width="46" height="12" rx="6"/>
+    <rect x="18" y="67" width="46" height="12" rx="6"/>
+    <path d="M70 44 L106 64 L70 84 Z"/>
+  </g>
+</svg>

--- a/logo-concepts/txt-prompt.svg
+++ b/logo-concepts/txt-prompt.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="ZNTC terminal prompt">
+  <defs>
+    <linearGradient id="tp" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f7a41d"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+    <mask id="tpm">
+      <rect x="10" y="10" width="108" height="108" rx="28" fill="#fff"/>
+      <!-- > 캐럿 -->
+      <path d="M36 42 L62 64 L36 86 L46 86 L72 64 L46 42 Z" fill="#000"/>
+      <!-- _ 커서 -->
+      <rect x="72" y="78" width="32" height="11" rx="3" fill="#000"/>
+    </mask>
+  </defs>
+  <!-- 터미널 프롬프트 >_ — CLI 트랜스파일러 정체성 -->
+  <rect x="10" y="10" width="108" height="108" rx="28" fill="url(#tp)" mask="url(#tpm)"/>
+</svg>


### PR DESCRIPTION
## 배경

현재 `documents/public/favicon.svg` 는 **Astro 기본 스파클**(브랜드 마크 아님)이고 Starlight `logo:` 도 미설정 — 실제 ZNTC 로고가 없습니다. 문서 사이트용 로고 시안을 만들어 선택받기 위한 PR입니다.

> ⚠️ **머지용 아님 / 선택용.** auto-merge 미설정. 시안 고르면 favicon·Starlight `logo` 배선은 후속 PR에서 진행하고, 이 `logo-concepts/` 스크래치는 정리합니다.

## 시안 3종 (Zig 오렌지 `#f7a41d`, 사이트 다크 `#0d0a07` 기준)

| 파일 | 컨셉 | 특징 |
|---|---|---|
| `mark-a-monogram.svg` | **① 모노그램 타일 Z** | 라운드 타일 + 각진 Z 음각. swc/oxc/esbuild 계열 정석, 16px 파비콘 최적 |
| `mark-b-bolt.svg` | **② 번개** | 오렌지 그라디언트 볼트. Zig 네이티브 속도 강조, 고유성↑, 소형 디테일 손실 주의 |
| `mark-c-brackets.svg` | **③ 브래킷 [ Z ]** | 트랜스파일 in→out 은유. 컬리 `{ }`는 16px에서 깨져 각진 브래킷으로 구현 |

`logo-concepts/index.html` — 다크/라이트 배경 × 파비콘(16·32)~로고(48·96) × **ZNTC 워드마크 락업** 한 화면 비교.

## 보는 법

- GitHub **Files changed** 탭에서 각 `.svg` 이미지 직접 렌더 확인
- 전체 비교는 로컬에서:
  ```
  git fetch origin docs/logo-concepts && git switch docs/logo-concepts
  open logo-concepts/index.html
  ```

## 선택 시 다음 단계

번호(또는 "②인데 색 더 진하게" 등 조정) 코멘트 주시면:
1. `documents/public/favicon.svg` 교체 (라이트/다크 `prefers-color-scheme` 대응)
2. `documents/astro.config.mjs` Starlight `logo` 배선 (아이콘 + "ZNTC" 텍스트 병기)
3. 스크래치 디렉토리 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)