### PR TITLE
ci: stale 회귀 가드 strict 전환 (#1960~#1962·#1885 CLOSED)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,11 +171,9 @@ jobs:
         run: cd packages/core && bun run test bin/zntc.test.ts
 
       # ZNTC 코어의 ES5 다운레벨링 / chunk split runtime helper / external 처리
-      # 회귀 검증 (wasm 발견 버그가 NAPI 에서도 동일 발생 확인됨). known bugs
-      # 는 #1960~#1962 추적 — fix 전까지 continue-on-error 로 정보용. fix 후
-      # strict 전환.
-      - name: Bundler 코어 회귀 검증 (#1960~#1962)
-        continue-on-error: true
+      # 회귀 검증 (wasm 발견 버그가 NAPI 에서도 동일 발생 확인됨). #1960~#1962
+      # 는 모두 fix·CLOSED — strict 전환 완료. 스크립트가 totalFails>0 시 exit 1.
+      - name: Bundler 코어 회귀 검증 (#1960~#1962 회귀 가드)
         run: bun scripts/napi-bundler-bug-check.ts
 
   napi-package-smoke:
@@ -421,7 +419,8 @@ jobs:
       # bundler 옵션 매트릭스 회귀 검증 — 의도된 제약 (CodeSplittingRequiresESM
       # 등) vs 새 회귀 구분. known bugs (#1960 ES5 destructuring / #1961 chunk
       # split __generator / #1962 external require) 가 fix 되기 전까지 fail
-      # 가능 — continue-on-error 로 정보용. fix 후 strict 로 전환.
-      - name: Bundler 매트릭스 회귀 검증 (#1885 follow-up)
-        continue-on-error: true
+      # #1885·#1960~#1962 fix·CLOSED — strict 전환 완료. 스크립트가 진짜 회귀
+      # (UNEXPECTED-FAIL/MISSING 등) 시 exit 1; 의도 제약 완화
+      # (EXPECTED-FAIL-BUT-OK) 는 ::notice:: 로만 노출 (CI 미차단, 검토 대상).
+      - name: Bundler 매트릭스 회귀 검증 (#1885 회귀 가드)
         run: bun scripts/wasm-bundler-full-matrix.ts

--- a/scripts/wasm-bundler-full-matrix.ts
+++ b/scripts/wasm-bundler-full-matrix.ts
@@ -314,3 +314,20 @@ if (fails.length > 0) {
   console.log(`\nFAILS:`);
   for (const f of fails) console.log(`  - [${f.status}] ${f.group} / ${f.label}`);
 }
+
+// EXPECTED-FAIL-BUT-OK = 의도된 제약(CodeSplittingRequiresESM 등)이 더 이상
+// 에러로 막히지 않는 케이스. 회귀가 아니라 제약 변경이므로 CI 를 막지 않고
+// 정보성으로만 노출 — 제약을 영구 해제할지는 별도 판단 (이슈 추적).
+// hard fail = 그 외 모든 !ok (UNEXPECTED-FAIL / MISSING / UNEXPECTED-PRESENT
+// / FAIL): 이전에 통과하던 동작이 깨진 진짜 회귀.
+const hardFails = fails.filter((r) => r.status !== "EXPECTED-FAIL-BUT-OK");
+const constraintLifted = fails.filter((r) => r.status === "EXPECTED-FAIL-BUT-OK");
+if (constraintLifted.length > 0) {
+  console.log(`\n::notice::의도 제약 완화 ${constraintLifted.length}건 (회귀 아님, 검토 대상):`);
+  for (const f of constraintLifted) console.log(`  - ${f.group} / ${f.label}`);
+}
+if (hardFails.length > 0) {
+  console.log(`\n❌ 회귀 ${hardFails.length}건 — CI fail`);
+  process.exit(1);
+}
+console.log("\n✅ 회귀 없음");


### PR DESCRIPTION
## 문제 (기술 부채)

`ci.yml` 의 bundler 회귀 검증 2스텝이 `continue-on-error: true` 로 **non-blocking** 인데, 대상 버그 **#1960·#1961·#1962·#1885 는 전부 fix·CLOSED**. 주석은 "fix 후 strict 전환" 이라 명시했으나 전환이 누락 → ES5 destructuring / chunk split / external require / 번들러 매트릭스가 **회귀해도 CI 통과**하는 false-safety.

추가 발견: `scripts/wasm-bundler-full-matrix.ts` 는 `process.exit` 자체가 없어 실패를 삼키고 **항상 exit 0** — `continue-on-error` 만 떼도 여전히 이빨이 없는 이중 무력 상태.

## 변경

- **wasm-bundler-full-matrix.ts**: exit 로직 신설
  - 진짜 회귀(`UNEXPECTED-FAIL` / `MISSING` / `UNEXPECTED-PRESENT` / `FAIL`) → `exit 1`
  - 의도 제약 완화(`EXPECTED-FAIL-BUT-OK` — code split cjs/iife/umd/amd 가 더 이상 에러로 안 막힘) → 회귀 아님, `::notice::` 로만 노출. CI 미차단
- **ci.yml**: 두 스텝 `continue-on-error: true` 제거 + 주석 갱신
- `napi-bundler-bug-check.ts` 는 이미 `exit(totalFails>0?1:0)` 정상 — 변경 불필요

## 로컬 검증 (green 확인 후 전환)

```
napi-bundler-bug-check.ts   → Total fails: 0          (exit 0)
wasm-bundler-full-matrix.ts → 회귀 0, 제약완화 4 notice (exit 0)
```

회귀 발생 시에만 exit 1 → 이제 가드가 실제로 동작.

## 검토 요청 (별도 판단 사항)

`EXPECTED-FAIL-BUT-OK` 4건 = `CodeSplittingRequiresESM` 제약이 cjs/iife/umd/amd 에서 더 이상 에러로 안 막힘. 이게 **의도된 기능 확장**인지 **제약 가드 유실**인지 확인 필요. 의도면 fixture 의 `expectFailMatch` 를 제거(정상 OK 로), 유실이면 별도 버그 이슈. 이 PR 은 회귀 차단만 복구하고 해당 판단은 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)