### PR TITLE
test(e2e): dev/preview 서버 대기를 readiness 폴링으로 (BACKLOG #72)

### DIFF
--- a/tests/e2e/tests/wait-for-server.ts
+++ b/tests/e2e/tests/wait-for-server.ts
@@ -1,0 +1,32 @@
+/**
+ * dev/preview 서버 기동 대기 helper.
+ *
+ * fixed `setTimeout(2000~2500)` 으로 기다리면 느린 CI 에서 서버가 그 안에
+ * 못 떠 flaky (BACKLOG #72). 포트가 응답할 때까지 폴링하고, 빠르면 즉시 반환.
+ * error-overlay fixture 처럼 500/에러 HTML 을 주는 경우도 "서버는 bind 됨"
+ * 으로 간주 — 어떤 HTTP 응답이든 오면 준비 완료.
+ */
+export async function waitForServer(
+  port: number,
+  {
+    path = '/',
+    timeoutMs = 20_000,
+    intervalMs = 150,
+  }: { path?: string; timeoutMs?: number; intervalMs?: number } = {},
+): Promise<void> {
+  const url = `http://localhost:${port}${path}`;
+  const deadline = Date.now() + timeoutMs;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url, { signal: AbortSignal.timeout(2000) });
+      await res.body?.cancel(); // 소켓 정리 (body 미소비 시 leak)
+      return;
+    } catch (e) {
+      lastErr = e;
+      await new Promise((r) => setTimeout(r, intervalMs));
+    }
+  }
+  const detail = lastErr instanceof Error ? lastErr.message : String(lastErr);
+  throw new Error(`waitForServer: ${url} 가 ${timeoutMs}ms 내 응답 없음 (마지막 에러: ${detail})`);
+}

--- a/tests/e2e/tests/zntc-app-builder-e2e.test.ts
+++ b/tests/e2e/tests/zntc-app-builder-e2e.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { PORTS } from './ports';
+import { waitForServer } from './wait-for-server';
 
 /**
  * Vite-style app builder (`zntc build` / `zntc dev` / `zntc preview`) 의 브라우저 E2E.
@@ -101,7 +102,7 @@ test.describe.serial('zntc build + preview E2E', () => {
       ['preview', join(fixtureDir, 'dist'), '--port', String(BUILD_PREVIEW_PORT)],
       { stdio: 'pipe' },
     );
-    await new Promise((r) => setTimeout(r, 2000));
+    await waitForServer(BUILD_PREVIEW_PORT);
   });
 
   test.afterAll(async () => {
@@ -163,7 +164,7 @@ test.describe.serial('zntc dev E2E', () => {
     server = spawn(ZNTC_BIN, ['dev', fixtureDir, '--port', String(DEV_PORT)], {
       stdio: 'pipe',
     });
-    await new Promise((r) => setTimeout(r, 2500));
+    await waitForServer(DEV_PORT);
   });
 
   test.afterAll(async () => {
@@ -206,7 +207,7 @@ test.describe.serial('zntc dev E2E', () => {
     const server = spawn(ZNTC_BIN, ['dev', dir, '--port', String(OVERLAY_DEV_PORT)], {
       stdio: 'pipe',
     });
-    await new Promise((r) => setTimeout(r, 2500));
+    await waitForServer(OVERLAY_DEV_PORT);
 
     try {
       await page.goto(`http://localhost:${OVERLAY_DEV_PORT}/`, { waitUntil: 'domcontentloaded' });
@@ -243,7 +244,7 @@ test.describe.serial('zntc dev E2E', () => {
     const server = spawn(ZNTC_BIN, ['dev', dir, '--port', String(RUNTIME_OVERLAY_DEV_PORT)], {
       stdio: 'pipe',
     });
-    await new Promise((r) => setTimeout(r, 2500));
+    await waitForServer(RUNTIME_OVERLAY_DEV_PORT);
 
     try {
       await page.goto(`http://localhost:${RUNTIME_OVERLAY_DEV_PORT}/`, {
@@ -292,7 +293,7 @@ test.describe.serial('zntc dev E2E', () => {
     const server = spawn(ZNTC_BIN, ['dev', dir, '--port', String(REJECTION_OVERLAY_DEV_PORT)], {
       stdio: 'pipe',
     });
-    await new Promise((r) => setTimeout(r, 2500));
+    await waitForServer(REJECTION_OVERLAY_DEV_PORT);
 
     try {
       await page.goto(`http://localhost:${REJECTION_OVERLAY_DEV_PORT}/`, {
@@ -362,7 +363,7 @@ test.describe.serial('zntc build: nested CSS path preservation E2E', () => {
       ['preview', join(nestedDir, 'dist'), '--port', String(NESTED_PORT)],
       { stdio: 'pipe' },
     );
-    await new Promise((r) => setTimeout(r, 2000));
+    await waitForServer(NESTED_PORT);
   });
 
   test.afterAll(async () => {
@@ -442,7 +443,7 @@ el.textContent = styles.button.includes("button_button__") ? "scoped" : "raw";
       [ZNTC_JS_CLI, 'preview', join(dir, 'dist'), '--port', String(CSS_MODULE_PREVIEW_PORT)],
       { stdio: 'pipe' },
     );
-    await new Promise((r) => setTimeout(r, 2000));
+    await waitForServer(CSS_MODULE_PREVIEW_PORT);
     try {
       await page.goto(`http://localhost:${CSS_MODULE_PREVIEW_PORT}/`);
       const button = page.getByTestId('button');
@@ -472,7 +473,7 @@ el.textContent = styles.button.includes("button_button__") ? "scoped" : "raw";
         stdio: 'pipe',
       },
     );
-    await new Promise((r) => setTimeout(r, 2500));
+    await waitForServer(CSS_MODULE_DEV_PORT);
 
     try {
       await page.goto(`http://localhost:${CSS_MODULE_DEV_PORT}/`);
@@ -561,7 +562,7 @@ $label-color: rgb(140, 30, 20);
       [ZNTC_JS_CLI, 'preview', join(dir, 'dist'), '--port', String(SCSS_PREVIEW_PORT)],
       { stdio: 'pipe' },
     );
-    await new Promise((r) => setTimeout(r, 2000));
+    await waitForServer(SCSS_PREVIEW_PORT);
     try {
       await page.goto(`http://localhost:${SCSS_PREVIEW_PORT}/`);
       await expect(page.getByTestId('panel')).toHaveAttribute('data-ready', 'yes');
@@ -625,7 +626,7 @@ $label-color: rgb(170, 20, 60)
       [ZNTC_JS_CLI, 'preview', join(dir, 'dist'), '--port', String(SASS_HTML_PREVIEW_PORT)],
       { stdio: 'pipe' },
     );
-    await new Promise((r) => setTimeout(r, 2000));
+    await waitForServer(SASS_HTML_PREVIEW_PORT);
     try {
       await page.goto(`http://localhost:${SASS_HTML_PREVIEW_PORT}/`);
       const direct = page.getByTestId('direct');
@@ -651,7 +652,7 @@ $label-color: rgb(170, 20, 60)
         stdio: 'pipe',
       },
     );
-    await new Promise((r) => setTimeout(r, 2500));
+    await waitForServer(SCSS_DEV_PORT);
 
     try {
       await page.goto(`http://localhost:${SCSS_DEV_PORT}/`);
@@ -689,7 +690,7 @@ $label-color: rgb(170, 20, 60)
         stdio: 'pipe',
       },
     );
-    await new Promise((r) => setTimeout(r, 2500));
+    await waitForServer(SCSS_RECOVERY_DEV_PORT);
 
     try {
       await page.goto(`http://localhost:${SCSS_RECOVERY_DEV_PORT}/`);
@@ -762,20 +763,6 @@ export function mountApp() {
     await writeFile(join(dir, 'src/main.tsx'), "import { mountApp } from './App';\nmountApp();\n");
   }
 
-  async function waitForServer(port: number, deadlineMs: number): Promise<boolean> {
-    const deadline = Date.now() + deadlineMs;
-    while (Date.now() < deadline) {
-      try {
-        const r = await fetch(`http://localhost:${port}/`);
-        if (r.ok) return true;
-      } catch {
-        // not ready
-      }
-      await new Promise((r) => setTimeout(r, 300));
-    }
-    return false;
-  }
-
   test.beforeAll(async () => {
     buildFixtureDir = await mkdtemp(join(tmpdir(), 'zntc-app-preact-jsx-build-'));
     devFixtureDir = await mkdtemp(join(tmpdir(), 'zntc-app-preact-jsx-dev-'));
@@ -806,11 +793,8 @@ export function mountApp() {
       stdio: 'pipe',
     });
 
-    const previewOk = await waitForServer(BUILD_JSX_PORT, 10000);
-    const devOk = await waitForServer(DEV_JSX_PORT, 15000);
-    if (!previewOk || !devOk) {
-      throw new Error(`servers not ready: preview=${previewOk} dev=${devOk}`);
-    }
+    await waitForServer(BUILD_JSX_PORT, { timeoutMs: 10000 });
+    await waitForServer(DEV_JSX_PORT, { timeoutMs: 15000 });
   });
 
   test.afterAll(async () => {


### PR DESCRIPTION
## 문제 (BACKLOG #72)

`tests/e2e/tests/zntc-app-builder-e2e.test.ts` 가 dev/preview 서버 기동을 fixed `setTimeout(2000~2500)` 으로 대기 → 느린 CI 에서 서버가 그 안에 못 떠 **flaky**. (앞선 CI 지연·큐잉 이슈와 맞물려 간헐 실패 가능.)

## 변경

- **`tests/e2e/tests/wait-for-server.ts` 신설** — 포트가 응답할 때까지 폴링. ECONNREFUSED 재시도, 어떤 HTTP 응답이든(500 포함 = error-overlay fixture) bind 완료로 간주, timeout 시 진단 메시지와 함께 throw. 빠르면 즉시 반환, 느리면 budget 까지 대기 → 양방향 flaky 제거.
- 서버 기동 `setTimeout` **12곳 → `await waitForServer(PORT)`**.
- **중복 제거**: 파일 안에 이미 있던 로컬 `waitForServer(): Promise<boolean>` 를 공유 helper 로 통합. JSX 블록 2개 호출부도 helper 사용 (도입한 import 와의 이름 충돌도 해소).
- HMR/rebuild 전파 대기 `setTimeout`(701/830/835)은 서버 기동이 아니므로 **범위 외로 보존**.

## 검증

helper 거동을 독립 sanity 로 확인 (브라우저 스택 없이 결정적):

| 케이스 | 결과 |
|---|---|
| 800ms 늦게 뜨는 서버 | 930ms 에 resolve (fixed 2000 보다 빠르고, 더 늦어도 적응) |
| 500 에러 응답 서버 | 4ms 즉시 resolve (overlay fixture 대응) |
| 죽은 포트 | timeout(1200ms) 내 throw + 진단 메시지 |

lint(oxlint) 0 errors. e2e 는 tsconfig 없이 Playwright 로만 실행돼 tsc 게이트 없음.

**동작 변경 1건**: JSX 블록이 `r.ok`(2xx) → 임의 응답 기준. overlay fixture 와 일관되고 "서버 bind = ready" 가 더 견고 (이후 테스트 본문이 페이지 내용 단언).

🤖 Generated with [Claude Code](https://claude.com/claude-code)