### PR TITLE
chore: /simplify 후속 정리 (#3531·#3532 리뷰 반영)

### DIFF
--- a/scripts/wasm-bundler-full-matrix.ts
+++ b/scripts/wasm-bundler-full-matrix.ts
@@ -232,11 +232,22 @@ const cases: Case[] = [
 ];
 
 // ─── 실행 ───
+// status 는 producer(아래 분류)와 consumer(말미 요약)가 공유 — 문자열 오타가
+// 회귀를 "제약 완화"로 오분류해 CI 를 green 으로 통과시키는 걸 막는다.
+const STATUS = {
+  OK: "OK",
+  FAIL: "FAIL",
+  EXPECTED_FAIL: "EXPECTED-FAIL",
+  UNEXPECTED_FAIL: "UNEXPECTED-FAIL",
+  EXPECTED_FAIL_BUT_OK: "EXPECTED-FAIL-BUT-OK",
+} as const;
+type Status = (typeof STATUS)[keyof typeof STATUS];
+
 interface Result {
   group: string;
   label: string;
   ok: boolean;
-  status: string;
+  status: Status | "";
   notes: string[];
 }
 const results: Result[] = [];
@@ -244,7 +255,7 @@ const results: Result[] = [];
 for (const c of cases) {
   const notes: string[] = [];
   let ok = true;
-  let status = "";
+  let status: Status | "" = "";
 
   const chunks = buildChunks(c.entry, c.opts);
 
@@ -253,20 +264,20 @@ for (const c of cases) {
     if (c.expectFailMatch) {
       const matched = c.expectFailMatch.test(msg);
       ok = matched;
-      status = matched ? "EXPECTED-FAIL" : "UNEXPECTED-FAIL";
+      status = matched ? STATUS.EXPECTED_FAIL : STATUS.UNEXPECTED_FAIL;
       notes.push(`msg=${msg}`);
     } else {
       ok = false;
-      status = "FAIL";
+      status = STATUS.FAIL;
       notes.push(`msg=${msg || "(none)"}`);
     }
   } else {
     if (c.expectFailMatch) {
       ok = false;
-      status = "EXPECTED-FAIL-BUT-OK";
+      status = STATUS.EXPECTED_FAIL_BUT_OK;
       notes.push(`got ${chunks.length} chunk(s)`);
     } else {
-      status = "OK";
+      status = STATUS.OK;
     }
 
     // 모든 chunk 합쳐서 패턴 검증
@@ -307,27 +318,25 @@ for (const r of results) {
   for (const n of r.notes) console.log(`     ${n}`);
 }
 
-const fails = results.filter((r) => !r.ok);
-console.log(`\n${"=".repeat(60)}`);
-console.log(`Total: ${results.length}, OK: ${results.length - fails.length}, FAIL: ${fails.length}`);
-if (fails.length > 0) {
-  console.log(`\nFAILS:`);
-  for (const f of fails) console.log(`  - [${f.status}] ${f.group} / ${f.label}`);
-}
-
 // EXPECTED-FAIL-BUT-OK = 의도된 제약(CodeSplittingRequiresESM 등)이 더 이상
 // 에러로 막히지 않는 케이스. 회귀가 아니라 제약 변경이므로 CI 를 막지 않고
 // 정보성으로만 노출 — 제약을 영구 해제할지는 별도 판단 (이슈 추적).
 // hard fail = 그 외 모든 !ok (UNEXPECTED-FAIL / MISSING / UNEXPECTED-PRESENT
 // / FAIL): 이전에 통과하던 동작이 깨진 진짜 회귀.
-const hardFails = fails.filter((r) => r.status !== "EXPECTED-FAIL-BUT-OK");
-const constraintLifted = fails.filter((r) => r.status === "EXPECTED-FAIL-BUT-OK");
+const constraintLifted = results.filter((r) => r.status === STATUS.EXPECTED_FAIL_BUT_OK);
+const hardFails = results.filter((r) => !r.ok && r.status !== STATUS.EXPECTED_FAIL_BUT_OK);
+const okCount = results.length - hardFails.length - constraintLifted.length;
+console.log(`\n${"=".repeat(60)}`);
+console.log(
+  `Total: ${results.length}, OK: ${okCount}, 회귀: ${hardFails.length}, 제약완화: ${constraintLifted.length}`,
+);
 if (constraintLifted.length > 0) {
   console.log(`\n::notice::의도 제약 완화 ${constraintLifted.length}건 (회귀 아님, 검토 대상):`);
   for (const f of constraintLifted) console.log(`  - ${f.group} / ${f.label}`);
 }
 if (hardFails.length > 0) {
   console.log(`\n❌ 회귀 ${hardFails.length}건 — CI fail`);
+  for (const f of hardFails) console.log(`  - [${f.status}] ${f.group} / ${f.label}`);
   process.exit(1);
 }
 console.log("\n✅ 회귀 없음");

--- a/tests/e2e/tests/wait-for-server.ts
+++ b/tests/e2e/tests/wait-for-server.ts
@@ -18,13 +18,21 @@ export async function waitForServer(
   const deadline = Date.now() + timeoutMs;
   let lastErr: unknown;
   while (Date.now() < deadline) {
+    // AbortSignal.timeout 은 성공 후에도 타이머가 살아 event loop 에 매달림
+    // (14곳 순차 호출 시 누적). 명시 controller + finally clearTimeout 로 정리.
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), 2000);
     try {
-      const res = await fetch(url, { signal: AbortSignal.timeout(2000) });
-      await res.body?.cancel(); // 소켓 정리 (body 미소비 시 leak)
+      const res = await fetch(url, { signal: ctrl.signal });
+      // body 미소비 시 소켓 leak. cancel 자체 reject 가 liveness 판정으로
+      // 새는 걸 막기 위해 swallow (서버는 이미 응답했으므로 ready 확정).
+      await res.body?.cancel().catch(() => {});
       return;
     } catch (e) {
       lastErr = e;
       await new Promise((r) => setTimeout(r, intervalMs));
+    } finally {
+      clearTimeout(t);
     }
   }
   const detail = lastErr instanceof Error ? lastErr.message : String(lastErr);

--- a/tests/e2e/tests/zntc-app-builder-e2e.test.ts
+++ b/tests/e2e/tests/zntc-app-builder-e2e.test.ts
@@ -793,8 +793,11 @@ export function mountApp() {
       stdio: 'pipe',
     });
 
-    await waitForServer(BUILD_JSX_PORT, { timeoutMs: 10000 });
-    await waitForServer(DEV_JSX_PORT, { timeoutMs: 15000 });
+    // preview·devServer 는 위에서 동시에 spawn — 대기도 병렬.
+    await Promise.all([
+      waitForServer(BUILD_JSX_PORT, { timeoutMs: 15000 }),
+      waitForServer(DEV_JSX_PORT, { timeoutMs: 15000 }),
+    ]);
   });
 
   test.afterAll(async () => {


### PR DESCRIPTION
머지된 **#3531**(회귀 가드 strict) · **#3532**(E2E readiness 폴링)에 정식 `/simplify` 3-에이전트를 돌려 나온 실질 지적을 정리합니다.

## 수정 3건

**A. `wasm-bundler-full-matrix.ts` — 상충하는 이중 요약 + stringly-typed status**
같은 run 에서 옛 `Total/FAIL:` + `FAILS:` 블록(EXPECTED-FAIL-BUT-OK 를 실패로 셈)과 새 `✅ 회귀 없음` 이 **동시 출력**되어 모순, 같은 케이스가 두 번 표기됐습니다. 요약을 `hardFails`/`constraintLifted`/`okCount` **단일 출처**로 통합. `status` 를 `STATUS` 상수 + union 타입으로 — producer/consumer 문자열 오타가 회귀를 제약완화로 **오분류해 CI 를 green 통과**시키는 위험 제거.
출력 확인: `Total: 32, OK: 28, 회귀: 0, 제약완화: 4` → `::notice::` → `✅ 회귀 없음` (모순 제거, exit semantics 동일).

**B. `wait-for-server.ts` — dangling 타이머 + cleanup reject 누수**
`AbortSignal.timeout(2000)` 이 fetch 성공 후에도 타이머가 살아 event loop 에 매달림(14곳 순차 호출 시 누적). `AbortController` + `finally clearTimeout` 로 정리. `body.cancel()` reject 가 liveness 판정으로 새지 않게 `.catch(()=>{})`.

**C. `zntc-app-builder-e2e.test.ts` — JSX 블록 순차 대기**
`preview`·`devServer` 를 함께 spawn 해놓고 순차 await → `Promise.all` 병렬.

## 보류 (사유 명시)

크로스-스위트 `waitForServer` 통합(`packages/core/test/cli/helpers.ts` · `tests/integration/.../devserver-sse-mcp.test.ts` 인라인 폴링 · 신규 e2e helper) — 3개 워크스페이스 분리 + `bun:test`↔Playwright 런너 결합으로 직접 import 불가. 리유즈 에이전트도 "현실적 불가" 결론. /simplify 후속 범위를 넘는 리팩터라 **BACKLOG 부채로 별도 기록**.

## 검증

lint 0 errors / 두 회귀 스크립트 green 유지(wasm 출력 단일화 확인) / helper sanity 3케이스(지연 773ms·500 2ms·dead throw) + 프로세스 즉시 종료(dangling 타이머 해소).

🤖 Generated with [Claude Code](https://claude.com/claude-code)