### PR TITLE
docs(backlog): #72 해결 표시 + #74 helper 통합 부채 기록

### DIFF
--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -55,7 +55,8 @@ CSS Modules + Sass 도입 (PR #2225) 후 식별된 후속 작업.
 |---|------|------|
 | ~~70~~ | ~~dev rebuild full re-prep (cpSync) 비용~~ | ✅ 해결: `prepare(dirtyPaths)` 가 incremental — 변경 파일만 cpSync, sass/css-modules transform 도 dirty 입력만 재처리, postcss prep 호출 자체도 CSS 관련 dirty 가 없으면 skip. JS-only 변경은 cpSync (dirty 만) + rewriter (dirty 만) 만 수행 — 풀 prep 의 비용 거의 전부 회피. |
 | ~~71~~ | ~~`.scss` 단일 파일 fast-path~~ | ✅ 해결: 단일 non-module `.scss/.sass` 변경은 `isCssOnlyChange=true` 로 분류되어 `rebuildScssIncremental` 진입 — 그 파일만 sass.compile + tempRoot/outdir 갱신 + `CssUpdate` broadcast. import dep 추적 없으므로 다른 sass 파일이 이 파일을 import 하면 갱신 누락 (별 issue 로 sass loadPaths dep tracking) |
-| 72 | E2E `setTimeout(2000-2500)` → readiness poll | `tests/e2e/tests/zntc-app-builder-e2e.test.ts` 가 dev/preview 서버 기동 대기로 fixed `setTimeout` 사용 — 느린 CI 에서 flaky 가능성. `fetch(url)` 폴링 helper (ECONNREFUSED 재시도 / 200 까지) 도입해 일괄 대체 |
+| ~~72~~ | ~~E2E `setTimeout(2000-2500)` → readiness poll~~ | ✅ 해결 (PR #3532): `tests/e2e/tests/wait-for-server.ts` 폴링 helper 도입, `zntc-app-builder-e2e.test.ts` 의 서버 기동 `setTimeout` 12곳 일괄 대체 + 로컬 중복 helper 제거. 200 한정이 아니라 **임의 HTTP 응답 = bind 완료** (error-overlay fixture 가 500/에러 HTML 을 주므로). |
+| 74 | 크로스-스위트 `waitForServer` 통합 | server-readiness 폴링이 3곳에 중복: `packages/core/test/cli/helpers.ts` (positional args), `tests/integration/tests/devserver-sse-mcp.test.ts` 인라인 루프, `tests/e2e/tests/wait-for-server.ts`. 워크스페이스 분리 + `bun:test`↔Playwright 런너 결합으로 직접 import 불가 — runner-agnostic 공유 모듈로 추출해야 단일화 가능. (#3533 /simplify 에서 식별, 범위 초과로 보류) |
 | ~~73~~ | ~~Dev mode 에서 bundler 가 CSS chunk 를 emit 하지 않음~~ | ✅ 해결: bundler 측은 그대로 두고, JS 파이프라인이 sass / css-modules 컴파일 산출물을 tempRoot → outdir 로 mirror 하고 HTML 에 `<link>` 를 주입. inline `<style>` 우회 (`buildDevStyleInjector`) 제거. |
 
 ---


### PR DESCRIPTION
#3533 /simplify 후속에서 약속한 BACKLOG 갱신.

- **#72** (E2E `setTimeout` → readiness poll): PR #3532 로 해결 → strike-through + 결과 기록. 실제 구현은 `200 까지`가 아니라 **임의 HTTP 응답 = bind 완료** (error-overlay fixture 가 500/에러 HTML 반환하므로) — 항목 설명과 실제 거동 차이를 정확히 반영.
- **#74** 신규: `waitForServer` 가 `packages/core/test/cli/helpers.ts` · `tests/integration/.../devserver-sse-mcp.test.ts` 인라인 · `tests/e2e/tests/wait-for-server.ts` 3곳에 중복. 워크스페이스 분리 + `bun:test`↔Playwright 런너 결합으로 직접 import 불가 → runner-agnostic 공유 모듈 추출이 선행돼야 단일화 가능. #3533 /simplify 리유즈 에이전트가 식별, 범위 초과로 보류한 부채를 추적용으로 기록.

docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)