### PR TITLE
fix(flow): object type proto 프로퍼티 modifier 미지원 — strip 출력 오염

### DIFF
--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -997,3 +997,19 @@ test "Flow: trailing %checks 선언문 회귀 가드 (#3527)" {
     defer r.deinit();
     try std.testing.expectEqualStrings("function f(x){return!!x;}", r.output);
 }
+
+test "Flow: object type `proto` property modifier stripped" {
+    var r = try e2eFlow(std.testing.allocator, "type T = { proto p: string }; let v: T = ({});");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let v=({});", r.output);
+}
+
+test "Flow: `proto` with variance + `proto` as key (회귀 가드)" {
+    var r1 = try e2eFlow(std.testing.allocator, "type U = { proto +q: number }; let w: U = ({});");
+    defer r1.deinit();
+    try std.testing.expectEqualStrings("let w=({});", r1.output);
+    // `proto` 자체가 키인 경우는 modifier 아님 — 정상 strip 유지.
+    var r2 = try e2eFlow(std.testing.allocator, "type P = { proto: string }; let z: P = ({});");
+    defer r2.deinit();
+    try std.testing.expectEqualStrings("let z=({});", r2.output);
+}

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -920,6 +920,17 @@ fn parseFlowObjectMembers(self: *Parser, terminator: Kind) ParseError2!ast_mod.N
 fn parseFlowTypeMember(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
 
+    // Flow `proto` 프로퍼티 modifier (`{ proto p: T }` — prototype property).
+    // strip 전용 — 토큰만 소비하고 실제 key 파싱으로 진행. `proto` 가 key 자체인
+    // 경우(`{ proto: T }`/`{ proto?: T }`/`{ proto(): R }`/`{ proto<T>(): R }`)와
+    // 구분: 뒤따르는 토큰이 `:`/`?`/`(`/`<` 면 key, 그 외면 modifier.
+    if (self.isContextual("proto")) {
+        const next = try self.peekNextKind();
+        if (next != .colon and next != .question and next != .l_paren and next != .l_angle) {
+            try self.advance(); // consume `proto` modifier
+        }
+    }
+
     // Variance marker: `+key` covariant (output position) → readonly 등가로 매핑.
     // `-key` contravariant (input position) → 현재 PropertySignatureFlags 에 별도 비트
     // 없음, 무시 (codegen view config 미사용 — RN spec 에서 거의 안 쓰임).


### PR DESCRIPTION
## 배경

Flow 파서 **재감사**(babel-flow 756 픽스처 코퍼스 + Hermes/Metro 대조, 카테고리별 대표 실픽스처 광역 probe → 실출력 직접 스캔)로 발견된 실 버그.

## 버그

`type T = { proto p: string }; let v: T = ({});` (표준 Flow, babel-flow `proto-props` 픽스처) → ZNTC strip 출력 `p:string;;let v=({});` **(오염)**. `{ proto +q: number }` 도 동일 (`+q;;number;;` 누출).

루트커즈: `parseFlowTypeMember` 가 Flow `proto`(prototype property) modifier 미인식 → `proto` 를 property key 로 오소비 → 멤버 파싱 derail, 나머지 누출.

## 변경 (`src/parser/flow.zig`, flow_ 독립·strip 전용)

변성(`+/-`)과 동일하게 `proto` 를 modifier 로 선소비. **`proto` 가 key 자체**인 경우(`{proto:T}`/`{proto?:T}`/`{proto():R}`/`{proto<T>():R}`)와 discriminate — 뒤 토큰이 `:`/`?`/`(`/`<` 면 key. `isContextual("proto")` (파일 내 modifier 처리 ~20곳 관례 일관).

## 검증 (TDD)

- RED 재현 → GREEN. 가드 3종: proto+key, proto+variance, **proto-as-key 회귀 가드**
- Flow 124/124 · Debug + **ReleaseFast** 전체 **5315/5319 / 0 fail** (4 skip baseline, 무회귀)
- `/simplify`: discriminator 전 케이스(`proto proto`/`proto [k]`/`proto ...` 등) 완전성·type-context only·peekNext 안전 전수 검증 → 결함 0

## 재감사 메타

같은 재감사에서 `function foo(this:number=2){}` / `class C{field:*=null}` "의심"은 **babel error/lexer-stress 픽스처로 실버그 아님**을 TDD-repro 로 확인(정상 케이스 `function foo(this:number){}` 등은 이미 정상 strip). TDD-first 가 non-bug 수정을 또 차단(일관 교훈).

🤖 Generated with [Claude Code](https://claude.com/claude-code)