### PR TITLE
fix(flow): declare namespace 미지원 — strip 출력 NS 누출

### DIFF
--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -556,6 +556,28 @@ test "Flow: declare module.exports stripped" {
     try std.testing.expectEqualStrings("let x=1;", r.output);
 }
 
+test "Flow: declare namespace stripped (Hermes declare-namespace.js)" {
+    var r = try e2eFlowModule(std.testing.allocator, "declare namespace NS {}\nlet x = 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+
+    // 본문에 declare/import 가 섞인 ambient namespace 도 통째 strip
+    var r2 = try e2eFlowModule(
+        std.testing.allocator,
+        "declare namespace N { declare const a: number; import type T from \"TM\"; }\nlet y = 2;",
+    );
+    defer r2.deinit();
+    try std.testing.expectEqualStrings("let y=2;", r2.output);
+
+    // 중첩 brace 도 balanced skip
+    var r3 = try e2eFlowModule(
+        std.testing.allocator,
+        "declare namespace O { declare const o: {| a: number |}; }\nlet z = 3;",
+    );
+    defer r3.deinit();
+    try std.testing.expectEqualStrings("let z=3;", r3.output);
+}
+
 test "Flow: interface declaration stripped" {
     var r = try e2eFlow(std.testing.allocator, "interface Foo { x: number; y: string; }\nlet x = 1;");
     defer r.deinit();

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -1720,20 +1720,18 @@ pub fn parseFlowDeclareStatement(self: *Parser) ParseError2!NodeIndex {
         if (next == .string_literal or next == .identifier) {
             try self.advance(); // skip 'module'
             try self.advance(); // skip name
-            if (self.current() == .l_curly) {
-                // balanced brace skip
-                try self.advance(); // skip '{'
-                var depth: u32 = 1;
-                while (depth > 0 and self.current() != .eof) {
-                    switch (self.current()) {
-                        .l_curly => depth += 1,
-                        .r_curly => depth -= 1,
-                        else => {},
-                    }
-                    if (depth > 0) try self.advance();
-                }
-                try self.expect(.r_curly);
-            }
+            try skipBalancedBraces(self);
+            return NodeIndex.none;
+        }
+    }
+
+    // declare namespace NS { ... } — ambient namespace, 본문 전체 type-only → 통째 strip
+    if (self.isContextual("namespace")) {
+        const next = try self.peekNextKind();
+        if (next == .identifier) {
+            try self.advance(); // skip 'namespace'
+            try self.advance(); // skip name
+            try skipBalancedBraces(self);
             return NodeIndex.none;
         }
     }


### PR DESCRIPTION
## 배경

RN/Metro 권위 Flow 파서(Hermes) 코퍼스 전수조사 (Refs #3536) 1/6.

## 버그

`declare namespace NS {}` / `declare namespace N { declare const a: number; import type T from "TM"; }` (유효 Flow, Hermes `references/hermes/test/Parser/flow/declare-namespace.js`, non-error 픽스처) → ZNTC strip 출력에 `NS;` 누출 **(오염)**.

루트커즈: `parseFlowDeclareStatement` 가 `declare module`/`declare export`/`declare component`/`declare opaque` 등은 처리하나 **`declare namespace` 분기 부재** → fallthrough `parseStatement` 가 `namespace NS {}` 를 식별자 표현식 문(`NS;`)으로 오파싱.

## 변경 (`src/parser/flow.zig`, flow_ 독립·strip 전용)

- `declare module "name" {...}` 와 동형 `declare namespace <id> {...}` 분기 추가 — 본문 전체가 ambient type-only 이므로 `skipBalancedBraces` 로 통째 strip, `NodeIndex.none` 반환.
- `peekNextKind() == .identifier` 가드로 `declare namespace;`/`: T`/`= x` (namespace 라는 이름의 var/type) 오발 방지 (Hermes `check(namespaceIdent_) + need(identifier)` 미러).
- 기존 `declare module` 분기의 인라인 brace-skip 도 동일 `skipBalancedBraces` 헬퍼로 정리 — **동작 무변경**, copy-paste 제거 (`/simplify` reuse 지적 반영).

## 검증 (TDD)

- RED 재현(`NS;` 누출 확인) → GREEN.
- 가드 3종: 빈 본문 / declare+import 혼합 본문 / 중첩 brace(`{| a:number |}`).
- Flow 전체 + `declare module` 회귀 0. Debug + **ReleaseFast** 전체 **0 fail**.
- `/simplify`: 통합 1-에이전트 — MED reuse(기존 `skipBalancedBraces` 미사용) 지적 반영해 신규 헬퍼 제거·기존 것 재사용. 오라클(declare-namespace.js 중첩/`import type` 본문) 정합 확인.
