### PR TITLE
fix(flow): enum of bigint base 미인식 — strip 출력 오염

### DIFF
--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -800,6 +800,27 @@ test "Flow enum: of boolean → callable" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "Off:false") != null);
 }
 
+test "Flow enum: of bigint → callable with bigint values (Hermes enum.js)" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\enum Big of bigint { Low = 1n, High = 10n }
+    );
+    defer r.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "const Big=require(\"flow-enums-runtime\")({") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "Low:1n") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "High:10n") != null);
+    // bigint 가 멤버명으로 오파싱되어 누출되지 않아야 함 (RED 회귀 가드)
+    try std.testing.expect(std.mem.indexOf(u8, r.output, "bigint:") == null);
+}
+
+test "Flow enum: of bigint empty body → callable (Hermes `enum E of bigint {}`)" {
+    var r = try e2eFlow(std.testing.allocator,
+        \\enum E of bigint {}
+        \\let x = 1;
+    );
+    defer r.deinit();
+    try std.testing.expectEqualStrings("const E=require(\"flow-enums-runtime\")({});let x=1;", r.output);
+}
+
 test "Flow enum: usage — member access / cast helper 호출 정합" {
     // `flow-enums-runtime` callable 결과는 RN core 의 `X.cast(value)` 호출 호환.
     // 본 테스트는 codegen 단계만 — 실제 cast 호출 동작은 flow-enums-runtime 의 책임.

--- a/src/codegen/type_runtime.zig
+++ b/src/codegen/type_runtime.zig
@@ -305,6 +305,13 @@ fn emitFlowEnumDefaultValue(self: anytype, base_type: u32, member_name: []const 
             const slice = std.fmt.bufPrint(&buf, "{d}", .{auto_idx}) catch unreachable;
             try self.write(slice);
         },
+        // Flow 는 bigint enum 멤버에 명시 `= Nn` 을 강제(default 불가)하므로 정상
+        // 입력에선 unreachable — exhaustive 보장 + 방어값(number 동형 + `n`).
+        .bigint => {
+            var buf: [17]u8 = undefined;
+            const slice = std.fmt.bufPrint(&buf, "{d}n", .{auto_idx}) catch unreachable;
+            try self.write(slice);
+        },
         .boolean => try self.write("false"),
     }
 }

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -2153,6 +2153,7 @@ pub const FlowEnumBaseType = enum(u32) {
     number = 2,
     boolean = 3,
     symbol = 4,
+    bigint = 5,
 };
 
 pub fn parseFlowEnumDeclaration(self: *Parser) ParseError2!NodeIndex {
@@ -2221,6 +2222,8 @@ fn parseFlowEnumBaseType(self: *Parser) ParseError2!FlowEnumBaseType {
         .boolean
     else if (std.mem.eql(u8, text, "symbol"))
         .symbol
+    else if (std.mem.eql(u8, text, "bigint"))
+        .bigint
     else
         .none;
     if (kind != .none) try self.advance();


### PR DESCRIPTION
## 배경

RN/Metro 권위 Flow 파서(Hermes) 전수조사 (Refs #3536) 2/6.

## 버그

`enum E of bigint { A = 1n, B = 2n }` / `enum E of bigint {}` (유효 Flow, Hermes `references/hermes/test/Parser/flow/enum.js` 의 `enum E of bigint {}`, non-error 픽스처) → ZNTC strip 출력 `const E=require("flow-enums-runtime")({bigint:Symbol("bigint")});` **(오염)**.

루트커즈: `parseFlowEnumBaseType` 가 `string/number/boolean/symbol` 만 인식, **`bigint` base 미처리** → `bigint` 토큰이 enum 멤버명으로 오파싱.

## 변경 (`src/parser/flow.zig`·`src/codegen/type_runtime.zig`, flow_ 독립·strip 전용)

- `FlowEnumBaseType` 에 `bigint = 5` 추가.
- `parseFlowEnumBaseType` 에 `bigint` 분기 (기존 else-if 체인 관례 일관).
- `emitFlowEnumDefaultValue` switch 에 `.bigint` 분기 — Flow 가 bigint 멤버 명시값(`= Nn`)을 강제하므로 정상 입력에선 unreachable, exhaustive 보장 + 방어값(number 동형 + `n`).
- `is_mirrored` 는 string-gated 유지 → `enum E of bigint {}` 는 `({})` (Mirrored 아님, Hermes `EnumBigIntBody` ≠ `EnumStringBody` 정합).

## 검증 (TDD)

- RED 재현(`bigint:Symbol` 오염) → GREEN.
- 가드: 명시 `Low=1n,High=10n` 값 정합 + `bigint:` 누출 음성가드 + empty-body exact-string + 후행문(`let x=1;`) 파서 desync 회복 확인.
- enum 회귀 0. Debug + **ReleaseFast** 전체 **0 fail**.
- `/simplify`: 통합 1-에이전트 **APPROVE**. FlowEnumBaseType 분기 사이트 전수(is_mirrored string-gated·transformer opaque pass·switch exhaustive) + Hermes 오라클(`= 1n` 강제·no auto-default·no Mirrored) 교차검증. 블로킹 0.
