### PR TITLE
fix(flow): renders 타입 연산자 미지원 — strip 출력 피연산자 누출

### DIFF
--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -368,6 +368,54 @@ test "Flow: declare export hook stripped" {
     try std.testing.expectEqualStrings("let x=1;", r.output);
 }
 
+test "Flow: renders type operator stripped (Hermes component-syntax/renders.js)" {
+    // type alias RHS 의 renders 타입 — 통째 strip
+    var r = try e2eFlow(std.testing.allocator, "type A = renders B;\nlet x = 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+
+    // renders (B | C) | null — renders 는 prefix 결합, | null 은 union 으로 wrap
+    var r2 = try e2eFlow(std.testing.allocator, "type A = renders (B | C) | null;\nlet y = 2;");
+    defer r2.deinit();
+    try std.testing.expectEqualStrings("let y=2;", r2.output);
+
+    // renders ?number — nullable 피연산자
+    var r3 = try e2eFlow(std.testing.allocator, "type A = renders ?number;\nlet z = 3;");
+    defer r3.deinit();
+    try std.testing.expectEqualStrings("let z=3;", r3.output);
+
+    // renders React.Node — qualified 피연산자
+    var r4 = try e2eFlow(std.testing.allocator, "type A = renders React.Node;\nlet w = 4;");
+    defer r4.deinit();
+    try std.testing.expectEqualStrings("let w=4;", r4.output);
+
+    // 파라미터 타입 위치의 renders — component lowering 시 타입만 strip
+    var r5 = try e2eFlow(std.testing.allocator, "component Foo(bar: renders A) {}");
+    defer r5.deinit();
+    try std.testing.expectEqualStrings("function Foo({bar:bar}){}", r5.output);
+}
+
+test "Flow: bare `renders` as generic type-arg (회귀 가드 — 연산자 오발 금지)" {
+    // `renders` 가 단독 type-arg (닫는 `>`/`>>`/`>>>`) → 일반 type reference,
+    // renders 연산자로 오발해 `>` 를 피연산자로 소비하면 안 됨.
+    var r = try e2eFlow(std.testing.allocator, "type X = Array<renders>;\nlet a = 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let a=1;", r.output);
+
+    var r2 = try e2eFlow(std.testing.allocator, "type X = Array<Array<renders>>;\nlet b = 2;");
+    defer r2.deinit();
+    try std.testing.expectEqualStrings("let b=2;", r2.output);
+
+    var r3 = try e2eFlow(std.testing.allocator, "type X = A<B<C<renders>>>;\nlet c = 3;");
+    defer r3.deinit();
+    try std.testing.expectEqualStrings("let c=3;", r3.output);
+
+    // bare `renders` 가 union 멤버 / 단독 (식별자) 인 경우도 불변
+    var r4 = try e2eFlow(std.testing.allocator, "type X = renders | number;\nlet d = 4;");
+    defer r4.deinit();
+    try std.testing.expectEqualStrings("let d=4;", r4.output);
+}
+
 test "Flow: mixed declare export sequence stripped" {
     var r = try e2eFlowModule(
         std.testing.allocator,

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -271,6 +271,22 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
         });
     }
 
+    // renders T / renders? T / renders* T — Flow component-syntax 렌더 타입 연산자.
+    // 피연산자는 prefix precedence → `renders (B|C) | null` 은 renders 가 (B|C) 에
+    // 결합되고 `| null` 은 union 으로 wrap (Hermes parsePrefixTypeAnnotationFlow).
+    // 피연산자 없는 bare `renders` 는 일반 type reference 이므로 연산자 아님.
+    if (self.current() == .identifier and self.isContextual("renders") and
+        try rendersHasOperand(self))
+    {
+        _ = try eatRendersOperator(self);
+        _ = try parsePrefixType(self);
+        return try self.ast.addNode(.{
+            .tag = .flow_literal_type,
+            .span = span,
+            .data = .{ .none = 0 },
+        });
+    }
+
     // infer T — conditional type의 타입 추론 변수
     if (self.current() == .identifier and self.isContextual("infer")) {
         try self.advance(); // skip 'infer'
@@ -1263,12 +1279,33 @@ fn skipBalancedBraces(self: *Parser) !void {
     return skipBalanced(self, .l_curly, .r_curly);
 }
 
-/// `renders Type` / `renders? Type` / `renders* Type` 절이 있으면 소비.
+/// `renders` / `renders?` / `renders*` 연산자 토큰을 소비. 소비 시 true.
+/// 피연산자 타입은 caller 가 자신의 precedence 로 파싱 — trailing(return-position)
+/// 은 parseType, prefix type-operator 위치는 parsePrefixType (Hermes
+/// parseRenderTypeOperator 와 동일한 토큰/피연산자 분리).
+fn eatRendersOperator(self: *Parser) ParseError2!bool {
+    if (self.current() != .identifier or !self.isContextual("renders")) return false;
+    try self.advance(); // skip 'renders'
+    _ = try self.eat(.question);
+    _ = try self.eat(.star);
+    return true;
+}
+
+/// `renders` 다음 토큰이 타입 피연산자를 시작하는지 — terminator 면 피연산자
+/// 없음(= `renders` 라는 이름의 일반 type reference) 이므로 연산자 아님.
+fn rendersHasOperand(self: *Parser) ParseError2!bool {
+    return switch (try self.peekNextKind()) {
+        // `.r_angle`/`.shift_right`/`.shift_right3` — `Array<renders>` 등 generic
+        // type-arg 의 단독 `renders` (닫는 `>`/`>>`/`>>>`) 도 피연산자 없음.
+        .semicolon, .comma, .r_paren, .r_curly, .r_bracket, .eq, .pipe, .amp, .colon, .arrow, .eof, .r_angle, .shift_right, .shift_right3 => false,
+        else => true,
+    };
+}
+
+/// `renders Type` / `renders? Type` / `renders* Type` 절이 있으면 소비
+/// (trailing return-position — 피연산자는 parseType precedence).
 fn trySkipRendersClause(self: *Parser) !void {
-    if (self.current() == .identifier and self.isContextual("renders")) {
-        try self.advance();
-        _ = try self.eat(.question);
-        _ = try self.eat(.star);
+    if (try eatRendersOperator(self)) {
         _ = try parseType(self);
     }
 }


### PR DESCRIPTION
## 배경

RN/Metro 권위 Flow 파서(Hermes) 전수조사 (Refs #3536) 3/6.

## 버그

`type A = renders B;` / `type A = renders (B | C) | null;` / `type A = renders ?number;` / `type A = renders React.Node;` / `component Foo(bar: renders A) {}` (유효 Flow, Hermes `references/hermes/test/Parser/flow/component-syntax/renders.js`, non-error 픽스처) → renders 피연산자 타입이 strip 출력에 누출 (`type A = renders B;` → `B;`, `component Foo(bar: renders A) {}` → 본문에 `A;;`).

루트커즈: 타입 그래머에 `renders` 연산자 부재 — trailing return-position `trySkipRendersClause` 만 존재해 type-alias RHS / param-type 위치의 `renders X` 미처리.

## 변경 (`src/parser/flow.zig`, flow_ 독립·strip 전용)

- `parsePrimaryType` 에 인접 `keyof` 와 동형 `renders` 연산자 분기 추가. 피연산자 = `parsePrefixType` precedence → `renders (B|C) | null` 은 renders 가 `(B|C)` 에 결합, `| null` 은 outer `parseUnionType` 으로 wrap (Hermes `parseRenderTypeOperator` + `parsePrefixTypeAnnotationFlow` 정합).
- 토큰 소비를 `eatRendersOperator` 헬퍼로 추출 → 기존 `trySkipRendersClause`(trailing, 피연산자 `parseType` 유지·back-compat) 와 공유 (중복 제거).
- `rendersHasOperand` terminator 가드로 bare `renders`(일반 type reference) 연산자 오발 방지. **`/simplify` HIGH 적발 반영**: `Array<renders>` 등 generic type-arg 단독 `renders` 의 닫는 `>`/`>>`/`>>>`(`.r_angle`/`.shift_right`/`.shift_right3`) 도 terminator 에 포함 — 미포함 시 `>` 를 피연산자로 오소비해 유효 Flow 회귀.

## 검증 (TDD)

- RED 재현(`B;` 누출) → GREEN. renders.js 5형태 + param-type lowering.
- 회귀 가드: `Array<renders>` / 중첩 `Array<Array<renders>>` / `A<B<C<renders>>>` / `renders | number` (union 멤버).
- `/simplify`: 통합 1-에이전트 — **HIGH** generic-arg closing-angle 회귀 적발(empirically 재현·main baseline 대조) → 수정+가드. 외부참조 주석 질의는 in-file 선례(인접 `infer` 블록 등)로 **위반 아님** 확정. 5형태 오라클 교차검증 PASS.
- Flow 전체 + Debug + **ReleaseFast** 전체 **0 fail**.
