### PR TITLE
fix(flow): const + variance type-param 순서 미지원 — strip 출력 오염

### DIFF
--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -522,6 +522,33 @@ test "Flow: type alias with generic stripped" {
     try std.testing.expectEqualStrings("let x=1;", r.output);
 }
 
+test "Flow: const + variance type parameter (Hermes function-typeparams.js)" {
+    // const +T (const → variance 순서) — Hermes function-typeparams.js:141
+    var r = try e2eFlow(std.testing.allocator, "(function<const +T>(): void {});");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("(function(){});", r.output);
+
+    // const -T (contravariant)
+    var r2 = try e2eFlow(std.testing.allocator, "(function<const -T>(): void {});");
+    defer r2.deinit();
+    try std.testing.expectEqualStrings("(function(){});", r2.output);
+
+    // 함수 선언 + class 의 const +T
+    var r3 = try e2eFlow(std.testing.allocator, "function f<const +T>(): void {}\nclass C<const -U> {}");
+    defer r3.deinit();
+    try std.testing.expectEqualStrings("function f(){}class C{}", r3.output);
+
+    // const +T: bound (constraint 동반)
+    var r4 = try e2eFlow(std.testing.allocator, "function g<const +T: string>(): void {}");
+    defer r4.deinit();
+    try std.testing.expectEqualStrings("function g(){}", r4.output);
+
+    // 회귀 가드: const T (variance 無) / +T (const 無) 기존 동작 불변
+    var r5 = try e2eFlow(std.testing.allocator, "(function<const T>(): void {});\n(function<+U>(): void {});");
+    defer r5.deinit();
+    try std.testing.expectEqualStrings("(function(){});(function(){});", r5.output);
+}
+
 test "Flow: opaque type stripped" {
     var r = try e2eFlow(std.testing.allocator, "opaque type ID = string;\nlet x = 1;");
     defer r.deinit();

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -593,14 +593,15 @@ pub fn parseTypeParameterDeclaration(self: *Parser) ParseError2!NodeIndex {
 fn parseTypeParameter(self: *Parser) ParseError2!NodeIndex {
     const span = self.currentSpan();
 
+    // Flow modifier 순서: const → variance → name (`<const +T>`).
+    // const type parameter: <const T> / <const +T> — const modifier 스킵.
+    if (self.current() == .kw_const) {
+        try self.advance(); // skip 'const'
+    }
+
     // variance: +T (covariant) 또는 -T (contravariant)
     if (self.current() == .plus or self.current() == .minus) {
         try self.advance();
-    }
-
-    // Flow const type parameter: <const T: {...}> — const modifier를 건너뛴다.
-    if (self.current() == .kw_const) {
-        try self.advance(); // skip 'const'
     }
 
     try self.advance(); // type param name


### PR DESCRIPTION
## 배경

RN/Metro 권위 Flow 파서(Hermes) 전수조사 (Refs #3536) 5/6.

## 버그

`(function<const +T>(): void {});` / `(function<const -T>(): void {});` (유효 Flow, Hermes `references/hermes/test/Parser/flow/function-typeparams.js:141`, non-error `%hermesc` 픽스처) → strip 출력 `(function(T){();;void {};;});` **(오염)**.

루트커즈: `parseTypeParameter` 가 variance(`+`/`-`)를 `const` 보다 **먼저** 검사 → `const +T` 에서 `const` skip 후 `try self.advance()` 가 `+` 를 type-param name 으로 오소비 → 파싱 derail.

## 변경 (`src/parser/flow.zig`, flow_ 독립·strip 전용)

Hermes `parseTypeParamFlow` (JSParserImpl-flow.cpp:4706 — `const` → variance → name 순) 와 1:1 정합하도록 `const`↔variance 검사 블록 순서 교체. `+const T`(variance-first)는 Flow syntax error 이므로 무회귀 — 기존 `<+T>`/`<-T>`/`<const T>`/`<T>`/`<const +T: Bound>`/`<const T = Default>` 전 경로 보존.

## 검증 (TDD)

- RED 재현(`(function(T){...` 누출) → GREEN.
- covariant `+` / contravariant `-` / 함수선언+class / constraint(`const +T: string`) + **기존 경로 회귀 가드**(`<const T>` variance無 / `<+U>` const無).
- Flow 전체 + Debug + **ReleaseFast** 전체 **0 fail**.
- `/simplify`: 통합 1-에이전트 **APPROVE**. ① 순서 swap strictly correct·valid-input 무회귀(Hermes 단일 const-first 경로·`+const T`=syntax error) ② sibling latent 없음 — parser 전체에 `parseTypeParameter` 단 1개, component/hook type-param 도 동일 경로, object/mapped variance 는 const modifier 부재로 비유사. nit cosmetic only.
