### PR TITLE
fix(flow): 무효 enum 입력 codegen OOB 패닉 — graceful 견고화

### DIFF
--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -919,6 +919,41 @@ test "Flow enum: of bigint → callable with bigint values (Hermes enum.js)" {
     try std.testing.expect(std.mem.indexOf(u8, r.output, "bigint:") == null);
 }
 
+test "Flow enum: 무효 입력 graceful — codegen OOB 패닉 금지" {
+    // `enum A : string {B,}` — 무효 Flow (Hermes: "'{' expected in enum
+    // declaration"). 깨진 enum AST → codegen OOB 패닉(crash) 이었음.
+    var r = try e2eFlow(std.testing.allocator, "enum A : string { B, }\nlet x = 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+
+    // of-base 없이 `:` + body
+    var r2 = try e2eFlow(std.testing.allocator, "enum A : number { B }\nlet y = 2;");
+    defer r2.deinit();
+    try std.testing.expectEqualStrings("let y=2;", r2.output);
+
+    // 무효 head, body 없음
+    var r3 = try e2eFlow(std.testing.allocator, "enum A : string;\nlet z = 3;");
+    defer r3.deinit();
+    try std.testing.expectEqualStrings("let z=3;", r3.output);
+
+    // 유효 braces 내 무효 멤버(키 없음) — codegen .left OOB 방어. 크래시 금지.
+    var r4 = try e2eFlow(std.testing.allocator, "enum E { , A }\nlet a = 1;");
+    defer r4.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r4.output, "let a=1;") != null);
+
+    var r5 = try e2eFlow(std.testing.allocator, "enum F { = 1 }\nlet b = 2;");
+    defer r5.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r5.output, "let b=2;") != null);
+
+    // 정상 enum 회귀 가드 (불변)
+    var r6 = try e2eFlow(std.testing.allocator, "enum E { A, B }\nlet w = 4;");
+    defer r6.deinit();
+    try std.testing.expectEqualStrings(
+        "const E=require(\"flow-enums-runtime\")({A:Symbol(\"A\"),B:Symbol(\"B\")});let w=4;",
+        r6.output,
+    );
+}
+
 test "Flow enum: of bigint empty body → callable (Hermes `enum E of bigint {}`)" {
     var r = try e2eFlow(std.testing.allocator,
         \\enum E of bigint {}

--- a/src/codegen/type_runtime.zig
+++ b/src/codegen/type_runtime.zig
@@ -253,9 +253,14 @@ pub fn emitFlowEnum(self: anytype, node: Node) std.mem.Allocator.Error!void {
 
     if (is_mirrored) {
         try self.write(".Mirrored([");
-        for (members, 0..) |raw_idx, i| {
-            if (i > 0) try self.writeByte(',');
+        var emitted: u32 = 0;
+        for (members) |raw_idx| {
             const member = self.ast.getNode(@enumFromInt(raw_idx));
+            // 키 없는(무효) 멤버 — member.binary.left 무조건 getNode 하므로
+            // .none 이면 OOB. 무효 입력에서만 발생, skip 으로 견고화.
+            if (member.data.binary.left.isNone()) continue;
+            if (emitted > 0) try self.writeByte(',');
+            emitted += 1;
             const member_name_node = self.ast.getNode(member.data.binary.left);
             const member_name = Ast.stripStringQuotes(self.ast.getText(member_name_node.span));
             try self.writeByte('"');
@@ -268,9 +273,12 @@ pub fn emitFlowEnum(self: anytype, node: Node) std.mem.Allocator.Error!void {
 
     try self.write("({");
     var auto_idx: u32 = 0;
-    for (members, 0..) |raw_idx, i| {
-        if (i > 0) try self.writeByte(',');
+    var emitted: u32 = 0;
+    for (members) |raw_idx| {
         const member = self.ast.getNode(@enumFromInt(raw_idx));
+        if (member.data.binary.left.isNone()) continue; // 무효 멤버 방어 (위와 동일)
+        if (emitted > 0) try self.writeByte(',');
+        emitted += 1;
         const member_name_node = self.ast.getNode(member.data.binary.left);
         const member_name = Ast.stripStringQuotes(self.ast.getText(member_name_node.span));
         try self.write(member_name);

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -2224,7 +2224,22 @@ pub fn parseFlowEnumDeclaration(self: *Parser) ParseError2!NodeIndex {
         base_type = try parseFlowEnumBaseType(self);
     }
 
-    try self.expect(.l_curly);
+    // 무효 enum head — `enum Name [of base]` 뒤는 반드시 `{` (Hermes:
+    // "'{' expected in enum declaration"). `{` 가 없으면 깨진 멤버 AST 를
+    // 만들지 않고(codegen OOB 방지) 진단 기록 후 잔여를 안전 지점까지 strip.
+    if (self.current() != .l_curly) {
+        try self.expect(.l_curly); // rich 진단만 기록 (커서 불변)
+        // `{`/`;`/eof 까지 skip. `{`/`;` 둘 다 없으면(예: `enum A : string\n
+        // let x=1`) 다음 `;` 까지 over-skip — 무효 입력의 허용 가능한 손실
+        // (크래시·무한루프 없음, Hermes 도 동일 위치에서 에러).
+        while (self.current() != .l_curly and self.current() != .semicolon and
+            self.current() != .eof) : (try self.advance())
+        {}
+        if (self.current() == .l_curly) try skipBalancedBraces(self);
+        _ = try self.eat(.semicolon);
+        return NodeIndex.none;
+    }
+    try self.advance(); // consume '{'
 
     const scratch_top = self.saveScratch();
     while (self.current() != .r_curly and self.current() != .eof) {
@@ -2239,7 +2254,8 @@ pub fn parseFlowEnumDeclaration(self: *Parser) ParseError2!NodeIndex {
         }
 
         const member = try parseFlowEnumMember(self);
-        try self.scratch.append(self.allocator, member);
+        // 무효 멤버(키 파싱 실패)는 append 안 함 — 깨진 enum AST 생성 회피.
+        if (!member.isNone()) try self.scratch.append(self.allocator, member);
         if (!try self.eat(.comma) and !try self.eat(.semicolon)) break;
 
         if (try self.ensureLoopProgress(loop_guard_pos)) break;
@@ -2288,6 +2304,9 @@ fn parseFlowEnumBaseType(self: *Parser) ParseError2!FlowEnumBaseType {
 fn parseFlowEnumMember(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
     const name = try self.parsePropertyKey();
+    // parsePropertyKey 는 무효 토큰서 진단+advance 후 `.invalid` 태그 노드를
+    // 반환(.none 아님). 키 없는 멤버는 무효 → 노드 미생성(caller append 스킵).
+    if (self.ast.getNode(name).tag == .invalid) return NodeIndex.none;
 
     var init_val = NodeIndex.none;
     if (try self.eat(.eq)) {


### PR DESCRIPTION
## 배경

RN/Metro 권위 Flow 파서(Hermes) 전수조사 (Closes #3536) **6/6 (최종)**.

## 버그 (견고성 — crash)

`enum A : string { B, }` (**무효 Flow** — Hermes `references/hermes/test/Parser/flow/enum-type-annot.js` 는 `(! %hermesc)` 에러 픽스처, "`'{' expected in enum declaration`" 기대) 입력 시 ZNTC 가 graceful error 가 아니라 **codegen OOB 패닉(crash, `index out of bounds: 4294967295`)** at `src/codegen/type_runtime.zig` `emitFlowEnum`.

루트커즈: `parseFlowEnumDeclaration` 의 `expect(.l_curly)` 가 진단만 기록(커서 불변, `parser.zig:521`) → body loop 가 잘못된 토큰서 실행 → `parsePropertyKey` 가 무효 토큰서 `.invalid` 노드 반환 → `.left` 가 transformer 거쳐 `.none` 인 깨진 `flow_enum_member` → codegen `getNode(member.binary.left)` OOB.

## 변경 (`src/parser/flow.zig`·`src/codegen/type_runtime.zig`, flow_ 독립·strip 전용)

1. **파서 head 가드**: `enum N [of b]` 뒤 `{` 없으면 rich 진단 기록 후 안전 지점(`{`/`;`/eof)까지 strip → `NodeIndex.none` (Hermes 와 동일 위치 에러). `{`/`;` 둘 다 없는 경우 다음 `;` 까지 over-skip — 무효 입력의 허용 가능한 손실(크래시·무한루프 없음, 주석 명시).
2. **파서 멤버 가드**: `parsePropertyKey` 가 `.invalid` 태그 반환 시 멤버 노드 미생성 → loop append 스킵 (clean strip).
3. **codegen 결정적 방어(크래시 지점)**: `emitFlowEnum` 의 Mirrored/일반 루프가 `member.binary.left.isNone()` 멤버를 skip — 모든 malformed 경로(head/멤버, parser/transformer 무관) OOB 차단.

## 검증 (TDD)

- RED(패닉 재현) → GREEN.
- 가드: 무효 head 3종(`enum A : string {B,}` / `: number {B}` / `: string;`) + **유효 braces 내 무효 멤버**(`{ , A }` / `{ = 1 }`) + 정상 enum 회귀.
- Flow 전체 + Debug + **ReleaseFast** 전체 **0 fail**.

## `/simplify` (통합 1-에이전트) — HIGH 적발·반영

초기 멤버 가드가 `.isNone()` 검사였으나 `parsePropertyKey` 실제 반환은 `.invalid` 태그 → **dead-code**, `{ , A }` 등 동일-클래스 패닉 잔존(에이전트 empirically 재현). → codegen `.left` 방어(진짜 크래시 지점) + 파서 `.invalid` 검출로 결정적 해소, 재현 케이스 전수 테스트화, 허위 주석 정정. 유효 enum 무회귀(26/26·전수 trace) 확인.
