### PR TITLE
fix(flow): 내부슬롯 @@name/[[name]] 미지원 — crash + strip 오염

### DIFF
--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -663,6 +663,53 @@ test "Flow: declare module.exports stripped" {
     try std.testing.expectEqualStrings("let x=1;", r.output);
 }
 
+test "Flow: 내부슬롯 @@name — 타입위치 strip / 런타임 key 보존 (babel iterator)" {
+    // declare class / interface / type / object-type 의 @@iterator → 통째 strip
+    var r = try e2eFlow(std.testing.allocator, "declare class A { @@iterator(): Iterator<File>; }\nlet x = 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let x=1;", r.output);
+
+    var r2 = try e2eFlow(std.testing.allocator, "interface A { @@asyncIterator(): Iterator<File>; }\nlet y = 2;");
+    defer r2.deinit();
+    try std.testing.expectEqualStrings("let y=2;", r2.output);
+
+    var r3 = try e2eFlow(std.testing.allocator, "type T = { @@iterator: () => string };\nlet z = 3;");
+    defer r3.deinit();
+    try std.testing.expectEqualStrings("let z=3;", r3.output);
+
+    // 런타임 class/object 의 @@iterator 메서드 — babel 처럼 key 보존(미변환), CRASH 금지
+    var r4 = try e2eFlow(std.testing.allocator, "class T { @@asyncIterator(){} }");
+    defer r4.deinit();
+    try std.testing.expectEqualStrings("class T{@@asyncIterator(){}}", r4.output);
+
+    var r5 = try e2eFlow(std.testing.allocator, "let o = { @@iterator() {} };");
+    defer r5.deinit();
+    try std.testing.expectEqualStrings("let o={@@iterator(){}};", r5.output);
+}
+
+test "Flow: 내부슬롯 [[name]] — object/interface 타입 strip (babel internal-slot)" {
+    var r = try e2eFlow(std.testing.allocator, "type T = { [[foo]](): X };\nlet a = 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let a=1;", r.output);
+
+    var r2 = try e2eFlow(std.testing.allocator, "type T = { [[foo]]?: X };\nlet b = 2;");
+    defer r2.deinit();
+    try std.testing.expectEqualStrings("let b=2;", r2.output);
+
+    var r3 = try e2eFlow(std.testing.allocator, "interface I { [[foo]](): X }\nlet c = 3;");
+    defer r3.deinit();
+    try std.testing.expectEqualStrings("let c=3;", r3.output);
+
+    // variance prefix `+[[foo]]` + declare-class `static [[foo]]` (회귀 가드)
+    var r4 = try e2eFlow(std.testing.allocator, "type T = { +[[foo]](): X };\nlet d = 4;");
+    defer r4.deinit();
+    try std.testing.expectEqualStrings("let d=4;", r4.output);
+
+    var r5 = try e2eFlow(std.testing.allocator, "declare class C { static [[foo]]: T }\nlet e = 5;");
+    defer r5.deinit();
+    try std.testing.expectEqualStrings("let e=5;", r5.output);
+}
+
 test "Flow: declare namespace stripped (Hermes declare-namespace.js)" {
     var r = try e2eFlowModule(std.testing.allocator, "declare namespace NS {}\nlet x = 1;");
     defer r.deinit();

--- a/src/lexer/scanner.zig
+++ b/src/lexer/scanner.zig
@@ -450,7 +450,7 @@ pub const Scanner = struct {
                 ';' => .semicolon,
                 ',' => .comma,
                 '~' => .tilde,
-                '@' => .at,
+                '@' => self.scanAt(),
                 ':' => .colon,
 
                 // 후속 문자에 따라 분기하는 토큰 — 추후 PR에서 구현
@@ -775,6 +775,19 @@ pub const Scanner = struct {
     // ====================================================================
     // 복합 연산자 스캔
     // ====================================================================
+
+    /// `@@name` (Flow internal-slot well-known-symbol, 예: `@@iterator`)는
+    /// babel `@babel/parser` flow 와 동일하게 단일 식별자 토큰(text=`@@name`)
+    /// 으로 lex. JS/TS 에선 `@@` 인접이 항상 무효(decorator 는 단일 `@`)이므로
+    /// flow-gate 없이 안전. 그 외 단일 `@` 는 decorator 토큰(`.at`).
+    fn scanAt(self: *Scanner) Kind {
+        if (self.peek() == '@' and isAsciiIdentStart(self.peekAt(1))) {
+            _ = self.advance(); // 2번째 '@' 소비
+            self.scanIdentifierTail(); // 슬롯 이름 (span 은 첫 '@' 부터 → text=`@@name`)
+            return .identifier;
+        }
+        return .at;
+    }
 
     fn scanDot(self: *Scanner) Kind {
         if (self.peek() == '.' and self.peekAt(1) == '.') {

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -986,6 +986,22 @@ fn parseFlowTypeMember(self: *Parser) ParseError2!NodeIndex {
         );
     }
 
+    // Flow internal slot: `[[name]]` / `[[name]]?: T` / `[[name]](): R`
+    // (babel ObjectTypeInternalSlot). variance(`+`/`-`)는 위 prefix 에서 소비;
+    // `static [[..]]` 는 declare-class 가 parseStatement 로 통째 strip 되어
+    // 여기 도달 안 함. strip 전용 — balanced `[[..]]` + `?` + 메서드/프롭 소비.
+    if (self.current() == .l_bracket and try self.peekNextKind() == .l_bracket) {
+        try skipBalanced(self, .l_bracket, .r_bracket); // `[[ name ]]` 통째
+        _ = try self.eat(.question);
+        if (self.current() == .l_paren) {
+            try skipBalancedParens(self);
+            if (try self.eat(.colon)) _ = try parseType(self);
+        } else if (try self.eat(.colon)) {
+            _ = try parseType(self);
+        }
+        return NodeIndex.none;
+    }
+
     // Indexer (`[key: T]: U`) 또는 call/construct signature (`(args): R`) — skip.
     if (self.current() == .l_bracket) {
         try skipBalanced(self, .l_bracket, .r_bracket);


### PR DESCRIPTION
## 배경

메트로 Babel(`@babel/parser` flow plugin) 권위 코퍼스 전수조사 (Refs #3544) **family A/8**.

## 버그 (crash + 오염)

Flow **internal slots** 2형태 — `references/babel-flow/.../fixtures/flow/iterator/*`·`internal-slot/*` (전부 non-throws = @babel/parser/Metro 수용 유효 Flow):

- `@@name`(`@@iterator`/`@@asyncIterator`): babel 은 단일 `Identifier`(name=`"@@iterator"`). declare class/interface/object-type(타입 → strip) + 런타임 `class T{@@iterator(){}}`/`{@@iterator(){}}`. **런타임 class 케이스가 parser 미인식 → 멤버 key=`.none` → stage3 decorator transform OOB 패닉(crash)**.
- `[[name]]`(babel `ObjectTypeInternalSlot`): `type T={[[foo]](): X}` 등 → `();;X;;` **누출**.

## 변경 (`src/lexer/scanner.zig`·`src/parser/flow.zig`, flow_ 독립·strip 전용)

- **A1 lexer `scanAt`**: `@`+`@`+ident-start → 단일 `.identifier`(span 첫 `@`부터 → text=`@@name`), babel 동형. `@@` 인접은 JS/TS 항상 무효(decorator=단일 `@`)이므로 flow-gate 불필요·안전. 그 외 단일 `@` 는 decorator(`.at`) 불변.
- **A2 `parseFlowTypeMember`**: `current==.l_bracket && peekNext==.l_bracket` → balanced `[[..]]` + optional `?` + 메서드`(...)[:Ret]`/프롭`:Type` 소비 후 `.none`(strip). variance(`+`/`-`)는 기존 prefix, `static [[..]]` 는 declare-class 가 `parseStatement` 로 통째 strip.

## 검증 (TDD)

- RED(crash 재현)→GREEN.
- 가드: declare-class/interface/type/object-type strip + 런타임 key 보존(`class T{@@asyncIterator(){}}`/`let o={@@iterator(){}}` — babel 미변환 정합) + `[[]]` 9형태(`+[[foo]]` variance / `static [[foo]]` declare-class 포함).
- Flow 전체 + Debug + **ReleaseFast** 전체 **0 fail** (lexer 변경 decorator 무회귀).
- `/simplify`: 통합 1-에이전트 **APPROVE-WITH-NITS**. 핵심 2체크 definitive **YES** — ① 무조건 `@@`→identifier 안전(decorator grammar 상 `@@foo`=항상 syntax error·corpus 무충돌·span/text 정합) ② A2 9형태 전부 zero-leak·`[[`/`[` branch 분리 타당(internal-slot 는 `?`+method-form 필요). LOW nit(주석 over-claim) 반영 + variance/static 단위 가드 추가.
