### PR TITLE
fix(flow): object type generic call property 미지원 — strip 오염

### DIFF
--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -663,6 +663,24 @@ test "Flow: declare module.exports stripped" {
     try std.testing.expectEqualStrings("let x=1;", r.output);
 }
 
+test "Flow: object type generic call property (babel call-properties/4)" {
+    // `{ <T>(x: T): number; }` — generic call sig. 타입주석만 strip
+    // (var a 는 실 변수 → `var a;` 유지, babel flow-strip 동일).
+    var r = try e2eFlow(std.testing.allocator, "var a : { <T>(x: T): number; };\nlet x = 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var a;let x=1;", r.output);
+
+    // interface 의 generic call sig — interface 는 통째 strip
+    var r2 = try e2eFlow(std.testing.allocator, "interface A { <T>(x: T): number; }\nlet y = 2;");
+    defer r2.deinit();
+    try std.testing.expectEqualStrings("let y=2;", r2.output);
+
+    // 회귀 가드: 비-generic call sig (기존 정상) 불변
+    var r3 = try e2eFlow(std.testing.allocator, "var b : { (): number; y: string };\nlet z = 3;");
+    defer r3.deinit();
+    try std.testing.expectEqualStrings("var b;let z=3;", r3.output);
+}
+
 test "Flow: 내부슬롯 @@name — 타입위치 strip / 런타임 key 보존 (babel iterator)" {
     // declare class / interface / type / object-type 의 @@iterator → 통째 strip
     var r = try e2eFlow(std.testing.allocator, "declare class A { @@iterator(): Iterator<File>; }\nlet x = 1;");

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -1008,6 +1008,16 @@ fn parseFlowTypeMember(self: *Parser) ParseError2!NodeIndex {
         if (try self.eat(.colon)) _ = try parseType(self);
         return NodeIndex.none;
     }
+    // Generic call signature: `<T>(args): R` (babel — type-param 동반 call
+    // property). type-params 소비 후 call-sig 와 동일 처리·strip.
+    if (self.isAtOpeningAngleBracket()) {
+        _ = try parseTypeParameterDeclaration(self);
+        if (self.current() == .l_paren) {
+            try skipBalancedParens(self);
+            if (try self.eat(.colon)) _ = try parseType(self);
+        }
+        return NodeIndex.none;
+    }
     if (self.current() == .l_paren) {
         try skipBalancedParens(self);
         if (try self.eat(.colon)) _ = try parseType(self);


### PR DESCRIPTION
## 배경
메트로 Babel(@babel/parser flow) 전수조사 (Refs #3544) family B/8.

## 버그
`var a:{ <T>(x:T):number }` / `interface A{ <T>(x:T):number }` (유효 Flow, babel `call-properties/4` non-throws) → `parseFlowTypeMember` 가 `(args):R` call-sig 는 처리하나 **선행 type-param `<T>` 미처리** → `x;;number;;` 누출.

## 변경 (`src/parser/flow.zig`, flow_ 독립·strip 전용)
call-sig 분기 앞에 generic call signature 분기: `isAtOpeningAngleBracket` → `parseTypeParameterDeclaration` 소비 후 call-sig 와 동일 처리·strip. `new<T>()` construct-sig 는 별도 경로(key=`new`) 불변.

## 검증 (TDD)
- RED→GREEN. `var a:{...}` 는 실변수 → `var a;` 유지(babel flow-strip 동형), interface 는 통째 strip. 비-generic call-sig 회귀 가드.
- Flow·Debug+**ReleaseFast** 전체 **0 fail**.
- `/simplify` 통합 1-에이전트 **APPROVE**(블로킹0·nit0): 전 generic call-sig 형태 zero-leak·construct-sig/plain-call-sig/indexer/variance 무회귀 definitive YES.