### PR TITLE
fix(flow): arrow 반환타입 중첩 =>/generic 미지원 — strip 오염

### DIFF
--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -663,6 +663,42 @@ test "Flow: declare module.exports stripped" {
     try std.testing.expectEqualStrings("let x=1;", r.output);
 }
 
+test "Flow: arrow 반환타입에 중첩 =>/generic (babel anon-fn-no-parens good_05/15)" {
+    // (x): (number => 123) => 123 — RT=괄호 anon fn type, `=>123`=arrow body.
+    var r = try e2eFlow(std.testing.allocator, "var f = (x): (number => 123) => 123;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("var f=x=>123;", r.output);
+
+    // (): Array<(string) => number> => [] — generic arg 안 fn type
+    var r2 = try e2eFlow(std.testing.allocator, "let x = (): Array<(string) => number> => [];");
+    defer r2.deinit();
+    try std.testing.expectEqualStrings("let x=()=>[];", r2.output);
+
+    // 회귀 가드: 단순 반환타입 arrow (기존 정상) 불변
+    var r3 = try e2eFlow(std.testing.allocator, "var g = (): string | number => 123;");
+    defer r3.deinit();
+    try std.testing.expectEqualStrings("var g=()=>123;", r3.output);
+
+    // 회귀 가드: 괄호 함수타입 type-alias (기존 정상) 불변
+    var r4 = try e2eFlow(std.testing.allocator, "type A = (string => boolean) => number;\nlet h = 4;");
+    defer r4.deinit();
+    try std.testing.expectEqualStrings("let h=4;", r4.output);
+
+    // 회귀 가드 (/simplify HIGH): empty-paren / named-param / comma fn-type RT
+    // — 내부 fn-type 반환타입이 outer arrow body 를 흡수하지 않아야 함.
+    var r5 = try e2eFlow(std.testing.allocator, "var a = (): (x: number) => R => 123;");
+    defer r5.deinit();
+    try std.testing.expectEqualStrings("var a=()=>123;", r5.output);
+
+    var r6 = try e2eFlow(std.testing.allocator, "var b = (): () => void => 123;");
+    defer r6.deinit();
+    try std.testing.expectEqualStrings("var b=()=>123;", r6.output);
+
+    var r7 = try e2eFlow(std.testing.allocator, "var c = (): (a: number, b: string) => number => 123;");
+    defer r7.deinit();
+    try std.testing.expectEqualStrings("var c=()=>123;", r7.output);
+}
+
 test "Flow: object type generic call property (babel call-properties/4)" {
     // `{ <T>(x: T): number; }` — generic call sig. 타입주석만 strip
     // (var a 는 실 변수 → `var a;` 유지, babel flow-strip 동일).

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -533,6 +533,12 @@ pub fn parseTypeArguments(self: *Parser) ParseError2!NodeIndex {
     const start = self.currentSpan().start;
     try self.expectOpeningAngleBracket();
 
+    // `<...>` 안의 `=>` 는 항상 함수타입(arrow body 와 무관) — outer 가
+    // arrow-return context 였어도 reset. `(): Array<(string) => number> => []`.
+    const prev_in_ret = self.flow_in_return_type;
+    self.flow_in_return_type = false;
+    defer self.flow_in_return_type = prev_in_ret;
+
     const scratch_top = self.saveScratch();
     while (!self.isAtClosingAngleBracket() and self.current() != .eof) {
         const loop_guard_pos = self.scanner.token.span.start;
@@ -639,11 +645,21 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
     const prev_allow_cond = self.flow_allow_conditional_type;
     self.flow_allow_conditional_type = true;
     defer self.flow_allow_conditional_type = prev_allow_cond;
+    // 괄호 내부의 `=>` 는 함수타입 화살표로 명확(outer arrow body 와 무관) →
+    // reset. 단, 닫는 `)` 뒤의 `=>`(이 paren 그룹 자체가 fn type 인지)는
+    // arrow-return 최상위에서 arrow body 와 모호하므로 outer 값(prev_in_ret)
+    // 으로 판정. `(x): (number => 123) => 123` — RT=`(number=>123)`, `=>123`=body.
+    const prev_in_ret = self.flow_in_return_type;
+    self.flow_in_return_type = false;
+    defer self.flow_in_return_type = prev_in_ret;
 
+    // fn-type 의 반환타입 파싱은 outer context(prev_in_ret) 로 — 그 trailing
+    // `=>` 는 outer arrow body 와 같은 모호성 레벨(param/content 만 reset 유지).
     // 빈 괄호: () => Type
     if (self.current() == .r_paren) {
         try self.advance();
         try self.expect(.arrow);
+        self.flow_in_return_type = prev_in_ret;
         const return_type = try parseType(self);
         return makeFunctionType(self, start, NodeIndex.none, .{ .start = 0, .len = 0 }, return_type);
     }
@@ -665,6 +681,7 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
         const params = try parseFunctionTypeParamList(self);
         try self.expect(.r_paren);
         try self.expect(.arrow);
+        self.flow_in_return_type = prev_in_ret;
         const return_type = try parseType(self);
         return makeFunctionType(self, start, NodeIndex.none, params, return_type);
     }
@@ -699,6 +716,7 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
         }
         try self.expect(.r_paren);
         try self.expect(.arrow);
+        self.flow_in_return_type = prev_in_ret;
         const return_type = try parseType(self);
         const items = self.scratch.items[scratch_top..];
         const params = try self.ast.addNodeList(items);
@@ -710,7 +728,7 @@ fn parseParenOrFunctionType(self: *Parser) ParseError2!NodeIndex {
     // return type context에서는 `=>` 가 arrow function body이므로 function type으로 해석하지 않는다.
     if (self.current() == .r_paren) {
         try self.advance();
-        if (self.current() == .arrow and !self.flow_in_return_type) {
+        if (self.current() == .arrow and !prev_in_ret) {
             try self.advance();
             const return_type = try parseType(self);
             const params = try self.ast.addNodeList(&.{first_type});


### PR DESCRIPTION
## 배경
메트로 Babel(@babel/parser flow) 전수조사 (Refs #3544) family C/8.

## 버그
`var f = (x): (number => 123) => 123;` (babel `anonymous-function-no-parens-types/good_05`, 유효) → `var f=x=>123;;;123;` 누출. `let x = (): Array<(string) => number> => []` (good_15) 도 누출.

루트커즈(instrumentation 확정): arrow 반환타입을 `flow_in_return_type=true` 로 파싱(top-level `=>` 를 arrow body 로 보호)하나, **반환타입 자체의 괄호/제네릭 안 `=>`(함수타입)까지 억제** → `(number => 123)` inner `=>` 미파싱 → 누출.

## 변경 (`src/parser/flow.zig`, flow_ 독립·strip 전용)
`parseParenOrFunctionType`/`parseTypeArguments` 가 내부 content 파싱 동안 `flow_in_return_type=false` reset. 단 ① 닫는 `) =>`→fn-type 게이트는 outer `prev_in_ret` ② empty-paren/is_definite_fn/comma 경로의 fn-type **반환타입** parseType 은 `prev_in_ret` 복원(trailing `=>` 는 outer arrow body 와 동일 모호성 레벨). `parseTypeArguments` 는 `<...>` 안 `=>` 가 항상 함수타입이라 전체 reset 안전.

## 검증 (TDD)
- RED→GREEN. 가드: g05/g15 + 단순-RT/괄호-fn-type-alias 회귀 + **/simplify HIGH 가 지목한 empty-paren/named-param/comma fn-type RT 3종**.
- Flow·Debug+**ReleaseFast** 전체 **0 fail**.
- `/simplify` 통합 1-에이전트: 초기 blanket reset 이 3경로 내부-반환 parseType 를 노출하는 **HIGH 회귀 적발** → `prev_in_ret` 복원으로 정공법 해소·해당 3 shape 전수 테스트화. parseTypeArguments reset 전 caller 안전 확인.

### 범위 외 (별도 루트커즈)
`const x=():*=>{}` (existential `*` RT + `*=>` lexer greedy tokenization, deprecated·낮은 ROI) — 본 PR 무영향(main 과 출력 동일). epic #3544 에 별도 기록.