### PR TITLE
fix(flow): interface/of 식별자 위치 미지원 — strip 오염

### DIFF
--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -663,6 +663,51 @@ test "Flow: declare module.exports stripped" {
     try std.testing.expectEqualStrings("let x=1;", r.output);
 }
 
+test "Flow: interface/of 식별자 위치 (babel interfaces-as-identifier/issue-10675)" {
+    // class interface {} — interface 가 클래스 이름
+    var r = try e2eFlow(std.testing.allocator, "class interface {}");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("class interface{}", r.output);
+
+    // interface ? a : b — interface 가 ternary test 식별자
+    var r2 = try e2eFlow(std.testing.allocator, "interface ? true : false;\nlet a = 1;");
+    defer r2.deinit();
+    try std.testing.expectEqualStrings("interface?true:false;let a=1;", r2.output);
+
+    // member expression — foo.interface / interface.foo
+    var r3 = try e2eFlow(std.testing.allocator, "foo.interface;\ninterface.foo;");
+    defer r3.deinit();
+    try std.testing.expectEqualStrings("foo.interface;interface.foo;", r3.output);
+
+    // class of<T> {} — of 가 클래스 이름 + type param strip (babel issue-10675)
+    var r4 = try e2eFlow(std.testing.allocator, "class of<T> {}");
+    defer r4.deinit();
+    try std.testing.expectEqualStrings("class of{}", r4.output);
+
+    // 회귀 가드: 진짜 interface 선언은 여전히 통째 strip
+    var r5 = try e2eFlow(std.testing.allocator, "interface I { x: number }\nlet b = 2;");
+    defer r5.deinit();
+    try std.testing.expectEqualStrings("let b=2;", r5.output);
+
+    // 회귀 가드: enum of string (of 는 enum base) 불변
+    var r6 = try e2eFlow(std.testing.allocator, "enum E of string { A, B }\nlet c = 3;");
+    defer r6.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r6.output, "flow-enums-runtime") != null);
+    try std.testing.expect(std.mem.indexOf(u8, r6.output, "let c=3;") != null);
+
+    // interface of<T> {} — interface 이름이 contextual keyword `of`
+    // (babel regression/issue-10675-interface, non-throws). 통째 strip.
+    var r7 = try e2eFlow(std.testing.allocator, "interface of<T> {}\nlet d = 4;");
+    defer r7.deinit();
+    try std.testing.expectEqualStrings("let d=4;", r7.output);
+
+    // 회귀 가드: strict-reserved(`let`)는 클래스 이름으로 silent-accept 금지
+    // (canBeFlowDeclName 제외 → main 처럼 정상 named class 로 안 나옴).
+    var r8 = try e2eFlow(std.testing.allocator, "class let {}");
+    defer r8.deinit();
+    try std.testing.expect(std.mem.indexOf(u8, r8.output, "class let{}") == null);
+}
+
 test "Flow: arrow 반환타입에 중첩 =>/generic (babel anon-fn-no-parens good_05/15)" {
     // (x): (number => 123) => 123 — RT=괄호 anon fn type, `=>123`=arrow body.
     var r = try e2eFlow(std.testing.allocator, "var f = (x): (number => 123) => 123;");

--- a/src/lexer/token.zig
+++ b/src/lexer/token.zig
@@ -382,6 +382,21 @@ pub const Kind = enum(u8) {
         return self == .identifier or (self.isKeyword() and !self.isReservedKeyword());
     }
 
+    /// class/interface 선언 이름(BindingIdentifier) 자리에 올 수 있는 토큰인지
+    /// — babel `@babel/parser` flow 와 동일: `.identifier`, 비-strict-reserved
+    /// contextual keyword(`of`/`async`/`from`/`type` 등), 그리고 Flow 가
+    /// contextually 허용하는 `interface`(`class interface {}`/`interface of {}`
+    /// non-throws). strict-reserved(`let`/`static`/`implements`/`yield`/
+    /// `package`/`private`/`protected`/`public`)는 제외 — strict 인 class/
+    /// interface 이름으로 무효(babel 도 거부). yield/await 는 generator/async/
+    /// module context 규칙이 있어 caller 가 별도 처리.
+    pub fn canBeFlowDeclName(self: Kind) bool {
+        if (self == .kw_interface) return true;
+        return (self == .identifier or
+            (self.canBeBindingName() and !self.isStrictModeReserved())) and
+            self != .kw_yield and self != .kw_await;
+    }
+
     /// 숫자 리터럴인지 (decimal..hex_bigint)
     pub fn isNumericLiteral(self: Kind) bool {
         return self.inRange(.decimal, .hex_bigint);

--- a/src/parser/declaration.zig
+++ b/src/parser/declaration.zig
@@ -369,13 +369,16 @@ pub fn parseClassWithDecorators(self: *Parser, tag: Tag, decorators: NodeList) P
     const saved_strict_mode = self.is_strict_mode;
     self.is_strict_mode = true;
 
-    // 클래스 이름 (선언은 필수, 표현식은 선택)
-    // kw_yield/kw_await는 컨텍스트에 따라 식별자로 사용 가능
+    // 클래스 이름 (선언은 필수, 표현식은 선택). kw_yield/kw_await 는 context 별
+    // 식별자 가능(자체 절). canBeFlowDeclName: 비-strict-reserved contextual
+    // keyword + Flow-lenient `interface`/`of` 수용, strict-reserved(let/static/
+    // implements 등)는 제외 — main 의 거부 동작 보존.
     var name = NodeIndex.none;
     if (self.current() == .identifier or
         (self.current() == .kw_yield and !self.ctx.in_generator) or
         (self.current() == .kw_await and !self.ctx.in_async and (!self.is_module or self.in_namespace)) or
-        self.current() == .escaped_keyword or self.current() == .escaped_strict_reserved)
+        self.current() == .escaped_keyword or self.current() == .escaped_strict_reserved or
+        self.current().canBeFlowDeclName())
     {
         name = try self.parseBindingIdentifier();
     }

--- a/src/parser/statement.zig
+++ b/src/parser/statement.zig
@@ -288,11 +288,13 @@ pub fn parseStatement(self: *Parser) ParseError2!NodeIndex {
             break :blk parseExpressionOrLabeledStatement(self);
         },
         .kw_interface => blk_iface: {
-            // interface\nFoo {} → 'interface' expression statement + 'Foo' + '{}' (ASI)
-            // interface Foo {} → TS interface declaration
-            // esbuild: !p.lexer.HasNewlineBefore
+            // interface Foo {} / interface of<T> {} → interface declaration.
+            // 그 외 — `interface ? a : b`, `interface.foo`, newline(ASI) — 는
+            // `interface` 식별자 표현식(babel: contextual keyword). class 이름과
+            // 동일 predicate(canBeFlowDeclName) 로 대칭 — next 가 선언 이름일
+            // 때만 선언(babel `issue-10675-interface` `interface of<T>{}` 유효).
             const next_iface = try self.peekNext();
-            if (next_iface.has_newline_before) {
+            if (next_iface.has_newline_before or !next_iface.kind.canBeFlowDeclName()) {
                 break :blk_iface parseExpressionOrLabeledStatement(self);
             }
             if (self.is_flow) {


### PR DESCRIPTION
## 배경
메트로 Babel(@babel/parser flow) 전수조사 (Refs #3544) family D/8.

## 버그 (babel 픽스처 전부 non-throws=유효)
`class interface {}`→`class{interface;;}` · `interface ? a : b`→`;true;;false;` · `foo.interface;/interface.foo;` 오염 · `class of<T> {}`/`interface of<T> {}`(regression/issue-10675)→`class{of;;}`.

루트커즈: ① statement.zig `kw_interface` 가 next 무관 항상 interface decl ② declaration.zig class name 이 contextual keyword 미수용.

## 변경 (`token.zig`·`statement.zig`·`declaration.zig`, flow_ 독립·strip 전용)
`canBeFlowDeclName` 헬퍼(babel flow 동형: identifier ∪ 비-strict-reserved contextual keyword ∪ Flow-lenient `interface`; strict-reserved `let/static/implements/yield/...` 제외 — class/interface 는 strict 라 babel 도 거부, **main 거부 동작 보존**). interface-dispatch + class-name 이 **동일 predicate 로 대칭**.

## 검증 (TDD)
- RED→GREEN. 가드: class interface/of<T>, interface?:, member-expr, **interface of<T>{}**(이름=of), real-interface strip, enum-of 불변, **strict-reserved `class let{}` silent-accept 금지**.
- Flow·Debug+**ReleaseFast** 전체 **0 fail**.
- `/simplify` 통합 1-에이전트 **HIGH 2건 적발**(build-verified): ① 가드가 class-name 과 비대칭이라 `interface of<T>{}`(babel issue-10675-interface) 거부 ② `canBeBindingName` 이 strict-reserved 까지 수용→`class let{}` silent-accept(main 거부) 회귀. → `canBeFlowDeclName` 정밀 predicate(오라클 매칭)로 2사이트 대칭·strict-reserved 제외, 해당 regression 전수 테스트화.