### PR TITLE
fix(flow): inline interface 타입 extends list 미지원 — strip 오염

### DIFF
--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -663,6 +663,31 @@ test "Flow: declare module.exports stripped" {
     try std.testing.expectEqualStrings("let x=1;", r.output);
 }
 
+test "Flow: inline interface type extends list (babel interface-types)" {
+    // type T = interface extends X, Y { p: string } — multiple extends
+    var r = try e2eFlow(std.testing.allocator, "type T = interface extends X, Y { p: string };\nlet a = 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let a=1;", r.output);
+
+    // 단일/무 extends/empty (회귀 가드)
+    var r2 = try e2eFlow(std.testing.allocator, "type T = interface extends X { p: string };\nlet b = 2;");
+    defer r2.deinit();
+    try std.testing.expectEqualStrings("let b=2;", r2.output);
+
+    var r3 = try e2eFlow(std.testing.allocator, "type T = interface { p: string };\nlet c = 3;");
+    defer r3.deinit();
+    try std.testing.expectEqualStrings("let c=3;", r3.output);
+
+    var r4 = try e2eFlow(std.testing.allocator, "type T = interface {};\nlet d = 4;");
+    defer r4.deinit();
+    try std.testing.expectEqualStrings("let d=4;", r4.output);
+
+    // generic heritage
+    var r5 = try e2eFlow(std.testing.allocator, "type T = interface extends A<number>, B { m(): void };\nlet e = 5;");
+    defer r5.deinit();
+    try std.testing.expectEqualStrings("let e=5;", r5.output);
+}
+
 test "Flow: interface/of 식별자 위치 (babel interfaces-as-identifier/issue-10675)" {
     // class interface {} — interface 가 클래스 이름
     var r = try e2eFlow(std.testing.allocator, "class interface {}");

--- a/src/parser/flow.zig
+++ b/src/parser/flow.zig
@@ -369,9 +369,19 @@ fn parsePrimaryType(self: *Parser) ParseError2!NodeIndex {
                 .data = .{ .none = 0 },
             });
         },
-        // interface {} — Flow inline interface type
+        // interface [extends T (, T)*] { ... } — Flow inline interface type.
+        // strip 전용: optional heritage list + body 통째 소비.
         .kw_interface => {
             try self.advance();
+            if (self.current() == .kw_extends) {
+                try self.advance();
+                while (self.current() != .l_curly and self.current() != .eof) {
+                    const loop_guard_pos = self.scanner.token.span.start;
+                    _ = try parsePrimaryType(self); // heritage 항목(`X`/`X<T>`)
+                    if (!try self.eat(.comma)) break;
+                    if (try self.ensureLoopProgress(loop_guard_pos)) break;
+                }
+            }
             if (self.current() == .l_curly) {
                 try skipBalancedBraces(self);
             }


### PR DESCRIPTION
## 배경
메트로 Babel(@babel/parser flow) 전수조사 (Refs #3544) family E/8.

## 버그
`type T = interface extends X, Y { p: string }` (유효 Flow, babel `interface-types/extends-multiple` non-throws) → `p:string;` 누출. basic/단일-extends/empty 는 정상(단일은 outer conditional-type fallback 이 우연 흡수).

루트커즈: `parsePrimaryType` 의 inline interface 타입 arm 이 `{...}` 만 skip, optional `extends Type (, Type)*` heritage 미소비.

## 변경 (`src/parser/flow.zig`, flow_ 독립·strip 전용)
`kw_extends` 면 comma-separated heritage list 를 `parsePrimaryType`(per entry — `,`/`{` 미흡수 granularity) 로 소비 후 body skip·strip. 파일 공용 idiom 대로 eof 종료 + `ensureLoopProgress` 가드. interface **선언**(statement.zig) 과 별개 경로(무영향).

## 검증 (TDD)
- RED→GREEN. 가드: multi-extends + 단일/무/empty 회귀 + generic heritage(`A<number>, B`).
- Flow·Debug+**ReleaseFast** 전체 **0 fail**.
- `/simplify` 통합 1-에이전트 **APPROVE-WITH-NITS**: correctness·무회귀 definitive YES, parsePrimaryType granularity 정합·선언경로 무영향 확인. LOW nit(파일 comma-list idiom 의 ensureLoopProgress+eof 가드) 반영(provably non-hang 였으나 defense-in-depth).