### PR TITLE
fix(flow): import type 예약어 local 미지원 — strip 오염

### DIFF
--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -663,6 +663,33 @@ test "Flow: declare module.exports stripped" {
     try std.testing.expectEqualStrings("let x=1;", r.output);
 }
 
+test "Flow: import type with reserved-word local (babel imports/import-type-keyword)" {
+    // import type switch from 'foo' — type-only, local=`switch`(예약어). 통째 strip.
+    var r = try e2eFlowModule(std.testing.allocator, "import type switch from 'foo';\nlet a = 1;");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("let a=1;", r.output);
+
+    // 회귀 가드: 일반 type-import 불변
+    var r2 = try e2eFlowModule(std.testing.allocator, "import type { T } from 'm';\nlet b = 2;");
+    defer r2.deinit();
+    try std.testing.expectEqualStrings("let b=2;", r2.output);
+
+    var r3 = try e2eFlowModule(std.testing.allocator, "import type T from 'm';\nlet c = 3;");
+    defer r3.deinit();
+    try std.testing.expectEqualStrings("let c=3;", r3.output);
+
+    // 회귀 가드: `import type, { foo }` 는 VALUE import (babel importKind=value,
+    // `type`=default 이름) — strip 안 함, 그대로 보존.
+    var r4 = try e2eFlowModule(std.testing.allocator, "import type, { foo } from \"bar\";\nlet d = 4;");
+    defer r4.deinit();
+    try std.testing.expectEqualStrings("import type, {foo} from \"bar\";let d=4;", r4.output);
+
+    // 회귀 가드: `import type from 'm'` 도 VALUE import (`type`=default 이름)
+    var r5 = try e2eFlowModule(std.testing.allocator, "import type from 'm';\nlet e = 5;");
+    defer r5.deinit();
+    try std.testing.expectEqualStrings("import type from \"m\";let e=5;", r5.output);
+}
+
 test "Flow: inline interface type extends list (babel interface-types)" {
     // type T = interface extends X, Y { p: string } — multiple extends
     var r = try e2eFlow(std.testing.allocator, "type T = interface extends X, Y { p: string };\nlet a = 1;");

--- a/src/parser/module.zig
+++ b/src/parser/module.zig
@@ -237,9 +237,12 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
         //   → next가 kw_from이고 그 다음이 string_literal이면 type-only가 아님
         //   → next가 kw_from이고 그 다음이 string이 아니면 type-only
         //     (예: import type from from 'bar' — from이 default import 이름)
-        // 비예약 키워드도 타입 이름으로 유효 (import type async from 'bar')
+        // 키워드(예약어 포함)도 type-only import 의 local 로 유효 — 타입 전용
+        // 바인딩은 erase 되어 reserved-word 런타임 충돌 없음 (babel 동일:
+        // `import type switch from 'foo'` → importKind=type, local=`switch`).
+        // `from`/`,` 는 아래 전용 분기/value-import 판정에 위임(여기서 제외).
         if (next == .l_curly or next == .star or next == .identifier or
-            (next != .kw_from and next.isKeyword() and !next.isReservedKeyword()) or
+            (next != .kw_from and next != .comma and next.isKeyword()) or
             (next == .kw_from and blk: {
                 // 2-token lookahead: from 다음이 string이 아니면 type-only
                 const saved = self.saveState();
@@ -366,9 +369,13 @@ pub fn parseImportDeclaration(self: *Parser) ParseError2!NodeIndex {
     }
 
     // default import: import foo from "module"
-    // contextual keyword (get/set/number/string/object/type 등)도 import 이름으로 유효
+    // contextual keyword (get/set/number/string/object/type 등)도 import 이름으로 유효.
+    // type-only import 는 local 이 erase 되어 예약어(`switch` 등)도 유효 — babel
+    // `import type switch from 'foo'` (importKind=type, local=`switch`).
     var has_default = false;
-    if (self.current().canBeBindingName()) {
+    if (self.current().canBeBindingName() or
+        (is_type_only and self.current().isKeyword()))
+    {
         const next = try self.peekNextKind();
         if (next == .comma or next == .kw_from) {
             const spec_span = self.currentSpan();


### PR DESCRIPTION
## 배경
메트로 Babel(@babel/parser flow) 전수조사 (Refs #3544) family F/8.

## 버그
`import type switch from 'foo';` (유효 Flow, babel `imports/import-type-keyword` non-throws; importKind=type, ImportDefaultSpecifier local=`switch`) → `switch(from){}` 오염.

루트커즈 2곳: ① type-only 판정이 `!isReservedKeyword()` 라 `switch` 거부 ② default-specifier 가 `canBeBindingName()` 라 예약어 local 거부. **type-only binding 은 erase** 되어 예약어 충돌 없음(babel 동일).

## 변경 (`src/parser/module.zig`, flow_ 독립·strip 전용)
① detector: `next != .kw_from and next != .comma and next.isKeyword()` — 예약어 type-only local 수용, `from`/`,` 는 기존 분기/value-import 위임(**`import type from`/`import type, {foo}` 는 babel importKind=value → 보존**). ② default-specifier: `is_type_only and isKeyword()` (type-only 한정 — non-type-only 불변, `import switch from 'x'` 는 main 처럼 에러).

## 검증 (TDD)
- RED→GREEN. 가드: `import type switch` strip + 일반 type-import 불변 + **value-import 비회귀**(`import type, {foo}`/`import type from` exact-string).
- Flow·Debug+**ReleaseFast** 전체 **0 fail**.
- `/simplify` 통합 1-에이전트 **APPROVE-WITH-NITS**: babel `parseMaybeImportPhase` 소스 대조 — value-import 무오탐·non-type-only 바이트동일·type-only local codegen 미도달 **definitive YES**. LOW nit(r4/r5 약한 indexOf)→exact assertion 강화.