### PR TITLE
fix(flow): f<T>(name:Type) generic-call 오판 — strip 오염

### DIFF
--- a/src/codegen/codegen_test/flow.zig
+++ b/src/codegen/codegen_test/flow.zig
@@ -663,6 +663,42 @@ test "Flow: declare module.exports stripped" {
     try std.testing.expectEqualStrings("let x=1;", r.output);
 }
 
+test "Flow: f<T>(name: Type) 는 generic-call 아닌 relational (babel async-arrow-like)" {
+    // async <T>(fn: () => T); — babel: BinaryExpression (async<T)>(fn:()=>T typecast).
+    // generic-call 로는 무효(call arg 에 `name:` 불가) → 누출 없이 relational.
+    var r = try e2eFlow(std.testing.allocator, "async <T>(fn: () => T);");
+    defer r.deinit();
+    try std.testing.expectEqualStrings("async<T>fn;", r.output);
+
+    // async 무관 — 일반 식별자도 동일
+    var r2 = try e2eFlow(std.testing.allocator, "foo <T>(fn: () => T);");
+    defer r2.deinit();
+    try std.testing.expectEqualStrings("foo<T>fn;", r2.output);
+
+    // 회귀 가드: 정상 generic call 은 불변 (`(...)` 가 typecast-paren 아님)
+    var r3 = try e2eFlow(std.testing.allocator, "foo<T>(x);");
+    defer r3.deinit();
+    try std.testing.expectEqualStrings("foo(x);", r3.output);
+
+    var r4 = try e2eFlow(std.testing.allocator, "foo<T>(x, y);\nfoo<U>();");
+    defer r4.deinit();
+    try std.testing.expectEqualStrings("foo(x,y);foo();", r4.output);
+
+    var r5 = try e2eFlow(std.testing.allocator, "const r = ident<number>(value);");
+    defer r5.deinit();
+    try std.testing.expectEqualStrings("const r=ident(value);", r5.output);
+
+    // 회귀 가드: 진짜 async generic arrow (=> 있음) 불변
+    var r6 = try e2eFlow(std.testing.allocator, "const f = async <T>(x: T): T => x;");
+    defer r6.deinit();
+    try std.testing.expectEqualStrings("const f=async x=>x;", r6.output);
+
+    // 회귀 가드: 괄호 typecast 단독 불변
+    var r7 = try e2eFlow(std.testing.allocator, "(fn: () => T);");
+    defer r7.deinit();
+    try std.testing.expectEqualStrings("fn;", r7.output);
+}
+
 test "Flow: import type with reserved-word local (babel imports/import-type-keyword)" {
     // import type switch from 'foo' — type-only, local=`switch`(예약어). 통째 strip.
     var r = try e2eFlowModule(std.testing.allocator, "import type switch from 'foo';\nlet a = 1;");

--- a/src/parser/expression.zig
+++ b/src/parser/expression.zig
@@ -1056,12 +1056,41 @@ fn trySkipTypeArgsSpeculative(self: *Parser, comptime strict: bool, comptime fol
         break :blk follow(self);
     };
 
+    // Flow: `f<T>( name : Type )` 의 `( name :` 는 parenthesized typecast 으로,
+    // generic-call argument 로는 유효하지 않다(call arg 에 `name:` 불가). 따라서
+    // 이 형태는 generic-call 이 아니라 relational `(f < T) > (name: Type)` 이
+    // 유일 해석(babel 동일: type-generics/async-arrow-like 는 BinaryExpression).
+    // type-args 확정을 취소해 `<`/`>` 가 비교 연산자로 처리되게 한다.
+    if (type_args_ok and self.is_flow and self.current() == .l_paren and
+        flowTypecastParenFollows(self))
+    {
+        checkpoint.rollback(self);
+        return false;
+    }
+
     if (type_args_ok) {
         checkpoint.rollbackKeepScanner(self);
     } else {
         checkpoint.rollback(self);
     }
     return type_args_ok;
+}
+
+/// 현재 `(` 직후가 `<simple> :` (parenthesized Flow typecast) 인지 — 2-token
+/// lookahead. call argument 는 `name:` 로 시작할 수 없으므로, 이 형태면
+/// 선행 `<...>` 는 type-args 가 아니라 비교 연산자다. `advance()` 로 전진하나
+/// SpeculationCheckpoint + `defer rollback` 으로 전 경로 scanner/parser 복원.
+fn flowTypecastParenFollows(self: *Parser) bool {
+    const cp = Parser.SpeculationCheckpoint.save(self);
+    defer cp.rollback(self);
+    self.advance() catch return false; // skip '('
+    // typecast 피연산자 시작: identifier / 비예약 keyword / this / string literal
+    const t = self.current();
+    const operand_ok = t == .identifier or t == .kw_this or t == .string_literal or
+        (t.isKeyword() and !t.isReservedKeyword());
+    if (!operand_ok) return false;
+    self.advance() catch return false; // skip operand
+    return self.current() == .colon; // `( name :` → typecast paren
 }
 
 fn followedByParenOnly(self: *const Parser) bool {


### PR DESCRIPTION
## 배경
메트로 Babel(@babel/parser flow) 전수조사 (Closes #3544) family H/8 (최종).

## 버그
`async <T>(fn: () => T);` (유효 Flow, babel `type-generics/async-arrow-like`, output.json **errors 없음**; AST=BinaryExpression `(async<T)>(fn:()=>T typecast)`) → `async(fn);();;T;;` 누출. 격리: async/typecast 무관 — `foo <T>(fn: () => T);` 동일·`(fn:()=>T);` 단독은 정상.

루트커즈(instrumentation 확정): `canFollowTypeArgumentsInExpression` 가 `<T>` 뒤 `(` 면 generic-call 확정(TS/esbuild 휴리스틱), Flow parenthesized typecast `( name : Type )` 미고려.

## 변경 (`src/parser/expression.zig`, flow_ 독립·strip 전용)
`f<T>( name : ...)` 의 `( name :` 는 typecast(call arg 에 `name:` 불가) → generic-call 무효 → relational `(f<T)>(name:T)` 이 유일 해석(babel 동일). `trySkipTypeArgsSpeculative` 에 **flow-mode·`( <simple> :` 한정 가드**(`flowTypecastParenFollows`, SpeculationCheckpoint 비파괴 2-token lookahead) — type-args 확정 취소.

## 검증 (TDD)
- 누출 제거(`async<T>fn;`/`foo<T>fn;`) + 회귀 가드: 정상 generic-call(`foo<T>(x)`/`(x,y)`/`()`/`ident<number>(value)`) 불변, 진짜 async generic arrow 불변, standalone typecast 불변.
- Flow·Debug+**ReleaseFast** 전체 **0 fail**.
- `/simplify` **APPROVE-WITH-NITS**: blast radius=정확히 flow `( name :`(is_flow gate TS 무영향·arrow 선행경로·gencall/new/optional-chain/tagged-template 불변) **definitive YES**, checkpoint 복원·nested sound·valid gencall 오분류 불가 **definitive YES**.