### PR TITLE
feat(docs): ZNTC 지구라트 로고 배선 (favicon + Starlight logo)

### DIFF
--- a/documents/astro.config.mjs
+++ b/documents/astro.config.mjs
@@ -14,6 +14,7 @@ export default defineConfig({
     starlight({
       title: 'ZNTC',
       description: 'Zig Native Transpiler & Compiler',
+      logo: { src: './src/assets/zntc-logo.svg', alt: 'ZNTC' },
       expressiveCode: {
         themes: ['github-dark', 'github-light'],
         styleOverrides: {

--- a/documents/src/assets/zntc-logo.svg
+++ b/documents/src/assets/zntc-logo.svg
@@ -5,6 +5,7 @@
       <stop offset="1" stop-color="#ea580c"/>
     </linearGradient>
   </defs>
+  <!-- 계단식 지구라트 — "Zig"(←ziggurat) 어원 / 네이티브 기반 -->
   <g fill="url(#zntc-zg)">
     <rect x="55" y="22" width="18" height="16" rx="2"/>
     <rect x="44" y="42" width="40" height="16" rx="2"/>


### PR DESCRIPTION
로고 시안(PR #3530, 25종) 중 사용자가 **⑲ 지구라트** 선택 → 문서 사이트 배선.

## 변경
- `documents/src/assets/zntc-logo.svg` 추가 + `astro.config.mjs` Starlight `logo` 키 (아이콘 + 기존 "ZNTC" 텍스트 병기)
- `documents/public/favicon.svg`: Astro 기본 스파클 → 지구라트 교체. 다크/라이트 탭 모두 오렌지 그라디언트로 시인성 확보

## 컨셉
계단식 지구라트 = "Zig"(←ziggurat) 어원 + 네이티브/기반 뉘앙스를 글자 없이. Zig 시그니처 오렌지 `#fbbf24→#ea580c`.

## 검증
SVG xmllint OK · `node --check astro.config.mjs` OK · logo src 경로(`./src/assets/...`, Starlight project-root 기준) 실재 확인.

`/simplify`: 선언 키 1줄 + SVG 에셋(로직 없음) → 정식 3-에이전트 해당 없음.

후속: PR #3530(시안 스크래치)은 선택 완료로 close, 개발 서버 ASCII 배너 로고화는 별도 PR 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)