### PR TITLE
feat(cli): 개발 서버 배너를 지구라트 ASCII 로고로 (web + RN)

### DIFF
--- a/packages/core/bin/banner.mjs
+++ b/packages/core/bin/banner.mjs
@@ -10,6 +10,9 @@ const colors = {
   blue: '\x1b[34m',
   magenta: '\x1b[35m',
   cyan: '\x1b[36m',
+  // ZNTC 브랜드 오렌지 (256-color; 미지원 터미널은 근사색으로 degrade)
+  amber: '\x1b[38;5;214m',
+  orange: '\x1b[38;5;208m',
 };
 
 /**
@@ -55,23 +58,33 @@ function bannerLine(content) {
   return `${colors.cyan}    ║${colors.reset}${' '.repeat(left)}${content}${' '.repeat(right)}${colors.cyan}║${colors.reset}`;
 }
 
-const ZNTC_ASCII = [
-  '███████╗███╗   ██╗████████╗ ██████╗',
-  '╚══███╔╝████╗  ██║╚══██╔══╝██╔════╝',
-  '  ███╔╝ ██╔██╗ ██║   ██║   ██║     ',
-  ' ███╔╝  ██║╚██╗██║   ██║   ██║     ',
-  '███████╗██║ ╚████║   ██║   ╚██████╗',
-  '╚══════╝╚═╝  ╚═══╝   ╚═╝    ╚═════╝',
+// 지구라트 로고 (계단식) — documents 의 zntc-logo.svg / favicon 과 동일 정체성.
+// 6줄 = ZNTC_GRADIENT 6색과 1:1. bannerLine 이 각 줄을 박스 중앙 정렬.
+export const ZNTC_ASCII = [
+  '████████',
+  '██████████████',
+  '████████████████████',
+  '██████████████████████████',
+  '████████████████████████████████',
+  '██████████████████████████████████████',
 ];
 
-const ZNTC_GRADIENT = [
-  colors.yellow,
-  colors.yellow,
-  colors.blue,
-  colors.blue,
-  colors.magenta,
-  colors.magenta,
+export const ZNTC_GRADIENT = [
+  colors.amber,
+  colors.amber,
+  colors.amber,
+  colors.orange,
+  colors.orange,
+  colors.orange,
 ];
+
+// ZNTC_ASCII[i] 는 ZNTC_GRADIENT[i] 로 색칠 — desync 시 undefined 가
+// visibleLen 을 오염시켜 줄 정렬이 깨진다. import 시점 fail-fast.
+if (ZNTC_ASCII.length !== ZNTC_GRADIENT.length) {
+  throw new Error(
+    `ZNTC banner: ZNTC_ASCII(${ZNTC_ASCII.length}) / ZNTC_GRADIENT(${ZNTC_GRADIENT.length}) 길이 불일치`,
+  );
+}
 
 const TAGLINES = {
   web: 'Lightning Fast Web Bundler',

--- a/packages/react-native/src/dev-server/logger.test.ts
+++ b/packages/react-native/src/dev-server/logger.test.ts
@@ -8,7 +8,14 @@ import {
   logInfo,
   logWarn,
   printZntcRnBanner,
+  ZNTC_ASCII as RN_ASCII,
+  ZNTC_GRADIENT as RN_GRADIENT,
 } from './logger.ts';
+// banner.mjs(@zntc/core) 와 ASCII/GRADIENT 는 수동 sync 계약 — drift 자동 차단.
+import {
+  ZNTC_ASCII as CORE_ASCII,
+  ZNTC_GRADIENT as CORE_GRADIENT,
+} from '../../../core/bin/banner.mjs';
 
 let logSpy: ReturnType<typeof mock>;
 let warnSpy: ReturnType<typeof mock>;
@@ -100,8 +107,8 @@ describe('printZntcRnBanner', () => {
   test('version 지정 시 banner 에 포함', () => {
     printZntcRnBanner('0.1.0');
     const out = (logSpy.mock.calls[0] as unknown[])[0] as string;
-    // ZNTC ASCII 로고 (Z 글리프 첫 줄) + 슬로건 + version.
-    expect(out).toContain('███████╗███╗');
+    // 지구라트 ASCII 로고 (최하단 base 타일) + 슬로건 + version.
+    expect(out).toContain('██████████████████████████████████████');
     expect(out).toContain('Lightning Fast React Native Bundler');
     expect(out).toContain('v0.1.0');
   });
@@ -109,7 +116,7 @@ describe('printZntcRnBanner', () => {
   test('version 없음 → version 영역 비움', () => {
     printZntcRnBanner();
     const out = (logSpy.mock.calls[0] as unknown[])[0] as string;
-    expect(out).toContain('███████╗███╗');
+    expect(out).toContain('██████████████████████████████████████');
     expect(out).not.toMatch(/v\d/);
   });
 
@@ -156,5 +163,19 @@ describe('formatLogBadge — RN client console.log forwarding (#2605 audit P2)',
   test('level uppercase 적용', () => {
     expect(formatLogBadge('error')).toContain(' ERROR ');
     expect(formatLogBadge('Warn')).toContain(' WARN ');
+  });
+});
+
+describe('banner ↔ @zntc/core 동기화 (수동 sync 계약 자동 차단)', () => {
+  test('ZNTC_ASCII 가 banner.mjs 와 byte-identical', () => {
+    expect([...RN_ASCII]).toEqual([...CORE_ASCII]);
+  });
+
+  test('ZNTC_GRADIENT 가 banner.mjs 와 동일', () => {
+    expect([...RN_GRADIENT]).toEqual([...CORE_GRADIENT]);
+  });
+
+  test('ASCII ↔ GRADIENT 길이 1:1', () => {
+    expect(RN_ASCII.length).toBe(RN_GRADIENT.length);
   });
 });

--- a/packages/react-native/src/dev-server/logger.ts
+++ b/packages/react-native/src/dev-server/logger.ts
@@ -14,6 +14,9 @@ export const colors = {
   blue: '\x1b[34m',
   magenta: '\x1b[35m',
   cyan: '\x1b[36m',
+  // ZNTC 브랜드 오렌지 (256-color; 미지원 터미널은 근사색으로 degrade)
+  amber: '\x1b[38;5;214m',
+  orange: '\x1b[38;5;208m',
 } as const;
 
 /** Metro 호환 ` INFO ` cyan inverse bold badge. */
@@ -76,23 +79,32 @@ function bannerLine(content: string): string {
   return `${colors.cyan}    ║${colors.reset}${' '.repeat(left)}${content}${' '.repeat(right)}${colors.cyan}║${colors.reset}`;
 }
 
-const ZNTC_ASCII = [
-  '███████╗███╗   ██╗████████╗ ██████╗',
-  '╚══███╔╝████╗  ██║╚══██╔══╝██╔════╝',
-  '  ███╔╝ ██╔██╗ ██║   ██║   ██║     ',
-  ' ███╔╝  ██║╚██╗██║   ██║   ██║     ',
-  '███████╗██║ ╚████║   ██║   ╚██████╗',
-  '╚══════╝╚═╝  ╚═══╝   ╚═╝    ╚═════╝',
+// 지구라트 로고 (계단식) — banner.mjs 와 sync 유지 (양쪽 동시 수정).
+export const ZNTC_ASCII = [
+  '████████',
+  '██████████████',
+  '████████████████████',
+  '██████████████████████████',
+  '████████████████████████████████',
+  '██████████████████████████████████████',
 ] as const;
 
-const ZNTC_GRADIENT = [
-  colors.yellow,
-  colors.yellow,
-  colors.blue,
-  colors.blue,
-  colors.magenta,
-  colors.magenta,
+export const ZNTC_GRADIENT = [
+  colors.amber,
+  colors.amber,
+  colors.amber,
+  colors.orange,
+  colors.orange,
+  colors.orange,
 ] as const;
+
+// ZNTC_ASCII[i] 는 ZNTC_GRADIENT[i] 로 색칠 — desync 시 undefined 가
+// visibleLen 을 오염시켜 줄 정렬이 깨진다. import 시점 fail-fast.
+if (ZNTC_ASCII.length !== ZNTC_GRADIENT.length) {
+  throw new Error(
+    `ZNTC banner: ZNTC_ASCII(${ZNTC_ASCII.length}) / ZNTC_GRADIENT(${ZNTC_GRADIENT.length}) 길이 불일치`,
+  );
+}
 
 /** ZNTC RN dev server 시작 banner — 6줄 ASCII 로고 + 그라디언트 + 박스. */
 export function printZntcRnBanner(version?: string): void {


### PR DESCRIPTION
dev 서버(web/RN) 시작 배너의 figlet식 "ZNTC" 블록글자를 **선택된 지구라트 로고의 ASCII 버전**으로 교체. `documents`의 favicon·Starlight 로고(PR #3552)와 동일 정체성으로 통일.

## 변경
- `packages/core/bin/banner.mjs`(web/CLI) · `packages/react-native/src/dev-server/logger.ts`(RN): `ZNTC_ASCII` → 계단식 6단 지구라트, `ZNTC_GRADIENT` → 브랜드 amber→orange (256-color), `colors`에 `amber`/`orange` 추가. 양쪽 sync.
- `logger.test.ts`: 옛 글리프 단언 갱신.

## /simplify (3-에이전트) 반영
- **[MED]** `ZNTC_ASCII.length !== ZNTC_GRADIENT.length` 시 import 시점 `throw` — desync 시 `undefined`가 `visibleLen`을 오염시켜 줄 정렬이 깨지는 silent 버그를 fail-fast 화 (양쪽 파일).
- **[MED]** 수동 sync 계약이 주석뿐 → 상수 `export` + `logger.test.ts`에 두 파일 `ZNTC_ASCII`/`ZNTC_GRADIENT` **byte-identical parity 테스트** 추가. 드리프트 시 CI 차단.
- **[보류]** `colors`/`bannerLine`/ASCII 중복 — 0.1.0 준비 때 의도적으로 도입된 선재 중복, `@zntc/core`↔`@zntc/react-native` 퍼블리시 경계(런타임 type-only, banner export subpath 없음)로 통합 비현실적. 3개 에이전트 합의로 미조치.

## 검증
web/RN 배너 렌더 박스 정렬 정상 · `logger.test.ts` 21 pass(parity 3 포함) · `banner.mjs` import no-throw · lint 0 errors. 비-TTY/NO_COLOR 경로는 기존대로 plain 한 줄.

🤖 Generated with [Claude Code](https://claude.com/claude-code)