### PR TITLE
fix(cli): dev 배너 무색·성김 해결 — 16-color 전환 + 솔리드 형태

### DIFF
--- a/packages/core/bin/banner.mjs
+++ b/packages/core/bin/banner.mjs
@@ -10,9 +10,10 @@ const colors = {
   blue: '\x1b[34m',
   magenta: '\x1b[35m',
   cyan: '\x1b[36m',
-  // ZNTC 브랜드 오렌지 (256-color; 미지원 터미널은 근사색으로 degrade)
-  amber: '\x1b[38;5;214m',
-  orange: '\x1b[38;5;208m',
+  // 16-color 엔 진짜 amber/orange 가 없어 bright-yellow→yellow→bright-red 로
+  // warm 근사. 256-color 는 미지원 터미널서 무색으로 떨어져 보편 16-color 사용.
+  brightYellow: '\x1b[93m',
+  brightRed: '\x1b[91m',
 };
 
 /**
@@ -61,21 +62,21 @@ function bannerLine(content) {
 // 지구라트 로고 (계단식) — documents 의 zntc-logo.svg / favicon 과 동일 정체성.
 // 6줄 = ZNTC_GRADIENT 6색과 1:1. bannerLine 이 각 줄을 박스 중앙 정렬.
 export const ZNTC_ASCII = [
-  '████████',
-  '██████████████',
-  '████████████████████',
-  '██████████████████████████',
-  '████████████████████████████████',
-  '██████████████████████████████████████',
+  '██████',
+  '████████████',
+  '██████████████████',
+  '████████████████████████',
+  '██████████████████████████████',
+  '████████████████████████████████████████',
 ];
 
 export const ZNTC_GRADIENT = [
-  colors.amber,
-  colors.amber,
-  colors.amber,
-  colors.orange,
-  colors.orange,
-  colors.orange,
+  colors.brightYellow,
+  colors.brightYellow,
+  colors.yellow,
+  colors.yellow,
+  colors.brightRed,
+  colors.brightRed,
 ];
 
 // ZNTC_ASCII[i] 는 ZNTC_GRADIENT[i] 로 색칠 — desync 시 undefined 가

--- a/packages/react-native/src/dev-server/logger.test.ts
+++ b/packages/react-native/src/dev-server/logger.test.ts
@@ -108,7 +108,7 @@ describe('printZntcRnBanner', () => {
     printZntcRnBanner('0.1.0');
     const out = (logSpy.mock.calls[0] as unknown[])[0] as string;
     // 지구라트 ASCII 로고 (최하단 base 타일) + 슬로건 + version.
-    expect(out).toContain('██████████████████████████████████████');
+    expect(out).toContain(RN_ASCII.at(-1)!);
     expect(out).toContain('Lightning Fast React Native Bundler');
     expect(out).toContain('v0.1.0');
   });
@@ -116,7 +116,7 @@ describe('printZntcRnBanner', () => {
   test('version 없음 → version 영역 비움', () => {
     printZntcRnBanner();
     const out = (logSpy.mock.calls[0] as unknown[])[0] as string;
-    expect(out).toContain('██████████████████████████████████████');
+    expect(out).toContain(RN_ASCII.at(-1)!);
     expect(out).not.toMatch(/v\d/);
   });
 

--- a/packages/react-native/src/dev-server/logger.ts
+++ b/packages/react-native/src/dev-server/logger.ts
@@ -14,9 +14,10 @@ export const colors = {
   blue: '\x1b[34m',
   magenta: '\x1b[35m',
   cyan: '\x1b[36m',
-  // ZNTC 브랜드 오렌지 (256-color; 미지원 터미널은 근사색으로 degrade)
-  amber: '\x1b[38;5;214m',
-  orange: '\x1b[38;5;208m',
+  // 16-color 엔 진짜 amber/orange 가 없어 bright-yellow→yellow→bright-red 로
+  // warm 근사. 256-color 는 미지원 터미널서 무색으로 떨어져 보편 16-color 사용.
+  brightYellow: '\x1b[93m',
+  brightRed: '\x1b[91m',
 } as const;
 
 /** Metro 호환 ` INFO ` cyan inverse bold badge. */
@@ -81,21 +82,21 @@ function bannerLine(content: string): string {
 
 // 지구라트 로고 (계단식) — banner.mjs 와 sync 유지 (양쪽 동시 수정).
 export const ZNTC_ASCII = [
-  '████████',
-  '██████████████',
-  '████████████████████',
-  '██████████████████████████',
-  '████████████████████████████████',
-  '██████████████████████████████████████',
+  '██████',
+  '████████████',
+  '██████████████████',
+  '████████████████████████',
+  '██████████████████████████████',
+  '████████████████████████████████████████',
 ] as const;
 
 export const ZNTC_GRADIENT = [
-  colors.amber,
-  colors.amber,
-  colors.amber,
-  colors.orange,
-  colors.orange,
-  colors.orange,
+  colors.brightYellow,
+  colors.brightYellow,
+  colors.yellow,
+  colors.yellow,
+  colors.brightRed,
+  colors.brightRed,
 ] as const;
 
 // ZNTC_ASCII[i] 는 ZNTC_GRADIENT[i] 로 색칠 — desync 시 undefined 가


### PR DESCRIPTION
#3553 의 dev 배너 지구라트가 사용자 환경에서 **무색 + 단 사이 띄엄띄엄**으로 보이는 문제 수정.

## 원인 / 수정
- **무색**: 그라디언트를 256-color(`\x1b[38;5;214m` 등)로 했는데 미지원 터미널에선 기본 fg로 떨어져 단색처럼 보임 → **보편 16-color**(bright-yellow→yellow→bright-red) 로 교체. 어디서나 렌더.
- **성김**: 단 폭 차가 커(±3/줄) 색 빠지면 흰 블록이 분리돼 보임 → 더 촘촘한 솔리드 형태 + 넓은 base 플린스(최하단 40)로 temple 느낌.
- web(`banner.mjs`) ↔ RN(`logger.ts`) 동일 적용, byte-parity 테스트 유지.

## /simplify (3-에이전트) 반영
- **[MED]** 색 상수명이 값을 속임 — `amber`=`\x1b[93m`(bright-yellow), `orange`=`\x1b[91m`(bright-red). `colors.orange`를 읽으면 빨강이 나옴 → `brightYellow`/`brightRed`로 rename, `ZNTC_GRADIENT`·주석 동기. 16-color엔 진짜 amber/orange가 없음을 주석에 정직히 명시.
- **[MED]** `logger.test.ts`가 base 타일 폭을 raw 리터럴 하드코딩 → 이번 PR서만 2회 재카운트(brittle). 이미 import된 `RN_ASCII.at(-1)` 단일 출처로 전환(폭 변경에 테스트 무영향).
- 효율/정렬: clean (40 ≤ BANNER_WIDTH 59, strip regex 16-color도 정상 → 중앙정렬 유지, start-only).

## 검증
web/RN 배너 색 정상 · `logger.test.ts` 21 pass(parity 3 포함) · `banner.mjs` import no-throw · lint 0. 비-TTY/NO_COLOR 는 기존대로 plain 한 줄.

🤖 Generated with [Claude Code](https://claude.com/claude-code)