### PR TITLE
fix(cli): dev 배너 컴팩트 half-block 지구라트 (적층 바·작고 쌈박)

### DIFF
--- a/packages/core/bin/banner.mjs
+++ b/packages/core/bin/banner.mjs
@@ -59,21 +59,20 @@ function bannerLine(content) {
   return `${colors.cyan}    ║${colors.reset}${' '.repeat(left)}${content}${' '.repeat(right)}${colors.cyan}║${colors.reset}`;
 }
 
-// 지구라트 로고 (계단식) — documents 의 zntc-logo.svg / favicon 과 동일 정체성.
-// 6줄 = ZNTC_GRADIENT 6색과 1:1. bannerLine 이 각 줄을 박스 중앙 정렬.
+// 지구라트 로고 — zntc-logo.svg / favicon 과 동일: 단 사이가 띈 적층 바
+// (햄버거식). half-block `▀` 로 한 줄에 바+여백을 담아 절반 높이·컴팩트.
+// ZNTC_GRADIENT 와 index 1:1. bannerLine 이 각 줄을 박스 중앙 정렬.
 export const ZNTC_ASCII = [
-  '██████',
-  '████████████',
-  '██████████████████',
-  '████████████████████████',
-  '██████████████████████████████',
-  '████████████████████████████████████████',
+  '▀▀▀▀▀▀▀▀',
+  '▀▀▀▀▀▀▀▀▀▀▀▀',
+  '▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀',
+  '▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀',
+  '▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀',
 ];
 
 export const ZNTC_GRADIENT = [
   colors.brightYellow,
   colors.brightYellow,
-  colors.yellow,
   colors.yellow,
   colors.brightRed,
   colors.brightRed,

--- a/packages/react-native/src/dev-server/logger.ts
+++ b/packages/react-native/src/dev-server/logger.ts
@@ -80,20 +80,20 @@ function bannerLine(content: string): string {
   return `${colors.cyan}    ║${colors.reset}${' '.repeat(left)}${content}${' '.repeat(right)}${colors.cyan}║${colors.reset}`;
 }
 
-// 지구라트 로고 (계단식) — banner.mjs 와 sync 유지 (양쪽 동시 수정).
+// 지구라트 로고 — 단 사이가 띈 적층 바(햄버거식, zntc-logo.svg 와 동일).
+// half-block `▀` 로 한 줄에 바+여백 → 절반 높이·컴팩트. banner.mjs 와
+// sync 유지 (양쪽 동시 수정).
 export const ZNTC_ASCII = [
-  '██████',
-  '████████████',
-  '██████████████████',
-  '████████████████████████',
-  '██████████████████████████████',
-  '████████████████████████████████████████',
+  '▀▀▀▀▀▀▀▀',
+  '▀▀▀▀▀▀▀▀▀▀▀▀',
+  '▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀',
+  '▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀',
+  '▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀',
 ] as const;
 
 export const ZNTC_GRADIENT = [
   colors.brightYellow,
   colors.brightYellow,
-  colors.yellow,
   colors.yellow,
   colors.brightRed,
   colors.brightRed,
@@ -107,7 +107,7 @@ if (ZNTC_ASCII.length !== ZNTC_GRADIENT.length) {
   );
 }
 
-/** ZNTC RN dev server 시작 banner — 6줄 ASCII 로고 + 그라디언트 + 박스. */
+/** ZNTC RN dev server 시작 banner — ASCII 로고 + 그라디언트 + 박스. */
 export function printZntcRnBanner(version?: string): void {
   const versionText = version ? `v${version}` : '';
   const logoLines = ZNTC_ASCII.map((line, i) =>


### PR DESCRIPTION
#3554 의 솔리드 6줄 형태가 (1) SVG(`zntc-logo.svg`/favicon)의 **단 사이 띈 적층 바**(햄버거식) 정체성과 안 맞고, (2) 빈 줄 separator를 넣으면 11줄로 너무 큼. **half-block `▀`** 로 한 줄에 바+여백을 담아 **5줄**로 — 햄버거 적층 느낌 유지 + 절반 높이·고해상·컴팩트("작고 쌈박").

```
    ║                         ▀▀▀▀▀▀▀▀                          ║  bright-yellow
    ║                       ▀▀▀▀▀▀▀▀▀▀▀▀                        ║
    ║                     ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀                      ║  yellow
    ║                   ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀                    ║
    ║                 ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀                  ║  bright-red
```
`▀`(U+2580)는 셀 상단 절반만 칠해져 아래 절반이 자연 여백 → 한 줄로 "바+간격" = 분리된 적층 바가 컴팩트하게. web(`banner.mjs`)↔RN(`logger.ts`) sync, byte-parity 테스트 유지.

## /simplify (3-에이전트)
- **[MED]** `logger.ts:110` JSDoc "6줄 ASCII 로고" stale(이전 6줄 버전 잔재) → 줄 수 표기 제거(향후 형태 변경에 무영향). banner.mjs 무관.
- 나머지 clean: byte-parity·length fail-fast 유지, `brightYellow/brightRed` 정확, art 리터럴은 로고라 generator 부적절(에이전트 합의), 효율/정렬 정상(24 ≤ 폭 59, strip regex OK, start-only).

## 검증
web/RN 렌더 정상 · `logger.test.ts` 21 pass(parity 3 포함) · `banner.mjs` import no-throw · lint 0. 비-TTY/NO_COLOR 는 기존대로 plain 한 줄.

🤖 Generated with [Claude Code](https://claude.com/claude-code)