### PR TITLE
fix(rn): logger ZNTC_GRADIENT --isolatedDeclarations TS9013 — CI 복구

### DIFF
--- a/packages/react-native/src/dev-server/logger.ts
+++ b/packages/react-native/src/dev-server/logger.ts
@@ -91,13 +91,15 @@ export const ZNTC_ASCII = [
   '▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀',
 ] as const;
 
-export const ZNTC_GRADIENT = [
+// 명시 타입 — `--isolatedDeclarations`(tsconfig.base) 는 exported const 의
+// 비-리터럴 요소(`colors.X` member access) 타입을 추론하지 못함(TS9013).
+export const ZNTC_GRADIENT: readonly string[] = [
   colors.brightYellow,
   colors.brightYellow,
   colors.yellow,
   colors.brightRed,
   colors.brightRed,
-] as const;
+];
 
 // ZNTC_ASCII[i] 는 ZNTC_GRADIENT[i] 로 색칠 — desync 시 undefined 가
 // visibleLen 을 오염시켜 줄 정렬이 깨진다. import 시점 fail-fast.


### PR DESCRIPTION
## 배경
main(48e4f236) 의 **Publish Smoke → "Build remaining publishable packages"** 의 `build:dts`(`bun x tsc -b`) 실패:
```
src/dev-server/logger.ts(95..99,3) error TS9013: Expression type can't be inferred with --isolatedDeclarations
```

## 루트커즈
배너 커밋이 `export const ZNTC_GRADIENT = [colors.brightYellow, ...] as const;` 도입. `tsconfig.base.json` 의 `isolatedDeclarations:true` 는 exported const 의 **비-리터럴 요소(`colors.X` member access)** 타입을 추론하지 못함 → 각 요소(95-99) TS9013. (sibling `ZNTC_ASCII` 는 string 리터럴이라 추론 가능 → 미플래그, 불변 유지.)

## 변경 (1 파일, +4/-2)
`export const ZNTC_GRADIENT: readonly string[] = [...]` 명시 타입 + `as const` 제거. 사용처가 런타임 전용(`.length` desync 가드 / `[i]` 보간)이라 tuple/literal 타입 의존 없음 — 타입안전 손실 0. `colors.*` 단일소스 유지(ANSI 인라인 안 함), `readonly` 로 불변 의도 보존.

## 검증
- 재현: 48e4f236 `tsc -b --force` 5 에러 → 수정 후 `bun run build`(build:bundle && build:dts) **EXIT=0**.
- `/simplify` **APPROVE**: CI 완전 해소·무회귀 definitive YES; **7 publishable 패키지 전수스캔 결과 동일 isolatedDeclarations latent 실패 없음**(완전 fix, whack-a-mole 아님). `readonly string[]` 최적 선택·WHY 주석 정당·단일소스 보존 확인.