### PR TITLE
fix(rn): disable unstable babel.config.js auto-detection/loading

### DIFF
--- a/packages/react-native/src/preset.test.ts
+++ b/packages/react-native/src/preset.test.ts
@@ -427,7 +427,9 @@ describe('buildRnBundleOptions — plugins (asset/optional-babel/require-context
     expect(names).toEqual(['zntc:react-native:runtime', 'zntc:react-native:require-context']);
   });
 
-  test('native 외 inline babel plugin 지정 시 babel plugin 추가', () => {
+  // DISABLED: babel.config.js auto-detection/loading is temporarily turned off
+  // in preset.ts (unstable). Re-enable this test together with that block.
+  test.skip('native 외 inline babel plugin 지정 시 babel plugin 추가', () => {
     const opts = buildRnBundleOptions(
       baseInput({
         extra: {

--- a/packages/react-native/src/preset.ts
+++ b/packages/react-native/src/preset.ts
@@ -31,7 +31,8 @@ import {
 
 import type { CustomResolver, MetroPlatform } from './metro-resolver-types.ts';
 import { createAssetPlugin } from './plugins/asset.ts';
-import { createBabelPlugin, detectCustomPlugins } from './plugins/babel.ts';
+// DISABLED: babel.config.js auto-detection/loading temporarily turned off (unstable).
+// import { createBabelPlugin, detectCustomPlugins } from './plugins/babel.ts';
 import { normalizeExt, requireFromCli } from './plugins/internal.ts';
 import {
   createMetroResolveRequestPlugin,
@@ -415,17 +416,20 @@ export function buildRnBundleOptions(input: RnBundleInput): BuildOptions {
   // Babel compatibility is opt-in by detection. Native RN preset/worklet/codegen
   // paths cover the default case, so projects with only native-equivalent Babel
   // config do not pay a per-file Babel pass.
-  if (detectCustomPlugins(projectRoot, extra?.babel)) {
-    plugins.push(
-      createBabelPlugin({
-        projectRoot,
-        assetExts,
-        rnPlatform,
-        sourceExts,
-        inlineBabel: extra?.babel,
-      }),
-    );
-  }
+  //
+  // DISABLED: babel.config.js auto-detection/loading is currently too unstable.
+  // Re-enable by uncommenting the block below once stabilized.
+  // if (detectCustomPlugins(projectRoot, extra?.babel)) {
+  //   plugins.push(
+  //     createBabelPlugin({
+  //       projectRoot,
+  //       assetExts,
+  //       rnPlatform,
+  //       sourceExts,
+  //       inlineBabel: extra?.babel,
+  //     }),
+  //   );
+  // }
 
   plugins.push(createRequireContextPlugin());
   if (extra?.metroResolveRequest) {


### PR DESCRIPTION
## 배경

RN 프리셋이 프로젝트 루트의 `babel.config.js` 를 자동 감지(`detectCustomPlugins`)해서 custom Babel plugin pass(`createBabelPlugin` → `createBabelTransformer`)를 등록하는 동작이 너무 불안정합니다. 요청에 따라 **일단 기능만 비활성화**합니다.

## 변경

코드를 삭제하지 않고 **진입 게이트만 주석 처리**해, 안정화 후 두 군데 주석만 풀면 원복되도록 했습니다.

- `packages/react-native/src/preset.ts`
  - `createBabelPlugin` / `detectCustomPlugins` import 주석 처리 (호출부가 죽으면 unused import → `tsc -b` CI 깨짐 방지)
  - `if (detectCustomPlugins(...)) { plugins.push(createBabelPlugin(...)) }` 게이트 블록 주석 처리
- `packages/react-native/src/preset.test.ts`
  - 대응 테스트 `'native 외 inline babel plugin 지정 시 babel plugin 추가'` 를 `test.skip` 처리 (소스 주석과 1:1, 원복 시 함께 복구)

구현체(`plugins/babel.ts`)와 `index.ts` 의 public export(`createBabelPlugin`, `createBabelTransformer`, `detectCustomPlugins`, ...)는 **그대로 보존** — 직접 import 하는 사용자/단위 테스트(`plugins/babel.test.ts`)는 영향 없음.

## 영향 (의도된 동작 변경)

- `extra.babel`(inlineBabel) 입력 — `zntc.config.ts` 의 `transformer.babel` 매핑 포함 — 이 **번들러로 forward 되지 않고 무시**됩니다. config→bundle.extra.babel 매핑 자체는 그대로 동작하므로 `metro-compatible.ts` 테스트는 PASS 하지만, 다운스트림에서 미적용 상태가 됩니다. (기능 비활성화의 의도된 결과)
- 네이티브 RN preset/worklet/codegen 경로는 영향 없음 — 기본 케이스는 그대로 동작.

## 검증

- `bun x tsc -b packages/react-native` → exit 0
- `bun test src/preset.test.ts` → 72 pass / 1 skip / 0 fail
- `/simplify` cross-file 검토로 CI 깨짐(테스트·unused import) 사전 차단

## 원복 방법

`preset.ts` 의 두 주석 블록(import + 게이트)과 `preset.test.ts` 의 `test.skip` 을 되돌리면 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)