### PR TITLE
test(bench): rspack-loader-bench @zntc/core를 dist로 alias

### DIFF
--- a/tests/benchmark/rspack-loader-bench.ts
+++ b/tests/benchmark/rspack-loader-bench.ts
@@ -29,6 +29,7 @@ import { performance } from 'node:perf_hooks';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '../..');
 const ZNTC_LOADER = resolve(ROOT, 'packages/rspack-loader/src/index.ts');
+const ZNTC_CORE_DIST = resolve(ROOT, 'packages/core/dist/index.js');
 
 const WARMUP = 2;
 const ITERATIONS = parseArg('iterations', 5);
@@ -126,6 +127,7 @@ async function runRspackOnce(opts: BuildOptions): Promise<{ ms: number; modules:
         resolve: {
           extensions: ['.ts', '.tsx', '.js', '.jsx', '.cjs', '.mjs'],
           modules: opts.modulesPaths,
+          alias: { '@zntc/core': ZNTC_CORE_DIST },
         },
         module: { rules: [opts.rule] },
         cache: false,


### PR DESCRIPTION
## 변경

`tests/benchmark/rspack-loader-bench.ts` 에 rspack `resolve.alias` 1개 추가:
`@zntc/core` → `packages/core/dist/index.js`.

## 왜

rspack 벤치는 `@zntc/core` 를 소스(`packages/core/index.ts` 등)로 해석해, 측정 대상인 ZNTC 로더가 실제로 쓰는 **빌드된 core** 와 불일치했다. alias 로 dist 에 고정해 로더가 배포물 기준으로 측정되도록 한다 (stash 에 있던 워크어라운드를 정식화).

## 영향

- benchmark 전용. 런타임/패키지 코드 변경 없음.
- `packages/core/dist/index.js` 사전 빌드 필요 (`bun run --cwd packages/core build`). 누락 시 rspack 이 명확히 에러 — 별도 존재 체크는 TOCTOU 라 두지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)