### PR TITLE
docs(electron): zntc.config.ts 타깃별 config 파일 예제 추가

### DIFF
--- a/documents/src/content/docs/en/guides/electron.md
+++ b/documents/src/content/docs/en/guides/electron.md
@@ -68,6 +68,53 @@ app.whenReady().then(() => {
 });
 ```
 
+## Using zntc.config.ts (config file)
+
+Instead of long flag lists in npm scripts, you can split the setup into a file — just like webpack's `webpack.config.ts`. `zntc.config.{ts,js,json}` accepts `entryPoints` · `platform` · `format` · `packagesExternal` · `outfile`.
+
+A ZNTC config is **one file = one build** (bundling multiple targets into a single array-style config is not supported). Since Electron's main · preload · renderer differ in platform/format, split the config per target and select it with `--config` — the same as webpack's multi-config Electron setup.
+
+```ts
+// zntc.main.config.ts
+import { defineConfig } from "@zntc/core";
+
+export default defineConfig({
+  entryPoints: ["src/main.ts"],
+  platform: "node",
+  format: "cjs",          // "esm" for Electron 28+ ESM main
+  packagesExternal: true, // keep electron · Node builtin bare imports external
+  outfile: "dist/main.cjs",
+});
+```
+
+```ts
+// zntc.preload.config.ts
+import { defineConfig } from "@zntc/core";
+
+export default defineConfig({
+  entryPoints: ["src/preload.ts"],
+  platform: "node",
+  format: "cjs",
+  packagesExternal: true,
+  outfile: "dist/preload.cjs",
+});
+```
+
+The renderer defaults to `browser`, so it needs no config — keep using `zntc dev src/renderer` / `zntc build src/renderer`.
+
+```jsonc
+{
+  "scripts": {
+    "build:main": "zntc --bundle --config zntc.main.config.ts",
+    "build:preload": "zntc --bundle --config zntc.preload.config.ts",
+    "build:renderer": "zntc build src/renderer",
+    "build": "npm-run-all build:main build:preload build:renderer"
+  }
+}
+```
+
+When a CLI flag and config both set the same option, the CLI wins (scalar override). For example, `zntc --bundle --config zntc.main.config.ts --format=esm` builds as `esm` instead of the config's `cjs`. A functional config (`defineConfig(({ mode, env }) => ({ … }))`) lets you branch dev/prod.
+
 ## Dev / prod scripts
 
 Watch · restart · concurrent execution is wired with standard tooling (`npm-run-all`, `wait-on`, `nodemon`) — the same pattern as webpack/rspack's Electron guides.

--- a/documents/src/content/docs/guides/electron.md
+++ b/documents/src/content/docs/guides/electron.md
@@ -68,6 +68,53 @@ app.whenReady().then(() => {
 });
 ```
 
+## zntc.config.ts 로 묶기 (config 파일 방식)
+
+위처럼 npm script 에 flag 를 길게 나열하는 대신, webpack 의 `webpack.config.ts` 처럼 설정을 파일로 분리할 수 있습니다. `zntc.config.{ts,js,json}` 은 `entryPoints` · `platform` · `format` · `packagesExternal` · `outfile` 을 모두 받습니다.
+
+ZNTC config 는 **파일 하나가 빌드 한 개** 입니다(여러 타깃을 한 파일에 배열로 묶는 형태는 미지원). Electron 은 main · preload · renderer 가 platform/format 이 서로 다르므로, webpack 의 Electron 멀티 config 와 동일하게 **타깃별로 config 파일을 나누고 `--config` 로 지정** 합니다.
+
+```ts
+// zntc.main.config.ts
+import { defineConfig } from "@zntc/core";
+
+export default defineConfig({
+  entryPoints: ["src/main.ts"],
+  platform: "node",
+  format: "cjs",          // Electron 28+ ESM main 은 "esm"
+  packagesExternal: true, // electron · Node builtin 등 bare import 유지
+  outfile: "dist/main.cjs",
+});
+```
+
+```ts
+// zntc.preload.config.ts
+import { defineConfig } from "@zntc/core";
+
+export default defineConfig({
+  entryPoints: ["src/preload.ts"],
+  platform: "node",
+  format: "cjs",
+  packagesExternal: true,
+  outfile: "dist/preload.cjs",
+});
+```
+
+renderer 는 browser 가 기본값이라 별도 config 가 필요 없습니다 — `zntc dev src/renderer` / `zntc build src/renderer` 를 그대로 씁니다.
+
+```jsonc
+{
+  "scripts": {
+    "build:main": "zntc --bundle --config zntc.main.config.ts",
+    "build:preload": "zntc --bundle --config zntc.preload.config.ts",
+    "build:renderer": "zntc build src/renderer",
+    "build": "npm-run-all build:main build:preload build:renderer"
+  }
+}
+```
+
+CLI flag 와 config 를 동시에 주면 CLI 가 이깁니다(scalar override). 예: `zntc --bundle --config zntc.main.config.ts --format=esm` 는 config 의 `cjs` 대신 `esm` 으로 빌드합니다. 함수형 config(`defineConfig(({ mode, env }) => ({ … }))`) 로 dev/prod 분기도 가능합니다.
+
 ## 개발 / 프로덕션 스크립트
 
 watch · 재시작 · 동시 실행은 webpack/rspack 의 Electron 가이드와 동일하게 `npm-run-all`, `wait-on`, `nodemon` 등 표준 도구로 구성합니다.


### PR DESCRIPTION
## 변경

Electron 가이드(KR `guides/electron.md` + EN `en/guides/electron.md`)에 `zntc.config.ts` 방식 섹션 추가. 기존엔 npm script 에 CLI flag 를 길게 나열하는 예제만 있었음.

## 내용

- webpack 의 `webpack.config.ts` 대응 — main/preload 를 타깃별 `zntc.main.config.ts` / `zntc.preload.config.ts` 로 분리, `--config` 로 지정
- renderer 는 browser 기본값이라 config 불필요(기존 `zntc dev/build src/renderer` 유지)
- **원리/한계 명시**: config 1개 = 빌드 1개(배열 멀티타깃 미지원)이라 타깃별 파일 분리가 정확한 매핑. CLI flag 가 config 를 scalar override 하는 우선순위도 명시
- KR ↔ EN 1:1 패리티

## 근거 (검증)

- `zntc.config` 가 `entryPoints`/`platform`/`format`/`packagesExternal`/`outfile` 지원 (docs/CONFIG.md)
- `--config <path>` 플래그 존재 (`packages/core/bin/cli-flags.mjs`)
- 추측·내부 구현 비교·이슈번호 없음 (docs 사용자 관점 유지)

문서 전용. 코드 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)