### PR TITLE
test(infra): byte-identical determinism gate (N=10) — 5 fixture + helpers + CI job

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -302,6 +302,24 @@ jobs:
             smoke-output.txt
             smoke-deep-min-output.txt
 
+  determinism:
+    name: Build Determinism (N=10) (#3564)
+    runs-on: ubuntu-latest
+    needs: prepare-zntc-cli-ubuntu
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/use-zntc-artifact
+        with:
+          artifact-name: zntc-cli-ubuntu-latest
+          napi: "false"
+
+      - name: Install integration dependencies
+        run: cd tests/integration && bun install --frozen-lockfile
+
+      - name: Run determinism gate (N=10 byte-identical)
+        run: cd tests/integration && bun test tests/determinism.test.ts --timeout 120000
+
   smoke-comment:
     name: Post Smoke Results
     needs: smoke

--- a/src/codegen/unified_mangler.zig
+++ b/src/codegen/unified_mangler.zig
@@ -456,6 +456,37 @@ test "mangleAll: Phase B loop runs with empty module (counter carried through)" 
     try std.testing.expectEqual(@as(usize, 0), result.phase_b_modules[0].slot_count);
 }
 
+test "mangleAll: deterministic — same input twice yields identical renames" {
+    const candidates = [_]TopLevelCandidate{
+        .{ .module_index = 0, .symbol_id = 0, .name = "alpha", .ref_count = 7 },
+        .{ .module_index = 1, .symbol_id = 0, .name = "beta", .ref_count = 12 },
+        .{ .module_index = 2, .symbol_id = 0, .name = "gamma", .ref_count = 3 },
+        .{ .module_index = 0, .symbol_id = 1, .name = "delta", .ref_count = 7 }, // tie with alpha
+    };
+
+    var r1 = try mangleAll(std.testing.allocator, .{
+        .modules = &.{},
+        .top_level_candidates = &candidates,
+    });
+    defer r1.deinit();
+
+    var r2 = try mangleAll(std.testing.allocator, .{
+        .modules = &.{},
+        .top_level_candidates = &candidates,
+    });
+    defer r2.deinit();
+
+    try std.testing.expectEqual(r1.renames.count(), r2.renames.count());
+    var it = r1.renames.iterator();
+    while (it.next()) |kv| {
+        const v2 = r2.renames.get(kv.key_ptr.*) orelse {
+            std.debug.print("missing key in r2: ({d},{d})\n", .{ kv.key_ptr.module_index, kv.key_ptr.symbol_id });
+            return error.MissingKey;
+        };
+        try std.testing.expectEqualStrings(kv.value_ptr.*, v2);
+    }
+}
+
 test "mangleAll: identity rename (name already equals base54 head) — no rename entry" {
     // 원본 이름이 base54 의 (reserved 'e'/'m' 을 skip 한 후) 첫 이름 "t" 와 같으면
     // renames 에 기록하지 않음 (no-op).

--- a/tests/integration/tests/determinism.test.ts
+++ b/tests/integration/tests/determinism.test.ts
@@ -1,0 +1,73 @@
+/// Build determinism gate (#3564) — 같은 입력으로 N=10회 빌드 → bundle byte-identical.
+/// 모든 케이스 `.skip` 으로 시작; 후속 PR 가 각자의 hotspot 을 fix 한 뒤 하나씩 활성화.
+
+import { afterAll, describe, test, expect } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { runZntc, sha256OfFile } from './helpers';
+
+const FIXTURE_ROOT = resolve(import.meta.dir, 'fixtures/determinism');
+const REPEAT_COUNT = 10;
+
+const tmpRoots: string[] = [];
+afterAll(async () => {
+  await Promise.all(tmpRoots.map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function expectDeterministic(
+  fixtureName: string,
+  entryFile: string,
+  extraArgs: string[] = [],
+): Promise<void> {
+  const fixtureDir = join(FIXTURE_ROOT, fixtureName);
+  const tmpRoot = await mkdtemp(join(tmpdir(), `zntc-determinism-${fixtureName}-`));
+  tmpRoots.push(tmpRoot);
+
+  const results: { hash: string; size: number; mapHash: string | null }[] = [];
+  for (let i = 0; i < REPEAT_COUNT; i++) {
+    const outFile = join(tmpRoot, `run-${i}`, 'bundle.js');
+    const r = await runZntc(['--bundle', join(fixtureDir, entryFile), '-o', outFile, ...extraArgs]);
+    if (r.exitCode !== 0) {
+      throw new Error(`[${fixtureName}] run ${i} exited ${r.exitCode}\n${r.stderr}`);
+    }
+    const js = await sha256OfFile(outFile);
+    const mapPath = `${outFile}.map`;
+    const mapHash = existsSync(mapPath) ? (await sha256OfFile(mapPath)).hash : null;
+    results.push({ hash: js.hash, size: js.size, mapHash });
+  }
+
+  const first = results[0];
+  for (let i = 1; i < results.length; i++) {
+    expect(
+      results[i].hash,
+      `run ${i} bundle.js SHA256 mismatch (size ${first.size}→${results[i].size})`,
+    ).toBe(first.hash);
+    if (first.mapHash) {
+      expect(results[i].mapHash, `run ${i} bundle.js.map SHA256 mismatch`).toBe(first.mapHash);
+    }
+  }
+}
+
+describe('build determinism (#3564)', () => {
+  test.skip('small — 5 file ESM, no collisions', async () => {
+    await expectDeterministic('small', 'index.js');
+  });
+
+  test.skip('name-collision — same export name across 3 modules', async () => {
+    await expectDeterministic('name-collision', 'index.js', ['--minify-identifiers']);
+  });
+
+  test.skip('dynamic-only — exec_index ties from import() only', async () => {
+    await expectDeterministic('dynamic-only', 'index.js');
+  });
+
+  test.skip('barrel — export * from chain', async () => {
+    await expectDeterministic('barrel', 'index.js');
+  });
+
+  test.skip('code-splitting — manualChunks + dynamic', async () => {
+    await expectDeterministic('code-splitting', 'index.js', ['--code-splitting']);
+  });
+});

--- a/tests/integration/tests/fixtures/determinism/barrel/barrel/a.js
+++ b/tests/integration/tests/fixtures/determinism/barrel/barrel/a.js
@@ -1,0 +1,2 @@
+export * from './nested-a.js';
+export const alpha = 'alpha';

--- a/tests/integration/tests/fixtures/determinism/barrel/barrel/b.js
+++ b/tests/integration/tests/fixtures/determinism/barrel/barrel/b.js
@@ -1,0 +1,2 @@
+export const gamma = 'gamma';
+export const delta = 'delta';

--- a/tests/integration/tests/fixtures/determinism/barrel/barrel/index.js
+++ b/tests/integration/tests/fixtures/determinism/barrel/barrel/index.js
@@ -1,0 +1,2 @@
+export * from './a.js';
+export * from './b.js';

--- a/tests/integration/tests/fixtures/determinism/barrel/barrel/nested-a.js
+++ b/tests/integration/tests/fixtures/determinism/barrel/barrel/nested-a.js
@@ -1,0 +1,1 @@
+export const beta = 'beta';

--- a/tests/integration/tests/fixtures/determinism/barrel/index.js
+++ b/tests/integration/tests/fixtures/determinism/barrel/index.js
@@ -1,0 +1,3 @@
+import * as all from './barrel/index.js';
+
+console.log(all.alpha, all.beta, all.gamma, all.delta);

--- a/tests/integration/tests/fixtures/determinism/code-splitting/heavy.js
+++ b/tests/integration/tests/fixtures/determinism/code-splitting/heavy.js
@@ -1,0 +1,5 @@
+import { farewell } from './shared.js';
+
+export function compute() {
+  return farewell() + '-done';
+}

--- a/tests/integration/tests/fixtures/determinism/code-splitting/index.js
+++ b/tests/integration/tests/fixtures/determinism/code-splitting/index.js
@@ -1,0 +1,6 @@
+async function main() {
+  const shared = await import('./shared.js');
+  const heavy = await import('./heavy.js');
+  console.log(shared.greet(), heavy.compute());
+}
+main();

--- a/tests/integration/tests/fixtures/determinism/code-splitting/shared.js
+++ b/tests/integration/tests/fixtures/determinism/code-splitting/shared.js
@@ -1,0 +1,6 @@
+export function greet() {
+  return 'hello';
+}
+export function farewell() {
+  return 'bye';
+}

--- a/tests/integration/tests/fixtures/determinism/dynamic-only/index.js
+++ b/tests/integration/tests/fixtures/determinism/dynamic-only/index.js
@@ -1,0 +1,11 @@
+async function main() {
+  const [a, b, c, d, e] = await Promise.all([
+    import('./lazyA.js'),
+    import('./lazyB.js'),
+    import('./lazyC.js'),
+    import('./lazyD.js'),
+    import('./lazyE.js'),
+  ]);
+  console.log(a.value, b.value, c.value, d.value, e.value);
+}
+main();

--- a/tests/integration/tests/fixtures/determinism/dynamic-only/lazyA.js
+++ b/tests/integration/tests/fixtures/determinism/dynamic-only/lazyA.js
@@ -1,0 +1,1 @@
+export const value = 'A';

--- a/tests/integration/tests/fixtures/determinism/dynamic-only/lazyB.js
+++ b/tests/integration/tests/fixtures/determinism/dynamic-only/lazyB.js
@@ -1,0 +1,1 @@
+export const value = 'B';

--- a/tests/integration/tests/fixtures/determinism/dynamic-only/lazyC.js
+++ b/tests/integration/tests/fixtures/determinism/dynamic-only/lazyC.js
@@ -1,0 +1,1 @@
+export const value = 'C';

--- a/tests/integration/tests/fixtures/determinism/dynamic-only/lazyD.js
+++ b/tests/integration/tests/fixtures/determinism/dynamic-only/lazyD.js
@@ -1,0 +1,1 @@
+export const value = 'D';

--- a/tests/integration/tests/fixtures/determinism/dynamic-only/lazyE.js
+++ b/tests/integration/tests/fixtures/determinism/dynamic-only/lazyE.js
@@ -1,0 +1,1 @@
+export const value = 'E';

--- a/tests/integration/tests/fixtures/determinism/name-collision/index.js
+++ b/tests/integration/tests/fixtures/determinism/name-collision/index.js
@@ -1,0 +1,5 @@
+import { help as h1 } from './util1.js';
+import { help as h2 } from './util2.js';
+import { help as h3 } from './util3.js';
+
+console.log(h1(), h2(), h3());

--- a/tests/integration/tests/fixtures/determinism/name-collision/util1.js
+++ b/tests/integration/tests/fixtures/determinism/name-collision/util1.js
@@ -1,0 +1,4 @@
+const PREFIX = '1';
+export function help() {
+  return `${PREFIX}-help`;
+}

--- a/tests/integration/tests/fixtures/determinism/name-collision/util2.js
+++ b/tests/integration/tests/fixtures/determinism/name-collision/util2.js
@@ -1,0 +1,4 @@
+const PREFIX = '2';
+export function help() {
+  return `${PREFIX}-help`;
+}

--- a/tests/integration/tests/fixtures/determinism/name-collision/util3.js
+++ b/tests/integration/tests/fixtures/determinism/name-collision/util3.js
@@ -1,0 +1,4 @@
+const PREFIX = '3';
+export function help() {
+  return `${PREFIX}-help`;
+}

--- a/tests/integration/tests/fixtures/determinism/small/a.js
+++ b/tests/integration/tests/fixtures/determinism/small/a.js
@@ -1,0 +1,2 @@
+import { c } from './c.js';
+export const a = `a-${c}`;

--- a/tests/integration/tests/fixtures/determinism/small/b.js
+++ b/tests/integration/tests/fixtures/determinism/small/b.js
@@ -1,0 +1,2 @@
+import { d } from './d.js';
+export const b = `b-${d}`;

--- a/tests/integration/tests/fixtures/determinism/small/c.js
+++ b/tests/integration/tests/fixtures/determinism/small/c.js
@@ -1,0 +1,1 @@
+export const c = 'c';

--- a/tests/integration/tests/fixtures/determinism/small/d.js
+++ b/tests/integration/tests/fixtures/determinism/small/d.js
@@ -1,0 +1,1 @@
+export const d = 'd';

--- a/tests/integration/tests/fixtures/determinism/small/index.js
+++ b/tests/integration/tests/fixtures/determinism/small/index.js
@@ -1,0 +1,4 @@
+import { a } from './a.js';
+import { b } from './b.js';
+
+console.log(a + b);

--- a/tests/integration/tests/helpers.ts
+++ b/tests/integration/tests/helpers.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'bun';
-import { mkdtemp, rm, writeFile, mkdir, symlink, realpath } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile, mkdir, symlink, realpath, readFile } from 'node:fs/promises';
 import { readFileSync, statSync, openSync, closeSync, mkdirSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import { dirname, join, relative, resolve } from 'node:path';
@@ -287,6 +288,11 @@ export async function runZntc(
   options?: RunOptions,
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   return runCmd([ZNTC_BIN, ...args], options);
+}
+
+export async function sha256OfFile(filePath: string): Promise<{ hash: string; size: number }> {
+  const buf = await readFile(filePath);
+  return { hash: createHash('sha256').update(buf).digest('hex'), size: buf.byteLength };
 }
 
 /// fixture 생성 → ZNTC 실행 → 자동 cleanup 한 번에 묶는 헬퍼. caller 의 try/finally


### PR DESCRIPTION
epic #3564 PR-0/7. **prod 코드 무변경** — test 인프라 + CI job + zig unit test 1개만 추가.

## 변경

- `tests/integration/tests/determinism.test.ts` (신규) — N=10 build → bundle.js + bundle.js.map SHA256 동일 게이트. 모든 케이스 `.skip` 으로 시작
- `tests/integration/tests/fixtures/determinism/` 5 합성 fixture
  - `small/` — 5 file ESM, 충돌 없음 (#3564 PR-1 활성화)
  - `name-collision/` — 같은 export 이름 3 모듈 충돌 (PR-2/3 활성화)
  - `dynamic-only/` — `import()` 만으로 도달, `exec_index = maxInt` 동률 (PR-4 활성화)
  - `barrel/` — `export *` 3-level chain, `esm_wrap.seen.iterator()` hot path (PR-5 활성화)
  - `code-splitting/` — `manualChunks` + dynamic, `chunks.exports_to.iterator()` (PR-5 활성화)
- `tests/integration/tests/helpers.ts` — `sha256OfFile(path) → {hash, size}` 헬퍼 추가 (`mf-runtime-interop-smoke.test.ts` 도 향후 흡수 가능)
- `src/codegen/unified_mangler.zig` 끝에 `mangleAll: deterministic — same input twice yields identical renames` unit test (현재 통과)
- `.github/workflows/integration.yml` 에 `determinism` job (CLI artifact 사용, NAPI 불필요)

## 검증

- `bun test tests/determinism.test.ts` → 5 skip / 0 fail
- `zig build test` 통과
- `bun run fmt:check` 통과

## 후속

PR-1~6 가 각자의 hotspot 을 fix 한 뒤 해당 `.skip` 을 제거하며 게이트를 활성화. epic 본문 (#3564) 참고.

Refs #3564