### PR TITLE
fix(graph): deterministic module index assignment via path-stable renumber

### DIFF
--- a/src/bundler/graph/build_flow.zig
+++ b/src/bundler/graph/build_flow.zig
@@ -15,6 +15,7 @@ const graph_project_root = @import("project_root.zig");
 const graph_requested_exports = @import("requested_exports.zig");
 const graph_runtime_polyfills = @import("runtime_polyfills.zig");
 const graph_discovery_scan = @import("discovery_scan.zig");
+const renumber = @import("renumber.zig");
 const graph_resolve_imports = @import("resolve_imports.zig");
 const graph_cycles = @import("cycles.zig");
 const graph_finalize = @import("finalize.zig");
@@ -264,6 +265,10 @@ fn linkDependencyUnique(self: *ModuleGraph, from: ModuleIndex, to: ModuleIndex) 
 fn finalizeGraph(self: *ModuleGraph, entry_points: []const []const u8) !void {
     var scope = profile.begin(.graph_finalize);
     defer scope.end();
+
+    // discovery 워커 race 로 비결정인 module_index 를 BFS 순으로 재부여.
+    // linker init 전에 수행해 외부 idx 키 자료구조 영향 0.
+    try renumber.renumberModulesDeterministically(self, entry_points);
 
     const count = self.modules.count();
     if (count == 0) return;

--- a/src/bundler/graph/renumber.zig
+++ b/src/bundler/graph/renumber.zig
@@ -1,0 +1,168 @@
+//! Post-discovery deterministic renumber of ModuleIndex.
+//!
+//! 호출 시점 안전성:
+//!   - discovery 워커 모두 join 완료 (linkExecutionRoots 직후) — 외부 *Module 보유자 없음
+//!   - linker init 전 — linker.export_map 등 idx-키 자료구조 미존재
+//!
+//! 메모리 안전성:
+//!   - 새 ModuleList 에 Module struct 얕은 복사 — ArrayList ptr / parse_arena 동일 ref 공유
+//!   - 기존 ModuleList 는 `deinit` 으로 shelf 만 free (Module.deinit 우회) — 새 list ref 보존
+//!   - 후속 graph.deinit() 시 새 list 의 Module.deinit 이 backing 정상 해제
+
+const std = @import("std");
+const types = @import("../types.zig");
+const ModuleIndex = types.ModuleIndex;
+const ModuleGraph = @import("../graph.zig").ModuleGraph;
+const ModuleList = ModuleGraph.ModuleList;
+const RequestedExports = @import("state.zig").RequestedExports;
+const profile = @import("../../profile.zig");
+
+pub const RenumberError = error{ RenumberIncomplete, OutOfMemory };
+
+pub fn renumberModulesDeterministically(
+    self: *ModuleGraph,
+    entry_points: []const []const u8,
+) RenumberError!void {
+    var scope = profile.begin(.graph_renumber);
+    defer scope.end();
+
+    const old_count = self.modules.count();
+    if (old_count == 0) return;
+    std.debug.assert(old_count <= std.math.maxInt(u32));
+
+    const allocator = self.allocator;
+
+    var old_to_new = try allocator.alloc(u32, old_count);
+    defer allocator.free(old_to_new);
+    var new_to_old = try allocator.alloc(u32, old_count);
+    defer allocator.free(new_to_old);
+
+    var visited = try std.DynamicBitSet.initEmpty(allocator, old_count);
+    defer visited.deinit();
+
+    var queue: std.ArrayList(u32) = .empty;
+    defer queue.deinit(allocator);
+    try queue.ensureTotalCapacity(allocator, old_count);
+
+    var new_idx: u32 = 0;
+
+    // seed 순서 = build_flow 의 add 순서 (inject → run-before-main → entry) 로 cold/incremental 동등.
+    try seedFromPaths(self, self.inject_files, &visited, &queue);
+    try seedFromPaths(self, self.run_before_main_files, &visited, &queue);
+    try seedFromPaths(self, entry_points, &visited, &queue);
+
+    var head: usize = 0;
+    while (head < queue.items.len) : (head += 1) {
+        const old_u32 = queue.items[head];
+        old_to_new[old_u32] = new_idx;
+        new_to_old[new_idx] = old_u32;
+        new_idx += 1;
+
+        const m = self.modules.at(old_u32);
+        for (m.import_records) |rec| {
+            try visitDep(rec.resolved, old_count, &visited, &queue, allocator);
+        }
+        for (m.dynamic_imports.items) |dep| {
+            try visitDep(dep, old_count, &visited, &queue, allocator);
+        }
+    }
+
+    var orphans: std.ArrayList(u32) = .empty;
+    defer orphans.deinit(allocator);
+    var i: u32 = 0;
+    while (i < old_count) : (i += 1) {
+        if (!visited.isSet(i)) try orphans.append(allocator, i);
+    }
+    std.mem.sort(u32, orphans.items, self, lessThanByPath);
+    for (orphans.items) |old_u32| {
+        old_to_new[old_u32] = new_idx;
+        new_to_old[new_idx] = old_u32;
+        new_idx += 1;
+    }
+    if (new_idx != old_count) return error.RenumberIncomplete;
+
+    var new_list: ModuleList = .{};
+    errdefer new_list.deinit(allocator);
+    for (0..old_count) |new_i| {
+        const old_u32 = new_to_old[new_i];
+        var m = self.modules.at(old_u32).*;
+        m.index = ModuleIndex.fromUsize(new_i);
+        try new_list.append(allocator, m);
+    }
+
+    var nlit = new_list.iterator(0);
+    while (nlit.next()) |m| {
+        remapList(&m.dependencies, old_to_new);
+        remapList(&m.importers, old_to_new);
+        remapList(&m.dynamic_imports, old_to_new);
+        remapList(&m.dynamic_importers, old_to_new);
+        for (m.import_records) |*rec| {
+            if (rec.resolved.isNone()) continue;
+            rec.resolved = @enumFromInt(old_to_new[rec.resolved.toU32()]);
+        }
+    }
+
+    var p_it = self.path_to_module.iterator();
+    while (p_it.next()) |entry| {
+        entry.value_ptr.* = @enumFromInt(old_to_new[entry.value_ptr.toU32()]);
+    }
+
+    var new_req: std.AutoHashMapUnmanaged(u32, RequestedExports) = .{};
+    errdefer new_req.deinit(allocator);
+    try new_req.ensureTotalCapacity(allocator, @intCast(self.requested_exports.count()));
+    var r_it = self.requested_exports.iterator();
+    while (r_it.next()) |entry| {
+        try new_req.put(allocator, old_to_new[entry.key_ptr.*], entry.value_ptr.*);
+    }
+    self.requested_exports.deinit(allocator);
+    self.requested_exports = new_req;
+
+    for (self.worker_entries.items) |*we| {
+        we.source_module = @enumFromInt(old_to_new[we.source_module.toU32()]);
+    }
+
+    // StableSegmentedList.deinit 은 Module.deinit 을 호출하지 않으므로 새 list 의 얕은 복사
+    // ref 가 보존된다 — 이 invariant 가 깨지면 dangling 발생.
+    self.modules.deinit(allocator);
+    self.modules = new_list;
+}
+
+fn seedFromPaths(
+    self: *ModuleGraph,
+    paths: []const []const u8,
+    visited: *std.DynamicBitSet,
+    queue: *std.ArrayList(u32),
+) !void {
+    const old_count = self.modules.count();
+    for (paths) |path| {
+        const idx_e = self.path_to_module.get(path) orelse continue;
+        const old_u32 = idx_e.toU32();
+        if (old_u32 >= old_count or visited.isSet(old_u32)) continue;
+        visited.set(old_u32);
+        try queue.append(self.allocator, old_u32);
+    }
+}
+
+fn visitDep(
+    dep: ModuleIndex,
+    old_count: usize,
+    visited: *std.DynamicBitSet,
+    queue: *std.ArrayList(u32),
+    allocator: std.mem.Allocator,
+) !void {
+    if (dep.isNone()) return;
+    const old_u32 = dep.toU32();
+    if (old_u32 >= old_count or visited.isSet(old_u32)) return;
+    visited.set(old_u32);
+    try queue.append(allocator, old_u32);
+}
+
+inline fn remapList(list: *std.ArrayList(ModuleIndex), old_to_new: []const u32) void {
+    for (list.items) |*idx| {
+        idx.* = @enumFromInt(old_to_new[idx.toU32()]);
+    }
+}
+
+fn lessThanByPath(graph: *const ModuleGraph, a: u32, b: u32) bool {
+    return std.mem.lessThan(u8, graph.modules.at(a).path, graph.modules.at(b).path);
+}

--- a/src/bundler/graph_test.zig
+++ b/src/bundler/graph_test.zig
@@ -5,6 +5,7 @@ const determineExportsKind = graph_mod.determineExportsKind;
 const Module = @import("module.zig").Module;
 const types = @import("types.zig");
 const ModuleIndex = types.ModuleIndex;
+const renumber_mod = @import("graph/renumber.zig");
 const import_scanner = @import("import_scanner.zig");
 const resolve_cache_mod = @import("resolve_cache.zig");
 const module_store_mod = @import("module_store.zig");
@@ -1334,4 +1335,44 @@ test "linkDependency: out-of-bounds dep is no-op" {
     try graph.modules.append(alloc, Module.init(@enumFromInt(0), "a.ts"));
     try graph.linkDependency(@enumFromInt(0), @enumFromInt(99));
     try std.testing.expectEqual(@as(usize, 0), graph.getModule(@enumFromInt(0)).?.dependencies.items.len);
+}
+
+test "renumber: empty graph is no-op" {
+    const alloc = std.testing.allocator;
+    var cache = resolve_cache_mod.ResolveCache.init(alloc, .{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(alloc, &cache);
+    defer graph.deinit();
+
+    try renumber_mod.renumberModulesDeterministically(&graph, &.{});
+    try std.testing.expectEqual(@as(usize, 0), graph.modules.count());
+}
+
+test "renumber: orphan modules sorted by path regardless of add order" {
+    const alloc = std.testing.allocator;
+    var cache = resolve_cache_mod.ResolveCache.init(alloc, .{});
+    defer cache.deinit();
+    var graph = ModuleGraph.init(alloc, &cache);
+    defer graph.deinit();
+
+    // 의도적 역순 add: c.ts → idx 0, b.ts → 1, a.ts → 2
+    try graph.modules.append(alloc, Module.init(@enumFromInt(0), "c.ts"));
+    try graph.modules.append(alloc, Module.init(@enumFromInt(1), "b.ts"));
+    try graph.modules.append(alloc, Module.init(@enumFromInt(2), "a.ts"));
+    try graph.path_to_module.put(try alloc.dupe(u8, "c.ts"), @enumFromInt(0));
+    try graph.path_to_module.put(try alloc.dupe(u8, "b.ts"), @enumFromInt(1));
+    try graph.path_to_module.put(try alloc.dupe(u8, "a.ts"), @enumFromInt(2));
+
+    try renumber_mod.renumberModulesDeterministically(&graph, &.{});
+
+    // orphan path-sort 후: a.ts → 0, b.ts → 1, c.ts → 2
+    try std.testing.expectEqualStrings("a.ts", graph.modules.at(0).path);
+    try std.testing.expectEqualStrings("b.ts", graph.modules.at(1).path);
+    try std.testing.expectEqualStrings("c.ts", graph.modules.at(2).path);
+    try std.testing.expectEqual(@as(u32, 0), graph.path_to_module.get("a.ts").?.toU32());
+    try std.testing.expectEqual(@as(u32, 1), graph.path_to_module.get("b.ts").?.toU32());
+    try std.testing.expectEqual(@as(u32, 2), graph.path_to_module.get("c.ts").?.toU32());
+    // Module.index 도 remap
+    try std.testing.expectEqual(@as(u32, 0), graph.modules.at(0).index.toU32());
+    try std.testing.expectEqual(@as(u32, 2), graph.modules.at(2).index.toU32());
 }

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -148,6 +148,7 @@ pub const Category = enum {
     graph_discover_pm_prepass_run,
     graph_discover_pm_is_pkg_type,
     graph_finalize,
+    graph_renumber,
     graph_resync,
     graph_resync_const,
     graph_resync_semantic,

--- a/tests/integration/tests/determinism.test.ts
+++ b/tests/integration/tests/determinism.test.ts
@@ -51,7 +51,7 @@ async function expectDeterministic(
 }
 
 describe('build determinism (#3564)', () => {
-  test.skip('small — 5 file ESM, no collisions', async () => {
+  test('small — 5 file ESM, no collisions', async () => {
     await expectDeterministic('small', 'index.js');
   });
 


### PR DESCRIPTION
epic #3564 PR-1/7. discovery 워커 race 로 비결정인 module_index 를 `finalizeGraph` 첫 줄에서 BFS-from-roots 순으로 재부여 + idx 키 자료구조 일괄 remap.

## 변경

- `src/bundler/graph/renumber.zig` (신규, ~170 LOC) — `renumberModulesDeterministically()` + 헬퍼
- `src/bundler/graph/build_flow.zig` — `finalizeGraph` 첫 줄에서 renumber 호출
- `src/profile.zig` — `graph_renumber` Category 추가
- `src/bundler/graph_test.zig` — empty graph + orphan path-sort unit test 2개
- `tests/integration/tests/determinism.test.ts` — `small/` fixture `.skip` 해제

## 알고리즘

1. seed = `inject_files` → `run_before_main_files` → `entry_points` 순 (build_flow add 순서와 동일 → cold/incremental 동등)
2. BFS: 각 module 의 `import_records` 순 → `dynamic_imports` 순
3. orphan modules (어떤 root 에서도 도달 못 한 helper/runtime) = path 사전순 tail-append
4. 새 `ModuleList` 에 Module 얕은 복사 + `.index` 갱신
5. Graph-level idx 자료구조 remap: `path_to_module`, `requested_exports` (rebuild), `worker_entries[*].source_module`
6. 기존 `ModuleList.deinit` (`StableSegmentedList.deinit` 는 Module.deinit 호출 안 함 → ArrayList/parse_arena ref 보존) + swap

## 검증

- **결정성**: `determinism.test.ts` 의 `small/` fixture N=10회 SHA256 동일 (`bun test`: 1 pass / 4 skip / 0 fail)
- **회귀 0**: `zig build test` 전 unit test 통과 + 신규 renumber unit test 2개
- **성능 영향**: `--profile=graph` 측정
  - small (5 module): `graph.renumber` = 0.00ms (0.3%)
  - lodash-es (~640 module): `graph.renumber` = **0.16ms / 0.1%** of total 119.94ms
  - 영향 무시 가능 확정

## 메모리 안전성

`StableSegmentedList.deinit` 가 `Module.deinit` 을 호출하지 않는 점을 활용:
- 새 list 의 Module struct 는 기존 ArrayList ptr / `parse_arena` 등 동일 ref 공유
- 기존 list 의 shelf 메모리만 free → 새 list 의 ref dangling 없음
- 후속 `graph.deinit` 시 새 list 의 Module.deinit 이 정상 해제

## 후속

PR-2~6 가 각자의 hotspot 을 fix 한 뒤 `determinism.test.ts` 의 나머지 4개 `.skip` 해제.

Refs #3564