### PR TITLE
fix(linker): path-stable NameOwner sort in name collision resolution

### DIFF
--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -458,6 +458,9 @@ pub const Linker = struct {
     const NameOwner = struct {
         module_index: u32,
         exec_index: u32,
+        /// calculateRenames sort tie-break. exec_index 동률 시 path 사전순 (cross-chunk
+        /// marker 는 ""), worker race 비결정성 방지.
+        path: []const u8,
     };
 
     /// name_to_owners HashMap의 타입 별칭.
@@ -562,12 +565,13 @@ pub const Linker = struct {
             try self.addNameOwner(name_to_owners, sym_name, .{
                 .module_index = module_index,
                 .exec_index = m.exec_index,
+                .path = m.path,
             });
         }
 
         // codegen이 현재 모듈에 `_default` 합성 변수를 만드는 모든 export를 수집.
         // 충돌 시 _default$N으로 리네이밍되도록 등록한다.
-        const owner: NameOwner = .{ .module_index = module_index, .exec_index = m.exec_index };
+        const owner: NameOwner = .{ .module_index = module_index, .exec_index = m.exec_index, .path = m.path };
         for (m.export_bindings) |eb| {
             if (eb.hasSyntheticDefault(m.semanticSymbols())) {
                 try self.addNameOwner(name_to_owners, "_default", owner);
@@ -646,10 +650,12 @@ pub const Linker = struct {
                 continue;
             }
 
-            // exec_index 순으로 정렬 — 가장 낮은 게 원본 유지
+            // exec_index 순으로 정렬 — 가장 낮은 게 원본 유지. 동률 (cross-chunk marker +
+            // 같은 entry barrel) 시 path 사전순 — worker race 비결정 차단.
             std.mem.sort(NameOwner, entry.value_ptr.items, {}, struct {
                 fn lessThan(_: void, a: NameOwner, b: NameOwner) bool {
-                    return a.exec_index < b.exec_index;
+                    if (a.exec_index != b.exec_index) return a.exec_index < b.exec_index;
+                    return types.stringLessThan({}, a.path, b.path);
                 }
             }.lessThan);
 
@@ -2224,6 +2230,7 @@ pub const Linker = struct {
             try entry.value_ptr.append(self.allocator, .{
                 .module_index = std.math.maxInt(u32), // 특수 마커 — 실제 모듈 아님
                 .exec_index = 0, // 가장 낮은 exec_index → 원본 이름 유지
+                .path = "", // marker — 항상 정렬 우선 (사전순 최상)
             });
         }
 


### PR DESCRIPTION
epic #3564 PR-3/7. `Linker.calculateRenames` 의 `exec_index` 동률 시 stable sort 가 module_index 비결정성을 노출하던 문제 fix.

## 변경

`src/bundler/linker.zig` (+10/-3):
- `NameOwner` struct 에 `path: []const u8` 필드 추가 (default 없음)
- `collectModuleNames` (line 565, 574) + cross-chunk marker (line 2233) 의 3 곳 append site 에 path 전달
- `calculateRenames` 의 sort comparator: `exec_index` 동률 시 `types.stringLessThan` 으로 path 사전순 tie-break

## 근거

기존 sort 가 `exec_index` 만 비교 → stable sort 가 input 순(= `module_index`) 보존 → entry barrel + 동일 exec_index 케이스에서 `_default\$1` / `_default\$2` 부여가 비결정. PR-1 의 renumber 가 `module_index` 자체는 결정적으로 만들었지만, 동률 케이스에서 module_index 의존 자체가 약한 invariant → path 직접 사용으로 강화.

cross-chunk marker (`module_index = maxInt`, `exec_index = 0`) 는 `path = ""` 로 정렬 우선 유지 — `skip_max_module_index` 가드와 invariant 일관 (원본 보존자 역할 후 skip).

## 검증

- `bun test tests/determinism.test.ts` → 2 pass / 3 skip / 0 fail (PR-1+PR-2 활성 fixture 회귀 없음)
- `zig build test` 통과
- 성능: sort 비교는 `exec_index` mismatch 가 hot path, path 비교는 동률에만 도달 — 영향 없음

Refs #3564