### PR TITLE
fix(bundler): path-stable bundleOrderLessThan for exec_index ties

### DIFF
--- a/src/bundler/module.zig
+++ b/src/bundler/module.zig
@@ -570,12 +570,14 @@ pub const Module = struct {
     /// 번들 출력 순서 comparator.
     /// 래핑된 모듈(__esm/__commonJS)을 scope-hoisted 모듈보다 먼저 배치.
     /// var init_xxx = __esm(...) 선언이 init_xxx() 호출보다 앞에 와야 하므로,
-    /// 같은 그룹 내에서는 exec_index 오름차순.
+    /// 같은 그룹 내에서는 exec_index 오름차순. exec_index 동률 (보통 dynamic-only
+    /// 미방문 모듈의 maxInt 마커) 시 path 사전순 — worker race 비결정 차단.
     pub fn bundleOrderLessThan(_: void, a: *const Module, b: *const Module) bool {
         const a_wrapped = a.wrap_kind != .none;
         const b_wrapped = b.wrap_kind != .none;
         if (a_wrapped != b_wrapped) return a_wrapped;
-        return a.exec_index < b.exec_index;
+        if (a.exec_index != b.exec_index) return a.exec_index < b.exec_index;
+        return types.stringLessThan({}, a.path, b.path);
     }
 
     pub fn init(index: ModuleIndex, path: []const u8) Module {

--- a/src/bundler/module_test.zig
+++ b/src/bundler/module_test.zig
@@ -27,3 +27,24 @@ test "Module: state transitions" {
     m.state = .ready;
     try std.testing.expectEqual(Module.State.ready, m.state);
 }
+
+test "bundleOrderLessThan: exec_index 동률 시 path 사전순" {
+    // dynamic-only 미방문 모듈은 모두 exec_index = maxInt(u32) — 동률 처리에서
+    // stable sort 가 input 순(= module_index) 보존하던 비결정성 차단 검증.
+    var a = Module.init(@enumFromInt(0), "z/last.ts");
+    var b = Module.init(@enumFromInt(1), "a/first.ts");
+    // exec_index 동률 (default maxInt)
+    try std.testing.expectEqual(a.exec_index, b.exec_index);
+    // path 사전순 — a/first.ts 가 z/last.ts 보다 우선
+    try std.testing.expect(Module.bundleOrderLessThan({}, &b, &a));
+    try std.testing.expect(!Module.bundleOrderLessThan({}, &a, &b));
+}
+
+test "bundleOrderLessThan: exec_index 우선 (path 사전순 무시)" {
+    var a = Module.init(@enumFromInt(0), "a/first.ts");
+    var b = Module.init(@enumFromInt(1), "z/last.ts");
+    a.exec_index = 10;
+    b.exec_index = 5;
+    // a 의 path 가 사전순 앞이지만 exec_index 가 더 커서 b 가 우선
+    try std.testing.expect(Module.bundleOrderLessThan({}, &b, &a));
+}

--- a/tests/integration/tests/determinism.test.ts
+++ b/tests/integration/tests/determinism.test.ts
@@ -59,7 +59,7 @@ describe('build determinism (#3564)', () => {
     await expectDeterministic('name-collision', 'index.js', ['--minify-identifiers']);
   });
 
-  test.skip('dynamic-only — exec_index ties from import() only', async () => {
+  test('dynamic-only — exec_index ties from import() only', async () => {
     await expectDeterministic('dynamic-only', 'index.js');
   });
 


### PR DESCRIPTION
epic #3564 PR-4/7. `bundleOrderLessThan` 의 `exec_index` 동률 시 stable sort 가 module_index 비결정성을 노출하던 문제 fix.

## 변경

- `src/bundler/module.zig:574-581` — `exec_index` 동률 시 `types.stringLessThan` 으로 path 사전순 tie-break 추가 (PR-3 의 NameOwner sort 와 일관)
- `src/bundler/module_test.zig` — unit test 2개 (path 우선 / exec_index 우선)
- `tests/integration/tests/determinism.test.ts` — `dynamic-only/` fixture `.skip` 해제

## 근거

`dynamic-only/` fixture (entry 가 `import()` 만으로 도달하는 5 lazy 모듈) 의 경우 모든 모듈이 `exec_index = maxInt(u32)` (DFS exec_counter 가 동기 dependency 만 따라가서 dynamic 만 도달한 모듈은 미방문). `std.mem.sort` (stable) 가 동률 시 input 순(`0..moduleCount()` = module_index 순)을 보존 → worker race 비결정 그대로 bundle concat 순서에 노출.

## 검증

- `bun test tests/determinism.test.ts` → **3 pass** (small + name-collision + dynamic-only) / 2 skip / 0 fail
- `zig build test` 통과 (새 unit test 2개 + 기존 모두)
- 성능: `bundleOrderLessThan` 호출 = `emitter.zig:355` 단일 (sort 1회/build). tie 시에만 path memcmp 도달 → hot path 아님

Refs #3564