### PR TITLE
fix(emitter): sort emit-path hashmap iterators (esm-wrap star + chunk exports)

### DIFF
--- a/src/bundler/emitter/chunks.zig
+++ b/src/bundler/emitter/chunks.zig
@@ -903,6 +903,8 @@ pub fn emitChunks(
                     try names.append(allocator, try allocator.dupe(u8, name));
                 }
             }
+            // hashmap 순회는 비결정 — 출력 결정성 위해 사전순 정렬 (line 654 와 일관).
+            std.mem.sort([]const u8, names.items, {}, types.stringLessThan);
             break :blk try names.toOwnedSlice(allocator);
         };
 

--- a/src/bundler/emitter/esm_wrap.zig
+++ b/src/bundler/emitter/esm_wrap.zig
@@ -477,6 +477,8 @@ pub fn emitEsmWrappedModule(
             defer seen.deinit();
             var visited = std.AutoHashMap(u32, void).init(allocator);
             defer visited.deinit();
+            var sorted_names: std.ArrayList([]const u8) = .empty;
+            defer sorted_names.deinit(allocator);
 
             for (module.export_bindings) |eb| {
                 if (!eb.kind.isReExportAll()) continue;
@@ -492,9 +494,15 @@ pub fn emitEsmWrappedModule(
                     visited.clearRetainingCapacity();
                     try collectStarExportNames(l, src_i, &seen, &visited);
 
+                    // hashmap 순회는 비결정 — 사전순 정렬 후 emit 해 namespace getter 출현 순서 결정.
+                    sorted_names.clearRetainingCapacity();
                     var it = seen.iterator();
                     while (it.next()) |entry| {
-                        const name = entry.key_ptr.*;
+                        try sorted_names.append(allocator, entry.key_ptr.*);
+                    }
+                    std.mem.sort([]const u8, sorted_names.items, {}, types.stringLessThan);
+
+                    for (sorted_names.items) |name| {
                         if (std.mem.eql(u8, name, "default")) continue;
                         if (direct_exports.contains(name)) continue;
 

--- a/tests/integration/tests/determinism.test.ts
+++ b/tests/integration/tests/determinism.test.ts
@@ -63,11 +63,12 @@ describe('build determinism (#3564)', () => {
     await expectDeterministic('dynamic-only', 'index.js');
   });
 
-  test.skip('barrel — export * from chain', async () => {
+  test('barrel — export * from chain', async () => {
     await expectDeterministic('barrel', 'index.js');
   });
 
+  // code-splitting fixture 는 --splitting + --outdir 모드라 helper 확장 필요 (별도 PR).
   test.skip('code-splitting — manualChunks + dynamic', async () => {
-    await expectDeterministic('code-splitting', 'index.js', ['--code-splitting']);
+    await expectDeterministic('code-splitting', 'index.js', ['--splitting']);
   });
 });


### PR DESCRIPTION
epic #3564 PR-5/7. emit 경로의 hashmap iterator 결과가 정렬 없이 사용자 출력에 그대로 노출되던 두 지점 fix.

## 변경

1. **`src/bundler/emitter/esm_wrap.zig:495`** — `collectStarExportNames` 결과 (`seen: StringHashMap(void)`) 를 iterator 직접 loop 대신 `sorted_names: ArrayList` 에 모은 뒤 `types.stringLessThan` 사전순 정렬. namespace getter 출현 순서 결정. `sorted_names` 는 `seen`/`visited` 와 함께 outer 루프 1회 할당 + `clearRetainingCapacity` 재사용
2. **`src/bundler/emitter/chunks.zig:906`** — `chunk.exports_to.iterator()` 결과 toOwnedSlice 직전 정렬 (같은 파일 line 654 의 기존 패턴과 일관성 회복)
3. **`tests/integration/tests/determinism.test.ts`** — `barrel/` (3-level `export *`) skip 해제 + `code-splitting` CLI flag 정정 (`--code-splitting` → `--splitting`, helper 확장 필요해 skip 유지)

## 근거

`esm_wrap.zig:495` 는 namespace re-export getter 의 emit 순서에 직접 영향 — `var ns_X = { foo, bar, baz }` 의 `foo`/`bar`/`baz` 순서가 hashmap 내부 비결정 그대로 노출. `chunks.zig:906` 은 `OutputFile.export_names` API 로 사용자에게 expose (rolldown manifest 호환).

## 검증

- `bun test tests/determinism.test.ts` → **4 pass** (small + name-collision + dynamic-only + barrel) / 1 skip / 0 fail
- `zig build test` 통과

Refs #3564