### PR TITLE
fix(linker): stable-order fatal diagnostics flush

### DIFF
--- a/src/bundler/emitter.zig
+++ b/src/bundler/emitter.zig
@@ -1109,6 +1109,13 @@ pub fn emitWithTreeShaking(
         try output.append(allocator, '\n');
     }
 
+    // emit Phase 3 의 per-module pending_diagnostics flush 가 worker 완료 순서로 append 되어
+    // fatal_diagnostics 의 stderr 출현 순서가 비결정 (#3564). emit 종료 직전 stable sort 로 결정성 회복.
+    if (linker) |l| {
+        const linker_mut = @constCast(l);
+        std.mem.sort(types.BundlerDiagnostic, linker_mut.fatal_diagnostics.items, {}, diagnosticLessThan);
+    }
+
     // Lazy 경로: stack bundle_sm 을 heap 으로 얕은 복사. ArrayList items 포인터는 allocator 가
     // 소유하므로 payload 만 heap 으로 옮겨도 double-free 없음. flag 토글 후 본 함수 defer 는 skip.
     // 반드시 `toOwnedSlice` 성공 후 이관 — 실패 시 defer 가 원본 builder 를 정리.
@@ -2176,3 +2183,37 @@ fn addIdentityMappings(sm: *SourceMap.SourceMapBuilder, source_idx: u32, gen_sta
 // --- 포맷별 래핑 (prologue/epilogue) ---
 const emitFormatPrologue = format_wrapper.emitFormatPrologue;
 const emitFormatEpilogue = format_wrapper.emitFormatEpilogue;
+
+/// fatal_diagnostics 결정성 정렬 키 (#3564): severity → file_path → span.start → message.
+fn diagnosticLessThan(_: void, a: types.BundlerDiagnostic, b: types.BundlerDiagnostic) bool {
+    const a_sev = @intFromEnum(a.severity);
+    const b_sev = @intFromEnum(b.severity);
+    if (a_sev != b_sev) return a_sev < b_sev;
+    const path_order = std.mem.order(u8, a.file_path, b.file_path);
+    if (path_order != .eq) return path_order == .lt;
+    if (a.span.start != b.span.start) return a.span.start < b.span.start;
+    return std.mem.lessThan(u8, a.message, b.message);
+}
+
+test "diagnosticLessThan: severity → path → span.start → message" {
+    const Span = @import("../lexer/token.zig").Span;
+    const d1: types.BundlerDiagnostic = .{
+        .code = .unresolved_import,
+        .severity = .@"error",
+        .message = "msg",
+        .file_path = "z.ts",
+        .span = Span{ .start = 10, .end = 20 },
+        .step = .resolve,
+    };
+    const d2: types.BundlerDiagnostic = .{
+        .code = .unresolved_import,
+        .severity = .@"error",
+        .message = "msg",
+        .file_path = "a.ts",
+        .span = Span{ .start = 10, .end = 20 },
+        .step = .resolve,
+    };
+    // path 사전순 — a.ts 가 z.ts 보다 우선
+    try std.testing.expect(diagnosticLessThan({}, d2, d1));
+    try std.testing.expect(!diagnosticLessThan({}, d1, d2));
+}


### PR DESCRIPTION
epic #3564 PR-6/7 (마지막). emit Phase 3 의 per-module `pending_diagnostics` flush 가 worker 완료 순서로 `linker.fatal_diagnostics` 에 append 되어 stderr 출현 순서가 비결정. emit 종료 직전 stable sort 로 결정성 회복.

## 변경

- `src/bundler/emitter.zig` — `emitWithTreeShaking` 의 `output.toOwnedSlice` 직전 `linker.fatal_diagnostics.items` 를 `diagnosticLessThan` 키로 sort
- 같은 파일에 `diagnosticLessThan` 정렬 키 함수 + invariant unit test 1개
- 정렬 키: `severity → file_path → span.start → message`

## 근거

bundle 출력 자체에는 영향 없음 (sort 위치가 emit 모두 끝난 직후). **사용자가 stderr 까지 hash 한다면 결정성 게이트 통과** — Plan agent 권고 게이트 항목.

`@constCast(l)` 패턴은 `linker.zig:1490` 의 기존 mutation 관행과 동일 (`ns_cache_mutex` 등).

## 검증

- `zig build test` 통과 (새 unit test 포함)
- `bun test tests/determinism.test.ts` → 5회 연속 4 pass / 1 skip / 0 fail

Refs #3564