### PR TITLE
test(infra): determinism gate code-splitting fixture — outdir 모드 helper 확장

### DIFF
--- a/tests/integration/tests/determinism.test.ts
+++ b/tests/integration/tests/determinism.test.ts
@@ -1,15 +1,16 @@
 /// Build determinism gate (#3564) — 같은 입력으로 N=10회 빌드 → bundle byte-identical.
-/// 모든 케이스 `.skip` 으로 시작; 후속 PR 가 각자의 hotspot 을 fix 한 뒤 하나씩 활성화.
 
 import { afterAll, describe, test, expect } from 'bun:test';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { runZntc, sha256OfFile } from './helpers';
+import { dirContentsHash, runZntc, sha256OfFile } from './helpers';
 
 const FIXTURE_ROOT = resolve(import.meta.dir, 'fixtures/determinism');
 const REPEAT_COUNT = 10;
+
+type Mode = 'file' | 'outdir';
 
 const tmpRoots: string[] = [];
 afterAll(async () => {
@@ -20,10 +21,34 @@ async function expectDeterministic(
   fixtureName: string,
   entryFile: string,
   extraArgs: string[] = [],
+  mode: Mode = 'file',
 ): Promise<void> {
   const fixtureDir = join(FIXTURE_ROOT, fixtureName);
   const tmpRoot = await mkdtemp(join(tmpdir(), `zntc-determinism-${fixtureName}-`));
   tmpRoots.push(tmpRoot);
+
+  if (mode === 'outdir') {
+    const allRuns: Array<Array<{ path: string; hash: string; size: number }>> = [];
+    for (let i = 0; i < REPEAT_COUNT; i++) {
+      const outDir = join(tmpRoot, `run-${i}`);
+      const r = await runZntc([
+        '--bundle',
+        join(fixtureDir, entryFile),
+        '--outdir',
+        outDir,
+        ...extraArgs,
+      ]);
+      if (r.exitCode !== 0) {
+        throw new Error(`[${fixtureName}] run ${i} exited ${r.exitCode}\n${r.stderr}`);
+      }
+      allRuns.push(await dirContentsHash(outDir));
+    }
+    const first = allRuns[0];
+    for (let i = 1; i < allRuns.length; i++) {
+      expect(allRuns[i], `run ${i} outdir contents mismatch`).toEqual(first);
+    }
+    return;
+  }
 
   const results: { hash: string; size: number; mapHash: string | null }[] = [];
   for (let i = 0; i < REPEAT_COUNT; i++) {
@@ -67,8 +92,7 @@ describe('build determinism (#3564)', () => {
     await expectDeterministic('barrel', 'index.js');
   });
 
-  // code-splitting fixture 는 --splitting + --outdir 모드라 helper 확장 필요 (별도 PR).
-  test.skip('code-splitting — manualChunks + dynamic', async () => {
-    await expectDeterministic('code-splitting', 'index.js', ['--splitting']);
+  test('code-splitting — manualChunks + dynamic', async () => {
+    await expectDeterministic('code-splitting', 'index.js', ['--splitting'], 'outdir');
   });
 });

--- a/tests/integration/tests/helpers.ts
+++ b/tests/integration/tests/helpers.ts
@@ -1,5 +1,14 @@
 import { spawn } from 'bun';
-import { mkdtemp, rm, writeFile, mkdir, symlink, realpath, readFile } from 'node:fs/promises';
+import {
+  mkdtemp,
+  rm,
+  writeFile,
+  mkdir,
+  symlink,
+  realpath,
+  readFile,
+  readdir,
+} from 'node:fs/promises';
 import { readFileSync, statSync, openSync, closeSync, mkdirSync, writeFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { createRequire } from 'node:module';
@@ -293,6 +302,20 @@ export async function runZntc(
 export async function sha256OfFile(filePath: string): Promise<{ hash: string; size: number }> {
   const buf = await readFile(filePath);
   return { hash: createHash('sha256').update(buf).digest('hex'), size: buf.byteLength };
+}
+
+/// 디렉토리 내 모든 파일을 path 사전순으로 정렬해 SHA256+size 수집. 결정성 게이트 / outdir
+/// 모드 결과 비교용. recursive 탐색, withFileTypes 로 stat 호출 제거, Promise.all 병렬 hash.
+export async function dirContentsHash(
+  dir: string,
+): Promise<Array<{ path: string; hash: string; size: number }>> {
+  const dirents = await readdir(dir, { recursive: true, withFileTypes: true });
+  const files = dirents
+    .filter((d) => d.isFile())
+    .map((d) => relative(dir, join(d.parentPath, d.name)))
+    .sort();
+  const hashes = await Promise.all(files.map((f) => sha256OfFile(join(dir, f))));
+  return files.map((path, i) => ({ path, ...hashes[i] }));
 }
 
 /// fixture 생성 → ZNTC 실행 → 자동 cleanup 한 번에 묶는 헬퍼. caller 의 try/finally


### PR DESCRIPTION
#3572 follow-up. determinism epic #3564 의 마지막 `code-splitting/` fixture skip 해제.

## 변경

- `tests/integration/tests/helpers.ts` — `dirContentsHash(dir)` 신규. readdir(`withFileTypes: true`) + Promise.all 병렬 hash (stat N 회 호출 제거)
- `tests/integration/tests/determinism.test.ts` — `expectDeterministic` 에 명시 `mode: 'file' | 'outdir'` 인자 추가 (stringly-typed flag 감지 제거). outdir 모드에서 디렉토리 전체 contents hash list deep-equal 비교
- `code-splitting` fixture (`manualChunks + dynamic import` + `--splitting`) `.skip` 해제

## 검증

- `bun test tests/determinism.test.ts` → **5 pass** (5 fixture 모두 활성) / 0 fail
- 5회 연속 동일 결과 (flaky 없음)
- PR-1~6 의 결정성 invariant 가 splitting 모드 chunk graph 까지 정확히 cover 확인

Closes #3572