### PR TITLE
feat(linker): setEmitFormat + resetEmitTransients per-emit entry points

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -1220,21 +1220,20 @@ pub const Bundler = struct {
             // 실제로 없어도 런타임 값은 ReferenceError가 아니라 undefined가 된다.
             l.shim_missing_exports = self.options.shim_missing_exports or self.options.platform == .react_native;
             l.dev_mode = self.options.dev_mode;
-            l.entry_error_guard = self.options.entry_error_guard;
-            l.inline_requires = self.options.platform == .react_native;
             // #1621: preamble/metadata 가 __toESM/__toCommonJS 를 축약 이름으로 emit.
             l.minify_whitespace = self.options.minify_whitespace;
             l.configurable_exports = self.options.configurable_exports;
             // #1791 Phase D: value-ref 0 binding elision 정책을 transformer 와 동기화.
             l.verbatim_module_syntax = self.options.verbatim_module_syntax;
-            // #1824: IIFE external globals 매핑 — linker 가 매핑 유무로 preamble 경로 분기.
-            l.iife_globals = self.options.globals;
-            // PR-1/PR-2 (#3459): 정적 remote import → seam 글로벌 매핑용
-            // KV + 발견 specifier 수집기(emitHostInit preload-gate 용).
-            if (self.options.mf) |*m| {
-                l.mf_remotes = m.remotes;
-                l.mf_static_remotes = &mf_static_remotes;
-            }
+            // per-emit format-dependent state — setter 일원화로 emit 루프에서 매 format 마다 재호출 가능.
+            const mf_opt = self.options.mf;
+            l.setEmitFormat(self.options.format, .{
+                .iife_globals = self.options.globals,
+                .mf_remotes = if (mf_opt) |*m| m.remotes else &.{},
+                .mf_static_remotes = if (mf_opt) |_| &mf_static_remotes else null,
+                .inline_requires = self.options.platform == .react_native,
+                .entry_error_guard = self.options.entry_error_guard,
+            });
             if (mangle_report_enabled) l.mangle_report = &mangle_collector;
             try l.link();
             // Phase 3b (#1328): populateReExportAliases 가 canonical_name 을 채우려면

--- a/src/bundler/linker.zig
+++ b/src/bundler/linker.zig
@@ -345,6 +345,32 @@ pub const Linker = struct {
         };
     }
 
+    /// per-emit format-dependent state set. 같은 Linker 가 다른 format 으로 reemit 될 때
+    /// 매 emit 직전 호출. emit 루프 진입점에서 매 OutputConfig 마다 재호출 가능.
+    pub const SetEmitFormatOpts = struct {
+        iife_globals: []const types.GlobalEntry = &.{},
+        mf_remotes: []const types.MfBundleConfig.KV = &.{},
+        mf_static_remotes: ?*MfStaticRemotes = null,
+        inline_requires: bool = false,
+        entry_error_guard: bool = false,
+    };
+
+    pub fn setEmitFormat(self: *Linker, format: types.Format, opts: SetEmitFormatOpts) void {
+        self.format = format;
+        self.iife_globals = opts.iife_globals;
+        self.mf_remotes = opts.mf_remotes;
+        self.mf_static_remotes = opts.mf_static_remotes;
+        self.inline_requires = opts.inline_requires;
+        self.entry_error_guard = opts.entry_error_guard;
+    }
+
+    /// emit 경로별 transient state 초기화. splitting 경로가 set 한 ns_preamble_chunked /
+    /// use_shared_ns_preamble 를 다음 emit 진입 전 reset. 단일 → 단일 reemit 시 stale 영향 차단.
+    pub fn resetEmitTransients(self: *Linker) void {
+        self.use_shared_ns_preamble = false;
+        self.ns_preamble_chunked = false;
+    }
+
     pub fn deinit(self: *Linker) void {
         if (self.unified_result) |*ur| ur.deinit();
         for (self.unified_module_scopes) |*b| b.deinit();


### PR DESCRIPTION
epic #3561 PR-B/9. multi-format 진입점 API 추가. **동작 무변경** — caller 가 1회만 호출.

## 변경

### `src/bundler/linker.zig` (+26)
- `Linker.SetEmitFormatOpts` struct — `iife_globals`/`mf_remotes`/`mf_static_remotes`/`inline_requires`/`entry_error_guard` 묶음 (default 값이 `Linker` 필드 default 와 1:1 일치)
- `setEmitFormat(format, opts)` — per-emit format-dependent 6개 필드 동시 갱신
- `resetEmitTransients()` — `use_shared_ns_preamble`/`ns_preamble_chunked` clear (emit 경로별 transient)

### `src/bundler/bundler.zig:1217-1236` (+8/-10)
- 직접 set 패턴 6개를 `l.setEmitFormat(...)` 한 번에 통합
- format-agnostic 필드 (shim_missing_exports/dev_mode/minify_whitespace/configurable_exports/verbatim_module_syntax) 는 직접 set 유지

## 근거

multi-format epic 의 2단계 — emit 루프 진입 시 매 OutputConfig 마다 setEmitFormat + resetEmitTransients 재호출하기 위한 entry point. 본 PR 까지는 1회 호출 → 동작 무변경.

## 검증

- `zig build test` 통과
- `bun test tests/determinism.test.ts` → 5 pass / 0 fail (byte-identical with main)

Refs #3561