### PR TITLE
feat(bundler): OutputConfig + BundleOptions.output[] (infrastructure only)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -232,6 +232,11 @@ pub const BundleOptions = struct {
     /// IIFE external → 전역 식별자 매핑 (--globals, rollup `output.globals` 호환, #1824).
     /// emitter 가 IIFE factory 호출 인자로 사용. 매핑되지 않은 external 은 에러.
     globals: []const types.GlobalEntry = &.{},
+    /// rollup 식 `output: [...]` multi-format emit 설정. 빈 슬라이스면 기존
+    /// `format`/`globals` 를 fallback 으로 단일 default 합성. 길이 ≥ 2 시 같은
+    /// module graph 를 N format 으로 reemit (후속 활성). 본 epic 단계에서는 dormant
+    /// — bundler 가 항상 단일 emit 경로 사용.
+    output: []const types.OutputConfig = &.{},
     /// 출력 파일 확장자 오버라이드 (--out-extension:.js=.mjs)
     out_extension_js: ?[]const u8 = null,
     /// 소스맵 관련 옵션 묶음 (enable/debug_ids/function_map/lazy/source_root/sources_content).

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -505,6 +505,16 @@ pub const Format = enum {
     }
 };
 
+/// 단일 output emit 설정 — 같은 module graph 에서 N format reemit 시 per-output 분리.
+/// 빈 슬라이스 (`BundleOptions.output = &.{}`) 면 `BundleOptions.format`/`globals` 등을
+/// fallback 으로 사용 (단일 default config 합성).
+pub const OutputConfig = struct {
+    format: Format = .esm,
+    /// `--globals SPEC=GLOBAL` 매핑 (IIFE/UMD/AMD external → factory param 이름).
+    /// rollup `output.globals` 호환.
+    globals: []const GlobalEntry = &.{},
+};
+
 // ============================================================
 // 로더 (Asset Loader)
 // ============================================================


### PR DESCRIPTION
epic #3561 PR-C1/10 (multi-format). **Infrastructure only — dormant feature**.

## 변경

- `src/bundler/types.zig` — `OutputConfig { format, globals }` struct 정의
- `src/bundler/bundler.zig` — `BundleOptions.output: []const OutputConfig = &.{}` 필드 추가

## 근거

multi-format epic 의 3단계. PR-A (metadata format thread) + PR-B (setEmitFormat 진입점) 위에 *옵션 표면* 만 추가. bundler 는 본 PR 까지 항상 단일 emit 경로 사용 — `output` 길이/내용 무시.

후속 단계가 `output.len ≥ 2` 시 emit loop 활성화하여 같은 module graph 를 N format 으로 reemit.

## 검증

- `zig build test` 통과
- `bun test tests/determinism.test.ts` → 5 pass / 0 fail (byte-identical with main)
- 총 변경 15 LOC (옵션 표면만)

Refs #3561