### PR TITLE
feat(bundler): emit loop for multi-format (single path only)

### DIFF
--- a/src/bundler/bundler.zig
+++ b/src/bundler/bundler.zig
@@ -394,6 +394,10 @@ pub const BundleResult = struct {
     /// 다중 출력 파일. code_splitting=true일 때 사용. allocator 소유.
     /// null이면 단일 파일 모드 (output 필드 사용).
     outputs: ?[]OutputFile = null,
+    /// Multi-format emit 결과 (`BundleOptions.output.len >= 2` 시 사용). allocator 소유.
+    /// null 이면 단일 format 모드 (`output`/`outputs` 필드 사용). 첫 entry 의 결과가
+    /// `output` 필드에 alias 로 노출되어 backward-compat.
+    outputs_by_format: ?[]types.FormatOutput = null,
     /// 빌드 중 발생한 진단 메시지들. deep copy — 내부 문자열도 allocator 소유.
     diagnostics: ?[]OwnedDiagnostic,
     /// 번들에 포함된 모든 모듈의 절대 경로. allocator 소유. dev server watch용.
@@ -457,6 +461,15 @@ pub const BundleResult = struct {
         if (self.outputs) |outs| {
             for (outs) |o| o.deinit(allocator);
             allocator.free(outs);
+        }
+        if (self.outputs_by_format) |by| {
+            for (by) |fo| {
+                // 첫 entry 의 output/sourcemap 은 result.output/sourcemap 으로 move 됐을 수 있음 —
+                // 빈 슬라이스 (len 0) free 는 allocator 별 동작 차이 회피.
+                if (fo.output.len > 0) allocator.free(fo.output);
+                if (fo.sourcemap) |sm| allocator.free(sm);
+            }
+            allocator.free(by);
         }
         if (self.diagnostics) |diags| {
             for (diags) |d| {
@@ -1422,6 +1435,22 @@ pub const Bundler = struct {
         var output_scope = profile.begin(.emit_output);
         var output: []const u8 = "";
         var outputs: ?[]OutputFile = null;
+        var outputs_by_format: ?[]types.FormatOutput = null;
+        errdefer if (outputs_by_format) |by| {
+            for (by) |fo| {
+                self.allocator.free(fo.output);
+                if (fo.sourcemap) |sm| self.allocator.free(sm);
+            }
+            self.allocator.free(by);
+        };
+
+        // multi-format emit: single 경로만 본 단계에서 지원. dev/splitting 와 조합은 후속.
+        const multi_format = self.options.output.len > 1;
+        if (multi_format) {
+            if (self.options.dev_mode or self.options.code_splitting or self.options.preserve_modules) {
+                return error.MultiFormatRequiresSinglePath;
+            }
+        }
         // #3318 P1-5: MF remote 의 mf-manifest.json (wrapContainer 산출,
         // asset_outputs 로 편입). errdefer 로 부분실패 누수 방지.
         var mf_manifest: ?[]const u8 = null;
@@ -1566,6 +1595,62 @@ pub const Bundler = struct {
 
             // output은 빈 문자열 — code splitting 시 outputs를 사용
             output = try self.allocator.dupe(u8, "");
+        } else if (multi_format) {
+            // Multi-format single-path emit. 매 OutputConfig 마다 linker setEmitFormat 으로
+            // format-dependent state 갱신, emit 결과 누적. 첫 entry 의 결과를 `output` /
+            // `dev_sourcemap` 에 alias 로 노출 (backward-compat).
+            const by = try self.allocator.alloc(types.FormatOutput, self.options.output.len);
+            errdefer self.allocator.free(by);
+            const mf_opt2 = self.options.mf;
+            var filled: usize = 0;
+            errdefer {
+                var k: usize = 0;
+                while (k < filled) : (k += 1) {
+                    if (by[k].output.len > 0) self.allocator.free(by[k].output);
+                    if (by[k].sourcemap) |sm| self.allocator.free(sm);
+                }
+            }
+            for (self.options.output, 0..) |cfg, i| {
+                if (linker) |*l| {
+                    l.setEmitFormat(cfg.format, .{
+                        .iife_globals = cfg.globals,
+                        .mf_remotes = if (mf_opt2) |*m| m.remotes else &.{},
+                        .mf_static_remotes = if (mf_opt2) |_| &mf_static_remotes else null,
+                        .inline_requires = self.options.platform == .react_native,
+                        .entry_error_guard = self.options.entry_error_guard,
+                    });
+                    l.resetEmitTransients();
+                }
+                var emit_opts = self.makeEmitOptions();
+                emit_opts.format = cfg.format;
+                emit_opts.polyfills = polyfill_entries.items;
+                emit_opts.worker_map_per_module = &worker_map_per_module;
+                if (self.options.sourcemap.enable) emit_opts.sourcemap.enable = true;
+                const emit_result = try emitter.emitWithTreeShaking(
+                    self.allocator,
+                    &graph,
+                    &emit_opts,
+                    if (linker) |*l| l else null,
+                    if (shaker) |*s| s else null,
+                );
+                by[i] = .{
+                    .format = cfg.format,
+                    .output = emit_result.output,
+                    .sourcemap = emit_result.sourcemap,
+                };
+                filled = i + 1;
+            }
+            // 첫 entry 의 output/sourcemap 을 result.output / dev_sourcemap 으로 *move* — 동일
+            // 메모리 중복 alloc 회피. by[0] 의 슬라이스는 빈 슬라이스로 marker, deinit 의 가드가
+            // 빈 슬라이스 free 를 skip. outputs_by_format = by 는 *마지막* statement 로 두어
+            // 이후 try 가 없음을 보장 — outer errdefer 가 double-free 트리거하지 않음.
+            output = by[0].output;
+            by[0].output = &.{};
+            if (by[0].sourcemap) |sm| {
+                dev_sourcemap = sm;
+                by[0].sourcemap = null;
+            }
+            outputs_by_format = by;
         } else {
             // 단일 파일 경로 (tree shaking + 소스맵 지원)
             var emit_opts = self.makeEmitOptions();
@@ -1867,6 +1952,7 @@ pub const Bundler = struct {
             .sourcemap = dev_sourcemap,
             .sourcemap_builder = dev_sourcemap_builder,
             .outputs = outputs,
+            .outputs_by_format = outputs_by_format,
             .diagnostics = diagnostics,
             .module_paths = module_paths,
             .module_dev_codes = module_dev_codes,

--- a/src/bundler/bundler_test.zig
+++ b/src/bundler/bundler_test.zig
@@ -37,5 +37,6 @@ comptime {
     _ = @import("bundler_test/lowering_rename_leak.zig");
     _ = @import("bundler_test/manual_chunks.zig");
     _ = @import("bundler_test/runtime_helper_shadow.zig");
+    _ = @import("bundler_test/multi_format.zig");
     _ = @import("namespace_access_test.zig");
 }

--- a/src/bundler/bundler_test/multi_format.zig
+++ b/src/bundler/bundler_test/multi_format.zig
@@ -1,0 +1,61 @@
+//! Multi-format emit sanity tests (epic 진행 중).
+
+const std = @import("std");
+const Bundler = @import("../bundler.zig").Bundler;
+const types = @import("../types.zig");
+const test_helpers = @import("../test_helpers.zig");
+const writeFile = test_helpers.writeFile;
+const absPath = test_helpers.absPath;
+
+test "multi-format: esm + cjs single path produces both outputs" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "export const x = 42;\nconsole.log(x);");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .output = &.{
+            .{ .format = .esm },
+            .{ .format = .cjs },
+        },
+    });
+    defer b.deinit();
+
+    const result = try b.bundle();
+    defer result.deinit(std.testing.allocator);
+
+    try std.testing.expect(result.outputs_by_format != null);
+    try std.testing.expectEqual(@as(usize, 2), result.outputs_by_format.?.len);
+    try std.testing.expectEqual(types.Format.esm, result.outputs_by_format.?[0].format);
+    try std.testing.expectEqual(types.Format.cjs, result.outputs_by_format.?[1].format);
+    // 첫 entry 의 output 은 result.output 으로 move — by[0].output 은 빈 슬라이스.
+    try std.testing.expectEqual(@as(usize, 0), result.outputs_by_format.?[0].output.len);
+    try std.testing.expect(result.output.len > 0);
+    // 두 번째 entry 는 정상 보유.
+    try std.testing.expect(result.outputs_by_format.?[1].output.len > 0);
+}
+
+test "multi-format: dev_mode rejected" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeFile(tmp.dir, "index.ts", "export const x = 1;");
+
+    const entry = try absPath(&tmp, "index.ts");
+    defer std.testing.allocator.free(entry);
+
+    var b = Bundler.init(std.testing.allocator, .{
+        .entry_points = &.{entry},
+        .dev_mode = true,
+        .output = &.{
+            .{ .format = .esm },
+            .{ .format = .cjs },
+        },
+    });
+    defer b.deinit();
+
+    const result = b.bundle();
+    try std.testing.expectError(error.MultiFormatRequiresSinglePath, result);
+}

--- a/src/bundler/types.zig
+++ b/src/bundler/types.zig
@@ -515,6 +515,14 @@ pub const OutputConfig = struct {
     globals: []const GlobalEntry = &.{},
 };
 
+/// Multi-format emit 의 단일 결과. `BundleResult.outputs_by_format` 의 element.
+/// 모든 필드는 allocator 소유. `BundleResult.deinit` 가 일괄 해제.
+pub const FormatOutput = struct {
+    format: Format,
+    output: []const u8,
+    sourcemap: ?[]const u8 = null,
+};
+
 // ============================================================
 // 로더 (Asset Loader)
 // ============================================================


### PR DESCRIPTION
epic #3561 PR-C2/10. **단일 emit 경로 multi-format 활성화**. dev/splitting + multi 는 validation error 로 거부.

## 변경 (4 파일, +156)

### `src/bundler/types.zig`
- `FormatOutput { format, output, sourcemap }` struct — multi-format 결과의 단일 entry

### `src/bundler/bundler.zig`
- `BundleResult.outputs_by_format: ?[]types.FormatOutput = null` + deinit cleanup (빈 슬라이스 가드)
- `bundle()` emit 영역:
  - `multi_format = self.options.output.len > 1` 분기
  - validation: dev_mode/code_splitting/preserve_modules + multi → `error.MultiFormatRequiresSinglePath`
  - `else if (multi_format)` path: loop over `self.options.output`, per iter setEmitFormat + resetEmitTransients + emitWithTreeShaking + 결과 누적
  - 첫 entry → result.output 으로 **move** (중복 alloc 회피, by[0] = empty marker)
  - errdefer 순서: outer (by alloc) → inner (filled prefix cleanup) → `outputs_by_format = by` 마지막 → **double-free 위험 차단**

### `src/bundler/bundler_test/multi_format.zig` (신규)
- "esm + cjs single path produces both outputs" — 2 format emit + by_format len 2 + first move 검증
- "dev_mode rejected" — `error.MultiFormatRequiresSinglePath`

## 근거

PR-C1 의 `OutputConfig` infrastructure 위에서 **진짜 multi-emit 활성**. PR-A (format thread) + PR-B (setEmitFormat) 의 entry point 활용. **본 PR 까지는 single path 만 cover** — dev_mode/splitting + multi 조합은 별도 PR 에서 cover (잠정 정책 = 즉시 error).

## 검증

- `zig build test` 통과 (multi_format 2 test + 기존 모두; RN snapshot 환경 fail 외 0)
- `bun test tests/determinism.test.ts` 5 pass / 0 fail (byte-identical with main — 단일 format 사용자 영향 0)

## 메모리 안전

- `outputs_by_format = by;` 가 마지막 statement → 이후 try 없음 → double-free 위험 없음
- 첫 entry move + deinit 의 `if (fo.output.len > 0) free` 가드 → 빈 슬라이스 free 회피
- 부분 fail 시 inner errdefer 가 filled prefix 만 cleanup

Refs #3561